### PR TITLE
userspace-dp: fix --features debug-log build (ICMPV6_EMBED_LOGGED private) (#1678)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildTime=$(BUILD_TIME)
 
 # eBPF compilation flags
-.PHONY: all generate generate-userspace-xdp build-userspace-xdp build build-ctl build-userspace-dp proto install clean test audit-check test-connectivity test-failover test-double-failover test-active-active test-stress-failover test-ha-crash test-chained-crash test-private-rg test-restart-connectivity
+.PHONY: all generate generate-userspace-xdp build-userspace-xdp build build-ctl build-userspace-dp build-userspace-dp-debug-log proto install clean test audit-check test-connectivity test-failover test-double-failover test-active-active test-stress-failover test-ha-crash test-chained-crash test-private-rg test-restart-connectivity
 
 all: generate build build-ctl
 
@@ -44,6 +44,17 @@ build-ctl:
 build-userspace-dp:
 	$(CARGO) build --manifest-path userspace-dp/Cargo.toml --release
 	install -m 0755 userspace-dp/target/release/xpf-userspace-dp ./xpf-userspace-dp
+
+# Manual build check for the diagnostic `debug-log` feature (#1678).
+# The debug-log build is not the production target and is deliberately
+# NOT wired into `all`/`build`/`test`, mirroring the opt-in
+# `audit-check` precedent. There is no CI in this repo, so this is a
+# developer convenience, not an automated gate: nothing runs it unless
+# invoked. It exists so the feature build (which silently rotted until
+# #1678 because nothing compiled it) can be revalidated with one
+# command before a commit. Compile-only; does not install.
+build-userspace-dp-debug-log:
+	$(CARGO) build --manifest-path userspace-dp/Cargo.toml --release --features debug-log
 
 # Generate protobuf/gRPC code
 proto:

--- a/docs/pr/1678-debuglog/plan.md
+++ b/docs/pr/1678-debuglog/plan.md
@@ -108,7 +108,7 @@ cargo targets are `build-userspace-dp` (default features) and `make test`
 
 - (A) Add a `build-userspace-dp-debug-log` Makefile target that runs
   `cargo build --release --features debug-log` so the feature build can
-  be checked locally and can't silently rebreak.
+  be checked locally with a one-command manual rebreak check.
 - (B) Note the gap and do nothing structural.
 
 This plan adds a minimal, **manual** guard: a phony Makefile target

--- a/docs/pr/1678-debuglog/plan.md
+++ b/docs/pr/1678-debuglog/plan.md
@@ -1,0 +1,165 @@
+# #1678 — fix `--features debug-log` build (ICMPV6_EMBED_LOGGED private)
+
+Status: DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+The `debug-log` feature build of `userspace-dp` does not compile on
+master. `cargo build --release --features debug-log` fails with:
+
+```
+error[E0425]: cannot find value `ICMPV6_EMBED_LOGGED` in this scope
+    --> src/afxdp/poll_descriptor/mod.rs:1220:40
+note: static `crate::afxdp::bpf_map::ICMPV6_EMBED_LOGGED` exists but is inaccessible
+    --> src/afxdp/bpf_map/mod.rs:871:1
+```
+
+The default (`default = []`) release build is unaffected. This is a
+pure build-config / symbol-visibility defect — no runtime or dataplane
+behaviour change.
+
+## Root cause (verified)
+
+`ICMPV6_EMBED_LOGGED` is defined private in `bpf_map`:
+
+```rust
+// userspace-dp/src/afxdp/bpf_map/mod.rs
+pub(super) static SESSION_CREATIONS_LOGGED: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "debug-log")]
+static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);   // line 871 — no `pub`
+```
+
+The consumer references it unqualified:
+
+```rust
+// userspace-dp/src/afxdp/poll_descriptor/mod.rs:1220 (inside #[cfg(feature="debug-log")])
+let icmpv6_trace = meta.protocol == PROTO_ICMPV6
+    && ICMPV6_EMBED_LOGGED.fetch_add(1, Ordering::Relaxed) < 32;
+```
+
+Resolution chain (confirmed by reading the source):
+
+1. `afxdp/mod.rs:144` has `use self::bpf_map::*;` — this glob pulls in
+   every `bpf_map` item *visible to `afxdp`* into the `afxdp` namespace.
+2. `poll_descriptor/mod.rs:31` has `use super::*;` — re-globs everything
+   in `afxdp` (including what step 1 imported).
+3. The sibling `SESSION_CREATIONS_LOGGED` is `pub(super)` (visible to
+   `crate::afxdp`), so it reaches `afxdp` via the glob and resolves in
+   `poll_descriptor` (used unqualified at line 1810).
+4. `ICMPV6_EMBED_LOGGED` is *private to `bpf_map`*, so the glob at
+   `afxdp/mod.rs:144` cannot see it → it never reaches `afxdp` → the
+   `use super::*` in `poll_descriptor` cannot resolve it. E0425.
+
+## Scope of the break (verified — exactly one symbol)
+
+`grep -rn ICMPV6_EMBED_LOGGED` returns exactly two hits: the definition
+(`bpf_map/mod.rs:871`) and the single consumer (`poll_descriptor/mod.rs:1220`).
+A full `cargo build --release --features debug-log` reports exactly **1**
+error (`E0425`) plus 36 pre-existing warnings (unused assignments etc.,
+not errors). The issue body's mention of a second reference in
+`tx/dispatch/mod.rs` is stale — no such reference exists on current
+master. So the fix is a single symbol re-scope; there are no other
+debug-log-only build breaks.
+
+## Fix
+
+Match the sibling exactly: change
+
+```rust
+static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);
+```
+
+to
+
+```rust
+pub(super) static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);
+```
+
+`pub(super)` = visible to the parent module `crate::afxdp`, which is the
+exact scope the consumer resolves through (steps 1–3 above). This is the
+minimal correct visibility: it is identical to `SESSION_CREATIONS_LOGGED`
+and `SESSION_PUBLISH_VERIFY_OK/FAIL` immediately above it, and it does
+NOT widen to `pub(crate)` or `pub`. `pub(in crate::afxdp)` (the issue's
+suggestion) is semantically identical here because `bpf_map`'s `super`
+*is* `crate::afxdp`; `pub(super)` is preferred only because it matches
+the established sibling spelling on adjacent lines.
+
+The consumer needs no import change: once the static is `pub(super)` it
+flows through the same two-hop glob as `SESSION_CREATIONS_LOGGED`.
+
+## Hidden invariants preserved
+
+- **No runtime change in the default build.** The static is
+  `#[cfg(feature = "debug-log")]`-gated; under `default = []` it does not
+  exist, so the visibility change is a no-op for the production binary.
+  Visibility annotations have no codegen effect regardless.
+- **No new symbol exposure beyond the crate.** `pub(super)` keeps it
+  internal to `crate::afxdp`; nothing outside that module can name it.
+- **Side-effect ordering / atomics unchanged.** Only the visibility
+  keyword changes; the `AtomicU32` and its single `fetch_add(_, Relaxed)`
+  use are untouched.
+
+## CI guard
+
+There is no `.github/workflows` (the repo has no GitHub Actions CI) and
+no Makefile target that builds with `--features debug-log`. The only
+cargo targets are `build-userspace-dp` (default features) and `make test`
+(Go only). Options considered:
+
+- (A) Add a `build-userspace-dp-debug-log` Makefile target that runs
+  `cargo build --release --features debug-log` so the feature build can
+  be checked locally and can't silently rebreak.
+- (B) Note the gap and do nothing structural.
+
+This plan proposes a minimal, opt-in guard: add a phony Makefile target
+`build-userspace-dp-debug-log` (standalone, not wired into `all`/`test`,
+mirroring the `audit-check` precedent of an opt-in drift guard) that
+compiles the debug-log feature. This gives a one-command rebreak check
+without slowing the default build or inventing CI that doesn't exist.
+Open question for reviewers below: is even target (A) over-reach for a
+one-symbol fix, or is the guard warranted given the feature build was
+silently broken until #1282 stumbled on it?
+
+## Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression | NONE | Visibility keyword only; default build has no such symbol. |
+| Lifetime / borrow-checker | NONE | No borrows touched. |
+| Performance regression | NONE | No codegen change in any build. |
+| Architectural mismatch | NONE | Matches the adjacent sibling convention exactly. |
+
+## Test plan
+
+- `cargo build --release --features debug-log` compiles clean (was: E0425).
+- Default `cargo build --release` still compiles (no-feature path unchanged).
+- `cargo test --release` stays green (no test regressions).
+- Go suite unaffected (no Go change) — spot-check `make test` not required
+  since no Go files change, but will note it.
+
+## Out of scope
+
+- The 36 pre-existing `unused_assignments` warnings in the debug-log
+  build (`tx/dispatch/mod.rs` `build_failed` / `fallback_to_slow_path`).
+  Those are warnings, not errors, and predate this fix. File separately
+  if cleanup is wanted.
+
+## Open questions for adversarial review
+
+1. Is `pub(super)` the minimal-correct visibility, or is there any
+   consumer outside `crate::afxdp` (now or imminently) that would force
+   `pub(crate)`? (Grep says no — only `poll_descriptor`, a child of
+   `afxdp`.)
+2. Does relying on the two-hop glob (`bpf_map::*` → `afxdp` → `super::*`
+   → `poll_descriptor`) introduce any ambiguity / shadowing risk vs. an
+   explicit `use crate::afxdp::bpf_map::ICMPV6_EMBED_LOGGED;` at the
+   consumer? (The sibling already relies on the glob, so this matches
+   precedent — but is explicit-import the better fix?)
+3. Is adding the `build-userspace-dp-debug-log` Makefile guard worth it,
+   or scope creep on a one-symbol fix?
+4. Are there OTHER feature flags (besides `debug-log`) whose builds are
+   also broken on master that this PR should sweep, or strictly out of
+   scope? (Plan asserts `debug-log` is the only feature; reviewers
+   should verify against `Cargo.toml [features]`.)
+5. Any reason `pub(in crate::afxdp)` should be preferred over
+   `pub(super)` here despite being semantically identical?

--- a/docs/pr/1678-debuglog/plan.md
+++ b/docs/pr/1678-debuglog/plan.md
@@ -1,6 +1,6 @@
 # #1678 — fix `--features debug-log` build (ICMPV6_EMBED_LOGGED private)
 
-Status: DRAFT v1 — pending adversarial plan review
+Status: PLAN-READY v2 — Codex PLAN-NEEDS-MINOR (Makefile framing, addressed below), AGY PLAN-READY (empirically verified), Claude SMR PLAN-READY
 
 ## Issue framing
 
@@ -111,14 +111,18 @@ cargo targets are `build-userspace-dp` (default features) and `make test`
   be checked locally and can't silently rebreak.
 - (B) Note the gap and do nothing structural.
 
-This plan proposes a minimal, opt-in guard: add a phony Makefile target
-`build-userspace-dp-debug-log` (standalone, not wired into `all`/`test`,
-mirroring the `audit-check` precedent of an opt-in drift guard) that
-compiles the debug-log feature. This gives a one-command rebreak check
-without slowing the default build or inventing CI that doesn't exist.
-Open question for reviewers below: is even target (A) over-reach for a
-one-symbol fix, or is the guard warranted given the feature build was
-silently broken until #1282 stumbled on it?
+This plan adds a minimal, **manual** guard: a phony Makefile target
+`build-userspace-dp-debug-log` (standalone, NOT wired into
+`all`/`build`/`test`, mirroring the `audit-check` precedent of an
+opt-in drift guard) that compiles the debug-log feature. To be precise
+about what this is and is not (Codex round-1 finding): there is no CI in
+this repo, so this target is a **manual convenience for local
+pre-commit validation**, not an automated gate — nothing runs it unless
+a developer invokes it. It does not slow the default build and does not
+invent CI that doesn't exist. AGY round-1 endorsed it as warranted
+(feature builds rot when nothing compiles them); Codex round-1 flagged
+only that the plan must not over-claim it as a "guard that prevents
+rebreak" — corrected here to "manual one-command rebreak check".
 
 ## Risk assessment
 

--- a/docs/pr/1678-debuglog/reviewer-ids.md
+++ b/docs/pr/1678-debuglog/reviewer-ids.md
@@ -1,0 +1,21 @@
+# #1678 reviewer task-id ledger
+
+Branch: pr/1678-debuglog
+Plan commit: 2bc4af81a
+
+## Plan review (round 1)
+
+| Reviewer | Task ID | Verdict |
+|---|---|---|
+| Codex | task-mprwpfr2-6bx57s | PLAN-NEEDS-MINOR (Makefile framing) → addressed |
+| AGY | review-mprwpnrr-388qye | PLAN-READY (empirically verified build) |
+| Claude SMR | inline | PLAN-READY |
+
+## Code review (round 1)
+
+| Reviewer | Task ID | Verdict |
+|---|---|---|
+| Codex | | |
+| AGY | | |
+| Copilot | | |
+| Claude SMR | inline | |

--- a/docs/pr/1678-debuglog/reviewer-ids.md
+++ b/docs/pr/1678-debuglog/reviewer-ids.md
@@ -11,11 +11,17 @@ Plan commit: 2bc4af81a
 | AGY | review-mprwpnrr-388qye | PLAN-READY (empirically verified build) |
 | Claude SMR | inline | PLAN-READY |
 
-## Code review (round 1)
+## Code review (round 1) — PR #1681, head 2ab700c39
 
 | Reviewer | Task ID | Verdict |
 |---|---|---|
-| Codex | | |
-| AGY | | |
-| Copilot | | |
-| Claude SMR | inline | |
+| Codex | task-mprx1r19-tdi4ly / mprx983k / mprxepe9 | BLOCKED-INFRA x3 (sandbox runner ENOENT — not a code finding) |
+| AGY | review-mprx1uat-68kojx | MERGE-READY (empirically rebuilt both configs + ran both test suites) |
+| Copilot | copilot-pull-request-reviewer | COMMENTED, no inline findings (clean) |
+| Claude SMR | inline | MERGE-READY |
+
+Note: Codex local sandbox runner is environmentally broken this session
+(every job fails with `Failed to create unified exec process: No such
+file or directory`). Three retries per feedback_codex_infra_must_retry;
+all BLOCKED-INFRA. Parent decides whether to accept 3-of-4-clean +
+Codex-infra-blocked or re-run Codex when the runner recovers.

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -868,7 +868,7 @@ pub(super) static SESSION_PUBLISH_VERIFY_OK: AtomicU64 = AtomicU64::new(0);
 pub(super) static SESSION_PUBLISH_VERIFY_FAIL: AtomicU64 = AtomicU64::new(0);
 pub(super) static SESSION_CREATIONS_LOGGED: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "debug-log")]
-static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);
+pub(super) static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);
 
 // The pinned map path keeps the historical "fallback" spelling for
 // mixed-version shim compatibility. Operator-facing names use


### PR DESCRIPTION
## Summary

- The `userspace-dp` `--features debug-log` build failed to compile on master with `E0425: cannot find value ICMPV6_EMBED_LOGGED in this scope`. The static at `afxdp/bpf_map/mod.rs:871` was declared private but is referenced under `#[cfg(feature = "debug-log")]` from `afxdp/poll_descriptor/mod.rs:1220`.
- Root cause: the consumer resolves the symbol through a two-hop glob (`use self::bpf_map::*` in `afxdp/mod.rs:144`, then `use super::*` in `poll_descriptor/mod.rs:31`). A *private* `bpf_map` item never reaches `afxdp`, so the glob can't surface it. The sibling `SESSION_CREATIONS_LOGGED` is `pub(super)` and resolves fine through the same path.
- Fix: re-scope `ICMPV6_EMBED_LOGGED` to `pub(super)`, matching the adjacent sibling exactly. Minimal-correct visibility (visible to `crate::afxdp`, the consumer's scope; not widened to `pub(crate)`/`pub`). No codegen change in any build — the static is debug-log-gated and absent from the default production binary.
- Added a standalone **manual** Makefile target `build-userspace-dp-debug-log` (compile-only, not wired into `all`/`build`/`test`, mirroring `audit-check`) so the feature build can be revalidated with one command. There is no CI in this repo, so this is a developer convenience, not an automated gate.

Default (no-feature) build and behaviour are unchanged.

## Plan + adversarial review

Plan doc: `docs/pr/1678-debuglog/plan.md`

- Codex plan review: PLAN-NEEDS-MINOR (Makefile over-claimed as a "guard"; reframed as manual check) — addressed
- AGY plan review: PLAN-READY (empirically compiled the `--features debug-log` build in the worktree and confirmed the resolution chain)
- Claude SMR: PLAN-READY

## Test plan

- [x] `cargo build --release --features debug-log`: clean (was: E0425)
- [x] `cargo build --release` (default features): clean, unchanged
- [x] `cargo test --release`: 1589 + 46 + 8 + 16 + 1 pass, 0 failed
- [x] `make build-userspace-dp-debug-log`: exits 0
- [x] No Go change — Go suite unaffected (no Go files touched)

No smoke: this is a build-config / symbol-visibility fix with no runtime or dataplane behaviour change.

Closes #1678

🤖 Generated with [Claude Code](https://claude.com/claude-code)