### PR TITLE
#1635: cold-path histogram log-linear buckets + direct zone-pair slot map

### DIFF
--- a/docs/pr/1635-cold-path-hist-redesign/plan.md
+++ b/docs/pr/1635-cold-path-hist-redesign/plan.md
@@ -590,13 +590,19 @@ deviations, each justified below:
   "v1 Rust / v3 Go").
 
 ### Slot zero-out (plan §2.4) realization
-- `forwarding_build` returns `(slot_map, slots_to_zero)`; `slots_to_zero`
-  is stashed on `ForwardingState`. The worker zeroes those slots in each
-  binding's local accumulator at the ForwardingState ArcSwap point
-  (`worker/loop_body/mod.rs`), BEFORE any `record_sample` into the
-  reused slot. The next publish merge overwrites the sibling atomics
-  from the freshly-zeroed local accumulators, so no separate atomic
-  zero-out path is needed on the hot tick.
+> SUPERSEDED by §IMPL.r3 finding 2 — the worker no longer consumes a
+> coordinator-stashed `slots_to_zero`; it derives the zero-set by
+> diffing its OWN old slot-map inverse against the new one at the
+> ArcSwap point (generation-independent). `ForwardingState` carries no
+> `slots_to_zero` field. The text below describes the initial
+> (superseded) realization.
+- `forwarding_build` returns `(slot_map, slots_to_zero)`; the worker
+  zeroes affected slots in each binding's local accumulator at the
+  ForwardingState ArcSwap point (`worker/loop_body/mod.rs`), BEFORE any
+  `record_sample` into the reused slot. The next publish merge
+  overwrites the sibling atomics from the freshly-zeroed local
+  accumulators, so no separate atomic zero-out path is needed on the
+  hot tick.
 
 ### §IMPL.r2 Code-review round-1 fixes (Codex MERGE-NEEDS-MAJOR → resolved)
 

--- a/docs/pr/1635-cold-path-hist-redesign/plan.md
+++ b/docs/pr/1635-cold-path-hist-redesign/plan.md
@@ -546,3 +546,54 @@ aggregate emission, #1622's plan proposes it; not this PR's surface.
   1M-rule (~5000-50000 ns) target.
 
 After this lands → #1622 reopens with the redesigned foundation in place.
+
+---
+
+## §IMPL Implementation deviations from plan v3 (recorded at code time)
+
+The implementation follows plan v3 faithfully with three bounded
+deviations, each justified below:
+
+1. **Slot capacity is 255 assignable, not 256.** `flat_table` uses
+   `u8::MAX` (255) as the "unassigned" sentinel, so slot index 255 can
+   never be handed out (it would be indistinguishable from a miss in
+   `lookup_slot`). The accumulator arrays are still 256-wide for layout
+   identity; `COLD_PATH_ASSIGNABLE_SLOTS = 255` bounds assignment and
+   `overflow_active` trips on the 256th distinct in-range zone-pair.
+   255 is still ~21× the largest known deployment.
+
+2. **Prometheus `from_zone` / `to_zone` labels carry zone-IDs, not
+   zone-names.** The sparse wire payload carries zone-ids; resolving
+   them to names would require plumbing a per-scrape zone-id→name table
+   into the Go collector. Zone-id labels fully satisfy the consumer
+   separability criterion (20 zone-pairs → 20 distinct, non-aliased
+   series). Name resolution can be a follow-up if operators want it.
+
+3. **The §5.5 feature-gated TSC-injection accuracy harness is realized
+   as deterministic unit tests** (`bucket_layout_resolves_low_end_within_2x`
+   + `old_pow2_layout_would_fail_low_end_resolution`) that exercise the
+   real `bucket_index_for_ns_48` / `bucket_upper_bound_ns_48` path and
+   prove the ≤2× per-bucket error at the 10-rule (~50-150 ns) and
+   1M-rule (~5000-50000 ns) targets, plus a fail-before demonstration
+   against the retired 24-bucket layout. This is stronger than a mocked
+   TSC harness for the bucket-resolution criterion and avoids a new
+   cargo feature; an end-to-end TSC-injection harness remains available
+   as a future addition if record→snapshot calibration regressions need
+   coverage.
+
+### Wire-protocol both-sides confirmation (feedback_wire_protocol_both_sides)
+- Rust: `userspace-dp/src/protocol/binding.rs` (sparse `cold_path_active_*`
+  + `cold_path_layout_version` + `cold_path_overflow_active`).
+- Go: `pkg/dataplane/userspace/protocol.go` (mirrored fields; legacy
+  dense v1 fields retained READ-ONLY so a new Go collector still emits
+  correct v1 metrics against a pre-#1635 Rust daemon — plan §3.2 row
+  "v1 Rust / v3 Go").
+
+### Slot zero-out (plan §2.4) realization
+- `forwarding_build` returns `(slot_map, slots_to_zero)`; `slots_to_zero`
+  is stashed on `ForwardingState`. The worker zeroes those slots in each
+  binding's local accumulator at the ForwardingState ArcSwap point
+  (`worker/loop_body/mod.rs`), BEFORE any `record_sample` into the
+  reused slot. The next publish merge overwrites the sibling atomics
+  from the freshly-zeroed local accumulators, so no separate atomic
+  zero-out path is needed on the hot tick.

--- a/docs/pr/1635-cold-path-hist-redesign/plan.md
+++ b/docs/pr/1635-cold-path-hist-redesign/plan.md
@@ -258,8 +258,8 @@ naturally bounded by active-pair cardinality.
 
 ```
 xpf_userspace_worker_cold_path_ns_bucket_v3{worker_id, from_zone, to_zone, le}
-xpf_userspace_worker_cold_path_samples_total_v3{worker_id, from_zone, to_zone}
-xpf_userspace_worker_cold_path_sum_ns_total_v3{worker_id, from_zone, to_zone}
+xpf_userspace_worker_cold_path_samples_v3_total{worker_id, from_zone, to_zone}
+xpf_userspace_worker_cold_path_sum_ns_v3_total{worker_id, from_zone, to_zone}
 xpf_userspace_worker_cold_path_builder_collision_v3{worker_id, from_zone, to_zone}
 xpf_userspace_worker_cold_path_overflow_active{worker_id}
 xpf_userspace_worker_cold_path_zone_id_out_of_range_total{worker_id}
@@ -407,7 +407,7 @@ Mirror the sparse fields. Add `ColdPathLayoutVersion uint32` and the seven
   series with `from_zone` / `to_zone` labels resolved from the
   `ColdPathActiveZoneFrom` / `ColdPathActiveZoneTo` indices through the snapshot's
   zone-name table.
-- other → emit `cold_path_layout_version_unknown_total` increment + warn.
+- other → emit `cold_path_layout_version_unknown` increment + warn.
 
 `bucketLeV3(idx int) string` returns:
 - `idx < 32` → `strconv.FormatUint(uint64((idx+1)*16-1), 10)` (linear, 15, 31, ..., 511).
@@ -662,3 +662,21 @@ Copilot's formal re-review found three deeper issues; all fixed:
    emitter so the overflow gauge never appeared. **Fix:** `status.rs`
    stamps v3 when `has_data || overflow_active`. Go regression
    `TestEmitWorkerColdPath_V3_OverflowNoSamples`.
+
+### §IMPL.r4 Code-review round-4 fixes (Copilot Prometheus naming)
+
+Copilot's review at the rebased HEAD flagged three Prometheus
+metric-name convention issues (no functional change):
+
+1. `..._samples_total_v3` → `..._samples_v3_total`: a `CounterValue`
+   metric must end in `_total`; the `_v3` suffix after `_total` broke
+   the convention used by the rest of the file.
+2. `..._sum_ns_total_v3` → `..._sum_ns_v3_total`: same fix.
+3. `..._layout_version_unknown_total` → `..._layout_version_unknown`:
+   this is a `GaugeValue=1` state indicator, not a counter, so the
+   `_total` suffix was misleading (operators might `rate()` it). The
+   name now omits `_total`.
+
+The `_ns_bucket_v3` family keeps its name — it carries the `le` label
+and is a histogram bucket (not a `_total` counter), so the `_v3`
+placement is unambiguous.

--- a/docs/pr/1635-cold-path-hist-redesign/plan.md
+++ b/docs/pr/1635-cold-path-hist-redesign/plan.md
@@ -597,3 +597,33 @@ deviations, each justified below:
   reused slot. The next publish merge overwrites the sibling atomics
   from the freshly-zeroed local accumulators, so no separate atomic
   zero-out path is needed on the hot tick.
+
+### §IMPL.r2 Code-review round-1 fixes (Codex MERGE-NEEDS-MAJOR → resolved)
+
+Codex code-r1 raised three MAJOR findings against the consumer criteria;
+all three are fixed in the implementation:
+
+1. **Delayed slot reuse across an intermediate free could mix old/new
+   counts.** The original `build` queued zero-out only when the
+   *immediately previous* map showed the slot occupied. The A→B(free,
+   no reuse)→C(reassign) path left A's stale worker-local counts in the
+   slot. **Fix:** `build` now queues EVERY newly-assigned (Pass-2) slot
+   for zero-out whenever a previous map exists (the worker may carry
+   stale counts from any earlier generation). Regression test
+   `build_zeros_slot_reassigned_after_intermediate_free`.
+
+2. **Zone-id ceiling 32 silently dropped valid zone-ids 32-63.** The
+   real limit is `MAX_ZONES = 64` (`bpf/headers/xpf_common.h`,
+   `pkg/dataplane/types.go MaxZones`; Go assigns sequential 1-based
+   ids). **Fix:** `COLD_PATH_ZONE_ID_CEILING = 64`, flat table 64×64 =
+   4096 bytes (still L1d-resident), row shift `<< 6`. Regression tests
+   `build_assigns_slots_for_zone_ids_32_to_63`,
+   `lookup_slot_returns_none_for_zone_id_ge_ceiling`.
+
+3. **Status could relabel stale reused-slot samples as the new pair**
+   for up to one publish tick (coordinator publishes the new slot-map
+   before workers zero reused slots). **Fix:** `status.rs` validates
+   `cold.first_key[slot] == zone_pair_packed_key(from, to)` before
+   emitting; on mismatch the counts belong to the old pair and are
+   skipped (not relabeled). Closes the 1-tick transient the Claude SMR
+   review had flagged as a NIT.

--- a/docs/pr/1635-cold-path-hist-redesign/plan.md
+++ b/docs/pr/1635-cold-path-hist-redesign/plan.md
@@ -407,7 +407,10 @@ Mirror the sparse fields. Add `ColdPathLayoutVersion uint32` and the seven
   series with `from_zone` / `to_zone` labels resolved from the
   `ColdPathActiveZoneFrom` / `ColdPathActiveZoneTo` indices through the snapshot's
   zone-name table.
-- other → emit `cold_path_layout_version_unknown` increment + warn.
+- other → emit the `cold_path_layout_version_unknown{worker_id, version}`
+  gauge with value 1 (a state indicator; the implementation does NOT log a
+  warning and does NOT increment a counter — it is a per-scrape gauge so
+  operators can alert on its presence).
 
 `bucketLeV3(idx int) string` returns:
 - `idx < 32` → `strconv.FormatUint(uint64((idx+1)*16-1), 10)` (linear, 15, 31, ..., 511).
@@ -453,7 +456,8 @@ Run 5/5 flake check.
 - `metrics_userspace_layout_version_3_emits_v3_with_zone_labels`: synthetic v3
   status (sparse active arrays) → v3 metrics + zone labels.
 - `metrics_userspace_layout_version_unknown_emits_warning`: synthetic v=99 →
-  no v1/v3 metrics; warning gauge increments.
+  no v1/v3 metrics; the `cold_path_layout_version_unknown{version="99"}`
+  gauge is emitted with value 1 (no log warning, no counter increment).
 - `metrics_userspace_v3_sparse_emits_only_active_slots`: 12 active slots out of
   256 → 12 series per family, not 256.
 
@@ -699,3 +703,23 @@ placement is unambiguous.
    `cold_path_layout_version_unknown` gauge that IS emitted). The §2.3
    design-prose mention of a hypothetical out-of-range counter is
    historical narrative; `overflow_active` is the shipped signal.
+
+### §IMPL.r7 Code-review round-7 fixes (Copilot, at the comment-fix HEAD)
+
+1. **Describe() registration-contract violation (SUBSTANTIVE).** All 17
+   cold-path descriptors were emitted by `Collect()`
+   (`emitWorkerColdPath`) but NONE were sent in
+   `xpfCollector.Describe()`. `xpfCollector` is a CHECKED collector, so
+   emitting undeclared `Desc`s makes promhttp log a Gather error on
+   every scrape and a `HTTPErrorOnError` registry return 500. The v1 +
+   scalar descs were already missing (latent gap from #1619/#1621); the
+   v3 descs added in #1635 widened it. Fix: declare the whole cold-path
+   family (v1 bucket/samples/sum_ns/alias_seen, the scalars, and the v3
+   bucket/samples/sum_ns/builder_collision + overflow_active +
+   layout_version + layout_version_unknown) in `Describe()`. Proof: a
+   metrics scrape now produces no registry/Gather error.
+
+2. **Plan text drift on the unknown-version metric (doc NIT).** The plan
+   said it "increments + warns", but the impl emits a `GaugeValue=1`
+   state indicator with no log warning and no counter increment. Plan
+   §4.8 + §5.2 text corrected to match the shipped behavior.

--- a/docs/pr/1635-cold-path-hist-redesign/plan.md
+++ b/docs/pr/1635-cold-path-hist-redesign/plan.md
@@ -262,8 +262,8 @@ xpf_userspace_worker_cold_path_samples_v3_total{worker_id, from_zone, to_zone}
 xpf_userspace_worker_cold_path_sum_ns_v3_total{worker_id, from_zone, to_zone}
 xpf_userspace_worker_cold_path_builder_collision_v3{worker_id, from_zone, to_zone}
 xpf_userspace_worker_cold_path_overflow_active{worker_id}
-xpf_userspace_worker_cold_path_zone_id_out_of_range_total{worker_id}
 xpf_userspace_worker_cold_path_layout_version{worker_id, version}
+xpf_userspace_worker_cold_path_layout_version_unknown{worker_id, version}
 ```
 
 The `_v3` suffix replaces v2's `_v2` and the existing v1 names. Operators querying
@@ -680,3 +680,22 @@ metric-name convention issues (no functional change):
 The `_ns_bucket_v3` family keeps its name — it carries the `le` label
 and is a histogram bucket (not a `_total` counter), so the `_v3`
 placement is unambiguous.
+
+### §IMPL.r5 Code-review round-5 fixes (Copilot, fresh review at rebased HEAD)
+
+1. **Out-of-range zone-pairs now set `overflow_active`.** The 65×65
+   table covers zone-ids `0..=64` (the Go compiler assigns 1-based ids
+   up to MaxZones=64), but the Rust snapshot path accepts ids up to
+   `u8::MAX` (255). A configured pair with an id in `65..=255` was
+   silently dropped by `ColdPathSlotMap::build` with no signal. It now
+   trips `overflow_active`, so operators see a configured pair went
+   unmeasured. Regression: `build_skips_out_of_range_pairs_and_flags_overflow`.
+
+2. **Dropped the never-emitted `zone_id_out_of_range_total` metric from
+   the §2.5 plan list.** The implementation represents out-of-range and
+   capacity-exhaustion uniformly via `cold_path_overflow_active`; there
+   is no separate out-of-range counter. The plan's §2.5 metric list now
+   matches the emitted surface (and adds the
+   `cold_path_layout_version_unknown` gauge that IS emitted). The §2.3
+   design-prose mention of a hypothetical out-of-range counter is
+   historical narrative; `overflow_active` is the shipped signal.

--- a/docs/pr/1635-cold-path-hist-redesign/plan.md
+++ b/docs/pr/1635-cold-path-hist-redesign/plan.md
@@ -627,3 +627,32 @@ all three are fixed in the implementation:
    emitting; on mismatch the counts belong to the old pair and are
    skipped (not relabeled). Closes the 1-tick transient the Claude SMR
    review had flagged as a NIT.
+
+### §IMPL.r3 Code-review round-2 fixes (Copilot formal review)
+
+Copilot's formal re-review found three deeper issues; all fixed:
+
+1. **Zone-id off-by-one (id 64 dropped).** Zone-ids are 1-based with
+   `MaxZones = 64`, so the highest assignable id is 64; the exclusive
+   ceiling of 64 dropped it. **Fix:** the table now indexes ids `0..=64`
+   (`COLD_PATH_ZONE_DIM = 65`, 65×65 = 4225 B), with a MULTIPLY index
+   (`from * 65 + to`) since 65 is not a power of two. New regression
+   `build_assigns_slots_for_zone_ids_up_to_64` (covers id 64) +
+   `lookup_slot_returns_none_for_zone_id_out_of_range` (id 65+).
+
+2. **Missed-generation slot zero-out gap.** The worker only ever loads
+   the LATEST `ForwardingState` from ArcSwap and can skip intermediate
+   config generations; the coordinator-computed `slots_to_zero` was
+   relative to its immediately-previous map, so a slot reassigned in a
+   skipped generation could be absent from the latest list. **Fix:** the
+   worker now derives its zero-set by diffing ITS OWN old slot-map
+   inverse against the new one at the swap (`worker/loop_body/mod.rs`) —
+   generation-independent. `ForwardingState.cold_path_slots_to_zero` is
+   removed; `build`'s returned list is kept for unit tests only.
+
+3. **Overflow-with-no-samples hid the overflow gauge.** A v3 payload
+   with `overflow_active=true` but no samples stamped
+   `cold_path_layout_version=0`, routing the Go collector to the v1
+   emitter so the overflow gauge never appeared. **Fix:** `status.rs`
+   stamps v3 when `has_data || overflow_active`. Go regression
+   `TestEmitWorkerColdPath_V3_OverflowNoSamples`.

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -30,3 +30,15 @@ Continuations:
 | Claude SMR | in-conversation                    | MERGE-READY (verified fixes) |
 | Copilot    | re-review requested @ b870f4303    | requested |
 | Copilot SWE| autonomous commits 7d8d2ab19, 422196ba5 (retry-budget 128->2048->8192) | integrated |
+
+### Round 3 verdicts (head b870f4303 code; 44c3c3db7 = docs/comments + Go test only)
+| Reviewer   | Task / job id                      | Verdict                         |
+|------------|------------------------------------|---------------------------------|
+| Codex      | task-mpreeci9-0dfrx9               | MERGE-NEEDS-MINOR (docs/comments only — "functional verdict merge-ready"); all stale comments fixed in 44c3c3db7 |
+| AGY        | adversarial-review-mpreek4k-h6dm4i  | MERGE-READY (all 3 r2 fixes verified; injective base-65 index; gen-independent zero-out; overflow gauge) |
+| Claude SMR | in-conversation                    | MERGE-READY                     |
+| Copilot    | re-review @ 44c3c3db7 requested     | 4 r3 NITs (stale comments + Go sparse-wire test) all addressed; awaiting confirm |
+
+Note: AGY + Codex independently confirmed the lone failing test
+(snat_contract_doc_guard) is unrelated pre-existing master drift
+("fail closed" vs "fail-closed" on docs/userspace-dataplane-gaps.md:40).

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -1,29 +1,14 @@
-# Reviewer task IDs — #1635 plan + code review
+# #1635 reviewer task IDs (code review round 1)
 
-## Round 1 — plan-review
+PR: #1668  branch: refactor/1635-cold-path-hist-redesign  head: ba1f8fc08  base: origin/master
 
-- **Plan SHA**: 913ab5f2061ce9be037e45e78e3027e565295f9a
-- **AGY**: adversarial-review-mppsdq37-vz0w2l → PLAN-NEEDS-MINOR (6 concrete remediations)
-- **Codex**: first dispatch task-mpprv1bq-bq48uj LOST (codex shared-session bug);
-  retried as task-mppse9m2-s3z6j1 also LOST; second retry task-mppsgess-w6pwan in
-  flight 2026-05-28
-- **Claude SMR**: r1 (PLAN-NEEDS-MAJOR F1/F2/F3/F4) + r2 (PLAN-READY conditional)
+| Reviewer   | Task / job id                          | Round | Status   |
+|------------|----------------------------------------|-------|----------|
+| Codex      | task-mprdfxxt-xz1j9x                    | r1    | running  |
+| AGY        | adversarial-review-mprdfjmu-msviir      | r1    | running  |
+| Claude SMR | (in-conversation, domain + arch)        | r1    | running  |
+| Copilot    | PR #1668 @copilot review requested      | r1    | requested|
 
-## Codex plan-review infra-blocked exception
-
-Three Codex plan-review dispatches all victim of the shared-session bug pattern:
-- task-mpprv1bq-bq48uj (lost — not in status listing)
-- task-mppse9m2-s3z6j1 (lost — not in status listing)
-- task-mppsgess-w6pwan (initially ran, returned WRONG verdict for a different task)
-- task-mppt0kr6-y9xoaf (immediately clobbered by parallel-session task; lost)
-
-The Codex companion in shared-session mode is clobbering my task IDs with
-another concurrent agent's. Per `feedback_codex_infra_must_retry` the canonical
-remedy is retry; three retries all hit the same structural failure. Per
-`feedback_codex_infra_must_retry` + the agent contract's
-"Codex/Copilot-infra-blocked exception applies" — proceeding to implementation
-on AGY + Claude SMR (2-of-3, both independent seats). Codex will get a fresh
-shot at code-review time when sandbox conditions may have cleared.
-
-This is the **plan-review** gate, not the final merge gate; AGY r1 PLAN-NEEDS-
-MINOR with 6 concrete remediations all absorbed, Claude SMR r1+r2+r3 PLAN-READY.
+Continuations: fetch by id —
+  node /home/ps/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs result task-mprdfxxt-xz1j9x
+  /agy:result adversarial-review-mprdfjmu-msviir

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -1,14 +1,23 @@
-# #1635 reviewer task IDs (code review round 1)
+# #1635 reviewer task IDs
 
-PR: #1668  branch: refactor/1635-cold-path-hist-redesign  head: ba1f8fc08  base: origin/master
+PR: #1668  branch: refactor/1635-cold-path-hist-redesign  base: origin/master
 
-| Reviewer   | Task / job id                          | Round | Status   |
-|------------|----------------------------------------|-------|----------|
-| Codex      | task-mprdfxxt-xz1j9x                    | r1    | running  |
-| AGY        | adversarial-review-mprdfjmu-msviir      | r1    | running  |
-| Claude SMR | (in-conversation, domain + arch)        | r1    | running  |
-| Copilot    | PR #1668 @copilot review requested      | r1    | requested|
+## Round 1 (head ba1f8fc08)
+| Reviewer   | Task / job id                      | Verdict            |
+|------------|------------------------------------|--------------------|
+| Codex      | task-mprdfxxt-xz1j9x               | MERGE-NEEDS-MAJOR (3 findings) |
+| AGY        | adversarial-review-mprdfjmu-msviir  | MERGE-READY        |
+| Claude SMR | in-conversation                    | MERGE-READY (1 NIT, escalated by Codex) |
+| Copilot SWE| (autonomous commit 7d8d2ab19)      | retry-budget fix integrated |
 
-Continuations: fetch by id —
-  node /home/ps/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs result task-mprdfxxt-xz1j9x
-  /agy:result adversarial-review-mprdfjmu-msviir
+## Round 2 (head 2074b5cc9 — 3 MAJOR fixes + Copilot budget fix)
+| Reviewer   | Task / job id                      | Verdict   |
+|------------|------------------------------------|-----------|
+| Codex      | task-mprdwcke-db45pk               | running   |
+| AGY        | adversarial-review-mprdwlwd-2ub6tm  | running   |
+| Claude SMR | in-conversation                    | MERGE-READY (verified fixes) |
+| Copilot    | re-review requested @ 2074b5cc9    | requested |
+
+Continuations:
+  node /home/ps/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs status task-mprdwcke-db45pk
+  /agy:result adversarial-review-mprdwlwd-2ub6tm

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -21,3 +21,12 @@ PR: #1668  branch: refactor/1635-cold-path-hist-redesign  base: origin/master
 Continuations:
   node /home/ps/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs status task-mprdwcke-db45pk
   /agy:result adversarial-review-mprdwlwd-2ub6tm
+
+## Round 3 (head b870f4303 — Copilot formal-review fixes: zone-id 64, gen-independent zero-out, overflow gauge)
+| Reviewer   | Task / job id                      | Verdict   |
+|------------|------------------------------------|-----------|
+| Codex      | task-mpreeci9-0dfrx9               | running   |
+| AGY        | adversarial-review-mpreek4k-h6dm4i  | running   |
+| Claude SMR | in-conversation                    | MERGE-READY (verified fixes) |
+| Copilot    | re-review requested @ b870f4303    | requested |
+| Copilot SWE| autonomous commits 7d8d2ab19, 422196ba5 (retry-budget 128->2048->8192) | integrated |

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -68,7 +68,7 @@ zone_id_out_of_range_total in plan §2.5. Both fixed in 207e01c64.
 
 | Reviewer   | Task / job id                      | Verdict   |
 |------------|------------------------------------|-----------|
-| Codex      | task-mprfc9u2-ahfcxq               | running (final confirm) |
-| AGY        | adversarial-review-mprfcg9v-z1rvm5  | running (final confirm) |
+| Codex      | task-mprfc9u2-ahfcxq               | MERGE-READY (overflow gated to ids>=65; retained-pair handling unchanged; no drift) |
+| AGY        | adversarial-review-mprfcg9v-z1rvm5  | MERGE-READY (overflow isolated; regression test passes; 1638 cargo tests green) |
 | Claude SMR | in-conversation                    | MERGE-READY (overflow fix verified; in-range unaffected) |
 | Copilot    | re-review @ 207e01c64 requested; polling | r5 findings addressed |

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -42,3 +42,21 @@ Continuations:
 Note: AGY + Codex independently confirmed the lone failing test
 (snat_contract_doc_guard) is unrelated pre-existing master drift
 ("fail closed" vs "fail-closed" on docs/userspace-dataplane-gaps.md:40).
+
+## Round 4 — rebased onto origin/master (HEAD 328beaeb4) + Prometheus metric rename
+Rebase: clean replay of 9 commits onto origin/master; picks up #1670 (doc-guard
+fix → snat_contract_doc_guard now GREEN), #1658, #1662. Disjoint files, no conflicts.
+Rename (Copilot r4, no logic change): samples_total_v3→samples_v3_total,
+sum_ns_total_v3→sum_ns_v3_total (CounterValue, _total final),
+layout_version_unknown_total→layout_version_unknown (GaugeValue state indicator).
+
+| Reviewer   | Task / job id                      | Verdict   |
+|------------|------------------------------------|-----------|
+| Codex      | task-mprf0sdn-tkln60               | running (confirm) |
+| AGY        | adversarial-review-mprf115e-ujupbb  | running (confirm) |
+| Claude SMR | in-conversation                    | MERGE-READY (rebase clean + rename verified) |
+| Copilot    | re-review @ 328beaeb4 requested; polling | r4 (3 naming) addressed |
+
+Continuations:
+  node /home/ps/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs status task-mprf0sdn-tkln60
+  /agy:result adversarial-review-mprf115e-ujupbb

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -60,3 +60,15 @@ layout_version_unknown_total→layout_version_unknown (GaugeValue state indicato
 Continuations:
   node /home/ps/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs status task-mprf0sdn-tkln60
   /agy:result adversarial-review-mprf115e-ujupbb
+
+## Round 5 — out-of-range overflow_active fix + plan metric cleanup (HEAD 207e01c64)
+Copilot fresh review at 9a191d70b (21:14) found: out-of-range zone-pairs (id 65..=255,
+reachable on the Rust path) silently dropped w/o overflow signal; stale
+zone_id_out_of_range_total in plan §2.5. Both fixed in 207e01c64.
+
+| Reviewer   | Task / job id                      | Verdict   |
+|------------|------------------------------------|-----------|
+| Codex      | task-mprfc9u2-ahfcxq               | running (final confirm) |
+| AGY        | adversarial-review-mprfcg9v-z1rvm5  | running (final confirm) |
+| Claude SMR | in-conversation                    | MERGE-READY (overflow fix verified; in-range unaffected) |
+| Copilot    | re-review @ 207e01c64 requested; polling | r5 findings addressed |

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -84,3 +84,17 @@ also fires on out-of-range zone-ids). Fixed all 3 comments. NO behavior/binary c
 | AGY        | MERGE-READY carries forward (comment-only delta) |
 | Claude SMR | MERGE-READY (verified: only doc comments in metrics_descriptors.go / protocol.go / binding.rs changed; cargo+go green) |
 | Copilot    | review @ 16b9dfa7d requested; polling (task bt3l1e6xb) |
+
+## Round 7 — Describe() checked-collector fix (HEAD 0f0db4db3, SUBSTANTIVE Go change)
+Copilot review 4393007808 @ ecb418ab6 found: all 17 cold-path descriptors emitted by
+Collect() but none declared in Describe() (checked-collector contract violation →
+Gather error / 500). Fixed: metrics.go Describe() declares all 17. New regression
+TestColdPathDescriptorsAreDescribed (fail-before 472 undeclared / pass-after 0).
+Plus plan §4.8/§5.2 doc fix (unknown-version metric is a gauge, not increment+warn).
+
+| Reviewer   | Task / job id                      | Verdict   |
+|------------|------------------------------------|-----------|
+| Codex      | task-mprgn0r3-oida5z               | running (re-confirm — real code change) |
+| AGY        | adversarial-review-mprgn840-ti0gac  | running (re-confirm) |
+| Claude SMR | in-conversation                    | MERGE-READY (Describe completeness verified; fail-before/pass-after proven) |
+| Copilot    | re-review @ 0f0db4db3 requested; polling | findings 1+2 addressed |

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -72,3 +72,15 @@ zone_id_out_of_range_total in plan §2.5. Both fixed in 207e01c64.
 | AGY        | adversarial-review-mprfcg9v-z1rvm5  | MERGE-READY (overflow isolated; regression test passes; 1638 cargo tests green) |
 | Claude SMR | in-conversation                    | MERGE-READY (overflow fix verified; in-range unaffected) |
 | Copilot    | re-review @ 207e01c64 requested; polling | r5 findings addressed |
+
+## Round 6 — overflow_active comment doc-drift fix (HEAD 16b9dfa7d, COMMENT-ONLY)
+Copilot review 4392934810 @ 18d634f84 (21:24) found the overflow_active describing
+comments at 3 sites still said "capacity-only" after the 207e01c64 broadening (now
+also fires on out-of-range zone-ids). Fixed all 3 comments. NO behavior/binary change.
+
+| Reviewer   | Verdict   |
+|------------|-----------|
+| Codex      | MERGE-READY carries forward (comment-only delta; binary unchanged from 207e01c64) |
+| AGY        | MERGE-READY carries forward (comment-only delta) |
+| Claude SMR | MERGE-READY (verified: only doc comments in metrics_descriptors.go / protocol.go / binding.rs changed; cargo+go green) |
+| Copilot    | review @ 16b9dfa7d requested; polling (task bt3l1e6xb) |

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -52,8 +52,8 @@ layout_version_unknown_total→layout_version_unknown (GaugeValue state indicato
 
 | Reviewer   | Task / job id                      | Verdict   |
 |------------|------------------------------------|-----------|
-| Codex      | task-mprf0sdn-tkln60               | running (confirm) |
-| AGY        | adversarial-review-mprf115e-ujupbb  | running (confirm) |
+| Codex      | task-mprf0sdn-tkln60               | MERGE-READY (range-diff patch-equivalent; rename consistent; types unchanged) |
+| AGY        | adversarial-review-mprf115e-ujupbb  | MERGE-READY (rebase clean; doc-guard GREEN; 1613 cargo tests pass) |
 | Claude SMR | in-conversation                    | MERGE-READY (rebase clean + rename verified) |
 | Copilot    | re-review @ 328beaeb4 requested; polling | r4 (3 naming) addressed |
 

--- a/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
+++ b/docs/pr/1635-cold-path-hist-redesign/reviewer-ids.md
@@ -98,3 +98,22 @@ Plus plan §4.8/§5.2 doc fix (unknown-version metric is a gauge, not increment+
 | AGY        | adversarial-review-mprgn840-ti0gac  | running (re-confirm) |
 | Claude SMR | in-conversation                    | MERGE-READY (Describe completeness verified; fail-before/pass-after proven) |
 | Copilot    | re-review @ 0f0db4db3 requested; polling | findings 1+2 addressed |
+
+## Round 7 verdicts + round 8 (test robustness, HEAD e490e846d)
+Codex r7 (task-mprgn0r3-oida5z): MERGE-NEEDS-MINOR — production Describe() fix
+verified complete (17 declared == 17 emitted; broader 133==133 across all collector
+descs; regression real at 207e01c64). MINOR: the new test's v1 fixture under-exercised
+SumNS/AliasSeen. ADDRESSED at e490e846d: v1 fixture now emits all 4 v1 families +
+exact-17-count assertion; verified removing SumNS+AliasSeen from Describe fails the
+test (32 undeclared). Test-only change.
+AGY r7 (adversarial-review-mprgn840-ti0gac): MERGE-READY — 17/17 declared verified,
+test fail-before(472)/pass-after(0) efficacy confirmed, invariants intact, suites green.
+Claude SMR: MERGE-READY — Describe 17==17 exact match; strengthened test catches
+single-desc removal.
+
+| Reviewer   | Verdict @ HEAD e490e846d |
+|------------|--------------------------|
+| Codex      | MERGE-READY (r7 MINOR addressed; production fix verified complete) |
+| AGY        | MERGE-READY (r7, at Describe-fix HEAD; test-only delta since) |
+| Claude SMR | MERGE-READY |
+| Copilot    | findings 1+2 fixed; re-review @ e490e846d requested; polling (task bk8ev5c6m) |

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -296,6 +296,29 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.userspaceEventStreamDataplaneDropsTotal
 	ch <- c.userspaceEventStreamUnknownDropsTotal
 	ch <- c.workerDead
+	// #1635: cold-path histogram descriptors. xpfCollector is a CHECKED
+	// collector — every Desc emitted by Collect() (via emitWorkerColdPath)
+	// MUST be declared here, or promhttp logs a Gather error on every
+	// scrape and a HTTPErrorOnError registry returns 500. The v1 +
+	// scalar descs were never declared (a latent gap from #1619/#1621);
+	// the v3 descs added in #1635 widened it. Declare the whole family.
+	ch <- c.workerColdPathBucket
+	ch <- c.workerColdPathSamples
+	ch <- c.workerColdPathSumNS
+	ch <- c.workerColdPathAliasSeen
+	ch <- c.workerColdPathSamplePhase
+	ch <- c.workerColdPathWrapperUnderflow
+	ch <- c.workerColdPathWrapperNSBaseline
+	ch <- c.workerColdPathNSPerTSCQ32
+	ch <- c.workerColdPathClockSource
+	ch <- c.workerColdPathSnapshotFailedTotal
+	ch <- c.workerColdPathBucketV3
+	ch <- c.workerColdPathSamplesV3
+	ch <- c.workerColdPathSumNSV3
+	ch <- c.workerColdPathBuilderCollisionV3
+	ch <- c.workerColdPathOverflowActive
+	ch <- c.workerColdPathLayoutVersion
+	ch <- c.workerColdPathLayoutUnknownTotal
 	ch <- c.bindingActiveFlowCount
 	ch <- c.bindingFlowCacheCapacity
 	ch <- c.bindingTXCompletions

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -153,6 +153,14 @@ type xpfCollector struct {
 	workerColdPathNSPerTSCQ32          *prometheus.Desc
 	workerColdPathClockSource          *prometheus.Desc
 	workerColdPathSnapshotFailedTotal  *prometheus.Desc
+	// #1635 sparse v3 per-zone-pair families (from_zone/to_zone labels).
+	workerColdPathBucketV3            *prometheus.Desc
+	workerColdPathSamplesV3           *prometheus.Desc
+	workerColdPathSumNSV3             *prometheus.Desc
+	workerColdPathBuilderCollisionV3  *prometheus.Desc
+	workerColdPathOverflowActive      *prometheus.Desc
+	workerColdPathLayoutVersion       *prometheus.Desc
+	workerColdPathLayoutUnknownTotal  *prometheus.Desc
 	// #1219: snapshot per-binding distinct active flow count for the
 	// fairness harness (read by test/incus/fairness-harness.sh ->
 	// fairness-eval to compute Cstruct + observed_CoV per

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -143,24 +143,24 @@ type xpfCollector struct {
 	// dataplane side; we expose it here as a Prometheus-native
 	// `_bucket{le="..."}` counter family compatible with PromQL
 	// histogram_quantile().
-	workerColdPathBucket               *prometheus.Desc
-	workerColdPathSamples              *prometheus.Desc
-	workerColdPathSumNS                *prometheus.Desc
-	workerColdPathAliasSeen            *prometheus.Desc
-	workerColdPathSamplePhase          *prometheus.Desc
-	workerColdPathWrapperUnderflow     *prometheus.Desc
-	workerColdPathWrapperNSBaseline    *prometheus.Desc
-	workerColdPathNSPerTSCQ32          *prometheus.Desc
-	workerColdPathClockSource          *prometheus.Desc
-	workerColdPathSnapshotFailedTotal  *prometheus.Desc
+	workerColdPathBucket              *prometheus.Desc
+	workerColdPathSamples             *prometheus.Desc
+	workerColdPathSumNS               *prometheus.Desc
+	workerColdPathAliasSeen           *prometheus.Desc
+	workerColdPathSamplePhase         *prometheus.Desc
+	workerColdPathWrapperUnderflow    *prometheus.Desc
+	workerColdPathWrapperNSBaseline   *prometheus.Desc
+	workerColdPathNSPerTSCQ32         *prometheus.Desc
+	workerColdPathClockSource         *prometheus.Desc
+	workerColdPathSnapshotFailedTotal *prometheus.Desc
 	// #1635 sparse v3 per-zone-pair families (from_zone/to_zone labels).
-	workerColdPathBucketV3            *prometheus.Desc
-	workerColdPathSamplesV3           *prometheus.Desc
-	workerColdPathSumNSV3             *prometheus.Desc
-	workerColdPathBuilderCollisionV3  *prometheus.Desc
-	workerColdPathOverflowActive      *prometheus.Desc
-	workerColdPathLayoutVersion       *prometheus.Desc
-	workerColdPathLayoutUnknownTotal  *prometheus.Desc
+	workerColdPathBucketV3           *prometheus.Desc
+	workerColdPathSamplesV3          *prometheus.Desc
+	workerColdPathSumNSV3            *prometheus.Desc
+	workerColdPathBuilderCollisionV3 *prometheus.Desc
+	workerColdPathOverflowActive     *prometheus.Desc
+	workerColdPathLayoutVersion      *prometheus.Desc
+	workerColdPathLayoutUnknownTotal *prometheus.Desc
 	// #1219: snapshot per-binding distinct active flow count for the
 	// fairness harness (read by test/incus/fairness-harness.sh ->
 	// fairness-eval to compute Cstruct + observed_CoV per

--- a/pkg/api/metrics_cold_path_test.go
+++ b/pkg/api/metrics_cold_path_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -262,4 +263,230 @@ func descName(d *prometheus.Desc) string {
 		return rest
 	}
 	return rest[:end]
+}
+
+// === #1635 sparse v3 cold-path emission tests ===
+
+// labelsOf reads a metric's labels into a map.
+func labelsOf(t *testing.T, m prometheus.Metric) map[string]string {
+	t.Helper()
+	var pb dto.Metric
+	if err := m.Write(&pb); err != nil {
+		t.Fatalf("metric.Write: %v", err)
+	}
+	out := map[string]string{}
+	for _, l := range pb.Label {
+		out[l.GetName()] = l.GetValue()
+	}
+	return out
+}
+
+func valueOf(t *testing.T, m prometheus.Metric) float64 {
+	t.Helper()
+	var pb dto.Metric
+	if err := m.Write(&pb); err != nil {
+		t.Fatalf("metric.Write: %v", err)
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	return 0
+}
+
+// #1635: layout version 1 (or 0) routes to the v1 dense emit path; the
+// v3 per-zone-pair families must NOT appear.
+func TestEmitWorkerColdPath_LayoutVersion1_EmitsV1(t *testing.T) {
+	c := newCollectorWithWorkerDescsOnly()
+	hist := make([][]uint64, 16)
+	for i := range hist {
+		hist[i] = make([]uint64, 24)
+	}
+	hist[3][5] = 7
+	status := dpuserspace.ProcessStatus{
+		WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{
+			{
+				WorkerID:              0,
+				ColdPathLayoutVersion: 1,
+				ColdPathHist:          hist,
+				ColdPathSamples:       make([]uint64, 16),
+			},
+		},
+	}
+	got := collectFromEmitWorkerRuntime(t, c, status)
+	var sawV1Bucket, sawV3Bucket bool
+	for _, m := range got {
+		switch descName(m.Desc()) {
+		case "xpf_userspace_worker_cold_path_ns_bucket":
+			sawV1Bucket = true
+		case "xpf_userspace_worker_cold_path_ns_bucket_v3":
+			sawV3Bucket = true
+		}
+	}
+	if !sawV1Bucket {
+		t.Error("version 1 must emit the v1 bucket family")
+	}
+	if sawV3Bucket {
+		t.Error("version 1 must NOT emit the v3 bucket family")
+	}
+}
+
+// #1635: layout version 3 routes to the sparse per-zone-pair path with
+// from_zone/to_zone labels and the 48-bucket log-linear `le` boundaries.
+func TestEmitWorkerColdPath_LayoutVersion3_EmitsV3WithZoneLabels(t *testing.T) {
+	c := newCollectorWithWorkerDescsOnly()
+	buckets := make([]uint64, 48)
+	buckets[6] = 5 // 100 ns lands in linear bucket 6 (le=111)
+	status := dpuserspace.ProcessStatus{
+		WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{
+			{
+				WorkerID:                       0,
+				ColdPathLayoutVersion:          3,
+				ColdPathActiveSlotIDs:          []uint32{0},
+				ColdPathActiveZoneFrom:         []uint32{2},
+				ColdPathActiveZoneTo:           []uint32{5},
+				ColdPathActiveSamples:          []uint64{5},
+				ColdPathActiveSumNS:            []uint64{500},
+				ColdPathActiveBuckets:          [][]uint64{buckets},
+				ColdPathActiveBuilderCollision: []bool{false},
+			},
+		},
+	}
+	got := collectFromEmitWorkerRuntime(t, c, status)
+	var sawSamplesV3, sawBucketLE111, sawVersionGauge bool
+	for _, m := range got {
+		switch descName(m.Desc()) {
+		case "xpf_userspace_worker_cold_path_samples_total_v3":
+			lbl := labelsOf(t, m)
+			if lbl["from_zone"] == "2" && lbl["to_zone"] == "5" &&
+				valueOf(t, m) == 5 {
+				sawSamplesV3 = true
+			}
+		case "xpf_userspace_worker_cold_path_ns_bucket_v3":
+			lbl := labelsOf(t, m)
+			if lbl["le"] == "111" && valueOf(t, m) == 5 {
+				sawBucketLE111 = true
+			}
+		case "xpf_userspace_worker_cold_path_layout_version":
+			if labelsOf(t, m)["version"] == "3" {
+				sawVersionGauge = true
+			}
+		}
+	}
+	if !sawSamplesV3 {
+		t.Error("v3 samples metric with from_zone=2/to_zone=5/value=5 not emitted")
+	}
+	if !sawBucketLE111 {
+		t.Error("v3 cumulative bucket le=111 (100 ns) not emitted — log-linear le mismatch")
+	}
+	if !sawVersionGauge {
+		t.Error("layout_version gauge {version=3} not emitted")
+	}
+}
+
+// #1635: an unknown layout version emits no v1/v3 metrics, only the
+// forward-compat unknown gauge.
+func TestEmitWorkerColdPath_LayoutVersionUnknown_EmitsWarning(t *testing.T) {
+	c := newCollectorWithWorkerDescsOnly()
+	status := dpuserspace.ProcessStatus{
+		WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{
+			{WorkerID: 0, ColdPathLayoutVersion: 99},
+		},
+	}
+	got := collectFromEmitWorkerRuntime(t, c, status)
+	var sawUnknown, sawV1, sawV3 bool
+	for _, m := range got {
+		switch descName(m.Desc()) {
+		case "xpf_userspace_worker_cold_path_layout_version_unknown_total":
+			if labelsOf(t, m)["version"] == "99" {
+				sawUnknown = true
+			}
+		case "xpf_userspace_worker_cold_path_ns_bucket":
+			sawV1 = true
+		case "xpf_userspace_worker_cold_path_ns_bucket_v3":
+			sawV3 = true
+		}
+	}
+	if !sawUnknown {
+		t.Error("unknown version must emit the unknown-version gauge")
+	}
+	if sawV1 || sawV3 {
+		t.Error("unknown version must NOT emit v1/v3 histogram families")
+	}
+}
+
+// #1635 CONSUMER CRITERION (per-zone-pair separability): a 20-zone-pair
+// workload must report 20 DISTINCT latency distributions with no
+// collision-exclusion artifact. With the direct slot map every active
+// pair publishes its own (from_zone, to_zone) series; none is excluded.
+func TestEmitWorkerColdPath_V3_TwentyZonePairsSeparable(t *testing.T) {
+	c := newCollectorWithWorkerDescsOnly()
+	const n = 20
+	w := dpuserspace.WorkerRuntimeStatus{
+		WorkerID:              0,
+		ColdPathLayoutVersion: 3,
+	}
+	for i := 0; i < n; i++ {
+		buckets := make([]uint64, 48)
+		buckets[i%48] = uint64(i + 1)
+		w.ColdPathActiveSlotIDs = append(w.ColdPathActiveSlotIDs, uint32(i))
+		w.ColdPathActiveZoneFrom = append(w.ColdPathActiveZoneFrom, uint32(i))
+		w.ColdPathActiveZoneTo = append(w.ColdPathActiveZoneTo, uint32(i+1))
+		w.ColdPathActiveSamples = append(w.ColdPathActiveSamples, uint64(i+1))
+		w.ColdPathActiveSumNS = append(w.ColdPathActiveSumNS, uint64((i+1)*100))
+		w.ColdPathActiveBuckets = append(w.ColdPathActiveBuckets, buckets)
+		w.ColdPathActiveBuilderCollision = append(w.ColdPathActiveBuilderCollision, false)
+	}
+	status := dpuserspace.ProcessStatus{WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{w}}
+	got := collectFromEmitWorkerRuntime(t, c, status)
+
+	distinctPairs := map[string]float64{}
+	for _, m := range got {
+		if descName(m.Desc()) != "xpf_userspace_worker_cold_path_samples_total_v3" {
+			continue
+		}
+		lbl := labelsOf(t, m)
+		distinctPairs[lbl["from_zone"]+"->"+lbl["to_zone"]] = valueOf(t, m)
+	}
+	if len(distinctPairs) != n {
+		t.Fatalf("expected %d separable zone-pair series, got %d (collision exclusion?)",
+			n, len(distinctPairs))
+	}
+	for i := 0; i < n; i++ {
+		key := strconv.Itoa(i) + "->" + strconv.Itoa(i+1)
+		if distinctPairs[key] != float64(i+1) {
+			t.Errorf("pair %s: want samples %d got %v", key, i+1, distinctPairs[key])
+		}
+	}
+}
+
+// #1635: the sparse encoding emits exactly one series per ACTIVE slot,
+// not POLICY_COLD_PATH_ZONE_PAIR_SLOTS (256) series. 12 active slots ⇒
+// 12 samples_v3 series.
+func TestEmitWorkerColdPath_V3_SparseEmitsOnlyActiveSlots(t *testing.T) {
+	c := newCollectorWithWorkerDescsOnly()
+	const n = 12
+	w := dpuserspace.WorkerRuntimeStatus{WorkerID: 0, ColdPathLayoutVersion: 3}
+	for i := 0; i < n; i++ {
+		w.ColdPathActiveSlotIDs = append(w.ColdPathActiveSlotIDs, uint32(i))
+		w.ColdPathActiveZoneFrom = append(w.ColdPathActiveZoneFrom, uint32(i))
+		w.ColdPathActiveZoneTo = append(w.ColdPathActiveZoneTo, uint32(31-i))
+		w.ColdPathActiveSamples = append(w.ColdPathActiveSamples, uint64(i+1))
+		w.ColdPathActiveSumNS = append(w.ColdPathActiveSumNS, 1)
+		w.ColdPathActiveBuckets = append(w.ColdPathActiveBuckets, make([]uint64, 48))
+		w.ColdPathActiveBuilderCollision = append(w.ColdPathActiveBuilderCollision, false)
+	}
+	status := dpuserspace.ProcessStatus{WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{w}}
+	got := collectFromEmitWorkerRuntime(t, c, status)
+	count := 0
+	for _, m := range got {
+		if descName(m.Desc()) == "xpf_userspace_worker_cold_path_samples_total_v3" {
+			count++
+		}
+	}
+	if count != n {
+		t.Fatalf("sparse encoding must emit %d samples_v3 series, got %d", n, count)
+	}
 }

--- a/pkg/api/metrics_cold_path_test.go
+++ b/pkg/api/metrics_cold_path_test.go
@@ -358,7 +358,7 @@ func TestEmitWorkerColdPath_LayoutVersion3_EmitsV3WithZoneLabels(t *testing.T) {
 	var sawSamplesV3, sawBucketLE111, sawVersionGauge bool
 	for _, m := range got {
 		switch descName(m.Desc()) {
-		case "xpf_userspace_worker_cold_path_samples_total_v3":
+		case "xpf_userspace_worker_cold_path_samples_v3_total":
 			lbl := labelsOf(t, m)
 			if lbl["from_zone"] == "2" && lbl["to_zone"] == "5" &&
 				valueOf(t, m) == 5 {
@@ -399,7 +399,7 @@ func TestEmitWorkerColdPath_LayoutVersionUnknown_EmitsWarning(t *testing.T) {
 	var sawUnknown, sawV1, sawV3 bool
 	for _, m := range got {
 		switch descName(m.Desc()) {
-		case "xpf_userspace_worker_cold_path_layout_version_unknown_total":
+		case "xpf_userspace_worker_cold_path_layout_version_unknown":
 			if labelsOf(t, m)["version"] == "99" {
 				sawUnknown = true
 			}
@@ -444,7 +444,7 @@ func TestEmitWorkerColdPath_V3_TwentyZonePairsSeparable(t *testing.T) {
 
 	distinctPairs := map[string]float64{}
 	for _, m := range got {
-		if descName(m.Desc()) != "xpf_userspace_worker_cold_path_samples_total_v3" {
+		if descName(m.Desc()) != "xpf_userspace_worker_cold_path_samples_v3_total" {
 			continue
 		}
 		lbl := labelsOf(t, m)
@@ -482,7 +482,7 @@ func TestEmitWorkerColdPath_V3_SparseEmitsOnlyActiveSlots(t *testing.T) {
 	got := collectFromEmitWorkerRuntime(t, c, status)
 	count := 0
 	for _, m := range got {
-		if descName(m.Desc()) == "xpf_userspace_worker_cold_path_samples_total_v3" {
+		if descName(m.Desc()) == "xpf_userspace_worker_cold_path_samples_v3_total" {
 			count++
 		}
 	}
@@ -516,7 +516,7 @@ func TestEmitWorkerColdPath_V3_OverflowNoSamples(t *testing.T) {
 				sawOverflow1 = true
 			}
 		case "xpf_userspace_worker_cold_path_ns_bucket_v3",
-			"xpf_userspace_worker_cold_path_samples_total_v3":
+			"xpf_userspace_worker_cold_path_samples_v3_total":
 			sawV3Bucket = true
 		}
 	}

--- a/pkg/api/metrics_cold_path_test.go
+++ b/pkg/api/metrics_cold_path_test.go
@@ -577,11 +577,23 @@ func TestColdPathDescriptorsAreDescribed(t *testing.T) {
 		hist[i] = make([]uint64, 24)
 	}
 	hist[3][5] = 1
+	// Populate ALL v1 per-slot families so workerColdPathSumNS and
+	// workerColdPathAliasSeen are actually emitted (Codex code-r7: the
+	// earlier fixture left these empty, so the test would not catch
+	// their removal from Describe()).
+	v1Samples := make([]uint64, 16)
+	v1Samples[3] = 1
+	v1SumNS := make([]uint64, 16)
+	v1SumNS[3] = 100
+	v1AliasSeen := make([]bool, 16)
+	v1AliasSeen[3] = true
 	workers = append(workers, dpuserspace.WorkerRuntimeStatus{
-		WorkerID:        2,
+		WorkerID:              2,
 		ColdPathLayoutVersion: 1,
-		ColdPathHist:    hist,
-		ColdPathSamples: make([]uint64, 16),
+		ColdPathHist:          hist,
+		ColdPathSamples:       v1Samples,
+		ColdPathSumNS:         v1SumNS,
+		ColdPathAliasSeen:     v1AliasSeen,
 	})
 
 	metricCh := make(chan prometheus.Metric, 1024)
@@ -606,9 +618,25 @@ func TestColdPathDescriptorsAreDescribed(t *testing.T) {
 		t.Fatalf("emitWorkerColdPath emitted %d undeclared descriptors (checked-collector "+
 			"contract violation — add them to Describe()): %v", len(undeclared), undeclared)
 	}
-	// Sanity: we actually exercised the v3 + v1 + scalar families.
-	if len(emitted) < 10 {
-		t.Fatalf("expected the test to exercise the full cold-path family; only %d distinct "+
-			"descs emitted", len(emitted))
+	// Sanity (Codex code-r7): the fixtures above exercise EVERY cold-path
+	// descriptor exactly once across the family — 4 v1 (bucket, samples,
+	// sum_ns, alias_seen) + 6 scalars (sample_phase, wrapper_underflow,
+	// wrapper_ns_baseline, ns_per_tsc_q32, clock_source, snapshot_failed)
+	// + 4 v3 (bucket, samples, sum_ns, builder_collision) + overflow +
+	// layout_version + layout_version_unknown = 17. Asserting the exact
+	// count means removing ANY cold-path desc from Describe() is caught
+	// here (the undeclared check above catches additions; this catches
+	// the test silently under-exercising the family).
+	const wantColdPathDescs = 17
+	coldPathEmitted := 0
+	for d := range emitted {
+		if strings.Contains(descName(d), "cold_path") {
+			coldPathEmitted++
+		}
+	}
+	if coldPathEmitted != wantColdPathDescs {
+		t.Fatalf("test exercised %d distinct cold-path descriptors, want exactly %d "+
+			"(fixtures must emit every family so removal of any desc is caught)",
+			coldPathEmitted, wantColdPathDescs)
 	}
 }

--- a/pkg/api/metrics_cold_path_test.go
+++ b/pkg/api/metrics_cold_path_test.go
@@ -527,3 +527,88 @@ func TestEmitWorkerColdPath_V3_OverflowNoSamples(t *testing.T) {
 		t.Error("no active slots ⇒ no per-zone-pair v3 series")
 	}
 }
+
+// #1635 (Copilot code-r7 finding 1): xpfCollector is a CHECKED
+// collector — every Desc emitted by Collect()/emitWorkerColdPath MUST
+// be declared in Describe(), or promhttp logs a Gather error on every
+// scrape and a HTTPErrorOnError registry returns 500. This test builds
+// the REAL collector (newCollector(nil) — Describe and emitWorkerColdPath
+// don't touch srv), captures the Describe() desc set, then drives
+// emitWorkerColdPath over a fully-populated v3 worker and asserts every
+// emitted Desc is declared. It FAILS if any cold-path desc (v1, scalar,
+// or v3) is emitted but undeclared — the registration-contract bug.
+func TestColdPathDescriptorsAreDescribed(t *testing.T) {
+	c := newCollector(nil)
+
+	// Capture the full Describe() desc set.
+	descCh := make(chan *prometheus.Desc, 256)
+	c.Describe(descCh)
+	close(descCh)
+	declared := map[*prometheus.Desc]struct{}{}
+	for d := range descCh {
+		declared[d] = struct{}{}
+	}
+
+	// Drive emitWorkerColdPath over a worker that exercises BOTH a
+	// populated v3 sparse slot AND the overflow/version/unknown paths,
+	// so every cold-path desc family is emitted at least once. Two
+	// workers: one v3-with-data, one unknown-version.
+	buckets := make([]uint64, 48)
+	buckets[6] = 3
+	workers := []dpuserspace.WorkerRuntimeStatus{
+		{
+			WorkerID:                       0,
+			ColdPathLayoutVersion:          3,
+			ColdPathActiveSlotIDs:          []uint32{0},
+			ColdPathActiveZoneFrom:         []uint32{1},
+			ColdPathActiveZoneTo:           []uint32{2},
+			ColdPathActiveSamples:          []uint64{3},
+			ColdPathActiveSumNS:            []uint64{300},
+			ColdPathActiveBuckets:          [][]uint64{buckets},
+			ColdPathActiveBuilderCollision: []bool{false},
+			ColdPathOverflowActive:         true,
+			ColdPathClockSource:            "tsc",
+		},
+		{WorkerID: 1, ColdPathLayoutVersion: 99}, // unknown-version path
+	}
+	// Also emit a v1 worker so the legacy dense families are exercised.
+	hist := make([][]uint64, 16)
+	for i := range hist {
+		hist[i] = make([]uint64, 24)
+	}
+	hist[3][5] = 1
+	workers = append(workers, dpuserspace.WorkerRuntimeStatus{
+		WorkerID:        2,
+		ColdPathLayoutVersion: 1,
+		ColdPathHist:    hist,
+		ColdPathSamples: make([]uint64, 16),
+	})
+
+	metricCh := make(chan prometheus.Metric, 1024)
+	go func() {
+		for _, w := range workers {
+			label := strconv.FormatUint(uint64(w.WorkerID), 10)
+			c.emitWorkerColdPath(metricCh, label, w)
+		}
+		close(metricCh)
+	}()
+
+	var undeclared []string
+	emitted := map[*prometheus.Desc]struct{}{}
+	for m := range metricCh {
+		d := m.Desc()
+		emitted[d] = struct{}{}
+		if _, ok := declared[d]; !ok {
+			undeclared = append(undeclared, descName(d))
+		}
+	}
+	if len(undeclared) > 0 {
+		t.Fatalf("emitWorkerColdPath emitted %d undeclared descriptors (checked-collector "+
+			"contract violation — add them to Describe()): %v", len(undeclared), undeclared)
+	}
+	// Sanity: we actually exercised the v3 + v1 + scalar families.
+	if len(emitted) < 10 {
+		t.Fatalf("expected the test to exercise the full cold-path family; only %d distinct "+
+			"descs emitted", len(emitted))
+	}
+}

--- a/pkg/api/metrics_cold_path_test.go
+++ b/pkg/api/metrics_cold_path_test.go
@@ -490,3 +490,40 @@ func TestEmitWorkerColdPath_V3_SparseEmitsOnlyActiveSlots(t *testing.T) {
 		t.Fatalf("sparse encoding must emit %d samples_v3 series, got %d", n, count)
 	}
 }
+
+// #1635 (Copilot code-r2): a v3 payload with overflow_active=true but
+// no sampled slots must still emit the overflow gauge (version stamped
+// v3 even with empty active arrays), and must not panic on the empty
+// parallel arrays.
+func TestEmitWorkerColdPath_V3_OverflowNoSamples(t *testing.T) {
+	c := newCollectorWithWorkerDescsOnly()
+	status := dpuserspace.ProcessStatus{
+		WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{
+			{
+				WorkerID:               0,
+				ColdPathLayoutVersion:  3,
+				ColdPathOverflowActive: true,
+				// All active arrays empty.
+			},
+		},
+	}
+	got := collectFromEmitWorkerRuntime(t, c, status)
+	var sawOverflow1, sawV3Bucket bool
+	for _, m := range got {
+		switch descName(m.Desc()) {
+		case "xpf_userspace_worker_cold_path_overflow_active":
+			if valueOf(t, m) == 1.0 {
+				sawOverflow1 = true
+			}
+		case "xpf_userspace_worker_cold_path_ns_bucket_v3",
+			"xpf_userspace_worker_cold_path_samples_total_v3":
+			sawV3Bucket = true
+		}
+	}
+	if !sawOverflow1 {
+		t.Error("overflow gauge=1 must emit even with no sampled slots")
+	}
+	if sawV3Bucket {
+		t.Error("no active slots ⇒ no per-zone-pair v3 series")
+	}
+}

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -559,7 +559,9 @@ func newCollector(srv *Server) *xpfCollector {
 		workerColdPathOverflowActive: prometheus.NewDesc(
 			"xpf_userspace_worker_cold_path_overflow_active",
 			"1 if a configured zone-pair could not be assigned a cold-path "+
-				"histogram slot (255-slot capacity exhausted). 0 otherwise.",
+				"histogram slot — either the 255-slot capacity was "+
+				"exhausted OR the pair references a zone-id outside the "+
+				"0..=64 direct-table range. 0 otherwise.",
 			[]string{"worker_id"}, nil,
 		),
 		workerColdPathLayoutVersion: prometheus.NewDesc(

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -538,13 +538,13 @@ func newCollector(srv *Server) *xpfCollector {
 			[]string{"worker_id", "from_zone", "to_zone", "le"}, nil,
 		),
 		workerColdPathSamplesV3: prometheus.NewDesc(
-			"xpf_userspace_worker_cold_path_samples_total_v3",
+			"xpf_userspace_worker_cold_path_samples_v3_total",
 			"Per-worker / (from_zone, to_zone) count of cold-path latency "+
 				"samples recorded (#1635 direct slot map).",
 			[]string{"worker_id", "from_zone", "to_zone"}, nil,
 		),
 		workerColdPathSumNSV3: prometheus.NewDesc(
-			"xpf_userspace_worker_cold_path_sum_ns_total_v3",
+			"xpf_userspace_worker_cold_path_sum_ns_v3_total",
 			"Per-worker / (from_zone, to_zone) cumulative sum of recorded "+
 				"delta_ns (post baseline subtraction).",
 			[]string{"worker_id", "from_zone", "to_zone"}, nil,
@@ -569,7 +569,11 @@ func newCollector(srv *Server) *xpfCollector {
 			[]string{"worker_id", "version"}, nil,
 		),
 		workerColdPathLayoutUnknownTotal: prometheus.NewDesc(
-			"xpf_userspace_worker_cold_path_layout_version_unknown_total",
+			// Gauge-style state indicator (NOT a counter): emitted as a
+			// GaugeValue=1 when the version is unknown, so the name must
+			// NOT end in `_total` (Copilot code-r4: a `_total` suffix
+			// would mislead operators into rate()-ing a state flag).
+			"xpf_userspace_worker_cold_path_layout_version_unknown",
 			"1 when this worker reported a cold-path wire layout version "+
 				"the collector does not understand (forward-compat guard).",
 			[]string{"worker_id", "version"}, nil,

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -527,6 +527,53 @@ func newCollector(srv *Server) *xpfCollector {
 				"starvation'.",
 			[]string{"worker_id"}, nil,
 		),
+		// === #1635 sparse v3 per-zone-pair cold-path families ===
+		workerColdPathBucketV3: prometheus.NewDesc(
+			"xpf_userspace_worker_cold_path_ns_bucket_v3",
+			"Cumulative cold-path policy-eval latency observations per "+
+				"worker / (from_zone, to_zone), bucketed into the #1635 "+
+				"48-bucket log-linear ns histogram (32 linear 16-ns "+
+				"buckets over [0,512) ns + 15 pow-2 buckets + saturate). "+
+				"Compatible with PromQL histogram_quantile() via `le`.",
+			[]string{"worker_id", "from_zone", "to_zone", "le"}, nil,
+		),
+		workerColdPathSamplesV3: prometheus.NewDesc(
+			"xpf_userspace_worker_cold_path_samples_total_v3",
+			"Per-worker / (from_zone, to_zone) count of cold-path latency "+
+				"samples recorded (#1635 direct slot map).",
+			[]string{"worker_id", "from_zone", "to_zone"}, nil,
+		),
+		workerColdPathSumNSV3: prometheus.NewDesc(
+			"xpf_userspace_worker_cold_path_sum_ns_total_v3",
+			"Per-worker / (from_zone, to_zone) cumulative sum of recorded "+
+				"delta_ns (post baseline subtraction).",
+			[]string{"worker_id", "from_zone", "to_zone"}, nil,
+		),
+		workerColdPathBuilderCollisionV3: prometheus.NewDesc(
+			"xpf_userspace_worker_cold_path_builder_collision_v3",
+			"1 if this (from_zone, to_zone) slot saw two distinct packed "+
+				"keys — a snapshot-builder bug with the #1635 direct slot "+
+				"map; should always be 0. 0 otherwise.",
+			[]string{"worker_id", "from_zone", "to_zone"}, nil,
+		),
+		workerColdPathOverflowActive: prometheus.NewDesc(
+			"xpf_userspace_worker_cold_path_overflow_active",
+			"1 if a configured zone-pair could not be assigned a cold-path "+
+				"histogram slot (255-slot capacity exhausted). 0 otherwise.",
+			[]string{"worker_id"}, nil,
+		),
+		workerColdPathLayoutVersion: prometheus.NewDesc(
+			"xpf_userspace_worker_cold_path_layout_version",
+			"1 when this worker's cold-path wire layout has the value of "+
+				"the `version` label (#1635: 3 = sparse log-linear).",
+			[]string{"worker_id", "version"}, nil,
+		),
+		workerColdPathLayoutUnknownTotal: prometheus.NewDesc(
+			"xpf_userspace_worker_cold_path_layout_version_unknown_total",
+			"1 when this worker reported a cold-path wire layout version "+
+				"the collector does not understand (forward-compat guard).",
+			[]string{"worker_id", "version"}, nil,
+		),
 		bindingActiveFlowCount: prometheus.NewDesc(
 			"xpf_userspace_binding_active_flow_count",
 			"Distinct active flows observed in this binding's flow_cache "+

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -196,6 +196,19 @@ func newCollectorWithWorkerDescsOnly() *xpfCollector {
 		return prometheus.NewDesc(name, name,
 			[]string{"worker_id", "source"}, nil)
 	}
+	// #1635 v3 per-zone-pair descriptors.
+	mkZonePair := func(name string) *prometheus.Desc {
+		return prometheus.NewDesc(name, name,
+			[]string{"worker_id", "from_zone", "to_zone"}, nil)
+	}
+	mkZonePairBucket := func(name string) *prometheus.Desc {
+		return prometheus.NewDesc(name, name,
+			[]string{"worker_id", "from_zone", "to_zone", "le"}, nil)
+	}
+	mkVersion := func(name string) *prometheus.Desc {
+		return prometheus.NewDesc(name, name,
+			[]string{"worker_id", "version"}, nil)
+	}
 	return &xpfCollector{
 		workerWallSecs:                           mk("xpf_userspace_worker_wall_seconds_total"),
 		workerActiveSecs:                         mk("xpf_userspace_worker_active_seconds_total"),
@@ -222,6 +235,13 @@ func newCollectorWithWorkerDescsOnly() *xpfCollector {
 		workerColdPathNSPerTSCQ32:         mk("xpf_userspace_worker_cold_path_ns_per_tsc_q32"),
 		workerColdPathClockSource:         mkSource("xpf_userspace_worker_cold_path_clock_source"),
 		workerColdPathSnapshotFailedTotal: mk("xpf_userspace_worker_cold_path_snapshot_failed_total"),
+		workerColdPathBucketV3:            mkZonePairBucket("xpf_userspace_worker_cold_path_ns_bucket_v3"),
+		workerColdPathSamplesV3:           mkZonePair("xpf_userspace_worker_cold_path_samples_total_v3"),
+		workerColdPathSumNSV3:             mkZonePair("xpf_userspace_worker_cold_path_sum_ns_total_v3"),
+		workerColdPathBuilderCollisionV3:  mkZonePair("xpf_userspace_worker_cold_path_builder_collision_v3"),
+		workerColdPathOverflowActive:      mk("xpf_userspace_worker_cold_path_overflow_active"),
+		workerColdPathLayoutVersion:       mkVersion("xpf_userspace_worker_cold_path_layout_version"),
+		workerColdPathLayoutUnknownTotal:  mkVersion("xpf_userspace_worker_cold_path_layout_version_unknown_total"),
 	}
 }
 
@@ -277,6 +297,14 @@ func collectFromEmitWorkerRuntime(
 		c.workerColdPathNSPerTSCQ32:             {},
 		c.workerColdPathClockSource:             {},
 		c.workerColdPathSnapshotFailedTotal:     {},
+		// #1635 v3 cold-path descriptors.
+		c.workerColdPathBucketV3:           {},
+		c.workerColdPathSamplesV3:          {},
+		c.workerColdPathSumNSV3:            {},
+		c.workerColdPathBuilderCollisionV3: {},
+		c.workerColdPathOverflowActive:     {},
+		c.workerColdPathLayoutVersion:      {},
+		c.workerColdPathLayoutUnknownTotal: {},
 	}
 	for _, m := range got {
 		if _, ok := expected[m.Desc()]; !ok {

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -236,12 +236,12 @@ func newCollectorWithWorkerDescsOnly() *xpfCollector {
 		workerColdPathClockSource:         mkSource("xpf_userspace_worker_cold_path_clock_source"),
 		workerColdPathSnapshotFailedTotal: mk("xpf_userspace_worker_cold_path_snapshot_failed_total"),
 		workerColdPathBucketV3:            mkZonePairBucket("xpf_userspace_worker_cold_path_ns_bucket_v3"),
-		workerColdPathSamplesV3:           mkZonePair("xpf_userspace_worker_cold_path_samples_total_v3"),
-		workerColdPathSumNSV3:             mkZonePair("xpf_userspace_worker_cold_path_sum_ns_total_v3"),
+		workerColdPathSamplesV3:           mkZonePair("xpf_userspace_worker_cold_path_samples_v3_total"),
+		workerColdPathSumNSV3:             mkZonePair("xpf_userspace_worker_cold_path_sum_ns_v3_total"),
 		workerColdPathBuilderCollisionV3:  mkZonePair("xpf_userspace_worker_cold_path_builder_collision_v3"),
 		workerColdPathOverflowActive:      mk("xpf_userspace_worker_cold_path_overflow_active"),
 		workerColdPathLayoutVersion:       mkVersion("xpf_userspace_worker_cold_path_layout_version"),
-		workerColdPathLayoutUnknownTotal:  mkVersion("xpf_userspace_worker_cold_path_layout_version_unknown_total"),
+		workerColdPathLayoutUnknownTotal:  mkVersion("xpf_userspace_worker_cold_path_layout_version_unknown"),
 	}
 }
 

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -562,16 +562,37 @@ func (c *xpfCollector) emitWorkerColdPath(
 	label string,
 	w dpuserspace.WorkerRuntimeStatus,
 ) {
+	// #1635: branch on the wire layout version. 0 (or absent) = either
+	// no data this scrape OR a pre-#1635 daemon emitting the v1 dense
+	// fields; 3 = sparse log-linear per-zone-pair encoding; anything
+	// else = forward-compat unknown.
+	switch w.ColdPathLayoutVersion {
+	case 0, 1:
+		c.emitColdPathV1(ch, label, w)
+	case 3:
+		c.emitColdPathV3(ch, label, w)
+		ch <- prometheus.MustNewConstMetric(c.workerColdPathLayoutVersion,
+			prometheus.GaugeValue, 1.0, label, "3")
+	default:
+		ch <- prometheus.MustNewConstMetric(c.workerColdPathLayoutUnknownTotal,
+			prometheus.GaugeValue, 1.0, label,
+			strconv.FormatUint(uint64(w.ColdPathLayoutVersion), 10))
+	}
+	c.emitWorkerColdPathScalars(ch, label, w)
+}
+
+// emitColdPathV1 emits the legacy 24-bucket pow-2 per-slot metrics from
+// the dense v1 fields. Reached only when paired with a pre-#1635 Rust
+// daemon (current daemons leave the dense fields empty and emit v3).
+func (c *xpfCollector) emitColdPathV1(
+	ch chan<- prometheus.Metric,
+	label string,
+	w dpuserspace.WorkerRuntimeStatus,
+) {
 	// 24-bucket power-of-two histogram. Bucket 0 covers [0, 1024) ns;
 	// bucket i ∈ [1, 22] covers [2^(9+i), 2^(10+i)) ns; bucket 23
-	// saturates at any ns ≥ 2^32 (~4.295 s). Per #1619 plan v3 §1.1.
-	//
-	// The `le` (less-than-or-equal) label carries the upper inclusive
-	// boundary in nanoseconds, matching Prometheus histogram convention
-	// for histogram_quantile().
+	// saturates at any ns ≥ 2^32.
 	bucketLe := func(idx int) string {
-		// idx == 0 → le = 1023 (just under 1024); idx ∈ [1, 22] →
-		// le = 2^(10+idx) - 1; idx >= 23 → le = +Inf.
 		if idx == 0 {
 			return "1023"
 		}
@@ -580,12 +601,6 @@ func (c *xpfCollector) emitWorkerColdPath(
 		}
 		return strconv.FormatUint((uint64(1)<<uint(10+idx))-1, 10)
 	}
-	// Prometheus histogram `_bucket{le="N"}` convention requires
-	// CUMULATIVE counts (count of observations ≤ N), not the raw
-	// per-bucket count. Copilot code-r1 C1 caught this: the v1 plan
-	// said `_bucket` "counter" but didn't specify cumulative. Without
-	// cumulative semantics, `histogram_quantile()` computes wrong
-	// quantiles. Accumulate per-slot before emit.
 	for slot := 0; slot < len(w.ColdPathHist); slot++ {
 		slotLabel := strconv.Itoa(slot)
 		var running uint64
@@ -616,6 +631,66 @@ func (c *xpfCollector) emitWorkerColdPath(
 				prometheus.GaugeValue, alias, label, slotLabel)
 		}
 	}
+}
+
+// emitColdPathV3 emits the #1635 sparse per-zone-pair metrics. The
+// payload is parallel arrays (one entry per active zone-pair); the
+// `from_zone` / `to_zone` labels carry the zone-ids so every active
+// pair publishes a SEPARABLE latency distribution with no collision
+// exclusion (fixes #1622 F2 + F3). `le` boundaries follow the
+// 48-bucket log-linear layout (bucketLeV3).
+func (c *xpfCollector) emitColdPathV3(
+	ch chan<- prometheus.Metric,
+	label string,
+	w dpuserspace.WorkerRuntimeStatus,
+) {
+	n := len(w.ColdPathActiveSamples)
+	for i := 0; i < n; i++ {
+		fromZone := zoneIDLabel(w.ColdPathActiveZoneFrom, i)
+		toZone := zoneIDLabel(w.ColdPathActiveZoneTo, i)
+		// Cumulative bucket counts for histogram_quantile().
+		if i < len(w.ColdPathActiveBuckets) {
+			var running uint64
+			buckets := w.ColdPathActiveBuckets[i]
+			for b := 0; b < len(buckets); b++ {
+				running += buckets[b]
+				ch <- prometheus.MustNewConstMetric(c.workerColdPathBucketV3,
+					prometheus.CounterValue, float64(running),
+					label, fromZone, toZone, bucketLeV3(b))
+			}
+		}
+		ch <- prometheus.MustNewConstMetric(c.workerColdPathSamplesV3,
+			prometheus.CounterValue, float64(w.ColdPathActiveSamples[i]),
+			label, fromZone, toZone)
+		if i < len(w.ColdPathActiveSumNS) {
+			ch <- prometheus.MustNewConstMetric(c.workerColdPathSumNSV3,
+				prometheus.CounterValue, float64(w.ColdPathActiveSumNS[i]),
+				label, fromZone, toZone)
+		}
+		if i < len(w.ColdPathActiveBuilderCollision) {
+			col := 0.0
+			if w.ColdPathActiveBuilderCollision[i] {
+				col = 1.0
+			}
+			ch <- prometheus.MustNewConstMetric(c.workerColdPathBuilderCollisionV3,
+				prometheus.GaugeValue, col, label, fromZone, toZone)
+		}
+	}
+	overflow := 0.0
+	if w.ColdPathOverflowActive {
+		overflow = 1.0
+	}
+	ch <- prometheus.MustNewConstMetric(c.workerColdPathOverflowActive,
+		prometheus.GaugeValue, overflow, label)
+}
+
+// emitWorkerColdPathScalars emits the per-worker scalar families shared
+// across all layout versions.
+func (c *xpfCollector) emitWorkerColdPathScalars(
+	ch chan<- prometheus.Metric,
+	label string,
+	w dpuserspace.WorkerRuntimeStatus,
+) {
 	// Per-worker scalars.
 	ch <- prometheus.MustNewConstMetric(c.workerColdPathSamplePhase,
 		prometheus.CounterValue,
@@ -643,6 +718,35 @@ func (c *xpfCollector) emitWorkerColdPath(
 	ch <- prometheus.MustNewConstMetric(c.workerColdPathSnapshotFailedTotal,
 		prometheus.CounterValue,
 		float64(w.ColdPathSnapshotFailed), label)
+}
+
+// bucketLeV3 returns the inclusive upper boundary (Prometheus `le`
+// label) for #1635 48-bucket log-linear histogram bucket idx:
+//   - idx < 32        → (idx+1)*16 - 1   (15, 31, …, 511) — linear band.
+//   - 32 ≤ idx ≤ 46   → 2^(10+idx-32) - 1 (1023, 2047, …) — exp band.
+//   - idx ≥ 47        → "+Inf"            — saturate band.
+//
+// Mirrors bucket_upper_bound_ns_48 / bucket_index_for_ns_48 on the Rust
+// side; the two MUST agree or histogram_quantile() reads wrong values.
+func bucketLeV3(idx int) string {
+	const linear = 32
+	if idx < linear {
+		return strconv.FormatUint(uint64((idx+1)*16-1), 10)
+	}
+	if idx >= 47 {
+		return "+Inf"
+	}
+	return strconv.FormatUint((uint64(1)<<uint(10+idx-linear))-1, 10)
+}
+
+// zoneIDLabel renders the i-th zone-id of a parallel sparse array as a
+// label string, or "unknown" if the array is too short (defensive
+// against a truncated/mismatched payload).
+func zoneIDLabel(ids []uint32, i int) string {
+	if i >= len(ids) {
+		return "unknown"
+	}
+	return strconv.FormatUint(uint64(ids[i]), 10)
 }
 
 func (c *xpfCollector) emitUserspaceEventStream(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {

--- a/pkg/dataplane/userspace/cold_path_status_test.go
+++ b/pkg/dataplane/userspace/cold_path_status_test.go
@@ -26,11 +26,23 @@ func TestWorkerRuntimeStatus_DefaultOmitsAllColdPathFields(t *testing.T) {
 	}
 	body := string(payload)
 	coldKeys := []string{
+		// legacy dense v1 (retained read-only).
 		"cold_path_hist",
 		"cold_path_sum_ns",
 		"cold_path_samples",
 		"cold_path_first_key",
 		"cold_path_alias_seen",
+		// #1635 sparse v3.
+		"cold_path_layout_version",
+		"cold_path_active_slot_ids",
+		"cold_path_active_zone_from",
+		"cold_path_active_zone_to",
+		"cold_path_active_samples",
+		"cold_path_active_sum_ns",
+		"cold_path_active_buckets",
+		"cold_path_active_builder_collision",
+		"cold_path_overflow_active",
+		// shared scalars.
 		"cold_path_sample_phase",
 		"cold_path_wrapper_underflow_count",
 		"cold_path_ns_per_tsc_q32",
@@ -162,5 +174,83 @@ func TestWorkerRuntimeStatus_RustEmittedJSONDecodes(t *testing.T) {
 	}
 	if got.ColdPathHist[0][3] != 5 {
 		t.Errorf("hist[0][3]: want 5 got %d", got.ColdPathHist[0][3])
+	}
+}
+
+// #1635 (Copilot code-r3 finding 4): pin the sparse v3 wire contract on
+// the Go side. Decodes a hand-crafted JSON payload using the exact
+// field names the Rust serializer emits (userspace-dp/src/protocol/
+// binding.rs cold_path_active_* + cold_path_layout_version +
+// cold_path_overflow_active), then re-encodes and re-decodes to confirm
+// the Go struct tags round-trip. A wrong/missing tag here would silently
+// drop sparse cold-path data from the v3 Prometheus emitter.
+func TestWorkerRuntimeStatus_SparseV3FieldsDecodeFromRustWire(t *testing.T) {
+	// Field names MUST match the Rust serde renames exactly.
+	rustJSON := `{
+		"worker_id": 4,
+		"cold_path_layout_version": 3,
+		"cold_path_active_slot_ids": [0, 5],
+		"cold_path_active_zone_from": [1, 2],
+		"cold_path_active_zone_to": [3, 4],
+		"cold_path_active_samples": [142, 7],
+		"cold_path_active_sum_ns": [12345, 700],
+		"cold_path_active_buckets": [[0,0,0,0,0,1], [9]],
+		"cold_path_active_builder_collision": [false, true],
+		"cold_path_overflow_active": true,
+		"cold_path_clock_source": "tsc"
+	}`
+	var got WorkerRuntimeStatus
+	if err := json.Unmarshal([]byte(rustJSON), &got); err != nil {
+		t.Fatalf("decode Rust-shaped sparse v3 JSON: %v", err)
+	}
+	if got.ColdPathLayoutVersion != 3 {
+		t.Errorf("layout_version: want 3 got %d", got.ColdPathLayoutVersion)
+	}
+	if len(got.ColdPathActiveSlotIDs) != 2 || got.ColdPathActiveSlotIDs[1] != 5 {
+		t.Errorf("active_slot_ids decode mismatch: %v", got.ColdPathActiveSlotIDs)
+	}
+	if len(got.ColdPathActiveZoneFrom) != 2 || got.ColdPathActiveZoneFrom[0] != 1 {
+		t.Errorf("active_zone_from decode mismatch: %v", got.ColdPathActiveZoneFrom)
+	}
+	if got.ColdPathActiveZoneTo[1] != 4 {
+		t.Errorf("active_zone_to decode mismatch: %v", got.ColdPathActiveZoneTo)
+	}
+	if got.ColdPathActiveSamples[0] != 142 || got.ColdPathActiveSumNS[1] != 700 {
+		t.Errorf("active samples/sum_ns decode mismatch: %v / %v",
+			got.ColdPathActiveSamples, got.ColdPathActiveSumNS)
+	}
+	if len(got.ColdPathActiveBuckets) != 2 || got.ColdPathActiveBuckets[0][5] != 1 {
+		t.Errorf("active_buckets decode mismatch: %v", got.ColdPathActiveBuckets)
+	}
+	if !got.ColdPathActiveBuilderCollision[1] {
+		t.Errorf("active_builder_collision decode mismatch: %v", got.ColdPathActiveBuilderCollision)
+	}
+	if !got.ColdPathOverflowActive {
+		t.Errorf("overflow_active: want true")
+	}
+
+	// Re-encode and re-decode to confirm Go's own tags round-trip and
+	// keep the same wire names.
+	payload, err := json.Marshal(&got)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	for _, k := range []string{
+		"cold_path_layout_version", "cold_path_active_slot_ids",
+		"cold_path_active_zone_from", "cold_path_active_zone_to",
+		"cold_path_active_samples", "cold_path_active_sum_ns",
+		"cold_path_active_buckets", "cold_path_active_builder_collision",
+		"cold_path_overflow_active",
+	} {
+		if !strings.Contains(string(payload), k) {
+			t.Errorf("re-encoded payload missing wire key %q: %s", k, payload)
+		}
+	}
+	var back WorkerRuntimeStatus
+	if err := json.Unmarshal(payload, &back); err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	if back.ColdPathActiveZoneTo[1] != 4 || !back.ColdPathOverflowActive {
+		t.Errorf("round-trip lost data: %+v", back)
 	}
 }

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -903,8 +903,9 @@ type WorkerRuntimeStatus struct {
 	ColdPathActiveSumNS            []uint64   `json:"cold_path_active_sum_ns,omitempty"`
 	ColdPathActiveBuckets          [][]uint64 `json:"cold_path_active_buckets,omitempty"`
 	ColdPathActiveBuilderCollision []bool     `json:"cold_path_active_builder_collision,omitempty"`
-	// True if a configured zone-pair could not be assigned a slot
-	// (255-slot capacity exhausted).
+	// True if a configured zone-pair could not be assigned a slot —
+	// either the 255-slot capacity was exhausted OR the pair references
+	// a zone-id outside the 0..=64 direct-table range.
 	ColdPathOverflowActive bool   `json:"cold_path_overflow_active,omitempty"`
 	ColdPathSamplePhase    uint64 `json:"cold_path_sample_phase,omitempty"`
 	ColdPathWrapperUnderflowCount uint64     `json:"cold_path_wrapper_underflow_count,omitempty"`

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -906,11 +906,11 @@ type WorkerRuntimeStatus struct {
 	// True if a configured zone-pair could not be assigned a slot —
 	// either the 255-slot capacity was exhausted OR the pair references
 	// a zone-id outside the 0..=64 direct-table range.
-	ColdPathOverflowActive bool   `json:"cold_path_overflow_active,omitempty"`
-	ColdPathSamplePhase    uint64 `json:"cold_path_sample_phase,omitempty"`
-	ColdPathWrapperUnderflowCount uint64     `json:"cold_path_wrapper_underflow_count,omitempty"`
-	ColdPathNSPerTSCQ32           uint64     `json:"cold_path_ns_per_tsc_q32,omitempty"`
-	ColdPathWrapperNSBaseline     uint64     `json:"cold_path_wrapper_ns_baseline,omitempty"`
+	ColdPathOverflowActive        bool   `json:"cold_path_overflow_active,omitempty"`
+	ColdPathSamplePhase           uint64 `json:"cold_path_sample_phase,omitempty"`
+	ColdPathWrapperUnderflowCount uint64 `json:"cold_path_wrapper_underflow_count,omitempty"`
+	ColdPathNSPerTSCQ32           uint64 `json:"cold_path_ns_per_tsc_q32,omitempty"`
+	ColdPathWrapperNSBaseline     uint64 `json:"cold_path_wrapper_ns_baseline,omitempty"`
 	// "tsc" / "clock_gettime" / "" (Unset). Harness gates Table
 	// publication on == "tsc" for every worker.
 	ColdPathClockSource string `json:"cold_path_clock_source,omitempty"`

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -869,25 +869,44 @@ type WorkerRuntimeStatus struct {
 	ActiveNS60s    uint64 `json:"active_ns_60s,omitempty"`
 	WindowNS       uint64 `json:"window_ns,omitempty"`
 
-	// === #1621 cold-path histogram surface ===
+	// === #1635 cold-path histogram surface (sparse v3) ===
 	//
-	// Mirrors the Rust WorkerColdPathCounters fields. All Vec fields
-	// use omitempty so an empty histogram (older Rust daemon, or
-	// worker that didn't get any cold-path samples this window)
-	// omits the field from the wire; the Go-side nil/empty values
-	// flow through to the Prometheus emitter which skips on empty.
-	// Per feedback_wire_protocol_both_sides.
+	// Mirrors the Rust WorkerRuntimeStatus cold_path_* fields. All
+	// slice fields use omitempty so an empty histogram (older Rust
+	// daemon, or a worker with no samples this window) omits the field
+	// from the wire; the Go emitter skips on empty. Per
+	// feedback_wire_protocol_both_sides.
 	//
-	// Aggregated PER WORKER: when a worker owns multiple bindings,
-	// the published values reflect the cross-binding merge performed
-	// at the publish tick (sum for histogram data, OR for alias_seen,
-	// first-non-zero for first_key).
-	ColdPathHist                  [][]uint64 `json:"cold_path_hist,omitempty"`
-	ColdPathSumNS                 []uint64   `json:"cold_path_sum_ns,omitempty"`
-	ColdPathSamples               []uint64   `json:"cold_path_samples,omitempty"`
-	ColdPathFirstKey              []uint64   `json:"cold_path_first_key,omitempty"`
-	ColdPathAliasSeen             []bool     `json:"cold_path_alias_seen,omitempty"`
-	ColdPathSamplePhase           uint64     `json:"cold_path_sample_phase,omitempty"`
+	// #1635 replaces the v1 dense [16-slot] arrays with a SPARSE
+	// active-slot encoding: parallel arrays, one entry per active
+	// (from_zone, to_zone) pair. ColdPathLayoutVersion selects the
+	// emission path (0/absent = no data / pre-#1635; 3 = sparse).
+	//
+	// Aggregated PER WORKER: when a worker owns multiple bindings, the
+	// published values reflect the cross-binding merge performed at the
+	// publish tick (sum for histogram data, OR for builder_collision).
+	ColdPathLayoutVersion uint32 `json:"cold_path_layout_version,omitempty"`
+	// Legacy v1 dense fields, retained READ-ONLY so a new Go collector
+	// still emits correct v1 metrics when paired with a pre-#1635 Rust
+	// daemon (plan §3.2 row "v1 Rust / v3 Go"). Current daemons leave
+	// these empty. Per feedback_wire_protocol_both_sides.
+	ColdPathHist      [][]uint64 `json:"cold_path_hist,omitempty"`
+	ColdPathSumNS     []uint64   `json:"cold_path_sum_ns,omitempty"`
+	ColdPathSamples   []uint64   `json:"cold_path_samples,omitempty"`
+	ColdPathFirstKey  []uint64   `json:"cold_path_first_key,omitempty"`
+	ColdPathAliasSeen []bool     `json:"cold_path_alias_seen,omitempty"`
+	// Parallel sparse arrays (index i describes one active zone-pair).
+	ColdPathActiveSlotIDs          []uint32   `json:"cold_path_active_slot_ids,omitempty"`
+	ColdPathActiveZoneFrom         []uint32   `json:"cold_path_active_zone_from,omitempty"`
+	ColdPathActiveZoneTo           []uint32   `json:"cold_path_active_zone_to,omitempty"`
+	ColdPathActiveSamples          []uint64   `json:"cold_path_active_samples,omitempty"`
+	ColdPathActiveSumNS            []uint64   `json:"cold_path_active_sum_ns,omitempty"`
+	ColdPathActiveBuckets          [][]uint64 `json:"cold_path_active_buckets,omitempty"`
+	ColdPathActiveBuilderCollision []bool     `json:"cold_path_active_builder_collision,omitempty"`
+	// True if a configured zone-pair could not be assigned a slot
+	// (255-slot capacity exhausted).
+	ColdPathOverflowActive bool   `json:"cold_path_overflow_active,omitempty"`
+	ColdPathSamplePhase    uint64 `json:"cold_path_sample_phase,omitempty"`
 	ColdPathWrapperUnderflowCount uint64     `json:"cold_path_wrapper_underflow_count,omitempty"`
 	ColdPathNSPerTSCQ32           uint64     `json:"cold_path_ns_per_tsc_q32,omitempty"`
 	ColdPathWrapperNSBaseline     uint64     `json:"cold_path_wrapper_ns_baseline,omitempty"`

--- a/userspace-dp/src/afxdp/cold_path_hist.rs
+++ b/userspace-dp/src/afxdp/cold_path_hist.rs
@@ -719,13 +719,14 @@ impl WorkerColdPathAtomics {
     /// from a legitimately-empty worker, masking retry-starvation
     /// regimes under heavy publish contention.
     ///
-    /// AGY code-r2 finding 2 (continued): the retry budget is now 128
-    /// (up from 16) with an exponential `std::hint::spin_loop` backoff.
-    /// For a 448-field payload at ~5 ns per Relaxed load, one publish
-    /// cycle takes ~2.2 µs; 128 retries × spin_loop give the writer
-    /// ~10-50 µs to publish before the reader gives up.
+    /// AGY code-r2 finding 2 (continued): the retry budget is now 2048
+    /// with an exponential `std::hint::spin_loop` backoff. #1635 grew
+    /// the payload from the old 16×24 dense surface to 256 slots × 48
+    /// buckets, so one publish now writes ~13k atomics instead of ~450.
+    /// The larger budget keeps status-path snapshots coherent under a
+    /// concurrent publish without changing the hot path.
     pub(in crate::afxdp) fn snapshot(&self) -> Option<WorkerColdPathCounters> {
-        const RETRY_BUDGET: u32 = 128;
+        const RETRY_BUDGET: u32 = 2048;
         for attempt in 0..RETRY_BUDGET {
             let s1 = self.cold_window_gen.load(Ordering::Acquire);
             if s1 & 1 != 0 {

--- a/userspace-dp/src/afxdp/cold_path_hist.rs
+++ b/userspace-dp/src/afxdp/cold_path_hist.rs
@@ -230,8 +230,15 @@ impl ColdPathSlotMap {
         let mut pending: Vec<(u16, u16)> = Vec::with_capacity(pairs.len());
         for &(from, to) in pairs {
             let Some(idx) = cold_path_flat_index(from, to) else {
-                // Unrepresentable in the 65×65 table (id ≥ 65); never
-                // assigned a slot. Defensive (zone-ids are 1..=64).
+                // Unrepresentable in the 65×65 table (zone-id ≥ 65). The
+                // Go compiler assigns 1-based ids up to MaxZones=64, but
+                // the Rust snapshot path accepts ids up to u8::MAX (255)
+                // — so a deployment (or non-Go producer) with an id in
+                // 65..=255 lands here. Surface it via `overflow_active`
+                // rather than silently dropping the pair, so operators
+                // see that a configured zone-pair was not measured
+                // (Copilot code-r4 finding).
+                overflow_active = true;
                 continue;
             };
             let retained = previous.and_then(|p| {
@@ -1305,12 +1312,19 @@ mod tests {
     }
 
     #[test]
-    fn build_skips_out_of_range_pairs() {
-        // A pair with a zone-id >= 64 (e.g. the junos-global sentinel)
-        // is never assigned a slot.
+    fn build_skips_out_of_range_pairs_and_flags_overflow() {
+        // A pair with a zone-id >= 65 (the Rust path accepts ids up to
+        // 255 even though the table covers 0..=64) is not assignable.
+        // Copilot code-r4: such a pair MUST set overflow_active so the
+        // operator sees a configured pair went unmeasured — not vanish
+        // silently.
         let pairs = [(1u16, 2u16), (200, 5), (3, 4)];
         let (map, _) = ColdPathSlotMap::build(None, &pairs);
         assert_eq!(lookup_slot(&map, 200, 5), None);
+        assert!(
+            map.overflow_active,
+            "an out-of-range (id >= 65) configured pair must trip overflow_active"
+        );
         // The two in-range pairs still get slots 0 and 1.
         assert!(lookup_slot(&map, 1, 2).is_some());
         assert!(lookup_slot(&map, 3, 4).is_some());

--- a/userspace-dp/src/afxdp/cold_path_hist.rs
+++ b/userspace-dp/src/afxdp/cold_path_hist.rs
@@ -74,11 +74,22 @@ pub(in crate::afxdp) const COLD_PATH_ASSIGNABLE_SLOTS: usize =
 const _: () = assert!(COLD_PATH_ASSIGNABLE_SLOTS == 255);
 
 /// Maximum zone-id (exclusive) the direct slot-map lookup table
-/// indexes. Junos vSRX deployments use small named zone counts
-/// (typically 4-20); xpf's historical `MAX_ZONES` is 32. Pairs where
-/// either zone-id ≥ 32 land in `None` and are counted out-of-range so
-/// operators see when a deployment outgrows the static limit.
-pub(in crate::afxdp) const COLD_PATH_ZONE_ID_CEILING: u16 = 32;
+/// indexes. MUST cover the full configurable zone space: the Go
+/// compiler assigns sequential 1-based zone-ids and `MAX_ZONES` is 64
+/// (`bpf/headers/xpf_common.h` + `pkg/dataplane/types.go MaxZones`), so
+/// the ceiling is 64 (Codex code-r1 finding 2: a 32 ceiling silently
+/// dropped valid zone-ids 32-63). Zone-ids are 1..=64, so a 64×64 table
+/// covers every assignable pair. Pairs at/above the ceiling land in
+/// `None` — a defensive guard for the reserved `junos-global` sentinel
+/// (`u16::MAX`), not an expected case.
+pub(in crate::afxdp) const COLD_PATH_ZONE_ID_CEILING: u16 = 64;
+/// Bit-shift for the flat-table row stride = `log2(COLD_PATH_ZONE_ID_CEILING)`.
+const COLD_PATH_ZONE_SHIFT: usize = 6;
+const _: () = assert!(1usize << COLD_PATH_ZONE_SHIFT == COLD_PATH_ZONE_ID_CEILING as usize);
+/// Flat lookup-table length = `CEILING²` = 64×64 = 4096 bytes (L1d-resident).
+const COLD_PATH_FLAT_TABLE_LEN: usize =
+    (COLD_PATH_ZONE_ID_CEILING as usize) * (COLD_PATH_ZONE_ID_CEILING as usize);
+const _: () = assert!(COLD_PATH_FLAT_TABLE_LEN == 4096);
 
 /// Wire/layout version stamped into the status payload (#1635).
 pub(in crate::afxdp) const COLD_PATH_LAYOUT_VERSION: u32 = 3;
@@ -136,22 +147,22 @@ pub(in crate::afxdp) fn zone_pair_packed_key(from_zone_id: u16, to_zone_id: u16)
 /// collided at 88.2% with 8 active zone-pairs (birthday paradox), the
 /// F2 finding in the #1622 PLAN-KILL.
 ///
-/// Lookup is a bounded 2D table indexed by `(from & 0x1F, to & 0x1F)`
-/// (32×32 = 1024 entries, L1d-resident). A miss (entry == `u8::MAX`)
-/// means the pair has no slot assigned (capacity exhausted or zone-id
-/// ≥ 32); the sample is dropped at the hot path.
+/// Lookup is a bounded 2D table indexed by `(from, to)` with
+/// `from, to < 64` (64×64 = 4096 entries, L1d-resident). A miss
+/// (entry == `u8::MAX`) means the pair has no slot assigned (capacity
+/// exhausted or zone-id ≥ 64); the sample is dropped at the hot path.
 ///
 /// `inverse[slot]` is the reverse map used by the status path to emit
 /// per-zone-pair labels for the sparse wire encoding.
 #[derive(Clone, Debug)]
 pub(in crate::afxdp) struct ColdPathSlotMap {
-    /// 32×32 flat table indexed by `((from & 0x1F) << 5) | (to & 0x1F)`.
-    /// `u8::MAX` = unassigned.
-    pub(in crate::afxdp) flat_table: Box<[u8; 1024]>,
+    /// 64×64 flat table indexed by `(from << 6) | to`. `u8::MAX` =
+    /// unassigned.
+    pub(in crate::afxdp) flat_table: Box<[u8; COLD_PATH_FLAT_TABLE_LEN]>,
     /// `slot → Some((from, to))` for assigned slots, `None` for free.
     pub(in crate::afxdp) inverse: Vec<Option<(u16, u16)>>,
     /// True if some configured zone-pair could not be assigned a slot
-    /// because the 256-slot capacity was exhausted.
+    /// because the 255-slot capacity was exhausted.
     pub(in crate::afxdp) overflow_active: bool,
 }
 
@@ -165,7 +176,7 @@ impl ColdPathSlotMap {
     /// An empty map: every lookup misses.
     pub(in crate::afxdp) fn empty() -> Self {
         Self {
-            flat_table: Box::new([u8::MAX; 1024]),
+            flat_table: Box::new([u8::MAX; COLD_PATH_FLAT_TABLE_LEN]),
             inverse: vec![None; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
             overflow_active: false,
         }
@@ -176,11 +187,18 @@ impl ColdPathSlotMap {
     /// pairs keep their slot (and their accumulated histogram) across a
     /// config apply.
     ///
-    /// Returns the new map plus the list of slots whose assignment
-    /// CHANGED (freed-then-reused, or newly assigned over a previously
-    /// occupied slot). The worker zeroes these slots' accumulators
-    /// before recording into them so a reused slot never carries the
-    /// previous zone-pair's counts (plan §2.4 / F4).
+    /// Returns the new map plus the list of slots that received a NEW
+    /// zone-pair (every Pass-2 assignment). The worker zeroes these
+    /// slots' accumulators before recording into them so a slot never
+    /// carries an EARLIER zone-pair's counts (plan §2.4 / F4).
+    ///
+    /// Codex code-r1 finding 1: zero-out MUST cover every newly-assigned
+    /// slot, not just slots the *immediately previous* map showed as
+    /// occupied. The worker-local accumulator can carry stale counts
+    /// from ANY earlier config generation (e.g. A assigns slot 0, B
+    /// frees it without reuse, C reassigns slot 0 — B's map shows slot 0
+    /// free, but the worker never cleared A's counts). Zeroing a
+    /// genuinely-fresh slot is a harmless no-op (it is already zero).
     ///
     /// `pairs` should be deduplicated and in a stable order (the caller
     /// passes a `BTreeSet`-derived `Vec`) so slot assignment is
@@ -189,7 +207,7 @@ impl ColdPathSlotMap {
         previous: Option<&ColdPathSlotMap>,
         pairs: &[(u16, u16)],
     ) -> (Self, Vec<u8>) {
-        let mut flat_table = Box::new([u8::MAX; 1024]);
+        let mut flat_table = Box::new([u8::MAX; COLD_PATH_FLAT_TABLE_LEN]);
         let mut inverse: Vec<Option<(u16, u16)>> =
             vec![None; POLICY_COLD_PATH_ZONE_PAIR_SLOTS];
         let mut used = [false; POLICY_COLD_PATH_ZONE_PAIR_SLOTS];
@@ -201,12 +219,12 @@ impl ColdPathSlotMap {
         let mut pending: Vec<(u16, u16)> = Vec::with_capacity(pairs.len());
         for &(from, to) in pairs {
             if from >= COLD_PATH_ZONE_ID_CEILING || to >= COLD_PATH_ZONE_ID_CEILING {
-                // Unrepresentable in the 32×32 table; never assigned a
-                // slot. Counted as out-of-range at the hot path.
+                // Unrepresentable in the 64×64 table; never assigned a
+                // slot. Defensive (zone-ids are 1..=64); not expected.
                 continue;
             }
             let retained = previous.and_then(|p| {
-                let idx = ((from as usize) << 5) | (to as usize);
+                let idx = ((from as usize) << COLD_PATH_ZONE_SHIFT) | (to as usize);
                 let s = p.flat_table[idx];
                 if s != u8::MAX && p.inverse[s as usize] == Some((from, to)) {
                     Some(s)
@@ -218,15 +236,16 @@ impl ColdPathSlotMap {
                 Some(s) => {
                     used[s as usize] = true;
                     inverse[s as usize] = Some((from, to));
-                    flat_table[((from as usize) << 5) | (to as usize)] = s;
+                    flat_table[((from as usize) << COLD_PATH_ZONE_SHIFT) | (to as usize)] = s;
                 }
                 None => pending.push((from, to)),
             }
         }
 
-        // Pass 2: assign the lowest free slot to each new pair. A slot
-        // that was occupied by a DIFFERENT pair in `previous` (now
-        // reused) is queued for zero-out.
+        // Pass 2: assign the lowest free slot to each new pair. EVERY
+        // newly-assigned slot is queued for zero-out (Codex finding 1) —
+        // the worker-local accumulator may carry stale counts from an
+        // earlier generation regardless of what `previous` shows.
         let mut next_free = 0usize;
         for &(from, to) in &pending {
             while next_free < COLD_PATH_ASSIGNABLE_SLOTS && used[next_free] {
@@ -239,13 +258,14 @@ impl ColdPathSlotMap {
             let s = next_free;
             used[s] = true;
             inverse[s] = Some((from, to));
-            flat_table[((from as usize) << 5) | (to as usize)] = s as u8;
-            // If the previous map had any (different) pair in this slot,
-            // the accumulator carries stale counts; queue zero-out.
-            let prev_occupied = previous
-                .map(|p| p.inverse.get(s).copied().flatten().is_some())
-                .unwrap_or(false);
-            if prev_occupied {
+            flat_table[((from as usize) << COLD_PATH_ZONE_SHIFT) | (to as usize)] = s as u8;
+            // Queue zero-out for every newly-assigned slot when a
+            // PREVIOUS map existed — the worker may have accumulated
+            // counts for an earlier pair in this slot during any prior
+            // generation (Codex finding 1). On the very first build
+            // (previous == None) the worker's accumulators are still
+            // default-zero, so no zero-out is needed.
+            if previous.is_some() {
                 slots_to_zero.push(s as u8);
             }
         }
@@ -262,7 +282,7 @@ impl ColdPathSlotMap {
 }
 
 /// Look up the slot for `(from, to)` in the direct map. Returns `None`
-/// for unmapped pairs (capacity exhausted) or zone-ids ≥ 32. Hot-path
+/// for unmapped pairs (capacity exhausted) or zone-ids ≥ 64. Hot-path
 /// cost: one bound check, one shift, one L1d-resident array index, one
 /// `!= u8::MAX` predicate.
 #[inline]
@@ -270,7 +290,7 @@ pub(in crate::afxdp) fn lookup_slot(map: &ColdPathSlotMap, from: u16, to: u16) -
     if from >= COLD_PATH_ZONE_ID_CEILING || to >= COLD_PATH_ZONE_ID_CEILING {
         return None;
     }
-    let entry = map.flat_table[((from as usize) << 5) | (to as usize)];
+    let entry = map.flat_table[((from as usize) << COLD_PATH_ZONE_SHIFT) | (to as usize)];
     if entry == u8::MAX {
         None
     } else {
@@ -1216,18 +1236,45 @@ mod tests {
                 lookup_slot(&map_a, from, to),
                 "surviving pair {from}->{to} kept its slot"
             );
+            // Retained pairs must NOT be zeroed (keep their histogram).
+            let s = lookup_slot(&map_b, from, to).unwrap();
+            assert!(
+                !zeroed.contains(&s),
+                "retained pair {from}->{to} (slot {s}) must NOT be zeroed"
+            );
         }
-        // (7,8) takes a fresh slot that was free in A ⇒ no zero-out.
-        assert!(zeroed.is_empty(), "no slot reused ⇒ nothing to zero");
-        assert!(lookup_slot(&map_b, 7, 8).is_some());
+        // (7,8) is a NEW pair ⇒ its slot IS queued for zero-out (every
+        // newly-assigned slot is zeroed per Codex finding 1).
+        let slot_78 = lookup_slot(&map_b, 7, 8).expect("(7,8) assigned");
+        assert!(
+            zeroed.contains(&slot_78),
+            "new pair (7,8) slot {slot_78} must be zeroed; zeroed={zeroed:?}"
+        );
     }
 
     #[test]
-    fn lookup_slot_returns_none_for_zone_id_ge_32() {
+    fn lookup_slot_returns_none_for_zone_id_ge_ceiling() {
         let (map, _) = ColdPathSlotMap::build(None, &[(1u16, 2u16)]);
-        assert_eq!(lookup_slot(&map, 33, 2), None);
-        assert_eq!(lookup_slot(&map, 2, 33), None);
-        assert_eq!(lookup_slot(&map, 32, 32), None);
+        // Ceiling is 64 (MAX_ZONES). Zone-ids 32-63 are now VALID and
+        // covered by the table (Codex code-r1 finding 2 fix); only
+        // ids >= 64 miss.
+        assert_eq!(lookup_slot(&map, 64, 2), None);
+        assert_eq!(lookup_slot(&map, 2, 64), None);
+        assert_eq!(lookup_slot(&map, 64, 64), None);
+        assert_eq!(lookup_slot(&map, u16::MAX, 1), None);
+    }
+
+    #[test]
+    fn build_assigns_slots_for_zone_ids_32_to_63() {
+        // Regression for Codex code-r1 finding 2: ids 32-63 were
+        // silently dropped under the old 32 ceiling. They must now get
+        // slots.
+        let pairs = [(32u16, 33u16), (63, 1), (1, 63)];
+        let (map, _) = ColdPathSlotMap::build(None, &pairs);
+        assert!(lookup_slot(&map, 32, 33).is_some());
+        assert!(lookup_slot(&map, 63, 1).is_some());
+        assert!(lookup_slot(&map, 1, 63).is_some());
+        assert!(!map.overflow_active);
     }
 
     #[test]
@@ -1238,15 +1285,41 @@ mod tests {
 
     #[test]
     fn build_skips_out_of_range_pairs() {
-        // A pair with a zone-id ≥ 32 is never assigned a slot.
-        let pairs = [(1u16, 2u16), (40, 5), (3, 4)];
+        // A pair with a zone-id >= 64 (e.g. the junos-global sentinel)
+        // is never assigned a slot.
+        let pairs = [(1u16, 2u16), (200, 5), (3, 4)];
         let (map, _) = ColdPathSlotMap::build(None, &pairs);
-        assert_eq!(lookup_slot(&map, 40, 5), None);
+        assert_eq!(lookup_slot(&map, 200, 5), None);
         // The two in-range pairs still get slots 0 and 1.
         assert!(lookup_slot(&map, 1, 2).is_some());
         assert!(lookup_slot(&map, 3, 4).is_some());
         let occupied = map.inverse.iter().filter(|s| s.is_some()).count();
         assert_eq!(occupied, 2);
+    }
+
+    /// Codex code-r1 finding 1: A assigns slot 0; B frees it (no reuse);
+    /// C reassigns slot 0 to a NEW pair. C's `previous` (= B) shows
+    /// slot 0 free, but the worker-local accumulator may still carry
+    /// A's counts — so C MUST queue slot 0 for zero-out.
+    #[test]
+    fn build_zeros_slot_reassigned_after_intermediate_free() {
+        // A: slot 0 = (1,2), slot 1 = (3,4).
+        let (map_a, za) = ColdPathSlotMap::build(None, &[(1u16, 2u16), (3, 4)]);
+        assert!(za.is_empty());
+        let slot_12 = lookup_slot(&map_a, 1, 2).unwrap();
+        // B: drop (1,2); keep (3,4). Slot for (1,2) is now free.
+        let (map_b, _zb) = ColdPathSlotMap::build(Some(&map_a), &[(3u16, 4u16)]);
+        assert_eq!(lookup_slot(&map_b, 1, 2), None);
+        // C: keep (3,4); add NEW (5,6). It takes the lowest free slot,
+        // which is the slot A used for (1,2).
+        let (map_c, zc) = ColdPathSlotMap::build(Some(&map_b), &[(3u16, 4u16), (5, 6)]);
+        let slot_56 = lookup_slot(&map_c, 5, 6).unwrap();
+        assert_eq!(slot_56, slot_12, "(5,6) reuses the slot A gave (1,2)");
+        assert!(
+            zc.contains(&slot_56),
+            "reassigned slot must be queued for zero-out even though B showed it free \
+             (Codex finding 1) — slots_to_zero={zc:?}"
+        );
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/cold_path_hist.rs
+++ b/userspace-dp/src/afxdp/cold_path_hist.rs
@@ -157,16 +157,17 @@ pub(in crate::afxdp) fn zone_pair_packed_key(from_zone_id: u16, to_zone_id: u16)
 /// collided at 88.2% with 8 active zone-pairs (birthday paradox), the
 /// F2 finding in the #1622 PLAN-KILL.
 ///
-/// Lookup is a bounded 2D table indexed by `(from, to)` with
-/// `from, to < 64` (64×64 = 4096 entries, L1d-resident). A miss
-/// (entry == `u8::MAX`) means the pair has no slot assigned (capacity
-/// exhausted or zone-id ≥ 64); the sample is dropped at the hot path.
+/// Lookup is a bounded 2D table indexed by `cold_path_flat_index`
+/// (`from * 65 + to`, ids `0..=64`; 65×65 = 4225 entries, L1d-resident).
+/// A miss (entry == `u8::MAX`) means the pair has no slot assigned
+/// (capacity exhausted or zone-id ≥ 65); the sample is dropped at the
+/// hot path.
 ///
 /// `inverse[slot]` is the reverse map used by the status path to emit
 /// per-zone-pair labels for the sparse wire encoding.
 #[derive(Clone, Debug)]
 pub(in crate::afxdp) struct ColdPathSlotMap {
-    /// 64×64 flat table indexed by `(from << 6) | to`. `u8::MAX` =
+    /// 65×65 flat table indexed by `from * 65 + to`. `u8::MAX` =
     /// unassigned.
     pub(in crate::afxdp) flat_table: Box<[u8; COLD_PATH_FLAT_TABLE_LEN]>,
     /// `slot → Some((from, to))` for assigned slots, `None` for free.

--- a/userspace-dp/src/afxdp/cold_path_hist.rs
+++ b/userspace-dp/src/afxdp/cold_path_hist.rs
@@ -739,14 +739,14 @@ impl WorkerColdPathAtomics {
     /// from a legitimately-empty worker, masking retry-starvation
     /// regimes under heavy publish contention.
     ///
-    /// AGY code-r2 finding 2 (continued): the retry budget is now 2048
+    /// AGY code-r2 finding 2 (continued): the retry budget is now 8192
     /// with an exponential `std::hint::spin_loop` backoff. #1635 grew
     /// the payload from the old 16×24 dense surface to 256 slots × 48
     /// buckets, so one publish now writes ~13k atomics instead of ~450.
     /// The larger budget keeps status-path snapshots coherent under a
     /// concurrent publish without changing the hot path.
     pub(in crate::afxdp) fn snapshot(&self) -> Option<WorkerColdPathCounters> {
-        const RETRY_BUDGET: u32 = 2048;
+        const RETRY_BUDGET: u32 = 8192;
         for attempt in 0..RETRY_BUDGET {
             let s1 = self.cold_window_gen.load(Ordering::Acquire);
             if s1 & 1 != 0 {

--- a/userspace-dp/src/afxdp/cold_path_hist.rs
+++ b/userspace-dp/src/afxdp/cold_path_hist.rs
@@ -11,100 +11,271 @@
 //!   ~25-40 ns on the loss cluster. (Codex code-r1 finding 1 +
 //!   Copilot code-r1: the prior `sample_tsc()` alias was removed
 //!   to prevent foot-gun usage at the end of a window.)
-//! - `bucket_index_for_ns_24(ns)` — branchless 24-bucket select. Same
-//!   formula family as `bucket_index_for_ns` at `umem/mod.rs:244`;
-//!   only the upper clamp changes (`.min(23)` vs `.min(15)`). Codex
-//!   plan-r1 finding 3 pinned the exact formula.
-//! - `splitmix64(x) -> u64` and `zone_pair_slot(from, to)` — 16-slot
-//!   per-zone-pair hash. Pinned via `POLICY_COLD_PATH_ZONE_PAIR_SLOTS
-//!   == 16` const assertion.
+//! - `bucket_index_for_ns_48(ns)` — #1635 log-linear 48-bucket select:
+//!   32 linear 16-ns buckets over `[0, 512)` ns + 15 pow-2 buckets over
+//!   `[512, 2^24)` ns + 1 saturate bucket. Fixes the #1622 F1
+//!   bucket-0 resolution floor (a 5-10× p50 error at low rule counts).
+//! - `ColdPathSlotMap` + `lookup_slot(map, from, to)` — #1635 DIRECT
+//!   `(from_zone_id, to_zone_id) → slot` map (256 slots) built at
+//!   config apply. Replaces the splitmix64 16-slot hash that collided
+//!   at 88.2% with 8 active zone-pairs (#1622 F2).
 //!
-//! Slot collision detection lives at the harness side per plan §3.4
-//! (v3): the dataplane keeps a `first_key` + `alias_seen` pair per
-//! slot. The hot path records the first packed key seen, and flips
-//! `alias_seen = true` on any subsequent sample with a different
-//! key. The harness publication gate excludes slots with
-//! `alias_seen == true`. v1/v2 used `keys_xor` but Codex r2 proved
-//! a false-pass mode (count(K) odd + count(L) even leaves
-//! `keys_xor == K`), so v3 retires XOR for first_key + alias_seen.
+//! Each slot keeps a `first_key` + `builder_collision` pair (renamed
+//! from `alias_seen` per AGY r1 [1.6]). With the direct map a
+//! `builder_collision` should NEVER fire — it indicates the snapshot
+//! builder produced two distinct keys for one slot and is treated as a
+//! hard error in operator dashboards.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering, compiler_fence};
 
 /// Number of histogram buckets per zone-pair slot.
 ///
-/// Pinned at 24 — bucket 0 covers `[0, 1024)` ns, bucket 23 saturates
-/// at any `ns ≥ 2^32` ≈ 4.295 s.
-pub(in crate::afxdp) const POLICY_COLD_PATH_HIST_BUCKETS: usize = 24;
-const _: () = assert!(POLICY_COLD_PATH_HIST_BUCKETS == 24);
+/// #1635: pinned at 48 (was 24). The layout is log-linear:
+///   - 32 LINEAR buckets of 16-ns stride covering `[0, 512)` ns
+///     (bucket `b` covers `[b*16, (b+1)*16)` for `0 ≤ b ≤ 31`).
+///   - 15 EXPONENTIAL buckets covering `[512, 2^24)` ns
+///     (bucket `32+i` covers `[2^(9+i), 2^(10+i))` for `0 ≤ i ≤ 14`).
+///   - 1 SATURATE bucket (index 47) for `ns ≥ 2^24` (≈16.8 ms).
+///
+/// The linear band gives ~16-ns resolution in the operator-critical
+/// 50-150 ns range that the old pow-2-from-0 layout collapsed into a
+/// single 1024-ns bucket-0 (a 5-10× p50 reporting error). See #1622
+/// PLAN-KILL finding F1.
+pub(in crate::afxdp) const POLICY_COLD_PATH_HIST_BUCKETS: usize = 48;
+const _: () = assert!(POLICY_COLD_PATH_HIST_BUCKETS == 48);
+
+/// Number of LINEAR buckets at the low end (16-ns stride, `[0, 512)` ns).
+pub(in crate::afxdp) const COLD_PATH_LINEAR_BUCKETS: usize = 32;
+/// Linear-band stride in nanoseconds.
+pub(in crate::afxdp) const COLD_PATH_LINEAR_STRIDE_NS: u64 = 16;
+/// Pivot: first nanosecond value handled by the exponential band.
+pub(in crate::afxdp) const COLD_PATH_PIVOT_NS: u64 =
+    (COLD_PATH_LINEAR_BUCKETS as u64) * COLD_PATH_LINEAR_STRIDE_NS; // 512
+const _: () = assert!(COLD_PATH_PIVOT_NS == 512);
 
 /// Number of per-zone-pair slots in the histogram.
 ///
-/// Pinned at 16 (4-bit splitmix mask). The cluster's active zone-pair
-/// set may exceed 16, in which case the `first_key + alias_seen`
-/// collision detector triggers and the harness excludes aliased
-/// slots from publication (plan §3.4).
-pub(in crate::afxdp) const POLICY_COLD_PATH_ZONE_PAIR_SLOTS: usize = 16;
-const _: () = assert!(POLICY_COLD_PATH_ZONE_PAIR_SLOTS == 16);
-const _: () = assert!(POLICY_COLD_PATH_ZONE_PAIR_SLOTS.is_power_of_two());
+/// #1635: pinned at 256 (was 16). The slot map is now a DIRECT
+/// `(from_zone_id, to_zone_id) → slot` assignment built at config
+/// apply (see [`ColdPathSlotMap`]). 256 gives ~21× headroom over the
+/// largest known deployment; wire cost is bounded by SPARSE
+/// serialization (only slots with `samples > 0` ride the wire), so
+/// the static cap does not impose a per-scrape byte cost.
+pub(in crate::afxdp) const POLICY_COLD_PATH_ZONE_PAIR_SLOTS: usize = 256;
+const _: () = assert!(POLICY_COLD_PATH_ZONE_PAIR_SLOTS == 256);
 
-/// Slot index mask = `POLICY_COLD_PATH_ZONE_PAIR_SLOTS - 1`.
-pub(in crate::afxdp) const ZONE_PAIR_SLOT_MASK: u64 =
-    (POLICY_COLD_PATH_ZONE_PAIR_SLOTS - 1) as u64;
+/// Maximum number of ASSIGNABLE slots. `u8::MAX` (255) is reserved as
+/// the `flat_table` "unassigned" sentinel, so slot index 255 can never
+/// be handed out; the accumulator arrays are still 256 wide for
+/// alignment and to keep slot indices identity-mapped. Capacity is
+/// therefore 255 active zone-pairs (~21× the largest known deployment).
+pub(in crate::afxdp) const COLD_PATH_ASSIGNABLE_SLOTS: usize =
+    POLICY_COLD_PATH_ZONE_PAIR_SLOTS - 1;
+const _: () = assert!(COLD_PATH_ASSIGNABLE_SLOTS == 255);
 
-/// 24-bucket power-of-two ns histogram bucket selector. Branchless.
+/// Maximum zone-id (exclusive) the direct slot-map lookup table
+/// indexes. Junos vSRX deployments use small named zone counts
+/// (typically 4-20); xpf's historical `MAX_ZONES` is 32. Pairs where
+/// either zone-id ≥ 32 land in `None` and are counted out-of-range so
+/// operators see when a deployment outgrows the static limit.
+pub(in crate::afxdp) const COLD_PATH_ZONE_ID_CEILING: u16 = 32;
+
+/// Wire/layout version stamped into the status payload (#1635).
+pub(in crate::afxdp) const COLD_PATH_LAYOUT_VERSION: u32 = 3;
+
+/// 48-bucket log-linear ns histogram bucket selector.
 ///
-/// Same math family as `bucket_index_for_ns` at
-/// `userspace-dp/src/afxdp/umem/mod.rs:244`; only the upper clamp
-/// changes from 15 → 23. Bucket 0 covers `[0, 1024)` ns; bucket[i]
-/// for i ∈ [1, 22] covers `[2^(9+i), 2^(10+i))` ns; bucket 23
-/// saturates at any `ns ≥ 2^32` ≈ 4.295 s.
+/// #1635 (replaces `bucket_index_for_ns_24`):
+///   - `ns < 512`            → linear: `ns / 16` ∈ `[0, 32)`.
+///   - `512 ≤ ns < 2^24`     → exponential: `32 + (floor(log2(ns)) - 9)`
+///                             ∈ `[32, 47)`.
+///   - `ns ≥ 2^24`           → saturate: `47`.
+///
+/// Branchless within each band; one predicate selects the band.
 #[inline]
-pub(in crate::afxdp) fn bucket_index_for_ns_24(ns: u64) -> usize {
-    let clz = (ns | 1).leading_zeros() as i32;
-    let b = (54 - clz).max(0) as usize;
-    b.min(POLICY_COLD_PATH_HIST_BUCKETS - 1)
+pub(in crate::afxdp) fn bucket_index_for_ns_48(ns: u64) -> usize {
+    if ns < COLD_PATH_PIVOT_NS {
+        // Linear band: 16-ns stride, indices [0, 32).
+        (ns / COLD_PATH_LINEAR_STRIDE_NS) as usize
+    } else {
+        // Exponential band: floor(log2(ns)) ∈ [9, +) for ns ≥ 512.
+        // log2 = 63 - clz(ns); bucket = 32 + (log2 - 9).
+        let log2 = (63 - ns.leading_zeros()) as usize;
+        let b = COLD_PATH_LINEAR_BUCKETS + (log2 - 9);
+        b.min(POLICY_COLD_PATH_HIST_BUCKETS - 1)
+    }
 }
 
-/// 64-bit splitmix scrambler. Single-step variant used to hash a
-/// packed `(from_zone_id, to_zone_id)` key into a 4-bit slot index.
-///
-/// Same constants as the public splitmix64 (Steele/Vigna), one
-/// xor-shift-multiply round; sufficient avalanche for the 16-slot
-/// pigeonhole. NOT a cryptographic hash.
+/// Inclusive upper boundary in nanoseconds for histogram bucket `idx`,
+/// for the Prometheus `le` label. Mirrors [`bucket_index_for_ns_48`]:
+///   - `idx < 32`        → `(idx + 1) * 16 - 1`  (15, 31, …, 511).
+///   - `32 ≤ idx ≤ 46`   → `2^(10 + idx - 32) - 1` (1023, 2047, …).
+///   - `idx ≥ 47`        → `u64::MAX` (rendered as `+Inf` on the wire).
 #[inline]
-pub(in crate::afxdp) fn splitmix64(x: u64) -> u64 {
-    let mut z = x.wrapping_add(0x9E3779B97F4A7C15);
-    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
-    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
-    z ^ (z >> 31)
+pub(in crate::afxdp) fn bucket_upper_bound_ns_48(idx: usize) -> u64 {
+    if idx < COLD_PATH_LINEAR_BUCKETS {
+        (idx as u64 + 1) * COLD_PATH_LINEAR_STRIDE_NS - 1
+    } else if idx >= POLICY_COLD_PATH_HIST_BUCKETS - 1 {
+        u64::MAX
+    } else {
+        (1u64 << (10 + idx - COLD_PATH_LINEAR_BUCKETS)) - 1
+    }
 }
 
-/// Pack zone IDs into a u64 key suitable for hashing or comparison.
-///
-/// **Injective encoding** (Codex r3 finding 1): `+ 1` instead of `| 1`
-/// — `| 1` collapses adjacent `to_zone_id` values that share the same
-/// odd parity into the same key (e.g. `(1,2)` and `(1,3)` both become
-/// `65539` under `| 1`). The `+ 1` form preserves injectivity by
-/// shifting the entire 32-bit packed key range by +1, which keeps
-/// `(0, 0)` from collapsing to zero while keeping all other pairs
-/// distinct.
-///
-/// The non-zero invariant is needed so that `first_key[slot] == 0`
-/// remains a reliable "no sample yet" sentinel (plan §3.4).
+/// Pack zone IDs into a u64 key suitable for the slot-map `first_key`
+/// collision sentinel. `+ 1` keeps `(0, 0)` from collapsing to the
+/// zero "no sample yet" sentinel while preserving injectivity over
+/// distinct `(u16, u16)` pairs (Codex r3 finding 1).
 #[inline]
 pub(in crate::afxdp) fn zone_pair_packed_key(from_zone_id: u16, to_zone_id: u16) -> u64 {
-    // (from << 16) | to fits in 32 bits and is injective over distinct
-    // (u16, u16) pairs. Adding 1 keeps zero free as the "no sample"
-    // sentinel without breaking injectivity.
     (((from_zone_id as u64) << 16) | (to_zone_id as u64)) + 1
 }
 
-/// Map a `(from_zone_id, to_zone_id)` pair to a slot index in
-/// `[0, POLICY_COLD_PATH_ZONE_PAIR_SLOTS)`.
+/// #1635: direct `(from_zone_id, to_zone_id) → slot` map built at
+/// config-apply time. Replaces the splitmix64 16-slot hash that
+/// collided at 88.2% with 8 active zone-pairs (birthday paradox), the
+/// F2 finding in the #1622 PLAN-KILL.
+///
+/// Lookup is a bounded 2D table indexed by `(from & 0x1F, to & 0x1F)`
+/// (32×32 = 1024 entries, L1d-resident). A miss (entry == `u8::MAX`)
+/// means the pair has no slot assigned (capacity exhausted or zone-id
+/// ≥ 32); the sample is dropped at the hot path.
+///
+/// `inverse[slot]` is the reverse map used by the status path to emit
+/// per-zone-pair labels for the sparse wire encoding.
+#[derive(Clone, Debug)]
+pub(in crate::afxdp) struct ColdPathSlotMap {
+    /// 32×32 flat table indexed by `((from & 0x1F) << 5) | (to & 0x1F)`.
+    /// `u8::MAX` = unassigned.
+    pub(in crate::afxdp) flat_table: Box<[u8; 1024]>,
+    /// `slot → Some((from, to))` for assigned slots, `None` for free.
+    pub(in crate::afxdp) inverse: Vec<Option<(u16, u16)>>,
+    /// True if some configured zone-pair could not be assigned a slot
+    /// because the 256-slot capacity was exhausted.
+    pub(in crate::afxdp) overflow_active: bool,
+}
+
+impl Default for ColdPathSlotMap {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl ColdPathSlotMap {
+    /// An empty map: every lookup misses.
+    pub(in crate::afxdp) fn empty() -> Self {
+        Self {
+            flat_table: Box::new([u8::MAX; 1024]),
+            inverse: vec![None; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
+            overflow_active: false,
+        }
+    }
+
+    /// Build a direct slot map from a set of configured zone-pairs,
+    /// optionally reusing a previous map's slot assignments so retained
+    /// pairs keep their slot (and their accumulated histogram) across a
+    /// config apply.
+    ///
+    /// Returns the new map plus the list of slots whose assignment
+    /// CHANGED (freed-then-reused, or newly assigned over a previously
+    /// occupied slot). The worker zeroes these slots' accumulators
+    /// before recording into them so a reused slot never carries the
+    /// previous zone-pair's counts (plan §2.4 / F4).
+    ///
+    /// `pairs` should be deduplicated and in a stable order (the caller
+    /// passes a `BTreeSet`-derived `Vec`) so slot assignment is
+    /// deterministic for a given config.
+    pub(in crate::afxdp) fn build(
+        previous: Option<&ColdPathSlotMap>,
+        pairs: &[(u16, u16)],
+    ) -> (Self, Vec<u8>) {
+        let mut flat_table = Box::new([u8::MAX; 1024]);
+        let mut inverse: Vec<Option<(u16, u16)>> =
+            vec![None; POLICY_COLD_PATH_ZONE_PAIR_SLOTS];
+        let mut used = [false; POLICY_COLD_PATH_ZONE_PAIR_SLOTS];
+        let mut slots_to_zero: Vec<u8> = Vec::new();
+        let mut overflow_active = false;
+
+        // Pass 1: retain slot assignments for pairs that survive from
+        // the previous map (so their accumulated histogram is kept).
+        let mut pending: Vec<(u16, u16)> = Vec::with_capacity(pairs.len());
+        for &(from, to) in pairs {
+            if from >= COLD_PATH_ZONE_ID_CEILING || to >= COLD_PATH_ZONE_ID_CEILING {
+                // Unrepresentable in the 32×32 table; never assigned a
+                // slot. Counted as out-of-range at the hot path.
+                continue;
+            }
+            let retained = previous.and_then(|p| {
+                let idx = ((from as usize) << 5) | (to as usize);
+                let s = p.flat_table[idx];
+                if s != u8::MAX && p.inverse[s as usize] == Some((from, to)) {
+                    Some(s)
+                } else {
+                    None
+                }
+            });
+            match retained {
+                Some(s) => {
+                    used[s as usize] = true;
+                    inverse[s as usize] = Some((from, to));
+                    flat_table[((from as usize) << 5) | (to as usize)] = s;
+                }
+                None => pending.push((from, to)),
+            }
+        }
+
+        // Pass 2: assign the lowest free slot to each new pair. A slot
+        // that was occupied by a DIFFERENT pair in `previous` (now
+        // reused) is queued for zero-out.
+        let mut next_free = 0usize;
+        for &(from, to) in &pending {
+            while next_free < COLD_PATH_ASSIGNABLE_SLOTS && used[next_free] {
+                next_free += 1;
+            }
+            if next_free >= COLD_PATH_ASSIGNABLE_SLOTS {
+                overflow_active = true;
+                break;
+            }
+            let s = next_free;
+            used[s] = true;
+            inverse[s] = Some((from, to));
+            flat_table[((from as usize) << 5) | (to as usize)] = s as u8;
+            // If the previous map had any (different) pair in this slot,
+            // the accumulator carries stale counts; queue zero-out.
+            let prev_occupied = previous
+                .map(|p| p.inverse.get(s).copied().flatten().is_some())
+                .unwrap_or(false);
+            if prev_occupied {
+                slots_to_zero.push(s as u8);
+            }
+        }
+
+        (
+            Self {
+                flat_table,
+                inverse,
+                overflow_active,
+            },
+            slots_to_zero,
+        )
+    }
+}
+
+/// Look up the slot for `(from, to)` in the direct map. Returns `None`
+/// for unmapped pairs (capacity exhausted) or zone-ids ≥ 32. Hot-path
+/// cost: one bound check, one shift, one L1d-resident array index, one
+/// `!= u8::MAX` predicate.
 #[inline]
-pub(in crate::afxdp) fn zone_pair_slot(from_zone_id: u16, to_zone_id: u16) -> usize {
-    let key = zone_pair_packed_key(from_zone_id, to_zone_id);
-    (splitmix64(key) & ZONE_PAIR_SLOT_MASK) as usize
+pub(in crate::afxdp) fn lookup_slot(map: &ColdPathSlotMap, from: u16, to: u16) -> Option<u8> {
+    if from >= COLD_PATH_ZONE_ID_CEILING || to >= COLD_PATH_ZONE_ID_CEILING {
+        return None;
+    }
+    let entry = map.flat_table[((from as usize) << 5) | (to as usize)];
+    if entry == u8::MAX {
+        None
+    } else {
+        Some(entry)
+    }
 }
 
 /// Read the TSC at the **start** of a measurement window via
@@ -446,13 +617,13 @@ pub(in crate::afxdp) struct WorkerColdPathAtomics {
     /// Calibration: set once at worker startup. Outside the per-tick seqlock.
     pub(in crate::afxdp) clock_source: AtomicU8,
     // === COLD FIELDS (written by publish_from_local) ===
-    /// v3: set true if any sample's packed key differs from
-    /// `first_key`. Once set, stays set for the window. The harness
-    /// publication gate excludes slots with `alias_seen = true`
-    /// from Tables A1/A2 per plan §3.4 (Codex r2 finding 3).
-    pub(in crate::afxdp) alias_seen: [AtomicBool; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
-    /// v3: first packed zone-pair key seen in this slot during the
-    /// current publish window. Zero = no sample yet.
+    /// #1635 (renamed from `alias_seen`): set true if a sample's packed
+    /// key differs from the slot's `first_key`. With the direct slot
+    /// map this should NEVER fire; a set bit means the snapshot builder
+    /// mapped two distinct zone-pairs to one slot (AGY r1 [1.6]).
+    pub(in crate::afxdp) builder_collision: [AtomicBool; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
+    /// First packed zone-pair key seen in this slot during the current
+    /// publish window. Zero = no sample yet.
     pub(in crate::afxdp) first_key: [AtomicU64; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
     pub(in crate::afxdp) sum_ns: [AtomicU64; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
     pub(in crate::afxdp) samples: [AtomicU64; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
@@ -476,7 +647,7 @@ impl WorkerColdPathAtomics {
             wrapper_ns_baseline: AtomicU64::new(0),
             wrapper_underflow_count: AtomicU64::new(0),
             clock_source: AtomicU8::new(ClockSource::Unset.as_u8()),
-            alias_seen: std::array::from_fn(|_| AtomicBool::new(false)),
+            builder_collision: std::array::from_fn(|_| AtomicBool::new(false)),
             first_key: std::array::from_fn(|_| AtomicU64::new(0)),
             sum_ns: std::array::from_fn(|_| AtomicU64::new(0)),
             samples: std::array::from_fn(|_| AtomicU64::new(0)),
@@ -527,7 +698,8 @@ impl WorkerColdPathAtomics {
             self.sum_ns[slot].store(local.sum_ns[slot], Ordering::Relaxed);
             self.samples[slot].store(local.samples[slot], Ordering::Relaxed);
             self.first_key[slot].store(local.first_key[slot], Ordering::Relaxed);
-            self.alias_seen[slot].store(local.alias_seen[slot], Ordering::Relaxed);
+            self.builder_collision[slot]
+                .store(local.builder_collision[slot], Ordering::Relaxed);
         }
         // 3. Bump gen odd → even with Release.
         self.cold_window_gen.fetch_add(1, Ordering::Release);
@@ -580,7 +752,8 @@ impl WorkerColdPathAtomics {
                 out.sum_ns[slot] = self.sum_ns[slot].load(Ordering::Relaxed);
                 out.samples[slot] = self.samples[slot].load(Ordering::Relaxed);
                 out.first_key[slot] = self.first_key[slot].load(Ordering::Relaxed);
-                out.alias_seen[slot] = self.alias_seen[slot].load(Ordering::Relaxed);
+                out.builder_collision[slot] =
+                    self.builder_collision[slot].load(Ordering::Relaxed);
             }
             // Seal Relaxed loads before s2 re-check.
             std::sync::atomic::fence(Ordering::Acquire);
@@ -612,6 +785,24 @@ impl WorkerColdPathAtomics {
     pub(in crate::afxdp) fn snapshot_failed_count(&self) -> u64 {
         self.snapshot_failed.load(Ordering::Relaxed)
     }
+
+    /// #1635 (plan §2.4): atomically zero one slot's accumulator
+    /// fields. Called by the owning worker on its next tick after a
+    /// config apply reassigns the slot to a new zone-pair, so the
+    /// reused slot never carries the previous pair's counts. Stores are
+    /// Relaxed under the same single-writer discipline as
+    /// `publish_from_local`; the caller runs this inside the worker's
+    /// publish path so the seqlock brackets it.
+    pub(in crate::afxdp) fn zero_slot(&self, idx: usize) {
+        debug_assert!(idx < POLICY_COLD_PATH_ZONE_PAIR_SLOTS);
+        for b in 0..POLICY_COLD_PATH_HIST_BUCKETS {
+            self.buckets[idx][b].store(0, Ordering::Relaxed);
+        }
+        self.sum_ns[idx].store(0, Ordering::Relaxed);
+        self.samples[idx].store(0, Ordering::Relaxed);
+        self.first_key[idx].store(0, Ordering::Relaxed);
+        self.builder_collision[idx].store(false, Ordering::Relaxed);
+    }
 }
 
 /// Worker-local mutable cold-path counters. Touched only by the
@@ -627,20 +818,20 @@ impl WorkerColdPathAtomics {
 /// default `#[repr(Rust)]` is free to reorder fields to optimize
 /// packing, which would destroy the hot-cacheline isolation.
 ///
-/// Verified layout (AGY r2 axis 2 + Claude SMR r3 cross-check):
+/// Verified layout (AGY r2 axis 2 + Claude SMR r3 cross-check; offsets
+/// re-derived for the #1635 256-slot / 48-bucket sizes):
 ///   [0..7]      sample_phase
 ///   [8..15]     ns_per_tsc_q32
 ///   [16..23]    wrapper_ns_baseline
 ///   [24..31]    wrapper_underflow_count
 ///   [32]        clock_source (enum #[repr(u8)])
-///   [33..48]    alias_seen   [bool; 16] (alignment 1, no padding)
-///   [49..55]    PADDING                  (to align next u64 array)
-///   [56..183]   first_key    [u64; 16]
-///   [184..311]  sum_ns       [u64; 16]
-///   [312..439]  samples      [u64; 16]
-///   [440..3511] buckets      [[u64; 24]; 16]
+///   [33..288]   builder_collision [bool; 256] (alignment 1, no padding)
+///   [288..295]  PADDING                       (to align next u64 array)
+///   first_key / sum_ns / samples / buckets follow as [_; 256] arrays.
 ///
-/// First 49 bytes fit in cacheline 0 ([0..63]).
+/// The hot-path read set (sample_phase, ns_per_tsc_q32,
+/// wrapper_ns_baseline, clock_source) still lands in cacheline 0
+/// ([0..63]); the cold per-slot arrays start at offset 33.
 #[repr(C)]
 #[derive(Clone, Debug)]
 pub(in crate::afxdp) struct WorkerColdPathCounters {
@@ -664,11 +855,12 @@ pub(in crate::afxdp) struct WorkerColdPathCounters {
     /// Per-worker clock source set once at startup.
     pub(in crate::afxdp) clock_source: ClockSource,
     // === COLD FIELDS (written only when sample fires) ===
-    /// v3 alias detector: monotonic per-slot flag set when a sample
-    /// arrives with a key different from `first_key`. Once true,
-    /// stays true for the publish window.
-    pub(in crate::afxdp) alias_seen: [bool; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
-    /// v3 alias detector: first packed zone-pair key per slot (0 = none).
+    /// #1635 (renamed from `alias_seen`): per-slot flag set when a
+    /// sample arrives with a key different from `first_key`. With the
+    /// direct slot map this is a builder-bug signal, not an aliasing
+    /// gate. Once true, stays true for the publish window.
+    pub(in crate::afxdp) builder_collision: [bool; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
+    /// First packed zone-pair key per slot (0 = none).
     pub(in crate::afxdp) first_key: [u64; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
     pub(in crate::afxdp) sum_ns: [u64; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
     pub(in crate::afxdp) samples: [u64; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
@@ -684,7 +876,7 @@ impl Default for WorkerColdPathCounters {
             wrapper_ns_baseline: 0,
             wrapper_underflow_count: 0,
             clock_source: ClockSource::Unset,
-            alias_seen: [false; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
+            builder_collision: [false; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
             first_key: [0u64; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
             sum_ns: [0u64; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
             samples: [0u64; POLICY_COLD_PATH_ZONE_PAIR_SLOTS],
@@ -694,31 +886,49 @@ impl Default for WorkerColdPathCounters {
 }
 
 impl WorkerColdPathCounters {
-    /// Hot-path-friendly sample record. Inlined to keep the call site
-    /// in `poll_descriptor/mod.rs` cheap. NOT branchless — but the
-    /// caller already gated on `sample_tag` so this fn is only invoked
-    /// at the sampling rate (1-in-256 unbounded; 1-in-1 bounded).
+    /// #1635 hot-path sample record. The caller resolves `slot` via
+    /// [`lookup_slot`] against the per-config `ColdPathSlotMap` and
+    /// skips the call entirely on a miss, so this fn never needs to
+    /// hash. `from_zone_id` / `to_zone_id` are still passed so the
+    /// `first_key` / `builder_collision` invariant can detect a builder
+    /// bug (two distinct pairs mapped to one slot). Inlined; only
+    /// invoked at the sampling rate.
     #[inline]
     pub(in crate::afxdp) fn record_sample(
         &mut self,
+        slot: u8,
         from_zone_id: u16,
         to_zone_id: u16,
         delta_ns: u64,
     ) {
-        let slot = zone_pair_slot(from_zone_id, to_zone_id);
-        let bucket = bucket_index_for_ns_24(delta_ns);
+        let slot = slot as usize;
+        debug_assert!(slot < POLICY_COLD_PATH_ZONE_PAIR_SLOTS);
+        let bucket = bucket_index_for_ns_48(delta_ns);
         self.buckets[slot][bucket] = self.buckets[slot][bucket].saturating_add(1);
         self.sum_ns[slot] = self.sum_ns[slot].saturating_add(delta_ns);
         self.samples[slot] = self.samples[slot].saturating_add(1);
-        // v3 alias detector: first_key + alias_seen (Codex r2 finding 3
-        // retired the v1/v2 XOR-rolling design which false-passes on
-        // count(K) odd + count(L) even).
+        // builder_collision invariant: with the direct slot map every
+        // sample in a slot MUST carry the same packed key. A mismatch
+        // means the snapshot builder mapped two pairs to one slot.
         let key = zone_pair_packed_key(from_zone_id, to_zone_id);
         if self.first_key[slot] == 0 {
             self.first_key[slot] = key;
         } else if self.first_key[slot] != key {
-            self.alias_seen[slot] = true;
+            self.builder_collision[slot] = true;
         }
+    }
+
+    /// #1635 (plan §2.4): zero one slot's local accumulator. Called by
+    /// the owning worker when a config apply reassigns the slot, before
+    /// the first `record_sample` into the new zone-pair.
+    #[inline]
+    pub(in crate::afxdp) fn zero_slot(&mut self, slot: usize) {
+        debug_assert!(slot < POLICY_COLD_PATH_ZONE_PAIR_SLOTS);
+        self.buckets[slot] = [0u64; POLICY_COLD_PATH_HIST_BUCKETS];
+        self.sum_ns[slot] = 0;
+        self.samples[slot] = 0;
+        self.first_key[slot] = 0;
+        self.builder_collision[slot] = false;
     }
 }
 
@@ -733,7 +943,7 @@ mod tests {
     // + AXIS-6 diagnostic (wrapper_underflow_count).
     #[test]
     fn worker_cold_path_counters_hot_fields_fit_in_cacheline_0() {
-        use std::mem::{offset_of, size_of};
+        use std::mem::offset_of;
         // Hot fields declared first; ClockSource is #[repr(u8)] so
         // its size is 1 byte and the offset math is deterministic.
         assert_eq!(offset_of!(WorkerColdPathCounters, sample_phase), 0);
@@ -741,12 +951,12 @@ mod tests {
         assert_eq!(offset_of!(WorkerColdPathCounters, wrapper_ns_baseline), 16);
         assert_eq!(offset_of!(WorkerColdPathCounters, wrapper_underflow_count), 24);
         assert_eq!(offset_of!(WorkerColdPathCounters, clock_source), 32);
-        // alias_seen [bool; 16] alignment 1: lives at [33..48], no padding.
-        assert_eq!(offset_of!(WorkerColdPathCounters, alias_seen), 33);
-        // first_key [u64; 16] alignment 8: padding to align at 56.
-        assert_eq!(offset_of!(WorkerColdPathCounters, first_key), 56);
-        // All hot reads land in cacheline 0 ([0..63]).
-        assert!(size_of::<WorkerColdPathCounters>() >= 432);
+        // #1635: builder_collision [bool; 256] alignment 1: lives at
+        // [33..289], no padding. All hot reads (sample_phase ..
+        // clock_source) still land in cacheline 0 ([0..63]).
+        assert_eq!(offset_of!(WorkerColdPathCounters, builder_collision), 33);
+        // first_key [u64; 256] alignment 8: padded from 33+256=289 to 296.
+        assert_eq!(offset_of!(WorkerColdPathCounters, first_key), 296);
     }
 
     #[test]
@@ -781,80 +991,261 @@ mod tests {
         assert_eq!(snap.wrapper_underflow_count, 7);
     }
 
+    // === #1635 log-linear 48-bucket layout ===
+
     #[test]
-    fn bucket_zero_covers_sub_1024_ns() {
-        for ns in [0u64, 1, 100, 500, 1000, 1023] {
-            assert_eq!(bucket_index_for_ns_24(ns), 0, "ns={ns}");
+    fn bucket_index_for_ns_48_linear_band() {
+        // Linear band: 16-ns stride, indices [0, 32).
+        assert_eq!(bucket_index_for_ns_48(0), 0);
+        assert_eq!(bucket_index_for_ns_48(15), 0);
+        assert_eq!(bucket_index_for_ns_48(16), 1);
+        assert_eq!(bucket_index_for_ns_48(31), 1);
+        assert_eq!(bucket_index_for_ns_48(100), 6); // 100/16 = 6
+        assert_eq!(bucket_index_for_ns_48(496), 31);
+        assert_eq!(bucket_index_for_ns_48(511), 31);
+    }
+
+    #[test]
+    fn bucket_index_for_ns_48_pivots_at_512() {
+        assert_eq!(bucket_index_for_ns_48(511), 31, "last linear bucket");
+        assert_eq!(bucket_index_for_ns_48(512), 32, "first exponential bucket");
+    }
+
+    #[test]
+    fn bucket_index_for_ns_48_exponential_band() {
+        // bucket 32 covers [512, 1024); 33 covers [1024, 2048); ...
+        assert_eq!(bucket_index_for_ns_48(512), 32);
+        assert_eq!(bucket_index_for_ns_48(1023), 32);
+        assert_eq!(bucket_index_for_ns_48(1024), 33);
+        assert_eq!(bucket_index_for_ns_48(2047), 33);
+        assert_eq!(bucket_index_for_ns_48(2048), 34);
+        // i=14 → bucket 46 covers [2^23, 2^24).
+        assert_eq!(bucket_index_for_ns_48(1u64 << 23), 46);
+        assert_eq!(bucket_index_for_ns_48((1u64 << 24) - 1), 46);
+    }
+
+    #[test]
+    fn bucket_index_for_ns_48_saturates() {
+        // ns ≥ 2^24 lands in bucket 47.
+        assert_eq!(bucket_index_for_ns_48(1u64 << 24), 47);
+        assert_eq!(bucket_index_for_ns_48(1u64 << 33), 47);
+        assert_eq!(bucket_index_for_ns_48(u64::MAX), 47);
+    }
+
+    #[test]
+    fn bucket_upper_bound_ns_48_matches_layout() {
+        // Linear band inclusive upper boundaries.
+        assert_eq!(bucket_upper_bound_ns_48(0), 15);
+        assert_eq!(bucket_upper_bound_ns_48(1), 31);
+        assert_eq!(bucket_upper_bound_ns_48(31), 511);
+        // Exponential band.
+        assert_eq!(bucket_upper_bound_ns_48(32), 1023);
+        assert_eq!(bucket_upper_bound_ns_48(33), 2047);
+        assert_eq!(bucket_upper_bound_ns_48(46), (1u64 << 24) - 1);
+        // Saturate bucket.
+        assert_eq!(bucket_upper_bound_ns_48(47), u64::MAX);
+    }
+
+    /// Consumer criterion (#1622 F1 / plan §X): a 10-rule cold-path
+    /// distribution centered at ~50-150 ns must read back a p50 within
+    /// 2× of truth, NOT collapsed to the old bucket-0 512-ns midpoint.
+    /// This test FAILS on the old 24-bucket pow-2-from-0 layout (which
+    /// puts all of [0,1024) ns into one bucket whose midpoint is 512)
+    /// and PASSES on the new log-linear layout.
+    #[test]
+    fn bucket_layout_resolves_low_end_within_2x() {
+        // For each true latency, the bucket's INCLUSIVE upper bound is
+        // the worst-case reported value for a histogram_quantile read
+        // landing in that bucket. Assert it is within 2× of truth (and
+        // that the lower edge is ≥ truth/2), i.e. relative error ≤ 1.0.
+        for truth in [50u64, 75, 100, 125, 150, 1000, 5000, 50000] {
+            let idx = bucket_index_for_ns_48(truth);
+            let upper = bucket_upper_bound_ns_48(idx);
+            let lower = if idx == 0 {
+                0
+            } else {
+                bucket_upper_bound_ns_48(idx - 1) + 1
+            };
+            // Reported value (bucket boundary) within 2× of truth.
+            assert!(
+                upper <= truth.saturating_mul(2),
+                "truth={truth} upper={upper} exceeds 2x (idx={idx})"
+            );
+            assert!(
+                lower <= truth,
+                "truth={truth} lower={lower} above truth (idx={idx})"
+            );
         }
     }
 
+    /// Adversarial demonstration that the OLD pow-2-from-0 layout
+    /// FAILS the consumer criterion the new layout passes: a true
+    /// 100 ns p50 reads as 1023 ns (>10× error) under the old bucket-0.
     #[test]
-    fn bucket_one_starts_at_1024_ns() {
-        assert_eq!(bucket_index_for_ns_24(1024), 1);
-        assert_eq!(bucket_index_for_ns_24(2047), 1);
-    }
-
-    #[test]
-    fn bucket_two_starts_at_2048_ns() {
-        assert_eq!(bucket_index_for_ns_24(2048), 2);
-        assert_eq!(bucket_index_for_ns_24(4095), 2);
-    }
-
-    #[test]
-    fn bucket_23_saturates_at_2_pow_32_ns() {
-        // Lower edge of bucket 23 is 2^(9+23) = 2^32.
-        assert_eq!(bucket_index_for_ns_24(1u64 << 32), 23);
-        // Upper saturation: anything ≥ 2^32 lands in bucket 23.
-        assert_eq!(bucket_index_for_ns_24(u64::MAX), 23);
-        assert_eq!(bucket_index_for_ns_24(1u64 << 33), 23);
-        assert_eq!(bucket_index_for_ns_24(1u64 << 40), 23);
-    }
-
-    #[test]
-    fn bucket_22_lower_edge_is_2_pow_31_ns() {
-        assert_eq!(bucket_index_for_ns_24(1u64 << 31), 22);
-        assert_eq!(bucket_index_for_ns_24((1u64 << 32) - 1), 22);
-    }
-
-    #[test]
-    fn bucket_formula_matches_existing_16_bucket_below_saturation() {
-        // Sanity: for ns up to 2^23, the 24-bucket formula matches the
-        // 16-bucket bucket_index_for_ns (which clamps at 15). The 16-
-        // bucket fn lives in umem; we re-implement the math here only
-        // to verify equivalence in the shared subrange.
-        for power in 10..=23u32 {
-            let ns = 1u64 << power;
-            let b24 = bucket_index_for_ns_24(ns);
+    fn old_pow2_layout_would_fail_low_end_resolution() {
+        // Re-implement the retired 24-bucket formula inline to prove
+        // the regression it caused.
+        fn old_bucket_index_for_ns_24(ns: u64) -> usize {
             let clz = (ns | 1).leading_zeros() as i32;
-            let b16 = ((54 - clz).max(0) as usize).min(15);
-            // The two formulas agree until the 16-bucket fn clamps.
-            let expected_unclamped = ((54 - clz).max(0) as usize).min(23);
-            assert_eq!(b24, expected_unclamped, "ns=2^{power}");
-            if expected_unclamped < 16 {
-                assert_eq!(b16, b24);
+            let b = (54 - clz).max(0) as usize;
+            b.min(23)
+        }
+        // 50, 100, 150 ns all collapse into old bucket 0 = [0, 1024).
+        assert_eq!(old_bucket_index_for_ns_24(50), 0);
+        assert_eq!(old_bucket_index_for_ns_24(100), 0);
+        assert_eq!(old_bucket_index_for_ns_24(150), 0);
+        // Old bucket-0 upper bound is 1023 ns ⇒ a true 100 ns p50
+        // reads up to 1023 ns: > 10× error. The new layout keeps it
+        // ≤ 2× (covered by bucket_layout_resolves_low_end_within_2x).
+        let old_upper = 1023u64;
+        assert!(old_upper > 100 * 2, "old layout error must exceed 2x");
+        // New layout: 100 ns → bucket 6 → upper 111 ns ⇒ 1.11×.
+        assert_eq!(bucket_index_for_ns_48(100), 6);
+        assert_eq!(bucket_upper_bound_ns_48(6), 111);
+    }
+
+    // === #1635 direct slot map ===
+
+    #[test]
+    fn direct_slot_map_assigns_sequential() {
+        let pairs = [(1u16, 2u16), (3, 4), (5, 6), (7, 8), (9, 10)];
+        let (map, zeroed) = ColdPathSlotMap::build(None, &pairs);
+        assert!(zeroed.is_empty(), "fresh build zeroes nothing");
+        // Sorted/dedup input ⇒ slots assigned 0..5 in pair order.
+        for (i, &(from, to)) in pairs.iter().enumerate() {
+            assert_eq!(lookup_slot(&map, from, to), Some(i as u8), "pair {from}->{to}");
+            assert_eq!(map.inverse[i], Some((from, to)));
+        }
+        assert!(!map.overflow_active);
+    }
+
+    #[test]
+    fn direct_slot_map_no_collisions_at_capacity() {
+        // 255 distinct in-range pairs ⇒ unique slots [0,255), no
+        // overflow. (Slot 255 is reserved as the u8::MAX sentinel.)
+        let mut pairs = Vec::new();
+        'outer: for from in 0u16..8 {
+            for to in 0u16..32 {
+                pairs.push((from, to));
+                if pairs.len() == COLD_PATH_ASSIGNABLE_SLOTS {
+                    break 'outer;
+                }
             }
         }
+        assert_eq!(pairs.len(), 255);
+        let (map, _) = ColdPathSlotMap::build(None, &pairs);
+        assert!(!map.overflow_active);
+        let mut seen = std::collections::HashSet::new();
+        for &(from, to) in &pairs {
+            let s = lookup_slot(&map, from, to).expect("all 255 pairs assigned");
+            assert!(s != u8::MAX, "slot 255 sentinel must never be handed out");
+            assert!(seen.insert(s), "slot {s} assigned twice");
+        }
+        assert_eq!(seen.len(), 255);
     }
 
     #[test]
-    fn splitmix64_avalanche_low_bits_distributes_zone_id_diagonal() {
-        // Copilot code-r3: prior test comment claimed 'should produce
-        // 16 distinct slots' which contradicted the actual >= 8
-        // assertion. Birthday-paradox on 16 uniform throws into 16
-        // bins gives ~10 distinct bins in expectation, never close
-        // to 16. The assertion is a statistical sanity check that
-        // splitmix is roughly uniform; the harness collision detector
-        // (first_key + alias_seen) handles aliasing semantics.
-        let mut slots = std::collections::HashSet::new();
-        for i in 0..16u16 {
-            let s = zone_pair_slot(i, i);
-            slots.insert(s);
+    fn direct_slot_map_overflow_past_capacity() {
+        // 256 in-range pairs: one more than the 255 assignable slots.
+        let mut pairs = Vec::new();
+        'outer: for from in 0u16..16 {
+            for to in 0u16..17 {
+                pairs.push((from, to));
+                if pairs.len() == 256 {
+                    break 'outer;
+                }
+            }
         }
+        assert_eq!(pairs.len(), 256);
+        let (map, _) = ColdPathSlotMap::build(None, &pairs);
         assert!(
-            slots.len() >= 8,
-            "splitmix avalanche too tight: only {} distinct slots out of 16 throws into 16 bins (slots={slots:?})",
-            slots.len()
+            map.overflow_active,
+            "the 256th pair must overflow the 255-slot capacity"
         );
+        // Exactly 255 slots occupied.
+        let occupied = map.inverse.iter().filter(|s| s.is_some()).count();
+        assert_eq!(occupied, 255);
+    }
+
+    #[test]
+    fn direct_slot_map_immediate_reuse_after_removal_zeros_atomics() {
+        // Build A with {(1,2),(3,4)}; record into both.
+        let pairs_a = [(1u16, 2u16), (3, 4)];
+        let (map_a, _) = ColdPathSlotMap::build(None, &pairs_a);
+        let slot_34 = lookup_slot(&map_a, 3, 4).unwrap();
+        // Build B with {(1,2),(5,6)} — drop (3,4), add (5,6).
+        let pairs_b = [(1u16, 2u16), (5, 6)];
+        let (map_b, zeroed) = ColdPathSlotMap::build(Some(&map_a), &pairs_b);
+        // (1,2) retains its slot; (5,6) takes the freed (3,4) slot.
+        assert_eq!(lookup_slot(&map_b, 1, 2), lookup_slot(&map_a, 1, 2));
+        let slot_56 = lookup_slot(&map_b, 5, 6).unwrap();
+        assert_eq!(slot_56, slot_34, "reused freed slot");
+        assert_eq!(lookup_slot(&map_b, 3, 4), None, "(3,4) no longer mapped");
+        // The reused slot is queued for zero-out.
+        assert!(zeroed.contains(&slot_56), "reused slot must be zeroed");
+
+        // Verify zero_slot actually clears local + atomic accumulators.
+        let mut local = WorkerColdPathCounters::default();
+        local.record_sample(slot_34, 3, 4, 5000);
+        assert_eq!(local.samples[slot_34 as usize], 1);
+        local.zero_slot(slot_34 as usize);
+        assert_eq!(local.samples[slot_34 as usize], 0);
+        assert_eq!(local.sum_ns[slot_34 as usize], 0);
+        assert_eq!(local.first_key[slot_34 as usize], 0);
+
+        let atomics = WorkerColdPathAtomics::new();
+        let mut l2 = WorkerColdPathCounters::default();
+        l2.record_sample(slot_34, 3, 4, 5000);
+        atomics.publish_from_local(&l2);
+        atomics.zero_slot(slot_34 as usize);
+        let snap = atomics.snapshot().expect("snapshot");
+        assert_eq!(snap.samples[slot_34 as usize], 0);
+    }
+
+    #[test]
+    fn direct_slot_map_retains_assignment_for_surviving_pairs() {
+        let pairs_a = [(1u16, 2u16), (3, 4), (5, 6)];
+        let (map_a, _) = ColdPathSlotMap::build(None, &pairs_a);
+        // Add a new pair; all original pairs survive.
+        let pairs_b = [(1u16, 2u16), (3, 4), (5, 6), (7, 8)];
+        let (map_b, zeroed) = ColdPathSlotMap::build(Some(&map_a), &pairs_b);
+        for &(from, to) in &pairs_a {
+            assert_eq!(
+                lookup_slot(&map_b, from, to),
+                lookup_slot(&map_a, from, to),
+                "surviving pair {from}->{to} kept its slot"
+            );
+        }
+        // (7,8) takes a fresh slot that was free in A ⇒ no zero-out.
+        assert!(zeroed.is_empty(), "no slot reused ⇒ nothing to zero");
+        assert!(lookup_slot(&map_b, 7, 8).is_some());
+    }
+
+    #[test]
+    fn lookup_slot_returns_none_for_zone_id_ge_32() {
+        let (map, _) = ColdPathSlotMap::build(None, &[(1u16, 2u16)]);
+        assert_eq!(lookup_slot(&map, 33, 2), None);
+        assert_eq!(lookup_slot(&map, 2, 33), None);
+        assert_eq!(lookup_slot(&map, 32, 32), None);
+    }
+
+    #[test]
+    fn lookup_slot_returns_none_for_unmapped_pair() {
+        let (map, _) = ColdPathSlotMap::build(None, &[(1u16, 2u16)]);
+        assert_eq!(lookup_slot(&map, 9, 9), None);
+    }
+
+    #[test]
+    fn build_skips_out_of_range_pairs() {
+        // A pair with a zone-id ≥ 32 is never assigned a slot.
+        let pairs = [(1u16, 2u16), (40, 5), (3, 4)];
+        let (map, _) = ColdPathSlotMap::build(None, &pairs);
+        assert_eq!(lookup_slot(&map, 40, 5), None);
+        // The two in-range pairs still get slots 0 and 1.
+        assert!(lookup_slot(&map, 1, 2).is_some());
+        assert!(lookup_slot(&map, 3, 4).is_some());
+        let occupied = map.inverse.iter().filter(|s| s.is_some()).count();
+        assert_eq!(occupied, 2);
     }
 
     #[test]
@@ -920,115 +1311,57 @@ mod tests {
     #[test]
     fn record_sample_updates_all_fields() {
         let mut c = WorkerColdPathCounters::default();
-        c.record_sample(1, 2, 1500);
-        let slot = zone_pair_slot(1, 2);
-        let bucket = bucket_index_for_ns_24(1500);
-        assert_eq!(c.buckets[slot][bucket], 1);
-        assert_eq!(c.sum_ns[slot], 1500);
-        assert_eq!(c.samples[slot], 1);
-        // v3 alias detector: first sample sets first_key, alias_seen
-        // remains false.
-        assert_eq!(c.first_key[slot], zone_pair_packed_key(1, 2));
-        assert!(!c.alias_seen[slot]);
+        let slot = 0u8;
+        c.record_sample(slot, 1, 2, 1500);
+        let bucket = bucket_index_for_ns_48(1500);
+        assert_eq!(c.buckets[slot as usize][bucket], 1);
+        assert_eq!(c.sum_ns[slot as usize], 1500);
+        assert_eq!(c.samples[slot as usize], 1);
+        // First sample sets first_key, builder_collision stays false.
+        assert_eq!(c.first_key[slot as usize], zone_pair_packed_key(1, 2));
+        assert!(!c.builder_collision[slot as usize]);
     }
 
     #[test]
-    fn record_sample_same_key_twice_no_alias() {
+    fn record_sample_same_key_twice_no_collision() {
         let mut c = WorkerColdPathCounters::default();
-        c.record_sample(1, 2, 100);
-        c.record_sample(1, 2, 100);
-        let slot = zone_pair_slot(1, 2);
-        // Two samples with the same key: first_key set, alias_seen still false.
-        assert_eq!(c.first_key[slot], zone_pair_packed_key(1, 2));
-        assert!(!c.alias_seen[slot]);
-        assert_eq!(c.samples[slot], 2);
+        let slot = 0u8;
+        c.record_sample(slot, 1, 2, 100);
+        c.record_sample(slot, 1, 2, 100);
+        assert_eq!(c.first_key[slot as usize], zone_pair_packed_key(1, 2));
+        assert!(!c.builder_collision[slot as usize]);
+        assert_eq!(c.samples[slot as usize], 2);
     }
 
     #[test]
-    fn record_sample_detects_alias() {
-        // Find two zone-pair keys that hash to the same slot.
-        let mut collisions: Option<((u16, u16), (u16, u16))> = None;
-        'outer: for a_from in 0..256u16 {
-            for a_to in 0..256u16 {
-                if a_from == 0 && a_to == 0 {
-                    continue;
-                }
-                let slot_a = zone_pair_slot(a_from, a_to);
-                for b_from in 0..256u16 {
-                    for b_to in 0..256u16 {
-                        if (b_from, b_to) == (a_from, a_to)
-                            || (b_from == 0 && b_to == 0)
-                        {
-                            continue;
-                        }
-                        if zone_pair_slot(b_from, b_to) == slot_a {
-                            collisions = Some(((a_from, a_to), (b_from, b_to)));
-                            break 'outer;
-                        }
-                    }
-                }
-            }
-        }
-        let ((af, at), (bf, bt)) =
-            collisions.expect("must find a slot collision in 256×256 zone-id subspace");
+    fn record_sample_detects_builder_collision() {
+        // With the direct slot map a slot should only ever see one
+        // zone-pair. If the builder mistakenly maps two pairs to the
+        // same slot, builder_collision must fire — this is a builder
+        // bug detector, not an aliasing gate.
         let mut c = WorkerColdPathCounters::default();
-        c.record_sample(af, at, 100);
-        // first_key set, alias_seen false.
-        let slot = zone_pair_slot(af, at);
-        assert!(!c.alias_seen[slot]);
-        c.record_sample(bf, bt, 200);
-        // alias_seen MUST be true now (different key in same slot).
-        assert!(c.alias_seen[slot], "alias detector must fire on slot collision");
-    }
-
-    #[test]
-    fn record_sample_codex_r2_false_pass_counter_example() {
-        // Codex r2 finding 3: with XOR-rolling, count(K)=odd + count(L)=even
-        // leaves final keys_xor == K, false-passing the gate. v3 first_key
-        // + alias_seen MUST detect this.
-        let mut collisions: Option<((u16, u16), (u16, u16))> = None;
-        'outer: for k_from in 1..32u16 {
-            for k_to in 1..32u16 {
-                let slot_k = zone_pair_slot(k_from, k_to);
-                for l_from in 1..32u16 {
-                    for l_to in 1..32u16 {
-                        if (l_from, l_to) == (k_from, k_to) {
-                            continue;
-                        }
-                        if zone_pair_slot(l_from, l_to) == slot_k {
-                            collisions = Some(((k_from, k_to), (l_from, l_to)));
-                            break 'outer;
-                        }
-                    }
-                }
-            }
-        }
-        let ((kf, kt), (lf, lt)) = collisions.expect("must find K/L collision in 1..32 space");
-        let mut c = WorkerColdPathCounters::default();
-        // count(K) = 3 (odd), count(L) = 2 (even).
-        c.record_sample(kf, kt, 100);
-        c.record_sample(kf, kt, 100);
-        c.record_sample(kf, kt, 100);
-        c.record_sample(lf, lt, 100);
-        c.record_sample(lf, lt, 100);
-        let slot = zone_pair_slot(kf, kt);
-        // v3 alias_seen MUST be true (would have been false-passed by
-        // the retired XOR-rolling design).
-        assert!(c.alias_seen[slot], "alias_seen must fire on Codex r2 false-pass counter-example");
+        let slot = 4u8;
+        c.record_sample(slot, 1, 2, 100);
+        assert!(!c.builder_collision[slot as usize]);
+        c.record_sample(slot, 3, 4, 200); // different key, same slot
+        assert!(
+            c.builder_collision[slot as usize],
+            "builder_collision must fire when two distinct keys share a slot"
+        );
     }
 
     #[test]
     fn snapshot_roundtrip() {
         let atomics = WorkerColdPathAtomics::new();
         let mut local = WorkerColdPathCounters::default();
-        local.record_sample(3, 5, 4000);
-        local.record_sample(3, 5, 8000);
+        let slot = 9u8;
+        local.record_sample(slot, 3, 5, 4000);
+        local.record_sample(slot, 3, 5, 8000);
         atomics.install_calibration(42, 30, ClockSource::Tsc);
         atomics.publish_from_local(&local);
         let snap = atomics.snapshot().expect("single-thread snapshot must succeed");
-        let slot = zone_pair_slot(3, 5);
-        assert_eq!(snap.samples[slot], 2);
-        assert_eq!(snap.sum_ns[slot], 12000);
+        assert_eq!(snap.samples[slot as usize], 2);
+        assert_eq!(snap.sum_ns[slot as usize], 12000);
         assert_eq!(snap.ns_per_tsc_q32, 42);
         assert_eq!(snap.wrapper_ns_baseline, 30);
         assert_eq!(snap.clock_source, ClockSource::Tsc);
@@ -1047,15 +1380,15 @@ mod tests {
     fn snapshot_sequential_publish_roundtrip() {
         let atomics = std::sync::Arc::new(WorkerColdPathAtomics::new());
         let mut local = WorkerColdPathCounters::default();
-        local.record_sample(7, 11, 12345);
+        let slot = 11u8;
+        local.record_sample(slot, 7, 11, 12345);
         atomics.publish_from_local(&local);
         let snap1 = atomics.snapshot().expect("seq snapshot 1 must succeed");
-        local.record_sample(7, 11, 67890);
+        local.record_sample(slot, 7, 11, 67890);
         atomics.publish_from_local(&local);
         let snap2 = atomics.snapshot().expect("seq snapshot 2 must succeed");
-        let slot = zone_pair_slot(7, 11);
-        assert_eq!(snap1.samples[slot], 1);
-        assert_eq!(snap2.samples[slot], 2);
+        assert_eq!(snap1.samples[slot as usize], 1);
+        assert_eq!(snap2.samples[slot as usize], 2);
     }
 
     /// AGY code-r2 finding 2: snapshot() now returns Option. Verify
@@ -1096,7 +1429,7 @@ mod tests {
             let mut local = WorkerColdPathCounters::default();
             let mut count = 0u64;
             while !writer_stop.load(AOrd::Relaxed) {
-                local.record_sample(3, 5, 1000 + (count & 0xff));
+                local.record_sample(5, 3, 5, 1000 + (count & 0xff));
                 writer_atomics.publish_from_local(&local);
                 count += 1;
                 // The production writer publishes at ~1 Hz cadence
@@ -1124,7 +1457,7 @@ mod tests {
         // slot AND cross-field invariants (Codex code-r3 NIT: the
         // weaker oracle would pass even if every snapshot returned
         // default zero after retry-exhaustion).
-        let slot = zone_pair_slot(3, 5);
+        let slot = 5usize;
         let mut last_samples = 0u64;
         let mut max_samples = 0u64;
         let mut at_least_one_observed_increase = false;

--- a/userspace-dp/src/afxdp/cold_path_hist.rs
+++ b/userspace-dp/src/afxdp/cold_path_hist.rs
@@ -73,23 +73,33 @@ pub(in crate::afxdp) const COLD_PATH_ASSIGNABLE_SLOTS: usize =
     POLICY_COLD_PATH_ZONE_PAIR_SLOTS - 1;
 const _: () = assert!(COLD_PATH_ASSIGNABLE_SLOTS == 255);
 
-/// Maximum zone-id (exclusive) the direct slot-map lookup table
-/// indexes. MUST cover the full configurable zone space: the Go
-/// compiler assigns sequential 1-based zone-ids and `MAX_ZONES` is 64
-/// (`bpf/headers/xpf_common.h` + `pkg/dataplane/types.go MaxZones`), so
-/// the ceiling is 64 (Codex code-r1 finding 2: a 32 ceiling silently
-/// dropped valid zone-ids 32-63). Zone-ids are 1..=64, so a 64×64 table
-/// covers every assignable pair. Pairs at/above the ceiling land in
-/// `None` — a defensive guard for the reserved `junos-global` sentinel
-/// (`u16::MAX`), not an expected case.
-pub(in crate::afxdp) const COLD_PATH_ZONE_ID_CEILING: u16 = 64;
-/// Bit-shift for the flat-table row stride = `log2(COLD_PATH_ZONE_ID_CEILING)`.
-const COLD_PATH_ZONE_SHIFT: usize = 6;
-const _: () = assert!(1usize << COLD_PATH_ZONE_SHIFT == COLD_PATH_ZONE_ID_CEILING as usize);
-/// Flat lookup-table length = `CEILING²` = 64×64 = 4096 bytes (L1d-resident).
-const COLD_PATH_FLAT_TABLE_LEN: usize =
-    (COLD_PATH_ZONE_ID_CEILING as usize) * (COLD_PATH_ZONE_ID_CEILING as usize);
-const _: () = assert!(COLD_PATH_FLAT_TABLE_LEN == 4096);
+/// Number of distinct zone-id values the direct slot-map lookup table
+/// indexes. MUST cover the full configurable zone space INCLUSIVELY:
+/// the Go compiler assigns sequential 1-based zone-ids and `MAX_ZONES`
+/// is 64 (`bpf/headers/xpf_common.h` + `pkg/dataplane/types.go
+/// MaxZones`), so the highest assignable id is 64. The table indexes
+/// ids `0..=64` = 65 rows/cols (Copilot code-r2: a ceiling of 64 used
+/// as an EXCLUSIVE bound dropped the valid 64th zone; Codex code-r1: a
+/// ceiling of 32 dropped 32-63). The index is a MULTIPLY
+/// (`from * 65 + to`), not a bit-shift, since 65 is not a power of two.
+/// Pairs with either id ≥ 65 (e.g. the `junos-global` `u16::MAX`
+/// sentinel) land in `None` — a defensive guard, not an expected case.
+pub(in crate::afxdp) const COLD_PATH_ZONE_DIM: usize = 65;
+const _: () = assert!(COLD_PATH_ZONE_DIM == 65);
+/// Flat lookup-table length = `DIM²` = 65×65 = 4225 bytes (L1d-resident).
+const COLD_PATH_FLAT_TABLE_LEN: usize = COLD_PATH_ZONE_DIM * COLD_PATH_ZONE_DIM;
+const _: () = assert!(COLD_PATH_FLAT_TABLE_LEN == 4225);
+
+/// Flat-table index for `(from, to)`; `None` if either id is out of
+/// range (≥ 65). `from * 65 + to` is injective over the in-range box.
+#[inline]
+fn cold_path_flat_index(from: u16, to: u16) -> Option<usize> {
+    let (from, to) = (from as usize, to as usize);
+    if from >= COLD_PATH_ZONE_DIM || to >= COLD_PATH_ZONE_DIM {
+        return None;
+    }
+    Some(from * COLD_PATH_ZONE_DIM + to)
+}
 
 /// Wire/layout version stamped into the status payload (#1635).
 pub(in crate::afxdp) const COLD_PATH_LAYOUT_VERSION: u32 = 3;
@@ -218,13 +228,12 @@ impl ColdPathSlotMap {
         // the previous map (so their accumulated histogram is kept).
         let mut pending: Vec<(u16, u16)> = Vec::with_capacity(pairs.len());
         for &(from, to) in pairs {
-            if from >= COLD_PATH_ZONE_ID_CEILING || to >= COLD_PATH_ZONE_ID_CEILING {
-                // Unrepresentable in the 64×64 table; never assigned a
-                // slot. Defensive (zone-ids are 1..=64); not expected.
+            let Some(idx) = cold_path_flat_index(from, to) else {
+                // Unrepresentable in the 65×65 table (id ≥ 65); never
+                // assigned a slot. Defensive (zone-ids are 1..=64).
                 continue;
-            }
+            };
             let retained = previous.and_then(|p| {
-                let idx = ((from as usize) << COLD_PATH_ZONE_SHIFT) | (to as usize);
                 let s = p.flat_table[idx];
                 if s != u8::MAX && p.inverse[s as usize] == Some((from, to)) {
                     Some(s)
@@ -236,7 +245,7 @@ impl ColdPathSlotMap {
                 Some(s) => {
                     used[s as usize] = true;
                     inverse[s as usize] = Some((from, to));
-                    flat_table[((from as usize) << COLD_PATH_ZONE_SHIFT) | (to as usize)] = s;
+                    flat_table[idx] = s;
                 }
                 None => pending.push((from, to)),
             }
@@ -258,7 +267,11 @@ impl ColdPathSlotMap {
             let s = next_free;
             used[s] = true;
             inverse[s] = Some((from, to));
-            flat_table[((from as usize) << COLD_PATH_ZONE_SHIFT) | (to as usize)] = s as u8;
+            // `from`/`to` are in-range here (only in-range pairs reach
+            // `pending`), so the index is always Some.
+            if let Some(idx) = cold_path_flat_index(from, to) {
+                flat_table[idx] = s as u8;
+            }
             // Queue zero-out for every newly-assigned slot when a
             // PREVIOUS map existed — the worker may have accumulated
             // counts for an earlier pair in this slot during any prior
@@ -282,15 +295,13 @@ impl ColdPathSlotMap {
 }
 
 /// Look up the slot for `(from, to)` in the direct map. Returns `None`
-/// for unmapped pairs (capacity exhausted) or zone-ids ≥ 64. Hot-path
-/// cost: one bound check, one shift, one L1d-resident array index, one
-/// `!= u8::MAX` predicate.
+/// for unmapped pairs (capacity exhausted) or zone-ids ≥ 65. Hot-path
+/// cost: one bound check, one multiply-add, one L1d-resident array
+/// index, one `!= u8::MAX` predicate.
 #[inline]
 pub(in crate::afxdp) fn lookup_slot(map: &ColdPathSlotMap, from: u16, to: u16) -> Option<u8> {
-    if from >= COLD_PATH_ZONE_ID_CEILING || to >= COLD_PATH_ZONE_ID_CEILING {
-        return None;
-    }
-    let entry = map.flat_table[((from as usize) << COLD_PATH_ZONE_SHIFT) | (to as usize)];
+    let idx = cold_path_flat_index(from, to)?;
+    let entry = map.flat_table[idx];
     if entry == u8::MAX {
         None
     } else {
@@ -1253,28 +1264,37 @@ mod tests {
     }
 
     #[test]
-    fn lookup_slot_returns_none_for_zone_id_ge_ceiling() {
-        let (map, _) = ColdPathSlotMap::build(None, &[(1u16, 2u16)]);
-        // Ceiling is 64 (MAX_ZONES). Zone-ids 32-63 are now VALID and
-        // covered by the table (Codex code-r1 finding 2 fix); only
-        // ids >= 64 miss.
-        assert_eq!(lookup_slot(&map, 64, 2), None);
-        assert_eq!(lookup_slot(&map, 2, 64), None);
-        assert_eq!(lookup_slot(&map, 64, 64), None);
+    fn lookup_slot_returns_none_for_zone_id_out_of_range() {
+        // The table indexes ids 0..=64 (DIM=65). Id 65+ (and the
+        // junos-global u16::MAX sentinel) is out of range and misses
+        // even when built — Copilot code-r2: the 64th zone (id 64) must
+        // NOT be treated as out of range.
+        let (map, _) = ColdPathSlotMap::build(None, &[(65u16, 2u16), (1, 2)]);
+        assert_eq!(lookup_slot(&map, 65, 2), None);
+        assert_eq!(lookup_slot(&map, 2, 65), None);
         assert_eq!(lookup_slot(&map, u16::MAX, 1), None);
+        // (1,2) is in-range and was built ⇒ Some.
+        assert!(lookup_slot(&map, 1, 2).is_some());
     }
 
     #[test]
-    fn build_assigns_slots_for_zone_ids_32_to_63() {
-        // Regression for Codex code-r1 finding 2: ids 32-63 were
-        // silently dropped under the old 32 ceiling. They must now get
-        // slots.
-        let pairs = [(32u16, 33u16), (63, 1), (1, 63)];
+    fn build_assigns_slots_for_zone_ids_up_to_64() {
+        // Regression for Codex code-r1 finding 2 (ids 32-63 dropped at
+        // ceiling 32) AND Copilot code-r2 (id 64 dropped at exclusive
+        // ceiling 64). The 1-based MAX_ZONES=64 means the 64th zone has
+        // id 64; it MUST get a slot.
+        let pairs = [(32u16, 33u16), (63, 1), (1, 63), (64, 64), (1, 64), (64, 1)];
         let (map, _) = ColdPathSlotMap::build(None, &pairs);
-        assert!(lookup_slot(&map, 32, 33).is_some());
-        assert!(lookup_slot(&map, 63, 1).is_some());
-        assert!(lookup_slot(&map, 1, 63).is_some());
+        for &(from, to) in &pairs {
+            assert!(
+                lookup_slot(&map, from, to).is_some(),
+                "in-range pair {from}->{to} must get a slot"
+            );
+        }
         assert!(!map.overflow_active);
+        // (64,64) and (1,2)-style pairs must not collide.
+        assert_ne!(lookup_slot(&map, 64, 64), lookup_slot(&map, 1, 64));
+        assert_ne!(lookup_slot(&map, 1, 64), lookup_slot(&map, 64, 1));
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -394,7 +394,13 @@ impl super::Coordinator {
                     // active-slot-only encoding (Vec::is_empty omits an
                     // empty worker's fields, preserving wire-compat with
                     // pre-#1635 Go readers per feedback_wire_protocol_both_sides).
-                    cold_path_layout_version: if has_data {
+                    // Stamp v3 when there is data OR when the slot map
+                    // overflowed (Copilot code-r2: an overflow with no
+                    // samples yet must still route the Go collector to
+                    // the v3 emitter so the overflow gauge is visible —
+                    // version 0 would route to the legacy v1 path and
+                    // hide it).
+                    cold_path_layout_version: if has_data || slot_map.overflow_active {
                         crate::afxdp::cold_path_hist::COLD_PATH_LAYOUT_VERSION
                     } else {
                         0

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -343,6 +343,23 @@ impl super::Coordinator {
                             // tick clears it.
                             continue;
                         };
+                        // Codex code-r1 finding 3: the coordinator
+                        // publishes the new slot-map BEFORE workers
+                        // necessarily load it and zero reused slots, so
+                        // for up to one publish tick the atomics can
+                        // carry the PREVIOUS pair's counts under the
+                        // NEW slot. Validate the recorded first_key
+                        // against the live mapping; on mismatch the
+                        // counts belong to the old pair — skip them
+                        // rather than relabel stale samples as the new
+                        // (from_zone, to_zone).
+                        let expected_key =
+                            crate::afxdp::cold_path_hist::zone_pair_packed_key(from, to);
+                        if cold.first_key[slot] != 0
+                            && cold.first_key[slot] != expected_key
+                        {
+                            continue;
+                        }
                         active_slot_ids.push(slot as u32);
                         active_zone_from.push(from as u32);
                         active_zone_to.push(to as u32);

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -311,15 +311,47 @@ impl super::Coordinator {
                     .map(|c| {
                         c.sample_phase != 0
                             || c.samples.iter().any(|&v| v != 0)
-                            || c.alias_seen.iter().any(|&v| v)
+                            || c.builder_collision.iter().any(|&v| v)
                     })
                     .unwrap_or(false);
                 let cold = cold_opt.unwrap_or_default();
-                let cold_hist: Vec<Vec<u64>> = if has_data {
-                    cold.buckets.iter().map(|row| row.to_vec()).collect()
-                } else {
-                    Vec::new()
-                };
+                // #1635: SPARSE wire encoding. Only slots with a live
+                // zone-pair assignment AND samples > 0 ride the wire.
+                // The slot→(from,to) mapping comes from the per-config
+                // slot map's inverse table; the worker's local buckets
+                // index by slot. A worker that never sampled emits zero
+                // new wire bytes (Vec::is_empty omits the fields).
+                let slot_map = &self.forwarding.cold_path_slot_map;
+                let mut active_slot_ids: Vec<u32> = Vec::new();
+                let mut active_zone_from: Vec<u32> = Vec::new();
+                let mut active_zone_to: Vec<u32> = Vec::new();
+                let mut active_samples: Vec<u64> = Vec::new();
+                let mut active_sum_ns: Vec<u64> = Vec::new();
+                let mut active_buckets: Vec<Vec<u64>> = Vec::new();
+                let mut active_builder_collision: Vec<bool> = Vec::new();
+                if has_data {
+                    for slot in 0..crate::afxdp::cold_path_hist::POLICY_COLD_PATH_ZONE_PAIR_SLOTS {
+                        if cold.samples[slot] == 0 {
+                            continue;
+                        }
+                        let Some((from, to)) =
+                            slot_map.inverse.get(slot).copied().flatten()
+                        else {
+                            // Sampled into a slot with no live mapping
+                            // (config rotated mid-window). Skip — the
+                            // next publish after the worker's zero-out
+                            // tick clears it.
+                            continue;
+                        };
+                        active_slot_ids.push(slot as u32);
+                        active_zone_from.push(from as u32);
+                        active_zone_to.push(to as u32);
+                        active_samples.push(cold.samples[slot]);
+                        active_sum_ns.push(cold.sum_ns[slot]);
+                        active_buckets.push(cold.buckets[slot].to_vec());
+                        active_builder_collision.push(cold.builder_collision[slot]);
+                    }
+                }
                 crate::protocol::WorkerRuntimeStatus {
                     worker_id: *worker_id,
                     tid: handle.runtime_atomics.tid(),
@@ -341,31 +373,23 @@ impl super::Coordinator {
                     wall_ns_60s: w.wall_ns,
                     active_ns_60s: w.active_ns,
                     window_ns: w.window_ns,
-                    // #1621 cold-path histogram fields.
-                    // Vec fields gated on has_data so an uncalibrated
-                    // / never-sampled worker emits ZERO new fields on
-                    // the wire (Copilot code-r1 C2 + C5).
-                    cold_path_hist: cold_hist,
-                    cold_path_sum_ns: if has_data {
-                        cold.sum_ns.to_vec()
+                    // #1635 cold-path histogram fields: SPARSE
+                    // active-slot-only encoding (Vec::is_empty omits an
+                    // empty worker's fields, preserving wire-compat with
+                    // pre-#1635 Go readers per feedback_wire_protocol_both_sides).
+                    cold_path_layout_version: if has_data {
+                        crate::afxdp::cold_path_hist::COLD_PATH_LAYOUT_VERSION
                     } else {
-                        Vec::new()
+                        0
                     },
-                    cold_path_samples: if has_data {
-                        cold.samples.to_vec()
-                    } else {
-                        Vec::new()
-                    },
-                    cold_path_first_key: if has_data {
-                        cold.first_key.to_vec()
-                    } else {
-                        Vec::new()
-                    },
-                    cold_path_alias_seen: if has_data {
-                        cold.alias_seen.to_vec()
-                    } else {
-                        Vec::new()
-                    },
+                    cold_path_active_slot_ids: active_slot_ids,
+                    cold_path_active_zone_from: active_zone_from,
+                    cold_path_active_zone_to: active_zone_to,
+                    cold_path_active_samples: active_samples,
+                    cold_path_active_sum_ns: active_sum_ns,
+                    cold_path_active_buckets: active_buckets,
+                    cold_path_active_builder_collision: active_builder_collision,
+                    cold_path_overflow_active: slot_map.overflow_active,
                     // Scalars: u64_is_zero in serde skips them on
                     // the wire when 0; safe to write the raw value
                     // (clock_source.as_str() returns "" for Unset

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -187,6 +187,19 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     // The Go side validates the mask (powers-of-two minus one, plus
     // explicit --enable-cold-path-1-in-1-sampling for mask=0).
     state.cold_path_sample_mask = snapshot.cold_path_sample_mask.unwrap_or(0xff);
+    // #1635: build the direct cold-path histogram slot map from the
+    // configured policy zone-pairs, reusing the previous map's slot
+    // assignments so retained pairs keep their accumulated histogram.
+    // Slots reassigned to a new pair are queued for zero-out so a reused
+    // slot never carries the previous zone-pair's counts (plan §2.4).
+    {
+        use crate::afxdp::cold_path_hist::ColdPathSlotMap;
+        let pairs = state.policy.configured_zone_pairs();
+        let prev_map = previous.map(|p| p.cold_path_slot_map.as_ref());
+        let (slot_map, slots_to_zero) = ColdPathSlotMap::build(prev_map, &pairs);
+        state.cold_path_slot_map = std::sync::Arc::new(slot_map);
+        state.cold_path_slots_to_zero = slots_to_zero;
+    }
     // Build filter state from snapshot
     state.filter_state = crate::filter::parse_filter_state_with_three_color_preserving(
         &snapshot.filters,

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -190,15 +190,17 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     // #1635: build the direct cold-path histogram slot map from the
     // configured policy zone-pairs, reusing the previous map's slot
     // assignments so retained pairs keep their accumulated histogram.
-    // Slots reassigned to a new pair are queued for zero-out so a reused
-    // slot never carries the previous zone-pair's counts (plan §2.4).
+    // The worker derives its own slot zero-out set by diffing the old
+    // and new map inverses at the ArcSwap point (Copilot code-r2:
+    // generation-independent, unlike a coordinator-computed list), so
+    // the build's `slots_to_zero` return is unused here — only the map
+    // is stored.
     {
         use crate::afxdp::cold_path_hist::ColdPathSlotMap;
         let pairs = state.policy.configured_zone_pairs();
         let prev_map = previous.map(|p| p.cold_path_slot_map.as_ref());
-        let (slot_map, slots_to_zero) = ColdPathSlotMap::build(prev_map, &pairs);
+        let (slot_map, _slots_to_zero) = ColdPathSlotMap::build(prev_map, &pairs);
         state.cold_path_slot_map = std::sync::Arc::new(slot_map);
-        state.cold_path_slots_to_zero = slots_to_zero;
     }
     // Build filter state from snapshot
     state.filter_state = crate::filter::parse_filter_state_with_three_color_preserving(

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1423,11 +1423,24 @@ pub(super) fn poll_binding_process_descriptor(
                                         } else {
                                             raw_ns - baseline
                                         };
-                                        binding.cold_path.record_sample(
-                                            from_zone_id,
-                                            to_zone_id,
-                                            delta_ns,
-                                        );
+                                        // #1635: direct slot map lookup;
+                                        // skip the sample on a miss
+                                        // (capacity exhausted or zone-id
+                                        // ≥ 32).
+                                        if let Some(slot) =
+                                            crate::afxdp::cold_path_hist::lookup_slot(
+                                                &worker_ctx.forwarding.cold_path_slot_map,
+                                                from_zone_id,
+                                                to_zone_id,
+                                            )
+                                        {
+                                            binding.cold_path.record_sample(
+                                                slot,
+                                                from_zone_id,
+                                                to_zone_id,
+                                                delta_ns,
+                                            );
+                                        }
                                     }
                                 }
                                 if let PolicyAction::Permit = policy_result.action {
@@ -2544,11 +2557,24 @@ pub(super) fn poll_binding_process_descriptor(
                                             } else {
                                                 raw_ns - baseline
                                             };
-                                            binding.cold_path.record_sample(
-                                                from_zone_id,
-                                                to_zone_id,
-                                                delta_ns,
-                                            );
+                                            // #1635: direct slot map lookup;
+                                            // skip the sample on a miss.
+                                            if let Some(slot) =
+                                                crate::afxdp::cold_path_hist::lookup_slot(
+                                                    &worker_ctx
+                                                        .forwarding
+                                                        .cold_path_slot_map,
+                                                    from_zone_id,
+                                                    to_zone_id,
+                                                )
+                                            {
+                                                binding.cold_path.record_sample(
+                                                    slot,
+                                                    from_zone_id,
+                                                    to_zone_id,
+                                                    delta_ns,
+                                                );
+                                            }
                                         }
                                     }
                                     if permit {

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1426,7 +1426,7 @@ pub(super) fn poll_binding_process_descriptor(
                                         // #1635: direct slot map lookup;
                                         // skip the sample on a miss
                                         // (capacity exhausted or zone-id
-                                        // ≥ 32).
+                                        // ≥ 65).
                                         if let Some(slot) =
                                             crate::afxdp::cold_path_hist::lookup_slot(
                                                 &worker_ctx.forwarding.cold_path_slot_map,

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -87,11 +87,6 @@ pub(in crate::afxdp) struct ForwardingState {
     /// via `lookup_slot`. Rotated via the ForwardingState ArcSwap.
     pub(in crate::afxdp) cold_path_slot_map:
         std::sync::Arc<crate::afxdp::cold_path_hist::ColdPathSlotMap>,
-    /// #1635 (plan §2.4): slots whose zone-pair assignment CHANGED in
-    /// this build relative to the previous one. The worker zeroes these
-    /// slots' local accumulators on the swap so a reused slot never
-    /// carries the previous pair's counts.
-    pub(in crate::afxdp) cold_path_slots_to_zero: Vec<u8>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -80,6 +80,18 @@ pub(in crate::afxdp) struct ForwardingState {
     /// Default) means "unset" — callers fall back to
     /// `PENDING_NEIGH_TIMEOUT_NS`.
     pub(in crate::afxdp) pending_neigh_timeout_ns: u64,
+    /// #1635: direct `(from_zone_id, to_zone_id) → slot` map for the
+    /// cold-path histogram, built at config apply from the configured
+    /// policy zone-pairs. Replaces the splitmix64 16-slot hash. Shared
+    /// by all bindings on a worker; read on every sampled session-miss
+    /// via `lookup_slot`. Rotated via the ForwardingState ArcSwap.
+    pub(in crate::afxdp) cold_path_slot_map:
+        std::sync::Arc<crate::afxdp::cold_path_hist::ColdPathSlotMap>,
+    /// #1635 (plan §2.4): slots whose zone-pair assignment CHANGED in
+    /// this build relative to the previous one. The worker zeroes these
+    /// slots' local accumulators on the swap so a reused slot never
+    /// carries the previous pair's counts.
+    pub(in crate::afxdp) cold_path_slots_to_zero: Vec<u8>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -368,15 +368,15 @@ pub(crate) fn worker_loop(
                                     [slot][b]
                                     .saturating_add(src.buckets[slot][b]);
                             }
-                            // first_key + alias_seen cross-binding merge.
+                            // first_key + builder_collision cross-binding merge.
                             if merged.first_key[slot] == 0 {
                                 merged.first_key[slot] = src.first_key[slot];
                             } else if src.first_key[slot] != 0
                                 && src.first_key[slot] != merged.first_key[slot]
                             {
-                                merged.alias_seen[slot] = true;
+                                merged.builder_collision[slot] = true;
                             }
-                            merged.alias_seen[slot] |= src.alias_seen[slot];
+                            merged.builder_collision[slot] |= src.builder_collision[slot];
                         }
                     }
                     // All bindings on this worker share the same pinned
@@ -420,6 +420,20 @@ pub(crate) fn worker_loop(
             sessions.set_timeouts(new_forwarding.session_timeouts);
 
             forwarding = new_forwarding;
+            // #1635 (plan §2.4): a config apply may have reassigned
+            // cold-path histogram slots to new zone-pairs. Zero those
+            // slots in every binding's worker-local accumulator BEFORE
+            // any record_sample into the reused slot, so a reused slot
+            // never carries the previous zone-pair's counts. The
+            // sibling atomics are zeroed at the next publish merge (a
+            // freshly-zeroed local accumulator overwrites the published
+            // value), so no separate atomic zero-out is needed here.
+            for &slot in forwarding.cold_path_slots_to_zero.iter() {
+                let slot = slot as usize;
+                for binding in bindings.iter_mut() {
+                    binding.cold_path.zero_slot(slot);
+                }
+            }
             let purged_input_dscp = purge_sessions_for_input_dscp_filter_revalidation(
                 &mut sessions,
                 session_map_fd,

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -419,21 +419,46 @@ pub(crate) fn worker_loop(
             screen_state.update_syn_cookie_master_key(new_forwarding.syn_cookie_master_key);
             sessions.set_timeouts(new_forwarding.session_timeouts);
 
-            forwarding = new_forwarding;
             // #1635 (plan §2.4): a config apply may have reassigned
             // cold-path histogram slots to new zone-pairs. Zero those
             // slots in every binding's worker-local accumulator BEFORE
             // any record_sample into the reused slot, so a reused slot
-            // never carries the previous zone-pair's counts. The
-            // sibling atomics are zeroed at the next publish merge (a
-            // freshly-zeroed local accumulator overwrites the published
-            // value), so no separate atomic zero-out is needed here.
-            for &slot in forwarding.cold_path_slots_to_zero.iter() {
-                let slot = slot as usize;
-                for binding in bindings.iter_mut() {
-                    binding.cold_path.zero_slot(slot);
+            // never carries the previous zone-pair's counts.
+            //
+            // Copilot code-r2: derive the zero-set from THIS WORKER's
+            // OWN old map vs the new map, NOT from the coordinator's
+            // `slots_to_zero` list. A worker can skip intermediate
+            // ForwardingState generations (ArcSwap only ever delivers
+            // the latest), and the coordinator computes `slots_to_zero`
+            // relative to its immediately-previous map — so a slot
+            // reassigned in a skipped generation would be absent from
+            // the latest list (it now looks "retained"). Comparing the
+            // worker's actual old slot-map inverse against the new one
+            // is generation-independent: any slot whose mapping changed
+            // since the worker last observed it gets zeroed. The
+            // sibling atomics are overwritten at the next publish merge
+            // from the freshly-zeroed local accumulator.
+            {
+                let old_inverse = &forwarding.cold_path_slot_map.inverse;
+                let new_inverse = &new_forwarding.cold_path_slot_map.inverse;
+                for slot in 0..crate::afxdp::cold_path_hist::POLICY_COLD_PATH_ZONE_PAIR_SLOTS {
+                    let new_pair = new_inverse.get(slot).copied().flatten();
+                    // Zero when the slot now maps to a pair that differs
+                    // from what the worker last saw there. A freed slot
+                    // (new == None) keeps its stale local data harmlessly
+                    // — it is unmapped, never sampled, and gets zeroed
+                    // when next reassigned.
+                    if new_pair.is_some()
+                        && new_pair != old_inverse.get(slot).copied().flatten()
+                    {
+                        for binding in bindings.iter_mut() {
+                            binding.cold_path.zero_slot(slot);
+                        }
+                    }
                 }
             }
+
+            forwarding = new_forwarding;
             let purged_input_dscp = purge_sessions_for_input_dscp_filter_revalidation(
                 &mut sessions,
                 session_map_fd,

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -440,6 +440,26 @@ impl PolicyState {
             .map(|rule| rule.hit_counter.snapshot(&rule.rule_id))
             .collect()
     }
+
+    /// #1635: the set of concrete `(from_zone_id, to_zone_id)` pairs the
+    /// configured policy distinguishes, used to build the cold-path
+    /// histogram's direct slot map. Returns a deduplicated, sorted Vec
+    /// for deterministic slot assignment. Pairs that reference the
+    /// `junos-global` sentinel zone-id are excluded — global rules don't
+    /// name a concrete zone-pair and would over-broaden the slot map.
+    pub(crate) fn configured_zone_pairs(&self) -> Vec<(u16, u16)> {
+        let mut pairs: Vec<(u16, u16)> = self
+            .zone_pair_index
+            .keys()
+            .map(|&key| (((key >> 16) & 0xffff) as u16, (key & 0xffff) as u16))
+            .filter(|&(from, to)| {
+                from < ZONE_ID_RESERVED_MIN && to < ZONE_ID_RESERVED_MIN
+            })
+            .collect();
+        pairs.sort_unstable();
+        pairs.dedup();
+        pairs
+    }
 }
 
 pub(crate) fn parse_policy_state(

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -136,8 +136,8 @@ pub struct WorkerRuntimeStatus {
             skip_serializing_if = "Vec::is_empty")]
     pub cold_path_active_builder_collision: Vec<bool>,
     /// True if some configured zone-pair could not be assigned a slot
-    /// (256-slot capacity exhausted). Surfaced so operators see when a
-    /// deployment outgrows the static cap.
+    /// (255-slot capacity exhausted; slot 255 is the u8::MAX sentinel).
+    /// Surfaced so operators see when a deployment outgrows the cap.
     #[serde(rename = "cold_path_overflow_active", default,
             skip_serializing_if = "crate::protocol::bool_is_false")]
     pub cold_path_overflow_active: bool,

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -135,9 +135,11 @@ pub struct WorkerRuntimeStatus {
     #[serde(rename = "cold_path_active_builder_collision", default,
             skip_serializing_if = "Vec::is_empty")]
     pub cold_path_active_builder_collision: Vec<bool>,
-    /// True if some configured zone-pair could not be assigned a slot
-    /// (255-slot capacity exhausted; slot 255 is the u8::MAX sentinel).
-    /// Surfaced so operators see when a deployment outgrows the cap.
+    /// True if some configured zone-pair could not be assigned a slot —
+    /// either the 255-slot capacity was exhausted (slot 255 is the
+    /// u8::MAX sentinel) OR the pair references a zone-id outside the
+    /// 0..=64 direct-table range. Surfaced so operators see when a
+    /// configured pair goes unmeasured.
     #[serde(rename = "cold_path_overflow_active", default,
             skip_serializing_if = "crate::protocol::bool_is_false")]
     pub cold_path_overflow_active: bool,

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -94,27 +94,53 @@ pub struct WorkerRuntimeStatus {
     // sum (buckets/sum_ns/samples/sample_phase/underflow_count) OR OR
     // (alias_seen) or first-non-zero (first_key) merge performed at
     // the publish tick. Per #1621 plan v1 §4.2.
-    /// Per-slot per-bucket histogram. Shape [16 zone-pair slots][24 ns buckets].
-    #[serde(rename = "cold_path_hist", default,
+    /// #1635 wire layout version. 0/absent = pre-#1635 (old dense v1
+    /// fields, no longer emitted by this daemon); 3 = sparse
+    /// active-slot encoding below. Go switches emission on this.
+    #[serde(rename = "cold_path_layout_version", default,
+            skip_serializing_if = "crate::protocol::u32_is_zero")]
+    pub cold_path_layout_version: u32,
+    /// #1635 SPARSE encoding — parallel arrays, one entry per ACTIVE
+    /// zone-pair slot (samples > 0 AND a live slot-map assignment).
+    /// Empty when the worker has never sampled, so its wire payload is
+    /// byte-identical to a pre-#1635 daemon (forward-compat with old Go
+    /// readers, per feedback_wire_protocol_both_sides).
+    ///
+    /// Slot index (for cross-reference / debugging).
+    #[serde(rename = "cold_path_active_slot_ids", default,
             skip_serializing_if = "Vec::is_empty")]
-    pub cold_path_hist: Vec<Vec<u64>>,
-    /// Per-slot sum of sampled delta_ns. Shape [16].
-    #[serde(rename = "cold_path_sum_ns", default,
+    pub cold_path_active_slot_ids: Vec<u32>,
+    /// Parallel: from_zone_id per active slot.
+    #[serde(rename = "cold_path_active_zone_from", default,
             skip_serializing_if = "Vec::is_empty")]
-    pub cold_path_sum_ns: Vec<u64>,
-    /// Per-slot sample count. Shape [16].
-    #[serde(rename = "cold_path_samples", default,
+    pub cold_path_active_zone_from: Vec<u32>,
+    /// Parallel: to_zone_id per active slot.
+    #[serde(rename = "cold_path_active_zone_to", default,
             skip_serializing_if = "Vec::is_empty")]
-    pub cold_path_samples: Vec<u64>,
-    /// Per-slot first packed (from_zone, to_zone) key. 0 = no sample.
-    /// Used by the harness §3.4 cross-worker key-set check. Shape [16].
-    #[serde(rename = "cold_path_first_key", default,
+    pub cold_path_active_zone_to: Vec<u32>,
+    /// Parallel: sample count per active slot.
+    #[serde(rename = "cold_path_active_samples", default,
             skip_serializing_if = "Vec::is_empty")]
-    pub cold_path_first_key: Vec<u64>,
-    /// Per-slot alias-detected flag. Shape [16].
-    #[serde(rename = "cold_path_alias_seen", default,
+    pub cold_path_active_samples: Vec<u64>,
+    /// Parallel: sum of sampled delta_ns per active slot.
+    #[serde(rename = "cold_path_active_sum_ns", default,
             skip_serializing_if = "Vec::is_empty")]
-    pub cold_path_alias_seen: Vec<bool>,
+    pub cold_path_active_sum_ns: Vec<u64>,
+    /// Parallel: 48-bucket histogram per active slot.
+    #[serde(rename = "cold_path_active_buckets", default,
+            skip_serializing_if = "Vec::is_empty")]
+    pub cold_path_active_buckets: Vec<Vec<u64>>,
+    /// Parallel: builder-collision flag per active slot (should always
+    /// be false with the direct slot map; true = builder bug).
+    #[serde(rename = "cold_path_active_builder_collision", default,
+            skip_serializing_if = "Vec::is_empty")]
+    pub cold_path_active_builder_collision: Vec<bool>,
+    /// True if some configured zone-pair could not be assigned a slot
+    /// (256-slot capacity exhausted). Surfaced so operators see when a
+    /// deployment outgrows the static cap.
+    #[serde(rename = "cold_path_overflow_active", default,
+            skip_serializing_if = "crate::protocol::bool_is_false")]
+    pub cold_path_overflow_active: bool,
     /// Per-worker monotonic count of eligible cold-path sampling
     /// attempts (incremented on every session-miss pass). Used by the
     /// #1622 harness as the denominator for actual_sampling_rate =
@@ -182,6 +208,14 @@ pub(crate) struct HAGroupStatus {
 
 pub(crate) fn u64_is_zero(value: &u64) -> bool {
     *value == 0
+}
+
+pub(crate) fn u32_is_zero(value: &u32) -> bool {
+    *value == 0
+}
+
+pub(crate) fn bool_is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -87,11 +87,16 @@ fn worker_runtime_status_cold_path_fields_roundtrip_default_omitted() {
     // default (uncalibrated) worker. This pins the wire-invariant
     // contract that pre-#1621 daemons see byte-identical payloads.
     let cold_keys = [
-        "cold_path_hist",
-        "cold_path_sum_ns",
-        "cold_path_samples",
-        "cold_path_first_key",
-        "cold_path_alias_seen",
+        // #1635 sparse v3 fields.
+        "cold_path_layout_version",
+        "cold_path_active_slot_ids",
+        "cold_path_active_zone_from",
+        "cold_path_active_zone_to",
+        "cold_path_active_samples",
+        "cold_path_active_sum_ns",
+        "cold_path_active_buckets",
+        "cold_path_active_builder_collision",
+        "cold_path_overflow_active",
         "cold_path_sample_phase",
         "cold_path_wrapper_underflow_count",
         "cold_path_ns_per_tsc_q32",
@@ -113,25 +118,30 @@ fn worker_runtime_status_cold_path_fields_roundtrip_default_omitted() {
 
 #[test]
 fn worker_runtime_status_cold_path_fields_roundtrip_populated() {
-    let mut hist = vec![vec![0u64; 24]; 16];
-    hist[3][5] = 42;
-    hist[3][6] = 100;
-    let mut sum_ns = vec![0u64; 16];
-    sum_ns[3] = 12345;
-    let mut samples = vec![0u64; 16];
-    samples[3] = 142;
-    let mut first_key = vec![0u64; 16];
-    first_key[3] = 0x1234;
-    let mut alias_seen = vec![false; 16];
-    alias_seen[7] = true;
+    // #1635 sparse v3 encoding: two active zone-pair slots.
+    let buckets_a = {
+        let mut b = vec![0u64; 48];
+        b[5] = 42;
+        b[6] = 100;
+        b
+    };
+    let buckets_b = {
+        let mut b = vec![0u64; 48];
+        b[0] = 7;
+        b
+    };
 
     let status = WorkerRuntimeStatus {
         worker_id: 2,
-        cold_path_hist: hist.clone(),
-        cold_path_sum_ns: sum_ns.clone(),
-        cold_path_samples: samples.clone(),
-        cold_path_first_key: first_key.clone(),
-        cold_path_alias_seen: alias_seen.clone(),
+        cold_path_layout_version: 3,
+        cold_path_active_slot_ids: vec![0, 5],
+        cold_path_active_zone_from: vec![1, 2],
+        cold_path_active_zone_to: vec![3, 4],
+        cold_path_active_samples: vec![142, 7],
+        cold_path_active_sum_ns: vec![12345, 700],
+        cold_path_active_buckets: vec![buckets_a.clone(), buckets_b.clone()],
+        cold_path_active_builder_collision: vec![false, false],
+        cold_path_overflow_active: true,
         cold_path_sample_phase: 50_000,
         cold_path_wrapper_underflow_count: 3,
         cold_path_ns_per_tsc_q32: 1_871_674_289,
@@ -143,22 +153,29 @@ fn worker_runtime_status_cold_path_fields_roundtrip_populated() {
     let value: serde_json::Value =
         serde_json::to_value(&status).expect("serialize populated");
     // Spot-check a few fields are present + correctly nested.
+    assert_eq!(value["cold_path_layout_version"], 3);
     assert_eq!(value["cold_path_sample_phase"], 50_000);
     assert_eq!(value["cold_path_clock_source"], "tsc");
     assert_eq!(value["cold_path_snapshot_failed"], 2);
-    assert_eq!(value["cold_path_hist"][3][5], 42);
-    assert_eq!(value["cold_path_hist"][3][6], 100);
-    assert_eq!(value["cold_path_samples"][3], 142);
-    assert_eq!(value["cold_path_alias_seen"][7], true);
+    assert_eq!(value["cold_path_active_zone_from"][0], 1);
+    assert_eq!(value["cold_path_active_zone_to"][1], 4);
+    assert_eq!(value["cold_path_active_samples"][0], 142);
+    assert_eq!(value["cold_path_active_buckets"][0][5], 42);
+    assert_eq!(value["cold_path_active_buckets"][0][6], 100);
+    assert_eq!(value["cold_path_overflow_active"], true);
 
     // Round-trip back.
     let back: WorkerRuntimeStatus =
         serde_json::from_value(value).expect("deserialize");
-    assert_eq!(back.cold_path_hist, hist);
-    assert_eq!(back.cold_path_sum_ns, sum_ns);
-    assert_eq!(back.cold_path_samples, samples);
-    assert_eq!(back.cold_path_first_key, first_key);
-    assert_eq!(back.cold_path_alias_seen, alias_seen);
+    assert_eq!(back.cold_path_layout_version, 3);
+    assert_eq!(back.cold_path_active_slot_ids, vec![0, 5]);
+    assert_eq!(back.cold_path_active_zone_from, vec![1, 2]);
+    assert_eq!(back.cold_path_active_zone_to, vec![3, 4]);
+    assert_eq!(back.cold_path_active_samples, vec![142, 7]);
+    assert_eq!(back.cold_path_active_sum_ns, vec![12345, 700]);
+    assert_eq!(back.cold_path_active_buckets, vec![buckets_a, buckets_b]);
+    assert_eq!(back.cold_path_active_builder_collision, vec![false, false]);
+    assert!(back.cold_path_overflow_active);
     assert_eq!(back.cold_path_sample_phase, 50_000);
     assert_eq!(back.cold_path_wrapper_underflow_count, 3);
     assert_eq!(back.cold_path_ns_per_tsc_q32, 1_871_674_289);


### PR DESCRIPTION
## Summary

Redesigns the #1619/#1621 cold-path latency histogram foundation so the #1612 Scale Target tables (and the #1622 measurement consumer) can publish trustworthy numbers. Implements the merged PLAN-READY v3 plan (`docs/pr/1635-cold-path-hist-redesign/plan.md`, shipped via #1637). Fixes the three structural defects that PLAN-KILLed #1622, plus follow-up correctness gaps found in review around zone-id coverage, generation-skipping slot reuse, overflow-only status emission, and sparse-v3 wire-test coverage.

## The three #1622 PLAN-KILL findings, fixed

- **F1 bucket-0 resolution floor** → 48-bucket **log-linear** layout: 32 linear 16-ns buckets over `[0,512)` ns + 15 pow-2 buckets over `[512,2^24)` ns + 1 saturate. A true ~100 ns p50 reads within 2× (bucket upper bound 111 ns) instead of the old bucket-0 1023-ns midpoint (&gt;10× error).
- **F2 16-slot splitmix collision bias** → **direct** `(from_zone_id, to_zone_id) → slot` map (`ColdPathSlotMap`, 255 assignable slots, `u8::MAX` reserved as lookup sentinel) built at config apply from configured policy zone-pairs. The table now covers zone-ids `0..=64` with a 65×65 direct index (`from * 65 + to`); retained pairs keep their slot + histogram, and reused slots are zeroed from the worker's own old→new map diff before reuse.
- **F3 bimodal aggregate corruption** → **sparse per-zone-pair** wire surface (parallel active-slot arrays + `builder_collision`, renamed from `alias_seen`). Every active pair is a separable distribution; no collision-exclusion artifact.

## Consumer success criteria (evaluated, not just internal correctness)

- **≤2× per-bucket error @ 10/100/1K/10K rule counts** — `bucket_layout_resolves_low_end_within_2x` + `old_pow2_layout_would_fail_low_end_resolution` (fail-before/pass-after vs the retired 24-bucket layout).
- **20-zone-pair separability, no alias exclusion** — Go `TestEmitWorkerColdPath_V3_TwentyZonePairsSeparable` (20 distinct series) + `..._SparseEmitsOnlyActiveSlots`.
- **Real per-zone-pair percentiles** — `from_zone`/`to_zone` labels on the v3 families; aggregation is the operator's PromQL choice.
- **O(1) hot-path, no per-packet alloc** — `lookup_slot` is bound-check + multiply + array index + `!= u8::MAX`; `record_sample` takes the precomputed slot.

## Wire protocol (both sides, per feedback_wire_protocol_both_sides)

- Rust `protocol/binding.rs`: `cold_path_layout_version=3` + `cold_path_active_*` + `cold_path_overflow_active`.
- Go `protocol.go`: mirrored; legacy dense v1 fields retained **read-only** so a new collector still emits correct v1 metrics against a pre-#1635 Rust daemon (plan §3.2 row "v1 Rust / v3 Go"). Go emitter branches v1 / v3 / unknown-version, and overflow-only payloads now stamp v3 so the sparse overflow gauge is visible even before any samples arrive.
- Go protocol tests now pin the sparse v3 serde/json field names with a Rust-shaped decode + re-encode round-trip test.

## Implementation deviations (documented in plan §IMPL)

1. Capacity is **255 assignable** (slot 255 = `u8::MAX` sentinel), not literally 256.
2. `from_zone`/`to_zone` labels carry **zone-ids**, not names (avoids plumbing a zone-name table to the collector; satisfies separability).
3. §5.5 TSC-injection accuracy harness realized as **deterministic unit tests** proving the same ≤2× criterion.

## Test plan

- [x] cargo build clean; clippy clean on changed files (pre-existing `umem/mmap.rs` lint unrelated)
- [x] 1610 Rust unit tests pass
- [x] 39 `cold_path` tests — 5/5 flake clean
- [x] Go `pkg/api` + `pkg/dataplane/userspace` + `pkg/daemon` pass
- [ ] Cluster smoke — see PR comment (argued not required; measurement/cold-path code validated by unit tests)

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>