### PR TITLE
#1755: eliminate per-packet __rust_probestack frames on the CoS hot path

### DIFF
--- a/docs/pr/1755-cos-probestack/evidence.md
+++ b/docs/pr/1755-cos-probestack/evidence.md
@@ -1,0 +1,34 @@
+# #1755 codegen + validation evidence
+
+## Codegen proof (release build, `objdump -d -C`)
+
+Before (from research plan §2.1 / §2.2a, build-id f8949d18):
+- `cos_queue_push_back`: `sub $0x56000,%r11` (352 KB frame) + `__rust_probestack`
+  page-touch loop = ~61% of the fn's self-time on every push.
+- `ensure_cos_interface_runtime`: `sub $0x9000,%r11` (36 KB frame) + probe loop
+  on every ingress packet (~25% of fn self-time).
+
+After (this PR, `/dev/shm/cargo/release/xpf-userspace-dp`):
+
+| symbol | frame | probe loop? |
+|---|---|---|
+| `cos_queue_push_back` | `sub $0x18,%rsp` (24 B) | **gone** |
+| `promote_to_flow_fair` (cold) | `sub $0xb8,%rsp` (184 B) | none (new_boxed → heap) |
+| `cos_queue_push_front` (control) | `sub $0x58,%rsp` (88 B) | none |
+| `FlowFairState::new_boxed` | tiny, builds into heap | none |
+| `ensure_cos_interface_runtime` (outer, `#[inline]`) | inlined; no giant frame at the per-packet call site | none |
+| `ensure_cos_interface_runtime_cold` | `sub $0x9000,%r11` (36 KB) | present, but fires ≤ once per (binding, ifindex), NOT per packet |
+
+`grep -c __rust_probestack` over the whole binary = **0** call sites; the 36 KB
+inline probe loop now exists only inside the cold callee.
+
+## Tests
+- `cargo test --release` (userspace-dp): 1787 passed, 0 failed.
+- miri (`MIRIFLAGS=-Zmiri-disable-isolation cargo +nightly miri test
+  flow_fair_state_tests`): 2 passed, 0 failed — no UB in the unsafe
+  `new_boxed` constructor (uninit reads / borrow stacks clean).
+- 5× flake on `afxdp::cos::queue_ops`: 60 passed / 0 failed each run.
+- Go suite (`go test ./...`, short TMPDIR): 0 failures. The one failure under a
+  `/dev/shm` TMPDIR (`TestWireUserspaceEventStream…FullResync`) is the documented
+  unix-socket sun_path >108-char env artifact — passes on master and here with a
+  short `/tmp` TMPDIR.

--- a/docs/pr/1755-cos-probestack/plan.md
+++ b/docs/pr/1755-cos-probestack/plan.md
@@ -1,0 +1,379 @@
+# #1755 — CoS exact-guarantee hot-path CPU reduction (Path A of #1752)
+
+**Status: v2 (PLAN-READY — converged after round-1 review: Codex PLAN-READY for
+Change A / NEEDS-MAJOR if Change B unspecified; AGY PLAN-NEEDS-MAJOR for a second
+probe site; Claude SMR PLAN-READY). v2 folds in (1) the second live probe site
+`ensure_cos_interface_runtime` AGY found, (2) a properly-specified `MaybeUninit`
+heap constructor for Change B per Codex, (3) a ≥1 pp ship gate per all three.**
+
+**Recommendation: PLAN-READY for a narrow, fairness-neutral codegen lever —
+eliminate TWO live `__rust_probestack` frames on the per-packet path:
+`cos_queue_push_back` (352 KB) and `ensure_cos_interface_runtime` (36 KB).
+PLAN-KILL the issue's three schema/hash headline candidate sub-levers (flow-hash
+caching, structural-compare bypass, descriptor-indexed queuing) as
+not-the-dominant-cost and/or fairness-perturbing — they are the #1207/#1545 trap.
+The min-bucket O(1)/heap lever is PLAN-DEFER pending its own measured case.**
+
+## 1. Issue framing and the kill-risk it carries
+
+#1755 (Path A of the #1752 umbrella) targets the ~19% of `-P48 -p5210` CoS-on
+self-time attributed to the CoS exact-guarantee queue machinery. The issue text
+proposes four candidate sub-levers from the AGY umbrella review (flow-hash
+caching, structural-compare bypass, descriptor-indexed queuing, O(1) min-bucket)
+and explicitly flags that the CoS path has **two prior PLAN-KILLs** (#1207
+queue_service skeleton, #1545 mirror clone) and demands "a no-code-PLAN-KILL
+exit if the dominant sub-cost is irreducible per-packet enqueue work."
+
+This plan takes that exit seriously. It does **not** optimize from the umbrella
+doc's candidate list. It annotates the dominant sub-cost to a concrete reducible
+operation on the live cluster first, then picks the single most-tractable lever
+that the annotation actually supports — which turns out to be **none of the four
+headline candidates**.
+
+## 2. Live annotation — the dominant sub-cost is a codegen artifact, not per-packet algorithm work
+
+Method: loss userspace cluster, `BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env`.
+iperf3 `-c 172.16.80.200 -t180 -p 5210 -P 48` from `loss:cluster-userspace-host`
+(port 5210 → `iperf-24g` queue, `scheduler-24g transmit-rate 24.0g exact` — the
+exact-guarantee path the profile targets, confirmed via
+`show configuration class-of-service` + `cos-iperf-config.set` term 10).
+`perf record -F 1999` (flat) on the live `xpf-userspace-dp` (build-id
+`f8949d18…`, `/usr/local/sbin/xpf-userspace-dp`) for 10 s under load.
+
+Top CoS self-time (`perf report --no-children`, matches the issue's numbers):
+
+| symbol | self% |
+|---|---|
+| `cos_queue_push_back` | 5.94 |
+| `cos_queue_pop_front_inner_with_cap` | 3.64 |
+| `service_exact_guarantee_queue_direct_with_info` | 3.13 |
+| `ingest_cos_pending_tx_with_provenance` | 1.94 |
+| `publish_cos_exact_backlog` | 1.87 |
+| `drain_shaped_tx` | 1.63 |
+| `enqueue_cos_item` | 1.61 |
+| `account_cos_queue_flow_enqueue` | 0.79 |
+
+Evidence files: `evidence/flat-report.txt`, `evidence/pushback-annotate.txt`,
+`evidence/pop-annotate.txt`.
+
+### 2.1 `cos_queue_push_back` — ~61% of its self-time is a stack-probe loop, NOT queue work
+
+`perf annotate -s cos_queue_push_back` (verbatim in `evidence/pushback-annotate.txt`):
+
+```
+    0.14 :  3703aa: mov    %rsp,%r11
+    0.00 :  3703ad: sub    $0x56000,%r11          ; reserve 352 KB frame
+   10.98 :  3703b4: sub    $0x1000,%rsp           ; __rust_probestack touch loop
+    7.23 :  3703bb: movq   $0x0,(%rsp)            ;   zero a page
+   43.23 :  3703c3: cmp    %r11,%rsp              ;   loop until whole frame touched
+    0.03 :  3703c6: jne    3703b4 ...
+```
+
+**10.98 + 7.23 + 43.23 = 61.4% of `cos_queue_push_back`'s self-time** is the
+Rust large-stack-frame probe loop touching every page of a **352 KB
+(`0x56000`)** stack frame — on **every** call, including the >99.99% of calls
+that take the already-promoted fast path.
+
+Control: `cos_queue_push_front` (`evidence` objdump) has a **0x58 (88-byte)**
+frame and **no probe loop**. The two functions are structurally identical
+except push_back contains the lazy-promotion path
+(`maybe_promote_best_effort` → `promote_to_flow_fair` →
+`Box::new(FlowFairState::new(...))`, push.rs:42-86). `FlowFairState` is ~352 KB
+(`flow_bucket_bytes/head/tail/tx_bytes/observed_bps/last_tx_ns: [u64;4096]` =
+32 KB each, `flow_bucket_items: [VecDeque;4096]` = 128 KB inline headers,
+`flow_bucket_pending_bytes: [u32;4096]` = 16 KB — types/cos.rs:735-928).
+
+`FlowFairState::new()` returns the struct **by value**. Even though `new` is a
+separate symbol (`nm`: it is NOT inlined), its 352 KB return value must be
+materialized in `cos_queue_push_back`'s frame before the move into the `Box`
+allocation at push.rs:79. RVO does not elide it here because the value crosses
+the `promote_to_flow_fair` (`#[inline]`) → `cos_queue_push_back` boundary. So
+push_back reserves and probe-touches 352 KB on every packet.
+
+### 2.2 The exact path NEVER promotes at runtime — the probe is pure waste
+
+Exact-guarantee queues (the -P48 -p5210 path) are promoted to flow-fair
+**eagerly at build** (`admission.rs:526` `Some(Box::new(FlowFairState::new(...)))`),
+not via the lazy front-key probe (that is the #1735 best-effort path).
+`maybe_promote_best_effort` returns at push.rs:44 on the first
+`flow_fair_state.is_some()` check; `promote_to_flow_fair` is never reached at
+runtime on an exact queue. The 352 KB frame is reserved and probed anyway,
+purely because of the inlined-but-never-taken promotion path. This is the same
+class of defect the codebase already fixes elsewhere with
+`#[cold] #[inline(never)]` (`poll_descriptor/cookie_reply.rs:46`,
+`poll_descriptor/nat_exception.rs`, `tx/dispatch/mod.rs:17`).
+
+### 2.2a Second live probe site — `ensure_cos_interface_runtime` (36 KB, ingress per-packet) [AGY round-1]
+
+AGY round-1 found, and §`evidence/ensure-cos-iface-annotate.txt` confirms live, a
+**second instance of the identical defect** on the ingress/classify hot path:
+
+```
+000000000036f410 <…cos::builders::ensure_cos_interface_runtime>:
+    0.00 : 36f41d: sub    $0x9000,%r11          ; reserve 36 KB frame
+    5.42 : 36f424: sub    $0x1000,%rsp          ; probe loop
+    1.41 : 36f42b: movq   $0x0,(%rsp)
+   18.43 : 36f433: cmp    %r11,%rsp
+    0.00 : 36f436: jne    36f424 ...
+```
+
+5.42 + 1.41 + 18.43 = **25.3% of `ensure_cos_interface_runtime`'s self-time**
+(1.12% of total, `evidence/flat-report.txt`) is a 36 KB probe loop. Root cause is
+identical: `ensure_cos_interface_runtime` is `#[inline]` (builders.rs:21), is
+called per-packet from `tx/cos_classify.rs:443` and `:579` (before
+`enqueue_cos_item`), and inlines the cold builder branch
+(`build_cos_interface_runtime` → `CoSInterfaceRuntime` ~36 KB by value,
+builders.rs:51,66). The probe runs on every packet **before** the
+`cos_interfaces.contains_key` early-exit at builders.rs:37 — pure waste on the
+>99.99% hot path where the interface runtime already exists.
+
+This is the same fix pattern (out-line the cold builder) and is folded into the
+scope below.
+
+### 2.3 `cos_queue_pop_front` — self-time is the O(N) min-finish scan over active buckets
+
+`perf annotate` (verbatim in `evidence/pop-annotate.txt`): pop has a normal 0xf8
+frame (no probe). Its self-time concentrates in the
+`cos_queue_min_finish_bucket` linear scan (`36fae0`-`36fb43`): per active bucket
+it does `and $0xfff` (1.90%) + strided loads of `flow_bucket_head_finish_bytes`
+(`0x28028(%rbp,%rax,8)`, 1.12%) and `flow_bucket_observed_bps`
+(`0x40028(%rbp,%rax,8)`, 1.51%) — two cold-cache-line loads per bucket from the
+big arrays. With -P48 ≈ up to 48 active buckets this is the documented O(N)
+scan (`mod.rs:77-120`, whose own comment says "If we ever profile this as
+hot… replacement is a min-heap"). It is real per-packet algorithm work, ~1.5-2%
+of total, and touches the **selection key** — i.e. fairness-sensitive.
+
+## 3. Disposition of the issue's four headline candidate sub-levers
+
+The annotation refutes the umbrella doc's framing that "the dominant sub-cost is
+per-packet enqueue/dequeue (~9.2%)" as *algorithmic* enqueue/dequeue work. The
+dominant single line item is a **codegen stack-probe**, not the hash or the
+VecDeque ops.
+
+- **Flow-hash caching (headline candidate #1) — PLAN-KILL.** The 5-tuple hash
+  (`exact_cos_flow_bucket`) lives in `account_cos_queue_flow_enqueue` (0.79%
+  self-time, total across enqueue+dequeue ≤ ~1.5%) and a cold branch of
+  push_back (line 132, 0.00% in the annotate). Caching a `u32` bucket index in
+  `TxRequest`/`PreparedTxRequest` would: (a) save < ~1.5% best case; (b) be
+  **unsound across queue boundaries** — the bucket index is
+  `f(queue.flow_hash_seed, key)` and the seed is per-queue and re-drawn on every
+  promotion/demotion (`cos_flow_hash_seed_from_os`), so a cached index is only
+  valid for one (queue, seed) epoch; the #1735 demote/re-promote cycle and the
+  `promote_to_flow_fair` re-enqueue (push.rs:80-85) silently invalidate it.
+  Carrying a seed-tag to detect staleness reintroduces a compare and grows the
+  already-100+-byte `CoSPendingTxItem`. Low gain, real soundness risk → KILL.
+  *Note (Codex round-1):* a **safe local** reuse does exist — `cos_queue_push_back`
+  currently hashes the key twice within one call (once in
+  `account_cos_queue_flow_enqueue` at accounting.rs:29, once at push.rs:132) under
+  the same `ff.flow_hash_seed`; these could be computed once and threaded. That is
+  sound (single seed epoch, intra-call) but it is < 0.4 pp and not worth doing
+  before/with the probe fix; recorded for the #4-follow-up, not this PR.
+
+- **Structural-compare bypass in `maybe_promote_best_effort` (candidate #2) —
+  PLAN-KILL.** The annotate shows the `SessionKey` compare at push.rs:50 is a
+  short-circuiting SSE compare (`pcmpeqb`/`pmovmskb`, `3704…`) at **0.00%
+  self-time**. It is already cheap and is on the best-effort path, not the exact
+  path. The #785 hash-free contract (push.rs:19-41) is load-bearing: caching a
+  hash to bypass the structural compare reintroduces exactly the hash the #1183
+  fast-path was written to avoid. Negative value → KILL.
+
+- **Descriptor-indexed queuing (candidate #3) — PLAN-KILL (scope/risk).**
+  Queuing `u32` frame indices instead of `CoSPendingTxItem` is the #1545 trap
+  one level up: `CoSPendingTxItem::Local(TxRequest)` owns a `Vec<u8>` (locally
+  built frames, not yet in UMEM) and a `flow_key`; it is not reducible to a bare
+  descriptor without re-architecting the Local-vs-Prepared admission split
+  (the exact #1207 Local/Prepared asymmetry). The VecDeque ops are not the
+  dominant cost (the probe is). Large blast radius, no measured win → KILL.
+
+- **O(1) / min-heap min-bucket (candidate #4) — PLAN-DEFER.** This one is real
+  (§2.3) but it is ~1.5-2% and it touches the MQFQ selection key, so it is
+  fairness-sensitive and needs property-differential testing + a CoV-neutrality
+  gate. It is a separate, smaller, higher-risk PR. Defer to its own follow-up
+  after the §4 codegen win lands and is re-measured. Do **not** bundle it.
+
+## 4. The chosen lever — remove the two per-packet `__rust_probestack` frames
+
+Narrow, **fairness-neutral by construction** (it changes only where large
+temporaries are materialized; it does not touch any vtime, finish-time, bucket,
+active-count, V_min, or lease arithmetic, nor any classify decision).
+
+### 4.1 Design
+
+**Change A1 — out-line `promote_to_flow_fair`** (push.rs:77, the 352 KB
+push_back probe). Add `#[cold] #[inline(never)]`. `maybe_promote_best_effort`
+stays `#[inline]` (its hot path is the `is_some()` short-circuit + SSE key
+compare); only the genuinely-cold `promote_to_flow_fair` body out-lines.
+
+**Change A2 — out-line the cold builder branch of `ensure_cos_interface_runtime`**
+(builders.rs, the 36 KB ingress probe; AGY round-1). Keep the `#[inline]` outer
+fn doing only the `egress_ifindex <= 0` and `cos_interfaces.contains_key`
+early-exits, and move the `build_cos_interface_runtime` + insert/sort tail into a
+`#[cold] #[inline(never)] fn ensure_cos_interface_runtime_cold(...)`. The 36 KB
+`CoSInterfaceRuntime` by-value return then lives only in the cold callee's frame,
+which fires at most once per (binding, egress-ifindex) — not per packet.
+
+Both A1 and A2 are the same #1207-reviewer-endorsed salvage direction (out-line a
+cold large-stack body) and match the existing `#[cold] #[inline(never)]` sites
+(`cookie_reply.rs:46`, `nat_exception.rs`, `tx/dispatch/mod.rs:17`).
+
+**Change B — `MaybeUninit` heap constructor for `FlowFairState`** (Codex
+round-1; AGY wants it mandatory). Rust has **no guaranteed placement-new into
+`Box`**, so A1 alone may only *relocate* the 352 KB by-value return slot into
+`promote_to_flow_fair`'s frame rather than eliminate it. On the profiled exact
+path that is already sufficient (promote is build-time only), but to guarantee
+the giant frame never lands on any thread's stack (and to fix the build-time
+`admission.rs:526` site), add:
+
+```rust
+impl FlowFairState {
+    pub(in crate::afxdp) fn new_boxed(flow_hash_seed: u64) -> Box<Self> {
+        // SAFETY contract: build into an uninit heap allocation, writing
+        // every field exactly once via raw ptr writes, THEN assume_init.
+        // Per-field writes are mandatory — a zeroed Vec/VecDeque is NOT a
+        // valid initialized representation (Codex round-1 finding 3), so
+        // Box::new_zeroed + transmute is unsound. Use addr_of_mut! writes
+        // for the Vec/VecDeque fields and ptr::write_bytes(0) only for the
+        // [u64;N]/[u32;N] POD arrays. Drop-safety: no field is initialized
+        // twice; if a future panic is introduced between writes, guard with
+        // a drop-on-unwind scaffold or keep the body panic-free (it is —
+        // all writes are infallible).
+        ...
+    }
+}
+```
+
+Call `FlowFairState::new_boxed(seed)` at push.rs:79, admission.rs:526, and the
+`fairness.rs`/`test_support.rs` sites. **Change B is REQUIRED, not optional**
+(decision per §4.3 procedure): the by-value `new()` return slot is the actual
+352 KB temporary; A1 only moves which function reserves it. Keep `new()` as a
+thin `*Self::new_boxed(seed)` for any caller that genuinely needs an owned value
+(tests), or delete it if unused.
+
+**Implementation guard (Codex finding 3):** do NOT improvise Change B from a
+`Box::new_zeroed + field init` sketch. Use `Box<MaybeUninit<FlowFairState>>` +
+`addr_of_mut!` per-field writes + `assume_init`, miri-verified.
+
+### 4.2 Why this is not the #1207 trap
+
+#1207 was killed because its `#[inline(never)]` skeleton funneled the hot
+submit/settle path through a fn-pointer (`callq *(reg)`) and hit E0502 aliasing.
+This change does the **opposite**: it out-lines a **cold, rarely-taken**
+constructor away from the hot path. There is no fn-pointer, no hot-path
+indirection, no borrow restructuring. The hot path (already-promoted push_back)
+ends up *shorter* (no probe loop), not longer. It is the #1207 reviewer-endorsed
+salvage direction ("out-line the cold large-stack body"), applied to a different
+function.
+
+### 4.3 Expected gain + decision procedure
+
+push_back probe = 61.4% × 5.94% ≈ **3.65 pp**; ensure_cos_interface_runtime
+probe = 25.3% × 1.12% ≈ **0.28 pp**. Combined ceiling ≈ **~3.9 pp** total CPU on
+this profile — the single largest reducible line item on the whole -P48 -p5210
+CoS-on profile. The true number is whatever the post-change live annotate shows.
+
+**Decision procedure (resolves Codex/SMR/AGY F1 — Change B mandatory-ness is
+measured, not assumed):**
+1. Land A1 + A2 alone. `objdump`/annotate `cos_queue_push_back`,
+   `cos_queue_push_front`, `promote_to_flow_fair`, `ensure_cos_interface_runtime`,
+   and `ensure_cos_interface_runtime_cold`.
+2. If push_back has no probe and a < 1 KB frame AND no probe reappears in any
+   per-packet caller → A-only is sufficient; B becomes optional cleanup.
+3. If the 352 KB probe merely relocated into `promote_to_flow_fair` AND that
+   function is reachable per-packet on best-effort queues (it is, on 1↔2-flow
+   transitions, though rare with #1735 hysteresis), OR if any hot path still
+   probes → **Change B is mandatory**, implement the `MaybeUninit` constructor.
+4. Re-measure live A/B per §2 method.
+
+**Ship gate (all three reviewers converge): ≥ 1 pp** net total-CPU reduction at
+zero fairness/correctness risk is worth shipping (it's free codegen).
+**PLAN-KILL-acceptable exit:** if the post-change annotate shows the probe is
+genuinely irreducible (LLVM keeps the frame for an unavoidable reason) OR net win
+< ~1 pp, KILL with the evidence — measured-gain gate, not a hope.
+
+## 5. Correctness / fairness invariants preserved
+
+- No change to any byte/finish/vtime/active-count/lease/V_min arithmetic.
+- `flow_fair() == true ↔ flow_fair_state.is_some()` invariant untouched.
+- Exact-queue eager promotion (admission.rs:526) path semantics identical; only
+  the constructor's stack materialization site moves.
+- #1735 lazy best-effort promote/demote behavior identical (`promote_to_flow_fair`
+  body byte-identical, only its inline attribute changes).
+- The fairness-regimes CoV contract (`docs/fairness-regimes.md`) is unaffected —
+  this is a codegen-only change with zero selection-order impact.
+
+## 6. Validation plan
+
+1. **Differential / property tests:** the existing `push.rs`/`pop_tests.rs`/
+   `tests.rs`/`v_min_tests.rs` (≈ 4800 LOC of CoS queue tests) must pass
+   byte-for-byte. `promote_to_flow_fair` is exercised by the best-effort
+   promotion tests; assert they still pass. No new behavior to test — assert
+   absence of behavior change.
+2. **Codegen proof:** post-build `objdump`/`perf annotate` of BOTH
+   `cos_queue_push_back` AND `ensure_cos_interface_runtime` MUST show no
+   `__rust_probestack`/`sub $0x…,%r11` loop and a small frame (target < 1 KB).
+   Verify the relocated frame (if Change B is skipped) lives only in the
+   `_cold` callees. miri the `new_boxed` constructor. Capture before/after into
+   `evidence/`.
+3. **Live A/B:** re-run the §2 method (perf record under -P48 -p5210). Gate:
+   push_back self-time drops materially AND no probe re-appears elsewhere.
+4. **Full CoS smoke matrix** (per repo policy): v4 + v6 × push + `-R` ×
+   CoS-on + CoS-off, once-per-configured-class (5201-5211), on the loss
+   userspace cluster. No throughput regression, no per-class CoV regression
+   vs the structural ceiling.
+5. `cargo test` (userspace-dp) + `make test` green; miri on the touched module
+   if practical.
+
+## 7. Risk register
+
+| risk | severity | mitigation |
+|---|---|---|
+| LLVM re-inlines / the win doesn't materialize | med | gate on post-change annotate; KILL exit in §4.3 |
+| probe relocates to `promote_to_flow_fair` but that path is hot on best-effort queues | low | best-effort promote fires once per 1↔2-flow transition with #1735 hysteresis; not per-packet. Change B removes it entirely if needed |
+| `#[inline(never)]` pessimizes the cold promote path | negligible | promote is ~once per queue lifetime |
+| scope creep into candidates #1-#4 | med | this plan KILLs #1-#3, DEFERs #4 to its own PR |
+
+## 8. Scope boundary
+
+IN:
+- `userspace-dp/src/afxdp/cos/queue_ops/push.rs` — `#[cold] #[inline(never)]` on
+  `promote_to_flow_fair` (Change A1).
+- `userspace-dp/src/afxdp/cos/builders.rs` — split out
+  `ensure_cos_interface_runtime_cold` (Change A2).
+- `userspace-dp/src/afxdp/types/cos.rs` — `FlowFairState::new_boxed` `MaybeUninit`
+  constructor (Change B, mandatory per §4.3 if A relocates rather than
+  eliminates), and callers at admission.rs:526 / fairness.rs / test_support.rs.
+- Docs: stack-probe gotcha + `#[cold] #[inline(never)]` rationale in
+  `queue_ops/README.md` / module headers; the engineering-style hot-path note.
+
+OUT: flow-hash caching, structural-compare bypass, descriptor-indexed queuing
+(KILLed §3), min-bucket heap (DEFERed §3), any `TxRequest`/`CoSPendingTxItem`
+schema change, any service.rs skeleton change (#1207).
+
+## 9. PLAN-KILL conditions (explicit)
+
+KILL the whole issue (no code) if any of:
+- post-change annotate shows both probes are not removable (LLVM keeps the
+  frames for an unavoidable reason) — irreducible codegen.
+- removing them yields < ~1 pp net total-CPU win on the live A/B — churn > gain.
+- the only remaining lever after the codegen win is candidate #4 (min-bucket),
+  which is its own gated PR, so #1755 itself closes as "codegen win shipped,
+  residual is #4-follow-up" rather than staying open.
+
+## 10. Open questions for reviewers
+
+1. Is Change A (out-line `promote_to_flow_fair`) sufficient, or is Change B
+   (heap constructor) required to guarantee the by-value 352 KB return never
+   lands in a hot frame after future inlining churn?
+2. Is the ~2 pp net-CPU KILL gate the right bar given this is the single largest
+   line item, or should it be lower (≥1 pp) because it's zero-risk codegen?
+3. Should candidate #4 (min-bucket heap) be folded in now (it's the only *real*
+   algorithmic per-packet cost left) or strictly deferred? Argument for defer:
+   it touches the selection key and needs its own CoV-differential gate.
+
+## 11. Recommendation
+
+PLAN-READY for §4 (codegen stack-probe elimination) as the single tractable,
+high-confidence, fairness-neutral lever. PLAN-KILL the three schema/hash
+candidates (§3). PLAN-DEFER the min-bucket heap to a follow-up. This converts
+the "biggest but highest-risk" framing into "the biggest line item happens to be
+the lowest-risk fix, and the headline candidates are the trap."

--- a/userspace-dp/src/afxdp/cos/admission.rs
+++ b/userspace-dp/src/afxdp/cos/admission.rs
@@ -523,7 +523,10 @@ fn promote_cos_queue_flow_fair(
     // queues never pay the FlowFairState footprint or the per-packet
     // hash (the #1183 fast-path boundary).
     queue.flow_fair_state = if queue.config.exact {
-        Some(Box::new(FlowFairState::new(cos_flow_hash_seed_from_os())))
+        // #1755: new_boxed builds the ~352 KB FlowFairState directly into
+        // the heap, so the giant struct never lands on this build-time
+        // frame.
+        Some(FlowFairState::new_boxed(cos_flow_hash_seed_from_os()))
     } else {
         None
     };

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -37,6 +37,23 @@ pub(in crate::afxdp) fn ensure_cos_interface_runtime(
     if binding.cos.cos_interfaces.contains_key(&egress_ifindex) {
         return true;
     }
+    // #1755: the build/insert tail materialises a ~36 KB `CoSInterfaceRuntime`
+    // by value, which forces a `__rust_probestack` 36 KB-frame loop. With
+    // this `#[inline]` outer fn doing only the two early-exits above, that
+    // probe ran on EVERY ingress packet before the `contains_key` hot exit.
+    // Out-line the cold tail so the 36 KB frame lives only in the callee,
+    // which fires at most once per (binding, egress-ifindex).
+    ensure_cos_interface_runtime_cold(binding, forwarding, egress_ifindex, now_ns)
+}
+
+#[cold]
+#[inline(never)]
+fn ensure_cos_interface_runtime_cold(
+    binding: &mut BindingWorker,
+    forwarding: &ForwardingState,
+    egress_ifindex: i32,
+    now_ns: u64,
+) -> bool {
     let Some(config) = forwarding.cos.interfaces.get(&egress_ifindex) else {
         return false;
     };
@@ -47,19 +64,17 @@ pub(in crate::afxdp) fn ensure_cos_interface_runtime(
     {
         return false;
     }
-    {
-        let mut runtime = build_cos_interface_runtime(config, now_ns);
-        if let Some(iface_fast) = binding.cos.cos_fast_interfaces.get(&egress_ifindex) {
-            apply_cos_queue_flow_fair_promotion(
-                &mut runtime,
-                &iface_fast.queue_fast_path,
-                binding.worker_id,
-            );
-        }
-        binding.cos.cos_interfaces.insert(egress_ifindex, runtime);
-        binding.cos.cos_interface_order.push(egress_ifindex);
-        binding.cos.cos_interface_order.sort_unstable();
+    let mut runtime = build_cos_interface_runtime(config, now_ns);
+    if let Some(iface_fast) = binding.cos.cos_fast_interfaces.get(&egress_ifindex) {
+        apply_cos_queue_flow_fair_promotion(
+            &mut runtime,
+            &iface_fast.queue_fast_path,
+            binding.worker_id,
+        );
     }
+    binding.cos.cos_interfaces.insert(egress_ifindex, runtime);
+    binding.cos.cos_interface_order.push(egress_ifindex);
+    binding.cos.cos_interface_order.sort_unstable();
     true
 }
 

--- a/userspace-dp/src/afxdp/cos/queue_ops/push.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/push.rs
@@ -73,10 +73,20 @@ fn maybe_promote_best_effort(queue: &mut CoSQueueRuntime, incoming: &CoSPendingT
 /// v8 lease / V_min: non-exact queues carry `queue_lease_v8 == None`
 /// and `v_min.vtime_floor == None`, so the lease-mirror block in
 /// `account_cos_queue_flow_enqueue` is a no-op here (asserted in test).
-#[inline]
+///
+/// #1755: `#[cold] #[inline(never)]`. This is the only caller of the
+/// ~352 KB `FlowFairState` constructor on the push path; keeping it
+/// out-of-line ensures the giant-frame materialisation never inflates the
+/// hot `cos_queue_push_back` frame (it used to `__rust_probestack`-touch a
+/// 352 KB frame on EVERY push). Promotion fires at most once per
+/// best-effort-queue lifetime (#1735 hysteresis), so out-lining it has no
+/// hot-path cost. Paired with `FlowFairState::new_boxed`, which builds
+/// directly into the heap so even this cold frame stays small.
+#[cold]
+#[inline(never)]
 fn promote_to_flow_fair(queue: &mut CoSQueueRuntime) {
     let resident: VecDeque<CoSPendingTxItem> = std::mem::take(&mut queue.hot.items);
-    queue.flow_fair_state = Some(Box::new(FlowFairState::new(cos_flow_hash_seed_from_os())));
+    queue.flow_fair_state = Some(FlowFairState::new_boxed(cos_flow_hash_seed_from_os()));
     for item in resident {
         if matches!(item, CoSPendingTxItem::Local(_)) {
             queue.hot.local_item_count = queue.hot.local_item_count.saturating_sub(1);

--- a/userspace-dp/src/afxdp/tx/test_support.rs
+++ b/userspace-dp/src/afxdp/tx/test_support.rs
@@ -14,7 +14,7 @@ pub(in crate::afxdp) fn enable_test_flow_fair(queue: &mut CoSQueueRuntime) {
     // the state (which flips `flow_fair()` to true) and mark eligibility
     // so promotion/demotion-aware logic sees a coherent queue.
     queue.config.flow_fair_eligible = true;
-    queue.flow_fair_state = Some(Box::new(FlowFairState::new(0)));
+    queue.flow_fair_state = Some(FlowFairState::new_boxed(0));
 }
 
 pub(in crate::afxdp) fn disable_test_flow_fair(queue: &mut CoSQueueRuntime) {
@@ -468,7 +468,7 @@ pub(in crate::afxdp) fn test_flow_fair_exact_queue_16_flows() -> CoSInterfaceRun
     );
     let queue = &mut root.queues[0];
     queue.config.flow_fair_eligible = true;
-    queue.flow_fair_state = Some(Box::new(FlowFairState::new(0)));
+    queue.flow_fair_state = Some(FlowFairState::new_boxed(0));
     root
 }
 
@@ -588,7 +588,7 @@ pub(in crate::afxdp) fn attach_test_vtime_floor(
     queue.config.shared_exact = true;
     queue.config.flow_fair_eligible = true;
     if queue.flow_fair_state.is_none() {
-        queue.flow_fair_state = Some(Box::new(FlowFairState::new(0)));
+        queue.flow_fair_state = Some(FlowFairState::new_boxed(0));
     }
     floor
 }

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -947,9 +947,9 @@ impl FlowFairState {
     /// raw pointers, then `assume_init`s it. No giant temporary is ever
     /// created.
     ///
-    /// SAFETY contract (verified by `flow_fair_state_new_boxed_*` tests and
-    /// `cargo +nightly miri`):
-    ///   * Every one of the 12 fields is written exactly once below — keep
+    /// SAFETY contract (verified by the `flow_fair_state_tests` field-
+    /// equivalence test and `cargo +nightly miri`):
+    ///   * Every one of the 14 fields is written exactly once below — keep
     ///     this in lockstep with the struct definition and with `new()`.
     ///   * `flow_bucket_items` (`[VecDeque; N]`) and `pop_snapshot_stack`
     ///     (`Vec`) are NON-trivial types: a zeroed `Vec`/`VecDeque` is NOT a
@@ -964,10 +964,14 @@ impl FlowFairState {
     ///     temporary on the stack.
     ///   * The POD `[u64; N]` / `[u32; N]` arrays and scalars are zeroed via
     ///     `write_bytes`/`write(0)` to match `new()`'s `[0; N]` values.
-    ///   * Drop-safety: the body is panic-free (every write is infallible —
-    ///     allocation aside, which aborts/unwinds before any field is
-    ///     written), so no field is ever both initialised and then dropped
-    ///     on unwind. No drop-on-unwind scaffold is required.
+    ///   * Drop-safety: the body is panic-free. The two heap-allocating
+    ///     writes (`Box::new_uninit` for the struct, `Vec::with_capacity`
+    ///     for `pop_snapshot_stack`) abort on OOM rather than unwinding, and
+    ///     `Vec::with_capacity(TX_BATCH_SIZE)` cannot capacity-overflow
+    ///     (`TX_BATCH_SIZE` is a small fixed constant). Every other write is
+    ///     infallible. So no path unwinds through partially-initialised
+    ///     memory, and no field is ever both initialised and then dropped on
+    ///     unwind — no drop-on-unwind scaffold is required.
     pub(in crate::afxdp) fn new_boxed(flow_hash_seed: u64) -> Box<Self> {
         use std::ptr::addr_of_mut;
 

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -1351,7 +1351,11 @@ mod flow_fair_state_tests {
         assert_eq!(boxed.flow_bucket_items.len(), COS_FLOW_FAIR_BUCKETS);
         assert!(boxed.flow_bucket_items.iter().all(|q| q.is_empty()));
         assert!(boxed.pop_snapshot_stack.is_empty());
-        assert_eq!(boxed.pop_snapshot_stack.capacity(), TX_BATCH_SIZE);
+        // `with_capacity` guarantees AT LEAST the requested capacity; match
+        // the same `>=` contract `owned` (via `new()`) satisfies rather than
+        // pinning an exact value the allocator is free to round up.
+        assert!(boxed.pop_snapshot_stack.capacity() >= TX_BATCH_SIZE);
+        assert!(owned.pop_snapshot_stack.capacity() >= TX_BATCH_SIZE);
 
         // FlowRrRing zero-init equivalence (POD).
         assert!(boxed.flow_rr_buckets.is_empty());

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -908,6 +908,15 @@ pub(in crate::afxdp) struct FlowFairState {
 }
 
 impl FlowFairState {
+    /// Owned-value constructor. Retained for tests that genuinely need an
+    /// owned `FlowFairState` on the stack (`fairness.rs`/`worker/cos/tests.rs`).
+    ///
+    /// **Do not call this on any production/hot path.** `FlowFairState` is
+    /// ~352 KB; returning it by value forces the caller's frame to reserve
+    /// and `__rust_probestack`-touch the whole 352 KB (#1755). Production
+    /// promotion sites (`promote_to_flow_fair`, `admission.rs`,
+    /// `test_support.rs`) must use `new_boxed`, which builds directly into a
+    /// heap allocation so the giant temporary never lands on any stack frame.
     pub(in crate::afxdp) fn new(flow_hash_seed: u64) -> Self {
         Self {
             queue_vtime: 0,
@@ -924,6 +933,86 @@ impl FlowFairState {
             flow_bucket_observed_bps: [0; COS_FLOW_FAIR_BUCKETS],
             flow_bucket_last_tx_ns: [0; COS_FLOW_FAIR_BUCKETS],
             flow_bucket_pending_bytes: [0; COS_FLOW_FAIR_BUCKETS],
+        }
+    }
+
+    /// #1755 — heap constructor that builds `FlowFairState` directly into a
+    /// `Box` without ever materialising the ~352 KB struct on the stack.
+    ///
+    /// Rust has no guaranteed placement-new into `Box`, so the by-value
+    /// `new()` return slot is the actual 352 KB temporary that forces the
+    /// `__rust_probestack` 352 KB-frame loop in `cos_queue_push_back` /
+    /// `promote_to_flow_fair`. This constructor allocates an uninitialised
+    /// `Box<MaybeUninit<Self>>` and writes every field exactly once through
+    /// raw pointers, then `assume_init`s it. No giant temporary is ever
+    /// created.
+    ///
+    /// SAFETY contract (verified by `flow_fair_state_new_boxed_*` tests and
+    /// `cargo +nightly miri`):
+    ///   * Every one of the 12 fields is written exactly once below — keep
+    ///     this in lockstep with the struct definition and with `new()`.
+    ///   * `flow_bucket_items` (`[VecDeque; N]`) and `pop_snapshot_stack`
+    ///     (`Vec`) are NON-trivial types: a zeroed `Vec`/`VecDeque` is NOT a
+    ///     valid initialised representation, so they MUST be written with a
+    ///     real value (`VecDeque::new()` / `Vec::with_capacity`), never left
+    ///     to `write_bytes(0)`. `Box::new_zeroed().assume_init()` /
+    ///     transmute-from-zeroed would be UB for exactly this reason and is
+    ///     deliberately not used.
+    ///   * `flow_rr_buckets: FlowRrRing` is POD (`[u16; N]` + two `u16`)
+    ///     whose `Default` is all-zero; its bytes are zeroed in place
+    ///     (`write_bytes(0)`) rather than materialising an 8 KB `Default`
+    ///     temporary on the stack.
+    ///   * The POD `[u64; N]` / `[u32; N]` arrays and scalars are zeroed via
+    ///     `write_bytes`/`write(0)` to match `new()`'s `[0; N]` values.
+    ///   * Drop-safety: the body is panic-free (every write is infallible —
+    ///     allocation aside, which aborts/unwinds before any field is
+    ///     written), so no field is ever both initialised and then dropped
+    ///     on unwind. No drop-on-unwind scaffold is required.
+    pub(in crate::afxdp) fn new_boxed(flow_hash_seed: u64) -> Box<Self> {
+        use std::ptr::addr_of_mut;
+
+        let mut uninit: Box<std::mem::MaybeUninit<Self>> = Box::new_uninit();
+        // SAFETY: `ptr` points at a freshly-allocated, properly-aligned,
+        // uninitialised `FlowFairState`. Each `addr_of_mut!` derives a raw
+        // pointer to a distinct field without forming a reference to the
+        // uninitialised whole, and every field is written exactly once
+        // before `assume_init`. See the SAFETY contract above.
+        unsafe {
+            let ptr = uninit.as_mut_ptr();
+
+            // Scalars / small POD fields.
+            addr_of_mut!((*ptr).queue_vtime).write(0);
+            addr_of_mut!((*ptr).flow_hash_seed).write(flow_hash_seed);
+            addr_of_mut!((*ptr).active_flow_buckets).write(0);
+            addr_of_mut!((*ptr).active_flow_buckets_peak).write(0);
+
+            // POD bucket arrays — zeroed in place, matching `[0; N]`.
+            addr_of_mut!((*ptr).flow_bucket_bytes).write_bytes(0, 1);
+            addr_of_mut!((*ptr).flow_bucket_head_finish_bytes).write_bytes(0, 1);
+            addr_of_mut!((*ptr).flow_bucket_tail_finish_bytes).write_bytes(0, 1);
+            addr_of_mut!((*ptr).flow_bucket_tx_bytes).write_bytes(0, 1);
+            addr_of_mut!((*ptr).flow_bucket_observed_bps).write_bytes(0, 1);
+            addr_of_mut!((*ptr).flow_bucket_last_tx_ns).write_bytes(0, 1);
+            addr_of_mut!((*ptr).flow_bucket_pending_bytes).write_bytes(0, 1);
+
+            // POD ring (`[u16; N]` + two `u16`); `Default` == all-zero, so
+            // zero in place to avoid an 8 KB stack temporary.
+            addr_of_mut!((*ptr).flow_rr_buckets).write_bytes(0, 1);
+
+            // NON-trivial collection fields — MUST be written with real
+            // initialised values; a zeroed Vec/VecDeque is invalid.
+            //
+            // Write each `VecDeque` directly into its slot rather than via
+            // `array::from_fn`, which would materialise the full 128 KB
+            // `[VecDeque; N]` array as a stack temporary first — exactly the
+            // large-frame footgun this constructor exists to avoid.
+            let items = addr_of_mut!((*ptr).flow_bucket_items) as *mut VecDeque<CoSPendingTxItem>;
+            for i in 0..COS_FLOW_FAIR_BUCKETS {
+                items.add(i).write(VecDeque::new());
+            }
+            addr_of_mut!((*ptr).pop_snapshot_stack).write(Vec::with_capacity(TX_BATCH_SIZE));
+
+            uninit.assume_init()
         }
     }
 }
@@ -1216,3 +1305,79 @@ impl<'a> Iterator for FlowRrRingIter<'a> {
 //    larger constant would silently truncate.
 const _: () = assert!(COS_FLOW_FAIR_BUCKETS.is_power_of_two());
 const _: () = assert!(COS_FLOW_FAIR_BUCKETS <= u16::MAX as usize);
+
+#[cfg(test)]
+mod flow_fair_state_tests {
+    use super::*;
+
+    /// #1755: `new_boxed` must initialise every field to byte-for-byte the
+    /// same value as the by-value `new()` constructor. This is the
+    /// field-equivalence guard for the unsafe `MaybeUninit` builder — if a
+    /// field is added to `FlowFairState` and not written in `new_boxed`,
+    /// `assume_init` would read uninitialised memory; this test (run under
+    /// `cargo +nightly miri`) catches that as UB, and even without miri it
+    /// catches a value mismatch.
+    #[test]
+    fn new_boxed_matches_new_field_for_field() {
+        let seed = 0x1234_5678_9abc_def0_u64;
+        let owned = FlowFairState::new(seed);
+        let boxed = FlowFairState::new_boxed(seed);
+
+        assert_eq!(boxed.queue_vtime, owned.queue_vtime);
+        assert_eq!(boxed.flow_hash_seed, owned.flow_hash_seed);
+        assert_eq!(boxed.flow_hash_seed, seed);
+        assert_eq!(boxed.active_flow_buckets, owned.active_flow_buckets);
+        assert_eq!(boxed.active_flow_buckets_peak, owned.active_flow_buckets_peak);
+        assert_eq!(boxed.flow_bucket_bytes, owned.flow_bucket_bytes);
+        assert_eq!(
+            boxed.flow_bucket_head_finish_bytes,
+            owned.flow_bucket_head_finish_bytes
+        );
+        assert_eq!(
+            boxed.flow_bucket_tail_finish_bytes,
+            owned.flow_bucket_tail_finish_bytes
+        );
+        assert_eq!(boxed.flow_bucket_tx_bytes, owned.flow_bucket_tx_bytes);
+        assert_eq!(boxed.flow_bucket_observed_bps, owned.flow_bucket_observed_bps);
+        assert_eq!(boxed.flow_bucket_last_tx_ns, owned.flow_bucket_last_tx_ns);
+        assert_eq!(boxed.flow_bucket_pending_bytes, owned.flow_bucket_pending_bytes);
+
+        // Collection fields: every bucket queue is a real, empty VecDeque;
+        // the pop-snapshot stack is empty with the preallocated capacity.
+        assert_eq!(boxed.flow_bucket_items.len(), COS_FLOW_FAIR_BUCKETS);
+        assert!(boxed.flow_bucket_items.iter().all(|q| q.is_empty()));
+        assert!(boxed.pop_snapshot_stack.is_empty());
+        assert_eq!(boxed.pop_snapshot_stack.capacity(), TX_BATCH_SIZE);
+
+        // FlowRrRing zero-init equivalence (POD).
+        assert!(boxed.flow_rr_buckets.is_empty());
+        assert_eq!(boxed.flow_rr_buckets.len(), owned.flow_rr_buckets.len());
+        assert_eq!(boxed.flow_rr_buckets.front(), owned.flow_rr_buckets.front());
+    }
+
+    /// Exercise the collection fields enough to prove they are genuinely
+    /// initialised (a zeroed VecDeque would UB/abort here, not silently
+    /// pass) — reserve/push on a couple of buckets and the snapshot stack.
+    #[test]
+    fn new_boxed_collections_are_usable() {
+        let mut boxed = FlowFairState::new_boxed(7);
+        // Reserving + reading capacity touches the VecDeque's internal
+        // raw-vec pointer/cap; a zeroed VecDeque would be invalid here.
+        boxed.flow_bucket_items[0].reserve(4);
+        boxed.flow_bucket_items[COS_FLOW_FAIR_BUCKETS - 1].reserve(4);
+        assert!(boxed.flow_bucket_items[0].capacity() >= 4);
+        assert!(boxed.flow_bucket_items[COS_FLOW_FAIR_BUCKETS - 1].capacity() >= 4);
+        assert_eq!(boxed.flow_bucket_items[0].len(), 0);
+
+        boxed.pop_snapshot_stack.push(CoSQueuePopSnapshot {
+            bucket: 3,
+            pre_pop_head_finish: 10,
+            pre_pop_tail_finish: 20,
+            pre_pop_queue_vtime: 30,
+        });
+        assert_eq!(boxed.pop_snapshot_stack.len(), 1);
+        assert_eq!(boxed.pop_snapshot_stack[0].bucket, 3);
+        // Dropping `boxed` here drops all 4096 VecDeques + the Vec; under
+        // miri this proves every collection field is a valid drop target.
+    }
+}


### PR DESCRIPTION
## Summary

Path A of #1752. Codegen-only, **zero CoS-fairness-algorithm change**.

The `-P48 -p5210` CoS-on profile attributed ~19% of self-time to the CoS
exact-guarantee queue machinery. Live annotation showed the dominant single
line item is not algorithmic enqueue work — it is a Rust large-stack-frame
`__rust_probestack` page-touch loop, run on **every** packet:

- `cos_queue_push_back` reserved a **352 KB** frame (`sub $0x56000,%r11`) +
  probe loop = ~61% of its self-time, because the inlined (but at runtime
  never-taken) `promote_to_flow_fair` materialised the ~352 KB `FlowFairState`
  by value.
- `ensure_cos_interface_runtime` reserved a **36 KB** frame + probe loop on
  every ingress packet (the cold builder materialises `CoSInterfaceRuntime`
  by value), before the `contains_key` hot early-exit.

## Changes (logical commits)

- **B** — `FlowFairState::new_boxed(seed) -> Box<Self>`: builds the ~352 KB
  struct directly into a `Box<MaybeUninit<Self>>` via `addr_of_mut!` per-field
  writes + `assume_init`, so the giant struct never lands on any stack frame.
  POD arrays/scalars + the POD `FlowRrRing` are zeroed in place; the
  `[VecDeque;4096]` (per-slot loop, no 128 KB temporary) and `Vec` fields are
  written with real values (a zeroed Vec/VecDeque is invalid — new_zeroed
  would be UB and is avoided). Panic-free body, no drop scaffold needed.
- **A1** — `promote_to_flow_fair` marked `#[cold] #[inline(never)]` and switched
  to `new_boxed`. `maybe_promote_best_effort` stays `#[inline]`.
- **A2** — `ensure_cos_interface_runtime` keeps a tiny `#[inline]` outer fn
  (early-exits only); the build/insert tail moves to a new
  `#[cold] #[inline(never)] ensure_cos_interface_runtime_cold`.

No vtime/finish/active-count/lease/V_min arithmetic or classify decision
changes. The `flow_fair() ↔ flow_fair_state.is_some()` invariant is untouched.

## Perf delta (codegen proof)

`objdump -d -C` on the release binary:

| symbol | before | after |
|---|---|---|
| `cos_queue_push_back` | `sub $0x56000,%r11` (352 KB) + probe loop | `sub $0x18,%rsp` (24 B), **no probe** |
| `ensure_cos_interface_runtime` (per-packet) | 36 KB frame + probe loop | inlined, no giant frame; 36 KB lives only in `_cold` callee (≤1×/ifindex) |

Whole-binary `__rust_probestack` call sites: **0**. Live `-P48 -p5210` CoS-on
`perf report`: **0 probestack frames**; `cos_queue_push_back` annotate shows no
probe-loop instructions. The probe component (~61% of push_back self-time) is
eliminated; residual self-time is genuine queue work.

## Test plan

- `cargo test --release` (userspace-dp): 1787 passed, 0 failed.
- miri on `new_boxed` (`flow_fair_state_tests`): clean — no uninit/UB.
- 5× flake on `afxdp::cos::queue_ops`: 60/0 each run.
- Go `go test ./...`: 0 failures (short TMPDIR; the `/dev/shm` unix-socket
  sun_path>108 failure is the documented env artifact).
- Smoke matrix on loss userspace cluster:
  - Pass A (CoS off): v4+v6 push+`-R` on 5201 (0 retrans); `-P12 -R` line-rate
    22.8 Gb/s v4 / 22.5 Gb/s v6.
  - Pass B (CoS on): per-class 5201-5206 v4+v6 push+`-R`, shaped classes hit
    caps (100m→95.8M, 1g→952M, 3g→2.86G, 6g→5.69G), 0 retrans on forward paths.
  - `-P48 -p5210` CoS-on: 14.7 Gb/s, 0 retrans.
- `make test-failover`: 13 passed, 0 failed.

Closes #1755
Part of #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)