### PR TITLE
#1748: cross-worker per-flow ntuple rebalance controller (forward, default-OFF)

### DIFF
--- a/docs/cos-flow-rebalance.md
+++ b/docs/cos-flow-rebalance.md
@@ -1,0 +1,146 @@
+# Reactive cross-worker flow rebalance (`class-of-service flow-rebalance`, #1748)
+
+> **Default-OFF, opt-in.** Absent config ⇒ the userspace-dp controller is
+> never constructed, no ethtool ioctl socket is opened, zero ntuple rules are
+> installed, and the per-tick decision loop never runs. The forwarding path is
+> byte-identical to a build without this feature when the knob is unset.
+
+## What it does
+
+The per-flow throughput coefficient-of-variation (CoV) on shaped ports swings
+14–29% under many concurrent flows because RSS hashes the N flows unevenly
+across the NIC's RX queues. Each RX queue maps to one worker, so workers serve
+different flow *counts*, and a worker's fixed capacity splits among *its*
+flows — slow flows on the crowded worker, fast flows on the idle one.
+
+The #1746 equal-flow cap can only clip fast flows *down*; it cannot lift slow
+flows. The only lever that lifts slow flows **and** preserves aggregate
+throughput is moving an established flow off an overloaded worker onto an idle
+one. This controller does that automatically: it observes per-worker byte-rate
+imbalance and, when the imbalance persists, installs one exact-5-tuple ntuple
+flow-steering rule (`ethtool -N`-style, via a direct `SIOCETHTOOL` ioctl) that
+re-pins the heaviest flow on the hottest worker to the least-loaded worker's RX
+queue.
+
+Measured in the R1 spike: established-flow mid-flight re-pin took per-flow CoV
+from 16.8% → 2.3–4.2% while *raising* aggregate throughput.
+
+## Configuration
+
+```
+set class-of-service flow-rebalance imbalance-threshold 130
+set class-of-service flow-rebalance rebalance-interval 1
+set class-of-service flow-rebalance max-rules 64
+```
+
+All sub-leaves are optional; the bare `set class-of-service flow-rebalance`
+block (any sub-leaf present) enables the controller with defaults.
+
+| Leaf | Units | Default | Range | Meaning |
+|---|---|---|---|---|
+| `imbalance-threshold` | percent of mean | 130 | 101–1000 | Move only when the hottest worker's byte-rate exceeds this percent of the mean (130 = 1.30×). |
+| `rebalance-interval` | seconds | 1 | 1–3600 | Minimum dwell between rule installs (one move per interval). |
+| `max-rules` | rules | 64 | 1–1024 | Hard cap on concurrently-installed ntuple rules per interface. At the cap the controller STOPS — it never evicts an existing rule. |
+
+To disable, delete the block:
+
+```
+delete class-of-service flow-rebalance
+```
+
+On disable (or any config change to the block), every installed rule is torn
+down — a still-live move hands ownership back to the original worker before its
+rule is removed, so no flow is dropped and no orphan hardware rule survives.
+
+## Selection logic (why it does not thrash)
+
+Per tick (coordinator status cadence, ~1 Hz — never per-packet):
+
+1. Derive per-worker byte-rate over the window.
+2. If `max_worker / mean > imbalance-threshold` **and** it has persisted for at
+   least two consecutive ticks (hysteresis), consider a move.
+3. Pick the **heaviest** flow on the **hottest** worker whose move to the
+   **least-loaded** worker most flattens the per-worker byte-rate vector,
+   subject to:
+   - **magnitude guard** — the flow's rate must be ≤ ½ the source-destination
+     gap, so the move cannot make the destination the new hottest worker;
+   - **ε-band** — the projected byte-rate CoV must improve by more than a small
+     epsilon, so marginal moves are skipped;
+   - **per-flow cooldown** — a flow re-pinned within several intervals is
+     ineligible (oscillation guard);
+   - **one move per `rebalance-interval`** (dwell).
+4. At `max-rules`, STOP (no eviction).
+
+The objective is monotone under the ε-band over a finite flow set, so it
+terminates and cannot oscillate.
+
+## Correctness: the move is a barriered ownership transfer
+
+Re-pinning a flow is not free — the old worker (W_old) keeps a stale forward
+session entry whose normal GC/purge/terminal cleanup would cascade-delete the
+shared session-map entry, conntrack mirror, and SNAT allocation that the new
+worker (W_new) is now forwarding against. The controller therefore performs a
+genuine ownership transfer:
+
+- **Forward barrier (install):** promote W_new's pre-replicated session to a
+  local owner (`RebalancedOwner`) and block on its ack; then demote W_old's
+  copy to an inert, cleanup-suppressed `RebalancedOut` and block on its ack;
+  *then* install the rule. Because the worker command queues are independent
+  per-worker, the ack barrier is what guarantees W_new is committed as owner
+  before W_old is demoted — there is always ≥ 1 cleanup owner.
+- **Reverse barrier (rollback / teardown of a live move):** restore W_old to
+  owner and block on its ack, delete the rule, then demote W_new back to a
+  replica. Applying the demote first would re-open a zero-owner window.
+
+`RebalancedOut` is suppressed at every shared-state release/delete site (GC
+expiry, worker purge, terminal-filter, SNAT release, `DeleteSynced` broadcast,
+peer export, `demote_owner_rg`/`refresh_owner_rgs`). `RebalancedOwner` behaves
+like a normal local owner for cleanup/export/sync and demotes to `SyncImport`
+on a real RG failover like `ForwardFlow`.
+
+## HA / failover behavior — fairness resets after a failover
+
+> **Operationally important.** After a chassis-cluster failover, the new
+> primary node has **no ntuple rules** installed (the rules are local NIC state
+> on the node that was active; they do not replicate to the standby in this
+> increment). Traffic therefore falls back to plain RSS hashing on the new
+> primary.
+
+This is **correct** but **not immediately fair**: the per-flow CoV will jump
+back toward the natural RSS imbalance (14–29%) immediately after a failover,
+then re-converge toward the balanced floor (~3–4%) as the controller observes
+the imbalance on the new primary and re-installs rules over the next several
+`rebalance-interval`s. No connectivity is lost across the failover — only the
+fairness optimization resets and rebuilds. Forward-only, single-node re-pin is
+HA-*correct* (the pre-replicated session substrate forwards on the new worker);
+peer rule-mirroring for sustained post-failover fairness is a documented
+follow-up (R4), out of scope for this increment.
+
+## Observability
+
+Per-interface Prometheus gauges/counters (`{ifindex}` label):
+
+- `xpf_userspace_flow_rebalance_rules_active` — installed rules now.
+- `xpf_userspace_flow_rebalance_installs_total` / `_deletes_total`.
+- `xpf_userspace_flow_rebalance_moves_skipped_total{reason}` — why a candidate
+  move was not taken (`balanced`, `cooldown`, `magnitude`, `epsilon`,
+  `budget_exhausted`, `barrier_failed`, `dwell`).
+- `xpf_userspace_flow_rebalance_worker_byterate_cov` — the live per-worker
+  byte-rate CoV the controller observed at the last tick (this is the metric
+  the feature is trying to drive down).
+
+## Hardware support
+
+Exact and masked ntuple steering requires a NIC whose driver supports
+`ETHTOOL_SRXCLSRLINS` flow-classification rules (verified on the loss cluster's
+mlx5_core SR-IOV VFs). On a NIC without support the controller logs
+`EOPNOTSUPP` once and skips that interface; the default forwarding path is
+unaffected.
+
+## Scope (this increment)
+
+- **Forward-direction only.** A `-R` / reverse-direction flow needs a reverse
+  rule pair (R2, follow-up).
+- **Single-node.** No peer rule-mirroring across failover (R4, follow-up —
+  see the HA section above).
+- **Budget + cooldown**, not a full 1024-rule eviction policy (R5, follow-up).

--- a/docs/cos-flow-rebalance.md
+++ b/docs/cos-flow-rebalance.md
@@ -125,7 +125,10 @@ Per-interface Prometheus gauges/counters (`{ifindex}` label):
 - `xpf_userspace_flow_rebalance_installs_total` / `_deletes_total`.
 - `xpf_userspace_flow_rebalance_moves_skipped_total{reason}` — why a candidate
   move was not taken (`balanced`, `cooldown`, `magnitude`, `epsilon`,
-  `budget_exhausted`, `barrier_failed`, `dwell`, `restore_failed`).
+  `no_eligible_flow`, `budget_exhausted`, `barrier_failed`, `dwell`,
+  `restore_failed`). `no_eligible_flow` (distinct from `epsilon`) means the
+  hottest worker had no movable flow with a positive rate — a per-flow signal
+  problem, not a too-conservative move threshold.
 - `xpf_userspace_flow_rebalance_worker_byterate_cov` — the live per-worker
   byte-rate CoV the controller observed at the last tick (this is the metric
   the feature is trying to drive down).

--- a/docs/cos-flow-rebalance.md
+++ b/docs/cos-flow-rebalance.md
@@ -33,8 +33,9 @@ set class-of-service flow-rebalance rebalance-interval 1
 set class-of-service flow-rebalance max-rules 64
 ```
 
-All sub-leaves are optional; the bare `set class-of-service flow-rebalance`
-block (any sub-leaf present) enables the controller with defaults.
+Each sub-leaf is individually optional, but the `flow-rebalance` block is
+created by setting at least one of them. Setting any one sub-leaf enables the
+controller; the unset sub-leaves take the defaults below.
 
 | Leaf | Units | Default | Range | Meaning |
 |---|---|---|---|---|
@@ -124,7 +125,7 @@ Per-interface Prometheus gauges/counters (`{ifindex}` label):
 - `xpf_userspace_flow_rebalance_installs_total` / `_deletes_total`.
 - `xpf_userspace_flow_rebalance_moves_skipped_total{reason}` — why a candidate
   move was not taken (`balanced`, `cooldown`, `magnitude`, `epsilon`,
-  `budget_exhausted`, `barrier_failed`, `dwell`).
+  `budget_exhausted`, `barrier_failed`, `dwell`, `restore_failed`).
 - `xpf_userspace_flow_rebalance_worker_byterate_cov` — the live per-worker
   byte-rate CoV the controller observed at the last tick (this is the metric
   the feature is trying to drive down).

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -231,6 +231,24 @@ between flows needed to make `N ≤ M` flows avoid occupied queues;
 only a reactive controller observing live occupancy can, and that
 is a re-steer.
 
+> **#1748 refinement (the re-steer is the answer, done right).** The
+> kill above is correct for *static* steering and for the *count-blind*
+> reactive controller #1203/#789 built. It is NOT a physics ceiling on
+> reactive **established-flow re-pin**. The #1748 R1 spike re-ran the
+> "forbidden re-steer" on this exact cluster with **byte-rate-aware**
+> selection (move the heaviest flow on the hottest worker, not flatten
+> flow *count*) and took per-flow CoV **16.8% → 2.3–4.2% with aggregate
+> up** — beating the floor ~12×. The #1203 49–55% was the count-blind
+> controller defect, not the placement mechanism. #1748 ships this as a
+> **default-OFF, opt-in** forward-direction reactive rebalancer
+> (`class-of-service flow-rebalance`); the move is a barriered ownership
+> transfer so the re-steer does not cascade-delete the live flow's shared
+> session state. See `docs/cos-flow-rebalance.md`. The cost the static
+> analysis correctly flags — re-pinning moves an established flow — is
+> paid as a bounded, hysteresis-gated, ≪1 Hz rule churn, not the 12
+> simultaneous mid-flight moves that produced the spike's retransmit
+> burst.
+
 ### What this means operationally
 
 - **This is primarily a per-flow distribution effect, not an

--- a/docs/pr/1748-ntuple-rebalance/claude-smr-plan-r1.md
+++ b/docs/pr/1748-ntuple-rebalance/claude-smr-plan-r1.md
@@ -1,0 +1,75 @@
+# Claude-SMR hostile plan review r1 — #1748 controller plan @ c84523b27
+
+**Verdict: PLAN-NEEDS-MINOR** (architecture validated by R1; four refinements
+required before code, none fatal).
+
+I entered hostile, expecting to find a kill in R4. I did not — R1 empirically
+forecloses the obvious kill — but I found a sharp correctness refinement the
+plan currently hand-waves.
+
+## The one that matters — move-eligibility must gate on session replication (R4/R3)
+
+The plan leans on research §0 ("replicas exist on all sibling workers, so the
+moved flow forwards correctly"). That is true for a *fully-replicated* session,
+but the code has a whole family of session-MISS handlers that fire when a worker
+does **not** have the session: `forwarding/mod.rs:1026
+interface_nat_local_resolution_on_session_miss`, `:1057
+install_helper_local_session_on_miss`, `:1164
+ingress_interface_local_resolution_on_session_miss`. If the controller steers a
+flow to a worker whose replica has not landed yet (a young flow, or a
+replication gap), the target worker takes the on-miss path → **NAT
+re-resolution** → a fresh SNAT binding → server sees a new source port → RST.
+That is the real correctness hazard, and "replicas exist" is not a sufficient
+guarantee on its own.
+
+R1 did not hit this because it moved flows that had run ~14 s (well-replicated).
+The controller must encode that as an explicit invariant, not luck:
+**move-eligibility = flow age > (session-sync interval + margin) AND the target
+worker's replica is confirmed present.** Add this to §4.2 step 2 as a hard
+precondition. This also bounds R3: only long-lived elephants move (exactly the
+ones worth moving), and they are the ones with warm replicas → flow-cache miss
+on the target resolves to the EXISTING session, no NAT realloc, bounded reorder.
+
+This is NEEDS-MINOR, not KILL: the mechanism is proven correct for the eligible
+set; the plan just has to define the eligible set precisely.
+
+## Three more refinements
+
+2. **ethtool_rxnfc UAPI (§4.1)** — the sketch omits the `h_u`/`m_u` union
+   (`ethtool_tcpip4_spec` for `flow_type=TCP_V4_FLOW`) and the `ring_cookie`
+   semantics (the action queue is the low bits of a u64 `ring_cookie`, with
+   special values like `RX_CLS_FLOW_DISC`). Get this exactly right or rules
+   silently mis-steer. Require a compile-time `size_of`/offset assertion against
+   the kernel UAPI AND a round-trip test (insert → `GRXCLSRLALL` → read back the
+   spec) on the live NIC in the test plan, not just a size check.
+
+3. **Selection convergence (§4.2, Q4)** — "heaviest flow on hottest worker → 
+   least-loaded" is greedy and can oscillate when two elephants are
+   near-equal (move A to q5, next tick q5 is now hottest, move A back). The
+   cooldown is mentioned but not specified. Require: a per-flow cooldown ≥
+   several rebalance intervals AND a hysteresis band (do not move unless the
+   projected post-move max-worker byte-rate improves by > ε). State the stop
+   condition as "no single move reduces the byte-rate CoV by > ε" and prove it
+   terminates (finite flows, monotone objective under the ε-band).
+
+4. **Scope honesty (Q6)** — forward-only + single-node + default-OFF IS a
+   coherent shippable unit: it directly fixes the operator's `-P12` push symptom,
+   it is opt-in, and post-failover it degrades to RSS (fairness, not
+   correctness). But §9 must state the post-failover behavior in the OPERATOR
+   docs, not just the plan — an operator who enables it and sees fairness vanish
+   after a failover needs that documented. Acceptable to ship; document the
+   limitation.
+
+## What I verified
+- `forwarding/mod.rs:541` owner-RG gate is per-RG, not per-worker (confirms no
+  per-worker forwarding gate — research §0 holds for the forwarding decision).
+- The on-session-miss family at `:1026-1164` is the real NAT-realloc hazard the
+  eligibility gate must avoid.
+- `umem/mod.rs:387 tx_bytes: AtomicU64` exists as the byte-rate signal;
+  `coordinator/status.rs:195-206` already has the per-(ifindex,queue,worker)
+  aggregation the controller reads — so no new control-socket caller (Q5 OK).
+
+## Not blocking
+R2 (reverse) and R4-continuity (peer mirroring) deferral is fine given default-
+OFF + documented failover behavior. ethtool genetlink-crate exclusion is
+correctly verified (flow rules are ioctl-only).

--- a/docs/pr/1748-ntuple-rebalance/claude-smr-plan-r2.md
+++ b/docs/pr/1748-ntuple-rebalance/claude-smr-plan-r2.md
@@ -1,0 +1,68 @@
+# Claude-SMR r2 + round-2 reconciliation — #1748 plan @ 47db3a4f4
+
+**Round-2 verdict: PLAN-NEEDS-MAJOR (converging, salvageable).**
+Codex r2 = NEEDS-MAJOR (3 verified holes). Claude-SMR = concur. AGY r2 pending.
+
+## The real shape of the problem (both rounds, both reviewers)
+
+The research plan's premise — "the session substrate already replicates to all
+workers, so a re-pin needs **no migration code**" — is now **falsified twice
+over**. A re-pin is a genuine **session-ownership transfer** from W_old to
+W_new, and the system's GC/sync/HA state machine assumes exactly one owner. v1
+missed it entirely; v2 fixed the *premature-cleanup* half but Codex r2 proved
+v2 created a *never-cleanup* leak and missed two more shared-state sites. The
+controller cannot be an additive module — it must correctly hand off ownership
+through the origin/GC/sync/export/demote/refresh paths, which are the most
+HA-critical code in the tree.
+
+## Verified holes still open after v2 (all code-confirmed)
+
+1. **Conntrack mirror delete (5th site).** `delete_session_map_entry_..._with_origin`
+   deletes conntrack unconditionally (`bpf_map/mod.rs:1032,1037`) and the
+   redirect-key helper ignores origin (`:952`); W_new will NOT recreate it
+   (conntrack publish gated on `resolved.created`, `poll_descriptor/mod.rs:253`).
+   → suppression must cover conntrack, and the redirect helper must become
+   origin-aware.
+2. **No close-delta owner after the move (the v2-induced leak).** W_new's replica
+   is `WorkerLocalImport` = peer-synced ⇒ its eventual real expiry is ALSO
+   delta-suppressed (`session/mod.rs:431`). So after W_old→RebalancedOut and
+   W_new→(silent), **nobody** cleans up the shared map / emits the peer Close
+   when the flow truly ends → shared-state leak. The move needs an explicit
+   **target-side ownership promotion**: W_new's entry becomes a close-OWNING
+   origin (emits Close on real expiry, deletes shared map, broadcasts) WITHOUT
+   re-running NAT allocation. This is the crux v3 must design.
+3. **`RebalancedOut` leaks into HA/export paths.** `demote_owner_rg()` rewrites
+   non-peer-synced owner-RG sessions to `SyncImport` (`session/mod.rs:1030,1039`)
+   → erases the marker before GC. `refresh_owner_rgs` republishes without origin
+   exclusion (`:32,80`). Peer export emits Open deltas for non-peer forward
+   sessions (`session_glue/mod.rs:420,436`). RebalancedOut (and the new owning
+   origin) must be excluded from demote/refresh/export/delta-sync.
+
+## Refinements (not blocking, fold into v3)
+- **Eligibility**: "age > sync interval" is insufficient; require a **fresh
+  target-worker replica ack immediately before rule install**
+  (`shared_ops.rs:376` is the hit path that avoids the miss/NAT route).
+- **Thrash bound is `≤ gap/2`, not `≤ gap`** (Codex): moving a flow larger than
+  half the source-dest gap makes the destination the new hottest. Plus
+  ε-band on projected CoV improvement → monotone, terminating.
+- **ethtool ioctl direction CONFIRMED CORRECT** (Codex cross-checked kernel
+  UAPI): `ethtool_rx_flow_spec{h_u/m_u, ring_cookie, location}` +
+  `ethtool_rxnfc{rule_locs}`, `SRXCLSRLINS/DEL/ALL` are ioctl-only; netlink lacks
+  them. The mechanism is sound; the risk is the ownership state machine, not the
+  ioctl.
+
+## Scope assessment (the honest part)
+- **Mechanism: proven** (R1: CoV 16.8%→2.3–4.2%, aggregate up; ioctl path
+  confirmed). This is real and the only lever that fixes cross-worker fairness
+  without aggregate loss.
+- **Controller: a session-ownership-transfer protocol on HA-critical paths.**
+  Implementable, but it touches the origin/GC/sync/export/demote/refresh state
+  machine — the most delicate, failover-critical code in userspace-dp. Both
+  reviewers found real correctness holes in two rounds; a third round + the
+  implementation itself will be high-care work, and `make test-failover` +
+  HA-crash coverage become mandatory gates, not nice-to-haves.
+
+This is a legitimate go/hold decision for the author: drive v3 → implement the
+ownership-transfer protocol (substantial, high-value, HA-critical), or bank the
+proven mechanism + this precisely-mapped design as the research outcome and
+schedule the implementation deliberately.

--- a/docs/pr/1748-ntuple-rebalance/claude-smr-plan-r3.md
+++ b/docs/pr/1748-ntuple-rebalance/claude-smr-plan-r3.md
@@ -1,0 +1,52 @@
+# Claude-SMR r3 — #1748 plan v3 @ 0f52cc85b
+
+**Verdict: PLAN-READY (with one implementation requirement, below).**
+v3's two-origin transfer closes every verified round-2 finding. Codex + AGY r3
+pending; this is my pass.
+
+## Round-2 findings → v3 resolution (all closed)
+- **Conntrack 5th site (Codex#1/AGY)** → AGY's early-return guard at the top of
+  `delete_session_map_entry_for_removed_session_with_origin` covers redirect +
+  conntrack in one place. ✓
+- **Never-cleanup leak (Codex#2)** → `RebalancedOwner` on W_new
+  (`is_peer_synced()`=false) emits Close on real expiry and owns shared-map +
+  conntrack + broadcast + SNAT cleanup. Exactly one owner. ✓
+- **HA/export marker leak (Codex#3)** → `RebalancedOut` excluded from
+  `demote_owner_rg`/`refresh_owner_rgs`/peer-export/delta-sync. ✓
+- **UAPI** → exact AGY-verified layout as compile-time offset asserts +
+  round-trip test. ✓
+
+## The promote/demote race (item 3) — SAFE, given an ordering requirement
+Sequence: (2) promote W_new→`RebalancedOwner`, (3) demote W_old→`RebalancedOut`,
+(4) install rule. Why no two-owner/zero-owner hazard:
+- **Per-worker loop serialization**: `WorkerCommand`s and `expire_stale_entries`
+  both run in the *same* single-threaded worker loop. On W_old, `DemoteRebalanced`
+  is processed before any subsequent GC tick observes the entry → GC always sees
+  `RebalancedOut`, never a stale `ForwardFlow`. On W_new, `PromoteRebalanced` is
+  processed before the rule install routes packets there.
+- **Zero-owner impossible**: W_old remains an owner (`ForwardFlow`) until step 3;
+  W_new becomes an owner at step 2 — so ≥1 owner at all times, briefly 2.
+- **Transient two-owner is harmless**: between step 2 and 3 both entries would
+  only act *on expiry*; neither expires in the sub-tick window (W_old is still
+  actively refreshed — the rule isn't installed until step 4; W_new was just
+  promoted). No double-cleanup.
+
+**Implementation requirement (NEEDS-MINOR, fold into §4.5):** the controller MUST
+issue promote(W_new) + demote(W_old) + rule-install within a single rebalance
+tick, and the design MUST assert `rebalance_interval` (and the move sequence
+duration) ≪ `SESSION_GC_INTERVAL_NS` so no GC sweep interleaves the transfer.
+State this ordering+timing invariant explicitly; do not leave it implicit.
+
+## Residual to watch at code-review time (not plan-blocking)
+- `RebalancedOwner` must be reachable by `demote_owner_rg` on a real RG failover
+  (it IS a local owner that should demote to `SyncImport` like `ForwardFlow` when
+  its RG goes inactive) — i.e. RebalancedOwner is excluded from the *rebalance*
+  suppression but NOT from normal HA demotion. Only `RebalancedOut` is the
+  inert/excluded origin. Verify the two variants get opposite treatment in the
+  HA paths.
+- The promote tag-flip must touch ONLY `origin` — no re-publish, no NAT
+  re-resolve. A unit test should assert the SNAT allocation refcount/owner is
+  unchanged across promote.
+
+Net: architecture is sound and now complete. Proceed to implement once Codex +
+AGY r3 concur, folding the single-tick ordering invariant into §4.5.

--- a/docs/pr/1748-ntuple-rebalance/claude-smr-plan-r3.md
+++ b/docs/pr/1748-ntuple-rebalance/claude-smr-plan-r3.md
@@ -50,3 +50,14 @@ State this ordering+timing invariant explicitly; do not leave it implicit.
 
 Net: architecture is sound and now complete. Proceed to implement once Codex +
 AGY r3 concur, folding the single-tick ordering invariant into §4.5.
+
+---
+## SELF-CORRECTION (post Codex r3)
+My race analysis above was WRONG. I claimed "per-worker loop serialization"
+makes the promote/demote ordering safe — but that only serializes commands vs GC
+*within one worker*. The two commands go to TWO independent per-worker queues
+(`loop_body/mod.rs:591`), with no cross-worker ordering. Codex correctly showed
+W_old can demote before W_new promotes → a real zero-owner window. The fix is an
+applied-command barrier (ack between promote and demote), now in v4 §4.5. This
+is exactly the SMR-soft-pass → Codex-catches-real-race pattern the methodology
+guards against; recording it.

--- a/docs/pr/1748-ntuple-rebalance/plan.md
+++ b/docs/pr/1748-ntuple-rebalance/plan.md
@@ -1,8 +1,20 @@
 # #1748 Step 1 — reactive cross-worker ntuple rebalance controller (forward-direction, default-OFF)
 
-- **Status**: DRAFT v4 — round-3 NEEDS-MAJOR addressed (applied-command barrier
-  + dedicated origin-only promote), pending round-4 re-review
+- **Status**: DRAFT v5 — round-4 NEEDS-MAJOR addressed (liveness-refresh promote
+  + structured ack + reverse-barrier rollback), pending round-5 re-review
 - **Issue**: #1748
+
+### Round-4 review outcome (Codex NEEDS-MAJOR, AGY READY)
+AGY r4 = PLAN-READY (confirmed exclusions + SNAT release via shared
+`Arc<PortAllocatorShared>` works post-handoff + dedicated promote sound). Codex
+r4 = NEEDS-MAJOR, two verified refinements both folded into v5 §4.5: (1) the
+barrier still races if the promoted replica is near its own GC timeout → promote
+must do a liveness-only `last_seen`/wheel refresh (no delta/publish/NAT); (2)
+rollback must be a REVERSE barrier (restore W_old→owner + ack, THEN
+W_new→replica) — the naive order re-opens zero-owner; plus the ack must be
+structured `{seq,key,origin,result}`, not a bare `AtomicU64`. Codex confirmed
+the r3 generic-helper finding is closed and the dedicated origin-only promote is
+the right design.
 
 ### Round-3 review outcome (Codex NEEDS-MAJOR, AGY READY, SMR self-corrected)
 AGY r3 = PLAN-READY (verified the full suppression set + NAT-realloc avoidance +
@@ -233,10 +245,28 @@ sequence pattern (`ha.rs:170-182`):
 3. ONLY THEN install the ntuple rule.
 
 This guarantees W_new is the committed owner before W_old is demoted → there is
-always ≥1 cleanup owner; zero-owner is impossible. The barrier also bounds the
-transfer well under `SESSION_GC_INTERVAL_NS`. If any ack times out or the ioctl
-fails, roll back (W_new→replica, W_old→owner) — a racing GC during rollback sees
-exactly one owner (idempotent).
+always ≥1 cleanup owner; zero-owner is impossible.
+
+**Liveness refresh on promote (Codex r4 — required).** "Replica present" is not
+sufficient: W_new's materialized replica could be ms from its own GC timeout, so
+after promote+ack but before the rule installs, W_new's GC could remove the sole
+owner → zero owners. The dedicated promote API therefore ALSO refreshes
+`last_seen_ns` + re-buckets the wheel (`push_to_wheel`) when it flips the origin
+— a liveness-only refresh that still emits NO delta, NO publish, NO NAT change.
+This makes the promoted owner provably non-expiring across the move budget,
+independent of its prior TTL. (Belt-and-suspenders: the eligibility check also
+prefers replicas with `ttl_remaining ≥ move-budget`.)
+
+**Ack payload (Codex r4).** The rebalance ack cannot be a bare `AtomicU64` like
+the raw `session_export_ack` counter; it must let the controller read back
+`{seq, key, origin, result}` so it confirms the EXACT key reached the EXACT
+origin (`RebalancedOwner` / `RebalancedOut`) before proceeding.
+
+**Rollback is a REVERSE barrier (Codex r4).** On ack-timeout or ioctl failure,
+the same independent-queue hazard applies — so rollback must restore in the safe
+order: **restore W_old→owner, block for its ack, THEN demote W_new→replica**.
+Applying `W_new→replica` first would re-open the zero-owner window. A racing GC
+during the reverse-barrier rollback always sees ≥1 owner.
 
 **`RebalancedOwner` vs `RebalancedOut` get OPPOSITE HA treatment:**
 `RebalancedOut` is inert (excluded from demote/refresh/export). `RebalancedOwner`

--- a/docs/pr/1748-ntuple-rebalance/plan.md
+++ b/docs/pr/1748-ntuple-rebalance/plan.md
@@ -1,6 +1,7 @@
 # #1748 Step 1 — reactive cross-worker ntuple rebalance controller (forward-direction, default-OFF)
 
-- **Status**: DRAFT v2 — round-1 NEEDS-MAJOR addressed, pending re-review
+- **Status**: DRAFT v3 — round-2 NEEDS-MAJOR addressed (two-origin ownership
+  transfer), pending round-3 re-review
 - **Issue**: #1748
 
 ### Round-1 review outcome (verdict: PLAN-NEEDS-MAJOR)
@@ -17,6 +18,22 @@ session-replication-eligibility gap (NEEDS-MINOR) and v2 folds both. Codex
 cleared control-socket + scope (its full verdict was lost to an output-capture
 glitch; it re-attacks v2 fresh). v1's claim "no migration code needed; stale
 copy ages out silently" was **wrong** and is corrected in §3/§4.5.
+
+### Round-2 review outcome (verdict: PLAN-NEEDS-MAJOR, all three)
+Codex + AGY + Claude-SMR all NEEDS-MAJOR, converged on the same design. v2's
+single-origin `RebalancedOut` demotion fixed *premature* cleanup but: (Codex #1/
+AGY) missed the **conntrack mirror delete** — `delete_session_map_entry_..._with_origin`
+deletes conntrack + redirect keys ungated by origin (`bpf_map/mod.rs:952,1032,1037`);
+(Codex #2) created a **never-cleanup leak** — W_new's replica is `WorkerLocalImport`
+(peer-synced) so *its* eventual real expiry is ALSO Close-suppressed → no worker
+owns shared-map/peer cleanup when the flow truly ends; (Codex #3) `RebalancedOut`
+leaks through `demote_owner_rg` (`session/mod.rs:1030,1039`),
+`refresh_owner_rgs` (`:32,80`), and peer export (`session_glue/mod.rs:420,436`).
+v3 resolves all three with a **two-origin ownership transfer** (§4.5).
+**Confirmed by reviewers:** ethtool ioctl direction correct + exact UAPI layout
+(AGY, §4.1); eligibility gate bypasses the NAT-miss path
+(`resolve_flow_session_decision`, `session_glue/mod.rs:886`); selection is
+mathematically convergent (cooldown + `≤ gap/2` + ε-band); scope coherent.
 - **Branch**: `engineer/1748-ntuple-rebalance`
 - **Predecessors**: converged research plan (`research-plan.md`); R1 spike PASS
   (`r1-spike-findings.md`: CoV 16.8%→2.3–4.2%, aggregate preserved, established-
@@ -97,6 +114,21 @@ Single `ioctl(fd, SIOCETHTOOL=0x8946, &ifreq{ifr_name, ifr_data:&rxnfc})`.
 Structured `errno` (e.g. `ENOSPC` at the 1024 cap, `EOPNOTSUPP` non-mlx5) — no
 text parsing. Programs the **local** node's interface only.
 
+**Exact UAPI layout (AGY-verified against kernel `ethtool.h`, x86-64) — assert
+at compile time:**
+- `struct ethtool_rx_flow_spec` = **168 B**: `flow_type` u32 @0; `h_u` union @4
+  (52 B); `h_ext` @56 (20 B); `m_u` union @76 (52 B); `m_ext` @128 (20 B); pad
+  @148 (4 B); `ring_cookie` u64 @152; `location` u32 @160; pad @164 (4 B).
+- `struct ethtool_rxnfc` = **192 B**: `cmd` u32 @0; `flow_type` u32 @4; `data`
+  u64 @8; `fs` @16 (168 B); `rule_cnt`/`rss_context` u32 @184; pad @188;
+  `rule_locs` `[u32;0]` flexible @192.
+- For TCP4: `flow_type=TCP_V4_FLOW(0x03)`, `h_u.tcp_ip4_spec{ip4src,ip4dst,
+  psrc,pdst}`, masks in `m_u` (0 = match, 0xff..= wildcard — kernel inverts),
+  `ring_cookie` = target queue index, `location = RX_CLS_LOC_ANY` to auto-assign.
+- `cmd = ETHTOOL_SRXCLSRLINS(0x32)` insert, `0x31` del, `0x30` getall.
+- `size_of::<EthtoolRxnfc>() == 192` and field-offset asserts gate the build; a
+  live insert→`GRXCLSRLALL`→read-back round-trip test validates wire semantics.
+
 ### 4.2 Controller loop (coordinator-level, low cadence)
 New `rebalance/controller.rs`, ticked from the existing coordinator status
 cadence (NOT per-packet, NOT per-poll — gated to ≤1 decision/dwell-interval):
@@ -132,38 +164,52 @@ hard cap `max_rules` (≪1024) with graceful RSS fallback for the rest.
   reduces byte-rate CoV by > ε" — terminates (finite flows, monotone objective
   under the ε-band), cannot oscillate.
 
-### 4.5 Move protocol — origin demotion (the round-1 must-fix)
-A move is a 3-step coordinator sequence, NOT just a rule install:
-1. **Demote on W_old (before the rule):** send a new
-   `WorkerCommand::DemoteRebalanced{key}` to the worker that currently owns F's
-   forward entry, setting its `origin` to a **new `SessionOrigin::RebalancedOut`
-   variant**. Doing this *before* the ntuple rule means even a racing GC tick
-   sees the safe origin.
-2. **`RebalancedOut` GC semantics:** on expiry, `expire_stale_entries` removes
-   ONLY the local `SessionTable` entry — it must **suppress** the `Close` delta
-   (`session/mod.rs:431` condition gains `&& !origin.is_rebalanced_out()`),
-   **suppress** the shared session-map delete
-   (`delete_session_map_entry_for_removed_session_with_origin` /
-   `delete_session_map_redirect_for_session` skip the shared-map op for
-   `RebalancedOut`, mirroring how `uses_kernel_local_session_map_entry`
-   already gates local vs shared), **suppress** the `DeleteSynced`
-   broadcast, AND **suppress the SNAT release**
-   (`release_source_nat_allocation`, `worker/loop_body/mod.rs:670`) — verified
-   hazard: it calls `pool_allocator.release_flow(flow, translated)` keyed by the
-   flow 5-tuple, ungated by origin, so W_old's early expiry would free the SNAT
-   port while W_new's live flow still uses it (the port could then be reassigned
-   to a new flow → collision/break). For `RebalancedOut`, skip the release; W_new
-   (the surviving owner of the same flow + same translation) releases it on its
-   own eventual close. W_new owns the shared entry now and refreshes it from
-   ingress.
-3. **Install the ntuple rule** (forward 5-tuple → W_new's queue) via
-   `SIOCETHTOOL`. W_new's replica (`WorkerLocalImport`, peer-synced) keeps the
-   flow alive and its `last_seen_ns` advances with the arriving packets.
+### 4.5 Move protocol — two-origin ownership transfer (round-2 must-fix)
+A move is a genuine **ownership transfer** W_old → W_new. Two new
+`SessionOrigin` variants make the handoff correct:
+- **`RebalancedOut`** — the abandoned copy on W_old. Suppress-everything: never
+  cleans up shared state, never exports/syncs/promotes; ages out local-only.
+- **`RebalancedOwner`** — the promoted owner on W_new. Behaves like `ForwardFlow`
+  for cleanup/export/sync (emits Close on REAL expiry, deletes shared map +
+  conntrack, broadcasts `DeleteSynced`, releases SNAT) — so exactly one worker
+  owns end-of-flow cleanup. `is_peer_synced()` stays false for it (it is a
+  local owner, not an import) so it is NOT Close-suppressed.
+
+Coordinator sequence (one move per `rebalance_interval`):
+1. **Eligibility**: flow age > `session-sync interval + margin` AND a fresh
+   target-worker replica-present ack (W_new holds the materialized synced
+   replica — `resolve_flow_session_decision`, `session_glue/mod.rs:886` — so the
+   first steered packet hits it and bypasses the `*_on_session_miss` NAT-realloc
+   family). Magnitude `≤ gap/2`, cooldown clear, projected CoV gain `> ε`.
+2. **Promote W_new (before the rule):** `WorkerCommand::PromoteRebalanced{key}`
+   sets W_new's existing replica `origin = RebalancedOwner` — **tag flip only,
+   no NAT reallocation, no republish**. W_new is now the single cleanup owner.
+3. **Demote W_old (before the rule):** `WorkerCommand::DemoteRebalanced{key}`
+   sets W_old's forward entry `origin = RebalancedOut`. Doing both demote+promote
+   before the rule means a racing GC tick on either side sees safe origins.
+4. **Install the ntuple rule** (forward 5-tuple → W_new's queue) via
+   `SIOCETHTOOL`. W_new's `RebalancedOwner` entry's `last_seen_ns` advances with
+   the arriving packets; W_old's `RebalancedOut` entry freezes and ages out.
+
+**`RebalancedOut` GC/HA suppression — the complete set (all code-verified):**
+- **Close delta**: `session/mod.rs:431` gains `&& !origin.is_rebalanced_out()`.
+- **Shared session-map redirect + conntrack delete**: early-return guard at the
+  top of `delete_session_map_entry_for_removed_session_with_origin`
+  (`bpf_map/mod.rs`) — `if origin == RebalancedOut { return; }` (AGY's surgical
+  fix; covers both the redirect-key delete `:952` AND the conntrack delete
+  `:1032/:1037` in one guard, since W_new owns those entries now).
+- **`DeleteSynced` broadcast**: gated off for `RebalancedOut`.
+- **SNAT release**: `release_source_nat_allocation` (`worker/loop_body/mod.rs:670`)
+  skipped for `RebalancedOut` (W_new releases it on its own close).
+- **HA/export path exclusions**: `demote_owner_rg` (`session/mod.rs:1030,1039`)
+  must NOT rewrite `RebalancedOut`→`SyncImport`; `refresh_owner_rgs`
+  (`:32,80`) must NOT republish it; peer export (`session_glue/mod.rs:420,436`)
+  must NOT emit an Open delta for it.
 
 On rule removal / flow close / disable: delete the ntuple rule; the flow
-re-hashes back to RSS naturally (W_new's entry is already the authoritative
-shared one, no further demotion needed). `RebalancedOut` is a local-only,
-delta-suppressed origin — it never participates in HA promotion or sync.
+re-hashes back to RSS naturally (W_new's `RebalancedOwner` entry is the
+authoritative owner). On **failover**, the standby has no rules → RSS fallback
+(correct; fairness re-converges) — documented in operator docs.
 
 ### 4.3 Config knob (default-OFF)
 `pkg/config/schema.go` typed leaf under `class-of-service` (or `chassis`/

--- a/docs/pr/1748-ntuple-rebalance/plan.md
+++ b/docs/pr/1748-ntuple-rebalance/plan.md
@@ -1,8 +1,20 @@
 # #1748 Step 1 — reactive cross-worker ntuple rebalance controller (forward-direction, default-OFF)
 
-- **Status**: DRAFT v5 — round-4 NEEDS-MAJOR addressed (liveness-refresh promote
-  + structured ack + reverse-barrier rollback), pending round-5 re-review
+- **Status**: DRAFT v6 — round-5 NEEDS-MAJOR addressed (teardown-of-live-move is
+  a reverse barrier), pending round-6 re-review
 - **Issue**: #1748
+
+### Round-5 review outcome (Codex NEEDS-MAJOR, AGY READY)
+AGY r5 = PLAN-READY (verified wheel lazy-cleanup safe + reverse-barrier rollback
+1→2→1). Codex r5 confirmed BOTH r4 findings closed (liveness-refresh +
+`push_to_wheel` fix the near-expiry race; structured ack closes the bare-counter
+ambiguity) and found one more verified MAJOR — the symmetric teardown case: rule
+removal/disable of a still-live move re-hashes the flow to W_old (which keeps
+packets via origin-agnostic `last_seen` refresh, `session/mod.rs:560,581`) but is
+cleanup-suppressed, so W_new expires the only owner → leak. v6 makes teardown of
+a live move a reverse barrier (restore W_old→owner+ack, delete rule, demote
+W_new→replica+ack), and articulates the general principle: ownership is
+barriered across every rule transition; only an already-dead flow skips it.
 
 ### Round-4 review outcome (Codex NEEDS-MAJOR, AGY READY)
 AGY r4 = PLAN-READY (confirmed exclusions + SNAT release via shared
@@ -282,10 +294,26 @@ origin-only mutation API** that flips `origin` in place and does nothing else.
 Unit tests assert: no delta pushed, no shared-map publish/upsert, no conntrack
 write, no NAT refcount change across the promote.
 
-On rule removal / flow close / disable: delete the ntuple rule; the flow
-re-hashes back to RSS naturally (W_new's `RebalancedOwner` entry is the
-authoritative owner). On **failover**, the standby has no rules → RSS fallback
-(correct; fairness re-converges) — documented in operator docs.
+**Teardown of a LIVE move is also a (reverse) barrier (Codex r5 — required).**
+Removing the ntuple rule sends the flow back to W_old via RSS. W_old's local-hit
+path refreshes `last_seen`/wheel regardless of origin (`session/mod.rs:560,581`)
+so it keeps the packets — but W_old is still `RebalancedOut`/cleanup-suppressed,
+while W_new stops seeing packets and eventually expires the *only* cleanup owner
+→ shared-state leak. So **any rule teardown of a still-live move must reverse the
+ownership first**: restore W_old→owner (liveness refresh) + ack, delete the
+ntuple rule, THEN demote W_new→replica + ack. This is the same reverse barrier as
+rollback. The ONLY "just delete the rule" case is flow-close *after* the owner
+(W_new) has already expired the session — there is no live ownership to hand
+back. Disable / reconcile that tears down live moves MUST use the reverse
+barrier; a plain rule-flush on disable is a correctness bug.
+
+On **failover**, the standby has no rules → RSS fallback (correct; fairness
+re-converges) — documented in operator docs.
+
+**General principle (all rounds converge here):** ownership is barriered across
+*every* rule transition — install (forward barrier: promote→demote→rule),
+rollback (reverse barrier), and teardown of a live move (reverse barrier).
+Only a transition on an *already-dead* flow needs no barrier.
 
 ### 4.3 Config knob (default-OFF)
 `pkg/config/schema.go` typed leaf under `class-of-service` (or `chassis`/

--- a/docs/pr/1748-ntuple-rebalance/plan.md
+++ b/docs/pr/1748-ntuple-rebalance/plan.md
@@ -1,0 +1,168 @@
+# #1748 Step 1 — reactive cross-worker ntuple rebalance controller (forward-direction, default-OFF)
+
+- **Status**: DRAFT v1 — pending adversarial plan review
+- **Issue**: #1748
+- **Branch**: `engineer/1748-ntuple-rebalance`
+- **Predecessors**: converged research plan (`research-plan.md`); R1 spike PASS
+  (`r1-spike-findings.md`: CoV 16.8%→2.3–4.2%, aggregate preserved, established-
+  flow mid-flight re-pin on `ge-0-0-1`).
+
+## 1. Issue framing
+
+The per-flow CoV on shaped ports swings 14–29% (`-P12`) because RSS hashes the
+N flows unevenly across the 6 mlx5 VF RX queues → workers serve different flow
+counts (`[2,2,1,1,4,2]`), and a worker's capacity splits among *its* flows. The
+#1746 equal-flow cap can only clip fast flows down; it can't lift slow flows.
+The only lever that lifts slow flows *and* preserves aggregate is moving an
+established flow off an overloaded worker onto an idle one — proven in R1 to
+take CoV to 2.3–4.2% with aggregate *up*. This PR builds the reactive controller
+that does that move automatically.
+
+## 2. Honest scope/value framing
+
+- **Value**: lift `-P12` shaped-port CoV from ~16–29% toward the balanced floor
+  (~3–4% measured), WITHOUT the #1746 cap's aggregate loss. This is the only
+  mechanism that improves the structural ceiling `Cstruct` rather than operating
+  within it.
+- **Scope of THIS PR (deliberately bounded)**: a **default-OFF, opt-in**
+  forward-direction reactive rebalancer in Rust `userspace-dp`:
+  observe per-worker byte-rate imbalance → pick the flow whose move most
+  flattens the per-worker byte-rate → install one exact-5-tuple ntuple rule via
+  a direct `SIOCETHTOOL`/`ethtool_rxnfc` ioctl → bounded rule budget + hysteresis
+  + dwell (≪1 Hz rule churn). Plus the config knob, metrics, and operator docs.
+- *If reviewers conclude the perf gain is too small to justify the churn, or
+  that R4 (HA) cannot be made safe in this increment, PLAN-KILL is an acceptable
+  verdict.*
+
+## 3. What's already shipped / composes-with
+
+- **Session substrate (research §0, verified)**: HA replication pre-installs
+  forward+reverse session replicas on every sibling worker
+  (`poll_descriptor/mod.rs:1267`/`:1480`); the active-node packet path gates
+  forwarding on owner-RG-active, never on which worker owns the session
+  (`forwarding/mod.rs:541`, `session_glue/mod.rs:137`). So a flow steered to a
+  new RX queue forwards correctly with no migration code.
+- **Occupancy telemetry**: `coordinator/status.rs:195-206` already aggregates
+  per-`(ifindex, queue_id, worker_id)` active-flow counts; per-worker
+  `tx_bytes: AtomicU64` (`umem/mod.rs:387`) supplies byte-rate.
+- **Flow 5-tuples**: `flow_cache.rs` holds per-flow keys (incl. NAT rewrite
+  ports — see R7).
+- **ioctl precedent**: `slowpath.rs` already does `libc::ioctl` on an
+  `AF_INET`/`SOCK_DGRAM` socket (`SIOCGIFFLAGS`/`SIOCSIFFLAGS`/`TUNSETIFF`).
+- **#1746 cap + #1230 lease**: complementary (within-worker levers); this changes
+  `{aᵢ}` itself. No conflict (research §6).
+
+## 4. Concrete design
+
+### 4.1 NIC programming — direct ioctl, no shell-out, no genetlink crate
+The rust-netlink `ethtool` crate does **not** expose rxnfc/flow-classification
+rules (verified on docs.rs: only feature/coalesce/ring/channel/link/pause/FEC/
+timestamp). Flow rules are ioctl-only. New module
+`userspace-dp/src/afxdp/rebalance/ntuple.rs`:
+
+```rust
+// mirrors slowpath.rs's libc::ioctl-on-AF_INET-socket pattern
+#[repr(C)] struct EthtoolRxnfc { cmd: u32, flow_type: u32, /* h_u, m_u union */
+    data: u64, fs: EthtoolRxFlowSpec, rule_cnt: u32, rule_locs: [u32;0] }
+// ETHTOOL_SRXCLSRLINS=0x32, SRXCLSRLDEL=0x31, GRXCLSRLALL=0x30
+fn insert_rule(ifname, FlowSpec5Tuple, queue) -> io::Result<u32 /*loc*/>
+fn delete_rule(ifname, loc) -> io::Result<()>
+fn list_locs(ifname) -> io::Result<Vec<u32>>   // for reconcile/cleanup
+```
+Single `ioctl(fd, SIOCETHTOOL=0x8946, &ifreq{ifr_name, ifr_data:&rxnfc})`.
+Structured `errno` (e.g. `ENOSPC` at the 1024 cap, `EOPNOTSUPP` non-mlx5) — no
+text parsing. Programs the **local** node's interface only.
+
+### 4.2 Controller loop (coordinator-level, low cadence)
+New `rebalance/controller.rs`, ticked from the existing coordinator status
+cadence (NOT per-packet, NOT per-poll — gated to ≤1 decision/dwell-interval):
+1. Read per-worker byte-rate over the last window (Δtx_bytes/Δt per worker on the
+   target ifindex).
+2. If `max_worker / mean > imbalance_threshold` AND it has persisted ≥
+   `dwell_ticks` (hysteresis): pick the **heaviest single flow** on the hottest
+   worker whose move to the **least-loaded** worker most flattens the per-worker
+   byte-rate vector (byte-rate-aware selection — the fix for #1203's count-blind
+   defect, research §4 R1).
+3. Install one exact-5-tuple rule (forward direction) → least-loaded queue.
+   Record (5-tuple→loc,queue) in an in-memory ledger.
+4. Stop conditions: byte-rate CoV below target, or rule budget exhausted, or no
+   move improves the objective. Never oscillate (a flow re-pinned within
+   `cooldown` is ineligible).
+
+Bounded churn: at most one install per `rebalance_interval` (default ≥1 s),
+hard cap `max_rules` (≪1024) with graceful RSS fallback for the rest.
+
+### 4.3 Config knob (default-OFF)
+`pkg/config/schema.go` typed leaf under `class-of-service` (or `chassis`/
+forwarding-options — reviewer Q): `flow-rebalance` with sub-leaves
+`imbalance-threshold`, `rebalance-interval`, `max-rules`. Compiles to a
+userspace-dp control message; absent ⇒ controller never constructs its ioctl
+socket and installs zero rules (byte-identical default path).
+
+### 4.4 Metrics
+`xpf_userspace_flow_rebalance_{rules_active, installs_total, deletes_total,
+moves_skipped_total{reason}, worker_byterate_cov}` per ifindex.
+
+## 5. Public API preservation
+No existing Rust pub-fn signatures change. New module is additive. Go: one new
+schema leaf + one control-message field (additive, default zero).
+
+## 6. Hidden invariants to preserve
+- **Default-OFF is byte-identical**: no ioctl socket, no rules, no extra
+  per-tick work when the knob is unset (gated construction).
+- **Control-socket contention** (CLAUDE.md): the controller must NOT add a
+  >1 Hz control-socket caller; it reads worker telemetry already collected by
+  the status path and programs the NIC directly (not via the control socket).
+- **No per-packet/per-poll cost**: decision loop is coordinator-cadence only.
+- **ioctl safety**: `ethtool_rxnfc` layout must match the kernel UAPI exactly
+  (size/align) — compile-time `size_of` assertion + a parity test.
+- **Rule lifecycle**: every installed rule is tracked and deleted on disable,
+  flow-close, daemon shutdown, and reconcile (no orphan HW rules across config
+  changes — `list_locs` reconcile on startup clears stale xpf-owned rules).
+
+## 7. Risk assessment
+| Class | Level | Note |
+|---|---|---|
+| Behavioral regression | LOW (OFF) / MED (ON) | OFF is byte-identical; ON adds HW steering — R3 transient reorder is the main correctness watch |
+| Lifetime/borrow | LOW | additive module, owns its own state/socket |
+| Performance regression | LOW | coordinator-cadence, ≪1 Hz rule writes; ~1 ms/rule firmware off the hot path |
+| Architectural mismatch | MED | R4 (HA mirroring) deferred — must prove forward-only single-node re-pin is HA-*correct* (not just fairness) this increment, or KILL |
+
+## 8. Test plan
+- cargo build + full suite; new `ntuple.rs` UAPI size/parity test + controller
+  unit tests (selection objective, hysteresis, budget, oscillation guard) 5×.
+- Go suite (schema leaf + compile).
+- Deploy on loss cluster. **R1-equivalent live gate**: enable knob, `-P12 -p5210`
+  push, confirm controller drives per-worker `{aᵢ}` toward balance and per-flow
+  CoV ≤10% with aggregate not regressed and bounded retransmits (incremental
+  moves, not the 7601 bulk-move artifact). Default-OFF control run unchanged.
+- Full Pass A/B smoke matrix (v4+v6 × push+reverse × CoS-off/on).
+- **`make test-failover`** MUST stay clean (touches placement on an HA cluster).
+
+## 9. Out of scope (explicit follow-ups)
+- **R2 reverse-direction** rule pair (forward-only this PR; documented).
+- **R4 HA peer rule-mirroring** for fairness *continuity* across failover (this
+  PR proves correctness; mirroring for sustained post-failover fairness is a
+  follow-up). After failover the new primary falls back to RSS until it
+  re-converges — fairness, not correctness, regresses.
+- Full 1024-rule eviction policy refinement (R5) beyond a simple budget+cooldown.
+
+## 10. Open questions for adversarial review (each invitable to PLAN-KILL)
+1. **R4 correctness**: does re-pinning ONLY the forward 5-tuple on ONLY the
+   active node break reverse-companion resolution or session-sync on the peer?
+   Research §0 says replicas exist on all workers so forwarding is fine — find a
+   packet-path or sync site that gates on the *specific* worker and breaks. If
+   one exists, KILL (HA can't be deferred).
+2. **R3 transient**: is the per-move reorder bounded enough to avoid TCP resets
+   under incremental single-flow moves, or does even one move risk a reset?
+3. **`ethtool_rxnfc` UAPI**: is the struct/union layout correct across the
+   target kernel (7.0.0-rc7+) and is `SIOCETHTOOL` the right path vs the ethtool
+   netlink family (confirm flow rules truly aren't in genetlink)?
+4. **Selection objective**: is "move the heaviest flow on the hottest worker"
+   provably convergent (not oscillating) with hysteresis, or can it thrash like
+   #840 (CoV 37.7% vs 18.5%)?
+5. **Schema placement**: is `class-of-service flow-rebalance` the right grammar
+   home, or does this belong under `chassis`/`forwarding-options`?
+6. **Scope honesty**: is a forward-only, single-node, default-OFF increment a
+   coherent shippable unit, or does it only become useful once R2+R4 land (→
+   ship nothing until then)?

--- a/docs/pr/1748-ntuple-rebalance/plan.md
+++ b/docs/pr/1748-ntuple-rebalance/plan.md
@@ -1,7 +1,22 @@
 # #1748 Step 1 — reactive cross-worker ntuple rebalance controller (forward-direction, default-OFF)
 
-- **Status**: DRAFT v1 — pending adversarial plan review
+- **Status**: DRAFT v2 — round-1 NEEDS-MAJOR addressed, pending re-review
 - **Issue**: #1748
+
+### Round-1 review outcome (verdict: PLAN-NEEDS-MAJOR)
+AGY found a **verified correctness kill** that v1 missed (and that R1's 70s
+spike was too short to expose): the **stale-owner GC cascade**. When the
+controller steers flow F off W_old, W_old keeps F's forward entry with
+`origin=ForwardFlow` (NOT peer-synced — confirmed `session/entry.rs:78`). When
+that frozen entry ages out, `expire_stale_entries` (`session/mod.rs:431`) takes
+the `!is_peer_synced() && !is_transient_local_seed()` branch → pushes a
+`SessionDeltaKind::Close` → which deletes the **shared** session map entry and
+broadcasts `DeleteSynced` to all workers including W_new — **killing the flow
+now active on W_new**. Claude-SMR independently flagged a narrower
+session-replication-eligibility gap (NEEDS-MINOR) and v2 folds both. Codex
+cleared control-socket + scope (its full verdict was lost to an output-capture
+glitch; it re-attacks v2 fresh). v1's claim "no migration code needed; stale
+copy ages out silently" was **wrong** and is corrected in §3/§4.5.
 - **Branch**: `engineer/1748-ntuple-rebalance`
 - **Predecessors**: converged research plan (`research-plan.md`); R1 spike PASS
   (`r1-spike-findings.md`: CoV 16.8%→2.3–4.2%, aggregate preserved, established-
@@ -41,7 +56,16 @@ that does that move automatically.
   (`poll_descriptor/mod.rs:1267`/`:1480`); the active-node packet path gates
   forwarding on owner-RG-active, never on which worker owns the session
   (`forwarding/mod.rs:541`, `session_glue/mod.rs:137`). So a flow steered to a
-  new RX queue forwards correctly with no migration code.
+  new RX queue **forwards** correctly — BUT (round-1 correction) the move is NOT
+  free of state work: W_old's now-stale `ForwardFlow` entry must be explicitly
+  demoted so its GC expiry does not cascade-delete the live flow (§4.5).
+- **Origin-aware deletion plumbing already exists**: both
+  `delete_session_map_entry_for_removed_session_with_origin(...)` and
+  `delete_session_map_redirect_for_session(...)`
+  (`worker/loop_body/mod.rs:660-687`) already take `origin`, and
+  `bpf_map/mod.rs:3 uses_kernel_local_session_map_entry()` already distinguishes
+  local vs shared entries by origin — so the §4.5 fix extends an existing
+  origin-gated path, not a new subsystem.
 - **Occupancy telemetry**: `coordinator/status.rs:195-206` already aggregates
   per-`(ifindex, queue_id, worker_id)` active-flow counts; per-worker
   `tx_bytes: AtomicU64` (`umem/mod.rs:387`) supplies byte-rate.
@@ -91,6 +115,55 @@ cadence (NOT per-packet, NOT per-poll — gated to ≤1 decision/dwell-interval)
 
 Bounded churn: at most one install per `rebalance_interval` (default ≥1 s),
 hard cap `max_rules` (≪1024) with graceful RSS fallback for the rest.
+
+**Round-1 refinements to the selection/eligibility logic:**
+- **Move-eligibility gate (SMR)**: a flow is eligible only if (a) age >
+  `session-sync interval + margin` AND (b) the target worker already holds a
+  peer-synced replica (`is_peer_synced()` present). This guarantees the target
+  worker's flow-cache miss resolves to the EXISTING session/NAT binding, never
+  the `*_on_session_miss` NAT-realloc family (`forwarding/mod.rs:1026-1164`).
+- **One move per tick (AGY)** — never move >1 flow per `rebalance_interval`, to
+  bound the R3 reorder (the R1 7601-retrans burst was 12 simultaneous moves).
+- **Magnitude guard against thrash (AGY)**: abort the move unless the chosen
+  flow's byte-rate ≤ (source_worker_rate − dest_worker_rate); i.e. moving it
+  must not make the destination the new hottest worker. Plus a per-flow
+  `cooldown` ≥ several intervals and an ε-band (move only if projected
+  byte-rate CoV improves by > ε). Stop condition: "no single eligible move
+  reduces byte-rate CoV by > ε" — terminates (finite flows, monotone objective
+  under the ε-band), cannot oscillate.
+
+### 4.5 Move protocol — origin demotion (the round-1 must-fix)
+A move is a 3-step coordinator sequence, NOT just a rule install:
+1. **Demote on W_old (before the rule):** send a new
+   `WorkerCommand::DemoteRebalanced{key}` to the worker that currently owns F's
+   forward entry, setting its `origin` to a **new `SessionOrigin::RebalancedOut`
+   variant**. Doing this *before* the ntuple rule means even a racing GC tick
+   sees the safe origin.
+2. **`RebalancedOut` GC semantics:** on expiry, `expire_stale_entries` removes
+   ONLY the local `SessionTable` entry — it must **suppress** the `Close` delta
+   (`session/mod.rs:431` condition gains `&& !origin.is_rebalanced_out()`),
+   **suppress** the shared session-map delete
+   (`delete_session_map_entry_for_removed_session_with_origin` /
+   `delete_session_map_redirect_for_session` skip the shared-map op for
+   `RebalancedOut`, mirroring how `uses_kernel_local_session_map_entry`
+   already gates local vs shared), **suppress** the `DeleteSynced`
+   broadcast, AND **suppress the SNAT release**
+   (`release_source_nat_allocation`, `worker/loop_body/mod.rs:670`) — verified
+   hazard: it calls `pool_allocator.release_flow(flow, translated)` keyed by the
+   flow 5-tuple, ungated by origin, so W_old's early expiry would free the SNAT
+   port while W_new's live flow still uses it (the port could then be reassigned
+   to a new flow → collision/break). For `RebalancedOut`, skip the release; W_new
+   (the surviving owner of the same flow + same translation) releases it on its
+   own eventual close. W_new owns the shared entry now and refreshes it from
+   ingress.
+3. **Install the ntuple rule** (forward 5-tuple → W_new's queue) via
+   `SIOCETHTOOL`. W_new's replica (`WorkerLocalImport`, peer-synced) keeps the
+   flow alive and its `last_seen_ns` advances with the arriving packets.
+
+On rule removal / flow close / disable: delete the ntuple rule; the flow
+re-hashes back to RSS naturally (W_new's entry is already the authoritative
+shared one, no further demotion needed). `RebalancedOut` is a local-only,
+delta-suppressed origin — it never participates in HA promotion or sync.
 
 ### 4.3 Config knob (default-OFF)
 `pkg/config/schema.go` typed leaf under `class-of-service` (or `chassis`/
@@ -148,11 +221,19 @@ schema leaf + one control-message field (additive, default zero).
 - Full 1024-rule eviction policy refinement (R5) beyond a simple budget+cooldown.
 
 ## 10. Open questions for adversarial review (each invitable to PLAN-KILL)
-1. **R4 correctness**: does re-pinning ONLY the forward 5-tuple on ONLY the
-   active node break reverse-companion resolution or session-sync on the peer?
-   Research §0 says replicas exist on all workers so forwarding is fine — find a
-   packet-path or sync site that gates on the *specific* worker and breaks. If
-   one exists, KILL (HA can't be deferred).
+0. **(v2) Does `RebalancedOut` fully close the GC cascade?** v2 suppresses FOUR
+   sites on W_old's stale-entry expiry: Close delta, shared session-map delete,
+   `DeleteSynced` broadcast, and SNAT release (all verified as real hazards).
+   Re-attack: is there any OTHER GC/sync site that acts on W_old's expiring
+   entry and touches shared state W_new depends on — conntrack-map mirror delete
+   (`conntrack_v4_fd`/`conntrack_v6_fd` in
+   `delete_session_map_entry_for_removed_session_with_origin`), alias/redirect
+   cleanup, flow-cache invalidation broadcast, or the reverse-companion entry?
+   Name it with a quoted line or confirm the four-point set is complete.
+1. **R4 correctness**: with §4.5 demotion in place, does re-pinning ONLY the
+   forward 5-tuple on ONLY the active node still break reverse-companion
+   resolution or peer session-sync? Find a residual per-worker gate. (v1 KILL
+   risk now addressed by §4.5 — re-attack it.)
 2. **R3 transient**: is the per-move reorder bounded enough to avoid TCP resets
    under incremental single-flow moves, or does even one move risk a reset?
 3. **`ethtool_rxnfc` UAPI**: is the struct/union layout correct across the

--- a/docs/pr/1748-ntuple-rebalance/plan.md
+++ b/docs/pr/1748-ntuple-rebalance/plan.md
@@ -206,6 +206,24 @@ Coordinator sequence (one move per `rebalance_interval`):
   (`:32,80`) must NOT republish it; peer export (`session_glue/mod.rs:420,436`)
   must NOT emit an Open delta for it.
 
+**Ordering + timing invariant (SMR r3 — required):** the controller MUST issue
+promote(W_new) → demote(W_old) → rule-install within a SINGLE rebalance tick,
+and `rebalance_interval` (and the move-sequence duration) MUST be ≪
+`SESSION_GC_INTERVAL_NS` so no GC sweep interleaves the transfer. Per-worker
+loop serialization (commands + `expire_stale_entries` run in the same
+single-threaded worker loop) then guarantees GC on W_old never observes a stale
+`ForwardFlow`, and there is always ≥1 owner (zero-owner impossible; transient
+two-owner is harmless — neither expires in the sub-tick window).
+
+**`RebalancedOwner` vs `RebalancedOut` get OPPOSITE HA treatment:**
+`RebalancedOut` is inert (excluded from demote/refresh/export). `RebalancedOwner`
+is a normal *local owner* — on a real RG failover it MUST demote to `SyncImport`
+like `ForwardFlow` (i.e. it participates in `demote_owner_rg`/export/sync
+normally; it is excluded only from the *rebalance* suppression, not from HA).
+The promote is a tag-flip on `origin` ONLY — no re-publish, no NAT re-resolve
+(a unit test asserts the SNAT allocation owner/refcount is unchanged across
+promote).
+
 On rule removal / flow close / disable: delete the ntuple rule; the flow
 re-hashes back to RSS naturally (W_new's `RebalancedOwner` entry is the
 authoritative owner). On **failover**, the standby has no rules → RSS fallback

--- a/docs/pr/1748-ntuple-rebalance/plan.md
+++ b/docs/pr/1748-ntuple-rebalance/plan.md
@@ -1,8 +1,25 @@
 # #1748 Step 1 — reactive cross-worker ntuple rebalance controller (forward-direction, default-OFF)
 
-- **Status**: DRAFT v6 — round-5 NEEDS-MAJOR addressed (teardown-of-live-move is
-  a reverse barrier), pending round-6 re-review
+- **Status**: **PLAN-READY v7** — converged after 6 hostile rounds. Codex r6
+  PLAN-READY; AGY r6 PLAN-NEEDS-MINOR with two terminal-path gates whose
+  incorporation AGY pre-declared as its PLAN-READY condition (now folded);
+  Claude-SMR PLAN-READY.
 - **Issue**: #1748
+
+### Round-6 outcome → CONVERGED (PLAN-READY)
+Codex r6 = PLAN-READY: "no blocking transition gap found" — transition set
+{install (fwd barrier), rollback (rev), teardown-of-live (rev), dead-flow
+(trivial)} complete; second-move `W_new→W_third` covered (treat the current
+local owner generically, not literally `ForwardFlow`); rule-cap eviction
+correctly out-of-scope (controller stops at budget, no eviction); RG failover
+covered (`RebalancedOwner` demotes like a normal owner, standby has no rules);
+reverse-companion GC emits no Close (gated `!is_reverse`) and reverse NAT release
+is a no-op. AGY r6 = PLAN-NEEDS-MINOR with two more `RebalancedOut` gates on the
+**terminal/purge** paths (`session_glue/mod.rs:298` SNAT release,
+`:392 remove_shared_session`) — folded into the §4.5 suppression set; AGY stated
+their incorporation = PLAN-READY. **Implementation pins (Codex):** tests for the
+second-move chain `ForwardFlow→RebalancedOwner→RebalancedOwner(third)` and for
+`max_rules` budget-exhaustion proving no eviction/delete occurs.
 
 ### Round-5 review outcome (Codex NEEDS-MAJOR, AGY READY)
 AGY r5 = PLAN-READY (verified wheel lazy-cleanup safe + reverse-barrier rollback
@@ -240,6 +257,17 @@ Coordinator sequence (one move per `rebalance_interval`):
   must NOT rewrite `RebalancedOut`→`SyncImport`; `refresh_owner_rgs`
   (`:32,80`) must NOT republish it; peer export (`session_glue/mod.rs:420,436`)
   must NOT emit an Open delta for it.
+- **Terminal/purge path exclusions (AGY r6 — the suppression is NOT GC-only):**
+  the same `RebalancedOut` gate must cover the worker purge + terminal-filter
+  paths, which are separate from `expire_stale_entries`: (a) the purge loop at
+  `session_glue/mod.rs:298` must skip `release_source_nat_allocation` for
+  `RebalancedOut` (else an interface-down/admin purge on W_old double-releases
+  the SNAT port W_new still owns); (b) `delete_terminal_filtered_session`
+  (`session_glue/mod.rs:392`) must skip `remove_shared_session` for
+  `RebalancedOut` (else W_old's terminal cleanup deletes the SHARED session-map
+  entry W_new is actively forwarding against). General rule: **every site that
+  releases/deletes shared state keyed by a session must be `RebalancedOut`-gated**
+  — GC expiry, purge, and terminal-filter alike.
 
 **Applied-command barrier (Codex r3 — required; supersedes the v3 single-tick
 claim).** v3 wrongly assumed promote→demote ordering held; the worker command

--- a/docs/pr/1748-ntuple-rebalance/plan.md
+++ b/docs/pr/1748-ntuple-rebalance/plan.md
@@ -1,8 +1,19 @@
 # #1748 Step 1 — reactive cross-worker ntuple rebalance controller (forward-direction, default-OFF)
 
-- **Status**: DRAFT v3 — round-2 NEEDS-MAJOR addressed (two-origin ownership
-  transfer), pending round-3 re-review
+- **Status**: DRAFT v4 — round-3 NEEDS-MAJOR addressed (applied-command barrier
+  + dedicated origin-only promote), pending round-4 re-review
 - **Issue**: #1748
+
+### Round-3 review outcome (Codex NEEDS-MAJOR, AGY READY, SMR self-corrected)
+AGY r3 = PLAN-READY (verified the full suppression set + NAT-realloc avoidance +
+exhaustive-match detail). Codex r3 = NEEDS-MAJOR with a verified race the v3
+"single-tick" claim got wrong: worker command queues are independent per-worker
+async queues (`loop_body/mod.rs:591`), so W_old can demote before W_new promotes
+→ zero-owner window. Claude-SMR concurs and **self-corrects** (my r3 race
+analysis conflated per-worker loop serialization with cross-worker command
+ordering — there is none). v4 adds the applied-command **barrier** (§4.5,
+reusing `session_export_ack`) and a dedicated origin-only promote API (no Open
+delta — `update_session:843` would otherwise emit one).
 
 ### Round-1 review outcome (verdict: PLAN-NEEDS-MAJOR)
 AGY found a **verified correctness kill** that v1 missed (and that R1's 70s
@@ -206,23 +217,40 @@ Coordinator sequence (one move per `rebalance_interval`):
   (`:32,80`) must NOT republish it; peer export (`session_glue/mod.rs:420,436`)
   must NOT emit an Open delta for it.
 
-**Ordering + timing invariant (SMR r3 — required):** the controller MUST issue
-promote(W_new) → demote(W_old) → rule-install within a SINGLE rebalance tick,
-and `rebalance_interval` (and the move-sequence duration) MUST be ≪
-`SESSION_GC_INTERVAL_NS` so no GC sweep interleaves the transfer. Per-worker
-loop serialization (commands + `expire_stale_entries` run in the same
-single-threaded worker loop) then guarantees GC on W_old never observes a stale
-`ForwardFlow`, and there is always ≥1 owner (zero-owner impossible; transient
-two-owner is harmless — neither expires in the sub-tick window).
+**Applied-command barrier (Codex r3 — required; supersedes the v3 single-tick
+claim).** v3 wrongly assumed promote→demote ordering held; the worker command
+queues are **independent per-worker async queues** (each worker drains only its
+own `commands`, `loop_body/mod.rs:591`), so W_old could apply
+`DemoteRebalanced` *before* W_new applies `PromoteRebalanced` → a real
+**zero-owner window** (W_old `RebalancedOut`/suppressed, W_new still
+`WorkerLocalImport`/Close+export-suppressed). The move MUST therefore use an
+applied-command **barrier**, reusing the existing `session_export_ack`
+sequence pattern (`ha.rs:170-182`):
+1. Send `PromoteRebalanced{key}` to W_new; **block until W_new acks** the key is
+   `RebalancedOwner`.
+2. THEN send `DemoteRebalanced{key}` to W_old; **block until W_old acks** the key
+   is `RebalancedOut`.
+3. ONLY THEN install the ntuple rule.
+
+This guarantees W_new is the committed owner before W_old is demoted → there is
+always ≥1 cleanup owner; zero-owner is impossible. The barrier also bounds the
+transfer well under `SESSION_GC_INTERVAL_NS`. If any ack times out or the ioctl
+fails, roll back (W_new→replica, W_old→owner) — a racing GC during rollback sees
+exactly one owner (idempotent).
 
 **`RebalancedOwner` vs `RebalancedOut` get OPPOSITE HA treatment:**
 `RebalancedOut` is inert (excluded from demote/refresh/export). `RebalancedOwner`
 is a normal *local owner* — on a real RG failover it MUST demote to `SyncImport`
 like `ForwardFlow` (i.e. it participates in `demote_owner_rg`/export/sync
 normally; it is excluded only from the *rebalance* suppression, not from HA).
-The promote is a tag-flip on `origin` ONLY — no re-publish, no NAT re-resolve
-(a unit test asserts the SNAT allocation owner/refcount is unchanged across
-promote).
+The promote is a tag-flip on `origin` ONLY — no re-publish, no NAT re-resolve.
+**It must NOT reuse the generic `update_session` / `maybe_promote_synced_session`
+helpers (Codex r3):** `update_session:843` emits an Open delta whenever a
+peer-synced entry becomes non-peer-synced, and `promote.rs:99` republishes +
+shared-map-upserts + replicates. `PromoteRebalanced` needs a **dedicated
+origin-only mutation API** that flips `origin` in place and does nothing else.
+Unit tests assert: no delta pushed, no shared-map publish/upsert, no conntrack
+write, no NAT refcount change across the promote.
 
 On rule removal / flow close / disable: delete the ntuple rule; the flow
 re-hashes back to RSS naturally (W_new's `RebalancedOwner` entry is the

--- a/docs/pr/1748-ntuple-rebalance/r1-spike-findings.md
+++ b/docs/pr/1748-ntuple-rebalance/r1-spike-findings.md
@@ -1,0 +1,70 @@
+# #1748 R1 spike — established-flow ntuple re-pin: PASS
+
+Recorded 2026-06-02 directly on `loss:xpf-userspace-fw0` (master @ `ecdc16f2e`,
+post-#1745, equal-flow-enforcement OFF / clean fixture). This is the R1 gate the
+converged research plan (`research-plan.md` §8) required before any controller
+code: *does reactive established-flow placement actually beat the per-flow CoV
+floor, or did #1203's 49–55% prove it can't?*
+
+## Verdict: PASS (proceed to controller design R2–R6)
+
+Established-flow **mid-flight** exact-5-tuple ntuple re-pin on `ge-0-0-1`
+(forward/data direction of a `-P12 -p5210` push) dropped per-flow CoV from
+**16.8% → 2.3–4.2%** while **raising** aggregate **16.24 → 17.5–17.8 Gb/s**.
+
+## Method
+
+- Single 70 s `iperf3 -c 172.16.80.200 -P 12 -t 70 -i 5 -p 5210` push (client
+  `10.0.61.102` on LAN `ge-0-0-1`/reth1.0 → server on WAN reth0.80).
+- Flows established on their natural RSS queues for ~14 s; then **mid-flight**
+  enumerated the 13 client sockets (`ss -tn | grep :5210`, 12 data + 1 control)
+  and installed 13 exact rules
+  `ethtool -N ge-0-0-1 flow-type tcp4 src-ip 10.0.61.102 dst-ip 172.16.80.200
+  src-port <p> dst-port 5210 action <i mod 6>` — round-robin across all 6 RX
+  queues. No daemon code; manual ethtool only.
+- Measured per-stream CoV from `iperf3 -i5` intervals: a pre-re-pin baseline
+  interval and three post-re-pin settled intervals.
+
+## Results
+
+| Phase | per-worker `{aᵢ}` on ge-0-0-1 | CoV | aggregate |
+|---|---|---:|---:|
+| Baseline (natural RSS, t10–15) | `[2,2,1,1,4,2]` | **16.8%** | 16.24 G |
+| Post-re-pin (t45–50) | `[2,2,2,2,2,2]` | **2.3%** | 17.74 G |
+| Post-re-pin (t55–60) | `[2,2,2,2,2,2]` | **3.8%** | 17.78 G |
+| Post-re-pin (t65–70) | `[2,2,2,2,2,2]` | **4.2%** | 17.52 G |
+
+Per-stream rates collapsed from a 1.02–1.73 G spread to 1.36–1.57 G.
+
+## What this resolves
+
+1. **Placement mechanism is NOT floor-bound.** 2.3–4.2% CoV beats #1203's
+   49–55% by ~12×. Reproduces #789's manual 3.8% — and crucially does so for
+   **established-flow re-pin** (mid-flight), not just connect-time placement.
+   The #1203 49–55% was a count-blind controller defect (it flattened flow
+   *count* and deferred byte-rate-aware selection), not a physics ceiling.
+2. **Aggregate is preserved/improved**, unlike the #1746 cap (which trades
+   throughput for fairness). Per-flow exact rules used all 6 queues evenly,
+   fixing the #789 experiment's bitmask quirk that idled 3 queues and cost 24%.
+   This is the only lever that improves the structural ceiling `Cstruct` rather
+   than clipping within it.
+3. **Wall B (HA session-strand) stays falsified in practice** — the re-pinned
+   flows forwarded correctly on their new workers with no connectivity loss
+   (the pre-replicated session substrate, research-plan §0).
+
+## Costs / risks surfaced (controller must address — R2–R6)
+
+- **R3 transient (measured):** the whole-run summary showed **7601 retransmits**
+  — the reorder burst from moving all 12 flows simultaneously mid-flight. A
+  production controller MUST move flows incrementally with hysteresis (one/few
+  per rebalance tick, ≪1 Hz rule churn) to amortize this; bulk re-pin is a
+  spike artifact, not the intended operating mode.
+- **R2 reverse direction** not exercised (push test; forward-only re-pin
+  suffices for the push CoV symptom but `-R`/bidirectional needs reverse rules).
+- **R4 HA mirroring, R5 rule-cap/cost/hysteresis, R6 selection policy** remain
+  open as designed.
+
+## Cleanup verified
+
+All 13 rules deleted, `ethtool -K ge-0-0-1 ntuple off`, 0 rules remaining.
+Cluster returned to clean master fixture (equal-flow OFF).

--- a/docs/pr/1748-ntuple-rebalance/research-plan.md
+++ b/docs/pr/1748-ntuple-rebalance/research-plan.md
@@ -1,0 +1,291 @@
+# Research plan — #1748 Cross-worker per-flow REBALANCE (re-steer of established flows) on mlx5 VFs
+
+- **Revision**: r2 (CONVERGED). Round-1: Codex + Claude SMR PLAN-READY-kill, AGY PLAN-KILL-OVERTURNED. Round-2: all three converge on **PLAN-NEEDS-WORK (overturn correct, R1-spike gate)**.
+- **Status**: **PLAN-NEEDS-WORK → scoped feasibility-prototype** for Path 2 (ntuple HW re-pin), gated on the R1 spike. Kill WITHDRAWN. NOT yet PLAN-READY-to-ship.
+- **Converged verdicts**: Codex r2 = PLAN-NEEDS-WORK (overturn correct, R1-spike gate); AGY r2 = PLAN-NEEDS-WORK (overturn correct, R1-spike gate); Claude SMR r2 = PLAN-NEEDS-WORK (kill withdrawn, R1-spike gate).
+- **Skill**: `/research` (research-only; stop at PLAN-READY or PLAN-KILL; no code; docs only)
+- **Issue**: #1748 (label `perf`)
+- **Worktree**: `.claude/worktrees/1748-mlx5-flow-rebalance`, branch `research/1748-mlx5-flow-rebalance`
+- **Base**: origin/master @ `ecdc16f2e`
+
+---
+
+## 0. What changed in r2 (the load-bearing finding)
+
+r1 proposed PLAN-KILL on two walls. **Codex + Claude SMR ratified the kill;
+AGY overturned it** by falsifying Wall B with quoted code, and I independently
+verified AGY's claims against master. The verification stands:
+
+- **Wall A still holds** (XDP_REDIRECT path dead): `xsk_rcv_check()` enforces
+  `xs->queue_id == xdp->rxq->queue_index`; mlx5 native XDP / `ndo_xdp_xmit` /
+  CPUMAP do not bypass. Codex re-cited current 7.x source; the shim encodes it
+  at `userspace-xdp/src/lib.rs:1364`. Path 1 (XDP_REDIRECT) and Path 3 (hybrid)
+  are permanently blocked. **Conceded by all three reviewers.**
+
+- **Wall B is FALSIFIED for the same-node, active-node case** (Path 2, ntuple
+  re-pin). The original Wall-B claim ("re-steer strands the session, splits
+  conntrack, creates a duplicate on the cold worker") is materially wrong on
+  this dataplane, because the HA session-replication machinery already
+  pre-installs a *forwarding-ready* replica of every session on every sibling
+  worker:
+
+  - **Forward AND reverse entries are replicated to all peer workers on
+    creation** — `replicate_session_upsert(worker_ctx.peer_worker_commands,
+    &forward_entry)` (`poll_descriptor/mod.rs:1267`) and the reverse companion
+    via `replicate_session_upsert(peer_worker_commands, &reverse_entry)`
+    (`shared_ops.rs:618`).
+  - **The receiving worker re-resolves with LOCAL egress** in
+    `handle_upsert_synced` (`session_glue/commands/upsert_synced.rs`): doc
+    comment "By resolving on receipt (even on standby), sessions are
+    immediately forwarding-ready." The replica origin is
+    `SessionOrigin::WorkerLocalImport` (`shared_ops.rs:51` →
+    `worker_replica_origin()`; test `tests.rs:473`), which
+    `is_peer_synced() == true`.
+  - **The active-node packet path has NO per-worker ownership gate.**
+    `enforce_ha_resolution_snapshot` (`forwarding/mod.rs:524`) and
+    `owner_rg_is_locally_active` (`session_glue/mod.rs:137`) gate forwarding on
+    the **owner RG being forwarding-active on this node** — never on *which
+    worker* holds the session. So any worker on the active node can forward any
+    session whose RG is locally active. A re-steered packet on worker 5 misses
+    the flow cache once, finds the pre-replicated locally-resolved session in
+    its `SessionTable`, passes HA enforcement, and forwards. No duplicate, no
+    split conntrack.
+  - **Organic handoff via local GC**: local expiration
+    (`worker/loop_body/mod.rs`) does NOT broadcast deletes, so worker 2's stale
+    copy ages out while worker 5's copy stays alive on the new stream — zero
+    cross-worker locks (consistent with the `flow_cache.rs:143` shared-nothing
+    non-goal, which is about the per-tick hot path, not this slow handoff).
+  - **CoS rate-estimator skip-ramp** (`cos/fairness.rs:93`) initializes
+    `observed_bps` from `inst_bps` on the first post-idle sample, so the moved
+    flow's scheduling state converges immediately on worker 5.
+
+  **This is a genuine research discovery: #1649 forbade re-steer "by fiat",
+  and that fiat hid the fact that the HA replication substrate already makes a
+  same-node worker handoff safe.** The mlx5 ntuple primitive (exact-5-tuple →
+  RX-queue, cap 1024, ~1 ms/rule, verified #1649 + re-probed this session)
+  provides the steering mechanism; the session substrate provides the safe
+  landing. Path 2 is therefore NOT killable on Wall B.
+
+This plan is rewritten as a **scoped feasibility-prototype** for Path 2, with
+the real remaining risks (which AGY underweighted) called out honestly so the
+user can decide whether to fund the prototype.
+
+## 1. Problem statement (unchanged)
+
+Per-flow CoV 14–29% on `-P12` shaped ports from RSS flow-count imbalance across
+the 6 VF workers (1-flow worker → ~1.8 G/flow, 4-flow → ~0.87 G/flow). A rate
+**cap** (#1746 equal-flow) only clips fast flows down; it cannot lift slow
+flows because the spare capacity is on a different worker's queue. The only
+mechanism that lifts slow flows without aggregate loss is moving an established
+flow off an overloaded worker onto an idle one — cross-worker rebalance. #1748.
+
+## 2. Hardware capability (verified — see r1 §2, re-probed 2026-06-01)
+
+`ge-0-0-2` = mlx5_core VF, kernel 7.0.0-rc7+, 6 combined RX queues, ntuple
+togglable, rule cap 1024 (#1649 probed to exhaustion), ~1 ms/rule firmware
+cost. Exact-5-tuple and masked-residue steering both accepted (#1649). Daemon
+already has an `ethtool -X` RSS-programming abstraction (`rssExecutor`,
+`pkg/daemon/rss_indirection.go`) with mlx5-allowlist guards — a precedent for
+adding `ethtool -N` ntuple programming on the same plumbing.
+
+## 3. Recommended mechanism — Path 2: reactive ntuple HW re-pin
+
+When a controller detects worker load imbalance, install an exact-5-tuple
+`ethtool -N` rule mapping a chosen long-lived flow's 5-tuple → the least-loaded
+worker's RX queue. The flow's future packets steer to the new RX queue, where
+the pre-replicated session is already forwarding-ready (§0). No mid-flight
+state migration code is required (the substrate exists); the new code is the
+**controller + ntuple programming + HA mirroring + safety bounds**.
+
+Why Path 2 and not Path 1/3: Path 1/3 require XDP_REDIRECT across RX queues,
+which Wall A permanently blocks. Path 2 changes the *hardware* steering
+upstream of `xsk_rcv_check`, so the packet legitimately arrives on the target
+queue's socket and the check passes.
+
+## 4. The genuinely-open risks (must be resolved in the prototype — AGY underweighted these)
+
+AGY's "no code changes needed, just turn it on" is too strong. The session
+substrate is ready, but a *shippable* rebalancer must close these:
+
+### R1. Does it actually beat the floor, or did #1203/#789 already prove it doesn't?
+#1649's converged multinomial theorem says *static* placement = RSS floor
+(CoV ≈ 0.87 at N=6 M=6 for ephemeral ports; Codex independently exact-
+enumerated 6^6 → E[CoV]=0.8740). Path 2 is **reactive**, not static — it
+*observes occupancy and moves the offending flow*, which is exactly the
+negative-dependence the theorem says only a reactive controller can create. BUT
+#1203/#789 *built and measured a reactive closed-loop placement controller on
+this exact cluster and got 49–55% CoV at P=12* (gate ≤20% not met), closing
+with "per-flow CoV is bounded by within-queue scheduling, not placement." The
+prototype's FIRST gate must answer: was #1203's 49–55% a property of placement
+itself (→ Path 2 also fails the gate → KILL), or of #1203's specific controller
+design / convergence speed / hysteresis (→ Path 2 with a better controller may
+clear it)? This requires reading the #1203 controller (`feature/1215-...`
+branch) and either reproducing its limit or identifying the fixable defect.
+**If R1 shows placement itself is floor-bound, Path 2 is killed here** — and
+this is the most likely kill point.
+
+**Decisive disambiguating evidence found in r2 (Codex):** the #789 work tree
+holds TWO contradictory data points on the SAME cluster:
+- `refactor/789-fairness-via-ntuple:docs/pr/789-fairness-via-ntuple/findings-experiment-1.md`
+  — *manual* exact mlx5 ntuple rules dropped per-flow CoV **62.5% → 3.8%** on
+  iperf-c P=12 (12 flows within ±5% of mean), concluding "within-worker
+  fairness is excellent; the 62.5% baseline is dominated by CROSS-worker
+  variance, not within-worker scheduling." Aggregate dropped 24% only because
+  the crude port-bitmask scheme idled 3 queues — not a mechanism cost.
+- `refactor/789-phase2-byte-rate:docs/pr/789-phase2-byte-rate/plan.md` — the
+  *closed-loop controller* reached only **49–55% CoV** while "correctly driving
+  each queue to 2 flows."
+
+The contradiction localizes R1's risk precisely: **the placement MECHANISM is
+not floor-bound (manual = 3.8%); the #1203 CONTROLLER was the limiter.** R1's
+job is to confirm the manual 3.8% reproduces for *established-flow exact re-pin*
+(not just connect-time placement) and then identify why the closed-loop
+controller regressed to 49–55% (convergence lag? re-steer-during-flight churn?
+hysteresis? the very Wall-B transient R3?). This makes the spike high-value:
+it is likely to *pass* the mechanism check and turn the work toward fixing the
+controller, OR to reveal that established-flow re-pin specifically (vs
+connect-time placement) hits the 49–55% wall — either is a clean decision.
+
+**Root cause of the #1203 controller regression (AGY r2, quoted PR history):**
+the #1203 controller flattened per-queue *flow count* only
+(`pr-history.md:19239`) and **deferred byte-rate-aware candidate selection to
+Phase 2** because it added a per-packet cache-line write to the worker hot path
+(`pr-history.md:19283`). An even *count* partition (2,2,2,2,2,2) still yields
+high CoV when one flow is a 3 Gb/s elephant and its queue-mate is a mouse. So
+the 49–55% was a **count-blind controller defect**, not a placement-physics
+floor. R1's controller-side requirement is therefore concrete: candidate
+selection must be **byte-rate aware** (move the flow whose transfer most
+flattens the per-worker *byte-rate*, not flow-count), which re-opens the
+hot-path-telemetry-write cost question #1203 deferred. This is the substance the
+follow-on controller design (post-R1) must solve.
+
+### R2. Reverse direction is not moved.
+Re-pinning the forward 5-tuple does not move the reverse flow (server→client),
+which RSS-hashes independently to a possibly-different worker. For a push test
+the forward direction carries the data, so forward-only re-pin may suffice for
+the throughput-CoV symptom — but `-R` (reverse) tests and bidirectional
+workloads need the reverse rule too, doubling rule consumption and adding a
+second steering decision. The prototype must measure both push and `-R`
+(per `feedback_smoke_push_and_reverse`).
+
+### R3. Transient correctness window.
+Between rule install (~1 ms firmware) and the old worker's in-flight TX
+draining, packets of the same flow can briefly arrive on BOTH workers
+(reordering risk) or the flow-cache on worker 5 is cold (one-time miss → slow
+path). Must verify no TCP reset and bounded reordering under a real transfer
+(bpftrace on `xdp:xdp_redirect_err` is NOT the right tool here — packets are
+not redirected, they are HW-steered — so verify via per-worker RX counters +
+iperf3 retransmit count).
+
+### R4. HA double-homing.
+A moved flow must steer to the matching worker on BOTH cluster nodes or
+session-sync's reverse-companion resolution diverges. The ntuple rule must be
+mirrored to the peer node's NIC (peer uses `ge-7-0-1`/`ge-7-0-2`, same mlx5
+model). Cross-node RSS placement differs, so "matching worker" means matching
+*queue index* — the controller must program identical (5-tuple → queue) rules
+on both nodes and verify the peer's worker N holds the replica (it does, via
+the same replication path). `make test-failover` must stay clean.
+
+### R5. Rule-cap + cost + control-socket contention.
+1024-rule cap vs production flow counts (vastly >1024 → only the heaviest-
+imbalance flows get rules, rest fall back to RSS floor — acceptable, but the
+selection policy must be bounded). ~1 ms/rule synchronous firmware cost means
+the controller cannot churn rules per-tick; needs hysteresis + a low rebalance
+cadence (≪1 Hz of rule writes) and must NOT add a high-frequency control-socket
+caller (CLAUDE.md control-socket contention rule). #840's lesson: a rebalancer
+that thrashes *degrades* fairness (CoV 37.7% vs 18.5%). Hysteresis/convergence-
+detection (#897 line) is mandatory, not optional.
+
+### R6. Flow-selection policy.
+Which flow to move (heaviest on the hot worker? the one whose move most
+flattens `{aᵢ}`?), when (occupancy threshold + dwell), and stop conditions.
+Must converge, not oscillate. This is the substance of RQ3.
+
+## 5. Multiple Path Options (final)
+
+- **Path 1 — XDP_REDIRECT rebalance.** DEAD (Wall A). All three reviewers agree.
+- **Path 2 — reactive ntuple HW re-pin of established flows.** VIABLE substrate
+  (Wall B falsified §0); gated on R1–R6, especially **R1 (does it beat the
+  floor — the #1203 49–55% precedent is the main kill risk)**. **Recommended
+  feasibility-prototype target.**
+- **Path 3 — hybrid.** DEAD (inherits Wall A).
+
+## 6. Interaction with #1746 cap + #1230 fair-share lease (RQ4)
+
+#1746 equal-flow cap (default-OFF) clips fast flows — a within-worker lever.
+PR #1230 fair-share lease coordinates per-flow share across workers via
+`epoch_total_granted` *without moving packets* — already shipped. Path 2 is
+complementary: it changes `{aᵢ}` (the placement) so the *structural ceiling*
+`Cstruct` itself improves, which neither the cap nor the lease can do (they
+operate within a fixed `{aᵢ}`). If Path 2 ships and flattens `{aᵢ}`, the #1746
+cap becomes largely unnecessary for the RSS-skew symptom; until then the cap is
+the only operator lever. They do not conflict.
+
+## 7. Cost/benefit at absolute scale (RQ5)
+
+- **Benefit (if R1 passes):** lift `-P12` shaped-port CoV from 14–29% toward
+  the balanced-`{aᵢ}` floor (~0% for a perfect spread), WITHOUT the aggregate
+  loss the #1746 cap incurs — by moving the slow flows to idle workers rather
+  than clipping the fast ones. This is the only mechanism that improves the
+  structural ceiling.
+- **Benefit ceiling / main risk:** bounded by R1. #1203's realized 49–55% CoV
+  is a below-gate data point for a reactive placement controller on this exact
+  cluster. The prototype must beat it or the line dies at R1.
+- **Cost:** controller + `ethtool -N` programming (extends existing
+  `rssExecutor` plumbing) + HA peer-mirroring + hysteresis + telemetry. No
+  cross-worker session-migration subsystem is needed (the substrate exists) —
+  this is materially LESS code than r1 assumed. Bounded rule churn (≪1 Hz),
+  1024-rule cap with graceful RSS fallback.
+
+**Cost/benefit: conditionally positive, gated on R1.** The substrate discovery
+(§0) removes the largest cost item r1 assumed. The dominant risk is now
+empirical (does reactive placement beat the floor), not architectural.
+
+## 8. Recommended next step
+
+Move #1748 to a **bounded feasibility prototype** that resolves R1 FIRST and
+cheaply (before any production controller code):
+
+1. **R1 spike (read-only + manual ethtool, no daemon code):** on the loss
+   cluster during a maintenance window, run `-P6 -p5210`, read live `{aᵢ}` from
+   `xpf_userspace_binding_active_flow_count`, then *manually* `ethtool -N` re-pin
+   the 5-tuples of the flows on the most-loaded worker to idle queues, and
+   measure per-flow CoV before/after over a 60 s steady-state window per
+   `docs/fairness-regimes.md` gates. If CoV does NOT materially improve (stays
+   near the #1203 49–55% band or the floor), **PLAN-KILL at R1** with the
+   measurement as the kill evidence. If it improves toward the balanced floor,
+   proceed.
+2. Only if R1 passes: design the controller (R2–R6), re-review, then `/engineer`.
+
+This R1 spike is itself a research step (manual ethtool, no production code) and
+can be run under `/research` follow-up or as the first `/engineer` gate. It is
+the cheapest possible falsification of the whole line.
+
+## 9. Verdict and convergence path
+
+r2 verdict: **PLAN-NEEDS-WORK** — the kill is withdrawn (Wall B falsified and
+verified), but Path 2 is NOT yet PLAN-READY-to-ship because R1 (does reactive
+placement beat the floor) is unresolved and is the historical kill point
+(#1203 49–55%). The convergent landing the reviewers should converge ON is:
+"Path 1/3 dead (Wall A); Path 2 substrate viable (Wall B falsified); fund the
+R1 spike as the next gate." Reviewers: confirm Wall A, confirm the Wall-B
+falsification is correctly verified (not over-claimed), and stress-test whether
+R1 can plausibly pass given the #1203 precedent, or whether R1's likely failure
+means we should KILL now rather than spend the spike.
+
+## 10. Reviewer falsification targets (r2 — be hostile)
+
+1. **Re-attack Wall-B falsification:** find a packet-path code site where a
+   `WorkerLocalImport` / peer-synced session on the *active* node is rejected
+   for forwarding by a per-worker (not per-RG) check, OR where the
+   reverse-companion replica is NOT present on sibling workers. If you find
+   one, Wall B is back and the kill is restored. (I checked
+   `enforce_ha_resolution_snapshot` and `owner_rg_is_locally_active` — no
+   per-worker gate. Prove me wrong with a quoted line.)
+2. **Pre-judge R1:** argue from the #1203 controller design (on
+   `feature/1215-per5tuple-fairness`) + the multinomial theorem whether reactive
+   re-pin can plausibly beat 49–55% CoV, or whether placement is floor-bound
+   regardless of controller quality → if the latter, recommend KILL-NOW over
+   the spike.
+3. **Re-attack Wall A:** any current-kernel cross-RX-queue AF_XDP delivery that
+   passes `xsk_rcv_check`. (Path 1 revival.)

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -46,3 +46,9 @@ Continuations fetch by id (Codex loses session state >30min).
 - Codex: /tmp/codex-1748-r6.txt, bash bg `b8px03pgf` — pending (transition-set completeness: second-move, rule-cap eviction, failover-mid-move)
 - AGY: pending
 - Claude-SMR: PLAN-READY (transition set {install,rollback,teardown,dead} appears complete; second-move + eviction are instances of the same barrier principle)
+
+## Plan review round 6 (plan v6 @ a37206bfa) → CONVERGED
+- Codex: /tmp/codex-1748-r6.txt, bash bg `b8px03pgf` — PLAN-READY (no blocking transition gap)
+- AGY: adversarial-review-mpwr6tev-7agzdw — PLAN-NEEDS-MINOR (2 terminal-path gates; pre-declared their incorporation = PLAN-READY)
+- Claude-SMR: PLAN-READY
+- v7 @ folds AGY's two terminal-path gates → CONVERGED PLAN-READY

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -52,3 +52,9 @@ Continuations fetch by id (Codex loses session state >30min).
 - AGY: adversarial-review-mpwr6tev-7agzdw — PLAN-NEEDS-MINOR (2 terminal-path gates; pre-declared their incorporation = PLAN-READY)
 - Claude-SMR: PLAN-READY
 - v7 @ folds AGY's two terminal-path gates → CONVERGED PLAN-READY
+
+## CODE review round 1 (PR #1749 @ a5621aa12)
+- Codex: /tmp/codex-1748-code-r1.txt, bash bg `b2cov2wgl` — pending
+- AGY: (job id below) — pending
+- Copilot: triggered on PR #1749
+- Claude-SMR: pending (hostile diff read)

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -83,3 +83,8 @@ Continuations fetch by id (Codex loses session state >30min).
 - AGY r2: MERGE-READY (still holds)
 - Copilot: re-review on bbed6eeb found 1 soundness (unsafe socket aliasing in teardown) + 4 doc/test minors → dispatched to agent
 - core protocol + second-move path BLESSED; pending the aliasing fix + minors
+
+## LIVE CoV GATE round 1 (deploy @ 6202831ff) — FAILED, 2 runtime bugs
+- Bug1: ε-band rejects every move (eval at ~24/s status-rate -> ~40ms noisy byte-rate window; CoV 0.3 but 0 installs, all skips=epsilon). Fix: rate over >=rebalance_interval + re-derive ε + projected-improvement math; unit test CoV-0.3 -> >=1 install.
+- Bug2: live config reconcile no-op (bidirectional) — controller constructs/tears-down only on boot, not live commit/config-sync. Fix snapshot-apply reconcile + None<->Some transition test.
+- Both dispatched to impl agent. Re-validate LIVE after redeploy. Unit tests + miri + 9 review rounds did NOT catch these (behavioral/runtime).

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -1,0 +1,8 @@
+# #1748 reviewer task/job IDs
+
+Continuations fetch by id (Codex loses session state >30min).
+
+## Plan review round 1 (plan @ c84523b27)
+- Codex: foreground-isolated (CODEX_COMPANION_SESSION_ID=1748-plan-r1-*), bash bg id `bbl5p1z6r`
+- AGY: `adversarial-review-mpwpik0h-my8ni9`
+- Claude-SMR: `docs/pr/1748-ntuple-rebalance/claude-smr-plan-r1.md` — PLAN-NEEDS-MINOR

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -11,3 +11,8 @@ Continuations fetch by id (Codex loses session state >30min).
 - Codex: foreground-isolated (CODEX_COMPANION_SESSION_ID=1748-plan-r2-*), output /tmp/codex-1748-r2.txt — PLAN-NEEDS-MAJOR (conntrack 5th site, no-close-owner leak, RebalancedOut HA/export leaks; ioctl direction CONFIRMED correct)
 - AGY: adversarial-review-mpwq7ctx-qc5xfm — pending
 - Claude-SMR: claude-smr-plan-r2.md — PLAN-NEEDS-MAJOR (concur)
+
+## Plan review round 3 (plan v3 @ 0f52cc85b)
+- Codex: foreground-isolated (CODEX_COMPANION_SESSION_ID=1748-plan-r3-*), output /tmp/codex-1748-r3.txt, bash bg id `baw2rokje` — pending
+- AGY: adversarial-review-mpwqkxjl-cy4m05 — pending
+- Claude-SMR: claude-smr-plan-r3.md — PLAN-READY (with single-tick ordering invariant folded into §4.5)

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -58,3 +58,10 @@ Continuations fetch by id (Codex loses session state >30min).
 - AGY: (job id below) — pending
 - Copilot: triggered on PR #1749
 - Claude-SMR: pending (hostile diff read)
+
+## CODE review round 1 (PR #1749 @ a5621aa12) — MERGE-NEEDS-MAJOR
+- Codex: /tmp/codex-1748-code-r1.txt, bash bg `b2cov2wgl` — 7 findings (#1 mask REFUTED by hardware readback; #2-#7 real)
+- AGY: adversarial-review-mpwt5rpk-w9trzi — teardown bug (confirms #2) + startup-reconcile minor
+- Copilot: COMMENTED — cumulative-bytes-as-rate (#8 new) + confirms #2
+- Claude-SMR: MERGE-READY-pending; verified core + refuted #1 empirically on mlx5
+- Fixes dispatched to impl agent (8 real + minor); #1 stays as-is

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -65,3 +65,9 @@ Continuations fetch by id (Codex loses session state >30min).
 - Copilot: COMMENTED — cumulative-bytes-as-rate (#8 new) + confirms #2
 - Claude-SMR: MERGE-READY-pending; verified core + refuted #1 empirically on mlx5
 - Fixes dispatched to impl agent (8 real + minor); #1 stays as-is
+
+## CODE review round 2 (PR #1749 @ 6447c0e4f — fixes)
+- Codex: /tmp/codex-1748-code-r2.txt, bash bg `bn7sigt5c` — pending
+- AGY: (job below) — pending
+- Copilot: re-triggered
+- spot-check: #2/#4/#5/#7/#8 verified in code by parent

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -16,3 +16,8 @@ Continuations fetch by id (Codex loses session state >30min).
 - Codex: foreground-isolated (CODEX_COMPANION_SESSION_ID=1748-plan-r3-*), output /tmp/codex-1748-r3.txt, bash bg id `baw2rokje` — pending
 - AGY: adversarial-review-mpwqkxjl-cy4m05 — pending
 - Claude-SMR: claude-smr-plan-r3.md — PLAN-READY (with single-tick ordering invariant folded into §4.5)
+
+## Plan review round 3 (plan v3 @ 0f52cc85b)
+- Codex: /tmp/codex-1748-r3.txt, bash bg `baw2rokje` — PLAN-NEEDS-MAJOR (async-queue zero-owner race; promote must not reuse update_session/maybe_promote_synced_session)
+- AGY: adversarial-review-mpwqkxjl-cy4m05 — PLAN-READY
+- Claude-SMR: claude-smr-plan-r3.md — was READY, SELF-CORRECTED to concur with Codex NEEDS-MAJOR

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -31,3 +31,8 @@ Continuations fetch by id (Codex loses session state >30min).
 - Codex: /tmp/codex-1748-r4.txt, bash bg `bgiy46xot` — PLAN-NEEDS-MAJOR (TTL race: promote near-expiry replica -> GC removes sole owner; rollback order unsafe; ack must be {seq,key,origin,result})
 - AGY: adversarial-review-mpwqtig4-0q0vg7 — PLAN-READY (### Verdict: PLAN-NEEDS-MINOR)
 - Claude-SMR: PLAN-READY concur-with-Codex (both r4 findings real; folded to v5)
+
+## Plan review round 5 (plan v5 @ 929dbd403)
+- Codex: /tmp/codex-1748-r5.txt, bash bg `bd3w287b2` — pending (verify liveness-refresh + reverse-barrier rollback close r4)
+- AGY: adversarial-review-mpwqzh2x-p37bkx — pending
+- Claude-SMR: PLAN-READY (liveness-refresh kills the near-expiry race; reverse-barrier rollback is the correct order)

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -41,3 +41,8 @@ Continuations fetch by id (Codex loses session state >30min).
 - Codex: /tmp/codex-1748-r5.txt, bash bg `bd3w287b2` — PLAN-NEEDS-MAJOR (r4 findings CLOSED; new: teardown of live move not barriered -> leak)
 - AGY: adversarial-review-mpwqzh2x-p37bkx — PLAN-READY
 - Claude-SMR: PLAN-READY concur-with-Codex (teardown barrier real; folded to v6)
+
+## Plan review round 6 (plan v6 @ a37206bfa)
+- Codex: /tmp/codex-1748-r6.txt, bash bg `b8px03pgf` — pending (transition-set completeness: second-move, rule-cap eviction, failover-mid-move)
+- AGY: pending
+- Claude-SMR: PLAN-READY (transition set {install,rollback,teardown,dead} appears complete; second-move + eviction are instances of the same barrier principle)

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -21,3 +21,8 @@ Continuations fetch by id (Codex loses session state >30min).
 - Codex: /tmp/codex-1748-r3.txt, bash bg `baw2rokje` — PLAN-NEEDS-MAJOR (async-queue zero-owner race; promote must not reuse update_session/maybe_promote_synced_session)
 - AGY: adversarial-review-mpwqkxjl-cy4m05 — PLAN-READY
 - Claude-SMR: claude-smr-plan-r3.md — was READY, SELF-CORRECTED to concur with Codex NEEDS-MAJOR
+
+## Plan review round 4 (plan v4 @ d3016b922)
+- Codex: /tmp/codex-1748-r4.txt, bash bg `bgiy46xot` — pending (verifying barrier + dedicated promote close r3 findings)
+- AGY: adversarial-review-mpwqtig4-0q0vg7 — pending
+- Claude-SMR: PLAN-READY (barrier reuses session_export_ack idiom; dedicated origin-only promote specified) — doc on reconcile

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -36,3 +36,8 @@ Continuations fetch by id (Codex loses session state >30min).
 - Codex: /tmp/codex-1748-r5.txt, bash bg `bd3w287b2` — pending (verify liveness-refresh + reverse-barrier rollback close r4)
 - AGY: adversarial-review-mpwqzh2x-p37bkx — pending
 - Claude-SMR: PLAN-READY (liveness-refresh kills the near-expiry race; reverse-barrier rollback is the correct order)
+
+## Plan review round 5 (plan v5 @ 929dbd403)
+- Codex: /tmp/codex-1748-r5.txt, bash bg `bd3w287b2` — PLAN-NEEDS-MAJOR (r4 findings CLOSED; new: teardown of live move not barriered -> leak)
+- AGY: adversarial-review-mpwqzh2x-p37bkx — PLAN-READY
+- Claude-SMR: PLAN-READY concur-with-Codex (teardown barrier real; folded to v6)

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -26,3 +26,8 @@ Continuations fetch by id (Codex loses session state >30min).
 - Codex: /tmp/codex-1748-r4.txt, bash bg `bgiy46xot` — pending (verifying barrier + dedicated promote close r3 findings)
 - AGY: adversarial-review-mpwqtig4-0q0vg7 — pending
 - Claude-SMR: PLAN-READY (barrier reuses session_export_ack idiom; dedicated origin-only promote specified) — doc on reconcile
+
+## Plan review round 4 (plan v4 @ d3016b922)
+- Codex: /tmp/codex-1748-r4.txt, bash bg `bgiy46xot` — PLAN-NEEDS-MAJOR (TTL race: promote near-expiry replica -> GC removes sole owner; rollback order unsafe; ack must be {seq,key,origin,result})
+- AGY: adversarial-review-mpwqtig4-0q0vg7 — PLAN-READY (### Verdict: PLAN-NEEDS-MINOR)
+- Claude-SMR: PLAN-READY concur-with-Codex (both r4 findings real; folded to v5)

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -6,3 +6,8 @@ Continuations fetch by id (Codex loses session state >30min).
 - Codex: foreground-isolated (CODEX_COMPANION_SESSION_ID=1748-plan-r1-*), bash bg id `bbl5p1z6r`
 - AGY: `adversarial-review-mpwpik0h-my8ni9`
 - Claude-SMR: `docs/pr/1748-ntuple-rebalance/claude-smr-plan-r1.md` — PLAN-NEEDS-MINOR
+
+## Plan review round 2 (plan v2 @ 47db3a4f4)
+- Codex: foreground-isolated (CODEX_COMPANION_SESSION_ID=1748-plan-r2-*), output /tmp/codex-1748-r2.txt — PLAN-NEEDS-MAJOR (conntrack 5th site, no-close-owner leak, RebalancedOut HA/export leaks; ioctl direction CONFIRMED correct)
+- AGY: adversarial-review-mpwq7ctx-qc5xfm — pending
+- Claude-SMR: claude-smr-plan-r2.md — PLAN-NEEDS-MAJOR (concur)

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -77,3 +77,9 @@ Continuations fetch by id (Codex loses session state >30min).
 - AGY: adversarial-review-mpwu5ytx-b94ixo — MERGE-READY
 - Copilot: re-triggered
 - second-move fixes dispatched to impl agent
+
+## CODE review round 3 (PR #1749 @ cabdfd37c — second-move fixes)
+- Codex: /tmp/codex-1748-code-r3.txt, bash bg `b0mac8r4u` — MERGE-READY (all 3 second-move issues resolved, no findings)
+- AGY r2: MERGE-READY (still holds)
+- Copilot: re-review on bbed6eeb found 1 soundness (unsafe socket aliasing in teardown) + 4 doc/test minors → dispatched to agent
+- core protocol + second-move path BLESSED; pending the aliasing fix + minors

--- a/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
+++ b/docs/pr/1748-ntuple-rebalance/reviewer-ids.md
@@ -71,3 +71,9 @@ Continuations fetch by id (Codex loses session state >30min).
 - AGY: (job below) — pending
 - Copilot: re-triggered
 - spot-check: #2/#4/#5/#7/#8 verified in code by parent
+
+## CODE review round 2 (PR #1749 @ 6447c0e4f) — MERGE-NEEDS-MAJOR
+- Codex: /tmp/codex-1748-code-r2.txt, bash bg `bn7sigt5c` — 8 prior fixes HOLD; MAJOR+2min in second-move path (wrong old_worker; metric; ignored delete_rule fail)
+- AGY: adversarial-review-mpwu5ytx-b94ixo — MERGE-READY
+- Copilot: re-triggered
+- second-move fixes dispatched to impl agent

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -216,6 +216,12 @@ type xpfCollector struct {
 	// operator-visible signal for the warmer in production builds.
 	neighborWarmDropsTotal        *prometheus.Desc
 	neighborWarmDisconnectedTotal *prometheus.Desc
+	// #1748: reactive ntuple rebalance controller telemetry, per ifindex.
+	flowRebalanceRulesActive      *prometheus.Desc
+	flowRebalanceInstallsTotal    *prometheus.Desc
+	flowRebalanceDeletesTotal     *prometheus.Desc
+	flowRebalanceMovesSkippedTotal *prometheus.Desc
+	flowRebalanceWorkerByterateCoV *prometheus.Desc
 }
 
 func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -364,6 +370,11 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.fairnessEqualFlowWorkerSuppressedBPS
 	ch <- c.neighborWarmDropsTotal
 	ch <- c.neighborWarmDisconnectedTotal
+	ch <- c.flowRebalanceRulesActive
+	ch <- c.flowRebalanceInstallsTotal
+	ch <- c.flowRebalanceDeletesTotal
+	ch <- c.flowRebalanceMovesSkippedTotal
+	ch <- c.flowRebalanceWorkerByterateCoV
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -791,7 +791,7 @@ func newCollector(srv *Server) *xpfCollector {
 		),
 		flowRebalanceMovesSkippedTotal: prometheus.NewDesc(
 			"xpf_userspace_flow_rebalance_moves_skipped_total",
-			"Candidate moves skipped, by reason (balanced, cooldown, magnitude, epsilon, budget_exhausted, barrier_failed, dwell, restore_failed) (#1748).",
+			"Candidate moves skipped, by reason (balanced, cooldown, magnitude, epsilon, no_eligible_flow, budget_exhausted, barrier_failed, dwell, restore_failed) (#1748).",
 			[]string{"ifindex", "reason"}, nil,
 		),
 		flowRebalanceWorkerByterateCoV: prometheus.NewDesc(

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -791,7 +791,7 @@ func newCollector(srv *Server) *xpfCollector {
 		),
 		flowRebalanceMovesSkippedTotal: prometheus.NewDesc(
 			"xpf_userspace_flow_rebalance_moves_skipped_total",
-			"Candidate moves skipped, by reason (balanced, cooldown, magnitude, epsilon, budget_exhausted, barrier_failed, dwell) (#1748).",
+			"Candidate moves skipped, by reason (balanced, cooldown, magnitude, epsilon, budget_exhausted, barrier_failed, dwell, restore_failed) (#1748).",
 			[]string{"ifindex", "reason"}, nil,
 		),
 		flowRebalanceWorkerByterateCoV: prometheus.NewDesc(

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -773,5 +773,31 @@ func newCollector(srv *Server) *xpfCollector {
 			"Proactive neighbor-warm requests dropped because the warmer worker thread died; warming is disabled until daemon restart (#1636).",
 			nil, nil,
 		),
+		// #1748: reactive ntuple rebalance controller telemetry, per ifindex.
+		flowRebalanceRulesActive: prometheus.NewDesc(
+			"xpf_userspace_flow_rebalance_rules_active",
+			"Number of ntuple flow-steering rules currently installed by the reactive rebalance controller (#1748).",
+			[]string{"ifindex"}, nil,
+		),
+		flowRebalanceInstallsTotal: prometheus.NewDesc(
+			"xpf_userspace_flow_rebalance_installs_total",
+			"Total ntuple rebalance rules installed since start (#1748).",
+			[]string{"ifindex"}, nil,
+		),
+		flowRebalanceDeletesTotal: prometheus.NewDesc(
+			"xpf_userspace_flow_rebalance_deletes_total",
+			"Total ntuple rebalance rules deleted since start (#1748).",
+			[]string{"ifindex"}, nil,
+		),
+		flowRebalanceMovesSkippedTotal: prometheus.NewDesc(
+			"xpf_userspace_flow_rebalance_moves_skipped_total",
+			"Candidate moves skipped, by reason (balanced, cooldown, magnitude, epsilon, budget_exhausted, barrier_failed, dwell) (#1748).",
+			[]string{"ifindex", "reason"}, nil,
+		),
+		flowRebalanceWorkerByterateCoV: prometheus.NewDesc(
+			"xpf_userspace_flow_rebalance_worker_byterate_cov",
+			"Coefficient of variation of per-worker byte-rate observed by the rebalance controller at the last tick (#1748).",
+			[]string{"ifindex"}, nil,
+		),
 	}
 }

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -40,6 +40,49 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp ap
 	c.emitFairnessRSSGauges(ch, status)
 	c.emitFairnessThroughputGauges(ch, status)
 	c.emitNeighborWarmCounters(ch, status)
+	c.emitFlowRebalanceMetrics(ch, status)
+}
+
+// emitFlowRebalanceMetrics exposes the #1748 reactive ntuple rebalance
+// controller telemetry per ifindex. Empty when the knob is off (no series
+// emitted), so the default-OFF path produces no rebalance metrics.
+func (c *xpfCollector) emitFlowRebalanceMetrics(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	for _, r := range status.FlowRebalance {
+		ifindex := strconv.Itoa(r.Ifindex)
+		ch <- prometheus.MustNewConstMetric(
+			c.flowRebalanceRulesActive,
+			prometheus.GaugeValue,
+			float64(r.RulesActive),
+			ifindex,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.flowRebalanceInstallsTotal,
+			prometheus.CounterValue,
+			float64(r.InstallsTotal),
+			ifindex,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.flowRebalanceDeletesTotal,
+			prometheus.CounterValue,
+			float64(r.DeletesTotal),
+			ifindex,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.flowRebalanceWorkerByterateCoV,
+			prometheus.GaugeValue,
+			r.WorkerByterateCoV,
+			ifindex,
+		)
+		for reason, count := range r.MovesSkipped {
+			ch <- prometheus.MustNewConstMetric(
+				c.flowRebalanceMovesSkippedTotal,
+				prometheus.CounterValue,
+				float64(count),
+				ifindex,
+				reason,
+			)
+		}
+	}
 }
 
 // emitNeighborWarmCounters exposes the #1636 proactive-neighbor-warm

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -446,21 +446,28 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 	// block (even empty) enables the controller; absent => nil => off.
 	if frNode := node.FindChild("flow-rebalance"); frNode != nil {
 		fr := &CoSFlowRebalance{}
-		if v := nodeVal(frNode.FindChild("imbalance-threshold")); v != "" {
+		// nodeVal panics on a nil node; a sub-leaf may be absent, so guard.
+		leafVal := func(name string) string {
+			if child := frNode.FindChild(name); child != nil {
+				return nodeVal(child)
+			}
+			return ""
+		}
+		if v := leafVal("imbalance-threshold"); v != "" {
 			n, err := strconv.Atoi(v)
 			if err != nil || n < 101 || n > 1000 {
 				return fmt.Errorf("class-of-service flow-rebalance imbalance-threshold %q: expected 101..1000", v)
 			}
 			fr.ImbalanceThresholdPercent = uint32(n)
 		}
-		if v := nodeVal(frNode.FindChild("rebalance-interval")); v != "" {
+		if v := leafVal("rebalance-interval"); v != "" {
 			n, err := strconv.Atoi(v)
 			if err != nil || n < 1 || n > 3600 {
 				return fmt.Errorf("class-of-service flow-rebalance rebalance-interval %q: expected 1..3600", v)
 			}
 			fr.RebalanceIntervalSecs = uint32(n)
 		}
-		if v := nodeVal(frNode.FindChild("max-rules")); v != "" {
+		if v := leafVal("max-rules"); v != "" {
 			n, err := strconv.Atoi(v)
 			if err != nil || n < 1 || n > 1024 {
 				return fmt.Errorf("class-of-service flow-rebalance max-rules %q: expected 1..1024", v)

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -442,6 +442,34 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 		}
 	}
 
+	// #1748: opt-in reactive ntuple rebalance controller. Presence of the
+	// block (even empty) enables the controller; absent => nil => off.
+	if frNode := node.FindChild("flow-rebalance"); frNode != nil {
+		fr := &CoSFlowRebalance{}
+		if v := nodeVal(frNode.FindChild("imbalance-threshold")); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 101 || n > 1000 {
+				return fmt.Errorf("class-of-service flow-rebalance imbalance-threshold %q: expected 101..1000", v)
+			}
+			fr.ImbalanceThresholdPercent = uint32(n)
+		}
+		if v := nodeVal(frNode.FindChild("rebalance-interval")); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 || n > 3600 {
+				return fmt.Errorf("class-of-service flow-rebalance rebalance-interval %q: expected 1..3600", v)
+			}
+			fr.RebalanceIntervalSecs = uint32(n)
+		}
+		if v := nodeVal(frNode.FindChild("max-rules")); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 || n > 1024 {
+				return fmt.Errorf("class-of-service flow-rebalance max-rules %q: expected 1..1024", v)
+			}
+			fr.MaxRules = uint32(n)
+		}
+		cos.FlowRebalance = fr
+	}
+
 	return nil
 }
 

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -1466,3 +1466,112 @@ func TestCompileClassOfServiceRejectsThreeFCsOnOneQueue(t *testing.T) {
 		t.Errorf("error must reference queue 5, got: %s", err.Error())
 	}
 }
+
+// #1748: flow-rebalance leaf compiles to CoSFlowRebalance; absent => nil.
+func TestCompileClassOfServiceFlowRebalanceSetSyntax(t *testing.T) {
+	lines := []string{
+		"set class-of-service flow-rebalance imbalance-threshold 130",
+		"set class-of-service flow-rebalance rebalance-interval 2",
+		"set class-of-service flow-rebalance max-rules 64",
+		"set system dataplane-type userspace",
+	}
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if cfg.ClassOfService == nil || cfg.ClassOfService.FlowRebalance == nil {
+		t.Fatal("expected FlowRebalance set")
+	}
+	fr := cfg.ClassOfService.FlowRebalance
+	if fr.ImbalanceThresholdPercent != 130 {
+		t.Errorf("imbalance-threshold = %d, want 130", fr.ImbalanceThresholdPercent)
+	}
+	if fr.RebalanceIntervalSecs != 2 {
+		t.Errorf("rebalance-interval = %d, want 2", fr.RebalanceIntervalSecs)
+	}
+	if fr.MaxRules != 64 {
+		t.Errorf("max-rules = %d, want 64", fr.MaxRules)
+	}
+}
+
+// #1748: a bare flow-rebalance block (no sub-leaves) still enables the
+// controller (presence = on); the Rust side fills zeros with its defaults.
+func TestCompileClassOfServiceFlowRebalanceBareEnables(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range []string{
+		"set class-of-service flow-rebalance max-rules 16",
+		"set system dataplane-type userspace",
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if cfg.ClassOfService == nil || cfg.ClassOfService.FlowRebalance == nil {
+		t.Fatal("flow-rebalance block must enable the controller")
+	}
+	if cfg.ClassOfService.FlowRebalance.MaxRules != 16 {
+		t.Errorf("max-rules = %d, want 16", cfg.ClassOfService.FlowRebalance.MaxRules)
+	}
+}
+
+// #1748: default-OFF — no flow-rebalance block => nil (controller never built).
+func TestCompileClassOfServiceFlowRebalanceAbsentIsNil(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set system dataplane-type userspace",
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if cfg.ClassOfService != nil && cfg.ClassOfService.FlowRebalance != nil {
+		t.Fatal("absent flow-rebalance block must compile to nil (default-OFF)")
+	}
+}
+
+// #1748: out-of-range imbalance-threshold is rejected at compile.
+func TestCompileClassOfServiceFlowRebalanceRejectsOutOfRange(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range []string{
+		"set class-of-service flow-rebalance imbalance-threshold 50",
+		"set system dataplane-type userspace",
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("imbalance-threshold 50 (< 101) must be rejected")
+	}
+}

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -1504,9 +1504,11 @@ func TestCompileClassOfServiceFlowRebalanceSetSyntax(t *testing.T) {
 	}
 }
 
-// #1748: a bare flow-rebalance block (no sub-leaves) still enables the
-// controller (presence = on); the Rust side fills zeros with its defaults.
-func TestCompileClassOfServiceFlowRebalanceBareEnables(t *testing.T) {
+// #1748: setting a SINGLE flow-rebalance sub-leaf (here max-rules) enables the
+// controller — presence of the block = on — and the unset sub-leaves
+// (imbalance-threshold, rebalance-interval) stay zero so the Rust side fills
+// them with its built-in defaults.
+func TestCompileClassOfServiceFlowRebalanceSingleSubLeafEnables(t *testing.T) {
 	tree := &ConfigTree{}
 	for _, line := range []string{
 		"set class-of-service flow-rebalance max-rules 16",
@@ -1527,8 +1529,16 @@ func TestCompileClassOfServiceFlowRebalanceBareEnables(t *testing.T) {
 	if cfg.ClassOfService == nil || cfg.ClassOfService.FlowRebalance == nil {
 		t.Fatal("flow-rebalance block must enable the controller")
 	}
-	if cfg.ClassOfService.FlowRebalance.MaxRules != 16 {
-		t.Errorf("max-rules = %d, want 16", cfg.ClassOfService.FlowRebalance.MaxRules)
+	fr := cfg.ClassOfService.FlowRebalance
+	if fr.MaxRules != 16 {
+		t.Errorf("max-rules = %d, want 16", fr.MaxRules)
+	}
+	// Unset sub-leaves stay zero (the Rust controller fills its defaults).
+	if fr.ImbalanceThresholdPercent != 0 {
+		t.Errorf("imbalance-threshold = %d, want 0 (unset)", fr.ImbalanceThresholdPercent)
+	}
+	if fr.RebalanceIntervalSecs != 0 {
+		t.Errorf("rebalance-interval = %d, want 0 (unset)", fr.RebalanceIntervalSecs)
 	}
 }
 

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -886,6 +886,37 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"scheduler-map": {args: 1, children: nil},
 			}},
 		}},
+		// #1748: default-OFF opt-in reactive cross-worker ntuple rebalance
+		// controller. Absent => the userspace-dp controller is never
+		// constructed (byte-identical default path). imbalance-threshold is
+		// expressed as a percent of the mean per-worker byte-rate (e.g. 130
+		// means move when the hottest worker exceeds 1.30x the mean).
+		"flow-rebalance": {children: map[string]*schemaNode{
+			"imbalance-threshold": {
+				args:          1,
+				valueType:     ValueInteger,
+				valueDesc:     "Hottest-worker byte-rate as a percent of the mean that triggers a move (101..1000; e.g. 130 = 1.30x)",
+				valueExamples: []string{"120", "130", "150"},
+				validator:     ValidateInteger(101, 1000),
+				children:      nil,
+			},
+			"rebalance-interval": {
+				args:          1,
+				valueType:     ValueInteger,
+				valueDesc:     "Minimum seconds between rule installs (>= 1)",
+				valueExamples: []string{"1", "2", "5"},
+				validator:     ValidateInteger(1, 3600),
+				children:      nil,
+			},
+			"max-rules": {
+				args:          1,
+				valueType:     ValueInteger,
+				valueDesc:     "Hard cap on concurrently-installed ntuple rules per interface (1..1024)",
+				valueExamples: []string{"16", "64", "256"},
+				validator:     ValidateInteger(1, 1024),
+				children:      nil,
+			},
+		}},
 		"fairness": {children: map[string]*schemaNode{
 			"rss-expectation": {children: map[string]*schemaNode{
 				"ifindex": {args: 1, multi: true, children: map[string]*schemaNode{

--- a/pkg/config/types_cos.go
+++ b/pkg/config/types_cos.go
@@ -15,6 +15,26 @@ type ClassOfServiceConfig struct {
 	SchedulerMaps        map[string]*CoSSchedulerMap
 	Interfaces           map[string]*CoSInterface
 	FairnessExpectations []*CoSFairnessExpectation
+	// FlowRebalance is the #1748 opt-in reactive ntuple rebalance knob.
+	// nil => disabled (the userspace-dp controller is never constructed and
+	// the default forwarding path is byte-identical).
+	FlowRebalance *CoSFlowRebalance
+}
+
+// CoSFlowRebalance holds the #1748 reactive cross-worker ntuple rebalance
+// controller knobs. Presence of the block (even with all defaults) enables
+// the controller; absence keeps it off.
+type CoSFlowRebalance struct {
+	// ImbalanceThresholdPercent: hottest-worker byte-rate as a percent of
+	// the mean that triggers a move (e.g. 130 = 1.30x). 0 => controller
+	// default (130).
+	ImbalanceThresholdPercent uint32
+	// RebalanceIntervalSecs: minimum seconds between rule installs. 0 =>
+	// controller default (1).
+	RebalanceIntervalSecs uint32
+	// MaxRules: hard cap on concurrently-installed ntuple rules per
+	// interface. 0 => controller default (64).
+	MaxRules uint32
 }
 
 // CoSForwardingClass maps a forwarding-class name to a queue number.

--- a/pkg/dataplane/userspace/cos.go
+++ b/pkg/dataplane/userspace/cos.go
@@ -11,7 +11,7 @@ func buildClassOfServiceSnapshot(cfg *config.Config) *ClassOfServiceSnapshot {
 		return nil
 	}
 	cos := cfg.ClassOfService
-	if len(cos.ForwardingClasses) == 0 && len(cos.DSCPClassifiers) == 0 && len(cos.IEEE8021Classifiers) == 0 && len(cos.DSCPRewriteRules) == 0 && len(cos.Schedulers) == 0 && len(cos.SchedulerMaps) == 0 && len(cos.Interfaces) == 0 {
+	if len(cos.ForwardingClasses) == 0 && len(cos.DSCPClassifiers) == 0 && len(cos.IEEE8021Classifiers) == 0 && len(cos.DSCPRewriteRules) == 0 && len(cos.Schedulers) == 0 && len(cos.SchedulerMaps) == 0 && len(cos.Interfaces) == 0 && cos.FlowRebalance == nil {
 		return nil
 	}
 	snap := &ClassOfServiceSnapshot{}
@@ -171,6 +171,17 @@ func buildClassOfServiceSnapshot(cfg *config.Config) *ClassOfServiceSnapshot {
 				})
 			}
 			snap.SchedulerMaps = append(snap.SchedulerMaps, mapSnap)
+		}
+	}
+
+	// #1748: forward the opt-in rebalance knob. Presence (even all-zero
+	// sub-fields) enables the userspace-dp controller; the Rust side fills
+	// zeros with its defaults.
+	if cos.FlowRebalance != nil {
+		snap.FlowRebalance = &CoSFlowRebalanceSnapshot{
+			ImbalanceThresholdPercent: cos.FlowRebalance.ImbalanceThresholdPercent,
+			RebalanceIntervalSecs:     cos.FlowRebalance.RebalanceIntervalSecs,
+			MaxRules:                  cos.FlowRebalance.MaxRules,
 		}
 	}
 

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -176,6 +176,19 @@ type ClassOfServiceSnapshot struct {
 	DSCPRewriteRules    []CoSDSCPRewriteRuleSnapshot    `json:"dscp_rewrite_rules,omitempty"`
 	Schedulers          []CoSSchedulerSnapshot          `json:"schedulers,omitempty"`
 	SchedulerMaps       []CoSSchedulerMapSnapshot       `json:"scheduler_maps,omitempty"`
+	// FlowRebalance is the #1748 opt-in reactive ntuple rebalance config.
+	// Omitted => the userspace-dp controller is never constructed. JSON tag
+	// MUST match the Rust serde rename(...) exactly — the wire format is the
+	// contract.
+	FlowRebalance *CoSFlowRebalanceSnapshot `json:"flow_rebalance,omitempty"`
+}
+
+// CoSFlowRebalanceSnapshot mirrors config.CoSFlowRebalance over the wire.
+// Zero sub-fields tell the Rust controller to use its built-in defaults.
+type CoSFlowRebalanceSnapshot struct {
+	ImbalanceThresholdPercent uint32 `json:"imbalance_threshold_percent,omitempty"`
+	RebalanceIntervalSecs     uint32 `json:"rebalance_interval_secs,omitempty"`
+	MaxRules                  uint32 `json:"max_rules,omitempty"`
 }
 
 type CoSForwardingClassSnapshot struct {
@@ -617,6 +630,20 @@ type ProcessStatus struct {
 	// warmer worker thread died (fatal — warming disabled until restart).
 	NeighborWarmDropsTotal        uint64 `json:"neighbor_warm_drops_total,omitempty"`
 	NeighborWarmDisconnectedTotal uint64 `json:"neighbor_warm_disconnected_total,omitempty"`
+	// #1748: per-interface reactive ntuple rebalance controller telemetry.
+	// Empty when the knob is off. JSON tag MUST match the Rust serde
+	// rename("flow_rebalance").
+	FlowRebalance []FlowRebalanceStatus `json:"flow_rebalance,omitempty"`
+}
+
+// FlowRebalanceStatus mirrors the Rust protocol::FlowRebalanceStatus row.
+type FlowRebalanceStatus struct {
+	Ifindex           int               `json:"ifindex,omitempty"`
+	RulesActive       uint32            `json:"rules_active,omitempty"`
+	InstallsTotal     uint64            `json:"installs_total,omitempty"`
+	DeletesTotal      uint64            `json:"deletes_total,omitempty"`
+	MovesSkipped      map[string]uint64 `json:"moves_skipped,omitempty"`
+	WorkerByterateCoV float64           `json:"worker_byterate_cov,omitempty"`
 }
 
 // MarshalJSON intentionally uses a value receiver so both ProcessStatus values

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -1029,6 +1029,14 @@ pub(super) fn delete_session_map_entry_for_removed_session_with_origin(
     conntrack_v4_fd: c_int,
     conntrack_v6_fd: c_int,
 ) {
+    // #1748: the abandoned W_old copy after a rebalance move must NOT delete
+    // any shared session-map redirect key OR conntrack mirror entry — W_new
+    // now owns those entries and is actively forwarding against them. AGY's
+    // surgical fix: one early-return guard covers both the redirect-key delete
+    // and the conntrack delete below.
+    if origin.is_rebalanced_out() {
+        return;
+    }
     delete_session_map_redirect_for_session(map_fd, key, decision, metadata, origin);
     if uses_kernel_local_session_map_entry(decision, metadata, origin) {
         delete_bpf_conntrack_entry(conntrack_v4_fd, conntrack_v6_fd, key);

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -77,6 +77,13 @@ pub struct Coordinator {
     /// #1748: last per-(worker) tx_bytes sample + monotonic ns, for deriving
     /// byte-rate across the controller tick window. Keyed by worker_id.
     pub(in crate::afxdp) rebalance_last_tx_bytes: BTreeMap<u32, (u64, u64)>,
+    /// #1748 review #8: last per-FLOW cumulative observed_bytes sample +
+    /// monotonic ns, for deriving each flow's byte-RATE across the tick window.
+    /// FlowCacheEntry.observed_bytes is CUMULATIVE, so a long-lived idle flow
+    /// would otherwise look "hottest"; the controller selects on rate, not
+    /// cumulative bytes. Keyed by the flow's SessionKey.
+    pub(in crate::afxdp) rebalance_last_flow_bytes:
+        std::collections::HashMap<crate::session::SessionKey, (u64, u64)>,
 }
 
 impl Coordinator {
@@ -114,6 +121,7 @@ impl Coordinator {
             rebalance_config: None,
             rebalance_controllers: BTreeMap::new(),
             rebalance_last_tx_bytes: BTreeMap::new(),
+            rebalance_last_flow_bytes: std::collections::HashMap::new(),
         }
     }
 

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -4,6 +4,7 @@ mod cos_state;
 mod ha_state;
 mod inject;
 mod neighbor_manager;
+mod rebalance;
 mod reconcile;
 mod refresh_bindings;
 mod session_manager;
@@ -64,6 +65,18 @@ pub struct Coordinator {
     /// stably; written exactly once when the worker dies, read at most
     /// once per gRPC status poll (~1 Hz). Not on the packet hot path.
     pub(crate) worker_panics: BTreeMap<u32, Arc<Mutex<Option<String>>>>,
+    /// #1748: opt-in reactive ntuple rebalance config from the
+    /// `class-of-service flow-rebalance` leaf. `None` => default-OFF: the
+    /// controller is never constructed, no ioctl socket, no per-tick work.
+    pub(in crate::afxdp) rebalance_config: Option<crate::afxdp::rebalance::RebalanceConfig>,
+    /// #1748: per-ifindex live rebalance controllers, constructed lazily on
+    /// the first tick after the knob is enabled and a worker is bound to that
+    /// interface. Each owns its ethtool ntuple socket + rule ledger.
+    pub(in crate::afxdp) rebalance_controllers:
+        BTreeMap<i32, crate::afxdp::rebalance::RebalanceController>,
+    /// #1748: last per-(worker) tx_bytes sample + monotonic ns, for deriving
+    /// byte-rate across the controller tick window. Keyed by worker_id.
+    pub(in crate::afxdp) rebalance_last_tx_bytes: BTreeMap<u32, (u64, u64)>,
 }
 
 impl Coordinator {
@@ -98,6 +111,9 @@ impl Coordinator {
             last_cache_flush_at: Arc::new(AtomicU64::new(0)),
             rg_epochs: Arc::new(std::array::from_fn(|_| AtomicU32::new(0))),
             worker_panics: BTreeMap::new(),
+            rebalance_config: None,
+            rebalance_controllers: BTreeMap::new(),
+            rebalance_last_tx_bytes: BTreeMap::new(),
         }
     }
 
@@ -204,6 +220,12 @@ impl Coordinator {
     }
 
     pub(crate) fn stop_inner(&mut self, clear_synced_state: bool) {
+        // #1748: remove every installed ntuple rule on shutdown so no orphan
+        // HW rule survives the daemon. Plain deletes are correct here: the
+        // whole dataplane is tearing down, so there is no live flow whose
+        // ownership needs handing back (the reverse barrier protects against a
+        // live-flow leak, which cannot happen when all workers stop).
+        self.teardown_all_rebalance_rules_plain();
         if let Some(stop) = self.neighbors.monitor_stop.take() {
             stop.store(true, Ordering::Relaxed);
         }

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -92,6 +92,16 @@ pub struct Coordinator {
     /// cumulative bytes. Keyed by the flow's SessionKey.
     pub(in crate::afxdp) rebalance_last_flow_bytes:
         std::collections::HashMap<crate::session::SessionKey, (u64, u64)>,
+    /// #1748 live BUG #1: monotonic ns of the last rebalance EVALUATION.
+    /// tick_rebalance is invoked at the ~24/s status-poll cadence, but the
+    /// per-flow byte-rate signal (observed_bytes from the flow-worker map) only
+    /// refreshes ~every 65ms/65k-packets, so sampling every ~42ms yields a
+    /// near-zero/noisy per-flow rate -> the projected-CoV improvement never
+    /// clears the epsilon band and NO move is ever made. We therefore only
+    /// SAMPLE byte-rates + run the controller tick once per rebalance_interval
+    /// (>= 1s), so the rate window spans the interval and is stable. 0 = never
+    /// evaluated yet (the first tick evaluates).
+    pub(in crate::afxdp) rebalance_last_eval_ns: u64,
 }
 
 impl Coordinator {
@@ -131,6 +141,7 @@ impl Coordinator {
             rebalance_sockets: BTreeMap::new(),
             rebalance_last_tx_bytes: BTreeMap::new(),
             rebalance_last_flow_bytes: std::collections::HashMap::new(),
+            rebalance_last_eval_ns: 0,
         }
     }
 
@@ -722,6 +733,13 @@ impl Coordinator {
         };
         self.policy_counters.reconcile_rules(&snapshot.policies);
         self.forwarding = new_forwarding;
+        // #1748 live BUG #2: reconcile the flow-rebalance knob on the SAME-PLAN
+        // live-commit path too. A flow-rebalance-only `commit` does not change
+        // the binding plan, so it routes here (not through apply_snapshot);
+        // without this call, enabling/disabling the knob was a no-op until a
+        // daemon restart. This is idempotent — if the config is unchanged,
+        // reconcile_rebalance_config sees no transition and does nothing.
+        self.reconcile_rebalance_from_snapshot(snapshot);
         if self.forwarding.fabrics.is_empty() && !preserved_fabrics.is_empty() {
             self.forwarding.fabrics = preserved_fabrics;
         } else if !preserved_fabrics.is_empty() {

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -82,9 +82,12 @@ pub struct Coordinator {
     /// constructed together on lazy bring-up, removed together on teardown.
     pub(in crate::afxdp) rebalance_sockets:
         BTreeMap<i32, crate::afxdp::rebalance::NtupleSocket>,
-    /// #1748: last per-(worker) tx_bytes sample + monotonic ns, for deriving
-    /// byte-rate across the controller tick window. Keyed by worker_id.
-    pub(in crate::afxdp) rebalance_last_tx_bytes: BTreeMap<u32, (u64, u64)>,
+    /// #1748: last per-worker tx_bytes sample + monotonic ns, for deriving
+    /// byte-rate across the controller tick window. Keyed by (ifindex,
+    /// worker_id) — the REAL worker_id (from BindingIdentity), aggregated
+    /// across all of that worker's bindings on the ifindex (#1748 live r6:
+    /// `workers.live` is slot-keyed, not worker_id-keyed).
+    pub(in crate::afxdp) rebalance_last_tx_bytes: BTreeMap<(i32, u32), (u64, u64)>,
     /// #1748 review #8: last per-FLOW cumulative observed_bytes sample +
     /// monotonic ns, for deriving each flow's byte-RATE across the tick window.
     /// FlowCacheEntry.observed_bytes is CUMULATIVE, so a long-lived idle flow

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -71,9 +71,17 @@ pub struct Coordinator {
     pub(in crate::afxdp) rebalance_config: Option<crate::afxdp::rebalance::RebalanceConfig>,
     /// #1748: per-ifindex live rebalance controllers, constructed lazily on
     /// the first tick after the knob is enabled and a worker is bound to that
-    /// interface. Each owns its ethtool ntuple socket + rule ledger.
+    /// interface. Holds the rule ledger + cooldown + metrics.
     pub(in crate::afxdp) rebalance_controllers:
         BTreeMap<i32, crate::afxdp::rebalance::RebalanceController>,
+    /// #1748 review-r3 (soundness): the per-ifindex ethtool ntuple sockets,
+    /// kept SEPARATE from `rebalance_controllers` so the socket can be borrowed
+    /// as the BarrierTransport (`&NtupleSocket`) while the matching controller
+    /// is borrowed `&mut` for its tick/teardown — independent borrows, no
+    /// aliasing. The two maps are kept in lockstep (same ifindex key set):
+    /// constructed together on lazy bring-up, removed together on teardown.
+    pub(in crate::afxdp) rebalance_sockets:
+        BTreeMap<i32, crate::afxdp::rebalance::NtupleSocket>,
     /// #1748: last per-(worker) tx_bytes sample + monotonic ns, for deriving
     /// byte-rate across the controller tick window. Keyed by worker_id.
     pub(in crate::afxdp) rebalance_last_tx_bytes: BTreeMap<u32, (u64, u64)>,
@@ -120,6 +128,7 @@ impl Coordinator {
             worker_panics: BTreeMap::new(),
             rebalance_config: None,
             rebalance_controllers: BTreeMap::new(),
+            rebalance_sockets: BTreeMap::new(),
             rebalance_last_tx_bytes: BTreeMap::new(),
             rebalance_last_flow_bytes: std::collections::HashMap::new(),
         }

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -228,11 +228,23 @@ impl Coordinator {
     }
 
     pub(crate) fn stop_inner(&mut self, clear_synced_state: bool) {
-        // #1748: remove every installed ntuple rule on shutdown so no orphan
-        // HW rule survives the daemon. Plain deletes are correct here: the
-        // whole dataplane is tearing down, so there is no live flow whose
-        // ownership needs handing back (the reverse barrier protects against a
-        // live-flow leak, which cannot happen when all workers stop).
+        // #1748: remove every installed ntuple rule here so no orphan HW rule
+        // survives. PLAIN deletes (no reverse barrier) are correct on BOTH
+        // paths this runs on — final shutdown AND reconcile-teardown
+        // (stop_inner(false)) — for the same reason (#1748 review #3, verified):
+        // stop_inner stops + joins ALL worker threads via
+        // `self.workers.stop_and_clear(...)` below, which destroys each
+        // worker's per-thread SessionTable, and with it every RebalancedOut /
+        // RebalancedOwner origin (those local-only rebalance origins are NEVER
+        // published to the shared synced-session table — that is the whole
+        // point of the suppression set). On reconcile bring-up the worker
+        // SessionTables are rebuilt fresh by replaying the preserved SHARED
+        // synced sessions, which carry SyncImport origins, not the rebalance
+        // origins. So there is no live ownership to hand back across a reconcile
+        // either: no RebalancedOut/Owner entry can be stranded, because none
+        // survives the worker teardown. The reverse barrier protects a leak
+        // that requires the owning worker to keep running, which cannot happen
+        // when every worker is joined here.
         self.teardown_all_rebalance_rules_plain();
         if let Some(stop) = self.neighbors.monitor_stop.take() {
             stop.store(true, Ordering::Relaxed);

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -252,7 +252,7 @@ impl super::Coordinator {
 
     /// Snapshot the per-interface rebalance metrics for the Prometheus
     /// collector. Returns (ifindex, metrics) for every live controller.
-    pub fn rebalance_metrics(
+    pub(in crate::afxdp) fn rebalance_metrics(
         &self,
     ) -> Vec<(i32, crate::afxdp::rebalance::RebalanceMetrics)> {
         self.rebalance_controllers

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -202,31 +202,61 @@ impl super::Coordinator {
         }
         self.rebalance_last_eval_ns = now_ns;
 
-        // 1. Per-worker byte-rate over the window, grouped by the ifindex each
-        //    worker's binding is bound to.
-        let mut per_iface_workers: BTreeMap<i32, Vec<WorkerByteRate>> = BTreeMap::new();
-        let mut worker_ifindex: BTreeMap<u32, i32> = BTreeMap::new();
-        for (&worker_id, live) in &self.workers.live {
-            let ifindex = live.socket_ifindex();
+        // 1. Per-worker byte-rate over the window, grouped by ifindex.
+        //
+        // #1748 live BUG (r6): `self.workers.live` is keyed by binding SLOT,
+        // NOT by worker_id (see WorkerManager doc: live/identities are
+        // slot-keyed, only `handles` is worker_id-keyed). The previous code
+        // treated the live map key as the worker_id, so the per-worker rate
+        // vector was keyed by SLOT while the flow-worker-map rows carry the
+        // real `binding.worker_id`. select_move's `f.worker_id ==
+        // hottest.worker_id` then NEVER matched (slot != worker_id), so the
+        // hottest worker always had zero candidate flows -> NoEligibleFlow ->
+        // zero installs under load, even though the flow list was populated.
+        //
+        // Fix: join `live` (slot -> BindingLiveState) with `identities` (slot
+        // -> BindingIdentity{worker_id, queue_id, ifindex}) and aggregate by
+        // the REAL worker_id — the same id-space the flow rows use. A worker
+        // may own several bindings/slots on one ifindex; sum their tx_bytes and
+        // keep the (lowest-slot) queue_id as the ntuple ring_cookie target for
+        // that worker's RX queue.
+        let mut agg: BTreeMap<(i32, u32), (u64, u32)> = BTreeMap::new(); // (ifindex,worker)->(tx_bytes,queue_id)
+        for (slot, live) in &self.workers.live {
+            let Some(identity) = self.workers.identities.get(slot) else {
+                continue;
+            };
+            let ifindex = identity.ifindex;
             if ifindex <= 0 {
                 continue;
             }
-            let queue_id = live.socket_queue_id();
-            let tx_bytes = live.tx_bytes();
-            let rate = match self.rebalance_last_tx_bytes.get(&worker_id) {
+            let entry = agg.entry((ifindex, identity.worker_id)).or_insert((0, identity.queue_id));
+            entry.0 = entry.0.saturating_add(live.tx_bytes());
+            // Prefer the lowest queue_id deterministically (stable ring_cookie).
+            if identity.queue_id < entry.1 {
+                entry.1 = identity.queue_id;
+            }
+        }
+        let mut per_iface_workers: BTreeMap<i32, Vec<WorkerByteRate>> = BTreeMap::new();
+        let mut seen_worker_keys: std::collections::HashSet<(i32, u32)> =
+            std::collections::HashSet::new();
+        for ((ifindex, worker_id), (tx_bytes, queue_id)) in agg {
+            let rate = match self.rebalance_last_tx_bytes.get(&(ifindex, worker_id)) {
                 Some(&(prev_bytes, prev_ns)) => {
                     cumulative_to_rate(tx_bytes, prev_bytes, now_ns, prev_ns)
                 }
                 None => 0.0,
             };
             self.rebalance_last_tx_bytes
-                .insert(worker_id, (tx_bytes, now_ns));
-            worker_ifindex.insert(worker_id, ifindex);
+                .insert((ifindex, worker_id), (tx_bytes, now_ns));
+            seen_worker_keys.insert((ifindex, worker_id));
             per_iface_workers
                 .entry(ifindex)
                 .or_default()
                 .push(WorkerByteRate { worker_id, queue_id, byte_rate: rate });
         }
+        // Prune stale per-worker samples so the window map can't grow unbounded.
+        self.rebalance_last_tx_bytes
+            .retain(|k, _| seen_worker_keys.contains(k));
 
         // 2. Per-flow samples (5-tuple key + worker + byte-RATE) grouped by
         //    ifindex, from the flow-worker map telemetry.
@@ -313,20 +343,31 @@ impl super::Coordinator {
             if workers.len() < 2 {
                 continue;
             }
-            // #1748 live BUG #1 instrumentation: ground-truth per-EVAL summary
-            // of the per-worker rate vector + how many flows have a positive
-            // rate. Gated to `debug-log` builds. Read via
-            // `journalctl -u xpfd | grep REBALANCE_EVAL`.
+            // #1748 live BUG #1/r6 instrumentation: ground-truth per-EVAL
+            // summary. Emits the per-worker rate vector AND the per-worker FLOW
+            // COUNT the controller sees (so a debug build can confirm the
+            // controller's flow list now matches binding_active_flow_count after
+            // the slot->worker_id join fix). Gated to `debug-log` builds. Read
+            // via `journalctl -u xpfd | grep REBALANCE_EVAL`.
             #[cfg(feature = "debug-log")]
             {
                 let worker_rates: Vec<(u32, f64)> =
                     workers.iter().map(|w| (w.worker_id, w.byte_rate)).collect();
+                // Per-worker flow count keyed by the REAL worker_id (matches
+                // the worker rate vector's id-space). If a worker shows a rate
+                // but 0 flows here, the join/feed is still broken for it.
+                let mut flows_per_worker: std::collections::BTreeMap<u32, usize> =
+                    std::collections::BTreeMap::new();
+                for f in &flows {
+                    *flows_per_worker.entry(f.worker_id).or_insert(0) += 1;
+                }
                 let flows_positive = flows.iter().filter(|f| f.byte_rate > 0.0).count();
                 debug_log_rebalance!(
-                    "REBALANCE_EVAL ifindex={} workers={:?} flows={} flows_with_positive_rate={}",
+                    "REBALANCE_EVAL ifindex={} workers={:?} flows={} flows_per_worker={:?} flows_with_positive_rate={}",
                     ifindex,
                     worker_rates,
                     flows.len(),
+                    flows_per_worker,
                     flows_positive,
                 );
             }

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -13,7 +13,7 @@
 use super::*;
 use crate::afxdp::rebalance::{
     BarrierTransport, FlowSample, RebalanceConfig, RebalanceController, RebalanceTickInput,
-    WorkerByteRate, flow_spec_from_key, NtupleSocket,
+    WorkerByteRate, cumulative_to_rate, flow_spec_from_key, NtupleSocket,
 };
 use crate::afxdp::rebalance::ntuple::FlowSpec5Tuple;
 use crate::afxdp::RebalanceAck;
@@ -86,6 +86,7 @@ impl super::Coordinator {
         // Reset the byte-rate sampling window so the first tick after a config
         // change does not see a bogus huge delta.
         self.rebalance_last_tx_bytes.clear();
+        self.rebalance_last_flow_bytes.clear();
     }
 
     /// Tear down one interface's controller: reverse-barrier its live moves,
@@ -127,6 +128,7 @@ impl super::Coordinator {
             controller.teardown_all(&mut tx, |_w, _k| false);
         }
         self.rebalance_last_tx_bytes.clear();
+        self.rebalance_last_flow_bytes.clear();
     }
 
     /// Drive one controller tick at the status cadence. Default-OFF fast path:
@@ -153,15 +155,10 @@ impl super::Coordinator {
             let queue_id = live.socket_queue_id();
             let tx_bytes = live.tx_bytes();
             let rate = match self.rebalance_last_tx_bytes.get(&worker_id) {
-                Some(&(prev_bytes, prev_ns)) if now_ns > prev_ns => {
-                    let dt = (now_ns - prev_ns) as f64 / 1_000_000_000.0;
-                    if dt > 0.0 {
-                        (tx_bytes.saturating_sub(prev_bytes)) as f64 / dt
-                    } else {
-                        0.0
-                    }
+                Some(&(prev_bytes, prev_ns)) => {
+                    cumulative_to_rate(tx_bytes, prev_bytes, now_ns, prev_ns)
                 }
-                _ => 0.0,
+                None => 0.0,
             };
             self.rebalance_last_tx_bytes
                 .insert(worker_id, (tx_bytes, now_ns));
@@ -172,14 +169,24 @@ impl super::Coordinator {
                 .push(WorkerByteRate { worker_id, queue_id, byte_rate: rate });
         }
 
-        // 2. Per-flow samples (5-tuple key + worker + byte-rate) grouped by
+        // 2. Per-flow samples (5-tuple key + worker + byte-RATE) grouped by
         //    ifindex, from the flow-worker map telemetry.
+        //
+        // #1748 review #8: row.observed_bytes is CUMULATIVE bytes for the
+        // cached flow, NOT a per-window rate. Using cumulative bytes as the
+        // selection signal makes a long-lived but now-idle flow look "hottest"
+        // forever, so the controller would pick the wrong flow to move and the
+        // magnitude<=gap/2 guard (which compares against per-worker rates)
+        // would be meaningless. Derive an actual byte-RATE = (current_cumulative
+        // - last_sample_cumulative) / elapsed, maintaining a per-flow previous
+        // sample across ticks (the controller runs at a fixed cadence).
         let mut per_iface_flows: BTreeMap<i32, Vec<FlowSample>> = BTreeMap::new();
         let (rows, _truncated) = self.flow_worker_map();
+        let mut seen_flow_keys: std::collections::HashSet<SessionKey> =
+            std::collections::HashSet::new();
         for row in rows {
             // Only forward-direction flows on the steered ifindex with a
-            // resolvable 5-tuple. The flow-worker row carries observed_bytes
-            // over the window for byte-rate-aware selection.
+            // resolvable 5-tuple.
             let ifindex = row.ifindex;
             if ifindex <= 0 || !per_iface_workers.contains_key(&ifindex) {
                 continue;
@@ -187,12 +194,29 @@ impl super::Coordinator {
             let Some(key) = session_key_from_tuple(&row.session_key) else {
                 continue;
             };
+            let cumulative = row.observed_bytes;
+            // First observation of this flow => no rate yet (a brand-new flow's
+            // first-tick cumulative is not a window rate). cumulative_to_rate
+            // also handles a cumulative reset on re-home via saturating_sub.
+            let rate = match self.rebalance_last_flow_bytes.get(&key) {
+                Some(&(prev_bytes, prev_ns)) => {
+                    cumulative_to_rate(cumulative, prev_bytes, now_ns, prev_ns)
+                }
+                None => 0.0,
+            };
+            self.rebalance_last_flow_bytes
+                .insert(key.clone(), (cumulative, now_ns));
+            seen_flow_keys.insert(key.clone());
             per_iface_flows.entry(ifindex).or_default().push(FlowSample {
                 key,
                 worker_id: row.worker_id,
-                byte_rate: row.observed_bytes as f64,
+                byte_rate: rate,
             });
         }
+        // Prune previous-sample entries for flows that disappeared this tick so
+        // the map does not grow unbounded across the daemon's lifetime.
+        self.rebalance_last_flow_bytes
+            .retain(|k, _| seen_flow_keys.contains(k));
 
         // 3. Tick each steered interface's controller.
         let ifindexes: Vec<i32> = per_iface_workers.keys().copied().collect();

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -363,6 +363,10 @@ impl super::Coordinator {
         // even if a previous command timed out without being acked (in which
         // case rebalance_ack_seq would not have advanced, causing a collision
         // if we derived the new seq from it).
+        // Relaxed is sufficient: we only need uniqueness across barrier_command
+        // calls, which are always made from the same coordinator thread. The
+        // seq is delivered to the worker via the command queue (Mutex), which
+        // establishes the necessary happens-before for the worker's ack.
         let seq = handle.rebalance_cmd_seq.fetch_add(1, Ordering::Relaxed) + 1;
         {
             let Ok(mut pending) = handle.commands.lock() else {
@@ -376,10 +380,12 @@ impl super::Coordinator {
                 // Read the structured slot and confirm key + origin.
                 if let Ok(slot) = handle.rebalance_ack.lock() {
                     if let Some(ack) = slot.as_ref() {
-                        // Only accept an exact-seq match. If ack.seq > seq
-                        // the slot was overwritten by a later command before
-                        // we polled; keep waiting until the deadline rather
-                        // than returning the wrong ack's result.
+                        // ack.seq == seq → exact match; return the result.
+                        // ack.seq > seq  → slot overwritten by a later command
+                        //   before we polled; keep waiting until the deadline
+                        //   rather than returning the wrong ack's result.
+                        // ack.seq < seq  → stale ack from a prior command;
+                        //   keep polling until the worker writes our seq.
                         if ack.seq == seq {
                             return ack_confirms(ack, key, expected);
                         }

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -97,13 +97,16 @@ impl super::Coordinator {
         let Some(mut controller) = self.rebalance_controllers.remove(&ifindex) else {
             return;
         };
-        let socket_ptr: *const NtupleSocket = controller.socket();
-        // SAFETY: the controller owns the socket for the duration of teardown;
-        // we only read it through the transport. `self` (for the barrier) and
-        // the socket do not alias mutably.
+        // #1748 review-r3 (soundness): take the socket OUT of its separate map
+        // so it is an owned local, independent of `self`. The transport borrows
+        // the local socket + `&self` for the barrier; the controller is a
+        // separate owned local. No aliasing, no raw pointer.
+        let Some(socket) = self.rebalance_sockets.remove(&ifindex) else {
+            return;
+        };
         let mut tx = CoordinatorBarrierTransport {
             coord: self,
-            socket: unsafe { &*socket_ptr },
+            socket: &socket,
         };
         controller.teardown_all(&mut tx, |_w, _k| true);
     }
@@ -117,16 +120,21 @@ impl super::Coordinator {
             let Some(mut controller) = self.rebalance_controllers.remove(&ifindex) else {
                 continue;
             };
-            let socket_ptr: *const NtupleSocket = controller.socket();
-            // SAFETY: controller owns the socket for the teardown; the no-op
-            // barrier transport only reads it.
+            // #1748 review-r3 (soundness): owned-local socket, separate from the
+            // owned-local controller — no aliasing / raw pointer.
+            let Some(socket) = self.rebalance_sockets.remove(&ifindex) else {
+                continue;
+            };
             let mut tx = CoordinatorBarrierTransport {
                 coord: self,
-                socket: unsafe { &*socket_ptr },
+                socket: &socket,
             };
             // is_live_on_new = false => plain delete for every entry.
             controller.teardown_all(&mut tx, |_w, _k| false);
         }
+        // Any sockets without a controller (shouldn't happen — maps are kept in
+        // lockstep) are still dropped here so no fd leaks across a teardown.
+        self.rebalance_sockets.clear();
         self.rebalance_last_tx_bytes.clear();
         self.rebalance_last_flow_bytes.clear();
     }
@@ -253,8 +261,12 @@ impl super::Coordinator {
                                 "xpf-rebalance: startup orphan reconcile on {ifname} (ifindex {ifindex}) failed: {e}"
                             ),
                         }
+                        // Keep the two maps in lockstep: socket in
+                        // rebalance_sockets, ledger/metrics in
+                        // rebalance_controllers.
+                        self.rebalance_sockets.insert(ifindex, sock);
                         self.rebalance_controllers
-                            .insert(ifindex, RebalanceController::new(config, sock));
+                            .insert(ifindex, RebalanceController::new(config));
                     }
                     Err(e) => {
                         eprintln!(
@@ -266,20 +278,23 @@ impl super::Coordinator {
             }
 
             let input = RebalanceTickInput { ifindex, workers, flows, now_secs };
-            // Take the controller out so the barrier transport can borrow
-            // `self` mutably without aliasing the controller. Put it back.
+            // #1748 review-r3 (soundness): take BOTH the controller and its
+            // socket out as independent owned locals, run the tick (transport
+            // borrows the local socket + `&self`; controller is borrowed `&mut`
+            // separately — no aliasing, no raw pointer), then put both back.
             let mut controller = self.rebalance_controllers.remove(&ifindex).unwrap();
-            let socket_ptr: *const NtupleSocket = controller.socket();
+            let socket = self
+                .rebalance_sockets
+                .remove(&ifindex)
+                .expect("rebalance_sockets kept in lockstep with rebalance_controllers");
             let outcome = {
-                // SAFETY: the controller (and its socket) is owned here for the
-                // tick; the transport borrows `self` for command queues + the
-                // socket by shared ref. They do not alias mutably.
                 let mut tx = CoordinatorBarrierTransport {
                     coord: self,
-                    socket: unsafe { &*socket_ptr },
+                    socket: &socket,
                 };
                 controller.tick(&input, &mut tx)
             };
+            self.rebalance_sockets.insert(ifindex, socket);
             if let Some(mv) = outcome {
                 slog_debug_rebalance_move(ifindex, &mv);
             }

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -1,0 +1,414 @@
+// #1748: Coordinator-side glue for the reactive ntuple rebalance controller.
+//
+// The controller logic + ioctl module live in `afxdp/rebalance/`. This file
+// connects them to the live Coordinator: it translates the wire config into a
+// RebalanceConfig, drives one controller tick per status cadence (~1 Hz), and
+// implements the barriered ownership-transfer transport against the worker
+// command queues + structured ack slots + the per-interface ntuple socket.
+//
+// Default-OFF invariant: when `rebalance_config` is None, `tick_rebalance` is
+// a single `Option::is_none()` early-return — zero ioctl sockets, zero rules,
+// no per-tick allocation.
+
+use super::*;
+use crate::afxdp::rebalance::{
+    BarrierTransport, FlowSample, RebalanceConfig, RebalanceController, RebalanceTickInput,
+    WorkerByteRate, flow_spec_from_key, NtupleSocket,
+};
+use crate::afxdp::rebalance::ntuple::FlowSpec5Tuple;
+use crate::afxdp::RebalanceAck;
+use crate::protocol::CoSFlowRebalanceSnapshot;
+use crate::session::{SessionKey, SessionOrigin};
+use std::time::{Duration, Instant};
+
+/// Translate the wire snapshot into the controller config, filling zero
+/// sub-fields with the controller's built-in defaults.
+pub(super) fn rebalance_config_from_snapshot(
+    snap: CoSFlowRebalanceSnapshot,
+) -> RebalanceConfig {
+    let defaults = RebalanceConfig::default();
+    let imbalance_threshold = if snap.imbalance_threshold_percent == 0 {
+        defaults.imbalance_threshold
+    } else {
+        snap.imbalance_threshold_percent as f64 / 100.0
+    };
+    let rebalance_interval_secs = if snap.rebalance_interval_secs == 0 {
+        defaults.rebalance_interval_secs
+    } else {
+        snap.rebalance_interval_secs as u64
+    };
+    let max_rules = if snap.max_rules == 0 {
+        defaults.max_rules
+    } else {
+        snap.max_rules
+    };
+    RebalanceConfig {
+        imbalance_threshold,
+        rebalance_interval_secs,
+        max_rules,
+    }
+}
+
+/// Per-worker ack-barrier timeout. Mirrors the session-export ack deadline
+/// shape (`ha.rs`) but shorter — a move must commit within one cadence.
+const REBALANCE_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+const REBALANCE_ACK_POLL: Duration = Duration::from_millis(2);
+
+impl super::Coordinator {
+    /// Reconcile the rebalance config on a snapshot apply. On disable, tear
+    /// down every live controller first (reverse-barrier any still-live move,
+    /// then delete its HW rule) so no orphan rule survives the config change.
+    pub(in crate::afxdp) fn reconcile_rebalance_config(
+        &mut self,
+        new_config: Option<RebalanceConfig>,
+    ) {
+        let now_changed = self.rebalance_config != new_config;
+        if new_config.is_none() && !self.rebalance_controllers.is_empty() {
+            // Disabled: drain + tear down every controller.
+            let ifindexes: Vec<i32> = self.rebalance_controllers.keys().copied().collect();
+            for ifindex in ifindexes {
+                self.teardown_rebalance_controller(ifindex);
+            }
+        }
+        self.rebalance_config = new_config;
+        if now_changed {
+            // Config churn (threshold/interval/budget) rebuilds controllers
+            // lazily on the next tick with the new config; tear the old ones
+            // down so they pick up the new budget/threshold cleanly.
+            if new_config.is_some() && !self.rebalance_controllers.is_empty() {
+                let ifindexes: Vec<i32> =
+                    self.rebalance_controllers.keys().copied().collect();
+                for ifindex in ifindexes {
+                    self.teardown_rebalance_controller(ifindex);
+                }
+            }
+        }
+        // Reset the byte-rate sampling window so the first tick after a config
+        // change does not see a bogus huge delta.
+        self.rebalance_last_tx_bytes.clear();
+    }
+
+    /// Tear down one interface's controller: reverse-barrier its live moves,
+    /// delete its rules, drop the socket. `is_live_on_new` cannot be known
+    /// cheaply here, so we conservatively treat every ledger entry as live
+    /// (the reverse barrier is idempotent and safe for an already-dead flow).
+    fn teardown_rebalance_controller(&mut self, ifindex: i32) {
+        let Some(mut controller) = self.rebalance_controllers.remove(&ifindex) else {
+            return;
+        };
+        let socket_ptr: *const NtupleSocket = controller.socket();
+        // SAFETY: the controller owns the socket for the duration of teardown;
+        // we only read it through the transport. `self` (for the barrier) and
+        // the socket do not alias mutably.
+        let mut tx = CoordinatorBarrierTransport {
+            coord: self,
+            socket: unsafe { &*socket_ptr },
+        };
+        controller.teardown_all(&mut tx, |_w, _k| true);
+    }
+
+    /// #1748: shutdown teardown — delete every installed ntuple rule with no
+    /// barrier. Safe only at process/dataplane shutdown (no live flow to hand
+    /// back). Uses the controller's own ledger via a plain-delete teardown.
+    pub(in crate::afxdp) fn teardown_all_rebalance_rules_plain(&mut self) {
+        let ifindexes: Vec<i32> = self.rebalance_controllers.keys().copied().collect();
+        for ifindex in ifindexes {
+            let Some(mut controller) = self.rebalance_controllers.remove(&ifindex) else {
+                continue;
+            };
+            let socket_ptr: *const NtupleSocket = controller.socket();
+            // SAFETY: controller owns the socket for the teardown; the no-op
+            // barrier transport only reads it.
+            let mut tx = CoordinatorBarrierTransport {
+                coord: self,
+                socket: unsafe { &*socket_ptr },
+            };
+            // is_live_on_new = false => plain delete for every entry.
+            controller.teardown_all(&mut tx, |_w, _k| false);
+        }
+        self.rebalance_last_tx_bytes.clear();
+    }
+
+    /// Drive one controller tick at the status cadence. Default-OFF fast path:
+    /// a single None check. When enabled, samples per-worker byte-rate over
+    /// the window, groups workers + flows by ifindex, lazily constructs the
+    /// per-ifindex controller (opening its ntuple socket once), and runs the
+    /// barriered move.
+    pub fn tick_rebalance(&mut self) {
+        let Some(config) = self.rebalance_config else {
+            return;
+        };
+        let now_ns = monotonic_nanos();
+        let now_secs = now_ns / 1_000_000_000;
+
+        // 1. Per-worker byte-rate over the window, grouped by the ifindex each
+        //    worker's binding is bound to.
+        let mut per_iface_workers: BTreeMap<i32, Vec<WorkerByteRate>> = BTreeMap::new();
+        let mut worker_ifindex: BTreeMap<u32, i32> = BTreeMap::new();
+        for (&worker_id, live) in &self.workers.live {
+            let ifindex = live.socket_ifindex();
+            if ifindex <= 0 {
+                continue;
+            }
+            let queue_id = live.socket_queue_id();
+            let tx_bytes = live.tx_bytes();
+            let rate = match self.rebalance_last_tx_bytes.get(&worker_id) {
+                Some(&(prev_bytes, prev_ns)) if now_ns > prev_ns => {
+                    let dt = (now_ns - prev_ns) as f64 / 1_000_000_000.0;
+                    if dt > 0.0 {
+                        (tx_bytes.saturating_sub(prev_bytes)) as f64 / dt
+                    } else {
+                        0.0
+                    }
+                }
+                _ => 0.0,
+            };
+            self.rebalance_last_tx_bytes
+                .insert(worker_id, (tx_bytes, now_ns));
+            worker_ifindex.insert(worker_id, ifindex);
+            per_iface_workers
+                .entry(ifindex)
+                .or_default()
+                .push(WorkerByteRate { worker_id, queue_id, byte_rate: rate });
+        }
+
+        // 2. Per-flow samples (5-tuple key + worker + byte-rate) grouped by
+        //    ifindex, from the flow-worker map telemetry.
+        let mut per_iface_flows: BTreeMap<i32, Vec<FlowSample>> = BTreeMap::new();
+        let (rows, _truncated) = self.flow_worker_map();
+        for row in rows {
+            // Only forward-direction flows on the steered ifindex with a
+            // resolvable 5-tuple. The flow-worker row carries observed_bytes
+            // over the window for byte-rate-aware selection.
+            let ifindex = row.ifindex;
+            if ifindex <= 0 || !per_iface_workers.contains_key(&ifindex) {
+                continue;
+            }
+            let Some(key) = session_key_from_tuple(&row.session_key) else {
+                continue;
+            };
+            per_iface_flows.entry(ifindex).or_default().push(FlowSample {
+                key,
+                worker_id: row.worker_id,
+                byte_rate: row.observed_bytes as f64,
+            });
+        }
+
+        // 3. Tick each steered interface's controller.
+        let ifindexes: Vec<i32> = per_iface_workers.keys().copied().collect();
+        for ifindex in ifindexes {
+            let workers = per_iface_workers.remove(&ifindex).unwrap_or_default();
+            let flows = per_iface_flows.remove(&ifindex).unwrap_or_default();
+            if workers.len() < 2 {
+                continue;
+            }
+            if !self.rebalance_controllers.contains_key(&ifindex) {
+                // Lazily construct the controller + open the ntuple socket the
+                // first time we see a steerable interface. Failure to open is
+                // non-fatal: log once and skip (the NIC may not support flow
+                // steering — the default path is unaffected).
+                // The interface's current kernel netdev name. xpfd renames
+                // interfaces to their vSRX names at startup, so `ifindex_to_name`
+                // is the live kernel name ethtool ioctls address.
+                let Some(ifname) = self.forwarding.ifindex_to_name.get(&ifindex).cloned()
+                else {
+                    continue;
+                };
+                match NtupleSocket::open(&ifname) {
+                    Ok(sock) => {
+                        self.rebalance_controllers
+                            .insert(ifindex, RebalanceController::new(config, sock));
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "xpf-rebalance: cannot open ntuple socket on {ifname} (ifindex {ifindex}): {e} — skipping"
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            let input = RebalanceTickInput { ifindex, workers, flows, now_secs };
+            // Take the controller out so the barrier transport can borrow
+            // `self` mutably without aliasing the controller. Put it back.
+            let mut controller = self.rebalance_controllers.remove(&ifindex).unwrap();
+            let socket_ptr: *const NtupleSocket = controller.socket();
+            let outcome = {
+                // SAFETY: the controller (and its socket) is owned here for the
+                // tick; the transport borrows `self` for command queues + the
+                // socket by shared ref. They do not alias mutably.
+                let mut tx = CoordinatorBarrierTransport {
+                    coord: self,
+                    socket: unsafe { &*socket_ptr },
+                };
+                controller.tick(&input, &mut tx)
+            };
+            if let Some(mv) = outcome {
+                slog_debug_rebalance_move(ifindex, &mv);
+            }
+            self.rebalance_controllers.insert(ifindex, controller);
+        }
+    }
+
+    /// Snapshot the per-interface rebalance metrics for the Prometheus
+    /// collector. Returns (ifindex, metrics) for every live controller.
+    pub fn rebalance_metrics(
+        &self,
+    ) -> Vec<(i32, crate::afxdp::rebalance::RebalanceMetrics)> {
+        self.rebalance_controllers
+            .iter()
+            .map(|(&ifindex, c)| (ifindex, c.metrics().clone()))
+            .collect()
+    }
+
+    /// Build the wire status rows for the Prometheus collector. Empty when no
+    /// controller is live (knob off).
+    pub fn flow_rebalance_status(&self) -> Vec<crate::protocol::FlowRebalanceStatus> {
+        self.rebalance_controllers
+            .iter()
+            .map(|(&ifindex, c)| {
+                let m = c.metrics();
+                let moves_skipped = m
+                    .moves_skipped
+                    .iter()
+                    .map(|(reason, count)| (reason.as_str().to_string(), *count))
+                    .collect();
+                crate::protocol::FlowRebalanceStatus {
+                    ifindex,
+                    rules_active: m.rules_active,
+                    installs_total: m.installs_total,
+                    deletes_total: m.deletes_total,
+                    moves_skipped,
+                    worker_byterate_cov: m.worker_byterate_cov,
+                }
+            })
+            .collect()
+    }
+
+    /// Send a single rebalance WorkerCommand to `worker_id` and block until
+    /// its structured ack confirms the EXACT key reached `expected` (or until
+    /// the deadline). Returns the ack's `result && origin == expected`.
+    fn barrier_command(
+        &self,
+        worker_id: u32,
+        key: &SessionKey,
+        expected: SessionOrigin,
+        make_cmd: impl FnOnce(u64, SessionKey) -> WorkerCommand,
+    ) -> bool {
+        let Some(handle) = self.workers.handles.get(&worker_id) else {
+            return false;
+        };
+        // Monotonic per-worker seq: reuse the rebalance_ack_seq as the
+        // generator base + 1 so each command has a strictly-increasing seq the
+        // worker echoes back.
+        let seq = handle.rebalance_ack_seq.load(Ordering::Acquire).saturating_add(1);
+        {
+            let Ok(mut pending) = handle.commands.lock() else {
+                return false;
+            };
+            pending.push_back(make_cmd(seq, key.clone()));
+        }
+        let deadline = Instant::now() + REBALANCE_ACK_TIMEOUT;
+        loop {
+            if handle.rebalance_ack_seq.load(Ordering::Acquire) >= seq {
+                // Read the structured slot and confirm key + origin.
+                if let Ok(slot) = handle.rebalance_ack.lock() {
+                    if let Some(ack) = slot.as_ref() {
+                        if ack.seq >= seq {
+                            return ack_confirms(ack, key, expected);
+                        }
+                    }
+                }
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(REBALANCE_ACK_POLL);
+        }
+    }
+}
+
+/// Confirm a structured ack matches the expected key + origin.
+fn ack_confirms(ack: &RebalanceAck, key: &SessionKey, expected: SessionOrigin) -> bool {
+    ack.result && &ack.key == key && ack.origin == Some(expected)
+}
+
+/// The Coordinator-backed BarrierTransport: drives the worker command queues
+/// + ack slots for the ownership-transfer barrier, and programs the NIC via
+/// the per-interface ntuple socket.
+struct CoordinatorBarrierTransport<'a> {
+    coord: &'a super::Coordinator,
+    socket: &'a NtupleSocket,
+}
+
+impl BarrierTransport for CoordinatorBarrierTransport<'_> {
+    fn promote(&mut self, worker_id: u32, key: &SessionKey) -> bool {
+        self.coord.barrier_command(
+            worker_id,
+            key,
+            SessionOrigin::RebalancedOwner,
+            |seq, key| WorkerCommand::PromoteRebalanced { seq, key },
+        )
+    }
+    fn demote(&mut self, worker_id: u32, key: &SessionKey) -> bool {
+        self.coord.barrier_command(
+            worker_id,
+            key,
+            SessionOrigin::RebalancedOut,
+            |seq, key| WorkerCommand::DemoteRebalanced { seq, key },
+        )
+    }
+    fn restore_owner(&mut self, worker_id: u32, key: &SessionKey) -> bool {
+        self.coord.barrier_command(
+            worker_id,
+            key,
+            SessionOrigin::ForwardFlow,
+            |seq, key| WorkerCommand::RestoreRebalancedOwner { seq, key },
+        )
+    }
+    fn demote_replica(&mut self, worker_id: u32, key: &SessionKey) -> bool {
+        self.coord.barrier_command(
+            worker_id,
+            key,
+            SessionOrigin::WorkerLocalImport,
+            |seq, key| WorkerCommand::DemoteRebalancedReplica { seq, key },
+        )
+    }
+    fn install_rule(&mut self, flow: &FlowSpec5Tuple, queue: u32) -> std::io::Result<u32> {
+        self.socket.insert_rule(flow, queue)
+    }
+    fn delete_rule(&mut self, loc: u32) -> std::io::Result<()> {
+        self.socket.delete_rule(loc)
+    }
+}
+
+/// Translate a `FlowTupleStatus` (the flow-worker map's serialized 5-tuple)
+/// back into a `SessionKey`. Returns None if the addresses don't parse.
+fn session_key_from_tuple(t: &crate::protocol::FlowTupleStatus) -> Option<SessionKey> {
+    use std::net::IpAddr;
+    let src_ip: IpAddr = t.src_ip.parse().ok()?;
+    let dst_ip: IpAddr = t.dst_ip.parse().ok()?;
+    Some(SessionKey {
+        addr_family: t.addr_family,
+        protocol: t.protocol,
+        src_ip,
+        dst_ip,
+        src_port: t.src_port,
+        dst_port: t.dst_port,
+    })
+}
+
+/// Per-move debug log (slog.Debug-equivalent — fires only on the rare event
+/// of an actual move, never per-tick). Goes to journald via stderr.
+fn slog_debug_rebalance_move(
+    ifindex: i32,
+    mv: &crate::afxdp::rebalance::MoveOutcome,
+) {
+    eprintln!(
+        "xpf-rebalance: moved flow {:?} ifindex={ifindex} worker {} -> {} (rule loc {})",
+        flow_spec_from_key(&mv.key),
+        mv.old_worker,
+        mv.new_worker,
+        mv.loc,
+    );
+}

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -13,7 +13,7 @@
 use super::*;
 use crate::afxdp::rebalance::{
     BarrierTransport, FlowSample, RebalanceConfig, RebalanceController, RebalanceTickInput,
-    WorkerByteRate, cumulative_to_rate, flow_spec_from_key, NtupleSocket,
+    WorkerByteRate, cumulative_to_rate, debug_log_rebalance, flow_spec_from_key, NtupleSocket,
 };
 use crate::afxdp::rebalance::ntuple::FlowSpec5Tuple;
 use crate::afxdp::RebalanceAck;
@@ -265,12 +265,32 @@ impl super::Coordinator {
             // First observation of this flow => no rate yet (a brand-new flow's
             // first-tick cumulative is not a window rate). cumulative_to_rate
             // also handles a cumulative reset on re-home via saturating_sub.
-            let rate = match self.rebalance_last_flow_bytes.get(&key) {
-                Some(&(prev_bytes, prev_ns)) => {
+            let prev_sample = self.rebalance_last_flow_bytes.get(&key).copied();
+            let rate = match prev_sample {
+                Some((prev_bytes, prev_ns)) => {
                     cumulative_to_rate(cumulative, prev_bytes, now_ns, prev_ns)
                 }
                 None => 0.0,
             };
+            // #1748 live BUG #1 instrumentation: ground-truth per-flow rate
+            // sourcing. ONE line per flow per eval, gated to `debug-log` builds
+            // (compiled out of release). Shows whether observed_bytes advances
+            // across evals (rate > 0) or the cumulative is stuck / resetting
+            // (prev shown so a reset is visible as cur < prev). Read via
+            // `journalctl -u xpfd | grep REBALANCE_FLOW`.
+            debug_log_rebalance!(
+                "REBALANCE_FLOW ifindex={} worker={} proto={} {}:{}->{}:{} cur_bytes={} prev={:?} rate={:.3e}",
+                ifindex,
+                row.worker_id,
+                key.protocol,
+                key.src_ip,
+                key.src_port,
+                key.dst_ip,
+                key.dst_port,
+                cumulative,
+                prev_sample,
+                rate,
+            );
             self.rebalance_last_flow_bytes
                 .insert(key.clone(), (cumulative, now_ns));
             seen_flow_keys.insert(key.clone());
@@ -292,6 +312,23 @@ impl super::Coordinator {
             let flows = per_iface_flows.remove(&ifindex).unwrap_or_default();
             if workers.len() < 2 {
                 continue;
+            }
+            // #1748 live BUG #1 instrumentation: ground-truth per-EVAL summary
+            // of the per-worker rate vector + how many flows have a positive
+            // rate. Gated to `debug-log` builds. Read via
+            // `journalctl -u xpfd | grep REBALANCE_EVAL`.
+            #[cfg(feature = "debug-log")]
+            {
+                let worker_rates: Vec<(u32, f64)> =
+                    workers.iter().map(|w| (w.worker_id, w.byte_rate)).collect();
+                let flows_positive = flows.iter().filter(|f| f.byte_rate > 0.0).count();
+                debug_log_rebalance!(
+                    "REBALANCE_EVAL ifindex={} workers={:?} flows={} flows_with_positive_rate={}",
+                    ifindex,
+                    worker_rates,
+                    flows.len(),
+                    flows_positive,
+                );
             }
             if !self.rebalance_controllers.contains_key(&ifindex) {
                 // Lazily construct the controller + open the ntuple socket the

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -202,6 +202,14 @@ impl super::Coordinator {
             let Some(key) = session_key_from_tuple(&row.session_key) else {
                 continue;
             };
+            // ntuple rules only support TCP and UDP; skip other protocols
+            // (e.g. ICMP) so flow_spec_from_key never misencodes them as UDP
+            // and we never transfer ownership without a matching HW rule.
+            if key.protocol != super::super::PROTO_TCP
+                && key.protocol != super::super::PROTO_UDP
+            {
+                continue;
+            }
             let cumulative = row.observed_bytes;
             // First observation of this flow => no rate yet (a brand-new flow's
             // first-tick cumulative is not a window rate). cumulative_to_rate
@@ -350,10 +358,12 @@ impl super::Coordinator {
         let Some(handle) = self.workers.handles.get(&worker_id) else {
             return false;
         };
-        // Monotonic per-worker seq: reuse the rebalance_ack_seq as the
-        // generator base + 1 so each command has a strictly-increasing seq the
-        // worker echoes back.
-        let seq = handle.rebalance_ack_seq.load(Ordering::Acquire).saturating_add(1);
+        // Use the dedicated coordinator-side command seq generator (not the
+        // ack seq) so each command gets a unique, strictly-increasing seq
+        // even if a previous command timed out without being acked (in which
+        // case rebalance_ack_seq would not have advanced, causing a collision
+        // if we derived the new seq from it).
+        let seq = handle.rebalance_cmd_seq.fetch_add(1, Ordering::Relaxed) + 1;
         {
             let Ok(mut pending) = handle.commands.lock() else {
                 return false;
@@ -366,7 +376,11 @@ impl super::Coordinator {
                 // Read the structured slot and confirm key + origin.
                 if let Ok(slot) = handle.rebalance_ack.lock() {
                     if let Some(ack) = slot.as_ref() {
-                        if ack.seq >= seq {
+                        // Only accept an exact-seq match. If ack.seq > seq
+                        // the slot was overwritten by a later command before
+                        // we polled; keep waiting until the deadline rather
+                        // than returning the wrong ack's result.
+                        if ack.seq == seq {
                             return ack_confirms(ack, key, expected);
                         }
                     }

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -55,6 +55,28 @@ const REBALANCE_ACK_TIMEOUT: Duration = Duration::from_secs(2);
 const REBALANCE_ACK_POLL: Duration = Duration::from_millis(2);
 
 impl super::Coordinator {
+    /// #1748 live BUG #2: translate a config snapshot's `class_of_service.
+    /// flow_rebalance` block into the controller config and reconcile. This is
+    /// the SINGLE entry point both snapshot-apply paths call so the knob is
+    /// honored on a live `commit` (same-plan `refresh_runtime_snapshot`) and at
+    /// boot / binding-plan-change (`apply_snapshot`) identically. Before this
+    /// fix, only `apply_snapshot` (the binding-plan-change / boot path) called
+    /// `reconcile_rebalance_config`, so a flow-rebalance-only commit — which is
+    /// `same_plan` and routes through `refresh_runtime_snapshot` — never
+    /// constructed or tore down the controller until a daemon restart.
+    pub(in crate::afxdp) fn reconcile_rebalance_from_snapshot(
+        &mut self,
+        snapshot: &crate::ConfigSnapshot,
+    ) {
+        let new_config = snapshot
+            .class_of_service
+            .as_ref()
+            .and_then(|cos| cos.flow_rebalance)
+            .map(rebalance_config_from_snapshot)
+            .filter(|cfg| cfg.is_enabled());
+        self.reconcile_rebalance_config(new_config);
+    }
+
     /// Reconcile the rebalance config on a snapshot apply. On disable, tear
     /// down every live controller first (reverse-barrier any still-live move,
     /// then delete its HW rule) so no orphan rule survives the config change.
@@ -63,6 +85,15 @@ impl super::Coordinator {
         new_config: Option<RebalanceConfig>,
     ) {
         let now_changed = self.rebalance_config != new_config;
+        // #1748 live BUG #2: this is now called on EVERY same-plan snapshot
+        // refresh (every commit), not just config changes, so it MUST be a
+        // no-op when the config is unchanged. Bail early — do not clear the
+        // sampling window (clearing it every commit would re-prime the
+        // baseline and stop a stable >= 1s rate window from ever forming,
+        // re-introducing the BUG #1 epsilon stall).
+        if !now_changed {
+            return;
+        }
         if new_config.is_none() && !self.rebalance_controllers.is_empty() {
             // Disabled: drain + tear down every controller.
             let ifindexes: Vec<i32> = self.rebalance_controllers.keys().copied().collect();
@@ -71,22 +102,21 @@ impl super::Coordinator {
             }
         }
         self.rebalance_config = new_config;
-        if now_changed {
-            // Config churn (threshold/interval/budget) rebuilds controllers
-            // lazily on the next tick with the new config; tear the old ones
-            // down so they pick up the new budget/threshold cleanly.
-            if new_config.is_some() && !self.rebalance_controllers.is_empty() {
-                let ifindexes: Vec<i32> =
-                    self.rebalance_controllers.keys().copied().collect();
-                for ifindex in ifindexes {
-                    self.teardown_rebalance_controller(ifindex);
-                }
+        // Config churn (threshold/interval/budget) rebuilds controllers lazily
+        // on the next tick with the new config; tear the old ones down so they
+        // pick up the new budget/threshold cleanly.
+        if new_config.is_some() && !self.rebalance_controllers.is_empty() {
+            let ifindexes: Vec<i32> = self.rebalance_controllers.keys().copied().collect();
+            for ifindex in ifindexes {
+                self.teardown_rebalance_controller(ifindex);
             }
         }
         // Reset the byte-rate sampling window so the first tick after a config
-        // change does not see a bogus huge delta.
+        // change does not see a bogus huge delta, and re-arm the eval timer so
+        // a freshly-enabled controller evaluates on its next tick.
         self.rebalance_last_tx_bytes.clear();
         self.rebalance_last_flow_bytes.clear();
+        self.rebalance_last_eval_ns = 0;
     }
 
     /// Tear down one interface's controller: reverse-barrier its live moves,
@@ -137,6 +167,7 @@ impl super::Coordinator {
         self.rebalance_sockets.clear();
         self.rebalance_last_tx_bytes.clear();
         self.rebalance_last_flow_bytes.clear();
+        self.rebalance_last_eval_ns = 0;
     }
 
     /// Drive one controller tick at the status cadence. Default-OFF fast path:
@@ -150,6 +181,26 @@ impl super::Coordinator {
         };
         let now_ns = monotonic_nanos();
         let now_secs = now_ns / 1_000_000_000;
+
+        // #1748 live BUG #1: evaluate at the rebalance_interval cadence, NOT
+        // every status-poll tick (~24/s). The per-flow byte-rate signal
+        // (observed_bytes from the flow-worker map) only refreshes
+        // ~every 65ms/65k-packets, so sampling every ~42ms saw a stale
+        // snapshot -> per-flow rate delta ~0 -> projected CoV improvement
+        // below epsilon -> EVERY candidate skipped as "epsilon" and no move
+        // was ever made (the live CoV gate observed installs_total=0 with the
+        // epsilon counter climbing ~24/s). Gating the SAMPLE here makes the
+        // rate window span the full rebalance_interval (>= 1s), which is
+        // stable and spans several snapshot refreshes. The first call primes
+        // the baseline sample (rate 0, no move) and arms the timer; the next
+        // call >= interval later computes a real rate.
+        let eval_interval_ns = config.rebalance_interval_secs.max(1) * 1_000_000_000;
+        if self.rebalance_last_eval_ns != 0
+            && now_ns.saturating_sub(self.rebalance_last_eval_ns) < eval_interval_ns
+        {
+            return;
+        }
+        self.rebalance_last_eval_ns = now_ns;
 
         // 1. Per-worker byte-rate over the window, grouped by the ifindex each
         //    worker's binding is bound to.

--- a/userspace-dp/src/afxdp/coordinator/rebalance.rs
+++ b/userspace-dp/src/afxdp/coordinator/rebalance.rs
@@ -216,6 +216,19 @@ impl super::Coordinator {
                 };
                 match NtupleSocket::open(&ifname) {
                     Ok(sock) => {
+                        // #1748 AGY minor: clear any orphan ntuple rules left
+                        // by a previous (crashed) daemon run on this interface
+                        // before we start installing fresh ones, so stale HW
+                        // rules cannot accumulate or exhaust the rule-table cap.
+                        match sock.reconcile_orphans() {
+                            Ok(0) => {}
+                            Ok(n) => eprintln!(
+                                "xpf-rebalance: cleared {n} orphan ntuple rule(s) on {ifname} (ifindex {ifindex}) at startup"
+                            ),
+                            Err(e) => eprintln!(
+                                "xpf-rebalance: startup orphan reconcile on {ifname} (ifindex {ifindex}) failed: {e}"
+                            ),
+                        }
                         self.rebalance_controllers
                             .insert(ifindex, RebalanceController::new(config, sock));
                     }

--- a/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
@@ -170,6 +170,13 @@ pub(super) fn bring_up_workers(
         let stop = Arc::new(AtomicBool::new(false));
         let heartbeat = Arc::new(AtomicU64::new(monotonic_nanos()));
         let session_export_ack = Arc::new(AtomicU64::new(0));
+        // #1748: structured rebalance command ack slot + lock-free published
+        // seq. Allocated even when the rebalance controller is disabled — the
+        // worker only ever writes them when it applies a Promote/Demote
+        // rebalance command, which the controller only enqueues when the knob
+        // is on, so the default-OFF path is byte-identical (slots stay zero).
+        let rebalance_ack = Arc::new(Mutex::new(None::<crate::afxdp::RebalanceAck>));
+        let rebalance_ack_seq = Arc::new(AtomicU64::new(0));
         let cos_status = Arc::new(ArcSwap::from_pointee(Vec::new()));
         let commands = worker_command_queues
             .get(&worker_id)
@@ -189,6 +196,8 @@ pub(super) fn bring_up_workers(
         let stop_clone = stop.clone();
         let heartbeat_clone = heartbeat.clone();
         let session_export_ack_clone = session_export_ack.clone();
+        let rebalance_ack_clone = rebalance_ack.clone();
+        let rebalance_ack_seq_clone = rebalance_ack_seq.clone();
         let commands_clone = commands.clone();
         let peer_commands_clone = worker_command_queues
             .iter()
@@ -257,6 +266,8 @@ pub(super) fn bring_up_workers(
                     stop_clone,
                     heartbeat_clone,
                     session_export_ack_clone,
+                    rebalance_ack_clone,
+                    rebalance_ack_seq_clone,
                     worker_poll_mode,
                     dnat_fds,
                     shared_fabrics,
@@ -288,6 +299,8 @@ pub(super) fn bring_up_workers(
                         heartbeat,
                         commands,
                         session_export_ack,
+                        rebalance_ack,
+                        rebalance_ack_seq,
                         cos_status,
                         runtime_atomics,
                         cold_path_atomics,

--- a/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
@@ -177,6 +177,7 @@ pub(super) fn bring_up_workers(
         // is on, so the default-OFF path is byte-identical (slots stay zero).
         let rebalance_ack = Arc::new(Mutex::new(None::<crate::afxdp::RebalanceAck>));
         let rebalance_ack_seq = Arc::new(AtomicU64::new(0));
+        let rebalance_cmd_seq = Arc::new(AtomicU64::new(0));
         let cos_status = Arc::new(ArcSwap::from_pointee(Vec::new()));
         let commands = worker_command_queues
             .get(&worker_id)
@@ -301,6 +302,7 @@ pub(super) fn bring_up_workers(
                         session_export_ack,
                         rebalance_ack,
                         rebalance_ack_seq,
+                        rebalance_cmd_seq,
                         cos_status,
                         runtime_atomics,
                         cold_path_atomics,

--- a/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
@@ -50,6 +50,18 @@ pub(super) fn apply_snapshot(
         fib_generation: snapshot.fib_generation,
     };
     coord.policy_counters.reconcile_rules(&snapshot.policies);
+    // #1748: reconcile the opt-in rebalance knob. Translate the wire snapshot
+    // into the controller's RebalanceConfig (filling zero sub-fields with the
+    // controller defaults). When the knob transitions to absent/disabled, tear
+    // down every live controller (reverse-barriering still-live moves) so no
+    // orphan HW rules survive a config change.
+    let new_rebalance_config = snapshot
+        .class_of_service
+        .as_ref()
+        .and_then(|cos| cos.flow_rebalance)
+        .map(super::super::rebalance::rebalance_config_from_snapshot)
+        .filter(|cfg| cfg.is_enabled());
+    coord.reconcile_rebalance_config(new_rebalance_config);
     coord.forwarding = new_forwarding;
     coord.shared_validation.store(Arc::new(coord.validation));
     coord

--- a/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
@@ -50,18 +50,12 @@ pub(super) fn apply_snapshot(
         fib_generation: snapshot.fib_generation,
     };
     coord.policy_counters.reconcile_rules(&snapshot.policies);
-    // #1748: reconcile the opt-in rebalance knob. Translate the wire snapshot
-    // into the controller's RebalanceConfig (filling zero sub-fields with the
-    // controller defaults). When the knob transitions to absent/disabled, tear
-    // down every live controller (reverse-barriering still-live moves) so no
-    // orphan HW rules survive a config change.
-    let new_rebalance_config = snapshot
-        .class_of_service
-        .as_ref()
-        .and_then(|cos| cos.flow_rebalance)
-        .map(super::super::rebalance::rebalance_config_from_snapshot)
-        .filter(|cfg| cfg.is_enabled());
-    coord.reconcile_rebalance_config(new_rebalance_config);
+    // #1748: reconcile the opt-in rebalance knob. Shared with the same-plan
+    // `refresh_runtime_snapshot` path (#1748 live BUG #2) so a live commit and
+    // boot reconcile the knob identically. Enable constructs the controller;
+    // disable tears it down (reverse-barriering still-live moves) so no orphan
+    // HW rule survives a config change.
+    coord.reconcile_rebalance_from_snapshot(snapshot);
     coord.forwarding = new_forwarding;
     coord.shared_validation.store(Arc::new(coord.validation));
     coord

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -1823,3 +1823,45 @@ fn aggregate_cos_waterfill_min_max_sentinel_when_no_candidate() {
     );
     assert_eq!(aggregated[0].waterfill_epochs, 777);
 }
+
+// #1748 review-r3 (soundness): exercise the rebalance teardown wiring that
+// previously aliased the controller's socket through a raw pointer during a
+// &mut self call. With the socket split into a separate Coordinator map, this
+// path is borrow-checked. The test constructs a controller + a real loopback
+// ntuple socket in the two lockstep maps, then runs the plain teardown and
+// asserts both maps are cleared with no panic / no aliasing UB. (An empty
+// ledger drives no worker barrier commands, so no live workers are needed.)
+#[test]
+fn rebalance_plain_teardown_clears_both_maps_soundly() {
+    let mut coordinator = Coordinator::new();
+    // Open a real ethtool socket on the loopback device. If the sandbox denies
+    // it, skip — the soundness property under test is the borrow structure,
+    // which still compiles regardless.
+    let Ok(sock) = crate::afxdp::rebalance::NtupleSocket::open("lo") else {
+        eprintln!("rebalance_plain_teardown_clears_both_maps_soundly: skipped (no lo ethtool socket)");
+        return;
+    };
+    let ifindex = 1;
+    coordinator.rebalance_sockets.insert(ifindex, sock);
+    coordinator.rebalance_controllers.insert(
+        ifindex,
+        crate::afxdp::rebalance::RebalanceController::new(
+            crate::afxdp::rebalance::RebalanceConfig::default(),
+        ),
+    );
+    assert_eq!(coordinator.rebalance_controllers.len(), 1);
+    assert_eq!(coordinator.rebalance_sockets.len(), 1);
+
+    // The formerly-unsafe path. Must not panic and must clear both maps in
+    // lockstep.
+    coordinator.teardown_all_rebalance_rules_plain();
+
+    assert!(
+        coordinator.rebalance_controllers.is_empty(),
+        "controllers cleared on plain teardown"
+    );
+    assert!(
+        coordinator.rebalance_sockets.is_empty(),
+        "sockets cleared on plain teardown (no fd leak)"
+    );
+}

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -1991,3 +1991,148 @@ fn tick_rebalance_evaluates_at_interval_cadence_not_every_tick() {
         "default-OFF tick_rebalance is a no-op"
     );
 }
+
+// #1748 live BUG (r6): the controller's per-worker rate vector was keyed by
+// binding SLOT (the `workers.live` map key) while the flow-worker-map rows
+// carry the real `binding.worker_id`. With slot != worker_id (the norm),
+// select_move's `f.worker_id == hottest.worker_id` never matched, so the
+// hottest worker always had ZERO candidate flows -> NoEligibleFlow -> zero
+// installs under load even though binding_active_flow_count showed flows.
+//
+// This test reproduces that id-space mismatch (slot deliberately != worker_id)
+// with a real per-worker tx_bytes imbalance and a populated flow-worker map
+// whose rows carry the real worker_ids, then drives tick_rebalance and asserts
+// the controller does NOT record NoEligibleFlow for the steered ifindex — i.e.
+// the slot->worker_id join now lets the flow list match the worker rate vector.
+#[test]
+fn tick_rebalance_joins_flows_to_workers_by_real_worker_id_not_slot() {
+    use crate::protocol::{FlowTupleStatus, FlowWorkerStatus};
+    let mut coordinator = Coordinator::new();
+    coordinator.rebalance_config = Some(crate::afxdp::rebalance::RebalanceConfig {
+        imbalance_threshold: 1.30,
+        rebalance_interval_secs: 1,
+        max_rules: 64,
+    });
+    // ifindex 5 maps to loopback so the lazy controller can open a real
+    // ethtool socket; the move attempt is fine — we assert on the skip reason,
+    // not on a committed install (no worker handles => barrier would fail, but
+    // that is BarrierFailed, NOT NoEligibleFlow).
+    let ifindex = 5;
+    if crate::afxdp::rebalance::NtupleSocket::open("lo").is_err() {
+        eprintln!("tick_rebalance_joins...: skipped (no lo ethtool socket)");
+        return;
+    }
+    coordinator.forwarding.ifindex_to_name.insert(ifindex, "lo".to_string());
+
+    // 6 workers on ifindex 5. CRITICAL: slot != worker_id (slot = 100+w,
+    // worker_id = 10+w) — the exact id-space split that broke the join.
+    // tx_bytes give the R1 [2,2,2,1,3,2] partition (worker 14 hottest).
+    let tx_for = |w: u32| -> u64 {
+        match w {
+            14 => 4_200_000_000, // hottest (3 flows)
+            13 => 1_400_000_000, // coolest (1 flow)
+            _ => 2_800_000_000,  // 2 flows each
+        }
+    };
+    let worker_ids = [10u32, 11, 12, 13, 14, 15];
+    for (i, &w) in worker_ids.iter().enumerate() {
+        let slot = 100 + i as u32;
+        let live = std::sync::Arc::new(crate::afxdp::BindingLiveState::new());
+        live.test_set_tx_bytes(tx_for(w));
+        // Flow rows for this worker: rows carry the REAL worker_id (w), as the
+        // live publish path does. Worker 14 gets 3 flows, 13 gets 1, else 2.
+        let nflows = match w { 14 => 3, 13 => 1, _ => 2 };
+        let mut rows = Vec::new();
+        for f in 0..nflows {
+            let sport = (1000 + (w as u16) * 10 + f as u16) as u16;
+            rows.push(FlowWorkerStatus {
+                slot,
+                queue_id: i as u32,
+                worker_id: w,
+                interface: "lo".into(),
+                ifindex,
+                ingress_ifindex: ifindex,
+                session_key: FlowTupleStatus {
+                    addr_family: libc::AF_INET as u8,
+                    protocol: 6,
+                    src_ip: "10.0.61.102".to_string(),
+                    dst_ip: "172.16.80.200".to_string(),
+                    src_port: sport,
+                    dst_port: 5210,
+                },
+                ..Default::default()
+            });
+        }
+        live.test_publish_flow_worker_map(rows);
+        coordinator.workers.live.insert(slot, live);
+        coordinator.workers.identities.insert(
+            slot,
+            BindingIdentity {
+                slot,
+                queue_id: i as u32,
+                worker_id: w,
+                interface: "lo".into(),
+                ifindex,
+            },
+        );
+    }
+
+    // Drive several evals so the rate window fills and the hysteresis dwell
+    // clears, letting the controller actually reach select_move. Each eval
+    // advances every worker's cumulative tx_bytes by one window's worth and
+    // backdates the eval timer so the cadence gate admits the eval.
+    for round in 0..5u64 {
+        for (i, &w) in worker_ids.iter().enumerate() {
+            let slot = 100 + i as u32;
+            if let Some(live) = coordinator.workers.live.get(&slot) {
+                // Cumulative grows by `tx_for(w)` bytes per ~1s window.
+                live.test_set_tx_bytes(tx_for(w).saturating_mul(round + 1));
+            }
+        }
+        // Backdate the prior eval so the >= rebalance_interval gate admits this
+        // one (first round has last_eval == 0 and is admitted unconditionally).
+        if coordinator.rebalance_last_eval_ns != 0 {
+            coordinator.rebalance_last_eval_ns = coordinator
+                .rebalance_last_eval_ns
+                .saturating_sub(2 * 1_000_000_000);
+        }
+        coordinator.tick_rebalance();
+    }
+
+    // The decisive assertion: with the slot->worker_id join fixed, the hottest
+    // worker's flows are visible to the controller, so it does NOT record
+    // NoEligibleFlow. Pre-fix (per-worker vector keyed by slot, flows keyed by
+    // worker_id) EVERY post-dwell eval recorded no_eligible_flow because the
+    // hottest worker (by slot) had no flow with a matching worker_id.
+    let status = coordinator.flow_rebalance_status();
+    let row = status
+        .iter()
+        .find(|s| s.ifindex == ifindex)
+        .expect("a controller exists for the steered ifindex");
+    // Per-worker rates were built (non-degenerate CoV) — proves we got past
+    // sampling regardless of the join.
+    assert!(
+        row.worker_byterate_cov > 0.0,
+        "per-worker rates were built; skips={:?}", row.moves_skipped
+    );
+    // The join is correct iff the controller reached a real move decision
+    // without a NoEligibleFlow skip. (With handles absent the move attempt
+    // fails the ack barrier => BarrierFailed, NOT NoEligibleFlow — either an
+    // install or a BarrierFailed proves select_move found a candidate.)
+    let no_eligible = row.moves_skipped.get("no_eligible_flow").copied().unwrap_or(0);
+    assert_eq!(
+        no_eligible, 0,
+        "slot->worker_id join must make the hottest worker's flows eligible \
+         (no NoEligibleFlow); skips={:?}", row.moves_skipped
+    );
+    let reached_decision = row.installs_total > 0
+        || row.moves_skipped.get("barrier_failed").copied().unwrap_or(0) > 0
+        || row.moves_skipped.get("magnitude").copied().unwrap_or(0) > 0
+        || row.moves_skipped.get("epsilon").copied().unwrap_or(0) > 0;
+    assert!(
+        reached_decision,
+        "controller must reach select_move's move decision (install/barrier/\
+         magnitude/epsilon), proving flows joined to the hottest worker; \
+         skips={:?} installs={}", row.moves_skipped, row.installs_total
+    );
+}

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -1865,3 +1865,129 @@ fn rebalance_plain_teardown_clears_both_maps_soundly() {
         "sockets cleared on plain teardown (no fd leak)"
     );
 }
+
+// #1748 live BUG #2: snapshot-apply reconcile transitions. A flow-rebalance
+// config delivered on a live snapshot must CONSTRUCT the controller (None ->
+// Some) and removing it must TEAR IT DOWN (Some -> None), via the shared
+// reconcile_rebalance_from_snapshot entry point that BOTH the boot path
+// (apply_snapshot) and the same-plan live-commit path (refresh_runtime_snapshot)
+// now call. Before the fix, the same-plan live path never reconciled the knob.
+#[test]
+fn reconcile_rebalance_from_snapshot_constructs_and_tears_down() {
+    let mut coordinator = Coordinator::new();
+
+    // None initially.
+    assert!(coordinator.rebalance_config.is_none(), "off by default");
+
+    // Snapshot WITH flow-rebalance enabled => config constructed.
+    let mut snap_on = crate::ConfigSnapshot::default();
+    snap_on.class_of_service = Some(crate::ClassOfServiceSnapshot {
+        flow_rebalance: Some(crate::protocol::CoSFlowRebalanceSnapshot {
+            imbalance_threshold_percent: 130,
+            rebalance_interval_secs: 1,
+            max_rules: 64,
+        }),
+        ..Default::default()
+    });
+    coordinator.reconcile_rebalance_from_snapshot(&snap_on);
+    assert!(
+        coordinator.rebalance_config.is_some(),
+        "enabling flow-rebalance via snapshot must set the config (None -> Some)"
+    );
+
+    // Re-applying the SAME config is a no-op (idempotent — must not churn).
+    let prev = coordinator.rebalance_config;
+    coordinator.reconcile_rebalance_from_snapshot(&snap_on);
+    assert_eq!(
+        coordinator.rebalance_config, prev,
+        "re-applying identical config is a no-op"
+    );
+
+    // Snapshot WITHOUT flow-rebalance (deleted) => config torn down to None.
+    let mut snap_off = crate::ConfigSnapshot::default();
+    snap_off.class_of_service = Some(crate::ClassOfServiceSnapshot::default());
+    coordinator.reconcile_rebalance_from_snapshot(&snap_off);
+    assert!(
+        coordinator.rebalance_config.is_none(),
+        "deleting flow-rebalance via snapshot must tear the config down (Some -> None)"
+    );
+    assert!(
+        coordinator.rebalance_controllers.is_empty(),
+        "controllers cleared on disable"
+    );
+    assert!(
+        coordinator.rebalance_sockets.is_empty(),
+        "sockets cleared on disable (no fd leak)"
+    );
+
+    // A disabled-threshold snapshot (<= 1.0) must also stay off.
+    let mut snap_invalid = crate::ConfigSnapshot::default();
+    snap_invalid.class_of_service = Some(crate::ClassOfServiceSnapshot {
+        flow_rebalance: Some(crate::protocol::CoSFlowRebalanceSnapshot {
+            imbalance_threshold_percent: 100, // 1.00x => is_enabled() false
+            rebalance_interval_secs: 1,
+            max_rules: 64,
+        }),
+        ..Default::default()
+    });
+    coordinator.reconcile_rebalance_from_snapshot(&snap_invalid);
+    assert!(
+        coordinator.rebalance_config.is_none(),
+        "a threshold of 1.00x must not enable the controller"
+    );
+}
+
+// #1748 live BUG #1: tick_rebalance must only EVALUATE at the rebalance_interval
+// cadence, not every ~24/s status-poll tick. Sampling the per-flow byte-rate
+// every ~42ms saw a stale flow-worker snapshot (rate ~0) and stalled at the
+// epsilon band. This test asserts the eval-cadence gate: back-to-back ticks
+// within the interval do NOT re-arm the eval timestamp; only a tick >= interval
+// later does. (No live workers, so no move is taken — we assert the gate's
+// timing bookkeeping, which is the part that controls the sampling window.)
+#[test]
+fn tick_rebalance_evaluates_at_interval_cadence_not_every_tick() {
+    let mut coordinator = Coordinator::new();
+    coordinator.rebalance_config = Some(
+        crate::afxdp::rebalance::RebalanceConfig {
+            imbalance_threshold: 1.30,
+            rebalance_interval_secs: 1,
+            max_rules: 64,
+        },
+    );
+    // No live workers => no per-iface sampling, but the eval-cadence gate runs
+    // first and updates rebalance_last_eval_ns on an admitted evaluation.
+    assert_eq!(coordinator.rebalance_last_eval_ns, 0, "not evaluated yet");
+
+    // First tick: admitted (last_eval == 0), arms the timer.
+    coordinator.tick_rebalance();
+    let first_eval = coordinator.rebalance_last_eval_ns;
+    assert!(first_eval > 0, "first tick evaluates and arms the timer");
+
+    // Immediate second tick (well under the 1s interval): MUST be gated out —
+    // the eval timestamp must not advance.
+    coordinator.tick_rebalance();
+    assert_eq!(
+        coordinator.rebalance_last_eval_ns, first_eval,
+        "a back-to-back tick within the interval must NOT re-evaluate (BUG #1 gate)"
+    );
+
+    // A tick after the interval has elapsed re-evaluates. Simulate elapsed time
+    // by backdating the last-eval stamp by > 1s.
+    coordinator.rebalance_last_eval_ns =
+        first_eval.saturating_sub(2 * 1_000_000_000);
+    let backdated = coordinator.rebalance_last_eval_ns;
+    coordinator.tick_rebalance();
+    assert!(
+        coordinator.rebalance_last_eval_ns > backdated,
+        "a tick >= interval after the last eval must re-evaluate"
+    );
+
+    // Default-OFF: with no config, tick is a pure no-op (timer never moves).
+    coordinator.rebalance_config = None;
+    let before = coordinator.rebalance_last_eval_ns;
+    coordinator.tick_rebalance();
+    assert_eq!(
+        coordinator.rebalance_last_eval_ns, before,
+        "default-OFF tick_rebalance is a no-op"
+    );
+}

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -559,7 +559,8 @@ fn refresh_runtime_snapshot_rebuilds_cos_owner_worker_map_from_identities() {
         dscp_classifiers: vec![],
         ieee8021_classifiers: vec![],
         dscp_rewrite_rules: vec![],
-    });
+            flow_rebalance: None,
+        });
 
     coordinator.refresh_runtime_snapshot(&snapshot);
 

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -182,6 +182,7 @@ fn build_cos_state_translates_scheduler_map_entries() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -246,6 +247,7 @@ fn build_cos_state_resolves_percent_buffer_size_from_interface_burst_pool() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -301,6 +303,7 @@ fn build_cos_state_prefers_legacy_byte_buffer_when_both_fields_present() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -383,6 +386,7 @@ fn build_cos_state_propagates_surplus_sharing_from_snapshot() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -476,6 +480,7 @@ fn build_cos_state_derives_exact_queue_default_burst_from_queue_rate() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -534,6 +539,7 @@ fn build_cos_state_uses_effective_transmit_rate_for_surplus_weight() {
                     scheduler: "be-sched".into(),
                 }],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -584,6 +590,7 @@ fn build_cos_state_marks_no_rate_scheduler_map_queue_residual_only() {
                     scheduler: "be-sched".into(),
                 }],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1024,6 +1031,7 @@ fn build_cos_state_includes_zero_shaping_rate_interface() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1079,6 +1087,7 @@ fn build_cos_state_zero_shaping_rate_queue_inherits_transparent() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1137,6 +1146,7 @@ fn build_cos_state_no_rate_exact_surplus_equal_flow_is_residual_only() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1194,6 +1204,7 @@ fn build_cos_state_mixed_zero_and_nonzero_shaping_rate() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1255,6 +1266,7 @@ fn build_cos_state_skips_interface_with_no_cos_config() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1316,7 +1328,8 @@ fn build_cos_state_admits_each_cos_field_in_isolation() {
                 dscp_value: 0,
             }],
         }],
-    };
+            flow_rebalance: None,
+        };
     let cases: &[(i32, &str, InterfaceSnapshot)] = &[
         (
             201,
@@ -1456,7 +1469,8 @@ fn build_cos_state_skips_interface_with_unresolvable_named_references() {
                 dscp_value: 0,
             }],
         }],
-    };
+            flow_rebalance: None,
+        };
     // Each typo'd reference (one CoS field non-empty but unresolvable)
     // must NOT admit the interface to CoSState.
     let cases: &[(i32, &str, InterfaceSnapshot)] = &[
@@ -1541,6 +1555,7 @@ fn build_cos_state_skips_interface_with_resolvable_but_empty_scheduler_map() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1593,6 +1608,7 @@ fn build_cos_state_skips_interface_with_scheduler_map_all_undefined_forwarding_c
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1637,7 +1653,8 @@ fn build_cos_state_skips_classifier_only_mapping_to_unmaterialized_queue() {
         }],
         ieee8021_classifiers: vec![],
         dscp_rewrite_rules: vec![],
-    };
+            flow_rebalance: None,
+        };
     let snapshot = ConfigSnapshot {
         interfaces: vec![InterfaceSnapshot {
             ifindex: 501,
@@ -1678,7 +1695,8 @@ fn build_cos_state_admits_classifier_mapping_to_materialized_queue() {
         }],
         ieee8021_classifiers: vec![],
         dscp_rewrite_rules: vec![],
-    };
+            flow_rebalance: None,
+        };
     let snapshot = ConfigSnapshot {
         interfaces: vec![InterfaceSnapshot {
             ifindex: 502,
@@ -1725,7 +1743,8 @@ fn build_cos_state_skips_rewrite_only_mapping_to_unmaterialized_class() {
                 dscp_value: 0x2e,
             }],
         }],
-    };
+            flow_rebalance: None,
+        };
     let snapshot = ConfigSnapshot {
         interfaces: vec![InterfaceSnapshot {
             ifindex: 503,
@@ -1765,7 +1784,8 @@ fn build_cos_state_admits_rewrite_only_mapping_to_materialized_class() {
                 dscp_value: 0,
             }],
         }],
-    };
+            flow_rebalance: None,
+        };
     let snapshot = ConfigSnapshot {
         interfaces: vec![InterfaceSnapshot {
             ifindex: 504,

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -413,6 +413,11 @@ impl super::Coordinator {
             if entry.origin.is_peer_synced() {
                 continue;
             }
+            // #1748: never export the abandoned W_old rebalance copy on bulk
+            // sync — W_new is the exporting owner.
+            if entry.origin.is_rebalanced_out() {
+                continue;
+            }
             // Skip fabric-ingress sessions (same exclusion as export_forward_sessions_for_owner_rgs).
             if entry.metadata.fabric_ingress {
                 continue;

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -239,6 +239,8 @@ fn update_ha_state_prewarms_split_rg_reverse_sessions_on_activation() {
             heartbeat: Arc::new(AtomicU64::new(0)),
             commands: worker_commands.clone(),
             session_export_ack: Arc::new(AtomicU64::new(0)),
+            rebalance_ack: Arc::new(Mutex::new(None)),
+            rebalance_ack_seq: Arc::new(AtomicU64::new(0)),
             cos_status: Arc::new(ArcSwap::from_pointee(Vec::new())),
             runtime_atomics: Arc::new(super::worker_runtime::WorkerRuntimeAtomics::new()),
             cold_path_atomics: Arc::new(

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -241,6 +241,7 @@ fn update_ha_state_prewarms_split_rg_reverse_sessions_on_activation() {
             session_export_ack: Arc::new(AtomicU64::new(0)),
             rebalance_ack: Arc::new(Mutex::new(None)),
             rebalance_ack_seq: Arc::new(AtomicU64::new(0)),
+            rebalance_cmd_seq: Arc::new(AtomicU64::new(0)),
             cos_status: Arc::new(ArcSwap::from_pointee(Vec::new())),
             runtime_atomics: Arc::new(super::worker_runtime::WorkerRuntimeAtomics::new()),
             cold_path_atomics: Arc::new(

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -372,6 +372,8 @@ const fn tx_frame_capacity() -> usize {
 
 #[path = "coordinator/mod.rs"]
 mod coordinator;
+// #1748: reactive cross-worker ntuple rebalance controller (default-OFF).
+mod rebalance;
 #[cfg(test)]
 #[path = "tests.rs"]
 mod tests;

--- a/userspace-dp/src/afxdp/rebalance/controller.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller.rs
@@ -16,7 +16,7 @@
 use std::collections::HashMap;
 use std::net::IpAddr;
 
-use super::ntuple::{FlowProto, FlowSpec5Tuple, NtupleSocket};
+use super::ntuple::{FlowProto, FlowSpec5Tuple};
 use crate::session::SessionKey;
 
 /// Operator-tunable knobs compiled from the `class-of-service flow-rebalance`
@@ -174,11 +174,20 @@ struct LedgerEntry {
     loc: u32,
 }
 
-/// Persistent controller state for one interface. Owns the NtupleSocket only
-/// when the knob is enabled.
+/// Persistent controller state for one interface (ledger + cooldown +
+/// hysteresis + metrics). The NtupleSocket is owned separately by the
+/// Coordinator (see the struct comment below) so it can be borrowed as the
+/// BarrierTransport while the controller is borrowed `&mut`.
 pub(in crate::afxdp) struct RebalanceController {
+    // #1748 review-r3 (soundness): the NtupleSocket is deliberately NOT owned
+    // by the controller. The barrier transport needs a shared `&NtupleSocket`
+    // while the controller's tick/teardown take `&mut self`; owning the socket
+    // here and aliasing it through a raw pointer into the transport during a
+    // `&mut self` call is undefined behavior under stacked borrows. The socket
+    // lives in the Coordinator's separate `rebalance_sockets` map so the socket
+    // and the controller are independent borrows; the socket is passed to
+    // tick/teardown_all via the BarrierTransport `tx` parameter.
     config: RebalanceConfig,
-    socket: NtupleSocket,
     ledger: Vec<LedgerEntry>,
     /// Per-flow cooldown: key -> monotonic secs until which it is ineligible.
     cooldown: HashMap<SessionKey, u64>,
@@ -197,13 +206,9 @@ const DWELL_TICKS_REQUIRED: u32 = 2;
 const EPSILON_COV_IMPROVEMENT: f64 = 0.02;
 
 impl RebalanceController {
-    pub(in crate::afxdp) fn new(
-        config: RebalanceConfig,
-        socket: NtupleSocket,
-    ) -> Self {
+    pub(in crate::afxdp) fn new(config: RebalanceConfig) -> Self {
         Self {
             config,
-            socket,
             ledger: Vec::new(),
             cooldown: HashMap::new(),
             last_move_secs: 0,
@@ -214,11 +219,6 @@ impl RebalanceController {
 
     pub(in crate::afxdp) fn metrics(&self) -> &RebalanceMetrics {
         &self.metrics
-    }
-
-    /// Borrow the owned NtupleSocket as a BarrierTransport rule programmer.
-    pub(in crate::afxdp) fn socket(&self) -> &NtupleSocket {
-        &self.socket
     }
 
     /// Test-only: clear the per-flow cooldown so a unit test can drive a

--- a/userspace-dp/src/afxdp/rebalance/controller.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller.rs
@@ -19,6 +19,21 @@ use std::net::IpAddr;
 use super::ntuple::{FlowProto, FlowSpec5Tuple};
 use crate::session::SessionKey;
 
+/// #1748 live BUG #1 instrumentation. Emits a per-eval diagnostic line to
+/// stderr (journald) ONLY in `debug-log` feature builds, so production release
+/// builds compile it out entirely (zero cost, removable). Mirrors the
+/// `debug_log!` pattern in `session/mod.rs`. Build the helper with
+/// `--features debug-log` to read these lines via `journalctl -u xpfd`.
+#[allow(unused_macros)]
+macro_rules! debug_log_rebalance {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "debug-log")]
+        eprintln!($($arg)*);
+    };
+}
+#[allow(unused_imports)]
+pub(in crate::afxdp) use debug_log_rebalance;
+
 /// Operator-tunable knobs compiled from the `class-of-service flow-rebalance`
 /// config leaf. Absent leaf => `None` controller => default path untouched.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -60,6 +75,13 @@ pub(in crate::afxdp) enum SkipReason {
     Magnitude,
     /// Projected byte-rate CoV improvement did not exceed epsilon.
     Epsilon,
+    /// #1748 live BUG #1 disambiguation: the hottest worker had NO eligible
+    /// candidate flow with a positive byte-rate to move — distinct from a real
+    /// epsilon reject (a candidate existed but its projected CoV gain was too
+    /// small). A high rate here while worker CoV is large means the per-flow
+    /// rate signal is broken (flows missing from the map, mismatched worker_id,
+    /// or zero per-flow rate), NOT that the move math is too conservative.
+    NoEligibleFlow,
     /// Rule budget exhausted (STOP — no eviction).
     BudgetExhausted,
     /// Barrier failed (ack timeout / key absent / ioctl error) — rolled back.
@@ -80,6 +102,7 @@ impl SkipReason {
             Self::Cooldown => "cooldown",
             Self::Magnitude => "magnitude",
             Self::Epsilon => "epsilon",
+            Self::NoEligibleFlow => "no_eligible_flow",
             Self::BudgetExhausted => "budget_exhausted",
             Self::BarrierFailed => "barrier_failed",
             Self::Dwell => "dwell",
@@ -488,17 +511,54 @@ impl RebalanceController {
             .collect();
         candidates.sort_by(|a, b| b.byte_rate.total_cmp(&a.byte_rate));
 
+        let candidate_count = candidates.len();
+        // #1748 live BUG #1 ROOT-CAUSE FIX: the direct per-flow byte-rate
+        // (observed_bytes delta) is an unreliable signal under real traffic —
+        // the per-flow-cache `observed_bytes` counter RESETS whenever the entry
+        // is evicted + re-inserted (LRU / generation / collision), so across a
+        // 1s eval window a heavy flow frequently reads rate ~0 (cur < prev =>
+        // saturating_sub => 0). That made every candidate look like a 0-rate
+        // flow, project_move shifted ~0 bytes, and the move never cleared the
+        // epsilon band (installs=0 on the live gate). The per-WORKER rate
+        // (tx_bytes delta) IS reliable (CoV 0.64 was computed from it), so when
+        // a flow's direct rate is missing we ESTIMATE it from the reliable
+        // worker rate: the hottest worker's rate divided evenly across its
+        // candidate flows. This is the physically-correct expectation for
+        // RSS-hashed equal flows and lets the controller make a beneficial move
+        // off the reliable signal instead of stalling on the flaky one.
+        let fallback_per_flow_rate = if candidate_count > 0 {
+            hottest.byte_rate / candidate_count as f64
+        } else {
+            0.0
+        };
         let mut had_cooldown_skip = false;
         let mut had_magnitude_skip = false;
+        // #1748 live BUG #1: track whether ANY candidate flow reached the
+        // epsilon comparison with a POSITIVE (estimated) byte-rate. If none did
+        // (no flows on the hottest worker at all, or a zero hottest rate), the
+        // skip is NoEligibleFlow, NOT a genuine epsilon reject.
+        let mut reached_epsilon_with_positive_rate = false;
         let mut best: Option<(MoveCandidate, f64)> = None;
         for flow in candidates {
             if self.cooldown.contains_key(&flow.key) {
                 had_cooldown_skip = true;
                 continue;
             }
+            // Effective move magnitude: the direct per-flow rate when present,
+            // else the reliable worker-rate-derived estimate (see above).
+            let move_rate = if flow.byte_rate > 0.0 {
+                flow.byte_rate
+            } else {
+                fallback_per_flow_rate
+            };
+            // A zero-rate move cannot improve CoV (project_move shifts ~0
+            // bytes); only possible if the hottest worker's own rate is 0.
+            if move_rate <= 0.0 {
+                continue;
+            }
             // Magnitude guard: moving it must not make the destination the new
-            // hottest worker (flow rate <= gap/2).
-            if flow.byte_rate > gap / 2.0 {
+            // hottest worker (move magnitude <= gap/2).
+            if move_rate > gap / 2.0 {
                 had_magnitude_skip = true;
                 continue;
             }
@@ -507,10 +567,11 @@ impl RebalanceController {
                 &input.workers,
                 hottest.worker_id,
                 coolest.worker_id,
-                flow.byte_rate,
+                move_rate,
             );
             let projected_cov = byte_rate_cov(&projected);
             let improvement = baseline_cov - projected_cov;
+            reached_epsilon_with_positive_rate = true;
             if improvement <= EPSILON_COV_IMPROVEMENT {
                 continue;
             }
@@ -529,14 +590,41 @@ impl RebalanceController {
         if let Some((cand, _)) = best {
             return Some(cand);
         }
-        // No winning move — attribute the dominant skip reason.
-        let reason = if had_magnitude_skip {
+        // No winning move — attribute the dominant skip reason. Magnitude and
+        // cooldown are real eligibility rejects on a positive-rate flow. A real
+        // epsilon reject requires a positive-rate candidate that reached the
+        // projection. Otherwise the hottest worker simply had no movable flow
+        // with a positive rate -> NoEligibleFlow (the live-BUG-1 signature).
+        let reason = if reached_epsilon_with_positive_rate {
+            SkipReason::Epsilon
+        } else if had_magnitude_skip {
             SkipReason::Magnitude
         } else if had_cooldown_skip {
             SkipReason::Cooldown
         } else {
-            SkipReason::Epsilon
+            SkipReason::NoEligibleFlow
         };
+        // #1748 live BUG #1 instrumentation: when imbalanced but no move is
+        // taken, emit ONE debug line per eval with the ground-truth vectors so
+        // a single deploy disambiguates "per-flow rate is zero" (NoEligibleFlow)
+        // from "move math too conservative" (Epsilon). Gated to the
+        // `debug-log` feature so it is OFF in normal release builds.
+        debug_log_rebalance!(
+            "REBALANCE_SKIP ifindex={} reason={} baseline_cov={:.4} eps={:.4} \
+             hottest_w={} hottest_rate={:.3e} coolest_w={} coolest_rate={:.3e} gap={:.3e} \
+             candidate_flows_on_hottest={} flows_total={}",
+            input.ifindex,
+            reason.as_str(),
+            baseline_cov,
+            EPSILON_COV_IMPROVEMENT,
+            hottest.worker_id,
+            hottest.byte_rate,
+            coolest.worker_id,
+            coolest.byte_rate,
+            gap,
+            candidate_count,
+            input.flows.len(),
+        );
         self.metrics.record_skip(reason);
         None
     }

--- a/userspace-dp/src/afxdp/rebalance/controller.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller.rs
@@ -1,0 +1,589 @@
+// #1748: reactive cross-worker ntuple rebalance controller.
+//
+// Ticked at the coordinator status cadence (~1 Hz, NOT per-packet, NOT
+// per-poll). On each tick it derives per-worker byte-rate over the window,
+// and — only when the imbalance has persisted past the dwell — moves the
+// single flow whose relocation most flattens the per-worker byte-rate
+// vector, subject to a magnitude guard (<= gap/2), a per-flow cooldown, an
+// epsilon improvement band, and a hard rule budget with STOP-on-exhaustion
+// (NO eviction). The move itself is a barriered ownership transfer
+// (`promote W_new -> ack -> demote W_old -> ack -> install rule`); rollback
+// and teardown-of-a-live-move use the reverse barrier.
+//
+// Default-OFF: when the knob is unset the Coordinator never constructs a
+// controller, so there is zero extra per-tick work and zero ioctl sockets.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use super::ntuple::{FlowProto, FlowSpec5Tuple, NtupleSocket};
+use crate::session::SessionKey;
+
+/// Operator-tunable knobs compiled from the `class-of-service flow-rebalance`
+/// config leaf. Absent leaf => `None` controller => default path untouched.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(in crate::afxdp) struct RebalanceConfig {
+    /// `max_worker_rate / mean_rate` must exceed this to consider a move.
+    pub imbalance_threshold: f64,
+    /// Minimum seconds between rule installs (dwell / one-move-per-interval).
+    pub rebalance_interval_secs: u64,
+    /// Hard cap on concurrently-installed xpf rules per interface.
+    pub max_rules: u32,
+}
+
+impl Default for RebalanceConfig {
+    fn default() -> Self {
+        Self {
+            imbalance_threshold: 1.30,
+            rebalance_interval_secs: 1,
+            max_rules: 64,
+        }
+    }
+}
+
+impl RebalanceConfig {
+    /// A config is meaningful only with a positive threshold and budget.
+    pub(in crate::afxdp) fn is_enabled(&self) -> bool {
+        self.imbalance_threshold > 1.0 && self.max_rules > 0
+    }
+}
+
+/// Reason a candidate move was skipped — exported as the
+/// `moves_skipped_total{reason}` metric label.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(in crate::afxdp) enum SkipReason {
+    /// Imbalance below threshold or not yet persisted past the dwell.
+    Balanced,
+    /// Within the per-flow cooldown window.
+    Cooldown,
+    /// Moving the flow would make the destination the new hottest worker.
+    Magnitude,
+    /// Projected byte-rate CoV improvement did not exceed epsilon.
+    Epsilon,
+    /// Rule budget exhausted (STOP — no eviction).
+    BudgetExhausted,
+    /// Barrier failed (ack timeout / key absent / ioctl error) — rolled back.
+    BarrierFailed,
+    /// One move already happened this interval.
+    Dwell,
+}
+
+impl SkipReason {
+    pub(in crate::afxdp) fn as_str(self) -> &'static str {
+        match self {
+            Self::Balanced => "balanced",
+            Self::Cooldown => "cooldown",
+            Self::Magnitude => "magnitude",
+            Self::Epsilon => "epsilon",
+            Self::BudgetExhausted => "budget_exhausted",
+            Self::BarrierFailed => "barrier_failed",
+            Self::Dwell => "dwell",
+        }
+    }
+}
+
+/// Per-interface controller metrics (exported as
+/// `xpf_userspace_flow_rebalance_*{ifindex}`).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(in crate::afxdp) struct RebalanceMetrics {
+    pub rules_active: u32,
+    pub installs_total: u64,
+    pub deletes_total: u64,
+    pub moves_skipped: HashMap<SkipReason, u64>,
+    /// Coefficient of variation of the per-worker byte-rate at the last tick.
+    pub worker_byterate_cov: f64,
+}
+
+impl RebalanceMetrics {
+    fn record_skip(&mut self, reason: SkipReason) {
+        *self.moves_skipped.entry(reason).or_insert(0) += 1;
+    }
+}
+
+/// One worker's byte-rate sample for the current tick.
+#[derive(Clone, Copy, Debug)]
+pub(in crate::afxdp) struct WorkerByteRate {
+    pub worker_id: u32,
+    pub queue_id: u32,
+    /// Bytes/sec over the observation window.
+    pub byte_rate: f64,
+}
+
+/// One live flow eligible to move: its 5-tuple key, current worker, and
+/// observed byte-rate over the window.
+#[derive(Clone, Debug)]
+pub(in crate::afxdp) struct FlowSample {
+    pub key: SessionKey,
+    pub worker_id: u32,
+    pub byte_rate: f64,
+}
+
+/// Per-tick input snapshot the Coordinator assembles from existing
+/// telemetry (umem `tx_bytes` deltas keyed by worker + the flow-worker map).
+pub(in crate::afxdp) struct RebalanceTickInput {
+    pub ifindex: i32,
+    pub workers: Vec<WorkerByteRate>,
+    pub flows: Vec<FlowSample>,
+    /// Monotonic seconds (for cooldown / dwell timing).
+    pub now_secs: u64,
+}
+
+/// The transport the controller uses to drive the barriered move and program
+/// the NIC. The Coordinator implements this against its worker command queues
+/// + ack slots + the per-interface `NtupleSocket`. Abstracted so the
+/// selection/barrier logic is unit-testable with a mock.
+pub(in crate::afxdp) trait BarrierTransport {
+    /// Promote W_new's replica to RebalancedOwner; block until acked. Returns
+    /// true iff the worker confirmed the key reached `RebalancedOwner`.
+    fn promote(&mut self, worker_id: u32, key: &SessionKey) -> bool;
+    /// Demote W_old's entry to RebalancedOut; block until acked. Returns true
+    /// iff the worker confirmed the key reached `RebalancedOut`.
+    fn demote(&mut self, worker_id: u32, key: &SessionKey) -> bool;
+    /// Reverse-barrier: restore W_old to a local owner; block until acked.
+    fn restore_owner(&mut self, worker_id: u32, key: &SessionKey) -> bool;
+    /// Reverse-barrier: demote W_new back to a worker-local replica; block
+    /// until acked.
+    fn demote_replica(&mut self, worker_id: u32, key: &SessionKey) -> bool;
+    /// Install the exact-5-tuple rule steering the flow to `queue`. Returns
+    /// the rule location on success.
+    fn install_rule(&mut self, flow: &FlowSpec5Tuple, queue: u32) -> std::io::Result<u32>;
+    /// Delete the rule at `loc`.
+    fn delete_rule(&mut self, loc: u32) -> std::io::Result<()>;
+}
+
+/// A live move record in the controller's in-memory ledger.
+#[derive(Clone, Debug)]
+struct LedgerEntry {
+    key: SessionKey,
+    /// The worker the flow now lives on (W_new).
+    new_worker: u32,
+    /// The driver-assigned ntuple rule location.
+    loc: u32,
+}
+
+/// Persistent controller state for one interface. Owns the NtupleSocket only
+/// when the knob is enabled.
+pub(in crate::afxdp) struct RebalanceController {
+    config: RebalanceConfig,
+    socket: NtupleSocket,
+    ledger: Vec<LedgerEntry>,
+    /// Per-flow cooldown: key -> monotonic secs until which it is ineligible.
+    cooldown: HashMap<SessionKey, u64>,
+    /// Monotonic secs of the last install (dwell gate).
+    last_move_secs: u64,
+    /// Ticks the imbalance has persisted above threshold (hysteresis).
+    dwell_ticks: u32,
+    metrics: RebalanceMetrics,
+}
+
+/// Number of consecutive over-threshold ticks required before the first move
+/// (hysteresis floor — avoids reacting to a single noisy sample).
+const DWELL_TICKS_REQUIRED: u32 = 2;
+
+/// Minimum fractional CoV improvement a move must project to be worth doing.
+const EPSILON_COV_IMPROVEMENT: f64 = 0.02;
+
+impl RebalanceController {
+    pub(in crate::afxdp) fn new(
+        config: RebalanceConfig,
+        socket: NtupleSocket,
+    ) -> Self {
+        Self {
+            config,
+            socket,
+            ledger: Vec::new(),
+            cooldown: HashMap::new(),
+            last_move_secs: 0,
+            dwell_ticks: 0,
+            metrics: RebalanceMetrics::default(),
+        }
+    }
+
+    pub(in crate::afxdp) fn metrics(&self) -> &RebalanceMetrics {
+        &self.metrics
+    }
+
+    /// Borrow the owned NtupleSocket as a BarrierTransport rule programmer.
+    pub(in crate::afxdp) fn socket(&self) -> &NtupleSocket {
+        &self.socket
+    }
+
+    /// One controller tick. Pure decision + barriered move. `tx` drives the
+    /// worker barrier and NIC programming. Returns the move outcome for the
+    /// caller's logging (None = no move attempted/taken this tick).
+    pub(in crate::afxdp) fn tick<T: BarrierTransport>(
+        &mut self,
+        input: &RebalanceTickInput,
+        tx: &mut T,
+    ) -> Option<MoveOutcome> {
+        // Always refresh the CoV gauge so operators see the live imbalance
+        // even when no move is taken.
+        let cov = byte_rate_cov(&input.workers);
+        self.metrics.worker_byterate_cov = cov;
+        self.expire_cooldowns(input.now_secs);
+
+        // Hysteresis: count consecutive over-threshold ticks.
+        let over_threshold = self.is_over_threshold(&input.workers);
+        if over_threshold {
+            self.dwell_ticks = self.dwell_ticks.saturating_add(1);
+        } else {
+            self.dwell_ticks = 0;
+            self.metrics.record_skip(SkipReason::Balanced);
+            return None;
+        }
+        if self.dwell_ticks < DWELL_TICKS_REQUIRED {
+            self.metrics.record_skip(SkipReason::Balanced);
+            return None;
+        }
+
+        // One move per rebalance_interval (dwell gate on install cadence).
+        if input.now_secs.saturating_sub(self.last_move_secs)
+            < self.config.rebalance_interval_secs
+        {
+            self.metrics.record_skip(SkipReason::Dwell);
+            return None;
+        }
+
+        // Budget gate: STOP at the cap, never evict.
+        if self.ledger.len() as u32 >= self.config.max_rules {
+            self.metrics.record_skip(SkipReason::BudgetExhausted);
+            return None;
+        }
+
+        let Some(candidate) = self.select_move(input) else {
+            // select_move records the precise skip reason.
+            return None;
+        };
+
+        // Forward barrier: promote W_new BEFORE the rule, then demote W_old,
+        // then install. Both before the rule so a racing GC on either side
+        // sees a safe origin (the applied-command ack serializes promote
+        // before demote so there is always >= 1 cleanup owner).
+        if !tx.promote(candidate.new_worker, &candidate.key) {
+            self.metrics.record_skip(SkipReason::BarrierFailed);
+            // Nothing to roll back: the only mutation attempted was the
+            // promote, which failed to commit. Reverse it defensively.
+            tx.demote_replica(candidate.new_worker, &candidate.key);
+            return None;
+        }
+        if !tx.demote(candidate.old_worker, &candidate.key) {
+            self.metrics.record_skip(SkipReason::BarrierFailed);
+            // Reverse barrier: restore W_old to owner FIRST (it never became
+            // RebalancedOut, but issue the restore to be safe), THEN demote
+            // W_new back to a replica.
+            tx.restore_owner(candidate.old_worker, &candidate.key);
+            tx.demote_replica(candidate.new_worker, &candidate.key);
+            return None;
+        }
+        // Only after BOTH acks: install the rule.
+        let spec = flow_spec_from_key(&candidate.key);
+        match tx.install_rule(&spec, candidate.new_queue) {
+            Ok(loc) => {
+                self.ledger.push(LedgerEntry {
+                    key: candidate.key.clone(),
+                    new_worker: candidate.new_worker,
+                    loc,
+                });
+                self.cooldown.insert(
+                    candidate.key.clone(),
+                    input.now_secs
+                        + self.config.rebalance_interval_secs
+                            * COOLDOWN_INTERVAL_MULTIPLIER,
+                );
+                self.last_move_secs = input.now_secs;
+                self.dwell_ticks = 0;
+                self.metrics.installs_total += 1;
+                self.metrics.rules_active = self.ledger.len() as u32;
+                Some(MoveOutcome {
+                    key: candidate.key,
+                    old_worker: candidate.old_worker,
+                    new_worker: candidate.new_worker,
+                    loc,
+                })
+            }
+            Err(_) => {
+                self.metrics.record_skip(SkipReason::BarrierFailed);
+                // Rule install failed: reverse the ownership transfer with the
+                // reverse barrier so >= 1 cleanup owner remains.
+                tx.restore_owner(candidate.old_worker, &candidate.key);
+                tx.demote_replica(candidate.new_worker, &candidate.key);
+                None
+            }
+        }
+    }
+
+    /// Tear down ALL installed rules (controller disable / daemon shutdown).
+    /// A still-live move must reverse the ownership transfer BEFORE the rule
+    /// is removed (reverse barrier): restore W_old -> owner + ack, delete the
+    /// rule, then demote W_new -> replica + ack. Only a flow already expired
+    /// off W_new is a plain rule delete — but the controller cannot prove
+    /// that here, so it conservatively reverse-barriers every live ledger
+    /// entry. The caller passes the set of keys still present on W_new (live)
+    /// vs gone (dead); empty `live_keys` => all plain deletes.
+    pub(in crate::afxdp) fn teardown_all<T: BarrierTransport, F>(
+        &mut self,
+        tx: &mut T,
+        mut is_live_on_new: F,
+    ) where
+        F: FnMut(u32, &SessionKey) -> bool,
+    {
+        let entries = std::mem::take(&mut self.ledger);
+        for entry in entries {
+            if is_live_on_new(entry.new_worker, &entry.key) {
+                // Reverse barrier: hand ownership back to W_old (it keeps the
+                // packets via origin-agnostic last_seen refresh once RSS
+                // re-hashes the flow there) BEFORE removing the rule.
+                tx.restore_owner(worker_for_old(&entry), &entry.key);
+                let _ = tx.delete_rule(entry.loc);
+                tx.demote_replica(entry.new_worker, &entry.key);
+            } else {
+                // Flow already expired off W_new — no live ownership to hand
+                // back; plain rule delete.
+                let _ = tx.delete_rule(entry.loc);
+            }
+            self.metrics.deletes_total += 1;
+        }
+        self.metrics.rules_active = 0;
+    }
+
+    fn is_over_threshold(&self, workers: &[WorkerByteRate]) -> bool {
+        let (max, mean) = max_and_mean(workers);
+        mean > 0.0 && (max / mean) > self.config.imbalance_threshold
+    }
+
+    fn expire_cooldowns(&mut self, now_secs: u64) {
+        self.cooldown.retain(|_, &mut until| until > now_secs);
+    }
+
+    /// Byte-rate-aware selection: among flows on the hottest worker, pick the
+    /// one whose move to the least-loaded worker most reduces the per-worker
+    /// byte-rate CoV, subject to magnitude guard + cooldown + epsilon band.
+    /// Records the precise skip reason on the no-move paths.
+    fn select_move(&mut self, input: &RebalanceTickInput) -> Option<MoveCandidate> {
+        if input.workers.len() < 2 {
+            self.metrics.record_skip(SkipReason::Balanced);
+            return None;
+        }
+        // Hottest (source) and least-loaded (destination) workers.
+        let hottest = input
+            .workers
+            .iter()
+            .max_by(|a, b| a.byte_rate.total_cmp(&b.byte_rate))?;
+        let coolest = input
+            .workers
+            .iter()
+            .min_by(|a, b| a.byte_rate.total_cmp(&b.byte_rate))?;
+        if hottest.worker_id == coolest.worker_id {
+            self.metrics.record_skip(SkipReason::Balanced);
+            return None;
+        }
+        let gap = hottest.byte_rate - coolest.byte_rate;
+        let baseline_cov = byte_rate_cov(&input.workers);
+
+        // Candidate flows: those currently on the hottest worker, heaviest
+        // first, not in cooldown.
+        let mut candidates: Vec<&FlowSample> = input
+            .flows
+            .iter()
+            .filter(|f| f.worker_id == hottest.worker_id)
+            .collect();
+        candidates.sort_by(|a, b| b.byte_rate.total_cmp(&a.byte_rate));
+
+        let mut had_cooldown_skip = false;
+        let mut had_magnitude_skip = false;
+        let mut best: Option<(MoveCandidate, f64)> = None;
+        for flow in candidates {
+            if self.cooldown.contains_key(&flow.key) {
+                had_cooldown_skip = true;
+                continue;
+            }
+            // Magnitude guard: moving it must not make the destination the new
+            // hottest worker (flow rate <= gap/2).
+            if flow.byte_rate > gap / 2.0 {
+                had_magnitude_skip = true;
+                continue;
+            }
+            // Project the post-move byte-rate vector and its CoV.
+            let projected = project_move(
+                &input.workers,
+                hottest.worker_id,
+                coolest.worker_id,
+                flow.byte_rate,
+            );
+            let projected_cov = byte_rate_cov(&projected);
+            let improvement = baseline_cov - projected_cov;
+            if improvement <= EPSILON_COV_IMPROVEMENT {
+                continue;
+            }
+            let cand = MoveCandidate {
+                key: flow.key.clone(),
+                old_worker: hottest.worker_id,
+                new_worker: coolest.worker_id,
+                new_queue: coolest.queue_id,
+            };
+            match &best {
+                Some((_, best_imp)) if *best_imp >= improvement => {}
+                _ => best = Some((cand, improvement)),
+            }
+        }
+
+        if let Some((cand, _)) = best {
+            return Some(cand);
+        }
+        // No winning move — attribute the dominant skip reason.
+        let reason = if had_magnitude_skip {
+            SkipReason::Magnitude
+        } else if had_cooldown_skip {
+            SkipReason::Cooldown
+        } else {
+            SkipReason::Epsilon
+        };
+        self.metrics.record_skip(reason);
+        None
+    }
+}
+
+/// Cooldown is several rebalance intervals so a flow re-pinned cannot
+/// immediately thrash back (oscillation guard, research §4 R6).
+const COOLDOWN_INTERVAL_MULTIPLIER: u64 = 5;
+
+#[derive(Clone, Debug)]
+struct MoveCandidate {
+    key: SessionKey,
+    old_worker: u32,
+    new_worker: u32,
+    new_queue: u32,
+}
+
+/// The outcome of a committed move, for caller-side logging.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) struct MoveOutcome {
+    pub key: SessionKey,
+    pub old_worker: u32,
+    pub new_worker: u32,
+    pub loc: u32,
+}
+
+// `LedgerEntry` only stores the new worker; the old worker is whichever RSS
+// queue the flow would re-hash to, which we cannot know at teardown. The
+// reverse barrier restores ownership to the entry's recorded provenance — for
+// the controller's purposes "W_old" on teardown is the worker that will own
+// the flow once the rule is gone, i.e. the RSS-natural worker. We approximate
+// it as the new_worker's pre-move owner, which the ledger does not retain;
+// teardown therefore issues restore_owner against the recorded new_worker's
+// peer. Since restore/demote are idempotent tag flips keyed by the session,
+// issuing them against new_worker is safe (it is a no-op if the entry there
+// is not RebalancedOut). See teardown_all for the conservative ordering.
+fn worker_for_old(entry: &LedgerEntry) -> u32 {
+    entry.new_worker
+}
+
+/// Compute the max and mean of a per-worker byte-rate vector.
+fn max_and_mean(workers: &[WorkerByteRate]) -> (f64, f64) {
+    if workers.is_empty() {
+        return (0.0, 0.0);
+    }
+    let sum: f64 = workers.iter().map(|w| w.byte_rate).sum();
+    let max = workers
+        .iter()
+        .map(|w| w.byte_rate)
+        .fold(0.0_f64, f64::max);
+    (max, sum / workers.len() as f64)
+}
+
+/// Coefficient of variation (stddev / mean) of the per-worker byte-rates.
+/// Returns 0 for a degenerate (empty / zero-mean) vector.
+pub(in crate::afxdp) fn byte_rate_cov(workers: &[WorkerByteRate]) -> f64 {
+    if workers.is_empty() {
+        return 0.0;
+    }
+    let n = workers.len() as f64;
+    let mean = workers.iter().map(|w| w.byte_rate).sum::<f64>() / n;
+    if mean <= 0.0 {
+        return 0.0;
+    }
+    let var = workers
+        .iter()
+        .map(|w| {
+            let d = w.byte_rate - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / n;
+    var.sqrt() / mean
+}
+
+/// Project the per-worker byte-rate vector after moving `flow_rate` from
+/// `from` to `to`. Returns a fresh vector (cheap — ~6 workers).
+fn project_move(
+    workers: &[WorkerByteRate],
+    from: u32,
+    to: u32,
+    flow_rate: f64,
+) -> Vec<WorkerByteRate> {
+    workers
+        .iter()
+        .map(|w| {
+            let mut nw = *w;
+            if w.worker_id == from {
+                nw.byte_rate = (w.byte_rate - flow_rate).max(0.0);
+            } else if w.worker_id == to {
+                nw.byte_rate = w.byte_rate + flow_rate;
+            }
+            nw
+        })
+        .collect()
+}
+
+/// Translate a SessionKey to the ethtool 5-tuple, converting host-order ports
+/// and `IpAddr` into the network-order words the kernel UAPI expects.
+pub(in crate::afxdp) fn flow_spec_from_key(key: &SessionKey) -> FlowSpec5Tuple {
+    let (proto, src_ip, dst_ip) = match (key.src_ip, key.dst_ip) {
+        (IpAddr::V4(s), IpAddr::V4(d)) => {
+            let proto = if key.protocol == super::super::PROTO_TCP {
+                FlowProto::Tcp4
+            } else {
+                FlowProto::Udp4
+            };
+            (
+                proto,
+                [u32::from_ne_bytes(s.octets()), 0, 0, 0],
+                [u32::from_ne_bytes(d.octets()), 0, 0, 0],
+            )
+        }
+        (IpAddr::V6(s), IpAddr::V6(d)) => {
+            let proto = if key.protocol == super::super::PROTO_TCP {
+                FlowProto::Tcp6
+            } else {
+                FlowProto::Udp6
+            };
+            (proto, v6_words(s), v6_words(d))
+        }
+        // Mixed families never form a real session key; default to v4 TCP so
+        // the spec is well-formed (the move would simply never match).
+        _ => (FlowProto::Tcp4, [0; 4], [0; 4]),
+    };
+    FlowSpec5Tuple {
+        proto,
+        src_ip,
+        dst_ip,
+        // SessionKey ports are host order; the kernel field is __be16.
+        src_port: key.src_port.to_be(),
+        dst_port: key.dst_port.to_be(),
+    }
+}
+
+/// IPv6 address -> four network-order u32 words (matching `__be32[4]`).
+fn v6_words(addr: std::net::Ipv6Addr) -> [u32; 4] {
+    let o = addr.octets();
+    [
+        u32::from_ne_bytes([o[0], o[1], o[2], o[3]]),
+        u32::from_ne_bytes([o[4], o[5], o[6], o[7]]),
+        u32::from_ne_bytes([o[8], o[9], o[10], o[11]]),
+        u32::from_ne_bytes([o[12], o[13], o[14], o[15]]),
+    ]
+}
+
+#[cfg(test)]
+#[path = "controller_tests.rs"]
+mod tests;

--- a/userspace-dp/src/afxdp/rebalance/controller.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller.rs
@@ -270,7 +270,7 @@ impl RebalanceController {
             return None;
         }
 
-        let Some(candidate) = self.select_move(input) else {
+        let Some(mut candidate) = self.select_move(input) else {
             // select_move records the precise skip reason.
             return None;
         };
@@ -291,21 +291,45 @@ impl RebalanceController {
             .position(|e| e.key == candidate.key);
         if let Some(idx) = prior_idx {
             let prior = self.ledger[idx].clone();
+            // #1748 review-r2 MAJOR: `old_worker` is the RSS-natural worker for
+            // the 5-tuple — the worker the flow lands on when NO rebalance rule
+            // exists. RSS is deterministic on the tuple, so this is INVARIANT
+            // across moves. On a second move `candidate.old_worker` is the prior
+            // W_new (the flow's *current* worker mid-move), NOT the RSS-natural
+            // worker. Carry the prior entry's `old_worker` forward so (a) the
+            // forward-barrier demote below targets the correct worker and (b)
+            // the replacement ledger entry records the RSS-natural worker, so a
+            // later teardown restores it (not the prior W_new).
+            candidate.old_worker = prior.old_worker;
             // Reverse barrier on the prior move: restore the prior W_old to
             // owner, delete the prior rule, demote the prior W_new to replica.
             // Gate the W_new demote on a successful restore ack (#1748 #4): if
             // the restore times out we must NOT demote the only owner.
-            if tx.restore_owner(prior.old_worker, &prior.key) {
-                let _ = tx.delete_rule(prior.loc);
-                tx.demote_replica(prior.new_worker, &prior.key);
-                self.metrics.deletes_total += 1;
-            } else {
+            if !tx.restore_owner(prior.old_worker, &prior.key) {
                 // Could not hand ownership back to the prior W_old. Abort the
                 // second move and leave the prior move intact (>= 1 owner is
                 // still the prior W_new). Do not append a second rule.
+                // #1748 review-r2 MINOR: this is a restore-ack failure — record
+                // RestoreFailed, matching the other three restore-fail sites.
+                self.metrics.record_skip(SkipReason::RestoreFailed);
+                return None;
+            }
+            // #1748 review-r2 MINOR: handle the prior-rule delete failure. If
+            // the delete fails we must NOT proceed to install a new rule for
+            // the same 5-tuple — that re-creates the duplicate-HW-rule hazard
+            // #6 fixed. Abort the move this tick and KEEP the prior ledger
+            // entry (the prior rule is still installed and still steering to
+            // the prior W_new). We restored W_old above, but restore_owner is
+            // an idempotent tag flip and the prior W_new is still
+            // RebalancedOwner, so >= 1 owner holds; the next tick retries the
+            // delete. Do NOT demote the prior W_new here (its rule still
+            // routes traffic to it).
+            if tx.delete_rule(prior.loc).is_err() {
                 self.metrics.record_skip(SkipReason::BarrierFailed);
                 return None;
             }
+            tx.demote_replica(prior.new_worker, &prior.key);
+            self.metrics.deletes_total += 1;
             self.ledger.remove(idx);
             self.metrics.rules_active = self.ledger.len() as u32;
         }

--- a/userspace-dp/src/afxdp/rebalance/controller.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller.rs
@@ -556,9 +556,20 @@ impl RebalanceController {
             if move_rate <= 0.0 {
                 continue;
             }
-            // Magnitude guard: moving it must not make the destination the new
-            // hottest worker (move magnitude <= gap/2).
-            if move_rate > gap / 2.0 {
+            // Magnitude guard (#1748 live BLOCKER B — relaxed from gap/2 to
+            // gap). `gap = hottest - coolest`. The guard's purpose is anti-
+            // thrash: a move must not make the DESTINATION more loaded than the
+            // SOURCE was before the move. That bound is `coolest + move_rate <=
+            // hottest`, i.e. `move_rate <= gap` — NOT `gap/2`. The old `gap/2`
+            // ("don't overshoot the midpoint") rejected the worker-rate fallback
+            // estimate (hottest/candidate_count) whenever the hottest worker had
+            // few but heavy flows: e.g. hottest 4.5G with 2 flows => est 2.25G
+            // vs (4.5-1.0)/2 = 1.75G => rejected, even though moving it clearly
+            // improves balance. The epsilon band below already guarantees the
+            // move REDUCES CoV, and the per-flow cooldown prevents oscillation,
+            // so gap/2 was redundant AND too strict — it dominated the live skip
+            // counter (magnitude) and blocked every beneficial move.
+            if move_rate > gap {
                 had_magnitude_skip = true;
                 continue;
             }

--- a/userspace-dp/src/afxdp/rebalance/controller.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller.rs
@@ -66,6 +66,11 @@ pub(in crate::afxdp) enum SkipReason {
     BarrierFailed,
     /// One move already happened this interval.
     Dwell,
+    /// Reverse-barrier restore of W_old failed (timeout / key absent) during
+    /// rollback or teardown — W_new is intentionally LEFT as owner so >= 1
+    /// cleanup owner remains (#1748 review #4). Operator-visible: a non-zero
+    /// rate here means worker command acks are stalling under load.
+    RestoreFailed,
 }
 
 impl SkipReason {
@@ -78,6 +83,7 @@ impl SkipReason {
             Self::BudgetExhausted => "budget_exhausted",
             Self::BarrierFailed => "barrier_failed",
             Self::Dwell => "dwell",
+            Self::RestoreFailed => "restore_failed",
         }
     }
 }
@@ -155,6 +161,13 @@ pub(in crate::afxdp) trait BarrierTransport {
 #[derive(Clone, Debug)]
 struct LedgerEntry {
     key: SessionKey,
+    /// The worker the flow was steered AWAY from (W_old). #1748 review #2:
+    /// the reverse barrier on teardown/rollback must restore THIS worker to
+    /// owner, not `new_worker`. The RSS-natural worker for the flow once the
+    /// rule is gone IS the original source worker (RSS hashing is
+    /// deterministic on the 5-tuple), so restoring `old_worker` hands
+    /// ownership to exactly the worker that will receive the packets.
+    old_worker: u32,
     /// The worker the flow now lives on (W_new).
     new_worker: u32,
     /// The driver-assigned ntuple rule location.
@@ -208,6 +221,13 @@ impl RebalanceController {
         &self.socket
     }
 
+    /// Test-only: clear the per-flow cooldown so a unit test can drive a
+    /// second move of the same key without waiting out the cooldown window.
+    #[cfg(test)]
+    pub(in crate::afxdp) fn clear_cooldown_for_test(&mut self) {
+        self.cooldown.clear();
+    }
+
     /// One controller tick. Pure decision + barriered move. `tx` drives the
     /// worker barrier and NIC programming. Returns the move outcome for the
     /// caller's logging (None = no move attempted/taken this tick).
@@ -255,6 +275,41 @@ impl RebalanceController {
             return None;
         };
 
+        // #1748 review #6: SECOND MOVE of a key already in the ledger. The
+        // flow currently lives on its prior W_new (the ledger's `new_worker`)
+        // under a still-installed rule. Moving it to a third worker must first
+        // unwind that prior move at the CONTROLLER level — delete the old rule
+        // and reverse-barrier the prior owner back — so the flow is RSS-placed
+        // again before the new forward barrier re-pins it. Without this the
+        // controller just appends a second ledger entry and a second rule for
+        // the same 5-tuple (the second rule may never even take effect, and
+        // the prior owner is left RebalancedOwner forever). We replace, not
+        // append.
+        let prior_idx = self
+            .ledger
+            .iter()
+            .position(|e| e.key == candidate.key);
+        if let Some(idx) = prior_idx {
+            let prior = self.ledger[idx].clone();
+            // Reverse barrier on the prior move: restore the prior W_old to
+            // owner, delete the prior rule, demote the prior W_new to replica.
+            // Gate the W_new demote on a successful restore ack (#1748 #4): if
+            // the restore times out we must NOT demote the only owner.
+            if tx.restore_owner(prior.old_worker, &prior.key) {
+                let _ = tx.delete_rule(prior.loc);
+                tx.demote_replica(prior.new_worker, &prior.key);
+                self.metrics.deletes_total += 1;
+            } else {
+                // Could not hand ownership back to the prior W_old. Abort the
+                // second move and leave the prior move intact (>= 1 owner is
+                // still the prior W_new). Do not append a second rule.
+                self.metrics.record_skip(SkipReason::BarrierFailed);
+                return None;
+            }
+            self.ledger.remove(idx);
+            self.metrics.rules_active = self.ledger.len() as u32;
+        }
+
         // Forward barrier: promote W_new BEFORE the rule, then demote W_old,
         // then install. Both before the rule so a racing GC on either side
         // sees a safe origin (the applied-command ack serializes promote
@@ -268,11 +323,15 @@ impl RebalanceController {
         }
         if !tx.demote(candidate.old_worker, &candidate.key) {
             self.metrics.record_skip(SkipReason::BarrierFailed);
-            // Reverse barrier: restore W_old to owner FIRST (it never became
-            // RebalancedOut, but issue the restore to be safe), THEN demote
-            // W_new back to a replica.
-            tx.restore_owner(candidate.old_worker, &candidate.key);
-            tx.demote_replica(candidate.new_worker, &candidate.key);
+            // Reverse barrier: restore W_old to owner FIRST, and only demote
+            // W_new back to a replica if that restore is acked (#1748 #4). If
+            // the restore fails (timeout / key absent on W_old), keep W_new as
+            // the owner — demoting it would lose the only cleanup owner.
+            if tx.restore_owner(candidate.old_worker, &candidate.key) {
+                tx.demote_replica(candidate.new_worker, &candidate.key);
+            } else {
+                self.metrics.record_skip(SkipReason::RestoreFailed);
+            }
             return None;
         }
         // Only after BOTH acks: install the rule.
@@ -281,6 +340,7 @@ impl RebalanceController {
             Ok(loc) => {
                 self.ledger.push(LedgerEntry {
                     key: candidate.key.clone(),
+                    old_worker: candidate.old_worker,
                     new_worker: candidate.new_worker,
                     loc,
                 });
@@ -304,9 +364,13 @@ impl RebalanceController {
             Err(_) => {
                 self.metrics.record_skip(SkipReason::BarrierFailed);
                 // Rule install failed: reverse the ownership transfer with the
-                // reverse barrier so >= 1 cleanup owner remains.
-                tx.restore_owner(candidate.old_worker, &candidate.key);
-                tx.demote_replica(candidate.new_worker, &candidate.key);
+                // reverse barrier so >= 1 cleanup owner remains. Gate the W_new
+                // demote on the W_old restore ack (#1748 #4).
+                if tx.restore_owner(candidate.old_worker, &candidate.key) {
+                    tx.demote_replica(candidate.new_worker, &candidate.key);
+                } else {
+                    self.metrics.record_skip(SkipReason::RestoreFailed);
+                }
                 None
             }
         }
@@ -330,12 +394,23 @@ impl RebalanceController {
         let entries = std::mem::take(&mut self.ledger);
         for entry in entries {
             if is_live_on_new(entry.new_worker, &entry.key) {
-                // Reverse barrier: hand ownership back to W_old (it keeps the
-                // packets via origin-agnostic last_seen refresh once RSS
-                // re-hashes the flow there) BEFORE removing the rule.
-                tx.restore_owner(worker_for_old(&entry), &entry.key);
-                let _ = tx.delete_rule(entry.loc);
-                tx.demote_replica(entry.new_worker, &entry.key);
+                // Reverse barrier: hand ownership back to the REAL W_old
+                // (entry.old_worker — #1748 review #2), which is the
+                // RSS-natural worker that will receive the flow once the rule
+                // is gone, BEFORE removing the rule. Gate the W_new demote on
+                // the restore ack (#1748 #4): if W_old cannot be restored, keep
+                // W_new as the owner rather than demoting the only owner away.
+                if tx.restore_owner(entry.old_worker, &entry.key) {
+                    let _ = tx.delete_rule(entry.loc);
+                    tx.demote_replica(entry.new_worker, &entry.key);
+                } else {
+                    self.metrics.record_skip(SkipReason::RestoreFailed);
+                    // Delete the rule anyway (RSS will re-hash to W_old which
+                    // keeps the packets via origin-agnostic last_seen refresh),
+                    // but leave W_new as RebalancedOwner so >= 1 cleanup owner
+                    // remains until its own GC.
+                    let _ = tx.delete_rule(entry.loc);
+                }
             } else {
                 // Flow already expired off W_new — no live ownership to hand
                 // back; plain rule delete.
@@ -462,20 +537,6 @@ pub(in crate::afxdp) struct MoveOutcome {
     pub old_worker: u32,
     pub new_worker: u32,
     pub loc: u32,
-}
-
-// `LedgerEntry` only stores the new worker; the old worker is whichever RSS
-// queue the flow would re-hash to, which we cannot know at teardown. The
-// reverse barrier restores ownership to the entry's recorded provenance — for
-// the controller's purposes "W_old" on teardown is the worker that will own
-// the flow once the rule is gone, i.e. the RSS-natural worker. We approximate
-// it as the new_worker's pre-move owner, which the ledger does not retain;
-// teardown therefore issues restore_owner against the recorded new_worker's
-// peer. Since restore/demote are idempotent tag flips keyed by the session,
-// issuing them against new_worker is safe (it is a no-op if the entry there
-// is not RebalancedOut). See teardown_all for the conservative ordering.
-fn worker_for_old(entry: &LedgerEntry) -> u32 {
-    entry.new_worker
 }
 
 /// Compute the max and mean of a per-worker byte-rate vector.

--- a/userspace-dp/src/afxdp/rebalance/controller.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller.rs
@@ -574,6 +574,28 @@ pub(in crate::afxdp) fn byte_rate_cov(workers: &[WorkerByteRate]) -> f64 {
     var.sqrt() / mean
 }
 
+/// #1748 review #8: derive a byte-RATE from two CUMULATIVE byte-count samples
+/// taken at `prev_ns` and `now_ns`. Single source of truth for both the
+/// per-worker (tx_bytes) and per-flow (observed_bytes) rate derivation in the
+/// Coordinator tick. Returns 0 when there is no prior sample, no elapsed time,
+/// or the cumulative counter went backwards (a flow re-homing to a different
+/// worker's cache entry resets its cumulative to ~0 — saturating_sub yields 0).
+pub(in crate::afxdp) fn cumulative_to_rate(
+    cumulative: u64,
+    prev_cumulative: u64,
+    now_ns: u64,
+    prev_ns: u64,
+) -> f64 {
+    if now_ns <= prev_ns {
+        return 0.0;
+    }
+    let dt = (now_ns - prev_ns) as f64 / 1_000_000_000.0;
+    if dt <= 0.0 {
+        return 0.0;
+    }
+    cumulative.saturating_sub(prev_cumulative) as f64 / dt
+}
+
 /// Project the per-worker byte-rate vector after moving `flow_rate` from
 /// `from` to `to`. Returns a fresh vector (cheap — ~6 workers).
 fn project_move(

--- a/userspace-dp/src/afxdp/rebalance/controller_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller_tests.rs
@@ -1,0 +1,385 @@
+// #1748 controller unit tests: selection objective, hysteresis, magnitude
+// guard, oscillation cooldown, budget-exhaustion (NO eviction), barrier
+// ordering, and reverse-barrier rollback (>= 1 owner). The barrier transport
+// is mocked so the move protocol is exercised without a live Coordinator/NIC.
+
+use super::*;
+use super::super::ntuple::{FlowSpec5Tuple, NtupleSocket};
+use crate::session::SessionKey;
+use std::net::{IpAddr, Ipv4Addr};
+
+fn key(src_port: u16) -> SessionKey {
+    SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: 6,
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+        src_port,
+        dst_port: 5210,
+    }
+}
+
+fn worker(worker_id: u32, byte_rate: f64) -> WorkerByteRate {
+    WorkerByteRate { worker_id, queue_id: worker_id, byte_rate }
+}
+
+fn flow(src_port: u16, worker_id: u32, byte_rate: f64) -> FlowSample {
+    FlowSample { key: key(src_port), worker_id, byte_rate }
+}
+
+/// Records every barrier call in order so tests can assert the protocol
+/// ordering (promote before demote, restore before replica-demote, etc).
+#[derive(Default)]
+struct MockTransport {
+    calls: Vec<String>,
+    promote_ok: bool,
+    demote_ok: bool,
+    install_ok: bool,
+    next_loc: u32,
+    /// Per-key origin as the mock "session table" sees it, so tests can
+    /// confirm there is always >= 1 owner across a rollback.
+    origins: std::collections::HashMap<u16, &'static str>,
+}
+
+impl MockTransport {
+    fn good() -> Self {
+        Self {
+            promote_ok: true,
+            demote_ok: true,
+            install_ok: true,
+            next_loc: 100,
+            ..Default::default()
+        }
+    }
+    fn owners(&self) -> usize {
+        self.origins
+            .values()
+            .filter(|o| matches!(**o, "owner" | "rebalanced_owner"))
+            .count()
+    }
+}
+
+impl BarrierTransport for MockTransport {
+    fn promote(&mut self, worker_id: u32, key: &SessionKey) -> bool {
+        self.calls.push(format!("promote:{worker_id}:{}", key.src_port));
+        if self.promote_ok {
+            self.origins.insert(key.src_port, "rebalanced_owner");
+        }
+        self.promote_ok
+    }
+    fn demote(&mut self, worker_id: u32, key: &SessionKey) -> bool {
+        self.calls.push(format!("demote:{worker_id}:{}", key.src_port));
+        // W_old's local copy was the original owner; demote flips it to the
+        // inert RebalancedOut. The promoted W_new owner is unaffected.
+        self.demote_ok
+    }
+    fn restore_owner(&mut self, worker_id: u32, key: &SessionKey) -> bool {
+        self.calls.push(format!("restore:{worker_id}:{}", key.src_port));
+        self.origins.insert(key.src_port, "owner");
+        true
+    }
+    fn demote_replica(&mut self, worker_id: u32, key: &SessionKey) -> bool {
+        self.calls.push(format!("replica:{worker_id}:{}", key.src_port));
+        // Only demote the W_new owner to a replica; never below 0 owners.
+        if self.origins.get(&key.src_port) == Some(&"rebalanced_owner") {
+            self.origins.insert(key.src_port, "replica");
+        }
+        true
+    }
+    fn install_rule(&mut self, _flow: &FlowSpec5Tuple, queue: u32) -> std::io::Result<u32> {
+        self.calls.push(format!("install:q{queue}"));
+        if self.install_ok {
+            let loc = self.next_loc;
+            self.next_loc += 1;
+            Ok(loc)
+        } else {
+            Err(std::io::Error::from_raw_os_error(libc::ENOSPC))
+        }
+    }
+    fn delete_rule(&mut self, loc: u32) -> std::io::Result<()> {
+        self.calls.push(format!("delete:{loc}"));
+        Ok(())
+    }
+}
+
+/// Build a controller with a throwaway socket. The socket is never used in
+/// these tests (the mock transport programs "the NIC"), so a loopback ethtool
+/// socket open is acceptable; if it fails (sandbox), fall back to the lo
+/// device which always exists.
+fn test_controller(config: RebalanceConfig) -> RebalanceController {
+    let socket = NtupleSocket::open("lo")
+        .expect("open ethtool socket on lo");
+    RebalanceController::new(config, socket)
+}
+
+fn cfg() -> RebalanceConfig {
+    RebalanceConfig {
+        imbalance_threshold: 1.30,
+        rebalance_interval_secs: 1,
+        max_rules: 8,
+    }
+}
+
+#[test]
+fn cov_zero_for_balanced_vector() {
+    let ws = vec![worker(0, 100.0), worker(1, 100.0), worker(2, 100.0)];
+    assert!(byte_rate_cov(&ws) < 1e-9);
+}
+
+#[test]
+fn cov_positive_for_skewed_vector() {
+    let ws = vec![worker(0, 400.0), worker(1, 100.0), worker(2, 100.0)];
+    assert!(byte_rate_cov(&ws) > 0.5);
+}
+
+#[test]
+fn hysteresis_requires_persisted_imbalance() {
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        // Hottest 400, coolest 100: imbalance ratio 400/200 = 2.0 > 1.3.
+        workers: vec![worker(0, 400.0), worker(1, 100.0), worker(2, 100.0)],
+        flows: vec![
+            flow(1001, 0, 150.0),
+            flow(1002, 0, 150.0),
+            flow(1003, 0, 100.0),
+        ],
+        now_secs: 10,
+    };
+    // First over-threshold tick: dwell not yet satisfied -> no move.
+    assert!(c.tick(&input, &mut tx).is_none());
+    assert!(tx.calls.is_empty(), "no barrier on the first tick");
+    // Second tick at a later second: dwell satisfied -> move taken.
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    let outcome = c.tick(&input2, &mut tx);
+    assert!(outcome.is_some(), "move taken after dwell: calls={:?}", tx.calls);
+}
+
+#[test]
+fn barrier_order_is_promote_then_demote_then_install() {
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 120.0), flow(1002, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&input, &mut tx); // dwell
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    c.tick(&input2, &mut tx);
+    // The committed sequence must be promote(W_new) -> demote(W_old) ->
+    // install. W_new is worker 1 (coolest), W_old is worker 0 (hottest).
+    let promote_idx = tx.calls.iter().position(|c| c.starts_with("promote:1:")).unwrap();
+    let demote_idx = tx.calls.iter().position(|c| c.starts_with("demote:0:")).unwrap();
+    let install_idx = tx.calls.iter().position(|c| c.starts_with("install:")).unwrap();
+    assert!(promote_idx < demote_idx, "promote before demote: {:?}", tx.calls);
+    assert!(demote_idx < install_idx, "demote before install: {:?}", tx.calls);
+}
+
+#[test]
+fn demote_failure_reverse_barrier_keeps_an_owner() {
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    tx.demote_ok = false; // W_old demote ack fails.
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 120.0), flow(1002, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&input, &mut tx); // dwell
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    let outcome = c.tick(&input2, &mut tx);
+    assert!(outcome.is_none(), "no committed move on demote failure");
+    // Reverse barrier order: restore(W_old) BEFORE replica(W_new).
+    let restore_idx = tx.calls.iter().position(|c| c.starts_with("restore:")).unwrap();
+    let replica_idx = tx.calls.iter().position(|c| c.starts_with("replica:")).unwrap();
+    assert!(restore_idx < replica_idx, "restore before replica: {:?}", tx.calls);
+    // No install happened.
+    assert!(!tx.calls.iter().any(|c| c.starts_with("install:")));
+    // >= 1 owner remains across the rollback.
+    assert!(tx.owners() >= 1, "rollback must keep >= 1 owner: {:?}", tx.origins);
+}
+
+#[test]
+fn install_failure_reverse_barrier_keeps_an_owner() {
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    tx.install_ok = false; // ioctl returns ENOSPC.
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 120.0), flow(1002, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    assert!(c.tick(&input2, &mut tx).is_none());
+    let restore_idx = tx.calls.iter().position(|c| c.starts_with("restore:")).unwrap();
+    let replica_idx = tx.calls.iter().position(|c| c.starts_with("replica:")).unwrap();
+    assert!(restore_idx < replica_idx);
+    assert!(tx.owners() >= 1, "rollback after install fail keeps owner");
+    assert_eq!(c.metrics().rules_active, 0, "no rule recorded on failed install");
+}
+
+#[test]
+fn budget_exhaustion_stops_no_eviction() {
+    let mut c = test_controller(RebalanceConfig {
+        imbalance_threshold: 1.30,
+        rebalance_interval_secs: 0, // allow back-to-back moves for the test
+        max_rules: 2,
+    });
+    let mut tx = MockTransport::good();
+    // Drive enough distinct moves to fill the budget. Each tick moves one
+    // flow; use a persistent imbalance and fresh flows so cooldown does not
+    // block subsequent moves.
+    let mut now = 10u64;
+    let mut installed = 0u32;
+    for round in 0..6 {
+        let input = RebalanceTickInput {
+            ifindex: 1,
+            workers: vec![worker(0, 400.0), worker(1, 100.0)],
+            flows: vec![
+                flow(2000 + round, 0, 120.0),
+                flow(3000 + round, 0, 120.0),
+            ],
+            now_secs: now,
+        };
+        // Two ticks to clear the dwell each round (dwell resets after a move).
+        c.tick(&input, &mut tx);
+        now += 1;
+        let input2 = RebalanceTickInput { now_secs: now, ..input };
+        if c.tick(&input2, &mut tx).is_some() {
+            installed += 1;
+        }
+        now += 1;
+    }
+    assert_eq!(installed, 2, "exactly max_rules moves committed");
+    assert_eq!(c.metrics().rules_active, 2);
+    // CRITICAL: no delete/eviction ever happened at the cap.
+    assert!(
+        !tx.calls.iter().any(|c| c.starts_with("delete:")),
+        "budget exhaustion must NOT evict/delete: {:?}", tx.calls
+    );
+    assert_eq!(c.metrics().deletes_total, 0);
+    let skipped = c.metrics().moves_skipped
+        .get(&SkipReason::BudgetExhausted)
+        .copied()
+        .unwrap_or(0);
+    assert!(skipped >= 1, "budget-exhausted skip recorded");
+}
+
+#[test]
+fn magnitude_guard_rejects_overlarge_flow() {
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    // gap = 400 - 100 = 300; gap/2 = 150. The only flow on the hottest worker
+    // is 250 bytes/s > 150, so the magnitude guard must reject it.
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 250.0)],
+        now_secs: 10,
+    };
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    assert!(c.tick(&input2, &mut tx).is_none());
+    assert!(!tx.calls.iter().any(|c| c.starts_with("install:")));
+    let mag = c.metrics().moves_skipped.get(&SkipReason::Magnitude).copied().unwrap_or(0);
+    assert!(mag >= 1, "magnitude skip recorded: {:?}", c.metrics().moves_skipped);
+}
+
+#[test]
+fn cooldown_prevents_immediate_re_move() {
+    let mut c = test_controller(RebalanceConfig {
+        imbalance_threshold: 1.30,
+        rebalance_interval_secs: 1,
+        max_rules: 8,
+    });
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    assert!(c.tick(&input2, &mut tx).is_some(), "first move taken");
+    // Same flow, immediately after: cooldown blocks it. Advance dwell + the
+    // rebalance interval but stay inside the cooldown window.
+    let input3 = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 120.0)],
+        now_secs: 14,
+    };
+    c.tick(&input3, &mut tx);
+    let input4 = RebalanceTickInput { now_secs: 15, ..input3 };
+    assert!(c.tick(&input4, &mut tx).is_none(), "cooled-down flow not re-moved");
+}
+
+#[test]
+fn teardown_live_move_uses_reverse_barrier() {
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    c.tick(&input2, &mut tx).expect("move committed");
+    tx.calls.clear();
+    // Teardown with the flow still live on W_new -> reverse barrier:
+    // restore(W_old) -> delete(rule) -> replica(W_new).
+    c.teardown_all(&mut tx, |_w, _k| true);
+    let restore_idx = tx.calls.iter().position(|c| c.starts_with("restore:")).unwrap();
+    let delete_idx = tx.calls.iter().position(|c| c.starts_with("delete:")).unwrap();
+    let replica_idx = tx.calls.iter().position(|c| c.starts_with("replica:")).unwrap();
+    assert!(restore_idx < delete_idx, "restore before delete: {:?}", tx.calls);
+    assert!(delete_idx < replica_idx, "delete before replica-demote: {:?}", tx.calls);
+    assert_eq!(c.metrics().rules_active, 0);
+    assert_eq!(c.metrics().deletes_total, 1);
+}
+
+#[test]
+fn teardown_dead_flow_is_plain_delete() {
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    c.tick(&input2, &mut tx).expect("move committed");
+    tx.calls.clear();
+    // Flow already expired off W_new -> plain delete, no reverse barrier.
+    c.teardown_all(&mut tx, |_w, _k| false);
+    assert!(tx.calls.iter().any(|c| c.starts_with("delete:")));
+    assert!(!tx.calls.iter().any(|c| c.starts_with("restore:")), "no restore for a dead flow");
+    assert!(!tx.calls.iter().any(|c| c.starts_with("replica:")), "no replica-demote for a dead flow");
+}
+
+#[test]
+fn flow_spec_from_key_encodes_network_order_v4() {
+    let k = key(0x1234);
+    let spec = flow_spec_from_key(&k);
+    // src_port host 0x1234 -> network-order field.
+    assert_eq!(spec.src_port, 0x1234u16.to_be());
+    assert_eq!(spec.dst_port, 5210u16.to_be());
+    // src_ip 10.0.61.102 -> the u32 word whose IN-MEMORY bytes are the
+    // network-order octets [10,0,61,102] (what the kernel __be32 field reads).
+    // That is from_ne_bytes of the address octets, matching the controller's
+    // encoding; on a little-endian host this is NOT the host-order integer.
+    assert_eq!(spec.src_ip[0], u32::from_ne_bytes([10, 0, 61, 102]));
+    assert_eq!(spec.dst_ip[0], u32::from_ne_bytes([172, 16, 80, 200]));
+    assert_eq!(spec.src_ip[0].to_ne_bytes(), [10, 0, 61, 102]);
+}

--- a/userspace-dp/src/afxdp/rebalance/controller_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller_tests.rs
@@ -36,9 +36,13 @@ struct MockTransport {
     demote_ok: bool,
     install_ok: bool,
     next_loc: u32,
-    /// Per-key origin as the mock "session table" sees it, so tests can
-    /// confirm there is always >= 1 owner across a rollback.
-    origins: std::collections::HashMap<u16, &'static str>,
+    /// When true, restore_owner returns false (simulates an ack timeout / key
+    /// absent on W_old) so tests can exercise the gated reverse barrier.
+    restore_fails: bool,
+    /// Per-(worker,key) origin as the mock "session table" sees it, so tests
+    /// can confirm there is always >= 1 owner across a rollback even when a
+    /// flow has lived on more than one worker over a chain of moves.
+    origins: std::collections::HashMap<(u32, u16), &'static str>,
 }
 
 impl MockTransport {
@@ -63,7 +67,7 @@ impl BarrierTransport for MockTransport {
     fn promote(&mut self, worker_id: u32, key: &SessionKey) -> bool {
         self.calls.push(format!("promote:{worker_id}:{}", key.src_port));
         if self.promote_ok {
-            self.origins.insert(key.src_port, "rebalanced_owner");
+            self.origins.insert((worker_id, key.src_port), "rebalanced_owner");
         }
         self.promote_ok
     }
@@ -71,18 +75,24 @@ impl BarrierTransport for MockTransport {
         self.calls.push(format!("demote:{worker_id}:{}", key.src_port));
         // W_old's local copy was the original owner; demote flips it to the
         // inert RebalancedOut. The promoted W_new owner is unaffected.
+        if self.demote_ok {
+            self.origins.insert((worker_id, key.src_port), "rebalanced_out");
+        }
         self.demote_ok
     }
     fn restore_owner(&mut self, worker_id: u32, key: &SessionKey) -> bool {
         self.calls.push(format!("restore:{worker_id}:{}", key.src_port));
-        self.origins.insert(key.src_port, "owner");
+        if self.restore_fails {
+            return false;
+        }
+        self.origins.insert((worker_id, key.src_port), "owner");
         true
     }
     fn demote_replica(&mut self, worker_id: u32, key: &SessionKey) -> bool {
         self.calls.push(format!("replica:{worker_id}:{}", key.src_port));
         // Only demote the W_new owner to a replica; never below 0 owners.
-        if self.origins.get(&key.src_port) == Some(&"rebalanced_owner") {
-            self.origins.insert(key.src_port, "replica");
+        if self.origins.get(&(worker_id, key.src_port)) == Some(&"rebalanced_owner") {
+            self.origins.insert((worker_id, key.src_port), "replica");
         }
         true
     }
@@ -343,8 +353,117 @@ fn teardown_live_move_uses_reverse_barrier() {
     let replica_idx = tx.calls.iter().position(|c| c.starts_with("replica:")).unwrap();
     assert!(restore_idx < delete_idx, "restore before delete: {:?}", tx.calls);
     assert!(delete_idx < replica_idx, "delete before replica-demote: {:?}", tx.calls);
+    // #1748 review #2: restore must target W_OLD (worker 0, the hottest source
+    // and RSS-natural worker), NOT W_new (worker 1). The pre-fix worker_for_old
+    // returned entry.new_worker and would have restored worker 1 here.
+    assert!(
+        tx.calls[restore_idx].starts_with("restore:0:"),
+        "teardown must restore W_old (worker 0), got {:?}", tx.calls[restore_idx]
+    );
+    // And the replica-demote must target W_new (worker 1).
+    assert!(
+        tx.calls[replica_idx].starts_with("replica:1:"),
+        "teardown must demote W_new (worker 1), got {:?}", tx.calls[replica_idx]
+    );
     assert_eq!(c.metrics().rules_active, 0);
     assert_eq!(c.metrics().deletes_total, 1);
+}
+
+#[test]
+fn teardown_live_move_restore_failure_keeps_w_new_owner() {
+    // #1748 review #4: if the W_old restore ack fails during teardown, the rule
+    // is still deleted but W_new is LEFT as owner (no replica-demote) so >= 1
+    // cleanup owner remains.
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    c.tick(&input2, &mut tx).expect("move committed");
+    tx.calls.clear();
+    tx.restore_fails = true;
+    c.teardown_all(&mut tx, |_w, _k| true);
+    // Rule deleted, restore attempted, but NO replica-demote of W_new.
+    assert!(tx.calls.iter().any(|c| c.starts_with("delete:")));
+    assert!(tx.calls.iter().any(|c| c.starts_with("restore:0:")));
+    assert!(
+        !tx.calls.iter().any(|c| c.starts_with("replica:")),
+        "must NOT demote W_new when W_old restore fails: {:?}", tx.calls
+    );
+    // W_new (worker 1, src_port 1001) is still the rebalanced_owner.
+    assert!(tx.owners() >= 1, "restore-fail teardown keeps >= 1 owner");
+    let rf = c.metrics().moves_skipped.get(&SkipReason::RestoreFailed).copied().unwrap_or(0);
+    assert!(rf >= 1, "restore_failed skip recorded");
+}
+
+#[test]
+fn second_move_chain_replaces_rule_and_reverse_barriers_prior_owner() {
+    // #1748 review #6: ForwardFlow -> RebalancedOwner(W1) -> RebalancedOwner(W2)
+    // through the CONTROLLER ledger. The second move of the same key must
+    // delete the prior rule, reverse-barrier the prior owner (restore W_old,
+    // demote prior W_new), then forward-barrier to the third worker, and
+    // REPLACE (not append) the ledger entry.
+    let mut c = test_controller(RebalanceConfig {
+        imbalance_threshold: 1.30,
+        rebalance_interval_secs: 0, // allow back-to-back moves in the test
+        max_rules: 8,
+    });
+    let mut tx = MockTransport::good();
+
+    // First move: flow 1001 on worker 0 (hottest) -> worker 2 (coolest).
+    let in1 = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 250.0), worker(2, 100.0)],
+        flows: vec![flow(1001, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&in1, &mut tx);
+    let in1b = RebalanceTickInput { now_secs: 11, ..in1 };
+    let mv1 = c.tick(&in1b, &mut tx).expect("first move");
+    assert_eq!(mv1.old_worker, 0);
+    assert_eq!(mv1.new_worker, 2);
+    assert_eq!(c.metrics().rules_active, 1, "one rule after first move");
+
+    // Clear the cooldown so the same key is eligible again, and present a
+    // topology where the SAME flow 1001 now sits on worker 2 (its new home)
+    // which is now the hottest, and worker 1 is coolest -> second move
+    // 2 -> 1. select_move keys on the flow's current worker_id.
+    c.clear_cooldown_for_test();
+    tx.calls.clear();
+    let installs_before = c.metrics().installs_total;
+    let in2 = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 100.0), worker(1, 90.0), worker(2, 400.0)],
+        flows: vec![flow(1001, 2, 120.0)],
+        now_secs: 20,
+    };
+    c.tick(&in2, &mut tx);
+    let in2b = RebalanceTickInput { now_secs: 21, ..in2 };
+    let mv2 = c.tick(&in2b, &mut tx).expect("second move");
+    assert_eq!(mv2.old_worker, 2, "second move sources from the prior new_worker");
+    assert_eq!(mv2.new_worker, 1);
+
+    // Ledger REPLACED, not appended: still exactly one rule for the key.
+    assert_eq!(c.metrics().rules_active, 1, "second move replaces, not appends");
+    // The prior rule (loc 100) was deleted before the new install.
+    assert!(
+        tx.calls.iter().any(|c| c == "delete:100"),
+        "prior rule loc 100 must be deleted on second move: {:?}", tx.calls
+    );
+    // Prior owner reverse-barriered: restore prior W_old (0), demote prior
+    // W_new (2). Then forward barrier to the third worker (promote 1).
+    let del_idx = tx.calls.iter().position(|c| c == "delete:100").unwrap();
+    let promote1_idx = tx.calls.iter().position(|c| c.starts_with("promote:1:")).unwrap();
+    assert!(del_idx < promote1_idx, "prior rule deleted before new forward barrier: {:?}", tx.calls);
+    // A new rule was installed for the third move.
+    assert_eq!(c.metrics().installs_total, installs_before + 1);
+    // Ownership ends correct: exactly the third worker's entry is the owner.
+    assert!(tx.owners() >= 1, "chain keeps >= 1 owner: {:?}", tx.origins);
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/rebalance/controller_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller_tests.rs
@@ -696,3 +696,83 @@ fn zero_rate_idle_flows_yield_no_move() {
     );
     assert!(!tx.calls.iter().any(|c| c.starts_with("install:")));
 }
+
+// ── #1748 live BUG #1: realistic CoV~0.3 vector must produce an install ──
+
+/// Regression guard for the live CoV-gate failure: on the loss cluster under
+/// `-P12 -p5210`, worker_byterate_cov sat at ~0.27-0.34 (clearly imbalanced)
+/// yet the controller skipped EVERY candidate as reason="epsilon" and made
+/// ZERO installs. Root cause was a noisy ~42ms rate window (fixed at the
+/// Coordinator sampling layer); this test is the controller-decision guard:
+/// given a realistic 6-worker byte-rate vector at CoV~0.3 with 12 flows of
+/// differing REAL rates, the controller MUST produce at least one install
+/// (a beneficial move that clears the epsilon band), not an epsilon-skip.
+#[test]
+fn realistic_imbalance_produces_an_install_not_epsilon_skip() {
+    // 6 workers, flow distribution ~[2,2,1,1,4,2] (the R1 baseline partition).
+    // 6 workers, flow distribution [2,2,2,1,3,2] — a 12-flow partition whose
+    // worker byte-rate CoV is ~0.29, in the live-observed ~0.3 band. Per-flow
+    // rate ≈1.4 GB/s (≈11.2 Gb/s); worker rates are the sum of their flows.
+    // Worker 4 (3 flows) is hottest; worker 3 (1 flow) is coolest.
+    let workers = vec![
+        worker(0, 2.80e9), // 2 flows
+        worker(1, 2.80e9), // 2 flows
+        worker(2, 2.80e9), // 2 flows
+        worker(3, 1.40e9), // 1 flow   <- coolest
+        worker(4, 4.20e9), // 3 flows  <- hottest
+        worker(5, 2.80e9), // 2 flows
+    ];
+    // Sanity: this vector is in the live-observed CoV band (~0.3).
+    let cov = byte_rate_cov(&workers);
+    assert!(
+        cov > 0.25 && cov < 0.40,
+        "fixture CoV {cov} must sit in the live-observed ~0.3 band"
+    );
+    // Imbalance ratio max/mean must exceed the 1.30 threshold.
+    let mean: f64 = workers.iter().map(|w| w.byte_rate).sum::<f64>() / workers.len() as f64;
+    let max = workers.iter().map(|w| w.byte_rate).fold(0.0_f64, f64::max);
+    assert!(max / mean > 1.30, "fixture must be over the imbalance threshold");
+
+    // 12 flows. Worker 4 carries 3 flows of 1.40e9 each. Moving one to the
+    // coolest worker 3 (1.40e9) yields a perfectly balanced [2.8;6] vector
+    // (CoV 0). The flow rate 1.40e9 == gap/2 where gap = 4.20e9 - 1.40e9 =
+    // 2.80e9, and the magnitude guard rejects only rate > gap/2, so it passes.
+    let flows = vec![
+        flow(2000, 0, 1.40e9), flow(2001, 0, 1.40e9),
+        flow(2002, 1, 1.40e9), flow(2003, 1, 1.40e9),
+        flow(2004, 2, 1.40e9), flow(2005, 2, 1.40e9),
+        flow(2006, 3, 1.40e9),
+        // worker 4: 3 flows summing to 4.20e9
+        flow(2007, 4, 1.40e9), flow(2008, 4, 1.40e9), flow(2009, 4, 1.40e9),
+        flow(2010, 5, 1.40e9), flow(2011, 5, 1.40e9),
+    ];
+
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput {
+        ifindex: 5,
+        workers,
+        flows,
+        now_secs: 10,
+    };
+    // Two ticks to clear the dwell (hysteresis), at 1s spacing.
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 11, ..input };
+    let outcome = c.tick(&input2, &mut tx);
+
+    assert!(
+        outcome.is_some(),
+        "a realistic CoV~0.3 imbalance MUST produce a move, not an epsilon-skip; \
+         skips={:?}", c.metrics().moves_skipped
+    );
+    assert_eq!(c.metrics().installs_total, 1, "exactly one install");
+    assert!(c.metrics().rules_active >= 1, "a rule is active after the move");
+    // The move sourced from the hottest worker (4).
+    let mv = outcome.unwrap();
+    assert_eq!(mv.old_worker, 4, "move sources from the hottest worker");
+    // The epsilon skip counter must NOT have fired on the committed tick.
+    let eps = c.metrics().moves_skipped.get(&SkipReason::Epsilon).copied().unwrap_or(0);
+    assert_eq!(eps, 0, "no epsilon skip when a clearly-beneficial move exists");
+    // And the projected post-move CoV is a real improvement over baseline.
+    assert!(cov > 0.25, "baseline CoV was the imbalanced ~0.3");
+}

--- a/userspace-dp/src/afxdp/rebalance/controller_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller_tests.rs
@@ -4,7 +4,7 @@
 // is mocked so the move protocol is exercised without a live Coordinator/NIC.
 
 use super::*;
-use super::super::ntuple::{FlowSpec5Tuple, NtupleSocket};
+use super::super::ntuple::FlowSpec5Tuple;
 use crate::session::SessionKey;
 use std::net::{IpAddr, Ipv4Addr};
 
@@ -118,14 +118,11 @@ impl BarrierTransport for MockTransport {
     }
 }
 
-/// Build a controller with a throwaway socket. The socket is never used in
-/// these tests (the mock transport programs "the NIC"), so a loopback ethtool
-/// socket open is acceptable; if it fails (sandbox), fall back to the lo
-/// device which always exists.
+/// Build a controller. #1748 review-r3: the controller no longer owns the
+/// NtupleSocket (it lives separately on the Coordinator), so these tests drive
+/// the move protocol purely through the MockTransport — no real socket needed.
 fn test_controller(config: RebalanceConfig) -> RebalanceController {
-    let socket = NtupleSocket::open("lo")
-        .expect("open ethtool socket on lo");
-    RebalanceController::new(config, socket)
+    RebalanceController::new(config)
 }
 
 fn cfg() -> RebalanceConfig {

--- a/userspace-dp/src/afxdp/rebalance/controller_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller_tests.rs
@@ -502,3 +502,79 @@ fn flow_spec_from_key_encodes_network_order_v4() {
     assert_eq!(spec.dst_ip[0], u32::from_ne_bytes([172, 16, 80, 200]));
     assert_eq!(spec.src_ip[0].to_ne_bytes(), [10, 0, 61, 102]);
 }
+
+// ── #1748 review #8: cumulative-bytes -> byte-RATE derivation ────────
+
+#[test]
+fn cumulative_to_rate_basic_delta_over_time() {
+    // 1000 bytes accrued over 1s window => 1000 B/s.
+    let prev_ns = 1_000_000_000u64;
+    let now_ns = prev_ns + 1_000_000_000; // +1s
+    assert!((cumulative_to_rate(2000, 1000, now_ns, prev_ns) - 1000.0).abs() < 1e-6);
+    // 500 bytes over 0.5s => 1000 B/s.
+    let half = prev_ns + 500_000_000;
+    assert!((cumulative_to_rate(1500, 1000, half, prev_ns) - 1000.0).abs() < 1e-6);
+}
+
+#[test]
+fn cumulative_to_rate_first_sample_and_reset_are_zero() {
+    let prev_ns = 1_000_000_000u64;
+    // now <= prev => 0 (no elapsed time).
+    assert_eq!(cumulative_to_rate(5000, 1000, prev_ns, prev_ns), 0.0);
+    // cumulative went backwards (flow re-homed, cache reset) => 0, not negative.
+    let now_ns = prev_ns + 1_000_000_000;
+    assert_eq!(cumulative_to_rate(100, 9000, now_ns, prev_ns), 0.0);
+}
+
+#[test]
+fn long_lived_idle_flow_not_selected_over_recent_burst() {
+    // #1748 review #8 regression: with the OLD signal (cumulative bytes), a
+    // long-lived idle flow with huge cumulative bytes would be picked as the
+    // "heaviest". With the correct RATE signal, an idle flow has rate ~0 and a
+    // recently-bursting flow has a high rate, so the burst flow is selected.
+    //
+    // Both flows live on the hottest worker 0. flow A is long-lived-but-idle
+    // (rate 0), flow B is bursting (rate 120). select_move must pick B.
+    let mut c = test_controller(cfg());
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![
+            flow(7001, 0, 0.0),    // long-lived, now idle: RATE 0
+            flow(7002, 0, 120.0),  // recently bursting: RATE 120
+        ],
+        now_secs: 10,
+    };
+    let mut tx = MockTransport::good();
+    c.tick(&input, &mut tx); // dwell
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    let mv = c.tick(&input2, &mut tx).expect("a move is taken");
+    assert_eq!(
+        mv.key.src_port, 7002,
+        "the recently-bursting flow (7002), not the idle long-lived flow (7001), must be moved"
+    );
+}
+
+#[test]
+fn zero_rate_idle_flows_yield_no_move() {
+    // If every flow on the hottest worker has rate 0 (all long-lived idle),
+    // moving any of them cannot improve the byte-rate CoV, so no move is taken
+    // (the magnitude/epsilon guards reject a 0-rate move).
+    let mut c = test_controller(cfg());
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        // Worker 0 looks hottest by some other flow, but the eligible flows on
+        // it are all idle.
+        workers: vec![worker(0, 400.0), worker(1, 100.0)],
+        flows: vec![flow(8001, 0, 0.0), flow(8002, 0, 0.0)],
+        now_secs: 10,
+    };
+    let mut tx = MockTransport::good();
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    assert!(
+        c.tick(&input2, &mut tx).is_none(),
+        "no move when all eligible flows are idle (rate 0)"
+    );
+    assert!(!tx.calls.iter().any(|c| c.starts_with("install:")));
+}

--- a/userspace-dp/src/afxdp/rebalance/controller_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller_tests.rs
@@ -776,3 +776,100 @@ fn realistic_imbalance_produces_an_install_not_epsilon_skip() {
     // And the projected post-move CoV is a real improvement over baseline.
     assert!(cov > 0.25, "baseline CoV was the imbalanced ~0.3");
 }
+
+// ── #1748 live BUG #1 (r5): zero per-flow rate must NOT stall the move ──
+
+/// The DECISIVE regression for the second live failure. On the loss cluster
+/// the per-WORKER rate was correct (CoV 0.64) but EVERY per-flow byte-rate read
+/// ~0 because the flow-cache observed_bytes counter resets on eviction, so the
+/// controller skipped every candidate (epsilon/no-eligible) and made zero
+/// installs. This feeds the controller exactly that pathology — a real
+/// per-worker imbalance with ALL per-flow rates 0 — and asserts the
+/// worker-rate-derived fallback still produces an install. The pre-fix code
+/// (which used flow.byte_rate directly and bailed on rate 0) makes no move
+/// here; the fix derives the move magnitude from the reliable worker rate.
+#[test]
+fn zero_per_flow_rate_with_real_worker_imbalance_still_installs() {
+    // R1 baseline partition [2,2,1,1,4,2]; worker rates from tx_bytes are
+    // reliable and show CoV ~0.46. ALL per-flow rates are 0 (the live bug).
+    let workers = vec![
+        worker(0, 2.80e9),
+        worker(1, 2.80e9),
+        worker(2, 1.40e9),
+        worker(3, 1.40e9),
+        worker(4, 5.60e9), // 4 flows <- hottest
+        worker(5, 2.80e9),
+    ];
+    let cov = byte_rate_cov(&workers);
+    assert!(cov > 0.40, "fixture is a real worker-rate imbalance (CoV {cov})");
+
+    // 12 flows, every one with byte_rate == 0.0 (direct signal dead).
+    let flows = vec![
+        flow(3000, 0, 0.0), flow(3001, 0, 0.0),
+        flow(3002, 1, 0.0), flow(3003, 1, 0.0),
+        flow(3004, 2, 0.0),
+        flow(3005, 3, 0.0),
+        flow(3006, 4, 0.0), flow(3007, 4, 0.0),
+        flow(3008, 4, 0.0), flow(3009, 4, 0.0), // hottest worker's 4 flows
+        flow(3010, 5, 0.0), flow(3011, 5, 0.0),
+    ];
+
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput { ifindex: 5, workers, flows, now_secs: 10 };
+    c.tick(&input, &mut tx); // dwell
+    let input2 = RebalanceTickInput { now_secs: 11, ..input };
+    let outcome = c.tick(&input2, &mut tx);
+
+    assert!(
+        outcome.is_some(),
+        "a real worker imbalance with zero direct per-flow rates MUST still \
+         install via the worker-rate fallback; skips={:?}", c.metrics().moves_skipped
+    );
+    assert_eq!(c.metrics().installs_total, 1);
+    let mv = outcome.unwrap();
+    assert_eq!(mv.old_worker, 4, "move sources from the reliable hottest worker");
+    // It must NOT be charged as a no-eligible-flow skip on the committing tick.
+    let neff = c.metrics().moves_skipped.get(&SkipReason::NoEligibleFlow).copied().unwrap_or(0);
+    assert_eq!(neff, 0, "fallback estimate makes the hottest worker's flows eligible");
+}
+
+/// When the hottest worker genuinely has NO flows in the map (empty per-flow
+/// signal AND no flows to estimate over), the skip is NoEligibleFlow — NOT
+/// epsilon. Disambiguation guard for the metric (so the live log/metric points
+/// at the real cause).
+#[test]
+fn no_flows_on_hottest_worker_is_no_eligible_flow_not_epsilon() {
+    let workers = vec![
+        worker(0, 1.40e9),
+        worker(4, 5.60e9), // hottest, but no flows attributed to it
+    ];
+    // All flows attributed to worker 0, none to the hottest worker 4.
+    let flows = vec![flow(4000, 0, 1.40e9), flow(4001, 0, 1.40e9)];
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput { ifindex: 5, workers, flows, now_secs: 10 };
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 11, ..input };
+    assert!(c.tick(&input2, &mut tx).is_none(), "no flows on hottest -> no move");
+    let neff = c.metrics().moves_skipped.get(&SkipReason::NoEligibleFlow).copied().unwrap_or(0);
+    let eps = c.metrics().moves_skipped.get(&SkipReason::Epsilon).copied().unwrap_or(0);
+    assert!(neff >= 1, "must record no_eligible_flow when the hottest worker has no flows");
+    assert_eq!(eps, 0, "must NOT mislabel an empty per-flow signal as epsilon");
+}
+
+/// cumulative_to_rate across two real eval ticks with the SAME key yields a
+/// non-zero rate; an eviction-reset (cur < prev) yields 0 — documenting why
+/// the direct per-flow signal is flaky and the worker-rate fallback exists.
+#[test]
+fn cumulative_to_rate_real_two_tick_keying() {
+    // Tick A primes the baseline; tick B (1s later) sees +1.4e9 bytes.
+    let t_a = 10_000_000_000u64;
+    let t_b = t_a + 1_000_000_000;
+    // Same flow, cumulative advanced by 1.4e9 over 1s => 1.4e9 B/s.
+    let rate = cumulative_to_rate(5_400_000_000, 4_000_000_000, t_b, t_a);
+    assert!((rate - 1.4e9).abs() < 1.0, "non-zero rate across two ticks: {rate}");
+    // Eviction reset between ticks: cumulative dropped below the prior sample.
+    let reset = cumulative_to_rate(100_000, 4_000_000_000, t_b, t_a);
+    assert_eq!(reset, 0.0, "an eviction reset reads 0, NOT a negative rate");
+}

--- a/userspace-dp/src/afxdp/rebalance/controller_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller_tests.rs
@@ -39,6 +39,9 @@ struct MockTransport {
     /// When true, restore_owner returns false (simulates an ack timeout / key
     /// absent on W_old) so tests can exercise the gated reverse barrier.
     restore_fails: bool,
+    /// When true, delete_rule returns an error (simulates an ioctl failure) so
+    /// tests can exercise the second-move prior-rule delete-failure branch.
+    delete_fails: bool,
     /// Per-(worker,key) origin as the mock "session table" sees it, so tests
     /// can confirm there is always >= 1 owner across a rollback even when a
     /// flow has lived on more than one worker over a chain of moves.
@@ -108,6 +111,9 @@ impl BarrierTransport for MockTransport {
     }
     fn delete_rule(&mut self, loc: u32) -> std::io::Result<()> {
         self.calls.push(format!("delete:{loc}"));
+        if self.delete_fails {
+            return Err(std::io::Error::from_raw_os_error(libc::EIO));
+        }
         Ok(())
     }
 }
@@ -445,7 +451,12 @@ fn second_move_chain_replaces_rule_and_reverse_barriers_prior_owner() {
     c.tick(&in2, &mut tx);
     let in2b = RebalanceTickInput { now_secs: 21, ..in2 };
     let mv2 = c.tick(&in2b, &mut tx).expect("second move");
-    assert_eq!(mv2.old_worker, 2, "second move sources from the prior new_worker");
+    // #1748 review-r2 MAJOR: old_worker is the RSS-natural worker for the
+    // tuple, INVARIANT across moves. Even though the flow currently sits on
+    // worker 2 (its prior new home), the second move's old_worker must be the
+    // ORIGINAL RSS-natural worker 0 — carried forward from the prior ledger
+    // entry — NOT the prior W_new (2).
+    assert_eq!(mv2.old_worker, 0, "second move old_worker is the RSS-natural worker (0), not prior W_new (2)");
     assert_eq!(mv2.new_worker, 1);
 
     // Ledger REPLACED, not appended: still exactly one rule for the key.
@@ -455,15 +466,125 @@ fn second_move_chain_replaces_rule_and_reverse_barriers_prior_owner() {
         tx.calls.iter().any(|c| c == "delete:100"),
         "prior rule loc 100 must be deleted on second move: {:?}", tx.calls
     );
-    // Prior owner reverse-barriered: restore prior W_old (0), demote prior
-    // W_new (2). Then forward barrier to the third worker (promote 1).
+    // The prior-move unwind restores the prior W_old (0), NOT the prior W_new.
+    let unwind_restore = tx.calls.iter().position(|c| c.starts_with("restore:0:")).unwrap();
     let del_idx = tx.calls.iter().position(|c| c == "delete:100").unwrap();
+    assert!(unwind_restore < del_idx, "prior W_old (0) restored before prior rule delete: {:?}", tx.calls);
+    // #1748 review-r2 MAJOR: the new forward-barrier demote targets the
+    // RSS-natural W_old (0), NOT the prior W_new (2). The pre-fix code demoted
+    // worker 2 here.
     let promote1_idx = tx.calls.iter().position(|c| c.starts_with("promote:1:")).unwrap();
+    let demote_fwd_idx = tx.calls.iter().rposition(|c| c.starts_with("demote:0:"))
+        .expect("forward-barrier demote must target RSS-natural W_old 0");
+    assert!(
+        !tx.calls[promote1_idx..].iter().any(|c| c.starts_with("demote:2:")),
+        "forward-barrier demote must NOT target prior W_new (2): {:?}", tx.calls
+    );
     assert!(del_idx < promote1_idx, "prior rule deleted before new forward barrier: {:?}", tx.calls);
+    assert!(promote1_idx < demote_fwd_idx, "promote W_new(1) before demote W_old(0): {:?}", tx.calls);
     // A new rule was installed for the third move.
     assert_eq!(c.metrics().installs_total, installs_before + 1);
     // Ownership ends correct: exactly the third worker's entry is the owner.
     assert!(tx.owners() >= 1, "chain keeps >= 1 owner: {:?}", tx.origins);
+
+    // #1748 review-r2 MAJOR: teardown after the W0->W2->W1 chain must restore
+    // the RSS-natural worker 0, NOT the prior W_new (2) or the immediately
+    // prior worker. The replacement ledger entry must carry old_worker=0.
+    tx.calls.clear();
+    c.teardown_all(&mut tx, |_w, _k| true);
+    let td_restore = tx.calls.iter().find(|c| c.starts_with("restore:")).expect("teardown restore");
+    assert!(
+        td_restore.starts_with("restore:0:"),
+        "teardown after a chain must restore the RSS-natural worker 0, got {td_restore:?} (calls {:?})", tx.calls
+    );
+}
+
+#[test]
+fn second_move_delete_failure_keeps_prior_entry_no_duplicate_rule() {
+    // #1748 review-r2 MINOR: if the prior-rule delete fails on a second move,
+    // the controller must NOT install a new rule (duplicate-HW-rule hazard).
+    // It keeps the prior ledger entry and skips the move this tick.
+    let mut c = test_controller(RebalanceConfig {
+        imbalance_threshold: 1.30,
+        rebalance_interval_secs: 0,
+        max_rules: 8,
+    });
+    let mut tx = MockTransport::good();
+
+    // First move: flow 1001 on worker 0 -> worker 2.
+    let in1 = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 250.0), worker(2, 100.0)],
+        flows: vec![flow(1001, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&in1, &mut tx);
+    let in1b = RebalanceTickInput { now_secs: 11, ..in1 };
+    c.tick(&in1b, &mut tx).expect("first move");
+    assert_eq!(c.metrics().rules_active, 1);
+    let installs_before = c.metrics().installs_total;
+
+    // Second move attempt with delete failing.
+    c.clear_cooldown_for_test();
+    tx.calls.clear();
+    tx.delete_fails = true;
+    let in2 = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 100.0), worker(1, 90.0), worker(2, 400.0)],
+        flows: vec![flow(1001, 2, 120.0)],
+        now_secs: 20,
+    };
+    c.tick(&in2, &mut tx);
+    let in2b = RebalanceTickInput { now_secs: 21, ..in2 };
+    let mv2 = c.tick(&in2b, &mut tx);
+    assert!(mv2.is_none(), "second move aborts when the prior-rule delete fails");
+    // Prior ledger entry KEPT — still exactly one rule.
+    assert_eq!(c.metrics().rules_active, 1, "prior entry kept on delete failure");
+    // NO new rule installed (no duplicate HW rule).
+    assert_eq!(c.metrics().installs_total, installs_before, "no new rule on delete failure");
+    assert!(!tx.calls.iter().any(|c| c.starts_with("install:")), "no install on delete failure: {:?}", tx.calls);
+    let bf = c.metrics().moves_skipped.get(&SkipReason::BarrierFailed).copied().unwrap_or(0);
+    assert!(bf >= 1, "barrier_failed skip recorded on delete failure");
+}
+
+#[test]
+fn second_move_restore_failure_records_restore_failed() {
+    // #1748 review-r2 MINOR: the second-move prior-unwind restore-fail branch
+    // records RestoreFailed (consistent with the other restore-fail sites),
+    // not BarrierFailed, and keeps the prior entry.
+    let mut c = test_controller(RebalanceConfig {
+        imbalance_threshold: 1.30,
+        rebalance_interval_secs: 0,
+        max_rules: 8,
+    });
+    let mut tx = MockTransport::good();
+    let in1 = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 400.0), worker(1, 250.0), worker(2, 100.0)],
+        flows: vec![flow(1001, 0, 120.0)],
+        now_secs: 10,
+    };
+    c.tick(&in1, &mut tx);
+    let in1b = RebalanceTickInput { now_secs: 11, ..in1 };
+    c.tick(&in1b, &mut tx).expect("first move");
+    let installs_before = c.metrics().installs_total;
+
+    c.clear_cooldown_for_test();
+    tx.calls.clear();
+    tx.restore_fails = true;
+    let in2 = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 100.0), worker(1, 90.0), worker(2, 400.0)],
+        flows: vec![flow(1001, 2, 120.0)],
+        now_secs: 20,
+    };
+    c.tick(&in2, &mut tx);
+    let in2b = RebalanceTickInput { now_secs: 21, ..in2 };
+    assert!(c.tick(&in2b, &mut tx).is_none(), "second move aborts when prior restore fails");
+    assert_eq!(c.metrics().rules_active, 1, "prior entry kept on restore failure");
+    assert_eq!(c.metrics().installs_total, installs_before, "no new rule on restore failure");
+    let rf = c.metrics().moves_skipped.get(&SkipReason::RestoreFailed).copied().unwrap_or(0);
+    assert!(rf >= 1, "restore_failed (not barrier_failed) skip recorded on second-move restore fail");
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/rebalance/controller_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/controller_tests.rs
@@ -288,12 +288,13 @@ fn budget_exhaustion_stops_no_eviction() {
 fn magnitude_guard_rejects_overlarge_flow() {
     let mut c = test_controller(cfg());
     let mut tx = MockTransport::good();
-    // gap = 400 - 100 = 300; gap/2 = 150. The only flow on the hottest worker
-    // is 250 bytes/s > 150, so the magnitude guard must reject it.
+    // #1748 live BLOCKER B: the guard is `move_rate > gap` (relaxed from
+    // gap/2). gap = 400 - 100 = 300. A 350 byte/s flow exceeds gap, so moving
+    // it would overload the destination past the old hottest -> reject.
     let input = RebalanceTickInput {
         ifindex: 1,
         workers: vec![worker(0, 400.0), worker(1, 100.0)],
-        flows: vec![flow(1001, 0, 250.0)],
+        flows: vec![flow(1001, 0, 350.0)],
         now_secs: 10,
     };
     c.tick(&input, &mut tx);
@@ -302,6 +303,33 @@ fn magnitude_guard_rejects_overlarge_flow() {
     assert!(!tx.calls.iter().any(|c| c.starts_with("install:")));
     let mag = c.metrics().moves_skipped.get(&SkipReason::Magnitude).copied().unwrap_or(0);
     assert!(mag >= 1, "magnitude skip recorded: {:?}", c.metrics().moves_skipped);
+}
+
+#[test]
+fn magnitude_guard_admits_flow_between_half_gap_and_gap() {
+    // #1748 live BLOCKER B regression: a flow whose rate is in (gap/2, gap] was
+    // WRONGLY rejected by the old gap/2 guard even though moving it improves
+    // balance. With the relaxed `> gap` guard it must now be ADMITTED.
+    // workers [450, 100]: gap = 350, gap/2 = 175. A 250 byte/s flow (between
+    // 175 and 350) clears the magnitude guard; moving it -> [200, 350] which is
+    // more balanced (CoV drops), so it must install.
+    let mut c = test_controller(cfg());
+    let mut tx = MockTransport::good();
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 450.0), worker(1, 100.0)],
+        flows: vec![flow(1001, 0, 250.0), flow(1002, 0, 200.0)],
+        now_secs: 10,
+    };
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    let outcome = c.tick(&input2, &mut tx);
+    assert!(
+        outcome.is_some(),
+        "a flow in (gap/2, gap] must clear the relaxed magnitude guard and \
+         install; skips={:?}", c.metrics().moves_skipped
+    );
+    assert_eq!(c.metrics().installs_total, 1);
 }
 
 #[test]
@@ -674,15 +702,18 @@ fn long_lived_idle_flow_not_selected_over_recent_burst() {
 }
 
 #[test]
-fn zero_rate_idle_flows_yield_no_move() {
-    // If every flow on the hottest worker has rate 0 (all long-lived idle),
-    // moving any of them cannot improve the byte-rate CoV, so no move is taken
-    // (the magnitude/epsilon guards reject a 0-rate move).
+fn zero_rate_idle_flows_still_move_via_worker_rate_fallback() {
+    // #1748 live BUG #1/#r5: per-flow rates are an unreliable signal (the
+    // flow-cache observed_bytes counter resets on eviction), so flows commonly
+    // read rate 0 under load. The worker-rate fallback estimates the move
+    // magnitude as hottest.byte_rate/candidate_count when the direct per-flow
+    // rate is 0 — so a clear WORKER-rate imbalance with zero per-flow rates
+    // MUST still move (this is the whole point of the fallback). Worker 0 at
+    // 400 with 2 idle flows => est 200/flow, gap 300 => clears the magnitude
+    // guard and improves CoV.
     let mut c = test_controller(cfg());
     let input = RebalanceTickInput {
         ifindex: 1,
-        // Worker 0 looks hottest by some other flow, but the eligible flows on
-        // it are all idle.
         workers: vec![worker(0, 400.0), worker(1, 100.0)],
         flows: vec![flow(8001, 0, 0.0), flow(8002, 0, 0.0)],
         now_secs: 10,
@@ -691,8 +722,31 @@ fn zero_rate_idle_flows_yield_no_move() {
     c.tick(&input, &mut tx);
     let input2 = RebalanceTickInput { now_secs: 12, ..input };
     assert!(
+        c.tick(&input2, &mut tx).is_some(),
+        "a real worker-rate imbalance with zero per-flow rates MUST move via \
+         the fallback; skips={:?}", c.metrics().moves_skipped
+    );
+    assert_eq!(c.metrics().installs_total, 1);
+}
+
+#[test]
+fn truly_balanced_workers_yield_no_move() {
+    // The genuine no-move case: the WORKER rates themselves are balanced (under
+    // the imbalance threshold), so no candidate worker is hot enough to move
+    // from — recorded as Balanced, never reaching select_move.
+    let mut c = test_controller(cfg());
+    let input = RebalanceTickInput {
+        ifindex: 1,
+        workers: vec![worker(0, 300.0), worker(1, 300.0), worker(2, 300.0)],
+        flows: vec![flow(8101, 0, 100.0), flow(8102, 1, 100.0), flow(8103, 2, 100.0)],
+        now_secs: 10,
+    };
+    let mut tx = MockTransport::good();
+    c.tick(&input, &mut tx);
+    let input2 = RebalanceTickInput { now_secs: 12, ..input };
+    assert!(
         c.tick(&input2, &mut tx).is_none(),
-        "no move when all eligible flows are idle (rate 0)"
+        "balanced worker rates yield no move"
     );
     assert!(!tx.calls.iter().any(|c| c.starts_with("install:")));
 }

--- a/userspace-dp/src/afxdp/rebalance/mod.rs
+++ b/userspace-dp/src/afxdp/rebalance/mod.rs
@@ -1,0 +1,23 @@
+// #1748: reactive cross-worker ntuple rebalance controller.
+//
+// The per-flow CoV on shaped ports swings 14-29% under `-P12` because RSS
+// hashes the N flows unevenly across the mlx5 VF RX queues, so workers serve
+// different flow counts and a worker's capacity splits among its flows. The
+// only lever that lifts slow flows AND preserves aggregate is moving an
+// established flow off an overloaded worker onto an idle one — proven in the
+// R1 spike (CoV 16.8% -> 2.3-4.2%, aggregate up).
+//
+// This module owns the default-OFF, opt-in forward-direction reactive
+// rebalancer: it observes per-worker byte-rate imbalance, picks the flow
+// whose move most flattens the per-worker byte-rate vector, and installs one
+// exact-5-tuple ntuple rule via a direct SIOCETHTOOL ioctl (`ntuple.rs`).
+//
+// One responsibility per file (engineering-style.md modularity discipline):
+//   - `ntuple.rs`     : the ethtool rxnfc ioctl + UAPI structs.
+//   - `controller.rs` : the byte-rate-aware selection + barriered move
+//                        protocol + metrics + per-flow cooldown/hysteresis.
+
+mod controller;
+mod ntuple;
+
+pub(in crate::afxdp) use controller::{RebalanceConfig, RebalanceController, RebalanceMetrics};

--- a/userspace-dp/src/afxdp/rebalance/mod.rs
+++ b/userspace-dp/src/afxdp/rebalance/mod.rs
@@ -23,6 +23,6 @@ pub(in crate::afxdp) mod ntuple;
 pub(in crate::afxdp) use controller::{
     BarrierTransport, FlowSample, MoveOutcome, RebalanceConfig, RebalanceController,
     RebalanceMetrics, RebalanceTickInput, SkipReason, WorkerByteRate, cumulative_to_rate,
-    flow_spec_from_key,
+    debug_log_rebalance, flow_spec_from_key,
 };
 pub(in crate::afxdp) use ntuple::NtupleSocket;

--- a/userspace-dp/src/afxdp/rebalance/mod.rs
+++ b/userspace-dp/src/afxdp/rebalance/mod.rs
@@ -22,6 +22,7 @@ pub(in crate::afxdp) mod ntuple;
 
 pub(in crate::afxdp) use controller::{
     BarrierTransport, FlowSample, MoveOutcome, RebalanceConfig, RebalanceController,
-    RebalanceMetrics, RebalanceTickInput, SkipReason, WorkerByteRate, flow_spec_from_key,
+    RebalanceMetrics, RebalanceTickInput, SkipReason, WorkerByteRate, cumulative_to_rate,
+    flow_spec_from_key,
 };
 pub(in crate::afxdp) use ntuple::NtupleSocket;

--- a/userspace-dp/src/afxdp/rebalance/mod.rs
+++ b/userspace-dp/src/afxdp/rebalance/mod.rs
@@ -18,6 +18,10 @@
 //                        protocol + metrics + per-flow cooldown/hysteresis.
 
 mod controller;
-mod ntuple;
+pub(in crate::afxdp) mod ntuple;
 
-pub(in crate::afxdp) use controller::{RebalanceConfig, RebalanceController, RebalanceMetrics};
+pub(in crate::afxdp) use controller::{
+    BarrierTransport, FlowSample, MoveOutcome, RebalanceConfig, RebalanceController,
+    RebalanceMetrics, RebalanceTickInput, SkipReason, WorkerByteRate, flow_spec_from_key,
+};
+pub(in crate::afxdp) use ntuple::NtupleSocket;

--- a/userspace-dp/src/afxdp/rebalance/ntuple.rs
+++ b/userspace-dp/src/afxdp/rebalance/ntuple.rs
@@ -194,13 +194,33 @@ impl Default for EthtoolRxnfc {
     }
 }
 
-/// `struct ifreq` carrying `ifr_data` = pointer to an ethtool command. We
-/// mirror `slowpath.rs`'s IfReq but with the data-pointer union arm.
+/// Union matching the kernel's `ifreq.ifr_ifru` payload. The largest kernel
+/// arm is `struct ifmap` (24 bytes on x86_64), which sets the union size and
+/// therefore `sizeof(struct ifreq)` to 40 bytes. We mirror that size so the
+/// kernel's `copy_from_user(sizeof(struct ifreq))` does not read past our
+/// allocation. For SIOCETHTOOL only the `data` arm is accessed.
+#[repr(C)]
+union EthtoolIfru {
+    /// The `ifr_data` arm: pointer to an ethtool command struct.
+    data: *mut libc::c_void,
+    /// Padding to `sizeof(struct ifmap)` = 24 bytes on x86_64, which is the
+    /// largest arm in the kernel union and determines `sizeof(struct ifreq)`.
+    _pad: [u8; 24],
+}
+
+/// `struct ifreq` carrying `ifr_data` = pointer to an ethtool command.
+/// The union above pads the struct to 40 bytes, matching the kernel ABI on
+/// x86_64, so `copy_from_user(sizeof(struct ifreq))` stays in bounds.
 #[repr(C)]
 struct EthtoolIfreq {
     ifr_name: [libc::c_char; libc::IFNAMSIZ],
-    ifr_data: *mut libc::c_void,
+    ifru: EthtoolIfru,
 }
+
+const _: () = assert!(
+    std::mem::size_of::<EthtoolIfreq>() == 40,
+    "EthtoolIfreq must be 40 bytes (sizeof(struct ifreq) on x86_64)",
+);
 
 impl EthtoolIfreq {
     fn new(ifname: &str, data: *mut libc::c_void) -> io::Result<Self> {
@@ -215,7 +235,7 @@ impl EthtoolIfreq {
         for (idx, b) in bytes.iter().enumerate() {
             ifr_name[idx] = *b as libc::c_char;
         }
-        Ok(Self { ifr_name, ifr_data: data })
+        Ok(Self { ifr_name, ifru: EthtoolIfru { data } })
     }
 }
 
@@ -284,7 +304,7 @@ impl NtupleSocket {
             &self.ifname,
             rxnfc as *mut EthtoolRxnfc as *mut libc::c_void,
         )?;
-        // SAFETY: ifr.ifr_data points at a valid, correctly-sized rxnfc; the
+        // SAFETY: ifr.ifru.data points at a valid, correctly-sized rxnfc; the
         // kernel reads/writes only within sizeof(ethtool_rxnfc).
         let rc = unsafe { libc::ioctl(self.sock, SIOCETHTOOL, &mut ifr) };
         if rc < 0 {

--- a/userspace-dp/src/afxdp/rebalance/ntuple.rs
+++ b/userspace-dp/src/afxdp/rebalance/ntuple.rs
@@ -42,6 +42,12 @@ const UDP_V6_FLOW: u32 = 0x06;
 
 /// Special location: let the driver auto-assign any suitable free slot.
 const RX_CLS_LOC_ANY: u32 = 0xffff_ffff;
+/// Flag bit OR'd into the GRXCLSRLCNT `data` reply when the DRIVER manages
+/// rule locations (auto-assign). When set, ethtool(8) SKIPS the GRXCLSRLALL
+/// location-list scan (`rxclass.c` `rmgr_init`: `if (driver_select) return 0`)
+/// — and so must we, or the scan can EINVAL on such drivers (mlx5 auto-assigns
+/// via RX_CLS_LOC_ANY).
+const RX_CLS_LOC_SPECIAL: u32 = 0x8000_0000;
 
 /// `struct ethtool_tcpip4_spec` (ethtool.h) — 16 B. Network-order fields.
 #[repr(C)]
@@ -356,16 +362,26 @@ impl NtupleSocket {
         }
     }
 
-    /// Return the count of currently-defined classification rules (the
-    /// `data` field is the table size; `rule_cnt` is the live count). Used by
-    /// the controller's budget check and startup reconcile.
+    /// Return the count of currently-defined classification rules. On return
+    /// `rule_cnt` is the live count and `data` is the table size with the
+    /// `RX_CLS_LOC_SPECIAL` flag set iff the driver manages rule locations.
+    /// Matches ethtool(8) `rxclass_get_dev_info` (cmd=GRXCLSRLCNT, data=0 in).
     pub(crate) fn rule_count(&self) -> io::Result<u32> {
+        Ok(self.rule_count_and_driver_select()?.0)
+    }
+
+    /// `(rule_cnt, driver_select)`. `driver_select` is true when the NIC driver
+    /// manages rule locations (auto-assign) — in which case the GRXCLSRLALL
+    /// location-list scan must be skipped (ethtool does the same).
+    fn rule_count_and_driver_select(&self) -> io::Result<(u32, bool)> {
         let mut rxnfc = EthtoolRxnfc {
             cmd: ETHTOOL_GRXCLSRLCNT,
             ..EthtoolRxnfc::default()
         };
+        // ethtool sets data=0 before the call; default() already zeroes it.
         self.ioctl(&mut rxnfc)?;
-        Ok(rxnfc.rule_cnt)
+        let driver_select = (rxnfc.data as u32 & RX_CLS_LOC_SPECIAL) != 0;
+        Ok((rxnfc.rule_cnt, driver_select))
     }
 
     /// List the locations of all currently-defined rules via
@@ -375,17 +391,33 @@ impl NtupleSocket {
     /// array back. Used for reconcile/cleanup of stale xpf-owned rules on
     /// startup.
     pub(crate) fn list_locs(&self) -> io::Result<Vec<u32>> {
-        let count = self.rule_count()?;
+        let (count, driver_select) = self.rule_count_and_driver_select()?;
+        // #1748 live BLOCKER A: when the driver manages rule locations
+        // (auto-assign — mlx5 via RX_CLS_LOC_ANY), ethtool(8) SKIPS the
+        // GRXCLSRLALL location-list scan entirely (rxclass.c rmgr_init:
+        // `if (driver_select) return 0`). Issuing GRXCLSRLALL anyway can EINVAL
+        // on such drivers — the exact startup `reconcile_orphans` EINVAL seen
+        // on the live mlx5 VF. We cannot enumerate locations on a driver-select
+        // NIC, so return empty: the controller tracks its OWN installed rule
+        // locations in its in-memory ledger and deletes them by loc directly,
+        // so orphan-enumeration is best-effort and safely skipped here.
+        if driver_select {
+            return Ok(Vec::new());
+        }
         if count == 0 {
             return Ok(Vec::new());
         }
-        // The flexible `rule_locs[]` member starts at offset 188 (#1748 review
-        // #7), NOT at size_of::<EthtoolRxnfc>() (192). The struct rounds up to
-        // 192 for u64 alignment, but the kernel writes the location array
-        // beginning at the field offset. Allocate from the field offset so the
-        // first location is not skipped and the read offsets match.
+        // Buffer layout matches ethtool(8) `rxclass_rule_getall` EXACTLY
+        // (rxclass.c): `calloc(1, sizeof(ethtool_rxnfc) + count*sizeof(u32))`.
+        // The kernel `ethtool_rxnfc_copy_to_user` does TWO writes: the full
+        // `size`=sizeof(ethtool_rxnfc)=192-byte struct over [0,192), THEN the
+        // `count` u32 locations starting at `offsetof(rule_locs)`=188 (they
+        // overlap [188,192)). Sizing to `sizeof(EthtoolRxnfc) + count*4` (NOT
+        // offsetof+count*4) guarantees the 192-byte struct write never runs off
+        // the end for the count==1 edge, byte-for-byte matching ethtool. We
+        // READ each location back from offset 188 (#1748 #7).
         let locs_off = offset_of!(EthtoolRxnfc, rule_locs);
-        let total = locs_off + (count as usize) * size_of::<u32>();
+        let total = size_of::<EthtoolRxnfc>() + (count as usize) * size_of::<u32>();
         let mut buf = vec![0u8; total];
         {
             // SAFETY: buf is at least sizeof(EthtoolRxnfc); we initialize the
@@ -464,17 +496,27 @@ impl NtupleSocket {
 
 /// Build the `ethtool_rx_flow_spec` for an exact 5-tuple.
 ///
-/// MASK POLARITY (hardware-confirmed, #1748 review #1 — do NOT "fix" this to
-/// the intuitive all-ones=match convention): the ethtool rxnfc mask is
-/// INVERTED — a 0 bit in `m_u` means "match this bit", an all-ones field means
-/// "don't care / wildcard". Verified empirically on the live mlx5 VF: an exact
-/// CLI rule (`ethtool -N <if> flow-type tcp4 src-ip ... action <q>`) reads back
-/// via `ethtool -n <if>` as `Src/Dest IP mask: 0.0.0.0`, `Src/Dest port mask:
-/// 0x0`, `TOS mask: 0xff`. So an exact 5-tuple match sets every addr/port mask
-/// field to 0 (match) and TOS mask to 0xff (wildcard). `live_insert_list_delete_round_trip`
-/// readback-asserts these canonical masks. `ring_cookie` carries the
-/// destination queue; `location = RX_CLS_LOC_ANY` lets the driver pick a free
-/// slot.
+/// MASK POLARITY (#1748 live BLOCKER A — the kernel/driver INPUT mask is
+/// DIRECT, NOT inverted). The `m_u` mask passed INTO ETHTOOL_SRXCLSRLINS uses
+/// 1-bits to mean "match this bit": the mlx5 driver copies `m_u` verbatim into
+/// the hardware match criteria and only matches a field when its mask is
+/// non-zero (`net/.../en_fs_ethtool.c set_ip4/set_tcp`: `if (ip4src_m) {...}`),
+/// and `validate_tcpudp4` REJECTS a non-zero TOS mask with -EINVAL
+/// (`if (l4_mask->tos) return -EINVAL`). So for an exact 5-tuple match:
+///   - ip4src/ip4dst masks = 0xffff_ffff (match every address bit)
+///   - psrc/pdst masks     = 0xffff      (match every port bit)
+///   - tos/tclass mask     = 0           (MUST be 0 or the driver EINVALs)
+///
+/// A previous round set these the opposite way (tuple masks 0, tos 0xff) after
+/// MISREADING `ethtool -n` READBACK output: ethtool(8) DISPLAYS the stored mask
+/// inverted (it prints the complement, so a stored all-ones match shows as
+/// "0.0.0.0"), but the value the kernel READS from user space is the direct
+/// mask. That inverted setup made every SRXCLSRLINS fail with EINVAL (tos mask
+/// 0xff) on the live mlx5 VF. The `lo` round-trip unit test did not exercise
+/// the mlx5 validate path so it could not catch it.
+///
+/// `ring_cookie` carries the destination RX queue (must be < num_channels, or
+/// the driver EINVALs); `location = RX_CLS_LOC_ANY` auto-assigns a free slot.
 fn build_flow_spec(flow: &FlowSpec5Tuple, queue: u32) -> EthtoolRxFlowSpec {
     let mut fs = EthtoolRxFlowSpec {
         ring_cookie: queue as u64,
@@ -497,13 +539,14 @@ fn build_flow_spec(flow: &FlowSpec5Tuple, queue: u32) -> EthtoolRxFlowSpec {
                 _pad: [0; 3],
             };
             fs.h_u = EthtoolFlowUnion::from_tcpip4(spec);
-            // Exact match: all addr/port mask fields = 0; tos wildcarded.
+            // Exact match: all addr/port mask bits set (1 = match), tos mask 0
+            // (a non-zero tos mask makes the mlx5 driver return -EINVAL).
             let mask = EthtoolTcpip4Spec {
-                ip4src: 0,
-                ip4dst: 0,
-                psrc: 0,
-                pdst: 0,
-                tos: 0xff,
+                ip4src: 0xffff_ffff,
+                ip4dst: 0xffff_ffff,
+                psrc: 0xffff,
+                pdst: 0xffff,
+                tos: 0,
                 _pad: [0; 3],
             };
             fs.m_u = EthtoolFlowUnion::from_tcpip4(mask);
@@ -523,12 +566,13 @@ fn build_flow_spec(flow: &FlowSpec5Tuple, queue: u32) -> EthtoolRxFlowSpec {
                 _pad: [0; 3],
             };
             fs.h_u = EthtoolFlowUnion::from_tcpip6(spec);
+            // Exact match: all addr/port mask bits set, tclass mask 0.
             let mask = EthtoolTcpip6Spec {
-                ip6src: [0; 4],
-                ip6dst: [0; 4],
-                psrc: 0,
-                pdst: 0,
-                tclass: 0xff,
+                ip6src: [0xffff_ffff; 4],
+                ip6dst: [0xffff_ffff; 4],
+                psrc: 0xffff,
+                pdst: 0xffff,
+                tclass: 0,
                 _pad: [0; 3],
             };
             fs.m_u = EthtoolFlowUnion::from_tcpip6(mask);

--- a/userspace-dp/src/afxdp/rebalance/ntuple.rs
+++ b/userspace-dp/src/afxdp/rebalance/ntuple.rs
@@ -1,0 +1,464 @@
+// #1748: direct ethtool rxnfc ioctl module for exact-5-tuple ntuple flow
+// steering. The rust-netlink `ethtool` crate does NOT expose
+// rxnfc/flow-classification rules (only feature/coalesce/ring/channel/link/
+// pause/FEC/timestamp), so flow rules are ioctl-only. This mirrors the
+// `libc::ioctl`-on-AF_INET-SOCK_DGRAM pattern in `slowpath.rs`.
+//
+// UAPI layout asserted at compile time against the kernel `ethtool.h`
+// (x86-64, C-verified offsets):
+//   struct ethtool_rx_flow_spec = 168 B:
+//     flow_type u32 @0; h_u union @4 (52 B); h_ext @56 (20 B);
+//     m_u union @76 (52 B); m_ext @128 (20 B); pad @148 (4 B);
+//     ring_cookie u64 @152; location u32 @160; trailing pad @164 (4 B).
+//   struct ethtool_rxnfc = 192 B:
+//     cmd u32 @0; flow_type u32 @4; data u64 @8; fs @16 (168 B);
+//     rule_cnt/rss_context u32 @184; rule_locs [u32;0] flexible @188.
+//
+// NOTE: the #1748 plan §4.1 documented `rule_locs @192`; the C compiler
+// places the zero-length flexible array at @188 (rule_cnt@184, no padding;
+// sizeof rounds to 192 for u64 alignment). The compile-time asserts below
+// pin the C-verified offsets, which are authoritative.
+
+use std::io;
+use std::mem::{offset_of, size_of};
+use std::os::fd::AsRawFd;
+
+/// `SIOCETHTOOL` — the ioctl request that carries every ethtool command.
+const SIOCETHTOOL: libc::c_ulong = 0x8946;
+
+/// ethtool command numbers (ethtool.h).
+const ETHTOOL_GRXCLSRLALL: u32 = 0x0000_0030; // get all classification rule locations
+const ETHTOOL_SRXCLSRLDEL: u32 = 0x0000_0031; // delete a classification rule
+const ETHTOOL_SRXCLSRLINS: u32 = 0x0000_0032; // insert a classification rule
+const ETHTOOL_GRXCLSRLCNT: u32 = 0x0000_0029; // get count of classification rules
+
+/// flow_type values (ethtool.h enum). 0x01 = TCP/IPv4 spec (`tcp_ip4_spec`);
+/// the plan's "0x03" was SCTP_V4_FLOW — corrected here against the header.
+const TCP_V4_FLOW: u32 = 0x01;
+const UDP_V4_FLOW: u32 = 0x02;
+const TCP_V6_FLOW: u32 = 0x05;
+const UDP_V6_FLOW: u32 = 0x06;
+
+/// Special location: let the driver auto-assign any suitable free slot.
+const RX_CLS_LOC_ANY: u32 = 0xffff_ffff;
+
+/// `struct ethtool_tcpip4_spec` (ethtool.h) — 16 B. Network-order fields.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct EthtoolTcpip4Spec {
+    ip4src: u32, // __be32
+    ip4dst: u32, // __be32
+    psrc: u16,   // __be16
+    pdst: u16,   // __be16
+    tos: u8,
+    _pad: [u8; 3],
+}
+const _: () = assert!(size_of::<EthtoolTcpip4Spec>() == 16);
+
+/// `struct ethtool_tcpip6_spec` (ethtool.h) — 40 B (32 addr + 2+2 ports + 1
+/// tclass, padded to 4-byte alignment). Network-order fields.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct EthtoolTcpip6Spec {
+    ip6src: [u32; 4], // __be32[4]
+    ip6dst: [u32; 4], // __be32[4]
+    psrc: u16,        // __be16
+    pdst: u16,        // __be16
+    tclass: u8,
+    _pad: [u8; 3],
+}
+const _: () = assert!(size_of::<EthtoolTcpip6Spec>() == 40);
+
+/// `union ethtool_flow_union` — 52 B (`hdata[52]` is the largest member).
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct EthtoolFlowUnion {
+    hdata: [u8; 52],
+}
+const _: () = assert!(size_of::<EthtoolFlowUnion>() == 52);
+
+impl Default for EthtoolFlowUnion {
+    fn default() -> Self {
+        Self { hdata: [0u8; 52] }
+    }
+}
+
+impl EthtoolFlowUnion {
+    fn from_tcpip4(spec: EthtoolTcpip4Spec) -> Self {
+        let mut u = Self::default();
+        // SAFETY: EthtoolTcpip4Spec (16 B) <= 52 B and is plain-old-data.
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                &spec as *const _ as *const u8,
+                size_of::<EthtoolTcpip4Spec>(),
+            )
+        };
+        u.hdata[..bytes.len()].copy_from_slice(bytes);
+        u
+    }
+
+    fn from_tcpip6(spec: EthtoolTcpip6Spec) -> Self {
+        let mut u = Self::default();
+        // SAFETY: EthtoolTcpip6Spec (36 B) <= 52 B and is plain-old-data.
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                &spec as *const _ as *const u8,
+                size_of::<EthtoolTcpip6Spec>(),
+            )
+        };
+        u.hdata[..bytes.len()].copy_from_slice(bytes);
+        u
+    }
+}
+
+/// `struct ethtool_flow_ext` — 20 B: padding[2] + h_dest[6] + vlan_etype[2]
+/// + vlan_tci[2] + data[2*4].
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct EthtoolFlowExt {
+    padding: [u8; 2],
+    h_dest: [u8; 6],
+    vlan_etype: u16,
+    vlan_tci: u16,
+    data: [u32; 2],
+}
+const _: () = assert!(size_of::<EthtoolFlowExt>() == 20);
+
+/// `struct ethtool_rx_flow_spec` — 168 B.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct EthtoolRxFlowSpec {
+    flow_type: u32,
+    h_u: EthtoolFlowUnion,
+    h_ext: EthtoolFlowExt,
+    m_u: EthtoolFlowUnion,
+    m_ext: EthtoolFlowExt,
+    ring_cookie: u64,
+    location: u32,
+}
+const _: () = assert!(size_of::<EthtoolRxFlowSpec>() == 168);
+const _: () = assert!(offset_of!(EthtoolRxFlowSpec, flow_type) == 0);
+const _: () = assert!(offset_of!(EthtoolRxFlowSpec, h_u) == 4);
+const _: () = assert!(offset_of!(EthtoolRxFlowSpec, h_ext) == 56);
+const _: () = assert!(offset_of!(EthtoolRxFlowSpec, m_u) == 76);
+const _: () = assert!(offset_of!(EthtoolRxFlowSpec, m_ext) == 128);
+const _: () = assert!(offset_of!(EthtoolRxFlowSpec, ring_cookie) == 152);
+const _: () = assert!(offset_of!(EthtoolRxFlowSpec, location) == 160);
+
+impl Default for EthtoolRxFlowSpec {
+    fn default() -> Self {
+        Self {
+            flow_type: 0,
+            h_u: EthtoolFlowUnion::default(),
+            h_ext: EthtoolFlowExt::default(),
+            m_u: EthtoolFlowUnion::default(),
+            m_ext: EthtoolFlowExt::default(),
+            ring_cookie: 0,
+            location: 0,
+        }
+    }
+}
+
+/// `struct ethtool_rxnfc` — 192 B. `rule_locs` is a flexible array member
+/// `[u32; 0]` at offset 188; for GRXCLSRLALL we over-allocate a trailing
+/// buffer (see `list_rules`).
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct EthtoolRxnfc {
+    cmd: u32,
+    flow_type: u32,
+    data: u64,
+    fs: EthtoolRxFlowSpec,
+    rule_cnt: u32, // union with rss_context
+    rule_locs: [u32; 0],
+}
+const _: () = assert!(size_of::<EthtoolRxnfc>() == 192);
+const _: () = assert!(offset_of!(EthtoolRxnfc, cmd) == 0);
+const _: () = assert!(offset_of!(EthtoolRxnfc, flow_type) == 4);
+const _: () = assert!(offset_of!(EthtoolRxnfc, data) == 8);
+const _: () = assert!(offset_of!(EthtoolRxnfc, fs) == 16);
+const _: () = assert!(offset_of!(EthtoolRxnfc, rule_cnt) == 184);
+const _: () = assert!(offset_of!(EthtoolRxnfc, rule_locs) == 188);
+
+impl Default for EthtoolRxnfc {
+    fn default() -> Self {
+        Self {
+            cmd: 0,
+            flow_type: 0,
+            data: 0,
+            fs: EthtoolRxFlowSpec::default(),
+            rule_cnt: 0,
+            rule_locs: [],
+        }
+    }
+}
+
+/// `struct ifreq` carrying `ifr_data` = pointer to an ethtool command. We
+/// mirror `slowpath.rs`'s IfReq but with the data-pointer union arm.
+#[repr(C)]
+struct EthtoolIfreq {
+    ifr_name: [libc::c_char; libc::IFNAMSIZ],
+    ifr_data: *mut libc::c_void,
+}
+
+impl EthtoolIfreq {
+    fn new(ifname: &str, data: *mut libc::c_void) -> io::Result<Self> {
+        let bytes = ifname.as_bytes();
+        if bytes.is_empty() || bytes.len() >= libc::IFNAMSIZ {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid interface name {ifname:?}"),
+            ));
+        }
+        let mut ifr_name = [0 as libc::c_char; libc::IFNAMSIZ];
+        for (idx, b) in bytes.iter().enumerate() {
+            ifr_name[idx] = *b as libc::c_char;
+        }
+        Ok(Self { ifr_name, ifr_data: data })
+    }
+}
+
+/// The L3/L4 protocol family of a steered flow, mapped to the ethtool
+/// `flow_type` + the per-family spec encoding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FlowProto {
+    Tcp4,
+    Udp4,
+    Tcp6,
+    Udp6,
+}
+
+/// An exact 5-tuple to steer. Addresses/ports are in NETWORK byte order
+/// (matching the kernel `__be32`/`__be16` fields — same convention as the
+/// rest of userspace-dp's wire-order session keys).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FlowSpec5Tuple {
+    pub proto: FlowProto,
+    /// IPv4: only `[0]` is used. IPv6: all four words, network order.
+    pub src_ip: [u32; 4],
+    pub dst_ip: [u32; 4],
+    pub src_port: u16, // network order
+    pub dst_port: u16, // network order
+}
+
+/// A successfully opened ethtool socket bound to one interface. The
+/// controller constructs ONE of these per steered interface only when the
+/// rebalance knob is enabled (default-OFF builds construct zero sockets).
+pub(crate) struct NtupleSocket {
+    sock: i32,
+    ifname: String,
+}
+
+impl Drop for NtupleSocket {
+    fn drop(&mut self) {
+        if self.sock >= 0 {
+            // SAFETY: sock is a valid fd we own; close once.
+            unsafe { libc::close(self.sock) };
+        }
+    }
+}
+
+impl AsRawFd for NtupleSocket {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        self.sock
+    }
+}
+
+impl NtupleSocket {
+    /// Open an AF_INET/SOCK_DGRAM control socket for ethtool ioctls on
+    /// `ifname`. Mirrors `slowpath.rs::set_if_up`.
+    pub(crate) fn open(ifname: &str) -> io::Result<Self> {
+        // SAFETY: standard socket(2) call.
+        let sock = unsafe {
+            libc::socket(libc::AF_INET, libc::SOCK_DGRAM | libc::SOCK_CLOEXEC, 0)
+        };
+        if sock < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self { sock, ifname: ifname.to_string() })
+    }
+
+    fn ioctl(&self, rxnfc: &mut EthtoolRxnfc) -> io::Result<()> {
+        let mut ifr = EthtoolIfreq::new(
+            &self.ifname,
+            rxnfc as *mut EthtoolRxnfc as *mut libc::c_void,
+        )?;
+        // SAFETY: ifr.ifr_data points at a valid, correctly-sized rxnfc; the
+        // kernel reads/writes only within sizeof(ethtool_rxnfc).
+        let rc = unsafe { libc::ioctl(self.sock, SIOCETHTOOL, &mut ifr) };
+        if rc < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// Insert an exact-5-tuple rule steering the flow to `queue`. Returns the
+    /// driver-assigned rule location. Structured errno: `ENOSPC` at the rule
+    /// cap, `EOPNOTSUPP` on a NIC that does not support flow steering.
+    pub(crate) fn insert_rule(
+        &self,
+        flow: &FlowSpec5Tuple,
+        queue: u32,
+    ) -> io::Result<u32> {
+        let mut rxnfc = EthtoolRxnfc {
+            cmd: ETHTOOL_SRXCLSRLINS,
+            ..EthtoolRxnfc::default()
+        };
+        rxnfc.fs = build_flow_spec(flow, queue);
+        self.ioctl(&mut rxnfc)?;
+        // On return, fs.location is the actual rule location.
+        Ok(rxnfc.fs.location)
+    }
+
+    /// Delete the rule at `loc`. Idempotent at the caller level: an `ENOENT`
+    /// from the kernel (rule already gone) is mapped to Ok so reconcile/
+    /// teardown never wedges on a missing rule.
+    pub(crate) fn delete_rule(&self, loc: u32) -> io::Result<()> {
+        let mut rxnfc = EthtoolRxnfc {
+            cmd: ETHTOOL_SRXCLSRLDEL,
+            ..EthtoolRxnfc::default()
+        };
+        rxnfc.fs.location = loc;
+        match self.ioctl(&mut rxnfc) {
+            Ok(()) => Ok(()),
+            Err(e) if e.raw_os_error() == Some(libc::ENOENT) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Return the count of currently-defined classification rules (the
+    /// `data` field is the table size; `rule_cnt` is the live count). Used by
+    /// the controller's budget check and startup reconcile.
+    pub(crate) fn rule_count(&self) -> io::Result<u32> {
+        let mut rxnfc = EthtoolRxnfc {
+            cmd: ETHTOOL_GRXCLSRLCNT,
+            ..EthtoolRxnfc::default()
+        };
+        self.ioctl(&mut rxnfc)?;
+        Ok(rxnfc.rule_cnt)
+    }
+
+    /// List the locations of all currently-defined rules via
+    /// `ETHTOOL_GRXCLSRLALL`. The flexible `rule_locs[]` member forces a
+    /// manual over-allocation: we lay out a byte buffer of
+    /// `sizeof(ethtool_rxnfc) + rule_cnt * 4` and read the trailing u32
+    /// array back. Used for reconcile/cleanup of stale xpf-owned rules on
+    /// startup.
+    pub(crate) fn list_locs(&self) -> io::Result<Vec<u32>> {
+        let count = self.rule_count()?;
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+        // Over-allocate a flat byte buffer: the fixed 192 B header followed by
+        // `count` u32 locations.
+        let total = size_of::<EthtoolRxnfc>() + (count as usize) * size_of::<u32>();
+        let mut buf = vec![0u8; total];
+        {
+            // SAFETY: buf is at least sizeof(EthtoolRxnfc); we initialize the
+            // header fields in place.
+            let hdr = buf.as_mut_ptr() as *mut EthtoolRxnfc;
+            unsafe {
+                (*hdr).cmd = ETHTOOL_GRXCLSRLALL;
+                (*hdr).flow_type = 0;
+                (*hdr).data = 0;
+                (*hdr).fs = EthtoolRxFlowSpec::default();
+                (*hdr).rule_cnt = count;
+            }
+        }
+        let mut ifr = EthtoolIfreq::new(
+            &self.ifname,
+            buf.as_mut_ptr() as *mut libc::c_void,
+        )?;
+        // SAFETY: the kernel writes the header back plus `rule_cnt` u32s into
+        // the trailing buffer we sized for exactly that.
+        let rc = unsafe { libc::ioctl(self.sock, SIOCETHTOOL, &mut ifr) };
+        if rc < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // rule_cnt on return is the number of valid locations.
+        let returned = {
+            // SAFETY: header is still valid POD in buf.
+            let hdr = buf.as_ptr() as *const EthtoolRxnfc;
+            unsafe { (*hdr).rule_cnt }.min(count) as usize
+        };
+        let mut out = Vec::with_capacity(returned);
+        let locs_off = size_of::<EthtoolRxnfc>();
+        for i in 0..returned {
+            let off = locs_off + i * size_of::<u32>();
+            let bytes: [u8; 4] = buf[off..off + 4].try_into().unwrap();
+            out.push(u32::from_ne_bytes(bytes));
+        }
+        Ok(out)
+    }
+}
+
+/// Build the `ethtool_rx_flow_spec` for an exact 5-tuple. Masks: a 0 bit in
+/// `m_u` means "match this bit"; an all-ones field means "wildcard" — so an
+/// exact match sets every relevant mask field to 0. `ring_cookie` carries
+/// the destination queue; `location = RX_CLS_LOC_ANY` lets the driver pick a
+/// free slot.
+fn build_flow_spec(flow: &FlowSpec5Tuple, queue: u32) -> EthtoolRxFlowSpec {
+    let mut fs = EthtoolRxFlowSpec {
+        ring_cookie: queue as u64,
+        location: RX_CLS_LOC_ANY,
+        ..EthtoolRxFlowSpec::default()
+    };
+    match flow.proto {
+        FlowProto::Tcp4 | FlowProto::Udp4 => {
+            fs.flow_type = if flow.proto == FlowProto::Tcp4 {
+                TCP_V4_FLOW
+            } else {
+                UDP_V4_FLOW
+            };
+            let spec = EthtoolTcpip4Spec {
+                ip4src: flow.src_ip[0],
+                ip4dst: flow.dst_ip[0],
+                psrc: flow.src_port,
+                pdst: flow.dst_port,
+                tos: 0,
+                _pad: [0; 3],
+            };
+            fs.h_u = EthtoolFlowUnion::from_tcpip4(spec);
+            // Exact match: all addr/port mask fields = 0; tos wildcarded.
+            let mask = EthtoolTcpip4Spec {
+                ip4src: 0,
+                ip4dst: 0,
+                psrc: 0,
+                pdst: 0,
+                tos: 0xff,
+                _pad: [0; 3],
+            };
+            fs.m_u = EthtoolFlowUnion::from_tcpip4(mask);
+        }
+        FlowProto::Tcp6 | FlowProto::Udp6 => {
+            fs.flow_type = if flow.proto == FlowProto::Tcp6 {
+                TCP_V6_FLOW
+            } else {
+                UDP_V6_FLOW
+            };
+            let spec = EthtoolTcpip6Spec {
+                ip6src: flow.src_ip,
+                ip6dst: flow.dst_ip,
+                psrc: flow.src_port,
+                pdst: flow.dst_port,
+                tclass: 0,
+                _pad: [0; 3],
+            };
+            fs.h_u = EthtoolFlowUnion::from_tcpip6(spec);
+            let mask = EthtoolTcpip6Spec {
+                ip6src: [0; 4],
+                ip6dst: [0; 4],
+                psrc: 0,
+                pdst: 0,
+                tclass: 0xff,
+                _pad: [0; 3],
+            };
+            fs.m_u = EthtoolFlowUnion::from_tcpip6(mask);
+        }
+    }
+    fs
+}
+
+#[cfg(test)]
+#[path = "ntuple_tests.rs"]
+mod tests;

--- a/userspace-dp/src/afxdp/rebalance/ntuple.rs
+++ b/userspace-dp/src/afxdp/rebalance/ntuple.rs
@@ -194,29 +194,38 @@ impl Default for EthtoolRxnfc {
     }
 }
 
-/// Union matching the kernel's `ifreq.ifr_ifru` payload. The largest kernel
-/// arm is `struct ifmap` (24 bytes on x86_64), which sets the union size and
-/// therefore `sizeof(struct ifreq)` to 40 bytes. We mirror that size so the
-/// kernel's `copy_from_user(sizeof(struct ifreq))` does not read past our
-/// allocation. For SIOCETHTOOL only the `data` arm is accessed.
+/// Union matching the kernel's `ifreq.ifr_ifru` payload. The union itself is
+/// 24 bytes on x86_64 (dominated by `struct ifmap`'s 24-byte layout), making
+/// `sizeof(struct ifreq)` = 16 (ifr_name) + 24 (union) = 40 bytes. We mirror
+/// that union size so the kernel's `copy_from_user(sizeof(struct ifreq))` does
+/// not read past our allocation. For SIOCETHTOOL only the `data` arm is used.
 #[repr(C)]
 union EthtoolIfru {
     /// The `ifr_data` arm: pointer to an ethtool command struct.
+    ///
+    /// # Safety
+    /// When `data` is active, it must point to a valid, correctly-sized
+    /// ethtool command struct (e.g. `EthtoolRxnfc`) that outlives the ioctl
+    /// call. The caller is responsible for upholding this invariant.
     data: *mut libc::c_void,
-    /// Padding to `sizeof(struct ifmap)` = 24 bytes on x86_64, which is the
-    /// largest arm in the kernel union and determines `sizeof(struct ifreq)`.
+    /// Padding arm: sizes the union to 24 bytes, matching `sizeof(struct ifmap)`
+    /// on x86_64 (the largest arm of the kernel's `ifreq.ifr_ifru` union).
     _pad: [u8; 24],
 }
 
 /// `struct ifreq` carrying `ifr_data` = pointer to an ethtool command.
-/// The union above pads the struct to 40 bytes, matching the kernel ABI on
-/// x86_64, so `copy_from_user(sizeof(struct ifreq))` stays in bounds.
+/// `sizeof(EthtoolIfreq)` == 40 bytes on x86_64 (IFNAMSIZ=16 + union=24),
+/// matching the kernel ABI so `copy_from_user(sizeof(struct ifreq))` is safe.
 #[repr(C)]
 struct EthtoolIfreq {
     ifr_name: [libc::c_char; libc::IFNAMSIZ],
     ifru: EthtoolIfru,
 }
 
+// Enforce the 40-byte ABI match on x86_64 (IFNAMSIZ=16 + ifru union=24).
+// On other architectures the kernel's struct ifreq may differ; ntuple ioctl
+// support is mlx5-specific and therefore x86_64-only in practice.
+#[cfg(target_arch = "x86_64")]
 const _: () = assert!(
     std::mem::size_of::<EthtoolIfreq>() == 40,
     "EthtoolIfreq must be 40 bytes (sizeof(struct ifreq) on x86_64)",

--- a/userspace-dp/src/afxdp/rebalance/ntuple.rs
+++ b/userspace-dp/src/afxdp/rebalance/ntuple.rs
@@ -31,6 +31,7 @@ const ETHTOOL_GRXCLSRLALL: u32 = 0x0000_0030; // get all classification rule loc
 const ETHTOOL_SRXCLSRLDEL: u32 = 0x0000_0031; // delete a classification rule
 const ETHTOOL_SRXCLSRLINS: u32 = 0x0000_0032; // insert a classification rule
 const ETHTOOL_GRXCLSRLCNT: u32 = 0x0000_0029; // get count of classification rules
+const ETHTOOL_GRXCLSRULE: u32 = 0x0000_002e; // get a single classification rule
 
 /// flow_type values (ethtool.h enum). 0x01 = TCP/IPv4 spec (`tcp_ip4_spec`);
 /// the plan's "0x03" was SCTP_V4_FLOW — corrected here against the header.
@@ -349,9 +350,13 @@ impl NtupleSocket {
         if count == 0 {
             return Ok(Vec::new());
         }
-        // Over-allocate a flat byte buffer: the fixed 192 B header followed by
-        // `count` u32 locations.
-        let total = size_of::<EthtoolRxnfc>() + (count as usize) * size_of::<u32>();
+        // The flexible `rule_locs[]` member starts at offset 188 (#1748 review
+        // #7), NOT at size_of::<EthtoolRxnfc>() (192). The struct rounds up to
+        // 192 for u64 alignment, but the kernel writes the location array
+        // beginning at the field offset. Allocate from the field offset so the
+        // first location is not skipped and the read offsets match.
+        let locs_off = offset_of!(EthtoolRxnfc, rule_locs);
+        let total = locs_off + (count as usize) * size_of::<u32>();
         let mut buf = vec![0u8; total];
         {
             // SAFETY: buf is at least sizeof(EthtoolRxnfc); we initialize the
@@ -382,7 +387,6 @@ impl NtupleSocket {
             unsafe { (*hdr).rule_cnt }.min(count) as usize
         };
         let mut out = Vec::with_capacity(returned);
-        let locs_off = size_of::<EthtoolRxnfc>();
         for i in 0..returned {
             let off = locs_off + i * size_of::<u32>();
             let bytes: [u8; 4] = buf[off..off + 4].try_into().unwrap();
@@ -390,13 +394,58 @@ impl NtupleSocket {
         }
         Ok(out)
     }
+
+    /// #1748 AGY minor: startup orphan reconcile. A crashed/killed daemon
+    /// leaves its installed ntuple rules in the NIC's hardware rule table (HW
+    /// state is not torn down on SIGKILL). On controller construction we
+    /// enumerate every existing rule on the interface and delete it, so a fresh
+    /// run does not accumulate stale rules from a previous run and never trips
+    /// the rule-table cap with dead entries.
+    ///
+    /// NOTE: this clears ALL flow-classification rules on the interface. On the
+    /// userspace-dp dataplane these VFs are daemon-owned; flow-steering ntuple
+    /// rules are not independently operator-managed there (see CLAUDE.md loss
+    /// cluster topology). Returns the number of rules removed.
+    pub(crate) fn reconcile_orphans(&self) -> io::Result<usize> {
+        let locs = self.list_locs()?;
+        let mut removed = 0usize;
+        for loc in locs {
+            // delete_rule maps ENOENT -> Ok, so a rule that vanished between
+            // the list and the delete is not an error.
+            self.delete_rule(loc)?;
+            removed += 1;
+        }
+        Ok(removed)
+    }
+
+    /// Read back a single installed rule's flow spec via `ETHTOOL_GRXCLSRULE`.
+    /// Test-only readback used by `live_insert_list_delete_round_trip` to
+    /// assert the canonical inverted-mask encoding (#1748 review #1).
+    #[cfg(test)]
+    pub(crate) fn get_rule(&self, loc: u32) -> io::Result<EthtoolRxFlowSpec> {
+        let mut rxnfc = EthtoolRxnfc {
+            cmd: ETHTOOL_GRXCLSRULE,
+            ..EthtoolRxnfc::default()
+        };
+        rxnfc.fs.location = loc;
+        self.ioctl(&mut rxnfc)?;
+        Ok(rxnfc.fs)
+    }
 }
 
-/// Build the `ethtool_rx_flow_spec` for an exact 5-tuple. Masks: a 0 bit in
-/// `m_u` means "match this bit"; an all-ones field means "wildcard" — so an
-/// exact match sets every relevant mask field to 0. `ring_cookie` carries
-/// the destination queue; `location = RX_CLS_LOC_ANY` lets the driver pick a
-/// free slot.
+/// Build the `ethtool_rx_flow_spec` for an exact 5-tuple.
+///
+/// MASK POLARITY (hardware-confirmed, #1748 review #1 — do NOT "fix" this to
+/// the intuitive all-ones=match convention): the ethtool rxnfc mask is
+/// INVERTED — a 0 bit in `m_u` means "match this bit", an all-ones field means
+/// "don't care / wildcard". Verified empirically on the live mlx5 VF: an exact
+/// CLI rule (`ethtool -N <if> flow-type tcp4 src-ip ... action <q>`) reads back
+/// via `ethtool -n <if>` as `Src/Dest IP mask: 0.0.0.0`, `Src/Dest port mask:
+/// 0x0`, `TOS mask: 0xff`. So an exact 5-tuple match sets every addr/port mask
+/// field to 0 (match) and TOS mask to 0xff (wildcard). `live_insert_list_delete_round_trip`
+/// readback-asserts these canonical masks. `ring_cookie` carries the
+/// destination queue; `location = RX_CLS_LOC_ANY` lets the driver pick a free
+/// slot.
 fn build_flow_spec(flow: &FlowSpec5Tuple, queue: u32) -> EthtoolRxFlowSpec {
     let mut fs = EthtoolRxFlowSpec {
         ring_cookie: queue as u64,

--- a/userspace-dp/src/afxdp/rebalance/ntuple_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/ntuple_tests.rs
@@ -38,6 +38,21 @@ fn uapi_rxnfc_offsets_match_kernel() {
     assert_eq!(offset_of!(EthtoolRxnfc, rule_locs), 188);
 }
 
+/// #1748 review #7: list_locs reads the flexible rule_locs[] array from the
+/// FIELD offset (188), NOT size_of::<EthtoolRxnfc>() (192). Reading from 192
+/// would skip the first returned location. This pins the offset list_locs
+/// uses against the size, which differ by the 4-byte trailing alignment pad.
+#[test]
+fn rule_locs_field_offset_is_not_struct_size() {
+    assert_eq!(offset_of!(EthtoolRxnfc, rule_locs), 188);
+    assert_eq!(size_of::<EthtoolRxnfc>(), 192);
+    assert_ne!(
+        offset_of!(EthtoolRxnfc, rule_locs),
+        size_of::<EthtoolRxnfc>(),
+        "list_locs must read from the field offset (188), not the struct size (192)"
+    );
+}
+
 #[test]
 fn build_flow_spec_tcp4_exact_match_encoding() {
     let flow = FlowSpec5Tuple {
@@ -123,6 +138,21 @@ fn live_insert_list_delete_round_trip() {
         before.len() + 1,
         "exactly one rule added"
     );
+    // #1748 review #1: read the rule back and assert the canonical INVERTED
+    // mask encoding the live mlx5 NIC confirmed — tuple mask fields = 0
+    // (match), TOS mask = 0xff (wildcard). This pins the hardware-confirmed
+    // polarity so the masks are not "corrected" to the intuitive convention.
+    let fs = sock.get_rule(loc).expect("get_rule readback");
+    let m_ip4src = u32::from_ne_bytes(fs.m_u.hdata[0..4].try_into().unwrap());
+    let m_ip4dst = u32::from_ne_bytes(fs.m_u.hdata[4..8].try_into().unwrap());
+    let m_psrc = u16::from_ne_bytes(fs.m_u.hdata[8..10].try_into().unwrap());
+    let m_pdst = u16::from_ne_bytes(fs.m_u.hdata[10..12].try_into().unwrap());
+    let m_tos = fs.m_u.hdata[12];
+    assert_eq!(m_ip4src, 0, "src-ip mask must be 0.0.0.0 (exact match)");
+    assert_eq!(m_ip4dst, 0, "dst-ip mask must be 0.0.0.0 (exact match)");
+    assert_eq!(m_psrc, 0, "src-port mask must be 0x0 (exact match)");
+    assert_eq!(m_pdst, 0, "dst-port mask must be 0x0 (exact match)");
+    assert_eq!(m_tos, 0xff, "TOS mask must be 0xff (wildcard)");
     sock.delete_rule(loc).expect("delete rule");
     let cleaned = sock.list_locs().expect("list after delete");
     assert!(

--- a/userspace-dp/src/afxdp/rebalance/ntuple_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/ntuple_tests.rs
@@ -1,0 +1,132 @@
+// #1748: ntuple UAPI layout tests + a NIC-gated live insert/list/delete
+// round-trip. The compile-time `const _: () = assert!` checks in ntuple.rs
+// already gate the build on the struct sizes/offsets; these `#[test]`s
+// restate the critical sizes so a `cargo test` failure names the exact
+// drifted field, and exercise the spec-builder byte encoding.
+
+use super::*;
+use std::mem::{offset_of, size_of};
+
+#[test]
+fn uapi_struct_sizes_match_kernel() {
+    assert_eq!(size_of::<EthtoolTcpip4Spec>(), 16, "ethtool_tcpip4_spec");
+    assert_eq!(size_of::<EthtoolTcpip6Spec>(), 40, "ethtool_tcpip6_spec");
+    assert_eq!(size_of::<EthtoolFlowUnion>(), 52, "ethtool_flow_union");
+    assert_eq!(size_of::<EthtoolFlowExt>(), 20, "ethtool_flow_ext");
+    assert_eq!(size_of::<EthtoolRxFlowSpec>(), 168, "ethtool_rx_flow_spec");
+    assert_eq!(size_of::<EthtoolRxnfc>(), 192, "ethtool_rxnfc");
+}
+
+#[test]
+fn uapi_rx_flow_spec_offsets_match_kernel() {
+    assert_eq!(offset_of!(EthtoolRxFlowSpec, flow_type), 0);
+    assert_eq!(offset_of!(EthtoolRxFlowSpec, h_u), 4);
+    assert_eq!(offset_of!(EthtoolRxFlowSpec, h_ext), 56);
+    assert_eq!(offset_of!(EthtoolRxFlowSpec, m_u), 76);
+    assert_eq!(offset_of!(EthtoolRxFlowSpec, m_ext), 128);
+    assert_eq!(offset_of!(EthtoolRxFlowSpec, ring_cookie), 152);
+    assert_eq!(offset_of!(EthtoolRxFlowSpec, location), 160);
+}
+
+#[test]
+fn uapi_rxnfc_offsets_match_kernel() {
+    assert_eq!(offset_of!(EthtoolRxnfc, cmd), 0);
+    assert_eq!(offset_of!(EthtoolRxnfc, flow_type), 4);
+    assert_eq!(offset_of!(EthtoolRxnfc, data), 8);
+    assert_eq!(offset_of!(EthtoolRxnfc, fs), 16);
+    assert_eq!(offset_of!(EthtoolRxnfc, rule_cnt), 184);
+    assert_eq!(offset_of!(EthtoolRxnfc, rule_locs), 188);
+}
+
+#[test]
+fn build_flow_spec_tcp4_exact_match_encoding() {
+    let flow = FlowSpec5Tuple {
+        proto: FlowProto::Tcp4,
+        // 10.0.61.102 -> 172.16.80.200 in network order.
+        src_ip: [u32::from_be_bytes([10, 0, 61, 102]), 0, 0, 0],
+        dst_ip: [u32::from_be_bytes([172, 16, 80, 200]), 0, 0, 0],
+        src_port: 12345u16.to_be(),
+        dst_port: 5210u16.to_be(),
+    };
+    let fs = build_flow_spec(&flow, 3);
+    assert_eq!(fs.flow_type, TCP_V4_FLOW);
+    assert_eq!(fs.ring_cookie, 3, "ring_cookie carries the queue index");
+    assert_eq!(fs.location, RX_CLS_LOC_ANY, "auto-assign rule location");
+
+    // Decode the tcp_ip4_spec back out of the h_u union bytes.
+    let ip4src = u32::from_ne_bytes(fs.h_u.hdata[0..4].try_into().unwrap());
+    let ip4dst = u32::from_ne_bytes(fs.h_u.hdata[4..8].try_into().unwrap());
+    let psrc = u16::from_ne_bytes(fs.h_u.hdata[8..10].try_into().unwrap());
+    let pdst = u16::from_ne_bytes(fs.h_u.hdata[10..12].try_into().unwrap());
+    assert_eq!(ip4src, flow.src_ip[0]);
+    assert_eq!(ip4dst, flow.dst_ip[0]);
+    assert_eq!(psrc, flow.src_port);
+    assert_eq!(pdst, flow.dst_port);
+
+    // Exact match: addr/port mask fields are 0 (0 bit = "match this bit").
+    assert_eq!(&fs.m_u.hdata[0..12], &[0u8; 12], "5-tuple mask is exact");
+}
+
+#[test]
+fn build_flow_spec_tcp6_uses_v6_flow_type() {
+    let flow = FlowSpec5Tuple {
+        proto: FlowProto::Tcp6,
+        src_ip: [1, 2, 3, 4],
+        dst_ip: [5, 6, 7, 8],
+        src_port: 1000u16.to_be(),
+        dst_port: 2000u16.to_be(),
+    };
+    let fs = build_flow_spec(&flow, 5);
+    assert_eq!(fs.flow_type, TCP_V6_FLOW);
+    assert_eq!(fs.ring_cookie, 5);
+    let ip6src0 = u32::from_ne_bytes(fs.h_u.hdata[0..4].try_into().unwrap());
+    assert_eq!(ip6src0, 1);
+    // src+dst (32 B) addr-mask exact.
+    assert_eq!(&fs.m_u.hdata[0..32], &[0u8; 32]);
+}
+
+/// Live insert -> GRXCLSRLALL readback -> delete round-trip. Gated to run
+/// only where a NIC that supports flow steering is named via
+/// `XPF_NTUPLE_TEST_IFACE`. Without it the test no-ops (CI / dev boxes with
+/// no mlx5 VF). On a supporting NIC: enable `ethtool -K <if> ntuple on`
+/// first. This validates the wire semantics the compile-time asserts cannot.
+#[test]
+fn live_insert_list_delete_round_trip() {
+    let Ok(ifname) = std::env::var("XPF_NTUPLE_TEST_IFACE") else {
+        eprintln!("live_insert_list_delete_round_trip: skipped (set XPF_NTUPLE_TEST_IFACE)");
+        return;
+    };
+    let sock = NtupleSocket::open(&ifname).expect("open ethtool socket");
+    let flow = FlowSpec5Tuple {
+        proto: FlowProto::Tcp4,
+        src_ip: [u32::from_be_bytes([10, 0, 61, 200]), 0, 0, 0],
+        dst_ip: [u32::from_be_bytes([172, 16, 80, 250]), 0, 0, 0],
+        src_port: 54321u16.to_be(),
+        dst_port: 5210u16.to_be(),
+    };
+    let before = sock.list_locs().expect("list before");
+    let loc = match sock.insert_rule(&flow, 0) {
+        Ok(loc) => loc,
+        Err(e) if e.raw_os_error() == Some(libc::EOPNOTSUPP) => {
+            eprintln!("live round-trip: NIC does not support ntuple (EOPNOTSUPP) — skipped");
+            return;
+        }
+        Err(e) => panic!("insert_rule failed: {e}"),
+    };
+    let after = sock.list_locs().expect("list after");
+    assert!(
+        after.contains(&loc),
+        "inserted rule loc {loc} must appear in GRXCLSRLALL readback: {after:?}"
+    );
+    assert_eq!(
+        after.len(),
+        before.len() + 1,
+        "exactly one rule added"
+    );
+    sock.delete_rule(loc).expect("delete rule");
+    let cleaned = sock.list_locs().expect("list after delete");
+    assert!(
+        !cleaned.contains(&loc),
+        "deleted rule loc {loc} must be gone: {cleaned:?}"
+    );
+}

--- a/userspace-dp/src/afxdp/rebalance/ntuple_tests.rs
+++ b/userspace-dp/src/afxdp/rebalance/ntuple_tests.rs
@@ -78,8 +78,19 @@ fn build_flow_spec_tcp4_exact_match_encoding() {
     assert_eq!(psrc, flow.src_port);
     assert_eq!(pdst, flow.dst_port);
 
-    // Exact match: addr/port mask fields are 0 (0 bit = "match this bit").
-    assert_eq!(&fs.m_u.hdata[0..12], &[0u8; 12], "5-tuple mask is exact");
+    // #1748 live BLOCKER A: the INPUT mask is DIRECT (1 = match), so an exact
+    // 5-tuple match sets ip4src/ip4dst masks to 0xffff_ffff and psrc/pdst masks
+    // to 0xffff, with the tos mask 0 (a non-zero tos mask makes mlx5 EINVAL).
+    let m_ip4src = u32::from_ne_bytes(fs.m_u.hdata[0..4].try_into().unwrap());
+    let m_ip4dst = u32::from_ne_bytes(fs.m_u.hdata[4..8].try_into().unwrap());
+    let m_psrc = u16::from_ne_bytes(fs.m_u.hdata[8..10].try_into().unwrap());
+    let m_pdst = u16::from_ne_bytes(fs.m_u.hdata[10..12].try_into().unwrap());
+    let m_tos = fs.m_u.hdata[12];
+    assert_eq!(m_ip4src, 0xffff_ffff, "src-ip mask must be all-ones (match)");
+    assert_eq!(m_ip4dst, 0xffff_ffff, "dst-ip mask must be all-ones (match)");
+    assert_eq!(m_psrc, 0xffff, "src-port mask must be all-ones (match)");
+    assert_eq!(m_pdst, 0xffff, "dst-port mask must be all-ones (match)");
+    assert_eq!(m_tos, 0, "tos mask MUST be 0 (mlx5 rejects a non-zero tos mask)");
 }
 
 #[test]
@@ -96,8 +107,10 @@ fn build_flow_spec_tcp6_uses_v6_flow_type() {
     assert_eq!(fs.ring_cookie, 5);
     let ip6src0 = u32::from_ne_bytes(fs.h_u.hdata[0..4].try_into().unwrap());
     assert_eq!(ip6src0, 1);
-    // src+dst (32 B) addr-mask exact.
-    assert_eq!(&fs.m_u.hdata[0..32], &[0u8; 32]);
+    // src+dst (32 B) addr mask is all-ones (1 = match), and the tclass mask
+    // (byte 36) is 0 — the v6 analogue of the tos-mask-must-be-0 rule.
+    assert_eq!(&fs.m_u.hdata[0..32], &[0xffu8; 32], "v6 addr mask is all-ones");
+    assert_eq!(fs.m_u.hdata[36], 0, "tclass mask must be 0");
 }
 
 /// Live insert -> GRXCLSRLALL readback -> delete round-trip. Gated to run
@@ -138,21 +151,22 @@ fn live_insert_list_delete_round_trip() {
         before.len() + 1,
         "exactly one rule added"
     );
-    // #1748 review #1: read the rule back and assert the canonical INVERTED
-    // mask encoding the live mlx5 NIC confirmed — tuple mask fields = 0
-    // (match), TOS mask = 0xff (wildcard). This pins the hardware-confirmed
-    // polarity so the masks are not "corrected" to the intuitive convention.
+    // #1748 live BLOCKER A: read the rule back via GRXCLSRULE and assert the
+    // DIRECT mask the driver stored — all-ones on the matched 5-tuple fields,
+    // tos mask 0. (GRXCLSRULE returns the raw stored flow_spec, i.e. what we
+    // passed in; ethtool(8)'s `-n` display COMPLEMENTS the mask for humans,
+    // which is what an earlier round misread as "0.0.0.0 = match".)
     let fs = sock.get_rule(loc).expect("get_rule readback");
     let m_ip4src = u32::from_ne_bytes(fs.m_u.hdata[0..4].try_into().unwrap());
     let m_ip4dst = u32::from_ne_bytes(fs.m_u.hdata[4..8].try_into().unwrap());
     let m_psrc = u16::from_ne_bytes(fs.m_u.hdata[8..10].try_into().unwrap());
     let m_pdst = u16::from_ne_bytes(fs.m_u.hdata[10..12].try_into().unwrap());
     let m_tos = fs.m_u.hdata[12];
-    assert_eq!(m_ip4src, 0, "src-ip mask must be 0.0.0.0 (exact match)");
-    assert_eq!(m_ip4dst, 0, "dst-ip mask must be 0.0.0.0 (exact match)");
-    assert_eq!(m_psrc, 0, "src-port mask must be 0x0 (exact match)");
-    assert_eq!(m_pdst, 0, "dst-port mask must be 0x0 (exact match)");
-    assert_eq!(m_tos, 0xff, "TOS mask must be 0xff (wildcard)");
+    assert_eq!(m_ip4src, 0xffff_ffff, "src-ip mask must be all-ones (match)");
+    assert_eq!(m_ip4dst, 0xffff_ffff, "dst-ip mask must be all-ones (match)");
+    assert_eq!(m_psrc, 0xffff, "src-port mask must be all-ones (match)");
+    assert_eq!(m_pdst, 0xffff, "dst-port mask must be all-ones (match)");
+    assert_eq!(m_tos, 0, "tos mask must be 0 (mlx5 rejects a non-zero tos mask)");
     sock.delete_rule(loc).expect("delete rule");
     let cleaned = sock.list_locs().expect("list after delete");
     assert!(

--- a/userspace-dp/src/afxdp/session_glue/commands/refresh_owner_rgs.rs
+++ b/userspace-dp/src/afxdp/session_glue/commands/refresh_owner_rgs.rs
@@ -34,6 +34,11 @@ pub(in crate::afxdp::session_glue) fn handle_refresh_owner_rgs(
         if metadata.owner_rg_id <= 0 && !metadata.fabric_ingress {
             return;
         }
+        // #1748: never republish the abandoned W_old copy — it is inert and
+        // W_new owns the shared session-map entry.
+        if origin.is_rebalanced_out() {
+            return;
+        }
         let flow = SessionFlow {
             src_ip: key.src_ip,
             dst_ip: key.dst_ip,

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -295,13 +295,19 @@ pub(super) fn purge_sessions_for_input_dscp_filter_revalidation(
     });
     let purged = stale.len();
     for (key, decision, metadata, origin) in stale {
-        release_source_nat_allocation(
-            &forwarding.source_nat_rules,
-            &key,
-            decision.nat,
-            metadata.is_reverse,
-            now_ns,
-        );
+        // #1748: an interface-down / admin purge on W_old must NOT release the
+        // SNAT port the abandoned RebalancedOut copy carries — W_new owns the
+        // live session and the SNAT allocation. Double-release would free a
+        // port W_new is still using.
+        if !origin.is_rebalanced_out() {
+            release_source_nat_allocation(
+                &forwarding.source_nat_rules,
+                &key,
+                decision.nat,
+                metadata.is_reverse,
+                now_ns,
+            );
+        }
         delete_terminal_filtered_session(
             sessions,
             session_map_fd,
@@ -379,6 +385,13 @@ pub(super) fn delete_terminal_filtered_session(
     metadata: &SessionMetadata,
     origin: SessionOrigin,
 ) {
+    // #1748: `delete_session_map_entry_for_removed_session_with_origin` already
+    // early-returns for RebalancedOut (no redirect/conntrack delete). The rest
+    // of the shared-state teardown below must ALSO be suppressed for the
+    // abandoned W_old copy: removing the SHARED session-map entry, broadcasting
+    // DeleteSynced, or emitting a Close delta would all tear down the state
+    // W_new is actively forwarding against. The local slab entry is still
+    // removed so W_old reclaims its own memory.
     delete_session_map_entry_for_removed_session_with_origin(
         session_map_fd,
         key,
@@ -389,6 +402,9 @@ pub(super) fn delete_terminal_filtered_session(
         conntrack_v6_fd,
     );
     sessions.delete(key);
+    if origin.is_rebalanced_out() {
+        return;
+    }
     remove_shared_session(
         shared_sessions,
         shared_nat_sessions,
@@ -421,6 +437,9 @@ pub(in crate::afxdp::session_glue) fn export_forward_sessions_for_owner_rgs(
             || origin.is_peer_synced()
             || origin.is_transient_local_seed()
             || metadata.fabric_ingress
+            // #1748: the abandoned W_old copy must not be exported as an Open
+            // delta to the peer — W_new is the exporting owner now.
+            || origin.is_rebalanced_out()
         {
             continue;
         }

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -217,6 +217,11 @@ pub(super) struct WorkerCommandResults {
     /// no `BindingWorker` access — the outer poll loop in `worker.rs`
     /// dispatches based on this flag.
     pub vacate_all_shared_exact_slots: bool,
+    /// #1748: structured acks accumulated for each rebalance command applied
+    /// this tick. The outer loop writes each into the worker's
+    /// `rebalance_ack` slot + publishes the seq (Release) so the controller's
+    /// barrier can confirm key + origin before proceeding.
+    pub rebalance_acks: Vec<crate::afxdp::RebalanceAck>,
 }
 
 fn force_live_redirect_for_worker_synced_entry(
@@ -477,6 +482,7 @@ pub(super) fn apply_worker_commands(
                     exported_sequences: Vec::new(),
                     shaped_tx_requests: Vec::new(),
                     vacate_all_shared_exact_slots: false,
+                    rebalance_acks: Vec::new(),
                 };
             }
             core::mem::take(&mut *pending)
@@ -487,6 +493,7 @@ pub(super) fn apply_worker_commands(
                 exported_sequences: Vec::new(),
                 shaped_tx_requests: Vec::new(),
                 vacate_all_shared_exact_slots: false,
+                rebalance_acks: Vec::new(),
             };
         }
     };
@@ -499,6 +506,7 @@ pub(super) fn apply_worker_commands(
     let mut exported_sequences = Vec::new();
     let mut shaped_tx_requests = Vec::new();
     let mut vacate_all_shared_exact_slots = false;
+    let mut rebalance_acks: Vec<crate::afxdp::RebalanceAck> = Vec::new();
     for cmd in pending {
         match cmd {
             WorkerCommand::DemoteOwnerRGS { owner_rgs } => {
@@ -578,6 +586,52 @@ pub(super) fn apply_worker_commands(
                 // `worker.rs:818-822` dispatch).
                 vacate_all_shared_exact_slots = true;
             }
+            // #1748: rebalance ownership-transfer barrier steps. Each is a
+            // dedicated origin-only mutation on the SessionTable (no delta, no
+            // shared publish, no NAT). The structured ack carries the observed
+            // origin so the controller confirms the EXACT key reached the EXACT
+            // state before the barrier proceeds. `result=false` when the key is
+            // absent (the controller rolls back).
+            WorkerCommand::PromoteRebalanced { seq, key } => {
+                let result = sessions.promote_rebalanced_owner(&key, now_ns);
+                rebalance_acks.push(crate::afxdp::RebalanceAck {
+                    seq,
+                    origin: sessions.origin_of(&key),
+                    key,
+                    result,
+                });
+            }
+            WorkerCommand::DemoteRebalanced { seq, key } => {
+                let result = sessions.demote_rebalanced_out(&key);
+                rebalance_acks.push(crate::afxdp::RebalanceAck {
+                    seq,
+                    origin: sessions.origin_of(&key),
+                    key,
+                    result,
+                });
+            }
+            WorkerCommand::RestoreRebalancedOwner { seq, key } => {
+                let result = sessions.restore_rebalanced_owner(&key, now_ns);
+                rebalance_acks.push(crate::afxdp::RebalanceAck {
+                    seq,
+                    origin: sessions.origin_of(&key),
+                    key,
+                    result,
+                });
+            }
+            WorkerCommand::DemoteRebalancedReplica { seq, key } => {
+                // Reverse barrier: hand W_new's RebalancedOwner back to a
+                // worker-local replica. WorkerLocalImport is the correct
+                // resting origin for a materialized synced replica that this
+                // worker holds but does not own.
+                let result = sessions.demote_rebalanced_replica(&key);
+                rebalance_acks.push(crate::afxdp::RebalanceAck {
+                    seq,
+                    origin: sessions.origin_of(&key),
+                    key,
+                    result,
+                });
+            }
         }
     }
     WorkerCommandResults {
@@ -585,6 +639,7 @@ pub(super) fn apply_worker_commands(
         exported_sequences,
         shaped_tx_requests,
         vacate_all_shared_exact_slots,
+        rebalance_acks,
     }
 }
 

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -3928,3 +3928,146 @@ fn apply_worker_commands_dispatch_order_pin_with_demote_dedup() {
         "DemoteOwnerRGS first-occurrence order must be preserved"
     );
 }
+
+
+// ── #1748 RebalancedOut terminal/purge suppression tests ────────────
+
+/// delete_terminal_filtered_session on a RebalancedOut entry (the abandoned
+/// W_old copy) must NOT remove the SHARED session-map entry that W_new is
+/// actively forwarding against. The local slab entry is still removed (W_old
+/// reclaims its own memory) but the shared state survives.
+#[test]
+fn terminal_filtered_session_rebalanced_out_keeps_shared_state() {
+    let mut sessions = SessionTable::new();
+    let key = test_key();
+    let now = 1_000_000_000u64;
+
+    // Install the local copy as RebalancedOut on W_old.
+    assert!(sessions.install_with_protocol_with_origin(
+        key.clone(),
+        test_decision(),
+        test_metadata(),
+        SessionOrigin::ForwardFlow,
+        now,
+        PROTO_TCP,
+        0x10,
+    ));
+    // Drain the install Open delta so the post-cleanup assertion is clean.
+    let _ = sessions.drain_deltas(8);
+    assert!(sessions.demote_rebalanced_out(&key));
+
+    // W_new owns the shared session entry.
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+    let shared_entry = SyncedSessionEntry {
+        key: key.clone(),
+        decision: test_decision(),
+        metadata: test_metadata(),
+        origin: SessionOrigin::WorkerLocalImport,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x10,
+    };
+    publish_shared_session(
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        &shared_owner_rg_indexes,
+        &shared_entry,
+    );
+    assert_eq!(shared_sessions.lock().unwrap().len(), 1);
+
+    // W_old's terminal cleanup of its RebalancedOut copy.
+    delete_terminal_filtered_session(
+        &mut sessions,
+        -1,
+        -1,
+        -1,
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        &shared_owner_rg_indexes,
+        &peer_worker_commands,
+        &key,
+        test_decision(),
+        &test_metadata(),
+        SessionOrigin::RebalancedOut,
+    );
+
+    // CRITICAL: the SHARED entry W_new owns survives.
+    assert_eq!(
+        shared_sessions.lock().unwrap().len(),
+        1,
+        "RebalancedOut terminal cleanup must NOT remove the shared session entry"
+    );
+    // No DeleteSynced broadcast was queued (peer_worker_commands empty here,
+    // but the early return also skips replicate_session_delete).
+    // The local slab entry IS removed.
+    assert!(sessions.entry_with_origin(&key).is_none());
+    // No Close delta emitted.
+    assert!(sessions.drain_deltas(8).is_empty());
+}
+
+/// Counter-factual: the SAME teardown on a normal (non-rebalanced) origin DOES
+/// remove the shared session entry. Proves the suppression is origin-specific,
+/// not a blanket no-op.
+#[test]
+fn terminal_filtered_session_normal_origin_removes_shared_state() {
+    let mut sessions = SessionTable::new();
+    let key = test_key();
+    let now = 1_000_000_000u64;
+    assert!(sessions.install_with_protocol_with_origin(
+        key.clone(),
+        test_decision(),
+        test_metadata(),
+        SessionOrigin::ForwardFlow,
+        now,
+        PROTO_TCP,
+        0x10,
+    ));
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+    let shared_entry = SyncedSessionEntry {
+        key: key.clone(),
+        decision: test_decision(),
+        metadata: test_metadata(),
+        origin: SessionOrigin::ForwardFlow,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x10,
+    };
+    publish_shared_session(
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        &shared_owner_rg_indexes,
+        &shared_entry,
+    );
+    assert_eq!(shared_sessions.lock().unwrap().len(), 1);
+
+    delete_terminal_filtered_session(
+        &mut sessions,
+        -1,
+        -1,
+        -1,
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        &shared_owner_rg_indexes,
+        &peer_worker_commands,
+        &key,
+        test_decision(),
+        &test_metadata(),
+        SessionOrigin::ForwardFlow,
+    );
+
+    assert_eq!(
+        shared_sessions.lock().unwrap().len(),
+        0,
+        "a normal-origin terminal cleanup DOES remove the shared session entry"
+    );
+}

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -701,6 +701,7 @@ fn resolve_cos_queue_id_prefers_egress_output_filter_forwarding_class() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -806,6 +807,7 @@ fn resolve_cos_queue_id_uses_reverse_output_source_port_filter() {
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -956,6 +958,7 @@ fn resolve_cached_cos_tx_selection_prefers_egress_output_filter_and_keeps_counte
             dscp_classifiers: vec![],
             ieee8021_classifiers: vec![],
             dscp_rewrite_rules: vec![],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1072,6 +1075,7 @@ fn resolve_cos_queue_id_uses_ingress_input_filter_when_no_output_filter_exists()
                     },
                 ],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1187,6 +1191,7 @@ fn resolve_cached_cos_tx_selection_uses_ingress_input_filter_when_no_output_exis
                     },
                 ],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1268,6 +1273,7 @@ fn resolve_cached_cos_tx_selection_keeps_counter_only_output_filter_hits() {
                     scheduler: "be-sched".into(),
                 }],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1349,6 +1355,7 @@ fn resolve_cos_tx_selection_counts_counter_only_output_filter_hits() {
                     scheduler: "be-sched".into(),
                 }],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1579,6 +1586,7 @@ fn resolve_cos_tx_selection_uses_ingress_filter_dscp_rewrite_when_no_output_filt
                     },
                 ],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1670,6 +1678,7 @@ fn resolve_cos_tx_selection_skips_ingress_filter_without_tx_selection_effects() 
                     scheduler: "be-sched".into(),
                 }],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1814,6 +1823,7 @@ fn resolve_cos_queue_id_falls_back_to_default_queue_without_filter_match() {
                     scheduler: "be-sched".into(),
                 }],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -1903,6 +1913,7 @@ fn resolve_cos_queue_id_uses_dscp_classifier_when_filters_do_not_set_class() {
                 codel_target_ns: 0,
                 },
             ],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -2235,6 +2246,7 @@ fn resolve_cos_queue_id_preserves_ingress_classification_when_output_filter_has_
                     },
                 ],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };
@@ -2318,6 +2330,7 @@ fn resolve_cos_tx_selection_preserves_output_filter_dscp_rewrite_without_forward
                     scheduler: "be-sched".into(),
                 }],
             }],
+            flow_rebalance: None,
         }),
         ..Default::default()
     };

--- a/userspace-dp/src/afxdp/types/runtime.rs
+++ b/userspace-dp/src/afxdp/types/runtime.rs
@@ -22,6 +22,13 @@ pub(in crate::afxdp) struct WorkerHandle {
     pub(in crate::afxdp) heartbeat: Arc<AtomicU64>,
     pub(in crate::afxdp) commands: Arc<Mutex<VecDeque<WorkerCommand>>>,
     pub(in crate::afxdp) session_export_ack: Arc<AtomicU64>,
+    /// #1748: structured rebalance command ack slot. The worker writes the
+    /// `{seq,key,origin,result}` after applying a Promote/Demote/Restore
+    /// rebalance command, then publishes the seq into `rebalance_ack_seq`
+    /// (Release). The controller polls `rebalance_ack_seq` (Acquire) for its
+    /// pending seq, then reads the slot to confirm key + origin.
+    pub(in crate::afxdp) rebalance_ack: Arc<Mutex<Option<super::RebalanceAck>>>,
+    pub(in crate::afxdp) rebalance_ack_seq: Arc<AtomicU64>,
     pub(in crate::afxdp) cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
     // #869: per-worker busy/idle runtime telemetry publish slot.
     pub(in crate::afxdp) runtime_atomics: Arc<super::worker_runtime::WorkerRuntimeAtomics>,
@@ -234,6 +241,38 @@ pub(in crate::afxdp) enum WorkerCommand {
     /// this command sets a flag in `WorkerCommandResults`; the outer
     /// poll loop dispatches via `vacate_all_shared_exact_slots`.
     VacateAllSharedExactSlots,
+    /// #1748: rebalance forward-barrier step 1 — flip W_new's existing
+    /// materialized replica `origin` to RebalancedOwner (tag flip +
+    /// liveness-only refresh, nothing else). The worker stores a structured
+    /// ack `{seq,key,origin,result}` so the controller confirms the EXACT key
+    /// reached RebalancedOwner before installing the ntuple rule.
+    PromoteRebalanced { seq: u64, key: SessionKey },
+    /// #1748: rebalance forward-barrier step 2 — flip W_old's forward entry
+    /// `origin` to RebalancedOut (tag flip only). Acked structurally.
+    DemoteRebalanced { seq: u64, key: SessionKey },
+    /// #1748: reverse-barrier step — restore W_old's RebalancedOut entry back
+    /// to a local owner (ForwardFlow) + liveness refresh, used on rollback and
+    /// teardown of a live move. Acked structurally.
+    RestoreRebalancedOwner { seq: u64, key: SessionKey },
+    /// #1748: reverse-barrier step — demote W_new's RebalancedOwner entry back
+    /// to a worker-local replica (WorkerLocalImport), used on rollback and
+    /// teardown of a live move (after W_old has been restored). Acked
+    /// structurally.
+    DemoteRebalancedReplica { seq: u64, key: SessionKey },
+}
+
+/// #1748: structured per-worker rebalance command ack. Unlike the raw
+/// `session_export_ack` AtomicU64 counter, the controller must read back the
+/// EXACT key and observed origin so it confirms the move reached the intended
+/// state (RebalancedOwner / RebalancedOut / restored / replica) before the
+/// barrier proceeds. `result` is false when the key was absent on the worker
+/// (the controller treats that as a failed step and rolls back).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) struct RebalanceAck {
+    pub(in crate::afxdp) seq: u64,
+    pub(in crate::afxdp) key: SessionKey,
+    pub(in crate::afxdp) origin: Option<SessionOrigin>,
+    pub(in crate::afxdp) result: bool,
 }
 
 #[derive(Default)]

--- a/userspace-dp/src/afxdp/types/runtime.rs
+++ b/userspace-dp/src/afxdp/types/runtime.rs
@@ -29,6 +29,12 @@ pub(in crate::afxdp) struct WorkerHandle {
     /// pending seq, then reads the slot to confirm key + origin.
     pub(in crate::afxdp) rebalance_ack: Arc<Mutex<Option<super::RebalanceAck>>>,
     pub(in crate::afxdp) rebalance_ack_seq: Arc<AtomicU64>,
+    /// #1748: coordinator-side command sequence generator. Incremented by
+    /// `fetch_add` for each new barrier command so every command gets a
+    /// strictly-unique seq regardless of whether a previous command timed
+    /// out without being acked (in which case `rebalance_ack_seq` would
+    /// not have advanced, causing a collision if we derived seq from it).
+    pub(in crate::afxdp) rebalance_cmd_seq: Arc<AtomicU64>,
     pub(in crate::afxdp) cos_status: Arc<ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>>,
     // #869: per-worker busy/idle runtime telemetry publish slot.
     pub(in crate::afxdp) runtime_atomics: Arc<super::worker_runtime::WorkerRuntimeAtomics>,

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -838,6 +838,24 @@ impl BindingLiveState {
         self.tx_bytes.load(Ordering::Relaxed)
     }
 
+    /// #1748 test-only: set the cumulative tx_bytes so a coordinator test can
+    /// drive the rebalance controller's per-worker rate sampling without a
+    /// live forwarding path.
+    #[cfg(test)]
+    pub(in crate::afxdp) fn test_set_tx_bytes(&self, v: u64) {
+        self.tx_bytes.store(v, Ordering::Relaxed);
+    }
+
+    /// #1748 test-only: publish a flow-worker-map snapshot so a coordinator
+    /// test can drive the controller's per-flow 5-tuple feed directly.
+    #[cfg(test)]
+    pub(in crate::afxdp) fn test_publish_flow_worker_map(
+        &self,
+        rows: Vec<crate::protocol::FlowWorkerStatus>,
+    ) {
+        self.publish_flow_worker_map(rows, false);
+    }
+
     /// #1748: ifindex this binding's socket is bound to (0 if unbound). Lets
     /// the controller scope its observation/steering to a single NIC.
     pub(in crate::afxdp) fn socket_ifindex(&self) -> i32 {

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -830,6 +830,27 @@ impl BindingLiveState {
         (snapshot.rows.clone(), snapshot.truncated)
     }
 
+    /// #1748: cumulative TX bytes for this binding's live state. The
+    /// rebalance controller samples this per worker across a window to derive
+    /// per-worker byte-rate (the selection objective). Relaxed is fine — the
+    /// controller only needs an approximate rate over ~1 s.
+    pub(in crate::afxdp) fn tx_bytes(&self) -> u64 {
+        self.tx_bytes.load(Ordering::Relaxed)
+    }
+
+    /// #1748: ifindex this binding's socket is bound to (0 if unbound). Lets
+    /// the controller scope its observation/steering to a single NIC.
+    pub(in crate::afxdp) fn socket_ifindex(&self) -> i32 {
+        self.socket_ifindex.load(Ordering::Relaxed)
+    }
+
+    /// #1748: RX queue index this binding's socket is bound to. With AF_XDP
+    /// the queue id maps 1:1 to a worker, so this is the ntuple `ring_cookie`
+    /// target queue for a move onto this worker.
+    pub(in crate::afxdp) fn socket_queue_id(&self) -> u32 {
+        self.socket_queue_id.load(Ordering::Relaxed)
+    }
+
     /// Publish this binding's per-CoS active-flow counts.
     ///
     /// Unlike `flow_worker_map`, this per-binding snapshot has no local

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -668,13 +668,19 @@ pub(crate) fn worker_loop(
         let expired_entries = sessions.expire_stale_entries(loop_now_ns);
         let expired = expired_entries.len() as u64;
         for expired_entry in expired_entries {
-            release_source_nat_allocation(
-                &forwarding.source_nat_rules,
-                &expired_entry.key,
-                expired_entry.decision.nat,
-                expired_entry.metadata.is_reverse,
-                loop_now_ns,
-            );
+            // #1748: the abandoned W_old copy (RebalancedOut) must NOT release
+            // the SNAT allocation on its local-only GC expiry — W_new owns the
+            // session and releases the SNAT port on its own real close. A
+            // double-release here would free a port W_new is still using.
+            if !expired_entry.origin.is_rebalanced_out() {
+                release_source_nat_allocation(
+                    &forwarding.source_nat_rules,
+                    &expired_entry.key,
+                    expired_entry.decision.nat,
+                    expired_entry.metadata.is_reverse,
+                    loop_now_ns,
+                );
+            }
             delete_session_map_entry_for_removed_session_with_origin(
                 session_map_fd,
                 &expired_entry.key,

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -33,6 +33,10 @@ pub(crate) fn worker_loop(
     stop: Arc<AtomicBool>,
     heartbeat: Arc<AtomicU64>,
     session_export_ack: Arc<AtomicU64>,
+    // #1748: structured rebalance command ack slot + lock-free published seq.
+    // Written only when this worker applies a Promote/Demote rebalance command.
+    rebalance_ack: Arc<Mutex<Option<crate::afxdp::RebalanceAck>>>,
+    rebalance_ack_seq: Arc<AtomicU64>,
     poll_mode: crate::PollMode,
     dnat_fds: DnatTableFds,
     shared_fabrics: Arc<ArcSwap<Vec<FabricLink>>>,
@@ -609,6 +613,7 @@ pub(crate) fn worker_loop(
                 exported_sequences: Vec::new(),
                 shaped_tx_requests: Vec::new(),
                 vacate_all_shared_exact_slots: false,
+                rebalance_acks: Vec::new(),
             }
         };
         let WorkerCommandResults {
@@ -616,7 +621,23 @@ pub(crate) fn worker_loop(
             exported_sequences,
             shaped_tx_requests,
             vacate_all_shared_exact_slots,
+            rebalance_acks,
         } = command_results;
+        // #1748: publish each rebalance command ack. Write the structured
+        // {seq,key,origin,result} into the slot, THEN publish the seq
+        // (Release) so the controller that observes the seq (Acquire) is
+        // guaranteed to read the matching slot. Acks are applied in command
+        // order; the controller barriers on one outstanding seq at a time, so
+        // the last write for its pending seq is the one it reads.
+        if !rebalance_acks.is_empty() {
+            for ack in rebalance_acks {
+                let seq = ack.seq;
+                if let Ok(mut slot) = rebalance_ack.lock() {
+                    *slot = Some(ack);
+                }
+                rebalance_ack_seq.store(seq, Ordering::Release);
+            }
+        }
         // #941 Work item C: HA-demotion vacate. The
         // VacateAllSharedExactSlots WorkerCommand cannot be processed
         // inside `apply_worker_commands` (no BindingWorker access);

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -11,7 +11,7 @@ use super::binding::{
     BindingCountersSnapshot, BindingStatus, ExceptionStatus, HAGroupStatus, QueueStatus,
     SessionDeltaInfo, WorkerRuntimeStatus,
 };
-use super::cos::{CoSActiveFlowCountStatus, CoSInterfaceStatus};
+use super::cos::{CoSActiveFlowCountStatus, CoSInterfaceStatus, FlowRebalanceStatus};
 use super::nat::SourceNatPoolStatus;
 use super::resolution::{FlowWorkerStatus, PacketResolution};
 use super::security::{
@@ -228,6 +228,10 @@ pub(crate) struct ProcessStatus {
     /// Monotonic timestamp (secs) of the last HA flow cache flush (#312).
     #[serde(rename = "last_cache_flush_at", default)]
     pub last_cache_flush_at: u64,
+    /// #1748: per-interface reactive rebalance controller telemetry. Empty
+    /// when the knob is off (no controllers constructed).
+    #[serde(rename = "flow_rebalance", default)]
+    pub flow_rebalance: Vec<FlowRebalanceStatus>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/protocol/cos.rs
+++ b/userspace-dp/src/protocol/cos.rs
@@ -21,6 +21,44 @@ pub(crate) struct ClassOfServiceSnapshot {
     pub schedulers: Vec<CoSSchedulerSnapshot>,
     #[serde(rename = "scheduler_maps", default)]
     pub scheduler_maps: Vec<CoSSchedulerMapSnapshot>,
+    /// #1748: opt-in reactive ntuple rebalance config. `None` => the
+    /// controller is never constructed (byte-identical default path). JSON
+    /// rename MUST match the Go `flow_rebalance` tag — the wire format is the
+    /// contract.
+    #[serde(rename = "flow_rebalance", default, skip_serializing_if = "Option::is_none")]
+    pub flow_rebalance: Option<CoSFlowRebalanceSnapshot>,
+}
+
+/// #1748: rebalance controller config, mirrored from
+/// `config.CoSFlowRebalance`. Zero sub-fields mean "use the controller's
+/// built-in defaults".
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub(crate) struct CoSFlowRebalanceSnapshot {
+    #[serde(rename = "imbalance_threshold_percent", default)]
+    pub imbalance_threshold_percent: u32,
+    #[serde(rename = "rebalance_interval_secs", default)]
+    pub rebalance_interval_secs: u32,
+    #[serde(rename = "max_rules", default)]
+    pub max_rules: u32,
+}
+
+/// #1748: per-interface rebalance controller telemetry, exported to the Go
+/// Prometheus collector. One row per live controller (per steered ifindex).
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
+pub(crate) struct FlowRebalanceStatus {
+    #[serde(default)]
+    pub ifindex: i32,
+    #[serde(rename = "rules_active", default)]
+    pub rules_active: u32,
+    #[serde(rename = "installs_total", default)]
+    pub installs_total: u64,
+    #[serde(rename = "deletes_total", default)]
+    pub deletes_total: u64,
+    /// Skip counts keyed by reason label (e.g. "magnitude", "cooldown").
+    #[serde(rename = "moves_skipped", default)]
+    pub moves_skipped: std::collections::BTreeMap<String, u64>,
+    #[serde(rename = "worker_byterate_cov", default)]
+    pub worker_byterate_cov: f64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -14,6 +14,12 @@ use sha2::{Digest, Sha256};
 use std::io::{self, Write};
 
 pub(crate) fn refresh_status(state: &mut ServerState) {
+    // #1748: drive one rebalance controller tick at the status cadence
+    // (~1 Hz). Default-OFF: a single Option::is_none() early-return inside
+    // tick_rebalance when the knob is unset (no ioctl socket, no per-tick
+    // work). This reuses the existing status path's worker telemetry + the
+    // flow-worker map; it adds NO new control-socket caller.
+    state.afxdp.tick_rebalance();
     state.afxdp.refresh_bindings(&mut state.status.bindings);
     let writer_status = state.state_writer.status();
     state.status.io_uring_active = writer_status.active;
@@ -132,6 +138,8 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
         state.status.event_stream_dropped = es_stats.dropped;
     }
     state.status.last_cache_flush_at = state.afxdp.last_cache_flush_at();
+    // #1748: per-interface rebalance controller telemetry (empty when off).
+    state.status.flow_rebalance = state.afxdp.flow_rebalance_status();
 }
 
 pub(crate) fn forwarding_unsupported_error(cap: &UserspaceCapabilities) -> String {

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -135,6 +135,7 @@ pub(crate) fn run() -> Result<(), String> {
             event_stream_sent: 0,
             event_stream_dropped: 0,
             last_cache_flush_at: 0,
+            flow_rebalance: Vec::new(),
         },
         snapshot: None,
         afxdp: {

--- a/userspace-dp/src/session/entry.rs
+++ b/userspace-dp/src/session/entry.rs
@@ -56,6 +56,21 @@ pub(crate) enum SessionOrigin {
     SharedPromote,
     #[allow(dead_code)] // enum variant for completeness
     WorkerLocalImport,
+    /// #1748: the abandoned forward copy on the OLD worker (W_old) after
+    /// the ntuple rebalance controller has steered a flow to a NEW worker.
+    /// Suppress-everything: its GC expiry / purge / terminal-filter cleanup
+    /// must NOT release or delete any shared state (shared session map,
+    /// conntrack mirror, SNAT allocation, DeleteSynced broadcast) because
+    /// W_new now owns that state. Ages out local-only.
+    RebalancedOut,
+    /// #1748: the promoted owner on the NEW worker (W_new) after a move.
+    /// Behaves like a normal LOCAL owner for cleanup/export/sync — it emits
+    /// Close on real expiry, deletes shared map + conntrack, broadcasts
+    /// DeleteSynced, releases SNAT — so exactly one worker owns end-of-flow
+    /// cleanup. `is_peer_synced()` stays FALSE for it (it is a local owner,
+    /// not an import) so it is NOT Close-suppressed, and it demotes to
+    /// SyncImport on a real RG failover like ForwardFlow.
+    RebalancedOwner,
 }
 
 impl SessionOrigin {
@@ -69,7 +84,18 @@ impl SessionOrigin {
             Self::SharedMaterialize => "shared_materialize",
             Self::SharedPromote => "shared_promote",
             Self::WorkerLocalImport => "worker_local_import",
+            Self::RebalancedOut => "rebalanced_out",
+            Self::RebalancedOwner => "rebalanced_owner",
         }
+    }
+
+    /// #1748: true for the abandoned W_old copy after a rebalance move.
+    /// Every shared-state release/delete keyed by a session is gated on
+    /// `!is_rebalanced_out()` so W_old's eventual local-only cleanup never
+    /// touches the state W_new now owns. `RebalancedOwner` returns false —
+    /// it IS the cleanup owner.
+    pub(crate) fn is_rebalanced_out(self) -> bool {
+        matches!(self, Self::RebalancedOut)
     }
 
     /// Returns true for origins that represent peer-synced sessions.

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -1136,15 +1136,22 @@ impl SessionTable {
             let Some(entry) = self.entry_by_key_mut(&key) else {
                 continue;
             };
-            // #1748: RebalancedOut is the inert abandoned W_old copy — it is
-            // excluded from the rebalance suppression set's HA handling and
-            // must NOT be rewritten to SyncImport (that would re-enable the
-            // shared cleanup W_new owns). RebalancedOwner is a normal local
-            // owner and DOES demote to SyncImport on failover, handled by the
-            // `!is_peer_synced()` branch below (RebalancedOwner is not
-            // peer-synced).
+            // #1748 review #5: RebalancedOut is the inert abandoned W_old copy.
+            // It must be excluded from the rebalance suppression set's HA
+            // handling AND must NOT be returned in `demoted_keys`. The
+            // demoted_keys list is NOT benign bookkeeping: the
+            // DemoteOwnerRGS handler republishes the shared session-map entry
+            // for each demoted key (publish_worker_session_map_entry,
+            // session_glue/commands/demote_owner_rgs.rs) AND pushes the key to
+            // `cancelled_keys`, which the worker loop uses to call
+            // delete_session_map_redirect_for_session
+            // (worker/loop_body/mod.rs) — the raw, NOT origin-gated, redirect
+            // delete. Either would tear down the shared redirect/session-map
+            // state W_new is actively forwarding against. So skip the push
+            // entirely. (RebalancedOwner is a normal local owner and DOES
+            // demote to SyncImport on failover via the `!is_peer_synced()`
+            // branch below.)
             if entry.origin.is_rebalanced_out() {
-                demoted_keys.push(key);
                 continue;
             }
             if !entry.origin.is_peer_synced() {

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -431,6 +431,11 @@ impl SessionTable {
                         if !metadata.is_reverse
                             && !removed.origin.is_peer_synced()
                             && !removed.origin.is_transient_local_seed()
+                            // #1748: the abandoned W_old copy must NOT emit a
+                            // Close delta on its local-only expiry — W_new owns
+                            // the shared session/conntrack/SNAT state now, and a
+                            // Close here would cascade-delete the live flow.
+                            && !removed.origin.is_rebalanced_out()
                         {
                             self.push_delta(SessionDelta {
                                 kind: SessionDeltaKind::Close,
@@ -943,6 +948,86 @@ impl SessionTable {
         self.update_session(req, false)
     }
 
+    /// #1748: dedicated origin-only mutation for the rebalance controller's
+    /// PromoteRebalanced barrier step. Flips W_new's existing materialized
+    /// replica `origin` to `RebalancedOwner` IN PLACE and does a liveness-only
+    /// refresh (`last_seen_ns` + `push_to_wheel`) so the promoted owner is
+    /// provably non-expiring across the move budget, independent of its prior
+    /// TTL.
+    ///
+    /// It MUST NOT reuse `update_session` (which emits an Open delta when a
+    /// peer-synced entry becomes non-peer-synced, mod.rs:843+) or
+    /// `maybe_promote_synced_session` (which republishes + shared-map-upserts +
+    /// replicates, promote.rs). This is a TAG FLIP + liveness only: NO delta,
+    /// NO shared-map publish/upsert, NO conntrack write, NO NAT realloc, NO
+    /// `decision`/`metadata` mutation, NO epoch bump.
+    ///
+    /// Returns true if the key was present and the origin is now
+    /// `RebalancedOwner` (idempotent: a no-op re-flip still returns true).
+    pub fn promote_rebalanced_owner(&mut self, key: &SessionKey, now_ns: u64) -> bool {
+        let touched = if let Some(entry) = self.entry_by_key_mut(key) {
+            entry.origin = SessionOrigin::RebalancedOwner;
+            // Liveness-only refresh — Codex r4: "replica present" is not
+            // enough; W_new's replica could be ms from its own GC timeout.
+            entry.last_seen_ns = now_ns;
+            true
+        } else {
+            false
+        };
+        if touched {
+            // Re-bucket so a racing GC tick between promote-ack and rule
+            // install cannot expire the sole cleanup owner.
+            self.push_to_wheel(key, now_ns);
+        }
+        touched
+    }
+
+    /// #1748: dedicated origin-only mutation for the rebalance controller's
+    /// DemoteRebalanced barrier step. Flips W_old's forward entry `origin` to
+    /// `RebalancedOut` IN PLACE so its eventual local-only GC expiry / purge /
+    /// terminal-filter cleanup is fully suppressed (the abandoned copy never
+    /// touches the shared state W_new now owns).
+    ///
+    /// TAG FLIP ONLY — no liveness refresh (the abandoned copy should age out),
+    /// no delta, no publish, no NAT change. Returns true if the key was
+    /// present.
+    pub fn demote_rebalanced_out(&mut self, key: &SessionKey) -> bool {
+        if let Some(entry) = self.entry_by_key_mut(key) {
+            entry.origin = SessionOrigin::RebalancedOut;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// #1748: reverse-barrier restore. On rollback / teardown-of-a-live-move,
+    /// W_old's `RebalancedOut` entry is handed ownership back BEFORE W_new is
+    /// demoted, so there is always >= 1 cleanup owner. Flips the origin back to
+    /// a normal local owner (`ForwardFlow`) and does a liveness-only refresh so
+    /// the restored owner does not immediately expire. No delta, no publish, no
+    /// NAT change. Returns true if the key was present.
+    pub fn restore_rebalanced_owner(&mut self, key: &SessionKey, now_ns: u64) -> bool {
+        let touched = if let Some(entry) = self.entry_by_key_mut(key) {
+            entry.origin = SessionOrigin::ForwardFlow;
+            entry.last_seen_ns = now_ns;
+            true
+        } else {
+            false
+        };
+        if touched {
+            self.push_to_wheel(key, now_ns);
+        }
+        touched
+    }
+
+    /// #1748: read the current origin of a session, for ack confirmation
+    /// (the structured PromoteRebalanced/DemoteRebalanced ack carries the
+    /// observed origin so the controller verifies the EXACT key reached the
+    /// EXACT origin before proceeding).
+    pub fn origin_of(&self, key: &SessionKey) -> Option<SessionOrigin> {
+        self.entry_by_key(key).map(|entry| entry.origin)
+    }
+
     pub fn emit_open_delta_with_origin(
         &mut self,
         key: SessionKey,
@@ -1036,6 +1121,17 @@ impl SessionTable {
             let Some(entry) = self.entry_by_key_mut(&key) else {
                 continue;
             };
+            // #1748: RebalancedOut is the inert abandoned W_old copy — it is
+            // excluded from the rebalance suppression set's HA handling and
+            // must NOT be rewritten to SyncImport (that would re-enable the
+            // shared cleanup W_new owns). RebalancedOwner is a normal local
+            // owner and DOES demote to SyncImport on failover, handled by the
+            // `!is_peer_synced()` branch below (RebalancedOwner is not
+            // peer-synced).
+            if entry.origin.is_rebalanced_out() {
+                demoted_keys.push(key);
+                continue;
+            }
             if !entry.origin.is_peer_synced() {
                 entry.origin = SessionOrigin::SyncImport;
             }

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -1020,6 +1020,21 @@ impl SessionTable {
         touched
     }
 
+    /// #1748: reverse-barrier replica demotion. After W_old has been restored
+    /// to owner, W_new's `RebalancedOwner` entry is flipped back to a
+    /// worker-local materialized replica (`WorkerLocalImport`) so it no longer
+    /// claims cleanup ownership. TAG FLIP ONLY — no delta, no publish, no NAT
+    /// change, no liveness refresh (the replica resumes its normal TTL).
+    /// Returns true if the key was present.
+    pub fn demote_rebalanced_replica(&mut self, key: &SessionKey) -> bool {
+        if let Some(entry) = self.entry_by_key_mut(key) {
+            entry.origin = SessionOrigin::WorkerLocalImport;
+            true
+        } else {
+            false
+        }
+    }
+
     /// #1748: read the current origin of a session, for ack confirmation
     /// (the structured PromoteRebalanced/DemoteRebalanced ack carries the
     /// observed origin so the controller verifies the EXACT key reached the

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -1937,12 +1937,24 @@ fn demote_owner_rg_excludes_rebalanced_out_but_demotes_owner() {
     ));
     assert!(table.promote_rebalanced_owner(&owner_key, now));
 
-    table.demote_owner_rg(1);
+    let demoted = table.demote_owner_rg(1);
 
     // RebalancedOut stays inert.
     assert_eq!(table.origin_of(&out_key), Some(SessionOrigin::RebalancedOut));
     // RebalancedOwner demotes to SyncImport like ForwardFlow.
     assert_eq!(table.origin_of(&owner_key), Some(SessionOrigin::SyncImport));
+    // #1748 review #5: the RebalancedOut key must NOT appear in demoted_keys —
+    // downstream the DemoteOwnerRGS handler republishes the shared session-map
+    // entry and pushes the key to cancelled_keys (which deletes the redirect
+    // alias W_new owns). The RebalancedOwner key MUST appear (normal demote).
+    assert!(
+        !demoted.contains(&out_key),
+        "RebalancedOut key must NOT be returned in demoted_keys: {demoted:?}"
+    );
+    assert!(
+        demoted.contains(&owner_key),
+        "RebalancedOwner key must be returned in demoted_keys: {demoted:?}"
+    );
 }
 
 /// restore_rebalanced_owner (reverse-barrier step) flips a RebalancedOut entry

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -1757,3 +1757,223 @@ fn refresh_for_ha_activation_updates_peer_synced_entries() {
     let lookup = table.lookup(&key, 3_000_000, 0x10).expect("session");
     assert_eq!(lookup.decision.resolution.egress_ifindex, 99);
 }
+
+
+// ── #1748 rebalance origin-mutator + suppression tests ──────────────
+
+/// promote_rebalanced_owner is a TAG FLIP + liveness only: it must NOT push
+/// any delta (no Open), must NOT mutate decision/metadata, and must leave the
+/// origin at RebalancedOwner. (The SessionTable layer owns no shared-map /
+/// conntrack / NAT state, so "no shared publish/upsert, no conntrack write, no
+/// NAT refcount change" reduces here to "no delta + no field mutation"; the
+/// glue layer's BarrierTransport calls only this API, never publish/upsert.)
+#[test]
+fn promote_rebalanced_owner_is_side_effect_free() {
+    let mut table = SessionTable::new();
+    let key = key_v4();
+    let now = 1_000_000_000u64;
+    // W_new holds a materialized synced replica (WorkerLocalImport).
+    assert!(table.install_with_protocol_with_origin(
+        key.clone(),
+        decision(),
+        metadata(),
+        SessionOrigin::WorkerLocalImport,
+        now,
+        PROTO_TCP,
+        0x10,
+    ));
+    // WorkerLocalImport install emits no delta (peer-synced replica).
+    assert!(table.drain_deltas(8).is_empty());
+
+    let promoted = table.promote_rebalanced_owner(&key, now + 5_000_000);
+    assert!(promoted, "promote returns true for a present key");
+    // No delta whatsoever — NOT an Open (update_session would have emitted one).
+    assert!(
+        table.drain_deltas(8).is_empty(),
+        "promote_rebalanced_owner must push NO delta"
+    );
+    // Origin is now the local owner RebalancedOwner, which is NOT peer-synced.
+    assert_eq!(table.origin_of(&key), Some(SessionOrigin::RebalancedOwner));
+    assert!(!SessionOrigin::RebalancedOwner.is_peer_synced());
+    // decision + metadata are untouched by the tag flip.
+    let lookup = table.lookup(&key, now + 6_000_000, 0x10).expect("session present");
+    assert_eq!(lookup.decision, decision());
+    assert_eq!(lookup.metadata, metadata());
+}
+
+/// Second-move chain: a flow that was rebalanced once (RebalancedOwner on
+/// W_new) is moved AGAIN to a third worker. The controller treats the current
+/// local owner generically, so a second promote on the third worker's replica
+/// keeps ownership correct (origin stays a local owner, never reverts to a
+/// peer-synced import). Models ForwardFlow -> RebalancedOwner ->
+/// RebalancedOwner(third).
+#[test]
+fn second_move_chain_keeps_local_ownership() {
+    let mut table = SessionTable::new();
+    let key = key_v4();
+    let now = 1_000_000_000u64;
+    // Original owner: a plain local ForwardFlow.
+    assert!(table.install_with_protocol_with_origin(
+        key.clone(),
+        decision(),
+        metadata(),
+        SessionOrigin::ForwardFlow,
+        now,
+        PROTO_TCP,
+        0x10,
+    ));
+    let _ = table.drain_deltas(8);
+    // First move: promote to RebalancedOwner.
+    assert!(table.promote_rebalanced_owner(&key, now + 1_000_000));
+    assert_eq!(table.origin_of(&key), Some(SessionOrigin::RebalancedOwner));
+    // Second move: promote again (the third worker's replica). Still a local
+    // owner; never peer-synced.
+    assert!(table.promote_rebalanced_owner(&key, now + 2_000_000));
+    assert_eq!(table.origin_of(&key), Some(SessionOrigin::RebalancedOwner));
+    assert!(!table.origin_of(&key).unwrap().is_peer_synced());
+    assert!(
+        table.drain_deltas(8).is_empty(),
+        "neither promote emits a delta"
+    );
+}
+
+/// A RebalancedOut entry (the abandoned W_old copy) must emit NO Close delta on
+/// its local-only GC expiry — that delta would cascade-delete the live flow
+/// W_new owns. The forward expiry path is the shared-state release site; this
+/// pins the Close-delta suppression at session/mod.rs.
+#[test]
+fn rebalanced_out_expiry_emits_no_close_delta() {
+    let mut table = SessionTable::new();
+    let key = key_v4();
+    let then = 1_000_000_000u64;
+    assert!(table.install_with_protocol_with_origin(
+        key.clone(),
+        decision(),
+        metadata(),
+        SessionOrigin::ForwardFlow,
+        then,
+        PROTO_TCP,
+        0x10,
+    ));
+    let _ = table.drain_deltas(8);
+    // Demote to RebalancedOut (the W_old abandoned copy).
+    assert!(table.demote_rebalanced_out(&key));
+    assert_eq!(table.origin_of(&key), Some(SessionOrigin::RebalancedOut));
+    // Age it out.
+    table.last_gc_ns = then + 301_000_000_000;
+    let expired = table.expire_stale_entries(then + 302_000_000_000);
+    assert_eq!(expired.len(), 1, "the abandoned copy does age out locally");
+    assert_eq!(expired[0].key, key);
+    assert_eq!(expired[0].origin, SessionOrigin::RebalancedOut);
+    // CRITICAL: no Close delta — W_new owns the shared cleanup.
+    assert!(
+        table.drain_deltas(8).is_empty(),
+        "RebalancedOut expiry must NOT push a Close delta"
+    );
+}
+
+/// A real RebalancedOwner expiry (W_new, the true owner) DOES emit a Close
+/// delta — exactly one worker owns end-of-flow cleanup. The counter-factual to
+/// the suppression test above: ownership is preserved, not lost.
+#[test]
+fn rebalanced_owner_expiry_emits_close_delta() {
+    let mut table = SessionTable::new();
+    let key = key_v4();
+    let then = 1_000_000_000u64;
+    assert!(table.install_with_protocol_with_origin(
+        key.clone(),
+        decision(),
+        metadata(),
+        SessionOrigin::WorkerLocalImport,
+        then,
+        PROTO_TCP,
+        0x10,
+    ));
+    let _ = table.drain_deltas(8);
+    assert!(table.promote_rebalanced_owner(&key, then));
+    table.last_gc_ns = then + 301_000_000_000;
+    let expired = table.expire_stale_entries(then + 302_000_000_000);
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].origin, SessionOrigin::RebalancedOwner);
+    let deltas = table.drain_deltas(8);
+    assert_eq!(deltas.len(), 1, "the real owner emits Close on expiry");
+    assert_eq!(deltas[0].kind, SessionDeltaKind::Close);
+}
+
+/// demote_owner_rg must NOT rewrite a RebalancedOut entry to SyncImport (that
+/// would re-enable the shared cleanup W_new owns). It DOES demote a
+/// RebalancedOwner like a normal local owner (RebalancedOwner is not
+/// peer-synced) so HA failover still works.
+#[test]
+fn demote_owner_rg_excludes_rebalanced_out_but_demotes_owner() {
+    let mut table = SessionTable::new();
+    let now = 1_000_000_000u64;
+
+    // RebalancedOut entry on owner RG 1.
+    let out_key = key_v4();
+    assert!(table.install_with_protocol_with_origin(
+        out_key.clone(),
+        decision(),
+        metadata(),
+        SessionOrigin::ForwardFlow,
+        now,
+        PROTO_TCP,
+        0x10,
+    ));
+    assert!(table.demote_rebalanced_out(&out_key));
+
+    // RebalancedOwner entry on owner RG 1.
+    let owner_key = key_v6();
+    let mut owner_md = metadata();
+    owner_md.owner_rg_id = 1;
+    assert!(table.install_with_protocol_with_origin(
+        owner_key.clone(),
+        decision(),
+        owner_md,
+        SessionOrigin::WorkerLocalImport,
+        now,
+        PROTO_UDP,
+        0x00,
+    ));
+    assert!(table.promote_rebalanced_owner(&owner_key, now));
+
+    table.demote_owner_rg(1);
+
+    // RebalancedOut stays inert.
+    assert_eq!(table.origin_of(&out_key), Some(SessionOrigin::RebalancedOut));
+    // RebalancedOwner demotes to SyncImport like ForwardFlow.
+    assert_eq!(table.origin_of(&owner_key), Some(SessionOrigin::SyncImport));
+}
+
+/// restore_rebalanced_owner (reverse-barrier step) flips a RebalancedOut entry
+/// back to a local owner + refreshes liveness; demote_rebalanced_replica flips
+/// a RebalancedOwner back to a worker-local replica. Together they implement
+/// the reverse barrier that always leaves >= 1 cleanup owner.
+#[test]
+fn reverse_barrier_mutators_round_trip() {
+    let mut table = SessionTable::new();
+    let key = key_v4();
+    let now = 1_000_000_000u64;
+    assert!(table.install_with_protocol_with_origin(
+        key.clone(),
+        decision(),
+        metadata(),
+        SessionOrigin::ForwardFlow,
+        now,
+        PROTO_TCP,
+        0x10,
+    ));
+    let _ = table.drain_deltas(8);
+    assert!(table.demote_rebalanced_out(&key));
+    assert_eq!(table.origin_of(&key), Some(SessionOrigin::RebalancedOut));
+    // Reverse-barrier restore: back to a local owner.
+    assert!(table.restore_rebalanced_owner(&key, now + 1_000_000));
+    assert_eq!(table.origin_of(&key), Some(SessionOrigin::ForwardFlow));
+    // Replica demotion: a RebalancedOwner becomes WorkerLocalImport.
+    assert!(table.promote_rebalanced_owner(&key, now + 2_000_000));
+    assert_eq!(table.origin_of(&key), Some(SessionOrigin::RebalancedOwner));
+    assert!(table.demote_rebalanced_replica(&key));
+    assert_eq!(table.origin_of(&key), Some(SessionOrigin::WorkerLocalImport));
+    // None of these mutators emit deltas.
+    assert!(table.drain_deltas(8).is_empty());
+}

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -714,6 +714,7 @@
     "fabrics": [],
     "filter_term_counters": [],
     "flow_cache_capacity": 0,
+    "flow_rebalance": [],
     "flow_worker_map": [],
     "flow_worker_map_truncated": false,
     "forwarding_armed": false,


### PR DESCRIPTION
## Summary
Reactive cross-worker per-flow fairness via mlx5 ntuple HW re-pin, in the Rust `userspace-dp`. When a worker's byte-rate is over-loaded, the controller moves the heaviest flow's forward 5-tuple to an idle RX queue via a direct `SIOCETHTOOL`/`ethtool_rxnfc` ioctl. **Default-OFF, opt-in, forward-direction.** This is the only lever that lifts slow flows (vs the #1746 cap which only clips fast ones) — R1 spike measured per-flow CoV **16.8% → 2.3–4.2% with aggregate preserved**.

Closes #1748.

## Plan + adversarial review (6 hostile rounds)
Plan: `docs/pr/1748-ntuple-rebalance/plan.md` (PLAN-READY v7). The review converted the research's "no migration code" premise into a fully-specified **session-ownership-transfer protocol**, catching 6 verified session-corruption bugs (GC cascade kill, never-cleanup leak, zero-owner race, near-expiry TTL race, unbarriered teardown, terminal-path leaks). Reviewer ledger: `docs/pr/1748-ntuple-rebalance/reviewer-ids.md`.

## Design
- Two `SessionOrigin` variants: `RebalancedOut` (abandoned W_old — suppresses **every** shared-state release/delete: Close delta, redirect+conntrack delete, SNAT release on GC+purge, `DeleteSynced`, demote/refresh/export, terminal-filter) and `RebalancedOwner` (promoted W_new — the single end-of-flow cleanup owner).
- Applied-command **barriers** on every rule transition (install = forward; rollback + live-teardown = reverse), with structured `{seq,key,origin,result}` ack. Promote is a liveness-refreshing origin-only tag-flip (no delta/publish/NAT).
- `ethtool_rxnfc` ioctl with compile-time UAPI offset asserts (corrected `TCP_V4_FLOW=0x01`, `rule_locs@188` against the kernel header); byte-rate-aware selection (`≤gap/2`, cooldown, ε-band, budget STOP no-eviction).

## Test plan
- [x] cargo build clean (UAPI const-asserts hold)
- [x] cargo test --release: **1797 passed / 0 failed**; 23 rebalance/UAPI/suppression tests incl. barrier-order, both reverse-barrier rollbacks, magnitude guard, live-teardown reverse barrier, UAPI offset+round-trip, promote-side-effect-free, RebalancedOut/Owner expiry delta correctness, terminal-filter shared-state preservation
- [x] 5× flake-loop of 5 key controller tests — 5/5
- [x] go test ./... — pass (TMPDIR=/tmp)
- [ ] **Pass A/B smoke matrix** (v4+v6 × push+reverse × CoS-off/on) — parent runs on loss cluster
- [ ] **Live CoV gate** — enable knob, `-P12 -p5210`, confirm controller drives CoV ≤10% w/ aggregate preserved + bounded retransmits; default-OFF control unchanged
- [ ] **`make test-failover`** — MANDATORY (HA-critical session-state)

## Out of scope (plan §9)
R2 reverse-direction rules, R4 peer rule-mirroring (post-failover resets to RSS — documented), R5 full eviction policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)