### PR TITLE
#1626: activate oversubscription-policy in CoS smoke fixture

### DIFF
--- a/docs/pr/1626-smoke-fixture-guarantee-rate/agy-code-r1.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/agy-code-r1.md
@@ -1,0 +1,37 @@
+# AGY code review r1 — PR #1629
+
+Job: review-mppmmo99-vhww42
+
+## Verdict: MERGE-READY
+
+## Verification
+
+### Plan v2 match
+- F1 (flat-set): line 260 uses `show configuration class-of-service |
+  display set`. Match.
+- F2/F6 (single failure path): `MISSING` accumulator; single
+  `if [[ "$MISSING" -ne 0 ]]` → rollback + exit 7. Match.
+- F3 (no warning grep): compiler-warning grep removed; assertion
+  rests on durable config state. Match.
+- F5 (fixture-content gate): line 256 `grep -qE '^set
+  .*oversubscription-policy' "$CONFIG_FILE"`. Match.
+- AGY CRLF nit: line 265 `want="${want%$'\r'}"`. Match.
+
+### Shell discipline
+- All expansions quoted (`"$CONFIG_FILE"`, `"$OVERSUB_OUT"`,
+  `"$TARGET"`, `"$want"`, `"$ROLLBACK_OUT"`).
+- Process substitution `< <(...)` correctly keeps `MISSING` in
+  parent shell.
+- Trap chain cumulative; cleanup fires on any exit.
+- Rollback heredoc uses `<<'EOF'` (single-quoted) so commands aren't
+  shell-expanded before reaching the target CLI.
+
+## Residual risk
+
+CLI output drift: `grep -Fxq` is strict exact-string. If a future
+Junos CLI adds whitespace/indentation to flat-set rendering, the
+assertion could false-fail. Minor; flat-set is highly standardized.
+
+## Conclusion
+
+**MERGE-READY**.

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/agy-code-r1.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/agy-code-r1.md
@@ -1,4 +1,4 @@
-# AGY code review r1 — PR #1629
+# AGY code review r1 — PR #1629 (closes #1626)
 
 Job: review-mppmmo99-vhww42
 

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/agy-plan-r1.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/agy-plan-r1.md
@@ -1,0 +1,69 @@
+# AGY plan review r1 — #1626
+
+Job: review-mppm1lhv-1kkpmo
+
+## Verdict: PLAN-NEEDS-MAJOR
+
+## Findings
+
+### F1. Hierarchical vs. Flat CLI Output Grep Failure (Syntax / Correctness)
+
+- Plan citation: section 6 "Grep `show configuration
+  class-of-service`" + "A literal `oversubscription-policy
+  guarantee-rate 0.7` grep against `show configuration` is trivially
+  correct."
+- `cli` outputs standard hierarchical curly-brace by default. The
+  configured line serializes as:
+  ```
+  interfaces { reth0 { unit 80 { oversubscription-policy {
+    guarantee-rate 0.7; } } } }
+  ```
+- A literal single-line grep for `oversubscription-policy
+  guarantee-rate 0.7` will fail (exit 1) and trigger false-positive
+  rollback.
+- **Correction**: use `show configuration class-of-service | display
+  set` for flat-set form, or a multi-line regex.
+
+### F2. Rollback Logic Contradiction (Assertion Fail-Safe)
+
+- Plan section 6 says rollback if either fails; section 9 says only
+  if both fail.
+- Either-AND lets compiler regressions pass silently (Check B fails
+  but Check A passes → no rollback).
+- **Correction**: OR semantics; both must pass.
+
+### F3. Tight Coupling to Compiler Diagnostics
+
+- Grep-asserting the exact English warning string couples harness to
+  Go source wording.
+- Future phrasing change silently breaks harness or triggers cluster
+  rollbacks.
+- **Correction**: verify via durable state (`show configuration |
+  display set`); use generic regex if checking warnings at all.
+
+### F4. Shaping Rate and Bandwidth Calculation Discrepancy
+
+- Plan section 4 cites `pass1_budget = 0.7 × 18 = 12.6 G` from v5
+  worked example.
+- Fixture sets `shaping-rate 25g` on `reth0 unit 80`.
+- True budget at 0.7 × 25g = 17.5 Gbps, not 12.6 G.
+- **Correction**: re-do the residual-bandwidth math against actual
+  fixture parameters before declaring smoke gate expectations.
+
+### F5. Fragile Hardcoded Skip Rules
+
+- Plan section 6 skips assertion for `--same-class` and `--symmetric`
+  by flag.
+- Adding guarantee-rate to one of those fixtures later would silently
+  skip the gate.
+- **Correction**: gate by fixture content:
+  ```
+  if grep -q "oversubscription-policy" "$CONFIG_FILE"; then ...
+  ```
+
+### Residual: surplus-sharing compatibility
+
+- `--surplus-sharing` appends `surplus-sharing` to exact schedulers.
+- Combined with new `oversubscription-policy guarantee-rate` needs
+  explicit verification (compiler must accept both; runtime must
+  not panic).

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/agy-plan-r2.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/agy-plan-r2.md
@@ -1,0 +1,41 @@
+# AGY plan review r2 — #1626
+
+Job: review-mppmady0-3jml3p
+
+## Verdict: PLAN-READY
+
+All 7 r1 findings verified FIXED in v2. AGY ran `show configuration
+class-of-service | display set` on a live cluster VM (bpfrx-fw1) to
+confirm the flat-set output format matches the fixture line format
+that `grep -Fxq` will receive. Also ran `go vet ./pkg/config/...` +
+`go test ./pkg/config/...` — both green.
+
+## Per-finding verification
+
+- **F1** FIXED — live VM check confirms `| display set` produces
+  exact-line matchable output (no trailing `;` or `\r`).
+- **F2/F6** FIXED — single `MISSING=1` failure path → unified
+  rollback.
+- **F3** FIXED — warning-string grep dropped; validation anchored to
+  running config state.
+- **F4** FIXED — 0.7 × 25g = 17.5G; 10.1G of small-class rates fits
+  inside.
+- **F5** FIXED — fixture-content gate via
+  `grep -qE '^set .*oversubscription-policy' "$CONFIG_FILE"`.
+- **F7** FIXED — both §8 and §11 consistent on `pkg/config/...`.
+
+## Residual hostile checks
+
+- **A. CRLF risk**: implementer should strip `\r` from `$want` before
+  grep (`want="${want%$'\r'}"`) as a safety measure. Files on cluster
+  currently use Unix LF.
+- **B. --surplus-sharing**: the awk pass only adds scheduler-level
+  lines; the §7 grep filters source-fixture content for
+  oversubscription-policy lines and doesn't overlap. Safe.
+- **C. Trap chain**: cumulative `$OVERSUB_OUT` registration works
+  whether success or rollback path fires.
+
+## Conclusion
+
+Plan v2 is robust, mathematically consistent, and technically correct.
+**PLAN-READY**.

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/claude-smr-code-r1.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/claude-smr-code-r1.md
@@ -1,0 +1,84 @@
+# Claude SMR code review r1 — PR #1629
+
+Reviewer profile: domain SMR for Junos CoS config syntax, smoke
+harness design, measurement validity, bash discipline.
+
+## Verdict: MERGE-READY
+
+## Implementation matches plan v2
+
+### `test/incus/cos-iperf-config.set`
+One-line diff, lands directly after `shaping-rate 25g` on `reth0 unit
+80`. Syntax verified against
+`pkg/config/parser_class_of_service_test.go:936` parser test. Matches
+plan §5 ("the line goes after shaping-rate 25g").
+
+### `test/incus/apply-cos-config.sh`
+Phase-3.5 block (lines 235-296) is a faithful realization of plan §7:
+
+- **F1 (flat-set)**: line 260 uses `show configuration
+  class-of-service | display set`. Match.
+- **F2/F6 (single failure path)**: `MISSING=0` accumulator (line
+  263); any missed line sets `MISSING=1`; single
+  `if [[ "$MISSING" -ne 0 ]]` triggers rollback (line 273). No
+  conflicting branches.
+- **F3 (no warning grep)**: zero references to compiler-warning
+  string. The assertion rests entirely on round-trip config state.
+- **F5 (fixture-content gate)**: line 256 `if grep -qE '^set
+  .*oversubscription-policy' "$CONFIG_FILE"`. Match.
+- **AGY-r2 CRLF nit**: line 265 `want="${want%$'\r'}"`. Match.
+
+### Bash discipline checks (SMR)
+
+- **process substitution survival**: `done < <(grep ...)` (line 271)
+  keeps `MISSING` in the parent shell (no subshell). Correct.
+- **trap chain**: line 258 extends the cumulative trap with
+  `$OVERSUB_OUT`; line 280 further extends with `$ROLLBACK_OUT` on
+  the rollback path. Both cleanups fire on any exit. Correct.
+- **quoting**: all expansions are quoted (`"$CONFIG_FILE"`,
+  `"$OVERSUB_OUT"`, `"$want"`). No word-splitting bug.
+- **heredoc termination**: line 281 uses `<<'EOF'` (single-quoted) so
+  the rollback commands aren't subject to shell expansion. Line 287
+  terminates the heredoc. The `EOF` token is also used by the outer
+  bash heredoc in plan §7 example — verify the actual script
+  doesn't have a nested-EOF clash. Reading line 281-287: the heredoc
+  starts inside an `if` clause with `incus exec ... <<'EOF'`. There
+  is no outer heredoc in the bash script (the script itself isn't a
+  heredoc). No clash.
+- **exit codes**: existing script uses 1 (CLI not found), 4 (commit
+  check fail), 5 (commit fail post-check), 6 (Phase-3 verification
+  fail). New phase uses 7. Distinct and monotonic. Correct.
+- **`incus exec ... || true`**: on line 261 the `|| true` lets us
+  inspect the output regardless of CLI exit. The gate is on file
+  content, not exit code. Same discipline as Phase-3 (line 208).
+
+### Smoke evidence
+
+I ran the smoke directly:
+- Phase-3.5 PASSED (assertion would have triggered rollback on miss;
+  it didn't).
+- `show class-of-service interface` confirms `Guarantee: yes` on all
+  exact-rate classes — the knob IS active at runtime, not just in the
+  config tree.
+- Aggregate push 19.78 Gbps; per-class equalization ~20% confirmed
+  proportional-mode-like behaviour. Algorithm bug to be filed as
+  #1627 (per plan §7 outcome-(b)). Out of scope for this PR.
+
+## Cross-cutting
+
+- **No HA touched**: pure smoke-harness change.
+- **No Rust source touched**: snapshot field already on wire.
+- **No CoS scheduler code touched**: per scope.
+- **Plan-doc lineage**: agy-plan-r1.md, agy-plan-r2.md,
+  codex-plan-r1.md, codex-plan-r2.md, claude-smr-plan-r1.md (with
+  honest self-correction), claude-smr-plan-r2.md, plan.md (v2),
+  smoke-measurement.md, smoke-verdict.json — all committed.
+
+## Conclusion
+
+Clean, surgical, well-reviewed. Implementation matches plan v2
+exactly. Smoke ran clean. The diagnostic value is realized: the
+algorithm bug is now visible (and out of scope for this PR — #1627
+filed next).
+
+**MERGE-READY** subject to AGY code-r1 and Copilot.

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/claude-smr-code-r1.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/claude-smr-code-r1.md
@@ -1,4 +1,4 @@
-# Claude SMR code review r1 — PR #1629
+# Claude SMR code review r1 — PR #1629 (closes #1626)
 
 Reviewer profile: domain SMR for Junos CoS config syntax, smoke
 harness design, measurement validity, bash discipline.

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/claude-smr-plan-r1.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/claude-smr-plan-r1.md
@@ -1,0 +1,147 @@
+# Claude SMR plan review r1 — #1626
+
+Reviewer profile: domain SMR for Junos CoS config syntax, smoke
+harness design, measurement validity, CPU arch / SW design patterns.
+
+## Verdict: PLAN-NEEDS-MAJOR (revised from initial PLAN-READY after AGY+Codex r1)
+
+**Self-correction**: I initially rated PLAN-READY. AGY (5 findings) +
+Codex (concur on all 5 + 2 new) both correctly found PLAN-NEEDS-MAJOR
+issues I missed:
+
+- F1: `show configuration` default is hierarchical not flat-set. My
+  grep assertion would have failed in real use. I claimed it was
+  "trivially correct" without verifying CLI output format. Bad call.
+- F2: Plan body has BOTH "rolls back if either fails" (§6) and "only
+  roll back if both fail" (§9) — direct contradiction I should have
+  caught on re-read.
+- F4: I cited `0.7 × 18 = 12.6 G` but the fixture's shaping-rate is
+  25g; budget is 17.5 G. Math copy-pasted from #1614 v5 worked example
+  without re-anchoring to actual fixture parameters.
+- F5: Hard-coded flag skip is fragile and couples logic to fixture
+  names.
+- F6 (Codex new): the "belt-and-suspenders" mitigation is backwards.
+  Same root as F2.
+- F7 (Codex new): test plan §11 mentions `go vet` but §8 only lists
+  `go test`.
+
+I move my verdict to **PLAN-NEEDS-MAJOR concurring with AGY+Codex**.
+SMR-plan-r2 will verify v2 addresses all 7 findings.
+
+## Original-r1 verdict (kept for record): PLAN-READY (non-blocking refinements)
+
+## Evidence — what I verified directly
+
+1. **Bug exists on master**.
+   `grep oversubscription test/incus/cos-iperf-config.set` returns no
+   match. The fixture currently has zero lines that activate the new
+   knob. The compiler path at
+   `pkg/config/compiler_class_of_service.go:339-380` only sets
+   `unit.OversubscriptionPolicy` if the `oversubscription-policy` node
+   exists. Absent that node, `unit.OversubscriptionPolicy == ""` which
+   the compiler treats as `proportional (default)`
+   (`pkg/config/compiler.go:1097`). So PR #1618's smoke was indeed
+   measuring proportional mode regardless of the new wire surface.
+
+2. **Junos syntax is correct**.
+   `pkg/config/parser_class_of_service_test.go:936` uses precisely
+   `set class-of-service interfaces ge-0/0/2 unit 80
+   oversubscription-policy guarantee-rate 0.7` and asserts the typed
+   config picks it up. The parser FLAT path
+   (`compiler_class_of_service.go:340-356`) handles
+   `Keys[1]=="guarantee-rate"`, `Keys[2]==<float>` which is exactly
+   what `ParseSetCommand` produces from the proposed line. Interface
+   name `reth0` vs `ge-0/0/2` is irrelevant — the lookup is by string
+   in `cos.Interfaces` map, the policy is keyed off the unit
+   sub-struct.
+
+3. **0.7 is the right fraction**.
+   `docs/pr/1614-multi-rss-cos/plan.md:300` uses 0.7 as the worked
+   example (`pass1_budget = 0.7 × 18 = 12.6 G`). The plan v5
+   acceptance criteria gate 1 (small classes ≥ 95%) was sized for 0.7.
+   The compiler warning text at
+   `pkg/config/compiler.go:1100` is `guarantee-rate %g`, so 0.7 emits
+   literal `guarantee-rate 0.7` which Phase-3.5 assertion can grep
+   for.
+
+4. **Compiler warning fires unconditionally on this fixture**.
+   The fixture sum of exact-class rates is
+   100m+1g+3g+6g+9g+12g+15g+18g+21g+24g = 109g (omitting BE +
+   uncapped which aren't `exact`). Shaping-rate is 25g. 109g > 25g →
+   warning fires unconditionally. The Phase-3.5 (B) check on the
+   warning is robust.
+
+5. **Phase-3.5 (A) assertion is robust**.
+   `show configuration class-of-service` is a round-trip serialization
+   of the active config tree. The fixture line we add will appear
+   verbatim in that output (per Junos CLI convention — verified by
+   reading `pkg/cli/cli.go:245-246` + `showConfigurationSubPath`).
+   Trivially correct as an assertion.
+
+6. **--same-class and --symmetric fixtures aren't broken**.
+   The plan correctly notes the assertion is gated on the chosen
+   fixture. Inspecting the apply script lines 64-72 (the
+   `CONFIG_FILE` selector): the new Phase-3.5 assertion can be guarded
+   by `if [[ "$SAME_CLASS" -eq 0 && "$SYMMETRIC" -eq 0 ]]` so the two
+   alternate fixtures don't trigger it. The plan's section 6 calls
+   this out; the implementer needs to remember to actually gate it.
+
+7. **Smoke harness gates 1+2 are designed for guarantee-rate mode**.
+   `cos-simul-load-smoke.sh:179-198` comments say "if guarantee-rate
+   mode active, each [small class] should hit ≥ 95% of rate" — gate 1
+   pre-supposes the knob is on. Gate 2 is "priority-low ≥ 5% of
+   cluster ceiling" — also a guarantee-rate-specific bound. So the
+   existing gate logic is the RIGHT downstream check; we don't need
+   to change it.
+
+## Issues / refinements
+
+### r1.1 (NIT, non-blocking) — assertion gating must be implementation-explicit
+
+Plan section 6 says "Skip the assertion for the `--same-class` and
+`--symmetric` fixtures". Make sure the actual implementation uses a
+bash `if` on `$SAME_CLASS`/`$SYMMETRIC` AROUND the new assertion, not
+just a comment. Otherwise a future `--same-class` operator would hit
+spurious rollback. I'll verify this in code-review r1.
+
+### r1.2 (NIT, non-blocking) — assertion should run BEFORE the existing rollback decision
+
+The existing Phase-3 check (line 187-203) is "if no shaper/scheduler
+match → rollback". The new Phase-3.5 must run after Phase-3 passed,
+NOT before, to preserve the existing safety net for the broader case.
+Plan section 6 says "after the existing grep" — good, just confirm
+ordering in the diff.
+
+### r1.3 (MINOR observation, no action required)
+
+The `show class-of-service interface` presenter at
+`pkg/dataplane/userspace/cosfmt.go:74-200` does NOT render
+oversubscription-policy. That's the right call for #1626 scope —
+adding it to the presenter is a separate UX issue. But it means
+operators who run `show class-of-service interface` today can't see
+the active policy. Worth a follow-up issue (NOT in this PR).
+
+## Cross-cutting considerations
+
+- **HA peer state**: VRRP/RG sync replicates the config — the
+  secondary will pick up the same policy line after commit. No HA
+  concern.
+- **Apply-script atomicity**: the existing two-phase commit-check +
+  commit pattern is preserved. The Phase-3.5 verification runs AFTER
+  commit succeeded, so a Phase-3.5 failure triggers `rollback 1 |
+  commit` per the existing safety net.
+- **Smoke serialization**: cluster shared with #1620+#1621, #1623
+  Path B. Coordinate via AWAITING-BATCH-MERGE marker if smoke contention.
+- **Failure mode if Phase-3.5 catches a regression**: rollback brings
+  the cluster back to whatever was committed before. Existing Phase-3
+  rollback hook covers this; new assertion just adds a second
+  trigger.
+
+## Conclusion
+
+Plan is sound and the scope is honest. The runtime change is zero LOC,
+the diagnostic value is high (it determines whether #1614 step-1 was
+a real regression or a measurement bug). I will verify the two
+implementation NITs (r1.1 gating + r1.2 ordering) at code-review time.
+
+**PLAN-READY** pending Codex + AGY concur.

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/claude-smr-plan-r2.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/claude-smr-plan-r2.md
@@ -1,0 +1,103 @@
+# Claude SMR plan review r2 — #1626
+
+Plan v2 review. Verify each of the 7 r1 findings is actually
+addressed by v2 design, not just declared addressed.
+
+## Verdict: PLAN-READY pending AGY+Codex r2 concur
+
+## Per-finding verification
+
+### F1 (hierarchical vs flat) — addressed
+v2 §7 explicitly uses `show configuration class-of-service | display
+set` (line 11 of the bash block) and a `grep -Fxq` fixed-string
+exact-line match. The CLI in this repo recognizes `| display set`
+because the same idiom is used by the existing tooling (verified
+earlier: `pkg/configstore/...ShowActivePathSet` etc.). Match.
+
+### F2 (rollback contradiction) — addressed
+v2 §7 has a SINGLE failure path: any line in the fixture matching
+`^set .*oversubscription-policy` that does not also appear in the
+running config triggers `MISSING=1` → rollback. §9 risk section
+matches this. No contradiction.
+
+### F3 (compiler warning grep coupling) — addressed
+v2 §7 contains no `grep` of the compiler warning string. The §6
+discussion of v1 has been dropped from v2 design; verification rests
+entirely on round-trip flat-set output. Match.
+
+### F4 (math wrong) — addressed
+v2 §6 explicitly distinguishes:
+- `shaping-rate 25g` (configured shaper),
+- `pass1_budget = 0.7 × 25g = 17.5g` (correct),
+- ~18 G NIC ceiling under simul-load (an OBSERVATIONAL bound, not
+  algorithm input).
+This is the right framing. The smoke gate-1 outcome
+(small classes honoured) is preserved qualitatively.
+
+### F5 (hard-coded flag skip) — addressed
+v2 §7 gates by:
+```bash
+if grep -qE '^set .*oversubscription-policy' "$CONFIG_FILE"; then
+  FIXTURE_HAS_OVERSUB=1
+fi
+```
+This is fixture-content driven. `--same-class`/`--symmetric` skip
+automatically; future fixtures that add the knob get gated unchanged.
+Match.
+
+### F6 (belt-and-suspenders backwards) — addressed
+Same root as F2. v2 §7's single failure path solves both. Match.
+
+### F7 (go vet/go test inconsistency) — addressed
+v2 §8 first bullet now lists `go vet ./pkg/config/...`; §11 first
+bullet says `go vet ./pkg/config/... && go test ./pkg/config/...`.
+Same command, both sections. Match.
+
+## Cross-cutting verification (new SMR checks)
+
+### SMR-1: heredoc pattern correctness
+The bash `done < <(grep ...)` process-substitution-with-while pattern
+in §7 is the canonical way to iterate command output without
+subshelling (so MISSING survives the loop). Correct.
+
+### SMR-2: trap chain
+§7 extends the trap chain with `OVERSUB_OUT`. Existing trap chain in
+apply-cos-config.sh already uses cumulative `trap "rm -f $A $B $C
+..."` — implementer must follow that pattern. Plan says "Phase 3.5"
+which fits between existing Phase-3 and the final success echo.
+
+### SMR-3: `incus exec ... -c "show configuration..."` exit code
+The `|| true` after the incus invocation is correct because the CLI
+may return non-zero on some edge cases (e.g., empty section). The
+gate is on output content, not exit code, which is the right
+discipline.
+
+### SMR-4: surplus-sharing interaction
+v2 §9 calls out that surplus-sharing awk pass appends NEW lines
+(scheduler-level) and doesn't transform the oversubscription line
+(unit-level). The two knobs live on different config subtrees
+(`schedulers.<name>` vs `interfaces.<if>.units.<u>`). Compiler
+accepts both independently (verified via
+parser_class_of_service_test.go). No interaction.
+
+### SMR-5: `display set` output format includes the leading `set`
+The flat-set form of a config tree starts with `set` per Junos
+convention. `grep -Fxq` (fixed-string exact-line) will match the
+fixture line verbatim. Implementer should also ensure the fixture
+line doesn't have trailing whitespace.
+
+### SMR-6: parser interface name normalization
+Junos accepts `ge-0/0/2` in display syntax but the fixture uses
+`reth0`. `show configuration | display set` always emits the form
+the operator typed (verified by reading
+`pkg/configstore/ShowCandidatePathSet` chain: returns the
+canonical-set representation of the AST). Round-trip identical.
+
+## Conclusion
+
+Plan v2 addresses all 7 r1 findings cleanly. The §7 design is
+considerably more robust than v1: durable contract (round-trip
+flat-set), single failure path, dynamic gating, no compiler-message
+coupling. The math in §6 is now correct.
+
+**PLAN-READY** subject to AGY+Codex r2 concur.

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/codex-code-r1.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/codex-code-r1.md
@@ -1,4 +1,4 @@
-# Codex code review r1 — PR #1629
+# Codex code review r1 — PR #1629 (closes #1626)
 
 ## Findings
 

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/codex-code-r1.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/codex-code-r1.md
@@ -1,0 +1,30 @@
+# Codex code review r1 — PR #1629
+
+## Findings
+
+FINDING 1 (none): No blocking code-review findings. The two-file diff
+matches plan v2 §6+§7: fixture enables `guarantee-rate 0.7` on `reth0
+unit 80`, and Phase-3.5 dynamically checks every fixture
+`oversubscription-policy` set line against `show configuration
+class-of-service | display set`.
+
+FINDING 2 (none): Bash structure looks sound. `done < <(grep ...)` is
+valid process substitution, quoted variables are safe, `grep -Fxq
+"$want"` avoids regex/substring false passes, and CRLF trimming is
+scoped to the expected fixture line.
+
+FINDING 3 (none): Failure handling is not silent. A missing
+round-trip line prints the expected line, dumps the flat running CoS
+config, attempts `rollback 1` + `commit`, warns loudly if rollback
+fails, and exits `7`.
+
+FINDING 4 (none): Phase-3.5 is placed after Phase 3's existing
+CoS-live verification and its `exit 6` failure path, so it only runs
+after the prior live CoS check has passed.
+
+FINDING 5 (none): Smoke evidence shows the scheduler still behaves
+proportionally under the now-active knob, but that is explicitly
+documented as out of scope for this surgical PR and is the point of
+making the fixture exercise the branch.
+
+## VERDICT: MERGE-READY

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/codex-plan-r1.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/codex-plan-r1.md
@@ -1,0 +1,35 @@
+# Codex plan review r1 — #1626
+
+Codex was given the AGY findings inline and asked to concur/dispute
+each, plus add anything missed.
+
+## Findings
+
+F1: concur — the plan says the line should appear verbatim in `show
+configuration class-of-service`, but if that command emits hierarchical
+config, the literal flat-set grep is not robust.
+
+F2: concur — section 6 says rollback if either assertion fails, while
+section 9 says only if both fail; for a required Phase-3.5 gate this
+must be OR.
+
+F3: concur — requiring the compiler warning text makes the harness
+depend on diagnostic wording rather than durable behavior.
+
+F4: concur — the plan's cited worked example uses 18G, but this
+fixture's stated shaping-rate is 25g, so `0.7` implies 17.5G.
+
+F5: concur — skipping by `--same-class`/`--symmetric` bakes fixture
+names into logic; the assertion should key off whether the applied
+fixture actually contains the guarantee-rate line.
+
+NEW F6 (major): section 9's "belt-and-suspenders" mitigation is
+backwards: requiring both A and B to fail would let parser/config or
+compiler acceptance regressions pass silently when only one assertion
+fails.
+
+NEW F7 (minor): test plan includes `go vet ./...`, but section 8 only
+lists `go test ./pkg/config/...`; validation scope is inconsistent and
+should be made explicit.
+
+## VERDICT: PLAN-NEEDS-MAJOR

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/codex-plan-r2.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/codex-plan-r2.md
@@ -1,0 +1,27 @@
+# Codex plan review r2 — #1626
+
+## Findings
+
+F1: addressed-yes — §7 uses `show configuration class-of-service |
+display set` before exact-line matching.
+
+F2: addressed-yes — §7 has one failure path: missing expected line
+triggers rollback and exits 7.
+
+F3: addressed-yes — §7 drops warning-string grep and checks only
+running flat-set config.
+
+F4: addressed-yes — §6 explicitly uses 25g shaping and computes
+`0.7 × 25g = 17.5g`.
+
+F5: addressed-yes — §7 gates on fixture content via
+`grep -qE '^set .*oversubscription-policy' "$CONFIG_FILE"`, not mode
+flags.
+
+F6: addressed-yes — §7 defines a single durable round-trip assertion
+and rollback path, with no backwards belt-and-suspenders mitigation.
+
+F7: addressed-yes — §8 and §11 both require `go vet ./pkg/config/...`
+and `go test ./pkg/config/...`.
+
+## VERDICT: PLAN-READY

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/plan.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/plan.md
@@ -3,232 +3,269 @@
 Branch: `fix/1626-smoke-fixture-guarantee-rate`
 Base: `origin/master` @ `4ac85e2fd`
 
+## Revision history
+
+- **v1** — initial plan; PLAN-NEEDS-MAJOR by AGY+Codex+Claude SMR.
+  Findings F1-F7 (see `agy-plan-r1.md`, `codex-plan-r1.md`,
+  `claude-smr-plan-r1.md`).
+- **v2** (this version) — addresses all 7 findings; tightens
+  assertion semantics, fixes math, gates by fixture content.
+
 ## 1. Problem statement
 
-The simul-load smoke harness shipped in PR #1618 (#1614 step-1) reports
-per-class equalization (~20%/class). I framed that as evidence the
-waterfill scaffold doesn't change distribution. The #1625 PLAN-KILL
-quad-review surfaced the real explanation: **the fixture itself
-doesn't activate the `guarantee-rate` knob it was supposed to test**.
+The simul-load smoke harness shipped in PR #1618 (#1614 step-1)
+reports per-class equalization (~20%/class). The #1625 PLAN-KILL
+quad-review surfaced the cause: **the fixture itself doesn't activate
+the `guarantee-rate` knob it was supposed to test**.
 
 Concrete bug — `test/incus/cos-iperf-config.set` on master:
 ```
 $ grep -n "oversubscription" test/incus/cos-iperf-config.set
-$ # empty — the line that opts the unit into guarantee-rate mode
-$ # is missing
+$ # empty — the policy line is missing
 ```
 
 Without `set class-of-service interfaces reth0 unit 80
 oversubscription-policy guarantee-rate <X>`, the compiler defaults to
-`proportional` mode (see `pkg/config/compiler_class_of_service.go:339`
-+ `pkg/config/compiler.go:1097-1108`). So the entire #1614 step-1
-measurement was testing the pre-existing proportional path — same as
-master before the wire surface shipped. The waterfill scaffold's
-runtime branch never executed under the smoke.
+`proportional` (see `pkg/config/compiler_class_of_service.go:339-380`
++ `pkg/config/compiler.go:1097-1108`). The #1614 step-1 smoke was
+measuring proportional mode — same as master before the wire surface
+shipped. The waterfill branch never executed under smoke.
 
 ## 2. Scope
 
-**In-scope (small surgical fixture+harness change):**
-1. Add one `set` line to `test/incus/cos-iperf-config.set` that
-   activates `guarantee-rate 0.7` on `reth0 unit 80` (the unit the
-   fixture already targets via `shaping-rate 25g` + `scheduler-map
-   bandwidth-limit`).
-2. Add a runtime-assertion in `apply-cos-config.sh` (post-apply) that
-   verifies the running config actually has `oversubscription-policy
-   guarantee-rate` set. Catches future regressions of "fixture forgot
-   the knob" + parser drops + dataplane fails to apply.
-3. Run the smoke and document the per-class distribution under the
-   activated knob in the PR body.
+**In-scope:**
+1. Add one line to `test/incus/cos-iperf-config.set` that activates
+   `guarantee-rate 0.7` on `reth0 unit 80`.
+2. Add a Phase-3.5 assertion to `test/incus/apply-cos-config.sh`:
+   - Use `show configuration class-of-service | display set` for flat
+     form (F1 fix).
+   - Gate the assertion on whether the chosen fixture actually
+     contains an `oversubscription-policy` line — fail loudly if so
+     (F5 fix).
+   - Assertion semantics: **the policy line MUST appear** in
+     post-commit flat-set output. That's the entire gate (F2/F3/F6
+     fix — drop the fragile compiler-warning grep).
+3. Run the smoke and document before/after per-class distribution
+   in the PR body.
 
 **Out of scope (per issue body + memory):**
 - `userspace-dp/src/afxdp/cos/queue_service/mod.rs` Phase-2 lock-in
   bug from #1625 kill — separate issue (file #1627 if needed).
-- `shared_cos_lease/rotate_epoch_v8.rs` lease scheduling.
-- Any new trace-counter instrumentation — that's #1628's territory.
-- Multi-RSS multi-core CoS architecture — #1614 umbrella.
-- Adding `oversubscription-policy` rendering to `show class-of-service
-  interface` (separate UX issue; we use `show configuration
-  class-of-service` or the commit warning for the assertion).
+- `shared_cos_lease/rotate_epoch_v8.rs`.
+- Trace-counter instrumentation (#1628 territory).
+- Multi-RSS multi-core CoS architecture (#1614 umbrella).
+- Adding oversubscription-policy rendering to `show class-of-service
+  interface` (separate UX issue).
 
 ## 3. Honest value framing
 
-- **LOC**: ~2 lines in `cos-iperf-config.set` (the policy line + maybe
-  a blank for grouping), ~6-10 lines in `apply-cos-config.sh` for the
-  verification step.
-- **Runtime code change**: 0 LOC. The wire surface, parser, compiler
-  warning, and runtime are unchanged.
-- **Diagnostic value**: HIGH. This is the gate that determines
-  whether the #1614 step-1 ship is a measurement bug (and the
-  algorithm works once the knob is on) OR the algorithm is broken in
-  the way #1625 reviewers suspected (Phase-2 lock-in at
-  queue_service/mod.rs:889-893; worker_fair_share math). The next-
-  priority bug fix (#1627) only makes sense after this fixture fix
-  produces a clean before/after measurement.
+- **LOC**: ~1 line in `cos-iperf-config.set`; ~15-25 lines in
+  `apply-cos-config.sh` for the gated assertion + helper.
+- **Runtime code change**: 0 LOC.
+- **Diagnostic value**: HIGH. Determines whether #1614 step-1 was a
+  measurement bug (algorithm works once knob is on) OR the algorithm
+  is broken (Phase-2 lock-in / worker_fair_share math).
 
 ## 4. Junos syntax — verified
 
-Confirmed against `pkg/config/parser_class_of_service_test.go:936`
-(`TestValidateCoSOversubscriptionWarningGuaranteeRate`):
+`pkg/config/parser_class_of_service_test.go:936`
+(`TestValidateCoSOversubscriptionWarningGuaranteeRate`) uses exactly:
 ```
 set class-of-service interfaces ge-0/0/2 unit 80 oversubscription-policy guarantee-rate 0.7
 ```
 
-Our fixture uses the RETH form (`reth0` not `ge-0/0/2`), unit 80.
-Compiler accepts both interface name forms (`reth0` literal lookup in
-`cos.Interfaces`).
-
-**Fraction choice**: 0.7 per the #1614 plan v5 worked example
-(`docs/pr/1614-multi-rss-cos/plan.md:300` — `pass1_budget = 0.7 × 18 =
-12.6 G`). This matches what the v5 acceptance criteria expects the
-distribution to look like, so the smoke harness gate 1 (small classes
-≥ 95% of configured rate) is the correct downstream check.
+Our fixture uses RETH form `reth0`. Interface lookup is by string
+key in `cos.Interfaces`; same code path.
 
 ## 5. Where the line goes in the fixture
 
-The existing fixture sets per-interface CoS on `reth0 unit 80`:
+Existing fixture sets per-interface CoS on `reth0 unit 80`:
 ```
 set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit
 set class-of-service interfaces reth0 unit 80 shaping-rate 25g
 ```
-I add the policy line directly after `shaping-rate 25g`:
+
+We add the policy line directly after `shaping-rate 25g`:
 ```
 set class-of-service interfaces reth0 unit 80 oversubscription-policy guarantee-rate 0.7
 ```
 
-This is the same unit/interface tuple the rest of the fixture targets,
-and the policy lives on the unit struct (`pkg/config/types.go:556`),
-so attaching it here is parser-correct.
+## 6. Fraction choice (F4 fix — math re-anchored to 25g shaping)
 
-## 6. Runtime assertion in `apply-cos-config.sh`
+**Fraction**: 0.7. Same numerical choice as v5 plan but the worked
+example must be re-anchored to the actual fixture parameters:
 
-Current Phase 3 verification (lines 167-180) greps `show
-class-of-service interface` for `shaper|scheduler|traffic-control-
-profile|output.*traffic`. That doesn't catch the missing-knob bug
-because the scheduler bindings still show up — the policy lives on a
-different (oversubscription) path that the show-interface presenter
-doesn't render today.
+- Fixture `shaping-rate = 25g` on `reth0.80` (NOT 18g — that was the
+  push-direction ceiling assumption from the v5 plan, not the
+  configured shaping-rate).
+- `pass1_budget = 0.7 × 25g = 17.5g` (NOT 12.6 G).
+- Sum of small-class rates (100m + 1g + 3g + 6g = 10.1 G) fits well
+  under 17.5 G → small classes fully honoured in Phase 1.
+- Sum of mid-class rates that fit under 17.5 G - 10.1 G = 7.4 G
+  residual: depending on order, 9g class might fit partially.
 
-Two viable assertion points:
+The push-direction ceiling under simul-load is ~18 G (NIC + waterfill
+overhead), but the configured shaper allows up to 25 G. The
+guarantee-rate algorithm computes budgets against the configured
+shaper (25 G), then the actual achieved throughput is bounded by the
+NIC + waterfill ceiling. So the Phase-1 budget calculation uses 25 G;
+the smoke's observed distribution will be bounded by ~18 G aggregate.
 
-A. **Grep `show configuration class-of-service`** — the canonical
-   round-trip serialization. The line we just set should appear
-   verbatim. Robust because it doesn't depend on any presenter
-   surface.
+What we expect at smoke time under guarantee-rate 0.7:
+- Small classes (100m, 1g, 3g, 6g) all sum to 10.1 G ≪ 17.5 G budget,
+  so each should be at or near its configured rate (gate 1: ≥ 95%).
+- Large classes (9g+) share residual ≈ (NIC ceiling 18 G - 10.1 G) =
+  7.9 G across remaining classes proportionally.
 
-B. **Grep the commit warning output** —
-   `pkg/config/compiler.go:1097-1108` emits a one-line warning of the
-   form `class-of-service interfaces reth0 unit 80: ... configured
-   oversubscription-policy=guarantee-rate 0.7: ...`. But this requires
-   capturing the commit transcript; the existing Phase-2 apply uses
-   `> "$APPLY_OUT" 2>&1` so the transcript is already on disk.
+This differs from the v5-plan A1.2 table (which presumed 18 G shaper)
+but the qualitative gate-1 outcome is preserved: under
+guarantee-rate, small classes are honoured.
 
-Choice: **(A) + (B) belt-and-suspenders**. (A) verifies the
-config-tree was set (catches parser/CLI bugs). (B) verifies the
-compiler accepted it and emitted the warning (catches compiler
-regressions). If either fails the apply rolls back per the existing
-Phase-3 rollback hook.
+## 7. Runtime assertion in `apply-cos-config.sh`
 
-The assertion is added as a new Phase-3.5 step after the existing
-`shaper|scheduler|traffic-control-profile` grep, so we don't
-regress the existing check. Skip the assertion for the `--same-class`
-and `--symmetric` fixtures which don't (yet) set guarantee-rate.
+Single-rule assertion (F2/F3/F6 fix — collapse to one durable check):
 
-## 7. Smoke flow and what we expect to see
+After Phase 3's existing `show class-of-service interface` grep:
 
-After deploy + apply with the fixed fixture:
+```bash
+# Phase 3.5: if the chosen fixture activates a guarantee-rate (or
+# other oversubscription-policy) line, the running config MUST round-
+# trip with that line present. Gate dynamically on the fixture
+# content; do NOT couple to flag names.
 
-1. **Pre-condition check** (in the apply script):
-   - `show configuration class-of-service` contains `oversubscription-
-     policy guarantee-rate 0.7`. PASS expected.
-   - Apply transcript contains the
-     `oversubscription-policy=guarantee-rate 0.7` compiler warning.
-     PASS expected (sum of exact-rates 109g > shaping-rate 25g per
-     existing fixture, so the warning ALWAYS fires).
+FIXTURE_HAS_OVERSUB=0
+if grep -qE '^set .*oversubscription-policy' "$CONFIG_FILE"; then
+  FIXTURE_HAS_OVERSUB=1
+fi
 
-2. **Smoke run**:
-   `./test/incus/cos-simul-load-smoke.sh push` →
-   capture `verdict.json`. Compare `recv_gbps` per class against the
-   broken-baseline measurement from PR #1618 (also ~20%/class).
+if [[ "$FIXTURE_HAS_OVERSUB" -eq 1 ]]; then
+  OVERSUB_OUT=$(mktemp)
+  trap "rm -f '$SETS_TMP' '$CHECK_OUT' '$APPLY_OUT' '$VERIFY_OUT' '$OVERSUB_OUT'" EXIT
+  incus exec "$TARGET" -- /usr/local/sbin/cli -c \
+    "show configuration class-of-service | display set" \
+    > "$OVERSUB_OUT" 2>&1 || true
 
-3. **Two possible outcomes:**
-   - **Algorithm works**: distribution shifts. Small classes (100m/1g/
-     3g/6g) honoured to ≥ 95% (gate 1 passes). Large classes share
-     residual proportionally. iperf-uncapped ≥ 5% of ceiling (gate 2).
-     → confirms #1625 kill was correct; no new scheduler mechanism
-     needed.
-   - **Algorithm still equalizes**: distribution unchanged. Small
-     classes still get their proportional ~20% share. → confirms one
-     of #1625's other findings (queue_service/mod.rs:889-893 Phase-2
-     lock-in OR worker_fair_share math). File #1627 with the
-     measurement evidence as the next-priority fix.
+  # Extract the canonical fixture lines that match
+  # ^set .*oversubscription-policy and confirm each appears in the
+  # running flat-set output. Strict line-match means parser drops,
+  # compiler regressions, and applied-but-not-persisted bugs all
+  # surface here.
+  MISSING=0
+  while IFS= read -r want; do
+    if ! grep -Fxq "$want" "$OVERSUB_OUT"; then
+      echo "error: fixture line missing from running config:" >&2
+      echo "  expected: $want" >&2
+      MISSING=1
+    fi
+  done < <(grep -E '^set .*oversubscription-policy' "$CONFIG_FILE")
 
-The PR body documents WHICHEVER outcome we get. The PR is
-"diagnostic-fixture-correctness" not "fix-the-scheduler", so we ship
-the fixture fix + measurement regardless of which outcome.
+  if [[ "$MISSING" -ne 0 ]]; then
+    echo "error: Phase-3.5 oversubscription-policy verification FAILED" >&2
+    echo "rolling forward with 'rollback 1 | commit'..." >&2
+    incus exec "$TARGET" -- /usr/local/sbin/cli > /dev/null 2>&1 <<'EOF' || true
+configure
+rollback 1
+commit
+exit
+quit
+EOF
+    exit 7
+  fi
+fi
+```
 
-## 8. Test plan
+Properties of this design:
 
-- **Go**: `go test ./pkg/config/...` — should be unaffected; we
-  already have `TestValidateCoSOversubscriptionWarningGuaranteeRate`
-  exercising the exact line we add.
-- **Rust**: `cargo build --release` in `userspace-dp/` — no Rust
-  changes; smoke check only.
-- **Apply script unit-ish**: run the modified
-  `apply-cos-config.sh` against the smoke cluster fw0 and confirm:
-  - Existing Phase-3 check still PASSes
-  - New Phase-3.5 check PASSes with the fixed fixture
-  - New Phase-3.5 check FAILs (and rolls back) if we temporarily
-    remove the new line from the fixture (manual sanity)
-- **Cluster smoke (loss userspace)**: deploy → apply → run
-  `cos-simul-load-smoke.sh push` → capture verdict.json → diff
-  per-class achievement vs broken-baseline.
+- **F1 fix**: uses `| display set` for flat-set form so a literal
+  `grep -Fxq` will match.
+- **F2/F6 fix**: single failure path — any missing fixture line
+  triggers rollback. No two-mode contradiction.
+- **F3 fix**: dropped the compiler-warning grep entirely. The
+  running config tree is the durable contract.
+- **F5 fix**: assertion is dynamically gated on whether
+  `$CONFIG_FILE` contains `oversubscription-policy` lines. So
+  `--same-class` (no such lines) skips automatically; if a future
+  operator adds the knob to symmetric/same-class, the gate fires
+  unchanged.
+- **No false positives on `--surplus-sharing`**: surplus-sharing
+  appends `set ... surplus-sharing` lines after the awk pass, but
+  this assertion only looks at `oversubscription-policy` lines —
+  surplus-sharing doesn't intersect.
 
-## 9. Risk assessment
+The gate uses `grep -Fxq` (fixed-string exact-line) so whitespace
+and partial matches can't false-pass.
 
-- **Rollback risk**: the new Phase-3.5 assertion adds a NEW
-  rollback trigger. If the assertion is wrong (false-positive),
-  we'd roll back a good config. Mitigation: belt-and-suspenders
-  (A+B); only roll back if BOTH fail. A literal `oversubscription-
-  policy guarantee-rate 0.7` grep against `show configuration` is
-  trivially correct.
-- **Fixture compatibility**: adding the line shouldn't break the
-  existing fixture for any other consumer. The line is OPT-IN and
-  only fires the warning + activates the guarantee-rate branch when
-  sum_exact > shaping_rate (already true here).
-- **Smoke harness gate drift**: the existing
-  `cos-simul-load-smoke.sh` push-direction gates 1+2 were written
-  for the guarantee-rate path. Activating the knob ENABLES them to
-  pass — not breaks them. If they don't pass, that's diagnostic
-  signal not regression.
+## 8. Test plan (F7 fix — explicit + consistent)
 
-## 10. Open questions for reviewers
+- **Go**:
+  - `go vet ./pkg/config/...` (consistent with §11)
+  - `go test ./pkg/config/...` — should be green unaffected; the
+    parser already has
+    `TestValidateCoSOversubscriptionWarningGuaranteeRate` covering
+    the syntax we add.
+- **Rust**: no Rust source changes. `cargo build --release` in
+  `userspace-dp/` is a sanity check only — the daemon must accept
+  the new snapshot field, which it already does (#1614 step-1
+  wire surface).
+- **Apply script bench**: manually run
+  `./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0` with
+  the v2 fixture; confirm:
+  - Existing Phase-3 grep still PASSes.
+  - New Phase-3.5 grep PASSes.
+  - Temporarily delete the oversubscription line from the fixture
+    and confirm the gate FAILs (rollback fires).
+- **Cluster smoke** (loss userspace): deploy → apply → run
+  `cos-simul-load-smoke.sh push` → diff per-class table against
+  PR #1618 broken-baseline.
 
-1. **Fraction value** — 0.7 per the v5 worked example, or different
-   number? 0.7 keeps small classes fully honoured and gives large
-   classes their fair share of residual. Lower (0.4) would be a
-   harsher test of the algorithm; higher (0.9) is less interesting.
-   Decision: **0.7** — matches plan v5 worked example, harness gate 1
-   thresholds, and the warning string the existing parser test
-   asserts.
-2. **Where to put the assertion** — apply script (entry point) vs
-   smoke harness (consumer)? Apply is better: it catches both
-   smoke-harness use AND any future use of the fixture by another
-   harness (failover, surplus-sharing diagnostic, etc.). Decision:
-   **apply script**.
-3. **Symmetric/same-class fixtures** — should they also activate
-   guarantee-rate? Out of scope for #1626. Those fixtures target
-   different test purposes (mirror-flow CoS coherence in #1250,
-   same-class echo override in #929). If/when their tests need
-   guarantee-rate they'll get their own fixture lines. The Phase-3.5
-   assertion gates on the chosen fixture, not all of them.
+## 9. Risk
+
+- **Phase-3.5 false-positive**: gated dynamically on fixture
+  content with strict exact-line `grep -Fxq`; the only way to
+  false-fail is if the running-config flat-set output drifts from
+  the fixture line (parser drops, compiler regression, daemon
+  apply failure). All three are real bugs we WANT to catch.
+- **Rollback safety**: assertion failure triggers the existing
+  `rollback 1 | commit` path, same as Phase-3.
+- **Fixture compatibility**: assertion is opt-in via fixture
+  content, so `--same-class`/`--symmetric` are not affected. If
+  `--surplus-sharing` is combined with this fixture, the
+  surplus-sharing awk pass appends NEW lines but doesn't remove
+  or transform the oversubscription line — the gate still passes
+  because the line is still present in `$CONFIG_FILE` and in the
+  running config.
+
+## 10. Open questions (now closed by v2)
+
+1. Fraction value → **0.7**, math re-anchored to 25g.
+2. Assertion location → **apply-cos-config.sh** (entry point).
+3. Symmetric/same-class fixtures → **auto-skipped via content gate**.
+4. Compiler warning grep → **dropped** (F3 fix).
+5. Rollback semantics → **single failure path** (F2/F6 fix).
 
 ## 11. Rollout / sequence
 
-- Implement: ~2 line .set + ~10 line apply assertion.
-- Build: `go vet ./...` + `go test ./pkg/config/...`.
-- Smoke: deploy + apply on loss:xpf-userspace-fw0 + run
+- Implement: 1-line `.set` change + ~25-line apply-script
+  assertion.
+- Build: `go vet ./pkg/config/... && go test ./pkg/config/...`
+  (consistency with §8).
+- Smoke: deploy + apply on `loss:xpf-userspace-fw0` + run
   `cos-simul-load-smoke.sh push` (+ optionally reverse). Capture
-  verdict.json + per-class table.
-- PR: body MUST include before/after per-class table and the verdict.
-- Auto-merge gate: 4-of-4 reviewer attestation (Codex + AGY + Copilot
-  + Claude SMR) + smoke pass on the loss userspace cluster.
+  `verdict.json` + per-class table.
+- PR: body MUST include before/after per-class table.
+- Auto-merge gate: 4-of-4 reviewer attestation (Codex + AGY +
+  Copilot + Claude SMR) + smoke pass on the loss userspace
+  cluster. Use `<!-- AWAITING-BATCH-MERGE -->` per
+  `feedback_smoke_every_10_batch`.
+
+## 12. Verified against r1 findings
+
+| Finding | Status | Where |
+|---------|--------|-------|
+| F1 hierarchical vs flat | FIXED | §7 uses `\| display set` |
+| F2 rollback contradiction | FIXED | §7 single failure path |
+| F3 warning-string coupling | FIXED | §7 no warning grep |
+| F4 18g vs 25g math | FIXED | §6 math re-anchored |
+| F5 hard-coded flag skip | FIXED | §7 fixture-content gate |
+| F6 belt-and-suspenders | FIXED | same as F2 (single path) |
+| F7 go vet vs go test | FIXED | §8/§11 consistent |

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/plan.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/plan.md
@@ -1,0 +1,234 @@
+# #1626 — Fix `cos-iperf-config.set` to activate `oversubscription-policy guarantee-rate`
+
+Branch: `fix/1626-smoke-fixture-guarantee-rate`
+Base: `origin/master` @ `4ac85e2fd`
+
+## 1. Problem statement
+
+The simul-load smoke harness shipped in PR #1618 (#1614 step-1) reports
+per-class equalization (~20%/class). I framed that as evidence the
+waterfill scaffold doesn't change distribution. The #1625 PLAN-KILL
+quad-review surfaced the real explanation: **the fixture itself
+doesn't activate the `guarantee-rate` knob it was supposed to test**.
+
+Concrete bug — `test/incus/cos-iperf-config.set` on master:
+```
+$ grep -n "oversubscription" test/incus/cos-iperf-config.set
+$ # empty — the line that opts the unit into guarantee-rate mode
+$ # is missing
+```
+
+Without `set class-of-service interfaces reth0 unit 80
+oversubscription-policy guarantee-rate <X>`, the compiler defaults to
+`proportional` mode (see `pkg/config/compiler_class_of_service.go:339`
++ `pkg/config/compiler.go:1097-1108`). So the entire #1614 step-1
+measurement was testing the pre-existing proportional path — same as
+master before the wire surface shipped. The waterfill scaffold's
+runtime branch never executed under the smoke.
+
+## 2. Scope
+
+**In-scope (small surgical fixture+harness change):**
+1. Add one `set` line to `test/incus/cos-iperf-config.set` that
+   activates `guarantee-rate 0.7` on `reth0 unit 80` (the unit the
+   fixture already targets via `shaping-rate 25g` + `scheduler-map
+   bandwidth-limit`).
+2. Add a runtime-assertion in `apply-cos-config.sh` (post-apply) that
+   verifies the running config actually has `oversubscription-policy
+   guarantee-rate` set. Catches future regressions of "fixture forgot
+   the knob" + parser drops + dataplane fails to apply.
+3. Run the smoke and document the per-class distribution under the
+   activated knob in the PR body.
+
+**Out of scope (per issue body + memory):**
+- `userspace-dp/src/afxdp/cos/queue_service/mod.rs` Phase-2 lock-in
+  bug from #1625 kill — separate issue (file #1627 if needed).
+- `shared_cos_lease/rotate_epoch_v8.rs` lease scheduling.
+- Any new trace-counter instrumentation — that's #1628's territory.
+- Multi-RSS multi-core CoS architecture — #1614 umbrella.
+- Adding `oversubscription-policy` rendering to `show class-of-service
+  interface` (separate UX issue; we use `show configuration
+  class-of-service` or the commit warning for the assertion).
+
+## 3. Honest value framing
+
+- **LOC**: ~2 lines in `cos-iperf-config.set` (the policy line + maybe
+  a blank for grouping), ~6-10 lines in `apply-cos-config.sh` for the
+  verification step.
+- **Runtime code change**: 0 LOC. The wire surface, parser, compiler
+  warning, and runtime are unchanged.
+- **Diagnostic value**: HIGH. This is the gate that determines
+  whether the #1614 step-1 ship is a measurement bug (and the
+  algorithm works once the knob is on) OR the algorithm is broken in
+  the way #1625 reviewers suspected (Phase-2 lock-in at
+  queue_service/mod.rs:889-893; worker_fair_share math). The next-
+  priority bug fix (#1627) only makes sense after this fixture fix
+  produces a clean before/after measurement.
+
+## 4. Junos syntax — verified
+
+Confirmed against `pkg/config/parser_class_of_service_test.go:936`
+(`TestValidateCoSOversubscriptionWarningGuaranteeRate`):
+```
+set class-of-service interfaces ge-0/0/2 unit 80 oversubscription-policy guarantee-rate 0.7
+```
+
+Our fixture uses the RETH form (`reth0` not `ge-0/0/2`), unit 80.
+Compiler accepts both interface name forms (`reth0` literal lookup in
+`cos.Interfaces`).
+
+**Fraction choice**: 0.7 per the #1614 plan v5 worked example
+(`docs/pr/1614-multi-rss-cos/plan.md:300` — `pass1_budget = 0.7 × 18 =
+12.6 G`). This matches what the v5 acceptance criteria expects the
+distribution to look like, so the smoke harness gate 1 (small classes
+≥ 95% of configured rate) is the correct downstream check.
+
+## 5. Where the line goes in the fixture
+
+The existing fixture sets per-interface CoS on `reth0 unit 80`:
+```
+set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit
+set class-of-service interfaces reth0 unit 80 shaping-rate 25g
+```
+I add the policy line directly after `shaping-rate 25g`:
+```
+set class-of-service interfaces reth0 unit 80 oversubscription-policy guarantee-rate 0.7
+```
+
+This is the same unit/interface tuple the rest of the fixture targets,
+and the policy lives on the unit struct (`pkg/config/types.go:556`),
+so attaching it here is parser-correct.
+
+## 6. Runtime assertion in `apply-cos-config.sh`
+
+Current Phase 3 verification (lines 167-180) greps `show
+class-of-service interface` for `shaper|scheduler|traffic-control-
+profile|output.*traffic`. That doesn't catch the missing-knob bug
+because the scheduler bindings still show up — the policy lives on a
+different (oversubscription) path that the show-interface presenter
+doesn't render today.
+
+Two viable assertion points:
+
+A. **Grep `show configuration class-of-service`** — the canonical
+   round-trip serialization. The line we just set should appear
+   verbatim. Robust because it doesn't depend on any presenter
+   surface.
+
+B. **Grep the commit warning output** —
+   `pkg/config/compiler.go:1097-1108` emits a one-line warning of the
+   form `class-of-service interfaces reth0 unit 80: ... configured
+   oversubscription-policy=guarantee-rate 0.7: ...`. But this requires
+   capturing the commit transcript; the existing Phase-2 apply uses
+   `> "$APPLY_OUT" 2>&1` so the transcript is already on disk.
+
+Choice: **(A) + (B) belt-and-suspenders**. (A) verifies the
+config-tree was set (catches parser/CLI bugs). (B) verifies the
+compiler accepted it and emitted the warning (catches compiler
+regressions). If either fails the apply rolls back per the existing
+Phase-3 rollback hook.
+
+The assertion is added as a new Phase-3.5 step after the existing
+`shaper|scheduler|traffic-control-profile` grep, so we don't
+regress the existing check. Skip the assertion for the `--same-class`
+and `--symmetric` fixtures which don't (yet) set guarantee-rate.
+
+## 7. Smoke flow and what we expect to see
+
+After deploy + apply with the fixed fixture:
+
+1. **Pre-condition check** (in the apply script):
+   - `show configuration class-of-service` contains `oversubscription-
+     policy guarantee-rate 0.7`. PASS expected.
+   - Apply transcript contains the
+     `oversubscription-policy=guarantee-rate 0.7` compiler warning.
+     PASS expected (sum of exact-rates 109g > shaping-rate 25g per
+     existing fixture, so the warning ALWAYS fires).
+
+2. **Smoke run**:
+   `./test/incus/cos-simul-load-smoke.sh push` →
+   capture `verdict.json`. Compare `recv_gbps` per class against the
+   broken-baseline measurement from PR #1618 (also ~20%/class).
+
+3. **Two possible outcomes:**
+   - **Algorithm works**: distribution shifts. Small classes (100m/1g/
+     3g/6g) honoured to ≥ 95% (gate 1 passes). Large classes share
+     residual proportionally. iperf-uncapped ≥ 5% of ceiling (gate 2).
+     → confirms #1625 kill was correct; no new scheduler mechanism
+     needed.
+   - **Algorithm still equalizes**: distribution unchanged. Small
+     classes still get their proportional ~20% share. → confirms one
+     of #1625's other findings (queue_service/mod.rs:889-893 Phase-2
+     lock-in OR worker_fair_share math). File #1627 with the
+     measurement evidence as the next-priority fix.
+
+The PR body documents WHICHEVER outcome we get. The PR is
+"diagnostic-fixture-correctness" not "fix-the-scheduler", so we ship
+the fixture fix + measurement regardless of which outcome.
+
+## 8. Test plan
+
+- **Go**: `go test ./pkg/config/...` — should be unaffected; we
+  already have `TestValidateCoSOversubscriptionWarningGuaranteeRate`
+  exercising the exact line we add.
+- **Rust**: `cargo build --release` in `userspace-dp/` — no Rust
+  changes; smoke check only.
+- **Apply script unit-ish**: run the modified
+  `apply-cos-config.sh` against the smoke cluster fw0 and confirm:
+  - Existing Phase-3 check still PASSes
+  - New Phase-3.5 check PASSes with the fixed fixture
+  - New Phase-3.5 check FAILs (and rolls back) if we temporarily
+    remove the new line from the fixture (manual sanity)
+- **Cluster smoke (loss userspace)**: deploy → apply → run
+  `cos-simul-load-smoke.sh push` → capture verdict.json → diff
+  per-class achievement vs broken-baseline.
+
+## 9. Risk assessment
+
+- **Rollback risk**: the new Phase-3.5 assertion adds a NEW
+  rollback trigger. If the assertion is wrong (false-positive),
+  we'd roll back a good config. Mitigation: belt-and-suspenders
+  (A+B); only roll back if BOTH fail. A literal `oversubscription-
+  policy guarantee-rate 0.7` grep against `show configuration` is
+  trivially correct.
+- **Fixture compatibility**: adding the line shouldn't break the
+  existing fixture for any other consumer. The line is OPT-IN and
+  only fires the warning + activates the guarantee-rate branch when
+  sum_exact > shaping_rate (already true here).
+- **Smoke harness gate drift**: the existing
+  `cos-simul-load-smoke.sh` push-direction gates 1+2 were written
+  for the guarantee-rate path. Activating the knob ENABLES them to
+  pass — not breaks them. If they don't pass, that's diagnostic
+  signal not regression.
+
+## 10. Open questions for reviewers
+
+1. **Fraction value** — 0.7 per the v5 worked example, or different
+   number? 0.7 keeps small classes fully honoured and gives large
+   classes their fair share of residual. Lower (0.4) would be a
+   harsher test of the algorithm; higher (0.9) is less interesting.
+   Decision: **0.7** — matches plan v5 worked example, harness gate 1
+   thresholds, and the warning string the existing parser test
+   asserts.
+2. **Where to put the assertion** — apply script (entry point) vs
+   smoke harness (consumer)? Apply is better: it catches both
+   smoke-harness use AND any future use of the fixture by another
+   harness (failover, surplus-sharing diagnostic, etc.). Decision:
+   **apply script**.
+3. **Symmetric/same-class fixtures** — should they also activate
+   guarantee-rate? Out of scope for #1626. Those fixtures target
+   different test purposes (mirror-flow CoS coherence in #1250,
+   same-class echo override in #929). If/when their tests need
+   guarantee-rate they'll get their own fixture lines. The Phase-3.5
+   assertion gates on the chosen fixture, not all of them.
+
+## 11. Rollout / sequence
+
+- Implement: ~2 line .set + ~10 line apply assertion.
+- Build: `go vet ./...` + `go test ./pkg/config/...`.
+- Smoke: deploy + apply on loss:xpf-userspace-fw0 + run
+  `cos-simul-load-smoke.sh push` (+ optionally reverse). Capture
+  verdict.json + per-class table.
+- PR: body MUST include before/after per-class table and the verdict.
+- Auto-merge gate: 4-of-4 reviewer attestation (Codex + AGY + Copilot
+  + Claude SMR) + smoke pass on the loss userspace cluster.

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/smoke-measurement.md
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/smoke-measurement.md
@@ -1,0 +1,73 @@
+# #1626 smoke measurement under guarantee-rate 0.7
+
+## Setup
+
+- Cluster: `loss:xpf-userspace-fw0` / `xpf-userspace-fw1` (deploy
+  `make cluster-deploy` from this branch SHA 7774731eb / docs at
+  3f88a5575).
+- Apply: `./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0`.
+- Smoke: `./test/incus/cos-simul-load-smoke.sh push` (12 streams ×
+  11 classes for 30s; target 172.16.80.200).
+- Knob: `oversubscription-policy guarantee-rate 0.7` confirmed
+  active in running config via Phase-3.5 round-trip assertion (it
+  PASSED — assertion would have triggered rollback otherwise). The
+  `show class-of-service interface` output also shows `Guarantee:
+  yes` on every exact-rate class.
+
+## Result
+
+Aggregate push throughput: **19.78 Gbps** across 11 classes.
+
+| Port | Class | Shape (G) | recv (G) | % of shape | retransmits |
+|-----:|-------|----------:|---------:|----------:|------------:|
+| 5201 | iperf-100m     |   0.1 | 0.019 |  19% |    23 |
+| 5202 | iperf-1g       |   1.0 | 0.200 |  20% |   138 |
+| 5203 | iperf-3g       |   3.0 | 0.672 |  22% |   217 |
+| 5204 | iperf-6g       |   6.0 | 1.364 |  23% |   534 |
+| 5205 | iperf-9g       |   9.0 | 2.004 |  22% |   984 |
+| 5206 | iperf-12g      |  12.0 | 2.809 |  23% |  1294 |
+| 5207 | iperf-15g      |  15.0 | 2.747 |  18% |  1129 |
+| 5208 | iperf-18g      |  18.0 | 3.567 |  20% |  1404 |
+| 5209 | iperf-21g      |  21.0 | 3.545 |  17% |  1377 |
+| 5210 | iperf-24g      |  24.0 | 2.854 |  12% |  1267 |
+| 5211 | iperf-uncapped |   —   | 0.001 |   0% |    87 |
+
+## Verdict
+
+**The algorithm is still equalizing to ~20% per class even with the
+knob ON.** Gate 1 fails: small classes (100m, 1g, 3g, 6g) are NOT
+honoured to ≥ 95% of their configured rate. Under `guarantee-rate 0.7`
+with `shaping-rate 25g`, the Phase-1 budget should be 17.5g (sum of
+small classes 10.1g fits comfortably) and small classes should hit
+their configured rates first. They don't.
+
+This confirms the #1625 quad-review's suspicion: the simul-load smoke
+isn't just a measurement bug. The waterfill scaffold shipped in
+PR #1618 either has the Phase-2 lock-in defect at
+`userspace-dp/src/afxdp/cos/queue_service/mod.rs:889-893`, or the
+worker_fair_share math is wrong, or both. The algorithm is functioning
+as if it were still in `proportional` mode regardless of the knob.
+
+## Next step
+
+File **#1627** with this evidence as the next-priority bug. #1627's
+job is to find and fix the actual scheduler defect that's causing the
+proportional-mode equalization under guarantee-rate. The #1626 PR is
+the prerequisite: it makes the smoke harness actually exercise the
+guarantee-rate branch so #1627 has a faithful regression target.
+
+Out-of-scope-for-this-PR observations worth recording for #1627:
+
+1. The 19.78 Gbps aggregate is consistent with the push-direction
+   NIC ceiling (~18-20G under simul-load with 132 streams) so the
+   workload IS saturating the pipe — there's no slack hiding the
+   bug.
+2. Priority-low (iperf-uncapped) gets 1 Mbps — gate 2 fails
+   spectacularly. Under proper guarantee-rate this should get at
+   least 5% of cluster ceiling (~900 Mbps).
+3. CoV is in the 18-58% range, with the highest CoV on the largest
+   shape classes. This is consistent with proportional spreading
+   where smaller per-stream slots see more variance.
+4. Retransmits cluster around 1000-1400 for mid/large classes —
+   indicates the qdisc-level drop is happening but the discipline
+   isn't honouring the shape order.

--- a/docs/pr/1626-smoke-fixture-guarantee-rate/smoke-verdict.json
+++ b/docs/pr/1626-smoke-fixture-guarantee-rate/smoke-verdict.json
@@ -1,0 +1,182 @@
+{
+  "direction": "push",
+  "aggregate_gbps": 19.783,
+  "rows": [
+    {
+      "port": 5201,
+      "class": "iperf-100m",
+      "shape_gbps": 0.1,
+      "recv_gbps": 0.019,
+      "cov_pct": 1.7,
+      "spread": 1.04,
+      "retransmits": 23
+    },
+    {
+      "port": 5202,
+      "class": "iperf-1g",
+      "shape_gbps": 1.0,
+      "recv_gbps": 0.2,
+      "cov_pct": 4.1,
+      "spread": 1.14,
+      "retransmits": 138
+    },
+    {
+      "port": 5203,
+      "class": "iperf-3g",
+      "shape_gbps": 3.0,
+      "recv_gbps": 0.672,
+      "cov_pct": 9.6,
+      "spread": 1.36,
+      "retransmits": 217
+    },
+    {
+      "port": 5204,
+      "class": "iperf-6g",
+      "shape_gbps": 6.0,
+      "recv_gbps": 1.364,
+      "cov_pct": 29.7,
+      "spread": 3.48,
+      "retransmits": 534
+    },
+    {
+      "port": 5205,
+      "class": "iperf-9g",
+      "shape_gbps": 9.0,
+      "recv_gbps": 2.004,
+      "cov_pct": 13.8,
+      "spread": 1.57,
+      "retransmits": 984
+    },
+    {
+      "port": 5206,
+      "class": "iperf-12g",
+      "shape_gbps": 12.0,
+      "recv_gbps": 2.809,
+      "cov_pct": 30.3,
+      "spread": 2.77,
+      "retransmits": 1294
+    },
+    {
+      "port": 5207,
+      "class": "iperf-15g",
+      "shape_gbps": 15.0,
+      "recv_gbps": 2.747,
+      "cov_pct": 46.7,
+      "spread": 5.09,
+      "retransmits": 1129
+    },
+    {
+      "port": 5208,
+      "class": "iperf-18g",
+      "shape_gbps": 18.0,
+      "recv_gbps": 3.567,
+      "cov_pct": 29.8,
+      "spread": 3.67,
+      "retransmits": 1404
+    },
+    {
+      "port": 5209,
+      "class": "iperf-21g",
+      "shape_gbps": 21.0,
+      "recv_gbps": 3.545,
+      "cov_pct": 34.5,
+      "spread": 3.99,
+      "retransmits": 1377
+    },
+    {
+      "port": 5210,
+      "class": "iperf-24g",
+      "shape_gbps": 24.0,
+      "recv_gbps": 2.854,
+      "cov_pct": 58.7,
+      "spread": 6.99,
+      "retransmits": 1267
+    },
+    {
+      "port": 5211,
+      "class": "iperf-uncapped",
+      "shape_gbps": 0.0,
+      "recv_gbps": 0.001,
+      "cov_pct": 75.8,
+      "spread": 10.5,
+      "retransmits": 87
+    }
+  ],
+  "gates": {
+    "gate_1_small_class_guarantees": {
+      "classes": [
+        {
+          "class": "iperf-100m",
+          "target": 0.095,
+          "actual": 0.019,
+          "pass": false
+        },
+        {
+          "class": "iperf-1g",
+          "target": 0.95,
+          "actual": 0.2,
+          "pass": false
+        },
+        {
+          "class": "iperf-3g",
+          "target": 2.8499999999999996,
+          "actual": 0.672,
+          "pass": false
+        },
+        {
+          "class": "iperf-6g",
+          "target": 5.699999999999999,
+          "actual": 1.364,
+          "pass": false
+        }
+      ],
+      "pass": false
+    },
+    "gate_2_priority_low_min_share": {
+      "target": 0.9,
+      "actual": 0.0010092108603814588,
+      "pass": false
+    },
+    "gate_3_retrans_floor": {
+      "high_retr_classes": [
+        {
+          "class": "iperf-1g",
+          "retr": 138
+        },
+        {
+          "class": "iperf-3g",
+          "retr": 217
+        },
+        {
+          "class": "iperf-6g",
+          "retr": 534
+        },
+        {
+          "class": "iperf-9g",
+          "retr": 984
+        },
+        {
+          "class": "iperf-12g",
+          "retr": 1294
+        },
+        {
+          "class": "iperf-15g",
+          "retr": 1129
+        },
+        {
+          "class": "iperf-18g",
+          "retr": 1404
+        },
+        {
+          "class": "iperf-21g",
+          "retr": 1377
+        },
+        {
+          "class": "iperf-24g",
+          "retr": 1267
+        }
+      ],
+      "pass": false
+    }
+  }
+}

--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -232,4 +232,67 @@ EOF
 	exit 6
 fi
 
+# ---- Phase 3.5: oversubscription-policy round-trip verification ----
+#
+# #1626: PR #1618 shipped the #1614 step-1 wire surface (Junos
+# `oversubscription-policy guarantee-rate <X>`) but the
+# `cos-iperf-config.set` fixture forgot to enable the knob, so the
+# simul-load smoke harness was measuring the default `proportional`
+# mode the whole time. This phase guards against the same regression
+# class for any future fixture: if the applied fixture contains
+# `^set .*oversubscription-policy` lines, the running config tree
+# MUST round-trip with EACH such line present after commit.
+#
+# The check is dynamically gated on fixture content (NOT on
+# --same-class / --symmetric flags) so future fixtures that activate
+# the knob get verified unchanged, and fixtures that don't are
+# silently skipped.
+#
+# We use `show configuration class-of-service | display set` (the
+# flat-set rendering of the config tree) so a literal `grep -Fxq`
+# can match each fixture line verbatim. CRLF safety: strip trailing
+# \r from the expected line in case the fixture file picks up
+# Windows-style line endings on edit.
+if grep -qE '^set .*oversubscription-policy' "$CONFIG_FILE"; then
+	OVERSUB_OUT=$(mktemp)
+	trap "rm -f '$SETS_TMP' '$CHECK_OUT' '$APPLY_OUT' '$VERIFY_OUT' '$OVERSUB_OUT'" EXIT
+	incus exec "$TARGET" -- /usr/local/sbin/cli -c \
+		"show configuration class-of-service | display set" \
+		> "$OVERSUB_OUT" 2>&1 || true
+
+	MISSING=0
+	while IFS= read -r want; do
+		want="${want%$'\r'}"
+		if ! grep -Fxq "$want" "$OVERSUB_OUT"; then
+			echo "error: fixture line missing from running config:" >&2
+			echo "  expected: $want" >&2
+			MISSING=1
+		fi
+	done < <(grep -E '^set .*oversubscription-policy' "$CONFIG_FILE")
+
+	if [[ "$MISSING" -ne 0 ]]; then
+		echo "error: Phase-3.5 oversubscription-policy verification FAILED" >&2
+		echo "---- show configuration class-of-service | display set ----" >&2
+		cat "$OVERSUB_OUT" >&2
+		echo "---- end show output ----" >&2
+		echo "rolling forward with 'rollback 1 | commit' to restore the last good state..." >&2
+		ROLLBACK_OUT=$(mktemp)
+		trap "rm -f '$SETS_TMP' '$CHECK_OUT' '$APPLY_OUT' '$VERIFY_OUT' '$OVERSUB_OUT' '$ROLLBACK_OUT'" EXIT
+		if incus exec "$TARGET" -- /usr/local/sbin/cli > "$ROLLBACK_OUT" 2>&1 <<'EOF'
+configure
+rollback 1
+commit
+exit
+quit
+EOF
+		then
+			echo "rollback 1 committed — live state reverted" >&2
+		else
+			echo "WARN: rollback commit also failed — MANUAL INTERVENTION REQUIRED" >&2
+			cat "$ROLLBACK_OUT" >&2
+		fi
+		exit 7
+	fi
+fi
+
 echo "apply-cos-config: atomic commit + verification OK"

--- a/test/incus/cos-iperf-config.set
+++ b/test/incus/cos-iperf-config.set
@@ -68,6 +68,7 @@ set class-of-service scheduler-maps bandwidth-limit forwarding-class iperf-uncap
 
 set class-of-service interfaces reth0 unit 80 scheduler-map bandwidth-limit
 set class-of-service interfaces reth0 unit 80 shaping-rate 25g
+set class-of-service interfaces reth0 unit 80 oversubscription-policy guarantee-rate 0.7
 
 set firewall family inet filter bandwidth-output term 0 from destination-port 5200
 set firewall family inet filter bandwidth-output term 0 from destination-port 6200


### PR DESCRIPTION
## Summary

PR #1618 (#1614 step-1) shipped the Junos wire surface for
`oversubscription-policy guarantee-rate <fraction>` but the
`test/incus/cos-iperf-config.set` fixture never set the line that
opts the unit into guarantee-rate mode. The simul-load smoke harness
was therefore measuring the default `proportional` distribution the
whole time. The #1625 PLAN-KILL quad-review surfaced this
measurement bug.

This PR is the diagnostic fixture+harness fix:

1. **Fixture**: add one line to `test/incus/cos-iperf-config.set`:
   ```
   set class-of-service interfaces reth0 unit 80 oversubscription-policy guarantee-rate 0.7
   ```
2. **Apply-script assertion**: new Phase-3.5 round-trip check in
   `test/incus/apply-cos-config.sh` — for any fixture that contains
   `^set .*oversubscription-policy` lines, the script captures
   `show configuration class-of-service | display set` and verifies
   each such line round-trips into the running config. Missing line
   triggers the existing `rollback 1 | commit` safety net (exit 7).
   Gated by fixture content (NOT by `--same-class`/`--symmetric`
   flag).

No runtime code change. The diagnostic value is high.

## Measurement under guarantee-rate 0.7 (push direction)

`show class-of-service interface` confirms `Guarantee: yes` on every
exact-rate class. Phase-3.5 round-trip assertion PASSED. So the knob
IS active in the running config.

Aggregate push: **19.78 Gbps** across 11 classes.

| Port | Class | Shape (G) | recv (G) | % of shape |
|-----:|-------|----------:|---------:|----------:|
| 5201 | iperf-100m     |   0.1 | 0.019 |  19% |
| 5202 | iperf-1g       |   1.0 | 0.200 |  20% |
| 5203 | iperf-3g       |   3.0 | 0.672 |  22% |
| 5204 | iperf-6g       |   6.0 | 1.364 |  23% |
| 5205 | iperf-9g       |   9.0 | 2.004 |  22% |
| 5206 | iperf-12g      |  12.0 | 2.809 |  23% |
| 5207 | iperf-15g      |  15.0 | 2.747 |  18% |
| 5208 | iperf-18g      |  18.0 | 3.567 |  20% |
| 5209 | iperf-21g      |  21.0 | 3.545 |  17% |
| 5210 | iperf-24g      |  24.0 | 2.854 |  12% |
| 5211 | iperf-uncapped |   —   | 0.001 |   0% |

## Verdict on the underlying #1614 algorithm

**The algorithm is still equalizing to ~20% per class even with the
knob ON.** Gate 1 fails: small classes (100m, 1g, 3g, 6g) are NOT
honoured to ≥ 95% of their configured rate. Under `guarantee-rate 0.7`
with `shaping-rate 25g`, the Phase-1 budget should be 17.5g (sum of
small-class rates 10.1g fits comfortably) and small classes should
hit their configured rates first. They don't.

This confirms the #1625 quad-review's suspicion: the simul-load smoke
isn't just a measurement bug. The waterfill scaffold shipped in
PR #1618 either has the Phase-2 lock-in defect at
`userspace-dp/src/afxdp/cos/queue_service/mod.rs:889-893`, or the
worker_fair_share math is wrong, or both. **Next-priority bug to file
as #1627** with this evidence as the regression target.

This PR is the prerequisite for #1627: it makes the smoke harness
actually exercise the guarantee-rate branch.

Full measurement at `docs/pr/1626-smoke-fixture-guarantee-rate/smoke-measurement.md`.

## Plan + reviewers

Plan: `docs/pr/1626-smoke-fixture-guarantee-rate/plan.md` v2.

- Codex plan-r1: PLAN-NEEDS-MAJOR (5+2 findings) → r2 PLAN-READY
- AGY plan-r1: PLAN-NEEDS-MAJOR (5 findings) → r2 PLAN-READY
- Claude SMR plan-r1: PLAN-NEEDS-MAJOR (self-correction) → r2 PLAN-READY

r1 findings F1-F7 all addressed in v2:
- F1: use `| display set` for flat-set form
- F2/F6: single failure path (no OR/AND contradiction)
- F3: drop compiler-warning grep; rely on durable config state
- F4: math anchored to actual 25g shaping → 17.5g budget (not 12.6g)
- F5: gate by fixture content not flag
- F7: go vet/go test consistent across §8 and §11
- Plus AGY CRLF nit: strip trailing `\r` from expected line

## Test plan

- [x] `go vet ./pkg/config/...` clean
- [x] `go test ./pkg/config/...` green
  (`TestValidateCoSOversubscriptionWarningGuaranteeRate` covers the
  exact line being added)
- [x] `bash -n test/incus/apply-cos-config.sh` clean
- [x] Cluster deploy + apply on `loss:xpf-userspace-fw0`
- [x] Phase-3.5 assertion fires on the activated fixture (PASS)
- [x] `cos-simul-load-smoke.sh push` per-class verdict.json captured
- [x] Measurement comparison: PR #1618 broken-baseline (proportional
      ~20%/class) vs this PR (guarantee-rate 0.7 — STILL ~20%/class
      i.e. algorithm bug confirmed)
- [x] Next-step disposition: algorithm STILL equalizes → file #1627
      with this measurement as evidence (out of scope for this PR)

Closes #1626