### PR TITLE
#1687: shared NAT presentation package (pkg/natshow)

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -291,11 +291,14 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/grpcapi/server_show.go` | gRPC show dispatcher still reaches legacy dataplane state. |
 | `pkg/grpcapi/server_show_cluster_text.go` | Cluster text output still reads legacy dataplane state. |
 | `pkg/grpcapi/server_show_flow.go` | Flow text output still uses legacy session keys and values. |
-| `pkg/grpcapi/server_show_nat.go` | NAT text output still uses legacy NAT/session metadata. |
 | `pkg/grpcapi/server_show_policies_text.go` | Policy text output still uses legacy counters. |
 | `pkg/grpcapi/server_show_security_text.go` | Security text output still uses legacy counters and filter types. |
 | `pkg/grpcapi/server_show_status.go` | Status output still reads legacy dataplane state. |
 | `pkg/grpcapi/server_show_zones.go` | Zone output still uses legacy dataplane types. |
+| `pkg/natshow/natshow.go` | #1687 — shared NAT presenter `Reader` interface names root `pkg/dataplane` session/counter types (`SessionKey`, `CounterValue`, `PersistentNATTable`). Net-neutral consolidation: the import moved here from `server_show_nat.go` (which no longer imports root dataplane) and is still named by `cli_show_nat.go`. |
+| `pkg/natshow/source.go` | #1687 — shared source-NAT rule-detail renderer iterates legacy `SessionKey`/`Value` via the `Reader`. |
+| `pkg/natshow/dest.go` | #1687 — shared destination-NAT rule-detail renderer iterates legacy `SessionKey`/`Value` via the `Reader`. |
+| `pkg/natshow/persistent.go` | #1687 — shared persistent-NAT renderers iterate legacy `SessionKey`/`Value` and read `PersistentNATTable` via the `Reader`. |
 
 ### Safe-Delete Blockers
 

--- a/docs/pr/1687-shared-presentation/plan.md
+++ b/docs/pr/1687-shared-presentation/plan.md
@@ -1,0 +1,232 @@
+# #1687 — Shared security/NAT/flow presentation package
+
+**Status:** DRAFT v1 — pending adversarial plan review. **Author leans PLAN-KILL** (see verdict thesis); inviting reviewers to refute with a viable narrower seam.
+
+## Issue framing
+
+#1687 (promoted from #1661 backlog item 3) asks to factor the
+"duplicated" security/NAT/flow presentation logic in
+`pkg/grpcapi/server_show.go` (2006 LOC) and
+`pkg/cli/cli_show_security.go` (1986 LOC) into a **shared presentation
+package** consumed by both the gRPC and CLI show paths — "a real
+shared-rendering seam, NOT more dispatcher files." The issue states a
+hard invariant: **the two consumers must produce byte-identical output
+post-split**, proven by golden tests on both paths. The issue itself
+authorizes PLAN-KILL "if the duplication isn't cleanly factorable."
+
+## Honest scope/value framing
+
+If the two paths genuinely produced the same output, a shared renderer
+would delete ~1-2K LOC of duplication and make the operator-facing show
+contract single-sourced. That would be real value.
+
+**But the core premise is false on master.** The gRPC and CLI security
+presenters are *independently authored, structurally divergent*
+renderers that only superficially resemble each other. They do not
+produce byte-identical output today, and several do not even produce
+*feature-equivalent* output. A "shared package" that preserved both
+behaviors would need consumer-specific branches at nearly every
+field — i.e. no real shared seam, just a parameterized fork. That is
+precisely the #961 PacketContext / #1544 file-motion dead-end the issue
+and the project's standing rules warn against.
+
+*If reviewers conclude the perf gain is too small to justify the churn,
+PLAN-KILL is an acceptable verdict.* Here the relevant axis is not perf
+but **architectural fit + contract risk**: forcing the shared seam
+requires either (a) changing operator-visible CLI or gRPC output to
+make them match (a behavior change, not a refactor, and a regression to
+whichever side loses its richer output), or (b) a branch-everywhere
+"shared" type that adds indirection without removing real duplication.
+
+## What's already shipped / structure on master
+
+- `server_show.go` is **already a topic dispatcher** (`ShowText`): most
+  cases delegate to extracted helpers `server_show_{nat,flow,firewall,
+  security_text,zones_text,...}.go` (the #1043 phased decomposition).
+  The remaining inline cases (alg, address-book, ike, screen-*,
+  routing-options, event-options, backup-router) write to a
+  `*strings.Builder`.
+- `cli_show_security.go` is a set of `(c *CLI) showX()` methods that
+  print directly to **stdout** via `fmt.Println` / `fmt.Printf`, routed
+  by `cli_show_security_dispatch.go`. The CLI does **not** call gRPC
+  `ShowText` for these topics — it has fully independent local
+  renderers.
+- There is **no** existing shared presentation package, and no import
+  of one from either side.
+
+## Evidence: the two render paths are divergent, not duplicated
+
+Four representative parallel pairs, read end-to-end on master:
+
+### 1. `screen-ids-option`
+- gRPC (`server_show.go:194-254`): hardcoded column spacing —
+  `"  Name                                        Value\n"` and
+  `"  TCP land attack                             enabled\n"` (literal
+  spaces baked into each string).
+- CLI (`cli_show_security.go:514-584`): `fmt.Printf("  %-45s %s\n",
+  "Name", "Value")` and `fmt.Printf("  %-45s %s\n", "TCP land attack",
+  "enabled")`.
+- **Verdict:** `%-45s` width vs hand-counted literal spacing → NOT
+  byte-identical. A shared renderer must pick one; either changes the
+  other consumer's output.
+
+### 2. `alg`
+- gRPC (`server_show.go:824-833`): 4 lines —
+  `"SIP:  %s\n" / "FTP: / "TFTP: / "DNS:` via `boolStatus()`.
+- CLI (`cli_show_security.go:1848-1885`): header `"ALG Status:"`, then
+  16 protocols (`DNS FTP H323 MGCP MSRPC PPTP RSH RTSP SCCP SIP SQL
+  SUNRPC TALK TFTP IKE-ESP TWAMP`) via `"  %-9s: %s\n"` with
+  "Enabled"/"Disabled".
+- **Verdict:** completely different content (4 vs 16 protocols),
+  different header, different format. Not factorable without changing
+  one side's behavior.
+
+### 3. `address-book`
+- gRPC (`server_show.go:868-885`): `"Addresses:\n"` + `"  %-20s %s\n"`;
+  `"Address sets:\n"` + `"  %-20s members: %s\n"`. Map iteration (no
+  sort), no name filter, no nested-set `set:` prefix, no member-detail
+  expansion, no empty fallback.
+- CLI (`cli_show_security.go:784-845`): `"  %-24s %s\n"`; name-filter
+  support; nested address-sets shown as `set:NAME`; member-detail
+  expansion when filtered; `"Address book is empty"` fallback.
+- **Verdict:** different column width (20 vs 24) AND the CLI has
+  features gRPC lacks (filter, nested-set prefix, member detail). Not
+  even feature-equivalent.
+
+### 4. `applications`
+- gRPC (`server_show_security_text.go:230-275`): header
+  `"Applications:"`, dense single line `"  %-24s proto=%-6s
+  dst-port=... src-port=... timeout=... alg=... (desc)"`.
+- CLI (`cli_show_security.go:846-973`): header `"User-defined
+  applications:"`, `detail` + `<name>` filter sub-commands, multi-line
+  detail block (`Application:`, `  Description:`, `  IP protocol:`, ...),
+  brief format `"  %-24s protocol: %-6s port: %s"`.
+- **Verdict:** different header text, different field syntax
+  (`proto=tcp` vs `protocol: tcp`), CLI has detail/filter modes gRPC
+  lacks. Not byte-identical, not feature-equivalent.
+
+Across all four sampled pairs the output diverges. The "duplication" is
+**parallel evolution of two distinct operator contracts**, not a single
+contract copy-pasted.
+
+## Why the issue's stated invariant cannot be met by a refactor
+
+The issue's acceptance gate is *byte-identical output before/after on
+both consumers*, proven by golden tests. Golden tests written against
+master would capture two **different** golden files per topic. A shared
+renderer can reproduce at most one of them per topic; reproducing both
+requires per-consumer branches keyed on caller identity at nearly every
+field — which is not a shared seam, it is a fork with a shared name. So:
+
+- **Pure code-motion is impossible** (the outputs differ, so you cannot
+  move one body and call it from both).
+- **A genuine shared seam is impossible** without first *unifying the
+  output contract*, which is a behavior change to the CLI and/or gRPC
+  operator-facing surface — out of scope for a refactor, and a
+  regression for whichever side loses its richer output (the CLI's
+  filter/detail/nested-set features, the gRPC's distinct formats).
+
+This matches the documented dead-ends: #961 PacketContext (forced a
+shared abstraction that didn't fit), #1544 lesson (file-motion that
+isn't a real seam), and the project's standing rule to kill
+"Refactor: <Pattern>" issues that don't fit codebase reality.
+
+## Concrete design (the only honest options)
+
+1. **PLAN-KILL (recommended).** The duplication is not cleanly
+   factorable; the byte-identical invariant is already false on master.
+   Label `plan-kill`, close, comment verdicts.
+
+2. **Narrow salvage, IF reviewers find one** — extract only the handful
+   of *genuinely identical, pure config→string helpers* that are
+   byte-for-byte equal on both sides (candidate: `boolStatus`,
+   `firewallFilterTermExpansionCount` vs `filterTermExpansionCount`,
+   `screenSYNCookieCounterRows` which both already delegate to
+   `dpuserspace.FormatSYNCookieCounterRows`). This would be a tiny,
+   honest dedup (tens of LOC), NOT the "shared presentation package"
+   the issue scopes, and would barely move the audit LOC. Reviewers must
+   confirm each candidate is byte-identical before it qualifies.
+
+3. **Re-scope to contract-unification (out of scope here).** A separate,
+   non-refactor work item could *intentionally* unify the CLI and gRPC
+   output for these topics (deciding which format wins per topic), then
+   build the shared renderer on the unified contract. That is a
+   behavior-change project requiring operator sign-off, not #1687.
+
+## Public API preservation
+
+N/A under option 1. Under option 2, only internal unexported helpers
+move; no exported gRPC/CLI signatures change.
+
+## Hidden invariants
+
+- Operator-visible output of every `show` topic on BOTH consumers must
+  not change (the whole point — and the reason the broad split fails).
+- CLI prints to stdout; gRPC accumulates into `*strings.Builder` and
+  returns over the wire. Any shared helper must take an `io.Writer` /
+  `*strings.Builder` sink, not print directly — another structural
+  mismatch the broad split would have to paper over.
+
+## Risk assessment
+
+| Class | Level | Note |
+|-------|-------|------|
+| Behavioral regression | **HIGH** | Forcing a shared renderer changes one consumer's operator-visible output for nearly every sampled topic. |
+| Lifetime/borrow (Go: aliasing) | LOW | Go; not the issue. |
+| Performance | N/A | Control-plane show path, not hot path. |
+| **Architectural mismatch (#961/#1544)** | **HIGH** | Two divergent contracts; "shared" type would be a branch-everywhere fork. This is the kill axis. |
+
+## Test plan (if any option 2 salvage proceeds)
+
+- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./...` all green.
+- Golden/snapshot tests on BOTH `grpcapi` `ShowText` and `cli` show
+  paths for every touched topic, asserting output is byte-identical
+  before/after (captured on master first). Any candidate helper that
+  changes either golden is disqualified.
+- `make audit-check` green on rebased branch; regen
+  `docs/refactoring-audit-current.txt`.
+- No cluster smoke (control-plane only) — state explicitly in PR.
+
+## Out of scope
+
+- Unifying the CLI/gRPC output contract (behavior change; needs its own
+  issue + operator sign-off).
+- The broader grpcapi package restructure (#1661 addendum-4 #24
+  `server_sessions`, addendum-9).
+- #1686 (dataplane/maps.go) — disjoint file scope; no conflict.
+
+## Open questions for adversarial review (each invitable to PLAN-KILL)
+
+1. Are the four sampled pairs representative, or is there a large
+   subset of topics where gRPC and CLI **are** byte-identical and
+   cleanly shareable? (If a real shared majority exists, the kill is
+   wrong — produce the list with file:line proof.)
+2. Is option 2 (narrow byte-identical-helper dedup) worth doing at all,
+   or is it churn below the noise floor that should just be left alone?
+3. Does the issue's "byte-identical output post-split" invariant
+   *actually* mean "identical to the consumer's own pre-split output"
+   (my reading), or "identical to each other" (which is already false
+   and would require a behavior change)? Either reading supports KILL of
+   the broad split; confirm.
+4. Is re-scoping to contract-unification (option 3) the right follow-up,
+   or should #1687 simply be closed as not-cleanly-factorable?
+5. Is there any seam I'm missing — e.g. a shared *data-model* (typed
+   intermediate structs) feeding two thin per-consumer formatters —
+   that would dedup the config-walking logic without touching the
+   divergent formatting? Quantify how much of each function is
+   config-walk vs format-emit before answering.
+
+   **Author's answer (steelman, then rejected):** the config-walk in
+   these functions is trivial (~3 lines: build name slice,
+   `sort.Strings`, range) — there is almost nothing to dedup. The bulk
+   is per-field format-emit, which diverges. Worse, where the walk *is*
+   non-trivial it also diverges: the CLI `address-book` walk has
+   name-filter + nested-`set:` expansion + member-detail that the gRPC
+   walk lacks, so a shared data-model would itself need consumer-keyed
+   walk parameters. And the one genuinely cross-cutting renderer
+   (`FormatSYNCookieCounterRows` + `SumSYNCookieCounters`) is **already
+   shared** in `pkg/dataplane/userspace/statusfmt.go:39,56` — both
+   consumers already call it. The factorable duplication was already
+   factored. The data-model seam does not exist here. Reviewers: refute
+   with a concrete typed-struct design + the per-function walk/format
+   LOC split if you disagree.

--- a/docs/pr/1687-shared-presentation/plan.md
+++ b/docs/pr/1687-shared-presentation/plan.md
@@ -1,8 +1,47 @@
 # #1687 — Shared NAT presentation seam (re-scoped)
 
-**Status:** DRAFT v2 — re-scoped after round-1 plan review. Universal
+**Status:** PLAN-READY v3 — round-2 converged (AGY PLAN-READY; Codex
+PLAN-NEEDS-MINOR, both minors folded in below). Universal
 shared-presentation package KILLED; bounded shared NAT renderer
-PROPOSED. Pending round-2 adversarial review.
+(`pkg/natshow`) APPROVED for implementation.
+
+## Round-2 verdicts
+
+- **AGY (adversarial-review-mpsgrpyp-6vmsdo): PLAN-READY.** Reversed its
+  round-1 misread after reading the leaf bodies directly; verified all
+  six leaf renderers byte-identical under sink normalization, the
+  `Reader` interface exact, and zero import-cycle risk.
+- **Codex (task-mpsgrdwm-mvt55w): PLAN-NEEDS-MINOR**, two items now
+  folded in:
+  1. **`nat-dest-rule-detail` leaf precondition.** The gRPC leaf
+     guards `cfg == nil || cfg.Security.NAT.Destination == nil ||
+     len(...RuleSets) == 0` and emits `"No destination NAT rules
+     configured\n"` (server_show_nat.go:195-199). The CLI leaf
+     (`showNATDestinationRuleDetail`, cli_show_nat.go:904) assumes its
+     dispatcher (`showNATDestination`, cli_show_nat.go:551-554) already
+     guarded `cfg == nil || Destination == nil` (emitting the
+     period-suffixed dispatcher message). **Resolution:** the shared
+     `RenderDestRuleDetail` adopts the **gRPC full guard verbatim**
+     (the gRPC behavior is the contract under test). The CLI dispatcher
+     keeps its existing pre-guard unchanged; for the non-empty path it
+     reaches the shared func which renders identically. The CLI golden
+     test asserts the dispatcher path is byte-identical to master.
+  2. **#1451 retirement-boundary canary.** `pkg/natshow` importing root
+     `pkg/dataplane` (unavoidable — the session-iteration callbacks use
+     `dataplane.SessionKey/Value`, and `ReadNATRuleCounter`/
+     `GetPersistentNAT` return `dataplane.CounterValue`/
+     `*dataplane.PersistentNATTable`) is flagged by
+     `TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports`
+     (retirement_boundary_canary_test.go:118) unless added to
+     `legacyDataplaneImportAllowlist` (line 31) AND the #1451 docs table
+     in `docs/pr/1373-retire-ebpf-dataplane/README.md:251`.
+     **Resolution:** add `pkg/natshow/*.go` files that import dataplane
+     to both, with the explicit design reason: "shared NAT presenter
+     extracted from server_show_nat.go + cli_show_nat.go (#1687); still
+     names root pkg/dataplane session/counter types until those move to
+     a domain package — net-neutral, consolidates two pre-existing
+     allowlisted surfaces." This is not #1451 regressing: the renderers
+     already lived in two allowlisted files; the import moves with them.
 
 ## Round-1 verdicts and resolution
 

--- a/docs/pr/1687-shared-presentation/plan.md
+++ b/docs/pr/1687-shared-presentation/plan.md
@@ -1,232 +1,212 @@
-# #1687 — Shared security/NAT/flow presentation package
+# #1687 — Shared NAT presentation seam (re-scoped)
 
-**Status:** DRAFT v1 — pending adversarial plan review. **Author leans PLAN-KILL** (see verdict thesis); inviting reviewers to refute with a viable narrower seam.
+**Status:** DRAFT v2 — re-scoped after round-1 plan review. Universal
+shared-presentation package KILLED; bounded shared NAT renderer
+PROPOSED. Pending round-2 adversarial review.
 
-## Issue framing
+## Round-1 verdicts and resolution
 
-#1687 (promoted from #1661 backlog item 3) asks to factor the
-"duplicated" security/NAT/flow presentation logic in
-`pkg/grpcapi/server_show.go` (2006 LOC) and
-`pkg/cli/cli_show_security.go` (1986 LOC) into a **shared presentation
-package** consumed by both the gRPC and CLI show paths — "a real
-shared-rendering seam, NOT more dispatcher files." The issue states a
-hard invariant: **the two consumers must produce byte-identical output
-post-split**, proven by golden tests on both paths. The issue itself
-authorizes PLAN-KILL "if the duplication isn't cleanly factorable."
+- **Codex (task-mpsghlr7-3p2gg5): PLAN-NEEDS-MAJOR.** "Kill the
+  universal shared renderer (security topics genuinely diverge), but
+  the kill is over-broad — there is a real, clean shared seam for the
+  NAT/status subset. The non-trivial walk (session counting + zoneByID)
+  is duplicated and *identical* between gRPC and CLI."
+- **AGY (adversarial-review-mpsgi8ie-81h4g8): PLAN-KILL.** Agreed the
+  security topics diverge, but dismissed the NAT subset as having "a
+  complex dispatcher hierarchy (summary/pool/rule-set/rule/detail)."
 
-## Honest scope/value framing
+**Resolution (evidence, not vote-count):** AGY's NAT dismissal is wrong.
+It conflated the CLI *dispatcher wrapper* (`showNATSource`'s
+sub-command router, which sends `summary`/`pool`/`rule-set`/`detail` to
+*different leaf functions*) with the *leaf renderer*
+`showNATSourceRuleDetail` itself. I diffed the leaf bodies after
+normalizing only the output sink (`fmt.Fprintf(buf,…)` vs
+`fmt.Printf(…)`) and the `return`/`return nil` wrapper:
 
-If the two paths genuinely produced the same output, a shared renderer
-would delete ~1-2K LOC of duplication and make the operator-facing show
-contract single-sourced. That would be real value.
+| Topic | gRPC | CLI | Rendering body |
+|-------|------|-----|----------------|
+| `nat-source-rule-detail` | server_show_nat.go:99 | cli_show_nat.go:455 | **byte-identical** |
+| `nat-dest-rule-detail` | server_show_nat.go:195 | cli_show_nat.go:904 | **byte-identical** |
+| `persistent-nat-detail` | server_show_nat.go:279 | cli_show_nat.go:1062 | **byte-identical** |
 
-**But the core premise is false on master.** The gRPC and CLI security
-presenters are *independently authored, structurally divergent*
-renderers that only superficially resemble each other. They do not
-produce byte-identical output today, and several do not even produce
-*feature-equivalent* output. A "shared package" that preserved both
-behaviors would need consumer-specific branches at nearly every
-field — i.e. no real shared seam, just a parameterized fork. That is
-precisely the #961 PacketContext / #1544 file-motion dead-end the issue
-and the project's standing rules warn against.
+The *only* diffs are: (1) the receiver/sink in the signature — exactly
+what a shared `Render(w io.Writer, …)` abstracts; (2) `return` vs
+`return nil`; (3) reworded doc-comments describing identical code; (4)
+`Fprintf(buf,"…%d\n\n")` vs `Printf("…%d\n")+Println()`, which emit
+identical bytes. Zero divergence in emitted strings or in the
+session/zone walk. This is sink-only duplicate rendering — a real seam,
+NOT the #961/#1544 dead-end. Codex's verdict stands; this plan adopts
+it. (Memory: AGY is documented low-signal on file-motion refactors —
+feedback_gemini_low_signal_on_refactor; the dispatcher-vs-leaf misread
+is that pattern.)
 
-*If reviewers conclude the perf gain is too small to justify the churn,
-PLAN-KILL is an acceptable verdict.* Here the relevant axis is not perf
-but **architectural fit + contract risk**: forcing the shared seam
-requires either (a) changing operator-visible CLI or gRPC output to
-make them match (a behavior change, not a refactor, and a regression to
-whichever side loses its richer output), or (b) a branch-everywhere
-"shared" type that adds indirection without removing real duplication.
+The simpler NAT tables (`nat-static`, `nat-nptv6`, `persistent-nat`)
+ALSO diff only by sink + wrapper, but their bodies are short (~15-25
+lines each) and they form a coherent family with the detail renderers,
+so they are included for a clean per-topic seam.
 
-## What's already shipped / structure on master
+## Final scope (what this PR does)
 
-- `server_show.go` is **already a topic dispatcher** (`ShowText`): most
-  cases delegate to extracted helpers `server_show_{nat,flow,firewall,
-  security_text,zones_text,...}.go` (the #1043 phased decomposition).
-  The remaining inline cases (alg, address-book, ike, screen-*,
-  routing-options, event-options, backup-router) write to a
-  `*strings.Builder`.
-- `cli_show_security.go` is a set of `(c *CLI) showX()` methods that
-  print directly to **stdout** via `fmt.Println` / `fmt.Printf`, routed
-  by `cli_show_security_dispatch.go`. The CLI does **not** call gRPC
-  `ShowText` for these topics — it has fully independent local
-  renderers.
-- There is **no** existing shared presentation package, and no import
-  of one from either side.
+**KILL** the universal "shared security/NAT/flow presentation package"
+premise. Security topics (`alg`, `address-book`, `applications`,
+`screen-ids-option`, `ike`, `security-log`, `dynamic-address`) are
+genuinely divergent operator contracts (different headers, column
+widths, field syntax, feature sets, sub-commands, runtime sources) and
+are explicitly PRESERVED as-is. The byte-identical invariant the issue
+states is already false for those topics on master; forcing them into a
+shared renderer would regress one consumer (the #961 pattern). This is
+documented and NOT attempted.
 
-## Evidence: the two render paths are divergent, not duplicated
+**BUILD** a bounded shared NAT renderer package, `pkg/natshow/`, with
+sink-only `Render*` functions for the six byte-identical NAT topics.
+Both consumers rewire onto it; output is proven byte-identical
+before/after by golden tests on BOTH the gRPC `ShowText` path and the
+CLI show path.
 
-Four representative parallel pairs, read end-to-end on master:
+### Package shape (module-dir layout)
 
-### 1. `screen-ids-option`
-- gRPC (`server_show.go:194-254`): hardcoded column spacing —
-  `"  Name                                        Value\n"` and
-  `"  TCP land attack                             enabled\n"` (literal
-  spaces baked into each string).
-- CLI (`cli_show_security.go:514-584`): `fmt.Printf("  %-45s %s\n",
-  "Name", "Value")` and `fmt.Printf("  %-45s %s\n", "TCP land attack",
-  "enabled")`.
-- **Verdict:** `%-45s` width vs hand-counted literal spacing → NOT
-  byte-identical. A shared renderer must pick one; either changes the
-  other consumer's output.
+`pkg/natshow/` — files by aspect:
+- `natshow.go` — package doc + the narrow `Reader` interface + shared
+  helpers (`zoneByID`, session-count walks).
+- `static.go` — `RenderStatic`, `RenderNPTv6`.
+- `source.go` — `RenderSourceRuleDetail`.
+- `dest.go` — `RenderDestRuleDetail`.
+- `persistent.go` — `RenderPersistent`, `RenderPersistentDetail`.
 
-### 2. `alg`
-- gRPC (`server_show.go:824-833`): 4 lines —
-  `"SIP:  %s\n" / "FTP: / "TFTP: / "DNS:` via `boolStatus()`.
-- CLI (`cli_show_security.go:1848-1885`): header `"ALG Status:"`, then
-  16 protocols (`DNS FTP H323 MGCP MSRPC PPTP RSH RTSP SCCP SIP SQL
-  SUNRPC TALK TFTP IKE-ESP TWAMP`) via `"  %-9s: %s\n"` with
-  "Enabled"/"Disabled".
-- **Verdict:** completely different content (4 vs 16 protocols),
-  different header, different format. Not factorable without changing
-  one side's behavior.
+### Narrow reader interface (both runtimes already satisfy it)
 
-### 3. `address-book`
-- gRPC (`server_show.go:868-885`): `"Addresses:\n"` + `"  %-20s %s\n"`;
-  `"Address sets:\n"` + `"  %-20s members: %s\n"`. Map iteration (no
-  sort), no name filter, no nested-set `set:` prefix, no member-detail
-  expansion, no empty fallback.
-- CLI (`cli_show_security.go:784-845`): `"  %-24s %s\n"`; name-filter
-  support; nested address-sets shown as `set:NAME`; member-detail
-  expansion when filtered; `"Address book is empty"` fallback.
-- **Verdict:** different column width (20 vs 24) AND the CLI has
-  features gRPC lacks (filter, nested-set prefix, member detail). Not
-  even feature-equivalent.
+```go
+// pkg/natshow/natshow.go
+type Reader interface {
+    IsLoaded() bool
+    IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+    IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+    ReadNATRuleCounter(counterID uint32) (dataplane.CounterValue, error)
+    GetPersistentNAT() *dataplane.PersistentNATTable
+}
+```
 
-### 4. `applications`
-- gRPC (`server_show_security_text.go:230-275`): header
-  `"Applications:"`, dense single line `"  %-24s proto=%-6s
-  dst-port=... src-port=... timeout=... alg=... (desc)"`.
-- CLI (`cli_show_security.go:846-973`): header `"User-defined
-  applications:"`, `detail` + `<name>` filter sub-commands, multi-line
-  detail block (`Application:`, `  Description:`, `  IP protocol:`, ...),
-  brief format `"  %-24s protocol: %-6s port: %s"`.
-- **Verdict:** different header text, different field syntax
-  (`proto=tcp` vs `protocol: tcp`), CLI has detail/filter modes gRPC
-  lacks. Not byte-identical, not feature-equivalent.
+Verified: `grpcRuntime` (pkg/grpcapi/runtime.go:12) and `cliRuntime`
+(pkg/cli/runtime.go:28) both declare every method above, so both `dp`
+fields satisfy `natshow.Reader` structurally. `*dataplane.ApplyResult`
+and `*config.Config` are the same concrete types on both sides
+(apply_result.go:5, cli.go:122).
 
-Across all four sampled pairs the output diverges. The "duplication" is
-**parallel evolution of two distinct operator contracts**, not a single
-contract copy-pasted.
+### Function signatures (sink = io.Writer)
 
-## Why the issue's stated invariant cannot be met by a refactor
+```go
+func RenderSourceRuleDetail(w io.Writer, cfg *config.Config, dp Reader, cr *dataplane.ApplyResult)
+func RenderDestRuleDetail(w io.Writer, cfg *config.Config, dp Reader, cr *dataplane.ApplyResult)
+func RenderPersistentDetail(w io.Writer, dp Reader)
+func RenderPersistent(w io.Writer, dp Reader)
+func RenderStatic(w io.Writer, cfg *config.Config)
+func RenderNPTv6(w io.Writer, cfg *config.Config)
+```
 
-The issue's acceptance gate is *byte-identical output before/after on
-both consumers*, proven by golden tests. Golden tests written against
-master would capture two **different** golden files per topic. A shared
-renderer can reproduce at most one of them per topic; reproducing both
-requires per-consumer branches keyed on caller identity at nearly every
-field — which is not a shared seam, it is a fork with a shared name. So:
+A nil `dp`/`cr` reproduces the existing "not loaded" branches. The
+gRPC side passes `&buf` (a `*strings.Builder` is an `io.Writer`); the
+CLI side passes `os.Stdout` (or `c.out` if present) — preserving the
+exact stdout behavior. The trailing-newline shape is normalized to the
+gRPC form (`…\n\n`), which is byte-identical to the CLI's
+`Printf("…\n")+Println()`.
 
-- **Pure code-motion is impossible** (the outputs differ, so you cannot
-  move one body and call it from both).
-- **A genuine shared seam is impossible** without first *unifying the
-  output contract*, which is a behavior change to the CLI and/or gRPC
-  operator-facing surface — out of scope for a refactor, and a
-  regression for whichever side loses its richer output (the CLI's
-  filter/detail/nested-set features, the gRPC's distinct formats).
+### Rewiring
 
-This matches the documented dead-ends: #961 PacketContext (forced a
-shared abstraction that didn't fit), #1544 lesson (file-motion that
-isn't a real seam), and the project's standing rule to kill
-"Refactor: <Pattern>" issues that don't fit codebase reality.
+- gRPC `server_show_nat.go`: each `(s *Server) showNATxxx(... buf)`
+  becomes a one-line `natshow.RenderXxx(buf, cfg, s.dp, s.applyResult())`.
+- CLI `cli_show_nat.go`: each `(c *CLI) showNATxxx(...)` becomes
+  `natshow.RenderXxx(c.out, cfg, c.dp, c.applyResult()); return nil`
+  (the CLI dispatcher sub-command routing in `showNATSource`/
+  `showNATDestination` is UNCHANGED — only the leaf renderer bodies move).
 
-## Concrete design (the only honest options)
+## Commit increments (no monolithic add; true merge commit)
 
-1. **PLAN-KILL (recommended).** The duplication is not cleanly
-   factorable; the byte-identical invariant is already false on master.
-   Label `plan-kill`, close, comment verdicts.
-
-2. **Narrow salvage, IF reviewers find one** — extract only the handful
-   of *genuinely identical, pure config→string helpers* that are
-   byte-for-byte equal on both sides (candidate: `boolStatus`,
-   `firewallFilterTermExpansionCount` vs `filterTermExpansionCount`,
-   `screenSYNCookieCounterRows` which both already delegate to
-   `dpuserspace.FormatSYNCookieCounterRows`). This would be a tiny,
-   honest dedup (tens of LOC), NOT the "shared presentation package"
-   the issue scopes, and would barely move the audit LOC. Reviewers must
-   confirm each candidate is byte-identical before it qualifies.
-
-3. **Re-scope to contract-unification (out of scope here).** A separate,
-   non-refactor work item could *intentionally* unify the CLI and gRPC
-   output for these topics (deciding which format wins per topic), then
-   build the shared renderer on the unified contract. That is a
-   behavior-change project requiring operator sign-off, not #1687.
+1. `pkg/natshow/` package + narrow Reader interface + shared helpers
+   (builds clean, no consumers yet).
+2. Rewire `pkg/grpcapi/server_show_nat.go` onto `natshow`.
+3. Rewire `pkg/cli/cli_show_nat.go` onto `natshow`.
+4. Golden tests: gRPC `ShowText` + CLI show path, byte-identical
+   assertions for all six topics, captured against master output.
+5. Regen `docs/refactoring-audit-current.txt`; doc updates.
 
 ## Public API preservation
 
-N/A under option 1. Under option 2, only internal unexported helpers
-move; no exported gRPC/CLI signatures change.
+No exported gRPC RPC or CLI command signature changes. Only unexported
+renderer bodies move to a new package. `ShowText` topic strings and CLI
+command grammar unchanged.
 
 ## Hidden invariants
 
-- Operator-visible output of every `show` topic on BOTH consumers must
-  not change (the whole point — and the reason the broad split fails).
-- CLI prints to stdout; gRPC accumulates into `*strings.Builder` and
-  returns over the wire. Any shared helper must take an `io.Writer` /
-  `*strings.Builder` sink, not print directly — another structural
-  mismatch the broad split would have to paper over.
+- Output of every rewired topic on BOTH consumers must be
+  byte-identical to master (golden tests enforce).
+- CLI prints to its writer; gRPC accumulates into `*strings.Builder`.
+  Shared funcs take `io.Writer` — both satisfied.
+- Session-count walk semantics (forward-only `IsReverse==0`,
+  `SessFlagSNAT`/`SessFlagDNAT`, zone-by-ID mapping, v4+v6) preserved
+  verbatim — moved, not rewritten.
 
 ## Risk assessment
 
 | Class | Level | Note |
 |-------|-------|------|
-| Behavioral regression | **HIGH** | Forcing a shared renderer changes one consumer's operator-visible output for nearly every sampled topic. |
-| Lifetime/borrow (Go: aliasing) | LOW | Go; not the issue. |
-| Performance | N/A | Control-plane show path, not hot path. |
-| **Architectural mismatch (#961/#1544)** | **HIGH** | Two divergent contracts; "shared" type would be a branch-everywhere fork. This is the kill axis. |
+| Behavioral regression | **LOW** | Pure sink-parameterized code motion of byte-identical bodies; golden tests on both consumers gate it. |
+| Lifetime / aliasing (Go) | LOW | No new shared mutable state; `dp`/`cr` read-only. |
+| Performance | N/A | Control-plane show path. |
+| Architectural mismatch (#961/#1544) | **LOW** | Verified byte-identical bodies + narrow interface both runtimes already satisfy; not a branch-everywhere fork. Security topics correctly excluded. |
 
-## Test plan (if any option 2 salvage proceeds)
+## Test plan
 
-- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./...` all green.
-- Golden/snapshot tests on BOTH `grpcapi` `ShowText` and `cli` show
-  paths for every touched topic, asserting output is byte-identical
-  before/after (captured on master first). Any candidate helper that
-  changes either golden is disqualified.
+- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./...` — all green.
+- New golden tests in `pkg/grpcapi` and `pkg/cli` asserting the six NAT
+  topics' output is byte-identical to a master-captured fixture, on
+  both consumers.
 - `make audit-check` green on rebased branch; regen
-  `docs/refactoring-audit-current.txt`.
-- No cluster smoke (control-plane only) — state explicitly in PR.
+  `docs/refactoring-audit-current.txt` (server_show_nat.go and
+  cli_show_nat.go both shrink).
+- **No cluster smoke** — this is pure control-plane gRPC/CLI
+  presentation, no dataplane / per-packet path. Stated explicitly in
+  the PR so the smoke-runner does not block.
 
-## Out of scope
+## Out of scope (explicitly)
 
-- Unifying the CLI/gRPC output contract (behavior change; needs its own
-  issue + operator sign-off).
-- The broader grpcapi package restructure (#1661 addendum-4 #24
-  `server_sessions`, addendum-9).
-- #1686 (dataplane/maps.go) — disjoint file scope; no conflict.
+- Security/flow topics (`alg`, `address-book`, `applications`,
+  `screen-*`, `ike`, `security-log`, `dynamic-address`) — divergent
+  contracts, PRESERVED as-is.
+- Any unification of CLI vs gRPC output for divergent topics (behavior
+  change; needs its own issue + operator sign-off).
+- The broader grpcapi package restructure (#1661 addendum-4/9).
+- `filterTermExpansionCount` dedup — below noise floor, not touched
+  unless a firewall renderer seam is opened (it is not, here).
+- #1686 (dataplane/maps.go) — disjoint scope.
 
-## Open questions for adversarial review (each invitable to PLAN-KILL)
+## Open questions for round-2 adversarial review
 
-1. Are the four sampled pairs representative, or is there a large
-   subset of topics where gRPC and CLI **are** byte-identical and
-   cleanly shareable? (If a real shared majority exists, the kill is
-   wrong — produce the list with file:line proof.)
-2. Is option 2 (narrow byte-identical-helper dedup) worth doing at all,
-   or is it churn below the noise floor that should just be left alone?
-3. Does the issue's "byte-identical output post-split" invariant
-   *actually* mean "identical to the consumer's own pre-split output"
-   (my reading), or "identical to each other" (which is already false
-   and would require a behavior change)? Either reading supports KILL of
-   the broad split; confirm.
-4. Is re-scoping to contract-unification (option 3) the right follow-up,
-   or should #1687 simply be closed as not-cleanly-factorable?
-5. Is there any seam I'm missing — e.g. a shared *data-model* (typed
-   intermediate structs) feeding two thin per-consumer formatters —
-   that would dedup the config-walking logic without touching the
-   divergent formatting? Quantify how much of each function is
-   config-walk vs format-emit before answering.
+1. Is `pkg/natshow/` the right home, or should the shared renderer live
+   under an existing neutral package to avoid a new top-level import
+   edge? (It must not import `grpcapi` or `cli` — only `config` +
+   `dataplane`.)
+2. Are the six NAT topics the complete byte-identical set, or did I
+   miss one (e.g. `nat64`)? Diff any candidate before claiming it.
+3. Does normalizing the trailing-newline to the gRPC `\n\n` form change
+   ANY consumer's bytes? (Claim: no — `Printf("…\n")+Println()` ==
+   `Fprintf("…\n\n")`. Refute with a counter-example if wrong.)
+4. Is the narrow `Reader` interface correct, or does any renderer touch
+   a `dp` method not in it (e.g. `ReadNATPortCounter`,
+   `ReadGlobalCounter`)? Verify against both function bodies.
+5. Does excluding the security topics leave #1687 meaningfully
+   addressed, or should the issue be partially closed with a follow-up
+   for the divergent topics?
 
-   **Author's answer (steelman, then rejected):** the config-walk in
-   these functions is trivial (~3 lines: build name slice,
-   `sort.Strings`, range) — there is almost nothing to dedup. The bulk
-   is per-field format-emit, which diverges. Worse, where the walk *is*
-   non-trivial it also diverges: the CLI `address-book` walk has
-   name-filter + nested-`set:` expansion + member-detail that the gRPC
-   walk lacks, so a shared data-model would itself need consumer-keyed
-   walk parameters. And the one genuinely cross-cutting renderer
-   (`FormatSYNCookieCounterRows` + `SumSYNCookieCounters`) is **already
-   shared** in `pkg/dataplane/userspace/statusfmt.go:39,56` — both
-   consumers already call it. The factorable duplication was already
-   factored. The data-model seam does not exist here. Reviewers: refute
-   with a concrete typed-struct design + the per-function walk/format
-   LOC split if you disagree.
+## Pre-resolved before round 2 (author verification)
+
+- **Q2/Q4 resolved.** The six in-scope gRPC renderers (server_show_nat.go
+  lines 22-355) call exactly: `GetPersistentNAT`, `IsLoaded`,
+  `IterateSessions`, `IterateSessionsV6`, `ReadNATRuleCounter` — the
+  `Reader` interface above is exact (no `ReadNATPortCounter` /
+  `ReadGlobalCounter` in scope; those belong to *other* CLI NAT
+  functions like the summary/pool views that stay put).
+- **`nat64` is NOT byte-identical and is EXCLUDED:** gRPC emits
+  `"No NAT64 rule-sets configured\n"` (server_show_nat.go:358) while CLI
+  emits `"No NAT64 rule-sets configured."` (cli_show_nat.go:1017) — a
+  trailing-period divergence. The six topics are the complete
+  byte-identical set.

--- a/docs/pr/1687-shared-presentation/reviewer-ids.md
+++ b/docs/pr/1687-shared-presentation/reviewer-ids.md
@@ -13,3 +13,9 @@ Branch: refactor/1687-shared-presentation
 - Codex: task-mpsgrdwm-mvt55w
 - AGY: adversarial-review-mpsgrpyp-6vmsdo
 - Claude-SMR: in-conversation (verified all six NAT leaf bodies byte-identical; Reader iface exact; nat64 excluded)
+
+## Code review round 1 (PR #1689, head ed21e665d, base 7988d4c25)
+- Codex: task-mpshe1up-ce5u4p
+- AGY: adversarial-review-mpsheamr-k357o5
+- Copilot: requested via @copilot review
+- Claude-SMR: in-conversation (hostile self-review during implementation)

--- a/docs/pr/1687-shared-presentation/reviewer-ids.md
+++ b/docs/pr/1687-shared-presentation/reviewer-ids.md
@@ -7,3 +7,9 @@ Branch: refactor/1687-shared-presentation
 - Codex: task-mpsghlr7-3p2gg5
 - AGY: adversarial-review-mpsgi8ie-81h4g8
 - Claude-SMR: in-conversation (author thesis = lean PLAN-KILL, steelmanned data-model seam)
+- Outcome: Codex PLAN-NEEDS-MAJOR (NAT seam exists), AGY PLAN-KILL (misread dispatcher vs leaf). Resolved → re-scope.
+
+## Plan review round 2 (v2 = bounded natshow seam, commit ba2fbcb58)
+- Codex: task-mpsgrdwm-mvt55w
+- AGY: adversarial-review-mpsgrpyp-6vmsdo
+- Claude-SMR: in-conversation (verified all six NAT leaf bodies byte-identical; Reader iface exact; nat64 excluded)

--- a/docs/pr/1687-shared-presentation/reviewer-ids.md
+++ b/docs/pr/1687-shared-presentation/reviewer-ids.md
@@ -1,0 +1,9 @@
+# #1687 reviewer task IDs
+
+Plan commit: a3503af65b299a97a500a24bda57c5f2ec46660d
+Branch: refactor/1687-shared-presentation
+
+## Plan review round 1
+- Codex: task-mpsghlr7-3p2gg5
+- AGY: adversarial-review-mpsgi8ie-81h4g8
+- Claude-SMR: in-conversation (author thesis = lean PLAN-KILL, steelmanned data-model seam)

--- a/docs/pr/1687-shared-presentation/reviewer-ids.md
+++ b/docs/pr/1687-shared-presentation/reviewer-ids.md
@@ -19,3 +19,8 @@ Branch: refactor/1687-shared-presentation
 - AGY: adversarial-review-mpsheamr-k357o5
 - Copilot: requested via @copilot review
 - Claude-SMR: in-conversation (hostile self-review during implementation)
+
+## Code review round 2 (PR #1689 head b76b04608)
+- Codex: task-mpshohv1-hkpnb4
+- AGY: adversarial-review-mpshop4o-7u3vhh
+- Round-1 verdicts: Codex MERGE-NEEDS-MINOR, AGY MERGE-NEEDS-MINOR (both: lazy applyResult + loaded-path test gap; both fixed @ b76b046)

--- a/pkg/cli/cli_show_nat.go
+++ b/pkg/cli/cli_show_nat.go
@@ -1,15 +1,13 @@
 package cli
 
 import (
-	"encoding/binary"
 	"fmt"
-	"net/netip"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/natshow"
 )
 
 // handleShowNAT dispatches `show security nat ...` subcommands to the
@@ -453,99 +451,8 @@ func (c *CLI) showNATSourceRuleAll(cfg *config.Config) error {
 // showNATSourceRuleDetail displays Junos-style detailed source NAT rules.
 
 func (c *CLI) showNATSourceRuleDetail(cfg *config.Config) error {
-	if cfg == nil || len(cfg.Security.NAT.Source) == 0 {
-		fmt.Println("No source NAT rules configured")
-		return nil
-	}
-
-	// Count active SNAT sessions per rule-set
-	type ruleSetKey struct{ from, to string }
-	rsSessions := make(map[ruleSetKey]int)
-	cr := c.applyResult()
-	if c.dp != nil && c.dp.IsLoaded() && cr != nil {
-		zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
-		for name, id := range cr.ZoneIDs {
-			zoneByID[id] = name
-		}
-		_ = c.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-			}
-			return true
-		})
-		_ = c.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-			}
-			return true
-		})
-	}
-
-	ruleIdx := 0
-	for _, rs := range cfg.Security.NAT.Source {
-		for _, rule := range rs.Rules {
-			ruleIdx++
-			action := "interface"
-			if rule.Then.PoolName != "" {
-				action = "pool " + rule.Then.PoolName
-			} else if rule.Then.Off {
-				action = "off"
-			}
-			srcMatch := "0.0.0.0/0"
-			if rule.Match.SourceAddress != "" {
-				srcMatch = rule.Match.SourceAddress
-			}
-			dstMatch := "0.0.0.0/0"
-			if rule.Match.DestinationAddress != "" {
-				dstMatch = rule.Match.DestinationAddress
-			}
-
-			fmt.Printf("source NAT rule: %s\n", rule.Name)
-			fmt.Printf("  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
-			fmt.Printf("    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
-			fmt.Printf("    Match:\n")
-			fmt.Printf("      Source addresses:      %s\n", srcMatch)
-			fmt.Printf("      Destination addresses: %s\n", dstMatch)
-			if rule.Match.Protocol != "" {
-				fmt.Printf("      IP protocol:           %s\n", rule.Match.Protocol)
-			}
-			fmt.Printf("    Action:                  %s\n", action)
-
-			if rule.Then.PoolName != "" && cfg.Security.NAT.SourcePools != nil {
-				if pool, ok := cfg.Security.NAT.SourcePools[rule.Then.PoolName]; ok {
-					if pool.PersistentNAT != nil {
-						fmt.Printf("    Persistent NAT:          enabled\n")
-					}
-					if len(pool.Addresses) > 0 {
-						fmt.Printf("    Pool addresses:          %s\n", strings.Join(pool.Addresses, ", "))
-					}
-					portLow, portHigh := pool.PortLow, pool.PortHigh
-					if portLow == 0 {
-						portLow = 1024
-					}
-					if portHigh == 0 {
-						portHigh = 65535
-					}
-					fmt.Printf("    Port range:              %d-%d\n", portLow, portHigh)
-				}
-			}
-
-			if c.dp != nil && cr != nil {
-				ruleKey := rs.Name + "/" + rule.Name
-				if cid, ok := cr.NATCounterIDs[ruleKey]; ok {
-					cnt, err := c.dp.ReadNATRuleCounter(uint32(cid))
-					if err == nil {
-						fmt.Printf("    Translation hits:        %d packets  %d bytes\n",
-							cnt.Packets, cnt.Bytes)
-					}
-				}
-			}
-
-			sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
-			fmt.Printf("    Number of sessions:      %d\n", sessions)
-			fmt.Println()
-		}
-	}
+	// #1687: shared with the gRPC ShowText path via pkg/natshow.
+	natshow.RenderSourceRuleDetail(os.Stdout, cfg, c.dp, c.applyResult())
 	return nil
 }
 
@@ -902,113 +809,16 @@ func (c *CLI) showNATDestinationRuleAll(cfg *config.Config) error {
 // showNATDestinationRuleDetail displays Junos-style detailed destination NAT rules.
 
 func (c *CLI) showNATDestinationRuleDetail(cfg *config.Config) error {
-	dnat := cfg.Security.NAT.Destination
-	if dnat == nil || len(dnat.RuleSets) == 0 {
-		fmt.Println("No destination NAT rules configured")
-		return nil
-	}
-
-	// Count active DNAT sessions per rule-set
-	type ruleSetKey struct{ from, to string }
-	rsSessions := make(map[ruleSetKey]int)
-	cr := c.applyResult()
-	if c.dp != nil && c.dp.IsLoaded() && cr != nil {
-		zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
-		for name, id := range cr.ZoneIDs {
-			zoneByID[id] = name
-		}
-		_ = c.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
-				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-			}
-			return true
-		})
-		_ = c.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
-				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-			}
-			return true
-		})
-	}
-
-	ruleIdx := 0
-	for _, rs := range dnat.RuleSets {
-		for _, rule := range rs.Rules {
-			ruleIdx++
-			action := "off"
-			if rule.Then.PoolName != "" {
-				action = "pool " + rule.Then.PoolName
-			}
-			dstMatch := "0.0.0.0/0"
-			if rule.Match.DestinationAddress != "" {
-				dstMatch = rule.Match.DestinationAddress
-			}
-
-			fmt.Printf("destination NAT rule: %s\n", rule.Name)
-			fmt.Printf("  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
-			fmt.Printf("    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
-			fmt.Printf("    Match:\n")
-			fmt.Printf("      Destination addresses: %s\n", dstMatch)
-			if rule.Match.DestinationPort != 0 {
-				fmt.Printf("      Destination port:      %d\n", rule.Match.DestinationPort)
-			}
-			if rule.Match.Protocol != "" {
-				fmt.Printf("      IP protocol:           %s\n", rule.Match.Protocol)
-			}
-			if rule.Match.Application != "" {
-				fmt.Printf("      Application:           %s\n", rule.Match.Application)
-			}
-			fmt.Printf("    Action:                  %s\n", action)
-
-			if rule.Then.PoolName != "" && dnat.Pools != nil {
-				if pool, ok := dnat.Pools[rule.Then.PoolName]; ok {
-					fmt.Printf("    Pool address:            %s\n", pool.Address)
-					if pool.Port != 0 {
-						fmt.Printf("    Pool port:               %d\n", pool.Port)
-					}
-				}
-			}
-
-			if c.dp != nil && cr != nil {
-				ruleKey := rs.Name + "/" + rule.Name
-				if cid, ok := cr.NATCounterIDs[ruleKey]; ok {
-					cnt, err := c.dp.ReadNATRuleCounter(uint32(cid))
-					if err == nil {
-						fmt.Printf("    Translation hits:        %d packets  %d bytes\n",
-							cnt.Packets, cnt.Bytes)
-					}
-				}
-			}
-
-			sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
-			fmt.Printf("    Number of sessions:      %d\n", sessions)
-			fmt.Println()
-		}
-	}
+	// #1687: shared with the gRPC ShowText path via pkg/natshow. The
+	// shared renderer carries the full nil/empty guard; the
+	// showNATDestination dispatcher keeps its own pre-guard.
+	natshow.RenderDestRuleDetail(os.Stdout, cfg, c.dp, c.applyResult())
 	return nil
 }
 
 func (c *CLI) showNATStatic(cfg *config.Config) error {
-	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
-		fmt.Println("No static NAT rules configured.")
-		return nil
-	}
-
-	for _, rs := range cfg.Security.NAT.Static {
-		fmt.Printf("Static NAT rule-set: %s\n", rs.Name)
-		fmt.Printf("  From zone: %s\n", rs.FromZone)
-		for _, rule := range rs.Rules {
-			fmt.Printf("  Rule: %s\n", rule.Name)
-			fmt.Printf("    Match destination-address: %s\n", rule.Match)
-			if rule.IsNPTv6 {
-				fmt.Printf("    Then nptv6-prefix:         %s\n", rule.Then)
-			} else {
-				fmt.Printf("    Then static-nat prefix:    %s\n", rule.Then)
-			}
-		}
-		fmt.Println()
-	}
-
+	// #1687: shared with the gRPC ShowText path via pkg/natshow.
+	natshow.RenderStatic(os.Stdout, cfg)
 	return nil
 }
 
@@ -1033,130 +843,21 @@ func (c *CLI) showNAT64(cfg *config.Config) error {
 }
 
 func (c *CLI) showPersistentNAT() error {
-	if c.dp == nil || c.dp.GetPersistentNAT() == nil {
-		fmt.Println("Persistent NAT table not available")
-		return nil
-	}
-	bindings := c.dp.GetPersistentNAT().All()
-	if len(bindings) == 0 {
-		fmt.Println("No persistent NAT bindings")
-		return nil
-	}
-	fmt.Printf("Total persistent NAT bindings: %d\n\n", len(bindings))
-	fmt.Printf("%-20s %-8s %-20s %-8s %-15s %-10s\n",
-		"Source IP", "SrcPort", "NAT IP", "NATPort", "Pool", "Timeout")
-	for _, b := range bindings {
-		remaining := time.Until(b.LastSeen.Add(b.Timeout))
-		if remaining < 0 {
-			remaining = 0
-		}
-		fmt.Printf("%-20s %-8d %-20s %-8d %-15s %-10s\n",
-			b.SrcIP, b.SrcPort, b.NatIP, b.NatPort, b.PoolName,
-			remaining.Truncate(time.Second))
-	}
+	// #1687: shared with the gRPC ShowText path via pkg/natshow.
+	natshow.RenderPersistent(os.Stdout, c.dp)
 	return nil
 }
 
 // showPersistentNATDetail displays detailed persistent NAT bindings with session counts and age.
 
 func (c *CLI) showPersistentNATDetail() error {
-	if c.dp == nil || c.dp.GetPersistentNAT() == nil {
-		fmt.Println("Persistent NAT table not available")
-		return nil
-	}
-	bindings := c.dp.GetPersistentNAT().All()
-	if len(bindings) == 0 {
-		fmt.Println("No persistent NAT bindings")
-		return nil
-	}
-
-	// #1152: natKey uses a unified `netip.Addr` so v4 and v6 NAT IPs
-	// share one map. v4 sessions use netip.AddrFrom4 (recovered from
-	// the BPF u32 via NativeEndian — see CLAUDE.md "Byte Order"),
-	// v6 sessions use netip.AddrFrom16. Mirrors the producer side in
-	// conntrack/gc.go (Save calls). The pre-fix code used
-	// `b.NatIP.As4()` which panicked on any v6 binding.
-	type natKey struct {
-		addr netip.Addr
-		port uint16
-	}
-	sessionCounts := make(map[natKey]int)
-	if c.dp.IsLoaded() {
-		_ = c.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-				// SessionValue.NATSrcIP is a u32 holding the IP's
-				// network-order bytes in native-endian word form
-				// (CLAUDE.md "Byte Order"). Recover the original
-				// 4 bytes via NativeEndian.PutUint32 to match
-				// conntrack/gc.go:277-279's storage path.
-				var ip4 [4]byte
-				binary.NativeEndian.PutUint32(ip4[:], val.NATSrcIP)
-				sessionCounts[natKey{netip.AddrFrom4(ip4), val.NATSrcPort}]++
-			}
-			return true
-		})
-		_ = c.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-				// Match conntrack/gc.go:397 — no Unmap, the binding
-				// stores the 16-byte form for v6 NAT.
-				addr := netip.AddrFrom16(val.NATSrcIP)
-				sessionCounts[natKey{addr, val.NATSrcPort}]++
-			}
-			return true
-		})
-	}
-
-	fmt.Printf("Total persistent NAT bindings: %d\n\n", len(bindings))
-	for i, b := range bindings {
-		if i > 0 {
-			fmt.Println()
-		}
-		remaining := time.Until(b.LastSeen.Add(b.Timeout))
-		if remaining < 0 {
-			remaining = 0
-		}
-
-		sessions := sessionCounts[natKey{b.NatIP, b.NatPort}]
-
-		fmt.Printf("Persistent NAT binding:\n")
-		fmt.Printf("  Internal IP:        %s\n", b.SrcIP)
-		fmt.Printf("  Internal port:      %d\n", b.SrcPort)
-		fmt.Printf("  Reflexive IP:       %s\n", b.NatIP)
-		fmt.Printf("  Reflexive port:     %d\n", b.NatPort)
-		fmt.Printf("  Pool:               %s\n", b.PoolName)
-		if b.PermitAnyRemoteHost {
-			fmt.Printf("  Any remote host:    yes\n")
-		}
-		fmt.Printf("  Current sessions:   %d\n", sessions)
-		fmt.Printf("  Left time:          %s\n", remaining.Truncate(time.Second))
-		fmt.Printf("  Configured timeout: %ds\n", int(b.Timeout.Seconds()))
-	}
+	// #1687: shared with the gRPC ShowText path via pkg/natshow.
+	natshow.RenderPersistentDetail(os.Stdout, c.dp)
 	return nil
 }
 
 func (c *CLI) showNPTv6(cfg *config.Config) error {
-	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
-		fmt.Println("No NPTv6 rules configured.")
-		return nil
-	}
-
-	found := false
-	for _, rs := range cfg.Security.NAT.Static {
-		for _, rule := range rs.Rules {
-			if !rule.IsNPTv6 {
-				continue
-			}
-			if !found {
-				fmt.Printf("%-20s %-20s %-50s %-50s\n",
-					"Rule-set", "Rule", "External prefix", "Internal prefix")
-				found = true
-			}
-			fmt.Printf("%-20s %-20s %-50s %-50s\n",
-				rs.Name, rule.Name, rule.Match, rule.Then)
-		}
-	}
-	if !found {
-		fmt.Println("No NPTv6 rules configured.")
-	}
+	// #1687: shared with the gRPC ShowText path via pkg/natshow.
+	natshow.RenderNPTv6(os.Stdout, cfg)
 	return nil
 }

--- a/pkg/cli/cli_show_nat.go
+++ b/pkg/cli/cli_show_nat.go
@@ -452,7 +452,7 @@ func (c *CLI) showNATSourceRuleAll(cfg *config.Config) error {
 
 func (c *CLI) showNATSourceRuleDetail(cfg *config.Config) error {
 	// #1687: shared with the gRPC ShowText path via pkg/natshow.
-	natshow.RenderSourceRuleDetail(os.Stdout, cfg, c.dp, c.applyResult())
+	natshow.RenderSourceRuleDetail(os.Stdout, cfg, c.dp, c.applyResult)
 	return nil
 }
 
@@ -812,7 +812,7 @@ func (c *CLI) showNATDestinationRuleDetail(cfg *config.Config) error {
 	// #1687: shared with the gRPC ShowText path via pkg/natshow. The
 	// shared renderer carries the full nil/empty guard; the
 	// showNATDestination dispatcher keeps its own pre-guard.
-	natshow.RenderDestRuleDetail(os.Stdout, cfg, c.dp, c.applyResult())
+	natshow.RenderDestRuleDetail(os.Stdout, cfg, c.dp, c.applyResult)
 	return nil
 }
 

--- a/pkg/cli/cli_show_nat_shared_test.go
+++ b/pkg/cli/cli_show_nat_shared_test.go
@@ -75,12 +75,12 @@ func TestCLINATWrappersMatchSharedRenderers(t *testing.T) {
 		{
 			"source-rule-detail",
 			func() error { return c.showNATSourceRuleDetail(cfg) },
-			func(b *strings.Builder) { natshow.RenderSourceRuleDetail(b, cfg, dp, c.applyResult()) },
+			func(b *strings.Builder) { natshow.RenderSourceRuleDetail(b, cfg, dp, c.applyResult) },
 		},
 		{
 			"dest-rule-detail",
 			func() error { return c.showNATDestinationRuleDetail(cfg) },
-			func(b *strings.Builder) { natshow.RenderDestRuleDetail(b, cfg, dp, c.applyResult()) },
+			func(b *strings.Builder) { natshow.RenderDestRuleDetail(b, cfg, dp, c.applyResult) },
 		},
 		{
 			"static",

--- a/pkg/cli/cli_show_nat_shared_test.go
+++ b/pkg/cli/cli_show_nat_shared_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/natshow"
+)
+
+// #1687 invariant: the CLI NAT show wrappers must produce byte-identical
+// output to the shared pkg/natshow renderers (which the gRPC ShowText
+// path also calls). These tests capture the CLI wrapper's stdout and
+// assert it equals a direct natshow render of the same fixture, on the
+// same Reader. Since the gRPC wrapper is the same one-line delegation,
+// equality here proves both consumers single-source the output.
+
+func sharedNATFixture() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name: "rs-src", FromZone: "trust", ToZone: "untrust",
+			Rules: []*config.NATRule{
+				{
+					Name:  "r1",
+					Match: config.NATMatch{SourceAddress: "10.0.1.0/24", Protocol: "tcp"},
+					Then:  config.NATThen{PoolName: "p-src"},
+				},
+			},
+		},
+	}
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"p-src": {Name: "p-src", Addresses: []string{"203.0.113.1"}},
+	}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{
+			"p-dst": {Name: "p-dst", Address: "10.0.30.5", Port: 8080},
+		},
+		RuleSets: []*config.NATRuleSet{
+			{
+				Name: "rs-dst", FromZone: "untrust", ToZone: "dmz",
+				Rules: []*config.NATRule{
+					{
+						Name:  "d1",
+						Match: config.NATMatch{DestinationAddress: "198.51.100.7/32", DestinationPort: 443, Protocol: "tcp"},
+						Then:  config.NATThen{PoolName: "p-dst"},
+					},
+				},
+			},
+		},
+	}
+	cfg.Security.NAT.Static = []*config.StaticNATRuleSet{
+		{
+			Name: "rs-static", FromZone: "trust",
+			Rules: []*config.StaticNATRule{
+				{Name: "s1", Match: "192.0.2.10", Then: "10.0.1.10"},
+				{Name: "n1", Match: "2001:db8:a::/64", Then: "fd00:a::/64", IsNPTv6: true},
+			},
+		},
+	}
+	return cfg
+}
+
+func TestCLINATWrappersMatchSharedRenderers(t *testing.T) {
+	cfg := sharedNATFixture()
+	dp := dataplane.New() // IsLoaded() == false -> deterministic, no sessions
+	c := &CLI{dp: dp}
+
+	cases := []struct {
+		name string
+		cli  func() error
+		want func(*strings.Builder)
+	}{
+		{
+			"source-rule-detail",
+			func() error { return c.showNATSourceRuleDetail(cfg) },
+			func(b *strings.Builder) { natshow.RenderSourceRuleDetail(b, cfg, dp, c.applyResult()) },
+		},
+		{
+			"dest-rule-detail",
+			func() error { return c.showNATDestinationRuleDetail(cfg) },
+			func(b *strings.Builder) { natshow.RenderDestRuleDetail(b, cfg, dp, c.applyResult()) },
+		},
+		{
+			"static",
+			func() error { return c.showNATStatic(cfg) },
+			func(b *strings.Builder) { natshow.RenderStatic(b, cfg) },
+		},
+		{
+			"nptv6",
+			func() error { return c.showNPTv6(cfg) },
+			func(b *strings.Builder) { natshow.RenderNPTv6(b, cfg) },
+		},
+		{
+			"persistent",
+			func() error { return c.showPersistentNAT() },
+			func(b *strings.Builder) { natshow.RenderPersistent(b, dp) },
+		},
+		{
+			"persistent-detail",
+			func() error { return c.showPersistentNATDetail() },
+			func(b *strings.Builder) { natshow.RenderPersistentDetail(b, dp) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := captureStdout(t, func() {
+				if err := tc.cli(); err != nil {
+					t.Fatalf("%s CLI wrapper error = %v", tc.name, err)
+				}
+			})
+			var want strings.Builder
+			tc.want(&want)
+			if got != want.String() {
+				t.Fatalf("%s: CLI wrapper output not byte-identical to shared renderer:\n cli =%q\nshared=%q",
+					tc.name, got, want.String())
+			}
+		})
+	}
+}

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -70,11 +70,14 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/grpcapi/server_show.go":               "gRPC show dispatcher still reaches legacy dataplane state",
 	"pkg/grpcapi/server_show_cluster_text.go":  "cluster text output still reads legacy dataplane state",
 	"pkg/grpcapi/server_show_flow.go":          "flow text output still uses legacy session keys and values",
-	"pkg/grpcapi/server_show_nat.go":           "NAT text output still uses legacy NAT/session metadata",
 	"pkg/grpcapi/server_show_policies_text.go": "policy text output still uses legacy counters",
 	"pkg/grpcapi/server_show_security_text.go": "security text output still uses legacy counters and filter types",
 	"pkg/grpcapi/server_show_status.go":        "status output still reads legacy dataplane state",
 	"pkg/grpcapi/server_show_zones.go":         "zone output still uses legacy dataplane types",
+	"pkg/natshow/natshow.go":                   "#1687 shared NAT presenter Reader interface names root pkg/dataplane session/counter types (SessionKey, CounterValue, PersistentNATTable); net-neutral consolidation of the import that previously lived in server_show_nat.go + cli_show_nat.go",
+	"pkg/natshow/source.go":                    "#1687 shared source-NAT rule-detail renderer iterates legacy SessionKey/Value via the Reader",
+	"pkg/natshow/dest.go":                      "#1687 shared dest-NAT rule-detail renderer iterates legacy SessionKey/Value via the Reader",
+	"pkg/natshow/persistent.go":                "#1687 shared persistent-NAT renderers iterate legacy SessionKey/Value and read PersistentNATTable via the Reader",
 }
 
 // retainedShimBoundaryBuildTagAllowlist enumerates files that may

--- a/pkg/grpcapi/server_show_nat.go
+++ b/pkg/grpcapi/server_show_nat.go
@@ -1,354 +1,63 @@
-// Phase 3 of #1043: extract the seven NAT-related ShowText case bodies
-// into dedicated methods. Same methodology as Phases 1-2 (#1148, #1150):
-// semantic relocation, no behavior change. Each case body is moved
-// verbatim apart from `&buf` references becoming `buf` (passed-in
-// `*strings.Builder`). Output is unchanged.
+// NAT-related ShowText case bodies.
+//
+// #1687: the six byte-identical NAT renderers (static, nptv6,
+// persistent-nat, persistent-nat-detail, source-rule-detail,
+// dest-rule-detail) were extracted to the shared pkg/natshow package so
+// the gRPC ShowText path and the CLI show path single-source them. The
+// methods below are thin sink-binding wrappers that pass the gRPC
+// *strings.Builder as the io.Writer. showNAT64 stays here: its empty
+// message diverges from the CLI ("...configured" vs "...configured."),
+// so it is intentionally NOT shared.
+//
+// History: Phase 3 of #1043 first extracted these case bodies from the
+// ShowText switch into dedicated methods (verbatim, no behavior change).
 
 package grpcapi
 
 import (
-	"encoding/binary"
 	"fmt"
-	"net/netip"
 	"strings"
-	"time"
 
 	"github.com/psaab/xpf/pkg/config"
-	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/natshow"
 )
 
 // showNATStatic renders `cli show security nat static` — static NAT and
-// NPTv6 prefix rule-sets from configuration.
+// NPTv6 rule-sets from configuration.
 func (s *Server) showNATStatic(cfg *config.Config, buf *strings.Builder) {
-	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
-		buf.WriteString("No static NAT rules configured.\n")
-		return
-	}
-	for _, rs := range cfg.Security.NAT.Static {
-		fmt.Fprintf(buf, "Static NAT rule-set: %s\n", rs.Name)
-		fmt.Fprintf(buf, "  From zone: %s\n", rs.FromZone)
-		for _, rule := range rs.Rules {
-			fmt.Fprintf(buf, "  Rule: %s\n", rule.Name)
-			fmt.Fprintf(buf, "    Match destination-address: %s\n", rule.Match)
-			if rule.IsNPTv6 {
-				fmt.Fprintf(buf, "    Then nptv6-prefix:         %s\n", rule.Then)
-			} else {
-				fmt.Fprintf(buf, "    Then static-nat prefix:    %s\n", rule.Then)
-			}
-		}
-		buf.WriteString("\n")
-	}
+	natshow.RenderStatic(buf, cfg)
 }
 
 // showNATNPTv6 renders `cli show security nat nptv6` — only the NPTv6
 // rules within the static rule-sets.
 func (s *Server) showNATNPTv6(cfg *config.Config, buf *strings.Builder) {
-	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
-		buf.WriteString("No NPTv6 rules configured.\n")
-		return
-	}
-	found := false
-	for _, rs := range cfg.Security.NAT.Static {
-		for _, rule := range rs.Rules {
-			if !rule.IsNPTv6 {
-				continue
-			}
-			if !found {
-				fmt.Fprintf(buf, "%-20s %-20s %-50s %-50s\n",
-					"Rule-set", "Rule", "External prefix", "Internal prefix")
-				found = true
-			}
-			fmt.Fprintf(buf, "%-20s %-20s %-50s %-50s\n",
-				rs.Name, rule.Name, rule.Match, rule.Then)
-		}
-	}
-	if !found {
-		buf.WriteString("No NPTv6 rules configured.\n")
-	}
+	natshow.RenderNPTv6(buf, cfg)
 }
 
 // showPersistentNAT renders the persistent-NAT bindings table with
 // remaining timeout per binding.
 func (s *Server) showPersistentNAT(buf *strings.Builder) {
-	if s.dp == nil || s.dp.GetPersistentNAT() == nil {
-		buf.WriteString("Persistent NAT table not available\n")
-		return
-	}
-	bindings := s.dp.GetPersistentNAT().All()
-	if len(bindings) == 0 {
-		buf.WriteString("No persistent NAT bindings\n")
-		return
-	}
-	fmt.Fprintf(buf, "Total persistent NAT bindings: %d\n\n", len(bindings))
-	fmt.Fprintf(buf, "%-20s %-8s %-20s %-8s %-15s %-10s\n",
-		"Source IP", "SrcPort", "NAT IP", "NATPort", "Pool", "Timeout")
-	for _, b := range bindings {
-		remaining := time.Until(b.LastSeen.Add(b.Timeout))
-		if remaining < 0 {
-			remaining = 0
-		}
-		fmt.Fprintf(buf, "%-20s %-8d %-20s %-8d %-15s %-10s\n",
-			b.SrcIP, b.SrcPort, b.NatIP, b.NatPort, b.PoolName,
-			remaining.Truncate(time.Second))
-	}
+	natshow.RenderPersistent(buf, s.dp)
 }
 
 // showNATSourceRuleDetail renders detailed source NAT rule information,
 // including pool details, translation hit counters, and active session
 // counts per rule-set.
 func (s *Server) showNATSourceRuleDetail(cfg *config.Config, buf *strings.Builder) {
-	if cfg == nil || len(cfg.Security.NAT.Source) == 0 {
-		buf.WriteString("No source NAT rules configured\n")
-		return
-	}
-	// Count active SNAT sessions per rule-set
-	type ruleSetKey struct{ from, to string }
-	rsSessions := make(map[ruleSetKey]int)
-	cr := s.applyResult()
-	if s.dp != nil && s.dp.IsLoaded() && cr != nil {
-		zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
-		for name, id := range cr.ZoneIDs {
-			zoneByID[id] = name
-		}
-		_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-			}
-			return true
-		})
-		_ = s.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-			}
-			return true
-		})
-	}
-
-	ruleIdx := 0
-	for _, rs := range cfg.Security.NAT.Source {
-		for _, rule := range rs.Rules {
-			ruleIdx++
-			action := "interface"
-			if rule.Then.PoolName != "" {
-				action = "pool " + rule.Then.PoolName
-			} else if rule.Then.Off {
-				action = "off"
-			}
-			srcMatch := "0.0.0.0/0"
-			if rule.Match.SourceAddress != "" {
-				srcMatch = rule.Match.SourceAddress
-			}
-			dstMatch := "0.0.0.0/0"
-			if rule.Match.DestinationAddress != "" {
-				dstMatch = rule.Match.DestinationAddress
-			}
-			fmt.Fprintf(buf, "source NAT rule: %s\n", rule.Name)
-			fmt.Fprintf(buf, "  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
-			fmt.Fprintf(buf, "    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
-			fmt.Fprintf(buf, "    Match:\n")
-			fmt.Fprintf(buf, "      Source addresses:      %s\n", srcMatch)
-			fmt.Fprintf(buf, "      Destination addresses: %s\n", dstMatch)
-			if rule.Match.Protocol != "" {
-				fmt.Fprintf(buf, "      IP protocol:           %s\n", rule.Match.Protocol)
-			}
-			fmt.Fprintf(buf, "    Action:                  %s\n", action)
-
-			if rule.Then.PoolName != "" && cfg.Security.NAT.SourcePools != nil {
-				if pool, ok := cfg.Security.NAT.SourcePools[rule.Then.PoolName]; ok {
-					if pool.PersistentNAT != nil {
-						fmt.Fprintf(buf, "    Persistent NAT:          enabled\n")
-					}
-					if len(pool.Addresses) > 0 {
-						fmt.Fprintf(buf, "    Pool addresses:          %s\n", strings.Join(pool.Addresses, ", "))
-					}
-					portLow, portHigh := pool.PortLow, pool.PortHigh
-					if portLow == 0 {
-						portLow = 1024
-					}
-					if portHigh == 0 {
-						portHigh = 65535
-					}
-					fmt.Fprintf(buf, "    Port range:              %d-%d\n", portLow, portHigh)
-				}
-			}
-
-			if s.dp != nil && cr != nil {
-				ruleKey := rs.Name + "/" + rule.Name
-				if cid, ok := cr.NATCounterIDs[ruleKey]; ok {
-					cnt, err := s.dp.ReadNATRuleCounter(uint32(cid))
-					if err == nil {
-						fmt.Fprintf(buf, "    Translation hits:        %d packets  %d bytes\n",
-							cnt.Packets, cnt.Bytes)
-					}
-				}
-			}
-
-			sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
-			fmt.Fprintf(buf, "    Number of sessions:      %d\n\n", sessions)
-		}
-	}
+	natshow.RenderSourceRuleDetail(buf, cfg, s.dp, s.applyResult())
 }
 
 // showNATDestRuleDetail renders detailed destination NAT rule
 // information, including pool address/port, translation hit counters,
 // and active session counts per rule-set.
 func (s *Server) showNATDestRuleDetail(cfg *config.Config, buf *strings.Builder) {
-	if cfg == nil || cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) == 0 {
-		buf.WriteString("No destination NAT rules configured\n")
-		return
-	}
-	dnat := cfg.Security.NAT.Destination
-	type ruleSetKey struct{ from, to string }
-	rsSessions := make(map[ruleSetKey]int)
-	cr := s.applyResult()
-	if s.dp != nil && s.dp.IsLoaded() && cr != nil {
-		zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
-		for name, id := range cr.ZoneIDs {
-			zoneByID[id] = name
-		}
-		_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
-				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-			}
-			return true
-		})
-		_ = s.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
-				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
-			}
-			return true
-		})
-	}
-
-	ruleIdx := 0
-	for _, rs := range dnat.RuleSets {
-		for _, rule := range rs.Rules {
-			ruleIdx++
-			action := "off"
-			if rule.Then.PoolName != "" {
-				action = "pool " + rule.Then.PoolName
-			}
-			dstMatch := "0.0.0.0/0"
-			if rule.Match.DestinationAddress != "" {
-				dstMatch = rule.Match.DestinationAddress
-			}
-			fmt.Fprintf(buf, "destination NAT rule: %s\n", rule.Name)
-			fmt.Fprintf(buf, "  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
-			fmt.Fprintf(buf, "    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
-			fmt.Fprintf(buf, "    Match:\n")
-			fmt.Fprintf(buf, "      Destination addresses: %s\n", dstMatch)
-			if rule.Match.DestinationPort != 0 {
-				fmt.Fprintf(buf, "      Destination port:      %d\n", rule.Match.DestinationPort)
-			}
-			if rule.Match.Protocol != "" {
-				fmt.Fprintf(buf, "      IP protocol:           %s\n", rule.Match.Protocol)
-			}
-			if rule.Match.Application != "" {
-				fmt.Fprintf(buf, "      Application:           %s\n", rule.Match.Application)
-			}
-			fmt.Fprintf(buf, "    Action:                  %s\n", action)
-
-			if rule.Then.PoolName != "" && dnat.Pools != nil {
-				if pool, ok := dnat.Pools[rule.Then.PoolName]; ok {
-					fmt.Fprintf(buf, "    Pool address:            %s\n", pool.Address)
-					if pool.Port != 0 {
-						fmt.Fprintf(buf, "    Pool port:               %d\n", pool.Port)
-					}
-				}
-			}
-
-			if s.dp != nil && cr != nil {
-				ruleKey := rs.Name + "/" + rule.Name
-				if cid, ok := cr.NATCounterIDs[ruleKey]; ok {
-					cnt, err := s.dp.ReadNATRuleCounter(uint32(cid))
-					if err == nil {
-						fmt.Fprintf(buf, "    Translation hits:        %d packets  %d bytes\n",
-							cnt.Packets, cnt.Bytes)
-					}
-				}
-			}
-
-			sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
-			fmt.Fprintf(buf, "    Number of sessions:      %d\n\n", sessions)
-		}
-	}
+	natshow.RenderDestRuleDetail(buf, cfg, s.dp, s.applyResult())
 }
 
 // showPersistentNATDetail renders per-binding detail for persistent-NAT
 // bindings, including current session counts per (NAT IP, NAT port).
 func (s *Server) showPersistentNATDetail(buf *strings.Builder) {
-	if s.dp == nil || s.dp.GetPersistentNAT() == nil {
-		buf.WriteString("Persistent NAT table not available\n")
-		return
-	}
-	bindings := s.dp.GetPersistentNAT().All()
-	if len(bindings) == 0 {
-		buf.WriteString("No persistent NAT bindings\n")
-		return
-	}
-	// natKey uses a unified `netip.Addr` so v4 and v6 NAT IPs share
-	// one map. v4 sessions are stored via `netip.AddrFrom4` and v6
-	// sessions via `netip.AddrFrom16` — matching the producer side
-	// in conntrack/gc.go (Save calls). Persistent-NAT bindings store
-	// `netip.Addr` directly so the lookup matches without
-	// family-specific shimming (was: hardcoded `b.NatIP.As4()` which
-	// panicked on v6 bindings).
-	type natKey struct {
-		addr netip.Addr
-		port uint16
-	}
-	sessionCounts := make(map[natKey]int)
-	if s.dp.IsLoaded() {
-		_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-				// SessionValue.NATSrcIP is a `uint32` holding the IP's
-				// network-order bytes in native-endian word form (the
-				// BPF `__be32` is serialized as native-endian uint32 by
-				// cilium/ebpf; see CLAUDE.md "Byte Order"). Recover the
-				// original 4 bytes via NativeEndian.PutUint32 to match
-				// conntrack/gc.go:277-279's storage path. Do NOT use
-				// BigEndian here — that would re-swap the bytes.
-				var ip4 [4]byte
-				binary.NativeEndian.PutUint32(ip4[:], val.NATSrcIP)
-				sessionCounts[natKey{netip.AddrFrom4(ip4), val.NATSrcPort}]++
-			}
-			return true
-		})
-		_ = s.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-				// Match conntrack/gc.go:397 — no Unmap, the binding
-				// stores the 16-byte form for v6 NAT.
-				addr := netip.AddrFrom16(val.NATSrcIP)
-				sessionCounts[natKey{addr, val.NATSrcPort}]++
-			}
-			return true
-		})
-	}
-
-	fmt.Fprintf(buf, "Total persistent NAT bindings: %d\n\n", len(bindings))
-	for i, b := range bindings {
-		if i > 0 {
-			buf.WriteString("\n")
-		}
-		remaining := time.Until(b.LastSeen.Add(b.Timeout))
-		if remaining < 0 {
-			remaining = 0
-		}
-		sessions := sessionCounts[natKey{b.NatIP, b.NatPort}]
-
-		fmt.Fprintf(buf, "Persistent NAT binding:\n")
-		fmt.Fprintf(buf, "  Internal IP:        %s\n", b.SrcIP)
-		fmt.Fprintf(buf, "  Internal port:      %d\n", b.SrcPort)
-		fmt.Fprintf(buf, "  Reflexive IP:       %s\n", b.NatIP)
-		fmt.Fprintf(buf, "  Reflexive port:     %d\n", b.NatPort)
-		fmt.Fprintf(buf, "  Pool:               %s\n", b.PoolName)
-		if b.PermitAnyRemoteHost {
-			fmt.Fprintf(buf, "  Any remote host:    yes\n")
-		}
-		fmt.Fprintf(buf, "  Current sessions:   %d\n", sessions)
-		fmt.Fprintf(buf, "  Left time:          %s\n", remaining.Truncate(time.Second))
-		fmt.Fprintf(buf, "  Configured timeout: %ds\n", int(b.Timeout.Seconds()))
-	}
+	natshow.RenderPersistentDetail(buf, s.dp)
 }
 
 // showNAT64 renders `cli show security nat nat64` — NAT64 rule-sets

--- a/pkg/grpcapi/server_show_nat.go
+++ b/pkg/grpcapi/server_show_nat.go
@@ -44,14 +44,14 @@ func (s *Server) showPersistentNAT(buf *strings.Builder) {
 // including pool details, translation hit counters, and active session
 // counts per rule-set.
 func (s *Server) showNATSourceRuleDetail(cfg *config.Config, buf *strings.Builder) {
-	natshow.RenderSourceRuleDetail(buf, cfg, s.dp, s.applyResult())
+	natshow.RenderSourceRuleDetail(buf, cfg, s.dp, s.applyResult)
 }
 
 // showNATDestRuleDetail renders detailed destination NAT rule
 // information, including pool address/port, translation hit counters,
 // and active session counts per rule-set.
 func (s *Server) showNATDestRuleDetail(cfg *config.Config, buf *strings.Builder) {
-	natshow.RenderDestRuleDetail(buf, cfg, s.dp, s.applyResult())
+	natshow.RenderDestRuleDetail(buf, cfg, s.dp, s.applyResult)
 }
 
 // showPersistentNATDetail renders per-binding detail for persistent-NAT

--- a/pkg/grpcapi/server_show_nat_shared_test.go
+++ b/pkg/grpcapi/server_show_nat_shared_test.go
@@ -1,0 +1,118 @@
+package grpcapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/natshow"
+)
+
+// #1687 invariant: the gRPC NAT show wrappers must produce byte-identical
+// output to the shared pkg/natshow renderers (which the CLI show path
+// also calls). These assert the gRPC *strings.Builder wrapper output
+// equals a direct natshow render of the same fixture and Reader.
+// Combined with the CLI-side test (pkg/cli/cli_show_nat_shared_test.go),
+// this proves both consumers single-source identical bytes.
+
+func sharedGRPCNATFixture() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name: "rs-src", FromZone: "trust", ToZone: "untrust",
+			Rules: []*config.NATRule{
+				{
+					Name:  "r1",
+					Match: config.NATMatch{SourceAddress: "10.0.1.0/24", Protocol: "tcp"},
+					Then:  config.NATThen{PoolName: "p-src"},
+				},
+			},
+		},
+	}
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"p-src": {Name: "p-src", Addresses: []string{"203.0.113.1"}},
+	}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{
+			"p-dst": {Name: "p-dst", Address: "10.0.30.5", Port: 8080},
+		},
+		RuleSets: []*config.NATRuleSet{
+			{
+				Name: "rs-dst", FromZone: "untrust", ToZone: "dmz",
+				Rules: []*config.NATRule{
+					{
+						Name:  "d1",
+						Match: config.NATMatch{DestinationAddress: "198.51.100.7/32", DestinationPort: 443, Protocol: "tcp"},
+						Then:  config.NATThen{PoolName: "p-dst"},
+					},
+				},
+			},
+		},
+	}
+	cfg.Security.NAT.Static = []*config.StaticNATRuleSet{
+		{
+			Name: "rs-static", FromZone: "trust",
+			Rules: []*config.StaticNATRule{
+				{Name: "s1", Match: "192.0.2.10", Then: "10.0.1.10"},
+				{Name: "n1", Match: "2001:db8:a::/64", Then: "fd00:a::/64", IsNPTv6: true},
+			},
+		},
+	}
+	return cfg
+}
+
+func TestGRPCNATWrappersMatchSharedRenderers(t *testing.T) {
+	cfg := sharedGRPCNATFixture()
+	dp := dataplane.New() // IsLoaded() == false -> deterministic, no sessions
+	s := &Server{dp: dp}
+
+	cases := []struct {
+		name string
+		grpc func(*strings.Builder)
+		want func(*strings.Builder)
+	}{
+		{
+			"source-rule-detail",
+			func(b *strings.Builder) { s.showNATSourceRuleDetail(cfg, b) },
+			func(b *strings.Builder) { natshow.RenderSourceRuleDetail(b, cfg, s.dp, s.applyResult()) },
+		},
+		{
+			"dest-rule-detail",
+			func(b *strings.Builder) { s.showNATDestRuleDetail(cfg, b) },
+			func(b *strings.Builder) { natshow.RenderDestRuleDetail(b, cfg, s.dp, s.applyResult()) },
+		},
+		{
+			"static",
+			func(b *strings.Builder) { s.showNATStatic(cfg, b) },
+			func(b *strings.Builder) { natshow.RenderStatic(b, cfg) },
+		},
+		{
+			"nptv6",
+			func(b *strings.Builder) { s.showNATNPTv6(cfg, b) },
+			func(b *strings.Builder) { natshow.RenderNPTv6(b, cfg) },
+		},
+		{
+			"persistent",
+			func(b *strings.Builder) { s.showPersistentNAT(b) },
+			func(b *strings.Builder) { natshow.RenderPersistent(b, s.dp) },
+		},
+		{
+			"persistent-detail",
+			func(b *strings.Builder) { s.showPersistentNATDetail(b) },
+			func(b *strings.Builder) { natshow.RenderPersistentDetail(b, s.dp) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got, want strings.Builder
+			tc.grpc(&got)
+			tc.want(&want)
+			if got.String() != want.String() {
+				t.Fatalf("%s: gRPC wrapper output not byte-identical to shared renderer:\n grpc =%q\nshared=%q",
+					tc.name, got.String(), want.String())
+			}
+		})
+	}
+}

--- a/pkg/grpcapi/server_show_nat_shared_test.go
+++ b/pkg/grpcapi/server_show_nat_shared_test.go
@@ -75,12 +75,12 @@ func TestGRPCNATWrappersMatchSharedRenderers(t *testing.T) {
 		{
 			"source-rule-detail",
 			func(b *strings.Builder) { s.showNATSourceRuleDetail(cfg, b) },
-			func(b *strings.Builder) { natshow.RenderSourceRuleDetail(b, cfg, s.dp, s.applyResult()) },
+			func(b *strings.Builder) { natshow.RenderSourceRuleDetail(b, cfg, s.dp, s.applyResult) },
 		},
 		{
 			"dest-rule-detail",
 			func(b *strings.Builder) { s.showNATDestRuleDetail(cfg, b) },
-			func(b *strings.Builder) { natshow.RenderDestRuleDetail(b, cfg, s.dp, s.applyResult()) },
+			func(b *strings.Builder) { natshow.RenderDestRuleDetail(b, cfg, s.dp, s.applyResult) },
 		},
 		{
 			"static",

--- a/pkg/natshow/dest.go
+++ b/pkg/natshow/dest.go
@@ -1,0 +1,99 @@
+package natshow
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// RenderDestRuleDetail renders detailed destination NAT rule
+// information, including pool address/port, translation hit counters,
+// and active session counts per rule-set.
+//
+// The nil/empty guard reproduces the gRPC contract verbatim
+// (cfg == nil, no Destination config, or no rule-sets all emit the same
+// "No destination NAT rules configured" line). The CLI dispatcher keeps
+// its own pre-guard; for the non-empty path it routes here and renders
+// identically.
+func RenderDestRuleDetail(w io.Writer, cfg *config.Config, dp Reader, cr *dataplane.ApplyResult) {
+	if cfg == nil || cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) == 0 {
+		io.WriteString(w, "No destination NAT rules configured\n")
+		return
+	}
+	dnat := cfg.Security.NAT.Destination
+	type ruleSetKey struct{ from, to string }
+	rsSessions := make(map[ruleSetKey]int)
+	if dp != nil && dp.IsLoaded() && cr != nil {
+		zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
+		for name, id := range cr.ZoneIDs {
+			zoneByID[id] = name
+		}
+		_ = dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
+				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
+			}
+			return true
+		})
+		_ = dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
+				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
+			}
+			return true
+		})
+	}
+
+	ruleIdx := 0
+	for _, rs := range dnat.RuleSets {
+		for _, rule := range rs.Rules {
+			ruleIdx++
+			action := "off"
+			if rule.Then.PoolName != "" {
+				action = "pool " + rule.Then.PoolName
+			}
+			dstMatch := "0.0.0.0/0"
+			if rule.Match.DestinationAddress != "" {
+				dstMatch = rule.Match.DestinationAddress
+			}
+			fmt.Fprintf(w, "destination NAT rule: %s\n", rule.Name)
+			fmt.Fprintf(w, "  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
+			fmt.Fprintf(w, "    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
+			fmt.Fprintf(w, "    Match:\n")
+			fmt.Fprintf(w, "      Destination addresses: %s\n", dstMatch)
+			if rule.Match.DestinationPort != 0 {
+				fmt.Fprintf(w, "      Destination port:      %d\n", rule.Match.DestinationPort)
+			}
+			if rule.Match.Protocol != "" {
+				fmt.Fprintf(w, "      IP protocol:           %s\n", rule.Match.Protocol)
+			}
+			if rule.Match.Application != "" {
+				fmt.Fprintf(w, "      Application:           %s\n", rule.Match.Application)
+			}
+			fmt.Fprintf(w, "    Action:                  %s\n", action)
+
+			if rule.Then.PoolName != "" && dnat.Pools != nil {
+				if pool, ok := dnat.Pools[rule.Then.PoolName]; ok {
+					fmt.Fprintf(w, "    Pool address:            %s\n", pool.Address)
+					if pool.Port != 0 {
+						fmt.Fprintf(w, "    Pool port:               %d\n", pool.Port)
+					}
+				}
+			}
+
+			if dp != nil && cr != nil {
+				ruleKey := rs.Name + "/" + rule.Name
+				if cid, ok := cr.NATCounterIDs[ruleKey]; ok {
+					cnt, err := dp.ReadNATRuleCounter(uint32(cid))
+					if err == nil {
+						fmt.Fprintf(w, "    Translation hits:        %d packets  %d bytes\n",
+							cnt.Packets, cnt.Bytes)
+					}
+				}
+			}
+
+			sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
+			fmt.Fprintf(w, "    Number of sessions:      %d\n\n", sessions)
+		}
+	}
+}

--- a/pkg/natshow/dest.go
+++ b/pkg/natshow/dest.go
@@ -17,12 +17,20 @@ import (
 // "No destination NAT rules configured" line). The CLI dispatcher keeps
 // its own pre-guard; for the non-empty path it routes here and renders
 // identically.
-func RenderDestRuleDetail(w io.Writer, cfg *config.Config, dp Reader, cr *dataplane.ApplyResult) {
+//
+// crFn lazily supplies the apply result; like RenderSourceRuleDetail it
+// is invoked only after the empty-config guard, preserving the master
+// ordering where applyResult() ran after the guard.
+func RenderDestRuleDetail(w io.Writer, cfg *config.Config, dp Reader, crFn func() *dataplane.ApplyResult) {
 	if cfg == nil || cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) == 0 {
 		io.WriteString(w, "No destination NAT rules configured\n")
 		return
 	}
 	dnat := cfg.Security.NAT.Destination
+	var cr *dataplane.ApplyResult
+	if crFn != nil {
+		cr = crFn()
+	}
 	type ruleSetKey struct{ from, to string }
 	rsSessions := make(map[ruleSetKey]int)
 	if dp != nil && dp.IsLoaded() && cr != nil {

--- a/pkg/natshow/natshow.go
+++ b/pkg/natshow/natshow.go
@@ -1,0 +1,48 @@
+// Package natshow renders the security/NAT operational show topics that
+// the gRPC ShowText path (pkg/grpcapi/server_show_nat.go) and the CLI
+// show path (pkg/cli/cli_show_nat.go) previously duplicated verbatim.
+//
+// Background (#1687, promoted from #1661 item 3): the broad "shared
+// security/NAT/flow presentation package" premise was killed at plan
+// time — the security topics (alg, address-book, applications, screen,
+// ike, security-log, dynamic-address) are independently authored,
+// structurally divergent operator contracts and are intentionally NOT
+// shared. The NAT detail/table renderers, by contrast, were
+// byte-identical between the two consumers (differing only in the
+// output sink: gRPC writes a *strings.Builder, the CLI prints to
+// os.Stdout, plus a return/return-nil wrapper). Those six renderers
+// move here behind an io.Writer sink so both consumers single-source
+// them. Golden tests on both consumers assert byte-identical output
+// vs the pre-extraction master behavior.
+//
+// The functions take the gRPC behavior as the canonical contract (the
+// gRPC nil/empty guards are reproduced verbatim; the trailing-newline
+// shape is the gRPC "\n\n" form, which equals the CLI's
+// fmt.Printf("...\n")+fmt.Println() byte-for-byte).
+//
+// This package imports root pkg/dataplane only for the session/counter
+// types named by the session-iteration callbacks and counter reads
+// (SessionKey/Value, CounterValue, PersistentNATTable). That import is
+// tracked in the #1451 retirement-boundary canary allowlist
+// (pkg/dataplane/retirement_boundary_canary_test.go) and the docs table
+// in docs/pr/1373-retire-ebpf-dataplane/README.md — it is a net-neutral
+// consolidation of the import that already lived in the two source
+// files, not #1451 regressing. natshow must never import pkg/grpcapi or
+// pkg/cli.
+package natshow
+
+import (
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// Reader is the narrow dataplane surface the NAT renderers need. Both
+// the gRPC grpcRuntime (pkg/grpcapi/runtime.go) and the CLI cliRuntime
+// (pkg/cli/runtime.go) already satisfy it structurally. A nil Reader is
+// permitted and reproduces the "not loaded" / unavailable branches.
+type Reader interface {
+	IsLoaded() bool
+	IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error
+	IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+	ReadNATRuleCounter(counterID uint32) (dataplane.CounterValue, error)
+	GetPersistentNAT() *dataplane.PersistentNATTable
+}

--- a/pkg/natshow/natshow_test.go
+++ b/pkg/natshow/natshow_test.go
@@ -1,8 +1,11 @@
 package natshow
 
 import (
+	"encoding/binary"
+	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
@@ -195,3 +198,173 @@ func TestRenderPersistentDetailNilReader(t *testing.T) {
 // natshow.Reader interface — compile-time assertion so a method-set
 // drift breaks the build, not just a test.
 var _ Reader = (*dataplane.Manager)(nil)
+
+// fakeReader exercises the loaded path (IsLoaded()==true) so the
+// session-count, translation-hit, and persistent-binding branches —
+// which dataplane.New() leaves dormant (IsLoaded()==false) — are
+// covered by golden assertions.
+type fakeReader struct {
+	v4       []dataplane.SessionValue
+	v6       []dataplane.SessionValueV6
+	counters map[uint32]dataplane.CounterValue
+	pnat     *dataplane.PersistentNATTable
+}
+
+func (f *fakeReader) IsLoaded() bool { return true }
+func (f *fakeReader) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for _, v := range f.v4 {
+		if !fn(dataplane.SessionKey{}, v) {
+			break
+		}
+	}
+	return nil
+}
+func (f *fakeReader) IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	for _, v := range f.v6 {
+		if !fn(dataplane.SessionKeyV6{}, v) {
+			break
+		}
+	}
+	return nil
+}
+func (f *fakeReader) ReadNATRuleCounter(id uint32) (dataplane.CounterValue, error) {
+	return f.counters[id], nil
+}
+func (f *fakeReader) GetPersistentNAT() *dataplane.PersistentNATTable { return f.pnat }
+
+func TestRenderSourceRuleDetailLoadedGolden(t *testing.T) {
+	cfg := natFixtureConfig()
+	cfg.Security.NAT.SourcePools["p-src"].PersistentNAT = &config.PersistentNATConfig{}
+	dp := &fakeReader{
+		// One forward SNAT session in the rs-src zone pair (zone IDs
+		// 7=trust, 8=untrust per the apply result below).
+		v4: []dataplane.SessionValue{
+			{Flags: dataplane.SessFlagSNAT, IsReverse: 0, IngressZone: 7, EgressZone: 8},
+			{Flags: dataplane.SessFlagSNAT, IsReverse: 1, IngressZone: 7, EgressZone: 8}, // reverse: skipped
+		},
+		counters: map[uint32]dataplane.CounterValue{5: {Packets: 42, Bytes: 4200}},
+	}
+	cr := &dataplane.ApplyResult{
+		ZoneIDs:       map[string]uint16{"trust": 7, "untrust": 8},
+		NATCounterIDs: map[string]uint32{"rs-src/r1": 5},
+	}
+	var b strings.Builder
+	RenderSourceRuleDetail(&b, cfg, dp, func() *dataplane.ApplyResult { return cr })
+	want := "source NAT rule: r1\n" +
+		"  Rule-set: rs-src                        ID: 1\n" +
+		"    From zone: trust    To zone: untrust\n" +
+		"    Match:\n" +
+		"      Source addresses:      10.0.1.0/24\n" +
+		"      Destination addresses: 0.0.0.0/0\n" +
+		"      IP protocol:           tcp\n" +
+		"    Action:                  pool p-src\n" +
+		"    Persistent NAT:          enabled\n" +
+		"    Pool addresses:          203.0.113.1\n" +
+		"    Port range:              1024-65535\n" +
+		"    Translation hits:        42 packets  4200 bytes\n" +
+		"    Number of sessions:      1\n\n"
+	if got := b.String(); got != want {
+		t.Fatalf("loaded source detail mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestRenderDestRuleDetailLoadedGolden(t *testing.T) {
+	cfg := natFixtureConfig()
+	dp := &fakeReader{
+		v4: []dataplane.SessionValue{
+			{Flags: dataplane.SessFlagDNAT, IsReverse: 0, IngressZone: 8, EgressZone: 9},
+		},
+		counters: map[uint32]dataplane.CounterValue{6: {Packets: 7, Bytes: 700}},
+	}
+	cr := &dataplane.ApplyResult{
+		ZoneIDs:       map[string]uint16{"untrust": 8, "dmz": 9},
+		NATCounterIDs: map[string]uint32{"rs-dst/d1": 6},
+	}
+	var b strings.Builder
+	RenderDestRuleDetail(&b, cfg, dp, func() *dataplane.ApplyResult { return cr })
+	want := "destination NAT rule: d1\n" +
+		"  Rule-set: rs-dst                        ID: 1\n" +
+		"    From zone: untrust    To zone: dmz\n" +
+		"    Match:\n" +
+		"      Destination addresses: 198.51.100.7/32\n" +
+		"      Destination port:      443\n" +
+		"      IP protocol:           tcp\n" +
+		"    Action:                  pool p-dst\n" +
+		"    Pool address:            10.0.30.5\n" +
+		"    Pool port:               8080\n" +
+		"    Translation hits:        7 packets  700 bytes\n" +
+		"    Number of sessions:      1\n\n"
+	if got := b.String(); got != want {
+		t.Fatalf("loaded dest detail mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestRenderPersistentLoadedGolden(t *testing.T) {
+	pnat := dataplane.NewPersistentNATTable()
+	now := time.Now()
+	pnat.Save(&dataplane.PersistentNATBinding{
+		SrcIP:    netip.MustParseAddr("10.0.1.5"),
+		SrcPort:  1111,
+		NatIP:    netip.MustParseAddr("203.0.113.1"),
+		NatPort:  40000,
+		PoolName: "p-src",
+		LastSeen: now,
+		Timeout:  600 * time.Second,
+	})
+	dp := &fakeReader{pnat: pnat}
+	var b strings.Builder
+	RenderPersistent(&b, dp)
+	got := b.String()
+	// Timeout is time-relative (Truncate(time.Second)); assert the
+	// stable prefix + the binding row's fixed columns.
+	wantHead := "Total persistent NAT bindings: 1\n\n" +
+		"Source IP            SrcPort  NAT IP               NATPort  Pool            Timeout   \n"
+	if !strings.HasPrefix(got, wantHead) {
+		t.Fatalf("persistent header mismatch:\n got=%q\nwantHead=%q", got, wantHead)
+	}
+	// Fixed columns up to (but excluding) the time-relative Timeout
+	// value; %-15s pads "p-src" to 15 chars.
+	if !strings.Contains(got, "10.0.1.5             1111     203.0.113.1          40000    p-src          ") {
+		t.Fatalf("persistent row mismatch: got=%q", got)
+	}
+}
+
+func TestRenderPersistentDetailLoadedGolden(t *testing.T) {
+	pnat := dataplane.NewPersistentNATTable()
+	now := time.Now()
+	pnat.Save(&dataplane.PersistentNATBinding{
+		SrcIP:    netip.MustParseAddr("10.0.1.5"),
+		SrcPort:  1111,
+		NatIP:    netip.MustParseAddr("203.0.113.1"),
+		NatPort:  40000,
+		PoolName: "p-src",
+		LastSeen: now,
+		Timeout:  600 * time.Second,
+	})
+	// A forward SNAT session whose NATSrcIP/Port matches the binding,
+	// so Current sessions == 1. NATSrcIP is native-endian network-order
+	// (CLAUDE.md byte order) — build it the same way the renderer
+	// recovers it.
+	var ip4 [4]byte
+	copy(ip4[:], netip.MustParseAddr("203.0.113.1").AsSlice())
+	dp := &fakeReader{
+		pnat: pnat,
+		v4: []dataplane.SessionValue{
+			{Flags: dataplane.SessFlagSNAT, IsReverse: 0,
+				NATSrcIP:   binary.NativeEndian.Uint32(ip4[:]),
+				NATSrcPort: 40000},
+		},
+	}
+	var b strings.Builder
+	RenderPersistentDetail(&b, dp)
+	got := b.String()
+	if !strings.Contains(got, "Total persistent NAT bindings: 1\n\n") {
+		t.Fatalf("detail count missing: %q", got)
+	}
+	if !strings.Contains(got, "  Reflexive IP:       203.0.113.1\n  Reflexive port:     40000\n") {
+		t.Fatalf("detail reflexive missing: %q", got)
+	}
+	if !strings.Contains(got, "  Current sessions:   1\n") {
+		t.Fatalf("detail session count != 1: %q", got)
+	}
+}

--- a/pkg/natshow/natshow_test.go
+++ b/pkg/natshow/natshow_test.go
@@ -113,9 +113,14 @@ func TestRenderDestRuleDetailGolden(t *testing.T) {
 }
 
 func TestRenderDestRuleDetailEmpty(t *testing.T) {
-	// nil cfg, nil Destination, and empty RuleSets all share the gRPC
-	// guard message.
-	for _, c := range []*config.Config{nil, {}} {
+	// All three branches of the gRPC guard share the same message:
+	// nil cfg, non-nil cfg with nil Destination, and non-nil
+	// Destination with zero RuleSets (the len(RuleSets)==0 branch that
+	// the CLI dispatcher's pre-guard does NOT cover — so the shared
+	// renderer must, and this case proves it).
+	withEmptyRuleSets := &config.Config{}
+	withEmptyRuleSets.Security.NAT.Destination = &config.DestinationNATConfig{RuleSets: nil}
+	for _, c := range []*config.Config{nil, {}, withEmptyRuleSets} {
 		var b strings.Builder
 		RenderDestRuleDetail(&b, c, nil, nil)
 		if got, want := b.String(), "No destination NAT rules configured\n"; got != want {

--- a/pkg/natshow/natshow_test.go
+++ b/pkg/natshow/natshow_test.go
@@ -1,0 +1,197 @@
+package natshow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// natFixtureConfig builds a deterministic NAT configuration exercising
+// source, destination, static, and nptv6 rule-sets so the golden
+// renderers below assert byte-for-byte output. The bytes here are the
+// pre-#1687 gRPC ShowText contract (server_show_nat.go); the CLI path
+// produced identical bytes and both now route through these funcs.
+func natFixtureConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name: "rs-src", FromZone: "trust", ToZone: "untrust",
+			Rules: []*config.NATRule{
+				{
+					Name:  "r1",
+					Match: config.NATMatch{SourceAddress: "10.0.1.0/24", Protocol: "tcp"},
+					Then:  config.NATThen{PoolName: "p-src"},
+				},
+			},
+		},
+	}
+	cfg.Security.NAT.SourcePools = map[string]*config.NATPool{
+		"p-src": {Name: "p-src", Addresses: []string{"203.0.113.1"}, PortLow: 0, PortHigh: 0},
+	}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{
+			"p-dst": {Name: "p-dst", Address: "10.0.30.5", Port: 8080},
+		},
+		RuleSets: []*config.NATRuleSet{
+			{
+				Name: "rs-dst", FromZone: "untrust", ToZone: "dmz",
+				Rules: []*config.NATRule{
+					{
+						Name:  "d1",
+						Match: config.NATMatch{DestinationAddress: "198.51.100.7/32", DestinationPort: 443, Protocol: "tcp"},
+						Then:  config.NATThen{PoolName: "p-dst"},
+					},
+				},
+			},
+		},
+	}
+	cfg.Security.NAT.Static = []*config.StaticNATRuleSet{
+		{
+			Name: "rs-static", FromZone: "trust",
+			Rules: []*config.StaticNATRule{
+				{Name: "s1", Match: "192.0.2.10", Then: "10.0.1.10"},
+				{Name: "n1", Match: "2001:db8:a::/64", Then: "fd00:a::/64", IsNPTv6: true},
+			},
+		},
+	}
+	return cfg
+}
+
+func TestRenderSourceRuleDetailGolden(t *testing.T) {
+	cfg := natFixtureConfig()
+	dp := dataplane.New() // IsLoaded() == false -> no session counts
+	var b strings.Builder
+	RenderSourceRuleDetail(&b, cfg, dp, nil)
+	want := "source NAT rule: r1\n" +
+		"  Rule-set: rs-src                        ID: 1\n" +
+		"    From zone: trust    To zone: untrust\n" +
+		"    Match:\n" +
+		"      Source addresses:      10.0.1.0/24\n" +
+		"      Destination addresses: 0.0.0.0/0\n" +
+		"      IP protocol:           tcp\n" +
+		"    Action:                  pool p-src\n" +
+		"    Pool addresses:          203.0.113.1\n" +
+		"    Port range:              1024-65535\n" +
+		"    Number of sessions:      0\n\n"
+	if got := b.String(); got != want {
+		t.Fatalf("RenderSourceRuleDetail mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestRenderSourceRuleDetailEmpty(t *testing.T) {
+	var b strings.Builder
+	RenderSourceRuleDetail(&b, &config.Config{}, nil, nil)
+	if got, want := b.String(), "No source NAT rules configured\n"; got != want {
+		t.Fatalf("empty source: got=%q want=%q", got, want)
+	}
+}
+
+func TestRenderDestRuleDetailGolden(t *testing.T) {
+	cfg := natFixtureConfig()
+	dp := dataplane.New()
+	var b strings.Builder
+	RenderDestRuleDetail(&b, cfg, dp, nil)
+	want := "destination NAT rule: d1\n" +
+		"  Rule-set: rs-dst                        ID: 1\n" +
+		"    From zone: untrust    To zone: dmz\n" +
+		"    Match:\n" +
+		"      Destination addresses: 198.51.100.7/32\n" +
+		"      Destination port:      443\n" +
+		"      IP protocol:           tcp\n" +
+		"    Action:                  pool p-dst\n" +
+		"    Pool address:            10.0.30.5\n" +
+		"    Pool port:               8080\n" +
+		"    Number of sessions:      0\n\n"
+	if got := b.String(); got != want {
+		t.Fatalf("RenderDestRuleDetail mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestRenderDestRuleDetailEmpty(t *testing.T) {
+	// nil cfg, nil Destination, and empty RuleSets all share the gRPC
+	// guard message.
+	for _, c := range []*config.Config{nil, {}} {
+		var b strings.Builder
+		RenderDestRuleDetail(&b, c, nil, nil)
+		if got, want := b.String(), "No destination NAT rules configured\n"; got != want {
+			t.Fatalf("empty dest: got=%q want=%q", got, want)
+		}
+	}
+}
+
+func TestRenderStaticGolden(t *testing.T) {
+	cfg := natFixtureConfig()
+	var b strings.Builder
+	RenderStatic(&b, cfg)
+	want := "Static NAT rule-set: rs-static\n" +
+		"  From zone: trust\n" +
+		"  Rule: s1\n" +
+		"    Match destination-address: 192.0.2.10\n" +
+		"    Then static-nat prefix:    10.0.1.10\n" +
+		"  Rule: n1\n" +
+		"    Match destination-address: 2001:db8:a::/64\n" +
+		"    Then nptv6-prefix:         fd00:a::/64\n" +
+		"\n"
+	if got := b.String(); got != want {
+		t.Fatalf("RenderStatic mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestRenderStaticEmpty(t *testing.T) {
+	var b strings.Builder
+	RenderStatic(&b, &config.Config{})
+	if got, want := b.String(), "No static NAT rules configured.\n"; got != want {
+		t.Fatalf("empty static: got=%q want=%q", got, want)
+	}
+}
+
+func TestRenderNPTv6Golden(t *testing.T) {
+	cfg := natFixtureConfig()
+	var b strings.Builder
+	RenderNPTv6(&b, cfg)
+	want := "Rule-set             Rule                 External prefix                                    Internal prefix                                   \n" +
+		"rs-static            n1                   2001:db8:a::/64                                    fd00:a::/64                                       \n"
+	if got := b.String(); got != want {
+		t.Fatalf("RenderNPTv6 mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestRenderNPTv6Empty(t *testing.T) {
+	var b strings.Builder
+	RenderNPTv6(&b, &config.Config{})
+	if got, want := b.String(), "No NPTv6 rules configured.\n"; got != want {
+		t.Fatalf("empty nptv6: got=%q want=%q", got, want)
+	}
+}
+
+func TestRenderPersistentNilReader(t *testing.T) {
+	var b strings.Builder
+	RenderPersistent(&b, nil)
+	if got, want := b.String(), "Persistent NAT table not available\n"; got != want {
+		t.Fatalf("nil reader: got=%q want=%q", got, want)
+	}
+}
+
+func TestRenderPersistentEmpty(t *testing.T) {
+	dp := dataplane.New()
+	var b strings.Builder
+	RenderPersistent(&b, dp)
+	if got, want := b.String(), "No persistent NAT bindings\n"; got != want {
+		t.Fatalf("empty persistent: got=%q want=%q", got, want)
+	}
+}
+
+func TestRenderPersistentDetailNilReader(t *testing.T) {
+	var b strings.Builder
+	RenderPersistentDetail(&b, nil)
+	if got, want := b.String(), "Persistent NAT table not available\n"; got != want {
+		t.Fatalf("nil reader: got=%q want=%q", got, want)
+	}
+}
+
+// dataplane.New() returns *dataplane.Manager, which satisfies the
+// natshow.Reader interface — compile-time assertion so a method-set
+// drift breaks the build, not just a test.
+var _ Reader = (*dataplane.Manager)(nil)

--- a/pkg/natshow/persistent.go
+++ b/pkg/natshow/persistent.go
@@ -1,0 +1,114 @@
+package natshow
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net/netip"
+	"time"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// RenderPersistent renders the persistent-NAT bindings table with
+// remaining timeout per binding.
+func RenderPersistent(w io.Writer, dp Reader) {
+	if dp == nil || dp.GetPersistentNAT() == nil {
+		io.WriteString(w, "Persistent NAT table not available\n")
+		return
+	}
+	bindings := dp.GetPersistentNAT().All()
+	if len(bindings) == 0 {
+		io.WriteString(w, "No persistent NAT bindings\n")
+		return
+	}
+	fmt.Fprintf(w, "Total persistent NAT bindings: %d\n\n", len(bindings))
+	fmt.Fprintf(w, "%-20s %-8s %-20s %-8s %-15s %-10s\n",
+		"Source IP", "SrcPort", "NAT IP", "NATPort", "Pool", "Timeout")
+	for _, b := range bindings {
+		remaining := time.Until(b.LastSeen.Add(b.Timeout))
+		if remaining < 0 {
+			remaining = 0
+		}
+		fmt.Fprintf(w, "%-20s %-8d %-20s %-8d %-15s %-10s\n",
+			b.SrcIP, b.SrcPort, b.NatIP, b.NatPort, b.PoolName,
+			remaining.Truncate(time.Second))
+	}
+}
+
+// RenderPersistentDetail renders per-binding detail for persistent-NAT
+// bindings, including current session counts per (NAT IP, NAT port).
+func RenderPersistentDetail(w io.Writer, dp Reader) {
+	if dp == nil || dp.GetPersistentNAT() == nil {
+		io.WriteString(w, "Persistent NAT table not available\n")
+		return
+	}
+	bindings := dp.GetPersistentNAT().All()
+	if len(bindings) == 0 {
+		io.WriteString(w, "No persistent NAT bindings\n")
+		return
+	}
+	// natKey uses a unified `netip.Addr` so v4 and v6 NAT IPs share
+	// one map. v4 sessions are stored via `netip.AddrFrom4` and v6
+	// sessions via `netip.AddrFrom16` — matching the producer side
+	// in conntrack/gc.go (Save calls). Persistent-NAT bindings store
+	// `netip.Addr` directly so the lookup matches without
+	// family-specific shimming (was: hardcoded `b.NatIP.As4()` which
+	// panicked on v6 bindings).
+	type natKey struct {
+		addr netip.Addr
+		port uint16
+	}
+	sessionCounts := make(map[natKey]int)
+	if dp.IsLoaded() {
+		_ = dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
+				// SessionValue.NATSrcIP is a `uint32` holding the IP's
+				// network-order bytes in native-endian word form (the
+				// BPF `__be32` is serialized as native-endian uint32 by
+				// cilium/ebpf; see CLAUDE.md "Byte Order"). Recover the
+				// original 4 bytes via NativeEndian.PutUint32 to match
+				// conntrack/gc.go:277-279's storage path. Do NOT use
+				// BigEndian here — that would re-swap the bytes.
+				var ip4 [4]byte
+				binary.NativeEndian.PutUint32(ip4[:], val.NATSrcIP)
+				sessionCounts[natKey{netip.AddrFrom4(ip4), val.NATSrcPort}]++
+			}
+			return true
+		})
+		_ = dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
+				// Match conntrack/gc.go:397 — no Unmap, the binding
+				// stores the 16-byte form for v6 NAT.
+				addr := netip.AddrFrom16(val.NATSrcIP)
+				sessionCounts[natKey{addr, val.NATSrcPort}]++
+			}
+			return true
+		})
+	}
+
+	fmt.Fprintf(w, "Total persistent NAT bindings: %d\n\n", len(bindings))
+	for i, b := range bindings {
+		if i > 0 {
+			io.WriteString(w, "\n")
+		}
+		remaining := time.Until(b.LastSeen.Add(b.Timeout))
+		if remaining < 0 {
+			remaining = 0
+		}
+		sessions := sessionCounts[natKey{b.NatIP, b.NatPort}]
+
+		fmt.Fprintf(w, "Persistent NAT binding:\n")
+		fmt.Fprintf(w, "  Internal IP:        %s\n", b.SrcIP)
+		fmt.Fprintf(w, "  Internal port:      %d\n", b.SrcPort)
+		fmt.Fprintf(w, "  Reflexive IP:       %s\n", b.NatIP)
+		fmt.Fprintf(w, "  Reflexive port:     %d\n", b.NatPort)
+		fmt.Fprintf(w, "  Pool:               %s\n", b.PoolName)
+		if b.PermitAnyRemoteHost {
+			fmt.Fprintf(w, "  Any remote host:    yes\n")
+		}
+		fmt.Fprintf(w, "  Current sessions:   %d\n", sessions)
+		fmt.Fprintf(w, "  Left time:          %s\n", remaining.Truncate(time.Second))
+		fmt.Fprintf(w, "  Configured timeout: %ds\n", int(b.Timeout.Seconds()))
+	}
+}

--- a/pkg/natshow/source.go
+++ b/pkg/natshow/source.go
@@ -1,0 +1,106 @@
+package natshow
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// RenderSourceRuleDetail renders detailed source NAT rule information,
+// including pool details, translation hit counters, and active session
+// counts per rule-set. A nil dp/cr reproduces the "not loaded" path
+// (no session counts, no translation hits).
+func RenderSourceRuleDetail(w io.Writer, cfg *config.Config, dp Reader, cr *dataplane.ApplyResult) {
+	if cfg == nil || len(cfg.Security.NAT.Source) == 0 {
+		io.WriteString(w, "No source NAT rules configured\n")
+		return
+	}
+	// Count active SNAT sessions per rule-set
+	type ruleSetKey struct{ from, to string }
+	rsSessions := make(map[ruleSetKey]int)
+	if dp != nil && dp.IsLoaded() && cr != nil {
+		zoneByID := make(map[uint16]string, len(cr.ZoneIDs))
+		for name, id := range cr.ZoneIDs {
+			zoneByID[id] = name
+		}
+		_ = dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
+				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
+			}
+			return true
+		})
+		_ = dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
+				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
+			}
+			return true
+		})
+	}
+
+	ruleIdx := 0
+	for _, rs := range cfg.Security.NAT.Source {
+		for _, rule := range rs.Rules {
+			ruleIdx++
+			action := "interface"
+			if rule.Then.PoolName != "" {
+				action = "pool " + rule.Then.PoolName
+			} else if rule.Then.Off {
+				action = "off"
+			}
+			srcMatch := "0.0.0.0/0"
+			if rule.Match.SourceAddress != "" {
+				srcMatch = rule.Match.SourceAddress
+			}
+			dstMatch := "0.0.0.0/0"
+			if rule.Match.DestinationAddress != "" {
+				dstMatch = rule.Match.DestinationAddress
+			}
+			fmt.Fprintf(w, "source NAT rule: %s\n", rule.Name)
+			fmt.Fprintf(w, "  Rule-set: %s                        ID: %d\n", rs.Name, ruleIdx)
+			fmt.Fprintf(w, "    From zone: %s    To zone: %s\n", rs.FromZone, rs.ToZone)
+			fmt.Fprintf(w, "    Match:\n")
+			fmt.Fprintf(w, "      Source addresses:      %s\n", srcMatch)
+			fmt.Fprintf(w, "      Destination addresses: %s\n", dstMatch)
+			if rule.Match.Protocol != "" {
+				fmt.Fprintf(w, "      IP protocol:           %s\n", rule.Match.Protocol)
+			}
+			fmt.Fprintf(w, "    Action:                  %s\n", action)
+
+			if rule.Then.PoolName != "" && cfg.Security.NAT.SourcePools != nil {
+				if pool, ok := cfg.Security.NAT.SourcePools[rule.Then.PoolName]; ok {
+					if pool.PersistentNAT != nil {
+						fmt.Fprintf(w, "    Persistent NAT:          enabled\n")
+					}
+					if len(pool.Addresses) > 0 {
+						fmt.Fprintf(w, "    Pool addresses:          %s\n", strings.Join(pool.Addresses, ", "))
+					}
+					portLow, portHigh := pool.PortLow, pool.PortHigh
+					if portLow == 0 {
+						portLow = 1024
+					}
+					if portHigh == 0 {
+						portHigh = 65535
+					}
+					fmt.Fprintf(w, "    Port range:              %d-%d\n", portLow, portHigh)
+				}
+			}
+
+			if dp != nil && cr != nil {
+				ruleKey := rs.Name + "/" + rule.Name
+				if cid, ok := cr.NATCounterIDs[ruleKey]; ok {
+					cnt, err := dp.ReadNATRuleCounter(uint32(cid))
+					if err == nil {
+						fmt.Fprintf(w, "    Translation hits:        %d packets  %d bytes\n",
+							cnt.Packets, cnt.Bytes)
+					}
+				}
+			}
+
+			sessions := rsSessions[ruleSetKey{rs.FromZone, rs.ToZone}]
+			fmt.Fprintf(w, "    Number of sessions:      %d\n\n", sessions)
+		}
+	}
+}

--- a/pkg/natshow/source.go
+++ b/pkg/natshow/source.go
@@ -11,12 +11,22 @@ import (
 
 // RenderSourceRuleDetail renders detailed source NAT rule information,
 // including pool details, translation hit counters, and active session
-// counts per rule-set. A nil dp/cr reproduces the "not loaded" path
-// (no session counts, no translation hits).
-func RenderSourceRuleDetail(w io.Writer, cfg *config.Config, dp Reader, cr *dataplane.ApplyResult) {
+// counts per rule-set.
+//
+// crFn lazily supplies the apply result (zone-ID and NAT-counter maps);
+// it is invoked only after the empty-config guard, preserving the
+// master ordering where the consumer's applyResult() was called after
+// the guard (so an empty config never touches dataplane state). A nil
+// crFn, or a crFn returning nil, reproduces the "not loaded" path (no
+// session counts, no translation hits).
+func RenderSourceRuleDetail(w io.Writer, cfg *config.Config, dp Reader, crFn func() *dataplane.ApplyResult) {
 	if cfg == nil || len(cfg.Security.NAT.Source) == 0 {
 		io.WriteString(w, "No source NAT rules configured\n")
 		return
+	}
+	var cr *dataplane.ApplyResult
+	if crFn != nil {
+		cr = crFn()
 	}
 	// Count active SNAT sessions per rule-set
 	type ruleSetKey struct{ from, to string }

--- a/pkg/natshow/static.go
+++ b/pkg/natshow/static.go
@@ -1,0 +1,58 @@
+package natshow
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// RenderStatic renders `show security nat static` — static NAT and
+// NPTv6 rule-sets from configuration.
+func RenderStatic(w io.Writer, cfg *config.Config) {
+	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
+		io.WriteString(w, "No static NAT rules configured.\n")
+		return
+	}
+	for _, rs := range cfg.Security.NAT.Static {
+		fmt.Fprintf(w, "Static NAT rule-set: %s\n", rs.Name)
+		fmt.Fprintf(w, "  From zone: %s\n", rs.FromZone)
+		for _, rule := range rs.Rules {
+			fmt.Fprintf(w, "  Rule: %s\n", rule.Name)
+			fmt.Fprintf(w, "    Match destination-address: %s\n", rule.Match)
+			if rule.IsNPTv6 {
+				fmt.Fprintf(w, "    Then nptv6-prefix:         %s\n", rule.Then)
+			} else {
+				fmt.Fprintf(w, "    Then static-nat prefix:    %s\n", rule.Then)
+			}
+		}
+		io.WriteString(w, "\n")
+	}
+}
+
+// RenderNPTv6 renders `show security nat nptv6` — only the NPTv6 rules
+// within the static rule-sets.
+func RenderNPTv6(w io.Writer, cfg *config.Config) {
+	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
+		io.WriteString(w, "No NPTv6 rules configured.\n")
+		return
+	}
+	found := false
+	for _, rs := range cfg.Security.NAT.Static {
+		for _, rule := range rs.Rules {
+			if !rule.IsNPTv6 {
+				continue
+			}
+			if !found {
+				fmt.Fprintf(w, "%-20s %-20s %-50s %-50s\n",
+					"Rule-set", "Rule", "External prefix", "Internal prefix")
+				found = true
+			}
+			fmt.Fprintf(w, "%-20s %-20s %-50s %-50s\n",
+				rs.Name, rule.Name, rule.Match, rule.Then)
+		}
+	}
+	if !found {
+		io.WriteString(w, "No NPTv6 rules configured.\n")
+	}
+}


### PR DESCRIPTION
## Summary

Factors the six byte-identical NAT operational-show renderers that the
gRPC `ShowText` path (`pkg/grpcapi/server_show_nat.go`) and the CLI show
path (`pkg/cli/cli_show_nat.go`) previously duplicated verbatim into a
shared `pkg/natshow` package, behind a narrow `Reader` interface that
both `grpcRuntime` and `cliRuntime` already satisfy. Both consumers now
single-source identical output.

Closes #1687.

## Scope decision (the #1687 premise was re-scoped at plan review)

The issue framed a broad "shared security/NAT/flow presentation package"
with a byte-identical-output invariant. Plan review found that invariant
is **already false on master** for the *security* topics: `alg`,
`address-book`, `applications`, `screen-ids-option`, `ike`,
`security-log`, and `dynamic-address` are independently-authored,
structurally-divergent operator contracts (different headers, column
widths, field syntax, sub-commands, and feature sets). Forcing them into
a shared renderer would regress one consumer (#961 PacketContext /
#1544 file-motion dead-end). Those topics are **intentionally preserved
as-is**.

The *NAT detail/table* renderers, by contrast, were byte-for-byte
identical between the two consumers (differing only in the output sink:
gRPC `*strings.Builder` vs CLI `os.Stdout`, plus a `return`/`return nil`
wrapper). Those six — `nat-static`, `nat-nptv6`, `persistent-nat`,
`persistent-nat-detail`, `nat-source-rule-detail`,
`nat-dest-rule-detail` — move to `pkg/natshow` with an `io.Writer` sink.
`nat64` is **excluded** (its empty-set message diverges: gRPC
`"...configured\n"` vs CLI `"...configured.\n"`).

This was pure code motion: the renderer bodies are moved verbatim from
the canonical gRPC implementation; only the sink and the apply-result
threading change.

## Plan + adversarial review

Plan doc: `docs/pr/1687-shared-presentation/plan.md` (v3 PLAN-READY).

- Round 1: Codex **PLAN-NEEDS-MAJOR** (kill the universal package, but a
  clean NAT seam exists); AGY **PLAN-KILL** (misread the CLI sub-command
  dispatcher as the leaf renderer). Resolved on evidence — diffed the
  leaf bodies directly; the NAT leaves are byte-identical.
- Round 2 (re-scoped to `pkg/natshow`): AGY **PLAN-READY** (reversed
  after reading the leaf bodies); Codex **PLAN-NEEDS-MINOR**, both
  minors folded in:
  1. `RenderDestRuleDetail` carries the full gRPC `cfg == nil || ... ==
     nil || len(RuleSets) == 0` guard; the CLI dispatcher keeps its own
     pre-guard.
  2. `pkg/natshow` is tracked in the #1451 retirement-boundary canary
     allowlist + README table (net-neutral: the `pkg/dataplane` import
     moved here from `server_show_nat.go`, which no longer imports it).

## Test plan

- [x] `go build ./...` clean
- [x] `pkg/natshow` per-renderer **golden tests** (exact bytes, populated
      + empty/nil branches) + compile-time `Reader` assertion
- [x] **Byte-identical cross-consumer tests** on BOTH consumers:
      `pkg/cli/cli_show_nat_shared_test.go` (captures CLI stdout) and
      `pkg/grpcapi/server_show_nat_shared_test.go` (gRPC builder) each
      assert equality with a direct `natshow` render
- [x] `pkg/dataplane` retirement-boundary canary green (allowlist updated)
- [x] `make audit-check` green
- [x] Full `go test ./...`: 32 packages green. The lone failure,
      `pkg/daemon TestWireUserspaceEventStreamCallbacksStandalone...`,
      is a **pre-existing sandbox artifact** (unix-socket event-stream
      bind blocked) — it fails identically on clean `origin/master` and
      is unrelated to this NAT-presentation change.

## No cluster smoke required

This is **pure control-plane gRPC/CLI presentation** — no dataplane, no
per-packet path, no shaper/classifier. The gate is the Go test suite +
the byte-identical golden tests above. No loss-cluster smoke is needed
and this PR does not contend for the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)