### PR TITLE
#1733 Phase 1: hard-reject equal-flow-enforcement above 32 workers

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4512,3 +4512,29 @@ top.
   divided-ceiling regression floor; >=95% guarantee stays SOLO (#1630).
 - **File(s)**: docs/fairness-regimes.md, test/incus/cos-simul-load-smoke.sh,
   docs/pr/1614-multi-rss-cos/plan.md
+
+## #1733 Phase 1 — hard-reject workers>32 + equal-flow (lenient on load/sync)
+- **Timestamp**: 2026-05-31
+- **Action**: Add validateEqualFlowWorkerCapStrict + MaxEqualFlowWorkers
+  const (mirrors rotate_epoch_v8.rs MAX_WORKERS_SCRATCH=32); wire into the
+  #1538 strict-validator accumulator. Commit-time hard-reject of
+  workers>32 with any equal-flow-enforcement scheduler (was a silent
+  release-build runtime fail-open).
+- **File(s)**: pkg/config/compiler.go,
+  pkg/config/compiler_equal_flow_worker_cap_test.go
+- **Action**: Lenient compile mode (CompileConfigLenient /
+  CompileConfigForNodeLenient + Store.compileTreeLenient) used ONLY by
+  Store.Load + Store.SyncApply so an upgraded node boots / HA sync
+  converges on a legacy config (downgrade reject -> cfg.Warnings + WARN,
+  no AST mutation). Effective workers computed by the real compiler =>
+  no false-strip on ${node}/group/split-stanza configs (round-2 fix).
+- **File(s)**: pkg/config/compiler.go, pkg/configstore/store.go,
+  pkg/configstore/equal_flow_worker_cap.go,
+  pkg/configstore/equal_flow_worker_cap_test.go
+- **Action**: Switch read-only peer-interface active-tree re-compiles to
+  CompileConfigForNodeLenient so a tolerated legacy active config does not
+  silently drop peer-interface display (round-3 Codex+AGY converged).
+- **File(s)**: pkg/cli/cli_show_interfaces.go,
+  pkg/grpcapi/server_show_interfaces.go
+- **Action**: Document the 32-worker equal-flow cap + tolerance behavior.
+- **File(s)**: docs/cos-traffic-shaping.md

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -892,6 +892,24 @@ Notes for this specific test:
   throughput can drop substantially when one active worker is much slower than
   its peers. The suppressor fails open when an active worker looks merely quiet
   rather than demand-saturated.
+- **`equal-flow-enforcement` is supported on at most 32 worker threads**
+  (`set system dataplane workers <= 32`). The v8 lease rotation samples
+  per-worker state from a 32-entry stack scratch
+  (`MAX_WORKERS_SCRATCH` in
+  `userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs`); above
+  32 workers an active worker beyond index 31 makes the publisher fail open
+  with reason `unsampled_active_worker`, silently disabling equal-flow for
+  that epoch. To prevent a silent fairness fail-open, **a `commit` of
+  `workers > 32` together with any `equal-flow-enforcement` scheduler is
+  hard-rejected** (#1733). An already-persisted or HA-peer-synced config in
+  that state is tolerated on load/sync (it boots with a loud warning and
+  the runtime continues to fail-open equal-flow exactly as before) so an
+  upgraded node does not blackout-boot and HA config sync does not
+  alarm-loop; the operator's next `commit` is rejected until they reduce
+  workers or remove `equal-flow-enforcement`. Watch the
+  `xpf_userspace_cos_equal_flow_fail_open{reason="unsampled_active_worker"}`
+  gauge for the runtime fail-open signal. Removing the 32-worker cap
+  entirely is tracked as #1731-e.
 - `loss-priority` on CoS DSCP / 802.1p classifiers is accepted for syntax
   compatibility but is not enforced yet
 - `loss-priority` on CoS DSCP rewrite-rules is accepted for syntax

--- a/docs/cos-traffic-shaping.md
+++ b/docs/cos-traffic-shaping.md
@@ -908,8 +908,10 @@ Notes for this specific test:
   alarm-loop; the operator's next `commit` is rejected until they reduce
   workers or remove `equal-flow-enforcement`. Watch the
   `xpf_userspace_cos_equal_flow_fail_open{reason="unsampled_active_worker"}`
-  gauge for the runtime fail-open signal. Removing the 32-worker cap
-  entirely is tracked as #1731-e.
+  gauge for the runtime fail-open signal, and
+  `xpf_fairness_equal_flow_unsampled_active_workers` for the exact count of
+  active workers that fell outside the sampled scratch. Removing the
+  32-worker cap entirely is tracked as #1731-e.
 - `loss-priority` on CoS DSCP / 802.1p classifiers is accepted for syntax
   compatibility but is not enforced yet
 - `loss-priority` on CoS DSCP rewrite-rules is accepted for syntax

--- a/docs/pr/1733-equal-flow-worker-cap-reject/plan.md
+++ b/docs/pr/1733-equal-flow-worker-cap-reject/plan.md
@@ -1,8 +1,12 @@
 # Plan of Action — #1733 Phase 1: hard-reject `workers > 32` when equal-flow enforcement is enabled
 
-- **Status**: DRAFT v2 — round-1 converged MAJOR (Codex + AGY) folded in:
-  the commit-time reject MUST be paired with a Load/SyncApply rewrite
-  bridge or upgrade/HA-sync blacks out. Section 5.2/5.3 rewritten.
+- **Status**: DRAFT v3 — round-2: AGY PLAN-READY; Codex flagged a
+  semantic-set-parity defect in the v2 AST-walk rewrite (false-strip on
+  `${node}`/split-stanza/group configs whose EFFECTIVE workers ≤32).
+  ADOPTED Codex's cleaner design: a **lenient compile mode** on
+  Load/SyncApply that downgrades ONLY this validator to a loud warning
+  (no AST mutation, effective workers computed once by the real compiler).
+  §5.2 rewritten; AGY's log-phrasing minor folded in as the warning text.
 - **Issue**: #1733 (sub-issue of #1731; research plan
   `research/1731-cos-mqfq-generalize:docs/research/1731-cos-mqfq-generalize/plan.md` §4.3)
 - **Base**: master `c9e552689` (canary-green #1723 lineage; latest merge #1730)
@@ -32,11 +36,11 @@ count is parsed by `compiler_system.go:443-446` (`strconv.Atoi`, no max) and
 `commit`/`commit check` time — hard-reject when
 `workers > 32 AND any scheduler has equal-flow-enforcement` — instead of
 fail-opening silently at runtime in release. Pair the commit-time reject
-with a **Load/SyncApply rewrite bridge** (mirroring
-`rewriteRetiredDataplaneType`) so a legacy persisted/peer-synced config
-does NOT black out daemon boot or break HA sync. Plus surface the existing
-dataplane fail-open-reason gauge as the runtime visibility for the
-condition.
+with a **lenient compile mode** on `Store.Load` / `Store.SyncApply` that
+downgrades ONLY this one validator to a loud `cfg.Warnings` entry (+ WARN
+log) so a legacy persisted/peer-synced config does NOT black out daemon
+boot or break HA sync. Plus surface the existing dataplane
+fail-open-reason gauge as the runtime visibility for the condition.
 
 **Out of scope / deferred to #1731-e:** removing the 32 cap by replacing
 the stack-scratch arrays with reusable heap scratch owned by `V8State`.
@@ -162,61 +166,70 @@ if err := validateEqualFlowWorkerCapStrict(cfg); err != nil {
 `validatePolicySchedulerReferencesStrict` reading `cfg.Security` directly;
 `cfg.System.UserspaceDataplane` is the only pointer hop, nil-guarded above.
 
-### 5.2 Load/SyncApply rewrite bridge (round-1 MAJOR — REQUIRED)
+### 5.2 Lenient compile mode on Load/SyncApply (round-1 MAJOR + round-2 parity fix)
 
-**The round-1 fatal (Codex + AGY converged):** my v1 claimed a legacy
+**Round-1 fatal (Codex + AGY converged):** my v1 claimed a legacy
 `workers>32 + equal-flow` config is "NOT auto-rejected at `Store.Load`".
-That is FALSE and verified false: `Store.Load()` (`configstore/store.go:105`)
-and `Store.SyncApply()` (`:222`) both call `s.compileTree(tree)` →
-`CompileConfig`/`CompileConfigForNode` → `compileExpanded` → the strict
-accumulator. Wiring the reject into the accumulator ALONE would, on a node
-upgraded past this gate:
-- fail `Store.Load()` at boot → daemon runs with nil active config (blind);
-- fail `Store.SyncApply()` on an upgraded standby receiving a >32+equal-flow
-  config from an un-upgraded primary → HA config-sync alarm loop.
+FALSE and verified: `Store.Load()` (`configstore/store.go:105`) and
+`Store.SyncApply()` (`:222`) both call `s.compileTree(tree)` ->
+`CompileConfig`/`CompileConfigForNode` -> `compileExpanded` -> the strict
+accumulator. A bare accumulator reject would blackout boot + break HA sync.
 
-**Fix — mirror `rewriteRetiredDataplaneType` (`configstore/dataplane_retire.go`).**
-Add `rewriteEqualFlowOverWorkerCap(tree, caller)` invoked AFTER parse,
-BEFORE compile, in BOTH `Store.Load()` (after the existing
-`rewriteRetiredDataplaneType(tree, LoadCaller)` at `store.go:103`) and
-`Store.SyncApply()` (after `:214`'s retired rewrite, `SyncCaller`). It:
-1. Discovers the effective worker count by walking
-   `system { dataplane { ... } }` for a `workers` leaf, handling BOTH AST
-   shapes verified empirically:
-   - normal: `dataplane` -> leaf `Keys:["workers","N"]`;
-   - redundant `set system dataplane userspace workers N`
-     (`compiler_system.go:415-436`): `dataplane` -> leaf
-     `Keys:["userspace","workers","N"]` (3-key leaf — the walk must match
-     a `workers` token anywhere in the dataplane leaf keys, not only
-     `Keys[0]=="workers"`).
-   Walk top-level AND `groups { <g> { system {...} } }` nesting — reuse the
-   existing `systemBlocksOf` / `groupsBlocksOf` / `systemBlocksOfNode`
-   helpers in `dataplane_retire.go`. Absent `workers` leaf => effective
-   count 1 (`lifecycle.rs:257`) => rewrite is a no-op.
-2. If `workers > MaxEqualFlowWorkers`, strip every
-   `equal-flow-enforcement` leaf (AST shape verified: `class-of-service`
-   -> `schedulers <name>` -> leaf `Keys:["equal-flow-enforcement"]`) from
-   both top-level and grouped `class-of-service` stanzas, logging one
-   `slog.Warn` per strip with caller-specific remediation.
+**Round-2 refinement (Codex):** my v2 proposed an AST-walk rewrite that
+strips `equal-flow-enforcement` when a raw-tree `workers` leaf > 32. That
+has a **semantic-set-parity defect**: the raw AST walk does NOT replicate
+the compiler's effective-config computation. `CompileConfig` /
+`CompileConfigForNode` run `ExpandGroups`/`ExpandGroupsWithVars` BEFORE
+`compileExpanded` (`compiler.go:51,82`). So a config like
+`groups { node0 { system dataplane workers 64 } }` + `apply-groups
+"${node}"` + equal-flow has EFFECTIVE workers 64 only on node0; on node1 it
+is the default (≤32). A raw walk would **false-strip** equal-flow on node1
+(and on a generic non-node compile). The validator, by contrast, sees the
+correctly-expanded per-node effective config and would NOT reject node1.
+Threshold-constant parity does not fix this — it is *worker-discovery*
+parity that is broken, and re-implementing group expansion in the rewrite
+is exactly the duplication that would drift.
 
-**Why stripping equal-flow is the behaviorally-correct rewrite (not a
-silent override):** a legacy `workers>32 + equal-flow` config was ALREADY
-fail-opening equal-flow at runtime in release (the exact bug #1733
-documents). Removing the leaf on load therefore *preserves the actual
-running behavior* (equal-flow effectively off), boots clean, and warns —
-precisely analogous to rewriting a retired `dataplane-type` to the
-userspace default. The operator's next `commit` that re-adds equal-flow
-without reducing workers will hard-reject, surfacing the limit.
+**Adopted fix — lenient compile mode (Codex's design).** Add a compile
+variant that runs the IDENTICAL pipeline (same expansion, same node
+context, same effective config) but downgrades ONLY
+`validateEqualFlowWorkerCapStrict` from a hard error to a
+`cfg.Warnings` append + one `slog`-style WARN. Everything else stays
+strict.
 
-Threshold parity: the rewrite uses the SAME `MaxEqualFlowWorkers` constant
-as the commit-time validator, so reject-set and rewrite-set are identical
-by construction (no skew).
+Concretely:
+- Thread a `strictMode` (or a `lenientEqualFlowWorkerCap bool`) through
+  `compileExpanded`: `CompileConfig`/`CompileConfigForNode` (strict, used
+  by candidate commit) keep today's behavior; new
+  `CompileConfigLenient`/`CompileConfigForNodeLenient` set the lenient flag.
+  In `compileExpanded`, when lenient, the equal-flow-worker-cap validator's
+  error is appended to `cfg.Warnings` instead of `strictErrs`.
+- `Store.compileTree` gains a lenient sibling (or a mode arg) used ONLY by
+  `Store.Load()` and `Store.SyncApply()`. Candidate commit / `commit
+  check` (`Store.CommitCheck`/`Commit`/`CommitConfirmed`, which compile
+  `s.candidate` directly — AGY confirmed they do NOT go through Load/Sync)
+  stay strict and hard-reject.
 
-Caller phrasing: reuse the existing `retireRewriteCaller`
-(LoadCaller/SyncCaller) — its local-`commit` vs update-the-primary
-distinction matches this case exactly. (If reuse turns out to couple the
-two rewrites awkwardly at implementation, fall back to a parallel
-two-value enum; the doc comment will cross-reference either way.)
+**Why this is correct and beats the AST rewrite:**
+- The effective worker count is computed ONCE, by the real compiler, with
+  the right node context — zero re-implementation, zero false-strip.
+- A legacy `workers>32 + equal-flow` config loads/sync-applies clean; the
+  equal-flow leaf stays in the typed config and the runtime continues to
+  fail-open it exactly as it does today — *running behavior preserved*,
+  identical to the pre-gate release (the AGY "preserve running behavior"
+  property holds, without mutating the tree).
+- The operator sees the condition via `cfg.Warnings` (surfaced by
+  `show ... | display ... warnings` / commit warnings) and the WARN log;
+  their next candidate commit that keeps the combo hard-rejects.
+
+**Warning text (AGY r2 minor):** do NOT reuse the retired-dataplane
+phrasing. The lenient-path warning is equal-flow-specific, e.g.
+`"system dataplane workers %d exceeds the equal-flow cap of %d: equal-flow
+fairness is silently disabled at runtime; reduce workers or remove
+equal-flow-enforcement (this config was tolerated on load/sync — your next
+commit will be rejected)"`. The Load vs Sync remediation hint differs
+(local `commit` vs update the un-upgraded primary), mirroring
+`retireRewriteCaller.remediation()` but with equal-flow wording.
 
 ### 5.3 Runtime visibility (the "status counter for the fail-open reason")
 
@@ -268,22 +281,25 @@ change (the `equal-flow-enforcement` and `workers` set-paths already exist).
   is untouched. ✓
 - **Load/SyncApply tolerance (round-1 MAJOR)**: a legacy persisted/synced
   `workers>32 + equal-flow` config must NOT blackout-boot or break HA sync;
-  the §5.2 rewrite bridge strips equal-flow (preserving the already-running
-  fail-open behavior) and warns, exactly as `rewriteRetiredDataplaneType`
-  does for retired backends. ✓
-- **Rewrite/reject threshold parity**: both use `MaxEqualFlowWorkers` — the
-  rewrite cannot strip a config the validator would have accepted, nor vice
-  versa. ✓
+  the §5.2 lenient compile mode downgrades ONLY this validator to a warning
+  on Load/Sync so the config loads clean, equal-flow stays in the typed
+  config, and the runtime continues to fail-open it as today. ✓
+- **Effective-config parity (round-2 MAJOR)**: leniency uses the SAME
+  compile pipeline (same group expansion, same node context) as the strict
+  path, so the lenient warning fires on EXACTLY the configs the strict
+  reject would — no false-strip on `${node}`/split-stanza/group configs
+  whose effective workers ≤32. ✓ (This is why AST mutation was rejected.)
 
 ## 8. Risk assessment
 
 | Class | Level | Note |
 |-------|-------|------|
-| Behavioral regression | LOW | Additive validator + load/sync rewrite. The rewrite strips equal-flow only when workers>32 — which was already fail-opening at runtime — so running behavior is preserved. Valid configs (<=32 workers, or equal-flow absent) compile unchanged. |
-| Upgrade / HA-sync regression | MED→LOW | Round-1 MAJOR: bare accumulator reject would blackout boot + break sync. MITIGATED by the §5.2 Load/SyncApply rewrite bridge mirroring the proven `rewriteRetiredDataplaneType` pattern. Must be covered by configstore tests (§9). |
+| Behavioral regression | LOW | Additive validator + lenient Load/Sync mode. On load the equal-flow leaf is untouched and the runtime fail-opens it as today — running behavior preserved. Valid configs (<=32 effective workers, or equal-flow absent) compile unchanged. |
+| Upgrade / HA-sync regression | MED→LOW | Round-1 MAJOR: bare accumulator reject would blackout boot + break sync. MITIGATED by §5.2 lenient compile mode (downgrade-to-warning on Load/SyncApply only). Covered by configstore + compiler tests (§9). |
+| False-strip / semantic-parity | round-2 MAJOR → RESOLVED | The v2 AST-walk could false-strip equal-flow on `${node}`/group configs whose effective workers ≤32. ELIMINATED by computing effective workers via the real compiler in lenient mode (no separate worker-discovery). |
 | Lifetime / borrow | N/A (Go) | No Rust change. |
-| Performance regression | NONE | Validator runs once per `commit`, O(schedulers); rewrite once per Load/SyncApply, O(tree). No hot-path touch. |
-| Architectural mismatch | LOW | Locus is the established `*Config`-scoped strict-validator pattern (`validatePolicySchedulerReferencesStrict`) + the established Load/SyncApply rewrite-bridge pattern (`rewriteRetiredDataplaneType`). Both are precedented in-tree. |
+| Performance regression | NONE | Validator runs once per compile, O(schedulers). No hot-path touch, no extra tree walk. |
+| Architectural mismatch | LOW | Lenient-compile-mode + `*Config`-scoped strict validator are both standard control-plane patterns. No AST mutation of stored config. |
 
 ## 9. Test plan
 
@@ -303,13 +319,21 @@ change (the `equal-flow-enforcement` and `workers` set-paths already exist).
   four-validator accumulation OR add a dedicated accumulation assertion so
   a silent removal of the new append is caught (same rationale as the
   comment at `compiler_test.go:168-186`).
-- **Load/SyncApply rewrite tests** (`pkg/configstore`, mirroring
-  `TestRewriteRetiredDataplaneType`): assert that a tree with
-  `workers 33` + `equal-flow-enforcement` (a) loads/sync-applies WITHOUT a
-  compile error (no blackout), (b) has the `equal-flow-enforcement` leaf
-  stripped post-rewrite, (c) leaves equal-flow intact when `workers <= 32`,
-  (d) covers the `groups { ... }`-nested workers + CoS shape. This is the
-  regression gate for the round-1 MAJOR.
+- **Lenient-mode compiler tests** (`pkg/config`): assert
+  `CompileConfigLenient` on `workers 33` + equal-flow returns NO error,
+  with a `cfg.Warnings` entry naming the cap; and that strict
+  `CompileConfig` on the SAME tree returns the hard error. Boundary:
+  `workers 32` + equal-flow → no warning, no error in both modes.
+- **Semantic-parity test (round-2 MAJOR gate)** (`pkg/config`): a config
+  with `workers 64` inside `groups { node0 { ... } }` + `apply-groups
+  "${node}"` + equal-flow — `CompileConfigForNode(tree, 1)` (node1, group
+  not applied) must NOT warn/reject (effective workers ≤32), while
+  `CompileConfigForNode(tree, 0)` (node0) lenient-warns and strict-rejects.
+  This is the test that an AST-walk rewrite would have failed.
+- **Store Load/SyncApply tests** (`pkg/configstore`): assert a persisted /
+  peer-synced `workers 33` + equal-flow config loads / sync-applies WITHOUT
+  error (no blackout) and produces a warning; and that a `workers 32` +
+  equal-flow config is unaffected. Regression gate for round-1 MAJOR.
 - **Go suite**: `go test ./...` (30 packages) green.
 - **Cargo lease tests** (regression, no code change):
   `cargo test --release -p userspace-dp shared_cos_lease` (the
@@ -327,47 +351,53 @@ change (the `equal-flow-enforcement` and `workers` set-paths already exist).
 - A new Prometheus counter (the existing reason-labelled
   `xpf_userspace_cos_equal_flow_fail_open` gauge already covers runtime
   visibility).
-- Auto-reducing workers or any silent config mutation OTHER than the
-  load/sync equal-flow strip (which only matches the already-running
-  fail-open behavior).
+- Auto-reducing workers or any config MUTATION on load/sync. The lenient
+  mode does NOT mutate the tree — it only downgrades the validator verdict.
 - Mirroring the reject in `lifecycle.rs` arg-parse (the daemon receives an
   already-validated config from the control plane; double-validating in the
-  helper is redundant — see Open Question Q2).
+  helper is redundant).
 
-## 11. Open questions for adversarial review (round-2)
+## 11. Open questions for adversarial review (round-3)
 
-Round-1 RESOLVED (verified, see §): Q-locus — no supported bypass of
-`CompileConfig` (Codex + AGY both confirmed Load/SyncApply/commit all
-route through it). Q-threshold — `> 32` exact, no off-by-one (both
-confirmed: id 32 is first `active_outside_scratch` at len 33). Q-dodge —
-equal-flow already requires transmit-rate exact (`compiler.go:427`),
-cannot slip past. Q-visibility — existing reason-labelled gauge +
-commit-check error + WARN log is sufficient; no new counter. Q-constant —
-hand-synced const with cross-ref accepted (AGY: pragmatic; #1731-e retires
-both); a canary test asserting parity is the cheap insurance (Codex
-suggestion — adopted, see below).
+ROUND-1 RESOLVED (verified): Q-locus — no supported bypass of
+`CompileConfig` (Load/SyncApply/commit all route through it). Q-threshold —
+`> 32` exact (id 32 is first `active_outside_scratch` at len 33). Q-dodge —
+equal-flow already requires transmit-rate exact (`compiler.go:427`).
+Q-visibility — existing reason-labelled gauge + reject error + WARN
+sufficient; no new counter. Q-constant — hand-synced const + parity canary
+test (adopted §9).
 
-Open for round-2:
+ROUND-2 RESOLVED: the v2 AST-walk rewrite is ABANDONED for a semantic-set
+parity defect (false-strip on `${node}`/group/split-stanza configs whose
+effective workers ≤32). Replaced by the lenient-compile-mode design
+(§5.2), which computes effective workers via the real compiler — no
+worker-discovery duplication, no false-strip. AGY's log-phrasing minor
+folded into the warning text.
 
-1. **Rewrite-bridge correctness (the round-1 MAJOR fix)**: is stripping
-   `equal-flow-enforcement` on Load/SyncApply when workers>32 the right
-   rewrite (preserving the already-running fail-open behavior), or should
-   the bridge instead leave equal-flow and reduce/clamp workers? (Belief:
-   strip equal-flow — clamping workers would silently change the dataplane
-   worker topology, a far larger behavioral change than removing a knob
-   that was already a runtime no-op. Mirrors retired-dataplane strip.)
-2. **Rewrite caller reuse**: reuse `retireRewriteCaller` (Load/Sync) vs a
-   new parallel enum — any coupling hazard from reuse?
-3. **Constant-parity canary**: should a Go test assert
-   `MaxEqualFlowWorkers == 32` with a comment pinning it to
-   `rotate_epoch_v8.rs:71`'s `MAX_WORKERS_SCRATCH` (Codex r1 suggestion)?
-   (Belief: yes — cheap, catches a future Rust-side bump that forgets Go.
-   Adopted in §9.)
-4. **Worker-count discovery in the rewrite**: the rewrite reads `workers`
-   from the AST (pre-compile). Are there worker-count forms the AST walk
-   could miss (e.g. `set system dataplane userspace workers N` redundant
-   path at `compiler_system.go:415-436`, or split `system` stanzas)? The
-   walk must cover the same shapes `compileUserspaceDataplane` accepts.
-5. **Default-workers semantics in the rewrite**: if no `workers` leaf is
-   present, the effective count is 1 (`lifecycle.rs:257`), so the rewrite
-   is a no-op — confirm the walk treats "absent" as <=32, never as >32.
+Open for round-3:
+
+1. **Lenient-mode plumbing shape**: is threading a `strictMode` flag /
+   adding `CompileConfigLenient` siblings the cleanest way to downgrade ONE
+   validator, or is there a less invasive hook? (Belief: a single bool
+   threaded into `compileExpanded` that routes this one validator's error
+   to `cfg.Warnings` is minimal and local.)
+2. **Candidate-path strictness**: confirm `CommitCheck`/`Commit`/
+   `CommitConfirmed` compile `s.candidate` WITHOUT the lenient flag so
+   operator edits still hard-reject (AGY confirmed they bypass Load/Sync;
+   re-verify in implementation).
+3. **Rollback path** — RESOLVED in plan: `Store.Rollback` (`store.go:946`)
+   only swaps `s.candidate` (no compile); the compile happens on the
+   subsequent `Commit` (strict). So an operator rolling back to a legacy
+   >32+equal-flow config and committing it correctly gets the hard reject
+   (active operator action, not a passive load). Lenient applies ONLY to
+   `Store.Load` (`:105`) and `Store.SyncApply` (`:222`); `compileTree`
+   stays strict for all commit paths — implement as a separate
+   `compileTreeLenient` rather than a flag on the shared `compileTree`.
+4. **Worker-count source for the validator** — the validator reads the
+   TYPED `cfg.System.UserspaceDataplane.Workers` (post-compile), NOT the
+   AST, so every worker-count form `compileUserspaceDataplane` accepts
+   (normal leaf, redundant `userspace`-prefixed leaf, split `system`
+   stanzas) is already normalized to one int by the compiler. This is the
+   key advantage over the abandoned AST walk: discovery parity is free.
+   Absent `workers` => `cfg.Workers == 0` => `0 <= 32` => no reject (the
+   runtime defaults to 1; 0/absent is correctly treated as ≤cap).

--- a/docs/pr/1733-equal-flow-worker-cap-reject/plan.md
+++ b/docs/pr/1733-equal-flow-worker-cap-reject/plan.md
@@ -1,12 +1,13 @@
 # Plan of Action — #1733 Phase 1: hard-reject `workers > 32` when equal-flow enforcement is enabled
 
-- **Status**: DRAFT v3 — round-2: AGY PLAN-READY; Codex flagged a
-  semantic-set-parity defect in the v2 AST-walk rewrite (false-strip on
-  `${node}`/split-stanza/group configs whose EFFECTIVE workers ≤32).
-  ADOPTED Codex's cleaner design: a **lenient compile mode** on
-  Load/SyncApply that downgrades ONLY this validator to a loud warning
-  (no AST mutation, effective workers computed once by the real compiler).
-  §5.2 rewritten; AGY's log-phrasing minor folded in as the warning text.
+- **Status**: PLAN-READY (v3, round-3 converged). Round-3 Codex + AGY both
+  flagged the SAME final item — read-only peer-display active-tree
+  re-compiles (`cli_show_interfaces.go`, `server_show_interfaces.go`) must
+  be lenient too — now fixed. AGY independently verified all other v3
+  points sound. Design history: v1 (accumulator-only) killed by the
+  Load/SyncApply blackout MAJOR; v2 (AST-walk rewrite) killed by Codex's
+  semantic-set-parity defect; v3 lenient-compile-mode adopted. Implemented
+  + tested; see §9 results.
 - **Issue**: #1733 (sub-issue of #1731; research plan
   `research/1731-cos-mqfq-generalize:docs/research/1731-cos-mqfq-generalize/plan.md` §4.3)
 - **Base**: master `c9e552689` (canary-green #1723 lineage; latest merge #1730)
@@ -289,6 +290,15 @@ change (the `equal-flow-enforcement` and `workers` set-paths already exist).
   path, so the lenient warning fires on EXACTLY the configs the strict
   reject would — no false-strip on `${node}`/split-stanza/group configs
   whose effective workers ≤32. ✓ (This is why AST mutation was rejected.)
+- **Read-only active-tree re-compiles must be lenient (round-3, Codex +
+  AGY converged)**: the peer-interface display paths
+  `cli_show_interfaces.go:577` and `server_show_interfaces.go:436`
+  re-compile the (already lenient-loaded) active tree for the peer node and
+  swallow errors with `if err == nil`. A STRICT re-compile there would now
+  error on a tolerated legacy config and silently drop peer-interface
+  display on a healthy cluster. Both switched to
+  `CompileConfigForNodeLenient`. ✓ (Audited all `config.CompileConfig*`
+  callers — these two are the only non-commit active-tree re-compiles.)
 
 ## 8. Risk assessment
 
@@ -325,11 +335,14 @@ change (the `equal-flow-enforcement` and `workers` set-paths already exist).
   `CompileConfig` on the SAME tree returns the hard error. Boundary:
   `workers 32` + equal-flow → no warning, no error in both modes.
 - **Semantic-parity test (round-2 MAJOR gate)** (`pkg/config`): a config
-  with `workers 64` inside `groups { node0 { ... } }` + `apply-groups
-  "${node}"` + equal-flow — `CompileConfigForNode(tree, 1)` (node1, group
-  not applied) must NOT warn/reject (effective workers ≤32), while
-  `CompileConfigForNode(tree, 0)` (node0) lenient-warns and strict-rejects.
-  This is the test that an AST-walk rewrite would have failed.
+  with `workers 64` inside `groups { node0 { ... } }` + a benign
+  `groups { node1 { ... } }` (no workers) + `apply-groups "${node}"` +
+  equal-flow — `CompileConfigForNode(tree, 1)` (node1, node0 group not
+  applied) must NOT warn/reject (effective workers ≤32), while
+  `CompileConfigForNode(tree, 0)` (node0) strict-rejects and
+  `CompileConfigForNodeLenient(tree, 0)` warns. The benign `node1` group is
+  required so `${node}` expansion for node1 does not error on an undefined
+  group (Codex r3). This is the test an AST-walk rewrite would have failed.
 - **Store Load/SyncApply tests** (`pkg/configstore`): assert a persisted /
   peer-synced `workers 33` + equal-flow config loads / sync-applies WITHOUT
   error (no blackout) and produces a warning; and that a `workers 32` +

--- a/docs/pr/1733-equal-flow-worker-cap-reject/plan.md
+++ b/docs/pr/1733-equal-flow-worker-cap-reject/plan.md
@@ -1,0 +1,278 @@
+# Plan of Action — #1733 Phase 1: hard-reject `workers > 32` when equal-flow enforcement is enabled
+
+- **Status**: DRAFT v1 — pending adversarial plan review
+- **Issue**: #1733 (sub-issue of #1731; research plan
+  `research/1731-cos-mqfq-generalize:docs/research/1731-cos-mqfq-generalize/plan.md` §4.3)
+- **Base**: master `c9e552689` (canary-green #1723 lineage; latest merge #1730)
+- **Scope**: control-plane config validation ONLY. No dataplane behavior
+  change. No removal of the 32-worker cap (that is the deferred #1731-e
+  heap-scratch follow-up).
+
+## 1. Issue framing
+
+`maybe_rotate_epoch_v8` (`userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs:71-79`)
+sizes its per-worker scratch arrays from a compile-time
+`const MAX_WORKERS_SCRATCH: usize = 32`. Worker ids `>= 32` are clamped
+out of the sampled set (`n_workers = len.min(32)`, `:72`) and only guarded
+by a `debug_assert!` (`:73`) that is **stripped in release builds**. When a
+worker beyond index 31 is active, `active_outside_scratch` is set (`:106-107`),
+and `publish_equal_flow_epoch_v8` (`publish_equal_flow_epoch_v8.rs:30-34`)
+takes the `fail_open(UnsampledActiveWorker)` branch and **silently disables
+equal-flow enforcement for the epoch**.
+
+Result: on a 48-/64-core deployment with `equal-flow-enforcement` configured,
+the fairness guarantee the operator asked for is silently NOT enforced —
+a fail-OPEN, not a loud failure. There is no config-time cap: the worker
+count is parsed by `compiler_system.go:443-446` (`strconv.Atoi`, no max) and
+`lifecycle.rs:269-273` (`.max(1)`, no upper bound).
+
+**Phase 1 (this issue):** make the unsupported combination fail LOUDLY at
+`commit`/apply time — hard-reject the config when
+`workers > 32 AND any scheduler has equal-flow-enforcement` — instead of
+fail-opening at runtime in release. Plus surface the existing dataplane
+fail-open-reason counter as the runtime visibility for the (now
+config-unreachable in a supported deploy) condition.
+
+**Out of scope / deferred to #1731-e:** removing the 32 cap by replacing
+the stack-scratch arrays with reusable heap scratch owned by `V8State`.
+This plan does NOT touch `rotate_epoch_v8.rs` or `publish_equal_flow_epoch_v8.rs`
+logic.
+
+## 2. Honest scope / value framing
+
+This is a small, high-certainty correctness/safety fix: it converts a
+silent prod fail-open on high-core boxes into a commit-check rejection the
+operator sees immediately. The "win" is not perf; it is operator-facing
+honesty — the firewall must not accept a config whose fairness contract it
+will silently not honor.
+
+The blast radius is one new strict validator (mirrors the three existing
+ones at `compiler.go:284-293`) and a doc/test touch. There is no hot-path
+change, no allocation change, no HA change.
+
+*If reviewers conclude the perf gain is too small to justify the churn,
+PLAN-KILL is an acceptable verdict.* (Here there is no perf claim at all;
+the kill criterion would instead be "this validator is the wrong locus" or
+"the 32 constant is not actually the supported ceiling".)
+
+## 3. Where worker-count and equal-flow-enable are BOTH known (verified)
+
+- **Worker count**: `cfg.System.UserspaceDataplane.Workers`
+  (`pkg/config/types_system.go:23,44`); set via `set system dataplane workers N`,
+  parsed at `compiler_system.go:443-446`. `UserspaceDataplane` is a pointer,
+  nil when no `dataplane` stanza is present.
+- **Equal-flow-enable**: per-scheduler `EqualFlowEnforcement bool`
+  (`pkg/config/types_cos.go:89`), set via
+  `set class-of-service schedulers <name> equal-flow-enforcement`
+  (`compiler_class_of_service.go:252-253`), validated today by
+  `validateClassOfServiceStrict` (`compiler.go:427-431`) which only sees
+  `cos`, not the system config.
+- **Both reachable from `*Config`**: `validatePolicySchedulerReferencesStrict(cfg *Config)`
+  (`compiler.go:385`) is the existing precedent for a strict validator that
+  takes the WHOLE `*Config`. The cross-cutting worker×equal-flow check needs
+  the same signature because the two facts live in different sub-structs.
+
+**Decision: the locus is a NEW `*Config`-scoped strict validator**, appended
+to the independent strict-validator accumulator in `compileExpanded`
+(`compiler.go:284-293`). It is independent of the other three (reads its
+own two sub-structs, fail-fasts internally), satisfying the documented
+accumulator contract at `compiler.go:270-283`.
+
+## 4. The 32 constant — value provenance
+
+`MAX_WORKERS_SCRATCH = 32` (`rotate_epoch_v8.rs:71`) is the supported
+equal-flow worker ceiling. Per the #1731 plan FACT (§4.3, F4 RESOLVED):
+the 32 cap is PURELY the stack-scratch array sizing — there is NO hidden
+packed-width ceiling (`PackedEpochGrant` encodes tag+byte-grant, not
+worker-id; worker arrays are heap-sized to actual count). So 32 is the
+exact, correct reject threshold for equal-flow, and only equal-flow.
+
+I will introduce a single named Go constant
+`MaxEqualFlowWorkers = 32` in `pkg/config` with a doc comment pointing at
+`rotate_epoch_v8.rs:71` so the two sites are greppable as a pair (and the
+#1731-e follow-up that removes the cap has one Go site to delete).
+
+## 5. Concrete design
+
+### 5.1 Go control-plane hard-reject (the gate)
+
+`pkg/config/compiler.go` — new validator + accumulator wire-up:
+
+```go
+// MaxEqualFlowWorkers is the supported worker ceiling for CoS
+// equal-flow-enforcement. It mirrors MAX_WORKERS_SCRATCH in
+// userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs:71 —
+// above this count the v8 rotation's per-worker stack scratch clamps the
+// sampled set and equal-flow silently fail-opens (UnsampledActiveWorker).
+// Reject loudly at commit instead. Removing this cap (heap scratch) is
+// tracked as #1731-e; this constant and that Rust const must be retired
+// together.
+const MaxEqualFlowWorkers = 32
+
+// validateEqualFlowWorkerCapStrict rejects a config that enables CoS
+// equal-flow-enforcement on more workers than the v8 rotation can sample.
+func validateEqualFlowWorkerCapStrict(cfg *Config) error {
+	if cfg == nil || cfg.ClassOfService == nil {
+		return nil
+	}
+	usd := cfg.System.UserspaceDataplane
+	if usd == nil || usd.Workers <= MaxEqualFlowWorkers {
+		return nil
+	}
+	for _, sched := range cfg.ClassOfService.Schedulers {
+		if sched != nil && sched.EqualFlowEnforcement {
+			return fmt.Errorf(
+				"class-of-service scheduler %q equal-flow-enforcement is unsupported with "+
+					"system dataplane workers %d (max %d); equal-flow fairness silently "+
+					"fail-opens above %d workers — reduce workers or disable "+
+					"equal-flow-enforcement (cap removal tracked as #1731-e)",
+				sched.Name, usd.Workers, MaxEqualFlowWorkers, MaxEqualFlowWorkers)
+		}
+	}
+	return nil
+}
+```
+
+Wire into the accumulator (`compiler.go:284-293`):
+
+```go
+if err := validateEqualFlowWorkerCapStrict(cfg); err != nil {
+	strictErrs = append(strictErrs, err)
+}
+```
+
+`cfg.System` is a value (not pointer) on `*Config` — confirmed by
+`validatePolicySchedulerReferencesStrict` reading `cfg.Security` directly;
+`cfg.System.UserspaceDataplane` is the only pointer hop, nil-guarded above.
+
+### 5.2 Runtime visibility (the "status counter for the fail-open reason")
+
+The dataplane already exposes the fail-open reason end-to-end:
+- Rust: `V8EqualFlowFailOpenReason::UnsampledActiveWorker`
+  (`shared_cos_lease/mod.rs:444`), `fail_open_reason`/`fail_open_count`
+  atomics, accessors `v8_equal_flow_fail_open_reason()` /
+  `v8_equal_flow_fail_open_count()` (tested in `shared_cos_lease_tests.rs`).
+- Go/Prometheus: `cosEqualFlowFailOpen` (`pkg/api/metrics.go:117`) +
+  `fairnessEqualFlowUnsampledActiveWorkers` (`:204`).
+
+So the *runtime* fail-open visibility the issue asks for already exists.
+Phase 1's additional visibility is the **commit-check rejection** itself
+(the loud control-plane failure). I will NOT add a duplicate counter.
+The plan documents this mapping in `docs/` (CoS scheduler doc) so an
+operator who sees `cosEqualFlowFailOpen` incrementing on a legacy stored
+config (workers>32 that predates this gate, replayed on upgrade) knows the
+condition and the fix.
+
+**Stored-config upgrade nuance:** a config with workers>32+equal-flow that
+was committed before this gate exists is now rejected on the next
+`commit`/`commit check`. It is NOT auto-rejected at `Store.Load` (Junos
+candidate semantics — live config stays unchanged). This matches how the
+other strict validators behave and is the intended UX (operator sees the
+error on next edit). Documented explicitly.
+
+### 5.3 No Rust change in Phase 1
+
+`rotate_epoch_v8.rs` / `publish_equal_flow_epoch_v8.rs` are untouched. The
+cargo lease tests are run as a regression gate to prove the existing
+fail-open machinery (the thing we are now preventing in supported configs)
+still behaves, NOT because we modify it.
+
+## 6. Public API preservation
+
+No public API change. New unexported validator + new exported package
+constant `MaxEqualFlowWorkers`. No proto, gRPC, CLI grammar, or schema
+change (the `equal-flow-enforcement` and `workers` set-paths already exist).
+
+## 7. Hidden invariants the change must preserve
+
+- **Accumulator independence** (`compiler.go:270-283`): the new validator
+  reads only `cfg.System.UserspaceDataplane` + `cfg.ClassOfService`, does
+  not depend on another validator's success, fail-fasts internally. ✓
+- **errors.Join framing**: single-error path must stay newline-free
+  (the existing `TestCompileMultipleStrictErrorsAccumulated` pins this).
+  New validator returns a single error like the others. ✓
+- **Nil-safety**: `UserspaceDataplane` pointer + `ClassOfService` pointer +
+  nil scheduler entries all guarded. ✓
+- **Threshold correctness**: reject only `Workers > 32` (strictly greater);
+  exactly 32 is supported (indices 0..31). ✓ (`min(32)` admits 32 workers).
+- **No false reject when equal-flow absent**: the loop requires at least
+  one `EqualFlowEnforcement` scheduler; a 64-worker box with no equal-flow
+  is untouched. ✓
+
+## 8. Risk assessment
+
+| Class | Level | Note |
+|-------|-------|------|
+| Behavioral regression | LOW | Pure additive validator; only rejects a config that today silently misbehaves. Existing valid configs (≤32 workers, or equal-flow absent) compile unchanged. |
+| Lifetime / borrow | N/A (Go) | No Rust change. |
+| Performance regression | NONE | Validator runs once per `commit`, O(schedulers). No hot-path touch. |
+| Architectural mismatch | LOW | Locus is the established `*Config`-scoped strict-validator pattern (precedent: `validatePolicySchedulerReferencesStrict`). Risk would be if reviewers think the gate belongs in the Rust `lifecycle.rs` arg-parse instead — addressed in Open Questions. |
+
+## 9. Test plan
+
+- `go build ./...` clean.
+- **FAILING-then-fixed config test** (`pkg/config/compiler_test.go`):
+  `TestCompileRejectsEqualFlowAbove32Workers` — set fixture
+  `set system dataplane workers 33` +
+  `set class-of-service schedulers s1 transmit-rate <bytes> exact` +
+  `set class-of-service schedulers s1 equal-flow-enforcement`, assert
+  `CompileConfig` returns an error matching the worker-cap message.
+  Companion `TestCompileAcceptsEqualFlowAt32Workers` (workers=32, same
+  scheduler) asserts NO worker-cap error (boundary). And
+  `TestCompileAcceptsAbove32WorkersWithoutEqualFlow` (workers=64, no
+  equal-flow) asserts acceptance. Confirm the test FAILS before the
+  validator wiring (red), PASSES after (green).
+- Extend `TestCompileAllThreeStrictValidatorsAccumulated` →
+  four-validator accumulation OR add a dedicated accumulation assertion so
+  a silent removal of the new append is caught (same rationale as the
+  comment at `compiler_test.go:168-186`).
+- **Go suite**: `go test ./...` (30 packages) green.
+- **Cargo lease tests** (regression, no code change):
+  `cargo test --release -p userspace-dp shared_cos_lease` (the
+  `equal_flow_fail_open_*` tests) green — proves we did not perturb the
+  fail-open machinery.
+- **No cluster smoke**: this is control-plane config-validation on the
+  reject path; no dataplane/runtime change, no HA change. `make
+  test-failover` NOT needed. (Stated explicitly per skill "when to not
+  smoke".)
+
+## 10. Out of scope (explicitly)
+
+- Removing the 32 cap via heap scratch (#1731-e).
+- Any change to `rotate_epoch_v8.rs` / `publish_equal_flow_epoch_v8.rs`.
+- A new Prometheus counter (the existing `cosEqualFlowFailOpen` +
+  `fairnessEqualFlowUnsampledActiveWorkers` already cover runtime
+  visibility).
+- Mirroring the reject in `lifecycle.rs` arg-parse (the daemon receives an
+  already-validated config from the control plane; double-validating in the
+  helper is redundant — see Open Question Q2).
+
+## 11. Open questions for adversarial review
+
+1. **Locus**: is the `*Config`-scoped strict validator in `compiler.go` the
+   right home, or should the gate ALSO live in `lifecycle.rs` arg-parse to
+   defend against a hand-crafted `--workers 64` invocation that bypasses the
+   control plane? (Belief: control-plane reject is the supported path; the
+   helper is not an independent config source in production. KILL-worthy if
+   reviewers show a supported path that constructs >32 workers + equal-flow
+   without passing through `CompileConfig`.)
+2. **Threshold**: is `> 32` exactly right? `n_workers = len.min(32)` admits
+   indices 0..31 = 32 workers; worker index 32 (the 33rd) is the first
+   `active_outside_scratch`. So 32 is supported, 33 is the first rejected
+   count. Confirm no off-by-one.
+3. **Does equal-flow truly require exact** (so the reject can't be dodged)?
+   `compiler.go:427` already rejects equal-flow without transmit-rate-exact.
+   Could a config enable equal-flow on a non-exact scheduler to slip past?
+   (Belief: no — the existing validator rejects that first; our check is
+   independent and fires regardless.)
+4. **Stored-config replay**: is rejecting a previously-valid stored config on
+   next `commit` (rather than at `Store.Load`) the correct UX, matching the
+   other strict validators? Any rolling-upgrade hazard?
+5. **Constant drift**: is a Go `MaxEqualFlowWorkers = 32` mirroring the Rust
+   `MAX_WORKERS_SCRATCH = 32` acceptable, or does the project prefer a single
+   generated source of truth? (Two hand-synced consts with a cross-reference
+   comment is the proposed approach; #1731-e retires both together.)
+6. **Visibility**: is "the commit-check error is the Phase-1 visibility, the
+   existing dataplane counter is the runtime visibility" a complete answer to
+   the issue's "add a status counter/visibility for the fail-open reason", or
+   does the issue demand a NEW distinct counter?

--- a/docs/pr/1733-equal-flow-worker-cap-reject/plan.md
+++ b/docs/pr/1733-equal-flow-worker-cap-reject/plan.md
@@ -1,6 +1,8 @@
 # Plan of Action — #1733 Phase 1: hard-reject `workers > 32` when equal-flow enforcement is enabled
 
-- **Status**: DRAFT v1 — pending adversarial plan review
+- **Status**: DRAFT v2 — round-1 converged MAJOR (Codex + AGY) folded in:
+  the commit-time reject MUST be paired with a Load/SyncApply rewrite
+  bridge or upgrade/HA-sync blacks out. Section 5.2/5.3 rewritten.
 - **Issue**: #1733 (sub-issue of #1731; research plan
   `research/1731-cos-mqfq-generalize:docs/research/1731-cos-mqfq-generalize/plan.md` §4.3)
 - **Base**: master `c9e552689` (canary-green #1723 lineage; latest merge #1730)
@@ -27,11 +29,14 @@ count is parsed by `compiler_system.go:443-446` (`strconv.Atoi`, no max) and
 `lifecycle.rs:269-273` (`.max(1)`, no upper bound).
 
 **Phase 1 (this issue):** make the unsupported combination fail LOUDLY at
-`commit`/apply time — hard-reject the config when
+`commit`/`commit check` time — hard-reject when
 `workers > 32 AND any scheduler has equal-flow-enforcement` — instead of
-fail-opening at runtime in release. Plus surface the existing dataplane
-fail-open-reason counter as the runtime visibility for the (now
-config-unreachable in a supported deploy) condition.
+fail-opening silently at runtime in release. Pair the commit-time reject
+with a **Load/SyncApply rewrite bridge** (mirroring
+`rewriteRetiredDataplaneType`) so a legacy persisted/peer-synced config
+does NOT black out daemon boot or break HA sync. Plus surface the existing
+dataplane fail-open-reason gauge as the runtime visibility for the
+condition.
 
 **Out of scope / deferred to #1731-e:** removing the 32 cap by replacing
 the stack-scratch arrays with reusable heap scratch owned by `V8State`.
@@ -45,6 +50,18 @@ silent prod fail-open on high-core boxes into a commit-check rejection the
 operator sees immediately. The "win" is not perf; it is operator-facing
 honesty — the firewall must not accept a config whose fairness contract it
 will silently not honor.
+
+**Predicate-precision note (Codex r1 minor):** `cfg.Workers > 32` is the
+*configured* worker count, which is a conservative proxy for the *runtime*
+lease worker count. The runtime lease is sized from planned workers
+(`coordinator/mod.rs:845` `last_planned_workers()`), and binding assignment
+is `queue_id % workers` over detected RX queues (`server/helpers.rs:618,636`),
+so a `workers 64` config on hardware with <=32 usable RX queues may build
+<=32 lease slots and NOT actually fail-open. The Phase-1 policy is
+deliberately "configured workers above 32 WITH equal-flow is unsupported" —
+reject the *configuration*, not only configs that provably misbehave on the
+current hardware. This is the safe, hardware-independent contract; the plan
+text no longer claims it rejects "only configs that currently misbehave".
 
 The blast radius is one new strict validator (mirrors the three existing
 ones at `compiler.go:284-293`) and a doc/test touch. There is no hot-path
@@ -145,32 +162,83 @@ if err := validateEqualFlowWorkerCapStrict(cfg); err != nil {
 `validatePolicySchedulerReferencesStrict` reading `cfg.Security` directly;
 `cfg.System.UserspaceDataplane` is the only pointer hop, nil-guarded above.
 
-### 5.2 Runtime visibility (the "status counter for the fail-open reason")
+### 5.2 Load/SyncApply rewrite bridge (round-1 MAJOR — REQUIRED)
+
+**The round-1 fatal (Codex + AGY converged):** my v1 claimed a legacy
+`workers>32 + equal-flow` config is "NOT auto-rejected at `Store.Load`".
+That is FALSE and verified false: `Store.Load()` (`configstore/store.go:105`)
+and `Store.SyncApply()` (`:222`) both call `s.compileTree(tree)` →
+`CompileConfig`/`CompileConfigForNode` → `compileExpanded` → the strict
+accumulator. Wiring the reject into the accumulator ALONE would, on a node
+upgraded past this gate:
+- fail `Store.Load()` at boot → daemon runs with nil active config (blind);
+- fail `Store.SyncApply()` on an upgraded standby receiving a >32+equal-flow
+  config from an un-upgraded primary → HA config-sync alarm loop.
+
+**Fix — mirror `rewriteRetiredDataplaneType` (`configstore/dataplane_retire.go`).**
+Add `rewriteEqualFlowOverWorkerCap(tree, caller)` invoked AFTER parse,
+BEFORE compile, in BOTH `Store.Load()` (after the existing
+`rewriteRetiredDataplaneType(tree, LoadCaller)` at `store.go:103`) and
+`Store.SyncApply()` (after `:214`'s retired rewrite, `SyncCaller`). It:
+1. Discovers the effective worker count by walking
+   `system { dataplane { ... } }` for a `workers` leaf, handling BOTH AST
+   shapes verified empirically:
+   - normal: `dataplane` -> leaf `Keys:["workers","N"]`;
+   - redundant `set system dataplane userspace workers N`
+     (`compiler_system.go:415-436`): `dataplane` -> leaf
+     `Keys:["userspace","workers","N"]` (3-key leaf — the walk must match
+     a `workers` token anywhere in the dataplane leaf keys, not only
+     `Keys[0]=="workers"`).
+   Walk top-level AND `groups { <g> { system {...} } }` nesting — reuse the
+   existing `systemBlocksOf` / `groupsBlocksOf` / `systemBlocksOfNode`
+   helpers in `dataplane_retire.go`. Absent `workers` leaf => effective
+   count 1 (`lifecycle.rs:257`) => rewrite is a no-op.
+2. If `workers > MaxEqualFlowWorkers`, strip every
+   `equal-flow-enforcement` leaf (AST shape verified: `class-of-service`
+   -> `schedulers <name>` -> leaf `Keys:["equal-flow-enforcement"]`) from
+   both top-level and grouped `class-of-service` stanzas, logging one
+   `slog.Warn` per strip with caller-specific remediation.
+
+**Why stripping equal-flow is the behaviorally-correct rewrite (not a
+silent override):** a legacy `workers>32 + equal-flow` config was ALREADY
+fail-opening equal-flow at runtime in release (the exact bug #1733
+documents). Removing the leaf on load therefore *preserves the actual
+running behavior* (equal-flow effectively off), boots clean, and warns —
+precisely analogous to rewriting a retired `dataplane-type` to the
+userspace default. The operator's next `commit` that re-adds equal-flow
+without reducing workers will hard-reject, surfacing the limit.
+
+Threshold parity: the rewrite uses the SAME `MaxEqualFlowWorkers` constant
+as the commit-time validator, so reject-set and rewrite-set are identical
+by construction (no skew).
+
+Caller phrasing: reuse the existing `retireRewriteCaller`
+(LoadCaller/SyncCaller) — its local-`commit` vs update-the-primary
+distinction matches this case exactly. (If reuse turns out to couple the
+two rewrites awkwardly at implementation, fall back to a parallel
+two-value enum; the doc comment will cross-reference either way.)
+
+### 5.3 Runtime visibility (the "status counter for the fail-open reason")
 
 The dataplane already exposes the fail-open reason end-to-end:
 - Rust: `V8EqualFlowFailOpenReason::UnsampledActiveWorker`
-  (`shared_cos_lease/mod.rs:444`), `fail_open_reason`/`fail_open_count`
-  atomics, accessors `v8_equal_flow_fail_open_reason()` /
+  (`shared_cos_lease/mod.rs:444`), `fail_open_reason` + `fail_open_count`
+  (`:497`) atomics, accessors `v8_equal_flow_fail_open_reason()` /
   `v8_equal_flow_fail_open_count()` (tested in `shared_cos_lease_tests.rs`).
-- Go/Prometheus: `cosEqualFlowFailOpen` (`pkg/api/metrics.go:117`) +
-  `fairnessEqualFlowUnsampledActiveWorkers` (`:204`).
+- Go/Prometheus: `xpf_userspace_cos_equal_flow_fail_open` is a **GaugeValue
+  with a `reason` label** (`metrics_userspace.go:977-981`,
+  `metrics_descriptors.go:349`); the `reason="unsampled_active_worker"`
+  series is the >32-worker fail-open signal. (Codex precision: it is a
+  reason GAUGE, not a monotonic end-to-end counter — accurate framing.)
 
-So the *runtime* fail-open visibility the issue asks for already exists.
-Phase 1's additional visibility is the **commit-check rejection** itself
-(the loud control-plane failure). I will NOT add a duplicate counter.
-The plan documents this mapping in `docs/` (CoS scheduler doc) so an
-operator who sees `cosEqualFlowFailOpen` incrementing on a legacy stored
-config (workers>32 that predates this gate, replayed on upgrade) knows the
-condition and the fix.
+So the *runtime* fail-open visibility the issue asks for already exists as
+a reason-labelled gauge. Phase 1's additional visibility is the **loud
+commit-check rejection** + the **Load/SyncApply WARN log**. I will NOT add
+a duplicate Prometheus counter. The plan documents this mapping in the CoS
+scheduler doc so an operator who sees the `unsampled_active_worker` gauge
+series on a legacy config knows the condition and the fix.
 
-**Stored-config upgrade nuance:** a config with workers>32+equal-flow that
-was committed before this gate exists is now rejected on the next
-`commit`/`commit check`. It is NOT auto-rejected at `Store.Load` (Junos
-candidate semantics — live config stays unchanged). This matches how the
-other strict validators behave and is the intended UX (operator sees the
-error on next edit). Documented explicitly.
-
-### 5.3 No Rust change in Phase 1
+### 5.4 No Rust change in Phase 1
 
 `rotate_epoch_v8.rs` / `publish_equal_flow_epoch_v8.rs` are untouched. The
 cargo lease tests are run as a regression gate to prove the existing
@@ -198,15 +266,24 @@ change (the `equal-flow-enforcement` and `workers` set-paths already exist).
 - **No false reject when equal-flow absent**: the loop requires at least
   one `EqualFlowEnforcement` scheduler; a 64-worker box with no equal-flow
   is untouched. ✓
+- **Load/SyncApply tolerance (round-1 MAJOR)**: a legacy persisted/synced
+  `workers>32 + equal-flow` config must NOT blackout-boot or break HA sync;
+  the §5.2 rewrite bridge strips equal-flow (preserving the already-running
+  fail-open behavior) and warns, exactly as `rewriteRetiredDataplaneType`
+  does for retired backends. ✓
+- **Rewrite/reject threshold parity**: both use `MaxEqualFlowWorkers` — the
+  rewrite cannot strip a config the validator would have accepted, nor vice
+  versa. ✓
 
 ## 8. Risk assessment
 
 | Class | Level | Note |
 |-------|-------|------|
-| Behavioral regression | LOW | Pure additive validator; only rejects a config that today silently misbehaves. Existing valid configs (≤32 workers, or equal-flow absent) compile unchanged. |
+| Behavioral regression | LOW | Additive validator + load/sync rewrite. The rewrite strips equal-flow only when workers>32 — which was already fail-opening at runtime — so running behavior is preserved. Valid configs (<=32 workers, or equal-flow absent) compile unchanged. |
+| Upgrade / HA-sync regression | MED→LOW | Round-1 MAJOR: bare accumulator reject would blackout boot + break sync. MITIGATED by the §5.2 Load/SyncApply rewrite bridge mirroring the proven `rewriteRetiredDataplaneType` pattern. Must be covered by configstore tests (§9). |
 | Lifetime / borrow | N/A (Go) | No Rust change. |
-| Performance regression | NONE | Validator runs once per `commit`, O(schedulers). No hot-path touch. |
-| Architectural mismatch | LOW | Locus is the established `*Config`-scoped strict-validator pattern (precedent: `validatePolicySchedulerReferencesStrict`). Risk would be if reviewers think the gate belongs in the Rust `lifecycle.rs` arg-parse instead — addressed in Open Questions. |
+| Performance regression | NONE | Validator runs once per `commit`, O(schedulers); rewrite once per Load/SyncApply, O(tree). No hot-path touch. |
+| Architectural mismatch | LOW | Locus is the established `*Config`-scoped strict-validator pattern (`validatePolicySchedulerReferencesStrict`) + the established Load/SyncApply rewrite-bridge pattern (`rewriteRetiredDataplaneType`). Both are precedented in-tree. |
 
 ## 9. Test plan
 
@@ -226,6 +303,13 @@ change (the `equal-flow-enforcement` and `workers` set-paths already exist).
   four-validator accumulation OR add a dedicated accumulation assertion so
   a silent removal of the new append is caught (same rationale as the
   comment at `compiler_test.go:168-186`).
+- **Load/SyncApply rewrite tests** (`pkg/configstore`, mirroring
+  `TestRewriteRetiredDataplaneType`): assert that a tree with
+  `workers 33` + `equal-flow-enforcement` (a) loads/sync-applies WITHOUT a
+  compile error (no blackout), (b) has the `equal-flow-enforcement` leaf
+  stripped post-rewrite, (c) leaves equal-flow intact when `workers <= 32`,
+  (d) covers the `groups { ... }`-nested workers + CoS shape. This is the
+  regression gate for the round-1 MAJOR.
 - **Go suite**: `go test ./...` (30 packages) green.
 - **Cargo lease tests** (regression, no code change):
   `cargo test --release -p userspace-dp shared_cos_lease` (the
@@ -240,39 +324,50 @@ change (the `equal-flow-enforcement` and `workers` set-paths already exist).
 
 - Removing the 32 cap via heap scratch (#1731-e).
 - Any change to `rotate_epoch_v8.rs` / `publish_equal_flow_epoch_v8.rs`.
-- A new Prometheus counter (the existing `cosEqualFlowFailOpen` +
-  `fairnessEqualFlowUnsampledActiveWorkers` already cover runtime
+- A new Prometheus counter (the existing reason-labelled
+  `xpf_userspace_cos_equal_flow_fail_open` gauge already covers runtime
   visibility).
+- Auto-reducing workers or any silent config mutation OTHER than the
+  load/sync equal-flow strip (which only matches the already-running
+  fail-open behavior).
 - Mirroring the reject in `lifecycle.rs` arg-parse (the daemon receives an
   already-validated config from the control plane; double-validating in the
   helper is redundant — see Open Question Q2).
 
-## 11. Open questions for adversarial review
+## 11. Open questions for adversarial review (round-2)
 
-1. **Locus**: is the `*Config`-scoped strict validator in `compiler.go` the
-   right home, or should the gate ALSO live in `lifecycle.rs` arg-parse to
-   defend against a hand-crafted `--workers 64` invocation that bypasses the
-   control plane? (Belief: control-plane reject is the supported path; the
-   helper is not an independent config source in production. KILL-worthy if
-   reviewers show a supported path that constructs >32 workers + equal-flow
-   without passing through `CompileConfig`.)
-2. **Threshold**: is `> 32` exactly right? `n_workers = len.min(32)` admits
-   indices 0..31 = 32 workers; worker index 32 (the 33rd) is the first
-   `active_outside_scratch`. So 32 is supported, 33 is the first rejected
-   count. Confirm no off-by-one.
-3. **Does equal-flow truly require exact** (so the reject can't be dodged)?
-   `compiler.go:427` already rejects equal-flow without transmit-rate-exact.
-   Could a config enable equal-flow on a non-exact scheduler to slip past?
-   (Belief: no — the existing validator rejects that first; our check is
-   independent and fires regardless.)
-4. **Stored-config replay**: is rejecting a previously-valid stored config on
-   next `commit` (rather than at `Store.Load`) the correct UX, matching the
-   other strict validators? Any rolling-upgrade hazard?
-5. **Constant drift**: is a Go `MaxEqualFlowWorkers = 32` mirroring the Rust
-   `MAX_WORKERS_SCRATCH = 32` acceptable, or does the project prefer a single
-   generated source of truth? (Two hand-synced consts with a cross-reference
-   comment is the proposed approach; #1731-e retires both together.)
-6. **Visibility**: is "the commit-check error is the Phase-1 visibility, the
-   existing dataplane counter is the runtime visibility" a complete answer to
-   the issue's "add a status counter/visibility for the fail-open reason", or
-   does the issue demand a NEW distinct counter?
+Round-1 RESOLVED (verified, see §): Q-locus — no supported bypass of
+`CompileConfig` (Codex + AGY both confirmed Load/SyncApply/commit all
+route through it). Q-threshold — `> 32` exact, no off-by-one (both
+confirmed: id 32 is first `active_outside_scratch` at len 33). Q-dodge —
+equal-flow already requires transmit-rate exact (`compiler.go:427`),
+cannot slip past. Q-visibility — existing reason-labelled gauge +
+commit-check error + WARN log is sufficient; no new counter. Q-constant —
+hand-synced const with cross-ref accepted (AGY: pragmatic; #1731-e retires
+both); a canary test asserting parity is the cheap insurance (Codex
+suggestion — adopted, see below).
+
+Open for round-2:
+
+1. **Rewrite-bridge correctness (the round-1 MAJOR fix)**: is stripping
+   `equal-flow-enforcement` on Load/SyncApply when workers>32 the right
+   rewrite (preserving the already-running fail-open behavior), or should
+   the bridge instead leave equal-flow and reduce/clamp workers? (Belief:
+   strip equal-flow — clamping workers would silently change the dataplane
+   worker topology, a far larger behavioral change than removing a knob
+   that was already a runtime no-op. Mirrors retired-dataplane strip.)
+2. **Rewrite caller reuse**: reuse `retireRewriteCaller` (Load/Sync) vs a
+   new parallel enum — any coupling hazard from reuse?
+3. **Constant-parity canary**: should a Go test assert
+   `MaxEqualFlowWorkers == 32` with a comment pinning it to
+   `rotate_epoch_v8.rs:71`'s `MAX_WORKERS_SCRATCH` (Codex r1 suggestion)?
+   (Belief: yes — cheap, catches a future Rust-side bump that forgets Go.
+   Adopted in §9.)
+4. **Worker-count discovery in the rewrite**: the rewrite reads `workers`
+   from the AST (pre-compile). Are there worker-count forms the AST walk
+   could miss (e.g. `set system dataplane userspace workers N` redundant
+   path at `compiler_system.go:415-436`, or split `system` stanzas)? The
+   walk must cover the same shapes `compileUserspaceDataplane` accepts.
+5. **Default-workers semantics in the rewrite**: if no `workers` leaf is
+   present, the effective count is 1 (`lifecycle.rs:257`), so the rewrite
+   is a no-op — confirm the walk treats "absent" as <=32, never as >32.

--- a/docs/pr/1733-equal-flow-worker-cap-reject/reviewer-ids.md
+++ b/docs/pr/1733-equal-flow-worker-cap-reject/reviewer-ids.md
@@ -1,0 +1,33 @@
+# #1733 Phase 1 — reviewer task IDs
+
+Plan + code reviewed via /engineer (triple-review): Codex + AGY + Claude-SMR.
+Copilot pending on PR (infra-down for ~6 prior PRs; merge on documented
+3-of-4 if non-responsive ~20min after trigger).
+
+## Plan review (3 rounds)
+
+- Round 1 (commit a6eacb53b):
+  - Codex: background task `battswgj7` — MAJOR (Load/SyncApply blackout +
+    HA-sync break; accumulator reject is reached by Store.Load/SyncApply).
+  - AGY: `adversarial-review-mpug6fqs-ll8lnf` — PLAN-NEEDS-MAJOR (same
+    Load/SyncApply blackout finding; proposed AST rewrite bridge).
+  - Claude-SMR: PLAN-READY pre-review; accepted the converged MAJOR.
+- Round 2 (commit 27906e7d5):
+  - Codex: `b5e82yqxx` — flagged semantic-set parity defect in the v2
+    AST-walk rewrite (false-strip on ${node}/group/split-stanza configs
+    whose effective workers <=32); proposed lenient-compile-mode.
+  - AGY: `adversarial-review-mpugrbom-aldal8` — PLAN-READY (minor: dedicated
+    equal-flow warn phrasing, not retired-dataplane phrasing).
+- Round 3 (commit 3db9ab3fb):
+  - Codex: `bag7rngh8` — NEEDS-MINOR: read-only peer-display active-tree
+    re-compiles (cli_show_interfaces.go, server_show_interfaces.go) must be
+    lenient; test fixture needs benign groups{node1}. Both addressed.
+  - AGY: `adversarial-review-mpuh830s-m5yifa` — PLAN-NEEDS-MINOR: same
+    server_show_interfaces.go lenient finding; all other v3 points verified
+    sound. Addressed.
+  - Claude-SMR: PLAN-READY — implementation matches converged design; all
+    round-3 findings fixed.
+
+## Code review
+
+(dispatched post-PR; see PR comments.)

--- a/pkg/cli/cli_show_interfaces.go
+++ b/pkg/cli/cli_show_interfaces.go
@@ -574,7 +574,12 @@ func (c *CLI) showInterfacesTerse() error {
 			}
 			tree := c.store.ActiveTree()
 			if tree != nil {
-				peerCfg, err := config.CompileConfigForNode(tree, peerNodeID)
+				// #1733: lenient compile — the active tree was already
+				// tolerated on load (workers>32 + equal-flow is warned,
+				// not rejected, on Store.Load). A strict re-compile here
+				// would error on such a legacy config and silently drop
+				// peer-interface display via the err==nil guard below.
+				peerCfg, err := config.CompileConfigForNodeLenient(tree, peerNodeID)
 				if err == nil {
 					for physName, ifCfg := range peerCfg.Interfaces.Interfaces {
 						if _, isLocal := cfg.Interfaces.Interfaces[physName]; isLocal {

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -553,9 +553,11 @@ func validateClassOfServiceStrict(cos *ClassOfServiceConfig) error {
 // fairness is NOT enforced above this worker count in release builds
 // (the only guard in the dataplane is a `debug_assert`, stripped in
 // release). Rather than accept a config the dataplane will silently
-// fail-open on, reject it loudly at commit (validateEqualFlowWorkerCapStrict)
-// and strip equal-flow on legacy load/sync
-// (configstore.rewriteEqualFlowOverWorkerCap).
+// fail-open on, reject it loudly at commit
+// (validateEqualFlowWorkerCapStrict) and, on the tolerant load / peer-sync
+// paths, downgrade the same check to a warning so an already-persisted
+// legacy config still boots (CompileConfigLenient /
+// configstore.Store.compileTreeLenient).
 //
 // Removing this cap entirely (reusable heap scratch in the v8 rotation)
 // is tracked as #1731-e; this Go constant and the Rust MAX_WORKERS_SCRATCH

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -63,11 +63,15 @@ func CompileConfig(tree *ConfigTree) (*Config, error) {
 }
 
 // CompileConfigLenient is CompileConfig with the #1733 equal-flow
-// worker-cap validator downgraded to a warning. Use ONLY on the
-// Store.Load path so an already-persisted unsupported config boots
-// through (the dataplane already silently fail-opens equal-flow above
-// MaxEqualFlowWorkers, so tolerating the config preserves running
-// behavior). Candidate commit must use the strict CompileConfig.
+// worker-cap validator downgraded to a warning. Use on TOLERANT paths
+// that compile an already-active / already-persisted config the operator
+// did not just author — e.g. Store.Load of a persisted config — so an
+// upgraded node boots through (the dataplane already silently fail-opens
+// equal-flow above MaxEqualFlowWorkers, so tolerating the config preserves
+// running behavior). MUST NOT be used on the candidate-commit path:
+// commit / commit-check use the strict CompileConfig so new operator edits
+// hard-reject. The node-aware sibling CompileConfigForNodeLenient covers
+// the cluster paths (Store.SyncApply, peer-interface display).
 func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 	return compileConfigWithOpts(tree, compileOpts{lenientEqualFlowWorkerCap: true})
 }
@@ -111,8 +115,12 @@ func CompileConfigForNode(tree *ConfigTree, nodeID int) (*Config, error) {
 }
 
 // CompileConfigForNodeLenient is CompileConfigForNode with the #1733
-// equal-flow worker-cap validator downgraded to a warning. Use ONLY on
-// the Store.SyncApply path (see CompileConfigLenient).
+// equal-flow worker-cap validator downgraded to a warning. Use on
+// node-aware TOLERANT paths that compile an already-active / peer-synced
+// config the local operator did not just author: Store.SyncApply (HA
+// peer-sync ingress) and the read-only peer-interface display re-compiles
+// (cli_show_interfaces.go, server_show_interfaces.go). MUST NOT be used on
+// the candidate-commit path — see CompileConfigLenient.
 func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) {
 	return compileConfigForNodeWithOpts(tree, nodeID, compileOpts{lenientEqualFlowWorkerCap: true})
 }

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -39,9 +39,40 @@ var ErrEBPFDataplaneRetired = errors.New(
 		"use 'set system dataplane-type userspace' " +
 		"(see #1373)")
 
+// compileOpts carries per-call compilation policy. It is threaded into
+// compileExpanded so the strict commit path and the tolerant
+// load/peer-sync path can share the identical compile + group-expansion
+// pipeline while differing on a single, narrow validator's severity.
+type compileOpts struct {
+	// lenientEqualFlowWorkerCap downgrades the
+	// validateEqualFlowWorkerCapStrict family from a hard compile error
+	// to a cfg.Warnings entry. Set ONLY on the Store.Load / Store.SyncApply
+	// paths (#1733): a node upgraded past the worker-cap gate must still
+	// boot an already-persisted >32-worker + equal-flow config, and an
+	// upgraded standby must still accept such a config peer-synced from an
+	// un-upgraded primary, rather than blacking out or alarm-looping HA
+	// sync. Candidate commit / commit-check stay strict (lenient stays
+	// false there) so new operator edits hard-reject loudly.
+	lenientEqualFlowWorkerCap bool
+}
+
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
 // It clones the tree before expansion so the original tree is not mutated.
 func CompileConfig(tree *ConfigTree) (*Config, error) {
+	return compileConfigWithOpts(tree, compileOpts{})
+}
+
+// CompileConfigLenient is CompileConfig with the #1733 equal-flow
+// worker-cap validator downgraded to a warning. Use ONLY on the
+// Store.Load path so an already-persisted unsupported config boots
+// through (the dataplane already silently fail-opens equal-flow above
+// MaxEqualFlowWorkers, so tolerating the config preserves running
+// behavior). Candidate commit must use the strict CompileConfig.
+func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
+	return compileConfigWithOpts(tree, compileOpts{lenientEqualFlowWorkerCap: true})
+}
+
+func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// Clone the tree before expanding groups — the caller's tree must retain
 	// groups and apply-groups nodes for display (show configuration groups).
 	tree = tree.Clone()
@@ -60,7 +91,7 @@ func CompileConfig(tree *ConfigTree) (*Config, error) {
 		}
 	}
 
-	cfg, err := compileExpanded(tree)
+	cfg, err := compileExpanded(tree, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +107,17 @@ func CompileConfig(tree *ConfigTree) (*Config, error) {
 // resolves to group "node0"). This supports a single shared config for both
 // nodes in a chassis cluster.
 func CompileConfigForNode(tree *ConfigTree, nodeID int) (*Config, error) {
+	return compileConfigForNodeWithOpts(tree, nodeID, compileOpts{})
+}
+
+// CompileConfigForNodeLenient is CompileConfigForNode with the #1733
+// equal-flow worker-cap validator downgraded to a warning. Use ONLY on
+// the Store.SyncApply path (see CompileConfigLenient).
+func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) {
+	return compileConfigForNodeWithOpts(tree, nodeID, compileOpts{lenientEqualFlowWorkerCap: true})
+}
+
+func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts) (*Config, error) {
 	tree = tree.Clone()
 
 	vars := map[string]string{"node": fmt.Sprintf("node%d", nodeID)}
@@ -83,12 +125,12 @@ func CompileConfigForNode(tree *ConfigTree, nodeID int) (*Config, error) {
 		return nil, fmt.Errorf("apply-groups: %w", err)
 	}
 
-	return compileExpanded(tree)
+	return compileExpanded(tree, opts)
 }
 
 // compileExpanded compiles an already-expanded (groups resolved) ConfigTree
 // into a typed Config. Shared by CompileConfig and CompileConfigForNode.
-func compileExpanded(tree *ConfigTree) (*Config, error) {
+func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg := &Config{
 		Security: SecurityConfig{
 			Zones:  make(map[string]*ZoneConfig),
@@ -291,6 +333,20 @@ func compileExpanded(tree *ConfigTree) (*Config, error) {
 	if err := validatePolicySchedulerReferencesStrict(cfg); err != nil {
 		strictErrs = append(strictErrs, err)
 	}
+	if err := validateEqualFlowWorkerCapStrict(cfg); err != nil {
+		// #1733: on the tolerant load/peer-sync path this unsupported
+		// combination is downgraded to a loud warning instead of a hard
+		// reject, so a node upgraded past the gate still boots an
+		// already-persisted config and HA sync does not alarm-loop. The
+		// dataplane already silently fail-opens equal-flow above the cap,
+		// so keeping the config as-is preserves running behavior. The
+		// operator's next candidate commit (strict) hard-rejects.
+		if opts.lenientEqualFlowWorkerCap {
+			cfg.Warnings = append(cfg.Warnings, err.Error())
+		} else {
+			strictErrs = append(strictErrs, err)
+		}
+	}
 	if err := errors.Join(strictErrs...); err != nil {
 		return nil, err
 	}
@@ -479,6 +535,61 @@ func validateClassOfServiceStrict(cos *ClassOfServiceConfig) error {
 					"sum of buffer-size percent across all schedulers is %.4g%% "+
 					"(must not exceed 100%%)",
 				schedMap.Name, totalPercent)
+		}
+	}
+	return nil
+}
+
+// MaxEqualFlowWorkers is the supported worker-thread ceiling for CoS
+// equal-flow-enforcement. It mirrors MAX_WORKERS_SCRATCH in
+// userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs:71.
+//
+// The v8 lease rotation sizes its per-worker scratch arrays from this
+// compile-time constant and clamps the sampled worker set to it
+// (`n_workers = len.min(MAX_WORKERS_SCRATCH)`). Any worker beyond this
+// index is "outside scratch": rotate_epoch_v8.rs sets
+// `active_outside_scratch`, and publish_equal_flow_epoch_v8.rs:30 then
+// silently takes `fail_open(UnsampledActiveWorker)` — equal-flow
+// fairness is NOT enforced above this worker count in release builds
+// (the only guard in the dataplane is a `debug_assert`, stripped in
+// release). Rather than accept a config the dataplane will silently
+// fail-open on, reject it loudly at commit (validateEqualFlowWorkerCapStrict)
+// and strip equal-flow on legacy load/sync
+// (configstore.rewriteEqualFlowOverWorkerCap).
+//
+// Removing this cap entirely (reusable heap scratch in the v8 rotation)
+// is tracked as #1731-e; this Go constant and the Rust MAX_WORKERS_SCRATCH
+// must be retired together. TestMaxEqualFlowWorkersMatchesRustScratch
+// pins the value so a future Rust-side change cannot silently desync.
+const MaxEqualFlowWorkers = 32
+
+// validateEqualFlowWorkerCapStrict rejects a config that enables CoS
+// equal-flow-enforcement on more worker threads than the v8 lease
+// rotation can sample (MaxEqualFlowWorkers). Above the cap, equal-flow
+// fairness silently fail-opens in release builds (see the constant's
+// doc comment); a loud commit-time rejection surfaces the unsupported
+// combination to the operator instead.
+//
+// This is one of the independent strict-validator families accumulated
+// in compileExpanded (it reads only cfg.System.UserspaceDataplane and
+// cfg.ClassOfService, depends on no other validator, and fail-fasts on
+// the first offending scheduler).
+func validateEqualFlowWorkerCapStrict(cfg *Config) error {
+	if cfg == nil || cfg.ClassOfService == nil {
+		return nil
+	}
+	usd := cfg.System.UserspaceDataplane
+	if usd == nil || usd.Workers <= MaxEqualFlowWorkers {
+		return nil
+	}
+	for _, sched := range cfg.ClassOfService.Schedulers {
+		if sched != nil && sched.EqualFlowEnforcement {
+			return fmt.Errorf(
+				"class-of-service scheduler %q equal-flow-enforcement is unsupported "+
+					"with system dataplane workers %d (max %d): equal-flow fairness "+
+					"silently fail-opens above %d workers; reduce workers or remove "+
+					"equal-flow-enforcement (cap removal tracked as #1731-e)",
+				sched.Name, usd.Workers, MaxEqualFlowWorkers, MaxEqualFlowWorkers)
 		}
 	}
 	return nil

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -46,13 +46,17 @@ var ErrEBPFDataplaneRetired = errors.New(
 type compileOpts struct {
 	// lenientEqualFlowWorkerCap downgrades the
 	// validateEqualFlowWorkerCapStrict family from a hard compile error
-	// to a cfg.Warnings entry. Set ONLY on the Store.Load / Store.SyncApply
-	// paths (#1733): a node upgraded past the worker-cap gate must still
-	// boot an already-persisted >32-worker + equal-flow config, and an
-	// upgraded standby must still accept such a config peer-synced from an
-	// un-upgraded primary, rather than blacking out or alarm-looping HA
-	// sync. Candidate commit / commit-check stay strict (lenient stays
-	// false there) so new operator edits hard-reject loudly.
+	// to a cfg.Warnings entry. Set on the TOLERANT paths that compile an
+	// already-active / persisted / peer-synced config the local operator
+	// did not just author — Store.Load, Store.SyncApply, and the read-only
+	// peer-interface display re-compiles (#1733). A node upgraded past the
+	// worker-cap gate must still boot an already-persisted >32-worker +
+	// equal-flow config, an upgraded standby must still accept such a
+	// config peer-synced from an un-upgraded primary, and `show interfaces`
+	// must still render peer interfaces — rather than blacking out,
+	// alarm-looping HA sync, or silently dropping display. Candidate commit
+	// / commit-check stay strict (lenient stays false there) so new
+	// operator edits hard-reject loudly.
 	lenientEqualFlowWorkerCap bool
 }
 

--- a/pkg/config/compiler_equal_flow_worker_cap_test.go
+++ b/pkg/config/compiler_equal_flow_worker_cap_test.go
@@ -1,0 +1,244 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildTree parses a sequence of `set ...` commands into a ConfigTree
+// using the production ParseSetCommand + SetPath path (never NewParser,
+// per the flat-set testing gotcha in CLAUDE.md).
+func buildTree(t *testing.T, lines []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	return tree
+}
+
+// validEqualFlowScheduler returns the set lines for a scheduler that
+// passes validateClassOfServiceStrict (positive transmit-rate exact, no
+// surplus-sharing) so that ONLY validateEqualFlowWorkerCapStrict can fire
+// for the worker-cap scenarios below.
+func validEqualFlowScheduler(name string) []string {
+	return []string{
+		"set class-of-service schedulers " + name + " transmit-rate 10m exact",
+		"set class-of-service schedulers " + name + " equal-flow-enforcement",
+	}
+}
+
+// TestCompileRejectsEqualFlowAboveWorkerCap is the FAILING-then-fixed
+// gate for #1733: a config that enables equal-flow-enforcement with more
+// than MaxEqualFlowWorkers dataplane workers must be hard-rejected at
+// commit (the v8 lease rotation silently fail-opens equal-flow above the
+// cap, so accepting the config would be a silent fairness fail-open).
+func TestCompileRejectsEqualFlowAboveWorkerCap(t *testing.T) {
+	lines := append([]string{
+		"set system dataplane-type userspace",
+		"set system dataplane workers 33", // MaxEqualFlowWorkers + 1
+	}, validEqualFlowScheduler("ef-sched")...)
+	tree := buildTree(t, lines)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded; want equal-flow worker-cap rejection")
+	}
+	if !strings.Contains(err.Error(), "equal-flow-enforcement is unsupported") {
+		t.Fatalf("error missing worker-cap substring: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "ef-sched") {
+		t.Fatalf("error should name the offending scheduler: %q", err.Error())
+	}
+}
+
+// TestCompileAcceptsEqualFlowAtWorkerCap pins the boundary: exactly
+// MaxEqualFlowWorkers workers is supported (the v8 rotation samples
+// indices 0..MaxEqualFlowWorkers-1), so it must NOT be rejected.
+func TestCompileAcceptsEqualFlowAtWorkerCap(t *testing.T) {
+	lines := append([]string{
+		"set system dataplane-type userspace",
+		"set system dataplane workers 32", // == MaxEqualFlowWorkers
+	}, validEqualFlowScheduler("ef-sched")...)
+	tree := buildTree(t, lines)
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig at the worker cap returned error: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "equal-flow-enforcement is unsupported") {
+			t.Fatalf("unexpected worker-cap warning at the boundary: %q", w)
+		}
+	}
+}
+
+// TestCompileAcceptsAboveWorkerCapWithoutEqualFlow verifies the gate only
+// fires when equal-flow-enforcement is actually enabled: a high worker
+// count alone is fine.
+func TestCompileAcceptsAboveWorkerCapWithoutEqualFlow(t *testing.T) {
+	lines := []string{
+		"set system dataplane-type userspace",
+		"set system dataplane workers 64",
+		// transmit-rate exact scheduler WITHOUT equal-flow-enforcement.
+		"set class-of-service schedulers be-sched transmit-rate 10m exact",
+	}
+	tree := buildTree(t, lines)
+
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig with >cap workers but no equal-flow returned error: %v", err)
+	}
+}
+
+// TestCompileLenientDowngradesEqualFlowWorkerCap proves the lenient
+// compile path (Store.Load / Store.SyncApply) downgrades the worker-cap
+// rejection to a cfg.Warnings entry WITHOUT mutating the config: the
+// scheduler's EqualFlowEnforcement stays true (the runtime fail-opens it,
+// exactly as before this gate), so running behavior is preserved.
+func TestCompileLenientDowngradesEqualFlowWorkerCap(t *testing.T) {
+	lines := append([]string{
+		"set system dataplane-type userspace",
+		"set system dataplane workers 33",
+	}, validEqualFlowScheduler("ef-sched")...)
+	tree := buildTree(t, lines)
+
+	// Strict still rejects.
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("strict CompileConfig accepted >cap equal-flow config; want rejection")
+	}
+
+	// Lenient warns instead.
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected >cap equal-flow config: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "equal-flow-enforcement is unsupported") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile produced no worker-cap warning: %v", cfg.Warnings)
+	}
+	// Warning-only downgrade — the leaf is NOT stripped.
+	sched := cfg.ClassOfService.Schedulers["ef-sched"]
+	if sched == nil || !sched.EqualFlowEnforcement {
+		t.Fatal("lenient compile must NOT strip equal-flow-enforcement (warning-only, no mutation)")
+	}
+}
+
+// TestCompileEqualFlowWorkerCapPerNodeParity is the round-2 semantic-set
+// parity gate. A config that sets workers>cap ONLY inside groups{node0}
+// (with a benign groups{node1} so ${node} expansion for node1 does not
+// error) plus apply-groups "${node}" + equal-flow must reject/warn for
+// node0 (effective workers>cap) but NOT for node1 (effective workers
+// default <=cap). An AST-walk rewrite that read the raw-tree workers leaf
+// would have false-stripped/false-warned node1; computing effective
+// workers via the real per-node compile is the fix.
+func TestCompileEqualFlowWorkerCapPerNodeParity(t *testing.T) {
+	lines := append([]string{
+		"set system dataplane-type userspace",
+		`set apply-groups "${node}"`,
+		// node0: over the cap.
+		"set groups node0 system dataplane workers 64",
+		// node1: benign group, no workers (effective stays default).
+		"set groups node1 system host-name fw1",
+	}, validEqualFlowScheduler("ef-sched")...)
+	tree := buildTree(t, lines)
+
+	// node0: strict rejects, lenient warns.
+	if _, err := CompileConfigForNode(tree, 0); err == nil {
+		t.Fatal("node0 (workers 64) strict compile accepted equal-flow; want rejection")
+	}
+	cfg0, err := CompileConfigForNodeLenient(tree, 0)
+	if err != nil {
+		t.Fatalf("node0 lenient compile errored: %v", err)
+	}
+	if !hasWorkerCapWarning(cfg0) {
+		t.Fatalf("node0 lenient compile missing worker-cap warning: %v", cfg0.Warnings)
+	}
+
+	// node1: effective workers default (<=cap) — must NOT reject or warn,
+	// in EITHER mode. This is the false-positive guard.
+	cfg1, err := CompileConfigForNode(tree, 1)
+	if err != nil {
+		t.Fatalf("node1 strict compile errored (false reject — parity bug): %v", err)
+	}
+	if hasWorkerCapWarning(cfg1) {
+		t.Fatalf("node1 strict compile has worker-cap warning (false positive): %v", cfg1.Warnings)
+	}
+	cfg1l, err := CompileConfigForNodeLenient(tree, 1)
+	if err != nil {
+		t.Fatalf("node1 lenient compile errored: %v", err)
+	}
+	if hasWorkerCapWarning(cfg1l) {
+		t.Fatalf("node1 lenient compile has worker-cap warning (false positive): %v", cfg1l.Warnings)
+	}
+}
+
+func hasWorkerCapWarning(cfg *Config) bool {
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "equal-flow-enforcement is unsupported") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCompileEqualFlowWorkerCapAccumulatesWithOtherStrictFamilies pins the
+// new validator into the #1538 strict-validator accumulator alongside an
+// independent family, so a silent removal of the
+// validateEqualFlowWorkerCapStrict append from compileExpanded is caught
+// (same rationale as TestCompileAllThreeStrictValidatorsAccumulated). The
+// fixture fires the equal-flow-worker-cap family (valid exact equal-flow
+// scheduler at workers>cap) AND the policer family (CIR=0) simultaneously.
+func TestCompileEqualFlowWorkerCapAccumulatesWithOtherStrictFamilies(t *testing.T) {
+	lines := append([]string{
+		"set system dataplane-type userspace",
+		"set system dataplane workers 33",
+		// Policer family: single-rate color-blind leaves CIR=0.
+		"set firewall three-color-policer bad-pol single-rate color-blind",
+		"set firewall three-color-policer bad-pol then discard",
+	}, validEqualFlowScheduler("ef-sched")...)
+	tree := buildTree(t, lines)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig succeeded; want accumulated worker-cap + policer errors")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "equal-flow-enforcement is unsupported") {
+		t.Errorf("error missing worker-cap family substring: %q", errStr)
+	}
+	if !strings.Contains(errStr, "committed-information-rate") {
+		t.Errorf("error missing policer family substring: %q", errStr)
+	}
+	// Two families → exactly one '\n' separator (errors.Join: N errors →
+	// N-1 newlines). A dropped worker-cap append reduces this to 0.
+	if nc := strings.Count(errStr, "\n"); nc != 1 {
+		t.Errorf("newline count = %d, want 1 (two joined families): %q", nc, errStr)
+	}
+}
+
+// TestMaxEqualFlowWorkersMatchesRustScratch is the constant-parity canary
+// (Codex r1 suggestion): MaxEqualFlowWorkers must stay equal to
+// MAX_WORKERS_SCRATCH in
+// userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs. If a
+// future Rust-side change bumps that constant, this test fails so the Go
+// side is updated in lockstep (both retire together under #1731-e).
+func TestMaxEqualFlowWorkersMatchesRustScratch(t *testing.T) {
+	const rustMaxWorkersScratch = 32 // rotate_epoch_v8.rs:71 MAX_WORKERS_SCRATCH
+	if MaxEqualFlowWorkers != rustMaxWorkersScratch {
+		t.Fatalf("MaxEqualFlowWorkers = %d, must match Rust MAX_WORKERS_SCRATCH = %d "+
+			"(rotate_epoch_v8.rs:71); update both in lockstep (#1731-e retires both)",
+			MaxEqualFlowWorkers, rustMaxWorkersScratch)
+	}
+}

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -4106,7 +4106,7 @@ apply-groups [ "${node}" common ];
 	if err := clone0.ExpandGroupsWithVars(vars0); err != nil {
 		t.Fatalf("ExpandGroupsWithVars node0: %v", err)
 	}
-	cfg0, err := compileExpanded(clone0)
+	cfg0, err := compileExpanded(clone0, compileOpts{})
 	if err != nil {
 		t.Fatalf("compile node0: %v", err)
 	}
@@ -4121,7 +4121,7 @@ apply-groups [ "${node}" common ];
 	if err := clone1.ExpandGroupsWithVars(vars1); err != nil {
 		t.Fatalf("ExpandGroupsWithVars node1: %v", err)
 	}
-	cfg1, err := compileExpanded(clone1)
+	cfg1, err := compileExpanded(clone1, compileOpts{})
 	if err != nil {
 		t.Fatalf("compile node1: %v", err)
 	}

--- a/pkg/configstore/equal_flow_worker_cap.go
+++ b/pkg/configstore/equal_flow_worker_cap.go
@@ -1,0 +1,73 @@
+// Package configstore: warnEqualFlowWorkerCap surfaces the #1733
+// equal-flow worker-cap condition on the tolerant load / peer-sync
+// paths.
+//
+// The commit-time strict validator (config.validateEqualFlowWorkerCapStrict)
+// hard-rejects a config that enables CoS equal-flow-enforcement on more
+// than config.MaxEqualFlowWorkers worker threads, because the v8 lease
+// rotation silently fail-opens equal-flow above that count
+// (rotate_epoch_v8.rs MAX_WORKERS_SCRATCH / publish_equal_flow_epoch_v8.rs
+// fail_open(UnsampledActiveWorker)). To avoid blacking out an upgraded
+// node's boot (Store.Load) or alarm-looping HA config sync
+// (Store.SyncApply) on an already-persisted/peer-synced legacy config,
+// those two paths compile leniently: the validator's error is downgraded
+// to a cfg.Warnings entry instead of a hard reject (see
+// Store.compileTreeLenient).
+//
+// This file emits the matching operator-facing journald WARN. The text is
+// equal-flow-specific (NOT the retired-dataplane phrasing) and the
+// remediation hint differs by caller: a local boot is fixed by a local
+// `commit`, while a peer-synced config originates on the un-upgraded
+// primary and must be fixed there.
+package configstore
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// warnEqualFlowWorkerCap logs a loud WARN for each #1733 equal-flow
+// worker-cap warning carried on the leniently-compiled config. The
+// warnings were appended by config.compileExpanded under the lenient
+// flag; they are identified by the stable substring
+// "equal-flow-enforcement is unsupported" emitted by
+// validateEqualFlowWorkerCapStrict.
+//
+// caller selects the remediation phrasing (LoadCaller: fix locally;
+// SyncCaller: fix the un-upgraded primary). Safe to call with a nil
+// compiled config (no-op).
+func warnEqualFlowWorkerCap(compiled *config.Config, caller retireRewriteCaller) {
+	if compiled == nil {
+		return
+	}
+	for _, w := range compiled.Warnings {
+		if !strings.Contains(w, "equal-flow-enforcement is unsupported") {
+			continue
+		}
+		slog.Warn(
+			equalFlowWorkerCapWarnMessage(caller),
+			"detail", w,
+			"remediation", equalFlowWorkerCapRemediation(caller),
+		)
+	}
+}
+
+func equalFlowWorkerCapWarnMessage(caller retireRewriteCaller) string {
+	switch caller {
+	case SyncCaller:
+		return "HA peer-synced config enables CoS equal-flow-enforcement above the supported worker cap; tolerating it (equal-flow silently disabled at runtime) so HA sync converges"
+	default:
+		return "persisted active-config enables CoS equal-flow-enforcement above the supported worker cap; tolerating it (equal-flow silently disabled at runtime) so the daemon boots"
+	}
+}
+
+func equalFlowWorkerCapRemediation(caller retireRewriteCaller) string {
+	switch caller {
+	case SyncCaller:
+		return "the un-upgraded primary is still pushing this config; on the primary, reduce system dataplane workers to <= the cap or remove equal-flow-enforcement, then `commit` so future sync rounds converge"
+	default:
+		return "reduce system dataplane workers to <= the cap or remove equal-flow-enforcement, then `commit`; the next candidate commit will be rejected until then"
+	}
+}

--- a/pkg/configstore/equal_flow_worker_cap_test.go
+++ b/pkg/configstore/equal_flow_worker_cap_test.go
@@ -1,0 +1,119 @@
+package configstore
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// equalFlowOverCapSets is a config that enables CoS equal-flow-enforcement
+// on more than config.MaxEqualFlowWorkers workers. The strict commit path
+// hard-rejects it (#1733); the tolerant Load / SyncApply paths must accept
+// it with a warning so an upgraded node boots and HA sync converges.
+func equalFlowOverCapSets() []string {
+	return []string{
+		"set system dataplane-type userspace",
+		"set system dataplane workers 33", // > MaxEqualFlowWorkers (32)
+		"set class-of-service schedulers ef-sched transmit-rate 10m exact",
+		"set class-of-service schedulers ef-sched equal-flow-enforcement",
+	}
+}
+
+func hasWorkerCapWarning(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "equal-flow-enforcement is unsupported") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestStoreLoad_ToleratesEqualFlowOverWorkerCap is the round-1 MAJOR
+// regression gate for the Load path: a persisted >cap + equal-flow config
+// (committed before the #1733 gate existed) must NOT blackout-boot. Load
+// must succeed, the active config must be present, and a worker-cap
+// warning must be surfaced.
+func TestStoreLoad_ToleratesEqualFlowOverWorkerCap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := New(filepath.Join(dir, "xpf.conf"))
+
+	tree := mustParseTree(t, equalFlowOverCapSets()...)
+	if err := store.db.WriteActive(tree); err != nil {
+		t.Fatalf("WriteActive (simulating pre-#1733 persisted config): %v", err)
+	}
+
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load blacked out on a tolerated legacy config: %v", err)
+	}
+	active := store.ActiveConfig()
+	if active == nil {
+		t.Fatal("ActiveConfig is nil after Load — daemon would boot blind")
+	}
+	if !hasWorkerCapWarning(active) {
+		t.Fatalf("Load did not surface a worker-cap warning: %v", active.Warnings)
+	}
+	// Warning-only downgrade: the equal-flow leaf is preserved (the
+	// runtime fail-opens it, exactly as before this gate).
+	sched := active.ClassOfService.Schedulers["ef-sched"]
+	if sched == nil || !sched.EqualFlowEnforcement {
+		t.Fatal("Load must preserve equal-flow-enforcement (warning-only, no mutation)")
+	}
+}
+
+// TestStoreLoad_NoWarnAtWorkerCapBoundary confirms a config exactly at the
+// cap loads cleanly with no worker-cap warning.
+func TestStoreLoad_NoWarnAtWorkerCapBoundary(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := New(filepath.Join(dir, "xpf.conf"))
+
+	tree := mustParseTree(t,
+		"set system dataplane-type userspace",
+		"set system dataplane workers 32", // == MaxEqualFlowWorkers
+		"set class-of-service schedulers ef-sched transmit-rate 10m exact",
+		"set class-of-service schedulers ef-sched equal-flow-enforcement",
+	)
+	if err := store.db.WriteActive(tree); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load at the worker cap returned error: %v", err)
+	}
+	if hasWorkerCapWarning(store.ActiveConfig()) {
+		t.Fatalf("unexpected worker-cap warning at the boundary: %v",
+			store.ActiveConfig().Warnings)
+	}
+}
+
+// TestStoreSyncApply_ToleratesEqualFlowOverWorkerCap is the round-1 MAJOR
+// regression gate for the HA peer-sync path: an upgraded standby
+// receiving a >cap + equal-flow config from an un-upgraded primary must
+// accept it (with a warning) rather than alarm-loop sync.
+func TestStoreSyncApply_ToleratesEqualFlowOverWorkerCap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := New(filepath.Join(dir, "xpf.conf"))
+
+	content := mustParseTree(t, equalFlowOverCapSets()...).Format()
+
+	compiled, err := store.SyncApply(content, nil)
+	if err != nil {
+		t.Fatalf("SyncApply rejected a tolerated peer config (HA sync would alarm-loop): %v", err)
+	}
+	if !hasWorkerCapWarning(compiled) {
+		t.Fatalf("SyncApply did not surface a worker-cap warning: %v", compiled.Warnings)
+	}
+	sched := compiled.ClassOfService.Schedulers["ef-sched"]
+	if sched == nil || !sched.EqualFlowEnforcement {
+		t.Fatal("SyncApply must preserve equal-flow-enforcement (warning-only, no mutation)")
+	}
+}

--- a/pkg/configstore/equal_flow_worker_cap_test.go
+++ b/pkg/configstore/equal_flow_worker_cap_test.go
@@ -117,3 +117,59 @@ func TestStoreSyncApply_ToleratesEqualFlowOverWorkerCap(t *testing.T) {
 		t.Fatal("SyncApply must preserve equal-flow-enforcement (warning-only, no mutation)")
 	}
 }
+
+// TestCommitCheck_RejectsEqualFlowOverWorkerCap is the store-level
+// strict-commit regression gate: an operator candidate edit that puts
+// workers > MaxEqualFlowWorkers with equal-flow-enforcement must be
+// hard-rejected by CommitCheck AND Commit (they use the strict
+// compileTree, not the lenient load/sync path). This pins the asymmetry:
+// load/sync tolerate (above), but a deliberate operator commit does not.
+func TestCommitCheck_RejectsEqualFlowOverWorkerCap(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	for _, cmd := range []string{
+		"system dataplane-type userspace",
+		"system dataplane workers 33",
+		"class-of-service schedulers ef-sched transmit-rate 10m exact",
+		"class-of-service schedulers ef-sched equal-flow-enforcement",
+	} {
+		if err := s.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q): %v", cmd, err)
+		}
+	}
+	_, err := s.CommitCheck()
+	if err == nil {
+		t.Fatal("expected CommitCheck to reject >cap equal-flow config, got nil")
+	}
+	if !strings.Contains(err.Error(), "equal-flow-enforcement is unsupported") {
+		t.Fatalf("CommitCheck error should reference the worker cap: %v", err)
+	}
+	// Commit must refuse the same way (also strict).
+	if _, err := s.Commit(); err == nil {
+		t.Fatal("expected Commit to reject >cap equal-flow config, got nil")
+	}
+}
+
+// TestCommitCheck_AcceptsEqualFlowAtWorkerCap is the boundary companion:
+// exactly MaxEqualFlowWorkers workers + equal-flow commits cleanly.
+func TestCommitCheck_AcceptsEqualFlowAtWorkerCap(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	for _, cmd := range []string{
+		"system dataplane-type userspace",
+		"system dataplane workers 32",
+		"class-of-service schedulers ef-sched transmit-rate 10m exact",
+		"class-of-service schedulers ef-sched equal-flow-enforcement",
+	} {
+		if err := s.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q): %v", cmd, err)
+		}
+	}
+	if _, err := s.CommitCheck(); err != nil {
+		t.Fatalf("CommitCheck at the worker cap returned error: %v", err)
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -102,10 +102,14 @@ func (s *Store) Load() error {
 	// up so the operator can fix the config from CLI.
 	rewriteRetiredDataplaneType(tree, LoadCaller)
 
-	compiled, err := s.compileTree(tree)
+	// #1733: tolerate (warn, don't reject) an already-persisted
+	// workers>32 + equal-flow-enforcement config on local boot so an
+	// upgraded node does not blackout-boot. See compileTreeLenient.
+	compiled, err := s.compileTreeLenient(tree)
 	if err != nil {
 		return fmt.Errorf("compile config: %w", err)
 	}
+	warnEqualFlowWorkerCap(compiled, LoadCaller)
 
 	s.active = tree
 	s.compiled = compiled
@@ -168,6 +172,40 @@ func (s *Store) compileTree(tree *config.ConfigTree) (*config.Config, error) {
 	return config.CompileConfig(tree)
 }
 
+// compileTreeLenient is compileTree with the #1733 equal-flow worker-cap
+// validator downgraded to a warning. It is used ONLY by the passive
+// load (Store.Load) and HA peer-sync (Store.SyncApply) ingress paths, NOT
+// by any operator-driven candidate commit / commit-check path.
+//
+// Rationale: Store.Load and Store.SyncApply compile a config the operator
+// did NOT just author — a persisted active config on local boot, or a
+// config pushed from a possibly-un-upgraded cluster primary. After the
+// commit-time worker-cap gate (#1733) lands, a strict reject here would
+// (a) fail Store.Load on an upgraded node carrying a legacy
+// workers>32 + equal-flow config, leaving the daemon with no active
+// config (operational blackout), and (b) fail Store.SyncApply on an
+// upgraded standby receiving such a config from an un-upgraded primary,
+// alarm-looping HA config sync. The dataplane already silently fail-opens
+// equal-flow above MaxEqualFlowWorkers, so tolerating the config with a
+// loud warning preserves the exact running behavior while surfacing the
+// condition; the operator's next strict candidate commit rejects it.
+//
+// This mirrors the rewriteRetiredDataplaneType tolerance bridge (which
+// runs just before compile on these same two paths) but uses validator
+// leniency rather than AST mutation, so the effective worker count is
+// computed by the real compiler (post-group-expansion, per-node) and the
+// warning fires on EXACTLY the configs the strict reject would — no
+// false-positive on a config whose effective per-node workers are <= cap.
+func (s *Store) compileTreeLenient(tree *config.ConfigTree) (*config.Config, error) {
+	if err := s.schemaValidateExpandedTree(tree); err != nil {
+		return nil, err
+	}
+	if s.nodeID >= 0 {
+		return config.CompileConfigForNodeLenient(tree, s.nodeID)
+	}
+	return config.CompileConfigLenient(tree)
+}
+
 func (s *Store) schemaValidateExpandedTree(tree *config.ConfigTree) error {
 	if tree == nil {
 		return nil
@@ -219,10 +257,14 @@ func (s *Store) SyncApply(content string, chassisPreserve func(*config.ConfigTre
 	// operator updates the primary.
 	rewriteRetiredDataplaneType(tree, SyncCaller)
 
-	compiled, err := s.compileTree(tree)
+	// #1733: tolerate (warn, don't reject) a workers>32 + equal-flow
+	// config peer-synced from a possibly-un-upgraded primary so HA config
+	// sync does not alarm-loop. See compileTreeLenient.
+	compiled, err := s.compileTreeLenient(tree)
 	if err != nil {
 		return nil, fmt.Errorf("sync config compile error: %w", err)
 	}
+	warnEqualFlowWorkerCap(compiled, SyncCaller)
 
 	// Push current active to history.
 	s.history.Push(&HistoryEntry{

--- a/pkg/grpcapi/server_show_interfaces.go
+++ b/pkg/grpcapi/server_show_interfaces.go
@@ -433,7 +433,12 @@ func (s *Server) showInterfacesTerse(cfg *config.Config, filterName string) (*pb
 			}
 			tree := s.store.ActiveTree()
 			if tree != nil {
-				peerCfg, err := config.CompileConfigForNode(tree, peerNodeID)
+				// #1733: lenient compile — the active tree was already
+				// tolerated on load (workers>32 + equal-flow is warned,
+				// not rejected, on Store.Load). A strict re-compile here
+				// would error on such a legacy config and silently drop
+				// peer-interface display via the err==nil guard below.
+				peerCfg, err := config.CompileConfigForNodeLenient(tree, peerNodeID)
 				if err == nil {
 					for physName, ifCfg := range peerCfg.Interfaces.Interfaces {
 						if _, isLocal := cfg.Interfaces.Interfaces[physName]; isLocal {


### PR DESCRIPTION
## Summary

Closes #1733. References #1731 (sub-issue #1731-b, control-plane half).

The v8 CoS lease rotation samples per-worker state from a 32-entry stack
scratch (`MAX_WORKERS_SCRATCH` in `rotate_epoch_v8.rs`). Above 32 workers
the only guard is a `debug_assert` (stripped in release): an active worker
beyond index 31 makes `publish_equal_flow_epoch_v8` take
`fail_open(UnsampledActiveWorker)`, **silently disabling equal-flow
fairness**. On a 48-/64-core box the operator's configured fairness
contract is silently not enforced.

This PR makes the unsupported combination fail **loudly at commit** instead
of fail-opening at runtime, while tolerating already-deployed legacy
configs so upgrades don't black out.

### What changed
- New `config.MaxEqualFlowWorkers` (= the Rust `MAX_WORKERS_SCRATCH`, pinned
  by a parity canary test) + `validateEqualFlowWorkerCapStrict`, wired into
  the #1538 independent strict-validator accumulator. A candidate commit /
  `commit check` of `system dataplane workers > 32` together with any
  `equal-flow-enforcement` scheduler is **hard-rejected**.
- The validator reads the **typed** `cfg.System.UserspaceDataplane.Workers`
  (post-compile), so all worker-count AST forms are already normalized — no
  AST re-walk, no discovery skew.
- **Lenient compile mode** (`CompileConfigLenient` /
  `CompileConfigForNodeLenient` + `Store.compileTreeLenient`) used ONLY by
  `Store.Load` and `Store.SyncApply`: downgrades this one validator to a
  `cfg.Warnings` entry + loud WARN so an upgraded node boots an
  already-persisted config and HA sync converges. The leaf is **not**
  mutated; the runtime keeps fail-opening equal-flow exactly as before.
  Because leniency runs the identical compile pipeline (same group
  expansion, same per-node context), it warns on exactly the configs the
  strict path rejects — no false-positive on a `${node}`/group/split-stanza
  config whose effective per-node workers are <= the cap.
- Read-only peer-interface display re-compiles
  (`cli_show_interfaces.go`, `server_show_interfaces.go`) switched to the
  lenient variant so a tolerated legacy active config does not silently drop
  peer-interface display.

### Runtime visibility
The fail-open reason is already exported end-to-end as the gauge
`xpf_userspace_cos_equal_flow_fail_open{reason="unsampled_active_worker"}`;
Phase 1 adds the loud commit-check rejection + the load/sync WARN. No new
counter.

### Out of scope
Removing the 32-worker cap entirely (reusable heap scratch in the v8
rotation) is the deferred #1731-e follow-up. No Rust dataplane change here.

## Plan + adversarial review

Plan doc: `docs/pr/1733-equal-flow-worker-cap-reject/plan.md` (PLAN-READY,
3 rounds). Reviewer task ids: `docs/pr/1733-equal-flow-worker-cap-reject/reviewer-ids.md`.

- Round 1: Codex + AGY converged MAJOR — a bare accumulator reject blacks
  out `Store.Load`/`SyncApply` (both route through the accumulator).
- Round 2: Codex flagged a semantic-set parity defect in the v2 AST-walk
  rewrite (false-strip on `${node}`/group configs whose effective workers
  <= cap); adopted the lenient-compile-mode design. AGY PLAN-READY.
- Round 3: Codex + AGY converged on the read-only peer-display re-compile
  needing leniency too (fixed). AGY verified all other v3 points sound.

## Test plan

- [x] `go build ./...` clean
- [x] FAILING-then-fixed config test: `workers 33` + equal-flow hard-reject
      (`TestCompileRejectsEqualFlowAboveWorkerCap`); 32-boundary accepted;
      >32 without equal-flow accepted
- [x] Lenient downgrade preserves the leaf (warning-only, no mutation)
- [x] Per-node semantic parity (node0 over cap rejects/warns; node1 default
      stays clean) — the case an AST-walk rewrite would have false-stripped
- [x] Store `Load` / `SyncApply` tolerate a legacy config (no blackout,
      warning surfaced); 32-boundary clean
- [x] Accumulator-membership test + constant-parity canary
- [x] Changed packages (`config`, `configstore`, `cli`, `grpcapi`) pass;
      new tests 5/5 flake-free
- [x] Cargo lease tests: 57 passed (incl. all `equal_flow_fail_open_*`) —
      proves the dataplane fail-open machinery is unperturbed (no Rust change)
- [x] Docs: `docs/cos-traffic-shaping.md` updated with the cap + tolerance
- No cluster smoke / `make test-failover`: control-plane config-validation
  only (the reject path); no dataplane or runtime HA change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)