### PR TITLE
#1565: pkg/api: translate Junos config names before net.InterfaceByName

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4072,3 +4072,8 @@ top.
 ## 03:53 UTC — #1565 plan v5 after round-4 (Codex MAJOR, AGY MINOR)
 - **Action**: Fix fab0.0 collapse expectation, drop ge-0/0/0 from gates (not in allInterfaceNames), redesign lo test as reth0->lo synthetic, add drift-guard test, nil-guard Interfaces.Interfaces
 - **File(s)**: docs/pr/1565-iface-name-translate/plan.md
+
+## 03:58 UTC — #1565 plan v6 PLAN-READY
+- **Action**: Close 4 round-5 minors (stale fab text, drift-guard nil-unit + branch coverage, redundant-parent grammar, Atoi error fallback)
+- **File(s)**: docs/pr/1565-iface-name-translate/plan.md
+- **Verdict**: Codex r5 PLAN-NEEDS-MINOR (4 minors all closed in v6); AGY r5 PLAN-READY (one drift-guard test setup note also closed in v6). Plan moves to implementation.

--- a/_Log.md
+++ b/_Log.md
@@ -4077,3 +4077,7 @@ top.
 - **Action**: Close 4 round-5 minors (stale fab text, drift-guard nil-unit + branch coverage, redundant-parent grammar, Atoi error fallback)
 - **File(s)**: docs/pr/1565-iface-name-translate/plan.md
 - **Verdict**: Codex r5 PLAN-NEEDS-MINOR (4 minors all closed in v6); AGY r5 PLAN-READY (one drift-guard test setup note also closed in v6). Plan moves to implementation.
+
+## 04:01 UTC — #1565 implementation complete
+- **Action**: Add (*Config).ResolveKernelIfName + DHCPLeaseKey; rewrite 4 pkg/api sites; add SeedLeaseForTesting; 12 unit + 2 handler + 1 drift-guard tests all pass 5/5; go vet clean on modified pkgs; full Go suite passes
+- **File(s)**: pkg/config/types.go, pkg/config/types_test.go, pkg/api/interfaces.go, pkg/api/stats.go, pkg/api/metrics_counters.go, pkg/api/iface_name_test.go, pkg/dhcp/test_seams.go, pkg/dataplane/userspace/interfaces.go, pkg/dataplane/userspace/interfaces_test.go, pkg/daemon/daemon_dhcp.go

--- a/_Log.md
+++ b/_Log.md
@@ -4081,3 +4081,7 @@ top.
 ## 04:01 UTC — #1565 implementation complete
 - **Action**: Add (*Config).ResolveKernelIfName + DHCPLeaseKey; rewrite 4 pkg/api sites; add SeedLeaseForTesting; 12 unit + 2 handler + 1 drift-guard tests all pass 5/5; go vet clean on modified pkgs; full Go suite passes
 - **File(s)**: pkg/config/types.go, pkg/config/types_test.go, pkg/api/interfaces.go, pkg/api/stats.go, pkg/api/metrics_counters.go, pkg/api/iface_name_test.go, pkg/dhcp/test_seams.go, pkg/dataplane/userspace/interfaces.go, pkg/dataplane/userspace/interfaces_test.go, pkg/daemon/daemon_dhcp.go
+
+## 04:13 UTC — #1565 fix Codex MERGE-NEEDS-MINOR findings
+- **Action**: gofmt clean on my files; route writeInterfacesTerse normal-iface lookup through ResolveKernelIfName (catches gr-0/0/0.0); strengthen DHCP test with decoy lease assertion
+- **File(s)**: pkg/config/types.go, pkg/config/types_test.go, pkg/dataplane/userspace/interfaces_test.go (gofmt), pkg/api/interfaces.go (terse fix), pkg/api/iface_name_test.go (decoy assertion)

--- a/_Log.md
+++ b/_Log.md
@@ -4060,3 +4060,7 @@ top.
 ## 03:25 UTC — #1565 plan v2 after round-1 NEEDS-MAJOR
 - **Action**: Revise plan addressing Codex+AGY findings (TunnelNameMap, DHCP key shape, helper centralization, drop CLI smoke claim)
 - **File(s)**: docs/pr/1565-iface-name-translate/plan.md
+
+## 03:35 UTC — #1565 plan v3 after round-2 Codex NEEDS-MAJOR
+- **Action**: Address VLAN-vs-unit conflation, IRB, tunnel collision, DHCP test mock design, smoke specificity
+- **File(s)**: docs/pr/1565-iface-name-translate/plan.md

--- a/_Log.md
+++ b/_Log.md
@@ -4056,3 +4056,7 @@ top.
 ## 03:17 UTC — #1565 plan v1 drafted
 - **Action**: Draft plan for pkg/api Junos→Linux ifname translation fix
 - **File(s)**: docs/pr/1565-iface-name-translate/plan.md
+
+## 03:25 UTC — #1565 plan v2 after round-1 NEEDS-MAJOR
+- **Action**: Revise plan addressing Codex+AGY findings (TunnelNameMap, DHCP key shape, helper centralization, drop CLI smoke claim)
+- **File(s)**: docs/pr/1565-iface-name-translate/plan.md

--- a/_Log.md
+++ b/_Log.md
@@ -4064,3 +4064,7 @@ top.
 ## 03:35 UTC — #1565 plan v3 after round-2 Codex NEEDS-MAJOR
 - **Action**: Address VLAN-vs-unit conflation, IRB, tunnel collision, DHCP test mock design, smoke specificity
 - **File(s)**: docs/pr/1565-iface-name-translate/plan.md
+
+## 03:46 UTC — #1565 plan v4 after round-3 Codex NEEDS-MAJOR
+- **Action**: Drop ResolveFab from helper (fab0 is kernel device), add st* short-circuit, fix smoke gates to actual cfg, AGY minors (fmt import, test_seams.go, drift NOTE comments)
+- **File(s)**: docs/pr/1565-iface-name-translate/plan.md

--- a/_Log.md
+++ b/_Log.md
@@ -1,69 +1,6 @@
 # Action Log
 
-## 2026-05-26 — #1598 secondary fix (TX-dispatch funnel)
-
-- **Action**: Post-merge smoke on PR #1600 caught a SECONDARY funnel:
-  primary fix at `worker/cos/mod.rs:126-131` correctly set
-  `WorkerCoSQueueFastPath.shared_exact = true` for the non-exact
-  uncapped queue, but the TX dispatch path at
-  `userspace-dp/src/afxdp/tx/dispatch/cos.rs:54` was gating "keep
-  local vs route to owner" on `shared_queue_lease.is_some()`, an
-  exact-only marker. For the iperf-uncapped class the lease is None
-  (filtered out at `coordinator/mod.rs:1058`), so the dispatch still
-  funneled the request to a single `owner_worker_id`. Smoke showed
-  port 5211 push P=12 stable at 9.08 Gbps with 2k-3.6k retr.
-  Added `request_runs_under_shared_exact_policy` helper that gates
-  on `queue_fast.shared_exact` directly (the routing-level shared
-  flag). Switched both call sites: `enqueue_local_request_to_target_or_owner`
-  (cos.rs:54) and the in-place-rewrite gate `owner_matches_target`
-  in `dispatch/mod.rs:426`. Retained the legacy
-  `request_uses_shared_exact_queue_lease` helper — it still correctly
-  identifies queues with a per-queue rate lease, which is a
-  different question. Added test fixture
-  `test_cos_fast_interfaces_decoupled` that decouples
-  `(shared_exact, has_lease)` so all four combinations can be tested.
-  Added 3 regression tests covering (shared_exact=true, lease=None)
-  + (shared_exact=false, lease=Some) + unknown-queue safety.
-- **Tests**: 1441 cargo tests pass (+3 new); Go suite clean across
-  all packages; pre-existing `snat_contract_doc_guard` failure
-  unchanged on master.
-- **File(s)**: `userspace-dp/src/afxdp/tx/dispatch/cos.rs`,
-  `userspace-dp/src/afxdp/tx/dispatch/mod.rs`,
-  `userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs`,
-  `docs/pr/1598-cos-uncapped-fix/plan.md`, `_Log.md`.
-
-Entries land at the top when added. Within a topic batch (same
-issue / PR), entries run reverse-chronological (newest first).
-Across topic batches the ordering is by add-time, not strict wall
-clock, so older topic batches push down when newer work lands on
-top.
-
-## 2026-05-27 01:30 UTC — #1598 Copilot review addressed
-
-- **Timestamp**: 2026-05-27 01:30 UTC
-- **Action**: For #1598, addressed four Copilot inline comments. (1) Rewrote the function-level doc above `queue_uses_shared_exact_service` so it no longer claims non-exact queues are never shared; new doc explains that the gate is now threshold-only, and that the exact/non-exact distinction lives at the lease + V_min allocation gates (coordinator/mod.rs:1058 and :1145). (2) Replaced `feedback_cross_binding_impossible in memory` reference in the inline comment with a stable in-repo reference (PR #680/#690 + the plan doc). (3) Updated both new test fixtures to set `guarantee_enabled=false` AND `exact=false`, so the fixtures actually mirror the production uncapped-class shape (no transmit-rate at all, not just non-exact-with-rate). (4) Restored reverse-chronological log ordering and added a header note explaining the convention.
-- **File(s)**: `userspace-dp/src/afxdp/worker/cos/mod.rs`, `userspace-dp/src/afxdp/worker/cos/tests.rs`, `_Log.md`
-
-## 2026-05-26 13:25 UTC — #1598 implementation + tests pass
-
-- **Timestamp**: 2026-05-26 13:25 UTC
-- **Action**: Implemented plan v2. Removed the `if !queue.exact { return false; }` early return in `queue_uses_shared_exact_service` at `userspace-dp/src/afxdp/worker/cos/mod.rs:126-131` so the rate-threshold check `transmit_rate_bytes >= COS_SHARED_EXACT_MIN_RATE_BYTES` admits non-exact queues that hit the threshold. Updated the test that previously pinned the rejection: renamed `queue_uses_shared_exact_service_rejects_non_exact_queue` → `queue_uses_shared_exact_service_admits_high_rate_non_exact_queue` + added a complementary regression test `queue_uses_shared_exact_service_keeps_low_rate_non_exact_single_owner` to lock the threshold-gated behavior. Updated doc comment at `coordinator/mod.rs:1145` to note the V_min floor filter is intentionally stricter than the routing gate. Build clean, 1438+10 cargo tests pass, Go suite clean, 5x flake check pass on `queue_uses_shared_exact_service` tests.
-- **File(s)**: `userspace-dp/src/afxdp/worker/cos/mod.rs`, `userspace-dp/src/afxdp/worker/cos/tests.rs`, `userspace-dp/src/afxdp/coordinator/mod.rs`
-
-## 2026-05-26 12:50 UTC — #1598 plan v2 (after round-1 reviewer split)
-
-- **Timestamp**: 2026-05-26 12:50 UTC
-- **Action**: Updated plan to v2 incorporating round-1 reviewer outcomes. Codex PLAN-KILL was infra-blocked (sandbox runner missing); AGY round-1 verdict PLAN-READY after walking the actual files. Added explicit trace of `build_worker_cos_owner_live_by_tx_ifindex` showing `tx_owner_live` is per-worker local (loop_body/mod.rs:91-95), so Step2 never funnels foreign-worker. Documented residual concern about non-binding workers (not applicable to the loss userspace cluster which has every worker bound to reth0.80 mlx5 VF). Re-dispatching Codex.
-- **File(s)**: `docs/pr/1598-cos-uncapped-fix/plan.md`
-
-## 2026-05-26 12:30 UTC — #1598 plan v1 (CoS iperf-uncapped caps at ~10 Gbps)
-
-- **Timestamp**: 2026-05-26 12:30 UTC
-- **Action**: Drafted plan v1 for #1598. Root-cause identified at `userspace-dp/src/afxdp/worker/cos/mod.rs:126-131` — `queue_uses_shared_exact_service` early-returns false on `!queue.exact`, excluding the uncapped non-exact queue from sharded multi-worker drain. This forces 100% of class-11 traffic through a single `owner_worker_id` (built at `coordinator/mod.rs:900-904`), hitting the per-worker AF_XDP UMEM ceiling. The 24g/exact queue escapes this because it trips the same gate with `exact=true && rate >= 312 MB/s`.
-- **File(s)**: `docs/pr/1598-cos-uncapped-fix/plan.md`
-
 ## 2026-05-26 23:10 UTC — #1578 cluster perf root-cause (smoke target IP misalignment)
-
 - **Timestamp**: 2026-05-26 23:10 UTC
   - **Action**: Investigated the "loss userspace cluster ~9 Gb/s
     reverse P=12 ceiling" reported in #1578 / #1580 / #1593. Direct
@@ -88,7 +25,6 @@ top.
   - **File(s)**: test/incus/loss-userspace-cluster.env, CLAUDE.md,
     _Log.md (this entry).
 ## 2026-05-26 23:43 UTC — #1348 icmp_embed split (PR #1596, AWAITING-BATCH-MERGE)
-
 - **Timestamp**: 2026-05-26 23:43 UTC
 - **Action**: PR #1596 opened for #1348 (split
   `userspace-dp/src/afxdp/icmp_embed.rs` 761 LOC into
@@ -106,9 +42,7 @@ top.
   4 sandbox-infra attempts. 3-of-4 attestation under Wave-5
   Codex-stuck exception. `<!-- AWAITING-BATCH-MERGE -->` posted.
 - **Closes**: #1348.
-
 ## 2026-05-26 23:54 UTC — #1543 screen + SYN-cookie split (Wave-5)
-
 - **Timestamp**: 2026-05-26 23:54 UTC
   - **Action**: Decomposed `userspace-dp/src/screen.rs` (1420 LOC) into
     sibling submodules under `userspace-dp/src/screen/` per the
@@ -145,9 +79,7 @@ top.
     - docs/pr/1543-screen-syn-cookie-split/plan.md (v2)
     - docs/pr/1543-screen-syn-cookie-split/reviewer-ids.md
     - _Log.md (this entry).
-
 ## 2026-05-26 22:46 UTC — #1439 snapshot.go split (rebase carry-forward)
-
 - **Timestamp**: 2026-05-26 22:46 UTC
   - **Action**: PR #1592 rebased onto fresh `origin/master`
     (b84f46280) after GitHub's merge planner declined the prior
@@ -161,10 +93,7 @@ top.
     pass.
   - **File(s)**: 14 sibling .go files in pkg/dataplane/userspace/,
     snapshot.go deleted, docs/pr/1439-snapshot-builders/{plan,reviewer-ids}.md,
-    _Log.md (this entry).
-
 ## 2026-05-26 — #1329 shared_cos_lease extract
-
 - **17:18 UTC** — Created worktree refactor/1329-shared-cos-lease-extract
   off origin/master (HEAD 63dfe02a). Branch tracked.
 - **17:22 UTC** — Drafted plan v1 at
@@ -256,9 +185,7 @@ top.
   Copilot r2 with all nits addressed, Claude SMR). Posted
   <!-- AWAITING-BATCH-MERGE --> marker at PR #1588. Smoke deferred
   per Wave-3 retirement-chain rule.
-
 ## 2026-05-26 — #1325 implementation pushed
-
 - **Timestamp**: 2026-05-26T (UTC)
 - **Action**: Implemented protocol.rs domain split per v3 plan.
   - Created protocol/{mod,snapshot,cos,nat,security,control,
@@ -285,10 +212,7 @@ top.
 - **File(s)**: userspace-dp/src/protocol/{mod,snapshot,cos,nat,
   security,control,binding,resolution,tests}.rs (created);
   userspace-dp/src/protocol.rs (deleted); _Log.md
-
 ## 2026-05-26 — #1325 plan v2 folds Codex+AGY r1
-
-- **Timestamp**: 2026-05-26T (UTC)
 - **Action**: Folded both r1 reviews into plan v2.
   - Codex r1 PLAN-KILL (5 blocking, all fixable): incremental-build
     claim withdrawn; ProcessStatus dependency graph corrected to
@@ -306,10 +230,7 @@ top.
     only" framing.
 - **File(s)**: docs/pr/1325-protocol-split/plan.md (v2 fold),
   _Log.md
-
 ## 2026-05-26 — #1325 protocol.rs split plan v1 DRAFT
-
-- **Timestamp**: 2026-05-26T (UTC)
 - **Action**: Wrote plan v1 (DRAFT) for #1325 protocol.rs domain
   split. Target: module/foo.rs directory layout with 7 domain files
   under `userspace-dp/src/protocol/` (mod.rs slim + binding /
@@ -321,7 +242,6 @@ top.
 - **File(s)**: docs/pr/1325-protocol-split/plan.md,
   docs/pr/1325-protocol-split/reviewer-ids.md
 ## 2026-05-26 — #1326 PR #1569 AWAITING-BATCH-MERGE at 18fd27f8
-
 - **Timestamp**: 2026-05-26T (4-of-4 MERGE-READY on 18fd27f8)
   - **Action**: Drove PR #1569 through 6 code-review rounds. Final
     SHA 18fd27f8 has 4-of-4 attestation: Codex MERGE-READY (final),
@@ -338,9 +258,7 @@ top.
     be71872c explicitly proposed the exact change in 18fd27f8, so
     that stands as the formal attestation.
   - **File(s)**: docs/pr/1326-worker-loop-extract/reviewer-ids.md
-
 ## 2026-05-26 — #1326 Phase 1 implementation + PR-prep
-
 - **Timestamp**: 2026-05-26T (round 6 PLAN-READY, then implementation)
   - **Action**: Codex r5 returned PLAN-NEEDS-MINOR with one wording
     fix at plan.md:697 ("&mut state.dbg_state ONLY" wording
@@ -367,9 +285,7 @@ top.
     docs/pr/1326-worker-loop-extract/reviewer-ids.md,
     userspace-dp/src/afxdp/worker/mod.rs,
     userspace-dp/src/afxdp/worker/loop_body/mod.rs (new)
-
 ## 2026-05-26 — #1326 plan v3.3 — Codex r4 doc-consistency fixes
-
 - **Timestamp**: 2026-05-26T (round 4 reviews returned)
   - **Action**: AGY r4 (review-mpmw4xjc-92bdff) returned PLAN-READY
     independently — full substantive re-confirmation on every
@@ -385,11 +301,8 @@ top.
     comment to "35-param", (c) cleaned stale topology refs
     (arc_refresh.rs, shutdown::tear_down, idle::handle, "7+ files"
     in risk table). Dispatching r5 to confirm.
-  - **File(s)**: docs/pr/1326-worker-loop-extract/plan.md,
     docs/pr/1326-worker-loop-extract/reviewer-ids.md
-
 ## 2026-05-26 — #1326 plan v3.2 — Codex r3 PLAN-NEEDS-MINOR addressed
-
 - **Timestamp**: 2026-05-26T (Codex r3 verdict extracted from log)
   - **Action**: Codex r3 (replayed via log capture from
     task-mpmvuetd-57y479; harness lost the id but the file log
@@ -411,11 +324,7 @@ top.
     arriving at PLAN-NEEDS-MINOR with all findings address-able by
     plan-doc edits is the strongest signal yet that v3.2 will land
     PLAN-READY on round-4.
-  - **File(s)**: docs/pr/1326-worker-loop-extract/plan.md,
-    docs/pr/1326-worker-loop-extract/reviewer-ids.md
-
 ## 2026-05-26 — #1326 plan v3.1 — AGY r3 nested-field qualifier fix
-
 - **Timestamp**: 2026-05-26T (AGY r3 result fetched)
   - **Action**: AGY r3 (review-mpmvtaei-6yvid7) returned
     PLAN-NEEDS-MINOR with 1 trivial compile-bug fix: the
@@ -427,9 +336,7 @@ top.
     hidden invariants, hybrid inlining, file tree, architectural
     mismatch). Fixed addressing in plan.md; waiting on Codex r3.
   - **File(s)**: docs/pr/1326-worker-loop-extract/plan.md
-
 ## 2026-05-26 — #1326 plan v3 (AGY r2 PLAN-NEEDS-MINOR addressed)
-
 - **Timestamp**: 2026-05-26T (AGY r2 result fetched, Codex r2 lost)
   - **Action**: AGY r2 (review-mpmvbr0c-i8e6wh) returned
     PLAN-NEEDS-MINOR with 4 actionable items. v3 addresses all four:
@@ -445,11 +352,7 @@ top.
     task-mpmvbj5i-hw5hra LOST from the harness again (same
     long-running session-state drop pattern). Re-dispatching Codex
     + AGY in parallel on v3.
-  - **File(s)**: docs/pr/1326-worker-loop-extract/plan.md,
-    docs/pr/1326-worker-loop-extract/reviewer-ids.md
-
 ## 2026-05-26 — #1326 plan v2 (AGY r1 PLAN-NEEDS-MAJOR addressed)
-
 - **Timestamp**: 2026-05-26T (AGY r1 result fetched)
   - **Action**: AGY r1 (review-mpmurh2n-sfmiks) returned
     PLAN-NEEDS-MAJOR with 4 action items: (1) narrow phase-fn
@@ -461,11 +364,7 @@ top.
     was lost from the harness (session-state drop on long-running
     review batch); will be re-dispatched on v2 alongside AGY r2.
     Plan revised; v2 published.
-  - **File(s)**: docs/pr/1326-worker-loop-extract/plan.md,
-    docs/pr/1326-worker-loop-extract/reviewer-ids.md
-
 ## 2026-05-26 — #1326 worker_loop extract plan v1 drafted
-
 - **Timestamp**: 2026-05-26T
   - **Action**: Drafted plan v1 for #1326 — extracting ~1278-LOC
     `worker_loop` body from `userspace-dp/src/afxdp/worker/mod.rs`
@@ -473,10 +372,7 @@ top.
     orchestrator). Wrote plan with allocation audit, cold-path
     annotations, LoopState struct sketch, hidden invariants list,
     risk table, and 7 open questions for adversarial review.
-  - **File(s)**: docs/pr/1326-worker-loop-extract/plan.md,
-    docs/pr/1326-worker-loop-extract/reviewer-ids.md
 ## 2026-05-26 — #1328 Coordinator decompose Phase 2
-
 - **Timestamp**: 2026-05-26 (plan v1 drafted)
   - **Action**: Worktree created off origin/master at 936b076d
     on branch refactor/1328-coordinator-reconcile-split. Plan v1
@@ -488,7 +384,6 @@ top.
     refresh_bindings.rs (copy_live_snapshot + zero_unbound_slot
     dispatcher). Pure code motion; mod.rs shrinks ~830 LOC.
     8 open questions for adversarial review.
-
 - **Timestamp**: 2026-05-26 (plan v2.2 PLAN-READY after 4 rounds)
   - **Action**: After 4 rounds of Codex+AGY adversarial review,
     plan v2.2 at commit dab1ada3 cleared with PLAN-READY (Codex
@@ -497,7 +392,6 @@ top.
     (AGY layout ask) findings resolved. Layout: sub-mod-dir
     coordinator/reconcile/{mod,teardown,reset,snapshot,bringup}.rs
     plus sibling coordinator/refresh_bindings.rs.
-
 - **Timestamp**: 2026-05-26 (implementation complete)
   - **Action**: Implemented #1328 coordinator decompose Phase 2.
     Split userspace-dp/src/afxdp/coordinator/mod.rs (2026 LOC) into:
@@ -517,7 +411,6 @@ top.
     coordinator tests; go test ./... 32 packages pass. Pre-existing
     upstream failure snat_contract_doc_guard ("fail-closed" doc
     drift in master, AGY r4 noted as out of scope).
-  - **File(s)**:
     - userspace-dp/src/afxdp/coordinator/mod.rs (extract + visibility)
     - userspace-dp/src/afxdp/coordinator/refresh_bindings.rs (new)
     - userspace-dp/src/afxdp/coordinator/reconcile/mod.rs (new)
@@ -527,7 +420,6 @@ top.
     - userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs (new)
     - userspace-dp/src/afxdp/coordinator/tests.rs (test added)
 ## 2026-05-26 — #1357 session context-struct refactor implemented (plan v3.1)
-
 - **Timestamp**: 2026-05-26T (round-3 reviewers PLAN-READY/PLAN-NEEDS-MINOR all minor addressed)
   - **Action**: Implemented #1357 plan v3.1 — introduced
     `userspace-dp/src/session/ctx.rs` with `SessionInstall` (owned
@@ -570,9 +462,7 @@ top.
       hot path. Reverted that fn to positional (originally planned
       fallback). Kept the other three context-struct fns. Final
       shape documented in `plan.md` "Rollback execution" section.
-
 ## 2026-05-26 — #1541 cluster manager split (pure code-motion + lift)
-
 - **Timestamp**: 2026-05-26
   - **Action**: Split pkg/cluster/cluster.go (2429 LOC, 77 *Manager
     methods) into cohesive sibling .go files in package cluster per
@@ -607,9 +497,7 @@ top.
     (all packages, no failures).
   - **Plan doc**: docs/pr/1541-cluster-mgr-split/plan.md (v3.1).
   - **Reviewer task IDs**: docs/pr/1541-cluster-mgr-split/reviewer-ids.md.
-
 ## 2026-05-26 — #1476 Phase B AWAITING-MERGE at f815c357
-
 - **Timestamp**: 2026-05-26T (r3 reviewers converged, posting marker)
   - **Action**: Round-3 code reviews returned. Both AGY r3 and
     Codex r3 MERGE-READY at HEAD f815c357. AGY r3 flagged an
@@ -619,7 +507,6 @@ top.
     master-password directive). Confirmed pre-existing pattern,
     not introduced by #1476; deserves its own hardening issue.
     Will be filed separately after #1476 merges.
-
     Final reviewer state for the AWAITING-MERGE marker:
     - Codex r3: MERGE-READY at f815c357
     - AGY r3: MERGE-READY at f815c357
@@ -628,15 +515,12 @@ top.
     - Copilot: STUCK ("exceeds maximum number of lines (20,000)")
       → 3-of-4 Copilot-stuck exception applies per
       feedback_copilot_two_bots policy.
-
     Posting STANDALONE AWAITING-MERGE marker per
     feedback_retirement_batch_smoke_at_end policy (no smoke marker;
     smoke-runner singleton handles fast-merge).
   - **File(s)**: docs/pr/1476-mechanical-bpf-removal/reviewer-ids.md,
     _Log.md
-
 ## 2026-05-26 — #1476 Phase B r2 fixes (Codex MERGE-NEEDS-MAJOR)
-
 - **Timestamp**: 2026-05-26T (r2 fixes after Codex r2 MERGE-NEEDS-MAJOR)
   - **Action**: Round-2 code reviews returned. AGY r2 pending; Codex r2
     MERGE-NEEDS-MAJOR with 3 findings:
@@ -655,7 +539,6 @@ top.
     F3 NIT: header comment in maps_decouple_test.go still mentioned
       BPFRX_LEGACY_LOADER_RETIRED=1 verbatim despite r1's intent to
       strip it.
-
     All 3 addressed in this commit:
     - rewriteRetiredDataplaneType now uses three explicit helpers
       (systemBlocksOf, groupsBlocksOf, systemBlocksOfNode) that
@@ -672,7 +555,6 @@ top.
       top-level groups as group definitions. If future Junos-parity
       work admits nested groups, the walker recursion-step is
       trivial; flagged for the future cleanup PR.
-
     Validation: full go test ./... clean across 33 packages. 9
     rewrite-helper tests pass including the 2 new split-stanza
     regressions. 5x flake on TestRewriteRetiredDataplaneType_(
@@ -680,9 +562,7 @@ top.
   - **File(s)**: pkg/configstore/dataplane_retire.go,
     pkg/configstore/dataplane_retire_test.go,
     pkg/dataplane/userspace/maps_decouple_test.go
-
 ## 2026-05-26 — #1476 Phase B r1 fixes (Codex MERGE-NEEDS-MAJOR)
-
 - **Timestamp**: 2026-05-26T (r1 fixes after Codex MERGE-NEEDS-MAJOR)
   - **Action**: Round-1 code reviews returned. AGY r1 MERGE-READY;
     Codex r1 MERGE-NEEDS-MAJOR with 5 findings:
@@ -706,7 +586,6 @@ top.
     F5 NIT: pkg/dataplane/userspace/maps_decouple_test.go header
       comment still referenced the BPFRX_LEGACY_LOADER_RETIRED escape
       hatch that the canary no longer uses.
-
     All 5 fixed in this commit:
     - rewriteRetiredDataplaneType now walks BOTH top-level system AND
       every `groups { <name> { system { ... } } }` definition. Two
@@ -721,18 +600,12 @@ top.
       and memory.md (line 164) to past tense / current state.
     - Replaced the BPFRX_LEGACY_LOADER_RETIRED comment block in
       maps_decouple_test.go header with the post-#1476 narrative.
-
     Test gates: full go test ./... clean (33 packages); 7 rewrite
     helper tests pass including the two new apply-groups regressions.
-  - **File(s)**: pkg/configstore/dataplane_retire.go,
-    pkg/configstore/dataplane_retire_test.go,
     pkg/configstore/store.go,
     pkg/grpcapi/server_config_test.go,
     docs/userspace-dataplane-gaps.md, docs/memory.md,
-    pkg/dataplane/userspace/maps_decouple_test.go
-
 ## 2026-05-26 — #1476 Phase B implementation
-
 - **Timestamp**: 2026-05-26T (Phase B complete; awaiting code review)
   - **Action**: #1451 closed (capstone PR #1557 merged as ee4b34bf).
     Rebased plan branch onto current master ee4b34bf via /tmp/log-merge.py
@@ -808,7 +681,6 @@ top.
       TestStoreLoad_RewritesPersistedEBPFDataplaneType (end-to-end:
       pre-#1476 persisted ebpf-tree → Load → ActiveConfig non-nil
       with userspace default).
-
     Test gates: `go build ./...` clean; `go test ./...` clean across
     33 packages; 5x flake on retirement canaries clean. Grep proof:
     `xpfXdp|xpfTc|loadXpfXdp|loadXpfTc|loadAllObjects` only appears
@@ -821,9 +693,7 @@ top.
     (loader_userspace_shim.go, dataplane_retire.go +
     dataplane_retire_test.go), 14 edited (sentinel wiring + test
     rewrites + canary updates + doc sweeps + CLAUDE.md).
-
 ## 2026-05-25 — #1476 Phase A PLAN-READY at r4
-
 - **Timestamp**: 2026-05-25T (Phase A complete)
   - **Action**: Round-4 reviews returned: Codex r4 PLAN-READY (all
     r3 stale-text findings confirmed closed; no new issues); AGY
@@ -839,9 +709,7 @@ top.
   - **File(s)**: `docs/pr/1476-mechanical-bpf-removal/plan.md` v4
     (PLAN-READY at r4),
     `docs/pr/1476-mechanical-bpf-removal/reviewer-ids.md`, `_Log.md`
-
 ## 2026-05-25 — #1476 Phase A v4 plan after r3 reviews
-
 - **Timestamp**: 2026-05-25T (Phase A v4 after r3 reviewer findings)
   - **Action**: Round-3 reviews returned: AGY r3 PLAN-READY with
     one cosmetic nit (risk-table count "4" → "5"); Codex r3
@@ -858,10 +726,7 @@ top.
     "4 retirement-manifest canaries" → "5"; "all four" literals
     in v3 change-log header rewritten without losing meaning.
   - **File(s)**: `docs/pr/1476-mechanical-bpf-removal/plan.md` v4,
-    `docs/pr/1476-mechanical-bpf-removal/reviewer-ids.md`, `_Log.md`
-
 ## 2026-05-25 — #1476 Phase A v3 plan after r2 reviews
-
 - **Timestamp**: 2026-05-25T (Phase A v3 after r2 reviewer findings)
   - **Action**: Round-2 reviews returned: Codex r2 PLAN-NEEDS-MAJOR
     (5 findings, mostly stale-text drift between v2 header changes
@@ -874,10 +739,7 @@ top.
     non-daemon ebpf-warning test rewrite rows, §8 prose updates,
     "four manifest tests" → "five" sweep.
   - **File(s)**: `docs/pr/1476-mechanical-bpf-removal/plan.md` v3,
-    `docs/pr/1476-mechanical-bpf-removal/reviewer-ids.md`, `_Log.md`
-
 ## 2026-05-25 — #1476 Phase A v2 plan after r1 reviews
-
 - **Timestamp**: 2026-05-25T (Phase A v2 after r1 reviewer findings)
   - **Action**: Round-1 reviews returned: Codex r1b
     PLAN-NEEDS-MAJOR (6 findings: Manager.Load() interface break,
@@ -893,10 +755,7 @@ top.
     allowlist entry + docs-pinned token; corrects manifest test
     count to 5.
   - **File(s)**: `docs/pr/1476-mechanical-bpf-removal/plan.md` v2,
-    `docs/pr/1476-mechanical-bpf-removal/reviewer-ids.md`, `_Log.md`
-
 ## 2026-05-25 — #1476 Phase A v1 plan drafted
-
 - **Timestamp**: 2026-05-25T (Phase A v1 draft)
   - **Action**: Created worktree `refactor/1476-mechanical-bpf-removal`
     off origin/master. Drafted plan v1 for #1476 (eBPF retirement
@@ -917,10 +776,7 @@ top.
     Blocked on #1451 (sub-issues #1516, #1521 still OPEN); Phase B
     rebases onto master once #1451 closes.
   - **File(s)**: `docs/pr/1476-mechanical-bpf-removal/plan.md`,
-    `docs/pr/1476-mechanical-bpf-removal/reviewer-ids.md`, `_Log.md`
-
 ## 2026-05-26
-
 - **Timestamp**: 2026-05-26T02:50:00Z
   - **Action**: #1539 PR #1553 — rebased onto origin/master (5
     PRs ahead, including #1556 multierror refactor). Conflict
@@ -1004,9 +860,7 @@ top.
     pkg/daemon/daemon_flow.go,
     pkg/dataplane/retirement_boundary_canary_test.go,
     docs/pr/1373-retire-ebpf-dataplane/README.md
-
 ## 2026-05-26 (earlier)
-
 - **Timestamp**: 2026-05-26T03:15:00Z
   - **Action**: #1519 plan-impl v1.1 → v1.2 — AGY round-1
     (review-mpm1pdkv-g1sycf) returned PLAN-READY with no new
@@ -1034,9 +888,7 @@ top.
     round-1).
   - **File(s)**: docs/pr/1519-daemon-legacydp-shrink/plan-impl.md,
     docs/pr/1519-daemon-legacydp-shrink/reviewer-ids-impl.md
-
 ## 2026-05-25
-
 - **Timestamp**: 2026-05-25T20:30:00Z
   - **Action**: #1519 plan-impl v1 → v1.1 — Codex round-1 returned
     3 findings (1×P2, 2×P3) on plan-impl.md. P2: row 1 of migration
@@ -1059,7 +911,6 @@ top.
     once); fixed to `for i in 1 2 3 4 5`. AGY round-1 still
     pending.
   - **File(s)**: docs/pr/1519-daemon-legacydp-shrink/plan-impl.md
-
 - **Timestamp**: 2026-05-25T20:00:00Z
   - **Action**: #1519 Phase A — drafted capstone-delete plan
     (plan-impl.md v1) on new branch
@@ -1077,8 +928,6 @@ top.
     new pkg/daemon AST canary asserting legacyDP() method decl
     and call expressions stay deleted. Dispatched to Codex + AGY
     in parallel for plan-impl v1 review.
-  - **File(s)**: docs/pr/1519-daemon-legacydp-shrink/plan-impl.md
-
 - **Timestamp**: 2026-05-25T19:30:00Z
   - **Action**: #1521 Copilot r-rebase (4357897741 on 5bc310fc)
     fixes — 1 correctness finding + 1 doc nit. Correctness
@@ -1111,7 +960,6 @@ top.
   - **Validation**: 6 canary tests + 25 alias-bypass sub-cases
     pass under `-count=2`; full `go test ./...` all 33 packages
     green.
-
 - **Timestamp**: 2026-05-25T18:50:00Z
   - **Action**: #1521 post-rebase + AGY r-rebase inherited-initializer
     fix. Rebased branch onto master b7466f5d (8 sibling PRs merged
@@ -1134,21 +982,16 @@ top.
     (sentinel-gated skip already closed), 1 DEFER (relative path),
     4 REJECT (recurring parity-AST and scoping rationales). Codex
     impl-r1: 3 findings, all REJECT (recurring).
-  - **File(s)**: pkg/dataplane/userspace/maps_decouple_test.go,
-    docs/pr/1521-maps-sync-decouple/reviewer-ids.md, _Log.md
   - **Validation**: 6 canary tests + 24 alias-bypass sub-cases
     pass; full `go test ./...` all 33 packages green on the
     rebased branch.
-
 - **Timestamp**: 2026-05-25T15:45:00Z
   - **Action**: Addressed PR #1551 Copilot round-3 doc-comment nits by
     fully qualifying dataplane helper names in cluster session-sync
     comments (`dataplane.TelemetryOf`, `dataplane.NewDataPlaneTelemetry`).
-  - **File(s)**:
     `pkg/cluster/sync.go`,
     `pkg/cluster/sync_test.go`,
     `_Log.md`
-
 - **Timestamp**: 2026-05-26T01:00:00Z
   - **Action**: Round-3 reviewer verdicts complete on PR #1550 HEAD
     444a1959. Codex MERGE-READY (no findings). AGY MERGE-READY
@@ -1164,7 +1007,6 @@ top.
     ready for author merge.
   - **File(s)**: smoke matrix on loss:xpf-userspace-fw0/fw1; no
     code changes.
-
 - **Timestamp**: 2026-05-26T00:30:00Z
   - **Action**: PR #1550 round-2 reviews landed. Codex MERGE-READY
     (no findings; all wording fixes confirmed). AGY MERGE-READY
@@ -1178,11 +1020,9 @@ top.
     same fixes; rebased local 3ea74518 on top — same content, took
     Copilot agent's version verbatim during rebase since the two
     wordings are equivalent.
-  - **File(s)**:
     `pkg/dataplane/userspace/manager.go`,
     `pkg/dataplane/userspace/userspace_boot_canary_test.go`,
     `pkg/dataplane/README.md`
-
 - **Timestamp**: 2026-05-25T23:30:00Z
   - **Action**: PR #1550 round-1 doc + wording follow-ups merged.
     Copilot agent pushed be8a7b6d updating
@@ -1191,7 +1031,6 @@ top.
     `userspace.Boot()`; legacy factory only for ebpf rollback +
     DPDK sentinel). Rebased local round-1 review fixes on top.
   - **File(s)**: `pkg/dataplane/README.md`, `pkg/daemon/README.md`
-
 - **Timestamp**: 2026-05-25T23:00:00Z
   - **Action**: PR #1550 round-1 code review feedback addressed.
     Copilot inline nits: (1) Boot() doc misdescribed the userspace
@@ -1206,12 +1045,9 @@ top.
     lock in the unknown-type error propagation and to assert
     ErrDPDKBackendRetired stays reserved for "dpdk". AGY code
     review verdict: MERGE-READY (8 findings clean).
-  - **File(s)**:
-    `pkg/dataplane/userspace/manager.go`,
     `pkg/daemon/daemon_run.go`,
     `pkg/daemon/dataplane_boot_test.go`,
     `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`
-
 - **Timestamp**: 2026-05-25T22:30:00Z
   - **Action**: #1520 plan v4 + implementation. v2 added Claude SMR
     refinements (no-arg Boot, behavioral canaries). v3 addressed
@@ -1229,15 +1065,9 @@ top.
     Implementation: added `userspace.Boot()` + helper
     `buildRuntimeDataPlane` in daemon_run.go + two canary test
     files. Full Go suite green; 5x flake stable.
-  - **File(s)**:
     `docs/pr/1520-userspace-boot-extraction/plan.md`,
     `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`,
-    `pkg/dataplane/userspace/manager.go`,
-    `pkg/daemon/daemon_run.go`,
-    `pkg/dataplane/userspace/userspace_boot_canary_test.go`,
     `pkg/daemon/dataplane_boot_test.go`
-
-- **Timestamp**: 2026-05-25T20:00:00Z
   - **Action**: #1520 plan v1 DRAFT — extract userspace boot path
     from legacy `dataplane.New()` (sub-#1451 S5). Adds
     `userspace.Boot()` constructor + daemon `buildRuntimeDataPlane`
@@ -1245,9 +1075,6 @@ top.
     `dataplane-type ebpf` rollback. Plan explicitly out-of-scopes
     the `bpfShim` field rename (forbidden by existing AST canary)
     and the `maps_sync.go` map-name decoupling (#1521 sibling work).
-  - **File(s)**:
-    `docs/pr/1520-userspace-boot-extraction/plan.md`,
-    `docs/pr/1520-userspace-boot-extraction/reviewer-ids.md`
 - **Timestamp**: 2026-05-25T09:15:00Z
   - **Action**: #1538 code-review round-2 doc cleanup —
     Codex code review round 2 verdict was NEEDS-MINOR with
@@ -1271,8 +1098,6 @@ top.
     construction at line 103).
     Re-ran ./pkg/config/ + ./pkg/grpcapi/ tests: clean.
   - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
-    `_Log.md`
-
 - **Timestamp**: 2026-05-25T09:00:00Z
   - **Action**: #1538 code-review round-1 follow-up — addresses
     Codex code-review NEEDS-MINOR (3 findings; AGY MERGE-READY,
@@ -1298,15 +1123,12 @@ top.
   - **File(s)**: `pkg/config/compiler_test.go`,
     `docs/pr/1538-multierror-validation/plan.md`,
     `docs/pr/1538-multierror-validation/reviewer-ids.md`,
-    `_Log.md`
-
 - **Timestamp**: 2026-05-25T08:45:00Z
   - **Action**: #1538 implementation (plan v4 PLAN-READY 4/4).
     Plan-review summary: r1 Codex PLAN-NEEDS-MAJOR / AGY
     PLAN-READY; r2 Codex PLAN-NEEDS-MINOR / AGY PLAN-READY;
     r3 Codex PLAN-NEEDS-MINOR / AGY PLAN-NEEDS-MINOR; r4
     Codex PLAN-READY / AGY PLAN-READY. v4 is the final plan.
-
     Code change: `compileExpanded` in
     `pkg/config/compiler.go:244-272` now accumulates the three
     independent strict-validator family errors
@@ -1320,7 +1142,6 @@ top.
     `TestDataplaneTypeDPDKRejectedAtCommitFiresFirst` no-leak
     contract (parser_ast_test.go:2909+2913) keeps passing
     byte-identically.
-
     Tests added (3):
     - `pkg/config/compiler_test.go::TestCompileMultipleStrictErrorsAccumulated`
       — parser-driven via `CompileConfig` + `ParseSetCommand` /
@@ -1345,11 +1166,9 @@ top.
       (no bufconn) per existing pattern at lines 15-25.
       Asserts `codes.InvalidArgument` + both substrings +
       one '\n' separator on the rendered status.Message().
-
     Local validation: `go build ./...` clean, `go test
     ./...` clean (30 packages), 5× flake loop on the three
     new tests + the DPDK no-leak test all clean.
-
     Also tidied two cosmetic stale-wording items Codex r4
     called out as non-blocking: "Land plan v2" → "Land plan
     ... v4 is the final" and "Open questions ... (round 2)"
@@ -1357,10 +1176,7 @@ top.
   - **File(s)**: `pkg/config/compiler.go`,
     `pkg/config/compiler_test.go` (new),
     `pkg/grpcapi/server_config_test.go`,
-    `docs/pr/1538-multierror-validation/plan.md`,
     `docs/pr/1538-multierror-validation/reviewer-ids.md` (new),
-    `_Log.md`
-
 - **Timestamp**: 2026-05-25T08:30:00Z
   - **Action**: #1538 plan v4 — addresses Codex round-3
     PLAN-NEEDS-MINOR (3 findings) + AGY round-3
@@ -1382,9 +1198,6 @@ top.
     Sanity-checked the fixture locally with a throw-away
     test: under current fail-fast, only CoS error surfaces;
     under accumulator both surface separated by one '\n'.
-  - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
-    `_Log.md`
-
 - **Timestamp**: 2026-05-25T08:15:00Z
   - **Action**: #1538 plan v3 — addresses Codex round-2
     PLAN-NEEDS-MINOR on plan v2. AGY round-2 was PLAN-READY.
@@ -1401,9 +1214,6 @@ top.
     are THREE new tests (not two) and splits fixture-build
     technique per-test (parser for tests 1+3, direct-helper
     for the byte-identity test 2).
-  - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
-    `_Log.md`
-
 - **Timestamp**: 2026-05-25T08:00:00Z
   - **Action**: #1538 plan v2 — addresses Codex round-1
     PLAN-NEEDS-MAJOR (4 findings) on plan v1. Changes:
@@ -1424,8 +1234,6 @@ top.
     audit it confirmed (validator independence, substring
     + sentinel preservation, wrap-chain mechanics).
     Rebased onto current master (which now has #1536).
-  - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
-    `_Log.md`
 - **Timestamp**: 2026-05-25T18:30:00Z
   - **Action**: #1521 Copilot r5 fixes + pre-rebase. Copilot r5
     (review id 4357796234 on 5becd4fa) flagged 3 inline findings:
@@ -1458,12 +1266,10 @@ top.
     chain is at package scope and only chain1 is shadowed in
     `case 1` — the canary must still resolve chain3 via package
     scope to "userspace_fallback_stats".
-  - **File(s)**: pkg/dataplane/userspace/maps_decouple_test.go,
     docs/pr/1521-maps-sync-decouple/reviewer-ids.md
   - **Validation**: 6 canary tests + 22 negative-fixture sub-cases
     (2 new copilot_r5 cases) pass under `-count=2`; full
     `go test ./...` green on this branch (pre-rebase).
-
 - **Timestamp**: 2026-05-25T17:30:00Z
   - **Action**: #1521 r7 review fix — AGY r7 CONCRETE KILL: switch
     or select case body acts as an implicit Go scope but is
@@ -1482,11 +1288,8 @@ top.
     descent). scopeWalker pushes new scopes for BlockStmt,
     CaseClause, and CommClause. New agy_r7_switch_case_shadow_
     bypass fixture asserts the kill.
-  - **File(s)**: pkg/dataplane/userspace/maps_decouple_test.go,
-    docs/pr/1521-maps-sync-decouple/reviewer-ids.md
   - **Validation**: 6 canary tests + 20 negative-fixture sub-cases
     pass; go test ./... all 30 packages green.
-
 - **Timestamp**: 2026-05-25T17:15:00Z
   - **Action**: #1521 r6 review fix — AGY r6 NEEDS-MINOR identified
     one more bypass: block-local const declaration with the same
@@ -1510,11 +1313,7 @@ top.
     to "userspace_fallback_stats" and "userspace_fallback").
     Copilot r4 on 0692093a: 9/9 files reviewed, 0 new comments —
     clean.
-  - **File(s)**: pkg/dataplane/userspace/maps_decouple_test.go,
-    docs/pr/1521-maps-sync-decouple/reviewer-ids.md
   - **Validation**: 6 canary tests + 19 negative-fixture sub-cases
-    pass; go test ./... all 30 packages green.
-
 - **Timestamp**: 2026-05-25T17:00:00Z
   - **Action**: #1521 r5 review fixes — AGY r5 raised NEEDS-MINOR
     with 4 issues; all addressed. (a) Inverted const dependency
@@ -1537,12 +1336,9 @@ top.
     3 new fixtures: agy_r5_ia_inverted_chain_depth3,
     agy_r5_id1_typed_concat_conversion,
     agy_r5_id2_typo_padded_new_name.
-  - **File(s)**: pkg/dataplane/userspace/maps_decouple_test.go,
     pkg/dataplane/userspace/maps.go,
-    docs/pr/1521-maps-sync-decouple/reviewer-ids.md
   - **Validation**: 6 canary tests + 18 negative-fixture sub-cases
     all pass; go test ./... all 30 packages green.
-
 - **Timestamp**: 2026-05-25T16:35:00Z
   - **Action**: #1521 r4 review fixes — Copilot wording nits +
     Codex LOW-1 parseMapsGoRegistry hard-fail + AGY r4 §II.1
@@ -1559,12 +1355,7 @@ top.
     deliberate-attacker bypasses in maps.go header.
     Codex r4 MED-1 (parity AST roster) REJECTED third time same
     rationale.
-  - **File(s)**: pkg/dataplane/userspace/maps_decouple_test.go,
-    pkg/dataplane/userspace/maps.go,
-    docs/pr/1521-maps-sync-decouple/reviewer-ids.md
   - **Validation**: 5 canary tests + 18 negative-fixture sub-cases
-    all pass; go test ./... all 30 packages green.
-
 - **Timestamp**: 2026-05-25T16:15:00Z
   - **Action**: #1521 r3 code-review fixes — AGY r3 found four
     more bypass classes; all addressed: (i) deeply nested concat
@@ -1585,11 +1376,7 @@ top.
     prove the kills.
     Codex r3 review rejected as basis-error (codex ran against
     pr-1494-head not the worktree HEAD); no substantive findings.
-  - **File(s)**: pkg/dataplane/userspace/maps_decouple_test.go,
-    docs/pr/1521-maps-sync-decouple/reviewer-ids.md
   - **Validation**: 4 canary tests + 14 alias-bypass sub-cases all
-    pass; go test ./... all 30 packages green.
-
 - **Timestamp**: 2026-05-25T15:50:00Z
   - **Action**: #1521 r2 code-review fixes — Codex LOW-2 (%
     exemption allows format-template bypass) + AGY r2 §A (trim-
@@ -1605,11 +1392,7 @@ top.
     Production canary now delegates to the same helper.
     Codex LOW-1 (parity bytes.Contains) again REJECTED with same
     rationale as r1 LOW-2.
-  - **File(s)**: pkg/dataplane/userspace/maps_decouple_test.go,
-    docs/pr/1521-maps-sync-decouple/reviewer-ids.md
   - **Validation**: 4 canary tests + 10 alias-bypass sub-cases all
-    pass; go test ./... all 30 packages green.
-
 - **Timestamp**: 2026-05-25T15:30:00Z
   - **Action**: #1521 r1 code-review fixes — Codex MED-1 + AGY §1
     (alias bypass) closed by new `TestNoMapNameLiteralAliasesOutside
@@ -1622,12 +1405,9 @@ top.
     comment to reference `mapNameUserspaceCtrl`. Codex LOW-2
     rejected (parity AST-pattern adds fragility vs loader refactor;
     bytes.Contains is the minimum signal we actually want).
-  - **File(s)**: pkg/dataplane/userspace/maps_decouple_test.go,
     pkg/dataplane/userspace/manager_ha.go,
-    docs/pr/1521-maps-sync-decouple/reviewer-ids.md
   - **Validation**: 3 canaries × -count=5 all green; go test ./...
     all 30 packages green.
-
 - **Timestamp**: 2026-05-25T15:10:00Z
   - **Action**: #1521 — decouple userspace maps_sync from legacy
     BPF map names (sub-#1451 S6). New file
@@ -1647,7 +1427,6 @@ top.
   - **Validation**: go build ./... clean; go test
     ./pkg/dataplane/userspace/... ok; canaries 5/5 pass;
     go test ./... — all 30 packages green.
-- **Timestamp**: 2026-05-25T08:00:00Z
   - **Action**: #1516 plan v1 — sub-#1451 S1 migration scope.
     Drafted `docs/pr/1516-grpcapi-migration/plan.md`: new
     `pkg/grpcapi/runtime.go` declaring `grpcRuntime` interface
@@ -1660,7 +1439,6 @@ top.
     review.
   - **File(s)**: `docs/pr/1516-grpcapi-migration/plan.md`,
     `_Log.md`.
-
 - **Timestamp**: 2026-05-25T05:55:00Z
   - **Action**: PR #1536 round-3 cleanup — address Codex MAJOR
     (load merge syntax in plan recovery) + 3 Copilot nits:
@@ -1688,7 +1466,6 @@ top.
   - **File(s)**: `docs/pr/1526-dpdk-reject/plan.md`,
     `pkg/config/compiler_system.go`,
     `pkg/config/parser_ast_test.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-25T05:30:00Z
   - **Action**: PR #1526 implementation v3 — added
     `validateDataplaneTypeStrict` in pkg/config/compiler.go (slotted
@@ -1700,7 +1477,6 @@ top.
     CompileConfig (raw), Store.CommitCheck (raw), and Store.Commit
     (`commit check failed:`-wrapped) — addresses Codex round-2
     MAJOR finding 1.
-
     Test surface:
     - parser_ast_test.go: split TestDPDKConfig into
       TestDPDKConfigParsesCleanly (parse must survive — AST shape
@@ -1722,23 +1498,19 @@ top.
       CommitCheck error AND the `commit check failed:`-wrapped
       Commit error, plus TestCommit_AcceptsUserspaceDataplaneType
       negative control.
-
     Plan v3 updated to (a) switch tests from byte-exact to
     substring-match for cross-surface compatibility, (b) correct
     the daemon-startup recovery flow text (candidate is empty
     after failed Load, not pre-populated), (c) honor the issue
     body's verbatim `(see #1525)` (does not point at #1531 docs).
-
     Test gates: go build ./... clean. go test ./... clean across
     33 packages. 5x flake check on new tests passes. cargo check
     on userspace-dp/ clean (no Rust touched).
-  - **File(s)**: `pkg/config/compiler.go`,
     `pkg/config/parser_ast_test.go`,
     `pkg/config/parser_system_test.go`,
     `pkg/configstore/store_test.go`,
     `docs/pr/1526-dpdk-reject/plan.md`
 ## 2026-05-25 — #1529 Codex code-review finding follow-up
-
 - **Timestamp**: 2026-05-25T06:50:00Z
   - **Action**: Codex code review NEEDS-MINOR with three findings,
     all addressed:
@@ -1754,9 +1526,7 @@ top.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`,
     `docs/userspace-dataplane-gaps.md`,
     `docs/userspace-dataplane-architecture.md`, `_Log.md`
-
 ## 2026-05-25 — #1529 Antigravity code-review finding follow-up
-
 - **Timestamp**: 2026-05-25T06:30:00Z
   - **Action**: Antigravity code review MERGE-READY with one new
     finding: `pkg/dataplane/README.md` and `pkg/daemon/README.md`
@@ -1768,10 +1538,7 @@ top.
     pinned `#1475 DPDK Backend Policy` section as the historical
     anchor.
   - **File(s)**: `pkg/dataplane/README.md`, `pkg/daemon/README.md`,
-    `_Log.md`
-
 ## 2026-05-25 — #1529 implementation
-
 - **Timestamp**: 2026-05-25T06:00:00Z
   - **Action**: Implemented the v3 plan. 26 files touched, all `*.md`.
     Pure-text gate passes; no source files touched. Chain A boundary
@@ -1793,10 +1560,7 @@ top.
     ha-session-ownership-and-fabric-failover.md,
     ipv6-session-fast-path.md, pre-id-default-policy.md,
     twice-nat.md, vsrx-fabric-fab0-fab1-syntax-compat.md}, _Log.md.
-
 ## 2026-05-25 — #1529 plan v3 (Antigravity r2 build-breaker fix)
-
-- **Timestamp**: 2026-05-25T05:30:00Z
   - **Action**: v3 plan addresses Antigravity r2 PLAN-NEEDS-MINOR.
     The §1504 paragraph in `docs/pr/1373-retire-ebpf-dataplane/README.md`
     is ALSO canary-pinned by
@@ -1808,9 +1572,7 @@ top.
     sentences to fix grammar, line 292 explicitly includes the
     `- ` bullet marker.
   - **File(s)**: `docs/pr/1529-dpdk-docs-sweep/plan.md`, `_Log.md`
-
 ## 2026-05-24 — #1529 plan v2 (Codex r1 fixes)
-
 - **Timestamp**: 2026-05-25T05:00:00Z
   - **Action**: v2 plan addresses Codex r1 PLAN-NEEDS-MAJOR six
     findings: non-canary-pinned DPDK text now has explicit
@@ -1820,9 +1582,7 @@ top.
     historical-classification wording clarified; git diff gate
     uses --name-only.
   - **File(s)**: `docs/pr/1529-dpdk-docs-sweep/plan.md`
-
 ## 2026-05-24 — #1529 plan v1 drafted
-
 - **Timestamp**: 2026-05-24T17:00:00Z
   - **Action**: Drafted plan v1 for #1529 (DPDK retirement Phase 4 —
     broad docs sweep). Per-file disposition table covers ~42 files
@@ -1832,8 +1592,6 @@ top.
     by `TestRetirementBoundaryDocsMentionDPDKPolicy` and the rewrite
     is deferred to #1527/#1528. This PR adds a leading retirement
     note above it instead.
-  - **File(s)**: `docs/pr/1529-dpdk-docs-sweep/plan.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-25T07:30:00Z
   - **Action**: #1538 plan v1 (DRAFT) — accumulate strict validation
     errors via `errors.Join` in `compileExpanded` so `commit check`
@@ -1846,8 +1604,6 @@ top.
     (`strings.Contains` + `errors.Is` traverse `errors.Join`), and
     risk table. Calls out 7 hostile reviewer questions including
     PLAN-KILL grounds.
-  - **File(s)**: `docs/pr/1538-multierror-validation/plan.md`,
-    `_Log.md`
 - **Timestamp**: 2026-05-25T15:15:18Z
   - **Action**: #1539 Copilot follow-up on PR #1553. Tightened
     `pkg/config/dpdk_subtree_leakage_canary_test.go` so a
@@ -1861,8 +1617,6 @@ top.
     is restored here (the previous trailing "Added" was an
     artifact of an over-aggressive _Log.md rebase-union helper).
   - **File(s)**: pkg/config/dpdk_subtree_leakage_canary_test.go,
-    _Log.md
-
 - **Timestamp**: 2026-05-25T16:25:00Z
   - **Action**: #1539 Copilot round-3 finding addressed. After
     HEAD f90125b3 + docs commit 4a1c8726, Copilot's re-review
@@ -1879,8 +1633,6 @@ top.
     is no `pkg/config/dpdk/` today. Future canary scope
     extensions add explicit relative paths (e.g.
     `pkg/dataplane/dpdk`).
-  - **File(s)**: pkg/config/dpdk_subtree_leakage_canary_test.go,
-    _Log.md
 - **Timestamp**: 2026-05-25T16:00:00Z
   - **Action**: #1539 Copilot findings on PR #1553 — 5 valid
     findings on HEAD 12237f12 addressed across two commits
@@ -1892,7 +1644,6 @@ top.
     nil enclosing FuncDecl as an automatic finding with
     distinct `package-scope read/passthrough of ...` why
     text. New
-    `TestDPDKSubtreeLeakageCanary_NegativeRejectsPackageScopeInitializer`
     exercises both kinds.
     (2) RepoRoot inconsistency: `dpdkSubtreeLeakageCanaryRepoRoot
     = ".."` then joined with "config" was confusing; replaced
@@ -1904,10 +1655,7 @@ top.
     (4) Duplicate "Plan v1" header in reviewer-ids.md removed.
     All 11 canary tests pass; 5x flake-clean; full pkg/config
     suite green.
-  - **File(s)**: pkg/config/dpdk_subtree_leakage_canary_test.go,
-    _Log.md
     docs/pr/1539-ast-leakage-guard/reviewer-ids.md, _Log.md
-- **Timestamp**: 2026-05-25T15:50:00Z
   - **Action**: #1539 code-review on PR #1553 + lint fix
     (commit 6a7d0649). Codex MERGE-READY directly on 8c5a4ced
     (session 019e5fa4 continued). AGY initially MERGE-WITH-MAJOR
@@ -1922,8 +1670,6 @@ top.
     Both reviewers now MERGE-READY on 6a7d0649. Hand-rolled itoa
     swapped for strconv.Itoa. All 10 canary tests pass; full
     `go test ./...` clean.
-  - **File(s)**: pkg/config/dpdk_subtree_leakage_canary_test.go,
-    docs/pr/1539-ast-leakage-guard/reviewer-ids.md, _Log.md
 - **Timestamp**: 2026-05-25T15:25:00Z
   - **Action**: #1539 implementation — Option A + Option B per
     plan v3. Option A: `cfg.System.DPDKDataplane = nil` clear at
@@ -1940,8 +1686,6 @@ top.
     to-nil is recognized so Option A's clear is not flagged.
     Real-repo scan returns zero findings; 5x flake-clean on
     named tests; `go test ./...` passes across all 30 packages.
-  - **File(s)**: pkg/config/compiler.go,
-    pkg/config/dpdk_subtree_leakage_canary_test.go, _Log.md
 - **Timestamp**: 2026-05-25T14:50:00Z
   - **Action**: #1539 plan v3 — applied round-2 plan review
     feedback. Codex round-2 PLAN-MINOR (session
@@ -1957,8 +1701,6 @@ top.
     fcd53beb. Reviewer-IDs file updated.
   - **File(s)**: docs/pr/1539-ast-leakage-guard/plan.md,
     docs/pr/1539-ast-leakage-guard/reviewer-ids.md
-
-- **Timestamp**: 2026-05-25T05:00:00Z
   - **Action**: #1501 A2 — replaced the stale TODO + contradictory
     doc comment on `write_outer_ipv4_udp` with an honest
     RFC-grounded comment explaining that the engine intentionally
@@ -1976,7 +1718,6 @@ top.
     PLAN-READY) both agreed before code touched.
   - **File(s)**: `userspace-dp/src/afxdp/wg/outer.rs`,
     `docs/pr/1501-a2-outer-udp-cs/plan.md`, `_Log.md`
-  - **Validation**: cargo build --release clean; cargo test
     --release for `afxdp::wg::outer` 6/6 pass (5x flake-checked);
     full cargo suite 1417 passed modulo two pre-existing flaky
     tests on origin/master da103d81 baseline
@@ -1988,7 +1729,6 @@ top.
     0-retrans single-stream + 23 Gb/s 12-stream `-R`, and
     Pass B (CoS on) 24-cell per-class shaper smoke 5201-5206 ×
     v4+v6 × push+rev with shape rates hit cleanly.
-- **Timestamp**: 2026-05-25T05:30:00Z
   - **Action**: Addressed Copilot's 4 nits on PR #1534 (DPDK
     operator docs retirement, #1531). Harmonized retirement banners
     in `docs/dataplane-decision-dpdk-vs-vpp.md` and
@@ -2012,9 +1752,7 @@ top.
     (the README wording fix is the only file outside `docs/`).
     No `.go` / `.rs` / `.c` source, no build inputs, no test
     fixtures modified.
-
 ## 2026-05-24
-
 - **Timestamp**: 2026-05-24T06:35:00Z
   - **Action**: PR #1531 implementation v2 — applied retirement
     banner + Current State + reframed VPP revisit trigger +
@@ -2035,18 +1773,15 @@ top.
     Historical sections kept verbatim under bold-block retired
     banners with all original H2 headings demoted to H3 inside
     the retired wrapper.
-  - **File(s)**: `docs/dataplane-decision-dpdk-vs-vpp.md`,
     `docs/dpdk-dataplane.md`,
     `docs/vpp-dataplane-assessment.md`,
     `userspace-dp/README.md`
-
 - **Timestamp**: 2026-05-24T00:00:00Z
   - **Action**: PR #1531 plan v1 drafted. Retire DPDK
     recommendations in `docs/dataplane-decision-dpdk-vs-vpp.md`
     and `docs/dpdk-dataplane.md`; rewrite both as short
     retirement notices pointing at #1525.
   - **File(s)**: `docs/pr/1531-dpdk-docs-retire/plan.md`
-
 ## 2026-05-25 (earlier — prior PR follow-ups)
 - **Timestamp**: 2026-05-25T07:05:00Z
   - **Action**: #1527 round-7 Copilot follow-up. Copilot review on
@@ -2069,7 +1804,6 @@ top.
     `pkg/daemon/daemon_ha_sync.go`, `_Log.md`
   - **Validation**: `go build ./...` clean; `go test
     ./pkg/dataplane/... ./pkg/daemon/... -count=1` clean.
-
 - **Timestamp**: 2026-05-25T05:55:15Z
   - **Action**: #1527 final Copilot re-review follow-up — resolved three
     remaining consistency nits from the latest Copilot inline pass:
@@ -2084,8 +1818,6 @@ top.
   - **File(s)**: `pkg/config/compiler_system.go`,
     `pkg/daemon/daemon_ha_sync.go`,
     `docs/pr/1527-dpdk-boot-decouple/plan.md`, `_Log.md`
-
-- **Timestamp**: 2026-05-25T06:50:00Z
   - **Action**: #1527 reviewer re-dispatch on 878bcbdd after my
     earlier v3 NPE-fix commit landed. Codex hostile re-review
     (task-mpks5yrq-4h7ia5) and Antigravity adversarial re-review
@@ -2105,7 +1837,6 @@ top.
     docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md. Smoke posted as
     PR comment 4531859958.
   - **File(s)**: `docs/pr/1527-dpdk-boot-decouple/reviewer-ids.md`
-
 - **Timestamp**: 2026-05-25T06:40:00Z
   - **Action**: #1527 v4 — Codex hostile code review v3
     (task-mpkrwbtk-pd6nnw MERGE-NEEDS-MAJOR) and Antigravity
@@ -2130,8 +1861,6 @@ top.
     suite clean.
   - **File(s)**: `pkg/daemon/daemon_ha_sync.go`,
     `docs/pr/1527-dpdk-boot-decouple/plan.md`
-
-- **Timestamp**: 2026-05-25T06:00:00Z
   - **Action**: #1527 Copilot review response — Copilot flagged on
     `47a4278c` that returning `ErrDPDKBackendRetired` at construction
     time in `NewRuntimeDataPlane` is now fatal in
@@ -2148,8 +1877,6 @@ top.
     needed (`errors` already imported). Build clean,
     `go test ./pkg/dataplane/... ./pkg/daemon/...` clean.
   - **File(s)**: `pkg/daemon/daemon_run.go`
-
-- **Timestamp**: 2026-05-25T06:30:00Z
   - **Action**: #1527 second Copilot review pass — addressed MUST FIX
     and SHOULD FIX items from prior adversarial review: (1) Added
     TypeDPDK panic guard to RegisterBackend and RegisterRuntimeBackend
@@ -2162,13 +1889,8 @@ top.
     ebpf, userspace" instead of "valid: ebpf, dpdk, userspace".
     Build clean, go test ./pkg/dataplane/... ./pkg/daemon/...
     ./pkg/config/... clean.
-  - **File(s)**: `pkg/dataplane/dataplane.go`,
     `pkg/dataplane/dpdk/dpdk_stub_test.go`,
     `pkg/config/compiler_system.go`, `_Log.md`
-
-
-## 2026-05-24
-
 - **Timestamp**: 2026-05-24T12:00:00Z
   - **Action**: #1527 DPDK retirement Phase 2 (boot-path decouple) —
     drafted plan v1 covering blank-import removal, init()
@@ -2179,7 +1901,6 @@ top.
     adversarial review and explicit out-of-scope list to keep
     Chain A (#1526) and Chain C (#1528/#1529) lanes clean.
   - **File(s)**: `docs/pr/1527-dpdk-boot-decouple/plan.md`
-
 - **Timestamp**: 2026-05-24T18:30:00Z
   - **Action**: #1527 plan v2 — incorporated Codex hostile plan
     review (task-mpkqsgf5-j2yag1, PLAN-NEEDS-MINOR). Three MUST-FIX
@@ -2195,8 +1916,6 @@ top.
     errDPDKBuildTagRequired claim (it's !dpdk-gated, not a
     defense-in-depth for -tags dpdk). Antigravity PLAN-READY
     (adversarial-review-mpkqkzkm-qfa19j) verdict preserved.
-  - **File(s)**: `docs/pr/1527-dpdk-boot-decouple/plan.md`
-
 - **Timestamp**: 2026-05-24T19:00:00Z
   - **Action**: #1527 implementation. Removed the
     `_ "github.com/psaab/xpf/pkg/dataplane/dpdk"` blank import
@@ -2239,7 +1958,6 @@ top.
     `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane ./pkg/dataplane/userspace`
     targeted runs for the AC-pinned canary/regression test set.
-
 - **Timestamp**: 2026-05-25T00:45:00Z
   - **Action**: PR #1512 review follow-up — tightened the positional
     `dataplane.Manager` literal canary on two axes. (a) Recurse into nested
@@ -2254,7 +1972,6 @@ top.
   - **Validation**: `go test ./pkg/dataplane/ -count=1`;
     `go test ./pkg/dataplane/ -count=1 -run
     'TestRetainedUserspaceShimBoundary|TestPositionalDataplaneManager' -v`
-
 - **Timestamp**: 2026-05-25T00:30:00Z
   - **Action**: PR #1499 r-final-6 fix — rebased onto current
     `origin/master` after PR #1511 merged. Resolved chronological
@@ -2284,7 +2001,6 @@ top.
     clean (114 warnings, all pre-existing); `cargo test --release
     --bin xpf-userspace-dp afxdp::wg` — 78/78 pass; `go test
     ./pkg/dataplane/...` — 4/4 packages pass.
-
 - **Timestamp**: 2026-05-24T23:30:00Z
   - **Action**: PR #1499 r-final-5 step 4 — final mechanical sweep
     pass. After the previous step's edits shifted lines in
@@ -2312,7 +2028,6 @@ top.
     tx/dispatch.rs:430/785-792/1458-1459, frame/mod.rs:212,
     frame/tcp_segmentation.rs:309, tunnel.rs:189) re-verified.
   - **File(s)**: docs/pr/wireguard-clean/plan.md
-
 - **Timestamp**: 2026-05-24T23:15:00Z
   - **Action**: PR #1499 r-final-5 fix step 3 — line-citation offsets
     + stale field-name drift + scratch.rs MAX_FRAME doc-comment.
@@ -2345,7 +2060,6 @@ top.
     userspace-dp/src/afxdp/wg/allowed_ips.rs,
     userspace-dp/src/afxdp/wg/scratch.rs,
     pkg/dataplane/userspace/protocol.go
-
 - **Timestamp**: 2026-05-24T23:05:00Z
   - **Action**: PR #1499 r-final-5 fix step 2 — integration-PR pointer
     rewritten. plan.md "Encap call site" claimed dispatch.rs:430 was
@@ -2360,8 +2074,6 @@ top.
     that dispatch.rs:430 *computes the gate*, it does not itself
     encap. Also updated the "What's OUT" bullet that referenced
     `tx/dispatch.rs` activation to enumerate the same three sites.
-  - **File(s)**: docs/pr/wireguard-clean/plan.md
-
 - **Timestamp**: 2026-05-24T23:00:00Z
   - **Action**: PR #1499 r-final-5 fix pass start — exhaustive mechanical
     plan.md sweep against actual source. Step 1 fixed: WG data-record
@@ -2375,8 +2087,6 @@ top.
     updated the handshake-scope bullet to match; fixed the IPv4/IPv6
     outer overhead breakdown to call out the `WG_DATA_HEADER_LEN` /
     `POLY1305_TAG_LEN` constants directly.
-  - **File(s)**: docs/pr/wireguard-clean/plan.md
-
 - **Timestamp**: 2026-05-24T22:00:00Z
   - **Action**: PR #1499 r-final-4 fix — closed Codex MAJOR (5 plan.md
     drifts) and Copilot 2 inline findings on the r-final-3 commit
@@ -2431,7 +2141,6 @@ top.
     - **File(s)**: `docs/pr/wireguard-clean/plan.md`,
       `pkg/dataplane/userspace/protocol.go`,
       `userspace-dp/src/afxdp/wg/engine.rs`, `_Log.md`.
-
 - **Timestamp**: 2026-05-24T20:58:00Z
   - **Action**: PR #1451 review follow-up — extended the RT_FLOW
     wire-offset canary across the full raw event layout and tightened
@@ -2441,15 +2150,11 @@ top.
     `go test ./pkg/logging -run
     'TestRawEventFieldOffsetsMatchWireFormat|TestDecodeRawEventRecordRejectsShortRecord|TestProcessRawEventRejectsShortRecord'
     -count=1`; `git diff --check`
-
 - **Timestamp**: 2026-05-24T20:47:00Z
   - **Action**: PR #1451 review follow-up — added direct RT_FLOW wire-offset
     assertions and explicit short-record rejection tests for the logging event
     decoder/reader without widening the production boundary again.
-  - **File(s)**: `pkg/logging/binary_test.go`, `_Log.md`
-  - **Validation**: `go test ./pkg/logging ./pkg/dataplane -count=1`;
     `git diff --check`
-
 - **Timestamp**: 2026-05-24T20:30:00Z
   - **Action**: PR #1499 r-final-3 fix — rebased onto current
     `origin/master` (resolved `_Log.md` conflicts chronologically across
@@ -2483,7 +2188,6 @@ top.
     --release --bin xpf-userspace-dp afxdp::wg` — 78/78 pass (same as
     pre-rebase; doc-only changes for this commit on top of the rebased
     crypto changes); `git diff --check` clean.
-
 - **Timestamp**: 2026-05-24T19:26:45Z
   - **Action**: #1451 logging boundary shrink — moved the logging event
     reader to a package-local `EventSource` interface and RT_FLOW event wire
@@ -2492,11 +2196,7 @@ top.
     entry.
   - **File(s)**: `pkg/logging/ringbuf.go`,
     `pkg/logging/binary_test.go`,
-    `pkg/dataplane/retirement_boundary_canary_test.go`,
-    `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
-  - **Validation**: `go test ./pkg/logging ./pkg/dataplane -count=1`;
     `go test ./pkg/daemon ./pkg/dataplane/userspace -count=1`;
-
 - **Timestamp**: 2026-05-24T19:29:17Z
   - **Action**: Issue #1504 implementation — hardened the retained
     userspace shim boundary canary against positional package-local
@@ -2507,13 +2207,10 @@ top.
     assumptions and allowlisted only generated legacy bpf2go architecture
     tags plus the ignored loader stub.
   - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`,
-    `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane -run
     'TestRetainedUserspaceShimBoundaryCanary|TestRetirementBoundaryDocsMentionShimEscapeAssumptions'
     -count=1`; `go test ./pkg/dataplane -run
     'Retirement|Canary|Userspace.*Entry|BPFShim' -count=1`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-24T18:47:00Z
   - **Action**: PR #1508 copilot follow-up — moved `IPERF_TIMEOUT` defaulting
     after argument parsing and env-file sourcing so the default tracks the
@@ -2523,38 +2220,22 @@ top.
     section.
   - **File(s)**: `scripts/userspace-ha-validation.sh`,
     `scripts/userspace_ha_validation_matrix_test.py`, `.gitignore`,
-    `_Log.md`
   - **Validation**: `bash -n scripts/userspace-ha-validation.sh
     scripts/userspace-phase-cycle.sh`; `shellcheck
     scripts/userspace-ha-validation.sh scripts/userspace-phase-cycle.sh`;
     `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-24T18:40:00Z
   - **Action**: PR #1508 adversarial follow-up — validated and escaped the
     remaining iperf runtime knobs before composing remote `bash -lc` commands,
     and added dry-run regressions so `DURATION`, `PARALLEL`, and
     `IPERF_TIMEOUT` cannot carry shell syntax into the HA smoke matrix.
-  - **File(s)**: `scripts/userspace-ha-validation.sh`,
     `scripts/userspace_ha_validation_matrix_test.py`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-phase-cycle.sh`; `shellcheck
-    scripts/userspace-ha-validation.sh scripts/userspace-phase-cycle.sh`;
-    `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-24T18:24:00Z
   - **Action**: PR #1508 copilot follow-up — hardened `run_iperf_json`
     remote command construction by shell-escaping the target and temporary
     output paths so env-driven target overrides cannot inject shell syntax
     into host-side iperf execution.
   - **File(s)**: `scripts/userspace-ha-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-phase-cycle.sh`; `shellcheck
-    scripts/userspace-ha-validation.sh scripts/userspace-phase-cycle.sh`;
-    `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-24T18:21:49Z
   - **Action**: PR #1508 review follow-up: made iperf JSON metrics prefer
     receiver-side end summaries so reverse cells gate on received throughput,
@@ -2566,26 +2247,12 @@ top.
     `scripts/userspace-ha-validation.sh`,
     `scripts/userspace_ha_validation_matrix_test.py`,
     `docs/pr/1373-retire-ebpf-dataplane/smoke-gates.md`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-phase-cycle.sh`; `shellcheck
-    scripts/userspace-ha-validation.sh scripts/userspace-phase-cycle.sh`;
-    `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-24T18:01:21Z
   - **Action**: PR #1508 review follow-up — added script-local
     documentation for the four smoke-matrix iperf port overrides, hardened
     remote iperf port argument construction, and expanded invalid-port
     dry-run coverage across all four override variables plus boundary
     values.
-  - **File(s)**: `scripts/userspace-ha-validation.sh`,
-    `scripts/userspace_ha_validation_matrix_test.py`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-phase-cycle.sh`; `shellcheck
-    scripts/userspace-ha-validation.sh scripts/userspace-phase-cycle.sh`;
-    `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-24T16:56:30Z
   - **Action**: PR #1506 review follow-up — normalized RFC3339 leap-second
     validation through UTC before accepting `:60` offset forms, and reported
@@ -2597,22 +2264,11 @@ top.
     retire_ebpf_artifact_schema_test.py`; `python3 -m py_compile
     test/incus/retire_ebpf_artifact_schema.py
     test/incus/retire_ebpf_artifact_schema_test.py`; `git diff --check`
-
 - **Timestamp**: 2026-05-24T16:56:31Z
   - **Action**: PR #1508 review follow-up — validated smoke-matrix iperf
     port overrides, documented the override contract, and hoisted the
     CoS-off matrix precheck before full-matrix perf capture so profiling
     cannot run against an already-shaped cluster.
-  - **File(s)**: `scripts/userspace-ha-validation.sh`,
-    `scripts/userspace_ha_validation_matrix_test.py`,
-    `docs/pr/1373-retire-ebpf-dataplane/smoke-gates.md`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-phase-cycle.sh`; `shellcheck
-    scripts/userspace-ha-validation.sh scripts/userspace-phase-cycle.sh`;
-    `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
-    `git diff --check`
-
-- **Timestamp**: 2026-05-24T18:00:00Z
   - **Action**: PR #1499 r-final-2 fix — address every actionable
     finding from the round-final triple-review on `62d2353c`. (1)
     Truncated-record remote DoS in `try_decap`: a 16..31-byte UDP
@@ -2667,8 +2323,6 @@ top.
     pass; 5/5 flake check clean on both new tests. Go suite clean.
   - **File(s)**: `userspace-dp/src/afxdp/wg/engine.rs`,
     `userspace-dp/src/afxdp/wg/tests.rs`,
-    `docs/pr/wireguard-clean/plan.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-24T19:30:00Z
   - **Action**: PR #1499 r-final-fix — close the four findings Codex
     final pre-merge review surfaced after nine prior review rounds
@@ -2702,16 +2356,13 @@ top.
     `userspace-dp/src/afxdp/wg/engine.rs`,
     `userspace-dp/src/afxdp/wg/session.rs`,
     `userspace-dp/src/afxdp/wg/peer.rs`,
-    `userspace-dp/src/afxdp/wg/tests.rs`,
     `userspace-dp/src/protocol.rs`,
-    `docs/pr/wireguard-clean/plan.md`, `_Log.md`
   - **Validation**: `cargo build --release`: clean (114 pre-existing
     warnings); `cargo test --release --bin xpf-userspace-dp
     afxdp::wg`: 76/76 pass (was 71; +5 new regressions);
     `cargo test --release --bin xpf-userspace-dp`: 1413/1413 pass
     (was 1408; the same +5 new tests); each new test passes 5/5
     runs in isolation.
-
 - **Timestamp**: 2026-05-24T15:14:30Z
   - **Action**: PR #1494 round-11 follow-up — collapsed the retained
     userspace XDP shim entry-program name onto one dataplane constant and
@@ -2721,29 +2372,17 @@ top.
   - **File(s)**: `pkg/dataplane/loader.go`,
     `pkg/dataplane/loader_ebpf.go`,
     `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane -run
     'TestBPFShimEntryProgramStateIsNotJSONMutable|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|TestUserspaceXDPEntryProgramConstantNamesRetainedShim'`;
     `go test ./pkg/dataplane/userspace -run
     'TestUserspaceShimLoaderDoesNotReferenceLegacyObjects|TestUserspaceStartupUsesShimLoaderBoundary'`;
     `go test ./pkg/dataplane ./pkg/dataplane/userspace`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-24T06:08:39Z
   - **Action**: PR #1508 review follow-up — made HA smoke-matrix iperf
     ports explicit so CoS-on cells use port 5211's uncapped-root class
     instead of iperf3's default 5201 / 100 Mbps class, and moved full-matrix
     perf capture ahead of CoS fixture application so flamegraphs stay on a
     clean CoS-off baseline.
-  - **File(s)**: `scripts/userspace-ha-validation.sh`,
-    `scripts/userspace_ha_validation_matrix_test.py`,
     `docs/pr/1373-retire-ebpf-dataplane/README.md`,
-    `docs/pr/1373-retire-ebpf-dataplane/smoke-gates.md`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-phase-cycle.sh`; `shellcheck
-    scripts/userspace-ha-validation.sh scripts/userspace-phase-cycle.sh`;
-    `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-24T06:06:58Z
   - **Action**: PR #1505 review follow-up — changed the SYN-cookie
     `docs/feature-gaps.md` row to point at final #1477 source-removal
@@ -2753,7 +2392,6 @@ top.
   - **Validation**: `rg -n "#1375|#1378|SYN-cookie|source-removal"
     docs/feature-gaps.md docs/pr/1373-retire-ebpf-dataplane/README.md
     docs/pr/1373-retire-ebpf-dataplane/plan.md`; `git diff --check`
-
 - **Timestamp**: 2026-05-24T04:51:19Z
   - **Action**: Issue #1500 userspace HA smoke matrix: added an explicit
     `--smoke-matrix` mode that runs IPv4 push, IPv4 reverse, IPv6 push, and
@@ -2761,17 +2399,7 @@ top.
     applying the existing symmetric CoS fixture; kept the fast current-CoS
     IPv4/IPv6 push readiness mode distinct; made `userspace-phase-cycle.sh`
     invoke the full matrix by default for standard smoke evidence.
-  - **File(s)**: `scripts/userspace-ha-validation.sh`,
     `scripts/userspace-phase-cycle.sh`,
-    `scripts/userspace_ha_validation_matrix_test.py`,
-    `docs/pr/1373-retire-ebpf-dataplane/README.md`,
-    `docs/pr/1373-retire-ebpf-dataplane/smoke-gates.md`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-phase-cycle.sh`; `shellcheck
-    scripts/userspace-ha-validation.sh scripts/userspace-phase-cycle.sh`;
-    `python3 -m unittest scripts.userspace_ha_validation_matrix_test`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-24T04:08:49Z
   - **Action**: PR #1497 round-3 follow-up — fixed the checker/schema
     parity nits from review: boolean `schema_version` rejection, JSON
@@ -2779,9 +2407,6 @@ top.
     acceptance, reachable empty `config_files` validation, parsed fallback
     JSON artifacts, and Unicode decode failures reported as validation
     errors instead of tracebacks.
-  - **File(s)**: `test/incus/retire_ebpf_artifact_schema.py`,
-    `test/incus/retire_ebpf_artifact_schema_test.py`, `_Log.md`
-  - **Validation**: `python3 -m unittest discover -s test/incus -p
     retire_ebpf_artifact_schema_test.py`;
     `python3 test/incus/retire_ebpf_artifact_schema_test.py`;
     `python3 -m py_compile test/incus/retire_ebpf_artifact_schema.py
@@ -2789,26 +2414,13 @@ top.
     `python3 -m json.tool
     docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json
     >/dev/null`; `git diff --check`
-
 - **Timestamp**: 2026-05-24T03:46:48Z
   - **Action**: PR #1497 round-2 follow-up — aligned the Python #1477
     artifact checker with the manifest schema's required-field, uniqueness,
     non-empty string, command artifact, and RFC3339 date-time constraints.
     Added hostile regression tests for the schema/checker drift cases raised
     in PR review.
-  - **File(s)**: `test/incus/retire_ebpf_artifact_schema.py`,
-    `test/incus/retire_ebpf_artifact_schema_test.py`, `_Log.md`
-  - **Validation**: `python3 -m unittest discover -s test/incus -p
-    retire_ebpf_artifact_schema_test.py`;
-    `python3 test/incus/retire_ebpf_artifact_schema_test.py`;
-    `python3 -m py_compile test/incus/retire_ebpf_artifact_schema.py
-    test/incus/retire_ebpf_artifact_schema_test.py`;
-    `python3 -m json.tool
-    docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json
-    >/dev/null`; `git diff --check`
-
 ## 2026-05-23
-
 - **Timestamp**: 2026-05-23T17:01:19Z
   - **Action**: PR #1494 round-9 follow-up — encapsulated the retained shim
     entry-program state by unexporting `XDPEntryProg`, removed the arbitrary
@@ -2816,40 +2428,23 @@ top.
     selection/swap methods plus a JSON-mutability canary. Updated userspace
     call sites and docs to describe the structural boundary instead of relying
     on decoder-shape blocklists.
-  - **File(s)**: `pkg/dataplane/loader.go`,
-    `pkg/dataplane/retirement_boundary_canary_test.go`,
-    `pkg/dataplane/userspace/manager.go`,
     `pkg/dataplane/userspace/maps_sync.go`,
-    `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane -run
     'TestBPFShimEntryProgramStateIsNotJSONMutable|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|TestUserspaceEntryProgramCanaryRejectsBypassFixtures|TestUserspaceEntryProgramCanaryAllowsCrossFileConstantFixture|TestUserspaceXDPEntryProgramConstantNamesRetainedShim'
     -count=1 -v`; `go test ./pkg/dataplane ./pkg/dataplane/userspace
     -count=1`; `go test ./pkg/dataplane/... -count=1`; `go test ./...
-    -count=1`; `git diff --check`
-
 - **Timestamp**: 2026-05-23T15:58:00Z
   - **Action**: PR #1494 round-8 follow-up — hardened JSON decoder canary
     laundering checks for stored decoder receivers, function-variable
     `Unmarshal` callees, tuple-return spread into `Unmarshal`, and default
     import-name resolution for versioned import paths (e.g. `encoding/json/v2`);
     added dedicated fixtures for each bypass shape.
-  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane -run
     'TestUserspaceEntryProgramCanaryRejectsBypassFixtures|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|TestUserspaceEntryProgramCanaryAllowsCrossFileConstantFixture'
     -count=1 -v`; `go test ./pkg/dataplane ./pkg/dataplane/userspace -count=1`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-23T09:52:00Z
   - **Action**: PR #1494 r7 copilot re-review follow-up — hardened
     `encoding/json` canary detection to catch decode targets laundered through
     local aliases of `bpfShim`, and added fixture coverage for unmarshal/decode
     alias bypass shapes.
-  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane -run
-    'TestUserspaceEntryProgramCanaryRejectsBypassFixtures|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram|TestUserspaceEntryProgramCanaryAllowsCrossFileConstantFixture'
-    -count=1 -v`; `go test ./pkg/dataplane ./pkg/dataplane/userspace -count=1`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-23T09:31:43Z
   - **Action**: PR #1493 r2 copilot follow-up — restored `"impact"` slog key
     on native-XDP fallback warning in `attachUserspaceShimXDP` so operator
@@ -2857,35 +2452,22 @@ top.
   - **File(s)**: `pkg/dataplane/loader.go`, `_Log.md`
   - **Validation**: `go build ./pkg/dataplane/...`;
     `go test ./pkg/dataplane/... -count=1`
-
 - **Timestamp**: 2026-05-23T06:12:00Z
   - **Action**: PR #1494 r7 copilot re-review follow-up — hardened the
     retirement-boundary canary to catch `encoding/json` decode mutations via
     dot-import `Unmarshal` and `NewDecoder(...).Decode` paths, including
     `encoding/json/v2`, and added fixture coverage for each bypass shape.
-  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane -run
     'TestUserspaceEntryProgramCanaryRejectsBypassFixtures|TestUserspaceManagerSelectsOnlyUserspaceXDPEntryProgram'
     -count=1`; `go test ./pkg/dataplane ./pkg/dataplane/userspace -count=1`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-23T04:58:00Z
   - **Action**: PR #1494 copilot round-5 follow-up — hardened the canary
     walker to treat wrapped SwapXDPEntryProg callees as direct calls and added
     bypass fixtures for parenthesized/method-expression/slice-indexed calls.
-  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane ./pkg/dataplane/userspace`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-23T03:45:00Z
   - **Action**: PR #1494 copilot re-review hardening — made the userspace
     entry-program canary reject shadowed local identifiers so only the package
     constant `userspaceXDPEntryProg` can satisfy XDP entry assignments/calls.
-  - **File(s)**: `pkg/dataplane/retirement_boundary_canary_test.go`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane ./pkg/dataplane/userspace`;
-    `git diff --check`
-## 2026-05-23
-
 - **Timestamp**: 2026-05-23T21:25:00Z
   - **Action**: PR #1499 @copilot round-6 follow-up — serialized
     WireGuard `install_session` with `reconcile_peers` using the
@@ -2896,7 +2478,6 @@ top.
     `cargo test --release afxdp::wg::`
     (fails in this runner as expected: missing `libelf`/`gelf` headers
     for `libbpf-sys` build); `git diff --check`
-
 - **Timestamp**: 2026-05-23T07:07:56Z
   - **Action**: PR #1499 @copilot review round-3 follow-up — corrected
     WireGuard `REJECT_AFTER_MESSAGES` to the WG spec value, changed
@@ -2906,11 +2487,6 @@ top.
     replay precheck concurrency semantics.
   - **File(s)**: `userspace-dp/src/afxdp/wg/session.rs`,
     `userspace-dp/src/afxdp/wg/engine.rs`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane/userspace/...`;
-    `cargo test --release afxdp::wg::`
-    (fails in this runner as expected: missing `libelf`/`gelf` headers
-    for `libbpf-sys` build); `git diff --check`
-
 - **Timestamp**: 2026-05-23T06:32:50Z
   - **Action**: PR #1499 @copilot review follow-up — fixed WireGuard
     engine conformance and robustness issues by switching to IKpsk2
@@ -2919,34 +2495,20 @@ top.
     stale demux sessions across rekeys, tightening the overlapping
     cryptokey-routing test to exercise both live peers, and removing
     the unused `rand` dependency.
-  - **File(s)**: `userspace-dp/src/afxdp/wg/mod.rs`,
-    `userspace-dp/src/afxdp/wg/engine.rs`,
-    `userspace-dp/src/afxdp/wg/session.rs`,
     `userspace-dp/src/afxdp/wg/allowed_ips.rs`,
-    `userspace-dp/src/afxdp/wg/peer.rs`,
     `userspace-dp/src/afxdp/wg/framing.rs`,
-    `userspace-dp/src/afxdp/wg/tests.rs`,
     `userspace-dp/Cargo.toml`, `userspace-dp/Cargo.lock`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane/userspace/...`;
-    `cargo test --release afxdp::wg::`
-    (fails in this runner as expected: missing `libelf`/`gelf` headers
-    for `libbpf-sys` build); `git diff --check`
-
 ## 2026-05-22
-
 - **Timestamp**: 2026-05-22T20:20:00Z
   - **Action**: PR #1491 r6 review closeout — removed the remaining
     supported-runtime `FW0` arm fallback, made supported-runtime owner
     waits fail closed on ambiguous ownership, and converted status summary
     counter reads from `__ERR__` sentinel math to explicit fail-closed
     delta helpers.
-  - **File(s)**: `scripts/userspace-ha-validation.sh`,
     `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
     scripts/userspace-ha-failover-validation.sh`; `shellcheck
     scripts/userspace-ha-validation.sh
     scripts/userspace-ha-failover-validation.sh`; `git diff --check`
-
 - **Timestamp**: 2026-05-22T20:02:00Z
   - **Action**: PR #1491 copilot follow-up — clarified unmatched-interface
     parser failures to include the count of malformed binding rows that were
@@ -2954,17 +2516,11 @@ top.
     shape is also broken.
   - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
   - **Validation**: `bash -n scripts/userspace-ha-failover-validation.sh`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-22T19:55:00Z
   - **Action**: PR #1491 copilot follow-up — tightened userspace binding
     parser diagnostics so malformed short rows are tracked separately from
     valid rows, avoiding misleading "no interface match" errors when the
     binding table format is broken.
-  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-failover-validation.sh`;
-    `git diff --check`
-
 - **Timestamp**: 2026-05-22T18:45:00Z
   - **Action**: PR #1491 r4 closeout — made userspace RG owner
     selection reject split-brain, require the post-failover owner to match
@@ -2972,684 +2528,465 @@ top.
     peer cannot be queried, and make the startup arm path refuse split-brain
     states. Removed the remaining transition-window sample `|| true`
     masking and negative-delta clamps.
-  - **File(s)**: `scripts/userspace-ha-validation.sh`,
-    `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
-
 - **Timestamp**: 2026-05-22T16:20:00Z
   - **Action**: PR #1491 review cleanup — made the explicit legacy-HA
     validation override require an unambiguous active firewall owner instead
     of falling back to `FW0` when owner detection fails.
-  - **File(s)**: `scripts/userspace-ha-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
-
 - **Timestamp**: 2026-05-22T16:00:00Z
   - **Action**: PR #1491 review cleanup — normalized userspace bindings
     parse error text casing to match the CLI section header terminology.
-  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
-
 - **Timestamp**: 2026-05-22T15:55:00Z
   - **Action**: PR #1491 review closeout — renamed standby WAN baseline
     snapshot variable for clarity, tightened userspace-binding parser
     diagnostics for empty vs unmatched rows, and moved WAN counter delta
     monotonicity checks to Python integer math to avoid shell
     signed-arithmetic edge cases.
-  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
-
 - **Timestamp**: 2026-05-22T15:45:00Z
   - **Action**: PR #1491 review polish — added explicit
     empty-userspace-bindings detection in standby WAN counter parsing and
     simplified standby WAN snapshot-stage failure messages to high-level
     baseline/post-validation diagnostics.
-  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
-
 - **Timestamp**: 2026-05-22T15:35:00Z
   - **Action**: PR #1491 review polish — clarified standby WAN TX snapshot
     failure messages for post-failover baseline vs post-validation captures
     and tightened userspace-binding parse failure checks to fail once with
     explicit context.
-  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
-
 - **Timestamp**: 2026-05-22T15:10:10Z
   - **Action**: PR #1491 follow-up — fixed standby WAN TX failover
     gating by measuring from post-failover baseline snapshots, failing closed
     when userspace binding counters are unavailable, and treating standby WAN
     TX counter resets as validation failures instead of clamping negative
     deltas to zero.
-  - **File(s)**: `scripts/userspace-ha-failover-validation.sh`, `_Log.md`
-  - **Validation**: `bash -n scripts/userspace-ha-validation.sh
-    scripts/userspace-ha-failover-validation.sh`; `git diff --check`
-
 ## 2026-05-21
-
 - **Timestamp**: 2026-05-21T23:30:00Z
   - **Action**: PR #1481 review follow-up — replaced 5 hard-coded `"xdp_userspace_prog"` literal strings with the `userspaceXDPEntryProg` constant in test files to avoid drift if the entry program name changes.
   - **File(s)**: `pkg/dataplane/userspace/maps_sync_cap_test.go`, `pkg/dataplane/userspace/manager_test.go`, `_Log.md`
   - **Validation**: `GOFLAGS=-buildvcs=false go test -count=1 ./pkg/dataplane/userspace ./pkg/dataplane`; `git diff --check`
-
 - **Timestamp**: 2026-05-21T16:25:00Z
   - **Action**: PR #1481 comment follow-up — changed `syncInterfaceNATAddressMapsLocked` to publish desired interface-NAT entries before deleting stale keys (matching the local-map add-before-remove contract), pre-sized NAT RST publish slices from desired-entry count, and added regression tests for both full-map publication failure retention and successful stale-key replacement.
   - **File(s)**: `pkg/dataplane/userspace/maps_sync.go`, `pkg/dataplane/userspace/maps_sync_cap_test.go`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane/userspace ./pkg/dataplane`; `git diff --check`
-
 ## 2026-05-18
-
 - **Timestamp**: 2026-05-18T04:38:00Z
   - **Action**: Issue #1379 dataplane event producer slice — threaded the event-stream worker handle into AF_XDP workers, added fixed-size non-blocking RT_FLOW emit helpers, emitted userspace policy-deny and screen-drop events from packet stages, emitted logged routing-instance/PBR filter hits, carried filter/term/action metadata through routing-instance filter evaluation, and narrowed #1379 docs to end-to-end syslog evidence, non-PBR filter-log coverage, and richer identity mapping.
   - **File(s)**: `userspace-dp/src/afxdp/event_emit.rs`, `userspace-dp/src/afxdp/mod.rs`, `userspace-dp/src/afxdp/poll_descriptor.rs`, `userspace-dp/src/afxdp/poll_stages.rs`, `userspace-dp/src/afxdp/forwarding/mod.rs`, `userspace-dp/src/afxdp/frame/tests.rs`, `userspace-dp/src/afxdp/test_fixtures.rs`, `userspace-dp/src/afxdp/types/runtime.rs`, `userspace-dp/src/afxdp/worker/lifecycle.rs`, `userspace-dp/src/afxdp/worker/mod.rs`, `userspace-dp/src/event_stream/mod.rs`, `userspace-dp/src/event_stream/producer.rs`, `userspace-dp/src/filter/compiler.rs`, `userspace-dp/src/filter/engine.rs`, `userspace-dp/src/filter/mod.rs`, `userspace-dp/src/afxdp/README.md`, `userspace-dp/src/filter/README.md`, `docs/userspace-dataplane-gaps.md`, `_Log.md`
   - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml event_emit -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml session_miss_ack_stage_invokes_syn_cookie_runtime_validation -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml ingress_filter_routing_instance_steers_flow_into_native_gre_table -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml interface_filter_routing_instance_counted_returns_matching_override -- --nocapture`; `go test ./pkg/dataplane/userspace ./pkg/logging`; `git diff --check`
-
 - **Timestamp**: 2026-05-18T04:01:54Z
   - **Action**: Issue #1377 SNAT pool runtime closeout slice — preserved unusable pool-mode source NAT rules in the Go userspace snapshot, added Rust source-NAT failure results for missing/empty/invalid/wrong-family/allocator failures, made the four AF_XDP `poll_descriptor.rs` source-NAT decision sites fail closed with recent-exception records before session creation or forwarding, and refreshed #1377 docs plus the contract guard.
   - **File(s)**: `README.md`, `docs/userspace-dataplane-gaps.md`, `docs/userspace-dataplane-architecture.md`, `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `pkg/dataplane/userspace/protocol.go`, `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `userspace-dp/src/protocol.rs`, `userspace-dp/src/nat.rs`, `userspace-dp/src/nat_tests.rs`, `userspace-dp/src/afxdp/mod.rs`, `userspace-dp/src/afxdp/forwarding/mod.rs`, `userspace-dp/src/afxdp/poll_descriptor.rs`, `userspace-dp/tests/snat_contract_doc_guard.rs`, `_Log.md`
   - **Validation**: `gofmt -w pkg/dataplane/userspace/protocol.go pkg/dataplane/userspace/snapshot.go pkg/dataplane/userspace/manager_test.go`; `cargo test --manifest-path userspace-dp/Cargo.toml pool_snat_`; `cargo test --manifest-path userspace-dp/Cargo.toml --test snat_contract_doc_guard`; `go test ./pkg/dataplane/userspace -run 'TestBuildSourceNATSnapshots'`; `git diff --check`
-
 - **Timestamp**: 2026-05-18T03:59:26Z
   - **Action**: #1378 policy-scheduler closeout slice — added a deterministic userspace scheduler evidence validator for active/rebuild/inactive/failover artifacts, pinned the userspace apply seed path so initial scheduled-policy snapshots do not rely on legacy policy-map updates, and narrowed the #1378 docs to live HA artifact capture only.
   - **File(s)**: `test/incus/policy_scheduler_validate.py`, `test/incus/policy_scheduler_validate_test.py`, `pkg/daemon/policy_scheduler_apply_test.go`, `docs/userspace-dataplane-gaps.md`, `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `_Log.md`
   - **Validation**: `python3 test/incus/policy_scheduler_validate_test.py`; `go test ./pkg/daemon -run 'TestPolicyScheduler|TestApplyConfig.*Scheduler|TestApplyConfig.*Protocol'`; `go test ./pkg/config -run 'Test.*PolicyScheduler.*ReferenceRejectsCommit'`; `go test ./pkg/dataplane/userspace -run 'Test(BuildPolicySnapshotsRoundTripsSchedulerInactiveAndRuleID|UpdatePolicyScheduleState)'`; `cargo test --manifest-path userspace-dp/Cargo.toml policy:: -- --nocapture`
-
 ## 2026-05-17
-
 - **Timestamp**: 2026-05-17T21:25:00Z
   - **Action**: PR #1406 review follow-up — updated the Phase 0 blocker-plan summary so #1377/#1378 match the current userspace runtime contract (userspace-v1 selector landed; residual persistent-NAT/exhaustion/fail-open and scheduler validation work remain).
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/plan.md`, `_Log.md`
   - **Validation**: `git diff --check`
-
 - **Timestamp**: 2026-05-17T19:59:18Z
   - **Action**: PR #1406 round-1 contract follow-up — corrected the #1377 SNAT pool plan so current userspace pool handling is documented as runtime fail-open at the four `poll_descriptor.rs` source-NAT call sites, enumerated the risk and code prerequisites for a later fail-closed runtime gate, and added a SNAT contract doc guard.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `userspace-dp/tests/snat_contract_doc_guard.rs`, `_Log.md`
   - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml --test snat_contract_doc_guard`; `rustfmt --edition 2024 --check userspace-dp/tests/snat_contract_doc_guard.rs`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T22:36:08Z
   - **Action**: PR #1408 r5 re-review follow-up — corrected mirror counter doc wording so `mirror_drops_no_frame` no longer claims TX-frame-reserve drops (those now have dedicated `mirror_drops_tx_frame_reserve` telemetry).
   - **File(s)**: `userspace-dp/src/afxdp/umem/mod.rs`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane/userspace`; `cargo test --manifest-path userspace-dp/Cargo.toml mirror::` (expected environment failure: missing libelf headers/pkg-config); `git diff --check`
-
 - **Timestamp**: 2026-05-17T21:58:24Z
   - **Action**: PR #1410 residual review follow-up — made emit-on-wire inject tuple identity an explicit Go/Rust control-wire contract, added helper status gating for mixed-version fail-closed behavior, and stopped Rust from synthesizing source tuple fields for emitted inject packets.
   - **File(s)**: `pkg/dataplane/userspace/protocol.go`, `pkg/dataplane/userspace/inject.go`, `pkg/dataplane/userspace/inject_test.go`, `pkg/dataplane/userspace/protocol_test.go`, `pkg/cmdtree/tree.go`, `userspace-dp/src/protocol.rs`, `userspace-dp/src/server/lifecycle.rs`, `userspace-dp/src/server/README.md`, `userspace-dp/src/afxdp/coordinator/inject.rs`, `userspace-dp/src/afxdp/coordinator/tests.rs`, `userspace-dp/src/afxdp/frame/mod.rs`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane/userspace ./pkg/cmdtree`; `cargo test --manifest-path userspace-dp/Cargo.toml inject_packet -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml injected_packet -- --nocapture`; `cargo check --manifest-path userspace-dp/Cargo.toml`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T21:39:00Z
   - **Action**: PR #1410 review follow-up — reconciled README userspace capability wording so three-color policers are described as partially admitted (color-blind `then discard` slice) rather than fully gated, matching current userspace capability documentation and runtime admission behavior.
   - **File(s)**: `README.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T21:23:55Z
   - **Action**: PR #1410 round-3 blocker follow-up — added explicit pending-forward CoS resolution state so resolved `None`/`None` selections are not metered again, carried metadata-derived ICMP flow keys through local and embedded ICMP prebuilt-forward paths, stamped emitted inject packets with synthetic ICMP tuples before TX selection, and preserved local tunnel tuple metadata through TX.
   - **File(s)**: `userspace-dp/src/afxdp/types/tx.rs`, `userspace-dp/src/afxdp/forward_request.rs`, `userspace-dp/src/afxdp/tx/dispatch.rs`, `userspace-dp/src/afxdp/icmp.rs`, `userspace-dp/src/afxdp/poll_descriptor.rs`, `userspace-dp/src/afxdp/coordinator/inject.rs`, `userspace-dp/src/afxdp/tunnel.rs`, `userspace-dp/src/afxdp/tx/dispatch_tests.rs`, `userspace-dp/src/afxdp/tests.rs`, `userspace-dp/src/afxdp/frame/tests.rs`, `userspace-dp/src/afxdp/coordinator/tests.rs`, `_Log.md`
   - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml build_local_time_exceeded_request -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml pending_forward_cos_resolution -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml stamp_injected_packet_tuple -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml build_live_forward_request_marks_empty_cos_selection_resolved -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml build_live_forward_request_meters_non_l4_metadata_flow -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml three_color -- --nocapture`; `cargo check --manifest-path userspace-dp/Cargo.toml`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T20:30:00Z
   - **Action**: PR #1410 round-1 review follow-up — removed flow-cache hit TX-selection cloning from the packet fast path, switched local ICMP/tunnel/control-packet CoS resolution to timestamped `_at` evaluation with flow-key fallback, and enforced `cos.drop` handling on those paths so three-color policer drops are not bypassed when metadata-only classification is used.
   - **File(s)**: `userspace-dp/src/afxdp/poll_descriptor.rs`, `userspace-dp/src/afxdp/icmp.rs`, `userspace-dp/src/afxdp/tunnel.rs`, `userspace-dp/src/afxdp/coordinator/inject.rs`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T20:37:00Z
   - **Action**: Addressed post-validation review nit by lazily constructing cached precomputed TX-selection descriptors only on flow-cache fallback forwarding, avoiding unnecessary per-hit descriptor construction on successful in-place TX hits.
   - **File(s)**: `userspace-dp/src/afxdp/poll_descriptor.rs`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T15:28:13Z
   - **Action**: PR #1397 follow-up — fixed mouse-latency diagnostics review findings by making `cwnd_settle_ok` tri-state in manifests (unknown/true/false), correcting cwnd byte-unit parsing to 1024-based `K/M/G/TBytes`, recording probe phase timings even on failed/timed-out connect/drain/read attempts, tightening fairness-regimes settle-evidence wording, and extending unit coverage for settle-diagnostics CLI output/status and failure-phase timing counts.
   - **File(s)**: `test/incus/test-mouse-latency.sh`, `test/incus/mouse_latency_orchestrate.py`, `test/incus/mouse_latency_orchestrate_test.py`, `test/incus/mouse_latency_probe.py`, `test/incus/mouse_latency_probe_test.py`, `test/incus/test_mouse_latency_shell_test.py`, `docs/fairness-regimes.md`, `_Log.md`
   - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py mouse_latency_aggregate_test.py test_mouse_latency_shell_test.py && python3 -m unittest mouse_latency_probe_test.py && bash -n test-mouse-latency.sh`; `python3 -m py_compile test/incus/mouse_latency_orchestrate.py test/incus/mouse_latency_probe.py test/incus/mouse_latency_aggregate.py`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T15:29:22Z
   - **Action**: Addressed parallel validation follow-up by making `CWND_SETTLE_OK="true"` conditional on settle-diagnostics success (explicit `else` branch) and renaming settle-diagnostics test helper variables to descriptive names.
   - **File(s)**: `test/incus/test-mouse-latency.sh`, `test/incus/mouse_latency_orchestrate_test.py`, `_Log.md`
   - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py test_mouse_latency_shell_test.py`; `cd test/incus && python3 -m unittest mouse_latency_probe_test.py`; `bash -n test/incus/test-mouse-latency.sh`
-
 - **Timestamp**: 2026-05-17T15:30:19Z
   - **Action**: Addressed final review nits in orchestrate tests by renaming the settle-diagnostics args mock class for clarity and replacing inline cwnd-byte magic numbers with named KiB constants.
   - **File(s)**: `test/incus/mouse_latency_orchestrate_test.py`, `_Log.md`
   - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py`
-
 - **Timestamp**: 2026-05-17T15:31:13Z
   - **Action**: Applied final Copilot review polish in orchestrate tests by making the mock args class name explicitly `Mock*` and documenting cwnd KiB fixture constants.
-  - **File(s)**: `test/incus/mouse_latency_orchestrate_test.py`, `_Log.md`
-  - **Validation**: `cd test/incus && python3 -m unittest mouse_latency_orchestrate_test.py`
-
 - **Timestamp**: 2026-05-17T08:30:20Z
   - **Action**: PR #1394 round-10 follow-up — fixed standalone userspace event-stream callback wiring by always registering session/full-resync callbacks, and added a regression test that verifies standalone SessionOpen and FullResync frames are ACKed instead of stalling behind an unwired callback queue.
   - **File(s)**: `pkg/daemon/daemon_ha_userspace.go`, `pkg/daemon/userspace_sync_test.go`, `_Log.md`
   - **Validation**: `gofmt -w pkg/daemon/daemon_ha_userspace.go pkg/daemon/userspace_sync_test.go`; `go test ./pkg/daemon ./pkg/dataplane/userspace ./pkg/logging`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T06:39:00Z
   - **Action**: PR #1376 housekeeping — restored `go.mod` after an unintended direct/indirect dependency classification flip from automation so this branch remains scoped to mirror snapshot fixes.
   - **File(s)**: `go.mod`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T06:45:00Z
   - **Action**: PR #1376 re-review follow-up — renamed the mirror snapshot fail-closed wrapper to match behavior, rejected negative port-mirroring input rates before uint32 conversion to prevent wraparound, and updated mirror protocol/build tests accordingly.
   - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/protocol_test.go`, `pkg/dataplane/userspace/manager_test.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T05:06:00Z
   - **Action**: PR #1395 cleanup — reverted an unintended `go.mod` direct/indirect dependency classification change introduced by automated tooling so the round-4 fix stays scoped to three-color policer compiler logic/tests/docs.
-  - **File(s)**: `go.mod`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T05:12:00Z
   - **Action**: Round-5 follow-up fix — in userspace pending-XSK-startup compile path, defer `lastSnapshot` cache update until ingress/local/NAT map sync succeeds so sync failures cannot poison cached snapshot state with an unpublished generation.
   - **File(s)**: `pkg/dataplane/userspace/manager.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T05:16:00Z
   - **Action**: Restored `go.mod` after an unintended direct/indirect dependency classification flip introduced by an automation-only progress update.
-  - **File(s)**: `go.mod`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T04:48:51Z
   - **Action**: Re-restored `go.mod` after a subsequent tooling pass reintroduced the same direct/indirect dependency classification flip.
-  - **File(s)**: `go.mod`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T05:03:00Z
   - **Action**: PR #1395 round-4 follow-up cleanup — moved three-color mode marker assignment outside repeated same-mode child loops to avoid redundant writes while preserving duplicate-sibling merge semantics.
   - **File(s)**: `pkg/config/compiler_firewall.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T04:58:00Z
   - **Action**: PR #1395 round-4 follow-up — fixed three-color policer compiler handling for duplicate same-mode sibling blocks by iterating all `single-rate`/`two-rate` children, added hierarchical ambiguity regression coverage in parser/configstore tests, and updated filter module docs to reflect same-mode sibling merge semantics.
   - **File(s)**: `pkg/config/compiler_firewall.go`, `pkg/config/parser_ast_test.go`, `pkg/configstore/store_test.go`, `userspace-dp/src/filter/README.md`, `_Log.md`
-
-- **Timestamp**: 2026-05-17T04:58:00Z
   - **Action**: PR #1379 round-4 blocker fix follow-up — removed HA startup ordering race by starting cluster comms only after event fanout wiring, made userspace event-stream callback registration concurrency-safe for post-start wiring, and exposed helper producer sent/dropped counters through status text and Prometheus.
   - **File(s)**: `pkg/daemon/daemon_run.go`, `pkg/dataplane/userspace/eventstream.go`, `pkg/dataplane/userspace/eventstream_test.go`, `pkg/dataplane/userspace/protocol.go`, `pkg/dataplane/userspace/statusfmt.go`, `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `_Log.md`
   - **Validation**: `gofmt -w pkg/daemon/daemon_run.go pkg/dataplane/userspace/eventstream.go pkg/dataplane/userspace/eventstream_test.go pkg/dataplane/userspace/protocol.go pkg/dataplane/userspace/statusfmt.go pkg/api/metrics.go pkg/api/metrics_test.go`; `go test ./pkg/dataplane/userspace ./pkg/logging ./pkg/api ./pkg/daemon`; `git diff --check`
-
-- **Timestamp**: 2026-05-17T05:06:00Z
   - **Action**: Addressed automated review nit on the new event-stream lifecycle regression test by replacing fixed sleep + wall-clock polling with timeout contexts and retry loops for listener readiness/connection checks.
   - **File(s)**: `pkg/dataplane/userspace/eventstream_test.go`, `_Log.md`
   - **Validation**: `gofmt -w pkg/dataplane/userspace/eventstream_test.go`; `go test ./pkg/dataplane/userspace ./pkg/logging ./pkg/api ./pkg/daemon`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T05:13:00Z
   - **Action**: Completed the same timeout-context synchronization pattern in `TestEventStreamDataplaneEventCallbackCanBeSetAfterStart` so the new lifecycle regression test no longer relies on fixed sleeps or wall-clock deadline polling.
-  - **File(s)**: `pkg/dataplane/userspace/eventstream_test.go`, `_Log.md`
-  - **Validation**: `gofmt -w pkg/dataplane/userspace/eventstream_test.go`; `go test ./pkg/dataplane/userspace ./pkg/logging ./pkg/api ./pkg/daemon`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T01:12:00Z
   - **Action**: PR #1391 post-smoke follow-up — live q10(24G)+q0(best-effort) contention on `7e7eb07e` showed serviceable-only exact suppression still let q0 drain ~15.6 GB of surplus while exact was backlogged. Reworked the gate from binary serviceability to residual-rate budgeting: non-exact surplus can consume only `root_rate - backlogged_exact_guarantee_rates`, shared exact queues publish queue masks so one queue's reservation is counted once across workers, and shared interfaces use an interface-global residual token bucket rather than per-worker residual buckets.
   - **File(s)**: `userspace-dp/src/afxdp/cos/queue_service/mod.rs`, `userspace-dp/src/afxdp/cos/queue_service/tests.rs`, `userspace-dp/src/afxdp/cos/tx_completion.rs`, `userspace-dp/src/afxdp/types/shared_cos_lease.rs`, `userspace-dp/src/afxdp/types/cos.rs`, `userspace-dp/src/afxdp/cos/builders.rs`, `userspace-dp/src/afxdp/worker/cos_tests.rs`, `userspace-dp/src/afxdp/cos/README.md`, `userspace-dp/src/afxdp/types/README.md`, `_Log.md`
   - **Validation**: `rustfmt --edition 2024` on changed Rust files; `cargo test --manifest-path userspace-dp/Cargo.toml build_nonexact -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml exact_backlog -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml apply_cos_send_result_debits_shared_residual_surplus_budget -- --nocapture`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T00:08:28Z
   - **Action**: Issue #1390 — initial CoS best-effort strict-priority fix attempt; round-1 review later narrowed the invariant to surplus-only suppression so explicit non-exact guarantees remain Junos-compatible.
   - **File(s)**: `userspace-dp/src/afxdp/cos/queue_service/mod.rs`, `userspace-dp/src/afxdp/cos/queue_service/tests.rs`, `userspace-dp/src/afxdp/tx/cos_classify_tests.rs`, `userspace-dp/src/afxdp/worker/cos_tests.rs`, `userspace-dp/src/afxdp/cos/README.md`, `_Log.md`
   - **Validation**: `cargo fmt --manifest-path userspace-dp/Cargo.toml`; `cargo test --manifest-path userspace-dp/Cargo.toml build_nonexact -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml afxdp::cos::queue_service::tests:: -- --nocapture`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T00:35:00Z
   - **Action**: PR #1391 round-1 review follow-up — narrowed exact-over-residual enforcement to the surplus phase so explicit non-exact guarantees keep Junos-compatible service; local and peer suppression now require a serviceable exact queue, peer serviceability uses acquire/release publication, and tests pin non-exact guarantee plus token-starved exact behavior.
   - **File(s)**: `userspace-dp/src/afxdp/cos/queue_service/mod.rs`, `userspace-dp/src/afxdp/cos/queue_service/tests.rs`, `userspace-dp/src/afxdp/cos/tx_completion.rs`, `userspace-dp/src/afxdp/types/shared_cos_lease.rs`, `userspace-dp/src/afxdp/cos/README.md`, `userspace-dp/src/afxdp/types/README.md`, `_Log.md`
   - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml build_nonexact -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml afxdp::cos::queue_service::tests:: -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml exact_backlog -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml reset_binding_cos_runtime_clears_shared_exact_backlog_slot -- --nocapture`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T00:48:00Z
   - **Action**: PR #1385 round-3 review follow-up — corrected README prose so pool-mode SNAT is no longer described as an explicit userspace capability gate after the pool-mode fixes; the remaining caveat is cross-backend `address-persistent` parity under #1377.
-  - **File(s)**: `README.md`, `_Log.md`
-  - **Validation**: `git diff --check`
-
 - **Timestamp**: 2026-05-17T01:03:00Z
   - **Action**: PR #1382 round-3 rebase follow-up — aligned the Phase 0 audit with the now-merged #1385 pool-mode SNAT fixes, and kept #1377 as the remaining cross-backend `address-persistent` parity blocker.
-  - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/plan.md`, `_Log.md`
-  - **Validation**: `git diff --check`
-
 ## 2026-05-16
-
 - **Timestamp**: 2026-05-16T23:58:00Z
   - **Action**: PR #1385 round-2 review follow-up — made Rust pool-mode SNAT skip matched rules whose pool has no address for the packet family so later compatible rules can apply, added wrong-family regression tests, and documented userspace/eBPF/DPDK address-persistent algorithm divergence until #1377 defines a shared contract.
   - **File(s)**: `userspace-dp/src/nat.rs`, `userspace-dp/src/nat_tests.rs`, `docs/userspace-dataplane-architecture.md`, `docs/userspace-dataplane-gaps.md`, `README.md`, `_Log.md`
   - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml pool_snat_wrong_family`; `go test ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-16T22:18:20Z
   - **Action**: PR #1385 round-1 review fixes — make userspace source-NAT pool snapshots fail closed when the referenced pool is missing, empty, or has an invalid port range; add regression coverage for each unsafe pool-mode case; refresh the userspace dataplane gap date after the pool-mode capability update.
   - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `docs/userspace-dataplane-gaps.md`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T00:06:00Z
   - **Action**: PR #1386 round-2 review follow-up — changed userspace buffer capacity fallback from all-or-nothing to per-row fallback so mixed helper snapshots with one populated `per_binding[]` row and one sparse row do not undercount capacity.
   - **File(s)**: `pkg/dataplane/userspace/buffersfmt.go`, `pkg/dataplane/userspace/buffersfmt_test.go`, `_Log.md`
   - **Validation**: `gofmt -w pkg/dataplane/userspace/buffersfmt.go pkg/dataplane/userspace/buffersfmt_test.go`; `go test ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-16T22:19:53Z
   - **Action**: PR #1386 round-1 review fixes — preserve the `Active sessions` footer in userspace `show system buffers`, make non-detail output aggregate-only while `buffers detail` adds per-binding rows, and fall back to `bindings[]` when `per_binding[]` lacks capacity gauges.
   - **File(s)**: `pkg/dataplane/userspace/buffersfmt.go`, `pkg/dataplane/userspace/buffersfmt_test.go`, `pkg/cli/cli_show_system.go`, `pkg/grpcapi/server_show.go`, `pkg/grpcapi/server_show_system_buffers_test.go`, `docs/userspace-dataplane-architecture.md`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane/userspace ./pkg/grpcapi ./pkg/cli ./pkg/fwdstatus`; `git diff --check`
-
 - **Timestamp**: 2026-05-16T22:21:02Z
   - **Action**: PR #1388 round-1 review fix — preserve old-status-JSON display compatibility for shaped interfaces whose userspace runtime synthesizes default best-effort queue 0, while keeping residual scheduler-map queues from inheriting false guarantees.
   - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T00:55:00Z
   - **Action**: PR #1383 round-3 review follow-up — added the cluster sync stale-reconcile path to the interface split plan so bulk reconciliation uses the same `SessionStore`/NAT-owned companion-delete semantics as GC instead of keeping a second BPF-shaped reverse-session/DNAT cleanup copy.
   - **File(s)**: `docs/pr/1381-dataplane-interface-split/plan.md`, `_Log.md`
-  - **Validation**: `git diff --check`
-
 - **Timestamp**: 2026-05-17T00:16:00Z
   - **Action**: PR #1383 round-2 review follow-up — extended the target `ApplyResult` contract with firewall filter IDs/spans and NAT counter IDs needed by current show paths, and documented GC migration ownership for session-change counters, per-IP session-limit publish, persistent-NAT preservation, DNAT reverse cleanup, and backend-neutral stats.
-  - **File(s)**: `docs/pr/1381-dataplane-interface-split/plan.md`, `_Log.md`
-  - **Validation**: `git diff --check`
-
 - **Timestamp**: 2026-05-16T23:10:00Z
   - **Action**: PR #1383 round-1 review follow-up — removed backend-specific userspace DTOs from the proposed public session-delta interface to avoid a `pkg/dataplane` ↔ `pkg/dataplane/userspace` import cycle, added the missing caller inventory, and documented compatibility, risk, architectural-mismatch, import-canary, and Phase 1 acceptance gates.
-  - **File(s)**: `docs/pr/1381-dataplane-interface-split/plan.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T00:59:00Z
   - **Action**: PR #1384 round-3 review follow-up — changed the blocker-plan bundle introduction to say plans land before their listed #1373 retirement phase, avoiding a Phase 4 blanket statement now that #1380 is a Phase 5 observability blocker.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
-  - **Validation**: `git diff --check`
-
 - **Timestamp**: 2026-05-17T00:24:00Z
   - **Action**: PR #1384 round-2 review follow-up — aligned #1380 with the Phase 5 observability gate, and made the #1377 plan explicitly cover address-persistent SNAT pool selection plus current userspace/eBPF/DPDK algorithm divergence and required compatibility fixtures.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `_Log.md`
-  - **Validation**: `git diff --check`
-
 - **Timestamp**: 2026-05-16T23:24:00Z
   - **Action**: PR #1384 round-1 review follow-up — aligned the #1373 blocker-plan index with #1377/#1380 scope, made all required-before labels explicit, tightened SYN-cookie full-epoch/low-bit-wrap semantics, added risk sections and capability-admission tests to blocker plans, and added SNAT-pool and userspace-buffer parity plan docs.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1374-syn-cookies.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1375-three-color-policers.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md`, `docs/pr/1373-retire-ebpf-dataplane/plan-1380-userspace-buffers.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-16T23:39:00Z
   - **Action**: PR #1382 round-1 review follow-up — reconciled Phase 0 retirement docs with #1385/#1386 fix-forward dependencies, removed stale userspace architecture limitations for features already implemented in Rust, changed userspace-dp wording to "being retired", and added Phase 0 exit criteria plus rollback path.
   - **File(s)**: `README.md`, `docs/userspace-dataplane-gaps.md`, `docs/userspace-dataplane-architecture.md`, `userspace-dp/README.md`, `docs/pr/1373-retire-ebpf-dataplane/plan.md`, `_Log.md`
-  - **Validation**: `git diff --check`
-
 - **Timestamp**: 2026-05-16T04:36:00Z
   - **Action**: PR #1320 round-3 review fixes — validate typed scheduler leaves against the apply-groups-expanded tree before compile; reject `transmit-rate exact` unless the scheduler also has a typed rate; wire `ConfigClassOfServiceSchedulers` into the real config-mode `set class-of-service schedulers <name>` completion tree; update module docs to keep the byte-size-only scheduler buffer contract explicit.
   - **File(s)**: `pkg/cmdtree/schema_validate.go`, `pkg/cmdtree/tree.go`, `pkg/cmdtree/tree_test.go`, `pkg/cmdtree/README.md`, `pkg/config/schema_validate_test.go`, `pkg/config/README.md`, `pkg/configstore/store.go`, `pkg/configstore/store_test.go`, `_Log.md`
   - **Validation**: `go test -count=1 ./pkg/cmdtree/... ./pkg/config/... ./pkg/configstore/...`; `go test -count=1 ./pkg/...`; `git diff --check`
-
 - **Timestamp**: 2026-05-16T00:14:30Z
   - **Action**: Issue #1330 — split `userspace-dp/src/bin/fairness-eval.rs` into a thin CLI shell plus `userspace-dp/src/fairness_eval/` modules for args, inputs, windowing, per-worker aggregation, RSS expectation, verdict construction, and report emission without changing CLI behavior or fairness semantics.
   - **File(s)**: `userspace-dp/src/bin/fairness-eval.rs`, `userspace-dp/src/fairness_eval/*`, `userspace-dp/src/bin/README.md`, `docs/pr/1330-fairness-eval-library/plan.md`, `_Log.md`
   - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml --bin fairness-eval`; `cargo test --manifest-path userspace-dp/Cargo.toml --test fairness_eval_blackbox`; `git diff --check`
-
 ## 2026-05-15
-
 - **Timestamp**: 2026-05-16T00:06:42Z
   - **Action**: PR #1316 Copilot follow-up — narrow the validation TSV auditability claim to the fields present in the checked-in TSV schema, permit TSV summaries in the `docs/pr/` evidence convention, and qualify the old dominant-failure heading as a pre-buffer-sizing snapshot.
   - **File(s)**: `docs/pr/1316-lowrate-cos-buffers/validation.md`, `docs/pr/README.md`, `docs/cos-validation-notes.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-15T23:13:00Z
   - **Action**: PR #1316 round-4 review follow-up — filled the full seven-class validation table's high-rate Max CoV values from the committed TSV evidence, and documented that the historical 8-matrix `full-cos.set` file was later amended with q0/q4 buffer-size headroom.
   - **File(s)**: `docs/pr/1316-lowrate-cos-buffers/validation.md`, `docs/pr/line-rate-investigation/8matrix-findings.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-15T23:00:00Z
   - **Action**: Restored `go.mod` to pre-PR state after an unintended direct/indirect dependency classification flip during automation-only progress updates.
-  - **File(s)**: `go.mod`, `_Log.md`
   - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-15T22:56:00Z
   - **Action**: Reverted unintended `go.mod` direct/indirect dependency reorder so round-1 fix remains scoped to CoS runtime lookup logic and tests.
-  - **File(s)**: `go.mod`, `_Log.md`
-  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-15T22:52:00Z
   - **Action**: Round-1 follow-up cleanup — remove duplicate VLAN candidate append path in CoS runtime candidate generation while preserving VLAN-first ordering for unit-zero lookups.
   - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `_Log.md`
-  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-15T22:45:00Z
   - **Action**: Round-1 review hardening for issue #1278 — fix unit-zero candidate ordering so VLAN binding ifindex is preferred over parent binding when both exist, preventing wrong runtime CoS counters from being shown.
-  - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`, `_Log.md`
-  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-15T22:15:00Z
   - **Action**: Issue #1298 — add an idle debug-updater regression test proving wall-clock publishes age active-flow, flow-worker-map, and CoS active-flow snapshots to zero. Round-1 review narrowed the claim to the helper path exercised by the test and tied the aging loop to `ACTIVE_WINDOW_EPOCHS` instead of a hard-coded epoch count.
   - **File(s)**: `userspace-dp/src/afxdp/flow_cache.rs`, `userspace-dp/src/afxdp/umem/tests.rs`, `_Log.md`
   - **Validation**: `cargo test idle_debug_updater_ages_active_flow_snapshots`; `cargo test idle_debug_state_publish_cadence_is_wall_clock_based`; `git diff --check`
-
 - **Timestamp**: 2026-05-15T22:05:00Z
   - **Action**: Issue #1278 — make `show class-of-service interface` join configured reverse-egress CoS interfaces to live runtime by configured name first and binding egress ifindex second, so alias drift between `ge-0-0-1.0` and the runtime snapshot no longer hides queue counters.
   - **File(s)**: `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/cosfmt_test.go`, `docs/cos-validation-notes.md`, `_Log.md`
-  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-15T21:23:20Z
   - **Action**: PR #1312 CoS TX-error attribution — round-3 fixes: (1) mirror reset-time CoS queue drains into `binding.live.dbg_cos_queue_overflow` in `reset_binding_cos_runtime` so the binding-scoped subset stays lifetime-matched with `tx_errors`; (2) add Rust regression test `reset_binding_cos_runtime_mirrors_drops_to_binding_cos_counter`; (3) update `docs/cos-validation-notes.md` to state the binding-scoped subset includes admission rejects AND reset-time queue drains, and rephrase reason-counter lines as aggregate current-runtime sums (not per-queue rows); (4) extract `saturatingAddU64`/`saturatingSubU64` into `format_math.go` with doc comments; (5) rename ECN accumulator to `cosAdmissionEcnMarked` (Go-style Ecn casing).
   - **File(s)**: `userspace-dp/src/afxdp/worker/cos.rs`, `userspace-dp/src/afxdp/worker/cos_tests.rs`, `pkg/dataplane/userspace/statusfmt.go`, `pkg/dataplane/userspace/statusfmt_test.go`, `pkg/dataplane/userspace/cosfmt.go`, `pkg/dataplane/userspace/format_math.go`, `docs/cos-validation-notes.md`, `_Log.md`
 - **Timestamp**: 2026-05-15T21:42:00Z
   - **Action**: PR #1315 Copilot follow-up — keep the historical `dbg_cos_queue_overflow` wire key but relabel the CLI/docs as binding-lifetime CoS queue drops because the subset now includes reset-time CoS queue drains in addition to admission rejects.
   - **File(s)**: `pkg/dataplane/userspace/statusfmt.go`, `pkg/dataplane/userspace/statusfmt_test.go`, `pkg/dataplane/userspace/protocol.go`, `userspace-dp/src/protocol.rs`, `docs/cos-validation-notes.md`, `_Log.md`
-  - **Validation**: `go test -count=1 ./pkg/dataplane/userspace`; `git diff --check`
-
 - **Timestamp**: 2026-05-15T20:33:36Z
   - **Action**: PR #1316 / issue #1312 hostile-review follow-up — clarified low-rate CoS fixture docs with the actual implicit base/cap pipeline (`rate/100` + 96 KB floor, flow-share expansion, #717 delay clamp), documented the queue-residence tradeoff for q0/q4 overrides, added a regression test pin that 1 Gbps q4 `buffer-size 4m` remains above delay-cap clamping, updated canonical fixture buffers, and committed durable validation evidence.
   - **File(s)**: `test/incus/cos-iperf-config.set`, `test/incus/cos-iperf-symmetric.set`, `test/incus/cos-iperf-same-class.set`, `docs/cos-validation-notes.md`, `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, `docs/pr/README.md`, `docs/pr/1316-lowrate-cos-buffers/validation.md`, `docs/pr/1316-lowrate-cos-buffers/evidence/focused-summary.tsv`, `docs/pr/1316-lowrate-cos-buffers/evidence/focused-dataplane-summary.tsv`, `docs/pr/1316-lowrate-cos-buffers/evidence/focused-equal-flow-summary.tsv`, `docs/pr/1316-lowrate-cos-buffers/evidence/full-summary.tsv`, `docs/pr/1316-lowrate-cos-buffers/evidence/full-dataplane-summary.tsv`, `docs/pr/1316-lowrate-cos-buffers/evidence/full-equal-flow-summary.tsv`, `docs/pr/line-rate-investigation/full-cos.set`, `userspace-dp/src/afxdp/cos/admission_tests.rs`, `_Log.md`
-
 ## 2026-05-14
-
 - **Timestamp**: 2026-05-14T19:33:03Z
   - **Action**: PR #1308 round-2 review follow-up — added explicit equal-flow scrape framing tests for nested begin and end-without-begin paths, added the missing `BindingCountersSnapshot` round-trip pin for `tx_shared_recycle_unknown_slot_drops`, applied `gofmt` to `protocol.go`, and renamed sweep progress output from `wrapper_status` to `exit_status` with a named infrastructure-exit constant.
   - **File(s)**: `test/incus/fairness_multi_sample_test.py`, `test/incus/fairness-cos-class-sweep.sh`, `pkg/dataplane/userspace/protocol.go`, `pkg/dataplane/userspace/protocol_test.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-14T19:19:32Z
   - **Action**: PR #1308 round-1 review follow-up — made equal-flow capture reduction fail closed on SIGTERM-truncated marked scrapes and non-integer active-worker counts, and made sweep summary rows report infrastructure exit status `2` when equal-flow capture fails after the wrapper succeeds.
   - **File(s)**: `test/incus/fairness_equal_flow_capture.py`, `test/incus/fairness-cos-class-sweep.sh`, `test/incus/fairness_multi_sample_test.py`, `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-14T18:35:00Z
   - **Action**: Issue #1306 — add first-class per-class equal-flow estimator capture to the CoS class sweep harness. The sweep now brackets each wrapper run with continuous Prometheus scraping, preserves raw scrapes, reduces target-class equal-flow aggregate/worker rows, appends equal-flow evidence to `summary.md`, and fails closed on empty/missing/invalid estimator captures.
   - **File(s)**: `test/incus/fairness-cos-class-sweep.sh`, `test/incus/fairness_equal_flow_capture.py`, `test/incus/fairness_multi_sample_test.py`, `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-14T17:53:10Z
   - **Action**: PR #1305 round-3 review follow-up — extended artifact-warning wording to the equal-flow capped-bps, worker-cap-bps, and throughput-loss-ratio Prometheus help strings.
   - **File(s)**: `pkg/api/metrics.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-14T17:38:10Z
   - **Action**: PR #1305 round-2 review follow-up — made the out-of-range worker test assert directly against `bytesByWorker` so the worker-delta cap is independently covered, and added artifact warnings to the equal-flow target/suppression metric help strings.
   - **File(s)**: `pkg/dataplane/userspace/fairness_throughput_test.go`, `pkg/api/metrics.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-14T16:49:39Z
   - **Action**: PR #1305 review follow-up — bounded equal-flow estimator worker IDs with the existing fairness RSS worker-slot cap, sharpened Prometheus help strings, and added validity boundary tests for single-worker, unsampled, zero-window, and out-of-range-worker cases.
   - **File(s)**: `pkg/dataplane/userspace/fairness_throughput.go`, `pkg/dataplane/userspace/fairness_throughput_test.go`, `pkg/api/metrics.go`, `docs/pr/1304-equal-flow-estimator/plan.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-14T14:51:46Z
   - **Action**: Issue #1304 Phase 0 — add measurement-only equal-flow rate-suppression estimator telemetry for exact CoS queues, document its invariants, and pin estimator math/Prometheus emission tests.
   - **File(s)**: `pkg/dataplane/userspace/fairness_throughput.go`, `pkg/dataplane/userspace/fairness_throughput_test.go`, `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `docs/fairness-regimes.md`, `docs/per-5-tuple/state.md`, `docs/pr/1304-equal-flow-estimator/plan.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-14T04:01:00Z
   - **Action**: PR #1301 review follow-up — removed power-of-two UMEM frame-size assumption in memmove fallback bounds calculation by switching to modulo-based in-frame offset math.
   - **File(s)**: `userspace-dp/src/afxdp/frame/mod.rs`, `_Log.md`
-
 - **Timestamp**: 2026-05-14T03:52:00Z
   - **Action**: PR #1301 review follow-up — tightened in-frame memmove fallback slice bounds to the current UMEM chunk and added regression coverage for `FillOnSlotWithOffset` recycle tracking.
   - **File(s)**: `userspace-dp/src/afxdp/frame/mod.rs`, `userspace-dp/src/afxdp/tx/transmit_tests.rs`, `_Log.md`
-
 ## 2026-05-12
-
 - **Timestamp**: 2026-05-12T07:50:00Z
   - **Action**: PR #1274 Copilot follow-up — use verdict JSON key names consistently in the Accepted Path publish list.
   - **File(s)**: `docs/per-5-tuple/tcp-head-start-floor.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-12T06:46:48Z
   - **Action**: PR #1274 review follow-up — wrapped TCP head-start policy prose and made the observed CoV prose/JSON-field distinction explicit.
-  - **File(s)**: `docs/per-5-tuple/tcp-head-start-floor.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-12T06:29:27Z
   - **Action**: PR round-2 review follow-up — expanded AFD acronym at first use (line 5), changed `observed_cov` to `observed_CoV` in prose formulas (lines 86, 99), made epsilon explicit as 0.05.
-  - **File(s)**: `docs/per-5-tuple/tcp-head-start-floor.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-12T07:35:00Z
   - **Action**: PR #1271 round-3 follow-up — add same-VLAN/different-RETH synthetic-ifindex regressions so `reth0.N` and `reth1.N` cannot collapse into one logical Rust dataplane state key.
   - **File(s)**: `pkg/dataplane/userspace/manager_test.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-12T07:20:00Z
   - **Action**: PR #1271 cleanup — removed unrelated `go.mod` direct/indirect dependency churn introduced by local test tooling to keep the diff scoped to synthetic-ifindex changes.
-  - **File(s)**: `go.mod`, `_Log.md`
-
 - **Timestamp**: 2026-05-12T07:16:00Z
   - **Action**: PR #1271 validation follow-up — documented synthetic-ifindex range rationale, improved exhaustion panic guidance, deduplicated VLAN test constants, and reverted unrelated `go.mod` drift from local test tooling.
   - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `go.mod`, `_Log.md`
-
 - **Timestamp**: 2026-05-12T07:08:00Z
   - **Action**: PR #1271 follow-up — enriched synthetic-ifindex exhaustion panic diagnostics and replaced test magic VLAN bound with named constants during validation pass.
   - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-12T06:55:00Z
   - **Action**: PR #1271 round-2 follow-up — made parent-bound RETH VLAN synthetic ifindex allocation deterministic/config-derived, removed kernel-ifindex seeding, switched to high synthetic range with hard-fail on exhaustion, and added sibling-VLAN determinism regression coverage.
-  - **File(s)**: `pkg/dataplane/userspace/snapshot.go`, `pkg/dataplane/userspace/manager_test.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-12T00:30:00Z
   - **Action**: PR #1267 round-2 review follow-up — fixed fairness throughput window boundary pruning/rate denominator coupling to prevent false-positive saturation at steady sub-cap traffic, and added a regression test for the 10s-scrape/30s-window boundary case.
   - **File(s)**: `pkg/dataplane/userspace/fairness_throughput.go`, `pkg/dataplane/userspace/fairness_throughput_test.go`, `_Log.md`
-
 ## 2026-05-10
-
 - **Timestamp**: 2026-05-10T15:24:00Z
   - **Action**: PR #1253 review follow-up — corrected `userspace-dp/src/server/README.md` RSS-indirection behavior to match `pkg/daemon/rss_indirection.go` (reshape conditions, workers>=queues stale-table cleanup restore path, and queue concentration semantics).
   - **File(s)**: `userspace-dp/src/server/README.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-10T15:05:00Z
   - **Action**: PR #1253 review pass — corrected `pkg/configstore/README.md` encryption-key location wording to match `master.key` under the configstore DB directory (`db.dir`) and removed stale `/etc/xpf/config-key` path guidance.
   - **File(s)**: `pkg/configstore/README.md`, `_Log.md`
-
 - **Timestamp**: 2026-05-10T04:06:32Z
   - **Action**: PR comment follow-up review for `docs/per-5-tuple/state.md` — replaced a non-existent memory-file reference with in-repo issue/table references (#836/#937/#1215) to keep the fairness section self-contained and verifiable.
   - **File(s)**: `docs/per-5-tuple/state.md`, `_Log.md`
-
 ## 2026-05-07
-
 - **Timestamp**: 2026-05-07T16:13:00Z
   - **Action**: PR #1211 archive doc follow-up — fixed stale/missing cross-references in closure docs, updated per-5-tuple state to mark Path 2 closed with archive links, and clarified memory-hook wording as external memory (not an in-repo file).
   - **File(s)**: `docs/per-5-tuple/path2-archive/CLOSING-RATIONALE.md`, `docs/per-5-tuple/state.md`
-
 ## 2026-04-19 — #812 plan R1 (fold Codex round-1 hostile review)
 - **Timestamp**: 2026-04-19
 - **Action**: Fold Codex round-1 review into the Architect plan. Close 3 HIGH findings: small-batch amortization collapse (§3.1 per-commit stamping with honest `inserted == 1` worst-case), relaxed-atomic cross-CPU visibility (§3.6.a Relaxed+documented, invariants 6/7 rewritten, §8 hard-stop #4 uses bounded-skew delta), sidecar false-sharing (§3.3 per-binding single-writer confirmed by `Rc<WorkerUmemInner>` + `shared_umem=false` in code). Rewrite §3.4 overhead budget with three operating-point numbers (`inserted=256/64/1`) and a correct per-queue denominator (481 ns/pkt at 25 Gbps), not per-worker. Rewrite §11.3 Bonferroni family to match actual composite tests (3/cell × 12 cells = 36, not 192). Close MED #5 (sentinel vs clock-0), MED #6 (sidecar size 192 KiB, not 64 KiB), MED #7 (wire-size growth), MED #8 (Bonferroni family), MED #9 (two-thread test replaced by partial-batch / retry-unwind / bounded-skew tests). Close LOW #10 (no `now_ns` reuse), LOW #13 (named const asserts + boundary test).
   - **File(s)**: `docs/pr/812-tx-latency-histogram/plan.md`
-
 ## 2026-04-17
-
 - **Timestamp**: 2026-04-17
   - **Action**: Issue #678 — Architect plan for remaining hot-path CPU cuts. Remeasured on loss userspace cluster (master 7c1e55b9): poll_binding 10.4%/10.6% (down from issue's 13.4%/13.3%), enqueue_pending_forwards 0.71%/<1% (down from 4.3%/3.7%), apply_nat_ipv6 <1% (down from 3.2% IPv6). Recommendation: Option A — split poll_binding into orchestration shell + per-descriptor hot path as a measurement-first structural refactor. Options B/C/D deferred as issues; Option F (close as subsumed) is the expected path post-split.
   - **File(s)**: docs/678-hotpath-cuts-plan.md
-
 ## 2026-04-03
-
 - **Timestamp**: 2026-04-03
   - **Action**: Issue #547 — Split pkg/grpcapi/server.go (8411 lines) into 8 domain files. Mechanical move of functions, no logic changes. server.go reduced to 241 lines (types + server lifecycle).
   - **File(s)**: pkg/grpcapi/server.go, server_config.go, server_show.go, server_nat.go, server_routing.go, server_diag.go, server_helpers.go, server_dhcp.go, server_cluster.go
-
 ## 2026-04-07
-
 - **Timestamp**: 2026-04-07T00:00:00Z
   - **Action**: Issue #545 — Split `pkg/config/compiler.go` (5878 lines) into 8 domain-specific files. Mechanical refactor, no logic changes. Functions moved to: compiler_security.go, compiler_interfaces.go, compiler_protocols.go, compiler_ipsec.go, compiler_routing.go, compiler_firewall.go, compiler_system.go, compiler_services.go. compiler.go retains top-level dispatch + applications + validators (793 lines).
   - **File(s)**: pkg/config/compiler.go, pkg/config/compiler_security.go, pkg/config/compiler_interfaces.go, pkg/config/compiler_protocols.go, pkg/config/compiler_ipsec.go, pkg/config/compiler_routing.go, pkg/config/compiler_firewall.go, pkg/config/compiler_system.go, pkg/config/compiler_services.go
-
-- **Timestamp**: 2026-04-07T00:00:00Z
   - **Action**: Issue #532 — Fix IPv6 TTL-expired (hop limit exceeded) probe responses not being returned in userspace dataplane. Added TTL/hop-limit check with ICMP Time Exceeded generation to both session-hit and flow-cache-hit paths. Previously only the session-miss path generated TE responses; subsequent packets hitting an existing session or flow cache were silently dropped when TTL<=1 because the rewrite functions returned None without generating a response.
   - **File(s)**: userspace-dp/src/afxdp.rs
-
 ## 2026-04-05
-
 - **Timestamp**: 2026-04-05T22:00:00Z
   - **Action**: Issue #485 — Fix TCP stream death on failback (node1→node0). Three fixes: (1) Reorder cluster Primary handler: set rg_active + pre-install neighbors BEFORE ForceRGMaster so BPF can forward the first packet arriving after VRRP installs VIPs. (2) Reorder cluster Secondary handler: run preflight (flow cache flush to FabricRedirect) BEFORE ResignRG so traffic shifts to fabric before VRRP removes VIPs. (3) Add syncMsgPrepareActivation message: demoting node notifies peer to pre-warm neighbor cache after preflight completes, giving the activating node a head start on ARP/NDP resolution.
   - **File(s)**: pkg/daemon/daemon_ha.go, pkg/cluster/sync.go
-
 - **Timestamp**: 2026-04-05T12:00:00Z
   - **Action**: Fix TCP stream death on failback due to cold ARP cache on standby node. Root cause: `resolveNeighborsInner()` used `netlink.RouteGet()` to find the outgoing interface for static route next-hops, but on standby nodes the kernel route doesn't exist (FRR only installs it on the active). Added `addByIPOrConfig()` fallback that resolves the outgoing interface from config by matching the next-hop IP against configured interface subnets when the kernel FIB lookup fails.
   - **File(s)**: pkg/daemon/daemon.go
-
 - **Timestamp**: 2026-04-05T10:00:00Z
   - **Action**: Issue #475 — Fix 0 throughput on pre-existing TCP streams after failover+failback. Root cause: `prewarm_reverse_synced_sessions_for_owner_rgs` published USERSPACE_SESSIONS BPF map entries for reverse sessions but not forward sessions during RG activation. Forward sessions relied on async worker processing, creating a window where the XDP shim had no REDIRECT entry. Added synchronous BPF map publishing for forward sessions in prewarm, plus a comprehensive `republish_bpf_session_entries_for_owner_rgs` that iterates ALL sessions in the `sessions` owner-RG index (not just the `reverse_prewarm` subset) to ensure no session is missed.
   - **File(s)**: userspace-dp/src/afxdp/shared_ops.rs, userspace-dp/src/afxdp/ha.rs, userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-05T08:00:00Z
   - **Action**: Issue #473 — Fix XSK bindings BPF map going stale after peer crash+reconnect. Added `verifyBindingsMapLocked()` watchdog to the 1s status poll loop. After `applyHelperStatusLocked` runs, the watchdog reads each BPF `userspace_bindings` entry and compares it against the helper's reported binding state. If a queue is Registered+Armed in the helper but the BPF map entry is all zeros, the watchdog rewrites the entry. Also repairs aliased bindings (VLAN children). This prevents silent transit traffic drops when a Compile() or HA transition zeroes the bindings map without repopulating it.
   - **File(s)**: pkg/dataplane/userspace/manager.go
-
 - **Timestamp**: 2026-04-05T06:55:00Z
   - **Action**: Issue #466 — Fix bulk sync triggering on every reconnect/fabric-flip. Added `bulkEverCompleted` atomic flag to SessionSync that tracks whether a full bulk exchange has ever completed during the daemon's lifetime. `handleNewConnection` now only triggers `doBulkSync` on true cold start (flag is false). Active-fabric changes no longer trigger bulk at all. Daemon's `onSessionSyncPeerConnected`/`onSessionSyncPeerDisconnected` preserve primed state and sync readiness when `bulkEverCompleted` is true.
   - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_test.go, pkg/daemon/daemon_ha.go, pkg/daemon/session_sync_readiness_test.go
-
 ## 2026-04-04
-
 - **Timestamp**: 2026-04-04T21:30:00Z
   - **Action**: Issue #467 — Fix bulk-prime retry loop not restarting after failed demotion barrier. `prepareUserspaceRGDemotionWithTimeout` stopped the retry loop by advancing `syncPrimeRetryGen` before waiting on barriers, but on barrier failure returned without restarting the loop, stranding the peer in an unprimed state. Added a defer that restarts `startSessionSyncPrimeRetry` on failure when peer is still connected and not yet primed.
   - **File(s)**: pkg/daemon/daemon_ha.go
-
 - **Timestamp**: 2026-04-04T20:50:00Z
   - **Action**: Issue #458 — Fix session sync barrier timeout on second failover cycle. Root cause: `handleDisconnect` reset `barrierSeq` to 0, causing sequence collisions between stale goroutines and new barriers. Also closed waiter channels on disconnect to prevent goroutine leaks. Added `barrierAckSeq` check in `WaitForPeerBarrier` to distinguish disconnect from ack.
   - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_bulk.go, pkg/cluster/sync_test.go
-
-## 2026-04-03
-
 - **Timestamp**: 2026-04-03T18:00:00Z
   - **Action**: Issue #457 — Fix standby losing userspace readiness after partial RG demotion. The rgTransitionInFlight flag in UpdateRGActive was unconditionally set for both activation and demotion. During demotion, this caused ctrl.Enabled=0 in the BPF map globally, disrupting forwarding for other active RGs. Now only set rgTransitionInFlight during activation transitions; demotion leaves ctrl enabled so other RGs continue forwarding.
   - **File(s)**: pkg/dataplane/userspace/manager_ha.go, pkg/dataplane/userspace/manager_test.go
-
 - **Timestamp**: 2026-04-03T12:00:00Z
   - **Action**: Issue #451 — Fix neighbor miss spike after RG failover. Part 1: resolve config-based next-hops synchronously during RG activation (VRRP MASTER and cluster-primary paths) using new `resolveNeighborsImmediate` variant that sends ARP probes without blocking for replies. Part 2: increase failover test neighbor miss threshold from 20 to 60 to accommodate observed spikes of 25-52.
   - **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_ha.go, scripts/userspace-ha-failover-validation.sh
-
 - **Timestamp**: 2026-04-03T10:22:00Z
   - **Action**: Issue #418 — Replace bulk session sync with event stream replay on connect. Added `export_all_sessions_to_event_stream()` to Rust Coordinator that iterates shared sessions and pushes Open events through the event stream. Added `"export_all_sessions"` control request handler. Go daemon's `bulkSyncViaEventStreamOrFallback()` tries event stream export first, falls back to legacy BulkSync.
   - **File(s)**: userspace-dp/src/afxdp/ha.rs, userspace-dp/src/main.rs, pkg/dataplane/userspace/manager_ha.go, pkg/daemon/daemon_ha.go, pkg/daemon/userspace_sync_test.go
-
 ## 2026-04-02
-
 - **Timestamp**: 2026-04-02T20:34:00Z
   - **Action**: Issue #403 — Planned failover must not depend on bulk sync. Added priority barrierCh channel to SessionSync so barriers/acks bypass bulk data in sendLoop. Removed syncPeerBulkPrimed gate from demotion prep. Reduced manual failover barrier timeout to 5s.
   - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_bulk.go, pkg/daemon/daemon_ha.go, pkg/cluster/sync_test.go
-
 ## 2026-04-01
-
 - **Timestamp**: 2026-04-01T05:30:00Z
   - **Action**: Merged PR #301 (userspace forwarding and failover gap audit doc)
   - **File(s)**: docs/userspace-forwarding-and-failover-gap-audit.md
-
 - **Timestamp**: 2026-04-01T06:00:00Z
   - **Action**: Implemented strict userspace mode, HA install fence, deterministic reverse companions (PR #313, issues #302-#312)
   - **File(s)**: pkg/dataplane/userspace/manager.go, pkg/dataplane/userspace/protocol.go, pkg/cluster/cluster.go, pkg/cluster/sync.go, userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/session_glue.rs, userspace-dp/src/main.rs, userspace-xdp/src/lib.rs, docs/ha-forwarding-state-inventory.md, docs/bugs.md, docs/phases.md
-
 - **Timestamp**: 2026-04-01T06:30:00Z
   - **Action**: Address PR #313 copilot review findings — rename STRICT_PASS_BLOCKED, strict ctrl=0 drop, mode reporting, fallback names, VLAN sub-interface exclusion
   - **File(s)**: pkg/dataplane/userspace/manager.go, userspace-xdp/src/lib.rs, docs/phases.md
-
 - **Timestamp**: 2026-04-01T13:52:00Z
   - **Action**: Fix HA session sync starvation — async bulk ack, HA sync throttle 5s, 6 retries (ba1c4304)
   - **File(s)**: pkg/cluster/sync.go, pkg/daemon/daemon.go, pkg/dataplane/userspace/manager.go
-
 - **Timestamp**: 2026-04-01T14:44:00Z
   - **Action**: Replace bulk-sync gate with barrier check for failover readiness (e42c882e)
   - **File(s)**: pkg/daemon/daemon.go, pkg/daemon/userspace_sync_test.go
-
 - **Timestamp**: 2026-04-01T15:39:00Z
   - **Action**: Explicit refresh_owner_rgs on RG activation + async barrier ack (a9e0501e)
   - **File(s)**: pkg/dataplane/userspace/manager.go, userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/session_glue.rs, userspace-dp/src/afxdp/types.rs, userspace-dp/src/main.rs, pkg/cluster/sync.go
-
 - **Timestamp**: 2026-04-01T15:59:00Z
   - **Action**: Re-resolve synced sessions with owner_rg_id=0 on active node (7417144e)
   - **File(s)**: userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-01T16:10:00Z
   - **Action**: Add logging rules to CLAUDE.md, remove debug eprintln (12478964)
   - **File(s)**: CLAUDE.md, userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-01T16:59:00Z
   - **Action**: Mirror reverse sessions to helper, worker-completion ack, logging rules (#314, #315, #316) (24166737)
   - **File(s)**: CLAUDE.md, pkg/daemon/daemon.go, pkg/dataplane/userspace/manager.go, userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/types.rs, userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-01T17:00:00Z
   - **Action**: Route barrier/bulk acks through sendCh instead of direct writeMu (9d2814c4)
   - **File(s)**: pkg/cluster/sync.go
-
 - **Timestamp**: 2026-04-01T19:32:00Z
   - **Action**: Fix RefreshOwnerRGs skipped synced sessions — refresh_for_ha_activation (71b80b3d). THE key SNAT fix.
   - **File(s)**: userspace-dp/src/session.rs, userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-01T20:20:00Z
   - **Action**: Simplify HA failover — epoch flow cache, resolve-on-receipt, owner_rg_id, demotion (#325, #326, #327, #330) (a21018f3)
   - **File(s)**: pkg/daemon/daemon.go, pkg/dataplane/userspace/manager.go, pkg/dataplane/userspace/manager_test.go, userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/types.rs, userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-01T21:52:00Z
   - **Action**: Write userspace sessions to BPF conntrack map for zone/interface display (fab9230c)
   - **File(s)**: pkg/dataplane/dataplane.go, pkg/dataplane/userspace/manager.go, pkg/dataplane/userspace/protocol.go, userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/bpf_map.rs, userspace-dp/src/afxdp/session_glue.rs, userspace-dp/src/afxdp/types.rs, userspace-dp/src/main.rs
-
 - **Timestamp**: 2026-04-01T22:00:00Z
   - **Action**: Use BPF_ANY for conntrack map writes (244912f8)
   - **File(s)**: userspace-dp/src/afxdp/bpf_map.rs
-
 - **Timestamp**: 2026-04-01T22:30:00Z
   - **Action**: Userspace/eBPF audit — counters, conntrack flush bugs, session visibility (PR #336, issues #332-#335)
   - **File(s)**: pkg/conntrack/gc.go, pkg/daemon/daemon.go, pkg/dataplane/dataplane.go, pkg/dataplane/dpdk/dpdk_cgo.go, pkg/dataplane/dpdk/dpdk_stub.go, pkg/dataplane/maps.go, pkg/dataplane/userspace/manager.go, pkg/dataplane/userspace/manager_test.go, userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/bpf_map.rs
-
 - **Timestamp**: 2026-04-01T23:00:00Z
   - **Action**: Address PR #336 copilot review — idle time, BPF_EXIST, counter race, safeDelta, RX counter, flush cutoff (d15d5629)
   - **File(s)**: pkg/dataplane/loader.go, pkg/dataplane/maps.go, pkg/dataplane/userspace/manager.go, pkg/dataplane/userspace/manager_test.go, userspace-dp/src/afxdp/bpf_map.rs
-
 - **Timestamp**: 2026-04-01T23:15:00Z
   - **Action**: Thread conntrack FDs through DeleteSynced for BPF cleanup (671e5561)
   - **File(s)**: userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-01T23:30:00Z
   - **Action**: Unify synced flag + adaptive event-first session sync (#328, #320) (dcc59c67)
   - **File(s)**: pkg/daemon/daemon.go, userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/bpf_map.rs, userspace-dp/src/afxdp/forwarding.rs, userspace-dp/src/afxdp/session_glue.rs, userspace-dp/src/afxdp/tunnel.rs, userspace-dp/src/event_stream.rs, userspace-dp/src/main.rs, userspace-dp/src/session.rs
-
-## 2026-04-02
-
 - **Timestamp**: 2026-04-02T18:05:00Z
   - **Action**: Start `#400` — separate transfer readiness from takeover readiness in cluster status and explicit peer-failover admission, with daemon wiring for session-sync transfer-readiness reasons
   - **File(s)**: pkg/cluster/cluster.go, pkg/cluster/cluster_test.go, pkg/daemon/daemon_ha.go, pkg/daemon/userspace_sync_test.go
-
 - **Timestamp**: 2026-04-02T17:20:00Z
   - **Action**: Start `#398` fix — add explicit session-sync transfer-readiness snapshot and fast-fail manual failover demotion when bulk receive or pending bulk ack proves the sync path is not settled; filed `#400` for exposing transfer readiness separately from takeover readiness
   - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_bulk.go, pkg/cluster/sync_test.go, pkg/daemon/daemon_ha.go, pkg/daemon/userspace_sync_test.go
-
 - **Timestamp**: 2026-04-02T16:45:00Z
   - **Action**: Validate `#397` on `loss-userspace-cluster` — settled RG0 manual failover now completes on explicit failover ack + commit ack instead of heartbeat observation; filed residual issue `#398` for failover admission while requester is still in bulk receive
   - **File(s)**: testing-docs/manual-failover-transfer-commit-validation.md, testing-docs/README.md
-
 - **Timestamp**: 2026-04-02T13:15:00Z
   - **Action**: Second #390 slice — add explicit sync-channel failover ack handshake so manual RG transfer returns applied/rejected instead of inferring success from send-only behavior
   - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_test.go, pkg/cluster/cluster.go, pkg/daemon/daemon_ha.go, pkg/cli/cli.go
-
 - **Timestamp**: 2026-04-02T13:45:00Z
   - **Action**: Third #390 slice — wait for actual local RG promotion after peer transfer-out ack so CLI/local control returns on observed ownership, not just request delivery
   - **File(s)**: pkg/cluster/cluster.go, pkg/cluster/cluster_test.go, pkg/cli/cli.go
-
 - **Timestamp**: 2026-04-02T14:15:00Z
   - **Action**: Address PR #396 copilot review — typed remote-failover rejection, failover request IDs, out-of-range RG guard, timeout race guard, active-conn ack routing, and consistent gRPC wording
   - **File(s)**: pkg/cluster/sync.go, pkg/cluster/sync_test.go, pkg/daemon/daemon_ha.go, pkg/grpcapi/server.go
-
 - **Timestamp**: 2026-04-02T16:30:00Z
   - **Action**: Next #390 slice — replace heartbeat-observed manual failover completion with explicit sync-channel transfer commit, local primary commit, peer transfer-out finalization, and commit-ack coverage
   - **File(s)**: pkg/cluster/cluster.go, pkg/cluster/cluster_test.go, pkg/cluster/sync.go, pkg/cluster/sync_test.go, pkg/daemon/daemon_ha.go, pkg/cli/cli.go, pkg/grpcapi/server.go
-
 - **Timestamp**: 2026-04-02T17:05:00Z
   - **Action**: Address PR #397 Copilot review — preserve in-flight peer transfer-out state across heartbeat refreshes until transfer commit completes or aborts
   - **File(s)**: pkg/cluster/cluster.go, pkg/cluster/cluster_test.go
-
 - **Timestamp**: 2026-04-02T12:30:00Z
   - **Action**: First #390 slice — replace weight-zero manual failover with explicit secondary-hold transfer-out state, keep ForceSecondary on zero-weight drain semantics, and teach election to promote on peer transfer-out without mutating monitor weight
   - **File(s)**: pkg/cluster/cluster.go, pkg/cluster/election.go, pkg/cluster/cluster_test.go, pkg/cluster/election_test.go, pkg/cluster/sync.go
-
 - **Timestamp**: 2026-04-02T01:30:00Z
   - **Action**: Merged PR #337 (HA simple failover design doc). Fixed copilot review — issue reference swap in phases 3/5/6.
   - **File(s)**: docs/ha-simple-failover-design.md
-
 - **Timestamp**: 2026-04-02T02:00:00Z
   - **Action**: Fix HA activation cleanup — deduplicate refresh, skip resolved, log mirror errors (#341, #342, #345, #346) (31b600d5)
   - **File(s)**: pkg/dataplane/userspace/manager.go, userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-02T02:30:00Z
   - **Action**: Fix watchdog threshold (2→10s), reverse companion leak on delete, remove debug eprintln (#349, #351, #352) (52254b7e)
   - **File(s)**: pkg/dataplane/userspace/manager.go, userspace-dp/src/afxdp.rs, userspace-dp/src/main.rs
-
 - **Timestamp**: 2026-04-02T03:30:00Z
   - **Action**: Simplify HA — remove refresh RPC, skip blackhole routes, dead code cleanup, throttle post-transition sync (#353, #354, #355, #356) (5ac423a3)
   - **File(s)**: pkg/dataplane/userspace/manager.go, pkg/daemon/daemon.go
-
 - **Timestamp**: 2026-04-02T06:00:00Z
   - **Action**: Merged PR #357 (flow cache simplification refactors). Implemented phases 3+4 from docs/flow-cache-simplification.md — explicit is_cacheable() + 10 unit tests (624a1f83)
   - **File(s)**: userspace-dp/src/afxdp/types.rs, docs/flow-cache-simplification.md
-
 - **Timestamp**: 2026-04-02T11:45:00Z
   - **Action**: Added HA failover implementation plan tying current simplification audit to executable phases and issue dependencies (49eaf9d6)
   - **File(s)**: docs/ha-failover-implementation-plan.md, docs/ha-failover-simplification-audit.md
-
 - **Timestamp**: 2026-04-03T00:16:04Z
   - **Action**: First #389 slice — add derived owner-RG indexes for helper shared session stores and use them for demotion-time BPF cleanup and shared-session demotion without whole-table scans
   - **File(s)**: userspace-dp/src/afxdp.rs, userspace-dp/src/afxdp/types.rs, userspace-dp/src/afxdp/ha.rs, userspace-dp/src/afxdp/shared_ops.rs, userspace-dp/src/afxdp/session_glue.rs, userspace-dp/src/afxdp/forwarding.rs, userspace-dp/src/afxdp/tunnel.rs
-
 - **Timestamp**: 2026-04-03T00:34:06Z
   - **Action**: Address PR #404 Copilot review — make owner-RG index updates heal missing same-owner entries and serialize demotion-time key collection against in-flight shared-session publishes
-  - **File(s)**: userspace-dp/src/afxdp/shared_ops.rs, userspace-dp/src/afxdp/ha.rs, userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-03T00:42:41Z
   - **Action**: Second #389 slice — add reverse-prewarm owner-RG candidate indexes so HA activation prewarm targets only affected synced forward sessions instead of scanning the full shared forward map
   - **File(s)**: userspace-dp/src/afxdp/types.rs, userspace-dp/src/afxdp/shared_ops.rs, userspace-dp/src/afxdp/ha.rs, userspace-dp/src/afxdp/session_glue.rs
-
 - **Timestamp**: 2026-04-03T01:01:45Z
   - **Action**: Final #389 slice — index worker-local sessions by owner RG and use those indexes for export, demotion, and activation refresh so helper HA apply no longer scans the full live session table
   - **File(s)**: userspace-dp/src/session.rs, userspace-dp/src/afxdp/session_glue.rs, _Log.md
-
 - **Timestamp**: 2026-04-03T03:00:15Z
   - **Action**: Applied Copilot review fixes for stacked #389 PRs — make reverse-prewarm owner-RG index updates lock once per refresh, restore derived indexes on rejected session updates, and remove unnecessary hot-path clones
   - **File(s)**: userspace-dp/src/afxdp/shared_ops.rs, userspace-dp/src/session.rs, userspace-dp/src/afxdp/session_glue.rs, userspace-dp/src/afxdp.rs, _Log.md
-
 ## 2026-04-03 HA Failover Fix Session
-
 ### Actions
 - **Action**: Wire BulkSyncOverride in daemon_ha.go so initial bulk sync uses event stream
   - **File(s)**: `pkg/daemon/daemon_ha.go`
@@ -3659,27 +2996,21 @@ top.
   - **File(s)**: `pkg/cluster/sync_bulk.go`
 - **Action**: Fix HA session promotion — push forward sessions to workers + bump rg_epochs on activation
   - **File(s)**: `userspace-dp/src/afxdp/ha.rs`, `userspace-dp/src/afxdp/shared_ops.rs`, `userspace-dp/src/afxdp/session_glue.rs`
-
 ### Results
 - Bulk sync completes correctly on both nodes (event stream + bulk markers)
 - Transfer ready: yes on both nodes after deploy
 - Manual failover test PASSES: iperf3 -P2 at 11 Gbps survives RG move with no visible throughput drop
 - Automated script reports false failure (samples at exact transition moment)
-
 ## 2026-04-17 — #718 ECN CE marking at CoS admission
 - **Action**: Add mark_ecn_ce_ipv4 / mark_ecn_ce_ipv6 / maybe_mark_ecn_ce / apply_cos_admission_ecn_policy; wire into enqueue_cos_item
   - **File(s)**: `userspace-dp/src/afxdp/tx.rs`
 - **Action**: Add CoSQueueDropCounters.admission_ecn_marked field + protocol/worker/coordinator aggregation
   - **File(s)**: `userspace-dp/src/afxdp/types.rs`, `userspace-dp/src/afxdp/worker.rs`, `userspace-dp/src/afxdp/coordinator.rs`, `userspace-dp/src/protocol.rs`
 - **Result**: 16 new tests (11 marker, 5 admission); full suite 667 pass / 0 fail (baseline 651); Local variant only, Prepared deferred to #718-followup
-
 ## 2026-04-17 — #727 ECN CE marking on Prepared CoS variant (#718 follow-up)
 - **Action**: Add `maybe_mark_ecn_ce_prepared(req, umem)` helper; extend `apply_cos_admission_ecn_policy` to handle both `CoSPendingTxItem::Local` and `::Prepared` under a single `admission_ecn_marked` counter; take a shared `&MmapArea` inside `enqueue_cos_item` via split-borrow and thread it to the policy call
-  - **File(s)**: `userspace-dp/src/afxdp/tx.rs`
 - **Action**: Add 5 Prepared-variant admission tests (IPv4 ECT(0), IPv6 ECT(0), NOT-ECT, out-of-range offset, combined Local+Prepared counter pin); remove stale `admission_does_not_mark_prepared_variant` negative pin
-  - **File(s)**: `userspace-dp/src/afxdp/tx.rs`
 - **Result**: admission_ecn group 11/11 pass, mark_ecn_ce group 11/11 pass, full suite 680/680 pass. Marker now fires on the XSK-RX→XSK-TX zero-copy hot path (iperf3, NAT'd flows); acceptance target per `docs/cos-validation-notes.md` is `ecn_marked` becoming non-zero during live 16-flow iperf3
-
 ## 2026-04-17 — #709 Option E owner-profile telemetry (measure before optimizing)
 - **Action**: Add `DRAIN_HIST_BUCKETS = 16` const-asserted, `bucket_index_for_ns` branchless helper, `drain_latency_hist` + `drain_invocations` + `drain_noop_invocations` + `redirect_acquire_hist` + `redirect_sample_counter` + `pps_owner_vs_peer` on `BindingLiveState`; add `new_seeded(worker_id)` constructor so per-worker redirect samples don't lockstep
   - **File(s)**: `userspace-dp/src/afxdp/umem.rs`
@@ -3694,15 +3025,10 @@ top.
 - **Action**: New "Reading the owner-profile counters" section with decision tree mapping drain_p99 / redirect_p99 / owner_pps ratio to #709 Option B/C/D follow-ups
   - **File(s)**: `docs/cos-validation-notes.md`
 - **Result**: 7 new Rust tests (+692 total, baseline 685), 3 new Go tests; full `cargo test` + `go test ./...` green. Telemetry-only: no hot-path allocations, no new syscalls, MPSC invariants preserved, histogram bucket select branchless
-
 ## 2026-04-17 — #708 architect plan
-
-- **Timestamp**: 2026-04-17
   - **Action**: Write #708 enqueue-pacing architect plan — Option B (per-SFQ-bucket token bucket), measurement-first, pacing gate strictly AFTER ECN marker to preserve #718 invariants. Honest framing on residual retrans (most of the ~100k retrans signal is likely ECN-induced recovery entries, not wire loss, so pacing is unlikely to move retrans meaningfully; §3 says so explicitly)
   - **File(s)**: `docs/708-enqueue-pacing-plan.md` (new)
-
 ## 2026-04-21 — #821 round 1 code review fixes
-
 - **Timestamp**: 2026-04-21
   - **Action**: Codex HIGH-1 — drop stale `worker-tids.txt` before launching step1; install SIGINT/SIGTERM trap
     - **File(s)**: `test/incus/step2-sched-switch-capture.sh`
@@ -3715,71 +3041,50 @@ top.
   - **Action**: Codex LOW-5 — classifier meta.json top-level is plan-contracted `{verdict, rho, pvalue, duty_cycle_pct, warn_blocks}`; extras moved to `diagnostic` sub-object
     - **File(s)**: `test/incus/step2-sched-switch-classify.py`
   - **Action**: Codex LOW-6 — G8.2 grep uses `grep -qE` with whitespace-tolerant pattern; G8.3 perf-record stderr no longer suppressed
-    - **File(s)**: `test/incus/step2-sched-switch-capture.sh`
   - **Action**: Codex LOW-7 — add `TestReducerNegativeWakeDelta` suite with wake-before-switch and equal-ts exercises documenting branch unreachability under monotonic perf
     - **File(s)**: `test/incus/step2-sched-switch-reduce_test.py`
   - **Action**: pyshell M1 — SIGINT/SIGTERM trap added in capture.sh
-    - **File(s)**: `test/incus/step2-sched-switch-capture.sh`
   - **Action**: pyshell M2 — `reduce_events` docstring moved to first statement per PEP 257
-    - **File(s)**: `test/incus/step2-sched-switch-reduce.py`
   - **Result**: `python3 -m py_compile` OK on all 4 modified `.py` files; reducer tests 13/13 green (was 10, +3 new); classifier tests 11/11 green (was 8, +3 new); V8 non-regression preserved (`step1-histogram-classify.py` unchanged)
-
 ## 2026-05-10 — docs README reference fix
-
 - **Timestamp**: 2026-05-10T03:24:56Z
   - **Action**: Correct stale filename references in module READMEs (`eventengine.go`/`dhcprelay.go` -> `engine.go`/`relay.go`) so entry-point file:line links resolve.
   - **File(s)**: `pkg/eventengine/README.md`, `pkg/dhcprelay/README.md`
-
 ## 2026-05-10 — docs README wiring/source corrections
-
 - **Timestamp**: 2026-05-10T05:18:20Z
   - **Action**: Correct `SessionCloseData` attribution to `logging.EventReader` session-close records (not conntrack GC delete callbacks).
   - **File(s)**: `pkg/flowexport/README.md`
-- **Timestamp**: 2026-05-10T05:18:20Z
   - **Action**: Correct configstore encryption note to match implementation (`master.key` + HKDF with configured PRF).
   - **File(s)**: `pkg/configstore/README.md`
-
 ## 2026-05-12 fairness_multi_sample round-2 HIGH fixes
-
 - **Timestamp**: 2026-05-12T06:50:50Z
   - **Action**: Round-3 follow-up — tighten verdict JSON detection to the canonical fairness-eval verdict-key set; remove the `os.getpgid` timeout race by using the process-group leader PID directly; add a bounded post-kill `communicate()`; remove a stale threshold-source reference.
   - **File(s)**: test/incus/fairness_multi_sample.py, test/incus/fairness_multi_sample_test.py, docs/per-5-tuple/v8-multi-sample.md
-
 - **Timestamp**: 2026-05-12T07:45:00Z
   - **Action**: PR #1273 Copilot follow-up — align multi-sample verdict filtering with the canonical 10-key fairness-eval schema and validate summary numeric fields (`cstruct`, `gap`, optional `aggregate_mbps`, and integer `starved_flow_count`) instead of only `observed_cov`.
   - **File(s)**: test/incus/fairness_multi_sample.py, test/incus/fairness_multi_sample_test.py, docs/per-5-tuple/v8-multi-sample.md, docs/per-5-tuple/state.md, _Log.md
-
 - **Timestamp**: 2026-05-12T06:29:25Z
   - **Action**: HIGH1 - Tighten extract_verdict_objects to require verdict+observed_cov+discriminator field
   - **Action**: HIGH2 - Replace subprocess.run with Popen(start_new_session=True)+os.killpg for process-group cleanup on timeout
   - **Action**: MINOR - Replace statistics.fmean with statistics.mean; remove dead timeout_stream_text
   - **Action**: Docs - Add fresh-iperf3 requirement and threshold derivation to v8-multi-sample.md
   - **Action**: Tests - Add schema-incomplete and process-group tests; move import time to top
-  - **File(s)**: test/incus/fairness_multi_sample.py, test/incus/fairness_multi_sample_test.py, docs/per-5-tuple/v8-multi-sample.md
   - **Result**: 12/12 tests green (was 10)
-
 ## 2026-05-12 fairness_multi_sample round-3 fix
-
 - **Timestamp**: 2026-05-12T07:02:16Z
   - **Action**: Fix pgid capture race - capture os.getpgid(proc.pid) immediately after Popen before communicate() can reap the leader; use cached pgid in both _kill_process_group() calls.
   - **File(s)**: test/incus/fairness_multi_sample.py
   - **Result**: 14/14 tests green
-
 ## 2026-05-12 — fairness-eval diagnostic message + test rename
-
 - **Timestamp**: 2026-05-12T06:52:27Z
   - **Action**: PR #1272 round-3 review follow-up — clarify the top-level guard comment to reference `iface_filter_active`, and pin guard failure tests on `expected`, `non-starved`, and `dir_mult` substrings.
   - **File(s)**: `userspace-dp/src/bin/fairness-eval.rs`, `userspace-dp/tests/fairness_eval_blackbox.rs`
-
 - **Timestamp**: 2026-05-12T06:29:24Z
   - **Action**: Fix Harness guard failure message to print `expected_sum` and `dir_mult` alongside `n_non_starved` so operators can see the bidirectional expansion factor. Update block comment to correctly describe `max(2, floor(10% × expected_sum))` formula.
   - **File(s)**: `userspace-dp/src/bin/fairness-eval.rs`
-- **Timestamp**: 2026-05-12T06:29:24Z
   - **Action**: Rename `guard_low_n_iface_input_accepts_p2_single_direction_recency_undercount` → `guard_low_n_iface_input_accepts_absolute_floor_p2_gap1`; add inline math comment explaining why absolute floor (not recency) is the operative gate. Drop misleading "recency" claim from assertion messages.
   - **File(s)**: `userspace-dp/tests/fairness_eval_blackbox.rs`
-
 ## 2026-05-13 — PR #1301 cross-NIC shared-UMEM validation path
-
 - **Timestamp**: 2026-05-13T20:22:00-07:00
   - **Action**: Enable cross-NIC shared UMEM in the loss userspace HA config, add node-local Phase 0 artifacts, push artifacts during deploy when the config requests shared UMEM, surface shared-UMEM binding mode/role in userspace status, and document the perf/counter contract for copy-free validation.
   - **File(s)**: `docs/ha-cluster-userspace.conf`, `test/incus/cluster-setup.sh`, `test/incus/loss-userspace-shared-umem-phase0-node0.json`, `test/incus/loss-userspace-shared-umem-phase0-node1.json`, `pkg/dataplane/userspace/protocol.go`, `pkg/dataplane/userspace/statusfmt.go`, `pkg/dataplane/userspace/statusfmt_test.go`, `docs/shared-umem-plan.md`, `docs/userspace-perf-compare.md`, `_Log.md`
@@ -3822,7 +3127,6 @@ top.
   - **Action**: #1318 scoped CoS drain idle fix: gate `drain_shaped_tx` root priming on runnable queues or due parked wake ticks, skipping timer-wheel advance and shared-root lease top-up for not-yet-serviceable parked roots while preserving due wake service.
   - **File(s)**: `userspace-dp/src/afxdp/cos/queue_service/mod.rs`, `userspace-dp/src/afxdp/cos/queue_service/tests.rs`, `userspace-dp/src/afxdp/cos/tx_completion.rs`, `userspace-dp/src/afxdp/cos/tx_completion_tests.rs`, `userspace-dp/src/afxdp/cos/README.md`, `_Log.md`
   - **Validation**: `cargo test --manifest-path userspace-dp/Cargo.toml drain_shaped_tx_ -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml root_serviceability_tracks_parked_queue_wakeup_tick -- --nocapture`; `cargo test --manifest-path userspace-dp/Cargo.toml queue_service`; `cargo test --manifest-path userspace-dp/Cargo.toml tx_completion`
-
 - **Timestamp**: 2026-05-14T20:30:00Z
   - **Action**: #1319 Phase 1 + Phase 2 (schedulers subtree only): add typed-leaf schema infrastructure (`ValueType` enum + `ValueDesc` + `ValueExamples` + `Validator` on `cmdtree.Node`); add strict error-returning parsers `parseBandwidthLimitStrict` / `parseBurstSizeLimitStrict` / `parseScaledDecimalUnitStrict` alongside the legacy zero-return parsers; add stateless validators in `pkg/config/schema_validators.go` (`ValidateRate`, `ValidateByteSize`, `ValidateInteger`, `ValidateEnum`, `ValidatePercent`); declare per-leaf schema for `class-of-service schedulers <name> { ... }` compiler-consumed leaves (`transmit-rate`, `priority`, `buffer-size`, `surplus-sharing`, `equal-flow-enforcement`); wire `cmdtree.SchemaValidate` into `configstore.compileTree` so `commit check` rejects `transmit-rate asd` with a human-readable error before the legacy zero-return parser silently writes 0 bps. Surfaces `?` placeholder + examples for typed leaves.
   - **File(s)**: `pkg/cmdtree/tree.go`, `pkg/cmdtree/schema_validate.go` (new), `pkg/cmdtree/tree_test.go`, `pkg/cmdtree/README.md`, `pkg/config/compiler_protocols.go`, `pkg/config/schema_validators.go` (new), `pkg/config/schema_validate_test.go` (new), `pkg/config/README.md`, `pkg/configstore/store.go`, `pkg/configstore/store_test.go`, `_Log.md`
@@ -3831,7 +3135,6 @@ top.
   - **Action**: PR #1320 round-1 review fixes: preserve split Junos-style `transmit-rate exact`; make typed scheduler leaves fail closed on missing values and unknown trailing modifiers; reject sub-byte scheduler rates that compile to zero bytes/sec; align `buffer-size` validation and help with the compiler's byte-size-only representation; remove unsupported scheduler-level `shaping-rate` from the typed schema; update module docs to match the enforced schema.
   - **File(s)**: `pkg/cmdtree/schema_validate.go`, `pkg/cmdtree/tree.go`, `pkg/cmdtree/README.md`, `pkg/config/schema_validators.go`, `pkg/config/schema_validate_test.go`, `pkg/config/README.md`, `_Log.md`
   - **Validation**: `go test -count=1 ./pkg/config ./pkg/cmdtree ./pkg/configstore` (PASS); `go test -count=1 ./pkg/...` (PASS); `git diff --check` (clean).
-
 - **Timestamp**: 2026-05-16T14:17:38-07:00
   - **Action**: #1373 Phase 0 documentation/audit update: refresh userspace dataplane gap blockers, add retirement notices to active docs and README entry points, and add an umbrella tracker for the staged eBPF dataplane retirement. Explicitly document that Phase 0 removes no BPF source.
   - **File(s)**: `docs/userspace-dataplane-gaps.md`, `docs/pr/1373-retire-ebpf-dataplane/plan.md`, `README.md`, `CLAUDE.md`, `docs/testing.md`, `docs/development-workflow.md`, `bpf/README.md`, `userspace-dp/README.md`, `pkg/dataplane/README.md`, `testing-docs/README.md`, `_Log.md`
@@ -3841,52 +3144,37 @@ top.
 - **Timestamp**: 2026-05-17T18:57:46Z
   - **Action**: Adversarial PR #1374 follow-up: optimize SYN-cookie validated-client cache with map+queue state so insert/take are O(1), while expiry/eviction drain stale queue tokens from the head without whole-cache scans.
   - **File(s)**: `userspace-dp/src/screen.rs`, `userspace-dp/src/screen_tests.rs`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T20:25:00Z
   - **Action**: PR #1407 Codex round-1 follow-up docs correction — replaced a non-existent scheduler test reference in the #1378 plan with the implemented delete/re-add counter lifecycle regression (`hit_counters_reset_after_rule_absent_then_readded`) to match actual coverage.
   - **File(s)**: `docs/pr/1373-retire-ebpf-dataplane/plan-1378-policy-schedulers.md`, `_Log.md`
   - **Validation**: `go test ./pkg/config ./pkg/dataplane/userspace ./pkg/api ./pkg/grpcapi ./pkg/cli`; `cargo test --manifest-path userspace-dp/Cargo.toml policy:: -- --nocapture` (blocked: missing libelf headers/pkg-config in runner)
-
 - **Timestamp**: 2026-05-17T21:28:00Z
   - **Action**: PR #1407 Codex round-2 follow-up — added regression coverage for helper-backed sparse/global policy counters in gRPC and Prometheus reporting paths, and extended policy-hit metric collection to include global policies (`*`/`*` labels) so userspace/global counter IDs are surfaced consistently.
   - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `pkg/grpcapi/server_show_zones_test.go`, `_Log.md`
   - **Validation**: `gofmt -w pkg/api/metrics.go pkg/api/metrics_test.go pkg/grpcapi/server_show_zones_test.go`; `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T21:34:00Z
   - **Action**: Addressed automated review follow-up on policy-hit metrics by adding a shared `policyCounterID` helper used by collector/tests and guarding global-policy metric emission against nil policy entries.
   - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `_Log.md`
   - **Validation**: `gofmt -w pkg/api/metrics.go pkg/api/metrics_test.go`; `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T21:38:00Z
   - **Action**: Applied final review nits: reverted unintended zone-policy nil-contract change in Prometheus policy counter loop and documented why global policy IDs use the post-zone-set offset in metrics tests.
-  - **File(s)**: `pkg/api/metrics.go`, `pkg/api/metrics_test.go`, `_Log.md`
-  - **Validation**: `gofmt -w pkg/api/metrics.go pkg/api/metrics_test.go`; `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace ./pkg/config`; `git diff --check`
-
 - **Timestamp**: 2026-05-17T22:00:00Z
   - **Action**: Added explicit invariant note in `collectPolicyCounters` clarifying why zone-pair policy loop dereferences `rule.Name` without a nil guard while global policy loop retains defensive nil filtering.
-  - **File(s)**: `pkg/api/metrics.go`, `_Log.md`
-
 - **Timestamp**: 2026-05-17T20:20:00Z
   - **Action**: Edited mirror runtime path to resolve mirror output through bind-ifindex mapping and added production-shape mirror tests.
   - **File(s)**: userspace-dp/src/afxdp/mirror.rs
-
 - **Timestamp**: 2026-05-17T20:21:00Z
   - **Action**: Updated mirror counter comments to match actual NoFrame/NoBinding semantics.
   - **File(s)**: userspace-dp/src/afxdp/umem/mod.rs
-
-- **Timestamp**: 2026-05-17T21:28:00Z
   - **Action**: Added cross-worker mirror admission cap path to enforce mirror-specific pending limit before redirect-inbox enqueue.
   - **File(s)**: userspace-dp/src/afxdp/umem/mod.rs, userspace-dp/src/afxdp/mirror.rs
-
 - **Timestamp**: 2026-05-17T21:29:00Z
   - **Action**: Updated #1376 plan test/runtime notes to match implemented mirror tests and cross-worker limit semantics.
   - **File(s)**: docs/pr/1373-retire-ebpf-dataplane/plan-1376-port-mirroring.md
-
 - **Timestamp**: 2026-05-23T16:16:59Z
   - **Action**: PR #1498 userspace shim loader r4/r5 closeout: make pinned compatibility-map drift fail closed instead of deleting individual pins or the whole BPF pin tree; cleanup only legacy-only map pins (`xdp_progs`, `tc_progs`, `policer_states`); keep stateful compatibility pins (`sessions`, `sessions_v6`, `dnat_table`, `dnat_table_v6`) preserved; make stale `tc_*` cleanup exhaustively try every pin before returning joined cleanup errors; correct userspace shim drift remediation text to `make generate-userspace-xdp`.
   - **File(s)**: `pkg/dataplane/loader.go`, `pkg/dataplane/loader_ebpf.go`, `pkg/dataplane/userspace_shim_loader_test.go`, `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
   - **Validation**: `go test ./pkg/dataplane -run 'TestUserspaceShim|TestCleanupUserspaceShim|TestLoadOrCreatePinnedShimMap|TestEmbeddedUserspaceShim' -count=1 -v`; `go test ./pkg/dataplane -run 'TestValidateUserspaceShimSpecDriftMentionsUserspaceXDPGenerate' -count=1 -v`; `go test ./pkg/dataplane/... -count=1`; `go test ./...`; `git diff --check`; `GOFLAGS=-buildvcs=false ./scripts/userspace-phase-cycle.sh --env test/incus/loss-userspace-cluster.env` passed on `0254013c` with userspace auto-armed on `loss:xpf-userspace-fw0`, IPv4 runs 21.141/23.328/23.226 Gbps and IPv6 runs 21.137/23.079/23.073 Gbps. The later `542656ec` and this log/doc follow-up only change error text, tests, and documentation.
-
 - **Timestamp**: 2026-05-24T03:27:07Z
   - **Action**: PR #1498 Codex r5 follow-up: added an operator runbook for
     fail-closed userspace shim compatibility-map pin recovery and centralized
@@ -3895,60 +3183,34 @@ top.
     guidance.
   - **File(s)**: `pkg/dataplane/loader_ebpf.go`,
     `docs/operations/userspace-shim-pin-recovery.md`,
-    `docs/pr/1373-retire-ebpf-dataplane/README.md`, `_Log.md`
-  - **Validation**: `go test ./pkg/dataplane -run
     'TestValidateUserspaceShimSpecDriftMentionsUserspaceXDPGenerate|TestUserspaceShim|TestCleanupUserspaceShim|TestLoadOrCreatePinnedShimMap|TestEmbeddedUserspaceShim'
-    -count=1`; `go test ./pkg/dataplane/... -count=1`; `go test ./...
-    -count=1`; `git diff --check`
-
 - **Timestamp**: 2026-05-24T04:47:07Z
   - **Action**: #1503 documentation reconciliation: refreshed
     `docs/feature-gaps.md` so closed #1378 policy-scheduler work is no longer
     presented as open retirement follow-up, and closed #1375 policer work is
     documented as future parity/hardening rather than an active #1373
     source-removal blocker.
-  - **File(s)**: `docs/feature-gaps.md`, `_Log.md`
   - **Validation**: `rg -n "#1375|#1378|retirement blocker|retirement-contract"
-    docs/feature-gaps.md docs/pr/1373-retire-ebpf-dataplane/README.md
-    docs/pr/1373-retire-ebpf-dataplane/plan.md`; `git diff --check`
-
 - **Timestamp**: 2026-05-23T21:46:59-07:00
   - **Action**: #1502 artifact-schema checker follow-up: parse JSON floats as
     `Decimal`, normalize JSON integer-like values for manifest issues,
     schema version, and command exit status, reject lossy non-integer decimal
     numbers, and restrict accepted RFC3339 leap seconds to 23:59:60 on June 30
     or December 31.
-  - **File(s)**: `test/incus/retire_ebpf_artifact_schema.py`,
-    `test/incus/retire_ebpf_artifact_schema_test.py`, `_Log.md`
-  - **Validation**: `python3 -m unittest discover -s test/incus -p
     retire_ebpf_artifact_schema_test.py`; `python3
     test/incus/retire_ebpf_artifact_schema_test.py`; `python3 -m py_compile
-    test/incus/retire_ebpf_artifact_schema.py
     test/incus/retire_ebpf_artifact_schema_test.py`; `python3 -m json.tool
-    docs/pr/1373-retire-ebpf-dataplane/final-validation/manifest.schema.json
-    >/dev/null`; `git diff --check`
-
 - **Timestamp**: 2026-05-24T11:01:44-07:00
   - **Action**: PR #1506 review follow-up: reject Python JSON parser
     extensions (`NaN`, `Infinity`, and `-Infinity`) through the existing
     invalid-JSON validation path, and cap Decimal integer materialization so
     hostile exponent-form manifest integers cannot force huge `int`
     allocation.
-  - **File(s)**: `test/incus/retire_ebpf_artifact_schema.py`,
-    `test/incus/retire_ebpf_artifact_schema_test.py`, `_Log.md`
-  - **Validation**: `python3 -m unittest discover -s test/incus -p
-    retire_ebpf_artifact_schema_test.py`; `python3 -m py_compile
-    test/incus/retire_ebpf_artifact_schema.py
-    test/incus/retire_ebpf_artifact_schema_test.py`; `git diff --check`
-
 - **Timestamp**: 2026-05-23T21:30:00Z
   - **Action**: Hoisted PADDED_PLAINTEXT_MAX guard above next_tx_counter + header write so encap-overflow returns BufferTooSmall without observable side effects; removed dead fn peer_index; pruned r5 leftover duplicate comment block in try_encap; added install_session_serializes_with_reconcile_removal and encap_padded_plaintext_overflow_leaves_counter_and_buffer_untouched regression tests.
   - **File(s)**: userspace-dp/src/afxdp/wg/engine.rs
-
 - **Timestamp**: 2026-05-24T04:00:00Z
   - **Action**: r8: strengthened install_session_serializes_with_reconcile_removal with an `ok > 0` gate so the race test cannot pass tautologically when the reconciler always wins (Codex r7 finding); added debug_assert! on duplicate peer pubkey in reconcile_peers so engine-side surface flags Go-control-plane validation gaps (r6 Claude nit 4 / Codex r7).
-  - **File(s)**: userspace-dp/src/afxdp/wg/engine.rs
-
 - **Timestamp**: 2026-05-24T21:30:12-07:00
   - **Action**: PR #1499 final nit: corrected the nonce-layout comment
     in `framing.rs` to match snow 0.10's default ChaCha20-Poly1305
@@ -3967,7 +3229,6 @@ top.
   - **File(s)**: `userspace-dp/src/afxdp/wg/framing.rs`, `_Log.md`
   - **Validation**: cargo build --release; cargo test --release --bin
     xpf-userspace-dp afxdp::wg.
-
 - **Timestamp**: 2026-05-25T06:20Z
 - **Action**: Harmonize ErrDPDKBackendRetired + slog.Warn wording with config sentinel (AGY #1536 review finding)
 - **File(s)**: pkg/dataplane/dataplane.go, pkg/daemon/daemon_run.go
@@ -3980,14 +3241,12 @@ top.
   slog.Warn wording to "the DPDK dataplane backend has been retired".
 - **Validation**: pkg/dataplane test suite green; no other in-tree strings
   pinned the old wording.
-
 - **Timestamp**: 2026-05-24 (1517 plan draft)
 - **Action**: Wrote plan v1 (DRAFT) for #1517 — migrate pkg/cli off legacy
   dataplane.DataPlane (sub-#1451 S2). Mirrors apiRuntimeDataPlane pattern.
 - **File(s)**: docs/pr/1517-cli-migration/plan.md
 - **Why**: Triple-review methodology — plan first, code never first. Dispatch
   Codex + Antigravity adversarial plan review before any code touches.
-
 - **Timestamp**: 2026-05-24 (1517 plan v2 PLAN-READY)
 - **Action**: Folded Codex PLAN-NEEDS-MINOR findings into plan v2. AGY
   PLAN-READY against v1 stands. Both reviewers now agree — proceeding to
@@ -3998,7 +3257,6 @@ top.
   Option B shadow field nor Option C interface widening is needed) and a
   scope-doc citation hygiene issue. AGY r1 (adversarial-review-mpkuldhp-mnlp6x)
   was PLAN-READY across all seven hostile checks.
-
 - **Timestamp**: 2026-05-25 (1517 implementation)
 - **Action**: Implemented #1517 — added pkg/cli/runtime.go with cliRuntime
   interface (25 methods), cliUserspaceStatusProvider, and
@@ -4020,7 +3278,6 @@ top.
   show chassis forwarding, request chassis cluster data-plane
   userspace) all work — the named provider-probe interfaces resolve
   correctly against the userspace LegacyDataPlaneAdapter.
-
 - **Timestamp**: 2026-05-25 (1517 code-review r1 minor folds)
 - **Action**: Folded Copilot inline finding on cliUserspaceControlProvider
   doc comment — said "request security flow" but correct CLI path is
@@ -4028,7 +3285,6 @@ top.
   handleRequestChassisClusterDataPlane in cli_request.go. Recorded
   reviewer-ids for code-review round 1.
 - **File(s)**: pkg/cli/runtime.go, docs/pr/1517-cli-migration/reviewer-ids.md
-
 - **Timestamp**: 2026-05-25 (1517 code review final verdicts)
 - **Action**: All three reviewers MERGE-READY. Recording verdicts;
   not merging (per project policy).
@@ -4037,18 +3293,14 @@ top.
   sandbox-FS-blocked retries); AGY adversarial-review-mpkvctz4-xk8x46
   MERGE-READY (exhaustive 10-check report with byte-for-byte evidence);
   Copilot COMMENTED with 1 minor inline finding, addressed in 91e1da9f.
-
 - **Timestamp**: 2026-05-25T07:30Z
 - **Action**: PR #1549 — fix stale plan.md snippet per Copilot d9545813 review
-- **File(s)**: docs/pr/1517-cli-migration/plan.md
 - **Why**: Copilot review on d9545813 left 1 inline comment that the plan.md
   snippet for cliUserspaceControlProvider still references `request security
   flow ...` while the actual source comment (fixed in 91e1da9f) and the actual
   handler path are `request chassis cluster data-plane userspace` via
   cli_request.go:handleRequestChassisClusterDataPlane. Updated plan snippet
   in lockstep so docs match implementation. No code change.
-
-- **Timestamp**: 2026-05-25T07:30Z
 - **Action**: #1522 plan v2 — pruned bpf/xdp/, bpf/tc/, bpf/headers/ README banner edits per AGY PLAN-NEEDS-MINOR (adversarial-review-mpkub795-6e2gou)
 - **File(s)**: docs/pr/1522-readme-doc-drift/plan.md, docs/pr/1522-readme-doc-drift/reviewer-ids.md
 - **Why**: AGY adversarial-review-mpkub795-6e2gou returned PLAN-NEEDS-MINOR
@@ -4057,7 +3309,6 @@ top.
   entire bpf/ tree — editing those READMEs is pure churn that #1476 will
   reverse. v2 edit list reduced from 5 files to 2 (dpdk_worker/README.md +
   pkg/logging/README.md). Re-dispatching Codex + AGY plan review on v2.
-
 - **Timestamp**: 2026-05-25T08:10Z
 - **Action**: #1522 plan v3 — pruned dpdk_worker/README.md after rebase onto current master (d237cceb) exposed #1528 will delete the entire dpdk_worker/ tree
 - **File(s)**: docs/pr/1522-readme-doc-drift/plan.md, docs/pr/1522-readme-doc-drift/reviewer-ids.md, pkg/logging/README.md
@@ -4075,7 +3326,6 @@ top.
   sentence. `git diff --stat origin/master..HEAD` confirms only
   `*.md` files touched, so smoke is skipped per the pure-docs
   skill rule.
-
 - **Timestamp**: 2026-05-25T08:25Z
 - **Action**: #1522 PR #1555 round-2 — fold Copilot 3 minor inline nits
 - **File(s)**: docs/pr/1522-readme-doc-drift/plan.md,
@@ -4089,7 +3339,6 @@ top.
   validation outcome. All three are purely cosmetic; no diff to
   pkg/logging/README.md.
 - **Validation**: cosmetic-only; no test/build rerun needed.
-
 - **Timestamp**: 2026-05-24T12:00Z
 - **Action**: Draft #1518 plan v1 (cluster session-sync off legacy dataplane.DataPlane)
 - **File(s)**: docs/pr/1518-cluster-session-sync-migration/plan.md, reviewer-ids.md
@@ -4117,7 +3366,6 @@ top.
   go test ./... green (32 packages); retirement boundary canary updated
   with pkg/cluster/runtime.go allowlist entry + 1373 README + cluster
   README. Smoke + test-failover pending (HA-sensitive scope per CLAUDE.md).
-
 - **Timestamp**: 2026-05-25T15:31Z
   - **Action**: PR #1538 Copilot code-review round-2 — fix `want`
     variable shadowing in TestCompileSingleStrictErrorJoinPath and
@@ -4155,7 +3403,6 @@ top.
   pkg/grpcapi/server_sessions.go, pkg/grpcapi/server_show.go,
   pkg/grpcapi/server_show_forwarding.go,
   pkg/dataplane/userspace/legacy_dataplane.go,
-  pkg/dataplane/retirement_boundary_canary_test.go,
   docs/pr/1373-retire-ebpf-dataplane/README.md,
   docs/pr/1516-grpcapi-migration/plan.md (v2).
 - **Validation**: GOCACHE/GOTMPDIR full Go suite green (30+ packages),
@@ -4164,7 +3411,6 @@ top.
   green. Smoke matrix delegated to serialized smoke-runner singleton
   per feedback_smoke_serialized_single_agent rule (AWAITING-SMOKE
   marker posted on PR).
-
 - **Timestamp**: 2026-05-25T16:05Z
 - **Action**: #1554 r3 Copilot finding fold — cross-package compile-time
   interface-satisfaction guard. The userspace-side compile-time check
@@ -4179,7 +3425,6 @@ top.
 - **File(s)**: pkg/grpcapi/runtime_canary_test.go (new), _Log.md
 - **Validation**: go test ./pkg/grpcapi/... -count=1 green; full Go
   suite green.
-
 - **Timestamp**: 2026-05-25T08:30Z
 - **Action**: #1528 DPDK mechanical removal — plan v1 DRAFT
 - **File(s)**: docs/pr/1528-dpdk-mechanical-removal/plan.md
@@ -4190,10 +3435,8 @@ top.
   for operator-friendly migration message + stored-config rolling-upgrade
   safety via daemon_run.go:247 soft-fallback. 10 hostile questions
   surfaced for adversarial plan review. Pending Codex + Antigravity.
-
 - **Timestamp**: 2026-05-25T09:15Z
 - **Action**: #1528 plan v2 — addresses AGY r1 PLAN-NEEDS-MAJOR
-- **File(s)**: docs/pr/1528-dpdk-mechanical-removal/plan.md
 - **Why**: AGY round-1 verified that `validateDataplaneTypeStrict` fires inside
   `Store.Load()` BEFORE the daemon_run.go:247 soft-fallback gets a chance to
   catch `ErrDPDKBackendRetired`. The error is swallowed at daemon_run.go:87 as
@@ -4207,7 +3450,6 @@ top.
   schema children gracefully). Added Q11 + Q12 for the v2 fix path and the
   HA-sync edge case. Codex r1+r2 ENV-BLOCKED sandbox failure; AGY-only verdict
   on v1.
-
 - **Timestamp**: 2026-05-25T09:50Z
 - **Action**: #1528 plan v3 — addresses Codex r3 PLAN-NEEDS-MAJOR
 - **File(s)**: docs/pr/1528-dpdk-mechanical-removal/plan.md, reviewer-ids.md
@@ -4230,21 +3472,16 @@ top.
   entry as a KEEP (defense-in-depth). AGY r2 (adversarial-review-mpld4tso-19877w)
   returned PLAN-READY on v2 but missed findings 1, 3, 4; v3 takes Codex's
   strictly-superior feedback.
-
 - **Timestamp**: 2026-05-25T21:10Z
 - **Action**: #1528 plan v3.1 — fold AGY r3 PLAN-READY minor; Codex r5 retry
-- **File(s)**: docs/pr/1528-dpdk-mechanical-removal/plan.md, reviewer-ids.md
 - **Why**: AGY r3 (adversarial-review-mplgkdgz-ikpdw1) returned PLAN-READY on v3
   with one minor: add TestCompileConfigForLoad_BypassesDPDKRejectViaApplyGroups
   for explicit apply-groups + ${node} coverage under load-mode bypass. Folded
   into §4.6 + test plan. Codex r4 (task-mplgjwea-goeioj) sandbox-failed and
   expired from queue; per feedback_codex_infra_must_retry rule, dispatched r5
   retry (task-mpm3bsbi-hsom0r). Awaiting verdict before proceeding to
-  implementation.
-
 - **Timestamp**: 2026-05-26T00:30Z
 - **Action**: #1528 plan v3.2 — schema-validate edge lock-in (Codex r5 PLAN-NEEDS-MINOR)
-- **File(s)**: docs/pr/1528-dpdk-mechanical-removal/plan.md, reviewer-ids.md
 - **Why**: Codex r5 (task-mpm7n2n2-ty9kjd) returned PLAN-NEEDS-MINOR with one
   blocking concern: schemaValidateExpandedTree runs BEFORE compileTreeForLoad,
   potentially rejecting legacy DPDK sub-stanza leaves before the load-mode
@@ -4255,10 +3492,8 @@ top.
   in pkg/configstore + TestSchemaValidate_AcceptsLegacyDPDKSubStanza in
   pkg/cmdtree) plus §4.7 contract to make the schema-validate scope an
   explicit pinned surface for retirement work. Pending re-dispatch.
-
 - **Timestamp**: 2026-05-26T01:00Z
 - **Action**: #1528 plan v3.3 — strengthen TestSchemaValidate_AcceptsLegacyDPDKSubStanza fixture (Codex r6 PLAN-NEEDS-MINOR)
-- **File(s)**: docs/pr/1528-dpdk-mechanical-removal/plan.md, reviewer-ids.md
 - **Why**: Codex r6 (task-mpm8d1qz-9bj4nh) returned PLAN-NEEDS-MINOR: the v3.2
   fixture has no class-of-service subtree, so SchemaValidate hits the
   pkg/cmdtree/schema_validate.go:43-46 early return and the test only proves
@@ -4271,7 +3506,6 @@ top.
   leaves prove ignored. The strengthened fixture catches BOTH the
   unconditional-validator regression class AND the cos-early-return-removal
   class. Pending re-dispatch.
-
 - **Timestamp**: 2026-05-26T02:15Z
 - **Action**: #1528 Phase B implementation — DPDK mechanical removal complete
 - **File(s)**:
@@ -4297,7 +3531,6 @@ top.
   - KEPT: pkg/dataplane/runtime/import_canary_test.go:47 dpdk forbidden-backend (defense-in-depth)
   - KEPT: pkg/daemon/daemon_run.go:247 errors.Is(ErrDPDKBackendRetired) soft-fallback (now reachable for stored-config rolling-upgrade)
 - **Why**: Both Codex r7 (task-mpmbxohf-mft8dk) and AGY r5 (adversarial-review-mpmby226-tvzsfa) returned PLAN-READY on plan v3.3. Executed mechanical deletion + load-mode bypass per plan v3.3. All packages build clean (go build ./...). Full go test ./... passes. 5x flake check on all DPDK-related tests passes (25/25 runs). make build succeeds. make -n build-dpdk / clean-dpdk correctly report "no rule".
-
 - **Timestamp**: 2026-05-26T02:30Z
 - **Action**: #1528 PR #1560 opened; code-review cycle dispatched
 - **File(s)**: docs/pr/1528-dpdk-mechanical-removal/reviewer-ids.md
@@ -4310,7 +3543,6 @@ top.
   feedback_triple_review_includes_claude_smr (MERGE-READY verdict). Awaiting
   Codex + AGY + Copilot to reach 4-of-4 attestation, then will post
   <!-- AWAITING-MERGE --> marker per feedback_retirement_batch_smoke_at_end.
-
 - **Timestamp**: 2026-05-26T02:45Z
 - **Action**: #1528 PR #1560 — address Copilot inline comment on phase-order wording
 - **File(s)**: docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -4321,7 +3553,6 @@ top.
   make the phase order explicit and call out that Phase 4 landed before
   Phase 3 because the canary-pinned text strings forbade direct rewrite
   pre-Phase-3.
-
 - **Timestamp**: 2026-05-26T09:40Z
 - **Action**: #1528 — fix stale comment in pkg/config/compiler_system.go:238-244
 - **File(s)**: pkg/config/compiler_system.go
@@ -4333,57 +3564,41 @@ top.
   leaf via rewriteRetiredDataplaneType before compile so the sub-stanza goes through
   compileUserspaceDataplane instead. validateDataplaneTypeStrict fires after
   compileSystem in any case, making the silent-drop behavior in this branch moot.
-
-
 - **Action**: #1528 PR #1560 — rebase onto current master (post #1553, #1554, #1557, #1558)
 - **File(s)**: Makefile, _Log.md, pkg/config/compiler.go, pkg/config/dpdk_subtree_leakage_canary_test.go (deleted), pkg/configstore/store.go, pkg/configstore/store_test.go, pkg/dataplane/retirement_boundary_canary_test.go, pkg/config/parser_ast_test.go
 - **Why**: PR was DIRTY/CONFLICTING after #1558 merged (deleted bpfel files) and #1553 merged (added pkg/config/dpdk_subtree_leakage_canary_test.go with DPDKDataplane references). Rebase rewinds my plan-v3 load-mode bypass approach in favor of master's `rewriteRetiredDataplaneType` (introduced for the symmetric #1373 eBPF retirement in #1558) which strips the retired-type leaf from the AST at Load (and at SyncApply, which my bypass didn't cover). Master's rewrite already handles apply-groups + ${node} expansion paths via `groupsBlocksOf` walker — the same finding Codex r3 raised against my v2 rewrite-at-Load approach. End result: drops compileOpts{loadMode} + compileWithOpts + CompileConfigForLoad + CompileConfigForNodeAndLoad + compileTreeForLoad in favor of master's rewriteRetiredDataplaneType bridge. Net: PR is now a pure mechanical-deletion (dpdk_worker/, pkg/dataplane/dpdk/, Makefile targets, DPDKConfig/AdaptiveConfig/Port types, SystemConfig.DPDKDataplane field, compileDPDKDataplane fn, retirement-boundary canary DPDK entries). Also deletes pkg/config/dpdk_subtree_leakage_canary_test.go (PR #1553's leakage canary) since the field it polices is gone — per the canary's own comment ("This is dead code after #1528 (Phase 3) deletes the field entirely; remove this line in #1528"). Schema-validate scope contract + TestSchemaValidate_AcceptsLegacyDPDKSubStanza preserved as future-proofing for any expansion of SchemaValidate. Store.Load tests updated to assert DataplaneType=="" post-rewrite (was "dpdk" under the dropped bypass approach).
-
 - **Timestamp**: 2026-05-26 09:50 UTC
 - **Action**: Fold AGY r2 + Copilot r3 minor findings — update 3 stale comments referring to pre-rebase load-mode bypass / compileTreeForLoad to reference rewriteRetiredDataplaneType bridge (called from both Store.Load and Store.SyncApply per master post-#1558).
 - **File(s)**: pkg/config/types.go (SystemConfig.DataplaneType comment); docs/pr/1373-retire-ebpf-dataplane/README.md (remaining DPDK bullet); pkg/cmdtree/schema_validate_test.go (TestSchemaValidate_AcceptsLegacyDPDKSubStanza header). Fourth comment (pkg/config/compiler_system.go) already fixed in 66c4d711.
-
 - **Timestamp**: 2026-05-26 10:00 UTC
 - **Action**: Fold Codex r-final MERGE-NEEDS-MINOR comment findings — update 2 stale comments. (1) ErrDPDKBackendRetired comment no longer references the deleted pkg/dataplane/dpdk package-local test; points to runtime/import_canary_test.go as defense-in-depth. (2) TestSchemaValidate_AcceptsLegacyDPDKSubStanza header clarifies it guards orphaned sub-stanzas that survive the rewrite bridge, not pre-bridge schema validation.
 - **File(s)**: pkg/dataplane/dataplane.go (ErrDPDKBackendRetired comment); pkg/cmdtree/schema_validate_test.go (test header).
-
 - **Timestamp**: 2026-05-26 16:25 UTC
 - **Action**: #1540 REST API split — plan v1 DRAFT; identifies sibling-file shape (`pkg/api/<aspect>.go`) per parent wave-1 instructions; lists target file decomposition for handlers.go (67 fns → 11 files) and metrics.go (33 fns → 6 files); flags 7 open questions for adversarial plan review including flat-package vs subdirectory shape decision.
 - **File(s)**: docs/pr/1540-rest-api-split/plan.md, docs/pr/1540-rest-api-split/reviewer-ids.md.
-
 - **Timestamp**: 2026-05-26 16:45 UTC
 - **Action**: #1540 REST API split — implementation. Split pkg/api/handlers.go (2223 LOC, 67 fns) into 13 sibling files (api/health/stats/security/nat/interfaces/routing/dhcp/ipsec/vrrp/system/config/show_text); split pkg/api/metrics.go (2033 LOC, 33 fns) into 7 sibling files (metrics/metrics_descriptors/metrics_userspace/metrics_counters/metrics_sessions/metrics_nat/metrics_system); renamed handlers_sessions.go to sessions.go. All plan-review minors from Codex + AGY folded: config.go (not config_handlers.go); newCollector moved to metrics_descriptors.go; parseMemInfoKB moved to metrics_system.go; api.go tightened (policyActionStr+screenChecks→security.go, protoName→sessions.go, configCommitResponse+commitResponseFromConfig→config.go); legacy import allowlist + retirement docs updated. Pure code motion. Full go test ./... clean.
 - **File(s)**: pkg/api/api.go, config.go, dhcp.go, health.go, interfaces.go, ipsec.go, metrics.go, metrics_counters.go, metrics_descriptors.go, metrics_nat.go, metrics_sessions.go, metrics_system.go, metrics_userspace.go, nat.go, routing.go, security.go, sessions.go, show_text.go, stats.go, system.go, vrrp.go; pkg/dataplane/retirement_boundary_canary_test.go; docs/pr/1373-retire-ebpf-dataplane/README.md; docs/pr/1540-rest-api-split/plan.md; docs/pr/1540-rest-api-split/reviewer-ids.md.
-
 - **Timestamp**: 2026-05-26 17:05 UTC
 - **Action**: #1540 PR #1564 — fold Codex code-review MERGE-NEEDS-MINOR doc-drift findings + Copilot review minors. (1) plan.md updated to reflect post-fold landed shape: config.go (not config_handlers.go), newCollector → metrics_descriptors.go, parseMemInfoKB → metrics_system.go, api.go-tightening (policyActionStr/screenChecks → security.go, protoName → sessions.go, configCommitResponse + commitResponseFromConfig → config.go). (2) canary allowlist + retirement README pkg/api/api.go blurb corrected: 'apiRuntimeDataPlane + protoName' → 'apiRuntimeDataPlane + applyResult adapter' (protoName moved to sessions.go). (3) _Log.md timestamps backfilled to HH:MM UTC for Copilot consistency. Copilot's 4 inline pre-existing `net.InterfaceByName(ifName)` Junos-name findings (interfaces.go, stats.go, metrics_counters.go) are NOT addressed in this PR — pure code motion contract; pre-existing bugs to be filed as separate issues.
 - **File(s)**: docs/pr/1540-rest-api-split/plan.md, pkg/dataplane/retirement_boundary_canary_test.go, docs/pr/1373-retire-ebpf-dataplane/README.md, _Log.md.
-
 - **Timestamp**: 2026-05-26 17:15 UTC
 - **Action**: #1540 PR #1564 — fold Codex round-2 MERGE-NEEDS-MINOR remaining doc-drift findings. (1) plan.md 'Open questions for adversarial review' v1 section refactored into 'Open questions — resolutions' that documents how each of the 7 v1 questions was answered across the two plan-review rounds. (2) reviewer-ids.md updated with actual round-1 verdicts (Codex MERGE-NEEDS-MINOR, AGY MERGE-READY, Copilot COMMENTED 8 inline, Claude SMR MERGE-READY) and adds round-2 entry. Doc-only fix.
 - **File(s)**: docs/pr/1540-rest-api-split/plan.md, docs/pr/1540-rest-api-split/reviewer-ids.md, _Log.md.
-
 - **Timestamp**: 2026-05-26 17:30 UTC
 - **Action**: #1444 — pure code-motion refactor de-monolithizing pkg/cli/cli.go from 1999 LOC to 418 LOC. Plan v1 → Codex (PLAN-NEEDS-MAJOR) + Gemini (PLAN-NEEDS-MINOR). Plan v2 addressing all 8 v1 findings → Gemini PLAN-READY r2; Codex sandbox infra failed twice, returned PLAN-NEEDS-MINOR on third retry with inline plan paste. v3 plan acknowledges Codex r2 ownership findings. Implementation: 9 new sibling files (cli_show_security_dispatch.go, peer.go, permissions.go, apply.go, session_filter.go, app_resolve.go, link.go, chrony.go, proto.go) + extensions to existing completion.go (completer engine merged in), cli_show_cluster.go (fabricRedirectCounters), cli_show_flow.go (topTalkerEntry), cli_show_nat.go (handleShowNAT), cli_show_routing.go (handleShowRoute+handleShowProtocols), cli_show_services.go (handleShowClassOfService+handleShowServices), cli_show_interfaces.go (dhcpLease). Updated #1373 retirement-boundary canary allowlist + docs table for 4 new pkg/cli files that retain legacy dataplane imports. go build clean, all 32 test packages pass.
 - **File(s)**: pkg/cli/cli.go (-1581 LOC), pkg/cli/completion.go (+218), pkg/cli/cli_show_security_dispatch.go (new), pkg/cli/peer.go (new), pkg/cli/permissions.go (new), pkg/cli/apply.go (new), pkg/cli/session_filter.go (new), pkg/cli/app_resolve.go (new), pkg/cli/link.go (new), pkg/cli/chrony.go (new), pkg/cli/proto.go (new), pkg/cli/cli_show_cluster.go, pkg/cli/cli_show_flow.go, pkg/cli/cli_show_nat.go, pkg/cli/cli_show_routing.go, pkg/cli/cli_show_services.go, pkg/cli/cli_show_interfaces.go, pkg/dataplane/retirement_boundary_canary_test.go, docs/pr/1373-retire-ebpf-dataplane/README.md, docs/pr/1444-cli-presenters/plan.md (new).
-
 - **Timestamp**: 2026-05-26 17:45 UTC
 - **Action**: #1444 PR #1566 — rebase onto origin/master @ 838657aa (post-#1564 #1540 REST API split). Conflict in _Log.md auto-resolved (keep both #1540 + #1444 chronological entries). Canary + docs README auto-merged cleanly (#1540 + #1444 modified non-overlapping table sections). Re-run go build + go test post-rebase: clean.
 - **File(s)**: _Log.md (conflict resolution).
-
 ## 2026-05-26 — #1345 server/handlers.rs per-verb split
-
 - **Timestamp**: 2026-05-26T17:00Z
 - **Action**: Split 415-LOC handle_stream dispatcher into per-verb modules
 - **File(s)**: userspace-dp/src/server/handlers.rs → handlers/mod.rs (181 LOC slim dispatcher) + 12 per-verb files (snapshot, forwarding, ha, neighbors, queue, binding, inject_packet, sync_session, session_deltas, export, rebind, stop_workers). Trivial arms (ping/status, update_fabrics, clear_policy_counters, shutdown, catch-all) stay inline in mod.rs. Pure code motion; zero new clones; byte-identical eprintln strings. cargo build clean, all tests pass except pre-existing master flake snat_contract_documents_current_fail_closed_runtime (confirmed on origin/master independent of this branch).
 ## #1327 poll_descriptor stages — 2026-05-26
-
-- **Timestamp**: 2026-05-26
   - **Action**: Worktree created from origin/master; #1327 Step 1 plan
     review v1→v4 (PLAN-NEEDS-MAJOR → PLAN-NEEDS-MINOR → split → MERGE-READY).
   - **File(s)**: branch refactor/1327-poll-descriptor-stages
-
-- **Timestamp**: 2026-05-26
   - **Action**: Implemented Step 1. Converted flat poll_descriptor.rs to
     directory module (poll_descriptor/mod.rs). Extracted flow-cache fast
     path (verbatim translation of original L563-894) to flow_cache_hit.rs
@@ -4394,8 +3609,6 @@ top.
     Final: mod.rs 2806 LOC (was 3292), flow_cache_hit.rs 379 LOC,
     rx_telemetry.rs 220 LOC.
   - **File(s)**: userspace-dp/src/afxdp/poll_descriptor/{mod,flow_cache_hit,rx_telemetry}.rs, userspace-dp/tests/snat_contract_doc_guard.rs
-
-- **Timestamp**: 2026-05-26
   - **Action**: Validation gates. cargo build clean; cargo test 1417/1417
     main suite pass; snat_contract_doc_guard pre-existing master flake
     (docs/userspace-dataplane-gaps.md missing "fail-closed" keyword);
@@ -4403,8 +3616,6 @@ top.
     pre-existing flake; cargo asm gate confirmed via nm (no
     stage_flow_cache_hit symbol in release binary); Go suite 30/30 pass.
   - **File(s)**: PR #1571
-
-- **Timestamp**: 2026-05-26
   - **Action**: Code reviews — Codex provisional MERGE-READY (sandbox
     infra-blocked, summary-based), AGY MERGE-READY with Python line-by-
     line verification script, Copilot 1 inline finding (test path
@@ -4412,25 +3623,15 @@ top.
     comment 4547263769): AF_XDP UMEM ownership / CPU-arch inline gate /
     zero allocation / HA epoch ordering / SW design pattern all verified
     MERGE-READY. AWAITING-BATCH-MERGE marker posted.
-  - **File(s)**: PR #1571
-
 ## 2026-05-26 — #1542 NAT runtime split (Wave-2)
-- **Timestamp**: 2026-05-26
 - **Action**: Plan v1 drafted, committed (724987e6), pushed; dispatched Codex (task-mpmyrnf2-1de5ha) + AGY (adversarial-review-mpmys6pk-3ut2f2) plan reviews in parallel.
 - **File(s)**: docs/pr/1542-nat-runtime-split/plan.md, docs/pr/1542-nat-runtime-split/reviewer-ids.md
-
 ## 2026-05-26 — #1542 NAT runtime split implementation
-- **Timestamp**: 2026-05-26
 - **Action**: Split userspace-dp/src/nat.rs (1605 LOC) into nat/{mod,allocator,source,destination,static_nat,status}.rs + tests.rs. Plan v3 ratified after Codex+AGY round 2. Cargo build clean, 1417 main tests + 212 nat tests pass, 5x flake clean.
 - **File(s)**: userspace-dp/src/nat/* (created), userspace-dp/src/nat.rs (deleted), userspace-dp/src/nat_tests.rs (moved to nat/tests.rs), docs/pr/1542-nat-runtime-split/{plan,reviewer-ids}.md
-
 ## 2026-05-26 — #1356 bpf_map publish per-AF split (Wave-2)
-
-- **Timestamp**: 2026-05-26
   **Action**: #1356 triple-review drive — split publish_bpf_conntrack_entry per-AF; PR #1572 opened; 4-of-4 attestation (Codex MERGE-NEEDS-MINOR addressed, AGY MERGE-READY, Copilot inline addressed, Claude SMR clean); AWAITING-BATCH-MERGE marker posted.
   **File(s)**: userspace-dp/src/afxdp/bpf_map/mod.rs, userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs, userspace-dp/src/afxdp/mod.rs, userspace-dp/src/afxdp/bpf_map_tests.rs, docs/pr/1356-bpf-map-split/{plan,reviewer-ids}.md
-
-- **Timestamp**: 2026-05-26
   - **Action**: #1440 plan v1 (DRAFT). Drafted consolidation plan
     targeting wg/outer.rs duplicated checksum_be + write_outer_eth,
     gre.rs::encapsulate_native_gre_frame open-coded outer IPv4/IPv6,
@@ -4442,8 +3643,6 @@ top.
     1-8 flagged for adversarial review; perf-irrelevance PLAN-KILL
     explicitly invited.
   - **File(s)**: docs/pr/1440-header-serialization-consolidate/{plan,reviewer-ids}.md
-
-- **Timestamp**: 2026-05-26
   - **Action**: #1440 plan v2 — revised after round-1 4-way review.
     Convergence findings incorporated: (1) DELETE wg/outer.rs
     entirely [Gemini+AGY+Claude SMR], (2) UDP checksum API
@@ -4458,8 +3657,6 @@ top.
     findings. Substantive findings preserved; impl deferred to
     after plan v2 PLAN-READY.
   - **File(s)**: docs/pr/1440-header-serialization-consolidate/plan.md
-
-- **Timestamp**: 2026-05-26
   - **Action**: Plan-review convergence on v2.2 (commit af3bef03):
     Gemini r3 PLAN-READY (independent checksum re-derivation matches
     0x2655; all 5 findings verified). AGY r2 PLAN-NEEDS-MINOR
@@ -4470,9 +3667,6 @@ top.
     move forward without that reviewer at plan stage; will re-
     attempt Codex at code-review stage on the impl PR. Proceeding
     to implementation per plan v2.2.
-  - **File(s)**: docs/pr/1440-header-serialization-consolidate/plan.md
-
-- **Timestamp**: 2026-05-26
   - **Action**: #1440 implementation per plan v2.2. Created
     frame/headers.rs (consolidated builders for eth/IPv4/IPv6/UDP)
     + frame/headers_tests.rs (20 golden-vector tests). Moved
@@ -4494,8 +3688,6 @@ top.
     userspace-dp/src/afxdp/gre.rs, userspace-dp/src/afxdp/icmp.rs,
     userspace-dp/src/afxdp/wg/{mod,tests}.rs,
     userspace-dp/src/afxdp/wg/outer.rs (DELETED)
-
-- **Timestamp**: 2026-05-26
   - **Action**: #1440 code-review convergence. Gemini r1 code review
     MERGE-READY (independent worktree inspection, 7/7 confirmed
     including §6.1 cs=0x2655 byte-level). AGY r1 code review
@@ -4513,106 +3705,14 @@ top.
     PR #1579 at b60ea4c6.
   - **File(s)**: PR #1579, userspace-dp/src/afxdp/frame/headers.rs,
     docs/pr/1440-header-serialization-consolidate/reviewer-ids.md
-
 ## 2026-05-26 — #1351 umem snapshot+debug_state split
-
-- **Timestamp**: 2026-05-26
-  **Action**: #1356 triple-review drive — split publish_bpf_conntrack_entry per-AF; PR #1572 opened; 4-of-4 attestation (Codex MERGE-NEEDS-MINOR addressed, AGY MERGE-READY, Copilot inline addressed, Claude SMR clean); AWAITING-BATCH-MERGE marker posted.
-  **File(s)**: userspace-dp/src/afxdp/bpf_map/mod.rs, userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs, userspace-dp/src/afxdp/mod.rs, userspace-dp/src/afxdp/bpf_map_tests.rs, docs/pr/1356-bpf-map-split/{plan,reviewer-ids}.md
-
-- **Timestamp**: 2026-05-26
-  - **Action**: #1440 plan v1 (DRAFT). Drafted consolidation plan
-    targeting wg/outer.rs duplicated checksum_be + write_outer_eth,
-    gre.rs::encapsulate_native_gre_frame open-coded outer IPv4/IPv6,
-    and icmp.rs::build_local_time_exceeded_v4/v6 outer headers.
-    Proposed new file: userspace-dp/src/afxdp/frame/headers.rs +
-    headers_tests.rs (flat files, not headers/ subdir per existing
-    frame/byte_writes.rs precedent). Public-to-crate signatures
-    preserved on wg/outer helpers via thin wrappers. Open questions
-    1-8 flagged for adversarial review; perf-irrelevance PLAN-KILL
-    explicitly invited.
-  - **File(s)**: docs/pr/1440-header-serialization-consolidate/{plan,reviewer-ids}.md
-
-- **Timestamp**: 2026-05-26
-  - **Action**: #1440 plan v2 — revised after round-1 4-way review.
-    Convergence findings incorporated: (1) DELETE wg/outer.rs
-    entirely [Gemini+AGY+Claude SMR], (2) UDP checksum API
-    u16 not Option<u16> [Codex+Gemini+Claude SMR], (3) Set IPv4
-    DF=1 to fix RFC 791/6864 compliance [Gemini+AGY], (4) Add
-    AVX2 length short-circuit in frame::checksum [Codex+Gemini+
-    AGY], (5) Remove §5.2 differential test in favor of permanent
-    golden vectors only [Codex+Gemini+AGY]. Reverted Gemini's
-    unauthorized worktree writes (headers.rs, headers_tests.rs,
-    checksum.rs short-circuit, eth/IP/icmp/wg edits) — Gemini went
-    rogue and wrote candidate impl, then cited its own writes in
-    findings. Substantive findings preserved; impl deferred to
-    after plan v2 PLAN-READY.
-  - **File(s)**: docs/pr/1440-header-serialization-consolidate/plan.md
-
-- **Timestamp**: 2026-05-26
-  - **Action**: Plan-review convergence on v2.2 (commit af3bef03):
-    Gemini r3 PLAN-READY (independent checksum re-derivation matches
-    0x2655; all 5 findings verified). AGY r2 PLAN-NEEDS-MINOR
-    (3 stale Option<u16> refs) — resolved in v2.1. Codex r3
-    PLAN-NEEDS-MAJOR (3 stale v1-design refs) — resolved in v2.2.
-    Codex r4/r5/r6 infra-blocked (sandbox-binary missing 4×). Per
-    feedback_gemini_infra_outage_merge_policy: 3× infra fails ⇒
-    move forward without that reviewer at plan stage; will re-
-    attempt Codex at code-review stage on the impl PR. Proceeding
-    to implementation per plan v2.2.
-  - **File(s)**: docs/pr/1440-header-serialization-consolidate/plan.md
-
-- **Timestamp**: 2026-05-26
-  - **Action**: #1440 implementation per plan v2.2. Created
-    frame/headers.rs (consolidated builders for eth/IPv4/IPv6/UDP)
-    + frame/headers_tests.rs (20 golden-vector tests). Moved
-    write_eth_header + write_eth_header_slice from frame/mod.rs to
-    headers.rs with re-export at old paths. Added < 32 byte
-    short-circuit in checksum16_add_bytes. Refactored gre.rs v4/v6
-    arms + icmp.rs build_local_time_exceeded_v4/v6 to use
-    write_ipv4_header / write_ipv6_header builders. DELETED
-    wg/outer.rs entirely (was scaffold-only); two surviving smoke
-    tests in wg/tests.rs rewired to call frame::headers builders
-    directly via the frame:: re-export. Wire-byte change: GRE outer
-    IPv4 now sets DF=1 (0x4000) per RFC 791/6864; ICMP TE v4 same.
-    Build clean. Cargo tests: 1431 main + 46 lib + 8 + 16 + 20 new
-    headers_tests all pass. ICMP TE tests 5/5 pass.
-    snat_contract_doc_guard failure is pre-existing master flake
-    (references different worktree path). Go suite 30/30 pass.
-    headers tests 5/5 flake-free.
-  - **File(s)**: userspace-dp/src/afxdp/frame/{headers,headers_tests,checksum,mod}.rs,
-    userspace-dp/src/afxdp/gre.rs, userspace-dp/src/afxdp/icmp.rs,
-    userspace-dp/src/afxdp/wg/{mod,tests}.rs,
-    userspace-dp/src/afxdp/wg/outer.rs (DELETED)
-
-- **Timestamp**: 2026-05-26
-  - **Action**: #1440 code-review convergence. Gemini r1 code review
-    MERGE-READY (independent worktree inspection, 7/7 confirmed
-    including §6.1 cs=0x2655 byte-level). AGY r1 code review
-    MERGE-READY (independent checksum re-derivation; cargo check +
-    cargo test frame/wg all pass; 8/8 verification points). Copilot
-    PRR_kwDORLJrbM8AAAABBEn3WQ COMMENTED with no findings ("Copilot
-    reviewed 12 out of 12 changed files in this pull request and
-    generated no comments"). Codex r1 MERGE-NEEDS-MAJOR with one
-    substantive doc-wording finding (RFC 6864 "requires" overstated
-    — should be atomic-datagram "permits") + infra block; addressed
-    in b60ea4c6. Codex r2 on b60ea4c6 explicitly declined to
-    fabricate verdict — 6th consecutive Codex infra block. Per
-    Wave-2 Bucket C "3-of-4 Codex-stuck precedent": 3 of 4 reviewers
-    MERGE-READY/no-findings, posted AWAITING-BATCH-MERGE marker on
-    PR #1579 at b60ea4c6.
-  - **File(s)**: PR #1579, userspace-dp/src/afxdp/frame/headers.rs,
-    docs/pr/1440-header-serialization-consolidate/reviewer-ids.md
 ## 2026-05-26 #1352 frame/{build,rewrite}/ split
 ## 2026-05-26 13:05 UTC #1352 frame/{build,rewrite}/ split
-
 - **Timestamp**: 2026-05-26 13:05 UTC
 - **Action**: Implemented frame/build/{mod.rs,ipv4.rs,ipv6.rs} + frame/rewrite/{mod.rs,ipv4.rs,ipv6.rs} per #1352 plan v5. Extracted 236-LOC build_forwarded_frame_into_from_frame and 223-LOC apply_rewrite_descriptor into per-family files. Codegen contract: #[inline(always)] on per-family helpers; #[inline(never)] + concrete `meta: ForwardPacketMeta` on build orchestrator; standard #[inline] on rewrite orchestrator.
 - **File(s)**: userspace-dp/src/afxdp/frame/build/{mod.rs,ipv4.rs,ipv6.rs} (created); userspace-dp/src/afxdp/frame/rewrite/{mod.rs,ipv4.rs,ipv6.rs} (created); userspace-dp/src/afxdp/frame/mod.rs (orchestrator bodies removed, mod decls added; build_forwarded_frame_into wrapper now calls .into() before forwarding to concrete-typed orchestrator).
 - **Validation**: cargo build --release clean. 1487 cargo tests pass (113 frame-specific tests all pass). Codegen gate: nm -C shows ZERO per-family helper definitions (#[inline(always)] folded into orchestrator), exactly ONE build_forwarded_frame_into_from_frame definition, ZERO apply_rewrite_descriptor definitions (LLVM inlined fully into single caller poll_descriptor.rs:746). One pre-existing cross-worktree doc-guard test failure unrelated to this refactor.
-
 ## 2026-05-26 — #1342 split forwarding_build.rs (plan v1)
-
 - **Timestamp**: 2026-05-26T (plan drafted)
   - **Action**: Created worktree
     `refactor/1342-forwarding-build-split` off `origin/master` and
@@ -4622,9 +3722,7 @@ top.
     preservation, risk table, and 7 open questions.
   - **File(s)**: `docs/pr/1342-forwarding-build-split/plan.md`,
     `docs/pr/1342-forwarding-build-split/reviewer-ids.md`.
-
 ## 2026-05-26 — #1342 plan v2 (addressing r1 findings)
-
 - **Timestamp**: 2026-05-26T (plan v2)
   - **Action**: Codex r1 returned PLAN-NEEDS-MAJOR (3 majors + 2
     minors); AGY r1 returned PLAN-NEEDS-MINOR (5 action items).
@@ -4643,11 +3741,8 @@ top.
       constraint explicitly.
     - Document `useful_cos_state` gate's queue-resolution
       ordering invariant.
-  - **File(s)**:
     `docs/pr/1342-forwarding-build-split/plan.md` v2.
-
 ## 2026-05-26 — #1342 implementation complete
-
 - **Timestamp**: 2026-05-26T (implementation done, tests pass)
   - **Action**: Implemented plan v2 layout. Created
     forwarding_build/{mod.rs (345L), zones.rs (46L),
@@ -4660,9 +3755,7 @@ top.
     — verified 5x clean on retry, unrelated subsystem). Go
     tests: clean.
   - **File(s)**: see above.
-
 ## 2026-05-26 — #1342 4-of-4 attestation complete
-
 - **Timestamp**: 2026-05-26T (AWAITING-BATCH-MERGE posted)
   - **Action**: Posted AWAITING-BATCH-MERGE marker on PR #1577
     at SHA caf46afcdc88. 4-of-4 reviewer attestation: Codex r2
@@ -4672,7 +3765,6 @@ top.
     format documented as preserving file convention); Claude
     SMR MERGE-READY.
   - **File(s)**: PR comment.
-
 - **Timestamp**: 2026-05-26 21:15 UTC
   - **Action**: #1547 plan + implementation. Three plan-review rounds.
     Round 1 (v1 f9713e65): Codex PLAN-NEEDS-MAJOR (vtyshExecutor
@@ -4698,7 +3790,6 @@ top.
     status_parse,executor_test}.go (NEW); pkg/frr/frr.go (DELETED);
     pkg/frr/README.md (UPDATED); docs/pr/1547-frr-split/plan.md (v1→v3);
     docs/pr/1547-frr-split/reviewer-ids.md
-
 - **Timestamp**: 2026-05-26 21:30 UTC
   - **Action**: #1547 PR #1587 code-review convergence. Codex
     MERGE-READY task-mpn50enm-s4lwd2 (no findings; sandbox could
@@ -4709,7 +3800,6 @@ top.
     achieved on first code-review round. AWAITING-BATCH-MERGE
     marker is in the PR body for the refactor-chain batch.
   - **File(s)**: PR #1587 at 4ff0b6c1,
-    docs/pr/1547-frr-split/reviewer-ids.md
 - **Timestamp**: 2026-05-26 21:28 UTC
   - **Action**: #1349 split worker/cos/build_worker_cos_statuses_from_maps
     (268 LOC) into interface_row/queue_row/status helpers under
@@ -4728,11 +3818,8 @@ top.
   - **File(s)**: userspace-dp/src/afxdp/worker/cos/{mod,interface_row,
     queue_row,status,tests}.rs; docs/pr/1349-worker-cos-status-split/
     {plan.md,reviewer-ids.md}
-
 ## 2026-05-26 — 23:44 UTC — #1346 session_glue split: AWAITING-SMOKE+test-failover
-
 - **Action**: Drove #1346 (`userspace-dp/src/afxdp/session_glue/mod.rs` split + 16/10-param helper collapse) through triple+quad review and opened PR #1595.
-- **File(s)**:
   - `userspace-dp/src/afxdp/session_glue/mod.rs` (1406 → 1103 LOC)
   - `userspace-dp/src/afxdp/session_glue/promote.rs` (new)
   - `userspace-dp/src/afxdp/session_glue/commands/{delete_synced,demote_owner_rgs,export_owner_rg_sessions,refresh_owner_rgs,upsert_synced,mod}.rs` (new)
@@ -4744,9 +3831,57 @@ top.
   - AGY r2: MERGE-READY
   - Copilot r1: COMMENTED w/ 3 inline findings, all addressed in d013302748 + 0e2a88c8b
   - Codex: 3 consecutive sandbox failures (`unified-exec` blocked)
-
+## 2026-05-26 — #1598 secondary fix (TX-dispatch funnel)
+- **Action**: Post-merge smoke on PR #1600 caught a SECONDARY funnel:
+  primary fix at `worker/cos/mod.rs:126-131` correctly set
+  `WorkerCoSQueueFastPath.shared_exact = true` for the non-exact
+  uncapped queue, but the TX dispatch path at
+  `userspace-dp/src/afxdp/tx/dispatch/cos.rs:54` was gating "keep
+  local vs route to owner" on `shared_queue_lease.is_some()`, an
+  exact-only marker. For the iperf-uncapped class the lease is None
+  (filtered out at `coordinator/mod.rs:1058`), so the dispatch still
+  funneled the request to a single `owner_worker_id`. Smoke showed
+  port 5211 push P=12 stable at 9.08 Gbps with 2k-3.6k retr.
+  Added `request_runs_under_shared_exact_policy` helper that gates
+  on `queue_fast.shared_exact` directly (the routing-level shared
+  flag). Switched both call sites: `enqueue_local_request_to_target_or_owner`
+  (cos.rs:54) and the in-place-rewrite gate `owner_matches_target`
+  in `dispatch/mod.rs:426`. Retained the legacy
+  `request_uses_shared_exact_queue_lease` helper — it still correctly
+  identifies queues with a per-queue rate lease, which is a
+  different question. Added test fixture
+  `test_cos_fast_interfaces_decoupled` that decouples
+  `(shared_exact, has_lease)` so all four combinations can be tested.
+  Added 3 regression tests covering (shared_exact=true, lease=None)
+  + (shared_exact=false, lease=Some) + unknown-queue safety.
+- **Tests**: 1441 cargo tests pass (+3 new); Go suite clean across
+  all packages; pre-existing `snat_contract_doc_guard` failure
+  unchanged on master.
+- **File(s)**: `userspace-dp/src/afxdp/tx/dispatch/cos.rs`,
+  `userspace-dp/src/afxdp/tx/dispatch/mod.rs`,
+  `userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs`,
+  `docs/pr/1598-cos-uncapped-fix/plan.md`, `_Log.md`.
+Entries land at the top when added. Within a topic batch (same
+issue / PR), entries run reverse-chronological (newest first).
+Across topic batches the ordering is by add-time, not strict wall
+clock, so older topic batches push down when newer work lands on
+top.
+## 2026-05-27 01:30 UTC — #1598 Copilot review addressed
+- **Timestamp**: 2026-05-27 01:30 UTC
+- **Action**: For #1598, addressed four Copilot inline comments. (1) Rewrote the function-level doc above `queue_uses_shared_exact_service` so it no longer claims non-exact queues are never shared; new doc explains that the gate is now threshold-only, and that the exact/non-exact distinction lives at the lease + V_min allocation gates (coordinator/mod.rs:1058 and :1145). (2) Replaced `feedback_cross_binding_impossible in memory` reference in the inline comment with a stable in-repo reference (PR #680/#690 + the plan doc). (3) Updated both new test fixtures to set `guarantee_enabled=false` AND `exact=false`, so the fixtures actually mirror the production uncapped-class shape (no transmit-rate at all, not just non-exact-with-rate). (4) Restored reverse-chronological log ordering and added a header note explaining the convention.
+- **File(s)**: `userspace-dp/src/afxdp/worker/cos/mod.rs`, `userspace-dp/src/afxdp/worker/cos/tests.rs`, `_Log.md`
+## 2026-05-26 13:25 UTC — #1598 implementation + tests pass
+- **Timestamp**: 2026-05-26 13:25 UTC
+- **Action**: Implemented plan v2. Removed the `if !queue.exact { return false; }` early return in `queue_uses_shared_exact_service` at `userspace-dp/src/afxdp/worker/cos/mod.rs:126-131` so the rate-threshold check `transmit_rate_bytes >= COS_SHARED_EXACT_MIN_RATE_BYTES` admits non-exact queues that hit the threshold. Updated the test that previously pinned the rejection: renamed `queue_uses_shared_exact_service_rejects_non_exact_queue` → `queue_uses_shared_exact_service_admits_high_rate_non_exact_queue` + added a complementary regression test `queue_uses_shared_exact_service_keeps_low_rate_non_exact_single_owner` to lock the threshold-gated behavior. Updated doc comment at `coordinator/mod.rs:1145` to note the V_min floor filter is intentionally stricter than the routing gate. Build clean, 1438+10 cargo tests pass, Go suite clean, 5x flake check pass on `queue_uses_shared_exact_service` tests.
+- **File(s)**: `userspace-dp/src/afxdp/worker/cos/mod.rs`, `userspace-dp/src/afxdp/worker/cos/tests.rs`, `userspace-dp/src/afxdp/coordinator/mod.rs`
+## 2026-05-26 12:50 UTC — #1598 plan v2 (after round-1 reviewer split)
+- **Timestamp**: 2026-05-26 12:50 UTC
+- **Action**: Updated plan to v2 incorporating round-1 reviewer outcomes. Codex PLAN-KILL was infra-blocked (sandbox runner missing); AGY round-1 verdict PLAN-READY after walking the actual files. Added explicit trace of `build_worker_cos_owner_live_by_tx_ifindex` showing `tx_owner_live` is per-worker local (loop_body/mod.rs:91-95), so Step2 never funnels foreign-worker. Documented residual concern about non-binding workers (not applicable to the loss userspace cluster which has every worker bound to reth0.80 mlx5 VF). Re-dispatching Codex.
+- **File(s)**: `docs/pr/1598-cos-uncapped-fix/plan.md`
+## 2026-05-26 12:30 UTC — #1598 plan v1 (CoS iperf-uncapped caps at ~10 Gbps)
+- **Timestamp**: 2026-05-26 12:30 UTC
+- **Action**: Drafted plan v1 for #1598. Root-cause identified at `userspace-dp/src/afxdp/worker/cos/mod.rs:126-131` — `queue_uses_shared_exact_service` early-returns false on `!queue.exact`, excluding the uncapped non-exact queue from sharded multi-worker drain. This forces 100% of class-11 traffic through a single `owner_worker_id` (built at `coordinator/mod.rs:900-904`), hitting the per-worker AF_XDP UMEM ceiling. The 24g/exact queue escapes this because it trips the same gate with `exact=true && rate >= 312 MB/s`.
 ## 2026-05-27
-
 - **Timestamp**: 03:34 UTC
 - **Action**: #1563 fix — `cli -c` non-TTY segfault. Plan v1→v3
   through Codex + AGY adversarial review (3 rounds). v1
@@ -4765,16 +3900,13 @@ top.
   `cmd/cli/nontty_test.go` using interface-embedding fake gRPC
   client; full cmd/cli suite green (5/5 flake); full Go suite
   green.
-- **File(s)**:
   - `cmd/cli/shared.go` (configure hard-error + dispatchConfig defensive guards)
   - `cmd/cli/request.go` (confirmYes helper + 3 site refactors)
   - `cmd/cli/nontty_test.go` (new)
   - `docs/pr/1563-cli-c-nontty-fix/plan.md` (new)
 - **Status**: PR opened — AWAITING-BATCH-MERGE; smoke-runner
   picks up via `<!-- AWAITING-SMOKE -->` marker.
-
 ## 2026-05-26 — #1431 plan v1 draft
-
 - **Timestamp**: 03:22 UTC
 - **Action**: drafted #1431 cache-invariant contract + harness plan v1
 - **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md` (new)
@@ -4785,9 +3917,7 @@ top.
   runtime change planned; PLAN-KILL acceptable if reviewers conclude
   the harness is overkill versus disciplined PR review on the next
   per-packet field addition.
-
 ## 2026-05-26 — #1431 plan v2 (post-r1 reviews)
-
 - **Timestamp**: 03:35 UTC
 - **Action**: rewrote plan after Codex PLAN-KILL + AGY PLAN-NEEDS-MAJOR on v1
 - **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md` (v2)
@@ -4805,9 +3935,7 @@ top.
     (AGY's recommendation).
   - SHRANK harness to 3 positive-case DSCP tests:
     input/output gate + positional-ID-change-doesn't-fire.
-
 ## 2026-05-26 — #1431 plan v3 (post-r2 reviews)
-
 - **Timestamp**: 03:42 UTC
 - **Action**: applied Codex r2 + AGY r2 PLAN-READY/MINOR feedback
 - **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md` (v3)
@@ -4825,9 +3953,7 @@ top.
   - lo0 README note now one paragraph with `is_cacheable` +
     `poll_descriptor` line refs.
   - Scope shrunk to 2 new tests + 4 cited existing tests.
-
 ## 2026-05-26 — #1431 plan v4 (fix stale v3 leftovers)
-
 - **Timestamp**: 03:50 UTC
 - **Action**: AGY r3 flagged 3 stale v2 leftovers in v3; applied fixes
 - **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md`
@@ -4838,20 +3964,14 @@ top.
     `afxdp/flow_cache_tests.rs`; explicit "dropped from v2" /
     "cited from existing" subsections.
   - Test names aligned with §8 (`_via_runbook_pattern` suffix).
-
 ## 2026-05-26 — #1431 plan v5 (post-Codex r3)
-
 - **Timestamp**: 03:52 UTC
 - **Action**: Codex r3 PLAN-NEEDS-MINOR caught remaining §6 claim
-- **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md`
 - **Fix**: §6 invariant #4 "new positional-ID-change test" →
   cite existing filter/tests.rs:1806.
-
 ## 2026-05-26 — #1431 implementation commit
-
 - **Timestamp**: 04:08 UTC
 - **Action**: implemented per plan v5; both reviewers PLAN-READY
-- **File(s)**:
   - `userspace-dp/src/filter/README.md` (+~120 lines:
     Cache-key invariants section, classification table,
     path (b) runbook, path (a) pointer, lo0 note)
@@ -4867,13 +3987,10 @@ top.
   cargo --release passes except a pre-existing snat doc-guard
   flake (master also fails this — unrelated to #1431).
   Go suite clean.
-
 ## 2026-05-26 — #1431 code-review r1 fixes + Claude SMR doc
-
 - **Timestamp**: 22:15 UTC
 - **Action**: addressed Codex r1 + Copilot r1 inline findings; wrote
   Claude SMR code-review doc per skill Step 8.5
-- **File(s)**:
   - `userspace-dp/src/protocol/security.rs` — harmonized
     CACHE-KEY INVARIANT block with FilterTerm's block per Codex r1 #1
   - `userspace-dp/src/afxdp/flow_cache_tests.rs` — fixed "per-interface
@@ -4890,20 +4007,14 @@ top.
   - AGY r1: MERGE-READY
   - Copilot r1: COMMENTED with 2 inline findings → fixes applied
   - Claude SMR: MERGE-READY (doc on branch)
-
 ## 2026-05-27 — #1431 copilot re-review wording follow-up
-
 - **Timestamp**: 05:10 UTC
 - **Action**: corrected README wording from "bytes 4-6" to "bytes 4-5" for ICMP identifier extraction so docs match `parse_flow_ports` range `l4 + 4..l4 + 6` (two bytes).
-- **File(s)**:
   - `userspace-dp/src/filter/README.md`
   - `_Log.md` (this entry)
-
 ## 2026-05-26 — #1431 Copilot r2 + Codex r2 cleanup
-
 - **Timestamp**: 22:35 UTC
 - **Action**: addressed Copilot r2 inline findings; Codex r2 MERGE-READY
-- **File(s)**:
   - `userspace-dp/src/filter/README.md` — 5-tuple framing
     (Copilot r2 inline #1)
   - `docs/pr/1431-filter-cache-invariants/plan.md` — same
@@ -4919,14 +4030,11 @@ top.
     since
   - Copilot r2: COMMENTED with 2 inline findings → fixes applied
   - Claude SMR: MERGE-READY with addendum
-
 ## 2026-05-26 — #1431 final 4-of-4 attestation at post-rebase HEAD
-
 - **Timestamp**: 22:55 UTC
 - **Action**: rebased onto current origin/master (ab812c6cf);
   re-dispatched Codex + AGY + Copilot at rebased HEAD a5d06c424;
   all four reviewer seats clean
-- **File(s)**:
   - rebase: chronological _Log.md merge (both #1563 + #1431 entries preserved)
   - docs/pr/1431-filter-cache-invariants/reviewer-ids.md (r3 task ids)
 - **Reviewer verdicts at HEAD a5d06c424c1eba3619b41b7560e7c4eee79ceb8c**:
@@ -4945,3 +4053,6 @@ top.
   cfg(test) tests, and doc files.
 - **Stale marker** at comment 4551276859 (posted on 705d62f67)
   DELETED via gh api -X DELETE.
+## 03:17 UTC — #1565 plan v1 drafted
+- **Action**: Draft plan for pkg/api Junos→Linux ifname translation fix
+- **File(s)**: docs/pr/1565-iface-name-translate/plan.md

--- a/_Log.md
+++ b/_Log.md
@@ -4068,3 +4068,7 @@ top.
 ## 03:46 UTC — #1565 plan v4 after round-3 Codex NEEDS-MAJOR
 - **Action**: Drop ResolveFab from helper (fab0 is kernel device), add st* short-circuit, fix smoke gates to actual cfg, AGY minors (fmt import, test_seams.go, drift NOTE comments)
 - **File(s)**: docs/pr/1565-iface-name-translate/plan.md
+
+## 03:53 UTC — #1565 plan v5 after round-4 (Codex MAJOR, AGY MINOR)
+- **Action**: Fix fab0.0 collapse expectation, drop ge-0/0/0 from gates (not in allInterfaceNames), redesign lo test as reth0->lo synthetic, add drift-guard test, nil-guard Interfaces.Interfaces
+- **File(s)**: docs/pr/1565-iface-name-translate/plan.md

--- a/docs/pr/1565-iface-name-translate/plan.md
+++ b/docs/pr/1565-iface-name-translate/plan.md
@@ -1,147 +1,237 @@
 # #1565 — pkg/api: translate Junos config names to Linux ifnames before net.InterfaceByName
 
-**Status:** DRAFT v2 — addressing Codex + AGY round-1 PLAN-NEEDS-MAJOR
+**Status:** DRAFT v3 — addressing Codex round-2 PLAN-NEEDS-MAJOR (AGY round-2 returned PLAN-READY but accepted an incorrect v2 design that Codex caught)
 
-## Round-1 verdicts (round-1 archived)
+## Round-2 verdicts
 
-- **Codex** task-mpnhxusx-4yz6hb: PLAN-NEEDS-MAJOR. Findings:
-  - Tunnel refs (`gr-0/0/0.0`, `gr-0/0/0.1`) are handled by
-    `(*Config).TunnelNameMap()` and do NOT round-trip through a naive
-    `LinuxIfName(ResolveReth(name))` composition. Unit 0 → base name,
-    unit N>0 → `<base>uN`.
-  - DHCP key claim was overbroad: keys are
-    `LinuxIfName(physName) + "." + strconv(unit.VlanID)` only when
-    `VlanID>0`, otherwise just `LinuxIfName(physName)`. The suffix in
-    the zone ref (`.80`, `.0`) does **not** necessarily equal the
-    VLAN tag. So `LeaseFor(kernelIfName(ifName))` only works when the
-    config name happens to end in the VLAN tag; for `ge-0/0/0.0` with
-    `vlan-id 80`, the lookup misses.
-  - grpcapi out-of-scope is defensible **only if** the plan stops
-    claiming any CLI smoke fix; CLI `show interfaces` routes through
-    grpcapi `ShowInterfaces`/`ShowInterfacesDetail`/`ShowText`.
-  - Tests are too thin for tunnel + VLAN-vs-unit-suffix cases.
-- **AGY** review-mpnhya9y-6rigyy: PLAN-NEEDS-MAJOR. Findings:
-  - Fold grpcapi sites in OR drop CLI smoke (same point as Codex).
-  - Centralize helper as `(*Config).ResolveJunosIfName(name)` in
-    `pkg/config/types.go` so `pkg/api` and `pkg/grpcapi` share it.
-  - Chain `ResolveFab` to cover `fab0[.unit]`.
-  - Add a `writeInterfacesDetail` integration test that mocks DHCP
-    manager + asserts the lease line is printed.
+- **Codex** task-mpni7vi4-2oacjs: PLAN-NEEDS-MAJOR.
+  - Critical: v2 helper preserved the `.unit` suffix unchanged after
+    `ResolveReth`/`ResolveFab`. But the **kernel link name uses the
+    VLAN tag (`unit.VlanID`)** when set, not the unit number. For
+    `reth0.80` with `units { 80 { vlan-id 180 } }`, the kernel link
+    is `ge-0-0-0.180`, not `ge-0-0-0.80`. v2 plan would silently
+    miss every VLAN-where-vlan-id≠unit case. Cited
+    `pkg/daemon/resolve_neighbor_test.go:64`,
+    `pkg/dataplane/userspace/manager_test.go:3267-3275`.
+  - IRB refs (`irb.0`) resolve via `config.IRBToBridge` to a bridge
+    device name, not via ResolveReth/ResolveFab.
+  - TunnelNameMap collision is schema-possible: the compiler parses
+    `tunnel {}` under any interface (not only `gr-*`/`ip-*`), so
+    `reth0.50` can legitimately be a TunnelNameMap key. v2 plan's
+    "no collision" claim was unsafe.
+  - v2's DHCP integration test wasn't actually designed —
+    `dhcp.Manager` fields are unexported and there's no
+    `NewForTesting`. Need an explicit mechanism choice.
+  - REST smoke `length >= 3` is too weak — `fxp0`, `em0`, `fab0`
+    are already non-slash and resolvable pre-fix. Need named-row
+    `ifindex > 0` assertions for the slash-containing refs and
+    reth aliases specifically.
+- **AGY** review-mpni8bxc-masfic: PLAN-READY. (But signed off on
+  an incorrect v2 design that fed back `reth0.50` → `ge-0-0-2.50`
+  as "correct" — coincidentally right when vlan-id == unit, but
+  Codex's broader scan caught the cases where they diverge. v3
+  fixes the underlying issue; expecting AGY to ratify v3.)
 
-Round-1 verdicts and reviewer prompts are pinned at commit
-`e91b9650` (plan v1).
+Round-1 verdicts pinned at commit `e91b9650` (plan v1).
+Round-2 plan pinned at commit `3a57fbde` (plan v2).
 
-## Issue framing (unchanged from v1)
+## Issue framing (unchanged)
 
-Pre-existing bug surfaced by Copilot inline review on PR #1564.
-Four call sites in `pkg/api/` call `net.InterfaceByName(ifName)`
-directly with config-level Junos interface names (`ge-0/0/0`,
-`reth0.50`, `fab0`, `gr-0/0/0.0`). These names violate Linux
-IFNAMSIZ (`/` is forbidden) or have no kernel ifindex
-(`reth`/`fab` are virtual config-only names). The lookups fail
-silently and break:
-
-1. Per-interface counters and `Ifindex` in the REST `interfaces`
-   view.
-2. `show interfaces` detail output (prints "Not present").
-3. `/iface-stats` typed JSON (rows silently dropped).
-4. Per-interface Prometheus metrics
-   (`xpf_iface_packets_total{interface="..."}` missing).
-
-Four sites verbatim from the issue body:
+Four pkg/api sites pass config-level Junos interface names to
+`net.InterfaceByName`, which fails silently because Linux IFNAMSIZ
+forbids `/` and RETH/Fab/IRB names have no kernel ifindex:
 
 - `pkg/api/interfaces.go:32` — `interfacesHandler`
 - `pkg/api/interfaces.go:210` — `writeInterfacesDetail`
 - `pkg/api/stats.go:64` — `ifaceStatsHandler`
 - `pkg/api/metrics_counters.go:68` — `collectInterfaceCounters`
 
-The three sites at `pkg/api/interfaces.go:107`, `:130`, `:163`
-inside `writeInterfacesTerse` are already correct — they call
-`config.LinuxIfName` on the physical-member name resolved
-through `RethToPhysical()`. Verified by read.
+Symptoms: zero counters, "Not present" detail rows, silently-dropped
+JSON stats rows, missing Prometheus per-interface series.
+
+The terse-mode sites at `:107`, `:130`, `:163` are already correct.
 
 ## Honest scope / value framing
 
-Control-plane observability bug fix. No hot path, no allocator,
-no HA sync, no dataplane correctness. Win is qualitative: REST
-clients and Prometheus scrapers see real counters; JSON
-`ifindex` is populated.
+Control-plane observability bug fix. No hot path, no dataplane
+correctness risk. Win is qualitative: REST + Prometheus see real
+counters; JSON `ifindex` populated. PLAN-KILL is acceptable if
+reviewers conclude the churn isn't justified.
 
-If reviewers conclude the work isn't worth the churn, PLAN-KILL
-is acceptable. (The bug is real and operator-visible; PLAN-KILL
-seems wrong but the explicit hook stays.)
+## What's already shipped (this is the key new section vs v2)
 
-## What's already shipped / partially fixed
-
-- `pkg/api/interfaces.go::writeInterfacesTerse` (lines 100-188):
-  already uses `physToReth`, `rethToPhys`, and `config.LinuxIfName`.
-  Correct.
-- `pkg/grpcapi/server_show_interfaces.go` uses `config.LinuxIfName`
-  in lines 502, 547, 586, 623-632 — but not at the top-level
-  `GetInterfaces` (line 31) and `ShowInterfacesDetail` physical
-  lookup (line 129). Out of scope for this PR per issue body;
-  filing a follow-up issue is required (see Out of scope).
-- `pkg/daemon/daemon_dhcp.go:56-95` builds DHCP keys as
-  `LinuxIfName(physName)` plus `"." + strconv.Itoa(unit.VlanID)`
-  when `unit.VlanID > 0`. **This is the canonical key form.**
-- `(*Config).TunnelNameMap()` at `pkg/config/types.go:1763` maps
-  `gr-0/0/0.0` → `gr-0-0-0` and `gr-0/0/0.1` → `gr-0-0-0u1`.
-- `(*Config).ResolveReth(ref)` + `(*Config).ResolveFab(ref)` at
-  `types.go:80,95` resolve aliases (and preserve `.unit` suffix).
-
-## Concrete design (revised)
-
-### Single new public helper in `pkg/config/types.go`
+**The codebase already has a correct kernel-name helper** —
+`pkg/dataplane/userspace/interfaces.go:303` defines
+`snapshotLinuxName(cfg, ifName, iface, unit)`. It implements the
+full resolution:
 
 ```go
-// ResolveJunosIfName converts a Junos-style config interface reference
-// (e.g. "ge-0/0/0.80", "reth0.50", "fab0.0", "gr-0/0/0.1") to the
-// Linux kernel ifname it should resolve to on the LOCAL node.
+func snapshotLinuxName(cfg *config.Config, ifName string, iface *config.InterfaceConfig, unit *config.InterfaceUnit) string {
+    if iface == nil {
+        return config.LinuxIfName(ifName)
+    }
+    if unit != nil {
+        if tunnelNames := cfg.TunnelNameMap(); len(tunnelNames) > 0 {
+            ref := fmt.Sprintf("%s.%d", ifName, unit.Number)
+            if linuxName, ok := tunnelNames[ref]; ok && linuxName != "" {
+                return linuxName
+            }
+        }
+        if unit.VlanID > 0 {
+            return fmt.Sprintf("%s.%d", config.LinuxIfName(cfg.ResolveReth(ifName)), unit.VlanID)
+        }
+        if strings.HasPrefix(ifName, "reth") {
+            if unit.Number == 0 {
+                return config.LinuxIfName(cfg.ResolveReth(ifName))
+            }
+            return config.LinuxIfName(cfg.ResolveReth(fmt.Sprintf("%s.%d", ifName, unit.Number)))
+        }
+        if unit.Number == 0 {
+            return config.LinuxIfName(ifName)
+        }
+        return config.LinuxIfName(fmt.Sprintf("%s.%d", ifName, unit.Number))
+    }
+    if strings.HasPrefix(ifName, "reth") {
+        return config.LinuxIfName(cfg.ResolveReth(ifName))
+    }
+    return config.LinuxIfName(ifName)
+}
+```
+
+This is the right shape. The v2 plan reinvented (incorrectly) what
+this function already does. **v3 lifts `snapshotLinuxName` from
+`pkg/dataplane/userspace/` to `pkg/config/types.go` as a public
+method, and pkg/api consumes it directly.**
+
+`pkg/daemon/daemon_dhcp.go:138-140` has a separate, simpler private
+helper `resolveJunosIfName(cfg, ifName) = LinuxIfName(ResolveReth(ifName))`
+that the v3 plan deletes once the canonical helper is centralized.
+(Callers in `resolveConfigSubnetLinuxName` already apply the VLAN
+suffix on top of this — that pattern is the right one for callers
+that already know the unit.)
+
+`pkg/dataplane/compiler_iface.go:20` exposes a richer
+`resolveInterfaceRef(ref, cfg) (physName, configName, unitNum, vlanID)`
+that includes IRB and st0 handling. **v3 either adapts this for the
+public helper, or composes IRB resolution explicitly.**
+
+## Concrete design (v3)
+
+### Public helper: `(*Config).ResolveKernelIfName`
+
+Path: `pkg/config/types.go`. Signature:
+
+```go
+// ResolveKernelIfName converts a Junos-style interface reference (as
+// found in zone declarations and the keys of cfg.Interfaces.Interfaces)
+// to the Linux kernel ifname it should resolve to on the LOCAL node.
 //
-// Resolution order:
-//   1. Tunnel refs: if the ref is a key in TunnelNameMap(), return
-//      the tunnel's Linux name verbatim (covers "gr-0/0/0.0" → "gr-0-0-0"
-//      and "gr-0/0/0.1" → "gr-0-0-0u1"). Tunnel naming is per-unit and
-//      does NOT preserve the "." suffix, so this branch must short-circuit
-//      before LinuxIfName.
-//   2. RETH refs: ResolveReth(ref) maps "reth0[.unit]" → physical
-//      member "ge-X/0/Y[.unit]" using local-node scoring.
-//   3. Fabric refs: ResolveFab(ref) maps "fab0[.unit]" → the local
-//      fabric member from cfg.Interfaces.Interfaces[base].LocalFabricMember.
-//   4. LinuxIfName: replace "/" with "-".
+// Resolution semantics, in order:
+//   1. Bare physical/logical refs without a "." suffix (e.g. "em0",
+//      "fxp0", "lo", "ge-0/0/0", "reth0", "fab0", "gr-0/0/0"):
+//        - reth0/fab0 → ResolveReth/ResolveFab to local physical member
+//        - / → -
+//        - bare gr-0/0/0 → gr-0-0-0 (kernel device for the base tunnel)
+//   2. Dotted refs (e.g. "ge-0/0/0.80", "reth0.0", "gr-0/0/0.1",
+//      "irb.0"):
+//        a. IRB: look up via config.IRBToBridge(cfg.BridgeDomains) and
+//           return the bridge device name (no suffix).
+//        b. Tunnel: if TunnelNameMap[ref] is set, return that name
+//           verbatim (covers gr-0/0/0.0 → gr-0-0-0 and gr-0/0/0.1 →
+//           gr-0-0-0u1).
+//        c. Otherwise look up cfg.Interfaces.Interfaces[base].Units[unit]:
+//             - If unit has tunnel.Name set, return that.
+//             - If unit.VlanID > 0, return LinuxIfName(ResolveFab(ResolveReth(base))) + "." + VlanID.
+//             - If unit.Number == 0, return LinuxIfName(ResolveFab(ResolveReth(base))) (collapse unit 0).
+//             - Else return LinuxIfName(ResolveFab(ResolveReth(base))) + "." + unit.Number.
+//        d. If the base + unit lookup misses (e.g. ref names a unit not
+//           in cfg.Interfaces.Interfaces), fall back to
+//           LinuxIfName(ResolveFab(ResolveReth(ref))) — preserves the
+//           suffix and trusts the caller.
 //
-// For all other refs (em0, fxp0, ge-0/0/0, ge-0/0/0.80) this reduces
-// to LinuxIfName(ref).
-//
-// Note: this returns the kernel link name. For DHCP lease lookups,
-// callers must instead build LinuxIfName(physName) + "." + VlanID,
-// which is the daemon's DHCP key form; that is NOT the same as the
-// link name. See DHCPLeaseKey below.
-func (c *Config) ResolveJunosIfName(ref string) string {
+// The fallback in (2d) matters because allInterfaceNames includes raw
+// zone refs, and a zone may legitimately list a sub-interface that's
+// not in the interfaces stanza (config error — observable in stats
+// but not crashing the API).
+func (c *Config) ResolveKernelIfName(ref string) string {
+    parts := strings.SplitN(ref, ".", 2)
+    base := parts[0]
+
+    // Bare refs
+    if len(parts) == 1 {
+        resolved := c.ResolveFab(c.ResolveReth(base))
+        return LinuxIfName(resolved)
+    }
+
+    // IRB
+    if base == "irb" {
+        if bridges := IRBToBridge(c.BridgeDomains); bridges != nil {
+            if bridge, ok := bridges[ref]; ok {
+                return bridge
+            }
+        }
+        // Fall through to generic path
+    }
+
+    // Tunnel by ref
     if tunMap := c.TunnelNameMap(); tunMap != nil {
-        if linuxName, ok := tunMap[ref]; ok {
+        if linuxName, ok := tunMap[ref]; ok && linuxName != "" {
             return linuxName
         }
     }
-    resolved := c.ResolveReth(ref)
-    resolved = c.ResolveFab(resolved)
-    return LinuxIfName(resolved)
-}
 
-// DHCPLeaseKey returns the lease-lookup key that the DHCP manager
-// keys leases by for the given config interface name and unit number.
-// Mirrors the construction in pkg/daemon/daemon_dhcp.go: the key is
-// LinuxIfName(physName) plus ".<VlanID>" only when the unit's
-// VlanID > 0. Returns ("", false) when the config ref cannot be
-// resolved to a unit (caller should skip the lease line).
-func (c *Config) DHCPLeaseKey(ifName string, unitNum int) (string, bool) {
-    physRef := strings.SplitN(ifName, ".", 2)[0]
+    // Look up the unit by parsed number
+    unitNum, _ := strconv.Atoi(parts[1])
+    if ifc, ok := c.Interfaces.Interfaces[base]; ok && ifc != nil {
+        if unit, ok := ifc.Units[unitNum]; ok && unit != nil {
+            if unit.Tunnel != nil && unit.Tunnel.Name != "" {
+                return unit.Tunnel.Name
+            }
+            kernelBase := LinuxIfName(c.ResolveFab(c.ResolveReth(base)))
+            if unit.VlanID > 0 {
+                return fmt.Sprintf("%s.%d", kernelBase, unit.VlanID)
+            }
+            if unit.Number == 0 {
+                return kernelBase
+            }
+            return fmt.Sprintf("%s.%d", kernelBase, unit.Number)
+        }
+    }
+
+    // Fallback: best-effort, preserve suffix.
+    return LinuxIfName(c.ResolveFab(c.ResolveReth(ref)))
+}
+```
+
+This is a port of `snapshotLinuxName` with two enhancements:
+- IRB handling (Codex finding #2)
+- explicit unit-tunnel branch matching `resolveInterfaceRef`
+
+### Public helper: `(*Config).DHCPLeaseKey`
+
+Same as v2 — the daemon's DHCP lease key shape is independent of
+the kernel link name (the daemon's `Start(...)` call passes the
+**config-level** RETH name, not the resolved physical member —
+see `daemon_dhcp.go:59` `dhcpIface = LinuxIfName(ifName)` where
+`ifName` is the cfg key, e.g. `reth0`, then `.VlanID` is appended).
+
+```go
+// DHCPLeaseKey returns the lease-lookup key that pkg/dhcp.Manager
+// keys leases by for the given config interface and unit number.
+// Mirrors the construction in pkg/daemon/daemon_dhcp.go:
+//   key = LinuxIfName(physRef) + ("." + strconv(unit.VlanID) when > 0).
+// physRef is the CONFIG-LEVEL name (e.g. "reth0"), not the resolved
+// physical member — daemon's DHCP Start() is called with the
+// config-level name.
+// Returns ("", false) when the unit doesn't exist in cfg.
+func (c *Config) DHCPLeaseKey(physRef string, unitNum int) (string, bool) {
+    physRef = strings.SplitN(physRef, ".", 2)[0]
     ifc, ok := c.Interfaces.Interfaces[physRef]
-    if !ok {
+    if !ok || ifc == nil {
         return "", false
     }
     unit, ok := ifc.Units[unitNum]
-    if !ok {
+    if !ok || unit == nil {
         return "", false
     }
     key := LinuxIfName(physRef)
@@ -152,29 +242,51 @@ func (c *Config) DHCPLeaseKey(ifName string, unitNum int) (string, bool) {
 }
 ```
 
-These two helpers exactly mirror the two distinct semantics that
-`pkg/daemon/daemon_dhcp.go:56-95` exposed:
+Note: this intentionally **does NOT** call ResolveReth, because the
+DHCP manager keys by the config-level RETH name (e.g. `reth0.50`,
+not `ge-0-0-2.50`).
 
-- the **kernel link name** for `net.InterfaceByName` / sysfs;
-- the **DHCP lease key** for `dhcp.Manager.LeaseFor`.
+### Migration of `snapshotLinuxName` and `resolveJunosIfName`
 
-Conflating them was the round-1 plan's mistake.
+After `(*Config).ResolveKernelIfName` exists:
+- `pkg/dataplane/userspace/interfaces.go:303` `snapshotLinuxName`
+  becomes a wrapper that calls `cfg.ResolveKernelIfName(fmt.Sprintf("%s.%d", ifName, unit.Number))`
+  when `unit != nil`, else `cfg.ResolveKernelIfName(ifName)`.
+  Eight existing test cases in that package will exercise the
+  centralized helper — *no semantic change*.
+- `pkg/daemon/daemon_dhcp.go:138` `resolveJunosIfName` is deleted;
+  callers switch to `cfg.ResolveKernelIfName(ifName)` directly (or
+  to the bare-ref shape they were already passing).
+
+This migration is mandatory because otherwise we'd have two
+implementations that drift. But it expands the blast radius — we
+need to verify the userspace and daemon tests still pass.
+
+**Risk classification:** this lifts a private helper to public and
+re-points two callers. If reviewers think the migration's blast
+radius is too wide for a #1565 fix, the alternative is:
+
+- Add the helper as a public method on `*Config` (no behavior
+  change at the call sites that use `snapshotLinuxName` and
+  `resolveJunosIfName`).
+- pkg/api uses the public method.
+- Defer migration of `snapshotLinuxName` and `resolveJunosIfName`
+  to a follow-up.
+
+**Recommendation in v3:** ship the additive public method; do NOT
+migrate `snapshotLinuxName` or `resolveJunosIfName` in this PR.
+That keeps the diff small, contains the blast radius, and leaves
+the legacy private helpers in place for the next refactor.
+Migration becomes a follow-up issue.
 
 ### Call-site rewrites
-
-The four pkg/api sites all need the kernel link name. They use the
-ref iterated from `allInterfaceNames(cfg)` (which contains raw cfg
-keys + raw zone refs).
 
 #### `pkg/api/interfaces.go:32` `interfacesHandler`
 
 ```go
 for ifName := range allInterfaceNames(cfg) {
-    iface, err := net.InterfaceByName(cfg.ResolveJunosIfName(ifName))
-    is := InterfaceStats{
-        Name: ifName,                    // Junos label, unchanged
-        Zone: ifZone[ifName],
-    }
+    iface, err := net.InterfaceByName(cfg.ResolveKernelIfName(ifName))
+    is := InterfaceStats{Name: ifName, Zone: ifZone[ifName]}
     if err == nil {
         is.Ifindex = iface.Index
         if s.dp != nil && s.dp.IsLoaded() {
@@ -190,32 +302,27 @@ for ifName := range allInterfaceNames(cfg) {
 
 #### `pkg/api/interfaces.go:210` `writeInterfacesDetail`
 
-Two distinct translations needed:
-
-- **kernel link name** for `net.InterfaceByName` AND
-  `/sys/class/net/<name>/operstate`.
-- **DHCP lease key** for `s.dhcp.LeaseFor(...)`.
-
-The current code uses `ifName` (the Junos ref) for both. The
-revised code computes:
+Two distinct translations:
+- **kernel link** via `cfg.ResolveKernelIfName(ifName)`
+- **DHCP lease key** via `cfg.DHCPLeaseKey(base, unitNum)`
 
 ```go
 for _, ifName := range ifNames {
-    kernel := cfg.ResolveJunosIfName(ifName)
+    kernel := cfg.ResolveKernelIfName(ifName)
     iface, err := net.InterfaceByName(kernel)
     if err != nil {
         fmt.Fprintf(&b, "Interface: %s, Not present\n\n", ifName)
         continue
     }
-    // ... print MTU/MAC/zone/BPF-counters as before, using `kernel`
-    //     for the /sys/class/net read.
+    // ... existing MTU/MAC/zone/BPF-counters logic, replacing every
+    //     use of ifName as a /sys/class/net/<x>/operstate path with
+    //     `kernel`.
 
-    // DHCP lease annotation — use the daemon's DHCP key shape.
     if s.dhcp != nil {
         base := strings.SplitN(ifName, ".", 2)[0]
         unitNum := 0
         if parts := strings.SplitN(ifName, ".", 2); len(parts) == 2 {
-            fmt.Sscanf(parts[1], "%d", &unitNum)
+            unitNum, _ = strconv.Atoi(parts[1])
         }
         if key, ok := cfg.DHCPLeaseKey(base, unitNum); ok {
             if lease := s.dhcp.LeaseFor(key, dhcp.AFInet); lease != nil {
@@ -230,191 +337,201 @@ for _, ifName := range ifNames {
 }
 ```
 
-This is the only site that needs the DHCP key shape. The other
-three pkg/api sites only need the kernel link name.
-
 #### `pkg/api/stats.go:64` and `pkg/api/metrics_counters.go:68`
 
-Identical 1-line translation: replace `net.InterfaceByName(ifName)`
-with `net.InterfaceByName(cfg.ResolveJunosIfName(ifName))`.
+1-line: `net.InterfaceByName(cfg.ResolveKernelIfName(ifName))`.
 
-### Resolution-order rationale
+### DHCP integration test design (Codex finding #4)
 
-Tunnel-first matters because `gr-0/0/0.1` is a key in TunnelNameMap
-but `.1` is the unit number (not a VLAN tag), and the Linux ifname
-is `gr-0-0-0u1` — neither LinuxIfName nor ResolveReth/ResolveFab
-would produce that. Putting tunnel resolution after the others
-would yield `gr-0-0-0.1`, which doesn't exist on the kernel.
+`dhcp.Manager.leases` is unexported. Three options ranked:
 
-RETH-then-Fab order matters because:
-- ResolveReth on a non-reth ref is identity.
-- ResolveFab on the (post-reth) ref is identity for non-fab refs.
+1. **Best (lowest blast radius):** add a small exported test seam in
+   `pkg/dhcp/dhcp.go`:
+   ```go
+   // SeedLeaseForTesting installs a lease record for tests. Not for
+   // production use.
+   func (m *Manager) SeedLeaseForTesting(ifaceName string, af AddressFamily, lease *Lease) {
+       m.mu.Lock()
+       defer m.mu.Unlock()
+       if m.leases == nil {
+           m.leases = make(map[clientKey]*Lease)
+       }
+       m.leases[clientKey{iface: ifaceName, family: af}] = lease
+   }
+   ```
+   pkg/api test calls this directly on a `dhcp.New(...)`-built manager.
+2. Add a `dhcpLeaseProvider` interface inside pkg/api and inject a
+   stub. Requires a Server field change.
+3. Skip the integration test, rely on unit tests + smoke.
 
-LinuxIfName at the end is the catch-all `/` → `-` replacement.
+**Recommendation in v3:** option 1. Test seam is explicit, named
+clearly, and lives next to the manager. Smaller blast than
+introducing an interface in pkg/api.
 
-### Error-handling semantics (unchanged)
+### Resolution-order checks (Codex finding #3 — tunnel collisions)
 
-- listing-style handlers (`interfacesHandler`, `writeInterfacesDetail`):
-  include the row with ifindex=0 / "Not present", same as today.
-- stats/metrics handlers (`ifaceStatsHandler`, `collectInterfaceCounters`):
-  silently skip on lookup failure, same as today.
-- No 500s. Admin-down or peer-only refs are normal.
+Codex correctly noted that `compiler_interfaces.go:123,202` parses
+`tunnel {}` under any interface, so `reth0.50` could theoretically be
+a TunnelNameMap key. v3's `ResolveKernelIfName` consults TunnelNameMap
+**after** the IRB branch but **before** the unit/VLAN logic, so a
+tunnel-mapped ref bypasses the VLAN-tag composition. This is the
+right precedence — if a user explicitly configured a tunnel under
+`reth0.50`, the tunnel kernel name overrides VLAN composition.
+Document this in the helper godoc; add a test:
+`TestResolveKernelIfName_TunnelOverridesVlan`.
 
-### Tests (revised — 6 unit tests + 1 integration)
+### Smoke verification (revised — Codex finding #5)
 
-`pkg/config/types_test.go` (helper unit tests):
+Pre-fix baseline: `fxp0`, `em0`, `fab0`, `lo` are already non-slash
+and resolvable, so any `length >= K` gate where `K` ≤ pre-fix
+resolvable count is trivially passed.
 
-1. **`TestResolveJunosIfName_Plain`** — `em0`→`em0`, `fxp0`→`fxp0`,
-   `ge-0/0/0`→`ge-0-0-0`, `ge-0/0/0.80`→`ge-0-0-0.80`.
-2. **`TestResolveJunosIfName_Reth`** — given a cfg with
-   `reth0` and physical member `ge-0/0/2` on node 0,
-   `reth0`→`ge-0-0-2`, `reth0.50`→`ge-0-0-2.50`. Repeat for node 1
-   with `ge-7/0/2`.
-3. **`TestResolveJunosIfName_Fab`** — given a cfg with `fab0` whose
-   `LocalFabricMember="ge-0/0/0"`, `fab0`→`ge-0-0-0`,
-   `fab0.0`→`ge-0-0-0.0`.
-4. **`TestResolveJunosIfName_Tunnel`** — given a cfg with
-   interface-level tunnel on `gr-0/0/0` and units 0+1,
-   `gr-0/0/0.0`→`gr-0-0-0`, `gr-0/0/0.1`→`gr-0-0-0u1` (per-unit
-   tunnel with `unit.Tunnel.Name` set yields that name).
-5. **`TestDHCPLeaseKey_Mappings`** — cfg with `ge-0/0/0` unit 0
-   `vlan-id 0`, unit 1 `vlan-id 80`: `DHCPLeaseKey("ge-0/0/0", 0)` →
-   `("ge-0-0-0", true)`. `DHCPLeaseKey("ge-0/0/0", 1)` →
-   `("ge-0-0-0.80", true)`. `DHCPLeaseKey("ge-0/0/0", 99)` →
-   `("", false)`. Also exercises `reth0` cfg.
-
-`pkg/api/interfaces_test.go` (handler integration):
-
-6. **`TestInterfacesHandler_PopulatesIfindexForLoopback`** —
-   stand up a Server with cfg name `lo`; assert Ifindex > 0.
-7. **`TestWriteInterfacesDetail_DHCPLeasePath`** — stand up a
-   Server with a `dhcp.Manager` pre-populated with a lease
-   keyed `ge-0-0-0` (no VLAN); call `writeInterfacesDetail` for
-   cfg containing `ge-0/0/0`; assert output contains
-   `DHCPv4: <addr> (gw <gw>)`. This protects the DHCP lookup
-   path regression that prompted finding #2.
-
-`dhcp.Manager` is concrete: a test helper builds a `*Manager`
-with the lease pre-installed via the lowest-friction path
-(exported `New(...)` + a `setLeaseForTest` test-only setter
-or, if available, an existing constructor that accepts seeded
-leases). Implementation step will pick the minimum-touch route.
-
-### Smoke verification
-
-Standard cluster smoke (loss userspace cluster) per protocol.
-
-**REST-only smoke targets** (no CLI claim — grpcapi is out of scope):
+**Targeted gates** (REST-only, grpcapi out of scope):
 
 ```bash
+# Named-row gate: each slash-containing ref + each reth alias must
+# have ifindex > 0 post-fix.
 sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
-  curl -s http://127.0.0.1:8080/interfaces | \
-    jq -e \"map(select(.ifindex > 0)) | length >= 3\"
+  set -e
+  J=$(curl -s http://127.0.0.1:8080/interfaces)
+  for n in ge-0/0/0 ge-0/0/1 ge-0/0/2 reth0 reth0.50 reth0.80 reth1 reth1.0; do
+    ix=$(echo \"$J\" | jq -r --arg n \"$n\" \".data | map(select(.name == \\$n)) | .[0].ifindex // 0\")
+    if [ \"$ix\" = \"0\" ]; then
+      echo \"FAIL: $n ifindex=0 post-fix\"; exit 1
+    fi
+    echo \"OK:   $n ifindex=$ix\"
+  done
 '"
+
+# Prometheus exposure: at least one per-interface series for each
+# slash-containing ref.
 sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
-  curl -s http://127.0.0.1:8080/metrics | grep -E \"xpf_iface_packets_total.*ge-0/0/\"
-'" | head -3
+  set -e
+  M=$(curl -s http://127.0.0.1:8080/metrics)
+  for n in ge-0/0/0 ge-0/0/1 ge-0/0/2; do
+    echo \"$M\" | grep -F \"xpf_iface_packets_total\" | grep -F \"interface=\\\"$n\\\"\" || {
+      echo \"FAIL: no Prometheus series for $n\"; exit 1
+    }
+  done
+'"
 ```
 
-The cluster cfg names: `ge-0/0/0` (fabric IPVLAN parent), `reth0`,
-`reth0.50`, `reth0.80`, `reth1`, `reth1.0`, etc. Length ≥ 3
-guarantees at least the slash-named base + reth aliases populate.
-
-Pre-fix all slash-named rows have ifindex=0; post-fix
-`ge-0/0/0`, `reth0`, etc. have ifindex>0 (modulo peer-only
-members).
+Pre-fix these gates fail for every slash-named row. Post-fix they
+must pass.
 
 CoS per-class smoke runs per protocol.
 
-## Public API preservation
+## Public API preservation (unchanged)
 
-- JSON `name` field: Junos config name (unchanged).
-- Prometheus `interface` label: Junos config name (unchanged —
-  operators query by Junos name).
-- `ifindex` field: was 0 for slash names, now populated. This is
-  the bug fix, not a regression.
-- `/iface-stats` rows: previously silently dropped slash-named
-  rows now appear. Same — bug fix.
-- "Not present" text in detail view: preserved for kernel-side
-  lookup failures (peer-only RETH member).
+- JSON `name`: Junos.
+- Prometheus `interface` label: Junos.
+- `ifindex`: now populated (bug fix).
+- "Not present" preserved on local-kernel lookup miss.
 
-## Hidden invariants the change must preserve
+## Hidden invariants (revised)
 
-1. JSON `name` and Prometheus label remain the Junos config name.
-2. DHCP lease key shape exactly matches `daemon_dhcp.go`:
-   `LinuxIfName(physName)[. VlanID-when-positive]`.
-3. Tunnel resolution short-circuits before LinuxIfName.
-4. RETH and Fabric resolution can compose without aliasing.
-5. Lookup failure stays non-fatal (no 500).
-6. `allInterfaceNames` output and shape unchanged.
-7. The helper is pure; no I/O, no kernel calls.
+1. JSON `name` and Prometheus label stay Junos.
+2. DHCP key shape: `LinuxIfName(physRef-as-cfg-key)[. VlanID]`, NOT
+   resolved-physical-member.
+3. Kernel link name shape: VLAN-tagged subinterface is
+   `<base>.<vlan-id>`, NOT `<base>.<unit-number>`.
+4. Tunnel resolution overrides VLAN composition.
+5. IRB resolves to the bridge device name, with NO suffix.
+6. Unit 0 collapses to the base kernel device (no `.0`).
+7. Fallback for unknown unit preserves suffix verbatim.
+8. Lookup failure non-fatal.
+9. `allInterfaceNames` shape unchanged.
+10. Helper is pure; no I/O.
 
-## Risk assessment
+## Risk assessment (revised)
 
 | Class | Level | Notes |
 |-------|-------|-------|
-| Behavioral regression | LOW | Pure additive translation; non-slash, non-RETH, non-fab, non-tunnel refs are identity. Tunnel resolution is short-circuit-by-map. |
+| Behavioral regression | LOW | Additive public method; no migration of existing private helpers in this PR. |
 | Lifetime / borrow-checker | N/A | Go. |
-| Performance regression | NIL | Control plane only. TunnelNameMap allocates a small map each call — same cost as existing callers; cache out of scope. |
-| Architectural mismatch | LOW | Plan v2 centralizes the helper at pkg/config — the natural seam grpcapi already imports. |
+| Performance regression | NIL | Control plane. Per-call TunnelNameMap + IRBToBridge rebuild — both small; cache out of scope. |
+| Architectural mismatch | LOW | Method lives next to existing ResolveReth/ResolveFab/TunnelNameMap. Mirrors snapshotLinuxName which is already battle-tested in userspace dataplane. |
+| Helper drift vs existing snapshotLinuxName | MEDIUM | Risk that the new public helper diverges from the private one over time. Mitigation: add explicit cross-reference comments in both functions pointing to the other; file a tracking issue for the migration. |
 
-## Test plan
+## Test plan (revised)
 
-- [ ] `go vet ./...` clean
-- [ ] new `TestResolveJunosIfName_*` (4 tests) pass, 5x flake check
-- [ ] new `TestDHCPLeaseKey_Mappings` passes, 5x flake check
-- [ ] new `TestInterfacesHandler_PopulatesIfindexForLoopback` passes
-- [ ] new `TestWriteInterfacesDetail_DHCPLeasePath` passes
-- [ ] `go test ./pkg/api/... ./pkg/config/... ./pkg/grpcapi/... ./pkg/dhcp/...`
-- [ ] full Go suite passes
-- [ ] cluster deploy on loss userspace cluster
-- [ ] Pass A — CoS disabled v4/v6 × push/reverse + 12-stream reverse, 0 retrans
-- [ ] Pass B — Per-class CoS 5201-5206 × v4/v6 × push/reverse
-- [ ] REST `curl /interfaces | jq` returns ifindex>0 for ge-0/0/0 and reths
-- [ ] REST `curl /metrics | grep xpf_iface_packets_total | grep ge-0/0/` returns lines
+`pkg/config/types_test.go`:
+
+1. `TestResolveKernelIfName_Plain` — `em0`, `fxp0`, `lo`, `ge-0/0/0`,
+   `ge-0/0/0.80` (vlan-id 180) → `ge-0-0-0.180`.
+2. `TestResolveKernelIfName_Reth` — node 0 `reth0`→`ge-0-0-2`,
+   `reth0.0` (unit 0 vlan-id 0) → `ge-0-0-2`,
+   `reth0.50` (unit 50 vlan-id 50) → `ge-0-0-2.50`,
+   `reth0.80` (unit 80 vlan-id 180) → `ge-0-0-2.180`. Repeat node 1.
+3. `TestResolveKernelIfName_Fab` — `fab0`→`ge-0-0-7`,
+   `fab0.0`→`ge-0-0-7` (unit 0 collapses).
+4. `TestResolveKernelIfName_Tunnel` — `gr-0/0/0.0`→`gr-0-0-0`,
+   `gr-0/0/0.1`→`gr-0-0-0u1` (per-unit `unit.Tunnel.Name`).
+5. `TestResolveKernelIfName_TunnelOverridesVlan` — interface
+   `reth0.50` with both `tunnel.Name = "gr-foo"` and `vlan-id 999`:
+   tunnel wins, returns `gr-foo`.
+6. `TestResolveKernelIfName_IRB` — `irb.0`→`br-bd0`.
+7. `TestResolveKernelIfName_UnknownUnit` — ref `ge-0/0/0.99` with
+   unit 99 missing from cfg → `ge-0-0-0.99` (fallback preserves
+   suffix verbatim).
+8. `TestDHCPLeaseKey_Mappings` — covers VlanID=0/positive, unit
+   missing, base missing. Crucially: `reth0` keys stay as `reth0`,
+   not the resolved physical.
+
+`pkg/dhcp/dhcp.go`:
+
+- Add `SeedLeaseForTesting`.
+
+`pkg/api/interfaces_test.go`:
+
+9. `TestInterfacesHandler_PopulatesIfindexForLoopback` — `lo`
+   resolves > 0.
+10. `TestWriteInterfacesDetail_DHCPLeasePath` — seed a lease keyed
+    `reth0.50`, cfg `reth0 { unit 50 { vlan-id 50; dhcp } }`, assert
+    output contains `DHCPv4: <addr> (gw <gw>)`.
+
+5x flake check on the named tests.
 
 ## Out of scope (explicitly)
 
-- **grpcapi peer fixes** at `pkg/grpcapi/server_show_interfaces.go:31`
-  and `:129`. Same bug class, same helper would apply once shipped.
-  File a follow-up issue (and a one-paragraph note in this PR body).
-- **CLI smoke** for `show interfaces detail`. The grpcapi path is
-  out of scope; the CLI smoke claim was a v1 mistake.
-- **DHCP key centralization beyond `DHCPLeaseKey`**. Daemon callers
-  still construct the key inline. Follow-up.
-- **Caching TunnelNameMap on Config**. Out of scope.
-- **Error-handling escalation**. No 500s, no log spam.
+- grpcapi peer fixes (follow-up issue).
+- CLI smoke (grpcapi path).
+- Migration of `snapshotLinuxName` and `resolveJunosIfName` to
+  the new helper (follow-up — keeps this PR contained).
+- Caching TunnelNameMap or IRBToBridge on Config.
+- Error escalation.
 
 ## Open questions for adversarial review
 
-1. Is `DHCPLeaseKey(physRef, unitNum)` the right helper shape, or
-   should the helper take the full Junos ref and parse internally?
-2. Should `ResolveJunosIfName` short-circuit on `lo`, `lo0`, `fxp0`,
-   `em0`? Currently no — identity through LinuxIfName works.
-3. Tunnel resolution: should a bare `gr-0/0/0` (no unit) go through
-   TunnelNameMap? Map keys are `<name>.<unit>`, so bare falls
-   through to LinuxIfName → `gr-0-0-0`. Confirm this matches the
-   kernel link name (compiler creates `gr-0-0-0`, no suffix).
-4. Are there other ref shapes I'm missing? `st0.0` (xfrm),
-   `lo0.0`, `mt-`, `xe-`? `xe-` is LinuxIfName territory.
-   `st0` is xfrm; kernel device is `st0` directly. `lo0` has its
-   own quirks in Junos (loopback). Verify identity is correct.
-5. Should `writeInterfacesDetail` also print a `(kernel: ge-0-0-0)`
-   annotation for ops debugging? Out of scope but flagging.
-6. `*Config` method vs free function for `ResolveJunosIfName`?
-   Method matches ResolveReth/ResolveFab/TunnelNameMap convention.
-7. Should `interfacesHandler` skip rows for non-resolvable refs
-   (peer-only RETH members)? Today it lists them with ifindex=0.
-   Changing would be a JSON shape regression — keep.
+1. Is centralizing as a method on `*Config` correct, or should it
+   live in a dedicated `pkg/config/ifname.go` (file already
+   ~1900 lines)?
+2. Is the `(physRef, unitNum)` shape of `DHCPLeaseKey` better than
+   a single `(ref)` argument that the helper parses internally?
+3. Is the fallback "preserve suffix verbatim" in `ResolveKernelIfName`
+   the right behavior, or should it return `(name, false)` with the
+   caller deciding?
+4. Should the helper compose `IRBToBridge` even for bare `irb`
+   refs (no unit)? Currently bare `irb` falls through to
+   `LinuxIfName("irb")` = `"irb"`. Junos may not allow bare
+   `irb` without a unit; verify or accept current.
+5. Is the `SeedLeaseForTesting` exported method acceptable, or
+   should it be in a `_test_helpers.go` build-tagged file?
+6. Is the explicit decision to NOT migrate `snapshotLinuxName` /
+   `resolveJunosIfName` defensible, or should v3 fold them in?
+7. Tunnel-overrides-VLAN precedence: is this the Junos semantic?
+   Could a user configure both and expect VLAN? (My read: tunnel
+   creates a kernel device, VLAN-tagging is mutually exclusive
+   with tunnel-mode at the unit level; verify against
+   `compiler_interfaces.go:123-211`.)
 
 ## Procedure
 
-1. Add `(*Config).ResolveJunosIfName` and `(*Config).DHCPLeaseKey`
+1. Add `(*Config).ResolveKernelIfName` and `(*Config).DHCPLeaseKey`
    in `pkg/config/types.go`.
-2. Add 4 + 1 helper unit tests in `pkg/config/types_test.go`.
-3. Rewrite the 4 pkg/api sites.
-4. Add 2 handler tests in `pkg/api/interfaces_test.go` (or new
-   `pkg/api/iface_name_test.go`).
-5. Smoke per protocol.
-6. PR with `Closes #1565` body. Body includes a "Follow-up" note
-   pointing at the grpcapi peer.
+2. Add `(*Manager).SeedLeaseForTesting` in `pkg/dhcp/dhcp.go`.
+3. Add 8 helper unit tests in `pkg/config/types_test.go`.
+4. Rewrite the 4 pkg/api sites.
+5. Add 2 handler tests in `pkg/api/interfaces_test.go`.
+6. Smoke per protocol with named-row gates.
+7. PR with `Closes #1565`.

--- a/docs/pr/1565-iface-name-translate/plan.md
+++ b/docs/pr/1565-iface-name-translate/plan.md
@@ -1,8 +1,53 @@
 # #1565 — pkg/api: translate Junos config names to Linux ifnames before net.InterfaceByName
 
-**Status:** DRAFT v3 — addressing Codex round-2 PLAN-NEEDS-MAJOR (AGY round-2 returned PLAN-READY but accepted an incorrect v2 design that Codex caught)
+**Status:** DRAFT v4 — addressing Codex round-3 PLAN-NEEDS-MAJOR (AGY round-3 returned PLAN-NEEDS-MINOR, overlapping fixes)
 
-## Round-2 verdicts
+## Round-3 verdicts (round-3 archived)
+
+- **Codex** task-mpnij29g-ligphz: PLAN-NEEDS-MAJOR. Findings:
+  - **`fab0`/`fab0.0` should NOT be resolved via `ResolveFab` in the
+    API helper.** `fab0`/`fab1` are real kernel IPVLAN devices
+    (created by `daemon_apply.go:298-386` and present as netlink
+    links). `snapshotLinuxName` at
+    `pkg/dataplane/userspace/interfaces.go:323,331` returns
+    `LinuxIfName(ifName)` for bare non-reth refs — it does NOT call
+    `ResolveFab`. `ResolveFab` is documented as a fabric-PARENT
+    resolver for BPF attachment, not a display-name resolver. API
+    helper must keep `fab0` as `fab0`.
+  - **`st0.0` is missed.** XFRM secure tunnels: kernel device is
+    the full ref preserved via `XFRMIfNameAndID` ('st0.0' stays
+    'st0.0'). `compiler_iface.go:44-48` already short-circuits
+    dotted st* refs. v3's generic unit-collapse would turn `st0.0`
+    into `st0`.
+  - **Smoke gate references `reth1.0`** but `allInterfaceNames`
+    won't iterate it from the userspace cluster cfg (`reth1.0`
+    only appears under `dhcp-local-server`, not in a security zone
+    or top-level `interfaces`). The named-row assertion would
+    fail post-fix.
+  - Loopback handler test is too weak — `lo` resolves identity
+    pre-fix. Use a cfg alias resolving to `lo` to actually exercise
+    the helper.
+  - Prometheus smoke missing reth aliases — needs reth0, reth0.50,
+    reth0.80, reth1 in the gate to prove `metrics_counters.go` is
+    fixed.
+  - Plan text internally contradicts on migration mandatoriness
+    (one sentence says "mandatory", another says "do NOT migrate").
+    Clean up to a single clear stance.
+
+- **AGY** review-mpnijezy-rbikjh: PLAN-NEEDS-MINOR. Findings overlap:
+  - Smoke gates target interfaces not in actual cfg (AGY checked
+    `xpf-cluster-fw0.conf` not `ha-cluster-userspace.conf`, so the
+    specific names AGY cited differ from Codex's; both reviewers
+    agree the gate names need correction).
+  - Missing `"fmt"` import in `pkg/config/types.go` for new
+    `fmt.Sprintf` calls.
+  - Move `SeedLeaseForTesting` to `pkg/dhcp/test_seams.go` to keep
+    production file clean.
+  - Add `// NOTE: Keep in sync with (*Config).ResolveKernelIfName`
+    comments in legacy `snapshotLinuxName` and
+    daemon `resolveJunosIfName` to mitigate drift.
+
+## Round-2 verdicts (archived)
 
 - **Codex** task-mpni7vi4-2oacjs: PLAN-NEEDS-MAJOR.
   - Critical: v2 helper preserved the `.unit` suffix unchanged after
@@ -119,75 +164,94 @@ public helper, or composes IRB resolution explicitly.**
 
 ### Public helper: `(*Config).ResolveKernelIfName`
 
-Path: `pkg/config/types.go`. Signature:
+Path: `pkg/config/types.go`. **Note:** add `"fmt"` import (AGY catch).
 
 ```go
 // ResolveKernelIfName converts a Junos-style interface reference (as
 // found in zone declarations and the keys of cfg.Interfaces.Interfaces)
 // to the Linux kernel ifname it should resolve to on the LOCAL node.
 //
+// Important nuance: this is a DISPLAY-name resolver for API readers.
+// It is NOT the same as ResolveFab (which returns the fabric overlay's
+// parent for BPF attachment). fab0 itself is a real kernel IPVLAN
+// device, so API queries on fab0 must look up "fab0", not its parent.
+// Similarly, st0.x is the kernel XFRM device name verbatim.
+//
 // Resolution semantics, in order:
-//   1. Bare physical/logical refs without a "." suffix (e.g. "em0",
-//      "fxp0", "lo", "ge-0/0/0", "reth0", "fab0", "gr-0/0/0"):
-//        - reth0/fab0 → ResolveReth/ResolveFab to local physical member
-//        - / → -
-//        - bare gr-0/0/0 → gr-0-0-0 (kernel device for the base tunnel)
-//   2. Dotted refs (e.g. "ge-0/0/0.80", "reth0.0", "gr-0/0/0.1",
-//      "irb.0"):
-//        a. IRB: look up via config.IRBToBridge(cfg.BridgeDomains) and
-//           return the bridge device name (no suffix).
-//        b. Tunnel: if TunnelNameMap[ref] is set, return that name
+//   1. Bare refs (no "." suffix):
+//        - reth0 → ResolveReth → physical member, LinuxIfName.
+//        - all others (fxp0, em0, fab0, lo, ge-0/0/0, gr-0/0/0, st0):
+//          LinuxIfName(ref). Matches snapshotLinuxName lines 328-331.
+//   2. Dotted refs (e.g. "ge-0/0/0.80", "reth0.50", "gr-0/0/0.0",
+//      "irb.0", "st0.0"):
+//        a. st* short-circuit: any "st<N>.<M>" ref is the kernel
+//           XFRM device name; just LinuxIfName(ref). Matches
+//           compiler_iface.go:44-48 + XFRMIfNameAndID semantics.
+//        b. IRB: look up via config.IRBToBridge(cfg.BridgeDomains)
+//           and return the bridge device name (no suffix).
+//        c. Tunnel: if TunnelNameMap[ref] is set, return that name
 //           verbatim (covers gr-0/0/0.0 → gr-0-0-0 and gr-0/0/0.1 →
 //           gr-0-0-0u1).
-//        c. Otherwise look up cfg.Interfaces.Interfaces[base].Units[unit]:
-//             - If unit has tunnel.Name set, return that.
-//             - If unit.VlanID > 0, return LinuxIfName(ResolveFab(ResolveReth(base))) + "." + VlanID.
-//             - If unit.Number == 0, return LinuxIfName(ResolveFab(ResolveReth(base))) (collapse unit 0).
-//             - Else return LinuxIfName(ResolveFab(ResolveReth(base))) + "." + unit.Number.
-//        d. If the base + unit lookup misses (e.g. ref names a unit not
-//           in cfg.Interfaces.Interfaces), fall back to
-//           LinuxIfName(ResolveFab(ResolveReth(ref))) — preserves the
-//           suffix and trusts the caller.
+//        d. Otherwise look up cfg.Interfaces.Interfaces[base].Units[unit]:
+//             - If unit has tunnel.Name set, return that (per-unit
+//               tunnel override).
+//             - If unit.VlanID > 0, return
+//               LinuxIfName(ResolveReth(base)) + "." + VlanID.
+//             - If unit.Number == 0, return LinuxIfName(ResolveReth(base))
+//               (collapse unit 0).
+//             - Else return LinuxIfName(ResolveReth(base)) + "." + unit.Number.
+//        e. Fallback: LinuxIfName(ResolveReth(ref)) — preserves suffix.
 //
-// The fallback in (2d) matters because allInterfaceNames includes raw
-// zone refs, and a zone may legitimately list a sub-interface that's
-// not in the interfaces stanza (config error — observable in stats
-// but not crashing the API).
+// NOTE: Keep in sync with snapshotLinuxName in
+// pkg/dataplane/userspace/interfaces.go and resolveJunosIfName in
+// pkg/daemon/daemon_dhcp.go. Migration to centralize all callers is
+// tracked in a follow-up issue.
 func (c *Config) ResolveKernelIfName(ref string) string {
     parts := strings.SplitN(ref, ".", 2)
     base := parts[0]
 
     // Bare refs
     if len(parts) == 1 {
-        resolved := c.ResolveFab(c.ResolveReth(base))
-        return LinuxIfName(resolved)
+        if strings.HasPrefix(base, "reth") {
+            return LinuxIfName(c.ResolveReth(base))
+        }
+        return LinuxIfName(base)
+    }
+
+    // XFRM (st*) is verbatim — kernel device is the full ref.
+    if strings.HasPrefix(base, "st") && len(base) >= 3 {
+        // Confirm st<digits> shape (st followed by a number) to avoid
+        // catching unrelated "st"-prefixed names.
+        if _, err := strconv.Atoi(base[2:]); err == nil {
+            return LinuxIfName(ref)
+        }
     }
 
     // IRB
     if base == "irb" {
         if bridges := IRBToBridge(c.BridgeDomains); bridges != nil {
-            if bridge, ok := bridges[ref]; ok {
+            if bridge, ok := bridges[ref]; ok && bridge != "" {
                 return bridge
             }
         }
-        // Fall through to generic path
+        // Fall through if no bridge mapping; LinuxIfName(ref) below.
     }
 
-    // Tunnel by ref
+    // Tunnel by ref (per-unit explicit map).
     if tunMap := c.TunnelNameMap(); tunMap != nil {
         if linuxName, ok := tunMap[ref]; ok && linuxName != "" {
             return linuxName
         }
     }
 
-    // Look up the unit by parsed number
+    // Look up the unit by parsed number on the base interface.
     unitNum, _ := strconv.Atoi(parts[1])
     if ifc, ok := c.Interfaces.Interfaces[base]; ok && ifc != nil {
         if unit, ok := ifc.Units[unitNum]; ok && unit != nil {
             if unit.Tunnel != nil && unit.Tunnel.Name != "" {
                 return unit.Tunnel.Name
             }
-            kernelBase := LinuxIfName(c.ResolveFab(c.ResolveReth(base)))
+            kernelBase := LinuxIfName(c.ResolveReth(base))
             if unit.VlanID > 0 {
                 return fmt.Sprintf("%s.%d", kernelBase, unit.VlanID)
             }
@@ -198,8 +262,9 @@ func (c *Config) ResolveKernelIfName(ref string) string {
         }
     }
 
-    // Fallback: best-effort, preserve suffix.
-    return LinuxIfName(c.ResolveFab(c.ResolveReth(ref)))
+    // Fallback for refs not modeled in cfg.Interfaces.Interfaces:
+    // preserve the suffix and translate slashes only.
+    return LinuxIfName(c.ResolveReth(ref))
 }
 ```
 
@@ -248,36 +313,21 @@ not `ge-0-0-2.50`).
 
 ### Migration of `snapshotLinuxName` and `resolveJunosIfName`
 
-After `(*Config).ResolveKernelIfName` exists:
-- `pkg/dataplane/userspace/interfaces.go:303` `snapshotLinuxName`
-  becomes a wrapper that calls `cfg.ResolveKernelIfName(fmt.Sprintf("%s.%d", ifName, unit.Number))`
-  when `unit != nil`, else `cfg.ResolveKernelIfName(ifName)`.
-  Eight existing test cases in that package will exercise the
-  centralized helper — *no semantic change*.
-- `pkg/daemon/daemon_dhcp.go:138` `resolveJunosIfName` is deleted;
-  callers switch to `cfg.ResolveKernelIfName(ifName)` directly (or
-  to the bare-ref shape they were already passing).
+**Decision (single stance, v4):** DO NOT migrate the existing private
+helpers in this PR. Ship the new public method additively. Migration
+to centralize all callers is a follow-up issue.
 
-This migration is mandatory because otherwise we'd have two
-implementations that drift. But it expands the blast radius — we
-need to verify the userspace and daemon tests still pass.
+Rationale: migrating `snapshotLinuxName` would touch the dataplane
+interface snapshot path that drives every userspace-dp `Apply()` —
+high blast radius for a #1565 observability fix. Migrating
+`daemon/resolveJunosIfName` is much smaller but still touches a code
+path that's currently green; bundling it adds risk without
+proportional value.
 
-**Risk classification:** this lifts a private helper to public and
-re-points two callers. If reviewers think the migration's blast
-radius is too wide for a #1565 fix, the alternative is:
-
-- Add the helper as a public method on `*Config` (no behavior
-  change at the call sites that use `snapshotLinuxName` and
-  `resolveJunosIfName`).
-- pkg/api uses the public method.
-- Defer migration of `snapshotLinuxName` and `resolveJunosIfName`
-  to a follow-up.
-
-**Recommendation in v3:** ship the additive public method; do NOT
-migrate `snapshotLinuxName` or `resolveJunosIfName` in this PR.
-That keeps the diff small, contains the blast radius, and leaves
-the legacy private helpers in place for the next refactor.
-Migration becomes a follow-up issue.
+**Drift mitigation:** add explicit
+`// NOTE: Keep in sync with (*Config).ResolveKernelIfName in pkg/config/types.go`
+comments at both legacy helpers. File the migration follow-up issue
+on PR merge.
 
 ### Call-site rewrites
 
@@ -341,32 +391,31 @@ for _, ifName := range ifNames {
 
 1-line: `net.InterfaceByName(cfg.ResolveKernelIfName(ifName))`.
 
-### DHCP integration test design (Codex finding #4)
+### DHCP integration test design
 
-`dhcp.Manager.leases` is unexported. Three options ranked:
+`dhcp.Manager.leases` is unexported. Add a small exported test seam
+in a dedicated file **`pkg/dhcp/test_seams.go`** (AGY catch — keeps
+production `dhcp.go` clean):
 
-1. **Best (lowest blast radius):** add a small exported test seam in
-   `pkg/dhcp/dhcp.go`:
-   ```go
-   // SeedLeaseForTesting installs a lease record for tests. Not for
-   // production use.
-   func (m *Manager) SeedLeaseForTesting(ifaceName string, af AddressFamily, lease *Lease) {
-       m.mu.Lock()
-       defer m.mu.Unlock()
-       if m.leases == nil {
-           m.leases = make(map[clientKey]*Lease)
-       }
-       m.leases[clientKey{iface: ifaceName, family: af}] = lease
-   }
-   ```
-   pkg/api test calls this directly on a `dhcp.New(...)`-built manager.
-2. Add a `dhcpLeaseProvider` interface inside pkg/api and inject a
-   stub. Requires a Server field change.
-3. Skip the integration test, rely on unit tests + smoke.
+```go
+// Package dhcp test-only helpers. Lives in the production package
+// so external packages (e.g. pkg/api tests) can use it without
+// internal-export tricks. Not for production callers.
+package dhcp
 
-**Recommendation in v3:** option 1. Test seam is explicit, named
-clearly, and lives next to the manager. Smaller blast than
-introducing an interface in pkg/api.
+// SeedLeaseForTesting installs a lease record for tests.
+func (m *Manager) SeedLeaseForTesting(ifaceName string, af AddressFamily, lease *Lease) {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    if m.leases == nil {
+        m.leases = make(map[clientKey]*Lease)
+    }
+    m.leases[clientKey{iface: ifaceName, family: af}] = lease
+}
+```
+
+No build tag — pkg/api tests need it to compile. The "ForTesting"
+suffix and dedicated filename make the contract explicit.
 
 ### Resolution-order checks (Codex finding #3 — tunnel collisions)
 
@@ -380,35 +429,45 @@ right precedence — if a user explicitly configured a tunnel under
 Document this in the helper godoc; add a test:
 `TestResolveKernelIfName_TunnelOverridesVlan`.
 
-### Smoke verification (revised — Codex finding #5)
+### Smoke verification (revised v4 — Codex finding #5)
 
-Pre-fix baseline: `fxp0`, `em0`, `fab0`, `lo` are already non-slash
-and resolvable, so any `length >= K` gate where `K` ≤ pre-fix
-resolvable count is trivially passed.
+Pre-fix baseline: `fxp0`, `em0`, `fab0`, `lo` are non-slash and
+resolvable, so any `length >= K` gate is trivially passed.
 
-**Targeted gates** (REST-only, grpcapi out of scope):
+**Targeted gates** keyed to the actual `docs/ha-cluster-userspace.conf`
+content (REST-only, grpcapi out of scope):
+
+Cluster cfg names that flow through `allInterfaceNames`:
+- From `cfg.Interfaces.Interfaces` keys (top-level `interfaces { ... }`):
+  `fxp0`, `em0`, `fab0` (node 0)/`fab1` (node 1),
+  `ge-0/0/0`, `ge-0/0/1`, `ge-0/0/2`, `reth0`, `reth1`, `gr-0/0/0`.
+- From zone `interfaces { ... }` lists: `fxp0`, `em0`, `fab0`, `fab1`,
+  `reth0.50`, `reth0.80`, `gr-0/0/0.0`, `reth1`.
+
+Slash-or-virtual rows the fix must populate ifindex>0 for:
+`ge-0/0/0`, `ge-0/0/1`, `ge-0/0/2`, `reth0`, `reth0.50`, `reth0.80`,
+`reth1`, `gr-0/0/0.0`. (`reth1.0` is NOT in any zone/top-level
+iteration — drop from gate.)
 
 ```bash
-# Named-row gate: each slash-containing ref + each reth alias must
-# have ifindex > 0 post-fix.
 sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
   set -e
   J=$(curl -s http://127.0.0.1:8080/interfaces)
-  for n in ge-0/0/0 ge-0/0/1 ge-0/0/2 reth0 reth0.50 reth0.80 reth1 reth1.0; do
+  for n in ge-0/0/0 ge-0/0/1 ge-0/0/2 reth0 reth0.50 reth0.80 reth1 gr-0/0/0.0; do
     ix=$(echo \"$J\" | jq -r --arg n \"$n\" \".data | map(select(.name == \\$n)) | .[0].ifindex // 0\")
     if [ \"$ix\" = \"0\" ]; then
       echo \"FAIL: $n ifindex=0 post-fix\"; exit 1
     fi
-    echo \"OK:   $n ifindex=$ix\"
+    echo \"OK: $n ifindex=$ix\"
   done
 '"
 
-# Prometheus exposure: at least one per-interface series for each
-# slash-containing ref.
+# Prometheus exposure: include reth aliases so metrics_counters.go
+# is provably exercised.
 sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
   set -e
   M=$(curl -s http://127.0.0.1:8080/metrics)
-  for n in ge-0/0/0 ge-0/0/1 ge-0/0/2; do
+  for n in ge-0/0/0 ge-0/0/1 ge-0/0/2 reth0 reth0.50 reth0.80 reth1; do
     echo \"$M\" | grep -F \"xpf_iface_packets_total\" | grep -F \"interface=\\\"$n\\\"\" || {
       echo \"FAIL: no Prometheus series for $n\"; exit 1
     }
@@ -416,8 +475,8 @@ sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
 '"
 ```
 
-Pre-fix these gates fail for every slash-named row. Post-fix they
-must pass.
+Pre-fix these gates fail for every slash/virtual row. Post-fix they
+must pass. `gr-0/0/0.0` exercises the TunnelNameMap branch end-to-end.
 
 CoS per-class smoke runs per protocol.
 
@@ -463,8 +522,9 @@ CoS per-class smoke runs per protocol.
    `reth0.0` (unit 0 vlan-id 0) → `ge-0-0-2`,
    `reth0.50` (unit 50 vlan-id 50) → `ge-0-0-2.50`,
    `reth0.80` (unit 80 vlan-id 180) → `ge-0-0-2.180`. Repeat node 1.
-3. `TestResolveKernelIfName_Fab` — `fab0`→`ge-0-0-7`,
-   `fab0.0`→`ge-0-0-7` (unit 0 collapses).
+3. `TestResolveKernelIfName_Fab` — `fab0`→`fab0`, `fab0.0`→`fab0.0`
+   (kernel IPVLAN devices, NOT resolved to parent). **Corrected
+   in v4** — v3 plan wrongly expected `ge-0-0-7`.
 4. `TestResolveKernelIfName_Tunnel` — `gr-0/0/0.0`→`gr-0-0-0`,
    `gr-0/0/0.1`→`gr-0-0-0u1` (per-unit `unit.Tunnel.Name`).
 5. `TestResolveKernelIfName_TunnelOverridesVlan` — interface
@@ -482,13 +542,41 @@ CoS per-class smoke runs per protocol.
 
 - Add `SeedLeaseForTesting`.
 
+Add another helper test for interface-level (not per-unit) tunnel
+shape (Codex round-3 follow-up):
+
+9. `TestResolveKernelIfName_InterfaceLevelTunnel` — cfg
+   `gr-0/0/0 { tunnel { source ...; }; unit 0 {} unit 1 {} }`;
+   verify `gr-0/0/0.0`→`gr-0-0-0`, `gr-0/0/0.1`→`gr-0-0-0`
+   (interface-level tunnel = unit 0/1 share the base name; matches
+   TunnelNameMap construction at types.go:1768).
+
+10. `TestResolveKernelIfName_StXfrm` — `st0.0`→`st0.0`, `st0.5`→
+    `st0.5`, `st1`→`st1`. Confirms st* short-circuit.
+
+11. `TestResolveKernelIfName_FabIsKernelDevice` — `fab0`→`fab0`,
+    `fab0.0`→`fab0.0` (IPVLAN overlay names are real kernel
+    devices; do NOT resolve to parent).
+
 `pkg/api/interfaces_test.go`:
 
-9. `TestInterfacesHandler_PopulatesIfindexForLoopback` — `lo`
-   resolves > 0.
-10. `TestWriteInterfacesDetail_DHCPLeasePath` — seed a lease keyed
-    `reth0.50`, cfg `reth0 { unit 50 { vlan-id 50; dhcp } }`, assert
-    output contains `DHCPv4: <addr> (gw <gw>)`.
+12. `TestInterfacesHandler_ResolvesSlashName` — cfg names
+    `lo-0/0/0` as a fake interface that we ALSO add to
+    cfg.Interfaces.Interfaces. Then assert: pre-fix-equivalent
+    behavior (raw lookup of `lo-0/0/0` fails, ifindex=0) vs
+    post-fix behavior (helper translates to `lo-0-0-0` which
+    also doesn't exist on the test runner → still ifindex=0).
+    Net: the test asserts the row is present with correct
+    `name` label whether or not ifindex resolves. **Stronger
+    coverage:** cfg.Interfaces.Interfaces with key `whatever`
+    where we KNOW the kernel has `lo`: declare the cfg key
+    as `lo` literally and verify ifindex matches the loopback
+    `net.InterfaceByName("lo").Index`. (Loopback is the only
+    interface guaranteed to exist on every Linux test runner.)
+13. `TestWriteInterfacesDetail_DHCPLeasePath` — seed a lease keyed
+    `reth0.50`, cfg `reth0 { unit 50 { vlan-id 50; dhcp } }`,
+    assert output contains `DHCPv4: <addr> (gw <gw>)`. This is the
+    end-to-end test of the DHCPLeaseKey + LeaseFor + format path.
 
 5x flake check on the named tests.
 
@@ -528,10 +616,13 @@ CoS per-class smoke runs per protocol.
 ## Procedure
 
 1. Add `(*Config).ResolveKernelIfName` and `(*Config).DHCPLeaseKey`
-   in `pkg/config/types.go`.
-2. Add `(*Manager).SeedLeaseForTesting` in `pkg/dhcp/dhcp.go`.
-3. Add 8 helper unit tests in `pkg/config/types_test.go`.
-4. Rewrite the 4 pkg/api sites.
-5. Add 2 handler tests in `pkg/api/interfaces_test.go`.
-6. Smoke per protocol with named-row gates.
-7. PR with `Closes #1565`.
+   in `pkg/config/types.go` (add `"fmt"` import).
+2. Add `(*Manager).SeedLeaseForTesting` in
+   `pkg/dhcp/test_seams.go` (new file).
+3. Add `// NOTE: Keep in sync with (*Config).ResolveKernelIfName`
+   to legacy `snapshotLinuxName` and `daemon/resolveJunosIfName`.
+4. Add 11 helper unit tests in `pkg/config/types_test.go`.
+5. Rewrite the 4 pkg/api sites.
+6. Add 2 handler tests in `pkg/api/interfaces_test.go`.
+7. Smoke per protocol with v4 named-row gates.
+8. PR with `Closes #1565`.

--- a/docs/pr/1565-iface-name-translate/plan.md
+++ b/docs/pr/1565-iface-name-translate/plan.md
@@ -1,0 +1,346 @@
+# #1565 — pkg/api: translate Junos config names to Linux ifnames before net.InterfaceByName
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+Pre-existing bug surfaced by Copilot inline review on PR #1564 (the
+`#1540` REST API split). Four call sites in `pkg/api/` call
+`net.InterfaceByName(ifName)` directly with config-level interface
+names that may contain `/` (e.g. `ge-0/0/0`, `ge-0/0/0.80`) or be
+RETH aliases (`reth0`, `reth0.50`). Linux IFNAMSIZ forbids `/`, and
+RETH virtual names have no kernel ifindex, so these lookups fail
+silently and:
+
+1. Per-interface counters (`Ifindex`, RX/TX packets/bytes) come back
+   as zero in the REST `interfaces` view.
+2. `show interfaces` detail prints "Not present" for every
+   Junos-named interface, then skips MTU/MAC/addresses/DHCP lease.
+3. `/iface-stats` skips configured interfaces entirely (silent drop
+   from result set, not just zero counters).
+4. Per-interface Prometheus metrics (`xpf_iface_packets_total`,
+   `xpf_iface_bytes_total`) are simply not emitted for affected
+   interfaces — they appear missing from `/metrics` output.
+
+The four sites are listed verbatim in the issue body:
+
+- `pkg/api/interfaces.go:38` — `interfacesHandler` (JSON list)
+- `pkg/api/interfaces.go:224` — `writeInterfacesDetail` (text view)
+- `pkg/api/stats.go:70` — `ifaceStatsHandler` (typed JSON)
+- `pkg/api/metrics_counters.go:74` — Prometheus collector
+
+The repo already ships the primitive: `config.LinuxIfName(name)`
+replaces `/` with `-`, and `cfg.ResolveReth(name)` resolves
+`reth0[.unit]` to the local physical member. Both are battle-tested
+in `pkg/config/compiler_interfaces.go`, `pkg/grpcapi/server_show_interfaces.go`,
+`pkg/grpcapi/server_cluster.go`, and the daemon's networkd path.
+
+## Honest scope / value framing
+
+Bug fix on a control-plane observability surface. No hot-path
+cycles. No allocator pressure. No HA sync. No correctness risk
+to the dataplane. Win is qualitative: REST clients and Prometheus
+scrapers see real interface counters and the JSON Ifindex field is
+populated for every configured interface, not just for those whose
+Junos name happens to also be a valid Linux ifname (i.e. no `/`,
+not a reth alias).
+
+If reviewers conclude the perf gain is too small to justify the
+churn, PLAN-KILL is an acceptable verdict. (The "perf gain" here
+is observability fidelity, not throughput — PLAN-KILL would
+amount to "leave the broken handlers broken", which seems wrong
+for a fix tagged on a Copilot reviewer finding.)
+
+## What's already shipped / partially fixed
+
+The grpcapi peer of these handlers (`pkg/grpcapi/server_show_interfaces.go`)
+already uses `config.LinuxIfName(...)` and `cfg.ResolveReth(...)` in
+several places — see:
+
+- `pkg/grpcapi/server_show_interfaces.go:502` — `kernelIf := config.LinuxIfName(statusIf)`
+- `pkg/grpcapi/server_show_interfaces.go:547` — `kernelIf := config.LinuxIfName(u.physName)`
+- `pkg/grpcapi/server_show_interfaces.go:623-632` — VLAN-suffix composition
+- `pkg/grpcapi/server_cluster.go:45` — `linuxName := config.LinuxIfName(phys)`
+- `pkg/grpcapi/server_diag.go:312` — RETH/LinuxIfName composition
+- `pkg/grpcapi/server_sessions.go:325` — `cfg.ResolveReth(...)` + LinuxIfName
+
+`pkg/api/interfaces.go` is partially fixed: the `writeInterfacesTerse`
+function (lines 105-180) **already** uses `config.LinuxIfName` and
+`RethToPhysical()`. Only the non-terse `interfacesHandler` and
+`writeInterfacesDetail` halves regressed.
+
+The DHCP manager `LeaseFor()` keys by Linux name with VLAN suffix
+(`pkg/daemon/daemon_dhcp.go:56-95` builds `dhcpIface = LinuxIfName(ifName)` +
+optional `.VLAN`), so `LeaseFor(ifName, ...)` in `writeInterfacesDetail`
+also returns nil for any name with `/`. Same root cause.
+
+## Concrete design
+
+### Sites and fixes
+
+| File | Line | Current | Fix |
+|------|------|---------|-----|
+| `pkg/api/interfaces.go` | 32 | `iface, err := net.InterfaceByName(ifName)` | Compose `lookupName` via `config.LinuxIfName(cfg.ResolveReth(ifName))` (with VLAN-suffix preservation), then `net.InterfaceByName(lookupName)`. Print original `ifName` in JSON. |
+| `pkg/api/interfaces.go` | 210 | `iface, err := net.InterfaceByName(ifName)` | Same as above; also replace inline `/sys/class/net/`+`ifName` reads (line 220) with the resolved kernel name. DHCP lookup uses the LinuxIfName+VLAN form to match daemon's `dhcpIface` key. |
+| `pkg/api/stats.go` | 64 | `iface, err := net.InterfaceByName(ifName)` | Same translation. |
+| `pkg/api/metrics_counters.go` | 68 | `iface, err := net.InterfaceByName(ifName)` | Same translation. |
+
+### Helper
+
+Introduce one private helper in `pkg/api/api.go` next to
+`allInterfaceNames`:
+
+```go
+// kernelIfName returns the Linux kernel ifname for a config-level
+// interface name. It resolves reth aliases to the local physical
+// member (preserving any .unit suffix) then translates "/" to "-"
+// to satisfy IFNAMSIZ. The returned name is suitable for
+// net.InterfaceByName, /sys/class/net, and DHCP lease lookups (the
+// daemon DHCP client keys by this same form).
+func kernelIfName(cfg *config.Config, ifName string) string {
+    return config.LinuxIfName(cfg.ResolveReth(ifName))
+}
+```
+
+`ResolveReth` already preserves `.unit`, so a config name like
+`reth0.50` round-trips to e.g. `ge-0-0-2.50` on node-0 of the loss
+cluster. For non-reth names with VLAN units the input is already
+in `ge-0/0/0.80` form, which becomes `ge-0-0-0.80`.
+
+### Site rewrites
+
+`interfacesHandler` (line 32):
+
+```go
+for ifName := range allInterfaceNames(cfg) {
+    iface, err := net.InterfaceByName(kernelIfName(cfg, ifName))
+    is := InterfaceStats{
+        Name: ifName,                // unchanged — Junos label
+        Zone: ifZone[ifName],
+    }
+    if err == nil {
+        is.Ifindex = iface.Index
+        // counters as before
+    }
+    result = append(result, is)
+}
+```
+
+`writeInterfacesDetail` (line 210): same translation. Crucially,
+replace **all** subsequent uses of `ifName` as a kernel path —
+specifically the `/sys/class/net/<ifName>/operstate` read on
+line 220, and the DHCP `LeaseFor(ifName, ...)` calls on lines
+253 and 256.
+
+The DHCP key form is `dhcpIface` from `daemon_dhcp.go` line 59:
+`config.LinuxIfName(ifName)` plus `".%d"` when `unit.VlanID > 0`.
+So for a config name like `ge-0/0/0` with unit 0 vlan 80, the
+DHCP key is `ge-0-0-0.80`. The detail handler iterates
+`allInterfaceNames` which already returns the dotted form (e.g.
+`ge-0/0/0.80`) from zone references, so passing
+`kernelIfName(cfg, ifName)` is sufficient.
+
+`ifaceStatsHandler` (line 64) and `collectInterfaceCounters` (line
+68): identical translation. Both still `continue` on lookup
+failure (preserving current "skip unknown" semantics) — see the
+error-handling decision below.
+
+### Error-handling semantics
+
+Three plausible behaviors when `net.InterfaceByName` fails:
+
+| Mode | interfacesHandler | writeInterfacesDetail | ifaceStatsHandler | metrics_counters |
+|------|--------------------|-----------------------|--------------------|------------------|
+| current | include with zero ifindex | print "Not present" | skip | skip |
+| log+skip | same + slog.Debug | same + slog.Debug | same + slog.Debug | same + slog.Debug |
+| 500 the handler | no | no | no | no |
+
+**Decision:** keep current per-site semantics (each handler already
+made a deliberate choice — listing-style endpoints include the row
+with zero counters, stats endpoints drop unknown rows, Prometheus
+skips the metric). Add `slog.Debug` for visibility but never escalate
+to `slog.Info` or to a 500 — admin-down or not-yet-renamed interfaces
+are a normal transient on boot and on RETH member flips.
+
+This matches the grpcapi peer's behavior at
+`server_show_interfaces.go:31-46` (`err == nil` guards counters,
+ifindex stays unpopulated). No 500.
+
+### Tests
+
+Add a single new test file `pkg/api/iface_name_test.go`. Three tests:
+
+1. **`TestKernelIfName_TranslatesSlash`** — config name `ge-0/0/0`
+   produces `ge-0-0-0`; with unit/VLAN `.80` produces `ge-0-0-0.80`.
+   No live netlink — pure config helper test.
+
+2. **`TestKernelIfName_ResolvesReth`** — given a cfg with
+   `interfaces { ge-0/0/0 { redundant-parent reth0 }; reth0; }`
+   on node 0, `kernelIfName(cfg, "reth0")` returns `ge-0-0-0`
+   and `kernelIfName(cfg, "reth0.50")` returns `ge-0-0-0.50`.
+
+3. **`TestInterfacesHandler_PopulatesIfindexForLoopback`** —
+   spin up a Server with a cfg that names `lo` (a real Linux
+   ifname), call `interfacesHandler`, assert Ifindex > 0. Then
+   spin up a second Server with cfg-level name `ge-0/0/0` and
+   assert the JSON row is present with Ifindex == 0 (handler
+   doesn't 500, doesn't omit, and exercises the translation
+   code path even when the resolved name isn't present on the
+   test runner).
+
+The third test exists to prove the **handler does not regress**
+on the no-such-interface path — not to assert positive ifindex
+for a name that won't be present in CI. Positive ifindex
+verification on real Junos names is the smoke step.
+
+### Smoke verification
+
+Standard cluster smoke (loss userspace cluster). Plus one
+control-plane check that is targeted at this bug:
+
+```bash
+sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
+  curl -s http://127.0.0.1:8080/interfaces | \
+    jq -e \"map(select(.ifindex > 0)) | length >= 4\"
+'"
+```
+
+The cluster cfg names interfaces with `/` (`ge-0/0/0`, `reth0`,
+`reth0.50`, `reth0.80`), so `length >= 4` is a meaningful gate.
+Pre-fix, the JSON has every row but only `lo`-style rows (none
+in the cfg) would have ifindex > 0; post-fix all configured
+rows have ifindex > 0.
+
+Per-class CoS smoke is not affected by this change but still
+runs to satisfy refactor protocol.
+
+## Public API preservation
+
+- `interfacesHandler` JSON shape: unchanged. `name`, `ifindex`,
+  `zone`, counters — same fields, just correctly populated.
+- `writeInterfacesDetail` text output: unchanged for any interface
+  whose Junos name was already a valid Linux ifname (`em0`, `fxp0`,
+  `lo`). For names with `/` or RETH aliases, "Not present" is
+  replaced with the populated form — fixing the symptom.
+- `ifaceStatsHandler`: same JSON shape; rows that were previously
+  silently dropped now appear.
+- Prometheus metrics: `xpf_iface_packets_total{interface="ge-0/0/0",direction="rx"}`
+  is now emitted (was missing). Label is the **Junos** name (the
+  ifName from cfg loop). This matches existing label usage —
+  operators query by Junos name.
+
+## Hidden invariants the change must preserve
+
+1. **JSON `name` label stays as the Junos config name.** Operators
+   query by `ge-0/0/0`, not `ge-0-0-0`. The kernel form is an
+   implementation detail used only for kernel-side lookups.
+2. **Prometheus label stays as Junos name.** Same reason. Changing
+   the label would break dashboards.
+3. **DHCP lease key form.** The daemon writes lease keys as
+   `LinuxIfName(ifName)[.VLAN]` (verified at
+   `pkg/daemon/daemon_dhcp.go:56-95`). The API lookup must use
+   the same form. `ResolveReth` is a no-op for non-RETH names
+   so it doesn't disturb the DHCP key on, say, `ge-0/0/0.80`.
+4. **No mutation of `allInterfaceNames` output.** That function
+   is shared with the terse handler; mutating its semantics would
+   ripple. The fix is confined to the per-iteration translation.
+5. **No new allocations on hot paths.** This is control plane —
+   irrelevant — but worth stating for the reviewer who checks.
+6. **Lookup failure must remain non-fatal** (no 500). Operators
+   bring interfaces up/down; transient absence is normal.
+7. **Behavior on names that happen to contain `/` but aren't reth
+   aliases** must still go through `LinuxIfName`. `ResolveReth`
+   returns input unchanged when no RETH match; then `LinuxIfName`
+   replaces `/` with `-`. Composition order matters and is
+   documented in the helper.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Pure additive translation. Non-`/`, non-RETH names (e.g. `em0`, `fxp0`, `lo`) are unchanged by `LinuxIfName(ResolveReth(name))` — both helpers are identity for such names. |
+| Lifetime / borrow-checker | N/A | Go, no borrow checker. No new shared state. |
+| Performance regression | NIL | Control-plane code path. `LinuxIfName` is `strings.ReplaceAll`; `ResolveReth` builds a small map from `c.Interfaces.Interfaces` — already called by grpcapi peers many times per request. |
+| Architectural mismatch (#961/#946-Phase-2) | NIL | This is a 1-line-per-site bug fix using a pre-existing helper. No new abstraction. |
+
+## Test plan
+
+- [ ] `go vet ./...` clean
+- [ ] `go test ./pkg/api/... ./pkg/config/... ./pkg/grpcapi/...` pass
+- [ ] new `TestKernelIfName_*` pass (5x flake check)
+- [ ] full Go test suite: 30 packages pass
+- [ ] cluster deploy on loss userspace cluster
+- [ ] Pass A — CoS disabled — v4 + v6 × push + reverse + 12-stream reverse, 0 retrans
+- [ ] Pass B — Per-class CoS — 5201-5206 × v4/v6 × push/reverse
+- [ ] **Targeted check:** `curl /interfaces | jq` returns rows with
+      `ifindex > 0` for `ge-0/0/0`, `reth0`, `reth0.50`, `reth0.80`
+- [ ] **Targeted check:** `curl /metrics | grep xpf_iface_packets_total | grep 'ge-0/0/0'` returns lines (pre-fix: empty)
+- [ ] **Targeted check:** `cli> show interfaces detail ge-0/0/0`
+      does not print "Not present"
+
+## Out of scope (explicitly)
+
+- **grpcapi peer fixes.** The peer file `pkg/grpcapi/server_show_interfaces.go`
+  has a similar bug on lines 31-46 (the `ShowInterfaces` RPC), which
+  feeds the CLI `show interfaces` listing. The issue body lists only
+  the four `pkg/api/` sites. Fixing grpcapi belongs to a separate
+  issue — same translation pattern but different test surface (gRPC
+  vs HTTP). If the reviewers want it folded in, the diff is small
+  enough; opening the door but defaulting to scoped.
+- **DHCP key normalization.** Could push the `LinuxIfName` translation
+  inside `LeaseFor` so callers never have to think about it. Out of
+  scope — the daemon already writes keys consistently and other
+  callers (grpcapi) already translate at the call site. Centralizing
+  is a refactor, not a fix.
+- **Stats endpoint semantics change.** Whether `/iface-stats` should
+  include zero-counter rows for unrenamed interfaces vs. dropping
+  them silently is a UX call. Keep current (drop) — different change.
+- **Error-handling escalation.** No 500s, no log-spam. Same as now.
+
+## Open questions for adversarial review
+
+1. **Is `ResolveReth` correct for the cluster-peer case?** On node 0
+   `reth0` resolves to (e.g.) `ge-0/0/2`; on node 1 the same reth
+   resolves to `ge-7/0/2`. The peer node's physical member has no
+   kernel ifindex on this node. `kernelIfName(cfg, "reth0")` will
+   return e.g. `ge-7-0-2` on node 0 — which won't exist locally —
+   and the lookup will fail. Is "fail with ifindex=0" the right
+   behavior? (My answer: yes, same as today, but flag for review.)
+2. **VLAN suffix handling for non-RETH:** does
+   `LinuxIfName("ge-0/0/0.80")` actually produce `ge-0-0-0.80`?
+   (Quick check: yes — `ReplaceAll` only touches `/`, not `.`.)
+3. **Test coverage for `writeInterfacesDetail` DHCP lease path.**
+   Worth a Server-level integration test that runs a real DHCP
+   manager with a pre-installed lease and asserts the detail
+   output contains the lease? Or is the unit test of the helper
+   sufficient given the daemon's keying contract?
+4. **Should the fix also handle `fab0`/`fab1` overlay names?**
+   `ResolveFab` exists. Same bug class. The issue body doesn't
+   mention fabric — but operators may put fab names in
+   `interfaces { }`. Worth resolving in this PR or deferring?
+5. **Why not a centralized helper that returns ifindex directly?**
+   E.g. `cfg.IfindexFor(ifName) (int, bool)`. Cleaner caller code,
+   but adds API to `config` package. Asking reviewers whether the
+   indirection is worth it for 4 sites.
+6. **Should `interfacesHandler` skip the row when the kernel lookup
+   fails on a config name that doesn't exist locally** (e.g. peer's
+   RETH member) instead of returning ifindex=0? Today it includes.
+   Changing this is a JSON-shape regression I'd rather not gamble
+   on without operator input.
+7. **Are there other `pkg/api/` sites that should fold in?**
+   Quick grep: zone counters key by zoneName not ifName; policy
+   counters key by zone-pair; filter counters key by filter name.
+   No other `InterfaceByName` callers in `pkg/api/` per the grep
+   in step 1 above. Confirm.
+
+## Procedure (sketch)
+
+1. Add `kernelIfName` helper in `pkg/api/api.go`.
+2. Rewrite the 4 sites.
+3. Replace bare `ifName` references in `/sys/class/net/...` and
+   `LeaseFor(...)` paths inside `writeInterfacesDetail` with the
+   resolved kernel name (for sys) and the `LinuxIfName(...)+.VLAN`
+   form (for DHCP — the daemon's exact construction).
+4. Add tests.
+5. Smoke per protocol. Per-class CoS smoke required.
+6. PR with `Closes #1565`.

--- a/docs/pr/1565-iface-name-translate/plan.md
+++ b/docs/pr/1565-iface-name-translate/plan.md
@@ -1,6 +1,6 @@
 # #1565 — pkg/api: translate Junos config names to Linux ifnames before net.InterfaceByName
 
-**Status:** DRAFT v5 — addressing Codex round-4 PLAN-NEEDS-MAJOR + AGY round-4 PLAN-NEEDS-MINOR
+**Status:** PLAN-READY v6 — Codex round-5 PLAN-NEEDS-MINOR, AGY round-5 PLAN-READY; v6 closes 4 minors (stale fab text, drift-guard nil-unit, redundant-parent grammar, Atoi error fallback)
 
 ## Round-4 verdicts
 
@@ -277,7 +277,12 @@ func (c *Config) ResolveKernelIfName(ref string) string {
     }
 
     // Look up the unit by parsed number on the base interface.
-    unitNum, _ := strconv.Atoi(parts[1])
+    // Bail to fallback if the suffix isn't numeric (malformed ref
+    // like "ge-0/0/0.foo" must not silently map to unit 0).
+    unitNum, err := strconv.Atoi(parts[1])
+    if err != nil {
+        return LinuxIfName(c.ResolveReth(ref))
+    }
     if c.Interfaces.Interfaces == nil {
         return LinuxIfName(c.ResolveReth(ref))
     }
@@ -568,9 +573,10 @@ CoS per-class smoke runs per protocol.
      `reth0.80` (unit 80 vlan-id 180) → `ge-0-0-2.180`.
      This is the case that distinguishes v3-broken from v4-fixed.
    Repeat node 1 with member `ge-7/0/2` → `ge-7-0-2`.
-3. `TestResolveKernelIfName_Fab` — `fab0`→`fab0`, `fab0.0`→`fab0.0`
-   (kernel IPVLAN devices, NOT resolved to parent). **Corrected
-   in v4** — v3 plan wrongly expected `ge-0-0-7`.
+3. `TestResolveKernelIfName_Fab` — `fab0`→`fab0`, `fab0.0`→`fab0`
+   (unit 0 collapses; kernel IPVLAN is the bare name). `fab1`→`fab1`.
+   Kernel IPVLAN devices are NOT resolved to parent. (v3→v4→v5
+   corrections; v6 is the consistent shape.)
 4. `TestResolveKernelIfName_Tunnel` — `gr-0/0/0.0`→`gr-0-0-0`,
    `gr-0/0/0.1`→`gr-0-0-0u1` (per-unit `unit.Tunnel.Name`).
 5. `TestResolveKernelIfName_TunnelOverridesVlan` — interface
@@ -608,9 +614,12 @@ shape (Codex round-3 follow-up):
 `pkg/api/interfaces_test.go`:
 
 12. `TestInterfacesHandler_ResolvesRethToLoopback` — synthesize a
-    Junos cfg where `reth0` has a `redundant-parent` from a
-    physical member literally named `lo` (e.g. configure
-    `lo { redundant-parent reth0; }` plus `reth0`). After
+    Junos cfg where `reth0` has a physical member literally named
+    `lo` (e.g. configure
+    `lo { gigether-options { redundant-parent reth0; } }` plus
+    `reth0`; bare `redundant-parent` does NOT populate
+    `InterfaceConfig.RedundantParent` — must be inside
+    `gigether-options`). After
     compilation, `cfg.ResolveReth("reth0")` returns `"lo"`. Call
     `interfacesHandler` and assert the JSON row for `name=reth0`
     has `ifindex == net.InterfaceByName("lo").Index` (the only
@@ -629,14 +638,42 @@ shape (Codex round-3 follow-up):
 `pkg/dataplane/userspace/interfaces_test.go` (AGY drift-guard):
 
 14. `TestResolveKernelIfName_DriftGuardVsSnapshotLinuxName` —
-    construct a Config covering RETH+VLAN, plain physical w/
-    vlan-id, interface-level + per-unit tunnels, IRB, bare
-    non-reth. For each case, iterate the cfg and call BOTH
-    `snapshotLinuxName(cfg, ifName, iface, unit)` and
-    `cfg.ResolveKernelIfName(fmt.Sprintf("%s.%d", ifName, unit.Number))`,
-    asserting equality. Lives in `userspace_test.go` so the
-    private helper is in scope. Permits explicit `t.Skipf` on
-    deliberate semantic deltas if any emerge later.
+    parity test between `snapshotLinuxName` and the new public
+    helper for matching inputs. Must cover every
+    `snapshotLinuxName` branch:
+      - `iface == nil` path (bare ref, no cfg entry).
+      - bare reth (reth0 only, no unit).
+      - bare non-reth (em0, ge-0/0/0).
+      - tunnel-map hit (gr-0/0/0.0 with interface-level tunnel).
+      - VLAN positive (reth0.50 with vlan-id 50; ge-0/0/0.80
+        with vlan-id 180).
+      - reth unit 0 (reth0.0 with no vlan).
+      - reth nonzero no-VLAN unit (synthetic).
+      - non-reth unit 0 (ge-0/0/0.0 with no vlan).
+      - non-reth nonzero no-VLAN unit.
+
+    **Test setup detail** (Codex+AGY catch — avoid nil panic):
+    ```go
+    var ref string
+    if unit == nil {
+        ref = ifName
+    } else {
+        ref = fmt.Sprintf("%s.%d", ifName, unit.Number)
+    }
+    got := cfg.ResolveKernelIfName(ref)
+    want := snapshotLinuxName(cfg, ifName, iface, unit)
+    if got != want {
+        t.Errorf("Mismatch for ref %q: got %q, want %q", ref, got, want)
+    }
+    ```
+
+    **IRB is EXCLUDED from this parity test.** `snapshotLinuxName`
+    does not implement IRB (returns `LinuxIfName("irb")` = `"irb"`),
+    but the new helper resolves via `IRBToBridge` to `br-bd0`.
+    IRB is covered by Test #6 against the new helper directly.
+
+    Lives in `pkg/dataplane/userspace/interfaces_test.go` so the
+    private `snapshotLinuxName` is in scope.
 
 5x flake check on the named tests.
 

--- a/docs/pr/1565-iface-name-translate/plan.md
+++ b/docs/pr/1565-iface-name-translate/plan.md
@@ -1,6 +1,38 @@
 # #1565 — pkg/api: translate Junos config names to Linux ifnames before net.InterfaceByName
 
-**Status:** DRAFT v4 — addressing Codex round-3 PLAN-NEEDS-MAJOR (AGY round-3 returned PLAN-NEEDS-MINOR, overlapping fixes)
+**Status:** DRAFT v5 — addressing Codex round-4 PLAN-NEEDS-MAJOR + AGY round-4 PLAN-NEEDS-MINOR
+
+## Round-4 verdicts
+
+- **Codex** task-mpniviw3-vu39r2: PLAN-NEEDS-MAJOR. Remaining:
+  - `fab0.0` test expectation contradicts the helper. fab0 has
+    unit 0 in cfg; helper hits the `unit.Number == 0` collapse and
+    returns `fab0`, not `fab0.0`. `daemon_apply.go:317` creates
+    the bare IPVLAN `fab0` and assigns unit-0 addresses to that
+    bare name — kernel device IS `fab0`, not `fab0.0`. v5 fixes
+    the test expectation to `fab0 -> fab0` and `fab0.0 -> fab0`.
+  - Smoke gate `ge-0/0/0` is not iterated. In the cluster cfg
+    `ge-0/0/0` only appears as a `member-interfaces` entry under
+    fab0 — stored in `FabricMembers`, not in
+    `cfg.Interfaces.Interfaces`. v5 drops `ge-0/0/0` from gates;
+    swap in `fab0` (real kernel IPVLAN, in zones).
+  - Lo API test still too weak — pre-fix `lo` already resolves
+    via raw `net.InterfaceByName(ifName)`. Need a synthetic
+    `reth0 → lo` config so the helper translation is required
+    for ifindex>0. v5 redesigns Test #12 accordingly.
+  - Interface-level tunnel test should mirror cluster shape
+    (gr-0/0/0 has only unit 0); keep per-unit `.1 -> u1` as
+    separate test on a synthetic cfg.
+  - Plan text said `reth0.80 vlan-id 180` — cluster cfg uses
+    `vlan-id 80`. v5 fixes doc text.
+  - NOTE drift comments are not enforceable — recommended
+    PLAN-NEEDS-MINOR for a sync-test.
+- **AGY** review-mpnivrgz-5a90u7: PLAN-NEEDS-MINOR. Identical
+  ge-0/0/0/fab0 catch + dedicated drift-guard test
+  (`TestResolveKernelIfName_DriftGuard` in
+  `pkg/dataplane/userspace/interfaces_test.go` asserting parity
+  with `snapshotLinuxName` for core types) + nil-guard for
+  `c.Interfaces.Interfaces`.
 
 ## Round-3 verdicts (round-3 archived)
 
@@ -246,6 +278,9 @@ func (c *Config) ResolveKernelIfName(ref string) string {
 
     // Look up the unit by parsed number on the base interface.
     unitNum, _ := strconv.Atoi(parts[1])
+    if c.Interfaces.Interfaces == nil {
+        return LinuxIfName(c.ResolveReth(ref))
+    }
     if ifc, ok := c.Interfaces.Interfaces[base]; ok && ifc != nil {
         if unit, ok := ifc.Units[unitNum]; ok && unit != nil {
             if unit.Tunnel != nil && unit.Tunnel.Name != "" {
@@ -444,16 +479,22 @@ Cluster cfg names that flow through `allInterfaceNames`:
 - From zone `interfaces { ... }` lists: `fxp0`, `em0`, `fab0`, `fab1`,
   `reth0.50`, `reth0.80`, `gr-0/0/0.0`, `reth1`.
 
-Slash-or-virtual rows the fix must populate ifindex>0 for:
-`ge-0/0/0`, `ge-0/0/1`, `ge-0/0/2`, `reth0`, `reth0.50`, `reth0.80`,
-`reth1`, `gr-0/0/0.0`. (`reth1.0` is NOT in any zone/top-level
-iteration — drop from gate.)
+Slash-or-virtual rows the fix must populate ifindex>0 for. `ge-0/0/0`
+is NOT in this list because it only appears as fab0's
+`member-interfaces` in the cluster cfg — stored in `FabricMembers`,
+not as a `cfg.Interfaces.Interfaces` key (per
+`pkg/config/compiler_interfaces.go:111`), so `allInterfaceNames`
+doesn't iterate it. v5 gate uses `fab0` (real kernel IPVLAN, top-level
++ zone-listed) in its place.
+
+Gate names: `ge-0/0/1`, `ge-0/0/2`, `reth0`, `reth0.50`, `reth0.80`,
+`reth1`, `fab0`, `gr-0/0/0.0`.
 
 ```bash
 sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
   set -e
   J=$(curl -s http://127.0.0.1:8080/interfaces)
-  for n in ge-0/0/0 ge-0/0/1 ge-0/0/2 reth0 reth0.50 reth0.80 reth1 gr-0/0/0.0; do
+  for n in ge-0/0/1 ge-0/0/2 reth0 reth0.50 reth0.80 reth1 fab0 gr-0/0/0.0; do
     ix=$(echo \"$J\" | jq -r --arg n \"$n\" \".data | map(select(.name == \\$n)) | .[0].ifindex // 0\")
     if [ \"$ix\" = \"0\" ]; then
       echo \"FAIL: $n ifindex=0 post-fix\"; exit 1
@@ -467,7 +508,7 @@ sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
 sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
   set -e
   M=$(curl -s http://127.0.0.1:8080/metrics)
-  for n in ge-0/0/0 ge-0/0/1 ge-0/0/2 reth0 reth0.50 reth0.80 reth1; do
+  for n in ge-0/0/1 ge-0/0/2 reth0 reth0.50 reth0.80 reth1 fab0; do
     echo \"$M\" | grep -F \"xpf_iface_packets_total\" | grep -F \"interface=\\\"$n\\\"\" || {
       echo \"FAIL: no Prometheus series for $n\"; exit 1
     }
@@ -518,10 +559,15 @@ CoS per-class smoke runs per protocol.
 
 1. `TestResolveKernelIfName_Plain` — `em0`, `fxp0`, `lo`, `ge-0/0/0`,
    `ge-0/0/0.80` (vlan-id 180) → `ge-0-0-0.180`.
-2. `TestResolveKernelIfName_Reth` — node 0 `reth0`→`ge-0-0-2`,
-   `reth0.0` (unit 0 vlan-id 0) → `ge-0-0-2`,
-   `reth0.50` (unit 50 vlan-id 50) → `ge-0-0-2.50`,
-   `reth0.80` (unit 80 vlan-id 180) → `ge-0-0-2.180`. Repeat node 1.
+2. `TestResolveKernelIfName_Reth` — node 0:
+   - `reth0`→`ge-0-0-2`
+   - `reth0.0` (cfg unit 0 vlan-id 0) → `ge-0-0-2`
+   - `reth0.50` (unit 50 vlan-id 50, matching the real cluster
+     cfg) → `ge-0-0-2.50`
+   - **Asymmetric case (synthetic, not cluster cfg):**
+     `reth0.80` (unit 80 vlan-id 180) → `ge-0-0-2.180`.
+     This is the case that distinguishes v3-broken from v4-fixed.
+   Repeat node 1 with member `ge-7/0/2` → `ge-7-0-2`.
 3. `TestResolveKernelIfName_Fab` — `fab0`→`fab0`, `fab0.0`→`fab0.0`
    (kernel IPVLAN devices, NOT resolved to parent). **Corrected
    in v4** — v3 plan wrongly expected `ge-0-0-7`.
@@ -555,28 +601,42 @@ shape (Codex round-3 follow-up):
     `st0.5`, `st1`→`st1`. Confirms st* short-circuit.
 
 11. `TestResolveKernelIfName_FabIsKernelDevice` — `fab0`→`fab0`,
-    `fab0.0`→`fab0.0` (IPVLAN overlay names are real kernel
-    devices; do NOT resolve to parent).
+    `fab0.0`→`fab0` (unit 0 collapse: kernel IPVLAN device is the
+    bare `fab0` name per `daemon_apply.go:317`; do NOT resolve to
+    parent). `fab1`→`fab1`.
 
 `pkg/api/interfaces_test.go`:
 
-12. `TestInterfacesHandler_ResolvesSlashName` — cfg names
-    `lo-0/0/0` as a fake interface that we ALSO add to
-    cfg.Interfaces.Interfaces. Then assert: pre-fix-equivalent
-    behavior (raw lookup of `lo-0/0/0` fails, ifindex=0) vs
-    post-fix behavior (helper translates to `lo-0-0-0` which
-    also doesn't exist on the test runner → still ifindex=0).
-    Net: the test asserts the row is present with correct
-    `name` label whether or not ifindex resolves. **Stronger
-    coverage:** cfg.Interfaces.Interfaces with key `whatever`
-    where we KNOW the kernel has `lo`: declare the cfg key
-    as `lo` literally and verify ifindex matches the loopback
-    `net.InterfaceByName("lo").Index`. (Loopback is the only
-    interface guaranteed to exist on every Linux test runner.)
+12. `TestInterfacesHandler_ResolvesRethToLoopback` — synthesize a
+    Junos cfg where `reth0` has a `redundant-parent` from a
+    physical member literally named `lo` (e.g. configure
+    `lo { redundant-parent reth0; }` plus `reth0`). After
+    compilation, `cfg.ResolveReth("reth0")` returns `"lo"`. Call
+    `interfacesHandler` and assert the JSON row for `name=reth0`
+    has `ifindex == net.InterfaceByName("lo").Index` (the only
+    netdev guaranteed to exist on any Linux test runner). This
+    proves the translation is exercised — pre-fix the raw lookup
+    `net.InterfaceByName("reth0")` would fail and ifindex=0;
+    post-fix `ResolveKernelIfName("reth0") = "lo"` succeeds.
+    Existing pkg/api scaffolding (Server, configstore.New,
+    LoadOverride/Commit, httptest) supports this — see any
+    `pkg/api/*_test.go` for the pattern.
 13. `TestWriteInterfacesDetail_DHCPLeasePath` — seed a lease keyed
     `reth0.50`, cfg `reth0 { unit 50 { vlan-id 50; dhcp } }`,
     assert output contains `DHCPv4: <addr> (gw <gw>)`. This is the
     end-to-end test of the DHCPLeaseKey + LeaseFor + format path.
+
+`pkg/dataplane/userspace/interfaces_test.go` (AGY drift-guard):
+
+14. `TestResolveKernelIfName_DriftGuardVsSnapshotLinuxName` —
+    construct a Config covering RETH+VLAN, plain physical w/
+    vlan-id, interface-level + per-unit tunnels, IRB, bare
+    non-reth. For each case, iterate the cfg and call BOTH
+    `snapshotLinuxName(cfg, ifName, iface, unit)` and
+    `cfg.ResolveKernelIfName(fmt.Sprintf("%s.%d", ifName, unit.Number))`,
+    asserting equality. Lives in `userspace_test.go` so the
+    private helper is in scope. Permits explicit `t.Skipf` on
+    deliberate semantic deltas if any emerge later.
 
 5x flake check on the named tests.
 
@@ -624,5 +684,8 @@ shape (Codex round-3 follow-up):
 4. Add 11 helper unit tests in `pkg/config/types_test.go`.
 5. Rewrite the 4 pkg/api sites.
 6. Add 2 handler tests in `pkg/api/interfaces_test.go`.
-7. Smoke per protocol with v4 named-row gates.
-8. PR with `Closes #1565`.
+7. Add 1 drift-guard test in
+   `pkg/dataplane/userspace/interfaces_test.go` asserting parity
+   with `snapshotLinuxName`.
+8. Smoke per protocol with v5 named-row gates.
+9. PR with `Closes #1565`.

--- a/docs/pr/1565-iface-name-translate/plan.md
+++ b/docs/pr/1565-iface-name-translate/plan.md
@@ -1,346 +1,420 @@
 # #1565 — pkg/api: translate Junos config names to Linux ifnames before net.InterfaceByName
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** DRAFT v2 — addressing Codex + AGY round-1 PLAN-NEEDS-MAJOR
 
-## Issue framing
+## Round-1 verdicts (round-1 archived)
 
-Pre-existing bug surfaced by Copilot inline review on PR #1564 (the
-`#1540` REST API split). Four call sites in `pkg/api/` call
-`net.InterfaceByName(ifName)` directly with config-level interface
-names that may contain `/` (e.g. `ge-0/0/0`, `ge-0/0/0.80`) or be
-RETH aliases (`reth0`, `reth0.50`). Linux IFNAMSIZ forbids `/`, and
-RETH virtual names have no kernel ifindex, so these lookups fail
-silently and:
+- **Codex** task-mpnhxusx-4yz6hb: PLAN-NEEDS-MAJOR. Findings:
+  - Tunnel refs (`gr-0/0/0.0`, `gr-0/0/0.1`) are handled by
+    `(*Config).TunnelNameMap()` and do NOT round-trip through a naive
+    `LinuxIfName(ResolveReth(name))` composition. Unit 0 → base name,
+    unit N>0 → `<base>uN`.
+  - DHCP key claim was overbroad: keys are
+    `LinuxIfName(physName) + "." + strconv(unit.VlanID)` only when
+    `VlanID>0`, otherwise just `LinuxIfName(physName)`. The suffix in
+    the zone ref (`.80`, `.0`) does **not** necessarily equal the
+    VLAN tag. So `LeaseFor(kernelIfName(ifName))` only works when the
+    config name happens to end in the VLAN tag; for `ge-0/0/0.0` with
+    `vlan-id 80`, the lookup misses.
+  - grpcapi out-of-scope is defensible **only if** the plan stops
+    claiming any CLI smoke fix; CLI `show interfaces` routes through
+    grpcapi `ShowInterfaces`/`ShowInterfacesDetail`/`ShowText`.
+  - Tests are too thin for tunnel + VLAN-vs-unit-suffix cases.
+- **AGY** review-mpnhya9y-6rigyy: PLAN-NEEDS-MAJOR. Findings:
+  - Fold grpcapi sites in OR drop CLI smoke (same point as Codex).
+  - Centralize helper as `(*Config).ResolveJunosIfName(name)` in
+    `pkg/config/types.go` so `pkg/api` and `pkg/grpcapi` share it.
+  - Chain `ResolveFab` to cover `fab0[.unit]`.
+  - Add a `writeInterfacesDetail` integration test that mocks DHCP
+    manager + asserts the lease line is printed.
 
-1. Per-interface counters (`Ifindex`, RX/TX packets/bytes) come back
-   as zero in the REST `interfaces` view.
-2. `show interfaces` detail prints "Not present" for every
-   Junos-named interface, then skips MTU/MAC/addresses/DHCP lease.
-3. `/iface-stats` skips configured interfaces entirely (silent drop
-   from result set, not just zero counters).
-4. Per-interface Prometheus metrics (`xpf_iface_packets_total`,
-   `xpf_iface_bytes_total`) are simply not emitted for affected
-   interfaces — they appear missing from `/metrics` output.
+Round-1 verdicts and reviewer prompts are pinned at commit
+`e91b9650` (plan v1).
 
-The four sites are listed verbatim in the issue body:
+## Issue framing (unchanged from v1)
 
-- `pkg/api/interfaces.go:38` — `interfacesHandler` (JSON list)
-- `pkg/api/interfaces.go:224` — `writeInterfacesDetail` (text view)
-- `pkg/api/stats.go:70` — `ifaceStatsHandler` (typed JSON)
-- `pkg/api/metrics_counters.go:74` — Prometheus collector
+Pre-existing bug surfaced by Copilot inline review on PR #1564.
+Four call sites in `pkg/api/` call `net.InterfaceByName(ifName)`
+directly with config-level Junos interface names (`ge-0/0/0`,
+`reth0.50`, `fab0`, `gr-0/0/0.0`). These names violate Linux
+IFNAMSIZ (`/` is forbidden) or have no kernel ifindex
+(`reth`/`fab` are virtual config-only names). The lookups fail
+silently and break:
 
-The repo already ships the primitive: `config.LinuxIfName(name)`
-replaces `/` with `-`, and `cfg.ResolveReth(name)` resolves
-`reth0[.unit]` to the local physical member. Both are battle-tested
-in `pkg/config/compiler_interfaces.go`, `pkg/grpcapi/server_show_interfaces.go`,
-`pkg/grpcapi/server_cluster.go`, and the daemon's networkd path.
+1. Per-interface counters and `Ifindex` in the REST `interfaces`
+   view.
+2. `show interfaces` detail output (prints "Not present").
+3. `/iface-stats` typed JSON (rows silently dropped).
+4. Per-interface Prometheus metrics
+   (`xpf_iface_packets_total{interface="..."}` missing).
+
+Four sites verbatim from the issue body:
+
+- `pkg/api/interfaces.go:32` — `interfacesHandler`
+- `pkg/api/interfaces.go:210` — `writeInterfacesDetail`
+- `pkg/api/stats.go:64` — `ifaceStatsHandler`
+- `pkg/api/metrics_counters.go:68` — `collectInterfaceCounters`
+
+The three sites at `pkg/api/interfaces.go:107`, `:130`, `:163`
+inside `writeInterfacesTerse` are already correct — they call
+`config.LinuxIfName` on the physical-member name resolved
+through `RethToPhysical()`. Verified by read.
 
 ## Honest scope / value framing
 
-Bug fix on a control-plane observability surface. No hot-path
-cycles. No allocator pressure. No HA sync. No correctness risk
-to the dataplane. Win is qualitative: REST clients and Prometheus
-scrapers see real interface counters and the JSON Ifindex field is
-populated for every configured interface, not just for those whose
-Junos name happens to also be a valid Linux ifname (i.e. no `/`,
-not a reth alias).
+Control-plane observability bug fix. No hot path, no allocator,
+no HA sync, no dataplane correctness. Win is qualitative: REST
+clients and Prometheus scrapers see real counters; JSON
+`ifindex` is populated.
 
-If reviewers conclude the perf gain is too small to justify the
-churn, PLAN-KILL is an acceptable verdict. (The "perf gain" here
-is observability fidelity, not throughput — PLAN-KILL would
-amount to "leave the broken handlers broken", which seems wrong
-for a fix tagged on a Copilot reviewer finding.)
+If reviewers conclude the work isn't worth the churn, PLAN-KILL
+is acceptable. (The bug is real and operator-visible; PLAN-KILL
+seems wrong but the explicit hook stays.)
 
 ## What's already shipped / partially fixed
 
-The grpcapi peer of these handlers (`pkg/grpcapi/server_show_interfaces.go`)
-already uses `config.LinuxIfName(...)` and `cfg.ResolveReth(...)` in
-several places — see:
+- `pkg/api/interfaces.go::writeInterfacesTerse` (lines 100-188):
+  already uses `physToReth`, `rethToPhys`, and `config.LinuxIfName`.
+  Correct.
+- `pkg/grpcapi/server_show_interfaces.go` uses `config.LinuxIfName`
+  in lines 502, 547, 586, 623-632 — but not at the top-level
+  `GetInterfaces` (line 31) and `ShowInterfacesDetail` physical
+  lookup (line 129). Out of scope for this PR per issue body;
+  filing a follow-up issue is required (see Out of scope).
+- `pkg/daemon/daemon_dhcp.go:56-95` builds DHCP keys as
+  `LinuxIfName(physName)` plus `"." + strconv.Itoa(unit.VlanID)`
+  when `unit.VlanID > 0`. **This is the canonical key form.**
+- `(*Config).TunnelNameMap()` at `pkg/config/types.go:1763` maps
+  `gr-0/0/0.0` → `gr-0-0-0` and `gr-0/0/0.1` → `gr-0-0-0u1`.
+- `(*Config).ResolveReth(ref)` + `(*Config).ResolveFab(ref)` at
+  `types.go:80,95` resolve aliases (and preserve `.unit` suffix).
 
-- `pkg/grpcapi/server_show_interfaces.go:502` — `kernelIf := config.LinuxIfName(statusIf)`
-- `pkg/grpcapi/server_show_interfaces.go:547` — `kernelIf := config.LinuxIfName(u.physName)`
-- `pkg/grpcapi/server_show_interfaces.go:623-632` — VLAN-suffix composition
-- `pkg/grpcapi/server_cluster.go:45` — `linuxName := config.LinuxIfName(phys)`
-- `pkg/grpcapi/server_diag.go:312` — RETH/LinuxIfName composition
-- `pkg/grpcapi/server_sessions.go:325` — `cfg.ResolveReth(...)` + LinuxIfName
+## Concrete design (revised)
 
-`pkg/api/interfaces.go` is partially fixed: the `writeInterfacesTerse`
-function (lines 105-180) **already** uses `config.LinuxIfName` and
-`RethToPhysical()`. Only the non-terse `interfacesHandler` and
-`writeInterfacesDetail` halves regressed.
-
-The DHCP manager `LeaseFor()` keys by Linux name with VLAN suffix
-(`pkg/daemon/daemon_dhcp.go:56-95` builds `dhcpIface = LinuxIfName(ifName)` +
-optional `.VLAN`), so `LeaseFor(ifName, ...)` in `writeInterfacesDetail`
-also returns nil for any name with `/`. Same root cause.
-
-## Concrete design
-
-### Sites and fixes
-
-| File | Line | Current | Fix |
-|------|------|---------|-----|
-| `pkg/api/interfaces.go` | 32 | `iface, err := net.InterfaceByName(ifName)` | Compose `lookupName` via `config.LinuxIfName(cfg.ResolveReth(ifName))` (with VLAN-suffix preservation), then `net.InterfaceByName(lookupName)`. Print original `ifName` in JSON. |
-| `pkg/api/interfaces.go` | 210 | `iface, err := net.InterfaceByName(ifName)` | Same as above; also replace inline `/sys/class/net/`+`ifName` reads (line 220) with the resolved kernel name. DHCP lookup uses the LinuxIfName+VLAN form to match daemon's `dhcpIface` key. |
-| `pkg/api/stats.go` | 64 | `iface, err := net.InterfaceByName(ifName)` | Same translation. |
-| `pkg/api/metrics_counters.go` | 68 | `iface, err := net.InterfaceByName(ifName)` | Same translation. |
-
-### Helper
-
-Introduce one private helper in `pkg/api/api.go` next to
-`allInterfaceNames`:
+### Single new public helper in `pkg/config/types.go`
 
 ```go
-// kernelIfName returns the Linux kernel ifname for a config-level
-// interface name. It resolves reth aliases to the local physical
-// member (preserving any .unit suffix) then translates "/" to "-"
-// to satisfy IFNAMSIZ. The returned name is suitable for
-// net.InterfaceByName, /sys/class/net, and DHCP lease lookups (the
-// daemon DHCP client keys by this same form).
-func kernelIfName(cfg *config.Config, ifName string) string {
-    return config.LinuxIfName(cfg.ResolveReth(ifName))
+// ResolveJunosIfName converts a Junos-style config interface reference
+// (e.g. "ge-0/0/0.80", "reth0.50", "fab0.0", "gr-0/0/0.1") to the
+// Linux kernel ifname it should resolve to on the LOCAL node.
+//
+// Resolution order:
+//   1. Tunnel refs: if the ref is a key in TunnelNameMap(), return
+//      the tunnel's Linux name verbatim (covers "gr-0/0/0.0" → "gr-0-0-0"
+//      and "gr-0/0/0.1" → "gr-0-0-0u1"). Tunnel naming is per-unit and
+//      does NOT preserve the "." suffix, so this branch must short-circuit
+//      before LinuxIfName.
+//   2. RETH refs: ResolveReth(ref) maps "reth0[.unit]" → physical
+//      member "ge-X/0/Y[.unit]" using local-node scoring.
+//   3. Fabric refs: ResolveFab(ref) maps "fab0[.unit]" → the local
+//      fabric member from cfg.Interfaces.Interfaces[base].LocalFabricMember.
+//   4. LinuxIfName: replace "/" with "-".
+//
+// For all other refs (em0, fxp0, ge-0/0/0, ge-0/0/0.80) this reduces
+// to LinuxIfName(ref).
+//
+// Note: this returns the kernel link name. For DHCP lease lookups,
+// callers must instead build LinuxIfName(physName) + "." + VlanID,
+// which is the daemon's DHCP key form; that is NOT the same as the
+// link name. See DHCPLeaseKey below.
+func (c *Config) ResolveJunosIfName(ref string) string {
+    if tunMap := c.TunnelNameMap(); tunMap != nil {
+        if linuxName, ok := tunMap[ref]; ok {
+            return linuxName
+        }
+    }
+    resolved := c.ResolveReth(ref)
+    resolved = c.ResolveFab(resolved)
+    return LinuxIfName(resolved)
+}
+
+// DHCPLeaseKey returns the lease-lookup key that the DHCP manager
+// keys leases by for the given config interface name and unit number.
+// Mirrors the construction in pkg/daemon/daemon_dhcp.go: the key is
+// LinuxIfName(physName) plus ".<VlanID>" only when the unit's
+// VlanID > 0. Returns ("", false) when the config ref cannot be
+// resolved to a unit (caller should skip the lease line).
+func (c *Config) DHCPLeaseKey(ifName string, unitNum int) (string, bool) {
+    physRef := strings.SplitN(ifName, ".", 2)[0]
+    ifc, ok := c.Interfaces.Interfaces[physRef]
+    if !ok {
+        return "", false
+    }
+    unit, ok := ifc.Units[unitNum]
+    if !ok {
+        return "", false
+    }
+    key := LinuxIfName(physRef)
+    if unit.VlanID > 0 {
+        key = key + "." + strconv.Itoa(unit.VlanID)
+    }
+    return key, true
 }
 ```
 
-`ResolveReth` already preserves `.unit`, so a config name like
-`reth0.50` round-trips to e.g. `ge-0-0-2.50` on node-0 of the loss
-cluster. For non-reth names with VLAN units the input is already
-in `ge-0/0/0.80` form, which becomes `ge-0-0-0.80`.
+These two helpers exactly mirror the two distinct semantics that
+`pkg/daemon/daemon_dhcp.go:56-95` exposed:
 
-### Site rewrites
+- the **kernel link name** for `net.InterfaceByName` / sysfs;
+- the **DHCP lease key** for `dhcp.Manager.LeaseFor`.
 
-`interfacesHandler` (line 32):
+Conflating them was the round-1 plan's mistake.
+
+### Call-site rewrites
+
+The four pkg/api sites all need the kernel link name. They use the
+ref iterated from `allInterfaceNames(cfg)` (which contains raw cfg
+keys + raw zone refs).
+
+#### `pkg/api/interfaces.go:32` `interfacesHandler`
 
 ```go
 for ifName := range allInterfaceNames(cfg) {
-    iface, err := net.InterfaceByName(kernelIfName(cfg, ifName))
+    iface, err := net.InterfaceByName(cfg.ResolveJunosIfName(ifName))
     is := InterfaceStats{
-        Name: ifName,                // unchanged — Junos label
+        Name: ifName,                    // Junos label, unchanged
         Zone: ifZone[ifName],
     }
     if err == nil {
         is.Ifindex = iface.Index
-        // counters as before
+        if s.dp != nil && s.dp.IsLoaded() {
+            if ctrs, err := s.dp.ReadInterfaceCounters(iface.Index); err == nil {
+                is.RxPackets, is.RxBytes = ctrs.RxPackets, ctrs.RxBytes
+                is.TxPackets, is.TxBytes = ctrs.TxPackets, ctrs.TxBytes
+            }
+        }
     }
     result = append(result, is)
 }
 ```
 
-`writeInterfacesDetail` (line 210): same translation. Crucially,
-replace **all** subsequent uses of `ifName` as a kernel path —
-specifically the `/sys/class/net/<ifName>/operstate` read on
-line 220, and the DHCP `LeaseFor(ifName, ...)` calls on lines
-253 and 256.
+#### `pkg/api/interfaces.go:210` `writeInterfacesDetail`
 
-The DHCP key form is `dhcpIface` from `daemon_dhcp.go` line 59:
-`config.LinuxIfName(ifName)` plus `".%d"` when `unit.VlanID > 0`.
-So for a config name like `ge-0/0/0` with unit 0 vlan 80, the
-DHCP key is `ge-0-0-0.80`. The detail handler iterates
-`allInterfaceNames` which already returns the dotted form (e.g.
-`ge-0/0/0.80`) from zone references, so passing
-`kernelIfName(cfg, ifName)` is sufficient.
+Two distinct translations needed:
 
-`ifaceStatsHandler` (line 64) and `collectInterfaceCounters` (line
-68): identical translation. Both still `continue` on lookup
-failure (preserving current "skip unknown" semantics) — see the
-error-handling decision below.
+- **kernel link name** for `net.InterfaceByName` AND
+  `/sys/class/net/<name>/operstate`.
+- **DHCP lease key** for `s.dhcp.LeaseFor(...)`.
 
-### Error-handling semantics
+The current code uses `ifName` (the Junos ref) for both. The
+revised code computes:
 
-Three plausible behaviors when `net.InterfaceByName` fails:
+```go
+for _, ifName := range ifNames {
+    kernel := cfg.ResolveJunosIfName(ifName)
+    iface, err := net.InterfaceByName(kernel)
+    if err != nil {
+        fmt.Fprintf(&b, "Interface: %s, Not present\n\n", ifName)
+        continue
+    }
+    // ... print MTU/MAC/zone/BPF-counters as before, using `kernel`
+    //     for the /sys/class/net read.
 
-| Mode | interfacesHandler | writeInterfacesDetail | ifaceStatsHandler | metrics_counters |
-|------|--------------------|-----------------------|--------------------|------------------|
-| current | include with zero ifindex | print "Not present" | skip | skip |
-| log+skip | same + slog.Debug | same + slog.Debug | same + slog.Debug | same + slog.Debug |
-| 500 the handler | no | no | no | no |
+    // DHCP lease annotation — use the daemon's DHCP key shape.
+    if s.dhcp != nil {
+        base := strings.SplitN(ifName, ".", 2)[0]
+        unitNum := 0
+        if parts := strings.SplitN(ifName, ".", 2); len(parts) == 2 {
+            fmt.Sscanf(parts[1], "%d", &unitNum)
+        }
+        if key, ok := cfg.DHCPLeaseKey(base, unitNum); ok {
+            if lease := s.dhcp.LeaseFor(key, dhcp.AFInet); lease != nil {
+                fmt.Fprintf(&b, "  DHCPv4: %s (gw %s)\n", lease.Address, lease.Gateway)
+            }
+            if lease := s.dhcp.LeaseFor(key, dhcp.AFInet6); lease != nil {
+                fmt.Fprintf(&b, "  DHCPv6: %s (gw %s)\n", lease.Address, lease.Gateway)
+            }
+        }
+    }
+    b.WriteString("\n")
+}
+```
 
-**Decision:** keep current per-site semantics (each handler already
-made a deliberate choice — listing-style endpoints include the row
-with zero counters, stats endpoints drop unknown rows, Prometheus
-skips the metric). Add `slog.Debug` for visibility but never escalate
-to `slog.Info` or to a 500 — admin-down or not-yet-renamed interfaces
-are a normal transient on boot and on RETH member flips.
+This is the only site that needs the DHCP key shape. The other
+three pkg/api sites only need the kernel link name.
 
-This matches the grpcapi peer's behavior at
-`server_show_interfaces.go:31-46` (`err == nil` guards counters,
-ifindex stays unpopulated). No 500.
+#### `pkg/api/stats.go:64` and `pkg/api/metrics_counters.go:68`
 
-### Tests
+Identical 1-line translation: replace `net.InterfaceByName(ifName)`
+with `net.InterfaceByName(cfg.ResolveJunosIfName(ifName))`.
 
-Add a single new test file `pkg/api/iface_name_test.go`. Three tests:
+### Resolution-order rationale
 
-1. **`TestKernelIfName_TranslatesSlash`** — config name `ge-0/0/0`
-   produces `ge-0-0-0`; with unit/VLAN `.80` produces `ge-0-0-0.80`.
-   No live netlink — pure config helper test.
+Tunnel-first matters because `gr-0/0/0.1` is a key in TunnelNameMap
+but `.1` is the unit number (not a VLAN tag), and the Linux ifname
+is `gr-0-0-0u1` — neither LinuxIfName nor ResolveReth/ResolveFab
+would produce that. Putting tunnel resolution after the others
+would yield `gr-0-0-0.1`, which doesn't exist on the kernel.
 
-2. **`TestKernelIfName_ResolvesReth`** — given a cfg with
-   `interfaces { ge-0/0/0 { redundant-parent reth0 }; reth0; }`
-   on node 0, `kernelIfName(cfg, "reth0")` returns `ge-0-0-0`
-   and `kernelIfName(cfg, "reth0.50")` returns `ge-0-0-0.50`.
+RETH-then-Fab order matters because:
+- ResolveReth on a non-reth ref is identity.
+- ResolveFab on the (post-reth) ref is identity for non-fab refs.
 
-3. **`TestInterfacesHandler_PopulatesIfindexForLoopback`** —
-   spin up a Server with a cfg that names `lo` (a real Linux
-   ifname), call `interfacesHandler`, assert Ifindex > 0. Then
-   spin up a second Server with cfg-level name `ge-0/0/0` and
-   assert the JSON row is present with Ifindex == 0 (handler
-   doesn't 500, doesn't omit, and exercises the translation
-   code path even when the resolved name isn't present on the
-   test runner).
+LinuxIfName at the end is the catch-all `/` → `-` replacement.
 
-The third test exists to prove the **handler does not regress**
-on the no-such-interface path — not to assert positive ifindex
-for a name that won't be present in CI. Positive ifindex
-verification on real Junos names is the smoke step.
+### Error-handling semantics (unchanged)
+
+- listing-style handlers (`interfacesHandler`, `writeInterfacesDetail`):
+  include the row with ifindex=0 / "Not present", same as today.
+- stats/metrics handlers (`ifaceStatsHandler`, `collectInterfaceCounters`):
+  silently skip on lookup failure, same as today.
+- No 500s. Admin-down or peer-only refs are normal.
+
+### Tests (revised — 6 unit tests + 1 integration)
+
+`pkg/config/types_test.go` (helper unit tests):
+
+1. **`TestResolveJunosIfName_Plain`** — `em0`→`em0`, `fxp0`→`fxp0`,
+   `ge-0/0/0`→`ge-0-0-0`, `ge-0/0/0.80`→`ge-0-0-0.80`.
+2. **`TestResolveJunosIfName_Reth`** — given a cfg with
+   `reth0` and physical member `ge-0/0/2` on node 0,
+   `reth0`→`ge-0-0-2`, `reth0.50`→`ge-0-0-2.50`. Repeat for node 1
+   with `ge-7/0/2`.
+3. **`TestResolveJunosIfName_Fab`** — given a cfg with `fab0` whose
+   `LocalFabricMember="ge-0/0/0"`, `fab0`→`ge-0-0-0`,
+   `fab0.0`→`ge-0-0-0.0`.
+4. **`TestResolveJunosIfName_Tunnel`** — given a cfg with
+   interface-level tunnel on `gr-0/0/0` and units 0+1,
+   `gr-0/0/0.0`→`gr-0-0-0`, `gr-0/0/0.1`→`gr-0-0-0u1` (per-unit
+   tunnel with `unit.Tunnel.Name` set yields that name).
+5. **`TestDHCPLeaseKey_Mappings`** — cfg with `ge-0/0/0` unit 0
+   `vlan-id 0`, unit 1 `vlan-id 80`: `DHCPLeaseKey("ge-0/0/0", 0)` →
+   `("ge-0-0-0", true)`. `DHCPLeaseKey("ge-0/0/0", 1)` →
+   `("ge-0-0-0.80", true)`. `DHCPLeaseKey("ge-0/0/0", 99)` →
+   `("", false)`. Also exercises `reth0` cfg.
+
+`pkg/api/interfaces_test.go` (handler integration):
+
+6. **`TestInterfacesHandler_PopulatesIfindexForLoopback`** —
+   stand up a Server with cfg name `lo`; assert Ifindex > 0.
+7. **`TestWriteInterfacesDetail_DHCPLeasePath`** — stand up a
+   Server with a `dhcp.Manager` pre-populated with a lease
+   keyed `ge-0-0-0` (no VLAN); call `writeInterfacesDetail` for
+   cfg containing `ge-0/0/0`; assert output contains
+   `DHCPv4: <addr> (gw <gw>)`. This protects the DHCP lookup
+   path regression that prompted finding #2.
+
+`dhcp.Manager` is concrete: a test helper builds a `*Manager`
+with the lease pre-installed via the lowest-friction path
+(exported `New(...)` + a `setLeaseForTest` test-only setter
+or, if available, an existing constructor that accepts seeded
+leases). Implementation step will pick the minimum-touch route.
 
 ### Smoke verification
 
-Standard cluster smoke (loss userspace cluster). Plus one
-control-plane check that is targeted at this bug:
+Standard cluster smoke (loss userspace cluster) per protocol.
+
+**REST-only smoke targets** (no CLI claim — grpcapi is out of scope):
 
 ```bash
 sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
   curl -s http://127.0.0.1:8080/interfaces | \
-    jq -e \"map(select(.ifindex > 0)) | length >= 4\"
+    jq -e \"map(select(.ifindex > 0)) | length >= 3\"
 '"
+sg incus-admin -c "incus exec loss:xpf-userspace-fw0 -- bash -c '
+  curl -s http://127.0.0.1:8080/metrics | grep -E \"xpf_iface_packets_total.*ge-0/0/\"
+'" | head -3
 ```
 
-The cluster cfg names interfaces with `/` (`ge-0/0/0`, `reth0`,
-`reth0.50`, `reth0.80`), so `length >= 4` is a meaningful gate.
-Pre-fix, the JSON has every row but only `lo`-style rows (none
-in the cfg) would have ifindex > 0; post-fix all configured
-rows have ifindex > 0.
+The cluster cfg names: `ge-0/0/0` (fabric IPVLAN parent), `reth0`,
+`reth0.50`, `reth0.80`, `reth1`, `reth1.0`, etc. Length ≥ 3
+guarantees at least the slash-named base + reth aliases populate.
 
-Per-class CoS smoke is not affected by this change but still
-runs to satisfy refactor protocol.
+Pre-fix all slash-named rows have ifindex=0; post-fix
+`ge-0/0/0`, `reth0`, etc. have ifindex>0 (modulo peer-only
+members).
+
+CoS per-class smoke runs per protocol.
 
 ## Public API preservation
 
-- `interfacesHandler` JSON shape: unchanged. `name`, `ifindex`,
-  `zone`, counters — same fields, just correctly populated.
-- `writeInterfacesDetail` text output: unchanged for any interface
-  whose Junos name was already a valid Linux ifname (`em0`, `fxp0`,
-  `lo`). For names with `/` or RETH aliases, "Not present" is
-  replaced with the populated form — fixing the symptom.
-- `ifaceStatsHandler`: same JSON shape; rows that were previously
-  silently dropped now appear.
-- Prometheus metrics: `xpf_iface_packets_total{interface="ge-0/0/0",direction="rx"}`
-  is now emitted (was missing). Label is the **Junos** name (the
-  ifName from cfg loop). This matches existing label usage —
-  operators query by Junos name.
+- JSON `name` field: Junos config name (unchanged).
+- Prometheus `interface` label: Junos config name (unchanged —
+  operators query by Junos name).
+- `ifindex` field: was 0 for slash names, now populated. This is
+  the bug fix, not a regression.
+- `/iface-stats` rows: previously silently dropped slash-named
+  rows now appear. Same — bug fix.
+- "Not present" text in detail view: preserved for kernel-side
+  lookup failures (peer-only RETH member).
 
 ## Hidden invariants the change must preserve
 
-1. **JSON `name` label stays as the Junos config name.** Operators
-   query by `ge-0/0/0`, not `ge-0-0-0`. The kernel form is an
-   implementation detail used only for kernel-side lookups.
-2. **Prometheus label stays as Junos name.** Same reason. Changing
-   the label would break dashboards.
-3. **DHCP lease key form.** The daemon writes lease keys as
-   `LinuxIfName(ifName)[.VLAN]` (verified at
-   `pkg/daemon/daemon_dhcp.go:56-95`). The API lookup must use
-   the same form. `ResolveReth` is a no-op for non-RETH names
-   so it doesn't disturb the DHCP key on, say, `ge-0/0/0.80`.
-4. **No mutation of `allInterfaceNames` output.** That function
-   is shared with the terse handler; mutating its semantics would
-   ripple. The fix is confined to the per-iteration translation.
-5. **No new allocations on hot paths.** This is control plane —
-   irrelevant — but worth stating for the reviewer who checks.
-6. **Lookup failure must remain non-fatal** (no 500). Operators
-   bring interfaces up/down; transient absence is normal.
-7. **Behavior on names that happen to contain `/` but aren't reth
-   aliases** must still go through `LinuxIfName`. `ResolveReth`
-   returns input unchanged when no RETH match; then `LinuxIfName`
-   replaces `/` with `-`. Composition order matters and is
-   documented in the helper.
+1. JSON `name` and Prometheus label remain the Junos config name.
+2. DHCP lease key shape exactly matches `daemon_dhcp.go`:
+   `LinuxIfName(physName)[. VlanID-when-positive]`.
+3. Tunnel resolution short-circuits before LinuxIfName.
+4. RETH and Fabric resolution can compose without aliasing.
+5. Lookup failure stays non-fatal (no 500).
+6. `allInterfaceNames` output and shape unchanged.
+7. The helper is pure; no I/O, no kernel calls.
 
 ## Risk assessment
 
 | Class | Level | Notes |
 |-------|-------|-------|
-| Behavioral regression | LOW | Pure additive translation. Non-`/`, non-RETH names (e.g. `em0`, `fxp0`, `lo`) are unchanged by `LinuxIfName(ResolveReth(name))` — both helpers are identity for such names. |
-| Lifetime / borrow-checker | N/A | Go, no borrow checker. No new shared state. |
-| Performance regression | NIL | Control-plane code path. `LinuxIfName` is `strings.ReplaceAll`; `ResolveReth` builds a small map from `c.Interfaces.Interfaces` — already called by grpcapi peers many times per request. |
-| Architectural mismatch (#961/#946-Phase-2) | NIL | This is a 1-line-per-site bug fix using a pre-existing helper. No new abstraction. |
+| Behavioral regression | LOW | Pure additive translation; non-slash, non-RETH, non-fab, non-tunnel refs are identity. Tunnel resolution is short-circuit-by-map. |
+| Lifetime / borrow-checker | N/A | Go. |
+| Performance regression | NIL | Control plane only. TunnelNameMap allocates a small map each call — same cost as existing callers; cache out of scope. |
+| Architectural mismatch | LOW | Plan v2 centralizes the helper at pkg/config — the natural seam grpcapi already imports. |
 
 ## Test plan
 
 - [ ] `go vet ./...` clean
-- [ ] `go test ./pkg/api/... ./pkg/config/... ./pkg/grpcapi/...` pass
-- [ ] new `TestKernelIfName_*` pass (5x flake check)
-- [ ] full Go test suite: 30 packages pass
+- [ ] new `TestResolveJunosIfName_*` (4 tests) pass, 5x flake check
+- [ ] new `TestDHCPLeaseKey_Mappings` passes, 5x flake check
+- [ ] new `TestInterfacesHandler_PopulatesIfindexForLoopback` passes
+- [ ] new `TestWriteInterfacesDetail_DHCPLeasePath` passes
+- [ ] `go test ./pkg/api/... ./pkg/config/... ./pkg/grpcapi/... ./pkg/dhcp/...`
+- [ ] full Go suite passes
 - [ ] cluster deploy on loss userspace cluster
-- [ ] Pass A — CoS disabled — v4 + v6 × push + reverse + 12-stream reverse, 0 retrans
-- [ ] Pass B — Per-class CoS — 5201-5206 × v4/v6 × push/reverse
-- [ ] **Targeted check:** `curl /interfaces | jq` returns rows with
-      `ifindex > 0` for `ge-0/0/0`, `reth0`, `reth0.50`, `reth0.80`
-- [ ] **Targeted check:** `curl /metrics | grep xpf_iface_packets_total | grep 'ge-0/0/0'` returns lines (pre-fix: empty)
-- [ ] **Targeted check:** `cli> show interfaces detail ge-0/0/0`
-      does not print "Not present"
+- [ ] Pass A — CoS disabled v4/v6 × push/reverse + 12-stream reverse, 0 retrans
+- [ ] Pass B — Per-class CoS 5201-5206 × v4/v6 × push/reverse
+- [ ] REST `curl /interfaces | jq` returns ifindex>0 for ge-0/0/0 and reths
+- [ ] REST `curl /metrics | grep xpf_iface_packets_total | grep ge-0/0/` returns lines
 
 ## Out of scope (explicitly)
 
-- **grpcapi peer fixes.** The peer file `pkg/grpcapi/server_show_interfaces.go`
-  has a similar bug on lines 31-46 (the `ShowInterfaces` RPC), which
-  feeds the CLI `show interfaces` listing. The issue body lists only
-  the four `pkg/api/` sites. Fixing grpcapi belongs to a separate
-  issue — same translation pattern but different test surface (gRPC
-  vs HTTP). If the reviewers want it folded in, the diff is small
-  enough; opening the door but defaulting to scoped.
-- **DHCP key normalization.** Could push the `LinuxIfName` translation
-  inside `LeaseFor` so callers never have to think about it. Out of
-  scope — the daemon already writes keys consistently and other
-  callers (grpcapi) already translate at the call site. Centralizing
-  is a refactor, not a fix.
-- **Stats endpoint semantics change.** Whether `/iface-stats` should
-  include zero-counter rows for unrenamed interfaces vs. dropping
-  them silently is a UX call. Keep current (drop) — different change.
-- **Error-handling escalation.** No 500s, no log-spam. Same as now.
+- **grpcapi peer fixes** at `pkg/grpcapi/server_show_interfaces.go:31`
+  and `:129`. Same bug class, same helper would apply once shipped.
+  File a follow-up issue (and a one-paragraph note in this PR body).
+- **CLI smoke** for `show interfaces detail`. The grpcapi path is
+  out of scope; the CLI smoke claim was a v1 mistake.
+- **DHCP key centralization beyond `DHCPLeaseKey`**. Daemon callers
+  still construct the key inline. Follow-up.
+- **Caching TunnelNameMap on Config**. Out of scope.
+- **Error-handling escalation**. No 500s, no log spam.
 
 ## Open questions for adversarial review
 
-1. **Is `ResolveReth` correct for the cluster-peer case?** On node 0
-   `reth0` resolves to (e.g.) `ge-0/0/2`; on node 1 the same reth
-   resolves to `ge-7/0/2`. The peer node's physical member has no
-   kernel ifindex on this node. `kernelIfName(cfg, "reth0")` will
-   return e.g. `ge-7-0-2` on node 0 — which won't exist locally —
-   and the lookup will fail. Is "fail with ifindex=0" the right
-   behavior? (My answer: yes, same as today, but flag for review.)
-2. **VLAN suffix handling for non-RETH:** does
-   `LinuxIfName("ge-0/0/0.80")` actually produce `ge-0-0-0.80`?
-   (Quick check: yes — `ReplaceAll` only touches `/`, not `.`.)
-3. **Test coverage for `writeInterfacesDetail` DHCP lease path.**
-   Worth a Server-level integration test that runs a real DHCP
-   manager with a pre-installed lease and asserts the detail
-   output contains the lease? Or is the unit test of the helper
-   sufficient given the daemon's keying contract?
-4. **Should the fix also handle `fab0`/`fab1` overlay names?**
-   `ResolveFab` exists. Same bug class. The issue body doesn't
-   mention fabric — but operators may put fab names in
-   `interfaces { }`. Worth resolving in this PR or deferring?
-5. **Why not a centralized helper that returns ifindex directly?**
-   E.g. `cfg.IfindexFor(ifName) (int, bool)`. Cleaner caller code,
-   but adds API to `config` package. Asking reviewers whether the
-   indirection is worth it for 4 sites.
-6. **Should `interfacesHandler` skip the row when the kernel lookup
-   fails on a config name that doesn't exist locally** (e.g. peer's
-   RETH member) instead of returning ifindex=0? Today it includes.
-   Changing this is a JSON-shape regression I'd rather not gamble
-   on without operator input.
-7. **Are there other `pkg/api/` sites that should fold in?**
-   Quick grep: zone counters key by zoneName not ifName; policy
-   counters key by zone-pair; filter counters key by filter name.
-   No other `InterfaceByName` callers in `pkg/api/` per the grep
-   in step 1 above. Confirm.
+1. Is `DHCPLeaseKey(physRef, unitNum)` the right helper shape, or
+   should the helper take the full Junos ref and parse internally?
+2. Should `ResolveJunosIfName` short-circuit on `lo`, `lo0`, `fxp0`,
+   `em0`? Currently no — identity through LinuxIfName works.
+3. Tunnel resolution: should a bare `gr-0/0/0` (no unit) go through
+   TunnelNameMap? Map keys are `<name>.<unit>`, so bare falls
+   through to LinuxIfName → `gr-0-0-0`. Confirm this matches the
+   kernel link name (compiler creates `gr-0-0-0`, no suffix).
+4. Are there other ref shapes I'm missing? `st0.0` (xfrm),
+   `lo0.0`, `mt-`, `xe-`? `xe-` is LinuxIfName territory.
+   `st0` is xfrm; kernel device is `st0` directly. `lo0` has its
+   own quirks in Junos (loopback). Verify identity is correct.
+5. Should `writeInterfacesDetail` also print a `(kernel: ge-0-0-0)`
+   annotation for ops debugging? Out of scope but flagging.
+6. `*Config` method vs free function for `ResolveJunosIfName`?
+   Method matches ResolveReth/ResolveFab/TunnelNameMap convention.
+7. Should `interfacesHandler` skip rows for non-resolvable refs
+   (peer-only RETH members)? Today it lists them with ifindex=0.
+   Changing would be a JSON shape regression — keep.
 
-## Procedure (sketch)
+## Procedure
 
-1. Add `kernelIfName` helper in `pkg/api/api.go`.
-2. Rewrite the 4 sites.
-3. Replace bare `ifName` references in `/sys/class/net/...` and
-   `LeaseFor(...)` paths inside `writeInterfacesDetail` with the
-   resolved kernel name (for sys) and the `LinuxIfName(...)+.VLAN`
-   form (for DHCP — the daemon's exact construction).
-4. Add tests.
-5. Smoke per protocol. Per-class CoS smoke required.
-6. PR with `Closes #1565`.
+1. Add `(*Config).ResolveJunosIfName` and `(*Config).DHCPLeaseKey`
+   in `pkg/config/types.go`.
+2. Add 4 + 1 helper unit tests in `pkg/config/types_test.go`.
+3. Rewrite the 4 pkg/api sites.
+4. Add 2 handler tests in `pkg/api/interfaces_test.go` (or new
+   `pkg/api/iface_name_test.go`).
+5. Smoke per protocol.
+6. PR with `Closes #1565` body. Body includes a "Follow-up" note
+   pointing at the grpcapi peer.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
@@ -73,6 +74,25 @@ func queryUint16(r *http.Request, key string, def uint16) uint16 {
 		return def
 	}
 	return uint16(n)
+}
+
+// parseRefBaseUnit splits a Junos interface ref into its base name
+// and unit number, returning ok=false for malformed (non-numeric)
+// suffixes. A bare ref returns (ref, 0, true). This matches the
+// stricter Atoi semantics used in (*Config).ResolveKernelIfName and
+// avoids the partial-numeric-prefix bug fmt.Sscanf has
+// (e.g. "80foo" parsing as 80).
+func parseRefBaseUnit(ref string) (base string, unitNum int, ok bool) {
+	parts := strings.SplitN(ref, ".", 2)
+	base = parts[0]
+	if len(parts) == 1 {
+		return base, 0, true
+	}
+	n, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return base, 0, false
+	}
+	return base, n, true
 }
 
 // allInterfaceNames returns a deduplicated set of interface names from

--- a/pkg/api/iface_name_test.go
+++ b/pkg/api/iface_name_test.go
@@ -1,0 +1,182 @@
+package api
+
+import (
+	"encoding/json"
+	"net"
+	"net/http/httptest"
+	"net/netip"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dhcp"
+)
+
+// TestInterfacesHandler_ResolvesRethToLoopback pins the #1565 fix: when
+// a Junos config name doesn't directly map to a kernel ifname (RETH
+// alias, slash-containing name, etc.), the handler must translate via
+// (*Config).ResolveKernelIfName before calling net.InterfaceByName.
+//
+// We synthesize a cfg where reth0's RETH member is literally named
+// "lo" — the loopback netdev is the only one guaranteed to exist on
+// any Linux test runner. Pre-fix, the raw lookup of "reth0" returns
+// no kernel ifindex (RETH names are virtual). Post-fix,
+// ResolveKernelIfName("reth0") returns "lo" and the row's ifindex
+// matches net.InterfaceByName("lo").Index.
+func TestInterfacesHandler_ResolvesRethToLoopback(t *testing.T) {
+	loIface, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Skipf("test runner has no lo netdev: %v", err)
+	}
+
+	// Build a Junos config via configstore.LoadSet so we exercise the
+	// real compiler path. `lo { gigether-options { redundant-parent reth0; } }`
+	// plus `reth0` registers lo as reth0's physical member.
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	sets := []string{
+		"set chassis cluster reth-count 1",
+		"set interfaces lo gigether-options redundant-parent reth0",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		"set security zones security-zone trust interfaces reth0",
+	}
+	for _, s := range sets {
+		if _, err := store.LoadSet(s); err != nil {
+			t.Fatalf("LoadSet(%q): %v", s, err)
+		}
+	}
+	cfg, err := store.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Sanity: cfg.ResolveReth must resolve reth0 to lo. If not, the
+	// test setup is wrong and we should fail loudly rather than
+	// silently observing ifindex=0.
+	if got := cfg.ResolveReth("reth0"); got != "lo" {
+		t.Fatalf("ResolveReth(reth0) = %q, want lo (test cfg setup wrong)", got)
+	}
+	if got := cfg.ResolveKernelIfName("reth0"); got != "lo" {
+		t.Fatalf("ResolveKernelIfName(reth0) = %q, want lo", got)
+	}
+
+	s := &Server{store: store}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/interfaces", nil)
+	s.interfacesHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rows, ok := resp.Data.([]any)
+	if !ok {
+		t.Fatalf("data = %T, want []any", resp.Data)
+	}
+
+	var rethRow map[string]any
+	for _, r := range rows {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := m["name"].(string); name == "reth0" {
+			rethRow = m
+			break
+		}
+	}
+	if rethRow == nil {
+		t.Fatalf("no row for reth0 in /interfaces response: %s", rr.Body.String())
+	}
+	idx, _ := rethRow["ifindex"].(float64)
+	if int(idx) != loIface.Index {
+		t.Errorf("reth0 ifindex = %v, want %d (loopback) — translation broken",
+			rethRow["ifindex"], loIface.Index)
+	}
+}
+
+// TestWriteInterfacesDetail_DHCPLeasePath pins the #1565 fix on the
+// detail handler: DHCP lease annotation must key by the daemon's
+// actual lease-key shape (LinuxIfName(configRef) + ".VlanID" when
+// positive), not by the raw Junos config name.
+//
+// We bind the cfg's reth0 to lo (the only netdev guaranteed to exist)
+// and use unit 0 with no VLAN tagging so the kernel link resolves
+// (ResolveKernelIfName("reth0")="lo") and the detail handler reaches
+// the lease-print branch.
+func TestWriteInterfacesDetail_DHCPLeasePath(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skipf("test runner has no lo netdev: %v", err)
+	}
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	sets := []string{
+		"set chassis cluster reth-count 1",
+		"set interfaces lo gigether-options redundant-parent reth0",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		"set interfaces reth0 unit 0 family inet dhcp",
+		"set security zones security-zone trust interfaces reth0",
+	}
+	for _, s := range sets {
+		if _, err := store.LoadSet(s); err != nil {
+			t.Fatalf("LoadSet(%q): %v", s, err)
+		}
+	}
+	cfg, err := store.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Compute the expected DHCP lease key the daemon would use.
+	// For unit 0 with no vlan-id, the key is just LinuxIfName("reth0")
+	// = "reth0".
+	wantKey, ok := cfg.DHCPLeaseKey("reth0", 0)
+	if !ok || wantKey != "reth0" {
+		t.Fatalf("DHCPLeaseKey(reth0, 0) = (%q, %v), want (reth0, true)", wantKey, ok)
+	}
+
+	// Seed a lease at that key in a real dhcp.Manager.
+	dm, err := dhcp.New(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("dhcp.New: %v", err)
+	}
+	lease := &dhcp.Lease{
+		Address: netip.MustParsePrefix("192.0.2.5/24"),
+		Gateway: netip.MustParseAddr("192.0.2.1"),
+	}
+	dm.SeedLeaseForTesting(wantKey, dhcp.AFInet, lease)
+
+	s := &Server{store: store, dhcp: dm}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/interfaces-detail", nil)
+	s.interfacesDetailHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp Response
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tr, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("data = %T, want map", resp.Data)
+	}
+	out, _ := tr["output"].(string)
+	if !strings.Contains(out, "DHCPv4: 192.0.2.5/24 (gw 192.0.2.1)") {
+		t.Errorf("output missing DHCPv4 lease annotation; got:\n%s", out)
+	}
+}

--- a/pkg/api/iface_name_test.go
+++ b/pkg/api/iface_name_test.go
@@ -133,12 +133,17 @@ func TestWriteInterfacesDetail_DHCPLeasePath(t *testing.T) {
 	if err := store.EnterConfigure(); err != nil {
 		t.Fatalf("EnterConfigure: %v", err)
 	}
+	// Zone references reth0.0 (unit-suffixed Junos ref) — this is the
+	// asymmetric case: handler-visible ifName is "reth0.0" but the
+	// daemon's DHCP key is "reth0" (no .VlanID since unit 0 vlan-id 0).
+	// A regression to raw LeaseFor(ifName, ...) would call
+	// LeaseFor("reth0.0", ...) which hits the decoy.
 	sets := []string{
 		"set chassis cluster reth-count 1",
 		"set interfaces lo gigether-options redundant-parent reth0",
 		"set interfaces reth0 redundant-ether-options redundancy-group 1",
 		"set interfaces reth0 unit 0 family inet dhcp",
-		"set security zones security-zone trust interfaces reth0",
+		"set security zones security-zone trust interfaces reth0.0",
 	}
 	for _, s := range sets {
 		if _, err := store.LoadSet(s); err != nil {

--- a/pkg/api/iface_name_test.go
+++ b/pkg/api/iface_name_test.go
@@ -104,14 +104,26 @@ func TestInterfacesHandler_ResolvesRethToLoopback(t *testing.T) {
 }
 
 // TestWriteInterfacesDetail_DHCPLeasePath pins the #1565 fix on the
-// detail handler: DHCP lease annotation must key by the daemon's
-// actual lease-key shape (LinuxIfName(configRef) + ".VlanID" when
-// positive), not by the raw Junos config name.
+// detail handler: DHCP lease annotation must route through
+// (*Config).DHCPLeaseKey (which produces the daemon's actual lease
+// key shape), not call LeaseFor with the raw Junos config name.
 //
-// We bind the cfg's reth0 to lo (the only netdev guaranteed to exist)
-// and use unit 0 with no VLAN tagging so the kernel link resolves
-// (ResolveKernelIfName("reth0")="lo") and the detail handler reaches
-// the lease-print branch.
+// The unit-0 / no-VLAN config below produces a DHCP key equal to
+// "reth0" (LinuxIfName("reth0") + no .VlanID suffix). The unit
+// test TestDHCPLeaseKey_Mappings in pkg/config covers the
+// vlan-id != unit case ("reth0", 80, vlan-id 180) → "reth0.180" —
+// proving DHCPLeaseKey returns the daemon's actual key shape.
+// This handler test additionally proves the handler ROUTES THROUGH
+// DHCPLeaseKey at all (a regression to raw LeaseFor(ifName, ...)
+// would still fail this test for the unit-0 case where
+// ifName==key, since the handler then would not invoke
+// DHCPLeaseKey and the test would skip the lease print path if
+// the call wiring regressed — see the route trace in the
+// production code at pkg/api/interfaces.go:223).
+//
+// We bind reth0 to lo (the only netdev guaranteed to exist) so the
+// kernel-link lookup succeeds and the detail handler reaches the
+// lease-print branch.
 func TestWriteInterfacesDetail_DHCPLeasePath(t *testing.T) {
 	if _, err := net.InterfaceByName("lo"); err != nil {
 		t.Skipf("test runner has no lo netdev: %v", err)
@@ -138,24 +150,32 @@ func TestWriteInterfacesDetail_DHCPLeasePath(t *testing.T) {
 		t.Fatalf("Commit: %v", err)
 	}
 
-	// Compute the expected DHCP lease key the daemon would use.
-	// For unit 0 with no vlan-id, the key is just LinuxIfName("reth0")
-	// = "reth0".
+	// Expected daemon DHCP key for unit 0 with no vlan-id: "reth0".
 	wantKey, ok := cfg.DHCPLeaseKey("reth0", 0)
 	if !ok || wantKey != "reth0" {
 		t.Fatalf("DHCPLeaseKey(reth0, 0) = (%q, %v), want (reth0, true)", wantKey, ok)
 	}
 
-	// Seed a lease at that key in a real dhcp.Manager.
+	// Seed a lease at the correct DHCPLeaseKey shape. Also seed a
+	// DECOY lease under a wrong-but-plausible regression key shape
+	// — the raw Junos ref with a unit suffix ("reth0.0"). A
+	// regression that keys LeaseFor by the raw ifName would print
+	// the decoy address; the correct DHCPLeaseKey-routed handler
+	// prints the correct one.
 	dm, err := dhcp.New(t.TempDir(), nil)
 	if err != nil {
 		t.Fatalf("dhcp.New: %v", err)
 	}
-	lease := &dhcp.Lease{
+	correctLease := &dhcp.Lease{
 		Address: netip.MustParsePrefix("192.0.2.5/24"),
 		Gateway: netip.MustParseAddr("192.0.2.1"),
 	}
-	dm.SeedLeaseForTesting(wantKey, dhcp.AFInet, lease)
+	decoyLease := &dhcp.Lease{
+		Address: netip.MustParsePrefix("203.0.113.99/24"),
+		Gateway: netip.MustParseAddr("203.0.113.1"),
+	}
+	dm.SeedLeaseForTesting(wantKey, dhcp.AFInet, correctLease)
+	dm.SeedLeaseForTesting("reth0.0", dhcp.AFInet, decoyLease)
 
 	s := &Server{store: store, dhcp: dm}
 
@@ -177,6 +197,9 @@ func TestWriteInterfacesDetail_DHCPLeasePath(t *testing.T) {
 	}
 	out, _ := tr["output"].(string)
 	if !strings.Contains(out, "DHCPv4: 192.0.2.5/24 (gw 192.0.2.1)") {
-		t.Errorf("output missing DHCPv4 lease annotation; got:\n%s", out)
+		t.Errorf("output missing correct DHCPv4 lease annotation; got:\n%s", out)
+	}
+	if strings.Contains(out, "203.0.113") {
+		t.Errorf("output contains decoy lease — handler keyed LeaseFor wrongly; got:\n%s", out)
 	}
 }

--- a/pkg/api/interfaces.go
+++ b/pkg/api/interfaces.go
@@ -29,7 +29,12 @@ func (s *Server) interfacesHandler(w http.ResponseWriter, _ *http.Request) {
 
 	var result []InterfaceStats
 	for ifName := range allInterfaceNames(cfg) {
-		iface, err := net.InterfaceByName(ifName)
+		// Translate Junos config name to Linux kernel ifname before
+		// the kernel lookup. Config names may contain '/' (e.g.
+		// "ge-0/0/0", forbidden by IFNAMSIZ) or be virtual aliases
+		// (reth0, fab0, irb.0, gr-0/0/0.0) that don't directly map
+		// to a kernel ifindex. See #1565.
+		iface, err := net.InterfaceByName(cfg.ResolveKernelIfName(ifName))
 		is := InterfaceStats{
 			Name: ifName,
 			Zone: ifZone[ifName],
@@ -207,7 +212,10 @@ func (s *Server) writeInterfacesDetail(w http.ResponseWriter, cfg *config.Config
 	sort.Strings(ifNames)
 
 	for _, ifName := range ifNames {
-		iface, err := net.InterfaceByName(ifName)
+		// Translate Junos config name to Linux kernel ifname before
+		// kernel lookups (#1565).
+		kernel := cfg.ResolveKernelIfName(ifName)
+		iface, err := net.InterfaceByName(kernel)
 		if err != nil {
 			fmt.Fprintf(&b, "Interface: %s, Not present\n\n", ifName)
 			continue
@@ -217,7 +225,7 @@ func (s *Server) writeInterfacesDetail(w http.ResponseWriter, cfg *config.Config
 		if iface.Flags&net.FlagUp != 0 {
 			linkUp = "Up"
 		}
-		if data, err := os.ReadFile("/sys/class/net/" + ifName + "/operstate"); err == nil {
+		if data, err := os.ReadFile("/sys/class/net/" + kernel + "/operstate"); err == nil {
 			if strings.TrimSpace(string(data)) == "up" {
 				linkUp = "Up"
 			}
@@ -248,13 +256,22 @@ func (s *Server) writeInterfacesDetail(w http.ResponseWriter, cfg *config.Config
 			}
 		}
 
-		// DHCP annotations
+		// DHCP annotations — key by the daemon's actual lease-key
+		// shape (LinuxIfName(configRef)+ ".VlanID" when > 0).
+		// This is distinct from the kernel link name (#1565).
 		if s.dhcp != nil {
-			if lease := s.dhcp.LeaseFor(ifName, dhcp.AFInet); lease != nil {
-				fmt.Fprintf(&b, "  DHCPv4: %s (gw %s)\n", lease.Address, lease.Gateway)
+			base := strings.SplitN(ifName, ".", 2)[0]
+			unitNum := 0
+			if parts := strings.SplitN(ifName, ".", 2); len(parts) == 2 {
+				fmt.Sscanf(parts[1], "%d", &unitNum)
 			}
-			if lease := s.dhcp.LeaseFor(ifName, dhcp.AFInet6); lease != nil {
-				fmt.Fprintf(&b, "  DHCPv6: %s (gw %s)\n", lease.Address, lease.Gateway)
+			if key, ok := cfg.DHCPLeaseKey(base, unitNum); ok {
+				if lease := s.dhcp.LeaseFor(key, dhcp.AFInet); lease != nil {
+					fmt.Fprintf(&b, "  DHCPv4: %s (gw %s)\n", lease.Address, lease.Gateway)
+				}
+				if lease := s.dhcp.LeaseFor(key, dhcp.AFInet6); lease != nil {
+					fmt.Fprintf(&b, "  DHCPv6: %s (gw %s)\n", lease.Address, lease.Gateway)
+				}
 			}
 		}
 

--- a/pkg/api/interfaces.go
+++ b/pkg/api/interfaces.go
@@ -163,8 +163,12 @@ func (s *Server) writeInterfacesTerse(w http.ResponseWriter, cfg *config.Config,
 			continue
 		}
 
-		// Normal interface: get addresses from kernel
-		kernelName := config.LinuxIfName(ifName)
+		// Normal interface: get addresses from kernel. Use the full
+		// ResolveKernelIfName helper so tunnel refs (gr-0/0/0.0 ->
+		// gr-0-0-0), IRB, and VLAN-tag-aware composition all resolve
+		// correctly. Plain LinuxIfName would mis-resolve gr-0/0/0.0
+		// to gr-0-0-0.0 (#1565).
+		kernelName := cfg.ResolveKernelIfName(ifName)
 		iface, err := net.InterfaceByName(kernelName)
 		admin, link := "down", "down"
 		var addrs []string

--- a/pkg/api/interfaces.go
+++ b/pkg/api/interfaces.go
@@ -264,17 +264,14 @@ func (s *Server) writeInterfacesDetail(w http.ResponseWriter, cfg *config.Config
 		// shape (LinuxIfName(configRef)+ ".VlanID" when > 0).
 		// This is distinct from the kernel link name (#1565).
 		if s.dhcp != nil {
-			base := strings.SplitN(ifName, ".", 2)[0]
-			unitNum := 0
-			if parts := strings.SplitN(ifName, ".", 2); len(parts) == 2 {
-				fmt.Sscanf(parts[1], "%d", &unitNum)
-			}
-			if key, ok := cfg.DHCPLeaseKey(base, unitNum); ok {
-				if lease := s.dhcp.LeaseFor(key, dhcp.AFInet); lease != nil {
-					fmt.Fprintf(&b, "  DHCPv4: %s (gw %s)\n", lease.Address, lease.Gateway)
-				}
-				if lease := s.dhcp.LeaseFor(key, dhcp.AFInet6); lease != nil {
-					fmt.Fprintf(&b, "  DHCPv6: %s (gw %s)\n", lease.Address, lease.Gateway)
+			if base, unitNum, ok := parseRefBaseUnit(ifName); ok {
+				if key, ok := cfg.DHCPLeaseKey(base, unitNum); ok {
+					if lease := s.dhcp.LeaseFor(key, dhcp.AFInet); lease != nil {
+						fmt.Fprintf(&b, "  DHCPv4: %s (gw %s)\n", lease.Address, lease.Gateway)
+					}
+					if lease := s.dhcp.LeaseFor(key, dhcp.AFInet6); lease != nil {
+						fmt.Fprintf(&b, "  DHCPv6: %s (gw %s)\n", lease.Address, lease.Gateway)
+					}
 				}
 			}
 		}

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -65,7 +65,8 @@ func (c *xpfCollector) collectInterfaceCounters(ch chan<- prometheus.Metric, dp 
 	}
 
 	for ifName := range allInterfaceNames(cfg) {
-		iface, err := net.InterfaceByName(ifName)
+		// Translate Junos config name to Linux kernel ifname (#1565).
+		iface, err := net.InterfaceByName(cfg.ResolveKernelIfName(ifName))
 		if err != nil {
 			continue
 		}

--- a/pkg/api/stats.go
+++ b/pkg/api/stats.go
@@ -61,7 +61,8 @@ func (s *Server) ifaceStatsHandler(w http.ResponseWriter, _ *http.Request) {
 
 	var result []InterfaceStats
 	for ifName := range allInterfaceNames(cfg) {
-		iface, err := net.InterfaceByName(ifName)
+		// Translate Junos config name to Linux kernel ifname (#1565).
+		iface, err := net.InterfaceByName(cfg.ResolveKernelIfName(ifName))
 		if err != nil {
 			continue
 		}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -126,24 +126,24 @@ func (c *Config) ResolveFab(ref string) string {
 //  1. Bare refs (no "." suffix):
 //     - reth* → ResolveReth → physical member, LinuxIfName.
 //     - all others (fxp0, em0, fab0, lo, ge-0/0/0, gr-0/0/0, st0):
-//       LinuxIfName(ref). Matches snapshotLinuxName for the no-unit
-//       case.
+//     LinuxIfName(ref). Matches snapshotLinuxName for the no-unit
+//     case.
 //  2. Dotted refs (e.g. "ge-0/0/0.80", "reth0.50", "gr-0/0/0.0",
 //     "irb.0", "st0.0"):
 //     a. st<N>.<M> short-circuit: kernel XFRM device is the full
-//        ref verbatim. Matches resolveInterfaceRef + XFRMIfNameAndID.
+//     ref verbatim. Matches resolveInterfaceRef + XFRMIfNameAndID.
 //     b. IRB: look up via IRBToBridge(cfg.BridgeDomains) and return
-//        the bridge device name (no suffix).
+//     the bridge device name (no suffix).
 //     c. Tunnel: if TunnelNameMap[ref] is set, return that name
-//        verbatim (covers gr-0/0/0.0 → gr-0-0-0 and
-//        gr-0/0/0.1 → gr-0-0-0u1).
+//     verbatim (covers gr-0/0/0.0 → gr-0-0-0 and
+//     gr-0/0/0.1 → gr-0-0-0u1).
 //     d. Otherwise look up cfg.Interfaces.Interfaces[base].Units[unit]:
-//        - If unit has tunnel.Name set, return that.
-//        - If unit.VlanID > 0, return
-//          LinuxIfName(ResolveReth(base)) + "." + VlanID.
-//        - If unit.Number == 0, return
-//          LinuxIfName(ResolveReth(base)) (unit-0 collapse).
-//        - Else return LinuxIfName(ResolveReth(base)) + "." + unit.Number.
+//     - If unit has tunnel.Name set, return that.
+//     - If unit.VlanID > 0, return
+//     LinuxIfName(ResolveReth(base)) + "." + VlanID.
+//     - If unit.Number == 0, return
+//     LinuxIfName(ResolveReth(base)) (unit-0 collapse).
+//     - Else return LinuxIfName(ResolveReth(base)) + "." + unit.Number.
 //     e. Fallback: LinuxIfName(ResolveReth(ref)) — preserves suffix.
 //
 // NOTE: Keep in sync with snapshotLinuxName in

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -107,6 +108,144 @@ func (c *Config) ResolveFab(ref string) string {
 		return resolved + "." + parts[1]
 	}
 	return resolved
+}
+
+// ResolveKernelIfName converts a Junos-style interface reference
+// (as found in zone declarations and the keys of
+// cfg.Interfaces.Interfaces) to the Linux kernel ifname it should
+// resolve to on the LOCAL node.
+//
+// This is a DISPLAY-name resolver for API readers — it is NOT the
+// same as ResolveFab (which returns the fabric overlay's parent
+// physical member for BPF attachment). fab0 itself is a real kernel
+// IPVLAN device, so API queries on fab0 must look up "fab0", not
+// its parent. Similarly, st0.x is the kernel XFRM device name
+// verbatim.
+//
+// Resolution semantics, in order:
+//  1. Bare refs (no "." suffix):
+//     - reth* → ResolveReth → physical member, LinuxIfName.
+//     - all others (fxp0, em0, fab0, lo, ge-0/0/0, gr-0/0/0, st0):
+//       LinuxIfName(ref). Matches snapshotLinuxName for the no-unit
+//       case.
+//  2. Dotted refs (e.g. "ge-0/0/0.80", "reth0.50", "gr-0/0/0.0",
+//     "irb.0", "st0.0"):
+//     a. st<N>.<M> short-circuit: kernel XFRM device is the full
+//        ref verbatim. Matches resolveInterfaceRef + XFRMIfNameAndID.
+//     b. IRB: look up via IRBToBridge(cfg.BridgeDomains) and return
+//        the bridge device name (no suffix).
+//     c. Tunnel: if TunnelNameMap[ref] is set, return that name
+//        verbatim (covers gr-0/0/0.0 → gr-0-0-0 and
+//        gr-0/0/0.1 → gr-0-0-0u1).
+//     d. Otherwise look up cfg.Interfaces.Interfaces[base].Units[unit]:
+//        - If unit has tunnel.Name set, return that.
+//        - If unit.VlanID > 0, return
+//          LinuxIfName(ResolveReth(base)) + "." + VlanID.
+//        - If unit.Number == 0, return
+//          LinuxIfName(ResolveReth(base)) (unit-0 collapse).
+//        - Else return LinuxIfName(ResolveReth(base)) + "." + unit.Number.
+//     e. Fallback: LinuxIfName(ResolveReth(ref)) — preserves suffix.
+//
+// NOTE: Keep in sync with snapshotLinuxName in
+// pkg/dataplane/userspace/interfaces.go and resolveJunosIfName in
+// pkg/daemon/daemon_dhcp.go. Migration to centralize all callers is
+// tracked as a follow-up to #1565.
+func (c *Config) ResolveKernelIfName(ref string) string {
+	parts := strings.SplitN(ref, ".", 2)
+	base := parts[0]
+
+	// Bare refs.
+	if len(parts) == 1 {
+		if strings.HasPrefix(base, "reth") {
+			return LinuxIfName(c.ResolveReth(base))
+		}
+		return LinuxIfName(base)
+	}
+
+	// XFRM (st<N>) is verbatim — kernel device is the full ref.
+	if strings.HasPrefix(base, "st") && len(base) >= 3 {
+		if _, err := strconv.Atoi(base[2:]); err == nil {
+			return LinuxIfName(ref)
+		}
+	}
+
+	// IRB.
+	if base == "irb" {
+		if bridges := IRBToBridge(c.BridgeDomains); bridges != nil {
+			if bridge, ok := bridges[ref]; ok && bridge != "" {
+				return bridge
+			}
+		}
+		// Fall through if no bridge mapping; fallback handles it.
+	}
+
+	// Per-unit tunnel by ref.
+	if tunMap := c.TunnelNameMap(); tunMap != nil {
+		if linuxName, ok := tunMap[ref]; ok && linuxName != "" {
+			return linuxName
+		}
+	}
+
+	// Bail to fallback if the suffix isn't numeric (malformed ref
+	// like "ge-0/0/0.foo" must not silently map to unit 0).
+	unitNum, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return LinuxIfName(c.ResolveReth(ref))
+	}
+	if c.Interfaces.Interfaces == nil {
+		return LinuxIfName(c.ResolveReth(ref))
+	}
+	if ifc, ok := c.Interfaces.Interfaces[base]; ok && ifc != nil {
+		if unit, ok := ifc.Units[unitNum]; ok && unit != nil {
+			if unit.Tunnel != nil && unit.Tunnel.Name != "" {
+				return unit.Tunnel.Name
+			}
+			kernelBase := LinuxIfName(c.ResolveReth(base))
+			if unit.VlanID > 0 {
+				return fmt.Sprintf("%s.%d", kernelBase, unit.VlanID)
+			}
+			if unit.Number == 0 {
+				return kernelBase
+			}
+			return fmt.Sprintf("%s.%d", kernelBase, unit.Number)
+		}
+	}
+
+	// Fallback for refs not modeled in cfg.Interfaces.Interfaces:
+	// preserve the suffix and translate slashes only.
+	return LinuxIfName(c.ResolveReth(ref))
+}
+
+// DHCPLeaseKey returns the lease-lookup key that pkg/dhcp.Manager
+// keys leases by for the given config-level interface ref and unit
+// number. Mirrors the construction in
+// pkg/daemon/daemon_dhcp.go:56-95:
+//
+//	key = LinuxIfName(physRef) + ("." + strconv(unit.VlanID)) when > 0
+//
+// physRef is the CONFIG-LEVEL name (e.g. "reth0"), not the resolved
+// physical member — the daemon's DHCP Start() is invoked with the
+// config-level name.
+//
+// Returns ("", false) when the unit doesn't exist in cfg.
+func (c *Config) DHCPLeaseKey(physRef string, unitNum int) (string, bool) {
+	physRef = strings.SplitN(physRef, ".", 2)[0]
+	if c.Interfaces.Interfaces == nil {
+		return "", false
+	}
+	ifc, ok := c.Interfaces.Interfaces[physRef]
+	if !ok || ifc == nil {
+		return "", false
+	}
+	unit, ok := ifc.Units[unitNum]
+	if !ok || unit == nil {
+		return "", false
+	}
+	key := LinuxIfName(physRef)
+	if unit.VlanID > 0 {
+		key = key + "." + strconv.Itoa(unit.VlanID)
+	}
+	return key, true
 }
 
 // Config is the top-level typed configuration, compiled from the AST.

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -221,19 +221,19 @@ func (c *Config) ResolveKernelIfName(ref string) string {
 // number. Mirrors the construction in
 // pkg/daemon/daemon_dhcp.go:56-95:
 //
-//	key = LinuxIfName(physRef) + ("." + strconv(unit.VlanID)) when > 0
+//	key = LinuxIfName(configRef) + ("." + strconv(unit.VlanID)) when > 0
 //
-// physRef is the CONFIG-LEVEL name (e.g. "reth0"), not the resolved
+// configRef is the CONFIG-LEVEL name (e.g. "reth0"), not the resolved
 // physical member — the daemon's DHCP Start() is invoked with the
 // config-level name.
 //
 // Returns ("", false) when the unit doesn't exist in cfg.
-func (c *Config) DHCPLeaseKey(physRef string, unitNum int) (string, bool) {
-	physRef = strings.SplitN(physRef, ".", 2)[0]
+func (c *Config) DHCPLeaseKey(configRef string, unitNum int) (string, bool) {
+	configRef = strings.SplitN(configRef, ".", 2)[0]
 	if c.Interfaces.Interfaces == nil {
 		return "", false
 	}
-	ifc, ok := c.Interfaces.Interfaces[physRef]
+	ifc, ok := c.Interfaces.Interfaces[configRef]
 	if !ok || ifc == nil {
 		return "", false
 	}
@@ -241,7 +241,7 @@ func (c *Config) DHCPLeaseKey(physRef string, unitNum int) (string, bool) {
 	if !ok || unit == nil {
 		return "", false
 	}
-	key := LinuxIfName(physRef)
+	key := LinuxIfName(configRef)
 	if unit.VlanID > 0 {
 		key = key + "." + strconv.Itoa(unit.VlanID)
 	}

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -116,7 +116,7 @@ func TestResolveKernelIfName_Plain(t *testing.T) {
 		{"fxp0", "fxp0"},
 		{"lo", "lo"},
 		{"ge-0/0/0", "ge-0-0-0"},
-		{"ge-0/0/0.0", "ge-0-0-0"},     // unit 0 with vlan-id 0 collapses
+		{"ge-0/0/0.0", "ge-0-0-0"},      // unit 0 with vlan-id 0 collapses
 		{"ge-0/0/0.80", "ge-0-0-0.180"}, // VLAN tag, NOT unit number
 	}
 	for _, tt := range tests {
@@ -147,9 +147,9 @@ func TestResolveKernelIfName_Reth(t *testing.T) {
 		in, want string
 	}{
 		{"reth0", "ge-0-0-2"},
-		{"reth0.0", "ge-0-0-2"},        // unit 0 collapse
-		{"reth0.50", "ge-0-0-2.50"},    // vlan-id == unit
-		{"reth0.80", "ge-0-0-2.180"},   // vlan-id != unit — the failure case
+		{"reth0.0", "ge-0-0-2"},      // unit 0 collapse
+		{"reth0.50", "ge-0-0-2.50"},  // vlan-id == unit
+		{"reth0.80", "ge-0-0-2.180"}, // vlan-id != unit — the failure case
 	}
 	for _, tt := range tests {
 		if got := cfg.ResolveKernelIfName(tt.in); got != tt.want {

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -1,6 +1,8 @@
 package config
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestRethToPhysical(t *testing.T) {
 	cfg := &Config{
@@ -88,5 +90,300 @@ func TestRethToPhysical_PrefersLocalClusterMember(t *testing.T) {
 	}
 	if got := cfg.ResolveReth("reth0.80"); got != "ge-0/0/2.80" {
 		t.Fatalf("ResolveReth(reth0.80) = %q, want ge-0/0/2.80", got)
+	}
+}
+
+// --- ResolveKernelIfName tests (#1565) ---
+
+func TestResolveKernelIfName_Plain(t *testing.T) {
+	cfg := &Config{
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*InterfaceUnit{
+					0:  {Number: 0, VlanID: 0},
+					80: {Number: 80, VlanID: 180},
+				}},
+				"em0":  {Name: "em0"},
+				"fxp0": {Name: "fxp0"},
+			},
+		},
+	}
+
+	tests := []struct {
+		in, want string
+	}{
+		{"em0", "em0"},
+		{"fxp0", "fxp0"},
+		{"lo", "lo"},
+		{"ge-0/0/0", "ge-0-0-0"},
+		{"ge-0/0/0.0", "ge-0-0-0"},     // unit 0 with vlan-id 0 collapses
+		{"ge-0/0/0.80", "ge-0-0-0.180"}, // VLAN tag, NOT unit number
+	}
+	for _, tt := range tests {
+		if got := cfg.ResolveKernelIfName(tt.in); got != tt.want {
+			t.Errorf("ResolveKernelIfName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestResolveKernelIfName_Reth(t *testing.T) {
+	// Node 0: local member is ge-0/0/2.
+	cfg := &Config{
+		Chassis: ChassisConfig{Cluster: &ClusterConfig{NodeID: 0}},
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"reth0": {Name: "reth0", RedundancyGroup: 1, Units: map[int]*InterfaceUnit{
+					0:  {Number: 0, VlanID: 0},
+					50: {Number: 50, VlanID: 50},
+					80: {Number: 80, VlanID: 180},
+				}},
+				"ge-0/0/2": {Name: "ge-0/0/2", RedundantParent: "reth0"},
+				"ge-7/0/2": {Name: "ge-7/0/2", RedundantParent: "reth0"},
+			},
+		},
+	}
+
+	tests := []struct {
+		in, want string
+	}{
+		{"reth0", "ge-0-0-2"},
+		{"reth0.0", "ge-0-0-2"},        // unit 0 collapse
+		{"reth0.50", "ge-0-0-2.50"},    // vlan-id == unit
+		{"reth0.80", "ge-0-0-2.180"},   // vlan-id != unit — the failure case
+	}
+	for _, tt := range tests {
+		if got := cfg.ResolveKernelIfName(tt.in); got != tt.want {
+			t.Errorf("node 0: ResolveKernelIfName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+
+	// Node 1: local member is ge-7/0/2.
+	cfg.Chassis.Cluster.NodeID = 1
+	if got := cfg.ResolveKernelIfName("reth0"); got != "ge-7-0-2" {
+		t.Errorf("node 1: ResolveKernelIfName(reth0) = %q, want ge-7-0-2", got)
+	}
+	if got := cfg.ResolveKernelIfName("reth0.80"); got != "ge-7-0-2.180" {
+		t.Errorf("node 1: ResolveKernelIfName(reth0.80) = %q, want ge-7-0-2.180", got)
+	}
+}
+
+func TestResolveKernelIfName_Fab(t *testing.T) {
+	// fab0 is a real kernel IPVLAN device — do NOT resolve to parent.
+	cfg := &Config{
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"fab0": {Name: "fab0", LocalFabricMember: "ge-0/0/0", Units: map[int]*InterfaceUnit{
+					0: {Number: 0, VlanID: 0},
+				}},
+				"fab1": {Name: "fab1", LocalFabricMember: "ge-0/0/0"},
+			},
+		},
+	}
+	tests := []struct {
+		in, want string
+	}{
+		{"fab0", "fab0"},
+		{"fab0.0", "fab0"}, // unit 0 collapse
+		{"fab1", "fab1"},
+	}
+	for _, tt := range tests {
+		if got := cfg.ResolveKernelIfName(tt.in); got != tt.want {
+			t.Errorf("ResolveKernelIfName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestResolveKernelIfName_Tunnel(t *testing.T) {
+	// Interface-level tunnel: unit 0 maps to base Linux name.
+	cfg := &Config{
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"gr-0/0/0": {
+					Name:   "gr-0/0/0",
+					Tunnel: &TunnelConfig{Source: "10.0.0.1", Destination: "10.0.0.2"},
+					Units: map[int]*InterfaceUnit{
+						0: {Number: 0},
+					},
+				},
+			},
+		},
+	}
+	if got := cfg.ResolveKernelIfName("gr-0/0/0.0"); got != "gr-0-0-0" {
+		t.Errorf("interface-level tunnel: ResolveKernelIfName(gr-0/0/0.0) = %q, want gr-0-0-0", got)
+	}
+
+	// Per-unit tunnel: explicit unit.Tunnel.Name.
+	cfgPerUnit := &Config{
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"gr-0/0/0": {
+					Name: "gr-0/0/0",
+					Units: map[int]*InterfaceUnit{
+						0: {Number: 0, Tunnel: &TunnelConfig{Name: "gr-0-0-0", Source: "10.0.0.1"}},
+						1: {Number: 1, Tunnel: &TunnelConfig{Name: "gr-0-0-0u1", Source: "10.0.0.3"}},
+					},
+				},
+			},
+		},
+	}
+	if got := cfgPerUnit.ResolveKernelIfName("gr-0/0/0.0"); got != "gr-0-0-0" {
+		t.Errorf("per-unit tunnel: ResolveKernelIfName(gr-0/0/0.0) = %q, want gr-0-0-0", got)
+	}
+	if got := cfgPerUnit.ResolveKernelIfName("gr-0/0/0.1"); got != "gr-0-0-0u1" {
+		t.Errorf("per-unit tunnel: ResolveKernelIfName(gr-0/0/0.1) = %q, want gr-0-0-0u1", got)
+	}
+}
+
+func TestResolveKernelIfName_TunnelOverridesVlan(t *testing.T) {
+	// If a unit has both tunnel.Name and a vlan-id, tunnel wins.
+	cfg := &Config{
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"reth0": {Name: "reth0", RedundancyGroup: 1, Units: map[int]*InterfaceUnit{
+					50: {Number: 50, VlanID: 999, Tunnel: &TunnelConfig{Name: "gr-foo"}},
+				}},
+				"ge-0/0/2": {Name: "ge-0/0/2", RedundantParent: "reth0"},
+			},
+		},
+	}
+	if got := cfg.ResolveKernelIfName("reth0.50"); got != "gr-foo" {
+		t.Errorf("tunnel-overrides-vlan: ResolveKernelIfName(reth0.50) = %q, want gr-foo", got)
+	}
+}
+
+func TestResolveKernelIfName_IRB(t *testing.T) {
+	cfg := &Config{
+		BridgeDomains: []*BridgeDomainConfig{
+			{Name: "bd0", RoutingInterface: "irb.0"},
+		},
+	}
+	if got := cfg.ResolveKernelIfName("irb.0"); got != "br-bd0" {
+		t.Errorf("IRB: ResolveKernelIfName(irb.0) = %q, want br-bd0", got)
+	}
+}
+
+func TestResolveKernelIfName_UnknownUnit(t *testing.T) {
+	cfg := &Config{
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*InterfaceUnit{
+					0: {Number: 0},
+				}},
+			},
+		},
+	}
+	// Unit 99 is not configured — fallback preserves suffix.
+	if got := cfg.ResolveKernelIfName("ge-0/0/0.99"); got != "ge-0-0-0.99" {
+		t.Errorf("unknown unit fallback: ResolveKernelIfName(ge-0/0/0.99) = %q, want ge-0-0-0.99", got)
+	}
+}
+
+func TestResolveKernelIfName_MalformedSuffix(t *testing.T) {
+	cfg := &Config{
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*InterfaceUnit{
+					0: {Number: 0},
+				}},
+			},
+		},
+	}
+	// Non-numeric suffix must NOT silently map to unit 0.
+	if got := cfg.ResolveKernelIfName("ge-0/0/0.foo"); got != "ge-0-0-0.foo" {
+		t.Errorf("malformed suffix fallback: ResolveKernelIfName(ge-0/0/0.foo) = %q, want ge-0-0-0.foo", got)
+	}
+}
+
+func TestResolveKernelIfName_InterfaceLevelTunnel(t *testing.T) {
+	// Mirrors cluster cfg shape: gr-0/0/0 with tunnel{} and unit 0 only.
+	cfg := &Config{
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"gr-0/0/0": {
+					Name:   "gr-0/0/0",
+					Tunnel: &TunnelConfig{Source: "2001:db8::1", Destination: "2001:db8::2"},
+					Units: map[int]*InterfaceUnit{
+						0: {Number: 0},
+					},
+				},
+			},
+		},
+	}
+	if got := cfg.ResolveKernelIfName("gr-0/0/0.0"); got != "gr-0-0-0" {
+		t.Errorf("interface-level tunnel cluster-shape: got %q, want gr-0-0-0", got)
+	}
+}
+
+func TestResolveKernelIfName_StXfrm(t *testing.T) {
+	cfg := &Config{}
+	tests := []struct {
+		in, want string
+	}{
+		{"st0", "st0"},
+		{"st0.0", "st0.0"},
+		{"st0.5", "st0.5"},
+		{"st1", "st1"},
+		{"st1.10", "st1.10"},
+	}
+	for _, tt := range tests {
+		if got := cfg.ResolveKernelIfName(tt.in); got != tt.want {
+			t.Errorf("ResolveKernelIfName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestResolveKernelIfName_NilInterfaces(t *testing.T) {
+	cfg := &Config{}
+	// Nil c.Interfaces.Interfaces must not panic; fallback to LinuxIfName.
+	if got := cfg.ResolveKernelIfName("ge-0/0/0.80"); got != "ge-0-0-0.80" {
+		t.Errorf("nil Interfaces: ResolveKernelIfName(ge-0/0/0.80) = %q, want ge-0-0-0.80", got)
+	}
+}
+
+// --- DHCPLeaseKey tests (#1565) ---
+
+func TestDHCPLeaseKey_Mappings(t *testing.T) {
+	cfg := &Config{
+		Interfaces: InterfacesConfig{
+			Interfaces: map[string]*InterfaceConfig{
+				"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*InterfaceUnit{
+					0: {Number: 0, VlanID: 0},
+					1: {Number: 1, VlanID: 80},
+				}},
+				"reth0": {Name: "reth0", Units: map[int]*InterfaceUnit{
+					50: {Number: 50, VlanID: 50},
+					80: {Number: 80, VlanID: 180},
+				}},
+				"ge-7/0/2": {Name: "ge-7/0/2", RedundantParent: "reth0"},
+			},
+		},
+	}
+
+	tests := []struct {
+		ref     string
+		unit    int
+		wantKey string
+		wantOK  bool
+	}{
+		// No-VLAN unit: key is just the Linux base.
+		{"ge-0/0/0", 0, "ge-0-0-0", true},
+		// Positive VlanID: key is base + .VlanID.
+		{"ge-0/0/0", 1, "ge-0-0-0.80", true},
+		// Reth keys by CONFIG-LEVEL name, NOT resolved physical.
+		{"reth0", 50, "reth0.50", true},
+		{"reth0", 80, "reth0.180", true},
+		// Unit not configured.
+		{"ge-0/0/0", 99, "", false},
+		// Base not configured.
+		{"ge-9/9/9", 0, "", false},
+		// Suffix in physRef must be stripped before lookup.
+		{"reth0.50", 50, "reth0.50", true},
+	}
+	for _, tt := range tests {
+		gotKey, gotOK := cfg.DHCPLeaseKey(tt.ref, tt.unit)
+		if gotKey != tt.wantKey || gotOK != tt.wantOK {
+			t.Errorf("DHCPLeaseKey(%q, %d) = (%q, %v), want (%q, %v)",
+				tt.ref, tt.unit, gotKey, gotOK, tt.wantKey, tt.wantOK)
+		}
 	}
 }

--- a/pkg/daemon/daemon_dhcp.go
+++ b/pkg/daemon/daemon_dhcp.go
@@ -135,6 +135,11 @@ func (d *Daemon) dhcpLeaseChangeRequiresRecompile(cfg *config.Config) bool {
 // equivalent. It resolves RETH names to their physical members (e.g.
 // reth0.50 → ge-0/0/0.50) and converts Junos slashes to dashes (e.g.
 // ge-0/0/0 → ge-0-0-0).
+//
+// NOTE: Keep in sync with (*Config).ResolveKernelIfName in
+// pkg/config/types.go. This helper only does the bare-ref subset of
+// the public method; callers that already have unit/vlan context
+// build the .VLAN suffix themselves (see resolveConfigSubnetLinuxName).
 func resolveJunosIfName(cfg *config.Config, ifName string) string {
 	return config.LinuxIfName(cfg.ResolveReth(ifName))
 }

--- a/pkg/dataplane/userspace/interfaces.go
+++ b/pkg/dataplane/userspace/interfaces.go
@@ -300,6 +300,10 @@ func coSUnitDSCPRewriteRule(unit *config.CoSInterfaceUnit) string {
 	return unit.DSCPRewriteRule
 }
 
+// NOTE: Keep in sync with (*Config).ResolveKernelIfName in
+// pkg/config/types.go. The two implementations have intentional
+// scope deltas (snapshotLinuxName does not implement IRB), but the
+// shared cases must match. See drift-guard test in this package.
 func snapshotLinuxName(cfg *config.Config, ifName string, iface *config.InterfaceConfig, unit *config.InterfaceUnit) string {
 	if iface == nil {
 		return config.LinuxIfName(ifName)

--- a/pkg/dataplane/userspace/interfaces_test.go
+++ b/pkg/dataplane/userspace/interfaces_test.go
@@ -1,0 +1,90 @@
+package userspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestResolveKernelIfName_DriftGuardVsSnapshotLinuxName asserts that the
+// public (*config.Config).ResolveKernelIfName helper and the private
+// snapshotLinuxName helper produce identical output for shared input
+// shapes. The two implementations have intentional scope deltas
+// (snapshotLinuxName does not implement IRB), but for every other
+// case they must match. See #1565.
+func TestResolveKernelIfName_DriftGuardVsSnapshotLinuxName(t *testing.T) {
+	// Construct a Config that exercises every branch of
+	// snapshotLinuxName:
+	//   - iface == nil path (bare ref, no cfg entry).
+	//   - bare reth (reth0 only, no unit).
+	//   - bare non-reth (em0, ge-0/0/0).
+	//   - tunnel-map hit (gr-0/0/0.0 with interface-level tunnel).
+	//   - VLAN positive (reth0.50 with vlan-id 50; ge-0/0/0.80 with
+	//     vlan-id 180).
+	//   - reth unit 0 (reth0.0 with no vlan).
+	//   - reth nonzero no-VLAN unit (synthetic).
+	//   - non-reth unit 0 (ge-0/0/0.0).
+	//   - non-reth nonzero no-VLAN unit (synthetic).
+	cfg := &config.Config{
+		Chassis: config.ChassisConfig{Cluster: &config.ClusterConfig{NodeID: 0}},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"em0":  {Name: "em0"},
+				"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
+					0:  {Number: 0, VlanID: 0},
+					3:  {Number: 3, VlanID: 0}, // non-reth nonzero no-VLAN
+					80: {Number: 80, VlanID: 180},
+				}},
+				"reth0": {Name: "reth0", RedundancyGroup: 1, Units: map[int]*config.InterfaceUnit{
+					0:  {Number: 0, VlanID: 0},
+					5:  {Number: 5, VlanID: 0}, // reth nonzero no-VLAN
+					50: {Number: 50, VlanID: 50},
+				}},
+				"ge-0/0/2": {Name: "ge-0/0/2", RedundantParent: "reth0"},
+				"gr-0/0/0": {
+					Name:   "gr-0/0/0",
+					Tunnel: &config.TunnelConfig{Source: "10.0.0.1"},
+					Units: map[int]*config.InterfaceUnit{
+						0: {Number: 0},
+					},
+				},
+			},
+		},
+	}
+
+	type tcase struct {
+		ifName string
+		iface  *config.InterfaceConfig
+		unit   *config.InterfaceUnit
+	}
+
+	// Collect cases by walking the config so the parity check matches
+	// real snapshot iteration shape.
+	var cases []tcase
+	for name, ifc := range cfg.Interfaces.Interfaces {
+		// iface, no unit (snapshotLinuxName's no-unit branch).
+		cases = append(cases, tcase{ifName: name, iface: ifc, unit: nil})
+		for _, u := range ifc.Units {
+			cases = append(cases, tcase{ifName: name, iface: ifc, unit: u})
+		}
+	}
+	// iface == nil branch.
+	cases = append(cases, tcase{ifName: "lo", iface: nil, unit: nil})
+	cases = append(cases, tcase{ifName: "fxp0", iface: nil, unit: nil})
+
+	for _, tc := range cases {
+		var ref string
+		if tc.unit == nil {
+			ref = tc.ifName
+		} else {
+			ref = fmt.Sprintf("%s.%d", tc.ifName, tc.unit.Number)
+		}
+		got := cfg.ResolveKernelIfName(ref)
+		want := snapshotLinuxName(cfg, tc.ifName, tc.iface, tc.unit)
+		if got != want {
+			t.Errorf("drift: ref %q (ifName=%q, unit=%+v) got %q, want %q",
+				ref, tc.ifName, tc.unit, got, want)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/interfaces_test.go
+++ b/pkg/dataplane/userspace/interfaces_test.go
@@ -30,7 +30,7 @@ func TestResolveKernelIfName_DriftGuardVsSnapshotLinuxName(t *testing.T) {
 		Chassis: config.ChassisConfig{Cluster: &config.ClusterConfig{NodeID: 0}},
 		Interfaces: config.InterfacesConfig{
 			Interfaces: map[string]*config.InterfaceConfig{
-				"em0":  {Name: "em0"},
+				"em0": {Name: "em0"},
 				"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*config.InterfaceUnit{
 					0:  {Number: 0, VlanID: 0},
 					3:  {Number: 3, VlanID: 0}, // non-reth nonzero no-VLAN

--- a/pkg/dhcp/test_seams.go
+++ b/pkg/dhcp/test_seams.go
@@ -1,0 +1,16 @@
+package dhcp
+
+// Test-only helpers for pkg/dhcp.Manager. Lives in the production
+// package so external packages (e.g. pkg/api tests) can use these
+// without internal-export tricks. Not for production callers.
+
+// SeedLeaseForTesting installs a lease record for tests. Callers
+// must not use this from production code paths.
+func (m *Manager) SeedLeaseForTesting(ifaceName string, af AddressFamily, lease *Lease) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.leases == nil {
+		m.leases = make(map[clientKey]*Lease)
+	}
+	m.leases[clientKey{iface: ifaceName, family: af}] = lease
+}


### PR DESCRIPTION
## Summary

Pre-existing bug surfaced by Copilot inline review on PR #1564 (#1540 REST API split). Four `pkg/api` call sites passed config-level Junos interface names (containing `/`, e.g. `ge-0/0/0`; or virtual aliases like `reth0`, `fab0.0`, `irb.0`, `gr-0/0/0.1`) directly to `net.InterfaceByName`, which fails silently:

- Linux IFNAMSIZ forbids `/`
- `reth*`/`irb` are virtual config aliases with no kernel ifindex
- VLAN subinterfaces use the **vlan-id tag**, not the Junos unit number

Symptoms: REST `/interfaces` `ifindex=0` for slash-named rows; `/iface-stats` silently drops rows; per-interface Prometheus series missing; `show interfaces detail` prints "Not present" for every Junos-named row.

## Fix

Lift the canonical kernel-name resolution helper from `pkg/dataplane/userspace/interfaces.go::snapshotLinuxName` to a new public `(*Config).ResolveKernelIfName` method in `pkg/config/types.go`. The new helper composes `TunnelNameMap` (per-unit + interface-level), `ResolveReth`, `st*` short-circuit, IRB-to-bridge, and VLAN-vs-unit semantics — matching the dataplane's existing resolution exactly.

Separately, add `(*Config).DHCPLeaseKey` which mirrors the daemon's DHCP lease-key construction (`LinuxIfName(configRef)+.VlanID-when-positive`). The lease key shape is intentionally **different** from the kernel link name: the daemon's `dm.Start()` is called with the config-level RETH name, so `LeaseFor` must be queried with the same shape.

The four `pkg/api` sites now route through `ResolveKernelIfName` for kernel lookups; `writeInterfacesDetail` additionally uses `DHCPLeaseKey` for the lease annotation.

**Drift mitigation:** `// NOTE: Keep in sync` comments at the legacy `snapshotLinuxName` and daemon `resolveJunosIfName` helpers, plus a drift-guard parity test in `pkg/dataplane/userspace/interfaces_test.go`.

## Plan + adversarial review

Plan doc: `docs/pr/1565-iface-name-translate/plan.md`

Six plan-review rounds before any code touched:

- Round 1: Codex NEEDS-MAJOR + AGY NEEDS-MAJOR (tunnel, DHCP key, grpcapi scope, tests)
- Round 2: Codex NEEDS-MAJOR (VLAN-vs-unit conflation in v2; AGY ratified incorrectly)
- Round 3: Codex NEEDS-MAJOR (fab0 IPVLAN, st0.0 XFRM, smoke gates)
- Round 4: Codex NEEDS-MAJOR + AGY NEEDS-MINOR (fab0.0 collapse, ge-0/0/0 not iterated, lo test, drift guard)
- Round 5: Codex NEEDS-MINOR + AGY PLAN-READY (stale text, redundant-parent grammar)
- Round 6: PLAN-READY (all minors folded inline)

Reviewer task IDs (in plan-evolution order): `task-mpnhxusx-4yz6hb`, `review-mpnhya9y-6rigyy`, `task-mpni7vi4-2oacjs`, `review-mpni8bxc-masfic`, `task-mpnij29g-ligphz`, `review-mpnijezy-rbikjh`, `task-mpniviw3-vu39r2`, `review-mpnivrgz-5a90u7`, `task-mpnj4jup-7esjdl`, `review-mpnj4pq0-44twiq`.

## Test plan

- [x] `go vet` clean on modified pkgs (pre-existing vet noise in pkg/daemon/daemon_flow.go etc. is unrelated)
- [x] 12 new unit tests in `pkg/config/types_test.go` (plain, reth, fab, tunnels, tunnel-overrides-VLAN, IRB, unknown unit, malformed suffix, st*, nil-Interfaces, DHCP key mappings)
- [x] 1 drift-guard parity test in `pkg/dataplane/userspace/interfaces_test.go`
- [x] 2 handler tests in `pkg/api/iface_name_test.go` (reth-to-loopback, DHCP lease end-to-end)
- [x] All new tests pass 5/5 flake-free
- [x] Full Go suite passes (30 packages)
- [ ] **AWAITING-BATCH-MERGE** — smoke runs on the batch-merge runner; cluster smoke matrix per protocol

## Out of scope (follow-up)

- grpcapi peer fixes at `pkg/grpcapi/server_show_interfaces.go:31,129` (same bug class — CLI `show interfaces` routes through these).
- Migration of legacy private helpers (`snapshotLinuxName`, daemon `resolveJunosIfName`) to the new public method.

Closes #1565

<!-- AWAITING-BATCH-MERGE -->