### PR TITLE
#1694: fix GetMapStats stale map names + filter_rules ARRAY mis-count

### DIFF
--- a/docs/pr/1694-getmapstats-name-count-fix/plan.md
+++ b/docs/pr/1694-getmapstats-name-count-fix/plan.md
@@ -1,5 +1,48 @@
 # #1694 — GetMapStats: stale map names + filter_rules ARRAY mis-count
 
+Status: v2 — Codex PLAN-NEEDS-MAJOR (round 1) addressed; AGY + Claude-SMR
+PLAN-READY (round 1). Reframed acceptance from "maps start reporting at
+runtime" to "static descriptor-table correctness" per Codex finding.
+
+## Round-1 review outcome + revision
+
+- **Codex (task-mpsi2hph-dukvbl): PLAN-NEEDS-MAJOR.** All three table
+  defects confirmed real. Major finding: the *current* runtime loads
+  the Rust userspace shim collection plus a fixed `userspaceShimShared
+  MapSpecs()` set (loader_userspace_shim.go:275) — which contains
+  `sessions`, `sessions_v6`, `dnat_table`, `dnat_table_v6`, and
+  counter/infra maps but **NOT** `nat_pool_configs`, `screen_configs`,
+  or `filter_rules`. `Manager.Load()` (the old full-eBPF-collection
+  path) is retired (loader.go:99). So the name fixes do NOT make two
+  maps "start reporting at runtime today" — those maps are absent from
+  `m.maps` regardless of name. The defects are real *descriptor-table*
+  bugs (latent: wrong output if/when those maps are ever surfaced),
+  but the v1 acceptance story was false. Also: `struct filter_rule`
+  (xpf_common.h:800) has no `valid` bit — validity is
+  `filter_config.num_rules/rule_start`, not slot contents, so
+  value-aware counting would be a *different* metric, not a cheap
+  used-count. Refinement: prefer an unexported package-level slice the
+  test reads but never mutates (or a helper returning the literal)
+  over a mutable exported var. **VERIFIED independently** against
+  loader_userspace_shim.go:275-300 and xpf_common.h:800-820.
+- **AGY (adversarial-review-mpsi2q1l-6ucrhb): PLAN-READY.** Same
+  source-grounded confirmation; additionally verified CLI
+  (cli_show_system.go:64-66) and gRPC (server_show.go:1811-1813)
+  already discard array `UsedCount` (print "-"/`continue`); only the
+  REST JSON (system.go:230) exposes raw `UsedCount`, so the
+  `filter_rules` fix only improves that one path. No consumer breaks.
+- **Claude-SMR: PLAN-READY**, crediting Codex's runtime-loading point
+  (I had missed it). Reframed below.
+
+### Revisions applied for v2
+1. Acceptance reframed: this fixes the **static descriptor table's
+   correctness**, not observable runtime output (the three maps aren't
+   loaded by the shim today). The test asserts the descriptor table's
+   names + countability statically — no live `m.maps`.
+2. Test seam: an **unexported** package-level slice
+   `mapStatsReportDescriptors` of an unexported type, read by the test,
+   never mutated, never exported. `GetMapStats` ranges over it.
+
 Status: DRAFT v1 — pending one hostile plan-review round (isolated bug fix)
 
 ## Issue framing
@@ -89,18 +132,22 @@ only the static descriptor table values change.
 
 - `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/dataplane/...`
   green.
-- New unit test exercising the corrected descriptor table:
-  - Asserts the `reportMaps` set contains `nat_pool_configs` and
+- New unit test exercising the corrected **static descriptor table**
+  (NOT runtime output — the three fixed maps are not loaded by the
+  userspace shim today; the test validates the table, which is the
+  thing the bug lives in):
+  - Asserts the descriptor set contains `nat_pool_configs` and
     `screen_configs` and NOT the stale `nat_pool_config` /
     `screen_profiles`.
   - Asserts `filter_rules` is in the non-countable set.
-  - Because `reportMaps` is a function-local literal, the test needs a
-    hook. Plan: extract the descriptor table to a package-level
-    `var mapStatsReport = []mapStatDescriptor{...}` (named struct
-    type) so the test can assert names + countability without a live
-    BPF collection. `GetMapStats` ranges over the package var. This is
-    a minimal, mechanical extraction — keeps the fix testable without
-    standing up the dataplane.
+  - Asserts the countability invariant by name: the only entries
+    expected countable are the sparse HASH/LPM_TRIE maps.
+  - Seam: extract the function-local literal to an **unexported**
+    package-level slice `mapStatsReportDescriptors` of an unexported
+    type `mapStatDescriptor{name string; countable bool}`. The test
+    reads it; it is never mutated, never exported, no test-only hook.
+    `GetMapStats` ranges over it. Minimal mechanical extraction; no
+    live BPF collection required.
 - Full `go test ./...` green except the known pre-existing
   pkg/daemon socket-path-overflow sandbox failures (prove identical on
   clean master).

--- a/docs/pr/1694-getmapstats-name-count-fix/plan.md
+++ b/docs/pr/1694-getmapstats-name-count-fix/plan.md
@@ -1,8 +1,9 @@
 # #1694 — GetMapStats: stale map names + filter_rules ARRAY mis-count
 
-Status: v2 — Codex PLAN-NEEDS-MAJOR (round 1) addressed; AGY + Claude-SMR
-PLAN-READY (round 1). Reframed acceptance from "maps start reporting at
-runtime" to "static descriptor-table correctness" per Codex finding.
+Status: PLAN-READY — Codex round-2 PLAN-NEEDS-MINOR (stale runtime
+wording in plan.md) addressed; AGY + Claude-SMR PLAN-READY (round 1).
+Reframed acceptance from "maps start reporting at runtime" to "static
+descriptor-table correctness" per Codex round-1 finding.
 
 ## Round-1 review outcome + revision
 
@@ -42,8 +43,6 @@ runtime" to "static descriptor-table correctness" per Codex finding.
 2. Test seam: an **unexported** package-level slice
    `mapStatsReportDescriptors` of an unexported type, read by the test,
    never mutated, never exported. `GetMapStats` ranges over it.
-
-Status: DRAFT v1 — pending one hostile plan-review round (isolated bug fix)
 
 ## Issue framing
 
@@ -85,8 +84,11 @@ Edit the `reportMaps` table in `maps_stats.go` only:
 {"filter_rules", false},       // was true; ARRAY iteration == MaxEntries
 ```
 
-- Names corrected so the two array configs actually resolve in
-  `m.maps` and report Name/Type/MaxEntries/Key/ValueSize (UsedCount
+- Names corrected to match the BPF header names so the two array
+  descriptors resolve in `m.maps` *if those maps are present* — today
+  the userspace shim does not load them, so the fix is a latent
+  descriptor-table correction, not new runtime output. When present
+  they would report Name/Type/MaxEntries/Key/ValueSize (UsedCount
   stays 0, correct for an ARRAY — same treatment already given to the
   other arrays in the table: `zone_configs`, `policy_rules`,
   `snat_rules`, `global_counters`, `policy_counters`).
@@ -109,20 +111,23 @@ only the static descriptor table values change.
   unchanged. Consumers (`apply.go:413`, `dataplane.go:406` interface,
   `show system buffers`, Prometheus collector) see the same shape.
 - Iteration safety: the only `countable:true` entries remaining are
-  genuine HASH maps (`sessions`, `sessions_v6`, `address_book_v4/v6`,
-  `address_membership`, `applications`, `dnat_table`, `dnat_table_v6`)
-  — all `BPF_MAP_TYPE_HASH`/`LRU_HASH`, where iteration counting is
-  valid. No behavioral change to those.
+  sparse maps (`sessions`, `sessions_v6`, `address_membership`,
+  `applications`, `dnat_table`, `dnat_table_v6` — `BPF_MAP_TYPE_HASH`;
+  `address_book_v4/v6` — `BPF_MAP_TYPE_LPM_TRIE`), where iteration
+  counting yields only live entries. No behavioral change to those.
 - Missing-map tolerance: `if !ok || bm == nil { continue }` already
-  guards the lookup; correcting the names makes two previously-skipped
-  entries now resolve. If a map genuinely isn't loaded, behavior is
-  unchanged (still skipped).
+  guards the lookup; correcting the names makes the two descriptors
+  resolve *if those maps are loaded*. They are not loaded by the
+  userspace shim today, so they stay skipped at runtime — the value of
+  the fix is the corrected static table, ready for whenever those maps
+  are surfaced. A genuinely-absent map is unchanged (still skipped).
 
 ## Risk assessment
 
-- Behavioral regression: LOW. Two entries start reporting (were silent);
-  one entry stops reporting a misleading count (reports 0). No
-  consumer asserts on the old wrong values.
+- Behavioral regression: LOW. The name fixes only change output if the
+  renamed maps are present (they are not today); the `filter_rules`
+  flip changes its UsedCount from MaxEntries to 0 if that map is
+  present. No consumer asserts on the old wrong values.
 - Lifetime/borrow: N/A (Go, static table edit).
 - Performance: NONE on the hot path. This is a 1/s-or-slower control
   accessor. Removing `filter_rules` iteration slightly *reduces* work.

--- a/docs/pr/1694-getmapstats-name-count-fix/plan.md
+++ b/docs/pr/1694-getmapstats-name-count-fix/plan.md
@@ -1,0 +1,159 @@
+# #1694 — GetMapStats: stale map names + filter_rules ARRAY mis-count
+
+Status: DRAFT v1 — pending one hostile plan-review round (isolated bug fix)
+
+## Issue framing
+
+`GetMapStats` (now in `pkg/dataplane/maps_stats.go` after the #1686
+byte-identical split, originally `maps.go:2074/2075/2078`, originally
+introduced in `fc6ad37d1`) carries three pre-existing correctness
+defects in its `reportMaps` table:
+
+1. `{"nat_pool_config", false}` — the real BPF map name is
+   `nat_pool_configs` (plural). Verified against the setter
+   `maps_nat.go:148` (`m.maps["nat_pool_configs"]`) and the C
+   definition `bpf/headers/xpf_maps.h:460` (`} nat_pool_configs`).
+   The map dict `m.maps` is keyed by the literal collection map name
+   (`loader_userspace_shim.go:128` — `m.maps[name] = umap`), so the
+   stale singular key never matches and this entry **silently never
+   reports**.
+2. `{"screen_profiles", false}` — the real name is `screen_configs`.
+   Verified against `maps_screen.go:17` (`m.maps["screen_configs"]`)
+   and `bpf/headers/xpf_maps.h:413` (`} screen_configs`). Same
+   silent-never-reports failure mode.
+3. `{"filter_rules", true}` — `filter_rules` is
+   `BPF_MAP_TYPE_ARRAY` (`bpf/headers/xpf_maps.h:800`, `max_entries =
+   MAX_FILTER_RULES`). A BPF ARRAY is pre-allocated: every index key
+   exists, so `bm.Iterate()` yields all `MaxEntries` elements, making
+   `UsedCount == MaxEntries` unconditionally — a misleading utilization
+   number for `show system buffers` / Prometheus.
+
+These are confirmed present verbatim on master and pre-date the #1686
+split, so they were out of scope for that pure-code-motion PR.
+
+## Fix
+
+Edit the `reportMaps` table in `maps_stats.go` only:
+
+```go
+{"nat_pool_configs", false},   // was "nat_pool_config" (silent miss)
+{"screen_configs", false},     // was "screen_profiles" (silent miss)
+...
+{"filter_rules", false},       // was true; ARRAY iteration == MaxEntries
+```
+
+- Names corrected so the two array configs actually resolve in
+  `m.maps` and report Name/Type/MaxEntries/Key/ValueSize (UsedCount
+  stays 0, correct for an ARRAY — same treatment already given to the
+  other arrays in the table: `zone_configs`, `policy_rules`,
+  `snat_rules`, `global_counters`, `policy_counters`).
+- `filter_rules` flipped to `countable:false`, matching how every
+  other `BPF_MAP_TYPE_ARRAY` in the table is already handled. The
+  issue offers "drop from countable set OR implement value-aware
+  counting"; value-aware counting of a pre-allocated rule array would
+  require decoding `struct filter_rule` to detect "unused" slots — a
+  scope/maintenance burden disproportionate to a stats accessor, and
+  there is no in-band "valid" flag contract to key on. `false` is the
+  honest, consistent choice: report the array's capacity, not a fake
+  used-count.
+
+No signature change. `GetMapStats() []MapStats` is preserved exactly;
+only the static descriptor table values change.
+
+## Hidden invariants preserved
+
+- Public API: `GetMapStats() []MapStats` unchanged; `MapStats` struct
+  unchanged. Consumers (`apply.go:413`, `dataplane.go:406` interface,
+  `show system buffers`, Prometheus collector) see the same shape.
+- Iteration safety: the only `countable:true` entries remaining are
+  genuine HASH maps (`sessions`, `sessions_v6`, `address_book_v4/v6`,
+  `address_membership`, `applications`, `dnat_table`, `dnat_table_v6`)
+  — all `BPF_MAP_TYPE_HASH`/`LRU_HASH`, where iteration counting is
+  valid. No behavioral change to those.
+- Missing-map tolerance: `if !ok || bm == nil { continue }` already
+  guards the lookup; correcting the names makes two previously-skipped
+  entries now resolve. If a map genuinely isn't loaded, behavior is
+  unchanged (still skipped).
+
+## Risk assessment
+
+- Behavioral regression: LOW. Two entries start reporting (were silent);
+  one entry stops reporting a misleading count (reports 0). No
+  consumer asserts on the old wrong values.
+- Lifetime/borrow: N/A (Go, static table edit).
+- Performance: NONE on the hot path. This is a 1/s-or-slower control
+  accessor. Removing `filter_rules` iteration slightly *reduces* work.
+- Architectural mismatch: NONE. Target is concrete and verified.
+
+## Test plan
+
+- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/dataplane/...`
+  green.
+- New unit test exercising the corrected descriptor table:
+  - Asserts the `reportMaps` set contains `nat_pool_configs` and
+    `screen_configs` and NOT the stale `nat_pool_config` /
+    `screen_profiles`.
+  - Asserts `filter_rules` is in the non-countable set.
+  - Because `reportMaps` is a function-local literal, the test needs a
+    hook. Plan: extract the descriptor table to a package-level
+    `var mapStatsReport = []mapStatDescriptor{...}` (named struct
+    type) so the test can assert names + countability without a live
+    BPF collection. `GetMapStats` ranges over the package var. This is
+    a minimal, mechanical extraction — keeps the fix testable without
+    standing up the dataplane.
+- Full `go test ./...` green except the known pre-existing
+  pkg/daemon socket-path-overflow sandbox failures (prove identical on
+  clean master).
+
+## Out of scope
+
+- Value-aware ("used slot") counting for any ARRAY map.
+- Adding more maps to the report set.
+- Any change to `show system buffers` rendering or the Prometheus
+  collector.
+
+## Open questions for hostile review
+
+1. Is flipping `filter_rules` to `false` the right call vs.
+   value-aware counting? Is there a `struct filter_rule` "valid" flag
+   that would make a real used-count cheap and correct?
+2. Are `nat_pool_configs` and `screen_configs` truly ARRAYs (so
+   `countable:false` is right) — verify against the header, not the
+   stale comment.
+3. Does any consumer (`show system buffers`, Prometheus) depend on the
+   stale names being absent, or on `filter_rules` reporting MaxEntries
+   as UsedCount? (i.e., would "fixing" it break a dashboard contract?)
+4. Is extracting `reportMaps` to a package-level var the minimal
+   testable seam, or does it over-reach for a 3-value fix?
+5. Are there OTHER stale names in the same table I haven't caught
+   (audit every entry against `m.maps` population)?
+
+## Self-audit: full table vs. C header types
+
+Every `reportMaps` entry checked against `bpf/headers/xpf_maps.h`
+(post-fix names):
+
+| name | C type | countable | correct? |
+|------|--------|-----------|----------|
+| sessions | HASH | true | yes (sparse) |
+| sessions_v6 | HASH | true | yes |
+| zone_configs | ARRAY | false | yes |
+| policy_rules | ARRAY | false | yes |
+| address_book_v4 | LPM_TRIE | true | yes (trie holds only inserts) |
+| address_book_v6 | LPM_TRIE | true | yes |
+| address_membership | HASH | true | yes |
+| applications | HASH | true | yes |
+| snat_rules | ARRAY | false | yes |
+| dnat_table | HASH | true | yes |
+| dnat_table_v6 | HASH | true | yes |
+| nat_pool_configs | ARRAY | false | yes (was wrong NAME only) |
+| screen_configs | ARRAY | false | yes (was wrong NAME only) |
+| global_counters | PERCPU_ARRAY | false | yes |
+| policy_counters | PERCPU_ARRAY | false | yes |
+| filter_rules | ARRAY | **false** (fixed) | yes (was wrongly true) |
+
+Post-fix invariant: every `countable:true` entry is HASH or LPM_TRIE
+(sparse, iteration-counting valid); every `countable:false` entry is
+ARRAY/PERCPU_ARRAY (pre-allocated, count == MaxEntries is meaningless).
+No other stale names; no other miscounts. All 16 names resolve against
+`m.maps` population keys (`loader_userspace_shim.go:128`).

--- a/docs/pr/1694-getmapstats-name-count-fix/plan.md
+++ b/docs/pr/1694-getmapstats-name-count-fix/plan.md
@@ -68,7 +68,12 @@ defects in its `reportMaps` table:
    MAX_FILTER_RULES`). A BPF ARRAY is pre-allocated: every index key
    exists, so `bm.Iterate()` yields all `MaxEntries` elements, making
    `UsedCount == MaxEntries` unconditionally — a misleading utilization
-   number for `show system buffers` / Prometheus.
+   number. The CLI (`cli_show_system.go`) and gRPC buffers-detail
+   (`server_show.go`) already print `-`/skip array `UsedCount`, and the
+   Prometheus collector (`pkg/api/metrics.go`) does not call
+   `GetMapStats` at all; the only path that surfaces the raw value is
+   the REST `/system/buffers` JSON (`pkg/api/system.go`). So the
+   user-visible impact is confined to that JSON field.
 
 These are confirmed present verbatim on master and pre-date the #1686
 split, so they were out of scope for that pure-code-motion PR.
@@ -108,8 +113,12 @@ only the static descriptor table values change.
 ## Hidden invariants preserved
 
 - Public API: `GetMapStats() []MapStats` unchanged; `MapStats` struct
-  unchanged. Consumers (`apply.go:413`, `dataplane.go:406` interface,
-  `show system buffers`, Prometheus collector) see the same shape.
+  unchanged. Consumers see the same shape: the `dataPlane` interfaces
+  (`apply.go:413`, `dataplane.go:406`), the CLI `show system buffers`
+  renderer (`cli_show_system.go`), the gRPC buffers-detail handler
+  (`server_show.go`), the `pkg/fwdstatus` builder, and the REST
+  `/system/buffers` JSON (`pkg/api/system.go`). The Prometheus
+  collector (`pkg/api/metrics.go`) does NOT consume `GetMapStats`.
 - Iteration safety: the only `countable:true` entries remaining are
   sparse maps (`sessions`, `sessions_v6`, `address_membership`,
   `applications`, `dnat_table`, `dnat_table_v6` — `BPF_MAP_TYPE_HASH`;

--- a/docs/pr/1694-getmapstats-name-count-fix/reviewer-ids.md
+++ b/docs/pr/1694-getmapstats-name-count-fix/reviewer-ids.md
@@ -6,4 +6,8 @@
 - Claude-SMR: in-conversation — PLAN-READY (credited Codex runtime-loading point)
 
 ## Plan review round 2 (re-converge Codex after v2 reframe)
-- Codex: (pending)
+- Codex: task-mpsii3sl-yd1lox — PLAN-NEEDS-MINOR (stale runtime wording
+  in plan.md only; major finding resolved) — minors addressed in v2.1.
+- AGY + Claude-SMR: PLAN-READY carried from round 1 (no design change).
+
+Converged: PLAN-READY (all minors addressed).

--- a/docs/pr/1694-getmapstats-name-count-fix/reviewer-ids.md
+++ b/docs/pr/1694-getmapstats-name-count-fix/reviewer-ids.md
@@ -1,0 +1,9 @@
+# #1694 reviewer task IDs
+
+## Plan review round 1
+- Codex: task-mpsi2hph-dukvbl — PLAN-NEEDS-MAJOR (acceptance/framing; bugs real)
+- AGY: adversarial-review-mpsi2q1l-6ucrhb — PLAN-READY
+- Claude-SMR: in-conversation — PLAN-READY (credited Codex runtime-loading point)
+
+## Plan review round 2 (re-converge Codex after v2 reframe)
+- Codex: (pending)

--- a/pkg/dataplane/maps_stats.go
+++ b/pkg/dataplane/maps_stats.go
@@ -13,33 +13,62 @@ type MapStats struct {
 	ValueSize  uint32
 }
 
+// mapStatDescriptor names a BPF map GetMapStats reports on and whether its
+// entries can be meaningfully counted by iteration.
+//
+// countable is true ONLY for sparse maps (HASH / LPM_TRIE), where iteration
+// yields exactly the live entries. It MUST be false for pre-allocated maps
+// (ARRAY / PERCPU_ARRAY): every index key in such a map already exists, so
+// iterating returns MaxEntries unconditionally, which makes UsedCount a
+// meaningless "100% utilized" value.
+type mapStatDescriptor struct {
+	name      string
+	countable bool
+}
+
+// mapStatsReportDescriptors is the static set of BPF maps GetMapStats reports
+// on. It is read (never mutated) by GetMapStats and by the unit test that
+// asserts the name + countability invariant; it stays unexported.
+//
+// Name correctness (#1694): nat_pool_configs and screen_configs are the real
+// BPF map names — see the C definitions in bpf/headers/xpf_maps.h and the
+// setters in maps_nat.go / maps_screen.go (m.maps is keyed by the literal
+// collection map name; see loader_userspace_shim.go). The earlier
+// nat_pool_config / screen_profiles spellings never matched an m.maps key, so
+// those descriptors silently reported nothing.
+//
+// Countability correctness (#1694): filter_rules is BPF_MAP_TYPE_ARRAY
+// (bpf/headers/xpf_maps.h), so it is non-countable; the earlier
+// countable:true made UsedCount always equal MaxEntries. struct filter_rule
+// has no per-slot "valid" flag — rule validity is carried by
+// filter_config.num_rules/rule_start, not by slot contents — so a real
+// used-count is not a cheap value-aware iteration and is left out of scope.
+//
+// Invariant: a descriptor is countable iff its BPF map type is HASH or
+// LPM_TRIE (sparse); ARRAY / PERCPU_ARRAY maps are non-countable.
+var mapStatsReportDescriptors = []mapStatDescriptor{
+	{"sessions", true},
+	{"sessions_v6", true},
+	{"zone_configs", false},
+	{"policy_rules", false},
+	{"address_book_v4", true},
+	{"address_book_v6", true},
+	{"address_membership", true},
+	{"applications", true},
+	{"snat_rules", false},
+	{"dnat_table", true},
+	{"dnat_table_v6", true},
+	{"nat_pool_configs", false},
+	{"screen_configs", false},
+	{"global_counters", false},
+	{"policy_counters", false},
+	{"filter_rules", false},
+}
+
 // GetMapStats returns utilization statistics for key BPF maps.
 func (m *Manager) GetMapStats() []MapStats {
-	// Maps to report on and whether to count entries (only for hash maps)
-	reportMaps := []struct {
-		name      string
-		countable bool // hash maps can be iterated; arrays cannot meaningfully count
-	}{
-		{"sessions", true},
-		{"sessions_v6", true},
-		{"zone_configs", false},
-		{"policy_rules", false},
-		{"address_book_v4", true},
-		{"address_book_v6", true},
-		{"address_membership", true},
-		{"applications", true},
-		{"snat_rules", false},
-		{"dnat_table", true},
-		{"dnat_table_v6", true},
-		{"nat_pool_config", false},
-		{"screen_profiles", false},
-		{"global_counters", false},
-		{"policy_counters", false},
-		{"filter_rules", true},
-	}
-
 	var stats []MapStats
-	for _, rm := range reportMaps {
+	for _, rm := range mapStatsReportDescriptors {
 		bm, ok := m.maps[rm.name]
 		if !ok || bm == nil {
 			continue

--- a/pkg/dataplane/maps_stats_test.go
+++ b/pkg/dataplane/maps_stats_test.go
@@ -1,0 +1,98 @@
+package dataplane
+
+import "testing"
+
+// expectedMapStatCountable is the authoritative name -> countable mapping for
+// every BPF map GetMapStats reports on. It mirrors the BPF map types declared
+// in bpf/headers/xpf_maps.h: a descriptor is countable iff its map type is
+// sparse (HASH / LPM_TRIE); pre-allocated ARRAY / PERCPU_ARRAY maps are not
+// countable because iterating them yields every index up to MaxEntries.
+//
+// This guards the #1694 fixes (correct names for nat_pool_configs /
+// screen_configs, and filter_rules marked non-countable) against regression.
+var expectedMapStatCountable = map[string]bool{
+	"sessions":           true,  // HASH
+	"sessions_v6":        true,  // HASH
+	"zone_configs":       false, // ARRAY
+	"policy_rules":       false, // ARRAY
+	"address_book_v4":    true,  // LPM_TRIE
+	"address_book_v6":    true,  // LPM_TRIE
+	"address_membership": true,  // HASH
+	"applications":       true,  // HASH
+	"snat_rules":         false, // ARRAY
+	"dnat_table":         true,  // HASH
+	"dnat_table_v6":      true,  // HASH
+	"nat_pool_configs":   false, // ARRAY (was stale "nat_pool_config")
+	"screen_configs":     false, // ARRAY (was stale "screen_profiles")
+	"global_counters":    false, // PERCPU_ARRAY
+	"policy_counters":    false, // PERCPU_ARRAY
+	"filter_rules":       false, // ARRAY (was wrongly countable:true)
+}
+
+// staleMapStatNames are the incorrect names #1694 removed. They never matched
+// an m.maps key, so descriptors using them silently reported nothing.
+var staleMapStatNames = []string{"nat_pool_config", "screen_profiles"}
+
+func TestMapStatsReportDescriptorsMatchExpected(t *testing.T) {
+	if len(mapStatsReportDescriptors) != len(expectedMapStatCountable) {
+		t.Fatalf("descriptor count = %d, want %d",
+			len(mapStatsReportDescriptors), len(expectedMapStatCountable))
+	}
+
+	seen := make(map[string]bool, len(mapStatsReportDescriptors))
+	for _, d := range mapStatsReportDescriptors {
+		if seen[d.name] {
+			t.Errorf("duplicate descriptor name %q", d.name)
+		}
+		seen[d.name] = true
+
+		want, ok := expectedMapStatCountable[d.name]
+		if !ok {
+			t.Errorf("unexpected descriptor name %q in mapStatsReportDescriptors", d.name)
+			continue
+		}
+		if d.countable != want {
+			t.Errorf("descriptor %q countable = %v, want %v", d.name, d.countable, want)
+		}
+	}
+
+	for name := range expectedMapStatCountable {
+		if !seen[name] {
+			t.Errorf("expected descriptor %q missing from mapStatsReportDescriptors", name)
+		}
+	}
+}
+
+// TestMapStatsReportDescriptorsCorrectNames asserts the #1694 name fixes: the
+// corrected names are present and the stale ones are gone.
+func TestMapStatsReportDescriptorsCorrectNames(t *testing.T) {
+	names := make(map[string]bool, len(mapStatsReportDescriptors))
+	for _, d := range mapStatsReportDescriptors {
+		names[d.name] = true
+	}
+
+	for _, want := range []string{"nat_pool_configs", "screen_configs"} {
+		if !names[want] {
+			t.Errorf("corrected map name %q not present in mapStatsReportDescriptors", want)
+		}
+	}
+	for _, stale := range staleMapStatNames {
+		if names[stale] {
+			t.Errorf("stale map name %q still present in mapStatsReportDescriptors", stale)
+		}
+	}
+}
+
+// TestMapStatsFilterRulesNotCountable pins the #1694 ARRAY mis-count fix:
+// filter_rules is a BPF_MAP_TYPE_ARRAY and must not be counted by iteration.
+func TestMapStatsFilterRulesNotCountable(t *testing.T) {
+	for _, d := range mapStatsReportDescriptors {
+		if d.name == "filter_rules" {
+			if d.countable {
+				t.Fatal("filter_rules is a BPF ARRAY and must be countable:false")
+			}
+			return
+		}
+	}
+	t.Fatal("filter_rules descriptor not found")
+}


### PR DESCRIPTION
## Summary

Fix three pre-existing correctness defects in `GetMapStats`
(`pkg/dataplane/maps_stats.go`), surfaced by Copilot during the #1686
byte-identical split (and confirmed present verbatim on master, so out
of scope there):

- `nat_pool_config` -> `nat_pool_configs` (the real BPF map name; setter
  in `maps_nat.go`, C def in `bpf/headers/xpf_maps.h`).
- `screen_profiles` -> `screen_configs` (real name; `maps_screen.go`).
  `m.maps` is keyed by the literal collection map name
  (`loader_userspace_shim.go`), so both stale spellings never matched a
  key and those descriptors silently reported nothing.
- `filter_rules` marked `countable:true` -> `false`. It is
  `BPF_MAP_TYPE_ARRAY` (pre-allocated), so iterating yields every index
  up to `MaxEntries`, making `UsedCount` an unconditional "100%
  utilized" value. `struct filter_rule` has no per-slot "valid" flag
  (validity is `filter_config.num_rules/rule_start`), so value-aware
  counting is not a cheap iteration and is left out of scope.

The function-local descriptor literal is extracted to an unexported,
never-mutated package-level slice `mapStatsReportDescriptors` so the
fix is unit-testable without a live BPF collection. The defects live in
the static table: the userspace shim does not load these three maps
today, so this is a latent descriptor-table correction, not a change in
current runtime output.

Closes #1694

## Plan + adversarial review

Plan doc: `docs/pr/1694-getmapstats-name-count-fix/plan.md`

- Codex round-1: PLAN-NEEDS-MAJOR (task-mpsi2hph-dukvbl) — defects real,
  but v1's "maps start reporting at runtime" acceptance claim was false
  (shim does not load them). Reframed to static descriptor-table
  correctness.
- Codex round-2: PLAN-NEEDS-MINOR (task-mpsii3sl-yd1lox) — stale runtime
  wording in plan.md; addressed.
- AGY round-1: PLAN-READY (adversarial-review-mpsi2q1l-6ucrhb).
- Claude-SMR round-1: PLAN-READY.

No consumer is affected: CLI (`cli_show_system.go`) and gRPC
buffers-detail (`server_show.go`) already print "-"/skip array
`UsedCount`; the Prometheus collector does not call `GetMapStats`; only
the REST `/system/buffers` JSON exposed the misleading raw value.

## Test plan

- [x] `go build ./pkg/dataplane/...` clean
- [x] New `maps_stats_test.go`: descriptor names + countability
      invariant (countable iff HASH/LPM_TRIE), correct-names, and
      filter-rules-not-countable. 3/3 pass.
- [x] `TestMapStats*` 5/5 flake check
- [x] `go test ./pkg/dataplane/` green
- [x] Full `go test ./...` green except two pre-existing
      `pkg/dataplane/userspace` `AF_UNIX sun_path` overflow sandbox
      failures (`control.sock: bind: invalid argument`) — proven to
      reproduce identically on clean `origin/master` (ea0a670bd),
      unrelated to this change.
- [x] `make audit-check` up to date

A light no-regression smoke on the loss userspace cluster verifies
`show system buffers` still renders correct counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)