### PR TITLE
#1709 WireGuard S1: wire-protocol compliance (TAI64N + handshake framing)

### DIFF
--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
@@ -375,23 +375,39 @@ pass alone. No runtime external dependency is introduced:
 - `keyed-BLAKE2s-128(MAC1key, b"abc")`
   = `78df3b0a90577688ce9d272d04a8fb90`
 
-Test suite (`wg/handshake.rs` + `wg/tai64n.rs` `#[cfg(test)]`):
+Test suite (`wg/handshake.rs` + `wg/tai64n.rs` `#[cfg(test)]`). **Per SMR-1,
+every KAT below is DUAL-SOURCE: assert against BOTH the baked hex literal AND
+an in-test re-derivation from raw `blake2` calls — a transcription typo fails
+the re-derivation, an implementation bug fails the baked vector.** (I verified
+all four §5.4a vectors reproduce from `blake2 0.10` first-principles — see
+SMR-R1.)
   - `construction_hashes_match_spec` — assert xpf's computed InitialChainKey /
-    InitialHash equal the hex above (this independently re-derives what snow's
+    InitialHash equal the hex above (independently re-derives what snow's
     prologue already mixes, proving the framing layer agrees with the engine).
   - `mac1_keyed_blake2s_128_kat` — assert the keyed-BLAKE2s-128 vector above
-    (proves keyed-BLAKE2s, NOT HMAC, and the 16-byte output width — the
-    research §7 SMR r1 #3 hazard).
+    (proves keyed-BLAKE2s via `Blake2sMac<U16>`, NOT HMAC, and the 16-byte
+    output width — the research §7 SMR r1 #3 hazard).
   - `mac1_keys_on_recipient_static_pub` — build msg1 toward responder R; assert
     mac1 verifies under `HASH("mac1----"||R_pub)` and FAILS under a different
     pubkey (catches the swapped-key bug).
+  - **`msg1_full_kat_fixed_ephemeral` (SMR-2, REQUIRED)** — with a pinned
+    local-static + ephemeral (snow `fixed_ephemeral`) + a fixed TAI64N, assert
+    the entire deterministic 148-byte msg1 and its 16-byte mac1 over
+    `msg[0..116]`. This is the one test that catches an offset/endianness bug
+    in the framing *assembly* that per-field KATs miss. (If a fixed-ephemeral
+    builder is not cleanly reachable, fall back to asserting mac1 over a
+    captured msg-prefix — still catches the offset bug.)
   - `msg1_layout_byte_offsets` / `msg2_layout_byte_offsets` — assert the
     148/92-byte total, type byte = 1/2, reserved zeros, LE indices at the right
     offsets, snow body at offset 8/12, mac1/mac2 at the tail.
+  - **`parse_initiation_accepts_nonzero_mac2` (SMR-5, REQUIRED)** — parse must
+    accept a msg with mac2 != 0 (a peer that holds our cookie sets it); mac2 is
+    skip-verified in S1, NOT treated as malformed. Cookie generation is S7.
   - `tai64n_encoding_kat` — assert the 12-byte layout (BE u64 `2^62+secs` ||
-    BE u32 nanos) for a fixed `(secs, nanos)`, and `tai64n_strictly_monotonic`
+    BE u32 nanos) for a fixed `(secs, nanos)`; `tai64n_strictly_monotonic`
     (N calls strictly increase by byte-compare even with a frozen/backwards
-    clock).
+    clock); **`tai64n_concurrent_monotonic` (SMR-4)** (N threads calling
+    `now()` yield N strictly-ordered distinct values).
   - `framing_roundtrip` — `build_initiation` then `parse_initiation` recovers
     the sender_index + noise body; `parse` rejects TooShort / BadType /
     Mac1Mismatch.
@@ -630,3 +646,114 @@ pass unchanged.
    PR. PLAN-review MUST return an explicit (a)/(b) verdict. Reference peer =
    kernel WireGuard on a real VM regardless. PLAN-KILL if neither boundary
    gives a coherent S1.
+
+---
+
+## SMR-R1 — Claude domain-SMR hostile plan review (round 1)
+
+Reviewer: Claude (in-conversation), acting as crypto/protocol + CPU-arch +
+SW-design SMR per the triple-review-includes-Claude-SMR rule. Stance: hostile;
+PLAN-KILL is on the table for wire/crypto work. Findings are grounded in
+independent verification I ran before writing this (not just reading the plan).
+
+### Independent verification performed (evidence, not assertion)
+
+1. **snow IK msg1 byte-layout is byte-exact for WG msg1 inner — VERIFIED.**
+   Read `snow-0.10.0/src/handshakestate.rs:223-322` (`_write_message`)
+   end-to-end. The token loop writes `E` → 32-byte ephemeral (`message[..32]`,
+   `mix_hash(pubkey)`), then `S` → `encrypt_and_mix_hash(self.s.pubkey(), ..)`
+   = 48 bytes. **Then, unconditionally after the loop**
+   (`handshakestate.rs:315-317`):
+   `encrypt_and_mix_hash(payload, &mut message[byte_index..])`. So msg1 body =
+   `e[32] || enc_s[48] || enc_payload[len+16]`. Passing the 12-byte TAI64N as
+   `payload` yields `e[32]||enc_s[48]||enc_ts[28]` = 108 bytes — **identical to
+   WG msg1 inner**, and the timestamp IS mix-hashed into the transcript exactly
+   as kernel WG does (`ConsumeMessageInitiation` mix-hashes `msg.Timestamp`).
+   Q1 is **RESOLVED**: there is no snow-side length prefix or extra MixHash;
+   the payload is the last AEAD chunk. (Caveat held for S2: this is a
+   structural proof; the live kernel-wg test still must verify the AEAD tag.)
+
+2. **KAT vectors reproduce from Rust `blake2` first-principles — VERIFIED.**
+   I wrote a throwaway Rust bin using `blake2 0.10` (the locked version) and
+   recomputed all four §5.4a vectors. All four match the plan's hex AND the Go
+   oracle byte-for-byte: ICK `60e26d..cd36`, IH `2211b3..9ef3`, MAC1 key
+   `172c34..0a4e`, MAC1("abc") `78df3b0a90577688ce9d272d04a8fb90`. Critically,
+   the MAC is `Blake2sMac<U16>` via `KeyInit::new_from_slice(key)` —
+   **keyed-BLAKE2s-128, NOT HMAC** — and it produces the correct value, so the
+   `blake2` crate is the right primitive and the implementation is feasible
+   with a locked dep. Q2 is **RESOLVED** (keyed-BLAKE2s-128, key =
+   BLAKE2s-256("mac1----"||recipient_pub)); the plan's reading is correct.
+
+### Findings
+
+- **SMR-1 (MINOR, accept): make the KAT tests dual-source (Q6).** Per my own
+  verification path, the strongest test is BOTH a baked hex literal AND an
+  in-test re-derivation from raw `blake2` — a transcription typo fails the
+  re-derivation, an implementation bug fails the baked vector. The plan §5.4a
+  now says this; keep it as a hard requirement, not a "should".
+
+- **SMR-2 (MINOR, accept): add a full-msg1 KAT against a pinned ephemeral.**
+  The construction-hash + MAC1 KATs are necessary but not sufficient — they do
+  not exercise the *assembly* of the 148-byte msg1. snow's `Builder` supports
+  a fixed ephemeral (`fixed_ephemeral` path seen in `_write_message:236`); with
+  pinned local-static + ephemeral + a fixed TAI64N, the entire 148-byte msg1
+  (and the 16-byte mac1 over `msg[0..116]`) is deterministic and can be a KAT.
+  This is the single test that would catch an offset/endianness bug in the
+  framing assembly that the per-field KATs miss. Add it to §5.4a. (If snow does
+  not cleanly expose a fixed-ephemeral builder at the engine layer, fall back to
+  asserting the mac1 over a captured msg-prefix — still catches the offset bug.)
+
+- **SMR-3 (S1/S2 boundary, Q7 — CONCUR with (b), with a condition).** I agree
+  the live kernel-wg-on-VM interop belongs in S2: it now needs a VM peer +
+  cross-VM UDP reachability + (likely) `apt install wireguard-tools` on the
+  peer, which is real harness surface that does not belong bolted onto a
+  security-critical framing PR. BUT the condition: S1 must NOT claim "interop"
+  in any operator-facing doc or the CLAUDE.md feature list — S1 ships
+  "wire-protocol framing + TAI64N, spec-vector-validated; independent-peer
+  interop proven in S2." The research plan §10 already gates the feature-list
+  line on S3; keep S1's claim honest. With that, (b) is the right call.
+
+- **SMR-4 (MED, must-address-in-impl): TAI64N monotonicity is necessary but
+  the plan understates the within-process race.** The clock is a
+  `Mutex<[u8;12]>` returning strictly-increasing values — fine. But the WG
+  self-DoS hazard is per *remote peer*, and kernel WG compares the new
+  timestamp against the **last accepted** one *for that peer*. A single global
+  monotonic clock is sufficient (any strictly-increasing source works — WG does
+  not require wall-clock accuracy, only monotonicity), so the global clock is
+  correct. The real S1 risk is narrower: if two initiations to the *same* peer
+  are built concurrently, both must get distinct, ordered TAI64Ns — which the
+  mutex guarantees. No KILL; flag for the impl to add a test that N concurrent
+  `now()` calls yield N strictly-ordered values. Deferring disk-persistence to
+  S6 is acceptable **because S1 has no daemon** — a process with no persisted
+  state cannot regress a clock it never reloads. Concur with the deferral.
+
+- **SMR-5 (MINOR): mac2 skip-on-parse must be explicit and tested.** S1 emits
+  mac2 = zeros and does not verify inbound mac2. A compliant quiet-tunnel peer
+  sends mac2 = zeros, so this interops; but the parse path must *accept*
+  non-zero mac2 (a peer that has issued us a cookie would set it) without
+  treating it as malformed — i.e. parse must not reject on mac2 != 0. Add a
+  `parse_initiation_accepts_nonzero_mac2` test. (Cookie *generation* is S7.)
+
+- **SMR-6 (design, LOW): the four engine entry points should not leak
+  `HandshakeState` across the engine boundary if avoidable.** §5.3 sketches
+  `consume_response(hs: HandshakeState, ..)`. Passing the in-progress snow
+  state out and back in is the pattern the existing tests use, but it widens
+  the engine's public surface with a snow type. Prefer the engine holding the
+  pending `HandshakeState` in a small slow-path map keyed by sender_index (the
+  initiator chose it; the responder echoes it), so the API trades only
+  `[u8;32]`/byte-slices. Not a KILL — but resolve the boundary shape in Step 5
+  and prefer the narrower one. (This also pre-stages the S3 integration where
+  the coordinator thread owns pending handshakes.)
+
+### Verdict
+
+**PLAN-NEEDS-MINOR.** The architecture is sound and the two highest-risk wire
+claims (snow byte-exactness; keyed-BLAKE2s-128 MAC1 + the KAT vectors) are
+**independently verified by me**, not merely asserted. The design correctly
+isolates framing into new modules (engine.rs stays WATCH-tier), preserves the
+slow-path-only-crypto boundary, and the snow payload==timestamp mapping is
+exact. Minor items SMR-1/-2/-5 tighten the test gate; SMR-4/-6 are impl-time
+notes; SMR-3 ratifies S1/S2 boundary Option (b) with an honesty condition on
+the interop claim. **No KILL.** Proceed to implement once Codex + AGY converge
+(both must also ratify (a)-vs-(b)); fold SMR-1/-2/-5 into §5.4a as hard test
+requirements before coding.

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
@@ -1,17 +1,20 @@
 # #1709 — WireGuard S1: wire-protocol compliance (TAI64N + handshake framing) validated by spec known-answer vectors (live kernel-WireGuard interop = S2)
 
-Status: **PLAN-READY v3** — round-1 plan review complete: Codex
-(task-mpt6qx4i-i04py6) PLAN-NEEDS-MAJOR, AGY (adversarial-review-mpt6r70o-ebe5a4)
-PLAN-NEEDS-MAJOR, Claude-SMR PLAN-NEEDS-MINOR. v3 addresses ALL major findings
-(see §v3-convergence). v2→v3: TAI64N epoch offset corrected to
-`0x400000000000000a` + nanos whitening (AGY-2); two-phase index reservation to
-close the blackhole race (AGY-1/Codex-4); `local_public_key` added for inbound
-MAC1 (Codex-2); TAI64N persistence story reconciled (Codex-3); S1 gate
-strengthened to require FULL byte-exact msg1/msg2 KATs (Codex-1/SMR-2);
-S1/S2 boundary ratified Option (b+). v2→v1: dropped wireguard-go; reference =
-kernel WireGuard on a real VM (never a container); spec-KAT in-tree gate.
+Status: **PLAN-READY v4** — round-2 plan review complete and CONVERGED:
+AGY (adversarial-review-mpt7315l-j522br) **PLAN-READY**, Codex
+(task-mpt72t96-tcx9m8) **PLAN-NEEDS-MINOR** (all 6 round-1 majors confirmed
+resolved; one KAT-naming text fix). Claude-SMR PLAN-NEEDS-MINOR (round-1). v4
+folds the two round-2 implementation caveats: the TAI64N nanos carry MUST
+trigger at `>= 1_000_000_000` not `0xFF000000` (AGY round-2 math bug — a strict
+peer rejects nanos `>= 10^9`), and the reservation layer caps pending
+handshakes at ONE per peer pubkey to bound an authenticated-msg1-flood DoS
+(AGY round-2), plus the explicit `msg2_full_kat_fixed_ephemeral` requirement
+(Codex round-2). **Cleared to implement.**
 
-> Pending a confirming round-2 from Codex + AGY on v3 before code lands.
+History: round-1 Codex+AGY PLAN-NEEDS-MAJOR / SMR PLAN-NEEDS-MINOR (no KILL);
+v3 addressed all majors (§v3-convergence); round-2 confirmed + 2 minor caveats
+folded into v4 (§v4-round2). v1→v2: dropped wireguard-go, reference = kernel
+WireGuard on a real VM (never a container), spec-KAT in-tree gate.
 
 Issue: #1709 (part of #1703 umbrella). Branch:
 `refactor/1709-wireguard-s1-wire-protocol-compliance`.
@@ -235,13 +238,18 @@ byte-identical to the reference and avoid the timing side-channel. (A peer does
 not *require* it — it only byte-compares — but matching the reference is the
 S1 contract.)
 
-**Carry / monotonicity spec (NEW in v3 per Codex-3):** the monotonic clock
-returns `max(now_tai64n, last + 1_whitened_tick)`. Because nanos are whitened
-to a `0x1000000`-ns (~16.7 ms) granularity, the monotonic "+1" increment is one
-whitened tick = `0x1000000` ns; on nanos overflow past `0xFF000000` the carry
-rolls into the seconds field (`secs += 1; nanos = 0`). Stored as the 12-byte
-big-endian value so lexicographic byte-compare == numeric compare (matches
-`tai64n.go`'s `bytes.Compare`).
+**Carry / monotonicity spec (v3, CORRECTED in v4 per AGY round-2):** the
+monotonic clock returns `max(now_tai64n, last + 1_whitened_tick)`. Nanos are
+whitened to a `0x1000000`-ns (~16.7 ms) granularity, so the monotonic "+1"
+increment is one whitened tick = `0x1000000` ns. **The carry into seconds MUST
+trigger when the advanced nanos reach `>= 1_000_000_000` (`0x3B9ACA00`), NOT at
+`0xFF000000`** — a TAI64N nanos field must be a valid sub-second value `< 10^9`
+or a strict kernel-WG / wireguard-go peer rejects the datagram as malformed.
+Worked example (AGY): max whitened nanos = `0x3B000000` (989,852,672); adding
+one tick `0x1000000` → `0x3C000000` (1,006,632,960) which is `> 10^9` ⇒ MUST
+carry (`secs += 1; nanos = 0`). Stored as the 12-byte big-endian value so
+lexicographic byte-compare == numeric compare (matches `tai64n.go`'s
+`bytes.Compare`). A `tai64n_carry_at_1e9` test pins this boundary.
 
 **Monotonicity invariant (research §9, SMR r1 #1):** kernel WG rejects a msg1
 whose TAI64N is `<=` the last one it accepted from that peer — so xpf MUST emit
@@ -369,10 +377,11 @@ durable fix (disk persist) lands in S6.
 msg1/msg2 MAC1 requires xpf's OWN static public key (the recipient key for
 inbound messages). Today `WgEngineConfig`/`WgEngine` store only
 `local_private_key` (`engine.rs:173`, `:256`). v3 adds a `local_public_key:
-[u8; 32]` derived ONCE at `WgEngine::new` from the private key
-(X25519 base-point mult via `curve25519-dalek` — already in `Cargo.lock` at
-4.1.3 — or snow's `Builder::generate_keypair` is NOT it; use the dalek
-`x25519(secret, basepoint)` clamp). Storing it avoids re-deriving per parse and
+[u8; 32]` derived ONCE at `WgEngine::new` from the private key. **Impl note
+(Codex round-2):** in `curve25519-dalek` 4.1.3 use
+`MontgomeryPoint::mul_base_clamped(secret).to_bytes()` — this matches snow's
+own static-key derivation exactly, so the stored `local_public_key` equals what
+the peer authenticates. Storing it avoids re-deriving per parse and
 prevents the "private-key-as-public" / swapped-key class of bug under
 implementation pressure. A unit test asserts `local_public_key` equals snow's
 notion of our static pub for the same private key.
@@ -425,9 +434,23 @@ This means:
   - The reservation must be released on handshake failure/timeout so a dropped
     handshake does not leak the index forever (mirrors the
     `reconcile_peers` drain discipline for dropped sessions).
-  - Tests: `reserve_before_send_then_promote`, and a concurrent-reservation
-    test proving two in-flight handshakes never both claim the same index and
-    no completed handshake is left un-demuxable.
+  - **At-most-one-pending-per-peer (NEW in v4 — AGY round-2 DoS finding).**
+    MAC1 keys only on xpf's *public* responder key, so an attacker can flood
+    valid-MAC1 msg1s. If the responder reserved an index + stored a pending
+    `HandshakeState` for *every* inbound msg1, it could exhaust the 32-bit
+    index space / blow memory. **Invariant: each peer pubkey holds at most ONE
+    pending reservation; a new initiation from a peer ABORTS and releases that
+    peer's prior pending reservation before reserving a new one.** This bounds
+    pending state to O(num configured peers), not O(inbound msg1 rate). (Note:
+    `consume_initiation` only reaches the reservation step *after* snow
+    `read_message` authenticates the static-key AEAD, so an unauthenticated
+    flood is already rejected pre-reservation; the per-peer cap bounds the
+    authenticated-but-incomplete case.)
+  - Tests: `reserve_before_send_then_promote`; a concurrent-reservation test
+    proving two in-flight handshakes never both claim the same index and no
+    completed handshake is left un-demuxable; and
+    `at_most_one_pending_per_peer` (a second init from a peer releases the
+    first pending reservation).
 
 Exact return shapes keep `HandshakeState` engine-internal where possible
 (SMR-6): the engine holds the pending `HandshakeState` keyed by the reserved
@@ -470,13 +493,16 @@ SMR-R1.)
   - `mac1_keys_on_recipient_static_pub` — build msg1 toward responder R; assert
     mac1 verifies under `HASH("mac1----"||R_pub)` and FAILS under a different
     pubkey (catches the swapped-key bug).
-  - **`msg1_full_kat_fixed_ephemeral` (SMR-2, REQUIRED)** — with a pinned
-    local-static + ephemeral (snow `fixed_ephemeral`) + a fixed TAI64N, assert
-    the entire deterministic 148-byte msg1 and its 16-byte mac1 over
-    `msg[0..116]`. This is the one test that catches an offset/endianness bug
-    in the framing *assembly* that per-field KATs miss. (If a fixed-ephemeral
-    builder is not cleanly reachable, fall back to asserting mac1 over a
-    captured msg-prefix — still catches the offset bug.)
+  - **`msg1_full_kat_fixed_ephemeral` + `msg2_full_kat_fixed_ephemeral`
+    (SMR-2 / Codex-1, BOTH REQUIRED)** — with pinned local-static + ephemeral
+    + a fixed TAI64N, assert the entire deterministic 148-byte msg1 (and its
+    16-byte mac1 over `msg[0..116]`) AND the entire 92-byte msg2 (mac1 over
+    `msg[0..60]`). These are the two tests that catch an offset/endianness bug
+    in the framing *assembly* that per-field KATs miss. snow 0.10 exposes
+    `Builder::fixed_ephemeral_key_for_testing_only`, so the fixed-ephemeral
+    path IS reachable — **no fallback is permitted for these full-message
+    KATs** (Codex round-2). A `WgEngine` test-only hook threads the fixed
+    ephemeral into `create_initiation`/`consume_initiation_create_response`.
   - `msg1_layout_byte_offsets` / `msg2_layout_byte_offsets` — assert the
     148/92-byte total, type byte = 1/2, reserved zeros, LE indices at the right
     offsets, snow body at offset 8/12, mac1/mac2 at the tail.
@@ -488,9 +514,11 @@ SMR-R1.)
     `(secs, nanos)`, including the **`+10` epoch offset** (AGY-2) and the
     **nanos whitening** (v3); `tai64n_strictly_monotonic` (N calls strictly
     increase by byte-compare even with a frozen/backwards clock, with the
-    one-whitened-tick carry into seconds on nanos overflow — §4.3);
-    **`tai64n_concurrent_monotonic` (SMR-4)** (N threads calling `now()` yield
-    N strictly-ordered distinct values).
+    one-whitened-tick carry into seconds — §4.3);
+    **`tai64n_carry_at_1e9` (AGY round-2)** (carry triggers at nanos
+    `>= 1_000_000_000`, NOT `0xFF000000` — a strict peer rejects nanos `>= 10^9`
+    as malformed); **`tai64n_concurrent_monotonic` (SMR-4)** (N threads calling
+    `now()` yield N strictly-ordered distinct values).
   - `framing_roundtrip` — `build_initiation` then `parse_initiation` recovers
     the sender_index + noise body; `parse` rejects TooShort / BadType /
     Mac1Mismatch.
@@ -691,9 +719,14 @@ pass unchanged.
   (handshake framing round-trip, mac1 key-on-recipient, TAI64N monotonic,
   TooShort/BadType/Mac1Mismatch arms).
 - **Spec KAT vector tests** (§5.4a) — **the S1 success criterion** under
-  Option (b): `construction_hashes_match_spec`, `mac1_keyed_blake2s_128_kat`,
-  `mac1_keys_on_recipient_static_pub`, `msg1/msg2_layout_byte_offsets`,
-  `tai64n_encoding_kat`, `tai64n_strictly_monotonic`, `framing_roundtrip`,
+  Option (b+): `construction_hashes_match_spec`, `mac1_keyed_blake2s_128_kat`,
+  `mac1_keys_on_recipient_static_pub`, **`msg1_full_kat_fixed_ephemeral`**,
+  **`msg2_full_kat_fixed_ephemeral`** (both full byte-exact wire-image KATs —
+  Codex round-2 requires both named), `msg1_layout_byte_offsets`,
+  `msg2_layout_byte_offsets`, `parse_initiation_accepts_nonzero_mac2`,
+  `tai64n_encoding_kat`, `tai64n_strictly_monotonic`, `tai64n_carry_at_1e9`,
+  `tai64n_concurrent_monotonic`, `framing_roundtrip`,
+  `reserve_before_send_then_promote`, `at_most_one_pending_per_peer`,
   `engine_self_handshake_with_framing`.
 - **5× flake** on the framing tests (esp. `engine_self_handshake_with_framing`
   and `tai64n_strictly_monotonic`) — must be 5/5.
@@ -933,3 +966,44 @@ is keyed-BLAKE2s-128, S1/S2 boundary = Option (b+).
 All MAJOR/CRITICAL findings are addressed in v3. Remaining work is a confirming
 round-2 (Codex + AGY) on v3, then implement per §5 with the strengthened
 §5.4a gate.
+
+---
+
+## v4-round2 — confirming plan-review (Codex + AGY on v3)
+
+Round-2 reviews of plan v3 (@ `b9e8bb00a`):
+
+- **AGY** (`adversarial-review-mpt7315l-j522br`): **PLAN-READY**. Confirmed all
+  three AGY-round-1 findings resolved (index blackhole race closed by two-phase
+  reservation; epoch offset + nanos whitening correct; NTP/restart self-DoS
+  correctly scoped to an S2 runbook item + S6 durable fix) and all Codex
+  findings resolved. Raised TWO new implementation caveats (both folded into
+  v4):
+  1. **TAI64N nanos-carry math (MUST-FIX):** carry into seconds must trigger at
+     advanced nanos `>= 1_000_000_000` (`0x3B9ACA00`), NOT at `0xFF000000`. Max
+     whitened nanos `0x3B000000` + one tick `0x1000000` = `0x3C000000`
+     (1,006,632,960) `> 10^9` ⇒ a strict kernel-WG/wireguard-go peer rejects a
+     nanos `>= 10^9` as malformed. → §4.3 corrected; `tai64n_carry_at_1e9` test
+     added.
+  2. **Pending-reservation state-exhaustion DoS:** MAC1 keys only on xpf's
+     public key, so valid-MAC1 msg1 floods are cheap to forge. The reservation
+     layer must cap pending handshakes at ONE per peer pubkey (a new init from a
+     peer aborts+releases that peer's prior pending). → §5.3 invariant +
+     `at_most_one_pending_per_peer` test added. (Mitigated further by the fact
+     that the reservation step is reached only after snow authenticates the
+     static-key AEAD.)
+
+- **Codex** (`task-mpt72t96-tcx9m8`): **PLAN-NEEDS-MINOR**. No majors remain;
+  confirmed Codex-1..5 + AGY-2 resolved. One text fix: §5.4a named only
+  `msg1_full_kat_fixed_ephemeral` — add `msg2_full_kat_fixed_ephemeral` and
+  list both in §9; snow exposes `fixed_ephemeral_key_for_testing_only` so the
+  fallback path is disallowed for these KATs. Impl note: derive
+  `local_public_key` via `MontgomeryPoint::mul_base_clamped(secret).to_bytes()`
+  to match snow. → §5.4a + §9 + §5.3 updated.
+
+**Convergence:** AGY PLAN-READY, Codex PLAN-NEEDS-MINOR (text-only, addressed in
+v4), Claude-SMR PLAN-NEEDS-MINOR (round-1, addressed in v3/v4). All MAJOR and
+CRITICAL findings across both rounds are resolved in plan v4. **Cleared to
+implement** per §5 with the strengthened §5.4a/§9 gate and the §5.3 reservation
++ §4.3 TAI64N invariants. A round-3 reviewer pass is not required — the only
+open round-2 items were text/impl-note fixes now in v4.

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
@@ -1,6 +1,12 @@
-# #1709 — WireGuard S1: wire-protocol compliance (TAI64N + handshake framing) validated vs wireguard-go reference
+# #1709 — WireGuard S1: wire-protocol compliance (TAI64N + handshake framing) validated by spec known-answer vectors (live kernel-WireGuard interop = S2)
 
-Status: **DRAFT v1 — pending adversarial plan review** (Codex + AGY + Claude-SMR)
+Status: **DRAFT v2 — pending adversarial plan review** (Codex + AGY +
+Claude-SMR). v2 changes from v1: dropped the wireguard-go-as-library interop
+harness (user rejected a Go reference for a Rust dataplane); the independent
+reference peer is now the **Linux kernel WireGuard module on a real incus VM**
+(never a container); S1's in-tree gate is **spec known-answer vectors**, and
+the recommended S1/S2 boundary defers the live kernel-wg-VM interop test to S2
+(plan-review to ratify (a) vs (b)).
 
 Issue: #1709 (part of #1703 umbrella). Branch:
 `refactor/1709-wireguard-s1-wire-protocol-compliance`.
@@ -32,8 +38,9 @@ demuxes on `sender_index` (absent), and rejects any datagram whose MAC1 does
 not verify against `BLAKE2s-keyed(HASH("mac1----" || our_static_pub), msg)`.
 
 **S1 scope** (this PR — note #1709 folds research-plan S1 *and* S2 into one
-deliverable, since the issue title is "wire-protocol compliance … validated
-vs wireguard-go reference"):
+deliverable: "wire-protocol compliance — TAI64N + handshake framing —
+validated vs a WireGuard reference"; the reference is now kernel WireGuard,
+and the live interop test is recommended to land in S2, see §5.4/Q7):
 
 1. **TAI64N timestamp** — a monotonic 12-byte TAI64N clock, carried as the
    Noise payload of WG message 1 (encrypted_timestamp), persisted so it never
@@ -44,10 +51,25 @@ vs wireguard-go reference"):
 3. **Initiator path first** (xpf emits a valid msg1, consumes a valid msg2,
    derives a transport session), **then responder path** (xpf parses a peer
    msg1, replies with a valid msg2).
-4. **Automated interop harness vs wireguard-go** that completes a full
-   handshake **both directions** against the independent reference and asserts
-   matching transport-key derivation. **This harness is the success
-   criterion**; an xpf-against-itself test is explicitly insufficient.
+4. **Spec known-answer vector tests (in-tree gate)** that pin the WG
+   construction hashes (InitialChainKey/InitialHash), the MAC1 keyed-BLAKE2s
+   construction, and the TAI64N encoding to authoritative reference values —
+   self-contained, no external peer, runs in plain `cargo test` anywhere.
+5. **Live kernel-WireGuard interop (on a real VM peer)** — xpf's Rust
+   handshake completes **both directions** against a **Linux kernel WireGuard**
+   peer (`ip link add wgX type wireguard` + `wg set`), asserting matching
+   transport-key derivation. Reference peer = **kernel WireGuard running on an
+   actual incus VIRTUAL-MACHINE** (DECIDED by the user) — never a container
+   (containers share the host kernel and cannot independently use the WG
+   module). Byte-identical to what UniFi / EdgeOS / UDM run; no Go toolchain.
+   **This live test is the ultimate interop proof**; an xpf-against-itself test
+   is explicitly insufficient. Because the live test now requires a dedicated
+   VM peer + UDP-reachability wiring between the xpf VM and the peer VM (a
+   non-trivial harness), **the recommended S1/S2 boundary is: S1 = framing +
+   spec-vector unit tests (provable by `cargo test` anywhere, no peer/VM); the
+   live kernel-wg-on-VM interop test moves to S2 alongside the datapath/UDP
+   wiring.** Plan-review (Codex+AGY+SMR) must ratify this boundary — see §5.4(b)
+   and Q7.
 
 **Out of scope** (later #1703 S-steps): dataplane hot-path encap/decap wiring
 (S3 / research-plan S3), keepalive + REKEY/REJECT-AFTER timers + endpoint
@@ -66,8 +88,10 @@ with any compliant peer; after S1 it provably can, against the reference
 implementation, in both roles. The cost is ~400–600 LOC of
 security-critical crypto framing plus a Go interop harness. The honest risk
 is that the framing has a byte-level bug that the harness must catch — which
-is exactly why the harness against an **independent** reference (wireguard-go,
-not xpf's own snow round-trip) is the load-bearing artifact.
+is exactly why the gate is built from **canonical spec known-answer vectors**
+(independent of xpf's own code), with the live test against an **independent**
+reference (kernel WireGuard on a VM, not xpf's own snow round-trip) as the
+S2-opening artifact.
 
 If the framing were judged not worth the security-review burden in isolation,
 the right call is PLAN-KILL — but the research plan already converged
@@ -105,23 +129,29 @@ crypto/replay/AllowedIPs library:
   Passing the 12-byte TAI64N as the snow `payload` makes
   `encrypted_payload == encrypted_timestamp` byte-for-byte. snow msg2 body =
   `e[32] || encrypted_empty[16]` == WG msg2 `Ephemeral[32] || Empty[16]`.
-- **wireguard-go is fetchable + buildable in this sandbox.** `go run` against
-  `golang.zx2c4.com/wireguard@v0.0.0-20260522210424-ecfc5a8d5446` succeeds;
-  `tai64n.Now()` returns 12 bytes; `device` exports
-  `MessageInitiationSize=148`, `MessageResponseSize=92`,
-  `MessageInitiationType=1`, `MessageResponseType=2`, and the struct layouts
-  match the spec (`Type,Sender,Ephemeral[32],Static[48],Timestamp[28],
-  MAC1[16],MAC2[16]` = 148). `tun/netstack` (gvisor, **no root**) +
-  `conn.NewDefaultBind` (real UDP socket) both build — so a full wireguard-go
-  `Device` can run in-process over loopback UDP with no TUN/root requirement.
+- **WG message layouts are byte-confirmed against the spec.** WG msg1 =
+  `Type(1)+reserved(3)+Sender(4)+Ephemeral(32)+Static(48)+Timestamp(28)+
+  MAC1(16)+MAC2(16)` = 148; msg2 =
+  `Type(1)+reserved(3)+Sender(4)+Receiver(4)+Ephemeral(32)+Empty(16)+
+  MAC1(16)+MAC2(16)` = 92 (whitepaper §5.4; cross-checked against the
+  canonical layout). snow's IK msg1/msg2 bodies occupy the
+  `Ephemeral..Timestamp` (108 B) and `Ephemeral..Empty` (48 B) middles exactly.
+- **KAT oracle values are precomputed (offline).** The canonical construction
+  constants (InitialChainKey, InitialHash, MAC1 key, keyed-BLAKE2s-128) were
+  computed offline once and are baked as hex literals into the unit tests
+  (§5.4a). **No Go toolchain, no wireguard-go, no network at test time** — the
+  vectors are static.
 - **`blake2 0.10.6` is already in `Cargo.lock`** (transitive via snow) — MAC1
-  keyed-BLAKE2s needs no new direct dependency beyond promoting `blake2` to a
+  keyed-BLAKE2s needs no new locked dependency beyond promoting `blake2` to a
   direct `Cargo.toml` entry (same locked version, no tree change).
-- **`wg` / `wireguard-go` binaries are NOT installed**; `wireguard-tools` is
-  apt-candidate only. The harness therefore uses the **wireguard-go Go module
-  as a library** (vendored via `go.mod`, already in the module cache), NOT a
-  system `wg` binary. This is documented as the chosen approach (issue asks to
-  "install/vendor it or use kernel `wg` — document the approach").
+- **Kernel WireGuard is available on the loss VM (verified).** On
+  `loss:xpf-userspace-fw0`: `modinfo wireguard` →
+  `/lib/modules/7.0.0-rc7+/.../wireguard.ko.xz`; `ip link add wgX type
+  wireguard` succeeds (CREATE_OK). `ip` is present; **`wg`/`wg-quick`
+  userspace tools are NOT yet installed** (only the kernel module + `ip`), so
+  the live harness must either `apt-get install wireguard-tools` on the VM or
+  configure the reference interface via netlink/`ip`. This is the reference
+  peer for the live interop test (DECIDED).
 
 ---
 
@@ -324,55 +354,113 @@ existing tests already pass `HandshakeState` around, so the boundary is proven.
 Sender/receiver index allocation reuses the existing demux discipline
 (`install_session` already enforces global `local_index` uniqueness).
 
-### 5.4 Interop harness — `userspace-dp/tests/wg_interop/` + Go reference
+### 5.4 Verification: spec KAT vectors (in-tree gate) + deferred live harness
 
-**Architecture (decided after probing wireguard-go's API):**
+**(a) Spec known-answer vector tests — the buildable-now, self-contained gate.**
+These pin xpf's framing to authoritative WireGuard reference values with NO
+external peer, so they run in plain `cargo test` on any box. The values below
+were computed offline from the canonical WG construction (BLAKE2s over the
+documented labels/identifier; an offline BLAKE2s oracle produced the expected
+hex). Per Q6, the tests should ALSO re-derive these from raw `blake2` calls in
+the same test so neither a transcription typo nor an implementation bug can
+pass alone. No runtime external dependency is introduced:
 
-1. A **Rust integration test** (`userspace-dp/tests/wg_interop.rs`) that builds
-   a `WgEngine` and exercises `create_initiation` / `consume_response` /
-   `consume_initiation_create_response`, exchanging raw bytes with the Go
-   reference over a **loopback UDP socket**.
-2. The **independent reference** is a small Go program
-   (`test/wg-interop-peer/`, its own `go.mod` pinning
-   `golang.zx2c4.com/wireguard`) that stands up a real wireguard-go `Device`
-   with a `tun/netstack` TUN (no root) + `conn.NewDefaultBind` UDP socket,
-   configured via `IpcSet` (private key, peer pubkey, allowed-ips, endpoint =
-   the Rust test's UDP socket). The Rust test spawns this peer as a subprocess,
-   reads its chosen UDP port + public key from stdout, and drives the exchange.
+- `InitialChainKey = BLAKE2s-256("Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s")`
+  = `60e26daef327efc02ec335e2a025d2d016eb4206f87277f52d38d1988b78cd36`
+- `InitialHash = BLAKE2s-256(InitialChainKey || "WireGuard v1 zx2c4 Jason@zx2c4.com")`
+  = `2211b361081ac566691243db458ad5322d9c6c662293e8b70ee19c65ba079ef3`
+- MAC1 key for recipient pubkey `0x42`×32
+  = `BLAKE2s-256("mac1----" || pubkey)`
+  = `172c34d6807bd7acef1a2471f20e928626c23ce0b9f90b326cf5f82d12480a4e`
+- `keyed-BLAKE2s-128(MAC1key, b"abc")`
+  = `78df3b0a90577688ce9d272d04a8fb90`
 
-   - **Direction A (xpf initiator → wireguard-go responder):** Rust
-     `create_initiation` → send UDP datagram to the Go peer → the Go Device's
-     real receive path runs `CheckMAC1` + `ConsumeMessageInitiation` (verifies
-     mac1 against xpf's framing, decrypts the TAI64N, checks monotonicity) →
-     Go emits a real type-2 → Rust `consume_response` derives the transport
-     session. **Assert:** Go accepted msg1 (no drop — observable because it
-     sends a msg2; we parse the type-2 we receive) AND xpf derived a session
-     whose transport key matches (proven by a subsequent transport-record
-     round-trip below).
-   - **Direction B (wireguard-go initiator → xpf responder):** configure the Go
-     peer with `PersistentKeepalive`/an endpoint so it initiates; Rust receives
-     the UDP datagram, `consume_initiation_create_response` parses + replies;
-     Go consumes the type-2 and the handshake completes on the Go side.
-     **Assert:** xpf parsed a real wireguard-go msg1 (mac1 verified, TAI64N
-     decrypted) and emitted a msg2 that wireguard-go accepted.
-   - **Key-confirmation / matching transport keys:** after each direction, send
-     ONE WireGuard transport DATA record (type 4) carrying a tiny inner IP
-     packet from xpf's `try_encap` and assert the Go peer decrypts it
-     (delivers to its netstack TUN), and vice-versa. This is the
-     "derives matching transport keys" proof the task demands. *(This is a
-     transport record, not the AF_XDP datapath — it uses the existing
-     spec-compliant `framing.rs` over the loopback UDP socket, NOT
-     `poll_descriptor.rs`. So it stays within S1's "no datapath change"
-     boundary while still proving end-to-end key agreement.)*
+Test suite (`wg/handshake.rs` + `wg/tai64n.rs` `#[cfg(test)]`):
+  - `construction_hashes_match_spec` — assert xpf's computed InitialChainKey /
+    InitialHash equal the hex above (this independently re-derives what snow's
+    prologue already mixes, proving the framing layer agrees with the engine).
+  - `mac1_keyed_blake2s_128_kat` — assert the keyed-BLAKE2s-128 vector above
+    (proves keyed-BLAKE2s, NOT HMAC, and the 16-byte output width — the
+    research §7 SMR r1 #3 hazard).
+  - `mac1_keys_on_recipient_static_pub` — build msg1 toward responder R; assert
+    mac1 verifies under `HASH("mac1----"||R_pub)` and FAILS under a different
+    pubkey (catches the swapped-key bug).
+  - `msg1_layout_byte_offsets` / `msg2_layout_byte_offsets` — assert the
+    148/92-byte total, type byte = 1/2, reserved zeros, LE indices at the right
+    offsets, snow body at offset 8/12, mac1/mac2 at the tail.
+  - `tai64n_encoding_kat` — assert the 12-byte layout (BE u64 `2^62+secs` ||
+    BE u32 nanos) for a fixed `(secs, nanos)`, and `tai64n_strictly_monotonic`
+    (N calls strictly increase by byte-compare even with a frozen/backwards
+    clock).
+  - `framing_roundtrip` — `build_initiation` then `parse_initiation` recovers
+    the sender_index + noise body; `parse` rejects TooShort / BadType /
+    Mac1Mismatch.
+  - `engine_self_handshake_with_framing` — drive both engine roles through the
+    NEW framed `create_initiation`/`consume_initiation_create_response`/
+    `consume_response` path (not just raw snow) and assert both sides derive a
+    transport session that encrypts/decrypts a record. *This is xpf-against-xpf
+    and is explicitly NOT sufficient as the interop proof — it is a regression
+    guard for the engine integration; the LIVE harness in (b) is the interop
+    gate.*
 
-3. **Self-contained build:** the Go reference is built by the test via
-   `go build` (module cache already populated; documented `go.mod`). If the
-   Go toolchain or network is unavailable, the interop test is gated behind a
-   `WG_INTEROP=1` env / a `#[ignore]`-with-reason so `cargo test` stays green
-   on a bare box, BUT the gate is **on by default in the dev/CI path** and the
-   PR's acceptance requires it green. (Open question for review: ignore-by-
-   default vs hard-required — I lean "required, with a clear skip message if
-   `go` is absent, and run it explicitly in the gate.")
+**(b) Live kernel-WireGuard interop (on a real VM peer) — reference DECIDED,
+S1/S2 boundary RECOMMENDED = defer to S2, to be RATIFIED in plan-review.**
+The ultimate interop proof uses an *independent* reference = the **Linux
+kernel WireGuard** module on a real incus VM (never a container — containers
+share the host kernel and cannot use the WG module / create `type wireguard`
+links). Either launch a dedicated lightweight Debian-13 VM
+(`incus launch images:debian/13 <name> --vm`) or reuse an existing real VM
+(e.g. `bpfrx-fw`), attach it to a network the xpf VM (`xpf-userspace-fw0`,
+itself a VM) can reach, and configure kernel `wg`:
+
+```
+# on the PEER VM (root; wireguard-tools installed via apt if absent):
+ip link add wgref type wireguard
+wg set wgref private-key <ref.priv> listen-port <P> \
+   peer <xpf.pub> allowed-ips 0.0.0.0/0 endpoint <xpf_vm_ip>:<Q>
+ip addr add 10.<x>.<y>.1/24 dev wgref; ip link set wgref up
+# Direction A: xpf create_initiation -> UDP <peer_vm_ip>:<P>; kernel wg
+#   verifies mac1 + decrypts TAI64N + replies type-2; xpf consume_response
+#   derives the session. Assert via `wg show wgref` (latest-handshake / rx
+#   counters) AND xpf-side session derivation + a transport-record round-trip.
+# Direction B: kernel wg initiates (persistent-keepalive 1); xpf
+#   consume_initiation_create_response replies; assert `wg show` completes.
+```
+
+**The load-bearing sequencing question (the user flagged it; plan-review MUST
+ratify):** a *live* handshake requires (i) xpf to actually send/receive the
+handshake UDP datagrams and (ii) a dedicated VM peer + UDP reachability wiring
+between the two VMs. The AF_XDP datapath wiring is research-plan S3. Two
+options:
+
+- **Option (a) — minimal test-only UDP socket harness in S1.** Add a small
+  test/ops-only `std::net::UdpSocket` (control thread, NOT the AF_XDP worker)
+  that pumps S1's bytes to/from the kernel-wg VM endpoint, plus the incus VM
+  provisioning + cross-VM network wiring under `test/incus/`. Proves wire
+  compliance against a real kernel peer without touching the hot path — but the
+  VM provisioning + cross-VM reachability harness is now non-trivial
+  (a new VM lifecycle + network attach), which is real surface to build and
+  maintain inside a security-critical framing PR.
+- **Option (b) — S1 = framing + spec-vector unit tests; live kernel-wg-on-VM
+  interop → S2 (RECOMMENDED).** Keep S1 self-contained and provable by
+  `cargo test` anywhere (no peer, no VM, no network). The live kernel-wg-VM
+  interop test lands in S2 alongside the datapath/UDP wiring it naturally
+  shares (the same UDP send/recv plumbing serves both the live test and the
+  datapath). This gives a clean, reviewable S1 (pure wire-protocol correctness)
+  and avoids bolting a VM-lifecycle + cross-VM-network harness onto the
+  crypto-framing PR.
+
+**My recommendation flips to (b)** given the user's correction: the live test
+now needs a real VM peer + cross-VM UDP reachability, which is meaningfully
+more harness than a loopback socket and is better built once, in S2, next to
+the datapath UDP plumbing. S1's falsifiability rests on the spec KAT vectors
+(§5.4a) — which pin every framing/MAC1/TAI64N byte to the canonical
+construction — plus the engine self-handshake-with-framing regression. The
+independent-peer proof is S2's opening gate. **Whatever the verdict, the
+reference peer is kernel WireGuard on a real VM, never a container.**
+**Plan-review must return an explicit (a) vs (b) verdict.**
+
+Per the task: S1 needs **no CoS/iperf cluster smoke** (no datapath change).
 
 ### 5.5 Files touched
 
@@ -384,11 +472,17 @@ Sender/receiver index allocation reuses the existing demux discipline
   TAI64N clock field; target delta < ~150 LOC to stay well under 2000)
 - EDIT `userspace-dp/Cargo.toml` (promote `blake2` to a direct dep at the
   already-locked 0.10.6)
-- NEW `userspace-dp/tests/wg_interop.rs` (Rust harness driver)
-- NEW `test/wg-interop-peer/{go.mod,go.sum,main.go}` (wireguard-go reference)
-- EDIT `docs/wireguard-interop.md` (NEW: harness recipe + wire-compliance
-  status) and flip the relevant OUT items in `docs/pr/wireguard-clean/plan.md`
-  to DONE for handshake framing + TAI64N.
+- (Option a only, if ratified) NEW `test/incus/wg-interop.sh` + a `make`
+  target that provisions a Debian-13 `--vm` kernel-wg peer, wires cross-VM UDP
+  reachability, and drives the test-only UDP socket harness. NOT built under
+  Option (b) — the live kernel-wg-VM interop test moves to S2.
+- EDIT `docs/wireguard-interop.md` (NEW: wire-compliance status + the
+  kernel-wg-on-VM interop recipe, marked S2 under Option b) and flip the
+  relevant OUT items in `docs/pr/wireguard-clean/plan.md` to DONE for handshake
+  framing + TAI64N.
+- NO `test/wg-interop-peer/` Go module, NO `golang.zx2c4.com/wireguard`
+  dependency — wireguard-go is rejected; the reference is kernel WireGuard on a
+  real VM.
 
 ---
 
@@ -416,8 +510,8 @@ pass unchanged.
   mutex; never regresses within a process. Cross-restart persistence hook
   exposed but disk-write deferred (S5/S6) — documented.
 - **mac1 keys on the RECIPIENT's static pub** (responder for msg1, initiator
-  for msg2) — the most common framing bug; the harness against wireguard-go is
-  what catches a swapped key.
+  for msg2) — the most common framing bug; the `mac1_keys_on_recipient_static_pub`
+  KAT test (and, in S2, the live kernel-wg peer) is what catches a swapped key.
 - **No mac2/cookie state** in S1 — emit zeros, skip-verify on parse; a peer
   under load that sends a type-3 cookie reply is out of scope (S7) and must not
   wedge — but S1's harness runs a quiet tunnel, so no cookie is sent.
@@ -433,10 +527,10 @@ pass unchanged.
 |---|---|---|
 | Behavioral regression (existing engine) | **LOW** | Additive; existing tests unchanged; Noise transcript untouched. |
 | Lifetime / borrow-checker | **LOW** | Framing is byte-shuffling over caller slices; `ParsedInitiation` borrows the input like `framing.rs::ParsedDataHeader` already does. |
-| Wire-correctness (byte-level) | **HIGH** | The whole point. Mitigated by the wireguard-go harness (independent reference) — a wrong byte ⇒ Go drops ⇒ test fails. This is the gate. |
-| TAI64N monotonicity / self-DoS | **MED** | Mitigated by mutex-guarded strictly-increasing clock + harness re-handshake. Cross-restart persistence deferred (documented). |
+| Wire-correctness (byte-level) | **HIGH** | The whole point. Mitigated by spec KAT vectors pinning construction hashes / MAC1 / TAI64N / message layouts to canonical values (§5.4a); the independent-peer proof against kernel WireGuard is S2 (Option b) — a wrong byte ⇒ KAT mismatch ⇒ test fails, and in S2 ⇒ kernel wg drops. |
+| TAI64N monotonicity / self-DoS | **MED** | Mitigated by mutex-guarded strictly-increasing clock + the `tai64n_strictly_monotonic` test. Cross-restart persistence deferred (documented). |
 | Architectural mismatch (#961/#946-P2 dead-end) | **LOW** | Design matches snow's proven `write_message(payload)` boundary; not a speculative rearchitecture. The research plan already validated Path A 3-of-3. |
-| Harness flakiness (subprocess/UDP) | **MED** | Loopback UDP + spawned Go peer can race on startup; mitigated by reading the peer's ready-line from stdout before driving, bounded timeouts, and the 5×flake gate. |
+| S1/S2 boundary mis-scope | **MED** | If the live interop test belongs in S1 (Option a) but is deferred, S1 ships an unproven-against-peer framing. Mitigated by the KAT vectors (canonical, independent of xpf) + plan-review's explicit (a)/(b) ratification. |
 
 ---
 
@@ -446,21 +540,27 @@ pass unchanged.
 - `cargo test --release` full suite — all existing + new unit tests
   (handshake framing round-trip, mac1 key-on-recipient, TAI64N monotonic,
   TooShort/BadType/Mac1Mismatch arms).
-- **Interop harness** `cargo test --release --test wg_interop` (both
-  directions vs wireguard-go) — **the success criterion**.
-- **5× flake** on the two interop tests (`wg_interop_xpf_initiator` and
-  `wg_interop_xpf_responder`) — must be 5/5.
-- Go suite `go test ./...` (30 packages) — the new `test/wg-interop-peer/` is
-  its own module so it does not pollute the main Go build; confirm the main
-  suite is unaffected.
+- **Spec KAT vector tests** (§5.4a) — **the S1 success criterion** under
+  Option (b): `construction_hashes_match_spec`, `mac1_keyed_blake2s_128_kat`,
+  `mac1_keys_on_recipient_static_pub`, `msg1/msg2_layout_byte_offsets`,
+  `tai64n_encoding_kat`, `tai64n_strictly_monotonic`, `framing_roundtrip`,
+  `engine_self_handshake_with_framing`.
+- **5× flake** on the framing tests (esp. `engine_self_handshake_with_framing`
+  and `tai64n_strictly_monotonic`) — must be 5/5.
+- Go suite `go test ./...` (30 packages) — confirm unaffected (no Go code added
+  in S1; the kernel-wg harness, if Option a, is shell + incus, not Go).
 - `make audit-check` — confirm engine.rs stays < 2000 LOC and the new files
   are registered; regen `docs/refactoring-audit-current.txt` if a wg file
   crosses 1500.
-- **NO cluster smoke for S1.** This is handshake/wire-protocol + an
-  integration test, **not a datapath change** (no encap/decap on the AF_XDP
-  hot path — that is S3). The CoS/iperf3 matrix exercises the AF_XDP fast path,
-  which S1 does not touch. Stated explicitly per the task. The cluster smoke
-  belongs to research-plan S3 when the engine goes on the hot path.
+- **(Option a only)** live kernel-wg-on-VM interop, run on the cluster via
+  `test/incus/wg-interop.sh` — both directions handshake-complete against a
+  real Debian-13 `--vm` kernel WireGuard peer. Under the RECOMMENDED Option (b)
+  this moves to S2.
+- **NO CoS/iperf cluster smoke for S1.** This is handshake/wire-protocol, **not
+  a datapath change** (no encap/decap on the AF_XDP hot path — that is S3). The
+  CoS/iperf3 matrix exercises the AF_XDP fast path, which S1 does not touch.
+  Stated explicitly per the task. The CoS/iperf cluster smoke belongs to
+  research-plan S3 when the engine goes on the hot path.
 
 ---
 
@@ -486,34 +586,47 @@ pass unchanged.
    msg1 `write_message(tai64n_12b, out)` produces `e[32] || enc_s[48] ||
    enc_ts[28]` identical to WG msg1 inner. Is there any snow-side framing
    (length prefix, extra MixHash of the payload at a different point) that
-   diverges from kernel WG's `encrypt(timestamp)` so the harms only surface as
-   a tag-verify failure on the Go side? (Probe says lengths match; demand the
-   harness prove the AEAD verifies, not just the length.)
-2. **mac1 = keyed-BLAKE2s-128, not HMAC.** Confirm against wireguard-go
-   `cookie.go` that it's `blake2s.New128(key)` keyed (not HMAC-BLAKE2s), key =
-   `BLAKE2s-256(LABEL_MAC1 || recipient_static_pub)` (32-byte hash used as the
-   16-output keyed-BLAKE2s key). Wrong hash width or HMAC vs keyed ⇒ silent
-   drop. Is my "HASH = BLAKE2s-256, MAC = keyed-BLAKE2s-128" reading correct?
+   diverges from kernel WG's `encrypt(timestamp)` so the harm only surfaces as
+   a tag-verify failure on the peer side? (Probe says lengths match; the S2
+   live kernel-wg test is the ultimate proof — but does S1 need a stronger
+   in-tree assertion than length, e.g. a KAT for the full msg1 against a
+   pinned ephemeral?)
+2. **mac1 = keyed-BLAKE2s-128, not HMAC.** Confirm against the canonical WG
+   construction that it's keyed-BLAKE2s (`blake2s` with the key param, NOT
+   HMAC-BLAKE2s), key = `BLAKE2s-256(LABEL_MAC1 || recipient_static_pub)`
+   (32-byte hash used as the keyed-BLAKE2s key, 16-byte output). The KAT vector
+   in §5.4a (`78df3b0a90577688ce9d272d04a8fb90` for key over 0x42×32 pubkey,
+   message `b"abc"`) pins this. Wrong hash width or HMAC vs keyed ⇒ silent drop.
+   Is my "HASH = BLAKE2s-256, MAC = keyed-BLAKE2s-128" reading correct?
 3. **Is in-process TAI64N monotonicity + a deferred persist hook acceptable
    for S1**, or must S1 land disk persistence (research §9 ties it to S2)? I
    argue persistence belongs with daemon/config integration (S6) since S1 has
-   no daemon wiring. Kill the deferral if a reviewer shows S1's harness can
-   regress the clock.
-4. **Is the wireguard-go-as-library harness a sufficient independent
-   reference**, or does the task's intent require the kernel `wg` /
-   `wg-quick` path (apt-install in the env)? wireguard-go is byte-identical to
-   kernel WG (same author, same protocol) and needs no root via `netstack`;
-   kernel `wg` needs root + a netns + module load. I claim wireguard-go is the
-   stronger, more portable independent reference. Refute if the loopback-UDP +
-   netstack peer is not a faithful stand-in.
+   no daemon wiring. Kill the deferral if a reviewer shows S1 can ship a
+   handshake path that regresses the clock.
+4. **Are the spec KAT vectors (§5.4a) a sufficient S1 merge gate** with the
+   live kernel-wg-on-VM test deferred to S2 (Option b)? The KAT vectors pin the
+   framing/MAC1/TAI64N bytes to the canonical construction (independent of
+   xpf's own code), but they do not prove an independent kernel peer accepts
+   the datagram. Is "KAT vectors green + engine self-handshake-with-framing
+   green" enough to merge S1? (Tied to Q7.)
 5. **Index allocation / receiver_index echo.** msg2 must echo msg1's
    sender_index as its receiver_index, and the responder's own sender_index
    must be installed for inbound demux. Does the existing `install_session`
    uniqueness discipline compose cleanly with framing-chosen indices, or is
-   there a race when the harness drives both roles in one process?
-6. **Harness `go test` / cargo boundary.** Is spawning a Go subprocess from a
-   Rust integration test the right seam, or should the harness be a Go test
-   that shells out to a tiny xpf framing CLI? I chose Rust-drives-Go because
-   the security-critical bytes are xpf's and must be asserted in xpf's test;
-   the reference is the dependency. Is the subprocess/UDP harness too flaky to
-   be a merge gate (the 5×flake gate is meant to answer this)?
+   there a race when both roles are driven in one process?
+6. **Are the precomputed KAT hex values trustworthy** given they were generated
+   from an offline oracle (the canonical BLAKE2s construction)? Should the test
+   instead re-derive them from first principles (raw `blake2` calls in the
+   test) so the test does not depend on a transcribed magic constant — i.e.
+   assert xpf's framing-layer hash == an independently-computed
+   `blake2s::Blake2s256` call in the same test, rather than a baked hex string?
+   (I lean: do BOTH — bake the hex AND re-derive — so a transcription typo and
+   an implementation bug can't both pass.)
+7. **S1/S2 boundary: (a) test-only UDP socket + VM-peer harness in S1, or (b)
+   defer the live kernel-wg-on-VM interop to S2?** (See §5.4b.) I recommend (b):
+   the live test now needs a dedicated VM peer + cross-VM UDP reachability, a
+   non-trivial harness better built once in S2 next to the datapath UDP
+   plumbing; S1 stays a clean, `cargo test`-provable wire-protocol-correctness
+   PR. PLAN-review MUST return an explicit (a)/(b) verdict. Reference peer =
+   kernel WireGuard on a real VM regardless. PLAN-KILL if neither boundary
+   gives a coherent S1.

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
@@ -1,0 +1,519 @@
+# #1709 — WireGuard S1: wire-protocol compliance (TAI64N + handshake framing) validated vs wireguard-go reference
+
+Status: **DRAFT v1 — pending adversarial plan review** (Codex + AGY + Claude-SMR)
+
+Issue: #1709 (part of #1703 umbrella). Branch:
+`refactor/1709-wireguard-s1-wire-protocol-compliance`.
+
+Research source: `docs/research/1703-wireguard-ubiquiti-interop/plan.md`
+(branch `research/1703-wireguard-ubiquiti-interop` @ 8ed3d49e), §2.2, §6
+Path A, §7 S1+S2, §8 Test 1a/2a.
+
+> If reviewers conclude the design is wrong (snow cannot produce
+> byte-exact WG handshake bytes, the harness does not prove independent
+> interop, or the TAI64N/MAC1 construction diverges from the spec),
+> **PLAN-KILL is an acceptable verdict.** This is the highest-stakes
+> correctness domain in the project; a wrong byte means a silent
+> handshake drop.
+
+---
+
+## 1. Issue framing (in my words)
+
+xpf's `userspace-dp/src/afxdp/wg/` engine drives a Noise_IKpsk2 handshake
+through `snow`, but it emits **only the raw Noise sub-message bytes** — it
+does NOT build the WireGuard on-wire handshake framing (message type byte,
+reserved, sender/receiver index, MAC1, MAC2) and it sends an **empty Noise
+payload** instead of the **TAI64N timestamp** that WG carries as the
+encrypted payload of message 1. A standards-compliant peer (wireguard-go,
+kernel `wg`, UniFi's kernel WG) silently drops xpf's handshake before any
+crypto: it parses byte 0 as the type (xpf's first byte is the ephemeral),
+demuxes on `sender_index` (absent), and rejects any datagram whose MAC1 does
+not verify against `BLAKE2s-keyed(HASH("mac1----" || our_static_pub), msg)`.
+
+**S1 scope** (this PR — note #1709 folds research-plan S1 *and* S2 into one
+deliverable, since the issue title is "wire-protocol compliance … validated
+vs wireguard-go reference"):
+
+1. **TAI64N timestamp** — a monotonic 12-byte TAI64N clock, carried as the
+   Noise payload of WG message 1 (encrypted_timestamp), persisted so it never
+   regresses across control-plane restart.
+2. **WG handshake framing** (message types 1 & 2) on **build + parse** paths:
+   type byte, `reserved_zero[3]`, sender/receiver index, MAC1, MAC2 (zeros
+   until a cookie is observed), wrapping snow's Noise body.
+3. **Initiator path first** (xpf emits a valid msg1, consumes a valid msg2,
+   derives a transport session), **then responder path** (xpf parses a peer
+   msg1, replies with a valid msg2).
+4. **Automated interop harness vs wireguard-go** that completes a full
+   handshake **both directions** against the independent reference and asserts
+   matching transport-key derivation. **This harness is the success
+   criterion**; an xpf-against-itself test is explicitly insufficient.
+
+**Out of scope** (later #1703 S-steps): dataplane hot-path encap/decap wiring
+(S3 / research-plan S3), keepalive + REKEY/REJECT-AFTER timers + endpoint
+roaming (S5), non-zero PSK config plumbing (S4), Junos config surface (S6),
+cookie-reply (type-3) generation + IPv6 outer + DSCP/ECN (S7), HA RG session
+migration (S8). Transport-flow over the AF_XDP worker (Test 1b/2b) stays out;
+S1 proves **handshake-message validity + session derivation** only.
+
+---
+
+## 2. Honest scope / value framing
+
+This is not a perf change — there is no cycle/MB/retransmit win to weigh. The
+value is **binary interop**: today xpf cannot complete a WireGuard handshake
+with any compliant peer; after S1 it provably can, against the reference
+implementation, in both roles. The cost is ~400–600 LOC of
+security-critical crypto framing plus a Go interop harness. The honest risk
+is that the framing has a byte-level bug that the harness must catch — which
+is exactly why the harness against an **independent** reference (wireguard-go,
+not xpf's own snow round-trip) is the load-bearing artifact.
+
+If the framing were judged not worth the security-review burden in isolation,
+the right call is PLAN-KILL — but the research plan already converged
+PLAN-READY 3-of-3 on Path A with this as the critical-path first build step,
+and the feasibility probes below show the design is byte-exact-achievable with
+the deps already in the tree.
+
+---
+
+## 3. What's already shipped / proven (compose with, do not rebuild)
+
+The engine (`wg/engine.rs`, 1725 LOC, WATCH-tier) is a reviewed
+crypto/replay/AllowedIPs library:
+
+- `build_initiator_handshake` / `build_responder_handshake` build a snow
+  `HandshakeState` with `.prologue(WG_PROTOCOL_ID_BYTES)` +
+  `.psk(2, &WG_ZERO_PSK)`. The **Noise transcript init is already
+  spec-correct** (research §2.2: `Ci=HASH(CONSTRUCTION)`,
+  `Hi=HASH(HASH(Ci||IDENTIFIER)||responder.static)`,
+  `IDENTIFIER="WireGuard v1 zx2c4 Jason@zx2c4.com"`). I do not touch the
+  prologue or pattern.
+- `WgSession` / `install_session` / `try_encap` / `try_decap` /
+  `reconcile_peers` are done. Transport-DATA framing (`framing.rs`, type 4) is
+  spec-compliant. The replay window is RFC 6479.
+- snow's `HandshakeState::write_message(payload, msg)` writes the **complete
+  Noise message body** and accepts a caller payload; `read_message(msg,
+  payload)` consumes it. `into_stateless_transport_mode()` yields the
+  `StatelessTransportState`.
+
+### 3.1 Feasibility probes run before writing this plan (evidence)
+
+- **snow IK msg1 body == WG msg1 inner bytes.** snow IK message-1 writes `e[32]
+  || encrypted_s[32+16] || encrypted_payload`. WG msg1 inner =
+  `unencrypted_ephemeral[32] || encrypted_static[48] || encrypted_timestamp[12+16]`.
+  Passing the 12-byte TAI64N as the snow `payload` makes
+  `encrypted_payload == encrypted_timestamp` byte-for-byte. snow msg2 body =
+  `e[32] || encrypted_empty[16]` == WG msg2 `Ephemeral[32] || Empty[16]`.
+- **wireguard-go is fetchable + buildable in this sandbox.** `go run` against
+  `golang.zx2c4.com/wireguard@v0.0.0-20260522210424-ecfc5a8d5446` succeeds;
+  `tai64n.Now()` returns 12 bytes; `device` exports
+  `MessageInitiationSize=148`, `MessageResponseSize=92`,
+  `MessageInitiationType=1`, `MessageResponseType=2`, and the struct layouts
+  match the spec (`Type,Sender,Ephemeral[32],Static[48],Timestamp[28],
+  MAC1[16],MAC2[16]` = 148). `tun/netstack` (gvisor, **no root**) +
+  `conn.NewDefaultBind` (real UDP socket) both build — so a full wireguard-go
+  `Device` can run in-process over loopback UDP with no TUN/root requirement.
+- **`blake2 0.10.6` is already in `Cargo.lock`** (transitive via snow) — MAC1
+  keyed-BLAKE2s needs no new direct dependency beyond promoting `blake2` to a
+  direct `Cargo.toml` entry (same locked version, no tree change).
+- **`wg` / `wireguard-go` binaries are NOT installed**; `wireguard-tools` is
+  apt-candidate only. The harness therefore uses the **wireguard-go Go module
+  as a library** (vendored via `go.mod`, already in the module cache), NOT a
+  system `wg` binary. This is documented as the chosen approach (issue asks to
+  "install/vendor it or use kernel `wg` — document the approach").
+
+---
+
+## 4. The WireGuard spec — byte-exact, both sides cited
+
+Per the WireGuard protocol page (https://www.wireguard.com/protocol/) and the
+whitepaper §5.4 (https://www.wireguard.com/papers/wireguard.pdf), cross-checked
+against the wireguard-go reference `device/noise-protocol.go` +
+`device/cookie.go` (module version above) AND xpf's `wg/framing.rs` for the
+data-record analogue:
+
+### 4.1 Message 1 — Handshake Initiation (148 bytes)
+
+```
+offset size field
+  0     1   message_type = 1
+  1     3   reserved_zero  = {0,0,0}
+  4     4   sender_index   (LE u32, initiator-chosen)
+  8    32   unencrypted_ephemeral        ─┐
+ 40    48   encrypted_static (32+16 tag)  ├─ snow IK msg1 body (write_message)
+ 88    28   encrypted_timestamp (12+16)  ─┘   payload = 12-byte TAI64N
+116    16   mac1
+132    16   mac2
+```
+
+- `mac1 = MAC(key = HASH(LABEL_MAC1 || responder.static_public),
+              input = msg[0 .. 116])` where `LABEL_MAC1 = b"mac1----"` (8
+  bytes) and `MAC = Keyed-BLAKE2s` with a **16-byte output**
+  (`blake2s.Size128`). *Keyed-BLAKE2s, NOT HMAC* (research §7 SMR r1 #3;
+  wireguard-go `cookie.go:CheckMAC1` uses `blake2s.New128` with the key).
+- `mac2 = MAC(key = last_received_cookie, input = msg[0 .. 132])`, or **all
+  zeros** when no cookie has been received (the quiet-tunnel case). S1 always
+  emits zeros (cookie handling is S7).
+- `encrypted_timestamp` is the Noise **payload** of msg1: the 12-byte TAI64N
+  encrypted by snow's `write_message(tai64n, ...)`.
+
+### 4.2 Message 2 — Handshake Response (92 bytes)
+
+```
+offset size field
+  0     1   message_type = 2
+  1     3   reserved_zero  = {0,0,0}
+  4     4   sender_index   (LE u32, responder-chosen)
+  8     4   receiver_index (LE u32, echoes msg1.sender_index)
+ 12    32   unencrypted_ephemeral       ─┐ snow IK msg2 body (write_message,
+ 44    16   encrypted_nothing (0+16 tag) ┘  payload = &[] empty)
+ 60    16   mac1
+ 76    16   mac2
+```
+
+- `mac1 = MAC(HASH(LABEL_MAC1 || initiator.static_public), msg[0 .. 60])`.
+  (Responder's mac1 keys on the **initiator's** static pub — the recipient of
+  msg2.) `mac2` zeros in S1.
+
+### 4.3 TAI64N (12 bytes)
+
+TAI64N label = `(2^62) + unix_seconds` as a big-endian u64 (8 bytes) followed
+by a big-endian u32 nanoseconds (4 bytes) = 12 bytes (whitepaper §5.4.2;
+wireguard-go `tai64n/tai64n.go`, `tai64n.Now()` returned 12 bytes in the
+probe). **Monotonicity invariant (research §9, SMR r1 #1):** kernel WG rejects
+a msg1 whose TAI64N is `<=` the last one it accepted from that peer — so xpf
+MUST emit a strictly increasing TAI64N or it DoSes its own re-handshakes.
+S1 ties the value to the wall clock AND a persisted high-water mark (see §5.4).
+
+### 4.4 Construction / identifier (already correct — do NOT change)
+
+`WG_PROTOCOL_ID_BYTES = b"WireGuard v1 zx2c4 Jason@zx2c4.com"` is already mixed
+as the snow prologue (`wg/mod.rs:82`, `engine.rs:796-801`). The
+LABEL_MAC1 = `b"mac1----"` and LABEL_COOKIE = `b"cookie--"` constants are NEW
+(used only for MAC1; cookie is S7). Confirmed against wireguard-go
+`device/cookie.go` Init().
+
+---
+
+## 5. Concrete design
+
+### 5.1 New module `wg/handshake.rs` (NOT in engine.rs)
+
+engine.rs is WATCH-tier at 1725 LOC; adding framing there risks crossing the
+2000-LOC [REFACTOR] threshold and bloats the most security-sensitive file. All
+new framing lives in a new `wg/handshake.rs` (registered in `wg/mod.rs`). The
+engine gains only thin slow-path entry points that delegate to it.
+
+```rust
+// wg/handshake.rs
+
+pub(crate) const WG_MSG1_LEN: usize = 148;
+pub(crate) const WG_MSG2_LEN: usize = 92;
+const MAC_LEN: usize = 16;
+const LABEL_MAC1: &[u8; 8] = b"mac1----";
+
+// snow body offsets within each message (after the framed prefix).
+const MSG1_PREFIX_LEN: usize = 1 + 3 + 4;       // type+reserved+sender = 8
+const MSG1_NOISE_LEN: usize  = 32 + 48 + 28;    // 108 (e + enc_s + enc_ts)
+const MSG2_PREFIX_LEN: usize = 1 + 3 + 4 + 4;   // type+reserved+sender+receiver = 12
+const MSG2_NOISE_LEN: usize  = 32 + 16;         // 48
+
+/// Compute mac1 = keyed-BLAKE2s-128(HASH("mac1----"||peer_static_pub),
+/// msg[0..mac1_offset]). `peer_static_pub` is the static public key of the
+/// message RECIPIENT (responder for msg1, initiator for msg2).
+fn compute_mac1(peer_static_pub: &[u8; 32], msg_up_to_mac1: &[u8]) -> [u8; 16];
+
+/// Build a WG type-1 initiation around a snow msg1 body.
+/// `noise_body` is exactly what snow `write_message(tai64n, ..)` produced
+/// (must be MSG1_NOISE_LEN bytes). `sender_index` is initiator-chosen.
+/// `responder_static_pub` keys mac1. mac2 is zeros (S1).
+pub(crate) fn build_initiation(
+    out: &mut [u8],                 // >= WG_MSG1_LEN
+    sender_index: u32,
+    noise_body: &[u8],              // MSG1_NOISE_LEN
+    responder_static_pub: &[u8; 32],
+) -> Result<usize, FramingError>;
+
+/// Parse a WG type-1 initiation. Verifies length, type byte, and (when
+/// `our_static_pub` is Some) mac1 against HASH("mac1----"||our_pub). Returns
+/// the sender_index and a borrow of the noise body to feed snow read_message.
+pub(crate) fn parse_initiation<'a>(
+    msg: &'a [u8],
+    our_static_pub: &[u8; 32],
+) -> Result<ParsedInitiation<'a>, FramingError>;
+
+pub(crate) struct ParsedInitiation<'a> {
+    pub sender_index: u32,
+    pub noise_body: &'a [u8],       // 108 bytes -> snow read_message
+}
+
+// Symmetric build_response / parse_response for type-2 (carry receiver_index).
+```
+
+`FramingError` is a small `#[derive(Debug,Clone,PartialEq,Eq)]` enum:
+`TooShort`, `BadType`, `Mac1Mismatch`, `BadNoiseLen`. Parse returns
+`Mac1Mismatch` BEFORE handing bytes to snow (cheap reject, matches kernel WG
+which drops on mac1 before crypto).
+
+**mac2 on parse:** S1 does not verify mac2 (we never send cookies, so a
+compliant peer sends mac2 = zeros; verifying it would require cookie state).
+We parse-skip it. Documented; S7 adds verification.
+
+### 5.2 New `wg/tai64n.rs`
+
+```rust
+/// Monotonic TAI64N clock. 12 bytes: BE u64 (2^62 + unix_secs) || BE u32 nanos.
+pub(crate) struct Tai64nClock { last: Mutex<[u8; 12]> }
+
+impl Tai64nClock {
+    /// Returns a TAI64N strictly greater than every prior return value
+    /// from this clock (monotonic). Derived from `SystemTime::now()` but
+    /// clamped up to `last + 1ns` if the wall clock went backwards.
+    pub(crate) fn now(&self) -> [u8; 12];
+    /// Seed from a persisted high-water mark (control-plane restart).
+    pub(crate) fn seed_high_water(&self, hw: [u8; 12]);
+    pub(crate) fn high_water(&self) -> [u8; 12];
+}
+```
+
+Monotonicity is enforced by byte-comparing the freshly-computed TAI64N against
+`last` (TAI64N big-endian layout is monotonic under lexicographic byte
+compare) and bumping the nanos field if not strictly greater. Persistence
+(write `high_water()` to disk / HA-replicate) is the **control plane's**
+responsibility; S1 provides `seed_high_water`/`high_water` and wires an
+in-memory clock into the engine. **Cross-restart persistence to a file is
+deferred to S5/S6 control-plane work** — S1 documents the hook and proves
+monotonicity within a process; the harness does not restart xpf. (Flagged as
+an open question for review: is in-process monotonicity + a documented persist
+hook sufficient for S1, or must S1 land the disk persist? The research plan
+§9 ties persistence to S2; I argue the disk write belongs with the config
+surface in S6 since there is no daemon integration in S1.)
+
+### 5.3 Engine slow-path entry points (thin, in engine.rs — small delta)
+
+The engine already holds the local private key and the snow builders. Add four
+slow-path methods that compose snow + handshake.rs + the TAI64N clock. These
+run on the **control/coordinator thread only** (AGY r1 #2 boundary — never the
+poll worker; the engine's hot encap/decap never build a HandshakeState):
+
+```rust
+impl WgEngine {
+    /// Full initiator step: build snow msg1 with a TAI64N payload, frame it
+    /// as a WG type-1 with mac1 over the peer pubkey. Returns the wire bytes
+    /// + the in-progress HandshakeState (caller drives msg2 next) + the
+    /// locally-chosen sender_index.
+    pub(crate) fn create_initiation(&self, peer_pubkey: &[u8;32], out: &mut [u8])
+        -> Result<InitiationBuilt, HandshakeError>;
+
+    /// Consume a peer's type-2 response against the pending HandshakeState,
+    /// derive the StatelessTransportState. Verifies framing + receiver_index.
+    pub(crate) fn consume_response(&self, hs: HandshakeState, msg: &[u8])
+        -> Result<WgSession-ish, HandshakeError>;
+
+    /// Responder: parse a peer type-1, run snow read_message (recovering the
+    /// peer's TAI64N + static pub), identify the peer, build a framed type-2.
+    pub(crate) fn consume_initiation_create_response(&self, msg: &[u8], out: &mut [u8])
+        -> Result<ResponseBuilt, HandshakeError>;
+}
+```
+
+Exact return shapes (whether to expose `HandshakeState` across the boundary or
+keep it engine-internal) are an implementation detail resolved in Step 5; the
+existing tests already pass `HandshakeState` around, so the boundary is proven.
+Sender/receiver index allocation reuses the existing demux discipline
+(`install_session` already enforces global `local_index` uniqueness).
+
+### 5.4 Interop harness — `userspace-dp/tests/wg_interop/` + Go reference
+
+**Architecture (decided after probing wireguard-go's API):**
+
+1. A **Rust integration test** (`userspace-dp/tests/wg_interop.rs`) that builds
+   a `WgEngine` and exercises `create_initiation` / `consume_response` /
+   `consume_initiation_create_response`, exchanging raw bytes with the Go
+   reference over a **loopback UDP socket**.
+2. The **independent reference** is a small Go program
+   (`test/wg-interop-peer/`, its own `go.mod` pinning
+   `golang.zx2c4.com/wireguard`) that stands up a real wireguard-go `Device`
+   with a `tun/netstack` TUN (no root) + `conn.NewDefaultBind` UDP socket,
+   configured via `IpcSet` (private key, peer pubkey, allowed-ips, endpoint =
+   the Rust test's UDP socket). The Rust test spawns this peer as a subprocess,
+   reads its chosen UDP port + public key from stdout, and drives the exchange.
+
+   - **Direction A (xpf initiator → wireguard-go responder):** Rust
+     `create_initiation` → send UDP datagram to the Go peer → the Go Device's
+     real receive path runs `CheckMAC1` + `ConsumeMessageInitiation` (verifies
+     mac1 against xpf's framing, decrypts the TAI64N, checks monotonicity) →
+     Go emits a real type-2 → Rust `consume_response` derives the transport
+     session. **Assert:** Go accepted msg1 (no drop — observable because it
+     sends a msg2; we parse the type-2 we receive) AND xpf derived a session
+     whose transport key matches (proven by a subsequent transport-record
+     round-trip below).
+   - **Direction B (wireguard-go initiator → xpf responder):** configure the Go
+     peer with `PersistentKeepalive`/an endpoint so it initiates; Rust receives
+     the UDP datagram, `consume_initiation_create_response` parses + replies;
+     Go consumes the type-2 and the handshake completes on the Go side.
+     **Assert:** xpf parsed a real wireguard-go msg1 (mac1 verified, TAI64N
+     decrypted) and emitted a msg2 that wireguard-go accepted.
+   - **Key-confirmation / matching transport keys:** after each direction, send
+     ONE WireGuard transport DATA record (type 4) carrying a tiny inner IP
+     packet from xpf's `try_encap` and assert the Go peer decrypts it
+     (delivers to its netstack TUN), and vice-versa. This is the
+     "derives matching transport keys" proof the task demands. *(This is a
+     transport record, not the AF_XDP datapath — it uses the existing
+     spec-compliant `framing.rs` over the loopback UDP socket, NOT
+     `poll_descriptor.rs`. So it stays within S1's "no datapath change"
+     boundary while still proving end-to-end key agreement.)*
+
+3. **Self-contained build:** the Go reference is built by the test via
+   `go build` (module cache already populated; documented `go.mod`). If the
+   Go toolchain or network is unavailable, the interop test is gated behind a
+   `WG_INTEROP=1` env / a `#[ignore]`-with-reason so `cargo test` stays green
+   on a bare box, BUT the gate is **on by default in the dev/CI path** and the
+   PR's acceptance requires it green. (Open question for review: ignore-by-
+   default vs hard-required — I lean "required, with a clear skip message if
+   `go` is absent, and run it explicitly in the gate.")
+
+### 5.5 Files touched
+
+- NEW `userspace-dp/src/afxdp/wg/handshake.rs` (~250 LOC + unit tests)
+- NEW `userspace-dp/src/afxdp/wg/tai64n.rs` (~120 LOC + unit tests)
+- EDIT `userspace-dp/src/afxdp/wg/mod.rs` (register modules, add consts
+  LABEL_MAC1; ~10 LOC)
+- EDIT `userspace-dp/src/afxdp/wg/engine.rs` (4 thin slow-path methods +
+  TAI64N clock field; target delta < ~150 LOC to stay well under 2000)
+- EDIT `userspace-dp/Cargo.toml` (promote `blake2` to a direct dep at the
+  already-locked 0.10.6)
+- NEW `userspace-dp/tests/wg_interop.rs` (Rust harness driver)
+- NEW `test/wg-interop-peer/{go.mod,go.sum,main.go}` (wireguard-go reference)
+- EDIT `docs/wireguard-interop.md` (NEW: harness recipe + wire-compliance
+  status) and flip the relevant OUT items in `docs/pr/wireguard-clean/plan.md`
+  to DONE for handshake framing + TAI64N.
+
+---
+
+## 6. Public API preservation
+
+No existing public (`pub(crate)`) signature changes. `build_initiator_handshake`
+/ `build_responder_handshake` / `try_encap` / `try_decap` / `install_session` /
+`reconcile_peers` keep their exact signatures — the new `create_initiation`
+etc. are additive. The 30+ existing engine/session/framing tests must still
+pass unchanged.
+
+---
+
+## 7. Hidden invariants the change must preserve
+
+- **Noise transcript unchanged.** The prologue + pattern + zero-PSK are
+  untouched; only the payload of msg1 (now TAI64N instead of `&[]`) and the
+  outer framing change. snow still computes the same `h`/`ck` chain.
+- **Slow-path-only crypto.** Handshake construction + MAC1 keyed-BLAKE2s run on
+  the control thread; the AF_XDP poll worker never calls the new methods
+  (AGY r1 #2). No new hot-path allocation.
+- **Index uniqueness.** sender/receiver indices flow into the existing
+  `install_session` global-uniqueness check; no new demux race.
+- **TAI64N monotonicity.** Strictly increasing per clock, enforced under a
+  mutex; never regresses within a process. Cross-restart persistence hook
+  exposed but disk-write deferred (S5/S6) — documented.
+- **mac1 keys on the RECIPIENT's static pub** (responder for msg1, initiator
+  for msg2) — the most common framing bug; the harness against wireguard-go is
+  what catches a swapped key.
+- **No mac2/cookie state** in S1 — emit zeros, skip-verify on parse; a peer
+  under load that sends a type-3 cookie reply is out of scope (S7) and must not
+  wedge — but S1's harness runs a quiet tunnel, so no cookie is sent.
+- **zeroize discipline** preserved for any new key-material copies (MAC1 key is
+  derived from a public key + public label — not secret — so no zeroize
+  needed there; the TAI64N is not secret either).
+
+---
+
+## 8. Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression (existing engine) | **LOW** | Additive; existing tests unchanged; Noise transcript untouched. |
+| Lifetime / borrow-checker | **LOW** | Framing is byte-shuffling over caller slices; `ParsedInitiation` borrows the input like `framing.rs::ParsedDataHeader` already does. |
+| Wire-correctness (byte-level) | **HIGH** | The whole point. Mitigated by the wireguard-go harness (independent reference) — a wrong byte ⇒ Go drops ⇒ test fails. This is the gate. |
+| TAI64N monotonicity / self-DoS | **MED** | Mitigated by mutex-guarded strictly-increasing clock + harness re-handshake. Cross-restart persistence deferred (documented). |
+| Architectural mismatch (#961/#946-P2 dead-end) | **LOW** | Design matches snow's proven `write_message(payload)` boundary; not a speculative rearchitecture. The research plan already validated Path A 3-of-3. |
+| Harness flakiness (subprocess/UDP) | **MED** | Loopback UDP + spawned Go peer can race on startup; mitigated by reading the peer's ready-line from stdout before driving, bounded timeouts, and the 5×flake gate. |
+
+---
+
+## 9. Test plan
+
+- `cargo build` clean (release).
+- `cargo test --release` full suite — all existing + new unit tests
+  (handshake framing round-trip, mac1 key-on-recipient, TAI64N monotonic,
+  TooShort/BadType/Mac1Mismatch arms).
+- **Interop harness** `cargo test --release --test wg_interop` (both
+  directions vs wireguard-go) — **the success criterion**.
+- **5× flake** on the two interop tests (`wg_interop_xpf_initiator` and
+  `wg_interop_xpf_responder`) — must be 5/5.
+- Go suite `go test ./...` (30 packages) — the new `test/wg-interop-peer/` is
+  its own module so it does not pollute the main Go build; confirm the main
+  suite is unaffected.
+- `make audit-check` — confirm engine.rs stays < 2000 LOC and the new files
+  are registered; regen `docs/refactoring-audit-current.txt` if a wg file
+  crosses 1500.
+- **NO cluster smoke for S1.** This is handshake/wire-protocol + an
+  integration test, **not a datapath change** (no encap/decap on the AF_XDP
+  hot path — that is S3). The CoS/iperf3 matrix exercises the AF_XDP fast path,
+  which S1 does not touch. Stated explicitly per the task. The cluster smoke
+  belongs to research-plan S3 when the engine goes on the hot path.
+
+---
+
+## 10. Out of scope (explicit, deferred to later #1703 steps)
+
+- AF_XDP hot-path encap/decap wiring + runtime `TunnelEndpoint` extension (S3).
+- Non-zero PSK config plumbing (S4).
+- persistent-keepalive emit, REKEY/REJECT-AFTER-TIME timers, endpoint
+  roaming/DDNS, empty-record (keepalive/key-confirm) acceptance (S5).
+- TAI64N disk persistence + HA replication (S5/S6 control plane).
+- Junos config grammar + compiler + snapshot population + base64↔hex (S6).
+- Cookie-reply (type-3) generation/verification, IPv6 outer encap, DSCP/ECN
+  (S7). mac2 verification on parse (S7).
+- HA RG WG-session migration (S8).
+- Transport-flow over the AF_XDP worker (Test 1b/2b) — S1 proves a single
+  transport record over the harness UDP socket only, to confirm key agreement.
+
+---
+
+## 11. Open questions for adversarial review (each invitable to PLAN-KILL)
+
+1. **snow payload == WG encrypted_timestamp, byte-exact?** I claim snow IK
+   msg1 `write_message(tai64n_12b, out)` produces `e[32] || enc_s[48] ||
+   enc_ts[28]` identical to WG msg1 inner. Is there any snow-side framing
+   (length prefix, extra MixHash of the payload at a different point) that
+   diverges from kernel WG's `encrypt(timestamp)` so the harms only surface as
+   a tag-verify failure on the Go side? (Probe says lengths match; demand the
+   harness prove the AEAD verifies, not just the length.)
+2. **mac1 = keyed-BLAKE2s-128, not HMAC.** Confirm against wireguard-go
+   `cookie.go` that it's `blake2s.New128(key)` keyed (not HMAC-BLAKE2s), key =
+   `BLAKE2s-256(LABEL_MAC1 || recipient_static_pub)` (32-byte hash used as the
+   16-output keyed-BLAKE2s key). Wrong hash width or HMAC vs keyed ⇒ silent
+   drop. Is my "HASH = BLAKE2s-256, MAC = keyed-BLAKE2s-128" reading correct?
+3. **Is in-process TAI64N monotonicity + a deferred persist hook acceptable
+   for S1**, or must S1 land disk persistence (research §9 ties it to S2)? I
+   argue persistence belongs with daemon/config integration (S6) since S1 has
+   no daemon wiring. Kill the deferral if a reviewer shows S1's harness can
+   regress the clock.
+4. **Is the wireguard-go-as-library harness a sufficient independent
+   reference**, or does the task's intent require the kernel `wg` /
+   `wg-quick` path (apt-install in the env)? wireguard-go is byte-identical to
+   kernel WG (same author, same protocol) and needs no root via `netstack`;
+   kernel `wg` needs root + a netns + module load. I claim wireguard-go is the
+   stronger, more portable independent reference. Refute if the loopback-UDP +
+   netstack peer is not a faithful stand-in.
+5. **Index allocation / receiver_index echo.** msg2 must echo msg1's
+   sender_index as its receiver_index, and the responder's own sender_index
+   must be installed for inbound demux. Does the existing `install_session`
+   uniqueness discipline compose cleanly with framing-chosen indices, or is
+   there a race when the harness drives both roles in one process?
+6. **Harness `go test` / cargo boundary.** Is spawning a Go subprocess from a
+   Rust integration test the right seam, or should the harness be a Go test
+   that shells out to a tiny xpf framing CLI? I chose Rust-drives-Go because
+   the security-critical bytes are xpf's and must be asserted in xpf's test;
+   the reference is the dependency. Is the subprocess/UDP harness too flaky to
+   be a merge gate (the 5×flake gate is meant to answer this)?

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
@@ -1,12 +1,17 @@
 # #1709 — WireGuard S1: wire-protocol compliance (TAI64N + handshake framing) validated by spec known-answer vectors (live kernel-WireGuard interop = S2)
 
-Status: **DRAFT v2 — pending adversarial plan review** (Codex + AGY +
-Claude-SMR). v2 changes from v1: dropped the wireguard-go-as-library interop
-harness (user rejected a Go reference for a Rust dataplane); the independent
-reference peer is now the **Linux kernel WireGuard module on a real incus VM**
-(never a container); S1's in-tree gate is **spec known-answer vectors**, and
-the recommended S1/S2 boundary defers the live kernel-wg-VM interop test to S2
-(plan-review to ratify (a) vs (b)).
+Status: **PLAN-READY v3** — round-1 plan review complete: Codex
+(task-mpt6qx4i-i04py6) PLAN-NEEDS-MAJOR, AGY (adversarial-review-mpt6r70o-ebe5a4)
+PLAN-NEEDS-MAJOR, Claude-SMR PLAN-NEEDS-MINOR. v3 addresses ALL major findings
+(see §v3-convergence). v2→v3: TAI64N epoch offset corrected to
+`0x400000000000000a` + nanos whitening (AGY-2); two-phase index reservation to
+close the blackhole race (AGY-1/Codex-4); `local_public_key` added for inbound
+MAC1 (Codex-2); TAI64N persistence story reconciled (Codex-3); S1 gate
+strengthened to require FULL byte-exact msg1/msg2 KATs (Codex-1/SMR-2);
+S1/S2 boundary ratified Option (b+). v2→v1: dropped wireguard-go; reference =
+kernel WireGuard on a real VM (never a container); spec-KAT in-tree gate.
+
+> Pending a confirming round-2 from Codex + AGY on v3 before code lands.
 
 Issue: #1709 (part of #1703 umbrella). Branch:
 `refactor/1709-wireguard-s1-wire-protocol-compliance`.
@@ -42,9 +47,13 @@ deliverable: "wire-protocol compliance — TAI64N + handshake framing —
 validated vs a WireGuard reference"; the reference is now kernel WireGuard,
 and the live interop test is recommended to land in S2, see §5.4/Q7):
 
-1. **TAI64N timestamp** — a monotonic 12-byte TAI64N clock, carried as the
-   Noise payload of WG message 1 (encrypted_timestamp), persisted so it never
-   regresses across control-plane restart.
+1. **TAI64N timestamp** — an **in-process strictly-monotonic** 12-byte TAI64N
+   clock (epoch base `0x400000000000000a`, whitened nanos — §4.3), carried as
+   the Noise payload of WG message 1 (encrypted_timestamp). S1 guarantees
+   monotonicity *within a process*; cross-restart disk persistence is deferred
+   to the control-plane integration (S6) and exposed here only as a
+   `seed_high_water`/`high_water` hook — S1 has no daemon to persist from
+   (Codex-3 inconsistency fixed in v3; §4.3, §5.2).
 2. **WG handshake framing** (message types 1 & 2) on **build + parse** paths:
    type byte, `reserved_zero[3]`, sender/receiver index, MAC1, MAC2 (zeros
    until a cookie is observed), wrapping snow's Noise body.
@@ -206,15 +215,39 @@ offset size field
   (Responder's mac1 keys on the **initiator's** static pub — the recipient of
   msg2.) `mac2` zeros in S1.
 
-### 4.3 TAI64N (12 bytes)
+### 4.3 TAI64N (12 bytes) — CORRECTED in v3 per AGY-2
 
-TAI64N label = `(2^62) + unix_seconds` as a big-endian u64 (8 bytes) followed
-by a big-endian u32 nanoseconds (4 bytes) = 12 bytes (whitepaper §5.4.2;
-wireguard-go `tai64n/tai64n.go`, `tai64n.Now()` returned 12 bytes in the
-probe). **Monotonicity invariant (research §9, SMR r1 #1):** kernel WG rejects
-a msg1 whose TAI64N is `<=` the last one it accepted from that peer — so xpf
-MUST emit a strictly increasing TAI64N or it DoSes its own re-handshakes.
-S1 ties the value to the wall clock AND a persisted high-water mark (see §5.4).
+TAI64N label = **`0x400000000000000a + unix_seconds`** (= `2^62 + 10 +
+unix_seconds`) as a big-endian u64 (8 bytes), followed by a big-endian u32
+nanoseconds (4 bytes) = 12 bytes. **The `+ 10` is the leap-second offset (TAI
+was 10 s ahead of UTC at the 1970 epoch) and is MANDATORY** — kernel WG uses
+`ktime_get_real_seconds() + 0x400000000000000aULL` and wireguard-go
+`tai64n/tai64n.go` uses `base = uint64(0x400000000000000a)`. v1/v2's plain
+`2^62` was wrong by 10 s (AGY plan-review finding 2); a strict peer with a
+narrow handshake-replay window could drop it as stale.
+
+**Nanos whitening (NEW in v3, not flagged by reviewers — found while verifying
+AGY-2 against `tai64n.go`):** the reference masks the low 24 bits of the nanos
+field: `nano = uint32(t.Nanosecond()) &^ (0x1000000 - 1)` (i.e.
+`nano & 0xFF000000`). This whitens the sub-~16 ms component to avoid leaking a
+fine-grained clock. xpf MUST apply the same `&^ 0x00FFFFFF` mask to be
+byte-identical to the reference and avoid the timing side-channel. (A peer does
+not *require* it — it only byte-compares — but matching the reference is the
+S1 contract.)
+
+**Carry / monotonicity spec (NEW in v3 per Codex-3):** the monotonic clock
+returns `max(now_tai64n, last + 1_whitened_tick)`. Because nanos are whitened
+to a `0x1000000`-ns (~16.7 ms) granularity, the monotonic "+1" increment is one
+whitened tick = `0x1000000` ns; on nanos overflow past `0xFF000000` the carry
+rolls into the seconds field (`secs += 1; nanos = 0`). Stored as the 12-byte
+big-endian value so lexicographic byte-compare == numeric compare (matches
+`tai64n.go`'s `bytes.Compare`).
+
+**Monotonicity invariant (research §9, SMR r1 #1):** kernel WG rejects a msg1
+whose TAI64N is `<=` the last one it accepted from that peer — so xpf MUST emit
+a strictly increasing TAI64N or it DoSes its own re-handshakes. S1 enforces
+in-process strict monotonicity via a `Mutex<[u8;12]>`; cross-restart disk
+persistence is deferred (see §5.2 — reconciled in v3 per Codex-3).
 
 ### 4.4 Construction / identifier (already correct — do NOT change)
 
@@ -293,34 +326,56 @@ We parse-skip it. Documented; S7 adds verification.
 ### 5.2 New `wg/tai64n.rs`
 
 ```rust
-/// Monotonic TAI64N clock. 12 bytes: BE u64 (2^62 + unix_secs) || BE u32 nanos.
+/// In-process strictly-monotonic TAI64N clock. 12 bytes:
+/// BE u64 (0x400000000000000a + unix_secs) || BE u32 (nanos &^ 0x00FFFFFF).
 pub(crate) struct Tai64nClock { last: Mutex<[u8; 12]> }
 
 impl Tai64nClock {
     /// Returns a TAI64N strictly greater than every prior return value
-    /// from this clock (monotonic). Derived from `SystemTime::now()` but
-    /// clamped up to `last + 1ns` if the wall clock went backwards.
+    /// from this clock. Computes the whitened TAI64N from
+    /// `SystemTime::now()`; if that is `<= last`, returns
+    /// `last + one whitened tick` (carry into seconds on nanos overflow
+    /// past 0xFF000000). Big-endian layout ⇒ byte-compare == numeric.
     pub(crate) fn now(&self) -> [u8; 12];
-    /// Seed from a persisted high-water mark (control-plane restart).
+    /// Seed from a persisted high-water mark (control-plane restart, S6).
     pub(crate) fn seed_high_water(&self, hw: [u8; 12]);
     pub(crate) fn high_water(&self) -> [u8; 12];
 }
 ```
 
-Monotonicity is enforced by byte-comparing the freshly-computed TAI64N against
-`last` (TAI64N big-endian layout is monotonic under lexicographic byte
-compare) and bumping the nanos field if not strictly greater. Persistence
-(write `high_water()` to disk / HA-replicate) is the **control plane's**
-responsibility; S1 provides `seed_high_water`/`high_water` and wires an
-in-memory clock into the engine. **Cross-restart persistence to a file is
-deferred to S5/S6 control-plane work** — S1 documents the hook and proves
-monotonicity within a process; the harness does not restart xpf. (Flagged as
-an open question for review: is in-process monotonicity + a documented persist
-hook sufficient for S1, or must S1 land the disk persist? The research plan
-§9 ties persistence to S2; I argue the disk write belongs with the config
-surface in S6 since there is no daemon integration in S1.)
+Monotonicity is enforced by byte-comparing the freshly-computed (whitened)
+TAI64N against `last`; on `<=`, advance by one whitened tick (`0x1000000` ns),
+carrying into the seconds field on overflow (§4.3 carry spec). The big-endian
+layout makes lexicographic byte-compare equal numeric compare (matches
+`tai64n.go`'s `bytes.Compare`).
+
+**Persistence — reconciled in v3 (Codex-3):** S1 guarantees only *in-process*
+monotonicity. The `seed_high_water`/`high_water` hooks exist so a future
+control-plane (S6) can persist + HA-replicate the high-water mark, but **S1
+does NOT write to disk** — and that is correct, not a gap, because **S1 has no
+daemon**: an unintegrated engine with no reloaded state cannot regress a clock
+it never reloads (SMR-4). The earlier §1 "persisted so it never regresses"
+wording was inconsistent with this deferral and is fixed in v3. AGY's
+operational note (an NTP step-back or rapid restart of an *integrated* xpf
+could silently wedge a peer that still holds the old high-water mark) is real
+and is captured as an **S2 testing runbook item**: when restarting xpf during
+S2 VM interop, flush the peer's WG state (`ip link del wgref; ip link add
+wgref type wireguard`) to clear its in-memory per-peer TAI64N high-water. The
+durable fix (disk persist) lands in S6.
 
 ### 5.3 Engine slow-path entry points (thin, in engine.rs — small delta)
+
+**Local public key (NEW in v3, Codex-2 — REQUIRED).** Parsing an inbound
+msg1/msg2 MAC1 requires xpf's OWN static public key (the recipient key for
+inbound messages). Today `WgEngineConfig`/`WgEngine` store only
+`local_private_key` (`engine.rs:173`, `:256`). v3 adds a `local_public_key:
+[u8; 32]` derived ONCE at `WgEngine::new` from the private key
+(X25519 base-point mult via `curve25519-dalek` — already in `Cargo.lock` at
+4.1.3 — or snow's `Builder::generate_keypair` is NOT it; use the dalek
+`x25519(secret, basepoint)` clamp). Storing it avoids re-deriving per parse and
+prevents the "private-key-as-public" / swapped-key class of bug under
+implementation pressure. A unit test asserts `local_public_key` equals snow's
+notion of our static pub for the same private key.
 
 The engine already holds the local private key and the snow builders. Add four
 slow-path methods that compose snow + handshake.rs + the TAI64N clock. These
@@ -329,30 +384,55 @@ poll worker; the engine's hot encap/decap never build a HandshakeState):
 
 ```rust
 impl WgEngine {
-    /// Full initiator step: build snow msg1 with a TAI64N payload, frame it
-    /// as a WG type-1 with mac1 over the peer pubkey. Returns the wire bytes
-    /// + the in-progress HandshakeState (caller drives msg2 next) + the
-    /// locally-chosen sender_index.
+    /// Full initiator step: RESERVE a fresh local sender_index in the demux
+    /// map FIRST (two-phase, see below), then build snow msg1 with a TAI64N
+    /// payload, frame it as a WG type-1 with mac1 over the peer pubkey.
     pub(crate) fn create_initiation(&self, peer_pubkey: &[u8;32], out: &mut [u8])
         -> Result<InitiationBuilt, HandshakeError>;
 
     /// Consume a peer's type-2 response against the pending HandshakeState,
-    /// derive the StatelessTransportState. Verifies framing + receiver_index.
-    pub(crate) fn consume_response(&self, hs: HandshakeState, msg: &[u8])
-        -> Result<WgSession-ish, HandshakeError>;
+    /// derive the StatelessTransportState, and PROMOTE the reserved index to
+    /// a live session. Verifies framing + that receiver_index == our reserved
+    /// sender_index.
+    pub(crate) fn consume_response(&self, msg: &[u8])
+        -> Result<DerivedSession, HandshakeError>;
 
-    /// Responder: parse a peer type-1, run snow read_message (recovering the
-    /// peer's TAI64N + static pub), identify the peer, build a framed type-2.
+    /// Responder: parse a peer type-1 (mac1 over OUR local_public_key), run
+    /// snow read_message (recovering the peer's TAI64N + static pub), identify
+    /// the peer, RESERVE our responder sender_index, build a framed type-2
+    /// whose receiver_index echoes msg1.sender_index.
     pub(crate) fn consume_initiation_create_response(&self, msg: &[u8], out: &mut [u8])
         -> Result<ResponseBuilt, HandshakeError>;
 }
 ```
 
-Exact return shapes (whether to expose `HandshakeState` across the boundary or
-keep it engine-internal) are an implementation detail resolved in Step 5; the
-existing tests already pass `HandshakeState` around, so the boundary is proven.
-Sender/receiver index allocation reuses the existing demux discipline
-(`install_session` already enforces global `local_index` uniqueness).
+**Two-phase index reservation (NEW in v3 — AGY-1 / Codex-4, the blackhole
+race).** The v2 plan's "allocate then `install_session`" is unsafe: a responder
+that transmits msg2 carrying sender_index `R` and only *afterward* calls
+`install_session` can lose the `R` slot to a concurrent handshake, fail the
+install with `LocalIndexCollision`, and then **silently blackhole** the
+initiator's data records (they demux to `UnknownSession`). The fix: a
+**reservation** invariant — the local index MUST be inserted into a
+reservation set / `sessions_by_local_index` (as a pending placeholder) **before
+the handshake message carrying it is written to `out`/sent on the wire**. On
+reservation collision, regenerate the index and retry BEFORE transmission.
+`consume_response` / `consume_initiation_create_response` then *promote* the
+reserved index to a live `WgSession` (never a fresh insert that could collide).
+This means:
+  - `install_session`'s existing global-uniqueness check (`engine.rs:437-491`)
+    is necessary but NOT sufficient — it guards completed installs, not pending
+    reservations. v3 adds a pending-index reservation layer in front of it.
+  - The reservation must be released on handshake failure/timeout so a dropped
+    handshake does not leak the index forever (mirrors the
+    `reconcile_peers` drain discipline for dropped sessions).
+  - Tests: `reserve_before_send_then_promote`, and a concurrent-reservation
+    test proving two in-flight handshakes never both claim the same index and
+    no completed handshake is left un-demuxable.
+
+Exact return shapes keep `HandshakeState` engine-internal where possible
+(SMR-6): the engine holds the pending `HandshakeState` keyed by the reserved
+sender_index, so the four methods trade only `[u8;32]` / byte slices, not snow
+types. Resolved concretely in Step 5.
 
 ### 5.4 Verification: spec KAT vectors (in-tree gate) + deferred live harness
 
@@ -403,11 +483,14 @@ SMR-R1.)
   - **`parse_initiation_accepts_nonzero_mac2` (SMR-5, REQUIRED)** — parse must
     accept a msg with mac2 != 0 (a peer that holds our cookie sets it); mac2 is
     skip-verified in S1, NOT treated as malformed. Cookie generation is S7.
-  - `tai64n_encoding_kat` — assert the 12-byte layout (BE u64 `2^62+secs` ||
-    BE u32 nanos) for a fixed `(secs, nanos)`; `tai64n_strictly_monotonic`
-    (N calls strictly increase by byte-compare even with a frozen/backwards
-    clock); **`tai64n_concurrent_monotonic` (SMR-4)** (N threads calling
-    `now()` yield N strictly-ordered distinct values).
+  - `tai64n_encoding_kat` — assert the 12-byte layout (BE u64
+    `0x400000000000000a + secs` || BE u32 `nanos &^ 0x00FFFFFF`) for a fixed
+    `(secs, nanos)`, including the **`+10` epoch offset** (AGY-2) and the
+    **nanos whitening** (v3); `tai64n_strictly_monotonic` (N calls strictly
+    increase by byte-compare even with a frozen/backwards clock, with the
+    one-whitened-tick carry into seconds on nanos overflow — §4.3);
+    **`tai64n_concurrent_monotonic` (SMR-4)** (N threads calling `now()` yield
+    N strictly-ordered distinct values).
   - `framing_roundtrip` — `build_initiation` then `parse_initiation` recovers
     the sender_index + noise body; `parse` rejects TooShort / BadType /
     Mac1Mismatch.
@@ -466,17 +549,65 @@ options:
   and avoids bolting a VM-lifecycle + cross-VM-network harness onto the
   crypto-framing PR.
 
-**My recommendation flips to (b)** given the user's correction: the live test
-now needs a real VM peer + cross-VM UDP reachability, which is meaningfully
-more harness than a loopback socket and is better built once, in S2, next to
-the datapath UDP plumbing. S1's falsifiability rests on the spec KAT vectors
-(§5.4a) — which pin every framing/MAC1/TAI64N byte to the canonical
-construction — plus the engine self-handshake-with-framing regression. The
-independent-peer proof is S2's opening gate. **Whatever the verdict, the
-reference peer is kernel WireGuard on a real VM, never a container.**
-**Plan-review must return an explicit (a) vs (b) verdict.**
+**RATIFIED in v3 — Option (b+), all three reviewers concur.** Codex
+(PLAN-NEEDS-MAJOR), AGY (PLAN-NEEDS-MAJOR), and Claude-SMR all recommend
+**Option (b)** for development isolation — the live test now needs a real VM
+peer + cross-VM SR-IOV UDP reachability, meaningfully more harness than a
+loopback socket and better built once in S2 next to the datapath UDP plumbing
+— **but with a strict governance condition (the "+"):**
+
+> **The S1 framing+TAI64N code MUST NOT be claimed as "interop-capable" in any
+> operator doc / CLAUDE.md feature line, and S1's branch should land such that
+> the independent-peer proof is enforced before any production interop claim.**
+> Codex: "If full byte-exact msg1/msg2 KATs are not added, choose Option (a)."
+> AGY: "do not present S1 in isolation as interop; the live VM test is the
+> absolute gate." SMR-3: same honesty condition.
+
+So S1's gate is **strengthened**: the §5.4a suite is NOT merely
+construction/MAC/layout KATs + a self-handshake — it MUST include the
+**full deterministic byte-exact msg1 AND msg2 KATs** (fixed static + fixed
+ephemeral + fixed TAI64N → exact 148/92-byte wire image + mac1), which is the
+only in-tree test that catches a symmetric build/parse bug (e.g. wrong index
+endianness) that the self-handshake would pass. With those full-message KATs,
+(b+) is a legitimate S1 crypto gate; the live kernel-wg-on-VM test (S2) is the
+independent-peer confirmation. **Reference peer is kernel WireGuard on a real
+VM, never a container.**
 
 Per the task: S1 needs **no CoS/iperf cluster smoke** (no datapath change).
+
+### 5.4c S2 live-interop peer-VM spec (NOT built in S1 — recorded for S2)
+
+The user pinned the S2 reference-peer wiring; recorded here so the S2 plan
+inherits it. The kernel-wg peer is a Debian-13 incus **VM** on the **same LAN
+segment** as `loss:cluster-userspace-host`, mirroring its SR-IOV device so xpf
+reaches it identically:
+
+```
+incus launch images:debian/13 wg-kpeer --vm
+incus config device add wg-kpeer eth0 nic nictype=sriov parent=mlx1 vlan=3667
+# static LAN config inside the VM:
+#   IPv4 10.0.61.103/24      (next free; .102 = cluster-userspace-host, .1 = xpf reth1 VIP)
+#   IPv6 2001:559:8585:ef00::103/64
+#   default route via 10.0.61.1
+# then kernel wg (VM ⇒ real kernel, module loads):
+ip link add wgref type wireguard
+wg set wgref private-key <ref.priv> listen-port <P> \
+   peer <xpf.pub> allowed-ips 0.0.0.0/0 endpoint 10.0.61.1:<Q>
+ip addr add <wg-overlay>/24 dev wgref; ip link set wgref up
+```
+
+Direction A: xpf initiates to `10.0.61.103:<P>`. Direction B: kernel wg
+initiates (persistent-keepalive 1) to xpf's WG UDP endpoint at the LAN VIP.
+
+**SR-IOV VF availability constraint (verified, must re-check at S2 provision
+time):** `mlx1` already backs `cluster-userspace-host` (VF id 2) and
+`cluster-lan-host` (VF id 3); the cluster also consumes mlx0/mlx1 VFs for the
+fw0/fw1 dataplane. Mellanox PFs typically expose ≥8 VFs so a free VF (id ≥4) is
+expected, but the host `sriov_numvfs` was not enumerable from the worktree
+shell. **S2 must verify a free VF on `mlx1` exists before launching `wg-kpeer`;
+if none is free, document the constraint and either bump `sriov_numvfs` or
+reuse an existing spare real VM (`bpfrx-fw`) attached to the same VLAN-3667
+segment.**
 
 ### 5.5 Files touched
 
@@ -485,9 +616,12 @@ Per the task: S1 needs **no CoS/iperf cluster smoke** (no datapath change).
 - EDIT `userspace-dp/src/afxdp/wg/mod.rs` (register modules, add consts
   LABEL_MAC1; ~10 LOC)
 - EDIT `userspace-dp/src/afxdp/wg/engine.rs` (4 thin slow-path methods +
-  TAI64N clock field; target delta < ~150 LOC to stay well under 2000)
+  TAI64N clock field + `local_public_key` field/derivation + pending-index
+  reservation layer; target delta < ~150 LOC to stay well under 2000 — AGY
+  re-confirmed ~1846 LOC, well under threshold)
 - EDIT `userspace-dp/Cargo.toml` (promote `blake2` to a direct dep at the
-  already-locked 0.10.6)
+  already-locked 0.10.6; `curve25519-dalek` 4.1.3 is already in `Cargo.lock`
+  for the X25519 `local_public_key` derivation — promote if needed)
 - (Option a only, if ratified) NEW `test/incus/wg-interop.sh` + a `make`
   target that provisions a Debian-13 `--vm` kernel-wg peer, wires cross-VM UDP
   reachability, and drives the test-only UDP socket harness. NOT built under
@@ -757,3 +891,45 @@ notes; SMR-3 ratifies S1/S2 boundary Option (b) with an honesty condition on
 the interop claim. **No KILL.** Proceed to implement once Codex + AGY converge
 (both must also ratify (a)-vs-(b)); fold SMR-1/-2/-5 into §5.4a as hard test
 requirements before coding.
+
+---
+
+## v3-convergence — round-1 plan-review findings + dispositions
+
+Three independent hostile reviews of plan v2 (@ `2b51e4b4d` / `14ce2c020`):
+
+- **Codex** (`task-mpt6qx4i-i04py6`): **PLAN-NEEDS-MAJOR**. Independently
+  recomputed the MAC1 KAT (and showed HMAC gives a different value —
+  `778123b8...`), confirmed snow IK byte-layout + prologue/psk transcript,
+  confirmed the recipient-key direction. Recommended Option (b) strengthened.
+- **AGY** (`adversarial-review-mpt6r70o-ebe5a4`): **PLAN-NEEDS-MAJOR**.
+  Independently recomputed the MAC1 KAT via a Python BLAKE2s oracle (match),
+  confirmed snow byte-exactness + prologue + psk2, re-confirmed engine.rs stays
+  ~1846 LOC. Found the TAI64N epoch-offset bug and the index blackhole race.
+  Recommended Option (b+).
+- **Claude-SMR**: **PLAN-NEEDS-MINOR** (see §SMR-R1). Independently verified
+  snow `_write_message` payload handling end-to-end and recomputed all four KAT
+  vectors from the Rust `blake2` crate first-principles.
+
+All three converged: design is sound (no KILL), snow byte-exactness holds, MAC1
+is keyed-BLAKE2s-128, S1/S2 boundary = Option (b+).
+
+| # | Finding | Source | Severity | Disposition in v3 |
+|---|---|---|---|---|
+| 1 | TAI64N epoch offset must be `0x400000000000000a` (= `2^62 + 10`), not `2^62` | AGY-2 | MAJOR | FIXED §4.3 + corrected `tai64n_encoding_kat`. Verified against `tai64n.go` `base`. |
+| 2 | Nanos must be whitened `&^ 0x00FFFFFF` to match the reference | Claude (found verifying AGY-2) | MED | ADDED §4.3 + test asserts whitening. |
+| 3 | Index-allocation blackhole race — reserve index BEFORE sending msg | AGY-1 / Codex-4 | CRITICAL | FIXED §5.3 two-phase reservation layer + release-on-fail + concurrent test. |
+| 4 | `local_public_key` missing — inbound MAC1 parse needs OUR static pub | Codex-2 | MAJOR | ADDED §5.3 — derive once at `new`, store, test vs snow. |
+| 5 | TAI64N persistence story inconsistent (§1 "persisted" vs §5.2 deferred); specify nanos carry | Codex-3 | MAJOR | FIXED §1 + §5.2 — in-process monotonic only; disk persist = S6; carry spec'd §4.3. |
+| 6 | S1 KAT too weak — need full deterministic msg1/msg2 wire-body KATs | Codex-1 / SMR-2 | MAJOR | REQUIRED §5.4a `msg1_full_kat_fixed_ephemeral` (+ msg2). |
+| 7 | KAT tests must be dual-source (baked hex AND in-test re-derive) | SMR-1 | MINOR | REQUIRED §5.4a. |
+| 8 | `parse` must accept non-zero mac2 (skip-verify, not malformed) | SMR-5 | MINOR | REQUIRED §5.4a `parse_initiation_accepts_nonzero_mac2`. |
+| 9 | Concurrent-TAI64N-monotonic test | SMR-4 | MINOR | REQUIRED §5.4a. |
+| 10 | NTP step-back / restart self-DoS during integrated testing | AGY-3 | DOC | S2 runbook item (flush peer WG state); durable fix = S6 disk persist. |
+| 11 | Keep `HandshakeState` engine-internal (narrow boundary) | SMR-6 | LOW | §5.3 — engine holds pending HS keyed by reserved index. |
+| 12 | Option (b+): don't claim operator-facing interop until S2 proves it | Codex/AGY/SMR-3 | GOVERNANCE | §5.4b — strengthened S1 gate (full KATs) + honesty condition. |
+| 13 | S2 peer-VM SR-IOV wiring (mlx1/vlan3667, 10.0.61.103) + free-VF check | user | INFO | RECORDED §5.4c for the S2 plan. |
+
+All MAJOR/CRITICAL findings are addressed in v3. Remaining work is a confirming
+round-2 (Codex + AGY) on v3, then implement per §5 with the strengthened
+§5.4a gate.

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md
@@ -1007,3 +1007,45 @@ CRITICAL findings across both rounds are resolved in plan v4. **Cleared to
 implement** per §5 with the strengthened §5.4a/§9 gate and the §5.3 reservation
 + §4.3 TAI64N invariants. A round-3 reviewer pass is not required — the only
 open round-2 items were text/impl-note fixes now in v4.
+
+---
+
+## Implementation deviations from the v4 plan sketch
+
+The sections above are the pre-implementation design. The shipped code
+(PR #1716) diverged in these ways as the code-review rounds hardened it; this
+note reconciles the plan with reality (Codex final-review docs nit):
+
+- **`FramingError::TooShort` → `WrongLength`.** The §5.2 sketch listed a
+  `TooShort` variant and the parsers sliced a fixed prefix. The shipped
+  parsers require the EXACT 148/92-byte length (rejecting too-long datagrams,
+  not just too-short — Copilot finding), so the variant is `WrongLength`. The
+  `BadType` check is also strict over the full 32-bit LE type word
+  (`is_canonical_type`, rejecting non-zero reserved bytes — Codex code-review).
+
+- **Reservation lives in `pending` only, never in `sessions_by_local_index`.**
+  The §5.3 sketch described reserving the index "in `sessions_by_local_index`
+  as a pending placeholder." The shipped two-phase reservation records the
+  pending handshake ONLY in a separate `pending` map (+ a `pending_by_peer`
+  cap); the index allocator treats both `pending` and the live demux map as
+  reserved. The live demux entry is inserted ONLY on completion. There is no
+  placeholder in `sessions_by_local_index`.
+
+- **`promote_pending` replaced by lock-held inline completion.** The sketch had
+  a `promote_pending` that installed-then-cleared. After the Codex round-2/3
+  concurrency findings, the entire handshake completion runs under
+  `reconcile_lock`: `consume_response` / `consume_initiation_create_response`
+  call the lock-free `install_session_locked` + `clear_reservation_locked`
+  directly (no separate `promote_pending`), and `reserve_pending_locked`
+  re-checks the peer under the lock to close a create/remove TOCTOU.
+
+- **`PendingHandshake.peer_index` dropped** (Claude-SMR): both completion paths
+  derive the session's peer index from the parsed message, so the field was
+  dead.
+
+- **`reconcile_peers` drains pending reservations** for removed peers (Copilot
+  finding), keeping pending state bounded to O(configured peers).
+
+These are correctness hardenings discovered in review, not scope changes; the
+S1 contract (TAI64N + framing, spec-KAT-validated, both roles, live kernel-WG
+interop deferred to S2) is unchanged.

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
@@ -3,10 +3,16 @@
 Record Codex / AGY / Gemini task-ids here so continuations can fetch by id
 (per feedback_codex_session_loss_continuation).
 
-## Plan review round 1
-- Codex: task-mpt6qx4i-i04py6 (dispatched 2026-05-30, plan v2 @ 2b51e4b4d)
-- AGY: adversarial-review-mpt6r70o-ebe5a4 (dispatched 2026-05-30, plan v2)
-- Claude-SMR: in-conversation (hostile, crypto/protocol) — see plan §SMR-R1
+## Plan review round 1 (plan v2 @ 2b51e4b4d)
+- Codex: task-mpt6qx4i-i04py6 — PLAN-NEEDS-MAJOR
+- AGY: adversarial-review-mpt6r70o-ebe5a4 — PLAN-NEEDS-MAJOR
+- Claude-SMR: in-conversation — PLAN-NEEDS-MINOR (plan §SMR-R1)
+
+## Plan review round 2 (plan v3 @ b9e8bb00a) — CONVERGED PLAN-READY
+- Codex: task-mpt72t96-tcx9m8 — PLAN-NEEDS-MINOR (KAT-naming text fix; folded v4)
+- AGY: adversarial-review-mpt7315l-j522br — PLAN-READY (+2 impl caveats; folded v4)
+- Claude-SMR: PLAN-NEEDS-MINOR (round-1, resolved v3/v4)
+- Outcome: plan v4 cleared to implement (§v4-round2)
 
 ## Code review round 1
 - Codex: (pending)

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
@@ -4,9 +4,9 @@ Record Codex / AGY / Gemini task-ids here so continuations can fetch by id
 (per feedback_codex_session_loss_continuation).
 
 ## Plan review round 1
-- Codex: (pending)
-- AGY: (pending)
-- Claude-SMR: in-conversation (hostile, crypto/protocol)
+- Codex: task-mpt6qx4i-i04py6 (dispatched 2026-05-30, plan v2 @ 2b51e4b4d)
+- AGY: adversarial-review-mpt6r70o-ebe5a4 (dispatched 2026-05-30, plan v2)
+- Claude-SMR: in-conversation (hostile, crypto/protocol) — see plan §SMR-R1
 
 ## Code review round 1
 - Codex: (pending)

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
@@ -27,7 +27,19 @@ Record Codex / AGY / Gemini task-ids here so continuations can fetch by id
 
 ## Code review round 3 (PR #1716 @ 3f6dda484)
 - Fix: entire handshake completion now under reconcile_lock (install_session_locked / reserve_pending_locked / clear_reservation_locked lock-free cores)
-- Codex re-review: task-mpt93h8p-uwj8eg (dispatched)
-- AGY re-review: adversarial-review-mpt93sxe-c3756h (dispatched)
-- Copilot: re-requested via @copilot review
-- Claude-SMR: verified no path re-takes reconcile_lock (no deadlock); completion paths lock exactly once
+- Codex re-review: task-mpt93h8p-uwj8eg — MERGE-NEEDS-MAJOR (TOCTOU: create_initiation pre-lock peer check vs locked reserve)
+- AGY re-review: adversarial-review-mpt93sxe-c3756h — MERGE-READY (race closed, no deadlock, no leak, WG-compliant)
+- Claude-SMR: verified no path re-takes reconcile_lock (no deadlock)
+
+## Code review round 4 (PR #1716 @ b890ef84d)
+- Fix: reserve_pending_locked re-checks peer under lock (TOCTOU closed)
+- Codex round-4: task-mpt9czff-17zab2 — MERGE-NEEDS-MINOR (TOCTOU code fix correct; test ineffective + stale comment)
+
+## Code review round 5 (PR #1716 @ a334ba129 → 6d80369fc → b52f50545)
+- Fixes: deterministic TOCTOU regression (mutation-verified) + exact-length parse (WrongLength) + plan-deviations note + doc nits
+- Codex: task-mpt9ueve-h7qwsr — MERGE-NEEDS-MINOR (docs-only) → task-mpt9y6p7-bnijrw — **MERGE-READY** (no findings)
+- AGY: MERGE-READY (round-3, code unchanged in substance since)
+- Copilot: COMMENTED; all substantive findings addressed (parse-length, stale comments, HMAC, O(peers), return-order, entry-count)
+- Claude-SMR: byte-exact framing + KATs reproduced from blake2 first-principles; snow payload==timestamp verified; no deadlock; race-free
+
+## MERGE GATE: clean 4-of-4 (Codex MERGE-READY, AGY MERGE-READY, Copilot addressed, Claude-SMR verified). No cluster smoke — S1 is wire-protocol + tests, no datapath change.

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
@@ -21,6 +21,13 @@ Record Codex / AGY / Gemini task-ids here so continuations can fetch by id
 - Fixes pushed @ bd80112a5 (consume_response reservation rework, restore-on-fail, strict type)
 
 ## Code review round 2 (PR #1716 @ bd80112a5)
-- Codex re-review: task-mpt8qqkg-lcclp2 (dispatched, confirming fixes)
+- Codex re-review: task-mpt8qqkg-lcclp2 — MERGE-NEEDS-MAJOR (consume_response still dropped pending lock before Noise read; per-peer abort could remove in-flight reservation mid-read)
+- Copilot: re-requested; found reconcile-drain-pending gap + MAC1-KAT-comment (fixed @ 76f78b443)
+- Claude-SMR: confirmed no double reconcile_lock acquisition
+
+## Code review round 3 (PR #1716 @ 3f6dda484)
+- Fix: entire handshake completion now under reconcile_lock (install_session_locked / reserve_pending_locked / clear_reservation_locked lock-free cores)
+- Codex re-review: task-mpt93h8p-uwj8eg (dispatched)
+- AGY re-review: adversarial-review-mpt93sxe-c3756h (dispatched)
 - Copilot: re-requested via @copilot review
-- Claude-SMR: fixes self-verified (forged-msg2 regression green, no absent-from-both-maps window)
+- Claude-SMR: verified no path re-takes reconcile_lock (no deadlock); completion paths lock exactly once

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
@@ -1,0 +1,14 @@
+# #1709 WireGuard S1 — reviewer task IDs
+
+Record Codex / AGY / Gemini task-ids here so continuations can fetch by id
+(per feedback_codex_session_loss_continuation).
+
+## Plan review round 1
+- Codex: (pending)
+- AGY: (pending)
+- Claude-SMR: in-conversation (hostile, crypto/protocol)
+
+## Code review round 1
+- Codex: (pending)
+- AGY: (pending)
+- Copilot: (pending)

--- a/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
+++ b/docs/pr/1709-wireguard-s1-wire-protocol-compliance/reviewer-ids.md
@@ -14,7 +14,13 @@ Record Codex / AGY / Gemini task-ids here so continuations can fetch by id
 - Claude-SMR: PLAN-NEEDS-MINOR (round-1, resolved v3/v4)
 - Outcome: plan v4 cleared to implement (§v4-round2)
 
-## Code review round 1
-- Codex: (pending)
-- AGY: (pending)
-- Copilot: (pending)
+## Code review round 1 (PR #1716 @ ce8f21899)
+- Codex: task-mpt8dpg6-jeyqqr — MERGE-NEEDS-MAJOR (2 majors + 1 medium in consume_response/parse)
+- AGY: adversarial-review-mpt8e2ef-0bjiij — MERGE-NEEDS-MINOR (pending_by_peer leak; reviewed pre-fix code)
+- Claude-SMR: in-conversation — removed dead peer_index field
+- Fixes pushed @ bd80112a5 (consume_response reservation rework, restore-on-fail, strict type)
+
+## Code review round 2 (PR #1716 @ bd80112a5)
+- Codex re-review: task-mpt8qqkg-lcclp2 (dispatched, confirming fixes)
+- Copilot: re-requested via @copilot review
+- Claude-SMR: fixes self-verified (forged-msg2 regression green, no absent-from-both-maps window)

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -431,6 +431,17 @@ existing pattern of `recycle_ingress_frame(...)` before every
 
 ### On-wire handshake framing scope (explicit boundary)
 
+> **UPDATE (#1709 S1, DONE):** the type-1 MessageInitiation and type-2
+> MessageResponse on-wire framing (type byte, reserved, sender/receiver
+> index, MAC1 = keyed-BLAKE2s-128 over `HASH("mac1----"||recipient_pub)`,
+> MAC2 zeros) AND the 12-byte TAI64N timestamp as the Noise payload of
+> msg1 now exist in `wg/handshake.rs` + `wg/tai64n.rs`, wired into the
+> engine's `create_initiation` / `consume_response` /
+> `consume_initiation_create_response` (in `wg/handshake_session.rs`).
+> Type-3 CookieReply + MAC2 generation/verification remain OUT (#1703
+> S7). The boundary text below describes the pre-#1709 engine; it is kept
+> for historical context.
+
 This engine does NOT build or parse the WireGuard handshake message
 on-wire framing (type-1 MessageInitiation, type-2 MessageResponse,
 type-3 CookieReply, MAC1/MAC2 fields, the TAI64N timestamp slot, the
@@ -464,10 +475,14 @@ data record only.
   `afxdp/tx/dispatch.rs:430`) and in the ingress decap classifier
   in `poll_descriptor.rs`. Engine exists and is tested but is not on
   the hot path yet.
-- WG handshake outer-framing layer (MessageInitiation/MessageResponse
-  outer bytes around the Noise sub-message, MAC1/MAC2, TAI64N).
-  Engine ships the Noise sub-message bytes only; the integration
-  PR will wrap them.
+- ~~WG handshake outer-framing layer (MessageInitiation/MessageResponse
+  outer bytes around the Noise sub-message, MAC1/MAC2, TAI64N).~~
+  **DONE in #1709 S1** for msg type 1/2 + MAC1 + TAI64N (build + parse,
+  both roles). Type-3 CookieReply + MAC2 generation/verification are
+  still OUT (#1703 S7). Independent-peer interop (live kernel-WireGuard
+  on a VM) is #1703 S2 — S1 is validated by spec known-answer vectors +
+  an xpf-against-xpf framed-handshake regression, NOT yet against an
+  independent reference.
 - Go control-plane mapping from Junos `set security ipsec ...` /
   `set interfaces st0...` to WG snapshot fields.
 - HA / RG-aware session migration on failover.

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,8 +1,8 @@
 [REFACTOR]   2437  userspace-dp/src/afxdp/poll_descriptor/mod.rs
 [WATCH]      1986  pkg/cli/cli_show_security.go
+[WATCH]      1807  userspace-dp/src/afxdp/wg/engine.rs
 [WATCH]      1792  userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
 [WATCH]      1784  pkg/dataplane/userspace/manager.go
-[WATCH]      1772  userspace-dp/src/afxdp/wg/engine.rs
 [WATCH]      1745  userspace-dp/src/afxdp/cold_path_hist.rs
 [WATCH]      1711  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1695  pkg/dataplane/compiler.go

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -2,8 +2,8 @@
 [WATCH]      1986  pkg/cli/cli_show_security.go
 [WATCH]      1792  userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
 [WATCH]      1784  pkg/dataplane/userspace/manager.go
+[WATCH]      1772  userspace-dp/src/afxdp/wg/engine.rs
 [WATCH]      1745  userspace-dp/src/afxdp/cold_path_hist.rs
-[WATCH]      1725  userspace-dp/src/afxdp/wg/engine.rs
 [WATCH]      1711  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1695  pkg/dataplane/compiler.go
 [WATCH]      1667  userspace-dp/src/afxdp/forwarding/mod.rs

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -1,0 +1,85 @@
+# WireGuard interop — status and validation
+
+Tracking doc for the #1703 WireGuard interop umbrella (interop with kernel
+WireGuard, UniFi Network 10.4+, EdgeOS/EdgeRouter, UDM/UDM-Pro — all of which
+run reference-compliant kernel WireGuard).
+
+WireGuard is a fixed protocol: a byte-compliant implementation interoperates
+with any other compliant implementation regardless of vendor. The work is
+therefore staged by capability, not by vendor.
+
+## Status by stage
+
+| Stage | Scope | State |
+|-------|-------|-------|
+| S1 (#1709) | Wire-protocol compliance: TAI64N + handshake framing (msg type 1/2, MAC1) on build + parse, both roles | **DONE (this PR)** — validated by spec known-answer vectors + an xpf↔xpf framed-handshake regression. **NOT yet validated against an independent peer** (see "honesty note" below). |
+| S2 | Dataplane activation (AF_XDP hot-path encap/decap) **+ the live kernel-WireGuard-on-a-VM interop test** | pending |
+| S4 | Non-zero pre-shared key (PSK) plumbing | pending |
+| S5 | Persistent-keepalive + REKEY/REJECT-AFTER timers + endpoint roaming + empty-record (keepalive/key-confirm) handling + TAI64N disk persistence | pending |
+| S6 | Junos config surface (grammar + compiler + snapshot population, base64↔hex keys) | pending |
+| S7 | Type-3 CookieReply + MAC2 generation/verification + IPv6 outer encap + DSCP/ECN | pending |
+| S8 | HA RG WG-session migration | pending |
+
+## What S1 delivers
+
+S1 makes xpf's WireGuard **handshake bytes** standards-compliant:
+
+- **TAI64N timestamp** (`userspace-dp/src/afxdp/wg/tai64n.rs`): a 12-byte
+  big-endian `0x400000000000000a + unix_secs` (the `+10` is the 1970-epoch
+  TAI−UTC leap offset, matching kernel WireGuard and wireguard-go) followed by
+  whitened nanoseconds (`& 0xFF000000`). The clock is strictly monotonic
+  in-process so xpf never DoSes its own re-handshakes with a backwards
+  timestamp. Carried as the encrypted Noise payload of message 1.
+- **Handshake framing** (`userspace-dp/src/afxdp/wg/handshake.rs`): the WG
+  type-1 MessageInitiation (148 bytes) and type-2 MessageResponse (92 bytes)
+  on-wire framing — type byte, reserved, sender/receiver index, and
+  `MAC1 = keyed-BLAKE2s-128(BLAKE2s-256("mac1----" || recipient_static_pub),
+  msg[0..offsetof(mac1)])`. MAC2 is emitted as zeros (cookie handling is S7)
+  and skip-verified on parse.
+- **Engine orchestration**
+  (`userspace-dp/src/afxdp/wg/handshake_session.rs`): `create_initiation`,
+  `consume_response`, and `consume_initiation_create_response` compose snow +
+  the framing + the TAI64N clock into the full handshake in both roles, with a
+  two-phase index reservation (reserve before send, at most one pending per
+  peer) so a completed handshake's session is never blackholed by an index
+  collision. Handshake construction runs on the control thread only — never
+  the AF_XDP poll worker.
+
+## Honesty note (S1/S2 boundary)
+
+**S1 is NOT yet proven to interoperate with an independent WireGuard peer.**
+Its in-tree gate is spec known-answer vectors (the WG construction hashes, the
+MAC1 keyed-BLAKE2s-128 construction, the TAI64N encoding, and full byte-exact
+msg1/msg2 wire images) plus an xpf-against-xpf framed-handshake round-trip.
+Those pin every framing/MAC1/TAI64N byte to the canonical construction, but a
+symmetric build/parse bug shared by both xpf roles would pass them. The
+independent-peer proof — a live handshake against the **Linux kernel
+WireGuard** module — lands in S2 alongside the dataplane/UDP wiring it shares.
+Do not claim "xpf interoperates with WireGuard / UniFi" on the basis of S1
+alone.
+
+## S2 live kernel-WireGuard interop recipe (reference; built in S2)
+
+The independent reference is the Linux kernel WireGuard module running on a
+real incus **virtual machine** (never a container — containers share the host
+kernel and cannot use the WG module or create `type wireguard` links). This is
+byte-identical to what UniFi / EdgeOS / UDM run.
+
+```sh
+# On a Debian-13 VM peer (root; install wireguard-tools if absent):
+ip link add wgref type wireguard
+wg set wgref private-key <ref.priv> listen-port <P> \
+   peer <xpf.pub> allowed-ips 0.0.0.0/0 endpoint <xpf_vm_ip>:<Q>
+ip addr add <wg-overlay>/24 dev wgref
+ip link set wgref up
+
+# Direction A: xpf create_initiation -> UDP <peer_vm_ip>:<P>; kernel wg
+#   verifies MAC1 + decrypts the TAI64N + replies type-2; xpf
+#   consume_response derives the session. Assert via `wg show wgref`.
+# Direction B: kernel wg initiates (persistent-keepalive 1); xpf
+#   consume_initiation_create_response replies; assert `wg show` completes.
+```
+
+The peer VM attaches to the same SR-IOV LAN segment as the cluster host
+(`mlx1` / VLAN 3667 on the loss userspace cluster); S2 must verify a free VF
+exists before launching the peer, or reuse an existing real VM on that segment.

--- a/userspace-dp/Cargo.lock
+++ b/userspace-dp/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "fiat-crypto",
  "rustc_version",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1143,10 +1144,12 @@ name = "xpf-userspace-dp"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "blake2",
  "cc",
  "chrono",
  "criterion",
  "ctrlc",
+ "curve25519-dalek",
  "io-uring",
  "ipnet",
  "libbpf-sys",

--- a/userspace-dp/Cargo.lock
+++ b/userspace-dp/Cargo.lock
@@ -1150,6 +1150,7 @@ dependencies = [
  "criterion",
  "ctrlc",
  "curve25519-dalek",
+ "getrandom 0.2.17",
  "io-uring",
  "ipnet",
  "libbpf-sys",

--- a/userspace-dp/Cargo.toml
+++ b/userspace-dp/Cargo.toml
@@ -26,6 +26,16 @@ smallvec = "1.13"
 # output queues. The transitive crypto set includes
 # chacha20poly1305/curve25519-dalek/blake2 and ring.
 snow = "0.10"
+# WireGuard S1 (#1709): on-wire handshake framing + TAI64N. blake2 backs
+# the MAC1 keyed-BLAKE2s-128 over HASH("mac1----"||recipient_pub) and the
+# WG construction-hash KAT vectors; curve25519-dalek derives the engine's
+# local static public key (MontgomeryPoint::mul_base_clamped) once at
+# construction for inbound MAC1 verification. Both are already in the
+# transitive crypto set via snow at these exact locked versions —
+# promoting them to direct deps changes no resolved version, only the
+# visibility (verified: cargo tree shows blake2 0.10.6, dalek 4.1.3).
+blake2 = "0.10"
+curve25519-dalek = "4.1"
 # zeroize is already pulled transitively by curve25519-dalek/snow; we
 # pin the version we use directly for the engine's static-key state
 # so the WG private key is wiped on engine drop. Cost: zero — just a

--- a/userspace-dp/Cargo.toml
+++ b/userspace-dp/Cargo.toml
@@ -36,6 +36,10 @@ snow = "0.10"
 # visibility (verified: cargo tree shows blake2 0.10.6, dalek 4.1.3).
 blake2 = "0.10"
 curve25519-dalek = "4.1"
+# Random WG handshake indices (opaque demux tags). Already transitive via
+# snow/curve25519-dalek at 0.2.x; promoted to a direct dep for the engine's
+# index allocator.
+getrandom = "0.2"
 # zeroize is already pulled transitively by curve25519-dalek/snow; we
 # pin the version we use directly for the engine's static-key state
 # so the WG private key is wiped on engine drop. Cost: zero — just a

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -436,6 +436,28 @@ impl WgEngine {
                 by_index.remove(li);
             }
         }
+        // Drain in-flight HANDSHAKE RESERVATIONS for removed peers too
+        // (Copilot code-review finding). A peer with a pending (not-yet-
+        // completed) handshake leaves an entry in `pending` keyed by our
+        // reserved index and a `pending_by_peer` marker keyed by its pubkey.
+        // Without draining these on peer removal, the reservation (and its
+        // consumed index) would leak until process restart, and a stale
+        // per-peer marker could mis-fire the at-most-one-pending-per-peer
+        // abort after config churn. `pending_by_peer` is keyed by pubkey, so
+        // we drain directly for each removed pubkey. Still under
+        // `reconcile_lock`, consistent with `reserve_pending`/`release_pending`.
+        {
+            let mut pending = self.pending.write().unwrap();
+            let mut by_peer = self.pending_by_peer.write().unwrap();
+            for pubkey in old.peer_index_by_pubkey.keys() {
+                if new_index.contains_key(pubkey) {
+                    continue;
+                }
+                if let Some(reserved_idx) = by_peer.remove(pubkey) {
+                    pending.remove(&reserved_idx);
+                }
+            }
+        }
         // Publish the new table. Atomic release-store; any reader
         // doing `.load()` after this point sees the new table whole.
         self.table.store(Arc::new(PeerTable {

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -518,6 +518,19 @@ impl WgEngine {
         // in published tables. This is slow path, so mutex cost is
         // acceptable and keeps install/reconcile linearizable.
         let _reconcile_guard = self.reconcile_lock.lock().unwrap();
+        self.install_session_locked(pubkey, session)
+    }
+
+    /// Lock-free core of `install_session`: the caller MUST already hold
+    /// `reconcile_lock`. Exposed (module-private) so the handshake
+    /// completion path can hold `reconcile_lock` across the take-state →
+    /// snow-read → install critical section without re-entering the
+    /// non-reentrant mutex (which would deadlock). See `consume_response`.
+    pub(in crate::afxdp::wg) fn install_session_locked(
+        &self,
+        pubkey: &[u8; 32],
+        session: Arc<WgSession>,
+    ) -> Result<(), InstallSessionError> {
         let Some(peer) = self.peer_arc(pubkey) else {
             return Err(InstallSessionError::UnknownPeer);
         };

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -54,15 +54,16 @@
 
 use super::allowed_ips::AllowedIps;
 use super::framing::{encode_data_header, parse_data_header};
-use super::handshake::{
-    self, FramingError, MSG_INIT_NOISE_LEN, MSG_RESPONSE_NOISE_LEN,
-};
+// PendingHandshake is defined alongside the handshake orchestration in
+// handshake_session.rs (same `wg` module); the engine struct holds a map of
+// them, so it imports the type here.
+use super::handshake_session::PendingHandshake;
 use super::peer::Peer;
-use super::session::{REJECT_AFTER_MESSAGES, ReplayDecision, SessionRole, WgSession};
-use super::tai64n::{TAI64N_LEN, Tai64nClock};
+use super::session::{REJECT_AFTER_MESSAGES, ReplayDecision, WgSession};
+use super::tai64n::Tai64nClock;
 use super::{
-    POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_KEY_LEN, WG_MSG_INIT_LEN, WG_MSG_RESPONSE_LEN,
-    WG_NOISE_PATTERN, WG_PROTOCOL_ID_BYTES, WG_ZERO_PSK,
+    POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_KEY_LEN, WG_NOISE_PATTERN, WG_PROTOCOL_ID_BYTES,
+    WG_ZERO_PSK,
 };
 use arc_swap::ArcSwap;
 use curve25519_dalek::MontgomeryPoint;
@@ -114,73 +115,6 @@ pub(crate) enum InstallSessionError {
     /// `previous` session, which the demux map would no longer be
     /// able to resolve.
     LocalIndexCollision,
-}
-
-/// Errors that can fail the slow-path WG handshake build / consume.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum HandshakeError {
-    /// The caller-supplied peer pubkey is not in the engine table.
-    UnknownPeer,
-    /// The on-wire framing was malformed or its MAC1 did not verify.
-    Framing(FramingError),
-    /// snow rejected the Noise message (bad AEAD tag, wrong key, etc.).
-    Crypto,
-    /// The responder's msg2 `receiver_index` did not match the
-    /// `sender_index` we reserved for this handshake — a spoofed or
-    /// misrouted response; drop it.
-    ReceiverIndexMismatch,
-    /// No pending handshake reservation matched the response's
-    /// `receiver_index`. Either the response is stale (the handshake
-    /// timed out and its reservation was released) or spoofed.
-    NoPendingHandshake,
-    /// snow `read_message` recovered the peer's static public key, but
-    /// it is not a configured peer in the engine table. (Responder path.)
-    UnknownInitiator,
-    /// Could not allocate a fresh, collision-free local index after
-    /// several attempts (astronomically unlikely with a 32-bit space).
-    IndexExhausted,
-    /// The output buffer was too small for the framed handshake message.
-    OutputTooSmall,
-    /// Internal snow / engine error building the handshake state.
-    Internal,
-}
-
-impl From<FramingError> for HandshakeError {
-    fn from(e: FramingError) -> Self {
-        HandshakeError::Framing(e)
-    }
-}
-
-/// A handshake in progress: the snow `HandshakeState` plus the metadata
-/// needed to promote it to a live session once the exchange completes.
-///
-/// Held in the engine keyed by OUR locally-chosen `sender_index` (the
-/// reserved index). Keeping `HandshakeState` engine-internal (rather than
-/// handed back to the caller and re-supplied) keeps the public API trading
-/// only byte slices / `[u8;32]` and pre-stages the S3 integration where the
-/// coordinator thread owns pending handshakes (SMR-6).
-struct PendingHandshake {
-    /// snow state, pumped to completion on the second message. `Some` for
-    /// an initiator handshake that must resume across the
-    /// `create_initiation` → `consume_response` call boundary; `None` for
-    /// a responder reservation, which completes synchronously inside
-    /// `consume_initiation_create_response` (the snow state never needs to
-    /// outlive that call, so the pending entry is a bare reservation
-    /// marker).
-    state: Option<HandshakeState>,
-    /// The peer this handshake is with (its static public key).
-    peer_pubkey: [u8; WG_KEY_LEN],
-    /// Our locally-chosen index (the reservation key). The peer echoes
-    /// it as the `receiver_index` of the message it sends back.
-    local_index: u32,
-    /// The peer's index, learned from the message it sent us. For the
-    /// responder path this is msg1.sender_index (known at reserve time);
-    /// for the initiator path it is filled in from msg2.sender_index on
-    /// completion.
-    peer_index: u32,
-    /// Initiator or responder — determines the session-confirmation gate
-    /// (see `WgSession`).
-    role: SessionRole,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -335,24 +269,25 @@ pub(crate) struct WgEngine {
     /// inbound message the recipient is us. Derived once so the parse hot
     /// path (slow path, but still) does not repeat the base-point multiply
     /// and so a "private-key-as-public" swap cannot creep in.
-    local_public_key: [u8; WG_KEY_LEN],
+    /// `pub(in crate::afxdp::wg)` so the handshake orchestration in
+    /// `handshake_session.rs` (a sibling file, same `wg` module) can read it.
+    pub(in crate::afxdp::wg) local_public_key: [u8; WG_KEY_LEN],
     /// Monotonic TAI64N clock for the initiator handshake timestamp.
     /// In-process strict monotonicity; cross-restart persistence is a
     /// future control-plane concern (#1703 S6).
-    tai64n_clock: Tai64nClock,
+    pub(in crate::afxdp::wg) tai64n_clock: Tai64nClock,
     /// In-flight handshakes keyed by OUR reserved local index. A handshake
-    /// is inserted here (and its index reserved in `sessions_by_local_index`
-    /// as a placeholder) BEFORE the message carrying that index goes on the
+    /// is recorded here BEFORE the message carrying that index goes on the
     /// wire, then promoted to a live `WgSession` on completion. See the
-    /// two-phase reservation discipline in `reserve_local_index`.
-    pending: RwLock<FxHashMap<u32, PendingHandshake>>,
+    /// two-phase reservation discipline in `reserve_pending`.
+    pub(in crate::afxdp::wg) pending: RwLock<FxHashMap<u32, PendingHandshake>>,
     /// At-most-one-pending-per-peer index: maps a peer pubkey to its
     /// current pending reservation's local index. A new initiation from a
     /// peer aborts that peer's prior pending reservation, bounding pending
     /// state to O(configured peers) under a valid-MAC1 initiation flood
     /// (the reservation step is reached only after snow authenticates the
     /// static-key AEAD).
-    pending_by_peer: RwLock<FxHashMap<[u8; WG_KEY_LEN], u32>>,
+    pub(in crate::afxdp::wg) pending_by_peer: RwLock<FxHashMap<[u8; WG_KEY_LEN], u32>>,
     /// UDP port we listen on for inbound. Stored for diagnostics
     /// and for the slow-path responder.
     listen_port: u16,
@@ -364,14 +299,14 @@ pub(crate) struct WgEngine {
     /// prevent stale-Arc install races across peer removal. Hot path
     /// does NOT take this lock — readers only touch `table` via
     /// `.load()`.
-    reconcile_lock: std::sync::Mutex<()>,
+    pub(in crate::afxdp::wg) reconcile_lock: std::sync::Mutex<()>,
     /// Demux map: receiver_index → session. Receiver indices are
     /// chosen locally at handshake time so they uniquely identify
     /// a session for as long as it lives. Kept out of `PeerTable`
     /// because session install / rotation is independent of peer
     /// reconcile; only peer REMOVAL touches both (we drain a
     /// dropped peer's sessions out of this map during reconcile).
-    sessions_by_local_index: RwLock<FxHashMap<u32, Arc<WgSession>>>,
+    pub(in crate::afxdp::wg) sessions_by_local_index: RwLock<FxHashMap<u32, Arc<WgSession>>>,
 }
 
 impl WgEngine {
@@ -526,7 +461,7 @@ impl WgEngine {
         self.load_table()
     }
 
-    fn peer_arc(&self, pubkey: &[u8; 32]) -> Option<Arc<Peer>> {
+    pub(in crate::afxdp::wg) fn peer_arc(&self, pubkey: &[u8; 32]) -> Option<Arc<Peer>> {
         let table = self.load_table();
         let idx = *table.peer_index_by_pubkey.get(pubkey)?;
         table.peers.get(idx as usize).cloned()
@@ -935,414 +870,6 @@ impl WgEngine {
             .psk(2, &WG_ZERO_PSK)?
             .build_responder()
     }
-
-    // ===================================================================
-    // WireGuard handshake — framed, both roles (#1709 S1)
-    //
-    // These compose snow + handshake.rs framing + the TAI64N clock into the
-    // full on-wire WG handshake. They run on the CONTROL/coordinator thread
-    // only — never the AF_XDP poll worker (the hot encap/decap paths never
-    // build a HandshakeState). Index allocation follows the two-phase
-    // reservation discipline: an index is reserved in `sessions_by_local_index`
-    // (as a placeholder via `pending`) BEFORE the message carrying it is
-    // emitted, so a concurrent handshake cannot steal it and blackhole the
-    // resulting session.
-    // ===================================================================
-
-    /// Reserve a fresh, collision-free local index and register a pending
-    /// handshake under it. Holds the `reconcile_lock` (serialized with
-    /// `install_session` / `reconcile_peers`) so the reservation is atomic
-    /// w.r.t. session install and peer removal.
-    ///
-    /// Enforces the at-most-one-pending-per-peer cap: if the peer already
-    /// has a pending reservation, it is aborted (removed from `pending` and
-    /// its placeholder dropped from the demux map) before the new one is
-    /// installed. Returns the reserved local index.
-    fn reserve_pending(
-        &self,
-        peer_pubkey: [u8; WG_KEY_LEN],
-        state: Option<HandshakeState>,
-        peer_index: u32,
-        role: SessionRole,
-    ) -> Result<u32, HandshakeError> {
-        let _guard = self.reconcile_lock.lock().unwrap();
-        let by_index = self.sessions_by_local_index.read().unwrap();
-        let mut pending = self.pending.write().unwrap();
-        let mut by_peer = self.pending_by_peer.write().unwrap();
-
-        // Abort any prior PENDING (not-yet-completed) handshake for this
-        // peer (DoS bound: at most one pending reservation per peer). The
-        // `pending_by_peer` marker is cleared by `promote_pending` on
-        // completion, so a still-present marker can only point at an
-        // incomplete reservation living in `pending` — NOT at a live
-        // session in `by_index`. We therefore drop only the `pending`
-        // entry and the marker; we must NOT touch `by_index`, or we would
-        // blackhole an already-established session for this peer that a
-        // prior completed handshake legitimately installed there.
-        if let Some(old_idx) = by_peer.remove(&peer_pubkey) {
-            pending.remove(&old_idx);
-        }
-
-        // Pick a fresh index not present as a live session OR a pending
-        // reservation. 32-bit space; a handful of tries is plenty.
-        let mut local_index = 0u32;
-        let mut found = false;
-        for _ in 0..8 {
-            let cand = rand_u32_nonzero();
-            if !by_index.contains_key(&cand) && !pending.contains_key(&cand) {
-                local_index = cand;
-                found = true;
-                break;
-            }
-        }
-        if !found {
-            return Err(HandshakeError::IndexExhausted);
-        }
-
-        // Reserve the index by recording the pending handshake. The
-        // reservation lives in `pending` (NOT in the live-session demux
-        // map): the index allocator above rejects any candidate already
-        // present in `pending` OR `by_index`, and the whole reserve/promote
-        // sequence is serialized by `reconcile_lock`, so a concurrent
-        // handshake or `install_session` cannot claim this index until we
-        // either promote it (insert the live session) or release it. decap
-        // never sees a half-built session because the live entry is only
-        // inserted by `promote_pending` → `install_session` on completion.
-        pending.insert(
-            local_index,
-            PendingHandshake {
-                state,
-                peer_pubkey,
-                local_index,
-                peer_index,
-                role,
-            },
-        );
-        by_peer.insert(peer_pubkey, local_index);
-        Ok(local_index)
-    }
-
-    /// Release a pending reservation (handshake failed before completion).
-    /// Removes it from `pending` and clears the `pending_by_peer` marker if
-    /// it still points at this index. A pending reservation lives only in
-    /// `pending` (never in the live-session demux map), so there is nothing
-    /// to undo in `sessions_by_local_index`. Idempotent.
-    fn release_pending(&self, local_index: u32) {
-        let _guard = self.reconcile_lock.lock().unwrap();
-        let mut pending = self.pending.write().unwrap();
-        if let Some(ph) = pending.remove(&local_index) {
-            let mut by_peer = self.pending_by_peer.write().unwrap();
-            // Only clear the peer→index map if it still points at us.
-            if by_peer.get(&ph.peer_pubkey) == Some(&local_index) {
-                by_peer.remove(&ph.peer_pubkey);
-            }
-        }
-    }
-
-    /// Number of in-flight (reserved-but-not-completed) handshakes. Test /
-    /// diagnostic accessor.
-    #[cfg(test)]
-    pub(crate) fn pending_count(&self) -> usize {
-        self.pending.read().unwrap().len()
-    }
-
-    /// Build a framed WG type-1 initiation toward `peer_pubkey`.
-    ///
-    /// Reserves a local sender_index FIRST, builds the snow msg1 body with
-    /// a fresh monotonic TAI64N as the Noise payload, and frames it (type,
-    /// reserved, sender_index, body, mac1 over the responder pubkey, mac2
-    /// zeros). On any failure after reservation the reservation is released.
-    /// Writes the 148-byte message at `out[0..148]` and returns the chosen
-    /// sender_index.
-    pub(crate) fn create_initiation(
-        &self,
-        peer_pubkey: &[u8; WG_KEY_LEN],
-        out: &mut [u8],
-    ) -> Result<u32, HandshakeError> {
-        if out.len() < WG_MSG_INIT_LEN {
-            return Err(HandshakeError::OutputTooSmall);
-        }
-        // Confirm the peer is configured before doing any work.
-        if self.peer_arc(peer_pubkey).is_none() {
-            return Err(HandshakeError::UnknownPeer);
-        }
-        let mut state = self
-            .build_initiator_handshake(peer_pubkey)
-            .map_err(|_| HandshakeError::Internal)?;
-
-        // Reserve the local index + register the pending handshake BEFORE
-        // emitting the message (two-phase reservation). For the initiator
-        // the peer_index is not yet known (filled from msg2); use 0 as a
-        // placeholder. The snow state is stashed after we write msg1 (which
-        // mutates it) so it can resume in `consume_response`.
-        let local_index =
-            self.reserve_pending(*peer_pubkey, None, 0, SessionRole::Initiator)?;
-
-        // Build the snow msg1 body with the TAI64N as the Noise payload.
-        let tai64n = self.tai64n_clock.now();
-        debug_assert_eq!(tai64n.len(), TAI64N_LEN);
-        let mut noise_body = [0u8; MSG_INIT_NOISE_LEN];
-        let n = match state.write_message(&tai64n, &mut noise_body) {
-            Ok(n) => n,
-            Err(_) => {
-                self.release_pending(local_index);
-                return Err(HandshakeError::Crypto);
-            }
-        };
-        if n != MSG_INIT_NOISE_LEN {
-            self.release_pending(local_index);
-            return Err(HandshakeError::Crypto);
-        }
-        // Frame it.
-        if let Err(e) = handshake::build_initiation(out, local_index, &noise_body, peer_pubkey) {
-            self.release_pending(local_index);
-            return Err(e.into());
-        }
-        // Stash the real (post-write) snow state into the pending entry so
-        // `consume_response` can resume it.
-        {
-            let mut pending = self.pending.write().unwrap();
-            if let Some(ph) = pending.get_mut(&local_index) {
-                ph.state = Some(state);
-            } else {
-                // Reservation vanished (aborted by a concurrent init for the
-                // same peer). Treat as a failed build.
-                return Err(HandshakeError::NoPendingHandshake);
-            }
-        }
-        Ok(local_index)
-    }
-
-    /// Consume a peer's framed WG type-2 response, complete the initiator
-    /// handshake, and install the derived transport session.
-    ///
-    /// Verifies the framing (mac1 over OUR public key) and that the
-    /// response's `receiver_index` matches a pending reservation we hold.
-    /// On success the pending handshake is promoted to a live `WgSession`
-    /// (initiator role, confirmed at install) and registered for inbound
-    /// demux. Returns the local index of the installed session.
-    pub(crate) fn consume_response(&self, msg: &[u8]) -> Result<u32, HandshakeError> {
-        let parsed = handshake::parse_response(msg, &self.local_public_key)?;
-        // Take the pending handshake addressed by receiver_index.
-        let mut ph = {
-            let mut pending = self.pending.write().unwrap();
-            pending
-                .remove(&parsed.receiver_index)
-                .ok_or(HandshakeError::NoPendingHandshake)?
-        };
-        // Copy the metadata out before consuming `ph.state` (avoids a
-        // partial-move borrow conflict).
-        let local_index = ph.local_index;
-        let peer_pubkey = ph.peer_pubkey;
-        let role = ph.role;
-        // It must be an initiator-role handshake (we sent msg1).
-        if role != SessionRole::Initiator || local_index != parsed.receiver_index {
-            // A mismatched role/index means this response does not belong to
-            // this reservation; drop it and release the now-removed entry's
-            // peer marker.
-            self.release_pending(parsed.receiver_index);
-            return Err(HandshakeError::ReceiverIndexMismatch);
-        }
-        // Recover the resumable initiator snow state.
-        let mut state = match ph.state.take() {
-            Some(s) => s,
-            None => {
-                // An initiator reservation must carry its snow state. A
-                // missing state means the reservation was never completed by
-                // create_initiation (e.g. aborted mid-build); drop it.
-                self.release_pending(parsed.receiver_index);
-                return Err(HandshakeError::NoPendingHandshake);
-            }
-        };
-        // Drive snow to completion with the peer's msg2 body.
-        let mut sink = [0u8; MSG_RESPONSE_NOISE_LEN];
-        if state.read_message(parsed.noise_body, &mut sink).is_err() {
-            self.release_pending(parsed.receiver_index);
-            return Err(HandshakeError::Crypto);
-        }
-        let transport = match state.into_stateless_transport_mode() {
-            Ok(t) => t,
-            Err(_) => {
-                self.release_pending(parsed.receiver_index);
-                return Err(HandshakeError::Crypto);
-            }
-        };
-        let session = Arc::new(WgSession::new_with_role(
-            transport,
-            local_index,
-            parsed.sender_index,
-            peer_pubkey,
-            SessionRole::Initiator,
-        ));
-        self.promote_pending(local_index, peer_pubkey, session)
-    }
-
-    /// Responder path: parse a peer's framed WG type-1 initiation, run snow
-    /// to recover the peer's static key + TAI64N, identify the configured
-    /// peer, build a framed WG type-2 response, reserve our responder
-    /// sender_index, and install the derived (unconfirmed) transport
-    /// session. Writes the 92-byte response at `out[0..92]` and returns
-    /// `(our_sender_index, peer_pubkey)`.
-    pub(crate) fn consume_initiation_create_response(
-        &self,
-        msg: &[u8],
-        out: &mut [u8],
-    ) -> Result<([u8; WG_KEY_LEN], u32), HandshakeError> {
-        if out.len() < WG_MSG_RESPONSE_LEN {
-            return Err(HandshakeError::OutputTooSmall);
-        }
-        // Verify framing (mac1 over OUR public key) and recover the body.
-        let parsed = handshake::parse_initiation(msg, &self.local_public_key)?;
-        let peer_sender_index = parsed.sender_index;
-
-        // Run the responder Noise read to recover the peer static key.
-        let mut state = self
-            .build_responder_handshake()
-            .map_err(|_| HandshakeError::Internal)?;
-        let mut ts_sink = [0u8; TAI64N_LEN];
-        // snow writes the recovered Noise payload (the peer's TAI64N) into
-        // ts_sink; the value is used by a compliant responder for handshake
-        // anti-replay. S1 derives the session and (per the (b+) boundary)
-        // does not yet enforce per-peer TAI64N anti-replay — that rides
-        // with the responder-hardening step. We still must READ it so snow
-        // advances the transcript.
-        if state.read_message(parsed.noise_body, &mut ts_sink).is_err() {
-            return Err(HandshakeError::Crypto);
-        }
-        // Identify the initiator from the recovered static key.
-        let peer_pubkey = {
-            let rs = state.get_remote_static().ok_or(HandshakeError::Crypto)?;
-            if rs.len() != WG_KEY_LEN {
-                return Err(HandshakeError::Crypto);
-            }
-            let mut pk = [0u8; WG_KEY_LEN];
-            pk.copy_from_slice(rs);
-            pk
-        };
-        if self.peer_arc(&peer_pubkey).is_none() {
-            return Err(HandshakeError::UnknownInitiator);
-        }
-
-        // Reserve our responder sender_index BEFORE emitting msg2. The
-        // responder completes synchronously in this call, so the pending
-        // entry is a bare reservation marker (state = None).
-        let local_index = self.reserve_pending(
-            peer_pubkey,
-            None,
-            peer_sender_index,
-            SessionRole::Responder,
-        )?;
-
-        // Build the snow msg2 body (empty Noise payload).
-        let mut noise_body = [0u8; MSG_RESPONSE_NOISE_LEN];
-        let n = match state.write_message(&[], &mut noise_body) {
-            Ok(n) => n,
-            Err(_) => {
-                self.release_pending(local_index);
-                return Err(HandshakeError::Crypto);
-            }
-        };
-        if n != MSG_RESPONSE_NOISE_LEN {
-            self.release_pending(local_index);
-            return Err(HandshakeError::Crypto);
-        }
-        // Frame the response: receiver_index echoes the initiator's
-        // sender_index; mac1 keys on the INITIATOR's public key (recipient).
-        if let Err(e) = handshake::build_response(
-            out,
-            local_index,
-            peer_sender_index,
-            &noise_body,
-            &peer_pubkey,
-        ) {
-            self.release_pending(local_index);
-            return Err(e.into());
-        }
-
-        // The handshake is complete on our side after writing msg2.
-        let transport = match state.into_stateless_transport_mode() {
-            Ok(t) => t,
-            Err(_) => {
-                self.release_pending(local_index);
-                return Err(HandshakeError::Crypto);
-            }
-        };
-        let session = Arc::new(WgSession::new_with_role(
-            transport,
-            local_index,
-            peer_sender_index,
-            peer_pubkey,
-            SessionRole::Responder,
-        ));
-        // Promote the reservation to a live session (clears the pending
-        // marker + per-peer marker, installs for demux). The responder
-        // session installs UNCONFIRMED — egress is gated until the first
-        // authenticated inbound transport record (WgSession key-confirmation).
-        self.promote_pending(local_index, peer_pubkey, session)?;
-        Ok((peer_pubkey, local_index))
-    }
-
-    /// Promote a completed pending handshake to a live session: install the
-    /// session for inbound demux + on the peer, then clear the reservation
-    /// bookkeeping. Returns the session's local index.
-    ///
-    /// Ordering matters: we `install_session` (which inserts the live entry
-    /// into `sessions_by_local_index` under `reconcile_lock`) BEFORE removing
-    /// the `pending` reservation. While install runs, the index is present
-    /// in BOTH `pending` and (newly) `by_index`; the index allocator in
-    /// `reserve_pending` rejects any candidate present in EITHER map (all
-    /// under `reconcile_lock`), so no concurrent handshake can claim this
-    /// index during the hand-off. Removing the reservation first would open
-    /// a window where the index is in neither map and a concurrent reserve
-    /// could collide.
-    fn promote_pending(
-        &self,
-        local_index: u32,
-        peer_pubkey: [u8; WG_KEY_LEN],
-        session: Arc<WgSession>,
-    ) -> Result<u32, HandshakeError> {
-        // Install the live session first. The reservation guaranteed
-        // `local_index` was free of any LIVE session; `install_session`
-        // re-checks under the reconcile lock and a same-index live collision
-        // here would be an engine bug.
-        let result = match self.install_session(&peer_pubkey, session) {
-            Ok(()) => Ok(local_index),
-            Err(InstallSessionError::UnknownPeer) => Err(HandshakeError::UnknownPeer),
-            Err(InstallSessionError::LocalIndexCollision) => Err(HandshakeError::Internal),
-        };
-        // Clear the reservation bookkeeping regardless of install outcome:
-        // on success the live entry now owns the index; on failure the
-        // reservation must not linger.
-        {
-            let mut pending = self.pending.write().unwrap();
-            pending.remove(&local_index);
-            let mut by_peer = self.pending_by_peer.write().unwrap();
-            if by_peer.get(&peer_pubkey) == Some(&local_index) {
-                by_peer.remove(&peer_pubkey);
-            }
-        }
-        result
-    }
-}
-
-/// Allocate a non-zero pseudo-random u32 for a handshake index. WG indices
-/// are opaque demux tags; uniqueness (not unpredictability) is what matters
-/// for correctness, but a random draw keeps collisions astronomically rare.
-/// Uses the OS RNG via `getrandom` (pulled in transitively); falls back to a
-/// time-seeded value only if that fails (never expected on Linux).
-fn rand_u32_nonzero() -> u32 {
-    let mut buf = [0u8; 4];
-    let v = if getrandom::getrandom(&mut buf).is_ok() {
-        u32::from_ne_bytes(buf)
-    } else {
-        // Extremely unlikely fallback; still non-zero below.
-        use std::time::{SystemTime, UNIX_EPOCH};
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
-            .unwrap_or(0x9e37_79b9)
-    };
-    if v == 0 { 0x9e37_79b9 } else { v }
 }
 
 /// Read the inner-IP packet's total length from its own header, so

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -54,12 +54,18 @@
 
 use super::allowed_ips::AllowedIps;
 use super::framing::{encode_data_header, parse_data_header};
+use super::handshake::{
+    self, FramingError, MSG_INIT_NOISE_LEN, MSG_RESPONSE_NOISE_LEN,
+};
 use super::peer::Peer;
-use super::session::{REJECT_AFTER_MESSAGES, ReplayDecision, WgSession};
+use super::session::{REJECT_AFTER_MESSAGES, ReplayDecision, SessionRole, WgSession};
+use super::tai64n::{TAI64N_LEN, Tai64nClock};
 use super::{
-    POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_NOISE_PATTERN, WG_PROTOCOL_ID_BYTES, WG_ZERO_PSK,
+    POLY1305_TAG_LEN, WG_DATA_HEADER_LEN, WG_KEY_LEN, WG_MSG_INIT_LEN, WG_MSG_RESPONSE_LEN,
+    WG_NOISE_PATTERN, WG_PROTOCOL_ID_BYTES, WG_ZERO_PSK,
 };
 use arc_swap::ArcSwap;
+use curve25519_dalek::MontgomeryPoint;
 use rustc_hash::FxHashMap;
 use snow::{Builder, HandshakeState};
 use std::mem::MaybeUninit;
@@ -108,6 +114,73 @@ pub(crate) enum InstallSessionError {
     /// `previous` session, which the demux map would no longer be
     /// able to resolve.
     LocalIndexCollision,
+}
+
+/// Errors that can fail the slow-path WG handshake build / consume.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HandshakeError {
+    /// The caller-supplied peer pubkey is not in the engine table.
+    UnknownPeer,
+    /// The on-wire framing was malformed or its MAC1 did not verify.
+    Framing(FramingError),
+    /// snow rejected the Noise message (bad AEAD tag, wrong key, etc.).
+    Crypto,
+    /// The responder's msg2 `receiver_index` did not match the
+    /// `sender_index` we reserved for this handshake — a spoofed or
+    /// misrouted response; drop it.
+    ReceiverIndexMismatch,
+    /// No pending handshake reservation matched the response's
+    /// `receiver_index`. Either the response is stale (the handshake
+    /// timed out and its reservation was released) or spoofed.
+    NoPendingHandshake,
+    /// snow `read_message` recovered the peer's static public key, but
+    /// it is not a configured peer in the engine table. (Responder path.)
+    UnknownInitiator,
+    /// Could not allocate a fresh, collision-free local index after
+    /// several attempts (astronomically unlikely with a 32-bit space).
+    IndexExhausted,
+    /// The output buffer was too small for the framed handshake message.
+    OutputTooSmall,
+    /// Internal snow / engine error building the handshake state.
+    Internal,
+}
+
+impl From<FramingError> for HandshakeError {
+    fn from(e: FramingError) -> Self {
+        HandshakeError::Framing(e)
+    }
+}
+
+/// A handshake in progress: the snow `HandshakeState` plus the metadata
+/// needed to promote it to a live session once the exchange completes.
+///
+/// Held in the engine keyed by OUR locally-chosen `sender_index` (the
+/// reserved index). Keeping `HandshakeState` engine-internal (rather than
+/// handed back to the caller and re-supplied) keeps the public API trading
+/// only byte slices / `[u8;32]` and pre-stages the S3 integration where the
+/// coordinator thread owns pending handshakes (SMR-6).
+struct PendingHandshake {
+    /// snow state, pumped to completion on the second message. `Some` for
+    /// an initiator handshake that must resume across the
+    /// `create_initiation` → `consume_response` call boundary; `None` for
+    /// a responder reservation, which completes synchronously inside
+    /// `consume_initiation_create_response` (the snow state never needs to
+    /// outlive that call, so the pending entry is a bare reservation
+    /// marker).
+    state: Option<HandshakeState>,
+    /// The peer this handshake is with (its static public key).
+    peer_pubkey: [u8; WG_KEY_LEN],
+    /// Our locally-chosen index (the reservation key). The peer echoes
+    /// it as the `receiver_index` of the message it sends back.
+    local_index: u32,
+    /// The peer's index, learned from the message it sent us. For the
+    /// responder path this is msg1.sender_index (known at reserve time);
+    /// for the initiator path it is filled in from msg2.sender_index on
+    /// completion.
+    peer_index: u32,
+    /// Initiator or responder — determines the session-confirmation gate
+    /// (see `WgSession`).
+    role: SessionRole,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -254,6 +327,32 @@ pub(crate) struct WgEngine {
     /// WG and wireguard-go both do this. snow internally zeroizes
     /// its own copies; this is for the engine's persistent copy.
     local_private_key: Zeroizing<[u8; 32]>,
+    /// Local X25519 static PUBLIC key, derived once at construction from
+    /// `local_private_key` via `MontgomeryPoint::mul_base_clamped` (the
+    /// same clamped base-point multiply snow uses for its static key).
+    /// Needed to verify the MAC1 on an INBOUND handshake message — kernel
+    /// WG keys mac1 on the recipient's static public key, and for an
+    /// inbound message the recipient is us. Derived once so the parse hot
+    /// path (slow path, but still) does not repeat the base-point multiply
+    /// and so a "private-key-as-public" swap cannot creep in.
+    local_public_key: [u8; WG_KEY_LEN],
+    /// Monotonic TAI64N clock for the initiator handshake timestamp.
+    /// In-process strict monotonicity; cross-restart persistence is a
+    /// future control-plane concern (#1703 S6).
+    tai64n_clock: Tai64nClock,
+    /// In-flight handshakes keyed by OUR reserved local index. A handshake
+    /// is inserted here (and its index reserved in `sessions_by_local_index`
+    /// as a placeholder) BEFORE the message carrying that index goes on the
+    /// wire, then promoted to a live `WgSession` on completion. See the
+    /// two-phase reservation discipline in `reserve_local_index`.
+    pending: RwLock<FxHashMap<u32, PendingHandshake>>,
+    /// At-most-one-pending-per-peer index: maps a peer pubkey to its
+    /// current pending reservation's local index. A new initiation from a
+    /// peer aborts that peer's prior pending reservation, bounding pending
+    /// state to O(configured peers) under a valid-MAC1 initiation flood
+    /// (the reservation step is reached only after snow authenticates the
+    /// static-key AEAD).
+    pending_by_peer: RwLock<FxHashMap<[u8; WG_KEY_LEN], u32>>,
     /// UDP port we listen on for inbound. Stored for diagnostics
     /// and for the slow-path responder.
     listen_port: u16,
@@ -277,8 +376,14 @@ pub(crate) struct WgEngine {
 
 impl WgEngine {
     pub(crate) fn new(config: WgEngineConfig) -> Self {
+        let local_public_key =
+            MontgomeryPoint::mul_base_clamped(config.local_private_key).to_bytes();
         let engine = Self {
             local_private_key: Zeroizing::new(config.local_private_key),
+            local_public_key,
+            tai64n_clock: Tai64nClock::new(),
+            pending: RwLock::new(FxHashMap::default()),
+            pending_by_peer: RwLock::new(FxHashMap::default()),
             listen_port: config.listen_port,
             table: ArcSwap::from_pointee(PeerTable::empty()),
             reconcile_lock: std::sync::Mutex::new(()),
@@ -286,6 +391,13 @@ impl WgEngine {
         };
         engine.reconcile_peers(&config.peers);
         engine
+    }
+
+    /// xpf's local static public key (X25519). The peer needs this to
+    /// configure us as its peer and to compute the MAC1 on messages it
+    /// sends us. Slow path / config-surface use.
+    pub(crate) fn local_public_key(&self) -> [u8; WG_KEY_LEN] {
+        self.local_public_key
     }
 
     pub(crate) fn listen_port(&self) -> u16 {
@@ -823,6 +935,414 @@ impl WgEngine {
             .psk(2, &WG_ZERO_PSK)?
             .build_responder()
     }
+
+    // ===================================================================
+    // WireGuard handshake — framed, both roles (#1709 S1)
+    //
+    // These compose snow + handshake.rs framing + the TAI64N clock into the
+    // full on-wire WG handshake. They run on the CONTROL/coordinator thread
+    // only — never the AF_XDP poll worker (the hot encap/decap paths never
+    // build a HandshakeState). Index allocation follows the two-phase
+    // reservation discipline: an index is reserved in `sessions_by_local_index`
+    // (as a placeholder via `pending`) BEFORE the message carrying it is
+    // emitted, so a concurrent handshake cannot steal it and blackhole the
+    // resulting session.
+    // ===================================================================
+
+    /// Reserve a fresh, collision-free local index and register a pending
+    /// handshake under it. Holds the `reconcile_lock` (serialized with
+    /// `install_session` / `reconcile_peers`) so the reservation is atomic
+    /// w.r.t. session install and peer removal.
+    ///
+    /// Enforces the at-most-one-pending-per-peer cap: if the peer already
+    /// has a pending reservation, it is aborted (removed from `pending` and
+    /// its placeholder dropped from the demux map) before the new one is
+    /// installed. Returns the reserved local index.
+    fn reserve_pending(
+        &self,
+        peer_pubkey: [u8; WG_KEY_LEN],
+        state: Option<HandshakeState>,
+        peer_index: u32,
+        role: SessionRole,
+    ) -> Result<u32, HandshakeError> {
+        let _guard = self.reconcile_lock.lock().unwrap();
+        let by_index = self.sessions_by_local_index.read().unwrap();
+        let mut pending = self.pending.write().unwrap();
+        let mut by_peer = self.pending_by_peer.write().unwrap();
+
+        // Abort any prior PENDING (not-yet-completed) handshake for this
+        // peer (DoS bound: at most one pending reservation per peer). The
+        // `pending_by_peer` marker is cleared by `promote_pending` on
+        // completion, so a still-present marker can only point at an
+        // incomplete reservation living in `pending` — NOT at a live
+        // session in `by_index`. We therefore drop only the `pending`
+        // entry and the marker; we must NOT touch `by_index`, or we would
+        // blackhole an already-established session for this peer that a
+        // prior completed handshake legitimately installed there.
+        if let Some(old_idx) = by_peer.remove(&peer_pubkey) {
+            pending.remove(&old_idx);
+        }
+
+        // Pick a fresh index not present as a live session OR a pending
+        // reservation. 32-bit space; a handful of tries is plenty.
+        let mut local_index = 0u32;
+        let mut found = false;
+        for _ in 0..8 {
+            let cand = rand_u32_nonzero();
+            if !by_index.contains_key(&cand) && !pending.contains_key(&cand) {
+                local_index = cand;
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return Err(HandshakeError::IndexExhausted);
+        }
+
+        // Reserve the index by recording the pending handshake. The
+        // reservation lives in `pending` (NOT in the live-session demux
+        // map): the index allocator above rejects any candidate already
+        // present in `pending` OR `by_index`, and the whole reserve/promote
+        // sequence is serialized by `reconcile_lock`, so a concurrent
+        // handshake or `install_session` cannot claim this index until we
+        // either promote it (insert the live session) or release it. decap
+        // never sees a half-built session because the live entry is only
+        // inserted by `promote_pending` → `install_session` on completion.
+        pending.insert(
+            local_index,
+            PendingHandshake {
+                state,
+                peer_pubkey,
+                local_index,
+                peer_index,
+                role,
+            },
+        );
+        by_peer.insert(peer_pubkey, local_index);
+        Ok(local_index)
+    }
+
+    /// Release a pending reservation (handshake failed before completion).
+    /// Removes it from `pending` and clears the `pending_by_peer` marker if
+    /// it still points at this index. A pending reservation lives only in
+    /// `pending` (never in the live-session demux map), so there is nothing
+    /// to undo in `sessions_by_local_index`. Idempotent.
+    fn release_pending(&self, local_index: u32) {
+        let _guard = self.reconcile_lock.lock().unwrap();
+        let mut pending = self.pending.write().unwrap();
+        if let Some(ph) = pending.remove(&local_index) {
+            let mut by_peer = self.pending_by_peer.write().unwrap();
+            // Only clear the peer→index map if it still points at us.
+            if by_peer.get(&ph.peer_pubkey) == Some(&local_index) {
+                by_peer.remove(&ph.peer_pubkey);
+            }
+        }
+    }
+
+    /// Number of in-flight (reserved-but-not-completed) handshakes. Test /
+    /// diagnostic accessor.
+    #[cfg(test)]
+    pub(crate) fn pending_count(&self) -> usize {
+        self.pending.read().unwrap().len()
+    }
+
+    /// Build a framed WG type-1 initiation toward `peer_pubkey`.
+    ///
+    /// Reserves a local sender_index FIRST, builds the snow msg1 body with
+    /// a fresh monotonic TAI64N as the Noise payload, and frames it (type,
+    /// reserved, sender_index, body, mac1 over the responder pubkey, mac2
+    /// zeros). On any failure after reservation the reservation is released.
+    /// Writes the 148-byte message at `out[0..148]` and returns the chosen
+    /// sender_index.
+    pub(crate) fn create_initiation(
+        &self,
+        peer_pubkey: &[u8; WG_KEY_LEN],
+        out: &mut [u8],
+    ) -> Result<u32, HandshakeError> {
+        if out.len() < WG_MSG_INIT_LEN {
+            return Err(HandshakeError::OutputTooSmall);
+        }
+        // Confirm the peer is configured before doing any work.
+        if self.peer_arc(peer_pubkey).is_none() {
+            return Err(HandshakeError::UnknownPeer);
+        }
+        let mut state = self
+            .build_initiator_handshake(peer_pubkey)
+            .map_err(|_| HandshakeError::Internal)?;
+
+        // Reserve the local index + register the pending handshake BEFORE
+        // emitting the message (two-phase reservation). For the initiator
+        // the peer_index is not yet known (filled from msg2); use 0 as a
+        // placeholder. The snow state is stashed after we write msg1 (which
+        // mutates it) so it can resume in `consume_response`.
+        let local_index =
+            self.reserve_pending(*peer_pubkey, None, 0, SessionRole::Initiator)?;
+
+        // Build the snow msg1 body with the TAI64N as the Noise payload.
+        let tai64n = self.tai64n_clock.now();
+        debug_assert_eq!(tai64n.len(), TAI64N_LEN);
+        let mut noise_body = [0u8; MSG_INIT_NOISE_LEN];
+        let n = match state.write_message(&tai64n, &mut noise_body) {
+            Ok(n) => n,
+            Err(_) => {
+                self.release_pending(local_index);
+                return Err(HandshakeError::Crypto);
+            }
+        };
+        if n != MSG_INIT_NOISE_LEN {
+            self.release_pending(local_index);
+            return Err(HandshakeError::Crypto);
+        }
+        // Frame it.
+        if let Err(e) = handshake::build_initiation(out, local_index, &noise_body, peer_pubkey) {
+            self.release_pending(local_index);
+            return Err(e.into());
+        }
+        // Stash the real (post-write) snow state into the pending entry so
+        // `consume_response` can resume it.
+        {
+            let mut pending = self.pending.write().unwrap();
+            if let Some(ph) = pending.get_mut(&local_index) {
+                ph.state = Some(state);
+            } else {
+                // Reservation vanished (aborted by a concurrent init for the
+                // same peer). Treat as a failed build.
+                return Err(HandshakeError::NoPendingHandshake);
+            }
+        }
+        Ok(local_index)
+    }
+
+    /// Consume a peer's framed WG type-2 response, complete the initiator
+    /// handshake, and install the derived transport session.
+    ///
+    /// Verifies the framing (mac1 over OUR public key) and that the
+    /// response's `receiver_index` matches a pending reservation we hold.
+    /// On success the pending handshake is promoted to a live `WgSession`
+    /// (initiator role, confirmed at install) and registered for inbound
+    /// demux. Returns the local index of the installed session.
+    pub(crate) fn consume_response(&self, msg: &[u8]) -> Result<u32, HandshakeError> {
+        let parsed = handshake::parse_response(msg, &self.local_public_key)?;
+        // Take the pending handshake addressed by receiver_index.
+        let mut ph = {
+            let mut pending = self.pending.write().unwrap();
+            pending
+                .remove(&parsed.receiver_index)
+                .ok_or(HandshakeError::NoPendingHandshake)?
+        };
+        // Copy the metadata out before consuming `ph.state` (avoids a
+        // partial-move borrow conflict).
+        let local_index = ph.local_index;
+        let peer_pubkey = ph.peer_pubkey;
+        let role = ph.role;
+        // It must be an initiator-role handshake (we sent msg1).
+        if role != SessionRole::Initiator || local_index != parsed.receiver_index {
+            // A mismatched role/index means this response does not belong to
+            // this reservation; drop it and release the now-removed entry's
+            // peer marker.
+            self.release_pending(parsed.receiver_index);
+            return Err(HandshakeError::ReceiverIndexMismatch);
+        }
+        // Recover the resumable initiator snow state.
+        let mut state = match ph.state.take() {
+            Some(s) => s,
+            None => {
+                // An initiator reservation must carry its snow state. A
+                // missing state means the reservation was never completed by
+                // create_initiation (e.g. aborted mid-build); drop it.
+                self.release_pending(parsed.receiver_index);
+                return Err(HandshakeError::NoPendingHandshake);
+            }
+        };
+        // Drive snow to completion with the peer's msg2 body.
+        let mut sink = [0u8; MSG_RESPONSE_NOISE_LEN];
+        if state.read_message(parsed.noise_body, &mut sink).is_err() {
+            self.release_pending(parsed.receiver_index);
+            return Err(HandshakeError::Crypto);
+        }
+        let transport = match state.into_stateless_transport_mode() {
+            Ok(t) => t,
+            Err(_) => {
+                self.release_pending(parsed.receiver_index);
+                return Err(HandshakeError::Crypto);
+            }
+        };
+        let session = Arc::new(WgSession::new_with_role(
+            transport,
+            local_index,
+            parsed.sender_index,
+            peer_pubkey,
+            SessionRole::Initiator,
+        ));
+        self.promote_pending(local_index, peer_pubkey, session)
+    }
+
+    /// Responder path: parse a peer's framed WG type-1 initiation, run snow
+    /// to recover the peer's static key + TAI64N, identify the configured
+    /// peer, build a framed WG type-2 response, reserve our responder
+    /// sender_index, and install the derived (unconfirmed) transport
+    /// session. Writes the 92-byte response at `out[0..92]` and returns
+    /// `(our_sender_index, peer_pubkey)`.
+    pub(crate) fn consume_initiation_create_response(
+        &self,
+        msg: &[u8],
+        out: &mut [u8],
+    ) -> Result<([u8; WG_KEY_LEN], u32), HandshakeError> {
+        if out.len() < WG_MSG_RESPONSE_LEN {
+            return Err(HandshakeError::OutputTooSmall);
+        }
+        // Verify framing (mac1 over OUR public key) and recover the body.
+        let parsed = handshake::parse_initiation(msg, &self.local_public_key)?;
+        let peer_sender_index = parsed.sender_index;
+
+        // Run the responder Noise read to recover the peer static key.
+        let mut state = self
+            .build_responder_handshake()
+            .map_err(|_| HandshakeError::Internal)?;
+        let mut ts_sink = [0u8; TAI64N_LEN];
+        // snow writes the recovered Noise payload (the peer's TAI64N) into
+        // ts_sink; the value is used by a compliant responder for handshake
+        // anti-replay. S1 derives the session and (per the (b+) boundary)
+        // does not yet enforce per-peer TAI64N anti-replay — that rides
+        // with the responder-hardening step. We still must READ it so snow
+        // advances the transcript.
+        if state.read_message(parsed.noise_body, &mut ts_sink).is_err() {
+            return Err(HandshakeError::Crypto);
+        }
+        // Identify the initiator from the recovered static key.
+        let peer_pubkey = {
+            let rs = state.get_remote_static().ok_or(HandshakeError::Crypto)?;
+            if rs.len() != WG_KEY_LEN {
+                return Err(HandshakeError::Crypto);
+            }
+            let mut pk = [0u8; WG_KEY_LEN];
+            pk.copy_from_slice(rs);
+            pk
+        };
+        if self.peer_arc(&peer_pubkey).is_none() {
+            return Err(HandshakeError::UnknownInitiator);
+        }
+
+        // Reserve our responder sender_index BEFORE emitting msg2. The
+        // responder completes synchronously in this call, so the pending
+        // entry is a bare reservation marker (state = None).
+        let local_index = self.reserve_pending(
+            peer_pubkey,
+            None,
+            peer_sender_index,
+            SessionRole::Responder,
+        )?;
+
+        // Build the snow msg2 body (empty Noise payload).
+        let mut noise_body = [0u8; MSG_RESPONSE_NOISE_LEN];
+        let n = match state.write_message(&[], &mut noise_body) {
+            Ok(n) => n,
+            Err(_) => {
+                self.release_pending(local_index);
+                return Err(HandshakeError::Crypto);
+            }
+        };
+        if n != MSG_RESPONSE_NOISE_LEN {
+            self.release_pending(local_index);
+            return Err(HandshakeError::Crypto);
+        }
+        // Frame the response: receiver_index echoes the initiator's
+        // sender_index; mac1 keys on the INITIATOR's public key (recipient).
+        if let Err(e) = handshake::build_response(
+            out,
+            local_index,
+            peer_sender_index,
+            &noise_body,
+            &peer_pubkey,
+        ) {
+            self.release_pending(local_index);
+            return Err(e.into());
+        }
+
+        // The handshake is complete on our side after writing msg2.
+        let transport = match state.into_stateless_transport_mode() {
+            Ok(t) => t,
+            Err(_) => {
+                self.release_pending(local_index);
+                return Err(HandshakeError::Crypto);
+            }
+        };
+        let session = Arc::new(WgSession::new_with_role(
+            transport,
+            local_index,
+            peer_sender_index,
+            peer_pubkey,
+            SessionRole::Responder,
+        ));
+        // Promote the reservation to a live session (clears the pending
+        // marker + per-peer marker, installs for demux). The responder
+        // session installs UNCONFIRMED — egress is gated until the first
+        // authenticated inbound transport record (WgSession key-confirmation).
+        self.promote_pending(local_index, peer_pubkey, session)?;
+        Ok((peer_pubkey, local_index))
+    }
+
+    /// Promote a completed pending handshake to a live session: install the
+    /// session for inbound demux + on the peer, then clear the reservation
+    /// bookkeeping. Returns the session's local index.
+    ///
+    /// Ordering matters: we `install_session` (which inserts the live entry
+    /// into `sessions_by_local_index` under `reconcile_lock`) BEFORE removing
+    /// the `pending` reservation. While install runs, the index is present
+    /// in BOTH `pending` and (newly) `by_index`; the index allocator in
+    /// `reserve_pending` rejects any candidate present in EITHER map (all
+    /// under `reconcile_lock`), so no concurrent handshake can claim this
+    /// index during the hand-off. Removing the reservation first would open
+    /// a window where the index is in neither map and a concurrent reserve
+    /// could collide.
+    fn promote_pending(
+        &self,
+        local_index: u32,
+        peer_pubkey: [u8; WG_KEY_LEN],
+        session: Arc<WgSession>,
+    ) -> Result<u32, HandshakeError> {
+        // Install the live session first. The reservation guaranteed
+        // `local_index` was free of any LIVE session; `install_session`
+        // re-checks under the reconcile lock and a same-index live collision
+        // here would be an engine bug.
+        let result = match self.install_session(&peer_pubkey, session) {
+            Ok(()) => Ok(local_index),
+            Err(InstallSessionError::UnknownPeer) => Err(HandshakeError::UnknownPeer),
+            Err(InstallSessionError::LocalIndexCollision) => Err(HandshakeError::Internal),
+        };
+        // Clear the reservation bookkeeping regardless of install outcome:
+        // on success the live entry now owns the index; on failure the
+        // reservation must not linger.
+        {
+            let mut pending = self.pending.write().unwrap();
+            pending.remove(&local_index);
+            let mut by_peer = self.pending_by_peer.write().unwrap();
+            if by_peer.get(&peer_pubkey) == Some(&local_index) {
+                by_peer.remove(&peer_pubkey);
+            }
+        }
+        result
+    }
+}
+
+/// Allocate a non-zero pseudo-random u32 for a handshake index. WG indices
+/// are opaque demux tags; uniqueness (not unpredictability) is what matters
+/// for correctness, but a random draw keeps collisions astronomically rare.
+/// Uses the OS RNG via `getrandom` (pulled in transitively); falls back to a
+/// time-seeded value only if that fails (never expected on Linux).
+fn rand_u32_nonzero() -> u32 {
+    let mut buf = [0u8; 4];
+    let v = if getrandom::getrandom(&mut buf).is_ok() {
+        u32::from_ne_bytes(buf)
+    } else {
+        // Extremely unlikely fallback; still non-zero below.
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0x9e37_79b9)
+    };
+    if v == 0 { 0x9e37_79b9 } else { v }
 }
 
 /// Read the inner-IP packet's total length from its own header, so

--- a/userspace-dp/src/afxdp/wg/handshake.rs
+++ b/userspace-dp/src/afxdp/wg/handshake.rs
@@ -94,8 +94,12 @@ const _: () = assert!(M2_MAC2 + WG_MAC_LEN == WG_MSG_RESPONSE_LEN);
 /// path counts them); a malformed or unauthenticated message is dropped.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FramingError {
-    /// Buffer shorter than the fixed message length.
-    TooShort,
+    /// The datagram length is not EXACTLY the fixed message size. WG
+    /// handshake messages are fixed-length (148 / 92 bytes); kernel WG and
+    /// wireguard-go reject `len != MessageInitiationSize` / `MessageResponseSize`
+    /// outright. We reject both too-short AND too-long (a trailing-garbage
+    /// datagram whose 148/92-byte prefix happens to verify must not parse).
+    WrongLength,
     /// Output buffer too small to hold the framed message.
     OutputTooSmall,
     /// `message_type` byte is not the expected 1 (init) or 2 (response).
@@ -204,7 +208,11 @@ pub(crate) fn parse_initiation<'a>(
     msg: &'a [u8],
     our_static_pub: &[u8; WG_KEY_LEN],
 ) -> Result<ParsedInitiation<'a>, FramingError> {
-    let msg = msg.get(..WG_MSG_INIT_LEN).ok_or(FramingError::TooShort)?;
+    // WG handshake messages are fixed-length; require EXACTLY 148 bytes
+    // (kernel WG / wireguard-go reject any other length).
+    if msg.len() != WG_MSG_INIT_LEN {
+        return Err(FramingError::WrongLength);
+    }
     // WG's message_type is a 32-bit little-endian word: a canonical
     // initiation is exactly 0x00000001, i.e. type byte = 1 AND the three
     // reserved bytes = 0. wireguard-go / kernel WG read the full u32 and
@@ -299,7 +307,9 @@ pub(crate) fn parse_response<'a>(
     msg: &'a [u8],
     our_static_pub: &[u8; WG_KEY_LEN],
 ) -> Result<ParsedResponse<'a>, FramingError> {
-    let msg = msg.get(..WG_MSG_RESPONSE_LEN).ok_or(FramingError::TooShort)?;
+    if msg.len() != WG_MSG_RESPONSE_LEN {
+        return Err(FramingError::WrongLength);
+    }
     // Strict 32-bit LE type word (type byte 2 + zero reserved). See
     // `parse_initiation` / `is_canonical_type`.
     if !is_canonical_type(msg, WG_TYPE_RESPONSE) {
@@ -523,13 +533,37 @@ mod tests {
     }
 
     #[test]
-    fn parse_rejects_short_and_bad_type() {
+    fn parse_rejects_wrong_length_and_bad_type() {
         let pub_k = [0x99u8; 32];
         // Too short.
         assert_eq!(
             parse_initiation(&[0u8; 100], &pub_k).unwrap_err(),
-            FramingError::TooShort
+            FramingError::WrongLength
         );
+        // Too LONG: a valid 148-byte msg1 with trailing garbage must be
+        // rejected (Copilot finding — fixed-length messages, no truncation).
+        let resp_pub = [0x5Bu8; 32];
+        let noise = [0x2Du8; MSG_INIT_NOISE_LEN];
+        let mut over = vec![0u8; WG_MSG_INIT_LEN + 8];
+        build_initiation(&mut over[..WG_MSG_INIT_LEN], 9, &noise, &resp_pub).unwrap();
+        assert_eq!(
+            parse_initiation(&over, &resp_pub).unwrap_err(),
+            FramingError::WrongLength,
+            "an oversized datagram must NOT parse by truncation"
+        );
+        // The exact-length prefix still parses on its own.
+        assert!(parse_initiation(&over[..WG_MSG_INIT_LEN], &resp_pub).is_ok());
+
+        // Same for the response: too-long is rejected.
+        let init_pub = [0x6Cu8; 32];
+        let rnoise = [0x3Eu8; MSG_RESPONSE_NOISE_LEN];
+        let mut rover = vec![0u8; WG_MSG_RESPONSE_LEN + 4];
+        build_response(&mut rover[..WG_MSG_RESPONSE_LEN], 1, 2, &rnoise, &init_pub).unwrap();
+        assert_eq!(
+            parse_response(&rover, &init_pub).unwrap_err(),
+            FramingError::WrongLength
+        );
+
         // Wrong type byte (response bytes parsed as initiation).
         let mut buf = [0u8; WG_MSG_INIT_LEN];
         buf[0] = WG_TYPE_RESPONSE;

--- a/userspace-dp/src/afxdp/wg/handshake.rs
+++ b/userspace-dp/src/afxdp/wg/handshake.rs
@@ -356,16 +356,23 @@ mod tests {
         assert_eq!(hex(&ih), ih_hex);
     }
 
-    /// MAC1 KAT: keyed-BLAKE2s-128, NOT HMAC. Dual-source — assert the
-    /// baked hex AND re-derive `compute_mac1`'s key independently. Also
-    /// assert HMAC over the same inputs is DIFFERENT, locking the
-    /// keyed-vs-HMAC distinction (Codex round-2 computed the HMAC value).
+    /// MAC1 KAT: keyed-BLAKE2s-128, NOT HMAC. Dual-source — assert the baked
+    /// hex AND re-derive `compute_mac1`'s key independently. The baked value
+    /// `78df3b0a...` is the keyed-BLAKE2s-128 output; an HMAC-BLAKE2s
+    /// implementation over the same key + message would instead produce
+    /// `778123b8eb3dffafb3cc980b88b84bbc` (independently computed by Codex in
+    /// the plan-review), so pinning the keyed value to this exact hex would
+    /// fail loudly if `compute_mac1` were ever switched to HMAC — locking the
+    /// keyed-vs-HMAC distinction without taking an `hmac` dependency.
     #[test]
     fn mac1_keyed_blake2s_128_kat() {
         let pk = [0x42u8; 32];
-        // compute_mac1 over message "abc".
+        // compute_mac1 over message "abc" — the keyed-BLAKE2s-128 value.
         let mac = compute_mac1(&pk, b"abc");
         assert_eq!(hex(&mac), "78df3b0a90577688ce9d272d04a8fb90");
+        // The HMAC-BLAKE2s value over the same inputs is documented-different;
+        // this is NOT it, confirming compute_mac1 is keyed-BLAKE2s.
+        assert_ne!(hex(&mac), "778123b8eb3dffafb3cc980b88b84bbc");
 
         // Independently re-derive the MAC1 key and confirm.
         let key = {

--- a/userspace-dp/src/afxdp/wg/handshake.rs
+++ b/userspace-dp/src/afxdp/wg/handshake.rs
@@ -1,0 +1,558 @@
+//! WireGuard on-wire handshake-message framing (message types 1 and 2).
+//!
+//! The engine ([`super::engine`]) drives the Noise IKpsk2 handshake through
+//! `snow`, which emits only the raw Noise message body. This module wraps
+//! that body in the WireGuard outer framing so the bytes are byte-identical
+//! to what kernel WireGuard / wireguard-go / UniFi put on the wire:
+//!
+//! ## Message 1 — Handshake Initiation (148 bytes)
+//!
+//! ```text
+//!   off  size  field
+//!    0    1    message_type = 1
+//!    1    3    reserved_zero = {0,0,0}
+//!    4    4    sender_index            (LE u32, initiator-chosen)
+//!    8   32    unencrypted_ephemeral   ─┐
+//!   40   48    encrypted_static (32+16) ├─ snow IK msg1 body (108 bytes)
+//!   88   28    encrypted_timestamp(12+16)┘  Noise payload = 12-byte TAI64N
+//!  116   16    mac1
+//!  132   16    mac2
+//! ```
+//!
+//! ## Message 2 — Handshake Response (92 bytes)
+//!
+//! ```text
+//!   off  size  field
+//!    0    1    message_type = 2
+//!    1    3    reserved_zero = {0,0,0}
+//!    4    4    sender_index            (LE u32, responder-chosen)
+//!    8    4    receiver_index          (LE u32, echoes msg1.sender_index)
+//!   12   32    unencrypted_ephemeral   ─┐ snow IK msg2 body (48 bytes)
+//!   44   16    encrypted_nothing (0+16) ┘  Noise payload = empty
+//!   60   16    mac1
+//!   76   16    mac2
+//! ```
+//!
+//! ## MAC1
+//!
+//! `mac1 = keyed-BLAKE2s-128(key, msg[0 .. offsetof(mac1)])` where
+//! `key = BLAKE2s-256(LABEL_MAC1 || recipient_static_public)` and
+//! `LABEL_MAC1 = b"mac1----"`. The MAC keys on the RECIPIENT's static
+//! public key: for msg1 the recipient is the responder, for msg2 the
+//! recipient is the initiator. This is keyed-BLAKE2s, NOT HMAC — the KAT
+//! tests pin the distinction (an HMAC over the same key/message yields a
+//! different value).
+//!
+//! ## MAC2
+//!
+//! `mac2 = keyed-BLAKE2s-128(last_received_cookie, msg[0 .. offsetof(mac2)])`
+//! or all-zeros when no cookie has been received. S1 only ever emits zeros
+//! (cookie/type-3 handling is #1703 S7) and SKIP-verifies inbound mac2 (a
+//! peer holding our cookie sets it; treating non-zero as malformed would
+//! wrongly drop such a peer). mac2 generation/verification lands in S7.
+
+use blake2::Blake2s256;
+use blake2::Blake2sMac;
+use blake2::digest::consts::U16;
+use blake2::digest::{FixedOutput, KeyInit, Update};
+use blake2::digest::Digest;
+
+use super::{
+    WG_KEY_LEN, WG_LABEL_MAC1, WG_MAC_LEN, WG_MSG_INIT_LEN, WG_MSG_RESPONSE_LEN,
+    WG_TYPE_INITIATION, WG_TYPE_RESPONSE,
+};
+
+/// snow IK message-1 Noise body length:
+///   ephemeral(32) + encrypted_static(32+16) + encrypted_timestamp(12+16).
+pub(crate) const MSG_INIT_NOISE_LEN: usize = 32 + (32 + 16) + (12 + 16); // 108
+
+/// snow IK message-2 Noise body length:
+///   ephemeral(32) + encrypted_nothing(0+16).
+pub(crate) const MSG_RESPONSE_NOISE_LEN: usize = 32 + 16; // 48
+
+// Message-1 field offsets.
+const M1_TYPE: usize = 0;
+const M1_SENDER: usize = 4;
+const M1_NOISE: usize = 8;
+const M1_MAC1: usize = M1_NOISE + MSG_INIT_NOISE_LEN; // 116
+const M1_MAC2: usize = M1_MAC1 + WG_MAC_LEN; // 132
+
+// Message-2 field offsets.
+const M2_TYPE: usize = 0;
+const M2_SENDER: usize = 4;
+const M2_RECEIVER: usize = 8;
+const M2_NOISE: usize = 12;
+const M2_MAC1: usize = M2_NOISE + MSG_RESPONSE_NOISE_LEN; // 60
+const M2_MAC2: usize = M2_MAC1 + WG_MAC_LEN; // 76
+
+// Compile-time invariants: the offset arithmetic must agree with the
+// published wire lengths.
+const _: () = assert!(M1_MAC2 + WG_MAC_LEN == WG_MSG_INIT_LEN);
+const _: () = assert!(M2_MAC2 + WG_MAC_LEN == WG_MSG_RESPONSE_LEN);
+
+/// Framing errors. All variants are non-fatal at the call site (the slow
+/// path counts them); a malformed or unauthenticated message is dropped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FramingError {
+    /// Buffer shorter than the fixed message length.
+    TooShort,
+    /// Output buffer too small to hold the framed message.
+    OutputTooSmall,
+    /// `message_type` byte is not the expected 1 (init) or 2 (response).
+    BadType,
+    /// The supplied Noise body length does not match the message type.
+    BadNoiseLen,
+    /// mac1 did not verify against `BLAKE2s-256(LABEL_MAC1 || our_pub)`.
+    /// A compliant peer (and kernel WG) drops the datagram here, before
+    /// any Noise crypto.
+    Mac1Mismatch,
+}
+
+/// Compute the keyed-BLAKE2s-128 MAC1 over `data` using the recipient's
+/// static public key.
+///
+/// `key = BLAKE2s-256(LABEL_MAC1 || recipient_static_pub)`,
+/// `mac1 = keyed-BLAKE2s-128(key, data)`.
+///
+/// Slow path only (handshake build/parse), never per-packet.
+pub(crate) fn compute_mac1(recipient_static_pub: &[u8; WG_KEY_LEN], data: &[u8]) -> [u8; WG_MAC_LEN] {
+    // key = BLAKE2s-256("mac1----" || recipient_pub)
+    let mut hasher = Blake2s256::new();
+    Digest::update(&mut hasher, WG_LABEL_MAC1);
+    Digest::update(&mut hasher, recipient_static_pub);
+    let key = hasher.finalize();
+
+    // mac1 = keyed-BLAKE2s with 16-byte output. NOT HMAC.
+    let mut mac = <Blake2sMac<U16> as KeyInit>::new_from_slice(&key)
+        .expect("BLAKE2s-256 digest is a valid 32-byte BLAKE2s key");
+    Update::update(&mut mac, data);
+    let mut out = [0u8; WG_MAC_LEN];
+    FixedOutput::finalize_into(mac, (&mut out).into());
+    out
+}
+
+/// Constant-time-ish comparison of two 16-byte MACs. MAC1 is computed over
+/// public inputs (the message + a public key + a public label), so it is
+/// not a secret-key comparison in the AEAD sense; nonetheless we avoid an
+/// early-return byte loop to keep the habit. (`subtle` is not a dep here;
+/// the fold avoids the short-circuit.)
+#[inline]
+fn macs_equal(a: &[u8; WG_MAC_LEN], b: &[u8; WG_MAC_LEN]) -> bool {
+    let mut diff = 0u8;
+    for i in 0..WG_MAC_LEN {
+        diff |= a[i] ^ b[i];
+    }
+    diff == 0
+}
+
+/// A WG type-1 initiation produced by [`build_initiation`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BuiltInitiation {
+    pub len: usize,
+}
+
+/// Frame a WG type-1 initiation around a snow msg1 Noise body.
+///
+/// - `out` must be at least [`WG_MSG_INIT_LEN`] (148) bytes; the framed
+///   message is written at `out[0..148]`.
+/// - `sender_index` is the initiator's locally-chosen index (LE on wire).
+/// - `noise_body` is exactly what snow `write_message(tai64n, ..)` produced
+///   — must be [`MSG_INIT_NOISE_LEN`] (108) bytes.
+/// - `responder_static_pub` keys mac1 (the recipient of msg1).
+/// - mac2 is all-zeros in S1.
+pub(crate) fn build_initiation(
+    out: &mut [u8],
+    sender_index: u32,
+    noise_body: &[u8],
+    responder_static_pub: &[u8; WG_KEY_LEN],
+) -> Result<BuiltInitiation, FramingError> {
+    if noise_body.len() != MSG_INIT_NOISE_LEN {
+        return Err(FramingError::BadNoiseLen);
+    }
+    let msg = out.get_mut(..WG_MSG_INIT_LEN).ok_or(FramingError::OutputTooSmall)?;
+    msg[M1_TYPE] = WG_TYPE_INITIATION;
+    msg[1] = 0;
+    msg[2] = 0;
+    msg[3] = 0;
+    msg[M1_SENDER..M1_SENDER + 4].copy_from_slice(&sender_index.to_le_bytes());
+    msg[M1_NOISE..M1_MAC1].copy_from_slice(noise_body);
+    // mac1 over msg[0..116].
+    let mac1 = compute_mac1(responder_static_pub, &msg[..M1_MAC1]);
+    msg[M1_MAC1..M1_MAC2].copy_from_slice(&mac1);
+    // mac2 = zeros (S1).
+    msg[M1_MAC2..WG_MSG_INIT_LEN].fill(0);
+    Ok(BuiltInitiation {
+        len: WG_MSG_INIT_LEN,
+    })
+}
+
+/// A parsed WG type-1 initiation. Borrows the Noise body from the input.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ParsedInitiation<'a> {
+    pub sender_index: u32,
+    pub noise_body: &'a [u8],
+}
+
+/// Parse + authenticate a WG type-1 initiation.
+///
+/// `our_static_pub` is xpf's own static public key — the recipient key for
+/// an inbound initiation; mac1 is verified against
+/// `BLAKE2s-256(LABEL_MAC1 || our_static_pub)`. mac2 is NOT verified in S1
+/// (skip-verify; a peer holding our cookie legitimately sets it). The
+/// returned `noise_body` (108 bytes) is fed to snow `read_message`.
+pub(crate) fn parse_initiation<'a>(
+    msg: &'a [u8],
+    our_static_pub: &[u8; WG_KEY_LEN],
+) -> Result<ParsedInitiation<'a>, FramingError> {
+    let msg = msg.get(..WG_MSG_INIT_LEN).ok_or(FramingError::TooShort)?;
+    if msg[M1_TYPE] != WG_TYPE_INITIATION {
+        return Err(FramingError::BadType);
+    }
+    // Verify mac1 over msg[0..116] BEFORE handing the body to snow — kernel
+    // WG drops on a bad mac1 before any crypto, and so do we.
+    let expect = compute_mac1(our_static_pub, &msg[..M1_MAC1]);
+    let got = {
+        let mut m = [0u8; WG_MAC_LEN];
+        m.copy_from_slice(&msg[M1_MAC1..M1_MAC2]);
+        m
+    };
+    if !macs_equal(&expect, &got) {
+        return Err(FramingError::Mac1Mismatch);
+    }
+    // bytes [1..4] reserved (accept non-zero for robustness); mac2 skipped.
+    let sender_index = u32::from_le_bytes([msg[4], msg[5], msg[6], msg[7]]);
+    Ok(ParsedInitiation {
+        sender_index,
+        noise_body: &msg[M1_NOISE..M1_MAC1],
+    })
+}
+
+/// A WG type-2 response produced by [`build_response`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BuiltResponse {
+    pub len: usize,
+}
+
+/// Frame a WG type-2 response around a snow msg2 Noise body.
+///
+/// - `out` must be at least [`WG_MSG_RESPONSE_LEN`] (92) bytes.
+/// - `sender_index` is the responder's locally-chosen index.
+/// - `receiver_index` MUST echo the initiator's msg1 sender_index.
+/// - `noise_body` is snow `write_message(&[], ..)` output — must be
+///   [`MSG_RESPONSE_NOISE_LEN`] (48) bytes.
+/// - `initiator_static_pub` keys mac1 (the recipient of msg2).
+pub(crate) fn build_response(
+    out: &mut [u8],
+    sender_index: u32,
+    receiver_index: u32,
+    noise_body: &[u8],
+    initiator_static_pub: &[u8; WG_KEY_LEN],
+) -> Result<BuiltResponse, FramingError> {
+    if noise_body.len() != MSG_RESPONSE_NOISE_LEN {
+        return Err(FramingError::BadNoiseLen);
+    }
+    let msg = out.get_mut(..WG_MSG_RESPONSE_LEN).ok_or(FramingError::OutputTooSmall)?;
+    msg[M2_TYPE] = WG_TYPE_RESPONSE;
+    msg[1] = 0;
+    msg[2] = 0;
+    msg[3] = 0;
+    msg[M2_SENDER..M2_SENDER + 4].copy_from_slice(&sender_index.to_le_bytes());
+    msg[M2_RECEIVER..M2_RECEIVER + 4].copy_from_slice(&receiver_index.to_le_bytes());
+    msg[M2_NOISE..M2_MAC1].copy_from_slice(noise_body);
+    let mac1 = compute_mac1(initiator_static_pub, &msg[..M2_MAC1]);
+    msg[M2_MAC1..M2_MAC2].copy_from_slice(&mac1);
+    msg[M2_MAC2..WG_MSG_RESPONSE_LEN].fill(0);
+    Ok(BuiltResponse {
+        len: WG_MSG_RESPONSE_LEN,
+    })
+}
+
+/// A parsed WG type-2 response. Borrows the Noise body from the input.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ParsedResponse<'a> {
+    pub sender_index: u32,
+    pub receiver_index: u32,
+    pub noise_body: &'a [u8],
+}
+
+/// Parse + authenticate a WG type-2 response. `our_static_pub` is xpf's own
+/// static public key (the recipient of a response is the initiator = us).
+/// mac1 verified; mac2 skipped (S1).
+pub(crate) fn parse_response<'a>(
+    msg: &'a [u8],
+    our_static_pub: &[u8; WG_KEY_LEN],
+) -> Result<ParsedResponse<'a>, FramingError> {
+    let msg = msg.get(..WG_MSG_RESPONSE_LEN).ok_or(FramingError::TooShort)?;
+    if msg[M2_TYPE] != WG_TYPE_RESPONSE {
+        return Err(FramingError::BadType);
+    }
+    let expect = compute_mac1(our_static_pub, &msg[..M2_MAC1]);
+    let got = {
+        let mut m = [0u8; WG_MAC_LEN];
+        m.copy_from_slice(&msg[M2_MAC1..M2_MAC2]);
+        m
+    };
+    if !macs_equal(&expect, &got) {
+        return Err(FramingError::Mac1Mismatch);
+    }
+    let sender_index = u32::from_le_bytes([msg[4], msg[5], msg[6], msg[7]]);
+    let receiver_index = u32::from_le_bytes([msg[8], msg[9], msg[10], msg[11]]);
+    Ok(ParsedResponse {
+        sender_index,
+        receiver_index,
+        noise_body: &msg[M2_NOISE..M2_MAC1],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Independently re-derive the WG construction hashes the same way the
+    /// reference does (`InitialChainKey = BLAKE2s-256(NoiseConstruction)`,
+    /// `InitialHash = BLAKE2s-256(InitialChainKey || WGIdentifier)`), and
+    /// pin them to the canonical hex. Dual-source: a transcription typo
+    /// fails the hex, an impl/primitive bug fails the re-derivation. This
+    /// proves the `blake2` crate computes the WG hashes correctly even
+    /// though snow's prologue (not this module) is what mixes them at
+    /// runtime — it is the foundation the MAC1 KAT builds on.
+    #[test]
+    fn construction_hashes_match_spec() {
+        let ick = {
+            let mut h = Blake2s256::new();
+            Digest::update(&mut h, b"Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s");
+            h.finalize()
+        };
+        let ih = {
+            let mut h = Blake2s256::new();
+            Digest::update(&mut h, &ick);
+            Digest::update(&mut h, b"WireGuard v1 zx2c4 Jason@zx2c4.com");
+            h.finalize()
+        };
+        // Canonical values (computed offline from the WG construction; also
+        // reproduced here from first principles above).
+        let ick_hex = "60e26daef327efc02ec335e2a025d2d016eb4206f87277f52d38d1988b78cd36";
+        let ih_hex = "2211b361081ac566691243db458ad5322d9c6c662293e8b70ee19c65ba079ef3";
+        assert_eq!(hex(&ick), ick_hex);
+        assert_eq!(hex(&ih), ih_hex);
+    }
+
+    /// MAC1 KAT: keyed-BLAKE2s-128, NOT HMAC. Dual-source — assert the
+    /// baked hex AND re-derive `compute_mac1`'s key independently. Also
+    /// assert HMAC over the same inputs is DIFFERENT, locking the
+    /// keyed-vs-HMAC distinction (Codex round-2 computed the HMAC value).
+    #[test]
+    fn mac1_keyed_blake2s_128_kat() {
+        let pk = [0x42u8; 32];
+        // compute_mac1 over message "abc".
+        let mac = compute_mac1(&pk, b"abc");
+        assert_eq!(hex(&mac), "78df3b0a90577688ce9d272d04a8fb90");
+
+        // Independently re-derive the MAC1 key and confirm.
+        let key = {
+            let mut h = Blake2s256::new();
+            Digest::update(&mut h, b"mac1----");
+            Digest::update(&mut h, &pk);
+            h.finalize()
+        };
+        assert_eq!(
+            hex(&key),
+            "172c34d6807bd7acef1a2471f20e928626c23ce0b9f90b326cf5f82d12480a4e"
+        );
+    }
+
+    /// mac1 keys on the RECIPIENT's static pub: a msg1 built toward
+    /// responder R verifies under R's pubkey and FAILS under any other.
+    #[test]
+    fn mac1_keys_on_recipient_static_pub() {
+        let resp_pub = [0x11u8; 32];
+        let other_pub = [0x22u8; 32];
+        let noise = [0xABu8; MSG_INIT_NOISE_LEN];
+        let mut buf = [0u8; WG_MSG_INIT_LEN];
+        build_initiation(&mut buf, 0xDEADBEEF, &noise, &resp_pub).unwrap();
+
+        // Verifies under the responder pubkey it was built for.
+        assert!(parse_initiation(&buf, &resp_pub).is_ok());
+        // Fails under a different recipient pubkey.
+        assert_eq!(
+            parse_initiation(&buf, &other_pub).unwrap_err(),
+            FramingError::Mac1Mismatch
+        );
+    }
+
+    #[test]
+    fn msg1_layout_byte_offsets() {
+        let resp_pub = [0x33u8; 32];
+        let mut noise = [0u8; MSG_INIT_NOISE_LEN];
+        for (i, b) in noise.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        let mut buf = [0xFFu8; WG_MSG_INIT_LEN];
+        let built = build_initiation(&mut buf, 0x01020304, &noise, &resp_pub).unwrap();
+        assert_eq!(built.len, 148);
+        assert_eq!(buf[0], WG_TYPE_INITIATION);
+        assert_eq!(&buf[1..4], &[0, 0, 0], "reserved must be zero");
+        // sender_index is little-endian.
+        assert_eq!(&buf[4..8], &0x01020304u32.to_le_bytes());
+        assert_eq!(&buf[8..116], &noise, "noise body at offset 8..116");
+        // mac2 zeros.
+        assert_eq!(&buf[132..148], &[0u8; 16]);
+    }
+
+    #[test]
+    fn msg2_layout_byte_offsets() {
+        let init_pub = [0x44u8; 32];
+        let mut noise = [0u8; MSG_RESPONSE_NOISE_LEN];
+        for (i, b) in noise.iter_mut().enumerate() {
+            *b = (i + 1) as u8;
+        }
+        let mut buf = [0xFFu8; WG_MSG_RESPONSE_LEN];
+        let built = build_response(&mut buf, 0x0A0B0C0D, 0x01020304, &noise, &init_pub).unwrap();
+        assert_eq!(built.len, 92);
+        assert_eq!(buf[0], WG_TYPE_RESPONSE);
+        assert_eq!(&buf[1..4], &[0, 0, 0]);
+        assert_eq!(&buf[4..8], &0x0A0B0C0Du32.to_le_bytes(), "sender LE");
+        assert_eq!(&buf[8..12], &0x01020304u32.to_le_bytes(), "receiver LE");
+        assert_eq!(&buf[12..60], &noise, "noise body at offset 12..60");
+        assert_eq!(&buf[76..92], &[0u8; 16], "mac2 zeros");
+    }
+
+    /// Full byte-exact msg1 KAT with a fixed responder pubkey and a fixed
+    /// (deterministic) Noise body. This pins the entire framing assembly —
+    /// type byte, reserved, LE sender, body placement, and the mac1 over
+    /// msg[0..116] — so an offset or endianness bug in the assembly fails
+    /// here even when the per-field KATs pass. (The Noise body is a fixed
+    /// pattern rather than a real snow output: this module's job is the
+    /// framing assembly + mac1; the snow body byte-exactness is covered by
+    /// the engine self-handshake test and the S2 live kernel-WG interop.)
+    #[test]
+    fn msg1_full_kat_fixed_body() {
+        let resp_pub = [0x42u8; 32];
+        let mut noise = [0u8; MSG_INIT_NOISE_LEN];
+        for (i, b) in noise.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        let mut buf = [0u8; WG_MSG_INIT_LEN];
+        build_initiation(&mut buf, 0x11223344, &noise, &resp_pub).unwrap();
+
+        // Re-derive the expected mac1 independently of build_initiation's
+        // own path: assemble the prefix by hand and keyed-BLAKE2s it.
+        let mut prefix = Vec::with_capacity(116);
+        prefix.push(1u8);
+        prefix.extend_from_slice(&[0, 0, 0]);
+        prefix.extend_from_slice(&0x11223344u32.to_le_bytes());
+        prefix.extend_from_slice(&noise);
+        assert_eq!(prefix.len(), 116);
+        let expect_mac1 = compute_mac1(&resp_pub, &prefix);
+        assert_eq!(&buf[116..132], &expect_mac1, "mac1 over msg[0..116]");
+        assert_eq!(&buf[0..116], &prefix[..], "framed prefix byte-exact");
+        assert_eq!(&buf[132..148], &[0u8; 16], "mac2 zeros");
+    }
+
+    /// Full byte-exact msg2 KAT (mirror of msg1).
+    #[test]
+    fn msg2_full_kat_fixed_body() {
+        let init_pub = [0x42u8; 32];
+        let mut noise = [0u8; MSG_RESPONSE_NOISE_LEN];
+        for (i, b) in noise.iter_mut().enumerate() {
+            *b = (200 - i) as u8;
+        }
+        let mut buf = [0u8; WG_MSG_RESPONSE_LEN];
+        build_response(&mut buf, 0xAABBCCDD, 0x11223344, &noise, &init_pub).unwrap();
+
+        let mut prefix = Vec::with_capacity(60);
+        prefix.push(2u8);
+        prefix.extend_from_slice(&[0, 0, 0]);
+        prefix.extend_from_slice(&0xAABBCCDDu32.to_le_bytes());
+        prefix.extend_from_slice(&0x11223344u32.to_le_bytes());
+        prefix.extend_from_slice(&noise);
+        assert_eq!(prefix.len(), 60);
+        let expect_mac1 = compute_mac1(&init_pub, &prefix);
+        assert_eq!(&buf[60..76], &expect_mac1, "mac1 over msg[0..60]");
+        assert_eq!(&buf[0..60], &prefix[..], "framed prefix byte-exact");
+        assert_eq!(&buf[76..92], &[0u8; 16], "mac2 zeros");
+    }
+
+    #[test]
+    fn framing_roundtrip_initiation() {
+        let resp_pub = [0x55u8; 32];
+        let noise = [0x77u8; MSG_INIT_NOISE_LEN];
+        let mut buf = [0u8; WG_MSG_INIT_LEN];
+        build_initiation(&mut buf, 0xCAFEF00D, &noise, &resp_pub).unwrap();
+        let parsed = parse_initiation(&buf, &resp_pub).unwrap();
+        assert_eq!(parsed.sender_index, 0xCAFEF00D);
+        assert_eq!(parsed.noise_body, &noise);
+    }
+
+    #[test]
+    fn framing_roundtrip_response() {
+        let init_pub = [0x66u8; 32];
+        let noise = [0x88u8; MSG_RESPONSE_NOISE_LEN];
+        let mut buf = [0u8; WG_MSG_RESPONSE_LEN];
+        build_response(&mut buf, 0x12345678, 0x9ABCDEF0, &noise, &init_pub).unwrap();
+        let parsed = parse_response(&buf, &init_pub).unwrap();
+        assert_eq!(parsed.sender_index, 0x12345678);
+        assert_eq!(parsed.receiver_index, 0x9ABCDEF0);
+        assert_eq!(parsed.noise_body, &noise);
+    }
+
+    #[test]
+    fn parse_rejects_short_and_bad_type() {
+        let pub_k = [0x99u8; 32];
+        // Too short.
+        assert_eq!(
+            parse_initiation(&[0u8; 100], &pub_k).unwrap_err(),
+            FramingError::TooShort
+        );
+        // Wrong type byte (response bytes parsed as initiation).
+        let mut buf = [0u8; WG_MSG_INIT_LEN];
+        buf[0] = WG_TYPE_RESPONSE;
+        assert_eq!(parse_initiation(&buf, &pub_k).unwrap_err(), FramingError::BadType);
+    }
+
+    /// S1 must SKIP-verify mac2: a peer that holds our cookie sets a
+    /// non-zero mac2; treating it as malformed would wrongly drop the
+    /// initiation. mac1 still authenticates the message.
+    #[test]
+    fn parse_initiation_accepts_nonzero_mac2() {
+        let resp_pub = [0xAAu8; 32];
+        let noise = [0xBBu8; MSG_INIT_NOISE_LEN];
+        let mut buf = [0u8; WG_MSG_INIT_LEN];
+        build_initiation(&mut buf, 7, &noise, &resp_pub).unwrap();
+        // Stamp a non-zero mac2 (last 16 bytes) — must NOT affect parse,
+        // because mac1 (which covers only msg[0..116]) is unchanged.
+        buf[132..148].copy_from_slice(&[0xCD; 16]);
+        let parsed = parse_initiation(&buf, &resp_pub).expect("non-zero mac2 must parse");
+        assert_eq!(parsed.sender_index, 7);
+    }
+
+    #[test]
+    fn build_rejects_wrong_noise_len() {
+        let pub_k = [0u8; 32];
+        let mut buf = [0u8; WG_MSG_INIT_LEN];
+        assert_eq!(
+            build_initiation(&mut buf, 0, &[0u8; 10], &pub_k).unwrap_err(),
+            FramingError::BadNoiseLen
+        );
+        let mut buf2 = [0u8; WG_MSG_RESPONSE_LEN];
+        assert_eq!(
+            build_response(&mut buf2, 0, 0, &[0u8; 10], &pub_k).unwrap_err(),
+            FramingError::BadNoiseLen
+        );
+    }
+
+    #[test]
+    fn build_rejects_small_output() {
+        let pub_k = [0u8; 32];
+        let noise = [0u8; MSG_INIT_NOISE_LEN];
+        let mut small = [0u8; 100];
+        assert_eq!(
+            build_initiation(&mut small, 0, &noise, &pub_k).unwrap_err(),
+            FramingError::OutputTooSmall
+        );
+    }
+
+    fn hex(b: &[u8]) -> String {
+        b.iter().map(|x| format!("{x:02x}")).collect()
+    }
+}

--- a/userspace-dp/src/afxdp/wg/handshake.rs
+++ b/userspace-dp/src/afxdp/wg/handshake.rs
@@ -205,7 +205,14 @@ pub(crate) fn parse_initiation<'a>(
     our_static_pub: &[u8; WG_KEY_LEN],
 ) -> Result<ParsedInitiation<'a>, FramingError> {
     let msg = msg.get(..WG_MSG_INIT_LEN).ok_or(FramingError::TooShort)?;
-    if msg[M1_TYPE] != WG_TYPE_INITIATION {
+    // WG's message_type is a 32-bit little-endian word: a canonical
+    // initiation is exactly 0x00000001, i.e. type byte = 1 AND the three
+    // reserved bytes = 0. wireguard-go / kernel WG read the full u32 and
+    // reject a non-canonical high byte, so we do too (strict parse). This is
+    // also belt-and-suspenders: mac1 already covers bytes [0..116] including
+    // the reserved bytes, so a forged non-zero-reserved datagram would fail
+    // mac1 regardless — but rejecting it up front keeps us byte-strict.
+    if !is_canonical_type(msg, WG_TYPE_INITIATION) {
         return Err(FramingError::BadType);
     }
     // Verify mac1 over msg[0..116] BEFORE handing the body to snow — kernel
@@ -219,12 +226,22 @@ pub(crate) fn parse_initiation<'a>(
     if !macs_equal(&expect, &got) {
         return Err(FramingError::Mac1Mismatch);
     }
-    // bytes [1..4] reserved (accept non-zero for robustness); mac2 skipped.
+    // mac2 (msg[132..148]) is skip-verified in S1 (cookie handling is S7).
     let sender_index = u32::from_le_bytes([msg[4], msg[5], msg[6], msg[7]]);
     Ok(ParsedInitiation {
         sender_index,
         noise_body: &msg[M1_NOISE..M1_MAC1],
     })
+}
+
+/// True iff `msg`'s leading 4 bytes are exactly the little-endian u32
+/// `expected_type` — i.e. the type byte matches AND the three reserved bytes
+/// are zero. WG transmits `message_type` as a u32; a compliant peer's
+/// initiation/response always has zero reserved bytes.
+#[inline]
+fn is_canonical_type(msg: &[u8], expected_type: u8) -> bool {
+    let word = u32::from_le_bytes([msg[0], msg[1], msg[2], msg[3]]);
+    word == expected_type as u32
 }
 
 /// A WG type-2 response produced by [`build_response`].
@@ -283,7 +300,9 @@ pub(crate) fn parse_response<'a>(
     our_static_pub: &[u8; WG_KEY_LEN],
 ) -> Result<ParsedResponse<'a>, FramingError> {
     let msg = msg.get(..WG_MSG_RESPONSE_LEN).ok_or(FramingError::TooShort)?;
-    if msg[M2_TYPE] != WG_TYPE_RESPONSE {
+    // Strict 32-bit LE type word (type byte 2 + zero reserved). See
+    // `parse_initiation` / `is_canonical_type`.
+    if !is_canonical_type(msg, WG_TYPE_RESPONSE) {
         return Err(FramingError::BadType);
     }
     let expect = compute_mac1(our_static_pub, &msg[..M2_MAC1]);
@@ -508,6 +527,39 @@ mod tests {
         let mut buf = [0u8; WG_MSG_INIT_LEN];
         buf[0] = WG_TYPE_RESPONSE;
         assert_eq!(parse_initiation(&buf, &pub_k).unwrap_err(), FramingError::BadType);
+    }
+
+    /// Strict 32-bit-LE type word: a correct type byte but a NON-ZERO
+    /// reserved byte must be rejected (the type is the u32 `0x00000001`, not
+    /// just byte 0). A real WG peer always sends zero reserved bytes; this
+    /// rejects non-canonical datagrams up front (Codex code-review finding 3).
+    #[test]
+    fn parse_rejects_nonzero_reserved_bytes() {
+        let resp_pub = [0x5Au8; 32];
+        let noise = [0x3Cu8; MSG_INIT_NOISE_LEN];
+        let mut buf = [0u8; WG_MSG_INIT_LEN];
+        build_initiation(&mut buf, 0x1234, &noise, &resp_pub).unwrap();
+        // Sanity: canonical build parses.
+        assert!(parse_initiation(&buf, &resp_pub).is_ok());
+        // Flip a reserved byte — must be rejected as BadType (the high bytes
+        // of the type word are non-zero), regardless of mac1.
+        buf[2] = 0x01;
+        assert_eq!(
+            parse_initiation(&buf, &resp_pub).unwrap_err(),
+            FramingError::BadType
+        );
+
+        // Same for the response.
+        let init_pub = [0xA5u8; 32];
+        let rnoise = [0xC3u8; MSG_RESPONSE_NOISE_LEN];
+        let mut rbuf = [0u8; WG_MSG_RESPONSE_LEN];
+        build_response(&mut rbuf, 1, 2, &rnoise, &init_pub).unwrap();
+        assert!(parse_response(&rbuf, &init_pub).is_ok());
+        rbuf[1] = 0xFF;
+        assert_eq!(
+            parse_response(&rbuf, &init_pub).unwrap_err(),
+            FramingError::BadType
+        );
     }
 
     /// S1 must SKIP-verify mac2: a peer that holds our cookie sets a

--- a/userspace-dp/src/afxdp/wg/handshake_session.rs
+++ b/userspace-dp/src/afxdp/wg/handshake_session.rs
@@ -1,0 +1,507 @@
+//! WireGuard handshake orchestration on `WgEngine` (#1709 S1).
+//!
+//! This file holds the slow-path, control-thread-only handshake driver: the
+//! `HandshakeError` enum, the `PendingHandshake` reservation record, the
+//! two-phase index reservation, and the four engine entry points that
+//! compose `snow` + the `handshake` framing module + the `Tai64nClock` into
+//! the full on-wire WireGuard handshake in both roles.
+//!
+//! It is split out of `engine.rs` (which holds the `WgEngine` struct, the
+//! peer table, and the hot encap/decap paths) purely for modularity — these
+//! methods are `impl WgEngine` blocks in the same `wg` module and reach the
+//! engine's private fields directly. Keeping them here keeps `engine.rs`
+//! under the 2000-LOC refactor threshold and the security-critical handshake
+//! orchestration auditable in one place.
+//!
+//! None of this runs on the AF_XDP poll worker: the hot encap/decap paths in
+//! `engine.rs` never build a `HandshakeState`. Handshake construction +
+//! MAC1 keyed-BLAKE2s + X25519 happen on the control/coordinator thread.
+
+use super::engine::{InstallSessionError, WgEngine};
+use super::handshake::{self, FramingError, MSG_INIT_NOISE_LEN, MSG_RESPONSE_NOISE_LEN};
+use super::session::{SessionRole, WgSession};
+use super::tai64n::TAI64N_LEN;
+use super::{WG_KEY_LEN, WG_MSG_INIT_LEN, WG_MSG_RESPONSE_LEN};
+use snow::HandshakeState;
+use std::sync::Arc;
+
+/// Errors that can fail the slow-path WG handshake build / consume.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HandshakeError {
+    /// The caller-supplied peer pubkey is not in the engine table.
+    UnknownPeer,
+    /// The on-wire framing was malformed or its MAC1 did not verify.
+    Framing(FramingError),
+    /// snow rejected the Noise message (bad AEAD tag, wrong key, etc.).
+    Crypto,
+    /// The responder's msg2 `receiver_index` did not match the
+    /// `sender_index` we reserved for this handshake — a spoofed or
+    /// misrouted response; drop it.
+    ReceiverIndexMismatch,
+    /// No pending handshake reservation matched the response's
+    /// `receiver_index`. Either the response is stale (the handshake
+    /// timed out and its reservation was released) or spoofed.
+    NoPendingHandshake,
+    /// snow `read_message` recovered the peer's static public key, but
+    /// it is not a configured peer in the engine table. (Responder path.)
+    UnknownInitiator,
+    /// Could not allocate a fresh, collision-free local index after
+    /// several attempts (astronomically unlikely with a 32-bit space).
+    IndexExhausted,
+    /// The output buffer was too small for the framed handshake message.
+    OutputTooSmall,
+    /// Internal snow / engine error building the handshake state.
+    Internal,
+}
+
+impl From<FramingError> for HandshakeError {
+    fn from(e: FramingError) -> Self {
+        HandshakeError::Framing(e)
+    }
+}
+
+/// A handshake in progress: the snow `HandshakeState` plus the metadata
+/// needed to promote it to a live session once the exchange completes.
+///
+/// Held in the engine keyed by OUR locally-chosen `sender_index` (the
+/// reserved index). Keeping `HandshakeState` engine-internal (rather than
+/// handed back to the caller and re-supplied) keeps the public API trading
+/// only byte slices / `[u8;32]` and pre-stages the S3 integration where the
+/// coordinator thread owns pending handshakes (SMR-6).
+///
+/// `pub(in crate::afxdp::wg)` so `engine.rs`'s `WgEngine` struct can name the
+/// type in its `pending: RwLock<FxHashMap<u32, PendingHandshake>>` field; the
+/// fields stay module-private (only this file's methods read them).
+pub(in crate::afxdp::wg) struct PendingHandshake {
+    /// snow state, pumped to completion on the second message. `Some` for
+    /// an initiator handshake that must resume across the
+    /// `create_initiation` → `consume_response` call boundary; `None` for
+    /// a responder reservation, which completes synchronously inside
+    /// `consume_initiation_create_response` (the snow state never needs to
+    /// outlive that call, so the pending entry is a bare reservation
+    /// marker).
+    state: Option<HandshakeState>,
+    /// The peer this handshake is with (its static public key).
+    peer_pubkey: [u8; WG_KEY_LEN],
+    /// Our locally-chosen index (the reservation key). The peer echoes
+    /// it as the `receiver_index` of the message it sends back.
+    local_index: u32,
+    /// The peer's index, learned from the message it sent us. For the
+    /// responder path this is msg1.sender_index (known at reserve time);
+    /// for the initiator path it is filled in from msg2.sender_index on
+    /// completion.
+    peer_index: u32,
+    /// Initiator or responder — determines the session-confirmation gate
+    /// (see `WgSession`).
+    role: SessionRole,
+}
+
+impl WgEngine {
+    // ===================================================================
+    // WireGuard handshake — framed, both roles (#1709 S1)
+    //
+    // These compose snow + handshake.rs framing + the TAI64N clock into the
+    // full on-wire WG handshake. They run on the CONTROL/coordinator thread
+    // only — never the AF_XDP poll worker (the hot encap/decap paths never
+    // build a HandshakeState). Index allocation follows the two-phase
+    // reservation discipline: an index is reserved in `sessions_by_local_index`
+    // (as a placeholder via `pending`) BEFORE the message carrying it is
+    // emitted, so a concurrent handshake cannot steal it and blackhole the
+    // resulting session.
+    // ===================================================================
+
+    /// Reserve a fresh, collision-free local index and register a pending
+    /// handshake under it. Holds the `reconcile_lock` (serialized with
+    /// `install_session` / `reconcile_peers`) so the reservation is atomic
+    /// w.r.t. session install and peer removal.
+    ///
+    /// Enforces the at-most-one-pending-per-peer cap: if the peer already
+    /// has a pending reservation, it is aborted (removed from `pending` and
+    /// its placeholder dropped from the demux map) before the new one is
+    /// installed. Returns the reserved local index.
+    fn reserve_pending(
+        &self,
+        peer_pubkey: [u8; WG_KEY_LEN],
+        state: Option<HandshakeState>,
+        peer_index: u32,
+        role: SessionRole,
+    ) -> Result<u32, HandshakeError> {
+        let _guard = self.reconcile_lock.lock().unwrap();
+        let by_index = self.sessions_by_local_index.read().unwrap();
+        let mut pending = self.pending.write().unwrap();
+        let mut by_peer = self.pending_by_peer.write().unwrap();
+
+        // Abort any prior PENDING (not-yet-completed) handshake for this
+        // peer (DoS bound: at most one pending reservation per peer). The
+        // `pending_by_peer` marker is cleared by `promote_pending` on
+        // completion, so a still-present marker can only point at an
+        // incomplete reservation living in `pending` — NOT at a live
+        // session in `by_index`. We therefore drop only the `pending`
+        // entry and the marker; we must NOT touch `by_index`, or we would
+        // blackhole an already-established session for this peer that a
+        // prior completed handshake legitimately installed there.
+        if let Some(old_idx) = by_peer.remove(&peer_pubkey) {
+            pending.remove(&old_idx);
+        }
+
+        // Pick a fresh index not present as a live session OR a pending
+        // reservation. 32-bit space; a handful of tries is plenty.
+        let mut local_index = 0u32;
+        let mut found = false;
+        for _ in 0..8 {
+            let cand = rand_u32_nonzero();
+            if !by_index.contains_key(&cand) && !pending.contains_key(&cand) {
+                local_index = cand;
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return Err(HandshakeError::IndexExhausted);
+        }
+
+        // Reserve the index by recording the pending handshake. The
+        // reservation lives in `pending` (NOT in the live-session demux
+        // map): the index allocator above rejects any candidate already
+        // present in `pending` OR `by_index`, and the whole reserve/promote
+        // sequence is serialized by `reconcile_lock`, so a concurrent
+        // handshake or `install_session` cannot claim this index until we
+        // either promote it (insert the live session) or release it. decap
+        // never sees a half-built session because the live entry is only
+        // inserted by `promote_pending` → `install_session` on completion.
+        pending.insert(
+            local_index,
+            PendingHandshake {
+                state,
+                peer_pubkey,
+                local_index,
+                peer_index,
+                role,
+            },
+        );
+        by_peer.insert(peer_pubkey, local_index);
+        Ok(local_index)
+    }
+
+    /// Release a pending reservation (handshake failed before completion).
+    /// Removes it from `pending` and clears the `pending_by_peer` marker if
+    /// it still points at this index. A pending reservation lives only in
+    /// `pending` (never in the live-session demux map), so there is nothing
+    /// to undo in `sessions_by_local_index`. Idempotent.
+    fn release_pending(&self, local_index: u32) {
+        let _guard = self.reconcile_lock.lock().unwrap();
+        let mut pending = self.pending.write().unwrap();
+        if let Some(ph) = pending.remove(&local_index) {
+            let mut by_peer = self.pending_by_peer.write().unwrap();
+            // Only clear the peer→index map if it still points at us.
+            if by_peer.get(&ph.peer_pubkey) == Some(&local_index) {
+                by_peer.remove(&ph.peer_pubkey);
+            }
+        }
+    }
+
+    /// Number of in-flight (reserved-but-not-completed) handshakes. Test /
+    /// diagnostic accessor.
+    #[cfg(test)]
+    pub(crate) fn pending_count(&self) -> usize {
+        self.pending.read().unwrap().len()
+    }
+
+    /// Build a framed WG type-1 initiation toward `peer_pubkey`.
+    ///
+    /// Reserves a local sender_index FIRST, builds the snow msg1 body with
+    /// a fresh monotonic TAI64N as the Noise payload, and frames it (type,
+    /// reserved, sender_index, body, mac1 over the responder pubkey, mac2
+    /// zeros). On any failure after reservation the reservation is released.
+    /// Writes the 148-byte message at `out[0..148]` and returns the chosen
+    /// sender_index.
+    pub(crate) fn create_initiation(
+        &self,
+        peer_pubkey: &[u8; WG_KEY_LEN],
+        out: &mut [u8],
+    ) -> Result<u32, HandshakeError> {
+        if out.len() < WG_MSG_INIT_LEN {
+            return Err(HandshakeError::OutputTooSmall);
+        }
+        // Confirm the peer is configured before doing any work.
+        if self.peer_arc(peer_pubkey).is_none() {
+            return Err(HandshakeError::UnknownPeer);
+        }
+        let mut state = self
+            .build_initiator_handshake(peer_pubkey)
+            .map_err(|_| HandshakeError::Internal)?;
+
+        // Reserve the local index + register the pending handshake BEFORE
+        // emitting the message (two-phase reservation). For the initiator
+        // the peer_index is not yet known (filled from msg2); use 0 as a
+        // placeholder. The snow state is stashed after we write msg1 (which
+        // mutates it) so it can resume in `consume_response`.
+        let local_index =
+            self.reserve_pending(*peer_pubkey, None, 0, SessionRole::Initiator)?;
+
+        // Build the snow msg1 body with the TAI64N as the Noise payload.
+        let tai64n = self.tai64n_clock.now();
+        debug_assert_eq!(tai64n.len(), TAI64N_LEN);
+        let mut noise_body = [0u8; MSG_INIT_NOISE_LEN];
+        let n = match state.write_message(&tai64n, &mut noise_body) {
+            Ok(n) => n,
+            Err(_) => {
+                self.release_pending(local_index);
+                return Err(HandshakeError::Crypto);
+            }
+        };
+        if n != MSG_INIT_NOISE_LEN {
+            self.release_pending(local_index);
+            return Err(HandshakeError::Crypto);
+        }
+        // Frame it.
+        if let Err(e) = handshake::build_initiation(out, local_index, &noise_body, peer_pubkey) {
+            self.release_pending(local_index);
+            return Err(e.into());
+        }
+        // Stash the real (post-write) snow state into the pending entry so
+        // `consume_response` can resume it.
+        {
+            let mut pending = self.pending.write().unwrap();
+            if let Some(ph) = pending.get_mut(&local_index) {
+                ph.state = Some(state);
+            } else {
+                // Reservation vanished (aborted by a concurrent init for the
+                // same peer). Treat as a failed build.
+                return Err(HandshakeError::NoPendingHandshake);
+            }
+        }
+        Ok(local_index)
+    }
+
+    /// Consume a peer's framed WG type-2 response, complete the initiator
+    /// handshake, and install the derived transport session.
+    ///
+    /// Verifies the framing (mac1 over OUR public key) and that the
+    /// response's `receiver_index` matches a pending reservation we hold.
+    /// On success the pending handshake is promoted to a live `WgSession`
+    /// (initiator role, confirmed at install) and registered for inbound
+    /// demux. Returns the local index of the installed session.
+    pub(crate) fn consume_response(&self, msg: &[u8]) -> Result<u32, HandshakeError> {
+        let parsed = handshake::parse_response(msg, &self.local_public_key)?;
+        // Take the pending handshake addressed by receiver_index.
+        let mut ph = {
+            let mut pending = self.pending.write().unwrap();
+            pending
+                .remove(&parsed.receiver_index)
+                .ok_or(HandshakeError::NoPendingHandshake)?
+        };
+        // Copy the metadata out before consuming `ph.state` (avoids a
+        // partial-move borrow conflict).
+        let local_index = ph.local_index;
+        let peer_pubkey = ph.peer_pubkey;
+        let role = ph.role;
+        // It must be an initiator-role handshake (we sent msg1).
+        if role != SessionRole::Initiator || local_index != parsed.receiver_index {
+            // A mismatched role/index means this response does not belong to
+            // this reservation; drop it and release the now-removed entry's
+            // peer marker.
+            self.release_pending(parsed.receiver_index);
+            return Err(HandshakeError::ReceiverIndexMismatch);
+        }
+        // Recover the resumable initiator snow state.
+        let mut state = match ph.state.take() {
+            Some(s) => s,
+            None => {
+                // An initiator reservation must carry its snow state. A
+                // missing state means the reservation was never completed by
+                // create_initiation (e.g. aborted mid-build); drop it.
+                self.release_pending(parsed.receiver_index);
+                return Err(HandshakeError::NoPendingHandshake);
+            }
+        };
+        // Drive snow to completion with the peer's msg2 body.
+        let mut sink = [0u8; MSG_RESPONSE_NOISE_LEN];
+        if state.read_message(parsed.noise_body, &mut sink).is_err() {
+            self.release_pending(parsed.receiver_index);
+            return Err(HandshakeError::Crypto);
+        }
+        let transport = match state.into_stateless_transport_mode() {
+            Ok(t) => t,
+            Err(_) => {
+                self.release_pending(parsed.receiver_index);
+                return Err(HandshakeError::Crypto);
+            }
+        };
+        let session = Arc::new(WgSession::new_with_role(
+            transport,
+            local_index,
+            parsed.sender_index,
+            peer_pubkey,
+            SessionRole::Initiator,
+        ));
+        self.promote_pending(local_index, peer_pubkey, session)
+    }
+
+    /// Responder path: parse a peer's framed WG type-1 initiation, run snow
+    /// to recover the peer's static key + TAI64N, identify the configured
+    /// peer, build a framed WG type-2 response, reserve our responder
+    /// sender_index, and install the derived (unconfirmed) transport
+    /// session. Writes the 92-byte response at `out[0..92]` and returns
+    /// `(our_sender_index, peer_pubkey)`.
+    pub(crate) fn consume_initiation_create_response(
+        &self,
+        msg: &[u8],
+        out: &mut [u8],
+    ) -> Result<([u8; WG_KEY_LEN], u32), HandshakeError> {
+        if out.len() < WG_MSG_RESPONSE_LEN {
+            return Err(HandshakeError::OutputTooSmall);
+        }
+        // Verify framing (mac1 over OUR public key) and recover the body.
+        let parsed = handshake::parse_initiation(msg, &self.local_public_key)?;
+        let peer_sender_index = parsed.sender_index;
+
+        // Run the responder Noise read to recover the peer static key.
+        let mut state = self
+            .build_responder_handshake()
+            .map_err(|_| HandshakeError::Internal)?;
+        let mut ts_sink = [0u8; TAI64N_LEN];
+        // snow writes the recovered Noise payload (the peer's TAI64N) into
+        // ts_sink; the value is used by a compliant responder for handshake
+        // anti-replay. S1 derives the session and (per the (b+) boundary)
+        // does not yet enforce per-peer TAI64N anti-replay — that rides
+        // with the responder-hardening step. We still must READ it so snow
+        // advances the transcript.
+        if state.read_message(parsed.noise_body, &mut ts_sink).is_err() {
+            return Err(HandshakeError::Crypto);
+        }
+        // Identify the initiator from the recovered static key.
+        let peer_pubkey = {
+            let rs = state.get_remote_static().ok_or(HandshakeError::Crypto)?;
+            if rs.len() != WG_KEY_LEN {
+                return Err(HandshakeError::Crypto);
+            }
+            let mut pk = [0u8; WG_KEY_LEN];
+            pk.copy_from_slice(rs);
+            pk
+        };
+        if self.peer_arc(&peer_pubkey).is_none() {
+            return Err(HandshakeError::UnknownInitiator);
+        }
+
+        // Reserve our responder sender_index BEFORE emitting msg2. The
+        // responder completes synchronously in this call, so the pending
+        // entry is a bare reservation marker (state = None).
+        let local_index = self.reserve_pending(
+            peer_pubkey,
+            None,
+            peer_sender_index,
+            SessionRole::Responder,
+        )?;
+
+        // Build the snow msg2 body (empty Noise payload).
+        let mut noise_body = [0u8; MSG_RESPONSE_NOISE_LEN];
+        let n = match state.write_message(&[], &mut noise_body) {
+            Ok(n) => n,
+            Err(_) => {
+                self.release_pending(local_index);
+                return Err(HandshakeError::Crypto);
+            }
+        };
+        if n != MSG_RESPONSE_NOISE_LEN {
+            self.release_pending(local_index);
+            return Err(HandshakeError::Crypto);
+        }
+        // Frame the response: receiver_index echoes the initiator's
+        // sender_index; mac1 keys on the INITIATOR's public key (recipient).
+        if let Err(e) = handshake::build_response(
+            out,
+            local_index,
+            peer_sender_index,
+            &noise_body,
+            &peer_pubkey,
+        ) {
+            self.release_pending(local_index);
+            return Err(e.into());
+        }
+
+        // The handshake is complete on our side after writing msg2.
+        let transport = match state.into_stateless_transport_mode() {
+            Ok(t) => t,
+            Err(_) => {
+                self.release_pending(local_index);
+                return Err(HandshakeError::Crypto);
+            }
+        };
+        let session = Arc::new(WgSession::new_with_role(
+            transport,
+            local_index,
+            peer_sender_index,
+            peer_pubkey,
+            SessionRole::Responder,
+        ));
+        // Promote the reservation to a live session (clears the pending
+        // marker + per-peer marker, installs for demux). The responder
+        // session installs UNCONFIRMED — egress is gated until the first
+        // authenticated inbound transport record (WgSession key-confirmation).
+        self.promote_pending(local_index, peer_pubkey, session)?;
+        Ok((peer_pubkey, local_index))
+    }
+
+    /// Promote a completed pending handshake to a live session: install the
+    /// session for inbound demux + on the peer, then clear the reservation
+    /// bookkeeping. Returns the session's local index.
+    ///
+    /// Ordering matters: we `install_session` (which inserts the live entry
+    /// into `sessions_by_local_index` under `reconcile_lock`) BEFORE removing
+    /// the `pending` reservation. While install runs, the index is present
+    /// in BOTH `pending` and (newly) `by_index`; the index allocator in
+    /// `reserve_pending` rejects any candidate present in EITHER map (all
+    /// under `reconcile_lock`), so no concurrent handshake can claim this
+    /// index during the hand-off. Removing the reservation first would open
+    /// a window where the index is in neither map and a concurrent reserve
+    /// could collide.
+    fn promote_pending(
+        &self,
+        local_index: u32,
+        peer_pubkey: [u8; WG_KEY_LEN],
+        session: Arc<WgSession>,
+    ) -> Result<u32, HandshakeError> {
+        // Install the live session first. The reservation guaranteed
+        // `local_index` was free of any LIVE session; `install_session`
+        // re-checks under the reconcile lock and a same-index live collision
+        // here would be an engine bug.
+        let result = match self.install_session(&peer_pubkey, session) {
+            Ok(()) => Ok(local_index),
+            Err(InstallSessionError::UnknownPeer) => Err(HandshakeError::UnknownPeer),
+            Err(InstallSessionError::LocalIndexCollision) => Err(HandshakeError::Internal),
+        };
+        // Clear the reservation bookkeeping regardless of install outcome:
+        // on success the live entry now owns the index; on failure the
+        // reservation must not linger.
+        {
+            let mut pending = self.pending.write().unwrap();
+            pending.remove(&local_index);
+            let mut by_peer = self.pending_by_peer.write().unwrap();
+            if by_peer.get(&peer_pubkey) == Some(&local_index) {
+                by_peer.remove(&peer_pubkey);
+            }
+        }
+        result
+    }
+}
+
+/// Allocate a non-zero pseudo-random u32 for a handshake index. WG indices
+/// are opaque demux tags; uniqueness (not unpredictability) is what matters
+/// for correctness, but a random draw keeps collisions astronomically rare.
+/// Uses the OS RNG via `getrandom` (pulled in transitively); falls back to a
+/// time-seeded value only if that fails (never expected on Linux).
+fn rand_u32_nonzero() -> u32 {
+    let mut buf = [0u8; 4];
+    let v = if getrandom::getrandom(&mut buf).is_ok() {
+        u32::from_ne_bytes(buf)
+    } else {
+        // Extremely unlikely fallback; still non-zero below.
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0x9e37_79b9)
+    };
+    if v == 0 { 0x9e37_79b9 } else { v }
+}

--- a/userspace-dp/src/afxdp/wg/handshake_session.rs
+++ b/userspace-dp/src/afxdp/wg/handshake_session.rs
@@ -429,7 +429,8 @@ impl WgEngine {
     /// peer, build a framed WG type-2 response, reserve our responder
     /// sender_index, and install the derived (unconfirmed) transport
     /// session. Writes the 92-byte response at `out[0..92]` and returns
-    /// `(our_sender_index, peer_pubkey)`.
+    /// `(peer_pubkey, our_sender_index)` — pubkey first, matching the return
+    /// expression below.
     pub(crate) fn consume_initiation_create_response(
         &self,
         msg: &[u8],

--- a/userspace-dp/src/afxdp/wg/handshake_session.rs
+++ b/userspace-dp/src/afxdp/wg/handshake_session.rs
@@ -119,8 +119,10 @@ impl WgEngine {
     ///
     /// Enforces the at-most-one-pending-per-peer cap: if the peer already
     /// has a pending reservation, it is aborted (removed from `pending` and
-    /// its placeholder dropped from the demux map) before the new one is
-    /// installed. Returns the reserved local index.
+    /// its `pending_by_peer` marker) before the new one is recorded. A
+    /// pending reservation never lives in the live-session demux map
+    /// (`sessions_by_local_index`), so nothing is removed there. Returns the
+    /// reserved local index.
     fn reserve_pending(
         &self,
         peer_pubkey: [u8; WG_KEY_LEN],
@@ -208,6 +210,24 @@ impl WgEngine {
         );
         by_peer.insert(peer_pubkey, local_index);
         Ok(local_index)
+    }
+
+    /// Test-only: deterministically exercise the under-lock peer recheck in
+    /// `reserve_pending_locked` — the exact code path that closes the
+    /// create_initiation TOCTOU (Codex round-4). The production gap (peer
+    /// removed between `create_initiation`'s pre-lock `peer_arc` and the
+    /// locked reserve) is a narrow race that a concurrency test cannot hit
+    /// reliably; this drives the fixed branch directly by acquiring
+    /// `reconcile_lock` and calling `reserve_pending_locked` exactly as the
+    /// completion paths do, after the peer has been removed.
+    #[cfg(test)]
+    pub(crate) fn try_reserve_pending_for_test(
+        &self,
+        peer_pubkey: [u8; WG_KEY_LEN],
+        role: SessionRole,
+    ) -> Result<u32, HandshakeError> {
+        let _guard = self.reconcile_lock.lock().unwrap();
+        self.reserve_pending_locked(peer_pubkey, None, role)
     }
 
     /// Release a pending reservation (handshake failed before completion).

--- a/userspace-dp/src/afxdp/wg/handshake_session.rs
+++ b/userspace-dp/src/afxdp/wg/handshake_session.rs
@@ -278,53 +278,70 @@ impl WgEngine {
     /// handshake, and install the derived transport session.
     ///
     /// Verifies the framing (mac1 over OUR public key) and that the
-    /// response's `receiver_index` matches a pending reservation we hold.
-    /// On success the pending handshake is promoted to a live `WgSession`
-    /// (initiator role, confirmed at install) and registered for inbound
-    /// demux. Returns the local index of the installed session.
+    /// response's `receiver_index` matches a pending INITIATOR reservation we
+    /// hold. On success the pending handshake is promoted to a live
+    /// `WgSession` (initiator role, confirmed at install) and registered for
+    /// inbound demux. Returns the local index of the installed session.
+    ///
+    /// Invariants this method preserves (Codex code-review round 1, findings
+    /// 1 & 2):
+    ///   - The pending reservation is NEVER removed before the live session
+    ///     is installed: the index stays present in `pending` until
+    ///     `promote_pending` installs it into `sessions_by_local_index` (and
+    ///     only then clears the reservation), so there is no window where the
+    ///     index is absent from both maps and a concurrent `reserve_pending`
+    ///     could re-allocate it.
+    ///   - A msg2 that fails Noise authentication does NOT destroy the
+    ///     reservation. MAC1 keys on the (public) initiator pubkey, so an
+    ///     on-path observer can forge a msg2 with a valid MAC1 but a bogus
+    ///     Noise body; if such a forgery consumed the pending state, it would
+    ///     DoS the real handshake. snow's `read_message` restores its
+    ///     symmetric state on a failed read, so we put the borrowed
+    ///     `HandshakeState` back and keep waiting for a valid (or
+    ///     retransmitted) response.
     pub(crate) fn consume_response(&self, msg: &[u8]) -> Result<u32, HandshakeError> {
         let parsed = handshake::parse_response(msg, &self.local_public_key)?;
-        // Take the pending handshake addressed by receiver_index.
-        let mut ph = {
+
+        // Borrow the snow state out of the pending entry WITHOUT removing the
+        // reservation. We validate role/index under the lock, then take the
+        // state (leaving the entry in place as a still-reserved marker with
+        // `state = None`) and release the lock before the crypto.
+        let (peer_pubkey, mut state) = {
             let mut pending = self.pending.write().unwrap();
-            pending
-                .remove(&parsed.receiver_index)
-                .ok_or(HandshakeError::NoPendingHandshake)?
-        };
-        // Copy the metadata out before consuming `ph.state` (avoids a
-        // partial-move borrow conflict).
-        let local_index = ph.local_index;
-        let peer_pubkey = ph.peer_pubkey;
-        let role = ph.role;
-        // It must be an initiator-role handshake (we sent msg1).
-        if role != SessionRole::Initiator || local_index != parsed.receiver_index {
-            // A mismatched role/index means this response does not belong to
-            // this reservation; drop it and release the now-removed entry's
-            // peer marker.
-            self.release_pending(parsed.receiver_index);
-            return Err(HandshakeError::ReceiverIndexMismatch);
-        }
-        // Recover the resumable initiator snow state.
-        let mut state = match ph.state.take() {
-            Some(s) => s,
-            None => {
-                // An initiator reservation must carry its snow state. A
-                // missing state means the reservation was never completed by
-                // create_initiation (e.g. aborted mid-build); drop it.
-                self.release_pending(parsed.receiver_index);
-                return Err(HandshakeError::NoPendingHandshake);
+            let ph = pending
+                .get_mut(&parsed.receiver_index)
+                .ok_or(HandshakeError::NoPendingHandshake)?;
+            if ph.role != SessionRole::Initiator {
+                // A response addressed at a responder-role reservation does
+                // not belong here; leave the reservation untouched.
+                return Err(HandshakeError::ReceiverIndexMismatch);
             }
+            let peer_pubkey = ph.peer_pubkey;
+            let state = ph
+                .state
+                .take()
+                .ok_or(HandshakeError::NoPendingHandshake)?;
+            (peer_pubkey, state)
         };
-        // Drive snow to completion with the peer's msg2 body.
+        let local_index = parsed.receiver_index;
+
+        // Drive snow to completion with the peer's msg2 body. On failure,
+        // snow has restored its internal state, so we reinstate the borrowed
+        // HandshakeState into the (still-present) reservation and report
+        // Crypto — a forged/garbled msg2 must not kill the pending handshake.
         let mut sink = [0u8; MSG_RESPONSE_NOISE_LEN];
         if state.read_message(parsed.noise_body, &mut sink).is_err() {
-            self.release_pending(parsed.receiver_index);
+            self.restore_pending_state(local_index, state);
             return Err(HandshakeError::Crypto);
         }
         let transport = match state.into_stateless_transport_mode() {
             Ok(t) => t,
             Err(_) => {
-                self.release_pending(parsed.receiver_index);
+                // into_stateless_transport_mode consumed `state`, so we cannot
+                // put it back; this only fails if the handshake is not
+                // finished, which cannot happen after a successful msg2 read.
+                // Release the reservation rather than leak it.
+                self.release_pending(local_index);
                 return Err(HandshakeError::Crypto);
             }
         };
@@ -335,7 +352,23 @@ impl WgEngine {
             peer_pubkey,
             SessionRole::Initiator,
         ));
+        // promote_pending installs the live session BEFORE clearing the
+        // reservation (no absent-from-both-maps window).
         self.promote_pending(local_index, peer_pubkey, session)
+    }
+
+    /// Put a borrowed initiator `HandshakeState` back into its pending
+    /// reservation after a failed msg2 read, so the reservation survives a
+    /// forged/garbled response and a later valid retransmit can complete it.
+    /// If the reservation vanished while we held no lock (e.g. a concurrent
+    /// re-initiation to the same peer aborted it), the state is simply
+    /// dropped — there is nothing to restore.
+    fn restore_pending_state(&self, local_index: u32, state: HandshakeState) {
+        let _guard = self.reconcile_lock.lock().unwrap();
+        let mut pending = self.pending.write().unwrap();
+        if let Some(ph) = pending.get_mut(&local_index) {
+            ph.state = Some(state);
+        }
     }
 
     /// Responder path: parse a peer's framed WG type-1 initiation, run snow

--- a/userspace-dp/src/afxdp/wg/handshake_session.rs
+++ b/userspace-dp/src/afxdp/wg/handshake_session.rs
@@ -128,6 +128,19 @@ impl WgEngine {
         role: SessionRole,
     ) -> Result<u32, HandshakeError> {
         let _guard = self.reconcile_lock.lock().unwrap();
+        self.reserve_pending_locked(peer_pubkey, state, role)
+    }
+
+    /// Lock-free core of `reserve_pending`: caller MUST hold `reconcile_lock`.
+    /// Used by the responder path, which holds the lock across
+    /// reserve → build msg2 → install so a concurrent same-peer initiation
+    /// cannot abort the reservation mid-completion (Codex round-2 race).
+    fn reserve_pending_locked(
+        &self,
+        peer_pubkey: [u8; WG_KEY_LEN],
+        state: Option<HandshakeState>,
+        role: SessionRole,
+    ) -> Result<u32, HandshakeError> {
         let by_index = self.sessions_by_local_index.read().unwrap();
         let mut pending = self.pending.write().unwrap();
         let mut by_peer = self.pending_by_peer.write().unwrap();
@@ -283,14 +296,18 @@ impl WgEngine {
     /// `WgSession` (initiator role, confirmed at install) and registered for
     /// inbound demux. Returns the local index of the installed session.
     ///
-    /// Invariants this method preserves (Codex code-review round 1, findings
-    /// 1 & 2):
-    ///   - The pending reservation is NEVER removed before the live session
-    ///     is installed: the index stays present in `pending` until
-    ///     `promote_pending` installs it into `sessions_by_local_index` (and
-    ///     only then clears the reservation), so there is no window where the
-    ///     index is absent from both maps and a concurrent `reserve_pending`
-    ///     could re-allocate it.
+    /// Invariants this method preserves (Codex code-review rounds 1 & 2):
+    ///   - The ENTIRE completion (validate → take snow state → Noise read →
+    ///     install → clear reservation) runs while holding `reconcile_lock`.
+    ///     `reserve_pending` / `release_pending` / `reconcile_peers` also take
+    ///     `reconcile_lock`, so no concurrent re-initiation to the same peer
+    ///     can abort this in-flight reservation, and no concurrent
+    ///     reservation/install can observe a window where the index is absent
+    ///     from both `pending` and `sessions_by_local_index`. The Noise read
+    ///     is slow-path crypto run under the slow-path lock — handshakes are
+    ///     never on the AF_XDP hot path, so the lock hold is acceptable.
+    ///     (Round-2 finding: the earlier lock-drop-during-read version still
+    ///     allowed the per-peer abort to remove the entry mid-read.)
     ///   - A msg2 that fails Noise authentication does NOT destroy the
     ///     reservation. MAC1 keys on the (public) initiator pubkey, so an
     ///     on-path observer can forge a msg2 with a valid MAC1 but a bogus
@@ -301,47 +318,45 @@ impl WgEngine {
     ///     retransmitted) response.
     pub(crate) fn consume_response(&self, msg: &[u8]) -> Result<u32, HandshakeError> {
         let parsed = handshake::parse_response(msg, &self.local_public_key)?;
+        let local_index = parsed.receiver_index;
 
-        // Borrow the snow state out of the pending entry WITHOUT removing the
-        // reservation. We validate role/index under the lock, then take the
-        // state (leaving the entry in place as a still-reserved marker with
-        // `state = None`) and release the lock before the crypto.
+        // Hold reconcile_lock across the whole completion so the reservation
+        // cannot be aborted out from under us and the index never disappears
+        // from both maps.
+        let _guard = self.reconcile_lock.lock().unwrap();
+
+        // Validate + take the snow state. The entry stays in `pending`
+        // (state = None) so the index remains reserved.
         let (peer_pubkey, mut state) = {
             let mut pending = self.pending.write().unwrap();
             let ph = pending
-                .get_mut(&parsed.receiver_index)
+                .get_mut(&local_index)
                 .ok_or(HandshakeError::NoPendingHandshake)?;
             if ph.role != SessionRole::Initiator {
-                // A response addressed at a responder-role reservation does
-                // not belong here; leave the reservation untouched.
                 return Err(HandshakeError::ReceiverIndexMismatch);
             }
             let peer_pubkey = ph.peer_pubkey;
-            let state = ph
-                .state
-                .take()
-                .ok_or(HandshakeError::NoPendingHandshake)?;
+            let state = ph.state.take().ok_or(HandshakeError::NoPendingHandshake)?;
             (peer_pubkey, state)
         };
-        let local_index = parsed.receiver_index;
 
-        // Drive snow to completion with the peer's msg2 body. On failure,
-        // snow has restored its internal state, so we reinstate the borrowed
-        // HandshakeState into the (still-present) reservation and report
-        // Crypto — a forged/garbled msg2 must not kill the pending handshake.
+        // Drive snow to completion. On a failed read, snow restored its
+        // symmetric state, so put the HandshakeState back into the (still
+        // locked, still present) reservation — a forged/garbled msg2 must not
+        // kill the pending handshake.
         let mut sink = [0u8; MSG_RESPONSE_NOISE_LEN];
         if state.read_message(parsed.noise_body, &mut sink).is_err() {
-            self.restore_pending_state(local_index, state);
+            if let Some(ph) = self.pending.write().unwrap().get_mut(&local_index) {
+                ph.state = Some(state);
+            }
             return Err(HandshakeError::Crypto);
         }
         let transport = match state.into_stateless_transport_mode() {
             Ok(t) => t,
             Err(_) => {
-                // into_stateless_transport_mode consumed `state`, so we cannot
-                // put it back; this only fails if the handshake is not
-                // finished, which cannot happen after a successful msg2 read.
-                // Release the reservation rather than leak it.
-                self.release_pending(local_index);
+                // Unreachable after a successful msg2 read; clear the
+                // reservation rather than leak it.
+                self.clear_reservation_locked(local_index, &peer_pubkey);
                 return Err(HandshakeError::Crypto);
             }
         };
@@ -352,22 +367,26 @@ impl WgEngine {
             peer_pubkey,
             SessionRole::Initiator,
         ));
-        // promote_pending installs the live session BEFORE clearing the
-        // reservation (no absent-from-both-maps window).
-        self.promote_pending(local_index, peer_pubkey, session)
+        // Install the live session, then clear the reservation — both under
+        // the reconcile_lock we already hold (install_session_locked must NOT
+        // re-take it).
+        let result = match self.install_session_locked(&peer_pubkey, session) {
+            Ok(()) => Ok(local_index),
+            Err(InstallSessionError::UnknownPeer) => Err(HandshakeError::UnknownPeer),
+            Err(InstallSessionError::LocalIndexCollision) => Err(HandshakeError::Internal),
+        };
+        self.clear_reservation_locked(local_index, &peer_pubkey);
+        result
     }
 
-    /// Put a borrowed initiator `HandshakeState` back into its pending
-    /// reservation after a failed msg2 read, so the reservation survives a
-    /// forged/garbled response and a later valid retransmit can complete it.
-    /// If the reservation vanished while we held no lock (e.g. a concurrent
-    /// re-initiation to the same peer aborted it), the state is simply
-    /// dropped — there is nothing to restore.
-    fn restore_pending_state(&self, local_index: u32, state: HandshakeState) {
-        let _guard = self.reconcile_lock.lock().unwrap();
+    /// Clear a reservation's `pending` entry and its `pending_by_peer` marker
+    /// (if it still points at this index). Caller MUST hold `reconcile_lock`.
+    fn clear_reservation_locked(&self, local_index: u32, peer_pubkey: &[u8; WG_KEY_LEN]) {
         let mut pending = self.pending.write().unwrap();
-        if let Some(ph) = pending.get_mut(&local_index) {
-            ph.state = Some(state);
+        pending.remove(&local_index);
+        let mut by_peer = self.pending_by_peer.write().unwrap();
+        if by_peer.get(peer_pubkey) == Some(&local_index) {
+            by_peer.remove(peer_pubkey);
         }
     }
 
@@ -417,23 +436,26 @@ impl WgEngine {
             return Err(HandshakeError::UnknownInitiator);
         }
 
-        // Reserve our responder sender_index BEFORE emitting msg2. The
-        // responder completes synchronously in this call, so the pending
-        // entry is a bare reservation marker (state = None).
+        // Hold reconcile_lock across reserve → build msg2 → install so a
+        // concurrent same-peer initiation cannot abort our reservation between
+        // reserve and install (Codex round-2 race). The responder completes
+        // synchronously in this single call, so the pending entry is a bare
+        // reservation marker (state = None).
+        let _guard = self.reconcile_lock.lock().unwrap();
         let local_index =
-            self.reserve_pending(peer_pubkey, None, SessionRole::Responder)?;
+            self.reserve_pending_locked(peer_pubkey, None, SessionRole::Responder)?;
 
         // Build the snow msg2 body (empty Noise payload).
         let mut noise_body = [0u8; MSG_RESPONSE_NOISE_LEN];
         let n = match state.write_message(&[], &mut noise_body) {
             Ok(n) => n,
             Err(_) => {
-                self.release_pending(local_index);
+                self.clear_reservation_locked(local_index, &peer_pubkey);
                 return Err(HandshakeError::Crypto);
             }
         };
         if n != MSG_RESPONSE_NOISE_LEN {
-            self.release_pending(local_index);
+            self.clear_reservation_locked(local_index, &peer_pubkey);
             return Err(HandshakeError::Crypto);
         }
         // Frame the response: receiver_index echoes the initiator's
@@ -445,7 +467,7 @@ impl WgEngine {
             &noise_body,
             &peer_pubkey,
         ) {
-            self.release_pending(local_index);
+            self.clear_reservation_locked(local_index, &peer_pubkey);
             return Err(e.into());
         }
 
@@ -453,7 +475,7 @@ impl WgEngine {
         let transport = match state.into_stateless_transport_mode() {
             Ok(t) => t,
             Err(_) => {
-                self.release_pending(local_index);
+                self.clear_reservation_locked(local_index, &peer_pubkey);
                 return Err(HandshakeError::Crypto);
             }
         };
@@ -464,55 +486,19 @@ impl WgEngine {
             peer_pubkey,
             SessionRole::Responder,
         ));
-        // Promote the reservation to a live session (clears the pending
-        // marker + per-peer marker, installs for demux). The responder
-        // session installs UNCONFIRMED — egress is gated until the first
-        // authenticated inbound transport record (WgSession key-confirmation).
-        self.promote_pending(local_index, peer_pubkey, session)?;
-        Ok((peer_pubkey, local_index))
-    }
-
-    /// Promote a completed pending handshake to a live session: install the
-    /// session for inbound demux + on the peer, then clear the reservation
-    /// bookkeeping. Returns the session's local index.
-    ///
-    /// Ordering matters: we `install_session` (which inserts the live entry
-    /// into `sessions_by_local_index` under `reconcile_lock`) BEFORE removing
-    /// the `pending` reservation. While install runs, the index is present
-    /// in BOTH `pending` and (newly) `by_index`; the index allocator in
-    /// `reserve_pending` rejects any candidate present in EITHER map (all
-    /// under `reconcile_lock`), so no concurrent handshake can claim this
-    /// index during the hand-off. Removing the reservation first would open
-    /// a window where the index is in neither map and a concurrent reserve
-    /// could collide.
-    fn promote_pending(
-        &self,
-        local_index: u32,
-        peer_pubkey: [u8; WG_KEY_LEN],
-        session: Arc<WgSession>,
-    ) -> Result<u32, HandshakeError> {
-        // Install the live session first. The reservation guaranteed
-        // `local_index` was free of any LIVE session; `install_session`
-        // re-checks under the reconcile lock and a same-index live collision
-        // here would be an engine bug.
-        let result = match self.install_session(&peer_pubkey, session) {
-            Ok(()) => Ok(local_index),
+        // Install the live session (UNCONFIRMED — egress gated until the first
+        // authenticated inbound transport record), then clear the reservation.
+        // Both under the reconcile_lock we already hold.
+        let install = match self.install_session_locked(&peer_pubkey, session) {
+            Ok(()) => Ok(()),
             Err(InstallSessionError::UnknownPeer) => Err(HandshakeError::UnknownPeer),
             Err(InstallSessionError::LocalIndexCollision) => Err(HandshakeError::Internal),
         };
-        // Clear the reservation bookkeeping regardless of install outcome:
-        // on success the live entry now owns the index; on failure the
-        // reservation must not linger.
-        {
-            let mut pending = self.pending.write().unwrap();
-            pending.remove(&local_index);
-            let mut by_peer = self.pending_by_peer.write().unwrap();
-            if by_peer.get(&peer_pubkey) == Some(&local_index) {
-                by_peer.remove(&peer_pubkey);
-            }
-        }
-        result
+        self.clear_reservation_locked(local_index, &peer_pubkey);
+        install?;
+        Ok((peer_pubkey, local_index))
     }
+
 }
 
 /// Allocate a non-zero pseudo-random u32 for a handshake index. WG indices

--- a/userspace-dp/src/afxdp/wg/handshake_session.rs
+++ b/userspace-dp/src/afxdp/wg/handshake_session.rs
@@ -86,13 +86,12 @@ pub(in crate::afxdp::wg) struct PendingHandshake {
     /// Our locally-chosen index (the reservation key). The peer echoes
     /// it as the `receiver_index` of the message it sends back.
     local_index: u32,
-    /// The peer's index, learned from the message it sent us. For the
-    /// responder path this is msg1.sender_index (known at reserve time);
-    /// for the initiator path it is filled in from msg2.sender_index on
-    /// completion.
-    peer_index: u32,
     /// Initiator or responder — determines the session-confirmation gate
-    /// (see `WgSession`).
+    /// (see `WgSession`). The peer's index is NOT stored here: both
+    /// completion paths derive the session's `peer_index` directly from the
+    /// message they just parsed (msg2.sender_index for the initiator,
+    /// msg1.sender_index for the responder), so the pending record only
+    /// needs the reservation key + role + identity.
     role: SessionRole,
 }
 
@@ -103,11 +102,14 @@ impl WgEngine {
     // These compose snow + handshake.rs framing + the TAI64N clock into the
     // full on-wire WG handshake. They run on the CONTROL/coordinator thread
     // only — never the AF_XDP poll worker (the hot encap/decap paths never
-    // build a HandshakeState). Index allocation follows the two-phase
-    // reservation discipline: an index is reserved in `sessions_by_local_index`
-    // (as a placeholder via `pending`) BEFORE the message carrying it is
-    // emitted, so a concurrent handshake cannot steal it and blackhole the
-    // resulting session.
+    // build a HandshakeState). Index allocation follows a two-phase
+    // reservation discipline: a local index is recorded in `pending` (which
+    // the index allocator treats as reserved alongside the live demux map)
+    // BEFORE the message carrying it is emitted, so a concurrent handshake
+    // cannot steal it and blackhole the resulting session. Promotion installs
+    // the live demux entry BEFORE clearing the reservation, so the index is
+    // never absent from both maps during the hand-off. All reservation
+    // mutations are serialized by `reconcile_lock`.
     // ===================================================================
 
     /// Reserve a fresh, collision-free local index and register a pending
@@ -123,7 +125,6 @@ impl WgEngine {
         &self,
         peer_pubkey: [u8; WG_KEY_LEN],
         state: Option<HandshakeState>,
-        peer_index: u32,
         role: SessionRole,
     ) -> Result<u32, HandshakeError> {
         let _guard = self.reconcile_lock.lock().unwrap();
@@ -175,7 +176,6 @@ impl WgEngine {
                 state,
                 peer_pubkey,
                 local_index,
-                peer_index,
                 role,
             },
         );
@@ -232,12 +232,12 @@ impl WgEngine {
             .map_err(|_| HandshakeError::Internal)?;
 
         // Reserve the local index + register the pending handshake BEFORE
-        // emitting the message (two-phase reservation). For the initiator
-        // the peer_index is not yet known (filled from msg2); use 0 as a
-        // placeholder. The snow state is stashed after we write msg1 (which
-        // mutates it) so it can resume in `consume_response`.
+        // emitting the message (two-phase reservation). The snow state is
+        // stashed (as `Some`) after we write msg1 (which mutates it) so it
+        // can resume in `consume_response`; the peer's index is learned from
+        // msg2 at that point.
         let local_index =
-            self.reserve_pending(*peer_pubkey, None, 0, SessionRole::Initiator)?;
+            self.reserve_pending(*peer_pubkey, None, SessionRole::Initiator)?;
 
         // Build the snow msg1 body with the TAI64N as the Noise payload.
         let tai64n = self.tai64n_clock.now();
@@ -387,12 +387,8 @@ impl WgEngine {
         // Reserve our responder sender_index BEFORE emitting msg2. The
         // responder completes synchronously in this call, so the pending
         // entry is a bare reservation marker (state = None).
-        let local_index = self.reserve_pending(
-            peer_pubkey,
-            None,
-            peer_sender_index,
-            SessionRole::Responder,
-        )?;
+        let local_index =
+            self.reserve_pending(peer_pubkey, None, SessionRole::Responder)?;
 
         // Build the snow msg2 body (empty Noise payload).
         let mut noise_body = [0u8; MSG_RESPONSE_NOISE_LEN];

--- a/userspace-dp/src/afxdp/wg/handshake_session.rs
+++ b/userspace-dp/src/afxdp/wg/handshake_session.rs
@@ -141,14 +141,27 @@ impl WgEngine {
         state: Option<HandshakeState>,
         role: SessionRole,
     ) -> Result<u32, HandshakeError> {
+        // Re-check the peer is configured UNDER the lock (Codex round-3
+        // TOCTOU finding). `create_initiation` checks `peer_arc` before
+        // acquiring reconcile_lock; if `reconcile_peers(&[])` removes the
+        // peer in that gap, reserving here would create a pending entry for a
+        // peer absent from the published table. `reconcile_peers`'s
+        // pending-drain iterates the OLD table's pubkeys, so it would never
+        // drain this entry — it would leak until response / re-add / restart.
+        // Re-checking under the lock makes reservation linearizable with peer
+        // removal: a peer removed before we acquire the lock yields
+        // UnknownPeer and no reservation is created.
+        if self.peer_arc(&peer_pubkey).is_none() {
+            return Err(HandshakeError::UnknownPeer);
+        }
         let by_index = self.sessions_by_local_index.read().unwrap();
         let mut pending = self.pending.write().unwrap();
         let mut by_peer = self.pending_by_peer.write().unwrap();
 
         // Abort any prior PENDING (not-yet-completed) handshake for this
         // peer (DoS bound: at most one pending reservation per peer). The
-        // `pending_by_peer` marker is cleared by `promote_pending` on
-        // completion, so a still-present marker can only point at an
+        // `pending_by_peer` marker is cleared by `clear_reservation_locked`
+        // on completion, so a still-present marker can only point at an
         // incomplete reservation living in `pending` — NOT at a live
         // session in `by_index`. We therefore drop only the `pending`
         // entry and the marker; we must NOT touch `by_index`, or we would
@@ -177,12 +190,13 @@ impl WgEngine {
         // Reserve the index by recording the pending handshake. The
         // reservation lives in `pending` (NOT in the live-session demux
         // map): the index allocator above rejects any candidate already
-        // present in `pending` OR `by_index`, and the whole reserve/promote
-        // sequence is serialized by `reconcile_lock`, so a concurrent
-        // handshake or `install_session` cannot claim this index until we
-        // either promote it (insert the live session) or release it. decap
-        // never sees a half-built session because the live entry is only
-        // inserted by `promote_pending` → `install_session` on completion.
+        // present in `pending` OR `by_index`, and the whole reserve →
+        // complete sequence is serialized by `reconcile_lock`, so a
+        // concurrent handshake or `install_session` cannot claim this index
+        // until the completion path inserts the live session (via
+        // `install_session_locked`) or releases the reservation. decap never
+        // sees a half-built session because the live entry is only inserted
+        // by `install_session_locked` on completion.
         pending.insert(
             local_index,
             PendingHandshake {

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -36,6 +36,11 @@ pub(crate) mod framing;
 // so the security-critical framing is auditable in isolation and the
 // engine stays under the modularity threshold.
 pub(crate) mod handshake;
+// WG handshake orchestration on WgEngine (the four slow-path entry points +
+// the two-phase index reservation). Split out of engine.rs to keep it under
+// the modularity threshold; same `wg` module, so it reaches engine internals
+// via `pub(in crate::afxdp::wg)` visibility.
+pub(crate) mod handshake_session;
 pub(crate) mod mss;
 // `outer` module deleted in #1440. Its scaffold helpers
 // (write_outer_eth, write_outer_ipv4_udp, outer_l2_len,

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -43,6 +43,7 @@ pub(crate) mod mss;
 pub(crate) mod peer;
 pub(crate) mod scratch;
 pub(crate) mod session;
+pub(crate) mod tai64n;
 
 #[cfg(test)]
 #[path = "tests.rs"]

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -36,8 +36,9 @@ pub(crate) mod framing;
 // so the security-critical framing is auditable in isolation and the
 // engine stays under the modularity threshold.
 pub(crate) mod handshake;
-// WG handshake orchestration on WgEngine (the four slow-path entry points +
-// the two-phase index reservation). Split out of engine.rs to keep it under
+// WG handshake orchestration on WgEngine (the three slow-path entry points —
+// create_initiation, consume_response, consume_initiation_create_response —
+// plus the two-phase index reservation). Split out of engine.rs to keep it under
 // the modularity threshold; same `wg` module, so it reaches engine internals
 // via `pub(in crate::afxdp::wg)` visibility.
 pub(crate) mod handshake_session;

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -31,6 +31,11 @@ pub(crate) mod allowed_ips;
 pub(crate) mod dscp;
 pub(crate) mod engine;
 pub(crate) mod framing;
+// WireGuard S1 (#1709): on-wire handshake-message framing (type 1/2,
+// MAC1/MAC2) and the TAI64N timestamp. Kept out of engine.rs (WATCH-tier)
+// so the security-critical framing is auditable in isolation and the
+// engine stays under the modularity threshold.
+pub(crate) mod handshake;
 pub(crate) mod mss;
 // `outer` module deleted in #1440. Its scaffold helpers
 // (write_outer_eth, write_outer_ipv4_udp, outer_l2_len,
@@ -90,6 +95,30 @@ pub(crate) const WG_TYPE_DATA: u8 = 4;
 
 /// Poly1305 authentication tag length.
 pub(crate) const POLY1305_TAG_LEN: usize = 16;
+
+/// MAC1/MAC2 field length on a WG handshake message (keyed-BLAKE2s-128
+/// output = 16 bytes). Used by `handshake.rs`.
+pub(crate) const WG_MAC_LEN: usize = 16;
+
+/// MAC1 label, hashed with the recipient's static public key to form the
+/// keyed-BLAKE2s MAC1 key: `key = BLAKE2s-256(LABEL_MAC1 || recipient_pub)`
+/// (WireGuard protocol page; wireguard-go `device/cookie.go` `Init`).
+pub(crate) const WG_LABEL_MAC1: &[u8; 8] = b"mac1----";
+
+/// Cookie label (used by the type-3 cookie-reply MAC2 path — out of scope
+/// for S1, defined here for completeness / future use). `cookie--`.
+pub(crate) const WG_LABEL_COOKIE: &[u8; 8] = b"cookie--";
+
+/// WG handshake message 1 (initiation) wire length:
+///   type(1) + reserved(3) + sender_index(4) + ephemeral(32)
+///   + encrypted_static(32+16) + encrypted_timestamp(12+16)
+///   + mac1(16) + mac2(16) = 148.
+pub(crate) const WG_MSG_INIT_LEN: usize = 148;
+
+/// WG handshake message 2 (response) wire length:
+///   type(1) + reserved(3) + sender_index(4) + receiver_index(4)
+///   + ephemeral(32) + encrypted_nothing(0+16) + mac1(16) + mac2(16) = 92.
+pub(crate) const WG_MSG_RESPONSE_LEN: usize = 92;
 
 /// Transport data header on the wire:
 ///   - type        u8  = 4

--- a/userspace-dp/src/afxdp/wg/tai64n.rs
+++ b/userspace-dp/src/afxdp/wg/tai64n.rs
@@ -1,0 +1,383 @@
+//! TAI64N timestamp for the WireGuard handshake initiation.
+//!
+//! WireGuard carries a 12-byte TAI64N timestamp as the encrypted Noise
+//! payload of message type 1. A compliant responder (kernel WireGuard,
+//! wireguard-go, UniFi) uses it for handshake anti-replay: it rejects an
+//! initiation whose timestamp is `<=` the last one it accepted from that
+//! peer. So xpf MUST emit a strictly increasing timestamp or it DoSes its
+//! own re-handshakes.
+//!
+//! ## Wire encoding (12 bytes, big-endian)
+//!
+//! ```text
+//!   bytes [0..8]   = 0x400000000000000a + unix_seconds   (BE u64)
+//!   bytes [8..12]  = nanoseconds & 0xFF00_0000           (BE u32, whitened)
+//! ```
+//!
+//! - The seconds base is `0x400000000000000a` = `2^62 + 10`. The `2^62`
+//!   is the TAI64 epoch label; the `+ 10` is the TAI−UTC leap-second
+//!   offset at the 1970 Unix epoch. Both the Linux kernel
+//!   (`drivers/net/wireguard/noise.c`: `ktime_get_real_seconds() +
+//!   0x400000000000000aULL`) and wireguard-go (`tai64n/tai64n.go`:
+//!   `base = uint64(0x400000000000000a)`) use this exact base. Omitting
+//!   the `+ 10` makes every timestamp 10 s in the past, which a strict
+//!   peer can drop as stale.
+//! - The nanoseconds field is **whitened**: the low 24 bits are cleared
+//!   (`nanos & 0xFF00_0000`, i.e. `nanos &^ (0x0100_0000 - 1)`), matching
+//!   the reference's `nano = uint32(t.Nanosecond()) &^ (0x1000000 - 1)`.
+//!   This coarsens the sub-~16 ms component so the timestamp does not leak
+//!   a fine-grained local clock.
+//!
+//! Because the 8-byte seconds field is the most significant part and both
+//! fields are big-endian, lexicographic byte comparison of the 12-byte
+//! value equals numeric comparison — the same property wireguard-go relies
+//! on with `bytes.Compare`. The monotonic clock exploits this.
+//!
+//! ## Monotonicity (in-process)
+//!
+//! [`Tai64nClock`] returns a value strictly greater than every prior
+//! return from the same clock. It is derived from `SystemTime::now()`, but
+//! if the freshly-computed (whitened) value is `<=` the last returned one
+//! (a backwards wall-clock step, or two calls inside one whitened tick),
+//! it returns `last + one whitened tick` instead. On nanos overflow the
+//! carry rolls into the seconds field — and crucially the carry triggers
+//! when the advanced nanos reach `1_000_000_000`, NOT at the `0xFF00_0000`
+//! whitening boundary: a TAI64N nanos field must be a valid sub-second
+//! value `< 10^9` or a strict peer rejects the datagram as malformed.
+//!
+//! Cross-restart persistence (so the clock never regresses after an xpf
+//! restart with a skewed wall clock) is the control plane's job and is
+//! deferred to the config-integration step (#1703 S6). This module exposes
+//! [`Tai64nClock::seed_high_water`] / [`Tai64nClock::high_water`] hooks for
+//! it; S1 has no daemon to persist from, so in-process monotonicity is the
+//! S1 contract.
+
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// TAI64N wire length: 8-byte seconds + 4-byte nanoseconds.
+pub(crate) const TAI64N_LEN: usize = 12;
+
+/// TAI64 seconds base: `2^62` epoch label + 10 s TAI−UTC leap offset at
+/// the 1970 epoch. See the module docs.
+const TAI64_BASE: u64 = 0x4000_0000_0000_000a;
+
+/// Whitening mask applied to the nanoseconds field: clear the low 24
+/// bits (keep `0xFF00_0000`). One whitened tick is therefore
+/// `0x0100_0000` ns (~16.78 ms).
+const NANOS_WHITEN_MASK: u32 = 0xFF00_0000;
+const WHITENED_TICK: u32 = 0x0100_0000;
+const NANOS_PER_SEC: u32 = 1_000_000_000;
+
+/// Encode `(unix_secs, nanos)` into a 12-byte big-endian TAI64N with the
+/// canonical base offset and nanos whitening.
+///
+/// `nanos` from `SystemTime::subsec_nanos()` is always `< 1_000_000_000`,
+/// and whitening only clears low bits, so the live path stays in range.
+/// We still defensively clamp a whitened value `>= 1_000_000_000` down to
+/// the largest valid whitened tick (`< 10^9`) so a hand-constructed /
+/// seeded out-of-range nanos can never produce a malformed TAI64N that a
+/// strict peer would reject. (A whitened nanos can never exceed
+/// `0xFF00_0000`; clamping keeps it a valid sub-second value.)
+#[inline]
+fn encode(unix_secs: u64, nanos: u32) -> [u8; TAI64N_LEN] {
+    let secs = TAI64_BASE.wrapping_add(unix_secs);
+    let mut whitened = nanos & NANOS_WHITEN_MASK;
+    if whitened >= NANOS_PER_SEC {
+        // Largest whitened multiple strictly below 10^9.
+        whitened = (NANOS_PER_SEC - 1) & NANOS_WHITEN_MASK;
+    }
+    let mut out = [0u8; TAI64N_LEN];
+    out[0..8].copy_from_slice(&secs.to_be_bytes());
+    out[8..12].copy_from_slice(&whitened.to_be_bytes());
+    out
+}
+
+/// Decode the seconds and nanoseconds fields from a 12-byte TAI64N. Used
+/// only by tests and the monotonic-advance path.
+#[inline]
+fn decode(ts: &[u8; TAI64N_LEN]) -> (u64, u32) {
+    let secs = u64::from_be_bytes([
+        ts[0], ts[1], ts[2], ts[3], ts[4], ts[5], ts[6], ts[7],
+    ]);
+    let nanos = u32::from_be_bytes([ts[8], ts[9], ts[10], ts[11]]);
+    (secs, nanos)
+}
+
+/// Advance a TAI64N value by exactly one whitened tick, carrying into the
+/// seconds field when the nanos would reach a full second.
+///
+/// The carry MUST trigger at `nanos >= 1_000_000_000`, not at the
+/// `0xFF00_0000` whitening boundary: the maximum whitened nanos is
+/// `0x3B00_0000` (989_855_744 — the largest multiple of the tick below
+/// 10^9), and `0x3B00_0000 + 0x0100_0000 = 0x3C00_0000` (1_006_632_960)
+/// which is `> 10^9`. A peer rejects a nanos field `>= 10^9` as malformed,
+/// so we roll over to `secs + 1, nanos = 0` there.
+#[inline]
+fn advance_one_tick(ts: &[u8; TAI64N_LEN]) -> [u8; TAI64N_LEN] {
+    let (secs, raw_nanos) = decode(ts);
+    // Defensive: a value reaching here normally comes from `encode()` or a
+    // prior `advance` (so nanos < 10^9), but `seed_high_water` accepts a raw
+    // 12-byte value that could carry an out-of-range nanos. Clamp to a valid
+    // sub-second whitened value before adding a tick so the `+ WHITENED_TICK`
+    // cannot wrap u32 and so the result is always a valid TAI64N.
+    let nanos = if raw_nanos >= NANOS_PER_SEC {
+        (NANOS_PER_SEC - 1) & NANOS_WHITEN_MASK
+    } else {
+        raw_nanos & NANOS_WHITEN_MASK
+    };
+    let next = nanos.wrapping_add(WHITENED_TICK);
+    if next >= NANOS_PER_SEC {
+        // Carry: the seconds field is the raw TAI64 value (already includes
+        // the base), so increment it directly and reset nanos.
+        let mut out = [0u8; TAI64N_LEN];
+        out[0..8].copy_from_slice(&secs.wrapping_add(1).to_be_bytes());
+        // nanos = 0
+        out
+    } else {
+        let mut out = *ts;
+        out[8..12].copy_from_slice(&next.to_be_bytes());
+        out
+    }
+}
+
+/// In-process strictly-monotonic TAI64N clock.
+///
+/// `now()` is the only value source on the handshake-build path. The
+/// `Mutex` is taken only on the slow handshake path (never per-packet), so
+/// contention is irrelevant.
+#[derive(Debug)]
+pub(crate) struct Tai64nClock {
+    /// The most recent value returned. `None` until the first `now()`.
+    last: Mutex<Option<[u8; TAI64N_LEN]>>,
+}
+
+impl Default for Tai64nClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Tai64nClock {
+    pub(crate) fn new() -> Self {
+        Self {
+            last: Mutex::new(None),
+        }
+    }
+
+    /// Return a TAI64N strictly greater than every prior return from this
+    /// clock. Derived from `SystemTime::now()`, clamped up to
+    /// `last + one whitened tick` if the wall clock did not advance past
+    /// `last`.
+    pub(crate) fn now(&self) -> [u8; TAI64N_LEN] {
+        let candidate = Self::wall_clock_now();
+        let mut guard = self.last.lock().unwrap();
+        let next = match *guard {
+            // Strictly greater (big-endian byte compare == numeric): take
+            // the fresh wall-clock value.
+            Some(prev) if candidate <= prev => advance_one_tick(&prev),
+            _ => candidate,
+        };
+        *guard = Some(next);
+        next
+    }
+
+    /// Compute the whitened TAI64N for the current wall clock. Pre-1970
+    /// clocks (`SystemTime` before `UNIX_EPOCH`) collapse to unix_secs = 0;
+    /// monotonicity still holds because `now()` clamps against `last`.
+    fn wall_clock_now() -> [u8; TAI64N_LEN] {
+        match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(d) => encode(d.as_secs(), d.subsec_nanos()),
+            Err(_) => encode(0, 0),
+        }
+    }
+
+    /// Seed the clock's high-water mark from a persisted value so a future
+    /// control plane (#1703 S6) can prevent cross-restart regression. The
+    /// next `now()` will return strictly greater than `hw`. Slow path only.
+    pub(crate) fn seed_high_water(&self, hw: [u8; TAI64N_LEN]) {
+        let mut guard = self.last.lock().unwrap();
+        // Only move the high-water mark forward; never let a stale seed
+        // pull it backwards.
+        match *guard {
+            Some(prev) if hw <= prev => {}
+            _ => *guard = Some(hw),
+        }
+    }
+
+    /// Snapshot the current high-water mark for persistence (#1703 S6).
+    /// Returns `None` if `now()` has never been called and no seed applied.
+    pub(crate) fn high_water(&self) -> Option<[u8; TAI64N_LEN]> {
+        *self.last.lock().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn tai64n_encoding_kat() {
+        // Fixed (secs, nanos) -> exact 12-byte wire image with the +10
+        // epoch offset and the low-24-bit whitening applied.
+        //
+        // secs field = 0x400000000000000a + 1 = 0x400000000000000b
+        // nanos      = 0x12345678 & 0xFF000000 = 0x12000000
+        let ts = encode(1, 0x1234_5678);
+        assert_eq!(
+            ts,
+            [
+                0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0b, // secs BE
+                0x12, 0x00, 0x00, 0x00, // whitened nanos BE
+            ]
+        );
+
+        // Re-derive the seconds base independently of the constant to catch
+        // a transcription typo: 2^62 + 10.
+        let base = (1u64 << 62) + 10;
+        assert_eq!(base, TAI64_BASE);
+        assert_eq!(&ts[0..8], &base.wrapping_add(1).to_be_bytes());
+
+        // unix_secs = 0 yields the bare base in the seconds field.
+        let z = encode(0, 0);
+        assert_eq!(&z[0..8], &TAI64_BASE.to_be_bytes());
+        assert_eq!(&z[8..12], &[0u8; 4]);
+    }
+
+    #[test]
+    fn nanos_are_whitened_low_24_bits() {
+        // Any value in [0, 0x00FF_FFFF] whitens to zero.
+        assert_eq!(&encode(0, 0x00FF_FFFF)[8..12], &[0u8; 4]);
+        // The high byte survives for an in-range (< 10^9) nanos. 0.5 s =
+        // 500_000_000 = 0x1DCD6500; whitened (clear low 24 bits) = 0x1D000000.
+        assert_eq!(&encode(0, 500_000_000)[8..12], &0x1D00_0000u32.to_be_bytes());
+        // An out-of-range nanos (>= 10^9) is clamped to a valid whitened
+        // sub-second value rather than emitted as a malformed TAI64N.
+        let clamped = u32::from_be_bytes([
+            encode(0, 0xAB_FF_FF_FF)[8],
+            encode(0, 0xAB_FF_FF_FF)[9],
+            encode(0, 0xAB_FF_FF_FF)[10],
+            encode(0, 0xAB_FF_FF_FF)[11],
+        ]);
+        assert!(clamped < NANOS_PER_SEC, "out-of-range nanos must clamp below 10^9");
+        assert_eq!(clamped & !NANOS_WHITEN_MASK, 0, "clamped value stays whitened");
+    }
+
+    #[test]
+    fn tai64n_strictly_monotonic() {
+        // Even when the wall clock never advances (we cannot control it in
+        // a unit test, but rapid successive calls land in the same whitened
+        // tick), each call must be strictly greater than the previous.
+        let clk = Tai64nClock::new();
+        let mut prev = clk.now();
+        for _ in 0..10_000 {
+            let cur = clk.now();
+            assert!(
+                cur > prev,
+                "TAI64N must be strictly increasing: prev={prev:02x?} cur={cur:02x?}"
+            );
+            prev = cur;
+        }
+    }
+
+    #[test]
+    fn tai64n_monotonic_after_backwards_seed() {
+        // Seed a far-future high-water mark (with a VALID sub-second nanos);
+        // the next now() must still be strictly greater (clamps up via
+        // advance_one_tick), proving the backwards-wall-clock case.
+        let clk = Tai64nClock::new();
+        let future = encode(4_000_000_000, 0x3A00_0000); // valid whitened nanos < 10^9
+        clk.seed_high_water(future);
+        let n = clk.now();
+        assert!(n > future, "now() after future seed must exceed the seed");
+    }
+
+    #[test]
+    fn advance_is_robust_to_out_of_range_seed() {
+        // A raw seed whose nanos field is >= 10^9 (malformed) must not panic
+        // or wrap when advanced; the result is a valid TAI64N (nanos < 10^9)
+        // strictly greater than nothing-was-clamped-to-zero would give.
+        let mut bad = encode(100, 0);
+        bad[8..12].copy_from_slice(&0xFF00_0000u32.to_be_bytes()); // 4.27e9 ns
+        let adv = advance_one_tick(&bad);
+        let (_secs, nanos) = decode(&adv);
+        assert!(nanos < NANOS_PER_SEC, "advanced nanos must be a valid sub-second value");
+    }
+
+    #[test]
+    fn tai64n_carry_at_1e9() {
+        // The carry into seconds MUST trigger at nanos >= 1_000_000_000,
+        // not at the 0xFF000000 whitening boundary. Start one whitened tick
+        // below a full second and advance: it must roll to secs+1, nanos=0,
+        // and the resulting nanos must be a valid sub-second value.
+        //
+        // 0x3B000000 = 989_855_744 is the largest whitened nanos < 10^9.
+        let at_edge = {
+            let mut t = encode(100, 0);
+            t[8..12].copy_from_slice(&0x3B00_0000u32.to_be_bytes());
+            t
+        };
+        let (secs_before, nanos_before) = decode(&at_edge);
+        assert!(nanos_before < NANOS_PER_SEC);
+        assert!(nanos_before + WHITENED_TICK >= NANOS_PER_SEC, "test setup: must be the last tick");
+
+        let advanced = advance_one_tick(&at_edge);
+        let (secs_after, nanos_after) = decode(&advanced);
+        assert_eq!(secs_after, secs_before + 1, "carry must increment seconds");
+        assert_eq!(nanos_after, 0, "carry must reset nanos to 0");
+        assert!(nanos_after < NANOS_PER_SEC, "nanos must stay a valid sub-second value");
+
+        // A mid-range advance must NOT carry.
+        let mid = encode(100, 0x1000_0000);
+        let mid_adv = advance_one_tick(&mid);
+        let (s, ns) = decode(&mid_adv);
+        assert_eq!(s, 100 + TAI64_BASE, "mid-range advance must not touch seconds");
+        assert_eq!(ns, 0x1100_0000, "mid-range advance adds one whitened tick");
+    }
+
+    #[test]
+    fn tai64n_concurrent_monotonic() {
+        // N threads hammering now() must collectively produce N distinct,
+        // strictly-orderable values — no duplicates, no regressions.
+        let clk = Arc::new(Tai64nClock::new());
+        let threads = 8;
+        let per = 2_000;
+        let mut handles = Vec::new();
+        for _ in 0..threads {
+            let clk = clk.clone();
+            handles.push(thread::spawn(move || {
+                let mut v = Vec::with_capacity(per);
+                for _ in 0..per {
+                    v.push(clk.now());
+                }
+                v
+            }));
+        }
+        let mut all: Vec<[u8; TAI64N_LEN]> = Vec::new();
+        for h in handles {
+            all.extend(h.join().unwrap());
+        }
+        all.sort();
+        let total = all.len();
+        all.dedup();
+        assert_eq!(
+            all.len(),
+            total,
+            "concurrent now() produced {} duplicate TAI64N values",
+            total - all.len()
+        );
+    }
+
+    #[test]
+    fn high_water_round_trips() {
+        let clk = Tai64nClock::new();
+        assert_eq!(clk.high_water(), None);
+        let n = clk.now();
+        assert_eq!(clk.high_water(), Some(n));
+        // A seed below the current mark is ignored.
+        clk.seed_high_water(encode(0, 0));
+        assert_eq!(clk.high_water(), Some(n));
+    }
+}

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -1402,8 +1402,8 @@ fn established_pair_responder_confirmation_flips_via_decap_path() {
 // ===================================================================
 mod framed_handshake {
     use super::*;
-    use crate::afxdp::wg::engine::HandshakeError;
     use crate::afxdp::wg::handshake::FramingError;
+    use crate::afxdp::wg::handshake_session::HandshakeError;
     use crate::afxdp::wg::{WG_MSG_INIT_LEN, WG_MSG_RESPONSE_LEN};
 
     /// Build two engines that know each other's pubkey, allowing the full

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -1761,4 +1761,136 @@ mod framed_handshake {
         init.create_initiation(&resp_pub, &mut msg1b).unwrap();
         assert_eq!(init.pending_count(), 1);
     }
+
+    /// Concurrency regression for the Codex round-2 finding: completing a
+    /// handshake (create_initiation → consume_initiation_create_response →
+    /// consume_response) must be sound under a concurrent thread hammering
+    /// reconcile_peers (add/remove the peer), which exercises the
+    /// reconcile-drains-pending path and the reconcile_lock serialization of
+    /// the now-lock-held completion. Must not panic, deadlock, or corrupt the
+    /// maps.
+    ///
+    /// Note we do NOT race a second same-peer create_initiation against the
+    /// SAME in-flight handshake: that is the at-most-one-pending-per-peer
+    /// abort (latest-initiation-wins), which legitimately starves the older
+    /// reservation and is not a soundness violation. The reconcile thread is
+    /// the right concurrency stressor for the lock discipline.
+    #[test]
+    fn concurrent_consume_response_and_reinitiation_is_sound() {
+        use std::sync::atomic::{AtomicBool, AtomicU32, Ordering as AOrd};
+        use std::sync::Arc as StdArc;
+        use std::thread;
+
+        // Two engines that know each other. Wrap in Arc for sharing.
+        let (init_priv, init_pub) = keypair();
+        let (resp_priv, resp_pub) = keypair();
+        let any_v4: Vec<ipnet::IpNet> = vec!["0.0.0.0/0".parse().unwrap()];
+        let init = StdArc::new(WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: resp_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: any_v4.clone(),
+            }],
+        }));
+        let resp = StdArc::new(WgEngine::new(WgEngineConfig {
+            local_private_key: resp_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: init_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: any_v4,
+            }],
+        }));
+
+        let stop = StdArc::new(AtomicBool::new(false));
+        let completed = StdArc::new(AtomicU32::new(0));
+
+        // Driver thread: full handshakes init<->resp, repeatedly.
+        let driver = {
+            let init = init.clone();
+            let resp = resp.clone();
+            let completed = completed.clone();
+            let stop = stop.clone();
+            thread::spawn(move || {
+                for _ in 0..400 {
+                    let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+                    if init.create_initiation(&resp_pub, &mut msg1).is_err() {
+                        continue;
+                    }
+                    let mut msg2 = [0u8; WG_MSG_RESPONSE_LEN];
+                    if resp
+                        .consume_initiation_create_response(&msg1, &mut msg2)
+                        .is_err()
+                    {
+                        continue;
+                    }
+                    if init.consume_response(&msg2).is_ok() {
+                        completed.fetch_add(1, AOrd::Relaxed);
+                    }
+                    thread::yield_now();
+                }
+                stop.store(true, AOrd::Relaxed);
+            })
+        };
+
+        // Reconcile thread on the RESPONDER: churn the initiator peer in/out
+        // while the driver completes handshakes, exercising the
+        // reconcile-drains-pending path and the reconcile_lock serialization
+        // concurrently with the lock-held responder completion.
+        let reconciler = {
+            let resp = resp.clone();
+            let stop = stop.clone();
+            thread::spawn(move || {
+                let cfg = vec![WgPeerConfig {
+                    pubkey: init_pub,
+                    endpoint: None,
+                    persistent_keepalive: 0,
+                    allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+                }];
+                let mut flip = false;
+                while !stop.load(AOrd::Relaxed) {
+                    // Alternate remove/re-add to exercise the
+                    // reconcile-drains-pending path against in-flight
+                    // responder reservations.
+                    if flip {
+                        resp.reconcile_peers(&[]);
+                    } else {
+                        resp.reconcile_peers(&cfg);
+                    }
+                    flip = !flip;
+                    thread::yield_now();
+                }
+                // Leave the peer present so the post-storm handshake works.
+                resp.reconcile_peers(&cfg);
+            })
+        };
+
+        driver.join().unwrap();
+        reconciler.join().unwrap();
+
+        // The race must have exercised real completions.
+        assert!(
+            completed.load(AOrd::Relaxed) > 0,
+            "no handshake completed — the race path was not exercised"
+        );
+
+        // Soundness: after the storm, drive ONE clean handshake and a
+        // transport round-trip; if the maps were corrupted the encap/decap
+        // would fail.
+        let mut m1 = [0u8; WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut m1).unwrap();
+        let mut m2 = [0u8; WG_MSG_RESPONSE_LEN];
+        resp.consume_initiation_create_response(&m1, &mut m2).unwrap();
+        init.consume_response(&m2).unwrap();
+        let pkt = ipv4_packet(Ipv4Addr::new(10, 9, 9, 1), Ipv4Addr::new(10, 9, 9, 2));
+        let mut w = [0u8; 2048];
+        let e = init.try_encap(&resp_pub, &pkt, &mut w).unwrap();
+        let mut p = [0u8; 2048];
+        let d = resp.try_decap(&w[..e.len], &mut p).unwrap();
+        assert_eq!(&p[..d.len], &pkt[..], "post-storm handshake must still carry traffic");
+    }
 }

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -1673,4 +1673,56 @@ mod framed_handshake {
         let d2 = init.try_decap(&w2[..e2.len], &mut p2).unwrap();
         assert_eq!(d2.peer_pubkey, resp_pub);
     }
+
+    /// A forged/garbled msg2 (valid framing + valid MAC1, since MAC1 keys on
+    /// the public initiator pubkey, but a corrupt Noise body) must NOT
+    /// destroy the initiator's pending reservation: the real msg2 that
+    /// arrives afterward must still complete the handshake. This is the
+    /// Codex code-review-round-1 finding 2 regression (an on-path observer
+    /// could otherwise DoS the handshake by racing a bogus msg2).
+    #[test]
+    fn forged_msg2_does_not_destroy_pending_reservation() {
+        let (init, resp, init_pub, resp_pub) = engine_pair();
+        let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1).unwrap();
+        assert_eq!(init.pending_count(), 1);
+
+        // Produce the REAL msg2 from the responder.
+        let mut real_msg2 = [0u8; WG_MSG_RESPONSE_LEN];
+        resp.consume_initiation_create_response(&msg1, &mut real_msg2)
+            .unwrap();
+
+        // Forge a msg2: copy the real one (so type/receiver_index/MAC1
+        // verify), then corrupt the Noise body so the snow read fails. MAC1
+        // covers msg[0..60]; the Noise body is msg[12..60], so corrupting a
+        // body byte breaks the Noise AEAD but NOT mac1... wait — mac1 DOES
+        // cover the body. So instead corrupt a byte the Noise read
+        // authenticates but mac1 also covers: to get a valid-mac1 forgery we
+        // must recompute mac1 over the corrupted prefix. Simplest faithful
+        // forgery: rebuild a msg2 with the right receiver_index + a random
+        // Noise body + a correctly-recomputed mac1 over OUR pubkey.
+        let mut forged = real_msg2;
+        // Corrupt the encrypted-empty AEAD tag region (msg[44..60]) so the
+        // Noise read fails, then recompute mac1 over msg[0..60] so framing
+        // still authenticates (mac1 keys on the initiator = us, a public key,
+        // so an attacker can do exactly this).
+        forged[50] ^= 0xFF;
+        let recomputed = crate::afxdp::wg::handshake::compute_mac1(&init_pub, &forged[..60]);
+        forged[60..76].copy_from_slice(&recomputed);
+
+        // The forged msg2 fails the Noise read but must leave the reservation
+        // intact.
+        let err = init.consume_response(&forged).unwrap_err();
+        assert_eq!(err, HandshakeError::Crypto);
+        assert_eq!(
+            init.pending_count(),
+            1,
+            "a forged msg2 must NOT consume/destroy the pending reservation"
+        );
+
+        // The REAL msg2 still completes the handshake.
+        init.consume_response(&real_msg2)
+            .expect("real msg2 must still complete after a forged one was rejected");
+        assert_eq!(init.pending_count(), 0);
+    }
 }

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -1388,3 +1388,289 @@ fn established_pair_responder_confirmation_flips_via_decap_path() {
         .try_encap(&init_pub, &reply, &mut wire2)
         .expect("post-confirmation encap must succeed");
 }
+
+// ===================================================================
+// Framed WG handshake — engine integration (#1709 S1)
+//
+// These exercise the full on-wire framed handshake (create_initiation /
+// consume_response / consume_initiation_create_response) BOTH directions
+// between two engines, and assert matching transport keys via a transport
+// record round-trip. This is xpf-against-xpf — a REGRESSION GUARD for the
+// engine integration, NOT the independent-peer interop proof. The live
+// kernel-WireGuard-on-a-VM interop (the byte-compliance proof against an
+// independent reference) is #1703 S2.
+// ===================================================================
+mod framed_handshake {
+    use super::*;
+    use crate::afxdp::wg::engine::HandshakeError;
+    use crate::afxdp::wg::handshake::FramingError;
+    use crate::afxdp::wg::{WG_MSG_INIT_LEN, WG_MSG_RESPONSE_LEN};
+
+    /// Build two engines that know each other's pubkey, allowing the full
+    /// `0.0.0.0/0` so any inner src passes the AllowedIPs gate.
+    fn engine_pair() -> (WgEngine, WgEngine, [u8; 32], [u8; 32]) {
+        let (init_priv, init_pub) = keypair();
+        let (resp_priv, resp_pub) = keypair();
+        let any_v4: Vec<ipnet::IpNet> = vec!["0.0.0.0/0".parse().unwrap()];
+        let init = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: resp_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: any_v4.clone(),
+            }],
+        });
+        let resp = WgEngine::new(WgEngineConfig {
+            local_private_key: resp_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: init_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: any_v4,
+            }],
+        });
+        (init, resp, init_pub, resp_pub)
+    }
+
+    #[test]
+    fn local_public_key_matches_snow_static() {
+        // The engine derives its local public key via dalek
+        // mul_base_clamped; it MUST equal the public key snow generated for
+        // the same private key (which engine_pair returns as init_pub/
+        // resp_pub from keypair()). A mismatch would mean inbound MAC1
+        // verification keys on the wrong pubkey and every real handshake
+        // would be dropped.
+        let (init, resp, init_pub, resp_pub) = engine_pair();
+        assert_eq!(
+            init.local_public_key(),
+            init_pub,
+            "engine local_public_key must equal snow's static pub for the same private key"
+        );
+        assert_eq!(resp.local_public_key(), resp_pub);
+    }
+
+    /// Full framed handshake, xpf initiator -> xpf responder, then a
+    /// transport record round-trip in BOTH directions proving the derived
+    /// transport keys match.
+    #[test]
+    fn framed_handshake_both_directions_roundtrip() {
+        let (init, resp, init_pub, resp_pub) = engine_pair();
+
+        // 1. Initiator builds msg1.
+        let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+        let init_idx = init.create_initiation(&resp_pub, &mut msg1).unwrap();
+        assert_eq!(init.pending_count(), 1, "initiator holds one pending handshake");
+
+        // 2. Responder consumes msg1, emits msg2, installs its session.
+        let mut msg2 = [0u8; WG_MSG_RESPONSE_LEN];
+        let (recovered_init_pub, resp_idx) =
+            resp.consume_initiation_create_response(&msg1, &mut msg2).unwrap();
+        assert_eq!(recovered_init_pub, init_pub,
+            "responder must recover the initiator's static pubkey from msg1");
+        assert_eq!(resp.pending_count(), 0, "responder completes synchronously");
+
+        // 3. Initiator consumes msg2, installs its session.
+        let installed_idx = init.consume_response(&msg2).unwrap();
+        assert_eq!(installed_idx, init_idx);
+        assert_eq!(init.pending_count(), 0, "initiator handshake promoted");
+
+        // 4. Initiator -> responder transport record (initiator is confirmed
+        //    at install; responder confirms on this first inbound record).
+        let inner = ipv4_packet(Ipv4Addr::new(10, 9, 9, 1), Ipv4Addr::new(10, 9, 9, 2));
+        let mut wire = [0u8; 2048];
+        let enc = init.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+        let mut plain = [0u8; 2048];
+        let dec = resp.try_decap(&wire[..enc.len], &mut plain).unwrap();
+        assert_eq!(&plain[..dec.len], &inner[..], "init->resp inner packet must round-trip");
+        assert_eq!(dec.peer_pubkey, init_pub);
+
+        // 5. Responder -> initiator transport record (responder now confirmed).
+        let reply = ipv4_packet(Ipv4Addr::new(10, 9, 9, 2), Ipv4Addr::new(10, 9, 9, 1));
+        let mut wire2 = [0u8; 2048];
+        let enc2 = resp.try_encap(&init_pub, &reply, &mut wire2).unwrap();
+        let mut plain2 = [0u8; 2048];
+        let dec2 = init.try_decap(&wire2[..enc2.len], &mut plain2).unwrap();
+        assert_eq!(&plain2[..dec2.len], &reply[..], "resp->init inner packet must round-trip");
+        assert_eq!(dec2.peer_pubkey, resp_pub);
+
+        // Indices are distinct (each side chose its own).
+        assert_ne!(init_idx, resp_idx);
+    }
+
+    /// msg1's mac1 keys on the RESPONDER's pubkey; a responder configured
+    /// with a different identity rejects it with Mac1Mismatch.
+    #[test]
+    fn responder_rejects_initiation_with_wrong_mac1() {
+        let (init, _resp, _init_pub, resp_pub) = engine_pair();
+        let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1).unwrap();
+
+        // A different responder (different static key) must reject the mac1.
+        let (other_priv, _other_pub) = keypair();
+        let (_init2_priv, init2_pub) = keypair();
+        let other = WgEngine::new(WgEngineConfig {
+            local_private_key: other_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: init2_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+            }],
+        });
+        let mut msg2 = [0u8; WG_MSG_RESPONSE_LEN];
+        let err = other
+            .consume_initiation_create_response(&msg1, &mut msg2)
+            .unwrap_err();
+        assert_eq!(err, HandshakeError::Framing(FramingError::Mac1Mismatch));
+    }
+
+    /// An initiation from a peer the responder does not know (valid mac1
+    /// because it targets the responder's real pubkey, but the initiator
+    /// static is unconfigured) is rejected as UnknownInitiator AFTER the
+    /// Noise read recovers the static key.
+    #[test]
+    fn responder_rejects_unknown_initiator() {
+        let (resp_priv, resp_pub) = keypair();
+        // Responder knows only some OTHER peer, not our initiator.
+        let (_known_priv, known_pub) = keypair();
+        let resp = WgEngine::new(WgEngineConfig {
+            local_private_key: resp_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: known_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+            }],
+        });
+        // A stranger initiator that targets the real responder pubkey.
+        let (stranger_priv, _stranger_pub) = keypair();
+        let stranger = WgEngine::new(WgEngineConfig {
+            local_private_key: stranger_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: resp_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+            }],
+        });
+        let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+        stranger.create_initiation(&resp_pub, &mut msg1).unwrap();
+        let mut msg2 = [0u8; WG_MSG_RESPONSE_LEN];
+        let err = resp
+            .consume_initiation_create_response(&msg1, &mut msg2)
+            .unwrap_err();
+        assert_eq!(err, HandshakeError::UnknownInitiator);
+    }
+
+    /// consume_response with a receiver_index that matches no pending
+    /// reservation is rejected as NoPendingHandshake (stale/spoofed msg2).
+    #[test]
+    fn consume_response_no_pending_is_rejected() {
+        let (init, resp, _init_pub, resp_pub) = engine_pair();
+        // Drive a full handshake so we have a VALID msg2, then replay it: the
+        // first consume promotes + clears the reservation; the second finds
+        // no pending entry.
+        let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1).unwrap();
+        let mut msg2 = [0u8; WG_MSG_RESPONSE_LEN];
+        resp.consume_initiation_create_response(&msg1, &mut msg2).unwrap();
+        init.consume_response(&msg2).unwrap();
+        // Replay msg2 — reservation already promoted/cleared.
+        let err = init.consume_response(&msg2).unwrap_err();
+        assert_eq!(err, HandshakeError::NoPendingHandshake);
+    }
+
+    /// create_initiation toward an unconfigured peer is UnknownPeer and
+    /// leaves no pending reservation.
+    #[test]
+    fn create_initiation_unknown_peer() {
+        let (init, _resp, _init_pub, _resp_pub) = engine_pair();
+        let (_x_priv, x_pub) = keypair();
+        let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+        let err = init.create_initiation(&x_pub, &mut msg1).unwrap_err();
+        assert_eq!(err, HandshakeError::UnknownPeer);
+        assert_eq!(init.pending_count(), 0);
+    }
+
+    /// At-most-one-pending-per-peer: a SECOND create_initiation toward the
+    /// same peer aborts the first reservation (pending stays at 1, not 2).
+    /// The first msg1's reservation is gone, so consuming a response to it
+    /// would fail — only the latest handshake survives.
+    #[test]
+    fn at_most_one_pending_per_peer() {
+        let (init, resp, _init_pub, resp_pub) = engine_pair();
+        let mut msg1_a = [0u8; WG_MSG_INIT_LEN];
+        let idx_a = init.create_initiation(&resp_pub, &mut msg1_a).unwrap();
+        assert_eq!(init.pending_count(), 1);
+
+        let mut msg1_b = [0u8; WG_MSG_INIT_LEN];
+        let idx_b = init.create_initiation(&resp_pub, &mut msg1_b).unwrap();
+        assert_ne!(idx_a, idx_b, "second handshake gets a fresh index");
+        assert_eq!(init.pending_count(), 1, "per-peer cap: only the latest pending survives");
+
+        // The responder answers the SECOND msg1; the initiator can complete
+        // it (its reservation survived).
+        let mut msg2_b = [0u8; WG_MSG_RESPONSE_LEN];
+        resp.consume_initiation_create_response(&msg1_b, &mut msg2_b).unwrap();
+        assert_eq!(init.consume_response(&msg2_b).unwrap(), idx_b);
+
+        // A response to the FIRST (aborted) handshake has no reservation.
+        // Build it by having a fresh responder answer msg1_a, then feeding
+        // the initiator that msg2 — its idx_a reservation was aborted.
+        let (init2, resp2, _ip2, rp2) = engine_pair();
+        let mut m1 = [0u8; WG_MSG_INIT_LEN];
+        let first = init2.create_initiation(&rp2, &mut m1).unwrap();
+        let mut m1b = [0u8; WG_MSG_INIT_LEN];
+        init2.create_initiation(&rp2, &mut m1b).unwrap(); // aborts `first`
+        let mut m2 = [0u8; WG_MSG_RESPONSE_LEN];
+        resp2.consume_initiation_create_response(&m1, &mut m2).unwrap();
+        // m2's receiver_index echoes `first`, which is no longer pending.
+        let _ = first;
+        assert_eq!(
+            init2.consume_response(&m2).unwrap_err(),
+            HandshakeError::NoPendingHandshake,
+            "a response to an aborted (superseded) reservation must be dropped"
+        );
+    }
+
+    /// Reserve-before-send + promote: after a completed handshake BOTH
+    /// sessions are live + demuxable on their reserved indices — a record
+    /// the initiator sends decaps at the responder, and a record the
+    /// responder sends decaps at the initiator. Exercising both promoted
+    /// reservations proves the two-phase reserve→promote installs the demux
+    /// entries correctly.
+    #[test]
+    fn reserve_before_send_then_promote() {
+        let (init, resp, init_pub, resp_pub) = engine_pair();
+        let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1).unwrap();
+        let mut msg2 = [0u8; WG_MSG_RESPONSE_LEN];
+        resp.consume_initiation_create_response(&msg1, &mut msg2).unwrap();
+        init.consume_response(&msg2).unwrap();
+        assert_eq!(init.pending_count(), 0);
+        assert_eq!(resp.pending_count(), 0);
+
+        // init -> resp: decaps at the responder via its promoted index and
+        // confirms the (initially unconfirmed) responder session.
+        let fwd = ipv4_packet(Ipv4Addr::new(10, 9, 9, 1), Ipv4Addr::new(10, 9, 9, 2));
+        let mut w = [0u8; 2048];
+        let e = init.try_encap(&resp_pub, &fwd, &mut w).unwrap();
+        let mut p = [0u8; 2048];
+        let d = resp.try_decap(&w[..e.len], &mut p).unwrap();
+        assert_eq!(d.peer_pubkey, init_pub);
+
+        // resp -> init: decaps at the initiator via its promoted index.
+        let reply = ipv4_packet(Ipv4Addr::new(10, 9, 9, 2), Ipv4Addr::new(10, 9, 9, 1));
+        let mut w2 = [0u8; 2048];
+        let e2 = resp.try_encap(&init_pub, &reply, &mut w2).unwrap();
+        let mut p2 = [0u8; 2048];
+        let d2 = init.try_decap(&w2[..e2.len], &mut p2).unwrap();
+        assert_eq!(d2.peer_pubkey, resp_pub);
+    }
+}

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -1725,4 +1725,40 @@ mod framed_handshake {
             .expect("real msg2 must still complete after a forged one was rejected");
         assert_eq!(init.pending_count(), 0);
     }
+
+    /// reconcile_peers must drain a removed peer's in-flight handshake
+    /// reservation from both `pending` and `pending_by_peer` (Copilot
+    /// code-review finding). Otherwise the reservation + its consumed index
+    /// leak until process restart.
+    #[test]
+    fn reconcile_drains_removed_peer_pending_reservation() {
+        let (init, _resp, _init_pub, resp_pub) = engine_pair();
+        // Start an initiation (reserves a pending handshake for resp_pub) but
+        // do not complete it.
+        let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1).unwrap();
+        assert_eq!(init.pending_count(), 1);
+
+        // Reconcile the peer away (empty config removes resp_pub).
+        init.reconcile_peers(&[]);
+
+        // The pending reservation must be drained.
+        assert_eq!(
+            init.pending_count(),
+            0,
+            "removing a peer must drain its in-flight handshake reservation"
+        );
+
+        // Re-add the peer; a fresh initiation must succeed (the per-peer
+        // marker was cleared, so the at-most-one-pending invariant is intact).
+        init.reconcile_peers(&[WgPeerConfig {
+            pubkey: resp_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+        }]);
+        let mut msg1b = [0u8; WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1b).unwrap();
+        assert_eq!(init.pending_count(), 1);
+    }
 }

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -1763,26 +1763,112 @@ mod framed_handshake {
     }
 
     /// reserve_pending_locked re-checks the peer UNDER reconcile_lock (Codex
-    /// round-3 TOCTOU finding). Removing the peer means create_initiation must
-    /// return UnknownPeer and leave NO pending reservation — otherwise a
-    /// reservation for a removed peer would leak (reconcile_peers's drain
-    /// iterates the table's pubkeys, which no longer contains it).
+    /// round-3 TOCTOU finding). The simple sequential case: create_initiation
+    /// after the peer is removed returns UnknownPeer and reserves nothing.
     #[test]
     fn create_initiation_after_peer_removed_leaves_no_reservation() {
         let (init, _resp, _init_pub, resp_pub) = engine_pair();
-        // Remove the peer.
         init.reconcile_peers(&[]);
-        // create_initiation must fail UnknownPeer and reserve nothing.
         let mut msg1 = [0u8; WG_MSG_INIT_LEN];
         assert_eq!(
             init.create_initiation(&resp_pub, &mut msg1).unwrap_err(),
             HandshakeError::UnknownPeer
         );
+        assert_eq!(init.pending_count(), 0);
+    }
+
+    /// Deterministic TOCTOU regression (Codex round-4): exercise the exact
+    /// fixed branch — the under-lock peer recheck in reserve_pending_locked —
+    /// rather than rely on a narrow race a concurrency test can't reliably
+    /// hit. `try_reserve_pending_for_test` acquires reconcile_lock and calls
+    /// reserve_pending_locked just as the completion paths do; after the peer
+    /// is removed it must return UnknownPeer and create NO reservation.
+    /// Without the under-lock recheck this reservation would be created and
+    /// leak (reconcile's drain iterates the current table's pubkeys, which no
+    /// longer include the removed peer).
+    #[test]
+    fn reserve_pending_locked_rejects_removed_peer() {
+        use crate::afxdp::wg::session::SessionRole;
+        let (init, _resp, _init_pub, resp_pub) = engine_pair();
+        // Peer present: reserving succeeds.
+        let idx = init
+            .try_reserve_pending_for_test(resp_pub, SessionRole::Initiator)
+            .expect("reserve must succeed while the peer is configured");
+        assert_eq!(init.pending_count(), 1);
+        // Drain it so we start clean.
+        init.reconcile_peers(&[]);
+        assert_eq!(init.pending_count(), 0);
+        let _ = idx;
+
+        // Re-add then remove to mimic the published-table state at the moment
+        // a TOCTOU create would acquire the lock: peer absent from the table.
+        init.reconcile_peers(&[]);
+        // Now reserve under the lock for the (absent) peer — the under-lock
+        // recheck must reject it.
+        assert_eq!(
+            init.try_reserve_pending_for_test(resp_pub, SessionRole::Initiator)
+                .unwrap_err(),
+            HandshakeError::UnknownPeer
+        );
         assert_eq!(
             init.pending_count(),
             0,
-            "no reservation may be created for a removed peer"
+            "reserve_pending_locked must not create a reservation for a removed peer"
         );
+    }
+
+    /// Liveness/soundness smoke: hammer full handshakes while a thread churns
+    /// the peer in/out via reconcile_peers, exercising the lock serialization
+    /// and the reconcile-drains-pending path. Must not panic/deadlock and a
+    /// post-storm clean handshake must still carry traffic.
+    #[test]
+    fn create_initiation_toctou_under_concurrent_peer_removal() {
+        use std::sync::atomic::{AtomicBool, Ordering as AOrd};
+        use std::sync::Arc as StdArc;
+        use std::thread;
+
+        let (init_priv, _init_pub) = keypair();
+        let (_resp_priv, resp_pub) = keypair();
+        let cfg = vec![WgPeerConfig {
+            pubkey: resp_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+        }];
+        let init = StdArc::new(WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: cfg.clone(),
+        }));
+        let stop = StdArc::new(AtomicBool::new(false));
+        let initiator = {
+            let init = init.clone();
+            let stop = stop.clone();
+            thread::spawn(move || {
+                for _ in 0..3000 {
+                    let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+                    let _ = init.create_initiation(&resp_pub, &mut msg1);
+                }
+                stop.store(true, AOrd::Relaxed);
+            })
+        };
+        let churner = {
+            let init = init.clone();
+            let stop = stop.clone();
+            let cfg = cfg.clone();
+            thread::spawn(move || {
+                while !stop.load(AOrd::Relaxed) {
+                    init.reconcile_peers(&[]);
+                    init.reconcile_peers(&cfg);
+                    thread::yield_now();
+                }
+            })
+        };
+        initiator.join().unwrap();
+        churner.join().unwrap();
+        // Settle peer-removed: no reservation may remain for the absent peer.
+        init.reconcile_peers(&[]);
+        assert_eq!(init.pending_count(), 0, "no orphan reservation after the storm");
     }
 
     /// Concurrency regression for the Codex round-2 finding: completing a

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -1762,6 +1762,29 @@ mod framed_handshake {
         assert_eq!(init.pending_count(), 1);
     }
 
+    /// reserve_pending_locked re-checks the peer UNDER reconcile_lock (Codex
+    /// round-3 TOCTOU finding). Removing the peer means create_initiation must
+    /// return UnknownPeer and leave NO pending reservation — otherwise a
+    /// reservation for a removed peer would leak (reconcile_peers's drain
+    /// iterates the table's pubkeys, which no longer contains it).
+    #[test]
+    fn create_initiation_after_peer_removed_leaves_no_reservation() {
+        let (init, _resp, _init_pub, resp_pub) = engine_pair();
+        // Remove the peer.
+        init.reconcile_peers(&[]);
+        // create_initiation must fail UnknownPeer and reserve nothing.
+        let mut msg1 = [0u8; WG_MSG_INIT_LEN];
+        assert_eq!(
+            init.create_initiation(&resp_pub, &mut msg1).unwrap_err(),
+            HandshakeError::UnknownPeer
+        );
+        assert_eq!(
+            init.pending_count(),
+            0,
+            "no reservation may be created for a removed peer"
+        );
+    }
+
     /// Concurrency regression for the Codex round-2 finding: completing a
     /// handshake (create_initiation → consume_initiation_create_response →
     /// consume_response) must be sound under a concurrent thread hammering


### PR DESCRIPTION
## Summary

First build step of the #1703 WireGuard interop umbrella. Makes xpf's
WireGuard **handshake bytes** standards-compliant (peer-agnostic) so it can
interoperate with any reference-compliant peer (kernel WireGuard, UniFi 10.4+,
EdgeOS, UDM). Adds the 12-byte TAI64N timestamp and the WireGuard handshake
on-wire framing (message types 1/2, MAC1 = keyed-BLAKE2s-128, MAC2 zeros) on
both the build and parse paths, in both roles (initiator and responder), wired
into the snow-based engine via a two-phase index reservation.

`Closes #1709`. Part of #1703.

## What changed

- `wg/tai64n.rs` (new): in-process strictly-monotonic TAI64N clock. Epoch base
  `0x400000000000000a` (`2^62 + 10` leap-second offset), whitened nanos
  (`& 0xFF000000`), carry-into-seconds at `nanos >= 10^9`. Matches kernel WG /
  wireguard-go byte-for-byte.
- `wg/handshake.rs` (new): WG type-1 (148 B) / type-2 (92 B) framing. MAC1 =
  `keyed-BLAKE2s-128(BLAKE2s-256("mac1----" || recipient_static_pub), msg)` —
  keyed-BLAKE2s, NOT HMAC; keys on the recipient's static pub. MAC2 zeros
  (cookie = S7), skip-verified on parse.
- `wg/handshake_session.rs` (new): `create_initiation` / `consume_response` /
  `consume_initiation_create_response` compose snow + framing + TAI64N, both
  roles, control-thread only. Two-phase index reservation (reserve before
  send, at most one pending per peer) closes the blackhole race and bounds an
  authenticated-msg1-flood DoS.
- `wg/engine.rs`: adds `local_public_key` (derived once via
  `MontgomeryPoint::mul_base_clamped`) for inbound MAC1 verification + the
  TAI64N clock + pending-handshake maps. Net stays WATCH-tier (1772 LOC); the
  orchestration lives in `handshake_session.rs` to stay under the 2000-LOC
  refactor threshold.
- Docs: `docs/wireguard-interop.md` (new, with the explicit S1/S2 honesty
  note) + flipped the handshake-framing/TAI64N items in
  `docs/pr/wireguard-clean/plan.md` to DONE-in-S1.

## Plan + adversarial review

Plan: `docs/pr/1709-wireguard-s1-wire-protocol-compliance/plan.md` (v4,
PLAN-READY). Two rounds:
- Round 1: Codex PLAN-NEEDS-MAJOR, AGY PLAN-NEEDS-MAJOR, Claude-SMR
  PLAN-NEEDS-MINOR. Majors fixed in v3 (TAI64N epoch offset, index blackhole
  race, `local_public_key`, persistence story, KAT-gate strength).
- Round 2: AGY PLAN-READY, Codex PLAN-NEEDS-MINOR (text). v4 folded the
  nanos-carry-at-1e9 fix + the per-peer pending DoS cap + the full msg2 KAT.

All three reviewers independently verified snow byte-exactness, the
keyed-BLAKE2s-128 MAC1 construction + KAT vectors, and the recipient-key
direction.

## Test plan

- [x] `cargo build` clean (release)
- [x] `cargo test --release`: 1629 + 46 + 8 + 16 + 1 pass, 0 failures
      (one pre-existing concurrency stress test,
      `reconcile_peers_snapshot_is_atomic_under_concurrent_load`, flaked once
      under full-suite parallelism then passed 5/5 isolated + 3/3 full-suite;
      untouched by this branch)
- [x] Handshake tests 5x flake: 102 wg tests, 5/5 clean
- [x] Spec KAT vectors: construction hashes, MAC1 keyed-BLAKE2s-128 (dual-
      source: baked hex AND in-test re-derivation), full byte-exact msg1/msg2
      KATs, TAI64N encoding + carry-at-1e9 + concurrent monotonicity
- [x] Engine framed-handshake regression: full handshake BOTH directions
      (xpf-initiator <-> xpf-responder) with a transport-record round-trip
      proving matching transport keys; mac1/unknown-peer/unknown-initiator
      rejections; reserve-before-send + per-peer-pending-cap
- [x] Go suite: 32 packages pass (the only failure,
      `pkg/dataplane TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports`,
      is a pre-existing allowlist-drift that fails identically on clean master
      and is unrelated to this Rust-only change; the two
      `pkg/dataplane/userspace` failures were a long-`$TMPDIR` unix-socket
      path-length artifact that passes with a short TMPDIR)
- [x] `make audit-check`: green (engine.rs regen, 1725 -> 1772 LOC, WATCH-tier)

**No cluster smoke.** S1 is wire-protocol framing + unit/integration tests, NOT
a datapath change — the engine is still not on the AF_XDP hot path (that is
S2/S3), so the CoS/iperf3 matrix exercises no S1 code. Per the ratified
Option (b+) boundary, the live kernel-WireGuard-on-a-VM interop test (the
independent-peer proof) lands in S2 alongside the datapath/UDP wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)