### PR TITLE
dataplane: wire-protocol address-book dedup (#1606)

### DIFF
--- a/docs/pr/1606-wire-protocol-address-book/claude-smr-code-r1.md
+++ b/docs/pr/1606-wire-protocol-address-book/claude-smr-code-r1.md
@@ -1,0 +1,105 @@
+# Claude SMR code review — round 1 (PR #1610)
+
+**SHA reviewed**: `0018eb42e237` (initial implementation push).
+**Verdict before Codex code review**: PLAN-FOLLOWS-CLEAN.
+**Verdict after Codex code review**: NEEDS-MAJOR (convergent w/
+Codex F1).
+
+## Code-level concerns I audited
+
+1. **Per-rule v3-shaped predicate** (`policy.rs` line ~423):
+   `source_is_v3_shaped = !snap.source_book_ids.is_empty() || !snap.source_literals.is_empty()`. Correct, per-side, matches the
+   plan v8.
+
+2. **MatchNone variant on PrefixSetV4 / PrefixSetV6**: implemented.
+   `is_match_any()`, `is_match_none()`, `contains() -> false` for
+   MatchNone, new `from_v3_literals` constructor, legacy
+   `from_prefixes` unchanged. All paths walked.
+
+3. **Hard-fail integrity errors**: id=0, duplicate book IDs,
+   unknown rule book references all return `SnapshotIntegrityError`
+   variants. Verified.
+
+4. **Preflight in `refresh_runtime_snapshot`**: moved to the top of
+   the function before any state mutation. Uses
+   `self.forwarding.zone_name_to_id` (existing, so no new
+   side-effect).
+
+5. **Flat-index hot path**: `try_match_rule` walks
+   `rule.source_book_idxs.iter().any(|&i| state.books[i as usize].
+   v4.contains(src))`. Zero Arc deref. Precomputed `_match_any`
+   flags. Verified.
+
+6. **HA snapshot sync**: `address_books` field travels in the
+   same `ConfigSnapshot` envelope. No new lock acquisitions on the
+   hot path. Verified by walking
+   `worker/loop_body/mod.rs:58` (pin Arc<ForwardingState>) and
+   `worker/mod.rs:976` (load_arc_if_changed).
+
+7. **Go-side determinism**: book names iterated in lex sorted
+   order (`sort.Strings(allNames)` at line ~166 of policies.go).
+   Buckets sorted by `(hash64, canonical_bytes)`. Linear-probe is
+   deterministic given sorted input. Verified.
+
+## What Codex found that I missed
+
+### Codex F1 [MAJOR]: Bare IP values dropped from book table
+
+I implemented `expandBookNameToCIDRs` to only handle CIDR strings
+and "any". Junos syntactically allows `set security address-book
+global address host1 10.0.0.1` — a bare IP value. Legacy
+`expandUserspacePolicyAddresses` (in manager.go) accepts bare IPs
+via `net.ParseIP` and normalizes them to the string form. My new
+path dropped these silently.
+
+A rule citing a book with bare IPs becomes v3-shaped (cited a
+book) → empty literal set → MatchNone → fails closed on traffic
+that would have matched before.
+
+**Fix applied**: `expandBookNameToCIDRs` now falls through to
+`net.ParseIP` and emits the IP as a /32 or /128 CIDR. New test
+`TestAddressBookContainingBareIPNormalizesToSlash32Or128`.
+
+### Codex F2 [MEDIUM]: refresh_runtime_snapshot preflight pollutes counter store
+
+The preflight call to `parse_policy_state_with_counters` passed
+the live `&self.policy_counters`. If validation succeeded, those
+entries would be re-inserted by the actual build that follows
+(idempotent). If validation FAILED mid-build (some rules processed
+before the unknown-book-id rule), the counter store retains stale
+entries until the next successful reconcile purges them via
+`PolicyCounterStore::reconcile_rules`.
+
+**Fix applied**: preflight uses a scratch
+`PolicyCounterStore::default()` so the live store is untouched on
+failed validation.
+
+Note: the reconcile path's "preflight" IS the actual build (single
+build, with Result propagation), so the same concern there is
+self-bounded: a failed build leaves transient stale entries, but
+the next successful reconcile purges them via `reconcile_rules`.
+This is documented as acceptable (no separate fix needed).
+
+### Codex F3 [MINOR]: CIDR sets not deduped before content hashing
+
+Two books with identical effective CIDR set but different multiset
+content (e.g. one has a duplicate member entry from an
+address-set membership cycle) would hash to different canonical
+bytes and not share an ID.
+
+**Fix applied**: `dedupSortedStrings` helper called after sorting
+each family list. New test `TestAddressBookDedupsCIDRSetByContent`.
+
+## What I'd reject in r2
+
+- Re-introducing the bare-IP drop.
+- Reverting the scratch counter store.
+- Letting CIDR lists carry duplicates.
+
+None of these are present after the fix push.
+
+## Final verdict on the SHA after fixes
+
+If the fix-push tests pass (1453 Rust + Go userspace pass) AND
+Codex r2 confirms F1/F2/F3 cleanly resolved AND no new findings,
+this should be MERGE-READY pending Copilot + smoke matrix.

--- a/docs/pr/1606-wire-protocol-address-book/claude-smr-code-r2.md
+++ b/docs/pr/1606-wire-protocol-address-book/claude-smr-code-r2.md
@@ -1,0 +1,173 @@
+# Claude SMR code review — round 2 (PR #1610, SHA 8edb77c5b277)
+
+**Verdict: MERGE-READY**
+
+This round re-audits the current HEAD (`8edb77c5b277`) after the
+post-r1 commits 77e72f41f / 68138b122 / 8edb77c5b landed. Codex
+r3 was at SHA 77e72f41f (pre-AGY-r2-fixes); my r1 doc was also at
+that SHA. This r2 doc covers the diff from 77e72f41f → 8edb77c5b277
+plus a fresh sweep for any new fail-open paths.
+
+## Diff coverage (post-r1 commits)
+
+### Commit 68138b122 — preflight before tear_down + status mutation
+
+Two new preflight sites added:
+
+**1. `userspace-dp/src/server/handlers/snapshot.rs::apply`** —
+runs `parse_policy_state_with_counters` with a scratch
+`PolicyCounterStore::default()` AFTER the version check, BEFORE
+the `guard.status.last_snapshot_generation` etc. mutations at
+lines 37-41. On error: `response.ok = false` + early return.
+
+I walked the snapshot.rs file in full. The preflight block is
+at lines 33-58 (roughly). The mutations at 37-41 are AFTER the
+preflight block. No `guard.*` writes happen before the preflight.
+The error path returns without touching any field. ✓
+
+**2. `userspace-dp/src/afxdp/coordinator/reconcile/mod.rs::reconcile`** —
+runs `parse_policy_state_with_counters` with a scratch counter
+store at the TOP of `reconcile()` BEFORE `teardown::tear_down(self)`.
+On error: returns early without tearing down workers.
+
+Pre-existing code at line 72 `let preserved = teardown::tear_down(self);`
+now runs only AFTER the preflight passes (line ~98). Workers
+remain on the previous good config when integrity fails.
+
+This was AGY r2's finding 4.2. Closed.
+
+**3. Scratch counter store usage** confirms isolation: `PolicyCounterStore::default()` creates a fresh `Arc<Mutex<FxHashMap<…>>>` per
+preflight. Rejected snapshots cannot leak `Arc<PolicyRuleCounter>`
+entries into `coord.policy_counters` because the parser inserts
+into whatever store is passed in. The scratch store is dropped at
+function exit. ✓
+
+### Commit 8edb77c5b — drop depth cap on book recursion
+
+`pkg/dataplane/userspace/policies.go::expandBookNameRecursive`:
+
+```go
+func expandBookNameRecursive(ab *config.AddressBook, name string, visited map[string]bool, _depth int) []string {
+    if visited[name] {
+        return nil
+    }
+    visited[name] = true
+    defer func() { delete(visited, name) }()
+    if addr, ok := ab.Addresses[name]; ok {
+        return []string{addr.Value}
+    }
+    if as, ok := ab.AddressSets[name]; ok {
+        var out []string
+        for _, member := range as.Addresses {
+            out = append(out, expandBookNameRecursive(ab, member, visited, 0)...)
+        }
+        for _, nested := range as.AddressSets {
+            out = append(out, expandBookNameRecursive(ab, nested, visited, 0)...)
+        }
+        return out
+    }
+    return nil
+}
+```
+
+Path-based cycle detection: `visited[name]` set on entry, unset
+on exit via deferred delete. Sibling AddressSets with shared
+parents work because `defer` unwinds before the sibling descent.
+
+Cycle case `A → B → A`: enters A (visited[A]=true), descends to B
+(visited[B]=true), descends to A → `visited[A]` is true → returns
+nil. No infinite recursion. ✓
+
+Sibling-share case `Parent { setA { common }, setB { common } }`:
+enters Parent, recurses into setA → common (visited[common]=true),
+returns from common (deletes visited[common]), returns from setA
+(deletes visited[setA]), recurses into setB → common (visited[common]
+not set anymore, expands normally). Legacy behavior preserved. ✓
+
+This was Copilot C2. Closed.
+
+## Hostile re-checks at current HEAD
+
+### Wire format Go ↔ Rust
+
+Walked once more:
+- `AddressBookSnapshot` (Go protocol.go:80-87) ↔ Rust security.rs
+  `AddressBookSnapshot` — fields `id`, `name`, `prefixes_v4`,
+  `prefixes_v6` match with serde rename tags.
+- `PolicyRuleSnapshot.SourceBookIDs` etc. ↔ Rust
+  `source_book_ids` — JSON tags identical.
+- `ConfigSnapshot.AddressBooks` ↔ Rust `address_books` — match.
+
+No drift.
+
+### Stale-state-past-validation sweep
+
+The fallible parse is called from three control paths in
+production code:
+1. `server/handlers/snapshot.rs::apply` — has preflight. ✓
+2. `Coordinator::reconcile` — has preflight before tear_down. ✓
+3. `Coordinator::refresh_runtime_snapshot` — has preflight (was
+   the Codex r1 F2 site). ✓
+
+The lower-level `build_forwarding_state_with_policy_counters_
+and_previous` returns the Result. Its only `?` propagation point
+is the `parse_policy_state_with_counters` call at
+`forwarding_build/mod.rs:156`. The function does construct
+`ForwardingState::default()` at the top and populates fields
+through to the parse — but on parse failure the function returns
+`Err(_)` and the half-built `ForwardingState` is dropped without
+escaping. ✓
+
+### HA snapshot sync
+
+The preflight uses the same parse function as the actual build,
+which is deterministic given identical inputs. Two HA peers
+receiving the same ConfigSnapshot will produce the same
+PolicyState (or fail validation identically). No new HA
+divergence path. ✓
+
+### Hot path Vec<BookEntry> + SmallVec<[u32; 8]>
+
+Unchanged from r1 review. `try_match_rule` walks
+`rule.source_book_idxs.iter().any(|&i| state.books[i as usize].
+v4.contains(src))`. Precomputed `_match_any` flags short-circuit.
+Zero Arc deref. No new findings. ✓
+
+### Counter-leak from refresh_runtime_snapshot rejection
+
+The Codex r1 F2 fix used a scratch counter store for the
+refresh_runtime_snapshot preflight. Verified at
+`coordinator/mod.rs:445` — `&preflight_counters` (a fresh
+`PolicyCounterStore::default()`). The actual rebuild later in
+the function uses `&self.policy_counters`. ✓
+
+## Verification commands
+
+```
+cd userspace-dp && cargo build --release    # clean (134 warnings)
+cd userspace-dp && cargo test --release --bin xpf-userspace-dp
+  test result: ok. 1453 passed; 0 failed; 2 ignored
+go test -count=1 ./pkg/dataplane/userspace/...
+  ok  github.com/psaab/xpf/pkg/dataplane/userspace 3.072s
+```
+
+5×/5× flake check on the 10 new Rust policy tests: all green.
+
+## Findings: none
+
+All AGY r2 NEEDS-MAJOR findings closed. All Copilot r1 inline
+findings closed. Codex r4 spot-check confirmed:
+- snapshot.rs preflight order ✓
+- reconcile preflight before tear_down ✓
+- scratch counters on both preflights ✓
+- expandBookNameRecursive path-based cycle detection terminates ✓
+- no Go/Rust wire drift ✓
+- no stale-state leak past validation ✓
+
+AGY r3 verdict at current HEAD: MERGE-READY.
+
+## Final SMR verdict on HEAD `8edb77c5b277`: MERGE-READY
+
+The PR is structurally sound, all known fail-open paths are
+closed, all reviewer findings across 4 code-review rounds are
+addressed at this SHA. Smoke gate is the only remaining checkpoint.

--- a/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r1.md
+++ b/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r1.md
@@ -1,0 +1,220 @@
+# Claude SMR plan review — round 1
+
+**Issue**: #1606 wire-protocol restructure for address-book deduplication
+**Plan**: `docs/pr/1606-wire-protocol-address-book/plan.md`
+**Reviewer**: Claude SMR (domain: cross-language wire protocols, Rust
+Arc/ArcSwap memory ownership, HA snapshot sync, LPM data structures)
+
+## Verdict: PLAN-NEEDS-MAJOR
+
+The plan is structurally sound on the wire-protocol axis but has three
+NEEDS-MAJOR issues that must be addressed before PLAN-READY. I'm not
+killing it — the architecture is right and the rescoping of §7 is
+honest. But the determinism story, the double-counting risk, and the
+acceptance-gate rewording all need tightening.
+
+## Findings
+
+### F1 [MAJOR] §6 collision recovery is non-deterministic across HA peers
+
+The plan acknowledges this risk obliquely but does not close it. Linear
+probe ID assignment requires a **stable iteration order** over the set
+of books being assigned. The plan says "ID assignment is content-hashed"
+in `buildAddressBookTable(cfg) []AddressBookSnapshot` (§3.2) but in Go
+`map[string]*Address` iteration is randomized per-process by design.
+
+> "if the low-32 collides with an already-assigned ID for a DIFFERENT
+> (name, CIDR-set) tuple, fold in the upper 32 bits of the hash by
+> XORing in `(hash >> 32) * (probe + 1)`, retry."
+
+This recovery depends on which book got assigned FIRST. If peer A
+processes book "alpha" before "beta" and peer B processes "beta" first,
+and both hash to the same low-32, they end up with DIFFERENT IDs for
+the same content.
+
+**Required fix**: walk
+`cfg.Security.AddressBook.Addresses` + `AddressSets` in a deterministic
+order — e.g. sort book names lexicographically before iteration. Add
+this requirement to §6 explicitly and add a unit test
+`TestAddressBookIDDeterministicAcrossMapOrder` that constructs the
+same config with the map keys inserted in different orders and asserts
+identical wire IDs. Without this, HA peers can disagree on book IDs
+under collision, and the divergence is silent (matching falls back to
+literal CIDRs which DO match identically, so the bug is "Arc sharing
+gets defeated under collision" not "forwarding diverges" — still
+worth fixing because it undermines the memory dedup story).
+
+### F2 [MAJOR] §3.4 double-counting risk in shim phase is hand-waved
+
+The plan §3.4 claims:
+
+> "Always populate `source_literal_v4/v6` / `destination_literal_v4/v6`
+> from `source_addresses` / `destination_addresses` regardless. ... A
+> v2 snapshot from a new Go binary with books AND literal CIDRs gets
+> both checked (union); since the new Go binary emits literals ONLY
+> for rule entries that were not address-book names (free-form CIDR
+> strings in the rule), this is also a union-equivalent — not
+> double-counting."
+
+This is true in matching semantics (union is union; matching the same
+prefix twice still says "match"). It is **NOT** true in memory: every
+named book referenced by a rule materializes BOTH as a shared
+`Arc<BookEntry>` AND as a per-rule literal prefix set built from the
+same CIDRs. The memory dedup goal of #1606 is silently defeated until
+the shim is removed in the follow-up PR.
+
+The plan must do ONE of:
+
+- **Option A**: change the new-Go emission so that `source_addresses`
+  carries ONLY free-form CIDR literals (i.e., addresses that were
+  inlined in the rule's `match { source-address X.X.X.X/Y }` rather
+  than referenced as a named book). Then the shim path still works
+  (old-Rust matches via literal CIDRs OR named-book-name-expanded
+  literals it does already), and new-Rust gets the dedup win.
+
+- **Option B**: explicitly document that the FIRST release with this
+  PR keeps full per-rule duplication for backward compatibility,
+  and the memory win lands only when the follow-up shim-removal PR
+  ships. The acceptance gate in this PR is then "the wire surface is
+  correct" rather than "the memory is reduced".
+
+Either is acceptable but the plan must pick one. As written §3.4
+implies Option A but §4 row 4 "literal CIDRs still emitted by new Go"
+implies Option B. The contradiction is the bug — resolve it.
+
+**My recommendation**: Option A. Make new-Go's expansion path
+distinguish "I am the result of expanding a named address book" from
+"I am a free-form CIDR literal", emit only the latter into
+`source_addresses`. The book IDs carry the former. Old-Rust reading
+a v2 snapshot then matches via literal-CIDRs (correct, equivalent
+semantics because old-Rust didn't know about books anyway, but
+matching against the union of (literal-CIDRs + named-book-expansions)
+was what old-Rust used to do — and old-Go used to put the named-book
+expansions into `source_addresses` for old-Rust to see). Wait — that
+means **old-Rust receiving a v2 snapshot loses the named-book matches**
+if Option A is taken.
+
+The cleanest resolution: Option B for this PR (full belt-and-braces
+emission, no immediate memory win), bake the wire format for one
+release, then ship the shim-removal PR that switches to Option A.
+The plan should be explicit that #1606 is **wire-protocol-only**;
+memory deduplication lands in the follow-up. This matches the plan's
+§2 "shim removal is out of scope" but contradicts §1's "memory
+acceptance: ≤ 200 MB" framing.
+
+### F3 [MAJOR] §7 acceptance gate rewording — be more direct
+
+The plan §7 walks the math and concludes the issue's stated 200 MB
+gate is structurally unachievable with the existing
+`PrefixSetV4::Trie`. I agree with the math. But the plan says
+"Pre-flight this rescoping with the reviewers in plan v1" — which is
+fine, but the new gate should be **stated definitively** in §7, not
+left as "tentative". Specifically:
+
+The plan must commit to:
+
+- **Wire-correctness gate**: new-Go emits books, new-Rust deserializes
+  them, every existing policy test passes.
+- **Arc-sharing gate**: a test asserts that two rules citing the same
+  book ID share the same `Arc<BookEntry>` (via `Arc::ptr_eq` or
+  `Arc::strong_count`).
+- **Memory gate (post-shim-removal)**: NOT in this PR. Move it to the
+  follow-up shim-removal issue.
+
+Failure to commit to a concrete gate makes this PR untestable. The
+issue's 200 MB is wrong; the plan correctly identifies this; but the
+plan must REPLACE it with something achievable in #1606 instead of
+saying "let's discuss with reviewers".
+
+### F4 [MINOR] PolicyRule field rename blast radius
+
+The plan §3.3 proposes renaming `source_v4` → `source_literal_v4`. I
+grep'd the project: this field is used in `policy.rs`,
+`policy_tests.rs`, and the `forwarding_build.rs:467` debug-log
+readout for `prefix_count()`. That's a small blast radius. The
+rename is fine. Recommend the plan note the exact call sites for
+reviewer convenience.
+
+### F5 [MINOR] Hot-path cost for Vec<Arc<BookEntry>> walk
+
+`try_match_rule` will iterate `rule.source_books.iter()` then deref
+`Arc::deref()` to read `book.v4.contains(ip)`. For a rule with 5
+books, that's 5 dependent loads on heap-allocated Arc bodies. With
+the precomputed `source_v4_match_any: bool` flag, the common-case
+"any" rule short-circuits cleanly. For rules with actual book
+content, the walk is 5 × (load Arc pointer, load PrefixSetV4 enum
+discriminant, dispatch). On modern x86 that's ~10-20ns/rule for the
+walk plus the trie lookup itself. Acceptable but worth a microbench
+in the implementation PR.
+
+Note that this is NOT worse than today's path — today's
+`source_v4.contains(ip)` already does enum dispatch + trie walk.
+The Arc indirection adds ~1 cache miss per book. At 2-3 books per
+rule (typical), this is ≤ 5ns overhead. Acceptable.
+
+### F6 [MINOR] Per-rule Vec<Arc<BookEntry>> allocation churn
+
+At 100K rules × avg 3 books per rule, snapshot apply allocates ~300K
+`Arc::clone()` calls. That's pure refcount increments (~30ns each on
+contended cache lines, but the Arcs are fresh per snapshot so no
+contention) → ~9ms one-shot. Acceptable for snapshot apply (one-shot,
+amortized over the rule build).
+
+### F7 [MINOR] Snapshot-apply work spike
+
+The plan defers per-book Arc reuse across snapshots to #1607. Without
+it, every snapshot apply rebuilds every book's `PrefixSetV4::Trie`.
+At 10K books × 100 CIDRs each, that's ~1M insertions, ~30ns each =
+~30ms. Acceptable as a one-shot, but at 10K × 1K (worst case) it's
+300ms per snapshot. Note this in the plan as a known limit lifted by
+#1607.
+
+### F8 [MINOR] Version field bump
+
+The plan §3.1 says "JSON `version` is bumped from 1 to 2". I verified
+`ConfigSnapshot::version: i32` exists in `protocol/snapshot.rs:163`.
+But what's the current value? `grep -n "version: 1\|Version: 1" pkg/`
+should be sanity-checked in the implementation. The plan should
+verify the current value and document the bump explicitly. Minor —
+just a docs cleanup.
+
+## Specific corrections to the plan text
+
+1. §6 "ID derivation": add "After hashing, books are processed in
+   lexicographic order of `name` (with v4-CIDRs sorted, v6-CIDRs
+   sorted, then name itself) to ensure deterministic ID assignment
+   across peers under collision."
+
+2. §3.4: pick Option A or Option B explicitly. My recommendation:
+   Option B with an explicit note that memory dedup is a follow-up.
+
+3. §7: replace "tentative" with a definitive gate that's measurable
+   in THIS PR (wire correctness + Arc-sharing test). Move memory
+   gate to the shim-removal follow-up.
+
+4. §11: add an entry for "stable book-table iteration in Go" with
+   a sort-by-name invariant.
+
+## What I'd accept
+
+If the plan v2 incorporates F1, F2, F3 cleanly:
+- F1: deterministic iteration via sorted book names.
+- F2: pick Option B (shim phase keeps duplication; memory win in
+  followup). State it explicitly.
+- F3: drop the 200 MB gate from this PR; replace with
+  wire-correctness + Arc-sharing.
+
+…then I'll vote PLAN-READY in round 2. Codex and AGY may find
+additional items.
+
+## What would force me to KILL
+
+- Insisting on the issue's 200 MB gate without restructuring the LPM
+  (would require DIR-24-8 work that's out of scope here).
+- Hand-waving the HA determinism story.
+- Keeping the wire schema unchanged but pretending the dedup
+  happened.
+
+None of those are currently in the plan — F1/F2/F3 are
+"add precision" items, not "wrong direction" items. The plan's
+architecture is correct.

--- a/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r2.md
+++ b/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r2.md
@@ -1,0 +1,166 @@
+# Claude SMR plan review — round 2
+
+**Verdict: PLAN-NEEDS-MAJOR**
+
+V2 addressed five of six v1 findings but introduced new structural
+issues, primarily because the plan author (me) failed to read
+`pkg/dataplane/userspace/protocol.go:11` before writing v1 or v2.
+
+## Confirmed against repo state
+
+```
+$ grep -n "ProtocolVersion" pkg/dataplane/userspace/protocol.go
+11:	ProtocolVersion                  = 3
+```
+
+```
+$ grep -n "CONFIG_SNAPSHOT_PROTOCOL_VERSION" userspace-dp/src/server/handlers/snapshot.rs
+25:    if snapshot.version != CONFIG_SNAPSHOT_PROTOCOL_VERSION {
+```
+
+The Rust side **strictly rejects** any mismatched version. The "old Go
+v1 → new Rust v2 falls through to literal path" claim in v2's §3.4
+table is **false**: the request fails closed at line 25 of
+`snapshot.rs` before the field-by-field deserialization that would
+let serde defaults kick in.
+
+This invalidates v2's rolling-upgrade compatibility story.
+
+## New findings
+
+### N1 [MAJOR] Wrong protocol version baseline
+
+V2 says "bump JSON version from 1 to 2" everywhere. The repo is at
+**version 3**. The change is "additive fields on version 3" — no
+version bump at all.
+
+**Fix**: keep `ProtocolVersion = 3`. The new fields land as additive
+JSON members (already covered by serde `default` / `omitempty`).
+Update v3 of the plan to drop every "bump 1→2" reference.
+
+### N2 [MAJOR] Inverted parse-condition in §7
+
+V2 §3.3 / §3.4 says "new Rust prefers the book path when
+`address_books` is non-empty". But §7 plan §3.3 pseudo-code says:
+
+> "if v2 path (any of `source_book_ids` / `source_literals` present
+> OR `address_books.is_empty()`)"
+
+This is inverted. With `address_books.is_empty()`, there are NO
+books to dereference, so the rule's `source_book_idxs` must also be
+empty, which means the dense-index path silently produces zero
+match candidates. Combined with `source_literal_v4` defaulting to
+`MatchAny` (per `prefix_set.rs:58`), an old-Go v1 snapshot fed to
+new-Rust would match-any everything — **fail open**.
+
+**Fix**: define the parse-condition cleanly:
+
+- Construct `source_literal_v4` from `source_literals` if the new
+  field is present, ELSE from `source_addresses` (legacy field).
+- Construct `source_book_idxs` from `source_book_ids` (always; empty
+  if absent).
+- The "v1 vs v2" distinction is purely about WHICH field feeds the
+  literal-CIDR side. Books are always optional on the wire.
+
+This is cleaner than the version-or-emptiness guard.
+
+### N3 [MAJOR] Content-dedup vs name-dedup invariant clash
+
+V2 §5 says "two address books with the same set ... hash to the
+same value" — implying content-dedup (same content → same ID).
+
+V2 §6 collision recovery talks about `(name, canonical-content)`
+tuples — implying name is part of identity.
+
+Pick one. Recommended: **content-only ID** (the hash is purely a
+function of the canonicalized CIDR set). Two books "alpha" and
+"beta" with identical CIDRs share the same ID. The
+`AddressBookSnapshot.name` becomes diagnostic-only (already stated in
+§3.1). The collision-recovery clause then talks about distinct
+canonical-content tuples (not name+content tuples).
+
+If we pick content-only, the `address_books` array must dedup
+entries by content — emit ONE row per unique content hash, regardless
+of how many name aliases reference it. The `book_id_to_idx` map then
+gives every alias the same dense index.
+
+### N4 [MAJOR] u16 cap with literal-fallback re-introduces the bug
+
+V2 §3.3 says "Cap at 65,535 books per snapshot. ... overflow falls
+through to the literal path (with a warning)."
+
+At the 1M-target scale (Codex's hostile reading) this brings BACK
+the per-rule duplication this PR exists to remove. Even at
+intermediate scales (50K-200K books), the fallback would be silent
+memory blow-up.
+
+**Fix**: either (a) widen the index type to `u32` now (modest cost;
+`SmallVec<[u32; 4]>` is 16 bytes inline same as `u16; 4`), or (b)
+hard-fail the snapshot apply if the book count exceeds the
+implementation cap.
+
+Recommended: **(a) widen to u32 now**. Future-proof for 1M books +
+no fail-open risk.
+
+### N5 [MAJOR] Collision math: high-bit reservation costs a bit
+
+V2 §6 sets `id = low_32(hash) | 0x8000_0000`. That reduces the ID
+space to 31 bits (low half reserved). At 1M books, P(collision)
+goes from 11.3% (32-bit) to ~22.6% (31-bit). Plan's "0.00001% at
+10K books" cite was computed against 32 bits.
+
+**Fix**: drop the high-bit reservation. ID = 0 is the only
+reservation needed (and even that is just a Rust-side "unused"
+sentinel; the Go side can guarantee 0 is never minted by post-
+hashing).
+
+### N6 [MINOR] SmallVec inline cap of 4 unproven
+
+Codex correctly notes "rule cites 2-5 books on average" implies the
+p95 likely exceeds 4. Without real-world data I'd bump the inline
+cap to 8 (still on-stack; 16 bytes inline at u16, 32 inline at
+u32). Not a kill blocker but worth doing.
+
+### N7 [MINOR] Per-rule book ID handling needs to be explicit
+
+V2 doesn't say what happens if:
+- A rule's `source_book_ids` contains a duplicate ID.
+- A rule's `source_book_ids` references an unknown ID (not in the
+  `address_books` array).
+- `address_books` contains duplicate IDs.
+
+Default policies:
+- Per-rule duplicate IDs: sort + dedup at parse time. Idempotent.
+- Unknown IDs: log + skip + continue. Don't fail-closed (could
+  blackhole traffic). Don't fail-open (could permit unintended).
+  Treat as "this book contributed no addresses" — equivalent to
+  the book being empty.
+- Duplicate `address_books.id`: hard-fail the snapshot. Indicates
+  a Go-side bug, not a degraded config.
+
+V3 should specify these.
+
+## What v3 needs
+
+1. Drop all "version 1 → 2" wording. Replace with "additive fields
+   on version 3, serde-default handles missing fields".
+2. Rewrite §3.4 (and the v1/v2 compat table) to be honest about the
+   actual Rust-side gate: it's field presence, not version.
+3. Pick content-only ID semantics. Make the dedup test consistent.
+4. Widen book index to u32.
+5. Drop the 0x8000_0000 reservation.
+6. Specify duplicate / unknown ID handling.
+7. Bump SmallVec inline cap to 8.
+
+If v3 cleanly addresses N1-N5 (the MAJOR items), and Codex round 3
+agrees, I'll vote PLAN-READY.
+
+## What I'd kill on
+
+- Insisting on the version bump.
+- Hand-waving the parse-condition.
+- Keeping the u16 cap with literal fallback.
+
+None of these are currently in v2 by intent — they're either
+unintentional (N1, N2) or under-specified (N3, N4). Plan v3 should
+resolve all five MAJOR items in one pass.

--- a/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r3.md
+++ b/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r3.md
@@ -1,0 +1,120 @@
+# Claude SMR plan review — round 3 (plan v3 + v4 reactions)
+
+## Plan v3 round-3 verdict: PLAN-NEEDS-MAJOR (convergent with Codex r3)
+
+Plan v3 fixed all five of Codex's round-2 findings but introduced one
+critical fail-open path Codex correctly identified.
+
+### Convergent findings with Codex r3
+
+**F1 [MAJOR] Fail-open via empty PrefixSet → MatchAny**
+
+V3 §3.3 says: "`source_literal_v4` ← parse from `source_literals` if
+non-empty, ELSE parse from `source_addresses`."
+
+Combined with `userspace-dp/src/prefix_set.rs:58`:
+
+```rust
+if prefixes.is_empty() {
+    return Self::MatchAny;
+}
+```
+
+…the parse-condition has a fail-open path. Walk the scenario:
+
+1. New-Go emits a snapshot with `address_books` populated (some
+   other rule cites a book).
+2. A specific rule has `source_addresses=["any"]` (a legacy "match
+   any source" rule, fully expanded by Go's full-expansion code).
+   That rule has empty `source_literals` AND empty
+   `source_book_ids`.
+3. If new-Rust uses a GLOBAL gate "address_books non-empty → use
+   new fields", that rule parses with empty `source_literals` →
+   `PrefixSetV4::MatchAny` → matches all v4 traffic.
+4. The legacy `source_addresses=["any"]` field that previously
+   would have produced this same `MatchAny` is now ignored.
+
+In this specific case the outcome is the same (MatchAny either
+way), but the parse-condition is wrong because:
+
+- A rule that legitimately has `source_addresses = ["10.0.0.0/8"]`
+  (no books, no inline literals — just legacy full-expansion) and
+  is in a SNAPSHOT where `address_books` is non-empty (other
+  rules cite books) would be parsed with empty `source_literals`
+  → `MatchAny` → match all v4 traffic. **Fail open.**
+
+V4 fixes this by changing to a per-rule v3-shaped predicate:
+`source_is_v3_shaped = !source_book_ids.is_empty() ||
+!source_literals.is_empty()`.
+
+**F2 [MAJOR] Unknown book ID should hard-fail, not log+skip**
+
+V3 says "if ID is unknown ... log a warning and skip the ID".
+Codex r3 correctly notes that Junos compiler already rejects
+unresolved address-book references at
+`pkg/config/compiler.go:590`+. A dataplane-level skip could:
+
+- Silently widen policy: e.g. a rule that should match "internal-
+  hosts" book but the book is missing on the wire → rule matches
+  NOTHING from books, but the rule ALSO has no inline literals →
+  policy applies to no flows → traffic affected by that rule is
+  governed by whatever rule comes next (could be a more-open
+  default).
+
+V4 hard-fails the snapshot apply on unknown book ID, falling back
+to the previous snapshot. Same failure semantics as the existing
+version-mismatch reject at `snapshot.rs:25`.
+
+**F3 [MINOR] Collision math correction**
+
+V3 said 100K books → 0.116% collision probability. Codex r3 noted
+the correct birthday formula gives ~68.8%. My round-2 review was
+also imprecise (said "0.116% — collision-free in practice" which is
+wrong at 100K).
+
+V4 corrects: 10K → 1.16%, 100K → 68.8%, 1M → effectively certain.
+The probe scheme still works because load factor at 1M / 2^32 is
+1/4096; clustering is not an issue.
+
+**F4 [MAJOR] Hash input needs family/count framing**
+
+Codex r3 correctly identifies that concatenating raw `addr || len`
+bytes without a family tag or count prefix can produce identical
+canonical bytes for distinct v4/v6 content. E.g., a book containing
+`[10.0.0.0/8]` (v4) and an empty v6 list canonicalizes to roughly
+`[8, 10, 0, 0, 0]`; a book containing only `[0a00:0000::/8]` (v6
+where the high byte happens to be 0x0a) would canonicalize to
+`[8, 0a, 00, 00, ...]` — distinguishable only by length, but FNV-1a
+of these is ambiguous on truncation/end-of-stream.
+
+V4 adds explicit `"V4" || u32_be(count) || ...` and `"V6" || u32_be(
+count) || ...` framing.
+
+## Plan v4 verdict: PLAN-READY (pending Codex r4 confirmation)
+
+V4 incorporates the four findings cleanly. My remaining concerns:
+
+### Open items (NONE blocking)
+
+- **SmallVec inline cap**: V4 keeps `SmallVec<[u32; 8]>`. Codex r3
+  was silent on cap-of-4 (AGY raised it against the stashed code,
+  not the plan). I think 8 is the right number; bench data from the
+  implementation will tell us if it's too small/large.
+
+- **Test coverage** for the per-rule predicate edge cases is added
+  in v4's test plan. Good.
+
+### What I'd reject in v5+
+
+- Re-introducing any "global flag" parse predicate.
+- Softening the "hard-fail" on unknown book ID.
+- Removing the V4/V6 framing prefix.
+
+## My SMR vote on v4: PLAN-READY.
+
+The architecture is correct. The wire surface is honest. The HA
+determinism story is closed. The fail-open paths are closed. The
+flat-index design is the right hot-path shape. The forwarding_build
+external user is in the change list.
+
+Pending Codex round-4 confirmation, this plan is ready to implement.

--- a/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r4.md
+++ b/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r4.md
@@ -1,0 +1,122 @@
+# Claude SMR plan review — round 4 (plan v4 → v5)
+
+## Plan v4 round-4 verdict: PLAN-NEEDS-MAJOR (convergent with Codex r4)
+
+### Convergent finding with Codex r4
+
+**F-r4-1 [MAJOR] Book-only rule fail-opens via legacy
+PrefixSet::from_prefixes(empty)=MatchAny**
+
+V4's per-rule predicate fix correctly identified that the
+literal-source-selection must be per-rule-per-side, not global. But
+v4 still routes the `source_literals` parse through the existing
+`PrefixSetV4::from_prefixes` factory at
+`userspace-dp/src/prefix_set.rs:62`:
+
+```rust
+pub(crate) fn from_prefixes(prefixes: Vec<PrefixV4>) -> Self {
+    if prefixes.is_empty() {
+        return Self::MatchAny;
+    }
+```
+
+This means a v3-shaped rule that cites ONLY books (empty
+`source_literals`) gets `source_literal_v4 = MatchAny`. Then in
+`try_match_rule`:
+
+```rust
+src_ok = rule.source_v4_match_any
+    || rule.source_literal_v4.contains(src)  // <- MatchAny.contains() = true
+    || ...
+```
+
+…short-circuits to true regardless of the cited books' actual CIDR
+content. **Fail open.**
+
+Codex r4 caught this with exact line cites. My v4 SMR review missed
+it (I voted PLAN-READY on v4 — wrongly).
+
+### Additional Codex r4 finding
+
+**F-r4-2 [MAJOR] Family-incomplete books also fail-open**
+
+A v4-only book (`prefixes_v4` populated, `prefixes_v6` empty) built
+via `from_prefixes` has `entry.v6 = MatchAny`. Then a v6 packet
+hitting a rule that cites this book matches the book on v6 because
+of the empty=MatchAny convention. **Fail open** on v6 traffic.
+
+V4 didn't address this. V5 must.
+
+## Plan v5 fix
+
+V5 introduces an explicit `MatchNone` variant on `PrefixSetV4` /
+`PrefixSetV6`:
+
+- `MatchNone.contains(_) -> false`.
+- `MatchNone.prefix_count() -> 0`.
+- `MatchNone.is_match_none() -> true`.
+- `MatchNone.is_match_any() -> false`.
+
+And a new constructor `from_v3_literals(prefixes)`:
+
+- Empty input → `MatchNone` (NEW v3 semantic).
+- `/0` present → `MatchAny`.
+- Else `Linear` / `Trie` as today.
+
+The existing `from_prefixes` factory keeps the empty=MatchAny
+semantics so the non-v3-shaped fallback path is unaffected.
+
+Per-rule build:
+- v3-shaped side → `from_v3_literals` (MatchNone on empty).
+- non-v3-shaped side → `from_prefixes` (MatchAny on empty, legacy
+  back-compat for old-Go snapshots).
+
+Book table build:
+- Every book row → use `from_v3_literals` for both v4 and v6.
+  A v4-only book has `entry.v6 = MatchNone`. A v6-only book has
+  `entry.v4 = MatchNone`. An empty book (no v4 OR v6 — which is
+  semantically malformed) has both MatchNone — the book contributes
+  nothing to any match. Note: we should consider whether an empty
+  book should be a hard-fail on the wire, but it's not critical
+  for correctness.
+
+## V5 verdict: PLAN-READY (pending Codex r5 confirmation)
+
+The MatchNone variant cleanly closes:
+- Book-only rule fail-open.
+- Family-incomplete book fail-open.
+- Without breaking non-v3-shaped legacy compatibility (those still
+  use `from_prefixes` which keeps empty=MatchAny).
+
+Codex r4's other items:
+- F2 (unknown book ID hard-fail): fully addressed in v5; the
+  parse-policy-state function becomes `Result<PolicyState,
+  ParseError>` and the snapshot handler propagates errors before
+  any side-effect.
+- F3 (collision math): corrected in v4, retained in v5.
+- F4 (hash framing): corrected in v4, retained in v5.
+
+The minor "22.6%" doc artifact is fixed in v5.
+
+## What I'd kill on
+
+- Re-introducing `from_prefixes` on the v3-shaped path.
+- Conflating "no criteria" with "match all".
+- Skipping the MatchNone variant.
+
+None of those are in v5. The plan is ready to implement.
+
+## Test coverage check
+
+V5 has tests for:
+- book-only rule does NOT fail open (the F-r4-1 fix).
+- Pure "any" rule with address_books present (the v4 predicate
+  test).
+- v4/v6 cross-family no-canonical-collision (F4 fix).
+- unknown book ID = hard-fail snapshot (F2).
+- duplicate book ID = hard-fail.
+- book ID 0 = hard-fail.
+
+Missing test (should add): v4-only book + v6 traffic packet should
+NOT match on v6. The `family-incomplete book fail-open` symmetry.
+Add `test_v4_only_book_does_not_match_v6_traffic` in r5.

--- a/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r5.md
+++ b/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r5.md
@@ -1,0 +1,103 @@
+# Claude SMR plan review — round 5 (plan v5 → v6)
+
+## Plan v5 round-5 verdict: PLAN-NEEDS-MAJOR (convergent with Codex r5)
+
+Codex r5 caught two real issues in v5 that I missed in my r4 review.
+
+### F-r5-1: v3-shaped "any" → MatchNone (FAIL-CLOSED regression)
+
+Verified against the code. `userspace-dp/src/policy.rs:520`:
+
+```rust
+fn parse_address(prefix: &str, out_v4: &mut Vec<PrefixV4>, out_v6: &mut Vec<PrefixV6>) {
+    if prefix.is_empty() || prefix == "any" {
+        return;
+    }
+    ...
+}
+```
+
+"any" pushes NO prefixes. So a v3-shaped rule with
+`source_literals=["any"]` would produce empty prefix vecs →
+`from_v3_literals(empty) = MatchNone` → `MatchNone.contains() =
+false` → src side fails closed.
+
+This is a structural semantic regression (Junos "match any" rule
+silently matches nothing in the v3 path).
+
+V6 fixes this by introducing an explicit "any" token handler in the
+new `parse_v3_literal_set` helper. The helper carries
+`any_v4: bool` / `any_v6: bool` flags before vec collapse; if set,
+force `MatchAny`.
+
+### F-r5-2: fallibility scope too narrow
+
+V5 said "`parse_policy_state_with_counters` becomes fallible; errors
+propagate to the snapshot handler BEFORE any side-effect." But
+walking the actual call graph reveals multiple side-effecting
+mutations BETWEEN the snapshot handler and the policy build:
+
+- `snapshot.rs:apply` mutates `guard.status.last_snapshot_generation`
+  + several other status fields at lines 37-41 BEFORE calling the
+  reconcile/refresh path.
+- `Coordinator::refresh_runtime_snapshot` mutates neighbor manager
+  keys, validation, and counters BEFORE calling
+  `build_forwarding_state_with_policy_counters_and_previous`.
+- `reconcile/snapshot.rs:apply` applies validation and reconciles
+  counters BEFORE the forwarding build.
+
+V5's "+2 LOC at the one call site" was wrong — the actual fix needs
+to propagate fallibility through `build_forwarding_state*`,
+`Coordinator::refresh_runtime_snapshot`, the reconcile path, and
+the snapshot handler. The snapshot handler must do a **preflight
+build** before any of its status-field mutations.
+
+V6 corrects the scope. The change list now includes:
+- `forwarding_build/mod.rs`: build_forwarding_state* fallible.
+- `coordinator/mod.rs:454-485`: refresh_runtime_snapshot
+  propagates the Result.
+- `reconcile/snapshot.rs`: preflight build before mutations.
+- `server/handlers/snapshot.rs`: preflight build at the top,
+  before any guard mutation.
+
+## V6 incorporates AGY r5 F2 (tie-breaker)
+
+AGY r5 voted PLAN-READY but offered a minor refinement: when two
+distinct CONTENT hashes collide on low_32, sort by full 64-bit hash
+value to break ties deterministically. V6 adds this — buckets are
+sorted by full 64-bit FNV-1a hash before entering the probe loop.
+This is overlay-safe: at ≤10K books (realistic enterprise) the
+content-hash collision rate is effectively zero, so the sort is a
+no-op in practice; at 100K+ books, it makes the order
+deterministic.
+
+## V6 verdict: PLAN-READY (pending Codex r6 confirmation)
+
+The plan now:
+1. Closes the original fail-open paths (book-only rule,
+   family-incomplete book) via `MatchNone` + `from_v3_literals`.
+2. Closes the v3-shaped "any" → MatchNone regression via the
+   explicit any-token handler in `parse_v3_literal_set`.
+3. Propagates fallibility through the full call graph
+   (forwarding_build → coordinator → reconcile → handler), with
+   the snapshot handler running a preflight build before any
+   side-effect.
+4. Has deterministic collision-resolution tie-breaking via
+   full-64-bit-hash bucket ordering (AGY r5 F2).
+5. Closes all prior-round findings (HA determinism, version
+   baseline, content-vs-name dedup, u32 widening, family/count
+   hash framing, hard-fail unknowns).
+
+If Codex r6 doesn't find a new structural issue, this should be
+PLAN-READY.
+
+## What I'd kill on r6
+
+- Discovery of any path where a `from_prefixes(empty)=MatchAny`
+  result reaches a v3-shaped rule's match-side.
+- An incomplete fallibility-propagation chain (e.g. a side-effect
+  that runs before the preflight build).
+- Any new collision-determinism gap.
+
+None of those should be present in v6 by construction. But Codex
+has surprised me three rounds in a row, so I won't pre-bless.

--- a/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r6.md
+++ b/docs/pr/1606-wire-protocol-address-book/claude-smr-plan-r6.md
@@ -1,0 +1,83 @@
+# Claude SMR plan review — round 6 (plan v6 → v7)
+
+## Plan v6 verdict: PLAN-NEEDS-MINOR (convergent with Codex r6)
+
+V6 cleanly closed F-r5-1 (v3 "any" → MatchAny path via the new
+`parse_v3_literal_set` helper with explicit `any_v4` / `any_v6`
+flags) and F-r5-2 (fallibility propagation through the full call
+graph with preflight builds).
+
+Codex r6 raised two MINOR refinements that I agree with:
+
+### Codex r6 refinement 1: bucket by canonical bytes, not by hash
+
+V6's wording said "bucket unique CONTENT by 64-bit hash" — this is
+ambiguous if two distinct canonical byte streams happen to FNV-1a-64
+to the same value. The probability is ~2^-32 at 1M books
+(birthday) ≈ 1e-7 — astronomically unlikely. But the plan should be
+correct by construction.
+
+V7 buckets by canonical bytes; the 64-bit hash is metadata used as
+the primary sort key, with canonical bytes as the deterministic
+tie-break. This makes the ID assignment correct EVEN under a
+64-bit collision.
+
+### Codex r6 refinement 2: "any" in address-book values
+
+`pkg/dataplane/userspace/manager.go:1327` treats "any" as a
+supported literal. If an operator declares
+`set security address-book global address foo any` (Junos
+syntactically supports declaring an address as a value "any" via
+some forms), the resolved address-book value is the string "any".
+
+If this propagates into `AddressBookSnapshot.prefixes_v4`, the
+Rust side would see `"any"` in the prefix list. The existing
+`parse_address("any", ...)` returns early without pushing —
+treating "any" as empty. Combined with `from_v3_literals(empty) =
+MatchNone`, a book containing only "any" would silently match
+nothing. **Fail closed** (not as severe as fail-open, but still a
+semantic regression).
+
+V7 normalizes "any" at the Go `buildAddressBookTable` stage:
+replace with the explicit pair `{ "0.0.0.0/0", "::/0" }` before
+canonicalization. This way the wire never carries an "any" string
+inside a book; the Rust side only ever sees concrete CIDRs.
+
+## V7 verdict: PLAN-READY (pending Codex r7 confirmation)
+
+The plan now:
+
+1. Closes all known fail-open paths (book-only, family-incomplete,
+   any-in-literal).
+2. Closes the v3 "any" → MatchNone regression.
+3. Has deterministic ID assignment under all collision regimes.
+4. Has correct "any" handling at every layer (rule literal, book
+   content).
+5. Propagates fallibility through the full call graph with
+   preflight builds before any side-effect.
+6. All five prior-round critical findings resolved (HA
+   determinism, version baseline, content-vs-name dedup, u32
+   widening, family/count hash framing).
+
+The plan also:
+- Specifies new constructor `from_v3_literals` distinct from
+  `from_prefixes`.
+- Uses `SmallVec<[u32; 8]>` for inline-cap-of-8 rule references.
+- Defines deterministic content-bucket sort by `(hash64,
+  canonical_bytes)`.
+- Has comprehensive test plan covering the fail-open scenarios,
+  the "any" regression, the preflight integrity errors, and the
+  HA determinism across map orders.
+
+Pending Codex r7 confirmation, I vote PLAN-READY on v7.
+
+## What would force a kill on r7
+
+- Any new fail-open discovery I missed.
+- Any escape hatch in the v3-shaped predicate.
+- Any place where `from_prefixes(empty)=MatchAny` leaks into a v3
+  path.
+- Any deserialization quirk that mixes legacy and v3 paths.
+
+I don't expect any of these. The plan has been hardened by six
+rounds of hostile review.

--- a/docs/pr/1606-wire-protocol-address-book/plan.md
+++ b/docs/pr/1606-wire-protocol-address-book/plan.md
@@ -1,0 +1,786 @@
+# Plan v8: Wire protocol address-book ID + shared CIDR table (#1606)
+
+**Revision history**
+- v1: original plan; killed by Codex (HA determinism, shim
+  contradiction, §7 rosy memory, forwarding_build rename blast
+  radius, Vec<Arc<BookEntry>> hot-path shape, ArcSwap wording).
+- v2: PLAN-NEEDS-MAJOR — wrong protocol version baseline, inverted
+  parse condition, content-vs-name clash, u16-fallback, 31-bit
+  math.
+- v3: PLAN-NEEDS-MAJOR — book-only fail-open via PrefixSet empty,
+  unknown ID should hard-fail, collision math, hash framing.
+- v4: per-rule v3-shaped predicate, hard-fail unknowns, family/
+  count framing. PLAN-NEEDS-MAJOR'd: book-only rule still
+  fail-opens via PrefixSetV4::from_prefixes(empty)=MatchAny.
+- v5: added MatchNone variant + from_v3_literals constructor.
+  PLAN-NEEDS-MAJOR'd by Codex r5: (F-r5-1) v3-shaped "any" token
+  produces empty prefix vec → MatchNone → fail CLOSED on a rule
+  that should match all; (F-r5-2) fallible Result<PolicyState>
+  propagation scope is too narrow (multiple side-effecting call
+  sites between the snapshot handler and the policy build).
+- v6: adds explicit "any" handling in the v3 literal parser;
+  expands fallibility scope to include `build_forwarding_state*`,
+  coordinator refresh, reconcile, and snapshot handler.
+  PLAN-NEEDS-MINOR'd by Codex r6 for two refinements: (1) sort by
+  `(hash64, canonical_bytes)` to disambiguate the impossible-in-
+  practice 64-bit hash collision; (2) address-book contents
+  containing "any" string need normalization (canonicalize to
+  `0.0.0.0/0` + `::/0` at book-build time, or reject).
+- v7 (this): Codex r6 minor fixes — bucket-by-canonical-content
+  with `(hash64, canonical_bytes)` sort key; normalize "any" in
+  address-book contents to `0.0.0.0/0` + `::/0` at the Go
+  buildAddressBookTable level, so book contents on the wire are
+  always concrete CIDR strings.
+
+## 0. Wire-protocol context (READ FIRST)
+
+The control-plane → dataplane wire on the userspace path is **JSON
+over the local control socket**, not protobuf.
+
+The `ConfigSnapshot` JSON has a `version: i32` field. The repo is
+already at **protocol version 3**, set at
+`pkg/dataplane/userspace/protocol.go:11` (`ProtocolVersion = 3`).
+The Rust side STRICTLY rejects mismatched versions at
+`userspace-dp/src/server/handlers/snapshot.rs:25` — there is NO
+graceful field-by-field fallback once versions diverge.
+
+**This PR DOES NOT bump the protocol version.** The new wire fields
+are additive on version 3: serde `default` + `omitempty` handle the
+"old binary missing the field" case naturally. Old Go binaries
+emit no `address_books` / `source_book_ids` / `source_literals` and
+new Rust binaries fall through to the existing legacy
+`source_addresses` parse path. New Go binaries emit the additive
+fields, and new Rust binaries prefer them.
+
+A future shim-removal PR will bump version to 4 when the legacy
+`source_addresses` field is finally retired.
+
+## 1. Goal
+
+Restructure the JSON snapshot wire surface so that:
+
+1. Address-book contents live in a top-level `address_books` array,
+   keyed by a stable `u32` ID computed at Go compile-time by
+   **content-only** content-hashing (two named books with identical
+   CIDR sets share the same ID and produce ONE row in
+   `address_books`).
+2. Each `PolicyRuleSnapshot` references books by ID
+   (`source_book_ids: Vec<u32>`, `destination_book_ids: Vec<u32>`)
+   AND carries a separate `source_literals: Vec<String>` /
+   `destination_literals: Vec<String>` for free-form CIDRs that
+   appeared inline in the rule (not via a named address-book name).
+3. The existing wire field `source_addresses` / `destination_addresses`
+   stays on the v3 wire for **back-compat with old Rust binaries**
+   reading new-Go snapshots — it carries the FULLY EXPANDED literal
+   CIDRs (union of book expansion + free-form literals), exactly as
+   today. New-Rust IGNORES this field when ANY of the new fields
+   (`source_book_ids` or `source_literals`) is present on the rule.
+4. The Rust side stores books in a **flat dense table**
+   (`Vec<BookEntry>` on `PolicyState`); rules reference books by
+   small dense `u32` index. No `Arc<BookEntry>` per rule; no per-
+   rule heap allocations for the common case (≤8 books per rule).
+5. Memory dedup lands as soon as the Rust side is upgraded — new
+   Rust no longer re-parses CIDRs from `source_addresses` when book
+   IDs are present.
+
+## 2. Non-goals
+
+- **No gRPC / protobuf changes.** The CLI-facing `xpf.proto` is
+  untouched.
+- **No protocol version bump.** New fields are additive on version
+  3. Version bump (to 4) is deferred to a follow-up shim-removal PR.
+- **No DIR-24-8 / multibit trie / Patricia compression.** That is
+  #1608 follow-up.
+- **No new HA wire frames.** Snapshot bulk-sync uses the existing
+  envelope; the book table travels inside.
+- **No JIT / Cranelift work.**
+- **No removal of legacy `source_addresses`.** Follow-up
+  shim-removal PR, ≥1 release later.
+- **No address-book CRUD CLI changes.**
+
+## 3. Architecture
+
+### 3.1 Snapshot DTO shape (Rust side, `protocol/security.rs`)
+
+```rust
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub(crate) struct AddressBookSnapshot {
+    /// Stable u32 ID assigned at Go compile-time by content-only
+    /// content-hashing. Two address-book DECLARATIONS with the same
+    /// CIDR set get the same ID and produce ONE row in the wire
+    /// `address_books` array. ID 0 is reserved as "unused" and
+    /// never minted for a real book.
+    pub id: u32,
+    /// Diagnostic-only. When multiple Junos address-book names map
+    /// to the same content hash, this is the lexicographically
+    /// smallest name. Lookups always go through `id`.
+    #[serde(default)]
+    pub name: String,
+    /// Already-resolved literal CIDRs (v4). Address-set nesting and
+    /// name indirection is fully expanded on the Go side.
+    #[serde(rename = "prefixes_v4", default)]
+    pub prefixes_v4: Vec<String>,
+    #[serde(rename = "prefixes_v6", default)]
+    pub prefixes_v6: Vec<String>,
+}
+```
+
+`PolicyRuleSnapshot` grows FOUR new optional fields (all additive on
+version 3; serde defaults handle absence):
+
+```rust
+#[serde(rename = "source_book_ids", default)]
+pub source_book_ids: Vec<u32>,
+#[serde(rename = "destination_book_ids", default)]
+pub destination_book_ids: Vec<u32>,
+#[serde(rename = "source_literals", default)]
+pub source_literals: Vec<String>,
+#[serde(rename = "destination_literals", default)]
+pub destination_literals: Vec<String>,
+```
+
+The existing `source_addresses` / `destination_addresses` (Vec<String>
+of fully-expanded CIDRs) STAYS on the wire as the back-compat
+channel for old-Rust binaries reading new-Go snapshots.
+
+`ConfigSnapshot` (`protocol/snapshot.rs`) grows:
+
+```rust
+#[serde(rename = "address_books", default)]
+pub address_books: Vec<AddressBookSnapshot>,
+```
+
+The `version` field stays at 3.
+
+### 3.2 Go control plane
+
+`pkg/dataplane/userspace/protocol.go`:
+
+- Add `AddressBookSnapshot` struct.
+- Add `SourceBookIDs []uint32`, `DestinationBookIDs []uint32`,
+  `SourceLiterals []string`, `DestinationLiterals []string` to
+  `PolicyRuleSnapshot` (all `,omitempty`).
+- Add `AddressBooks []AddressBookSnapshot` to the wire snapshot
+  envelope (`,omitempty`).
+- **Do NOT bump `ProtocolVersion`.** Stays at 3.
+
+`pkg/dataplane/userspace/policies.go`:
+
+- New `buildAddressBookTable(cfg) ([]AddressBookSnapshot, map[string]uint32)`:
+  - Walk `cfg.Security.AddressBook.Addresses` +
+    `cfg.Security.AddressBook.AddressSets` in
+    **lexicographic sorted order** of the map keys. Go map iteration
+    is randomized; sorting is the HA determinism gate.
+  - For each declared book name, fully expand to a canonical
+    `(v4 CIDRs sorted by network bytes, v6 CIDRs sorted by network
+    bytes)` tuple.
+  - **"any" normalization (Codex r6 refinement)**: if a resolved
+    address-book entry value is `"any"`, replace it with the pair
+    `{ v4: "0.0.0.0/0", v6: "::/0" }` BEFORE canonicalization.
+    This way book-content wire bytes are always concrete CIDR
+    strings; the Rust side never sees `"any"` inside an
+    `AddressBookSnapshot.prefixes_v*`, eliminating the "any
+    inside a book" semantic-ambiguity case. Test
+    `TestAddressBookContainingAnyNormalizesToZeroSlash` asserts
+    this.
+  - **Bucket by canonical CIDR-set bytes** (NOT by hash — see §5
+    for why). Compute FNV-1a 64-bit hash per bucket as metadata.
+    Each unique bucket → one `AddressBookSnapshot`; its `name` is
+    the lexicographically smallest of the names whose canonical
+    bytes are in the bucket; its `id` is derived from the bucket's
+    hash (after collision recovery; see §5).
+  - Return `(books []AddressBookSnapshot, nameToID
+    map[string]uint32)`. Multiple names sharing a content hash all
+    map to the same ID.
+- Refactor `expandUserspacePolicyAddresses` into a new variant
+  `classifyUserspacePolicyAddresses(cfg, nameToID, addrs)`:
+  - Returns `(bookIDs []uint32, literals []string, legacyExpanded
+    []string, ok bool)`.
+  - For each entry in `addrs`:
+    - If it's a recognized address-book / address-set name → append
+      `nameToID[name]` to `bookIDs`.
+    - If it's a literal CIDR / IP → append to `literals`.
+    - If it's "any" → emit "any" into `literals` (matches existing
+      behaviour; PrefixSetV4::MatchAny is built from "any" via the
+      Rust side's `parse_address`).
+    - `legacyExpanded` is the union of `literals` + the expansion of
+      every named-book reference — identical to what
+      `expandUserspacePolicyAddresses` returns today.
+  - Per-rule `bookIDs` are sorted + deduped before being emitted
+    (so wire output is canonical regardless of input order).
+
+`pkg/dataplane/userspace/manager.go` (and `builder.go` where the
+snapshot is assembled):
+
+- Call `buildAddressBookTable` once per snapshot build.
+- Populate `AddressBooks` on the wire snapshot.
+- For each policy rule, populate `SourceBookIDs` /
+  `DestinationBookIDs` (from named-book references),
+  `SourceLiterals` / `DestinationLiterals` (from free-form CIDRs),
+  AND `SourceAddresses` / `DestinationAddresses` (full legacy
+  expansion, unchanged from today, for old-Rust back-compat).
+
+### 3.3 Rust dataplane (`userspace-dp/src/policy.rs`)
+
+- Add `BookEntry { v4: PrefixSetV4, v6: PrefixSetV6 }` (no `Arc`,
+  flat-owned).
+- `PolicyState` grows:
+  - `books: Vec<BookEntry>` — dense table.
+  - `book_id_to_idx: FxHashMap<u32, u32>` — wire-ID → dense index.
+  - `u32` index throughout (future-proof for >65K books).
+- `PolicyRule`:
+  - Rename `source_v4` → `source_literal_v4`. Same for
+    `destination_v4` / `source_v6` / `destination_v6`.
+  - Add `source_book_idxs: SmallVec<[u32; 8]>` — inline cap of 8 to
+    cover Codex's "p95 may exceed 4" concern.
+  - Add `destination_book_idxs: SmallVec<[u32; 8]>`.
+  - Add precomputed `source_v4_match_any: bool`,
+    `source_v6_match_any: bool`, `destination_v4_match_any: bool`,
+    `destination_v6_match_any: bool` (true iff EITHER the literal
+    set OR any cited book is `MatchAny` on that family).
+
+- `parse_policy_state_with_counters` grows a new parameter:
+  `address_books: &[AddressBookSnapshot]`.
+
+- **Book table build (HARD-FAIL on integrity errors)**:
+  - First pass: iterate `address_books`. For each row:
+    - If `row.id == 0`, hard-fail (0 is the reserved sentinel).
+    - If `row.id` is already in `book_id_to_idx`, hard-fail (Go-
+      side dedup bug).
+    - **Parse via the new MatchNone-aware constructor**: build
+      `entry.v4 = PrefixSetV4::from_v3_literals(prefixes_v4)` and
+      `entry.v6 = PrefixSetV6::from_v3_literals(prefixes_v6)`.
+      A v4-only book (empty v6 list) gets `entry.v6 = MatchNone`,
+      NOT `MatchAny`. Likewise a v6-only book.
+    - Push `BookEntry` to `state.books`; insert `(row.id,
+      books.len() - 1)` into `book_id_to_idx`.
+  - Hard-fail = return a snapshot-apply error from
+    `parse_policy_state_with_counters` up through the
+    snapshot-apply handler. The control plane retains the previous
+    snapshot. This matches the existing version-mismatch failure
+    mode at `userspace-dp/src/server/handlers/snapshot.rs:25`.
+    The implementation MUST return BEFORE mutating
+    `guard.snapshot` or publishing forwarding state — i.e. the
+    parse-policy-state path becomes fallible (`Result<PolicyState,
+    Error>`) and the snapshot handler propagates the error before
+    any side-effect.
+
+- **Per-rule build (v3-shaped predicate, FAIL-CLOSED safe)**:
+  - Define `source_is_v3_shaped =
+    !snap.source_book_ids.is_empty() || !snap.source_literals.is_empty()`.
+    Same for destination.
+  - **CRITICAL**: the literal-field selection is per-rule-per-side
+    based on this predicate, NOT a global `address_books.is_empty()`
+    check.
+  - If `source_is_v3_shaped`: build the literal sets via a new
+    helper `parse_v3_literal_set(source_literals: &[String]) ->
+    (PrefixSetV4, PrefixSetV6)`:
+    - Walk `source_literals`. For each token:
+      - "any" → set `any_v4 = true` AND `any_v6 = true`.
+      - CIDR / IP literal → push to the appropriate prefix vec.
+      - "any4" / "any6" (future-proof): force MatchAny on one
+        family. Not required by today's Junos syntax but supported.
+    - At end: if `any_v4` → `source_literal_v4 = MatchAny`; else
+      build via `PrefixSetV4::from_v3_literals(v4_prefixes)` which
+      returns `MatchNone` on empty, `MatchAny` on `/0`, else
+      `Linear` / `Trie`. Symmetric for v6.
+    - **CRITICAL**: this fixes Codex r5 F-r5-1 — "any" in
+      `source_literals` correctly produces `MatchAny`, not
+      `MatchNone`.
+  - Else (non-v3-shaped — legacy emitter): parse `source_literal_v4`
+    from `source_addresses` via the existing
+    `PrefixSetV4::from_prefixes`. Empty `source_addresses` still
+    means "match any" — that's the legacy semantics this PR
+    preserves.
+  - `source_book_idxs` ← for each ID in `source_book_ids`:
+    - sort + dedup the input IDs first;
+    - if ID is in `book_id_to_idx`, append the index;
+    - if ID is unknown (no matching `address_books` row):
+      **HARD-FAIL the snapshot apply**, returning a snapshot-
+      integrity error to the control plane. Junos compiler already
+      rejects unresolved address-book references at
+      `pkg/config/compiler.go:590`+ ; a dataplane-level "log+skip"
+      could silently widen policy. Bail to the previous snapshot.
+  - Precompute `source_v4_match_any` = true iff the **union** of
+    the literal set + cited books would match any address. That is:
+    - `source_literal_v4.is_match_any() == true`, OR
+    - any cited book has `v4.is_match_any() == true`.
+    `MatchNone` on the literal does NOT short-circuit `match_any`.
+  - Symmetric: precompute `source_v4_match_none` = true iff the
+    literal is `MatchNone` AND every cited book's v4 is
+    `MatchNone`. Used to short-circuit "no source v4 criteria"
+    rules at parse time — they immediately fail the v4 side of the
+    match (returns None from `try_match_rule`).
+
+  This eliminates the book-only fail-open path Codex r4 identified:
+  a rule citing only books has `source_literal_v4 = MatchNone`, so
+  `source_literal_v4.contains(src) = false`, and the union falls
+  through to the book walk. Correct.
+
+- **`try_match_rule`** (the hot path):
+
+```rust
+fn try_match_rule(rule: &PolicyRule, state: &PolicyState, ...) -> Option<...> {
+    if rule.inactive { return None; }
+    if !rule.compiled_apps.matches(protocol, src_port, dst_port) { return None; }
+
+    let src_ok = match src_ip {
+        IpAddr::V4(src) => rule.source_v4_match_any
+            || rule.source_literal_v4.contains(src)
+            || rule.source_book_idxs.iter()
+                .any(|&i| state.books[i as usize].v4.contains(src)),
+        IpAddr::V6(src) => /* mirror */,
+    };
+    if !src_ok { return None; }
+
+    let dst_ok = /* mirror destination */;
+    if !dst_ok { return None; }
+
+    rule.hit_counter.add(packet_len);
+    Some(PolicyEvaluationResult { action: rule.action, policy_id: rule.policy_id })
+}
+```
+
+All book lookups are dense-index Vec accesses. No `Arc` deref.
+
+`userspace-dp/src/afxdp/mod.rs`:
+- Pass `&snapshot.address_books` to
+  `parse_policy_state_with_counters`.
+
+`userspace-dp/src/afxdp/forwarding_build/mod.rs:309-310`:
+- Replace `rule.source_v4.prefix_count()` /
+  `rule.destination_v4.prefix_count()` with an aggregate over
+  `source_literal_v4` + indexed books. ~10 LOC.
+
+`userspace-dp/src/prefix_set.rs`:
+- Add `MatchNone` variant to both `PrefixSetV4` and `PrefixSetV6`.
+  `contains()` on `MatchNone` returns `false`. `prefix_count()`
+  returns 0. `is_match_none(&self) -> bool` helper.
+- Add `is_match_any(&self) -> bool` helper.
+- Add new constructor `from_v3_literals(prefixes)` that returns
+  `MatchNone` on empty input (distinguishes "no criteria specified"
+  from "match all"). The legacy `from_prefixes` factory keeps the
+  empty=MatchAny convention (for the non-v3-shaped fallback path).
+- This eliminates the book-only fail-open path: a v3-shaped rule
+  citing only books has `source_literal_v4 = MatchNone`, so
+  `source_literal_v4.contains(src) = false`, and the match-union
+  correctly falls through to the book walk.
+
+### 3.4 Cross-version compatibility (rolling upgrade)
+
+Because the protocol version stays at 3, this is purely a
+field-presence story:
+
+| Combo                          | source_addresses | source_book_ids | source_literals | Behaviour |
+|--------------------------------|------------------|-----------------|-----------------|-----------|
+| Old Go (no new fields) → Old Rust | full expansion | absent          | absent          | unchanged |
+| Old Go → New Rust              | full expansion   | absent          | absent          | new Rust falls through: `source_literal_v4` built from `source_addresses` (since `source_literals` is empty). |
+| New Go → Old Rust              | full expansion   | ignored         | ignored         | old Rust uses `source_addresses` (unchanged). |
+| New Go → New Rust              | (ignored at parse) | dense table | inline literals | full dedup win. |
+
+Key invariant: **`source_literals` takes precedence over
+`source_addresses` IFF `source_literals` is non-empty on the rule
+(or `source_book_ids` is non-empty)**. If a rule has no books cited
+AND no inline literals, the rule has nothing to match — back-compat
+demands we fall through to `source_addresses` as before.
+
+The exact predicate: a rule is "v3-shaped" iff
+`!source_literals.is_empty() || !source_book_ids.is_empty()`.
+For v3-shaped rules, new-Rust ignores `source_addresses`. For
+non-v3-shaped rules, new-Rust falls through to `source_addresses`
+(legacy parse). Same logic for destination, independently.
+
+Old Go produces NO v3-shaped rules; new Go produces all v3-shaped
+rules. There's no mixed-shape rule on a single side from a single
+emitter.
+
+### 3.5 Shim-removal followup (out of scope)
+
+Follow-up PR (≥1 release later):
+1. Drop Go-side `SourceAddresses` / `DestinationAddresses`.
+2. Drop Rust-side fallback path.
+3. Bump JSON `version` to 4 (with the corresponding RX-side check
+   updated).
+
+## 4. HA snapshot sync portability
+
+`pkg/cluster/configsync` ships the same `ConfigSnapshot` JSON
+between HA peers. Adding new JSON fields with `omitempty` / serde
+defaults is HA-safe — the established pattern.
+
+**Determinism gates** (see §5 for the algorithm):
+
+- `cfg.Security.AddressBook.Addresses` and `.AddressSets` keys are
+  iterated in lexicographic sorted order before any ID assignment.
+- Collision-resolution loop is FULLY deterministic given a sorted
+  input order.
+- Unit test `TestAddressBookIDDeterministicAcrossMapOrder` constructs
+  the same config with map keys inserted in 5 different orders
+  and asserts the emitted `AddressBookSnapshot.id` array is
+  IDENTICAL across all 5 builds.
+
+**No new lock acquisitions on the hot path.** `PolicyState::books`
+is `Vec<BookEntry>`. `PolicyState` is owned by `ForwardingState`,
+published via the existing `ArcSwap` discipline at
+`userspace-dp/src/afxdp/worker/mod.rs:976` (`load_arc_if_changed`).
+The packet worker pins `Arc<ForwardingState>` once at the top of
+each tick via `loop_body/mod.rs:58` (`shared_forwarding.load_full()`)
+and packet matching reads from the pinned `&forwarding` reference.
+Per-packet code never touches an atomic.
+
+## 5. Content-hash interning algorithm
+
+**Hash input** (with explicit framing to prevent v4/v6 cross-family
+collisions):
+
+```
+"V4" || u32_be(v4_count) || (for each v4 prefix:
+    u8(prefix_len) || u32_be(addr_bytes))
+"V6" || u32_be(v6_count) || (for each v6 prefix:
+    u8(prefix_len) || u128_be(addr_bytes))
+```
+
+v4 and v6 lists are sorted by `(prefix_len, addr_bytes)` before
+serialization for canonicalization. The literal "V4" / "V6" tags +
+the count prefixes prevent two distinct sets from canonicalizing to
+the same byte stream (e.g. a single v4 /24 and a single v6 ::/24
+would otherwise share the same raw `[24, ...]` if the addresses
+happen to share the prefix bytes).
+
+**Hash function**: FNV-1a 64-bit fold.
+
+**Pre-hash input ordering**: book NAMES are iterated in lexicographic
+sort order during bucket-by-content. This is the HA determinism
+gate. Multiple names hashing to the same content → all map to the
+same ID; the lexicographically smallest name becomes the diagnostic
+`name` field on the wire.
+
+**ID derivation**: `id = low_32(hash)` (no high-bit reservation —
+we'd lose a bit of headroom without need). Special case: if
+`id == 0`, set `id = 1`. ID 0 is reserved as "unused" by convention.
+
+**Collision recovery**: when two DISTINCT content-hashes collide on
+the low-32 bits:
+- Probe sequence: `id_probe = ((hash >> 32) ^ low_32(hash)) + probe_count`,
+  where `probe_count` starts at 1 and increments until a free ID is
+  found. Wraps at u32. If `id_probe == 0`, set to 1.
+- The probe sequence is deterministic given (hash, probe_count)
+  AND a deterministic visit order across distinct unique content-
+  hashes. Visit order is:
+  1. **Bucket by canonical CIDR-set bytes**, NOT by full 64-bit
+     hash. Multiple book NAMES sharing the same canonical bytes
+     all map to the same bucket. (Codex r6 refinement: this
+     handles the theoretically-possible 64-bit hash collision
+     where two distinct canonical-byte streams produce the same
+     FNV-1a 64-bit output. Buckets are keyed on canonical bytes
+     so distinct content always lives in distinct buckets.)
+  2. Compute full 64-bit FNV-1a hash on each bucket's canonical
+     bytes; store as bucket metadata.
+  3. Sort buckets by `(hash64, canonical_bytes)` ascending before
+     entering the linear-probe ID-assignment loop. The
+     `canonical_bytes` tie-break disambiguates the impossible-in-
+     practice case where two distinct contents share a 64-bit
+     hash; even if it ever happens, ID assignment is deterministic
+     because byte-comparison is total.
+  4. Within a bucket: the diagnostic `name` is the
+     lexicographically smallest of the names that hashed to it.
+- Hard termination: if probe_count > 256, hard-fail the snapshot.
+  At 1M books in a 2^32 ID space, expected collision pairs ~116;
+  probe length per affected book is tiny (load factor ≈ 1/4096),
+  so cap of 256 is generous and effectively never trips.
+
+**Collision math (32-bit hash, full birthday formula)**:
+- 10K books: P(any collision) = 1 − exp(−1e8 / 2^33) ≈ 1.16%.
+- 100K books: P ≈ 1 − exp(−1e10 / 2^33) ≈ 68.8%.
+- 1M books: effectively certain (≈ expected 116 collision pairs).
+
+Probe scheme: at load factor << 1 (1M entries in 2^32 space ≈ 1
+in 4096), clustering is not an issue. Linear-probe-from-hash
+walks an average of < 2 slots even at 1M scale. Probe cap of 256
+is generous.
+
+Updated v3 from earlier-version's understated math.
+
+**Content-only identity**: two address-book DECLARATIONS with the
+same canonical CIDR content share the same ID. The wire
+`address_books` array contains ONE row per unique content; the row's
+`name` field is the lexicographically smallest declaring name (for
+diagnostics).
+
+**Why content-hashing**: two configuration commits that re-declare
+the same address book (rollback, equivalent rename) produce the
+same wire ID. Enables #1607 (per-book Arc reuse across snapshots)
+without code change to the Rust side.
+
+## 6. Memory footprint — informational only, NOT a PR gate
+
+The acceptance gate for this PR is wire-correctness + dedup-by-
+construction. Memory numbers are measured but not gated.
+
+Math against the existing `PrefixSetV4::Trie` (24-byte node +
+jemalloc 32-byte bin):
+
+- 100 random v4 /32 → ~2.6K nodes → ~83 KB per book.
+- 100 random v6 /64 → ~5.6K nodes → ~180 KB per book.
+- 1K random v4 /32 → ~24K nodes → ~770 KB per book.
+- 1K random v6 /64 → ~56K nodes → ~1.79 MB per book.
+- 10K books × 100 CIDRs (v4+v6) → ~2.6 GB.
+- 10K books × 1K CIDRs → ~25 GB.
+
+The issue's stated 200 MB gate at 10K × 1K is structurally
+unachievable with the current binary trie. We comment on the issue
+explaining the rescoping when the PR lands.
+
+The memory win is **structural deduplication**: at 100K rules each
+citing on average 3 books × 10K total books, the prefix tables now
+scale as `O(book_count × per_book_size)` not
+`O(rule_count × per_rule_avg_size)`. That's a 10×-100× memory
+reduction depending on book reuse ratio.
+
+Informational measurements (in `userspace-dp/tests/policy_scale.rs`,
+gated `#[ignore]`):
+
+- 10K books × 10 CIDRs × 100K rules → expect ΔVmRSS ≤ 500 MB.
+- 10K books × 100 CIDRs × 100K rules → expect ΔVmRSS ≤ 3 GB.
+- 10K books × 1K CIDRs × 100K rules → expect ΔVmRSS ≤ 30 GB
+  (vs. 255 GB without dedup).
+
+These run on-demand, not in CI.
+
+## 7. Detailed change list
+
+### Go (`pkg/dataplane/userspace/`)
+
+1. `protocol.go` (+40 LOC):
+   - Add `AddressBookSnapshot`.
+   - Add four new fields to `PolicyRuleSnapshot`.
+   - Add `AddressBooks` to the wire snapshot envelope.
+   - **Do NOT bump `ProtocolVersion`.**
+
+2. `policies.go` (+150 LOC):
+   - `buildAddressBookTable(cfg) ([]AddressBookSnapshot,
+     map[string]uint32)`.
+   - `classifyUserspacePolicyAddresses(cfg, nameToID, addrs)`.
+   - Sort + dedup per-rule `bookIDs` before emit.
+   - Updated `buildPolicySnapshotsWithSchedulerState` to use the
+     new classifier.
+
+3. `manager.go` / `builder.go` (snapshot assembler, +30 LOC):
+   - Call `buildAddressBookTable`.
+   - Populate new wire fields.
+
+4. `policies_test.go` (+300 LOC):
+   - `TestAddressBookIDStability` — same config emits same IDs.
+   - `TestAddressBookIDDeterministicAcrossMapOrder` — 5 different
+     map-key insertion orders → identical wire output.
+   - `TestAddressBookContentDedup` — two names, same content → one
+     row in `address_books`, same ID, diag-name is the
+     lexicographically smaller.
+   - `TestAddressBookCollisionRecovery` — synthetic adversarial.
+   - `TestPolicyBuildEmitsBookIDsAndLiterals`.
+   - `TestPolicyBuildLegacyFieldStillExpanded` — old-Rust
+     back-compat channel still populated.
+
+### Rust (`userspace-dp/src/`)
+
+1. `protocol/security.rs` (+30 LOC):
+   - `AddressBookSnapshot`.
+   - Four new fields on `PolicyRuleSnapshot`.
+
+2. `protocol/snapshot.rs` (+3 LOC):
+   - `address_books` on `ConfigSnapshot`.
+
+3. `prefix_set.rs` (+50 LOC):
+   - Add `MatchNone` variant to both `PrefixSetV4` and `PrefixSetV6`.
+   - Add `is_match_any(&self) -> bool` and
+     `is_match_none(&self) -> bool` on both types.
+   - `contains()` on `MatchNone` returns `false`.
+   - New constructor `from_v3_literals(prefixes: Vec<PrefixV*>)`:
+     - Empty → `MatchNone` (v3 semantic).
+     - `/0` present → `MatchAny`.
+     - Else `Linear` / `Trie` as today.
+   - Existing `from_prefixes(empty) -> MatchAny` stays intact for
+     the non-v3 legacy fallback path.
+   - `prefix_count()` on `MatchNone` returns 0.
+
+4. `policy.rs` (~+200 LOC, ~−15 LOC):
+   - `BookEntry`.
+   - `PolicyState::books: Vec<BookEntry>` +
+     `book_id_to_idx: FxHashMap<u32, u32>`.
+   - `PolicyRule` renamed fields + new SmallVec fields +
+     precomputed match-any bools.
+   - `parse_policy_state_with_counters` becomes **fallible**
+     (returns `Result<PolicyState, SnapshotIntegrityError>`). New
+     `address_books` parameter; per-rule literal-field selection
+     via "v3-shaped predicate"; book index resolution with
+     duplicate/unknown/zero-ID hard-fail handling per §3.3.
+   - Fallibility propagation scope (Codex r5 F-r5-2):
+     - `build_forwarding_state` /
+       `build_forwarding_state_with_policy_counters` /
+       `build_forwarding_state_with_policy_counters_and_previous`
+       in `forwarding_build/mod.rs` all become fallible (return
+       `Result<ForwardingState, SnapshotIntegrityError>`).
+     - `Coordinator::refresh_runtime_snapshot` in
+       `afxdp/coordinator/mod.rs:454` checks the Result BEFORE
+       mutating neighbor manager keys, validation, and policy
+       counters. On error, propagates back up; no partial state.
+     - `reconcile/snapshot.rs:apply` likewise validates the
+       Result BEFORE applying validation and reconciling counters.
+     - `snapshot.rs::apply` in `server/handlers/`: runs a
+       **preflight build**: tries `build_forwarding_state(...)`
+       FIRST, in a side-effect-free path, before mutating
+       `guard.status.last_snapshot_generation`,
+       `guard.status.last_fib_generation`,
+       `guard.status.last_snapshot_at`, `guard.status.capabilities`,
+       or `guard.status.bindings`. On preflight failure, return
+       `ControlResponse { ok: false, error: "snapshot integrity
+       error: ..." }`. The guard's existing snapshot stays.
+   - `try_match_rule` new dense-index walk; consumes the
+     `state: &PolicyState` reference so books are addressable.
+
+5. `policy_tests.rs` (+250 LOC):
+   - `test_book_table_dedup_by_index`.
+   - `test_match_book_union_with_literal`.
+   - `test_match_any_short_circuit`.
+   - `test_v3_shaped_predicate_ignores_legacy_field`.
+   - `test_non_v3_shaped_falls_through_to_legacy_field`.
+   - `test_unknown_book_id_hard_fails_snapshot` (changed from
+     skip-not-fatal per Codex r3 F2; matches Junos
+     compiler-rejects-unresolved semantics).
+   - `test_duplicate_address_book_id_hard_fails_snapshot`.
+   - `test_book_id_zero_hard_fails_snapshot`.
+   - `test_per_rule_duplicate_book_ids_are_deduped`.
+   - `test_book_only_rule_does_not_fail_open` — rule with
+     non-empty `source_book_ids` + empty `source_literals` parses
+     `source_literal_v4 = MatchNone` (via the new
+     `from_v3_literals` constructor). Match path then ONLY matches
+     IPs covered by the cited books — IPs outside the books do
+     NOT match. Without `MatchNone`, the empty-literal would have
+     been `MatchAny` (legacy `from_prefixes` semantics) and the
+     rule would have matched ALL traffic.
+   - `test_pure_any_rule_with_address_books_present` — a rule with
+     ALL empty new fields (book_ids + literals) when
+     `address_books.is_empty()` is false (some OTHER rule cites
+     books): is correctly treated as non-v3-shaped and falls
+     through to `source_addresses`. Without the per-rule
+     predicate, this would fail open.
+   - `test_v4_v6_canonical_framing_no_cross_family_collision` —
+     constructs two distinct books (one v4-only, one v6-only)
+     whose raw bytes would collide WITHOUT the V4/V6 framing
+     prefix; assert their IDs differ.
+   - `test_v4_only_book_does_not_match_v6_traffic` — a v4-only
+     book has `entry.v6 = MatchNone`; a rule citing only this book
+     must NOT match v6 packets. Closes the family-incomplete-book
+     fail-open path Codex r4 identified.
+   - `test_v6_only_book_does_not_match_v4_traffic` — symmetric.
+   - `test_v3_shaped_any_token_matches_all_v4_and_v6` — closes
+     Codex r5 F-r5-1: a v3-shaped rule with
+     `source_literals=["any"]` must match all v4 AND all v6
+     traffic, not fail closed via MatchNone.
+   - `test_v3_shaped_any4_token_matches_all_v4_only` (future-
+     proof; can be `#[ignore]` if Junos syntax doesn't support).
+   - `test_snapshot_preflight_rejects_unknown_book_id` — preflight
+     `build_forwarding_state` on a snapshot with unknown book ID
+     returns Err; the snapshot handler does NOT mutate
+     `guard.status.last_snapshot_generation` etc.
+   - `test_snapshot_preflight_rejects_duplicate_book_id` —
+     similar.
+   - Plus signature updates for all existing tests that call
+     `parse_policy_state_with_counters` / `parse_policy_state`.
+
+6. `afxdp/mod.rs` (+5 LOC):
+   - Pass `&snapshot.address_books` to
+     `parse_policy_state_with_counters`.
+
+7. `afxdp/forwarding_build/mod.rs` (~+40 LOC):
+   - Make `build_forwarding_state*` family fallible
+     (Result<ForwardingState, SnapshotIntegrityError>).
+   - Replace `rule.source_v4.prefix_count()` at line 309-310 with
+     aggregate across `source_literal_v4` + indexed books.
+   - Add `SnapshotIntegrityError` type (or reuse an existing
+     error type; check `src/error.rs` if it exists).
+
+8. `afxdp/coordinator/mod.rs:454-485` (+20 LOC):
+   - `refresh_runtime_snapshot` propagates the fallible
+     forwarding-state build. On error, returns/logs without
+     mutating coordinator state.
+
+9. `afxdp/coordinator/reconcile/snapshot.rs` (+15 LOC):
+   - `apply` does a preflight forwarding-state build before
+     side-effecting mutations.
+
+10. `server/handlers/snapshot.rs` (+25 LOC):
+    - Preflight `build_forwarding_state(...)` BEFORE the existing
+      `guard.status.*` mutations at lines 37-41.
+    - On preflight failure, return `ControlResponse { ok: false,
+      error: "snapshot integrity error: ..." }` without touching
+      the guard.
+
+8. `Cargo.toml`:
+   - Add `smallvec = "1.13"` (verify not already present).
+
+### Docs
+
+1. `docs/userspace-jit-design.md` (Phase 3 row): note that wire
+   format for book sharing landed in #1606; trie compaction
+   (DIR-24-8) deferred to #1608.
+
+2. `docs/per-rule-policy-memory.md` (new, ~80 LOC): memory math,
+   content-hash ID scheme with sort-by-name gate, deduplication
+   test, deferred DIR-24-8 work.
+
+## 8. Test plan
+
+### Unit (Rust)
+
+- All existing 600+ policy tests pass after signature updates.
+- New tests above. 5× flake loop on each new test.
+
+### Unit (Go)
+
+- All existing `pkg/dataplane/userspace` tests pass.
+- New tests above. `TestAddressBookIDDeterministicAcrossMapOrder` is
+  the HA-correctness gate.
+
+### Synthetic memory smoke (informational, `#[ignore]`)
+
+As §6. Run on demand; not in CI.
+
+### Smoke (loss userspace cluster)
+
+`make cluster-deploy` (default `loss-userspace-cluster.env`) →
+`./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0` →
+
+Pass A (CoS off):
+- iperf3 to 172.16.80.200, -P 12 (push), 60s — 0 retrans.
+- iperf3 to 172.16.80.200, -P 12 -R (reverse), 60s — 0 retrans.
+- iperf3 to 2001:559:8585:80::200, -P 12, 60s.
+- iperf3 to 2001:559:8585:80::200, -P 12 -R, 60s.
+
+Pass B (CoS on, per-class ports 5201-5206):
+- All four directions × six classes.
+
+Gates: zero retrans, throughput within ±5% of master baseline.
+
+### HA failover
+
+`make test-failover` — must remain ≤ 60ms with no session loss.
+
+## 9. Rollback
+
+Pure code rollback is `git revert` clean — no schema migration.
+Because the protocol version is unchanged (still 3), old and new
+binaries can be mixed in either direction.
+
+## 10. Followups (out of scope)
+
+1. **Shim-removal PR** — bump version to 4, drop legacy
+   `source_addresses` / `destination_addresses` fields, drop
+   Rust-side fallback path. Ships ≥ 1 release after #1606.
+
+2. **DIR-24-8 / Patricia sparse LPM (#1608)** — replace the binary
+   trie. Pre-requisite for 1M-rule line-rate gate.
+
+3. **Per-book reuse across snapshots (#1607)** — keep
+   process-lifetime cache of `BookEntry` keyed on book ID for fast
+   apply at 10K-book scale.

--- a/docs/pr/1606-wire-protocol-address-book/reviewer-ids.md
+++ b/docs/pr/1606-wire-protocol-address-book/reviewer-ids.md
@@ -1,0 +1,42 @@
+# Reviewer task IDs for #1606
+
+Track every Codex and AGY task per round so a context-loss resume can
+fetch results by ID rather than re-dispatch.
+
+## Round 1 — plan review
+
+- **Codex**: `task-mpoila11-z7cr9w` (session lost)
+- **Codex (retry, --wait mode)**: ran inline; PLAN-KILL — flagged HA determinism, shim contradiction, §7 rosy math, forwarding_build rename blast radius, Arc-vs-flat-index, ArcSwap wording.
+- **AGY**:   `adversarial-review-mpoilt8i-qtngsz` (PLAN-NEEDS-MAJOR — convergent with Codex, plus flat-index recommendation and 70 GB OOM warning).
+- **Claude SMR**: `claude-smr-plan-r1.md` — PLAN-NEEDS-MAJOR.
+
+## Round 2 — plan review
+
+- **Codex (--wait mode)**: ran inline; PLAN-NEEDS-MAJOR — flagged wrong protocol version baseline (repo is at v3, not v1), inverted parse-condition in §7, content-dedup vs name-dedup clash, u16+fallback fail-open risk, weak collision math.
+- **AGY**: `adversarial-review-mpok2srd-6xmmqo` — ran out of context implementing the plan instead of reviewing it. Aborted at timeout. Partial implementation stashed.
+- **Claude SMR**: `claude-smr-plan-r2.md` — PLAN-NEEDS-MAJOR (convergent with Codex r2).
+
+## Round 3 — plan review (plan v3 → v4)
+
+- **Codex (--wait mode)**: ran inline; PLAN-NEEDS-MAJOR. Findings: F1 fail-open via empty PrefixSet→MatchAny, F2 unknown book ID should hard-fail not log+skip, F3 collision math wrong (100K = 68.8% not 0.116%), F4 hash input needs family/count framing.
+- **AGY**: `adversarial-review-mpokesx0-ttdz0g` — reviewed against the stashed code from r2 (partial impl); confirmed F1 fail-open path independently.
+- **Claude SMR**: `claude-smr-plan-r3.md` — PLAN-NEEDS-MAJOR on v3.
+
+## Round 4 — plan review (plan v4 → v5)
+
+- **Codex (--wait mode)**: ran inline; PLAN-NEEDS-MAJOR. F-r4-1 book-only rule still fail-opens via PrefixSet::from_prefixes(empty)=MatchAny. F-r4-2 family-incomplete book also fail-opens.
+- **AGY**: not run.
+- **Claude SMR**: missed the bug in r4; corrected in r5 doc.
+
+## Round 5 — plan review (plan v5 → v6)
+
+- **Codex (--wait mode)**: ran inline; PLAN-NEEDS-MAJOR. F-r5-1 v3-shaped "any" → MatchNone (fail-closed regression). F-r5-2 fallibility propagation scope too narrow (preflight build needed before guard mutations).
+- **AGY**: `adversarial-review-mpokuj73-5gg2kn` — PLAN-READY with two MINOR refinements (front-gate validation, 64-bit-hash collision-tie-break).
+- **Claude SMR**: `claude-smr-plan-r5.md` — PLAN-NEEDS-MAJOR on v5 (convergent with Codex).
+
+## Round 6 — plan review (plan v6 → v7)
+
+- **Codex (--wait mode)**: ran inline; PLAN-NEEDS-MINOR. Two refinements: (1) bucket by canonical-bytes with (hash64, canonical_bytes) tie-break; (2) normalize "any" in address-book values to (0.0.0.0/0, ::/0) at Go buildAddressBookTable level.
+- **AGY**: not run (rate limiting risk + Codex sufficient for minor refinement round).
+- **Claude SMR**: `claude-smr-plan-r6.md` — PLAN-NEEDS-MINOR on v6 (convergent with Codex), PLAN-READY on v7.
+- **Claude SMR**: see `claude-smr-plan-r1.md` (this run)

--- a/docs/pr/1606-wire-protocol-address-book/reviewer-ids.md
+++ b/docs/pr/1606-wire-protocol-address-book/reviewer-ids.md
@@ -39,4 +39,22 @@ fetch results by ID rather than re-dispatch.
 - **Codex (--wait mode)**: ran inline; PLAN-NEEDS-MINOR. Two refinements: (1) bucket by canonical-bytes with (hash64, canonical_bytes) tie-break; (2) normalize "any" in address-book values to (0.0.0.0/0, ::/0) at Go buildAddressBookTable level.
 - **AGY**: not run (rate limiting risk + Codex sufficient for minor refinement round).
 - **Claude SMR**: `claude-smr-plan-r6.md` — PLAN-NEEDS-MINOR on v6 (convergent with Codex), PLAN-READY on v7.
-- **Claude SMR**: see `claude-smr-plan-r1.md` (this run)
+
+## Code review round 1 (PR #1610, SHA 0018eb42e)
+
+- **Codex**: ran inline; NEEDS-MAJOR. F1 bare-IP drop, F2 counter-store leak in refresh preflight, F3 CIDR multiset dedup. All fixed in commit 77e72f41f.
+- **Copilot**: formal review on 0018eb42e — 4 inline comments (C1 bare IPs, C2 depth-5 cap, C3 refresh_runtime_snapshot returns (), C4 guard.snapshot before reconcile).
+- **AGY**: not run at r1.
+- **Claude SMR**: `claude-smr-code-r1.md`.
+
+## Code review round 2 (PR #1610, SHA 77e72f41f)
+
+- **Codex (--wait)**: MERGE-READY at SHA 77e72f41f.
+- **AGY**: `adversarial-review-mpom8200-oa2t7m` — NEEDS-MAJOR. Findings 4.1 (handler mutates guard.status before validation), 4.2 (reconcile tears workers before validation), 4.3 counter leakage. All fixed in commit 68138b122.
+
+## Code review round 3 (PR #1610, SHA 8edb77c5b277 — current HEAD)
+
+- **Codex**: `task-mponbft1-cxjpa4` — re-dispatched at current HEAD after post-r2 commits (68138b122 + 8edb77c5b) landed.
+- **AGY**: `adversarial-review-mponboy5-seies9` — re-dispatched at current HEAD.
+- **Copilot**: re-trigger posted; awaiting formal copilot-pull-request-reviewer review at current HEAD (NOT swe-agent).
+- **Claude SMR**: `claude-smr-code-r2.md` — forthcoming.

--- a/docs/userspace-jit-design.md
+++ b/docs/userspace-jit-design.md
@@ -507,15 +507,35 @@ config apply time.
 **Expected gain**: O(1)-O(log N) policy evaluation vs O(N) linear scan.
 Significant for rulesets with 20+ rules per zone-pair.
 
-### Phase 3: Address-book trie compilation — NOT STARTED
+### Phase 3: Address-book trie compilation — WIRE FORMAT LANDED (#1606), TRIE COMPACTION DEFERRED TO #1608
 
-**Scope**: Replace linear CIDR matching with precomputed tries.
+**Wire format (done in #1606)**: ConfigSnapshot now carries a top-
+level `address_books: Vec<AddressBookSnapshot>` table. Multiple
+named books with identical canonical CIDR content share one row
+and one u32 ID (content-hashed). Each `PolicyRuleSnapshot` cites
+books by ID via `source_book_ids` / `destination_book_ids` and
+free-form CIDRs via `source_literals` / `destination_literals`.
+The legacy `source_addresses` field stays on the wire for one-
+release rolling-upgrade compatibility with old Rust binaries.
 
-1. At config compile time, build a compact IPv4/IPv6 trie for each
-   address-book entry
-2. Store tries in the ConfigSnapshot
-3. In Rust, deserialize into a flat array trie (cache-friendly)
-4. Replace `match_address()` linear scan with trie lookup
+The Rust side stores books in a flat dense `Vec<BookEntry>` on
+`PolicyState`; rules carry `SmallVec<[u32; 8]>` indices. No
+`Arc<BookEntry>` per rule; the table lifetime is tied to the
+ArcSwap-published `ForwardingState` snapshot.
+
+This delivers the **structural memory deduplication** prerequisite
+for the 1M-policy scale: prefix-table memory is now
+`O(book_count × per_book_size)` not
+`O(rule_count × avg_books_per_rule)`. A 10K-book × 100K-rule
+config with 3 books per rule averages 30× fewer prefix-set
+materializations than today.
+
+**Trie compaction (deferred to #1608)**: the per-book `PrefixSetV4`/
+`PrefixSetV6` is still the uncompressed binary trie introduced in
+#923. At 10K books × 1K CIDRs each, that's ~25 GB of trie node
+memory — usable but not optimal. #1608 will replace the binary
+trie with a DIR-24-8 or Patricia compressed structure to bring
+the per-book footprint down 10-100×.
 
 ### Phase 4: Cranelift JIT for flow rewrite functions — NOT STARTED
 

--- a/pkg/dataplane/userspace/address_book_test.go
+++ b/pkg/dataplane/userspace/address_book_test.go
@@ -1,0 +1,215 @@
+// #1606: tests for the wire-protocol address-book deduplication.
+// Covers ID stability, HA determinism across map insertion order,
+// content-dedup, collision recovery, the v3-shaped predicate, and
+// the "any" normalization at book-build time.
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func newBookCfg(addresses map[string]string) *config.Config {
+	addrs := make(map[string]*config.Address, len(addresses))
+	for name, value := range addresses {
+		addrs[name] = &config.Address{Name: name, Value: value}
+	}
+	return &config.Config{
+		Security: config.SecurityConfig{
+			AddressBook: &config.AddressBook{
+				Addresses:   addrs,
+				AddressSets: nil,
+			},
+		},
+	}
+}
+
+func TestAddressBookIDStability(t *testing.T) {
+	cfg := newBookCfg(map[string]string{
+		"alpha": "10.0.0.0/24",
+		"beta":  "192.168.0.0/16",
+	})
+	a, _ := buildAddressBookTable(cfg)
+	b, _ := buildAddressBookTable(cfg)
+	if len(a) != len(b) || len(a) != 2 {
+		t.Fatalf("expected 2 books in each build, got %d / %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].ID != b[i].ID {
+			t.Fatalf("book %d: id drifted across builds (%d vs %d)", i, a[i].ID, b[i].ID)
+		}
+	}
+}
+
+func TestAddressBookIDDeterministicAcrossMapOrder(t *testing.T) {
+	// Same content, 5 different insertion orders. All must produce
+	// identical wire output.
+	contents := map[string]string{
+		"book-a": "10.1.0.0/24",
+		"book-b": "10.2.0.0/24",
+		"book-c": "10.3.0.0/24",
+		"book-d": "10.4.0.0/24",
+		"book-e": "10.5.0.0/24",
+	}
+	// Run multiple times. Because Go map iteration is randomized,
+	// repeated builds should still produce identical output thanks
+	// to the sort-by-name gate.
+	var first []AddressBookSnapshot
+	for i := 0; i < 5; i++ {
+		cfg := newBookCfg(contents)
+		books, _ := buildAddressBookTable(cfg)
+		if i == 0 {
+			first = books
+			continue
+		}
+		if len(books) != len(first) {
+			t.Fatalf("iter %d: book count drifted (%d vs %d)", i, len(books), len(first))
+		}
+		for j := range books {
+			if books[j].ID != first[j].ID {
+				t.Fatalf("iter %d book %d: id drifted (%d vs %d)", i, j, books[j].ID, first[j].ID)
+			}
+			if books[j].Name != first[j].Name {
+				t.Fatalf("iter %d book %d: diag-name drifted (%q vs %q)", i, j, books[j].Name, first[j].Name)
+			}
+		}
+	}
+}
+
+func TestAddressBookContentDedup(t *testing.T) {
+	// Two books with identical content collapse to ONE row with ONE
+	// id. The diagnostic name is the lexicographically smallest.
+	cfg := newBookCfg(map[string]string{
+		"zeta":    "10.0.0.0/24",
+		"alpha":   "10.0.0.0/24",
+		"middle":  "10.0.0.0/24",
+		"unique":  "192.168.0.0/16",
+	})
+	books, nameToID := buildAddressBookTable(cfg)
+	if len(books) != 2 {
+		t.Fatalf("expected 2 unique rows (one for 10.0.0.0/24, one for 192.168), got %d", len(books))
+	}
+	if nameToID["alpha"] != nameToID["middle"] || nameToID["alpha"] != nameToID["zeta"] {
+		t.Fatalf("three names with same content should share an id")
+	}
+	// Diagnostic name for the shared content is "alpha" (smallest).
+	var sharedRow *AddressBookSnapshot
+	for i := range books {
+		if books[i].ID == nameToID["alpha"] {
+			sharedRow = &books[i]
+		}
+	}
+	if sharedRow == nil {
+		t.Fatalf("could not find shared content row")
+	}
+	if sharedRow.Name != "alpha" {
+		t.Fatalf("diag-name for shared row should be 'alpha' (smallest), got %q", sharedRow.Name)
+	}
+}
+
+func TestAddressBookContainingAnyNormalizesToZeroSlash(t *testing.T) {
+	cfg := newBookCfg(map[string]string{"world": "any"})
+	books, _ := buildAddressBookTable(cfg)
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	hasV4 := false
+	hasV6 := false
+	for _, p := range books[0].PrefixesV4 {
+		if p == "0.0.0.0/0" {
+			hasV4 = true
+		}
+	}
+	for _, p := range books[0].PrefixesV6 {
+		if p == "::/0" {
+			hasV6 = true
+		}
+	}
+	if !hasV4 || !hasV6 {
+		t.Fatalf("'any' should normalize to (0.0.0.0/0, ::/0); got v4=%v v6=%v", books[0].PrefixesV4, books[0].PrefixesV6)
+	}
+}
+
+func TestClassifyPolicyAddresses(t *testing.T) {
+	cfg := newBookCfg(map[string]string{
+		"corp-net": "10.0.0.0/8",
+		"vpn-net":  "192.168.0.0/16",
+	})
+	_, nameToID := buildAddressBookTable(cfg)
+	// Mix: 2 named books + 1 literal CIDR + 1 "any" + 1 unknown name.
+	bookIDs, literals := classifyPolicyAddresses(cfg, nameToID, []string{
+		"corp-net", "192.168.5.5/32", "any", "vpn-net", "unknown-book",
+	})
+	if len(bookIDs) != 2 {
+		t.Fatalf("expected 2 book IDs, got %d", len(bookIDs))
+	}
+	// bookIDs are sorted+deduped.
+	if !(bookIDs[0] < bookIDs[1]) {
+		t.Fatalf("bookIDs not sorted: %v", bookIDs)
+	}
+	// Literals include the explicit CIDR + "any" + the unknown
+	// name (treated as free-form literal).
+	wantLiterals := map[string]bool{
+		"192.168.5.5/32": true,
+		"any":            true,
+		"unknown-book":   true,
+	}
+	for _, lit := range literals {
+		if !wantLiterals[lit] {
+			t.Fatalf("unexpected literal %q in %v", lit, literals)
+		}
+	}
+	if len(literals) != 3 {
+		t.Fatalf("expected 3 literals, got %d (%v)", len(literals), literals)
+	}
+}
+
+func TestPolicyBuildEmitsBookIDsAndLiterals(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			AddressBook: &config.AddressBook{
+				Addresses: map[string]*config.Address{
+					"corp-net": {Name: "corp-net", Value: "10.0.0.0/8"},
+				},
+			},
+			Policies: []*config.ZonePairPolicies{
+				{
+					FromZone: "trust",
+					ToZone:   "untrust",
+					Policies: []*config.Policy{
+						{
+							Name: "test-rule",
+							Match: config.PolicyMatch{
+								SourceAddresses:      []string{"corp-net"},
+								DestinationAddresses: []string{"192.168.1.0/24"},
+							},
+							Action: config.PolicyPermit,
+						},
+					},
+				},
+			},
+		},
+	}
+	snaps := buildPolicySnapshots(cfg)
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(snaps))
+	}
+	if len(snaps[0].SourceBookIDs) != 1 {
+		t.Fatalf("expected 1 source book id, got %v", snaps[0].SourceBookIDs)
+	}
+	if len(snaps[0].SourceLiterals) != 0 {
+		t.Fatalf("source had a book ref, no literals expected, got %v", snaps[0].SourceLiterals)
+	}
+	if len(snaps[0].DestinationBookIDs) != 0 {
+		t.Fatalf("destination was a literal CIDR, no book ids expected, got %v", snaps[0].DestinationBookIDs)
+	}
+	if len(snaps[0].DestinationLiterals) != 1 || snaps[0].DestinationLiterals[0] != "192.168.1.0/24" {
+		t.Fatalf("expected destination literal=[192.168.1.0/24], got %v", snaps[0].DestinationLiterals)
+	}
+	// Legacy back-compat field MUST still be populated for
+	// old-Rust readers.
+	if len(snaps[0].SourceAddresses) == 0 {
+		t.Fatalf("legacy SourceAddresses must still be populated (full expansion)")
+	}
+}

--- a/pkg/dataplane/userspace/address_book_test.go
+++ b/pkg/dataplane/userspace/address_book_test.go
@@ -108,6 +108,61 @@ func TestAddressBookContentDedup(t *testing.T) {
 	}
 }
 
+func TestAddressBookContainingBareIPNormalizesToSlash32Or128(t *testing.T) {
+	// Junos `set security address-book global address host1 10.0.0.1`
+	// produces a value of "10.0.0.1" (bare IP, NOT CIDR). The wire
+	// row must normalize this to "10.0.0.1/32" so the Rust side
+	// sees a concrete CIDR. (Codex code-review F1.)
+	cfg := newBookCfg(map[string]string{
+		"host1": "10.0.0.1",
+		"host2": "2001:db8::1",
+	})
+	books, _ := buildAddressBookTable(cfg)
+	if len(books) != 2 {
+		t.Fatalf("expected 2 books, got %d", len(books))
+	}
+	for _, b := range books {
+		if b.Name == "host1" {
+			if len(b.PrefixesV4) != 1 || b.PrefixesV4[0] != "10.0.0.1/32" {
+				t.Fatalf("host1 bare IP should normalize to 10.0.0.1/32, got %v", b.PrefixesV4)
+			}
+		}
+		if b.Name == "host2" {
+			if len(b.PrefixesV6) != 1 || b.PrefixesV6[0] != "2001:db8::1/128" {
+				t.Fatalf("host2 bare IP should normalize to 2001:db8::1/128, got %v", b.PrefixesV6)
+			}
+		}
+	}
+}
+
+func TestAddressBookDedupsCIDRSetByContent(t *testing.T) {
+	// Two books with the SAME effective CIDR set but one has a
+	// duplicate member entry — after dedup they should share an ID.
+	// (Codex code-review F3.)
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			AddressBook: &config.AddressBook{
+				Addresses: map[string]*config.Address{
+					"plain": {Name: "plain", Value: "10.0.0.0/24"},
+				},
+				AddressSets: map[string]*config.AddressSet{
+					"dup-set": {
+						Name:      "dup-set",
+						Addresses: []string{"plain", "plain"},
+					},
+				},
+			},
+		},
+	}
+	books, nameToID := buildAddressBookTable(cfg)
+	if len(books) != 1 {
+		t.Fatalf("expected 1 deduped row, got %d (members: %+v)", len(books), books)
+	}
+	if nameToID["plain"] != nameToID["dup-set"] {
+		t.Fatalf("plain and dup-set should share id; got %d vs %d", nameToID["plain"], nameToID["dup-set"])
+	}
+}
+
 func TestAddressBookContainingAnyNormalizesToZeroSlash(t *testing.T) {
 	cfg := newBookCfg(map[string]string{"world": "any"})
 	books, _ := buildAddressBookTable(cfg)

--- a/pkg/dataplane/userspace/builder.go
+++ b/pkg/dataplane/userspace/builder.go
@@ -58,7 +58,11 @@ func buildSnapshotWithSchedulerState(cfg *config.Config, ucfg config.UserspaceCo
 		ClassOfService:     buildClassOfServiceSnapshot(cfg),
 		FlowExport:         buildFlowExportSnapshot(cfg),
 		MirrorConfigs:      buildMirrorConfigSnapshotsFailClosed(cfg, interfaces),
-		Config:             cfg,
+		AddressBooks: func() []AddressBookSnapshot {
+			books, _ := buildAddressBookTable(cfg)
+			return books
+		}(),
+		Config: cfg,
 		Summary: SnapshotSummary{
 			HostName:       cfg.System.HostName,
 			DataplaneType:  cfg.System.DataplaneType,

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -695,6 +695,11 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 	next.GeneratedAt = time.Now().UTC()
 	next.Config = cfg
 	next.Policies = buildPolicySnapshotsWithSchedulerState(cfg, activeCopy)
+	// #1606: refresh the address-book table alongside the policies
+	// so book IDs cited in the new policies always resolve on the
+	// dataplane side.
+	books, _ := buildAddressBookTable(cfg)
+	next.AddressBooks = books
 
 	publishSnap := next
 	publishSnap.Neighbors = filterPublishableNeighbors(next.Neighbors)

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -179,9 +179,14 @@ func buildAddressBookTable(cfg *config.Config) ([]AddressBookSnapshot, map[strin
 		v4, v6 := expandBookNameToCIDRs(cfg, name)
 		// Normalise "any" → 0.0.0.0/0 + ::/0 (Codex r6 refinement).
 		v4, v6 = normalizeAnyInCIDRs(v4, v6)
-		// Canonical sort within each family.
+		// Canonical sort + dedup within each family. Without
+		// dedup, two books that differ only by repeated members
+		// would canonicalize to different bytes and not share an
+		// ID (Codex code-review F3).
 		sortV4CIDRs(v4)
 		sortV6CIDRs(v6)
+		v4 = dedupSortedStrings(v4)
+		v6 = dedupSortedStrings(v6)
 		canon := canonicalizeAddressBookContent(v4, v6)
 		key := string(canon)
 		b, exists := contentToBucket[key]
@@ -263,6 +268,14 @@ func buildAddressBookTable(cfg *config.Config) ([]AddressBookSnapshot, map[strin
 // expandBookNameToCIDRs resolves a single address-book name
 // (Address or AddressSet, recursively) into its v4 + v6 CIDR
 // lists. Returns empty slices if name does not exist.
+//
+// Junos address-book values can be:
+//   - CIDR strings (10.0.0.0/24)
+//   - bare IPs (10.0.0.1, normalized to /32 or /128)
+//   - "any" → both 0.0.0.0/0 and ::/0
+//
+// All three forms are surfaced here as canonical CIDRs so the wire
+// row carries concrete prefixes.
 func expandBookNameToCIDRs(cfg *config.Config, name string) ([]string, []string) {
 	ab := cfg.Security.AddressBook
 	if ab == nil {
@@ -279,8 +292,19 @@ func expandBookNameToCIDRs(cfg *config.Config, name string) ([]string, []string)
 		}
 		if isV4CIDR(value) {
 			v4 = append(v4, value)
-		} else if isV6CIDR(value) {
+			continue
+		}
+		if isV6CIDR(value) {
 			v6 = append(v6, value)
+			continue
+		}
+		// Bare IP: normalize to /32 (v4) or /128 (v6).
+		if ip := net.ParseIP(value); ip != nil {
+			if ip.To4() != nil {
+				v4 = append(v4, ip.String()+"/32")
+			} else {
+				v6 = append(v6, ip.String()+"/128")
+			}
 		}
 	}
 	return v4, v6
@@ -383,6 +407,19 @@ func canonicalizeAddressBookContent(v4, v6 []string) []byte {
 		buf.Write(ipnet.IP.To16())
 	}
 	return buf.Bytes()
+}
+
+func dedupSortedStrings(s []string) []string {
+	if len(s) <= 1 {
+		return s
+	}
+	out := s[:1]
+	for i := 1; i < len(s); i++ {
+		if s[i] != out[len(out)-1] {
+			out = append(out, s[i])
+		}
+	}
+	return out
 }
 
 func isV4CIDR(s string) bool {

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -1,7 +1,13 @@
 package userspace
 
 import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
+	"hash/fnv"
+	"net"
+	"sort"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
@@ -15,6 +21,7 @@ func buildPolicySnapshotsWithSchedulerState(cfg *config.Config, activeState map[
 	if cfg == nil || (len(cfg.Security.Policies) == 0 && len(cfg.Security.GlobalPolicies) == 0) {
 		return nil
 	}
+	_, nameToID := buildAddressBookTable(cfg)
 	out := make([]PolicyRuleSnapshot, 0)
 	policySetID := uint32(0)
 	for _, zpp := range cfg.Security.Policies {
@@ -28,75 +35,375 @@ func buildPolicySnapshotsWithSchedulerState(cfg *config.Config, activeState map[
 				continue
 			}
 			policyID := policySetID*dataplane.MaxRulesPerPolicy + ruleIndex
-			sourceAddresses, ok := expandUserspacePolicyAddresses(cfg, pol.Match.SourceAddresses)
-			if !ok {
-				sourceAddresses = append([]string(nil), pol.Match.SourceAddresses...)
-			}
-			destinationAddresses, ok := expandUserspacePolicyAddresses(cfg, pol.Match.DestinationAddresses)
-			if !ok {
-				destinationAddresses = append([]string(nil), pol.Match.DestinationAddresses...)
-			}
-			applicationTerms, ok := expandUserspacePolicyApplications(cfg, pol.Match.Applications)
-			if !ok {
-				applicationTerms = nil
-			}
-			schedulerName := pol.SchedulerName
-			out = append(out, PolicyRuleSnapshot{
-				RuleID:               stablePolicyRuleID(zpp.FromZone, zpp.ToZone, pol.Name),
-				PolicyID:             policyID,
-				Name:                 pol.Name,
-				FromZone:             zpp.FromZone,
-				ToZone:               zpp.ToZone,
-				SchedulerName:        schedulerName,
-				Inactive:             policyRuleInactive(schedulerName, activeState),
-				SourceAddresses:      sourceAddresses,
-				DestinationAddresses: destinationAddresses,
-				Applications:         append([]string(nil), pol.Match.Applications...),
-				ApplicationTerms:     applicationTerms,
-				Action:               policyActionString(pol.Action),
-			})
+			snap := buildOneRuleSnapshot(cfg, nameToID, pol, zpp.FromZone, zpp.ToZone, policyID, activeState)
+			out = append(out, snap)
 			ruleIndex += userspacePolicyRuleExpansionCount(cfg, pol.Match.Applications)
 		}
 		policySetID++
 	}
-	// Global policies match traffic regardless of zone pair.
 	globalRuleIndex := uint32(0)
 	for _, pol := range cfg.Security.GlobalPolicies {
 		if pol == nil {
 			continue
 		}
 		policyID := policySetID*dataplane.MaxRulesPerPolicy + globalRuleIndex
-		sourceAddresses, ok := expandUserspacePolicyAddresses(cfg, pol.Match.SourceAddresses)
-		if !ok {
-			sourceAddresses = append([]string(nil), pol.Match.SourceAddresses...)
-		}
-		destinationAddresses, ok := expandUserspacePolicyAddresses(cfg, pol.Match.DestinationAddresses)
-		if !ok {
-			destinationAddresses = append([]string(nil), pol.Match.DestinationAddresses...)
-		}
-		applicationTerms, ok := expandUserspacePolicyApplications(cfg, pol.Match.Applications)
-		if !ok {
-			applicationTerms = nil
-		}
-		schedulerName := pol.SchedulerName
-		out = append(out, PolicyRuleSnapshot{
-			RuleID:               stablePolicyRuleID("junos-global", "junos-global", pol.Name),
-			PolicyID:             policyID,
-			Name:                 pol.Name,
-			FromZone:             "junos-global",
-			ToZone:               "junos-global",
-			SchedulerName:        schedulerName,
-			Inactive:             policyRuleInactive(schedulerName, activeState),
-			SourceAddresses:      sourceAddresses,
-			DestinationAddresses: destinationAddresses,
-			Applications:         append([]string(nil), pol.Match.Applications...),
-			ApplicationTerms:     applicationTerms,
-			Action:               policyActionString(pol.Action),
-		})
+		snap := buildOneRuleSnapshot(cfg, nameToID, pol, "junos-global", "junos-global", policyID, activeState)
+		out = append(out, snap)
 		globalRuleIndex += userspacePolicyRuleExpansionCount(cfg, pol.Match.Applications)
 	}
 	return out
 }
+
+func buildOneRuleSnapshot(
+	cfg *config.Config,
+	nameToID map[string]uint32,
+	pol *config.Policy,
+	fromZone, toZone string,
+	policyID uint32,
+	activeState map[string]bool,
+) PolicyRuleSnapshot {
+	// Legacy back-compat field: full expansion. Same as today's
+	// behaviour for old-Rust readers.
+	sourceAddresses, okSrc := expandUserspacePolicyAddresses(cfg, pol.Match.SourceAddresses)
+	if !okSrc {
+		sourceAddresses = append([]string(nil), pol.Match.SourceAddresses...)
+	}
+	destinationAddresses, okDst := expandUserspacePolicyAddresses(cfg, pol.Match.DestinationAddresses)
+	if !okDst {
+		destinationAddresses = append([]string(nil), pol.Match.DestinationAddresses...)
+	}
+	applicationTerms, ok := expandUserspacePolicyApplications(cfg, pol.Match.Applications)
+	if !ok {
+		applicationTerms = nil
+	}
+	// #1606 v3 fields: classify each address token as "named book
+	// reference" vs "free-form literal".
+	srcBookIDs, srcLiterals := classifyPolicyAddresses(cfg, nameToID, pol.Match.SourceAddresses)
+	dstBookIDs, dstLiterals := classifyPolicyAddresses(cfg, nameToID, pol.Match.DestinationAddresses)
+	schedulerName := pol.SchedulerName
+	return PolicyRuleSnapshot{
+		RuleID:               stablePolicyRuleID(fromZone, toZone, pol.Name),
+		PolicyID:             policyID,
+		Name:                 pol.Name,
+		FromZone:             fromZone,
+		ToZone:               toZone,
+		SchedulerName:        schedulerName,
+		Inactive:             policyRuleInactive(schedulerName, activeState),
+		SourceAddresses:      sourceAddresses,
+		DestinationAddresses: destinationAddresses,
+		SourceBookIDs:        srcBookIDs,
+		DestinationBookIDs:   dstBookIDs,
+		SourceLiterals:       srcLiterals,
+		DestinationLiterals:  dstLiterals,
+		Applications:         append([]string(nil), pol.Match.Applications...),
+		ApplicationTerms:     applicationTerms,
+		Action:               policyActionString(pol.Action),
+	}
+}
+
+// classifyPolicyAddresses splits the policy's address-token list
+// into (book IDs, free-form CIDR literals). #1606. The returned
+// bookIDs are sorted + deduped.
+func classifyPolicyAddresses(cfg *config.Config, nameToID map[string]uint32, addrs []string) ([]uint32, []string) {
+	if len(addrs) == 0 {
+		return nil, nil
+	}
+	bookSet := make(map[uint32]struct{}, len(addrs))
+	literals := make([]string, 0, len(addrs))
+	seen := make(map[string]struct{}, len(addrs))
+	for _, tok := range addrs {
+		if tok == "" {
+			continue
+		}
+		if id, ok := nameToID[tok]; ok {
+			bookSet[id] = struct{}{}
+			continue
+		}
+		// Not a known book name → treat as a free-form literal.
+		// Includes "any", "any4", "any6", or a CIDR/IP literal.
+		if _, dup := seen[tok]; dup {
+			continue
+		}
+		seen[tok] = struct{}{}
+		literals = append(literals, tok)
+	}
+	if len(bookSet) == 0 {
+		return nil, literals
+	}
+	bookIDs := make([]uint32, 0, len(bookSet))
+	for id := range bookSet {
+		bookIDs = append(bookIDs, id)
+	}
+	sort.Slice(bookIDs, func(i, j int) bool { return bookIDs[i] < bookIDs[j] })
+	return bookIDs, literals
+}
+
+// buildAddressBookTable builds the deduplicated #1606 address-book
+// table for inclusion on the wire ConfigSnapshot. Returns the
+// table + a map from each declared address-book name (Addresses
+// and AddressSets) to its assigned u32 ID. Names that reference
+// the same canonical CIDR content share an ID.
+//
+// HA determinism: names are iterated in lexicographic sorted order
+// before any hashing/ID assignment. Content hashing buckets by
+// canonical bytes (not by hash), and the bucket sort key is
+// (hash64, canonical_bytes) so collision-resolution is fully
+// deterministic across HA peers.
+func buildAddressBookTable(cfg *config.Config) ([]AddressBookSnapshot, map[string]uint32) {
+	if cfg == nil || cfg.Security.AddressBook == nil {
+		return nil, nil
+	}
+	ab := cfg.Security.AddressBook
+
+	// Collect all unique names (Addresses + AddressSets) and sort.
+	allNames := make([]string, 0, len(ab.Addresses)+len(ab.AddressSets))
+	for name := range ab.Addresses {
+		allNames = append(allNames, name)
+	}
+	for name := range ab.AddressSets {
+		if _, dup := ab.Addresses[name]; !dup {
+			allNames = append(allNames, name)
+		}
+	}
+	sort.Strings(allNames)
+
+	type bucket struct {
+		canonical []byte
+		hash64    uint64
+		names     []string // declaring names in this bucket, sorted
+		v4        []string
+		v6        []string
+	}
+	contentToBucket := make(map[string]*bucket)
+	for _, name := range allNames {
+		v4, v6 := expandBookNameToCIDRs(cfg, name)
+		// Normalise "any" → 0.0.0.0/0 + ::/0 (Codex r6 refinement).
+		v4, v6 = normalizeAnyInCIDRs(v4, v6)
+		// Canonical sort within each family.
+		sortV4CIDRs(v4)
+		sortV6CIDRs(v6)
+		canon := canonicalizeAddressBookContent(v4, v6)
+		key := string(canon)
+		b, exists := contentToBucket[key]
+		if !exists {
+			h := fnv.New64a()
+			h.Write(canon)
+			b = &bucket{canonical: canon, hash64: h.Sum64(), v4: v4, v6: v6}
+			contentToBucket[key] = b
+		}
+		b.names = append(b.names, name) // already in sorted-name order
+	}
+
+	// Sort buckets by (hash64, canonical_bytes) for deterministic
+	// ID assignment.
+	buckets := make([]*bucket, 0, len(contentToBucket))
+	for _, b := range contentToBucket {
+		buckets = append(buckets, b)
+	}
+	sort.Slice(buckets, func(i, j int) bool {
+		if buckets[i].hash64 != buckets[j].hash64 {
+			return buckets[i].hash64 < buckets[j].hash64
+		}
+		return bytes.Compare(buckets[i].canonical, buckets[j].canonical) < 0
+	})
+
+	// Assign u32 IDs via deterministic linear probe. ID 0 is
+	// reserved.
+	used := make(map[uint32]struct{})
+	out := make([]AddressBookSnapshot, 0, len(buckets))
+	nameToID := make(map[string]uint32)
+	for _, b := range buckets {
+		id := uint32(b.hash64 & 0xFFFFFFFF)
+		if id == 0 {
+			id = 1
+		}
+		if _, dup := used[id]; dup {
+			// Linear probe (deterministic given bucket sort).
+			folded := uint32(b.hash64 ^ (b.hash64 >> 32))
+			probe := uint32(1)
+			for {
+				cand := folded + probe
+				if cand == 0 {
+					cand = 1
+				}
+				if _, dup := used[cand]; !dup {
+					id = cand
+					break
+				}
+				probe++
+				if probe > 256 {
+					// Hard-fail by panic — would indicate
+					// astronomically-unlikely 256 simultaneous
+					// collisions in a 2^32 ID space.
+					panic(fmt.Sprintf(
+						"address-book content hash collision could not be resolved within 256 probes (bucket count = %d)",
+						len(buckets)))
+				}
+			}
+		}
+		used[id] = struct{}{}
+		// Diagnostic name: smallest in this bucket.
+		diagName := ""
+		if len(b.names) > 0 {
+			diagName = b.names[0]
+		}
+		out = append(out, AddressBookSnapshot{
+			ID:         id,
+			Name:       diagName,
+			PrefixesV4: b.v4,
+			PrefixesV6: b.v6,
+		})
+		for _, n := range b.names {
+			nameToID[n] = id
+		}
+	}
+	return out, nameToID
+}
+
+// expandBookNameToCIDRs resolves a single address-book name
+// (Address or AddressSet, recursively) into its v4 + v6 CIDR
+// lists. Returns empty slices if name does not exist.
+func expandBookNameToCIDRs(cfg *config.Config, name string) ([]string, []string) {
+	ab := cfg.Security.AddressBook
+	if ab == nil {
+		return nil, nil
+	}
+	visited := make(map[string]bool)
+	values := expandBookNameRecursive(ab, name, visited, 0)
+	var v4, v6 []string
+	for _, value := range values {
+		if value == "" || value == "any" {
+			v4 = append(v4, "0.0.0.0/0")
+			v6 = append(v6, "::/0")
+			continue
+		}
+		if isV4CIDR(value) {
+			v4 = append(v4, value)
+		} else if isV6CIDR(value) {
+			v6 = append(v6, value)
+		}
+	}
+	return v4, v6
+}
+
+func expandBookNameRecursive(ab *config.AddressBook, name string, visited map[string]bool, depth int) []string {
+	if depth > 5 || visited[name] {
+		return nil
+	}
+	visited[name] = true
+	if addr, ok := ab.Addresses[name]; ok {
+		return []string{addr.Value}
+	}
+	if as, ok := ab.AddressSets[name]; ok {
+		var out []string
+		for _, member := range as.Addresses {
+			out = append(out, expandBookNameRecursive(ab, member, visited, depth+1)...)
+		}
+		for _, nested := range as.AddressSets {
+			out = append(out, expandBookNameRecursive(ab, nested, visited, depth+1)...)
+		}
+		return out
+	}
+	return nil
+}
+
+func normalizeAnyInCIDRs(v4, v6 []string) ([]string, []string) {
+	hasAny4 := false
+	hasAny6 := false
+	cleanV4 := v4[:0]
+	for _, s := range v4 {
+		if s == "0.0.0.0/0" {
+			hasAny4 = true
+		}
+		cleanV4 = append(cleanV4, s)
+	}
+	cleanV6 := v6[:0]
+	for _, s := range v6 {
+		if s == "::/0" {
+			hasAny6 = true
+		}
+		cleanV6 = append(cleanV6, s)
+	}
+	_ = hasAny4
+	_ = hasAny6
+	return cleanV4, cleanV6
+}
+
+func sortV4CIDRs(s []string) {
+	sort.Slice(s, func(i, j int) bool {
+		_, a, errA := net.ParseCIDR(s[i])
+		_, b, errB := net.ParseCIDR(s[j])
+		if errA != nil || errB != nil {
+			return s[i] < s[j]
+		}
+		if c := bytes.Compare(a.IP, b.IP); c != 0 {
+			return c < 0
+		}
+		ma, _ := a.Mask.Size()
+		mb, _ := b.Mask.Size()
+		return ma < mb
+	})
+}
+
+func sortV6CIDRs(s []string) {
+	sortV4CIDRs(s) // same logic; works on any net.IP
+}
+
+// canonicalizeAddressBookContent serializes the v4 + v6 CIDR
+// lists into a fixed byte stream with explicit family + count
+// framing (Codex r3 F4 fix).
+//
+// Layout:
+//   "V4" || u32_be(len(v4)) || (for each: u8(prefix_len) || u32_be(addr_bytes))
+//   "V6" || u32_be(len(v6)) || (for each: u8(prefix_len) || u128_be(addr_bytes))
+//
+// CIDR strings that fail to parse are skipped (defensive).
+func canonicalizeAddressBookContent(v4, v6 []string) []byte {
+	var buf bytes.Buffer
+	buf.WriteString("V4")
+	binary.Write(&buf, binary.BigEndian, uint32(len(v4)))
+	for _, s := range v4 {
+		_, ipnet, err := net.ParseCIDR(s)
+		if err != nil {
+			continue
+		}
+		ones, _ := ipnet.Mask.Size()
+		buf.WriteByte(byte(ones))
+		buf.Write(ipnet.IP.To4())
+	}
+	buf.WriteString("V6")
+	binary.Write(&buf, binary.BigEndian, uint32(len(v6)))
+	for _, s := range v6 {
+		_, ipnet, err := net.ParseCIDR(s)
+		if err != nil {
+			continue
+		}
+		ones, _ := ipnet.Mask.Size()
+		buf.WriteByte(byte(ones))
+		buf.Write(ipnet.IP.To16())
+	}
+	return buf.Bytes()
+}
+
+func isV4CIDR(s string) bool {
+	ip, _, err := net.ParseCIDR(s)
+	return err == nil && ip.To4() != nil
+}
+
+func isV6CIDR(s string) bool {
+	ip, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		return false
+	}
+	// To4 returning non-nil means the string parsed as a 4-byte
+	// address (or v4-mapped); only return true if the underlying
+	// representation is 16 bytes (v6).
+	return ip.To4() == nil && len(ipnet.IP) == net.IPv6len
+}
+
+// Silence unused-import warnings when this build is ever stripped
+// of address-book content.
+var _ = hex.EncodeToString
 
 func stablePolicyRuleID(fromZone, toZone, ruleName string) string {
 	return fmt.Sprintf("%s->%s/%s", fromZone, toZone, ruleName)

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -310,21 +310,27 @@ func expandBookNameToCIDRs(cfg *config.Config, name string) ([]string, []string)
 	return v4, v6
 }
 
-func expandBookNameRecursive(ab *config.AddressBook, name string, visited map[string]bool, depth int) []string {
-	if depth > 5 || visited[name] {
+// expandBookNameRecursive resolves named book references via
+// path-based cycle detection. No depth cap (matches the legacy
+// `resolveUserspaceAddressBookEntry` semantics — Copilot review C2).
+// `visited` is mutated on entry and unwound on exit so siblings
+// can share parents without false cycles.
+func expandBookNameRecursive(ab *config.AddressBook, name string, visited map[string]bool, _depth int) []string {
+	if visited[name] {
 		return nil
 	}
 	visited[name] = true
+	defer func() { delete(visited, name) }()
 	if addr, ok := ab.Addresses[name]; ok {
 		return []string{addr.Value}
 	}
 	if as, ok := ab.AddressSets[name]; ok {
 		var out []string
 		for _, member := range as.Addresses {
-			out = append(out, expandBookNameRecursive(ab, member, visited, depth+1)...)
+			out = append(out, expandBookNameRecursive(ab, member, visited, 0)...)
 		}
 		for _, nested := range as.AddressSets {
-			out = append(out, expandBookNameRecursive(ab, nested, visited, depth+1)...)
+			out = append(out, expandBookNameRecursive(ab, nested, visited, 0)...)
 		}
 		return out
 	}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -68,9 +68,21 @@ type ConfigSnapshot struct {
 	ClassOfService     *ClassOfServiceSnapshot      `json:"class_of_service,omitempty"`
 	FlowExport         *FlowExportSnapshot          `json:"flow_export,omitempty"`
 	MirrorConfigs      []MirrorConfigSnapshot       `json:"mirror_configs,omitempty"`
+	AddressBooks       []AddressBookSnapshot        `json:"address_books,omitempty"`
 	Config             *config.Config               `json:"config,omitempty"`
 	Userspace          config.UserspaceConfig       `json:"userspace"`
 	DeferWorkers       bool                         `json:"defer_workers,omitempty"`
+}
+
+// AddressBookSnapshot is #1606: one row of the deduplicated address-book
+// table. Multiple Junos-declared names whose canonical CIDR sets are
+// identical share one row + one ID. Name is diagnostic-only
+// (lexicographically smallest declaring name).
+type AddressBookSnapshot struct {
+	ID         uint32   `json:"id"`
+	Name       string   `json:"name,omitempty"`
+	PrefixesV4 []string `json:"prefixes_v4,omitempty"`
+	PrefixesV6 []string `json:"prefixes_v6,omitempty"`
 }
 
 type FlowSnapshot struct {
@@ -421,18 +433,29 @@ type PolicyApplicationSnapshot struct {
 }
 
 type PolicyRuleSnapshot struct {
-	RuleID               string                      `json:"rule_id,omitempty"`
-	PolicyID             uint32                      `json:"policy_id,omitempty"`
-	Name                 string                      `json:"name"`
-	FromZone             string                      `json:"from_zone,omitempty"`
-	ToZone               string                      `json:"to_zone,omitempty"`
-	SchedulerName        string                      `json:"scheduler_name,omitempty"`
-	Inactive             bool                        `json:"inactive,omitempty"`
-	SourceAddresses      []string                    `json:"source_addresses,omitempty"`
-	DestinationAddresses []string                    `json:"destination_addresses,omitempty"`
-	Applications         []string                    `json:"applications,omitempty"`
-	ApplicationTerms     []PolicyApplicationSnapshot `json:"application_terms,omitempty"`
-	Action               string                      `json:"action,omitempty"`
+	RuleID        string `json:"rule_id,omitempty"`
+	PolicyID      uint32 `json:"policy_id,omitempty"`
+	Name          string `json:"name"`
+	FromZone      string `json:"from_zone,omitempty"`
+	ToZone        string `json:"to_zone,omitempty"`
+	SchedulerName string `json:"scheduler_name,omitempty"`
+	Inactive      bool   `json:"inactive,omitempty"`
+	// Legacy field (carries full expansion: literals ∪ book CIDRs).
+	// Used by old-Rust binaries reading new-Go snapshots. New-Rust
+	// IGNORES this field when the rule is v3-shaped.
+	SourceAddresses      []string `json:"source_addresses,omitempty"`
+	DestinationAddresses []string `json:"destination_addresses,omitempty"`
+	// #1606: dense u32 IDs of named address books cited by the
+	// rule.
+	SourceBookIDs      []uint32 `json:"source_book_ids,omitempty"`
+	DestinationBookIDs []uint32 `json:"destination_book_ids,omitempty"`
+	// #1606: free-form CIDR / "any" literals written inline in the
+	// rule (NOT a named address-book reference).
+	SourceLiterals      []string                    `json:"source_literals,omitempty"`
+	DestinationLiterals []string                    `json:"destination_literals,omitempty"`
+	Applications        []string                    `json:"applications,omitempty"`
+	ApplicationTerms    []PolicyApplicationSnapshot `json:"application_terms,omitempty"`
+	Action              string                      `json:"action,omitempty"`
 }
 
 type InterfaceAddressSnapshot struct {

--- a/userspace-dp/Cargo.lock
+++ b/userspace-dp/Cargo.lock
@@ -829,6 +829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "snow"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1156,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "slab",
+ "smallvec",
  "snow",
  "zeroize",
 ]

--- a/userspace-dp/Cargo.toml
+++ b/userspace-dp/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 rustc-hash = "2.1"
 sha2 = "0.10"
 slab = "0.4"
+smallvec = "1.13"
 # WireGuard clean-room termination (docs/pr/wireguard-clean/plan.md):
 # snow provides Noise IK with explicit state machine and no hidden
 # output queues. The transitive crypto set includes

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -433,6 +433,24 @@ impl Coordinator {
     }
 
     pub fn refresh_runtime_snapshot(&mut self, snapshot: &crate::ConfigSnapshot) {
+        // #1606: preflight policy validation BEFORE any
+        // side-effecting mutation (neighbor manager keys,
+        // validation, policy_counters). If integrity errors fire,
+        // keep ALL existing state.
+        if let Err(err) = crate::policy::parse_policy_state_with_counters(
+            &snapshot.default_policy,
+            &snapshot.policies,
+            &self.forwarding.zone_name_to_id,
+            &snapshot.address_books,
+            &self.policy_counters,
+        ) {
+            eprintln!(
+                "xpf-userspace-dp: snapshot integrity error during refresh_runtime_snapshot preflight: {} — keeping previous state",
+                err
+            );
+            return;
+        }
+
         let next_manager_keys = snapshot
             .neighbors
             .iter()
@@ -474,12 +492,24 @@ impl Coordinator {
         // may not include them if the peer MAC wasn't resolved at
         // snapshot build time. Always keep the better-resolved set.
         let preserved_fabrics = self.forwarding.fabrics.clone();
-        self.policy_counters.reconcile_rules(&snapshot.policies);
-        self.forwarding = build_forwarding_state_with_policy_counters_and_previous(
+        // #1606: preflight policy build. If integrity errors fire,
+        // keep the existing forwarding state.
+        let new_forwarding = match build_forwarding_state_with_policy_counters_and_previous(
             snapshot,
             &self.policy_counters,
             Some(&self.forwarding),
-        );
+        ) {
+            Ok(fwd) => fwd,
+            Err(err) => {
+                eprintln!(
+                    "xpf-userspace-dp: snapshot integrity error during runtime-snapshot refresh: {} — keeping previous forwarding state",
+                    err
+                );
+                return;
+            }
+        };
+        self.policy_counters.reconcile_rules(&snapshot.policies);
+        self.forwarding = new_forwarding;
         if self.forwarding.fabrics.is_empty() && !preserved_fabrics.is_empty() {
             self.forwarding.fabrics = preserved_fabrics;
         } else if !preserved_fabrics.is_empty() {

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -437,12 +437,17 @@ impl Coordinator {
         // side-effecting mutation (neighbor manager keys,
         // validation, policy_counters). If integrity errors fire,
         // keep ALL existing state.
+        //
+        // CRITICAL (Codex code-review F2): use a SCRATCH counter
+        // store for the preflight so we don't leak counter
+        // registry entries on rejected snapshots.
+        let preflight_counters = crate::policy::PolicyCounterStore::default();
         if let Err(err) = crate::policy::parse_policy_state_with_counters(
             &snapshot.default_policy,
             &snapshot.policies,
             &self.forwarding.zone_name_to_id,
             &snapshot.address_books,
-            &self.policy_counters,
+            &preflight_counters,
         ) {
             eprintln!(
                 "xpf-userspace-dp: snapshot integrity error during refresh_runtime_snapshot preflight: {} — keeping previous state",

--- a/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
@@ -69,6 +69,32 @@ impl Coordinator {
     ) {
         self.reconcile_calls += 1;
         self.last_reconcile_stage = "start".to_string();
+        // #1606 (AGY r2 finding 4.2): policy-integrity preflight
+        // BEFORE tear_down. If the snapshot has duplicate / zero /
+        // unknown book IDs, reject WITHOUT tearing down the
+        // existing workers. Workers keep running on the previous
+        // good config until a valid snapshot arrives.
+        //
+        // Uses a scratch counter store (Codex r1 F2) so we don't
+        // leak Arc<PolicyRuleCounter> entries on rejected snapshots.
+        if let Some(snap) = snapshot {
+            let preflight_counters = crate::policy::PolicyCounterStore::default();
+            if let Err(err) = crate::policy::parse_policy_state_with_counters(
+                &snap.default_policy,
+                &snap.policies,
+                &self.forwarding.zone_name_to_id,
+                &snap.address_books,
+                &preflight_counters,
+            ) {
+                eprintln!(
+                    "xpf-userspace-dp: snapshot integrity error during reconcile preflight: {} — keeping previous workers + forwarding state",
+                    err
+                );
+                self.last_reconcile_stage =
+                    format!("snapshot_integrity_error: {}", err);
+                return;
+            }
+        }
         let preserved = teardown::tear_down(self);
         reset::reset_binding_counters(bindings);
         let Some(snapshot) = snapshot else {

--- a/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
@@ -24,17 +24,33 @@ pub(super) fn apply_snapshot(
     bindings: &mut [BindingStatus],
     preserved_slow_path: Option<Arc<SlowPathReinjector>>,
 ) -> Option<ReconcileSnapshotFds> {
+    // #1606: preflight policy build BEFORE any side-effecting
+    // mutation. Surfaces address-book integrity errors (id=0,
+    // duplicate ids, unknown rule references) before
+    // ValidationState, policy_counters, or coord.forwarding is
+    // mutated.
+    let new_forwarding = match build_forwarding_state_with_policy_counters_and_previous(
+        snapshot,
+        &coord.policy_counters,
+        Some(&coord.forwarding),
+    ) {
+        Ok(fwd) => fwd,
+        Err(err) => {
+            eprintln!(
+                "xpf-userspace-dp: snapshot integrity error during reconcile: {} — keeping previous forwarding state",
+                err
+            );
+            return None;
+        }
+    };
+
     coord.validation = ValidationState {
         snapshot_installed: true,
         config_generation: snapshot.generation,
         fib_generation: snapshot.fib_generation,
     };
     coord.policy_counters.reconcile_rules(&snapshot.policies);
-    coord.forwarding = build_forwarding_state_with_policy_counters_and_previous(
-        snapshot,
-        &coord.policy_counters,
-        Some(&coord.forwarding),
-    );
+    coord.forwarding = new_forwarding;
     coord.shared_validation.store(Arc::new(coord.validation));
     coord
         .ha

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -105,14 +105,26 @@ fn parse_syn_cookie_master_key(key: &str) -> Option<[u8; 16]> {
     Some(out)
 }
 
+/// Test/legacy entry point — infallible; panics on snapshot
+/// integrity error (which test snapshots never hit). Production
+/// code uses `try_build_forwarding_state_*` instead.
 pub(super) fn build_forwarding_state(snapshot: &ConfigSnapshot) -> ForwardingState {
-    build_forwarding_state_with_policy_counters(snapshot, &PolicyCounterStore::default())
+    try_build_forwarding_state_with_policy_counters(snapshot, &PolicyCounterStore::default())
+        .expect("test snapshot must not produce policy integrity error")
 }
 
 pub(super) fn build_forwarding_state_with_policy_counters(
     snapshot: &ConfigSnapshot,
     policy_counters: &PolicyCounterStore,
 ) -> ForwardingState {
+    try_build_forwarding_state_with_policy_counters(snapshot, policy_counters)
+        .expect("test snapshot must not produce policy integrity error")
+}
+
+pub(super) fn try_build_forwarding_state_with_policy_counters(
+    snapshot: &ConfigSnapshot,
+    policy_counters: &PolicyCounterStore,
+) -> Result<ForwardingState, crate::policy::SnapshotIntegrityError> {
     build_forwarding_state_with_policy_counters_and_previous(snapshot, policy_counters, None)
 }
 
@@ -120,7 +132,7 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     snapshot: &ConfigSnapshot,
     policy_counters: &PolicyCounterStore,
     previous: Option<&ForwardingState>,
-) -> ForwardingState {
+) -> Result<ForwardingState, crate::policy::SnapshotIntegrityError> {
     let mut state = ForwardingState::default();
     let (excluded_local_v4, excluded_local_v6) = nat_translated_local_exclusions(snapshot);
 
@@ -145,8 +157,9 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
         &snapshot.default_policy,
         &snapshot.policies,
         &state.zone_name_to_id,
+        &snapshot.address_books,
         policy_counters,
-    );
+    )?;
     state.allow_dns_reply = snapshot.flow.allow_dns_reply;
     state.allow_embedded_icmp = snapshot.flow.allow_embedded_icmp;
     state.session_timeouts = crate::session::SessionTimeouts::from_seconds(
@@ -300,14 +313,28 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
             state.policy.rules.len(),
         );
         for (i, rule) in state.policy.rules.iter().enumerate() {
+            // #1606: aggregate prefix count across the rule's
+            // literal set + every cited book's dense entry.
+            let src_v4_count = rule.source_literal_v4.prefix_count()
+                + rule
+                    .source_book_idxs
+                    .iter()
+                    .map(|&idx| state.policy.books[idx as usize].v4.prefix_count())
+                    .sum::<usize>();
+            let dst_v4_count = rule.destination_literal_v4.prefix_count()
+                + rule
+                    .destination_book_idxs
+                    .iter()
+                    .map(|&idx| state.policy.books[idx as usize].v4.prefix_count())
+                    .sum::<usize>();
             debug_log!(
                 "FWD_STATE: policy[{}] {}->{}  action={:?} src_v4={} dst_v4={} apps={}",
                 i,
                 rule.from_zone,
                 rule.to_zone,
                 rule.action,
-                rule.source_v4.prefix_count(),
-                rule.destination_v4.prefix_count(),
+                src_v4_count,
+                dst_v4_count,
                 rule.applications.len(),
             );
         }
@@ -349,5 +376,5 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     // the DP handles all TCP state for those addresses.
     install_kernel_rst_suppression(&state);
 
-    state
+    Ok(state)
 }

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -77,7 +77,8 @@ fn forwarding_state_refresh_preserves_three_color_runtime_state() {
         &snapshot,
         &policy_counters,
         Some(&state),
-    );
+    )
+    .expect("test snapshot must not produce integrity error");
     assert!(std::sync::Arc::ptr_eq(
         &state.filter_state.three_color_policers[0],
         &refreshed.filter_state.three_color_policers[0]

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -1,11 +1,47 @@
 use crate::prefix::{PrefixV4, PrefixV6};
 use crate::prefix_set::{PrefixSetV4, PrefixSetV6};
-use crate::{PolicyApplicationSnapshot, PolicyRuleCounterStatus, PolicyRuleSnapshot};
+use crate::{
+    AddressBookSnapshot, PolicyApplicationSnapshot, PolicyRuleCounterStatus, PolicyRuleSnapshot,
+};
 use ipnet::IpNet;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+
+/// #1606: snapshot integrity errors from the policy parser.
+#[derive(Debug, Clone)]
+pub(crate) enum SnapshotIntegrityError {
+    AddressBookIdZero,
+    DuplicateAddressBookId(u32),
+    UnknownAddressBookId { rule_id: String, book_id: u32 },
+}
+
+impl std::fmt::Display for SnapshotIntegrityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AddressBookIdZero => write!(f, "address book has reserved id=0"),
+            Self::DuplicateAddressBookId(id) => {
+                write!(f, "duplicate address_books.id={}", id)
+            }
+            Self::UnknownAddressBookId { rule_id, book_id } => write!(
+                f,
+                "rule {:?} references unknown address book id={}",
+                rule_id, book_id
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotIntegrityError {}
+
+/// #1606: one row of the deduplicated address-book table.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct BookEntry {
+    pub(crate) v4: PrefixSetV4,
+    pub(crate) v6: PrefixSetV6,
+}
 
 /// #922: zone-pair key packed as u32 (`from_id << 16 | to_id`).
 /// Replaces the previous `(String, String)` key that allocated two
@@ -58,14 +94,26 @@ pub(crate) struct PolicyRule {
     pub(crate) to_zone: String,
     pub(crate) scheduler_name: String,
     pub(crate) inactive: bool,
-    /// #923: adaptive prefix set (MatchAny / Linear ≤16 / Trie >16).
-    /// Replaces the legacy `Vec<PrefixV*>` linear scan in
-    /// `nets_match_v4/v6`. Empty input collapses to `MatchAny`,
-    /// preserving the legacy `is_empty()` match-all behavior.
-    pub(crate) source_v4: PrefixSetV4,
-    pub(crate) source_v6: PrefixSetV6,
-    pub(crate) destination_v4: PrefixSetV4,
-    pub(crate) destination_v6: PrefixSetV6,
+    /// #1606: literal CIDRs inlined in the rule (renamed from
+    /// `source_v4`). For v3-shaped rules, built via
+    /// `PrefixSetV4::from_v3_literals` (empty → MatchNone). For
+    /// non-v3-shaped (legacy) rules, built via the legacy
+    /// `from_prefixes` (empty → MatchAny).
+    pub(crate) source_literal_v4: PrefixSetV4,
+    pub(crate) source_literal_v6: PrefixSetV6,
+    pub(crate) destination_literal_v4: PrefixSetV4,
+    pub(crate) destination_literal_v6: PrefixSetV6,
+    /// #1606: dense indices into `PolicyState::books`. Inline cap
+    /// of 8 covers the realistic case (≤8 books per rule); spills
+    /// to heap above that.
+    pub(crate) source_book_idxs: SmallVec<[u32; 8]>,
+    pub(crate) destination_book_idxs: SmallVec<[u32; 8]>,
+    /// #1606: precomputed match-any short-circuit flags. True iff
+    /// the union of literal + cited books matches every address.
+    pub(crate) source_v4_match_any: bool,
+    pub(crate) source_v6_match_any: bool,
+    pub(crate) destination_v4_match_any: bool,
+    pub(crate) destination_v6_match_any: bool,
     pub(crate) applications: Vec<ApplicationMatch>,
     /// Precompiled application matcher (protocol-indexed, exact-port sets).
     compiled_apps: CompiledApplications,
@@ -82,10 +130,16 @@ impl Default for PolicyRule {
             to_zone: String::new(),
             scheduler_name: String::new(),
             inactive: false,
-            source_v4: PrefixSetV4::default(),
-            source_v6: PrefixSetV6::default(),
-            destination_v4: PrefixSetV4::default(),
-            destination_v6: PrefixSetV6::default(),
+            source_literal_v4: PrefixSetV4::default(),
+            source_literal_v6: PrefixSetV6::default(),
+            destination_literal_v4: PrefixSetV4::default(),
+            destination_literal_v6: PrefixSetV6::default(),
+            source_book_idxs: SmallVec::new(),
+            destination_book_idxs: SmallVec::new(),
+            source_v4_match_any: true,
+            source_v6_match_any: true,
+            destination_v4_match_any: true,
+            destination_v6_match_any: true,
             applications: Vec::new(),
             compiled_apps: CompiledApplications {
                 match_any: true,
@@ -106,10 +160,16 @@ impl Clone for PolicyRule {
             to_zone: self.to_zone.clone(),
             scheduler_name: self.scheduler_name.clone(),
             inactive: self.inactive,
-            source_v4: self.source_v4.clone(),
-            source_v6: self.source_v6.clone(),
-            destination_v4: self.destination_v4.clone(),
-            destination_v6: self.destination_v6.clone(),
+            source_literal_v4: self.source_literal_v4.clone(),
+            source_literal_v6: self.source_literal_v6.clone(),
+            destination_literal_v4: self.destination_literal_v4.clone(),
+            destination_literal_v6: self.destination_literal_v6.clone(),
+            source_book_idxs: self.source_book_idxs.clone(),
+            destination_book_idxs: self.destination_book_idxs.clone(),
+            source_v4_match_any: self.source_v4_match_any,
+            source_v6_match_any: self.source_v6_match_any,
+            destination_v4_match_any: self.destination_v4_match_any,
+            destination_v6_match_any: self.destination_v6_match_any,
             applications: self.applications.clone(),
             compiled_apps: self.compiled_apps.clone(),
             action: self.action,
@@ -271,6 +331,11 @@ pub(crate) struct PolicyState {
     zone_pair_index: FxHashMap<ZonePairKey, Vec<usize>>,
     /// Indices of global rules (from_zone or to_zone = "junos-global").
     global_indices: Vec<usize>,
+    /// #1606: deduplicated address-book table. Rules reference
+    /// books by dense `u32` index (`PolicyRule::source_book_idxs`).
+    pub(crate) books: Vec<BookEntry>,
+    /// #1606: wire-ID → dense-index map used at parse time only.
+    book_id_to_idx: FxHashMap<u32, u32>,
 }
 
 impl Default for PolicyState {
@@ -280,6 +345,8 @@ impl Default for PolicyState {
             rules: Vec::new(),
             zone_pair_index: FxHashMap::default(),
             global_indices: Vec::new(),
+            books: Vec::new(),
+            book_id_to_idx: FxHashMap::default(),
         }
     }
 }
@@ -299,36 +366,122 @@ pub(crate) fn parse_policy_state(
     zone_name_to_id: &FxHashMap<String, u16>,
 ) -> PolicyState {
     let counter_store = PolicyCounterStore::default();
-    parse_policy_state_with_counters(default_policy, rules, zone_name_to_id, &counter_store)
+    parse_policy_state_with_counters(default_policy, rules, zone_name_to_id, &[], &counter_store)
+        .expect("legacy parse_policy_state called with no books — cannot raise integrity errors")
 }
 
+/// #1606: fallible policy-state parser. Returns
+/// `SnapshotIntegrityError` for duplicate/zero/unknown book IDs.
+/// Callers MUST run this as a preflight before any side-effecting
+/// snapshot mutation (see `server/handlers/snapshot.rs::apply`).
 pub(crate) fn parse_policy_state_with_counters(
     default_policy: &str,
     rules: &[PolicyRuleSnapshot],
     zone_name_to_id: &FxHashMap<String, u16>,
+    address_books: &[AddressBookSnapshot],
     counter_store: &PolicyCounterStore,
-) -> PolicyState {
+) -> Result<PolicyState, SnapshotIntegrityError> {
     let mut state = PolicyState {
         default_action: parse_action(default_policy),
         rules: Vec::with_capacity(rules.len()),
         zone_pair_index: FxHashMap::default(),
         global_indices: Vec::new(),
+        books: Vec::with_capacity(address_books.len()),
+        book_id_to_idx: FxHashMap::default(),
     };
+
+    // #1606: build the dense book table first. Hard-fail on
+    // integrity errors (id=0, duplicate ids).
+    for snap in address_books {
+        if snap.id == 0 {
+            return Err(SnapshotIntegrityError::AddressBookIdZero);
+        }
+        if state.book_id_to_idx.contains_key(&snap.id) {
+            return Err(SnapshotIntegrityError::DuplicateAddressBookId(snap.id));
+        }
+        // Parse v4 / v6 literals using the v3 factory: empty
+        // collapses to MatchNone (NOT MatchAny). A v4-only book
+        // gets entry.v6 = MatchNone, etc.
+        let mut v4: Vec<PrefixV4> = Vec::with_capacity(snap.prefixes_v4.len());
+        let mut v6: Vec<PrefixV6> = Vec::with_capacity(snap.prefixes_v6.len());
+        for s in &snap.prefixes_v4 {
+            parse_literal_cidr_into(s, &mut v4, &mut v6);
+        }
+        for s in &snap.prefixes_v6 {
+            parse_literal_cidr_into(s, &mut v4, &mut v6);
+        }
+        let entry = BookEntry {
+            v4: PrefixSetV4::from_v3_literals(v4),
+            v6: PrefixSetV6::from_v3_literals(v6),
+        };
+        let dense_idx = state.books.len() as u32;
+        state.books.push(entry);
+        state.book_id_to_idx.insert(snap.id, dense_idx);
+    }
+
     for snap in rules {
-        // #923: buffer prefixes in temporary Vecs, then collapse
-        // each side to a `PrefixSet*` (MatchAny / Linear / Trie)
-        // when the rule is fully parsed.
-        let mut src_v4: Vec<PrefixV4> = Vec::new();
-        let mut src_v6: Vec<PrefixV6> = Vec::new();
-        let mut dst_v4: Vec<PrefixV4> = Vec::new();
-        let mut dst_v6: Vec<PrefixV6> = Vec::new();
-        for prefix in &snap.source_addresses {
-            parse_address(prefix, &mut src_v4, &mut src_v6);
-        }
-        for prefix in &snap.destination_addresses {
-            parse_address(prefix, &mut dst_v4, &mut dst_v6);
-        }
+        let source_is_v3_shaped =
+            !snap.source_book_ids.is_empty() || !snap.source_literals.is_empty();
+        let destination_is_v3_shaped = !snap.destination_book_ids.is_empty()
+            || !snap.destination_literals.is_empty();
+
+        // Build literal prefix sets per side using the appropriate
+        // factory.
+        let (source_literal_v4, source_literal_v6) = if source_is_v3_shaped {
+            parse_v3_literal_set(&snap.source_literals)
+        } else {
+            let mut v4: Vec<PrefixV4> = Vec::new();
+            let mut v6: Vec<PrefixV6> = Vec::new();
+            for prefix in &snap.source_addresses {
+                parse_address(prefix, &mut v4, &mut v6);
+            }
+            (
+                PrefixSetV4::from_prefixes(v4),
+                PrefixSetV6::from_prefixes(v6),
+            )
+        };
+        let (destination_literal_v4, destination_literal_v6) = if destination_is_v3_shaped {
+            parse_v3_literal_set(&snap.destination_literals)
+        } else {
+            let mut v4: Vec<PrefixV4> = Vec::new();
+            let mut v6: Vec<PrefixV6> = Vec::new();
+            for prefix in &snap.destination_addresses {
+                parse_address(prefix, &mut v4, &mut v6);
+            }
+            (
+                PrefixSetV4::from_prefixes(v4),
+                PrefixSetV6::from_prefixes(v6),
+            )
+        };
+
         let rule_id = stable_policy_rule_id(snap);
+
+        // Resolve book IDs to dense indices. Sort + dedup + hard
+        // fail on unknown.
+        let source_book_idxs =
+            resolve_book_idxs(&state.book_id_to_idx, &snap.source_book_ids, &rule_id)?;
+        let destination_book_idxs =
+            resolve_book_idxs(&state.book_id_to_idx, &snap.destination_book_ids, &rule_id)?;
+
+        // Precompute match-any flags. True iff EITHER the literal
+        // set OR any cited book's v4/v6 is MatchAny.
+        let source_v4_match_any = source_literal_v4.is_match_any()
+            || source_book_idxs
+                .iter()
+                .any(|&i| state.books[i as usize].v4.is_match_any());
+        let source_v6_match_any = source_literal_v6.is_match_any()
+            || source_book_idxs
+                .iter()
+                .any(|&i| state.books[i as usize].v6.is_match_any());
+        let destination_v4_match_any = destination_literal_v4.is_match_any()
+            || destination_book_idxs
+                .iter()
+                .any(|&i| state.books[i as usize].v4.is_match_any());
+        let destination_v6_match_any = destination_literal_v6.is_match_any()
+            || destination_book_idxs
+                .iter()
+                .any(|&i| state.books[i as usize].v6.is_match_any());
+
         let mut rule = PolicyRule {
             rule_id: rule_id.clone(),
             policy_id: snap.policy_id,
@@ -338,10 +491,16 @@ pub(crate) fn parse_policy_state_with_counters(
             inactive: snap.inactive,
             action: parse_action(&snap.action),
             hit_counter: counter_store.rule_hit_counter(&rule_id),
-            source_v4: PrefixSetV4::from_prefixes(src_v4),
-            source_v6: PrefixSetV6::from_prefixes(src_v6),
-            destination_v4: PrefixSetV4::from_prefixes(dst_v4),
-            destination_v6: PrefixSetV6::from_prefixes(dst_v6),
+            source_literal_v4,
+            source_literal_v6,
+            destination_literal_v4,
+            destination_literal_v6,
+            source_book_idxs,
+            destination_book_idxs,
+            source_v4_match_any,
+            source_v6_match_any,
+            destination_v4_match_any,
+            destination_v6_match_any,
             ..PolicyRule::default()
         };
         rule.applications = parse_applications(&snap.application_terms);
@@ -353,11 +512,6 @@ pub(crate) fn parse_policy_state_with_counters(
         if is_global {
             state.global_indices.push(idx);
         } else {
-            // #922: translate zone names to IDs at config-load time.
-            // A rule referencing an unknown zone is kept in `rules`
-            // (so hit-counter reporting still works) but omitted from
-            // the index — it becomes a dead rule with the same
-            // semantics as today's "name not in any session" case.
             match (
                 zone_name_to_id.get(&snap.from_zone).copied(),
                 zone_name_to_id.get(&snap.to_zone).copied(),
@@ -375,7 +529,87 @@ pub(crate) fn parse_policy_state_with_counters(
             }
         }
     }
-    state
+    Ok(state)
+}
+
+/// #1606: parse the v3 `source_literals` / `destination_literals`
+/// field. "any" token forces MatchAny on BOTH families (Codex r5
+/// F-r5-1 fix); empty input or no-any → MatchNone (via
+/// `from_v3_literals`).
+fn parse_v3_literal_set(literals: &[String]) -> (PrefixSetV4, PrefixSetV6) {
+    let mut any_v4 = false;
+    let mut any_v6 = false;
+    let mut v4: Vec<PrefixV4> = Vec::new();
+    let mut v6: Vec<PrefixV6> = Vec::new();
+    for tok in literals {
+        match tok.as_str() {
+            "any" => {
+                any_v4 = true;
+                any_v6 = true;
+            }
+            "any4" => any_v4 = true,
+            "any6" => any_v6 = true,
+            "" => {}
+            s => parse_literal_cidr_into(s, &mut v4, &mut v6),
+        }
+    }
+    let v4_set = if any_v4 {
+        PrefixSetV4::MatchAny
+    } else {
+        PrefixSetV4::from_v3_literals(v4)
+    };
+    let v6_set = if any_v6 {
+        PrefixSetV6::MatchAny
+    } else {
+        PrefixSetV6::from_v3_literals(v6)
+    };
+    (v4_set, v6_set)
+}
+
+fn parse_literal_cidr_into(
+    prefix: &str,
+    out_v4: &mut Vec<PrefixV4>,
+    out_v6: &mut Vec<PrefixV6>,
+) {
+    if prefix.is_empty() || prefix == "any" {
+        return;
+    }
+    match prefix.parse::<IpNet>() {
+        Ok(IpNet::V4(net)) => out_v4.push(PrefixV4::from_net(net)),
+        Ok(IpNet::V6(net)) => out_v6.push(PrefixV6::from_net(net)),
+        Err(_) => {
+            if let Ok(ip) = prefix.parse::<Ipv4Addr>() {
+                out_v4.push(PrefixV4::from_net(
+                    ipnet::Ipv4Net::new(ip, 32).expect("v4 /32"),
+                ));
+            } else if let Ok(ip) = prefix.parse::<Ipv6Addr>() {
+                out_v6.push(PrefixV6::from_net(
+                    ipnet::Ipv6Net::new(ip, 128).expect("v6 /128"),
+                ));
+            }
+        }
+    }
+}
+
+fn resolve_book_idxs(
+    book_id_to_idx: &FxHashMap<u32, u32>,
+    ids: &[u32],
+    rule_id: &str,
+) -> Result<SmallVec<[u32; 8]>, SnapshotIntegrityError> {
+    let mut sorted = ids.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    let mut out: SmallVec<[u32; 8]> = SmallVec::new();
+    for id in sorted {
+        let Some(&idx) = book_id_to_idx.get(&id) else {
+            return Err(SnapshotIntegrityError::UnknownAddressBookId {
+                rule_id: rule_id.to_string(),
+                book_id: id,
+            });
+        };
+        out.push(idx);
+    }
+    Ok(out)
 }
 
 pub(crate) fn evaluate_policy(
@@ -422,14 +656,12 @@ pub(crate) fn evaluate_policy_result_with_len(
     dst_port: u16,
     packet_len: u64,
 ) -> PolicyEvaluationResult {
-    // Phase 2 optimisation: look up only the rules for this zone-pair
-    // instead of scanning all rules. Global rules are checked afterward.
-    // #922: zero-allocation key (packed u32).
     let key = zone_pair_key(from_id, to_id);
     if let Some(indices) = state.zone_pair_index.get(&key) {
         for &idx in indices {
             if let Some(result) = try_match_rule(
                 &state.rules[idx],
+                state,
                 src_ip,
                 dst_ip,
                 protocol,
@@ -441,10 +673,10 @@ pub(crate) fn evaluate_policy_result_with_len(
             }
         }
     }
-    // Global policies (junos-global) apply to any zone-pair.
     for &idx in &state.global_indices {
         if let Some(result) = try_match_rule(
             &state.rules[idx],
+            state,
             src_ip,
             dst_ip,
             protocol,
@@ -462,10 +694,13 @@ pub(crate) fn evaluate_policy_result_with_len(
 }
 
 /// Try to match a single policy rule against packet fields.
-/// Returns the rule's action if all criteria match, None otherwise.
+/// #1606: walks the literal set + every cited book's dense entry
+/// via `state.books[idx]`. Match-any flags short-circuit the
+/// common "any" case.
 #[inline]
 fn try_match_rule(
     rule: &PolicyRule,
+    state: &PolicyState,
     src_ip: IpAddr,
     dst_ip: IpAddr,
     protocol: u8,
@@ -479,26 +714,47 @@ fn try_match_rule(
     if !rule.compiled_apps.matches(protocol, src_port, dst_port) {
         return None;
     }
-    match (src_ip, dst_ip) {
-        (IpAddr::V4(src), IpAddr::V4(dst))
-            if rule.source_v4.contains(src) && rule.destination_v4.contains(dst) =>
-        {
-            rule.hit_counter.add(packet_len);
-            Some(PolicyEvaluationResult {
-                action: rule.action,
-                policy_id: rule.policy_id,
-            })
+    let (src_ok, dst_ok) = match (src_ip, dst_ip) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => {
+            let s = rule.source_v4_match_any
+                || rule.source_literal_v4.contains(src)
+                || rule
+                    .source_book_idxs
+                    .iter()
+                    .any(|&i| state.books[i as usize].v4.contains(src));
+            let d = rule.destination_v4_match_any
+                || rule.destination_literal_v4.contains(dst)
+                || rule
+                    .destination_book_idxs
+                    .iter()
+                    .any(|&i| state.books[i as usize].v4.contains(dst));
+            (s, d)
         }
-        (IpAddr::V6(src), IpAddr::V6(dst))
-            if rule.source_v6.contains(src) && rule.destination_v6.contains(dst) =>
-        {
-            rule.hit_counter.add(packet_len);
-            Some(PolicyEvaluationResult {
-                action: rule.action,
-                policy_id: rule.policy_id,
-            })
+        (IpAddr::V6(src), IpAddr::V6(dst)) => {
+            let s = rule.source_v6_match_any
+                || rule.source_literal_v6.contains(src)
+                || rule
+                    .source_book_idxs
+                    .iter()
+                    .any(|&i| state.books[i as usize].v6.contains(src));
+            let d = rule.destination_v6_match_any
+                || rule.destination_literal_v6.contains(dst)
+                || rule
+                    .destination_book_idxs
+                    .iter()
+                    .any(|&i| state.books[i as usize].v6.contains(dst));
+            (s, d)
         }
-        _ => None,
+        _ => return None,
+    };
+    if src_ok && dst_ok {
+        rule.hit_counter.add(packet_len);
+        Some(PolicyEvaluationResult {
+            action: rule.action,
+            policy_id: rule.policy_id,
+        })
+    } else {
+        None
     }
 }
 

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -231,8 +231,9 @@ fn hit_counters_survive_scheduler_snapshot_rebuild() {
         "deny",
         &[scheduled_allow_snapshot(&rule_id, false)],
         &test_zone_name_to_id(),
+        &[],
         &counter_store,
-    );
+    ).expect("test snapshot must not produce integrity error");
 
     for _ in 0..2 {
         assert_eq!(
@@ -259,8 +260,9 @@ fn hit_counters_survive_scheduler_snapshot_rebuild() {
         "deny",
         &[scheduled_allow_snapshot(&rule_id, true)],
         &test_zone_name_to_id(),
+        &[],
         &counter_store,
-    );
+    ).expect("test snapshot must not produce integrity error");
     assert!(inactive.rules[0].inactive);
     assert_eq!(policy_counter(&inactive, &rule_id).packets, 2);
     assert_eq!(
@@ -285,8 +287,9 @@ fn hit_counters_survive_scheduler_snapshot_rebuild() {
         "deny",
         &[scheduled_allow_snapshot(&rule_id, false)],
         &test_zone_name_to_id(),
+        &[],
         &counter_store,
-    );
+    ).expect("test snapshot must not produce integrity error");
     assert_eq!(policy_counter(&active_again, &rule_id).packets, 2);
     assert_eq!(
         evaluate_policy(
@@ -313,8 +316,9 @@ fn hit_counters_reset_after_rule_absent_then_readded() {
         "deny",
         &[scheduled_allow_snapshot(&rule_id, false)],
         &test_zone_name_to_id(),
+        &[],
         &counter_store,
-    );
+    ).expect("test snapshot must not produce integrity error");
     assert_eq!(
         evaluate_policy_with_len(
             &active,
@@ -335,7 +339,13 @@ fn hit_counters_reset_after_rule_absent_then_readded() {
 
     counter_store.reconcile_rules(&[]);
     let deleted =
-        parse_policy_state_with_counters("deny", &[], &test_zone_name_to_id(), &counter_store);
+        parse_policy_state_with_counters(
+        "deny",
+        &[],
+        &test_zone_name_to_id(),
+        &[],
+        &counter_store,
+    ).expect("test snapshot must not produce integrity error");
     assert!(deleted.counter_snapshots().is_empty());
 
     counter_store.reconcile_rules(&[scheduled_allow_snapshot(&rule_id, false)]);
@@ -343,8 +353,9 @@ fn hit_counters_reset_after_rule_absent_then_readded() {
         "deny",
         &[scheduled_allow_snapshot(&rule_id, false)],
         &test_zone_name_to_id(),
+        &[],
         &counter_store,
-    );
+    ).expect("test snapshot must not produce integrity error");
     let reset_counter = policy_counter(&active_again, &rule_id);
     assert_eq!(reset_counter.packets, 0);
     assert_eq!(reset_counter.bytes, 0);
@@ -663,5 +674,340 @@ fn malformed_only_input_yields_match_all_via_evaluate_policy() {
             80,
         ),
         PolicyAction::Permit
+    );
+}
+
+// #1606 — address-book wire-protocol tests.
+
+fn book(id: u32, name: &str, v4: &[&str], v6: &[&str]) -> AddressBookSnapshot {
+    AddressBookSnapshot {
+        id,
+        name: name.to_string(),
+        prefixes_v4: v4.iter().map(|s| s.to_string()).collect(),
+        prefixes_v6: v6.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+fn v3_rule(name: &str, src_books: &[u32], src_lits: &[&str]) -> PolicyRuleSnapshot {
+    PolicyRuleSnapshot {
+        name: name.to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_book_ids: src_books.to_vec(),
+        source_literals: src_lits.iter().map(|s| s.to_string()).collect(),
+        destination_literals: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_book_table_dedup_by_index() {
+    // Two rules cite the same book ID. After parsing, both rules
+    // resolve to the same dense index → identical match path.
+    let books = [book(42, "corp-net", &["10.0.0.0/8"], &[])];
+    let rules = [
+        v3_rule("rule-a", &[42], &[]),
+        v3_rule("rule-b", &[42], &[]),
+    ];
+    let counter_store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters(
+        "deny",
+        &rules,
+        &test_zone_name_to_id(),
+        &books,
+        &counter_store,
+    )
+    .expect("parse");
+    assert_eq!(state.books.len(), 1);
+    assert_eq!(state.rules[0].source_book_idxs[..], state.rules[1].source_book_idxs[..]);
+}
+
+#[test]
+fn test_book_only_rule_does_not_fail_open() {
+    // A rule citing only a book (empty source_literals) must
+    // match ONLY IPs covered by the book — NOT all v4 traffic.
+    // Without the MatchNone fix this rule would have
+    // source_literal_v4 = MatchAny (legacy from_prefixes(empty)
+    // semantics) and match-all.
+    let books = [book(7, "internal", &["10.0.0.0/8"], &[])];
+    let rules = [v3_rule("internal-only", &[7], &[])];
+    let counter_store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters(
+        "deny",
+        &rules,
+        &test_zone_name_to_id(),
+        &books,
+        &counter_store,
+    )
+    .expect("parse");
+    // Inside the book → match (Permit).
+    assert_eq!(
+        evaluate_policy(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "10.5.5.5".parse().expect("src"),
+            "1.1.1.1".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            80,
+        ),
+        PolicyAction::Permit
+    );
+    // Outside the book → default Deny. If MatchNone is broken,
+    // this would be Permit (match-all).
+    assert_eq!(
+        evaluate_policy(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "8.8.8.8".parse().expect("src"),
+            "1.1.1.1".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            80,
+        ),
+        PolicyAction::Deny
+    );
+}
+
+#[test]
+fn test_v3_shaped_any_token_matches_all_v4_and_v6() {
+    // Codex r5 F-r5-1 regression test: a v3-shaped rule with
+    // source_literals=["any"] must match all v4 AND v6, NOT
+    // fail closed via MatchNone.
+    let rules = [PolicyRuleSnapshot {
+        name: "any-perm".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_literals: vec!["any".to_string()],
+        destination_literals: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    }];
+    let counter_store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters(
+        "deny",
+        &rules,
+        &test_zone_name_to_id(),
+        &[],
+        &counter_store,
+    )
+    .expect("parse");
+    assert_eq!(
+        evaluate_policy(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "8.8.8.8".parse().expect("src"),
+            "1.1.1.1".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            80,
+        ),
+        PolicyAction::Permit
+    );
+    assert_eq!(
+        evaluate_policy(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "2001:db8::1".parse().expect("src"),
+            "2001:db8::2".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            80,
+        ),
+        PolicyAction::Permit
+    );
+}
+
+#[test]
+fn test_v4_only_book_does_not_match_v6_traffic() {
+    // Codex r4 family-incomplete-book test. A v4-only book has
+    // entry.v6 = MatchNone, so a v6 packet hitting a rule citing
+    // only this book MUST NOT match.
+    let books = [book(11, "v4-only", &["10.0.0.0/8"], &[])];
+    let rules = [v3_rule("v4-only-rule", &[11], &[])];
+    let counter_store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters(
+        "deny",
+        &rules,
+        &test_zone_name_to_id(),
+        &books,
+        &counter_store,
+    )
+    .expect("parse");
+    // v6 packet → no match → default deny.
+    assert_eq!(
+        evaluate_policy(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "2001:db8::1".parse().expect("src"),
+            "2001:db8::2".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            80,
+        ),
+        PolicyAction::Deny
+    );
+}
+
+#[test]
+fn test_v6_only_book_does_not_match_v4_traffic() {
+    let books = [book(12, "v6-only", &[], &["2001:db8::/32"])];
+    let rules = [v3_rule("v6-only-rule", &[12], &[])];
+    let counter_store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters(
+        "deny",
+        &rules,
+        &test_zone_name_to_id(),
+        &books,
+        &counter_store,
+    )
+    .expect("parse");
+    assert_eq!(
+        evaluate_policy(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "8.8.8.8".parse().expect("src"),
+            "1.1.1.1".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            80,
+        ),
+        PolicyAction::Deny
+    );
+}
+
+#[test]
+fn test_unknown_book_id_hard_fails_snapshot() {
+    // Rule cites book ID 99 but address_books is empty → hard fail.
+    let rules = [v3_rule("missing-book", &[99], &[])];
+    let counter_store = PolicyCounterStore::default();
+    let result = parse_policy_state_with_counters(
+        "deny",
+        &rules,
+        &test_zone_name_to_id(),
+        &[],
+        &counter_store,
+    );
+    match result {
+        Err(SnapshotIntegrityError::UnknownAddressBookId { book_id, .. }) => {
+            assert_eq!(book_id, 99);
+        }
+        other => panic!("expected UnknownAddressBookId(99), got {:?}", other),
+    }
+}
+
+#[test]
+fn test_duplicate_address_book_id_hard_fails_snapshot() {
+    let books = [book(5, "a", &["10.0.0.0/24"], &[]), book(5, "b", &["10.1.0.0/24"], &[])];
+    let counter_store = PolicyCounterStore::default();
+    let result = parse_policy_state_with_counters(
+        "deny",
+        &[],
+        &test_zone_name_to_id(),
+        &books,
+        &counter_store,
+    );
+    match result {
+        Err(SnapshotIntegrityError::DuplicateAddressBookId(id)) => assert_eq!(id, 5),
+        other => panic!("expected DuplicateAddressBookId(5), got {:?}", other),
+    }
+}
+
+#[test]
+fn test_book_id_zero_hard_fails_snapshot() {
+    let books = [book(0, "reserved", &["10.0.0.0/24"], &[])];
+    let counter_store = PolicyCounterStore::default();
+    let result = parse_policy_state_with_counters(
+        "deny",
+        &[],
+        &test_zone_name_to_id(),
+        &books,
+        &counter_store,
+    );
+    assert!(
+        matches!(result, Err(SnapshotIntegrityError::AddressBookIdZero)),
+        "expected AddressBookIdZero, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_per_rule_duplicate_book_ids_are_deduped() {
+    let books = [book(8, "x", &["10.0.0.0/8"], &[])];
+    let rules = [v3_rule("dup-ids", &[8, 8, 8], &[])];
+    let counter_store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters(
+        "deny",
+        &rules,
+        &test_zone_name_to_id(),
+        &books,
+        &counter_store,
+    )
+    .expect("parse");
+    // After sort+dedup, only one index is stored.
+    assert_eq!(state.rules[0].source_book_idxs.len(), 1);
+}
+
+#[test]
+fn test_non_v3_shaped_falls_through_to_legacy_field() {
+    // Rule has source_addresses populated (legacy emission) but
+    // NO source_book_ids or source_literals → non-v3-shaped → use
+    // legacy field via from_prefixes (empty → MatchAny). With a
+    // concrete CIDR in the legacy field, matching is correct.
+    let rules = [PolicyRuleSnapshot {
+        name: "legacy".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["10.0.0.0/8".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    }];
+    let counter_store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters(
+        "deny",
+        &rules,
+        &test_zone_name_to_id(),
+        &[],
+        &counter_store,
+    )
+    .expect("parse");
+    // In the 10/8 range → match.
+    assert_eq!(
+        evaluate_policy(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "10.5.5.5".parse().expect("src"),
+            "1.1.1.1".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            80,
+        ),
+        PolicyAction::Permit
+    );
+    // Outside 10/8 → no match.
+    assert_eq!(
+        evaluate_policy(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "8.8.8.8".parse().expect("src"),
+            "1.1.1.1".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            80,
+        ),
+        PolicyAction::Deny
     );
 }

--- a/userspace-dp/src/prefix_set.rs
+++ b/userspace-dp/src/prefix_set.rs
@@ -32,9 +32,16 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 pub(crate) const PREFIX_SET_LINEAR_MAX: usize = 16;
 
 /// IPv4 prefix membership set. See module docs.
+///
+/// `MatchNone` (#1606) is distinct from `MatchAny`: it means
+/// "no criteria specified; the address-side of the rule does not
+/// match any IP". `from_prefixes(empty)` returns `MatchAny`
+/// (legacy convention preserved for back-compat), while the new
+/// `from_v3_literals(empty)` returns `MatchNone`.
 #[derive(Debug, Clone)]
 pub(crate) enum PrefixSetV4 {
     MatchAny,
+    MatchNone,
     Linear(Vec<PrefixV4>),
     Trie(PrefixTrieV4),
 }
@@ -42,22 +49,40 @@ pub(crate) enum PrefixSetV4 {
 #[derive(Debug, Clone)]
 pub(crate) enum PrefixSetV6 {
     MatchAny,
+    MatchNone,
     Linear(Vec<PrefixV6>),
     Trie(PrefixTrieV6),
 }
 
 impl PrefixSetV4 {
-    /// Build a `PrefixSetV4` from a vector of prefixes.
-    ///
-    /// - Empty input → `MatchAny` (legacy behavior — `is_empty()`
-    ///   on the old `Vec<PrefixV4>` was treated as "match everything").
-    /// - Any prefix with length 0 (`0.0.0.0/0`) → `MatchAny`. The
-    ///   trie path never sets `covers` on the root, so we shortcut.
-    /// - Up to `PREFIX_SET_LINEAR_MAX` prefixes → `Linear`.
-    /// - More → `Trie`.
+    /// Legacy factory: empty input collapses to `MatchAny`. Used by
+    /// the non-v3-shaped fallback path that parses fully-expanded
+    /// `source_addresses` from old-Go snapshots.
     pub(crate) fn from_prefixes(prefixes: Vec<PrefixV4>) -> Self {
         if prefixes.is_empty() {
             return Self::MatchAny;
+        }
+        if prefixes.iter().any(|p| p.prefix_len() == 0) {
+            return Self::MatchAny;
+        }
+        if prefixes.len() <= PREFIX_SET_LINEAR_MAX {
+            Self::Linear(prefixes)
+        } else {
+            let mut trie = PrefixTrieV4::default();
+            for p in &prefixes {
+                trie.insert(p);
+            }
+            Self::Trie(trie)
+        }
+    }
+
+    /// #1606 v3 factory: empty input collapses to `MatchNone`,
+    /// breaking the legacy "empty Vec = MatchAny" coupling for
+    /// v3-shaped rule sides + book entries. Used when the rule
+    /// is v3-shaped on this side, and when building book entries.
+    pub(crate) fn from_v3_literals(prefixes: Vec<PrefixV4>) -> Self {
+        if prefixes.is_empty() {
+            return Self::MatchNone;
         }
         if prefixes.iter().any(|p| p.prefix_len() == 0) {
             return Self::MatchAny;
@@ -78,24 +103,26 @@ impl PrefixSetV4 {
     pub(crate) fn contains(&self, ip: Ipv4Addr) -> bool {
         match self {
             Self::MatchAny => true,
+            Self::MatchNone => false,
             Self::Linear(v) => v.iter().any(|p| p.contains(ip)),
             Self::Trie(t) => t.contains(ip),
         }
     }
 
-    /// Set cardinality (count of unique terminal prefixes), used
-    /// only for the `forwarding_build.rs:467` debug-log readout.
-    /// Two intentional changes vs the legacy `Vec::len()`:
-    /// - `MatchAny` reports 0 (matches the legacy "empty Vec ⇒ 0"
-    ///   read; new path is `["any"]` or all-malformed-input or any
-    ///   `/0` collapse).
-    /// - `Trie` reports the deduped count: inserting the same
-    ///   prefix N times yields size 1, not N. Linear preserves the
-    ///   raw input length.
-    /// Debug-only; not on any data-path.
+    #[inline]
+    pub(crate) fn is_match_any(&self) -> bool {
+        matches!(self, Self::MatchAny)
+    }
+
+    #[inline]
+    pub(crate) fn is_match_none(&self) -> bool {
+        matches!(self, Self::MatchNone)
+    }
+
+    /// Set cardinality. Debug-only.
     pub(crate) fn prefix_count(&self) -> usize {
         match self {
-            Self::MatchAny => 0,
+            Self::MatchAny | Self::MatchNone => 0,
             Self::Linear(v) => v.len(),
             Self::Trie(t) => t.size,
         }
@@ -121,18 +148,47 @@ impl PrefixSetV6 {
         }
     }
 
+    pub(crate) fn from_v3_literals(prefixes: Vec<PrefixV6>) -> Self {
+        if prefixes.is_empty() {
+            return Self::MatchNone;
+        }
+        if prefixes.iter().any(|p| p.prefix_len() == 0) {
+            return Self::MatchAny;
+        }
+        if prefixes.len() <= PREFIX_SET_LINEAR_MAX {
+            Self::Linear(prefixes)
+        } else {
+            let mut trie = PrefixTrieV6::default();
+            for p in &prefixes {
+                trie.insert(p);
+            }
+            Self::Trie(trie)
+        }
+    }
+
     #[inline]
     pub(crate) fn contains(&self, ip: Ipv6Addr) -> bool {
         match self {
             Self::MatchAny => true,
+            Self::MatchNone => false,
             Self::Linear(v) => v.iter().any(|p| p.contains(ip)),
             Self::Trie(t) => t.contains(ip),
         }
     }
 
+    #[inline]
+    pub(crate) fn is_match_any(&self) -> bool {
+        matches!(self, Self::MatchAny)
+    }
+
+    #[inline]
+    pub(crate) fn is_match_none(&self) -> bool {
+        matches!(self, Self::MatchNone)
+    }
+
     pub(crate) fn prefix_count(&self) -> usize {
         match self {
-            Self::MatchAny => 0,
+            Self::MatchAny | Self::MatchNone => 0,
             Self::Linear(v) => v.len(),
             Self::Trie(t) => t.size,
         }

--- a/userspace-dp/src/protocol/security.rs
+++ b/userspace-dp/src/protocol/security.rs
@@ -178,16 +178,50 @@ pub(crate) struct PolicyRuleSnapshot {
     pub scheduler_name: String,
     #[serde(default)]
     pub inactive: bool,
+    /// Legacy back-compat field (kept on v3 wire). Carries the
+    /// FULLY EXPANDED literal CIDRs (union of book content + free
+    /// CIDRs). Old Rust uses ONLY this field. New Rust uses ONLY
+    /// `source_literals` / `source_book_ids` when the rule is
+    /// v3-shaped (see #1606).
     #[serde(rename = "source_addresses", default)]
     pub source_addresses: Vec<String>,
     #[serde(rename = "destination_addresses", default)]
     pub destination_addresses: Vec<String>,
+    /// #1606: dense u32 IDs of address books cited by this rule.
+    #[serde(rename = "source_book_ids", default)]
+    pub source_book_ids: Vec<u32>,
+    #[serde(rename = "destination_book_ids", default)]
+    pub destination_book_ids: Vec<u32>,
+    /// #1606: free-form CIDR / "any" literals the operator wrote
+    /// inline in the rule match (NOT via a named address book).
+    /// New Rust reads these via the v3-shaped predicate.
+    #[serde(rename = "source_literals", default)]
+    pub source_literals: Vec<String>,
+    #[serde(rename = "destination_literals", default)]
+    pub destination_literals: Vec<String>,
     #[serde(default)]
     pub applications: Vec<String>,
     #[serde(rename = "application_terms", default)]
     pub application_terms: Vec<PolicyApplicationSnapshot>,
     #[serde(default)]
     pub action: String,
+}
+
+/// #1606: snapshot row for a unique address-book content.
+/// Multiple Junos-declared book names whose canonical CIDR sets
+/// are identical share one row + one ID. `name` is diagnostic-
+/// only (lexicographically smallest declaring name).
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub(crate) struct AddressBookSnapshot {
+    /// Stable u32 ID assigned by content-only hashing on the Go
+    /// side. ID 0 is reserved as "unused" sentinel.
+    pub id: u32,
+    #[serde(default)]
+    pub name: String,
+    #[serde(rename = "prefixes_v4", default)]
+    pub prefixes_v4: Vec<String>,
+    #[serde(rename = "prefixes_v6", default)]
+    pub prefixes_v6: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/protocol/snapshot.rs
+++ b/userspace-dp/src/protocol/snapshot.rs
@@ -12,8 +12,8 @@ use super::nat::{
     StaticNATRuleSnapshot,
 };
 use super::security::{
-    FirewallFilterSnapshot, FlowExportSnapshot, PolicerSnapshot, PolicyRuleSnapshot,
-    ScreenProfileSnapshot, ThreeColorPolicerSnapshot,
+    AddressBookSnapshot, FirewallFilterSnapshot, FlowExportSnapshot, PolicerSnapshot,
+    PolicyRuleSnapshot, ScreenProfileSnapshot, ThreeColorPolicerSnapshot,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -189,6 +189,10 @@ pub(crate) struct ConfigSnapshot {
     pub default_policy: String,
     #[serde(default)]
     pub policies: Vec<PolicyRuleSnapshot>,
+    /// #1606: address-book table (content-hashed deduplication).
+    /// Empty on snapshots from old Go binaries (v3-additive field).
+    #[serde(rename = "address_books", default)]
+    pub address_books: Vec<AddressBookSnapshot>,
     #[serde(rename = "source_nat_rules", default)]
     pub source_nat_rules: Vec<SourceNATRuleSnapshot>,
     #[serde(rename = "static_nat_rules", default)]

--- a/userspace-dp/src/server/handlers/snapshot.rs
+++ b/userspace-dp/src/server/handlers/snapshot.rs
@@ -30,6 +30,32 @@ pub(super) fn apply(
         );
         return;
     }
+    // #1606 (AGY r2 finding 4.1): preflight policy-state validation
+    // BEFORE any guard.status mutation. If the snapshot has
+    // duplicate / zero / unknown book IDs, reject WITHOUT touching
+    // any guard fields. The existing snapshot + workers stay
+    // running on the previous good config.
+    //
+    // Uses a scratch counter store so we don't leak Arc entries on
+    // rejected snapshots.
+    {
+        let preflight_counters = crate::policy::PolicyCounterStore::default();
+        if let Err(err) = crate::policy::parse_policy_state_with_counters(
+            &snapshot.default_policy,
+            &snapshot.policies,
+            guard.afxdp.zone_name_to_id_ref(),
+            &snapshot.address_books,
+            &preflight_counters,
+        ) {
+            response.ok = false;
+            response.error = format!("snapshot integrity error: {}", err);
+            eprintln!(
+                "CTRL_REQ: apply_snapshot rejected (integrity preflight): {}",
+                err
+            );
+            return;
+        }
+    }
     eprintln!(
         "CTRL_REQ: apply_snapshot generation={} fib_generation={} forwarding_armed_before={}",
         snapshot.generation, snapshot.fib_generation, guard.status.forwarding_armed

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -188,6 +188,7 @@
     "schedulers": []
   },
   "config_snapshot": {
+    "address_books": [],
     "capabilities": {
       "forwarding_supported": false,
       "unsupported_reasons": []
@@ -662,6 +663,8 @@
     "application_terms": [],
     "applications": [],
     "destination_addresses": [],
+    "destination_book_ids": [],
+    "destination_literals": [],
     "from_zone": "",
     "inactive": false,
     "name": "",
@@ -669,6 +672,8 @@
     "rule_id": "",
     "scheduler_name": "",
     "source_addresses": [],
+    "source_book_ids": [],
+    "source_literals": [],
     "to_zone": ""
   },
   "process_status": {


### PR DESCRIPTION
## Summary

Restructure the JSON snapshot wire surface between Go xpfd and Rust userspace-dp so address-book contents live in a top-level dedup table keyed by content-hash u32 IDs, and policy rules cite books by ID instead of inlining fully-expanded CIDR strings. Foundational prerequisite for the 1M-policy JIT umbrella (#1605) — per-rule prefix-set duplication is now structurally bounded by book_count, not by rule_count.

Closes #1606.

## Wire surface

Additive on JSON protocol version 3 (NOT a version bump; serde defaults + omitempty handle missing fields, so old Go and old Rust binaries can roll forward/back freely):

- `ConfigSnapshot.address_books: Vec<AddressBookSnapshot>` (top-level).
- `PolicyRuleSnapshot.source_book_ids` / `destination_book_ids` (`Vec<u32>`).
- `PolicyRuleSnapshot.source_literals` / `destination_literals` (`Vec<String>` for free-form CIDRs operator wrote inline).
- Legacy `source_addresses` / `destination_addresses` stays as back-compat for old-Rust readers.

## Key design points

**Content-hash interning (Go side, HA-deterministic)**: book names iterated in lex sorted order before any hashing; canonical hash input has explicit V4/V6 family + count framing; buckets sorted by (hash64, canonical_bytes) for deterministic collision recovery; multiple book names with identical content share ONE row + ONE ID (diag name is lex smallest); "any" in book values normalized to (0.0.0.0/0, ::/0) at build time.

**Flat-index runtime (Rust side, Arc-free)**: `PolicyState` owns `Vec<BookEntry>`; rules carry `SmallVec<[u32; 8]>` dense indices. Worker pins `Arc<ForwardingState>` per tick via existing `load_arc_if_changed`. Hot path: `state.books[idx as usize].v4.contains(src)` — zero Arc deref, precomputed `match_any` flags short-circuit the common case.

**New `PrefixSetV4::MatchNone` variant** breaks the legacy `from_prefixes(empty) → MatchAny` convention for v3-shaped rules. New constructor `from_v3_literals` returns `MatchNone` on empty input. Closes Codex-found fail-open paths: book-only rule, family-incomplete book.

**Per-rule v3-shaped predicate**: rule is v3-shaped on a side iff `source_book_ids` OR `source_literals` is non-empty. v3-shaped sides use `from_v3_literals`; non-v3-shaped sides fall through to `source_addresses` via the legacy `from_prefixes`. Eliminates fail-open via empty=MatchAny.

**Fallible snapshot apply**: `parse_policy_state_with_counters` returns `Result<PolicyState, SnapshotIntegrityError>`. Hard-fails on id=0, duplicate book IDs, or unknown rule book references — matches the existing version-mismatch reject pattern. Preflight builds in `Coordinator::refresh_runtime_snapshot` + `reconcile/snapshot.rs::apply` happen BEFORE any side-effect (status mutation, neighbor manager keys, policy counters). On integrity error, the previous snapshot is retained.

## Plan history

Plan iterated v1→v8 across seven hostile review rounds (Codex + AGY + Claude SMR). Convergent issues closed across iterations:
- HA determinism (sort book names before hashing).
- Shim contradiction (three-field wire surface: legacy + new book IDs + new free-form literals).
- Version baseline (stays at 3; NOT a bump).
- u32 dense indices (was u16 + literal-fallback in v2).
- Content-only ID semantics (drop name from identity).
- MatchNone variant (closes empty-PrefixSet fail-open).
- "any" literal token (forces MatchAny on v3 side via explicit any_v4/any_v6 flags).
- Hash framing (explicit V4/V6 + count to prevent cross-family collisions).
- Hard-fail unknown / duplicate / zero book IDs (matches Junos compiler semantics).
- Bucket-by-canonical-content with (hash64, canonical_bytes) sort tie-break.

Plan + SMR docs live at `docs/pr/1606-wire-protocol-address-book/`.

## Test plan

- [x] Rust: 1453 tests pass (1443 baseline + 10 new). 5/5 flake check on new tests.
- [x] Go: pkg/dataplane/userspace passes including 5 new tests (stability, HA-determinism across map order, content dedup, "any" normalization, classifier).
- [x] Full Rust + Go builds clean.
- [x] Wire fixture (`protocol_wire_v1.json`) regenerated with new additive fields.
- [ ] Smoke matrix on `loss:xpf-userspace-fw0/1` (CoS-off and CoS-on, v4 + v6, push + reverse, 0-retrans gate).
- [ ] `make test-failover` ≤ 60ms.

## Followups (out of scope)

- Shim-removal PR — drops legacy `source_addresses`, bumps version to 4. Ships ≥1 release later for rollback safety.
- #1608 DIR-24-8 / sparse LPM — replaces binary trie for absolute memory-headroom gate.
- #1607 per-book reuse across snapshots — process-lifetime `BookEntry` cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)