### PR TITLE
Fix legacy-dataplane import-allowlist drift after #1700 server_show split

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -288,7 +288,6 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/grpcapi/runtime.go` | #1516 — `grpcRuntime` interface declares the narrow gRPC dataplane surface; still depends on root `pkg/dataplane` type names (`SessionKey`, `CounterValue`, etc.) until those types move to a domain package. |
 | `pkg/grpcapi/server_helpers.go` | gRPC helpers still format legacy dataplane types and bridge runtime accessors. |
 | `pkg/grpcapi/server_sessions.go` | gRPC session RPCs still use legacy session types. |
-| `pkg/grpcapi/server_show.go` | gRPC show dispatcher still reaches legacy dataplane state. |
 | `pkg/grpcapi/server_show_cluster_text.go` | Cluster text output still reads legacy dataplane state. |
 | `pkg/grpcapi/server_show_flow.go` | Flow text output still uses legacy session keys and values. |
 | `pkg/grpcapi/server_show_policies_text.go` | Policy text output still uses legacy counters. |

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -67,7 +67,6 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/grpcapi/runtime.go":                   "#1516 grpcRuntime interface declares the narrow gRPC dataplane surface; still depends on root pkg/dataplane type names (SessionKey, CounterValue, etc.) until those types move to a domain package",
 	"pkg/grpcapi/server_helpers.go":            "gRPC helpers still format legacy dataplane types and bridge runtime accessors",
 	"pkg/grpcapi/server_sessions.go":           "gRPC session RPCs still use legacy session types",
-	"pkg/grpcapi/server_show.go":               "gRPC show dispatcher still reaches legacy dataplane state",
 	"pkg/grpcapi/server_show_cluster_text.go":  "cluster text output still reads legacy dataplane state",
 	"pkg/grpcapi/server_show_flow.go":          "flow text output still uses legacy session keys and values",
 	"pkg/grpcapi/server_show_policies_text.go": "policy text output still uses legacy counters",


### PR DESCRIPTION
## Summary
Master is RED: `TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports` fails with `stale allowlist entries: [pkg/grpcapi/server_show.go]`.

#1700 split `server_show.go` into per-topic files, moving the legacy-`pkg/dataplane` reaching code out of `server_show.go` (it now has **zero** dataplane imports) and into topic files that #1700 correctly added to the allowlist — but it left the now-stale `server_show.go` entry behind. Several agents dismissed the resulting failure as "pre-existing"; it was #1700's own un-reconciled drift.

## Change (test + docs only, no production code)
- Remove the stale `pkg/grpcapi/server_show.go` entry from `legacyDataplaneImportAllowlist` (`pkg/dataplane/retirement_boundary_canary_test.go`).
- Remove the matching row from the #1451 mirror table (`docs/pr/1373-retire-ebpf-dataplane/README.md`).
- The topic files that DO still import `pkg/dataplane` (server_show_flow/status/zones/...) remain allowlisted.

## Test plan
- [x] `server_show.go` confirmed to import no `pkg/dataplane`
- [x] canary `TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports` → green
- [x] `pkg/dataplane` + `pkg/grpcapi` packages pass
- Mechanical master-red drift hotfix (test+docs only) — same expedited class as the #1675 audit-drift fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)