### PR TITLE
#1642: close Rust->Go control-socket status parity gaps

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,25 @@
 # Action Log
 
+## 2026-05-29 — #1642 Rust→Go status-field parity drift
+- **Timestamp**: 2026-05-29 UTC
+- **Action**: Fixed 4 field-level JSON parity gaps where the Rust helper
+  serialized status fields the Go side dropped on unmarshal (observability,
+  not HA behavior). Added to Go protocol.go: HAGroupStatus
+  {forwarding_active, lease_state, lease_until}; CoSQueueStatus
+  {root_token_starvation_parks, queue_token_starvation_parks,
+  tx_ring_full_submit_stalls}; ProcessStatus {event_stream_connected,
+  event_stream_seq, event_stream_acked}. Moved post_drain_backup_cos_drops /
+  _cos_drop_bytes from Go CoSQueueStatus to Go BindingStatus to match the
+  Rust source struct level (left post_drain_backup_bytes on CoSQueueStatus —
+  it is correctly there). Verified no existing Go consumers of the moved
+  fields. Added cross-language parity tests: Go decodes Rust-shaped JSON
+  literals (protocol_test.go *Parity1642), Rust serde wire-key pins
+  (protocol/tests.rs *_1642). 5/5 flake both sides; wire-invariant fixture
+  unaffected (no Rust fields changed).
+- **File(s)**: pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/protocol_test.go,
+  userspace-dp/src/protocol/tests.rs
+
 ## 2026-05-28 — #1630 cause-1 rotation credit carry + #1643 seqlock fence
 - **Timestamp**: 2026-05-28 UTC
 - **Action**: Implemented the scoped #1630 cause-1 fix (CoS small-class

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -582,25 +582,35 @@ type ProcessStatus struct {
 	// #1248: per-CoS-queue active flow distribution by egress ifindex,
 	// queue, and worker. This is the class-specific {a_i} source for
 	// mixed-workload fairness diagnostics.
-	CoSActiveFlowCounts          []CoSActiveFlowCountStatus        `json:"cos_active_flow_counts,omitempty"`
-	CoSActiveFlowCountsTruncated bool                              `json:"cos_active_flow_counts_truncated,omitempty"`
-	RecentSessionDeltas          []SessionDeltaInfo                `json:"recent_session_deltas,omitempty"`
-	RecentExceptions             []ExceptionStatus                 `json:"recent_exceptions,omitempty"`
-	EventStream                  *EventStreamStatus                `json:"event_stream,omitempty"`
-	EventStreamSent              uint64                            `json:"event_stream_sent,omitempty"`
-	EventStreamDropped           uint64                            `json:"event_stream_dropped,omitempty"`
-	CoSInterfaces                []CoSInterfaceStatus              `json:"cos_interfaces,omitempty"`
-	PolicyRuleCounters           []PolicyRuleCounterStatus         `json:"policy_rule_counters,omitempty"`
-	FilterTermCounters           []FirewallFilterTermCounterStatus `json:"filter_term_counters,omitempty"`
-	ThreeColorPolicerCounters    []ThreeColorPolicerStatus         `json:"three_color_policer_counters,omitempty"`
-	SourceNATPools               []SourceNATPoolStatus             `json:"source_nat_pools,omitempty"`
-	LastResolution               *PacketResolution                 `json:"last_resolution,omitempty"`
-	SlowPath                     SlowPathStatus                    `json:"slow_path,omitempty"`
-	LastCacheFlushAt             uint64                            `json:"last_cache_flush_at,omitempty"`    // monotonic secs (#312)
-	DataplaneMode                string                            `json:"dataplane_mode,omitempty"`         // Current active mode: "ebpf_only", "userspace_compat", "userspace_strict"
-	ConfiguredMode               string                            `json:"configured_mode,omitempty"`        // Desired mode from config
-	EntryPrograms                map[int]string                    `json:"entry_programs,omitempty"`         // ifindex -> attached XDP program name
-	DegradedPathCounters         map[string]uint64                 `json:"degraded_path_counters,omitempty"` // reason_name -> count
+	CoSActiveFlowCounts          []CoSActiveFlowCountStatus `json:"cos_active_flow_counts,omitempty"`
+	CoSActiveFlowCountsTruncated bool                       `json:"cos_active_flow_counts_truncated,omitempty"`
+	RecentSessionDeltas          []SessionDeltaInfo         `json:"recent_session_deltas,omitempty"`
+	RecentExceptions             []ExceptionStatus          `json:"recent_exceptions,omitempty"`
+	EventStream                  *EventStreamStatus         `json:"event_stream,omitempty"`
+	EventStreamSent              uint64                     `json:"event_stream_sent,omitempty"`
+	EventStreamDropped           uint64                     `json:"event_stream_dropped,omitempty"`
+	// #1642: the Rust helper serializes these three flat event-stream
+	// fields on ProcessStatus (protocol/control.rs) alongside _sent /
+	// _dropped, but the Go side only declared _sent / _dropped, so
+	// connected / seq / acked were silently dropped. The nested
+	// *EventStreamStatus above carries different, Go-populated counters
+	// (frames_read, decode_errors) the Rust helper never emits. JSON tags
+	// MUST match Rust serde rename(...) exactly.
+	EventStreamConnected      bool                              `json:"event_stream_connected,omitempty"`
+	EventStreamSeq            uint64                            `json:"event_stream_seq,omitempty"`
+	EventStreamAcked          uint64                            `json:"event_stream_acked,omitempty"`
+	CoSInterfaces             []CoSInterfaceStatus              `json:"cos_interfaces,omitempty"`
+	PolicyRuleCounters        []PolicyRuleCounterStatus         `json:"policy_rule_counters,omitempty"`
+	FilterTermCounters        []FirewallFilterTermCounterStatus `json:"filter_term_counters,omitempty"`
+	ThreeColorPolicerCounters []ThreeColorPolicerStatus         `json:"three_color_policer_counters,omitempty"`
+	SourceNATPools            []SourceNATPoolStatus             `json:"source_nat_pools,omitempty"`
+	LastResolution            *PacketResolution                 `json:"last_resolution,omitempty"`
+	SlowPath                  SlowPathStatus                    `json:"slow_path,omitempty"`
+	LastCacheFlushAt          uint64                            `json:"last_cache_flush_at,omitempty"`    // monotonic secs (#312)
+	DataplaneMode             string                            `json:"dataplane_mode,omitempty"`         // Current active mode: "ebpf_only", "userspace_compat", "userspace_strict"
+	ConfiguredMode            string                            `json:"configured_mode,omitempty"`        // Desired mode from config
+	EntryPrograms             map[int]string                    `json:"entry_programs,omitempty"`         // ifindex -> attached XDP program name
+	DegradedPathCounters      map[string]uint64                 `json:"degraded_path_counters,omitempty"` // reason_name -> count
 	// #1636 option C: proactive-neighbor-warm telemetry. WarmDrops counts
 	// warm requests dropped because the bounded warmer queue was full
 	// (transient); WarmDisconnected counts requests dropped because the
@@ -737,6 +747,13 @@ type CoSQueueStatus struct {
 	AdmissionFlowShareDrops uint64 `json:"admission_flow_share_drops,omitempty"`
 	AdmissionBufferDrops    uint64 `json:"admission_buffer_drops,omitempty"`
 	AdmissionEcnMarked      uint64 `json:"admission_ecn_marked,omitempty"`
+	// #1642: shaper starvation / TX-ring-pressure diagnostics the Rust
+	// helper serializes on CoSQueueStatus (protocol/cos.rs). These are
+	// distinct from the DrainPark* fields below (which count drain-loop
+	// parks). JSON tags MUST match Rust serde rename(...) exactly.
+	RootTokenStarvationParks  uint64 `json:"root_token_starvation_parks,omitempty"`
+	QueueTokenStarvationParks uint64 `json:"queue_token_starvation_parks,omitempty"`
+	TxRingFullSubmitStalls    uint64 `json:"tx_ring_full_submit_stalls,omitempty"`
 	// #1304: Rust-owned equal-flow enforcement telemetry. The
 	// measurement-only xpf_fairness_equal_flow_* gauges remain advisory;
 	// these fields describe the opt-in shared v8 queue-lease suppressor.
@@ -783,8 +800,13 @@ type CoSQueueStatus struct {
 	DrainParkQueueTokens                       uint64 `json:"drain_park_queue_tokens,omitempty"`
 	PostDrainBackupBytes                       uint64 `json:"post_drain_backup_bytes,omitempty"`
 	DrainSentBytesShapedUnconditional          uint64 `json:"drain_sent_bytes_shaped_unconditional,omitempty"`
-	PostDrainBackupCosDrops                    uint64 `json:"post_drain_backup_cos_drops,omitempty"`
-	PostDrainBackupCosDropBytes                uint64 `json:"post_drain_backup_cos_drop_bytes,omitempty"`
+	// #1642: post_drain_backup_cos_drops / _cos_drop_bytes were on this
+	// struct, but the Rust helper serializes them on BindingStatus
+	// (protocol/binding.rs), a different JSON nesting level. The Rust
+	// binding-level values never decoded into CoSQueueStatus, so they were
+	// silently dropped. They now live on BindingStatus to match the source.
+	// (PostDrainBackupBytes above is correct here — Rust does serialize
+	// post_drain_backup_bytes on CoSQueueStatus.)
 }
 
 type FirewallFilterTermCounterStatus struct {
@@ -882,6 +904,13 @@ type HAGroupStatus struct {
 	RGID              int    `json:"rg_id"`
 	Active            bool   `json:"active"`
 	WatchdogTimestamp uint64 `json:"watchdog_timestamp,omitempty"`
+	// #1642: lease-telemetry fields the Rust helper serializes on
+	// HAGroupStatus (protocol/binding.rs). Observability only — the HA
+	// failover *decision* is taken from BPF maps via mergeHAStateFromMaps,
+	// not from these. JSON tags MUST match the Rust serde rename(...) exactly.
+	ForwardingActive bool   `json:"forwarding_active,omitempty"`
+	LeaseState       string `json:"lease_state,omitempty"`
+	LeaseUntil       uint64 `json:"lease_until,omitempty"`
 }
 
 type SlowPathStatus struct {
@@ -1150,13 +1179,21 @@ type BindingStatus struct {
 	// #819 §4.1). omitempty keeps forward-compat — a pre-#825
 	// helper that lacks these fields decodes into empty slice /
 	// zero uint64.
-	TxKickLatencyHist  []uint64  `json:"tx_kick_latency_hist,omitempty"`
-	TxKickLatencyCount uint64    `json:"tx_kick_latency_count,omitempty"`
-	TxKickLatencySumNs uint64    `json:"tx_kick_latency_sum_ns,omitempty"`
-	TxKickRetryCount   uint64    `json:"tx_kick_retry_count,omitempty"`
-	LastHeartbeat      time.Time `json:"last_heartbeat,omitempty"`
-	LastError          string    `json:"last_error,omitempty"`
-	LastChange         time.Time `json:"last_change,omitempty"`
+	TxKickLatencyHist  []uint64 `json:"tx_kick_latency_hist,omitempty"`
+	TxKickLatencyCount uint64   `json:"tx_kick_latency_count,omitempty"`
+	TxKickLatencySumNs uint64   `json:"tx_kick_latency_sum_ns,omitempty"`
+	TxKickRetryCount   uint64   `json:"tx_kick_retry_count,omitempty"`
+	// #760 (#1642): the post-drain backup filter drop counters are
+	// binding-scoped in the Rust helper (protocol/binding.rs), not
+	// queue-scoped. They were previously declared on CoSQueueStatus, a
+	// different JSON nesting level, so the Rust binding-level values were
+	// silently dropped on unmarshal. JSON tags MUST match Rust serde
+	// rename(...) exactly.
+	PostDrainBackupCosDrops     uint64    `json:"post_drain_backup_cos_drops,omitempty"`
+	PostDrainBackupCosDropBytes uint64    `json:"post_drain_backup_cos_drop_bytes,omitempty"`
+	LastHeartbeat               time.Time `json:"last_heartbeat,omitempty"`
+	LastError                   string    `json:"last_error,omitempty"`
+	LastChange                  time.Time `json:"last_change,omitempty"`
 }
 
 // BindingCountersSnapshot is the focused per-binding ring-pressure view

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -1169,3 +1169,183 @@ func TestProcessStatusPolicyRuleCountersRoundTrip(t *testing.T) {
 		t.Fatalf("PolicyRuleCounters mismatch: got %+v, want %+v", back.PolicyRuleCounters, in.PolicyRuleCounters)
 	}
 }
+
+// #1642: the Rust helper serialized several status fields the Go side had
+// no matching json: tag for, so json.Unmarshal silently dropped them and
+// the operator-facing telemetry stayed zero. These tests decode the exact
+// wire JSON the Rust structs emit (serde rename strings verified against
+// userspace-dp/src/protocol/{binding,cos,control}.rs at the same revision)
+// and assert the Go side now observes every field. A Rust rename without a
+// matching Go update will land in the field as zero rather than erroring,
+// so feeding the Rust-shaped JSON literal is the real regression gate — a
+// pure Go marshal round-trip would not have caught the dropped fields,
+// since the Go struct lacked them entirely.
+
+func TestHAGroupStatusLeaseFieldsParity1642(t *testing.T) {
+	// Wire JSON exactly as Rust HAGroupStatus (protocol/binding.rs) emits.
+	const rustJSON = `{
+		"rg_id": 1,
+		"active": true,
+		"watchdog_timestamp": 1234567890,
+		"forwarding_active": true,
+		"lease_state": "owner",
+		"lease_until": 9876543210
+	}`
+	var got HAGroupStatus
+	if err := json.Unmarshal([]byte(rustJSON), &got); err != nil {
+		t.Fatalf("unmarshal Rust HAGroupStatus JSON: %v", err)
+	}
+	if !got.ForwardingActive {
+		t.Errorf("forwarding_active dropped: got false")
+	}
+	if got.LeaseState != "owner" {
+		t.Errorf("lease_state dropped: got %q, want %q", got.LeaseState, "owner")
+	}
+	if got.LeaseUntil != 9876543210 {
+		t.Errorf("lease_until dropped: got %d, want %d", got.LeaseUntil, uint64(9876543210))
+	}
+
+	// Wire-key presence on the Go marshal side (the contract is symmetric).
+	raw, err := json.Marshal(&HAGroupStatus{ForwardingActive: true, LeaseState: "owner", LeaseUntil: 1})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range []string{"forwarding_active", "lease_state", "lease_until"} {
+		if _, ok := obj[key]; !ok {
+			t.Errorf("wire key %q missing from HAGroupStatus JSON: %s", key, string(raw))
+		}
+	}
+}
+
+func TestCoSQueueStatusStarvationCountersParity1642(t *testing.T) {
+	// Wire JSON exactly as Rust CoSQueueStatus (protocol/cos.rs) emits for
+	// the shaper-starvation / ring-pressure diagnostics.
+	const rustJSON = `{
+		"queue_id": 3,
+		"root_token_starvation_parks": 11,
+		"queue_token_starvation_parks": 22,
+		"tx_ring_full_submit_stalls": 33
+	}`
+	var got CoSQueueStatus
+	if err := json.Unmarshal([]byte(rustJSON), &got); err != nil {
+		t.Fatalf("unmarshal Rust CoSQueueStatus JSON: %v", err)
+	}
+	if got.RootTokenStarvationParks != 11 {
+		t.Errorf("root_token_starvation_parks dropped: got %d, want 11", got.RootTokenStarvationParks)
+	}
+	if got.QueueTokenStarvationParks != 22 {
+		t.Errorf("queue_token_starvation_parks dropped: got %d, want 22", got.QueueTokenStarvationParks)
+	}
+	if got.TxRingFullSubmitStalls != 33 {
+		t.Errorf("tx_ring_full_submit_stalls dropped: got %d, want 33", got.TxRingFullSubmitStalls)
+	}
+
+	raw, _ := json.Marshal(&CoSQueueStatus{
+		RootTokenStarvationParks:  1,
+		QueueTokenStarvationParks: 1,
+		TxRingFullSubmitStalls:    1,
+	})
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range []string{
+		"root_token_starvation_parks",
+		"queue_token_starvation_parks",
+		"tx_ring_full_submit_stalls",
+	} {
+		if _, ok := obj[key]; !ok {
+			t.Errorf("wire key %q missing from CoSQueueStatus JSON: %s", key, string(raw))
+		}
+	}
+}
+
+func TestBindingStatusPostDrainBackupCosDropsParity1642(t *testing.T) {
+	// Rust serializes post_drain_backup_cos_drops / _cos_drop_bytes on
+	// BindingStatus (protocol/binding.rs), NOT on CoSQueueStatus. Feed
+	// binding-level wire JSON and assert the Go BindingStatus now reads it.
+	const rustJSON = `{
+		"slot": 4,
+		"queue_id": 0,
+		"worker_id": 2,
+		"registered": true,
+		"armed": true,
+		"ready": true,
+		"bound": true,
+		"xsk_registered": true,
+		"post_drain_backup_cos_drops": 7,
+		"post_drain_backup_cos_drop_bytes": 4096
+	}`
+	var got BindingStatus
+	if err := json.Unmarshal([]byte(rustJSON), &got); err != nil {
+		t.Fatalf("unmarshal Rust BindingStatus JSON: %v", err)
+	}
+	if got.PostDrainBackupCosDrops != 7 {
+		t.Errorf("post_drain_backup_cos_drops dropped: got %d, want 7", got.PostDrainBackupCosDrops)
+	}
+	if got.PostDrainBackupCosDropBytes != 4096 {
+		t.Errorf("post_drain_backup_cos_drop_bytes dropped: got %d, want 4096", got.PostDrainBackupCosDropBytes)
+	}
+
+	// Guard against re-introducing the wrong-level bug: CoSQueueStatus must
+	// NOT declare these keys (post_drain_backup_bytes is the only legitimate
+	// post_drain key on CoSQueueStatus).
+	cosRaw, _ := json.Marshal(&CoSQueueStatus{PostDrainBackupBytes: 1})
+	var cosObj map[string]json.RawMessage
+	if err := json.Unmarshal(cosRaw, &cosObj); err != nil {
+		t.Fatalf("unmarshal cos obj: %v", err)
+	}
+	for _, key := range []string{"post_drain_backup_cos_drops", "post_drain_backup_cos_drop_bytes"} {
+		if _, ok := cosObj[key]; ok {
+			t.Errorf("CoSQueueStatus must not carry binding-scoped key %q: %s", key, string(cosRaw))
+		}
+	}
+	if _, ok := cosObj["post_drain_backup_bytes"]; !ok {
+		t.Errorf("post_drain_backup_bytes must remain on CoSQueueStatus: %s", string(cosRaw))
+	}
+}
+
+func TestProcessStatusEventStreamFieldsParity1642(t *testing.T) {
+	// Rust ProcessStatus (protocol/control.rs) emits flat event_stream_*
+	// fields. _sent / _dropped already matched; connected / seq / acked
+	// were dropped on the Go side.
+	const rustJSON = `{
+		"event_stream_connected": true,
+		"event_stream_seq": 4242,
+		"event_stream_acked": 4200,
+		"event_stream_sent": 5000,
+		"event_stream_dropped": 3
+	}`
+	var got ProcessStatus
+	if err := json.Unmarshal([]byte(rustJSON), &got); err != nil {
+		t.Fatalf("unmarshal Rust ProcessStatus JSON: %v", err)
+	}
+	if !got.EventStreamConnected {
+		t.Errorf("event_stream_connected dropped: got false")
+	}
+	if got.EventStreamSeq != 4242 {
+		t.Errorf("event_stream_seq dropped: got %d, want 4242", got.EventStreamSeq)
+	}
+	if got.EventStreamAcked != 4200 {
+		t.Errorf("event_stream_acked dropped: got %d, want 4200", got.EventStreamAcked)
+	}
+	// Sanity: the previously-matching fields still decode.
+	if got.EventStreamSent != 5000 || got.EventStreamDropped != 3 {
+		t.Errorf("event_stream_sent/dropped regressed: sent=%d dropped=%d", got.EventStreamSent, got.EventStreamDropped)
+	}
+
+	raw, _ := json.Marshal(&ProcessStatus{EventStreamConnected: true, EventStreamSeq: 1, EventStreamAcked: 1})
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range []string{"event_stream_connected", "event_stream_seq", "event_stream_acked"} {
+		if _, ok := obj[key]; !ok {
+			t.Errorf("wire key %q missing from ProcessStatus JSON: %s", key, string(raw))
+		}
+	}
+}

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -893,3 +893,84 @@ fn wire_invariant_default_specimens() {
         );
     }
 }
+
+// #1642: Rust→Go status-field parity. These serde tests pin the exact wire
+// keys for the four field groups the Go side previously dropped on unmarshal
+// (HAGroupStatus lease telemetry, CoSQueueStatus starvation/ring counters,
+// BindingStatus post-drain backup drops, ProcessStatus event-stream
+// connected/seq/acked). The matching Go decode tests live in
+// pkg/dataplane/userspace/protocol_test.go (*Parity1642). A rename on this
+// side is caught here; the Go side then fails to decode the renamed key.
+
+#[test]
+fn ha_group_status_lease_fields_wire_keys_1642() {
+    let status = HAGroupStatus {
+        rg_id: 1,
+        active: true,
+        watchdog_timestamp: 1,
+        forwarding_active: true,
+        lease_state: "owner".to_string(),
+        lease_until: 9876543210,
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize HAGroupStatus");
+    assert_eq!(value["forwarding_active"], true);
+    assert_eq!(value["lease_state"], "owner");
+    assert_eq!(value["lease_until"], 9876543210u64);
+    let back: HAGroupStatus = serde_json::from_value(value).expect("deserialize HAGroupStatus");
+    assert!(back.forwarding_active);
+    assert_eq!(back.lease_state, "owner");
+    assert_eq!(back.lease_until, 9876543210);
+}
+
+#[test]
+fn cos_queue_status_starvation_counters_wire_keys_1642() {
+    let status = CoSQueueStatus {
+        root_token_starvation_parks: 11,
+        queue_token_starvation_parks: 22,
+        tx_ring_full_submit_stalls: 33,
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize CoSQueueStatus");
+    assert_eq!(value["root_token_starvation_parks"], 11u64);
+    assert_eq!(value["queue_token_starvation_parks"], 22u64);
+    assert_eq!(value["tx_ring_full_submit_stalls"], 33u64);
+}
+
+#[test]
+fn binding_status_post_drain_backup_cos_drops_wire_keys_1642() {
+    let status = BindingStatus {
+        post_drain_backup_cos_drops: 7,
+        post_drain_backup_cos_drop_bytes: 4096,
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize BindingStatus");
+    assert_eq!(value["post_drain_backup_cos_drops"], 7u64);
+    assert_eq!(value["post_drain_backup_cos_drop_bytes"], 4096u64);
+    // These are binding-scoped: CoSQueueStatus must NOT also carry them.
+    let cos: serde_json::Value = serde_json::to_value(CoSQueueStatus {
+        post_drain_backup_bytes: 1,
+        ..Default::default()
+    })
+    .expect("serialize CoSQueueStatus");
+    assert!(cos.get("post_drain_backup_cos_drops").is_none());
+    assert!(cos.get("post_drain_backup_cos_drop_bytes").is_none());
+    assert_eq!(cos["post_drain_backup_bytes"], 1u64);
+}
+
+#[test]
+fn process_status_event_stream_fields_wire_keys_1642() {
+    let status = ProcessStatus {
+        event_stream_connected: true,
+        event_stream_seq: 4242,
+        event_stream_acked: 4200,
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize ProcessStatus");
+    assert_eq!(value["event_stream_connected"], true);
+    assert_eq!(value["event_stream_seq"], 4242u64);
+    assert_eq!(value["event_stream_acked"], 4200u64);
+}


### PR DESCRIPTION
Observability-only (no dataplane/HA behavior change). Four status fields the Rust helper serializes over the JSON control socket had no matching (or a wrong-level) Go `json:` tag, so the field-name-keyed wire format silently dropped them on `json.Unmarshal`. `show` output and Prometheus metrics driven from these values stayed at zero.

## Fixes (Go `pkg/dataplane/userspace/protocol.go`)
1. **HAGroupStatus**: add `forwarding_active`, `lease_state`, `lease_until` (Rust `protocol/binding.rs`). Lease telemetry only — failover decisions still come from BPF maps via `mergeHAStateFromMaps`.
2. **CoSQueueStatus**: add `root_token_starvation_parks`, `queue_token_starvation_parks`, `tx_ring_full_submit_stalls` (Rust `protocol/cos.rs`). Distinct from the existing `DrainPark*` counters.
3. **post_drain_backup_cos_drops / _cos_drop_bytes**: moved from Go CoSQueueStatus to Go **BindingStatus** to match the Rust source struct level (`protocol/binding.rs`). `post_drain_backup_bytes` stays on CoSQueueStatus — Rust emits it there. No existing Go consumer referenced the moved fields.
4. **ProcessStatus**: add flat `event_stream_connected`, `event_stream_seq`, `event_stream_acked` (Rust `protocol/control.rs`). `_sent`/`_dropped` already matched.

## Tests
- Go `protocol_test.go` `*Parity1642`: decode the exact Rust-shaped JSON literal, assert every field is observed (the real gate — a pure Go round-trip misses fields the struct lacked). Also asserts CoSQueueStatus does not re-introduce the binding-scoped keys.
- Rust `protocol/tests.rs` `*_1642`: pin the serde wire keys so a Rust rename is caught with the Go decode test failing in tandem.

Wire-protocol both-sides discipline applied. 5/5 flake both suites; wire-invariant default-specimen fixture unchanged (no Rust fields added).

Closes #1642

🤖 Generated with [Claude Code](https://claude.com/claude-code)