### PR TITLE
Regenerate refactoring-audit artifact after #1628 queue_service growth

### DIFF
--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -9,9 +9,10 @@
 [WATCH]      1784  pkg/dataplane/userspace/manager.go
 [WATCH]      1745  userspace-dp/src/afxdp/cold_path_hist.rs
 [WATCH]      1725  userspace-dp/src/afxdp/wg/engine.rs
+[WATCH]      1711  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1695  pkg/dataplane/compiler.go
 [WATCH]      1667  userspace-dp/src/afxdp/forwarding/mod.rs
-[WATCH]      1662  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1652  cmd/cli/show.go
 [WATCH]      1617  pkg/dataplane/userspace/maps_sync.go
+[WATCH]      1520  userspace-dp/src/afxdp/coordinator/mod.rs
 [WATCH]      1501  pkg/cmdtree/tree.go


### PR DESCRIPTION
## Summary
#1628 (per-class waterfill instrumentation, merged) grew the audit-tracked `queue_service/mod.rs` 1662→1711, so `make audit-check` drifted on master. Regenerate the committed artifact so the guard is green. Mechanical regen of the generated artifact, validated by the deterministic guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)