### PR TITLE
docs: fix three doc-vs-reality drift claims (#1639, #1644, #1645)

### DIFF
--- a/docs/dataplane-decision-dpdk-vs-vpp.md
+++ b/docs/dataplane-decision-dpdk-vs-vpp.md
@@ -15,11 +15,15 @@
   dataplane (`userspace-dp/`) is the primary/default backend, and
   the legacy eBPF dataplane is being retired in parallel under
   #1373.
-- The DPDK source under `dpdk_worker/` and `pkg/dataplane/dpdk/`
-  remains in-tree until Phase 3 of #1525 deletes it. Commit-time
-  rejection of `set system dataplane-type dpdk` is planned in
-  Phase 1 (#1526; not yet on master). Per #1525, builds with
-  `-tags dpdk` are not supported for production.
+- The DPDK retirement is **complete**. The DPDK source under
+  `dpdk_worker/` and `pkg/dataplane/dpdk/` has been **deleted from
+  master** (mechanical removal #1528; boot decoupling #1527); only
+  the retirement docs remain. Commit-time rejection of `set system
+  dataplane-type dpdk` is **live on master** (#1526) in
+  `pkg/config/compiler_system.go` (`compileSystemDataplaneType`),
+  which rejects `dpdk` at commit while still parsing the token for
+  legacy-config compatibility. Per #1525, builds with `-tags dpdk`
+  are not supported.
 - VPP was never implemented in xpf. There is no current plan to
   add a VPP backend. If one becomes interesting in the future, a
   fresh decision document will be filed at that time; the section

--- a/docs/dataplane-decision-dpdk-vs-vpp.md
+++ b/docs/dataplane-decision-dpdk-vs-vpp.md
@@ -19,9 +19,10 @@
   `dpdk_worker/` and `pkg/dataplane/dpdk/` has been **deleted from
   master** (mechanical removal #1528; boot decoupling #1527); only
   the retirement docs remain. Commit-time rejection of `set system
-  dataplane-type dpdk` is **live on master** (#1526) in
-  `pkg/config/compiler_system.go` (`compileSystemDataplaneType`),
-  which rejects `dpdk` at commit while still parsing the token for
+  dataplane-type dpdk` is **live on master** (#1526):
+  `validateDataplaneTypeStrict` in `pkg/config/compiler.go` returns
+  `ErrDPDKDataplaneRetired` at commit, while
+  `compileSystemDataplaneType` still parses the `dpdk` token for
   legacy-config compatibility. Per #1525, builds with `-tags dpdk`
   are not supported.
 - VPP was never implemented in xpf. There is no current plan to

--- a/docs/dpdk-dataplane.md
+++ b/docs/dpdk-dataplane.md
@@ -14,12 +14,16 @@
 - DPDK is retired under #1525. The userspace AF_XDP dataplane
   (`userspace-dp/`) is the primary/default backend, and the legacy
   eBPF dataplane is being retired in parallel under #1373.
-- The DPDK source under `dpdk_worker/` and `pkg/dataplane/dpdk/`
-  remains in-tree until Phase 3 of #1525 deletes it. Per #1525,
-  builds with `-tags dpdk` are not supported for production.
+- The DPDK retirement is **complete**. The DPDK source under
+  `dpdk_worker/` and `pkg/dataplane/dpdk/` has been **deleted from
+  master** by the mechanical-removal phase (#1528; boot decoupling
+  #1527). Only these retirement docs remain in-tree. Per #1525,
+  builds with `-tags dpdk` are not supported.
 - Commit-time rejection of `set system dataplane-type dpdk` is
-  planned in Phase 1 (#1526; not yet on master). Operators
-  should migrate with
+  **live on master** (#1526) — `compileSystemDataplaneType` in
+  `pkg/config/compiler_system.go` rejects `dpdk` at commit, citing
+  #1525, while still parsing the token for legacy-config
+  compatibility. Operators should migrate with
   `set system dataplane-type userspace`, or simply omit
   `system dataplane-type` entirely (userspace is the default).
 - For the project-level retirement context, see

--- a/docs/dpdk-dataplane.md
+++ b/docs/dpdk-dataplane.md
@@ -20,10 +20,11 @@
   #1527). Only these retirement docs remain in-tree. Per #1525,
   builds with `-tags dpdk` are not supported.
 - Commit-time rejection of `set system dataplane-type dpdk` is
-  **live on master** (#1526) — `compileSystemDataplaneType` in
-  `pkg/config/compiler_system.go` rejects `dpdk` at commit, citing
-  #1525, while still parsing the token for legacy-config
-  compatibility. Operators should migrate with
+  **live on master** (#1526) — `validateDataplaneTypeStrict` in
+  `pkg/config/compiler.go` returns `ErrDPDKDataplaneRetired` at
+  commit (citing #1525), while `compileSystemDataplaneType` still
+  parses the `dpdk` token for legacy-config compatibility.
+  Operators should migrate with
   `set system dataplane-type userspace`, or simply omit
   `system dataplane-type` entirely (userspace is the default).
 - For the project-level retirement context, see

--- a/docs/pr/doc-honesty-1639-1644-1645/claude-smr-accuracy.md
+++ b/docs/pr/doc-honesty-1639-1644-1645/claude-smr-accuracy.md
@@ -1,0 +1,115 @@
+# Claude SMR — Accuracy Self-Review: doc-honesty (#1639 + #1644 + #1645)
+
+Docs-only PR. Every corrected claim is grounded against `origin/master`
+(`dbfbf680c`) or a verified issue measurement. I reviewed each edit
+hostilely against its own source-of-truth to confirm I did not replace
+one wrong claim with another overclaim.
+
+## #1639 — `docs/userspace-jit-design.md` Phase 6 CoS row
+
+**Before:** `**DONE** — ... small-class guarantees honoured under 6×
+oversubscription; ~3-7× per-class throughput improvement on
+100m/1g/3g/6g classes`
+
+**After:** `**WIRED / NOT YET MEETING GATE**` — wire surface + commit
+warning shipped (#1618), smoke fixture activates the knob (#1629), but
+the scheduler does not honour small-class guarantees: under
+`guarantee-rate 0.7` it still equalizes ~20%/class instead of meeting
+the small-class ≥95% gate (#1630). Root cause: the v8 epoch-cap clamp
+discards lagged rate credit (`rotate_epoch_v8.rs`). Gain column →
+`regression open, see #1630/#1614`.
+
+**Source of truth:**
+- #1614 OPEN, #1630 OPEN (verified via `gh issue view`).
+- #1630 body measurement: 100m/1g/3g/6g classes receive 19/20/22/23%
+  of configured shape under `guarantee-rate 0.7`, `shaping-rate 25g`.
+- Root cause is the latest converged finding in #1630 comments
+  (`/engineer` STOP-and-report): the v8 rotation clamp
+  `elapsed.min(EPOCH_DURATION)` at `rotate_epoch_v8.rs:218` discards
+  `rate × (lag − EPOCH_DURATION)` rate credit when a rotation lags past
+  one epoch; a diagnostic probe relaxing the clamp lifted solo ceilings
+  to ~94-95%. File `rotate_epoch_v8.rs` exists on master
+  (`userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs`).
+
+**Hostile check:** Did I overclaim the root cause as "fixed/known-safe"?
+No — I phrase it as "root cause proven," which matches the #1630
+converged diagnosis, and I keep the feature status as NOT meeting the
+gate with the regression tracked open. I did not assert a fix exists.
+The "#1618 wire surface shipped" and "#1629 fixture" sub-claims are
+both stated in #1630/#1639 bodies. I removed the fabricated "~3-7×"
+multiplier entirely — that number had no measurement backing it.
+
+**Scope guard:** I did NOT touch the Phase 1 row or any "~2ms" line in
+this file (owned by in-flight #1636). Only the Phase 6 row changed
+(`git diff` shows 1 line, +1/-1).
+
+## #1644 — `docs/dpdk-dataplane.md` + `docs/dataplane-decision-dpdk-vs-vpp.md`
+
+**Before (both, "Current State"):** source "remains in-tree until Phase
+3 of #1525 deletes it"; commit-rejection "planned in Phase 1 (#1526;
+not yet on master)."
+
+**After (both):** retirement complete — source deleted from master
+(#1528 mechanical removal, #1527 boot decoupling), only docs remain;
+commit-rejection live on master (#1526) in
+`pkg/config/compiler_system.go` (`compileSystemDataplaneType`).
+
+**Source of truth:**
+- `git ls-tree -r --name-only origin/master | grep -i dpdk` returns
+  only `docs/...` paths — no `dpdk_worker/` or `pkg/dataplane/dpdk/`
+  source. Confirms deletion.
+- `git show origin/master:pkg/config/compiler_system.go` shows
+  `compileSystemDataplaneType` returning an error for invalid
+  dataplane-type and the validity gate that rejects `dpdk` at commit,
+  citing #1525, "dpdk parses for legacy-config compatibility but is
+  rejected at commit per #1525." Confirms live rejection + token still
+  parsed.
+- PR refs #1526/#1527/#1528 are the retirement-chain PRs named in the
+  #1644 issue body and confirmed CLOSED COMPLETED there.
+
+**Hostile check:** Did I attribute deletion to the wrong PR? The issue
+body and CLAUDE.md both state `dpdk_worker/` + `pkg/dataplane/dpdk/`
+are "removed in #1527/#1528" — I credit #1528 mechanical removal +
+#1527 boot decoupling, consistent with both. I did NOT touch the
+"[Retired] Historical Decision/Design" sections (lines ~61+ / ~44+),
+which are explicitly preserved as as-of-2026-03-02/2026-03 reference
+and correctly framed as historical; editing them would misrepresent
+the decision-time record. Only the "Current State" bullets changed.
+
+## #1645 — `docs/userspace-cold-start-resolution.md`
+
+**Before:** four lines presenting cold connect as resolved to ~2ms
+(L16 "~2ms delay after all fixes", "Total cold latency: ~2ms", table
+rows "Cold TCP connect ... ~2ms" and "Neighbor resolution ... ~2ms").
+
+**After:** added an accuracy banner; reframed each "~2ms" as the
+intended target and added "currently measured ~3.371s under a cold
+neighbor cache (post `ip neigh flush`)" with the 260 ms-probe vs
+2000 ms-timeout gap as cause; mitigation tracked by #1636.
+
+**Source of truth:**
+- #1636 body: measured wall-clock cold connect = 3.371 s after
+  `ip neigh flush all` (transcript: 1779989031.725 − 1779989028.354 =
+  3.371 s). The 260 ms probe schedule vs 2000 ms
+  `PENDING_NEIGH_TIMEOUT_NS` gap is documented in the same body, in
+  `neighbor_dispatch.rs`.
+
+**Hostile check:** Did I hardcode 3.371s as a permanent resolved value?
+No — I phrase it as "currently measured ~3.371s" + "mitigation tracked
+by #1636" and explicitly say "once it lands these figures will be
+updated to the post-fix measurement." I did NOT delete the ~2ms design
+target (kept as the goal), so when #1636 lands the editor has the
+target and the to-be-replaced current value both visible. This is a
+different file from `userspace-jit-design.md`, so no conflict with
+#1636's own doc-update checkbox.
+
+## Cross-cutting accuracy
+
+- No source under `userspace-dp/src/`, `pkg/`, `cmd/`, `test/` touched
+  (`git diff --stat` = 4 docs only).
+- No new claim introduced that I cannot cite to master state or an
+  issue measurement.
+- No harness/control tags in any GitHub-bound text.
+
+**Verdict: CLEAN.** All three corrections are grounded; no new
+overclaim introduced.

--- a/docs/pr/doc-honesty-1639-1644-1645/claude-smr-accuracy.md
+++ b/docs/pr/doc-honesty-1639-1644-1645/claude-smr-accuracy.md
@@ -51,19 +51,32 @@ not yet on master)."
 
 **After (both):** retirement complete — source deleted from master
 (#1528 mechanical removal, #1527 boot decoupling), only docs remain;
-commit-rejection live on master (#1526) in
-`pkg/config/compiler_system.go` (`compileSystemDataplaneType`).
+commit-rejection live on master (#1526) via `validateDataplaneTypeStrict`
+in `pkg/config/compiler.go` (returns `ErrDPDKDataplaneRetired`), while
+`compileSystemDataplaneType` still parses the `dpdk` token for
+legacy-config compatibility.
 
 **Source of truth:**
 - `git ls-tree -r --name-only origin/master | grep -i dpdk` returns
   only `docs/...` paths — no `dpdk_worker/` or `pkg/dataplane/dpdk/`
   source. Confirms deletion.
+- `git show origin/master:pkg/config/compiler.go` shows
+  `validateDataplaneTypeStrict` (called from `compileExpanded` at
+  `compiler.go:266`) returning `ErrDPDKDataplaneRetired` when
+  `cfg.System.DataplaneType == dataplaneTypeDPDK` (`compiler.go:372-383`).
+  This is the actual hard commit-time rejection.
 - `git show origin/master:pkg/config/compiler_system.go` shows
-  `compileSystemDataplaneType` returning an error for invalid
-  dataplane-type and the validity gate that rejects `dpdk` at commit,
-  citing #1525, "dpdk parses for legacy-config compatibility but is
-  rejected at commit per #1525." Confirms live rejection + token still
-  parsed.
+  `compileSystemDataplaneType` *accepting* `dpdk` as a known type and
+  only parsing the token ("dpdk parses for legacy-config compatibility
+  but is rejected at commit per #1525"); the rejection itself is in
+  `validateDataplaneTypeStrict`, not here.
+
+**Correction (Copilot review, r1):** the first draft cited
+`compileSystemDataplaneType` as the rejecting function. Copilot
+correctly flagged that this function only parses the token — the hard
+rejection returning `ErrDPDKDataplaneRetired` is
+`validateDataplaneTypeStrict` in `pkg/config/compiler.go`. Both DPDK
+docs and this note were corrected to point at the right function/file.
 - PR refs #1526/#1527/#1528 are the retirement-chain PRs named in the
   #1644 issue body and confirmed CLOSED COMPLETED there.
 

--- a/docs/userspace-cold-start-resolution.md
+++ b/docs/userspace-cold-start-resolution.md
@@ -3,6 +3,16 @@
 **Date:** 2026-03-22
 **Commits:** `e0c01ac` through `2f818e8`
 
+> **Accuracy note (#1645):** The "~2ms" cold-connect figures below
+> describe the intended steady-state target, not the current measured
+> cost. Cold TCP connect is **currently measured ~3.371s** under a cold
+> neighbor cache (after `ip neigh flush all`), because of the gap
+> between the 260 ms userspace probe schedule and the 2000 ms pending-
+> neighbor timeout in `neighbor_dispatch.rs`. The mitigation is tracked
+> by **#1636**; once it lands these figures will be updated to the
+> post-fix measurement. Treat the "~2ms" values here as the design
+> goal, not a shipped result.
+
 ## Problem Statement
 
 After daemon restart or when encountering a new destination host, the
@@ -13,7 +23,9 @@ slow-path TUN, resulting in:
 
 - **Infinite timeout** for new TCP connections (initial state)
 - **~1.2s delay** after adding slow-path reinject (TCP SYN retransmit)
-- **~2ms delay** after all fixes (buffer-and-retry with ICMP probe)
+- **~2ms target** after all fixes (buffer-and-retry with ICMP probe)
+  — but cold connect is **currently measured ~3.371s** under a cold
+  neighbor cache; mitigation tracked by #1636 (see accuracy note above)
 
 ## Root Causes
 
@@ -182,18 +194,21 @@ SYN-ACK's reverse lookup finds it via `install_reverse_session_from_forward_matc
 12. ACK: session hit → TCP established → data flows at line rate
 ```
 
-**Total cold latency: ~2ms** (ARP/NDP roundtrip + netlink + retry)
+**Total cold latency target: ~2ms** (ARP/NDP roundtrip + netlink +
+retry) — **currently measured ~3.371s** under a cold neighbor cache
+because of the 260 ms-probe vs 2000 ms-timeout gap; mitigation tracked
+by #1636 (see accuracy note at the top of this file).
 
 ## Performance Results
 
 | Metric | Before | After |
 |--------|--------|-------|
-| Cold TCP connect (after ARP flush) | Infinite timeout | ~2ms |
+| Cold TCP connect (after ARP flush) | Infinite timeout | ~2ms target; **~3.371s measured** (#1636) |
 | Cold iperf3 IPv4 (8 streams, 5s) | 0 Gbps (timeout) | 20.1 Gbps |
 | Cold iperf3 IPv6 (8 streams, 5s) | 0 Gbps (broken) | 20.0 Gbps |
 | Warm iperf3 (8 streams, 10s) | 23+ Gbps | 23+ Gbps |
 | Fill ring bootstrap | Failed (0/12 queues) | 12/12 queues |
-| Neighbor resolution | 1-5s (Go snapshot) | ~2ms (netlink event) |
+| Neighbor resolution | 1-5s (Go snapshot) | ~2ms target; gated by 260 ms-probe/2000 ms-timeout gap, ~3.371s cold today (#1636) |
 
 ## Files Changed
 

--- a/docs/userspace-jit-design.md
+++ b/docs/userspace-jit-design.md
@@ -33,7 +33,7 @@ explicitly in the PR review notes.
 | 3 | Address-book trie compilation | Not started | — |
 | 4 | Cranelift JIT | Not started | — |
 | 5 | Screen function specialization | **DONE** — zones without screen profiles return Pass immediately (O(1) HashMap miss); no further specialization needed | O(1) |
-| 6 | CoS scheduler oversubscription semantics (#1614) | **DONE** — operator-selectable `oversubscription-policy guarantee-rate <X>` two-phase waterfill allocator (default `proportional` preserves current behaviour bit-for-bit); `priority-low-min-share` orthogonal reserve; A3 CoDel sojourn-time AQM opt-in via `codel-target <ms>`. See `docs/fairness-regimes.md` "CoS oversubscription policy" + `docs/pr/1614-multi-rss-cos/plan.md` v5. | small-class guarantees honoured under 6× oversubscription; ~3-7× per-class throughput improvement on 100m/1g/3g/6g classes |
+| 6 | CoS scheduler oversubscription semantics (#1614) | **WIRED / NOT YET MEETING GATE** — the operator-selectable `oversubscription-policy guarantee-rate <X>` wire surface + commit warning shipped (#1618) and the smoke fixture activates the knob (#1629), but the scheduler does **not** yet honour small-class guarantees: under `guarantee-rate 0.7` it still equalizes ~20%/class instead of meeting the small-class ≥ 95% acceptance gate (#1630 measurement, see `docs/fairness-regimes.md` "CoS oversubscription policy"). Root cause proven — the v8 epoch-cap clamp discards lagged rate credit (`rotate_epoch_v8.rs`). The `proportional` default and `priority-low-min-share`/`codel-target` knobs parse as designed. See `docs/pr/1614-multi-rss-cos/plan.md` v5. | regression open, see #1630/#1614 |
 
 ### Phase 1 implementation details (as of `2f818e8`, 2026-03-22)
 


### PR DESCRIPTION
Documentation-only PR. Three verified doc-vs-reality drift fixes. No
source changes; the binary is unaffected, so no smoke matrix.

Each corrected claim is grounded against `origin/master` (`dbfbf680c`)
or a verified issue measurement. Claude SMR accuracy self-review:
`docs/pr/doc-honesty-1639-1644-1645/claude-smr-accuracy.md`.

## #1639 — userspace-jit-design.md Phase 6 CoS row overclaim

**Before:** `**DONE** — ... small-class guarantees honoured under 6×
oversubscription; ~3-7× per-class throughput improvement on
100m/1g/3g/6g classes`

**After:** `**WIRED / NOT YET MEETING GATE**` — wire surface + commit
warning shipped (#1618), smoke fixture activates the knob (#1629), but
the scheduler still equalizes ~20%/class under `guarantee-rate 0.7`
instead of meeting the small-class ≥95% gate; root cause proven (v8
epoch-cap clamp discards lagged rate credit, `rotate_epoch_v8.rs`).
Gain column → `regression open, see #1630/#1614`. Fabricated "~3-7×"
multiplier removed.

**Source of truth:** #1614 + #1630 OPEN; #1630 body measurement shows
19/20/22/23% of configured shape for 100m/1g/3g/6g; #1630 converged
root cause (`/engineer` STOP-and-report) pins the loss on the v8
rotation clamp `elapsed.min(EPOCH_DURATION)` at `rotate_epoch_v8.rs:218`
discarding `rate × (lag − EPOCH_DURATION)`. Phase 1 "~2ms" line (owned
by in-flight #1636) deliberately untouched.

## #1644 — DPDK docs describe retirement as in-progress

`docs/dpdk-dataplane.md` + `docs/dataplane-decision-dpdk-vs-vpp.md`
"Current State" said source "remains in-tree until Phase 3" and
commit-rejection "not yet on master".

**Before:** "remains in-tree until Phase 3 of #1525 deletes it ...
commit-time rejection planned in Phase 1 (#1526; not yet on master)"

**After:** retirement complete — source deleted from master (#1528
mechanical removal; #1527 boot decoupling), only docs remain;
commit-rejection live on master (#1526) via `validateDataplaneTypeStrict` (`pkg/config/compiler.go`, returns `ErrDPDKDataplaneRetired`); `compileSystemDataplaneType` only parses the `dpdk` token for legacy-config compat.

**Source of truth:** `git ls-tree -r --name-only origin/master | grep -i
dpdk` → only `docs/...` paths (no `dpdk_worker/` or
`pkg/dataplane/dpdk/`); `git show origin/master:pkg/config/compiler.go` shows `validateDataplaneTypeStrict` returning `ErrDPDKDataplaneRetired` for `dataplaneTypeDPDK` (the hard rejection), called from `compileExpanded`. The "[Retired] Historical" sections are preserved as-is.

## #1645 — cold-start-resolution.md overclaims ~2ms

**Before:** four lines presenting cold connect as resolved to ~2ms.

**After:** accuracy banner + each "~2ms" reframed as the intended
target with "**currently measured ~3.371s** under a cold neighbor cache
(post `ip neigh flush`); mitigation tracked by #1636". The ~2ms target
is kept (not hardcoded as resolved) so #1636 can update to the post-fix
number on landing.

**Source of truth:** #1636 transcript measures 3.371s
(1779989031.725 − 1779989028.354) after `ip neigh flush all`; 260 ms
probe vs 2000 ms `PENDING_NEIGH_TIMEOUT_NS` gap in
`neighbor_dispatch.rs`. Separate file from `userspace-jit-design.md`, so
no conflict with #1636's own doc-update checkbox.

Closes #1639
Closes #1644
Closes #1645

🤖 Generated with [Claude Code](https://claude.com/claude-code)