### PR TITLE
Regenerate refactoring-audit artifact after #1319 PR1

### DIFF
--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -2,9 +2,9 @@
 [REFACTOR]   2113  pkg/dataplane/maps.go
 [REFACTOR]   2085  pkg/routing/routing.go
 [REFACTOR]   2055  pkg/config/types.go
+[REFACTOR]   2021  pkg/config/ast.go
 [REFACTOR]   2006  pkg/grpcapi/server_show.go
 [WATCH]      1986  pkg/cli/cli_show_security.go
-[WATCH]      1923  pkg/config/ast.go
 [WATCH]      1792  userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
 [WATCH]      1784  pkg/dataplane/userspace/manager.go
 [WATCH]      1745  userspace-dp/src/afxdp/cold_path_hist.rs
@@ -15,4 +15,3 @@
 [WATCH]      1652  cmd/cli/show.go
 [WATCH]      1617  pkg/dataplane/userspace/maps_sync.go
 [WATCH]      1520  userspace-dp/src/afxdp/coordinator/mod.rs
-[WATCH]      1501  pkg/cmdtree/tree.go


### PR DESCRIPTION
#1319 PR1 changed audit-tracked ast.go (+fields) and cmdtree/tree.go (-overlay), drifting the artifact. Regenerate so make audit-check stays green. Mechanical regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)