### PR TITLE
userspace-dp: dead-host negative neighbor cache fast-fails cold storms (#1651)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4383,3 +4383,8 @@ top.
 - **Timestamp**: 2026-05-28
   **Action**: AGY r2 re-review (adversarial-review-mpq2jl5d-sqd223): all 4 round-1 fixes verified correct/complete, no new defect, ran Go+Rust suites clean — MERGE-READY. Copilot r2 doc nits fixed (plan path refs + converged status). Post-fix cluster re-validation: cold connect 1.016s, smoke reverse healthy, make test-failover 13/0. Added SMR r2 + AGY r2 docs.
   **File(s)**: docs/pr/1636-cold-connect-mitigation/{claude-smr-code-r2.md,agy-code-r2.md,reviewer-ids.md}, _Log.md
+
+## #1651 B3 dead-host negative neighbor cache
+- **Timestamp**: 2026-05-29
+- **Action**: Implement per-binding short-TTL negative cache; fast-fail at MissingNeighbor buffer site; record at pending_neigh drop site; resolved-wins + TTL invalidation.
+- **File(s)**: userspace-dp/src/afxdp/{mod.rs,neg_neigh.rs (new),neighbor_dispatch.rs,poll_descriptor/mod.rs,types/runtime.rs,worker/mod.rs}

--- a/docs/pr/1651-b3-negcache/plan.md
+++ b/docs/pr/1651-b3-negcache/plan.md
@@ -1,0 +1,356 @@
+# Plan — #1651 Path B3: dead-host negative cache
+
+- **Status:** DRAFT v1 — pending adversarial plan review (B3 already
+  design-blessed in the research plan; this is the IMPLEMENTATION plan).
+- **Branch:** `pr/1651-b3-negcache`
+- **Base:** origin/master @ `a107e7489`
+- **Issue:** #1651 (reopened) — Path B3 ONLY. Path A (active resolution)
+  is KILLED. Path C (do-nothing on resolve latency) is the disposition
+  for the *latency* question; B3 is the one shippable code change.
+- **Research plan (design authority):**
+  `docs/research/1651-cold-resolve-latency/plan.md` v4 @ `c148d04ae`
+  (Codex r3 + AGY r2 + Claude SMR converged PLAN-READY).
+
+---
+
+## §1. Issue framing
+
+The reopened-#1651 research established (measured on `loss:xpf-userspace-
+fw0/fw1`): live-host empty-cache cold connect is already 1–9 ms across all
+four cells (on-link v4/v6, routed v4/v6, post-failover). The 800 ms
+`PENDING_NEIGH_TIMEOUT_FAST_NS` drop fires ONLY for dead / non-responding
+destinations. The genuine hazard AGY-r1 surfaced is an **availability**
+one, not a latency one:
+
+> `pending_neigh` is capped at `MAX_PENDING_NEIGH = 4096` and each entry is
+> held for 800 ms. A sustained dead-host SYN storm (port scan, a subnet of
+> down hosts, a failover storm) keeps that bounded queue saturated. New
+> packets hit the full-queue gate at `poll_descriptor/mod.rs:2644` and are
+> dropped without buffering — **starving LIVE cold connects** that would
+> otherwise resolve in 1–9 ms.
+
+Path B3 adds a short-TTL **negative cache** so repeated cold packets to a
+non-responding destination fast-fail immediately (no 800 ms buffer, no
+queue slot consumed) instead of each re-occupying a `pending_neigh` slot.
+This both (a) frees the queue for live cold connects and (b) removes the
+per-attempt 800 ms penalty an operator perceives as "new connections are
+slow when caches are empty" when their targets are intermittently
+unreachable.
+
+## §2. Honest scope / value framing
+
+- **Win:** under a dead-host SYN storm, live cold connects continue to
+  resolve in single-digit ms instead of being dropped at the full-queue
+  gate. Steady-state (no dead hosts) behavior is byte-identical — the
+  negative cache is empty and adds one O(1) hashmap lookup on the
+  MissingNeighbor cold path only (NOT the established-flow hot path).
+- **Cost:** one `FastMap<(i32, IpAddr), u64>` per binding (bounded at 256
+  entries), one O(1) lookup on the MissingNeighbor slow path, one O(1)
+  insert at the drop-at-timeout site. No per-packet (established-flow)
+  cost. No allocation on the hot path after first-grow.
+- *If reviewers conclude the perf/availability gain is too small to
+  justify the churn, PLAN-KILL is an acceptable verdict.* (It is not
+  expected here — AGY-r1 rated the starvation hazard HIGH and the research
+  triple-review elevated B3 from "optional" to "recommended shippable".)
+
+## §3. What already exists / composes with
+
+- `pending_neigh: VecDeque<PendingNeighPacket>` per binding
+  (`worker/mod.rs:126`), cap `MAX_PENDING_NEIGH = 4096` (`mod.rs:342`).
+- Buffer/probe-fire site: `poll_descriptor/mod.rs:2379` (MissingNeighbor
+  handler) → push into `pending_neigh` at `:2644` gated by the cap.
+  Initial `trigger_kernel_arp_probe` at `:2413-2432`.
+- Re-probe schedule + drop-at-timeout: `neighbor_dispatch.rs`
+  `retry_pending_neigh` (`:47`), `PROBE_SCHEDULE_NS` (`:33`, 10/60/260 ms),
+  drop site at `:110` (`now - queued > pending_neigh_timeout_ns`).
+- `pending_neigh_timeout_ns`: 800 ms fast (`PENDING_NEIGH_TIMEOUT_FAST_NS`,
+  `forwarding_build/mod.rs`) when kernel retrans confirmed, else 2 s
+  (`PENDING_NEIGH_TIMEOUT_NS`, `mod.rs:329`).
+- Resolution learn path: shared `neigh_monitor_thread` →
+  `parse_neighbor_msg` (`neighbor.rs:297`) → `update_dynamic_neighbor`
+  (`:280`) → `ShardedNeighborMap::insert_if_changed` populates the shared
+  `Arc<ShardedNeighborMap> dynamic_neighbors`. RTM_DELNEIGH / NUD_FAILED →
+  `remove_dynamic_neighbor`.
+- Neighbor lookup order (must mirror): static/Go-push `forwarding.neighbors`
+  FIRST, then `dynamic_neighbors` (`neighbor_dispatch.rs:117-126`,
+  `forwarding/mod.rs:1529`).
+
+## §4. Concrete design
+
+### 4.1 Constants (`afxdp/mod.rs`, next to `MAX_PENDING_NEIGH`)
+
+```rust
+/// #1651 B3: short TTL for the dead-host negative neighbor cache. A dst
+/// that exhausted all PROBE_SCHEDULE_NS re-probes and hit the
+/// pending_neigh drop is suppressed for this long so a dead-host SYN
+/// storm cannot re-occupy pending_neigh slots and starve live cold
+/// connects. 3 s is: (a) > the 800 ms fast drop, so each storm packet is
+/// suppressed across many connection attempts; (b) short enough that a
+/// recovered host is penalized at most one TTL window — and recovery is
+/// usually faster because RTM_NEWNEIGH eviction (below) is immediate.
+const NEG_NEIGH_TTL_NS: u64 = 3_000_000_000;
+
+/// #1651 B3: bound on the per-binding negative cache. A /24 scan touches
+/// 254 dsts; 256 covers a full subnet sweep without unbounded growth.
+/// On overflow the map is cleared wholesale (best-effort optimization —
+/// losing suppression for a few dsts only costs one more 800 ms drop,
+/// never correctness). clear() retains capacity → no realloc churn.
+const MAX_NEG_NEIGH_CACHE: usize = 256;
+```
+
+### 4.2 Per-binding field (`worker/mod.rs` BindingWorker, all 3 ctors)
+
+```rust
+/// #1651 B3: dead-host negative neighbor cache. Key
+/// (egress_ifindex, next_hop); value = insertion now_ns. A dst is
+/// inserted when it exhausts all re-probes and hits the pending_neigh
+/// drop; while present + un-expired + still-unresolved, new
+/// MissingNeighbor packets to it fast-fail (recycle) instead of buffering
+/// for another 800 ms. Per-binding (mirrors pending_neigh) — the
+/// per-queue AF_XDP model keeps this thread-local, no cross-core sync.
+pub(crate) neg_neigh_cache: FastMap<(i32, IpAddr), u64>,
+```
+
+Constructed `FastMap::default()` in all three ctors (lazy-grow, like
+`pending_neigh`).
+
+### 4.3 Helper module (`afxdp/neg_neigh.rs`, new file, per modularity rules)
+
+Small, pure-as-possible, fully unit-tested. Two functions plus the lookup
+that the hot site calls:
+
+```rust
+use super::*;
+
+/// Returns true if `key` is currently negatively cached (present AND
+/// un-expired). Expired entries are evicted on access (lazy TTL). Does
+/// NOT consult the neighbor maps — the caller does that first so a
+/// resolved dst wins (RTM_NEWNEIGH eviction, §4.5).
+pub(super) fn neg_neigh_active(
+    cache: &mut FastMap<(i32, IpAddr), u64>,
+    key: &(i32, IpAddr),
+    now_ns: u64,
+) -> bool {
+    match cache.get(key) {
+        Some(&inserted) if now_ns.saturating_sub(inserted) < NEG_NEIGH_TTL_NS => true,
+        Some(_) => { cache.remove(key); false }   // expired — evict
+        None => false,
+    }
+}
+
+/// Record a dead-host drop. Bounded: on overflow, clear (retains cap).
+pub(super) fn neg_neigh_record(
+    cache: &mut FastMap<(i32, IpAddr), u64>,
+    key: (i32, IpAddr),
+    now_ns: u64,
+) {
+    if cache.len() >= MAX_NEG_NEIGH_CACHE && !cache.contains_key(&key) {
+        cache.clear();
+    }
+    cache.insert(key, now_ns);
+}
+
+/// Explicit eviction (resolved-neighbor-wins, §4.5). Idempotent.
+pub(super) fn neg_neigh_evict(
+    cache: &mut FastMap<(i32, IpAddr), u64>,
+    key: &(i32, IpAddr),
+) { cache.remove(key); }
+```
+
+### 4.4 Fast-fail at the MissingNeighbor site (`poll_descriptor/mod.rs`)
+
+Inside `ForwardingDisposition::MissingNeighbor`, immediately after
+`if let Some(next_hop) = decision.resolution.next_hop` is known and BEFORE
+the `trigger_kernel_arp_probe` / session-seed / buffer work, insert the
+fast-fail gate. It only fires when there IS a next_hop (no next_hop already
+cannot probe):
+
+```rust
+if let Some(next_hop) = decision.resolution.next_hop {
+    let neg_key = (decision.resolution.egress_ifindex, next_hop);
+    // Resolved-neighbor-wins (RTM_NEWNEIGH eviction): if the dst is now
+    // resolved (static or dynamic), drop any stale negative entry and
+    // fall through to normal forwarding. Mirrors the lookup order in
+    // retry_pending_neigh / lookup_neighbor_entry.
+    let resolved = worker_ctx.forwarding.neighbors.contains_key(&neg_key)
+        || worker_ctx.dynamic_neighbors.get(&neg_key).is_some();
+    if resolved {
+        neg_neigh_evict(&mut binding.neg_neigh_cache, &neg_key);
+    } else if neg_neigh_active(&mut binding.neg_neigh_cache, &neg_key, now_ns) {
+        // Dead-host fast-fail: recycle the frame, do NOT buffer, do NOT
+        // probe, do NOT consume a pending_neigh slot. This is what frees
+        // the queue for live cold connects under a dead-host storm.
+        telemetry.dbg.<new_counter> += 1;   // see §4.6
+        binding.scratch.scratch_recycle.push(desc.addr);
+        recycle_now = false;                 // we recycled explicitly
+        continue;                            // skip buffer + session-seed
+    }
+}
+```
+
+NOTE: the gate must run BEFORE the session-seed block (which installs the
+MissingNeighborSeed session + publishes shared/BPF entries). Fast-failing
+a dead host must NOT create a session. Placement: the very top of the
+`MissingNeighbor` arm.
+
+Concern to verify in review: the existing `MissingNeighbor` arm computes
+`from_zone`/`to_zone` then conditionally seeds a session and buffers. The
+`continue` must land us at the descriptor-loop boundary cleanly (same as
+the existing `continue`s at `:2533`/`:2563`). Confirm `scratch_recycle` is
+the correct recycle channel here (the source-NAT-failure path uses exactly
+`binding.scratch.scratch_recycle.push(desc.addr); continue;`).
+
+### 4.5 Record at the drop-at-timeout site (`neighbor_dispatch.rs:110`)
+
+```rust
+if now_ns.saturating_sub(pkt.queued_ns) > pending_neigh_timeout_ns {
+    // #1651 B3: this dst exhausted all re-probes and never resolved —
+    // negatively cache it so subsequent cold packets fast-fail instead
+    // of re-buffering for another 800 ms.
+    if let Some(hop) = pkt.decision.resolution.next_hop {
+        neg_neigh_record(
+            &mut binding.neg_neigh_cache,
+            (pkt.decision.resolution.egress_ifindex, hop),
+            now_ns,
+        );
+    }
+    binding.tx_pipeline.pending_fill_frames.push_back(pkt.addr);
+    continue;
+}
+```
+
+### 4.6 Invalidation summary (mandatory RTM_NEWNEIGH + TTL)
+
+- **RTM_NEWNEIGH (host came back):** the shared monitor thread populates
+  `dynamic_neighbors` (existing, unchanged). The per-binding fast-fail
+  gate (§4.4) checks `forwarding.neighbors` + `dynamic_neighbors` BEFORE
+  honoring a negative entry; on a resolved hit it calls `neg_neigh_evict`
+  and falls through to normal forwarding. So a recovered host connects on
+  the very next packet — invalidation is immediate, not TTL-bounded.
+  Rationale for lazy (not monitor-thread-driven) eviction: the negative
+  cache is per-binding (per-queue AF_XDP model) and the monitor thread has
+  no per-binding handle; coupling them would need a shared structure +
+  cross-core sync on the resolve path. Lazy resolved-wins is allocation-
+  free, O(1), and strictly correct (a resolved dst can never be wrongly
+  fast-failed).
+- **TTL:** `neg_neigh_active` evicts on access once
+  `now - inserted >= NEG_NEIGH_TTL_NS` (3 s). Covers the case where a dst
+  recovers but no traffic flowed for it (entry just ages out) and bounds
+  worst-case suppression of a recovered-but-silent host.
+
+### 4.7 Telemetry
+
+Add `neg_neigh_fast_fail: u64` to `WorkerTelemetry.dbg` (debug counter
+cluster) bumped at the fast-fail site. Cheap, matches the existing
+`missing_neigh` / `no_route` debug counters. (No new Prometheus surface in
+this PR — keep scope narrow; a follow-up can export it if ops wants it.)
+
+## §5. Public API preservation
+
+No public API change. New items are `pub(super)` / `pub(crate)` field on
+an internal struct. `retry_pending_neigh` and the MissingNeighbor handler
+keep their signatures (both already take `&mut BindingWorker`). No protocol
+/ wire / config / CLI surface touched.
+
+## §6. Hidden invariants to preserve
+
+- **Lookup order:** negative-cache resolved-wins check uses
+  `forwarding.neighbors` THEN `dynamic_neighbors` — identical to
+  `retry_pending_neigh:117-126` and `lookup_neighbor_entry`. A negative
+  entry must never shadow a resolved neighbor.
+- **No session for a dead host:** the fast-fail `continue` runs before the
+  session-seed block. A fast-failed packet creates no session, publishes
+  no shared/BPF entry, allocates no NAT binding.
+- **Recycle correctness:** fast-fail uses `scratch.scratch_recycle` +
+  `recycle_now = false` (the established pattern at the source-NAT-failure
+  paths). The frame is returned exactly once.
+- **Per-queue thread-locality:** `neg_neigh_cache` is touched ONLY by the
+  owning worker thread (poll_descriptor + retry both run on it). No Arc,
+  no Mutex, no cross-core sharing — consistent with `pending_neigh`.
+- **Allocation:** `FastMap` grows lazily; `clear()` on overflow retains
+  capacity. No per-packet allocation. Established-flow hot path untouched.
+- **Drop-newest policy:** unchanged for `pending_neigh`. The negative
+  cache itself uses clear-on-overflow (documented best-effort).
+- **HA portability:** negative cache is pure local optimization, NOT
+  synced. A failover peer rebuilds it naturally (first dead-host drop
+  re-populates). No HA-sync change.
+
+## §7. Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression | LOW | Empty cache ⇒ byte-identical to today. Only new behavior: dead-host repeat packets recycle instead of buffer. Resolved-wins guard prevents shadowing a live host. |
+| Lifetime / borrow-checker | LOW | `&mut binding.neg_neigh_cache` borrows disjoint from `worker_ctx.forwarding`/`dynamic_neighbors` (different objects). Helper takes `&mut FastMap` + plain key. |
+| Performance regression | LOW | One O(1) lookup on the MissingNeighbor *cold* path only. Zero cost on established-flow hot path and on the empty-cache common case (a `contains_key` miss). |
+| Architectural mismatch | LOW | Mirrors `pending_neigh` placement exactly; no new shared map, no monitor-thread coupling. Design blessed by the research triple-review. |
+
+## §8. Test plan
+
+- `cargo build --release` clean after each change.
+- New `mod tests` in `neg_neigh.rs`: TTL active/expire edges; record +
+  bounded-clear-on-overflow; evict idempotence; resolved-wins (a key in
+  `dynamic_neighbors` is never fast-failed); a dead key is fast-failed,
+  then after `insert_if_changed` into `dynamic_neighbors` the same key is
+  NOT fast-failed (RTM_NEWNEIGH-evict simulation).
+- A `retry_pending_neigh` test: a never-resolving pkt that crosses the
+  timeout records its key in `neg_neigh_cache`.
+- Full `cargo test --release`.
+- 5/5 flake on the most-affected named test (`retry_pending_*` /
+  `neg_neigh_*`).
+- Go suite (`go test ./...`).
+- DEPLOY + FULL SMOKE MATRIX on `loss:xpf-userspace-fw0/fw1`
+  (v4+v6 × push+`-R` × CoS-off+CoS-on, per-class 5201-5211).
+- **Dead-host-starvation proof (added):** hammer cold SYNs at a batch of
+  unused on-link IPs (172.16.80.120-139) WHILE running a live cold connect
+  to a real host; prove the live connect still completes in single-digit
+  ms and the dead-host attempts fast-fail after the first 800 ms drop.
+  fail-before/pass-after: run the same storm against the origin/master
+  binary (live connect starves) vs this branch (live connect survives).
+- `make test-failover` (touches the worker/binding path).
+
+## §9. Out of scope (explicitly)
+
+- Path A (active dataplane ARP/NDP resolution) — KILLED.
+- Path B1 (netlink fd in worker poll set) — optional ≤1 ms polish,
+  separate change.
+- Prometheus export of the fast-fail counter — follow-up.
+- The two spin-off cache-correctness bugs (dynamic-neighbor leak on
+  `update_neighbors` replace; monitor socket `SO_RCVBUF`) — separate
+  issues per research §7.
+- Lowering `PENDING_NEIGH_TIMEOUT_FAST_NS` — bounded by the <1 s TCP-RTO
+  design constraint; not touched.
+
+## §10. Open questions for adversarial review
+
+1. **Placement of the gate (§4.4):** is the very top of the
+   `MissingNeighbor` arm correct, and is `scratch.scratch_recycle` +
+   `recycle_now = false` + `continue` the right recycle channel there
+   (vs `pending_fill_frames`)? The frame here is a fresh RX descriptor,
+   not a previously-buffered pending frame — so `scratch_recycle` (the
+   RX-recycle channel) is what the source-NAT-failure path uses. Confirm.
+2. **Resolved-wins races:** can a key be in `dynamic_neighbors` AND
+   negatively cached simultaneously in a way that wrongly fast-fails a
+   live host? (Claim: no — the resolved check runs first and evicts.)
+   Conversely, can a dst resolve *between* the resolved-check and the
+   buffer, causing a needless 800 ms wait? (Claim: same as today — the
+   retry loop re-drives within ≤1 ms once `dynamic_neighbors` updates.)
+3. **TTL value (3 s):** too long (penalizes a recovered-but-silent host)
+   or too short (storm leaks through more often)? Given RTM_NEWNEIGH
+   eviction is immediate for any host that *receives traffic*, the TTL
+   only governs recovered-but-silent hosts. Is 3 s defensible?
+4. **Overflow policy (clear-on-full):** is wholesale `clear()` acceptable
+   vs LRU/random eviction? (Claim: yes — losing suppression for a few
+   dsts costs at most one extra 800 ms drop, never correctness; clear is
+   O(1)-amortized and allocation-free. A /24 scan = 254 dsts < 256 cap so
+   clear is rare even under a full-subnet sweep.)
+5. **Key correctness:** `(egress_ifindex, next_hop)` — is `egress_ifindex`
+   the logical (VLAN) ifindex consistently between the record site
+   (`pkt.decision.resolution.egress_ifindex`) and the fast-fail site
+   (`decision.resolution.egress_ifindex`)? Gate-M' showed `egress_if=14` =
+   logical VLAN ifindex at both. Confirm no physical/logical mismatch.
+6. **Does the gate starve a live-but-SLOW host** that legitimately takes
+   >800 ms to ARP-reply once, then is negatively cached for 3 s? (Claim:
+   such a host, once it replies, lands in `dynamic_neighbors` and is
+   evicted by resolved-wins on its next packet. The only loss is the
+   in-flight 3 s window for a host whose reply was dropped AND who sends
+   no further packets — degenerate.)

--- a/docs/pr/1651-b3-negcache/plan.md
+++ b/docs/pr/1651-b3-negcache/plan.md
@@ -1,7 +1,30 @@
 # Plan — #1651 Path B3: dead-host negative cache
 
-- **Status:** DRAFT v1 — pending adversarial plan review (B3 already
-  design-blessed in the research plan; this is the IMPLEMENTATION plan).
+- **Status:** PLAN-READY v2 — Codex r1 PLAN-NEEDS-MINOR (4 minors folded
+  below), AGY r1 PLAN-READY, Claude SMR PLAN-READY. B3 design-blessed by
+  the research triple-review; this is the IMPLEMENTATION plan.
+
+### Plan-review dispositions (round 1)
+
+- **Codex #1 / Claude SMR (recycle channel):** drop the redundant
+  `recycle_now = false`; use bare `scratch_recycle.push(desc.addr);
+  continue;` matching the source-NAT-failure paths (`:2532`/`:2562`).
+  APPLIED in §4.4 below.
+- **Codex #2 (probe-exhaustion wording):** the drop branch
+  (`neighbor_dispatch.rs:110`) runs BEFORE the probe block (`:136`), so a
+  delayed sweep can drop after <3 probes. Reworded: "timed out after
+  best-effort probes" rather than "exhausted all 3". The record condition
+  is the timeout itself (the dst never resolved within the window), which
+  is the right signal regardless of probe count. APPLIED §4.5.
+- **Codex #3 (resolved-wins race):** correct as a steady-state rule, not a
+  race-free absolute. A RTM_NEWNEIGH landing between the resolved-check
+  and the fast-fail costs AT MOST one stale fast-fail (one extra cold
+  connect attempt) — never a persistent shadow. Wording softened from
+  "never" to "never persistently". APPLIED §6.
+- **Codex #4 (telemetry target):** the `missing_neigh`/`no_route` counters
+  live in `DebugPollCounters` accessed via `telemetry.dbg`
+  (`types/runtime.rs:239`), NOT `WorkerTelemetry`. The new counter goes on
+  `DebugPollCounters` as `neg_neigh_fast_fail`. APPLIED §4.7.
 - **Branch:** `pr/1651-b3-negcache`
 - **Base:** origin/master @ `a107e7489`
 - **Issue:** #1651 (reopened) — Path B3 ONLY. Path A (active resolution)
@@ -180,10 +203,9 @@ if let Some(next_hop) = decision.resolution.next_hop {
         // Dead-host fast-fail: recycle the frame, do NOT buffer, do NOT
         // probe, do NOT consume a pending_neigh slot. This is what frees
         // the queue for live cold connects under a dead-host storm.
-        telemetry.dbg.<new_counter> += 1;   // see §4.6
+        telemetry.dbg.neg_neigh_fast_fail += 1;   // §4.7
         binding.scratch.scratch_recycle.push(desc.addr);
-        recycle_now = false;                 // we recycled explicitly
-        continue;                            // skip buffer + session-seed
+        continue;  // recycled explicitly; skips epilogue + session-seed
     }
 }
 ```
@@ -204,9 +226,11 @@ the correct recycle channel here (the source-NAT-failure path uses exactly
 
 ```rust
 if now_ns.saturating_sub(pkt.queued_ns) > pending_neigh_timeout_ns {
-    // #1651 B3: this dst exhausted all re-probes and never resolved —
-    // negatively cache it so subsequent cold packets fast-fail instead
-    // of re-buffering for another 800 ms.
+    // #1651 B3: this dst timed out after best-effort probes and never
+    // resolved — negatively cache it so subsequent cold packets fast-fail
+    // instead of re-buffering for another 800 ms. (The timeout, not the
+    // probe count, is the signal: the dst never landed in the neighbor
+    // maps within the window.)
     if let Some(hop) = pkt.decision.resolution.next_hop {
         neg_neigh_record(
             &mut binding.neg_neigh_cache,
@@ -240,10 +264,10 @@ if now_ns.saturating_sub(pkt.queued_ns) > pending_neigh_timeout_ns {
 
 ### 4.7 Telemetry
 
-Add `neg_neigh_fast_fail: u64` to `WorkerTelemetry.dbg` (debug counter
-cluster) bumped at the fast-fail site. Cheap, matches the existing
-`missing_neigh` / `no_route` debug counters. (No new Prometheus surface in
-this PR — keep scope narrow; a follow-up can export it if ops wants it.)
+Add `neg_neigh_fast_fail: u64` to `DebugPollCounters` (`types/runtime.rs`,
+the struct behind `telemetry.dbg` — same home as `missing_neigh`/
+`no_route`), bumped at the fast-fail site. Cheap; no new Prometheus
+surface in this PR (follow-up can export it).
 
 ## §5. Public API preservation
 

--- a/docs/pr/1651-b3-negcache/reviewer-ids.md
+++ b/docs/pr/1651-b3-negcache/reviewer-ids.md
@@ -16,3 +16,9 @@
 - AGY: adversarial-review-mpr5spiq-lcavkt
 - Copilot: requested via @copilot review on PR #1660
 - Claude SMR: in-conversation hostile review (below)
+
+## Code review (round 2 — follow-up on a4b9322bf after addressing Codex minors)
+- Codex: task-mpr66mkq-t86yph — MERGE-READY (both minors addressed, 53 placeholders=53 args, refactor behavior-identical)
+- AGY: adversarial-review-mpr5spiq-lcavkt — MERGE-READY (round 1; delta is review-fixes only)
+- Copilot: COMMENTED on b215c201e, zero inline comments (clean); did not re-fire on a4b9322bf
+- Claude SMR: MERGE-READY

--- a/docs/pr/1651-b3-negcache/reviewer-ids.md
+++ b/docs/pr/1651-b3-negcache/reviewer-ids.md
@@ -10,3 +10,9 @@
 - AGY: (pending)
 - Copilot: (pending)
 - Claude SMR: in-conversation
+
+## Code review (round 1) — actual IDs
+- Codex: task-mpr5sfbi-hba88j
+- AGY: adversarial-review-mpr5spiq-lcavkt
+- Copilot: requested via @copilot review on PR #1660
+- Claude SMR: in-conversation hostile review (below)

--- a/docs/pr/1651-b3-negcache/reviewer-ids.md
+++ b/docs/pr/1651-b3-negcache/reviewer-ids.md
@@ -1,0 +1,12 @@
+# #1651 B3 negative-cache — reviewer task IDs
+
+## Plan review (round 1)
+- Codex: (pending)
+- AGY: (pending)
+- Claude SMR: in-conversation (see below)
+
+## Code review (round 1)
+- Codex: (pending)
+- AGY: (pending)
+- Copilot: (pending)
+- Claude SMR: in-conversation

--- a/docs/pr/1651-b3-negcache/reviewer-ids.md
+++ b/docs/pr/1651-b3-negcache/reviewer-ids.md
@@ -1,12 +1,12 @@
 # #1651 B3 negative-cache — reviewer task IDs
 
 ## Plan review (round 1)
-- Codex: (pending)
-- AGY: (pending)
+- Codex: task-mpr4kgso-aecjuf
+- AGY: adversarial-review-mpr4ku4x-d2899w
 - Claude SMR: in-conversation (see below)
 
 ## Code review (round 1)
-- Codex: (pending)
+- Codex: task-mpr4kgso-aecjuf
 - AGY: (pending)
 - Copilot: (pending)
 - Claude SMR: in-conversation

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -341,6 +341,30 @@ const PENDING_NEIGH_TIMEOUT_NS: u64 = 2_000_000_000; // 2 seconds
 // keeping idle-binding RSS near zero.
 const MAX_PENDING_NEIGH: usize = 4096;
 
+// #1651 B3: dead-host negative neighbor cache (per binding). When a
+// pending_neigh entry times out after best-effort ARP/NDP probes without
+// resolving, its (egress_ifindex, next_hop) is recorded here so subsequent
+// cold packets to the same dead host fast-fail immediately (recycle, no
+// pending_neigh slot consumed) instead of each buffering a SYN for the full
+// PENDING_NEIGH_TIMEOUT. This is the AGY-r1 HIGH starvation defense: a
+// dead-host SYN storm can no longer saturate the bounded pending_neigh queue
+// and drop LIVE cold connects at the full-queue gate.
+//
+// NEG_NEIGH_TTL_NS = 3 s: (a) > the 800 ms fast drop so each storm packet is
+// suppressed across many connection attempts; (b) short enough that a
+// recovered-but-silent host is penalized at most one TTL window. A host that
+// actually recovers AND receives traffic is evicted immediately by the
+// resolved-neighbor-wins check in poll_descriptor (RTM_NEWNEIGH populates the
+// shared dynamic_neighbors), so the TTL only governs recovered-but-silent
+// destinations.
+const NEG_NEIGH_TTL_NS: u64 = 3_000_000_000; // 3 seconds
+// Per-binding cap on the negative cache. A /24 scan touches 254 distinct
+// dsts; 256 covers a full subnet sweep without unbounded growth. On overflow
+// the map is cleared wholesale — a best-effort optimization, so losing
+// suppression for a few dsts only costs one more PENDING_NEIGH_TIMEOUT drop,
+// never correctness. FastMap::clear() retains bucket capacity (no realloc).
+const MAX_NEG_NEIGH_CACHE: usize = 256;
+
 #[inline]
 const fn tx_frame_capacity() -> usize {
     UMEM_FRAME_SIZE as usize
@@ -570,6 +594,10 @@ mod poll_stages;
 // extracted into afxdp/session_delta.rs.
 mod session_delta;
 use session_delta::{flush_session_deltas, purge_queued_flows_for_closed_deltas};
+
+// #1651 B3: dead-host negative neighbor cache helpers.
+mod neg_neigh;
+use neg_neigh::{neg_neigh_active, neg_neigh_evict, neg_neigh_record};
 
 // Issue 67.2: neighbor-dispatch helpers extracted into
 // afxdp/neighbor_dispatch.rs.

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -597,7 +597,7 @@ use session_delta::{flush_session_deltas, purge_queued_flows_for_closed_deltas};
 
 // #1651 B3: dead-host negative neighbor cache helpers.
 mod neg_neigh;
-use neg_neigh::{neg_neigh_active, neg_neigh_evict, neg_neigh_record};
+use neg_neigh::{neg_neigh_gate, neg_neigh_record};
 
 // Issue 67.2: neighbor-dispatch helpers extracted into
 // afxdp/neighbor_dispatch.rs.

--- a/userspace-dp/src/afxdp/neg_neigh.rs
+++ b/userspace-dp/src/afxdp/neg_neigh.rs
@@ -1,0 +1,167 @@
+//! #1651 Path B3: dead-host negative neighbor cache.
+//!
+//! A per-binding, short-TTL cache of `(egress_ifindex, next_hop)` keys that
+//! failed to resolve within `PENDING_NEIGH_TIMEOUT`. While a dst is present,
+//! un-expired, and still-unresolved, new `MissingNeighbor` packets to it
+//! fast-fail (recycle) at the buffer site instead of each consuming a
+//! `pending_neigh` slot for the full timeout window.
+//!
+//! This is the AGY-r1 HIGH starvation defense from the reopened-#1651
+//! research: a dead-host SYN storm can otherwise saturate the bounded
+//! `pending_neigh` queue (cap `MAX_PENDING_NEIGH`, 800 ms hold each) and
+//! starve LIVE cold connects at the full-queue gate.
+//!
+//! ## Invalidation
+//! - **RTM_NEWNEIGH (host recovered):** lazy resolved-neighbor-wins. The
+//!   caller checks `forwarding.neighbors` then `dynamic_neighbors` BEFORE
+//!   honoring a negative entry; on a resolved hit it calls
+//!   [`neg_neigh_evict`] and forwards normally. The shared netlink monitor
+//!   thread populates `dynamic_neighbors`, so a recovered host that receives
+//!   traffic is evicted on its very next packet — no monitor→per-binding
+//!   coupling needed.
+//! - **TTL:** [`neg_neigh_active`] evicts on access once the entry is older
+//!   than `NEG_NEIGH_TTL_NS`.
+//!
+//! ## Placement
+//! Per-binding (mirrors `pending_neigh`). Touched ONLY by the owning worker
+//! thread (both `poll_descriptor` and `retry_pending_neigh` run on it), so no
+//! `Arc`/`Mutex`/cross-core sync — consistent with the per-queue AF_XDP model.
+
+use super::types::FastMap;
+use super::{MAX_NEG_NEIGH_CACHE, NEG_NEIGH_TTL_NS};
+use std::net::IpAddr;
+
+/// Negative-cache map type: key `(egress_ifindex, next_hop)`, value =
+/// insertion `now_ns`.
+pub(super) type NegNeighCache = FastMap<(i32, IpAddr), u64>;
+
+/// Returns true if `key` is currently negatively cached (present AND
+/// un-expired). Expired entries are evicted on access (lazy TTL).
+///
+/// Does NOT consult the neighbor maps — the caller must check
+/// `forwarding.neighbors` / `dynamic_neighbors` FIRST so a resolved dst wins
+/// (RTM_NEWNEIGH eviction). This keeps the function pure w.r.t. the neighbor
+/// maps and trivially testable.
+pub(super) fn neg_neigh_active(cache: &mut NegNeighCache, key: &(i32, IpAddr), now_ns: u64) -> bool {
+    match cache.get(key) {
+        Some(&inserted) if now_ns.saturating_sub(inserted) < NEG_NEIGH_TTL_NS => true,
+        Some(_) => {
+            // Expired — evict on access so the map self-prunes.
+            cache.remove(key);
+            false
+        }
+        None => false,
+    }
+}
+
+/// Record a dead-host drop at `now_ns`. Bounded by `MAX_NEG_NEIGH_CACHE`: on
+/// overflow (and only when inserting a genuinely new key) the map is cleared
+/// wholesale. `clear()` retains capacity, so this is allocation-free.
+pub(super) fn neg_neigh_record(cache: &mut NegNeighCache, key: (i32, IpAddr), now_ns: u64) {
+    if cache.len() >= MAX_NEG_NEIGH_CACHE && !cache.contains_key(&key) {
+        cache.clear();
+    }
+    cache.insert(key, now_ns);
+}
+
+/// Explicit eviction (resolved-neighbor-wins). Idempotent.
+pub(super) fn neg_neigh_evict(cache: &mut NegNeighCache, key: &(i32, IpAddr)) {
+    cache.remove(key);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::afxdp::{MAX_NEG_NEIGH_CACHE, NEG_NEIGH_TTL_NS};
+    use std::net::Ipv4Addr;
+
+    fn key(last: u8) -> (i32, IpAddr) {
+        (14, IpAddr::V4(Ipv4Addr::new(172, 16, 80, last)))
+    }
+
+    #[test]
+    fn record_then_active_within_ttl() {
+        let mut c = NegNeighCache::default();
+        neg_neigh_record(&mut c, key(137), 1_000);
+        assert!(neg_neigh_active(&mut c, &key(137), 1_000));
+        // Just under TTL: still active.
+        assert!(neg_neigh_active(
+            &mut c,
+            &key(137),
+            1_000 + NEG_NEIGH_TTL_NS - 1
+        ));
+    }
+
+    #[test]
+    fn expires_at_ttl_boundary_and_evicts_on_access() {
+        let mut c = NegNeighCache::default();
+        neg_neigh_record(&mut c, key(137), 1_000);
+        // Exactly TTL elapsed (now - inserted == TTL) is NOT active (< TTL).
+        assert!(!neg_neigh_active(&mut c, &key(137), 1_000 + NEG_NEIGH_TTL_NS));
+        // The expired entry was evicted on access.
+        assert!(!c.contains_key(&key(137)));
+    }
+
+    #[test]
+    fn absent_key_is_not_active() {
+        let mut c = NegNeighCache::default();
+        assert!(!neg_neigh_active(&mut c, &key(99), 5_000));
+    }
+
+    #[test]
+    fn evict_is_idempotent() {
+        let mut c = NegNeighCache::default();
+        neg_neigh_record(&mut c, key(137), 1_000);
+        neg_neigh_evict(&mut c, &key(137));
+        assert!(!neg_neigh_active(&mut c, &key(137), 1_000));
+        // Second evict on an already-absent key is a no-op, no panic.
+        neg_neigh_evict(&mut c, &key(137));
+        assert!(!c.contains_key(&key(137)));
+    }
+
+    #[test]
+    fn resolved_wins_eviction_unsuppresses_recovered_host() {
+        // Simulates the RTM_NEWNEIGH path: a dead host is negatively cached,
+        // then resolves (caller evicts on the resolved-wins check). The same
+        // key must no longer fast-fail.
+        let mut c = NegNeighCache::default();
+        neg_neigh_record(&mut c, key(137), 1_000);
+        assert!(neg_neigh_active(&mut c, &key(137), 1_500));
+        // Host came back → caller evicts.
+        neg_neigh_evict(&mut c, &key(137));
+        assert!(!neg_neigh_active(&mut c, &key(137), 1_500));
+    }
+
+    #[test]
+    fn overflow_clears_then_reinserts_new_key() {
+        let mut c = NegNeighCache::default();
+        // Fill exactly to the cap with distinct keys.
+        for i in 0..MAX_NEG_NEIGH_CACHE {
+            // Spread across two octets so >256 distinct keys are expressible.
+            let k = (14i32, IpAddr::V4(Ipv4Addr::new(10, 0, (i >> 8) as u8, i as u8)));
+            neg_neigh_record(&mut c, k, 1_000);
+        }
+        assert_eq!(c.len(), MAX_NEG_NEIGH_CACHE);
+        // One more NEW key triggers wholesale clear, then inserts the new key.
+        let extra = (14i32, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+        neg_neigh_record(&mut c, extra, 2_000);
+        assert_eq!(c.len(), 1, "overflow must clear then hold only the new key");
+        assert!(neg_neigh_active(&mut c, &extra, 2_000));
+    }
+
+    #[test]
+    fn at_cap_reinsert_existing_key_does_not_clear() {
+        let mut c = NegNeighCache::default();
+        for i in 0..MAX_NEG_NEIGH_CACHE {
+            let k = (14i32, IpAddr::V4(Ipv4Addr::new(10, 0, (i >> 8) as u8, i as u8)));
+            neg_neigh_record(&mut c, k, 1_000);
+        }
+        assert_eq!(c.len(), MAX_NEG_NEIGH_CACHE);
+        // Re-recording an EXISTING key at cap must NOT clear (the
+        // !contains_key guard) — it just refreshes the timestamp.
+        let existing = (14i32, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)));
+        neg_neigh_record(&mut c, existing, 2_000);
+        assert_eq!(c.len(), MAX_NEG_NEIGH_CACHE);
+        assert!(neg_neigh_active(&mut c, &existing, 2_000));
+    }
+}

--- a/userspace-dp/src/afxdp/neg_neigh.rs
+++ b/userspace-dp/src/afxdp/neg_neigh.rs
@@ -69,6 +69,38 @@ pub(super) fn neg_neigh_evict(cache: &mut NegNeighCache, key: &(i32, IpAddr)) {
     cache.remove(key);
 }
 
+/// The full dead-host gate decision used at the `MissingNeighbor` handler.
+///
+/// `is_resolved` is the caller-supplied resolved-neighbor probe (static
+/// `forwarding.neighbors` THEN `dynamic_neighbors`, in that order — the
+/// closure encapsulates the lookup so this helper stays decoupled from the
+/// concrete map types and is unit-testable in isolation).
+///
+/// Semantics (resolved-neighbor-wins, then TTL):
+/// - If the dst is now resolved, any stale negative entry is evicted and the
+///   gate returns `false` (proceed to normal forwarding). This is the
+///   RTM_NEWNEIGH invalidation path.
+/// - Else, if the dst is negatively cached + un-expired, return `true`
+///   (fast-fail: caller recycles the frame without buffering / probing /
+///   seeding a session).
+/// - Else return `false` (proceed: first cold connect for this dst, or the
+///   negative entry has expired).
+///
+/// Returns `true` ⇒ the caller must fast-fail this packet.
+pub(super) fn neg_neigh_gate<F: FnOnce() -> bool>(
+    cache: &mut NegNeighCache,
+    key: &(i32, IpAddr),
+    now_ns: u64,
+    is_resolved: F,
+) -> bool {
+    if is_resolved() {
+        neg_neigh_evict(cache, key);
+        false
+    } else {
+        neg_neigh_active(cache, key, now_ns)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,6 +179,54 @@ mod tests {
         neg_neigh_record(&mut c, extra, 2_000);
         assert_eq!(c.len(), 1, "overflow must clear then hold only the new key");
         assert!(neg_neigh_active(&mut c, &extra, 2_000));
+    }
+
+    #[test]
+    fn gate_first_cold_connect_proceeds() {
+        // No negative entry, not resolved → proceed (false). The first cold
+        // connect to a dst must NOT fast-fail (it buffers + probes normally).
+        let mut c = NegNeighCache::default();
+        assert!(!neg_neigh_gate(&mut c, &key(137), 1_000, || false));
+    }
+
+    #[test]
+    fn gate_dead_host_fast_fails_then_resolved_wins() {
+        // The exact poll_descriptor gate decision sequence:
+        let mut c = NegNeighCache::default();
+        // 1) dst dropped at timeout → recorded.
+        neg_neigh_record(&mut c, key(137), 1_000);
+        // 2) repeat cold packet, still unresolved + un-expired → fast-fail.
+        assert!(
+            neg_neigh_gate(&mut c, &key(137), 1_500, || false),
+            "negatively-cached unresolved dst must fast-fail",
+        );
+        // 3) RTM_NEWNEIGH: dst now resolved → gate evicts and proceeds.
+        assert!(
+            !neg_neigh_gate(&mut c, &key(137), 1_600, || true),
+            "resolved dst must NOT fast-fail (resolved-wins)",
+        );
+        // 4) the negative entry was evicted by the resolved-wins branch, so a
+        //    later un-resolved check no longer fast-fails.
+        assert!(
+            !neg_neigh_gate(&mut c, &key(137), 1_700, || false),
+            "resolved-wins must have evicted the negative entry",
+        );
+        assert!(!c.contains_key(&key(137)));
+    }
+
+    #[test]
+    fn gate_expired_entry_proceeds_and_prunes() {
+        let mut c = NegNeighCache::default();
+        neg_neigh_record(&mut c, key(137), 1_000);
+        // Past TTL, still unresolved → gate returns false (proceed) and the
+        // expired entry is pruned by the active() lazy-evict.
+        assert!(!neg_neigh_gate(
+            &mut c,
+            &key(137),
+            1_000 + NEG_NEIGH_TTL_NS,
+            || false
+        ));
+        assert!(!c.contains_key(&key(137)));
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -108,6 +108,22 @@ pub(super) fn retry_pending_neigh(
             .expect("pending_neigh shrank during retry sweep");
         // Timeout: recycle frame and drop.
         if now_ns.saturating_sub(pkt.queued_ns) > pending_neigh_timeout_ns {
+            // #1651 B3: this dst timed out after best-effort ARP/NDP probes
+            // and never resolved — negatively cache (egress_ifindex,
+            // next_hop) so subsequent cold packets fast-fail at the
+            // MissingNeighbor buffer site instead of re-buffering for
+            // another full PENDING_NEIGH_TIMEOUT. The timeout (not the probe
+            // count) is the signal: the dst never landed in the neighbor
+            // maps within the window. Same lookup key the fast-fail gate
+            // uses (egress_ifindex is the logical/VLAN ifindex at both
+            // sites).
+            if let Some(hop) = pkt.decision.resolution.next_hop {
+                neg_neigh_record(
+                    &mut binding.neg_neigh_cache,
+                    (pkt.decision.resolution.egress_ifindex, hop),
+                    now_ns,
+                );
+            }
             binding.tx_pipeline.pending_fill_frames.push_back(pkt.addr);
             continue;
         }
@@ -499,6 +515,88 @@ mod mirror_tests {
         assert!(
             !forwarded_req.mirror_clone,
             "primary forwarding request must not inherit mirror identity",
+        );
+    }
+
+    /// #1651 B3: a never-resolving pending packet that crosses the timeout
+    /// must (a) be dropped (recycled, removed from the queue) and (b) record
+    /// its (egress_ifindex, next_hop) in the binding's negative cache so
+    /// subsequent cold packets to the same dead host fast-fail.
+    #[test]
+    fn timed_out_pending_neighbor_records_negative_cache() {
+        let mut bindings = vec![
+            BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+            BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+        ];
+        let original_frame = build_ipv4_test_packet(0);
+        unsafe {
+            bindings[0]
+                .umem
+                .area()
+                .slice_mut_unchecked(0, original_frame.len())
+        }
+        .expect("ingress frame")
+        .copy_from_slice(&original_frame);
+
+        let next_hop = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 137));
+        let meta = pending_neighbor_meta(original_frame.len());
+        bindings[0].pending_neigh.push_back(PendingNeighPacket {
+            addr: 0,
+            desc: XdpDesc {
+                addr: 0,
+                len: original_frame.len() as u32,
+                options: 0,
+            },
+            meta,
+            decision: resolved_neighbor_decision(next_hop),
+            flow_key: Some(test_session_key(12345, 443)),
+            queued_ns: 0,
+            // All probes already fired; the dst never resolved.
+            probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
+        });
+
+        // No neighbor for `next_hop` anywhere → unresolved. Use the
+        // compile-time fallback timeout (default ForwardingState leaves
+        // pending_neigh_timeout_ns == 0).
+        let forwarding = ForwardingState::default();
+        let lookup = WorkerBindingLookup::from_bindings(&bindings);
+        let mirror_targets = MirrorTargetMap::default();
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+        let mut shared_recycles = Vec::new();
+        let area = bindings[0].umem.area() as *const MmapArea;
+        let (left, rest) = bindings.split_at_mut(0);
+        let (binding, right) = rest.split_first_mut().expect("ingress binding");
+
+        // now_ns just past the 2s fallback timeout.
+        let now_ns = PENDING_NEIGH_TIMEOUT_NS + 1;
+        retry_pending_neigh(
+            binding,
+            left,
+            0,
+            right,
+            &lookup,
+            &mirror_targets,
+            &forwarding,
+            &dynamic_neighbors,
+            now_ns,
+            unsafe { &*area },
+            &mut shared_recycles,
+        );
+
+        // The packet was dropped (recycled to fill ring, queue drained).
+        assert!(
+            bindings[0].pending_neigh.is_empty(),
+            "timed-out pending packet must be dropped",
+        );
+        // The dead-host key was recorded and is active.
+        let key = (80i32, next_hop); // egress_ifindex 80 per resolved_neighbor_decision
+        assert!(
+            crate::afxdp::neg_neigh::neg_neigh_active(
+                &mut bindings[0].neg_neigh_cache,
+                &key,
+                now_ns,
+            ),
+            "timed-out dst must be negatively cached",
         );
     }
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2378,6 +2378,54 @@ pub(super) fn poll_binding_process_descriptor(
                             }
                             ForwardingDisposition::MissingNeighbor => {
                                 telemetry.dbg.missing_neigh += 1;
+                                // #1651 B3: dead-host fast-fail gate. Runs at
+                                // the very top of the MissingNeighbor arm,
+                                // BEFORE the kernel probe, session seed, and
+                                // pending_neigh buffer, so a dead host never
+                                // consumes a queue slot, fires a probe, or
+                                // creates a MissingNeighborSeed session.
+                                //
+                                // Resolved-neighbor-wins (RTM_NEWNEIGH
+                                // invalidation): check static then dynamic
+                                // neighbors FIRST (same order as
+                                // retry_pending_neigh / lookup_neighbor_entry).
+                                // If the dst is now resolved, drop any stale
+                                // negative entry and fall through to normal
+                                // forwarding. Otherwise, if it is still
+                                // negatively cached + un-expired, recycle the
+                                // frame immediately.
+                                if let Some(next_hop) = decision.resolution.next_hop {
+                                    let neg_key =
+                                        (decision.resolution.egress_ifindex, next_hop);
+                                    let resolved = worker_ctx
+                                        .forwarding
+                                        .neighbors
+                                        .contains_key(&neg_key)
+                                        || worker_ctx
+                                            .dynamic_neighbors
+                                            .get(&neg_key)
+                                            .is_some();
+                                    if resolved {
+                                        neg_neigh_evict(
+                                            &mut binding.neg_neigh_cache,
+                                            &neg_key,
+                                        );
+                                    } else if neg_neigh_active(
+                                        &mut binding.neg_neigh_cache,
+                                        &neg_key,
+                                        now_ns,
+                                    ) {
+                                        telemetry.dbg.neg_neigh_fast_fail += 1;
+                                        // Fresh RX descriptor → recycle via
+                                        // scratch_recycle + continue, matching
+                                        // the source-NAT-failure discard
+                                        // pattern. The continue skips the
+                                        // recycle_now epilogue and the
+                                        // session-seed/buffer below.
+                                        binding.scratch.scratch_recycle.push(desc.addr);
+                                        continue;
+                                    }
+                                }
                                 // #919/#922: zero-allocation ID-native resolution.
                                 let (from_zone_id, to_zone_id) = zone_pair_ids_for_flow_with_override(
                                     worker_ctx.forwarding,

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2397,24 +2397,27 @@ pub(super) fn poll_binding_process_descriptor(
                                 if let Some(next_hop) = decision.resolution.next_hop {
                                     let neg_key =
                                         (decision.resolution.egress_ifindex, next_hop);
-                                    let resolved = worker_ctx
-                                        .forwarding
-                                        .neighbors
-                                        .contains_key(&neg_key)
-                                        || worker_ctx
-                                            .dynamic_neighbors
-                                            .get(&neg_key)
-                                            .is_some();
-                                    if resolved {
-                                        neg_neigh_evict(
-                                            &mut binding.neg_neigh_cache,
-                                            &neg_key,
-                                        );
-                                    } else if neg_neigh_active(
+                                    // neg_neigh_gate runs the resolved-wins
+                                    // probe (static neighbors THEN dynamic,
+                                    // same order as retry_pending_neigh /
+                                    // lookup_neighbor_entry) and the TTL check.
+                                    // Returns true ⇒ fast-fail this packet.
+                                    let fast_fail = neg_neigh_gate(
                                         &mut binding.neg_neigh_cache,
                                         &neg_key,
                                         now_ns,
-                                    ) {
+                                        || {
+                                            worker_ctx
+                                                .forwarding
+                                                .neighbors
+                                                .contains_key(&neg_key)
+                                                || worker_ctx
+                                                    .dynamic_neighbors
+                                                    .get(&neg_key)
+                                                    .is_some()
+                                        },
+                                    );
+                                    if fast_fail {
                                         telemetry.dbg.neg_neigh_fast_fail += 1;
                                         // Fresh RX descriptor → recycle via
                                         // scratch_recycle + continue, matching

--- a/userspace-dp/src/afxdp/types/runtime.rs
+++ b/userspace-dp/src/afxdp/types/runtime.rs
@@ -254,6 +254,11 @@ pub(in crate::afxdp) struct DebugPollCounters {
     pub(in crate::afxdp) no_route: u64,
     #[allow(dead_code)]
     pub(in crate::afxdp) missing_neigh: u64,
+    /// #1651 B3: dead-host negative-cache fast-fail count. Bumped when a
+    /// MissingNeighbor packet to a negatively-cached (un-expired,
+    /// still-unresolved) dst is recycled without buffering.
+    #[allow(dead_code)]
+    pub(in crate::afxdp) neg_neigh_fast_fail: u64,
     #[allow(dead_code)]
     pub(in crate::afxdp) policy_deny: u64,
     #[allow(dead_code)]

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -199,6 +199,9 @@ pub(crate) fn worker_loop(
     let mut dbg_no_route = 0u64;
     #[cfg(feature = "debug-log")]
     let mut dbg_missing_neigh = 0u64;
+    // #1651 B3: dead-host negative-cache fast-fail count.
+    #[cfg(feature = "debug-log")]
+    let mut dbg_neg_neigh_fast_fail = 0u64;
     #[cfg(feature = "debug-log")]
     let mut dbg_policy_deny = 0u64;
     #[cfg(feature = "debug-log")]
@@ -740,6 +743,7 @@ pub(crate) fn worker_loop(
             dbg_session_create += dbg_poll.session_create;
             dbg_no_route += dbg_poll.no_route;
             dbg_missing_neigh += dbg_poll.missing_neigh;
+            dbg_neg_neigh_fast_fail += dbg_poll.neg_neigh_fast_fail;
             dbg_policy_deny += dbg_poll.policy_deny;
             dbg_ha_inactive += dbg_poll.ha_inactive;
             dbg_no_egress_binding += dbg_poll.no_egress_binding;
@@ -991,7 +995,7 @@ pub(crate) fn worker_loop(
                 #[cfg(feature = "debug-log")]
                 eprintln!(
                     "DBG w{}: {:.1}s rx={} tx={} fwd={} local={} sess_hit={} sess_miss={} sess_create={} \
-                     no_route={} miss_neigh={} pol_deny={} ha_inact={} no_egress={} build_fail={} \
+                     no_route={} miss_neigh={} neg_ff={} pol_deny={} ha_inact={} no_egress={} build_fail={} \
                      tx_err={} meta_err={} other={} enq_ok={} enq_ip={} enq_dir={} enq_cp={} sessions={} \
                      DIR:trust_rx={}/wan_rx={}/t2w={}/w2t={} NAT:snat={}/dnat={}/none={}/bld_none={} RST:rx={}/tx={} \
                      SIZE:rx_avg={}/rx_max={}/tx_avg={}/tx_max={}/rx_over={}/seg_miss={} \
@@ -1009,6 +1013,7 @@ pub(crate) fn worker_loop(
                     dbg_session_create,
                     dbg_no_route,
                     dbg_missing_neigh,
+                    dbg_neg_neigh_fast_fail,
                     dbg_policy_deny,
                     dbg_ha_inactive,
                     dbg_no_egress_binding,
@@ -1095,6 +1100,7 @@ pub(crate) fn worker_loop(
                     dbg_session_create = 0;
                     dbg_no_route = 0;
                     dbg_missing_neigh = 0;
+                    dbg_neg_neigh_fast_fail = 0;
                     dbg_policy_deny = 0;
                     dbg_ha_inactive = 0;
                     dbg_no_egress_binding = 0;

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -124,6 +124,15 @@ pub(crate) struct BindingWorker {
     /// Packets waiting for neighbor resolution. The UMEM frame is held
     /// (not recycled) until the neighbor resolves or the entry times out.
     pub(crate) pending_neigh: VecDeque<PendingNeighPacket>,
+    /// #1651 B3: dead-host negative neighbor cache. Key
+    /// `(egress_ifindex, next_hop)`; value = insertion `now_ns`. A dst is
+    /// recorded when it times out in `pending_neigh` without resolving;
+    /// while present + un-expired + still-unresolved, new `MissingNeighbor`
+    /// packets to it fast-fail (recycle) instead of buffering for another
+    /// `PENDING_NEIGH_TIMEOUT`. Per-binding (mirrors `pending_neigh`) —
+    /// touched only by the owning worker thread, no cross-core sync. Lazy
+    /// allocation (grows on first dead-host drop), like `pending_neigh`.
+    pub(crate) neg_neigh_cache: super::neg_neigh::NegNeighCache,
     /// #959 Phase 5: 4 BPF map FDs extracted into `WorkerBpfMaps`.
     /// Field semantics unchanged; access via `binding.bpf_maps.X_fd`.
     pub(crate) bpf_maps: WorkerBpfMaps,
@@ -406,6 +415,8 @@ impl BindingWorker {
             // idle. Start at 0 capacity and let VecDeque grow on push as
             // packets actually queue up.
             pending_neigh: VecDeque::new(),
+            // #1651 B3: lazy-grow (empty until first dead-host drop).
+            neg_neigh_cache: super::neg_neigh::NegNeighCache::default(),
             bpf_maps: WorkerBpfMaps {
                 heartbeat_map_fd,
                 session_map_fd,
@@ -539,6 +550,8 @@ impl BindingWorker {
                 scratch_rst_teardowns: Vec::with_capacity(16),
             },
             pending_neigh: VecDeque::new(),
+            // #1651 B3: lazy-grow (empty until first dead-host drop).
+            neg_neigh_cache: super::neg_neigh::NegNeighCache::default(),
             bpf_maps: WorkerBpfMaps {
                 heartbeat_map_fd: -1,
                 session_map_fd: -1,
@@ -653,6 +666,8 @@ impl BindingWorker {
                 scratch_rst_teardowns: Vec::with_capacity(16),
             },
             pending_neigh: VecDeque::new(),
+            // #1651 B3: lazy-grow (empty until first dead-host drop).
+            neg_neigh_cache: super::neg_neigh::NegNeighCache::default(),
             bpf_maps: WorkerBpfMaps {
                 heartbeat_map_fd: -1,
                 session_map_fd: -1,


### PR DESCRIPTION
## Summary

Path B3 of reopened #1651. The converged 3-way research (Codex+AGY+Claude SMR PLAN-READY) established that live empty-cache cold connects are already 1-9 ms on the supported dataplane; the 800 ms `pending_neigh` drop fires **only** for dead/non-responding hosts. The genuine hazard AGY-r1 rated HIGH is an **availability** one: a dead-host SYN storm saturates the bounded `pending_neigh` queue (`MAX_PENDING_NEIGH=4096`, 800 ms hold each) and, once full, drops LIVE cold connects at the admission gate — starving connects that would otherwise resolve in single-digit ms.

This adds a per-binding, short-TTL dead-host **negative cache** so repeated cold packets to a non-responding dst fast-fail immediately instead of each re-occupying a `pending_neigh` slot for the full timeout:

- **Record:** when a `pending_neigh` entry times out after best-effort ARP/NDP probes without resolving (`neighbor_dispatch.rs` drop site), its `(egress_ifindex, next_hop)` is recorded with the insertion timestamp.
- **Fast-fail:** at the `MissingNeighbor` handler (`poll_descriptor`), BEFORE the kernel probe / session seed / `pending_neigh` buffer, a negatively-cached, un-expired, still-unresolved dst is recycled immediately (`scratch_recycle` + `continue`) — no queue slot, no probe, no `MissingNeighborSeed` session.
- **Invalidation (both mandatory paths):**
  - **RTM_NEWNEIGH** (host recovered): lazy resolved-neighbor-wins. The gate checks `forwarding.neighbors` then `dynamic_neighbors` FIRST (same order as `retry_pending_neigh` / `lookup_neighbor_entry`); on a resolved hit it evicts the negative entry and forwards normally. The shared netlink monitor thread already populates `dynamic_neighbors`, so a recovered host that receives traffic is unsuppressed on its very next packet — no monitor-thread/per-binding coupling needed.
  - **TTL:** `NEG_NEIGH_TTL_NS = 3 s`, evicted on access. Bounds suppression of a recovered-but-silent host.

Bounded at `MAX_NEG_NEIGH_CACHE=256`; on overflow the `FastMap` is cleared wholesale (best-effort optimization, never a correctness issue; `clear()` retains capacity). The established-flow hot path is untouched; the only added cost is one O(1) lookup on the `MissingNeighbor` cold path. Steady-state (empty cache) behavior is byte-identical. Per-binding placement mirrors `pending_neigh` — touched only by the owning worker thread, no `Arc`/`Mutex`/cross-core sync. Not HA-synced; a failover peer rebuilds it on the first dead-host drop.

## Plan + adversarial plan review

Plan doc: `docs/pr/1651-b3-negcache/plan.md`

- Codex round-1: PLAN-NEEDS-MINOR (4 minors, all folded) — task `task-mpr4kgso-aecjuf`
- AGY round-1: PLAN-READY — job `adversarial-review-mpr4ku4x-d2899w`
- Claude SMR round-1: PLAN-READY (one minor, same as Codex #1)

## Test plan

- [x] cargo build --release clean
- [x] cargo test --release: 1668 pass (the lone `snat_contract_doc_guard` failure is pre-existing on master — `docs/userspace-dataplane-gaps.md` lacks the scanned `fail-closed` token and is not in this diff)
- [x] 8 new tests: 7 `neg_neigh` unit tests (TTL active/expire edges, overflow clear-vs-refresh, idempotent evict, resolved-wins) + 1 `retry_pending_neigh` integration test (timed-out dst is recorded)
- [x] `neg_neigh` 5/5 flake check
- [x] Go suite: all packages pass (with `TMPDIR=/tmp`; `/dev/shm` only fails 2 unrelated tests on unix-socket path length — diff is Rust-only)
- [x] Deploy on loss userspace cluster (both nodes run B3)
- [x] **Pass A — CoS disabled** (best-effort fast path)
  - [x] v4 push 8.52 / rev 8.54 Gbps, 0 retrans @ 172.16.80.200
  - [x] v6 push 8.24 / rev 8.56 Gbps, 0 retrans @ 2001:559:8585:80::200
  - [x] v4 `-P12 -R`: 23.0 Gbps, 0 retrans; v6 `-P12 -R`: 22.6-22.7 Gbps, 0 retrans (initial 818-retrans run was transient; 0 on two reruns)
- [x] **Pass B — CoS enabled** (per-class shaper + classifier): 44 measurements (ports 5201-5211, v4+v6, push+reverse) all 0 retrans; shaped classes hit configured rates (100m/1g/3g/6g/9g/...)
- [x] **Dead-host-storm proof:** live cold connect under a 143K-SYN storm at 20 unused on-link IPs — 6/6 succeed, all <100 ms (median 0.52 ms, max 3.06 ms). NOTE: on this /24 topology the `pending_neigh` queue cannot be fully saturated (max ~254 distinct on-link hops < 4096 cap), consistent with the research finding that the starvation hazard requires a large distinct-destination fan-out; the mechanism itself is proven by the unit/integration tests. Master comparison: both pass on the /24 (no regression).
- [x] `make test-failover`: 13/13 correctness assertions pass (iperf3 survived reboot-failover + rejoin + manual failback, 12/12 sessions synced, 22.6 Gbps post-failover). The lone failure is a boot-window timing artifact ("fw0 xpfd did not come back within 60s") — the immediately-following "fw0 rejoined as secondary" check passed; fw0 came back just past the 60s probe.

Closes #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)