### PR TITLE
Regenerate refactoring-audit artifact to fix make audit-check on master

### DIFF
--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,4 +1,4 @@
-[REFACTOR]   2957  userspace-dp/src/afxdp/poll_descriptor/mod.rs
+[REFACTOR]   2983  userspace-dp/src/afxdp/poll_descriptor/mod.rs
 [REFACTOR]   2113  pkg/dataplane/maps.go
 [REFACTOR]   2085  pkg/routing/routing.go
 [REFACTOR]   2055  pkg/config/types.go
@@ -7,10 +7,11 @@
 [WATCH]      1923  pkg/config/ast.go
 [WATCH]      1792  userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
 [WATCH]      1784  pkg/dataplane/userspace/manager.go
+[WATCH]      1745  userspace-dp/src/afxdp/cold_path_hist.rs
 [WATCH]      1725  userspace-dp/src/afxdp/wg/engine.rs
 [WATCH]      1695  pkg/dataplane/compiler.go
 [WATCH]      1667  userspace-dp/src/afxdp/forwarding/mod.rs
 [WATCH]      1662  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1652  cmd/cli/show.go
-[WATCH]      1559  pkg/dataplane/userspace/maps_sync.go
+[WATCH]      1617  pkg/dataplane/userspace/maps_sync.go
 [WATCH]      1501  pkg/cmdtree/tree.go


### PR DESCRIPTION
## Summary

#1671 added the `make audit-check` drift guard but merged with a **stale artifact**: a force-push of the rebased+regenerated branch silently failed (no upstream refspec), so the squash-merge captured the pre-#1635/#1666 LOC. `make audit-check` is consequently RED on master.

This regenerates `docs/refactoring-audit-current.txt` against current master so committed == fresh:
- `poll_descriptor/mod.rs` 2957 → 2983 (#1635 histogram redesign)
- `cold_path_hist.rs` new WATCH entry 1745 (#1635)
- `maps_sync.go` 1559 → 1617 (#1666 READY-gate)

`make audit-check` now passes (verified deterministic, run twice). Mechanical regeneration of a generated artifact — validated by the deterministic guard it restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)