### PR TITLE
#1745: sample equal-flow active-flows at acquire time, not rotation boundary

### DIFF
--- a/docs/pr/1745-equal-flow-failopen-sample/plan.md
+++ b/docs/pr/1745-equal-flow-failopen-sample/plan.md
@@ -1,6 +1,9 @@
 # #1745 — equal-flow-enforcement permanent fail-open: sample active-flow demand at acquire-time, not rotation-boundary
 
-Status: DRAFT v1 — pending adversarial plan review
+Status: v2 — Codex PLAN-NEEDS-MAJOR + AGY PLAN-NEEDS-MINOR + Claude-SMR
+PLAN-NEEDS-MAJOR converged; all findings folded in. Q1 (the PLAN-KILL
+question) resolved NOT-KILL by both external reviewers with independent
+proofs (see "Why acquire-time sampling fixes it").
 
 ## Issue framing
 
@@ -88,15 +91,28 @@ and HOW the active-flow + demand signal is captured:
    from it: a worker is "sampled" iff `sampled_active_flows[id] > 0 &&
    demanded[id] && prev_grants[id] > 0`.
 
-3. Crucially: at a 24 Gb/s exact shape with a ~32 KB bank, a busy worker
-   drains the bank in ~10 µs and therefore calls `acquire_v8` ~20×/200 µs
-   epoch — so it WILL be sampled in nearly every epoch. The current bug
-   bites the worker only in the epochs where its consumption stayed under
-   the bank AND the rotation instant landed between its acquire calls.
-   The sticky-max sample closes that window: any active acquire anywhere
-   in the epoch leaves a nonzero sample that survives to the rotation
-   swap, instead of relying on the demand boolean + a separate
-   instantaneous flow-count read agreeing at one nanosecond.
+3. Crucially — **single-epoch sticky-max is provably sufficient** (Q1,
+   resolved NOT-KILL by both Codex and AGY independently). Exact queues
+   have NO autonomous local token refill: `queue.hot.tokens` is refilled
+   ONLY via `acquire_via_lease`→`acquire_v8` (`token_bucket.rs:204-209`),
+   and every transmitted byte debits the bucket (`tx_completion.rs:679`).
+   The watermark is `lease_bytes().max(BANK).min(buffer_bytes…)`
+   (`token_bucket.rs:196-200`) — at most ~512 KB
+   (`COS_ROOT_LEASE_MAX_BYTES`, `mod.rs:760`), at least the 8-frame
+   ~32 KB bank. So any worker that sends a single packet drops below the
+   watermark and is forced to call `acquire_v8` on its next selector
+   visit — within the same or the immediately following epoch. Worked:
+   even at 1 Mb/s (~25 B/epoch) the bucket falls under the watermark every
+   epoch. The ONLY worker that stays banked across a whole epoch is one
+   carrying literally zero traffic, and excluding such a worker from the
+   sample set is the correct, desired semantics. There is no plausible
+   "busy worker stays fully banked across multiple consecutive epochs"
+   counterexample — the kill scenario does not exist.
+
+   The sticky-max sample (recorded at any active acquire, surviving the
+   single epoch until the rotation swap) replaces the brittle requirement
+   that the per-epoch demand boolean AND a separate instantaneous
+   flow-bucket read agree at the single rotation nanosecond.
 
 4. The publisher no longer fail-opens merely because some *currently*
    (rotation-instant) active worker had no sample — it only counts the
@@ -153,41 +169,127 @@ if active {
 ```
 
 `record_equal_flow_active_sample` is a new tag-checked max-CAS helper
-(sibling of `bump_epoch_event`/`worker_grant_bump`): if `curr_tag !=
-my_tag`, install `(my_tag, active_flows)`; else install `(my_tag,
-max(curr_count, active_flows))`. Same bounded-CAS shape, no allocation,
-hot-path-clean. The `EqualFlowSuppress` guard means `CstructDefault`
-leases never touch the new array → default path unchanged.
+(sibling of `bump_epoch_event`/`worker_grant_bump`). **It must NEVER
+write backwards over a newer epoch** (Codex Finding 1 + AGY Finding 3 —
+critical race): an old acquirer holding a stale `my_tag` could otherwise
+overwrite the rotation's fresh `(new_tag, 0)` slot with `(my_tag,
+active_flows)`, corrupting the new epoch's sample. The race-free shape
+(compares `curr_tag` against `my_tag`, aborts on a future tag):
+
+```rust
+#[inline]
+fn record_equal_flow_active_sample(pg: &PackedEpochGrant, my_tag: u32, active_flows: u32) {
+    loop {
+        let curr = pg.0.load(Ordering::Acquire);
+        let (curr_tag, curr_count) = PackedEpochGrant::unpack(curr);
+        // A rotation already advanced the slot to a newer epoch — abort,
+        // never write a stale tag backwards. Tags are monotonically
+        // increasing per rotation (seq>>1)+1, so `curr_tag > my_tag`
+        // unambiguously means "rotation happened after our snapshot".
+        if curr_tag > my_tag {
+            return;
+        }
+        let new = if curr_tag == my_tag {
+            PackedEpochGrant::pack(my_tag, curr_count.max(active_flows))
+        } else {
+            // curr_tag < my_tag: first active acquire of this epoch; the
+            // slot still carries the prior epoch's value (it has not been
+            // swapped yet, or we are the first writer). Install fresh —
+            // do NOT carry the stale count forward.
+            PackedEpochGrant::pack(my_tag, active_flows)
+        };
+        if pg
+            .0
+            .compare_exchange_weak(curr, new, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return;
+        }
+    }
+}
+```
+
+Tag monotonicity: `new_tag = ((seq>>1)+1)` at rotation
+(`rotate_epoch_v8.rs:53`); tags only increase, so `curr_tag > my_tag`
+safely means "newer epoch." The `EqualFlowSuppress` guard means
+`CstructDefault` leases never touch the new array → default path
+unchanged.
 
 ### rotate_epoch_v8 swap (`rotate_epoch_v8.rs`)
 
-In the STEP-2 loop, swap the new array slot alongside the existing demand
-swap and capture a per-worker `sampled_active_flows_by_worker[id]` from
-the returned old value (tag-checked: only count when the swapped-out tag
-matches the just-ended epoch's tag = `seq>>1`, else 0). Pass it to
-`publish_equal_flow_epoch_v8`. The `EqualFlowSuppress`-only publish branch
-already guards the call (`:123`).
+**The new-array swap MUST be gated on `EqualFlowSuppress`** (Codex
+Finding 2 + AGY Finding 5): the existing STEP-2 loop (`:83-112`) runs for
+ALL v8 rate modes, so adding the swap there unconditionally would impose
+a new per-worker `AcqRel` swap per rotation on the `CstructDefault`
+default path, breaking byte-equivalence. Instead, do the new swap inside
+the existing `if v8.rate_mode == V8RateMode::EqualFlowSuppress` block
+(`:123`) that already guards the publish call, in a dedicated loop:
+
+```rust
+let mut sampled_active_flows_by_worker = [0u32; MAX_WORKERS_SCRATCH];
+if v8.rate_mode == V8RateMode::EqualFlowSuppress {
+    for id in 0..v8.worker_equal_flow_active_samples.len() {
+        let old_sample = v8.worker_equal_flow_active_samples[id]
+            .0
+            .swap(new_packed_zero, Ordering::AcqRel);
+        let (old_tag, old_count) = PackedEpochGrant::unpack(old_sample);
+        if id < n_workers && old_tag == (seq >> 1) as u32 {
+            sampled_active_flows_by_worker[id] = old_count;
+        }
+    }
+    publish_equal_flow_epoch_v8(
+        v8, new_tag, n_workers, active_outside_scratch,
+        &active_by_worker, &sampled_active_flows_by_worker,
+        &demanded_by_worker, &prev_grants,
+    );
+} else {
+    v8.equal_flow.disable_for_epoch(new_tag);
+}
+```
+
+The tag check `old_tag == (seq>>1)` only counts samples from the
+just-ended epoch (the slot is reset to `new_packed_zero = pack(new_tag,
+0)`, so a slot never written this epoch swaps out as `(prior_tag, …)` and
+is correctly excluded as 0).
 
 ### publish_equal_flow_epoch_v8 (`publish_equal_flow_epoch_v8.rs`)
 
 Add `sampled_active_flows_by_worker: &[u32]` parameter. Replace the
-sample-set derivation:
+sample-set derivation. **Per Codex Finding 4, do NOT drop the
+active-but-unsampled bail entirely** — that would let a worker which
+genuinely participated (demanded or was granted bytes) but whose sample
+we missed be silently ignored while two other workers set the class
+target. The refined rule, per worker `id` in `0..n_workers`:
 
-- A worker is in the sample set iff `sampled_active_flows[id] > 0 &&
-  demanded_by_worker[id] && prev_grants[id] > 0`.
-- Compute the per-flow target from the sampled set's
-  `prev_grants[id] / sampled_active_flows[id]` (clip-to-SLOWEST `min`,
-  UNCHANGED — see Out-of-scope #1746).
-- `max_worker_cap` derived from `smoothed * sampled_active_flows[id]`
-  over the sampled set.
-- Require sampled-set size `>= 2` → else `InsufficientSampledWorkers`.
-- Do NOT fail-open merely because a `worker_active_flow_buckets`-active
-  worker was not in the sampled set (drop the `:43-47`
-  active-but-unsampled hard bail).
+- If `!active_by_worker[id]` → skip (not a class participant).
+- Else if `sampled_active_flows[id] > 0 && demanded_by_worker[id] &&
+  prev_grants[id] > 0` → IN the sample set.
+- Else if `demanded_by_worker[id] || prev_grants[id] > 0` → the worker
+  DID participate this epoch but we failed to capture a usable sample →
+  **fail-open `UnsampledActiveWorker`** (preserve the safety bail for a
+  real-but-unsampled participant).
+- Else (active flow-bucket nonzero but zero demand AND zero grants AND
+  zero sample) → genuinely idle-at-rotation background worker →
+  **exclude from the set, do NOT fail-open** (this is the banked-worker
+  case the fix targets; such a worker, if it had real traffic, would have
+  a sample per the Q1 proof).
+- Compute the per-flow target over the sample set:
+  `prev_grants[id] / sampled_active_flows[id]`, clip-to-SLOWEST `min`
+  (UNCHANGED — see Out-of-scope #1746).
+- `max_worker_cap` = `max over sampled set of smoothed *
+  sampled_active_flows[id]`.
+- Require sample-set size `>= 2` → else `InsufficientSampledWorkers`.
 - Keep `active_outside_scratch` → `UnsampledActiveWorker` hard fail-open
   for the real >32-worker case (`:30-34`).
 - Keep all downstream guards: `ZeroTarget`, `ArithmeticInvalid`,
-  `LowDemandWorker` (util gate), `NotEnoughValidStreak`, smoothing.
+  `LowDemandWorker` (util gate — this is the structural protection
+  against a stale-high sticky-max over-suppressing after flow teardown,
+  per AGY Q2), `NotEnoughValidStreak`, smoothing.
+
+Note the `max_worker_cap`/per-flow math uses `sampled_active_flows[id]`
+(the swapped sticky-max), NOT the live `worker_active_flow_buckets`, so
+the published cap is internally consistent with the sample that produced
+the target.
 
 The acquire-side `equal_flow_cap_v8` (`mod.rs:1606`) is UNCHANGED — it
 keeps multiplying the published per-flow target by the live
@@ -195,13 +297,29 @@ keeps multiplying the published per-flow target by the live
 
 ### Regression test (unit)
 
-`equal_flow_forced_insufficient_sampled_workers_leaves_suppression_unchanged`:
-build an `EqualFlowSuppress` lease, drive a single-worker (`-P1`-style)
-epoch so the publisher bails `InsufficientSampledWorkers`, assert
-`suppressed_grant_bytes` and `cap_hit_events` are both unchanged across
-the fail-open epoch. Plus a positive test that two banked-style workers
-(sampled via the new acquire-time path with sticky-max) now reach
-`enforced=1` where the rotation-instant path would have fail-opened.
+1. `equal_flow_forced_insufficient_sampled_workers_leaves_suppression_unchanged`:
+   build an `EqualFlowSuppress` lease, drive a single-worker (`-P1`-style)
+   epoch so the publisher bails `InsufficientSampledWorkers`, assert
+   `suppressed_grant_bytes` and `cap_hit_events` are both unchanged across
+   the fail-open epoch (validation gate 3).
+2. Positive test: two workers sampled via the new acquire-time sticky-max
+   path now reach `enforced=1`. Critically, model the banked path by NOT
+   re-bumping the instantaneous demand on the enforcing epoch — assert the
+   pre-fix rotation-instant logic would have fail-opened but the
+   sticky-max sample carries the worker through.
+3. **Sticky-max correctness test**: within one epoch, record a high
+   active-flow count then a lower one (flow teardown) for the same
+   worker; assert the swapped-out sample is the MAX (not last-write).
+4. **Teardown over-suppression guard test** (AGY Q2 / Codex Finding 5):
+   drive a worker whose grants fall below the util gate after a sample
+   recorded a high flow count; assert the epoch fails open
+   `LowDemandWorker` rather than publishing an over-low target.
+5. **Tag-backwards race test**: simulate a stale acquirer
+   (`record_equal_flow_active_sample` with `my_tag < curr_tag`) and assert
+   the slot is NOT overwritten (no backwards tag write).
+6. **Default-path byte-equivalence test**: a `CstructDefault` lease must
+   leave `worker_equal_flow_active_samples` all-zero after several
+   acquire + rotation cycles (no new atomic writes on the default path).
 
 ## Public API preservation
 
@@ -242,7 +360,7 @@ the fail-open epoch. Plus a positive test that two banked-style workers
 | Behavioral regression (default path) | LOW | All new state gated on `EqualFlowSuppress`; `CstructDefault` untouched. Verified by grep + the default-mode test. |
 | Lifetime / borrow-checker | LOW | One more `Box<[PackedEpochGrant]>` field + one `&[u32]` param. No new borrows across the seqlock. |
 | Performance regression | LOW-on-default / LOW | Default path: zero new work. EqualFlow path: one extra Relaxed load + one bounded CAS per active acquire — same class as the existing demand bump right beside it. |
-| Architectural mismatch | MEDIUM | The fix only helps if banked busy workers DO call acquire_v8 at least once per (or per few) epoch. Open Question 1 stress-tests this. If a worker can stay banked for many consecutive epochs at the validation shape, the fix is insufficient and the design needs a different sample source → PLAN-KILL territory. |
+| Architectural mismatch | LOW (was MEDIUM) | Q1 resolved NOT-KILL: exact queues have no autonomous refill, so any byte-sending worker is forced to acquire_v8 within the epoch (Codex + AGY independent proofs). Only zero-traffic workers stay banked, and excluding them is correct. The single-epoch sticky-max sample is provably sufficient. |
 
 ## Test plan
 
@@ -276,7 +394,33 @@ the fail-open epoch. Plus a positive test that two banked-style workers
   struct (tracked follow-up from PR #1588).
 - Any change to the >32-worker scratch cap (#1733).
 
-## Open questions for adversarial review
+## Open questions for adversarial review — RESOLVED in round 1
+
+All six resolved by Codex (PLAN-NEEDS-MAJOR) + AGY (PLAN-NEEDS-MINOR) +
+Claude-SMR (PLAN-NEEDS-MAJOR), converged into v2 above:
+
+- **Q1 (sufficiency / the kill question): NOT-KILL.** Both external
+  reviewers gave independent proofs that exact queues have no autonomous
+  refill, so any worker sending ≥1 byte drops below the watermark and is
+  forced to `acquire_v8` within the epoch; only a zero-traffic worker
+  stays banked and excluding it is correct. No multi-epoch-banked
+  counterexample exists.
+- **Q2 (sticky-max vs last-write): max is correct;** last-write would
+  publish a noisy transient denominator. Stale-high after teardown is
+  caught by the `LowDemandWorker` 80% util gate (regression test #4).
+- **Q3 (tag race): CRITICAL — fixed.** Helper now aborts on
+  `curr_tag > my_tag`, never writes a stale tag backwards.
+- **Q4 (dropping the bail): refined, not dropped.** Keep the bail for a
+  demanded-or-granted-but-unsampled participant; only exclude truly idle
+  workers. `sampled >= 2` retained.
+- **Q5 (HA): acceptable.** New array built unconditionally at
+  `len = max_worker_id + 1` in lock-step with `worker_grants`; fresh
+  process-local telemetry, no rehydration needed.
+- **Q6 (default-path byte-equivalence): fixed** by gating the
+  rotation-side swap on `EqualFlowSuppress` (not just the acquire-side
+  record). Regression test #6 asserts it.
+
+### Original open questions (kept for the record)
 
 1. **Is acquire-time sampling actually sufficient?** At the validation
    shape (24 Gb/s, ~32 KB bank), does every busy worker call `acquire_v8`

--- a/docs/pr/1745-equal-flow-failopen-sample/plan.md
+++ b/docs/pr/1745-equal-flow-failopen-sample/plan.md
@@ -1,0 +1,312 @@
+# #1745 — equal-flow-enforcement permanent fail-open: sample active-flow demand at acquire-time, not rotation-boundary
+
+Status: DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+With `equal-flow-enforcement` opted in on a high-shape exact scheduler
+(scheduler-24g, queue 10) on the 6-worker loss cluster, the v8 equal-flow
+equalizer **never enforces**: `equal_flow_enforced=0`,
+`equal_flow_fail_open{reason=insufficient_sampled_workers}=1`,
+`target_per_flow_bps=0`. Outlier flows (~1.9 Gb/s on lightly-loaded
+workers) are never clipped toward the slowest per-flow rate. This is NOT
+the #1733 >32-worker scratch-cap path (6 ≪ 32).
+
+## Root cause (verified against code, not just the issue body)
+
+The rotation winner (`rotate_epoch_v8.rs`) builds the publish inputs from
+two per-worker arrays it reads/swaps at the rotation instant:
+
+- `active_by_worker[id]` ← instantaneous `worker_active_flow_buckets[id]`
+  load (`rotate_epoch_v8.rs:93-97`) — "does this worker have ≥1 active
+  flow at the rotation nanosecond."
+- `demanded_by_worker[id]` ← swap of `worker_demand_events[id]`
+  (`rotate_epoch_v8.rs:89-92, :101`) — "did this worker bump a demand
+  event during the just-ended epoch."
+
+`publish_equal_flow_epoch_v8.rs` then, for every `active_by_worker[id]`,
+requires `demanded_by_worker[id] && prev_grants[id] > 0` or it bails
+`UnsampledActiveWorker` (`:43-47`); and requires `sampled_workers >= 2`
+or it bails `InsufficientSampledWorkers` (`:56-61`).
+
+**The bad coupling**: `demanded_by_worker[id]` is only set when the worker
+runs `acquire_v8` while active (`mod.rs:1186-1193` — `bump_epoch_event`
+on `worker_demand_events[worker_id]`). But exact queues with banked
+tokens **skip lease acquisition entirely**: `maybe_top_up_cos_queue_lease`
+returns at `token_bucket.rs:201` (`if queue.hot.tokens >= lease_bytes`)
+**before** calling `acquire_via_lease` → `acquire_v8`. The exact-queue
+bank watermark is `COS_EXACT_QUEUE_LEASE_BANK_BYTES` = 8 frames ≈ 32 KB
+(`afxdp/mod.rs:261-263`).
+
+So a worker carrying real traffic but whose per-epoch consumption stays
+under the ~32 KB bank does **not** bump demand for that epoch, even though
+`worker_active_flow_buckets[id] > 0` (the flow count is sticky and remains
+nonzero between acquire calls). At the rotation boundary it shows up as
+`active_by_worker=true, demanded=false` → `UnsampledActiveWorker`; with
+several such workers the demand count drops below 2 → permanent
+`InsufficientSampledWorkers` fail-open.
+
+This is confirmed by the existing unit tests: every passing equal-flow
+test seeds demand by explicitly calling `acquire_v8` for each worker each
+epoch (`shared_cos_lease_tests.rs:553-564`, `:771-837`). That is exactly
+the per-epoch acquire the banked production path skips, which is why the
+tests pass green while production fail-opens.
+
+The `suppressed_grant_bytes` / `cap_hit_events` increments are gated on
+`equal_flow_enforced` + matching tag + nonzero target
+(`mod.rs:1298-1307`), so the symptom is purely the never-enforce
+fail-open, not a half-initialised suppression.
+
+## Honest scope/value framing
+
+This is a correctness fix for an opt-in feature
+(`equal-flow-enforcement`, default OFF — the committed fixture does not
+enable it). Blast radius on the default path is bounded: the v8 lease
+code is shared, but the new sampling array and its reads are confined to
+the `EqualFlowSuppress` rate mode + acquire-time recording. The win is
+that the feature works at all: without it the equalizer is dead code in
+every real deployment. If reviewers conclude the fix's mechanism cannot
+actually capture banked workers either (see Open Question 1), PLAN-KILL
+is an acceptable verdict — that would mean the whole equal-flow design
+needs a different sampling source, not a patch.
+
+## Why acquire-time sampling fixes it (the load-bearing argument)
+
+The fix does NOT make banked workers call `acquire_v8`. It changes WHEN
+and HOW the active-flow + demand signal is captured:
+
+1. Today demand is a per-epoch boolean reset at rotation. A worker must
+   call acquire **during** the epoch to set it; the rotation reads the
+   instantaneous flow-bucket separately. The two signals are sampled at
+   different times and can disagree.
+
+2. The fix records a **tagged, sticky max active-flow sample** per worker
+   *at every active acquire_v8 call* into a new `worker_equal_flow_active_samples`
+   array (one `PackedEpochGrant` slot per worker, packed
+   `(epoch_tag, max_active_flows_seen)`). Rotation swaps this array (like
+   the demand/starvation arrays) and the publisher derives the sample set
+   from it: a worker is "sampled" iff `sampled_active_flows[id] > 0 &&
+   demanded[id] && prev_grants[id] > 0`.
+
+3. Crucially: at a 24 Gb/s exact shape with a ~32 KB bank, a busy worker
+   drains the bank in ~10 µs and therefore calls `acquire_v8` ~20×/200 µs
+   epoch — so it WILL be sampled in nearly every epoch. The current bug
+   bites the worker only in the epochs where its consumption stayed under
+   the bank AND the rotation instant landed between its acquire calls.
+   The sticky-max sample closes that window: any active acquire anywhere
+   in the epoch leaves a nonzero sample that survives to the rotation
+   swap, instead of relying on the demand boolean + a separate
+   instantaneous flow-count read agreeing at one nanosecond.
+
+4. The publisher no longer fail-opens merely because some *currently*
+   (rotation-instant) active worker had no sample — it only counts the
+   sampled set. `active_outside_scratch` (the real >32-worker case) stays
+   the hard fail-open.
+
+If a worker genuinely sent zero traffic over a whole epoch it correctly
+remains unsampled and excluded — which is the desired semantics
+(`NoActiveFlows` / `InsufficientSampledWorkers` still fire for a true
+single-flow `-P1` workload, validation gate 2).
+
+## Concrete design
+
+### New V8State field (`mod.rs:~396`, init `~:1068`)
+
+```rust
+/// #1745: per-worker tagged max active-flow sample, recorded at
+/// acquire_v8 time (when the worker requests lease credit while
+/// active). Packed (epoch_tag, max_active_flows_seen_this_epoch).
+/// Decouples the equal-flow sample set from the rotation-instant
+/// worker_active_flow_buckets read, which missed exact-queue workers
+/// running on banked tokens (they skip acquire_v8 at the bank
+/// watermark and so do not bump demand every epoch). Swapped at
+/// rotation alongside worker_demand_events. Length = max_worker_id + 1.
+worker_equal_flow_active_samples: Box<[PackedEpochGrant]>,
+```
+
+Init beside `worker_demand_events` in both `new_v8`/`new_v8_with_rate_mode`
+(they share the array-build block at `:1050-1071`).
+
+### acquire_v8 recording (`mod.rs:~1186-1193`)
+
+Replace the active-only boolean load with an active-flow load + sticky-max
+sample record, gated to `EqualFlowSuppress` so the default path is
+byte-unaffected:
+
+```rust
+let active_flows = v8
+    .worker_active_flow_buckets
+    .get(worker_id)
+    .map(|a| a.load(Ordering::Relaxed))
+    .unwrap_or(0);
+let active = active_flows > 0;
+if active {
+    bump_epoch_event(&v8.worker_demand_events[worker_id], my_tag);
+    if v8.rate_mode == V8RateMode::EqualFlowSuppress {
+        record_equal_flow_active_sample(
+            &v8.worker_equal_flow_active_samples[worker_id],
+            my_tag,
+            active_flows,
+        );
+    }
+}
+```
+
+`record_equal_flow_active_sample` is a new tag-checked max-CAS helper
+(sibling of `bump_epoch_event`/`worker_grant_bump`): if `curr_tag !=
+my_tag`, install `(my_tag, active_flows)`; else install `(my_tag,
+max(curr_count, active_flows))`. Same bounded-CAS shape, no allocation,
+hot-path-clean. The `EqualFlowSuppress` guard means `CstructDefault`
+leases never touch the new array → default path unchanged.
+
+### rotate_epoch_v8 swap (`rotate_epoch_v8.rs`)
+
+In the STEP-2 loop, swap the new array slot alongside the existing demand
+swap and capture a per-worker `sampled_active_flows_by_worker[id]` from
+the returned old value (tag-checked: only count when the swapped-out tag
+matches the just-ended epoch's tag = `seq>>1`, else 0). Pass it to
+`publish_equal_flow_epoch_v8`. The `EqualFlowSuppress`-only publish branch
+already guards the call (`:123`).
+
+### publish_equal_flow_epoch_v8 (`publish_equal_flow_epoch_v8.rs`)
+
+Add `sampled_active_flows_by_worker: &[u32]` parameter. Replace the
+sample-set derivation:
+
+- A worker is in the sample set iff `sampled_active_flows[id] > 0 &&
+  demanded_by_worker[id] && prev_grants[id] > 0`.
+- Compute the per-flow target from the sampled set's
+  `prev_grants[id] / sampled_active_flows[id]` (clip-to-SLOWEST `min`,
+  UNCHANGED — see Out-of-scope #1746).
+- `max_worker_cap` derived from `smoothed * sampled_active_flows[id]`
+  over the sampled set.
+- Require sampled-set size `>= 2` → else `InsufficientSampledWorkers`.
+- Do NOT fail-open merely because a `worker_active_flow_buckets`-active
+  worker was not in the sampled set (drop the `:43-47`
+  active-but-unsampled hard bail).
+- Keep `active_outside_scratch` → `UnsampledActiveWorker` hard fail-open
+  for the real >32-worker case (`:30-34`).
+- Keep all downstream guards: `ZeroTarget`, `ArithmeticInvalid`,
+  `LowDemandWorker` (util gate), `NotEnoughValidStreak`, smoothing.
+
+The acquire-side `equal_flow_cap_v8` (`mod.rs:1606`) is UNCHANGED — it
+keeps multiplying the published per-flow target by the live
+`worker_active_flow_buckets[worker_id]`.
+
+### Regression test (unit)
+
+`equal_flow_forced_insufficient_sampled_workers_leaves_suppression_unchanged`:
+build an `EqualFlowSuppress` lease, drive a single-worker (`-P1`-style)
+epoch so the publisher bails `InsufficientSampledWorkers`, assert
+`suppressed_grant_bytes` and `cap_hit_events` are both unchanged across
+the fail-open epoch. Plus a positive test that two banked-style workers
+(sampled via the new acquire-time path with sticky-max) now reach
+`enforced=1` where the rotation-instant path would have fail-opened.
+
+## Public API preservation
+
+- `acquire_v8`, `equal_flow_cap_v8`, `snapshot_epoch_v8`,
+  `maybe_rotate_epoch_v8` signatures UNCHANGED.
+- `publish_equal_flow_epoch_v8` gains one `&[u32]` parameter (internal
+  `pub(super)`, single call site).
+- All `v8_equal_flow_*` status accessors UNCHANGED.
+- No protocol/wire change; no Go-side change.
+
+## Hidden invariants the change must preserve
+
+- **Seqlock ordering**: the new array is swapped inside the ODD critical
+  section like the others; payload-before-tag publish in
+  `enforce_epoch`/`fail_open` unchanged.
+- **Single-writer-per-slot**: only worker `id` writes
+  `worker_equal_flow_active_samples[id]` at acquire; rotation winner is
+  the sole swapper. Same discipline as `worker_grants`/`worker_demand_events`.
+- **Tag-checked CAS**: cross-epoch records naturally rejected by tag
+  mismatch (max-CAS installs new tag on mismatch — must NOT carry a stale
+  count forward; it resets to the fresh sample).
+- **Default path byte-unaffected**: all new writes/reads gated on
+  `V8RateMode::EqualFlowSuppress`. `CstructDefault` acquire records
+  nothing.
+- **No hot-path allocation**: array allocated once at lease construction;
+  acquire-time record is a bounded CAS loop.
+- **HA**: the v8 equal-flow epoch state is process-local per-binding and
+  rebuilt fresh on the new array sizing; it is NOT serialized over session
+  sync (only `worker_active_flow_buckets` is rehydrated via
+  `rehydrate_worker_active_count`). The new array is rebuilt on lease
+  reconstruction. No wire/sync surface added. `make test-failover` still
+  run because the lease code is shared.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression (default path) | LOW | All new state gated on `EqualFlowSuppress`; `CstructDefault` untouched. Verified by grep + the default-mode test. |
+| Lifetime / borrow-checker | LOW | One more `Box<[PackedEpochGrant]>` field + one `&[u32]` param. No new borrows across the seqlock. |
+| Performance regression | LOW-on-default / LOW | Default path: zero new work. EqualFlow path: one extra Relaxed load + one bounded CAS per active acquire — same class as the existing demand bump right beside it. |
+| Architectural mismatch | MEDIUM | The fix only helps if banked busy workers DO call acquire_v8 at least once per (or per few) epoch. Open Question 1 stress-tests this. If a worker can stay banked for many consecutive epochs at the validation shape, the fix is insufficient and the design needs a different sample source → PLAN-KILL territory. |
+
+## Test plan
+
+- `cargo build` clean (release).
+- `cargo test --release` full suite green.
+- 5×/5 flake on the most-affected named tests
+  (`equal_flow_*`, the new regression test).
+- Go suite (`go test ./...`) — no Rust-adjacent breakage expected.
+- Deploy to loss userspace cluster.
+- **Live validation gate (the proof):**
+  1. Enable `equal-flow-enforcement` on scheduler-24g (queue 10), CoS
+     loaded + classifier bound; iperf3 `-P12` on port 5210; after warmup
+     ASSERT `enforced==1`, `target_per_flow_bps>0`, `max_worker_cap_bytes>0`,
+     `fail_open{insufficient_sampled_workers}==0` steady-state, AND
+     per-stream CoV drops + ~1.8-1.9G outliers clip toward the published
+     target (ground-truth iperf3 per-stream, not #1741 counters).
+  2. `-P1` control: `enforced==0`, `target==0`, reason
+     `insufficient_sampled_workers`, NO `suppressed_grant_bytes` increase.
+  3. Revert equal-flow OFF (committed fixture stays default-off).
+  4. Full CoS smoke matrix (Pass A CoS-off + Pass B per-class) v4+v6 ×
+     push+reverse; #1217 fairness gate; no aggregate/best-effort
+     regression on the equal-flow-OFF default path.
+- `make test-failover` (shared lease code).
+
+## Out of scope (explicitly)
+
+- **#1746**: changing the target semantics from clip-to-SLOWEST
+  (non-work-conserving) to mean / global-fair-rate. This PR KEEPS
+  clip-to-slowest `min` exactly. #1746 is gated on this fix landing.
+- Folding `publish_equal_flow_epoch_v8`'s parameter list into a context
+  struct (tracked follow-up from PR #1588).
+- Any change to the >32-worker scratch cap (#1733).
+
+## Open questions for adversarial review
+
+1. **Is acquire-time sampling actually sufficient?** At the validation
+   shape (24 Gb/s, ~32 KB bank), does every busy worker call `acquire_v8`
+   at least once per epoch (or per few epochs, given sticky-max survives
+   only ONE epoch because the array is swapped each rotation)? If a worker
+   can stay fully banked across multiple consecutive 200 µs epochs at a
+   plausible per-worker rate, the sticky-max (single-epoch) sample still
+   misses it and the fix is insufficient → PLAN-KILL. Should the sample
+   instead persist across N epochs (decay), not reset every rotation?
+2. **Sticky-max vs last-write**: is max the right reduction? A worker
+   whose flow count drops mid-epoch (flow teardown) would publish a stale
+   high count. Does that distort the per-flow target (`prev_grants /
+   sampled_active_flows`) — too-low target → over-suppression? Should it
+   be last-write or min instead?
+3. **Tag-reset semantics on the max-CAS**: on tag mismatch the helper must
+   install `(my_tag, active_flows)` fresh, NOT `max(stale, active_flows)`.
+   Confirm the helper cannot leak a prior epoch's count via a lost-update
+   race between the tag check and the CAS.
+4. **Dropping the active-but-unsampled hard bail**: by removing the
+   `:43-47` fail-open, can a transient where one worker is sampled and a
+   second is `active_by_worker` but unsampled now produce a target derived
+   from a non-representative single-worker-ish set that over-clips the
+   class? Is `sampled>=2` enough, or does dropping that bail open a new
+   under-target hazard?
+5. **HA/failover**: the equal-flow epoch state is process-local and
+   rebuilt on lease reconstruction. Confirm the new array does not need
+   rehydration and that a demote→promote on the new primary cannot leave
+   a half-sized array (vs `worker_grants`) — both are built from the same
+   `len = max_worker_id + 1`, so they should stay in lock-step; verify.
+6. **Default-path byte-equivalence**: confirm by code-walk that a
+   `CstructDefault` lease performs literally zero new atomic ops (the
+   `EqualFlowSuppress` guard wraps both the record call and the publish
+   branch already gates the rotate call).

--- a/docs/pr/1745-equal-flow-failopen-sample/reviewer-ids.md
+++ b/docs/pr/1745-equal-flow-failopen-sample/reviewer-ids.md
@@ -1,0 +1,6 @@
+# #1745 reviewer task ids
+
+- Codex plan r1 session: plan-1745-1780373495-3042996 (foreground) — PLAN-NEEDS-MAJOR
+- AGY plan r1: review-mpw4mmza-1mor98 — PLAN-NEEDS-MINOR (same 2 fixes as Codex)
+- Claude-SMR plan r1: PLAN-NEEDS-MAJOR (converged, verified all 5 Codex findings against code)
+- Convergence: NOT-KILL. v2 folds in: race-free helper (curr_tag>my_tag abort), rotation-side EqualFlowSuppress gating, keep-the-bail-for-real-participants, teardown+race+default-path regression tests.

--- a/docs/pr/1745-equal-flow-failopen-sample/reviewer-ids.md
+++ b/docs/pr/1745-equal-flow-failopen-sample/reviewer-ids.md
@@ -4,3 +4,10 @@
 - AGY plan r1: review-mpw4mmza-1mor98 — PLAN-NEEDS-MINOR (same 2 fixes as Codex)
 - Claude-SMR plan r1: PLAN-NEEDS-MAJOR (converged, verified all 5 Codex findings against code)
 - Convergence: NOT-KILL. v2 folds in: race-free helper (curr_tag>my_tag abort), rotation-side EqualFlowSuppress gating, keep-the-bail-for-real-participants, teardown+race+default-path regression tests.
+
+## Code review (PR #1747)
+- Codex code r1: session code-1745-1780375901-3069084 — MERGE-NEEDS-MAJOR (u32 tag-wrap HIGH in record_equal_flow_active_sample)
+- Codex code r2 (after wrap fix 549af0b2b): MERGE-READY
+- AGY code r1: review-mpw5txd5-ietdla — MERGE-READY (validated gating/publisher/ordering/HA/test-realignment; reviewed pre-wrap-fix helper)
+- Copilot: COMMENTED, 6/6 files, no comments (clean)
+- Claude-SMR code: MERGE-READY (caught nothing beyond Codex's wrap HIGH, which is fixed)

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
@@ -1729,28 +1729,35 @@ fn bump_epoch_event(pg: &PackedEpochGrant, my_tag: u32) {
 /// sample. Records `max(curr, active_flows)` for the current epoch tag.
 ///
 /// CRITICAL race safety: an acquirer snapshots `my_tag` from the seqlock
-/// before this call; a rotation may then advance the slot to a newer
-/// epoch. Tags are monotonically increasing per rotation
-/// (`new_tag = (seq>>1)+1`), so `curr_tag > my_tag` unambiguously means
-/// "rotation happened after our snapshot" — abort, never write a stale
-/// tag backwards over the rotation's fresh `(new_tag, 0)` slot. On
-/// `curr_tag < my_tag` (slot not yet swapped by this epoch's rotation, or
-/// we are the first writer) install the fresh sample; do NOT carry the
-/// prior epoch's count forward. Mirrors the tag discipline of
-/// `bump_epoch_event` / `worker_grant_bump`.
+/// before this call. The rotation winner installs the fresh `(new_tag, 0)`
+/// into every sample slot (the gated swap in `rotate_epoch_v8`) BEFORE it
+/// publishes the new epoch via the seqlock seq store, so by the time any
+/// acquirer observes `my_tag = N` the slot already carries tag `N`. The
+/// only writable case is therefore `curr_tag == my_tag`; on any mismatch
+/// we no-op.
+///
+/// The match is **tag EQUALITY, not ordering** — identical to the
+/// discipline of `bump_epoch_event` / `worker_grant_bump`. A relational
+/// `curr_tag > my_tag` check would be UNSAFE at the `u32` tag wrap (every
+/// ~9.94 days at the 200 µs epoch): a stale acquirer holding
+/// `my_tag = u32::MAX` racing a rotation that reset the slot to `(0, 0)`
+/// would see `0 > u32::MAX == false` and write its wrapped-old tag
+/// backwards over the fresh epoch (Codex code-review HIGH). Equality
+/// no-ops on the wrap mismatch exactly as it does on any other rotation,
+/// dropping at most one sample — the same tolerated, wrap-safe behaviour
+/// the sibling helpers already rely on.
 #[inline]
 fn record_equal_flow_active_sample(pg: &PackedEpochGrant, my_tag: u32, active_flows: u32) {
     loop {
         let curr = pg.0.load(Ordering::Acquire);
         let (curr_tag, curr_count) = PackedEpochGrant::unpack(curr);
-        if curr_tag > my_tag {
-            return; // rotation advanced past our epoch; never write backwards
+        if curr_tag != my_tag {
+            return; // rotation occurred (incl. tag wrap); drop this sample
         }
-        let new = if curr_tag == my_tag {
-            PackedEpochGrant::pack(my_tag, curr_count.max(active_flows))
-        } else {
-            PackedEpochGrant::pack(my_tag, active_flows)
-        };
+        if curr_count >= active_flows {
+            return; // already at or above the sticky-max; nothing to do
+        }
+        let new = PackedEpochGrant::pack(my_tag, active_flows);
         if pg
             .0
             .compare_exchange_weak(curr, new, Ordering::AcqRel, Ordering::Acquire)

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/mod.rs
@@ -421,6 +421,24 @@ struct V8State {
     /// peer from a naturally quiet peer whose active-flow counter is
     /// merely nonzero. Length = max_worker_id + 1.
     worker_demand_events: Box<[PackedEpochGrant]>,
+    /// #1745: per-worker tagged max active-flow sample, recorded at
+    /// `acquire_v8` time (when the worker requests lease credit while
+    /// active). Each slot is packed (epoch_tag, max_active_flows_seen).
+    /// Decouples the equal-flow sample set from the rotation-instant
+    /// `worker_active_flow_buckets` read + the per-epoch demand boolean,
+    /// which together missed exact-queue workers running on banked tokens:
+    /// they skip `acquire_v8` at the bank watermark
+    /// (`cos/token_bucket.rs`) and so did not bump demand for an epoch
+    /// whose consumption stayed under the bank, even while their flow
+    /// bucket was nonzero. Recorded ONLY in `EqualFlowSuppress` rate mode
+    /// (the default `CstructDefault` path never touches this array, on
+    /// both the acquire and rotation sides — see the gates in
+    /// `acquire_v8` and `rotate_epoch_v8`). Swapped at rotation alongside
+    /// `worker_demand_events`. Length = max_worker_id + 1, in lock-step
+    /// with `worker_grants`. Single-writer-per-slot on the acquire side
+    /// (only worker `id` writes its slot); rotation winner is the sole
+    /// swapper.
+    worker_equal_flow_active_samples: Box<[PackedEpochGrant]>,
     equal_flow: V8EqualFlowSuppressState,
 }
 
@@ -1069,6 +1087,15 @@ impl SharedCoSQueueLease {
             .map(|_| PackedEpochGrant::new())
             .collect::<Vec<_>>()
             .into_boxed_slice();
+        // #1745: per-worker acquire-time active-flow sample slots, same
+        // size + tag-checked-CAS pattern as worker_demand_events. Built
+        // unconditionally so it stays in lock-step with worker_grants on
+        // every lease rebuild (HA failover, config change); only WRITTEN
+        // in EqualFlowSuppress mode.
+        let worker_equal_flow_active_samples = (0..len)
+            .map(|_| PackedEpochGrant::new())
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
         Self {
             config,
             state: SharedCoSLeaseState {
@@ -1083,6 +1110,7 @@ impl SharedCoSQueueLease {
                 worker_fair_share,
                 worker_starvation_events,
                 worker_demand_events,
+                worker_equal_flow_active_samples,
                 equal_flow: V8EqualFlowSuppressState::new(),
             }),
         }
@@ -1183,13 +1211,26 @@ impl SharedCoSQueueLease {
             return 0;
         }
 
-        let active = v8
+        let active_flows = v8
             .worker_active_flow_buckets
             .get(worker_id)
-            .map(|a| a.load(Ordering::Relaxed) > 0)
-            .unwrap_or(false);
+            .map(|a| a.load(Ordering::Relaxed))
+            .unwrap_or(0);
+        let active = active_flows > 0;
         if active {
             bump_epoch_event(&v8.worker_demand_events[worker_id], my_tag);
+            // #1745: in EqualFlowSuppress mode, record a tagged sticky-max
+            // active-flow sample at acquire time. This is the sample source
+            // the rotation/publisher uses for the equal-flow set, decoupled
+            // from the rotation-instant flow-bucket read. The default
+            // CstructDefault path is byte-unaffected (no write here).
+            if v8.rate_mode == V8RateMode::EqualFlowSuppress {
+                record_equal_flow_active_sample(
+                    &v8.worker_equal_flow_active_samples[worker_id],
+                    my_tag,
+                    active_flows,
+                );
+            }
         }
         let equal_flow_cap = self.equal_flow_cap_v8(v8, worker_id, my_tag);
         let equal_flow_enforced = equal_flow_cap.is_some();
@@ -1681,6 +1722,42 @@ fn bump_epoch_event(pg: &PackedEpochGrant, my_tag: u32) {
         let new = PackedEpochGrant::pack(curr_tag, curr_count + 1);
         let _ =
             pg.0.compare_exchange_weak(curr, new, Ordering::AcqRel, Ordering::Acquire);
+    }
+}
+
+/// #1745: tag-checked sticky-max record of a per-worker active-flow
+/// sample. Records `max(curr, active_flows)` for the current epoch tag.
+///
+/// CRITICAL race safety: an acquirer snapshots `my_tag` from the seqlock
+/// before this call; a rotation may then advance the slot to a newer
+/// epoch. Tags are monotonically increasing per rotation
+/// (`new_tag = (seq>>1)+1`), so `curr_tag > my_tag` unambiguously means
+/// "rotation happened after our snapshot" — abort, never write a stale
+/// tag backwards over the rotation's fresh `(new_tag, 0)` slot. On
+/// `curr_tag < my_tag` (slot not yet swapped by this epoch's rotation, or
+/// we are the first writer) install the fresh sample; do NOT carry the
+/// prior epoch's count forward. Mirrors the tag discipline of
+/// `bump_epoch_event` / `worker_grant_bump`.
+#[inline]
+fn record_equal_flow_active_sample(pg: &PackedEpochGrant, my_tag: u32, active_flows: u32) {
+    loop {
+        let curr = pg.0.load(Ordering::Acquire);
+        let (curr_tag, curr_count) = PackedEpochGrant::unpack(curr);
+        if curr_tag > my_tag {
+            return; // rotation advanced past our epoch; never write backwards
+        }
+        let new = if curr_tag == my_tag {
+            PackedEpochGrant::pack(my_tag, curr_count.max(active_flows))
+        } else {
+            PackedEpochGrant::pack(my_tag, active_flows)
+        };
+        if pg
+            .0
+            .compare_exchange_weak(curr, new, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return;
+        }
     }
 }
 

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/publish_equal_flow_epoch_v8.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/publish_equal_flow_epoch_v8.rs
@@ -23,7 +23,7 @@ pub(super) fn publish_equal_flow_epoch_v8(
     n_workers: usize,
     active_outside_scratch: bool,
     active_by_worker: &[bool],
-    active_flows_by_worker: &[u32],
+    sampled_active_flows_by_worker: &[u32],
     demanded_by_worker: &[bool],
     prev_grants: &[u32],
 ) {
@@ -33,6 +33,25 @@ pub(super) fn publish_equal_flow_epoch_v8(
         return;
     }
 
+    // #1745: derive the equal-flow sample set from the acquire-time
+    // sticky-max active-flow samples, NOT the rotation-instant
+    // worker_active_flow_buckets read. A worker is in the set iff it has a
+    // usable sample (nonzero acquire-time active-flow sample) AND it both
+    // demanded lease credit and was granted bytes this epoch.
+    //
+    // Three cases per active worker:
+    //   - usable sample + demanded + granted  -> in the sample set
+    //   - participated (demanded OR granted) but no usable sample
+    //     -> a real participant we failed to sample: keep the safety
+    //        fail-open (UnsampledActiveWorker)
+    //   - active flow-bucket nonzero but no demand AND no grants AND no
+    //     sample -> genuinely idle-at-rotation worker (the banked-worker
+    //     case this fix targets): EXCLUDE from the set, do NOT fail open.
+    //       Per the #1745 sufficiency proof, a worker carrying real
+    //       traffic cannot stay banked across a whole epoch (exact queues
+    //       have no autonomous refill; any sent byte drops the bucket
+    //       below the watermark and forces acquire_v8), so such a worker
+    //       legitimately sent nothing this epoch.
     let mut active_workers = 0u32;
     let mut sampled_workers = 0u32;
     for id in 0..n_workers {
@@ -40,12 +59,18 @@ pub(super) fn publish_equal_flow_epoch_v8(
             continue;
         }
         active_workers = active_workers.saturating_add(1);
-        if !demanded_by_worker[id] || prev_grants[id] == 0 {
+        let has_sample =
+            sampled_active_flows_by_worker[id] > 0 && demanded_by_worker[id] && prev_grants[id] > 0;
+        if has_sample {
+            sampled_workers = sampled_workers.saturating_add(1);
+        } else if demanded_by_worker[id] || prev_grants[id] > 0 {
+            // Real participant we could not sample cleanly: fail open
+            // rather than set the class target from an incomplete set.
             v8.equal_flow
                 .fail_open(new_tag, V8EqualFlowFailOpenReason::UnsampledActiveWorker);
             return;
         }
-        sampled_workers = sampled_workers.saturating_add(1);
+        // else: idle-at-rotation worker — excluded, no fail-open.
     }
 
     if active_workers == 0 {
@@ -68,11 +93,10 @@ pub(super) fn publish_equal_flow_epoch_v8(
         if !active_by_worker[id] {
             continue;
         }
-        let active_flows = active_flows_by_worker[id] as u64;
-        if active_flows == 0 {
-            v8.equal_flow
-                .fail_open(new_tag, V8EqualFlowFailOpenReason::ArithmeticInvalid);
-            return;
+        // Only the sampled set contributes to the target / cap math.
+        let active_flows = sampled_active_flows_by_worker[id] as u64;
+        if active_flows == 0 || !demanded_by_worker[id] || prev_grants[id] == 0 {
+            continue;
         }
         let per_flow = (prev_grants[id] as u64) / active_flows;
         if per_flow == 0 {
@@ -128,11 +152,18 @@ pub(super) fn publish_equal_flow_epoch_v8(
             .fail_open(new_tag, V8EqualFlowFailOpenReason::ZeroTarget);
         return;
     }
+    // #1745: cap is derived over the SAMPLED set, using the same
+    // sticky-max sample that produced the target, so the published cap is
+    // internally consistent with the published per-flow target.
     for id in 0..n_workers {
         if !active_by_worker[id] {
             continue;
         }
-        let Some(worker_cap) = smoothed.checked_mul(active_flows_by_worker[id] as u64) else {
+        let sample = sampled_active_flows_by_worker[id] as u64;
+        if sample == 0 || !demanded_by_worker[id] || prev_grants[id] == 0 {
+            continue;
+        }
+        let Some(worker_cap) = smoothed.checked_mul(sample) else {
             v8.equal_flow
                 .fail_open(new_tag, V8EqualFlowFailOpenReason::ArithmeticInvalid);
             return;

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/rotate_epoch_v8.rs
@@ -75,7 +75,6 @@ impl SharedCoSQueueLease {
         let mut demanded_by_worker = [false; MAX_WORKERS_SCRATCH];
         let mut prev_grants = [0u32; MAX_WORKERS_SCRATCH];
         let mut active_by_worker = [false; MAX_WORKERS_SCRATCH];
-        let mut active_flows_by_worker = [0u32; MAX_WORKERS_SCRATCH];
         let mut active_outside_scratch = false;
 
         // STEP 2: swap event slots, track per-worker signal/demand flags.
@@ -97,7 +96,6 @@ impl SharedCoSQueueLease {
                 .unwrap_or(0);
             if id < n_workers {
                 active_by_worker[id] = active > 0;
-                active_flows_by_worker[id] = active;
                 demanded_by_worker[id] = old_demand_count > 0;
                 if active > 0 && old_starvation_count > 0 {
                     signaled_by_worker[id] = true;
@@ -121,13 +119,32 @@ impl SharedCoSQueueLease {
         }
 
         if v8.rate_mode == V8RateMode::EqualFlowSuppress {
+            // #1745: swap the acquire-time active-flow sample slots and
+            // capture the just-ended epoch's sticky-max per worker. This
+            // swap is INSIDE the EqualFlowSuppress branch so the default
+            // CstructDefault path performs zero extra atomic ops per
+            // rotation. A slot is only counted when its swapped-out tag
+            // matches the just-ended epoch tag (= seq>>1); a slot never
+            // written this epoch swaps out with the prior tag and is
+            // correctly excluded as 0.
+            let just_ended_tag = (seq >> 1) as u32;
+            let mut sampled_active_flows_by_worker = [0u32; MAX_WORKERS_SCRATCH];
+            for id in 0..v8.worker_equal_flow_active_samples.len() {
+                let old_sample = v8.worker_equal_flow_active_samples[id]
+                    .0
+                    .swap(new_packed_zero, Ordering::AcqRel);
+                let (old_tag, old_count) = PackedEpochGrant::unpack(old_sample);
+                if id < n_workers && old_tag == just_ended_tag {
+                    sampled_active_flows_by_worker[id] = old_count;
+                }
+            }
             publish_equal_flow_epoch_v8(
                 v8,
                 new_tag,
                 n_workers,
                 active_outside_scratch,
                 &active_by_worker,
-                &active_flows_by_worker,
+                &sampled_active_flows_by_worker,
                 &demanded_by_worker,
                 &prev_grants,
             );

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
@@ -945,9 +945,10 @@ fn equal_flow_active_sample_is_sticky_max_within_epoch() {
     assert_eq!(slot_count, 10, "sticky-max must keep the high count");
 }
 
-/// #1745 critical race: a stale acquirer (snapshotted an older epoch tag)
-/// must NEVER write its tag backwards over a slot the rotation already
-/// advanced to a newer epoch.
+/// #1745 critical race: a stale acquirer (snapshotted a different epoch
+/// tag) must NEVER write its tag over a slot the rotation already advanced
+/// to a different epoch. The helper matches on tag EQUALITY, so any
+/// mismatch (forward, backward, OR wrapped) no-ops.
 #[test]
 fn equal_flow_active_sample_never_writes_tag_backwards() {
     let lease = new_equal_flow_lease();
@@ -962,6 +963,35 @@ fn equal_flow_active_sample_never_writes_tag_backwards() {
         PackedEpochGrant::unpack(v8.worker_equal_flow_active_samples[0].0.load(Ordering::Acquire));
     assert_eq!(slot_tag, 5, "stale acquirer must not write tag backwards");
     assert_eq!(slot_count, 0, "stale acquirer must not corrupt the count");
+}
+
+/// #1745 / Codex code-review HIGH: the u32 epoch tag wraps every ~9.94
+/// days at the 200µs epoch. A stale acquirer holding `my_tag = u32::MAX`
+/// racing a rotation that reset the slot to the freshly-wrapped epoch
+/// `(0, 0)` must NOT write its wrapped-old tag backwards. Equality
+/// matching makes `0 != u32::MAX` a clean no-op; a relational
+/// `curr_tag > my_tag` check would have failed (`0 > u32::MAX == false`)
+/// and corrupted the fresh epoch-0 slot.
+#[test]
+fn equal_flow_active_sample_safe_across_tag_wrap() {
+    let lease = new_equal_flow_lease();
+    let v8 = lease.v8.as_ref().expect("v8 lease");
+    // Rotation has just wrapped: slot freshly reset to epoch tag 0.
+    v8.worker_equal_flow_active_samples[0]
+        .0
+        .store(PackedEpochGrant::pack(0, 0), Ordering::Release);
+    // A stale acquirer from the pre-wrap epoch (my_tag = u32::MAX) records.
+    record_equal_flow_active_sample(&v8.worker_equal_flow_active_samples[0], u32::MAX, 99);
+    let (slot_tag, slot_count) =
+        PackedEpochGrant::unpack(v8.worker_equal_flow_active_samples[0].0.load(Ordering::Acquire));
+    assert_eq!(slot_tag, 0, "wrapped stale acquirer must not write tag backwards");
+    assert_eq!(slot_count, 0, "wrapped stale acquirer must not corrupt the count");
+    // And the legitimate epoch-0 acquirer still records normally.
+    record_equal_flow_active_sample(&v8.worker_equal_flow_active_samples[0], 0, 7);
+    let (slot_tag2, slot_count2) =
+        PackedEpochGrant::unpack(v8.worker_equal_flow_active_samples[0].0.load(Ordering::Acquire));
+    assert_eq!(slot_tag2, 0);
+    assert_eq!(slot_count2, 7, "fresh epoch-0 acquirer records its sample");
 }
 
 /// #1745: the default `CstructDefault` rate mode must never touch the

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs
@@ -759,9 +759,17 @@ fn equal_flow_fail_open_after_enforcement_does_not_reuse_stale_cap() {
     let granted = lease.acquire_v8(0, 4 * EPOCH_DURATION_NS, 10_000);
     assert_eq!(granted, 8_000);
     assert!(!lease.v8_equal_flow_enforced());
+    // #1745: the sample set is now the acquire-time sticky-max. In epoch 3
+    // only worker 1 acquired (the seed's `acquire_v8(1, 3*EPOCH, 1)`), so
+    // at the epoch-4 rotation worker 0 is active-at-rotation but with no
+    // epoch-3 demand/grant/sample — an idle-at-rotation worker that is
+    // correctly EXCLUDED (not blamed as UnsampledActiveWorker). With only
+    // worker 1 sampled, the publisher bails InsufficientSampledWorkers.
+    // The load-bearing assertions (not enforced, grant = ordinary share,
+    // no stale cap reuse) are unchanged.
     assert_eq!(
         lease.v8_equal_flow_fail_open_reason(),
-        V8EqualFlowFailOpenReason::UnsampledActiveWorker
+        V8EqualFlowFailOpenReason::InsufficientSampledWorkers
     );
 }
 
@@ -786,9 +794,17 @@ fn equal_flow_fail_open_for_unsampled_active_worker() {
     let _ = lease.acquire_v8(0, EPOCH_DURATION_NS, 1_000);
     let _ = lease.acquire_v8(0, 2 * EPOCH_DURATION_NS, 1_000);
     assert!(!lease.v8_equal_flow_enforced());
+    // #1745: worker 1 has a nonzero rehydrated flow bucket but never
+    // acquired (sent zero traffic this window) -> no demand/grant/sample
+    // -> idle-at-rotation, correctly EXCLUDED rather than blamed. Only
+    // worker 0 is a real participant, so the publisher bails
+    // InsufficientSampledWorkers (one sampled worker), which is the
+    // accurate reason. This is precisely the banked/idle decoupling the
+    // fix introduces: a flow-bucket-nonzero-but-silent worker no longer
+    // forces a fail-open on behalf of the truly-active worker.
     assert_eq!(
         lease.v8_equal_flow_fail_open_reason(),
-        V8EqualFlowFailOpenReason::UnsampledActiveWorker
+        V8EqualFlowFailOpenReason::InsufficientSampledWorkers
     );
 }
 
@@ -815,9 +831,13 @@ fn equal_flow_fail_open_for_quiet_active_worker_without_demand_or_grant() {
     let _ = lease.acquire_v8(0, EPOCH_DURATION_NS, 8_000);
     let _ = lease.acquire_v8(0, 2 * EPOCH_DURATION_NS, 8_000);
     assert!(!lease.v8_equal_flow_enforced());
+    // #1745: worker 1 is "quiet active" — a nonzero flow bucket but no
+    // demand/grant/sample (it never acquired). It is the idle-at-rotation
+    // exclude case, so it no longer forces an UnsampledActiveWorker bail.
+    // Only worker 0 is sampled -> InsufficientSampledWorkers.
     assert_eq!(
         lease.v8_equal_flow_fail_open_reason(),
-        V8EqualFlowFailOpenReason::UnsampledActiveWorker
+        V8EqualFlowFailOpenReason::InsufficientSampledWorkers
     );
 }
 
@@ -834,6 +854,166 @@ fn equal_flow_fail_open_for_nonzero_low_demand_worker() {
     assert_eq!(
         lease.v8_equal_flow_fail_open_reason(),
         V8EqualFlowFailOpenReason::LowDemandWorker
+    );
+}
+
+// === #1745: acquire-time active-flow sampling regression tests ===
+
+/// #1745 regression: a forced `InsufficientSampledWorkers` epoch must
+/// leave `suppressed_grant_bytes` and `cap_hit_events` untouched (it is a
+/// fail-open, not a suppression). Validation gate 3.
+#[test]
+fn equal_flow_insufficient_sampled_workers_leaves_suppression_unchanged() {
+    let lease = new_equal_flow_lease();
+    // Single active worker (-P1-style): it acquires alone, so the
+    // publisher can never reach the sampled>=2 threshold.
+    lease.rehydrate_worker_active_count(0, 1);
+    let _ = lease.acquire_v8(0, EPOCH_DURATION_NS, 1_000);
+    let _ = lease.acquire_v8(0, 2 * EPOCH_DURATION_NS, 1_000);
+    assert!(!lease.v8_equal_flow_enforced());
+    assert_eq!(
+        lease.v8_equal_flow_fail_open_reason(),
+        V8EqualFlowFailOpenReason::InsufficientSampledWorkers
+    );
+    let suppressed_before = lease.v8_equal_flow_suppressed_grant_bytes();
+    let cap_hits_before = lease.v8_equal_flow_cap_hit_events();
+    // Drive another fail-open epoch with the same single worker.
+    let _ = lease.acquire_v8(0, 3 * EPOCH_DURATION_NS, 1_000);
+    assert!(!lease.v8_equal_flow_enforced());
+    assert_eq!(
+        lease.v8_equal_flow_suppressed_grant_bytes(),
+        suppressed_before,
+        "fail-open epoch must not increment suppressed_grant_bytes"
+    );
+    assert_eq!(
+        lease.v8_equal_flow_cap_hit_events(),
+        cap_hits_before,
+        "fail-open epoch must not increment cap_hit_events"
+    );
+}
+
+/// #1745 positive: two workers sampled via the acquire-time sticky-max
+/// path reach enforcement. Crucially, the worker that is "ahead" stops
+/// re-acquiring on the enforcing epoch (models the banked exact queue
+/// that skips acquire_v8 while it has tokens); the OTHER worker's acquire
+/// triggers the rotation. Enforcement must still publish because both
+/// workers left a sticky-max sample in the just-ended epoch, even though
+/// only one of them demands on the rotating epoch itself.
+#[test]
+fn equal_flow_enforces_from_acquire_time_samples_when_ahead_worker_banks() {
+    let lease = new_equal_flow_lease();
+    lease.rehydrate_worker_active_count(0, 4);
+    lease.rehydrate_worker_active_count(1, 1);
+
+    // Epoch 1 + 2: both workers acquire (both leave samples + demand).
+    let _ = lease.acquire_v8(0, EPOCH_DURATION_NS, 8_000);
+    let _ = lease.acquire_v8(1, EPOCH_DURATION_NS, 1_800);
+    let _ = lease.acquire_v8(0, 2 * EPOCH_DURATION_NS, 8_000);
+    let _ = lease.acquire_v8(1, 2 * EPOCH_DURATION_NS, 1_800);
+    assert!(!lease.v8_equal_flow_enforced());
+
+    // Epoch 3 rotation: only worker 1 acquires (worker 0 is "banked" and
+    // skips acquire). The epoch-2 samples for BOTH workers were captured
+    // at acquire time, so the publisher has a 2-worker sample set and
+    // enforces. Under the pre-#1745 rotation-instant logic worker 0 would
+    // have been active-but-undemanded and forced a fail-open.
+    let _ = lease.acquire_v8(1, 3 * EPOCH_DURATION_NS, 1);
+    assert!(
+        lease.v8_equal_flow_enforced(),
+        "enforcement must trigger from acquire-time samples even when the \
+         ahead worker banks and skips acquire on the rotating epoch"
+    );
+    assert!(lease.v8_equal_flow_target_per_flow() > 0);
+    assert!(lease.v8_equal_flow_worker_cap() > 0);
+}
+
+/// #1745: the sample is a STICKY-MAX across the epoch, not last-write. A
+/// worker that records a high flow count then a lower one (flow teardown)
+/// in the same epoch must contribute the MAX to the rotation sample.
+#[test]
+fn equal_flow_active_sample_is_sticky_max_within_epoch() {
+    let lease = new_equal_flow_lease();
+    let v8 = lease.v8.as_ref().expect("v8 lease");
+    // Use the published epoch tag the slot was reset to at construction
+    // (tag 0). Record high then low for worker 0.
+    let tag = v8.equal_flow.epoch_tag.load(Ordering::Acquire);
+    record_equal_flow_active_sample(&v8.worker_equal_flow_active_samples[0], tag, 10);
+    record_equal_flow_active_sample(&v8.worker_equal_flow_active_samples[0], tag, 3);
+    let (slot_tag, slot_count) =
+        PackedEpochGrant::unpack(v8.worker_equal_flow_active_samples[0].0.load(Ordering::Acquire));
+    assert_eq!(slot_tag, tag);
+    assert_eq!(slot_count, 10, "sticky-max must keep the high count");
+}
+
+/// #1745 critical race: a stale acquirer (snapshotted an older epoch tag)
+/// must NEVER write its tag backwards over a slot the rotation already
+/// advanced to a newer epoch.
+#[test]
+fn equal_flow_active_sample_never_writes_tag_backwards() {
+    let lease = new_equal_flow_lease();
+    let v8 = lease.v8.as_ref().expect("v8 lease");
+    // Simulate a rotation having advanced the slot to epoch tag 5, count 0.
+    v8.worker_equal_flow_active_samples[0]
+        .0
+        .store(PackedEpochGrant::pack(5, 0), Ordering::Release);
+    // A stale acquirer holding my_tag = 3 tries to record.
+    record_equal_flow_active_sample(&v8.worker_equal_flow_active_samples[0], 3, 99);
+    let (slot_tag, slot_count) =
+        PackedEpochGrant::unpack(v8.worker_equal_flow_active_samples[0].0.load(Ordering::Acquire));
+    assert_eq!(slot_tag, 5, "stale acquirer must not write tag backwards");
+    assert_eq!(slot_count, 0, "stale acquirer must not corrupt the count");
+}
+
+/// #1745: the default `CstructDefault` rate mode must never touch the
+/// acquire-time sample array, on either the acquire or rotation side.
+#[test]
+fn equal_flow_default_mode_never_records_active_samples() {
+    let lease = SharedCoSQueueLease::new_v8(50_000_000, 256 * 1024, 2, 1);
+    lease.rehydrate_worker_active_count(0, 4);
+    lease.rehydrate_worker_active_count(1, 1);
+    let _ = lease.acquire_v8(0, EPOCH_DURATION_NS, 8_000);
+    let _ = lease.acquire_v8(1, EPOCH_DURATION_NS, 2_000);
+    let _ = lease.acquire_v8(0, 2 * EPOCH_DURATION_NS, 8_000);
+    let _ = lease.acquire_v8(1, 2 * EPOCH_DURATION_NS, 2_000);
+    let v8 = lease.v8.as_ref().expect("v8 lease");
+    for slot in v8.worker_equal_flow_active_samples.iter() {
+        assert_eq!(
+            slot.0.load(Ordering::Acquire),
+            0,
+            "CstructDefault path must leave the equal-flow sample array untouched"
+        );
+    }
+}
+
+/// #1745 / Codex Finding 4 safety: a worker that demanded-or-was-granted
+/// bytes but whose acquire-time sample is missing (a real participant we
+/// failed to sample, e.g. via the tag-backwards race) must keep the
+/// `UnsampledActiveWorker` fail-open rather than be silently excluded.
+#[test]
+fn equal_flow_unsampled_real_participant_still_fails_open() {
+    let lease = new_equal_flow_lease();
+    lease.rehydrate_worker_active_count(0, 4);
+    lease.rehydrate_worker_active_count(1, 1);
+    // Both workers acquire for two epochs to build demand + grants +
+    // samples, reaching the verge of enforcement.
+    let _ = lease.acquire_v8(0, EPOCH_DURATION_NS, 8_000);
+    let _ = lease.acquire_v8(1, EPOCH_DURATION_NS, 1_800);
+    let _ = lease.acquire_v8(0, 2 * EPOCH_DURATION_NS, 8_000);
+    let _ = lease.acquire_v8(1, 2 * EPOCH_DURATION_NS, 1_800);
+    // Before the next rotation, wipe worker 0's epoch-2 sample slot so it
+    // becomes a "demanded+granted but unsampled" participant at rotation.
+    let v8 = lease.v8.as_ref().expect("v8 lease");
+    v8.worker_equal_flow_active_samples[0]
+        .0
+        .store(0, Ordering::Release);
+    // Worker 1 triggers the rotation into epoch 3.
+    let _ = lease.acquire_v8(1, 3 * EPOCH_DURATION_NS, 1);
+    assert!(!lease.v8_equal_flow_enforced());
+    assert_eq!(
+        lease.v8_equal_flow_fail_open_reason(),
+        V8EqualFlowFailOpenReason::UnsampledActiveWorker,
+        "a demanded/granted-but-unsampled real participant must keep the \
+         safety fail-open, not be silently excluded"
     );
 }
 


### PR DESCRIPTION
## Summary

CoS `equal-flow-enforcement` (opt-in, default OFF) permanently
fail-opened with `reason=insufficient_sampled_workers`, so the v8
equalizer never clipped outlier flows. Root cause: the epoch sampler
derived the equal-flow worker set from the instantaneous
`worker_active_flow_buckets` read plus the per-epoch demand boolean, both
captured at the 200 µs rotation boundary — but exact CoS queues skip
`acquire_v8` while they hold banked tokens (`token_bucket.rs:201`), so a
worker carrying real traffic whose per-epoch consumption stayed under the
bank never bumped demand for that epoch even though its flow bucket was
nonzero. At rotation it looked active-but-undemanded → the publisher
bailed `UnsampledActiveWorker`, and with several such workers the demanded
set fell below 2 → permanent `InsufficientSampledWorkers`.

Fix: record the sample **when the worker requests lease credit**, not at
the rotation instant. A new `EqualFlowSuppress`-only `V8State` array
`worker_equal_flow_active_samples` holds a tagged sticky-max active-flow
sample per worker; rotation swaps it and the publisher derives the sample
set from `sampled_active_flows>0 && demanded && prev_grants>0`. A
demanded-or-granted-but-unsampled worker keeps the `UnsampledActiveWorker`
safety fail-open; a genuinely idle-at-rotation worker is excluded without
forcing a fail-open. Target semantics stay clip-to-SLOWEST; the
work-conserving / global-fair-rate target policy is the separate #1746,
which this fix unblocks.

The default (equal-flow-OFF) path is byte-unaffected: all new reads/writes
are gated on the `EqualFlowSuppress` rate mode, on both the acquire and
rotation sides.

Closes #1745. References #1746.

## Plan + adversarial review

Plan doc: `docs/pr/1745-equal-flow-failopen-sample/plan.md`

- Codex plan r1: PLAN-NEEDS-MAJOR (5 code-grounded findings)
- Antigravity (AGY) plan r1: PLAN-NEEDS-MINOR (independent proofs, same 2 required fixes)
- Claude-SMR plan r1: PLAN-NEEDS-MAJOR (verified all findings against code)
- Converged NOT-KILL. Q1 (sufficiency / the kill question) resolved by
  both external reviewers with independent proofs: exact queues have no
  autonomous local refill, so any byte-sending worker is forced to
  `acquire_v8` within the epoch; only a zero-traffic worker stays banked
  and excluding it is correct. All round-1 findings folded into plan v2 +
  the implementation (race-free helper, rotation-side gating,
  keep-the-bail-for-real-participants, regression tests).

## Test plan

- [x] cargo build clean (release)
- [x] cargo test --release: 1699 passed, 0 failed (2 ignored). 25/25
      equal_flow tests pass (19 existing + 6 new).
- [x] Full suite green across 2 consecutive runs (one transient
      `tx_latency_hist` timing-skew flake under CPU contention, unrelated
      to CoS — passes 5/5 in isolation and 2/2 full re-runs)
- [x] Go: build clean; `pkg/dataplane/userspace` socket-path failures
      reproduce identically on clean master (sandbox tmpdir + long
      test-name > 108-char sockaddr_un limit), not introduced here
- [x] Deploy on loss userspace cluster (rolling, both nodes)

### Live validation gate (the proof — scheduler-24g queue 10, iperf3 -P12)

- [x] **Gate 1 (enforced 0→1):** with equal-flow ON, `enforced=1`,
      `target_per_flow_bps≈2.0e9`, `max_worker_cap_bytes=151362`,
      `fail_open{reason="none"}=1` steady-state — the previously-permanent
      `insufficient_sampled_workers` fail-open is gone.
- [x] **Outlier clipping / CoV:** per-stream **CoV 22.1% (OFF) → 8.6%
      (ON)**; spread 0.88G → 0.47G; high outliers (~1.88G) clip toward the
      ~2.0G target, floor lifts 1.00G → 1.31G. Aggregate preserved
      (16.8G → 17.3G — no regression).
- [x] **Gate 2 (forced fail-open control, -P1):** `enforced=0`,
      `target=0`, `reason=insufficient_sampled_workers`, and
      `suppressed_grant_bytes` **unchanged** across the entire window (no
      suppression while failed open).
- [x] Reverted equal-flow OFF in the live fixture (committed fixture
      stays default-off).

### CoS smoke matrix (equal-flow-OFF default path)

- [x] **Pass A — CoS disabled** (best-effort fast path): baselines
      7.6–8.7 Gb/s v4+v6 push+reverse, 0 retrans; **P12 -R v4 22.9G / v6
      22.6–22.7G, 0 retrans** (line-rate-class, no TX-path regression)
- [x] **Pass B — CoS enabled** per-class: shaped classes hit configured
      rate cleanly (iperf-100m → ~96 Mb/s), 0 retrans v4+v6 push+reverse
- [x] **#1217 fairness gate:** observed CoV well within structural
      ceiling; default-path aggregate unregressed
- [x] **`make test-failover`:** 13 passed, 0 failed (shared v8 lease code;
      equal-flow epoch state is process-local, not HA-synced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)