### PR TITLE
#1662: NAT64 copies traffic class (DSCP+ECN) across translation

### DIFF
--- a/docs/pr/1662-nat64-dscp/plan.md
+++ b/docs/pr/1662-nat64-dscp/plan.md
@@ -1,0 +1,226 @@
+# #1662 — NAT64 must copy traffic class (DSCP+ECN) across translation
+
+**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
+
+## Issue framing
+
+`userspace-dp/src/nat64.rs` zeroes the IP DSCP/ECN field in **both**
+translation directions instead of copying it across the translation.
+Packets traversing the NAT64 path lose all QoS marking, which is wrong
+for any DiffServ-aware downstream and breaks CoS classification on the
+far side. Junos NAT64 preserves the DiffServ codepoint by default.
+
+Concrete evidence (origin/master @ da88f1ab):
+
+- v6→v4 (`translate_v6_to_v4`): `nat64.rs:149` computes
+  `_traffic_class` then discards it; `nat64.rs:174` hard-sets the IPv4
+  TOS byte to `0` with a `// TODO: copy from traffic class` comment.
+- v4→v6 (`translate_v4_to_v6`): `nat64.rs:259` leaves the IPv6 traffic
+  class octet (low nibble of byte 0 + high nibble of byte 1) at zero;
+  the IPv4 source TOS is never read.
+
+This is a distinct, still-open gap from #1641 (NAT64 reverse-path
+Ethernet-padding trim) — that fixed length/padding; this is the
+traffic-class copy.
+
+## Honest scope / value framing
+
+This is a small, isolated, design-blessed correctness fix: two byte
+manipulations plus reads, no new types, no control-flow change, no hot
+path restructuring. The win is real but narrow — QoS/DiffServ marking
+preservation across NAT64 (a parity gap vs Junos and vs xpf's own
+DiffServ claims) and end-to-end ECN survival across the translator.
+NAT64 is not the saturating fast path; this does not move iperf3
+numbers. **If reviewers conclude the perf gain is too small to justify
+the churn, PLAN-KILL is an acceptable verdict** — but the value here is
+correctness/parity, not perf, so that bar is about churn risk, and the
+churn is ~6 lines.
+
+## Correctness contract (RFC + in-tree consistency)
+
+**RFC 7915 (SIIT, the current revision of RFC 6145) §4 (v4→v6) and §5
+(v6→v4) IP header translation:**
+
+- **DSCP**: the 6 DiffServ bits are copied between the IPv4 TOS byte
+  (bits 7:2) and the IPv6 Traffic Class field (bits 7:2 of the 8-bit
+  TC). This is the default; an operator-configured DSCP mapping is the
+  only thing that would diverge, and xpf has no such NAT64 DSCP-map
+  config, so default = copy.
+- **ECN**: RFC 7915 copies the 2-bit ECN field verbatim in both
+  directions by default. (RFC 6040 governs ECN propagation across
+  *encapsulating* tunnels — inner/outer header interaction — which is a
+  different operation from NAT64 *translation*, where there is exactly
+  one IP header in and one IP header out and no nesting.)
+
+**Decision: full 8-bit traffic-class copy (DSCP+ECN together).** Because
+the entire 8-bit field maps 1:1 between IPv4 TOS and IPv6 Traffic Class
+(both are `DSCP[7:2] | ECN[1:0]`), and RFC 7915's default is "copy DSCP,
+copy ECN verbatim," a straight full-byte copy is exactly the RFC 7915
+default behavior with no DSCP mapping configured. This is simpler and
+less error-prone than splitting DSCP-only + a separate ECN path, and it
+is correct: it preserves both the DiffServ codepoint and the ECN
+congestion signal end-to-end.
+
+**Why this differs from `afxdp/wg/dscp.rs` (which clears ECN):** that
+module builds a tunnel **outer** header from a 6-bit DSCP value during
+WireGuard **encapsulation** — there is no inner ECN byte being copied
+through at that call site, ECN propagation for that encap path is the
+tracked RFC 6040 follow-up noted in `wg/dscp.rs:8`. NAT64 is translation
+(1 header in → 1 header out), so the full-byte copy is the right model
+and is *more* faithful than the encap path, not divergent from it. The
+relevant in-tree consistency anchor is instead
+`afxdp/frame/mod.rs:102-139` `apply_dscp_rewrite_to_frame`, which uses
+the identical IPv6 TC extract/insert bit layout this fix will use.
+
+## Bit layout (verified against `afxdp/frame/mod.rs:128-134`)
+
+IPv4 TOS = `out[1]` = full 8 bits = `DSCP[7:2] | ECN[1:0]`.
+
+IPv6 Traffic Class straddles bytes 0-1:
+- extract: `tc = ((b[0] & 0x0f) << 4) | (b[1] >> 4)`
+  (exactly what nat64.rs:149 already computes)
+- insert : `b[0] = (b[0] & 0xf0) | (tc >> 4)`
+           `b[1] = ((tc & 0x0f) << 4) | (b[1] & 0x0f)`
+- Version nibble `b[0][7:4] = 6` and flow-label nibble `b[1][3:0]` must
+  be preserved. The insert masks (`& 0xf0` on b[0], `& 0x0f` on b[1])
+  preserve them; flow label stays 0 as today.
+
+## Concrete design
+
+### v6→v4 (`translate_v6_to_v4`, ~line 149 + 174)
+
+Rename `_traffic_class` → `traffic_class` (value already correct: full
+8-bit TC extracted from the IPv6 header). Then:
+
+```rust
+out[1] = traffic_class; // copy DSCP+ECN (RFC 7915 §5 default)
+```
+
+The IPv4 header checksum is computed *after* this (`out[10..12]` from
+`checksum16(&out[..20])` at line ~198), so it already covers the new
+TOS byte. No checksum-adjust needed. L4 checksums (TCP/UDP) do not cover
+the IP TOS byte, so they are unaffected.
+
+### v4→v6 (`translate_v4_to_v6`, ~line 258)
+
+Read the IPv4 TOS byte from the source packet (`packet[1]`) and place it
+into the IPv6 traffic-class field, preserving the version nibble:
+
+```rust
+let tos = packet[1]; // IPv4 DSCP+ECN
+out[0] = 0x60 | (tos >> 4);            // version=6 + TC[7:4]
+out[1] = (out[1] & 0x0f) | (tos << 4); // TC[3:0] | flow-label nibble (0)
+```
+
+`out[1]` is freshly zeroed (`vec![0u8; ...]`), so `out[1] & 0x0f == 0`;
+the `& 0x0f` mask is defensive/explicit and documents that the low
+nibble is the flow-label high nibble we intend to leave at 0. IPv6 has
+no header checksum, so nothing else changes. L4 checksums use the IPv6
+pseudo-header (addresses, length, next-header) — not the TC — so they
+are unaffected.
+
+## Public API preservation
+
+No signature changes. `translate_v6_to_v4`, `translate_v4_to_v6`,
+`build_nat64_v6_to_v4_frame`, `build_nat64_v4_to_v6_frame` all keep
+identical signatures and return types. Pure value-level change inside
+two function bodies.
+
+## Hidden invariants the change must preserve
+
+1. **IPv4 header checksum** must still verify after writing the TOS
+   byte. Preserved: header checksum is computed last, over `out[..20]`,
+   which includes `out[1]`.
+2. **IPv6 version nibble** (`out[0][7:4] = 6`) must survive the TC
+   insert. Preserved by `0x60 | (tos >> 4)` (tos>>4 is ≤ 0x0f).
+3. **Flow label** stays 0. Preserved: only the high nibble of byte 1
+   (TC[3:0]) is written; bytes 2-3 (rest of flow label) untouched.
+4. **L4 checksums** must not be invalidated. Preserved: neither IPv4 TOS
+   nor IPv6 TC participates in the TCP/UDP/ICMP pseudo-header or L4
+   checksum, so the existing recompute logic is unaffected.
+5. **No new allocation / no hot-path change.** Two byte writes + one
+   read; no Vec growth, no branch added to a per-packet loop beyond what
+   already runs.
+6. **ICMP error embedded-packet translation:** out of scope — current
+   code only handles ICMP echo request/reply (other ICMP types return
+   `None`), so there is no embedded inner-header TOS to translate. No
+   regression introduced.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Only the TOS/TC byte changes; was hard-zero, now copied. Checksums verified above. |
+| Lifetime / borrow-checker | NONE | No borrows change; `out` already `&mut`; `packet` already read. |
+| Performance regression | NONE | 2 writes + 1 read, no alloc, no branch in saturating path (NAT64 is slow path). |
+| Architectural mismatch | NONE | Not a rearchitecture; this is the TODO the original author left at nat64.rs:174. |
+
+## Test plan (mandatory fail-before / pass-after)
+
+Add to `nat64_tests.rs`:
+
+1. `translate_v6_to_v4_copies_traffic_class` — build an IPv6 TCP packet
+   with TC = `(46<<2)|0b10` (DSCP EF + ECN ECT(0)), translate, assert
+   `out[1] == 0xBA` exactly (`46<<2 = 0xB8`, `| 0b10 = 0xBA`), and
+   assert IPv4 header checksum still verifies (`checksum16(&out[..20]) == 0`).
+2. `translate_v4_to_v6_copies_traffic_class` — build an IPv4 TCP packet
+   with TOS = `0xBA`, translate, assert the reconstructed TC byte
+   `((out[0] & 0x0f) << 4) | (out[1] >> 4) == 0xBA`, assert
+   `out[0] >> 4 == 6` (version preserved), assert flow label bytes
+   (`out[1] & 0x0f`, `out[2]`, `out[3]`) are 0.
+3. `nat64_traffic_class_round_trips` — v4→v6→v4 (and v6→v4→v6) of a
+   marked packet preserves the exact byte both ways.
+4. Reuse a non-trivial ECN value (`0b10`) so a DSCP-only implementation
+   that drops ECN would fail the assertion.
+
+**Fail-before/pass-after demonstration:** revert the two edits (restore
+`out[1] = 0` and the zero TC) → the three new tests must fail; reapply →
+pass. 5/5 flake on the named tests. Full `cargo test --release`.
+
+Go suite is unaffected (Rust-only change) — will run it to confirm.
+
+Smoke (parent runs it per the work order): NAT64 is not on the iperf3
+saturating path, but per the smoke matrix the parent will run v4+v6 ×
+push+reverse × CoS-off/on. This change cannot regress the best-effort or
+CoS fast path (it only touches the NAT64 translation functions, which
+the iperf3 path does not invoke).
+
+## Docs
+
+No dedicated NAT64 DSCP doc exists (`grep -rn nat64 docs/` shows only the
+retired DPDK milestone list and unrelated plan docs). The behavior is
+captured in code comments + this plan + the issue. No module doc update
+required; will state this explicitly in the PR review notes.
+
+## Out of scope (explicitly)
+
+- ICMP error / embedded-packet inner-header translation (current code
+  only handles echo request/reply).
+- Operator-configurable NAT64 DSCP remapping (no such config exists; RFC
+  default copy is correct).
+- RFC 6040 ECN-on-encapsulation for the WG/GRE tunnel path (tracked
+  separately at `wg/dscp.rs:8`).
+- Flow-label synthesis (left 0, as today).
+
+## Open questions for adversarial review
+
+1. Is full-byte (DSCP+ECN) copy the right call vs DSCP-only + RFC 6040
+   ECN? (Plan argues: NAT64 is translation not encap, RFC 7915 default
+   is verbatim ECN copy, full-byte copy = that default.) Invite KILL if
+   wrong.
+2. Bit layout: is `out[1] = (out[1] & 0x0f) | (tos << 4)` correct for
+   the IPv6 TC low nibble, and does `0x60 | (tos >> 4)` correctly place
+   TC[7:4] without clobbering version? Cross-check against
+   `frame/mod.rs:133-134`.
+3. Does any checksum (IPv4 header, L4 pseudo-header) actually cover the
+   TOS/TC byte such that the existing recompute order matters? (Plan
+   says IPv4 header checksum covers TOS and is computed last; L4 does
+   not.) Verify.
+4. Could the v4→v6 `tos << 4` ever set bits in `out[1][3:0]`
+   (flow-label nibble)? (`tos << 4` keeps only low nibble of tos in
+   bits 7:4; bits 3:0 are 0 — verify the truncation semantics on u8.)
+5. Is there any HA session-sync / conntrack state that snapshots the
+   TOS/TC and would now diverge? (Believed none — translation is
+   stateless w.r.t. TC.) Invite a counter-example.
+6. Architectural mismatch (#961 / #946-Phase-2 pattern): is this the
+   wrong target entirely? (No — it's the literal TODO at nat64.rs:174.)

--- a/docs/pr/1662-nat64-dscp/plan.md
+++ b/docs/pr/1662-nat64-dscp/plan.md
@@ -1,6 +1,8 @@
 # #1662 — NAT64 must copy traffic class (DSCP+ECN) across translation
 
-**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
+**Status:** PLAN-READY v1 — Codex PLAN-READY (task-mpraygb5-6rk1v9), AGY
+PLAN-READY (adversarial-review-mpraypis-m3213h), Claude SMR PLAN-READY. One
+non-blocking Codex nit adopted: `((tos & 0x0f) << 4)` mirrors frame/mod.rs:134.
 
 ## Issue framing
 

--- a/docs/pr/1662-nat64-dscp/reviewer-ids.md
+++ b/docs/pr/1662-nat64-dscp/reviewer-ids.md
@@ -1,0 +1,12 @@
+# #1662 reviewer task IDs
+
+## Plan review (round 1)
+- Codex: task-mpraygb5-6rk1v9
+- AGY: adversarial-review-mpraypis-m3213h
+- Claude SMR: in-conversation (this session)
+
+## Code review (round 1)
+- Codex: TBD
+- AGY: TBD
+- Copilot: TBD (gh pr comment "@copilot review" + poll)
+- Claude SMR: in-conversation

--- a/docs/pr/1662-nat64-dscp/reviewer-ids.md
+++ b/docs/pr/1662-nat64-dscp/reviewer-ids.md
@@ -6,7 +6,8 @@
 - Claude SMR: in-conversation (this session)
 
 ## Code review (round 1)
-- Codex: TBD
-- AGY: TBD
-- Copilot: TBD (gh pr comment "@copilot review" + poll)
+- PR #1665 @ f1d5201cf
+- Codex: task-mprbm62a-511l1g
+- AGY: adversarial-review-mprbmead-mlxnza
+- Copilot: requested via @copilot review comment (poll gh pr view)
 - Claude SMR: in-conversation

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -146,7 +146,11 @@ pub(crate) fn translate_v6_to_v4(
         return None;
     }
     // IPv6 header fields.
-    let _traffic_class = ((packet[0] & 0x0f) << 4) | (packet[1] >> 4);
+    // Full 8-bit traffic class (DSCP[7:2] | ECN[1:0]) straddling bytes 0-1 of
+    // the IPv6 header. Copied verbatim into the IPv4 TOS byte below per the
+    // RFC 7915 §5 default (DSCP copied, ECN copied verbatim — NAT64 is
+    // stateless translation, not RFC 6040 tunnel encapsulation).
+    let traffic_class = ((packet[0] & 0x0f) << 4) | (packet[1] >> 4);
     let payload_len = u16::from_be_bytes([packet[4], packet[5]]) as usize;
     let next_header = packet[6];
     let hop_limit = packet[7];
@@ -171,7 +175,7 @@ pub(crate) fn translate_v6_to_v4(
 
     // Build IPv4 header.
     out[0] = 0x45; // version=4, IHL=5
-    out[1] = 0; // DSCP/ECN (TODO: copy from traffic class)
+    out[1] = traffic_class; // DSCP/ECN copied from IPv6 traffic class (RFC 7915 §5)
     out[2..4].copy_from_slice(&ipv4_total_len.to_be_bytes());
     // ID = 0, flags = DF (0x4000)
     out[4..6].copy_from_slice(&0u16.to_be_bytes()); // identification
@@ -220,6 +224,10 @@ pub(crate) fn translate_v4_to_v6(
     if ihl < 20 || packet.len() < ihl {
         return None;
     }
+    // IPv4 TOS byte (DSCP[7:2] | ECN[1:0]) — copied verbatim into the IPv6
+    // traffic class below per the RFC 7915 §4 default (DSCP copied, ECN copied
+    // verbatim — NAT64 is stateless translation, not RFC 6040 encapsulation).
+    let tos = packet[1];
     let ttl = packet[8];
     if ttl <= 1 {
         return None; // TTL expired
@@ -254,9 +262,13 @@ pub(crate) fn translate_v4_to_v6(
     let ipv6_total_len = 40 + l4_payload.len();
     let mut out = vec![0u8; ipv6_total_len];
 
-    // Build IPv6 header.
-    out[0] = 0x60; // version=6
-    // flow label and traffic class = 0 for now
+    // Build IPv6 header. The 8-bit traffic class straddles bytes 0-1: TC[7:4]
+    // in the low nibble of byte 0 (alongside the version=6 nibble) and TC[3:0]
+    // in the high nibble of byte 1 (alongside the flow-label high nibble, left
+    // at 0). Mirrors apply_dscp_rewrite_to_frame in afxdp/frame/mod.rs:133-134.
+    out[0] = 0x60 | (tos >> 4); // version=6 | TC[7:4]
+    out[1] = (out[1] & 0x0f) | ((tos & 0x0f) << 4); // TC[3:0] | flow-label nibble (0)
+    // flow label (bytes 2-3 and low nibble of byte 1) = 0
     out[4..6].copy_from_slice(&ipv6_payload_len.to_be_bytes());
     out[6] = next_header;
     out[7] = new_hop_limit;

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -645,6 +645,29 @@ fn nat64_traffic_class_round_trips() {
     let rt_tc = ((v6[0] & 0x0f) << 4) | (v6[1] >> 4);
     assert_eq!(rt_tc, TC_EF_ECT0, "traffic class must survive round trip");
     assert_eq!(v6[0] >> 4, 6);
+
+    // v4 → v6 → v4: the traffic class also survives the opposite round trip.
+    let server_v4 = Ipv4Addr::new(198, 51, 100, 50);
+    let client_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let server_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let client_v6b: Ipv6Addr = "2001:db8::1".parse().unwrap();
+
+    let mut ipv4_pkt = make_ipv4_tcp_packet(server_v4, client_v4, 80, 12345, b"rt2");
+    ipv4_pkt[1] = TC_EF_ECT0;
+    ipv4_pkt[10..12].copy_from_slice(&[0, 0]);
+    let ip_sum = checksum16(&ipv4_pkt[..20]);
+    ipv4_pkt[10..12].copy_from_slice(&ip_sum.to_be_bytes());
+
+    let v6b = translate_v4_to_v6(&ipv4_pkt, server_v6, client_v6b).expect("v4->v6");
+    let v6b_tc = ((v6b[0] & 0x0f) << 4) | (v6b[1] >> 4);
+    assert_eq!(v6b_tc, TC_EF_ECT0);
+
+    let v4b = translate_v6_to_v4(&v6b, server_v4, client_v4).expect("v6->v4");
+    assert_eq!(
+        v4b[1], TC_EF_ECT0,
+        "traffic class must survive v4->v6->v4 round trip"
+    );
+    assert_eq!(checksum16(&v4b[..20]), 0, "IPv4 header checksum must verify");
 }
 
 #[test]

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -552,6 +552,101 @@ fn translate_v4_to_v6_total_len_larger_than_slice_returns_none() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// #1662: NAT64 must copy the IP traffic class (DSCP + ECN) across translation
+// in BOTH directions. Before the fix the IPv4 TOS byte / IPv6 traffic class was
+// hard-zeroed, so DiffServ marking and end-to-end ECN were lost across the
+// translator. RFC 7915 §4/§5 default is a verbatim full-byte copy (DSCP copied,
+// ECN copied verbatim) — NAT64 is stateless translation, not RFC 6040 tunnel
+// encapsulation.
+//
+// All cases use TOS/TC = 0xBA = (DSCP 46 EF << 2) | ECN 0b10 (ECT(0)). The
+// non-zero ECN nibble means a DSCP-only implementation that dropped ECN would
+// also fail these assertions.
+// ---------------------------------------------------------------------------
+
+/// DSCP 46 (EF) in bits 7:2, ECN 0b10 (ECT(0)) in bits 1:0 → 0xBA.
+const TC_EF_ECT0: u8 = (46u8 << 2) | 0b10;
+
+#[test]
+fn translate_v6_to_v4_copies_traffic_class() {
+    let src_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let snat_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(198, 51, 100, 50);
+
+    let mut ipv6_pkt = make_ipv6_tcp_packet(src_v6, dst_v6, 12345, 80, b"qos");
+    // Set the IPv6 traffic class to 0xBA across bytes 0-1 (preserving version
+    // nibble and flow label). TC[7:4] in byte0 low nibble, TC[3:0] in byte1
+    // high nibble. (TCP checksum does not cover the TC byte, so no recompute.)
+    ipv6_pkt[0] = (ipv6_pkt[0] & 0xf0) | (TC_EF_ECT0 >> 4);
+    ipv6_pkt[1] = (ipv6_pkt[1] & 0x0f) | ((TC_EF_ECT0 & 0x0f) << 4);
+    // Sanity: reconstruct and confirm the input really carries 0xBA.
+    let in_tc = ((ipv6_pkt[0] & 0x0f) << 4) | (ipv6_pkt[1] >> 4);
+    assert_eq!(in_tc, TC_EF_ECT0);
+
+    let v4 = translate_v6_to_v4(&ipv6_pkt, snat_v4, dst_v4).expect("translate");
+
+    // IPv4 TOS byte must equal the source traffic class exactly (DSCP+ECN).
+    assert_eq!(v4[1], TC_EF_ECT0, "IPv4 TOS must copy the IPv6 traffic class");
+    // IPv4 header checksum must still verify with the non-zero TOS byte.
+    assert_eq!(checksum16(&v4[..20]), 0, "IPv4 header checksum must verify");
+}
+
+#[test]
+fn translate_v4_to_v6_copies_traffic_class() {
+    let src_v4 = Ipv4Addr::new(198, 51, 100, 50);
+    let dst_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let src_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let dst_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+
+    let mut ipv4_pkt = make_ipv4_tcp_packet(src_v4, dst_v4, 80, 12345, b"qos");
+    // Set the IPv4 TOS byte to 0xBA and recompute the IPv4 header checksum
+    // (the header checksum DOES cover the TOS byte).
+    ipv4_pkt[1] = TC_EF_ECT0;
+    ipv4_pkt[10..12].copy_from_slice(&[0, 0]);
+    let ip_sum = checksum16(&ipv4_pkt[..20]);
+    ipv4_pkt[10..12].copy_from_slice(&ip_sum.to_be_bytes());
+
+    let v6 = translate_v4_to_v6(&ipv4_pkt, src_v6, dst_v6).expect("translate");
+
+    // Reconstruct the IPv6 traffic class from bytes 0-1 and compare exactly.
+    let out_tc = ((v6[0] & 0x0f) << 4) | (v6[1] >> 4);
+    assert_eq!(
+        out_tc, TC_EF_ECT0,
+        "IPv6 traffic class must copy the IPv4 TOS byte"
+    );
+    // Version nibble must remain 6.
+    assert_eq!(v6[0] >> 4, 6, "IPv6 version nibble must be preserved");
+    // Flow label (low nibble of byte 1 + bytes 2-3) must stay 0.
+    assert_eq!(v6[1] & 0x0f, 0, "flow-label high nibble must be 0");
+    assert_eq!(v6[2], 0, "flow label must be 0");
+    assert_eq!(v6[3], 0, "flow label must be 0");
+}
+
+#[test]
+fn nat64_traffic_class_round_trips() {
+    // v6 → v4 → v6: the traffic class survives a full round trip.
+    let client_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let snat_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(198, 51, 100, 50);
+
+    let mut ipv6_pkt = make_ipv6_tcp_packet(client_v6, dst_v6, 12345, 80, b"rt");
+    ipv6_pkt[0] = (ipv6_pkt[0] & 0xf0) | (TC_EF_ECT0 >> 4);
+    ipv6_pkt[1] = (ipv6_pkt[1] & 0x0f) | ((TC_EF_ECT0 & 0x0f) << 4);
+
+    let v4 = translate_v6_to_v4(&ipv6_pkt, snat_v4, dst_v4).expect("v6->v4");
+    assert_eq!(v4[1], TC_EF_ECT0);
+
+    // Translate the IPv4 packet back to IPv6 (reply direction reuses the same
+    // helper). The TOS byte carried by v4 must reappear in the IPv6 TC.
+    let v6 = translate_v4_to_v6(&v4, dst_v6, client_v6).expect("v4->v6");
+    let rt_tc = ((v6[0] & 0x0f) << 4) | (v6[1] >> 4);
+    assert_eq!(rt_tc, TC_EF_ECT0, "traffic class must survive round trip");
+    assert_eq!(v6[0] >> 4, 6);
+}
+
 #[test]
 fn translate_v4_to_v6_total_len_below_ihl_returns_none() {
     // Total Length shorter than the IPv4 header is nonsensical: reject it.

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -650,7 +650,7 @@ fn nat64_traffic_class_round_trips() {
     let server_v4 = Ipv4Addr::new(198, 51, 100, 50);
     let client_v4 = Ipv4Addr::new(198, 51, 100, 1);
     let server_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
-    let client_v6b: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let client_v6_reverse: Ipv6Addr = "2001:db8::1".parse().unwrap();
 
     let mut ipv4_pkt = make_ipv4_tcp_packet(server_v4, client_v4, 80, 12345, b"rt2");
     ipv4_pkt[1] = TC_EF_ECT0;
@@ -658,16 +658,20 @@ fn nat64_traffic_class_round_trips() {
     let ip_sum = checksum16(&ipv4_pkt[..20]);
     ipv4_pkt[10..12].copy_from_slice(&ip_sum.to_be_bytes());
 
-    let v6b = translate_v4_to_v6(&ipv4_pkt, server_v6, client_v6b).expect("v4->v6");
-    let v6b_tc = ((v6b[0] & 0x0f) << 4) | (v6b[1] >> 4);
-    assert_eq!(v6b_tc, TC_EF_ECT0);
+    let v6_reverse = translate_v4_to_v6(&ipv4_pkt, server_v6, client_v6_reverse).expect("v4->v6");
+    let v6_reverse_tc = ((v6_reverse[0] & 0x0f) << 4) | (v6_reverse[1] >> 4);
+    assert_eq!(v6_reverse_tc, TC_EF_ECT0);
 
-    let v4b = translate_v6_to_v4(&v6b, server_v4, client_v4).expect("v6->v4");
+    let v4_reverse = translate_v6_to_v4(&v6_reverse, server_v4, client_v4).expect("v6->v4");
     assert_eq!(
-        v4b[1], TC_EF_ECT0,
+        v4_reverse[1], TC_EF_ECT0,
         "traffic class must survive v4->v6->v4 round trip"
     );
-    assert_eq!(checksum16(&v4b[..20]), 0, "IPv4 header checksum must verify");
+    assert_eq!(
+        checksum16(&v4_reverse[..20]),
+        0,
+        "IPv4 header checksum must verify"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

NAT64 translation in `userspace-dp/src/nat64.rs` zeroed the IP DSCP/ECN field (IPv4 TOS byte / IPv6 traffic class) in **both** directions instead of copying it across the translation. Packets traversing the NAT64 path lost all QoS marking and end-to-end ECN. This copies the full 8-bit traffic class verbatim in both directions.

Closes #1662

## ECN / DSCP policy decision

**Full 8-bit traffic-class copy (DSCP + ECN together)** — the RFC 7915 §4/§5 default for stateless translation (DSCP copied, ECN copied verbatim). This is intentionally distinct from the RFC 6040 *encapsulation* path in `afxdp/wg/dscp.rs` (which clears ECN because it builds a tunnel outer header). NAT64 is one-header-in/one-header-out translation, so verbatim copy is correct and preserves congestion signalling end to end. Bit layout mirrors `apply_dscp_rewrite_to_frame` in `afxdp/frame/mod.rs:133-134`.

## Implementation

- `translate_v6_to_v4`: use the already-reconstructed 8-bit traffic class (was discarded as `_traffic_class` at nat64.rs:149) for the IPv4 TOS byte instead of hard-zeroing. IPv4 header checksum is computed last over `out[..20]`, so it covers the new byte.
- `translate_v4_to_v6`: read the IPv4 TOS byte and place it into the IPv6 traffic class straddling bytes 0-1, preserving the version nibble and leaving flow label 0.
- Neither TOS nor TC is in any L4 pseudo-header, so TCP/UDP/ICMP checksums are unaffected. `Nat64ReverseInfo` stores only original IPv6 addresses, so no HA/session-sync state diverges.

## Plan + adversarial review

Plan doc: `docs/pr/1662-nat64-dscp/plan.md`

- Codex plan review: **PLAN-READY** (task-mpraygb5-6rk1v9)
- AGY adversarial plan review: **PLAN-READY** (adversarial-review-mpraypis-m3213h)
- Claude SMR plan review: **PLAN-READY**

## Test plan

- [x] cargo build clean
- [x] 3 new exact-byte tests (`translate_v6_to_v4_copies_traffic_class`, `translate_v4_to_v6_copies_traffic_class`, `nat64_traffic_class_round_trips`) using DSCP 46 EF + ECN ECT(0) = 0xBA — non-zero ECN nibble so a DSCP-only impl would fail
- [x] **Fail-before / pass-after demonstrated**: reverting the two edits fails all three with the exact assertions; reapplying passes
- [x] 5/5 flake clean on the three named tests
- [x] cargo test --release: green except one **pre-existing master failure** unrelated to this change — `snat_contract_documents_current_fail_closed_runtime` fails identically on pristine origin/master because `docs/userspace-dataplane-gaps.md` lacks the `"fail-closed"` string (a SNAT doc-guard, different subsystem; not in this diff)
- [x] Go suite: green (with a sane TMPDIR; two manager tests fail only when the sandbox `/tmp` socket path exceeds the 108-char `sun_path` limit — environment artifact, unrelated)

## Docs

No dedicated NAT64 DSCP doc exists; behavior is captured in code comments + the plan + this PR. No module doc update required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)