### PR TITLE
#1710: locate SNMPv3 USM authParams by position, not by length heuristic

### DIFF
--- a/docs/pr/1710-snmpv3-authparams-position/plan.md
+++ b/docs/pr/1710-snmpv3-authparams-position/plan.md
@@ -1,0 +1,287 @@
+# #1710 — SNMPv3 USM: zero authParams by position, not by length heuristic
+
+Status: DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+`pkg/snmp/v3.go` `zeroAuthParams(pkt, truncLen)` blanks the
+`msgAuthenticationParameters` OCTET STRING before HMAC recomputation by
+scanning the raw packet for the **first non-zero OCTET STRING whose BER
+length == truncLen** and zeroing it. In the USM security-parameters
+SEQUENCE (RFC 3414) the field order is:
+
+```
+msgAuthoritativeEngineID   OCTET STRING
+msgAuthoritativeEngineBoots INTEGER
+msgAuthoritativeEngineTime  INTEGER
+msgUserName                 OCTET STRING   <-- precedes authParams
+msgAuthenticationParameters OCTET STRING   <-- the field we must zero
+msgPrivacyParameters        OCTET STRING
+```
+
+`truncLen` is 12 (HMAC-MD5-96 / HMAC-SHA-96) or 24 (HMAC-SHA-256, 192-bit
+truncation). A user whose username is exactly 12 chars (MD5/SHA-1) or 24
+chars (SHA-256) makes the scan hit `msgUserName` first (lower index,
+matching length, non-zero) and zero the username instead of authParams.
+HMAC then runs over a packet with the username blanked but authParams
+intact, the computed MAC never matches the received MAC, and that user is
+**locked out of SNMPv3**. A `msgAuthoritativeEngineID` of exactly
+`truncLen` bytes (e.g. a 12-byte engine ID, which is a legal length) is
+also scanned before authParams and would be zeroed first — second trigger
+of the same class.
+
+## Honest scope/value framing
+
+This is a management-plane correctness bug, not a perf change. The win is
+that SNMPv3 auth works for the (specific but entirely plausible) set of
+usernames/engine-IDs whose byte length collides with the HMAC truncation
+length. There is no throughput or cycle dimension. The blast radius is one
+helper (`zeroAuthParams`) plus its single caller (`verifyAuth`) plus the
+parse site in `handleV3Packet` that must surface the field offset. If
+reviewers conclude the fix is wrong or unneeded, PLAN-KILL is an acceptable
+verdict.
+
+## What's already in place
+
+- `handleV3Packet` (v3.go:125) already **fully parses** the USM sequence in
+  field order: engineID, boots, time, `userNameBytes`, `authParams`,
+  `privParams` — each via `berDecodeOctetString`/`berDecodeInteger`
+  (v3.go:183-212). The positional information the fix needs is already
+  computed; it is simply discarded.
+- All `berDecode*` helpers return **subslices of the original backing
+  array** (`data[headerLen : headerLen+length]`), not copies
+  (agent.go:815, 885). `data` passed into `handlePacket` is the source the
+  agent copies into `a.lastPacket` (agent.go:240-241). Therefore
+  `authParams` (a subslice reached through msgBody→afterHeader→secParamsRaw)
+  shares the same backing array as the packet `a.lastPacket` is copied
+  from; the value's byte offset within that array is well-defined.
+- `verifyAuth` (v3.go:371) copies `a.lastPacket` into a fresh `pkt`, calls
+  `zeroAuthParams(pkt, truncLen)`, then HMACs `pkt`.
+
+## Concrete design
+
+### 1. Compute the authParams byte offset at parse time
+
+`authParams` is a subslice of the same backing array as the slice handed to
+`handlePacket`. We do NOT have that original slice inside
+`handleV3Packet` (it receives `rest`, the post-version remainder). Two
+candidate offset sources:
+
+- **(A) pointer arithmetic against `a.lastPacket`'s source.** Fragile:
+  `a.lastPacket` is a *copy*, so its backing array differs from
+  `authParams`'s. We would need the pre-copy slice. Rejected.
+
+- **(B) pointer arithmetic against the slice the parse chain descends
+  from.** `handlePacket` has `data` (the original). It computes
+  `a.lastPacket` as a copy of `data`, then decodes `data` into `msgBody`,
+  passes `rest` to `handleV3Packet`. `authParams` is a subslice of `data`'s
+  backing array. The offset of `authParams` within `data` equals the offset
+  within `a.lastPacket` (same length, index-for-index copy). Compute it as
+  `offset = int(uintptr(unsafe.Pointer(&authParams[0])) -
+  uintptr(unsafe.Pointer(&data[0])))`. **Rejected** — introduces `unsafe`,
+  and `authParams` may be zero-length (empty authParams on a noAuth probe),
+  making `&authParams[0]` invalid.
+
+- **(C) Track offsets explicitly through the decode, no unsafe.** The clean
+  approach: replace the offset-free `berDecodeOctetString` calls in the USM
+  parse with offset-aware decoding **relative to `secParamsRaw`**, then
+  translate `secParamsRaw`'s base offset within `a.lastPacket`. But
+  `secParamsRaw` is also a subslice — its base offset must be tracked from
+  the top. This means threading a running offset from `handlePacket` down.
+
+  Cleanest no-unsafe form: have `handlePacket` pass `data` (the original
+  full packet) into the v3 handler and compute the offset using a helper
+  that walks the USM sequence **on `a.lastPacket` directly** to the
+  authParams field, returning its `(start, len)` — i.e. a *positional*
+  locator that decodes engineID, boots, time, userName, then authParams,
+  returning the byte range of the 5th field. This decodes structure, not
+  "first match of length L", so it is immune to the username/engineID
+  length collision.
+
+**Chosen design = (C) positional locator.** Add:
+
+```go
+// usmAuthParamsRange parses the USM security-parameters SEQUENCE that lives
+// inside the SNMPv3 message `pkt` and returns the [start,end) byte range of
+// the msgAuthenticationParameters OCTET STRING *value* (not its TLV header),
+// located by RFC 3414 field position. Returns ok=false if `pkt` is not a
+// well-formed v3 message with a USM sequence.
+func usmAuthParamsRange(pkt []byte) (start, end int, ok bool)
+```
+
+It re-walks the outer SEQUENCE → version INTEGER → header SEQUENCE →
+msgSecurityParameters OCTET STRING → USM SEQUENCE → engineID, boots, time,
+userName, then authParams, computing a running absolute offset into `pkt`
+via the consumed-byte counts of each TLV (header bytes + value bytes). No
+`unsafe`, no pointer arithmetic. Because it walks to the **fifth USM field
+by position**, a username or engineID of length `truncLen` cannot be
+mistaken for authParams.
+
+`zeroAuthParams` becomes:
+
+```go
+func zeroAuthParams(pkt []byte) {
+    start, end, ok := usmAuthParamsRange(pkt)
+    if !ok {
+        return
+    }
+    for j := start; j < end; j++ {
+        pkt[j] = 0
+    }
+}
+```
+
+`verifyAuth` drops the `truncLen` argument to `zeroAuthParams` (the range
+is determined by parse, not by the caller's expected length) but still uses
+`truncLen` for the `len(receivedMAC)` check and HMAC truncation. The
+zeroed range is exactly the authParams value as encoded on the wire — if a
+non-conformant peer sent an authParams of unexpected length, we zero what
+is actually there, which is the correct input to the HMAC recomputation
+per RFC 3414 §6.3.1 (blank the field as received).
+
+### Why re-walk instead of plumbing the offset from handleV3Packet
+
+`handleV3Packet` already parses the same fields, so re-walking duplicates
+work. But threading an absolute offset out of `handleV3Packet` requires
+`handlePacket` to compute `rest`'s offset within `data`, pass it down, and
+`handleV3Packet` to accumulate offsets across `berDecodeHeader` /
+`berEncodedLen` boundaries — touching the hot decode path and several call
+sites for a once-per-auth-packet operation. A self-contained
+`usmAuthParamsRange(a.lastPacket)` called only from `verifyAuth` keeps the
+change to one helper + its caller, is independently testable, and runs only
+on the auth path (never per-PDU). The duplicate parse is negligible
+(management plane, one SNMP request).
+
+### Offset accounting detail
+
+`berDecodeHeader` returns `(tag, value, err)` but not bytes consumed. I will
+use `berEncodedLen(slice)` (agent.go:988, returns total TLV length =
+header+value) and `berDecodeLength` to advance an absolute cursor. The
+locator computes, at each step, `cursor += headerBytes` before reading a
+value and `cursor += valueLen` after, so when it reaches the authParams
+value the cursor is its absolute start. I will assert in tests that
+`start..end` lands exactly on the authParams bytes for both 12- and
+24-char usernames and for a 12-byte engineID.
+
+## Public API preservation
+
+- `zeroAuthParams` is unexported, single caller (`verifyAuth`). Signature
+  changes from `(pkt []byte, truncLen int)` to `(pkt []byte)`. No external
+  consumer.
+- `verifyAuth` signature unchanged.
+- `handleV3Packet` / `handlePacket` signatures unchanged.
+- New unexported helper `usmAuthParamsRange`.
+- `insertAuthMAC` (the response-build mirror, v3.go:691) is **out of
+  scope** — see below.
+
+## Hidden invariants the change must preserve
+
+- **HMAC input identity (RFC 3414 §6.3.1):** the packet handed to HMAC must
+  be byte-identical to the received packet except authParams blanked to
+  zeros. Zeroing exactly the parsed authParams value range preserves this
+  (same as before for the non-colliding case; corrects the colliding case).
+- **Copy isolation:** `verifyAuth` still HMACs a *copy* of `lastPacket`, so
+  the original packet (used downstream for decrypt) is untouched. The
+  locator runs read-only on the copy.
+- **Empty / malformed packets:** locator returns `ok=false` →
+  `zeroAuthParams` no-ops → HMAC over the unmodified copy → mismatch →
+  auth fails closed. Same fail-closed posture as today (today's loop simply
+  finds nothing and returns). No new panic path: all indexing is guarded by
+  `berDecode*` truncation checks and an explicit `start/end <= len(pkt)`
+  guard.
+- **truncLen still gates `len(receivedMAC)`** in `verifyAuth` — unchanged.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Positional locator is a strict superset of correctness vs the heuristic; non-colliding packets get the identical authParams range zeroed. New tests pin both paths. |
+| Lifetime / borrow | N/A (Go) | No `unsafe`, no aliasing; operates on the local copy. |
+| Performance | NONE | Management plane, one re-parse per auth packet; never per-PDU/per-packet on the dataplane. |
+| Architectural mismatch | LOW | Self-contained helper; does not re-plumb the decode hot path. Matches existing `berDecode*` walk style. |
+
+## Test plan
+
+New tests in `pkg/snmp` (table-driven, build a real v3 USM packet, run the
+verify path):
+
+1. **Regression — 12-char username, SHA-1 (truncLen 12):** construct a
+   v3 authNoPriv message for a user with a 12-byte name, real HMAC-SHA-96
+   authParams. Assert `verifyAuth` returns true. With the old heuristic this
+   fails (username zeroed). Also assert with MD5 (truncLen 12).
+2. **Regression — 24-char username, SHA-256 (truncLen 24):** same, name 24
+   bytes. Assert auth succeeds.
+3. **Negative-collision — 12-byte engineID:** username short (e.g. 4 chars),
+   engineID exactly 12 bytes, SHA-1. Assert auth succeeds (engineID must NOT
+   be zeroed).
+4. **Locator unit test:** `usmAuthParamsRange` returns the exact
+   `[start,end)` of authParams for a hand-built packet; cross-check by
+   confirming `pkt[start:end]` equals the known authParams bytes and that
+   the username/engineID bytes are at different offsets.
+5. **Non-colliding control:** ordinary 5-char username, SHA-1 — auth
+   succeeds (proves no regression for the common case the old code handled).
+6. **Malformed packet:** truncated USM sequence → `usmAuthParamsRange`
+   returns ok=false, `verifyAuth` returns false (fail closed), no panic.
+
+To exercise `verifyAuth` end-to-end the test must set `a.lastPacket` and a
+`usmUser` with `authKey`/`authProto`, then call the unexported `verifyAuth`
+(same package). I will build the packet with the existing `berEncodeTLV`
+helpers so the encoding matches what the agent emits, compute the real
+HMAC over the zeroed-placeholder form, splice it in, then verify.
+
+Gates:
+
+- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/snmp/...` — green.
+- New auth tests run 5× (flake check).
+- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./...` — full Go suite.
+  Pre-existing `pkg/dataplane/userspace` sandbox unix-socket failures are
+  known artifacts; reproduce on clean master and document.
+- `make audit-check` (regen only if a file crosses the size threshold —
+  unlikely for a ~40-line helper).
+- **No cluster smoke** — this is a control-plane (SNMP management) change
+  with no dataplane/CoS/HA surface. The gate is the Go suite plus the new
+  auth tests.
+
+## Out of scope (explicitly)
+
+- **`insertAuthMAC` (v3.go:691)** uses the same first-OCTET-STRING-of-length
+  heuristic on the **response-build** path. There the authParams placeholder
+  is `make([]byte, truncLen)` (all-zero) and the locator requires the match
+  to be all-zero, so a non-zero username of length `truncLen` is skipped.
+  The residual risk is a username of exactly `truncLen` **zero** bytes
+  (implausible) or a privParams placeholder collision. The response path
+  builds the packet itself and knows the placeholder offset directly, so the
+  correct fix there is to thread the offset from the builder, not re-walk —
+  a different change. Tracked separately; not in this PR. I will note it in
+  a code comment so it is not forgotten.
+- Any change to BER decode helpers, the v2c path, or trap emission.
+- DES/AES privacy paths.
+
+## Open questions for adversarial review (each may justify PLAN-KILL)
+
+1. **Is positional re-walk actually immune?** Confirm that decoding to the
+   5th USM field by position cannot be fooled by a malformed sequence where
+   an earlier field's declared length over/under-runs. (My read: `berDecode*`
+   truncation checks make an over-run return err → ok=false → fail closed.
+   Is there a length-confusion variant that lands the cursor on the wrong
+   field while still returning ok=true?)
+2. **Offset accounting correctness.** Does using `berEncodedLen` +
+   `berDecodeLength` to advance an absolute cursor through nested
+   SEQUENCE/OCTET-STRING wrappers (outer SEQ → version → header SEQ →
+   secParams OCTET STRING → USM SEQ) correctly arrive at the authParams
+   value start, accounting for multi-byte BER length encodings on the outer
+   wrappers? Worked example requested.
+3. **Should the fix instead plumb the offset out of `handleV3Packet`** (no
+   duplicate parse) rather than re-walk in a standalone locator? Trade-off:
+   touches the decode path + several call sites vs a once-per-auth re-parse.
+   Is the re-walk's duplication a real defect or acceptable?
+4. **Fail-closed posture:** is no-op-on-unparseable the right behavior, or
+   should a parse failure in the locator be distinguishable from "authParams
+   legitimately absent"? Today both fall through to mismatch. Acceptable?
+5. **Is the bug even reachable in this codebase's config surface?** Does the
+   SNMP config allow a 12/24-char username (no length cap that would prevent
+   it)? If usernames are hard-capped below 12 the bug is latent-only — but
+   the engineID-collision trigger remains, and Junos/standard USM allows
+   long usernames. Verify the config path imposes no cap that makes this
+   purely theoretical (which would weaken but not eliminate the fix's value
+   via the engineID path).

--- a/docs/pr/1710-snmpv3-authparams-position/plan.md
+++ b/docs/pr/1710-snmpv3-authparams-position/plan.md
@@ -1,6 +1,49 @@
 # #1710 — SNMPv3 USM: zero authParams by position, not by length heuristic
 
-Status: DRAFT v1 — pending adversarial plan review
+Status: v2 — Codex PLAN-NEEDS-MINOR (4 minors addressed below) + AGY
+PLAN-READY. Core positional design ratified by both; no KILL
+counterexample found.
+
+## Adversarial review resolution (round 1)
+
+- **Codex** (task-mpta4cny-05mmyf): PLAN-NEEDS-MINOR. Core design immune
+  to the collision; no KILL counterexample. 4 minors, all resolved below.
+- **AGY** (adversarial-review-mpta4okq-75xv55): PLAN-READY, with a
+  bounds-checking hardening note (same as Codex minor #1).
+
+Resolutions:
+
+1. **Bounded parse invariant (Codex #1 / AGY hardening).** The locator
+   MUST decode every child TLV from its **parent value slice**, never from
+   `pkt[cursor:]`, so a nested length cannot escape its enclosing
+   SEQUENCE/OCTET-STRING. `berEncodedLen` returns the *advertised* size
+   without bounds-checking it fits (agent.go:988-996); the safety comes
+   from `berDecodeHeader`/`berDecodeOctetString` decoding against the
+   bounded container slice (agent.go:812-815, 882-885). Implementation:
+   the locator descends by slicing the parent's value (returned by
+   `berDecodeHeader`) and accumulates the absolute offset as
+   `base += headerBytes` on descent / `base += berEncodedLen(field)` on
+   sibling-skip, where each step first decodes from the bounded slice (so
+   an over-run returns err → ok=false). Every cursor advance is also
+   guarded by an explicit `start >= 0 && end <= len(pkt)` check before the
+   range is returned.
+2. **`ok` semantics (Codex #2).** The locator parses through the **sixth**
+   USM field (privParams) before returning `ok=true`, matching
+   `handleV3Packet`'s requirement that privParams decode (v3.go:208-212).
+   `ok=true` therefore means "the USM sequence is well-formed through
+   privParams and authParams is locatable." Documented on the helper.
+3. **Long-form length test (Codex #3).** Test 7 added: a packet whose
+   `msgSecurityParameters` OCTET STRING (and outer SEQUENCE) carry a
+   long-form (>127) BER length, exercising the multi-byte
+   `headerBytes = 1 + lenBytes` path (`berDecodeLength` long-form,
+   agent.go:824-838).
+4. **authParams-length wording (Codex #4).** Corrected: `verifyAuth`
+   rejects `len(receivedMAC) != truncLen` *before* calling
+   `zeroAuthParams` (v3.go:376-379), so a non-truncLen authParams never
+   reaches the zeroing path. The locator zeroes the on-wire authParams
+   value range regardless of its length, but for any packet that gets that
+   far the length already equals `truncLen`. The earlier "zero
+   unexpected-length authParams as received" rationale is withdrawn.
 
 ## Issue framing
 

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -381,7 +381,7 @@ func (a *Agent) verifyAuth(user *usmUser, receivedMAC []byte) bool {
 	// Build a copy of the whole packet with authParams zeroed.
 	pkt := make([]byte, len(a.lastPacket))
 	copy(pkt, a.lastPacket)
-	zeroAuthParams(pkt, truncLen)
+	zeroAuthParams(pkt)
 
 	mac := hmac.New(hashFn, user.authKey)
 	mac.Write(pkt)
@@ -392,34 +392,181 @@ func (a *Agent) verifyAuth(user *usmUser, receivedMAC []byte) bool {
 	return hmac.Equal(computed, receivedMAC)
 }
 
-// zeroAuthParams finds the auth params OCTET STRING in a raw SNMPv3 packet and zeroes it.
-func zeroAuthParams(pkt []byte, truncLen int) {
-	for i := 0; i < len(pkt)-truncLen-1; i++ {
-		if pkt[i] == tagOctetString {
-			length, lenBytes, err := berDecodeLength(pkt[i+1:])
-			if err != nil {
-				continue
-			}
-			if length == truncLen {
-				start := i + 1 + lenBytes
-				if start+truncLen <= len(pkt) {
-					nonZero := false
-					for j := start; j < start+truncLen; j++ {
-						if pkt[j] != 0 {
-							nonZero = true
-							break
-						}
-					}
-					if nonZero {
-						for j := start; j < start+truncLen; j++ {
-							pkt[j] = 0
-						}
-						return
-					}
-				}
-			}
-		}
+// zeroAuthParams blanks the USM msgAuthenticationParameters value in a raw
+// SNMPv3 packet (in place) before HMAC recomputation, per RFC 3414 §6.3.1.
+//
+// It locates authParams by its POSITION in the parsed USM
+// security-parameters SEQUENCE (#1710), not by a length heuristic. The
+// previous implementation scanned for the first non-zero OCTET STRING whose
+// BER length matched the HMAC truncation length, which mistakenly zeroed
+// msgUserName (a 12- or 24-char username collides with truncLen) or a
+// truncLen-byte msgAuthoritativeEngineID instead of authParams, locking the
+// user out of SNMPv3. If the packet is not a well-formed v3 USM message the
+// function is a no-op, so HMAC then runs over the unmodified copy and
+// verifyAuth fails closed.
+func zeroAuthParams(pkt []byte) {
+	start, end, ok := usmAuthParamsRange(pkt)
+	if !ok {
+		return
 	}
+	for j := start; j < end; j++ {
+		pkt[j] = 0
+	}
+}
+
+// usmAuthParamsRange walks the SNMPv3 message in pkt to the USM
+// msgAuthenticationParameters field and returns the [start,end) byte range
+// of its OCTET STRING value within pkt. ok is true only when the message is
+// well-formed all the way through the sixth USM field (msgPrivacyParameters),
+// matching the parse requirements of handleV3Packet; ok=true therefore means
+// "the USM sequence parsed cleanly and authParams is locatable."
+//
+// The field is found by RFC 3414 position — engineID, boots, time,
+// msgUserName, msgAuthenticationParameters, msgPrivacyParameters — so a
+// username or engineID whose length happens to equal the HMAC truncation
+// length is never mistaken for authParams.
+//
+// Every descent decodes the child TLV from its parent's bounded value slice
+// (returned by berDecodeHeader/berDecodeOctetString), never from a raw
+// pkt[cursor:] window, so a nested length cannot escape its enclosing
+// SEQUENCE/OCTET STRING: an over-running length makes the bounded decode
+// return an error and ok=false. The absolute cursor into pkt is advanced by
+// the byte counts the bounded decode consumed.
+func usmAuthParamsRange(pkt []byte) (start, end int, ok bool) {
+	// Outer message SEQUENCE.
+	tag, msgBody, err := berDecodeHeader(pkt)
+	if err != nil || tag != tagSequence {
+		return 0, 0, false
+	}
+	// base = absolute offset of msgBody[0] within pkt = the outer SEQUENCE's
+	// TLV header length. berEncodedLen(pkt) is header+value and len(msgBody)
+	// is value, so their difference is the header length — independent of
+	// whether the outer SEQUENCE fills the whole datagram.
+	outerHdr := berEncodedLen(pkt) - len(msgBody)
+	if outerHdr < 0 {
+		return 0, 0, false
+	}
+	base := outerHdr
+
+	// version INTEGER.
+	cur := msgBody
+	off, ok := advancePastTLV(cur, tagInteger)
+	if !ok {
+		return 0, 0, false
+	}
+	base += off
+	cur = cur[off:]
+
+	// msgGlobalData header SEQUENCE.
+	off, ok = advancePastTLV(cur, tagSequence)
+	if !ok {
+		return 0, 0, false
+	}
+	base += off
+	cur = cur[off:]
+
+	// msgSecurityParameters OCTET STRING wrapping the USM SEQUENCE.
+	secParams, _, err := berDecodeOctetString(cur)
+	if err != nil {
+		return 0, 0, false
+	}
+	// Absolute offset of the OCTET STRING value (the USM bytes) within pkt:
+	// the value sits after this OCTET STRING's TLV header.
+	usmHdrLen := berEncodedLen(cur) - len(secParams)
+	if usmHdrLen < 0 {
+		return 0, 0, false
+	}
+	usmBase := base + usmHdrLen
+
+	// USM SEQUENCE.
+	tag, usmBody, err := berDecodeHeader(secParams)
+	if err != nil || tag != tagSequence {
+		return 0, 0, false
+	}
+	usmSeqHdr := berEncodedLen(secParams) - len(usmBody)
+	if usmSeqHdr < 0 {
+		return 0, 0, false
+	}
+	usmBodyBase := usmBase + usmSeqHdr
+
+	// USM fields by position: engineID, boots, time, userName, authParams.
+	f := usmBody
+	fbase := usmBodyBase
+
+	// msgAuthoritativeEngineID OCTET STRING.
+	off, ok = advancePastTLV(f, tagOctetString)
+	if !ok {
+		return 0, 0, false
+	}
+	fbase += off
+	f = f[off:]
+
+	// msgAuthoritativeEngineBoots INTEGER.
+	off, ok = advancePastTLV(f, tagInteger)
+	if !ok {
+		return 0, 0, false
+	}
+	fbase += off
+	f = f[off:]
+
+	// msgAuthoritativeEngineTime INTEGER.
+	off, ok = advancePastTLV(f, tagInteger)
+	if !ok {
+		return 0, 0, false
+	}
+	fbase += off
+	f = f[off:]
+
+	// msgUserName OCTET STRING.
+	off, ok = advancePastTLV(f, tagOctetString)
+	if !ok {
+		return 0, 0, false
+	}
+	fbase += off
+	f = f[off:]
+
+	// msgAuthenticationParameters OCTET STRING — the field to blank.
+	authVal, afterAuth, err := berDecodeOctetString(f)
+	if err != nil {
+		return 0, 0, false
+	}
+	authHdrLen := berEncodedLen(f) - len(authVal)
+	if authHdrLen < 0 {
+		return 0, 0, false
+	}
+	start = fbase + authHdrLen
+	end = start + len(authVal)
+	if start < 0 || end > len(pkt) || start > end {
+		return 0, 0, false
+	}
+
+	// msgPrivacyParameters OCTET STRING — parse to confirm well-formedness
+	// (matches handleV3Packet, which requires privParams to decode).
+	if _, _, err := berDecodeOctetString(afterAuth); err != nil {
+		return 0, 0, false
+	}
+
+	return start, end, true
+}
+
+// advancePastTLV decodes one TLV of the expected tag from the bounded slice
+// data and returns the number of bytes it occupies (header + value), so the
+// caller can advance both its slice and an absolute cursor in lockstep. ok is
+// false if the tag does not match or the TLV is malformed/truncated relative
+// to data's bounds.
+func advancePastTLV(data []byte, expectTag byte) (consumed int, ok bool) {
+	if len(data) == 0 || data[0] != expectTag {
+		return 0, false
+	}
+	tag, _, err := berDecodeHeader(data)
+	if err != nil || tag != expectTag {
+		return 0, false
+	}
+	n := berEncodedLen(data)
+	if n <= 0 || n > len(data) {
+		return 0, false
+	}
+	return n, true
 }
 
 // decryptPDU decrypts an encrypted scopedPDU using the user's privacy key.

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -834,32 +834,23 @@ func (a *Agent) buildV3Response(msgID int, reqFlags byte, user *usmUser,
 	return wholeMsg
 }
 
-// insertAuthMAC finds the zeroed auth placeholder in a packet and replaces it with the HMAC.
+// insertAuthMAC writes the computed HMAC into the USM
+// msgAuthenticationParameters field of a freshly built SNMPv3 response.
+//
+// It locates the field by USM position via usmAuthParamsRange (the same
+// positional locator zeroAuthParams uses) rather than scanning for the first
+// all-zero OCTET STRING of length truncLen. The old heuristic could land on
+// an earlier all-zero field of the same length -- e.g. an all-zero
+// truncLen-byte engineID or username -- and corrupt it instead of the
+// authParams placeholder (the response-path sibling of #1710). The
+// end-start == len(authMAC) check guards against writing a MAC of the wrong
+// length into a mismatched slot.
 func insertAuthMAC(pkt, authMAC []byte, truncLen int) {
-	for i := 0; i < len(pkt)-truncLen; i++ {
-		if pkt[i] == tagOctetString {
-			length, lenBytes, err := berDecodeLength(pkt[i+1:])
-			if err != nil {
-				continue
-			}
-			if length == truncLen {
-				start := i + 1 + lenBytes
-				if start+truncLen <= len(pkt) {
-					allZero := true
-					for j := start; j < start+truncLen; j++ {
-						if pkt[j] != 0 {
-							allZero = false
-							break
-						}
-					}
-					if allZero {
-						copy(pkt[start:start+truncLen], authMAC)
-						return
-					}
-				}
-			}
-		}
+	start, end, ok := usmAuthParamsRange(pkt)
+	if !ok || end-start != truncLen || end-start != len(authMAC) {
+		return
 	}
+	copy(pkt[start:end], authMAC)
 }
 
 // V3UserInfo returns user info for display (without passwords).

--- a/pkg/snmp/v3_auth_test.go
+++ b/pkg/snmp/v3_auth_test.go
@@ -1,0 +1,285 @@
+package snmp
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"testing"
+)
+
+// buildV3AuthPacket constructs a complete SNMPv3 authNoPriv message for the
+// given user/engine parameters and returns the on-wire bytes together with
+// the byte range of the (real) msgAuthenticationParameters value. The
+// authParams are computed exactly as a conformant manager would: HMAC over
+// the message with the authParams field present but zeroed, truncated to
+// truncLen, then spliced back into that same field.
+//
+// longForm forces the msgSecurityParameters OCTET STRING (and therefore the
+// outer SEQUENCE) to carry a long-form (>127) BER length by padding the
+// engineID, exercising the multi-byte length path in the locator.
+func buildV3AuthPacket(t *testing.T, authProto string, userName string, engineID []byte, authKey []byte, longForm bool) (pkt []byte, authStart, authEnd int) {
+	t.Helper()
+
+	hashFn, _ := authHashFunc(authProto)
+	if hashFn == nil {
+		t.Fatalf("unknown auth proto %q", authProto)
+	}
+	truncLen := authTruncLen(authProto)
+
+	if longForm {
+		// Pad the engineID so the USM sequence (and its OCTET STRING wrapper)
+		// exceed 127 bytes, forcing long-form BER length encoding.
+		engineID = append(append([]byte{}, engineID...), bytes.Repeat([]byte{0xAB}, 200)...)
+	}
+
+	// USM security parameters with a zeroed authParams placeholder.
+	authPlaceholder := make([]byte, truncLen)
+	usmFields := berEncodeTLV(tagOctetString, engineID)
+	usmFields = append(usmFields, berEncodeIntegerTLV(1)...) // engineBoots
+	usmFields = append(usmFields, berEncodeIntegerTLV(2)...) // engineTime
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, []byte(userName))...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, authPlaceholder)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...) // privParams (empty)
+	usmOctet := berEncodeTLV(tagOctetString, berEncodeTLV(tagSequence, usmFields))
+
+	// Global header (msgID, maxSize, flags=auth, securityModel=USM).
+	hdr := berEncodeIntegerTLV(42)
+	hdr = append(hdr, berEncodeIntegerTLV(maxPacketSize)...)
+	hdr = append(hdr, berEncodeTLV(tagOctetString, []byte{msgFlagAuth})...)
+	hdr = append(hdr, berEncodeIntegerTLV(usmSecurityModel)...)
+	hdrSeq := berEncodeTLV(tagSequence, hdr)
+
+	// Scoped PDU (plaintext) — contextEngineID, contextName, empty GetRequest.
+	scopedBody := berEncodeTLV(tagOctetString, engineID)
+	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, nil)...)
+	scopedBody = append(scopedBody, berEncodeTLV(0xA0, nil)...) // GetRequest PDU, empty
+	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
+
+	// Assemble the whole message.
+	msgBody := berEncodeIntegerTLV(snmpVersion3)
+	msgBody = append(msgBody, hdrSeq...)
+	msgBody = append(msgBody, usmOctet...)
+	msgBody = append(msgBody, scopedPDU...)
+	wholeMsg := berEncodeTLV(tagSequence, msgBody)
+
+	// Locate the authParams field (still zeroed) and compute the HMAC over
+	// the zeroed-placeholder form, then splice it in.
+	start, end, ok := usmAuthParamsRange(wholeMsg)
+	if !ok {
+		t.Fatalf("usmAuthParamsRange failed on freshly built packet")
+	}
+	if end-start != truncLen {
+		t.Fatalf("authParams range %d..%d has len %d, want truncLen %d", start, end, end-start, truncLen)
+	}
+	mac := hmac.New(hashFn, authKey)
+	mac.Write(wholeMsg)
+	computed := mac.Sum(nil)
+	if len(computed) > truncLen {
+		computed = computed[:truncLen]
+	}
+	copy(wholeMsg[start:end], computed)
+
+	return wholeMsg, start, end
+}
+
+// runVerify exercises the agent's verifyAuth path end-to-end for a packet
+// built by buildV3AuthPacket.
+func runVerify(t *testing.T, authProto, userName string, engineID []byte, longForm bool) bool {
+	t.Helper()
+	hashFn, hashLen := authHashFunc(authProto)
+	authKey := passwordToKey("the-auth-password-1234", engineID, hashFn, hashLen)
+	if authKey == nil {
+		t.Fatalf("passwordToKey returned nil")
+	}
+
+	pkt, start, end := buildV3AuthPacket(t, authProto, userName, engineID, authKey, longForm)
+
+	a := &Agent{
+		engineID:   engineID,
+		v3Users:    map[string]*usmUser{},
+		lastPacket: pkt,
+	}
+	user := &usmUser{name: userName, authProto: authProto, authKey: authKey}
+	a.v3Users[userName] = user
+
+	// The received MAC is the authParams that were spliced into the packet.
+	receivedMAC := append([]byte{}, pkt[start:end]...)
+	return a.verifyAuth(user, receivedMAC)
+}
+
+// TestVerifyAuth_CollidingUsernameLength is the direct regression for #1710:
+// a username whose byte length equals the HMAC truncation length used to make
+// zeroAuthParams blank the username instead of authParams, breaking auth.
+func TestVerifyAuth_CollidingUsernameLength(t *testing.T) {
+	engineID := []byte{0x80, 0x00, 0x1f, 0x88, 0x80, 0x01, 0x02, 0x03} // 8 bytes, no collision
+
+	cases := []struct {
+		name      string
+		authProto string
+		userName  string // length == truncLen
+	}{
+		{"sha-12char-username", "sha", "abcdefghijkl"},                 // 12 chars, truncLen 12
+		{"md5-12char-username", "md5", "abcdefghijkl"},                 // 12 chars, truncLen 12
+		{"sha256-24char-username", "sha256", "abcdefghijklmnopqrstuvwx"}, // 24 chars, truncLen 24
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if len(c.userName) != authTruncLen(c.authProto) {
+				t.Fatalf("test setup: username len %d != truncLen %d", len(c.userName), authTruncLen(c.authProto))
+			}
+			if !runVerify(t, c.authProto, c.userName, engineID, false) {
+				t.Fatalf("verifyAuth failed for %s with %d-char username (regression #1710)", c.authProto, len(c.userName))
+			}
+		})
+	}
+}
+
+// TestVerifyAuth_CollidingEngineIDLength covers the second #1710 trigger: a
+// msgAuthoritativeEngineID of exactly truncLen bytes must not be mistaken for
+// authParams.
+func TestVerifyAuth_CollidingEngineIDLength(t *testing.T) {
+	// 12-byte engineID collides with SHA-1/MD5 truncLen. Username is short.
+	engineID := []byte{0x80, 0x00, 0x1f, 0x88, 0x80, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77}
+	if len(engineID) != authTruncLen("sha") {
+		t.Fatalf("test setup: engineID len %d != truncLen %d", len(engineID), authTruncLen("sha"))
+	}
+	if !runVerify(t, "sha", "user", engineID, false) {
+		t.Fatal("verifyAuth failed with a 12-byte engineID (regression #1710 engineID trigger)")
+	}
+}
+
+// TestVerifyAuth_NonColliding is the control: an ordinary short username on
+// the common path must still authenticate.
+func TestVerifyAuth_NonColliding(t *testing.T) {
+	engineID := []byte{0x80, 0x00, 0x1f, 0x88, 0x80, 0x09, 0x08, 0x07}
+	for _, proto := range []string{"md5", "sha", "sha256"} {
+		t.Run(proto, func(t *testing.T) {
+			if !runVerify(t, proto, "admin", engineID, false) {
+				t.Fatalf("verifyAuth failed for %s with ordinary username", proto)
+			}
+		})
+	}
+}
+
+// TestVerifyAuth_LongFormLength forces multi-byte (long-form, >127) BER
+// lengths on the wrapping TLVs so the locator's header-length accounting is
+// exercised against the long-form path (Codex plan-review minor #3).
+func TestVerifyAuth_LongFormLength(t *testing.T) {
+	engineID := []byte{0x80, 0x00, 0x1f, 0x88, 0x80, 0xAA, 0xBB, 0xCC}
+	if !runVerify(t, "sha256", "admin", engineID, true) {
+		t.Fatal("verifyAuth failed with long-form BER lengths")
+	}
+}
+
+// TestUsmAuthParamsRange_LocatesField checks that the locator returns the
+// exact authParams range and that the username/engineID occupy different,
+// non-overlapping ranges (so they cannot be confused even when their lengths
+// match truncLen).
+func TestUsmAuthParamsRange_LocatesField(t *testing.T) {
+	engineID := []byte{0x80, 0x00, 0x1f, 0x88, 0x80, 0x01, 0x02, 0x03}
+	authProto := "sha"
+	truncLen := authTruncLen(authProto)
+	hashFn, hashLen := authHashFunc(authProto)
+	authKey := passwordToKey("pw", engineID, hashFn, hashLen)
+	userName := "abcdefghijkl" // 12 chars == truncLen
+
+	pkt, start, end := buildV3AuthPacket(t, authProto, userName, engineID, authKey, false)
+	if end-start != truncLen {
+		t.Fatalf("authParams range len %d, want %d", end-start, truncLen)
+	}
+
+	// The username bytes must appear before authParams at a distinct offset.
+	unameIdx := bytes.Index(pkt, []byte(userName))
+	if unameIdx < 0 {
+		t.Fatal("username not found in packet")
+	}
+	if unameIdx >= start && unameIdx < end {
+		t.Fatalf("username offset %d overlaps authParams range %d..%d", unameIdx, start, end)
+	}
+	if unameIdx >= start {
+		t.Fatalf("username offset %d should precede authParams start %d", unameIdx, start)
+	}
+
+	// re-running the locator on a copy yields the same range (deterministic).
+	cp := append([]byte{}, pkt...)
+	s2, e2, ok := usmAuthParamsRange(cp)
+	if !ok || s2 != start || e2 != end {
+		t.Fatalf("locator non-deterministic: got %d..%d ok=%v, want %d..%d", s2, e2, ok, start, end)
+	}
+}
+
+// TestZeroAuthParams_ZeroesOnlyAuthParams confirms zeroAuthParams blanks
+// exactly the authParams value and leaves the username/engineID intact.
+func TestZeroAuthParams_ZeroesOnlyAuthParams(t *testing.T) {
+	engineID := []byte{0x80, 0x00, 0x1f, 0x88, 0x80, 0x01, 0x02, 0x03}
+	authProto := "sha"
+	hashFn, hashLen := authHashFunc(authProto)
+	authKey := passwordToKey("pw", engineID, hashFn, hashLen)
+	userName := "abcdefghijkl" // 12 chars == truncLen
+
+	pkt, start, end := buildV3AuthPacket(t, authProto, userName, engineID, authKey, false)
+
+	zeroAuthParams(pkt)
+
+	// authParams range is all zero.
+	for i := start; i < end; i++ {
+		if pkt[i] != 0 {
+			t.Fatalf("authParams byte %d not zeroed", i)
+		}
+	}
+	// Username bytes survive.
+	if !bytes.Contains(pkt, []byte(userName)) {
+		t.Fatal("username was zeroed by zeroAuthParams (bug #1710)")
+	}
+	// engineID bytes survive.
+	if !bytes.Contains(pkt, engineID) {
+		t.Fatal("engineID was zeroed by zeroAuthParams (bug #1710)")
+	}
+}
+
+// TestUsmAuthParamsRange_Malformed confirms fail-closed behavior: an
+// unparseable packet returns ok=false (no-op zero), so verifyAuth fails.
+func TestUsmAuthParamsRange_Malformed(t *testing.T) {
+	cases := map[string][]byte{
+		"empty":            {},
+		"not-a-sequence":   {0x02, 0x01, 0x03},
+		"truncated-seq":    {0x30, 0x05, 0x02, 0x01},
+		"seq-no-usm":       berEncodeTLV(tagSequence, berEncodeIntegerTLV(snmpVersion3)),
+		"usm-too-few-flds": buildShortUSM(),
+	}
+	for name, pkt := range cases {
+		t.Run(name, func(t *testing.T) {
+			cp := append([]byte{}, pkt...)
+			if _, _, ok := usmAuthParamsRange(cp); ok {
+				t.Fatalf("expected ok=false for malformed packet %q", name)
+			}
+			// zeroAuthParams must be a no-op (no panic, no mutation).
+			before := append([]byte{}, cp...)
+			zeroAuthParams(cp)
+			if !bytes.Equal(before, cp) {
+				t.Fatalf("zeroAuthParams mutated bytes for malformed packet %q", name)
+			}
+		})
+	}
+}
+
+// buildShortUSM builds a structurally valid v3 message whose USM sequence has
+// only four fields (missing authParams + privParams), so the locator must
+// fail closed.
+func buildShortUSM() []byte {
+	usmFields := berEncodeTLV(tagOctetString, []byte{0x01, 0x02})
+	usmFields = append(usmFields, berEncodeIntegerTLV(1)...)
+	usmFields = append(usmFields, berEncodeIntegerTLV(2)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, []byte("user"))...)
+	usmOctet := berEncodeTLV(tagOctetString, berEncodeTLV(tagSequence, usmFields))
+
+	hdr := berEncodeIntegerTLV(42)
+	hdr = append(hdr, berEncodeIntegerTLV(maxPacketSize)...)
+	hdr = append(hdr, berEncodeTLV(tagOctetString, []byte{msgFlagAuth})...)
+	hdr = append(hdr, berEncodeIntegerTLV(usmSecurityModel)...)
+	hdrSeq := berEncodeTLV(tagSequence, hdr)
+
+	msgBody := berEncodeIntegerTLV(snmpVersion3)
+	msgBody = append(msgBody, hdrSeq...)
+	msgBody = append(msgBody, usmOctet...)
+	return berEncodeTLV(tagSequence, msgBody)
+}

--- a/pkg/snmp/v3_auth_test.go
+++ b/pkg/snmp/v3_auth_test.go
@@ -212,6 +212,58 @@ func TestUsmAuthParamsRange_LocatesField(t *testing.T) {
 	if !ok || s2 != start || e2 != end {
 		t.Fatalf("locator non-deterministic: got %d..%d ok=%v, want %d..%d", s2, e2, ok, start, end)
 	}
+
+	// Independently walk the BER structure (NOT via usmAuthParamsRange) to
+	// derive the authParams offset, so the exact-offset assertion does not
+	// depend on the function under test.
+	wantStart, wantEnd := independentAuthParamsOffset(t, pkt)
+	if wantStart != start || wantEnd != end {
+		t.Fatalf("locator range %d..%d disagrees with independent walk %d..%d", start, end, wantStart, wantEnd)
+	}
+}
+
+// independentAuthParamsOffset computes the authParams value byte range by an
+// independent manual walk of the BER structure, deliberately NOT calling
+// usmAuthParamsRange, so it can cross-check the function under test.
+func independentAuthParamsOffset(t *testing.T, pkt []byte) (start, end int) {
+	t.Helper()
+	hdrLen := func(slice []byte) int {
+		_, lb, err := berDecodeLength(slice[1:])
+		if err != nil {
+			t.Fatalf("berDecodeLength: %v", err)
+		}
+		return 1 + lb
+	}
+	// Outer SEQUENCE.
+	base := hdrLen(pkt)
+	body := pkt[base:]
+	skip := func(slice []byte) int { return berEncodedLen(slice) }
+	// version INTEGER.
+	base += skip(body)
+	body = pkt[base:]
+	// header SEQUENCE.
+	base += skip(body)
+	body = pkt[base:]
+	// secParams OCTET STRING -> descend into its value (the USM SEQUENCE).
+	base += hdrLen(body)
+	body = pkt[base:]
+	// USM SEQUENCE -> descend into its body.
+	base += hdrLen(body)
+	body = pkt[base:]
+	// engineID, boots, time, userName -> skip 4 fields.
+	for i := 0; i < 4; i++ {
+		base += skip(body)
+		body = pkt[base:]
+	}
+	// authParams OCTET STRING -> value range.
+	vh := hdrLen(body)
+	length, _, err := berDecodeLength(body[1:])
+	if err != nil {
+		t.Fatalf("berDecodeLength authParams: %v", err)
+	}
+	start = base + vh
+	end = start + length
+	return start, end
 }
 
 // TestZeroAuthParams_ZeroesOnlyAuthParams confirms zeroAuthParams blanks
@@ -240,6 +292,82 @@ func TestZeroAuthParams_ZeroesOnlyAuthParams(t *testing.T) {
 	// engineID bytes survive.
 	if !bytes.Contains(pkt, engineID) {
 		t.Fatal("engineID was zeroed by zeroAuthParams (bug #1710)")
+	}
+}
+
+// buildV3PlaceholderPacket builds a v3 USM message with the authParams field
+// left as an all-zero placeholder (not yet signed). engineID is used verbatim
+// so a caller can supply an all-zero truncLen-length engineID to exercise the
+// response-path collision that the old insertAuthMAC heuristic was prone to.
+func buildV3PlaceholderPacket(authProto string, userName string, engineID []byte) []byte {
+	truncLen := authTruncLen(authProto)
+	authPlaceholder := make([]byte, truncLen)
+	usmFields := berEncodeTLV(tagOctetString, engineID)
+	usmFields = append(usmFields, berEncodeIntegerTLV(1)...)
+	usmFields = append(usmFields, berEncodeIntegerTLV(2)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, []byte(userName))...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, authPlaceholder)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...)
+	usmOctet := berEncodeTLV(tagOctetString, berEncodeTLV(tagSequence, usmFields))
+
+	hdr := berEncodeIntegerTLV(42)
+	hdr = append(hdr, berEncodeIntegerTLV(maxPacketSize)...)
+	hdr = append(hdr, berEncodeTLV(tagOctetString, []byte{msgFlagAuth})...)
+	hdr = append(hdr, berEncodeIntegerTLV(usmSecurityModel)...)
+	hdrSeq := berEncodeTLV(tagSequence, hdr)
+
+	scopedBody := berEncodeTLV(tagOctetString, engineID)
+	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, nil)...)
+	scopedBody = append(scopedBody, berEncodeTLV(0xA2, nil)...) // GetResponse PDU, empty
+	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
+
+	msgBody := berEncodeIntegerTLV(snmpVersion3)
+	msgBody = append(msgBody, hdrSeq...)
+	msgBody = append(msgBody, usmOctet...)
+	msgBody = append(msgBody, scopedPDU...)
+	return berEncodeTLV(tagSequence, msgBody)
+}
+
+// TestInsertAuthMAC_TargetsAuthParams confirms insertAuthMAC writes the MAC
+// into the authParams field located by position, even when an earlier field
+// (an all-zero truncLen-length engineID) would have matched the old all-zero
+// length heuristic first — the response-path sibling of #1710.
+func TestInsertAuthMAC_TargetsAuthParams(t *testing.T) {
+	authProto := "sha"
+	truncLen := authTruncLen(authProto) // 12
+	// engineID of exactly truncLen all-zero bytes: a decoy the OLD heuristic
+	// would have matched (all-zero, length 12) before authParams.
+	engineID := make([]byte, truncLen)
+	pkt := buildV3PlaceholderPacket(authProto, "user", engineID)
+
+	start, end, ok := usmAuthParamsRange(pkt)
+	if !ok {
+		t.Fatal("locator failed on placeholder packet")
+	}
+
+	mac := bytes.Repeat([]byte{0x5A}, truncLen)
+	insertAuthMAC(pkt, mac, truncLen)
+
+	// The MAC must land in authParams.
+	if !bytes.Equal(pkt[start:end], mac) {
+		t.Fatalf("authParams not set to MAC; got %x", pkt[start:end])
+	}
+	// The all-zero engineID decoy must NOT have received the MAC: it precedes
+	// authParams, so if the old heuristic ran it would be 0x5A here.
+	idx := bytes.Index(pkt, mac)
+	if idx != start {
+		t.Fatalf("MAC found at offset %d, expected only at authParams start %d (decoy corrupted)", idx, start)
+	}
+}
+
+// TestInsertAuthMAC_WrongLengthNoOp confirms insertAuthMAC refuses to write a
+// MAC whose length does not match the authParams slot.
+func TestInsertAuthMAC_WrongLengthNoOp(t *testing.T) {
+	pkt := buildV3PlaceholderPacket("sha", "user", []byte{0x80, 0x00, 0x1f, 0x88})
+	before := append([]byte{}, pkt...)
+	insertAuthMAC(pkt, bytes.Repeat([]byte{0x5A}, 8), 12) // 8 != truncLen 12
+	if !bytes.Equal(before, pkt) {
+		t.Fatal("insertAuthMAC mutated packet with mismatched MAC length")
 	}
 }
 

--- a/pkg/snmp/v3_auth_test.go
+++ b/pkg/snmp/v3_auth_test.go
@@ -6,6 +6,16 @@ import (
 	"testing"
 )
 
+func authTestEngineID(engineID []byte, longForm bool) []byte {
+	engineID = append([]byte{}, engineID...)
+	if !longForm {
+		return engineID
+	}
+	// Pad the engineID so the USM sequence (and its OCTET STRING wrapper)
+	// exceed 127 bytes, forcing long-form BER length encoding.
+	return append(engineID, bytes.Repeat([]byte{0xAB}, 200)...)
+}
+
 // buildV3AuthPacket constructs a complete SNMPv3 authNoPriv message for the
 // given user/engine parameters and returns the on-wire bytes together with
 // the byte range of the (real) msgAuthenticationParameters value. The
@@ -25,11 +35,7 @@ func buildV3AuthPacket(t *testing.T, authProto string, userName string, engineID
 	}
 	truncLen := authTruncLen(authProto)
 
-	if longForm {
-		// Pad the engineID so the USM sequence (and its OCTET STRING wrapper)
-		// exceed 127 bytes, forcing long-form BER length encoding.
-		engineID = append(append([]byte{}, engineID...), bytes.Repeat([]byte{0xAB}, 200)...)
-	}
+	engineID = authTestEngineID(engineID, longForm)
 
 	// USM security parameters with a zeroed authParams placeholder.
 	authPlaceholder := make([]byte, truncLen)
@@ -85,6 +91,7 @@ func buildV3AuthPacket(t *testing.T, authProto string, userName string, engineID
 // built by buildV3AuthPacket.
 func runVerify(t *testing.T, authProto, userName string, engineID []byte, longForm bool) bool {
 	t.Helper()
+	engineID = authTestEngineID(engineID, longForm)
 	hashFn, hashLen := authHashFunc(authProto)
 	authKey := passwordToKey("the-auth-password-1234", engineID, hashFn, hashLen)
 	if authKey == nil {

--- a/pkg/snmp/v3_auth_test.go
+++ b/pkg/snmp/v3_auth_test.go
@@ -91,6 +91,9 @@ func buildV3AuthPacket(t *testing.T, authProto string, userName string, engineID
 // built by buildV3AuthPacket.
 func runVerify(t *testing.T, authProto, userName string, engineID []byte, longForm bool) bool {
 	t.Helper()
+	// Resolve the on-wire engineID once here so the localized authKey is
+	// derived from the exact engineID that appears in the packet. Pass
+	// longForm=false to buildV3AuthPacket so it does not pad a second time.
 	engineID = authTestEngineID(engineID, longForm)
 	hashFn, hashLen := authHashFunc(authProto)
 	authKey := passwordToKey("the-auth-password-1234", engineID, hashFn, hashLen)
@@ -98,7 +101,7 @@ func runVerify(t *testing.T, authProto, userName string, engineID []byte, longFo
 		t.Fatalf("passwordToKey returned nil")
 	}
 
-	pkt, start, end := buildV3AuthPacket(t, authProto, userName, engineID, authKey, longForm)
+	pkt, start, end := buildV3AuthPacket(t, authProto, userName, engineID, authKey, false)
 
 	a := &Agent{
 		engineID:   engineID,


### PR DESCRIPTION
## Summary

`pkg/snmp/v3.go` previously used a truncation-length heuristic in both
`zeroAuthParams` and `insertAuthMAC`: each scanned the raw packet for an
OCTET STRING whose BER length matched the HMAC truncation length (12 for
MD5/SHA-1, 24 for SHA-256). Because `msgUserName` and
`msgAuthoritativeEngineID` precede `msgAuthenticationParameters` in the
USM security-parameters SEQUENCE (RFC 3414), a 12/24-byte username, a
`truncLen`-byte engineID, or an all-zero decoy field could be matched
first. On verify, that meant blanking the wrong field instead of
authParams; on response build, it could mean writing the MAC into the
wrong field instead of the authParams placeholder.

The fix replaces that heuristic with `usmAuthParamsRange`, which walks the
message to the authParams field by its RFC 3414 **position** and returns
the field's exact value byte range. `zeroAuthParams` now zeroes exactly
that range, and `insertAuthMAC` now writes through the same locator with
an `end-start == len(authMAC)` guard so mismatched or malformed packets
fail closed. The locator decodes every child TLV from its parent's bounded
value slice (never a raw `pkt[cursor:]` window), so a nested length cannot
escape its container and an over-run returns `ok=false`. Offsets are
derived as `berEncodedLen(parent) - len(value)`, which also handles
multi-byte (long-form) BER lengths.

## Plan + adversarial review

Plan doc: `docs/pr/1710-snmpv3-authparams-position/plan.md`

- Codex round-1 (task-mpta4cny-05mmyf): PLAN-NEEDS-MINOR — core
  positional design immune to the collision, no KILL counterexample; 4
  minors (bounded-parse invariant, `ok` semantics, long-form length test,
  authParams-length wording) were folded into plan v2 and the
  implementation.
- AGY round-1 (adversarial-review-mpta4okq-75xv55): PLAN-READY, with a
  bounds-checking hardening note (matches Codex minor 1).
- Claude SMR (in-conversation): concurred; validated the offset
  accounting with a worked example and the bounded-parse fail-closed
  posture.
- Follow-up review feedback was folded into the implementation by routing
  `insertAuthMAC` through the same positional locator and strengthening the
  locator tests to check offsets against an independent manual BER walk.

## Test plan

- `go build ./pkg/snmp/...` clean, `go vet` clean
- New `pkg/snmp/v3_auth_test.go` coverage includes:
  - 12-char username MD5 + SHA-1, 24-char username SHA-256 authenticate
    (direct #1710 regression)
  - 12-byte engineID not mistaken for authParams
  - ordinary short username MD5/SHA-1/SHA-256 still authenticates (no
    common-path regression)
  - long-form (>127) BER length packet authenticates
  - locator returns the exact authParams range and is cross-checked against
    an independent manual BER walk
  - `zeroAuthParams` blanks only authParams (username + engineID survive)
  - `insertAuthMAC` targets authParams even with a preceding all-zero
    truncLen-byte decoy and no-ops on wrong-length replacements
  - malformed packets return `ok=false`, `zeroAuthParams` no-ops, and no
    panic occurs
- A throwaway copy of the old heuristic was shown to zero the username and
  leave authParams intact on the same fixtures
- Regression tests passed in repeated runs; `pkg/snmp` package tests are
  green
- Full Go suite remained green except for the pre-existing
  `pkg/dataplane/userspace` unix-socket `bind: invalid argument` sandbox
  artifact reproduced on clean master
- `make audit-check` up to date

No cluster smoke: this is a control-plane SNMP-management change with no
dataplane / CoS / HA surface, so the gate is the Go suite plus the new
auth tests.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>