### PR TITLE
userspace-dp: enlarge neigh_monitor netlink rcvbuf to absorb bursts (#1658)

### DIFF
--- a/docs/pr/1658-rcvbuf/plan.md
+++ b/docs/pr/1658-rcvbuf/plan.md
@@ -1,5 +1,55 @@
 # #1658 — neigh_monitor netlink socket SO_RCVBUF bump
 
+Status: v2 — Codex PLAN-NEEDS-MAJOR (task-mpraz4ey-2t7j92) + AGY PLAN-READY
+(review-mprazbiq-ikscx2) + Claude SMR. v2 incorporates all Codex/AGY
+findings; ready for implementation.
+
+## Reviewer dispositions (v1 → v2)
+
+- **Codex #1 / AGY #1 — ENOBUFS premise correct.** Verified: netlink
+  multicast overflow calls `netlink_overrun()` → sets `sk->sk_err =
+  ENOBUFS`; next `recvmsg()` returns -1/ENOBUFS. The `recv()<=0 ->
+  continue` at `:528` silently swallows it. NOT a kill. Kept.
+- **Codex #2 — 4 MiB under-justified.** FIXED: explicit burst target
+  stated below (survive ~20k queued events ≈ a full large-L2-domain
+  neighbor flush while the thread is stalled up to the 500 ms
+  SO_RCVTIMEO tick). AGY #2 independently endorses 4 MiB and notes
+  1/128 KiB would *shrink* below the 208 KiB default.
+- **Codex #3 vs AGY #3 — FORCE-first vs RCVBUF-first (reviewers
+  disagree).** RESOLVED toward FORCE-first: AGY verified the helper
+  holds CAP_NET_ADMIN (root, needs it for AF_XDP/BPF), so FORCE has no
+  added dependency cost in production, and it makes the 4 MiB guarantee
+  self-contained rather than dependent on the cross-process `rmem_max`
+  bump (which Go swallows on failure). Codex's substantive concern was
+  observability ("noisy failure for little benefit" + #4 "setsockopt
+  return is insufficient"); both are addressed by the runtime
+  getsockopt readback + effective-size log added in v2. FORCE failure
+  is logged once at start, not noisy. Keep FORCE primary, RCVBUF
+  fallback.
+- **Codex #4 — checking setsockopt return is insufficient (clamp is
+  silent).** FIXED: v2 adds a `getsockopt(SO_RCVBUF)` readback after
+  the set and logs the effective size + which option succeeded, so an
+  operator can see whether the preventive buffer is actually active.
+- **Codex #5 / AGY #4 — readback test flaky under non-root /
+  rmem_max.** FIXED + verified on this host: cargo-test here runs as
+  **uid 1000 (non-root)** and `rmem_max == 4194304` (exactly 4 MiB).
+  Requesting 4 MiB non-root would clamp to exactly `rmem_max` (kernel
+  doubles *then* clamps), so a `>= 2*requested` assert would FAIL. v2
+  test requests a small 256 KiB (well below any realistic `rmem_max`),
+  reads `/proc/sys/net/core/rmem_max`, and asserts
+  `readback >= min(2*256KiB, rmem_max)` with a graceful fallback if
+  `rmem_max` is unreadable. AGY corrected my v1 formula: non-root clamp
+  is `min(2*req, rmem_max)`, NOT `2*rmem_max`.
+- **Codex #6 / AGY #5 — logged-continue not fatal.** Kept; both agree.
+- **Codex #7 / AGY #7 — same single fd, set before dump.** AGY verified
+  exactly one fd in `neigh_monitor_thread` (`:471`), placement after
+  `bind()` (`:492`) and before `initial_neighbor_dump` (`:514`). Kept.
+- **AGY codegen nit — promote const to a stack local before taking
+  `&`.** Applied: bind `let rcvbuf_val: libc::c_int = ...;` and pass
+  `&rcvbuf_val`.
+
+---
+
 Status: DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
 
 ## Issue framing
@@ -33,17 +83,24 @@ acceptable verdict.
 
 ## Buffer size + setsockopt choice
 
-### Size: 4 MiB requested
+### Size: 4 MiB requested — explicit burst target
 
-Each neighbor event netlink message is small (~80-200 B with the
-`ndmsg` header + `NDA_DST`/`NDA_LLADDR`/`NDA_CACHEINFO` attributes). A
-4 MiB receive buffer holds on the order of 20k-50k queued events, which
-comfortably absorbs a full neighbor-table churn burst (a cluster RETH
-failover re-resolves at most a few hundred neighbors; a large L2 domain
-flush is thousands). 4 MiB is the same order as typical netlink-monitor
-tooling (`ip monitor` uses ~1 MiB; routing daemons use 1-8 MiB). We pick
-4 MiB as a conservative headroom choice with negligible memory cost
-(one socket, charged once).
+**Burst target: survive ~20,000 queued neighbor notifications while the
+monitor thread is stalled up to one 500 ms `SO_RCVTIMEO` tick** (the
+worst-case latency between `recv()` calls, since the loop blocks up to
+500 ms per iteration). That covers a full large-L2-domain neighbor-table
+flush (a cluster RETH failover re-resolves a few hundred neighbors; a
+domain-wide flush is low thousands), with headroom.
+
+Sizing note (Codex #2): receive-buffer accounting charges skb
+`truesize`, not just the nlmsg payload, so the per-event cost is larger
+than the 80-200 B wire size. Using a conservative ~200 B *effective*
+charge per small event, 4 MiB ≈ 20k events of headroom; with realistic
+truesize inflation it is still many thousands — comfortably above the
+burst target. 4 MiB is the same order as `ip monitor` / routing-daemon
+netlink buffers (1-8 MiB). `SO_RCVBUF` is an upper bound on dynamically
+allocated `sk_buff` memory, so idle cost is ~0; only a real burst
+materializes the memory, capped at the doubled value (≤ 8 MiB).
 
 ### setsockopt: SO_RCVBUFFORCE primary, SO_RCVBUF fallback
 
@@ -99,51 +156,78 @@ existing `SO_RCVTIMEO` block (creation-time, on the SAME `fd` the
 steady-state loop uses — there is only one fd in this function;
 `initial_neighbor_dump(fd, ...)` and the loop both use it):
 
+Logic is extracted into a free helper so the readback can be unit-tested
+on an independent socket (see test plan). The helper sets FORCE first,
+falls back to plain `SO_RCVBUF`, then does a `getsockopt` readback and
+logs the *effective* buffer (addresses Codex #4 — a plain `SO_RCVBUF`
+can return success while silently clamping, so the setsockopt return is
+not enough; the readback is the ground truth).
+
 ```rust
-// Enlarge the receive buffer so a burst of RTM_NEWNEIGH/DELNEIGH
-// multicast notifications (HA failover, large neighbor churn) does not
-// overflow the default rcvbuf and drop adverts (which would silently
-// desync dynamic_neighbors — the full dump is startup-only). #1658.
-//
-// SO_RCVBUFFORCE bypasses net.core.rmem_max and requires CAP_NET_ADMIN,
-// which xpfd/the helper hold (run as root). Fall back to plain
-// SO_RCVBUF (clamped to rmem_max) if FORCE is unavailable.
-const NEIGH_RCVBUF_BYTES: libc::c_int = 4 * 1024 * 1024; // 4 MiB
-let forced = unsafe {
-    libc::setsockopt(
-        fd,
-        libc::SOL_SOCKET,
-        libc::SO_RCVBUFFORCE,
-        &NEIGH_RCVBUF_BYTES as *const libc::c_int as *const libc::c_void,
-        core::mem::size_of::<libc::c_int>() as libc::socklen_t,
-    )
-};
-if forced < 0 {
-    eprintln!(
-        "neigh_monitor: SO_RCVBUFFORCE({NEIGH_RCVBUF_BYTES}) failed, \
-         falling back to SO_RCVBUF"
-    );
-    let set = unsafe {
-        libc::setsockopt(
-            fd,
-            libc::SOL_SOCKET,
-            libc::SO_RCVBUF,
-            &NEIGH_RCVBUF_BYTES as *const libc::c_int as *const libc::c_void,
-            core::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        )
+const NEIGH_RCVBUF_BYTES: libc::c_int = 4 * 1024 * 1024; // 4 MiB, #1658
+
+const _: () = assert!(NEIGH_RCVBUF_BYTES >= (1 << 20)); // ≥1 MiB floor
+
+/// Enlarge the netlink monitor receive buffer so an RTM_NEWNEIGH/
+/// DELNEIGH multicast burst does not overflow the default rcvbuf and
+/// silently drop adverts (which would desync dynamic_neighbors — the
+/// full dump is startup-only). Best-effort: logs and continues on
+/// failure. Returns the effective rcvbuf bytes read back via getsockopt
+/// (the kernel doubles the request and may clamp to rmem_max).
+fn set_neigh_monitor_rcvbuf(fd: RawFd, request: libc::c_int) -> libc::c_int {
+    // Promote to a stack local so &-of-const is well-defined (AGY nit).
+    let want: libc::c_int = request;
+    // SO_RCVBUFFORCE bypasses net.core.rmem_max; needs CAP_NET_ADMIN,
+    // held because xpfd/the helper run as root for AF_XDP/BPF. Make the
+    // 4 MiB guarantee self-contained rather than depend on the Go-side
+    // tuneSocketBuffers() rmem_max bump (cross-process, swallowed on
+    // failure). Fall back to plain SO_RCVBUF (rmem_max-clamped).
+    let forced = unsafe {
+        libc::setsockopt(fd, libc::SOL_SOCKET, libc::SO_RCVBUFFORCE,
+            &want as *const _ as *const libc::c_void,
+            core::mem::size_of::<libc::c_int>() as libc::socklen_t)
     };
-    if set < 0 {
-        eprintln!(
-            "neigh_monitor: SO_RCVBUF({NEIGH_RCVBUF_BYTES}) also failed; \
-             using kernel default receive buffer"
-        );
+    let mut via = "SO_RCVBUFFORCE";
+    if forced < 0 {
+        let err = std::io::Error::last_os_error();
+        let set = unsafe {
+            libc::setsockopt(fd, libc::SOL_SOCKET, libc::SO_RCVBUF,
+                &want as *const _ as *const libc::c_void,
+                core::mem::size_of::<libc::c_int>() as libc::socklen_t)
+        };
+        via = "SO_RCVBUF";
+        if set < 0 {
+            eprintln!("neigh_monitor: SO_RCVBUFFORCE({want}) and \
+                SO_RCVBUF({want}) both failed (force: {err}, set: {}); \
+                using kernel default receive buffer",
+                std::io::Error::last_os_error());
+            via = "default";
+        }
     }
+    // Read back the effective size (Codex #4: setsockopt return alone
+    // hides the silent rmem_max clamp on the SO_RCVBUF fallback path).
+    let mut eff: libc::c_int = 0;
+    let mut len = core::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let rc = unsafe {
+        libc::getsockopt(fd, libc::SOL_SOCKET, libc::SO_RCVBUF,
+            &mut eff as *mut _ as *mut libc::c_void, &mut len)
+    };
+    if rc == 0 {
+        eprintln!("neigh_monitor: rcvbuf set via {via}: requested \
+            {want}, effective {eff} bytes");
+    }
+    eff
 }
 ```
 
-(Final wording / ordering relative to the `SO_RCVTIMEO` block decided
-during implementation; placement is after `bind()` succeeds, before
-`initial_neighbor_dump`.)
+Call site in `neigh_monitor_thread`, after `bind()` succeeds and before
+the existing `SO_RCVTIMEO` block / `initial_neighbor_dump`:
+
+```rust
+set_neigh_monitor_rcvbuf(fd, NEIGH_RCVBUF_BYTES);
+```
+
+(`RawFd` import / exact log wording finalized during implementation.)
 
 ## Test plan
 
@@ -151,29 +235,38 @@ A pure socket-option change on a raw netlink fd is hard to fully
 unit-test, but the size constant and the setsockopt/getsockopt contract
 can be pinned:
 
-1. **Compile-time guard** on the constant — `const _: () =
-   assert!(NEIGH_RCVBUF_BYTES >= 1 << 20)` (≥ 1 MiB) so a future edit
-   can't silently shrink it below the burst-absorbing floor. (Module
-   const, so it must live at module scope or be re-derived in the test;
-   see below.)
-2. **getsockopt readback test** — create a `NETLINK_ROUTE` socket in the
-   test, apply the same `SO_RCVBUFFORCE`/`SO_RCVBUF` logic via a small
-   extracted helper `set_neigh_rcvbuf(fd) -> io::Result<()>` /
-   `-> bool`, then `getsockopt(SO_RCVBUF)` and assert the readback is
-   `>= NEIGH_RCVBUF_BYTES` (the kernel doubles, so readback is ~2× the
-   request; assert `>= requested`, not `== requested`). The test runs as
-   whatever user `cargo test` runs as — if not root, `SO_RCVBUFFORCE`
-   fails and we fall back to `SO_RCVBUF` clamped to the runner's
-   `rmem_max`; in that case assert `readback >= min(requested,
-   2*rmem_max)` OR simply that the helper returned without erroring and
-   readback > default. The test asserts the **return is checked**
-   (helper returns a status) and the buffer grew above the 208 KB
-   default when permitted. Mark `#[ignore]`-free but tolerant of the
-   non-root clamp.
+1. **Compile-time guard** on the constant —
+   `const _: () = assert!(NEIGH_RCVBUF_BYTES >= (1 << 20))` (≥ 1 MiB)
+   at module scope, so a future edit can't silently shrink it below the
+   burst-absorbing floor (runs on every `cargo build`, not just test).
+2. **getsockopt readback test (flake-proof, verified on this host).**
+   The test creates its own `NETLINK_ROUTE` `SOCK_RAW` socket and calls
+   `set_neigh_monitor_rcvbuf(fd, TEST_REQ)` with **`TEST_REQ =
+   256 * 1024`** — deliberately small, well below any realistic
+   `rmem_max`, so it does not depend on root. The helper returns the
+   `getsockopt` readback. Expected floor:
+   - kernel doubles the request, then (non-root) clamps to `rmem_max`:
+     `expected = min(2*TEST_REQ, rmem_max)` (AGY #4 — the clamp is
+     `rmem_max`, NOT `2*rmem_max`).
+   - read `/proc/sys/net/core/rmem_max`; if unreadable, fall back to
+     asserting `readback >= TEST_REQ` (still true in every case since
+     `TEST_REQ < rmem_max` on any sane host and the kernel never
+     returns *less* than the doubled-or-clamped value, both ≥ TEST_REQ
+     when TEST_REQ ≤ rmem_max).
+   Concretely: `assert!(readback >= min(2*TEST_REQ, rmem_max))`. On this
+   host (uid 1000 non-root, `rmem_max == 4194304`): `2*256K = 512K <
+   4 MiB` → no clamp → readback `== 512K` → passes. The test also
+   asserts the helper **returned a value** (return is checked, not
+   silently dropped like the surrounding `recv()`), satisfying the
+   "don't ignore the return" contract. No `#[ignore]`; tolerant of both
+   root and non-root.
+   - A second assertion proves the buffer actually grew above the
+     208 KB default: `assert!(readback > 212992 || rmem_max <= TEST_REQ)`
+     (the `||` guards the pathological tiny-rmem_max CI host).
 3. **5/5 flake** on the new test.
-4. `cargo build` clean, full `cargo test --release`.
-5. Go suite unaffected (no Go change) — run `go test ./...` for the
-   userspace package as a sanity check.
+4. `cargo build` clean (also exercises the `const _: ()` guard), full
+   `cargo test --release`.
+5. Go suite unaffected (no Go change) — `go test ./...` sanity check.
 6. Smoke (v4+v6 × push+reverse × CoS off/on) — **owned by the PARENT**
    per the cluster rule; this agent does not deploy.
 

--- a/docs/pr/1658-rcvbuf/plan.md
+++ b/docs/pr/1658-rcvbuf/plan.md
@@ -1,0 +1,239 @@
+# #1658 — neigh_monitor netlink socket SO_RCVBUF bump
+
+Status: DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
+
+## Issue framing
+
+`neigh_monitor_thread` in `userspace-dp/src/afxdp/neighbor.rs` creates a
+`NETLINK_ROUTE` `SOCK_RAW` socket, binds it to the `RTNLGRP_NEIGH`
+multicast group, and sets **only** `SO_RCVTIMEO` (`:506`). It never sets
+`SO_RCVBUF`, so the socket uses the kernel default receive buffer
+(`net.core.rmem_default`, 208 KB unless raised). Under a burst of
+`RTM_NEWNEIGH`/`RTM_DELNEIGH` multicast notifications (HA failover, large
+neighbor churn) that default can overflow → the kernel sets the socket's
+`sk_err` and `recv()` returns `ENOBUFS`. The steady-state loop
+(`:526-556`) treats any `recv() <= 0` as `continue` with **no errno
+inspection**, so the overflow is silently swallowed. Because the only
+full reconcile (`initial_neighbor_dump`) runs once at startup, a dropped
+`RTM_NEWNEIGH`/`DELNEIGH` can leave `dynamic_neighbors` permanently
+out of sync with the kernel neighbor table.
+
+## Scope (isolated, preventive only)
+
+This PR sets a larger `SO_RCVBUF` on the monitor socket at creation
+time, before the steady-state loop. That is the **preventive** half of
+#1648's section 5.E. The **recovery** half (errno inspection on `recv()`
++ socket recreation/resync, gated on Gate-R measurement that ENOBUFS
+actually occurs) is **explicitly out of scope** and stays in #1648 so
+the two changes do not collide. This PR touches only `neighbor.rs`.
+
+If reviewers conclude the buffer bump is unjustified or that the Go-side
+`tuneSocketBuffers` already covers it, NEEDS-MINOR / KILL is an
+acceptable verdict.
+
+## Buffer size + setsockopt choice
+
+### Size: 4 MiB requested
+
+Each neighbor event netlink message is small (~80-200 B with the
+`ndmsg` header + `NDA_DST`/`NDA_LLADDR`/`NDA_CACHEINFO` attributes). A
+4 MiB receive buffer holds on the order of 20k-50k queued events, which
+comfortably absorbs a full neighbor-table churn burst (a cluster RETH
+failover re-resolves at most a few hundred neighbors; a large L2 domain
+flush is thousands). 4 MiB is the same order as typical netlink-monitor
+tooling (`ip monitor` uses ~1 MiB; routing daemons use 1-8 MiB). We pick
+4 MiB as a conservative headroom choice with negligible memory cost
+(one socket, charged once).
+
+### setsockopt: SO_RCVBUFFORCE primary, SO_RCVBUF fallback
+
+- Plain `SO_RCVBUF` is **clamped to `net.core.rmem_max`** by the kernel.
+  The kernel also **doubles** the supplied value (bookkeeping overhead),
+  so a 4 MiB request becomes an 8 MiB internal value capped at
+  `2 * rmem_max`.
+- `SO_RCVBUFFORCE` bypasses the `rmem_max` clamp but requires
+  `CAP_NET_ADMIN`.
+
+xpfd (and therefore the spawned `xpf-userspace-dp` helper) runs as
+**root** — the systemd unit `test/incus/xpfd.service` has no `User=` and
+no capability drop, so `CAP_NET_ADMIN` is held. `SO_RCVBUFFORCE` is
+therefore the robust, self-contained choice: it makes the 4 MiB
+guarantee independent of the ambient `rmem_max` sysctl.
+
+Relationship to the existing Go-side tuning: `tuneSocketBuffers()`
+(`pkg/dataplane/userspace/process.go:139`) already raises
+`net.core.rmem_max`/`rmem_default` to 64 MiB before launching the helper
+(for the AF_XDP copy-mode XSK sockets). That means even a plain
+`SO_RCVBUF(4 MiB)` would *currently* succeed unclamped. But that is a
+cross-process ordering dependency on a sysctl set for a different
+purpose; relying on it for the netlink monitor is fragile. We use
+`SO_RCVBUFFORCE` so the monitor's buffer guarantee does not silently
+regress if that Go-side tuning is ever changed, scoped, or the helper is
+launched standalone in a test harness. If `SO_RCVBUFFORCE` fails
+(e.g. helper somehow lacks `CAP_NET_ADMIN`), we fall back to plain
+`SO_RCVBUF` so a capability-restricted environment still gets the
+rmem_max-clamped best effort rather than the raw default.
+
+### Error handling
+
+The surrounding code ignores the `SO_RCVTIMEO` setsockopt return. We do
+NOT replicate that here — per the issue's own framing ("don't silently
+ignore the return like the surrounding code does"). We check both
+returns:
+
+- `SO_RCVBUFFORCE` failure → log via `eprintln!("neigh_monitor: ...")`
+  and fall through to `SO_RCVBUF`.
+- `SO_RCVBUF` failure (only reached if FORCE also failed) → log a
+  warning. Non-fatal: the monitor still works with the default buffer,
+  just without the burst headroom. Crashing the monitor over a buffer
+  tuning failure would be worse than running with the default.
+
+This is a best-effort tuning knob (overflow policy table: "Path not
+found / best-effort cleanup → warn + continue"), so a setsockopt failure
+is logged-and-continue, not fatal.
+
+## Concrete design
+
+Insert immediately after the `bind()` success and before/alongside the
+existing `SO_RCVTIMEO` block (creation-time, on the SAME `fd` the
+steady-state loop uses — there is only one fd in this function;
+`initial_neighbor_dump(fd, ...)` and the loop both use it):
+
+```rust
+// Enlarge the receive buffer so a burst of RTM_NEWNEIGH/DELNEIGH
+// multicast notifications (HA failover, large neighbor churn) does not
+// overflow the default rcvbuf and drop adverts (which would silently
+// desync dynamic_neighbors — the full dump is startup-only). #1658.
+//
+// SO_RCVBUFFORCE bypasses net.core.rmem_max and requires CAP_NET_ADMIN,
+// which xpfd/the helper hold (run as root). Fall back to plain
+// SO_RCVBUF (clamped to rmem_max) if FORCE is unavailable.
+const NEIGH_RCVBUF_BYTES: libc::c_int = 4 * 1024 * 1024; // 4 MiB
+let forced = unsafe {
+    libc::setsockopt(
+        fd,
+        libc::SOL_SOCKET,
+        libc::SO_RCVBUFFORCE,
+        &NEIGH_RCVBUF_BYTES as *const libc::c_int as *const libc::c_void,
+        core::mem::size_of::<libc::c_int>() as libc::socklen_t,
+    )
+};
+if forced < 0 {
+    eprintln!(
+        "neigh_monitor: SO_RCVBUFFORCE({NEIGH_RCVBUF_BYTES}) failed, \
+         falling back to SO_RCVBUF"
+    );
+    let set = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVBUF,
+            &NEIGH_RCVBUF_BYTES as *const libc::c_int as *const libc::c_void,
+            core::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if set < 0 {
+        eprintln!(
+            "neigh_monitor: SO_RCVBUF({NEIGH_RCVBUF_BYTES}) also failed; \
+             using kernel default receive buffer"
+        );
+    }
+}
+```
+
+(Final wording / ordering relative to the `SO_RCVTIMEO` block decided
+during implementation; placement is after `bind()` succeeds, before
+`initial_neighbor_dump`.)
+
+## Test plan
+
+A pure socket-option change on a raw netlink fd is hard to fully
+unit-test, but the size constant and the setsockopt/getsockopt contract
+can be pinned:
+
+1. **Compile-time guard** on the constant — `const _: () =
+   assert!(NEIGH_RCVBUF_BYTES >= 1 << 20)` (≥ 1 MiB) so a future edit
+   can't silently shrink it below the burst-absorbing floor. (Module
+   const, so it must live at module scope or be re-derived in the test;
+   see below.)
+2. **getsockopt readback test** — create a `NETLINK_ROUTE` socket in the
+   test, apply the same `SO_RCVBUFFORCE`/`SO_RCVBUF` logic via a small
+   extracted helper `set_neigh_rcvbuf(fd) -> io::Result<()>` /
+   `-> bool`, then `getsockopt(SO_RCVBUF)` and assert the readback is
+   `>= NEIGH_RCVBUF_BYTES` (the kernel doubles, so readback is ~2× the
+   request; assert `>= requested`, not `== requested`). The test runs as
+   whatever user `cargo test` runs as — if not root, `SO_RCVBUFFORCE`
+   fails and we fall back to `SO_RCVBUF` clamped to the runner's
+   `rmem_max`; in that case assert `readback >= min(requested,
+   2*rmem_max)` OR simply that the helper returned without erroring and
+   readback > default. The test asserts the **return is checked**
+   (helper returns a status) and the buffer grew above the 208 KB
+   default when permitted. Mark `#[ignore]`-free but tolerant of the
+   non-root clamp.
+3. **5/5 flake** on the new test.
+4. `cargo build` clean, full `cargo test --release`.
+5. Go suite unaffected (no Go change) — run `go test ./...` for the
+   userspace package as a sanity check.
+6. Smoke (v4+v6 × push+reverse × CoS off/on) — **owned by the PARENT**
+   per the cluster rule; this agent does not deploy.
+
+### Extracted-helper decision
+
+To make (2) testable without standing up the whole monitor thread, the
+setsockopt logic is factored into a free fn
+`set_neigh_monitor_rcvbuf(fd: RawFd) -> bool` (true if the buffer was
+enlarged beyond best-effort, i.e. at least one setsockopt succeeded).
+`neigh_monitor_thread` calls it on its fd. The helper is `pub(super)` or
+private-with-`#[cfg(test)]`-reachable so the colocated `mod tests` can
+drive it on an independent socket. This keeps the production call site a
+one-liner and gives the test a real fd to read back.
+
+## Hidden invariants preserved
+
+- Same single fd used by `initial_neighbor_dump` and the steady-state
+  loop — buffer set once, before either runs.
+- No change to the parse loop, the generation counter, or the stop flag.
+- No new allocation on any path (one stack `c_int`).
+- Setsockopt placement does not change `SO_RCVTIMEO` behavior (both are
+  independent SOL_SOCKET options on the same fd).
+
+## Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression | LOW | Adds a socket option; no control-flow change to parse/dump/loop. |
+| Lifetime / borrow | LOW | Stack `c_int`, raw fd, no borrows. |
+| Performance | LOW | One extra setsockopt at thread start; zero hot-path cost. Larger buffer = bounded extra kernel memory (≤ 8 MiB doubled). |
+| Architectural mismatch | LOW | Matches issue scope exactly; preventive-only, recovery deferred to #1648. |
+
+## Out of scope (explicitly)
+
+- ENOBUFS errno inspection on `recv()` (#1648 5.E recovery half).
+- Socket recreation / resync on overflow (#1648 5.E).
+- Periodic re-dump / reconcile of `dynamic_neighbors` (separate concern).
+- Making the size operator-configurable (no evidence it needs tuning).
+- Touching the ICMP probe sockets' setsockopt calls (`:48/:81/:97`).
+
+## Open questions for adversarial review
+
+1. Is 4 MiB justified, or over/under-sized? Each event is ~80-200 B; is
+   the 20k-50k-event headroom right for the worst-case churn (full L2
+   flush on a large domain)? Should it be 1 MiB or 8 MiB instead?
+2. Is `SO_RCVBUFFORCE` the right primary, given the Go side already
+   raises `rmem_max` to 64 MiB? Or does the cross-process sysctl make
+   plain `SO_RCVBUF` sufficient and `SO_RCVBUFFORCE` an unnecessary
+   capability dependency? (If the helper is ever de-privileged,
+   `SO_RCVBUFFORCE` would log-fail every start — is that acceptable
+   noise vs. the fallback?)
+3. Does the kernel actually drop netlink multicast and return ENOBUFS on
+   rcvbuf overflow for `NETLINK_ROUTE` SOCK_RAW, or does it block / use a
+   different mechanism? (Verify the premise: netlink overflow sets
+   `NETLINK_OVERRUN`/`ENOBUFS` on the next `recvmsg`.) If the premise is
+   wrong, the buffer bump is theater.
+4. Is the getsockopt-readback test sound given the non-root cargo-test
+   environment, where `SO_RCVBUFFORCE` fails and the fallback is clamped
+   to the runner's `rmem_max`? Will it flake on CI hosts with a small
+   `rmem_max`?
+5. Should the setsockopt failure be fatal (return from the thread)
+   instead of logged-and-continue? The monitor with a default buffer is
+   still functional; argument for/against crashing.

--- a/docs/pr/1658-rcvbuf/reviewer-ids.md
+++ b/docs/pr/1658-rcvbuf/reviewer-ids.md
@@ -1,0 +1,18 @@
+# #1658 reviewer task IDs
+
+## Plan review (round 1)
+- Codex: task-mpraz4ey-2t7j92 — PLAN-NEEDS-MAJOR (premise confirmed real;
+  required burst target, getsockopt readback, flake-proof test,
+  FORCE-vs-RCVBUF justification). All findings addressed in plan v2.
+- AGY: review-mprazbiq-ikscx2 — PLAN-READY (corrected test clamp formula
+  to min(2*req, rmem_max); stack-local promotion nit). Applied in v2.
+- Claude SMR: PLAN-READY — verified netlink-overrun ENOBUFS premise,
+  reconciled FORCE-vs-RCVBUF split toward FORCE-first (root holds
+  CAP_NET_ADMIN) + runtime readback for observability; verified single-fd
+  placement.
+
+## Code review (PR)
+- Copilot: pending
+- Codex: pending
+- AGY: pending
+- Claude SMR: pending

--- a/docs/pr/1658-rcvbuf/reviewer-ids.md
+++ b/docs/pr/1658-rcvbuf/reviewer-ids.md
@@ -11,8 +11,18 @@
   CAP_NET_ADMIN) + runtime readback for observability; verified single-fd
   placement.
 
-## Code review (PR)
-- Copilot: pending
-- Codex: pending
-- AGY: pending
-- Claude SMR: pending
+## Code review (PR #1664)
+- Copilot: MERGE-READY equivalent — reviewed all 3 files, generated no
+  comments (clean).
+- Codex: task-mprbc0w5-uxkgn4 BLOCKED (sandbox shell failure, no verdict)
+  -> retried per feedback_codex_infra_must_retry as task-mprc3t6u-juvstu
+  = MERGE-READY (1 minor comment-wording nit on the test docstring,
+  applied; not a blocker).
+- AGY: review-mprbc8hm-cuiivs — MERGE-READY (item-by-item code-grounded
+  verification; independently re-derived the test floor math + errno
+  capture correctness).
+- Claude SMR: MERGE-READY — verified errno capture ordering (force_err
+  before second setsockopt; second last_os_error is the SO_RCVBUF errno,
+  no intervening libc call), FFI types, single-fd placement.
+
+4-of-4 clean.

--- a/userspace-dp/src/afxdp/neighbor.rs
+++ b/userspace-dp/src/afxdp/neighbor.rs
@@ -799,11 +799,11 @@ mod pin_tests {
     /// return the read-back size (the surrounding production recv() loop
     /// ignores its return; this knob must not). Uses a deliberately small
     /// request (256 KiB) so the test does not depend on running as root:
-    /// the kernel doubles the request, then (non-root) clamps the plain
-    /// SO_RCVBUF fallback to rmem_max. 256 KiB is below any realistic
-    /// rmem_max, so no clamp fires and the doubled value (512 KiB) is the
-    /// effective size — flake-proof regardless of privilege or host
-    /// rmem_max.
+    /// the kernel sets buf = 2 * min(request, rmem_max). On a typical host
+    /// rmem_max far exceeds 256 KiB, so the effective size is ~512 KiB; the
+    /// assertion below uses a conservative floor (min(2*req, rmem_max),
+    /// which is always <= the kernel value) so it stays flake-proof across
+    /// privilege levels and any host rmem_max.
     #[test]
     fn neigh_monitor_rcvbuf_enlarges_effective_buffer() {
         const TEST_REQ: libc::c_int = 256 * 1024; // well below typical rmem_max
@@ -818,10 +818,11 @@ mod pin_tests {
 
         let effective = super::set_neigh_monitor_rcvbuf(fd, TEST_REQ);
 
-        // Effective floor: kernel doubles the request, then the non-root
-        // SO_RCVBUF fallback clamps to rmem_max (NOT 2*rmem_max). Read
-        // rmem_max to build the exact expected floor; fall back to the
-        // weaker "grew to at least the request" check if it is unreadable.
+        // Conservative floor: the kernel sets buf = 2 * min(request,
+        // rmem_max) (the non-root SO_RCVBUF fallback clamps to rmem_max,
+        // NOT 2*rmem_max). min(2*req, rmem_max) is always <= that value,
+        // so asserting >= it never false-fails. Fall back to the weaker
+        // "grew to at least the request" check if rmem_max is unreadable.
         let rmem_max = std::fs::read_to_string("/proc/sys/net/core/rmem_max")
             .ok()
             .and_then(|s| s.trim().parse::<i64>().ok());

--- a/userspace-dp/src/afxdp/neighbor.rs
+++ b/userspace-dp/src/afxdp/neighbor.rs
@@ -462,6 +462,103 @@ pub(super) fn initial_neighbor_dump(
     Ok(if changed { 1 } else { 0 })
 }
 
+/// Requested receive-buffer size for the neighbor-monitor netlink socket
+/// (#1658). Under an RTM_NEWNEIGH/DELNEIGH multicast burst (HA failover,
+/// large neighbor churn) the default rcvbuf can overflow and the kernel
+/// drops notifications + returns ENOBUFS; the steady-state loop swallows
+/// `recv() <= 0` so the loss is silent and `dynamic_neighbors` can
+/// permanently desync (the full dump is startup-only). 4 MiB holds many
+/// thousands of small (~80-200 B wire, larger skb truesize) events —
+/// enough headroom to absorb a full large-L2-domain neighbor flush while
+/// the thread is stalled up to one 500 ms SO_RCVTIMEO tick.
+const NEIGH_RCVBUF_BYTES: libc::c_int = 4 * 1024 * 1024; // 4 MiB
+
+// Compile-time floor: a future edit must not silently shrink the monitor
+// buffer below the burst-absorbing target.
+const _: () = assert!(NEIGH_RCVBUF_BYTES >= (1 << 20));
+
+/// Enlarge the netlink monitor receive buffer to `request` bytes.
+///
+/// Best-effort: tries `SO_RCVBUFFORCE` first (bypasses
+/// `net.core.rmem_max`, requires CAP_NET_ADMIN — held because the helper
+/// runs as root for AF_XDP/BPF), falling back to plain `SO_RCVBUF`
+/// (clamped to `rmem_max`). FORCE makes the buffer guarantee
+/// self-contained instead of depending on the Go-side `tuneSocketBuffers`
+/// `rmem_max` bump (a cross-process side effect that is silently
+/// swallowed on failure).
+///
+/// Returns the effective buffer size read back via `getsockopt`. The
+/// kernel doubles the request for bookkeeping and may clamp the plain
+/// `SO_RCVBUF` path to `rmem_max`, so the `setsockopt` return alone hides
+/// a silent clamp — the readback is the ground truth and is logged. A
+/// tuning failure is logged and tolerated (the monitor still works with
+/// the default buffer); crashing the thread over a socket-buffer knob
+/// would be a worse outcome.
+fn set_neigh_monitor_rcvbuf(fd: libc::c_int, request: libc::c_int) -> libc::c_int {
+    // Stack local so &-of-value is well-defined for the FFI pointer.
+    let want: libc::c_int = request;
+    let optlen = core::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let forced = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVBUFFORCE,
+            &want as *const libc::c_int as *const libc::c_void,
+            optlen,
+        )
+    };
+    let mut via = "SO_RCVBUFFORCE";
+    if forced < 0 {
+        let force_err = std::io::Error::last_os_error();
+        let set = unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVBUF,
+                &want as *const libc::c_int as *const libc::c_void,
+                optlen,
+            )
+        };
+        via = "SO_RCVBUF";
+        if set < 0 {
+            eprintln!(
+                "neigh_monitor: SO_RCVBUFFORCE({want}) and SO_RCVBUF({want}) \
+                 both failed (force: {force_err}, set: {}); using kernel \
+                 default receive buffer",
+                std::io::Error::last_os_error()
+            );
+            via = "default";
+        }
+    }
+    // Read back the effective size: a plain SO_RCVBUF set can succeed
+    // while silently clamping to rmem_max, so the setsockopt return is
+    // not enough to confirm the preventive buffer is active.
+    let mut eff: libc::c_int = 0;
+    let mut len = core::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let rc = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVBUF,
+            &mut eff as *mut libc::c_int as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if rc == 0 {
+        eprintln!(
+            "neigh_monitor: rcvbuf set via {via}: requested {want}, \
+             effective {eff} bytes"
+        );
+    } else {
+        eprintln!(
+            "neigh_monitor: rcvbuf set via {via}: requested {want}, \
+             getsockopt readback failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    eff
+}
+
 pub(super) fn neigh_monitor_thread(
     stop: Arc<AtomicBool>,
     dynamic_neighbors: Arc<ShardedNeighborMap>,
@@ -495,6 +592,11 @@ pub(super) fn neigh_monitor_thread(
         unsafe { libc::close(fd) };
         return;
     }
+    // Enlarge the receive buffer before the dump + steady-state loop so a
+    // burst of RTM_NEWNEIGH/DELNEIGH multicast notifications does not
+    // overflow the default rcvbuf and silently drop adverts (#1658). Same
+    // fd used by initial_neighbor_dump() and the recv() loop below.
+    set_neigh_monitor_rcvbuf(fd, NEIGH_RCVBUF_BYTES);
     // Set 500ms receive timeout for periodic stop check.
     // Neighbor events arrive instantly via the multicast group —
     // recv() returns immediately when the kernel pushes an update.
@@ -690,6 +792,65 @@ mod pin_tests {
         let mut buf = [0u16; 16];
         assert_eq!(nth_allowed_cpu(0, is_set, &mut buf), None);
         assert_eq!(nth_allowed_cpu(7, is_set, &mut buf), None);
+    }
+
+    /// #1658: setting SO_RCVBUF[FORCE] on a NETLINK_ROUTE socket must
+    /// actually enlarge the effective receive buffer, and the helper must
+    /// return the read-back size (the surrounding production recv() loop
+    /// ignores its return; this knob must not). Uses a deliberately small
+    /// request (256 KiB) so the test does not depend on running as root:
+    /// the kernel doubles the request, then (non-root) clamps the plain
+    /// SO_RCVBUF fallback to rmem_max. 256 KiB is below any realistic
+    /// rmem_max, so no clamp fires and the doubled value (512 KiB) is the
+    /// effective size — flake-proof regardless of privilege or host
+    /// rmem_max.
+    #[test]
+    fn neigh_monitor_rcvbuf_enlarges_effective_buffer() {
+        const TEST_REQ: libc::c_int = 256 * 1024; // well below typical rmem_max
+        let fd = unsafe {
+            libc::socket(
+                libc::AF_NETLINK,
+                libc::SOCK_RAW | libc::SOCK_CLOEXEC,
+                libc::NETLINK_ROUTE,
+            )
+        };
+        assert!(fd >= 0, "failed to create NETLINK_ROUTE socket for test");
+
+        let effective = super::set_neigh_monitor_rcvbuf(fd, TEST_REQ);
+
+        // Effective floor: kernel doubles the request, then the non-root
+        // SO_RCVBUF fallback clamps to rmem_max (NOT 2*rmem_max). Read
+        // rmem_max to build the exact expected floor; fall back to the
+        // weaker "grew to at least the request" check if it is unreadable.
+        let rmem_max = std::fs::read_to_string("/proc/sys/net/core/rmem_max")
+            .ok()
+            .and_then(|s| s.trim().parse::<i64>().ok());
+        match rmem_max {
+            Some(max) => {
+                let doubled = 2i64 * TEST_REQ as i64;
+                let expected_floor = doubled.min(max);
+                assert!(
+                    effective as i64 >= expected_floor,
+                    "effective {effective} < expected floor {expected_floor} \
+                     (request {TEST_REQ}, rmem_max {max})"
+                );
+                // Confirm the buffer actually grew past the ~208 KB default
+                // (unless this host's rmem_max is pathologically small).
+                assert!(
+                    effective > 212992 || max <= TEST_REQ as i64,
+                    "effective {effective} did not exceed the 208 KB default \
+                     (rmem_max {max})"
+                );
+            }
+            None => {
+                assert!(
+                    effective >= TEST_REQ,
+                    "effective {effective} < requested {TEST_REQ}"
+                );
+            }
+        }
+
+        unsafe { libc::close(fd) };
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The neighbor-monitor netlink socket (`neigh_monitor_thread` in `userspace-dp/src/afxdp/neighbor.rs`) set only `SO_RCVTIMEO` and left `SO_RCVBUF` at the system default. Under an `RTM_NEWNEIGH`/`DELNEIGH` multicast burst (HA failover, large neighbor churn) the default buffer can overflow: the kernel calls `netlink_overrun()`, sets `sk_err = ENOBUFS`, drops notifications. The steady-state `recv()` loop treats `recv() <= 0` as a bare `continue` with no errno inspection, so the loss is silent and `dynamic_neighbors` can permanently desync (the full reconcile dump is startup-only).
- Set a **4 MiB** receive buffer at socket-creation time, on the same fd used by `initial_neighbor_dump()` and the steady-state loop, before either runs. `SO_RCVBUFFORCE` first (bypasses `net.core.rmem_max`; `CAP_NET_ADMIN` is held — helper runs as root for AF_XDP/BPF), falling back to plain `SO_RCVBUF`.
- After the set, `getsockopt()` reads the effective size back and logs it — a plain `SO_RCVBUF` can succeed while silently clamping to `rmem_max`, so the `setsockopt` return alone does not confirm the buffer is active.
- Tuning failure is logged and tolerated (monitor still works with the default buffer); not fatal.

## Relationship to #1648 (do not collide)

This is the **preventive** half of #1648 section 5.E. The **recovery** half (ENOBUFS errno inspection on `recv()` + socket recreation/resync, gated on Gate-R measurement) stays in #1648 and is **explicitly out of scope** here. This PR touches only `neighbor.rs`; #1648 owns `lib.rs`/`worker`/`maps_sync` and the recv-loop recovery.

## Chosen size / option rationale

- **4 MiB**: holds many thousands of small events (~80-200 B wire, larger skb truesize) — enough to absorb a full large-L2-domain neighbor flush while the thread is stalled up to one 500 ms `SO_RCVTIMEO` tick. Idle cost ~0 (`SO_RCVBUF` is an upper bound on dynamic `sk_buff` allocation).
- **`SO_RCVBUFFORCE` primary**: keeps the guarantee self-contained rather than depending on the Go-side `tuneSocketBuffers()` `rmem_max` bump (`pkg/dataplane/userspace/process.go:139`), which is a cross-process side effect swallowed on failure. Plain `SO_RCVBUF` fallback covers any de-privileged path.

## Plan + adversarial plan review

Plan doc: `docs/pr/1658-rcvbuf/plan.md`

- Codex round 1: **PLAN-NEEDS-MAJOR** (task `task-mpraz4ey-2t7j92`) — confirmed the ENOBUFS premise is real (cited `netlink_overrun`/`nlmsg_notify`); required an explicit burst target, a runtime `getsockopt` readback (setsockopt return is insufficient), a flake-proof test, and a FORCE-vs-RCVBUF justification. All addressed in plan v2 + this implementation.
- AGY round 1: **PLAN-READY** (`review-mprazbiq-ikscx2`) — verified single-fd placement after `bind()` and before the dump; corrected the test clamp formula to `min(2*req, rmem_max)`; stack-local promotion nit. Applied.
- Claude SMR: PLAN-READY — reconciled the FORCE-vs-RCVBUF reviewer split toward FORCE-first with runtime readback for observability.

## Test plan

- [x] `cargo build` clean (also exercises `const _: () = assert!(NEIGH_RCVBUF_BYTES >= 1 MiB)`)
- [x] `cargo test --release`: all Rust suites green (1602 + 46 + 8 + 16) — see note below
- [x] New `neigh_monitor_rcvbuf_enlarges_effective_buffer` test: 5/5 flake pass. Creates a `NETLINK_ROUTE` socket, requests a small 256 KiB (below any realistic `rmem_max`, so root-independent), asserts the `getsockopt` readback meets the doubled-then-clamped floor `min(2*req, rmem_max)`.
- [ ] **Smoke (v4+v6 × push+reverse × CoS off/on): owned by the PARENT** — #1648 owns the loss cluster this cycle; this is a socket-buffer bump (low risk) and the parent runs the no-regression smoke.

### Pre-existing failures (NOT from this PR — verified on pristine `origin/master`)

- `snat_contract_doc_guard::snat_contract_documents_current_fail_closed_runtime` — doc-drift guard wanting "fail-closed" in `docs/userspace-dataplane-gaps.md`. **Reproduced on a clean `origin/master` checkout** (the string is absent on master); my diff does not touch that doc or the SNAT path.
- `pkg/dataplane/userspace` two `bind: invalid argument` failures — unix-socket `sun_path` length limit in the sandbox `/tmp/claude-1000/...` path; environmental, no Go file touched by this PR.

Closes #1658

🤖 Generated with [Claude Code](https://claude.com/claude-code)