### PR TITLE
#1646: harden frr writeManagedSection against torn-write corruption

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,23 @@
 # Action Log
 
+## 2026-05-29 — #1646 frr writeManagedSection torn-write hardening
+- **Timestamp**: 2026-05-29 UTC
+- **Action**: Hardened `writeManagedSection` in pkg/frr/manager.go against
+  torn-write corruption. (1) When markerBegin is present but markerEnd is
+  absent (an orphaned begin from a prior truncated write), discard from the
+  begin marker to EOF instead of skipping the strip — prevents the
+  double-begin state that a later write would over-cut, deleting unrelated
+  operator config. (2) Write frr.conf atomically via new `atomicWriteFile`
+  (temp file in same dir + fsync + chmod + rename) so a crash/disk-full can
+  never leave a half-written file in the first place. Preserve an existing
+  file's mode + best-effort ownership across the inode-replacing rename
+  (Copilot); preserve symlinks via EvalSymlinks/Readlink incl. dangling
+  links, surface chown failures when owner differs (AGY + Copilot r2). Added
+  regression tests TestWriteManagedSection_{OrphanedBeginMarker,
+  PreservesExistingMode,PreservesSymlink,DanglingSymlink}; verified
+  fail-before (2 begin markers, partial body retained) / pass-after.
+- **File(s)**: pkg/frr/manager.go, pkg/frr/frr_test.go
+
 ## 2026-05-29 — #1642 Rust→Go status-field parity drift
 - **Timestamp**: 2026-05-29 UTC
 - **Action**: Fixed 4 field-level JSON parity gaps where the Rust helper

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -534,6 +534,58 @@ func TestWriteManagedSection_PreservesExistingMode(t *testing.T) {
 	}
 }
 
+// TestWriteManagedSection_PreservesSymlink guards the AGY adversarial-review
+// finding on #1646: the old os.WriteFile path followed a symlink and wrote
+// through to its target, whereas a naive rename onto the link path would
+// destroy the link and leave a regular file. xpfd is sometimes pointed at
+// /etc/frr/frr.conf via a symlink; the atomic write must resolve and preserve
+// it.
+func TestWriteManagedSection_PreservesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real-frr.conf")
+	linkPath := filepath.Join(dir, "frr.conf")
+
+	if err := os.WriteFile(realPath, []byte("log syslog informational\n"), 0640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{frrConf: linkPath}
+	if err := m.writeManagedSection("ip route 10.0.0.0/8 192.168.1.1\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	// frr.conf must still be a symlink pointing at the real file.
+	fi, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("symlink was replaced by a regular file")
+	}
+	// The managed section must have landed in the real target, through the link.
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "192.168.1.1") {
+		t.Errorf("write did not reach the symlink target:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "log syslog informational") {
+		t.Errorf("existing content in symlink target lost:\n%s", string(data))
+	}
+	// Mode of the real target preserved.
+	rfi, err := os.Stat(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rfi.Mode().Perm(); got != 0640 {
+		t.Errorf("symlink target mode not preserved: got %o, want 0640", got)
+	}
+}
+
 func TestGeneratePolicyOptions(t *testing.T) {
 	m := &Manager{frrConf: "/dev/null"}
 	po := &config.PolicyOptionsConfig{

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -486,6 +486,54 @@ func TestWriteManagedSection_OrphanedBeginMarker(t *testing.T) {
 	}
 }
 
+// TestWriteManagedSection_PreservesExistingMode guards the Copilot finding on
+// #1646: the atomic temp-file + rename write replaces the inode, so it must
+// reuse the existing file's mode rather than unconditionally applying 0644.
+// frr.conf is commonly deployed 0640; making it world-readable on the next
+// apply would be a permission regression vs the old os.WriteFile path (which
+// preserved the mode of an existing file).
+func TestWriteManagedSection_PreservesExistingMode(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "frr.conf")
+
+	m := &Manager{frrConf: confPath}
+
+	initial := "log syslog informational\n"
+	if err := os.WriteFile(confPath, []byte(initial), 0640); err != nil {
+		t.Fatal(err)
+	}
+	// Chmod explicitly in case the umask masked bits at create time.
+	if err := os.Chmod(confPath, 0640); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.writeManagedSection("ip route 10.0.0.0/8 192.168.1.1\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	fi, err := os.Stat(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0640 {
+		t.Errorf("mode not preserved across atomic write: got %o, want 0640", got)
+	}
+
+	// A brand-new file (no existing target) uses the default 0644.
+	freshPath := filepath.Join(dir, "fresh.conf")
+	mf := &Manager{frrConf: freshPath}
+	if err := mf.writeManagedSection("ip route 10.0.0.0/8 Null0\n"); err != nil {
+		t.Fatal(err)
+	}
+	fi, err = os.Stat(freshPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0644 {
+		t.Errorf("new file mode: got %o, want 0644", got)
+	}
+}
+
 func TestGeneratePolicyOptions(t *testing.T) {
 	m := &Manager{frrConf: "/dev/null"}
 	po := &config.PolicyOptionsConfig{

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -586,6 +586,42 @@ func TestWriteManagedSection_PreservesSymlink(t *testing.T) {
 	}
 }
 
+// TestWriteManagedSection_DanglingSymlink covers the Copilot round-2 finding:
+// when frr.conf is a symlink whose target does not exist yet, EvalSymlinks
+// fails; os.WriteFile would still follow the link and create the target, so
+// the atomic write must Readlink and write through the link rather than
+// replacing it with a regular file.
+func TestWriteManagedSection_DanglingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "real-frr.conf") // does NOT exist yet
+	linkPath := filepath.Join(dir, "frr.conf")
+
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{frrConf: linkPath}
+	if err := m.writeManagedSection("ip route 10.0.0.0/8 192.168.1.1\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The link must survive and now resolve to a created target.
+	fi, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("dangling symlink was replaced by a regular file")
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("symlink target was not created: %v", err)
+	}
+	if !strings.Contains(string(data), "192.168.1.1") {
+		t.Errorf("write did not reach the dangling-symlink target:\n%s", string(data))
+	}
+}
+
 func TestGeneratePolicyOptions(t *testing.T) {
 	m := &Manager{frrConf: "/dev/null"}
 	po := &config.PolicyOptionsConfig{

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -410,6 +410,82 @@ func TestWriteManagedSection_NoExistingFile(t *testing.T) {
 	}
 }
 
+// TestWriteManagedSection_OrphanedBeginMarker is the #1646 regression test.
+// A prior torn write (os.WriteFile is not atomic) can leave an orphaned
+// markerBegin with no markerEnd. The pre-fix code skipped the strip entirely
+// when markerEnd was absent, appending a SECOND managed block — and the write
+// after that would over-cut from the orphan begin to the new block's end,
+// deleting everything in between, including unrelated operator/tool config.
+//
+// The fix discards an orphaned-begin tail to EOF. After one writeManagedSection
+// the file must contain exactly one managed block and must NOT carry the torn
+// partial content forward into a state that a subsequent write would over-cut.
+func TestWriteManagedSection_OrphanedBeginMarker(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "frr.conf")
+
+	m := &Manager{frrConf: confPath}
+
+	// Simulate a torn write: legitimate config, then an orphaned begin marker
+	// with a partial managed body and NO end marker (the write was truncated).
+	torn := "log syslog informational\n" +
+		"ip route 192.0.2.0/24 198.51.100.1\n" + // unrelated, operator-added
+		markerBegin + "\n" +
+		"ip route 10.0.0.0/8 192.168.9.9\n" // partial body, no markerEnd
+	if err := os.WriteFile(confPath, []byte(torn), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First write after the torn state.
+	if err := m.writeManagedSection("ip route 10.0.0.0/8 192.168.2.1\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(confPath)
+	got := string(data)
+
+	// Exactly one begin marker — the orphan must have been discarded, not kept.
+	if n := strings.Count(got, markerBegin); n != 1 {
+		t.Errorf("expected exactly 1 begin marker, got %d:\n%s", n, got)
+	}
+	if n := strings.Count(got, markerEnd); n != 1 {
+		t.Errorf("expected exactly 1 end marker, got %d:\n%s", n, got)
+	}
+	// Unrelated operator config above the torn block must survive.
+	if !strings.Contains(got, "ip route 192.0.2.0/24 198.51.100.1") {
+		t.Errorf("unrelated operator config was lost:\n%s", got)
+	}
+	if !strings.Contains(got, "log syslog informational") {
+		t.Errorf("base config lost:\n%s", got)
+	}
+	// The partial torn body must be gone.
+	if strings.Contains(got, "192.168.9.9") {
+		t.Errorf("orphaned partial managed body was not discarded:\n%s", got)
+	}
+	// The new managed route is present.
+	if !strings.Contains(got, "ip route 10.0.0.0/8 192.168.2.1") {
+		t.Errorf("new managed route missing:\n%s", got)
+	}
+
+	// A SECOND write must remain stable and must not over-cut the unrelated
+	// config — this is the step where the pre-fix double-begin state corrupted
+	// the file.
+	if err := m.writeManagedSection("ip route 10.0.0.0/8 192.168.3.3\n"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ = os.ReadFile(confPath)
+	got = string(data)
+	if !strings.Contains(got, "ip route 192.0.2.0/24 198.51.100.1") {
+		t.Errorf("unrelated operator config lost on second write:\n%s", got)
+	}
+	if n := strings.Count(got, markerBegin); n != 1 {
+		t.Errorf("second write: expected 1 begin marker, got %d:\n%s", n, got)
+	}
+	if !strings.Contains(got, "192.168.3.3") {
+		t.Errorf("second write's route missing:\n%s", got)
+	}
+}
+
 func TestGeneratePolicyOptions(t *testing.T) {
 	m := &Manager{frrConf: "/dev/null"}
 	po := &config.PolicyOptionsConfig{

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -361,7 +362,29 @@ func (m *Manager) writeManagedSection(section string) error {
 // path and renames it into place. The rename is atomic within a filesystem,
 // so a reader (or a crash) never observes a partially written file. The temp
 // file is removed on any error before the rename completes.
+//
+// Because rename replaces the inode, the mode (and ownership) of any existing
+// target would otherwise be lost. The previous direct os.WriteFile path
+// preserved the mode of an existing file (it only applied perm on creation),
+// so frr.conf deployed as e.g. 0640 must stay 0640. We therefore stat the
+// target first and reuse its mode/ownership when it exists, falling back to
+// the supplied perm only when creating a brand-new file.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	// Preserve the mode/ownership of an existing target across the rename.
+	mode := perm
+	var (
+		preserveOwner bool
+		uid, gid      int
+	)
+	if fi, statErr := os.Stat(path); statErr == nil {
+		mode = fi.Mode().Perm()
+		if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+			preserveOwner = true
+			uid = int(st.Uid)
+			gid = int(st.Gid)
+		}
+	}
+
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, ".frr.conf.tmp-*")
 	if err != nil {
@@ -389,8 +412,15 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close temp file: %w", err)
 	}
-	if err := os.Chmod(tmpName, perm); err != nil {
+	if err := os.Chmod(tmpName, mode); err != nil {
 		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	// Restore ownership if the target existed and we are privileged enough.
+	// A best-effort failure (EPERM when not root) must not abort the write —
+	// CreateTemp already created the file owned by the current process, which
+	// matches the common case where xpfd runs as the frr.conf owner.
+	if preserveOwner {
+		_ = os.Chown(tmpName, uid, gid)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
 		return fmt.Errorf("rename temp file: %w", err)

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -363,20 +363,38 @@ func (m *Manager) writeManagedSection(section string) error {
 // so a reader (or a crash) never observes a partially written file. The temp
 // file is removed on any error before the rename completes.
 //
-// Because rename replaces the inode, the mode (and ownership) of any existing
-// target would otherwise be lost. The previous direct os.WriteFile path
-// preserved the mode of an existing file (it only applied perm on creation),
-// so frr.conf deployed as e.g. 0640 must stay 0640. We therefore stat the
-// target first and reuse its mode/ownership when it exists, falling back to
-// the supplied perm only when creating a brand-new file.
+// Behavioral parity with the previous direct os.WriteFile path:
+//   - Mode/ownership: rename replaces the inode, so the mode (and ownership)
+//     of an existing target would otherwise be lost. os.WriteFile only applied
+//     perm on creation and preserved the mode of an existing file, so frr.conf
+//     deployed as e.g. 0640 must stay 0640. We stat the target and reuse its
+//     mode/ownership when it exists, falling back to perm for a new file.
+//   - Symlinks: os.WriteFile follows a symlink and writes through to its
+//     target. A naive rename onto the link path would instead destroy the
+//     link and leave a regular file. We resolve the symlink and create the
+//     temp file in the resolved target's directory, then rename onto the
+//     resolved path — preserving the operator's symlink.
+//
+// chmod/chown are applied to the temp file's open fd before close (and before
+// rename), so the file is never world-visible at the final path with a
+// transient mode, and there is no path-based TOCTOU on the temp name.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	// Resolve a symlink target so the rename replaces the real file, not the
+	// link. EvalSymlinks fails if the final path does not exist yet; in that
+	// case (new file, possibly via a dangling link) fall back to the path
+	// as given.
+	target := path
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		target = resolved
+	}
+
 	// Preserve the mode/ownership of an existing target across the rename.
 	mode := perm
 	var (
 		preserveOwner bool
 		uid, gid      int
 	)
-	if fi, statErr := os.Stat(path); statErr == nil {
+	if fi, statErr := os.Stat(target); statErr == nil {
 		mode = fi.Mode().Perm()
 		if st, ok := fi.Sys().(*syscall.Stat_t); ok {
 			preserveOwner = true
@@ -385,7 +403,7 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		}
 	}
 
-	dir := filepath.Dir(path)
+	dir := filepath.Dir(target)
 	tmp, err := os.CreateTemp(dir, ".frr.conf.tmp-*")
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
@@ -403,6 +421,19 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		_ = tmp.Close()
 		return fmt.Errorf("write temp file: %w", err)
 	}
+	// Apply mode/ownership on the open fd (fchmod/fchown) before rename, so the
+	// final path never appears with a transient mode and there is no path-race
+	// on the temp name. Ownership restore is best-effort: an EPERM when xpfd is
+	// not root must not abort the write, since CreateTemp already created the
+	// file owned by the running process (the common case where xpfd owns
+	// frr.conf).
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if preserveOwner {
+		_ = tmp.Chown(uid, gid)
+	}
 	// fsync the data before rename so the rename does not point at a file
 	// whose contents are still only in the page cache after a power loss.
 	if err := tmp.Sync(); err != nil {
@@ -412,17 +443,7 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close temp file: %w", err)
 	}
-	if err := os.Chmod(tmpName, mode); err != nil {
-		return fmt.Errorf("chmod temp file: %w", err)
-	}
-	// Restore ownership if the target existed and we are privileged enough.
-	// A best-effort failure (EPERM when not root) must not abort the write —
-	// CreateTemp already created the file owned by the current process, which
-	// matches the common case where xpfd runs as the frr.conf owner.
-	if preserveOwner {
-		_ = os.Chown(tmpName, uid, gid)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
+	if err := os.Rename(tmpName, target); err != nil {
 		return fmt.Errorf("rename temp file: %w", err)
 	}
 	cleanup = false

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -308,17 +309,33 @@ func (m *Manager) writeManagedSection(section string) error {
 		}
 	}
 
-	// Strip existing managed section
+	// Strip existing managed section.
+	//
+	// A correct file has a begin marker followed by an end marker. But a
+	// prior torn write (os.WriteFile is not atomic — a crash or disk-full
+	// mid-write can truncate after the begin marker) can leave an orphaned
+	// markerBegin with no markerEnd. If we only stripped on the both-found
+	// case, the orphan would survive: we would append a second managed block,
+	// leaving two begin markers. The next write's strings.Index(markerEnd)
+	// then matches the new block's end while content[:start] cuts from the
+	// orphaned begin — deleting everything between them, which may include
+	// unrelated FRR config the operator appended. So we treat a begin with no
+	// end as a corrupt tail and discard it to EOF.
 	content := string(existing)
 	if start := strings.Index(content, markerBegin); start >= 0 {
-		end := strings.Index(content, markerEnd)
-		if end >= 0 {
+		if end := strings.Index(content, markerEnd); end >= 0 {
 			end += len(markerEnd)
 			// Also consume the trailing newline
 			if end < len(content) && content[end] == '\n' {
 				end++
 			}
 			content = content[:start] + content[end:]
+		} else {
+			// Orphaned begin marker (torn write): discard from the begin
+			// marker to EOF. Whatever followed an unterminated managed block
+			// is xpf-generated partial config that must not be preserved, and
+			// keeping the orphan begin would cause the next write to over-cut.
+			content = content[:start]
 		}
 	}
 
@@ -330,9 +347,55 @@ func (m *Manager) writeManagedSection(section string) error {
 		content += markerEnd + "\n"
 	}
 
-	if err := os.WriteFile(m.frrConf, []byte(content), 0644); err != nil {
+	// Write atomically: a temp file in the same directory followed by rename,
+	// so a crash or disk-full can never leave frr.conf half-written (which is
+	// what creates the orphaned-begin-marker state handled above in the first
+	// place). rename(2) within a filesystem is atomic.
+	if err := atomicWriteFile(m.frrConf, []byte(content), 0644); err != nil {
 		return fmt.Errorf("write frr.conf: %w", err)
 	}
+	return nil
+}
+
+// atomicWriteFile writes data to a temporary file in the same directory as
+// path and renames it into place. The rename is atomic within a filesystem,
+// so a reader (or a crash) never observes a partially written file. The temp
+// file is removed on any error before the rename completes.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".frr.conf.tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we return before a successful rename.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	// fsync the data before rename so the rename does not point at a file
+	// whose contents are still only in the page cache after a power loss.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	cleanup = false
 	return nil
 }
 

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -378,14 +378,44 @@ func (m *Manager) writeManagedSection(section string) error {
 // chmod/chown are applied to the temp file's open fd before close (and before
 // rename), so the file is never world-visible at the final path with a
 // transient mode, and there is no path-based TOCTOU on the temp name.
+// ownerIDs holds a file's numeric owner uid/gid.
+type ownerIDs struct {
+	uid int
+	gid int
+}
+
+// currentOwner returns the uid/gid of an open file. ok is false when the
+// platform stat cannot be obtained, in which case callers should fall back to
+// attempting a chown rather than assuming a match.
+func currentOwner(f *os.File) (ownerIDs, bool) {
+	fi, err := f.Stat()
+	if err != nil {
+		return ownerIDs{}, false
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return ownerIDs{}, false
+	}
+	return ownerIDs{uid: int(st.Uid), gid: int(st.Gid)}, true
+}
+
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	// Resolve a symlink target so the rename replaces the real file, not the
-	// link. EvalSymlinks fails if the final path does not exist yet; in that
-	// case (new file, possibly via a dangling link) fall back to the path
-	// as given.
+	// link. EvalSymlinks succeeds only when the whole chain exists. When the
+	// final component is a *dangling* symlink (target does not exist yet),
+	// EvalSymlinks fails, but os.WriteFile would still follow the link and
+	// create the target — so fall back to Readlink to recover that target
+	// path (resolved relative to the link's directory). Only when path is not
+	// a symlink at all do we use it as given (the genuine new-file case).
 	target := path
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
 		target = resolved
+	} else if linkDest, lerr := os.Readlink(path); lerr == nil {
+		if filepath.IsAbs(linkDest) {
+			target = linkDest
+		} else {
+			target = filepath.Join(filepath.Dir(path), linkDest)
+		}
 	}
 
 	// Preserve the mode/ownership of an existing target across the rename.
@@ -423,16 +453,25 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	}
 	// Apply mode/ownership on the open fd (fchmod/fchown) before rename, so the
 	// final path never appears with a transient mode and there is no path-race
-	// on the temp name. Ownership restore is best-effort: an EPERM when xpfd is
-	// not root must not abort the write, since CreateTemp already created the
-	// file owned by the running process (the common case where xpfd owns
-	// frr.conf).
+	// on the temp name.
 	if err := tmp.Chmod(mode); err != nil {
 		_ = tmp.Close()
 		return fmt.Errorf("chmod temp file: %w", err)
 	}
+	// Preserve ownership only when it actually differs from the temp file's
+	// current owner. CreateTemp makes the file owned by the running process,
+	// so when xpfd already runs as the frr.conf owner (the common case) no
+	// chown is needed and we never call it. When the target's owner differs
+	// and we cannot change it, do NOT silently rename a differently-owned file
+	// over a 0640 frr.conf — that could break ownership and leave FRR unable
+	// to read its config; surface the error instead.
 	if preserveOwner {
-		_ = tmp.Chown(uid, gid)
+		if cur, ok := currentOwner(tmp); !ok || cur.uid != uid || cur.gid != gid {
+			if err := tmp.Chown(uid, gid); err != nil {
+				_ = tmp.Close()
+				return fmt.Errorf("chown temp file to %d:%d: %w", uid, gid, err)
+			}
+		}
 	}
 	// fsync the data before rename so the rename does not point at a file
 	// whose contents are still only in the page cache after a power loss.


### PR DESCRIPTION
Low likelihood, real data-loss: silent loss of FRR routing config (HA/forwarding-relevant).

## Problem
`writeManagedSection` stripped the xpf-managed block only when **both** `markerBegin` and `markerEnd` were found. A prior torn write (`os.WriteFile` is not atomic — a crash or disk-full mid-write can truncate after the begin marker) leaves an orphaned `markerBegin` with no `markerEnd`. The pre-fix code then skipped the strip and appended a second managed block → two begin markers. The next write's `strings.Index(markerEnd)` matched the new block's end while `content[:start]` cut from the orphaned first begin — **deleting everything in between**, which can include unrelated FRR config the operator or another tool appended.

## Fix (two parts)
1. **Orphaned-begin handling**: when `markerBegin` is found but `markerEnd` is not, discard from the begin marker to EOF (treat the unterminated managed block as a corrupt tail). Stops the double-begin state from ever forming.
2. **Atomic write**: new `atomicWriteFile` helper (temp file in same dir, Write + Sync + Chmod, then `rename`). `rename(2)` within a filesystem is atomic, closing the window that produces the orphaned-begin state in the first place.

## Test (fail-before / pass-after verified)
`TestWriteManagedSection_OrphanedBeginMarker` seeds a torn file (unrelated operator route + orphaned begin + partial body, no end marker), runs two consecutive `writeManagedSection` calls, and asserts exactly one managed block, unrelated operator config preserved, partial torn body discarded. Fail-before confirmed (2 begin markers, partial body retained). 5/5 flake pass-after.

Cluster-free, Go-test gated.

Closes #1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)