### PR TITLE
#1724: dedup L4 checksum-offset match sites via statically-dispatched helpers

### DIFF
--- a/docs/pr/1724-checksum-offset-helper/plan.md
+++ b/docs/pr/1724-checksum-offset-helper/plan.md
@@ -1,6 +1,45 @@
 # #1724 — dedup the 5 offset-lookup `match protocol` checksum sites via a statically-dispatched helper
 
-**Status:** DRAFT v3 — Codex PLAN-NEEDS-MINOR + AGY PLAN-KILL(LOC-bloat) both addressed; pending re-review convergence
+**Status:** DRAFT v4 — Codex r2 PLAN-NEEDS-MAJOR (two correctness bugs) fixed; pending re-review convergence
+
+## v4 changelog (addressing Codex round-2 PLAN-NEEDS-MAJOR — two real bugs)
+
+Codex round-2 found two genuine correctness defects in the v3
+family-independent offset helper. Both are fixed in v4 by **splitting the
+offset helper per family** (the form AGY's round-1 alternative and Codex
+both endorse) and keeping `checked_add` at the call site:
+
+1. **BUG (Codex r2 #2): IPv4 protocol-58 behavior change.** v3's
+   family-independent `l4_checksum_offset` added `PROTO_ICMPV6 => 2`
+   unconditionally. But the current IPv4 offset matches (checksum.rs:278,
+   367) have NO ICMPv6 arm — an IPv4 packet with protocol 58 hits
+   `_ => return Some(())` (no-op) today. The IPv4 NAT adjust paths
+   (mod.rs:711/715) call the v4 helpers WITHOUT protocol filtering, so v3
+   would make IPv4/proto-58 adjust offset `ihl+2` — a live behavior change.
+   **Fix:** `l4_checksum_field_delta_v4` has NO ICMPv6 arm; only the v6
+   variant does.
+2. **BUG (Codex r2 #1): overflow vs unsupported-protocol conflation.** v3's
+   helper returned `base.checked_add(delta)`, folding `checked_add`
+   overflow into the same `None` the call site mapped to `Some(())` (no-op
+   success). But the original v4 sites do `ihl.checked_add(16)?` — overflow
+   → `None` (FAILURE). v3 silently turned recognized-protocol overflow into
+   success. **Fix:** the helper returns ONLY the per-protocol delta
+   (`Option<usize>` where `None` == unsupported protocol). The `checked_add`
+   stays at the call site with `?`, preserving overflow-as-failure.
+
+Consequence: the call site reverts from a single `let-else` to the
+`match { Some(d)=>d, None=>return Some(()) }` + `base.checked_add(delta)?`
+form (4 lines + 1). This is ~LOC-neutral on the offset path, NOT the
+−14 v3 claimed (Codex r2 #3: rustfmt also expands the one-liner let-else to
+3 lines regardless). The honest value of the refactor is therefore the
+**centralization of the offset table per family and the v4/v6
+zero-checksum-canonicalization asymmetry into named, doc-commented,
+unit-tested predicates** — NOT a LOC reduction. If reviewers judge that
+centralization insufficient to justify ~LOC-neutral churn in
+correctness-critical code, **PLAN-KILL remains the right call.**
+
+Also fixed stale-naming doc drift Codex r2 #4 flagged (old
+`adjust_zero_checksum_is_illegal` / "two helpers" references).
 
 ## v3 changelog (addressing AGY round-1 PLAN-KILL: LOC-negative payoff)
 
@@ -82,9 +121,11 @@ risk that a future edit fixes the offset in 4 places and forgets the 5th),
 and centralize the correctness-critical v4/v6 zero-checksum guard
 asymmetry in one named, doc-commented, unit-tested predicate. There is
 **no measurable runtime win** — the `#[inline(always)]` fns fold to the
-same code. With the v3 `let-else` shape the offset path is **−14 LOC**
-(28 → 14); the predicate path is roughly LOC-neutral but turns 5 inline
-`matches!` expressions into 5 named-predicate calls.
+same code. With the v4 corrected (per-family, call-site `checked_add`)
+shape the offset path is roughly **LOC-neutral** (the v3 `−14` claim was
+wrong — Codex r2 #3); the value is centralizing the offset table per
+family and the v4/v6 canonicalization asymmetry into named, doc-commented,
+unit-tested predicates rather than 5 open-coded `match`/`matches!` blocks.
 
 *If reviewers conclude the dedup doesn't cleanly share enough to justify
 the helper (over-abstraction worse than a little duplication), PLAN-KILL
@@ -139,29 +180,40 @@ offset helper.** The arms could *consume* the same delta constants for the
 field offset, but doing so does not reduce the match (each arm still needs
 its own body), so it is churn without dedup. Plan keeps Class B untouched.
 
-## Concrete design (v3)
+## Concrete design (v4)
 
-Three small `#[inline(always)]` statically-dispatched free functions (no
-`dyn`, no trait, no generics — zero dynamic dispatch). The offset helper
-takes the L4 BASE so the call site is a single `let-else`.
+Four small `#[inline(always)]` statically-dispatched free functions (no
+`dyn`, no trait, no generics — zero dynamic dispatch). The offset is split
+per family so IPv4 protocol 58 keeps its current no-op behavior; the
+`checked_add` stays at the call site so overflow remains a failure.
 
 ```rust
-/// Absolute offset of the L4 checksum field within `packet`, given the L4
-/// header `base` (the IPv4 IHL, or 40 for the fixed IPv6 header). The
-/// field deltas are family-independent: TCP=+16, UDP=+6 in both families,
-/// and ICMPv6=+2 only ever applies on v6 (v4 callers never pass
-/// PROTO_ICMPV6 — IPv4 ICMP has no entry and falls to `None`). `None` =>
-/// no L4 checksum field this module adjusts (IPv4 ICMP, unknown) → caller
-/// no-ops with `Some(())`, never propagates as a failure.
+/// Per-protocol delta of the L4 checksum field from the start of the IPv4
+/// L4 header. `None` => protocol carries no L4 checksum field this module
+/// adjusts (IPv4 ICMP, IPv4 protocol 58, unknown) → caller no-ops with
+/// `Some(())`. NOTE: NO ICMPv6 arm — IPv4 packets never carry ICMPv6, and
+/// the IPv4 NAT adjust paths call this without protocol filtering, so a
+/// stray ICMPv6 arm would change live behavior (Codex r2 #2).
 #[inline(always)]
-fn l4_checksum_offset(protocol: u8, base: usize) -> Option<usize> {
-    let delta = match protocol {
-        PROTO_TCP => 16,
-        PROTO_UDP => 6,
-        PROTO_ICMPV6 => 2,
-        _ => return None,
-    };
-    base.checked_add(delta)
+fn l4_checksum_field_delta_v4(protocol: u8) -> Option<usize> {
+    match protocol {
+        PROTO_TCP => Some(16),
+        PROTO_UDP => Some(6),
+        _ => None,
+    }
+}
+
+/// Per-protocol delta of the L4 checksum field from the start of the IPv6
+/// L4 header (after the fixed 40-byte IPv6 header). `None` => no adjusted
+/// L4 checksum field (unknown) → caller no-ops with `Some(())`.
+#[inline(always)]
+fn l4_checksum_field_delta_v6(protocol: u8) -> Option<usize> {
+    match protocol {
+        PROTO_TCP => Some(16),
+        PROTO_UDP => Some(6),
+        PROTO_ICMPV6 => Some(2),
+        _ => None,
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -193,20 +245,20 @@ fn adjust_zero_checksum_illegal(protocol: u8, family: ChecksumFamily) -> bool {
 }
 ```
 
-Rationale: the offset is genuinely single-source across all 5 sites and the
-helper absorbs both the delta table AND the `base + delta` arithmetic, so
-the call site is one `let-else` line — that is what makes the refactor
-LOC-negative. The zero-canonicalization guard legitimately differs by
-family (the #1724 correctness point), so it carries a `ChecksumFamily` arg
-with both arms written out. `l4_udp_checksum_optional` is kept separate per
-both reviewers so the RFC-768 skip is not confused with canonicalization.
-Every caller passes a literal `V4`/`V6`; under `#[inline(always)]` the
-match folds to a constant → identical codegen to today, zero dynamic
-dispatch.
+Rationale: the offset delta table is single-sourced PER FAMILY (v4 has no
+ICMPv6 arm, preserving current IPv4-proto-58 no-op behavior). The
+`checked_add` stays at the call site so overflow remains a failure (`?`),
+NOT folded into the unsupported-protocol `None`. The zero-canonicalization
+guard legitimately differs by family (the #1724 correctness point), so it
+carries a `ChecksumFamily` arg with both arms written out.
+`l4_udp_checksum_optional` is kept separate per both reviewers so the
+RFC-768 skip is not confused with canonicalization. Every caller passes a
+literal family; under `#[inline(always)]` the match folds to a constant →
+identical codegen to today, zero dynamic dispatch.
 
-### Call-site transformation (Class A site 1 shown)
+### Call-site transformation (Class A site 1, IPv4, shown)
 
-Before (5 lines for the match + 1 for the guard):
+Before (4 lines for the match + 1 for the guard):
 ```rust
 let checksum_offset = match protocol {
     PROTO_TCP => ihl.checked_add(16)?,
@@ -216,35 +268,42 @@ let checksum_offset = match protocol {
 ...
 if matches!(protocol, PROTO_UDP) && updated == 0 { updated = 0xffff; }
 ```
-After (1 line for the offset + 1 for the guard):
+After:
 ```rust
-let Some(checksum_offset) = l4_checksum_offset(protocol, ihl) else {
-    return Some(());   // unknown proto → no-op success (NOT a failure)
+let delta = match l4_checksum_field_delta_v4(protocol) {
+    Some(d) => d,
+    None => return Some(()),      // unsupported proto → no-op success
 };
+let checksum_offset = ihl.checked_add(delta)?;   // overflow → None (failure), preserved
 ...
 if adjust_zero_checksum_illegal(protocol, ChecksumFamily::V4) && updated == 0 {
     updated = 0xffff;
 }
 ```
 
-- Site 2/4 (v6): `l4_checksum_offset(protocol, 40)`.
-- Site 5 (`adjust_l4_checksum_ipv6_addr_bytes`): `l4_checksum_offset(protocol, 40)`
-  yields `56`/`46`/`42` exactly (`40+16`/`40+6`/`40+2`), replacing the
-  hard-coded constants. Build-time codegen check confirms the
-  `#[inline(always)]` fn still folds to constant offsets.
+- Site 1/3 (v4): `l4_checksum_field_delta_v4` + `ihl.checked_add(delta)?`.
+- Site 2/4 (v6): `l4_checksum_field_delta_v6` + `40usize.checked_add(delta)?`.
+- Site 5 (`adjust_l4_checksum_ipv6_addr_bytes`): v6 delta +
+  `40usize.checked_add(delta)?` yields `56`/`46`/`42` exactly
+  (`40+16`/`40+6`/`40+2`), replacing the hard-coded constants. Build-time
+  codegen check confirms the `#[inline(always)]` fn still folds to constant
+  offsets.
 - Site 3 (`adjust_l4_checksum_ipv4_words`) pre-adjust skip (checksum.rs:376)
   becomes `if l4_udp_checksum_optional(protocol) && current == 0 { return
   Some(()); }` — RFC-768 concept kept textually separate.
 
-`let-else` is mandatory over `?`: `?` on the `Option<usize>` would `return
-None` (a failure) but the original `_` arm is `return Some(())` (no-op
-success).
+The `match { None => return Some(()) }` form (NOT `?`) is mandatory: the
+helper's `None` means unsupported protocol (no-op success), whereas `?`
+would `return None` (a failure). Overflow failure is preserved separately
+by the `checked_add(delta)?` at the call site.
 
 ## Public API preservation
 
 NO public signatures change. The 7 `pub(in crate::afxdp)` / `pub(super)`
-functions keep identical signatures and visibility. The two new helpers are
-private (`fn`, file-local). No callers in `frame/mod.rs`, `nat64.rs`,
+functions keep identical signatures and visibility. The four new helpers
+(`l4_checksum_field_delta_v4`, `l4_checksum_field_delta_v6`,
+`l4_udp_checksum_optional`, `adjust_zero_checksum_illegal`) are private
+(`fn`, file-local). No callers in `frame/mod.rs`, `nat64.rs`,
 `poll_stages.rs`, `tx/tcp_segmentation.rs`, `frame/build/*` are touched.
 
 ## Hidden invariants the change must preserve
@@ -280,10 +339,12 @@ private (`fn`, file-local). No callers in `frame/mod.rs`, `nat64.rs`,
   `simd_checksum_tests` parity / one's-complement-wrap + `frame/tests.rs`
   checksum tests) green.
 - **New unit tests** in `checksum.rs` test module:
-  - `l4_checksum_offset(proto, base)`: returns `base+16`/`base+6`/`None` for
-    TCP/UDP/IPv4-ICMP, and `base+2` for ICMPV6; `None` for unknown. Asserted
-    for `base=20` (v4 IHL) and `base=40` (v6), and that `base=40` reproduces
-    `56/46/42`.
+  - `l4_checksum_field_delta_v4(proto)`: `Some(16)`/`Some(6)` for TCP/UDP;
+    **`None` for IPv4 ICMP, protocol 58 (ICMPv6), and unknown** (the
+    proto-58 no-op regression guard from Codex r2 #2).
+  - `l4_checksum_field_delta_v6(proto)`: `Some(16)`/`Some(6)`/`Some(2)` for
+    TCP/UDP/ICMPV6; `None` for unknown. Assert `40 + delta` reproduces
+    `56/46/42` for site 5.
   - `adjust_zero_checksum_illegal`: true for (V4, UDP) only — false for
     (V4, TCP/ICMP/ICMPV6); true for (V6, UDP) and (V6, ICMPV6) — false for
     (V6, TCP).
@@ -316,7 +377,7 @@ for AGY + SMR:
 1. **Is the dedup worth it at all?** 5 sites, ~20-30 LOC saved, zero perf.
    Over-abstraction (PLAN-KILL) or genuine maintainability win (offset
    table single-source)? Codex round-1 said "worth doing after the edits".
-2. **Predicate name + scope.** Is `adjust_zero_checksum_is_illegal` with
+2. **Predicate name + scope.** Is `adjust_zero_checksum_illegal` with
    the "incremental-adjust ONLY" doc comment a sufficiently clear guard
    against a future dev extending it to `recompute_l4_checksum_ipv6` (which
    would change behavior on the v6-ICMPv6 arm)? Or should the predicate

--- a/docs/pr/1724-checksum-offset-helper/plan.md
+++ b/docs/pr/1724-checksum-offset-helper/plan.md
@@ -353,6 +353,14 @@ functions keep identical signatures and visibility. The four new helpers
     adjusted checksum computes to 0 yields `0xFFFF` (the #1669-trap
     regression); a v4 ICMP/TCP packet computing to 0 is left unchanged
     (no canonicalization).
+  - **Overflow/no-op call-site regression (Codex r3):** call
+    `adjust_l4_checksum_ipv4*` with a recognized proto (TCP/UDP) and an
+    `ihl` so large that `ihl.checked_add(delta)` overflows `usize` —
+    assert the fn returns `None` (failure preserved, the round-2 bug-#1
+    guard). Call the same fn with IPv4 protocol 58 (ICMPv6) and any `ihl`
+    — assert it returns `Some(())` no-op (round-2 bug-#2 guard), i.e. the
+    helper's `_ => None` path maps to no-op success and never reads the
+    packet at `ihl+2`.
 - 5× flake loop on the checksum test module.
 - Go suite (`go test ./...`) — known pre-existing
   `pkg/dataplane/userspace` sandbox unix-socket failures proven

--- a/docs/pr/1724-checksum-offset-helper/plan.md
+++ b/docs/pr/1724-checksum-offset-helper/plan.md
@@ -1,6 +1,67 @@
-# #1724 — dedup 7× `match protocol` checksum-offset logic via a monomorphized helper
+# #1724 — dedup the 5 offset-lookup `match protocol` checksum sites via a statically-dispatched helper
 
-**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
+**Status:** DRAFT v3 — Codex PLAN-NEEDS-MINOR + AGY PLAN-KILL(LOC-bloat) both addressed; pending re-review convergence
+
+## v3 changelog (addressing AGY round-1 PLAN-KILL: LOC-negative payoff)
+
+AGY's PLAN-KILL rested on the v1/v2 call-site shape being **LOC-negative**:
+the `match l4_checksum_field_delta(protocol) { Some(d)=>d, None=>return
+Some(()) }` form is 4 lines + `checked_add` = 5 lines/site vs the 5-6 line
+match it replaces — net ~+5 LOC, no dedup win. **AGY is correct about that
+shape.** v3 fixes it with two changes that make the refactor genuinely
+LOC-negative AND centralize the correctness-critical pieces:
+
+1. **`let-else` single-line call sites.** Edition 2024 + rustc 1.95 support
+   `let-else`. The offset helper takes the BASE (`ihl` for v4, `40` for v6)
+   and returns the ABSOLUTE offset, so each call site collapses to ONE
+   line: `let Some(off) = l4_checksum_offset(protocol, base) else { return
+   Some(()) };`. 5 sites: 5 lines (was 28) + helper ~9 lines = 14 vs 28 →
+   **−14 LOC on the offset path.** This is the dedup win AGY said was
+   missing.
+2. **AGY's split-predicate naming adopted.** AGY Finding 1 (site-3 naming
+   inversion) and Codex Finding #1 converge: the site-3 pre-adjust skip is
+   "IPv4 UDP checksum 0 = sender disabled it, RFC 768" — a DIFFERENT concept
+   from "computed 0 must canonicalize to 0xFFFF". v3 uses AGY's two clearly
+   named predicates: `l4_udp_checksum_optional(protocol)` for the site-3
+   skip and `adjust_zero_checksum_illegal(protocol, family)` for the
+   canonicalization. No `zeroed_checksum_is_illegal` overload.
+
+AGY's remaining objections (codegen reliance on inliner; "worth it") are
+addressed: `#[inline(always)]` + a build-time codegen confirmation, and the
+now-negative LOC delta answers "worth it". If reviewers still judge the
+abstraction not worth the churn, PLAN-KILL remains acceptable.
+
+## v2 changelog (addressing Codex round-1 PLAN-NEEDS-MINOR)
+
+- **Title fixed** (Codex #4): the dedup target is **5** Class-A
+  offset-lookup sites, not 7. The 2 Class-B recompute sites are out of
+  scope. Title no longer says "7×".
+- **Wording fixed** (Codex #2): dropped the inaccurate "monomorphized"
+  term (a non-generic fn with a runtime enum arg is not monomorphized).
+  The helpers are `#[inline(always)]` **statically-dispatched free
+  functions** — no `dyn`, no trait, no generics. The task's
+  "monomorphized" constraint is satisfied in spirit: zero dynamic
+  dispatch on the hot path.
+- **Design simplified** (Codex #6 + SMR): the offset delta is
+  **family-independent** (TCP=16, UDP=6, ICMPv6=2 universally — ICMPv6
+  simply never reaches the v4 callers because v4 packets aren't ICMPv6).
+  So there is exactly ONE offset fn (no enum needed for offsets), plus
+  ONE family-aware zero-canonicalization predicate. No `ChecksumFamily`
+  enum on the offset path.
+- **Site-3 guard kept literal** (Codex #1 + SMR): the pre-adjust
+  `if matches!(protocol, PROTO_UDP) && current == 0 { return Some(()) }`
+  at checksum.rs:376 stays a literal `protocol == PROTO_UDP`. It encodes
+  RFC 768 "received IPv4/UDP datagram with checksum 0 = no checksum
+  computed, don't fabricate one" — a DISTINCT concept from the
+  computed-zero canonicalization. Not routed through the predicate helper.
+- **Predicate scoped + renamed** (Codex #3 + SMR): renamed to
+  `adjust_zero_checksum_is_illegal` with a doc comment scoping it to the
+  **incremental-adjust** sites only. Verified pre-existing asymmetry:
+  `recompute_l4_checksum_ipv6` ICMPv6 arm (checksum.rs:533) writes raw
+  `sum` and does NOT canonicalize 0→0xFFFF, whereas the incremental v6
+  ICMPv6 adjust sites DO (checksum.rs:319/428/455). This refactor
+  PRESERVES that pre-existing inconsistency verbatim and does not extend
+  the predicate to Class B.
 
 ## Issue framing
 
@@ -17,9 +78,13 @@ would break ICMPv6 zero-checksum handling.
 
 This is a **readability / DRY** refactor, not a perf change. The win is:
 eliminate 5 near-identical `match protocol` offset-lookup blocks (and the
-risk that a future edit fixes the offset in 4 places and forgets the
-5th). There is **no measurable runtime win** — the helper is `#[inline]`
-and monomorphizes to the same code. LOC drops modestly (~25-35 lines).
+risk that a future edit fixes the offset in 4 places and forgets the 5th),
+and centralize the correctness-critical v4/v6 zero-checksum guard
+asymmetry in one named, doc-commented, unit-tested predicate. There is
+**no measurable runtime win** — the `#[inline(always)]` fns fold to the
+same code. With the v3 `let-else` shape the offset path is **−14 LOC**
+(28 → 14); the predicate path is roughly LOC-neutral but turns 5 inline
+`matches!` expressions into 5 named-predicate calls.
 
 *If reviewers conclude the dedup doesn't cleanly share enough to justify
 the helper (over-abstraction worse than a little duplication), PLAN-KILL
@@ -74,34 +139,53 @@ offset helper.** The arms could *consume* the same delta constants for the
 field offset, but doing so does not reduce the match (each arm still needs
 its own body), so it is churn without dedup. Plan keeps Class B untouched.
 
-## Concrete design
+## Concrete design (v3)
 
-Introduce two small free functions (monomorphized, no `dyn`, no trait):
+Three small `#[inline(always)]` statically-dispatched free functions (no
+`dyn`, no trait, no generics — zero dynamic dispatch). The offset helper
+takes the L4 BASE so the call site is a single `let-else`.
 
 ```rust
-/// L4 checksum-field offset within the L4 segment, relative to the start
-/// of the L4 header (i.e. add the IPv4 IHL or the fixed IPv6 40-byte
-/// header to get the packet offset). `None` => protocol carries no L4
-/// checksum field we adjust (IPv4 ICMP, unknown) → caller no-ops.
-#[inline]
-fn l4_checksum_field_delta(protocol: u8, family: ChecksumFamily) -> Option<usize> {
-    match (protocol, family) {
-        (PROTO_TCP, _) => Some(16),
-        (PROTO_UDP, _) => Some(6),
-        (PROTO_ICMPV6, ChecksumFamily::V6) => Some(2),
-        _ => None,
-    }
+/// Absolute offset of the L4 checksum field within `packet`, given the L4
+/// header `base` (the IPv4 IHL, or 40 for the fixed IPv6 header). The
+/// field deltas are family-independent: TCP=+16, UDP=+6 in both families,
+/// and ICMPv6=+2 only ever applies on v6 (v4 callers never pass
+/// PROTO_ICMPV6 — IPv4 ICMP has no entry and falls to `None`). `None` =>
+/// no L4 checksum field this module adjusts (IPv4 ICMP, unknown) → caller
+/// no-ops with `Some(())`, never propagates as a failure.
+#[inline(always)]
+fn l4_checksum_offset(protocol: u8, base: usize) -> Option<usize> {
+    let delta = match protocol {
+        PROTO_TCP => 16,
+        PROTO_UDP => 6,
+        PROTO_ICMPV6 => 2,
+        _ => return None,
+    };
+    base.checked_add(delta)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ChecksumFamily { V4, V6 }
 
-/// Apply the family-correct zero-checksum fixup. IPv4: UDP only.
-/// IPv6: UDP and ICMPv6 (both forbid a transmitted 0x0000 checksum;
-/// 0x0000 means "no checksum" for v4 UDP and is illegal for v6 UDP /
-/// ICMPv6, so a computed 0 is rewritten to the equivalent 0xFFFF).
-#[inline]
-fn zeroed_checksum_is_illegal(protocol: u8, family: ChecksumFamily) -> bool {
+/// IPv4-UDP-only: a received IPv4 UDP datagram with checksum 0x0000 carried
+/// NO checksum (RFC 768 — the checksum is optional for IPv4 UDP). The
+/// incremental-adjust path must NOT fabricate one, so it skips. This is a
+/// DISTINCT concept from `adjust_zero_checksum_illegal` (computed-to-zero
+/// canonicalization) and must not be conflated with it (AGY/Codex r1).
+#[inline(always)]
+fn l4_udp_checksum_optional(protocol: u8) -> bool {
+    protocol == PROTO_UDP
+}
+
+/// Whether a freshly-computed checksum of 0x0000 must be canonicalized to
+/// 0xFFFF on the INCREMENTAL-ADJUST sites. IPv4: UDP only. IPv6: UDP and
+/// ICMPv6 (RFC 2460 §8.1 / RFC 8200 forbid a transmitted 0x0000 for both).
+/// SCOPE: incremental adjust_l4_checksum_* sites ONLY — deliberately does
+/// NOT describe recompute_l4_checksum_ipv6, whose ICMPv6 arm
+/// (checksum.rs:533) writes the raw sum without canonicalization, a
+/// pre-existing asymmetry this refactor preserves and does not unify.
+#[inline(always)]
+fn adjust_zero_checksum_illegal(protocol: u8, family: ChecksumFamily) -> bool {
     match family {
         ChecksumFamily::V4 => protocol == PROTO_UDP,
         ChecksumFamily::V6 => matches!(protocol, PROTO_UDP | PROTO_ICMPV6),
@@ -109,23 +193,20 @@ fn zeroed_checksum_is_illegal(protocol: u8, family: ChecksumFamily) -> bool {
 }
 ```
 
-Why `family` param rather than two helpers: it keeps the offset deltas in
-ONE place (the real dedup value) while making the v4/v6 asymmetry explicit
-and type-checked. `ChecksumFamily` is a 1-byte `Copy` enum; the `#[inline]`
-fns monomorphize at each call with `family` a compile-time constant at
-every call site (every caller passes a literal `V4`/`V6`), so the match
-folds to a constant — identical codegen to today.
-
-Alternative considered: separate `l4_checksum_field_delta_v4` /
-`_v6` free fns + `zeroed_v4`/`zeroed_v6`. This avoids the enum entirely.
-The enum keeps the delta table truly single-source (v4 and v6 share TCP/UDP
-deltas); two fns would duplicate the TCP/UDP arms again. The plan leans
-toward the `family`-param form; reviewers may prefer the split-fn form —
-flagged as Open Question 1.
+Rationale: the offset is genuinely single-source across all 5 sites and the
+helper absorbs both the delta table AND the `base + delta` arithmetic, so
+the call site is one `let-else` line — that is what makes the refactor
+LOC-negative. The zero-canonicalization guard legitimately differs by
+family (the #1724 correctness point), so it carries a `ChecksumFamily` arg
+with both arms written out. `l4_udp_checksum_optional` is kept separate per
+both reviewers so the RFC-768 skip is not confused with canonicalization.
+Every caller passes a literal `V4`/`V6`; under `#[inline(always)]` the
+match folds to a constant → identical codegen to today, zero dynamic
+dispatch.
 
 ### Call-site transformation (Class A site 1 shown)
 
-Before:
+Before (5 lines for the match + 1 for the guard):
 ```rust
 let checksum_offset = match protocol {
     PROTO_TCP => ihl.checked_add(16)?,
@@ -135,34 +216,29 @@ let checksum_offset = match protocol {
 ...
 if matches!(protocol, PROTO_UDP) && updated == 0 { updated = 0xffff; }
 ```
-After:
+After (1 line for the offset + 1 for the guard):
 ```rust
-let delta = match l4_checksum_field_delta(protocol, ChecksumFamily::V4) {
-    Some(d) => d,
-    None => return Some(()),
+let Some(checksum_offset) = l4_checksum_offset(protocol, ihl) else {
+    return Some(());   // unknown proto → no-op success (NOT a failure)
 };
-let checksum_offset = ihl.checked_add(delta)?;
 ...
-if zeroed_checksum_is_illegal(protocol, ChecksumFamily::V4) && updated == 0 {
+if adjust_zero_checksum_illegal(protocol, ChecksumFamily::V4) && updated == 0 {
     updated = 0xffff;
 }
 ```
 
-Site 5 (`adjust_l4_checksum_ipv6_addr_bytes`) becomes
-`40usize.checked_add(delta)?` (was const `56`/`46`/`42`) — preserves the
-exact same values; `40+16=56`, `40+6=46`, `40+2=42`. The `checked_add` on a
-const can't actually overflow but keeps the shape uniform with the others;
-the optimizer folds it.
+- Site 2/4 (v6): `l4_checksum_offset(protocol, 40)`.
+- Site 5 (`adjust_l4_checksum_ipv6_addr_bytes`): `l4_checksum_offset(protocol, 40)`
+  yields `56`/`46`/`42` exactly (`40+16`/`40+6`/`40+2`), replacing the
+  hard-coded constants. Build-time codegen check confirms the
+  `#[inline(always)]` fn still folds to constant offsets.
+- Site 3 (`adjust_l4_checksum_ipv4_words`) pre-adjust skip (checksum.rs:376)
+  becomes `if l4_udp_checksum_optional(protocol) && current == 0 { return
+  Some(()); }` — RFC-768 concept kept textually separate.
 
-Site 3 (`adjust_l4_checksum_ipv4_words`) additionally has the
-`if matches!(protocol, PROTO_UDP) && current == 0 { return Some(()); }`
-early-return BEFORE the adjust. That guard is **v4-UDP-specific** and is
-NOT the zero-checksum-illegal fixup — it's "incoming UDP packet had no
-checksum, don't start computing one". Keep it as
-`if zeroed_checksum_is_illegal(protocol, ChecksumFamily::V4) && current == 0`
-— for v4 this is `protocol == PROTO_UDP`, identical. (Confirmed: there is
-no ICMP arm on v4, so `zeroed_checksum_is_illegal(_, V4)` is true ONLY for
-UDP, exactly matching the original `matches!(protocol, PROTO_UDP)`.)
+`let-else` is mandatory over `?`: `?` on the `Option<usize>` would `return
+None` (a failure) but the original `_` arm is `return Some(())` (no-op
+success).
 
 ## Public API preservation
 
@@ -174,12 +250,13 @@ private (`fn`, file-local). No callers in `frame/mod.rs`, `nat64.rs`,
 ## Hidden invariants the change must preserve
 
 1. **v4 zero-guard = UDP only; v6 zero-guard = UDP|ICMPV6.** Encoded in
-   `zeroed_checksum_is_illegal` and asserted by new unit tests.
+   `adjust_zero_checksum_illegal` and asserted by new unit tests.
 2. **`_` arm = `return Some(())` (no-op success), NOT `None`.** Helper
-   returns `None` for unknown proto; caller maps `None -> return Some(())`.
-   This must stay `Some(())`, not propagate `None` (which would signal a
-   parse failure to the caller).
-3. **Site-3 `current == 0` UDP early-skip** stays before the adjust.
+   returns `None` for unknown proto; caller maps via `let-else { return
+   Some(()) }`, never `?`. Must not propagate `None` (a parse failure).
+3. **Site-3 `current == 0` UDP early-skip** stays before the adjust as
+   `l4_udp_checksum_optional(protocol)` (== `protocol == PROTO_UDP`) — a
+   separate predicate from the canonicalization guard.
 4. **Offset deltas unchanged:** TCP 16, UDP 6, ICMPV6 2.
 5. **Site-5 absolute constants 56/46/42** remain numerically identical via
    `40 + delta`.
@@ -203,14 +280,18 @@ private (`fn`, file-local). No callers in `frame/mod.rs`, `nat64.rs`,
   `simd_checksum_tests` parity / one's-complement-wrap + `frame/tests.rs`
   checksum tests) green.
 - **New unit tests** in `checksum.rs` test module:
-  - `l4_checksum_field_delta` returns 16/6/None for v4 TCP/UDP/ICMP and
-    16/6/2/None for v6 TCP/UDP/ICMPV6.
-  - `zeroed_checksum_is_illegal` is true for v4 UDP only (false for v4 TCP /
-    v4 ICMP / v4 ICMPV6); true for v6 UDP and v6 ICMPV6 (false for v6 TCP).
+  - `l4_checksum_offset(proto, base)`: returns `base+16`/`base+6`/`None` for
+    TCP/UDP/IPv4-ICMP, and `base+2` for ICMPV6; `None` for unknown. Asserted
+    for `base=20` (v4 IHL) and `base=40` (v6), and that `base=40` reproduces
+    `56/46/42`.
+  - `adjust_zero_checksum_illegal`: true for (V4, UDP) only — false for
+    (V4, TCP/ICMP/ICMPV6); true for (V6, UDP) and (V6, ICMPV6) — false for
+    (V6, TCP).
+  - `l4_udp_checksum_optional`: true for UDP, false otherwise.
   - End-to-end: an `adjust_l4_checksum_ipv6` call on an ICMPv6 packet whose
-    adjusted checksum computes to 0 yields `0xFFFF` (the regression the
-    #1669 trap warns about); the matching v4-UDP-only behavior verified by
-    showing a v4 ICMP/TCP packet computing to 0 is left as 0.
+    adjusted checksum computes to 0 yields `0xFFFF` (the #1669-trap
+    regression); a v4 ICMP/TCP packet computing to 0 is left unchanged
+    (no canonicalization).
 - 5× flake loop on the checksum test module.
 - Go suite (`go test ./...`) — known pre-existing
   `pkg/dataplane/userspace` sandbox unix-socket failures proven
@@ -227,29 +308,19 @@ private (`fn`, file-local). No callers in `frame/mod.rs`, `nat64.rs`,
 - Any change to `checksum16*` arithmetic, SIMD path, or pseudo-header fns.
 - Any public API / visibility change.
 
-## Open questions for adversarial review
+## Open questions for adversarial review (v2)
 
-1. **`family` enum vs split free fns.** Is the `ChecksumFamily` enum the
-   right call, or do two pairs of family-specific free fns
-   (`l4_checksum_field_delta_v4/_v6`) read cleaner and remove the enum?
-   The enum keeps the TCP/UDP deltas single-source; split fns re-duplicate
-   them. Which wins?
-2. **Is the dedup worth it at all?** 5 sites, ~25-35 LOC saved, zero perf.
-   Is this over-abstraction (PLAN-KILL) or a genuine maintainability win
-   (the offset table now lives in one place)?
-3. **Site-3 `current == 0` early-skip rewrite.** Is reusing
-   `zeroed_checksum_is_illegal(_, V4)` for the pre-adjust skip correct, or
-   does conflating the "incoming had no checksum" skip with the
-   "computed-to-zero illegal" fixup obscure two distinct concerns? Keep a
-   literal `protocol == PROTO_UDP` there instead?
-4. **Site-5 `40 + delta` vs literal constants.** Does replacing `56/46/42`
-   with `40usize.checked_add(delta)?` improve or harm clarity, given the
-   `#[inline(always)]` hot-path-adjacent annotation on that fn? Any codegen
-   concern from the extra `checked_add` on a const base?
-5. **Class B exclusion.** Is leaving `recompute_*` untouched correct, or
-   should the offset literals there also consume the delta helper for
-   consistency even though it doesn't reduce the match?
-6. **`None` → `Some(())` mapping.** Is mapping the helper's `None` to
-   `return Some(())` at each call site clear enough, or does it risk a
-   future caller treating `None` as a hard error? Should the helper's
-   contract be documented to forbid that?
+Codex round-1 resolved its own OQs 1/3/4/5/6 (see v2 changelog). Remaining
+for AGY + SMR:
+
+1. **Is the dedup worth it at all?** 5 sites, ~20-30 LOC saved, zero perf.
+   Over-abstraction (PLAN-KILL) or genuine maintainability win (offset
+   table single-source)? Codex round-1 said "worth doing after the edits".
+2. **Predicate name + scope.** Is `adjust_zero_checksum_is_illegal` with
+   the "incremental-adjust ONLY" doc comment a sufficiently clear guard
+   against a future dev extending it to `recompute_l4_checksum_ipv6` (which
+   would change behavior on the v6-ICMPv6 arm)? Or should the predicate
+   live as a private fn physically adjacent to the 3 adjust sites?
+3. **`#[inline(always)]` codegen.** Does forcing inline on these two tiny
+   fns risk any regression vs the current open-coded `match`/`matches!`?
+   (Expectation: identical; flagged for build-time confirmation.)

--- a/docs/pr/1724-checksum-offset-helper/plan.md
+++ b/docs/pr/1724-checksum-offset-helper/plan.md
@@ -1,0 +1,255 @@
+# #1724 — dedup 7× `match protocol` checksum-offset logic via a monomorphized helper
+
+**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
+
+## Issue framing
+
+`userspace-dp/src/afxdp/frame/checksum.rs` (631 LOC) contains 7
+`match protocol { ... }` sites. #1724 (promoted from #1669 §3) asks for a
+small **monomorphized** (NON-`dyn`, hot-path-safe) helper —
+`l4_checksum_offset(protocol) -> Option<usize>` or similar — to dedup the
+uniform `match protocol => offset` arms, while explicitly **preserving the
+v4/v6 zero-checksum distinction**: IPv4 sites zero-guard on `PROTO_UDP`
+only; IPv6 sites zero-guard on `PROTO_UDP | PROTO_ICMPV6`. A blind unify
+would break ICMPv6 zero-checksum handling.
+
+## Honest scope/value framing
+
+This is a **readability / DRY** refactor, not a perf change. The win is:
+eliminate 5 near-identical `match protocol` offset-lookup blocks (and the
+risk that a future edit fixes the offset in 4 places and forgets the
+5th). There is **no measurable runtime win** — the helper is `#[inline]`
+and monomorphizes to the same code. LOC drops modestly (~25-35 lines).
+
+*If reviewers conclude the dedup doesn't cleanly share enough to justify
+the helper (over-abstraction worse than a little duplication), PLAN-KILL
+is an acceptable verdict.*
+
+## Site-by-site audit (all 7, read end-to-end)
+
+The 7 `match protocol` sites split into TWO structurally distinct classes.
+
+### Class A — offset-lookup matches (the dedup target): 5 sites
+
+These compute an L4 checksum-field offset, read the current u16, adjust it,
+optionally apply the zero-checksum fixup, and write it back. The `match`
+arm is *purely* `protocol -> base + delta`.
+
+| # | Fn | Line | Base | TCP | UDP | ICMPV6 | `_` arm | Zero-guard |
+|---|----|------|------|-----|-----|--------|---------|------------|
+| 1 | `adjust_l4_checksum_ipv4` | 278 | `ihl` | `+16` | `+6` | — | `return Some(())` | `UDP` only |
+| 2 | `adjust_l4_checksum_ipv6` | 307 | `40` | `+16` | `+6` | `+2` | `return Some(())` | `UDP\|ICMPV6` |
+| 3 | `adjust_l4_checksum_ipv4_words` | 367 | `ihl` | `+16` | `+6` | — | `return Some(())` | `UDP` only (+ `current==0` UDP skip) |
+| 4 | `adjust_l4_checksum_ipv6_words` | 417 | `40` | `+16` | `+6` | `+2` | `return Some(())` | `UDP\|ICMPV6` |
+| 5 | `adjust_l4_checksum_ipv6_addr_bytes` | 444 | `40` (const-folded) | `56` | `46` | `42` | `return Some(())` | `UDP\|ICMPV6` |
+
+Observations:
+- All five use the SAME deltas: TCP `+16`, UDP `+6`, ICMPV6 `+2`.
+- IPv4 sites (1, 3) have base `ihl` (runtime) and NO ICMPV6 arm.
+- IPv6 sites (2, 4, 5) have base `40` (fixed). Site 5 writes the constants
+  pre-added (`56`/`46`/`42` = `40+16`/`40+6`/`40+2`) — semantically
+  identical to `40 + delta`.
+- The `_ => return Some(())` arm is uniform: unknown protocol → no-op
+  success.
+- **Zero-guard asymmetry (the #1669 trap):** sites 1, 3 guard
+  `matches!(protocol, PROTO_UDP)`; sites 2, 4, 5 guard
+  `matches!(protocol, PROTO_UDP | PROTO_ICMPV6)`. This MUST be preserved.
+
+### Class B — full-recompute matches (NOT a clean dedup target): 2 sites
+
+| # | Fn | Line | Shape |
+|---|----|------|-------|
+| 6 | `recompute_l4_checksum_ipv4` | 471 | per-proto min-len check + zero the field + pseudo-header `checksum16_ipv4` recompute + UDP `zero_offset` fixup |
+| 7 | `recompute_l4_checksum_ipv6` | 506 | per-proto min-len check + zero the field + pseudo-header `checksum16_ipv6` recompute |
+
+Class B does NOT compute-then-reuse an offset the same way: each arm does a
+min-length guard (`segment.len() < 20/8/4`), zeroes the field, calls the
+pseudo-header checksum, and (for v4 UDP) applies a `zero_offset`-gated
+fixup. The offset *literals* (`ihl+16`, `40+6`, ...) match Class A's
+deltas, but the surrounding per-arm logic (different min-len per proto,
+zeroing-before-recompute, distinct fixup conditions) is not uniform. The
+ICMPV6 arm in site 7 has min-len 4 (vs TCP 20 / UDP 8), and the v4 UDP arm
+threads the `zero_offset` parameter. **Class B is OUT OF SCOPE for the
+offset helper.** The arms could *consume* the same delta constants for the
+field offset, but doing so does not reduce the match (each arm still needs
+its own body), so it is churn without dedup. Plan keeps Class B untouched.
+
+## Concrete design
+
+Introduce two small free functions (monomorphized, no `dyn`, no trait):
+
+```rust
+/// L4 checksum-field offset within the L4 segment, relative to the start
+/// of the L4 header (i.e. add the IPv4 IHL or the fixed IPv6 40-byte
+/// header to get the packet offset). `None` => protocol carries no L4
+/// checksum field we adjust (IPv4 ICMP, unknown) → caller no-ops.
+#[inline]
+fn l4_checksum_field_delta(protocol: u8, family: ChecksumFamily) -> Option<usize> {
+    match (protocol, family) {
+        (PROTO_TCP, _) => Some(16),
+        (PROTO_UDP, _) => Some(6),
+        (PROTO_ICMPV6, ChecksumFamily::V6) => Some(2),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ChecksumFamily { V4, V6 }
+
+/// Apply the family-correct zero-checksum fixup. IPv4: UDP only.
+/// IPv6: UDP and ICMPv6 (both forbid a transmitted 0x0000 checksum;
+/// 0x0000 means "no checksum" for v4 UDP and is illegal for v6 UDP /
+/// ICMPv6, so a computed 0 is rewritten to the equivalent 0xFFFF).
+#[inline]
+fn zeroed_checksum_is_illegal(protocol: u8, family: ChecksumFamily) -> bool {
+    match family {
+        ChecksumFamily::V4 => protocol == PROTO_UDP,
+        ChecksumFamily::V6 => matches!(protocol, PROTO_UDP | PROTO_ICMPV6),
+    }
+}
+```
+
+Why `family` param rather than two helpers: it keeps the offset deltas in
+ONE place (the real dedup value) while making the v4/v6 asymmetry explicit
+and type-checked. `ChecksumFamily` is a 1-byte `Copy` enum; the `#[inline]`
+fns monomorphize at each call with `family` a compile-time constant at
+every call site (every caller passes a literal `V4`/`V6`), so the match
+folds to a constant — identical codegen to today.
+
+Alternative considered: separate `l4_checksum_field_delta_v4` /
+`_v6` free fns + `zeroed_v4`/`zeroed_v6`. This avoids the enum entirely.
+The enum keeps the delta table truly single-source (v4 and v6 share TCP/UDP
+deltas); two fns would duplicate the TCP/UDP arms again. The plan leans
+toward the `family`-param form; reviewers may prefer the split-fn form —
+flagged as Open Question 1.
+
+### Call-site transformation (Class A site 1 shown)
+
+Before:
+```rust
+let checksum_offset = match protocol {
+    PROTO_TCP => ihl.checked_add(16)?,
+    PROTO_UDP => ihl.checked_add(6)?,
+    _ => return Some(()),
+};
+...
+if matches!(protocol, PROTO_UDP) && updated == 0 { updated = 0xffff; }
+```
+After:
+```rust
+let delta = match l4_checksum_field_delta(protocol, ChecksumFamily::V4) {
+    Some(d) => d,
+    None => return Some(()),
+};
+let checksum_offset = ihl.checked_add(delta)?;
+...
+if zeroed_checksum_is_illegal(protocol, ChecksumFamily::V4) && updated == 0 {
+    updated = 0xffff;
+}
+```
+
+Site 5 (`adjust_l4_checksum_ipv6_addr_bytes`) becomes
+`40usize.checked_add(delta)?` (was const `56`/`46`/`42`) — preserves the
+exact same values; `40+16=56`, `40+6=46`, `40+2=42`. The `checked_add` on a
+const can't actually overflow but keeps the shape uniform with the others;
+the optimizer folds it.
+
+Site 3 (`adjust_l4_checksum_ipv4_words`) additionally has the
+`if matches!(protocol, PROTO_UDP) && current == 0 { return Some(()); }`
+early-return BEFORE the adjust. That guard is **v4-UDP-specific** and is
+NOT the zero-checksum-illegal fixup — it's "incoming UDP packet had no
+checksum, don't start computing one". Keep it as
+`if zeroed_checksum_is_illegal(protocol, ChecksumFamily::V4) && current == 0`
+— for v4 this is `protocol == PROTO_UDP`, identical. (Confirmed: there is
+no ICMP arm on v4, so `zeroed_checksum_is_illegal(_, V4)` is true ONLY for
+UDP, exactly matching the original `matches!(protocol, PROTO_UDP)`.)
+
+## Public API preservation
+
+NO public signatures change. The 7 `pub(in crate::afxdp)` / `pub(super)`
+functions keep identical signatures and visibility. The two new helpers are
+private (`fn`, file-local). No callers in `frame/mod.rs`, `nat64.rs`,
+`poll_stages.rs`, `tx/tcp_segmentation.rs`, `frame/build/*` are touched.
+
+## Hidden invariants the change must preserve
+
+1. **v4 zero-guard = UDP only; v6 zero-guard = UDP|ICMPV6.** Encoded in
+   `zeroed_checksum_is_illegal` and asserted by new unit tests.
+2. **`_` arm = `return Some(())` (no-op success), NOT `None`.** Helper
+   returns `None` for unknown proto; caller maps `None -> return Some(())`.
+   This must stay `Some(())`, not propagate `None` (which would signal a
+   parse failure to the caller).
+3. **Site-3 `current == 0` UDP early-skip** stays before the adjust.
+4. **Offset deltas unchanged:** TCP 16, UDP 6, ICMPV6 2.
+5. **Site-5 absolute constants 56/46/42** remain numerically identical via
+   `40 + delta`.
+6. **One's-complement arithmetic untouched** — only offset/guard derivation
+   is refactored; `checksum16_adjust*` calls are byte-identical.
+7. **Class B (recompute_*) untouched** — no behavior change there at all.
+
+## Risk assessment
+
+| Class | Level | Note |
+|-------|-------|------|
+| Behavioral regression | LOW | Pure offset/guard derivation move; deltas + guards preserved verbatim; new tests pin both family cases. |
+| Lifetime / borrow-checker | NONE | Helpers take `u8` + `Copy` enum, return `Option<usize>`; no refs. |
+| Performance regression | NONE | `#[inline]` fns with const `family` arg fold to identical codegen; checksum16 path untouched. |
+| Architectural mismatch (#961/#1207) | NONE | Free fns + `Copy` enum; NO `dyn`, NO trait object, NO new trait. afxdp's single trait is untouched. |
+
+## Test plan
+
+- `cargo build --release` clean.
+- `cargo test --release` full userspace-dp suite (incl. existing
+  `simd_checksum_tests` parity / one's-complement-wrap + `frame/tests.rs`
+  checksum tests) green.
+- **New unit tests** in `checksum.rs` test module:
+  - `l4_checksum_field_delta` returns 16/6/None for v4 TCP/UDP/ICMP and
+    16/6/2/None for v6 TCP/UDP/ICMPV6.
+  - `zeroed_checksum_is_illegal` is true for v4 UDP only (false for v4 TCP /
+    v4 ICMP / v4 ICMPV6); true for v6 UDP and v6 ICMPV6 (false for v6 TCP).
+  - End-to-end: an `adjust_l4_checksum_ipv6` call on an ICMPv6 packet whose
+    adjusted checksum computes to 0 yields `0xFFFF` (the regression the
+    #1669 trap warns about); the matching v4-UDP-only behavior verified by
+    showing a v4 ICMP/TCP packet computing to 0 is left as 0.
+- 5× flake loop on the checksum test module.
+- Go suite (`go test ./...`) — known pre-existing
+  `pkg/dataplane/userspace` sandbox unix-socket failures proven
+  pre-existing on master before claiming green.
+- **No cluster smoke required:** this is a pure offset-computation /
+  guard-derivation refactor with no datapath behavior change; the existing
+  checksum parity tests + new per-protocol/zero-checksum unit tests cover
+  the change. Confirm coverage in the PR body.
+
+## Out of scope (explicitly)
+
+- Class B `recompute_l4_checksum_ipv4` / `_ipv6` (sites 6, 7) — full
+  recompute, not offset-lookup; touching them is churn without dedup.
+- Any change to `checksum16*` arithmetic, SIMD path, or pseudo-header fns.
+- Any public API / visibility change.
+
+## Open questions for adversarial review
+
+1. **`family` enum vs split free fns.** Is the `ChecksumFamily` enum the
+   right call, or do two pairs of family-specific free fns
+   (`l4_checksum_field_delta_v4/_v6`) read cleaner and remove the enum?
+   The enum keeps the TCP/UDP deltas single-source; split fns re-duplicate
+   them. Which wins?
+2. **Is the dedup worth it at all?** 5 sites, ~25-35 LOC saved, zero perf.
+   Is this over-abstraction (PLAN-KILL) or a genuine maintainability win
+   (the offset table now lives in one place)?
+3. **Site-3 `current == 0` early-skip rewrite.** Is reusing
+   `zeroed_checksum_is_illegal(_, V4)` for the pre-adjust skip correct, or
+   does conflating the "incoming had no checksum" skip with the
+   "computed-to-zero illegal" fixup obscure two distinct concerns? Keep a
+   literal `protocol == PROTO_UDP` there instead?
+4. **Site-5 `40 + delta` vs literal constants.** Does replacing `56/46/42`
+   with `40usize.checked_add(delta)?` improve or harm clarity, given the
+   `#[inline(always)]` hot-path-adjacent annotation on that fn? Any codegen
+   concern from the extra `checked_add` on a const base?
+5. **Class B exclusion.** Is leaving `recompute_*` untouched correct, or
+   should the offset literals there also consume the delta helper for
+   consistency even though it doesn't reduce the match?
+6. **`None` → `Some(())` mapping.** Is mapping the helper's `None` to
+   `return Some(())` at each call site clear enough, or does it risk a
+   future caller treating `None` as a hard error? Should the helper's
+   contract be documented to forbid that?

--- a/userspace-dp/src/afxdp/frame/checksum.rs
+++ b/userspace-dp/src/afxdp/frame/checksum.rs
@@ -19,6 +19,76 @@
 use crate::afxdp::{PROTO_ICMPV6, PROTO_TCP, PROTO_UDP};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+/// Address family for the L4 checksum-offset / zero-checksum helpers.
+/// Only ever passed as a compile-time-literal at the call sites, so the
+/// `#[inline(always)]` helpers fold the match to a constant.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ChecksumFamily {
+    V4,
+    V6,
+}
+
+/// Per-protocol delta of the L4 checksum field from the start of the IPv4
+/// L4 header (add the IPv4 IHL to get the packet offset). `None` => the
+/// protocol carries no L4 checksum field this module adjusts (IPv4 ICMP,
+/// IPv4 protocol 58, unknown) → the caller no-ops with `Some(())`.
+///
+/// NOTE: there is deliberately NO `PROTO_ICMPV6` arm here. IPv4 packets
+/// never carry ICMPv6, and the IPv4 NAT adjust paths call the v4 helpers
+/// without protocol filtering, so a stray ICMPv6 arm would adjust at
+/// `ihl + 2` for protocol 58 instead of no-op'ing — a live behavior change.
+#[inline(always)]
+fn l4_checksum_field_delta_v4(protocol: u8) -> Option<usize> {
+    match protocol {
+        PROTO_TCP => Some(16),
+        PROTO_UDP => Some(6),
+        _ => None,
+    }
+}
+
+/// Per-protocol delta of the L4 checksum field from the start of the IPv6
+/// L4 header (add the fixed 40-byte IPv6 header to get the packet offset).
+/// `None` => no adjusted L4 checksum field (unknown) → caller no-ops.
+#[inline(always)]
+fn l4_checksum_field_delta_v6(protocol: u8) -> Option<usize> {
+    match protocol {
+        PROTO_TCP => Some(16),
+        PROTO_UDP => Some(6),
+        PROTO_ICMPV6 => Some(2),
+        _ => None,
+    }
+}
+
+/// Whether a received IPv4 UDP datagram carries an OPTIONAL checksum that
+/// may legitimately be 0x0000 (RFC 768 — the checksum is optional for IPv4
+/// UDP and 0x0000 means "no checksum was computed"). The incremental-adjust
+/// path must NOT fabricate a checksum for such a packet, so it skips.
+///
+/// This is a DISTINCT concept from `adjust_zero_checksum_illegal` (which
+/// canonicalizes a freshly-computed 0x0000 to 0xFFFF). It is intentionally
+/// kept as its own predicate so the two RFC concepts are not conflated.
+#[inline(always)]
+fn l4_udp_checksum_optional(protocol: u8) -> bool {
+    protocol == PROTO_UDP
+}
+
+/// Whether a freshly-computed L4 checksum of 0x0000 must be canonicalized
+/// to 0xFFFF on the INCREMENTAL-ADJUST sites. IPv4: UDP only. IPv6: UDP and
+/// ICMPv6 (RFC 2460 §8.1 / RFC 8200 forbid a transmitted 0x0000 for both,
+/// since 0x0000 has the "no checksum" meaning for IPv4 UDP).
+///
+/// SCOPE: this describes the incremental `adjust_l4_checksum_*` sites ONLY.
+/// It deliberately does NOT describe `recompute_l4_checksum_ipv6`, whose
+/// ICMPv6 arm writes the raw sum without canonicalizing 0 → 0xFFFF — a
+/// pre-existing asymmetry this module preserves and does not unify here.
+#[inline(always)]
+fn adjust_zero_checksum_illegal(protocol: u8, family: ChecksumFamily) -> bool {
+    match family {
+        ChecksumFamily::V4 => protocol == PROTO_UDP,
+        ChecksumFamily::V6 => matches!(protocol, PROTO_UDP | PROTO_ICMPV6),
+    }
+}
+
 pub(in crate::afxdp) fn checksum16(bytes: &[u8]) -> u16 {
     checksum16_finish(checksum16_add_bytes(0, bytes))
 }
@@ -275,18 +345,18 @@ pub(in crate::afxdp) fn adjust_l4_checksum_ipv4(
     old_dst: Ipv4Addr,
     new_dst: Ipv4Addr,
 ) -> Option<()> {
-    let checksum_offset = match protocol {
-        PROTO_TCP => ihl.checked_add(16)?,
-        PROTO_UDP => ihl.checked_add(6)?,
-        _ => return Some(()),
+    let delta = match l4_checksum_field_delta_v4(protocol) {
+        Some(d) => d,
+        None => return Some(()),
     };
+    let checksum_offset = ihl.checked_add(delta)?;
     let current = u16::from_be_bytes([
         *packet.get(checksum_offset)?,
         *packet.get(checksum_offset + 1)?,
     ]);
     let mut updated = checksum16_adjust(current, &ipv4_words(old_src), &ipv4_words(new_src));
     updated = checksum16_adjust(updated, &ipv4_words(old_dst), &ipv4_words(new_dst));
-    if matches!(protocol, PROTO_UDP) && updated == 0 {
+    if adjust_zero_checksum_illegal(protocol, ChecksumFamily::V4) && updated == 0 {
         updated = 0xffff;
     }
     packet
@@ -304,19 +374,18 @@ pub(in crate::afxdp) fn adjust_l4_checksum_ipv6(
     old_dst: Ipv6Addr,
     new_dst: Ipv6Addr,
 ) -> Option<()> {
-    let checksum_offset = match protocol {
-        PROTO_TCP => 40usize.checked_add(16)?,
-        PROTO_UDP => 40usize.checked_add(6)?,
-        PROTO_ICMPV6 => 40usize.checked_add(2)?,
-        _ => return Some(()),
+    let delta = match l4_checksum_field_delta_v6(protocol) {
+        Some(d) => d,
+        None => return Some(()),
     };
+    let checksum_offset = 40usize.checked_add(delta)?;
     let current = u16::from_be_bytes([
         *packet.get(checksum_offset)?,
         *packet.get(checksum_offset + 1)?,
     ]);
     let mut updated = checksum16_adjust(current, &ipv6_words(old_src), &ipv6_words(new_src));
     updated = checksum16_adjust(updated, &ipv6_words(old_dst), &ipv6_words(new_dst));
-    if matches!(protocol, PROTO_UDP | PROTO_ICMPV6) && updated == 0 {
+    if adjust_zero_checksum_illegal(protocol, ChecksumFamily::V6) && updated == 0 {
         updated = 0xffff;
     }
     packet
@@ -364,20 +433,20 @@ pub(in crate::afxdp) fn adjust_l4_checksum_ipv4_words(
     old_words: &[u16],
     new_words: &[u16],
 ) -> Option<()> {
-    let checksum_offset = match protocol {
-        PROTO_TCP => ihl.checked_add(16)?,
-        PROTO_UDP => ihl.checked_add(6)?,
-        _ => return Some(()),
+    let delta = match l4_checksum_field_delta_v4(protocol) {
+        Some(d) => d,
+        None => return Some(()),
     };
+    let checksum_offset = ihl.checked_add(delta)?;
     let current = u16::from_be_bytes([
         *packet.get(checksum_offset)?,
         *packet.get(checksum_offset + 1)?,
     ]);
-    if matches!(protocol, PROTO_UDP) && current == 0 {
+    if l4_udp_checksum_optional(protocol) && current == 0 {
         return Some(());
     }
     let updated = checksum16_adjust(current, old_words, new_words);
-    let updated = if matches!(protocol, PROTO_UDP) && updated == 0 {
+    let updated = if adjust_zero_checksum_illegal(protocol, ChecksumFamily::V4) && updated == 0 {
         0xffff
     } else {
         updated
@@ -414,18 +483,17 @@ pub(in crate::afxdp) fn adjust_l4_checksum_ipv6_words(
     old_words: &[u16],
     new_words: &[u16],
 ) -> Option<()> {
-    let checksum_offset = match protocol {
-        PROTO_TCP => 40usize.checked_add(16)?,
-        PROTO_UDP => 40usize.checked_add(6)?,
-        PROTO_ICMPV6 => 40usize.checked_add(2)?,
-        _ => return Some(()),
+    let delta = match l4_checksum_field_delta_v6(protocol) {
+        Some(d) => d,
+        None => return Some(()),
     };
+    let checksum_offset = 40usize.checked_add(delta)?;
     let current = u16::from_be_bytes([
         *packet.get(checksum_offset)?,
         *packet.get(checksum_offset + 1)?,
     ]);
     let mut updated = checksum16_adjust(current, old_words, new_words);
-    if matches!(protocol, PROTO_UDP | PROTO_ICMPV6) && updated == 0 {
+    if adjust_zero_checksum_illegal(protocol, ChecksumFamily::V6) && updated == 0 {
         updated = 0xffff;
     }
     packet
@@ -441,18 +509,18 @@ pub(super) fn adjust_l4_checksum_ipv6_addr_bytes(
     old_addr: &[u8; 16],
     new_addr: &[u8; 16],
 ) -> Option<()> {
-    let checksum_offset = match protocol {
-        PROTO_TCP => 56usize,
-        PROTO_UDP => 46usize,
-        PROTO_ICMPV6 => 42usize,
-        _ => return Some(()),
+    let delta = match l4_checksum_field_delta_v6(protocol) {
+        Some(d) => d,
+        None => return Some(()),
     };
+    // 40 + {16,6,2} reproduces the previous absolute constants 56/46/42.
+    let checksum_offset = 40usize.checked_add(delta)?;
     let current = u16::from_be_bytes([
         *packet.get(checksum_offset)?,
         *packet.get(checksum_offset + 1)?,
     ]);
     let mut updated = checksum16_adjust_ipv6_addr_bytes(current, old_addr, new_addr);
-    if matches!(protocol, PROTO_UDP | PROTO_ICMPV6) && updated == 0 {
+    if adjust_zero_checksum_illegal(protocol, ChecksumFamily::V6) && updated == 0 {
         updated = 0xffff;
     }
     packet

--- a/userspace-dp/src/afxdp/frame/checksum.rs
+++ b/userspace-dp/src/afxdp/frame/checksum.rs
@@ -697,3 +697,215 @@ mod simd_checksum_tests {
         assert_eq!(direct, composed);
     }
 }
+
+#[cfg(test)]
+mod l4_offset_helper_tests {
+    use super::*;
+    use crate::afxdp::PROTO_ICMP;
+
+    #[test]
+    fn v4_field_delta_table() {
+        // IPv4: TCP +16, UDP +6. No ICMPv6 arm — IPv4 packets never carry
+        // ICMPv6 and the IPv4 NAT adjust paths call the v4 helper without
+        // protocol filtering, so PROTO_ICMPV6 MUST fall through to None
+        // (no-op), not produce ihl+2.
+        assert_eq!(l4_checksum_field_delta_v4(PROTO_TCP), Some(16));
+        assert_eq!(l4_checksum_field_delta_v4(PROTO_UDP), Some(6));
+        assert_eq!(l4_checksum_field_delta_v4(PROTO_ICMP), None);
+        assert_eq!(l4_checksum_field_delta_v4(PROTO_ICMPV6), None);
+        assert_eq!(l4_checksum_field_delta_v4(0), None);
+    }
+
+    #[test]
+    fn v6_field_delta_table() {
+        // IPv6: TCP +16, UDP +6, ICMPv6 +2.
+        assert_eq!(l4_checksum_field_delta_v6(PROTO_TCP), Some(16));
+        assert_eq!(l4_checksum_field_delta_v6(PROTO_UDP), Some(6));
+        assert_eq!(l4_checksum_field_delta_v6(PROTO_ICMPV6), Some(2));
+        assert_eq!(l4_checksum_field_delta_v6(PROTO_ICMP), None);
+        assert_eq!(l4_checksum_field_delta_v6(0), None);
+    }
+
+    #[test]
+    fn v6_addr_bytes_offsets_match_old_constants() {
+        // adjust_l4_checksum_ipv6_addr_bytes previously hard-coded
+        // 56/46/42; now derived as 40 + delta. Confirm bit-identical.
+        for (proto, want) in [(PROTO_TCP, 56usize), (PROTO_UDP, 46), (PROTO_ICMPV6, 42)] {
+            let delta = l4_checksum_field_delta_v6(proto).expect("v6 proto has delta");
+            assert_eq!(40usize + delta, want, "proto {proto}");
+        }
+    }
+
+    #[test]
+    fn udp_checksum_optional_is_udp_only() {
+        assert!(l4_udp_checksum_optional(PROTO_UDP));
+        assert!(!l4_udp_checksum_optional(PROTO_TCP));
+        assert!(!l4_udp_checksum_optional(PROTO_ICMPV6));
+        assert!(!l4_udp_checksum_optional(PROTO_ICMP));
+    }
+
+    #[test]
+    fn zero_checksum_illegal_preserves_v4_v6_asymmetry() {
+        // The #1669 trap: IPv4 canonicalizes UDP zero only; IPv6
+        // canonicalizes BOTH UDP and ICMPv6 zero. A blind unify would
+        // break ICMPv6.
+        // IPv4: UDP only.
+        assert!(adjust_zero_checksum_illegal(PROTO_UDP, ChecksumFamily::V4));
+        assert!(!adjust_zero_checksum_illegal(PROTO_TCP, ChecksumFamily::V4));
+        assert!(!adjust_zero_checksum_illegal(
+            PROTO_ICMPV6,
+            ChecksumFamily::V4
+        ));
+        assert!(!adjust_zero_checksum_illegal(
+            PROTO_ICMP,
+            ChecksumFamily::V4
+        ));
+        // IPv6: UDP and ICMPv6.
+        assert!(adjust_zero_checksum_illegal(PROTO_UDP, ChecksumFamily::V6));
+        assert!(adjust_zero_checksum_illegal(
+            PROTO_ICMPV6,
+            ChecksumFamily::V6
+        ));
+        assert!(!adjust_zero_checksum_illegal(PROTO_TCP, ChecksumFamily::V6));
+        assert!(!adjust_zero_checksum_illegal(
+            PROTO_ICMP,
+            ChecksumFamily::V6
+        ));
+    }
+
+    /// Build a minimal IPv4 + L4 frame (no Ethernet) for adjust tests.
+    /// `proto` goes in the IPv4 protocol byte; src/dst at the usual
+    /// offsets. Returns a 60-byte buffer (20 IHL + 40 payload room).
+    fn ipv4_frame(proto: u8) -> Vec<u8> {
+        let mut p = vec![0u8; 60];
+        p[0] = 0x45; // version 4, IHL 5
+        p[9] = proto;
+        // src 10.0.0.1, dst 10.0.0.2
+        p[12..16].copy_from_slice(&[10, 0, 0, 1]);
+        p[16..20].copy_from_slice(&[10, 0, 0, 2]);
+        p
+    }
+
+    #[test]
+    fn ipv4_proto_58_is_noop_not_adjusted() {
+        // Regression guard (Codex r2 #2): an IPv4 packet with protocol 58
+        // (ICMPv6 number) must hit the helper's None arm and no-op via
+        // Some(()), NOT adjust the bytes at ihl+2. Verify the packet is
+        // untouched.
+        let mut p = ipv4_frame(PROTO_ICMPV6);
+        let before = p.clone();
+        let r = adjust_l4_checksum_ipv4(
+            &mut p,
+            20,
+            PROTO_ICMPV6,
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 1, 1, 1),
+            Ipv4Addr::new(10, 0, 0, 2),
+            Ipv4Addr::new(10, 2, 2, 2),
+        );
+        assert_eq!(r, Some(()));
+        assert_eq!(p, before, "IPv4 proto-58 must not be adjusted");
+
+        // Same for the *_words and *_src/_dst entry points.
+        let mut p = ipv4_frame(PROTO_ICMPV6);
+        let before = p.clone();
+        assert_eq!(
+            adjust_l4_checksum_ipv4_src(
+                &mut p,
+                20,
+                PROTO_ICMPV6,
+                Ipv4Addr::new(10, 0, 0, 1),
+                Ipv4Addr::new(10, 1, 1, 1),
+            ),
+            Some(())
+        );
+        assert_eq!(p, before, "IPv4 proto-58 (_src) must not be adjusted");
+    }
+
+    #[test]
+    fn ipv4_recognized_proto_overflow_returns_none() {
+        // Regression guard (Codex r2 #1): a recognized protocol (TCP/UDP)
+        // with an IHL so large that ihl.checked_add(delta) overflows usize
+        // must return None (failure), NOT Some(()) (no-op success). The
+        // helper returns Some(delta) for the recognized proto; the
+        // overflow is caught by the call-site `?` on checked_add.
+        let mut p = ipv4_frame(PROTO_TCP);
+        assert_eq!(
+            adjust_l4_checksum_ipv4(
+                &mut p,
+                usize::MAX,
+                PROTO_TCP,
+                Ipv4Addr::new(10, 0, 0, 1),
+                Ipv4Addr::new(10, 1, 1, 1),
+                Ipv4Addr::new(10, 0, 0, 2),
+                Ipv4Addr::new(10, 2, 2, 2),
+            ),
+            None,
+            "recognized-proto overflow must propagate as None failure"
+        );
+        // Unsupported proto with the same overflowing ihl must still no-op
+        // (it returns Some(()) before ever touching checked_add).
+        let mut p = ipv4_frame(PROTO_ICMP);
+        assert_eq!(
+            adjust_l4_checksum_ipv4(
+                &mut p,
+                usize::MAX,
+                PROTO_ICMP,
+                Ipv4Addr::new(10, 0, 0, 1),
+                Ipv4Addr::new(10, 1, 1, 1),
+                Ipv4Addr::new(10, 0, 0, 2),
+                Ipv4Addr::new(10, 2, 2, 2),
+            ),
+            Some(()),
+            "unsupported proto must no-op regardless of ihl"
+        );
+    }
+
+    #[test]
+    fn ipv6_icmpv6_zero_canonicalizes_to_ffff() {
+        // The #1669-trap end-to-end check: an ICMPv6 packet whose adjusted
+        // checksum computes to 0 must be written as 0xFFFF, not 0x0000.
+        // Construct an IPv6 frame and choose the stored checksum + address
+        // delta so the incremental adjust lands on 0.
+        //
+        // adjust_l4_checksum_ipv6_words computes:
+        //   updated = checksum16_adjust(current, old_words, new_words)
+        // We want updated == 0. Pick old_words == new_words so the adjust
+        // is identity: updated = current. Then set the stored checksum so
+        // that the "current" read at offset 42 is 0 — but a stored 0 read
+        // would already be 0 and identity-adjust keeps it 0, triggering
+        // the canonicalization to 0xFFFF.
+        let mut p = vec![0u8; 60];
+        p[6] = PROTO_ICMPV6; // next-header
+        // ICMPv6 checksum field is at 40 + 2 = 42. Start it at 0.
+        p[42] = 0;
+        p[43] = 0;
+        let same = ipv6_words(Ipv6Addr::LOCALHOST);
+        let r = adjust_l4_checksum_ipv6_words(&mut p, PROTO_ICMPV6, &same, &same);
+        assert_eq!(r, Some(()));
+        // current=0, identity adjust -> 0, canonicalized -> 0xffff.
+        assert_eq!(
+            u16::from_be_bytes([p[42], p[43]]),
+            0xffff,
+            "ICMPv6 computed-zero must canonicalize to 0xffff"
+        );
+    }
+
+    #[test]
+    fn ipv4_tcp_zero_not_canonicalized() {
+        // Counterpart: IPv4 TCP computing to 0 is left as 0 (only IPv4 UDP
+        // canonicalizes on v4). Identity-adjust a stored-0 TCP checksum.
+        let mut p = ipv4_frame(PROTO_TCP);
+        // TCP checksum at ihl + 16 = 36. Start at 0.
+        p[36] = 0;
+        p[37] = 0;
+        let same = ipv4_words(Ipv4Addr::new(10, 0, 0, 1));
+        let r = adjust_l4_checksum_ipv4_words(&mut p, 20, PROTO_TCP, &same, &same);
+        assert_eq!(r, Some(()));
+        assert_eq!(
+            u16::from_be_bytes([p[36], p[37]]),
+            0,
+            "IPv4 TCP computed-zero must NOT canonicalize"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Dedup the five duplicated `match protocol { TCP/UDP[/ICMPv6] => offset }`
blocks in `userspace-dp/src/afxdp/frame/checksum.rs` into statically-
dispatched `#[inline(always)]` free helpers, preserving the IPv4
(UDP-only) vs IPv6 (UDP|ICMPv6) zero-checksum-canonicalization asymmetry
the #1669 §3 triage flagged as the trap to avoid. No `dyn`, no trait, no
generics (the #961/#1207 hot-path rule). No public API or behavior change.

`match protocol` sites in the file drop from 7 to 4 (two single-source
offset helpers + the two intentionally-untouched `recompute_l4_checksum_*`
functions).

Closes #1724. References #1669.

## Design (per-family split — NOT a blind unify)

- `l4_checksum_field_delta_v4` (TCP/UDP only, **no** ICMPv6 arm) and
  `l4_checksum_field_delta_v6` (adds ICMPv6 => +2). The v4 helper has no
  ICMPv6 arm so an IPv4 packet carrying protocol 58 still no-ops exactly
  as before — the IPv4 NAT adjust paths call the v4 helpers without
  protocol filtering, so a shared ICMPv6 arm would have changed live
  behavior to adjust at `ihl+2`.
- `checked_add` stays at the call site so recognized-protocol offset
  overflow still propagates as `None` (failure); the helper's `None`
  means only "unsupported protocol", mapped to the no-op `Some(())`.
- Two clearly-named zero-checksum predicates: `l4_udp_checksum_optional`
  (RFC 768 IPv4-UDP "checksum optional, do not fabricate" skip) is kept
  separate from `adjust_zero_checksum_illegal(protocol, family)` (the
  computed-zero -> 0xFFFF canonicalization), which is documented as scoped
  to the incremental-adjust sites only. The pre-existing
  `recompute_l4_checksum_ipv6` ICMPv6 non-canonicalization is left
  untouched.
- The two `recompute_l4_checksum_*` functions (full recompute with
  distinct per-protocol min-length checks + field zeroing) are
  intentionally NOT folded in — they don't share the offset-lookup shape.

## Plan + adversarial review

Plan doc: `docs/pr/1724-checksum-offset-helper/plan.md`

- Codex plan-review: r1 PLAN-NEEDS-MINOR, r2 PLAN-NEEDS-MAJOR (found two
  real correctness bugs in the v3 family-independent helper), r3
  PLAN-NEEDS-MINOR (both bugs fixed by design; asked for the overflow/
  proto-58 regression tests, now added).
- AGY adversarial plan-review: r1 PLAN-KILL (LOC-negative payoff on the
  early shape), r2 PLAN-READY (KILL lifted) — independently flagged the
  same two issues Codex blocked on, which v4 fixes.
- Claude SMR: independently verified the proto-58 and overflow hazards
  and the v4/v6 canonicalization asymmetry against the source.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release`: full suite green (1649 lib tests + 9 new)
- [x] 9 new unit tests: per-family offset tables, `40+delta == 56/46/42`,
      v4/v6 zero-checksum asymmetry, IPv4-proto-58 no-op regression,
      recognized-proto-overflow-returns-None regression, ICMPv6 computed-
      zero -> 0xFFFF end-to-end, IPv4 TCP zero left unchanged
- [x] 5/5 flake-clean on the checksum tests
- [x] Go suite green except the known `pkg/dataplane/userspace`
      sandbox unix-socket `bind: invalid argument` failures — **proven
      pre-existing**: the identical failures reproduce on a clean master
      checkout, and this PR touches only Rust (`checksum.rs`), which
      cannot affect Go `pkg/dataplane/userspace`.

## No cluster smoke

This is a pure offset-computation / guard-derivation refactor with no
datapath behavior change. The existing SIMD/one's-complement parity tests
plus the 9 new per-protocol/zero-checksum/regression unit tests cover the
change end-to-end (including the exact `56/46/42` offsets and the v4/v6
canonicalization asymmetry). Per the issue's own guidance, no cluster
smoke is required when the checksum unit/parity tests cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)