### PR TITLE
#1711: reject malformed IP in policy simulator (all three boundaries)

### DIFF
--- a/docs/pr/1711-policy-sim-ip-validation/plan.md
+++ b/docs/pr/1711-policy-sim-ip-validation/plan.md
@@ -1,7 +1,37 @@
-# #1711 — Policy simulator: reject malformed IP at all three boundaries
+# #1711 — Policy simulator: reject malformed IP at all five boundaries
 
-Status: PLAN-READY v2 — expanded to all three simulator boundaries
-after Codex + AGY both returned PLAN-NEEDS-MAJOR on the gRPC-only v1.
+Status: PLAN-READY v3 — expanded to all FIVE simulator entry points
+after the round-2 hostile CODE review (Codex + AGY) found two more
+in-process copies of the matcher beyond the three in v2.
+
+## v2 → v3: round-2 code review (two more simulator copies)
+
+The round-2 hostile code review on PR #1721 (Codex
+`task-mptayaxl-m5m8ks`, AGY `adversarial-review-mptayhsi-15ez9v`, both
+MERGE-NEEDS-MAJOR) found that "the simulator" has FIVE entry points,
+not three. v2 fixed three; v3 adds the remaining two:
+
+4. **Local CLI `test policy`** — `pkg/cli/cli_request.go` `testPolicy`,
+   dispatched as the operational `test policy` command. Separate copy,
+   uses the `pkg/cli/cli_helpers.go` matcher. Returns `error` → guard
+   returns `fmt.Errorf`.
+5. **gRPC ShowText `test-policy:`** — `pkg/grpcapi/server_show_firewall.go`
+   `showTestPolicy`, dispatched from `ShowText`. Uses a fourth matcher
+   copy `matchShowPolicyAddr` (`server_cluster.go:302`). Renders
+   diagnostic text into a buffer rather than returning a structured
+   error, so the guard writes an `invalid src/dst` line (matching its
+   existing "Missing from/to zone parameters" style) and skips matching.
+
+Round-2 also flagged: the branch was stale (forked before #1709/#1712/
+#1713/#1714) — fixed by rebasing onto current origin/master; and the
+CLI/REST positive tests only checked `err==nil`/status — strengthened
+to assert the actual match verdict (`Matching policy`/`Policy match` +
+policy name; `data.matched`).
+
+The nil-config early-return (gRPC/REST/CLI return before validation
+when there is no active config) is a documented contract nit, NOT the
+bug: with no config there are no policies to match, so no false-positive
+PERMIT is possible. Left as-is.
 
 ## Issue framing
 

--- a/docs/pr/1711-policy-sim-ip-validation/plan.md
+++ b/docs/pr/1711-policy-sim-ip-validation/plan.md
@@ -1,22 +1,17 @@
-# #1711 — Policy simulator `MatchPolicies`: reject malformed IP at the gRPC boundary
+# #1711 — Policy simulator: reject malformed IP at all three boundaries
 
-Status: DRAFT v1 — pending adversarial plan review
+Status: PLAN-READY v2 — expanded to all three simulator boundaries
+after Codex + AGY both returned PLAN-NEEDS-MAJOR on the gRPC-only v1.
 
 ## Issue framing
 
-`pkg/grpcapi/server_cluster.go` `MatchPolicies` (the gRPC policy
-simulator behind `show security match-policies`) does:
+The policy simulator (`show security match-policies`) parses the
+operator-supplied source/destination IP with `net.ParseIP` and feeds
+the result to `matchPolicyAddr`:
 
 ```go
-parsedSrc := net.ParseIP(req.SourceIp)
-parsedDst := net.ParseIP(req.DestinationIp)
-```
-
-`net.ParseIP` returns `nil` for **both** an empty string and a
-syntactically invalid string. `matchPolicyAddr` then treats
-`ip == nil` as an unconditional wildcard match:
-
-```go
+parsedSrc := net.ParseIP(req.SourceIp)   // grpc
+...
 func matchPolicyAddr(addrs []string, ip net.IP, cfg *config.Config) bool {
 	if len(addrs) == 0 || ip == nil { // ip==nil → matches every term
 		return true
@@ -25,208 +20,208 @@ func matchPolicyAddr(addrs []string, ip net.IP, cfg *config.Config) bool {
 }
 ```
 
-So feeding the simulator a non-empty but malformed source/dest IP
-(e.g. `source-ip 10.0.0.999` or `source-ip garbage`) makes the
-address match always succeed, producing a **false-positive PERMIT
-verdict** in the simulation output. This is diagnostic-only (the
-simulator, not the dataplane enforcement path), so it does not admit
-real traffic, but it gives the operator a misleading answer for bad
-input.
+`net.ParseIP` returns `nil` for **both** an empty string and a
+syntactically invalid string. `matchPolicyAddr` treats `ip == nil` as
+an unconditional wildcard, so a **non-empty malformed** IP (e.g.
+`source-ip 10.0.0.999` or `source-ip garbage`) silently matches every
+policy term → **false-positive PERMIT verdict** in the simulator
+output. Diagnostic-only (does not admit real traffic), but misleading.
 
-The issue is explicit that two of the three `ip == nil` triggers are
-*correct*:
+Two of the three `ip == nil` triggers are *correct* and must be kept:
 
-- `len(addrs) == 0` → the policy term itself lists no addresses →
-  Junos "any" semantics. **Keep.**
-- empty `req.SourceIp` / `req.DestinationIp` → the operator did not
-  constrain that tuple field → "any" / unspecified. This is how the
-  CLI is used (`source-ip` / `destination-ip` are optional args;
-  omitting them is a legitimate "match against any source"). **Keep.**
-- non-empty but invalid `req.SourceIp` / `req.DestinationIp` →
-  operator typo / malformed input → currently silently becomes "any".
-  **This is the bug.**
+- `len(addrs) == 0` → the policy term lists no addresses → Junos "any".
+- empty `SourceIp` / `DestinationIp` → operator left the tuple field
+  unconstrained → "any" / unspecified (the dominant CLI usage; the
+  `source-ip`/`destination-ip` args are optional).
+
+Only the **non-empty-but-invalid** case is the bug.
+
+## v1 → v2: why scope expanded (adversarial review)
+
+v1 fixed only the gRPC handler. Codex (`task-mpta3t25-pi958d`) and AGY
+(`adversarial-review-mpta4os9-m2em4w`) both returned **PLAN-NEEDS-MAJOR**
+with the same blocking finding: `show security match-policies` is
+served by **three independent in-process copies** of this matcher, and
+a gRPC-only fix leaves two of them false-positiveing:
+
+1. **gRPC** — `pkg/grpcapi/server_cluster.go:123` `MatchPolicies`,
+   matcher at `:174`. Used by the remote `cli` binary
+   (`cmd/cli/show.go:882`) and any direct gRPC client.
+2. **Local interactive CLI** — `pkg/cli/cli_show_security.go:1888`
+   `(*CLI).showMatchPolicies`, dispatched in-process at
+   `pkg/cli/cli_show_security_dispatch.go:332`, parses at `:1939`,
+   matches via its own `pkg/cli/cli_helpers.go:189` copy. **Does NOT
+   call the gRPC handler** — runs the whole simulation locally.
+   Counterexample (Codex): local `show security match-policies ...
+   source-ip garbage ...` still prints `Matching policy` after a
+   gRPC-only fix.
+3. **HTTP REST** — `pkg/api/security.go:184` `matchPoliciesHandler`
+   (route `GET /api/v1/security/match`, `pkg/api/server.go:153`),
+   parses at `:193`, matches via its own `pkg/api/security.go:229`
+   copy. Automation/UI clients remain vulnerable under a gRPC-only fix.
+
+To genuinely close #1711 ("operator running the simulator gets a false
+permit for malformed input"), validate at **all three** boundaries.
 
 ## Honest scope/value framing
 
-This is a single-function input-validation fix on a diagnostic gRPC
-RPC. It is not a perf change and not a refactor. The value is purely
-correctness of operator-facing output for malformed input: instead of
-a misleading PERMIT verdict, the operator gets a clear
-`InvalidArgument` error naming the bad field/value.
-
-If reviewers conclude the perf gain is too small to justify the churn,
-PLAN-KILL is an acceptable verdict. (There is no perf dimension here;
-the relevant kill criterion would be "the fix is wrong / breaks the
-legit any-path / belongs elsewhere".)
-
-## What's already shipped / partially relevant
-
-- `pkg/cli/cli_helpers.go` carries a **near-identical duplicate**
-  `matchPolicyAddr` / `matchPolicyAddrSet` (local-CLI path,
-  `pkg/cli` package). The local-CLI `showMatchPolicies`
-  (`pkg/cli/cli_show_security.go:1888`) has the same `net.ParseIP`
-  →`nil`→wildcard shape and the same latent false-positive on
-  malformed input.
-- The issue scopes the fix to the **gRPC** `server_cluster.go`
-  handler. See "Out of scope" + Open Question 5 on whether to also
-  fix the local-CLI twin in the same PR.
+Input-validation fix on three diagnostic entry points. Not perf, not a
+refactor. Value: correctness of operator-facing output for malformed
+input — a clear error instead of a misleading PERMIT. PLAN-KILL would
+only be warranted if the fix were wrong or broke the legit "any" path;
+neither reviewer found that — the core rule is sound.
 
 ## Concrete design
 
-Validate the two IP fields at the top of `MatchPolicies`, *after* the
-`cfg == nil` short-circuit, *before* the `net.ParseIP` calls feed the
-matcher. Distinguish empty (legit "any") from non-empty-invalid (error):
+Inline a non-empty-invalid guard at each of the three boundaries,
+before the existing `net.ParseIP` feeds the matcher. Each boundary
+keeps its native error type. The three `matchPolicyAddr` copies are
+**unchanged** — after the guard, the only remaining `ip == nil` cause
+is an *empty* (unspecified → any) input, which is intended. We do NOT
+consolidate the three copies in this PR (separate refactor concern).
+
+### gRPC — `pkg/grpcapi/server_cluster.go`
 
 ```go
-func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) (*pb.MatchPoliciesResponse, error) {
-	cfg := s.store.ActiveConfig()
-	if cfg == nil {
-		return &pb.MatchPoliciesResponse{}, nil
-	}
-
-	// An empty source/destination IP means "unspecified" (match any),
-	// which is a legitimate simulator query. A NON-EMPTY but malformed
-	// value is an operator error: net.ParseIP would return nil and the
-	// matcher would silently treat nil as a wildcard, yielding a
-	// false-positive PERMIT verdict (#1711). Reject it explicitly.
-	if req.SourceIp != "" && net.ParseIP(req.SourceIp) == nil {
-		return nil, status.Errorf(codes.InvalidArgument,
-			"invalid source-ip %q", req.SourceIp)
-	}
-	if req.DestinationIp != "" && net.ParseIP(req.DestinationIp) == nil {
-		return nil, status.Errorf(codes.InvalidArgument,
-			"invalid destination-ip %q", req.DestinationIp)
-	}
-
-	parsedSrc := net.ParseIP(req.SourceIp)
-	parsedDst := net.ParseIP(req.DestinationIp)
-	...
+if req.SourceIp != "" && net.ParseIP(req.SourceIp) == nil {
+	return nil, status.Errorf(codes.InvalidArgument, "invalid source-ip %q", req.SourceIp)
 }
+if req.DestinationIp != "" && net.ParseIP(req.DestinationIp) == nil {
+	return nil, status.Errorf(codes.InvalidArgument, "invalid destination-ip %q", req.DestinationIp)
+}
+parsedSrc := net.ParseIP(req.SourceIp)
+parsedDst := net.ParseIP(req.DestinationIp)
 ```
 
-`matchPolicyAddr` is **unchanged**: with the guard above, by the time
-it sees `ip == nil` the only remaining cause is an *empty* input
-(unspecified → any), which is the intended Junos semantics. The
-`len(addrs) == 0` arm is also unchanged (policy-term "any").
+`status`/`codes`/`net` already imported.
 
-Notes:
-- Empty-string check uses `req.SourceIp != ""` (not a trimmed
-  compare) — the proto field is a plain `string`; the CLI only
-  populates it from an explicit `source-ip <token>` arg, so a
-  whitespace-only value is itself malformed and should be rejected.
-  `net.ParseIP(" 1.2.3.4")` returns nil, so a leading-space value
-  takes the InvalidArgument path, which is the correct behavior.
-- `status` + `codes` are already imported in `server_cluster.go`
-  (lines 17-18). No new imports.
-- We call `net.ParseIP` twice for each field on the valid path (once
-  in the guard, once for `parsedSrc`/`parsedDst`). This is a
-  diagnostic RPC invoked interactively at human rate; the redundant
-  parse is negligible and keeps the guard self-contained and obviously
-  correct. Open Question 4 asks whether to instead reuse the parsed
-  value.
+### Local CLI — `pkg/cli/cli_show_security.go`
+
+```go
+if srcIP != "" && net.ParseIP(srcIP) == nil {
+	return fmt.Errorf("invalid source-ip %q", srcIP)
+}
+if dstIP != "" && net.ParseIP(dstIP) == nil {
+	return fmt.Errorf("invalid destination-ip %q", dstIP)
+}
+parsedSrc := net.ParseIP(srcIP)
+parsedDst := net.ParseIP(dstIP)
+```
+
+`fmt`/`net` already imported. Returned error propagates to the console.
+
+### HTTP REST — `pkg/api/security.go`
+
+```go
+srcIPStr := r.URL.Query().Get("src_ip")
+if srcIPStr != "" && net.ParseIP(srcIPStr) == nil {
+	writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid src_ip %q", srcIPStr))
+	return
+}
+dstIPStr := r.URL.Query().Get("dst_ip")
+if dstIPStr != "" && net.ParseIP(dstIPStr) == nil {
+	writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid dst_ip %q", dstIPStr))
+	return
+}
+srcIP := net.ParseIP(srcIPStr)
+dstIP := net.ParseIP(dstIPStr)
+```
+
+Needs `"fmt"` added to imports (`net`/`net/http` already present).
+`writeError(w, http.StatusBadRequest, ...)` is the existing helper
+(`pkg/api/api.go:44`).
+
+## Empty-vs-invalid discriminator (reviewer-confirmed)
+
+`field != "" && net.ParseIP(field) == nil`. Codex + AGY both confirmed
+no legitimate caller passes a non-empty sentinel (`any`, `0.0.0.0/0`,
+or a CIDR) in the IP field — the CLI and REST clients only copy a raw
+IP token. Resolved open questions:
+
+- `"0.0.0.0"` / `"::"` parse fine → valid path, matched by address-book
+  containment. Correct, no special-casing.
+- CIDR-in-IP-field (`10.0.0.0/24`) → `net.ParseIP` returns nil → now
+  rejected as invalid. The field contract is a single IP; the matcher
+  uses `cidr.Contains(ip)` against address-book entries, not the
+  reverse. Rejecting is correct.
+- Whitespace-only / leading-space values → `net.ParseIP` returns nil →
+  rejected. Correct.
 
 ## Public API preservation
 
-- `MatchPolicies` gRPC signature unchanged.
-- `MatchPoliciesRequest` / `MatchPoliciesResponse` proto unchanged.
-- `matchPolicyAddr` / `matchPolicyAddrSet` signatures and bodies
-  unchanged.
-- New behavior: a previously-accepted (and silently-wildcarded)
-  malformed IP now returns `codes.InvalidArgument`. This is a
-  behavior change on an error/garbage input path, not on any valid
-  query. The CLI caller (`cmd/cli/show.go:882`) already surfaces the
-  gRPC error via `return fmt.Errorf("%v", err)`, so the operator sees
-  the message.
+- gRPC `MatchPolicies` signature + proto unchanged.
+- REST route + `MatchPoliciesResult` shape unchanged (error uses the
+  existing `Response{Success:false,Error:...}` envelope at 400).
+- `(*CLI).showMatchPolicies` signature unchanged (already returns
+  `error`).
+- All three `matchPolicyAddr` / `matchPolicyAddrSet` bodies unchanged.
+- New behavior only on the malformed-input path.
 
-## Hidden invariants the change must preserve
+## Hidden invariants preserved
 
-1. **Empty-IP "any" path preserved** — omitting source-ip and/or
-   destination-ip must still simulate against "any" (the dominant CLI
-   usage). Guarded by the `!= ""` precondition.
-2. **Policy-term "any" preserved** — `len(addrs) == 0` arm untouched.
-3. **No new imports / no import cycle** — `codes`/`status` already in
-   the file.
-4. **Error surfacing** — gRPC `status.Error` propagates to the remote
-   CLI (`cmd/cli`) and the embedded local path; verify the embedded
-   local CLI (`pkg/cli`) does not call this gRPC handler (it has its
-   own in-process matcher), so the gRPC fix covers only the remote
-   `cli` binary + any direct gRPC client. (See Open Question 5.)
-5. **Determinism** — `MatchPolicies` is read-only against
-   `ActiveConfig()`; adding the guard introduces no state.
+1. Empty-IP "any" path — guarded by `!= ""`.
+2. Policy-term "any" (`len(addrs)==0`) — matcher untouched.
+3. No new import cycles — gRPC/CLI imports already present; REST adds
+   stdlib `fmt`.
+4. Read-only against `ActiveConfig()` — no new state.
 
 ## Risk assessment
 
 | Class | Level | Notes |
 |-------|-------|-------|
-| Behavioral regression | LOW | Only changes the malformed-input path. Valid queries and empty/any queries unchanged. Worst case if the empty-vs-invalid boundary is wrong: a legit query gets rejected — covered by tests for empty + valid + invalid. |
-| Lifetime / borrow | N/A | Go; no borrow checker. |
-| Performance | NONE | Interactive diagnostic RPC; one extra `net.ParseIP` per non-empty field. |
-| Architectural mismatch | LOW | Boundary input validation at the gRPC handler is the idiomatic location; matches existing `status.Error(codes.InvalidArgument, ...)` usage in the package. |
+| Behavioral regression | LOW | Only the malformed-input path changes; valid + empty/any unchanged, covered by tests at all three boundaries. |
+| Lifetime / borrow | N/A | Go. |
+| Performance | NONE | Interactive diagnostic paths; one extra ParseIP per non-empty field. |
+| Architectural mismatch | LOW | Boundary input validation is the idiomatic location; matches existing `codes.InvalidArgument` / `writeError(400)` usage. |
 
 ## Test plan
 
-New test in `pkg/grpcapi/server_cluster_test.go` (new file), package
-`grpcapi`, using the existing `configstore.New` + `LoadOverride` +
-`Commit` + `&Server{store: store}` scaffolding (mirrors
-`server_show_zones_test.go`):
+Per Codex: invalid-IP tests use a **restricted address-book term**
+(not only permit-any) so they prove the actual false-positive shape —
+with the bug the malformed IP would match a term it should not, and
+the fix turns that into an error rather than a (wrong) match. Also
+include an empty-means-any preservation test and a valid-match test.
 
-1. `TestMatchPoliciesRejectsInvalidSourceIP` — config with a
-   permit-any policy from trust→untrust; request with
-   `SourceIp: "10.0.0.999"` (or `"not-an-ip"`); assert the call
-   returns an error with `status.Code(err) == codes.InvalidArgument`
-   and the response is **not** a PERMIT verdict (resp nil on error).
-2. `TestMatchPoliciesRejectsInvalidDestinationIP` — same for
-   destination.
-3. `TestMatchPoliciesEmptyIPsMatchAny` — request with both IPs empty
-   against the permit-any policy → `Matched == true`, action permit,
-   **no error** (proves the legit "any" path is preserved).
-4. `TestMatchPoliciesValidIPMatches` — request with a valid
-   `SourceIp`/`DestinationIp` that falls inside an address-book term →
-   correct match, no error (proves valid path unaffected).
+- `pkg/grpcapi/server_cluster_test.go` (new):
+  - `TestMatchPoliciesRejectsInvalidSourceIP` — restricted src term;
+    `SourceIp:"10.0.0.999"` → `codes.InvalidArgument`, resp nil.
+  - `TestMatchPoliciesRejectsInvalidDestinationIP` — same for dest.
+  - `TestMatchPoliciesEmptyIPsMatchAny` — both IPs empty vs permit-any
+    → `Matched==true`, no error (empty-any preserved).
+  - `TestMatchPoliciesValidIPMatches` — valid IP inside the restricted
+    term → matched, no error (valid path unaffected).
+- `pkg/cli/cli_show_security_test.go` (append
+  `TestShowMatchPoliciesValidation`):
+  - invalid source-ip / destination-ip → non-nil error, no
+    "Matching policy" output.
+  - empty IPs → no error, simulates against any.
+- `pkg/api/security_test.go` (new):
+  - invalid `src_ip` / `dst_ip` query → HTTP 400, `Success:false`.
+  - empty / valid → 200.
 
-Gates (control-plane / gRPC diagnostic change — NO cluster smoke):
-
+Gates (control-plane diagnostic change — NO cluster smoke):
 - `go build ./...` clean.
-- `go vet ./pkg/grpcapi/...` clean.
-- `go test ./pkg/grpcapi/...` — new tests pass + existing pass.
-- Full Go suite `go test ./...` green.
-- New named test 5× loop (no flake).
-- `make audit-check` only if a file crosses the size threshold (this
-  change adds <15 LOC to a 600-line file + one new test file — should
-  not trip it; will verify).
+- `go vet ./pkg/grpcapi/... ./pkg/cli/... ./pkg/api/...` clean.
+- `go test ./pkg/grpcapi/... ./pkg/cli/... ./pkg/api/...` pass.
+- Full `go test ./...` green.
+- New named tests 5× loop, no flake.
+- `make audit-check` only if a file crosses the size threshold (each
+  edit adds <15 LOC; verify it does not trip).
 
 ## Out of scope (explicitly)
 
-- **`pkg/cli/cli_helpers.go` + `pkg/cli/cli_show_security.go`
-  local-CLI twin.** Same latent bug, different package, not named by
-  the issue. Open Question 5 asks reviewers whether to fold it in.
-  Default plan: gRPC-only per issue scope; file a follow-up for the
-  CLI twin if reviewers prefer scope discipline.
-- Consolidating the two `matchPolicyAddr` copies into one shared
-  helper (a refactor, separate concern).
-- Any proto/schema change.
+- Consolidating the three `matchPolicyAddr` copies into one shared
+  helper (a refactor; deliberately deferred to keep this a tight bug
+  fix). Noted as a possible follow-up.
+- Any proto / schema / route change.
 
-## Open questions for adversarial review
+## Open questions — resolved by review
 
-1. **Empty-vs-invalid boundary.** Is `req.SourceIp != "" &&
-   net.ParseIP(...) == nil` the correct discriminator? Is there any
-   legitimate caller that passes a non-empty sentinel like `"any"` or
-   `"0.0.0.0/0"` as the IP field (which would now be rejected)? Grep
-   of CLI callers shows only raw IP tokens — but confirm.
-2. **Should `"0.0.0.0"` / `"::"` be accepted?** They parse fine via
-   `net.ParseIP` (valid IPs), so they take the valid path and match
-   per address-book containment. That seems correct — confirm no
-   special-casing is wanted.
-3. **CIDR input.** The field is documented as an IP, not a CIDR.
-   `net.ParseIP("10.0.0.0/24")` returns nil → would now be rejected as
-   InvalidArgument. Previously it silently wildcarded. Is rejecting
-   CIDR-in-IP-field the right call, or should we accept a CIDR? (Plan
-   position: reject — the field contract is a single IP; matcher uses
-   `cidr.Contains(ip)` against address-book entries, not the reverse.)
-4. **Double-parse.** Acceptable on a diagnostic RPC, or should we
-   parse once and branch on nil+empty? (Plan position: keep the guard
-   self-contained for clarity; cost is nil at human invocation rate.)
-5. **Local-CLI twin scope.** Fold the identical
-   `pkg/cli` fix into this PR, or keep gRPC-only per the issue and
-   file a follow-up? PLAN-KILL is *not* warranted either way — this is
-   a scope-boundary question.
+1. Discriminator correctness → confirmed (no non-empty sentinel
+   callers).
+2. `0.0.0.0`/`::` acceptance → correct as-is.
+3. CIDR-in-IP-field → reject (field contract is a single IP).
+4. Double-parse → acceptable on diagnostic paths.
+5. Twin scope → **resolved by expanding to all three boundaries** (the
+   blocking finding). gRPC-only would not close the operator-visible
+   bug.

--- a/docs/pr/1711-policy-sim-ip-validation/plan.md
+++ b/docs/pr/1711-policy-sim-ip-validation/plan.md
@@ -1,0 +1,232 @@
+# #1711 — Policy simulator `MatchPolicies`: reject malformed IP at the gRPC boundary
+
+Status: DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+`pkg/grpcapi/server_cluster.go` `MatchPolicies` (the gRPC policy
+simulator behind `show security match-policies`) does:
+
+```go
+parsedSrc := net.ParseIP(req.SourceIp)
+parsedDst := net.ParseIP(req.DestinationIp)
+```
+
+`net.ParseIP` returns `nil` for **both** an empty string and a
+syntactically invalid string. `matchPolicyAddr` then treats
+`ip == nil` as an unconditional wildcard match:
+
+```go
+func matchPolicyAddr(addrs []string, ip net.IP, cfg *config.Config) bool {
+	if len(addrs) == 0 || ip == nil { // ip==nil → matches every term
+		return true
+	}
+	...
+}
+```
+
+So feeding the simulator a non-empty but malformed source/dest IP
+(e.g. `source-ip 10.0.0.999` or `source-ip garbage`) makes the
+address match always succeed, producing a **false-positive PERMIT
+verdict** in the simulation output. This is diagnostic-only (the
+simulator, not the dataplane enforcement path), so it does not admit
+real traffic, but it gives the operator a misleading answer for bad
+input.
+
+The issue is explicit that two of the three `ip == nil` triggers are
+*correct*:
+
+- `len(addrs) == 0` → the policy term itself lists no addresses →
+  Junos "any" semantics. **Keep.**
+- empty `req.SourceIp` / `req.DestinationIp` → the operator did not
+  constrain that tuple field → "any" / unspecified. This is how the
+  CLI is used (`source-ip` / `destination-ip` are optional args;
+  omitting them is a legitimate "match against any source"). **Keep.**
+- non-empty but invalid `req.SourceIp` / `req.DestinationIp` →
+  operator typo / malformed input → currently silently becomes "any".
+  **This is the bug.**
+
+## Honest scope/value framing
+
+This is a single-function input-validation fix on a diagnostic gRPC
+RPC. It is not a perf change and not a refactor. The value is purely
+correctness of operator-facing output for malformed input: instead of
+a misleading PERMIT verdict, the operator gets a clear
+`InvalidArgument` error naming the bad field/value.
+
+If reviewers conclude the perf gain is too small to justify the churn,
+PLAN-KILL is an acceptable verdict. (There is no perf dimension here;
+the relevant kill criterion would be "the fix is wrong / breaks the
+legit any-path / belongs elsewhere".)
+
+## What's already shipped / partially relevant
+
+- `pkg/cli/cli_helpers.go` carries a **near-identical duplicate**
+  `matchPolicyAddr` / `matchPolicyAddrSet` (local-CLI path,
+  `pkg/cli` package). The local-CLI `showMatchPolicies`
+  (`pkg/cli/cli_show_security.go:1888`) has the same `net.ParseIP`
+  →`nil`→wildcard shape and the same latent false-positive on
+  malformed input.
+- The issue scopes the fix to the **gRPC** `server_cluster.go`
+  handler. See "Out of scope" + Open Question 5 on whether to also
+  fix the local-CLI twin in the same PR.
+
+## Concrete design
+
+Validate the two IP fields at the top of `MatchPolicies`, *after* the
+`cfg == nil` short-circuit, *before* the `net.ParseIP` calls feed the
+matcher. Distinguish empty (legit "any") from non-empty-invalid (error):
+
+```go
+func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) (*pb.MatchPoliciesResponse, error) {
+	cfg := s.store.ActiveConfig()
+	if cfg == nil {
+		return &pb.MatchPoliciesResponse{}, nil
+	}
+
+	// An empty source/destination IP means "unspecified" (match any),
+	// which is a legitimate simulator query. A NON-EMPTY but malformed
+	// value is an operator error: net.ParseIP would return nil and the
+	// matcher would silently treat nil as a wildcard, yielding a
+	// false-positive PERMIT verdict (#1711). Reject it explicitly.
+	if req.SourceIp != "" && net.ParseIP(req.SourceIp) == nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"invalid source-ip %q", req.SourceIp)
+	}
+	if req.DestinationIp != "" && net.ParseIP(req.DestinationIp) == nil {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"invalid destination-ip %q", req.DestinationIp)
+	}
+
+	parsedSrc := net.ParseIP(req.SourceIp)
+	parsedDst := net.ParseIP(req.DestinationIp)
+	...
+}
+```
+
+`matchPolicyAddr` is **unchanged**: with the guard above, by the time
+it sees `ip == nil` the only remaining cause is an *empty* input
+(unspecified → any), which is the intended Junos semantics. The
+`len(addrs) == 0` arm is also unchanged (policy-term "any").
+
+Notes:
+- Empty-string check uses `req.SourceIp != ""` (not a trimmed
+  compare) — the proto field is a plain `string`; the CLI only
+  populates it from an explicit `source-ip <token>` arg, so a
+  whitespace-only value is itself malformed and should be rejected.
+  `net.ParseIP(" 1.2.3.4")` returns nil, so a leading-space value
+  takes the InvalidArgument path, which is the correct behavior.
+- `status` + `codes` are already imported in `server_cluster.go`
+  (lines 17-18). No new imports.
+- We call `net.ParseIP` twice for each field on the valid path (once
+  in the guard, once for `parsedSrc`/`parsedDst`). This is a
+  diagnostic RPC invoked interactively at human rate; the redundant
+  parse is negligible and keeps the guard self-contained and obviously
+  correct. Open Question 4 asks whether to instead reuse the parsed
+  value.
+
+## Public API preservation
+
+- `MatchPolicies` gRPC signature unchanged.
+- `MatchPoliciesRequest` / `MatchPoliciesResponse` proto unchanged.
+- `matchPolicyAddr` / `matchPolicyAddrSet` signatures and bodies
+  unchanged.
+- New behavior: a previously-accepted (and silently-wildcarded)
+  malformed IP now returns `codes.InvalidArgument`. This is a
+  behavior change on an error/garbage input path, not on any valid
+  query. The CLI caller (`cmd/cli/show.go:882`) already surfaces the
+  gRPC error via `return fmt.Errorf("%v", err)`, so the operator sees
+  the message.
+
+## Hidden invariants the change must preserve
+
+1. **Empty-IP "any" path preserved** — omitting source-ip and/or
+   destination-ip must still simulate against "any" (the dominant CLI
+   usage). Guarded by the `!= ""` precondition.
+2. **Policy-term "any" preserved** — `len(addrs) == 0` arm untouched.
+3. **No new imports / no import cycle** — `codes`/`status` already in
+   the file.
+4. **Error surfacing** — gRPC `status.Error` propagates to the remote
+   CLI (`cmd/cli`) and the embedded local path; verify the embedded
+   local CLI (`pkg/cli`) does not call this gRPC handler (it has its
+   own in-process matcher), so the gRPC fix covers only the remote
+   `cli` binary + any direct gRPC client. (See Open Question 5.)
+5. **Determinism** — `MatchPolicies` is read-only against
+   `ActiveConfig()`; adding the guard introduces no state.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Only changes the malformed-input path. Valid queries and empty/any queries unchanged. Worst case if the empty-vs-invalid boundary is wrong: a legit query gets rejected — covered by tests for empty + valid + invalid. |
+| Lifetime / borrow | N/A | Go; no borrow checker. |
+| Performance | NONE | Interactive diagnostic RPC; one extra `net.ParseIP` per non-empty field. |
+| Architectural mismatch | LOW | Boundary input validation at the gRPC handler is the idiomatic location; matches existing `status.Error(codes.InvalidArgument, ...)` usage in the package. |
+
+## Test plan
+
+New test in `pkg/grpcapi/server_cluster_test.go` (new file), package
+`grpcapi`, using the existing `configstore.New` + `LoadOverride` +
+`Commit` + `&Server{store: store}` scaffolding (mirrors
+`server_show_zones_test.go`):
+
+1. `TestMatchPoliciesRejectsInvalidSourceIP` — config with a
+   permit-any policy from trust→untrust; request with
+   `SourceIp: "10.0.0.999"` (or `"not-an-ip"`); assert the call
+   returns an error with `status.Code(err) == codes.InvalidArgument`
+   and the response is **not** a PERMIT verdict (resp nil on error).
+2. `TestMatchPoliciesRejectsInvalidDestinationIP` — same for
+   destination.
+3. `TestMatchPoliciesEmptyIPsMatchAny` — request with both IPs empty
+   against the permit-any policy → `Matched == true`, action permit,
+   **no error** (proves the legit "any" path is preserved).
+4. `TestMatchPoliciesValidIPMatches` — request with a valid
+   `SourceIp`/`DestinationIp` that falls inside an address-book term →
+   correct match, no error (proves valid path unaffected).
+
+Gates (control-plane / gRPC diagnostic change — NO cluster smoke):
+
+- `go build ./...` clean.
+- `go vet ./pkg/grpcapi/...` clean.
+- `go test ./pkg/grpcapi/...` — new tests pass + existing pass.
+- Full Go suite `go test ./...` green.
+- New named test 5× loop (no flake).
+- `make audit-check` only if a file crosses the size threshold (this
+  change adds <15 LOC to a 600-line file + one new test file — should
+  not trip it; will verify).
+
+## Out of scope (explicitly)
+
+- **`pkg/cli/cli_helpers.go` + `pkg/cli/cli_show_security.go`
+  local-CLI twin.** Same latent bug, different package, not named by
+  the issue. Open Question 5 asks reviewers whether to fold it in.
+  Default plan: gRPC-only per issue scope; file a follow-up for the
+  CLI twin if reviewers prefer scope discipline.
+- Consolidating the two `matchPolicyAddr` copies into one shared
+  helper (a refactor, separate concern).
+- Any proto/schema change.
+
+## Open questions for adversarial review
+
+1. **Empty-vs-invalid boundary.** Is `req.SourceIp != "" &&
+   net.ParseIP(...) == nil` the correct discriminator? Is there any
+   legitimate caller that passes a non-empty sentinel like `"any"` or
+   `"0.0.0.0/0"` as the IP field (which would now be rejected)? Grep
+   of CLI callers shows only raw IP tokens — but confirm.
+2. **Should `"0.0.0.0"` / `"::"` be accepted?** They parse fine via
+   `net.ParseIP` (valid IPs), so they take the valid path and match
+   per address-book containment. That seems correct — confirm no
+   special-casing is wanted.
+3. **CIDR input.** The field is documented as an IP, not a CIDR.
+   `net.ParseIP("10.0.0.0/24")` returns nil → would now be rejected as
+   InvalidArgument. Previously it silently wildcarded. Is rejecting
+   CIDR-in-IP-field the right call, or should we accept a CIDR? (Plan
+   position: reject — the field contract is a single IP; matcher uses
+   `cidr.Contains(ip)` against address-book entries, not the reverse.)
+4. **Double-parse.** Acceptable on a diagnostic RPC, or should we
+   parse once and branch on nil+empty? (Plan position: keep the guard
+   self-contained for clarity; cost is nil at human invocation rate.)
+5. **Local-CLI twin scope.** Fold the identical
+   `pkg/cli` fix into this PR, or keep gRPC-only per the issue and
+   file a follow-up? PLAN-KILL is *not* warranted either way — this is
+   a scope-boundary question.

--- a/docs/pr/1711-policy-sim-ip-validation/reviewer-ids.md
+++ b/docs/pr/1711-policy-sim-ip-validation/reviewer-ids.md
@@ -6,3 +6,17 @@
 - Claude SMR: PLAN-NEEDS-MAJOR — local CLI runs simulator in-process, gRPC-only insufficient
 
 Convergent verdict: expand to all three boundaries (gRPC + local CLI + REST).
+
+## Code review round 2 (PR #1721, three-boundary impl)
+- Codex: `task-mptayaxl-m5m8ks` — MERGE-NEEDS-MAJOR
+  - HIGH: two more simulator copies missed (cli_request.go testPolicy,
+    server_show_firewall.go showTestPolicy via ShowText)
+  - HIGH: branch stale (forked before #1709/#1712/#1713/#1714) → rebase
+  - MEDIUM: CLI/REST positive tests only check err==nil/status
+  - Minor: nil-config bypasses validation (contract nit, not the bug)
+- AGY: `adversarial-review-mptayhsi-15ez9v` — MERGE-NEEDS-MAJOR
+  - Found the 4th caller (cli_request.go testPolicy); confirmed
+    discriminator + contracts + no scope creep otherwise
+
+Resolution (v3): fixed both extra copies, rebased onto current master,
+strengthened positive tests to assert the actual match verdict.

--- a/docs/pr/1711-policy-sim-ip-validation/reviewer-ids.md
+++ b/docs/pr/1711-policy-sim-ip-validation/reviewer-ids.md
@@ -1,0 +1,8 @@
+# #1711 reviewer task IDs
+
+## Plan review round 1 (v1, gRPC-only)
+- Codex: `task-mpta3t25-pi958d` — PLAN-NEEDS-MAJOR (twin CLI + REST out of scope)
+- AGY: `adversarial-review-mpta4os9-m2em4w` — PLAN-NEEDS-MAJOR (same: 3 boundaries)
+- Claude SMR: PLAN-NEEDS-MAJOR — local CLI runs simulator in-process, gRPC-only insufficient
+
+Convergent verdict: expand to all three boundaries (gRPC + local CLI + REST).

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,5 +1,5 @@
 [REFACTOR]   2437  userspace-dp/src/afxdp/poll_descriptor/mod.rs
-[WATCH]      1986  pkg/cli/cli_show_security.go
+[WATCH]      1997  pkg/cli/cli_show_security.go
 [WATCH]      1807  userspace-dp/src/afxdp/wg/engine.rs
 [WATCH]      1792  userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
 [WATCH]      1784  pkg/dataplane/userspace/manager.go

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"sort"
@@ -190,8 +191,24 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 
 	fromZone := r.URL.Query().Get("from_zone")
 	toZone := r.URL.Query().Get("to_zone")
-	srcIP := net.ParseIP(r.URL.Query().Get("src_ip"))
-	dstIP := net.ParseIP(r.URL.Query().Get("dst_ip"))
+
+	// A non-empty but malformed src_ip/dst_ip would parse to nil and be
+	// treated as a wildcard by matchPolicyAddr, yielding a false-positive
+	// PERMIT verdict in the simulator (#1711). Reject it with 400. An
+	// empty value still means "unspecified" (match any).
+	srcIPStr := r.URL.Query().Get("src_ip")
+	if srcIPStr != "" && net.ParseIP(srcIPStr) == nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid src_ip %q", srcIPStr))
+		return
+	}
+	dstIPStr := r.URL.Query().Get("dst_ip")
+	if dstIPStr != "" && net.ParseIP(dstIPStr) == nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid dst_ip %q", dstIPStr))
+		return
+	}
+
+	srcIP := net.ParseIP(srcIPStr)
+	dstIP := net.ParseIP(dstIPStr)
 	dstPort := queryInt(r, "dst_port", 0)
 	proto := r.URL.Query().Get("protocol")
 

--- a/pkg/api/security_test.go
+++ b/pkg/api/security_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// matchPoliciesAPIStore builds a config with a single trust->untrust
+// policy whose terms reference a restricted address-book entry (not
+// "any"), exercising the actual #1711 false-positive shape in the REST
+// simulator handler.
+func matchPoliciesAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    address-book {
+        global {
+            address trust-net 10.0.1.0/24;
+        }
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy restricted-allow {
+                match { source-address trust-net; destination-address trust-net; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestMatchPoliciesHandlerValidation covers the REST simulator handler
+// (GET /api/v1/security/match): a non-empty malformed src_ip/dst_ip must
+// return 400 rather than silently wildcard-matching, while empty/valid
+// inputs succeed (#1711).
+func TestMatchPoliciesHandlerValidation(t *testing.T) {
+	s := &Server{store: matchPoliciesAPIStore(t)}
+
+	tests := []struct {
+		name     string
+		query    url.Values
+		wantCode int
+	}{
+		{
+			name:     "invalid src_ip",
+			query:    url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}, "src_ip": {"10.0.0.999"}},
+			wantCode: 400,
+		},
+		{
+			name:     "invalid dst_ip",
+			query:    url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}, "dst_ip": {"garbage"}},
+			wantCode: 400,
+		},
+		{
+			name:     "cidr in ip field rejected",
+			query:    url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}, "src_ip": {"10.0.0.0/24"}},
+			wantCode: 400,
+		},
+		{
+			name:     "empty ips match any",
+			query:    url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}},
+			wantCode: 200,
+		},
+		{
+			name:     "valid in-term ip",
+			query:    url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}, "src_ip": {"10.0.1.5"}, "dst_ip": {"10.0.1.6"}},
+			wantCode: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/api/v1/security/match?"+tt.query.Encode(), nil)
+			s.matchPoliciesHandler(rr, req)
+
+			if rr.Code != tt.wantCode {
+				t.Fatalf("status = %d, want %d; body: %s", rr.Code, tt.wantCode, rr.Body.String())
+			}
+
+			var resp struct {
+				Success bool   `json:"success"`
+				Error   string `json:"error"`
+			}
+			if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal response: %v; body: %s", err, rr.Body.String())
+			}
+			if tt.wantCode == 400 {
+				if resp.Success {
+					t.Fatalf("success = true on 400; body: %s", rr.Body.String())
+				}
+				if resp.Error == "" {
+					t.Fatalf("error message empty on 400; body: %s", rr.Body.String())
+				}
+			} else if !resp.Success {
+				t.Fatalf("success = false on 200; body: %s", rr.Body.String())
+			}
+		})
+	}
+}

--- a/pkg/api/security_test.go
+++ b/pkg/api/security_test.go
@@ -58,9 +58,10 @@ func TestMatchPoliciesHandlerValidation(t *testing.T) {
 	s := &Server{store: matchPoliciesAPIStore(t)}
 
 	tests := []struct {
-		name     string
-		query    url.Values
-		wantCode int
+		name      string
+		query     url.Values
+		wantCode  int
+		wantMatch bool // for 200 cases: must data.matched be true?
 	}{
 		{
 			name:     "invalid src_ip",
@@ -78,14 +79,16 @@ func TestMatchPoliciesHandlerValidation(t *testing.T) {
 			wantCode: 400,
 		},
 		{
-			name:     "empty ips match any",
-			query:    url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}},
-			wantCode: 200,
+			name:      "empty ips match any",
+			query:     url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}},
+			wantCode:  200,
+			wantMatch: true,
 		},
 		{
-			name:     "valid in-term ip",
-			query:    url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}, "src_ip": {"10.0.1.5"}, "dst_ip": {"10.0.1.6"}},
-			wantCode: 200,
+			name:      "valid in-term ip",
+			query:     url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}, "src_ip": {"10.0.1.5"}, "dst_ip": {"10.0.1.6"}},
+			wantCode:  200,
+			wantMatch: true,
 		},
 	}
 
@@ -102,6 +105,10 @@ func TestMatchPoliciesHandlerValidation(t *testing.T) {
 			var resp struct {
 				Success bool   `json:"success"`
 				Error   string `json:"error"`
+				Data    struct {
+					Matched    bool   `json:"matched"`
+					PolicyName string `json:"policy_name"`
+				} `json:"data"`
 			}
 			if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 				t.Fatalf("unmarshal response: %v; body: %s", err, rr.Body.String())
@@ -113,8 +120,17 @@ func TestMatchPoliciesHandlerValidation(t *testing.T) {
 				if resp.Error == "" {
 					t.Fatalf("error message empty on 400; body: %s", rr.Body.String())
 				}
-			} else if !resp.Success {
+				return
+			}
+			if !resp.Success {
 				t.Fatalf("success = false on 200; body: %s", rr.Body.String())
+			}
+			// Assert the actual verdict, not just the envelope — a silent
+			// default-deny would otherwise pass the 200 cases.
+			gotMatch := resp.Data.Matched && resp.Data.PolicyName == "restricted-allow"
+			if gotMatch != tt.wantMatch {
+				t.Fatalf("matched=%v policy=%q, want match=%v; body: %s",
+					resp.Data.Matched, resp.Data.PolicyName, tt.wantMatch, rr.Body.String())
 			}
 		})
 	}

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -211,6 +211,17 @@ func (c *CLI) testPolicy(args []string) error {
 		return nil
 	}
 
+	// A non-empty but malformed source/destination IP would parse to
+	// nil and be treated as a wildcard by matchPolicyAddr, yielding a
+	// false-positive policy match (#1711). Reject it explicitly. An
+	// empty value still means "unspecified" (match any).
+	if srcIP != "" && net.ParseIP(srcIP) == nil {
+		return fmt.Errorf("invalid source-ip %q", srcIP)
+	}
+	if dstIP != "" && net.ParseIP(dstIP) == nil {
+		return fmt.Errorf("invalid destination-ip %q", dstIP)
+	}
+
 	parsedSrc := net.ParseIP(srcIP)
 	parsedDst := net.ParseIP(dstIP)
 

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -1936,6 +1936,17 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		return nil
 	}
 
+	// A non-empty but malformed source/destination IP would parse to
+	// nil and be treated as a wildcard by matchPolicyAddr, yielding a
+	// false-positive PERMIT verdict in the simulator (#1711). Reject it
+	// explicitly. An empty value still means "unspecified" (match any).
+	if srcIP != "" && net.ParseIP(srcIP) == nil {
+		return fmt.Errorf("invalid source-ip %q", srcIP)
+	}
+	if dstIP != "" && net.ParseIP(dstIP) == nil {
+		return fmt.Errorf("invalid destination-ip %q", dstIP)
+	}
+
 	parsedSrc := net.ParseIP(srcIP)
 	parsedDst := net.ParseIP(dstIP)
 

--- a/pkg/cli/cli_show_security_test.go
+++ b/pkg/cli/cli_show_security_test.go
@@ -201,9 +201,10 @@ func TestShowMatchPoliciesValidation(t *testing.T) {
 	c := &CLI{}
 
 	tests := []struct {
-		name    string
-		args    []string
-		wantErr bool
+		name      string
+		args      []string
+		wantErr   bool
+		wantMatch bool // for the no-error cases: must the simulator report a match?
 	}{
 		{
 			name:    "invalid source-ip",
@@ -221,14 +222,16 @@ func TestShowMatchPoliciesValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "empty ips match any",
-			args:    []string{"from-zone", "trust", "to-zone", "untrust"},
-			wantErr: false,
+			name:      "empty ips match any",
+			args:      []string{"from-zone", "trust", "to-zone", "untrust"},
+			wantErr:   false,
+			wantMatch: true,
 		},
 		{
-			name:    "valid in-term ip",
-			args:    []string{"from-zone", "trust", "to-zone", "untrust", "source-ip", "10.0.1.5", "destination-ip", "10.0.1.6"},
-			wantErr: false,
+			name:      "valid in-term ip",
+			args:      []string{"from-zone", "trust", "to-zone", "untrust", "source-ip", "10.0.1.5", "destination-ip", "10.0.1.6"},
+			wantErr:   false,
+			wantMatch: true,
 		},
 	}
 
@@ -249,6 +252,105 @@ func TestShowMatchPoliciesValidation(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("showMatchPolicies(%v) error = %v, want nil", tt.args, err)
+			}
+			// Assert the actual simulator verdict, not just "no error" — a
+			// silent default-deny would otherwise pass the no-error cases.
+			gotMatch := strings.Contains(out, "Matching policy") && strings.Contains(out, "restricted-allow")
+			if gotMatch != tt.wantMatch {
+				t.Fatalf("showMatchPolicies(%v) match=%v, want %v; out = %q", tt.args, gotMatch, tt.wantMatch, out)
+			}
+		})
+	}
+}
+
+// TestTestPolicyValidation covers the operational `test policy` CLI
+// simulator (pkg/cli/cli_request.go testPolicy), a separate in-process
+// copy of the matcher. Malformed IPs must error rather than
+// wildcard-match; empty/valid inputs report a match (#1711).
+func TestTestPolicyValidation(t *testing.T) {
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    address-book {
+        global {
+            address trust-net 10.0.1.0/24;
+        }
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy restricted-allow {
+                match { source-address trust-net; destination-address trust-net; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	c := &CLI{store: store}
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantErr   bool
+		wantMatch bool
+	}{
+		{
+			name:    "invalid source-ip",
+			args:    []string{"from-zone", "trust", "to-zone", "untrust", "source-ip", "10.0.0.999"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid destination-ip",
+			args:    []string{"from-zone", "trust", "to-zone", "untrust", "destination-ip", "garbage"},
+			wantErr: true,
+		},
+		{
+			name:      "empty ips match any",
+			args:      []string{"from-zone", "trust", "to-zone", "untrust"},
+			wantErr:   false,
+			wantMatch: true,
+		},
+		{
+			name:      "valid in-term ip",
+			args:      []string{"from-zone", "trust", "to-zone", "untrust", "source-ip", "10.0.1.5"},
+			wantErr:   false,
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			out := captureStdout(t, func() {
+				err = c.testPolicy(tt.args)
+			})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("testPolicy(%v) returned no error; out = %q (false-positive #1711)", tt.args, out)
+				}
+				if strings.Contains(out, "Policy match") {
+					t.Fatalf("testPolicy(%v) printed a match for malformed input: %q", tt.args, out)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("testPolicy(%v) error = %v, want nil", tt.args, err)
+			}
+			gotMatch := strings.Contains(out, "Policy match") && strings.Contains(out, "restricted-allow")
+			if gotMatch != tt.wantMatch {
+				t.Fatalf("testPolicy(%v) match=%v, want %v; out = %q", tt.args, gotMatch, tt.wantMatch, out)
 			}
 		})
 	}

--- a/pkg/cli/cli_show_security_test.go
+++ b/pkg/cli/cli_show_security_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
@@ -144,5 +145,111 @@ func TestScreenSYNCookieCounterRowsUsesUserspaceStatus(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("screen SYN-cookie rows missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// matchPoliciesCLITestConfig builds a config with a single trust->untrust
+// policy whose terms reference a restricted address-book entry (not
+// "any"), so the test exercises the actual #1711 false-positive shape in
+// the local in-process simulator.
+func matchPoliciesCLITestConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    address-book {
+        global {
+            address trust-net 10.0.1.0/24;
+        }
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy restricted-allow {
+                match { source-address trust-net; destination-address trust-net; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	return cfg
+}
+
+// TestShowMatchPoliciesValidation covers the local interactive CLI
+// simulator (which runs in-process, not via the gRPC handler): malformed
+// source/destination IP input must return an error rather than silently
+// wildcard-matching, while empty IPs preserve the "any" semantics (#1711).
+func TestShowMatchPoliciesValidation(t *testing.T) {
+	cfg := matchPoliciesCLITestConfig(t)
+	c := &CLI{}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "invalid source-ip",
+			args:    []string{"from-zone", "trust", "to-zone", "untrust", "source-ip", "10.0.0.999"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid destination-ip",
+			args:    []string{"from-zone", "trust", "to-zone", "untrust", "destination-ip", "garbage"},
+			wantErr: true,
+		},
+		{
+			name:    "cidr in ip field rejected",
+			args:    []string{"from-zone", "trust", "to-zone", "untrust", "source-ip", "10.0.0.0/24"},
+			wantErr: true,
+		},
+		{
+			name:    "empty ips match any",
+			args:    []string{"from-zone", "trust", "to-zone", "untrust"},
+			wantErr: false,
+		},
+		{
+			name:    "valid in-term ip",
+			args:    []string{"from-zone", "trust", "to-zone", "untrust", "source-ip", "10.0.1.5", "destination-ip", "10.0.1.6"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			out := captureStdout(t, func() {
+				err = c.showMatchPolicies(cfg, tt.args)
+			})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("showMatchPolicies(%v) returned no error; out = %q (false-positive #1711)", tt.args, out)
+				}
+				if strings.Contains(out, "Matching policy") {
+					t.Fatalf("showMatchPolicies(%v) printed a match for malformed input: %q", tt.args, out)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("showMatchPolicies(%v) error = %v, want nil", tt.args, err)
+			}
+		})
 	}
 }

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -126,6 +126,19 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		return &pb.MatchPoliciesResponse{}, nil
 	}
 
+	// An empty source/destination IP means "unspecified" (match any),
+	// which is a legitimate simulator query. A NON-EMPTY but malformed
+	// value is an operator error: net.ParseIP returns nil and
+	// matchPolicyAddr treats nil as a wildcard, which would yield a
+	// false-positive PERMIT verdict (#1711). Reject it explicitly so the
+	// simulator never silently turns garbage input into "any".
+	if req.SourceIp != "" && net.ParseIP(req.SourceIp) == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid source-ip %q", req.SourceIp)
+	}
+	if req.DestinationIp != "" && net.ParseIP(req.DestinationIp) == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid destination-ip %q", req.DestinationIp)
+	}
+
 	parsedSrc := net.ParseIP(req.SourceIp)
 	parsedDst := net.ParseIP(req.DestinationIp)
 	dstPort := int(req.DestinationPort)

--- a/pkg/grpcapi/server_cluster_test.go
+++ b/pkg/grpcapi/server_cluster_test.go
@@ -3,6 +3,7 @@ package grpcapi
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/configstore"
@@ -168,5 +169,42 @@ func TestMatchPoliciesValidIPOutsideTermNoFalsePositive(t *testing.T) {
 	}
 	if resp.Matched {
 		t.Fatalf("out-of-term IP unexpectedly matched; restricted term not enforced: resp = %+v", resp)
+	}
+}
+
+// TestShowTestPolicyRejectsInvalidIP covers the ShowText "test-policy:"
+// simulator (the operational `test policy` command served via gRPC),
+// which is a separate copy of the matcher (matchShowPolicyAddr). A
+// non-empty malformed IP must not produce a "Policy match" line.
+func TestShowTestPolicyRejectsInvalidIP(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{
+		Topic: "test-policy:from=trust,to=untrust,src=10.0.0.999",
+	})
+	if err != nil {
+		t.Fatalf("ShowText(test-policy invalid src) error = %v", err)
+	}
+	if strings.Contains(resp.Output, "Policy match") {
+		t.Fatalf("invalid src produced a policy match (false-positive #1711): %q", resp.Output)
+	}
+	if !strings.Contains(resp.Output, "invalid src") {
+		t.Fatalf("output = %q, want an invalid-src diagnostic", resp.Output)
+	}
+}
+
+// TestShowTestPolicyEmptyIPMatches proves the ShowText simulator still
+// treats empty IPs as "any" (matches the restricted-term policy).
+func TestShowTestPolicyEmptyIPMatches(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{
+		Topic: "test-policy:from=trust,to=untrust",
+	})
+	if err != nil {
+		t.Fatalf("ShowText(test-policy empty IPs) error = %v", err)
+	}
+	if !strings.Contains(resp.Output, "Policy match") || !strings.Contains(resp.Output, "restricted-allow") {
+		t.Fatalf("empty-IP test-policy did not match; empty-means-any regressed: %q", resp.Output)
 	}
 }

--- a/pkg/grpcapi/server_cluster_test.go
+++ b/pkg/grpcapi/server_cluster_test.go
@@ -1,0 +1,172 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// matchPoliciesTestStore builds a config with a single trust->untrust
+// policy whose source/destination terms reference a RESTRICTED
+// address-book entry (10.0.1.0/24), not "any". This shape proves the
+// #1711 false-positive: with the bug a malformed IP collapses to nil
+// and matchPolicyAddr returns true even though 10.0.1.0/24 should not
+// match arbitrary input.
+func matchPoliciesTestStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    address-book {
+        global {
+            address trust-net 10.0.1.0/24;
+        }
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy restricted-allow {
+                match { source-address trust-net; destination-address trust-net; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func TestMatchPoliciesRejectsInvalidSourceIP(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone: "trust",
+		ToZone:   "untrust",
+		SourceIp: "10.0.0.999", // non-empty but unparseable
+	})
+	if err == nil {
+		t.Fatalf("MatchPolicies(invalid source-ip) returned no error; resp = %+v (false-positive #1711)", resp)
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("status code = %v, want InvalidArgument", status.Code(err))
+	}
+	if resp != nil {
+		t.Fatalf("resp = %+v, want nil on InvalidArgument", resp)
+	}
+}
+
+func TestMatchPoliciesRejectsInvalidDestinationIP(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone:      "trust",
+		ToZone:        "untrust",
+		DestinationIp: "not-an-ip",
+	})
+	if err == nil {
+		t.Fatalf("MatchPolicies(invalid destination-ip) returned no error; resp = %+v", resp)
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("status code = %v, want InvalidArgument", status.Code(err))
+	}
+	if resp != nil {
+		t.Fatalf("resp = %+v, want nil on InvalidArgument", resp)
+	}
+}
+
+// TestMatchPoliciesRejectsCIDRInIPField guards the resolved open
+// question: a CIDR in the single-IP field is malformed input and must
+// be rejected, not silently wildcarded.
+func TestMatchPoliciesRejectsCIDRInIPField(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	_, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone: "trust",
+		ToZone:   "untrust",
+		SourceIp: "10.0.0.0/24",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("CIDR in source-ip: status code = %v, want InvalidArgument", status.Code(err))
+	}
+}
+
+// TestMatchPoliciesEmptyIPsMatchAny proves the legitimate Junos "any"
+// semantics survive: with both IP fields empty the simulator matches
+// the (restricted-term) policy because an unspecified tuple field is
+// treated as "any". This is the behavior the #1711 fix must NOT break.
+func TestMatchPoliciesEmptyIPsMatchAny(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone: "trust",
+		ToZone:   "untrust",
+		// SourceIp / DestinationIp intentionally empty.
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies(empty IPs) error = %v, want nil", err)
+	}
+	if !resp.Matched {
+		t.Fatalf("empty-IP query did not match; the empty-means-any path regressed")
+	}
+	if resp.Action != "permit" {
+		t.Fatalf("action = %q, want permit", resp.Action)
+	}
+}
+
+// TestMatchPoliciesValidIPMatches proves the valid path is unaffected:
+// a real IP inside the restricted 10.0.1.0/24 term matches.
+func TestMatchPoliciesValidIPMatches(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone:      "trust",
+		ToZone:        "untrust",
+		SourceIp:      "10.0.1.5",
+		DestinationIp: "10.0.1.6",
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies(valid IPs) error = %v, want nil", err)
+	}
+	if !resp.Matched || resp.PolicyName != "restricted-allow" {
+		t.Fatalf("valid IP inside term did not match expected policy; resp = %+v", resp)
+	}
+}
+
+// TestMatchPoliciesValidIPOutsideTermNoFalsePositive confirms the
+// matcher is actually constrained by the term: a valid IP OUTSIDE
+// 10.0.1.0/24 does not match (proving the term restriction is live, so
+// the malformed-input rejection closes a real gap rather than masking a
+// matcher that always returns true).
+func TestMatchPoliciesValidIPOutsideTermNoFalsePositive(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone:      "trust",
+		ToZone:        "untrust",
+		SourceIp:      "192.168.99.1",
+		DestinationIp: "192.168.99.2",
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies(valid out-of-term IPs) error = %v, want nil", err)
+	}
+	if resp.Matched {
+		t.Fatalf("out-of-term IP unexpectedly matched; restricted term not enforced: resp = %+v", resp)
+	}
+}

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -189,6 +189,13 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 		buf.WriteString("No active configuration\n")
 	} else if fromZone == "" || toZone == "" {
 		buf.WriteString("Missing from/to zone parameters\n")
+	} else if srcIP != "" && net.ParseIP(srcIP) == nil {
+		// A non-empty but malformed src would parse to nil and be treated
+		// as a wildcard by matchShowPolicyAddr, yielding a false-positive
+		// policy match (#1711). Report it instead. Empty still means any.
+		fmt.Fprintf(buf, "invalid src %q\n", srcIP)
+	} else if dstIP != "" && net.ParseIP(dstIP) == nil {
+		fmt.Fprintf(buf, "invalid dst %q\n", dstIP)
 	} else {
 		parsedSrc := net.ParseIP(srcIP)
 		parsedDst := net.ParseIP(dstIP)


### PR DESCRIPTION
## Summary

The policy simulator behind `show security match-policies` parsed the
operator-supplied source/destination IP with `net.ParseIP` and fed the
result to `matchPolicyAddr`, which treats a `nil` IP as an
unconditional wildcard. Because `net.ParseIP` returns `nil` for both an
empty string and a malformed one, a **non-empty but malformed** IP
(e.g. `source-ip 10.0.0.999`) silently matched every policy term,
producing a false-positive PERMIT verdict in the diagnostic output.

Adversarial plan review (Codex + AGY, both PLAN-NEEDS-MAJOR on the
gRPC-only v1) established that the simulator is served by **three
independent in-process copies** of the matcher, so a gRPC-only fix
would leave two of them false-positiveing. This PR validates the
non-empty-but-invalid IP at all three boundaries, each with its native
error type, while preserving the legitimate empty-means-any semantics
and the `len(addrs)==0` policy-term "any" arm:

- **gRPC** `pkg/grpcapi/server_cluster.go` `MatchPolicies` → `codes.InvalidArgument`
- **Local CLI** `pkg/cli/cli_show_security.go` `showMatchPolicies` (runs in-process) → `error` printed to console
- **HTTP REST** `pkg/api/security.go` `matchPoliciesHandler` → HTTP 400

The three `matchPolicyAddr` copies are left unchanged; consolidating
them is an explicitly out-of-scope refactor.

Closes #1711

## Plan + adversarial review

Plan doc: `docs/pr/1711-policy-sim-ip-validation/plan.md`

- Codex plan round 1 (`task-mpta3t25-pi958d`): PLAN-NEEDS-MAJOR — twin CLI + REST out of scope
- AGY plan round 1 (`adversarial-review-mpta4os9-m2em4w`): PLAN-NEEDS-MAJOR — same three-boundary finding
- Claude SMR: PLAN-NEEDS-MAJOR — local CLI runs the simulator in-process, gRPC-only insufficient

All converged: expand to all three boundaries. Resolved open questions
(empty-vs-invalid discriminator, CIDR-in-IP-field rejection, double-parse)
are recorded in the plan.

## Test plan

Control-plane diagnostic change — no cluster smoke (state explicitly).

- [x] `go build ./...` clean
- [x] `go vet ./pkg/grpcapi/... ./pkg/cli/... ./pkg/api/...` clean (the
      pre-existing `pkg/cli/cli.go:380` unreachable-code warning is on
      master, in a file this PR does not touch)
- [x] `go test ./pkg/grpcapi/... ./pkg/cli/... ./pkg/api/...` pass
- [x] Full `go test ./...` green except the pre-existing
      `TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports`
      allowlist-drift canary, which fails identically on clean
      `origin/master` and is unrelated to this change
- [x] New named tests 5/5 flake check across all three packages
- [x] `make audit-check` green (regenerated the WATCH-tier line count
      after the local CLI guard grew `cli_show_security.go` 1986→1997)

Tests build policies whose terms reference a restricted address-book
entry (`10.0.1.0/24`) rather than `any`, so they exercise the actual
false-positive shape: malformed/CIDR input is rejected, empty input
still matches via the any path, a valid in-term IP matches, and a valid
out-of-term IP does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)