### PR TITLE
userspace: gate BPF READY write on binding.Ready && !Dead (#1666)

### DIFF
--- a/docs/pr/1666-ready-gate/plan.md
+++ b/docs/pr/1666-ready-gate/plan.md
@@ -1,0 +1,288 @@
+# #1666 — Gate the BPF READY write on helper-reported binding liveness
+
+**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY +
+Claude SMR). PLAN-KILL is an acceptable verdict and is explicitly on
+the table for this work (see §11).
+
+## 1. Issue framing
+
+`pkg/dataplane/userspace/maps_sync.go` writes the `userspace_bindings`
+BPF-array READY flag (`userspaceBindingReady = 1`) at four sites. The
+flag is what the `userspace-xdp` shim checks to decide whether to steer
+a packet into the AF_XDP socket for a given (ifindex, queue) slot. The
+issue's hypothesis: two of those sites mark a binding forwarding-ready
+on `Registered && Armed` alone, *without* gating on the helper-reported
+`Bound`/`XSKRegistered`/`Ready` liveness. If a worker crashes (panics)
+or never finishes XSK registration, the control plane can keep
+advertising the slot as forwarding-ready while no worker drains its RX
+ring — transit packets steer to a socket nobody is servicing and are
+silently dropped. The issue calls this a "crash-blind blackhole" and
+proposes gating the READY write on `binding.Ready && XSKRegistered`.
+
+## 2. The four sites (verified against current master, 3f47f0b33)
+
+Issue cited lines 596/634/1101/1147; verified exact behaviour:
+
+| # | Location | Current gate | Path |
+|---|----------|--------------|------|
+| 1 | `applyHelperStatusLocked`, maps_sync.go:596–602 | `Registered && Armed` (NOT Bound) — has an explicit anti-deadlock comment | primary per-binding apply |
+| 2 | `applyHelperStatusLocked`, maps_sync.go:633–635 | `Registered && Armed && Bound` | VLAN-alias child apply |
+| 3 | `verifyBindingsMapLocked` (watchdog), maps_sync.go:1076 + 1101 | `Registered && Armed` (NOT Bound) | primary stale-entry repair |
+| 4 | `verifyBindingsMapLocked` (watchdog), maps_sync.go:1122 + 1147 | `Registered && Armed && Bound` | VLAN-alias stale-entry repair |
+
+**Asymmetry already in the tree:** the alias sites (2, 4) already gate
+on `Bound`; the primary sites (1, 3) deliberately do not, with the
+comment at 597–601 claiming a chicken-and-egg if `Bound` is required.
+
+## 3. The READY field is already strictly stronger than the proposal
+
+`binding.Ready` is **derived**, not helper-asserted. In
+`userspace-dp/src/afxdp/coordinator/refresh_bindings.rs:225`:
+
+```rust
+binding.ready = binding.registered
+    && binding.bound
+    && binding.xsk_registered
+    && heartbeat_fresh(snap.last_heartbeat);
+```
+
+Consequences:
+
+- `Ready` already implies `Bound` **and** `XSKRegistered` **and** a
+  fresh heartbeat. The issue's proposed `Ready && XSKRegistered` is
+  redundant — `Ready` alone is the right and complete gate. The plan
+  uses **`binding.Ready`** as the single gate at all four sites.
+- Gating sites 1/3 on `Ready` is strictly more conservative than the
+  current `Registered && Armed`, and strictly more conservative than
+  the alias sites' `Registered && Armed && Bound` (it adds
+  `xsk_registered` + heartbeat freshness on top of `Bound`).
+
+## 4. Deadlock analysis (Open question #1 — the gating risk)
+
+The hard question: does gating the binding-array READY on `binding.Ready`
+withhold READY from a legitimately-live binding, given that `Ready`
+requires `Bound`/`XSKRegistered`, and the shim must steer packets for
+RX to flow?
+
+### 4.1 When do Bound / XSKRegistered / heartbeat flip true?
+
+Traced through the worker bringup, **all three become true from worker
+bringup alone, with no dependency on inbound packets**:
+
+- `bound`: set in `BindingWorker::new` immediately after
+  `open_binding_worker_rings` returns — `live.set_bound(user_fd)` at
+  `worker/mod.rs:328`. Socket creation only; no RX.
+- `xsk_registered`: set in `register_binding_xsk` →
+  `live.set_xsk_registered(true)` at `worker/mod.rs:746`, called from
+  `worker_loop` bringup at `worker/mod.rs:472` (and the shared-UMEM path
+  at :950) **before** the RX poll loop. This is the syscall that inserts
+  the socket FD into the XSKMAP — i.e. it is itself the precondition for
+  the kernel to deliver to the socket, and it happens unconditionally.
+- heartbeat: touched once at init (`worker/mod.rs:355`) and then at the
+  top of **every** `poll_binding` iteration via `maybe_touch_heartbeat`
+  (`worker/lifecycle.rs:57`), before the RX batch loop. `heartbeat_fresh`
+  (`bpf_map/mod.rs:209`) is true within `HEARTBEAT_STALE_AFTER` (5s) of
+  the last touch.
+
+The chronology for a healthy worker is therefore:
+
+```
+spawn worker thread
+  → open rings           → set_bound(true)
+  → register_binding_xsk → set_xsk_registered(true)   [FD now in XSKMAP]
+  → enter poll loop      → maybe_touch_heartbeat (every tick)
+next coordinator status poll → refresh_bindings → ready = true
+```
+
+`ready` flips true after roughly one helper status-poll cycle following
+worker spawn, with **zero dependency on RX traffic**. This is exactly the
+#1648 Gate-B research finding that **refutes** the maps_sync.go:597
+"Bound never becomes true" comment.
+
+### 4.2 Does the shim/liveness probe deadlock?
+
+The ctrl-enable + liveness probe (`maps_sync.go:340–457`) gates
+`ctrl.Enabled = 1` on `probeBindingsReady` = `Registered && Armed`
+(NOT Bound, NOT Ready). So:
+
+1. ctrl enables and the shim is swapped in as soon as `Registered &&
+   Armed` — **unchanged by this plan** (we touch only the binding-array
+   READY write, not the ctrl gate).
+2. Worker bringup independently flips `Ready` true (per §4.1) within a
+   poll cycle.
+3. Once `Ready`, the binding-array READY flag is written → shim steers
+   RX into XSK → `xskReceiveLive` → `xskLivenessProven`.
+
+No circular dependency: `Ready` does not require the binding-array flag
+to be set first; it requires only that the worker completed its own
+bringup syscalls. **No deadlock for the steady-state bringup path.**
+
+### 4.3 The one genuine behavioural change — a narrow startup window
+
+There is a real, narrow window where behaviour changes: between
+"ctrl enabled (`Registered && Armed`)" and "worker finished bringup
+(`Ready` true)". Today site 1 writes READY=1 the instant `Registered &&
+Armed`. Under the gate, the binding-array flag stays 0 until `Ready`,
+i.e. until the worker has (a) created the socket, (b) registered the FD
+in XSKMAP, and (c) had one heartbeat-fresh poll cycle observed by the
+coordinator status path.
+
+- **Lower bound today:** READY=1 may be written ~1 poll cycle before the
+  socket can actually receive (FD not yet in XSKMAP). In that sub-window
+  today's behaviour is itself a micro-blackhole — the shim steers to a
+  slot whose FD isn't in the XSKMAP. The gate *removes* that sub-window.
+- **Upper bound under the gate:** READY is withheld until `xsk_registered`
+  + one fresh heartbeat are observed — bounded by worker bringup latency
+  + one helper status-poll interval (sub-second in practice). It cannot
+  be withheld forever for a legitimately-live binding because none of the
+  three sub-conditions depend on the flag.
+
+This window is the crux reviewers must weigh: it is **strictly safer**
+(READY now means "a worker can actually receive"), at the cost of a
+sub-second-longer "transit fail-closed" startup window. Because transit
+is *already* fail-closed until `xskLivenessProven` (which itself needs
+RX, which needs the flag), the practical net change to first-transit
+latency is near zero — the flag must be set before RX can be proven
+either way.
+
+## 5. Crash-detection → READY-clear (Open question #3)
+
+The blackhole the issue targets is the **mid-life** crash: a worker that
+was Ready, then panics. This plan must define how READY is *cleared*, not
+just gated at write time.
+
+**An existing signal already drives the clear — no new mechanism needed:**
+
+1. On panic, `spawn_supervised_worker` (`coordinator/supervisor.rs:98`)
+   catches the unwind, sets `runtime_atomics.dead = true`, and the
+   thread exits. The worker stops calling `maybe_touch_heartbeat`.
+2. The `live` `BindingLiveState` Arc **stays** in `coord.workers.live`
+   (it is removed only on explicit reconcile/reset, not on panic). So
+   `refresh_bindings` keeps taking `live.snapshot()`, which now returns
+   the last-written `bound=true`, `xsk_registered=true`, and a
+   **frozen** `last_heartbeat`.
+3. Within `HEARTBEAT_STALE_AFTER` (5s) of the worker's last poll tick,
+   `heartbeat_fresh(snap.last_heartbeat)` returns false →
+   `binding.ready = false` (refresh_bindings.rs:228).
+4. The next `applyHelperStatusLocked` / watchdog pass (site 1/3) then
+   writes flags=0 for that slot — **READY cleared**, blackhole closed,
+   within ≤5s + one poll cycle.
+
+Without this plan, sites 1/3 key on `Registered && Armed`, which is set
+in the binding handler and is **never cleared on worker panic** — so the
+flag stays 1 forever after a crash. That permanent-vs-bounded difference
+is the entire correctness win.
+
+Caveat to surface for review: the explicit rebind/stop_workers handlers
+(`server/handlers/rebind.rs`, `stop_workers.rs`,
+`coordinator/reconcile/reset.rs`) already clear `ready=false`
+synchronously, so orchestrated teardown clears the flag immediately;
+only an *unorchestrated panic with no respawn* relies on the 5s
+heartbeat-staleness path. (#925 explicitly deferred worker respawn.)
+
+## 6. Concrete design
+
+Single-line gate change at each of the four sites — replace the
+liveness predicate with `binding.Ready`:
+
+- **Site 1** (maps_sync.go:596): `if binding.Registered && binding.Armed`
+  → `if binding.Ready`. Replace the now-stale anti-deadlock comment with
+  a comment documenting the #1648/#1666 finding (Ready already implies
+  bound+xsk_registered+heartbeat-fresh; this is the crash-clear gate).
+- **Site 2** (maps_sync.go:633): `if binding.Registered && binding.Armed
+  && binding.Bound` → `if binding.Ready`. Tightens (adds xsk_registered
+  + heartbeat) and unifies with site 1.
+- **Site 3** (maps_sync.go:1076 guard): `if !binding.Registered ||
+  !binding.Armed { continue }` → `if !binding.Ready { continue }`. The
+  flag literal at :1101 is unchanged.
+- **Site 4** (maps_sync.go:1122 guard): `if !binding.Registered ||
+  !binding.Armed || !binding.Bound { continue }` → `if !binding.Ready {
+  continue }`.
+
+No new fields, no protocol change, no Rust change. The gate reuses the
+already-shipped, already-wire-exposed `BindingStatus.Ready`.
+
+## 7. Public API preservation
+
+No exported signatures change. `userspaceBindingReady` constant, map
+layout, `BindingStatus` wire shape — all unchanged. This is purely the
+Go control plane choosing a stronger predicate before an existing map
+write.
+
+## 8. Hidden invariants the change must preserve
+
+- **Fail-closed bringup (Open question #2):** the change only ever makes
+  the binding-array flag *harder* to set (never easier). It cannot weaken
+  fail-closed; worst case it withholds READY slightly longer (§4.3). The
+  ctrl-enable path and `drop_degraded_transit`/W-CTRL guard at
+  `lib.rs` are untouched.
+- **Liveness probe still terminates:** the probe needs RX to flow, which
+  needs the flag, which now needs `Ready`. Since `Ready` is reached from
+  bringup alone (§4.1), the probe still reaches its RX-flowing state; the
+  60s hard-timeout fallback (maps_sync.go:449) remains as the backstop.
+- **Watchdog semantics:** site 3/4 repair only rewrites entries the
+  helper reports live; tightening to `Ready` means the watchdog will no
+  longer "repair" (re-assert READY for) a slot whose worker has died —
+  which is precisely the desired blackhole-clear, not a regression.
+- **Idle standby (`shouldAutoProveIdleStandbyXSKLocked`):** uses
+  `allBindingsBound`, not the binding-array flag; unaffected.
+
+## 9. Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioural regression | LOW–MED | Only change is the §4.3 sub-second startup window; transit is already fail-closed there. Reviewer judgement needed on whether that window is acceptable. |
+| Lifetime / borrow | N/A | Go-side predicate swap; no Rust change. |
+| Performance | NONE | One bool read replaces two/three bool reads per binding per poll. |
+| Architectural mismatch | LOW | Reuses shipped `Ready` derivation; no new abstraction. The risk is that the issue is solving an already-mitigated problem (Open question #2). |
+
+## 10. Test plan
+
+- `go build ./...`, `go test ./...` (note: `pkg/dataplane/userspace`
+  socket tests need `TMPDIR=/tmp` for the <108-char sun_path artifact).
+- **Existing test update:** `TestNotifyLinkCycleRebindsAndAppliesHelper
+  StatusCompat` (link_cycle_test.go:97) seeds `Registered/Armed/Bound`
+  but `Ready:false, XSKRegistered:false` and asserts the array flag ==
+  `userspaceBindingReady`. Under the gate this fixture must set
+  `Ready:true` to remain a genuinely-live binding. This is a correct
+  fixture fix, and demonstrates the gate is exercised.
+- **New unit tests:**
+  - READY withheld when `Registered && Armed` but `!Ready` (e.g.
+    `XSKRegistered:false`) → array flag stays 0 at site 1.
+  - READY written when `Ready:true` → array flag == `userspaceBindingReady`.
+  - Watchdog (site 3) does NOT repair/re-assert a slot with `!Ready`.
+  - Crash-clear: a binding that was Ready then reports `Ready:false`
+    (heartbeat-stale proxy) → next apply writes flags=0.
+- **`make test-failover` — HARD GATE** (touches HA forwarding-ready
+  path). VRRP ~60ms, zero-drop failover.
+- **Full smoke matrix** on loss userspace cluster: v4+v6 × push+reverse ×
+  CoS-off/CoS-on, per-class 5201-5206.
+- **No-deadlock proof:** confirm a normal bringup reaches READY promptly
+  (cluster comes up, traffic flows) and a simulated XSK-unregistered
+  binding does not get READY.
+
+## 11. PLAN-KILL criteria (explicitly on the table)
+
+Kill this plan if any reviewer establishes:
+
+- **(a)** A path where `Ready` is permanently withheld from a
+  legitimately-live binding (a real deadlock, not the bounded §4.3
+  window). Would be worse than the blackhole. *Current analysis: no such
+  path — see §4.1/4.2.*
+- **(b)** The blackhole is already fully mitigated elsewhere (e.g. the
+  watchdog already clears it, or `drop_degraded_transit`/liveness already
+  fails the slot closed on worker death) such that the §4.3 startup-window
+  cost buys nothing. *This is the strongest kill candidate — Open
+  question #2. Reviewers must verify whether a dead worker's slot is
+  already driven READY=0 by some other existing mechanism within a
+  comparable window.*
+- **(c)** The 5s heartbeat-staleness crash-clear is too slow to matter
+  and no faster signal exists, making the "mid-life crash" half of the
+  win illusory while the startup window is a real (if small) cost.
+
+## 12. Out of scope
+
+- Worker respawn after panic (#925 deferred indefinitely).
+- Any faster-than-heartbeat crash-detection signal (would be a separate
+  issue if 5s proves too slow).
+- Touching the ctrl-enable / liveness-probe gates themselves.

--- a/docs/pr/1666-ready-gate/plan.md
+++ b/docs/pr/1666-ready-gate/plan.md
@@ -51,14 +51,19 @@ binding.ready = binding.registered
 
 Consequences:
 
-- `Ready` already implies `Bound` **and** `XSKRegistered` **and** a
+- `Ready` already implies `Registered`, `Bound`, `XSKRegistered`, and a
   fresh heartbeat. The issue's proposed `Ready && XSKRegistered` is
-  redundant — `Ready` alone is the right and complete gate. The plan
-  uses **`binding.Ready`** as the single gate at all four sites.
-- Gating sites 1/3 on `Ready` is strictly more conservative than the
-  current `Registered && Armed`, and strictly more conservative than
-  the alias sites' `Registered && Armed && Bound` (it adds
-  `xsk_registered` + heartbeat freshness on top of `Bound`).
+  redundant in the XSKRegistered leg.
+- **But `Ready` does NOT imply `Armed`** (Codex round-2 finding). The
+  Rust derivation omits `armed`; `armed = armed_req && registered` is a
+  separate control-plane flag (server/handlers/binding.rs:29). A
+  Ready-but-disarmed binding (control plane disarmed it while it is
+  otherwise live) must NOT forward, and the historical sites required
+  `Armed`. So the gate must keep `Registered && Armed` AND add `Ready`
+  — it is **`Registered && Armed && Ready && !Dead`**, NOT `Ready`
+  alone. With `Armed` retained, the gate is then strictly stronger than
+  the historical `Registered && Armed` predicate (adds bound +
+  xsk_registered + heartbeat-fresh + not-dead).
 
 ## 4. Deadlock analysis (Open question #1 — the gating risk)
 
@@ -257,7 +262,8 @@ A small helper computes the gate once per apply/watchdog pass:
 // worker has not panicked. deadWorkers is built once per pass from
 // status.WorkerRuntime[] (keyed by WorkerID).
 func bindingForwardingLive(b BindingStatus, deadWorkers map[uint32]bool) bool {
-    return b.Ready && !deadWorkers[b.WorkerID]
+    // Registered && Armed retained: Ready does not imply Armed.
+    return b.Registered && b.Armed && b.Ready && !deadWorkers[b.WorkerID]
 }
 ```
 
@@ -323,7 +329,7 @@ write.
 
 | Class | Level | Notes |
 |---|---|---|
-| Behavioural regression | LOW–MED | Only change is the §4.3 sub-second startup window; transit is already fail-closed there. Reviewer judgement needed on whether that window is acceptable. |
+| Behavioural regression | LOW–MED | Main change is the §4.3 sub-second startup delay before READY is first written (transit is NOT fail-closed there — the gate adds a real, poll-cycle-bounded first-transit delay, see corrected §4.3). Reviewer judgement needed on whether that window is acceptable. |
 | Lifetime / borrow | N/A | Go-side predicate swap; no Rust change. |
 | Performance | NONE | One bool read replaces two/three bool reads per binding per poll. |
 | Architectural mismatch | LOW | Reuses shipped `Ready` derivation; no new abstraction. The risk is that the issue is solving an already-mitigated problem (Open question #2). |

--- a/docs/pr/1666-ready-gate/plan.md
+++ b/docs/pr/1666-ready-gate/plan.md
@@ -1,8 +1,11 @@
 # #1666 — Gate the BPF READY write on helper-reported binding liveness
 
-**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY +
-Claude SMR). PLAN-KILL is an acceptable verdict and is explicitly on
-the table for this work (see §11).
+**Status:** v2 — PLAN-READY (AGY) + NEEDS-MAJOR findings from Codex/SMR
+applied. Round-1 verdicts: AGY PLAN-READY, Codex PLAN-NEEDS-MAJOR
+(framing corrections), Claude SMR NEEDS-MAJOR (self-corrected magnitude).
+All three converge: the gate is correct, deadlock-free, strictly safer;
+NOT a kill. v2 fixes the two framing errors and adopts the faster `Dead`
+crash signal. See §13 for the round-1 dispositions.
 
 ## 1. Issue framing
 
@@ -130,20 +133,27 @@ coordinator status path.
 - **Lower bound today:** READY=1 may be written ~1 poll cycle before the
   socket can actually receive (FD not yet in XSKMAP). In that sub-window
   today's behaviour is itself a micro-blackhole — the shim steers to a
-  slot whose FD isn't in the XSKMAP. The gate *removes* that sub-window.
+  slot whose FD isn't in the XSKMAP and `bpf_redirect_map` fails
+  (`USERSPACE_XSK_MAP.redirect(binding.slot, 0)`, lib.rs:635). The gate
+  *removes* that sub-window.
 - **Upper bound under the gate:** READY is withheld until `xsk_registered`
   + one fresh heartbeat are observed — bounded by worker bringup latency
   + one helper status-poll interval (sub-second in practice). It cannot
   be withheld forever for a legitimately-live binding because none of the
   three sub-conditions depend on the flag.
 
-This window is the crux reviewers must weigh: it is **strictly safer**
-(READY now means "a worker can actually receive"), at the cost of a
-sub-second-longer "transit fail-closed" startup window. Because transit
-is *already* fail-closed until `xskLivenessProven` (which itself needs
-RX, which needs the flag), the practical net change to first-transit
-latency is near zero — the flag must be set before RX can be proven
-either way.
+**Honest first-transit-latency framing (Codex round-1 finding #1 — the v1
+"near zero" claim was WRONG).** Transit is NOT fail-closed until
+`xskLivenessProven`. The shim has no liveness gate: once ctrl is enabled
+(maps_sync.go:389, on `Registered && Armed`), READY is set, and the
+heartbeat is fresh, the shim redirects transit at lib.rs:635 —
+*before* Go observes `xskLivenessProven` (which is set only later, after
+RX moves, at maps_sync.go:396). So gating on `Ready` adds a real
+first-transit delay of up to the next Go status/apply cycle after the
+worker becomes XSK-ready (sub-second to ~1 poll interval). That delay is
+acceptable — it is precisely the interval during which steering would
+otherwise hit a not-yet-registered FD — but it is NOT zero, and the plan
+states it as a real (small) cost rather than a wash.
 
 ## 5. Crash-detection → READY-clear (Open question #3)
 
@@ -151,7 +161,36 @@ The blackhole the issue targets is the **mid-life** crash: a worker that
 was Ready, then panics. This plan must define how READY is *cleared*, not
 just gated at write time.
 
-**An existing signal already drives the clear — no new mechanism needed:**
+### 5.0 What "blackhole" actually means today (corrected magnitude)
+
+Round-1 reviews (Codex finding #2, AGY finding #2, SMR self-correction)
+established that the mid-life crash is **NOT a permanent blackhole** — it
+is a **~30s** one, and the control plane actively keeps it open:
+
+- The XDP shim independently fail-closes transit to a slot whose
+  heartbeat is stale: lib.rs:425 reads `USERSPACE_HEARTBEAT`, lib.rs:449
+  compares against `ctrl.heartbeat_timeout_ms`, and on staleness calls
+  `drop_degraded_transit` → `XDP_DROP` (lib.rs:463, 939–946; transit
+  drops in both compat and strict). **But** Go programs
+  `HeartbeatTimeoutMS: 30000` (maps_sync.go:98/223/291), so the shim's
+  in-band clear is **~30s**, not the 5s the shim default would give.
+- Worse, the Go control plane keeps the binding-array READY=1 the whole
+  time: on master site 1 writes READY from `Registered && Armed`
+  (maps_sync.go:596), which stay true after a worker panic, and the
+  watchdog (verifyBindingsMapLocked) *re-asserts* READY=1 for any zeroed
+  slot whose helper status still shows `Registered && Armed`
+  (maps_sync.go:1076 + 1101) — so even if something cleared the flag,
+  the watchdog would fight it back to 1. The system cannot fail the slot
+  out of the blackhole.
+
+**So the honest win is: reduce dead-worker transit exposure from ~30s
+(shim heartbeat timeout, with the watchdog pinning READY=1) to ~5s — or
+near-instant with the `Dead` signal below.** This is a real correctness
+improvement, NOT redundant; the v1 "permanent → bounded" framing was an
+overstatement and the SMR "redundant on same 5s timescale" conclusion was
+based on the wrong (5s) shim timeout.
+
+### 5.1 The clear mechanisms this plan installs
 
 1. On panic, `spawn_supervised_worker` (`coordinator/supervisor.rs:98`)
    catches the unwind, sets `runtime_atomics.dead = true`, and the
@@ -177,30 +216,83 @@ Caveat to surface for review: the explicit rebind/stop_workers handlers
 (`server/handlers/rebind.rs`, `stop_workers.rs`,
 `coordinator/reconcile/reset.rs`) already clear `ready=false`
 synchronously, so orchestrated teardown clears the flag immediately;
-only an *unorchestrated panic with no respawn* relies on the 5s
+only an *unorchestrated panic with no respawn* relies on the
 heartbeat-staleness path. (#925 explicitly deferred worker respawn.)
+
+### 5.2 Faster crash signal: gate also on `!Dead` (Codex round-1 finding #3)
+
+There is an immediate, already-parsed crash signal that beats the ~5s
+heartbeat path. On panic, `spawn_supervised_worker` sets
+`runtime_atomics.dead = true` synchronously (supervisor.rs:114). This is
+published per-worker in `ProcessStatus.WorkerRuntime[]` as
+`WorkerRuntimeStatus.Dead` (protocol.go:858; surfaced as the
+`xpf_userspace_worker_dead` Prometheus gauge, #925 Phase 2). Go already
+parses it.
+
+v2 therefore gates the four sites on **`binding.Ready` AND the binding's
+worker is not Dead** — `binding.Ready && !deadWorkerIDs[binding.WorkerID]`,
+where `deadWorkerIDs` is built once per apply from
+`status.WorkerRuntime[]`. `WorkerRuntimeStatus` is keyed by `WorkerID`
+(protocol.go:835) and `BindingStatus.WorkerID` (protocol.go:1009) joins
+them; multiple bindings may share a worker, so a dead worker clears all
+its bindings at once. This collapses the unorchestrated-panic clear from
+~5s (heartbeat staleness) to one status-poll cycle (~1s).
+
+`!Dead` is a latency optimization layered on the correctness gate
+(`Ready` self-clears in ~5s regardless), but it reuses an already-shipped,
+already-parsed field at near-zero cost and directly addresses the
+"mid-life crash still blackholes" concern, so it is folded into this PR
+rather than deferred. `Dead` is set-only until daemon restart (#925), so
+it can never *spuriously* withhold READY from a live binding — it only
+ever fires for a worker that genuinely panicked.
 
 ## 6. Concrete design
 
-Single-line gate change at each of the four sites — replace the
-liveness predicate with `binding.Ready`:
+A small helper computes the gate once per apply/watchdog pass:
+
+```go
+// bindingForwardingLive reports whether a binding is safe to mark
+// READY in the XDP binding array: the helper derived it Ready
+// (registered && bound && xsk_registered && heartbeat_fresh) AND its
+// worker has not panicked. deadWorkers is built once per pass from
+// status.WorkerRuntime[] (keyed by WorkerID).
+func bindingForwardingLive(b BindingStatus, deadWorkers map[uint32]bool) bool {
+    return b.Ready && !deadWorkers[b.WorkerID]
+}
+```
+
+`deadWorkers` is assembled at the top of `applyHelperStatusLocked` and
+`verifyBindingsMapLocked` from `status.WorkerRuntime` / `m.lastStatus.
+WorkerRuntime` (a few entries; cheap). Then at each site:
 
 - **Site 1** (maps_sync.go:596): `if binding.Registered && binding.Armed`
-  → `if binding.Ready`. Replace the now-stale anti-deadlock comment with
-  a comment documenting the #1648/#1666 finding (Ready already implies
-  bound+xsk_registered+heartbeat-fresh; this is the crash-clear gate).
+  → `if bindingForwardingLive(binding, deadWorkers)`. Replace the
+  now-stale anti-deadlock comment with one documenting the #1648/#1666
+  finding (Ready already implies bound+xsk_registered+heartbeat-fresh;
+  `!Dead` adds the fast panic clear).
 - **Site 2** (maps_sync.go:633): `if binding.Registered && binding.Armed
-  && binding.Bound` → `if binding.Ready`. Tightens (adds xsk_registered
-  + heartbeat) and unifies with site 1.
+  && binding.Bound` → `if bindingForwardingLive(binding, deadWorkers)`.
+  Tightens and unifies with site 1.
 - **Site 3** (maps_sync.go:1076 guard): `if !binding.Registered ||
-  !binding.Armed { continue }` → `if !binding.Ready { continue }`. The
-  flag literal at :1101 is unchanged.
+  !binding.Armed { continue }` → `if !bindingForwardingLive(binding,
+  deadWorkers) { continue }`. Flag literal at :1101 unchanged.
 - **Site 4** (maps_sync.go:1122 guard): `if !binding.Registered ||
-  !binding.Armed || !binding.Bound { continue }` → `if !binding.Ready {
-  continue }`.
+  !binding.Armed || !binding.Bound { continue }` → `if
+  !bindingForwardingLive(binding, deadWorkers) { continue }`.
 
 No new fields, no protocol change, no Rust change. The gate reuses the
-already-shipped, already-wire-exposed `BindingStatus.Ready`.
+already-shipped, already-wire-exposed `BindingStatus.Ready`,
+`BindingStatus.WorkerID`, and `WorkerRuntimeStatus.Dead`.
+
+**Crash-clear is apply-driven, not watchdog-driven (Codex finding #4).**
+`verifyBindingsMapLocked` only *repairs zeroed* entries (it skips entries
+where `Flags != 0 || Slot != 0`, maps_sync.go:1095); it never zeros a
+populated slot. The actual READY=0 write for a dead worker comes from
+`applyHelperStatusLocked`, which writes `Flags: flags` for *every*
+binding each pass (maps_sync.go:616/649) with `flags` computed from the
+gate. Tightening site 3/4 prevents the watchdog from *re-asserting*
+READY=1 for a dead slot (the watchdog-fighting problem in §5.0); the
+clear itself is the next `applyHelperStatusLocked` pass.
 
 ## 7. Public API preservation
 
@@ -249,10 +341,16 @@ write.
 - **New unit tests:**
   - READY withheld when `Registered && Armed` but `!Ready` (e.g.
     `XSKRegistered:false`) → array flag stays 0 at site 1.
-  - READY written when `Ready:true` → array flag == `userspaceBindingReady`.
-  - Watchdog (site 3) does NOT repair/re-assert a slot with `!Ready`.
-  - Crash-clear: a binding that was Ready then reports `Ready:false`
-    (heartbeat-stale proxy) → next apply writes flags=0.
+  - READY written when `Ready:true` and worker not Dead → array flag ==
+    `userspaceBindingReady`.
+  - READY withheld when `Ready:true` but the binding's worker is Dead
+    (`WorkerRuntime[WorkerID].Dead == true`) → array flag stays 0
+    (the fast panic clear).
+  - Watchdog (site 3) does NOT repair/re-assert a slot with `!Ready` or a
+    Dead worker.
+  - Crash-clear via apply: a binding previously written READY=1, whose
+    worker is now Dead (or `Ready:false`), gets flags=0 on the next
+    `applyHelperStatusLocked` pass.
 - **`make test-failover` — HARD GATE** (touches HA forwarding-ready
   path). VRRP ~60ms, zero-drop failover.
 - **Full smoke matrix** on loss userspace cluster: v4+v6 × push+reverse ×
@@ -280,50 +378,40 @@ Kill this plan if any reviewer establishes:
   and no faster signal exists, making the "mid-life crash" half of the
   win illusory while the startup window is a real (if small) cost.
 
-## 11a. Claude SMR plan review (round 1) — trending PLAN-KILL on criterion (b)
+## 13. Round-1 plan-review verdicts and dispositions
 
-Reviewing my own plan adversarially as domain SMR, I found a decisive
-fact the issue body **and** plan §5 both missed: **the XDP shim already
-guards the crash-blind blackhole in-band via the per-slot heartbeat
-map.** Evidence (whole-function-verified in `userspace-xdp/src/lib.rs`):
+**AGY (`review-mpre0wvf-wq0j4q`): PLAN-READY.** Verified all function
+bodies; confirmed no deadlock, live-Arc-stays-after-panic, watchdog would
+fight an out-of-band clear (hence gating site 3/4 is mandatory), and the
+gate is strictly safer (avoids steering to a not-yet-registered FD).
+Confirmed the shim's in-band timeout is the Go-configured **30s**, so the
+fix is real (not mitigated today).
 
-- The shim reads `USERSPACE_HEARTBEAT` per packet (lib.rs:425) and, if
-  `now_ns - last_heartbeat > timeout_ns` where `timeout_ms` defaults to
-  `USERSPACE_DEFAULT_HEARTBEAT_TIMEOUT_MS = 5000` (lib.rs:16, 442–447),
-  it does NOT steer transit — it calls `drop_degraded_transit`
-  (lib.rs:449→463). `drop_degraded_transit` returns `XDP_DROP` for
-  transit in both compat and strict modes (lib.rs:939–946); only
-  local/control may `pass_local_control`.
-- The heartbeat map is the same per-slot value the worker touches every
-  poll tick (`maybe_touch_heartbeat` → `touch_heartbeat` →
-  `update_heartbeat_slot`, bpf_map/mod.rs:204). A crashed worker stops
-  touching it; within ≤5s the shim stops steering transit to that slot.
+**Codex (`task-mpre0hw1-i0d2rj`): PLAN-NEEDS-MAJOR.** No deadlock, no
+existing Go clear path. Four findings, all applied:
+- *#1 (applied, §4.3):* v1's "near-zero first-transit latency" was wrong —
+  transit is not fail-closed until `xskLivenessProven`; the shim
+  redirects at lib.rs:635 once ctrl+READY+heartbeat hold. Reframed as a
+  real sub-second/poll-cycle delay.
+- *#2 (applied, §5.0):* reframe win as 30s (shim heartbeat) → ~5s
+  (`Ready`), not "permanent → bounded."
+- *#3 (applied, §5.2, §6):* use the faster `WorkerRuntimeStatus.Dead`
+  signal; gate on `Ready && !Dead`.
+- *#4 (applied, §6):* crash-clear is apply-driven, not watchdog-driven;
+  watchdog only repairs zeroed entries.
 
-**Implication for the issue's headline:** the mid-life-crash blackhole
-is **neither latent nor permanent** — it self-heals in the dataplane
-within the same ~5s heartbeat window the plan proposes to enforce from
-the Go side via `binding.Ready` (whose `heartbeat_fresh` is the SAME 5s
-`HEARTBEAT_STALE_AFTER`). For the mid-life crash the Go `binding.Ready`
-gate is therefore **redundant** with an already-shipped per-packet guard.
+**Claude SMR (in-conversation): NEEDS-MAJOR, self-corrected.** Initially
+trended KILL on the belief the shim self-heals in 5s (criterion b), which
+would make the gate redundant. Codex's verification that Go programs the
+shim timeout to **30s** (maps_sync.go:291) invalidated that: the in-band
+clear is ~30s and the watchdog pins READY=1 the whole time, so the
+~5s/`!Dead` Go gate is a genuine improvement. SMR kill withdrawn.
 
-**Residual incremental coverage:** only the ≤5s *startup* sub-window
-where a worker created its socket, touched the init heartbeat
-(worker/mod.rs:355), then died or failed `register_binding_xsk`
-(worker/mod.rs:472) before its heartbeat went stale — during which
-site 1 has written READY=1 (on `Registered && Armed`) and the heartbeat
-is still fresh. The shim would steer to that dead slot for ≤5s. The gate
-closes exactly this narrow window, at the cost of the §4.3 startup-delay
-window on *every normal bringup* plus modification of the sensitive
-fail-closed path.
-
-**SMR verdict:** PLAN-NEEDS-MAJOR trending PLAN-KILL on criterion (b).
-The motivating "latent crash-blind blackhole" is already mitigated
-in-dataplane on the same timescale. What remains is a ≤5s startup-only
-edge that must be re-justified on its own merits (and may itself be
-covered if the never-registered worker also fails `probeBindingsReady`
-elsewhere — reviewers to confirm). Awaiting Codex + AGY independent
-verification of the lib.rs:449 heartbeat-staleness finding before
-finalizing the kill.
+**Convergence:** NOT a PLAN-KILL. The PLAN-KILL criteria in §11 are
+recorded but none fired — (a) no deadlock exists, (b) the blackhole is
+NOT already mitigated on a comparable timescale (30s + watchdog-pinned),
+(c) the crash-clear is real and `!Dead` makes it near-instant. v2 is
+PLAN-READY pending a confirmation pass on the two framing fixes.
 
 ## 12. Out of scope
 

--- a/docs/pr/1666-ready-gate/plan.md
+++ b/docs/pr/1666-ready-gate/plan.md
@@ -280,6 +280,51 @@ Kill this plan if any reviewer establishes:
   and no faster signal exists, making the "mid-life crash" half of the
   win illusory while the startup window is a real (if small) cost.
 
+## 11a. Claude SMR plan review (round 1) — trending PLAN-KILL on criterion (b)
+
+Reviewing my own plan adversarially as domain SMR, I found a decisive
+fact the issue body **and** plan §5 both missed: **the XDP shim already
+guards the crash-blind blackhole in-band via the per-slot heartbeat
+map.** Evidence (whole-function-verified in `userspace-xdp/src/lib.rs`):
+
+- The shim reads `USERSPACE_HEARTBEAT` per packet (lib.rs:425) and, if
+  `now_ns - last_heartbeat > timeout_ns` where `timeout_ms` defaults to
+  `USERSPACE_DEFAULT_HEARTBEAT_TIMEOUT_MS = 5000` (lib.rs:16, 442–447),
+  it does NOT steer transit — it calls `drop_degraded_transit`
+  (lib.rs:449→463). `drop_degraded_transit` returns `XDP_DROP` for
+  transit in both compat and strict modes (lib.rs:939–946); only
+  local/control may `pass_local_control`.
+- The heartbeat map is the same per-slot value the worker touches every
+  poll tick (`maybe_touch_heartbeat` → `touch_heartbeat` →
+  `update_heartbeat_slot`, bpf_map/mod.rs:204). A crashed worker stops
+  touching it; within ≤5s the shim stops steering transit to that slot.
+
+**Implication for the issue's headline:** the mid-life-crash blackhole
+is **neither latent nor permanent** — it self-heals in the dataplane
+within the same ~5s heartbeat window the plan proposes to enforce from
+the Go side via `binding.Ready` (whose `heartbeat_fresh` is the SAME 5s
+`HEARTBEAT_STALE_AFTER`). For the mid-life crash the Go `binding.Ready`
+gate is therefore **redundant** with an already-shipped per-packet guard.
+
+**Residual incremental coverage:** only the ≤5s *startup* sub-window
+where a worker created its socket, touched the init heartbeat
+(worker/mod.rs:355), then died or failed `register_binding_xsk`
+(worker/mod.rs:472) before its heartbeat went stale — during which
+site 1 has written READY=1 (on `Registered && Armed`) and the heartbeat
+is still fresh. The shim would steer to that dead slot for ≤5s. The gate
+closes exactly this narrow window, at the cost of the §4.3 startup-delay
+window on *every normal bringup* plus modification of the sensitive
+fail-closed path.
+
+**SMR verdict:** PLAN-NEEDS-MAJOR trending PLAN-KILL on criterion (b).
+The motivating "latent crash-blind blackhole" is already mitigated
+in-dataplane on the same timescale. What remains is a ≤5s startup-only
+edge that must be re-justified on its own merits (and may itself be
+covered if the never-registered worker also fails `probeBindingsReady`
+elsewhere — reviewers to confirm). Awaiting Codex + AGY independent
+verification of the lib.rs:449 heartbeat-staleness finding before
+finalizing the kill.
+
 ## 12. Out of scope
 
 - Worker respawn after panic (#925 deferred indefinitely).

--- a/docs/pr/1666-ready-gate/reviewer-ids.md
+++ b/docs/pr/1666-ready-gate/reviewer-ids.md
@@ -9,9 +9,13 @@ Ledger for resuming reviewer sessions across context loss
 - AGY: review-mpre0wvf-wq0j4q
 - Claude SMR: in-conversation (this thread)
 
+## Plan review round 2 (Codex confirmation)
+
+- Codex: task-mpre9ku1-e5pvs2 (NEEDS-MAJOR: Ready !imply Armed — fixed)
+
 ## Code review round 1
 
-- Codex: <pending>
-- AGY: <pending>
-- Copilot: <pending>
+- Codex: task-mpreidym-m4vmgs (round-3 confirm + code review @ 2321c4219)
+- AGY: review-mpref... (dispatching)
+- Copilot: <pending PR open>
 - Claude SMR: in-conversation (this thread)

--- a/docs/pr/1666-ready-gate/reviewer-ids.md
+++ b/docs/pr/1666-ready-gate/reviewer-ids.md
@@ -13,9 +13,16 @@ Ledger for resuming reviewer sessions across context loss
 
 - Codex: task-mpre9ku1-e5pvs2 (NEEDS-MAJOR: Ready !imply Armed — fixed)
 
-## Code review round 1 (PR #1672)
+## Code review round 1 (PR #1672) — 4-of-4 clean
 
 - Codex: task-mpreidym-m4vmgs — MERGE-READY (@ 2321c4219, nits fixed in dc8ba33b8)
-- AGY: review-mpreiq7i-3zz00p (timed out mid-run); re-dispatched code-only review-mpreyrkg-zjq2bq
-- Copilot: requested via @copilot review on PR #1672
+- AGY: review-mpreyrkg-zjq2bq — MERGE-READY (code-only; review-mpreiq7i-3zz00p timed out mid-run earlier)
+- Copilot: COMMENTED, no findings (reviewed 5/5 files) on PR #1672
 - Claude SMR: in-conversation (this thread) — MERGE-READY
+
+## Gates
+- make test-failover: 14/14 passed, 0 failed; 14.7 Gbps; "XSK liveness proven" no-deadlock proof.
+- Smoke Pass A (CoS off) + Pass B (CoS on, per-class 5201-5206) clean.
+
+DO NOT auto-merge (fail-closed HA bringup path). Posted
+<!-- AWAITING-PARENT-MERGE-1666 -->; parent verifies + merges.

--- a/docs/pr/1666-ready-gate/reviewer-ids.md
+++ b/docs/pr/1666-ready-gate/reviewer-ids.md
@@ -1,0 +1,17 @@
+# #1666 reviewer task IDs
+
+Ledger for resuming reviewer sessions across context loss
+(`feedback_codex_session_loss_continuation`).
+
+## Plan review round 1
+
+- Codex: <pending>
+- AGY: <pending>
+- Claude SMR: in-conversation (this thread)
+
+## Code review round 1
+
+- Codex: <pending>
+- AGY: <pending>
+- Copilot: <pending>
+- Claude SMR: in-conversation (this thread)

--- a/docs/pr/1666-ready-gate/reviewer-ids.md
+++ b/docs/pr/1666-ready-gate/reviewer-ids.md
@@ -5,8 +5,8 @@ Ledger for resuming reviewer sessions across context loss
 
 ## Plan review round 1
 
-- Codex: <pending>
-- AGY: <pending>
+- Codex: task-mpre0hw1-i0d2rj
+- AGY: review-mpre0wvf-wq0j4q
 - Claude SMR: in-conversation (this thread)
 
 ## Code review round 1

--- a/docs/pr/1666-ready-gate/reviewer-ids.md
+++ b/docs/pr/1666-ready-gate/reviewer-ids.md
@@ -13,9 +13,9 @@ Ledger for resuming reviewer sessions across context loss
 
 - Codex: task-mpre9ku1-e5pvs2 (NEEDS-MAJOR: Ready !imply Armed — fixed)
 
-## Code review round 1
+## Code review round 1 (PR #1672)
 
-- Codex: task-mpreidym-m4vmgs (round-3 confirm + code review @ 2321c4219)
-- AGY: review-mpref... (dispatching)
-- Copilot: <pending PR open>
-- Claude SMR: in-conversation (this thread)
+- Codex: task-mpreidym-m4vmgs — MERGE-READY (@ 2321c4219, nits fixed in dc8ba33b8)
+- AGY: review-mpreiq7i-3zz00p (timed out mid-run); re-dispatched code-only review-mpreyrkg-zjq2bq
+- Copilot: requested via @copilot review on PR #1672
+- Claude SMR: in-conversation (this thread) — MERGE-READY

--- a/pkg/dataplane/userspace/binding_ready_gate_test.go
+++ b/pkg/dataplane/userspace/binding_ready_gate_test.go
@@ -1,0 +1,97 @@
+package userspace
+
+import "testing"
+
+// #1666: the binding-array READY write is gated on bindingForwardingLive,
+// which requires the helper-derived binding.Ready AND the worker not being
+// Dead. These tests pin the gate logic directly (no BPF map / memlock
+// needed, so they run in every environment, unlike the map-touching
+// applyHelperStatusLocked / verifyBindingsMapLocked tests which require
+// privilege). They are the always-runnable guard for the gate semantics.
+
+func TestBindingForwardingLiveRequiresReady(t *testing.T) {
+	cases := []struct {
+		name    string
+		binding BindingStatus
+		dead    map[uint32]bool
+		want    bool
+	}{
+		{
+			name: "registered+armed but not ready (e.g. XSK not registered) is withheld",
+			// The historical (Registered && Armed) predicate would have
+			// marked this READY — the crash-blind blackhole. The gate now
+			// withholds it.
+			binding: BindingStatus{Registered: true, Armed: true, Bound: true, XSKRegistered: false, Ready: false},
+			want:    false,
+		},
+		{
+			name:    "ready, worker not dead is forwarding-live",
+			binding: BindingStatus{WorkerID: 2, Registered: true, Armed: true, Bound: true, XSKRegistered: true, Ready: true},
+			want:    true,
+		},
+		{
+			name: "ready but worker dead is withheld (fast panic clear)",
+			// Ready is still true in this snapshot (heartbeat not yet
+			// stale), but the supervisor flagged the worker dead — the
+			// !Dead leg withholds READY immediately rather than waiting
+			// ~5s for heartbeat staleness to flip Ready false.
+			binding: BindingStatus{WorkerID: 4, Registered: true, Armed: true, Bound: true, XSKRegistered: true, Ready: true},
+			dead:    map[uint32]bool{4: true},
+			want:    false,
+		},
+		{
+			name:    "ready, a different worker is dead does not affect this binding",
+			binding: BindingStatus{WorkerID: 4, Ready: true},
+			dead:    map[uint32]bool{9: true},
+			want:    true,
+		},
+		{
+			name:    "not ready and not dead is withheld",
+			binding: BindingStatus{WorkerID: 1, Ready: false},
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bindingForwardingLive(tc.binding, tc.dead); got != tc.want {
+				t.Fatalf("bindingForwardingLive(%+v, %v) = %v, want %v",
+					tc.binding, tc.dead, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeadWorkerIDSet(t *testing.T) {
+	if got := deadWorkerIDSet(nil); got != nil {
+		t.Fatalf("deadWorkerIDSet(nil) = %v, want nil", got)
+	}
+	runtime := []WorkerRuntimeStatus{
+		{WorkerID: 0, Dead: false},
+		{WorkerID: 1, Dead: true},
+		{WorkerID: 2, Dead: false},
+		{WorkerID: 3, Dead: true},
+	}
+	dead := deadWorkerIDSet(runtime)
+	if !dead[1] || !dead[3] {
+		t.Fatalf("deadWorkerIDSet did not flag dead workers 1 and 3: %v", dead)
+	}
+	if dead[0] || dead[2] {
+		t.Fatalf("deadWorkerIDSet flagged live workers: %v", dead)
+	}
+	// No dead workers -> nil set (so the gate degenerates to b.Ready).
+	if got := deadWorkerIDSet([]WorkerRuntimeStatus{{WorkerID: 5, Dead: false}}); got != nil {
+		t.Fatalf("deadWorkerIDSet with no dead workers = %v, want nil", got)
+	}
+}
+
+// A nil dead-set (the common case: no panics) must never withhold READY
+// from an otherwise-Ready binding. Guards against a nil-map regression in
+// bindingForwardingLive.
+func TestBindingForwardingLiveNilDeadSetHonoursReady(t *testing.T) {
+	if !bindingForwardingLive(BindingStatus{WorkerID: 7, Ready: true}, nil) {
+		t.Fatal("a Ready binding with a nil dead-set must be forwarding-live")
+	}
+	if bindingForwardingLive(BindingStatus{WorkerID: 7, Ready: false}, nil) {
+		t.Fatal("a non-Ready binding must not be forwarding-live")
+	}
+}

--- a/pkg/dataplane/userspace/binding_ready_gate_test.go
+++ b/pkg/dataplane/userspace/binding_ready_gate_test.go
@@ -92,7 +92,8 @@ func TestDeadWorkerIDSet(t *testing.T) {
 	if dead[0] || dead[2] {
 		t.Fatalf("deadWorkerIDSet flagged live workers: %v", dead)
 	}
-	// No dead workers -> nil set (so the gate degenerates to b.Ready).
+	// No dead workers -> nil set (so the gate degenerates to
+	// Registered && Armed && Ready).
 	if got := deadWorkerIDSet([]WorkerRuntimeStatus{{WorkerID: 5, Dead: false}}); got != nil {
 		t.Fatalf("deadWorkerIDSet with no dead workers = %v, want nil", got)
 	}

--- a/pkg/dataplane/userspace/binding_ready_gate_test.go
+++ b/pkg/dataplane/userspace/binding_ready_gate_test.go
@@ -30,6 +30,20 @@ func TestBindingForwardingLiveRequiresReady(t *testing.T) {
 			want:    true,
 		},
 		{
+			name: "ready but disarmed is withheld",
+			// The Rust Ready derivation does NOT include Armed, so a
+			// Ready:true / Armed:false binding (disarmed by the control
+			// plane while otherwise live) must NOT forward — the gate keeps
+			// the Registered && Armed admission alongside Ready.
+			binding: BindingStatus{WorkerID: 2, Registered: true, Armed: false, Bound: true, XSKRegistered: true, Ready: true},
+			want:    false,
+		},
+		{
+			name: "ready but unregistered is withheld",
+			binding: BindingStatus{WorkerID: 2, Registered: false, Armed: true, Bound: true, XSKRegistered: true, Ready: true},
+			want:    false,
+		},
+		{
 			name: "ready but worker dead is withheld (fast panic clear)",
 			// Ready is still true in this snapshot (heartbeat not yet
 			// stale), but the supervisor flagged the worker dead — the
@@ -41,13 +55,13 @@ func TestBindingForwardingLiveRequiresReady(t *testing.T) {
 		},
 		{
 			name:    "ready, a different worker is dead does not affect this binding",
-			binding: BindingStatus{WorkerID: 4, Ready: true},
+			binding: BindingStatus{WorkerID: 4, Registered: true, Armed: true, Ready: true},
 			dead:    map[uint32]bool{9: true},
 			want:    true,
 		},
 		{
 			name:    "not ready and not dead is withheld",
-			binding: BindingStatus{WorkerID: 1, Ready: false},
+			binding: BindingStatus{WorkerID: 1, Registered: true, Armed: true, Ready: false},
 			want:    false,
 		},
 	}
@@ -88,10 +102,10 @@ func TestDeadWorkerIDSet(t *testing.T) {
 // from an otherwise-Ready binding. Guards against a nil-map regression in
 // bindingForwardingLive.
 func TestBindingForwardingLiveNilDeadSetHonoursReady(t *testing.T) {
-	if !bindingForwardingLive(BindingStatus{WorkerID: 7, Ready: true}, nil) {
-		t.Fatal("a Ready binding with a nil dead-set must be forwarding-live")
+	if !bindingForwardingLive(BindingStatus{WorkerID: 7, Registered: true, Armed: true, Ready: true}, nil) {
+		t.Fatal("a Ready+armed binding with a nil dead-set must be forwarding-live")
 	}
-	if bindingForwardingLive(BindingStatus{WorkerID: 7, Ready: false}, nil) {
+	if bindingForwardingLive(BindingStatus{WorkerID: 7, Registered: true, Armed: true, Ready: false}, nil) {
 		t.Fatal("a non-Ready binding must not be forwarding-live")
 	}
 }

--- a/pkg/dataplane/userspace/link_cycle_test.go
+++ b/pkg/dataplane/userspace/link_cycle_test.go
@@ -95,13 +95,19 @@ func TestNotifyLinkCycleRebindsAndAppliesHelperStatusCompat(t *testing.T) {
 		LastFIBGeneration:      13,
 		NeighborGeneration:     21,
 		Bindings: []BindingStatus{{
-			Slot:       5,
-			Ifindex:    2,
-			QueueID:    1,
-			Registered: true,
-			Armed:      true,
-			Bound:      true,
-			RXPackets:  17,
+			Slot:          5,
+			Ifindex:       2,
+			QueueID:       1,
+			Registered:    true,
+			Armed:         true,
+			Bound:         true,
+			XSKRegistered: true,
+			// #1666: the binding-array READY write now gates on the
+			// helper-derived Ready (registered && bound && xsk_registered
+			// && heartbeat_fresh), so a genuinely-live binding fixture must
+			// set Ready to keep asserting Flags == userspaceBindingReady.
+			Ready:     true,
+			RXPackets: 17,
 		}},
 	}
 	events := startLinkCycleControlServer(t, controlSock, ctrlMap, []ProcessStatus{rebindStatus})

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -65,13 +65,18 @@ func deadWorkerIDSet(runtime []WorkerRuntimeStatus) map[uint32]bool {
 // bindingForwardingLive reports whether a binding is safe to mark READY
 // (userspaceBindingReady) in the XDP userspace_bindings array.
 //
-// #1666: the gate is the helper-derived binding.Ready — which is
+// #1666: the gate keeps the historical (Registered && Armed)
+// admission AND adds the helper-derived binding.Ready — which is
 // (registered && bound && xsk_registered && heartbeat_fresh), computed in
 // userspace-dp coordinator/refresh_bindings.rs — ANDed with the binding's
-// worker not being Dead. This is strictly stronger than the historical
-// (Registered && Armed) predicate: it withholds READY until the worker
-// has actually created its socket, registered the FD in the XSKMAP, and
-// shown a fresh heartbeat, and it clears READY when the worker panics.
+// worker not being Dead.
+//
+// Registered && Armed must stay in the predicate: the Rust Ready
+// derivation does NOT include Armed (armed = armed_req && registered is a
+// separate control-plane flag), so a Ready-but-disarmed binding must not
+// forward. The Ready + !Dead legs are what newly withhold/clear READY for
+// a worker that crashed or never finished XSK registration (the
+// crash-blind blackhole).
 //
 // All of Ready's sub-conditions are flipped true by worker bringup alone
 // (socket create -> set_bound, XSKMAP register -> set_xsk_registered,
@@ -79,7 +84,7 @@ func deadWorkerIDSet(runtime []WorkerRuntimeStatus) map[uint32]bool {
 // cannot deadlock a legitimately-live binding (see
 // docs/pr/1666-ready-gate/plan.md §4).
 func bindingForwardingLive(b BindingStatus, deadWorkers map[uint32]bool) bool {
-	return b.Ready && !deadWorkers[b.WorkerID]
+	return b.Registered && b.Armed && b.Ready && !deadWorkers[b.WorkerID]
 }
 
 type userspaceBindingKey struct {

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -1153,7 +1153,8 @@ func (m *Manager) verifyBindingsMapLocked() bool {
 			continue
 		}
 		// BPF map entry is all zeros but the helper says the queue is
-		// registered and armed. Rewrite the entry.
+		// forwarding-live (Registered && Armed && Ready && !Dead, gated
+		// above). Rewrite the entry.
 		flags := uint32(userspaceBindingReady)
 		newVal := userspaceBindingValue{
 			Slot:  binding.Slot,

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -41,6 +41,47 @@ const bindingQueuesPerIface = 16 // must match BINDING_QUEUES_PER_IFACE in BPF
 
 const userspaceBindingReady = 1
 
+// deadWorkerIDSet builds the set of worker IDs whose worker_loop has
+// panicked, from the helper's per-worker runtime status. On panic the
+// supervisor (coordinator/supervisor.rs) sets runtime_atomics.dead which
+// surfaces as WorkerRuntimeStatus.Dead (#925). Dead is set-only until
+// daemon restart, so it never spuriously fires for a live worker.
+func deadWorkerIDSet(runtime []WorkerRuntimeStatus) map[uint32]bool {
+	if len(runtime) == 0 {
+		return nil
+	}
+	var dead map[uint32]bool
+	for _, w := range runtime {
+		if w.Dead {
+			if dead == nil {
+				dead = make(map[uint32]bool, len(runtime))
+			}
+			dead[w.WorkerID] = true
+		}
+	}
+	return dead
+}
+
+// bindingForwardingLive reports whether a binding is safe to mark READY
+// (userspaceBindingReady) in the XDP userspace_bindings array.
+//
+// #1666: the gate is the helper-derived binding.Ready — which is
+// (registered && bound && xsk_registered && heartbeat_fresh), computed in
+// userspace-dp coordinator/refresh_bindings.rs — ANDed with the binding's
+// worker not being Dead. This is strictly stronger than the historical
+// (Registered && Armed) predicate: it withholds READY until the worker
+// has actually created its socket, registered the FD in the XSKMAP, and
+// shown a fresh heartbeat, and it clears READY when the worker panics.
+//
+// All of Ready's sub-conditions are flipped true by worker bringup alone
+// (socket create -> set_bound, XSKMAP register -> set_xsk_registered,
+// per-poll-tick heartbeat), independent of inbound traffic, so this gate
+// cannot deadlock a legitimately-live binding (see
+// docs/pr/1666-ready-gate/plan.md §4).
+func bindingForwardingLive(b BindingStatus, deadWorkers map[uint32]bool) bool {
+	return b.Ready && !deadWorkers[b.WorkerID]
+}
+
 type userspaceBindingKey struct {
 	Ifindex uint32
 	QueueID uint32
@@ -588,17 +629,21 @@ ctrlReady:
 		m.ctrlWasEnabled = false
 	}
 
+	deadWorkers := deadWorkerIDSet(status.WorkerRuntime)
 	for _, binding := range status.Bindings {
 		if binding.Ifindex <= 0 {
 			continue
 		}
 		flags := uint32(0)
-		if binding.Registered && binding.Armed {
-			// Mark ready once registered + armed. Don't wait for Bound:
-			// the Bound flag is set asynchronously by worker threads
-			// after XSK socket creation. Waiting creates a chicken-and-egg
-			// where the XDP shim drops packets (flags=0) preventing the
-			// XSK socket from ever receiving (so Bound never becomes true).
+		if bindingForwardingLive(binding, deadWorkers) {
+			// #1666: mark forwarding-ready only when the helper derives
+			// the binding Ready (registered && bound && xsk_registered &&
+			// heartbeat_fresh) and the worker has not panicked. The prior
+			// (Registered && Armed) predicate let the XDP shim steer
+			// transit to a slot whose worker had crashed or never finished
+			// XSK registration (crash-blind blackhole). Ready's
+			// sub-conditions are all set by worker bringup independent of
+			// RX, so this does not deadlock startup (plan §4).
 			flags = userspaceBindingReady
 		}
 		idx := uint32(binding.Ifindex)*bindingQueuesPerIface + binding.QueueID
@@ -631,7 +676,8 @@ ctrlReady:
 				continue
 			}
 			flags := uint32(0)
-			if binding.Registered && binding.Armed && binding.Bound {
+			if bindingForwardingLive(binding, deadWorkers) {
+				// #1666: unify the VLAN-alias child with the primary gate.
 				flags = userspaceBindingReady
 			}
 			idx := childIfindex*bindingQueuesPerIface + binding.QueueID
@@ -1068,12 +1114,17 @@ func (m *Manager) verifyBindingsMapLocked() bool {
 		return false
 	}
 
+	deadWorkers := deadWorkerIDSet(m.lastStatus.WorkerRuntime)
 	repaired := 0
 	for _, binding := range bindings {
 		if binding.Ifindex <= 0 {
 			continue
 		}
-		if !binding.Registered || !binding.Armed {
+		// #1666: only repair (re-assert READY for) slots whose worker is
+		// actually forwarding-live. Repairing on (Registered && Armed)
+		// would let the watchdog fight the crash-clear by rewriting
+		// READY=1 for a dead worker.
+		if !bindingForwardingLive(binding, deadWorkers) {
 			continue
 		}
 		idx := uint32(binding.Ifindex)*bindingQueuesPerIface + binding.QueueID
@@ -1119,7 +1170,8 @@ func (m *Manager) verifyBindingsMapLocked() bool {
 				if binding.Ifindex != int(parentIfindex) {
 					continue
 				}
-				if !binding.Registered || !binding.Armed || !binding.Bound {
+				// #1666: same forwarding-live gate as the primary repair.
+				if !bindingForwardingLive(binding, deadWorkers) {
 					continue
 				}
 				idx := childIfindex*bindingQueuesPerIface + binding.QueueID


### PR DESCRIPTION
## Summary

Closes #1666.

The `userspace_bindings` BPF-array READY flag — checked by the
`userspace-xdp` shim to decide whether to steer transit into a slot's
AF_XDP socket — was written at four sites in `maps_sync.go` on a
`Registered && Armed` predicate (the two primary sites) or `Registered
&& Armed && Bound` (the two VLAN-alias sites). `Registered`/`Armed` are
set in the binding handler and are **not** cleared when a worker thread
dies, so a panicked or never-registered worker kept its slot advertised
forwarding-ready and the shim steered transit to a socket nobody drains.

All four sites now gate on `bindingForwardingLive(binding, deadWorkers)`
= `binding.Registered && binding.Armed && binding.Ready &&
!deadWorkers[binding.WorkerID]`:

- `binding.Ready` is the helper-derived `registered && bound &&
  xsk_registered && heartbeat_fresh` (coordinator/refresh_bindings.rs:225).
  All sub-conditions flip true from worker **bringup** alone (socket
  create → `set_bound`, XSKMAP register → `set_xsk_registered`,
  per-poll-tick heartbeat), independent of inbound traffic — so the gate
  **cannot deadlock** a legitimately-live binding.
- `Registered && Armed` is retained because `Ready` does **not** imply
  `Armed` (the Rust derivation omits it; `armed` is a separate
  control-plane flag) — a Ready-but-disarmed binding must not forward.
- `!Dead` uses the already-parsed `WorkerRuntimeStatus.Dead` panic signal
  (#925, set synchronously by the supervisor on `catch_unwind`) to clear
  a crashed worker's slot in one status-poll cycle (~1s) instead of
  waiting ~5s for heartbeat staleness to flip `Ready` false.

The clear is **apply-driven**: `applyHelperStatusLocked` rewrites `Flags`
for every binding each pass. Tightening the watchdog
(`verifyBindingsMapLocked`) on the same gate stops it from fighting the
clear by re-asserting READY=1 for a dead slot.

No new fields, no protocol change, no Rust change.

## Why this is a real fix (not redundant)

The XDP shim independently fail-closes transit to a stale-heartbeat slot
(lib.rs:449 → `drop_degraded_transit` → `XDP_DROP`), but Go programs that
timeout to **30s** (`HeartbeatTimeoutMS: 30000`), and the bindings
watchdog actively re-asserts READY=1 for a dead slot the whole time. The
honest win is reducing dead-worker transit exposure from **~30s
(watchdog-pinned)** to **~5s** (`Ready`) — or near-instant with `!Dead`.

## Plan + adversarial review

Plan + full deadlock analysis + round-by-round dispositions:
`docs/pr/1666-ready-gate/plan.md`.

- AGY plan review: **PLAN-READY** (confirmed no deadlock, watchdog would
  fight an out-of-band clear, gate is strictly safer, win is real at 30s).
- Codex plan review r1: PLAN-NEEDS-MAJOR (4 framing findings — applied);
  r2: NEEDS-MAJOR (Ready ≠ Armed — fixed); **r3 code review: MERGE-READY**.
- Claude SMR: NEEDS-MAJOR, self-corrected (had assumed 5s shim timeout;
  Codex established it is 30s, so the gate is a genuine improvement).

## Test plan

- [x] `go build ./...` clean
- [x] Full Go suite passes (`go test ./...`)
- [x] New privilege-free unit tests pin the gate: `bindingForwardingLive`
      (ready-but-disarmed / ready-but-unregistered / ready-but-dead all
      withheld) + `deadWorkerIDSet`. 5/5 flake-clean.
- [x] Updated `link_cycle_test.go` compat fixture (`Ready`/`XSKRegistered`)
      so its live-binding `Flags == userspaceBindingReady` assertion holds.
      (Map-touching apply/watchdog tests require BPF privilege and skip in
      the sandbox; they run in the privileged cluster/CI.)
- [x] **`make test-failover` (HARD GATE) — 14/14 passed, 0 failed.** iperf3
      survived unclean fw0 reboot (failover to fw1), rejoin as secondary,
      and manual failover; throughput 14.7 Gbps. **No-deadlock proof:**
      journal shows "userspace: XSK liveness proven" ~1s after RG readiness
      — bindings reached READY promptly under the gate.
- [x] **Smoke matrix on loss userspace cluster** (deploy + re-apply CoS):
  - **Pass A (CoS disabled):** v4+v6 × push+reverse 0 retrans;
    multi-stream `-P 12 -R` v4 22.8 Gbps / v6 22.6 Gbps, 0 retrans
    (steady-state; first-run v6 retrans was a warm-up transient that
    settled to 0).
  - **Pass B (CoS enabled):** per-class 5201-5206 v4+v6 × push+reverse —
    shapers enforce rates cleanly (100m→96Mb, 1g→959Mb, 3g→2.86Gb,
    6g→5.7Gb) with **0 retrans on the shaped/classified push path**;
    CoS multi-stream `-P 12` on 5206 (12g) hit 11.0 Gbps v4 / 10.9 Gbps
    v6, 0 retrans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)