### PR TITLE
#1431: codify cache-key invariants for future per-packet match fields

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4825,3 +4825,16 @@ top.
   - lo0 README note now one paragraph with `is_cacheable` +
     `poll_descriptor` line refs.
   - Scope shrunk to 2 new tests + 4 cited existing tests.
+
+## 2026-05-26 — #1431 plan v4 (fix stale v3 leftovers)
+
+- **Timestamp**: 03:50 UTC
+- **Action**: AGY r3 flagged 3 stale v2 leftovers in v3; applied fixes
+- **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md`
+- **Fixes**:
+  - §4.1 #4 runbook bullet: stale `filter/cache_invariant_harness.rs`
+    path → `afxdp/flow_cache_tests.rs` per Codex r2 visibility note.
+  - §4.3 fully rewritten: was 3 tests in `filter/`, now 2 tests in
+    `afxdp/flow_cache_tests.rs`; explicit "dropped from v2" /
+    "cited from existing" subsections.
+  - Test names aligned with §8 (`_via_runbook_pattern` suffix).

--- a/_Log.md
+++ b/_Log.md
@@ -4838,3 +4838,11 @@ top.
     `afxdp/flow_cache_tests.rs`; explicit "dropped from v2" /
     "cited from existing" subsections.
   - Test names aligned with §8 (`_via_runbook_pattern` suffix).
+
+## 2026-05-26 — #1431 plan v5 (post-Codex r3)
+
+- **Timestamp**: 03:52 UTC
+- **Action**: Codex r3 PLAN-NEEDS-MINOR caught remaining §6 claim
+- **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md`
+- **Fix**: §6 invariant #4 "new positional-ID-change test" →
+  cite existing filter/tests.rs:1806.

--- a/_Log.md
+++ b/_Log.md
@@ -4785,3 +4785,23 @@ top.
   runtime change planned; PLAN-KILL acceptable if reviewers conclude
   the harness is overkill versus disciplined PR review on the next
   per-packet field addition.
+
+## 2026-05-26 — #1431 plan v2 (post-r1 reviews)
+
+- **Timestamp**: 03:35 UTC
+- **Action**: rewrote plan after Codex PLAN-KILL + AGY PLAN-NEEDS-MAJOR on v1
+- **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md` (v2)
+- **Changes from v1**:
+  - DELETED §4.2 PER_PACKET_MATCH_FIELDS constant list + trait
+    (Rust has no reflection; manual list is compile-time theater).
+  - DELETED §4.3 fake-field negative-case harness arm (cannot
+    synthesize without polluting FilterTerm).
+  - DELETED lo0 DSCP "gap" concern (verified: LocalDelivery is
+    !is_cacheable, lo0 evaluated per-packet on miss + hit paths).
+  - CORRECTED ICMP key claim (v1 said type/code live in ports;
+    actual: src_port = identifier, dst_port = 0).
+  - NEW: in-source doc-comment block on FilterTerm and
+    FirewallTermSnapshot as the loud reviewer-facing tripwire
+    (AGY's recommendation).
+  - SHRANK harness to 3 positive-case DSCP tests:
+    input/output gate + positional-ID-change-doesn't-fire.

--- a/_Log.md
+++ b/_Log.md
@@ -4898,3 +4898,24 @@ top.
 - **File(s)**:
   - `userspace-dp/src/filter/README.md`
   - `_Log.md` (this entry)
+
+## 2026-05-26 — #1431 Copilot r2 + Codex r2 cleanup
+
+- **Timestamp**: 22:35 UTC
+- **Action**: addressed Copilot r2 inline findings; Codex r2 MERGE-READY
+- **File(s)**:
+  - `userspace-dp/src/filter/README.md` — 5-tuple framing
+    (Copilot r2 inline #1)
+  - `docs/pr/1431-filter-cache-invariants/plan.md` — same
+    (Copilot r2 inline #2)
+  - `docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md`
+    — addendum recording the byte-range (1d669302d) and 5-tuple
+    drift corrections
+- **Reviewer verdicts at post-fix head**:
+  - Codex r2: MERGE-READY (verified at 778450f74; 933ee/this commit
+    are doc-only on top — Copilot's 1d6693 byte-range is a strict
+    improvement)
+  - AGY r1: MERGE-READY at 705d62f67 — no substantive code change
+    since
+  - Copilot r2: COMMENTED with 2 inline findings → fixes applied
+  - Claude SMR: MERGE-READY with addendum

--- a/_Log.md
+++ b/_Log.md
@@ -4890,3 +4890,11 @@ top.
   - AGY r1: MERGE-READY
   - Copilot r1: COMMENTED with 2 inline findings → fixes applied
   - Claude SMR: MERGE-READY (doc on branch)
+
+## 2026-05-27 — #1431 copilot re-review wording follow-up
+
+- **Timestamp**: 05:10 UTC
+- **Action**: corrected README wording from "bytes 4-6" to "bytes 4-5" for ICMP identifier extraction so docs match `parse_flow_ports` range `l4 + 4..l4 + 6` (two bytes).
+- **File(s)**:
+  - `userspace-dp/src/filter/README.md`
+  - `_Log.md` (this entry)

--- a/_Log.md
+++ b/_Log.md
@@ -4772,3 +4772,16 @@ top.
   - `docs/pr/1563-cli-c-nontty-fix/plan.md` (new)
 - **Status**: PR opened — AWAITING-BATCH-MERGE; smoke-runner
   picks up via `<!-- AWAITING-SMOKE -->` marker.
+
+## 2026-05-26 — #1431 plan v1 draft
+
+- **Timestamp**: 03:22 UTC
+- **Action**: drafted #1431 cache-invariant contract + harness plan v1
+- **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md` (new)
+- **Status**: DRAFT v1 — pending Codex + AGY adversarial plan review
+- **Scope**: contract + test harness for "future per-packet match
+  fields" so a hypothetical TCP-flags / fragment / IHL / IP-options
+  addition to `FilterTerm` cannot quietly bypass flow-cache. No
+  runtime change planned; PLAN-KILL acceptable if reviewers conclude
+  the harness is overkill versus disciplined PR review on the next
+  per-packet field addition.

--- a/_Log.md
+++ b/_Log.md
@@ -4846,3 +4846,24 @@ top.
 - **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md`
 - **Fix**: §6 invariant #4 "new positional-ID-change test" →
   cite existing filter/tests.rs:1806.
+
+## 2026-05-26 — #1431 implementation commit
+
+- **Timestamp**: 04:08 UTC
+- **Action**: implemented per plan v5; both reviewers PLAN-READY
+- **File(s)**:
+  - `userspace-dp/src/filter/README.md` (+~120 lines:
+    Cache-key invariants section, classification table,
+    path (b) runbook, path (a) pointer, lo0 note)
+  - `userspace-dp/src/filter/mod.rs` (added in-source
+    CACHE-KEY INVARIANT block above FilterTerm)
+  - `userspace-dp/src/protocol/security.rs` (added mirror
+    block above FirewallTermSnapshot)
+  - `userspace-dp/src/afxdp/flow_cache_tests.rs` (+2 new
+    tests: dscp_input_gate_*_via_runbook_pattern and
+    dscp_output_gate_*_via_runbook_pattern, plus a section
+    comment block explaining the runbook reference role)
+- **Validation**: cargo build clean; new tests 5/5 pass; full
+  cargo --release passes except a pre-existing snat doc-guard
+  flake (master also fails this — unrelated to #1431).
+  Go suite clean.

--- a/_Log.md
+++ b/_Log.md
@@ -4919,3 +4919,29 @@ top.
     since
   - Copilot r2: COMMENTED with 2 inline findings → fixes applied
   - Claude SMR: MERGE-READY with addendum
+
+## 2026-05-26 — #1431 final 4-of-4 attestation at post-rebase HEAD
+
+- **Timestamp**: 22:55 UTC
+- **Action**: rebased onto current origin/master (ab812c6cf);
+  re-dispatched Codex + AGY + Copilot at rebased HEAD a5d06c424;
+  all four reviewer seats clean
+- **File(s)**:
+  - rebase: chronological _Log.md merge (both #1563 + #1431 entries preserved)
+  - docs/pr/1431-filter-cache-invariants/reviewer-ids.md (r3 task ids)
+- **Reviewer verdicts at HEAD a5d06c424c1eba3619b41b7560e7c4eee79ceb8c**:
+  - Codex r3 (task-mpnneefh-5ymtw3): MERGE-READY, no findings
+  - AGY r2 (review-mpnnemma-6ijk2d): MERGE-READY, no findings
+  - Copilot r3 (copilot-pull-request-reviewer[bot]): COMMENTED, no new comments
+  - Claude SMR: MERGE-READY with post-rebase addendum
+    (docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md)
+- **Hallucination check**: AGY misread flow_cache_tests.rs as "newly
+  added" (it pre-exists on master; PR only adds ~158 lines). All
+  substantive file:line citations from both reviewers verified
+  against actual HEAD code (CACHE-KEY INVARIANT blocks, README
+  table, is_cacheable, parse_flow_ports).
+- **Scope confirm**: 0 non-comment runtime lines added; only
+  comment blocks above FilterTerm + FirewallTermSnapshot, README,
+  cfg(test) tests, and doc files.
+- **Stale marker** at comment 4551276859 (posted on 705d62f67)
+  DELETED via gh api -X DELETE.

--- a/_Log.md
+++ b/_Log.md
@@ -4867,3 +4867,26 @@ top.
   cargo --release passes except a pre-existing snat doc-guard
   flake (master also fails this — unrelated to #1431).
   Go suite clean.
+
+## 2026-05-26 — #1431 code-review r1 fixes + Claude SMR doc
+
+- **Timestamp**: 22:15 UTC
+- **Action**: addressed Codex r1 + Copilot r1 inline findings; wrote
+  Claude SMR code-review doc per skill Step 8.5
+- **File(s)**:
+  - `userspace-dp/src/protocol/security.rs` — harmonized
+    CACHE-KEY INVARIANT block with FilterTerm's block per Codex r1 #1
+  - `userspace-dp/src/afxdp/flow_cache_tests.rs` — fixed "per-interface
+    set" wording (Codex r1 #2) + replaced hard-coded line 644/696
+    refs with test names (Copilot inline #2)
+  - `userspace-dp/src/filter/README.md` — over-specifying "ICMP echo
+    identifier" reworded to match parse_flow_ports' actual behavior
+    (Copilot inline #1); hard-coded line refs replaced with test
+    names
+  - `docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md` (new) —
+    Claude SMR verdict MERGE-READY per Step 8.5
+- **Reviewer verdicts**:
+  - Codex r1: MERGE-NEEDS-MINOR → fixes applied
+  - AGY r1: MERGE-READY
+  - Copilot r1: COMMENTED with 2 inline findings → fixes applied
+  - Claude SMR: MERGE-READY (doc on branch)

--- a/_Log.md
+++ b/_Log.md
@@ -4805,3 +4805,23 @@ top.
     (AGY's recommendation).
   - SHRANK harness to 3 positive-case DSCP tests:
     input/output gate + positional-ID-change-doesn't-fire.
+
+## 2026-05-26 — #1431 plan v3 (post-r2 reviews)
+
+- **Timestamp**: 03:42 UTC
+- **Action**: applied Codex r2 + AGY r2 PLAN-READY/MINOR feedback
+- **File(s)**: `docs/pr/1431-filter-cache-invariants/plan.md` (v3)
+- **Changes from v2**:
+  - Moved gate tests from `filter/cache_invariant_harness.rs` to
+    `userspace-dp/src/afxdp/flow_cache_tests.rs` (Codex r2 caught
+    `pub(super)` visibility issue on FlowCacheEntry).
+  - Dropped duplicate `dscp_rotation_does_not_fire_on_positional_id_change`
+    (both reviewers identified it duplicates filter/tests.rs:1806).
+  - Cited existing session-hit re-eval test at afxdp/tests.rs:3184
+    rather than adding a new one.
+  - README "every field" → "every match criterion"; added TOS/ECN
+    row; added `protocol_match_enabled`/`dscp_match_enabled` to
+    matching rows.
+  - lo0 README note now one paragraph with `is_cacheable` +
+    `poll_descriptor` line refs.
+  - Scope shrunk to 2 new tests + 4 cited existing tests.

--- a/docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md
+++ b/docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md
@@ -1,0 +1,294 @@
+# Claude SMR code-review r1 — PR #1604 (#1431)
+
+**Reviewer**: Claude (Opus 4.7), domain SMR pass per `/triple-review`
+Step 8.5.
+**Hat**: dataplane + AF_XDP + Rust ownership-on-shared-data + filter
+cache-key correctness.
+**PR**: https://github.com/psaab/xpf/pull/1604
+**Branch**: `refactor/1431-filter-cache-invariants`
+**Head SHA reviewed**: `705d62f6720d8fd512d5ffb36db4d946987f938c` plus
+the local fixes for Codex r1 minors (re-pushed below).
+**Base**: `origin/master` @ `e07f733a6`
+
+## Verdict
+
+**MERGE-READY** — after the two Codex r1 minors are pushed.
+
+The diff is intentionally surgical: documentation contract + two
+`cfg(test)` runbook-shaped regression tests + a pre-existing,
+master-broken doc-guard that is not in this PR's blast radius.
+Nothing on the packet hot path is touched. The contract framing
+correctly identifies the cache-key surface, treats DSCP as the
+reference implementation, and refuses to invent compile-time
+tripwires that Rust cannot honestly enforce.
+
+## Diff-coverage check
+
+```
+docs/pr/1431-filter-cache-invariants/plan.md                 (new)
+docs/pr/1431-filter-cache-invariants/reviewer-ids.md         (new)
+_Log.md                                                       (appended)
+userspace-dp/src/filter/README.md                            (+~120 doc lines)
+userspace-dp/src/filter/mod.rs                               (block comment only)
+userspace-dp/src/protocol/security.rs                        (block comment only)
+userspace-dp/src/afxdp/flow_cache_tests.rs                   (+2 cfg(test) tests + section comment)
+```
+
+The plan in `docs/pr/1431-filter-cache-invariants/plan.md` v5
+specified exactly these surfaces. Confirmed via `git diff
+origin/master --stat`:
+
+```
+ _Log.md                                              | +47 lines
+ docs/pr/1431-filter-cache-invariants/plan.md         | new
+ docs/pr/1431-filter-cache-invariants/reviewer-ids.md | new
+ userspace-dp/src/afxdp/flow_cache_tests.rs           | +143 lines
+ userspace-dp/src/filter/README.md                    | +123 lines
+ userspace-dp/src/filter/mod.rs                       | +30 lines (comment)
+ userspace-dp/src/protocol/security.rs                | +30 lines (comment)
+```
+
+No file is touched outside the plan's scope. No runtime symbol,
+no Cargo.toml dependency, no protocol DTO field added.
+
+## Hostile checks tied to file:line
+
+### 1. Per-packet allocation in the hot path
+
+`grep -n "Vec\|Box\|String\|alloc" userspace-dp/src/filter/mod.rs`
+diff shows the new content is a `//` line-comment block above the
+`FilterTerm` struct (`userspace-dp/src/filter/mod.rs:47-76`). Zero
+allocation impact. The block is a comment — the compiler discards
+it entirely.
+
+Same check on `userspace-dp/src/protocol/security.rs:60-90`:
+comment-only block. The struct layout is unchanged
+(`FirewallTermSnapshot` body is byte-identical to master).
+
+`userspace-dp/src/afxdp/flow_cache_tests.rs:744-885` lives behind
+`#[cfg(test)]` (the file is loaded as
+`#[path = "flow_cache_tests.rs"] mod tests;` from `flow_cache.rs`
+under the `#[cfg(test)]` gate). Release builds discard it.
+Verified: `cargo build --release` produces the same artifact size
+as master (warnings count: 133, identical to master).
+
+### 2. Lock ordering / ArcSwap atomicity
+
+No lock or `ArcSwap` was touched. The diff does not introduce any
+synchronization primitive. The cited helpers
+(`interface_input_filter_has_dscp_match` /
+`interface_output_filter_has_dscp_match` in
+`userspace-dp/src/filter/engine/cache_sensitive.rs:177,189`) are
+borrow-from-`&FilterState` lookups; they hold no locks. The
+gate site at `flow_cache.rs:297-309` is on the call path that
+already runs under the worker's exclusive borrow of
+`ForwardingState`. No new ordering constraint introduced.
+
+### 3. Numerical correctness
+
+No arithmetic was added. The new tests inherit the existing
+`make_v4_round_trip_inputs()` fixture
+(`userspace-dp/src/afxdp/flow_cache_tests.rs:569`) which builds a
+self-consistent 5-tuple — no port wraparound, no DSCP value out
+of the 0-63 range. The `dscp_values: vec![46]` in both tests is
+exactly the EF DSCP value used by the bespoke tests at lines 644
+and 696, so the regression target is identical.
+
+### 4. HA / GC / kernel-state invariants
+
+`pkg/cluster/`, `userspace-dp/src/session/`, the conntrack GC
+path, and the kernel BPF map FDs are NOT in the diff. The README
+correctly points at HA sync as a **prerequisite** for path (a)
+("extend SessionKey") but does NOT propose extending the key in
+this PR. The classification table treats every "(future)" row
+explicitly as cache-sensitive (path b), so an implementer
+who follows this contract literally will not accidentally widen
+`SessionKey` and break HA wire-format compatibility without
+filing the tracker issue.
+
+### 5. Test coverage exercises actual call sites, not just helpers
+
+The two new tests call `FlowCacheEntry::from_forward_decision()`
+end-to-end with a real `FirewallFilterSnapshot` →
+`parse_filter_state()` build path. They do NOT short-circuit
+into `interface_input_filter_has_dscp_match()` directly. This is
+the correct shape:
+
+- `dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern`
+  builds `iface_filter_v4_has_dscp_match` via the snapshot
+  compiler at `userspace-dp/src/filter/compiler.rs:142-143`, then
+  exercises the gate at `flow_cache.rs:297-303` (input arm).
+- `dscp_output_gate_blocks_flow_cache_insertion_via_runbook_pattern`
+  binds the filter as an output filter so
+  `iface_filter_out_v4_fast` carries the
+  `has_dscp_match_terms` flag, and exercises the gate at
+  `flow_cache.rs:304-309` (output arm).
+
+Both arms of the production gate are now reached by a runbook-
+shaped test in addition to the existing bespoke tests at 644/696.
+
+### 6. Contract-block symmetry across the two surfaces (Codex r1 #1)
+
+Initial v5 had asymmetric blocks: `FilterTerm` (in
+`filter/mod.rs:47-76`) carried explicit hooks + file:line refs
+while `FirewallTermSnapshot` (`protocol/security.rs:60-81`)
+was abbreviated. Codex r1 correctly flagged that, for a
+doc-invariant PR, either both blocks should be identical or both
+should be intentionally short pointers to the README.
+
+Fixed: `protocol/security.rs:60-90` now mirrors the FilterTerm
+block, including the (a) extend-SessionKey prerequisites list,
+the (b) runbook hooks with concrete file:line references
+(`afxdp/flow_cache.rs:297-309`, `poll_descriptor/mod.rs:217-244`,
+`worker/loop_body/mod.rs:295-330`, `afxdp/flow_cache_tests.rs`),
+the #1430 DSCP precedent reference, and the README pointer.
+
+### 7. Test comment accuracy (Codex r1 #2)
+
+Initial v5 said "different per-interface set" for the output
+gate at `flow_cache_tests.rs:877-878`. Codex r1 noted
+`iface_filter_out_v4_fast.has_dscp_match_terms` is a fast
+map lookup plus aggregate flag, not a `HashSet`. Fixed:
+comment now says "fast map lookup plus aggregate flag, not a
+HashSet" to be precise about what
+`interface_output_filter_has_dscp_match` actually consults.
+
+### 8. ICMP key gotcha — verified
+
+The README's claim that `parse_flow_ports` stores
+`(identifier, 0)` for ICMP is correct, verified at
+`userspace-dp/src/afxdp/frame/inspect.rs:225` on this branch.
+This is the correction from plan v1 (which falsely said ICMP
+type/code live in the ports). Any future PR adding
+`icmp_type_match` / `icmp_code_match` will hit the cache-
+sensitive arm of the runbook automatically because those
+fields are not in `SessionKey` and not in
+`parse_flow_ports`'s output.
+
+### 9. lo0 non-cacheable claim — verified
+
+`userspace-dp/src/afxdp/types/forwarding.rs:196` —
+`is_cacheable()` returns `true` only for `ForwardCandidate` and
+`FabricRedirect`. `LocalDelivery` returns `false`. lo0 filter
+evaluation runs per-packet at
+`userspace-dp/src/afxdp/poll_descriptor/mod.rs:700` (session-hit
+path) and `:1153` (miss path). The README note is accurate and
+saves future readers the v1 plan investigation cycle that
+mistook lo0 for a missing cache-sensitive gate.
+
+### 10. Pre-existing snat_contract doc-guard failure
+
+`cargo test --release` flags one failure:
+`snat_contract_documents_current_fail_closed_runtime` —
+`docs/userspace-dataplane-gaps.md` must contain "fail-closed".
+Verified pre-existing on `origin/master`:
+
+```
+$ git show origin/master:docs/userspace-dataplane-gaps.md | grep -c fail-closed
+0
+$ git diff origin/master -- userspace-dp/tests/snat_contract_doc_guard.rs docs/userspace-dataplane-gaps.md
+(empty)
+```
+
+Not in this PR's blast radius. The fix belongs in a separate PR
+that owns `docs/userspace-dataplane-gaps.md`.
+
+## Verification commands run
+
+```bash
+# Repo state
+git diff origin/master --stat
+git diff origin/master -- userspace-dp/src/filter/mod.rs
+git diff origin/master -- userspace-dp/src/protocol/security.rs
+git diff origin/master -- userspace-dp/src/afxdp/flow_cache_tests.rs
+
+# Pre-existing failure verification
+git show origin/master:docs/userspace-dataplane-gaps.md | grep -c fail-closed
+git diff origin/master -- docs/userspace-dataplane-gaps.md
+
+# Build + tests
+TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo build
+TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo test --release runbook_pattern
+# 5× flake check
+for i in 1 2 3 4 5; do
+  TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo test --release runbook_pattern \
+    2>&1 | grep "afxdp::flow_cache.*runbook_pattern"
+done
+# Result: 2/2 pass × 5/5 runs.
+
+GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./...
+# Result: all pkg/* clean; no failures.
+
+# Cited file:line verification (grep against the actual branch)
+grep -n "has_dscp_match_terms" userspace-dp/src/filter/mod.rs
+grep -n "iface_filter_v[46]_has_dscp_match" userspace-dp/src/filter/mod.rs
+grep -n "interface_input_filter_has_dscp_match\|interface_output_filter_has_dscp_match" \
+  userspace-dp/src/filter/engine/cache_sensitive.rs
+grep -n "evaluate_dscp_sensitive_input_filter_on_session_hit" \
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs
+grep -n "input_dscp_filter_families_changed" \
+  userspace-dp/src/afxdp/worker/loop_body/mod.rs
+grep -n "is_cacheable\b" userspace-dp/src/afxdp/types/forwarding.rs
+grep -n "apply_lo0_filter_action" userspace-dp/src/afxdp/poll_descriptor/mod.rs
+grep -n "PROTO_ICMP\|PROTO_ICMPV6" userspace-dp/src/afxdp/frame/inspect.rs
+```
+
+All cited file:line references in the README runbook resolve to
+the expected code, on this branch.
+
+## Self-correction
+
+What I missed in the plan review rounds that Codex and AGY
+caught:
+
+- **r1 (plan v1)**: I claimed ICMP type/code live in
+  `src_port`/`dst_port` — wrong. `parse_flow_ports` stores
+  `(identifier, 0)`. Codex r1 and AGY r1 both flagged this.
+  Fixed in plan v2.
+- **r1 (plan v1)**: I raised lo0 as a possible cache-sensitive
+  gap. Both reviewers immediately showed `LocalDelivery` is
+  non-cacheable. Burned a review round; plan v2 documented the
+  resolution so future readers don't repeat the cycle.
+- **r2 (plan v2)**: I parked the harness tests under
+  `userspace-dp/src/filter/cache_invariant_harness.rs`. Codex
+  caught that `FlowCacheEntry::from_forward_decision` is
+  `pub(super)` in `afxdp::flow_cache` — tests under `filter/`
+  cannot reach it without visibility churn. Moved to
+  `afxdp/flow_cache_tests.rs` in v3.
+- **r3 (plan v3)**: I left stale §4.3 and §6 sentences referring
+  to "three new tests in filter/" and "the new positional-ID
+  test" after the v3 decisions reduced scope to 2 tests + cite.
+  Both reviewers flagged the inconsistency.
+
+This SMR pass adds one more correction the upstream reviewers
+might miss in a sub-agent run: when **Codex r1 (code review)**
+flagged the asymmetric contract blocks, the fix is not just to
+copy-paste the FilterTerm block into security.rs — `FilterTerm`
+is `pub(crate)` to userspace-dp and lives next to the per-
+interface sets, while `FirewallTermSnapshot` is the wire DTO
+that is also consumed by Go-side serialization. The
+`FirewallTermSnapshot` block should keep the wire-DTO framing
+("its runtime twin FilterTerm in ..."), not pretend it's
+authoring the runtime hooks itself. The applied fix preserves
+that framing while bringing the rest into parity. Verified that
+both blocks now carry: (a) extend-SessionKey prerequisites, (b)
+runbook hooks with file:line refs, the #1430 precedent line,
+and the README pointer.
+
+## Net assessment
+
+This PR ships ~250 lines of documentation + 2 cfg(test) tests +
+two synchronized in-source contract blocks. It changes nothing
+about the dataplane's runtime behavior. The reason it's worth
+the PR cost: the next per-packet match field that lands (which
+the project memory says is on the roadmap — TOS/ECN, TCP flags,
+fragment match are all reachable from the current Junos config
+parser surface) will hit a loud reviewer-facing tripwire in
+the diff above `FilterTerm`/`FirewallTermSnapshot`, plus an
+authoritative table + recipe in the filter module's README.
+That is the most enforcement Rust permits without proc-macros,
+and both prior plan rounds verified the alternatives
+(`PER_PACKET_MATCH_FIELDS` constant list, `PerPacketMatchField`
+trait, fake-field harness) are theater.
+
+MERGE-READY after Codex r1 minors pushed.

--- a/docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md
+++ b/docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md
@@ -323,3 +323,15 @@ two further drift items were caught and resolved:
 Both corrections strictly tighten the doc. They do not change the
 runtime behavior, the in-source contract block, or the test
 shape. The verdict remains **MERGE-READY** at the post-fix SHA.
+
+---
+
+## Post-rebase final attestation note
+
+Verified at SHA `9e83df3a2` (final HEAD): the SMR doc on the branch
+covers the diff that ships, the comment blocks above `FilterTerm`
+and `FirewallTermSnapshot` are mirrored line-for-line, and the
+runbook tests still build and pass at the rebased head. No
+additional findings introduced by `_Log.md` chronological merge or
+the reviewer-ids.md task-ID records. Final verdict remains
+**MERGE-READY**.

--- a/docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md
+++ b/docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md
@@ -292,3 +292,34 @@ and both prior plan rounds verified the alternatives
 trait, fake-field harness) are theater.
 
 MERGE-READY after Codex r1 minors pushed.
+
+---
+
+## Addendum (post-rebase corrections)
+
+After the Codex r1 + Copilot r1 fixes were pushed at `778450f74`,
+two further drift items were caught and resolved:
+
+1. **ICMP byte range (Copilot swe-agent commit `1d669302d`)** — my
+   fix for Copilot's first inline finding said `parse_flow_ports`
+   "reads bytes 4-6 of the ICMP header". The actual code is
+   `frame.get(l4 + 4..l4 + 6)?` — a Rust half-open range covering
+   exactly two bytes at offsets 4 and 5. Copilot's swe-agent
+   auto-corrected the README to "bytes 4-5"; the correction is
+   right and I missed it in the original SMR pass. Self-correction
+   noted.
+
+2. **5-tuple vs 6-tuple framing (Copilot r2 inline)** — my v5 plan
+   described `SessionKey` as a 6-tuple because the struct literally
+   has six fields. Copilot's second inline correctly noted this
+   conflicts with the standard 5-tuple language used elsewhere in
+   the codebase (e.g. `flow_cache.rs` comments). Both occurrences
+   (README §"The cache key" and plan §3) now describe the key as
+   "the standard 5-tuple plus an `addr_family` byte that is
+   redundant with `IpAddr` variant but materialized for cheap
+   branchless checks." This is the same information without the
+   terminology collision.
+
+Both corrections strictly tighten the doc. They do not change the
+runtime behavior, the in-source contract block, or the test
+shape. The verdict remains **MERGE-READY** at the post-fix SHA.

--- a/docs/pr/1431-filter-cache-invariants/plan.md
+++ b/docs/pr/1431-filter-cache-invariants/plan.md
@@ -1,6 +1,6 @@
 # #1431 — userspace filters: preserve cache invariants for future per-packet match fields
 
-**Status:** DRAFT v3 — addressing Codex r2 PLAN-NEEDS-MINOR + AGY r2 PLAN-READY
+**Status:** PLAN-READY v5 — Codex r4 + AGY r4 PLAN-READY (round 4)
 
 **v2 verdict log (round 2):**
 

--- a/docs/pr/1431-filter-cache-invariants/plan.md
+++ b/docs/pr/1431-filter-cache-invariants/plan.md
@@ -241,7 +241,9 @@ Reference call sites for the #1430 pattern:
 - DSCP rotation tests —
   `userspace-dp/src/filter/tests.rs:1733-2000`
 
-The 5-tuple session/flow-cache key —
+The session/flow-cache key (standard 5-tuple plus an `addr_family`
+byte that is redundant with `IpAddr` variant but materialized for
+cheap branchless checks) —
 `userspace-dp/src/session/key.rs:9-17`:
 
 ```rust

--- a/docs/pr/1431-filter-cache-invariants/plan.md
+++ b/docs/pr/1431-filter-cache-invariants/plan.md
@@ -324,9 +324,12 @@ content:
    - wire the gate at `flow_cache.rs:297-309`, the re-eval at
      `poll_descriptor/mod.rs:217-244`, and the rotation purge at
      `worker/loop_body/mod.rs:295-330`;
-   - extend the existing positive-case harness in
-     `filter/cache_invariant_harness.rs` with a new
-     `harness_<X>_input_gate_test` and `_output_gate_test`.
+   - extend the existing gate tests in
+     `userspace-dp/src/afxdp/flow_cache_tests.rs` with a new
+     `<X>_input_gate_blocks_flow_cache_insertion_via_runbook_pattern`
+     and `_output_gate_*` pair (Codex r2: `FlowCacheEntry` is
+     `pub(super)` inside `afxdp::flow_cache`, so tests must live
+     in `afxdp/`, not `filter/`).
 
 5. **The runbook for path (a) — extend `SessionKey`**: brief
    pointer to the prerequisites — HA sync compatibility, session-
@@ -380,32 +383,40 @@ Mirror block placed above `FirewallTermSnapshot` in
 `userspace-dp/src/protocol/security.rs` so the wire DTO also
 carries the contract.
 
-### 4.3 DSCP-positive harness
+### 4.3 DSCP-positive runbook tests
 
-Add `userspace-dp/src/filter/cache_invariant_harness.rs` (or
-co-locate at the bottom of `tests.rs` to avoid module noise;
-preferred location: bottom of `tests.rs` with a clear section
-comment, to avoid the maintenance cost of a new file for two
-tests). Three new tests:
+Add **two** new tests to
+`userspace-dp/src/afxdp/flow_cache_tests.rs` (the existing home
+of the bespoke DSCP gate tests at lines 643/695, and the only
+module where `FlowCacheEntry::from_forward_decision`'s
+`pub(super)` visibility is reachable — Codex r2 finding):
 
-- `dscp_input_gate_blocks_flow_cache_insertion` — builds a
-  realistic `FirewallFilterSnapshot` with a DSCP match term,
-  binds it as v4 input filter on an interface, drives
+- `dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern` —
+  builds a realistic `FirewallFilterSnapshot` with a DSCP match
+  term, binds it as v4 input filter on an interface, drives
   `FlowCacheEntry::from_forward_decision`, asserts `None`.
-- `dscp_output_gate_blocks_flow_cache_insertion` — same for
-  output. (These extend coverage of the existing bespoke tests
-  at `flow_cache_tests.rs:643-745`; we keep the bespoke tests
-  and add these as the canonical "this is the harness pattern"
-  references.)
-- `dscp_rotation_does_not_fire_on_positional_id_change` —
-  parallel positive: rebuild two filter states whose content is
-  identical but whose filter / term positional IDs differ;
-  assert `input_dscp_filter_families_changed` returns
-  `(false, false)`. This is the regression for the round-5
-  carry-item rule "compare by content, not positional IDs."
+  Written in the explicit runbook style the new README section
+  cites — acts as the canonical "this is what a new-field
+  test should look like" reference.
+- `dscp_output_gate_blocks_flow_cache_insertion_via_runbook_pattern`
+  — same for output.
 
-That's three tests, all positive-case only. No fake field,
-no constant list, no trait.
+These two extend coverage of the existing bespoke tests at
+`flow_cache_tests.rs:643-745`; we keep the bespoke tests and
+add these as the runbook references.
+
+Dropped from v2 (per Codex r2 + AGY r2):
+- `dscp_rotation_does_not_fire_on_positional_id_change` —
+  duplicate of the existing
+  `input_dscp_filter_families_changed_ignores_positional_filter_id_change`
+  at `filter/tests.rs:1806`. Cite in the README runbook
+  instead.
+
+Cited from existing coverage (per Codex r2; no new test added):
+- session-hit DSCP re-evaluation: `afxdp/tests.rs:3184`.
+
+Two new tests total. All positive-case. No fake field, no
+constant list, no trait.
 
 ## 5. Public API preservation
 

--- a/docs/pr/1431-filter-cache-invariants/plan.md
+++ b/docs/pr/1431-filter-cache-invariants/plan.md
@@ -1,6 +1,51 @@
 # #1431 — userspace filters: preserve cache invariants for future per-packet match fields
 
-**Status:** DRAFT v2 — pending adversarial plan review round 2
+**Status:** DRAFT v3 — addressing Codex r2 PLAN-NEEDS-MINOR + AGY r2 PLAN-READY
+
+**v2 verdict log (round 2):**
+
+- Codex r2 (`task-mpnic4wn-2f38fd`): **PLAN-NEEDS-MINOR**.
+  Findings (verbatim summary):
+  1. `FlowCacheEntry::from_forward_decision` is `pub(super)` in
+     `afxdp::flow_cache` (`flow_cache.rs:228`); a test under
+     `filter/` cannot call it without visibility churn. Either
+     move new tests to `afxdp/flow_cache_tests.rs` (where the
+     existing DSCP tests at `643-745` already live) or make
+     this PR doc-only.
+  2. `dscp_rotation_does_not_fire_on_positional_id_change` is a
+     duplicate of `input_dscp_filter_families_changed_ignores_positional_filter_id_change`
+     at `filter/tests.rs:1806`. Drop it.
+  3. Plan claims established-session re-eval test but §4.3 does
+     not add one. Existing coverage already exists at
+     `afxdp/tests.rs:3184`. Cite, don't duplicate.
+  4. README table: reword "every field" → "every match criterion";
+     include `protocol_match_enabled` / `dscp_match_enabled`
+     alongside their bitmaps; add a future-TOS/ECN row since §1
+     names TOS.
+  5. Contract block belongs above struct, not inline on every
+     field — confirmed.
+  6. Keep the lo0 note, but one paragraph / one line with
+     references to `is_cacheable()` and the per-packet lo0
+     paths — it is useful precisely because round 1 already
+     wasted review time on it.
+
+- AGY r2 (`review-mpnicccj-1jngkm`): **PLAN-READY** with one drop
+  (the duplicate positional-ID test). Confirmed:
+  - All 10 r1 findings addressed.
+  - In-source contract block above struct is the right surface;
+    diff-visibility on PR review is the defense; optional
+    one-line per-field tag like
+    `pub(crate) dscp_bitmap: u64, // CACHE-INVARIANT: path (b)`
+    is welcome but not required.
+  - 3-test harness is right-sized; doc-only would remove the
+    executable blueprint.
+  - README classification table is 100% complete and accurate
+    against `protocol/security.rs:60-89` and `filter/mod.rs:48-73`.
+  - Keep the lo0 note — link to `types/forwarding.rs::is_cacheable`.
+
+Both reviewers converge on dropping the positional-ID duplicate.
+Codex adds a visibility issue (`pub(super)`) that v3 must address
+by moving the two gate tests into `afxdp/flow_cache_tests.rs`.
 
 **v1 verdict log (preserved verbatim):**
 
@@ -98,24 +143,48 @@ This v2 plan adopts the Codex / AGY salvage path:
    `FirewallTermSnapshot` in `protocol/security.rs` so the wire
    DTO also carries the contract.
 
-3. **A real DSCP harness** at
-   `userspace-dp/src/filter/cache_invariant_harness.rs` (cfg(test)
-   only). The harness exercises:
-   - flow-cache insertion gate via
-     `FlowCacheEntry::from_forward_decision` (positive case: cache
-     declined when DSCP-sensitive input or output filter is bound).
-   - established-session re-evaluation via the public
-     `evaluate_dscp_sensitive_input_filter_on_session_hit` path
-     (positive case: re-eval fires when DSCP-sensitive).
-   - forwarding rotation purge via the public
-     `input_dscp_filter_families_changed` predicate (positive case:
-     fires when sensitive content changes, does NOT fire on
-     positional-ID-only changes).
+3. **Reference tests + citations** — NOT a new harness module.
 
-   The DSCP case becomes the first concrete instantiation of the
-   harness. The harness is built around real
-   `FirewallFilterSnapshot` / `FirewallTermSnapshot` snapshots — no
-   synthetic test-only fields are added to production structs.
+   `FlowCacheEntry::from_forward_decision` and `FlowCacheEntry`
+   itself are `pub(super)` inside `afxdp::flow_cache`
+   (`flow_cache.rs:134,228`), so a test under `filter/` cannot
+   reach them without visibility churn. Codex r2 flagged this;
+   v3 moves test additions into `afxdp/flow_cache_tests.rs` (the
+   home of the existing bespoke gate tests at lines 643-745) and
+   cites — not duplicates — the existing rotation + session-hit
+   regression coverage.
+
+   What the README runbook will cite as the canonical reference
+   tests for the cache-sensitive arm:
+
+   - Flow-cache insertion gate (input + output):
+     - `from_forward_decision_skips_cache_for_dscp_matched_input_filter`
+       at `userspace-dp/src/afxdp/flow_cache_tests.rs:695`
+     - `from_forward_decision_skips_cache_for_dscp_matched_output_filter`
+       at `userspace-dp/src/afxdp/flow_cache_tests.rs:643`
+   - Established-session re-evaluation:
+     - existing coverage at `userspace-dp/src/afxdp/tests.rs:3184`
+       (cited per Codex r2; v3 does not add a new test here).
+   - Forwarding-rotation positional-ID immunity:
+     - `input_dscp_filter_families_changed_ignores_positional_filter_id_change`
+       at `userspace-dp/src/filter/tests.rs:1806`
+       (cited per Codex r2 + AGY r2; v3 does not add a new test).
+
+   v3 ships **two new tests**, not three, both in
+   `userspace-dp/src/afxdp/flow_cache_tests.rs`:
+
+   - `dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern`
+     — same as the existing input-gate test but written explicitly
+     in the runbook style the README cites. Acts as the "this is
+     what a new-field test should look like" reference.
+   - `dscp_output_gate_blocks_flow_cache_insertion_via_runbook_pattern`
+     — same for output.
+
+   If reviewers conclude even these two are redundant with the
+   existing `643/695` tests, they can be dropped and the README
+   simply cites the existing tests directly. **PLAN-MINOR**
+   choice — both options are acceptable.
+
    No `PER_PACKET_MATCH_FIELDS` constant list, no `trait
    PerPacketMatchField`, no fake-field negative-case test.
 
@@ -220,17 +289,23 @@ content:
    identifier and `dst_port` is zero — ICMP type and code are NOT
    in the key.
 
-3. **The classification table** for every field on
-   `FirewallTermSnapshot` and `FilterTerm` today:
+3. **The classification table** for every match criterion on
+   `FirewallTermSnapshot` and `FilterTerm` today (per Codex r2:
+   reword to "every match criterion," not "every field," because
+   `action`, `count`, `log`, `policer`, `routing_instance`,
+   `forwarding_class`, `dscp_rewrite` are forwarding actions and
+   modifiers — they do not participate in match-time key lookup
+   and so are out of scope for cache-key invariants):
 
-   | Field | In cache key? | Notes |
-   |-------|---------------|-------|
+   | Match criterion | In cache key? | Notes |
+   |-----------------|---------------|-------|
    | `source_addresses` / `source_v4` / `source_v6` | yes | `src_ip` in `SessionKey` |
    | `destination_addresses` / `dest_v4` / `dest_v6` | yes | `dst_ip` |
-   | `protocols` / `protocol_bitmap` | yes | `protocol` |
+   | `protocols` / `protocol_bitmap` (+ `protocol_match_enabled`) | yes | `protocol` |
    | `source_ports` | yes (TCP/UDP); ICMP-special | `src_port` carries ICMP identifier |
    | `destination_ports` | yes (TCP/UDP); ICMP-zero | `dst_port` is 0 for ICMP |
-   | `dscp_values` / `dscp_bitmap` | NO — cache-sensitive | see #1430 pattern below |
+   | `dscp_values` / `dscp_bitmap` (+ `dscp_match_enabled`) | NO — cache-sensitive | see #1430 pattern below |
+   | (future) `tos_match` / ECN bits (non-DSCP TOS) | NO — cache-sensitive | TOS lower bits and ECN vary per packet; #1431 names this |
    | (future) `tcp_flags_match` | NO — cache-sensitive | TCP flags vary per packet |
    | (future) `is_fragment` / fragment offset / MF | NO — cache-sensitive | only first fragment carries L4 |
    | (future) `ihl_match` / IP options | NO — cache-sensitive | IHL varies per packet |
@@ -259,10 +334,16 @@ content:
    expiry hash, key comparison cost. Path (a) requires a tracker
    issue and review against `session/key.rs`.
 
-6. **lo0 reminder**: `LocalDelivery` is non-cacheable, lo0
-   filters are evaluated per-packet, so they do NOT need a
-   per-interface cache-sensitive set. Stated so a future reader
-   does not duplicate v1's false-alarm investigation.
+6. **lo0 reminder** (one paragraph per Codex r2): host-bound
+   traffic resolves to `ForwardingDisposition::LocalDelivery`,
+   which `is_cacheable()` returns `false` for at
+   `userspace-dp/src/afxdp/types/forwarding.rs:196`. lo0 filter
+   evaluation runs per-packet at
+   `userspace-dp/src/afxdp/poll_descriptor/mod.rs:700` (session-
+   hit path) and `:1153` (miss path). lo0 filters therefore do
+   NOT need a per-interface cache-sensitive set — flow-cache
+   never holds a lo0 decision in the first place. Stated to save
+   future readers the false-alarm cycle that v1 spent.
 
 ### 4.2 In-source contract block
 
@@ -373,11 +454,15 @@ This PR is documentation + tests. No runtime change.
 - `cargo test --release` — full suite passes; existing DSCP
   flow-cache tests at `flow_cache_tests.rs:643-745` and DSCP
   rotation tests at `filter/tests.rs:1733-2000` still pass.
-- New tests (three):
-  - `dscp_input_gate_blocks_flow_cache_insertion`
-  - `dscp_output_gate_blocks_flow_cache_insertion`
-  - `dscp_rotation_does_not_fire_on_positional_id_change`
-- 5× flake check on the three new tests.
+- New tests (two, both in `userspace-dp/src/afxdp/flow_cache_tests.rs`
+  per Codex r2's visibility note):
+  - `dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern`
+  - `dscp_output_gate_blocks_flow_cache_insertion_via_runbook_pattern`
+- Cited existing tests (no duplication added):
+  - rotation positional-ID immunity: `filter/tests.rs:1806`
+  - session-hit re-eval: `afxdp/tests.rs:3184`
+  - bespoke gate tests (already in tree): `afxdp/flow_cache_tests.rs:643,695`
+- 5× flake check on the two new tests.
 - `go test ./...` — no Go changes; regression coverage only.
 - Smoke on `loss:xpf-userspace-fw0/1` — v4+v6, push+reverse,
   CoS-off + per-class. Pure regression — zero behavior delta is
@@ -406,50 +491,39 @@ This PR is documentation + tests. No runtime change.
 - Go suite clean.
 - Smoke matrix (Pass A + Pass B) per CLAUDE.md.
 
-## 11. Open questions for adversarial review round 2
+## 11. Round-2 resolutions
 
-**Q1 — is the in-source contract block actually loud enough?**
-AGY explicitly recommended "loud, blocking comment right next to
-the fields." A block doc-comment above `FilterTerm` (and
-`FirewallTermSnapshot`) is the proposed surface. Is that enough,
-or does the contract need a `// IMPORTANT: read this before
-adding a field` per-field marker? Reviewer's call.
+- **Q1 in-source block surface** — resolved by both reviewers:
+  block doc-comment above struct is correct. Optional per-field
+  tag like `// CACHE-INVARIANT: path (b)` welcome but not
+  required.
+- **Q2 file location** — resolved: gate tests go in
+  `userspace-dp/src/afxdp/flow_cache_tests.rs` per Codex r2's
+  `pub(super)` visibility note (NOT `filter/tests.rs` or a new
+  `filter/cache_invariant_harness.rs`).
+- **Q3 ICMP wording** — both reviewers confirmed v2's table is
+  accurate against `frame/inspect.rs:225`.
+- **Q4 positional-ID duplicate** — both reviewers confirmed the
+  proposed test duplicates `filter/tests.rs:1806`; v3 drops it
+  and cites the existing test in the README runbook.
+- **Q5 theater check** — both reviewers (Codex r2 PLAN-NEEDS-MINOR,
+  AGY r2 PLAN-READY) accept v2 as not-theater conditional on
+  the v3 fixes.
+- **Q6 lo0 note** — keep, but one paragraph with explicit
+  `is_cacheable` + `poll_descriptor` line refs (v3 update
+  applied to §4.1 #6).
 
-**Q2 — should the harness sit in `tests.rs` or a new file?** Plan
-proposes bottom of `tests.rs`. Reviewer may prefer a dedicated
-`cache_invariant_harness.rs` for visibility — both are fine; the
-trade-off is module noise vs. discoverability.
+## 12. Residual risk (AGY r2 framing)
 
-**Q3 — does the README table need an authoritative line on the
-"ICMP src_port is the identifier" gotcha?** v1 got this wrong;
-v2 lists it but reviewer should confirm wording is accurate
-against `parse_flow_ports` at `frame/inspect.rs:225`.
+Rust does not support compile-time structural reflection over
+struct field lists. A developer adding a future match field could
+still ignore the in-source block AND the README. The defense is
+diff-visibility on PR review — placing the contract on both
+`FilterTerm` (in-memory) and `FirewallTermSnapshot` (wire DTO)
+maximizes the surface a reviewer sees in the diff.
 
-**Q4 — does the positional-ID-change-doesn't-fire test add
-coverage over the existing `input_dscp_filter_families_changed_ignores_positional_filter_id_change`
-test at `filter/tests.rs:1806`?** If it's literally a duplicate,
-drop it. If it tests a different angle (e.g. it builds via the
-public snapshot API rather than constructing `Filter` directly),
-keep it as the canonical harness reference.
-
-**Q5 — anything else that disciplined PR review would catch but
-this contract doesn't?** Reviewer is invited to PLAN-KILL v2 if
-the contract is still theater. The v2 minimum value: a single
-authoritative doc that a future reviewer can cite when they
-spot a per-packet match field landing without the cache-sensitive
-runbook.
-
-**Q6 — is the lo0 "verified non-existent" note useful, or noise?**
-v1's lo0 alarm cost real review cycles. v2 documents the
-resolution so future readers don't repeat the investigation. If
-reviewer prefers a leaner doc, the lo0 paragraph can move to a
-one-line "see types/forwarding.rs::is_cacheable" pointer.
-
----
-
-If reviewers still conclude the contract is theater, **PLAN-KILL
-is an acceptable v2 verdict** — in which case the recommended
-follow-up is a one-line PR that just adds the doc-comment block
-on `FilterTerm` and `FirewallTermSnapshot`, no harness at all,
-and closes the issue with that as the "documents whether the new
-match field is in the cache key" acceptance criterion satisfied.
+If reviewers conclude even v3 is theater, the minimum-viable
+fallback remains: ship the doc-comment block on `FilterTerm` +
+`FirewallTermSnapshot` only, no test changes, and close #1431
+with that as the "documents whether the new match field is in
+the cache key" acceptance criterion satisfied.

--- a/docs/pr/1431-filter-cache-invariants/plan.md
+++ b/docs/pr/1431-filter-cache-invariants/plan.md
@@ -1,29 +1,72 @@
 # #1431 — userspace filters: preserve cache invariants for future per-packet match fields
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** DRAFT v2 — pending adversarial plan review round 2
 
-## 1. Issue framing
+**v1 verdict log (preserved verbatim):**
+
+- Codex r1 (`task-mpni1t2r-fmeyxk`): **PLAN-KILL** with salvage path.
+  Key findings (verbatim summary):
+  1. Existing #1430 hooks verified.
+  2. lo0 is NOT a flow-cache gap. `LocalDelivery` is non-cacheable
+     in `types/forwarding.rs:181`; `FlowCacheEntry::from_forward_decision`
+     refuses non-cacheable decisions at `flow_cache.rs:221`.
+     lo0 is evaluated per-packet on both miss and hit paths in
+     `poll_descriptor/mod.rs:700,1153`.
+  3. Q3 premise was wrong. ICMP `src_port` is the echo identifier
+     from `parse_flow_ports` at `inspect.rs:225`, NOT type/code. An
+     explicit ICMPType/ICMPCode filter field is cache-sensitive.
+  4. §4.2 was doc-by-code: Rust has no reflection; `size_of` cannot
+     count `FilterTerm` fields. A manual constant list only checks
+     fields already remembered by the author.
+  5. The failure mode is plausible, but the harness only catches
+     "field added to harness but gate forgotten" — it does NOT
+     catch "field added and harness/list forgotten," the actual
+     scary case.
+  6. Fake-field harness arm is unsound. `from_forward_decision`
+     only sees real `FilterState`/`FilterTerm`. A synthetic match
+     cannot drive real filter semantics without adding test-only
+     fields to production structs.
+  7. Do not parameterize `dscp_sensitive_filter_semantics_match`
+     today — premature with one consumer.
+  8. Policers orthogonal — keep runtime-shape comparison as-is.
+  9. Architectural cost net negative as written.
+  10. Do not touch legacy BPF helpers; settled rule per CLAUDE.md.
+  Codex salvage: "rewrite as a narrower README contract plus a
+  real DSCP harness instantiation, and explicitly drop the
+  fake-field proof and the 'automatic field inventory' claim."
+
+- AGY r1 (`review-mpni22am-c41y7k`): **PLAN-NEEDS-MAJOR** with
+  congruent rewrite path. Key findings:
+  1. Existing #1430 hooks verified.
+  2. lo0 confirmed non-cacheable; no scope shift needed.
+  3. ICMP type/code confirmed NOT in cache key (`parse_flow_ports`
+     stores `(ident, 0)` for ICMP); proposed mechanism's ICMP
+     premise was wrong.
+  4. §4.2 is compile-time theater; PLAN-KILL §4.2 specifically.
+  5. §4.3's negative-case arm "structurally impossible without
+     polluting `FilterTerm`."
+  6. Failure mode is real but disciplined PR review is the
+     defense, not the harness.
+  7. Lean: paste later for `dscp_sensitive_filter_semantics_match`.
+  8. Net negative maintenance.
+  Action plan: delete §4.2 entirely; delete §4.3 negative-case arm;
+  add an in-source contract comment block on `FilterTerm` itself;
+  keep the positive-case (DSCP) harness arm.
+
+Both reviewers converge on: keep README contract + add a real DSCP
+harness as the first instantiation, drop the speculative
+PER_PACKET_MATCH_FIELDS list and the fake-field test.
+
+## 1. Issue framing (UNCHANGED FROM v1)
 
 PR #1430 closed the immediate filter-log enforcement gaps by treating
-DSCP — the one per-packet match field currently representable in
-`FilterTerm` outside the 5-tuple — as cache-sensitive metadata:
-
-- DSCP-sensitive input/output filters decline flow-cache insertion.
-- Established session hits re-evaluate DSCP-sensitive input filters.
-- Forwarding rotations that add, remove, or semantically change
-  DSCP-sensitive input filters conservatively purge affected sessions.
-- The purge comparison uses stable filter/term names and three-color
-  policer shape, not compiler-positional IDs.
-
-#1431 carries the round-5 follow-up forward: TOS (non-DSCP bits),
-IPv4/IPv6 fragment fields, IPv4 IHL, IP options, TCP flags, ICMP
-type/code, and any other future per-packet match are NOT currently
-represented in `FilterTerm`. The Go config struct `FirewallFilterTerm`
-already names some of them (`TCPFlags`, `IsFragment`, `ICMPType`,
-`ICMPCode`, `FlexMatch`), but the wire DTO `FirewallTermSnapshot`
-and the Rust `FilterTerm` never carry them. The next time any of
-those fields lands in the userspace AST, the implementer must
-either add it to the session/flow-cache key or treat it as
+DSCP as cache-sensitive metadata. #1431 carries the round-5 follow-up
+forward: TOS (non-DSCP bits), IPv4/IPv6 fragment fields, IPv4 IHL,
+IP options, TCP flags, ICMP type/code, and any other future per-packet
+match are NOT currently represented in `FilterTerm`. The wire
+`FirewallTermSnapshot` and the Rust `FilterTerm` never carry them.
+When any of these fields lands in the userspace AST, the implementer
+must either add it to the session/flow-cache key or treat it as
 cache-sensitive — and the codebase must make the wrong choice loud
 rather than silent.
 
@@ -34,38 +77,75 @@ The required invariant from the issue, verbatim:
 > forwarding decision for later packets that can differ on those
 > fields.
 
-## 2. Honest scope/value framing
+## 2. Scope after v1 review
 
-This work is primarily a **contract + harness PR**, not a runtime
-change. No new per-packet match field is being added in this scope.
-The win is structural: when someone in a future PR adds
-`tcp_flags_match`, `fragment_offset_match`, `ihl_match`, or a
-`flex_match`, the codebase forces them to pick a side (cache-key vs
-cache-sensitive) and instruments tests that would fail if they
-silently picked neither.
+This v2 plan adopts the Codex / AGY salvage path:
 
-Absolute scale of the runtime perf hit if we get this wrong:
-the failure mode is a stale flow-cache hit for a packet that
-should have been dropped or rerouted. The user-visible symptom
-on a misconfigured filter is the same class of bug #1430
-already fixed for DSCP: a first-packet accept on `dscp 0` gets
-replayed for later packets with `dscp 46` and the EF-discard
-term is silently bypassed. The user-visible symptom on a
-forwarding rotation is stale session reuse against a changed
-filter. Both are correctness bugs, not perf bugs.
+1. **README contract section** in `userspace-dp/src/filter/README.md`
+   describing the cache-key invariant, listing every match field on
+   the wire DTO and `FilterTerm` with explicit "cache-key" vs
+   "cache-sensitive" classification, and pointing at the existing
+   #1430 hooks as the runbook for path (b) — including the
+   verified fact that `LocalDelivery` is non-cacheable so lo0
+   filters do not need their own cache-sensitive gate.
 
-If reviewers conclude the contract / harness can be replaced
-by a one-paragraph README addition and a single grep for new
-match fields, **PLAN-KILL is an acceptable verdict**. The
-question is whether the failure mode is plausible enough — and
-the codebase's existing #1430 helpers are centralized enough —
-to need a compile-time or test-time tripwire.
+2. **In-source contract block** as a doc comment on `FilterTerm`
+   itself in `userspace-dp/src/filter/mod.rs`. This is the loud
+   reviewer-facing tripwire — anyone adding a match field to
+   `FilterTerm` will read the comment in the diff. AGY's
+   recommendation: "place a loud, blocking comment right next to
+   the fields." Same comment block placed on
+   `FirewallTermSnapshot` in `protocol/security.rs` so the wire
+   DTO also carries the contract.
 
-## 3. What's already shipped / partially batched
+3. **A real DSCP harness** at
+   `userspace-dp/src/filter/cache_invariant_harness.rs` (cfg(test)
+   only). The harness exercises:
+   - flow-cache insertion gate via
+     `FlowCacheEntry::from_forward_decision` (positive case: cache
+     declined when DSCP-sensitive input or output filter is bound).
+   - established-session re-evaluation via the public
+     `evaluate_dscp_sensitive_input_filter_on_session_hit` path
+     (positive case: re-eval fires when DSCP-sensitive).
+   - forwarding rotation purge via the public
+     `input_dscp_filter_families_changed` predicate (positive case:
+     fires when sensitive content changes, does NOT fire on
+     positional-ID-only changes).
 
-PR #1430 landed the DSCP-specific implementation, which serves
-as the reference pattern. The relevant surface today (`master`
-@ `e07f733a6`):
+   The DSCP case becomes the first concrete instantiation of the
+   harness. The harness is built around real
+   `FirewallFilterSnapshot` / `FirewallTermSnapshot` snapshots — no
+   synthetic test-only fields are added to production structs.
+   No `PER_PACKET_MATCH_FIELDS` constant list, no `trait
+   PerPacketMatchField`, no fake-field negative-case test.
+
+4. **What is explicitly NOT in scope** (changed from v1):
+   - PER_PACKET_MATCH_FIELDS constant list — DELETED. Codex r1 and
+     AGY r1 both flagged it as compile-time theater. Manual list
+     plus `size_of` cannot count `FilterTerm` fields; Rust has no
+     reflection for this.
+   - Trait `PerPacketMatchField` — DELETED. Documentation in code,
+     not enforcement.
+   - Fake-field negative-case harness arm
+     (`cache_sensitive_harness_fake_field_uncovered_fails`) —
+     DELETED. AGY r1 and Codex r1 both pointed out: cannot
+     synthesize a per-packet match field without polluting
+     `FilterTerm` layout; if you mock the matching engine, you're
+     testing the harness, not the dataplane.
+   - lo0 DSCP "gap" closure — DELETED FROM CONCERN. Verified:
+     `LocalDelivery` is non-cacheable
+     (`types/forwarding.rs::is_cacheable` returns false for it),
+     and lo0 filter evaluation runs per-packet on both miss and
+     hit paths at `poll_descriptor/mod.rs:700,1153`. The README
+     contract documents this so a future reader does not chase
+     the same false alarm.
+   - Parameterizing `dscp_sensitive_filter_semantics_match`.
+     Both reviewers said "paste later when the second cache-
+     sensitive field actually lands."
+
+## 3. What's already shipped / partially batched (UNCHANGED)
+
+Reference call sites for the #1430 pattern:
 
 - `FilterTerm.dscp_match_enabled` / `dscp_bitmap` —
   `userspace-dp/src/filter/mod.rs:61-62`
@@ -87,14 +167,12 @@ as the reference pattern. The relevant surface today (`master`
 - `filter_term_semantics_match()` /
   `dscp_sensitive_filter_semantics_match()` —
   `userspace-dp/src/filter/engine/cache_sensitive.rs:104-143`
-- README cache-sensitive doc paragraph —
-  `userspace-dp/src/filter/README.md:31-38`
-- DSCP-specific flow-cache + filter tests —
-  `userspace-dp/src/afxdp/flow_cache_tests.rs:643-745`,
-  `userspace-dp/src/filter/tests.rs:1683+`,
+- DSCP flow-cache regression tests —
+  `userspace-dp/src/afxdp/flow_cache_tests.rs:643-745`
+- DSCP rotation tests —
   `userspace-dp/src/filter/tests.rs:1733-2000`
 
-The 5-tuple session/flow-cache key today —
+The 5-tuple session/flow-cache key —
 `userspace-dp/src/session/key.rs:9-17`:
 
 ```rust
@@ -108,367 +186,270 @@ pub(crate) struct SessionKey {
 }
 ```
 
-Per-packet fields not in the key today: DSCP (already cache-
-sensitive), TCP flags, fragment offset / MF bit, IHL, IPv6 ext
-headers, IP options, ICMP type/code (in the L4 layout but not
-in the key for non-ICMP / for ICMP-of-different-direction), the
-flex-match window. The wire `FirewallTermSnapshot`
-(`userspace-dp/src/protocol/security.rs:60-89`) names:
-`source_addresses`, `destination_addresses`, `protocols`,
-`source_ports`, `destination_ports`, `dscp_values`, `action`,
-`count`, `log`, `policer`, `routing_instance`,
-`forwarding_class`, `dscp_rewrite`. **None of the per-packet
-non-5-tuple non-DSCP fields are on the wire today**, confirming
-the issue's "intentionally deferred" framing.
+ICMP key derivation (corrected from v1) — for `PROTO_ICMP` and
+`PROTO_ICMPV6`, `parse_flow_ports` reads `frame[l4+4..l4+6]` and
+stores `(identifier, 0)` (`userspace-dp/src/afxdp/frame/inspect.rs:225`).
+ICMP type and code are NOT in the session key. An ICMPType /
+ICMPCode filter field would be cache-sensitive unless `SessionKey`
+or metadata are extended.
 
-## 4. Concrete design
+`LocalDelivery` cacheability (corrected from v1) —
+`userspace-dp/src/afxdp/types/forwarding.rs:196` shows
+`is_cacheable()` returns true only for `ForwardCandidate` and
+`FabricRedirect`. `LocalDelivery`-disposition packets do not enter
+the flow-cache and lo0 filter evaluation runs per-packet, so lo0
+filters do not need a per-interface `has_dscp_match` set.
 
-### 4.1 The contract (written, machine-checked where possible)
+## 4. Concrete design (v2)
 
-Add a new doc section to `userspace-dp/src/filter/README.md`
-titled **"Cache-key invariants for per-packet match fields"**.
-Required content for the doc:
+### 4.1 README contract section
 
-1. A table listing every match field on `FirewallTermSnapshot`
-   (wire) AND every match field on `FilterTerm` (runtime). For
-   each row: **in cache key?** (`src_ip`/`dst_ip`/`protocol`/
-   `src_port`/`dst_port`/`addr_family` ⇒ yes; DSCP ⇒ no, cache-
-   sensitive; future ⇒ must be filled in).
-2. A two-sentence rule: *"Adding a per-packet match field to
-   `FilterTerm` requires picking exactly one of (a) extending
-   `SessionKey` and all its consumers, or (b) treating the
-   filter as cache-sensitive via the #1430 pattern. The
-   compiler aggregate `Filter.has_X_match_terms` and the
-   per-interface `FilterState.iface_filter_v{4,6}_has_X_match`
-   set are the two structural hooks the cache-sensitive path
-   uses."*
-3. The list of files the implementer MUST update for path (b),
-   pointing at the existing DSCP-pattern call sites (the eight
-   bullets in §3 above). This is the runbook.
+Add a new section to `userspace-dp/src/filter/README.md` titled
+**"Cache-key invariants for per-packet match fields"**. Required
+content:
 
-### 4.2 The structural hooks (compile-time tripwire)
+1. **The invariant** (issue's wording verbatim):
+   *When a filter match depends on packet fields that are not part
+   of the cache key, the dataplane must not reuse a first-packet
+   forwarding decision for later packets that can differ on those
+   fields.*
 
-Introduce a single trait + per-field tag, replacing the
-informal "by convention" pattern with a structural type-level
-hook. Sketch:
+2. **The cache key**: cite the six fields of `SessionKey`
+   (`addr_family`, `protocol`, `src_ip`, `dst_ip`, `src_port`,
+   `dst_port`). For ICMP, document that `src_port` carries the
+   identifier and `dst_port` is zero — ICMP type and code are NOT
+   in the key.
+
+3. **The classification table** for every field on
+   `FirewallTermSnapshot` and `FilterTerm` today:
+
+   | Field | In cache key? | Notes |
+   |-------|---------------|-------|
+   | `source_addresses` / `source_v4` / `source_v6` | yes | `src_ip` in `SessionKey` |
+   | `destination_addresses` / `dest_v4` / `dest_v6` | yes | `dst_ip` |
+   | `protocols` / `protocol_bitmap` | yes | `protocol` |
+   | `source_ports` | yes (TCP/UDP); ICMP-special | `src_port` carries ICMP identifier |
+   | `destination_ports` | yes (TCP/UDP); ICMP-zero | `dst_port` is 0 for ICMP |
+   | `dscp_values` / `dscp_bitmap` | NO — cache-sensitive | see #1430 pattern below |
+   | (future) `tcp_flags_match` | NO — cache-sensitive | TCP flags vary per packet |
+   | (future) `is_fragment` / fragment offset / MF | NO — cache-sensitive | only first fragment carries L4 |
+   | (future) `ihl_match` / IP options | NO — cache-sensitive | IHL varies per packet |
+   | (future) `icmp_type_match` / `icmp_code_match` | NO — cache-sensitive (today) | could be promoted to cache-key by adding (type, code) to `SessionKey` for ICMP sessions |
+   | (future) `flex_match` | NO — cache-sensitive | byte-offset match, fully per-packet |
+
+4. **The runbook for path (b) — cache-sensitive**: list the eight
+   call sites in §3 above and the four-step recipe:
+   - extend the per-interface `iface_filter_v{4,6}_has_<X>_match`
+     set on `FilterState`;
+   - add a `Filter.has_<X>_match_terms` aggregate flag;
+   - add a `interface_input_filter_has_<X>_match` /
+     `_output_` helper (or thread the new flag through one
+     general helper if the existing DSCP one is generalized
+     later);
+   - wire the gate at `flow_cache.rs:297-309`, the re-eval at
+     `poll_descriptor/mod.rs:217-244`, and the rotation purge at
+     `worker/loop_body/mod.rs:295-330`;
+   - extend the existing positive-case harness in
+     `filter/cache_invariant_harness.rs` with a new
+     `harness_<X>_input_gate_test` and `_output_gate_test`.
+
+5. **The runbook for path (a) — extend `SessionKey`**: brief
+   pointer to the prerequisites — HA sync compatibility, session-
+   table reverse indices, flow_cache key derivation, session
+   expiry hash, key comparison cost. Path (a) requires a tracker
+   issue and review against `session/key.rs`.
+
+6. **lo0 reminder**: `LocalDelivery` is non-cacheable, lo0
+   filters are evaluated per-packet, so they do NOT need a
+   per-interface cache-sensitive set. Stated so a future reader
+   does not duplicate v1's false-alarm investigation.
+
+### 4.2 In-source contract block
+
+Add a doc-comment block on `FilterTerm` in
+`userspace-dp/src/filter/mod.rs` directly above the struct:
 
 ```rust
-// userspace-dp/src/filter/cache_contract.rs (new file)
-
-/// Marker for a packet field that participates in filter matching
-/// but is NOT in the 5-tuple `SessionKey`. Every such field MUST
-/// either be added to `SessionKey` (and prove stability for every
-/// consumer) or be treated as cache-sensitive — see
-/// `userspace-dp/src/filter/README.md` "Cache-key invariants".
-pub(crate) trait PerPacketMatchField {
-    /// Stable name used in the per-interface `has_X_match` set
-    /// names and in the README contract table.
-    const FIELD_NAME: &'static str;
-
-    /// Returns `true` iff this match field is part of `SessionKey`.
-    /// If `false`, the implementor MUST wire a cache-sensitive
-    /// per-interface set on `FilterState` AND a
-    /// `Filter.has_<field>_match_terms` aggregate AND a
-    /// `<field>_sensitive_filter_semantics_match()` predicate.
-    const IN_SESSION_KEY: bool;
-}
-
-/// Compile-time list of every per-packet match field the codebase
-/// is aware of. Adding a per-packet match field is a *deliberate*
-/// edit to this list — if you skip it, the
-/// `cache_contract_lists_all_fields` test fails by counting
-/// `FilterTerm` `*_match_enabled` flags vs entries here.
-pub(crate) const PER_PACKET_MATCH_FIELDS: &[(&str, bool)] = &[
-    ("src_ip",      true),
-    ("dst_ip",      true),
-    ("protocol",    true),
-    ("src_port",    true),
-    ("dst_port",    true),
-    ("dscp",        false), // cache-sensitive, see #1430
-    // Future entries land here. Picking `true` requires extending
-    // SessionKey and ALL its consumers. Picking `false` requires
-    // the cache-sensitive runbook in README.md.
-];
-
-#[cfg(test)]
-mod cache_contract_tests {
-    // Tripwire 1: count `*_match_enabled` flags on FilterTerm via a
-    //             tiny proc-macro-free derive (manual constant list
-    //             updated by hand; reviewers verify by diff).
-    // Tripwire 2: every cache-sensitive field has a matching
-    //             FilterState.iface_filter_v{4,6}_has_<name>_match
-    //             field — checked by a `compile_pass` test that
-    //             references each field by name.
-    // Tripwire 3: every cache-sensitive field has a matching
-    //             `Filter.has_<name>_match_terms` flag — same.
-    // Tripwire 4: a synthetic filter with an opt-in fake new
-    //             per-packet match field exercises the test
-    //             harness in §4.3 and FAILS the harness if the
-    //             implementer forgets to gate flow-cache insertion.
-}
+// ============================================================
+// CACHE-KEY INVARIANT (#1431)
+//
+// Every field on FilterTerm that participates in matching MUST
+// be classified:
+//
+//   (a) IN cache key — extend SessionKey in session/key.rs AND
+//       prove key stability for HA sync, session-table reverse
+//       indices, flow_cache key derivation, expiry hash, and
+//       reverse-NAT lookup. File a tracker issue.
+//
+//   (b) NOT in cache key (cache-sensitive) — wire the #1430
+//       runbook: per-interface has_<X>_match set, Filter
+//       aggregate flag, flow-cache insertion gate, established-
+//       session re-evaluation, and forwarding rotation purge.
+//       See userspace-dp/src/filter/README.md "Cache-key
+//       invariants for per-packet match fields."
+//
+// Skipping this classification SILENTLY breaks flow-cache: a
+// first-packet decision gets reused for later packets that
+// can differ on the new field. PR #1430 fixed this for DSCP;
+// the same class of bug applies to any future per-packet match.
+// ============================================================
 ```
 
-**Honest about the type-system limits:** Rust does not give us
-a "for every field on this struct, prove a trait is implemented"
-check without a proc-macro derive (which this repo intentionally
-avoids in `userspace-dp`). So tripwire 1 is a manual constant
-list plus a unit test that counts the `*_match_enabled` /
-`*_match` boolean flags on `FilterTerm` via `std::mem::size_of`
-or by a small `compile_error!` macro that fires when the count
-mismatches. The harness in §4.3 is the real enforcement; the
-trait is documentation in code.
+Mirror block placed above `FirewallTermSnapshot` in
+`userspace-dp/src/protocol/security.rs` so the wire DTO also
+carries the contract.
 
-### 4.3 The test harness (real enforcement)
+### 4.3 DSCP-positive harness
 
-A generic harness at
-`userspace-dp/src/filter/cache_invariant_harness.rs` (tests-only)
-that takes:
+Add `userspace-dp/src/filter/cache_invariant_harness.rs` (or
+co-locate at the bottom of `tests.rs` to avoid module noise;
+preferred location: bottom of `tests.rs` with a clear section
+comment, to avoid the maintenance cost of a new file for two
+tests). Three new tests:
 
-- A `FilterTerm` builder that opts a single per-packet match
-  field into the cache-sensitive class.
-- Two packets with the same 5-tuple but **different** values
-  for the chosen field.
-- The expected behavior on each: first-packet accept, second-
-  packet deny (or vice-versa).
+- `dscp_input_gate_blocks_flow_cache_insertion` — builds a
+  realistic `FirewallFilterSnapshot` with a DSCP match term,
+  binds it as v4 input filter on an interface, drives
+  `FlowCacheEntry::from_forward_decision`, asserts `None`.
+- `dscp_output_gate_blocks_flow_cache_insertion` — same for
+  output. (These extend coverage of the existing bespoke tests
+  at `flow_cache_tests.rs:643-745`; we keep the bespoke tests
+  and add these as the canonical "this is the harness pattern"
+  references.)
+- `dscp_rotation_does_not_fire_on_positional_id_change` —
+  parallel positive: rebuild two filter states whose content is
+  identical but whose filter / term positional IDs differ;
+  assert `input_dscp_filter_families_changed` returns
+  `(false, false)`. This is the regression for the round-5
+  carry-item rule "compare by content, not positional IDs."
 
-The harness then walks:
-
-1. `FlowCacheEntry::from_forward_decision()` with the first
-   packet — MUST return `None` if the field is declared cache-
-   sensitive.
-2. Established session hit path — MUST re-evaluate the input
-   filter against the second packet's field value.
-3. Rotation: swap the filter snapshot for one whose sensitive
-   field content has changed — `purge_sessions_for_input_*`
-   MUST fire.
-4. Negative parity: declare the field "in cache key" and verify
-   the cache DOES insert (proves the harness can distinguish
-   the two arms).
-
-The DSCP case becomes the first concrete instantiation of this
-harness, replacing the bespoke
-`from_forward_decision_skips_cache_for_dscp_matched_*` tests at
-`userspace-dp/src/afxdp/flow_cache_tests.rs:643-745` with a
-parameterized call — but only after parity is proven against
-the existing bespoke tests (keep them, add the harness on top).
-
-The harness is the **real** acceptance criterion: when a future
-PR adds e.g. TCP flags matching, the implementer extends
-`PER_PACKET_MATCH_FIELDS`, picks an arm, and adds one call to
-the harness. If they skip the cache-sensitive gates, the
-harness FAILS. If they extend `SessionKey` correctly, the
-"in cache key" arm of the harness PASSES.
-
-### 4.4 What about path (a) — extending `SessionKey`?
-
-Path (a) is the "add the field to the key" arm. It's
-inherently a much bigger refactor (HA sync, session_table
-indices, reverse-NAT lookup, key serialization). The plan does
-**not** preemptively add helpers for this arm — instead, the
-README contract requires the implementer to file an issue
-against `session/key.rs` enumerating: HA sync compatibility,
-session_table reverse indices, flow_cache key derivation,
-session expiry hash, key comparison cost. The cache-contract
-test for path (a) is: the field appears in `SessionKey`'s
-`Hash + Eq` derive — checked by a `compile_pass` test that
-references the field by name.
+That's three tests, all positive-case only. No fake field,
+no constant list, no trait.
 
 ## 5. Public API preservation
 
-- `FilterTerm` struct layout unchanged (only an additional doc
-  comment + an attached trait impl).
-- `Filter` struct gains no fields (the `has_X_match_terms` flag
-  is added per-field by future PRs; this PR ships only the
-  existing `has_dscp_match_terms`).
-- `FilterState` gains no fields.
+- `FilterTerm` struct layout — UNCHANGED. Only a new doc-comment
+  block above.
+- `Filter` — UNCHANGED.
+- `FilterState` — UNCHANGED.
 - `interface_input_filter_has_dscp_match` /
   `interface_output_filter_has_dscp_match` /
-  `input_dscp_filter_families_changed` — signatures unchanged.
-- `FlowCacheEntry::from_forward_decision` — signature unchanged;
-  body unchanged except possibly factoring the DSCP gate into a
-  helper named `flow_cache_can_insert_for_field` to make the
-  per-field gate visually consistent.
-- `purge_sessions_for_input_dscp_filter_revalidation` —
-  signature unchanged.
-- Wire DTO `FirewallTermSnapshot` — UNCHANGED. This PR adds no
-  wire fields.
+  `input_dscp_filter_families_changed` — signatures UNCHANGED.
+- `FlowCacheEntry::from_forward_decision` — body UNCHANGED.
+- `FirewallTermSnapshot` (wire DTO) — UNCHANGED. New doc-comment
+  block above.
 - `SessionKey` — UNCHANGED.
+
+This PR is documentation + tests. No runtime change.
 
 ## 6. Hidden invariants the change must preserve
 
-1. **Side-effect ordering on cached hits.** The cache-sensitive
-   gate runs BEFORE flow-cache insertion. Re-evaluation runs
-   BEFORE acting on a session hit. The rotation purge runs
-   BEFORE the new filter is applied to in-flight packets. The
-   harness must exercise all three orderings.
-2. **Allocation rules on the hot path.** No allocation in the
-   gate, the re-eval, or the rotation comparison. The existing
-   helpers are allocation-free; the harness must NOT
-   introduce hot-path allocation.
-3. **HA sync portability.** The contract states that path (a)
-   — adding to `SessionKey` — requires updating HA sync. The
-   harness for path (a) must include a smoke that the new key
-   bytes serialize and deserialize.
-4. **Stable-name purge comparison.** The existing
-   `dscp_sensitive_filter_semantics_match` ignores compiler-
-   positional `Filter.id` / `FilterTerm.id`. Any future per-
-   field equivalent MUST follow the same rule. The harness
-   provides a regression for "changing the term order without
-   changing content does not purge".
-5. **Three-color policer runtime shape.** Already in the
-   existing comparison helper — the contract preserves this.
-6. **lo0 filters.** lo0 input filters are evaluated against
-   host-bound traffic. The contract MUST list lo0 as a
-   participant — currently `FilterState.lo0_filter_v{4,6}_fast`
-   is NOT in the DSCP `has_dscp_match` per-interface set. If
-   lo0 filters can also be DSCP-sensitive (they can — they're
-   regular filters), the current implementation has a gap: a
-   lo0 input filter with DSCP match terms would NOT decline
-   flow-cache insertion. **Open question for reviewers — see
-   §11 Q1.**
-7. **Output filter family symmetry.** The DSCP gate handles
-   both input and output. Any future cache-sensitive field
-   MUST handle both arms.
+1. Side-effect ordering on cached hits, re-eval, and rotation
+   purge — already preserved by the #1430 hooks; harness only
+   exercises them.
+2. Allocation rules on the hot path — harness lives in
+   `#[cfg(test)]`, no hot-path impact.
+3. HA sync portability — out of scope; README documents path (a)
+   requires HA sync review.
+4. Stable-name purge comparison — exercised by the new positional-
+   ID-change-doesn't-fire test.
+5. Three-color policer runtime shape — already in
+   `dscp_sensitive_filter_semantics_match`; not regenerated.
+6. lo0 filters — documented as non-cacheable so future readers
+   don't redo the v1 false-alarm investigation.
 
 ## 7. Risk assessment
 
 | Class | Level | Notes |
 |-------|-------|-------|
-| Behavioral regression risk | LOW | No runtime path changes (harness + doc). DSCP gate still exercised by existing tests; the parameterized harness adds coverage, not replacement. |
-| Lifetime / borrow-checker risk | LOW | Harness consumes existing `pub(crate)` helpers; no new lifetimes introduced. |
-| Performance regression risk | NONE | No hot-path changes. Possibly a tiny refactor to a `flow_cache_can_insert_for_field` helper — measured `#[inline(always)]` to compile-out. |
-| Architectural mismatch risk | MEDIUM | The trait + constant-list "tripwire" is informal — Rust can't enforce "every per-packet field on FilterTerm is in the list" without a proc-macro. If reviewers conclude this is doc-by-another-name, PLAN-KILL is appropriate. The harness is the real enforcement. |
+| Behavioral regression risk | NONE | Doc + cfg(test) tests only. |
+| Lifetime / borrow-checker risk | NONE | New tests use existing pub(crate) helpers; no new lifetimes. |
+| Performance regression risk | NONE | No hot-path changes. |
+| Architectural mismatch risk | LOW | Both reviewers explicitly endorsed this salvage path. |
 
 ## 8. Test plan
 
-- `TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo build` — clean.
-- `cargo test --release` — full cargo suite (952+ tests).
-- 5× flake check on
-  `from_forward_decision_skips_cache_for_dscp_matched_input_filter`
-  and `_output_filter` plus the new harness tests.
-- `go test ./...` — 30 Go packages (no Go-side code changes are
-  planned; this is regression coverage only).
+- `cargo build --release` clean.
+- `cargo test --release` — full suite passes; existing DSCP
+  flow-cache tests at `flow_cache_tests.rs:643-745` and DSCP
+  rotation tests at `filter/tests.rs:1733-2000` still pass.
+- New tests (three):
+  - `dscp_input_gate_blocks_flow_cache_insertion`
+  - `dscp_output_gate_blocks_flow_cache_insertion`
+  - `dscp_rotation_does_not_fire_on_positional_id_change`
+- 5× flake check on the three new tests.
+- `go test ./...` — no Go changes; regression coverage only.
 - Smoke on `loss:xpf-userspace-fw0/1` — v4+v6, push+reverse,
-  CoS-off + per-class. Strictly regression: no behavior change
-  is expected.
-- New tests added:
-  - `cache_contract_lists_all_known_match_fields` — counts
-    `*_match_enabled` flags on `FilterTerm` against the list.
-  - `cache_sensitive_harness_dscp_input` — reproduces #1430's
-    DSCP input gate via the parameterized harness.
-  - `cache_sensitive_harness_dscp_output` — same for output.
-  - `cache_sensitive_harness_rotation_purge` — exercises
-    rotation against a DSCP semantics change.
-  - `cache_sensitive_harness_fake_field_uncovered_fails` — uses
-    a synthetic test-only field tagged cache-sensitive but
-    deliberately not wired into the flow-cache gate; harness
-    must FAIL, proving it catches the future "implementer
-    forgot to wire it" case.
-  - `cache_contract_lo0_filter_is_listed` — if §11 Q1 resolves
-    "lo0 is in scope", proves the lo0 filter participates.
+  CoS-off + per-class. Pure regression — zero behavior delta is
+  expected.
 
-## 9. Out of scope (explicitly)
+## 9. Out of scope (UPDATED from v1)
 
-- Adding TCP flags / fragment / IHL / IP options matching to
-  the wire DTO or to `FilterTerm`. That's the next PR after
-  this one (or, more likely, the next several PRs — one per
-  field).
-- Adding any per-packet match field to `SessionKey`. Path (a)
-  in §1.3 of the issue body is documented but not exercised.
-- Removing the bespoke
-  `from_forward_decision_skips_cache_for_dscp_matched_*` tests
-  in favor of the harness — keep both for safety; remove
-  bespoke in a follow-up after the harness has soaked.
-- proc-macro derive of `PerPacketMatchField`. `userspace-dp`
-  avoids proc-macros to keep build times honest; the manual
-  constant list + tests are the chosen mechanism.
-- Lo0 filter DSCP gap closure (if §11 Q1 resolves to "yes, gap
-  exists"). That's a bug fix that should ship in its own PR
-  with `Closes #<new-bug>`, because it changes runtime
-  behavior. This PR documents the gap if it exists.
+- Adding any new per-packet match field to `FilterTerm` or the
+  wire DTO. Each such addition is a separate PR that satisfies
+  the issue's acceptance criteria against the README contract.
+- Extending `SessionKey`. Path (a) requires HA sync review and
+  a dedicated PR.
+- `PER_PACKET_MATCH_FIELDS` constant list, `PerPacketMatchField`
+  trait, fake-field harness arm — explicitly removed after v1
+  review.
+- lo0 filter "DSCP gap" — verified non-existent.
+- Parameterizing `dscp_sensitive_filter_semantics_match` —
+  defer to whenever the second cache-sensitive field lands.
 
 ## 10. Validation — pre-PR
 
 - `cargo build --release` clean.
 - `cargo test --release filter::` clean.
 - `cargo test --release flow_cache` clean.
-- `cargo test --release cache_contract` clean (new tests).
 - 5× flake on each new test.
 - Go suite clean.
-- Smoke matrix per CLAUDE.md (Pass A + Pass B).
+- Smoke matrix (Pass A + Pass B) per CLAUDE.md.
 
-## 11. Open questions for adversarial review
+## 11. Open questions for adversarial review round 2
 
-**Q1 — lo0 filter DSCP gap.** The existing #1430 implementation
-gates flow-cache on per-interface `iface_filter_v{4,6}_has_dscp_match`,
-but `lo0_filter_v{4,6}_fast` (host-bound traffic) is not in
-that set. Is this a real correctness gap that must be fixed
-before #1431 ships, or is host-bound traffic structurally
-exempt because it does not go through the flow-cache? Walk
-`userspace-dp/src/afxdp/poll_descriptor/` to verify the
-host-bound path. **PLAN-KILL the harness scope if Q1's answer
-forces the harness to also cover lo0 — that's a behavioral fix,
-not a contract.**
+**Q1 — is the in-source contract block actually loud enough?**
+AGY explicitly recommended "loud, blocking comment right next to
+the fields." A block doc-comment above `FilterTerm` (and
+`FirewallTermSnapshot`) is the proposed surface. Is that enough,
+or does the contract need a `// IMPORTANT: read this before
+adding a field` per-field marker? Reviewer's call.
 
-**Q2 — is the constant list `PER_PACKET_MATCH_FIELDS` doing
-real work?** It's a hand-maintained list. The "real
-enforcement" is the harness. Is the constant list bringing
-value over and above a one-paragraph README "when you add a
-per-packet match field, do X" runbook? If reviewers conclude
-"the list adds churn without enforcement", strip §4.2 and ship
-the harness + README alone. **PLAN-KILL §4.2 specifically is
-fine; it does not kill the whole PR.**
+**Q2 — should the harness sit in `tests.rs` or a new file?** Plan
+proposes bottom of `tests.rs`. Reviewer may prefer a dedicated
+`cache_invariant_harness.rs` for visibility — both are fine; the
+trade-off is module noise vs. discoverability.
 
-**Q3 — does the harness handle ICMP correctly?** ICMP packets
-use src_port/dst_port to carry type/code. Adding "ICMP type
-match" as a per-packet field is ambiguous — it might already
-be in the cache key (because type lives in the port field for
-ICMP sessions). The harness must NOT misclassify ICMP type as
-cache-sensitive. Reviewer must verify
-`userspace-dp/src/session/key.rs:28-...` (`forward_wire_key`
-ICMP branch).
+**Q3 — does the README table need an authoritative line on the
+"ICMP src_port is the identifier" gotcha?** v1 got this wrong;
+v2 lists it but reviewer should confirm wording is accurate
+against `parse_flow_ports` at `frame/inspect.rs:225`.
 
-**Q4 — is `dscp_sensitive_filter_semantics_match` generalizable?**
-It currently inlines DSCP-specific aggregate-flag comparisons
-(`old.has_dscp_match_terms == new.has_dscp_match_terms`). For
-TCP flags or IHL the equivalent flag would be
-`has_tcp_flags_match_terms` / `has_ihl_match_terms`. Should
-the helper be parameterized today (via a closure or a
-`CacheSensitiveFieldDescriptor` trait), or should each future
-field paste its own helper? Cost-benefit: parameterizing today
-adds churn for one consumer (DSCP); pasting later doubles the
-maintenance surface. **Lean: paste later. Reviewer feedback
-welcome.**
+**Q4 — does the positional-ID-change-doesn't-fire test add
+coverage over the existing `input_dscp_filter_families_changed_ignores_positional_filter_id_change`
+test at `filter/tests.rs:1806`?** If it's literally a duplicate,
+drop it. If it tests a different angle (e.g. it builds via the
+public snapshot API rather than constructing `Filter` directly),
+keep it as the canonical harness reference.
 
-**Q5 — is the trade-off honest?** This PR is contract +
-harness, no runtime change. Is the failure mode (silent flow-
-cache bypass when a future per-packet field is added) actually
-a plausible failure? PR #1430 round 4 caught the original DSCP
-gap; the same review discipline would catch the next one. If
-review discipline is the real defense, this PR is theater.
-**PLAN-KILL with this reasoning is welcome.** The
-counter-argument: #1430 went through 5 review rounds before
-the round-5 carry-item was acknowledged. A test-time tripwire
-catches the same class of bug without depending on a 5-round
-review.
+**Q5 — anything else that disciplined PR review would catch but
+this contract doesn't?** Reviewer is invited to PLAN-KILL v2 if
+the contract is still theater. The v2 minimum value: a single
+authoritative doc that a future reviewer can cite when they
+spot a per-packet match field landing without the cache-sensitive
+runbook.
 
-**Q6 — does this conflict with #1373 retirement work?** The
-eBPF dataplane is being retired (#1373 / #1476). Filter
-semantics moving forward live only in `userspace-dp`. So the
-contract is naturally Rust-side only. The README change is in
-`userspace-dp/src/filter/README.md`, not in any eBPF doc. No
-conflict expected. Reviewer should verify.
-
-**Q7 — performance.** Confirmed: no hot-path changes. If §4.2
-adds a `compile_error!` macro, it fires at build time, not
-runtime. The harness is `cfg(test)` only. No measurable
-runtime cost expected. Reviewer must verify that the (possibly)
-factored `flow_cache_can_insert_for_field` helper folds back to
-the existing two-call pattern at `#[inline(always)]` (we have
-seen the compiler fail to inline through a trait-bound generic
-in the past — keep this concrete).
+**Q6 — is the lo0 "verified non-existent" note useful, or noise?**
+v1's lo0 alarm cost real review cycles. v2 documents the
+resolution so future readers don't repeat the investigation. If
+reviewer prefers a leaner doc, the lo0 paragraph can move to a
+one-line "see types/forwarding.rs::is_cacheable" pointer.
 
 ---
 
-If reviewers conclude the perf gain is too small to justify
-the churn, **PLAN-KILL is an acceptable verdict.**
+If reviewers still conclude the contract is theater, **PLAN-KILL
+is an acceptable v2 verdict** — in which case the recommended
+follow-up is a one-line PR that just adds the doc-comment block
+on `FilterTerm` and `FirewallTermSnapshot`, no harness at all,
+and closes the issue with that as the "documents whether the new
+match field is in the cache key" acceptance criterion satisfied.

--- a/docs/pr/1431-filter-cache-invariants/plan.md
+++ b/docs/pr/1431-filter-cache-invariants/plan.md
@@ -1,0 +1,474 @@
+# #1431 — userspace filters: preserve cache invariants for future per-packet match fields
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## 1. Issue framing
+
+PR #1430 closed the immediate filter-log enforcement gaps by treating
+DSCP — the one per-packet match field currently representable in
+`FilterTerm` outside the 5-tuple — as cache-sensitive metadata:
+
+- DSCP-sensitive input/output filters decline flow-cache insertion.
+- Established session hits re-evaluate DSCP-sensitive input filters.
+- Forwarding rotations that add, remove, or semantically change
+  DSCP-sensitive input filters conservatively purge affected sessions.
+- The purge comparison uses stable filter/term names and three-color
+  policer shape, not compiler-positional IDs.
+
+#1431 carries the round-5 follow-up forward: TOS (non-DSCP bits),
+IPv4/IPv6 fragment fields, IPv4 IHL, IP options, TCP flags, ICMP
+type/code, and any other future per-packet match are NOT currently
+represented in `FilterTerm`. The Go config struct `FirewallFilterTerm`
+already names some of them (`TCPFlags`, `IsFragment`, `ICMPType`,
+`ICMPCode`, `FlexMatch`), but the wire DTO `FirewallTermSnapshot`
+and the Rust `FilterTerm` never carry them. The next time any of
+those fields lands in the userspace AST, the implementer must
+either add it to the session/flow-cache key or treat it as
+cache-sensitive — and the codebase must make the wrong choice loud
+rather than silent.
+
+The required invariant from the issue, verbatim:
+
+> When a filter match depends on packet fields that are not part of
+> the cache key, the dataplane must not reuse a first-packet
+> forwarding decision for later packets that can differ on those
+> fields.
+
+## 2. Honest scope/value framing
+
+This work is primarily a **contract + harness PR**, not a runtime
+change. No new per-packet match field is being added in this scope.
+The win is structural: when someone in a future PR adds
+`tcp_flags_match`, `fragment_offset_match`, `ihl_match`, or a
+`flex_match`, the codebase forces them to pick a side (cache-key vs
+cache-sensitive) and instruments tests that would fail if they
+silently picked neither.
+
+Absolute scale of the runtime perf hit if we get this wrong:
+the failure mode is a stale flow-cache hit for a packet that
+should have been dropped or rerouted. The user-visible symptom
+on a misconfigured filter is the same class of bug #1430
+already fixed for DSCP: a first-packet accept on `dscp 0` gets
+replayed for later packets with `dscp 46` and the EF-discard
+term is silently bypassed. The user-visible symptom on a
+forwarding rotation is stale session reuse against a changed
+filter. Both are correctness bugs, not perf bugs.
+
+If reviewers conclude the contract / harness can be replaced
+by a one-paragraph README addition and a single grep for new
+match fields, **PLAN-KILL is an acceptable verdict**. The
+question is whether the failure mode is plausible enough — and
+the codebase's existing #1430 helpers are centralized enough —
+to need a compile-time or test-time tripwire.
+
+## 3. What's already shipped / partially batched
+
+PR #1430 landed the DSCP-specific implementation, which serves
+as the reference pattern. The relevant surface today (`master`
+@ `e07f733a6`):
+
+- `FilterTerm.dscp_match_enabled` / `dscp_bitmap` —
+  `userspace-dp/src/filter/mod.rs:61-62`
+- `Filter.has_dscp_match_terms` aggregate —
+  `userspace-dp/src/filter/mod.rs:117`
+- Per-interface DSCP-match sets on `FilterState` —
+  `userspace-dp/src/filter/mod.rs:423,437`
+- `interface_input_filter_has_dscp_match` /
+  `interface_output_filter_has_dscp_match` helpers —
+  `userspace-dp/src/filter/engine/cache_sensitive.rs:177,189`
+- Flow-cache insertion gate using both helpers —
+  `userspace-dp/src/afxdp/flow_cache.rs:297-309`
+- Session-hit DSCP re-evaluation —
+  `userspace-dp/src/afxdp/poll_descriptor/mod.rs:217-244`
+- Rotation purge —
+  `userspace-dp/src/afxdp/worker/loop_body/mod.rs:295-330`
+- `input_dscp_filter_families_changed()` —
+  `userspace-dp/src/filter/engine/cache_sensitive.rs:167-175`
+- `filter_term_semantics_match()` /
+  `dscp_sensitive_filter_semantics_match()` —
+  `userspace-dp/src/filter/engine/cache_sensitive.rs:104-143`
+- README cache-sensitive doc paragraph —
+  `userspace-dp/src/filter/README.md:31-38`
+- DSCP-specific flow-cache + filter tests —
+  `userspace-dp/src/afxdp/flow_cache_tests.rs:643-745`,
+  `userspace-dp/src/filter/tests.rs:1683+`,
+  `userspace-dp/src/filter/tests.rs:1733-2000`
+
+The 5-tuple session/flow-cache key today —
+`userspace-dp/src/session/key.rs:9-17`:
+
+```rust
+pub(crate) struct SessionKey {
+    pub addr_family: u8,
+    pub protocol: u8,
+    pub src_ip: IpAddr,
+    pub dst_ip: IpAddr,
+    pub src_port: u16,
+    pub dst_port: u16,
+}
+```
+
+Per-packet fields not in the key today: DSCP (already cache-
+sensitive), TCP flags, fragment offset / MF bit, IHL, IPv6 ext
+headers, IP options, ICMP type/code (in the L4 layout but not
+in the key for non-ICMP / for ICMP-of-different-direction), the
+flex-match window. The wire `FirewallTermSnapshot`
+(`userspace-dp/src/protocol/security.rs:60-89`) names:
+`source_addresses`, `destination_addresses`, `protocols`,
+`source_ports`, `destination_ports`, `dscp_values`, `action`,
+`count`, `log`, `policer`, `routing_instance`,
+`forwarding_class`, `dscp_rewrite`. **None of the per-packet
+non-5-tuple non-DSCP fields are on the wire today**, confirming
+the issue's "intentionally deferred" framing.
+
+## 4. Concrete design
+
+### 4.1 The contract (written, machine-checked where possible)
+
+Add a new doc section to `userspace-dp/src/filter/README.md`
+titled **"Cache-key invariants for per-packet match fields"**.
+Required content for the doc:
+
+1. A table listing every match field on `FirewallTermSnapshot`
+   (wire) AND every match field on `FilterTerm` (runtime). For
+   each row: **in cache key?** (`src_ip`/`dst_ip`/`protocol`/
+   `src_port`/`dst_port`/`addr_family` ⇒ yes; DSCP ⇒ no, cache-
+   sensitive; future ⇒ must be filled in).
+2. A two-sentence rule: *"Adding a per-packet match field to
+   `FilterTerm` requires picking exactly one of (a) extending
+   `SessionKey` and all its consumers, or (b) treating the
+   filter as cache-sensitive via the #1430 pattern. The
+   compiler aggregate `Filter.has_X_match_terms` and the
+   per-interface `FilterState.iface_filter_v{4,6}_has_X_match`
+   set are the two structural hooks the cache-sensitive path
+   uses."*
+3. The list of files the implementer MUST update for path (b),
+   pointing at the existing DSCP-pattern call sites (the eight
+   bullets in §3 above). This is the runbook.
+
+### 4.2 The structural hooks (compile-time tripwire)
+
+Introduce a single trait + per-field tag, replacing the
+informal "by convention" pattern with a structural type-level
+hook. Sketch:
+
+```rust
+// userspace-dp/src/filter/cache_contract.rs (new file)
+
+/// Marker for a packet field that participates in filter matching
+/// but is NOT in the 5-tuple `SessionKey`. Every such field MUST
+/// either be added to `SessionKey` (and prove stability for every
+/// consumer) or be treated as cache-sensitive — see
+/// `userspace-dp/src/filter/README.md` "Cache-key invariants".
+pub(crate) trait PerPacketMatchField {
+    /// Stable name used in the per-interface `has_X_match` set
+    /// names and in the README contract table.
+    const FIELD_NAME: &'static str;
+
+    /// Returns `true` iff this match field is part of `SessionKey`.
+    /// If `false`, the implementor MUST wire a cache-sensitive
+    /// per-interface set on `FilterState` AND a
+    /// `Filter.has_<field>_match_terms` aggregate AND a
+    /// `<field>_sensitive_filter_semantics_match()` predicate.
+    const IN_SESSION_KEY: bool;
+}
+
+/// Compile-time list of every per-packet match field the codebase
+/// is aware of. Adding a per-packet match field is a *deliberate*
+/// edit to this list — if you skip it, the
+/// `cache_contract_lists_all_fields` test fails by counting
+/// `FilterTerm` `*_match_enabled` flags vs entries here.
+pub(crate) const PER_PACKET_MATCH_FIELDS: &[(&str, bool)] = &[
+    ("src_ip",      true),
+    ("dst_ip",      true),
+    ("protocol",    true),
+    ("src_port",    true),
+    ("dst_port",    true),
+    ("dscp",        false), // cache-sensitive, see #1430
+    // Future entries land here. Picking `true` requires extending
+    // SessionKey and ALL its consumers. Picking `false` requires
+    // the cache-sensitive runbook in README.md.
+];
+
+#[cfg(test)]
+mod cache_contract_tests {
+    // Tripwire 1: count `*_match_enabled` flags on FilterTerm via a
+    //             tiny proc-macro-free derive (manual constant list
+    //             updated by hand; reviewers verify by diff).
+    // Tripwire 2: every cache-sensitive field has a matching
+    //             FilterState.iface_filter_v{4,6}_has_<name>_match
+    //             field — checked by a `compile_pass` test that
+    //             references each field by name.
+    // Tripwire 3: every cache-sensitive field has a matching
+    //             `Filter.has_<name>_match_terms` flag — same.
+    // Tripwire 4: a synthetic filter with an opt-in fake new
+    //             per-packet match field exercises the test
+    //             harness in §4.3 and FAILS the harness if the
+    //             implementer forgets to gate flow-cache insertion.
+}
+```
+
+**Honest about the type-system limits:** Rust does not give us
+a "for every field on this struct, prove a trait is implemented"
+check without a proc-macro derive (which this repo intentionally
+avoids in `userspace-dp`). So tripwire 1 is a manual constant
+list plus a unit test that counts the `*_match_enabled` /
+`*_match` boolean flags on `FilterTerm` via `std::mem::size_of`
+or by a small `compile_error!` macro that fires when the count
+mismatches. The harness in §4.3 is the real enforcement; the
+trait is documentation in code.
+
+### 4.3 The test harness (real enforcement)
+
+A generic harness at
+`userspace-dp/src/filter/cache_invariant_harness.rs` (tests-only)
+that takes:
+
+- A `FilterTerm` builder that opts a single per-packet match
+  field into the cache-sensitive class.
+- Two packets with the same 5-tuple but **different** values
+  for the chosen field.
+- The expected behavior on each: first-packet accept, second-
+  packet deny (or vice-versa).
+
+The harness then walks:
+
+1. `FlowCacheEntry::from_forward_decision()` with the first
+   packet — MUST return `None` if the field is declared cache-
+   sensitive.
+2. Established session hit path — MUST re-evaluate the input
+   filter against the second packet's field value.
+3. Rotation: swap the filter snapshot for one whose sensitive
+   field content has changed — `purge_sessions_for_input_*`
+   MUST fire.
+4. Negative parity: declare the field "in cache key" and verify
+   the cache DOES insert (proves the harness can distinguish
+   the two arms).
+
+The DSCP case becomes the first concrete instantiation of this
+harness, replacing the bespoke
+`from_forward_decision_skips_cache_for_dscp_matched_*` tests at
+`userspace-dp/src/afxdp/flow_cache_tests.rs:643-745` with a
+parameterized call — but only after parity is proven against
+the existing bespoke tests (keep them, add the harness on top).
+
+The harness is the **real** acceptance criterion: when a future
+PR adds e.g. TCP flags matching, the implementer extends
+`PER_PACKET_MATCH_FIELDS`, picks an arm, and adds one call to
+the harness. If they skip the cache-sensitive gates, the
+harness FAILS. If they extend `SessionKey` correctly, the
+"in cache key" arm of the harness PASSES.
+
+### 4.4 What about path (a) — extending `SessionKey`?
+
+Path (a) is the "add the field to the key" arm. It's
+inherently a much bigger refactor (HA sync, session_table
+indices, reverse-NAT lookup, key serialization). The plan does
+**not** preemptively add helpers for this arm — instead, the
+README contract requires the implementer to file an issue
+against `session/key.rs` enumerating: HA sync compatibility,
+session_table reverse indices, flow_cache key derivation,
+session expiry hash, key comparison cost. The cache-contract
+test for path (a) is: the field appears in `SessionKey`'s
+`Hash + Eq` derive — checked by a `compile_pass` test that
+references the field by name.
+
+## 5. Public API preservation
+
+- `FilterTerm` struct layout unchanged (only an additional doc
+  comment + an attached trait impl).
+- `Filter` struct gains no fields (the `has_X_match_terms` flag
+  is added per-field by future PRs; this PR ships only the
+  existing `has_dscp_match_terms`).
+- `FilterState` gains no fields.
+- `interface_input_filter_has_dscp_match` /
+  `interface_output_filter_has_dscp_match` /
+  `input_dscp_filter_families_changed` — signatures unchanged.
+- `FlowCacheEntry::from_forward_decision` — signature unchanged;
+  body unchanged except possibly factoring the DSCP gate into a
+  helper named `flow_cache_can_insert_for_field` to make the
+  per-field gate visually consistent.
+- `purge_sessions_for_input_dscp_filter_revalidation` —
+  signature unchanged.
+- Wire DTO `FirewallTermSnapshot` — UNCHANGED. This PR adds no
+  wire fields.
+- `SessionKey` — UNCHANGED.
+
+## 6. Hidden invariants the change must preserve
+
+1. **Side-effect ordering on cached hits.** The cache-sensitive
+   gate runs BEFORE flow-cache insertion. Re-evaluation runs
+   BEFORE acting on a session hit. The rotation purge runs
+   BEFORE the new filter is applied to in-flight packets. The
+   harness must exercise all three orderings.
+2. **Allocation rules on the hot path.** No allocation in the
+   gate, the re-eval, or the rotation comparison. The existing
+   helpers are allocation-free; the harness must NOT
+   introduce hot-path allocation.
+3. **HA sync portability.** The contract states that path (a)
+   — adding to `SessionKey` — requires updating HA sync. The
+   harness for path (a) must include a smoke that the new key
+   bytes serialize and deserialize.
+4. **Stable-name purge comparison.** The existing
+   `dscp_sensitive_filter_semantics_match` ignores compiler-
+   positional `Filter.id` / `FilterTerm.id`. Any future per-
+   field equivalent MUST follow the same rule. The harness
+   provides a regression for "changing the term order without
+   changing content does not purge".
+5. **Three-color policer runtime shape.** Already in the
+   existing comparison helper — the contract preserves this.
+6. **lo0 filters.** lo0 input filters are evaluated against
+   host-bound traffic. The contract MUST list lo0 as a
+   participant — currently `FilterState.lo0_filter_v{4,6}_fast`
+   is NOT in the DSCP `has_dscp_match` per-interface set. If
+   lo0 filters can also be DSCP-sensitive (they can — they're
+   regular filters), the current implementation has a gap: a
+   lo0 input filter with DSCP match terms would NOT decline
+   flow-cache insertion. **Open question for reviewers — see
+   §11 Q1.**
+7. **Output filter family symmetry.** The DSCP gate handles
+   both input and output. Any future cache-sensitive field
+   MUST handle both arms.
+
+## 7. Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression risk | LOW | No runtime path changes (harness + doc). DSCP gate still exercised by existing tests; the parameterized harness adds coverage, not replacement. |
+| Lifetime / borrow-checker risk | LOW | Harness consumes existing `pub(crate)` helpers; no new lifetimes introduced. |
+| Performance regression risk | NONE | No hot-path changes. Possibly a tiny refactor to a `flow_cache_can_insert_for_field` helper — measured `#[inline(always)]` to compile-out. |
+| Architectural mismatch risk | MEDIUM | The trait + constant-list "tripwire" is informal — Rust can't enforce "every per-packet field on FilterTerm is in the list" without a proc-macro. If reviewers conclude this is doc-by-another-name, PLAN-KILL is appropriate. The harness is the real enforcement. |
+
+## 8. Test plan
+
+- `TMPDIR=/dev/shm CARGO_TARGET_DIR=/dev/shm/cargo cargo build` — clean.
+- `cargo test --release` — full cargo suite (952+ tests).
+- 5× flake check on
+  `from_forward_decision_skips_cache_for_dscp_matched_input_filter`
+  and `_output_filter` plus the new harness tests.
+- `go test ./...` — 30 Go packages (no Go-side code changes are
+  planned; this is regression coverage only).
+- Smoke on `loss:xpf-userspace-fw0/1` — v4+v6, push+reverse,
+  CoS-off + per-class. Strictly regression: no behavior change
+  is expected.
+- New tests added:
+  - `cache_contract_lists_all_known_match_fields` — counts
+    `*_match_enabled` flags on `FilterTerm` against the list.
+  - `cache_sensitive_harness_dscp_input` — reproduces #1430's
+    DSCP input gate via the parameterized harness.
+  - `cache_sensitive_harness_dscp_output` — same for output.
+  - `cache_sensitive_harness_rotation_purge` — exercises
+    rotation against a DSCP semantics change.
+  - `cache_sensitive_harness_fake_field_uncovered_fails` — uses
+    a synthetic test-only field tagged cache-sensitive but
+    deliberately not wired into the flow-cache gate; harness
+    must FAIL, proving it catches the future "implementer
+    forgot to wire it" case.
+  - `cache_contract_lo0_filter_is_listed` — if §11 Q1 resolves
+    "lo0 is in scope", proves the lo0 filter participates.
+
+## 9. Out of scope (explicitly)
+
+- Adding TCP flags / fragment / IHL / IP options matching to
+  the wire DTO or to `FilterTerm`. That's the next PR after
+  this one (or, more likely, the next several PRs — one per
+  field).
+- Adding any per-packet match field to `SessionKey`. Path (a)
+  in §1.3 of the issue body is documented but not exercised.
+- Removing the bespoke
+  `from_forward_decision_skips_cache_for_dscp_matched_*` tests
+  in favor of the harness — keep both for safety; remove
+  bespoke in a follow-up after the harness has soaked.
+- proc-macro derive of `PerPacketMatchField`. `userspace-dp`
+  avoids proc-macros to keep build times honest; the manual
+  constant list + tests are the chosen mechanism.
+- Lo0 filter DSCP gap closure (if §11 Q1 resolves to "yes, gap
+  exists"). That's a bug fix that should ship in its own PR
+  with `Closes #<new-bug>`, because it changes runtime
+  behavior. This PR documents the gap if it exists.
+
+## 10. Validation — pre-PR
+
+- `cargo build --release` clean.
+- `cargo test --release filter::` clean.
+- `cargo test --release flow_cache` clean.
+- `cargo test --release cache_contract` clean (new tests).
+- 5× flake on each new test.
+- Go suite clean.
+- Smoke matrix per CLAUDE.md (Pass A + Pass B).
+
+## 11. Open questions for adversarial review
+
+**Q1 — lo0 filter DSCP gap.** The existing #1430 implementation
+gates flow-cache on per-interface `iface_filter_v{4,6}_has_dscp_match`,
+but `lo0_filter_v{4,6}_fast` (host-bound traffic) is not in
+that set. Is this a real correctness gap that must be fixed
+before #1431 ships, or is host-bound traffic structurally
+exempt because it does not go through the flow-cache? Walk
+`userspace-dp/src/afxdp/poll_descriptor/` to verify the
+host-bound path. **PLAN-KILL the harness scope if Q1's answer
+forces the harness to also cover lo0 — that's a behavioral fix,
+not a contract.**
+
+**Q2 — is the constant list `PER_PACKET_MATCH_FIELDS` doing
+real work?** It's a hand-maintained list. The "real
+enforcement" is the harness. Is the constant list bringing
+value over and above a one-paragraph README "when you add a
+per-packet match field, do X" runbook? If reviewers conclude
+"the list adds churn without enforcement", strip §4.2 and ship
+the harness + README alone. **PLAN-KILL §4.2 specifically is
+fine; it does not kill the whole PR.**
+
+**Q3 — does the harness handle ICMP correctly?** ICMP packets
+use src_port/dst_port to carry type/code. Adding "ICMP type
+match" as a per-packet field is ambiguous — it might already
+be in the cache key (because type lives in the port field for
+ICMP sessions). The harness must NOT misclassify ICMP type as
+cache-sensitive. Reviewer must verify
+`userspace-dp/src/session/key.rs:28-...` (`forward_wire_key`
+ICMP branch).
+
+**Q4 — is `dscp_sensitive_filter_semantics_match` generalizable?**
+It currently inlines DSCP-specific aggregate-flag comparisons
+(`old.has_dscp_match_terms == new.has_dscp_match_terms`). For
+TCP flags or IHL the equivalent flag would be
+`has_tcp_flags_match_terms` / `has_ihl_match_terms`. Should
+the helper be parameterized today (via a closure or a
+`CacheSensitiveFieldDescriptor` trait), or should each future
+field paste its own helper? Cost-benefit: parameterizing today
+adds churn for one consumer (DSCP); pasting later doubles the
+maintenance surface. **Lean: paste later. Reviewer feedback
+welcome.**
+
+**Q5 — is the trade-off honest?** This PR is contract +
+harness, no runtime change. Is the failure mode (silent flow-
+cache bypass when a future per-packet field is added) actually
+a plausible failure? PR #1430 round 4 caught the original DSCP
+gap; the same review discipline would catch the next one. If
+review discipline is the real defense, this PR is theater.
+**PLAN-KILL with this reasoning is welcome.** The
+counter-argument: #1430 went through 5 review rounds before
+the round-5 carry-item was acknowledged. A test-time tripwire
+catches the same class of bug without depending on a 5-round
+review.
+
+**Q6 — does this conflict with #1373 retirement work?** The
+eBPF dataplane is being retired (#1373 / #1476). Filter
+semantics moving forward live only in `userspace-dp`. So the
+contract is naturally Rust-side only. The README change is in
+`userspace-dp/src/filter/README.md`, not in any eBPF doc. No
+conflict expected. Reviewer should verify.
+
+**Q7 — performance.** Confirmed: no hot-path changes. If §4.2
+adds a `compile_error!` macro, it fires at build time, not
+runtime. The harness is `cfg(test)` only. No measurable
+runtime cost expected. Reviewer must verify that the (possibly)
+factored `flow_cache_can_insert_for_field` helper folds back to
+the existing two-call pattern at `#[inline(always)]` (we have
+seen the compiler fail to inline through a trait-bound generic
+in the past — keep this concrete).
+
+---
+
+If reviewers conclude the perf gain is too small to justify
+the churn, **PLAN-KILL is an acceptable verdict.**

--- a/docs/pr/1431-filter-cache-invariants/plan.md
+++ b/docs/pr/1431-filter-cache-invariants/plan.md
@@ -443,8 +443,10 @@ This PR is documentation + tests. No runtime change.
    `#[cfg(test)]`, no hot-path impact.
 3. HA sync portability — out of scope; README documents path (a)
    requires HA sync review.
-4. Stable-name purge comparison — exercised by the new positional-
-   ID-change-doesn't-fire test.
+4. Stable-name purge comparison — exercised by the existing
+   `input_dscp_filter_families_changed_ignores_positional_filter_id_change`
+   test at `userspace-dp/src/filter/tests.rs:1806` (cited from
+   the README runbook; no new test added).
 5. Three-color policer runtime shape — already in
    `dscp_sensitive_filter_semantics_match`; not regenerated.
 6. lo0 filters — documented as non-cacheable so future readers

--- a/docs/pr/1431-filter-cache-invariants/reviewer-ids.md
+++ b/docs/pr/1431-filter-cache-invariants/reviewer-ids.md
@@ -9,3 +9,13 @@
 
 - **Codex**: `task-mpnic4wn-2f38fd` — verify all r1 findings addressed; in-source block surface; harness right-sized; Q4 dup question; lo0 note keep/shrink.
 - **AGY**: `review-mpnicccj-1jngkm` — congruent verification of r1 action plan items.
+
+## Round 3 (plan v3 @ commit d5bd4651826bb703b49f47d33c6f95f51793c936)
+
+- **Codex**: `task-mpnijinr-08835k` — confirm r2 findings applied.
+- **AGY**: `review-mpnijmli-su8ofn` — confirm v3 still PLAN-READY.
+
+## Round 4 (plan v5 @ commit f4b7b041456d952fca10c358f95558cebab31323)
+
+- **Codex**: `task-mpnjcswx-l02e6k` — confirm r3 stale leftovers fixed.
+- **AGY**: `review-mpnjcvjj-zvj9hv` — same.

--- a/docs/pr/1431-filter-cache-invariants/reviewer-ids.md
+++ b/docs/pr/1431-filter-cache-invariants/reviewer-ids.md
@@ -19,3 +19,15 @@
 
 - **Codex**: `task-mpnjcswx-l02e6k` — confirm r3 stale leftovers fixed.
 - **AGY**: `review-mpnjcvjj-zvj9hv` — same.
+
+## Code review round 1 (PR #1604 @ head 705d62f6720d8fd512d5ffb36db4d946987f938c)
+
+- **Codex**: `task-mpnkbtew-5ayuov` — hostile code review.
+- **AGY**: `review-mpnkbzwi-6lhyzx` — hostile code review.
+
+## Code review round 2 (head 778450f74e4773872272bf4d782671e20c5d41e6)
+
+- **Codex r2**: `task-mpnlp6rw-8zl5ny` — confirm r1 findings + Copilot inline findings fixed.
+- **AGY r1**: already MERGE-READY at 705d62f67 — re-attestation not required for a doc-only fix on top.
+- **Copilot**: re-review requested via PR comment.
+- **Claude SMR**: `docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md` MERGE-READY (covers the fixed surface inline).

--- a/docs/pr/1431-filter-cache-invariants/reviewer-ids.md
+++ b/docs/pr/1431-filter-cache-invariants/reviewer-ids.md
@@ -31,3 +31,10 @@
 - **AGY r1**: already MERGE-READY at 705d62f67 — re-attestation not required for a doc-only fix on top.
 - **Copilot**: re-review requested via PR comment.
 - **Claude SMR**: `docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md` MERGE-READY (covers the fixed surface inline).
+
+## Code review round 3 — post-rebase + post-Copilot-r2 (head a5d06c424c1eba3619b41b7560e7c4eee79ceb8c)
+
+- **Codex r3**: `task-mpnneefh-5ymtw3` — re-confirm MERGE-READY after rebase + four doc tightenings.
+- **AGY r2**: `review-mpnnemma-6ijk2d` — same.
+- **Copilot r3**: `@copilot review` requested at this SHA — awaiting `copilot-pull-request-reviewer[bot]` formal review.
+- **Claude SMR**: `docs/pr/1431-filter-cache-invariants/claude-smr-code-r1.md` includes post-rebase addendum recording byte-range + 5-tuple corrections.

--- a/docs/pr/1431-filter-cache-invariants/reviewer-ids.md
+++ b/docs/pr/1431-filter-cache-invariants/reviewer-ids.md
@@ -1,0 +1,11 @@
+# #1431 reviewer task IDs
+
+## Round 1 (plan v1 @ commit ff242c3a8cc0428d88f98f7bc3e2abfb74f0e341)
+
+- **Codex**: `task-mpni1t2r-fmeyxk` — adversarial PLAN review, 10 Qs incl Q1 lo0 gap, Q3 ICMP, Q5 plausibility, Q6 fake-field harness soundness.
+- **AGY**: `review-mpni22am-c41y7k` — same Q set, parallel hostile review.
+
+## Round 2 (plan v2 @ commit 29d06607fa8865e332c1fe1690a13d239f568003)
+
+- **Codex**: `task-mpnic4wn-2f38fd` — verify all r1 findings addressed; in-source block surface; harness right-sized; Q4 dup question; lo0 note keep/shrink.
+- **AGY**: `review-mpnicccj-1jngkm` — congruent verification of r1 action plan items.

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -744,6 +744,160 @@ fn from_forward_decision_skips_cache_for_dscp_matched_input_filter() {
     );
 }
 
+// ============================================================
+// #1431 cache-invariant runbook reference tests
+//
+// These two tests are the canonical "this is what a new
+// cache-sensitive per-packet match field's flow-cache gate test
+// should look like" references for the runbook in
+// userspace-dp/src/filter/README.md
+// "Cache-key invariants for per-packet match fields (#1431)".
+//
+// They re-exercise the DSCP gate (already covered by the bespoke
+// tests above at lines 644 and 696), but in an explicitly
+// runbook-shaped layout: build a snapshot with the cache-sensitive
+// match field on a terminal action, bind it to the relevant
+// interface direction, drive `FlowCacheEntry::from_forward_decision`,
+// and assert the cache declines insertion.
+//
+// When a future PR adds a new cache-sensitive match field
+// (tcp_flags, fragment, ihl, tos lower bits / ECN, icmp_type,
+// flex_match, etc.), clone the pattern below — substitute the
+// new match field's snapshot field and the per-interface
+// has_<X>_match set the snapshot compiler populated. The flow-
+// cache home is `afxdp/`, not `filter/`, because
+// `FlowCacheEntry::from_forward_decision` is `pub(super)`-scoped
+// to `afxdp::flow_cache`.
+// ============================================================
+
+#[test]
+fn dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern() {
+    let rg_epochs = default_rg_epochs();
+    let (flow, mut meta, validation, decision, mut forwarding, ha_state) =
+        make_v4_round_trip_inputs();
+    // Step 1: pick a DSCP value the term will NOT match — the
+    // first-packet decision must be allowed to enter the cache
+    // path so the gate, not the term, is what blocks insertion.
+    meta.dscp = 0;
+    // Step 2: build a realistic snapshot whose terminal action
+    // depends on a per-packet field outside the cache key.
+    // For DSCP this is `dscp_values`; future fields would
+    // substitute their own snapshot field.
+    forwarding.filter_state = crate::filter::parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "lan-runbook-input".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-ef-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                dscp_values: vec![46],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[InterfaceSnapshot {
+            name: "reth1.0".into(),
+            ifindex: meta.ingress_ifindex as i32,
+            // Step 3: bind the filter as an INPUT filter on the
+            // ingress interface. The snapshot compiler in
+            // userspace-dp/src/filter/compiler.rs populates the
+            // per-interface has_dscp_match set
+            // (FilterState.iface_filter_v4_has_dscp_match).
+            filter_input_v4: "lan-runbook-input".into(),
+            ..Default::default()
+        }],
+        "",
+        "",
+    );
+
+    // Step 4: drive FlowCacheEntry::from_forward_decision and
+    // confirm the gate at flow_cache.rs:297-309 declined
+    // insertion via interface_input_filter_has_dscp_match.
+    let entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(TEST_TRUST_ZONE_ID),
+        Some(7),
+        None,
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+    );
+
+    assert!(
+        entry.is_none(),
+        "input-bound DSCP-matched filters must decline flow-cache \
+         insertion — see #1431 runbook in filter/README.md",
+    );
+}
+
+#[test]
+fn dscp_output_gate_blocks_flow_cache_insertion_via_runbook_pattern() {
+    let rg_epochs = default_rg_epochs();
+    let (flow, mut meta, validation, decision, mut forwarding, ha_state) =
+        make_v4_round_trip_inputs();
+    meta.dscp = 0;
+    // Step 1-2 identical to the input variant — build a
+    // snapshot whose terminal action depends on DSCP.
+    // Step 3 (changed from input): bind the filter as an
+    // OUTPUT filter on the egress interface. The compiler
+    // populates FilterState.iface_filter_out_v4_fast and the
+    // has_dscp_match aggregate is observed by
+    // interface_output_filter_has_dscp_match.
+    forwarding.filter_state = crate::filter::parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "wan-runbook-output".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-ef-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                dscp_values: vec![46],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: decision.resolution.egress_ifindex,
+            filter_output_v4: "wan-runbook-output".into(),
+            ..Default::default()
+        }],
+        "",
+        "",
+    );
+
+    // Step 4: same gate, different per-interface set
+    // (iface_filter_out_v4_fast.has_dscp_match_terms).
+    let entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(TEST_TRUST_ZONE_ID),
+        Some(7),
+        None,
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+    );
+
+    assert!(
+        entry.is_none(),
+        "output-bound DSCP-matched filters must decline flow-cache \
+         insertion — see #1431 runbook in filter/README.md",
+    );
+}
+
 /// Build a self-consistent v6-meta + v6-NAT scenario for the
 /// mirror-image mismatch test (v4 rewrite_dst on v6 meta). Separate
 /// from `make_v4_round_trip_inputs` so the v6 test doesn't have to

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -754,7 +754,9 @@ fn from_forward_decision_skips_cache_for_dscp_matched_input_filter() {
 // "Cache-key invariants for per-packet match fields (#1431)".
 //
 // They re-exercise the DSCP gate (already covered by the bespoke
-// tests above at lines 644 and 696), but in an explicitly
+// tests `from_forward_decision_skips_cache_for_dscp_matched_output_filter`
+// and `from_forward_decision_skips_cache_for_dscp_matched_input_filter`
+// above in this file), but in an explicitly
 // runbook-shaped layout: build a snapshot with the cache-sensitive
 // match field on a terminal action, bind it to the relevant
 // interface direction, drive `FlowCacheEntry::from_forward_decision`,
@@ -874,8 +876,10 @@ fn dscp_output_gate_blocks_flow_cache_insertion_via_runbook_pattern() {
         "",
     );
 
-    // Step 4: same gate, different per-interface set
-    // (iface_filter_out_v4_fast.has_dscp_match_terms).
+    // Step 4: same gate, different lookup —
+    // interface_output_filter_has_dscp_match consults
+    // iface_filter_out_v{4,6}_fast.has_dscp_match_terms (a fast
+    // map lookup plus aggregate flag, not a HashSet).
     let entry = FlowCacheEntry::from_forward_decision(
         &flow,
         meta,

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -128,7 +128,7 @@ on those fields.
 `addr_family`, `protocol`, `src_ip`, `dst_ip`, `src_port`, `dst_port`.
 For ICMP and ICMPv6 sessions, `parse_flow_ports`
 (`userspace-dp/src/afxdp/frame/inspect.rs:212-232`) unconditionally
-reads bytes 4-6 of the ICMP header into `src_port` (the ICMP
+reads bytes 4-5 of the ICMP header into `src_port` (the ICMP
 identifier word — meaningful for Echo Request/Reply, opaque for
 other ICMP types) and stores zero in `dst_port`. ICMP **type**
 and **code** are NOT in the cache key — adding an explicit
@@ -147,7 +147,7 @@ exactly one of these two classes:
 | `source_addresses` / `source_v4` / `source_v6` | yes | `src_ip` in `SessionKey` |
 | `destination_addresses` / `dest_v4` / `dest_v6` | yes | `dst_ip` |
 | `protocols` / `protocol_bitmap` (+ `protocol_match_enabled`) | yes | `protocol` |
-| `source_ports` | yes (TCP/UDP); ICMP-special | `src_port` carries the ICMP identifier word from bytes 4-6 of the ICMP header (meaningful for Echo Request/Reply, opaque otherwise) |
+| `source_ports` | yes (TCP/UDP); ICMP-special | `src_port` carries the ICMP identifier word from bytes 4-5 of the ICMP header (meaningful for Echo Request/Reply, opaque otherwise) |
 | `destination_ports` | yes (TCP/UDP); ICMP-zero | `dst_port` is 0 for ICMP |
 | `dscp_values` / `dscp_bitmap` (+ `dscp_match_enabled`) | NO — cache-sensitive | see #1430 pattern below |
 | (future) `tos_match` / ECN bits (non-DSCP TOS) | NO — cache-sensitive | TOS lower bits and ECN vary per packet |

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -124,8 +124,11 @@ first-packet forwarding decision for later packets that can differ
 on those fields.
 
 **The cache key.** `SessionKey`
-(`userspace-dp/src/session/key.rs`) is a 6-tuple:
-`addr_family`, `protocol`, `src_ip`, `dst_ip`, `src_port`, `dst_port`.
+(`userspace-dp/src/session/key.rs`) is the standard 5-tuple
+(`protocol`, `src_ip`, `dst_ip`, `src_port`, `dst_port`) plus an
+`addr_family` byte. The `addr_family` byte is redundant with the
+`IpAddr` variant carried by `src_ip` / `dst_ip` but is materialized
+on the struct for cheap branchless checks on the hot path.
 For ICMP and ICMPv6 sessions, `parse_flow_ports`
 (`userspace-dp/src/afxdp/frame/inspect.rs:212-232`) unconditionally
 reads bytes 4-5 of the ICMP header into `src_port` (the ICMP

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -127,8 +127,10 @@ on those fields.
 (`userspace-dp/src/session/key.rs`) is a 6-tuple:
 `addr_family`, `protocol`, `src_ip`, `dst_ip`, `src_port`, `dst_port`.
 For ICMP and ICMPv6 sessions, `parse_flow_ports`
-(`userspace-dp/src/afxdp/frame/inspect.rs:225`) stores the ICMP
-echo identifier in `src_port` and zero in `dst_port`. ICMP **type**
+(`userspace-dp/src/afxdp/frame/inspect.rs:212-232`) unconditionally
+reads bytes 4-6 of the ICMP header into `src_port` (the ICMP
+identifier word — meaningful for Echo Request/Reply, opaque for
+other ICMP types) and stores zero in `dst_port`. ICMP **type**
 and **code** are NOT in the cache key — adding an explicit
 `icmp_type` or `icmp_code` filter match makes the filter
 cache-sensitive unless `SessionKey` or trusted per-session
@@ -145,7 +147,7 @@ exactly one of these two classes:
 | `source_addresses` / `source_v4` / `source_v6` | yes | `src_ip` in `SessionKey` |
 | `destination_addresses` / `dest_v4` / `dest_v6` | yes | `dst_ip` |
 | `protocols` / `protocol_bitmap` (+ `protocol_match_enabled`) | yes | `protocol` |
-| `source_ports` | yes (TCP/UDP); ICMP-special | `src_port` carries ICMP identifier |
+| `source_ports` | yes (TCP/UDP); ICMP-special | `src_port` carries the ICMP identifier word from bytes 4-6 of the ICMP header (meaningful for Echo Request/Reply, opaque otherwise) |
 | `destination_ports` | yes (TCP/UDP); ICMP-zero | `dst_port` is 0 for ICMP |
 | `dscp_values` / `dscp_bitmap` (+ `dscp_match_enabled`) | NO — cache-sensitive | see #1430 pattern below |
 | (future) `tos_match` / ECN bits (non-DSCP TOS) | NO — cache-sensitive | TOS lower bits and ECN vary per packet |
@@ -199,7 +201,9 @@ implementation (#1430); use it as the template:
    filter/term IDs** — `Filter.id` and `FilterTerm.id` are
    stable only within a snapshot.
 7. **Tests** in `userspace-dp/src/afxdp/flow_cache_tests.rs`
-   following the DSCP runbook pattern at lines 643/695 and the
+   following the DSCP runbook pattern in
+   `from_forward_decision_skips_cache_for_dscp_matched_input_filter`
+   /`_output_filter` (DSCP-bespoke regression tests) and the
    #1431 references
    `dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern`
    / `_output_*`. The flow-cache test home is `afxdp/` because
@@ -208,7 +212,9 @@ implementation (#1430); use it as the template:
 
 Reference tests (already in the tree, cite from new field PRs):
 
-- gate insertion: `afxdp/flow_cache_tests.rs:643,695`
+- gate insertion: `afxdp/flow_cache_tests.rs` ::
+  `from_forward_decision_skips_cache_for_dscp_matched_input_filter`
+  / `_output_filter`
 - rotation purge positional-ID immunity:
   `filter/tests.rs:1806`
   (`input_dscp_filter_families_changed_ignores_positional_filter_id_change`)

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -111,3 +111,135 @@ Remaining limitations:
   trusted metadata.
 - Traffic-level integration, failover, and performance evidence remain
   production-hardening follow-ups for #1375, not active feature-gap blockers.
+
+## Cache-key invariants for per-packet match fields (#1431)
+
+PR #1430 closed the immediate filter-log enforcement gaps by treating
+DSCP as cache-sensitive metadata that lives outside the 5-tuple
+session/flow-cache key. #1431 codifies the contract going forward.
+
+**The invariant.** When a filter match depends on packet fields that
+are not part of the cache key, the dataplane must not reuse a
+first-packet forwarding decision for later packets that can differ
+on those fields.
+
+**The cache key.** `SessionKey`
+(`userspace-dp/src/session/key.rs`) is a 6-tuple:
+`addr_family`, `protocol`, `src_ip`, `dst_ip`, `src_port`, `dst_port`.
+For ICMP and ICMPv6 sessions, `parse_flow_ports`
+(`userspace-dp/src/afxdp/frame/inspect.rs:225`) stores the ICMP
+echo identifier in `src_port` and zero in `dst_port`. ICMP **type**
+and **code** are NOT in the cache key — adding an explicit
+`icmp_type` or `icmp_code` filter match makes the filter
+cache-sensitive unless `SessionKey` or trusted per-session
+metadata is extended to carry those fields.
+
+**Classification table.** Every match criterion (not action /
+modifier) on the wire DTO `FirewallTermSnapshot`
+(`userspace-dp/src/protocol/security.rs`) and the runtime
+`FilterTerm` (`userspace-dp/src/filter/mod.rs`) must fall into
+exactly one of these two classes:
+
+| Match criterion | In cache key? | Notes |
+|-----------------|---------------|-------|
+| `source_addresses` / `source_v4` / `source_v6` | yes | `src_ip` in `SessionKey` |
+| `destination_addresses` / `dest_v4` / `dest_v6` | yes | `dst_ip` |
+| `protocols` / `protocol_bitmap` (+ `protocol_match_enabled`) | yes | `protocol` |
+| `source_ports` | yes (TCP/UDP); ICMP-special | `src_port` carries ICMP identifier |
+| `destination_ports` | yes (TCP/UDP); ICMP-zero | `dst_port` is 0 for ICMP |
+| `dscp_values` / `dscp_bitmap` (+ `dscp_match_enabled`) | NO — cache-sensitive | see #1430 pattern below |
+| (future) `tos_match` / ECN bits (non-DSCP TOS) | NO — cache-sensitive | TOS lower bits and ECN vary per packet |
+| (future) `tcp_flags_match` | NO — cache-sensitive | TCP flags vary per packet |
+| (future) `is_fragment` / fragment offset / MF | NO — cache-sensitive | only first fragment carries L4 |
+| (future) `ihl_match` / IP options | NO — cache-sensitive | IHL varies per packet |
+| (future) `icmp_type_match` / `icmp_code_match` | NO — cache-sensitive (today) | could be promoted to cache-key by adding (type, code) to `SessionKey` for ICMP |
+| (future) `flex_match` | NO — cache-sensitive | byte-offset match, fully per-packet |
+
+Fields like `action`, `count`, `log`, `policer`, `routing_instance`,
+`forwarding_class`, and `dscp_rewrite` are forwarding actions and
+modifiers, applied after a match has succeeded. They do not
+participate in match-time key lookup and are out of scope for the
+cache-key contract.
+
+### Path (b) runbook — cache-sensitive
+
+Adding a per-packet match field that is NOT in the cache key
+requires wiring all of these hooks. DSCP is the reference
+implementation (#1430); use it as the template:
+
+1. **Aggregate flag** on `Filter` —
+   `Filter.has_<X>_match_terms: bool`, computed during snapshot
+   compile. See `Filter.has_dscp_match_terms` in
+   `userspace-dp/src/filter/mod.rs`.
+2. **Per-interface sets** on `FilterState` —
+   `iface_filter_v4_has_<X>_match: FxHashSet<i32>` and the v6
+   sibling, populated during snapshot compile. See the
+   `iface_filter_v{4,6}_has_dscp_match` fields in
+   `userspace-dp/src/filter/mod.rs`.
+3. **Lookup helpers** in
+   `userspace-dp/src/filter/engine/cache_sensitive.rs` —
+   `interface_input_filter_has_<X>_match` and
+   `interface_output_filter_has_<X>_match` (or thread the new
+   flag through one general helper if the DSCP-specific
+   functions are generalized in a future PR).
+4. **Flow-cache insertion gate** —
+   `userspace-dp/src/afxdp/flow_cache.rs:297-309` calls the
+   input + output helpers and returns `None` if either fires.
+5. **Established-session re-evaluation** —
+   `userspace-dp/src/afxdp/poll_descriptor/mod.rs:217-244`
+   (`evaluate_dscp_sensitive_input_filter_on_session_hit`) is
+   the DSCP shape; mirror it.
+6. **Forwarding-rotation purge** —
+   `userspace-dp/src/afxdp/worker/loop_body/mod.rs:295-330`
+   uses `input_dscp_filter_families_changed` to decide whether
+   to purge sessions. Extend the semantics-match comparison in
+   `userspace-dp/src/filter/engine/cache_sensitive.rs:104-143`
+   to cover the new match field's aggregate flag and per-term
+   content. **Compare by content, never by compiler-positional
+   filter/term IDs** — `Filter.id` and `FilterTerm.id` are
+   stable only within a snapshot.
+7. **Tests** in `userspace-dp/src/afxdp/flow_cache_tests.rs`
+   following the DSCP runbook pattern at lines 643/695 and the
+   #1431 references
+   `dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern`
+   / `_output_*`. The flow-cache test home is `afxdp/` because
+   `FlowCacheEntry::from_forward_decision` is
+   `pub(super)`-scoped to `afxdp::flow_cache`.
+
+Reference tests (already in the tree, cite from new field PRs):
+
+- gate insertion: `afxdp/flow_cache_tests.rs:643,695`
+- rotation purge positional-ID immunity:
+  `filter/tests.rs:1806`
+  (`input_dscp_filter_families_changed_ignores_positional_filter_id_change`)
+- session-hit re-eval: `afxdp/tests.rs:3184`
+
+### Path (a) — extend `SessionKey`
+
+Promoting a per-packet match field into the cache key requires
+extending `SessionKey` in `userspace-dp/src/session/key.rs` AND
+proving stability across:
+
+- HA session sync wire format (`pkg/cluster/`),
+- session-table reverse / NAT-translated / forward-wire indices
+  (`userspace-dp/src/session/mod.rs`),
+- flow-cache key derivation (`flow_cache.rs`),
+- session expiry hash bucket math,
+- reverse-NAT lookup keys.
+
+This is a significant cross-cutting refactor — file a tracker
+issue against `session/key.rs` before attempting it.
+
+### lo0 is not on the flow-cache path
+
+Host-bound traffic resolves to
+`ForwardingDisposition::LocalDelivery`, which
+`is_cacheable()` returns `false` for at
+`userspace-dp/src/afxdp/types/forwarding.rs:196`. Per-packet lo0
+filter evaluation runs at
+`userspace-dp/src/afxdp/poll_descriptor/mod.rs:700` (session-hit
+path) and `:1153` (miss path). lo0 filters therefore do NOT need
+a per-interface `has_<X>_match` set — the flow-cache never holds
+a lo0 decision in the first place. This is noted here so future
+readers do not repeat the v1 plan investigation that mistook lo0
+for a missing cache-sensitive gate.

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -44,6 +44,36 @@ pub(crate) enum FilterAction {
     Reject,
 }
 
+// ============================================================
+// CACHE-KEY INVARIANT (#1431) — read before adding a match field
+//
+// Every match criterion on FilterTerm (and the wire DTO
+// FirewallTermSnapshot) MUST be classified as either:
+//
+//   (a) IN cache key — extend SessionKey in session/key.rs AND
+//       prove key stability for HA sync (pkg/cluster/),
+//       session-table reverse/NAT/forward-wire indices, flow_cache
+//       key derivation, expiry hash bucket math, and reverse-NAT
+//       lookup. File a tracker issue against session/key.rs.
+//
+//   (b) NOT in cache key (cache-sensitive) — wire the #1430
+//       runbook: per-interface FilterState.iface_filter_v{4,6}_has_<X>_match
+//       set, Filter.has_<X>_match_terms aggregate flag, flow-cache
+//       insertion gate at afxdp/flow_cache.rs:297-309, established-
+//       session re-evaluation at afxdp/poll_descriptor/mod.rs:217-244,
+//       forwarding rotation purge at afxdp/worker/loop_body/mod.rs:295-330,
+//       and tests at afxdp/flow_cache_tests.rs.
+//
+// Skipping this classification SILENTLY breaks flow-cache: a
+// first-packet decision gets reused for later packets that can
+// differ on the new field. PR #1430 fixed this for DSCP; the same
+// class of bug applies to any future per-packet match.
+//
+// See userspace-dp/src/filter/README.md
+//   "Cache-key invariants for per-packet match fields (#1431)"
+// for the classification table, the path (a) / path (b) recipes,
+// and the canonical reference tests.
+// ============================================================
 /// Compiled filter term with pre-parsed match criteria.
 #[allow(dead_code)]
 #[derive(Clone, Debug)]

--- a/userspace-dp/src/protocol/security.rs
+++ b/userspace-dp/src/protocol/security.rs
@@ -62,22 +62,31 @@ pub(crate) struct FirewallFilterSnapshot {
 //
 // Every match criterion on FirewallTermSnapshot (and its runtime
 // twin FilterTerm in userspace-dp/src/filter/mod.rs) MUST be
-// classified as either (a) IN cache key — extend SessionKey in
-// session/key.rs and prove key stability across HA sync, the
-// session-table reverse indices, flow-cache key derivation, and
-// reverse-NAT lookup — or (b) NOT in cache key (cache-sensitive),
-// which requires wiring the #1430 runbook (per-interface
-// has_<X>_match set, flow-cache insertion gate, established-session
-// re-evaluation, and forwarding-rotation purge).
+// classified as either:
+//
+//   (a) IN cache key — extend SessionKey in session/key.rs AND
+//       prove key stability for HA sync (pkg/cluster/),
+//       session-table reverse/NAT/forward-wire indices, flow_cache
+//       key derivation, expiry hash bucket math, and reverse-NAT
+//       lookup. File a tracker issue against session/key.rs.
+//
+//   (b) NOT in cache key (cache-sensitive) — wire the #1430
+//       runbook: per-interface FilterState.iface_filter_v{4,6}_has_<X>_match
+//       set, Filter.has_<X>_match_terms aggregate flag, flow-cache
+//       insertion gate at afxdp/flow_cache.rs:297-309, established-
+//       session re-evaluation at afxdp/poll_descriptor/mod.rs:217-244,
+//       forwarding rotation purge at afxdp/worker/loop_body/mod.rs:295-330,
+//       and tests at afxdp/flow_cache_tests.rs.
 //
 // Skipping this classification SILENTLY breaks flow-cache: a
 // first-packet decision gets reused for later packets that can
-// differ on the new field.
+// differ on the new field. PR #1430 fixed this for DSCP; the same
+// class of bug applies to any future per-packet match.
 //
 // See userspace-dp/src/filter/README.md
 //   "Cache-key invariants for per-packet match fields (#1431)"
-// for the full classification table, recipe pointers, and
-// canonical reference tests.
+// for the classification table, the path (a) / path (b) recipes,
+// and the canonical reference tests.
 // ============================================================
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub(crate) struct FirewallTermSnapshot {

--- a/userspace-dp/src/protocol/security.rs
+++ b/userspace-dp/src/protocol/security.rs
@@ -57,6 +57,28 @@ pub(crate) struct FirewallFilterSnapshot {
     pub terms: Vec<FirewallTermSnapshot>,
 }
 
+// ============================================================
+// CACHE-KEY INVARIANT (#1431) — read before adding a match field
+//
+// Every match criterion on FirewallTermSnapshot (and its runtime
+// twin FilterTerm in userspace-dp/src/filter/mod.rs) MUST be
+// classified as either (a) IN cache key — extend SessionKey in
+// session/key.rs and prove key stability across HA sync, the
+// session-table reverse indices, flow-cache key derivation, and
+// reverse-NAT lookup — or (b) NOT in cache key (cache-sensitive),
+// which requires wiring the #1430 runbook (per-interface
+// has_<X>_match set, flow-cache insertion gate, established-session
+// re-evaluation, and forwarding-rotation purge).
+//
+// Skipping this classification SILENTLY breaks flow-cache: a
+// first-packet decision gets reused for later packets that can
+// differ on the new field.
+//
+// See userspace-dp/src/filter/README.md
+//   "Cache-key invariants for per-packet match fields (#1431)"
+// for the full classification table, recipe pointers, and
+// canonical reference tests.
+// ============================================================
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub(crate) struct FirewallTermSnapshot {
     pub name: String,


### PR DESCRIPTION
## Summary

PR #1430 closed the immediate filter-log enforcement gaps by treating
DSCP as cache-sensitive metadata outside the 5-tuple session/flow-cache
key. #1431 codifies the contract going forward so a future per-packet
match field (TOS lower bits / ECN, TCP flags, fragment/IHL, IP options,
ICMP type/code, flex_match, etc.) cannot silently bypass flow-cache.

This PR is documentation + tests. **No runtime change.**

## What ships

- `userspace-dp/src/filter/README.md` grows a "Cache-key invariants
  for per-packet match fields (#1431)" section: the invariant verbatim
  from the issue, a classification table for every match criterion on
  `FirewallTermSnapshot` and `FilterTerm` (including future
  candidates), a path (b) runbook listing the seven cache-sensitive
  hooks with file:line refs to the #1430 DSCP reference implementation,
  a path (a) pointer for promoting a field into `SessionKey`, and a
  lo0 note clarifying that `LocalDelivery` is non-cacheable so lo0
  filters do not need a per-interface `has_<X>_match` set.
- In-source `CACHE-KEY INVARIANT` comment blocks above `FilterTerm`
  (in `userspace-dp/src/filter/mod.rs`) and `FirewallTermSnapshot`
  (in `userspace-dp/src/protocol/security.rs`). These are the loud
  reviewer-facing tripwires — anyone adding a match field to either
  surface will see the contract in the diff.
- Two new runbook-shaped tests in
  `userspace-dp/src/afxdp/flow_cache_tests.rs`:
  - `dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern`
  - `dscp_output_gate_blocks_flow_cache_insertion_via_runbook_pattern`

  These re-exercise the DSCP gate already covered by the bespoke
  tests at lines 644/696, but in an explicitly runbook-shaped
  layout with step-by-step comments. They serve as the canonical
  "clone this when adding a new cache-sensitive match field"
  references that the README cites.

Cited (not duplicated) existing coverage:
- rotation purge positional-ID immunity:
  `userspace-dp/src/filter/tests.rs:1806`
- session-hit DSCP re-evaluation: `userspace-dp/src/afxdp/tests.rs:3184`

## Plan + adversarial review

Plan doc: `docs/pr/1431-filter-cache-invariants/plan.md`
Reviewer task ids: `docs/pr/1431-filter-cache-invariants/reviewer-ids.md`

- Codex r1 (`task-mpni1t2r-fmeyxk`): PLAN-KILL with salvage path —
  rejected v1 `PER_PACKET_MATCH_FIELDS` constant list +
  `PerPacketMatchField` trait + fake-field harness as compile-time
  theater (Rust has no struct-field reflection without proc-macros).
- AGY r1 (`review-mpni22am-c41y7k`): PLAN-NEEDS-MAJOR — congruent.
- Codex r2 (`task-mpnic4wn-2f38fd`): PLAN-NEEDS-MINOR — kept salvage
  path; caught `pub(super)` visibility on
  `FlowCacheEntry::from_forward_decision` forcing tests into `afxdp/`,
  not `filter/`.
- AGY r2 (`review-mpnicccj-1jngkm`): PLAN-READY with one drop ask.
- Codex r3 (`task-mpnijinr-08835k`) + AGY r3 (`review-mpnijmli-su8ofn`):
  both PLAN-NEEDS-MINOR on stale-from-v2 leftovers in v3.
- Codex r4 (`task-mpnjcswx-l02e6k`) + AGY r4 (`review-mpnjcvjj-zvj9hv`):
  both PLAN-READY.

## Test plan

- [x] cargo build clean (warnings unchanged from master)
- [x] `dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern`
      and `_output_gate_*_via_runbook_pattern` — 5/5 passes
- [x] Full `cargo test --release` passes except a pre-existing
      `snat_contract_documents_current_fail_closed_runtime` doc-guard
      that also fails on origin/master
      (`docs/userspace-dataplane-gaps.md` has 0 occurrences of
      "fail-closed" on master) — unrelated to #1431.
- [x] Go suite (`go test ./...`) clean.
- [ ] Smoke skipped — doc-only PR, no runtime change; batch-merge
      per project memory pattern for review-only / doc-only PRs in
      the retirement chain. Posting `<!-- AWAITING-BATCH-MERGE -->`.

Closes #1431