### PR TITLE
#1725: filter/engine evaluation test coverage

### DIFF
--- a/docs/pr/1725-filter-engine-tests/plan.md
+++ b/docs/pr/1725-filter-engine-tests/plan.md
@@ -1,6 +1,23 @@
 # #1725 — Test coverage for filter/engine evaluation path
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** PLAN-READY v2 — Codex PLAN-NEEDS-MINOR (corrections folded),
+AGY PLAN-READY (0 false positives, all 9 gaps genuinely uncovered),
+Claude-SMR PLAN-NEEDS-MINOR (same two corrections + fold accessors into
+one test). Consensus: proceed.
+
+## v2 corrections from review
+
+- **`FilterAction::Reject` is NOT untested repo-wide** — it is asserted
+  in `afxdp/tx/cos_classify_tests.rs` and `afxdp/event_emit.rs`. The
+  genuine gap is narrower: no test drives a `reject` term through the
+  **plain `evaluate_filter` engine path** to assert the returned
+  `FilterResult.action == Reject`. Gap #1 reworded to that.
+- **IPv6 input-interface eval was overclaimed** — `interface_filter_assignment`
+  defines `filter_input_v6` (tests.rs:1290) but the input eval call uses
+  `is_v6=false` (tests.rs:1346). So the v6 `evaluate_interface_filter`
+  input path is also uncovered; folded into gap #4.
+- **Gap #8 (thin accessors)** — grouped into ONE compact table-driven
+  test (`thin_accessor_predicates`), not four boilerplate tests.
 
 ## Issue framing
 
@@ -53,10 +70,11 @@ full read of tests.rs + all three engine files.
 
 ### Genuine gaps (this PR fills these)
 
-1. **`FilterAction::Reject` verdict** — never tested anywhere. The reject
-   action (`compiler.rs:373`) is a distinct verdict with documented
-   fail-closed semantics; no test proves a `reject` term yields
-   `FilterAction::Reject`.
+1. **`FilterAction::Reject` via the plain `evaluate_filter` path** — the
+   reject action (`compiler.rs:373`) is asserted elsewhere
+   (`cos_classify_tests.rs`, `event_emit.rs`) but no test drives a
+   `reject` term through `evaluate_filter` and asserts the returned
+   `FilterResult.action == FilterAction::Reject`.
 2. **Missing-filter-key / empty-filter → default Accept** —
    `evaluate_filter` against an absent `filter_key`, and against a filter
    with zero terms, both must return `FilterResult::default()`
@@ -65,10 +83,12 @@ full read of tests.rs + all three engine files.
    `evaluate_filter_ref_tx_selection_*` / `evaluate_filter_ref_tx_selection_cached`
    with a V4 src + V6 dst (the `_ => default` arm) returns default.
    Never tested.
-4. **IPv6 baseline `evaluate_filter` + `evaluate_lo0_filter`** — the v6
-   `evaluate_filter` and v6 lo0 evaluation paths
-   (`evaluate_filter_ref_counted_v6`, `evaluate_lo0_filter` is_v6=true)
-   are not exercised by a plain (non-tx-selection) evaluate test.
+4. **IPv6 baseline evaluate paths** — the v6 `evaluate_filter`
+   (`evaluate_filter_ref_counted_v6`), v6 `evaluate_lo0_filter`
+   (is_v6=true), and the v6 `evaluate_interface_filter` input path are
+   not exercised by a plain (non-tx-selection) evaluate test.
+   `interface_filter_assignment` defines `filter_input_v6` but only calls
+   the input evaluator with `is_v6=false` (tests.rs:1346).
 5. **`evaluate_filter_counted` hit-counter increment (baseline path)** —
    counter increment is tested for the tx-selection/output paths, but the
    plain `evaluate_filter_counted` → `evaluate_filter_ref_counted` counter

--- a/docs/pr/1725-filter-engine-tests/plan.md
+++ b/docs/pr/1725-filter-engine-tests/plan.md
@@ -1,0 +1,181 @@
+# #1725 — Test coverage for filter/engine evaluation path
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+#1725 (promoted from #1663 §3 test-gap rank 1-3) asks for cargo unit
+tests covering the firewall filter-engine evaluation path:
+`userspace-dp/src/filter/engine/{eval.rs (681), tx_selection.rs (286),
+cache_sensitive.rs (200)}`, which carry **0 `cfg(test)` blocks** of
+their own. The functions are pure/injectable: build a
+`Filter`/`FilterState`, call with a 5-tuple + dscp, assert the
+verdict / counter / log-match. No socket/UMEM/thread needed.
+
+This is a **TEST-ONLY** addition. No production code changes.
+
+## Critical first finding — existing coverage is substantial
+
+`userspace-dp/src/filter/tests.rs` (1998 LOC, loaded via
+`#[path="tests.rs"]` from `filter/mod.rs`) **already exercises most of
+the engine evaluation surface**. Tests live in the parent `filter`
+module's `cfg(test)` submodule, so the engine files show 0 local
+`cfg(test)` blocks but are NOT uncovered. A blanket "add tests for the
+engine" would largely duplicate existing assertions. The scope below is
+**narrowed to the genuinely-uncovered functions and behaviors** after a
+full read of tests.rs + all three engine files.
+
+### Already covered (do NOT duplicate)
+
+- `evaluate_filter`: accept/discard (`basic_accept_discard`), port-range
+  (`port_range_matching`), protocol (`protocol_matching`), src/dst CIDR
+  (`source_dest_address_matching`), multi-term first-match
+  (`multiple_terms_first_match_wins`), DSCP match (`dscp_match_in_term`),
+  DSCP rewrite (`dscp_rewrite_action`, `dscp_rewrite_action_allows_default_zero`).
+- `evaluate_lo0_filter`: v4 accept/discard (`lo0_filter_evaluation`).
+- `evaluate_interface_filter` / `evaluate_interface_output_filter` /
+  `evaluate_interface_output_filter_counted`: v4 + v6
+  (`interface_filter_assignment`, `interface_output_filter_counted_records_term_hits`,
+  `interface_output_filter_without_count_does_not_record_term_hits`).
+- `evaluate_interface_filter_log_match`: filter/term identity + PBR skip
+  (`interface_filter_log_match_returns_filter_and_term_identity`,
+  `..._skips_pbr_terms_without_double_emit`).
+- `evaluate_interface_filter_routing_instance_counted`: override + counter
+  (`interface_filter_routing_instance_counted_returns_matching_override`).
+- `evaluate_filter_ref_tx_selection_runtime_counted` /
+  `evaluate_filter_ref_tx_selection_cached`: extensive three-color policer
+  coverage (`three_color_*`, `flow_cache_hits_run_three_color_policer`,
+  `cached_three_color_descriptor_dedupes_without_vec_allocation`, etc.).
+- `input_dscp_filter_families_changed` (cache_sensitive): 6 tests.
+- `interface_filter_affects_route_lookup`,
+  `interface_output_filter_needs_tx_eval`,
+  `filter_state_has_output_tx_selection`: asserted in passing.
+
+### Genuine gaps (this PR fills these)
+
+1. **`FilterAction::Reject` verdict** — never tested anywhere. The reject
+   action (`compiler.rs:373`) is a distinct verdict with documented
+   fail-closed semantics; no test proves a `reject` term yields
+   `FilterAction::Reject`.
+2. **Missing-filter-key / empty-filter → default Accept** —
+   `evaluate_filter` against an absent `filter_key`, and against a filter
+   with zero terms, both must return `FilterResult::default()`
+   (Accept). Not directly asserted.
+3. **Address-family mismatch → default** — `evaluate_filter` /
+   `evaluate_filter_ref_tx_selection_*` / `evaluate_filter_ref_tx_selection_cached`
+   with a V4 src + V6 dst (the `_ => default` arm) returns default.
+   Never tested.
+4. **IPv6 baseline `evaluate_filter` + `evaluate_lo0_filter`** — the v6
+   `evaluate_filter` and v6 lo0 evaluation paths
+   (`evaluate_filter_ref_counted_v6`, `evaluate_lo0_filter` is_v6=true)
+   are not exercised by a plain (non-tx-selection) evaluate test.
+5. **`evaluate_filter_counted` hit-counter increment (baseline path)** —
+   counter increment is tested for the tx-selection/output paths, but the
+   plain `evaluate_filter_counted` → `evaluate_filter_ref_counted` counter
+   bump (v4 and v6) is not asserted.
+6. **`evaluate_interface_filter_non_routing_counted`** — the PBR-reject
+   variant: a matching term carrying a non-empty `routing_instance` must
+   return `FilterResult::default()` (route-lookup deferred), while a
+   non-routing matching term returns its action. Never tested.
+7. **tx_selection state-level dispatch wrappers** —
+   `evaluate_interface_filter_tx_selection_counted` and
+   `evaluate_interface_output_filter_tx_selection_counted` (the
+   `FilterState`-keyed wrappers, vs. the already-tested `_ref_` forms),
+   including the no-filter → default arm.
+8. **tx_selection / cache_sensitive accessor predicates** —
+   `interface_filter_affects_tx_selection`,
+   `filter_state_has_input_tx_selection`,
+   `interface_input_filter_has_dscp_match`,
+   `interface_output_filter_has_dscp_match`. Not asserted via these
+   accessors.
+9. **cached-vs-runtime baseline parity** — for a plain (no-policer) term,
+   `evaluate_filter_ref_tx_selection_cached` and
+   `evaluate_filter_ref_tx_selection_runtime_counted` must agree on
+   action / forwarding_class / dscp_rewrite / log_match. Existing
+   three-color tests assert policer runtime behavior but not a clean
+   baseline-equivalence assertion against the plain `evaluate_filter`
+   verdict.
+
+## Test seam (verified real + non-duplicative)
+
+- Tests are added to `userspace-dp/src/filter/tests.rs` as new `#[test]`
+  fns in the existing `cfg(test)` submodule. The three helper builders
+  (`make_filter_state`, `make_filter_state_with_three_color`,
+  `make_filter_state_with_interfaces`) plus `parse_filter_state`
+  directly are reused. All engine entry points are `pub(crate)` and
+  reachable via `use super::*` (already in place at tests.rs:6).
+- Each new test asserts **observable production behavior** (verdict
+  enum value, counter atomic load, log-match identity, default fall-
+  through), not internal structure — so a regression in the production
+  function fails the test. No test passes against a stubbed/buggy body.
+- Builders construct `FirewallFilterSnapshot` / `FirewallTermSnapshot`
+  and run them through the real `parse_filter_state*` compiler, so the
+  tests exercise the compile→evaluate pipeline end-to-end (same path the
+  dataplane uses), not a hand-built `Filter`.
+
+## Public API preservation
+
+No production signatures change. Test-only file edits to tests.rs.
+
+## Hidden invariants the tests must respect
+
+- **First-match-wins**: terms evaluated in order; first matching term's
+  action returned. New multi-term tests must order terms to prove this.
+- **Implicit default Accept**: no match (or missing filter) →
+  `FilterResult::default()` whose `action` is `Accept`. Verify the
+  default really is Accept (read `FilterResult::default`).
+- **Counter increment is conditional on `has_count`**: only terms with a
+  non-empty `count` bump the atomic. The `packet_bytes` argument is the
+  byte delta. Tests must set `count` to observe the bump and pass an
+  explicit byte count.
+- **PBR non-routing variant**: a matching term with non-empty
+  `routing_instance` short-circuits to default in
+  `evaluate_filter_ref_non_routing_counted` (route lookup wins).
+- **AF mismatch is a silent default**, not a panic.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | NONE | test-only, no production edit |
+| Lifetime / borrow-checker | LOW | tests build owned state, call by ref; same shape as existing tests |
+| Performance regression | NONE | tests not on any hot path |
+| Architectural mismatch | NONE | filling a real, verified gap; no rearchitecture |
+
+The only real failure mode is a **vacuous test** (asserts something
+trivially true regardless of production correctness). Mitigation:
+every test asserts a discriminating value (e.g. Reject vs Accept,
+counter == exact byte count, default vs matched action) and the gate
+requires the full suite green at HEAD (canary #1723 baseline).
+
+## Test plan / gate
+
+- `cargo build` clean.
+- New filter tests pass; full `cargo test --release` suite green.
+- 5x flake loop on the new tests (`filter::tests::`).
+- Go suite unaffected (no Go change) — spot-run optional.
+- **No cluster smoke** — test-only, no datapath change (per issue).
+
+## Out of scope (explicitly)
+
+- `engine/matching.rs` term-match primitives (separate file, has its own
+  coverage via the evaluate tests; not in #1725 scope).
+- `engine/policer.rs` three-color internals (already covered).
+- Any production refactor of the engine modules.
+
+## Open questions for adversarial review (each invitable to PLAN-KILL)
+
+1. Is the gap analysis correct, or does tests.rs already cover one of the
+   9 claimed gaps (e.g. is `Reject` asserted somewhere I missed)? If
+   ≥7 of 9 are already covered, PLAN-KILL as "already covered".
+2. Is gap #9 (cached-vs-runtime baseline parity) meaningfully distinct
+   from the existing three-color tests, or is it redundant churn?
+3. Is testing the thin accessor predicates (gap #8) worth it, or are they
+   so trivial (`set.contains`) that a test is vacuous?
+4. Does building state via `parse_filter_state` (vs. hand-built `Filter`)
+   risk testing the compiler instead of the evaluator — and is that
+   acceptable given the dataplane uses the same path?
+5. Is the AF-mismatch case (gap #3) a real reachable production state, or
+   dead defensive code not worth a test?
+6. Any borrow/lifetime hazard in asserting on `TxSelectionFilterResult`'s
+   borrowed `forwarding_class: Option<&str>` across the state's lifetime?

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2426,3 +2426,209 @@ fn interface_filter_non_routing_counted_defers_pbr_term() {
     assert_eq!(filter.terms[1].counter.packets.load(Ordering::Relaxed), 1);
     assert_eq!(filter.terms[1].counter.bytes.load(Ordering::Relaxed), 500);
 }
+
+// --- Gap 7: FilterState-keyed tx_selection dispatch wrappers ---
+#[test]
+fn interface_filter_tx_selection_wrappers_dispatch_and_default() {
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "reth0.80".into(),
+        ifindex: 7,
+        filter_input_v4: "tx-in".into(),
+        filter_output_v4: "tx-out".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(
+        &[
+            FirewallFilterSnapshot {
+                name: "tx-in".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "classify-in".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: "accept".into(),
+                    forwarding_class: "iperf-a".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "tx-out".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "classify-out".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5202".into()],
+                    action: "accept".into(),
+                    forwarding_class: "iperf-b".into(),
+                    ..Default::default()
+                }],
+            },
+        ],
+        &[],
+        &ifaces,
+        "",
+        "",
+    );
+
+    let input = evaluate_interface_filter_tx_selection_counted(
+        &state,
+        7,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        1400,
+    );
+    assert_eq!(input.action, FilterAction::Accept);
+    assert_eq!(input.forwarding_class, Some("iperf-a"));
+
+    let output = evaluate_interface_output_filter_tx_selection_counted(
+        &state,
+        7,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        5202,
+        0,
+        1400,
+    );
+    assert_eq!(output.action, FilterAction::Accept);
+    assert_eq!(output.forwarding_class, Some("iperf-b"));
+
+    // No filter bound to an unrelated ifindex returns the default.
+    let none_in = evaluate_interface_filter_tx_selection_counted(
+        &state,
+        99,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        1400,
+    );
+    assert_eq!(none_in.action, FilterAction::Accept);
+    assert_eq!(none_in.forwarding_class, None);
+}
+
+// --- Gap 8: thin accessor predicates (grouped, table-driven) ---
+#[test]
+fn thin_accessor_predicates() {
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "reth1.0".into(),
+        ifindex: 21,
+        // Input filter with both a forwarding-class (tx-selection) term and a
+        // DSCP-match term.
+        filter_input_v4: "accessor-in".into(),
+        // Output filter with a DSCP-match term.
+        filter_output_v4: "accessor-out".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(
+        &[
+            FirewallFilterSnapshot {
+                name: "accessor-in".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "classify".into(),
+                    protocols: vec!["tcp".into()],
+                    dscp_values: vec![46],
+                    action: "accept".into(),
+                    forwarding_class: "iperf-a".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "accessor-out".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "match-ef".into(),
+                    dscp_values: vec![46],
+                    action: "accept".into(),
+                    ..Default::default()
+                }],
+            },
+        ],
+        &[],
+        &ifaces,
+        "",
+        "",
+    );
+
+    // tx_selection accessors: input v4 has a forwarding-class term, so it
+    // affects TX-selection; v6 has no filter at all.
+    assert!(interface_filter_affects_tx_selection(&state, 21, false));
+    assert!(!interface_filter_affects_tx_selection(&state, 21, true));
+    assert!(filter_state_has_input_tx_selection(&state, false));
+    assert!(!filter_state_has_input_tx_selection(&state, true));
+
+    // cache_sensitive DSCP-match accessors: input and output v4 both carry a
+    // DSCP-match term; v6 carries none.
+    assert!(interface_input_filter_has_dscp_match(&state, 21, false));
+    assert!(!interface_input_filter_has_dscp_match(&state, 21, true));
+    assert!(interface_output_filter_has_dscp_match(&state, 21, false));
+    assert!(!interface_output_filter_has_dscp_match(&state, 21, true));
+    // No filter bound to an unrelated ifindex.
+    assert!(!interface_input_filter_has_dscp_match(&state, 99, false));
+    assert!(!interface_filter_affects_tx_selection(&state, 99, false));
+}
+
+// --- Gap 9: cached-vs-runtime baseline parity for a plain (no-policer) term ---
+#[test]
+fn cached_and_runtime_tx_selection_agree_on_plain_term() {
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "reth0.80".into(),
+        ifindex: 30,
+        filter_input_v4: "parity".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "parity".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "classify".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["5201".into()],
+                action: "accept".into(),
+                forwarding_class: "iperf-a".into(),
+                dscp_rewrite: Some(46),
+                log: true,
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &ifaces,
+        "",
+        "",
+    );
+    let filter = state.iface_filter_v4_fast.get(&30).expect("input filter");
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+    let runtime = evaluate_filter_ref_tx_selection_runtime_counted(
+        filter, src, dst, PROTO_TCP, 40000, 5201, 0, 0, 1,
+    );
+    let cached = evaluate_filter_ref_tx_selection_cached(filter, src, dst, PROTO_TCP, 40000, 5201, 0);
+
+    // A term with no three-color policer must yield identical action,
+    // forwarding-class, DSCP rewrite, and log-match identity on both paths.
+    assert_eq!(runtime.action, cached.action);
+    assert_eq!(runtime.action, FilterAction::Accept);
+    assert_eq!(
+        runtime.forwarding_class,
+        cached.forwarding_class.as_deref()
+    );
+    assert_eq!(runtime.forwarding_class, Some("iperf-a"));
+    assert_eq!(runtime.dscp_rewrite, cached.dscp_rewrite);
+    assert_eq!(runtime.dscp_rewrite, Some(46));
+    assert_eq!(runtime.log_match, cached.log_match);
+    assert!(runtime.log_match.is_some());
+    assert!(!runtime.policer_drop);
+}

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -1996,3 +1996,433 @@ fn input_dscp_filter_families_changed_detects_filter_removed_from_interface() {
         (true, false)
     );
 }
+
+// ============================================================
+// #1725 — engine evaluation coverage gaps
+//
+// filter/tests.rs already covers most of eval.rs / tx_selection.rs /
+// cache_sensitive.rs. The tests below fill the nine genuinely-uncovered
+// behaviors identified in docs/pr/1725-filter-engine-tests/plan.md:
+// Reject via the plain evaluate_filter path; missing-filter / empty-filter
+// default; address-family mismatch default; IPv6 baseline evaluate / lo0 /
+// interface-input paths; baseline counter increment; the non-routing
+// (PBR-reject) variant; the FilterState-keyed tx_selection wrappers; the
+// thin accessor predicates; and cached-vs-runtime baseline parity.
+// ============================================================
+
+// --- Gap 1: FilterAction::Reject through the plain evaluate_filter path ---
+#[test]
+fn evaluate_filter_returns_reject_action() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "reject-filter".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "reject-telnet".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["23".into()],
+                action: "reject".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter(
+        &state,
+        "inet:reject-filter",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        23,
+        0,
+    );
+    assert_eq!(result.action, FilterAction::Reject);
+}
+
+// --- Gap 2: missing filter key + empty filter both fall through to Accept ---
+#[test]
+fn evaluate_filter_missing_key_returns_default_accept() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "present".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "deny-all".into(),
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    // A key that was never compiled must return the implicit Accept default,
+    // never panic and never reach into an unrelated filter.
+    let result = evaluate_filter(
+        &state,
+        "inet:does-not-exist",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        1234,
+        80,
+        0,
+    );
+    assert_eq!(result.action, FilterAction::Accept);
+    assert_eq!(result, FilterResult::default());
+}
+
+#[test]
+fn evaluate_filter_empty_filter_returns_default_accept() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "empty".into(),
+            family: "inet".into(),
+            terms: vec![],
+        }],
+        &[],
+    );
+    let result = evaluate_filter(
+        &state,
+        "inet:empty",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        1234,
+        80,
+        0,
+    );
+    assert_eq!(result.action, FilterAction::Accept);
+}
+
+// --- Gap 3: address-family mismatch (V4 src + V6 dst) takes the default arm ---
+#[test]
+fn evaluate_filter_mixed_address_family_returns_default_accept() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "deny-all".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "deny".into(),
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    // A V4 source with a V6 destination hits the `_ => default` arm in
+    // evaluate_filter_ref_counted rather than matching the discard term.
+    let result = evaluate_filter(
+        &state,
+        "inet:deny-all",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V6("2001:db8::2".parse().unwrap()),
+        PROTO_TCP,
+        1234,
+        80,
+        0,
+    );
+    assert_eq!(result.action, FilterAction::Accept);
+}
+
+// --- Gap 4: IPv6 baseline evaluate_filter / lo0 / interface-input paths ---
+#[test]
+fn evaluate_filter_ipv6_matches_term() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "v6-filter".into(),
+            family: "inet6".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "deny-from-doc".into(),
+                    source_addresses: vec!["2001:db8::/32".into()],
+                    action: "discard".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "allow-rest".into(),
+                    action: "accept".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[],
+    );
+    // In-prefix source matches the discard term.
+    let denied = evaluate_filter(
+        &state,
+        "inet6:v6-filter",
+        IpAddr::V6("2001:db8::100".parse().unwrap()),
+        IpAddr::V6("2001:db8::200".parse().unwrap()),
+        PROTO_TCP,
+        40000,
+        443,
+        0,
+    );
+    assert_eq!(denied.action, FilterAction::Discard);
+    // Out-of-prefix source falls through to the accept term.
+    let allowed = evaluate_filter(
+        &state,
+        "inet6:v6-filter",
+        IpAddr::V6("2001:db9::1".parse().unwrap()),
+        IpAddr::V6("2001:db8::200".parse().unwrap()),
+        PROTO_TCP,
+        40000,
+        443,
+        0,
+    );
+    assert_eq!(allowed.action, FilterAction::Accept);
+}
+
+#[test]
+fn evaluate_lo0_filter_ipv6_path() {
+    let state = parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "protect-RE-v6".into(),
+            family: "inet6".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "allow-ssh".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["22".into()],
+                    action: "accept".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "deny-rest".into(),
+                    action: "discard".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[],
+        &[],
+        "",
+        "protect-RE-v6",
+    );
+    let accepted = evaluate_lo0_filter(
+        &state,
+        true,
+        IpAddr::V6("2001:db8::1".parse().unwrap()),
+        IpAddr::V6("2001:db8::2".parse().unwrap()),
+        PROTO_TCP,
+        40000,
+        22,
+        0,
+    );
+    assert_eq!(accepted.action, FilterAction::Accept);
+    let discarded = evaluate_lo0_filter(
+        &state,
+        true,
+        IpAddr::V6("2001:db8::1".parse().unwrap()),
+        IpAddr::V6("2001:db8::2".parse().unwrap()),
+        PROTO_TCP,
+        40000,
+        80,
+        0,
+    );
+    assert_eq!(discarded.action, FilterAction::Discard);
+}
+
+#[test]
+fn evaluate_interface_filter_ipv6_input_path() {
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "reth0.80".into(),
+        ifindex: 9,
+        filter_input_v6: "edge-in-v6".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "edge-in-v6".into(),
+            family: "inet6".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "deny-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &ifaces,
+        "",
+        "",
+    );
+    let result = evaluate_interface_filter(
+        &state,
+        9,
+        true,
+        IpAddr::V6("2001:db8::10".parse().unwrap()),
+        IpAddr::V6("2001:db8::200".parse().unwrap()),
+        PROTO_TCP,
+        49152,
+        443,
+        0,
+    );
+    assert_eq!(result.action, FilterAction::Discard);
+}
+
+// --- Gap 5: baseline evaluate_filter_counted hit-counter increment (v4 + v6) ---
+#[test]
+fn evaluate_filter_counted_increments_term_counter() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "counted".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "count-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["80".into()],
+                action: "accept".into(),
+                count: "web-hits".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter_counted(
+        &state,
+        "inet:counted",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        80,
+        0,
+        1400,
+    );
+    assert_eq!(result.action, FilterAction::Accept);
+    let filter = state.filters.get("inet:counted").expect("counted filter");
+    let term = filter.terms.first().expect("first term");
+    assert_eq!(term.counter.packets.load(Ordering::Relaxed), 1);
+    assert_eq!(term.counter.bytes.load(Ordering::Relaxed), 1400);
+
+    // A non-matching packet (wrong port) must not bump the counter.
+    let miss = evaluate_filter_counted(
+        &state,
+        "inet:counted",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        443,
+        0,
+        1400,
+    );
+    assert_eq!(miss.action, FilterAction::Accept);
+    assert_eq!(term.counter.packets.load(Ordering::Relaxed), 1);
+    assert_eq!(term.counter.bytes.load(Ordering::Relaxed), 1400);
+}
+
+#[test]
+fn evaluate_filter_counted_increments_term_counter_ipv6() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "counted6".into(),
+            family: "inet6".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "count-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["80".into()],
+                action: "accept".into(),
+                count: "web-hits-v6".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter_counted(
+        &state,
+        "inet6:counted6",
+        IpAddr::V6("2001:db8::1".parse().unwrap()),
+        IpAddr::V6("2001:db8::2".parse().unwrap()),
+        PROTO_TCP,
+        40000,
+        80,
+        0,
+        1500,
+    );
+    assert_eq!(result.action, FilterAction::Accept);
+    let filter = state.filters.get("inet6:counted6").expect("counted filter");
+    let term = filter.terms.first().expect("first term");
+    assert_eq!(term.counter.packets.load(Ordering::Relaxed), 1);
+    assert_eq!(term.counter.bytes.load(Ordering::Relaxed), 1500);
+}
+
+// --- Gap 6: evaluate_interface_filter_non_routing_counted PBR-reject behavior ---
+#[test]
+fn interface_filter_non_routing_counted_defers_pbr_term() {
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "reth1.0".into(),
+        ifindex: 12,
+        filter_input_v4: "mixed-pbr".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "mixed-pbr".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "route-to-blue".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: "accept".into(),
+                    count: "pbr-hits".into(),
+                    routing_instance: "blue".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "plain-deny".into(),
+                    protocols: vec!["udp".into()],
+                    destination_ports: vec!["53".into()],
+                    action: "discard".into(),
+                    count: "dns-hits".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[],
+        &ifaces,
+        "",
+        "",
+    );
+
+    // A packet that matches the routing-instance term must short-circuit to
+    // the default (route-lookup wins) and must NOT increment that term's
+    // counter — the non-routing evaluator returns before recording.
+    let pbr = evaluate_interface_filter_non_routing_counted(
+        &state,
+        12,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        1400,
+    );
+    assert_eq!(pbr.action, FilterAction::Accept);
+    assert!(pbr.routing_instance.is_empty());
+    let filter = state.iface_filter_v4_fast.get(&12).expect("input filter");
+    assert_eq!(filter.terms[0].counter.packets.load(Ordering::Relaxed), 0);
+
+    // A packet matching the plain (non-routing) term gets its action and a
+    // counter bump as normal.
+    let plain = evaluate_interface_filter_non_routing_counted(
+        &state,
+        12,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_UDP,
+        40000,
+        53,
+        0,
+        500,
+    );
+    assert_eq!(plain.action, FilterAction::Discard);
+    assert_eq!(filter.terms[1].counter.packets.load(Ordering::Relaxed), 1);
+    assert_eq!(filter.terms[1].counter.bytes.load(Ordering::Relaxed), 500);
+}

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2091,7 +2091,13 @@ fn evaluate_filter_empty_filter_returns_default_accept() {
         80,
         0,
     );
-    assert_eq!(result.action, FilterAction::Accept);
+    // A compiled-but-empty filter must fall through to the full default,
+    // distinguishable from the missing-key path: the filter exists with zero
+    // terms, so a compiler bug that dropped empty filters would also surface
+    // here.
+    assert_eq!(result, FilterResult::default());
+    let filter = state.filters.get("inet:empty").expect("empty filter compiled");
+    assert!(filter.terms.is_empty());
 }
 
 // --- Gap 3: address-family mismatch (V4 src + V6 dst) takes the default arm ---
@@ -2121,7 +2127,9 @@ fn evaluate_filter_mixed_address_family_returns_default_accept() {
         80,
         0,
     );
-    assert_eq!(result.action, FilterAction::Accept);
+    // The default arm must produce the full default result, not just an Accept
+    // action with leftover rewrite/routing/forwarding-class fields.
+    assert_eq!(result, FilterResult::default());
 }
 
 // --- Gap 4: IPv6 baseline evaluate_filter / lo0 / interface-input paths ---
@@ -2520,32 +2528,57 @@ fn interface_filter_tx_selection_wrappers_dispatch_and_default() {
 // --- Gap 8: thin accessor predicates (grouped, table-driven) ---
 #[test]
 fn thin_accessor_predicates() {
-    let ifaces = vec![crate::InterfaceSnapshot {
-        name: "reth1.0".into(),
-        ifindex: 21,
-        // Input filter with both a forwarding-class (tx-selection) term and a
-        // DSCP-match term.
-        filter_input_v4: "accessor-in".into(),
-        // Output filter with a DSCP-match term.
-        filter_output_v4: "accessor-out".into(),
-        ..Default::default()
-    }];
+    // Two separate input ifindices so the TX-selection and DSCP-match
+    // accessors are cross-checked: ifindex 21 is TX-selection-only (a
+    // forwarding-class term, no DSCP match), ifindex 22 is DSCP-only (a DSCP
+    // match, no forwarding class). An accessor that consulted the wrong set
+    // (aliasing bug) would flip on one of the cross-negative assertions
+    // below. ifindex 23 carries a DSCP-match output filter.
+    let ifaces = vec![
+        crate::InterfaceSnapshot {
+            name: "reth1.0".into(),
+            ifindex: 21,
+            filter_input_v4: "tx-only-in".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "reth1.1".into(),
+            ifindex: 22,
+            filter_input_v4: "dscp-only-in".into(),
+            ..Default::default()
+        },
+        crate::InterfaceSnapshot {
+            name: "reth1.2".into(),
+            ifindex: 23,
+            filter_output_v4: "dscp-out".into(),
+            ..Default::default()
+        },
+    ];
     let state = parse_filter_state(
         &[
             FirewallFilterSnapshot {
-                name: "accessor-in".into(),
+                name: "tx-only-in".into(),
                 family: "inet".into(),
                 terms: vec![FirewallTermSnapshot {
                     name: "classify".into(),
                     protocols: vec!["tcp".into()],
-                    dscp_values: vec![46],
                     action: "accept".into(),
                     forwarding_class: "iperf-a".into(),
                     ..Default::default()
                 }],
             },
             FirewallFilterSnapshot {
-                name: "accessor-out".into(),
+                name: "dscp-only-in".into(),
+                family: "inet".into(),
+                terms: vec![FirewallTermSnapshot {
+                    name: "match-ef".into(),
+                    dscp_values: vec![46],
+                    action: "accept".into(),
+                    ..Default::default()
+                }],
+            },
+            FirewallFilterSnapshot {
+                name: "dscp-out".into(),
                 family: "inet".into(),
                 terms: vec![FirewallTermSnapshot {
                     name: "match-ef".into(),
@@ -2561,19 +2594,21 @@ fn thin_accessor_predicates() {
         "",
     );
 
-    // tx_selection accessors: input v4 has a forwarding-class term, so it
-    // affects TX-selection; v6 has no filter at all.
+    // TX-selection accessor reads the TX-selection set, NOT the DSCP set:
+    // true on the TX-only ifindex, false on the DSCP-only ifindex.
     assert!(interface_filter_affects_tx_selection(&state, 21, false));
+    assert!(!interface_filter_affects_tx_selection(&state, 22, false));
     assert!(!interface_filter_affects_tx_selection(&state, 21, true));
     assert!(filter_state_has_input_tx_selection(&state, false));
     assert!(!filter_state_has_input_tx_selection(&state, true));
 
-    // cache_sensitive DSCP-match accessors: input and output v4 both carry a
-    // DSCP-match term; v6 carries none.
-    assert!(interface_input_filter_has_dscp_match(&state, 21, false));
-    assert!(!interface_input_filter_has_dscp_match(&state, 21, true));
-    assert!(interface_output_filter_has_dscp_match(&state, 21, false));
-    assert!(!interface_output_filter_has_dscp_match(&state, 21, true));
+    // DSCP-match accessor reads the DSCP set, NOT the TX-selection set:
+    // true on the DSCP-only ifindex, false on the TX-only ifindex.
+    assert!(interface_input_filter_has_dscp_match(&state, 22, false));
+    assert!(!interface_input_filter_has_dscp_match(&state, 21, false));
+    assert!(!interface_input_filter_has_dscp_match(&state, 22, true));
+    assert!(interface_output_filter_has_dscp_match(&state, 23, false));
+    assert!(!interface_output_filter_has_dscp_match(&state, 23, true));
     // No filter bound to an unrelated ifindex.
     assert!(!interface_input_filter_has_dscp_match(&state, 99, false));
     assert!(!interface_filter_affects_tx_selection(&state, 99, false));


### PR DESCRIPTION
## Summary

Adds 13 cargo unit tests filling the genuinely-uncovered behaviors in
the firewall filter-engine evaluation path
(`userspace-dp/src/filter/engine/{eval.rs, tx_selection.rs,
cache_sensitive.rs}`). These files carry 0 *local* `cfg(test)` blocks,
but `filter/tests.rs` (1998 LOC) already covers most of the surface via
the parent module's `cfg(test)` submodule — so this PR is scoped to the
nine real gaps, not a duplicate of existing coverage.

Test-only. No production code change. No cluster smoke (cargo test is
the gate, per the issue).

Closes #1725. References #1663 (§3 test-gap rank 1-3).

## Gaps filled

1. `FilterAction::Reject` through the plain `evaluate_filter` path
   (Reject was only asserted in `cos_classify_tests.rs` / `event_emit.rs`).
2. Missing filter key + empty filter -> implicit Accept default.
3. Address-family mismatch (V4 src + V6 dst) -> `_ => default` arm.
4. IPv6 baseline `evaluate_filter`, `evaluate_lo0_filter` (is_v6), and
   `evaluate_interface_filter` input (existing test only called is_v6=false).
5. `evaluate_filter_counted` baseline hit-counter increment, v4 + v6,
   including a non-match leaving the counter at 0.
6. `evaluate_interface_filter_non_routing_counted` PBR-reject: a matching
   routing-instance term short-circuits to default without recording.
7. `evaluate_interface_filter_tx_selection_counted` /
   `evaluate_interface_output_filter_tx_selection_counted` FilterState
   wrappers + the no-filter default arm.
8. Thin accessor predicates (`interface_filter_affects_tx_selection`,
   `filter_state_has_input_tx_selection`,
   `interface_input_filter_has_dscp_match`,
   `interface_output_filter_has_dscp_match`) in one table-driven test.
9. Cached-vs-runtime baseline parity for a plain (no-policer) term.

## Plan + adversarial review

Plan doc: `docs/pr/1725-filter-engine-tests/plan.md`

- Codex plan review: PLAN-NEEDS-MINOR (two factual corrections folded
  into plan v2: Reject is tested elsewhere repo-wide; v6 interface-input
  was uncovered). Confirmed 0/9 fully covered in `filter/tests.rs`.
- Antigravity plan review: PLAN-READY (all 9 gaps genuinely uncovered,
  zero false positives).
- Claude-SMR: PLAN-NEEDS-MINOR (same corrections + fold accessors).

## Non-vacuity

Tests build state through the real `parse_filter_state` compiler and
assert discriminating values. Mutation-checked: removing the
non-routing short-circuit fails `interface_filter_non_routing_counted_defers_pbr_term`;
remapping `reject -> accept` fails `evaluate_filter_returns_reject_action`.

## Test plan

- [x] cargo build clean
- [x] `cargo test --release`: 1720 passed, 0 failed
- [x] `filter::tests` 46/46 pass, 5/5 flake-clean
- [x] No production change -> no cluster smoke (per issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)