### PR TITLE
#1743: CoS waterfill — anchor Phase-1 budget to shaped cap + stable honor charge + time refresh

### DIFF
--- a/docs/pr/1743-cos-waterfill-shaped-budget/agy-plan-r1.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/agy-plan-r1.md
@@ -1,0 +1,15 @@
+# AGY adversarial plan review r1 (adversarial-review-mpvavgvw-04ia5f) — PLAN-READY
+
+Root-cause bit-for-bit correct vs master. All 7 hostile checks pass,
+including the N->N+1 double-serve trace (impossible: Phase-1 runs
+first every call, re-sets honored bits before Phase-2). Hunk A u128
+math overflow-safe. Undersubscribed case correct.
+
+RISK-1 (substantive): if operator sets a tiny-positive fraction,
+pass1 = floor(cap*frac) = 0 -> exhausted true every call -> refill +
+cursor-reset every call -> Phase-2 starves from index 0. Mitigation:
+clamp pass1 to >= 1 (or QUANTUM_MIN) when frac > 0, OR guard the
+cursor reset against pass1==0 thrash.
+
+RISK-2 (minor): idle-path refill thrash (return None resets pass1=0,
+next call refills) — extremely low cost; acceptable.

--- a/docs/pr/1743-cos-waterfill-shaped-budget/codex-plan-r1.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/codex-plan-r1.md
@@ -1,0 +1,15 @@
+# Codex plan review r1 (task-mpvav706-nx3l72) — PLAN-NEEDS-MINOR
+
+Root cause holds against master e4556085a. All 7 hostile checks pass.
+
+Minor:
+1. Fixture math: 10 exact classes not 11; quantum_sum (with 512 KiB
+   clamp) = 2,651,076 B; legacy x0.7 = 1,855,753 B (not ~1.91 MB).
+   Ratio 1,855,753/437,500 = 4.24x holds.
+2. Add explicit undersubscribed shaped-root (shaper > sum R_i) unit test.
+
+Hunk A units correct (shaping_rate_bytes is bytes/sec, matches
+cos_guarantee_quantum_bytes). Hunk B does not over-charge 0.7 fixture
+(honors {100m,1g,3g,6g}, breaks at 9g). Hunk C consistent with #1732
+(bits clear before Phase-1 re-honors; no double-serve at N->N+1).
+HA portability correct. Mandatory live gate stands.

--- a/docs/pr/1743-cos-waterfill-shaped-budget/plan.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/plan.md
@@ -1,0 +1,278 @@
+# Plan v1 — CoS waterfill: anchor Phase-1 budget to shaped cap + stable honor charge + time refresh (#1743)
+
+**Status: DRAFT v1 — pending adversarial plan review**
+
+## §1 Issue framing
+
+Operator reports per-flow CoV too high on high-shape exact CoS
+queues (iperf-21g/24g, ports 5209/5210) after this session's CoS
+merges. Live telemetry: the waterfill selector's `phase2_admit=0`
+— the surplus-distribution phase never admits — so the residual
+capacity left after Phase-1 honors is never equalized across the
+large un-honored classes. Codex root-caused it to the Phase-1
+budget accounting in
+`userspace-dp/src/afxdp/cos/queue_service/mod.rs`.
+
+This is the same defect class as #1630 (CLOSED) — but #1630's fix
+branch (`fix/1630-cos-scheduler-equalize` @ `57b355226`) was NEVER
+merged to master. #1732/PR #1737 ("persistent honored set") landed
+on master WITHOUT the #1630 pass1-anchor/time-refresh. The two
+diverged: master carries #1732 (persistent `waterfill_honored_
+epoch_bits`) + the #1630 P1/P2 send-budget frame-cap split, but
+NOT the #1630 Hunk A (shaper-anchored pass1) nor Hunk B (time
+refresh). The result is the regression re-surfacing at high shape.
+
+## §2 Honest scope / value framing
+
+This is a correctness fix for an opt-in feature
+(`oversubscription-policy guarantee-rate <fraction>`). Default
+behaviour (Proportional) is bit-for-bit unchanged via the dispatch
+gate. The win is restoring the documented fairness contract
+(small classes honored to ≥95% of configured rate; residual
+equalized across large classes) at high shape, which the operator
+empirically lost. The cost is ~3 small arithmetic/timing hunks +
+one new per-binding runtime `u64` field + unit tests. The hot path
+gains one `saturating_sub` + one compare per selector call (the
+elapsed-time check) — negligible.
+
+If reviewers conclude the root-cause does not hold up against the
+live bisect, PLAN-KILL is an acceptable verdict — the validation
+gate (§9) is mandatory before any merge.
+
+## §3 What's already shipped / partially landed
+
+- **#1732 (master)**: persistent `waterfill_honored_epoch_bits`
+  (u64, keyed by ascending-vec ordinal), read+set by BOTH phases,
+  cleared at the `pass1 == 0` lazy refill (mod.rs:814). This is
+  CORRECT and MUST be preserved — do NOT revert it.
+- **#1630 P1/P2 (master)**: the per-visit `send_budget` /
+  `candidate_budget` frame-count cap (`cos_guarantee_visit_cap_
+  bytes()`), decoupled from the Phase-1 rate-scaled quantum. Kept.
+- **#1630 Hunk A/B (NOT on master)**: shaper-anchored pass1 +
+  time-based refresh. This plan re-lands these on top of #1732.
+- **v8 lease** (`maybe_top_up_cos_queue_lease`): per-binding
+  runtime token grant. Preserved; this plan does not touch it.
+
+## §4 Confirmed root cause (verified against master e4556085a)
+
+### Point 1 — Phase-1 budget over-provisioned (mod.rs:793-805)
+```rust
+if root.waterfill_pass1_remaining_bytes == 0 {
+    let mut quantum_sum: u64 = 0;
+    for &qi in &root.exact_queues_by_rate_ascending {
+        quantum_sum = quantum_sum.saturating_add(
+            cos_guarantee_quantum_bytes(&root.queues[qi]));
+    }
+    let frac = root.oversubscription_guarantee_fraction;
+    let pass1 = ((quantum_sum as f64) * frac).floor() as u64;
+    ...
+}
+```
+For the smoke fixture (Σ R_i = 109 Gbps over 11 classes, shaper
+25 Gbps, fraction 0.7): `quantum_sum × frac ≈ 1.91 MB` vs the
+shaper-delivered `cap × frac = 25e9/8 × 200µs × 0.7 = 437.5 KB`.
+Phase-1 budget is ~4.24× the bytes the root can deliver per epoch
+→ Phase-1 honors EVERY class → Phase-2 never reached. **CONFIRMED.**
+
+### Point 2 — Phase-1 honor undercharged (mod.rs:941-945, :956, :975-976, :1023-1025)
+```rust
+let phase1_cost = queue.hot.tokens
+    .min(cos_guarantee_quantum_bytes(queue))
+    .max(head_len);
+...
+if phase1_cost > root.waterfill_pass1_remaining_bytes { break; }
+...
+root.waterfill_pass1_remaining_bytes =
+    root.waterfill_pass1_remaining_bytes.saturating_sub(phase1_cost);
+if i < 64 { root.waterfill_honored_epoch_bits |= 1u64 << i; }
+```
+The `.min(queue.hot.tokens)` couples the *honor charge* to the
+queue's depleted lease tokens. Under v8-lease pressure
+`queue.hot.tokens` collapses toward one frame, so `phase1_cost`
+falls to `head_len` — passes the budget gate trivially, charges
+almost nothing against pass1, yet **marks the queue fully honored**
+(:975-976). Phase-2 then skips it (:1023-1025). The honor charge
+should be the *stable configured quantum*, not the depleted token
+count. **CONFIRMED.** (Note: the per-visit SEND budget correctly
+stays token-clamped at :946-950 — only the honor-decision charge
+is wrong.)
+
+### Point 3 — #1732 exposed, did not introduce
+Pre-#1732 (`70530498c`) used a function-local mask that was empty
+when Phase-2 ran, so Phase-2 admitted anyway (accidentally masking
+the bad accounting). #1732's persistent bits are correct and
+unmasked the latent Phase-1 over-honor → Phase-2 genuinely dies.
+**CONFIRMED** (#1737 = 660ecf019 on master; #1630 branch not
+merged). **Do NOT revert #1732.**
+
+### No time refresh on master
+Master only refreshes pass1 on the `pass1 == 0` exhausted path.
+Under saturation, Phase-2 does not decrement pass1, so once pass1
+sits at a small positive value it never refills — small classes
+starve across epochs (the #1630 Hunk B regression). On master this
+is partially shadowed by the honored-bits clear only firing on the
+exhausted path; combined with the over-budget it produces the
+observed `phase2_admit=0`. A time refresh is required for
+correctness and is the carrier for clearing the honored bits each
+epoch.
+
+## §5 Fix design (3 hunks)
+
+### Hunk A — anchor pass1 to shaped cap (mod.rs:793-818)
+```rust
+let frac = root.oversubscription_guarantee_fraction;
+let pass1 = if root.shaping_rate_bytes == 0 {
+    // transparent (unshaped) root: no shaper-delivered cap to
+    // anchor against — keep the legacy quantum_sum × fraction.
+    let mut quantum_sum: u64 = 0;
+    for &qi in &root.exact_queues_by_rate_ascending {
+        quantum_sum = quantum_sum.saturating_add(
+            cos_guarantee_quantum_bytes(&root.queues[qi]));
+    }
+    ((quantum_sum as f64) * frac).floor() as u64
+} else {
+    let cap_per_epoch = ((root.shaping_rate_bytes as u128)
+        * (COS_GUARANTEE_VISIT_NS as u128) / 1_000_000_000u128) as u64;
+    ((cap_per_epoch as f64) * frac).floor() as u64
+};
+```
+(`root.shaping_rate_bytes` is bytes/s — same unit
+`cos_guarantee_quantum_bytes` divides by 1e9 with VISIT_NS; the
+cap is bytes/epoch.)
+
+### Hunk B — stable Phase-1 honor charge (mod.rs:941-945)
+```rust
+// honor charge = STABLE configured quantum (not depleted tokens),
+// so a token-starved small queue is charged its full guaranteed
+// share and is not falsely "fully honored" for one frame.
+let phase1_cost = cos_guarantee_quantum_bytes(queue).max(head_len);
+```
+The per-visit `send_budget` at :946-950 (token-clamped frame cap)
+is UNCHANGED — only the honor/budget-gate charge changes.
+
+### Hunk C — time-based refresh + honored-bits clear (mod.rs:793-818)
+Add field `waterfill_epoch_start_ns: u64` to `CoSInterfaceRuntime`
+(types/cos.rs), init 0 in `build_cos_interface_runtime`
+(builders.rs) + all test literals. Refill trigger:
+```rust
+let elapsed = now_ns.saturating_sub(root.waterfill_epoch_start_ns);
+let time_refresh = elapsed >= COS_GUARANTEE_VISIT_NS;
+let exhausted = root.waterfill_pass1_remaining_bytes == 0;
+if time_refresh || exhausted {
+    root.waterfill_pass1_remaining_bytes = pass1; // (Hunk A)
+    root.waterfill_epoch_start_ns = now_ns;
+    root.waterfill_honored_epoch_bits = 0;   // clear EACH epoch
+    root.waterfill_epochs = root.waterfill_epochs.wrapping_add(1);
+    if exhausted {
+        root.waterfill_phase2_cursor = 0;    // ONLY exhausted resets cursor
+    }
+}
+```
+**CRITICAL invariants:**
+1. Honored bits cleared on BOTH refresh paths (master only clears
+   on exhausted — without this the time refresh leaves stale
+   honored bits and both phases skip honored queues forever; this
+   is the #1732-interaction wrinkle the #1630 branch never had).
+2. Phase-2 cursor reset ONLY on the exhausted path (Codex #1630
+   r4 invariant — resetting on every timed refresh starves classes
+   deep in the descending walk).
+3. `waterfill_epochs` bump moves into the shared `if` so the
+   counter still increments once per refresh on either path.
+
+## §6 Public API preservation
+No public signatures change. `select_exact_cos_guarantee_queue_
+waterfill` keeps its `(root, queue_fast_path, now_ns,
+lease_telemetry)` signature. The Proportional dispatch gate is
+untouched.
+
+## §7 Hidden invariants preserved
+- **#1732 persistent honored bits** preserved; cleared once per
+  epoch on EITHER refresh path (single clear point semantics
+  maintained — both epoch-exit paths funnel through the refill).
+- **Side-effect ordering**: honor charge → mark honored → advance
+  RR → telemetry → return, unchanged.
+- **Allocation**: no heap alloc added; iterates the persistent
+  ascending vec by index (no clone).
+- **HA portability**: `waterfill_epoch_start_ns` is per-binding
+  worker-local runtime, NOT HA-synced (grep of pkg/cluster shows
+  zero waterfill references) — same class as the existing
+  `waterfill_pass1_remaining_bytes`/`_phase2_cursor`/`_honored_
+  epoch_bits`. No session-sync wire change; `make test-failover`
+  not strictly required but will be run if time permits since the
+  field is fresh.
+- **Borrow shape**: `now_ns` is `Copy u64` read before any `&mut
+  root.queues` borrow; bit set uses ordinal `i` copied out.
+- **>64-queue guard**: ordinal `< 64` shift guards unchanged.
+
+## §8 Risk assessment
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression | MED | Opt-in path only; Proportional unchanged. Validated by live bisect + #1217 gate. |
+| Lifetime / borrow | LOW | One new scalar field; no new borrows. |
+| Performance | LOW | +1 sub +1 cmp per selector call; no alloc. Best-effort fast path (CoS-off) untouched. |
+| Architectural mismatch | LOW | Re-lands a 5-round-reviewed #1630 design adapted to #1732; not a new architecture. |
+
+## §9 Validation gate (MANDATORY — the crux)
+1. **Confirm regression**: deploy `70530498c` (pre-#1732) vs
+   `e4556085a` (current master) on loss:xpf-userspace-fw0, reapply
+   CoS, verify classifier counters increment, compare
+   `phase2_admit` + iperf3 per-stream CoV at ports 5209/5210 -P12.
+   Expected: pre-#1732 phase2_admit>0; current=0.
+2. **Confirm fix**: deploy fixed build → phase2_admit MUST go >0
+   AND iperf3 per-stream CoV at high shapes MUST drop materially
+   vs current master. If phase2_admit stays 0 OR CoV doesn't
+   improve → STOP, report BLOCKED, do NOT merge.
+3. **Ground truth = iperf3 per-stream throughput CoV** (compute
+   from [N] sender lines). Do NOT trust cos_active_flow_count
+   (#1741). Validate counter sums vs known stream count.
+4. Full CoS smoke matrix (v4/v6 × push/reverse × CoS-off/on ×
+   per-class) + #1217 structural-CoV gate. MUST NOT regress
+   aggregate throughput or the best-effort fast path (#1183:
+   CoS-off -P12 -R line rate).
+
+## §10 Test plan
+- `cargo build` clean.
+- New unit tests pinning each hunk:
+  - `waterfill_pass1_anchored_to_shaper_per_epoch` (Hunk A)
+  - `waterfill_pass1_transparent_root_fallback_to_quantum_sum`
+  - `waterfill_phase1_honor_charge_is_configured_quantum_not_tokens`
+    (Hunk B — token-starved small queue still charged full quantum,
+    still admits in Phase-2 if not honored)
+  - `waterfill_pass1_refreshes_on_time_tick_clears_honored_bits`
+    (Hunk C — honored bits cleared on timed refresh)
+  - `waterfill_phase2_cursor_only_resets_on_exhausted_path`
+    (cursor preservation invariant)
+- Existing waterfill + worker CoS test literals updated for the
+  new field.
+- 5/5 flake on the most-affected new test.
+- Go suite (30 packages).
+- Smoke matrix per §9.
+
+## §11 Out of scope
+- #1741 (buggy cos_active_flow_count) — not touched; ground truth
+  is iperf per-stream CoV.
+- Any change to v8 lease token refill.
+- Proportional policy path.
+
+## §12 Open questions for adversarial review
+1. Is anchoring pass1 to `shaping_rate_bytes` correct when the
+   root shaper is below the sum of exact rates AND below line rate
+   (does the shaper rate reflect the actual deliverable bytes, or
+   should it be `min(shaper, line_rate)`)?
+2. Does charging the full configured quantum (Hunk B) over-charge
+   pass1 such that FEWER small classes are honored than intended
+   for a low fraction, pushing too much to Phase-2? Worked trace
+   needed for fraction 0.7 fixture.
+3. Clearing honored bits on the TIMED refresh (not just exhausted)
+   — does this re-introduce the per-call re-honor monopoly #1732
+   fixed, given the timed refresh can fire mid-epoch under clock
+   skew? (Bound: timed refresh fires at most once per VISIT_NS.)
+4. Phase-2 cursor preservation across a timed refresh while
+   honored bits ARE cleared — can a queue be honored in Phase-1
+   epoch N, then re-served in Phase-2 epoch N+1 before its bit is
+   re-set, double-serving it? Trace the N→N+1 boundary.
+5. Is there any config where `shaping_rate_bytes != 0` but the
+   intended budget really is quantum_sum-based (e.g. shaper above
+   Σ R_i, undersubscribed)? Does cap-anchoring under-budget Phase-1
+   and wrongly push small classes to Phase-2 when there's plenty
+   of capacity?

--- a/docs/pr/1743-cos-waterfill-shaped-budget/plan.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/plan.md
@@ -177,19 +177,29 @@ if time_refresh || exhausted {
     root.waterfill_epoch_start_ns = now_ns;
     root.waterfill_honored_epoch_bits = 0;   // clear EACH epoch
     root.waterfill_epochs = root.waterfill_epochs.wrapping_add(1);
-    if exhausted {
-        root.waterfill_phase2_cursor = 0;    // ONLY exhausted resets cursor
-    }
+    // (r2 update — see invariant 2 below: the exhausted-path cursor
+    // reset shown here was REMOVED in the shipped code.)
 }
 ```
+> **r2 amendment (Codex code-r2):** the `if exhausted { cursor = 0 }`
+> block above was REMOVED. NEITHER refill path resets the Phase-2
+> cursor; the only reset is the genuine Phase-2 wrap at the
+> end-of-function `None` path. See invariant 2.
+
 **CRITICAL invariants:**
 1. Honored bits cleared on BOTH refresh paths (master only clears
    on exhausted — without this the time refresh leaves stale
    honored bits and both phases skip honored queues forever; this
    is the #1732-interaction wrinkle the #1630 branch never had).
-2. Phase-2 cursor reset ONLY on the exhausted path (Codex #1630
-   r4 invariant — resetting on every timed refresh starves classes
-   deep in the descending walk).
+2. Phase-2 cursor reset ONLY on a genuine Phase-2 WRAP (the
+   end-of-function `None` path) — NEITHER refill path touches it.
+   (r1 design reset on the exhausted path per the #1630 r4 intent,
+   but Codex code-r2 showed a degenerate all-min-quantum config can
+   land pass1 at exactly 0 after one Phase-1 honor and re-enter the
+   exhausted path every call, restarting the descending walk and
+   starving Phase-2 within a 200µs window. Removing the reset keeps
+   the cursor continuous across epochs on both refill paths, which
+   is the stronger form of the same #1630 r4 continuity invariant.)
 3. `waterfill_epochs` bump moves into the shared `if` so the
    counter still increments once per refresh on either path.
 

--- a/docs/pr/1743-cos-waterfill-shaped-budget/plan.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/plan.md
@@ -1,6 +1,11 @@
 # Plan v1 — CoS waterfill: anchor Phase-1 budget to shaped cap + stable honor charge + time refresh (#1743)
 
-**Status: DRAFT v1 — pending adversarial plan review**
+**Status: PLAN-READY v2 — Codex PLAN-NEEDS-MINOR (addressed), AGY PLAN-READY, Claude-SMR PLAN-READY**
+
+v2 changes vs v1: corrected fixture math (10 exact classes,
+quantum_sum=2,651,076 B → ×0.7=1,855,753 B, ratio 4.24×); added
+undersubscribed shaped-root unit test; added RISK-1 zero-budget
+mitigation (Hunk A clamps pass1 ≥ QUANTUM_MIN when frac > 0).
 
 ## §1 Issue framing
 
@@ -68,11 +73,13 @@ if root.waterfill_pass1_remaining_bytes == 0 {
     ...
 }
 ```
-For the smoke fixture (Σ R_i = 109 Gbps over 11 classes, shaper
-25 Gbps, fraction 0.7): `quantum_sum × frac ≈ 1.91 MB` vs the
-shaper-delivered `cap × frac = 25e9/8 × 200µs × 0.7 = 437.5 KB`.
-Phase-1 budget is ~4.24× the bytes the root can deliver per epoch
-→ Phase-1 honors EVERY class → Phase-2 never reached. **CONFIRMED.**
+For the smoke fixture (10 exact classes 100m..24g, Σ R_i = 109
+Gbps, shaper 25 Gbps, fraction 0.7): with the 512 KiB quantum clamp
+`quantum_sum = 2,651,076 B`, so legacy `quantum_sum × frac =
+1,855,753 B` vs the shaper-delivered `cap × frac = 25e9/8 × 200µs ×
+0.7 = 437,500 B`. Phase-1 budget is 1,855,753/437,500 = **4.24×**
+the bytes the root can deliver per epoch → Phase-1 honors EVERY
+class → Phase-2 never reached. **CONFIRMED.**
 
 ### Point 2 — Phase-1 honor undercharged (mod.rs:941-945, :956, :975-976, :1023-1025)
 ```rust
@@ -133,7 +140,14 @@ let pass1 = if root.shaping_rate_bytes == 0 {
 } else {
     let cap_per_epoch = ((root.shaping_rate_bytes as u128)
         * (COS_GUARANTEE_VISIT_NS as u128) / 1_000_000_000u128) as u64;
-    ((cap_per_epoch as f64) * frac).floor() as u64
+    let raw = ((cap_per_epoch as f64) * frac).floor() as u64;
+    // AGY RISK-1: a tiny-positive fraction floors pass1 to 0, which
+    // makes `exhausted` true on every selector call → refill +
+    // cursor-reset thrash → Phase-2 starves from index 0. Since the
+    // dispatch gate already requires frac > 0, clamp pass1 to at
+    // least one min-quantum so at least the smallest class is
+    // honorable and the exhausted path can't fire every call.
+    raw.max(COS_GUARANTEE_QUANTUM_MIN_BYTES)
 };
 ```
 (`root.shaping_rate_bytes` is bytes/s — same unit
@@ -242,6 +256,11 @@ untouched.
     (Hunk C — honored bits cleared on timed refresh)
   - `waterfill_phase2_cursor_only_resets_on_exhausted_path`
     (cursor preservation invariant)
+  - `waterfill_pass1_undersubscribed_shaper_honors_all_classes`
+    (Codex r1 #6 — shaper > Σ R_i: pass1 ≥ quantum_sum, all classes
+    honorable in Phase-1, no spurious Phase-2 push)
+  - `waterfill_pass1_tiny_fraction_clamped_to_min_quantum`
+    (AGY RISK-1 — frac→0 floor does not zero pass1)
 - Existing waterfill + worker CoS test literals updated for the
   new field.
 - 5/5 flake on the most-affected new test.

--- a/docs/pr/1743-cos-waterfill-shaped-budget/plan.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/plan.md
@@ -172,36 +172,42 @@ Add field `waterfill_epoch_start_ns: u64` to `CoSInterfaceRuntime`
 let elapsed = now_ns.saturating_sub(root.waterfill_epoch_start_ns);
 let time_refresh = elapsed >= COS_GUARANTEE_VISIT_NS;
 let exhausted = root.waterfill_pass1_remaining_bytes == 0;
+// SHIPPED (r3): refill the BUDGET on time_refresh || exhausted, but
+// clear honored bits ONLY on a genuine epoch boundary.
 if time_refresh || exhausted {
     root.waterfill_pass1_remaining_bytes = pass1; // (Hunk A)
     root.waterfill_epoch_start_ns = now_ns;
-    root.waterfill_honored_epoch_bits = 0;   // clear EACH epoch
+    if time_refresh || root.waterfill_epoch_wrap_pending {
+        root.waterfill_honored_epoch_bits = 0;    // clear on boundary only
+    }
+    root.waterfill_epoch_wrap_pending = false;
     root.waterfill_epochs = root.waterfill_epochs.wrapping_add(1);
-    // (r2 update — see invariant 2 below: the exhausted-path cursor
-    // reset shown here was REMOVED in the shipped code.)
+    // NOTE: the cursor is NOT reset here (r2); only the Phase-2 wrap
+    // `None` path resets the cursor + arms epoch_wrap_pending.
 }
 ```
-> **r2 amendment (Codex code-r2):** the `if exhausted { cursor = 0 }`
-> block above was REMOVED. NEITHER refill path resets the Phase-2
-> cursor; the only reset is the genuine Phase-2 wrap at the
-> end-of-function `None` path. See invariant 2.
+> **r2/r3 amendments (Codex code review):**
+> - **r2** — the original `if exhausted { cursor = 0 }` was REMOVED;
+>   NEITHER refill path resets the Phase-2 cursor.
+> - **r3** — the honored-bits clear was moved off the bare
+>   `exhausted` path. It now fires ONLY on the time tick OR a genuine
+>   Phase-2 wrap (`waterfill_epoch_wrap_pending`, set by the `None`
+>   path). A bare mid-walk `pass1 == 0` refills the budget but keeps
+>   the bits, so an exact-fit honor cannot re-honor the same queue
+>   forever (the r3 livelock). See invariants 1–2.
 
 **CRITICAL invariants:**
-1. Honored bits cleared on BOTH refresh paths (master only clears
-   on exhausted — without this the time refresh leaves stale
-   honored bits and both phases skip honored queues forever; this
-   is the #1732-interaction wrinkle the #1630 branch never had).
+1. Honored bits cleared ONLY on a genuine epoch boundary — the 200µs
+   time tick OR a Phase-2 wrap (`waterfill_epoch_wrap_pending`). NOT
+   on every budget refill: a bare mid-walk `pass1 == 0` refill keeps
+   the bits (r3 — else an all-min-quantum exact-fit config livelocks
+   Phase 1 on q0 and never reaches Phase 2). Forward progress is
+   guaranteed because the time tick fires at least every 200µs.
 2. Phase-2 cursor reset ONLY on a genuine Phase-2 WRAP (the
-   end-of-function `None` path) — NEITHER refill path touches it.
-   (r1 design reset on the exhausted path per the #1630 r4 intent,
-   but Codex code-r2 showed a degenerate all-min-quantum config can
-   land pass1 at exactly 0 after one Phase-1 honor and re-enter the
-   exhausted path every call, restarting the descending walk and
-   starving Phase-2 within a 200µs window. Removing the reset keeps
-   the cursor continuous across epochs on both refill paths, which
-   is the stronger form of the same #1630 r4 continuity invariant.)
-3. `waterfill_epochs` bump moves into the shared `if` so the
-   counter still increments once per refresh on either path.
+   end-of-function `None` path) — NEITHER refill path touches it
+   (r2 — the #1630 r4 continuity invariant, hardened).
+3. `waterfill_epochs` bumps on every budget refill (either trigger);
+   it counts refreshes, not RR completions.
 
 ## §6 Public API preservation
 No public signatures change. `select_exact_cos_guarantee_queue_
@@ -211,8 +217,8 @@ untouched.
 
 ## §7 Hidden invariants preserved
 - **#1732 persistent honored bits** preserved; cleared once per
-  epoch on EITHER refresh path (single clear point semantics
-  maintained — both epoch-exit paths funnel through the refill).
+  epoch on a genuine boundary (time tick OR Phase-2 wrap, r3) — NOT
+  on a bare mid-walk `pass1 == 0` refill.
 - **Side-effect ordering**: honor charge → mark honored → advance
   RR → telemetry → return, unchanged.
 - **Allocation**: no heap alloc added; iterates the persistent

--- a/docs/pr/1743-cos-waterfill-shaped-budget/reviewer-ids.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/reviewer-ids.md
@@ -4,3 +4,11 @@
 - Codex: task-mpvav706-nx3l72 (PLAN-NEEDS-MINOR)
 - AGY: adversarial-review-mpvavgvw-04ia5f (PLAN-READY)
 - Claude SMR: PLAN-READY (traces match)
+
+## Code review round 1 (commit e1e9589d5)
+- Codex: task-mpvc5qwe-5rktyb (MERGE-NEEDS-MINOR — 3 findings addressed in fcbdf1f04)
+- AGY: adversarial-review-mpvc5zqw-2g4al3 (MERGE-READY, ran suite 1715 tests pass)
+- Claude SMR: MERGE-READY (borrow/u128/monotonicity verified; coordinator MIN/SUM semantics preserved)
+
+## Code review round 2 (commit fcbdf1f04 — review-fix verification)
+- Codex: re-dispatched

--- a/docs/pr/1743-cos-waterfill-shaped-budget/reviewer-ids.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/reviewer-ids.md
@@ -1,6 +1,6 @@
 # #1743 reviewer task IDs
 
 ## Plan review round 1 (commit 8b5d0b9ba)
-- Codex: <pending>
-- AGY: <pending (MCP background)>
-- Claude SMR: in-conversation
+- Codex: task-mpvav706-nx3l72 (PLAN-NEEDS-MINOR)
+- AGY: adversarial-review-mpvavgvw-04ia5f (PLAN-READY)
+- Claude SMR: PLAN-READY (traces match)

--- a/docs/pr/1743-cos-waterfill-shaped-budget/reviewer-ids.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/reviewer-ids.md
@@ -1,0 +1,6 @@
+# #1743 reviewer task IDs
+
+## Plan review round 1 (commit 8b5d0b9ba)
+- Codex: <pending>
+- AGY: <pending (MCP background)>
+- Claude SMR: in-conversation

--- a/docs/pr/1743-cos-waterfill-shaped-budget/reviewer-ids.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/reviewer-ids.md
@@ -12,3 +12,8 @@
 
 ## Code review round 2 (commit fcbdf1f04 — review-fix verification)
 - Codex: re-dispatched
+
+## Code review round 2 result + round 3
+- Codex r2: task-mpvcikph-cgum6h (MERGE-NEEDS-MINOR — degenerate min-quantum exhausted-path cursor-reset thrash; fixed in b2fb8028b by removing the exhausted-path cursor reset)
+- Codex r3: task-mpvd64p6-e1gppr (re-review of cursor-reset removal)
+- Copilot: addressed audit line-count (non-issue, snapshot current) + epoch doc phrase (fixed 69bf42892)

--- a/docs/pr/1743-cos-waterfill-shaped-budget/validation-gate.md
+++ b/docs/pr/1743-cos-waterfill-shaped-budget/validation-gate.md
@@ -1,0 +1,43 @@
+# #1743 live validation gate — loss:xpf-userspace-fw0 (matched A/B)
+
+Master baseline = e4556085a. Fix = fix/1743-cos-waterfill-shaped-budget.
+CoS fixture cos-iperf-config.set (shaping-rate 25g, oversubscription-policy
+guarantee-rate 0.7, 10 exact classes 100m..24g + best-effort + uncapped).
+Ground truth = iperf3 per-stream throughput CoV (NOT cos_active_flow_count,
+which is buggy per #1741).
+
+## Primary signal — Phase-2 admission (waterfill_phaseN_admissions_total deltas)
+Full 11-class simul push, 20s, P12 each, 3 matched runs per build:
+
+| run | MASTER p2/p1 | FIX p2/p1 |
+|----:|-------------:|----------:|
+| 1   | 0.0064       | 1.433     |
+| 2   | 0.0059       | 1.323     |
+| 3   | 0.0054       | 1.405     |
+
+Master Phase-2 admits ~0.6% of Phase-1 (phase2_admit effectively 0 — the
+reported regression). Fix Phase-2 admits ~135% of Phase-1 — the surplus
+distribution phase is alive. ~230x increase in the phase2/phase1 ratio.
+This is the phase2_admit 0->nonzero transition the gate requires.
+
+Also on master gate_2 (priority-low/uncapped min share) FAILED (uncapped
+got 0.00 Gbps — starved by the dead Phase-2); on the fix it PASSED.
+
+## Ground truth — isolated high-shape per-stream CoV (5209+5210 alone, P12, 12s, 5 reps)
+Isolating the two high-shape classes removes the 11-class divided-ceiling
+noise so per-flow CoV reflects intra-class fairness.
+
+| metric  | MASTER mean (5 runs) | FIX mean (5 runs) | delta     |
+|---------|---------------------:|------------------:|----------:|
+| 21g CoV | 35.6%                | 25.1%             | -10.5 pts |
+| 24g CoV | 45.7%                | 31.9%             | -13.8 pts |
+
+Material CoV drop at BOTH high shapes. Gate satisfied.
+
+MASTER raw: 21g {43.3,49.5,33.3,27.1,24.8} 24g {72.6,51.6,49.7,24.2,30.3}
+FIX raw:    21g {23.0,16.3,37.3,22.3,26.4} 24g {17.4,34.0,28.3,29.4,50.4}
+
+## Conclusion
+Both halves of the hard gate pass: phase2_admit 0->nonzero (~230x), and
+high-shape per-stream CoV drops materially (-10.5 / -13.8 pts). The
+root-cause and fix hold up empirically on the live cluster.

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,7 +1,7 @@
 [REFACTOR]   2437  userspace-dp/src/afxdp/poll_descriptor/mod.rs
 [WATCH]      1997  pkg/cli/cli_show_security.go
 [WATCH]      1919  userspace-dp/src/afxdp/wg/engine.rs
-[WATCH]      1804  userspace-dp/src/afxdp/cos/queue_service/mod.rs
+[WATCH]      1818  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1792  userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
 [WATCH]      1784  pkg/dataplane/userspace/manager.go
 [WATCH]      1745  userspace-dp/src/afxdp/cold_path_hist.rs

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,7 +1,7 @@
 [REFACTOR]   2437  userspace-dp/src/afxdp/poll_descriptor/mod.rs
 [WATCH]      1997  pkg/cli/cli_show_security.go
 [WATCH]      1919  userspace-dp/src/afxdp/wg/engine.rs
-[WATCH]      1829  userspace-dp/src/afxdp/cos/queue_service/mod.rs
+[WATCH]      1844  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1792  userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
 [WATCH]      1784  pkg/dataplane/userspace/manager.go
 [WATCH]      1745  userspace-dp/src/afxdp/cold_path_hist.rs

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,9 +1,9 @@
 [REFACTOR]   2437  userspace-dp/src/afxdp/poll_descriptor/mod.rs
 [WATCH]      1997  pkg/cli/cli_show_security.go
 [WATCH]      1919  userspace-dp/src/afxdp/wg/engine.rs
+[WATCH]      1804  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1792  userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
 [WATCH]      1784  pkg/dataplane/userspace/manager.go
-[WATCH]      1751  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1745  userspace-dp/src/afxdp/cold_path_hist.rs
 [WATCH]      1695  pkg/dataplane/compiler.go
 [WATCH]      1667  userspace-dp/src/afxdp/forwarding/mod.rs

--- a/docs/refactoring-audit-current.txt
+++ b/docs/refactoring-audit-current.txt
@@ -1,7 +1,7 @@
 [REFACTOR]   2437  userspace-dp/src/afxdp/poll_descriptor/mod.rs
 [WATCH]      1997  pkg/cli/cli_show_security.go
 [WATCH]      1919  userspace-dp/src/afxdp/wg/engine.rs
-[WATCH]      1818  userspace-dp/src/afxdp/cos/queue_service/mod.rs
+[WATCH]      1829  userspace-dp/src/afxdp/cos/queue_service/mod.rs
 [WATCH]      1792  userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
 [WATCH]      1784  pkg/dataplane/userspace/manager.go
 [WATCH]      1745  userspace-dp/src/afxdp/cold_path_hist.rs

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -136,6 +136,10 @@ pub(in crate::afxdp) fn build_cos_interface_runtime(
         waterfill_honored_epoch_bits: 0,
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
+        // #1743: 0 forces the first selector call to take the exhausted
+        // refill path (pass1 starts at 0) which seeds epoch_start_ns to
+        // the live now_ns; from then on the time-based refresh drives it.
+        waterfill_epoch_start_ns: 0,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -136,10 +136,14 @@ pub(in crate::afxdp) fn build_cos_interface_runtime(
         waterfill_honored_epoch_bits: 0,
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
-        // #1743: 0 forces the first selector call to take the exhausted
+        // #1743: 0 forces the first selector call to take the budget-spent
         // refill path (pass1 starts at 0) which seeds epoch_start_ns to
         // the live now_ns; from then on the time-based refresh drives it.
         waterfill_epoch_start_ns: 0,
+        // #1743 (Codex r3): true forces the first refill to also clear the
+        // honored bitset (a clean first epoch); the Phase-2 wrap path
+        // re-arms it on each genuine epoch boundary.
+        waterfill_epoch_wrap_pending: true,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -784,36 +784,81 @@ fn select_exact_cos_guarantee_queue_waterfill(
     if queue_count == 0 || root.exact_queues_by_rate_ascending.is_empty() {
         return None;
     }
-    // Phase 1 epoch refill: when `pass1_remaining` is zero we're
-    // either at first call OR just completed an epoch. Compute the
-    // new budget from `quantum_sum × fraction`. quantum_sum is
-    // taken over the current eligible set (runnable + nonempty)
-    // so a transiently empty queue doesn't inflate the budget
-    // it would consume.
-    if root.waterfill_pass1_remaining_bytes == 0 {
-        let mut quantum_sum: u64 = 0;
-        for &qi in &root.exact_queues_by_rate_ascending {
-            quantum_sum =
-                quantum_sum.saturating_add(cos_guarantee_quantum_bytes(&root.queues[qi]));
-        }
-        // fraction is clamped 0.0..1.0 at config-apply time; here
-        // we use f64 → u64 with saturating cast guarded by the
-        // multiplication via f64. The result fits in u64 because
-        // quantum_sum ≤ 512 KB × N_queues and fraction ≤ 1.0.
+    // Phase 1 epoch refill. Two trigger conditions:
+    //   (a) `pass1 == 0` — legacy "budget exhausted" path. Preserved
+    //       semantics including resetting the Phase-2 cursor to 0. Also
+    //       the first-call path (pass1 seeds to 0 in the builder).
+    //   (b) #1743 time-based: `elapsed >= COS_GUARANTEE_VISIT_NS` since
+    //       the last refill. Phase-2 selections do NOT decrement `pass1`,
+    //       so under saturation `pass1` freezes at a small non-zero value
+    //       below every remaining quantum and small classes stop being
+    //       honored after a few epochs. The time-based path refreshes the
+    //       budget once per 200µs visit window even while Phase-2 keeps
+    //       draining root tokens. CRITICAL: the time-based path does NOT
+    //       reset `waterfill_phase2_cursor` (only the exhausted (a) path
+    //       does) so the descending RR walk advances through ALL large
+    //       classes across epochs rather than restarting at the largest
+    //       every 200µs (the residual-starvation regression #1630 r4
+    //       caught). Both paths clear the persistent honored bitset.
+    let elapsed_since_refresh = now_ns.saturating_sub(root.waterfill_epoch_start_ns);
+    let time_refresh = elapsed_since_refresh >= COS_GUARANTEE_VISIT_NS;
+    let exhausted = root.waterfill_pass1_remaining_bytes == 0;
+    if time_refresh || exhausted {
+        // fraction is clamped 0.0..1.0 at config-apply time; the
+        // dispatch gate also requires fraction > 0. We use f64 → u64
+        // with a floor + saturating cast guarded by the multiplication.
         let frac = root.oversubscription_guarantee_fraction;
-        let pass1 = ((quantum_sum as f64) * frac).floor() as u64;
+        let pass1 = if root.shaping_rate_bytes == 0 {
+            // Transparent (unshaped) root: there is no shaper-delivered
+            // cap to anchor against, so fall back to the legacy
+            // `quantum_sum × fraction` over the current eligible set.
+            // The result fits in u64 because quantum_sum ≤ 512 KB ×
+            // N_queues and fraction ≤ 1.0.
+            let mut quantum_sum: u64 = 0;
+            for &qi in &root.exact_queues_by_rate_ascending {
+                quantum_sum =
+                    quantum_sum.saturating_add(cos_guarantee_quantum_bytes(&root.queues[qi]));
+            }
+            ((quantum_sum as f64) * frac).floor() as u64
+        } else {
+            // #1743 Hunk A: anchor pass1 to the shaper-delivered bytes
+            // per epoch × fraction — the documented contract "fraction ×
+            // cap" where cap = shaper × VISIT_NS (docs/fairness-regimes.md).
+            // The legacy `quantum_sum × fraction` over-provisioned pass1
+            // by ~4× for any oversubscribed config (Σ R_i > shaper), so
+            // Phase 2 never fired and the selector degenerated to
+            // ascending RR over all classes. shaping_rate_bytes is
+            // bytes/sec; the u128 product is overflow-safe.
+            let cap_per_epoch = ((root.shaping_rate_bytes as u128)
+                * (COS_GUARANTEE_VISIT_NS as u128)
+                / 1_000_000_000u128) as u64;
+            let raw = ((cap_per_epoch as f64) * frac).floor() as u64;
+            // AGY RISK-1: a tiny-positive fraction floors `raw` to 0,
+            // which would make `exhausted` true on every selector call →
+            // refill + cursor-reset thrash → Phase-2 starves from index 0.
+            // Clamp to at least one min-quantum so the smallest class is
+            // honorable and the exhausted path can't fire every call.
+            raw.max(COS_GUARANTEE_QUANTUM_MIN_BYTES)
+        };
         root.waterfill_pass1_remaining_bytes = pass1;
-        root.waterfill_phase2_cursor = 0;
-        // #1732: a new epoch starts here — clear the persistent honored
-        // bitset so this epoch's Phase-1 honors start fresh. This is the
-        // single clear point: the exhaustion-reset path at the END of this
-        // function (after the Phase-2 loop) sets `pass1_remaining` to 0,
-        // which forces this refill block (and thus this clear) on the next
-        // selector call, so both epoch-exit paths are covered without a
-        // redundant double-clear.
+        root.waterfill_epoch_start_ns = now_ns;
+        // #1732/#1743: clear the persistent honored bitset on EVERY refill
+        // (both the exhausted and the time-based path) so this epoch's
+        // Phase-1 honors start fresh. Without clearing on the time-based
+        // path, honored bits would persist forever and both phases would
+        // skip every once-honored queue — the same starvation in a new
+        // guise. Phase 1 still skips already-honored bits WITHIN an epoch
+        // (the `i < 64` check below), so the per-call re-honor monopoly
+        // #1732 fixed is not reintroduced.
         root.waterfill_honored_epoch_bits = 0;
+        if exhausted {
+            // Legacy exhausted path also resets the Phase-2 cursor to 0,
+            // matching pre-#1743 behaviour. The time-based path must NOT
+            // (see the CRITICAL note above).
+            root.waterfill_phase2_cursor = 0;
+        }
         // #1628 site 1: completed-epoch / Phase-1-refill counter. Bumped
-        // here (no `queue` borrowed yet) on every lazy refill.
+        // here (no `queue` borrowed yet) on every refill, either path.
         root.waterfill_epochs = root.waterfill_epochs.wrapping_add(1);
     }
     // Phase 1: ascending-rate walk. Pick the first runnable queue
@@ -932,17 +977,25 @@ fn select_exact_cos_guarantee_queue_waterfill(
         // Picked. #1630 (P2): decouple the two roles the quantum used
         // to play. The Phase-1 budget gate / consumption stays on the
         // RATE-SCALED quantum (`phase1_cost`) so the small-first
-        // ordering and the `quantum_sum × fraction` Phase-1 budget
-        // remain consistent with `oversubscription_guarantee_fraction`.
+        // ordering and the shaper-anchored Phase-1 budget remain
+        // consistent with `oversubscription_guarantee_fraction`.
         // The actual per-visit send budget (`send_budget`) is the
         // FRAME-count cap so a queue whose token bucket has banked
         // several frames (#1630 P1) drains them whole instead of
         // discarding the sub-frame remainder of the small quantum.
-        let phase1_cost = queue
-            .hot
-            .tokens
-            .min(cos_guarantee_quantum_bytes(queue))
-            .max(head_len);
+        //
+        // #1743 Hunk B: charge the STABLE configured quantum, NOT
+        // `queue.hot.tokens.min(quantum)`. Under v8-lease pressure
+        // `queue.hot.tokens` collapses toward one frame, which collapsed
+        // `phase1_cost` to `head_len`: the queue then trivially passed
+        // the budget gate, consumed almost none of `pass1`, yet was
+        // marked fully honored (below) — so Phase-2 skipped it
+        // (phase2_admit stayed 0) while pass1 never neared exhaustion.
+        // The honor decision must reflect the queue's full guaranteed
+        // share for the epoch, independent of its current token bank.
+        // (`send_budget` keeps the token clamp — it bounds the bytes
+        // actually drained this visit, which legitimately tracks tokens.)
+        let phase1_cost = cos_guarantee_quantum_bytes(queue).max(head_len);
         let send_budget = queue
             .hot
             .tokens

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -752,20 +752,30 @@ fn select_exact_cos_guarantee_queue_with_lease_telemetry(
 //
 // Per-call state (carried on `CoSInterfaceRuntime`):
 //   - `waterfill_pass1_remaining_bytes`: Phase 1 budget remaining
-//     in the current epoch. Initialized lazily to
-//     `(quantum_sum × guarantee_fraction).floor()` whenever it's
-//     zero on entry (one full epoch == one full ascending walk +
-//     one descending Phase 2 walk).
+//     in the current epoch. #1743: refilled to
+//     `(shaping_rate_bytes × COS_GUARANTEE_VISIT_NS / 1e9 ×
+//     guarantee_fraction)` for a SHAPED root (the documented
+//     "fraction × cap" contract), or the legacy
+//     `(quantum_sum × guarantee_fraction)` for a transparent
+//     (unshaped) root, clamped to ≥ one min-quantum. Refilled on
+//     EITHER the exhausted (`pass1 == 0`) path OR the time-based
+//     path (`elapsed ≥ COS_GUARANTEE_VISIT_NS`).
 //   - `waterfill_phase2_cursor`: where Phase 2's descending walk
 //     last stopped; lets the selector resume on subsequent calls.
+//     Reset to 0 ONLY on the exhausted refill path; the time-based
+//     refresh PRESERVES it (#1743 Hunk C).
+//   - `waterfill_epoch_start_ns`: timestamp of the last refill,
+//     drives the time-based refresh (#1743).
 //
 // Each call returns ONE queue selection. The selector first tries
-// Phase 1 (ascending walk; each selection decrements
-// `pass1_remaining` by the chosen queue's secondary_budget). When
-// Phase 1 has insufficient budget for the next ascending queue,
-// the selector enters Phase 2 (descending walk through queues
-// NOT honored in Phase 1). When Phase 2 exhausts, the epoch
-// resets and Phase 1 budget is refilled.
+// Phase 1 (ascending walk; each Phase-1 honor decrements
+// `pass1_remaining` by the chosen queue's STABLE configured
+// quantum `phase1_cost`, #1743 Hunk B — NOT the token-clamped
+// send budget). When Phase 1 has insufficient budget for the next
+// ascending queue, the selector enters Phase 2 (descending walk
+// through queues NOT honored in Phase 1; Phase 2 does NOT debit
+// `pass1`). When Phase 2 exhausts, the epoch resets and Phase 1
+// budget is refilled.
 //
 // AGY r2 #1's equal-rate starvation concern is bounded by
 // stable sort (queues with identical rates retain queue_id
@@ -808,7 +818,7 @@ fn select_exact_cos_guarantee_queue_waterfill(
         // dispatch gate also requires fraction > 0. We use f64 → u64
         // with a floor + saturating cast guarded by the multiplication.
         let frac = root.oversubscription_guarantee_fraction;
-        let pass1 = if root.shaping_rate_bytes == 0 {
+        let raw_pass1 = if root.shaping_rate_bytes == 0 {
             // Transparent (unshaped) root: there is no shaper-delivered
             // cap to anchor against, so fall back to the legacy
             // `quantum_sum × fraction` over the current eligible set.
@@ -832,14 +842,18 @@ fn select_exact_cos_guarantee_queue_waterfill(
             let cap_per_epoch = ((root.shaping_rate_bytes as u128)
                 * (COS_GUARANTEE_VISIT_NS as u128)
                 / 1_000_000_000u128) as u64;
-            let raw = ((cap_per_epoch as f64) * frac).floor() as u64;
-            // AGY RISK-1: a tiny-positive fraction floors `raw` to 0,
-            // which would make `exhausted` true on every selector call →
-            // refill + cursor-reset thrash → Phase-2 starves from index 0.
-            // Clamp to at least one min-quantum so the smallest class is
-            // honorable and the exhausted path can't fire every call.
-            raw.max(COS_GUARANTEE_QUANTUM_MIN_BYTES)
+            ((cap_per_epoch as f64) * frac).floor() as u64
         };
+        // AGY RISK-1 (Codex code-r1 #2): a tiny-positive fraction floors
+        // `raw_pass1` to 0 on EITHER branch — the dispatch gate admits any
+        // `fraction > 0`, including transparent + tiny-fraction. A zero
+        // budget makes `exhausted` true on every selector call → refill +
+        // cursor-reset thrash → Phase-2 starves from index 0. Clamp BOTH
+        // branches to at least one min-quantum so the smallest class is
+        // honorable and the exhausted path can't fire every call. (The
+        // clamp is a no-op for normal fractions where raw_pass1 already
+        // exceeds the smallest quantum.)
+        let pass1 = raw_pass1.max(COS_GUARANTEE_QUANTUM_MIN_BYTES);
         root.waterfill_pass1_remaining_bytes = pass1;
         root.waterfill_epoch_start_ns = now_ns;
         // #1732/#1743: clear the persistent honored bitset on EVERY refill

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -767,6 +767,10 @@ fn select_exact_cos_guarantee_queue_with_lease_telemetry(
 //     walk advances continuously across epochs (#1743 Hunk C / r2).
 //   - `waterfill_epoch_start_ns`: timestamp of the last refill,
 //     drives the time-based refresh (#1743).
+//   - `waterfill_epoch_wrap_pending`: set by the Phase-2 wrap (`None`)
+//     path; gates the honored-bitset clear so a bare mid-walk
+//     `pass1 == 0` refill does NOT re-honor an exact-fit queue
+//     (#1743 r3 livelock fix).
 //
 // Each call returns ONE queue selection. The selector first tries
 // Phase 1 (ascending walk; each Phase-1 honor decrements
@@ -795,24 +799,28 @@ fn select_exact_cos_guarantee_queue_waterfill(
     if queue_count == 0 || root.exact_queues_by_rate_ascending.is_empty() {
         return None;
     }
-    // Phase 1 epoch refill. Two trigger conditions:
-    //   (a) `pass1 == 0` — legacy "budget exhausted" path. Preserved
-    //       semantics including resetting the Phase-2 cursor to 0. Also
-    //       the first-call path (pass1 seeds to 0 in the builder).
-    //   (b) #1743 time-based: `elapsed >= COS_GUARANTEE_VISIT_NS` since
-    //       the last refill. Phase-2 selections do NOT decrement `pass1`,
-    //       so under saturation `pass1` freezes at a small non-zero value
-    //       below every remaining quantum and small classes stop being
-    //       honored after a few epochs. The time-based path refreshes the
-    //       budget once per 200µs visit window even while Phase-2 keeps
-    //       draining root tokens. CRITICAL: NEITHER refill path resets
-    //       `waterfill_phase2_cursor` (#1743 r2 — only a genuine Phase-2
-    //       wrap at the end-of-function `None` path does) so the descending
-    //       RR walk advances through ALL large classes across epochs rather
-    //       than restarting at the largest (the residual-starvation
-    //       regression #1630 r4 caught, and the sub-200µs thrash Codex r2
-    //       found in the degenerate min-quantum case). Both refill paths
-    //       clear the persistent honored bitset.
+    // Phase 1 epoch refill. The BUDGET is refilled on two triggers:
+    //   (a) `pass1 == 0` — budget spent. Covers both the genuine Phase-2
+    //       wrap (the `None` path zeroes pass1 and arms wrap-pending) and a
+    //       mid-walk Phase-1 exact-fit honor that subtracted the last bytes.
+    //       Also the first-call path (pass1 seeds to 0 in the builder).
+    //   (b) #1743 time-based: `elapsed >= COS_GUARANTEE_VISIT_NS` since the
+    //       last refill. Phase-2 selections do NOT decrement `pass1`, so
+    //       under saturation `pass1` freezes at a small non-zero value below
+    //       every remaining quantum and small classes stop being honored;
+    //       the time tick refreshes the budget once per 200µs window.
+    //
+    // The honored BITSET, however, is cleared (allowing re-honoring) ONLY on
+    // a genuine epoch boundary: the time tick OR a Phase-2 WRAP
+    // (`waterfill_epoch_wrap_pending`). #1743 r3: a bare mid-walk `pass1 == 0`
+    // refills the budget but must NOT clear the bits, else an all-min-quantum
+    // exact-fit config livelocks Phase 1 on q0 and never reaches Phase 2.
+    //
+    // CRITICAL: NEITHER refill path resets `waterfill_phase2_cursor`
+    // (#1743 r2 — only the genuine Phase-2 wrap at the end-of-function `None`
+    // path does) so the descending RR walk advances through ALL large classes
+    // across epochs rather than restarting at the largest (the
+    // residual-starvation regression #1630 r4 caught).
     let elapsed_since_refresh = now_ns.saturating_sub(root.waterfill_epoch_start_ns);
     let time_refresh = elapsed_since_refresh >= COS_GUARANTEE_VISIT_NS;
     let exhausted = root.waterfill_pass1_remaining_bytes == 0;
@@ -859,31 +867,32 @@ fn select_exact_cos_guarantee_queue_waterfill(
         let pass1 = raw_pass1.max(COS_GUARANTEE_QUANTUM_MIN_BYTES);
         root.waterfill_pass1_remaining_bytes = pass1;
         root.waterfill_epoch_start_ns = now_ns;
-        // #1732/#1743: clear the persistent honored bitset on EVERY refill
-        // (both the exhausted and the time-based path) so this epoch's
-        // Phase-1 honors start fresh. Without clearing on the time-based
-        // path, honored bits would persist forever and both phases would
-        // skip every once-honored queue — the same starvation in a new
-        // guise. Phase 1 still skips already-honored bits WITHIN an epoch
-        // (the `i < 64` check below), so the per-call re-honor monopoly
-        // #1732 fixed is not reintroduced.
-        root.waterfill_honored_epoch_bits = 0;
-        // #1743 (Codex code-r2): NEITHER refill path resets the Phase-2
-        // cursor here. A degenerate all-min-quantum config can land pass1 at
-        // exactly 0 after a single Phase-1 honor (phase1_cost == the clamped
-        // min budget), returning BEFORE Phase 2 — so resetting the cursor on
-        // the `exhausted` refill would restart the descending walk from the
-        // largest class on every such call and starve it within a 200µs
-        // window. The cursor's ONLY legitimate reset is a genuine Phase-2
-        // WRAP: the end-of-function `None` path sets both pass1 = 0 and
-        // cursor = 0 when a full descending cycle serviced nothing. Resetting
-        // solely there means the cursor advances continuously across epochs
-        // on BOTH refill paths — exactly the #1630 r4 continuity invariant —
-        // and closes the sub-VISIT_NS thrash window the old exhausted-path
-        // reset opened. (`exhausted` is still read above as a refill trigger.)
+        // #1743 (Codex code-r3): clear the persistent honored bitset ONLY on
+        // a genuine epoch boundary — the time tick OR a Phase-2 WRAP
+        // (`waterfill_epoch_wrap_pending`, set by the end-of-function `None`
+        // path). A bare `exhausted` (pass1 == 0) that did NOT come from a
+        // wrap — e.g. a Phase-1 exact-fit honor that subtracted the last
+        // bytes mid-walk — must NOT clear the bits: clearing there re-enabled
+        // a degenerate all-min-quantum livelock where q0 is honored, pass1
+        // hits 0, the next call clears its bit, q0 is re-honored, and Phase 2
+        // is never reached. With the bits intact, the already-honored small
+        // queue is skipped (the `i < 64` check below), so the walk advances
+        // to the next queue or breaks to Phase 2 — guaranteeing forward
+        // progress. The budget is still refilled on a bare `exhausted` so
+        // Phase 1 can resume against the un-honored queues.
+        let epoch_boundary = time_refresh || root.waterfill_epoch_wrap_pending;
+        if epoch_boundary {
+            root.waterfill_honored_epoch_bits = 0;
+        }
+        root.waterfill_epoch_wrap_pending = false;
+        // #1743 (Codex code-r2): the refill never resets the Phase-2 cursor.
+        // The cursor's ONLY reset is the genuine Phase-2 WRAP at the
+        // end-of-function `None` path (which also re-arms epoch_wrap_pending),
+        // so the descending walk advances continuously across epochs — the
+        // #1630 r4 continuity invariant.
         //
         // #1628 site 1: completed-epoch / Phase-1-refill counter. Bumped
-        // here (no `queue` borrowed yet) on every refill, either path.
+        // here (no `queue` borrowed yet) on every refill, either trigger.
         root.waterfill_epochs = root.waterfill_epochs.wrapping_add(1);
     }
     // Phase 1: ascending-rate walk. Pick the first runnable queue
@@ -1185,10 +1194,16 @@ fn select_exact_cos_guarantee_queue_waterfill(
             kind,
         });
     }
-    // Epoch exhausted: nothing serviced. Reset Phase 1 budget
-    // for next call (lazy refill above will recompute).
+    // Genuine Phase-2 WRAP: a full descending cycle serviced nothing, so the
+    // epoch is fully consumed. Reset the Phase-1 budget and the cursor for
+    // the next call, and arm `epoch_wrap_pending` so the refill above clears
+    // the honored bitset (a true epoch boundary). #1743 (Codex r3): this is
+    // the ONLY place that arms the honored-bits clear besides the time tick —
+    // a bare mid-walk `pass1 == 0` does not, which avoids the all-min-quantum
+    // re-honor livelock.
     root.waterfill_pass1_remaining_bytes = 0;
     root.waterfill_phase2_cursor = 0;
+    root.waterfill_epoch_wrap_pending = true;
     None
 }
 

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -762,8 +762,9 @@ fn select_exact_cos_guarantee_queue_with_lease_telemetry(
 //     path (`elapsed ≥ COS_GUARANTEE_VISIT_NS`).
 //   - `waterfill_phase2_cursor`: where Phase 2's descending walk
 //     last stopped; lets the selector resume on subsequent calls.
-//     Reset to 0 ONLY on the exhausted refill path; the time-based
-//     refresh PRESERVES it (#1743 Hunk C).
+//     Reset to 0 ONLY on a genuine Phase-2 WRAP (the end-of-function
+//     `None` path); NEITHER refill path touches it, so the descending
+//     walk advances continuously across epochs (#1743 Hunk C / r2).
 //   - `waterfill_epoch_start_ns`: timestamp of the last refill,
 //     drives the time-based refresh (#1743).
 //
@@ -804,12 +805,14 @@ fn select_exact_cos_guarantee_queue_waterfill(
     //       below every remaining quantum and small classes stop being
     //       honored after a few epochs. The time-based path refreshes the
     //       budget once per 200µs visit window even while Phase-2 keeps
-    //       draining root tokens. CRITICAL: the time-based path does NOT
-    //       reset `waterfill_phase2_cursor` (only the exhausted (a) path
-    //       does) so the descending RR walk advances through ALL large
-    //       classes across epochs rather than restarting at the largest
-    //       every 200µs (the residual-starvation regression #1630 r4
-    //       caught). Both paths clear the persistent honored bitset.
+    //       draining root tokens. CRITICAL: NEITHER refill path resets
+    //       `waterfill_phase2_cursor` (#1743 r2 — only a genuine Phase-2
+    //       wrap at the end-of-function `None` path does) so the descending
+    //       RR walk advances through ALL large classes across epochs rather
+    //       than restarting at the largest (the residual-starvation
+    //       regression #1630 r4 caught, and the sub-200µs thrash Codex r2
+    //       found in the degenerate min-quantum case). Both refill paths
+    //       clear the persistent honored bitset.
     let elapsed_since_refresh = now_ns.saturating_sub(root.waterfill_epoch_start_ns);
     let time_refresh = elapsed_since_refresh >= COS_GUARANTEE_VISIT_NS;
     let exhausted = root.waterfill_pass1_remaining_bytes == 0;
@@ -865,12 +868,20 @@ fn select_exact_cos_guarantee_queue_waterfill(
         // (the `i < 64` check below), so the per-call re-honor monopoly
         // #1732 fixed is not reintroduced.
         root.waterfill_honored_epoch_bits = 0;
-        if exhausted {
-            // Legacy exhausted path also resets the Phase-2 cursor to 0,
-            // matching pre-#1743 behaviour. The time-based path must NOT
-            // (see the CRITICAL note above).
-            root.waterfill_phase2_cursor = 0;
-        }
+        // #1743 (Codex code-r2): NEITHER refill path resets the Phase-2
+        // cursor here. A degenerate all-min-quantum config can land pass1 at
+        // exactly 0 after a single Phase-1 honor (phase1_cost == the clamped
+        // min budget), returning BEFORE Phase 2 — so resetting the cursor on
+        // the `exhausted` refill would restart the descending walk from the
+        // largest class on every such call and starve it within a 200µs
+        // window. The cursor's ONLY legitimate reset is a genuine Phase-2
+        // WRAP: the end-of-function `None` path sets both pass1 = 0 and
+        // cursor = 0 when a full descending cycle serviced nothing. Resetting
+        // solely there means the cursor advances continuously across epochs
+        // on BOTH refill paths — exactly the #1630 r4 continuity invariant —
+        // and closes the sub-VISIT_NS thrash window the old exhausted-path
+        // reset opened. (`exhausted` is still read above as a refill trigger.)
+        //
         // #1628 site 1: completed-epoch / Phase-1-refill counter. Bumped
         // here (no `queue` borrowed yet) on every refill, either path.
         root.waterfill_epochs = root.waterfill_epochs.wrapping_add(1);

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -2662,13 +2662,14 @@ fn waterfill_counters_budget_break_into_phase2() {
     // phase1_cost exceeds the remaining budget at mod.rs:906.
     let mut root = waterfill_guarantee_rate_root(0.0001);
     // #1743: use a TRANSPARENT root (shaping_rate_bytes == 0) so the
-    // Phase-1 budget takes the legacy `quantum_sum × fraction` path. The
-    // budget floors to 0 and the symmetric anti-thrash clamp (Codex r1 #2)
-    // raises it to one min-quantum (1500 B). To force the Phase-1 break we
-    // need every exact queue's quantum to EXCEED that clamped 1500 B floor,
-    // so bump the exact queues to 3 Gbps (quantum 75,000 B ≫ 1500). The
-    // clamped 1500 B budget is then below every quantum and Phase 1 breaks
-    // immediately into Phase 2. (The clamp itself is verified separately in
+    // Phase-1 budget takes the legacy `quantum_sum × fraction` path. After
+    // bumping the exact queues to 3 Gbps (quantum 75,000 B), raw pass1 =
+    // floor(quantum_sum × 0.0001) is a few bytes, which the symmetric
+    // anti-thrash clamp (Codex r1 #2) raises to one min-quantum (1500 B).
+    // To force the Phase-1 break we need every exact queue's quantum to
+    // EXCEED that clamped 1500 B floor — 75,000 B ≫ 1500 — so the clamped
+    // budget is below every quantum and Phase 1 breaks immediately into
+    // Phase 2. (The clamp itself is verified separately in
     // waterfill_pass1_tiny_fraction_clamped_to_min_quantum.)
     root.shaping_rate_bytes = 0;
     for q in &mut root.queues {
@@ -2864,8 +2865,8 @@ fn waterfill_pass1_refreshes_on_time_tick_clears_honored_bits() {
     );
     assert_eq!(
         root.waterfill_phase2_cursor, cursor_after_epoch1,
-        "the time-based refresh must PRESERVE the Phase-2 cursor (only the \
-         exhausted path resets it)"
+        "the time-based refresh must PRESERVE the Phase-2 cursor (#1743 r2: \
+         neither refill path resets it — only a genuine Phase-2 wrap does)"
     );
 }
 
@@ -2930,5 +2931,35 @@ fn waterfill_pass1_tiny_fraction_clamped_to_min_quantum() {
         root.waterfill_phase1_budget_breaks, 1,
         "Phase-1 broke because the clamped budget (1500) is below the \
          smallest quantum (2500)"
+    );
+}
+
+#[test]
+fn waterfill_exhausted_refill_does_not_reset_phase2_cursor() {
+    // #1743 (Codex code-r2): the exhausted (`pass1 == 0`) refill path must
+    // NOT reset the Phase-2 cursor. A degenerate config can land pass1 at
+    // exactly 0 after a Phase-1 honor (phase1_cost == the remaining budget),
+    // returning before Phase 2 — so an exhausted-refill cursor reset on the
+    // next call would restart the descending walk from the largest class and
+    // starve it. Only a genuine Phase-2 wrap (the end-of-function `None`
+    // path) may reset the cursor. Pin that an exhausted refill preserves a
+    // nonzero cursor.
+    let mut root = waterfill_three_unequal_exact_root(0.7);
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    // Drive epoch 1 to advance the Phase-2 cursor to a nonzero value (q0+q1
+    // honored Phase-1, q2 served Phase-2 — see the time-tick test).
+    for _ in 0..3 {
+        let _ = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel);
+    }
+    let cursor = root.waterfill_phase2_cursor;
+    assert_ne!(cursor, 0, "precondition: Phase-2 cursor advanced in epoch 1");
+    // Force the exhausted refill path WITHOUT advancing the clock (so it is
+    // the exhausted trigger, not the time-based one) by zeroing pass1.
+    root.waterfill_pass1_remaining_bytes = 0;
+    let _ = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel);
+    assert_eq!(
+        root.waterfill_phase2_cursor, cursor,
+        "the exhausted refill path must PRESERVE the Phase-2 cursor; only a \
+         genuine Phase-2 wrap (`None` path) may reset it"
     );
 }

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -2538,10 +2538,14 @@ fn waterfill_honored_set_clears_on_epoch_refill() {
         "honored bits accumulate within an epoch"
     );
 
-    // Force the epoch boundary: zero the Phase-1 budget so the next call
-    // takes the lazy-refill path (the same effect as the natural exhaustion
-    // reset at the end of the selector).
+    // Force a GENUINE epoch boundary: zero the Phase-1 budget AND arm
+    // `waterfill_epoch_wrap_pending`, exactly as the end-of-function Phase-2
+    // WRAP (`None`) path does. #1743 r3: a bare `pass1 == 0` alone refills the
+    // budget but does NOT clear the honored bits (that avoids the exact-fit
+    // livelock); only the time tick or a genuine wrap clears them — which is
+    // what this #1732 test means by "epoch boundary".
     root.waterfill_pass1_remaining_bytes = 0;
+    root.waterfill_epoch_wrap_pending = true;
     let epochs_before = root.waterfill_epochs;
 
     let s_next = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
@@ -2961,5 +2965,62 @@ fn waterfill_exhausted_refill_does_not_reset_phase2_cursor() {
         root.waterfill_phase2_cursor, cursor,
         "the exhausted refill path must PRESERVE the Phase-2 cursor; only a \
          genuine Phase-2 wrap (`None` path) may reset it"
+    );
+}
+
+#[test]
+fn waterfill_exact_fit_honor_does_not_livelock_phase1() {
+    // #1743 (Codex code-r3): the deeper degenerate-config defect. When a
+    // Phase-1 exact-fit honor subtracts the budget to exactly 0, the next
+    // call's bare `exhausted` refill must NOT clear the honored bitset — only
+    // a genuine epoch boundary (time tick OR Phase-2 wrap) clears it.
+    // Clearing on a bare mid-walk `pass1 == 0` re-enabled a livelock: q0
+    // honored → pass1=0 → next call clears q0's bit → q0 re-honored → … with
+    // Phase 2 NEVER reached, starving every larger class.
+    //
+    // Fixture: shaper 187,500,000 B/s (cap_per_epoch == quantum_sum ==
+    // 37,500 B); fraction tuned so the Phase-1 budget == q0's quantum exactly
+    // (2,500 B). q0 (100m, quantum 2,500) is an exact-fit honor; q1 (400m,
+    // 10,000) and q2 (1g, 25,000) must still get Phase-2 service.
+    let mut root = waterfill_three_unequal_exact_root(2_500.0 / 37_500.0);
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+
+    // Call 1: Phase-1 honors q0 (cost 2,500), pass1 → 0.
+    let s1 = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("call 1");
+    assert_eq!(s1.queue_idx, 0, "call 1 honors q0 (smallest, exact-fit)");
+    assert_eq!(
+        root.waterfill_pass1_remaining_bytes, 0,
+        "the exact-fit honor drained pass1 to exactly 0"
+    );
+
+    // Drive several more calls at the SAME now_ns (no time tick) and confirm
+    // a non-q0 queue is serviced — i.e. Phase 2 IS reached, no livelock. With
+    // the pre-r3 bug (clearing bits on bare exhausted) q0 would be re-honored
+    // on every call and q1/q2 would never run.
+    let mut serviced_non_q0 = false;
+    let mut q0_admits = 0u64;
+    for _ in 0..8 {
+        if let Some(s) =
+            select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        {
+            if s.queue_idx == 0 {
+                q0_admits += 1;
+            } else {
+                serviced_non_q0 = true;
+            }
+        }
+    }
+    assert!(
+        serviced_non_q0,
+        "Phase 2 must service a larger class within a few calls — q0's \
+         exact-fit honor must not livelock Phase 1 (the #1743 r3 defect)"
+    );
+    // q0 is honored at most once per genuine epoch boundary, not on every
+    // bare-exhausted refill. Over 8 same-tick calls it cannot dominate.
+    assert!(
+        q0_admits <= 2,
+        "q0 must not be re-honored on every bare-exhausted refill (got \
+         {q0_admits} Phase-1 admits in 8 same-tick calls)"
     );
 }

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -2662,13 +2662,20 @@ fn waterfill_counters_budget_break_into_phase2() {
     // phase1_cost exceeds the remaining budget at mod.rs:906.
     let mut root = waterfill_guarantee_rate_root(0.0001);
     // #1743: use a TRANSPARENT root (shaping_rate_bytes == 0) so the
-    // Phase-1 budget takes the legacy `quantum_sum × fraction` path and a
-    // tiny fraction can genuinely floor it below the smallest quantum,
-    // forcing the break. The shaped path now clamps pass1 to at least one
-    // min-quantum (AGY RISK-1), so a shaped root can no longer produce a
-    // budget below the smallest phase1_cost — that anti-thrash clamp is
-    // verified separately in waterfill_pass1_tiny_fraction_clamped_to_min.
+    // Phase-1 budget takes the legacy `quantum_sum × fraction` path. The
+    // budget floors to 0 and the symmetric anti-thrash clamp (Codex r1 #2)
+    // raises it to one min-quantum (1500 B). To force the Phase-1 break we
+    // need every exact queue's quantum to EXCEED that clamped 1500 B floor,
+    // so bump the exact queues to 3 Gbps (quantum 75,000 B ≫ 1500). The
+    // clamped 1500 B budget is then below every quantum and Phase 1 breaks
+    // immediately into Phase 2. (The clamp itself is verified separately in
+    // waterfill_pass1_tiny_fraction_clamped_to_min_quantum.)
     root.shaping_rate_bytes = 0;
+    for q in &mut root.queues {
+        if q.config.exact {
+            q.config.transmit_rate_bytes = 3_000_000_000 / 8;
+        }
+    }
     let mut tel = CoSQueueLeaseAcquireTelemetry::default();
     let s = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
         .expect("phase-2 selection after budget break");
@@ -2805,11 +2812,18 @@ fn waterfill_pass1_refreshes_on_time_tick_clears_honored_bits() {
     // time-based path must refresh pass1 AND clear the persistent honored
     // bitset once `now_ns - epoch_start >= COS_GUARANTEE_VISIT_NS`, while
     // PRESERVING the Phase-2 cursor.
+    //
+    // Codex code-r1: use the DEFAULT 187,500,000 B/s shaper (cap_per_epoch
+    // == quantum_sum == 37,500 B) so at fraction 0.7 the budget is 26,250 B
+    // — enough to honor q0 (2,500) + q1 (10,000) in Phase 1 but NOT q2
+    // (25,000) — which forces a Phase-2 admit and advances the cursor to a
+    // NONZERO value. A 25 Gbps override here would budget 437,500 B, honor
+    // all three queues in Phase 1, never advance Phase 2, and leave the
+    // cursor at 0 — making the preservation assertion vacuous.
     let mut root = waterfill_three_unequal_exact_root(0.7);
-    root.shaping_rate_bytes = 25_000_000_000 / 8;
     let mut tel = CoSQueueLeaseAcquireTelemetry::default();
-    // Epoch 1 at t = 1ns: honor some small classes (sets honored bits) and
-    // advance the Phase-2 cursor.
+    // Epoch 1 at t = 1ns: honor q0+q1 (sets honored bits) and serve q2 in
+    // Phase 2 (advances the cursor to nonzero).
     for _ in 0..3 {
         let _ = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel);
     }
@@ -2818,6 +2832,11 @@ fn waterfill_pass1_refreshes_on_time_tick_clears_honored_bits() {
         "honored bits accumulate within epoch 1"
     );
     let cursor_after_epoch1 = root.waterfill_phase2_cursor;
+    assert_ne!(
+        cursor_after_epoch1, 0,
+        "epoch 1 must have advanced the Phase-2 cursor (a Phase-2 admit \
+         occurred) so the preservation assertion below is non-vacuous"
+    );
     let pass1_mid_epoch = root.waterfill_pass1_remaining_bytes;
     assert_ne!(pass1_mid_epoch, 0, "pass1 is non-zero mid-epoch (not exhausted)");
     let epochs_before = root.waterfill_epochs;

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -2400,8 +2400,15 @@ fn waterfill_three_unequal_exact_root(frac: f64) -> CoSInterfaceRuntime {
             codel_target_ns: 0,
         }
     }
+    // #1743: the Phase-1 budget is now `shaper × VISIT_NS × fraction`, not
+    // `quantum_sum × fraction`. Pin the shaper so cap_per_epoch equals the
+    // quantum_sum (37,500 B) — `shaper × 200µs = 37,500` ⇒ shaper =
+    // 187,500,000 B/s (1.5 Gbps). That keeps the per-epoch budget identical
+    // to the pre-#1743 `quantum_sum`-based value at any fraction, so the
+    // budget-break-into-Phase-2 semantics these tests pin are preserved
+    // under the corrected formula.
     let mut root = test_cos_runtime_with_queues(
-        10_000_000_000 / 8,
+        187_500_000,
         vec![
             exact_queue(0, "exact-100m", 100_000_000 / 8),
             exact_queue(1, "exact-400m", 400_000_000 / 8),
@@ -2654,6 +2661,14 @@ fn waterfill_counters_budget_break_into_phase2() {
     // any single queue's quantum, the first ascending queue's
     // phase1_cost exceeds the remaining budget at mod.rs:906.
     let mut root = waterfill_guarantee_rate_root(0.0001);
+    // #1743: use a TRANSPARENT root (shaping_rate_bytes == 0) so the
+    // Phase-1 budget takes the legacy `quantum_sum × fraction` path and a
+    // tiny fraction can genuinely floor it below the smallest quantum,
+    // forcing the break. The shaped path now clamps pass1 to at least one
+    // min-quantum (AGY RISK-1), so a shaped root can no longer produce a
+    // budget below the smallest phase1_cost — that anti-thrash clamp is
+    // verified separately in waterfill_pass1_tiny_fraction_clamped_to_min.
+    root.shaping_rate_bytes = 0;
     let mut tel = CoSQueueLeaseAcquireTelemetry::default();
     let s = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
         .expect("phase-2 selection after budget break");
@@ -2692,4 +2707,209 @@ fn waterfill_counters_phase1_admit_flake_5x() {
         );
         assert_eq!(root.waterfill_epochs, 1);
     }
+}
+
+// ---------------------------------------------------------------------------
+// #1743: shaper-anchored Phase-1 budget + stable honor charge + time refresh.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn waterfill_pass1_anchored_to_shaper_per_epoch() {
+    // #1743 Hunk A: for a SHAPED root the Phase-1 budget must be
+    // `shaper × VISIT_NS × fraction`, NOT `quantum_sum × fraction`. The
+    // smoke fixture is oversubscribed (Σ R_i ≫ shaper), so the old formula
+    // over-budgeted pass1 by ~4× and Phase-2 never fired. Pin the corrected
+    // budget directly: a 25 Gbps shaper at fraction 0.7 yields
+    // floor(25e9/8 × 200µs × 0.7) = floor(625_000 × 0.7) = 437_500 B,
+    // regardless of how large the sum of configured class rates is.
+    let mut root = waterfill_three_unequal_exact_root(0.7);
+    root.shaping_rate_bytes = 25_000_000_000 / 8;
+    // First selector call takes the exhausted refill path (pass1 seeded 0)
+    // and computes the shaper-anchored budget. Inspect it before any honor
+    // debit by checking the value the refill installs: drive one call then
+    // add back the single honor charge it consumed.
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    let s = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("first selection");
+    let charged = cos_guarantee_quantum_bytes(&root.queues[s.queue_idx])
+        .max(1500 /* head_len of the primed 1500-byte item */);
+    let installed_budget = root.waterfill_pass1_remaining_bytes + charged;
+    assert_eq!(
+        installed_budget, 437_500,
+        "Phase-1 budget must be shaper × VISIT_NS × fraction (437,500 B at \
+         25 Gbps / 0.7), not the oversubscribed quantum_sum × fraction"
+    );
+}
+
+#[test]
+fn waterfill_pass1_transparent_root_fallback_to_quantum_sum() {
+    // #1743 Hunk A: a TRANSPARENT root (shaping_rate_bytes == 0) has no
+    // shaper-delivered cap to anchor against, so it must fall back to the
+    // legacy quantum_sum × fraction. Quanta 2500/10000/25000, sum 37,500;
+    // fraction 0.4 ⇒ budget floor(37_500 × 0.4) = 15_000 B.
+    let mut root = waterfill_three_unequal_exact_root(0.4);
+    root.shaping_rate_bytes = 0;
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    let s = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("first selection");
+    let charged = cos_guarantee_quantum_bytes(&root.queues[s.queue_idx]).max(1500);
+    let installed_budget = root.waterfill_pass1_remaining_bytes + charged;
+    assert_eq!(
+        installed_budget, 15_000,
+        "transparent-root budget must use quantum_sum × fraction (15,000 B)"
+    );
+}
+
+#[test]
+fn waterfill_phase1_honor_charge_is_configured_quantum_not_tokens() {
+    // #1743 Hunk B: the Phase-1 honor charge must be the STABLE configured
+    // quantum, NOT `queue.hot.tokens.min(quantum)`. Under v8-lease pressure
+    // tokens collapse toward one frame; the old charge then fell to head_len,
+    // the queue was marked fully honored for ~one frame, and Phase-2 skipped
+    // it. With the fixed charge a token-pressured small queue still consumes
+    // its full quantum against pass1 (or is left for Phase-2 if it does not
+    // fit), so the budget is spent honestly.
+    //
+    // Shaper anchored so the budget equals quantum_sum (37,500 B) at frac 1.0
+    // (see waterfill_three_unequal_exact_root). Pin q1's tokens to exactly
+    // one frame; its configured quantum is 10,000 B (400 Mbps × 200µs).
+    let mut root = waterfill_three_unequal_exact_root(1.0);
+    // q0 quantum 2,500; q1 quantum 10,000; q2 quantum 25,000; sum 37,500.
+    // Starve q1's token bank to one frame to exercise the old undercharge.
+    root.queues[1].hot.tokens = 1500;
+    let q1_quantum = cos_guarantee_quantum_bytes(&root.queues[1]);
+    assert!(
+        q1_quantum > root.queues[1].hot.tokens,
+        "precondition: configured quantum exceeds the depleted token bank"
+    );
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    // Selection 1 honors q0 (smallest). Selection 2 reaches q1.
+    let _ = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("selection 1");
+    let budget_before_q1 = root.waterfill_pass1_remaining_bytes;
+    let s2 = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("selection 2");
+    assert_eq!(s2.queue_idx, 1, "selection 2 honors q1");
+    let charged = budget_before_q1 - root.waterfill_pass1_remaining_bytes;
+    assert_eq!(
+        charged, q1_quantum,
+        "Phase-1 must charge q1's FULL configured quantum ({q1_quantum} B), \
+         not its depleted token bank (1500 B) — the #1743 undercharge"
+    );
+}
+
+#[test]
+fn waterfill_pass1_refreshes_on_time_tick_clears_honored_bits() {
+    // #1743 Hunk C: under saturation Phase-2 does not decrement pass1, so the
+    // budget never hits 0 and the legacy exhausted-refill never fires. The
+    // time-based path must refresh pass1 AND clear the persistent honored
+    // bitset once `now_ns - epoch_start >= COS_GUARANTEE_VISIT_NS`, while
+    // PRESERVING the Phase-2 cursor.
+    let mut root = waterfill_three_unequal_exact_root(0.7);
+    root.shaping_rate_bytes = 25_000_000_000 / 8;
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    // Epoch 1 at t = 1ns: honor some small classes (sets honored bits) and
+    // advance the Phase-2 cursor.
+    for _ in 0..3 {
+        let _ = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel);
+    }
+    assert_ne!(
+        root.waterfill_honored_epoch_bits, 0,
+        "honored bits accumulate within epoch 1"
+    );
+    let cursor_after_epoch1 = root.waterfill_phase2_cursor;
+    let pass1_mid_epoch = root.waterfill_pass1_remaining_bytes;
+    assert_ne!(pass1_mid_epoch, 0, "pass1 is non-zero mid-epoch (not exhausted)");
+    let epochs_before = root.waterfill_epochs;
+
+    // Advance the clock past one VISIT_NS without ever zeroing pass1. The
+    // time-based refresh must fire on the next call.
+    let next_ns = 1 + COS_GUARANTEE_VISIT_NS + 1;
+    let _ = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], next_ns, &mut tel)
+        .expect("selection after time refresh");
+
+    assert_eq!(
+        root.waterfill_epochs,
+        epochs_before + 1,
+        "the time-based refresh must bump the epoch counter"
+    );
+    assert_eq!(
+        root.waterfill_epoch_start_ns, next_ns,
+        "the refresh must re-seed epoch_start_ns to now_ns"
+    );
+    // The honored bitset was cleared at the refresh, then the smallest queue
+    // was re-honored on this same call — so only ordinal 0's bit is set now.
+    assert_eq!(
+        root.waterfill_honored_epoch_bits, 0b001,
+        "timed refresh must clear honored bits, then Phase-1 re-honors q0"
+    );
+    assert_eq!(
+        root.waterfill_phase2_cursor, cursor_after_epoch1,
+        "the time-based refresh must PRESERVE the Phase-2 cursor (only the \
+         exhausted path resets it)"
+    );
+}
+
+#[test]
+fn waterfill_pass1_undersubscribed_shaper_honors_all_classes() {
+    // Codex r1 #6: when the shaper is UNDERSUBSCRIBED (shaper > Σ R_i) the
+    // cap-anchored budget is ≥ quantum_sum, so Phase-1 can honor every class
+    // without spuriously pushing any to Phase-2. Shaper 10 Gbps, quanta
+    // 2500/10000/25000 (sum 37,500), fraction 1.0 ⇒ cap_per_epoch =
+    // floor(10e9/8 × 200µs) = 250,000 B ⇒ budget 250,000 ≫ 37,500.
+    let mut root = waterfill_three_unequal_exact_root(1.0);
+    root.shaping_rate_bytes = 10_000_000_000 / 8;
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    let s1 = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("s1");
+    let s2 = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("s2");
+    let s3 = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("s3");
+    assert_eq!((s1.queue_idx, s2.queue_idx, s3.queue_idx), (0, 1, 2));
+    for qi in 0..3 {
+        assert_eq!(
+            root.queues[qi].telemetry.waterfill_counters.phase1_admissions, 1,
+            "queue {qi} must be honored in Phase 1 under an undersubscribed shaper"
+        );
+        assert_eq!(
+            root.queues[qi].telemetry.waterfill_counters.phase2_admissions, 0,
+            "no class should fall to Phase 2 when shaper > Σ R_i"
+        );
+    }
+}
+
+#[test]
+fn waterfill_pass1_tiny_fraction_clamped_to_min_quantum() {
+    // AGY RISK-1: a tiny-positive fraction floors the shaped budget to 0,
+    // which would make `exhausted` true every call → refill + cursor-reset
+    // thrash. The shaped path clamps pass1 to ≥ COS_GUARANTEE_QUANTUM_MIN_BYTES
+    // so at least the smallest class is honorable and the exhausted path does
+    // not fire on every selector call.
+    let mut root = waterfill_three_unequal_exact_root(0.0000001);
+    root.shaping_rate_bytes = 25_000_000_000 / 8;
+    let mut tel = CoSQueueLeaseAcquireTelemetry::default();
+    // The tiny fraction floors raw to 0; the clamp installs pass1 =
+    // COS_GUARANTEE_QUANTUM_MIN_BYTES (1500). 1500 is below the smallest
+    // class quantum (2500), so Phase-1 breaks immediately into Phase-2 —
+    // which still admits the largest un-honored queue. The point: pass1 is
+    // NOT 0, so the exhausted path does not fire on every call.
+    let s = select_exact_cos_guarantee_queue_with_lease_telemetry(&mut root, &[], 1, &mut tel)
+        .expect("first selection still admits via Phase-2");
+    // Phase-1 broke before honoring anyone and Phase-2 does not debit pass1,
+    // so the installed clamped budget is observable directly.
+    assert_eq!(
+        root.waterfill_pass1_remaining_bytes, COS_GUARANTEE_QUANTUM_MIN_BYTES,
+        "a tiny fraction must clamp the Phase-1 budget to one min-quantum, \
+         not floor it to 0"
+    );
+    assert_eq!(
+        root.queues[s.queue_idx].telemetry.waterfill_counters.phase2_admissions, 1,
+        "the budget-broke selection is served by Phase-2"
+    );
+    assert_eq!(
+        root.waterfill_phase1_budget_breaks, 1,
+        "Phase-1 broke because the clamped budget (1500) is below the \
+         smallest quantum (2500)"
+    );
 }

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -440,8 +440,12 @@ pub(in crate::afxdp) struct CoSInterfaceRuntime {
     /// the Phase-1 budget (skew toward the lowest-rate queue). This bitset
     /// is now persisted across selector calls, read by BOTH phases (so each
     /// queue is honored at most once per epoch, smallest-first, and Phase 2
-    /// serves the residual to the larger un-honored queues), and CLEARED at
-    /// the lazy Phase-1 refill where `waterfill_epochs` bumps. The set/skip
+    /// serves the residual to the larger un-honored queues). #1743 r3: it is
+    /// CLEARED only on a genuine epoch boundary — the 200µs time tick OR a
+    /// Phase-2 WRAP (`waterfill_epoch_wrap_pending`) — NOT on every Phase-1
+    /// budget refill (`waterfill_epochs` still bumps on every refill, but a
+    /// bare mid-walk `pass1 == 0` refill must keep the bits so an exact-fit
+    /// honor does not re-honor the same queue forever). The set/skip
     /// sites guard the shift with `ordinal < 64`, so a (malformed) config
     /// with >64 exact queues leaves ordinals ≥64 conservatively untracked
     /// rather than wrapping `1u64 << (≥64)`. Single-writer owner worker.

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -456,6 +456,19 @@ pub(in crate::afxdp) struct CoSInterfaceRuntime {
     /// breaks-per-epoch ratio means Phase 1 routinely exhausts its budget
     /// mid-walk. Single-writer owner worker, plain `u64`.
     pub(in crate::afxdp) waterfill_phase1_budget_breaks: u64,
+    /// #1743: monotonic nanosecond timestamp of the most recent waterfill
+    /// Phase-1 epoch refill. The selector refreshes the Phase-1 budget when
+    /// `now_ns - waterfill_epoch_start_ns >= COS_GUARANTEE_VISIT_NS` (200µs)
+    /// in addition to the legacy `pass1 == 0` exhausted path. Without the
+    /// time-based refresh, Phase-2 selections (which do NOT decrement the
+    /// Phase-1 budget) let the budget freeze at a small non-zero value under
+    /// saturation, so small classes stop being honored after a few epochs.
+    /// The timed-refresh path clears `waterfill_honored_epoch_bits` but
+    /// PRESERVES `waterfill_phase2_cursor` (only the exhausted path resets
+    /// the cursor) so the Phase-2 descending RR walk stays continuous across
+    /// epochs. Worker-local runtime; NOT HA-synced (same class as the other
+    /// waterfill_* fields above). Single-writer owner worker, plain `u64`.
+    pub(in crate::afxdp) waterfill_epoch_start_ns: u64,
     // Round-robin cursors for the two guarantee service classes. Exact and
     // non-exact guarantee queues rotate independently — the scheduler gives
     // exact queues strict priority over non-exact guarantee service (the

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -465,16 +465,27 @@ pub(in crate::afxdp) struct CoSInterfaceRuntime {
     /// #1743: monotonic nanosecond timestamp of the most recent waterfill
     /// Phase-1 epoch refill. The selector refreshes the Phase-1 budget when
     /// `now_ns - waterfill_epoch_start_ns >= COS_GUARANTEE_VISIT_NS` (200µs)
-    /// in addition to the legacy `pass1 == 0` exhausted path. Without the
+    /// in addition to the `pass1 == 0` budget-spent path. Without the
     /// time-based refresh, Phase-2 selections (which do NOT decrement the
     /// Phase-1 budget) let the budget freeze at a small non-zero value under
     /// saturation, so small classes stop being honored after a few epochs.
-    /// The timed-refresh path clears `waterfill_honored_epoch_bits` but
-    /// PRESERVES `waterfill_phase2_cursor` (only the exhausted path resets
-    /// the cursor) so the Phase-2 descending RR walk stays continuous across
-    /// epochs. Worker-local runtime; NOT HA-synced (same class as the other
+    /// Worker-local runtime; NOT HA-synced (same class as the other
     /// waterfill_* fields above). Single-writer owner worker, plain `u64`.
     pub(in crate::afxdp) waterfill_epoch_start_ns: u64,
+    /// #1743 (Codex code-r3): true when a genuine epoch boundary is pending
+    /// — set ONLY by the end-of-function Phase-2 WRAP (`None`) path, which
+    /// also zeroes `waterfill_pass1_remaining_bytes` and the cursor. The
+    /// distinction matters because `pass1` can also reach 0 mid-walk when a
+    /// Phase-1 exact-fit honor subtracts the last bytes; that is NOT an epoch
+    /// boundary. The honored-bitset is cleared (allowing queues to be
+    /// re-honored) ONLY on the time tick OR when this flag is set — NOT on
+    /// every `pass1 == 0` refill. Clearing on a bare mid-walk `pass1 == 0`
+    /// re-enabled a degenerate all-min-quantum livelock (q0 honored → pass1=0
+    /// → clear bits → q0 re-honored → … with Phase 2 never reached). A bare
+    /// `pass1 == 0` still REFILLS the budget so Phase 1 can resume, but with
+    /// the honored bits intact the already-honored small queue is skipped and
+    /// the walk advances / breaks to Phase 2. Single-writer owner worker.
+    pub(in crate::afxdp) waterfill_epoch_wrap_pending: bool,
     // Round-robin cursors for the two guarantee service classes. Exact and
     // non-exact guarantee queues rotate independently — the scheduler gives
     // exact queues strict priority over non-exact guarantee service (the

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -405,7 +405,10 @@ pub(in crate::afxdp) struct CoSInterfaceRuntime {
     /// waterfill phase 1 greedy honor loop.
     pub(in crate::afxdp) exact_queues_by_rate_ascending: Vec<usize>,
     /// #1614 A1: Phase 1 byte budget remaining in the current
-    /// service epoch (one RR cycle through the sorted vec).
+    /// service epoch. #1743: an epoch ends on EITHER a Phase-2 wrap
+    /// (full RR cycle through the sorted vec) OR a 200µs time tick —
+    /// it is no longer strictly one RR cycle, so `waterfill_epochs`
+    /// counts budget refreshes (either trigger), not RR completions.
     /// #1743: refilled to `(shaping_rate_bytes × COS_GUARANTEE_VISIT_NS
     /// / 1e9 × guarantee_fraction)` for a SHAPED root (the documented
     /// "fraction × cap" contract) or the legacy `(quantum_sum ×

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -406,11 +406,14 @@ pub(in crate::afxdp) struct CoSInterfaceRuntime {
     pub(in crate::afxdp) exact_queues_by_rate_ascending: Vec<usize>,
     /// #1614 A1: Phase 1 byte budget remaining in the current
     /// service epoch (one RR cycle through the sorted vec).
-    /// Initialized to `(quantum_sum × guarantee_fraction).floor()`
-    /// at the start of each cycle. Decremented per successful
-    /// Phase 1 selection by the chosen queue's secondary_budget.
-    /// When it drops below the next-queue's quantum, the selector
-    /// switches to Phase 2 residual distribution.
+    /// #1743: refilled to `(shaping_rate_bytes × COS_GUARANTEE_VISIT_NS
+    /// / 1e9 × guarantee_fraction)` for a SHAPED root (the documented
+    /// "fraction × cap" contract) or the legacy `(quantum_sum ×
+    /// guarantee_fraction)` for a transparent root, clamped to ≥ one
+    /// min-quantum. Decremented per successful Phase 1 honor by the
+    /// chosen queue's STABLE configured quantum (`phase1_cost`, NOT the
+    /// token-clamped send budget). When it drops below the next queue's
+    /// quantum, the selector switches to Phase 2 residual distribution.
     pub(in crate::afxdp) waterfill_pass1_remaining_bytes: u64,
     /// #1614 A1: descending-rate cursor into the sorted vec for
     /// Phase 2 residual distribution. Tracks where in the

--- a/userspace-dp/src/afxdp/worker/cos/tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos/tests.rs
@@ -194,6 +194,7 @@ fn build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue() {
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
         waterfill_epoch_start_ns: 0,
+        waterfill_epoch_wrap_pending: false,
             exact_guarantee_rr: 0,
             nonexact_guarantee_rr: 0,
             #[cfg(test)]
@@ -369,6 +370,7 @@ fn build_worker_cos_statuses_sums_owner_profile_without_breaking_hist_invariant(
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
         waterfill_epoch_start_ns: 0,
+        waterfill_epoch_wrap_pending: false,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -606,6 +608,7 @@ fn build_worker_cos_statuses_owner_profile_only_surfaces_on_unambiguous_owner_lo
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
         waterfill_epoch_start_ns: 0,
+        waterfill_epoch_wrap_pending: false,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -895,6 +898,7 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_exact_
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
         waterfill_epoch_start_ns: 0,
+        waterfill_epoch_wrap_pending: false,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -1099,6 +1103,7 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_interf
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
         waterfill_epoch_start_ns: 0,
+        waterfill_epoch_wrap_pending: false,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -1304,6 +1309,7 @@ fn build_worker_cos_statuses_surfaces_distinct_per_queue_drain_telemetry() {
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
         waterfill_epoch_start_ns: 0,
+        waterfill_epoch_wrap_pending: false,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -2387,6 +2393,7 @@ fn active_flow_buckets_peak_is_max_not_sum_across_workers() {
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
         waterfill_epoch_start_ns: 0,
+        waterfill_epoch_wrap_pending: false,
             exact_guarantee_rr: 0,
             nonexact_guarantee_rr: 0,
             #[cfg(test)]

--- a/userspace-dp/src/afxdp/worker/cos/tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos/tests.rs
@@ -193,6 +193,7 @@ fn build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue() {
         waterfill_honored_epoch_bits: 0,
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
+        waterfill_epoch_start_ns: 0,
             exact_guarantee_rr: 0,
             nonexact_guarantee_rr: 0,
             #[cfg(test)]
@@ -367,6 +368,7 @@ fn build_worker_cos_statuses_sums_owner_profile_without_breaking_hist_invariant(
         waterfill_honored_epoch_bits: 0,
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
+        waterfill_epoch_start_ns: 0,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -603,6 +605,7 @@ fn build_worker_cos_statuses_owner_profile_only_surfaces_on_unambiguous_owner_lo
         waterfill_honored_epoch_bits: 0,
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
+        waterfill_epoch_start_ns: 0,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -891,6 +894,7 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_exact_
         waterfill_honored_epoch_bits: 0,
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
+        waterfill_epoch_start_ns: 0,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -1094,6 +1098,7 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_interf
         waterfill_honored_epoch_bits: 0,
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
+        waterfill_epoch_start_ns: 0,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -1298,6 +1303,7 @@ fn build_worker_cos_statuses_surfaces_distinct_per_queue_drain_telemetry() {
         waterfill_honored_epoch_bits: 0,
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
+        waterfill_epoch_start_ns: 0,
         exact_guarantee_rr: 0,
         nonexact_guarantee_rr: 0,
         #[cfg(test)]
@@ -2380,6 +2386,7 @@ fn active_flow_buckets_peak_is_max_not_sum_across_workers() {
         waterfill_honored_epoch_bits: 0,
         waterfill_epochs: 0,
         waterfill_phase1_budget_breaks: 0,
+        waterfill_epoch_start_ns: 0,
             exact_guarantee_rr: 0,
             nonexact_guarantee_rr: 0,
             #[cfg(test)]


### PR DESCRIPTION
## Summary

The CoS GuaranteeRate waterfill selector regressed at high shapes: per-flow
CoV spiked because Phase-2 (surplus distribution) never admitted
(`phase2_admit≈0`). Three coupled defects in the Phase-1 accounting in
`userspace-dp/src/afxdp/cos/queue_service/mod.rs` (opt-in
`oversubscription-policy guarantee-rate` path only — Proportional untouched):

- **Hunk A** — Phase-1 budget used `quantum_sum × fraction`, which for any
  oversubscribed config (Σ R_i &gt; shaper) over-budgets pass1 by ~4.24× the
  bytes the root shaper can deliver per epoch (1,855,753 B vs 437,500 B for
  the 25g/0.7 fixture). Phase-1 then honored every class and Phase-2 never
  fired. Now anchored to `shaping_rate_bytes × COS_GUARANTEE_VISIT_NS / 1e9 ×
  fraction` (the documented "fraction × cap" contract); transparent (unshaped)
  root keeps the legacy quantum_sum formula; shaped result clamped to
  ≥ one min-quantum so a tiny fraction can't floor pass1 to 0 (AGY RISK-1).
- **Hunk B** — Phase-1 honor charge was `queue.hot.tokens.min(quantum)`, which
  under v8-lease pressure collapsed to one frame, marking a small queue fully
  honored while consuming almost no budget — so Phase-2 skipped it. Now charges
  the stable configured quantum `cos_guarantee_quantum_bytes(queue).max(head_len)`.
- **Hunk C** — no time-based budget refresh; Phase-2 selections don't decrement
  pass1 so it froze under saturation. Adds `waterfill_epoch_start_ns` +
  refresh every `COS_GUARANTEE_VISIT_NS`, clearing the #1732 persistent honored
  bitset only on genuine epoch boundaries (time tick OR Phase-2 wrap, NOT on
  bare mid-walk `pass1 == 0` refills) while PRESERVING the Phase-2 cursor
  across epochs (only the Phase-2 wrap None path resets the cursor — the
  #1630 r4 invariant).

Re-lands the #1630 shaper-anchor + time-refresh design (its branch was never
merged to master) on top of #1732's persistent honored set (which exposed, not
introduced, the Phase-2 death). #1732 is preserved, not reverted.

Closes #1743

## Plan + adversarial review

Plan doc: `docs/pr/1743-cos-waterfill-shaped-budget/plan.md`
- Codex plan-r1: PLAN-NEEDS-MINOR (fixture math + undersubscribed test — addressed) — task-mpvav706-nx3l72
- AGY plan-r1: PLAN-READY (RISK-1 tiny-fraction clamp — addressed) — adversarial-review-mpvavgvw-04ia5f
- Claude SMR: PLAN-READY (root-cause + traces verified against master e4556085a)

## Live validation gate (loss:xpf-userspace-fw0, matched A/B)

Ground truth = iperf3 per-stream CoV (NOT cos_active_flow_count, #1741).
Full evidence in `docs/pr/1743-cos-waterfill-shaped-budget/validation-gate.md`.

**Phase-2 admission (primary signal), full 11-class simul P12, 3 matched runs:**
| run | master p2/p1 | fix p2/p1 |
|----:|-------------:|----------:|
| 1 | 0.0064 | 1.433 |
| 2 | 0.0059 | 1.323 |
| 3 | 0.0054 | 1.405 |

Master Phase-2 admits ~0.6% of Phase-1 (the reported `phase2_admit≈0`); fix
admits ~135% — **~230× increase**, the required 0→nonzero transition. Master
gate_2 (priority-low share) FAILED (uncapped starved to 0); fix PASSED.

**Isolated high-shape per-stream CoV (5209+5210, P12, 5 matched runs each):**
| metric | master mean | fix mean | delta |
|--------|------------:|---------:|------:|
| 21g CoV | 35.6% | 25.1% | -10.5 pts |
| 24g CoV | 45.7% | 31.9% | -13.8 pts |

Material CoV drop at both high shapes.

## Test plan

- [x] cargo build clean
- [x] cargo test --release: full suite green (1691 lib + others)
- [x] 20 waterfill tests pass (14 existing + 6 new pinning each hunk)
- [x] `waterfill_pass1_refreshes_on_time_tick_clears_honored_bits` 5/5 flake
- [x] Go suite: clean except 2 pre-existing env-only failures (`bind: invalid
      argument` on long unix-socket paths — fail identically on clean master,
      I touched zero Go code)
- [x] `make audit-check` green
- [x] Deploy on loss userspace cluster
- [x] **Live gate**: phase2_admit 0→nonzero (~230×) + high-shape CoV −10.5/−13.8 pts
- [x] **Pass A — CoS disabled** best-effort fast path (#1183): v4 -P12-R 22.9G, v6 22.3G; single-stream 7.2–8.4G, 0 retrans
- [x] **Pass B — CoS enabled** per-class: all shaped classes hit rate cleanly, 0 retrans

## HA assessment

`waterfill_epoch_start_ns` is per-binding worker-local runtime, NOT HA-synced
(same class as the existing `waterfill_*` fields; zero `pkg/cluster`
references). No session-sync wire change. `make test-failover` not required —
the field is local scheduler state reset on restart, not portable HA state.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>