### PR TITLE
#1641: trim NAT64 reverse-path L4 payload to IPv4 Total Length (MAJOR)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,19 @@
 # Action Log
 
+## 2026-05-29 — #1641 NAT64 reverse-path Ethernet padding fix
+- **Timestamp**: 2026-05-29 UTC
+- **Action**: Fixed `translate_v4_to_v6` in the userspace-dp NAT64
+  reverse path to trim the L4 payload to the IPv4 Total Length field
+  instead of the end of the (possibly Ethernet-padded) input slice.
+  Padding had been inflating IPv6 `payload_len` and poisoning the
+  recomputed L4 checksum, dropping every padded reply. Clamp rejects
+  malformed `total_len` (< ihl or > slice). Added 4 regression tests in
+  `nat64_tests.rs` (padded payload-less TCP segment, padded UDP/DNS reply,
+  oversized and undersized total_len). Verified fail-before (payload_len
+  26 vs 20) / pass-after. Documented in docs/bugs.md.
+- **File(s)**: userspace-dp/src/nat64.rs, userspace-dp/src/nat64_tests.rs,
+  docs/bugs.md
+
 ## 2026-05-29 — #1646 frr writeManagedSection torn-write hardening
 - **Timestamp**: 2026-05-29 UTC
 - **Action**: Hardened `writeManagedSection` in pkg/frr/manager.go against

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -127,6 +127,31 @@
 - **Fix:** Added `else if (orig_proto == PROTO_ICMPV6) { old_sport = meta->dst_port; }` — `meta->dst_port` retains original echo ID since policy only changes `src_port`
 - **File:** `bpf/xdp/xdp_nat64.c` line 282
 
+### NAT64 reverse path copies Ethernet padding into IPv6 payload (#1641)
+- **Severity:** MAJOR — reverse-path packet corruption / L4 checksum failure
+- **Symptom:** Every TCP/UDP/ICMPv6 NAT64 reply whose original IPv4
+  packet was Ethernet-padded (< 64B on the wire: ACKs, DNS replies,
+  short HTTP responses) is dropped by the IPv6 client
+- **Root cause:** `translate_v4_to_v6` (userspace-dp Rust path) read
+  `l4_payload = packet.get(ihl..)` — every byte from the IPv4 header to
+  the end of the slice. The caller passes the whole L3-onward frame,
+  including any Ethernet padding the NIC/driver added to reach the
+  60-byte minimum. That padding inflated the IPv6 `payload_len` and was
+  fed into the recomputed L4 checksum (wrong pseudo-header length), so
+  the receiver's checksum verification failed
+- **Fix:** Trim the L4 slice to the IPv4 Total Length field
+  (`packet[2..4]`), mirroring the forward path which trims to the IPv6
+  `payload_len`. Clamp safely: reject `total_len < ihl` or
+  `total_len > packet.len()` (malformed/oversized header) before
+  slicing, so a crafted header cannot panic or read OOB
+- **Regression test:** `nat64_tests.rs`
+  `translate_v4_to_v6_trims_ethernet_padding_{tcp,udp_dns}` feed a
+  zero-padded 46B L3 slice and assert the translated IPv6 `payload_len`
+  excludes the padding and the L4 checksum verifies; plus
+  `translate_v4_to_v6_total_len_{larger_than_slice,below_ihl}_returns_none`
+  for the malformed-length clamp
+- **File:** `userspace-dp/src/nat64.rs`
+
 ### ipToUint32BE byte order
 - `binary.BigEndian.Uint32(ip4)` produced wrong bytes when cilium/ebpf serializes as native-endian
 - **Fix:** Use `binary.NativeEndian.Uint32(ip4)` so bytes match raw network order BPF writes to `__be32`

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -225,7 +225,22 @@ pub(crate) fn translate_v4_to_v6(
         return None; // TTL expired
     }
     let protocol = packet[9];
-    let l4_payload = packet.get(ihl..)?;
+    // Trim the L4 payload to the IPv4 Total Length field rather than the end
+    // of the slice. The caller passes the whole L3-onward frame, which may
+    // include Ethernet padding appended to reach the 60/64-byte minimum frame
+    // size (common for TCP ACKs, DNS replies, short HTTP). Copying that padding
+    // into the IPv6 packet inflates payload_len and poisons the recomputed L4
+    // checksum, so the receiver drops the reply. This mirrors the forward path
+    // (translate_v6_to_v4) which trims to the IPv6 payload_len field.
+    //
+    // total_len is attacker/driver-controlled, so clamp safely: a malformed
+    // header could advertise a length shorter than the IPv4 header or longer
+    // than the bytes we actually received.
+    let total_len = u16::from_be_bytes([packet[2], packet[3]]) as usize;
+    if total_len < ihl || total_len > packet.len() {
+        return None;
+    }
+    let l4_payload = packet.get(ihl..total_len)?;
 
     // Map protocol.
     let next_header = match protocol {

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -236,11 +236,11 @@ pub(crate) fn translate_v4_to_v6(
     // total_len is attacker/driver-controlled, so clamp safely: a malformed
     // header could advertise a length shorter than the IPv4 header or longer
     // than the bytes we actually received.
-    let total_len = u16::from_be_bytes([packet[2], packet[3]]) as usize;
-    if total_len < ihl || total_len > packet.len() {
+    let ipv4_total_len = u16::from_be_bytes([packet[2], packet[3]]) as usize;
+    if ipv4_total_len < ihl || ipv4_total_len > packet.len() {
         return None;
     }
-    let l4_payload = packet.get(ihl..total_len)?;
+    let l4_payload = packet.get(ihl..ipv4_total_len)?;
 
     // Map protocol.
     let next_header = match protocol {
@@ -251,8 +251,8 @@ pub(crate) fn translate_v4_to_v6(
 
     let new_hop_limit = ttl - 1;
     let ipv6_payload_len = l4_payload.len() as u16;
-    let total_len = 40 + l4_payload.len();
-    let mut out = vec![0u8; total_len];
+    let ipv6_total_len = 40 + l4_payload.len();
+    let mut out = vec![0u8; ipv6_total_len];
 
     // Build IPv6 header.
     out[0] = 0x60; // version=6

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -433,3 +433,138 @@ fn frame_building_v6_to_v4_with_vlan() {
     assert_eq!(u16::from_be_bytes([result[12], result[13]]), 0x8100);
     assert_eq!(u16::from_be_bytes([result[16], result[17]]), 0x0800);
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests for #1641: translate_v4_to_v6 must trim the L4 payload to
+// the IPv4 Total Length field, not the end of the input slice. The caller
+// passes the whole L3-onward frame, which can carry Ethernet padding when the
+// reply is shorter than the 60/64-byte minimum frame size. Before the fix the
+// padding was copied into the IPv6 packet, inflating payload_len and poisoning
+// the L4 checksum so the receiver dropped the reply.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn translate_v4_to_v6_trims_ethernet_padding_tcp() {
+    let src_v4 = Ipv4Addr::new(198, 51, 100, 50);
+    let dst_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let src_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let dst_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+
+    // A bare TCP ACK: 20B IP + 20B TCP, no L4 payload = 40B on the wire. The
+    // NIC/driver pads the frame to the 60-byte L2 minimum, so the L3-onward
+    // slice the caller hands us is 46 bytes (40B real + 6B zero padding).
+    let mut packet = make_ipv4_tcp_packet(src_v4, dst_v4, 80, 12345, b"");
+    assert_eq!(packet.len(), 40, "unpadded ACK should be 40 bytes");
+    let real_len = packet.len();
+    packet.extend_from_slice(&[0u8; 6]); // simulate trailing Ethernet padding
+    assert_eq!(packet.len(), 46);
+
+    let ipv6_pkt = translate_v4_to_v6(&packet, src_v6, dst_v6).expect("translate");
+
+    // payload_len must reflect the real L4 length (20B TCP), NOT the padded
+    // slice length. Before the fix this was 26 (20 + 6 padding bytes).
+    let payload_len = u16::from_be_bytes([ipv6_pkt[4], ipv6_pkt[5]]) as usize;
+    assert_eq!(payload_len, 20, "payload_len must exclude Ethernet padding");
+    // Total translated length = 40B IPv6 header + 20B TCP, with no padding.
+    assert_eq!(ipv6_pkt.len(), 40 + (real_len - 20));
+    assert_eq!(ipv6_pkt.len(), 60);
+
+    // The L4 checksum must verify over the trimmed payload. A padding-poisoned
+    // checksum (the pre-fix bug) leaves a non-zero residual here.
+    let src6 = Ipv6Addr::from(<[u8; 16]>::try_from(&ipv6_pkt[8..24]).unwrap());
+    let dst6 = Ipv6Addr::from(<[u8; 16]>::try_from(&ipv6_pkt[24..40]).unwrap());
+    assert_eq!(
+        checksum16_ipv6_pseudo(src6, dst6, PROTO_TCP, &ipv6_pkt[40..]),
+        0,
+        "TCP checksum must verify over the unpadded payload"
+    );
+}
+
+#[test]
+fn translate_v4_to_v6_trims_ethernet_padding_udp_dns() {
+    // Short UDP/DNS reply (the canonical Ethernet-padded case). Build a 12B
+    // DNS-ish payload: 20B IP + 8B UDP + 12B = 40B real, padded to 46B.
+    let src_v4 = Ipv4Addr::new(8, 8, 8, 8);
+    let dst_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let src_v6: Ipv6Addr = "64:ff9b::0808:0808".parse().unwrap();
+    let dst_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+
+    let dns = b"\x00\x01\x81\x80\x00\x01\x00\x00\x00\x00\x00\x00";
+    let udp_len = 8 + dns.len();
+    let total_len = 20 + udp_len;
+    let mut packet = vec![0u8; total_len];
+    packet[0] = 0x45;
+    packet[2..4].copy_from_slice(&(total_len as u16).to_be_bytes());
+    packet[6..8].copy_from_slice(&0x4000u16.to_be_bytes());
+    packet[8] = 64;
+    packet[9] = PROTO_UDP;
+    packet[12..16].copy_from_slice(&src_v4.octets());
+    packet[16..20].copy_from_slice(&dst_v4.octets());
+    packet[10..12].copy_from_slice(&[0, 0]);
+    let ip_sum = checksum16(&packet[..20]);
+    packet[10..12].copy_from_slice(&ip_sum.to_be_bytes());
+    packet[20..22].copy_from_slice(&53u16.to_be_bytes()); // src port
+    packet[22..24].copy_from_slice(&12345u16.to_be_bytes()); // dst port
+    packet[24..26].copy_from_slice(&(udp_len as u16).to_be_bytes());
+    packet[28..28 + dns.len()].copy_from_slice(dns);
+    packet[26..28].copy_from_slice(&[0, 0]);
+    let udp_sum = checksum16_ipv4_pseudo(src_v4, dst_v4, PROTO_UDP, &packet[20..]);
+    packet[26..28].copy_from_slice(&udp_sum.to_be_bytes());
+
+    assert_eq!(packet.len(), 40);
+    packet.extend_from_slice(&[0u8; 6]); // Ethernet padding to 46B L3 slice
+
+    let v6 = translate_v4_to_v6(&packet, src_v6, dst_v6).expect("translate");
+    let payload_len = u16::from_be_bytes([v6[4], v6[5]]) as usize;
+    assert_eq!(payload_len, udp_len, "payload_len must exclude padding");
+    assert_eq!(v6.len(), 40 + udp_len);
+
+    let s6 = Ipv6Addr::from(<[u8; 16]>::try_from(&v6[8..24]).unwrap());
+    let d6 = Ipv6Addr::from(<[u8; 16]>::try_from(&v6[24..40]).unwrap());
+    assert_eq!(
+        checksum16_ipv6_pseudo(s6, d6, PROTO_UDP, &v6[40..]),
+        0,
+        "UDP checksum must verify over the unpadded payload"
+    );
+}
+
+#[test]
+fn translate_v4_to_v6_total_len_larger_than_slice_returns_none() {
+    // Malformed Total Length advertising more bytes than we received: must be
+    // rejected safely (no panic, no out-of-bounds), not trusted.
+    let src_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let dst_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let mut packet = make_ipv4_tcp_packet(
+        Ipv4Addr::new(198, 51, 100, 50),
+        Ipv4Addr::new(198, 51, 100, 1),
+        80,
+        12345,
+        b"hi",
+    );
+    // Advertise a Total Length 100 bytes beyond the actual slice.
+    let bogus = (packet.len() + 100) as u16;
+    packet[2..4].copy_from_slice(&bogus.to_be_bytes());
+    assert!(
+        translate_v4_to_v6(&packet, src_v6, dst_v6).is_none(),
+        "oversized total_len must be rejected"
+    );
+}
+
+#[test]
+fn translate_v4_to_v6_total_len_below_ihl_returns_none() {
+    // Total Length shorter than the IPv4 header is nonsensical: reject it.
+    let src_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let dst_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let mut packet = make_ipv4_tcp_packet(
+        Ipv4Addr::new(198, 51, 100, 50),
+        Ipv4Addr::new(198, 51, 100, 1),
+        80,
+        12345,
+        b"hi",
+    );
+    packet[2..4].copy_from_slice(&10u16.to_be_bytes()); // < 20B IHL
+    assert!(
+        translate_v4_to_v6(&packet, src_v6, dst_v6).is_none(),
+        "total_len below the IPv4 header length must be rejected"
+    );
+}

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -450,11 +450,13 @@ fn translate_v4_to_v6_trims_ethernet_padding_tcp() {
     let src_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
     let dst_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
 
-    // A bare TCP ACK: 20B IP + 20B TCP, no L4 payload = 40B on the wire. The
-    // NIC/driver pads the frame to the 60-byte L2 minimum, so the L3-onward
-    // slice the caller hands us is 46 bytes (40B real + 6B zero padding).
+    // A minimal TCP segment with no L4 payload: 20B IP + 20B TCP = 40B on the
+    // wire (make_ipv4_tcp_packet sets SYN+ACK flags; the exact flag bits are
+    // irrelevant to the padding bug). The NIC/driver pads the frame to the
+    // 60-byte L2 minimum, so the L3-onward slice the caller hands us is 46
+    // bytes (40B real + 6B zero padding).
     let mut packet = make_ipv4_tcp_packet(src_v4, dst_v4, 80, 12345, b"");
-    assert_eq!(packet.len(), 40, "unpadded ACK should be 40 bytes");
+    assert_eq!(packet.len(), 40, "unpadded segment should be 40 bytes");
     let real_len = packet.len();
     packet.extend_from_slice(&[0u8; 6]); // simulate trailing Ethernet padding
     assert_eq!(packet.len(), 46);


### PR DESCRIPTION
**MAJOR / data-corruption.** Reverse-path NAT64 packet corruption / L4 checksum failure.

## Problem
`translate_v4_to_v6` (userspace-dp NAT64 reverse path) read the L4 payload as `packet.get(ihl..)` — every byte from the IPv4 header to the end of the input slice. The caller passes the whole L3-onward frame, which includes any Ethernet padding the NIC/driver appended to satisfy the 60/64-byte minimum frame size.

For any IPv4 reply small enough to be padded (the common case: **TCP ACKs, DNS replies, short HTTP responses**), the trailing padding was copied into the translated IPv6 packet. That inflated the IPv6 `payload_len` and was fed into the recomputed L4 checksum with the wrong pseudo-header length, so the receiving IPv6 host's checksum verification failed and it **dropped the reply**.

The forward path (`translate_v6_to_v4`) already trims correctly via the IPv6 `payload_len` field; the reverse path now mirrors it.

## Fix
Derive the L4 slice from the IPv4 Total Length field (`packet[2..4]`) and clamp safely — reject `total_len < ihl` or `total_len > packet.len()` before slicing so a malformed/oversized header cannot panic or read out of bounds.

## Tests (fail-before / pass-after verified)
In `nat64_tests.rs`:
- `translate_v4_to_v6_trims_ethernet_padding_tcp`: 40B bare ACK padded to a 46B L3 slice → IPv6 `payload_len` 20 (not 26) + verifying TCP checksum.
- `translate_v4_to_v6_trims_ethernet_padding_udp_dns`: canonical short DNS reply → `payload_len` + UDP checksum.
- `translate_v4_to_v6_total_len_{larger_than_slice,below_ihl}_returns_none`: malformed Total Length rejected, no panic.

Fail-before confirmed: all four fail on the buggy code (payload_len 26 vs 20). 5/5 flake pass-after. Pure translation logic — unit-provable; no cluster dependency.

Closes #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)