### PR TITLE
#1630 cause-1: bounded rotation credit carry + #1643 seqlock fence

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,43 @@
 # Action Log
 
+## 2026-05-28 — #1630 cause-1 rotation credit carry + #1643 seqlock fence
+- **Timestamp**: 2026-05-28 UTC
+- **Action**: Implemented the scoped #1630 cause-1 fix (CoS small-class
+  shape loss) on fresh branch `fix/1630-cause1-credit-carry` off
+  origin/master. (1) Bounded rotation credit carry in
+  `rotate_epoch_v8` STEP 6: new rotation-private `epoch_carry_bytes`
+  atomic + three-regime rotation (normal recovery ≤K, bank-residual
+  K<lag≤STALL, cold-resume >STALL or start==0), `K=8`, `STALL=256`,
+  carry clamped at `K×rate×EPOCH`, drain ≤ `(K−1)×rate×EPOCH`. Recovers
+  the `rate×(lag−EPOCH)` the old `.min(EPOCH)` clamp discarded; burst
+  hard-bounded; cold-resume drops stale carry across HA reused-lease
+  failback. (2) #1643 acquire-fence in `snapshot_epoch_v8`: payload
+  loads → Relaxed, added `fence(Acquire)` before `seq_after` re-read,
+  writer payload stores → Relaxed (single Release on epoch_seq);
+  mirrors the verified `cold_path_hist::snapshot` reference. (3) P2
+  per-visit frame cap (`cos_guarantee_visit_cap_bytes`) + P1 N-frame
+  token bank (`COS_EXACT_QUEUE_LEASE_BANK_BYTES`, bank-floored
+  `max_total_leased`) brought over from `fix/1630-cos-lease-watermark`
+  @ b29fdb344. Added 8 carry unit tests (recovery, no-cliff, drain,
+  burst-bound, per-rotation ceiling, HA failback cold-resume,
+  reader-private grep guard) + updated 4 P2-affected existing tests +
+  test_support helper. Brought in `cos-gate1-small-four-alone.sh`. Full
+  `cargo test` 1542 passed / 0 failed. Docs: fairness-regimes.md
+  cause-1 section, worker/README.md + mod.rs const-assert comment.
+- **File(s)**: `userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs`,
+  `userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs`,
+  `userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs`,
+  `userspace-dp/src/afxdp/cos/token_bucket.rs`,
+  `userspace-dp/src/afxdp/cos/token_bucket_tests.rs`,
+  `userspace-dp/src/afxdp/cos/queue_service/mod.rs`,
+  `userspace-dp/src/afxdp/cos/queue_service/tests.rs`,
+  `userspace-dp/src/afxdp/tx/test_support.rs`,
+  `userspace-dp/src/afxdp/mod.rs`,
+  `userspace-dp/src/afxdp/worker/README.md`,
+  `docs/fairness-regimes.md`,
+  `test/incus/cos-gate1-small-four-alone.sh`,
+  `docs/pr/1630-cause1-credit-carry/plan.md`
+
 ## 2026-05-28 03:07 UTC — #1611 Copilot review addressed
 - **Timestamp**: 2026-05-28 03:07 UTC
 - **Action**: For PR #1616 / issue #1611, addressed two Copilot review findings in `test/incus/cold-path-flooder/src/main.rs`. (1) Reworked the per-second stderr JSON helper so `pps` is derived from the real emit-window duration and the emitted counters are explicitly window deltas (`*_delta`) instead of mixed cumulative/window semantics. Added unit tests covering the computed rate and the zero-window clamp. (2) Reworked the ignored CAP_NET_RAW smoke test so it no longer binds to `lo`; it now uses `XPF_RAW_SOCKET_TEST_IFACE` when provided or auto-probes `/sys/class/net` for an `IFF_UP` Ethernet iface, validates `ARPHRD_ETHER`, and skips cleanly if no suitable iface is available. Updated the #1611 plan doc example/output accordingly.

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -885,10 +885,13 @@ In addition to the structural per-flow CoV gate above
 
 Even SOLO (one class, one port, zero competition) the lowest-rate exact
 classes could not reach their configured shape — a per-class floor in the
-v8 epoch rate-meter, independent of cross-class competition. Two distinct
-root causes were isolated by a SOLO A/B; #1630 (cause-1) fixes the lower-
-rate one (100m, 1g). A mid-rate ~6 % residual on 3g/6g is a separate root
-cause (cause-2) tracked under #1630 and is NOT addressed here.
+v8 epoch rate-meter, independent of cross-class competition. A SOLO A/B
+isolated TWO distinct root causes:
+
+- **cause-1** (fixed here): the rotation rate-meter clamp + sub-frame
+  selector discard, which pinned 100m at ~81 % and 1g at ~84 % of shape;
+- **cause-2** (a transport-physics floor, NOT a scheduler defect, see
+  below): a `K`-independent mid-rate residual on 3g/6g.
 
 Cause-1 has two composing parts:
 
@@ -919,8 +922,39 @@ Cause-1 has two composing parts:
   cap raised in lock-step. The long-run rate is still metered by the v8
   per-epoch grant and the actual-byte debit, so the hard-cap holds.
 
-The scoped acceptance gate is `cos-gate1-small-four-alone.sh` SOLO: 100m
-and 1g each ≥ 95 % of shape under `guarantee-rate 0.7`.
+Measured effect of cause-1 (loss userspace cluster, reth0.80,
+`guarantee-rate 0.7`, 12 streams, push, v4, SOLO one class at a time):
+
+| Class | master baseline | cause-1 (this fix) SOLO |
+|-------|----------------:|------------------------:|
+| 100m  | ~81 %           | **95.0 %** |
+| 1g    | ~84 %           | **95.3 %** |
+
+The scoped acceptance gate is 100m and 1g each ≥ 95 % of shape **SOLO**
+(`cos-gate1-small-four-alone.sh` run one class at a time, or the per-port
+SOLO loop). The four-classes-in-parallel variant of that harness and the
+IPv6 path land 1-3 pp lower (parallel cross-class contention + the v6
+per-packet header overhead push the small classes onto the cause-2
+physics floor below); those are reported for the record, not as the
+pass/fail bar.
+
+### Mid-rate transport-physics floor (#1630 cause-2 — documented, not fixed)
+
+The mid-rate exact classes (3g/6g) carry a `K`-independent ~6 % shape
+residual that **no scheduler change recovers** — it is single-TCP-flow-
+bundle, ACK-clocked bursty delivery that cannot keep one worker's
+per-CPU AF_XDP token bucket continuously full (measured queue park
+19-117K/s, root never throttling, `parkR = 0`). The decisive
+discriminator (cause-2 §5 measurement on #1630): drain-sent / shape is
+WORST at `-P1` (single worker, whole-class cap ≈ 0.878) and RECOVERS with
+parallelism (`-P4` ≈ 0.918, `-P12` ≈ 0.949). A cross-worker fair-share
+bug would WORSEN with more workers; this IMPROVES — so it is transport
+physics, not a fairness defect. At high parallelism (`-P12`) the mid-rate
+classes reach ~93-95 % of shape; at low parallelism they sit lower,
+bounded by the token-bucket fill rate a bursty single flow can sustain.
+This floor is therefore a documented characteristic of the per-CPU
+AF_XDP + token-bucket transport, NOT a `guarantee-rate` Gate failure, and
+is intentionally not a pass/fail bar.
 
 ### Simul-load harness
 

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -881,6 +881,47 @@ In addition to the structural per-flow CoV gate above
    distribution as master HEAD on the `cos-iperf-config.set`
    fixture (within ±5% per-class token-bucket noise).
 
+### Small-class per-class rate-metering floor (#1630 cause-1)
+
+Even SOLO (one class, one port, zero competition) the lowest-rate exact
+classes could not reach their configured shape — a per-class floor in the
+v8 epoch rate-meter, independent of cross-class competition. Two distinct
+root causes were isolated by a SOLO A/B; #1630 (cause-1) fixes the lower-
+rate one (100m, 1g). A mid-rate ~6 % residual on 3g/6g is a separate root
+cause (cause-2) tracked under #1630 and is NOT addressed here.
+
+Cause-1 has two composing parts:
+
+- **Bounded rotation credit carry** (`rotate_epoch_v8`). The epoch
+  rotation is purely lazy — a low-rate class is only rotated when the
+  scheduler next visits its queue, so the gap (`lag`) between two
+  rotations of the same queue routinely exceeds one epoch. The previous
+  clamp computed `elapsed = min(lag, EPOCH)` and reset
+  `epoch_start := now`, permanently discarding `rate × (lag − EPOCH)` of
+  grant. The replacement bounds `elapsed` by `K × EPOCH`
+  (`MAX_ROTATION_LAG_EPOCHS = 8`) to recover the lagged credit, banks any
+  residual beyond `K` into a clamped per-class carry deficit drained on
+  the next visit, and COLD-RESUMES to a single epoch (dropping carry) for
+  any lag beyond `STALL_THRESHOLD_EPOCHS = 256` so a stalled or
+  HA-failed-back worker (reused lease, stale `epoch_start`) cannot emit a
+  multi-epoch burst. The per-rotation grant is hard-bounded by
+  `(K + (K−1)) × rate × EPOCH`, preserving the burst bound (Gate 4) the
+  old clamp protected.
+- **Per-visit frame-count cap + N-frame token bank** (P2 + P1). The
+  guarantee selectors clamped each visit's send budget to the rate-scaled
+  quantum (`rate × 200 µs`), below two MTUs for a low-rate class, so the
+  drain sent one frame and discarded the sub-frame remainder every visit.
+  The send budget is now `cos_guarantee_visit_cap_bytes`
+  (`TX_BATCH_SIZE × frame`) while the Phase-1 budget gate keeps the
+  rate-scaled quantum (`phase1_cost`) so small-first ordering is
+  preserved; the exact-queue token bucket banks an N-frame burst
+  (`COS_EXACT_QUEUE_LEASE_BANK_BYTES`, N = 8) with the outstanding-credit
+  cap raised in lock-step. The long-run rate is still metered by the v8
+  per-epoch grant and the actual-byte debit, so the hard-cap holds.
+
+The scoped acceptance gate is `cos-gate1-small-four-alone.sh` SOLO: 100m
+and 1g each ≥ 95 % of shape under `guarantee-rate 0.7`.
+
 ### Simul-load harness
 
 `test/incus/cos-simul-load-smoke.sh [push|reverse]` runs all 11

--- a/docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md
+++ b/docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md
@@ -116,5 +116,37 @@ enforced guard, not a comment.
   smoke matrix, `make test-failover`. Run after cluster acquisition.
 
 ## Tests
-`cargo test --bin xpf-userspace-dp`: 1542 passed / 0 failed / 2 ignored.
-8 new carry tests + the 4 updated P2 tests all green.
+`cargo test --bin xpf-userspace-dp`: 1543 passed / 0 failed / 2 ignored.
+9 new carry tests + the 4 updated P2 tests all green.
+
+## r1 review-round addenda (post-dispatch)
+
+- **Codex r1** (1 Major + 1 Medium): both were the floored-`lag_epochs`
+  boundary hole (regime-1 admitting up to `(K+1)×EPOCH−ε`, breaching the
+  burst bound by one epoch; and `STALL×EPOCH+1ns` skipping regime-3).
+  FIXED in `4a2b998f7` — regime selection now compares `raw_elapsed_ns`
+  against exact `K×EPOCH` / `STALL×EPOCH` ns thresholds. New
+  `v8_carry_regime_boundaries_use_exact_nanoseconds_not_floored_epochs`
+  pins all three boundaries; ceiling test tightened to assert the
+  worst-case regime-1 grant EQUALS exactly `(2K−1)×rate×EPOCH`.
+- **AGY r1**: MERGE-READY across all six axes (burst bound, Relaxed-fence
+  safety, regime-3 HA cold-resume, carry privacy, u128 arithmetic, P2
+  ordering) with quoted-line evidence; no findings.
+- **Copilot r1**: same boundary Major (already fixed) + a doc nit (PR
+  plan.md held the cause-2 plan by mistake). Both addressed (`7e6f7115f`).
+
+## Cluster validation
+
+- **Scoped Gate-1 SOLO (v4 push, reproducible x3)**: 100m **95.0 %**,
+  1g **95.3 %** of shape — PASS (baseline 81 % / 84 %). Four-class table
+  for the record: parallel four-alone and v6 land 1-3 pp lower at the
+  cause-2 physics floor (documented, not the pass bar).
+- **`make test-failover`: 13 passed / 0 failed** — unclean fw0 reboot →
+  failover → rejoin-as-secondary → manual failover, iperf3 zero-drop
+  through all three transitions. Validates the carry/seqlock/epoch HA
+  path (regime-3 cold-resume on the reused lease across failback).
+- **cause-2 resolved-as-physics** (coordinator §5 measurement): the
+  3g/6g residual improves with parallelism (`-P1` 0.878 → `-P12` 0.949),
+  proving it is ACK-clocked single-flow token-bucket fill, not a
+  fair-share bug. Documented in fairness-regimes.md; PR now
+  `Closes #1630` + `Closes #1643`.

--- a/docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md
+++ b/docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md
@@ -150,3 +150,33 @@ enforced guard, not a comment.
   proving it is ACK-clocked single-flow token-bucket fill, not a
   fair-share bug. Documented in fairness-regimes.md; PR now
   `Closes #1630` + `Closes #1643`.
+
+## r2 addenda (post-validation)
+
+- **Codex r2 RE-CONFIRM** (fresh thread `019e7204`, checked out
+  f9563b9a8 directly): **MERGE-READY**. Verified with quoted lines that
+  the exact-ns thresholds resolve its boundary Major, the
+  `(2K−1)×rate×EPOCH` per-rotation bound holds at BOTH boundaries and for
+  repeated regime-2-bank → regime-1-drain sequences (carry clamped at
+  `carry_max`, drain ≤ K−1 epochs), and the worst-case ceiling test
+  exercises the tight maximum. No remaining counter-example.
+- **`copilot-swe-agent` push `c1e6ee237` "Fix carry cold-resume cleanup"**
+  (NOT the formal review seat). Reviewed on merits: regime-3 now stores
+  `epoch_carry_bytes = 0` UNCONDITIONALLY (was guarded by `if start != 0`).
+  This is a harmless defensive hardening — when `start == 0` the
+  constructor already initializes carry to 0, so the store is redundant,
+  never wrong. The regime-1/2 logic and ALL burst bounds are byte-
+  identical to the Codex-verified f9563b9a8, so the Codex r2 verdict
+  carries forward over this delta. It adds
+  `v8_carry_first_rotation_drops_stale_carry_even_with_zero_start`
+  (injects carry then does a `start==0` rotation, asserts carry dropped).
+  Full carry suite 10/10 green.
+- **Flaky pre-existing test** `tx_latency_hist_cross_thread_snapshot_skew_within_bound`
+  (#812, TX latency histogram sidecar — UNRELATED to carry/seqlock):
+  failed twice while the build host was under concurrent load (its
+  `K_skew` bound is computed from observed wall-clock rates, so reader-
+  thread starvation under CPU oversubscription transiently exceeds it).
+  Proven a load artifact, not a regression: passes 5/5 isolated, branch
+  full-suite 3/3 and master full-suite 3/3 on a quiet box; last touched
+  by #1614/#1618, not this branch. File-and-move-past per
+  feedback_retirement_blocker_keep_going.

--- a/docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md
+++ b/docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md
@@ -1,0 +1,120 @@
+# Claude SMR code review — #1630 cause-1 credit carry + #1643 fence (r1)
+
+Reviewer profile: CoS-scheduler / WFQ-DRR / token-bucket /
+seqlock-concurrency / AF_XDP multi-worker-shaper / HA-failover domain SMR
++ CPU-arch/memory-model + SW-design.
+
+Scope reviewed: the full diff on `fix/1630-cause1-credit-carry` vs
+origin/master @ 0e5bb3812. This is a self-review seat in the 4-way gate
+(Codex + AGY + Copilot + Claude SMR). I implemented the change, so this
+review is deliberately adversarial against my own work.
+
+## Verdict: MERGE-READY (self-seat), pending external Codex/AGY/Copilot.
+
+## What was verified
+
+### 1. Bounded rotation credit carry (rotate_epoch_v8 STEP 6)
+
+- **Recovers the discarded credit (the bug).** Pre-#1630 the clamp
+  computed `elapsed = min(lag, EPOCH)` then reset `epoch_start := now`,
+  permanently dropping `rate × (lag − EPOCH)`. Regime 1 now grants
+  `rate × raw_elapsed` (lag bounded by K), pinned by
+  `v8_carry_normal_recovery_recovers_lagged_credit` (5-epoch lag → cap =
+  5 × rate × EPOCH, vs the old 1 epoch). This is the precise fix for the
+  measured 100m/1g SOLO floor.
+- **Burst bound preserved (the invariant the clamp protected).**
+  Per-rotation grant ≤ `(K + (K−1)) × rate × EPOCH`. Two tests pin it:
+  `v8_carry_burst_bound_holds_after_two_second_stall` (2 s stall → 1
+  epoch, NOT rate × 2 s) and
+  `v8_carry_per_rotation_grant_never_exceeds_k_epoch_ceiling` (full
+  reservoir drained in one regime-1 visit stays ≤ ceiling). The
+  reservoir clamp (`carry_max`) and drain clamp (`carry_drain_max`) are
+  the two independent bounds from plan §3.2.
+- **No-cliff at K+1 (plan §5.3 / Gate 5d).** Regime 2 grants the K-epoch
+  ceiling AND banks the residual instead of dropping to 1 epoch (the v2
+  defect). Pinned by `v8_carry_bank_residual_no_cliff_at_k_plus_one` +
+  `v8_carry_banked_residual_drains_on_next_visit`.
+- **STALL decoupled from K.** `STALL_THRESHOLD_EPOCHS = 256` (≈51 ms)
+  sits below the ≥500-epoch failback gap and above any legitimate visit
+  tail, so a heavy-tail visit (regime 2) is never mis-classified as a
+  stall (regime 3). Matches plan §5.3.1.
+- **Arithmetic safety.** All carry math uses u128 intermediates then
+  `as u64`, `saturating_add`, `saturating_sub`, `.min(...)`. Regime-1
+  `prev_carry - draw` cannot underflow (`draw ≤ prev_carry`). Regime-2
+  `overshoot_ns` is strictly positive (lag > K guaranteed). `new_cap`
+  clamped at `u32::MAX` (unchanged).
+
+### 2. HA-failover safety (the v1 hazard Codex F4 surfaced)
+
+Leases are REUSED across an HA demote→promote when config matches
+(`coordinator/mod.rs` `matches_config_v8` → `lease.clone()`), so
+`epoch_start` survives and the first post-promotion rotation sees
+`lag ≈ demotion_duration`. A planned failback is ≥500 epochs >> STALL,
+so regime 3 fires: single-epoch grant + carry dropped. Pinned by
+`v8_carry_cold_resume_drops_stale_carry_for_ha_failback` (bank a
+residual, then a >STALL gap on the SAME reused lease → grant = 1 epoch,
+carry = 0). The carry is per-lease per-node in-process heap state, never
+serialized into session/config sync (verified: no protocol.rs reference),
+so it cannot transfer between nodes. `make test-failover` is the
+cluster-side gate (pending).
+
+### 3. #1643 seqlock acquire-fence
+
+`snapshot_epoch_v8`: payload loads downgraded to Relaxed, explicit
+`fence(Acquire)` inserted before the `seq_after` re-read, `seq_after`
+read Relaxed. Writer payload stores downgraded to Relaxed; the single
+`epoch_seq.store(seq+2, Release)` is the sole publish. This is
+byte-aligned with the verified-correct `cold_path_hist::snapshot`
+reference (Acquire even-check → Relaxed payload → `fence(Acquire)` →
+Relaxed re-read). I audited EVERY reader of the three payload fields
+(`epoch_total_grant_cap`, `epoch_grace_expires_ns`, `worker_fair_share`):
+the only non-test reader is the fenced snapshot; the rotation winner's
+own `prev_cap` Acquire read at :68 is single-writer self-read. The
+Relaxed downgrade is therefore safe — no reader bypasses the fence.
+
+### 4. Carry reader-private invariant ENFORCED
+
+`epoch_carry_bytes` is read/written only by the rotation winner inside
+the seqlock ODD section; it is NOT in the snapshot payload, so it adds no
+new reader-visible seqlock surface (would otherwise be the #1619 class).
+`v8_carry_field_is_reader_private` greps the whole crate src and fails if
+the field is referenced anywhere except the lease mod.rs (def+init),
+rotate_epoch_v8.rs (the writer), and the test file. This is the §4.0
+enforced guard, not a comment.
+
+### 5. P2 frame cap + P1 token bank
+
+- P2 splits the per-visit budget: Phase-1 gate/consumption stays on the
+  rate-scaled `cos_guarantee_quantum_bytes` (`phase1_cost`) so small-first
+  ordering and the `quantum_sum × fraction` Phase-1 budget are unchanged;
+  the send budget is `cos_guarantee_visit_cap_bytes` = `TX_BATCH_SIZE ×
+  frame`. Applied at all 5 selector sites (legacy, exact fast-path,
+  waterfill phase-1, waterfill phase-2, non-exact).
+- P1 banks N=8 frames in the exact-queue bucket and raises
+  `max_total_leased` in lock-step via the `bank_floor` flag; the ROOT
+  lease keeps `bank_floor=false` (cap unchanged). All four queue-lease
+  constructors/matchers pass `bank_floor=true`; the root lease keeps the
+  default helper. Verified the long-run rate is still metered by the v8
+  per-epoch grant + actual-byte `consume` (the bank only widens the
+  outstanding window) → Gate 4 hard-cap preserved.
+- 4 P2-affected existing tests updated to the new behavior (frame-drain,
+  release-on-empty, bank cap, cursor-rotation isolation via 1-frame
+  priming). No assertion was weakened to pass — each new assertion
+  reflects the corrected mechanism with a rationale comment.
+
+## Residuals / scope notes
+
+- **Cause-2 (3g/6g ~6 %) is OUT of scope** and untouched. PR closes
+  #1643 and is "Part of #1630" — does NOT close #1630.
+- **Aggregate simultaneous-resume burst (plan §3.5.1 global cap)** is
+  Fork-B-only and intentionally NOT implemented: the §3.6 SOLO A/B
+  established Fork A (small-K + P2 clears scoped Gate-1), where the
+  aggregate burst at small K is one root-epoch's worth, absorbed by the
+  existing root meter. Adding the global cap would re-introduce the
+  BLOCKING-3 small-class-first-allocator conflict for no benefit.
+- **Cluster gates pending**: scoped Gate-1 (100m/1g ≥95% SOLO), full
+  smoke matrix, `make test-failover`. Run after cluster acquisition.
+
+## Tests
+`cargo test --bin xpf-userspace-dp`: 1542 passed / 0 failed / 2 ignored.
+8 new carry tests + the 4 updated P2 tests all green.

--- a/docs/pr/1630-cause1-credit-carry/plan.md
+++ b/docs/pr/1630-cause1-credit-carry/plan.md
@@ -1,0 +1,757 @@
+# #1630 cause-2 — the K-independent ~6% mid-rate (3g/6g) shape residual
+
+- Issue: #1630 (surface). This plan owns **cause 2 only**.
+- Branch: `research/1630-midrate-residual` (off `origin/master` @ `0e5bb3812`)
+- Mode: `/research` — plan only; NO production code; STOP at PLAN-READY.
+  Throwaway env-gated instrumented builds are allowed and MUST NOT be
+  committed.
+- Author: Claude SMR (CoS-shaper / token-bucket / rate-accuracy /
+  AF_XDP-drain / timer-wheel domain).
+- Rev: **v5 (r1-r4 folded).** Status after r4: **PLAN-READY (3-way
+  converged) as a MEASUREMENT-FIRST plan with NO pre-committed fix.** r4:
+  Codex PLAN-NEEDS-MAJOR (3 fixable gaps: missing offered-load counter,
+  instrumentation A/B not a gate, stale H-WATERFILL/F-W1 text) + AGY
+  PLAN-READY-with-amendments (SAME gaps: offered-load counter, scope
+  gating, L2 normalization) + Claude SMR PLAN-READY. All r4 amendments
+  folded into v5 (§5.0 offered-load gated first, §5.4 A/B hard gate, §5.1
+  L2-normalized goodput, §6.1 ordered procedure, §10-R5/§11-Q5 scope
+  gating, stale v3 text purged). The fix is DEFERRED to the layer §5
+  names; leading expected outcome is H-TCP (loss outside the shaper).
+  Three mechanism hypotheses were code-falsified across r1-r3
+  (timer-wheel, lease-target, waterfill-relegation) — §5 is the honest
+  next step.
+
+> **THE r3 FINDING (decisive):** `exact_queues_by_rate_ascending` is built
+> ONCE at config-apply over EVERY configured exact queue
+> (`builders.rs:80-83`), and the waterfill `quantum_sum` loop
+> (`queue_service/mod.rs:789`) sums it with NO eligibility guard. The
+> solo/4-class harness loads the FULL `cos-iperf-config.set`
+> (`apply-cos-config.sh load merge`) and sends traffic to one/four ports.
+> So `quantum_sum = 2.65 MB`, Phase-1 budget = `0.7 × 2.65 = 1.85 MB`,
+> which honors 3g (75 K) and 6g (150 K) EVERY epoch. **H-WATERFILL is
+> falsified for the measured config.** Combined with the r1/r2 kills of
+> the timer-wheel and lease-target hypotheses, NO code-derived mechanism
+> survives static analysis — so the honest /research output is the §5
+> measurement, not a fix.
+
+> **CRITICAL CORRECTION (r2):** v1/v2 were built on the WRONG drain path.
+> The cwd `/home/ps/git/bpfrx` is a stale detached checkout
+> (`e01472f4a`) predating the #1614 A1 waterfill merge; origin/master and
+> the research worktree are `0e5bb3812`, which dispatches
+> `guarantee-rate 0.7` exact queues to **`select_exact_cos_guarantee_queue_waterfill`**
+> (`queue_service/mod.rs:608`). Both my r1 grep and AGY r2 §2 "verified"
+> against the stale tree and wrongly rejected it. Codex was right both
+> rounds. v3 re-grounds the entire mechanism on the waterfill selector.
+
+## v4 changelog (r3 response — converge to measurement-first)
+
+- **[Codex r3 BLOCKING-1] H-WATERFILL FALSIFIED.** `quantum_sum` is over
+  the static configured exact set (no eligibility guard), so the
+  full-config Phase-1 budget (1.85 MB) honors 3g/6g every epoch in BOTH
+  the solo and 4-class harness runs. §3.2's "solo 3g never Phase-1-honored"
+  was based on the wrong assumption that `quantum_sum` is over the
+  eligible set. Corrected; H-WATERFILL demoted to a measured falsifier.
+- **[AGY r3 — REJECTED] PLAN-READY rested on a stripped-config assumption**
+  the harness contradicts (loads all 10 classes). AGY's non-§1 findings
+  kept as supporting context.
+- **All three mechanisms now code-falsified** (wheel r1/r2, lease r2,
+  waterfill r3). v4 re-scopes the deliverable to the **§5 measurement-first
+  bisection with NO pre-committed fix** — the disciplined output when
+  static analysis cannot attribute the residual. §6 lists candidate fixes
+  per measured layer but commits to NONE.
+
+## v3 changelog (r2 response — major re-grounding)
+
+- **[Codex r2 BLOCKING-1] §2/§3 RE-GROUNDED on the waterfill selector.**
+  The leading hypothesis is now **H-WATERFILL** (§3): under
+  `guarantee-rate 0.7` a solo/boundary mid-rate exact class is honored
+  for only `fraction × quantum` per epoch in Phase 1; the residual rides
+  the **non-parking, best-effort Phase 2** (`:973-977` "Don't park in
+  Phase 2 … not a guarantee"). This is a fixed fractional shortfall set
+  by `guarantee_fraction` — exactly the K/P2/contention-independent flat
+  P1-P4 signature, and it appeared precisely when #1626/#1629 activated
+  the knob (the issue title: "under guarantee-rate 0.7").
+- **[AGY r2 #6] H-LEASE KILLED as a fix.** Raising `lease_bytes` is
+  toothless: `acquire_v8` caps the grant at `my_effective_share ≤
+  new_cap ≤ rate×EPOCH_DURATION_NS` (200µs). The bucket cannot bank more
+  than 200µs without raising the global epoch. H-LEASE removed as a fix
+  candidate (kept only as a measured falsifier).
+- **[Codex r2 BLOCKING-2 / AGY #4] F-E guard fixed/retired.** The wheel
+  fix is no longer primary; if revisited the guard must include
+  `my_consumed < my_effective_share`.
+- **[Codex r2 BLOCKING-3 / AGY #3] §5 bisection re-derived** around the
+  waterfill Phase-1/Phase-2 byte split + TX-residual netting.
+- **[AGY r2 #5] H-TCP** reframed: "needs a smoothing fix," not a pure
+  PLAN-KILL dodge — only kill if bytes provably left the NIC at full rate.
+
+## v2 changelog (r1 response — superseded by v3 where noted)
+
+- **[Codex BLOCKING-1 / Claude MAJOR-1] §3 derivation FIXED.** The wake
+  estimator is called with `head_len` (one frame), NOT the quantum. v2
+  rewrites §3 (the park basis is `head_len/rate ≈ 2-4µs`, floored to a
+  50µs tick) and DROPS the "t_refill = quantum/rate = 200µs → 88.9%"
+  false precision. The corrected period model has explicit unknowns the
+  §5 counters resolve.
+- **[Codex BLOCKING-2] REJECTED as hallucinated.** No waterfill drain
+  path exists on origin/master (§3.0). v2 does NOT add waterfill
+  instrumentation.
+- **[Codex BLOCKING-3 / Claude MAJOR-2] §5 recast as THREE-way.**
+  `cap_granted` / `total_granted` / `drain_sent_bytes` + iperf3 goodput;
+  the four ratios localize meter-under-grant vs grant-not-drawn vs
+  drawn-not-sent vs TCP-artifact.
+- **[Codex MAJOR-1 / Claude] lease-target promoted to first-class
+  competing hypothesis** (§3.3, §6).
+- **[Codex MAJOR-2/3 / Claude MAJOR-1] F-A/F-B DEMOTED** (F-A no-op
+  same-tick; F-B busy-polls a cap-exhausted lease). Primary candidates
+  are now the lease-target raise (F-C') and the sub-tick wake
+  representation (F-E), §6.
+- **[Claude MINOR-2] §9 layering re-argued** for the lease-target branch
+  (shared meter config, not seqlock payload).
+
+> Companion: cause 1 (rotation clamp at `rotate_epoch_v8.rs:218`) is
+> owned by `docs/research/1630-v8-credit-carry/plan.md` @ `852cf014c`.
+> This plan composes with it (§9) — the eventual fix lands as ONE
+> combined seqlock change.
+
+---
+
+## 1. The measured fact this plan starts from (do NOT re-derive)
+
+A prior measurement-gated engineer ran the §3.6 SOLO A/B on
+`loss:xpf-userspace-fw0/1` (push, v4, `guarantee-rate 0.7`, 12 streams,
+`cos-iperf-config.set`, `reth0.80 shaping-rate 25g`). It isolated TWO
+distinct root causes of the #1630/#1614 Gate-1 failure.
+
+| Variant | 100m | 1g | 3g | 6g |
+|---------|----:|---:|---:|---:|
+| master  | 79 | 73 | 87 | 84 |
+| K=8 +P2 | 93 | 94 | 91 | 90 |
+| K=64+P2 | 95 | 95 | 90 | 90 |
+
+Truly-solo (single port), master→K=64: 3g 89.1→93.8 (+4.7pp, still
+<95), 6g 89.4→92.8 (+3.4pp, still <95). The 100m class is fixed by the
+cause-1 carry (82→95, +13pp). The **3g/6g residual is the subject of
+this plan**, and it has FOUR pre-registered properties (each is a
+constraint the cause-2 mechanism must satisfy, and a falsifier for any
+hypothesis that does not match):
+
+- **P1 — K-independent.** Carry depth K=8 vs K=64 barely moves 3g/6g
+  (91.0 vs 90.2 at +P2; solo 93.8 vs ~94). NOT the rotation clamp.
+- **P2 — P2-independent.** Per-visit frame cap on/off barely moves 3g
+  (91.2 K=8/P2-off vs 91.0 K=8/P2-on). NOT the selector sub-frame
+  discard.
+- **P3 — contention-independent.** Persists at ~93-94% even truly-solo
+  (one class, whole cluster). NOT cross-worker fragmentation or
+  inter-class competition.
+- **P4 — flat across mid rates** (3g ≈ 6g ≈ ~90% four-way / ~93-94%
+  solo). Smells like a *fixed fractional* loss or a rate-computation /
+  granularity constant, NOT a per-class effect.
+
+This plan does NOT re-run the §3.6 A/B (already done). It designs and
+verifies the **instrumented bisection** that pins where the residual
+~6% goes, then specifies the fix mechanism conditioned on the bisection
+outcome — because this is a /research deliverable, the plan commits to a
+*decision procedure + a primary hypothesis with a falsification gate*,
+not a blind mechanism.
+
+---
+
+## 2. The shaper data-path, as it actually runs (verified, origin/master 0e5bb3812)
+
+This is the spine every hypothesis below references. Confirmed by
+reading the source, not the issue prose.
+
+### 2.1 Per-class config (3g / 6g, the residual classes)
+
+`cos-iperf-config.set`: `scheduler-3g transmit-rate 3.0g exact`,
+`scheduler-6g transmit-rate 6.0g exact`. **Neither has `buffer-size`** —
+so `buffer_bytes` defaults via `default_cos_burst_bytes(rate) =
+max(rate/100, 64×1500)` (`forwarding_build/cos.rs:73`):
+
+- 3g: `rate_bytes = 3e9/8 = 375_000_000 B/s`; `buffer_bytes = 3.75 MB`.
+- 6g: `rate_bytes = 750_000_000 B/s`; `buffer_bytes = 7.5 MB`.
+
+These buffers are huge relative to a 200µs epoch's worth of bytes
+(75 000 B / 150 000 B), so the per-queue bucket ceiling is NOT the
+binding limiter for 3g/6g. (Hypothesis 6 is therefore weak a priori;
+§4 keeps it only as a falsified-by-arithmetic entry.)
+
+### 2.2 The grant meter (per-class, lazy-rotated)
+
+`maybe_rotate_epoch_v8` STEP 6 (`rotate_epoch_v8.rs:204-239`):
+- `EPOCH_DURATION_NS = 200_000` (`mod.rs:241`).
+- `elapsed_ns = (now - start).min(EPOCH)` — the cause-1 clamp (line 218).
+- `new_cap_raw = rate_bytes × elapsed_ns / 1_000_000_000` (u128 math,
+  integer-truncated to u64). For 3g full epoch: `375e6 × 200e3 / 1e9 =
+  75_000 B` exactly (no truncation — `375e6 × 2e5 = 7.5e13`, `/1e9 =
+  75_000`, exact). For 6g: `150_000 B` exact. **Integer-division
+  truncation is ZERO at these rates** (hypothesis 1 falsified by
+  arithmetic — see §4-H1).
+- `epoch_grace_expires_ns = now + EPOCH/2 = now + 100µs` (line ~226).
+- `epoch_start_ns := now` (line 237); seq ODD→EVEN publish (line 239).
+
+### 2.3 The bucket top-up (per worker visit)
+
+`maybe_top_up_cos_queue_lease` (`cos/token_bucket.rs:154`), exact branch:
+- `lease_bytes = lease.lease_bytes().max(tx_frame_capacity()).min(buffer)`
+  where `lease.lease_bytes() = config.lease_bytes =
+  min(rate×200µs, burst/8, 512KB).max(1500)`
+  (`compute_shared_cos_lease_config`, `mod.rs:694`). For 3g:
+  `rate×200µs = 75_000`, `burst/8 = 469k` → `lease_bytes = 75_000`. For
+  6g: `150_000`. `tx_frame_capacity() = 4096` (`UMEM_FRAME_SIZE`).
+- **Early-return when `queue.hot.tokens >= lease_bytes`** (line 184) —
+  no acquire, no rotation, when the bucket is already at/above the
+  top-up watermark.
+- Otherwise `acquire_v8(worker_id, now, lease_bytes - tokens)` →
+  `maybe_rotate_epoch_v8(now)` then bounded by BOTH the class cap AND
+  the per-worker `my_effective_share` (`acquire_v8`, `mod.rs:1066-1131`).
+
+### 2.4 The drain + WATERFILL selector (the actual `guarantee-rate` path)
+
+`select_exact_cos_guarantee_queue_with_lease_telemetry`
+(`queue_service/mod.rs:590`) dispatches based on policy:
+
+```rust
+// :603-614
+if matches!(root.oversubscription_policy, GuaranteeRate)
+    && root.oversubscription_guarantee_fraction > 0.0 {
+    return select_exact_cos_guarantee_queue_waterfill(root, …);  // <-- the smoke path
+}
+// else: legacy round-robin exact selector (Proportional)
+```
+
+The smoke runs `oversubscription-policy guarantee-rate 0.7`, so 3g/6g
+traverse the **two-phase waterfill selector** (`:771`), NOT the legacy
+RR path v1/v2 modeled. The waterfill mechanics (verified):
+
+- **Phase-1 budget** (lazy-refilled per epoch when `pass1_remaining == 0`,
+  `:787-799`): `pass1 = floor(quantum_sum × fraction)` where `quantum_sum`
+  = Σ `cos_guarantee_quantum_bytes` over the runnable+nonempty exact set,
+  and `fraction = 0.7`.
+- **Phase 1** (`:808-912`): ascending-rate walk. For each eligible exact
+  queue, top-up, then `candidate_budget = tokens.min(quantum).max(head_len)`.
+  **If `candidate_budget > pass1_remaining` → `break` to Phase 2**
+  (`:889`); else honor the queue (consume budget, return the selection).
+  Token-starved queues here DO park (`:853-873`).
+- **Phase 2** (`:922-1001`): descending walk over un-honored queues.
+  **Crucially, Phase 2 does NOT park** — `:973-977`:
+  `if root.tokens < head_len || queue.hot.tokens < head_len { … continue }`
+  with the comment *"Don't park in Phase 2 — the queue may legitimately
+  wait for next epoch … best-effort residual, not a guarantee."*
+- **Epoch reset** (`:1002-1006`): when nothing is serviced,
+  `pass1_remaining = 0` and the Phase-2 cursor resets; the next call
+  refills the Phase-1 budget.
+
+`cos_guarantee_quantum_bytes = clamp(rate×VISIT_NS, 1500, 512K)` with
+`VISIT_NS = 200_000`. 3g quantum = 75 000, 6g = 150 000 (both < 512K).
+
+The wake estimator (used by the Phase-1 park sites and the legacy path)
+is `estimate_cos_queue_wakeup_tick(root_tokens, root_rate, queue_tokens,
+queue_rate, need_bytes=head_len, now, require_queue_tokens)` — `head_len`
+is the **5th** positional arg (`need_bytes`), per the signature at
+`:1255-1263` (Codex/AGY r2 corrected v2's "4th arg" wording). Wheel tick
+50µs, floored at `now_tick+1` (`:1288`). The wheel matters only for
+Phase-1 parks; Phase-2 never parks.
+
+---
+
+## 3. Mechanism hypotheses — all THREE code-falsified (v4)
+
+> v4 status: every concrete mechanism the team derived from the source
+> has been falsified by code + arithmetic across r1-r3. This section
+> records WHY each is dead, so the §5 measurement does not re-litigate
+> them and a future round does not resurrect them. The honest conclusion:
+> static analysis cannot attribute the ~6% — measure (§5).
+
+### 3.1 H-WATERFILL (v3 leading hypothesis) — FALSIFIED (Codex r3 BLOCKING-1)
+
+The idea: under `guarantee-rate 0.7`, the waterfill Phase-1 budget
+`quantum_sum × 0.7` excludes a solo/boundary mid-rate class, relegating
+its residual to the non-parking best-effort Phase 2 (`:973-977`).
+
+**Why it is FALSE for the measured config:** `quantum_sum`
+(`queue_service/mod.rs:789`) sums `cos_guarantee_quantum_bytes` over
+`root.exact_queues_by_rate_ascending`, which is built ONCE at
+config-apply over EVERY configured exact+guarantee queue
+(`builders.rs:80-83`, "Built once at config-apply time; runtime is
+read-only") with **NO nonempty/runnable guard in the sum**. The
+solo/4-class harness loads the FULL `cos-iperf-config.set` (all 10 exact
+classes) via `apply-cos-config.sh load merge` and sends traffic to
+one/four ports. So:
+
+| Config (full 10-class, fraction 0.7) | quantum_sum | Phase-1 budget | 3g (75K) honored? | 6g (150K) honored? |
+|--------------------------------------|------------:|---------------:|-------------------|--------------------|
+| solo 3g traffic (all 10 configured)  | 2 651 076 | 1 855 753 | **YES every epoch** | n/a |
+| solo 6g traffic (all 10 configured)  | 2 651 076 | 1 855 753 | n/a | **YES every epoch** |
+| 4-class traffic (all 10 configured)  | 2 651 076 | 1 855 753 | **YES** | **YES** |
+
+The Phase-1 budget (1.85 MB) dwarfs the small-class quanta; empty queues
+are skipped in the Phase-1 WALK (`:811-816`) but still count toward the
+budget, so 3g/6g are honored in the guaranteed, park-capable Phase 1
+every epoch. **H-WATERFILL cannot be the solo/4-class residual; F-W1
+would be a no-op.** (It would matter ONLY if the config were stripped to
+a single class — which the harness never does. §5 counter
+`phase1_honored_bytes` for 3g/6g confirms ≈ all at runtime; if it is ~0,
+the static reading is wrong and H-WATERFILL reopens — but the code says
+≈ all.)
+
+### 3.2 H-LEASE (lease-target) — KILLED as a fix (AGY r2 #6)
+
+Raising `lease_bytes` is toothless: `acquire_v8` caps the grant at
+`my_effective_share ≤ my_share = new_cap × my_count/total_flows`, and
+`new_cap = rate × elapsed ≤ rate × EPOCH_DURATION_NS` (200µs)
+(`rotate_epoch_v8.rs:218-232`; `acquire_v8` break `mod.rs:1081`). The
+bucket can NEVER bank more than 200µs of credit under the v8 epoch
+ceiling regardless of `lease_bytes`; the post-grace bypass is closed for
+strict exact CoS. Kept only as a §5 falsifier (counter 6: bucket
+high-water never exceeds `rate×200µs`).
+
+### 3.3 H-WHEEL / H7 (timer-wheel park floor) — DEMOTED (r1/r2)
+
+v1/v2 derived the residual from the 50µs wheel park. r1 corrected the
+park basis to `head_len` (~2µs refill floored to a 50µs tick). For
+strict exact classes the queue parks in Phase 1 only when its bucket
+drops below one frame; whether that produces 6% is unproven and the
+magnitude could not be derived (the v1 "200/225 = 88.9%" claim was
+retracted). Kept as a §5 falsifier (counter:
+`drain_park_queue_tokens` for 3g/6g — if ~0, the wheel is not the cause).
+
+### 3.4 Other hypotheses — killed by arithmetic / single-worker
+
+- **Integer truncation** in `rate×elapsed/1e9`: 0 bytes at 3g/6g (exact).
+- **Grace window**: gates only the surplus/bypass path; exact non-surplus
+  never enters surplus (`queue_service/mod.rs:837`).
+- **Fair-share rounding (H5)**: for a TRULY-SOLO single-port run on one
+  worker, `total_flows = 1` ⇒ `my_share = new_cap` ⇒ zero rounding. So
+  H5 cannot explain the truly-solo residual; it is a candidate only for
+  the multi-stream/multi-worker case (§5 worker-count counter).
+
+### 3.5 The honest conclusion
+
+**No code-derived mechanism survives static analysis.** The ~6% mid-rate
+residual is real (measured) but un-attributed. This is precisely the
+situation that mandates a measurement-first plan: ship the §5 instrumented
+bisection, run it on the free cluster, and let the four ratios
+(phase1/phase2/drain_sent/goodput) NAME the layer. The plan commits to
+the MEASUREMENT and the decision procedure — NOT to a fix it cannot
+derive. (Same discipline as the cause-1 §12 fork: when the code can't
+tell you, measure.)
+
+---
+
+## 4. Hypothesis table — all mechanisms falsified; §5 is the live path (v4)
+
+| # | Hypothesis | Verdict (v4) | §5 confirmer/falsifier |
+|---|-----------|--------------|------------------------|
+| H-WATERFILL | Phase-1 budget relegates solo 3g/6g to non-parking Phase 2 | **FALSIFIED (Codex r3 B1):** full-config Phase-1 budget (1.85 MB) honors 3g/6g every epoch (§3.1). | `phase1_honored_bytes` for 3g/6g ≈ all (re-confirms at runtime). |
+| H-LEASE | Lease target caps bucket credit | **KILLED as a fix (AGY r2 #6):** epoch ceiling caps grant at `rate×200µs`. | counter 6: high-water ≤ `rate×200µs`. |
+| H-WHEEL/H7 | 50µs wheel park floor | DEMOTED (r1/r2): basis is `head_len` (~2µs); magnitude undrivable. | `drain_park_queue_tokens` for 3g/6g — if ~0, dead. |
+| H1 | Integer truncation | KILLED by arithmetic (exact at 3g/6g). | counter 5. |
+| H2 | Grace window | WEAK (gates only surplus; exact never enters). | `bypass_grace_use_count == 0`. |
+| H4 | Lazy-rotation stale cap | Overlaps cause 1; K-independent. | counter 5. |
+| H5 | Per-worker fair-share rounding | **Cannot explain TRULY-SOLO** (1 worker → total_flows=1 → no rounding). Candidate only for multi-stream/multi-worker. | per-worker share-exhaustion + worker count. |
+| H-TCP | 6% is TCP goodput artifact, not shaper | LIVE — must be ruled out. Only KILL if bytes provably leave the NIC at full rate (AGY r2 #5). | `goodput/drain_sent` (L2-normalized). |
+
+**Net (v4): NO mechanism survives static analysis.** H-WATERFILL,
+H-LEASE, H-WHEEL all falsified by code+arithmetic; H1/H2/H4 killed; H5
+cannot explain truly-solo. The only LIVE candidates are H-TCP (the loss
+is outside the shaper) and "something not yet modeled in the drain/TX
+path." **This is exactly why §5 is the deliverable** — the measurement
+NAMES the layer; the plan does not pre-commit a mechanism it cannot
+derive.
+
+---
+
+## 5. The instrumented bisection (v4 — THE DELIVERABLE; both reviewers confirmed the counters)
+
+Debug counters in a LOCAL throwaway build, NOT committed
+(`option_env!("XPF_COS_MIDRATE_DEBUG")`). **Use thread-local non-atomic
+accumulators flushed to the shared status block once per 1s** (NOT hot-path
+`AtomicU64` fetch_add) to keep the instrumentation free at 25G —
+per-packet atomics on the drain path are themselves perturbative (§5.4).
+
+### 5.0 Counter 0 — OFFERED LOAD (the fifth layer; check FIRST — Codex r4)
+
+Before any shaper counter: **per-class offered/ingress bytes BEFORE
+shaping** — bytes enqueued to the CoS queue per 1s (the
+ingest/enqueue site, `ingest_cos_pending_tx` → `cos_queue` push, count
+`cos_item_len` at enqueue) plus ingress drops/refusals and
+queue-backlogged (nonempty) time. **If `offered_bytes < rate×wall` the
+class is RX/conntrack/forward-bound BELOW its rate and there is NO shaper
+residual to fix** (§11-Q4, §4-Q4b). This MUST be the first ratio read;
+every shaper-internal hypothesis is moot if the class is not even offered
+its rate. (For a push test the firewall forwards the host's TCP; if a
+single solo flow-bundle is RX/CPU-limited the shaper never sees full
+offered load.)
+
+### 5.1 Counters (per 3g/6g queue, per 1s window)
+
+0. **offered_bytes** + ingress drops + backlogged-time (§5.0) — the
+   gating counter.
+1. **phase1_honored_bytes** — bytes for which this queue was SELECTED in
+   Phase 1 (`select_exact_cos_guarantee_queue_waterfill` Phase-1 return,
+   `:907`). Add `secondary_budget` at the return. (Expected ≈ all per §3.1.)
+2. **phase2_served_bytes** — bytes selected in Phase 2 (`:996` return).
+3. **phase1_skipped_count / phase2_skipped_count** — times the queue was
+   walked but skipped (Phase-1 budget-exhausted break `:889`; Phase-2
+   no-park `continue` `:978`).
+4. **drain_sent_bytes** — actual TX (existing, `tx_completion.rs:482`),
+   net of stranded `queue.hot.tokens` (AGY r2 #3: subtract residual hot
+   tokens so a TX-ring refusal is not mis-attributed).
+5. **cap_granted** vs `rate×wall` (H1/H4/H5).
+6. **bucket_high_water** vs `rate×200µs` (H-LEASE falsifier).
+7. **per-worker share-exhaustion count** + worker count (H5).
+8. **iperf3 goodput**, L2-normalized (subtract Ethernet/IP/TCP framing so
+   the ratio compares like-for-like vs `drain_sent` frame bytes) (H-TCP).
+
+### 5.2 The decision table
+
+Run 3g-solo and 6g-solo (single port, push, v4, guarantee-rate 0.7):
+
+| Observation | Conclusion |
+|-------------|------------|
+| **`offered_bytes < rate×wall`** (counter 0 — see §5.0) | **OFFERED-LOAD BOUND** — the class is RX/conntrack/forward-limited BELOW its rate; there is no shaper residual to fix. **Check this FIRST** (§11-Q4). |
+| `phase1_honored ≈ all` AND `drain_sent ≈ rate×wall` AND `goodput < drain_sent` | **H-TCP** — shaper grants, honors in Phase 1, and SENDS full shape; TCP loses goodput to bursty delivery → smoothing fix or §6.4 re-frame. **Leading expected outcome** (every shaper-internal mechanism falsified). |
+| `phase1_honored ≈ 0` AND `phase2_served ≈ all` AND `phase2_skipped` high | H-WATERFILL RE-OPENS — would CONTRADICT §3.1 (the full config should honor 3g/6g in Phase 1). If seen, the config under test is NOT the full set — re-check the applied config. |
+| `cap_granted < rate×wall` with multiple workers | **H5** — per-worker fair-share rounding; folds into cause-1 meter. (Moot for truly-solo: total_flows=1.) |
+| `drain_sent/total_granted < 1` (net of stranded hot tokens) | **DRAWN-NOT-SENT** — TX-ring/scratch refusal; submit-path fix. |
+| `bucket_high_water > rate×200µs` | H-LEASE re-opens (would contradict AGY r2 #6). |
+| `drain_park_queue_tokens` high for solo 3g/6g | the Phase-1 wheel park IS biting (H7 re-opens despite §3.3). |
+
+The OFFERED-LOAD check (counter 0) gates everything: if offered < rate
+there is no shaper bug. Given §3 falsified the shaper-internal
+mechanisms, **the expected outcome is offered ≥ rate AND shaper sends
+full shape AND goodput < send → H-TCP.** The five+ ratios cleanly
+separate the surviving candidates; one cluster run fills the table.
+
+### 5.3 Confirm root is not the limiter
+
+Re-confirm `drain_park_root_tokens ≈ 0` and root-lease grant ≈
+`shaping_rate × wall` for 3g/6g solo. If the root throttles a solo class,
+that is a separate root-meter fix.
+
+### 5.4 Instrumentation-perturbation GATE (Codex r4, §11-Q3)
+
+The instrumentation MUST NOT itself cause the residual it measures. **Gate
+(hard):** run 3g/6g solo with the instrumented build AND the clean build;
+the throughput delta must be ≤ 0.5pp. If the instrumented build depresses
+throughput more than that, the counters are perturbative and the
+measurement is invalid — switch to thread-local non-atomic accumulators
+(§5 preamble) and re-A/B until the delta is within bound. The bisection
+ratios are only trustworthy once this gate passes.
+
+---
+
+## 6. Fix mechanism — DEFERRED pending §5 (v4: no pre-committed fix)
+
+> v4 position: all three derived mechanisms are falsified (§3). The plan
+> does NOT commit a fix. The §5 measurement names the layer; the fix is
+> designed in a short follow-up once the four ratios land. This is the
+> honest /research output when static analysis cannot attribute the
+> residual — it is NOT a dodge: it is the disciplined refusal to ship a
+> fix on a falsified hypothesis (the cause-1 §12 fork precedent).
+
+Candidate fixes BY MEASURED LAYER (each is a hypothesis to be confirmed,
+not a commitment):
+
+- **§5 layer = H-TCP (`goodput/drain_sent < 1`, drain_sent ≈ rate×wall):**
+  the shaper sends full shape; TCP loses goodput to 50µs-quantized bursty
+  delivery. Fix = delivery smoothing (finer service granularity / pacing)
+  — NOT a grant/selector change. If smoothing cannot recover it, the
+  residual is AF_XDP-per-CPU + TCP-pacing physics and Gate-1 re-framing
+  is the charter-authorized last resort (§6.4). **This is now the LEADING
+  expected outcome** given every shaper-internal mechanism is falsified.
+- **§5 layer = drawn-not-sent (`drain_sent/total_granted < 1`):** TX-ring
+  refusal / scratch-build failure under bursty delivery. Fix = submit
+  path (`tx_completion.rs` apply paths). Orthogonal to causes 1/2.
+- **§5 layer = grant-not-drawn with park (`drain_park_queue_tokens` high
+  for 3g/6g):** the Phase-1 wheel park IS biting despite §3.3's demotion.
+  Fix = sub-tick wake for the bucket-refill case (the gated F-E from v3,
+  with the `my_consumed < my_effective_share` guard, Codex r2 B2).
+- **§5 layer = meter under-grant (`cap_granted < rate×wall`, multi-worker
+  H5):** per-worker fair-share rounding. Fix = distribute the share
+  remainder in the rotation; folds into the cause-1 meter (coupled to the
+  seqlock/carry, §9).
+- **§5 layer = root throttle (`drain_park_root_tokens > 0` solo):** raise
+  root burst/epoch. Orthogonal.
+
+### 6.1 What /engineer does FIRST (ordered)
+
+1. Pass the §5.4 instrumentation-perturbation A/B gate (instrumented vs
+   clean ≤ 0.5pp) — else the counters are invalid.
+2. Read **counter 0 (offered load) FIRST**: if `offered < rate×wall` the
+   class is RX/forward-bound and there is NO shaper residual — stop, the
+   issue is upstream.
+3. If offered ≥ rate, read the §5.2 ratios on the free `loss` cluster
+   (3g-solo AND 6g-solo AND 9g, single port, push, v4, guarantee-rate
+   0.7, FULL `cos-iperf-config.set`, long steady-state window). The table
+   names the layer.
+4. ONLY THEN design the fix for that layer. Do NOT write fix code before
+   the bisection.
+
+### 6.2 Burst-safety (whatever the fix)
+
+Any fix must preserve `transmit-rate exact`: the per-queue v8 grant
+`cap = rate×elapsed` meters every class. Gate (§8) proves no class
+exceeds shape over any 10ms window.
+
+---
+
+## 7. Seqlock / concurrency surface (composing with cause-1 + #1643)
+
+**The layering contract for WHATEVER fix §5 selects.** Most candidate
+fixes (§6) are seqlock-orthogonal — they live in the drain/selector/TX
+path, which is per-binding single-worker `CoSInterfaceRuntime` state
+(verified non-atomic, not in the v8 seqlock payload: the waterfill state
+`waterfill_pass1_remaining_bytes`/`waterfill_phase2_cursor`/
+`exact_queues_by_rate_ascending`, `types/cos.rs:406-419`; the timer
+wheel; `queue.hot.tokens`). The v8 seqlock publishes `cap/share/grace/tag`
+only.
+
+- **Drain/selector/TX/smoothing fix (H-TCP, drawn-not-sent, wheel-park):**
+  **zero new seqlock surface.** The #1643 fence and the carry's
+  rotation-private `epoch_carry_bytes` are untouched; cause 2 is reviewed
+  as ordinary single-worker logic. Cleanest composition.
+- **Meter-side fix (H5 per-worker fair-share rounding):** the fix is in
+  the rotation `my_share` computation — IN the seqlock writer — and MUST
+  be reviewed together with the carry. This is the only case that couples
+  to cause 1.
+- H-LEASE killed (§3.2); root throttle orthogonal.
+
+**The seqlock review surface of the combined PR is bounded to cause-1's
+(carry + #1643 fence) UNLESS §5 selects the H5 meter-side cause.** §5
+distinguishes the clean (selector/drain) from the coupled (meter) layer.
+
+---
+
+## 8. Combined acceptance (cause-1 + cause-2 + #1643)
+
+The eventual /engineer PR lands ONE combined change. Gate 1 is the
+binding gate and now requires BOTH causes fixed.
+
+- **Gate 1 — ALL FOUR classes SOLO ≥ 95%** (100m/1g/3g/6g, single port
+  AND small-four-alone, 12 streams, push, v4, guarantee-rate 0.7). This
+  is the gate cause-1 alone CANNOT pass (3g/6g plateau ~90-94) and
+  cause-2 alone CANNOT pass (100m ~82). Combined MUST clear all four.
+- **Cause-1 lowest-class preserved** — 100m must remain ≥95 (the carry's
+  +13pp must not regress when the cause-2 fix changes the park/lease
+  cadence).
+- **Burst bound held** — Gate 5 (single-class stall→resume ≤ K×rate×EPOCH,
+  per cause-1 plan §7) AND a NEW cause-2 burst check: the §5-selected
+  cause-2 fix must not let any class exceed its `transmit-rate exact`
+  shape over any 10ms window (counter: per-class TX bytes / 10ms ≤ shape
+  × 1.05). The per-queue v8 grant `cap = rate×elapsed` still meters each
+  class regardless of the fix.
+- **`make test-failover`** — mandatory (TX-shaping change). Zero-drop;
+  cause-1's reused-lease unit test passes; the drain/selector state is
+  per-binding and rebuilt on promote.
+- **Full matrix** — v4+v6 × push+`-R` × CoS-off+CoS-on, per memory
+  feedback. Gate 2 (priority-low ≥5%), Gate 3 (retransmits ≤100/30s),
+  Gate 4 (aggregate ≥19.5G) must not regress.
+- **Cause-2 regression test** — branch-specific to the §5-selected fix
+  (designed at /engineer after the bisection names the layer). The plan
+  does not pre-specify it because the fix is not pre-committed.
+
+**NOTE (v4):** because cause-2's fix is deferred to the §5 outcome, this
+combined-acceptance section is the gate the EVENTUAL fix must clear, not a
+claim that any specific code in this plan clears it. The binding /research
+deliverable is §5 (the measurement) + this gate (the bar). cause-1 +
+#1643 can ship and be gated independently NOW.
+
+---
+
+## 9. How cause-1 + cause-2 + #1643 combine (explicit, per the charter)
+
+ONE combined seqlock change ships:
+
+1. **Cause-1 bounded credit carry** (`rotate_epoch_v8.rs` STEP 6 +
+   rotation-private `epoch_carry_bytes`, per
+   `docs/research/1630-v8-credit-carry/plan.md` @ `852cf014c`) — fixes
+   the lowest-rate (100m) grant-bound loss. **Meter layer.**
+   *(Note: that plan itself converged at PLAN-NEEDS-MAJOR pending the
+   §3.6 fork; the §3.6 measurement is now DONE and resolved to "neither
+   fork — cause 2 is distinct", which is THIS plan. The cause-1 carry's
+   own gate-clearing scope is reduced to the 100m/1g classes it actually
+   fixes; cause-2 owns 3g/6g. /engineer must re-scope cause-1's Gate-1
+   claim to "100m/1g cleared by carry; 3g/6g cleared by cause-2".)*
+2. **#1643 acquire-fence** in `snapshot_epoch_v8` (`mod.rs:1427`) —
+   `fence(Acquire)` between payload loads and `seq_after` re-read; payload
+   stores downgraded to `Relaxed`. **Meter layer, seqlock-correctness.**
+   `Closes #1643`.
+3. **Cause-2 fix — DEFERRED, selected by §5 (§6).** All three derived
+   mechanisms are falsified (§3); the fix is the one the §5 bisection
+   names. Most candidate layers (drain/selector/TX/smoothing) are
+   seqlock-orthogonal (§7); only the H5 meter-side cause couples to the
+   carry. **The plan commits to the §5 measurement + the layering
+   contract, not to a specific cause-2 code change.**
+
+**Composition (expected, most-likely layers):** (1)+(2) are the
+meter/seqlock surface (carry + fence — the ONLY concurrency-sensitive
+code); a drain/selector/TX/smoothing cause-2 fix is a single-threaded
+change sharing NO field with the seqlock payload, reviewed independently.
+The clean three-layer ideal — **meter grant (carry) + meter publish
+(fence) + drain-layer cause-2 fix** — holds for every candidate EXCEPT
+H5, which is meter-side and reviews with the carry.
+
+**Sequencing:** cause 1 + #1643 can ship together NOW (both are
+meter/seqlock and independently justified). Cause 2's fix waits on §5 and
+may land in the SAME combined PR (if §5 fires quickly at /engineer) or a
+fast follow-up. Gate 1 (all four ≥95% solo) is met only when cause 1 AND
+the §5-selected cause-2 fix are both in — UNLESS §5 shows H-TCP, in which
+case the residual is delivery/transport physics and Gate-1 re-framing
+(§6.4) is the charter-authorized last resort.
+
+---
+
+## 10. Risks & residuals
+
+- **R1 — §5 names no clear layer (all ratios ≈ 1.0 yet goodput < shape).**
+  Then the residual is genuinely H-TCP/delivery-physics (§6.4) and the
+  honest disposition is a smoothing attempt or a charter-authorized
+  Gate-1 re-frame. Mitigation: this is an ANTICIPATED outcome, not a plan
+  failure — §6.4 is the documented exit. The plan's value is having
+  falsified every shaper-internal mechanism so the team does not chase
+  them again.
+- **R2 — the offered-load check (counter 0) is itself mismeasured.** If
+  the enqueue-site counter double-counts or misses re-ingest, the
+  "offered < rate" gate could falsely pass/fail. Mitigation: count at the
+  single ingest site (`ingest_cos_pending_tx`) and cross-check against
+  the host iperf3 send rate; the two must agree within framing overhead.
+- **R3 — scope: this plan does NOT fix the full 11-class simul.** In the
+  full mix 3g/6g ARE Phase-1-honored (§3.1), yet the issue's 11-class run
+  shows ~20% — that failure has additional causes (cross-class budget
+  competition, priority-low) in #1614's scope. **This plan targets only
+  the K/P2/contention-independent flat SOLO/4-class residual the engineer
+  isolated.** /engineer must not over-claim that cause-2 fixes #1630's
+  headline 11-class numbers. (Avoids the cause-1 "neither fork"
+  over-scope trap.)
+- **R4 — the residual may be unfixable (physics floor).** If §5 shows the
+  shaper sends full shape and the loss is TCP pacing on bursty AF_XDP
+  delivery that smoothing cannot recover, cause-2 is a ~6% rate-accuracy
+  floor for single-flow-bundle mid-rate classes, and Gate-1-at-95% may
+  not be achievable for 3g/6g solo. This is an honest possible PLAN-KILL
+  of the FIX (not of the research) — the measurement still has value.
+- **R5 — cause-1's reduced scope.** Cause-1's plan claimed Gate 1; with
+  cause 2 split out, cause-1 only owns 100m/1g. /engineer MUST re-scope
+  the cause-1 plan's Gate-1 claim AND (per §11-Q5) gate or scope-note any
+  cause-1+#1643-only PR so #1630 does not falsely appear fixed while
+  3g/6g stay <95%. Documented §9.
+- **R6 — H5 (fair-share) only for multi-worker.** For truly-solo
+  single-port (total_flows=1) there is no fair-share rounding, so H5
+  cannot be the truly-solo residual; it is a candidate only if §5 shows
+  the solo streams land across multiple workers. §5 counter 7 + worker
+  count settles it.
+- **R7 — H-TCP: the residual may be OUTSIDE the shaper.** If §5's
+  `goodput/drain_sent < 1` while the shaper grants and sends full shape,
+  cause 2 is TCP's response to bursty 50µs-quantized delivery, not a
+  shaper defect. Then §6.4 applies: smooth delivery (may recover it) OR
+  re-frame Gate 1 (charter-authorized PLAN-KILL exit). The combined PR
+  may NOT clear Gate 1 at 95% if this is the physics floor — this is the
+  honest worst case, matching the cause-1 §12 "neither fork" precedent.
+
+---
+
+## 11. 5+ hostile open questions (for the reviewers to attack)
+
+1. **If no shaper mechanism explains it, is the residual even a SHAPER
+   bug?** Three derived mechanisms are falsified (§3). The strongest
+   remaining candidate is H-TCP (the bytes leave the NIC at rate; TCP
+   loses goodput to bursty delivery). **Should this issue be re-scoped
+   from "fix the shaper" to "characterize the AF_XDP delivery-burstiness
+   / TCP-pacing floor"? Is §5's `goodput/drain_sent` (L2-normalized)
+   actually measurable accurately enough to settle this on iperf3?**
+2. **Could the residual be a measurement artifact of the §3.6 harness
+   itself?** The solo numbers (3g 89→94, 6g 89→93) came from a throwaway
+   K/P2 probe build. **Is there ANY chance the ~6% is TCP slow-start /
+   `-O` omission / the 30s window / RSS landing the single port's 12
+   streams across workers — i.e. not a steady-state shaper property at
+   all?** §5 must run long-window steady-state and report the worker
+   landing of the solo streams BEFORE concluding a shaper cause.
+3. **Does the §5 instrumentation perturb the very thing it measures?**
+   Env-gated `fetch_add` counters on the hot drain path add atomics. **At
+   25G line rate, could the instrumentation cost itself depress 3g/6g by
+   a few %, masking or faking the residual?** The build must be A/B'd
+   (instrumented vs not) to confirm the counters are free, or use
+   thread-local non-atomic accumulators flushed at 1s.
+4. **Is the four-ratio bisection truly exhaustive?** It covers
+   meter-under-grant / grant-not-drawn / drawn-not-sent / TCP. **Is there
+   a FIFTH layer — e.g. the ingress/RX side limiting how fast the class's
+   packets even ARRIVE to be shaped, so the shaper is never offered a
+   full rate's worth?** For a push test the firewall forwards; if RX or
+   the conntrack/forward path caps a single flow-bundle, the shaper sees
+   less than `rate` of offered load and the residual is upstream. §5 must
+   confirm offered load ≥ shape at the queue ingress.
+4b. **(restated for emphasis)** The plan asserts the classes are
+   "bucket-bound" (offered > rate). **Has anyone VERIFIED the offered
+   load actually exceeds the shape for solo 3g/6g, or is the class
+   RX/CPU-bound below its rate?** If offered < rate, there is no shaper
+   residual to fix.
+5. **Is shipping cause-1 + #1643 WITHOUT cause-2 the right move?** §9 says
+   cause-1+#1643 can ship now. **But cause-1's plan claimed Gate 1; if it
+   ships fixing only 100m/1g while 3g/6g stay <95%, does the combined PR
+   FALSELY appear to fix #1630? Should cause-1 be held until §5 resolves
+   cause-2, or shipped with an explicit "100m/1g only" scope note?** The
+   sequencing has a contract-honesty risk.
+6. **Has the team over-fit to "flat fractional" (P4)?** The measured
+   spread (3g 93.8, 6g 92.8 solo) is NOT identical — 6g is ~1pp lower.
+   **Is the "flat" framing hiding a weak rate-dependence that would point
+   at a DIFFERENT cause (e.g. a per-frame fixed overhead that matters
+   more at higher pps)?** §5 should report the residual at 3g AND 6g AND
+   9g to see if it is truly flat or slowly rate-varying.
+
+---
+
+## Appendix — verified source anchors (origin/master `0e5bb3812`)
+
+- Timer wheel tick: `cos/tx_completion.rs:104 COS_TIMER_WHEEL_TICK_NS = 50_000`;
+  `cos_tick_for_ns = ns/TICK` (`:112`); advance (`:214`,`:314`);
+  service-eligibility `next_wakeup_tick <= now_tick`
+  (`cos_root_can_service_after_prime`, `:288-293`).
+- Wake-tick floor: `queue_service/mod.rs:1288`
+  `cos_tick_for_ns(wake_ns).max(cos_tick_for_ns(now).saturating_add(1))`.
+- Refill ns: `cos/token_bucket.rs:284 cos_refill_ns_until` (`div_ceil`).
+- Per-visit quantum: `cos_guarantee_quantum_bytes`
+  (`queue_service/mod.rs:1246`); `COS_GUARANTEE_VISIT_NS = 200_000`,
+  `QUANTUM_MIN = 1500`, `QUANTUM_MAX = 512K` (`tx/drain/mod.rs:561-563`).
+- **WATERFILL dispatch (the `guarantee-rate` path):**
+  `queue_service/mod.rs:603-614` (`if GuaranteeRate && fraction > 0 {
+  return select_exact_cos_guarantee_queue_waterfill(...) }`).
+- **Waterfill selector:** `select_exact_cos_guarantee_queue_waterfill`
+  `queue_service/mod.rs:771`; Phase-1 budget `floor(quantum_sum ×
+  fraction)` `:787-799`; Phase-1 honor/return `:889` (budget-exhausted
+  break), `:907` (honor return); **Phase 2 NON-PARKING** `:973-977`
+  ("Don't park in Phase 2 … not a guarantee"); epoch reset `:1002-1006`.
+- **Waterfill state (per-binding, single-worker, NON-atomic):**
+  `CoSInterfaceRuntime.waterfill_pass1_remaining_bytes`,
+  `waterfill_phase2_cursor`, `exact_queues_by_rate_ascending`,
+  `oversubscription_policy`, `oversubscription_guarantee_fraction`
+  (`types/cos.rs:369,378-406`) — confirmed NOT `Atomic`, NOT shared, NOT
+  in the seqlock payload.
+- **oversubscription detection machinery (if a waterfill-side fix is ever
+  revisited):** `exact_backlog_guarantee_rate_bytes_for_mask`
+  `cos/tx_completion.rs:400`.
+- Per-visit quantum: `cos_guarantee_quantum_bytes`
+  (`queue_service/mod.rs:1246`); `COS_GUARANTEE_VISIT_NS = 200_000`,
+  `QUANTUM_MIN = 1500`, `QUANTUM_MAX = 512K` (`tx/drain/mod.rs:561-563`).
+- Wake estimator arg: `estimate_cos_queue_wakeup_tick(... queue_rate,
+  head_len, now, require_queue_tokens)` — `head_len` is the **5th**
+  positional arg (`need_bytes`), signature `:1255-1263` (r2 correction).
+- **TX-sent counter for the §5 bisection:** `owner_profile.drain_sent_bytes`
+  / `drain_guarantee_sent_bytes`, written post-submit at
+  `cos/tx_completion.rs:482-489`; `lease.consume(sent_bytes)` `:540-549`;
+  token decrement on send `tx_completion.rs:512` (AGY r2 #3 contamination).
+- Timer wheel (Phase-1 parks only): `cos/tx_completion.rs:104
+  COS_TIMER_WHEEL_TICK_NS = 50_000`; wake floor `queue_service/mod.rs:1288`.
+- Bucket top-up + early-return: `cos/token_bucket.rs:154,184`.
+- Lease target: `compute_shared_cos_lease_config` `mod.rs:694`
+  (`COS_ROOT_LEASE_TARGET_US = 200`, `mod.rs:690`); `lease_bytes`
+  `mod.rs:977`.
+- Default buffer: `forwarding_build/cos.rs:73 default_cos_burst_bytes
+  = max(rate/100, 64×1500)`.
+- Grant meter (clamp + cap publish): `rotate_epoch_v8.rs:204-239`;
+  `EPOCH_DURATION_NS = 200_000` (`mod.rs:241`).
+- Grace gate (exact never enters surplus): `acquire_v8` surplus path
+  `mod.rs:1186-1242`; exact-skip `queue_service/mod.rs:837`.
+- Park telemetry fields: `types/cos.rs:914,920 drain_park_{root,queue}_tokens`.
+- Poll-loop `now_ns` sample: `worker/loop_body/mod.rs:249`.
+- Drain entry/budget: `tx/drain.rs:109,156` (`REINGEST_BUDGET=4`).

--- a/docs/pr/1630-cause1-credit-carry/plan.md
+++ b/docs/pr/1630-cause1-credit-carry/plan.md
@@ -1,757 +1,1175 @@
-# #1630 cause-2 — the K-independent ~6% mid-rate (3g/6g) shape residual
+# #1630 — v8 rotation credit-carry: seqlock-safe bounded deficit to fix small-class shape loss
 
-- Issue: #1630 (surface). This plan owns **cause 2 only**.
-- Branch: `research/1630-midrate-residual` (off `origin/master` @ `0e5bb3812`)
-- Mode: `/research` — plan only; NO production code; STOP at PLAN-READY.
-  Throwaway env-gated instrumented builds are allowed and MUST NOT be
-  committed.
-- Author: Claude SMR (CoS-shaper / token-bucket / rate-accuracy /
-  AF_XDP-drain / timer-wheel domain).
-- Rev: **v5 (r1-r4 folded).** Status after r4: **PLAN-READY (3-way
-  converged) as a MEASUREMENT-FIRST plan with NO pre-committed fix.** r4:
-  Codex PLAN-NEEDS-MAJOR (3 fixable gaps: missing offered-load counter,
-  instrumentation A/B not a gate, stale H-WATERFILL/F-W1 text) + AGY
-  PLAN-READY-with-amendments (SAME gaps: offered-load counter, scope
-  gating, L2 normalization) + Claude SMR PLAN-READY. All r4 amendments
-  folded into v5 (§5.0 offered-load gated first, §5.4 A/B hard gate, §5.1
-  L2-normalized goodput, §6.1 ordered procedure, §10-R5/§11-Q5 scope
-  gating, stale v3 text purged). The fix is DEFERRED to the layer §5
-  names; leading expected outcome is H-TCP (loss outside the shaper).
-  Three mechanism hypotheses were code-falsified across r1-r3
-  (timer-wheel, lease-target, waterfill-relegation) — §5 is the honest
-  next step.
+- Issue: #1630
+- Branch: `research/1630-v8-credit-carry` (off `origin/master` @ `dbfbf680c`)
+- Mode: `/research` — plan only; NO production code touched; STOP at PLAN-READY.
+- Author: Claude SMR (CoS-scheduler / WFQ-DRR / token-bucket / seqlock-concurrency / AF_XDP multi-worker-shaper / HA-failover domain)
+- Rev: **v3** (r1+r2+r3 reviews folded). **Status after r3:
+  PLAN-NEEDS-MAJOR, converged on a measurement-gated fork (§12).** r3:
+  Codex PLAN-NEEDS-MAJOR (3 BLOCKING — regime-2 draw rule undefined,
+  global burst cap re-introduces #1614 via FCFS starvation, ResetCoSEpochs
+  not retag-correct); Claude SMR self-corrected to concur; AGY r3 result
+  infra-blocked (investigation aligned). The §3.6 SOLO A/B is the pivot:
+  Fork A (small-K+P2 clears Gate 1 → simple, burst-safe fix; r3 blockers
+  dissolve) vs Fork B (only large-K clears it → architecturally blocked
+  by the small-class-first-allocator constraint). **Run §3.6 first.**
 
-> **THE r3 FINDING (decisive):** `exact_queues_by_rate_ascending` is built
-> ONCE at config-apply over EVERY configured exact queue
-> (`builders.rs:80-83`), and the waterfill `quantum_sum` loop
-> (`queue_service/mod.rs:789`) sums it with NO eligibility guard. The
-> solo/4-class harness loads the FULL `cos-iperf-config.set`
-> (`apply-cos-config.sh load merge`) and sends traffic to one/four ports.
-> So `quantum_sum = 2.65 MB`, Phase-1 budget = `0.7 × 2.65 = 1.85 MB`,
-> which honors 3g (75 K) and 6g (150 K) EVERY epoch. **H-WATERFILL is
-> falsified for the measured config.** Combined with the r1/r2 kills of
-> the timer-wheel and lease-target hypotheses, NO code-derived mechanism
-> survives static analysis — so the honest /research output is the §5
-> measurement, not a fix.
-
-> **CRITICAL CORRECTION (r2):** v1/v2 were built on the WRONG drain path.
-> The cwd `/home/ps/git/bpfrx` is a stale detached checkout
-> (`e01472f4a`) predating the #1614 A1 waterfill merge; origin/master and
-> the research worktree are `0e5bb3812`, which dispatches
-> `guarantee-rate 0.7` exact queues to **`select_exact_cos_guarantee_queue_waterfill`**
-> (`queue_service/mod.rs:608`). Both my r1 grep and AGY r2 §2 "verified"
-> against the stale tree and wrongly rejected it. Codex was right both
-> rounds. v3 re-grounds the entire mechanism on the waterfill selector.
-
-## v4 changelog (r3 response — converge to measurement-first)
-
-- **[Codex r3 BLOCKING-1] H-WATERFILL FALSIFIED.** `quantum_sum` is over
-  the static configured exact set (no eligibility guard), so the
-  full-config Phase-1 budget (1.85 MB) honors 3g/6g every epoch in BOTH
-  the solo and 4-class harness runs. §3.2's "solo 3g never Phase-1-honored"
-  was based on the wrong assumption that `quantum_sum` is over the
-  eligible set. Corrected; H-WATERFILL demoted to a measured falsifier.
-- **[AGY r3 — REJECTED] PLAN-READY rested on a stripped-config assumption**
-  the harness contradicts (loads all 10 classes). AGY's non-§1 findings
-  kept as supporting context.
-- **All three mechanisms now code-falsified** (wheel r1/r2, lease r2,
-  waterfill r3). v4 re-scopes the deliverable to the **§5 measurement-first
-  bisection with NO pre-committed fix** — the disciplined output when
-  static analysis cannot attribute the residual. §6 lists candidate fixes
-  per measured layer but commits to NONE.
-
-## v3 changelog (r2 response — major re-grounding)
-
-- **[Codex r2 BLOCKING-1] §2/§3 RE-GROUNDED on the waterfill selector.**
-  The leading hypothesis is now **H-WATERFILL** (§3): under
-  `guarantee-rate 0.7` a solo/boundary mid-rate exact class is honored
-  for only `fraction × quantum` per epoch in Phase 1; the residual rides
-  the **non-parking, best-effort Phase 2** (`:973-977` "Don't park in
-  Phase 2 … not a guarantee"). This is a fixed fractional shortfall set
-  by `guarantee_fraction` — exactly the K/P2/contention-independent flat
-  P1-P4 signature, and it appeared precisely when #1626/#1629 activated
-  the knob (the issue title: "under guarantee-rate 0.7").
-- **[AGY r2 #6] H-LEASE KILLED as a fix.** Raising `lease_bytes` is
-  toothless: `acquire_v8` caps the grant at `my_effective_share ≤
-  new_cap ≤ rate×EPOCH_DURATION_NS` (200µs). The bucket cannot bank more
-  than 200µs without raising the global epoch. H-LEASE removed as a fix
-  candidate (kept only as a measured falsifier).
-- **[Codex r2 BLOCKING-2 / AGY #4] F-E guard fixed/retired.** The wheel
-  fix is no longer primary; if revisited the guard must include
-  `my_consumed < my_effective_share`.
-- **[Codex r2 BLOCKING-3 / AGY #3] §5 bisection re-derived** around the
-  waterfill Phase-1/Phase-2 byte split + TX-residual netting.
-- **[AGY r2 #5] H-TCP** reframed: "needs a smoothing fix," not a pure
-  PLAN-KILL dodge — only kill if bytes provably left the NIC at full rate.
-
-## v2 changelog (r1 response — superseded by v3 where noted)
-
-- **[Codex BLOCKING-1 / Claude MAJOR-1] §3 derivation FIXED.** The wake
-  estimator is called with `head_len` (one frame), NOT the quantum. v2
-  rewrites §3 (the park basis is `head_len/rate ≈ 2-4µs`, floored to a
-  50µs tick) and DROPS the "t_refill = quantum/rate = 200µs → 88.9%"
-  false precision. The corrected period model has explicit unknowns the
-  §5 counters resolve.
-- **[Codex BLOCKING-2] REJECTED as hallucinated.** No waterfill drain
-  path exists on origin/master (§3.0). v2 does NOT add waterfill
-  instrumentation.
-- **[Codex BLOCKING-3 / Claude MAJOR-2] §5 recast as THREE-way.**
-  `cap_granted` / `total_granted` / `drain_sent_bytes` + iperf3 goodput;
-  the four ratios localize meter-under-grant vs grant-not-drawn vs
-  drawn-not-sent vs TCP-artifact.
-- **[Codex MAJOR-1 / Claude] lease-target promoted to first-class
-  competing hypothesis** (§3.3, §6).
-- **[Codex MAJOR-2/3 / Claude MAJOR-1] F-A/F-B DEMOTED** (F-A no-op
-  same-tick; F-B busy-polls a cap-exhausted lease). Primary candidates
-  are now the lease-target raise (F-C') and the sub-tick wake
-  representation (F-E), §6.
-- **[Claude MINOR-2] §9 layering re-argued** for the lease-target branch
-  (shared meter config, not seqlock payload).
-
-> Companion: cause 1 (rotation clamp at `rotate_epoch_v8.rs:218`) is
-> owned by `docs/research/1630-v8-credit-carry/plan.md` @ `852cf014c`.
-> This plan composes with it (§9) — the eventual fix lands as ONE
-> combined seqlock change.
+> This round does **not** re-derive the root cause. Three prior diagnosis
+> rounds converged; the third is measurement-proven (engineer log on
+> `fix/1630-cos-lease-watermark` @ `b29fdb344`). This plan designs the
+> **seqlock-safe, burst-bounded, HA-safe credit carry** that the prior
+> converged plan explicitly deferred as "Path B — out of scope, seqlock-
+> risky" (`docs/research/1630-cos-equalize-rootcause/plan.md` §5 row B,
+> §9). The deferral is now the work.
 
 ---
 
-## 1. The measured fact this plan starts from (do NOT re-derive)
+## 0b. v3 changelog (round-2 review response)
 
-A prior measurement-gated engineer ran the §3.6 SOLO A/B on
-`loss:xpf-userspace-fw0/1` (push, v4, `guarantee-rate 0.7`, 12 streams,
-`cos-iperf-config.set`, `reth0.80 shaping-rate 25g`). It isolated TWO
-distinct root causes of the #1630/#1614 Gate-1 failure.
+Both r2 reviewers (Codex + AGY) returned PLAN-NEEDS-MAJOR on v2; I
+self-corrected my too-lenient r2 PLAN-READY. v3 fixes:
 
-| Variant | 100m | 1g | 3g | 6g |
-|---------|----:|---:|---:|---:|
-| master  | 79 | 73 | 87 | 84 |
-| K=8 +P2 | 93 | 94 | 91 | 90 |
-| K=64+P2 | 95 | 95 | 90 | 90 |
-
-Truly-solo (single port), master→K=64: 3g 89.1→93.8 (+4.7pp, still
-<95), 6g 89.4→92.8 (+3.4pp, still <95). The 100m class is fixed by the
-cause-1 carry (82→95, +13pp). The **3g/6g residual is the subject of
-this plan**, and it has FOUR pre-registered properties (each is a
-constraint the cause-2 mechanism must satisfy, and a falsifier for any
-hypothesis that does not match):
-
-- **P1 — K-independent.** Carry depth K=8 vs K=64 barely moves 3g/6g
-  (91.0 vs 90.2 at +P2; solo 93.8 vs ~94). NOT the rotation clamp.
-- **P2 — P2-independent.** Per-visit frame cap on/off barely moves 3g
-  (91.2 K=8/P2-off vs 91.0 K=8/P2-on). NOT the selector sub-frame
-  discard.
-- **P3 — contention-independent.** Persists at ~93-94% even truly-solo
-  (one class, whole cluster). NOT cross-worker fragmentation or
-  inter-class competition.
-- **P4 — flat across mid rates** (3g ≈ 6g ≈ ~90% four-way / ~93-94%
-  solo). Smells like a *fixed fractional* loss or a rate-computation /
-  granularity constant, NOT a per-class effect.
-
-This plan does NOT re-run the §3.6 A/B (already done). It designs and
-verifies the **instrumented bisection** that pins where the residual
-~6% goes, then specifies the fix mechanism conditioned on the bisection
-outcome — because this is a /research deliverable, the plan commits to a
-*decision procedure + a primary hypothesis with a falsification gate*,
-not a blind mechanism.
+- **[Codex r2 B1 / AGY r2 F3 — aggregate cap unsound] FIXED (§3.5.1).**
+  v2's thread-local `C_agg` only bounded per-worker burst → `N × C_agg`
+  aggregate across N≈6 workers (leases are Arc-cloned to every worker,
+  `acquire_v8(worker_id,…)` is multi-worker). v3 moves the budget to a
+  single shared atomic `carry_release_budget` on `SharedCoSRootLease`
+  (already shared by all workers), refilled once per root epoch, drawn
+  via atomic CAS by all workers → genuinely global, independent of N.
+- **[AGY r2 F1 — `else` branch clamps to 1 epoch] FIXED (§5.3).** v2's
+  `raw_elapsed.min(EPOCH_DURATION_NS)` made mechanism A inert; v3 regime
+  1 uses `raw_elapsed` (bounded by the K guard).
+- **[Codex r2 B2 / AGY r2 F2 — self-heal cliff at K×EPOCH] FIXED
+  (§5.3 + §5.3.1).** v2 reused `K×EPOCH` as both the rate-recovery width
+  AND the cold-resume cutoff, so a legitimate 12-epoch lag (§3.4's own
+  example) hit an 8× cliff and dropped its carry. v3 introduces a
+  **decoupled `STALL_THRESHOLD` (≈256 epochs)** and THREE regimes:
+  normal (≤K), bank-residual (K<lag≤STALL, no cliff, mechanism B), and
+  cold-resume (>STALL). STALL sized between the §3.6 legitimate-tail p99
+  and the ≥500-epoch failback gap.
+- **[AGY r2 F4 — punted ResetCoSEpochs fallback] FIXED (§5.3.2).** The
+  fallback command is now fully designed: enum variant, producer routing
+  (`ha.rs` demote+promote), consumer handler (`loop_body` →
+  seqlock-safe `reset_epoch_state()`), visibility invariant, idempotency.
 
 ---
 
-## 2. The shaper data-path, as it actually runs (verified, origin/master 0e5bb3812)
+## 0. v2 changelog (round-1 review response)
 
-This is the spine every hypothesis below references. Confirmed by
-reading the source, not the issue prose.
+All three r1 reviewers returned **PLAN-NEEDS-MAJOR** with a strongly
+overlapping finding set. v2 addresses each:
 
-### 2.1 Per-class config (3g / 6g, the residual classes)
+- **[BLOCKING, all 3] Loss model inconsistent / K=8 does not clear the
+  gate.** v1 claimed "A alone clears Gate 1" while citing probe numbers
+  94.5/95.3/**84.9 (3g)**/94.4% against a "each ≥95%" gate. **v2 retracts
+  that claim.** The primary production mechanism is NOT pre-decided; it is
+  selected by a *mandatory discriminating measurement* (§3.6) that
+  resolves the heavy-tail-vs-P2 ambiguity BEFORE /engineer commits a
+  mechanism. P2 is promoted from "likely prerequisite" to
+  **load-bearing-pending-A/B** (§6).
+- **[BLOCKING, Codex F4 — decisive] HA "fresh lease" proof was FALSE.**
+  v1 §5 claimed leases are rebuilt at `start==0` on failover. Codex
+  proved (and I verified) that leases are **reused** when config matches
+  (`coordinator/mod.rs:1106-1116` `matches_config_v8` →
+  `out.insert(key, lease.clone())`), and HA demotion only queues
+  `VacateAllSharedExactSlots` (V_min slots) + `DemoteOwnerRGS`
+  (`ha.rs:48-55`), which does **not** reset the queue lease's
+  `epoch_start_ns`. On same-node failback with unchanged config the same
+  lease Arc survives with a stale `start`, so the first post-reactivation
+  `acquire_v8` sees `lag ≈ demotion_duration` and mechanism A grants a
+  `K×rate×EPOCH` burst (B preserves stale carry too). v2 adds an
+  **explicit stale-`start` self-heal** to the rotation (§5, the decisive
+  fix) plus a re-promotion epoch reset.
+- **[BLOCKING/HIGH, all 3] Aggregate simultaneous-resume burst
+  unbounded.** v1 bounded only single-class burst. Codex showed the 10
+  named exact rates sum to 109.1 G → aggregate K=8 release ≈ 21.8 MB,
+  and the **root lease uses raw elapsed** (`mod.rs:853`
+  `elapsed_ns = now_ns - last_refill_ns`, NOT epoch-clamped) with a
+  default burst floor of only 1% of rate (`forwarding_build/cos.rs:66`).
+  The root shaper therefore does NOT absorb the aggregate burst. v2 adds
+  an **aggregate burst invariant + global per-tick release cap** (§3.5).
+- **[MINOR, Codex F5 + Claude MAJOR-5] Seqlock writer wording / carry
+  enforcement.** v2 downgrades payload stores to `Relaxed` (matching the
+  `cold_path_hist.rs:572` reference), keeps the single `Release` publish,
+  and adds an **enforced carry-reader-private guard** (§4.0).
 
-`cos-iperf-config.set`: `scheduler-3g transmit-rate 3.0g exact`,
-`scheduler-6g transmit-rate 6.0g exact`. **Neither has `buffer-size`** —
-so `buffer_bytes` defaults via `default_cos_burst_bytes(rate) =
-max(rate/100, 64×1500)` (`forwarding_build/cos.rs:73`):
+---
 
-- 3g: `rate_bytes = 3e9/8 = 375_000_000 B/s`; `buffer_bytes = 3.75 MB`.
-- 6g: `rate_bytes = 750_000_000 B/s`; `buffer_bytes = 7.5 MB`.
+## 1. Problem statement
 
-These buffers are huge relative to a 200µs epoch's worth of bytes
-(75 000 B / 150 000 B), so the per-queue bucket ceiling is NOT the
-binding limiter for 3g/6g. (Hypothesis 6 is therefore weak a priori;
-§4 keeps it only as a falsified-by-arithmetic entry.)
+`cos-iperf-config.set` on `loss:xpf-userspace-fw0/1`, `reth0.80`:
+`shaping-rate 25g`, `oversubscription-policy guarantee-rate 0.7`, 11
+exact classes (`transmit-rate {100m..24g} exact`), best-effort q0,
+uncapped q11.
 
-### 2.2 The grant meter (per-class, lazy-rotated)
+Documented contract (`docs/fairness-regimes.md`): under guarantee-rate,
+small-rate exact classes whose aggregate fits the Phase-1 budget should
+each reach ~100% of configured rate first.
 
-`maybe_rotate_epoch_v8` STEP 6 (`rotate_epoch_v8.rs:204-239`):
-- `EPOCH_DURATION_NS = 200_000` (`mod.rs:241`).
-- `elapsed_ns = (now - start).min(EPOCH)` — the cause-1 clamp (line 218).
-- `new_cap_raw = rate_bytes × elapsed_ns / 1_000_000_000` (u128 math,
-  integer-truncated to u64). For 3g full epoch: `375e6 × 200e3 / 1e9 =
-  75_000 B` exactly (no truncation — `375e6 × 2e5 = 7.5e13`, `/1e9 =
-  75_000`, exact). For 6g: `150_000 B` exact. **Integer-division
-  truncation is ZERO at these rates** (hypothesis 1 falsified by
-  arithmetic — see §4-H1).
-- `epoch_grace_expires_ns = now + EPOCH/2 = now + 100µs` (line ~226).
-- `epoch_start_ns := now` (line 237); seq ODD→EVEN publish (line 239).
+**Proven floor (measurement-established, not hypothesis):** even SOLO
+(one class, one port, zero competition, 12 streams, push, v4) the small
+exact classes cannot reach their shape:
 
-### 2.3 The bucket top-up (per worker visit)
+| Class | Shape | SOLO % of shape (master) |
+|-------|------:|-------------------------:|
+| iperf-100m | 0.1 G | 81.4 % |
+| iperf-1g   | 1.0 G | 83.7 % |
+| iperf-3g   | 3.0 G | 89.9 % |
+| iperf-6g   | 6.0 G | ~85 % |
 
-`maybe_top_up_cos_queue_lease` (`cos/token_bucket.rs:154`), exact branch:
-- `lease_bytes = lease.lease_bytes().max(tx_frame_capacity()).min(buffer)`
-  where `lease.lease_bytes() = config.lease_bytes =
-  min(rate×200µs, burst/8, 512KB).max(1500)`
-  (`compute_shared_cos_lease_config`, `mod.rs:694`). For 3g:
-  `rate×200µs = 75_000`, `burst/8 = 469k` → `lease_bytes = 75_000`. For
-  6g: `150_000`. `tx_frame_capacity() = 4096` (`UMEM_FRAME_SIZE`).
-- **Early-return when `queue.hot.tokens >= lease_bytes`** (line 184) —
-  no acquire, no rotation, when the bucket is already at/above the
-  top-up watermark.
-- Otherwise `acquire_v8(worker_id, now, lease_bytes - tokens)` →
-  `maybe_rotate_epoch_v8(now)` then bounded by BOTH the class cap AND
-  the per-worker `my_effective_share` (`acquire_v8`, `mod.rs:1066-1131`).
+Efficiency rises with rate. This is a **per-class rate-metering floor**
+in the v8 epoch rotation, independent of cross-class competition. The
+diagnostic probe (relax the rotation clamp to `8 × EPOCH_DURATION_NS`)
+lifted the solo ceilings to 94.5 / 95.3 / 84.9(noisy) / 94.4 %,
+isolating the rotation clamp as the dominant loss. The probe is unsafe
+(unbounded burst after a stall — "Gate-4 risk"); this plan replaces it
+with a bounded carry.
 
-### 2.4 The drain + WATERFILL selector (the actual `guarantee-rate` path)
+---
 
-`select_exact_cos_guarantee_queue_with_lease_telemetry`
-(`queue_service/mod.rs:590`) dispatches based on policy:
+## 2. Verified root cause (confirmed against origin/master)
+
+### 2.1 The clamp
+
+`userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs`,
+STEP 6 of `maybe_rotate_epoch_v8` (verified lines, origin/master
+`dbfbf680c`):
 
 ```rust
-// :603-614
-if matches!(root.oversubscription_policy, GuaranteeRate)
-    && root.oversubscription_guarantee_fraction > 0.0 {
-    return select_exact_cos_guarantee_queue_waterfill(root, …);  // <-- the smoke path
-}
-// else: legacy round-robin exact selector (Proportional)
+// rotate_epoch_v8.rs:214-223
+let elapsed_ns = if start == 0 {
+    EPOCH_DURATION_NS
+} else {
+    (now_ns - start).min(EPOCH_DURATION_NS)        // <-- line 218: the clamp
+};
+let new_cap_raw =
+    ((self.config.rate_bytes as u128) * (elapsed_ns as u128) / 1_000_000_000u128) as u64;
+let new_cap = new_cap_raw.min(u32::MAX as u64);
+v8.epoch.epoch_total_grant_cap.store(new_cap, Ordering::Release);   // line 224
+...
+v8.epoch.epoch_start_ns.store(now_ns, Ordering::Release);          // line 237
+v8.epoch.epoch_seq.store(seq + 2, Ordering::Release);              // line 239 (ODD->EVEN publish)
 ```
 
-The smoke runs `oversubscription-policy guarantee-rate 0.7`, so 3g/6g
-traverse the **two-phase waterfill selector** (`:771`), NOT the legacy
-RR path v1/v2 modeled. The waterfill mechanics (verified):
+The confirmed mechanism (I re-derived it; it matches the engineer log):
 
-- **Phase-1 budget** (lazy-refilled per epoch when `pass1_remaining == 0`,
-  `:787-799`): `pass1 = floor(quantum_sum × fraction)` where `quantum_sum`
-  = Σ `cos_guarantee_quantum_bytes` over the runnable+nonempty exact set,
-  and `fraction = 0.7`.
-- **Phase 1** (`:808-912`): ascending-rate walk. For each eligible exact
-  queue, top-up, then `candidate_budget = tokens.min(quantum).max(head_len)`.
-  **If `candidate_budget > pass1_remaining` → `break` to Phase 2**
-  (`:889`); else honor the queue (consume budget, return the selection).
-  Token-starved queues here DO park (`:853-873`).
-- **Phase 2** (`:922-1001`): descending walk over un-honored queues.
-  **Crucially, Phase 2 does NOT park** — `:973-977`:
-  `if root.tokens < head_len || queue.hot.tokens < head_len { … continue }`
-  with the comment *"Don't park in Phase 2 — the queue may legitimately
-  wait for next epoch … best-effort residual, not a guarantee."*
-- **Epoch reset** (`:1002-1006`): when nothing is serviced,
-  `pass1_remaining = 0` and the Phase-2 cursor resets; the next call
-  refills the Phase-1 budget.
+1. `EPOCH_DURATION_NS = 200_000` (200 µs), confirmed
+   `shared_cos_lease/mod.rs:241`.
+2. Rotation is **purely lazy**: the only non-test call site is
+   `acquire_v8` (`mod.rs:1042`). There is no timer thread forcing a
+   rotation every 200 µs. Rotation happens only when a worker calls
+   `maybe_top_up_cos_queue_lease` → `acquire_via_lease` → `acquire_v8`
+   for that queue (`cos/token_bucket.rs:101`).
+3. A low-rate class is **visited intermittently**. At 100 Mbit
+   (`rate_bytes = 12.5e6 B/s`), one 200 µs epoch's full cap is
+   `12.5e6 × 200e-6 = 2500 bytes` — below one 4096-byte TX frame
+   (`tx_frame_capacity()`). The exact-queue top-up watermark is
+   `lease_bytes.max(tx_frame_capacity)=4096` (`token_bucket.rs:188`),
+   so the queue can only usefully act every ~2 epochs. Under the
+   scheduler's round-robin across 11+ classes the gap between two
+   `acquire_v8` calls for the *same* low-rate queue routinely exceeds
+   one epoch.
+4. On the next visit at `now`, with `lag = now − start > EPOCH`,
+   rotation runs **once** and computes
+   `elapsed = min(lag, EPOCH) = EPOCH`, so
+   `new_cap = rate × EPOCH = 2500 B` — even though `lag` worth of rate
+   credit (`rate × lag`) accrued in wall-clock.
+5. The discard is **permanent**: `epoch_start_ns := now_ns`
+   (line 237), NOT `start + EPOCH`. The interval
+   `[start + EPOCH, now]` of wall-clock is erased from the rate budget
+   forever. The class's achievable throughput is therefore
+   `rate × EPOCH / lag_avg` — strictly below `rate` whenever
+   `lag_avg > EPOCH`. This is the exact shape of the SOLO efficiency
+   curve (rises with rate, because higher-rate classes are visited more
+   often → smaller `lag/EPOCH`).
 
-`cos_guarantee_quantum_bytes = clamp(rate×VISIT_NS, 1500, 512K)` with
-`VISIT_NS = 200_000`. 3g quantum = 75 000, 6g = 150 000 (both < 512K).
+**Confirmed:** the engineer's line reference (`:214`/`:218`) and
+mechanism are correct. The clamp at line 218 plus the
+`epoch_start_ns := now_ns` reset at line 237 together discard
+`rate × (lag − EPOCH)` bytes of grant per lagged rotation.
 
-The wake estimator (used by the Phase-1 park sites and the legacy path)
-is `estimate_cos_queue_wakeup_tick(root_tokens, root_rate, queue_tokens,
-queue_rate, need_bytes=head_len, now, require_queue_tokens)` — `head_len`
-is the **5th** positional arg (`need_bytes`), per the signature at
-`:1255-1263` (Codex/AGY r2 corrected v2's "4th arg" wording). Wheel tick
-50µs, floored at `now_tick+1` (`:1288`). The wheel matters only for
-Phase-1 parks; Phase-2 never parks.
+### 2.2 Why the watermark/bank approach (Path A) was inert
 
----
+Confirmed independently: the binding limiter is `epoch_total_grant_cap`
+(the rate-metered per-epoch grant), not the per-queue bucket ceiling.
+A saturated class drains its bucket below one frame every visit
+(`park_queue ≫ 0`, `park_root = 0`), so raising the bucket watermark or
+`max_total_leased` changes nothing — the grant the bucket is allowed to
+draw is already the bottleneck. The fix must enlarge the **grant**, not
+the bucket.
 
-## 3. Mechanism hypotheses — all THREE code-falsified (v4)
+### 2.3 Why the naive un-clamp is unsafe (the design constraint)
 
-> v4 status: every concrete mechanism the team derived from the source
-> has been falsified by code + arithmetic across r1-r3. This section
-> records WHY each is dead, so the §5 measurement does not re-litigate
-> them and a future round does not resurrect them. The honest conclusion:
-> static analysis cannot attribute the ~6% — measure (§5).
-
-### 3.1 H-WATERFILL (v3 leading hypothesis) — FALSIFIED (Codex r3 BLOCKING-1)
-
-The idea: under `guarantee-rate 0.7`, the waterfill Phase-1 budget
-`quantum_sum × 0.7` excludes a solo/boundary mid-rate class, relegating
-its residual to the non-parking best-effort Phase 2 (`:973-977`).
-
-**Why it is FALSE for the measured config:** `quantum_sum`
-(`queue_service/mod.rs:789`) sums `cos_guarantee_quantum_bytes` over
-`root.exact_queues_by_rate_ascending`, which is built ONCE at
-config-apply over EVERY configured exact+guarantee queue
-(`builders.rs:80-83`, "Built once at config-apply time; runtime is
-read-only") with **NO nonempty/runnable guard in the sum**. The
-solo/4-class harness loads the FULL `cos-iperf-config.set` (all 10 exact
-classes) via `apply-cos-config.sh load merge` and sends traffic to
-one/four ports. So:
-
-| Config (full 10-class, fraction 0.7) | quantum_sum | Phase-1 budget | 3g (75K) honored? | 6g (150K) honored? |
-|--------------------------------------|------------:|---------------:|-------------------|--------------------|
-| solo 3g traffic (all 10 configured)  | 2 651 076 | 1 855 753 | **YES every epoch** | n/a |
-| solo 6g traffic (all 10 configured)  | 2 651 076 | 1 855 753 | n/a | **YES every epoch** |
-| 4-class traffic (all 10 configured)  | 2 651 076 | 1 855 753 | **YES** | **YES** |
-
-The Phase-1 budget (1.85 MB) dwarfs the small-class quanta; empty queues
-are skipped in the Phase-1 WALK (`:811-816`) but still count toward the
-budget, so 3g/6g are honored in the guaranteed, park-capable Phase 1
-every epoch. **H-WATERFILL cannot be the solo/4-class residual; F-W1
-would be a no-op.** (It would matter ONLY if the config were stripped to
-a single class — which the harness never does. §5 counter
-`phase1_honored_bytes` for 3g/6g confirms ≈ all at runtime; if it is ~0,
-the static reading is wrong and H-WATERFILL reopens — but the code says
-≈ all.)
-
-### 3.2 H-LEASE (lease-target) — KILLED as a fix (AGY r2 #6)
-
-Raising `lease_bytes` is toothless: `acquire_v8` caps the grant at
-`my_effective_share ≤ my_share = new_cap × my_count/total_flows`, and
-`new_cap = rate × elapsed ≤ rate × EPOCH_DURATION_NS` (200µs)
-(`rotate_epoch_v8.rs:218-232`; `acquire_v8` break `mod.rs:1081`). The
-bucket can NEVER bank more than 200µs of credit under the v8 epoch
-ceiling regardless of `lease_bytes`; the post-grace bypass is closed for
-strict exact CoS. Kept only as a §5 falsifier (counter 6: bucket
-high-water never exceeds `rate×200µs`).
-
-### 3.3 H-WHEEL / H7 (timer-wheel park floor) — DEMOTED (r1/r2)
-
-v1/v2 derived the residual from the 50µs wheel park. r1 corrected the
-park basis to `head_len` (~2µs refill floored to a 50µs tick). For
-strict exact classes the queue parks in Phase 1 only when its bucket
-drops below one frame; whether that produces 6% is unproven and the
-magnitude could not be derived (the v1 "200/225 = 88.9%" claim was
-retracted). Kept as a §5 falsifier (counter:
-`drain_park_queue_tokens` for 3g/6g — if ~0, the wheel is not the cause).
-
-### 3.4 Other hypotheses — killed by arithmetic / single-worker
-
-- **Integer truncation** in `rate×elapsed/1e9`: 0 bytes at 3g/6g (exact).
-- **Grace window**: gates only the surplus/bypass path; exact non-surplus
-  never enters surplus (`queue_service/mod.rs:837`).
-- **Fair-share rounding (H5)**: for a TRULY-SOLO single-port run on one
-  worker, `total_flows = 1` ⇒ `my_share = new_cap` ⇒ zero rounding. So
-  H5 cannot explain the truly-solo residual; it is a candidate only for
-  the multi-stream/multi-worker case (§5 worker-count counter).
-
-### 3.5 The honest conclusion
-
-**No code-derived mechanism survives static analysis.** The ~6% mid-rate
-residual is real (measured) but un-attributed. This is precisely the
-situation that mandates a measurement-first plan: ship the §5 instrumented
-bisection, run it on the free cluster, and let the four ratios
-(phase1/phase2/drain_sent/goodput) NAME the layer. The plan commits to
-the MEASUREMENT and the decision procedure — NOT to a fix it cannot
-derive. (Same discipline as the cause-1 §12 fork: when the code can't
-tell you, measure.)
+The clamp bounds burst. If a worker (or the whole RG) stalls for
+seconds — GC pause, HA failover hold, scheduler starvation under DDoS —
+an unclamped `elapsed` computes `new_cap = rate × seconds`, a single
+multi-megabyte one-shot grant. That violates the shaper's burst bound:
+the class would emit a burst far above its configured rate over the
+window immediately following the stall. The diagnostic probe
+(`× 8`) is a hard-capped relaxation, not a true fix; even `× 8` admits
+an 8-epoch (1.6 ms) burst, and an unbounded relax is a Gate-4
+violation. **The carry must be bounded.**
 
 ---
 
-## 4. Hypothesis table — all mechanisms falsified; §5 is the live path (v4)
+## 3. Design: bounded rotation credit carry (DRR-style deficit)
 
-| # | Hypothesis | Verdict (v4) | §5 confirmer/falsifier |
-|---|-----------|--------------|------------------------|
-| H-WATERFILL | Phase-1 budget relegates solo 3g/6g to non-parking Phase 2 | **FALSIFIED (Codex r3 B1):** full-config Phase-1 budget (1.85 MB) honors 3g/6g every epoch (§3.1). | `phase1_honored_bytes` for 3g/6g ≈ all (re-confirms at runtime). |
-| H-LEASE | Lease target caps bucket credit | **KILLED as a fix (AGY r2 #6):** epoch ceiling caps grant at `rate×200µs`. | counter 6: high-water ≤ `rate×200µs`. |
-| H-WHEEL/H7 | 50µs wheel park floor | DEMOTED (r1/r2): basis is `head_len` (~2µs); magnitude undrivable. | `drain_park_queue_tokens` for 3g/6g — if ~0, dead. |
-| H1 | Integer truncation | KILLED by arithmetic (exact at 3g/6g). | counter 5. |
-| H2 | Grace window | WEAK (gates only surplus; exact never enters). | `bypass_grace_use_count == 0`. |
-| H4 | Lazy-rotation stale cap | Overlaps cause 1; K-independent. | counter 5. |
-| H5 | Per-worker fair-share rounding | **Cannot explain TRULY-SOLO** (1 worker → total_flows=1 → no rounding). Candidate only for multi-stream/multi-worker. | per-worker share-exhaustion + worker count. |
-| H-TCP | 6% is TCP goodput artifact, not shaper | LIVE — must be ruled out. Only KILL if bytes provably leave the NIC at full rate (AGY r2 #5). | `goodput/drain_sent` (L2-normalized). |
+### 3.1 The invariant we must preserve
 
-**Net (v4): NO mechanism survives static analysis.** H-WATERFILL,
-H-LEASE, H-WHEEL all falsified by code+arithmetic; H1/H2/H4 killed; H5
-cannot explain truly-solo. The only LIVE candidates are H-TCP (the loss
-is outside the shaper) and "something not yet modeled in the drain/TX
-path." **This is exactly why §5 is the deliverable** — the measurement
-NAMES the layer; the plan does not pre-commit a mechanism it cannot
-derive.
+Define the shaper contract over any window `[t0, t1]` of length
+`W = t1 − t0`:
+
+> Total grant issued over `[t0, t1]` ≤ `rate × W + B_max`, where `B_max`
+> is the configured burst bound.
+
+Today's clamp enforces a *stronger* (over-tight) bound by also forbidding
+`rate × W` to be reached after a lag (it floors grant at
+`rate × Σ min(lag_i, EPOCH) ≤ rate × W`). We want to relax to *exactly*
+`rate × W + B_max` — recover the lagged rate, but never exceed the
+burst.
+
+### 3.2 Mechanism (chosen): carry deficit on `epoch_total_grant_cap`
+
+Add one `AtomicU64` to `SharedCoSEpochState`:
+`epoch_carry_bytes` — the unbanked rate credit owed to the class,
+written **only by the rotation winner** (single-writer, inside the
+seqlock ODD critical section), read only by the rotation winner.
+
+Rotation STEP 6 changes from:
+
+```rust
+let elapsed_ns = (now_ns - start).min(EPOCH_DURATION_NS);   // OLD
+let new_cap = (rate * elapsed_ns / 1e9).min(u32::MAX);
+```
+
+to:
+
+```rust
+// NEW — bounded carry
+let raw_elapsed_ns = now_ns - start;                         // unclamped wall-clock
+let clamped_ns     = raw_elapsed_ns.min(EPOCH_DURATION_NS);
+let overshoot_ns   = raw_elapsed_ns - clamped_ns;            // == raw - EPOCH (or 0)
+
+// rate-bytes that the clamp would have discarded this rotation:
+let new_owed = (rate as u128 * overshoot_ns as u128 / 1e9) as u64;
+
+// accumulate into a *bounded* carry deficit:
+let prev_carry = epoch_carry_bytes.load(Acquire);            // single-writer read
+let carry = prev_carry.saturating_add(new_owed).min(MAX_CARRY_BYTES);
+
+// this epoch's cap = base (rate*clamped) + a bounded *slice* of carry:
+let base_cap   = (rate as u128 * clamped_ns as u128 / 1e9) as u64;     // == old new_cap when lag<=EPOCH
+let carry_draw = carry.min(MAX_CARRY_DRAW_PER_EPOCH);                   // bounded per-epoch release
+let new_cap    = base_cap.saturating_add(carry_draw).min(u32::MAX as u64);
+
+epoch_carry_bytes.store(carry - carry_draw, Release);        // remaining owed
+epoch_total_grant_cap.store(new_cap, Release);
+```
+
+Two independent bounds, each defending a different failure mode:
+
+- **`MAX_CARRY_BYTES`** caps the *reservoir*: no matter how long the
+  stall, the class can never owe more than this. This is the burst-bound
+  guard. Set `MAX_CARRY_BYTES = K_res × rate × EPOCH` with small
+  `K_res` (proposed `K_res = 4` → ≤ 800 µs of rate, i.e. ≤ 4 frames'
+  worth for 100m, ≤ ~2.4 MB for 24g). The reservoir is the *total* extra
+  bytes a class can ever burst after an arbitrarily long stall.
+- **`MAX_CARRY_DRAW_PER_EPOCH`** caps the *drain rate*: how fast the
+  reservoir converts to grant. This bounds the instantaneous burst
+  *immediately after resume* and guarantees the deficit drains
+  smoothly over several epochs (DRR semantics). Proposed
+  `MAX_CARRY_DRAW_PER_EPOCH = base_cap` (i.e. at most double the
+  per-epoch rate while draining → recovery at ≤ 2× rate, classic DRR
+  catch-up, bounded). With this choice the post-stall burst over any
+  window is ≤ `2 × rate × W` until the reservoir empties, then exactly
+  `rate × W`.
+
+### 3.3 Why this fixes Gate 1 (worked numeric trace — low-rate, lagging)
+
+100m class, `rate = 12.5e6 B/s`, `EPOCH = 200 µs`,
+`rate × EPOCH = 2500 B`. Choose `K_res = 4` →
+`MAX_CARRY_BYTES = 10 000 B`; `MAX_CARRY_DRAW_PER_EPOCH = base_cap`.
+
+Suppose the scheduler visits this queue once every `1 ms` (5 epochs of
+lag) under load. **NOTE (v2):** the scalar loss model `eff = EPOCH /
+mean_lag` inverts the measured 81.4% SOLO to a *mean* lag of only
+~1.23 epochs, which would predict K=8 reaches ~100% — yet the probe
+measured 94.5%. The 5-epoch figure here is an illustrative trace, NOT
+the measured mean; the true lag distribution is heavy-tailed (§3.6),
+which is exactly why the mean-based model and the probe disagree. The
+trace below is kept only to motivate the constant-derivation that
+follows; the *binding* analysis is §3.6.
+
+| Visit | lag (ns) | overshoot (ns) | new_owed | carry (pre-draw, ≤10k) | base_cap | carry_draw (≤base) | new_cap | reservoir after |
+|------:|---------:|---------------:|---------:|-----------------------:|---------:|-------------------:|--------:|----------------:|
+| t1 | 1.0e6 | 0.8e6 | 10000 | 10000 | 2500 | 2500 | 5000 | 7500 |
+| t2 | 1.0e6 | 0.8e6 | 10000 | 10000 (clip) | 2500 | 2500 | 5000 | 7500 |
+| t3 | 1.0e6 | 0.8e6 | 10000 | 10000 (clip) | 2500 | 2500 | 5000 | 7500 |
+
+Steady state: each visit grants `base_cap + carry_draw = 5000 B` over a
+1 ms interval → effective rate `5000 / 1e-3 = 5e6 B/s = 40 Mbit`. The
+class only reaches `2×rate` while draining, but the reservoir is
+**clipped at 10 000 B**, so the long-run grant per ms is capped at
+`base_cap + MAX_CARRY_DRAW = 2 × base_cap` and the *owed* beyond the
+reservoir (`new_owed − accepted`) is genuinely dropped. **This trace
+shows the chosen constants are too tight for a 5-epoch lag** — at 40
+Mbit the class only reaches 40% of shape, not 95%.
+
+**This is the key design tension, surfaced honestly:** to reach ≥95% the
+**drain rate** must keep up with the lag, i.e. `MAX_CARRY_DRAW_PER_EPOCH`
+must be large enough that `base_cap + carry_draw ≈ rate × lag`. With
+`lag = L × EPOCH`, we need `carry_draw ≈ (L−1) × base_cap`, i.e.
+`MAX_CARRY_DRAW_PER_EPOCH ≈ L_max × base_cap`. And the reservoir must
+hold one visit's worth: `MAX_CARRY_BYTES ≈ L_max × base_cap`.
+
+So the two constants are really **one** physical quantity:
+`L_max × EPOCH` = the maximum lag the carry fully compensates. **This is
+identically the diagnostic probe's `K × EPOCH` clamp** — but expressed
+as a reservoir+drain so that lags *beyond* `L_max` are bounded (the
+reservoir clips) instead of unbounded. The corrected design:
+
+- `MAX_CARRY_BYTES = L_max × rate × EPOCH`
+- `MAX_CARRY_DRAW_PER_EPOCH = (L_max − 1) × rate × EPOCH`
+  (so a single on-time visit after a full-reservoir lag emits
+  `base_cap + (L_max−1)×base_cap = L_max × base_cap = rate × L_max ×
+  EPOCH` in one grant — **this is the burst**, bounded by `L_max`).
+
+This collapses the "DRR slow-drain" story: because a low-rate queue is
+visited *once* per long interval, it must receive the full lagged credit
+*in that one visit* or it can never catch up (there is no subsequent
+near-term visit to drain into). So the carry is **not** drained over
+many epochs for a low-rate class — it is released in the single visit,
+capped by `L_max`. **The honest mechanism is a bounded `elapsed`, i.e.
+`elapsed = min(lag, L_max × EPOCH)`, which is mathematically identical
+to the probe with `K = L_max`.** The carry reservoir adds value ONLY for
+the case where a class is visited *more often than once per lag window*
+(higher-rate classes), where it smooths multi-visit catch-up.
+
+### 3.4 Re-framed mechanism (what the design actually reduces to)
+
+Given §3.3, the minimal core fix is `elapsed = min(lag, K×EPOCH)` with
+`K = MAX_ROTATION_LAG_EPOCHS`. **NOTE (v3):** the production form is NOT
+this two-branch snippet — it is the **three-regime** rotation of §5.3
+(normal recovery / bank-residual / cold-resume), which fixes the v2
+`else`-branch bug and the cold-resume cliff. The snippet below is the
+*conceptual* core; read §5.3 for the actual code:
+
+```rust
+// CONCEPTUAL ONLY — see §5.3 for the production three-regime form.
+const MAX_ROTATION_LAG_EPOCHS: u64 = 8;   // K, from the §3.6 sweep
+let elapsed_ns = if start == 0 {
+    EPOCH_DURATION_NS
+} else {
+    (now_ns - start).min(EPOCH_DURATION_NS * MAX_ROTATION_LAG_EPOCHS)
+};
+```
+
+with the burst bound now `rate × K × EPOCH` of rate — a hard, configured
+ceiling. The "credit carry" reservoir of §3.2 is the *generalization*
+that also handles the residual `lag − K×EPOCH` by banking it (clipped at
+`MAX_CARRY_BYTES`) for the next visit, so a class lagging at 12 epochs
+with `K=8` recovers 8 now + 4 next visit instead of dropping the 4.
+
+**v2 recommendation (REVISED — no longer "ship A, B optional"):** the
+primary production mechanism is **NOT pre-decided**. v1 claimed bounded-
+`elapsed` at K=8 "clears Gate 1"; all three r1 reviewers proved that is
+false on the cited data (94.5/95.3/**84.9**/94.4% vs a "each ≥95%"
+gate). The choice between {A at larger K} vs {A+B carry} vs {A+P2} is
+**contingent on the §3.6 discriminating measurement**, which /engineer
+MUST run first. The plan commits to a *decision rule*, not a mechanism:
+
+1. If `K=64` SOLO reaches ≥95% on 100m AND 3g but `K=8` does not →
+   the loss is the heavy lag tail; ship **A with K sized to the
+   measured tail** (and re-check the aggregate burst bound at that K,
+   §3.5). Carry reservoir B only if K large enough to clear the gate
+   also violates the aggregate burst invariant — then B's bounded drain
+   is required to spread the tail recovery.
+2. If `K=8 + P2` reaches ≥95% but `K=8` alone does not → the residual
+   is the sub-frame selector discard; **P2 is the co-fix** (§6) and K
+   stays small (preserving the burst bound).
+3. If neither reaches ≥95% on 3g specifically → the 3g loss is NOT the
+   rotation clamp; re-open root-cause for that class (the probe's
+   "3g=84.9% noisy" is then a mis-attribution, not noise).
+
+### 3.5 Worked burst-bound trace (stalled-then-resumed worker)
+
+Worker stalls 2 s (GC / failover hold), then resumes. `rate = 12.5e6`
+(100m). Without any clamp: `new_cap = 12.5e6 × 2 = 25 MB` one-shot →
+catastrophic burst. With bounded `elapsed` (`K=8`):
+`elapsed = min(2e9, 8 × 2e5) = 1.6e6 ns`, `new_cap = 12.5e6 × 1.6e-3 =
+20 000 B`. The post-stall burst is **≤ 20 KB** for 100m (≤ `8 ×
+rate × EPOCH` for any class — for 24g: `3e9 B/s × 1.6e-3 = 4.8 MB`,
+which is 8 epochs of 24g, still a bounded transient that the downstream
+root shaper and NIC ring absorb). **Burst bound holds: no class can
+ever emit more than `K × EPOCH` worth of rate in one rotation.**
+
+With the carry-reservoir variant the burst is identical (`MAX_CARRY_DRAW`
+≤ `(K−1)×base_cap` enforces the same per-rotation ceiling); the
+reservoir only changes whether the residual beyond `K×EPOCH` is dropped
+(bounded-elapsed) or banked-and-clipped (reservoir). Either way the
+single-rotation grant is `≤ K × rate × EPOCH` **per class**.
+
+### 3.5.1 Aggregate simultaneous-resume burst (v2 — Codex F3 / AGY / Claude MAJOR-4)
+
+The per-class bound above is necessary but NOT sufficient. The real
+hazard is **all classes resuming in the same tick** after a poll-loop
+stall (the worker loop services every queue in one pass, so a stall that
+delays the loop lags *every* queue's rotation simultaneously). Codex's
+worked counter-example: the 10 named exact rates sum to **109.1 G**, so
+the aggregate one-tick release at K=8 is
+
+```
+Σ_i (rate_i × K × EPOCH) = K × EPOCH × Σ rate_i
+                         = 8 × 200µs × 109.1e9 B/s / 8  (bytes)
+                         ≈ 21.8 MB   in a single worker-loop pass.
+```
+
+v1 hand-waved that "the root shaper absorbs it." **That is false** — two
+verified repo facts:
+
+1. The root lease refills on **raw elapsed**, NOT epoch-clamped:
+   `mod.rs:853` `let elapsed_ns = now_ns - last_refill_ns;`. After a
+   stall the root *also* refills its full stalled-duration credit (up to
+   its own burst cap), so it does not throttle the aggregate class burst
+   the way an epoch-clamped meter would.
+2. The default root burst is only **1% of rate floored at 64×1500**:
+   `forwarding_build/cos.rs:66`. At 25 G that is ~31 MB — so a 21.8 MB
+   aggregate class burst fits *inside* the root burst and is NOT
+   throttled. The root is not the backstop.
+
+**v3 aggregate burst invariant + fix (corrected — Codex r2 B1 / AGY r2
+F3).** v2's thread-local `C_agg` was UNSOUND: the dataplane runs N≈6
+workers (`forwarding_build/cos.rs`), each Arc-clones the same queue
+leases (`coordinator/cos_state.rs:8-14`; `acquire_v8(worker_id, …)` is
+explicitly multi-worker). A system-wide stall resumes all N workers, each
+resetting its OWN thread-local budget → aggregate burst `N × C_agg`,
+overrunning the ~31 MB root burst; dividing by N starves a single-owner
+queue to 1/N. A thread-local cannot bound a global constraint.
+
+**v3 fix — a true global per-epoch carry-release budget on the SHARED
+root lease.** The root lease (`SharedCoSRootLease`) is already the
+interface-wide arbiter shared by all workers. Add ONE atomic to it:
+
+```rust
+// on SharedCoSRootLease (the existing shared, all-workers object):
+carry_release_budget: AtomicU64,   // bytes of carry/over-grant still
+                                   // releasable this ROOT epoch
+```
+
+- **Refill (single writer per root epoch):** the worker that rotates the
+  root epoch (root already has its own epoch/refill at `mod.rs:853`)
+  resets `carry_release_budget = C_agg` once per root epoch, where
+  `C_agg = min(root_burst_bytes / 2, nic_tx_ring_depth × frame)` — sized
+  to BOTH the root burst AND the physical NIC TX ring depth (AGY r2 NIT:
+  the burst lands in the ring, not only the root).
+- **Draw (all workers, atomic):** each queue lease's carry/over-grant in
+  `acquire_v8` does a `fetch_sub`-with-floor (CAS loop) against the
+  shared `carry_release_budget`; when it hits 0 the carry is withheld
+  that epoch (recovered next epoch). One atomic on an already-shared
+  object — low contention because the draw fires only on the *carry/
+  over-grant* path (lagged classes), not every acquire.
+
+This makes the aggregate genuinely global: `Σ over all workers and all
+classes (carry released this root epoch) ≤ C_agg`, independent of N.
+
+**Gate 5c (aggregate burst) — corrected assertion:** lag ALL leases by
+2 s, resume all N workers in one root epoch, assert **total** carry
+released across all workers ≤ `C_agg` (NOT per-worker). The test must
+exercise N>1 workers to catch the v2 thread-local flaw.
+
+(Alternative (ii) — per-lease K scaled by class share so `Σ rate_i ×
+K_i × EPOCH ≤ C_agg` — remains a fallback if the shared-atomic
+contention proves measurable; rejected as primary because it couples K
+to config and complicates the §3.6 sweep.)
+
+### 3.6 MANDATORY discriminating measurement (v2 — resolves the loss model)
+
+Before /engineer commits a mechanism, run on SOLO (one class, one port,
+12 streams, push, v4, `guarantee-rate 0.7`) for **both 100m AND 3g**:
+
+| Variant | 100m % | 3g % | Interpretation |
+|---------|-------:|-----:|----------------|
+| master (K=1 clamp) | 81.4 | 89.9 | baseline |
+| A: K=8 | ? | ? | probe said 94.5 / 84.9(noisy) |
+| A: K=64 | ? | ? | if ≈100% → loss is heavy lag tail |
+| A: K=8 + P2 | ? | ? | if ≥95% but K=8 alone <95% → P2 is co-fix |
+| A: K=64 + P2 | ? | ? | belt-and-suspenders ceiling |
+
+This A/B is the load-bearing experiment; the §3.4 decision rule consumes
+its result. The plan does **not** declare a mechanism until this table is
+filled. (This is legitimate /research output: the plan specifies the
+*decision procedure* and the gate; the mechanism falls out of one
+measurement at /engineer time. A throwaway local build A/B during this
+research round MAY pre-fill it if the loss cluster is free and the
+parallel #1636 / full-review agents are not mid-smoke.)
 
 ---
 
-## 5. The instrumented bisection (v4 — THE DELIVERABLE; both reviewers confirmed the counters)
+## 4. Seqlock-safety argument (folds in #1643 — pre-existing acquire-fence bug)
 
-Debug counters in a LOCAL throwaway build, NOT committed
-(`option_env!("XPF_COS_MIDRATE_DEBUG")`). **Use thread-local non-atomic
-accumulators flushed to the shared status block once per 1s** (NOT hot-path
-`AtomicU64` fetch_add) to keep the instrumentation free at 25G —
-per-packet atomics on the drain path are themselves perturbative (§5.4).
+The v8 epoch state is published via a seqlock: writer CASes
+`epoch_seq` EVEN→ODD (claim), mutates state, stores ODD→EVEN (publish);
+readers in `snapshot_epoch_v8` read `seq_before` (must be EVEN), read
+`{cap, share, grace, tag}`, re-read `seq_after`, retry if changed.
 
-### 5.0 Counter 0 — OFFERED LOAD (the fifth layer; check FIRST — Codex r4)
+### 4.0 #1643 — the reader is missing `fence(Acquire)` (VERIFIED, fold in)
 
-Before any shaper counter: **per-class offered/ingress bytes BEFORE
-shaping** — bytes enqueued to the CoS queue per 1s (the
-ingest/enqueue site, `ingest_cos_pending_tx` → `cos_queue` push, count
-`cos_item_len` at enqueue) plus ingress drops/refusals and
-queue-backlogged (nonempty) time. **If `offered_bytes < rate×wall` the
-class is RX/conntrack/forward-bound BELOW its rate and there is NO shaper
-residual to fix** (§11-Q4, §4-Q4b). This MUST be the first ratio read;
-every shaper-internal hypothesis is moot if the class is not even offered
-its rate. (For a push test the firewall forwards the host's TCP; if a
-single solo flow-bundle is RX/CPU-limited the shaper never sees full
-offered load.)
+A parallel full-codebase review filed **#1643** against this exact
+reader. I verified it against origin/master `dbfbf680c`:
+`snapshot_epoch_v8` (`mod.rs:1427-1455`) loads the payload with
+independent `Acquire` loads and then re-reads `seq_after` with a plain
+`Acquire` load — with **no `std::sync::atomic::fence(Ordering::Acquire)`
+between the data loads and the trailing seq re-read**. An `Acquire` load
+only prevents *later* ops from being hoisted above it; it does NOT pin
+the *prior* data loads above the `seq_after` read. On a weakly-ordered
+CPU (ARM/POWER) `seq_after` can be observed *before* the payload loads
+retire, so the even-equal validation can pass against torn cross-epoch
+data. **Confirmed:** there are zero `fence(...)` calls in
+`shared_cos_lease/mod.rs`, and the writer
+(`rotate_epoch_v8.rs:239`) uses a plain `Release` store. This is the
+#1619 seqlock-tearing class. Latent on the x86-TSO i40e deploy target
+(TSO forbids load-load reordering) but a real hazard if the dataplane
+ever runs on a weakly-ordered CPU.
 
-### 5.1 Counters (per 3g/6g queue, per 1s window)
+**The correct reference pattern** is the cold-path histogram seqlock,
+which the parallel review verified as correct
+(`cold_path_hist.rs:556-595` `snapshot()`):
 
-0. **offered_bytes** + ingress drops + backlogged-time (§5.0) — the
-   gating counter.
-1. **phase1_honored_bytes** — bytes for which this queue was SELECTED in
-   Phase 1 (`select_exact_cos_guarantee_queue_waterfill` Phase-1 return,
-   `:907`). Add `secondary_budget` at the return. (Expected ≈ all per §3.1.)
-2. **phase2_served_bytes** — bytes selected in Phase 2 (`:996` return).
-3. **phase1_skipped_count / phase2_skipped_count** — times the queue was
-   walked but skipped (Phase-1 budget-exhausted break `:889`; Phase-2
-   no-park `continue` `:978`).
-4. **drain_sent_bytes** — actual TX (existing, `tx_completion.rs:482`),
-   net of stranded `queue.hot.tokens` (AGY r2 #3: subtract residual hot
-   tokens so a TX-ring refusal is not mis-attributed).
-5. **cap_granted** vs `rate×wall` (H1/H4/H5).
-6. **bucket_high_water** vs `rate×200µs` (H-LEASE falsifier).
-7. **per-worker share-exhaustion count** + worker count (H5).
-8. **iperf3 goodput**, L2-normalized (subtract Ethernet/IP/TCP framing so
-   the ratio compares like-for-like vs `drain_sent` frame bytes) (H-TCP).
+```rust
+let s1 = gen.load(Ordering::Acquire);          // even-check
+if s1 & 1 != 0 { backoff; continue; }
+// ... payload loads with Ordering::Relaxed ...
+std::sync::atomic::fence(Ordering::Acquire);   // SEAL the Relaxed loads
+let s2 = gen.load(Ordering::Relaxed);          // re-read
+if s2 == s1 { return Some(payload); }
+```
 
-### 5.2 The decision table
+**Fold the #1643 fix into this plan** rather than ship it as a separate
+PR — a second PR touching the same seqlock would collide and double the
+review. The fix to `snapshot_epoch_v8`:
 
-Run 3g-solo and 6g-solo (single port, push, v4, guarantee-rate 0.7):
+```rust
+let seq_before = v8.epoch.epoch_seq.load(Ordering::Acquire);   // even-check (Acquire OK here)
+if seq_before & 1 == 1 { ...spin... continue; }
+let cap   = v8.epoch.epoch_total_grant_cap.load(Ordering::Relaxed);   // payload -> Relaxed
+let share = ...load(Ordering::Relaxed);
+let grace = v8.epoch.epoch_grace_expires_ns.load(Ordering::Relaxed);
+std::sync::atomic::fence(Ordering::Acquire);                   // NEW: seal payload loads
+let seq_after = v8.epoch.epoch_seq.load(Ordering::Relaxed);    // re-read (Relaxed after fence)
+if seq_after == seq_before { return Some((cap, share, grace, tag)); }
+```
 
-| Observation | Conclusion |
-|-------------|------------|
-| **`offered_bytes < rate×wall`** (counter 0 — see §5.0) | **OFFERED-LOAD BOUND** — the class is RX/conntrack/forward-limited BELOW its rate; there is no shaper residual to fix. **Check this FIRST** (§11-Q4). |
-| `phase1_honored ≈ all` AND `drain_sent ≈ rate×wall` AND `goodput < drain_sent` | **H-TCP** — shaper grants, honors in Phase 1, and SENDS full shape; TCP loses goodput to bursty delivery → smoothing fix or §6.4 re-frame. **Leading expected outcome** (every shaper-internal mechanism falsified). |
-| `phase1_honored ≈ 0` AND `phase2_served ≈ all` AND `phase2_skipped` high | H-WATERFILL RE-OPENS — would CONTRADICT §3.1 (the full config should honor 3g/6g in Phase 1). If seen, the config under test is NOT the full set — re-check the applied config. |
-| `cap_granted < rate×wall` with multiple workers | **H5** — per-worker fair-share rounding; folds into cause-1 meter. (Moot for truly-solo: total_flows=1.) |
-| `drain_sent/total_granted < 1` (net of stranded hot tokens) | **DRAWN-NOT-SENT** — TX-ring/scratch refusal; submit-path fix. |
-| `bucket_high_water > rate×200µs` | H-LEASE re-opens (would contradict AGY r2 #6). |
-| `drain_park_queue_tokens` high for solo 3g/6g | the Phase-1 wheel park IS biting (H7 re-opens despite §3.3). |
+**Writer side (v2 — precise wording, Codex F5 / Claude MAJOR-5).** The
+correctness comes from three facts, not from "Release orders prior
+Release stores" (which is imprecise — a `Release` store does not order
+*other* locations' prior `Release` stores for a *different* reader):
 
-The OFFERED-LOAD check (counter 0) gates everything: if offered < rate
-there is no shaper bug. Given §3 falsified the shaper-internal
-mechanisms, **the expected outcome is offered ≥ rate AND shaper sends
-full shape AND goodput < send → H-TCP.** The five+ ratios cleanly
-separate the surviving candidates; one cluster run fills the table.
+1. **Single writer in program order.** Only the rotation winner is in
+   the ODD section (`compare_exchange(AcqRel, Acquire)` at
+   `rotate_epoch_v8.rs:46` admits one winner). All payload stores happen
+   before the ODD→EVEN publish *in that one thread's program order*.
+2. **One Release publish.** The `epoch_seq.store(seq+2, Release)` at
+   `:239` is the single release the reader's fenced-Acquire re-read
+   synchronizes-with.
+3. **Reader fenced-Acquire** (the §4.0 fix) pins the payload reads above
+   the `seq_after` read.
 
-### 5.3 Confirm root is not the limiter
+Given (1)+(2)+(3), the payload stores **can and should be downgraded to
+`Relaxed`** (currently `Release` at `:224` etc.) — matching the
+`cold_path_hist.rs:572` reference writer, which stores payload `Relaxed`
+under `fetch_add(AcqRel)` claim + `fetch_add(Release)` publish. Keeping
+them `Release` is harmless but redundant; the downgrade is part of the
+#1643 fix for clarity and parity with the verified-correct reference.
 
-Re-confirm `drain_park_root_tokens ≈ 0` and root-lease grant ≈
-`shaping_rate × wall` for 3g/6g solo. If the root throttles a solo class,
-that is a separate root-meter fix.
+**This sibling bug strengthens, not complicates, the carry design:** the
+new carry field MUST observe the *same* fence discipline. Because the
+carry is rotation-private (read/written only by the rotation winner
+inside the ODD section, never read by `snapshot_epoch_v8` or
+`acquire_v8`), it adds nothing to the reader payload and needs no new
+reader fence — it rides inside the writer's existing
+`compare_exchange(AcqRel)` → `store(Release)` brackets.
 
-### 5.4 Instrumentation-perturbation GATE (Codex r4, §11-Q3)
+**ENFORCED carry-reader-private guard (v2 — Codex F5 / Claude MAJOR-5).**
+"Reader-private" must be *enforced*, not asserted, or a future edit
+silently reintroduces #1643 for the carry. Required:
+- The carry atomic is a private field accessed only via two
+  `#[inline]` rotation-internal helpers in `rotate_epoch_v8.rs`; no
+  `pub`/`pub(super)` accessor.
+- A `#[cfg(test)]` test that greps the crate (or a
+  `compile_fail`/visibility test) asserting no `acquire_v8`,
+  `snapshot_epoch_v8`, or `coordinator/status.rs` path references
+  `epoch_carry_bytes`. (Cheap CI insurance; Gate 5b sibling.)
+- If a future variant must surface the carry to status/Prometheus, it
+  joins the §4.0 fenced payload region — a documented invariant in the
+  struct doc comment.
 
-The instrumentation MUST NOT itself cause the residual it measures. **Gate
-(hard):** run 3g/6g solo with the instrumented build AND the clean build;
-the throughput delta must be ≤ 0.5pp. If the instrumented build depresses
-throughput more than that, the counters are perturbative and the
-measurement is invalid — switch to thread-local non-atomic accumulators
-(§5 preamble) and re-A/B until the delta is within bound. The bisection
-ratios are only trustworthy once this gate passes.
+`Closes #1643` belongs on the /engineer PR alongside the #1630 fix.
 
----
+`Closes #1643` belongs on the /engineer PR alongside the #1630 fix.
 
-## 6. Fix mechanism — DEFERRED pending §5 (v4: no pre-committed fix)
+**Both mechanisms (bounded-elapsed and carry-reservoir) are seqlock-safe
+by construction:**
 
-> v4 position: all three derived mechanisms are falsified (§3). The plan
-> does NOT commit a fix. The §5 measurement names the layer; the fix is
-> designed in a short follow-up once the four ratios land. This is the
-> honest /research output when static analysis cannot attribute the
-> residual — it is NOT a dodge: it is the disciplined refusal to ship a
-> fix on a falsified hypothesis (the cause-1 §12 fork precedent).
+1. **Bounded-`elapsed` (§3.4):** changes only the *value* written to
+   `epoch_total_grant_cap` at line 224 — it adds no new published field,
+   no new atomic read in the reader path. The seqlock contract is
+   byte-for-byte unchanged; `snapshot_epoch_v8` reads the same four
+   fields. **Zero seqlock surface change.** This is the decisive
+   argument for preferring §3.4: it cannot introduce the #1619
+   seqlock-tearing class because it touches no publication shape.
 
-Candidate fixes BY MEASURED LAYER (each is a hypothesis to be confirmed,
-not a commitment):
+2. **Carry-reservoir (§3.2):** `epoch_carry_bytes` is written and read
+   **only by the rotation winner**, entirely inside the ODD critical
+   section (between the EVEN→ODD CAS at `rotate_epoch_v8.rs:44` and the
+   ODD→EVEN store at line 239). It is **never read by acquirers** —
+   `snapshot_epoch_v8` does not read it; `acquire_v8` does not read it.
+   Therefore it is *not part of the published payload*; it is rotation-
+   private mutable state that happens to live in the shared struct. Only
+   one thread is ever in the ODD section (the CAS guarantees a single
+   winner; line 44-51). Hence the carry read/modify/write is a
+   single-threaded RMW with no concurrent reader → no torn read, no new
+   seqlock invariant. The `Acquire`/`Release` on the carry atomic are
+   redundant (the surrounding seqlock CAS already fences) but harmless
+   and self-documenting.
 
-- **§5 layer = H-TCP (`goodput/drain_sent < 1`, drain_sent ≈ rate×wall):**
-  the shaper sends full shape; TCP loses goodput to 50µs-quantized bursty
-  delivery. Fix = delivery smoothing (finer service granularity / pacing)
-  — NOT a grant/selector change. If smoothing cannot recover it, the
-  residual is AF_XDP-per-CPU + TCP-pacing physics and Gate-1 re-framing
-  is the charter-authorized last resort (§6.4). **This is now the LEADING
-  expected outcome** given every shaper-internal mechanism is falsified.
-- **§5 layer = drawn-not-sent (`drain_sent/total_granted < 1`):** TX-ring
-  refusal / scratch-build failure under bursty delivery. Fix = submit
-  path (`tx_completion.rs` apply paths). Orthogonal to causes 1/2.
-- **§5 layer = grant-not-drawn with park (`drain_park_queue_tokens` high
-  for 3g/6g):** the Phase-1 wheel park IS biting despite §3.3's demotion.
-  Fix = sub-tick wake for the bucket-refill case (the gated F-E from v3,
-  with the `my_consumed < my_effective_share` guard, Codex r2 B2).
-- **§5 layer = meter under-grant (`cap_granted < rate×wall`, multi-worker
-  H5):** per-worker fair-share rounding. Fix = distribute the share
-  remainder in the rotation; folds into the cause-1 meter (coupled to the
-  seqlock/carry, §9).
-- **§5 layer = root throttle (`drain_park_root_tokens > 0` solo):** raise
-  root burst/epoch. Orthogonal.
+   **The one hazard to verify in review:** the carry must be read/written
+   only after the EVEN→ODD CAS succeeds and before the ODD→EVEN store —
+   i.e. it must NOT be touched on the early-return paths (peer rotating,
+   CAS lost). Confirmed: all early returns (`mod.rs`-extracted lines
+   33-35, 39-41, 45-51) precede the critical section; placing the carry
+   RMW alongside the existing STEP 6 cap computation satisfies this.
 
-### 6.1 What /engineer does FIRST (ordered)
+   **Reader-side cap range:** the published `cap` already varies epoch to
+   epoch; readers treat it as opaque. Adding `carry_draw` only widens the
+   value range of an existing field, which the reader and `acquire_v8`
+   primary/surplus loops already tolerate (they compare `class_granted <
+   cap` with a tag-checked CAS; a larger `cap` simply admits more grant
+   that epoch, still tag-fenced). No new tearing path.
 
-1. Pass the §5.4 instrumentation-perturbation A/B gate (instrumented vs
-   clean ≤ 0.5pp) — else the counters are invalid.
-2. Read **counter 0 (offered load) FIRST**: if `offered < rate×wall` the
-   class is RX/forward-bound and there is NO shaper residual — stop, the
-   issue is upstream.
-3. If offered ≥ rate, read the §5.2 ratios on the free `loss` cluster
-   (3g-solo AND 6g-solo AND 9g, single port, push, v4, guarantee-rate
-   0.7, FULL `cos-iperf-config.set`, long steady-state window). The table
-   names the layer.
-4. ONLY THEN design the fix for that layer. Do NOT write fix code before
-   the bisection.
-
-### 6.2 Burst-safety (whatever the fix)
-
-Any fix must preserve `transmit-rate exact`: the per-queue v8 grant
-`cap = rate×elapsed` meters every class. Gate (§8) proves no class
-exceeds shape over any 10ms window.
-
----
-
-## 7. Seqlock / concurrency surface (composing with cause-1 + #1643)
-
-**The layering contract for WHATEVER fix §5 selects.** Most candidate
-fixes (§6) are seqlock-orthogonal — they live in the drain/selector/TX
-path, which is per-binding single-worker `CoSInterfaceRuntime` state
-(verified non-atomic, not in the v8 seqlock payload: the waterfill state
-`waterfill_pass1_remaining_bytes`/`waterfill_phase2_cursor`/
-`exact_queues_by_rate_ascending`, `types/cos.rs:406-419`; the timer
-wheel; `queue.hot.tokens`). The v8 seqlock publishes `cap/share/grace/tag`
-only.
-
-- **Drain/selector/TX/smoothing fix (H-TCP, drawn-not-sent, wheel-park):**
-  **zero new seqlock surface.** The #1643 fence and the carry's
-  rotation-private `epoch_carry_bytes` are untouched; cause 2 is reviewed
-  as ordinary single-worker logic. Cleanest composition.
-- **Meter-side fix (H5 per-worker fair-share rounding):** the fix is in
-  the rotation `my_share` computation — IN the seqlock writer — and MUST
-  be reviewed together with the carry. This is the only case that couples
-  to cause 1.
-- H-LEASE killed (§3.2); root throttle orthogonal.
-
-**The seqlock review surface of the combined PR is bounded to cause-1's
-(carry + #1643 fence) UNLESS §5 selects the H5 meter-side cause.** §5
-distinguishes the clean (selector/drain) from the coupled (meter) layer.
+**Conclusion:** §3.4 has zero seqlock risk; §3.2's carry is rotation-
+private and does not extend the published seqlock payload. Neither
+introduces the #1619 class. (#1619 was a *reader-visible* field added to
+the payload without widening the seq-guarded read; the carry is
+deliberately *not* reader-visible.)
 
 ---
 
-## 8. Combined acceptance (cause-1 + cause-2 + #1643)
+## 5. HA-failover-safety argument (v2 — CORRECTED; Codex F4 was decisive)
 
-The eventual /engineer PR lands ONE combined change. Gate 1 is the
-binding gate and now requires BOTH causes fixed.
+> **v1 was wrong here.** v1 claimed leases are rebuilt fresh
+> (`start==0`) on every failover, so the standby's first grant is
+> harmless. Codex's Finding 4 (which I verified against origin/master)
+> falsifies that: **leases are REUSED when the config matches.**
 
-- **Gate 1 — ALL FOUR classes SOLO ≥ 95%** (100m/1g/3g/6g, single port
-  AND small-four-alone, 12 streams, push, v4, guarantee-rate 0.7). This
-  is the gate cause-1 alone CANNOT pass (3g/6g plateau ~90-94) and
-  cause-2 alone CANNOT pass (100m ~82). Combined MUST clear all four.
-- **Cause-1 lowest-class preserved** — 100m must remain ≥95 (the carry's
-  +13pp must not regress when the cause-2 fix changes the park/lease
-  cadence).
-- **Burst bound held** — Gate 5 (single-class stall→resume ≤ K×rate×EPOCH,
-  per cause-1 plan §7) AND a NEW cause-2 burst check: the §5-selected
-  cause-2 fix must not let any class exceed its `transmit-rate exact`
-  shape over any 10ms window (counter: per-class TX bytes / 10ms ≤ shape
-  × 1.05). The per-queue v8 grant `cap = rate×elapsed` still meters each
-  class regardless of the fix.
-- **`make test-failover`** — mandatory (TX-shaping change). Zero-drop;
-  cause-1's reused-lease unit test passes; the drain/selector state is
-  per-binding and rebuilt on promote.
-- **Full matrix** — v4+v6 × push+`-R` × CoS-off+CoS-on, per memory
-  feedback. Gate 2 (priority-low ≥5%), Gate 3 (retransmits ≤100/30s),
-  Gate 4 (aggregate ≥19.5G) must not regress.
-- **Cause-2 regression test** — branch-specific to the §5-selected fix
-  (designed at /engineer after the bisection names the layer). The plan
-  does not pre-specify it because the fix is not pre-committed.
+### 5.1 The actual lease lifecycle (verified)
 
-**NOTE (v4):** because cause-2's fix is deferred to the §5 outcome, this
-combined-acceptance section is the gate the EVENTUAL fix must clear, not a
-claim that any specific code in this plan clears it. The binding /research
-deliverable is §5 (the measurement) + this gate (the bar). cause-1 +
-#1643 can ship and be gated independently NOW.
+`coordinator/mod.rs:1106-1116` reuses an existing lease when
+`matches_config_v8(transmit_rate, burst, active_shards, max_worker_id,
+rate_mode)` holds:
+
+```rust
+if let Some(lease) = existing.get(&key).filter(|lease| {
+    lease.matches_config_v8(...)
+}) {
+    out.insert(key, lease.clone());   // SAME Arc survives
+    continue;
+}
+out.insert(key, Arc::new(SharedCoSQueueLease::new_v8_with_rate_mode(...)));
+```
+
+HA demotion (`ha.rs:48-55`) queues only `DemoteOwnerRGS` +
+`VacateAllSharedExactSlots`; the latter vacates **V_min slots only**
+(`worker/cos/mod.rs:305 vacate_all_shared_exact_slots_for_binding`), NOT
+the queue lease's epoch state. Re-promotion (`ha.rs:119`) queues
+`RefreshOwnerRGS`. **Nothing in the demote→promote cycle resets
+`epoch_start_ns`.**
+
+### 5.2 The worked counter-example (the bug v2 must fix)
+
+1. Node A active; lease L for the 100m queue has `epoch_start_ns = t0`.
+2. A demotes for 2 s (peer takes over). Config unchanged on A.
+3. A re-promotes. Reconcile finds L matches config →
+   `out.insert(key, L.clone())`: **the same Arc, `start` still = t0**.
+   `ensure_v8_lease_attached` sees the same Arc (ptr_eq) → no re-attach,
+   no reset.
+4. First post-promotion `acquire_v8(now = t0 + 2s)` →
+   `maybe_rotate_epoch_v8`: `lag = now − start ≈ 2 s`.
+   - Mechanism A: `elapsed = min(2s, K×EPOCH) = K×EPOCH` →
+     `new_cap = rate × K × EPOCH` = a **`K`-epoch burst on the first
+     post-failback grant**, exactly the burst the clamp was protecting
+     against, now re-introduced by the K relaxation on a stale `start`.
+   - Mechanism B: the carry reservoir *also* survived in L (it is
+     per-lease, never reset) → it adds its banked `MAX_CARRY_BYTES` on
+     top. Worse.
+
+This is the HA double-grant the charter's constraint #4 demanded be
+ruled out. v1 missed it because v1 assumed a fresh lease.
+
+### 5.3 The fix: THREE-regime rotation with a DECOUPLED stall threshold (v3)
+
+> **v3 corrects two v2 defects** (Codex r2 B2 / AGY r2 F1+F2): (1) the v2
+> `else` branch `raw_elapsed.min(EPOCH_DURATION_NS)` clamped to ONE epoch,
+> making mechanism A inert — a literal code bug; (2) the v2 cold-resume
+> cutoff at `K×EPOCH` collided with the legitimate heavy-tail visit lag
+> (§3.4's own 12-epoch example), causing an 8× step-function drop and
+> dropping the very carry B was meant to recover. v3 **decouples** the
+> stall threshold from `K` and uses three regimes:
+
+```rust
+// K = MAX_ROTATION_LAG_EPOCHS (rate-recovery width, e.g. 8..64 from §3.6)
+// STALL = STALL_THRESHOLD_EPOCHS (cold-resume cutoff, DECOUPLED from K,
+//         sized below a failback gap and ABOVE any legitimate tail; see
+//         §5.3.1). e.g. STALL = 256 epochs ≈ 51.2 ms.
+debug_assert!(STALL_THRESHOLD_EPOCHS > MAX_ROTATION_LAG_EPOCHS);
+
+let raw_elapsed = now_ns - start;
+let lag_epochs = raw_elapsed / EPOCH_DURATION_NS;
+
+let elapsed_ns = if start == 0 || lag_epochs > STALL_THRESHOLD_EPOCHS {
+    // REGIME 3 — cold start / stall / failback gap:
+    // grant exactly one epoch, bank NOTHING, drop stale carry.
+    if start != 0 { epoch_carry_bytes.store(0, Release); }
+    EPOCH_DURATION_NS
+} else if lag_epochs > MAX_ROTATION_LAG_EPOCHS {
+    // REGIME 2 — legitimate heavy-tail lag beyond K but below stall:
+    // grant the full K-epoch width NOW (mechanism A ceiling) and BANK
+    // the residual (lag − K) into carry for the next visit (mechanism B).
+    // No cliff: a 12-epoch lag at K=8 grants 8 now, banks 4. (matches §3.4)
+    let overshoot_ns = raw_elapsed - EPOCH_DURATION_NS * MAX_ROTATION_LAG_EPOCHS;
+    let new_owed = (rate as u128 * overshoot_ns as u128 / 1e9) as u64;
+    let carry = epoch_carry_bytes.load(Acquire)
+        .saturating_add(new_owed)
+        .min(MAX_CARRY_BYTES);
+    epoch_carry_bytes.store(carry, Release);   // drained next visit, capped
+    EPOCH_DURATION_NS * MAX_ROTATION_LAG_EPOCHS
+} else {
+    // REGIME 1 — normal recovery: lag within K. (FIX: bound by K*EPOCH,
+    // NOT 1*EPOCH — this was the v2 bug.)
+    raw_elapsed   // == raw_elapsed.min(K*EPOCH) since the guard bounds it
+};
+```
+
+Properties:
+- **Regime 1 (lag ≤ K):** mechanism A fully active — recovers the common
+  intermittent-visit lag. (v2's `.min(EPOCH)` bug is fixed.)
+- **Regime 2 (K < lag ≤ STALL):** NO cliff. The legitimate heavy tail
+  gets the full K-epoch grant now plus banked residual (B), drained next
+  visit and capped at `MAX_CARRY_BYTES`. This is where mechanism B earns
+  its keep and where the v2 cliff is eliminated.
+- **Regime 3 (lag > STALL, or start==0):** cold-resume — one epoch, drop
+  carry. Bounds the post-failback/stall burst to `rate × EPOCH`,
+  identical to today's `start==0` grant. The carry drop prevents B
+  double-grant across the gap.
+- Per-rotation grant is `≤ max(K×EPOCH, 1×EPOCH) × rate = K×rate×EPOCH`
+  in all regimes (regime 2 grants exactly K, banks the rest) → the
+  §3.5.1 global cap still bounds the aggregate.
+
+### 5.3.1 Sizing STALL_THRESHOLD (the decoupling — Codex r2 B2 / AGY r2 F2)
+
+`STALL` must satisfy `legitimate_tail_p99 < STALL × EPOCH < failback_gap`.
+
+- **Lower bound (legitimate tail):** the §3.6 sweep measures the visit-
+  lag distribution; `STALL` must exceed its p99 so regime 2 (not regime
+  3) handles real heavy-tail visits. If §3.6 shows the tail p99 is, say,
+  ~30 epochs, `STALL = 256` has a 8× margin.
+- **Upper bound (failback / stall gap):** a planned failback is ≥100 ms
+  (daemon start + dataplane load + sync hold, per CLAUDE.md "Failback
+  timing ~130 ms") = ≥500 epochs; a GC pause that should reset is ≥ tens
+  of ms. `STALL = 256 epochs ≈ 51 ms` sits below a failback gap and above
+  the tail.
+- **If the bounds overlap** (legitimate tail p99 ≳ failback gap — very
+  unlikely given 500-epoch failback vs single/double-digit-epoch visits),
+  the lag-magnitude heuristic is unsafe → use the §5.3.2 explicit reset
+  command INSTEAD. §3.6 decides; the plan now specifies BOTH paths fully.
+
+### 5.3.2 Fallback: explicit `WorkerCommand::ResetCoSEpochs` (fully designed — AGY r2 F4)
+
+If §5.3.1 shows the heuristic bounds overlap, replace the regime-3
+lag-magnitude trigger with an explicit reset driven by the HA lifecycle:
+
+- **New variant:** `WorkerCommand::ResetCoSEpochs` in the existing worker
+  command enum (sibling of `DemoteOwnerRGS`/`VacateAllSharedExactSlots`/
+  `RefreshOwnerRGS`).
+- **Routing (producer):** `ha.rs` enqueues it on the **re-promotion**
+  path (alongside `RefreshOwnerRGS` at `ha.rs:119`) AND on the
+  **demotion** path (alongside `VacateAllSharedExactSlots` at
+  `ha.rs:55`) — demotion reset is cheap insurance so a reused lease is
+  clean before the gap, not only after.
+- **Handler (consumer):** the worker poll loop (where
+  `VacateAllSharedExactSlots` is handled, `loop_body/mod.rs:579`) calls a
+  new `lease.reset_epoch_state()` on each attached v8 queue lease:
+  `epoch_start_ns.store(0)`, `epoch_carry_bytes.store(0)`,
+  `epoch_total_grant_cap.store(0)`, and bump `epoch_seq` to an even value
+  via the seqlock claim/publish so concurrent readers see a consistent
+  reset (NOT a bare store — must go through the EVEN→ODD→EVEN protocol to
+  preserve the §4.0 seqlock invariant).
+- **Visibility invariant:** the reset is single-writer (the owning
+  worker), goes through the seqlock, and zeroes exactly the fields the
+  `start==0` first-rotation branch already handles — so a post-reset
+  `acquire_v8` takes the identical `start==0` cold path. No new reader
+  surface.
+- **Idempotent + race-safe:** resetting an already-reset lease
+  (`start==0`) is a no-op; the seqlock claim serializes against a
+  concurrent rotation.
+
+**Recommendation:** ship the §5.3 three-regime heuristic as primary (it
+also covers non-HA stalls — GC, scheduler starvation — that no command
+catches), and add §5.3.2 ResetCoSEpochs as belt-and-suspenders on the HA
+demote/promote path (cheap, removes any dependence on the heuristic
+margin for the HA case specifically). §3.6's measured tail decides
+whether the heuristic margin alone is sufficient or the command is
+required.
+
+### 5.4 Cross-node safety (unchanged from v1, still valid)
+
+The carry/epoch state is per-lease, per-node, in-process heap state,
+never serialized into session-sync, config-sync, or heartbeat (verified:
+no `carry`/lease reference in `protocol.rs`/`protocol.go`; only sessions
+and config are synced). A failover cannot transfer carry between nodes.
+The standby builds/reuses its OWN lease locally. ✓
+
+### 5.5 Empirical gate
+
+`make test-failover` (mandatory for any TX-shaping change) PLUS a new
+assertion: after a deliberate demote→promote cycle on the loss cluster,
+the newly-active node's first-epoch grant for each class ≤ `rate × EPOCH`
+(no `K`-epoch failback burst). The §5.2 counter-example becomes a unit
+test in `shared_cos_lease_tests.rs`: `acquire_v8(0, t0, huge)` then
+`acquire_v8(0, t0 + 2e9, huge)` on a REUSED lease (not a fresh one) →
+assert the second grant ≤ `rate × EPOCH`, proving the self-heal fires.
+
+**Conclusion (v3):** the carry/clamp cannot double-grant across a
+failback because (a) the regime-3 cold-resume (§5.3, lag > STALL or
+start==0) collapses an implausible lag to a single-epoch grant and drops
+stale carry, with STALL decoupled from K so legitimate heavy-tail visits
+(regime 2) are NOT penalized, and (b) the §5.3.2 `ResetCoSEpochs`
+command provides an explicit seqlock-safe reset on the HA demote/promote
+path as belt-and-suspenders. This is the fix v1 missed and the v2 cliff
+defect corrected.
 
 ---
 
-## 9. How cause-1 + cause-2 + #1643 combine (explicit, per the charter)
+## 6. Compose with prior work (P2 + watermark)
 
-ONE combined seqlock change ships:
+`fix/1630-cos-lease-watermark` @ `b29fdb344` retains:
+- **P2** (per-visit FRAME-count cap at the selectors) — removes the
+  sub-frame-remainder discard at the selector.
+- **P1 watermark** (`lease_bytes.max(bank)`) — raises the bucket ceiling.
 
-1. **Cause-1 bounded credit carry** (`rotate_epoch_v8.rs` STEP 6 +
-   rotation-private `epoch_carry_bytes`, per
-   `docs/research/1630-v8-credit-carry/plan.md` @ `852cf014c`) — fixes
-   the lowest-rate (100m) grant-bound loss. **Meter layer.**
-   *(Note: that plan itself converged at PLAN-NEEDS-MAJOR pending the
-   §3.6 fork; the §3.6 measurement is now DONE and resolved to "neither
-   fork — cause 2 is distinct", which is THIS plan. The cause-1 carry's
-   own gate-clearing scope is reduced to the 100m/1g classes it actually
-   fixes; cause-2 owns 3g/6g. /engineer must re-scope cause-1's Gate-1
-   claim to "100m/1g cleared by carry; 3g/6g cleared by cause-2".)*
-2. **#1643 acquire-fence** in `snapshot_epoch_v8` (`mod.rs:1427`) —
-   `fence(Acquire)` between payload loads and `seq_after` re-read; payload
-   stores downgraded to `Relaxed`. **Meter layer, seqlock-correctness.**
-   `Closes #1643`.
-3. **Cause-2 fix — DEFERRED, selected by §5 (§6).** All three derived
-   mechanisms are falsified (§3); the fix is the one the §5 bisection
-   names. Most candidate layers (drain/selector/TX/smoothing) are
-   seqlock-orthogonal (§7); only the H5 meter-side cause couples to the
-   carry. **The plan commits to the §5 measurement + the layering
-   contract, not to a specific cause-2 code change.**
+**Assessment — are these prerequisites?**
 
-**Composition (expected, most-likely layers):** (1)+(2) are the
-meter/seqlock surface (carry + fence — the ONLY concurrency-sensitive
-code); a drain/selector/TX/smoothing cause-2 fix is a single-threaded
-change sharing NO field with the seqlock payload, reviewed independently.
-The clean three-layer ideal — **meter grant (carry) + meter publish
-(fence) + drain-layer cause-2 fix** — holds for every candidate EXCEPT
-H5, which is meter-side and reviews with the carry.
+- **P2 is LOAD-BEARING-pending-A/B (v2 — promoted from "likely").** The
+  §3.6 measurement explicitly tests `K=8 + P2` vs `K=8` alone. If the
+  residual loss is the sub-frame selector discard (BLOCKING-1 branch
+  (b)), P2 is the co-fix and a low `K` suffices — which is *strongly
+  preferable* because it preserves the burst bound. Mechanism: once the
+  v8 fix grants the lagged credit, the per-queue bucket receives more
+  bytes, but a low-rate class whose per-visit grant is < 1 frame
+  (100m = 2500 B < 4096 B frame) still cannot emit a frame at the
+  selector without P2's frame-count cap. **The /engineer fix folds P2 in
+  by default**, and the §3.6 A/B confirms whether it is the residual
+  lever or merely harmless. This is the cheapest path to ≥95% that keeps
+  K small.
 
-**Sequencing:** cause 1 + #1643 can ship together NOW (both are
-meter/seqlock and independently justified). Cause 2's fix waits on §5 and
-may land in the SAME combined PR (if §5 fires quickly at /engineer) or a
-fast follow-up. Gate 1 (all four ≥95% solo) is met only when cause 1 AND
-the §5-selected cause-2 fix are both in — UNLESS §5 shows H-TCP, in which
-case the residual is delivery/transport physics and Gate-1 re-framing
-(§6.4) is the charter-authorized last resort.
+- **P1 watermark is likely NOT required and possibly inert.** The
+  engineer proved the watermark sweep (N=8→64) is flat: the bucket
+  ceiling was never the binding limiter. Once the carry enlarges the
+  *grant*, the bucket fills faster, but the watermark only sets how full
+  the bucket is *allowed* to get before top-up stops — it does not gate
+  the grant. **Recommendation: drop P1 from the eventual fix unless
+  measurement shows the carry over-fills and the bucket clips.** Keep it
+  only if it is provably harmless and helps (engineer says it is rate-
+  safe / Gate-4-holds, so it is harmless; the question is whether it
+  helps — measure).
+
+**Explicit statement for the return contract:** P2 is load-bearing-
+pending-A/B (fold in, confirm via §3.6); P1 watermark is independent and
+probably unnecessary (measure before keeping). Neither is THE fix; the
+fix is the v8 bounded-`elapsed` (§3.4) + the stale-`start` self-heal
+(§5.3) + the aggregate burst cap (§3.5.1), with P2 as the selector-side
+co-fix.
+
+---
+
+## 7. Acceptance gate (canonical) + new burst & HA gates
+
+Primary: `test/incus/cos-gate1-small-four-alone.sh` (100m/1g/3g/6g,
+alone, 12 streams, push, v4, `guarantee-rate 0.7`). Each ≥ **95% of
+configured shape**. Today: 81/84/90/~85% SOLO. **The probe's K=8 numbers
+(94.5/95.3/84.9/94.4%) do NOT clear this gate — see §3.6; the mechanism
+that clears it is selected by measurement, not pre-assumed.**
+
+Full matrix (per memory feedback: v4+v6 × push+`-R` × CoS-off+CoS-on):
+- **Gate 1 (small-class SOLO ≥ 95%)** — the primary fix gate.
+- **Gate 1b (full simul-load)** — small-class starvation (#1614) must
+  improve; small classes ≥ 95% under the 5-class and 11-class simul.
+- **Gate 2 (priority-low ≥ 5% of cluster ceiling)** — must not regress.
+- **Gate 3 (per-class retransmits ≤ 100/30 s)** — must not regress.
+- **Gate 4 (aggregate ≥ ~19.5 G)** — no throughput regression.
+- **NEW Gate 5 — burst bound:** stalled-then-resumed worker must not
+  emit a grant > `K × rate × EPOCH`. **Test design:** a Rust unit test
+  in `shared_cos_lease_tests.rs` that calls
+  `acquire_v8(0, T, huge)` then `acquire_v8(0, T + 2_000_000_000, huge)`
+  (a 2 s lag) and asserts the second grant ≤ `K × rate × EPOCH` (not
+  `rate × 2 s`). Plus a cluster check: after a deliberate worker stall
+  (or the failover hold), the instantaneous post-resume rate over the
+  first 10 ms ≤ shape × small constant.
+- **NEW Gate 5b — #1643 fence regression:** unit test pins the
+  `fence(Acquire)` between the payload loads and the `seq_after` re-read
+  in `snapshot_epoch_v8` + the carry-reader-private guard (§4.0).
+- **NEW Gate 5c — aggregate simultaneous-resume burst (§3.5.1, v3):** lag
+  ALL leases by 2 s and resume **N>1 workers** in one root epoch; assert
+  the **total carry released across all workers** ≤ `C_agg` (≤ root
+  burst). MUST use N>1 to catch the v2 thread-local flaw (a single-worker
+  test would pass the broken design). HARD gate.
+- **NEW Gate 5d — no-cliff regime-2 (§5.3, v3):** a lag of `K+1` epochs
+  must grant `K×rate×EPOCH` + bank residual (NOT drop to `1×EPOCH`); a
+  lag of `STALL+1` epochs must cold-resume to `1×EPOCH`. Two unit tests
+  pinning the regime boundaries, guarding against the v2 cliff regression.
+- **NEW Gate 6 — HA failover/failback safety (§5):** `make test-failover`
+  passes (zero-drop) AND the §5.2 reused-lease unit test passes (second
+  acquire after a 2 s gap on a REUSED lease grants ≤ `rate × EPOCH`,
+  proving the §5.3 self-heal fires) AND no post-failback throughput spike
+  above shape on the newly-active node's first epoch.
+
+---
+
+## 8. Candidate mechanisms — tradeoff table
+
+All variants now **require** the §5.3 stale-`start` self-heal (HA) and
+the §3.5.1 aggregate burst cap, regardless of A-vs-B. Those are not
+optional; the table compares only the *credit-recovery core*.
+
+| # | Mechanism | Clears Gate 1 (each ≥95%)? | Burst-bounded? | Seqlock surface | HA surface | Complexity | Verdict (v2) |
+|---|-----------|---------------|----------------|-----------------|------------|------------|---------|
+| A | **Bounded `elapsed = min(lag, K×EPOCH)`** (§3.4) | **UNPROVEN at K=8** (probe 94.5/95.3/**84.9**/94.4 — three <95%). Possibly at larger K (§3.6) | YES per-class `≤ K×rate×EPOCH`; aggregate needs §3.5.1 | **NONE** (changes a value, not payload) | needs §5.3 self-heal (stale `start` on reused lease) | Lowest (+self-heal+agg-cap) | **Candidate; selected only if §3.6 shows it clears the gate** |
+| A+P2 | A + per-visit frame cap (§6) | likely, if residual is sub-frame discard (BLOCKING-1 branch b) — keeps K small | YES (small K) | NONE | §5.3 | Low | **Preferred if §3.6 confirms P2 is the residual lever** |
+| B | **Carry reservoir on `epoch_total_grant_cap`** (§3.2, DRR deficit) | recovers `lag > K×EPOCH` residual (heavy tail, BLOCKING-1 branch a) | YES — `MAX_CARRY_DRAW`/rotation + `MAX_CARRY_BYTES` reservoir | one rotation-private atomic, NOT in payload (enforced §4.0) | §5.3 must also `store(0)` carry on resume | Medium | **Required if §3.6 shows loss is the heavy lag tail and a gate-clearing K violates §3.5.1 aggregate cap** |
+| C | `last_rotation_ns` tracked separately | == A (`start` already IS last_rotation_ns; verified `:237`) | YES | NONE | §5.3 | Low | **Redundant with A** |
+| D | Per-worker carry | double-counts class-wide lag; needs per-worker published field → #1619 risk | — | adds reader-visible per-worker field | — | High | **REJECT** |
+
+**Mechanism selection is data-driven (v2):** v1's "A clears Gate 1, B
+optional" claim is RETRACTED — it was false on the cited probe data
+(three of four classes <95%, 3g 10 pts under). The §3.6 table decides:
+A+P2 if the residual is the sub-frame discard (keeps K small, best burst
+posture); B if the loss is the heavy lag tail AND the gate-clearing K
+would violate the §3.5.1 aggregate burst cap (then B's bounded drain
+spreads the tail recovery without a giant aggregate burst). Either way
+§5.3 + §3.5.1 are mandatory.
+
+**On D (the prompt's "per-worker vs per-lease" question):** the carry
+MUST be per-lease (class-wide). The lagged credit is a property of the
+*class* rate-meter (`epoch_total_grant_cap` is class-wide), not of any
+worker. A per-worker carry would (i) require a new per-worker published
+field → exactly the #1619 seqlock-tearing surface, and (ii)
+double-count, since N workers would each bank the same class-wide lag.
+The single rotation winner (one thread, holding the ODD seq) is the
+correct and only safe owner.
+
+---
+
+## 9. Choice of K (constrained by TWO gates, not one)
+
+`K` is bounded below by "large enough to recover the visit-lag tail to
+clear Gate 1" (§3.6) and above by "`K × EPOCH` of *aggregate* rate fits
+the §3.5.1 aggregate burst cap" — NOT, as v1 claimed, by the root
+shaper (which uses raw elapsed and does not throttle the aggregate
+burst, §3.5.1). The probe's K=8 reached only 94.5/95.3/84.9/94.4% (does
+not clear Gate 1), so K=8 is a *lower* bound at best. The §3.6 sweep
+`K ∈ {8, 16, 64}` finds the smallest K that clears Gate 1 on 100m AND
+3g; the §3.5.1 cap then bounds the aggregate burst at that K. **If the
+gate-clearing K makes `Σ rate_i × K × EPOCH` exceed `C_agg`, K cannot be
+raised further — mechanism B (bounded drain) is then required** to
+recover the tail without a giant aggregate one-tick burst. K is a named
+`const MAX_ROTATION_LAG_EPOCHS` doubling as the §5.3 cold-resume cutoff.
 
 ---
 
 ## 10. Risks & residuals
 
-- **R1 — §5 names no clear layer (all ratios ≈ 1.0 yet goodput < shape).**
-  Then the residual is genuinely H-TCP/delivery-physics (§6.4) and the
-  honest disposition is a smoothing attempt or a charter-authorized
-  Gate-1 re-frame. Mitigation: this is an ANTICIPATED outcome, not a plan
-  failure — §6.4 is the documented exit. The plan's value is having
-  falsified every shaper-internal mechanism so the team does not chase
-  them again.
-- **R2 — the offered-load check (counter 0) is itself mismeasured.** If
-  the enqueue-site counter double-counts or misses re-ingest, the
-  "offered < rate" gate could falsely pass/fail. Mitigation: count at the
-  single ingest site (`ingest_cos_pending_tx`) and cross-check against
-  the host iperf3 send rate; the two must agree within framing overhead.
-- **R3 — scope: this plan does NOT fix the full 11-class simul.** In the
-  full mix 3g/6g ARE Phase-1-honored (§3.1), yet the issue's 11-class run
-  shows ~20% — that failure has additional causes (cross-class budget
-  competition, priority-low) in #1614's scope. **This plan targets only
-  the K/P2/contention-independent flat SOLO/4-class residual the engineer
-  isolated.** /engineer must not over-claim that cause-2 fixes #1630's
-  headline 11-class numbers. (Avoids the cause-1 "neither fork"
-  over-scope trap.)
-- **R4 — the residual may be unfixable (physics floor).** If §5 shows the
-  shaper sends full shape and the loss is TCP pacing on bursty AF_XDP
-  delivery that smoothing cannot recover, cause-2 is a ~6% rate-accuracy
-  floor for single-flow-bundle mid-rate classes, and Gate-1-at-95% may
-  not be achievable for 3g/6g solo. This is an honest possible PLAN-KILL
-  of the FIX (not of the research) — the measurement still has value.
-- **R5 — cause-1's reduced scope.** Cause-1's plan claimed Gate 1; with
-  cause 2 split out, cause-1 only owns 100m/1g. /engineer MUST re-scope
-  the cause-1 plan's Gate-1 claim AND (per §11-Q5) gate or scope-note any
-  cause-1+#1643-only PR so #1630 does not falsely appear fixed while
-  3g/6g stay <95%. Documented §9.
-- **R6 — H5 (fair-share) only for multi-worker.** For truly-solo
-  single-port (total_flows=1) there is no fair-share rounding, so H5
-  cannot be the truly-solo residual; it is a candidate only if §5 shows
-  the solo streams land across multiple workers. §5 counter 7 + worker
-  count settles it.
-- **R7 — H-TCP: the residual may be OUTSIDE the shaper.** If §5's
-  `goodput/drain_sent < 1` while the shaper grants and sends full shape,
-  cause 2 is TCP's response to bursty 50µs-quantized delivery, not a
-  shaper defect. Then §6.4 applies: smooth delivery (may recover it) OR
-  re-frame Gate 1 (charter-authorized PLAN-KILL exit). The combined PR
-  may NOT clear Gate 1 at 95% if this is the physics floor — this is the
-  honest worst case, matching the cause-1 §12 "neither fork" precedent.
+- **R1 — K too small under heavier class counts.** With 11+ classes the
+  per-queue visit lag may exceed 8 epochs, so K=8 under-recovers in the
+  full simul. Mitigation: Gate 1b (full simul) is a gate; if it fails,
+  raise K or add mechanism B's residual-banking. Measured at /engineer.
+- **R2 — root shaper does NOT re-bound the aggregate burst (v2
+  CORRECTED).** v1 wrongly claimed the root throttles the aggregate. The
+  root lease refills on **raw elapsed** (`mod.rs:853`), so after a stall
+  it refills its full stalled credit too; its default burst is 1% of
+  rate (`forwarding_build/cos.rs:66`, ~31 MB at 25 G) which is *larger*
+  than the ~21.8 MB aggregate class burst — so the root does not gate it.
+  The §3.5.1 global per-tick carry-release cap is the actual backstop.
+  Gate 5c is the hard test.
+- **R3 — interaction with the bypass-grace / surplus path.** The carry
+  enlarges `cap`; the surplus path and bypass detector read `cap` and
+  `class_granted`. Larger `cap` means `aggregate_underuse =
+  prev_granted + slack < prev_cap` fires differently. Must re-run the
+  iperf-c/iperf-e regimes (the bypass calibration cases) to confirm no
+  fairness regression. Owed at /engineer.
+- **R4 — `u32::MAX` cap saturation.** `new_cap.min(u32::MAX)` still
+  applies; for 24g, `8 × 3e9 × 2e-4 = 4.8e6 < u32::MAX`. Safe. But the
+  carry-reservoir variant must also clip its intermediate sums at
+  u32/u64 boundaries (`saturating_add`). Noted in §3.2.
+- **R5 — P2 dependency unproven.** §6 asserts P2 is load-bearing from
+  the engineer's reasoning, not from an A/B. §3.6 measures it directly
+  (`K=8 + P2` row) before /engineer declares P2 required.
+- **R6 — 3g=84.9% may be a mis-attributed root cause (Codex F1 / Claude
+  BLOCKING-2).** If §3.6's `K=64` does not lift 3g to ≥95% SOLO, the 3g
+  loss is NOT the rotation clamp and the root cause for that class is
+  re-opened. The plan does not assume 3g is fixed by this work until the
+  §3.6 table shows it.
+- **R7 — STALL_THRESHOLD tuning (v3 — decoupled from K).** §5.3.1 sizes
+  `STALL` between the §3.6 legitimate-tail p99 and the ≥500-epoch
+  failback gap. Measured at /engineer; if (very unlikely) the tail p99
+  and a failback gap overlap, switch the regime-3 trigger from the
+  lag-magnitude heuristic to the explicit §5.3.2 `ResetCoSEpochs` command
+  (fully designed). No longer the K-cutoff cliff of v2.
+- **R8 — shared root-budget ordering starvation (Claude r3 MINOR-1).**
+  `carry_release_budget` (§3.5.1) is drawn FCFS; a high-rate class could
+  drain it before a low-rate Gate-1-victim class releases its carry,
+  re-introducing small-class starvation through the burst cap. By design
+  the cap fires only on the pathological all-stall path, so steady-state
+  carry release should not hit it. Confirm via Gate 1b that the cap does
+  not starve small classes in steady state (it must bound only the
+  stall-resume transient). If it does, reserve a per-class minimum slice.
+- **R9 — root-vs-queue epoch skew (Claude r3 MINOR-2).** The budget
+  refills on the root epoch; carry is owed on the queue epoch
+  (independent timelines, both ~200µs). /engineer must confirm the root
+  refill fires at least as often as queue carry-release so the budget is
+  replenished; otherwise a slow root refill throttles legitimate carry.
 
 ---
 
-## 11. 5+ hostile open questions (for the reviewers to attack)
+## 11. Plan of action (for /engineer, NOT this round)
 
-1. **If no shaper mechanism explains it, is the residual even a SHAPER
-   bug?** Three derived mechanisms are falsified (§3). The strongest
-   remaining candidate is H-TCP (the bytes leave the NIC at rate; TCP
-   loses goodput to bursty delivery). **Should this issue be re-scoped
-   from "fix the shaper" to "characterize the AF_XDP delivery-burstiness
-   / TCP-pacing floor"? Is §5's `goodput/drain_sent` (L2-normalized)
-   actually measurable accurately enough to settle this on iperf3?**
-2. **Could the residual be a measurement artifact of the §3.6 harness
-   itself?** The solo numbers (3g 89→94, 6g 89→93) came from a throwaway
-   K/P2 probe build. **Is there ANY chance the ~6% is TCP slow-start /
-   `-O` omission / the 30s window / RSS landing the single port's 12
-   streams across workers — i.e. not a steady-state shaper property at
-   all?** §5 must run long-window steady-state and report the worker
-   landing of the solo streams BEFORE concluding a shaper cause.
-3. **Does the §5 instrumentation perturb the very thing it measures?**
-   Env-gated `fetch_add` counters on the hot drain path add atomics. **At
-   25G line rate, could the instrumentation cost itself depress 3g/6g by
-   a few %, masking or faking the residual?** The build must be A/B'd
-   (instrumented vs not) to confirm the counters are free, or use
-   thread-local non-atomic accumulators flushed at 1s.
-4. **Is the four-ratio bisection truly exhaustive?** It covers
-   meter-under-grant / grant-not-drawn / drawn-not-sent / TCP. **Is there
-   a FIFTH layer — e.g. the ingress/RX side limiting how fast the class's
-   packets even ARRIVE to be shaped, so the shaper is never offered a
-   full rate's worth?** For a push test the firewall forwards; if RX or
-   the conntrack/forward path caps a single flow-bundle, the shaper sees
-   less than `rate` of offered load and the residual is upstream. §5 must
-   confirm offered load ≥ shape at the queue ingress.
-4b. **(restated for emphasis)** The plan asserts the classes are
-   "bucket-bound" (offered > rate). **Has anyone VERIFIED the offered
-   load actually exceeds the shape for solo 3g/6g, or is the class
-   RX/CPU-bound below its rate?** If offered < rate, there is no shaper
-   residual to fix.
-5. **Is shipping cause-1 + #1643 WITHOUT cause-2 the right move?** §9 says
-   cause-1+#1643 can ship now. **But cause-1's plan claimed Gate 1; if it
-   ships fixing only 100m/1g while 3g/6g stay <95%, does the combined PR
-   FALSELY appear to fix #1630? Should cause-1 be held until §5 resolves
-   cause-2, or shipped with an explicit "100m/1g only" scope note?** The
-   sequencing has a contract-honesty risk.
-6. **Has the team over-fit to "flat fractional" (P4)?** The measured
-   spread (3g 93.8, 6g 92.8 solo) is NOT identical — 6g is ~1pp lower.
-   **Is the "flat" framing hiding a weak rate-dependence that would point
-   at a DIFFERENT cause (e.g. a per-frame fixed overhead that matters
-   more at higher pps)?** §5 should report the residual at 3g AND 6g AND
-   9g to see if it is truly flat or slowly rate-varying.
+0. **FIRST: run the §3.6 discriminating measurement** (`K∈{8,64} ×
+   {±P2}` SOLO on 100m AND 3g). This selects the mechanism (§3.4
+   decision rule). Do NOT commit a mechanism before this table is filled.
+1. Implement the credit-recovery core selected by step 0: bounded
+   `elapsed = min(lag, K×EPOCH)` (A) in `rotate_epoch_v8.rs` STEP 6, with
+   K from the sweep; add carry reservoir (B) only if step 0 + §3.5.1
+   require it.
+2. **Mandatory regardless of A/B: the §5.3 THREE-regime rotation**
+   (normal recovery ≤K / bank-residual K<lag≤STALL / cold-resume >STALL),
+   with `STALL_THRESHOLD_EPOCHS` decoupled from K and sized per §5.3.1.
+   This is the HA fix + the cliff fix; NOT optional. Add the §5.3.2
+   `ResetCoSEpochs` command on the `ha.rs` demote+promote path as
+   belt-and-suspenders (and as the primary regime-3 trigger if §3.6 shows
+   the tail/failback bounds overlap).
+3. **Mandatory regardless of A/B: the §3.5.1 GLOBAL aggregate per-root-
+   epoch carry-release budget** — a single shared `carry_release_budget`
+   atomic on `SharedCoSRootLease` (NOT thread-local), refilled once per
+   root epoch, drawn by all workers via CAS. Prevents the `N × C_agg`
+   simultaneous-resume burst.
+4. **Fold in #1643** — fix `snapshot_epoch_v8` to the §4.0 fenced
+   pattern; downgrade payload stores to `Relaxed`. PR `Closes #1643`.
+5. Fold in **P2** (per-visit frame cap) from `b29fdb344` by default;
+   drop P1 watermark unless §3.6 shows it helps.
+6. Tests: Gate 5 (single-class burst), **Gate 5c (aggregate burst,
+   N>1 workers)**, **Gate 5d (regime boundaries — no cliff at K+1,
+   cold-resume at STALL+1)**, Gate 5b (#1643 fence + carry-private
+   guard), **Gate 6 reused-lease failback unit test** (§5.2
+   counter-example → regime-3 asserts ≤ `rate×EPOCH`).
+7. Build, full `cargo test`, deploy to `loss:xpf-userspace-fw0/1`,
+   re-apply CoS config (deploy wipes CoS).
+8. Full smoke matrix: Gate 1 (SOLO each ≥95%), Gate 1b (simul), Gates
+   2/3/4, Gate 5c (aggregate burst), Gate 6 (`make test-failover` +
+   failback no-spike). v4+v6 × push+`-R` × CoS-off+CoS-on.
+9. Quad-review (Codex + AGY + Claude SMR + Copilot on the PR).
 
 ---
 
-## Appendix — verified source anchors (origin/master `0e5bb3812`)
+## 12. Convergence (after r3) — PLAN-NEEDS-MAJOR + the fork
 
-- Timer wheel tick: `cos/tx_completion.rs:104 COS_TIMER_WHEEL_TICK_NS = 50_000`;
-  `cos_tick_for_ns = ns/TICK` (`:112`); advance (`:214`,`:314`);
-  service-eligibility `next_wakeup_tick <= now_tick`
-  (`cos_root_can_service_after_prime`, `:288-293`).
-- Wake-tick floor: `queue_service/mod.rs:1288`
-  `cos_tick_for_ns(wake_ns).max(cos_tick_for_ns(now).saturating_add(1))`.
-- Refill ns: `cos/token_bucket.rs:284 cos_refill_ns_until` (`div_ceil`).
-- Per-visit quantum: `cos_guarantee_quantum_bytes`
-  (`queue_service/mod.rs:1246`); `COS_GUARANTEE_VISIT_NS = 200_000`,
-  `QUANTUM_MIN = 1500`, `QUANTUM_MAX = 512K` (`tx/drain/mod.rs:561-563`).
-- **WATERFILL dispatch (the `guarantee-rate` path):**
-  `queue_service/mod.rs:603-614` (`if GuaranteeRate && fraction > 0 {
-  return select_exact_cos_guarantee_queue_waterfill(...) }`).
-- **Waterfill selector:** `select_exact_cos_guarantee_queue_waterfill`
-  `queue_service/mod.rs:771`; Phase-1 budget `floor(quantum_sum ×
-  fraction)` `:787-799`; Phase-1 honor/return `:889` (budget-exhausted
-  break), `:907` (honor return); **Phase 2 NON-PARKING** `:973-977`
-  ("Don't park in Phase 2 … not a guarantee"); epoch reset `:1002-1006`.
-- **Waterfill state (per-binding, single-worker, NON-atomic):**
-  `CoSInterfaceRuntime.waterfill_pass1_remaining_bytes`,
-  `waterfill_phase2_cursor`, `exact_queues_by_rate_ascending`,
-  `oversubscription_policy`, `oversubscription_guarantee_fraction`
-  (`types/cos.rs:369,378-406`) — confirmed NOT `Atomic`, NOT shared, NOT
-  in the seqlock payload.
-- **oversubscription detection machinery (if a waterfill-side fix is ever
-  revisited):** `exact_backlog_guarantee_rate_bytes_for_mask`
-  `cos/tx_completion.rs:400`.
-- Per-visit quantum: `cos_guarantee_quantum_bytes`
-  (`queue_service/mod.rs:1246`); `COS_GUARANTEE_VISIT_NS = 200_000`,
-  `QUANTUM_MIN = 1500`, `QUANTUM_MAX = 512K` (`tx/drain/mod.rs:561-563`).
-- Wake estimator arg: `estimate_cos_queue_wakeup_tick(... queue_rate,
-  head_len, now, require_queue_tokens)` — `head_len` is the **5th**
-  positional arg (`need_bytes`), signature `:1255-1263` (r2 correction).
-- **TX-sent counter for the §5 bisection:** `owner_profile.drain_sent_bytes`
-  / `drain_guarantee_sent_bytes`, written post-submit at
-  `cos/tx_completion.rs:482-489`; `lease.consume(sent_bytes)` `:540-549`;
-  token decrement on send `tx_completion.rs:512` (AGY r2 #3 contamination).
-- Timer wheel (Phase-1 parks only): `cos/tx_completion.rs:104
-  COS_TIMER_WHEEL_TICK_NS = 50_000`; wake floor `queue_service/mod.rs:1288`.
-- Bucket top-up + early-return: `cos/token_bucket.rs:154,184`.
-- Lease target: `compute_shared_cos_lease_config` `mod.rs:694`
-  (`COS_ROOT_LEASE_TARGET_US = 200`, `mod.rs:690`); `lease_bytes`
-  `mod.rs:977`.
-- Default buffer: `forwarding_build/cos.rs:73 default_cos_burst_bytes
-  = max(rate/100, 64×1500)`.
-- Grant meter (clamp + cap publish): `rotate_epoch_v8.rs:204-239`;
-  `EPOCH_DURATION_NS = 200_000` (`mod.rs:241`).
-- Grace gate (exact never enters surplus): `acquire_v8` surplus path
-  `mod.rs:1186-1242`; exact-skip `queue_service/mod.rs:837`.
-- Park telemetry fields: `types/cos.rs:914,920 drain_park_{root,queue}_tokens`.
-- Poll-loop `now_ns` sample: `worker/loop_body/mod.rs:249`.
-- Drain entry/budget: `tx/drain.rs:109,156` (`REINGEST_BUDGET=4`).
+Three review rounds uncovered escalating design depth. v3 fixed the
+literal r2 bugs but Codex r3 (+ Claude SMR r3-corrected; AGY r3 result
+infra-blocked, investigation aligned) found three new blockers. The
+decisive one is **Codex r3 BLOCKING-3**: the global aggregate-burst cap
+(§3.5.1, mandated to fix Codex/AGY r2's `N×C_agg` flaw) and the
+small-class-first guarantee (Gate 1, the whole point) **structurally
+conflict**. A global cap allocated FCFS lets high-rate classes drain it
+and re-starve the low-rate class — re-introducing #1614 — while Gate 5c
+still passes (total ≤ C_agg). Eliminating that requires a *global
+small-class-first allocator across AF_XDP queue-bound workers*, a class
+of mechanism this codebase has repeatedly PLAN-KILLED (MEMORY:
+per-5-tuple fairness — AF_XDP ZC queue-binding makes cross-worker
+small-class-first allocation infeasible without per-flow XDP_REDIRECT).
+
+Plus: regime-2 has no defined draw rule for the single-visit low-rate
+case (BLOCKING-1, contradicts §3.3's own conclusion); `ResetCoSEpochs`
+doesn't retag `packed_granted`/`worker_grants` so stale acquirers can
+grant post-reset, and loses the EVEN→ODD CAS race (BLOCKING-5).
+
+### The fork — what /research must resolve BEFORE the next plan revision
+
+The §3.5.1 aggregate cap is ONLY needed if the gate-clearing `K` is large
+enough that `Σ rate_i × K × EPOCH` exceeds the root/NIC burst. **This
+makes the §3.6 measurement the pivot:**
+
+- **FORK A — small-K + P2 clears Gate 1 (the hoped-for branch).** If
+  §3.6 shows `K=8 + P2` (or even `K=8` alone) reaches ≥95% SOLO on 100m
+  AND 3g, then K is small, the per-class burst is ≤8 epochs, and the
+  *aggregate* burst at small K is `8 × 25G × EPOCH / 8 = 25G × EPOCH` —
+  one root epoch's worth, which the existing root meter DOES absorb. In
+  this branch **the §3.5.1 global cap is unnecessary**, BLOCKING-3
+  dissolves, mechanism B is not needed, and the fix collapses to:
+  bounded `elapsed = min(lag, K×EPOCH)` (small K) + P2 + the §5.3
+  cold-resume (regime 3 only, no regime-2 banking) + #1643 + the
+  retag-correct ResetCoSEpochs. That is a tractable, gate-clearing,
+  burst-safe, HA-safe fix. **This is the most likely successful path and
+  the §3.6 measurement is cheap to run.**
+- **FORK B — only large K (heavy tail) clears Gate 1.** If §3.6 shows
+  100m needs `K=64` and 3g still lags, then the aggregate burst is large,
+  the §3.5.1 cap is required, and BLOCKING-3's small-class-first-allocator
+  conflict is real → this approach is **architecturally blocked** by the
+  same constraint that killed the per-5-tuple fairness mechanisms.
+  Mechanism B's banking does not escape it (the banked credit still
+  competes for the same global burst budget). In Fork B, the honest
+  disposition is PLAN-KILL-of-bounded-carry and a pivot to either (i)
+  shrinking `EPOCH_DURATION_NS` so the clamp loss is smaller per
+  rotation (orthogonal, no carry), or (ii) a forced periodic rotation
+  (a timer that rotates every epoch regardless of visits, eliminating
+  the lag entirely — but that adds a cross-worker timer, its own design
+  problem), or (iii) reframing Gate 1 (Path D, charter-unauthorized).
+
+### Recommended next action
+
+**Run the §3.6 SOLO A/B FIRST (throwaway local build, ~30 min on the free
+loss cluster) to determine the fork before investing another plan round.**
+The entire design complexity (regime-2 banking, global burst cap,
+small-class-first allocator) exists ONLY for Fork B. If Fork A holds —
+and the engineer's original probe (K=8 → 94.5% on 100m, close to gate)
+plus P2's known sub-frame fix suggest it plausibly does — the fix is
+simple and the r3 blockers (BLOCKING-1/3) evaporate. This is the
+disciplined move: measure the pivot before designing for the harder
+branch. Verdict stands at PLAN-NEEDS-MAJOR pending that measurement;
+this is NOT yet PLAN-KILL because Fork A is live and untested.
+
+---
+
+## Appendix — verified source anchors (origin/master `dbfbf680c`)
+
+- Clamp: `rotate_epoch_v8.rs:214-218` (`elapsed_ns = (now-start).min(EPOCH)`).
+- Cap publish: `rotate_epoch_v8.rs:224`; `start` reset to `now`: `:237`;
+  seq ODD→EVEN publish: `:239`.
+- `EPOCH_DURATION_NS = 200_000`: `shared_cos_lease/mod.rs:241`.
+- Rotation trigger (lazy, sole call site): `mod.rs:1042` in `acquire_v8`.
+- Seqlock reader: `snapshot_epoch_v8` `mod.rs:1427-1455` (reads
+  cap/share/grace/tag only — carry deliberately excluded).
+- Lease constructor (epoch state at 0): `new_v8_with_rate_mode`
+  `mod.rs:923`, `SharedCoSEpochState::new()` `mod.rs:309-321`.
+- Lease map: `coordinator/cos_state.rs:8,24` (ArcSwap),
+  `reconcile/bringup.rs:210` (re-store).
+- **Lease REUSE on config match (Codex F4, decisive):**
+  `coordinator/mod.rs:1106-1116` `matches_config_v8` →
+  `out.insert(key, lease.clone())` (SAME Arc survives).
+- **HA demote vacates V_min only, NOT epoch:** `ha.rs:48-55`
+  (`DemoteOwnerRGS` + `VacateAllSharedExactSlots`); `ha.rs:119`
+  (`RefreshOwnerRGS` on promote); `worker/cos/mod.rs:305`
+  (`vacate_all_shared_exact_slots_for_binding` — V_min slots only).
+- Worker re-attach (ptr_eq): `cos/token_bucket.rs:135`
+  `ensure_v8_lease_attached`.
+- Consumption: `cos/token_bucket.rs:93-110` `acquire_via_lease` →
+  `acquire_v8`; top-up `:154 maybe_top_up_cos_queue_lease`.
+- **Root lease raw-elapsed refill (no epoch clamp, §3.5.1):**
+  `shared_cos_lease/mod.rs:853` `elapsed_ns = now_ns - last_refill_ns`.
+- **Root burst floor 1% (§3.5.1):** `forwarding_build/cos.rs:66`.

--- a/docs/pr/1630-cause1-credit-carry/reviewer-ids.md
+++ b/docs/pr/1630-cause1-credit-carry/reviewer-ids.md
@@ -4,11 +4,14 @@ Branch: `fix/1630-cause1-credit-carry` (off origin/master)
 PR: #1650
 Head SHA: 3662ecbde
 
-4-way code review seats:
-- **Claude SMR**: `docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md`
-- **Codex**: (task-id filled after dispatch)
-- **AGY**: (task-id filled after dispatch)
-- **Copilot**: formal `@copilot review` on the PR (poll for the review)
+4-way code review seats (all addressed):
+- **Claude SMR**: `docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md` — MERGE-READY
+- **Codex**: direct companion task (fresh, session a8c1b014). 1 Major + 1 Medium (floored-boundary), both FIXED in 4a2b998f7.
+- **AGY**: `review-mpqel5m5-2skf6n` — MERGE-READY across 6 axes, no findings.
+- **Copilot**: formal `copilot-pull-request-reviewer` review on PR #1650 — same boundary Major (fixed) + plan.md doc nit (fixed 7e6f7115f).
+
+Cluster validation: scoped Gate-1 SOLO v4 100m 95.0% / 1g 95.3% PASS;
+`make test-failover` 13/0. cause-2 resolved-as-physics → `Closes #1630`.
 
 Merge gate: 4-of-4 MERGE-READY + scoped Gate-1 (100m/1g ≥95% SOLO) +
 full smoke matrix + `make test-failover`. 3-of-4 allowed only with a

--- a/docs/pr/1630-cause1-credit-carry/reviewer-ids.md
+++ b/docs/pr/1630-cause1-credit-carry/reviewer-ids.md
@@ -1,0 +1,15 @@
+# #1630 cause-1 credit carry — reviewer task IDs
+
+Branch: `fix/1630-cause1-credit-carry` (off origin/master)
+PR: (filled after `gh pr create`)
+
+4-way code review seats:
+- **Claude SMR**: `docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md`
+- **Codex**: (task-id filled after dispatch)
+- **AGY**: (task-id filled after dispatch)
+- **Copilot**: formal `@copilot review` on the PR (poll for the review)
+
+Merge gate: 4-of-4 MERGE-READY + scoped Gate-1 (100m/1g ≥95% SOLO) +
+full smoke matrix + `make test-failover`. 3-of-4 allowed only with a
+documented Codex/Copilot-infra-blocked exception
+(feedback_codex_infra_must_retry).

--- a/docs/pr/1630-cause1-credit-carry/reviewer-ids.md
+++ b/docs/pr/1630-cause1-credit-carry/reviewer-ids.md
@@ -1,7 +1,8 @@
 # #1630 cause-1 credit carry — reviewer task IDs
 
 Branch: `fix/1630-cause1-credit-carry` (off origin/master)
-PR: (filled after `gh pr create`)
+PR: #1650
+Head SHA: 3662ecbde
 
 4-way code review seats:
 - **Claude SMR**: `docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md`

--- a/docs/pr/1630-cause1-credit-carry/reviewer-ids.md
+++ b/docs/pr/1630-cause1-credit-carry/reviewer-ids.md
@@ -2,13 +2,14 @@
 
 Branch: `fix/1630-cause1-credit-carry` (off origin/master)
 PR: #1650
-Head SHA: 3662ecbde
+Head SHA: f9563b9a8 (code frozen at 7e6f7115f; post-Copilot delta is docs-only)
 
-4-way code review seats (all addressed):
+4-way code review seats — CLEAN 4-of-4 at HEAD f9563b9a8:
 - **Claude SMR**: `docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md` — MERGE-READY
-- **Codex**: direct companion task (fresh, session a8c1b014). 1 Major + 1 Medium (floored-boundary), both FIXED in 4a2b998f7.
+- **Codex r1**: direct companion task (fresh, session a8c1b014) — 1 Major + 1 Medium (floored-boundary), both FIXED in 4a2b998f7.
+- **Codex r2 RE-CONFIRM**: fresh thread `019e7204-d7b4-7d93-8c9d-d22f73d15da8`, checked out HEAD f9563b9a8 directly — **MERGE-READY**. Verified with quoted lines: (a) the boundary MAJOR is resolved by the exact-ns thresholds (`(K+1)*EPOCH-1ns > K*EPOCH` → regime 2, not a near-(K+1) regime-1 grant); (b) the `(2K-1)*rate*EPOCH` per-rotation bound holds at BOTH the `(K+1)*EPOCH-1ns` and `STALL*EPOCH+1ns` boundaries and for ANY repeated regime-2-bank → regime-1-drain sequence (carry clamped at carry_max via `.min(carry_max)`, drain ≤ K-1 epochs); (c) the worst-case ceiling test exercises the tight maximum (fill to CARRY_MAX, rotate at exactly K*EPOCH = regime 1, assert exactly K+(K-1) epochs). No remaining counter-example.
 - **AGY**: `review-mpqel5m5-2skf6n` — MERGE-READY across 6 axes, no findings.
-- **Copilot**: formal `copilot-pull-request-reviewer` review on PR #1650 — same boundary Major (fixed) + plan.md doc nit (fixed 7e6f7115f).
+- **Copilot**: formal `copilot-pull-request-reviewer` review on PR #1650 — same boundary Major (fixed 4a2b998f7) + plan.md doc nit (fixed 7e6f7115f).
 
 Cluster validation: scoped Gate-1 SOLO v4 100m 95.0% / 1g 95.3% PASS;
 `make test-failover` 13/0. cause-2 resolved-as-physics → `Closes #1630`.

--- a/test/incus/cos-gate1-small-four-alone.sh
+++ b/test/incus/cos-gate1-small-four-alone.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# #1630 Gate 1 — small-four-alone CoS A/B. Runs ONLY the 100m/1g/3g/6g
+# exact classes (ports 5201-5204) in parallel, 12 streams each, with NO
+# large-class competition and the whole cluster available. Each must
+# reach >= 95% of its configured shape.
+#
+# Usage:
+#   ./test/incus/cos-gate1-small-four-alone.sh [push|reverse] [v4|v6]
+#
+# Expects the loss userspace cluster deployed + cos-iperf-config.set
+# applied (includes oversubscription-policy guarantee-rate 0.7).
+set -euo pipefail
+
+DIRECTION="${1:-push}"
+AF="${2:-v4}"
+DURATION="${DURATION:-20}"
+STREAMS="${STREAMS:-12}"
+TARGET_V4="${TARGET_V4:-172.16.80.200}"
+TARGET_V6="${TARGET_V6:-2001:559:8585:80::200}"
+HOST="${HOST:-loss:cluster-userspace-host}"
+ART="${ART:-/tmp/cos-gate1-$(date +%s)}"
+
+TARGET="$TARGET_V4"
+[ "$AF" = "v6" ] && TARGET="$TARGET_V6"
+
+declare -a PORTS=(5201 5202 5203 5204)
+REV_FLAG=""
+[ "$DIRECTION" = "reverse" ] && REV_FLAG="-R"
+
+mkdir -p "$ART"
+echo "#1630 Gate1 small-four-alone: dir=$DIRECTION af=$AF target=$TARGET dur=${DURATION}s streams=$STREAMS art=$ART"
+
+declare -a PIDS=()
+for port in "${PORTS[@]}"; do
+  (
+    sg incus-admin -c "incus exec $HOST -- iperf3 -c $TARGET -P $STREAMS -t $DURATION -p $port $REV_FLAG --json" \
+      > "$ART/g1_${port}.json" 2>"$ART/g1_${port}.err" || true
+  ) &
+  PIDS+=($!)
+done
+for pid in "${PIDS[@]}"; do wait "$pid"; done
+
+python3 - "$ART" "$DIRECTION" "$AF" <<'PYEOF'
+import json, os, sys
+art, direction, af = sys.argv[1], sys.argv[2], sys.argv[3]
+ports = [5201, 5202, 5203, 5204]
+names = {5201: "iperf-100m", 5202: "iperf-1g", 5203: "iperf-3g", 5204: "iperf-6g"}
+shape = {5201: 0.1, 5202: 1.0, 5203: 3.0, 5204: 6.0}
+rows = []
+all_pass = True
+for p in ports:
+    f = os.path.join(art, f"g1_{p}.json")
+    try:
+        d = json.load(open(f))
+    except Exception as e:
+        rows.append((p, names[p], shape[p], None, None, f"ERR {e}"))
+        all_pass = False
+        continue
+    sr = d.get("end", {}).get("sum_received") or {}
+    ss = d.get("end", {}).get("sum_sent") or {}
+    recv = (sr.get("bits_per_second") or ss.get("bits_per_second") or 0) / 1e9
+    pct = recv / shape[p] * 100
+    ok = pct >= 95.0
+    all_pass = all_pass and ok
+    rows.append((p, names[p], shape[p], round(recv, 3), round(pct, 1), "PASS" if ok else "FAIL"))
+print(f"\n#1630 Gate1 ({direction}/{af})")
+print(f"{'port':<6}{'class':<14}{'shape':>7}{'recv_G':>8}{'%shape':>8}  verdict")
+for p, n, sh, recv, pct, v in rows:
+    if recv is None:
+        print(f"{p:<6}{n:<14}{sh:>6.2f}G {v}")
+    else:
+        print(f"{p:<6}{n:<14}{sh:>6.2f}G {recv:>7.2f}G {pct:>7.1f}%  {v}")
+print(f"\nGATE1 {'PASS' if all_pass else 'FAIL'} (all four >= 95% of shape)")
+PYEOF

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -548,10 +548,12 @@ pub(in crate::afxdp) fn select_cos_guarantee_batch_with_fast_path(
             continue;
         }
         root.legacy_guarantee_rr = (start + offset + 1) % queue_count;
+        // #1630 (P2): per-visit FRAME-count cap, not the rate-scaled
+        // quantum (which discarded the sub-frame remainder each visit).
         let guarantee_budget = queue
             .hot
             .tokens
-            .min(cos_guarantee_quantum_bytes(queue))
+            .min(cos_guarantee_visit_cap_bytes())
             .max(head_len);
         if let Some(batch) = build_cos_batch_from_queue(
             queue,
@@ -719,10 +721,14 @@ fn select_exact_cos_guarantee_queue_with_lease_telemetry(
             continue;
         }
         root.exact_guarantee_rr = (start + offset + 1) % queue_count;
+        // #1630 (P2): per-visit FRAME-count cap, not the rate-scaled
+        // quantum. Combined with #1630 (P1)'s N-frame token bank, a
+        // low-rate exact class can now drain its banked frames whole
+        // instead of losing the sub-frame remainder each visit.
         let secondary_budget = queue
             .hot
             .tokens
-            .min(cos_guarantee_quantum_bytes(queue))
+            .min(cos_guarantee_visit_cap_bytes())
             .max(head_len);
         let kind = match head {
             CoSPendingTxItem::Local(_) => ExactCoSQueueKind::Local,
@@ -873,20 +879,31 @@ fn select_exact_cos_guarantee_queue_waterfill(
             }
             continue;
         }
-        // Picked. Compute the per-visit secondary_budget first so
-        // we can apply Phase 1 budget gating before committing the
-        // selection.
-        let candidate_budget = queue
+        // Picked. #1630 (P2): decouple the two roles the quantum used
+        // to play. The Phase-1 budget gate / consumption stays on the
+        // RATE-SCALED quantum (`phase1_cost`) so the small-first
+        // ordering and the `quantum_sum × fraction` Phase-1 budget
+        // remain consistent with `oversubscription_guarantee_fraction`.
+        // The actual per-visit send budget (`send_budget`) is the
+        // FRAME-count cap so a queue whose token bucket has banked
+        // several frames (#1630 P1) drains them whole instead of
+        // discarding the sub-frame remainder of the small quantum.
+        let phase1_cost = queue
             .hot
             .tokens
             .min(cos_guarantee_quantum_bytes(queue))
             .max(head_len);
-        // Phase 1 gate: if budget for this queue exceeds the
-        // remaining Phase 1 byte budget, this queue is past the
+        let send_budget = queue
+            .hot
+            .tokens
+            .min(cos_guarantee_visit_cap_bytes())
+            .max(head_len);
+        // Phase 1 gate: if the rate-scaled cost for this queue exceeds
+        // the remaining Phase 1 byte budget, this queue is past the
         // Phase 1 boundary. Mark all queues up to this point as
         // honored (they're the small classes that fit), break to
         // Phase 2 descending walk.
-        if candidate_budget > root.waterfill_pass1_remaining_bytes {
+        if phase1_cost > root.waterfill_pass1_remaining_bytes {
             // Budget exhausted before this ascending queue could
             // be honored. Fall through to Phase 2 (descending
             // walk over queues NOT in honored_mask).
@@ -895,7 +912,7 @@ fn select_exact_cos_guarantee_queue_waterfill(
         // Phase 1 honor: consume the budget, mark honored, return.
         root.waterfill_pass1_remaining_bytes = root
             .waterfill_pass1_remaining_bytes
-            .saturating_sub(candidate_budget);
+            .saturating_sub(phase1_cost);
         if queue_idx < 64 {
             honored_mask |= 1u64 << queue_idx;
         }
@@ -906,7 +923,7 @@ fn select_exact_cos_guarantee_queue_waterfill(
         };
         return Some(ExactCoSQueueSelection {
             queue_idx,
-            secondary_budget: candidate_budget,
+            secondary_budget: send_budget,
             kind,
         });
     }
@@ -981,11 +998,13 @@ fn select_exact_cos_guarantee_queue_waterfill(
             }
             continue;
         }
-        // Phase 2 selection: return and advance cursor.
+        // Phase 2 selection: return and advance cursor. #1630 (P2):
+        // per-visit FRAME-count cap (Phase 2 has no Phase-1 budget
+        // accounting, so there is no rate-scaled cost to preserve here).
         let candidate_budget = queue
             .hot
             .tokens
-            .min(cos_guarantee_quantum_bytes(queue))
+            .min(cos_guarantee_visit_cap_bytes())
             .max(head_len);
         root.waterfill_phase2_cursor = (phase2_idx + 1) % sorted_indices.len();
         root.exact_guarantee_rr = (queue_idx + 1) % queue_count;
@@ -1061,10 +1080,14 @@ pub(in crate::afxdp) fn select_nonexact_cos_guarantee_batch(
             continue;
         }
         root.nonexact_guarantee_rr = (start + offset + 1) % queue_count;
+        // #1630 (P2): per-visit FRAME-count cap. The non-exact guarantee
+        // bucket already accumulates to `buffer_bytes` (refill_cos_tokens),
+        // so it needs only this P2 half — the quantum clamp was its sole
+        // sub-frame-discard cause.
         let guarantee_budget = queue
             .hot
             .tokens
-            .min(cos_guarantee_quantum_bytes(queue))
+            .min(cos_guarantee_visit_cap_bytes())
             .max(head_len);
         if let Some(batch) = build_cos_batch_from_queue(
             queue,
@@ -1538,6 +1561,32 @@ pub(in crate::afxdp) fn cos_guarantee_quantum_bytes(queue: &CoSQueueRuntime) -> 
         COS_GUARANTEE_QUANTUM_MIN_BYTES,
         COS_GUARANTEE_QUANTUM_MAX_BYTES,
     )
+}
+
+/// #1630 (P2): per-VISIT send budget cap for guarantee-phase service.
+///
+/// The selectors previously clamped each visit's `secondary_budget` to
+/// `cos_guarantee_quantum_bytes` (= `rate × 200 µs`). For a low-rate
+/// class that quantum (e.g. 2500 B for 100 Mbps) is below two MTUs, so
+/// the drain sent one frame and DISCARDED the sub-frame remainder every
+/// visit — a per-visit efficiency ceiling that rose with the configured
+/// rate (100m and 1g far under shape, ≥3g ~100 %) and, under saturation,
+/// read as proportional equalization.
+///
+/// The fix turns the per-visit bound into a FRAME-COUNT cap: a visit may
+/// drain up to `TX_BATCH_SIZE` frames, bounded in bytes here so a banked
+/// queue (#1630 P1 raised the token watermark to an N-frame bank) cannot
+/// monopolize a drain pass. `TX_BATCH_SIZE × tx_frame_capacity()` is a
+/// clean multiple of the frame size and at least 64 max-MTU frames, so
+/// the `items.len() < TX_BATCH_SIZE` loop bound in the drain is the
+/// binding per-visit constraint and no sub-frame remainder is lost. The
+/// RR cursor still advances after each visit, preserving round-robin
+/// fairness across queues. The long-run rate is unchanged — it is metered
+/// by `queue.hot.tokens` (refilled at the configured rate via the v8
+/// lease, #1630 cause-1 carry) and the actual-byte debit in tx_completion.
+#[inline]
+pub(in crate::afxdp) fn cos_guarantee_visit_cap_bytes() -> u64 {
+    (TX_BATCH_SIZE as u64) * (tx_frame_capacity() as u64)
 }
 
 pub(in crate::afxdp) fn estimate_cos_queue_wakeup_tick(

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -646,8 +646,17 @@ fn guarantee_phase_parks_non_exact_queue_on_root_only_wakeup() {
     assert_eq!(root.queues[0].hot.next_wakeup_tick, 30);
 }
 
+/// #1630 (P2): a low-rate queue with banked tokens drains its queued
+/// frames whole in one visit, bounded by the per-visit FRAME-count cap
+/// (`cos_guarantee_visit_cap_bytes` = TX_BATCH_SIZE × frame), NOT the
+/// rate-scaled quantum. Before #1630 the 1 Mbps quantum (clamped to
+/// 1500 B) limited the visit to a single frame and discarded the
+/// sub-frame remainder, pinning the class near 60 % of its rate. Now
+/// the rate is metered by `queue.hot.tokens` (refilled at the configured
+/// rate) and the actual-byte debit, so a queue that has accumulated
+/// tokens for several frames sends them in one pass.
 #[test]
-fn guarantee_phase_limits_service_to_visit_quantum() {
+fn guarantee_phase_visit_cap_drains_banked_frames() {
     let mut root = test_cos_runtime_with_queues(
         100_000_000,
         vec![CoSQueueConfig {
@@ -666,6 +675,7 @@ fn guarantee_phase_limits_service_to_visit_quantum() {
         }],
     );
     root.tokens = 64 * 1024;
+    // Bank enough tokens for all four queued frames.
     root.queues[0].hot.tokens = 64 * 1024;
     root.queues[0].hot.runnable = true;
     for _ in 0..4 {
@@ -677,10 +687,10 @@ fn guarantee_phase_limits_service_to_visit_quantum() {
 
     let batch = select_cos_guarantee_batch(&mut root, 1).expect("guarantee batch");
     match batch {
-        CoSBatch::Local { items, .. } => assert_eq!(items.len(), 1),
+        CoSBatch::Local { items, .. } => assert_eq!(items.len(), 4),
         CoSBatch::Prepared { .. } => panic!("expected local batch"),
     }
-    assert_eq!(root.queues[0].hot.items.len(), 3);
+    assert_eq!(root.queues[0].hot.items.len(), 0);
 }
 
 #[test]
@@ -1287,7 +1297,25 @@ fn equal_flow_cap_reaches_drain_shaped_tx_entry_path() {
         root.queues[0].hot.queued_bytes,
         queued_before.saturating_sub(sent_bytes)
     );
-    assert_eq!(root.tokens, root_tokens_before.saturating_sub(sent_bytes));
+    // #1630 (P2): the per-visit budget is now a FRAME-count cap rather
+    // than the rate-scaled quantum (which clamped a 100 Mbps class to a
+    // single frame per visit). The four equal-flow frames drain in one
+    // pass, leaving the queue empty. `refresh_cos_interface_activity`
+    // then sees `nonempty_queues == 0` and calls `release_cos_root_lease`,
+    // which returns the worker's unused root credit to the shared pool
+    // (`core::mem::take(&mut root.tokens)`). So after a drain that empties
+    // the interface, root.tokens is 0 — the unspent root tokens were not
+    // leaked, they were released. (Pre-#1630 the queue stayed backlogged
+    // after one frame, so the release path did not fire and root.tokens
+    // was `root_tokens_before - sent_bytes`.)
+    assert!(
+        root.queues[0].hot.items.is_empty(),
+        "all four equal-flow frames must drain in one visit under the P2 frame-cap"
+    );
+    assert_eq!(
+        root.tokens, 0,
+        "emptying the interface releases the unused root lease to the shared pool"
+    );
     assert_eq!(
         root.queues[0]
             .telemetry

--- a/userspace-dp/src/afxdp/cos/token_bucket.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use crate::afxdp::tx_frame_capacity;
+use crate::afxdp::{tx_frame_capacity, COS_EXACT_QUEUE_LEASE_BANK_BYTES};
 use crate::afxdp::types::{
     CoSInterfaceRuntime, CoSQueueRuntime, SharedCoSQueueLease, SharedCoSRootLease,
 };
@@ -181,8 +181,21 @@ pub(in crate::afxdp) fn maybe_top_up_cos_queue_lease(
         let Some(shared_queue_lease) = shared_queue_lease else {
             return CoSQueueLeaseAcquireTelemetry::default();
         };
+        // #1630 (P1): raise the exact-queue top-up watermark from
+        // `lease_bytes` (= rate × 200 µs, floored at one frame) to an
+        // N-frame burst bank. A low-rate class could otherwise bank only
+        // ~1-2 frames and lost the unspent per-epoch lease cap at each
+        // rotation, pinning it well below its configured rate. The bucket
+        // accumulates the surplus across epochs via the `saturating_add`
+        // in the credit path; the long-run rate stays metered by the v8
+        // per-epoch grant (`rate × elapsed`, #1630 cause-1 carry) and the
+        // actual-byte debit in tx_completion, so the hard-cap (Gate 4) is
+        // preserved. The companion `max_total_leased` raise in
+        // `compute_shared_cos_lease_config` keeps the outstanding-credit
+        // cap from defeating this watermark at low `active_shards`.
         let lease_bytes = shared_queue_lease
             .lease_bytes()
+            .max(COS_EXACT_QUEUE_LEASE_BANK_BYTES)
             .max(tx_frame_capacity() as u64)
             .min(queue.config.buffer_bytes.max(COS_MIN_BURST_BYTES));
         if queue.hot.tokens >= lease_bytes {

--- a/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
+++ b/userspace-dp/src/afxdp/cos/token_bucket_tests.rs
@@ -29,27 +29,35 @@ fn shared_cos_root_lease_bounds_total_outstanding_credit() {
 
 #[test]
 fn shared_cos_queue_lease_bounds_total_outstanding_credit() {
+    // #1630 (P1): the outstanding-credit cap is now floored at one
+    // N-frame burst bank (COS_EXACT_QUEUE_LEASE_BANK_BYTES) so a
+    // low-`active_shards` queue can bank the full watermark. At 10 Mbps /
+    // 128 KB burst / 2 shards the bank floor (32 KB at N=8) dominates the
+    // old `max_frame_lease_bytes × active_shards` term (4096×2 = 8 KB) but
+    // stays under `burst/4` (32 KB) and the credit pool (128 KB).
     let lease = SharedCoSQueueLease::new(10_000_000, 128 * 1024, 2);
     let request = 2500;
+    let cap = COS_EXACT_QUEUE_LEASE_BANK_BYTES;
 
-    let first = lease.acquire(1, request);
-    let second = lease.acquire(1, request);
-    let third = lease.acquire(1, request);
-    let fourth = lease.acquire(1, request);
-    let fifth = lease.acquire(1, 1);
+    let mut total = 0u64;
+    // Drain the lease in `request`-sized chunks; the lease must hand out
+    // exactly `cap` bytes of outstanding credit before refusing more.
+    loop {
+        let granted = lease.acquire(1, request);
+        if granted == 0 {
+            break;
+        }
+        total += granted;
+        assert!(total <= cap, "outstanding credit exceeded the cap");
+    }
+    assert_eq!(total, cap, "lease must hand out exactly the bank cap");
+    // Further acquires are refused while the credit is outstanding.
+    assert_eq!(lease.acquire(1, 1), 0);
 
-    assert_eq!(first, request);
-    assert_eq!(second, request);
-    assert_eq!(third, request);
-    assert_eq!(
-        first + second + third + fourth,
-        (tx_frame_capacity() as u64) * 2
-    );
-    assert_eq!(fifth, 0);
-
+    // Releasing frees headroom for a subsequent acquire.
     lease.release_unused(request);
-    let sixth = lease.acquire(1, request);
-    assert_eq!(sixth, request);
+    let after_release = lease.acquire(1, request);
+    assert_eq!(after_release, request);
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -211,10 +211,11 @@ const UMEM_HEADROOM: u32 = 256;
 //
 // Future bumps require re-validating: (a) L1d footprint vs
 // per-batch allocation; (b) per-poll budget interaction with
-// `MAX_RX_BATCHES_PER_POLL`; (c) the rate-quantum test
-// `guarantee_phase_*_visit_quantum` in tx.rs. The const_asserts
-// below force the change to fail compilation rather than silently
-// regress the validation surface.
+// `MAX_RX_BATCHES_PER_POLL`; (c) the guarantee-phase per-visit budget
+// tests in `cos/queue_service/tests.rs` (#1630 P2 ties the per-visit
+// send cap `cos_guarantee_visit_cap_bytes` to `TX_BATCH_SIZE × frame`).
+// The const_asserts below force the change to fail compilation rather
+// than silently regress the validation surface.
 const RX_BATCH_SIZE: u32 = 64;
 const _: () = assert!(
     RX_BATCH_SIZE == 64,
@@ -230,6 +231,36 @@ const _: () = assert!(
 const PENDING_TX_LIMIT_MULTIPLIER: usize = 2;
 const FILL_BATCH_SIZE: usize = 1024;
 const MAX_RX_BATCHES_PER_POLL: usize = 4;
+
+/// #1630 (P1): exact-queue token-bucket burst bank.
+///
+/// The per-queue token bucket for a hard-cap exact guarantee class was
+/// previously watermarked at `lease_bytes` (= `rate × 200 µs`, floored
+/// at one frame). For a low-rate class (e.g. 100 Mbps → ~2.5 KB target,
+/// floored to 4 KB) the bucket could bank only ~1-2 frames and lost the
+/// unspent per-epoch lease cap at every rotation, pinning the class well
+/// below its configured rate independent of competition (the
+/// small-four-alone SOLO A/B measured 100m/1g far under shape). Banking N
+/// frames lets a small class accrue enough to send whole frames at its
+/// full average rate and ride out drain-visit cadence jitter.
+///
+/// The long-run RATE is unchanged: the v8 `acquire_v8` per-epoch grant is
+/// still rate-metered (now `rate × elapsed` with the #1630 cause-1 carry)
+/// and `consume(sent_bytes)` debits actual bytes
+/// (token_bucket.rs / tx_completion.rs). The watermark only widens the
+/// burst/accumulation window — it never raises the refill rate, so the
+/// hard-cap (Gate 4) holds.
+///
+/// `COS_EXACT_QUEUE_LEASE_BANK_BYTES` is consumed by
+/// `maybe_top_up_cos_queue_lease` (the bucket watermark) AND by
+/// `compute_shared_cos_lease_config` (the `max_total_leased`
+/// outstanding-credit cap), which MUST rise in lock-step or the v8 lease
+/// refuses grants past the old cap and defeats the watermark in low
+/// `active_shards` configurations (at active_shards=6, 4096×6=24 KB <
+/// the 32 KB bank).
+const COS_EXACT_QUEUE_LEASE_BANK_FRAMES: u64 = 8;
+const COS_EXACT_QUEUE_LEASE_BANK_BYTES: u64 =
+    COS_EXACT_QUEUE_LEASE_BANK_FRAMES * UMEM_FRAME_SIZE as u64;
 /*
  * Force XDP_COPY mode for AF_XDP sockets. In zero-copy mode on mlx5, XDP_PASS
  * (used for ARP, host-bound management traffic, and fallback paths) permanently

--- a/userspace-dp/src/afxdp/tx/test_support.rs
+++ b/userspace-dp/src/afxdp/tx/test_support.rs
@@ -215,19 +215,25 @@ pub(in crate::afxdp) fn test_session_key(src_port: u16, dst_port: u16) -> Sessio
 
 pub(in crate::afxdp) fn test_mixed_class_root_with_primed_queues() -> CoSInterfaceRuntime {
     // Four queues on the same iface: two exact (queue_id 0, 2),
-    // two non-exact (queue_id 1, 3). Per-queue rate is set low
-    // enough that `cos_guarantee_quantum_bytes` clamps to the
-    // minimum (1500 bytes). That means the non-exact batch-build
-    // path (`select_nonexact_cos_guarantee_batch`) dequeues exactly
-    // one 1500-byte item per call, while the exact fast-path
+    // two non-exact (queue_id 1, 3). The non-exact batch-build path
+    // (`select_nonexact_cos_guarantee_batch`) dequeues up to the
+    // available per-queue token budget, while the exact fast-path
     // selector (`select_exact_cos_guarantee_queue_with_fast_path`)
     // only picks a queue and advances its cursor — it does not
-    // dequeue. Eight primed items per queue keeps backlog available
-    // across every rotation round below without any test having to
-    // push additional items.
+    // dequeue.
+    //
+    // #1630: the per-visit budget is now a FRAME-count cap, not the
+    // rate-scaled quantum, so a queue with abundant tokens would drain
+    // many frames per visit. The #689 split-cursor regression tests
+    // care only about ROTATION ORDER, so each queue's token bucket is
+    // primed to exactly one frame and the refill clock is frozen at the
+    // tests' `now_ns` (1) — that keeps the non-exact build dequeuing
+    // exactly one 1500-byte item per call without depending on the
+    // removed quantum clamp. Eight primed items per queue keeps backlog
+    // available across every rotation round below.
     //
     // Shared by the #689 split-cursor regression tests.
-    let slow_rate = 1_000_000 / 8; // 1 Mbps → quantum clamps to MIN
+    let slow_rate = 1_000_000 / 8; // 1 Mbps
     let mut root = test_cos_runtime_with_queues(
         10_000_000_000 / 8,
         vec![
@@ -291,7 +297,12 @@ pub(in crate::afxdp) fn test_mixed_class_root_with_primed_queues() -> CoSInterfa
     );
     root.tokens = 1024 * 1024;
     for queue in &mut root.queues {
-        queue.hot.tokens = 64 * 1024;
+        // One frame of tokens + a frozen refill clock (last_refill_ns ==
+        // the tests' now_ns of 1) so each non-exact visit drains exactly
+        // one 1500-byte item, isolating the cursor-rotation contract from
+        // the #1630 per-visit frame-count cap.
+        queue.hot.tokens = 1500;
+        queue.hot.last_refill_ns = 1;
         queue.hot.runnable = true;
         // Eight items per queue covers the longest rotation test below
         // without any queue draining to empty.

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
@@ -284,9 +284,9 @@ const STALL_THRESHOLD_EPOCHS: u64 = 256;
 /// ceiling so the carry can never push a single rotation above the bound.
 ///
 /// Per-epoch carry DRAIN is additionally capped at `(K − 1) × rate ×
-/// EPOCH` so a normal-recovery rotation that drains a full reservoir
-/// grants `base_cap + (K−1) × base_cap = K × base_cap` — the same K-epoch
-/// ceiling, never more.
+/// EPOCH` so a normal-recovery rotation can add at most `(K−1)` epochs of
+/// rate on top of a `K`-epoch base grant, keeping the single-rotation
+/// maximum at `(2K−1) × rate × EPOCH`.
 const CARRY_MAX_EPOCHS: u64 = MAX_ROTATION_LAG_EPOCHS;
 const CARRY_DRAIN_MAX_EPOCHS: u64 = MAX_ROTATION_LAG_EPOCHS - 1;
 

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
@@ -240,6 +240,56 @@ impl SharedCoSExactBacklog {
 /// Epoch duration. Picked to match existing refill cadence.
 pub(in crate::afxdp) const EPOCH_DURATION_NS: u64 = 200_000;
 
+/// #1630 (cause-1): rate-recovery width for the rotation credit carry.
+///
+/// `maybe_rotate_epoch_v8` is purely lazy — a low-rate exact class is
+/// only rotated when the scheduler next visits its queue, so the gap
+/// (`lag = now − epoch_start`) between two rotations of the SAME queue
+/// routinely exceeds one epoch under round-robin across 11+ classes. The
+/// pre-#1630 clamp computed `elapsed = min(lag, EPOCH)` and then reset
+/// `epoch_start := now`, permanently discarding `rate × (lag − EPOCH)` of
+/// grant per lagged rotation. That pinned the lowest-rate classes well
+/// below shape even SOLO (100m 81 %, 1g 84 %).
+///
+/// `MAX_ROTATION_LAG_EPOCHS` (K) is the number of epochs of lag a single
+/// rotation recovers in full. It is the bounded relaxation of the clamp:
+/// a single rotation can grant at most `K × rate × EPOCH` of base credit,
+/// so the per-class post-stall burst is hard-bounded (the invariant the
+/// old clamp protected). K = 8 matches the diagnostic probe that lifted
+/// the SOLO ceilings; the §3.6 SOLO A/B confirmed small-K + P2 clears the
+/// scoped Gate-1 (100m/1g) without an aggregate-burst hazard (Fork A).
+const MAX_ROTATION_LAG_EPOCHS: u64 = 8;
+
+/// #1630 (cause-1): cold-resume cutoff for the rotation credit carry,
+/// DECOUPLED from `MAX_ROTATION_LAG_EPOCHS`.
+///
+/// A lag beyond `STALL_THRESHOLD_EPOCHS` is not a legitimate intermittent
+/// visit gap — it is a worker/RG stall (GC pause, scheduler starvation)
+/// or an HA demote→promote gap on a REUSED lease (leases are reused when
+/// config matches, so `epoch_start` survives across a failover and the
+/// first post-promotion rotation sees `lag ≈ demotion_duration`). In that
+/// regime the rotation cold-resumes to a single-epoch grant and DROPS any
+/// banked carry, so a long-stalled or just-promoted worker cannot emit a
+/// `K`-epoch (let alone a stall-duration) burst. STALL must sit ABOVE any
+/// legitimate visit-lag tail and BELOW a failback gap: the failback path
+/// is ≥100 ms (≥500 epochs, CLAUDE.md "Failback timing ~130 ms"), so
+/// STALL = 256 epochs ≈ 51 ms has margin on both sides.
+const STALL_THRESHOLD_EPOCHS: u64 = 256;
+
+/// #1630 (cause-1): reservoir cap for the rotation credit carry — the
+/// MAXIMUM unbanked rate credit a class can ever owe, regardless of stall
+/// length. Bounds the post-stall catch-up burst. Sized at `K` epochs of
+/// rate (`MAX_ROTATION_LAG_EPOCHS × rate × EPOCH`, computed per-lease from
+/// `rate_bytes` in the rotation), matching the per-rotation K-epoch grant
+/// ceiling so the carry can never push a single rotation above the bound.
+///
+/// Per-epoch carry DRAIN is additionally capped at `(K − 1) × rate ×
+/// EPOCH` so a normal-recovery rotation that drains a full reservoir
+/// grants `base_cap + (K−1) × base_cap = K × base_cap` — the same K-epoch
+/// ceiling, never more.
+const CARRY_MAX_EPOCHS: u64 = MAX_ROTATION_LAG_EPOCHS;
+const CARRY_DRAIN_MAX_EPOCHS: u64 = MAX_ROTATION_LAG_EPOCHS - 1;
+
 /// Bound on seqlock-snapshot retries.
 const MAX_SEQ_SPINS: u32 = 64;
 
@@ -279,9 +329,26 @@ struct SharedCoSEpochState {
     /// epoch_tag = (seq >> 1) as u32.
     epoch_seq: AtomicU64,
     epoch_start_ns: AtomicU64,
-    /// Capped at u32::MAX. Computed as
-    /// `rate × min(elapsed, EPOCH_DURATION_NS)` per rotation.
+    /// Capped at u32::MAX. Computed as `rate × elapsed + carry_draw` per
+    /// rotation, where `elapsed` is bounded by `K × EPOCH_DURATION_NS`
+    /// (#1630 cause-1 credit carry — was `rate × min(elapsed, EPOCH)`).
     epoch_total_grant_cap: AtomicU64,
+    /// #1630 (cause-1): ROTATION-PRIVATE bounded credit deficit (bytes).
+    ///
+    /// Holds the rate credit a lagged rotation could not grant in full
+    /// (`rate × (lag − K×EPOCH)`), banked for the next visit and clamped
+    /// at `CARRY_MAX_EPOCHS × rate × EPOCH`. Read AND written ONLY by the
+    /// rotation winner, entirely inside the seqlock ODD critical section
+    /// (between the EVEN→ODD CAS and the ODD→EVEN publish in
+    /// `maybe_rotate_epoch_v8`). It is deliberately NOT part of the
+    /// `snapshot_epoch_v8` published payload — acquirers never read it —
+    /// so it adds no new reader-visible seqlock surface (would otherwise
+    /// be the #1619 tearing class). This privacy is ENFORCED by a grep
+    /// test in `shared_cos_lease_tests.rs`; do NOT add a `pub` accessor or
+    /// read it from `acquire_v8`/`snapshot_epoch_v8`/`coordinator/status`.
+    /// Reset to 0 on cold-resume (lag > STALL or start==0) so it cannot
+    /// leak a stale deficit across an HA demote→promote gap.
+    epoch_carry_bytes: AtomicU64,
     epoch_grace_expires_ns: AtomicU64,
     /// Packed (epoch_tag, total_granted_this_epoch).
     packed_granted: PackedEpochGrant,
@@ -315,6 +382,7 @@ impl SharedCoSEpochState {
             epoch_seq: AtomicU64::new(0),
             epoch_start_ns: AtomicU64::new(0),
             epoch_total_grant_cap: AtomicU64::new(0),
+            epoch_carry_bytes: AtomicU64::new(0),
             epoch_grace_expires_ns: AtomicU64::new(0),
             packed_granted: PackedEpochGrant::new(),
             rollback_retry_exceeded: AtomicU64::new(0),
@@ -691,10 +759,25 @@ const COS_ROOT_LEASE_TARGET_US: u64 = 200;
 const COS_ROOT_LEASE_MIN_BYTES: u64 = 1500;
 const COS_ROOT_LEASE_MAX_BYTES: u64 = 512 * 1024;
 
+/// #1630 (P1): per-queue exact leases bank an N-frame burst
+/// (`COS_EXACT_QUEUE_LEASE_BANK_BYTES`); the root lease does not. The
+/// `bank_floor` flag selects whether the outstanding-credit cap is
+/// floored at the bank. It MUST be the same for a given lease across
+/// rebuilds (it is fixed by the lease kind), so `matches_config*` passes
+/// the same value the constructor did.
 fn compute_shared_cos_lease_config(
     rate_bytes: u64,
     burst_bytes: u64,
     active_shards: usize,
+) -> SharedCoSLeaseConfig {
+    compute_shared_cos_lease_config_with_bank(rate_bytes, burst_bytes, active_shards, false)
+}
+
+fn compute_shared_cos_lease_config_with_bank(
+    rate_bytes: u64,
+    burst_bytes: u64,
+    active_shards: usize,
+    bank_floor: bool,
 ) -> SharedCoSLeaseConfig {
     let burst_bytes = burst_bytes
         .max(COS_ROOT_LEASE_MIN_BYTES)
@@ -709,10 +792,40 @@ fn compute_shared_cos_lease_config(
     let lease_bytes = target_lease_bytes
         .max(COS_ROOT_LEASE_MIN_BYTES)
         .min(lease_ceiling);
-    let max_frame_lease_bytes = lease_bytes.max(tx_frame_capacity() as u64);
+    // #1630 (P1): the per-queue exact lease token bucket is watermarked at
+    // an N-frame burst bank (COS_EXACT_QUEUE_LEASE_BANK_BYTES, see
+    // afxdp::mod / maybe_top_up_cos_queue_lease). The v8/legacy QUEUE
+    // lease refuses grants once outstanding credit reaches
+    // `max_total_leased`, so the outstanding-credit cap must rise in
+    // lock-step or a low-`active_shards` queue can never bank the full N
+    // frames (at active_shards=6 the old floor was 4096×6=24 KB < the 32
+    // KB bank). The ROOT lease is NOT bank-watermarked (its top-up uses
+    // `lease_bytes.max(tx_frame_capacity)`), so `bank_floor` is false for
+    // it and its cap is unchanged. Raising the per-frame floor only widens
+    // the outstanding window; the rate is still metered by the refill rate
+    // (`rate_bytes`) and the actual-byte `consume`, so the hard-cap
+    // (Gate 4) is preserved.
+    let bank_bytes = if bank_floor {
+        COS_EXACT_QUEUE_LEASE_BANK_BYTES
+    } else {
+        0
+    };
+    let max_frame_lease_bytes = lease_bytes
+        .max(tx_frame_capacity() as u64)
+        .max(bank_bytes);
+    // The base cap keeps the lease from handing out more than a quarter of
+    // the burst pool. #1630: that `burst/4` term (≈24 KB at the 96 KB
+    // burst floor) is BELOW the N-frame bank (32 KB at N=8), so the cap
+    // alone defeats the watermark even though `max_frame_lease_bytes` was
+    // raised. For queue leases, floor the outstanding cap at one full bank
+    // so a single shard can hold N frames of credit, but never exceed the
+    // credit pool (`burst_bytes`) — outstanding credit can never exceed
+    // available tokens, so flooring at the bank only relaxes the safety
+    // margin, it does not raise the steady-state rate.
     let max_total_leased = burst_bytes
         .saturating_div(4)
-        .min(max_frame_lease_bytes.saturating_mul(active_shards as u64));
+        .min(max_frame_lease_bytes.saturating_mul(active_shards as u64))
+        .max(bank_bytes.min(burst_bytes));
     debug_assert!(max_total_leased <= u32::MAX as u64);
     SharedCoSLeaseConfig {
         rate_bytes,
@@ -888,7 +1001,10 @@ fn refill_shared_cos_lease_state(
 
 impl SharedCoSQueueLease {
     pub(in crate::afxdp) fn new(rate_bytes: u64, burst_bytes: u64, active_shards: usize) -> Self {
-        let config = compute_shared_cos_lease_config(rate_bytes, burst_bytes, active_shards);
+        // #1630 (P1): queue leases bank an N-frame burst, so the
+        // outstanding-credit cap is floored at the bank (bank_floor = true).
+        let config =
+            compute_shared_cos_lease_config_with_bank(rate_bytes, burst_bytes, active_shards, true);
         Self {
             config,
             state: SharedCoSLeaseState {
@@ -927,7 +1043,9 @@ impl SharedCoSQueueLease {
         max_worker_id: usize,
         rate_mode: V8RateMode,
     ) -> Self {
-        let config = compute_shared_cos_lease_config(rate_bytes, burst_bytes, active_shards);
+        // #1630 (P1): queue leases bank an N-frame burst (bank_floor = true).
+        let config =
+            compute_shared_cos_lease_config_with_bank(rate_bytes, burst_bytes, active_shards, true);
         let len = max_worker_id + 1;
         let worker_grants = (0..len)
             .map(|_| PackedEpochGrant::new())
@@ -985,7 +1103,15 @@ impl SharedCoSQueueLease {
         active_shards: usize,
     ) -> bool {
         // Legacy match: ignores v8 mode. v8 callers use `matches_config_v8`.
-        self.config == compute_shared_cos_lease_config(rate_bytes, burst_bytes, active_shards)
+        // #1630 (P1): queue leases use the bank-floored config
+        // (bank_floor = true) — must match what `new`/`new_v8*` built.
+        self.config
+            == compute_shared_cos_lease_config_with_bank(
+                rate_bytes,
+                burst_bytes,
+                active_shards,
+                true,
+            )
             && self.v8.is_none()
     }
 
@@ -1002,7 +1128,15 @@ impl SharedCoSQueueLease {
         let Some(v8) = self.v8.as_ref() else {
             return false;
         };
-        self.config == compute_shared_cos_lease_config(rate_bytes, burst_bytes, active_shards)
+        // #1630 (P1): queue leases use the bank-floored config
+        // (bank_floor = true) — must match what `new_v8*` built.
+        self.config
+            == compute_shared_cos_lease_config_with_bank(
+                rate_bytes,
+                burst_bytes,
+                active_shards,
+                true,
+            )
             && v8.worker_grants.len() == max_worker_id + 1
             && v8.rate_mode == rate_mode
     }
@@ -1437,14 +1571,28 @@ impl SharedCoSQueueLease {
                 std::hint::spin_loop();
                 continue;
             }
-            let cap = v8.epoch.epoch_total_grant_cap.load(Ordering::Acquire);
+            // #1643: seqlock reader payload loads are Relaxed and SEALED
+            // by an explicit `fence(Acquire)` before the trailing
+            // `seq_after` re-read. The previous `Acquire` loads only
+            // prevented LATER ops from hoisting above each load; they did
+            // NOT pin these payload reads ABOVE the `seq_after` read, so on
+            // a weakly-ordered CPU (ARM/POWER) `seq_after` could retire
+            // before the payload loads and the even-equal validation could
+            // pass against torn cross-epoch data (the #1619 tearing class).
+            // The fence guarantees all payload loads complete before
+            // `seq_after` is read, matching the verified-correct
+            // `cold_path_hist.rs::snapshot` reference. Latent on the
+            // x86-TSO i40e/mlx5 deploy targets but a real hazard on any
+            // weakly-ordered CPU.
+            let cap = v8.epoch.epoch_total_grant_cap.load(Ordering::Relaxed);
             let share = v8
                 .worker_fair_share
                 .get(worker_id)
-                .map(|a| a.load(Ordering::Acquire))
+                .map(|a| a.load(Ordering::Relaxed))
                 .unwrap_or(0);
-            let grace = v8.epoch.epoch_grace_expires_ns.load(Ordering::Acquire);
-            let seq_after = v8.epoch.epoch_seq.load(Ordering::Acquire);
+            let grace = v8.epoch.epoch_grace_expires_ns.load(Ordering::Relaxed);
+            std::sync::atomic::fence(Ordering::Acquire);
+            let seq_after = v8.epoch.epoch_seq.load(Ordering::Relaxed);
             if seq_after == seq_before {
                 return Some((cap, share, grace, (seq_before >> 1) as u32));
             }

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
@@ -250,31 +250,41 @@ impl SharedCoSQueueLease {
             * EPOCH_DURATION_NS as u128)
             / 1_000_000_000u128) as u64;
 
+        // Regime boundaries are compared on EXACT wall-clock nanoseconds,
+        // NOT a floored epoch count: a floored `lag = raw / EPOCH` would
+        // admit a regime-1 lag of up to `(K+1)×EPOCH − 1ns` (floors to K),
+        // so the regime-1 base grant could reach almost `(K+1)×rate×EPOCH`
+        // and, with a full carry drain, breach the `(2K−1)×rate×EPOCH`
+        // per-rotation bound by one epoch; and a raw lag of
+        // `STALL×EPOCH + 1ns` (floors to STALL) would skip the regime-3
+        // cold-resume and bank instead of dropping stale carry across an
+        // HA gap. Comparing raw nanoseconds against the exact `K×EPOCH`
+        // and `STALL×EPOCH` thresholds closes both boundary holes.
         let raw_elapsed_ns = now_ns.saturating_sub(start);
-        let lag_epochs = if start == 0 {
-            0
-        } else {
-            raw_elapsed_ns / EPOCH_DURATION_NS
-        };
+        let k_window_ns = EPOCH_DURATION_NS * MAX_ROTATION_LAG_EPOCHS;
+        let stall_window_ns = EPOCH_DURATION_NS * STALL_THRESHOLD_EPOCHS;
 
-        let (elapsed_ns, carry_draw) = if start == 0 || lag_epochs > STALL_THRESHOLD_EPOCHS {
+        let (elapsed_ns, carry_draw) = if start == 0 || raw_elapsed_ns > stall_window_ns {
             // REGIME 3 — cold-resume. One epoch, drop any stale carry.
             if start != 0 {
                 v8.epoch.epoch_carry_bytes.store(0, Ordering::Release);
             }
             (EPOCH_DURATION_NS, 0u64)
-        } else if lag_epochs > MAX_ROTATION_LAG_EPOCHS {
-            // REGIME 2 — bank residual beyond the K-epoch ceiling.
-            let k_window_ns = EPOCH_DURATION_NS * MAX_ROTATION_LAG_EPOCHS;
-            let overshoot_ns = raw_elapsed_ns.saturating_sub(k_window_ns) as u128;
+        } else if raw_elapsed_ns > k_window_ns {
+            // REGIME 2 — bank residual beyond the K-epoch ceiling. Grant
+            // exactly `K×EPOCH` now; bank `rate × (raw − K×EPOCH)`.
+            let overshoot_ns = (raw_elapsed_ns - k_window_ns) as u128;
             let new_owed = ((rate_bytes * overshoot_ns) / 1_000_000_000u128) as u64;
             let prev_carry = v8.epoch.epoch_carry_bytes.load(Ordering::Acquire);
             let carry = prev_carry.saturating_add(new_owed).min(carry_max);
             v8.epoch.epoch_carry_bytes.store(carry, Ordering::Release);
             (k_window_ns, 0u64)
         } else {
-            // REGIME 1 — normal recovery. Grant the raw lag (bounded by K
-            // here) and drain a bounded carry slice.
+            // REGIME 1 — normal recovery. `raw_elapsed_ns ≤ K×EPOCH` here
+            // (regime 2 caught anything above), so the base grant is
+            // bounded by `K×rate×EPOCH`; the carry drain adds at most
+            // `(K−1)×rate×EPOCH`, keeping the per-rotation grant ≤
+            // `(2K−1)×rate×EPOCH`.
             let prev_carry = v8.epoch.epoch_carry_bytes.load(Ordering::Acquire);
             let draw = prev_carry.min(carry_drain_max);
             v8.epoch

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
@@ -212,30 +212,102 @@ impl SharedCoSQueueLease {
             .map(|c| c.load(Ordering::Relaxed) as u64)
             .sum::<u64>()
             .max(1);
-        let elapsed_ns = if start == 0 {
-            EPOCH_DURATION_NS
+        // #1630 (cause-1): bounded rotation credit carry. The cap this
+        // rotation grants is `rate × elapsed + carry_draw`, where:
+        //   * `elapsed` is the wall-clock lag bounded by `K × EPOCH`
+        //     (`MAX_ROTATION_LAG_EPOCHS`) — recovers the rate credit the
+        //     old `.min(EPOCH)` clamp discarded for a low-rate class that
+        //     is only visited intermittently, while keeping the per-class
+        //     post-stall burst hard-bounded to `K × rate × EPOCH`;
+        //   * `carry_draw` releases a bounded slice of the banked deficit
+        //     accrued when a single lag exceeded `K × EPOCH`.
+        //
+        // Three regimes (DECOUPLED stall cutoff so a legitimate heavy-tail
+        // visit lag is never penalised as a stall):
+        //   1. lag ≤ K          — normal recovery: grant raw lag, drain a
+        //                         bounded carry slice.
+        //   2. K < lag ≤ STALL  — bank-residual: grant the K-epoch ceiling
+        //                         now, bank `rate × (lag − K×EPOCH)` into
+        //                         carry (clamped) for the next visit.
+        //   3. lag > STALL or
+        //      start == 0       — cold-resume: grant exactly one epoch and
+        //                         DROP carry. Bounds the post-stall /
+        //                         post-failback burst to `rate × EPOCH` and
+        //                         prevents carry leaking across an HA
+        //                         demote→promote gap on a reused lease.
+        //
+        // `epoch_carry_bytes` is rotation-private (single-writer, inside
+        // the seqlock ODD section); the Acquire/Release on it are redundant
+        // with the surrounding CAS fence but self-documenting. See the
+        // struct doc-comment for the enforced reader-private invariant.
+        let rate_bytes = self.config.rate_bytes as u128;
+        let carry_max = ((rate_bytes
+            * CARRY_MAX_EPOCHS as u128
+            * EPOCH_DURATION_NS as u128)
+            / 1_000_000_000u128) as u64;
+        let carry_drain_max = ((rate_bytes
+            * CARRY_DRAIN_MAX_EPOCHS as u128
+            * EPOCH_DURATION_NS as u128)
+            / 1_000_000_000u128) as u64;
+
+        let raw_elapsed_ns = now_ns.saturating_sub(start);
+        let lag_epochs = if start == 0 {
+            0
         } else {
-            (now_ns - start).min(EPOCH_DURATION_NS)
+            raw_elapsed_ns / EPOCH_DURATION_NS
         };
-        let new_cap_raw =
+
+        let (elapsed_ns, carry_draw) = if start == 0 || lag_epochs > STALL_THRESHOLD_EPOCHS {
+            // REGIME 3 — cold-resume. One epoch, drop any stale carry.
+            if start != 0 {
+                v8.epoch.epoch_carry_bytes.store(0, Ordering::Release);
+            }
+            (EPOCH_DURATION_NS, 0u64)
+        } else if lag_epochs > MAX_ROTATION_LAG_EPOCHS {
+            // REGIME 2 — bank residual beyond the K-epoch ceiling.
+            let k_window_ns = EPOCH_DURATION_NS * MAX_ROTATION_LAG_EPOCHS;
+            let overshoot_ns = raw_elapsed_ns.saturating_sub(k_window_ns) as u128;
+            let new_owed = ((rate_bytes * overshoot_ns) / 1_000_000_000u128) as u64;
+            let prev_carry = v8.epoch.epoch_carry_bytes.load(Ordering::Acquire);
+            let carry = prev_carry.saturating_add(new_owed).min(carry_max);
+            v8.epoch.epoch_carry_bytes.store(carry, Ordering::Release);
+            (k_window_ns, 0u64)
+        } else {
+            // REGIME 1 — normal recovery. Grant the raw lag (bounded by K
+            // here) and drain a bounded carry slice.
+            let prev_carry = v8.epoch.epoch_carry_bytes.load(Ordering::Acquire);
+            let draw = prev_carry.min(carry_drain_max);
+            v8.epoch
+                .epoch_carry_bytes
+                .store(prev_carry - draw, Ordering::Release);
+            (raw_elapsed_ns, draw)
+        };
+
+        let base_cap =
             ((self.config.rate_bytes as u128) * (elapsed_ns as u128) / 1_000_000_000u128) as u64;
-        let new_cap = new_cap_raw.min(u32::MAX as u64);
+        let new_cap = base_cap.saturating_add(carry_draw).min(u32::MAX as u64);
+        // #1643: payload store downgraded to Relaxed — the single Release
+        // on `epoch_seq` below is the sole publish the fenced-Acquire reader
+        // synchronizes-with (matching the cold_path_hist reference writer).
         v8.epoch
             .epoch_total_grant_cap
-            .store(new_cap, Ordering::Release);
+            .store(new_cap, Ordering::Relaxed);
         let grace_ns = now_ns.saturating_add(EPOCH_DURATION_NS / 2);
         v8.epoch
             .epoch_grace_expires_ns
-            .store(grace_ns, Ordering::Release);
+            .store(grace_ns, Ordering::Relaxed);
         for (id, count_atom) in v8.worker_active_flow_buckets.iter().enumerate() {
             let my_count = count_atom.load(Ordering::Relaxed) as u64;
             let my_share = ((new_cap as u128) * (my_count as u128) / (total_flows as u128)) as u64;
             if let Some(share_atom) = v8.worker_fair_share.get(id) {
-                share_atom.store(my_share, Ordering::Release);
+                share_atom.store(my_share, Ordering::Relaxed);
             }
         }
-        v8.epoch.epoch_start_ns.store(now_ns, Ordering::Release);
-        // Publish completion: seq ODD→EVEN.
+        v8.epoch.epoch_start_ns.store(now_ns, Ordering::Relaxed);
+        // Publish completion: seq ODD→EVEN. This Release is the seqlock
+        // publish that synchronizes-with the reader's fenced-Acquire
+        // re-read (#1643); all payload stores above happen-before it in
+        // this single rotation-winner thread's program order.
         v8.epoch.epoch_seq.store(seq + 2, Ordering::Release);
     }
 }

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
@@ -217,8 +217,7 @@ impl SharedCoSQueueLease {
         //   * `elapsed` is the wall-clock lag bounded by `K × EPOCH`
         //     (`MAX_ROTATION_LAG_EPOCHS`) — recovers the rate credit the
         //     old `.min(EPOCH)` clamp discarded for a low-rate class that
-        //     is only visited intermittently, while keeping the per-class
-        //     post-stall burst hard-bounded to `K × rate × EPOCH`;
+        //     is only visited intermittently;
         //   * `carry_draw` releases a bounded slice of the banked deficit
         //     accrued when a single lag exceeded `K × EPOCH`.
         //
@@ -266,9 +265,7 @@ impl SharedCoSQueueLease {
 
         let (elapsed_ns, carry_draw) = if start == 0 || raw_elapsed_ns > stall_window_ns {
             // REGIME 3 — cold-resume. One epoch, drop any stale carry.
-            if start != 0 {
-                v8.epoch.epoch_carry_bytes.store(0, Ordering::Release);
-            }
+            v8.epoch.epoch_carry_bytes.store(0, Ordering::Release);
             (EPOCH_DURATION_NS, 0u64)
         } else if raw_elapsed_ns > k_window_ns {
             // REGIME 2 — bank residual beyond the K-epoch ceiling. Grant

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
@@ -1072,6 +1072,23 @@ fn v8_carry_first_rotation_is_cold_resume_single_epoch() {
 }
 
 #[test]
+fn v8_carry_first_rotation_drops_stale_carry_even_with_zero_start() {
+    let lease = carry_test_lease();
+    lease
+        .v8
+        .as_ref()
+        .unwrap()
+        .epoch
+        .epoch_carry_bytes
+        .store(CAP_PER_EPOCH_100M, Ordering::Release);
+
+    let _ = lease.acquire_v8(0, EPOCH_DURATION_NS, u64::MAX);
+
+    assert_eq!(published_cap(&lease), CAP_PER_EPOCH_100M);
+    assert_eq!(published_carry(&lease), 0, "start==0 cold-resume drops stale carry");
+}
+
+#[test]
 fn v8_carry_normal_recovery_recovers_lagged_credit() {
     // THE cause-1 fix. A lag within K epochs (regime 1) must grant the
     // FULL lagged credit (`rate × lag`), not the clamped single epoch the

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
@@ -1183,16 +1183,91 @@ fn v8_carry_per_rotation_grant_never_exceeds_k_epoch_ceiling() {
         CARRY_MAX_EPOCHS * CAP_PER_EPOCH_100M,
         "reservoir clamps at CARRY_MAX_EPOCHS even for a near-STALL lag"
     );
-    // Single on-time visit drains the bounded slice.
-    let t2 = t1 + EPOCH_DURATION_NS;
+    // WORST-CASE regime-1 drain: a lag of EXACTLY K×EPOCH is the largest
+    // raw lag that still selects regime 1 (regime 2 is `raw > K×EPOCH`), so
+    // base = K epochs AND the full reservoir drain adds (K−1) epochs — the
+    // tight `(2K−1)×rate×EPOCH` per-rotation maximum.
+    let t2 = t1 + MAX_ROTATION_LAG_EPOCHS * EPOCH_DURATION_NS;
     let _ = lease.acquire_v8(0, t2, u64::MAX);
     let ceiling = (MAX_ROTATION_LAG_EPOCHS + CARRY_DRAIN_MAX_EPOCHS) * CAP_PER_EPOCH_100M;
+    assert_eq!(
+        published_cap(&lease),
+        ceiling,
+        "worst-case regime-1 grant equals exactly the (2K−1)-epoch ceiling"
+    );
     assert!(
         published_cap(&lease) <= ceiling,
-        "single-rotation grant {} must not exceed (K + drain) ceiling {}",
+        "single-rotation grant {} must not exceed (2K−1) ceiling {}",
         published_cap(&lease),
         ceiling
     );
+}
+
+#[test]
+fn v8_carry_regime_boundaries_use_exact_nanoseconds_not_floored_epochs() {
+    // Codex r1 Major/Medium: regime selection must compare EXACT wall-clock
+    // nanoseconds, not a floored epoch count. A floored `lag = raw/EPOCH`
+    // would (a) admit a regime-1 lag up to `(K+1)×EPOCH − 1ns` (breaching
+    // the per-rotation burst bound by one epoch), and (b) skip regime-3
+    // cold-resume for a raw lag of `STALL×EPOCH + 1ns` (floors to STALL),
+    // banking instead of dropping stale carry across an HA gap.
+    //
+    // (a) K-window upper edge: raw lag = (K+1)×EPOCH − 1ns must be REGIME 2
+    // (grants exactly the K-epoch ceiling), NOT regime 1 with a near-(K+1)
+    // base grant.
+    {
+        let lease = carry_test_lease();
+        let t0 = EPOCH_DURATION_NS;
+        let _ = lease.acquire_v8(0, t0, u64::MAX);
+        let raw = (MAX_ROTATION_LAG_EPOCHS + 1) * EPOCH_DURATION_NS - 1;
+        let _ = lease.acquire_v8(0, t0 + raw, u64::MAX);
+        assert_eq!(
+            published_cap(&lease),
+            MAX_ROTATION_LAG_EPOCHS * CAP_PER_EPOCH_100M,
+            "raw lag just under (K+1) epochs is regime 2 (K-epoch ceiling), not a near-(K+1) regime-1 grant"
+        );
+    }
+    // (b) STALL upper edge: raw lag = STALL×EPOCH + 1ns must be REGIME 3
+    // (cold-resume, drop carry), NOT regime 2 (bank).
+    {
+        let lease = carry_test_lease();
+        let t0 = EPOCH_DURATION_NS;
+        let _ = lease.acquire_v8(0, t0, u64::MAX);
+        // First bank a residual so there is carry to (not) preserve.
+        let t1 = t0 + (MAX_ROTATION_LAG_EPOCHS + 3) * EPOCH_DURATION_NS;
+        let _ = lease.acquire_v8(0, t1, u64::MAX);
+        assert!(published_carry(&lease) > 0, "carry banked");
+        let raw = STALL_THRESHOLD_EPOCHS * EPOCH_DURATION_NS + 1;
+        let _ = lease.acquire_v8(0, t1 + raw, u64::MAX);
+        assert_eq!(
+            published_cap(&lease),
+            CAP_PER_EPOCH_100M,
+            "raw lag just over STALL is regime-3 cold-resume (one epoch)"
+        );
+        assert_eq!(
+            published_carry(&lease),
+            0,
+            "regime-3 at the exact STALL+1ns boundary drops stale carry"
+        );
+    }
+    // Lower edge of regime 3 / upper edge of regime 2: raw lag = exactly
+    // STALL×EPOCH must still be REGIME 2 (banks), proving the `>` is strict.
+    {
+        let lease = carry_test_lease();
+        let t0 = EPOCH_DURATION_NS;
+        let _ = lease.acquire_v8(0, t0, u64::MAX);
+        let raw = STALL_THRESHOLD_EPOCHS * EPOCH_DURATION_NS;
+        let _ = lease.acquire_v8(0, t0 + raw, u64::MAX);
+        assert_eq!(
+            published_cap(&lease),
+            MAX_ROTATION_LAG_EPOCHS * CAP_PER_EPOCH_100M,
+            "raw lag of exactly STALL epochs is still regime 2 (banks), not regime 3"
+        );
+        assert!(
+            published_carry(&lease) > 0,
+            "exactly-STALL lag banks the residual (not a cold-resume drop)"
+        );
+    }
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
@@ -1008,3 +1008,269 @@ fn bypass_starvation_events_swap_at_rotation() {
     assert!(new_tag > tag, "rotation incremented tag");
     assert_eq!(count, 0, "rotation reset count to 0");
 }
+
+// === #1630 (cause-1): bounded rotation credit carry ===
+//
+// `maybe_rotate_epoch_v8` is purely lazy — a low-rate exact class is only
+// rotated when the scheduler next visits its queue, so the gap between two
+// rotations of the SAME queue routinely exceeds one epoch. The pre-#1630
+// clamp computed `elapsed = min(lag, EPOCH)` and reset `epoch_start := now`,
+// permanently discarding `rate × (lag − EPOCH)` of grant per lagged
+// rotation and pinning the lowest-rate classes below shape. These tests
+// pin the bounded-carry replacement and the burst bound (the invariant the
+// clamp protected) so a future refactor that re-clamps, removes a regime,
+// or unbounds the carry fails loudly in CI.
+//
+// All tests drive the rotation through the public `acquire_v8` entrypoint
+// (it rotates then snapshots) and read the published `epoch_total_grant_cap`
+// directly — the cap is the rate-meter the carry enlarges. 100 Mbps =
+// 12.5 MB/s, so `rate × EPOCH = 12_500_000 × 200µs = 2500 B`.
+
+const RATE_100M: u64 = 12_500_000;
+const CAP_PER_EPOCH_100M: u64 = 2_500; // rate × EPOCH_DURATION_NS
+
+fn carry_test_lease() -> SharedCoSQueueLease {
+    // active_shards/burst chosen large enough that the per-class cap, not
+    // the outstanding-credit cap, is the binding limiter for these reads.
+    let lease = SharedCoSQueueLease::new_v8(RATE_100M, 4_000_000, 8, 0);
+    lease.rehydrate_worker_active_count(0, 1);
+    lease
+}
+
+fn published_cap(lease: &SharedCoSQueueLease) -> u64 {
+    lease
+        .v8
+        .as_ref()
+        .unwrap()
+        .epoch
+        .epoch_total_grant_cap
+        .load(Ordering::Acquire)
+}
+
+fn published_carry(lease: &SharedCoSQueueLease) -> u64 {
+    lease
+        .v8
+        .as_ref()
+        .unwrap()
+        .epoch
+        .epoch_carry_bytes
+        .load(Ordering::Acquire)
+}
+
+#[test]
+fn v8_carry_first_rotation_is_cold_resume_single_epoch() {
+    // start == 0 → regime 3 cold-resume → exactly one epoch of grant,
+    // identical to the pre-#1630 first-rotation behavior. No carry banked.
+    let lease = carry_test_lease();
+    let _ = lease.acquire_v8(0, EPOCH_DURATION_NS, u64::MAX);
+    assert_eq!(
+        published_cap(&lease),
+        CAP_PER_EPOCH_100M,
+        "first (start==0) rotation grants exactly one epoch"
+    );
+    assert_eq!(published_carry(&lease), 0, "cold-resume banks no carry");
+}
+
+#[test]
+fn v8_carry_normal_recovery_recovers_lagged_credit() {
+    // THE cause-1 fix. A lag within K epochs (regime 1) must grant the
+    // FULL lagged credit (`rate × lag`), not the clamped single epoch the
+    // old code gave. This is exactly the per-class shape loss being fixed.
+    let lease = carry_test_lease();
+    let t0 = EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t0, u64::MAX); // cold-resume, start := t0
+    // Second visit 5 epochs later (lag = 5 ≤ K=8 → regime 1).
+    let lag_epochs = 5u64;
+    let _ = lease.acquire_v8(0, t0 + lag_epochs * EPOCH_DURATION_NS, u64::MAX);
+    assert_eq!(
+        published_cap(&lease),
+        lag_epochs * CAP_PER_EPOCH_100M,
+        "regime-1 recovery grants the full lagged credit (was clamped to 1 epoch pre-#1630)"
+    );
+}
+
+#[test]
+fn v8_carry_bank_residual_no_cliff_at_k_plus_one() {
+    // Gate 5d: a lag just beyond K (regime 2) must NOT drop to a single
+    // epoch (the v2 cliff). It grants the K-epoch ceiling NOW and banks
+    // the residual `rate × (lag − K×EPOCH)` for the next visit.
+    let lease = carry_test_lease();
+    let t0 = EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t0, u64::MAX);
+    let lag_epochs = MAX_ROTATION_LAG_EPOCHS + 4; // 12 epochs at K=8
+    let _ = lease.acquire_v8(0, t0 + lag_epochs * EPOCH_DURATION_NS, u64::MAX);
+    assert_eq!(
+        published_cap(&lease),
+        MAX_ROTATION_LAG_EPOCHS * CAP_PER_EPOCH_100M,
+        "regime-2 grants exactly the K-epoch ceiling (no cliff to 1 epoch)"
+    );
+    // Residual = (lag − K) epochs of rate, banked.
+    let residual = (lag_epochs - MAX_ROTATION_LAG_EPOCHS) * CAP_PER_EPOCH_100M;
+    assert_eq!(
+        published_carry(&lease),
+        residual,
+        "regime-2 banks the residual beyond the K-epoch window"
+    );
+}
+
+#[test]
+fn v8_carry_banked_residual_drains_on_next_visit() {
+    // The banked residual (regime 2) must be released on the next
+    // on-time visit (regime 1 draw), bounded by the per-epoch drain cap.
+    let lease = carry_test_lease();
+    let t0 = EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t0, u64::MAX);
+    // Bank a residual: lag K+2 → banks 2 epochs of rate.
+    let lag1 = MAX_ROTATION_LAG_EPOCHS + 2;
+    let t1 = t0 + lag1 * EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t1, u64::MAX);
+    let banked = published_carry(&lease);
+    assert_eq!(banked, 2 * CAP_PER_EPOCH_100M, "2 epochs banked");
+    // Next on-time visit (lag = 1 epoch → regime 1) drains the carry on
+    // top of the base epoch grant.
+    let t2 = t1 + EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t2, u64::MAX);
+    assert!(
+        published_cap(&lease) > CAP_PER_EPOCH_100M,
+        "next visit drains banked carry on top of base epoch grant"
+    );
+    assert!(
+        published_carry(&lease) < banked,
+        "carry reservoir shrinks as it drains"
+    );
+}
+
+#[test]
+fn v8_carry_burst_bound_holds_after_two_second_stall() {
+    // Gate 5 (burst bound) — the invariant the old clamp protected. A
+    // worker stalled 2 s then resumed must NOT receive a `rate × 2s`
+    // one-shot grant (= 25 MB). lag = 2s ≫ STALL → regime-3 cold-resume
+    // → exactly one epoch. This is the burst the unclamped probe risked.
+    let lease = carry_test_lease();
+    let t0 = EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t0, u64::MAX);
+    let two_seconds = 2_000_000_000u64;
+    let _ = lease.acquire_v8(0, t0 + two_seconds, u64::MAX);
+    assert_eq!(
+        published_cap(&lease),
+        CAP_PER_EPOCH_100M,
+        "2 s stall cold-resumes to ONE epoch, not rate × 2 s"
+    );
+    // Sanity: rate × 2 s would have been 25 MB — assert we are far below.
+    assert!(
+        published_cap(&lease) < RATE_100M * 2,
+        "cap must be nowhere near the unbounded rate × stall grant"
+    );
+}
+
+#[test]
+fn v8_carry_per_rotation_grant_never_exceeds_k_epoch_ceiling() {
+    // Stronger burst bound: across ANY single rotation, including one
+    // that drains a full reservoir in regime 1, the published cap is
+    // bounded by `(2K − 1) × rate × EPOCH`. Drive the worst case: bank a
+    // full reservoir (regime 2 with a huge-but-below-STALL lag), then a
+    // single on-time visit that drains the reservoir.
+    let lease = carry_test_lease();
+    let t0 = EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t0, u64::MAX);
+    // Lag below STALL but large enough to fill the reservoir to its cap.
+    let lag = STALL_THRESHOLD_EPOCHS - 1;
+    let t1 = t0 + lag * EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t1, u64::MAX);
+    // Reservoir is clamped at CARRY_MAX_EPOCHS × rate × EPOCH.
+    assert_eq!(
+        published_carry(&lease),
+        CARRY_MAX_EPOCHS * CAP_PER_EPOCH_100M,
+        "reservoir clamps at CARRY_MAX_EPOCHS even for a near-STALL lag"
+    );
+    // Single on-time visit drains the bounded slice.
+    let t2 = t1 + EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t2, u64::MAX);
+    let ceiling = (MAX_ROTATION_LAG_EPOCHS + CARRY_DRAIN_MAX_EPOCHS) * CAP_PER_EPOCH_100M;
+    assert!(
+        published_cap(&lease) <= ceiling,
+        "single-rotation grant {} must not exceed (K + drain) ceiling {}",
+        published_cap(&lease),
+        ceiling
+    );
+}
+
+#[test]
+fn v8_carry_cold_resume_drops_stale_carry_for_ha_failback() {
+    // Gate 6 (HA): leases are REUSED across an HA demote→promote when the
+    // config matches, so `epoch_start` survives. A long demotion gap on a
+    // reused lease must NOT replay a banked deficit or a multi-epoch
+    // burst. Bank a residual, then simulate a >STALL failback gap and
+    // assert the next grant is a single epoch with the stale carry dropped.
+    let lease = carry_test_lease();
+    let t0 = EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t0, u64::MAX);
+    // Bank a residual via a regime-2 lag.
+    let t1 = t0 + (MAX_ROTATION_LAG_EPOCHS + 3) * EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t1, u64::MAX);
+    assert!(published_carry(&lease) > 0, "carry banked before failback");
+    // Demotion gap well beyond STALL (failback ≥ 500 epochs).
+    let t2 = t1 + (STALL_THRESHOLD_EPOCHS + 1000) * EPOCH_DURATION_NS;
+    let _ = lease.acquire_v8(0, t2, u64::MAX);
+    assert_eq!(
+        published_cap(&lease),
+        CAP_PER_EPOCH_100M,
+        "post-failback first grant on a REUSED lease is one epoch (no K-epoch burst)"
+    );
+    assert_eq!(
+        published_carry(&lease),
+        0,
+        "cold-resume drops the stale carry so it cannot replay across the gap"
+    );
+}
+
+#[test]
+fn v8_carry_field_is_reader_private() {
+    // Gate 5b (carry-reader-private guard). `epoch_carry_bytes` must be
+    // written/read ONLY by the rotation winner inside the seqlock ODD
+    // section. If it ever leaks into the acquire/snapshot reader path or
+    // the coordinator status path it re-introduces the #1619 seqlock
+    // tearing class for the carry. Grep the crate source: the only
+    // references allowed are the field definition + its initializer in
+    // mod.rs, and the rotation read/write in rotate_epoch_v8.rs, and this
+    // test file. Any reference in acquire_v8 / snapshot_epoch_v8 /
+    // coordinator/status.rs is a regression.
+    use std::path::Path;
+    let crate_src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    let allowed = [
+        // field def + initializer + doc live in the lease mod.rs
+        "afxdp/types/shared_cos_lease/mod.rs",
+        // the single legitimate writer/reader: the rotation winner
+        "afxdp/types/shared_cos_lease/rotate_epoch_v8.rs",
+        // this test file
+        "afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs",
+    ];
+    fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let p = entry.unwrap().path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(p);
+            }
+        }
+    }
+    let mut files = Vec::new();
+    walk(&crate_src, &mut files);
+    for f in files {
+        let rel = f.strip_prefix(&crate_src).unwrap().to_string_lossy().replace('\\', "/");
+        if allowed.iter().any(|a| rel == *a) {
+            continue;
+        }
+        let body = std::fs::read_to_string(&f).unwrap();
+        if body.contains("epoch_carry_bytes") {
+            offenders.push(rel);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "epoch_carry_bytes is rotation-private; unexpected references in: {:?}",
+        offenders
+    );
+}

--- a/userspace-dp/src/afxdp/worker/README.md
+++ b/userspace-dp/src/afxdp/worker/README.md
@@ -63,8 +63,13 @@ each cluster has a clear ownership boundary.
   there with a `const _: () = assert!(MAX_RX_BATCHES_PER_POLL >= 1);`
   compile-time guard in `worker/lifecycle.rs`. The guard pins the
   lower bound only — there is no compile-time pin on the value 4
-  itself; change it deliberately and re-run the
-  `guarantee_phase_*_visit_quantum` tests.
+  itself; change it deliberately and re-run the guarantee-phase
+  per-visit budget tests (`guarantee_phase_visit_cap_drains_banked_frames`
+  and `guarantee_phase_allows_larger_high_rate_visit_quantum`). #1630 (P2)
+  split the per-visit budget into a rate-scaled Phase-1 cost
+  (`cos_guarantee_quantum_bytes`) and a FRAME-count send cap
+  (`cos_guarantee_visit_cap_bytes` = `TX_BATCH_SIZE × frame`); the
+  `TX_BATCH_SIZE` const-assert covers the latter.
 - Binding creation must publish the selected shared-UMEM mode/group/role
   into `BindingLiveState` for both private and shared paths before the
   first coordinator refresh. The coordinator treats the live snapshot as


### PR DESCRIPTION
## Summary

The lowest-rate CoS exact classes could not reach their configured shape even SOLO: 100m ~81%, 1g ~84%. A SOLO A/B isolated **two distinct root causes**. This PR ships the **cause-1** fix (the actionable scheduler fix) and documents **cause-2** as a transport-physics floor.

`Closes #1630` — cause-1 carry + #1643 fence fix the classes that can be fixed (100m/1g SOLO 81/84% → **95.0/95.3%**); cause-2 (the K-independent ~6% mid-rate 3g/6g residual) was measured to be ACK-clocked single-flow token-bucket fill physics (improves with parallelism, root never throttles), documented in `fairness-regimes.md`, not a scheduler defect. #1614 (broader 11-class simul umbrella) stays open for separate re-scoping.

`Closes #1643`

## Cause-1: the v8 epoch rotation rate-meter

Rotation is purely lazy — a low-rate class is only rotated when the scheduler next visits its queue, so the lag between two rotations of the same queue routinely exceeds one epoch. The old STEP-6 clamp computed `elapsed = min(lag, EPOCH)` and reset `epoch_start := now`, permanently discarding `rate × (lag − EPOCH)` of grant per lagged rotation.

### Fix: bounded credit carry (`rotate_epoch_v8` STEP 6), three regimes
Regime boundaries compared on **exact wall-clock nanoseconds** (not floored epoch counts):
- **Regime 1** (raw ≤ K×EPOCH): grant full lagged credit, drain a bounded carry slice.
- **Regime 2** (K×EPOCH < raw ≤ STALL×EPOCH): grant the K-epoch ceiling now, bank the residual into a clamped carry deficit drained next visit (no cliff).
- **Regime 3** (raw > STALL×EPOCH, or start == 0): cold-resume to one epoch, DROP carry.

`K = 8`, `STALL = 256` epochs (≈51 ms, below the ≥500-epoch failback gap). Reservoir clamped at `K × rate × EPOCH`, drain at `(K−1) × rate × EPOCH` → a single rotation can never grant more than `(2K−1) × rate × EPOCH`, preserving the per-class burst bound the old clamp protected. `epoch_carry_bytes` is rotation-private (single-writer in the seqlock ODD section, never in the snapshot payload); a grep test enforces it is never read from acquire/snapshot/status so it cannot re-introduce the #1619 tearing class.

### HA-failover safety
Leases are REUSED across an HA demote→promote when config matches, so `epoch_start` survives and the first post-promotion rotation sees `lag ≈ demotion_duration`. Regime 3 cold-resumes that to a single-epoch grant and drops stale carry → no multi-epoch failback burst. Validated by `make test-failover` (13/0).

## #1643 (folded in — same seqlock)
`snapshot_epoch_v8` was missing the `fence(Acquire)` between the payload loads and the `seq_after` re-read, so on a weakly-ordered CPU `seq_after` could be observed before the payload loads retire and the even-equal check could pass against torn cross-epoch data. Downgraded payload loads/stores to Relaxed and added the fence, mirroring the verified-correct `cold_path_hist::snapshot` reference. Audited every reader of the three payload fields: only the fenced snapshot reads them concurrently.

## Composing P2 + P1 (genuine prereqs, confirmed by the SOLO A/B)
The guarantee selectors clamped each visit's send budget to the rate-scaled quantum (`rate × 200 µs`, below two MTUs for a low-rate class), sending one frame and discarding the sub-frame remainder every visit. Split the per-visit budget: Phase-1 gate keeps the rate-scaled quantum (small-first ordering preserved); send budget is a FRAME-count cap (`cos_guarantee_visit_cap_bytes` = `TX_BATCH_SIZE × frame`). Bank an N-frame burst in the exact-queue bucket (N=8) with the outstanding-credit cap raised in lock-step. Long-run rate is still metered by the v8 per-epoch grant + actual-byte debit, so Gate 4 holds.

## Validation
- **Unit tests**: `cargo test --bin xpf-userspace-dp` **1543 passed / 0 failed**. 9 new carry tests (recovery, no-cliff, drain, burst-bound, exact-ns regime boundaries, worst-case (2K−1) ceiling, HA reused-lease cold-resume, reader-private grep guard) + 4 updated P2 tests.
- **Scoped Gate-1 SOLO (v4 push, reproducible)**: 100m **95.0%**, 1g **95.3%** of shape — PASS. (Baseline 81% / 84%.) Four-parallel and v6 land 1-3 pp lower at the cause-2 physics floor — reported for the record, not the pass bar.
- **`make test-failover`: 13 passed / 0 failed** — unclean fw0 reboot → failover → rejoin → manual failover, iperf3 zero-drop.

## Reviews (4-of-4 addressed)
- **Claude SMR**: MERGE-READY (`docs/pr/1630-cause1-credit-carry/claude-smr-code-r1.md`).
- **Codex**: 1 Major + 1 Medium (floored-boundary) → both FIXED (`4a2b998f7`).
- **AGY**: MERGE-READY across 6 axes, no findings.
- **Copilot**: same boundary Major (fixed) + plan.md doc nit (fixed `7e6f7115f`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)