### PR TITLE
#1706: fix four latent routing-correctness defects in pkg/routing

### DIFF
--- a/docs/pr/1706-routing-latent-defects/plan.md
+++ b/docs/pr/1706-routing-latent-defects/plan.md
@@ -1,0 +1,265 @@
+# #1706 — Fix four latent routing-correctness defects in pkg/routing
+
+Status: DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+#1705 (the #1698 routing.go per-domain split) review surfaced four
+latent correctness defects. All four are verbatim-identical to the
+pre-split `routing.go` on master — #1698/#1705 were behavior-preserving
+motion and deliberately left them unchanged. #1706 is the focused
+follow-up that fixes them. They are cohesive (one package, surfaced
+together) and ship as ONE PR, four logical-increment commits.
+
+This is a correctness bug-fix, not a refactor or a perf change. PLAN-KILL
+of an individual defect is acceptable if it turns out not to be real;
+each has been verified end-to-end against the worktree source below.
+
+## Defect verification (read end-to-end against the worktree)
+
+### Defect 1 — TUN anchor reuse operates on a fresh ifindex-less link
+`tunnelManager.Apply`, `pkg/routing/tunnel.go:110-168`.
+
+When `tc.AnchorOnly` and the anchor already exists as a TUN, the code:
+```go
+anchor := &netlink.Tuntap{ LinkAttrs: netlink.LinkAttrs{Name: tc.Name}, ... } // :111
+if err := t.ops.LinkAdd(anchor); err != nil {                                 // :118
+    if existing, lookupErr := t.ops.LinkByName(tc.Name); lookupErr == nil {   // :122
+        if _, isTun := existing.(*netlink.Tuntap); isTun {
+            goto anchorReady                                                   // :126
+        }
+        ...
+    }
+}
+anchorReady:
+closeTuntapFiles(anchor.Fds)              // :143  uses fresh `anchor`
+if err := t.ops.LinkSetUp(anchor); ...    // :144  uses fresh `anchor` (no ifindex)
+    ... t.ops.AddrAdd(anchor, addr) ...    // :155  uses fresh `anchor`
+```
+On the reuse path `existing` (which HAS an ifindex from the kernel) is
+discarded; `LinkSetUp`/`AddrAdd` run against the freshly-constructed
+`anchor` whose `LinkAttrs.Index == 0`. With the real netlink handle,
+`LinkSetUp`/`AddrAdd` resolve by ifindex when set, falling back to name
+only when index==0 — but the anchor was never populated from the kernel,
+so its attrs (flags, etc.) are stale and the operation targets a
+zero-index link. The retry/replace arm (`:131`) correctly re-adds into
+`anchor`, so only the `goto anchorReady` reuse arm is wrong.
+
+SEVERITY CAVEAT (verified against vishvananda/netlink v1.3.1):
+`Handle.LinkSetUp` (link_linux.go:391) and `Handle.addrHandle`
+(addr_linux.go:83, reached by AddrAdd) BOTH call `h.ensureIndex(base)`,
+which, when `base.Index == 0`, re-resolves the index via
+`LinkByName(base.Name)` (link_linux.go:77-83). The fresh `anchor` DOES
+carry `LinkAttrs{Name: tc.Name}`, so in production the index is
+re-resolved by name before the op fires — the operation targets the
+correct kernel link despite the zero index. Therefore defect 1 is
+**largely benign in production today**: it relies on the netlink
+library's implicit name re-resolution rather than being outright broken.
+
+The fix is still warranted as a correctness/robustness improvement:
+(a) it removes the dependency on an undocumented library fallback;
+(b) the fresh anchor carries stale/default LinkAttrs (flags, etc.) that
+ensureIndex does NOT refresh — only Index is patched — so any future op
+reading other attrs off `anchor` would be wrong; (c) it matches the
+replace arm which already operates on a properly-populated link.
+
+If reviewers judge the benign-in-production reality means the churn
+isn't justified, PLAN-KILL of defect 1 is acceptable and the PR ships
+the other three.
+
+Fix: on the reuse arm, assign the existing link before the goto:
+```go
+if existingTun, isTun := existing.(*netlink.Tuntap); isTun {
+    slog.Info("tunnel anchor already exists as TUN, reusing", "name", tc.Name)
+    anchor = existingTun
+    goto anchorReady
+}
+```
+`anchor` is `*netlink.Tuntap`, `existing` is `netlink.Link`; the type
+assert already in the branch yields the concrete `*netlink.Tuntap`.
+`closeTuntapFiles(anchor.Fds)` then runs against the reused link whose
+`Fds` is nil (kernel-fetched link carries no fds) — harmless no-op.
+
+### Defect 2 — xfrm double LinkByName + LinkSetUp(nil) panic risk
+`xfrmManager.Apply`, `pkg/routing/xfrm.go:44-60`.
+```go
+if _, err := x.ops.LinkByName(ifName); err == nil {  // :44 first lookup, link discarded
+    link, _ := x.ops.LinkByName(ifName)               // :45 second lookup, error ignored
+    x.ops.LinkSetUp(link)                             // :46 link may be nil
+    ...
+}
+```
+If the second `LinkByName` transiently fails (EINVAL/EBUSY/etc.), `link`
+is nil and `LinkSetUp(nil)` is called. With the real netlink handle this
+dereferences `link.Attrs()` on a nil interface value → panic. This exact
+double-call was preserved byte-identical in #1705 (pure motion).
+
+CONFIRMED real (nil-deref panic on a transient second-lookup failure).
+
+Fix: reuse the link from the FIRST lookup and handle its error:
+```go
+if link, err := x.ops.LinkByName(ifName); err == nil {
+    if upErr := x.ops.LinkSetUp(link); upErr != nil {
+        slog.Warn("failed to bring up existing xfrmi", "name", ifName, "err", upErr)
+    }
+    slog.Debug("xfrmi already exists", "name", ifName, "if_id", ifID)
+    ... track ...
+    continue
+}
+```
+Single lookup, no second call, no nil passed to LinkSetUp.
+
+### Defect 3 — next-table ip-rule priority can escape the cleared range
+`nextTableManager.Apply` + `clear`, `pkg/routing/rules.go:50-121`.
+
+`prio` starts at `nextTableRulePriority` (100), `prio++` once per
+programmed route (`:99`). `clear()` only deletes
+`[nextTableRulePriority, nextTableRulePriority+100)` = `[100,200)`
+(`:112`). So the 101st next-table route programs prio 200, which lands
+OUTSIDE the cleared window and leaks permanently across re-applies.
+
+CONFIRMED real. The PBR manager already models the right fix
+(`rules.go:326-329`): cap with a warning and stop.
+
+Fix: cap inside the loop, mirroring PBR's pattern. Guard BEFORE the
+RuleAdd (so we never program an out-of-range rule):
+```go
+if prio >= nextTableRulePriority+100 {
+    slog.Warn("next-table rule limit reached; ignoring further next-table routes",
+        "limit", 100, "destination", sr.Destination)
+    break
+}
+```
+Placed after the per-route skip/validation checks, immediately before
+`rule := netlink.NewRule()` so only admit-able routes count against the
+cap (matches PBR semantics where `prio++` only fires on a real add).
+
+### Defect 4 — rib-group ip-rule priority can escape the cleared range
+`ribGroupManager.Apply` + `clear`, `pkg/routing/rules.go:143-255`.
+
+`prio` starts at `ribGroupRulePriority` (33000); each leaked source
+table consumes TWO priorities (v4 `:214` then v6 `:230`). `clear()`
+deletes `[33000,33100)` (`:244`). So the 51st leaking table programs
+33100/33101 — outside the window — and leaks permanently.
+
+CONFIRMED real.
+
+Fix: cap before programming each table's pair. Because a table uses two
+slots, stop when the NEXT pair would not fit (i.e. require room for both
+v4 and v6 within the window):
+```go
+if prio+1 >= ribGroupRulePriority+100 {
+    slog.Warn("rib-group rule limit reached; ignoring further leaking tables",
+        "limit", 100, "instance", inst.Name, "table", sourceTable)
+    break
+}
+```
+Placed after `leakedTables[sourceTable] = true` is decided — actually
+BEFORE marking the table leaked, so a capped table isn't recorded as
+done (it was never programmed). Concretely: place the guard immediately
+after the `if leakedTables[sourceTable] { continue }` skip and before
+`leakedTables[sourceTable] = true`, so the v4+v6 pair is admitted
+atomically or not at all. `prio+1 >= 33100` means the v6 slot (`prio+1`)
+would be the 100th-or-beyond offset → reject the whole pair.
+
+## Hidden invariants the change must preserve
+
+- **Defect 1**: side-effect order (closeTuntapFiles → LinkSetUp →
+  AddrAdd → VRF bind → track) is unchanged; only the link object the
+  ops act on changes from fresh→existing on the reuse arm. The create
+  and replace arms are untouched. `closeTuntapFiles(anchor.Fds)` stays
+  correct: a kernel-fetched `*netlink.Tuntap` has nil `Fds`.
+- **Defect 2**: tracking dedupe loop (`:48-58`) and `continue` are
+  preserved; only the lookup count drops 2→1 and the error is handled.
+  Debug log message preserved. `slog.Warn` on bring-up failure is new
+  but matches the create path's `:82-85` style (non-fatal).
+- **Defect 3/4**: the cap is a hard upper bound matching the clear()
+  window so every programmed rule is guaranteed inside the cleared
+  range — that is exactly the invariant clear() assumes. No behavior
+  change below the cap; identical rules for ≤100 next-table routes /
+  ≤50 leaking tables. Mirrors the already-shipped PBR cap (1000 window).
+- **Logging**: all new logs are `slog.Warn` for the cap (rare,
+  one-time at config-apply) and `slog.Warn` for the xfrm bring-up
+  failure — no per-packet/per-tick logging. Compliant with CLAUDE.md.
+
+## HA assessment
+
+rib-group / next-table leak into kernel ip-rule state, NOT into HA
+session-sync or VRRP state. The managers are driven by `applyConfig`
+(control-plane commit path), not by the failover hot path. No RG-owned
+session table, no VRRP priority, no fabric-redirect state is touched.
+Conclusion: `make test-failover` is NOT required for this change. A
+light route-correctness smoke (routes/VRFs/tunnels still program +
+v4/v6 connectivity) on loss:xpf-userspace-fw0 is the appropriate gate.
+
+## Test plan
+
+New unit tests (all hermetic, fake ops — no netlink):
+
+- **Defect 3 cap** (`fakeRuleOps`): feed 101 next-table routes to one
+  table; assert (a) ≤100 rules programmed, (b) every programmed
+  priority is `< nextTableRulePriority+100`, so a subsequent clear()
+  removes ALL of them (re-apply leaves count stable, no leak).
+- **Defect 4 cap** (`fakeRuleOps`): feed 51 leaking instances; assert
+  ≤100 rules total and every priority `< ribGroupRulePriority+100`;
+  re-apply leaves no residue.
+- **Boundary** for both: exactly-at-limit (100 routes / 50 tables)
+  programs the full set with NO warning/break; one-over triggers the
+  cap. Assert the highest programmed prio is the last in-range slot.
+- **Defect 1 reuse** (new `fakeLinkOps` for linkOps): seed an existing
+  `*netlink.Tuntap` with a non-zero ifindex; make LinkAdd return
+  EEXIST; assert LinkSetUp/AddrAdd are invoked against the SEEDED link
+  (non-zero index), not a fresh zero-index one.
+- **Defect 2 single-lookup** (`fakeLinkOps`): existing xfrmi present;
+  assert LinkByName called exactly ONCE on the already-exists path and
+  LinkSetUp receives the non-nil seeded link; add a transient-second-
+  lookup variant to prove no nil is ever passed (with the fix there is
+  no second lookup to fail).
+
+Gates:
+- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/routing/...`
+  then `./...` (full Go suite). Pre-existing pkg/dataplane/userspace
+  sandbox unix-socket failures are known artifacts — reproduce on clean
+  master and prove pre-existing, do not be blocked.
+- `make audit-check` (regen only if a pkg/routing file crosses a
+  threshold — unlikely; these are small edits).
+- Light route-correctness smoke on loss:xpf-userspace-fw0 (deploy +
+  verify routes/VRFs/tunnels program + v4+v6 connectivity through fw).
+  NOT the full CoS iperf matrix.
+
+## Out of scope
+
+- The PBR manager's existing 1000-window cap is already correct — no
+  change. Only documenting it as the model.
+- Any restructuring of the #1698 domain split. Pure correctness fixes.
+- Promoting next-table/rib-group windows to larger ranges — the cap is
+  the minimal correct fix; widening the window is a separate decision.
+
+## Open questions for adversarial review (each invitable to PLAN-KILL)
+
+1. **Defect 1**: does the real netlink handle resolve `LinkSetUp`/
+   `AddrAdd` by name when `LinkAttrs.Index==0`, making the bug benign?
+   (My read: no — netlink ops key on ifindex; a zero-index fresh
+   Tuntap targets ifindex 0. But if the library re-resolves by name
+   internally on these calls, defect 1 may be cosmetic → PLAN-KILL it.)
+2. **Defect 2**: is `LinkSetUp(nil)` actually a panic, or does the
+   netlink library nil-check and return an error? If it returns an
+   error gracefully, the "panic" framing is wrong though the double
+   lookup is still wasteful — assess whether the fix is still warranted.
+3. **Defect 3/4 cap placement**: is `break` (stop programming further)
+   the right Junos-faithful behavior vs. logging-and-continuing-without-
+   add? Junos would reject at commit; we cap at apply. Is silent-drop
+   past the cap acceptable, or must commit-time validation reject it?
+4. **Defect 4 boundary math**: is `prio+1 >= base+100` the correct
+   guard for a two-slot consumer, or off-by-one (should it be
+   `prio+1 > base+99`, i.e. `prio+2 > base+100`)? Verify the last
+   admitted table uses slots 98+99 and the 51st (slots 100+101) is
+   rejected.
+5. **Defect 1 `closeTuntapFiles(anchor.Fds)`**: after reassigning
+   `anchor = existingTun`, is `existingTun.Fds` guaranteed nil/empty
+   (kernel-fetched link), so the close is a safe no-op? If a fetched
+   Tuntap could carry live fds, the reassignment could double-close —
+   verify.
+6. Are any of these four actually NOT reachable in production (dead
+   config path)? If a defect's trigger config can't be expressed in
+   Junos syntax this firewall accepts, PLAN-KILL that defect.

--- a/docs/pr/1706-routing-latent-defects/plan.md
+++ b/docs/pr/1706-routing-latent-defects/plan.md
@@ -1,6 +1,39 @@
 # #1706 — Fix four latent routing-correctness defects in pkg/routing
 
-Status: DRAFT v1 — pending adversarial plan review
+Status: v2 — PLAN-READY (Codex PLAN-NEEDS-MAJOR on silent truncation
+addressed by adding commit-time warnings; AGY PLAN-READY all four;
+defect 1 reframed as robustness cleanup per both reviewers)
+
+## Adversarial plan review outcome (round 1, commit d90bc3523)
+
+- **Codex** (isolated session): Defect 2 PLAN-READY; Defect 1 PLAN-KILL
+  *as a correctness defect* (benign in prod via ensureIndex name
+  re-resolution) — demote to optional robustness cleanup; Defect 3/4
+  math+placement correct but PLAN-NEEDS-MAJOR because the apply-time cap
+  silently truncates an over-limit config that still commits cleanly —
+  wants commit-time rejection OR explicit acceptance of the Junos
+  divergence.
+- **AGY**: all four PLAN-READY. Confirmed defect-1 benign-but-fix-worthy
+  (ensureIndex patches only Index, not other LinkAttrs; reassignment
+  cleaner than relying on the library fallback; `existingTun.Fds` nil →
+  closeTuntapFiles safe no-op). Confirmed defect-2 panic 100% real.
+  Confirmed defect-4 boundary math exact (50th table → 33098/33099;
+  51st rejected). All four config paths reachable.
+
+### Resolution applied in v2
+
+- **Defect 1**: KEEP the fix but reframe as a robustness/clarity cleanup,
+  not a production correctness bug (honest framing per both reviewers).
+- **Defect 3/4 (Codex NEEDS-MAJOR)**: add commit-time warnings in
+  `config.ValidateConfig` that fire when the raw config exceeds the
+  programmable window (>100 next-table routes; >50 rib-group-leaking
+  instances). These are CONSERVATIVE UPPER BOUNDS computed from the same
+  inputs the applier consumes (global+inet6 static routes with NextTable
+  set; instances referencing a non-empty interface-routes rib-group),
+  so they never miss a real truncation, and they do NOT replicate the
+  applier's exact dedup/skip logic (avoiding validator/applier drift).
+  The apply-time hard cap stays as defense-in-depth against the
+  permanent rule leak. This is a fifth commit.
 
 ## Issue framing
 

--- a/docs/pr/1706-routing-latent-defects/reviewer-ids.md
+++ b/docs/pr/1706-routing-latent-defects/reviewer-ids.md
@@ -1,0 +1,13 @@
+# #1706 reviewer task IDs
+
+## Plan review round 1 (commit d90bc3523)
+
+- Codex: isolated foreground session (CODEX_COMPANION_SESSION_ID =
+  codex-1706-plan-<ts>). Verdict: Defect 2 PLAN-READY; Defect 1
+  PLAN-KILL-as-correctness/optional-cleanup; Defect 3/4 PLAN-NEEDS-MAJOR
+  (silent truncation — wants commit-time rejection/acceptance).
+- AGY: adversarial-review-mptumeh6-ek4ges. Verdict: all four PLAN-READY.
+
+Resolution: keep all four fixes (defect 1 reframed as robustness
+cleanup); add commit-time warnings in ValidateConfig for >100 next-table
+routes / >50 rib-group-leaking instances to address Codex NEEDS-MAJOR.

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -10,3 +10,4 @@
 [WATCH]      1652  cmd/cli/show.go
 [WATCH]      1617  pkg/dataplane/userspace/maps_sync.go
 [WATCH]      1520  userspace-dp/src/afxdp/coordinator/mod.rs
+[WATCH]      1502  pkg/config/compiler.go

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1064,6 +1064,75 @@ func ValidateConfig(cfg *Config) []string {
 		warnings = append(warnings, validateCoSOversubscriptionWarnings(cos)...)
 	}
 
+	// #1706: the next-table and rib-group ip-rule reconcilers program
+	// into fixed 100-priority windows that their clear() passes scan.
+	// The applier hard-caps at the window boundary so out-of-range rules
+	// never leak, but a config that exceeds the window would be silently
+	// truncated at apply time. Surface the over-limit condition here at
+	// commit time so the operator sees it before applying.
+	warnings = append(warnings, validateRoutingRuleWindowWarnings(cfg)...)
+
+	return warnings
+}
+
+// validateRoutingRuleWindowWarnings emits commit-time warnings when a
+// config would program more next-table or rib-group ip rules than the
+// applier's fixed priority window can hold (see pkg/routing/rules.go:
+// nextTableRulePriority window of 100, ribGroupRulePriority window of
+// 100 split into 50 v4+v6 pairs). The counts here are CONSERVATIVE
+// upper bounds computed from the same inputs the applier consumes —
+// they intentionally do NOT replicate the applier's exact skip/dedup
+// logic (unknown-instance skips, self-only rib-groups, duplicate source
+// tables), so they may warn slightly early but never miss a real
+// truncation. The runtime accepts the config; the apply-time cap is the
+// hard guard against the rule leak.
+func validateRoutingRuleWindowWarnings(cfg *Config) []string {
+	var warnings []string
+
+	// next-table: the applier feeds it the global inet + inet6 static
+	// routes (daemon_apply.go), counting those with a NextTable set.
+	const nextTableWindow = 100
+	nextTableRoutes := 0
+	for _, sr := range cfg.RoutingOptions.StaticRoutes {
+		if sr != nil && sr.NextTable != "" {
+			nextTableRoutes++
+		}
+	}
+	for _, sr := range cfg.RoutingOptions.Inet6StaticRoutes {
+		if sr != nil && sr.NextTable != "" {
+			nextTableRoutes++
+		}
+	}
+	if nextTableRoutes > nextTableWindow {
+		warnings = append(warnings, fmt.Sprintf(
+			"routing-options: %d static routes use next-table, but only %d can be "+
+				"programmed as ip rules; routes beyond the limit will be ignored at "+
+				"apply time. Reduce the number of next-table routes.",
+			nextTableRoutes, nextTableWindow))
+	}
+
+	// rib-group: the applier walks routing-instances and programs two ip
+	// rules (v4+v6) per source table that references an interface-routes
+	// rib-group. Window of 100 priorities fits 50 such tables.
+	const ribGroupTableLimit = 50
+	ribGroupInstances := 0
+	for _, inst := range cfg.RoutingInstances {
+		if inst == nil {
+			continue
+		}
+		if inst.InterfaceRoutesRibGroup != "" || inst.InterfaceRoutesRibGroupV6 != "" {
+			ribGroupInstances++
+		}
+	}
+	if ribGroupInstances > ribGroupTableLimit {
+		warnings = append(warnings, fmt.Sprintf(
+			"routing-options: %d routing-instances reference an interface-routes "+
+				"rib-group, but only %d leaking tables can be programmed as ip rules "+
+				"(two priorities each); instances beyond the limit will be ignored at "+
+				"apply time. Reduce the number of rib-group-leaking instances.",
+			ribGroupInstances, ribGroupTableLimit))
+	}
+
 	return warnings
 }
 

--- a/pkg/config/compiler_routing_rules_test.go
+++ b/pkg/config/compiler_routing_rules_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateRoutingRuleWindowWarnings covers the #1706 commit-time
+// warnings that pair with the applier's fixed next-table / rib-group
+// ip-rule priority windows. The warning fires only when the config
+// exceeds the window the applier can program; at or below the limit it
+// stays silent.
+func TestValidateRoutingRuleWindowWarnings(t *testing.T) {
+	mkNextTableRoutes := func(n int) []*StaticRoute {
+		routes := make([]*StaticRoute, n)
+		for i := range routes {
+			routes[i] = &StaticRoute{Destination: "10.0.0.0/8", NextTable: "vr"}
+		}
+		return routes
+	}
+	mkRibGroupInstances := func(n int) []*RoutingInstanceConfig {
+		insts := make([]*RoutingInstanceConfig, n)
+		for i := range insts {
+			insts[i] = &RoutingInstanceConfig{InterfaceRoutesRibGroup: "leak"}
+		}
+		return insts
+	}
+
+	t.Run("next-table at limit is silent", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.RoutingOptions.StaticRoutes = mkNextTableRoutes(100)
+		got := validateRoutingRuleWindowWarnings(cfg)
+		if len(got) != 0 {
+			t.Fatalf("expected no warning at 100 next-table routes, got %v", got)
+		}
+	})
+
+	t.Run("next-table over limit warns", func(t *testing.T) {
+		cfg := &Config{}
+		// Split across inet + inet6 to prove both lists are counted.
+		cfg.RoutingOptions.StaticRoutes = mkNextTableRoutes(60)
+		cfg.RoutingOptions.Inet6StaticRoutes = mkNextTableRoutes(41)
+		got := validateRoutingRuleWindowWarnings(cfg)
+		if len(got) == 0 || !strings.Contains(got[0], "next-table") {
+			t.Fatalf("expected a next-table over-limit warning, got %v", got)
+		}
+		if !strings.Contains(got[0], "101") {
+			t.Errorf("warning should report the combined count 101, got %q", got[0])
+		}
+	})
+
+	t.Run("rib-group at limit is silent", func(t *testing.T) {
+		cfg := &Config{RoutingInstances: mkRibGroupInstances(50)}
+		got := validateRoutingRuleWindowWarnings(cfg)
+		if len(got) != 0 {
+			t.Fatalf("expected no warning at 50 rib-group instances, got %v", got)
+		}
+	})
+
+	t.Run("rib-group over limit warns", func(t *testing.T) {
+		cfg := &Config{RoutingInstances: mkRibGroupInstances(51)}
+		got := validateRoutingRuleWindowWarnings(cfg)
+		if len(got) != 1 || !strings.Contains(got[0], "rib-group") {
+			t.Fatalf("expected a rib-group over-limit warning, got %v", got)
+		}
+		if !strings.Contains(got[0], "51") {
+			t.Errorf("warning should report the count 51, got %q", got[0])
+		}
+	})
+
+	t.Run("instances with no rib-group reference are not counted", func(t *testing.T) {
+		insts := make([]*RoutingInstanceConfig, 60)
+		for i := range insts {
+			insts[i] = &RoutingInstanceConfig{} // no rib-group reference
+		}
+		cfg := &Config{RoutingInstances: insts}
+		got := validateRoutingRuleWindowWarnings(cfg)
+		if len(got) != 0 {
+			t.Fatalf("instances without a rib-group reference must not warn, got %v", got)
+		}
+	})
+
+	t.Run("v6-only rib-group reference is counted", func(t *testing.T) {
+		insts := make([]*RoutingInstanceConfig, 51)
+		for i := range insts {
+			insts[i] = &RoutingInstanceConfig{InterfaceRoutesRibGroupV6: "leak6"}
+		}
+		cfg := &Config{RoutingInstances: insts}
+		got := validateRoutingRuleWindowWarnings(cfg)
+		if len(got) != 1 || !strings.Contains(got[0], "rib-group") {
+			t.Fatalf("expected a rib-group over-limit warning for v6-only refs, got %v", got)
+		}
+	})
+}

--- a/pkg/config/compiler_routing_rules_test.go
+++ b/pkg/config/compiler_routing_rules_test.go
@@ -92,3 +92,37 @@ func TestValidateRoutingRuleWindowWarnings(t *testing.T) {
 		}
 	})
 }
+
+// TestValidateConfigSurfacesRoutingRuleWindowWarnings asserts the
+// over-limit warnings actually flow out of the commit-time entry point
+// ValidateConfig, not just the standalone helper. If the wiring in
+// ValidateConfig were dropped, the operator would lose the warning even
+// though the helper-level tests above still pass.
+func TestValidateConfigSurfacesRoutingRuleWindowWarnings(t *testing.T) {
+	cfg := &Config{}
+	for i := 0; i < 101; i++ {
+		cfg.RoutingOptions.StaticRoutes = append(cfg.RoutingOptions.StaticRoutes,
+			&StaticRoute{Destination: "10.0.0.0/8", NextTable: "vr"})
+	}
+	for i := 0; i < 51; i++ {
+		cfg.RoutingInstances = append(cfg.RoutingInstances,
+			&RoutingInstanceConfig{InterfaceRoutesRibGroup: "leak"})
+	}
+
+	warnings := ValidateConfig(cfg)
+	var sawNextTable, sawRibGroup bool
+	for _, w := range warnings {
+		if strings.Contains(w, "next-table") && strings.Contains(w, "ignored at") {
+			sawNextTable = true
+		}
+		if strings.Contains(w, "rib-group") && strings.Contains(w, "ignored at") {
+			sawRibGroup = true
+		}
+	}
+	if !sawNextTable {
+		t.Errorf("ValidateConfig did not surface the next-table over-limit warning; got %v", warnings)
+	}
+	if !sawRibGroup {
+		t.Errorf("ValidateConfig did not surface the rib-group over-limit warning; got %v", warnings)
+	}
+}

--- a/pkg/routing/iface_reuse_test.go
+++ b/pkg/routing/iface_reuse_test.go
@@ -1,0 +1,189 @@
+package routing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// fakeLinkOps is an in-memory linkOps for the #1706 tunnel/xfrm reuse
+// tests. It records which link object LinkSetUp/AddrAdd were invoked
+// against so the tests can prove the apply paths operate on the
+// kernel-fetched (indexed) link rather than a freshly-constructed,
+// ifindex-less one. LinkAdd can be made to fail (EEXIST) to drive the
+// "already exists" branches.
+type fakeLinkOps struct {
+	links map[string]netlink.Link // name -> seeded existing link
+
+	// addExisting makes LinkAdd report the link already exists.
+	addExisting bool
+
+	// byNameErrAfter, when > 0, makes LinkByName return an error once it
+	// has been called this many times for the same name (used to drive a
+	// transient second-lookup failure under the OLD double-lookup code).
+	byNameCount    map[string]int
+	byNameErrAfter int
+
+	// hiddenUntil[name] = k makes LinkByName report not-found for the
+	// first k calls, then return the seeded link. Models a link that the
+	// pre-loop delete lookup misses but that exists by the time LinkAdd's
+	// EEXIST fallback lookup runs — the only way the tunnel reuse path
+	// (goto anchorReady) is reached.
+	hiddenUntil map[string]int
+
+	// Recorded ops.
+	setUpLinks []netlink.Link
+	addrLinks  []netlink.Link
+}
+
+func newFakeLinkOps() *fakeLinkOps {
+	return &fakeLinkOps{
+		links:       map[string]netlink.Link{},
+		byNameCount: map[string]int{},
+		hiddenUntil: map[string]int{},
+	}
+}
+
+func (f *fakeLinkOps) LinkByName(name string) (netlink.Link, error) {
+	f.byNameCount[name]++
+	if f.byNameErrAfter > 0 && f.byNameCount[name] > f.byNameErrAfter {
+		return nil, errors.New("transient netlink error")
+	}
+	if hide, ok := f.hiddenUntil[name]; ok && f.byNameCount[name] <= hide {
+		return nil, errLinkNotFound{errors.New("link not found")}
+	}
+	if l, ok := f.links[name]; ok {
+		return l, nil
+	}
+	return nil, errLinkNotFound{errors.New("link not found")}
+}
+
+func (f *fakeLinkOps) LinkAdd(l netlink.Link) error {
+	if f.addExisting {
+		return errors.New("file exists")
+	}
+	f.links[l.Attrs().Name] = l
+	return nil
+}
+
+func (f *fakeLinkOps) LinkDel(l netlink.Link) error {
+	delete(f.links, l.Attrs().Name)
+	return nil
+}
+
+func (f *fakeLinkOps) LinkSetUp(l netlink.Link) error {
+	// Mirror the real netlink handle: dereferencing a nil link panics.
+	// A correct caller never passes nil here.
+	_ = l.Attrs()
+	f.setUpLinks = append(f.setUpLinks, l)
+	return nil
+}
+
+func (f *fakeLinkOps) LinkSetDown(l netlink.Link) error      { return nil }
+func (f *fakeLinkOps) LinkSetMaster(l, m netlink.Link) error { return nil }
+func (f *fakeLinkOps) LinkList() ([]netlink.Link, error)     { return nil, nil }
+
+func (f *fakeLinkOps) AddrAdd(l netlink.Link, a *netlink.Addr) error {
+	_ = l.Attrs()
+	f.addrLinks = append(f.addrLinks, l)
+	return nil
+}
+
+func (f *fakeLinkOps) AddrList(l netlink.Link, family int) ([]netlink.Addr, error) {
+	return nil, nil
+}
+
+// noopVRFBinder satisfies vrfBinder without touching netlink.
+type noopVRFBinder struct{}
+
+func (noopVRFBinder) BindInterfaceToVRF(ifaceName, instanceName string) error { return nil }
+
+// TestTunnelAnchorReuseUsesExistingLink covers #1706 defect 1: when an
+// anchor-only TUN already exists, the reuse path (LinkAdd fails, lookup
+// finds an existing *netlink.Tuntap) must run LinkSetUp/AddrAdd against
+// the kernel-fetched link that carries the real ifindex — NOT the
+// freshly-constructed, ifindex-less anchor.
+func TestTunnelAnchorReuseUsesExistingLink(t *testing.T) {
+	ops := newFakeLinkOps()
+	const name = "gr-0/0/0.0"
+	const wantIndex = 42
+	existing := &netlink.Tuntap{
+		LinkAttrs: netlink.LinkAttrs{Name: name, Index: wantIndex},
+		Mode:      netlink.TUNTAP_MODE_TUN,
+	}
+	ops.links[name] = existing
+	ops.addExisting = true // force the LinkAdd-fails reuse branch
+	// The pre-loop delete lookup (call #1) must miss so the link is not
+	// deleted; LinkAdd then fails EEXIST and the fallback lookup (call #2)
+	// finds the existing TUN — the only path that reaches goto anchorReady.
+	ops.hiddenUntil[name] = 1
+
+	tm := &tunnelManager{ops: ops, vrfBinder: noopVRFBinder{}, keepalives: map[string]*keepaliveRunner{}}
+	tunnels := []*config.TunnelConfig{{
+		Name:       name,
+		AnchorOnly: true,
+		Addresses:  []string{"10.1.2.3/32"},
+	}}
+	if err := tm.Apply(tunnels); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if len(ops.setUpLinks) != 1 {
+		t.Fatalf("expected exactly one LinkSetUp, got %d", len(ops.setUpLinks))
+	}
+	if got := ops.setUpLinks[0].Attrs().Index; got != wantIndex {
+		t.Errorf("LinkSetUp ran against a link with index %d, want the existing link's index %d "+
+			"(reuse path used the fresh ifindex-less anchor)", got, wantIndex)
+	}
+	if len(ops.addrLinks) != 1 {
+		t.Fatalf("expected exactly one AddrAdd, got %d", len(ops.addrLinks))
+	}
+	if got := ops.addrLinks[0].Attrs().Index; got != wantIndex {
+		t.Errorf("AddrAdd ran against a link with index %d, want %d", got, wantIndex)
+	}
+}
+
+// TestXfrmAlreadyExistsSingleLookup covers #1706 defect 2: the
+// "already exists" path must look up the link exactly once and bring up
+// the non-nil link from that lookup — never a second lookup whose error
+// is ignored (which risked LinkSetUp(nil) panicking).
+func TestXfrmAlreadyExistsSingleLookup(t *testing.T) {
+	ops := newFakeLinkOps()
+	// config.XFRMIfNameAndID maps "st0.1" -> ("xfrm1", id). Seed that.
+	ifName, _ := config.XFRMIfNameAndID("st0.1")
+	if ifName == "" {
+		t.Fatalf("XFRMIfNameAndID returned empty name for st0.1")
+	}
+	const wantIndex = 7
+	ops.links[ifName] = &netlink.Xfrmi{
+		LinkAttrs: netlink.LinkAttrs{Name: ifName, Index: wantIndex},
+	}
+	// Make any SECOND LinkByName for this name fail — under the old
+	// double-lookup code this would feed nil to LinkSetUp and panic. The
+	// fixed single-lookup code never makes the second call.
+	ops.byNameErrAfter = 1
+
+	xm := &xfrmManager{ops: ops}
+	vpns := map[string]*config.IPsecVPN{
+		"v1": {Name: "v1", BindInterface: "st0.1"},
+	}
+	if err := xm.Apply(vpns); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if got := ops.byNameCount[ifName]; got != 1 {
+		t.Errorf("expected exactly 1 LinkByName for %s on the already-exists path, got %d "+
+			"(a second lookup risks LinkSetUp(nil))", ifName, got)
+	}
+	if len(ops.setUpLinks) != 1 {
+		t.Fatalf("expected exactly one LinkSetUp, got %d", len(ops.setUpLinks))
+	}
+	if ops.setUpLinks[0] == nil {
+		t.Fatal("LinkSetUp received nil link")
+	}
+	if got := ops.setUpLinks[0].Attrs().Index; got != wantIndex {
+		t.Errorf("LinkSetUp ran against index %d, want existing %d", got, wantIndex)
+	}
+}

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -208,6 +208,19 @@ func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instance
 		if leakedTables[sourceTable] {
 			continue
 		}
+
+		// Each leaked table consumes TWO priorities (IPv4 then IPv6).
+		// clear() only scans [ribGroupRulePriority, ribGroupRulePriority+100),
+		// so a pair that would place the IPv6 rule (prio+1) at or beyond the
+		// upper bound must be rejected as a unit — otherwise it leaks
+		// permanently across applies. Stop before marking the table leaked
+		// so a capped table is not recorded as done. ValidateConfig emits a
+		// commit-time warning before this point is ever reached.
+		if prio+1 >= ribGroupRulePriority+100 {
+			slog.Warn("rib-group rule limit reached; ignoring further leaking tables",
+				"limit", 100, "instance", inst.Name, "table", sourceTable)
+			break
+		}
 		leakedTables[sourceTable] = true
 
 		// Add IPv4 rule

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -82,6 +82,19 @@ func (n *nextTableManager) Apply(routes []*config.StaticRoute, instances []*conf
 			family = unix.AF_INET6
 		}
 
+		// Hard-cap the priority inside the window that clear() scans
+		// (nextTableRulePriority .. nextTableRulePriority+100). A rule
+		// programmed at or beyond the upper bound would never be removed
+		// on a later apply and would leak permanently. Stop programming
+		// further next-table routes once the window is exhausted, matching
+		// the pbrManager cap pattern below. ValidateConfig emits a
+		// commit-time warning before this point is ever reached.
+		if prio >= nextTableRulePriority+100 {
+			slog.Warn("next-table rule limit reached; ignoring further next-table routes",
+				"limit", 100, "destination", sr.Destination, "instance", sr.NextTable)
+			break
+		}
+
 		rule := netlink.NewRule()
 		rule.Dst = dst
 		rule.Table = tableID

--- a/pkg/routing/rules_test.go
+++ b/pkg/routing/rules_test.go
@@ -224,6 +224,69 @@ func TestNextTableRulesPriorityCap(t *testing.T) {
 	})
 }
 
+// TestRibGroupRulesPriorityCap exercises the #1706 hard cap for rib-group
+// rules. Each leaking table consumes TWO priorities (v4+v6), so the
+// window of 100 priorities fits 50 tables. The 50th table must program at
+// slots 33098/33099 (the last in-range pair); the 51st must be rejected.
+func TestRibGroupRulesPriorityCap(t *testing.T) {
+	mkConfig := func(n int) (map[string]*config.RibGroup, []*config.RoutingInstanceConfig) {
+		ribGroups := map[string]*config.RibGroup{}
+		instances := make([]*config.RoutingInstanceConfig, n)
+		for i := 0; i < n; i++ {
+			rgName := fmt.Sprintf("leak-%d", i)
+			// Import a different table than the source so needsLeak is true.
+			ribGroups[rgName] = &config.RibGroup{
+				Name:       rgName,
+				ImportRibs: []string{"inet.0"}, // main table 254 != source
+			}
+			instances[i] = &config.RoutingInstanceConfig{
+				Name:                    fmt.Sprintf("vr-%d", i),
+				TableID:                 1000 + i, // distinct source tables
+				InterfaceRoutesRibGroup: rgName,
+			}
+		}
+		return ribGroups, instances
+	}
+
+	t.Run("at-limit", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		rg := &ribGroupManager{ops: ops}
+		ribGroups, instances := mkConfig(50)
+		if err := rg.Apply(ribGroups, instances); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		total := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6)
+		if total != 100 {
+			t.Fatalf("expected 50 tables * 2 = 100 rules at the limit, got %d", total)
+		}
+		assertAllRulesInRange(t, ops, ribGroupRulePriority, ribGroupRulePriority+100)
+	})
+
+	t.Run("over-limit", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		rg := &ribGroupManager{ops: ops}
+		ribGroups, instances := mkConfig(60)
+		if err := rg.Apply(ribGroups, instances); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		total := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6)
+		if total != 100 {
+			t.Fatalf("expected cap to hold at 100 rules (50 tables), got %d", total)
+		}
+		assertAllRulesInRange(t, ops, ribGroupRulePriority, ribGroupRulePriority+100)
+
+		// Re-apply must not leak: all programmed rules are inside the
+		// cleared window.
+		if err := rg.Apply(ribGroups, instances); err != nil {
+			t.Fatalf("Apply (second): %v", err)
+		}
+		total = ops.count(unix.AF_INET) + ops.count(unix.AF_INET6)
+		if total != 100 {
+			t.Fatalf("re-apply leaked rib-group rules: expected 100, got %d", total)
+		}
+	})
+}
+
 // assertAllRulesInRange fails the test if any programmed rule in either
 // family has a priority outside [lo, hi) — i.e. a rule clear() would not
 // remove. This is the invariant the #1706 priority caps guarantee.

--- a/pkg/routing/rules_test.go
+++ b/pkg/routing/rules_test.go
@@ -260,6 +260,14 @@ func TestRibGroupRulesPriorityCap(t *testing.T) {
 			t.Fatalf("expected 50 tables * 2 = 100 rules at the limit, got %d", total)
 		}
 		assertAllRulesInRange(t, ops, ribGroupRulePriority, ribGroupRulePriority+100)
+		// The 50th (last admitted) table must occupy the final in-range
+		// pair: IPv4 at 33098, IPv6 at 33099.
+		if !hasPriority(ops, unix.AF_INET, ribGroupRulePriority+98) {
+			t.Errorf("expected IPv4 rule at the last in-range slot %d", ribGroupRulePriority+98)
+		}
+		if !hasPriority(ops, unix.AF_INET6, ribGroupRulePriority+99) {
+			t.Errorf("expected IPv6 rule at the last in-range slot %d", ribGroupRulePriority+99)
+		}
 	})
 
 	t.Run("over-limit", func(t *testing.T) {
@@ -274,6 +282,12 @@ func TestRibGroupRulesPriorityCap(t *testing.T) {
 			t.Fatalf("expected cap to hold at 100 rules (50 tables), got %d", total)
 		}
 		assertAllRulesInRange(t, ops, ribGroupRulePriority, ribGroupRulePriority+100)
+		// The 51st table (would-be slots 33100/33101) must be absent.
+		if hasPriority(ops, unix.AF_INET, ribGroupRulePriority+100) ||
+			hasPriority(ops, unix.AF_INET6, ribGroupRulePriority+101) {
+			t.Errorf("51st table leaked beyond the cleared window (slot %d/%d present)",
+				ribGroupRulePriority+100, ribGroupRulePriority+101)
+		}
 
 		// Re-apply must not leak: all programmed rules are inside the
 		// cleared window.
@@ -285,6 +299,17 @@ func TestRibGroupRulesPriorityCap(t *testing.T) {
 			t.Fatalf("re-apply leaked rib-group rules: expected 100, got %d", total)
 		}
 	})
+}
+
+// hasPriority reports whether any rule in the family was programmed at
+// the exact priority.
+func hasPriority(ops *fakeRuleOps, family, prio int) bool {
+	for _, r := range ops.rules[family] {
+		if r.Priority == prio {
+			return true
+		}
+	}
+	return false
 }
 
 // assertAllRulesInRange fails the test if any programmed rule in either

--- a/pkg/routing/rules_test.go
+++ b/pkg/routing/rules_test.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -160,6 +161,81 @@ func TestNextTableRulesApply_Fake(t *testing.T) {
 	}
 	if got := ops.count(unix.AF_INET6); got != 1 {
 		t.Errorf("expected 1 IPv6 rule, got %d", got)
+	}
+}
+
+// TestNextTableRulesPriorityCap exercises the #1706 hard cap: programming
+// more next-table routes than the clear() window (100 priorities) must
+// stop at the boundary so every programmed rule stays inside the range
+// clear() scans — otherwise rules at prio >= 200 leak permanently. The
+// boundary case (exactly 100 routes) programs the full set; one over
+// triggers the cap.
+func TestNextTableRulesPriorityCap(t *testing.T) {
+	mkRoutes := func(n int) []*config.StaticRoute {
+		routes := make([]*config.StaticRoute, n)
+		for i := 0; i < n; i++ {
+			// Distinct /24 destinations, all pointing at the same table.
+			routes[i] = &config.StaticRoute{
+				Destination: fmt.Sprintf("10.%d.%d.0/24", i/256, i%256),
+				NextTable:   "dmz-vr",
+			}
+		}
+		return routes
+	}
+	instances := []*config.RoutingInstanceConfig{{Name: "dmz-vr", TableID: 101}}
+
+	// Exactly at the window size: all 100 admitted, none beyond range.
+	t.Run("at-limit", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		nt := &nextTableManager{ops: ops}
+		if err := nt.Apply(mkRoutes(100), instances); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		total := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6)
+		if total != 100 {
+			t.Fatalf("expected all 100 routes programmed at the limit, got %d", total)
+		}
+		assertAllRulesInRange(t, ops, nextTableRulePriority, nextTableRulePriority+100)
+	})
+
+	// One over the window: cap fires, only 100 admitted, none out of range.
+	t.Run("over-limit", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		nt := &nextTableManager{ops: ops}
+		if err := nt.Apply(mkRoutes(150), instances); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		total := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6)
+		if total != 100 {
+			t.Fatalf("expected cap to hold at 100 programmed rules, got %d", total)
+		}
+		assertAllRulesInRange(t, ops, nextTableRulePriority, nextTableRulePriority+100)
+
+		// Re-apply must leave no residue: every programmed rule is inside
+		// clear()'s window, so clear-then-add keeps the count stable. A
+		// leaked rule at prio >= 200 would survive clear() and grow the set.
+		if err := nt.Apply(mkRoutes(150), instances); err != nil {
+			t.Fatalf("Apply (second): %v", err)
+		}
+		total = ops.count(unix.AF_INET) + ops.count(unix.AF_INET6)
+		if total != 100 {
+			t.Fatalf("re-apply leaked rules: expected 100, got %d", total)
+		}
+	})
+}
+
+// assertAllRulesInRange fails the test if any programmed rule in either
+// family has a priority outside [lo, hi) — i.e. a rule clear() would not
+// remove. This is the invariant the #1706 priority caps guarantee.
+func assertAllRulesInRange(t *testing.T, ops *fakeRuleOps, lo, hi int) {
+	t.Helper()
+	for _, family := range []int{unix.AF_INET, unix.AF_INET6} {
+		for _, r := range ops.rules[family] {
+			if r.Priority < lo || r.Priority >= hi {
+				t.Errorf("rule priority %d outside cleared window [%d,%d) — would leak",
+					r.Priority, lo, hi)
+			}
+		}
 	}
 }
 

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -120,9 +120,19 @@ func (t *tunnelManager) Apply(tunnels []*config.TunnelConfig) error {
 				// this name already exists, check if it's already a TUN.
 				// If it's a different type (e.g. dummy), delete and recreate.
 				if existing, lookupErr := t.ops.LinkByName(tc.Name); lookupErr == nil {
-					if _, isTun := existing.(*netlink.Tuntap); isTun {
+					if existingTun, isTun := existing.(*netlink.Tuntap); isTun {
 						slog.Info("tunnel anchor already exists as TUN, reusing",
 							"name", tc.Name)
+						// Operate on the kernel-fetched link (which carries
+						// the real ifindex and attributes) rather than the
+						// freshly-constructed, ifindex-less anchor. The
+						// subsequent LinkSetUp/AddrAdd would otherwise rely
+						// on the netlink library re-resolving the index by
+						// name (ensureIndex) while still reading stale
+						// non-index LinkAttrs off the fresh struct.
+						// existingTun.Fds is nil on a kernel-fetched Tuntap,
+						// so closeTuntapFiles below is a safe no-op.
+						anchor = existingTun
 						goto anchorReady
 					}
 					slog.Info("replacing non-TUN tunnel anchor",

--- a/pkg/routing/xfrm.go
+++ b/pkg/routing/xfrm.go
@@ -40,10 +40,16 @@ func (x *xfrmManager) Apply(vpns map[string]*config.IPsecVPN) error {
 			continue
 		}
 
-		// Check if already exists
-		if _, err := x.ops.LinkByName(ifName); err == nil {
-			link, _ := x.ops.LinkByName(ifName)
-			x.ops.LinkSetUp(link)
+		// Check if already exists. Reuse the link from this single
+		// lookup: calling LinkByName a second time and ignoring its
+		// error risked passing a nil link to LinkSetUp on a transient
+		// second-lookup failure, which panics inside netlink's LinkSetUp
+		// (link.Attrs() on a nil interface).
+		if link, err := x.ops.LinkByName(ifName); err == nil {
+			if upErr := x.ops.LinkSetUp(link); upErr != nil {
+				slog.Warn("failed to bring up existing xfrmi",
+					"name", ifName, "err", upErr)
+			}
 			slog.Debug("xfrmi already exists", "name", ifName, "if_id", ifID)
 			// Track if not already tracked
 			found := false


### PR DESCRIPTION
## Summary

Fixes four latent correctness defects in `pkg/routing` surfaced by the
#1698/#1705 domain-split review. All four were verbatim-identical to the
pre-split `routing.go` on master (behavior-preserving motion left them
unchanged); #1706 is the focused follow-up. Cohesive (one package,
surfaced together) → one PR, logical-increment commits.

1. **TUN anchor reuse** (`tunnel.go`): on the `goto anchorReady` reuse
   arm, `LinkSetUp`/`AddrAdd` ran against the freshly-constructed,
   ifindex-less `anchor` instead of the kernel-fetched link. Benign in
   production (netlink `ensureIndex` re-resolves the index by name) but
   relied on an undocumented library fallback and left other LinkAttrs
   stale. Fixed by reusing the existing `*netlink.Tuntap`.
2. **xfrm double `LinkByName` + `LinkSetUp(nil)`** (`xfrm.go`): the
   already-exists path looked the link up twice and ignored the second
   error, so a transient second-lookup failure passed `nil` to
   `LinkSetUp`, panicking the daemon. Fixed by reusing the first lookup
   and handling its error. (This double-call was preserved byte-identical
   in #1705 pure-motion.)
3. **next-table priority escape** (`rules.go`): priorities 100-199, but
   >100 next-table routes pushed `prio` past 199 — outside the window
   `clear()` scans — leaking rules permanently. Fixed with a hard cap at
   the window boundary, mirroring the existing `pbrManager` cap.
4. **rib-group priority escape** (`rules.go`): priorities 33000-33099,
   two per leaked table; >50 leaking tables overflowed and leaked. Fixed
   with a cap before programming each v4+v6 pair.

Plus a commit-time warning in `config.ValidateConfig` (conservative
upper bounds) so an over-limit next-table/rib-group config is surfaced
to the operator at commit, not silently truncated at apply — the
apply-time cap stays as defense-in-depth.

Closes #1706

## Plan + adversarial review

Plan doc: `docs/pr/1706-routing-latent-defects/plan.md`

- Codex (plan): Defect 2 PLAN-READY; Defect 1 benign-in-prod →
  reframed as robustness cleanup; Defects 3/4 math/placement correct,
  PLAN-NEEDS-MAJOR on silent truncation → addressed by the commit-time
  warning.
- AGY (plan): all four PLAN-READY; confirmed defect-2 panic real,
  defect-4 boundary math exact (50th table 33098/33099; 51st rejected),
  defect-1 Fds-nil safe no-op.

## HA assessment

These reconcilers program kernel ip-rule state only — no session-sync,
VRRP, or fabric-redirect state — so `make test-failover` is not
required. A light route-correctness smoke is the appropriate gate.

## Test plan

- [x] `go build ./pkg/routing/` clean at every commit
- [x] `go vet ./pkg/routing/ ./pkg/config/` clean
- [x] New unit tests: next-table + rib-group priority-cap boundary
      (at-limit silent, over-limit caps, re-apply no leak); commit-time
      warning thresholds; tunnel anchor reuse uses indexed link; xfrm
      single-lookup (no `LinkSetUp(nil)`). Reuse/cap tests verified to
      fail/panic against behavioral reverts of each fix.
- [x] `go test ./pkg/routing/ ./pkg/config/` pass
- [x] Full `go test ./...` — only `pkg/dataplane/userspace`
      `bind: invalid argument` unix-socket failures, reproduced on clean
      master (pre-existing sandbox artifact, unrelated)
- [x] `make audit-check` green (compiler.go regen)
- [x] allowlist-drift canary + legacy-dataplane canary pass (no new drift)
- [ ] Light route-correctness smoke on loss:xpf-userspace-fw0

🤖 Generated with [Claude Code](https://claude.com/claude-code)