### PR TITLE
#1752 Path E: in-place session refresh (eliminate per-packet remove+restore churn)

### DIFF
--- a/docs/pr/1752-session-inplace-refresh/plan.md
+++ b/docs/pr/1752-session-inplace-refresh/plan.md
@@ -1,6 +1,6 @@
 # #1752 Path E — session refresh in-place mutation
 
-**Status: v2 — folds Codex r1 (PLAN-NEEDS-MAJOR) + Gemini r1 (PLAN-NEEDS-MINOR). Re-dispatched.**
+**Status: v3 — folds Codex r2 (PLAN-NEEDS-MAJOR, reject-path re-assert) + Gemini r2 (PLAN-READY). Re-dispatched for r3.**
 
 v2 changes: (a) secondary-index **adds are always re-asserted** (matches today's
 unconditional `index_forward_nat_key` insert exactly, incl. the
@@ -95,15 +95,22 @@ pub fn update_session(&mut self, req: SessionUpdate<'_>, ha_activation: bool) ->
     let old_owner_rg = record.entry.metadata.owner_rg_id;
     // (immutable borrow of `record` ends here)
 
-    // Collision rules — IDENTICAL to current semantics; reject is now a pure
-    // early return (today's reject does remove_entry then restore_entry then
-    // returns false → net-state-neutral, confirmed by both reviewers).
+    // Collision rules — IDENTICAL to current semantics. NOTE (Codex r2): today's
+    // reject path does remove_entry THEN restore_entry THEN returns false, and
+    // restore_entry's unconditional index_forward_nat_key RE-ASSERTS this entry's
+    // own secondary ADDS even on reject. To stay byte-identical, the reject
+    // branches must re-assert too (parts-based, zero-clone) before returning.
     if !ha_activation {
         let new_peer = origin.is_peer_synced();
-        if old_origin.is_peer_synced() && !new_peer { /* promote: allow */ }
-        else if old_origin.is_peer_synced() && new_peer { return false; }
-        else if !old_origin.is_peer_synced() && new_peer { return false; }
-        // both local: allow
+        let reject = (old_origin.is_peer_synced() && new_peer)      // peer→peer
+                  || (!old_origin.is_peer_synced() && new_peer);     // local←peer
+        if reject {
+            // Re-assert OLD secondary ADDS (entry unchanged), then bail — matches
+            // restore_entry's re-assert on the current reject path exactly.
+            self.index_forward_nat_key_parts(key, handle, old_nat, old_is_reverse, old_owner_rg);
+            return false;
+        }
+        // else: peer→local promote, or local→local refresh: fall through to accept.
     }
 
     // Reindex predicate — complete per §2 (key + handle invariant). Gates only
@@ -176,13 +183,15 @@ No public signature changes. `update_session`, `refresh_local`,
    peer→peer reject; local←peer reject; local→local refresh) must behave
    identically. In-place makes reject a no-op early return — observably
    identical to remove+restore-then-return-false (net state unchanged).
-2. **Index semantics (v2)**: secondary ADDS are always re-asserted (parity with
-   today's unconditional `index_forward_nat_key`), so the unconditional-insert /
-   value-guarded-remove collision behavior is preserved exactly even if two live
-   sessions transiently derive the same secondary key. The `reindex` predicate
-   gates only the value-guarded REMOVES of the OLD keys; it is complete per §2
-   (indices depend only on key+nat+is_reverse+owner_rg; key & handle invariant).
-   **This is the #1 review target.**
+2. **Index semantics (v3)**: secondary ADDS are always re-asserted (parity with
+   today's unconditional `index_forward_nat_key` in `restore_entry`) on BOTH the
+   accept path AND the reject path (Codex r2: today's reject = remove+restore+
+   false, and restore re-asserts). A new private `index_forward_nat_key_parts(key,
+   handle, nat, is_reverse, owner_rg)` re-asserts from Copy parts (zero clone) on
+   the reject path; the accept path uses the full `index_forward_nat_key` with the
+   new metadata in hand. The `reindex` predicate gates only the value-guarded
+   REMOVES of the OLD keys; it is complete per §2 (indices depend only on
+   key+nat+is_reverse+owner_rg; key & handle invariant). **#1 review target.**
 2b. **Stale-handle / primary-key guard**: `entries.get(handle)` + `record.key ==
    *key` before any mutation; mismatch → return false (no-op), matching
    `remove_entry`'s release-mode guards. Never `entries[handle]` (panic/corrupt).
@@ -222,6 +231,9 @@ No public signature changes. `update_session`, `refresh_local`,
   - **secondary-index collision** (Codex Major #1): two live sessions whose
     derived secondary key collides — refresh one, assert the in-place table
     matches the reference (the re-assert re-wins identically);
+  - **reject-path collision re-assert** (Codex r2): a displaced-collision session
+    hit with a REJECTED update (peer→peer AND local←peer) must re-win its
+    secondary key identically to today's remove+restore-then-false;
   - **stale/wrong-key guard**: stale `key_to_handle` → vacant slot, and reused
     slot holding a different `record.key` → both return false, no mutation;
   - `refresh_for_ha_transition` liveness parity;
@@ -260,7 +272,10 @@ proof. Q2 reject-early-return net-neutral — confirmed by both. Q3 borrow/zero-
 hot path — confirmed feasible. Q4 owner_rg transition — works via reindex branch;
 added owner_rg `0↔>0`/`>0→>0'` + ha_transition tests. Q5 wheel_tick parity —
 confirmed. Q6 differential sufficiency — added collision + stale-handle +
-randomized property tests (Codex wanted them; cheap insurance). Remaining for r2:
+randomized property tests (Codex wanted them; cheap insurance). **r2 resolution (v3):** Gemini r2 PLAN-READY. Codex r2 NEEDS-MAJOR — accepted-
+path re-assert was correct but the REJECT branches returned before re-asserting,
+diverging from today's restore-on-reject. v3 re-asserts on reject via
+`index_forward_nat_key_parts` and adds reject-path collision tests. Remaining:
 
 1. Is the reindex predicate (`old_nat != nat || old_is_reverse != is_reverse ||
    old_owner_rg != owner_rg`) provably complete, or is there an index whose key

--- a/docs/pr/1752-session-inplace-refresh/plan.md
+++ b/docs/pr/1752-session-inplace-refresh/plan.md
@@ -1,0 +1,221 @@
+# #1752 Path E — session refresh in-place mutation
+
+**Status: DRAFT v1 — pending adversarial plan review (Codex + Gemini)**
+
+Implements Path E from the converged research plan
+(`docs/research/1752-cpu-headroom/plan.md`, PLAN-READY @ 0fdda93f0): eliminate
+the per-packet `remove_entry`+`restore_entry` index teardown/rebuild in
+`SessionTable::update_session` (the established-flow refresh path), replacing it
+with in-place `get_mut` slab mutation that touches secondary indices only when a
+key-relevant input actually changes.
+
+## 1. Issue framing
+
+`update_session` (session/mod.rs:803) is the unified refresh path
+(`refresh_local`, `promote_synced_with_origin`, `refresh_for_ha_activation` all
+route through it). For **every packet of an established flow** it currently:
+`remove_entry(key)` → mutate ~7 fields → `restore_entry(key, entry)`. That tears
+down and rebuilds the full index set (`key_to_handle` map remove+insert, slab
+remove+insert with a *new* handle, `nat_reverse_index`/`forward_wire_index`/
+`reverse_translated_index`/`owner_rg_sessions` value-guarded remove+re-add) plus
+~3 `SessionMetadata` clones — just to bump `last_seen_ns`/`expires_after_ns`.
+
+Live `-P48 5210` flat profile (#1752): `remove_entry` 2.73% + slab `insert`
+1.72% self ≈ **~4.5% of total CPU**, all of it index churn on flows whose
+key/NAT-mapping/owner-RG never change.
+
+## 2. Why in-place is correct (the index-input invariant)
+
+The four secondary indices are derived **only** from
+`(key, decision.nat, metadata.is_reverse, metadata.owner_rg_id)`:
+- `index_forward_nat_key` (:1204) and `remove_forward_nat_index` (:1240) compute
+  their keys from `key` + `decision.nat` (via `translated_session_key`,
+  `reverse_wire_key`, `reverse_canonical_key`, `forward_wire_key`), branch on
+  `metadata.is_reverse`, and add to `owner_rg_sessions` iff
+  `metadata.owner_rg_id > 0`.
+- `key_to_handle` is keyed on `key`.
+
+In `update_session` **`key` is invariant** (it is the lookup key) and, with
+in-place mutation, **the slab handle is invariant** (no insert → no new handle).
+Therefore the index entries are unchanged **unless** `decision.nat`,
+`metadata.is_reverse`, or `metadata.owner_rg_id` differs between the stored entry
+and the incoming update. On the steady-state refresh path all three are
+identical → **zero index operations**.
+
+## 3. Honest scope/value framing
+
+Target ~4.5% CPU on the saturated 6/6 cluster — directly recoverable, isolated
+to one function, no architectural premise. Secondary win: removes ~3
+`SessionMetadata` clones per refresh and the per-call `no_index_points_at` debug
+scan. *If reviewers conclude the perf gain is too small to justify the churn, or
+that the in-place reindex predicate cannot be made provably complete, PLAN-KILL
+is an acceptable verdict.*
+
+## 4. What's already shipped
+
+#964 Step 1 introduced the slab + `key_to_handle` + handle-valued secondary
+indices and the `remove_entry`/`restore_entry` pair (kept "for API compatibility
+with the prior FxHashMap shape" — restore_entry doc comment). This plan replaces
+the remove+restore *inside refresh paths only*; install/synced-upsert/GC paths
+keep remove_entry (they legitimately change identity or remove).
+
+## 5. Concrete design
+
+New private helper `refresh_in_place` + rewrite `update_session` to use it.
+
+```
+pub fn update_session(&mut self, req: SessionUpdate<'_>, ha_activation: bool) -> bool {
+    let SessionUpdate { key, decision, metadata, origin, now_ns, protocol, tcp_flags } = req;
+    let Some(&handle) = self.key_to_handle.get(key) else { return false };
+
+    // Snapshot the index-relevant + collision-relevant OLD state (all Copy
+    // except we avoid cloning metadata on the hot path).
+    let (old_origin, old_nat, old_is_reverse, old_owner_rg) = {
+        let r = &self.entries[handle as usize];
+        (r.entry.origin, r.entry.decision.nat, r.entry.metadata.is_reverse,
+         r.entry.metadata.owner_rg_id)
+    };
+
+    // Collision rules — IDENTICAL to current semantics, but reject is now a
+    // pure early return (no remove+restore round-trip).
+    if !ha_activation {
+        let new_peer = origin.is_peer_synced();
+        if old_origin.is_peer_synced() && !new_peer { /* promote: allow */ }
+        else if old_origin.is_peer_synced() && new_peer { return false; }
+        else if !old_origin.is_peer_synced() && new_peer { return false; }
+        // both local: allow
+    }
+
+    // Reindex predicate — complete per §2 (key + handle invariant).
+    let reindex = old_nat != decision.nat
+        || old_is_reverse != metadata.is_reverse
+        || old_owner_rg != metadata.owner_rg_id;
+
+    if reindex {
+        // Tear down OLD secondary indices (value-guarded; key + handle same).
+        // Need an old-metadata shim carrying is_reverse + owner_rg_id; build a
+        // minimal one or pass fields. (impl detail: small owned snapshot.)
+        self.remove_forward_nat_index(key, handle, old_decision, &old_md_shim);
+        remove_owner_rg_index_entry(&mut self.owner_rg_sessions, old_owner_rg, handle);
+    }
+
+    let epoch = self.next_epoch();
+    {
+        let r = &mut self.entries[handle as usize];   // get_mut, scoped
+        r.entry.decision = decision;
+        r.entry.metadata = metadata.clone();           // single clone (parity)
+        r.entry.origin = origin;
+        r.entry.install_epoch = epoch;
+        r.entry.last_seen_ns = now_ns;
+        r.entry.expires_after_ns = session_timeout_ns(protocol, tcp_flags, &self.timeouts);
+        r.entry.closing = matches!(protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN|TCP_RST)) != 0;
+    }
+    if reindex {
+        self.index_forward_nat_key(key, handle, decision, &metadata);
+    }
+
+    self.push_to_wheel(key, now_ns);
+    if old_origin.is_peer_synced() && !origin.is_peer_synced() && !metadata.is_reverse {
+        self.push_delta(SessionDelta { kind: Open, key: key.clone(), decision, metadata, origin, fabric_redirect_sync: false });
+    }
+    true
+}
+```
+
+Borrow shape: `next_epoch`/`remove_*`/`index_*`/`push_*` all take `&mut self`;
+the `get_mut` borrow is scoped to the field-write block so it never overlaps
+them. The old-decision/old-metadata snapshot for the reindex-teardown is taken
+*before* the field write (impl: capture `old_decision` = `r.entry.decision` and
+an owned `SessionMetadata` shim with old `is_reverse`/`owner_rg_id` in the
+snapshot block; only built when `reindex` is true to keep the hot path
+clone-free).
+
+`refresh_for_ha_transition` (:918) gets the same treatment (it also removes +
+restores, no collision rules, never changes nat/owner_rg in practice but apply
+the same reindex predicate for safety).
+
+## 6. Public API preservation
+
+No public signature changes. `update_session`, `refresh_local`,
+`refresh_for_ha_activation`, `refresh_for_ha_transition`,
+`promote_synced_with_origin` keep identical signatures + return semantics.
+`remove_entry`/`restore_entry` stay (still used by install/upsert/GC/lookup).
+
+## 7. Hidden invariants the change must preserve
+
+1. **Collision semantics**: the 4 branches (ha_activation; peer→local promote;
+   peer→peer reject; local←peer reject; local→local refresh) must behave
+   identically. In-place makes reject a no-op early return — observably
+   identical to remove+restore-then-return-false (net state unchanged).
+2. **Index completeness**: reindex predicate must catch every case where a
+   secondary-index key changes. Proven by §2 (indices depend only on key+nat+
+   is_reverse+owner_rg; key & handle invariant). **This is the #1 review target.**
+3. **Wheel**: `push_to_wheel(key, now_ns)` unchanged; entry's `wheel_tick`
+   field is preserved across in-place mutation (we do NOT reset it to 0, unlike
+   install which sets wheel_tick:0). Current remove+restore preserves wheel_tick
+   too (restore_entry keeps the passed entry's wheel_tick). Parity holds.
+4. **Open-delta emission**: identical condition (was_peer_synced &&
+   !new_peer && !is_reverse).
+5. **install_epoch** bumped via next_epoch() — identical.
+6. **No stale handle**: handle stays valid (never freed); on reject we never
+   touched it.
+7. **HA paths**: refresh_for_ha_activation/transition go through the same code;
+   owner_rg reindex on a genuine owner_rg change (RG failover re-resolve) must
+   still move the handle between owner_rg sets — covered by the reindex branch.
+
+## 8. Risk assessment
+
+| Class | Level | Note |
+|---|---|---|
+| Behavioral regression | MED | collision + reindex semantics must match exactly; differential test gates it |
+| Lifetime / borrow-checker | LOW-MED | get_mut borrow scoped away from &mut self index calls; snapshot-before-mutate |
+| Performance regression | LOW | strictly fewer ops; worst case (reindex every time) equals today |
+| Architectural mismatch | LOW | localized to refresh paths; install/GC unchanged |
+
+## 9. Test plan
+
+- `cargo build` + full `cargo test --release` (1763+ lib tests) clean.
+- **Differential test (new, the gate)**: for each branch (local refresh, peer→
+  local promote, peer→peer reject, local←peer reject, ha_activation, nat change,
+  owner_rg change, is_reverse entry), assert the in-place result is
+  byte-identical (entry fields + all four index maps + key_to_handle + deltas) to
+  the old remove+restore implementation. Implement by keeping a reference
+  remove+restore helper in the test module and comparing table snapshots.
+- 5×flake on the differential test + the heaviest existing session test.
+- Go suite (30 pkgs).
+- Smoke matrix on loss userspace cluster: Pass A (CoS off) v4+v6 push+`-R` +
+  `-P12 -R` line-rate; Pass B per-class 5201-5206 v4+v6 push+`-R`.
+- Perf re-profile `-P48 5210`: confirm `remove_entry`/slab `insert` self-time
+  drops and aggregate Gb/s rises (CoS-off and CoS-on).
+- `make test-failover` (touches session-sync/HA refresh paths — required by
+  CLAUDE.md for any HA-adjacent change).
+
+## 10. Out of scope
+
+- Path A (CoS hot-path reduction), Path B (crypto DEK trace), Path C/D — separate.
+- `install_with_protocol_with_origin` / `upsert_synced_with_origin` keep
+  remove_entry (they change identity / may replace a different session; in-place
+  there is a measurable but smaller win — deferred, noted as a follow-up).
+- GC / `lookup_and_remove` / terminal paths — unchanged.
+
+## 11. Open questions for adversarial review
+
+1. Is the reindex predicate (`old_nat != nat || old_is_reverse != is_reverse ||
+   old_owner_rg != owner_rg`) provably complete, or is there an index whose key
+   depends on a field not in that set? (Walk `index_forward_nat_key` +
+   `remove_forward_nat_index` + the `*_key` helpers and try to break it.)
+2. Does making "reject" a pure early return (vs remove+restore-then-false) change
+   any observable state or side effect? (e.g. does today's reject path mutate
+   wheel/epoch/deltas? It does not — restore_entry re-adds verbatim and returns
+   false. Confirm.)
+3. Borrow-checker: can the old-metadata teardown snapshot + the scoped get_mut +
+   the &mut self index calls coexist without a clone on the no-reindex hot path?
+4. HA owner_rg transition: when `refresh_for_ha_activation` re-resolves a session
+   whose owner_rg_id changed, does the reindex branch correctly move the handle
+   between `owner_rg_sessions` sets (remove old set entry, add new)? 
+5. `wheel_tick` preservation: in-place keeps the existing `wheel_tick`; is there
+   any path where remove+restore's behavior (also preserves it) differs such
+   that parity breaks?
+6. Is the differential-test strategy (reference remove+restore impl in tests +
+   full table-snapshot compare) sufficient to catch a divergence, or is a
+   property/fuzz test over random update sequences needed?

--- a/docs/pr/1752-session-inplace-refresh/plan.md
+++ b/docs/pr/1752-session-inplace-refresh/plan.md
@@ -1,6 +1,15 @@
 # #1752 Path E — session refresh in-place mutation
 
-**Status: DRAFT v1 — pending adversarial plan review (Codex + Gemini)**
+**Status: v2 — folds Codex r1 (PLAN-NEEDS-MAJOR) + Gemini r1 (PLAN-NEEDS-MINOR). Re-dispatched.**
+
+v2 changes: (a) secondary-index **adds are always re-asserted** (matches today's
+unconditional `index_forward_nat_key` insert exactly, incl. the
+collision-displacement re-win case Codex flagged) — only the value-guarded
+*removes* are gated on `reindex`; (b) restore the stale-handle + primary-key
+guard (`entries.get` + `record.key == *key`, return false) that v1's pseudocode
+dropped; (c) private index helpers take `NatDecision`/`is_reverse`/owner fields
+directly (no metadata shim); (d) expanded differential + collision + randomized
+test plan; (e) honest value revised to ~3–3.5% (re-assert retained).
 
 Implements Path E from the converged research plan
 (`docs/research/1752-cpu-headroom/plan.md`, PLAN-READY @ 0fdda93f0): eliminate
@@ -44,12 +53,17 @@ identical → **zero index operations**.
 
 ## 3. Honest scope/value framing
 
-Target ~4.5% CPU on the saturated 6/6 cluster — directly recoverable, isolated
-to one function, no architectural premise. Secondary win: removes ~3
-`SessionMetadata` clones per refresh and the per-call `no_index_points_at` debug
-scan. *If reviewers conclude the perf gain is too small to justify the churn, or
-that the in-place reindex predicate cannot be made provably complete, PLAN-KILL
-is an acceptable verdict.*
+Target **~3–3.5% CPU** on the saturated 6/6 cluster (revised down from a naive
+~4.5%: v2 retains the 4 secondary-index re-assert inserts for exact-parity, so
+the win is the eliminated slab remove+insert (the measured 1.72% `insert` + the
+slab part of `remove_entry`'s 2.73%), the `key_to_handle` remove+insert, 2 of 3
+`SessionMetadata` clones, the value-guarded *removes* on the hot path, and the
+`no_index_points_at` debug scan). Isolated to one function, no architectural
+premise. *If reviewers conclude the perf gain is too small to justify the churn,
+or that the in-place change cannot preserve secondary-index semantics exactly,
+PLAN-KILL is an acceptable verdict.* (Full skip of the re-assert inserts — the
+remaining ~1% — is an explicit out-of-scope follow-up gated on a proven
+secondary-key uniqueness invariant + property test; see §10/§11.)
 
 ## 4. What's already shipped
 
@@ -68,16 +82,22 @@ pub fn update_session(&mut self, req: SessionUpdate<'_>, ha_activation: bool) ->
     let SessionUpdate { key, decision, metadata, origin, now_ns, protocol, tcp_flags } = req;
     let Some(&handle) = self.key_to_handle.get(key) else { return false };
 
-    // Snapshot the index-relevant + collision-relevant OLD state (all Copy
-    // except we avoid cloning metadata on the hot path).
-    let (old_origin, old_nat, old_is_reverse, old_owner_rg) = {
-        let r = &self.entries[handle as usize];
-        (r.entry.origin, r.entry.decision.nat, r.entry.metadata.is_reverse,
-         r.entry.metadata.owner_rg_id)
-    };
+    // STALE-HANDLE + PRIMARY-KEY GUARD (parity with remove_entry:1127/1144 and
+    // record_by_key_mut:314): never index the slab raw — a stale key_to_handle
+    // could point at a vacant or reused slot.
+    let Some(record) = self.entries.get(handle as usize) else { return false };
+    if record.key != *key { return false; }
 
-    // Collision rules — IDENTICAL to current semantics, but reject is now a
-    // pure early return (no remove+restore round-trip).
+    // Snapshot OLD index-relevant + collision-relevant state (all Copy).
+    let old_origin = record.entry.origin;
+    let old_nat = record.entry.decision.nat;
+    let old_is_reverse = record.entry.metadata.is_reverse;
+    let old_owner_rg = record.entry.metadata.owner_rg_id;
+    // (immutable borrow of `record` ends here)
+
+    // Collision rules — IDENTICAL to current semantics; reject is now a pure
+    // early return (today's reject does remove_entry then restore_entry then
+    // returns false → net-state-neutral, confirmed by both reviewers).
     if !ha_activation {
         let new_peer = origin.is_peer_synced();
         if old_origin.is_peer_synced() && !new_peer { /* promote: allow */ }
@@ -86,22 +106,22 @@ pub fn update_session(&mut self, req: SessionUpdate<'_>, ha_activation: bool) ->
         // both local: allow
     }
 
-    // Reindex predicate — complete per §2 (key + handle invariant).
+    // Reindex predicate — complete per §2 (key + handle invariant). Gates only
+    // the value-guarded REMOVES of the OLD secondary keys.
     let reindex = old_nat != decision.nat
         || old_is_reverse != metadata.is_reverse
         || old_owner_rg != metadata.owner_rg_id;
 
     if reindex {
-        // Tear down OLD secondary indices (value-guarded; key + handle same).
-        // Need an old-metadata shim carrying is_reverse + owner_rg_id; build a
-        // minimal one or pass fields. (impl detail: small owned snapshot.)
-        self.remove_forward_nat_index(key, handle, old_decision, &old_md_shim);
+        // Tear down OLD secondary keys. Helpers take the OLD nat/is_reverse/
+        // owner fields directly (no metadata shim, no clone).
+        self.remove_forward_nat_index_parts(key, handle, old_nat, old_is_reverse);
         remove_owner_rg_index_entry(&mut self.owner_rg_sessions, old_owner_rg, handle);
     }
 
     let epoch = self.next_epoch();
     {
-        let r = &mut self.entries[handle as usize];   // get_mut, scoped
+        let r = self.entries.get_mut(handle as usize).expect("handle validated above");
         r.entry.decision = decision;
         r.entry.metadata = metadata.clone();           // single clone (parity)
         r.entry.origin = origin;
@@ -109,10 +129,17 @@ pub fn update_session(&mut self, req: SessionUpdate<'_>, ha_activation: bool) ->
         r.entry.last_seen_ns = now_ns;
         r.entry.expires_after_ns = session_timeout_ns(protocol, tcp_flags, &self.timeouts);
         r.entry.closing = matches!(protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN|TCP_RST)) != 0;
+        // entry.wheel_tick deliberately preserved (parity with restore_entry).
     }
-    if reindex {
-        self.index_forward_nat_key(key, handle, decision, &metadata);
-    }
+
+    // ALWAYS re-assert the secondary ADDS — byte-identical to today's
+    // unconditional index_forward_nat_key insert in restore_entry. For the
+    // no-reindex case the keys are unchanged so this re-inserts key→same handle
+    // (idempotent when unique; re-wins when a collision displaced us — exactly
+    // today's behavior). For the reindex case it installs the NEW keys after the
+    // removes above. This is what preserves the unconditional-insert /
+    // value-guarded-remove collision semantics Codex flagged.
+    self.index_forward_nat_key(key, handle, decision, &metadata);
 
     self.push_to_wheel(key, now_ns);
     if old_origin.is_peer_synced() && !origin.is_peer_synced() && !metadata.is_reverse {
@@ -122,13 +149,15 @@ pub fn update_session(&mut self, req: SessionUpdate<'_>, ha_activation: bool) ->
 }
 ```
 
-Borrow shape: `next_epoch`/`remove_*`/`index_*`/`push_*` all take `&mut self`;
-the `get_mut` borrow is scoped to the field-write block so it never overlaps
-them. The old-decision/old-metadata snapshot for the reindex-teardown is taken
-*before* the field write (impl: capture `old_decision` = `r.entry.decision` and
-an owned `SessionMetadata` shim with old `is_reverse`/`owner_rg_id` in the
-snapshot block; only built when `reindex` is true to keep the hot path
-clone-free).
+Borrow shape (confirmed feasible by both reviewers): the immutable `get`
+snapshot drops before any `&mut self` call; `next_epoch`/`remove_*`/`index_*`/
+`push_*` take `&mut self`; the `get_mut` borrow is scoped to the field-write
+block. Zero clones on the hot path beyond the single mandatory
+`metadata.clone()` into the entry. **Impl note:** add a private
+`remove_forward_nat_index_parts(key, handle, nat, is_reverse)` (the existing
+`remove_forward_nat_index` re-derived these from a `&SessionMetadata`; the new
+variant takes the parts so the reindex teardown needs no old-metadata shim).
+`refresh_for_ha_transition` (:918) gets the identical treatment.
 
 `refresh_for_ha_transition` (:918) gets the same treatment (it also removes +
 restores, no collision rules, never changes nat/owner_rg in practice but apply
@@ -147,9 +176,16 @@ No public signature changes. `update_session`, `refresh_local`,
    peer→peer reject; local←peer reject; local→local refresh) must behave
    identically. In-place makes reject a no-op early return — observably
    identical to remove+restore-then-return-false (net state unchanged).
-2. **Index completeness**: reindex predicate must catch every case where a
-   secondary-index key changes. Proven by §2 (indices depend only on key+nat+
-   is_reverse+owner_rg; key & handle invariant). **This is the #1 review target.**
+2. **Index semantics (v2)**: secondary ADDS are always re-asserted (parity with
+   today's unconditional `index_forward_nat_key`), so the unconditional-insert /
+   value-guarded-remove collision behavior is preserved exactly even if two live
+   sessions transiently derive the same secondary key. The `reindex` predicate
+   gates only the value-guarded REMOVES of the OLD keys; it is complete per §2
+   (indices depend only on key+nat+is_reverse+owner_rg; key & handle invariant).
+   **This is the #1 review target.**
+2b. **Stale-handle / primary-key guard**: `entries.get(handle)` + `record.key ==
+   *key` before any mutation; mismatch → return false (no-op), matching
+   `remove_entry`'s release-mode guards. Never `entries[handle]` (panic/corrupt).
 3. **Wheel**: `push_to_wheel(key, now_ns)` unchanged; entry's `wheel_tick`
    field is preserved across in-place mutation (we do NOT reset it to 0, unlike
    install which sets wheel_tick:0). Current remove+restore preserves wheel_tick
@@ -175,13 +211,25 @@ No public signature changes. `update_session`, `refresh_local`,
 ## 9. Test plan
 
 - `cargo build` + full `cargo test --release` (1763+ lib tests) clean.
-- **Differential test (new, the gate)**: for each branch (local refresh, peer→
-  local promote, peer→peer reject, local←peer reject, ha_activation, nat change,
-  owner_rg change, is_reverse entry), assert the in-place result is
-  byte-identical (entry fields + all four index maps + key_to_handle + deltas) to
-  the old remove+restore implementation. Implement by keeping a reference
-  remove+restore helper in the test module and comparing table snapshots.
-- 5×flake on the differential test + the heaviest existing session test.
+- **Differential test (new, the gate)**: keep a reference remove+restore helper
+  in the test module; assert the in-place result is byte-identical (entry fields
+  + all four index maps + `key_to_handle` + `owner_rg_sessions` + deltas + wheel
+  state) to the reference across ALL of:
+  - local refresh, peer→local promote, peer→peer reject, local←peer reject,
+    ha_activation refresh;
+  - `reindex` triggers: NAT mapping change, owner_rg `0→>0`, `>0→0`, `>0→>0'`,
+    is_reverse toggle, NAT64 / NPTv6 decisions;
+  - **secondary-index collision** (Codex Major #1): two live sessions whose
+    derived secondary key collides — refresh one, assert the in-place table
+    matches the reference (the re-assert re-wins identically);
+  - **stale/wrong-key guard**: stale `key_to_handle` → vacant slot, and reused
+    slot holding a different `record.key` → both return false, no mutation;
+  - `refresh_for_ha_transition` liveness parity;
+  - a bounded **randomized update-sequence** property test (random installs +
+    refreshes + promotes + owner_rg flips) comparing in-place vs reference table
+    snapshots each step.
+- 5×flake on the differential + randomized tests + the heaviest existing
+  session test.
 - Go suite (30 pkgs).
 - Smoke matrix on loss userspace cluster: Pass A (CoS off) v4+v6 push+`-R` +
   `-P12 -R` line-rate; Pass B per-class 5201-5206 v4+v6 push+`-R`.
@@ -197,8 +245,22 @@ No public signature changes. `update_session`, `refresh_local`,
   remove_entry (they change identity / may replace a different session; in-place
   there is a measurable but smaller win — deferred, noted as a follow-up).
 - GC / `lookup_and_remove` / terminal paths — unchanged.
+- **Full skip of the secondary re-assert inserts** (the remaining ~1%):
+  deferred follow-up, gated on a *proven* secondary-key uniqueness invariant
+  across all live sessions (incl. the transient NAT-port-reuse / not-yet-GC'd
+  window) + a property test. v2 keeps the re-assert for exact parity.
 
 ## 11. Open questions for adversarial review
+
+**r1 resolutions (v2):** Q1 predicate completeness — confirmed by both reviewers
+(indices depend only on key+nat+is_reverse+owner_rg; key & handle invariant);
+**but** Codex's deeper point (unconditional-insert collision re-assert) is now
+handled by always re-asserting the ADDS, so v2 no longer depends on a uniqueness
+proof. Q2 reject-early-return net-neutral — confirmed by both. Q3 borrow/zero-clone
+hot path — confirmed feasible. Q4 owner_rg transition — works via reindex branch;
+added owner_rg `0↔>0`/`>0→>0'` + ha_transition tests. Q5 wheel_tick parity —
+confirmed. Q6 differential sufficiency — added collision + stale-handle +
+randomized property tests (Codex wanted them; cheap insurance). Remaining for r2:
 
 1. Is the reindex predicate (`old_nat != nat || old_is_reverse != is_reverse ||
    old_owner_rg != owner_rg`) provably complete, or is there an index whose key

--- a/docs/pr/1752-session-inplace-refresh/plan.md
+++ b/docs/pr/1752-session-inplace-refresh/plan.md
@@ -1,6 +1,6 @@
 # #1752 Path E — session refresh in-place mutation
 
-**Status: v3 — folds Codex r2 (PLAN-NEEDS-MAJOR, reject-path re-assert) + Gemini r2 (PLAN-READY). Re-dispatched for r3.**
+**Status: v4 (PLAN-READY) — Gemini r3 PLAN-READY; Codex r3 NEEDS-MINOR (handle-normalized test wording) folded; Claude SMR PLAN-READY. Proceeding to implement.**
 
 v2 changes: (a) secondary-index **adds are always re-asserted** (matches today's
 unconditional `index_forward_nat_key` insert exactly, incl. the
@@ -221,9 +221,14 @@ No public signature changes. `update_session`, `refresh_local`,
 
 - `cargo build` + full `cargo test --release` (1763+ lib tests) clean.
 - **Differential test (new, the gate)**: keep a reference remove+restore helper
-  in the test module; assert the in-place result is byte-identical (entry fields
-  + all four index maps + `key_to_handle` + `owner_rg_sessions` + deltas + wheel
-  state) to the reference across ALL of:
+  in the test module; assert **handle-normalized behavioral equivalence** to the
+  reference (NOT raw `u32` map equality — in-place preserves the slab handle
+  while remove+restore allocates a fresh one, so raw `key_to_handle`/
+  `owner_rg_sessions`/index values legitimately differ; Codex r3). Compare:
+  canonical entry fields by session key; every lookup (forward + all reverse/NAT/
+  wire/translated lookups) resolves to the same logical entry; owner-RG
+  membership as the set of session **keys** (not handles); the collision winner
+  by session key; deltas; wheel state. Cover ALL of:
   - local refresh, peer→local promote, peer→peer reject, local←peer reject,
     ha_activation refresh;
   - `reindex` triggers: NAT mapping change, owner_rg `0→>0`, `>0→0`, `>0→>0'`,

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -815,8 +815,8 @@ impl SessionTable {
         // every index (key_to_handle map, slab slot with a NEW handle, all four
         // secondary indices) plus ~3 SessionMetadata clones on EVERY packet of an
         // established flow, only to bump timestamps. We now mutate the slab record
-        // in place, gating value-guarded secondary-index REMOVES on key-relevant
-        // input changes (nat / is_reverse / owner_rg_id) while still re-asserting
+        // in place, gating secondary-index REMOVES on key-relevant input changes
+        // (nat / is_reverse / owner_rg_id) while still re-asserting
         // secondary-index ADDS every refresh (restore_entry parity). Behavior is
         // byte-identical (modulo the opaque slab handle value); see
         // docs/pr/1752-session-inplace-refresh/plan.md.
@@ -852,8 +852,8 @@ impl SessionTable {
             // unconditionally re-asserts the entry's own secondary ADDS. To stay
             // byte-identical (incl. re-winning a displaced secondary-index
             // collision), re-assert the OLD adds before bailing.
-            let reject = new_peer;
-            if reject {
+            let should_reject_update = new_peer;
+            if should_reject_update {
                 self.index_forward_nat_key_parts(
                     key,
                     handle,

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -815,8 +815,9 @@ impl SessionTable {
         // every index (key_to_handle map, slab slot with a NEW handle, all four
         // secondary indices) plus ~3 SessionMetadata clones on EVERY packet of an
         // established flow, only to bump timestamps. We now mutate the slab record
-        // in place and touch the secondary indices only when a key-relevant input
-        // (nat / is_reverse / owner_rg_id) actually changed. Behavior is
+        // in place, gating value-guarded secondary-index REMOVES on key-relevant
+        // input changes (nat / is_reverse / owner_rg_id) while still re-asserting
+        // secondary-index ADDS every refresh (restore_entry parity). Behavior is
         // byte-identical (modulo the opaque slab handle value); see
         // docs/pr/1752-session-inplace-refresh/plan.md.
         let Some(&handle) = self.key_to_handle.get(key) else {
@@ -851,8 +852,7 @@ impl SessionTable {
             // unconditionally re-asserts the entry's own secondary ADDS. To stay
             // byte-identical (incl. re-winning a displaced secondary-index
             // collision), re-assert the OLD adds before bailing.
-            let reject = (old_origin.is_peer_synced() && new_peer)
-                || (!old_origin.is_peer_synced() && new_peer);
+            let reject = new_peer;
             if reject {
                 self.index_forward_nat_key_parts(
                     key,
@@ -1288,7 +1288,8 @@ impl SessionTable {
     /// #1752 Path E: no longer used by the refresh paths (`update_session` /
     /// `refresh_for_ha_transition` now mutate in place). Retained as the
     /// reference half of the remove+restore round-trip the differential tests
-    /// compare against, so it is test-only in release builds.
+    /// compare against, so in release builds it is retained as dead-code-allowed
+    /// test reference logic (not conditionally compiled out).
     #[cfg_attr(not(test), allow(dead_code))]
     fn restore_entry(&mut self, key: SessionKey, entry: SessionEntry) -> Option<SessionEntry> {
         let record = SessionRecord {

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -810,35 +810,105 @@ impl SessionTable {
             protocol,
             tcp_flags,
         } = req;
-        let Some(mut entry) = self.remove_entry(key) else {
+        // #1752 Path E: in-place refresh. The prior implementation did
+        // `remove_entry` + mutate + `restore_entry`, which tore down and rebuilt
+        // every index (key_to_handle map, slab slot with a NEW handle, all four
+        // secondary indices) plus ~3 SessionMetadata clones on EVERY packet of an
+        // established flow, only to bump timestamps. We now mutate the slab record
+        // in place and touch the secondary indices only when a key-relevant input
+        // (nat / is_reverse / owner_rg_id) actually changed. Behavior is
+        // byte-identical (modulo the opaque slab handle value); see
+        // docs/pr/1752-session-inplace-refresh/plan.md.
+        let Some(&handle) = self.key_to_handle.get(key) else {
             return false;
         };
+        // Stale-handle + primary-key guard (parity with remove_entry): never
+        // index the slab raw — a stale key_to_handle could point at a vacant or
+        // reused slot. On mismatch behave like remove_entry returning None.
+        let Some(record) = self.entries.get(handle as usize) else {
+            debug_assert!(
+                false,
+                "update_session: key_to_handle had stale handle {} for {:?}",
+                handle, key
+            );
+            return false;
+        };
+        if record.key != *key {
+            debug_assert!(false, "update_session: stale key_to_handle for {:?}", key);
+            return false;
+        }
+        // Snapshot the OLD index-relevant + collision-relevant state (all Copy).
+        let old_origin = record.entry.origin;
+        let old_nat = record.entry.decision.nat;
+        let old_is_reverse = record.entry.metadata.is_reverse;
+        let old_owner_rg = record.entry.metadata.owner_rg_id;
+
         if !ha_activation {
-            if entry.origin.is_peer_synced() && !origin.is_peer_synced() {
-                // Peer-synced entry being promoted by local traffic — allow
-            } else if entry.origin.is_peer_synced() && origin.is_peer_synced() {
-                // Both peer-synced: reject (refresh_local on synced entry)
-                self.restore_entry(key.clone(), entry);
-                return false;
-            } else if !entry.origin.is_peer_synced() && origin.is_peer_synced() {
-                // Local entry: reject peer data trying to overwrite
-                self.restore_entry(key.clone(), entry);
+            let new_peer = origin.is_peer_synced();
+            // Reject: both peer-synced (refresh_local on a synced entry) OR peer
+            // data trying to overwrite a local entry. The prior code reached this
+            // via remove_entry + restore_entry + return false, and restore_entry
+            // unconditionally re-asserts the entry's own secondary ADDS. To stay
+            // byte-identical (incl. re-winning a displaced secondary-index
+            // collision), re-assert the OLD adds before bailing.
+            let reject = (old_origin.is_peer_synced() && new_peer)
+                || (!old_origin.is_peer_synced() && new_peer);
+            if reject {
+                self.index_forward_nat_key_parts(
+                    key,
+                    handle,
+                    old_nat,
+                    old_is_reverse,
+                    old_owner_rg,
+                );
                 return false;
             }
-            // Both local: allow (local refresh of local entry)
+            // Else: peer→local promote, or local→local refresh — fall through.
         }
-        let was_peer_synced = entry.origin.is_peer_synced();
-        entry.decision = decision;
-        entry.metadata = metadata.clone();
-        entry.origin = origin;
-        entry.install_epoch = self.next_epoch();
-        entry.last_seen_ns = now_ns;
-        entry.expires_after_ns = session_timeout_ns(protocol, tcp_flags, &self.timeouts);
-        entry.closing = matches!(protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN | TCP_RST)) != 0;
-        self.restore_entry(key.clone(), entry);
-        // #965: schedule the refreshed entry. Last_seen / expires_after
-        // were rewritten above; push_to_wheel is throttled and will only
-        // emit a new wheel entry if the canonical tick changed.
+        let was_peer_synced = old_origin.is_peer_synced();
+
+        // Reindex only when a secondary-index input changed (§2 of the plan:
+        // indices depend only on key + nat + is_reverse + owner_rg_id, and key +
+        // handle are invariant here). Gates only the value-guarded REMOVES.
+        let reindex = old_nat != decision.nat
+            || old_is_reverse != metadata.is_reverse
+            || old_owner_rg != metadata.owner_rg_id;
+        if reindex {
+            self.remove_forward_nat_index_parts(key, handle, old_nat, old_is_reverse);
+            remove_owner_rg_index_entry(&mut self.owner_rg_sessions, old_owner_rg, handle);
+        }
+
+        let epoch = self.next_epoch();
+        {
+            let record = self
+                .entries
+                .get_mut(handle as usize)
+                .expect("handle validated above");
+            record.entry.decision = decision;
+            record.entry.metadata = metadata.clone();
+            record.entry.origin = origin;
+            record.entry.install_epoch = epoch;
+            record.entry.last_seen_ns = now_ns;
+            record.entry.expires_after_ns = session_timeout_ns(protocol, tcp_flags, &self.timeouts);
+            record.entry.closing =
+                matches!(protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN | TCP_RST)) != 0;
+            // wheel_tick deliberately preserved (parity with restore_entry).
+        }
+        // Always re-assert the secondary ADDS — byte-identical to restore_entry's
+        // unconditional index_forward_nat_key. For the no-reindex case this
+        // re-inserts the same keys→handle (idempotent when unique, re-wins on a
+        // collision); for the reindex case it installs the NEW keys after the
+        // removes above.
+        self.index_forward_nat_key_parts(
+            key,
+            handle,
+            decision.nat,
+            metadata.is_reverse,
+            metadata.owner_rg_id,
+        );
+        // #965: schedule the refreshed entry. Last_seen / expires_after were
+        // rewritten above; push_to_wheel is throttled and will only emit a new
+        // wheel entry if the canonical tick changed.
         self.push_to_wheel(key, now_ns);
         // Emit open delta when promoting a peer-synced entry to local
         if was_peer_synced && !origin.is_peer_synced() && !metadata.is_reverse {
@@ -922,14 +992,55 @@ impl SessionTable {
         metadata: SessionMetadata,
         now_ns: u64,
     ) -> bool {
-        let Some(mut entry) = self.remove_entry(key) else {
+        // #1752 Path E: in-place (mirrors update_session, minus collision rules
+        // — this path always applies). No expires_after_ns / closing rewrite,
+        // matching the prior behavior.
+        let Some(&handle) = self.key_to_handle.get(key) else {
             return false;
         };
-        entry.decision = decision;
-        entry.metadata = metadata;
-        entry.install_epoch = self.next_epoch();
-        entry.last_seen_ns = now_ns;
-        self.restore_entry(key.clone(), entry);
+        let Some(record) = self.entries.get(handle as usize) else {
+            debug_assert!(
+                false,
+                "refresh_for_ha_transition: stale handle {} for {:?}",
+                handle, key
+            );
+            return false;
+        };
+        if record.key != *key {
+            debug_assert!(
+                false,
+                "refresh_for_ha_transition: stale key_to_handle for {:?}",
+                key
+            );
+            return false;
+        }
+        let old_nat = record.entry.decision.nat;
+        let old_is_reverse = record.entry.metadata.is_reverse;
+        let old_owner_rg = record.entry.metadata.owner_rg_id;
+        // Capture the new index parts before `metadata` is moved into the record.
+        let new_nat = decision.nat;
+        let new_is_reverse = metadata.is_reverse;
+        let new_owner_rg = metadata.owner_rg_id;
+
+        let reindex =
+            old_nat != new_nat || old_is_reverse != new_is_reverse || old_owner_rg != new_owner_rg;
+        if reindex {
+            self.remove_forward_nat_index_parts(key, handle, old_nat, old_is_reverse);
+            remove_owner_rg_index_entry(&mut self.owner_rg_sessions, old_owner_rg, handle);
+        }
+
+        let epoch = self.next_epoch();
+        {
+            let record = self
+                .entries
+                .get_mut(handle as usize)
+                .expect("handle validated above");
+            record.entry.decision = decision;
+            record.entry.metadata = metadata;
+            record.entry.install_epoch = epoch;
+            record.entry.last_seen_ns = now_ns;
+        }
+        self.index_forward_nat_key_parts(key, handle, new_nat, new_is_reverse, new_owner_rg);
         // #965: schedule the refreshed entry for expiration check.
         self.push_to_wheel(key, now_ns);
         true
@@ -1173,6 +1284,12 @@ impl SessionTable {
     /// #964 Step 1: re-insert an entry that was just `remove_entry`'d.
     /// Returns None always — kept return type for API compatibility
     /// with the prior FxHashMap-based shape.
+    ///
+    /// #1752 Path E: no longer used by the refresh paths (`update_session` /
+    /// `refresh_for_ha_transition` now mutate in place). Retained as the
+    /// reference half of the remove+restore round-trip the differential tests
+    /// compare against, so it is test-only in release builds.
+    #[cfg_attr(not(test), allow(dead_code))]
     fn restore_entry(&mut self, key: SessionKey, entry: SessionEntry) -> Option<SessionEntry> {
         let record = SessionRecord {
             key: key.clone(),
@@ -1208,26 +1325,48 @@ impl SessionTable {
         decision: SessionDecision,
         metadata: &SessionMetadata,
     ) {
-        if metadata.is_reverse {
-            let translated = translated_session_key(key, decision.nat);
+        self.index_forward_nat_key_parts(
+            key,
+            handle,
+            decision.nat,
+            metadata.is_reverse,
+            metadata.owner_rg_id,
+        );
+    }
+
+    /// #1752 Path E: secondary-index insert from the Copy parts the index
+    /// actually depends on (`nat`, `is_reverse`, `owner_rg_id`). Lets the
+    /// in-place refresh path re-assert (and reindex) without cloning a
+    /// `SessionMetadata` / `SessionDecision`. `index_forward_nat_key` delegates
+    /// here so the two stay bit-identical.
+    fn index_forward_nat_key_parts(
+        &mut self,
+        key: &SessionKey,
+        handle: u32,
+        nat: NatDecision,
+        is_reverse: bool,
+        owner_rg_id: i32,
+    ) {
+        if is_reverse {
+            let translated = translated_session_key(key, nat);
             if translated != *key {
                 self.reverse_translated_index.insert(translated, handle);
             }
         } else {
             self.nat_reverse_index
-                .insert(reverse_wire_key(key, decision.nat), handle);
-            let reverse_canonical = reverse_canonical_key(key, decision.nat);
+                .insert(reverse_wire_key(key, nat), handle);
+            let reverse_canonical = reverse_canonical_key(key, nat);
             if reverse_canonical != *key {
                 self.nat_reverse_index.insert(reverse_canonical, handle);
             }
-            let forward_wire = forward_wire_key(key, decision.nat);
+            let forward_wire = forward_wire_key(key, nat);
             if forward_wire != *key {
                 self.forward_wire_index.insert(forward_wire, handle);
             }
         }
-        if metadata.owner_rg_id > 0 {
+        if owner_rg_id > 0 {
             self.owner_rg_sessions
-                .entry(metadata.owner_rg_id)
+                .entry(owner_rg_id)
                 .or_default()
                 .insert(handle);
         }
@@ -1244,8 +1383,22 @@ impl SessionTable {
         decision: SessionDecision,
         metadata: &SessionMetadata,
     ) {
-        if metadata.is_reverse {
-            let translated = translated_session_key(key, decision.nat);
+        self.remove_forward_nat_index_parts(key, handle, decision.nat, metadata.is_reverse);
+    }
+
+    /// #1752 Path E: value-guarded secondary-index removal from the Copy parts
+    /// (`nat`, `is_reverse`). Used by the in-place reindex teardown so it needs
+    /// no `SessionMetadata`/`SessionDecision` clone. `remove_forward_nat_index`
+    /// delegates here.
+    fn remove_forward_nat_index_parts(
+        &mut self,
+        key: &SessionKey,
+        handle: u32,
+        nat: NatDecision,
+        is_reverse: bool,
+    ) {
+        if is_reverse {
+            let translated = translated_session_key(key, nat);
             if matches!(
                 self.reverse_translated_index.get(&translated),
                 Some(stored) if *stored == handle
@@ -1254,18 +1407,18 @@ impl SessionTable {
             }
             return;
         }
-        let reverse_wire = reverse_wire_key(key, decision.nat);
+        let reverse_wire = reverse_wire_key(key, nat);
         if matches!(self.nat_reverse_index.get(&reverse_wire), Some(stored) if *stored == handle) {
             self.nat_reverse_index.remove(&reverse_wire);
         }
-        let reverse_canonical = reverse_canonical_key(key, decision.nat);
+        let reverse_canonical = reverse_canonical_key(key, nat);
         if matches!(
             self.nat_reverse_index.get(&reverse_canonical),
             Some(stored) if *stored == handle
         ) {
             self.nat_reverse_index.remove(&reverse_canonical);
         }
-        let forward_wire = forward_wire_key(key, decision.nat);
+        let forward_wire = forward_wire_key(key, nat);
         if matches!(self.forward_wire_index.get(&forward_wire), Some(stored) if *stored == handle) {
             self.forward_wire_index.remove(&forward_wire);
         }

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -1757,3 +1757,435 @@ fn refresh_for_ha_activation_updates_peer_synced_entries() {
     let lookup = table.lookup(&key, 3_000_000, 0x10).expect("session");
     assert_eq!(lookup.decision.resolution.egress_ifindex, 99);
 }
+
+// ---------------------------------------------------------------------------
+// #1752 Path E: in-place refresh differential tests.
+//
+// The pre-#1752 update_session did remove_entry + mutate + restore_entry. The
+// in-place rewrite must be behaviorally equivalent (handle-normalized — the
+// slab handle VALUE legitimately differs because remove+restore allocates a
+// fresh slot while in-place keeps the slot). `reference_update_session` below
+// reproduces the OLD path verbatim; every scenario applies the same op to two
+// tables and asserts equivalence via observable views (entries, lookups,
+// owner-RG key sets, deltas) — never raw u32 handles.
+// ---------------------------------------------------------------------------
+
+/// Verbatim reproduction of the pre-#1752 remove+restore update_session.
+fn reference_update_session(
+    table: &mut SessionTable,
+    req: SessionUpdate<'_>,
+    ha_activation: bool,
+) -> bool {
+    let SessionUpdate {
+        key,
+        decision,
+        metadata,
+        origin,
+        now_ns,
+        protocol,
+        tcp_flags,
+    } = req;
+    let Some(mut entry) = table.remove_entry(key) else {
+        return false;
+    };
+    if !ha_activation {
+        if entry.origin.is_peer_synced() && !origin.is_peer_synced() {
+        } else if entry.origin.is_peer_synced() && origin.is_peer_synced() {
+            table.restore_entry(key.clone(), entry);
+            return false;
+        } else if !entry.origin.is_peer_synced() && origin.is_peer_synced() {
+            table.restore_entry(key.clone(), entry);
+            return false;
+        }
+    }
+    let was_peer_synced = entry.origin.is_peer_synced();
+    entry.decision = decision;
+    entry.metadata = metadata.clone();
+    entry.origin = origin;
+    entry.install_epoch = table.next_epoch();
+    entry.last_seen_ns = now_ns;
+    entry.expires_after_ns = session_timeout_ns(protocol, tcp_flags, &table.timeouts);
+    entry.closing = matches!(protocol, PROTO_TCP) && (tcp_flags & (TCP_FIN | TCP_RST)) != 0;
+    table.restore_entry(key.clone(), entry);
+    table.push_to_wheel(key, now_ns);
+    if was_peer_synced && !origin.is_peer_synced() && !metadata.is_reverse {
+        table.push_delta(SessionDelta {
+            kind: SessionDeltaKind::Open,
+            key: key.clone(),
+            decision,
+            metadata,
+            origin,
+            fabric_redirect_sync: false,
+        });
+    }
+    true
+}
+
+fn entries_equiv(a: &SessionTable, b: &SessionTable, key: &SessionKey) -> bool {
+    match (a.entry_by_key(key), b.entry_by_key(key)) {
+        (Some(ea), Some(eb)) => {
+            ea.decision == eb.decision
+                && ea.metadata == eb.metadata
+                && ea.origin == eb.origin
+                && ea.install_epoch == eb.install_epoch
+                && ea.last_seen_ns == eb.last_seen_ns
+                && ea.expires_after_ns == eb.expires_after_ns
+                && ea.closing == eb.closing
+                && ea.wheel_tick == eb.wheel_tick
+        }
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn sorted_keys(mut v: Vec<SessionKey>) -> Vec<String> {
+    let mut s: Vec<String> = v.drain(..).map(|k| format!("{k:?}")).collect();
+    s.sort();
+    s
+}
+
+/// Assert handle-normalized equivalence of two tables across entries, the
+/// reverse/wire NAT lookups for the given probe keys, owner-RG key sets, and
+/// drained deltas.
+fn assert_tables_equiv(
+    inplace: &mut SessionTable,
+    reference: &mut SessionTable,
+    keys: &[SessionKey],
+    probe_keys: &[SessionKey],
+    owner_rgs: &[i32],
+) {
+    assert_eq!(inplace.len(), reference.len(), "len mismatch");
+    for k in keys {
+        assert!(entries_equiv(inplace, reference, k), "entry mismatch for {k:?}");
+    }
+    for pk in probe_keys {
+        assert_eq!(
+            inplace.find_forward_nat_match(pk).map(|m| m.key),
+            reference.find_forward_nat_match(pk).map(|m| m.key),
+            "find_forward_nat_match diverged for {pk:?}"
+        );
+        assert_eq!(
+            inplace.find_forward_wire_match(pk).map(|m| m.key),
+            reference.find_forward_wire_match(pk).map(|m| m.key),
+            "find_forward_wire_match diverged for {pk:?}"
+        );
+    }
+    assert_eq!(
+        sorted_keys(inplace.owner_rg_session_keys(owner_rgs)),
+        sorted_keys(reference.owner_rg_session_keys(owner_rgs)),
+        "owner_rg_session_keys diverged"
+    );
+    assert_eq!(
+        inplace.drain_deltas(256),
+        reference.drain_deltas(256),
+        "deltas diverged"
+    );
+}
+
+fn nat_rewrite() -> SessionDecision {
+    SessionDecision {
+        resolution: resolution(),
+        nat: NatDecision {
+            rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7))),
+            rewrite_src_port: Some(40001),
+            ..NatDecision::default()
+        },
+    }
+}
+
+/// Build two identical tables with `key` installed at the given origin.
+fn two_tables_with(
+    key: &SessionKey,
+    decision: SessionDecision,
+    md: SessionMetadata,
+    origin: SessionOrigin,
+    now: u64,
+) -> (SessionTable, SessionTable) {
+    let mut a = SessionTable::new();
+    let mut b = SessionTable::new();
+    for t in [&mut a, &mut b] {
+        assert!(t.install_with_protocol_with_origin(
+            key.clone(),
+            decision,
+            md.clone(),
+            origin,
+            now,
+            key.protocol,
+            0,
+        ));
+    }
+    (a, b)
+}
+
+#[test]
+fn inplace_local_refresh_matches_reference() {
+    let key = key_v4();
+    let (mut ip, mut rf) = two_tables_with(&key, decision(), metadata(), SessionOrigin::ForwardFlow, 1_000);
+    let req = |now| SessionUpdate {
+        key: &key,
+        decision: decision(),
+        metadata: metadata(),
+        origin: SessionOrigin::ForwardFlow,
+        now_ns: now,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    assert!(ip.update_session(req(2_000), false));
+    assert!(reference_update_session(&mut rf, req(2_000), false));
+    assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[], &[1, 2]);
+}
+
+#[test]
+fn inplace_peer_to_local_promote_matches_reference() {
+    let key = key_v4();
+    let (mut ip, mut rf) = two_tables_with(&key, decision(), metadata(), SessionOrigin::SyncImport, 1_000);
+    let req = SessionUpdate {
+        key: &key,
+        decision: decision(),
+        metadata: metadata(),
+        origin: SessionOrigin::ForwardFlow,
+        now_ns: 2_000,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    let r1 = ip.update_session(req.clone(), false);
+    let r2 = reference_update_session(&mut rf, req, false);
+    assert_eq!(r1, r2);
+    assert!(r1, "promote should succeed");
+    assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[], &[1, 2]);
+}
+
+#[test]
+fn inplace_peer_to_peer_reject_matches_reference() {
+    let key = key_v4();
+    let (mut ip, mut rf) = two_tables_with(&key, decision(), metadata(), SessionOrigin::SyncImport, 1_000);
+    let req = SessionUpdate {
+        key: &key,
+        decision: decision(),
+        metadata: metadata(),
+        origin: SessionOrigin::SyncImport,
+        now_ns: 2_000,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    assert!(!ip.update_session(req.clone(), false));
+    assert!(!reference_update_session(&mut rf, req, false));
+    assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[], &[1, 2]);
+}
+
+#[test]
+fn inplace_local_from_peer_reject_matches_reference() {
+    let key = key_v4();
+    let (mut ip, mut rf) = two_tables_with(&key, decision(), metadata(), SessionOrigin::ForwardFlow, 1_000);
+    let req = SessionUpdate {
+        key: &key,
+        decision: decision(),
+        metadata: metadata(),
+        origin: SessionOrigin::SyncImport,
+        now_ns: 2_000,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    assert!(!ip.update_session(req.clone(), false));
+    assert!(!reference_update_session(&mut rf, req, false));
+    assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[], &[1, 2]);
+}
+
+#[test]
+fn inplace_ha_activation_matches_reference() {
+    let key = key_v4();
+    let (mut ip, mut rf) = two_tables_with(&key, decision(), metadata(), SessionOrigin::SyncImport, 1_000);
+    // ha_activation=true always applies regardless of origin.
+    let req = SessionUpdate {
+        key: &key,
+        decision: decision(),
+        metadata: metadata(),
+        origin: SessionOrigin::SyncImport,
+        now_ns: 3_000,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    assert!(ip.update_session(req.clone(), true));
+    assert!(reference_update_session(&mut rf, req, true));
+    assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[], &[1, 2]);
+}
+
+#[test]
+fn inplace_nat_reindex_matches_reference() {
+    let key = key_v4();
+    // baseline: default nat. refresh: nat rewrite -> reverse index keys change.
+    let (mut ip, mut rf) = two_tables_with(&key, decision(), metadata(), SessionOrigin::ForwardFlow, 1_000);
+    let probe_old = reverse_wire_key(&key, NatDecision::default());
+    let probe_new = reverse_wire_key(&key, nat_rewrite().nat);
+    let req = SessionUpdate {
+        key: &key,
+        decision: nat_rewrite(),
+        metadata: metadata(),
+        origin: SessionOrigin::ForwardFlow,
+        now_ns: 2_000,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    assert!(ip.update_session(req.clone(), false));
+    assert!(reference_update_session(&mut rf, req, false));
+    assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[probe_old, probe_new], &[1, 2]);
+}
+
+#[test]
+fn inplace_owner_rg_transitions_match_reference() {
+    let key = key_v4();
+    for (from_rg, to_rg) in [(1i32, 2i32), (1, 0), (0, 1)] {
+        let mut md_from = metadata();
+        md_from.owner_rg_id = from_rg;
+        let (mut ip, mut rf) =
+            two_tables_with(&key, decision(), md_from, SessionOrigin::ForwardFlow, 1_000);
+        let mut md_to = metadata();
+        md_to.owner_rg_id = to_rg;
+        let req = SessionUpdate {
+            key: &key,
+            decision: decision(),
+            metadata: md_to,
+            origin: SessionOrigin::ForwardFlow,
+            now_ns: 2_000,
+            protocol: PROTO_TCP,
+            tcp_flags: 0,
+        };
+        assert!(ip.update_session(req.clone(), false));
+        assert!(reference_update_session(&mut rf, req, false));
+        assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[], &[0, 1, 2]);
+    }
+}
+
+#[test]
+fn inplace_reject_reasserts_displaced_collision_like_reference() {
+    // Simulate a secondary-index collision: another (bogus) handle has displaced
+    // this session's reverse-wire index slot. Today's reject path re-asserts via
+    // remove+restore; in-place re-asserts via index_forward_nat_key_parts. Both
+    // must re-win the slot identically.
+    let key = key_v4();
+    let (mut ip, mut rf) =
+        two_tables_with(&key, decision(), metadata(), SessionOrigin::ForwardFlow, 1_000);
+    let collide = reverse_wire_key(&key, NatDecision::default());
+    for t in [&mut ip, &mut rf] {
+        t.nat_reverse_index.insert(collide.clone(), 9999u32);
+    }
+    // local<-peer reject (origin SyncImport on a local entry).
+    let req = SessionUpdate {
+        key: &key,
+        decision: decision(),
+        metadata: metadata(),
+        origin: SessionOrigin::SyncImport,
+        now_ns: 2_000,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    assert!(!ip.update_session(req.clone(), false));
+    assert!(!reference_update_session(&mut rf, req, false));
+    // Both must have re-won the displaced slot back to the real session.
+    assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[collide], &[1, 2]);
+}
+
+#[test]
+fn inplace_accept_reasserts_displaced_collision_like_reference() {
+    let key = key_v4();
+    let (mut ip, mut rf) =
+        two_tables_with(&key, decision(), metadata(), SessionOrigin::ForwardFlow, 1_000);
+    let collide = reverse_wire_key(&key, NatDecision::default());
+    for t in [&mut ip, &mut rf] {
+        t.nat_reverse_index.insert(collide.clone(), 9999u32);
+    }
+    let req = SessionUpdate {
+        key: &key,
+        decision: decision(),
+        metadata: metadata(),
+        origin: SessionOrigin::ForwardFlow,
+        now_ns: 2_000,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    assert!(ip.update_session(req.clone(), false));
+    assert!(reference_update_session(&mut rf, req, false));
+    assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[collide], &[1, 2]);
+}
+
+#[test]
+fn inplace_stale_handle_returns_false_no_panic() {
+    let key = key_v4();
+    let other = key_v6();
+    let mut t = SessionTable::new();
+    assert!(t.install_with_protocol_with_origin(
+        key.clone(), decision(), metadata(), SessionOrigin::ForwardFlow, 1_000, key.protocol, 0,
+    ));
+    assert!(t.install_with_protocol_with_origin(
+        other.clone(), decision(), metadata(), SessionOrigin::ForwardFlow, 1_000, other.protocol, 0,
+    ));
+    // Point `key` at `other`'s handle => primary-key guard must reject.
+    let other_handle = *t.key_to_handle.get(&other).expect("other handle");
+    t.key_to_handle.insert(key.clone(), other_handle);
+    let req = SessionUpdate {
+        key: &key,
+        decision: decision(),
+        metadata: metadata(),
+        origin: SessionOrigin::ForwardFlow,
+        now_ns: 2_000,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    // Must not panic and must not mutate the unrelated `other` session.
+    let before = t.entry_by_key(&other).map(|e| e.last_seen_ns);
+    assert!(!t.update_session(req, false));
+    assert_eq!(t.entry_by_key(&other).map(|e| e.last_seen_ns), before);
+}
+
+#[test]
+fn inplace_randomized_sequence_matches_reference() {
+    // Deterministic LCG (Math.random is unavailable in this env; fixed seed).
+    let mut state: u64 = 0x9E3779B97F4A7C15;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        (state >> 33) as u32
+    };
+    let keys = [key_v4(), key_v6()];
+    let mut ip = SessionTable::new();
+    let mut rf = SessionTable::new();
+    // Install both keys identically.
+    for t in [&mut ip, &mut rf] {
+        for k in &keys {
+            assert!(t.install_with_protocol_with_origin(
+                k.clone(), decision(), metadata(), SessionOrigin::ForwardFlow, 1_000, k.protocol, 0,
+            ));
+        }
+    }
+    for step in 0..400u64 {
+        let k = &keys[(next() % 2) as usize];
+        let origin = if next() % 3 == 0 { SessionOrigin::SyncImport } else { SessionOrigin::ForwardFlow };
+        let dec = if next() % 4 == 0 { nat_rewrite() } else { decision() };
+        let mut md = metadata();
+        md.owner_rg_id = (next() % 3) as i32; // 0,1,2
+        md.is_reverse = next() % 5 == 0;
+        let ha = next() % 7 == 0;
+        let now = 2_000 + step * 10;
+        let req = SessionUpdate {
+            key: k,
+            decision: dec,
+            metadata: md,
+            origin,
+            now_ns: now,
+            protocol: k.protocol,
+            tcp_flags: 0,
+        };
+        let r1 = ip.update_session(req.clone(), ha);
+        let r2 = reference_update_session(&mut rf, req, ha);
+        assert_eq!(r1, r2, "accept/reject diverged at step {step}");
+        let probes: Vec<SessionKey> = keys
+            .iter()
+            .flat_map(|kk| {
+                [
+                    reverse_wire_key(kk, NatDecision::default()),
+                    reverse_wire_key(kk, nat_rewrite().nat),
+                ]
+            })
+            .collect();
+        assert_tables_equiv(&mut ip, &mut rf, &keys, &probes, &[0, 1, 2]);
+    }
+}

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -2164,6 +2164,13 @@ fn inplace_randomized_sequence_matches_reference() {
         md.owner_rg_id = (next() % 3) as i32; // 0,1,2
         md.is_reverse = next() % 5 == 0;
         let ha = next() % 7 == 0;
+        // Vary tcp_flags so the FIN/RST `closing` + `expires_after_ns` branch is
+        // exercised, not only the steady-state tcp_flags=0 path.
+        let tcp_flags = match next() % 4 {
+            0 => TCP_FIN,
+            1 => TCP_RST,
+            _ => 0,
+        };
         let now = 2_000 + step * 10;
         let req = SessionUpdate {
             key: k,
@@ -2172,7 +2179,7 @@ fn inplace_randomized_sequence_matches_reference() {
             origin,
             now_ns: now,
             protocol: k.protocol,
-            tcp_flags: 0,
+            tcp_flags,
         };
         let r1 = ip.update_session(req.clone(), ha);
         let r2 = reference_update_session(&mut rf, req, ha);
@@ -2187,5 +2194,96 @@ fn inplace_randomized_sequence_matches_reference() {
             })
             .collect();
         assert_tables_equiv(&mut ip, &mut rf, &keys, &probes, &[0, 1, 2]);
+    }
+}
+
+/// Verbatim reproduction of the pre-#1752 remove+restore refresh_for_ha_transition.
+fn reference_refresh_for_ha_transition(
+    table: &mut SessionTable,
+    key: &SessionKey,
+    decision: SessionDecision,
+    metadata: SessionMetadata,
+    now_ns: u64,
+) -> bool {
+    let Some(mut entry) = table.remove_entry(key) else {
+        return false;
+    };
+    entry.decision = decision;
+    entry.metadata = metadata;
+    entry.install_epoch = table.next_epoch();
+    entry.last_seen_ns = now_ns;
+    table.restore_entry(key.clone(), entry);
+    table.push_to_wheel(key, now_ns);
+    true
+}
+
+#[test]
+fn inplace_ha_transition_matches_reference() {
+    let key = key_v4();
+    // Plain transition (no index change) + a reindex transition (nat rewrite +
+    // owner_rg change) so both the skip and the reindex branch are covered.
+    for (dec, mut md) in [(decision(), metadata()), (nat_rewrite(), metadata())] {
+        md.owner_rg_id = 2; // differs from baseline owner_rg_id=1 -> reindex
+        let (mut ip, mut rf) =
+            two_tables_with(&key, decision(), metadata(), SessionOrigin::SyncImport, 1_000);
+        let probe_old = reverse_wire_key(&key, NatDecision::default());
+        let probe_new = reverse_wire_key(&key, dec.nat);
+        assert!(ip.refresh_for_ha_transition(&key, dec, md.clone(), 2_000));
+        assert!(reference_refresh_for_ha_transition(&mut rf, &key, dec, md, 2_000));
+        assert_tables_equiv(
+            &mut ip,
+            &mut rf,
+            &[key.clone()],
+            &[probe_old, probe_new],
+            &[0, 1, 2],
+        );
+    }
+}
+
+#[test]
+fn inplace_vacant_handle_returns_false_no_panic() {
+    // key_to_handle points at a slab slot that was never allocated -> the
+    // entries.get(handle) == None guard must return false without panicking.
+    let key = key_v4();
+    let mut t = SessionTable::new();
+    t.key_to_handle.insert(key.clone(), 9999u32);
+    let req = SessionUpdate {
+        key: &key,
+        decision: decision(),
+        metadata: metadata(),
+        origin: SessionOrigin::ForwardFlow,
+        now_ns: 2_000,
+        protocol: PROTO_TCP,
+        tcp_flags: 0,
+    };
+    assert!(!t.update_session(req, false));
+    // refresh_for_ha_transition shares the same guard.
+    assert!(!t.refresh_for_ha_transition(&key, decision(), metadata(), 2_000));
+}
+
+#[test]
+fn inplace_fin_rst_closing_matches_reference() {
+    // FIN/RST set `closing` and shorten expires_after_ns; verify the in-place
+    // path writes them identically to the reference for both flags.
+    let key = key_v4();
+    for flags in [TCP_FIN, TCP_RST, TCP_FIN | TCP_RST] {
+        let (mut ip, mut rf) =
+            two_tables_with(&key, decision(), metadata(), SessionOrigin::ForwardFlow, 1_000);
+        let req = SessionUpdate {
+            key: &key,
+            decision: decision(),
+            metadata: metadata(),
+            origin: SessionOrigin::ForwardFlow,
+            now_ns: 2_000,
+            protocol: PROTO_TCP,
+            tcp_flags: flags,
+        };
+        assert!(ip.update_session(req.clone(), false));
+        assert!(reference_update_session(&mut rf, req, false));
+        assert!(
+            ip.entry_by_key(&key).expect("entry").closing,
+            "closing should be set for flags {flags:#x}"
+        );
+        assert_tables_equiv(&mut ip, &mut rf, &[key.clone()], &[], &[1, 2]);
     }
 }

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -2220,10 +2220,16 @@ fn reference_refresh_for_ha_transition(
 #[test]
 fn inplace_ha_transition_matches_reference() {
     let key = key_v4();
-    // Plain transition (no index change) + a reindex transition (nat rewrite +
-    // owner_rg change) so both the skip and the reindex branch are covered.
-    for (dec, mut md) in [(decision(), metadata()), (nat_rewrite(), metadata())] {
-        md.owner_rg_id = 2; // differs from baseline owner_rg_id=1 -> reindex
+    // Case 0: identical decision + metadata (owner_rg_id stays 1, nat unchanged)
+    // -> the no-reindex/skip branch. Case 1: nat rewrite + owner_rg 1->2 -> the
+    // reindex branch. Baseline metadata() has owner_rg_id=1, so case 0 must NOT
+    // mutate md (else it would also reindex).
+    let reindex_md = {
+        let mut m = metadata();
+        m.owner_rg_id = 2;
+        m
+    };
+    for (dec, md) in [(decision(), metadata()), (nat_rewrite(), reindex_md)] {
         let (mut ip, mut rf) =
             two_tables_with(&key, decision(), metadata(), SessionOrigin::SyncImport, 1_000);
         let probe_old = reverse_wire_key(&key, NatDecision::default());


### PR DESCRIPTION
## Summary

`SessionTable::update_session` (the established-flow refresh path —
`refresh_local`/`promote_synced_with_origin`/`refresh_for_ha_activation` route
through it) previously did `remove_entry` → mutate → `restore_entry` **per
packet**, tearing down and rebuilding `key_to_handle`, the slab slot (new
handle), all four secondary indices, and cloning `SessionMetadata` ~3× — just to
bump `last_seen_ns`/`expires_after_ns`. This rewrites it (and
`refresh_for_ha_transition`) to mutate the slab record in place via `get_mut`,
touching the value-guarded secondary-index **removes** only when a key-relevant
input (`decision.nat` / `is_reverse` / `owner_rg_id`) actually changed. Secondary
**adds** are always re-asserted (byte-identical to `restore_entry`'s
unconditional `index_forward_nat_key`, incl. the reject branches and the
collision-displacement re-win). A stale-handle + primary-key guard mirrors
`remove_entry`'s release-mode safety nets.

Part of #1752 (Path E — the first lever; Paths B/A/C/D remain as tracked follow-ups, not closed by this PR).

## Perf (live, loss userspace cluster, `-P48 -p5210`)

Session-churn flat self-time, master → this branch:
- `hashbrown remove_entry`: **2.73% → 0.56%**
- `hashbrown insert`: **1.72% → 0.36%**
- ≈ **3.5 percentage points of CPU freed** (matches the plan's ~3–3.5% target).

Aggregate throughput unchanged within noise (15.9 vs 16.0 Gb/s, 0 retrans) — at
16 Gb/s CoS-on the binding constraint is the CoS shaping path, not this churn;
the change frees CPU headroom, which is why the plan anchors on CPU% not Gb/s.

## Plan + 3-way adversarial review (research convergence)

Plan doc: `docs/pr/1752-session-inplace-refresh/plan.md` (PLAN-READY @ `a983c6e59`).
- Codex: r1 NEEDS-MAJOR (collision re-assert + stale-handle guard) → r2
  NEEDS-MAJOR (reject-path re-assert) → r3 NEEDS-MINOR (handle-normalized test) — all folded.
- Gemini: r1 NEEDS-MINOR → r2/r3 PLAN-READY.
- Claude SMR: PLAN-READY.

## Test plan

- [x] cargo build clean (release)
- [x] cargo test --release: 1711 pass (full suite); 11 new differential tests
- [x] randomized differential test 5/5 flake-clean; single-threaded full suite clean
- [x] Go suite passes (2 unrelated tests fail only on the sandbox's >108-char unix `sun_path`; no Go files changed)
- [x] Deploy on loss userspace cluster (fw0 primary, fw1 secondary)
- [x] **Pass A — CoS disabled**: v4/v6 push+reverse on 5201, 0 retrans; `-P12 -R` line rate **v4 22.9 / v6 22.6 Gb/s**, 0 retrans
- [x] **Pass B — CoS enabled**: per-class 5201–5206 v4+v6 push+reverse — all 24 measurements 0 retrans; shaped classes hit caps (5201≈97M, 5202≈960M, 5203≈2.87G) cleanly
- [x] `make test-failover`: **13/13** — fw1 synced 65 sessions; sessions survived unclean reboot + manual failover
- [x] perf re-profile confirms the session-churn reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)