### PR TITLE
#1763: fuse MQFQ select+pop, no-cap min-finish fast path (Path 1)

### DIFF
--- a/docs/pr/1763-fused-minfinish/plan.md
+++ b/docs/pr/1763-fused-minfinish/plan.md
@@ -1,0 +1,322 @@
+# #1763 — Residual addressable CPU levers (post-#1753/#1755/#1760)
+
+Research-only plan. Stops at PLAN-READY or PLAN-KILL. No production code is
+touched here. Sub-path of #1752.
+
+## 1. Problem statement
+
+After #1753 (session in-place), #1755 (CoS probestack removal) and #1760
+(collision counter) merged, a fresh profile on the loss userspace cluster shows
+throughput 16.0 → 16.6 Gb/s with **all 6 cores 99-100% busy** — the 6/6
+no-headroom ceiling (#1757). Mutex contention is already ruled out (workers
+`futex_wait` 2×/10s; the only contended kernel lock is `rtnl_mutex`, off the
+forwarding path). This research evaluates the two residual *addressable*
+software levers the issue names, and is explicit up front that **PLAN-KILL on
+both — documenting why the residual is the floor — is a valid and expected
+outcome.**
+
+- **Path 1 (primary):** `cos_queue_pop_front_inner_with_cap` → the O(N)
+  `cos_queue_min_finish_bucket` linear scan over active flow buckets per
+  dequeue (MQFQ head-finish selection). Reported ~3.84%, now the largest CoS
+  sub-cost.
+- **Path 2 (secondary):** neighbor-dispatch / `rtnl_mutex` netlink churn —
+  `learn_dynamic_neighbor_from_packet` (0.36%) + `retry_pending_neigh` (0.19%),
+  reportedly driving ~45 netlink/rtnl ops/s at steady state.
+
+## 2. Code under study (master @ 4feab15ef)
+
+### 2.1 Path 1 — the min-finish scan
+
+`userspace-dp/src/afxdp/cos/queue_ops/mod.rs:101` `cos_queue_min_finish_bucket`:
+
+```rust
+for bucket in ff.flow_rr_buckets.iter() {
+    let b = usize::from(bucket);
+    let finish = ff.flow_bucket_head_finish_bytes[b];   // strided u64 load
+    if finish < fallback_finish { fallback_finish = finish; fallback = Some(bucket); }
+    let observed = ff.flow_bucket_observed_bps[b];       // 2nd strided u64 load
+    if observed <= target_bps && finish < eligible_finish { ... }
+}
+eligible.or(fallback)
+```
+
+Called from `cos_queue_pop_front_inner_with_cap` (pop.rs:81), `cos_queue_front`
+(mod.rs:136) and `cos_queue_front_with_cap` (mod.rs:158). The scan iterates the
+active ring `flow_rr_buckets` (a `FlowRrRing`, `types/cos.rs:171`: fixed `[u16;
+4096]` ring, O(1) push/pop, **O(len) `remove`**). Per dequeue the cost is the
+scan (O(len)) PLUS, when a bucket drains to empty, `FlowRrRing::remove`
+(types/cos.rs:286, another O(len) shift). Two strided loads per bucket from two
+4096-entry `[u64; …]` arrays (`flow_bucket_head_finish_bytes`,
+`flow_bucket_observed_bps`) — different cache lines, so each active bucket can
+cost up to two L1/L2 misses on a cold working set.
+
+This is the deferred candidate #4 from the #1755 plan (§2.3 / §3): "real,
+~1.5-2%, touches the MQFQ **selection key**, fairness-sensitive, needs
+property-differential + CoV-neutrality gate, do **not** bundle." It is the
+#1207/#1545 trap one level up: any structure that changes *which* bucket wins
+ties or perturbs the head-finish ordering is a fairness correctness regression.
+
+### 2.2 Path 2 — neighbor netlink writes
+
+`userspace-dp/src/afxdp/poll_stages.rs:72` `stage_link_layer_classify` calls
+`add_kernel_neighbor` (neighbor.rs:214) on **every transiting ARP-Reply / NDP-NA
+frame**, with NO per-key dedup or rate-limit (unlike the warmer's
+`WARM_PER_KEY_RATE_LIMIT_NS = 5 s`). `add_kernel_neighbor` does
+`socket(AF_NETLINK) + sendto(RTM_NEWNEIGH) + close()` (3 syscalls + a `vec!`
+alloc) per call; `RTM_NEWNEIGH` is the `rtnl_mutex` acquisition.
+`learn_dynamic_neighbor_from_packet` (neighbor_dispatch.rs:288) and
+`learn_dynamic_neighbor` (:336) only mutate the **in-process** `ShardedNeighborMap`
+(`with_all_shards`) — no syscalls. `retry_pending_neigh`
+(neighbor_dispatch.rs:47) walks `binding.pending_neigh` post-poll; it is a no-op
+early-return when the queue is empty (`:60`).
+
+## 3. Live measurements (loss:xpf-userspace-fw0, primary, master @ 4feab15ef)
+
+Environment: `BPFRX_CLUSTER_ENV=test/incus/loss-userspace-cluster.env`. fw0 is
+RG primary (forwarding-active). CoS loaded (`show class-of-service interface`
+→ reth0.80, 12 exact iperf-* queues + best-effort). iperf3 from
+`cluster-userspace-host` → 172.16.80.200.
+
+### 3.1 Path 1 — active flow bucket count N (the decisive number)
+
+`active_flow_buckets_peak` is a per-queue, owner-only, MAX-only,
+lifetime-monotonic counter (`types/cos.rs:781`, only ever `peak = max(peak,
+active)`; aggregated MAX across workers in coordinator/mod.rs:1143; reset only on
+`FlowFairState` (re)alloc). Exact queues promote eagerly and stay promoted, so
+their peak is a true lifetime maximum. Read live from
+`/run/xpf/userspace-dp.json`.
+
+| Run | Offered flows | Realized SUM | Peak `active_flow_buckets` (max over all exact queues) |
+|-----|---------------|--------------|--------------------------------------------------------|
+| iperf3 `-P48 -p5210` | 48 TCP | ~9.4 Gb/s | **14** |
+| iperf3 `-P12 -p5210` | 12 TCP | ~6.2 Gb/s | **14** (lifetime max unchanged; ≤14 at -P12) |
+
+**N peaks at 14 active flow buckets even under -P48.** The 48 offered TCP flows
+never produce >14 concurrently-backlogged buckets: the per-class exact queue
+drains faster than flows accumulate, so the instantaneous active set is small.
+This is well below the per-flow-spread expectation in the counter's own contract
+doc (`active_flow_buckets_peak >= N` for `-P N`); under a single exact class the
+backlog set is the bottleneck, not the hash spread.
+
+### 3.2 Path 1 — self-time
+
+`perf report -i perf_p48.data --no-children` (worker threads 2000-2005, -F999,
+20 s during -P48): `cos_queue_pop_front_inner_with_cap` = **4.28% self-time**
+(matches the issue's ~3.84%; the inlined `cos_queue_min_finish_bucket` is the
+dominant inner cost per #1755 §2.3 annotate). For reference,
+`poll_binding_process_descriptor` = 8.93% (NOT addressable, our per-packet
+dispatch). The `mlx5_crypto_dek_pool_remove_bulk` / `mlx5_crypto_modify_dek_key`
+caller edges in the callgraph are the **known symbolization artifact** (broken
+frame unwind under the BPF prog), not a real caller — self-times are the
+trustworthy figures.
+
+### 3.3 Path 2 — netlink / rtnl ops rate
+
+bpftrace kprobes on `neigh_add` (the RTM_NEWNEIGH netlink handler — the
+`rtnl_mutex` path) and `__neigh_update` (all neighbor-state updates):
+
+| Window (under load) | `neigh_add` (RTM_NEWNEIGH netlink) | `__neigh_update` (all) |
+|---------------------|------------------------------------|------------------------|
+| 30 s steady -P12 | **0** | 56 (≈1.9/s, kernel-internal) |
+| 20 s, 8× short reconnect churn | **0** | 49 (≈2.4/s) |
+
+`add_kernel_neighbor`'s netlink write fires **0 times/s** at steady state and
+even under connection churn — once a neighbor is resolved in the kernel table,
+no further ARP-Reply/NDP-NA frames transit, so `stage_link_layer_classify` never
+re-fires the netlink write. The `~45 ops/s` in the issue body was a **transient**
+(cold-start ARP/NDP resolution burst), not a steady-state forwarding cost. The
+`rtnl_mutex` contention `perf lock` saw (227 acq/5 s, 16.9 ms wait) is real but
+is control-plane / cold-start, off the forwarding hot path, and does not recur
+during the saturated transfer.
+
+## 4. Disposition
+
+### Path 1 — PLAN-READY (fused select+pop, NOT a heap)
+
+**The data-structure framing is a KILL; the redundant-work framing is a
+PLAN-READY win.** Round-1 hostile review (Codex + AGY + Claude SMR) converged:
+replacing the scan with a heap/incremental-pointer/SoA structure is correctly
+killed at N=14, but the scan **runs twice per successful dequeue** on both hot
+paths and that redundancy is a safe, fairness-neutral lever.
+
+**Why the heap idea is dead (KILL retained for that sub-option):** N peaks at 14
+(§3.1). At N=14 a min-heap is no faster — the head-finish key mutates on every
+pop (pop.rs:163), forcing a re-heapify per dequeue, and the `eligible`/`fallback`
+two-pass (over-cap skip, mod.rs:114) cannot be a single-key heap. The
+`FlowRrRing` is a flat `[u16; …]`; 14 contiguous u16s are one cache line. An
+incremental min-pointer is invalidated on every pop (winning bucket's key
+advances). Structure replacement: KILL.
+
+**The actual lever — fuse the double scan (Codex/AGY/SMR-verified):** both hot
+drain paths peek then pop with NO queue mutation between, so the second scan
+re-derives the identical bucket:
+
+- Cap-aware drain: `cos_queue_front_with_cap` (drain.rs:209, and Prepared :461)
+  → inspect len/type/mirror_clone → `cos_queue_pop_front_with_cap` (drain.rs:234,
+  :472) re-scans. `target_bps` is sampled once and constant for the batch
+  (drain.rs:206-208) → same winner both times.
+- No-cap best-effort builder: `cos_queue_front` (mod.rs:1605/1646) →
+  `cos_queue_pop_front` (mod.rs:1617/1658) re-scans.
+
+Each `front*`/`pop*` calls `cos_queue_min_finish_bucket` (mod.rs:81/136/158), so
+the 4.28% pop self-time pays the scan **once for the peek and once for the pop**.
+
+Two complementary, composable sub-levers, both **fairness-neutral by
+construction** (they reuse the exact same scan result / skip provably-dead work;
+they do not touch selection order, the head-key advance, the cap arithmetic, or
+the eligible/fallback semantics):
+
+- **Lever A — fused `peek_min_bucket` + `pop_known_bucket(bucket)`.** Peek
+  returns the *bucket id*; the caller inspects `flow_bucket_items[bucket].front()`
+  for len/type/budget/mirror gating; if it commits, `pop_known_bucket` pops that
+  exact bucket with NO re-scan. Removes one full scan per committed pop. The
+  abandon paths (drain.rs:217 budget break, :221 mirror reserve) stay at exactly
+  1 scan (same as today) → strictly non-regressing. A `debug_assert` that the
+  known bucket is still the active-front guards the no-mutation invariant.
+- **Lever B — `target_bps == u64::MAX` no-cap fast path.** For every
+  `cos_queue_front`/`cos_queue_pop_front` caller (the whole best-effort builder,
+  mod.rs:1597-1658), `observed <= u64::MAX` is always true so `eligible ==
+  fallback` always — the `flow_bucket_observed_bps` load (mod.rs:113) and the
+  two-pass are dead. A no-cap branch that scans only
+  `flow_bucket_head_finish_bytes` removes the second strided big-array load per
+  bucket (the two arrays are on different cache lines), halving the per-bucket
+  cache-miss exposure with zero ordering change.
+
+Combined, a fused no-cap pop does ~1 single-array O(14) scan instead of 2
+double-array O(14) scans on the best-effort path (up to ~3-4× less scan work);
+the cap-aware path gets Lever A's ~2× on the scan. Realistic upside on the 4.28%
+is meaningful and the change is fairness-neutral by construction.
+
+**Risk gate (mandatory before merge):** property-differential test (fused vs
+current produce byte-identical dequeue order on randomized backlogs incl.
+over-cap mixes and equal-depth flows), CoV-neutrality on the full
+v4/v6 × push/-R × CoS-on matrix, `make test-failover` (exact-queue HA sync), and
+a live re-measure of pop self-time to confirm the win. This is a separate,
+narrow PR — do NOT bundle with anything else.
+
+### Path 2 — PLAN-KILL
+
+`neigh_add` (the netlink/`rtnl_mutex` write) fires **0/s** at steady state and
+under churn. `learn_*` (0.31%) and `retry_pending_neigh` (0.18%) are in-process
+map / empty-queue-early-return work, not netlink. There is no steady-state
+netlink churn to batch, cache, or rate-limit; the issue's 45 ops/s was a
+cold-start transient. A latent hardening opportunity exists (the
+`stage_link_layer_classify` netlink write at poll_stages.rs:92/113 has no
+per-key dedup, unlike the warmer's 5 s rate-limit, so a pathological ARP-Reply
+flood *could* storm `rtnl_mutex`), but it does not fire on the forwarding hot
+path at steady state and is a robustness item, not a throughput lever. KILL for
+throughput; note the dedup gap for a possible separate robustness issue.
+
+## 5. Why the rest of the residual is the floor
+
+After the Path 1 fused-scan win, the remaining worker time is: driver RX
+(`mlx5e_xsk_skb_from_cqe_linear` + `xp_raw_get_dma` + irq/poll_rx_cq ≈ inherent
+~16% at 1.39 Mpps — not addressable), the per-packet poll dispatch
+(`poll_binding_process_descriptor` 8.93% — our own per-packet work, not a clean
+lever), and the irreducible single min-finish scan (an O(14) selection that no
+structure beats). Removing the *redundant* second scan is the one clean software
+lever; the single scan itself, the RX path, and the poll dispatch are the floor
+on this 6/6 box.
+
+## 6. Alternatives considered (Path 1) — all structure-replacement options rejected; the chosen lever (§4) is redundant-scan removal, not any of these
+
+- **Min-heap keyed by head-finish:** rejected — key mutates every pop →
+  re-heapify per dequeue; cannot express the eligible/fallback two-pass; pointer
+  chasing worse than a 14-entry contiguous scan.
+- **Incremental min-pointer:** rejected — invalidated on every pop; degenerates
+  to re-scan.
+- **≤1-active-bucket short-circuit:** marginal — only helps when N≤1, but the
+  hot regime is N≈14, and a `len()==1` branch adds a per-pop compare to the
+  N≥2 common case for zero benefit there. Not worth a fairness-gated PR.
+- **Two strided arrays → struct-of-arrays packing (one cache line per bucket):**
+  the only *structurally* plausible micro-win (co-locate head_finish +
+  observed_bps so one line serves both loads). Still touches the selection data
+  layout, still fairness-gated, ≤~1% best case, and risks the 4096-entry array
+  sizing / `CoSQueueRuntime` ~232 KB box. Not worth it on a 6/6 box. Recorded,
+  not proposed.
+
+## 7. Risks of acting anyway
+
+Perturbing MQFQ selection ordering regresses the per-class exact guarantees and
+the equal-flow / surplus-sharing equalizers (#911/#915/#1743/#1745) that took
+many cycles to stabilize. The blast radius (every CoS dequeue, every HA-synced
+exact queue) is large; the measured win is zero-to-negative at N=14.
+
+## 8. Test / validation plan (if a lever had survived — it did not)
+
+For the record, any Path 1 change would have required: property-differential
+test (old vs new selection produces identical dequeue order on randomized
+backlogs), a CoV-neutrality gate (per-flow CoV unchanged within noise on the
+full v4/v6 × push/-R × CoS-on matrix), and `make test-failover` (touches HA
+exact-queue sync). None run because both paths KILL.
+
+## 9. Measurements appendix (raw)
+
+- `active_flow_buckets_peak` peak = 14 (qid with iperf-* exact class) under -P48
+  and -P12, read from `/run/xpf/userspace-dp.json` (monotonic lifetime max).
+- `perf report` worker self-time: pop 4.28%, poll_descriptor 8.93%,
+  account_enqueue 0.68%, push_back 0.55%, learn_dynamic_neighbor 0.31%,
+  retry_pending_neigh 0.18%.
+- `neigh_add` kprobe = 0 over 30 s steady + 20 s churn; `__neigh_update` ≈ 2/s
+  (kernel-internal).
+- Callgraph `mlx5_crypto_*` edges = symbolization artifact (validated against
+  self-time + the #1755 cautionary note); not a real caller.
+
+## 10. Recommendation
+
+**Path 1: PLAN-READY. Path 2: PLAN-KILL.**
+
+Path 1 — the *heap* idea is dead (N=14 measured under -P48; a heap is no faster
+and the selection key is the #1207/#1545 fairness trap), but the min-finish scan
+**runs twice per dequeue** on both hot paths (peek then pop, no mutation
+between). Fusing them (Lever A: `peek_min_bucket` + `pop_known_bucket`) plus a
+`target_bps == u64::MAX` no-cap fast path (Lever B: skip the dead
+`observed_bps` load + fallback pass) removes the redundant scan / dead load,
+fairness-neutral by construction, up to ~3-4× less scan work on the best-effort
+path against the 4.28% pop self-time. **`/engineer 1763` is warranted for this
+narrow, gated refactor.** Do NOT replace the data structure with a heap.
+
+Path 2 — KILL. The netlink/rtnl `neigh_add` write fires **0/s** at steady state
+and under churn (measured); the issue's 45 ops/s was a cold-start ARP/NDP
+transient. No steady-state churn to batch. Separately, file a low-priority
+robustness issue for the missing per-key dedup on the `stage_link_layer_classify`
+netlink write (poll_stages.rs:92/113, ARP-flood hardening) — unrelated to
+throughput.
+
+Measured active-bucket N (Path 1): **14** (peak under iperf3 -P48, exact queue).
+
+## 11. Reviewer verdicts
+
+### Round 1 (against v1, which had killed both paths)
+
+All three reviewers KILLED the v1 Path-1 KILL and confirmed Path-2 KILL.
+
+- **Codex (foreground, task this session):** "PLAN-KILL-THE-KILL. Path 2 KILL
+  stands, but Path 1 KILL is defective. The plan argues heap vs linear scan, but
+  misses a safer lever: the hot drain paths do the same min-finish selection
+  twice, back-to-back, before one pop." Quoted the front+pop pairs at
+  drain.rs:209/234, drain.rs:461/472, mod.rs:1605/1617. "A fused
+  select/check/pop helper can preserve the exact MQFQ key and tie behavior while
+  removing one full scan per successful pop. No heap, no new ordering, no
+  eligible/fallback semantic change." Confirmed N=14 not undercut by #1735
+  (exact queues return before demotion at mod.rs:223). Confirmed `neigh_add` is
+  the correct RTM_NEWNEIGH kprobe (neighbour.c:3916 registration, RTNL assert).
+
+- **AGY (background adversarial-review-mpz0f3xy-diho0y):** PLAN-KILL-THE-KILL.
+  Confirmed Path 2 KILL and the `neigh_add` kprobe. For Path 1 proposed a
+  complementary lever: split a `target_bps == u64::MAX` no-cap fast path that
+  loads only `flow_bucket_head_finish_bytes` and skips `flow_bucket_observed_bps`
+  + the eligible/fallback pass — "reducing memory loads and cache-line misses by
+  50% per active bucket… does not alter selection priority or equal-share
+  ordering… no data-structure layout changes." Confirmed exact queues never
+  demote/reset peak.
+
+- **Claude SMR (claude-smr-plan-r1.md):** PLAN-NEEDS-WORK. v1 evaluated only
+  data-structure replacement and never asked how many times the scan runs per
+  pop — it runs twice on both hot paths. Endorsed both Lever A (fuse) and Lever
+  B (no-cap fast path) as complementary and composable, fairness-neutral by
+  construction; required property-differential + CoV-neutrality + test-failover
+  gates and a non-regression contract for the peek-then-abandon paths.
+
+**Convergence:** 3/3 → Path 1 PLAN-READY (fused select+pop + no-cap fast path,
+NOT a heap), Path 2 PLAN-KILL. v2 incorporates both levers and the gates.

--- a/docs/pr/1763-fused-minfinish/reviewer-ids.md
+++ b/docs/pr/1763-fused-minfinish/reviewer-ids.md
@@ -1,0 +1,5 @@
+# #1763 PR #1764 reviewer IDs
+
+- AGY adversarial: adversarial-review-mpz2di7a-yjtwp7
+- Gemini: (background, see below)
+- Codex: (foreground)

--- a/docs/pr/1763-fused-minfinish/reviewer-ids.md
+++ b/docs/pr/1763-fused-minfinish/reviewer-ids.md
@@ -1,5 +1,7 @@
-# #1763 PR #1764 reviewer IDs
+# #1763 PR #1764 reviewer IDs + verdicts
 
-- AGY adversarial: adversarial-review-mpz2di7a-yjtwp7
-- Gemini: (background, see below)
-- Codex: (foreground)
+- Codex (foreground): MERGE-READY (no fairness blocker; confirmed all 6 hammer points; raised 2 test-oracle gaps -> addressed in 32c175f69)
+- AGY adversarial: adversarial-review-mpz2di7a-yjtwp7 -> PLAN-READY/approve (byte-identical no-cap, zero mutation, exhaustive FlowFairState diff). Flagged 2 session test names that DO NOT EXIST in the codebase (hallucinated); real inplace_* session tests + full suite all pass.
+- Gemini (gemini-3.1-pro-preview, foreground): MERGE-READY (7-point quoted-line verification, no counter-example)
+- Claude SMR: MERGE-READY (immutable-borrow-then-pop makes mid-sequence mutation impossible at the type level; differential + no-cap oracle prove byte-identical selection)
+- Copilot: 6 comments addressed (1 false-positive autofix reverted; #[inline], stale msg, doc wording fixed)

--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -70,9 +70,22 @@ mod.rs for further file-level breakdown.
   `apply_cos_send_result` / `apply_cos_prepared_result`, after the retry
   restore) drops its `FlowFairState` box so idle queues release the
   ~232 KB footprint. Surplus DWRR across queues + MQFQ inside the
-  selected queue compose for free: `build_cos_batch_from_queue` already
-  pops via `cos_queue_front`/`cos_queue_pop_front`, both dispatching on
-  `flow_fair()`. This also folds in the residual/best-effort
+  selected queue compose for free: `build_cos_batch_from_queue` and the
+  cap-aware exact drains pop via the fused select+pop pair
+  `cos_queue_peek_min_bucket` + `cos_queue_pop_known_bucket` (#1763),
+  both dispatching on `flow_fair()`. The MQFQ min-head-finish scan
+  (`cos_queue_min_finish_bucket`, an O(N) linear scan over the active
+  flow-bucket ring, N≈14 measured under iperf3 -P48) used to run twice
+  per dequeue — once for the `cos_queue_front*` peek and again inside the
+  `cos_queue_pop_front*` re-scan, with no queue mutation between — so the
+  fused pair hands the peek's selected bucket straight to the pop and
+  removes the redundant scan. A `target_bps == u64::MAX` no-cap fast path
+  scans only `flow_bucket_head_finish_bytes`, skipping the dead
+  `flow_bucket_observed_bps` load. Both levers are fairness-neutral by
+  construction (byte-identical bucket selection and dequeue order),
+  pinned by the `fused_diff_tests.rs` differential test against the
+  retained `cos_queue_pop_front*` reference oracle. This also folds in
+  the residual/best-effort
   queue-level → flow-level item from the #1731 research plan (its
   finding #7; NOT GitHub issue #7, which is an unrelated SNAT bug).
 - Single-writer per FlowFairState. The owner worker that polls a

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -25,7 +25,9 @@ pub(super) use queue_ops::{
     cos_queue_push_front, cos_queue_restore_front, cos_queue_v_min_consume_suspension,
     cos_queue_v_min_continue, publish_committed_queue_vtime,
 };
-// #1763: test-only reference single-pop API (fused out of production).
+// #1763: reference single-pop API retained for tests (fused out of the
+// production drain paths). Still present in non-test builds;
+// `allow(unused_imports)` only suppresses the dead re-export lint there.
 #[cfg_attr(not(test), allow(unused_imports))]
 pub(super) use queue_ops::{cos_queue_pop_front, cos_queue_pop_front_with_cap};
 pub(super) use queue_service::drain_shaped_tx;

--- a/userspace-dp/src/afxdp/cos/mod.rs
+++ b/userspace-dp/src/afxdp/cos/mod.rs
@@ -20,11 +20,14 @@ pub(super) use cross_binding::{
 pub(super) use flow_hash::{cos_flow_bucket_index, cos_item_flow_key};
 pub(super) use queue_ops::{
     cos_item_len, cos_queue_clear_orphan_snapshot_after_drop, cos_queue_drain_all, cos_queue_front,
-    cos_queue_front_with_cap, cos_queue_is_empty, cos_queue_len, cos_queue_pop_front,
-    cos_queue_pop_front_no_snapshot, cos_queue_pop_front_with_cap, cos_queue_push_back,
+    cos_queue_front_with_cap, cos_queue_is_empty, cos_queue_len, cos_queue_peek_min_bucket,
+    cos_queue_pop_front_no_snapshot, cos_queue_pop_known_bucket, cos_queue_push_back,
     cos_queue_push_front, cos_queue_restore_front, cos_queue_v_min_consume_suspension,
     cos_queue_v_min_continue, publish_committed_queue_vtime,
 };
+// #1763: test-only reference single-pop API (fused out of production).
+#[cfg_attr(not(test), allow(unused_imports))]
+pub(super) use queue_ops::{cos_queue_pop_front, cos_queue_pop_front_with_cap};
 pub(super) use queue_service::drain_shaped_tx;
 pub(super) use token_bucket::{
     COS_MIN_BURST_BYTES, CoSQueueLeaseAcquireTelemetry, cos_refill_ns_until,

--- a/userspace-dp/src/afxdp/cos/queue_ops/fused_diff_tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/fused_diff_tests.rs
@@ -91,10 +91,22 @@ fn item_identity(item: &CoSPendingTxItem) -> (Option<u16>, u64) {
 struct FfSnapshot {
     queue_vtime: u64,
     active_flow_buckets: u16,
+    active_flow_buckets_peak: u16,
     rr_order: Vec<u16>,
     bucket_head_finish: Vec<(u16, u64)>,
     bucket_tail_finish: Vec<(u16, u64)>,
     bucket_item_lens: Vec<(u16, Vec<u64>)>,
+    // #1763 Codex review: the per-bucket accounting + selection-input
+    // arrays MUST also match. `observed_bps` is a selection INPUT (the
+    // cap-aware eligibility key), and `bytes`/`tx_bytes`/`pending_bytes`/
+    // `last_tx_ns` are mutated by the shared pop accounting body — a
+    // divergence here would be a real fairness or accounting regression
+    // even if the dequeue order matched. Captured per active bucket.
+    bucket_observed_bps: Vec<(u16, u64)>,
+    bucket_bytes: Vec<(u16, u64)>,
+    bucket_tx_bytes: Vec<(u16, u64)>,
+    bucket_last_tx_ns: Vec<(u16, u64)>,
+    bucket_pending_bytes: Vec<(u16, u32)>,
     snapshot_stack: Vec<crate::afxdp::types::CoSQueuePopSnapshot>,
     queued_bytes: u64,
     local_item_count: u32,
@@ -103,11 +115,17 @@ struct FfSnapshot {
 fn snapshot_ff(queue: &CoSQueueRuntime) -> FfSnapshot {
     let ff = test_flow_fair_state(queue);
     let rr_order: Vec<u16> = ff.flow_rr_buckets.iter().collect();
-    // For every active bucket record the head/tail finish and the item
-    // lengths in FIFO order, keyed by bucket id (ring order).
+    // For every active bucket record the head/tail finish, item lengths
+    // (FIFO order), and the per-bucket accounting + selection-input
+    // arrays, keyed by bucket id (ring order).
     let mut bucket_head_finish = Vec::new();
     let mut bucket_tail_finish = Vec::new();
     let mut bucket_item_lens = Vec::new();
+    let mut bucket_observed_bps = Vec::new();
+    let mut bucket_bytes = Vec::new();
+    let mut bucket_tx_bytes = Vec::new();
+    let mut bucket_last_tx_ns = Vec::new();
+    let mut bucket_pending_bytes = Vec::new();
     for b in rr_order.iter().copied() {
         let bi = usize::from(b);
         bucket_head_finish.push((b, ff.flow_bucket_head_finish_bytes[bi]));
@@ -117,14 +135,25 @@ fn snapshot_ff(queue: &CoSQueueRuntime) -> FfSnapshot {
             .map(cos_item_len)
             .collect();
         bucket_item_lens.push((b, lens));
+        bucket_observed_bps.push((b, ff.flow_bucket_observed_bps[bi]));
+        bucket_bytes.push((b, ff.flow_bucket_bytes[bi]));
+        bucket_tx_bytes.push((b, ff.flow_bucket_tx_bytes[bi]));
+        bucket_last_tx_ns.push((b, ff.flow_bucket_last_tx_ns[bi]));
+        bucket_pending_bytes.push((b, ff.flow_bucket_pending_bytes[bi]));
     }
     FfSnapshot {
         queue_vtime: ff.queue_vtime,
         active_flow_buckets: ff.active_flow_buckets,
+        active_flow_buckets_peak: ff.active_flow_buckets_peak,
         rr_order,
         bucket_head_finish,
         bucket_tail_finish,
         bucket_item_lens,
+        bucket_observed_bps,
+        bucket_bytes,
+        bucket_tx_bytes,
+        bucket_last_tx_ns,
+        bucket_pending_bytes,
         snapshot_stack: ff.pop_snapshot_stack.clone(),
         queued_bytes: queue.hot.queued_bytes,
         local_item_count: queue.hot.local_item_count,
@@ -479,6 +508,89 @@ fn diff_randomized_sequences() {
             }
         }
         run_diff(&steps, &format!("randomized seed={seed}"));
+    }
+}
+
+/// #1763 Codex review — INDEPENDENT no-cap-vs-two-pass oracle. The
+/// scripted/randomized diff tests above route BOTH the reference and the
+/// fused popper through `cos_queue_min_finish_bucket`, so they prove
+/// peek-vs-pop equivalence but NOT that the no-cap fast path (Lever B)
+/// equals the ORIGINAL eligible/fallback two-pass at `target_bps ==
+/// u64::MAX`. This test closes that gap with a self-contained reference:
+/// it builds randomized active-ring states (varied head-finish + nonzero
+/// observed_bps) and asserts `cos_queue_min_finish_bucket(ff, u64::MAX)`
+/// (which dispatches to `cos_queue_min_finish_bucket_no_cap`) selects the
+/// IDENTICAL bucket as a hand-rolled replay of the pre-#1763 two-pass
+/// loop evaluated at `target_bps == u64::MAX`. Because every bucket is
+/// eligible at u64::MAX, the two-pass collapses to "lowest head-finish,
+/// first-wins on strict <" — exactly what the no-cap path must produce.
+#[test]
+fn no_cap_fast_path_equals_two_pass_at_max() {
+    use crate::afxdp::tx::test_support::test_flow_fair_state_mut;
+
+    // Reference: replay the ORIGINAL eligible/fallback two-pass loop
+    // (verbatim semantics from the pre-#1763 cos_queue_min_finish_bucket)
+    // at target_bps == u64::MAX. NOT routed through the new dispatch.
+    fn two_pass_ref_at_max(ff: &crate::afxdp::types::FlowFairState) -> Option<u16> {
+        let target_bps = u64::MAX;
+        let mut eligible: Option<u16> = None;
+        let mut eligible_finish = u64::MAX;
+        let mut fallback: Option<u16> = None;
+        let mut fallback_finish = u64::MAX;
+        for bucket in ff.flow_rr_buckets.iter() {
+            let b = usize::from(bucket);
+            let finish = ff.flow_bucket_head_finish_bytes[b];
+            if finish < fallback_finish {
+                fallback_finish = finish;
+                fallback = Some(bucket);
+            }
+            let observed = ff.flow_bucket_observed_bps[b];
+            if observed <= target_bps && finish < eligible_finish {
+                eligible_finish = finish;
+                eligible = Some(bucket);
+            }
+        }
+        eligible.or(fallback)
+    }
+
+    let mut rng = Rng(0xC0FF_EE12_3456_789A);
+    for _iter in 0..2000 {
+        let mut queue = make_flow_fair_queue();
+        let ff = test_flow_fair_state_mut(&mut queue);
+        // Populate a random set of active buckets with varied head-finish
+        // and observed_bps directly (bypassing enqueue so we can hit
+        // equal-finish ties and large observed values exhaustively).
+        let n = 1 + rng.below(20) as usize; // up to 20 active buckets
+        for _ in 0..n {
+            let bucket = (1 + rng.below(4000)) as u16; // avoid bucket 0 sentinel-ish
+            let bi = usize::from(bucket);
+            // Skip duplicates (ring invariant: no dup bucket ids).
+            if ff.flow_bucket_head_finish_bytes[bi] != 0 {
+                continue;
+            }
+            // Head finish drawn from a small set to force frequent ties.
+            let finish = 1 + rng.below(6) * 500;
+            ff.flow_bucket_head_finish_bytes[bi] = finish;
+            ff.flow_bucket_tail_finish_bytes[bi] = finish;
+            // Observed bps: mix of 0, small, and near-u64::MAX values to
+            // confirm the no-cap path ignores observed entirely.
+            ff.flow_bucket_observed_bps[bi] = match rng.below(4) {
+                0 => 0,
+                1 => rng.below(1_000_000_000),
+                2 => u64::MAX - 1,
+                _ => u64::MAX,
+            };
+            ff.flow_rr_buckets.push_back(bucket);
+        }
+        let want = two_pass_ref_at_max(ff);
+        let got = cos_queue_min_finish_bucket(ff, u64::MAX);
+        assert_eq!(
+            got, want,
+            "no-cap fast path diverged from two-pass@u64::MAX: ring={:?}",
+            ff.flow_rr_buckets.iter().collect::<Vec<_>>()
+        );
+        // Also confirm the no_cap specialization directly matches.
+        assert_eq!(cos_queue_min_finish_bucket_no_cap(ff), want);
     }
 }
 

--- a/userspace-dp/src/afxdp/cos/queue_ops/fused_diff_tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/fused_diff_tests.rs
@@ -1,0 +1,502 @@
+// #1763 — fused select+pop fairness-neutrality differential test.
+//
+// THE HARD GATE for Path 1. The MQFQ min-finish-bucket scan used to run
+// TWICE per dequeue (peek then pop). #1763 fuses it: the peek selects
+// the bucket, the pop reuses it with no re-scan, plus a no-cap fast path
+// that skips the dead `flow_bucket_observed_bps` load. This test proves
+// the fused path is BYTE-IDENTICAL in selection behavior to the original
+// double-scan — same dequeue order AND same FlowFairState after every op.
+//
+// Method (mirrors the #1753 differential approach): build two
+// independent, identically-configured flow-fair queues. Apply the SAME
+// enqueue / pop / push_front / drain sequence to both, popping from the
+// REFERENCE queue via the original double-scan API
+// (`cos_queue_front*` peek + `cos_queue_pop_front*` re-scan) and from the
+// FUSED queue via `cos_queue_peek_min_bucket` + `cos_queue_pop_known_bucket`.
+// After every op assert the popped item identity and the full observable
+// FlowFairState match. If the fused path EVER selects a different bucket,
+// the assert trips. A randomized sequence test exercises the same
+// invariant over thousands of mixed ops.
+
+use super::*;
+use crate::afxdp::cos::flow_hash::{cos_flow_bucket_index, cos_item_flow_key};
+use crate::afxdp::cos::queue_ops::{
+    cos_queue_drain_all, cos_queue_front, cos_queue_front_with_cap, cos_queue_peek_min_bucket,
+    cos_queue_pop_front, cos_queue_pop_front_no_snapshot, cos_queue_pop_front_with_cap,
+    cos_queue_pop_known_bucket, cos_queue_push_back, cos_queue_push_front,
+};
+use crate::afxdp::tx::test_support::{
+    enable_test_flow_fair, test_cos_runtime_with_queues, test_flow_fair_state, test_session_key,
+};
+use crate::afxdp::types::{CoSPendingTxItem, CoSQueueConfig, CoSQueueRuntime, TxRequest};
+use crate::afxdp::{PROTO_TCP, TX_BATCH_SIZE};
+
+// ---- helpers --------------------------------------------------------
+
+/// Build a single-queue exact flow-fair runtime and return the promoted
+/// queue. Exact queues stay promoted for life (the regime the lever
+/// targets).
+fn make_flow_fair_queue() -> CoSQueueRuntime {
+    let mut root = test_cos_runtime_with_queues(
+        25_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 4,
+            forwarding_class: "iperf-a".into(),
+            priority: 5,
+            transmit_rate_bytes: 1_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            surplus_weight: 1,
+            buffer_bytes: 4 * 1024 * 1024,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let mut queue = root.queues.remove(0);
+    enable_test_flow_fair(&mut queue);
+    queue
+}
+
+/// A flow-fair item carrying a unique `(src_port, len)` identity so two
+/// independent queues can be compared item-for-item. `seq` is folded
+/// into the payload length's low bits is avoided — instead identity is
+/// `(src_port, len)` and we keep len distinct per logical packet.
+fn flow_item(src_port: u16, len: usize) -> CoSPendingTxItem {
+    CoSPendingTxItem::Local(TxRequest {
+        bytes: vec![0u8; len],
+        expected_ports: None,
+        expected_addr_family: libc::AF_INET as u8,
+        expected_protocol: PROTO_TCP,
+        flow_key: Some(test_session_key(src_port, 5201)),
+        egress_ifindex: 42,
+        cos_queue_id: Some(4),
+        dscp_rewrite: None,
+        mirror_clone: false,
+    })
+}
+
+/// Identity tuple for cross-queue item comparison: (flow src_port, len).
+fn item_identity(item: &CoSPendingTxItem) -> (Option<u16>, u64) {
+    let port = cos_item_flow_key(item).map(|k| k.src_port);
+    (port, cos_item_len(item))
+}
+
+/// Capture the full observable FlowFairState for equality comparison.
+/// Includes everything the selection scan reads or the pop mutates:
+/// queue_vtime, active_flow_buckets, the active ring order, per-bucket
+/// head/tail finish, per-bucket item lengths, and the snapshot stack.
+#[derive(Debug, PartialEq)]
+struct FfSnapshot {
+    queue_vtime: u64,
+    active_flow_buckets: u16,
+    rr_order: Vec<u16>,
+    bucket_head_finish: Vec<(u16, u64)>,
+    bucket_tail_finish: Vec<(u16, u64)>,
+    bucket_item_lens: Vec<(u16, Vec<u64>)>,
+    snapshot_stack: Vec<crate::afxdp::types::CoSQueuePopSnapshot>,
+    queued_bytes: u64,
+    local_item_count: u32,
+}
+
+fn snapshot_ff(queue: &CoSQueueRuntime) -> FfSnapshot {
+    let ff = test_flow_fair_state(queue);
+    let rr_order: Vec<u16> = ff.flow_rr_buckets.iter().collect();
+    // For every active bucket record the head/tail finish and the item
+    // lengths in FIFO order, keyed by bucket id (ring order).
+    let mut bucket_head_finish = Vec::new();
+    let mut bucket_tail_finish = Vec::new();
+    let mut bucket_item_lens = Vec::new();
+    for b in rr_order.iter().copied() {
+        let bi = usize::from(b);
+        bucket_head_finish.push((b, ff.flow_bucket_head_finish_bytes[bi]));
+        bucket_tail_finish.push((b, ff.flow_bucket_tail_finish_bytes[bi]));
+        let lens: Vec<u64> = ff.flow_bucket_items[bi]
+            .iter()
+            .map(cos_item_len)
+            .collect();
+        bucket_item_lens.push((b, lens));
+    }
+    FfSnapshot {
+        queue_vtime: ff.queue_vtime,
+        active_flow_buckets: ff.active_flow_buckets,
+        rr_order,
+        bucket_head_finish,
+        bucket_tail_finish,
+        bucket_item_lens,
+        snapshot_stack: ff.pop_snapshot_stack.clone(),
+        queued_bytes: queue.hot.queued_bytes,
+        local_item_count: queue.hot.local_item_count,
+    }
+}
+
+/// Reference popper (the original DOUBLE-scan): peek via `cos_queue_front`
+/// (one scan), then `cos_queue_pop_front` (a second scan that re-derives
+/// the same bucket). This is exactly what production did before #1763.
+fn reference_pop_nocap(queue: &mut CoSQueueRuntime) -> Option<CoSPendingTxItem> {
+    // Mirror the build_cos_batch_from_queue peek-then-pop shape: the peek
+    // result is inspected then discarded, the pop re-scans.
+    let _ = cos_queue_front(queue)?;
+    cos_queue_pop_front(queue)
+}
+
+fn reference_pop_cap(queue: &mut CoSQueueRuntime, target_bps: u64) -> Option<CoSPendingTxItem> {
+    let _ = cos_queue_front_with_cap(queue, target_bps)?;
+    cos_queue_pop_front_with_cap(queue, target_bps)
+}
+
+/// Fused popper (the #1763 SINGLE-scan): peek returns the bucket id, the
+/// pop reuses it with no re-scan.
+fn fused_pop_nocap(queue: &mut CoSQueueRuntime) -> Option<CoSPendingTxItem> {
+    let bucket = {
+        let (b, _front) = cos_queue_peek_min_bucket(queue, u64::MAX)?;
+        b
+    };
+    cos_queue_pop_known_bucket(queue, bucket, u64::MAX)
+}
+
+fn fused_pop_cap(queue: &mut CoSQueueRuntime, target_bps: u64) -> Option<CoSPendingTxItem> {
+    let bucket = {
+        let (b, _front) = cos_queue_peek_min_bucket(queue, target_bps)?;
+        b
+    };
+    cos_queue_pop_known_bucket(queue, bucket, target_bps)
+}
+
+/// Assert two queues are in byte-identical observable state.
+fn assert_states_equal(reference: &CoSQueueRuntime, fused: &CoSQueueRuntime, ctx: &str) {
+    assert_eq!(
+        snapshot_ff(reference),
+        snapshot_ff(fused),
+        "fused vs reference FlowFairState diverged: {ctx}"
+    );
+}
+
+// ---- scripted differential scenarios --------------------------------
+
+/// Step kinds applied identically to both the reference and fused queues.
+#[derive(Clone, Debug)]
+enum Step {
+    Enqueue { src_port: u16, len: usize },
+    PopNoCap,
+    PopCap(u64),
+    /// push_front the most-recently-popped item back (rollback). Carried
+    /// per-queue because the items differ by identity but are equal by
+    /// shape.
+    PushFrontLast,
+}
+
+/// Drive `steps` through both queues and assert identical pops + state.
+fn run_diff(steps: &[Step], scenario: &str) {
+    let mut reference = make_flow_fair_queue();
+    let mut fused = make_flow_fair_queue();
+    // Per-queue stash of the last popped item for PushFrontLast rollback.
+    let mut ref_last: Option<CoSPendingTxItem> = None;
+    let mut fused_last: Option<CoSPendingTxItem> = None;
+
+    for (i, step) in steps.iter().enumerate() {
+        let ctx = format!("{scenario} step {i}: {step:?}");
+        match step {
+            Step::Enqueue { src_port, len } => {
+                cos_queue_push_back(&mut reference, flow_item(*src_port, *len));
+                cos_queue_push_back(&mut fused, flow_item(*src_port, *len));
+            }
+            Step::PopNoCap => {
+                let r = reference_pop_nocap(&mut reference);
+                let f = fused_pop_nocap(&mut fused);
+                assert_eq!(
+                    r.as_ref().map(item_identity),
+                    f.as_ref().map(item_identity),
+                    "no-cap pop identity diverged: {ctx}"
+                );
+                ref_last = r;
+                fused_last = f;
+            }
+            Step::PopCap(target_bps) => {
+                let r = reference_pop_cap(&mut reference, *target_bps);
+                let f = fused_pop_cap(&mut fused, *target_bps);
+                assert_eq!(
+                    r.as_ref().map(item_identity),
+                    f.as_ref().map(item_identity),
+                    "cap pop identity diverged: {ctx}"
+                );
+                ref_last = r;
+                fused_last = f;
+            }
+            Step::PushFrontLast => {
+                if let Some(item) = ref_last.take() {
+                    cos_queue_push_front(&mut reference, item);
+                }
+                if let Some(item) = fused_last.take() {
+                    cos_queue_push_front(&mut fused, item);
+                }
+            }
+        }
+        assert_states_equal(&reference, &fused, &ctx);
+    }
+}
+
+#[test]
+fn diff_single_active_bucket() {
+    let steps = vec![
+        Step::Enqueue { src_port: 1111, len: 1500 },
+        Step::Enqueue { src_port: 1111, len: 1500 },
+        Step::Enqueue { src_port: 1111, len: 700 },
+        Step::PopNoCap,
+        Step::PopNoCap,
+        Step::PopNoCap,
+        Step::PopNoCap, // drains empty
+    ];
+    run_diff(&steps, "single_active_bucket");
+}
+
+#[test]
+fn diff_n_buckets_equal_finish() {
+    // Several flows, all equal-byte packets — every head finish ties, so
+    // selection falls to ring insertion order. A re-scan that broke ties
+    // differently would diverge here.
+    let mut steps = Vec::new();
+    for port in [2001u16, 2002, 2003, 2004, 2005] {
+        steps.push(Step::Enqueue { src_port: port, len: 1500 });
+        steps.push(Step::Enqueue { src_port: port, len: 1500 });
+    }
+    for _ in 0..10 {
+        steps.push(Step::PopNoCap);
+    }
+    run_diff(&steps, "n_buckets_equal_finish");
+}
+
+#[test]
+fn diff_skewed_finish() {
+    // Mixed packet sizes → distinct head finish times → MQFQ orders by
+    // byte-finish, not arrival. The single min-finish winner must match.
+    let steps = vec![
+        Step::Enqueue { src_port: 3001, len: 1500 },
+        Step::Enqueue { src_port: 3002, len: 200 },
+        Step::Enqueue { src_port: 3003, len: 800 },
+        Step::Enqueue { src_port: 3001, len: 1500 },
+        Step::Enqueue { src_port: 3002, len: 200 },
+        Step::Enqueue { src_port: 3003, len: 800 },
+        Step::PopNoCap,
+        Step::PopNoCap,
+        Step::PopNoCap,
+        Step::PopNoCap,
+        Step::PopNoCap,
+        Step::PopNoCap,
+    ];
+    run_diff(&steps, "skewed_finish");
+}
+
+#[test]
+fn diff_idle_bucket_reanchor() {
+    // Drain a bucket to empty, advance vtime via other flows, then
+    // re-enqueue the drained flow — it must re-anchor at queue_vtime.
+    // The fused and reference paths must compute the identical re-anchor.
+    let steps = vec![
+        Step::Enqueue { src_port: 4001, len: 1500 },
+        Step::Enqueue { src_port: 4002, len: 1500 },
+        Step::Enqueue { src_port: 4002, len: 1500 },
+        Step::PopNoCap, // drains one of them
+        Step::PopNoCap,
+        Step::Enqueue { src_port: 4001, len: 1500 }, // re-anchor at vtime
+        Step::Enqueue { src_port: 4003, len: 300 },
+        Step::PopNoCap,
+        Step::PopNoCap,
+        Step::PopNoCap,
+    ];
+    run_diff(&steps, "idle_bucket_reanchor");
+}
+
+#[test]
+fn diff_snapshot_push_front_rollback() {
+    // pop (records snapshot) then push_front (consumes snapshot, restores
+    // pre-pop bucket state). The snapshot stack must match between fused
+    // and reference after each rollback.
+    let steps = vec![
+        Step::Enqueue { src_port: 5001, len: 1500 },
+        Step::Enqueue { src_port: 5002, len: 900 },
+        Step::Enqueue { src_port: 5001, len: 1500 },
+        Step::PopNoCap,
+        Step::PushFrontLast,
+        Step::PopNoCap,
+        Step::PopNoCap,
+        Step::PushFrontLast,
+        Step::PopNoCap,
+        Step::PopNoCap,
+    ];
+    run_diff(&steps, "snapshot_push_front_rollback");
+}
+
+#[test]
+fn diff_cap_aware_over_cap_mix() {
+    // Cap-aware pops with a finite target. Some buckets are "over cap"
+    // (observed_bps starts at 0 in the test, so all are eligible) but the
+    // finite target_bps still drives the eligible/fallback two-pass in the
+    // reference, while the fused path runs the SAME cap-aware scan. They
+    // must agree.
+    let steps = vec![
+        Step::Enqueue { src_port: 6001, len: 1500 },
+        Step::Enqueue { src_port: 6002, len: 400 },
+        Step::Enqueue { src_port: 6003, len: 1200 },
+        Step::Enqueue { src_port: 6001, len: 1500 },
+        Step::PopCap(100_000_000),
+        Step::PopCap(100_000_000),
+        Step::PopCap(50_000),
+        Step::PopCap(50_000),
+    ];
+    run_diff(&steps, "cap_aware_over_cap_mix");
+}
+
+#[test]
+fn diff_mixed_cap_and_nocap() {
+    // Interleave cap-aware and no-cap pops on the same backlog — the
+    // no-cap fast path (Lever B) and the cap-aware path must each match
+    // their reference.
+    let steps = vec![
+        Step::Enqueue { src_port: 7001, len: 1500 },
+        Step::Enqueue { src_port: 7002, len: 600 },
+        Step::Enqueue { src_port: 7003, len: 1000 },
+        Step::Enqueue { src_port: 7001, len: 1500 },
+        Step::Enqueue { src_port: 7002, len: 600 },
+        Step::PopNoCap,
+        Step::PopCap(200_000_000),
+        Step::PopNoCap,
+        Step::PopCap(200_000_000),
+        Step::PopNoCap,
+    ];
+    run_diff(&steps, "mixed_cap_and_nocap");
+}
+
+#[test]
+fn diff_drain_all_after_fused_pops() {
+    // After a run of fused pops on both queues, drain_all (which uses the
+    // no-snapshot pop) must produce the identical residual order on both.
+    let mut reference = make_flow_fair_queue();
+    let mut fused = make_flow_fair_queue();
+    for port in [8001u16, 8002, 8003] {
+        for len in [1500usize, 1500, 300] {
+            cos_queue_push_back(&mut reference, flow_item(port, len));
+            cos_queue_push_back(&mut fused, flow_item(port, len));
+        }
+    }
+    // Pop a few via the divergent paths.
+    for _ in 0..4 {
+        let r = reference_pop_nocap(&mut reference);
+        let f = fused_pop_nocap(&mut fused);
+        assert_eq!(r.as_ref().map(item_identity), f.as_ref().map(item_identity));
+    }
+    assert_states_equal(&reference, &fused, "drain_all pre-drain");
+    let ref_rest = cos_queue_drain_all(&mut reference);
+    let fused_rest = cos_queue_drain_all(&mut fused);
+    let ref_ids: Vec<_> = ref_rest.iter().map(item_identity).collect();
+    let fused_ids: Vec<_> = fused_rest.iter().map(item_identity).collect();
+    assert_eq!(ref_ids, fused_ids, "drain_all residual order diverged");
+}
+
+#[test]
+fn diff_no_snapshot_pop_parity() {
+    // The no-snapshot pop path (used by drain_all) shares the fused
+    // post-scan body via the FIFO/known-bucket inner. Pop both ways from
+    // identical state and confirm parity through the no_snapshot variant.
+    let mut reference = make_flow_fair_queue();
+    let mut fused = make_flow_fair_queue();
+    for port in [9001u16, 9002] {
+        cos_queue_push_back(&mut reference, flow_item(port, 1500));
+        cos_queue_push_back(&mut fused, flow_item(port, 1500));
+    }
+    // reference: front peek + no_snapshot pop; fused: peek_min_bucket +
+    // pop_known_bucket(no_snapshot path is internal to drain_all, so here
+    // we just confirm the no_snapshot reference path itself matches a
+    // fused snapshotting pop is NOT valid — instead compare two
+    // no_snapshot pops driven by the same selection).
+    let r = {
+        let _ = cos_queue_front(&reference);
+        cos_queue_pop_front_no_snapshot(&mut reference)
+    };
+    let f = {
+        let _ = cos_queue_peek_min_bucket(&fused, u64::MAX);
+        cos_queue_pop_front_no_snapshot(&mut fused)
+    };
+    assert_eq!(r.as_ref().map(item_identity), f.as_ref().map(item_identity));
+    assert_states_equal(&reference, &fused, "no_snapshot parity");
+}
+
+// ---- randomized differential ----------------------------------------
+
+/// Tiny deterministic xorshift PRNG — no external dep, reproducible.
+struct Rng(u64);
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn below(&mut self, n: u64) -> u64 {
+        self.next_u64() % n
+    }
+}
+
+#[test]
+fn diff_randomized_sequences() {
+    // Many randomized mixed sequences: enqueue across a small flow set,
+    // no-cap pops, cap-aware pops, and push_front rollbacks. Each seed is
+    // an independent backlog evolution; any selection divergence trips an
+    // assert. Flow count kept around the measured N=14 regime.
+    let ports: [u16; 14] = [
+        10001, 10002, 10003, 10004, 10005, 10006, 10007, 10008, 10009, 10010, 10011, 10012,
+        10013, 10014,
+    ];
+    let lens = [64usize, 200, 512, 800, 1200, 1500];
+    let caps = [u64::MAX, 500_000_000, 100_000_000, 25_000, u64::MAX];
+
+    for seed in 1u64..=40 {
+        let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+        let mut steps: Vec<Step> = Vec::new();
+        // Build up an initial backlog so the active set is populated.
+        for _ in 0..(20 + rng.below(20)) {
+            let port = ports[rng.below(ports.len() as u64) as usize];
+            let len = lens[rng.below(lens.len() as u64) as usize];
+            steps.push(Step::Enqueue { src_port: port, len });
+        }
+        // Then a long mixed op stream.
+        for _ in 0..200 {
+            match rng.below(10) {
+                0 | 1 | 2 => {
+                    let port = ports[rng.below(ports.len() as u64) as usize];
+                    let len = lens[rng.below(lens.len() as u64) as usize];
+                    steps.push(Step::Enqueue { src_port: port, len });
+                }
+                3 | 4 | 5 | 6 => steps.push(Step::PopNoCap),
+                7 | 8 => {
+                    let cap = caps[rng.below(caps.len() as u64) as usize];
+                    steps.push(Step::PopCap(cap));
+                }
+                _ => steps.push(Step::PushFrontLast),
+            }
+        }
+        run_diff(&steps, &format!("randomized seed={seed}"));
+    }
+}
+
+#[test]
+fn diff_full_batch_drain_parity() {
+    // Drain a full TX_BATCH_SIZE worth interleaved across many flows, the
+    // realistic hot-path batch shape, and confirm parity across the whole
+    // batch.
+    let mut steps = Vec::new();
+    let ports: Vec<u16> = (12001u16..12001 + 14).collect();
+    for round in 0..(TX_BATCH_SIZE / ports.len() + 2) {
+        for (i, &port) in ports.iter().enumerate() {
+            let len = 200 + (i * 91 + round * 37) % 1300;
+            steps.push(Step::Enqueue { src_port: port, len });
+        }
+    }
+    for _ in 0..TX_BATCH_SIZE {
+        steps.push(Step::PopNoCap);
+    }
+    run_diff(&steps, "full_batch_drain_parity");
+}

--- a/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
@@ -37,9 +37,13 @@ pub(in crate::afxdp) use drain::{
 // #1034 P3: push + pop ops split into siblings.
 mod pop;
 mod push;
-pub(in crate::afxdp) use pop::{
-    cos_queue_pop_front, cos_queue_pop_front_no_snapshot, cos_queue_pop_front_with_cap,
-};
+// #1763: `cos_queue_pop_front` / `cos_queue_pop_front_with_cap` are now
+// fused out of production (peek_min_bucket + pop_known_bucket); they
+// survive as the reference single-pop API for tests, so the re-export
+// is test-only in non-test builds.
+#[cfg_attr(not(test), allow(unused_imports))]
+pub(in crate::afxdp) use pop::{cos_queue_pop_front, cos_queue_pop_front_with_cap};
+pub(in crate::afxdp) use pop::{cos_queue_pop_front_no_snapshot, cos_queue_pop_known_bucket};
 pub(in crate::afxdp) use push::{cos_queue_push_back, cos_queue_push_front};
 
 #[inline]
@@ -97,8 +101,23 @@ pub(in crate::afxdp) fn cos_queue_len(queue: &CoSQueueRuntime) -> usize {
 /// flows on a single queue), the replacement is a min-heap keyed by
 /// `flow_bucket_head_finish_bytes`. For iperf3-sized workloads the
 /// linear scan is cache-friendlier and simpler.
+///
+/// #1763 Lever B — no-cap fast path. When `target_bps == u64::MAX`
+/// (every `cos_queue_front` / `cos_queue_pop_front` caller, i.e. the
+/// whole best-effort builder) `observed <= u64::MAX` is always true,
+/// so `eligible == fallback` always holds and the two-pass plus the
+/// second strided `flow_bucket_observed_bps` load are dead work. The
+/// no-cap branch scans only `flow_bucket_head_finish_bytes`, removing
+/// one big-array load per bucket (the two arrays live on different
+/// cache lines, so this halves the per-bucket cache-miss exposure).
+/// The selected bucket is **byte-identical** to the cap-aware pass at
+/// `target_bps == u64::MAX`: both return the lowest-finish active
+/// bucket (first-wins on ties, since `<` is strict).
 #[inline]
 fn cos_queue_min_finish_bucket(ff: &FlowFairState, target_bps: u64) -> Option<u16> {
+    if target_bps == u64::MAX {
+        return cos_queue_min_finish_bucket_no_cap(ff);
+    }
     let mut eligible: Option<u16> = None;
     let mut eligible_finish = u64::MAX;
     let mut fallback: Option<u16> = None;
@@ -117,6 +136,26 @@ fn cos_queue_min_finish_bucket(ff: &FlowFairState, target_bps: u64) -> Option<u1
         }
     }
     eligible.or(fallback)
+}
+
+/// #1763 Lever B — the `target_bps == u64::MAX` specialization of
+/// `cos_queue_min_finish_bucket`. Single pass, single big-array load
+/// per bucket. Returns the lowest-`flow_bucket_head_finish_bytes`
+/// active bucket, first-wins on ties — identical selection to the
+/// cap-aware loop evaluated at `target_bps == u64::MAX`, where every
+/// bucket is eligible so `eligible` collapses onto `fallback`.
+#[inline]
+fn cos_queue_min_finish_bucket_no_cap(ff: &FlowFairState) -> Option<u16> {
+    let mut best: Option<u16> = None;
+    let mut best_finish = u64::MAX;
+    for bucket in ff.flow_rr_buckets.iter() {
+        let finish = ff.flow_bucket_head_finish_bytes[usize::from(bucket)];
+        if finish < best_finish {
+            best_finish = finish;
+            best = Some(bucket);
+        }
+    }
+    best
 }
 
 #[inline]
@@ -158,6 +197,53 @@ pub(in crate::afxdp) fn cos_queue_front_with_cap(
     let bucket = usize::from(cos_queue_min_finish_bucket(ff, target_bps)?);
     ff.flow_bucket_items[bucket].front()
 }
+
+/// #1763 Lever A — fused select+peek that ALSO returns the selected
+/// MQFQ bucket id so the caller can pop that exact bucket via
+/// `cos_queue_pop_known_bucket` without a second min-finish scan.
+///
+/// The drain hot paths peek-then-pop with NO queue mutation between
+/// the two calls, so the second `cos_queue_min_finish_bucket` scan
+/// inside `cos_queue_pop_front*` re-derives the identical bucket. This
+/// helper hands the peek's chosen bucket to the pop so the redundant
+/// scan is removed on every committed pop.
+///
+/// Selection is byte-identical to `cos_queue_front_with_cap`: it calls
+/// the same `cos_queue_min_finish_bucket`. The returned `bucket` is the
+/// active-set winner; the returned item is that bucket's head.
+///
+/// FIFO (non-flow-fair) queues return a `MIN_FINISH_BUCKET_FIFO`
+/// sentinel for the bucket; `cos_queue_pop_known_bucket` ignores the
+/// bucket on the FIFO path (it pops the hot deque directly), so the
+/// sentinel never indexes a bucket array.
+#[inline]
+pub(in crate::afxdp) fn cos_queue_peek_min_bucket(
+    queue: &CoSQueueRuntime,
+    target_bps: u64,
+) -> Option<(u16, &CoSPendingTxItem)> {
+    if !queue.flow_fair() {
+        return queue
+            .hot
+            .items
+            .front()
+            .map(|item| (MIN_FINISH_BUCKET_FIFO, item));
+    }
+    let ff = queue
+        .flow_fair_state
+        .as_ref()
+        .expect("cos_queue_peek_min_bucket: flow_fair queue without flow_fair_state");
+    let bucket_u16 = cos_queue_min_finish_bucket(ff, target_bps)?;
+    let item = ff.flow_bucket_items[usize::from(bucket_u16)].front()?;
+    Some((bucket_u16, item))
+}
+
+/// #1763 — sentinel bucket id returned by `cos_queue_peek_min_bucket`
+/// for FIFO (non-flow-fair) queues. `cos_queue_pop_known_bucket`
+/// branches on `queue.flow_fair()` and never indexes a bucket array
+/// with this value on the FIFO path, so the exact value is immaterial;
+/// it is documented as "not a real bucket" for the debug_assert and
+/// reader clarity.
+pub(in crate::afxdp) const MIN_FINISH_BUCKET_FIFO: u16 = u16::MAX;
 
 /// #917 — V_min sync throttle decision. Plan §3.3 v2 cadence:
 /// K=8 + mandatory check at drain-batch start (`pop_count == 1`).

--- a/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
@@ -341,3 +341,9 @@ pub(in crate::afxdp) fn cos_item_len(item: &CoSPendingTxItem) -> u64 {
 #[cfg(test)]
 #[path = "tests.rs"]
 mod tests;
+
+// #1763 — fused select+pop fairness-neutrality differential test (the
+// hard gate: proves byte-identical selection vs the original double-scan).
+#[cfg(test)]
+#[path = "fused_diff_tests.rs"]
+mod fused_diff_tests;

--- a/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/mod.rs
@@ -38,9 +38,11 @@ pub(in crate::afxdp) use drain::{
 mod pop;
 mod push;
 // #1763: `cos_queue_pop_front` / `cos_queue_pop_front_with_cap` are now
-// fused out of production (peek_min_bucket + pop_known_bucket); they
-// survive as the reference single-pop API for tests, so the re-export
-// is test-only in non-test builds.
+// fused out of production (peek_min_bucket + pop_known_bucket). They are
+// retained as the reference single-pop API used by tests (incl. the
+// fused-vs-reference differential oracle). The symbols still exist in
+// non-test builds — `allow(unused_imports)` only suppresses the dead
+// re-export lint there; it does not conditionally compile them out.
 #[cfg_attr(not(test), allow(unused_imports))]
 pub(in crate::afxdp) use pop::{cos_queue_pop_front, cos_queue_pop_front_with_cap};
 pub(in crate::afxdp) use pop::{cos_queue_pop_front_no_snapshot, cos_queue_pop_known_bucket};

--- a/userspace-dp/src/afxdp/cos/queue_ops/pop.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/pop.rs
@@ -79,7 +79,7 @@ fn cos_queue_pop_front_inner_with_cap(
     let ff = queue
         .flow_fair_state
         .as_ref()
-        .expect("cos_queue_pop_front_inner: flow_fair queue without flow_fair_state");
+        .expect("cos_queue_pop_front_inner_with_cap: flow_fair queue without flow_fair_state");
     // #785 Phase 3 — MQFQ: pop from the bucket whose head
     // packet has the smallest virtual-finish-time, not DRR
     // rotation order. The active set (`flow_rr_buckets`) is
@@ -110,6 +110,7 @@ fn cos_queue_pop_front_inner_with_cap(
 /// trust the no-mutation invariant and skip the second scan entirely.
 ///
 /// `MIN_FINISH_BUCKET_FIFO` selects the non-flow-fair hot-deque path.
+#[inline]
 pub(in crate::afxdp) fn cos_queue_pop_known_bucket(
     queue: &mut CoSQueueRuntime,
     bucket_u16: u16,

--- a/userspace-dp/src/afxdp/cos/queue_ops/pop.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/pop.rs
@@ -6,6 +6,12 @@ use super::*;
 // is the non-batched variant used when the caller has already committed
 // to dropping the item. `pop_front_inner` is the shared implementation.
 
+/// #1763: production callers now fuse select+pop via
+/// `cos_queue_peek_min_bucket` + `cos_queue_pop_known_bucket`, so this
+/// scan-then-pop wrapper is retained as the canonical single-pop API
+/// for tests (it is also the double-scan REFERENCE oracle the
+/// fused-vs-reference differential test drives, fused_diff_tests.rs).
+#[cfg_attr(not(test), allow(dead_code))]
 #[inline]
 pub(in crate::afxdp) fn cos_queue_pop_front(
     queue: &mut CoSQueueRuntime,
@@ -44,6 +50,12 @@ fn cos_queue_pop_front_inner(
 /// no-cap default (existing behavior). Drain loops compute the
 /// per-bucket fair-share target and pass it here so over-cap
 /// buckets are deferred in favor of cooler ones.
+///
+/// #1763: production drain loops now fuse select+pop via
+/// `cos_queue_peek_min_bucket` + `cos_queue_pop_known_bucket`; this
+/// scan-then-pop cap-aware wrapper is retained as the reference oracle
+/// for the differential test and for direct single-pop test use.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(in crate::afxdp) fn cos_queue_pop_front_with_cap(
     queue: &mut CoSQueueRuntime,
     target_bps: u64,
@@ -56,29 +68,111 @@ fn cos_queue_pop_front_inner_with_cap(
     push_snapshot: bool,
     target_bps: u64,
 ) -> Option<CoSPendingTxItem> {
+    if !queue.flow_fair() {
+        return cos_queue_pop_known_bucket_inner(queue, MIN_FINISH_BUCKET_FIFO, push_snapshot);
+    }
+    // Invariant: `flow_fair() == true` ↔ `flow_fair_state.is_some()`.
+    // Set together at every promotion / demotion site (admission.rs:508,
+    // tx/test_support.rs enable_/disable_test_flow_fair). Silently
+    // returning None here would make the queue look empty and stall
+    // service while masking a structural bug.
+    let ff = queue
+        .flow_fair_state
+        .as_ref()
+        .expect("cos_queue_pop_front_inner: flow_fair queue without flow_fair_state");
+    // #785 Phase 3 — MQFQ: pop from the bucket whose head
+    // packet has the smallest virtual-finish-time, not DRR
+    // rotation order. The active set (`flow_rr_buckets`) is
+    // still maintained on 0↔>0 transitions so the min-scan
+    // only iterates the currently-active buckets (typically
+    // 2-16), not all 4096.
+    //
+    // #1229 v7: scan now skips buckets whose EWMA-observed bps
+    // exceeds `target_bps`, falling back to the lowest-finish
+    // bucket if all are over-cap (work-conserving).
+    let bucket_u16 = cos_queue_min_finish_bucket(ff, target_bps)?;
+    cos_queue_pop_known_bucket_inner(queue, bucket_u16, push_snapshot)
+}
+
+/// #1763 Lever A — pop from a bucket already selected by
+/// `cos_queue_peek_min_bucket` (or, internally, by the min-finish scan
+/// in `cos_queue_pop_front_inner_with_cap`). Carries out the SAME
+/// post-selection bookkeeping the inline path always did — snapshot
+/// push, served-finish vtime advance, head-finish re-anchor, active-set
+/// vacate, accounting — with NO re-scan.
+///
+/// Fairness-neutrality contract: the caller MUST NOT mutate the queue
+/// between the `cos_queue_peek_min_bucket` that produced `bucket_u16`
+/// and this call. Under that invariant `bucket_u16` is still the
+/// active-front winner, so this pops the byte-identical item the
+/// double-scan would have. A `debug_assert` re-runs the scan in dev/
+/// test builds and verifies the known bucket matches; release builds
+/// trust the no-mutation invariant and skip the second scan entirely.
+///
+/// `MIN_FINISH_BUCKET_FIFO` selects the non-flow-fair hot-deque path.
+pub(in crate::afxdp) fn cos_queue_pop_known_bucket(
+    queue: &mut CoSQueueRuntime,
+    bucket_u16: u16,
+    target_bps: u64,
+) -> Option<CoSPendingTxItem> {
+    debug_assert!(
+        cos_queue_pop_known_bucket_matches(queue, bucket_u16, target_bps),
+        "cos_queue_pop_known_bucket: bucket {bucket_u16} is not the current \
+         min-finish active-front winner — the queue was mutated between \
+         peek and pop, violating the fused select+pop no-mutation invariant",
+    );
+    cos_queue_pop_known_bucket_inner(queue, bucket_u16, true)
+}
+
+/// #1763 — dev/test guard for `cos_queue_pop_known_bucket`. Re-runs the
+/// min-finish scan and confirms `bucket_u16` is what it would have
+/// chosen. FIFO queues are trivially consistent (the sentinel is not a
+/// real bucket and the hot deque is popped directly).
+#[cfg(debug_assertions)]
+fn cos_queue_pop_known_bucket_matches(
+    queue: &CoSQueueRuntime,
+    bucket_u16: u16,
+    target_bps: u64,
+) -> bool {
+    if !queue.flow_fair() {
+        return bucket_u16 == MIN_FINISH_BUCKET_FIFO;
+    }
+    let Some(ff) = queue.flow_fair_state.as_ref() else {
+        return false;
+    };
+    cos_queue_min_finish_bucket(ff, target_bps) == Some(bucket_u16)
+}
+
+#[cfg(not(debug_assertions))]
+#[inline(always)]
+fn cos_queue_pop_known_bucket_matches(
+    _queue: &CoSQueueRuntime,
+    _bucket_u16: u16,
+    _target_bps: u64,
+) -> bool {
+    true
+}
+
+/// #1763 — shared post-selection pop body. `bucket_u16` is the
+/// already-selected MQFQ bucket (or `MIN_FINISH_BUCKET_FIFO` for the
+/// non-flow-fair hot-deque path).
+fn cos_queue_pop_known_bucket_inner(
+    queue: &mut CoSQueueRuntime,
+    bucket_u16: u16,
+    push_snapshot: bool,
+) -> Option<CoSPendingTxItem> {
     let item = if !queue.flow_fair() {
+        debug_assert_eq!(
+            bucket_u16, MIN_FINISH_BUCKET_FIFO,
+            "cos_queue_pop_known_bucket_inner: FIFO queue must use the FIFO sentinel bucket",
+        );
         queue.hot.items.pop_front()?
     } else {
         // Invariant: `flow_fair() == true` ↔ `flow_fair_state.is_some()`.
-        // Set together at every promotion / demotion site (admission.rs:508,
-        // tx/test_support.rs enable_/disable_test_flow_fair). Silently
-        // returning None here would make the queue look empty and stall
-        // service while masking a structural bug.
         let ff = queue
             .flow_fair_state
             .as_mut()
-            .expect("cos_queue_pop_front_inner: flow_fair queue without flow_fair_state");
-        // #785 Phase 3 — MQFQ: pop from the bucket whose head
-        // packet has the smallest virtual-finish-time, not DRR
-        // rotation order. The active set (`flow_rr_buckets`) is
-        // still maintained on 0↔>0 transitions so the min-scan
-        // only iterates the currently-active buckets (typically
-        // 2-16), not all 4096.
-        //
-        // #1229 v7: scan now skips buckets whose EWMA-observed bps
-        // exceeds `target_bps`, falling back to the lowest-finish
-        // bucket if all are over-cap (work-conserving).
-        let bucket_u16 = cos_queue_min_finish_bucket(ff, target_bps)?;
+            .expect("cos_queue_pop_known_bucket_inner: flow_fair queue without flow_fair_state");
         let bucket = usize::from(bucket_u16);
         if push_snapshot {
             // #785 Phase 3 — Codex round-3 HIGH + NEW-1: snapshot

--- a/userspace-dp/src/afxdp/cos/queue_service/drain.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/drain.rs
@@ -206,7 +206,15 @@ pub(in crate::afxdp) fn drain_exact_local_items_to_scratch_flow_fair(
         // #1229 v7: cap-aware front/pop. target_bps was sampled
         // once at drain-batch start; same value used for every
         // pop in the batch so the eligible-set is stable.
-        let Some(front) = cos_queue_front_with_cap(queue, target_bps) else {
+        //
+        // #1763 Lever A — fused select+pop. Peek returns the cap-aware
+        // min-finish bucket id; the matching pop reuses it with no
+        // re-scan. The queue is NOT mutated between peek and pop (the
+        // budget break below abandons WITHOUT popping → 1 scan, same as
+        // before; the mirror-reserve abandon pops the same `bucket`),
+        // so the selected bucket is byte-identical to the prior
+        // double-scan.
+        let Some((bucket, front)) = cos_queue_peek_min_bucket(queue, target_bps) else {
             break;
         };
         let len = match front {
@@ -221,7 +229,7 @@ pub(in crate::afxdp) fn drain_exact_local_items_to_scratch_flow_fair(
         {
             if scratch_local_tx.is_empty() {
                 let Some(CoSPendingTxItem::Local(_req)) =
-                    cos_queue_pop_front_with_cap(queue, target_bps)
+                    cos_queue_pop_known_bucket(queue, bucket, target_bps)
                 else {
                     break;
                 };
@@ -231,7 +239,7 @@ pub(in crate::afxdp) fn drain_exact_local_items_to_scratch_flow_fair(
             break;
         }
         let Some(CoSPendingTxItem::Local(mut req)) =
-            cos_queue_pop_front_with_cap(queue, target_bps)
+            cos_queue_pop_known_bucket(queue, bucket, target_bps)
         else {
             break;
         };
@@ -458,7 +466,10 @@ pub(in crate::afxdp) fn drain_exact_prepared_items_to_scratch_flow_fair(
         if !suspended && !cos_queue_v_min_continue(queue, v_min_pop_count) {
             break;
         }
-        let Some(front) = cos_queue_front_with_cap(queue, target_bps) else {
+        // #1763 Lever A — fused select+pop (Prepared cap-aware arm).
+        // Budget break abandons without popping (1 scan); commit reuses
+        // `bucket` (no re-scan). See the Local arm for the invariant.
+        let Some((bucket, front)) = cos_queue_peek_min_bucket(queue, target_bps) else {
             break;
         };
         let len = match front {
@@ -469,7 +480,7 @@ pub(in crate::afxdp) fn drain_exact_prepared_items_to_scratch_flow_fair(
             break;
         }
         let Some(CoSPendingTxItem::Prepared(mut req)) =
-            cos_queue_pop_front_with_cap(queue, target_bps)
+            cos_queue_pop_known_bucket(queue, bucket, target_bps)
         else {
             break;
         };

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -31,7 +31,7 @@ use crate::xsk_ffi::xdp::XdpDesc;
 use super::{
     COS_MIN_BURST_BYTES, CoSQueueLeaseAcquireTelemetry, cos_item_len,
     cos_queue_clear_orphan_snapshot_after_drop, cos_queue_front, cos_queue_front_with_cap,
-    cos_queue_is_empty, cos_queue_pop_front, cos_queue_pop_front_with_cap, cos_queue_push_front,
+    cos_queue_is_empty, cos_queue_peek_min_bucket, cos_queue_pop_known_bucket, cos_queue_push_front,
     cos_queue_v_min_consume_suspension, cos_queue_v_min_continue, cos_refill_ns_until,
     maybe_top_up_cos_queue_lease, publish_committed_queue_vtime, refill_cos_tokens,
 };
@@ -1602,7 +1602,12 @@ fn build_cos_batch_from_queue(
             let mut remaining_secondary = secondary_budget;
             let mut batch_bytes = 0u64;
             while items.len() < TX_BATCH_SIZE {
-                let Some(front) = cos_queue_front(queue) else {
+                // #1763 Lever A — fused select+pop. Peek returns the
+                // min-finish bucket id; if we commit to popping, reuse
+                // that exact bucket (no re-scan). No queue mutation
+                // occurs between peek and the matching pop, so the
+                // selected bucket is byte-identical to a re-scan.
+                let Some((bucket, front)) = cos_queue_peek_min_bucket(queue, u64::MAX) else {
                     break;
                 };
                 let len = cos_item_len(front);
@@ -1614,7 +1619,7 @@ fn build_cos_batch_from_queue(
                 }
                 remaining_root = remaining_root.saturating_sub(len);
                 remaining_secondary = remaining_secondary.saturating_sub(len);
-                match cos_queue_pop_front(queue) {
+                match cos_queue_pop_known_bucket(queue, bucket, u64::MAX) {
                     Some(CoSPendingTxItem::Local(req)) => {
                         batch_bytes = batch_bytes.saturating_add(len);
                         items.push_back(req);
@@ -1643,7 +1648,9 @@ fn build_cos_batch_from_queue(
             let mut remaining_secondary = secondary_budget;
             let mut batch_bytes = 0u64;
             while items.len() < TX_BATCH_SIZE {
-                let Some(front) = cos_queue_front(queue) else {
+                // #1763 Lever A — fused select+pop (Prepared arm). See
+                // the Local arm above for the no-mutation invariant.
+                let Some((bucket, front)) = cos_queue_peek_min_bucket(queue, u64::MAX) else {
                     break;
                 };
                 let len = cos_item_len(front);
@@ -1655,7 +1662,7 @@ fn build_cos_batch_from_queue(
                 }
                 remaining_root = remaining_root.saturating_sub(len);
                 remaining_secondary = remaining_secondary.saturating_sub(len);
-                match cos_queue_pop_front(queue) {
+                match cos_queue_pop_known_bucket(queue, bucket, u64::MAX) {
                     Some(CoSPendingTxItem::Prepared(req)) => {
                         batch_bytes = batch_bytes.saturating_add(len);
                         items.push_back(req);

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -30,8 +30,8 @@ use crate::xsk_ffi::xdp::XdpDesc;
 
 use super::{
     COS_MIN_BURST_BYTES, CoSQueueLeaseAcquireTelemetry, cos_item_len,
-    cos_queue_clear_orphan_snapshot_after_drop, cos_queue_front, cos_queue_is_empty,
-    cos_queue_peek_min_bucket, cos_queue_pop_known_bucket, cos_queue_push_front,
+    cos_queue_clear_orphan_snapshot_after_drop, cos_queue_front, cos_queue_front_with_cap,
+    cos_queue_is_empty, cos_queue_peek_min_bucket, cos_queue_pop_known_bucket, cos_queue_push_front,
     cos_queue_v_min_consume_suspension, cos_queue_v_min_continue, cos_refill_ns_until,
     maybe_top_up_cos_queue_lease, publish_committed_queue_vtime, refill_cos_tokens,
 };

--- a/userspace-dp/src/afxdp/cos/queue_service/mod.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/mod.rs
@@ -30,8 +30,8 @@ use crate::xsk_ffi::xdp::XdpDesc;
 
 use super::{
     COS_MIN_BURST_BYTES, CoSQueueLeaseAcquireTelemetry, cos_item_len,
-    cos_queue_clear_orphan_snapshot_after_drop, cos_queue_front, cos_queue_front_with_cap,
-    cos_queue_is_empty, cos_queue_peek_min_bucket, cos_queue_pop_known_bucket, cos_queue_push_front,
+    cos_queue_clear_orphan_snapshot_after_drop, cos_queue_front, cos_queue_is_empty,
+    cos_queue_peek_min_bucket, cos_queue_pop_known_bucket, cos_queue_push_front,
     cos_queue_v_min_consume_suspension, cos_queue_v_min_continue, cos_refill_ns_until,
     maybe_top_up_cos_queue_lease, publish_committed_queue_vtime, refill_cos_tokens,
 };


### PR DESCRIPTION
## Summary

Path 1 of #1763 (residual CPU levers, sub-path of #1752). The MQFQ
min-head-finish bucket scan (`cos_queue_min_finish_bucket`, an O(N)
linear scan over the active flow-bucket ring, **N=14 measured** under
iperf3 `-P48` on the loss userspace cluster) ran **twice per successful
dequeue** on every hot drain path: once in the `cos_queue_front*` peek to
select the bucket, then again inside `cos_queue_pop_front*` to re-derive
the same bucket. No queue mutation occurs between peek and pop, so the
second scan re-computes a byte-identical result.
`cos_queue_pop_front_inner_with_cap` was **4.28% worker self-time**,
dominated by this redundant scan.

The converged research plan (Codex + AGY + Claude SMR PLAN-READY) killed
the heap/structure-replacement framing at N=14 and converged on two
fairness-neutral-by-construction levers:

- **Lever A — fused select+pop.** `cos_queue_peek_min_bucket` returns the
  selected bucket id alongside the head item; the caller inspects
  len/type/budget/mirror gating and, if it commits, pops that exact
  bucket via `cos_queue_pop_known_bucket` with NO re-scan. Peek-then-
  abandon paths (budget break) stay at exactly one scan -> strictly
  non-regressing. A `debug_assert` re-runs the scan in dev/test and
  verifies the known bucket is still the active-front winner, guarding
  the no-mutation invariant.
- **Lever B — `target_bps == u64::MAX` no-cap fast path.** Every
  best-effort caller passes the no-cap sentinel where `observed <=
  u64::MAX` always holds, so the eligible/fallback two-pass collapses and
  the second strided `flow_bucket_observed_bps` load is dead.
  `cos_queue_min_finish_bucket_no_cap` scans only
  `flow_bucket_head_finish_bytes`, halving per-bucket cache-miss exposure
  (the two arrays live on different cache lines). Selection is
  byte-identical to the cap-aware loop at `target_bps == u64::MAX`.

Wired all three hot drain paths: the no-cap best-effort builder
(`build_cos_batch_from_queue`, Local + Prepared arms) and the cap-aware
exact drains (`drain_exact_*_to_scratch_flow_fair`, Local + Prepared).

**Path 2 (neighbor/rtnl) is PLAN-KILLED and untouched** — `neigh_add`
fires 0/s at steady state; the issue's 45 ops/s was a cold-start
transient.

## Fairness-neutrality — the hard gate

This is the #1207/#1545 CoS-fairness-selection path; any change that
picks a different bucket is a fairness regression. `fused_diff_tests.rs`
builds two independent identically-configured flow-fair queues, drives
the SAME enqueue/pop/push_front/drain sequence through both (reference =
original double-scan `cos_queue_front*` + `cos_queue_pop_front*`; fused =
`cos_queue_peek_min_bucket` + `cos_queue_pop_known_bucket`) and asserts
after EVERY op that the popped item identity AND the full observable
`FlowFairState` (queue_vtime, active ring order, per-bucket head/tail
finish, per-bucket item lengths, pop-snapshot stack, queued_bytes,
local_item_count) are byte-identical. Scenarios: single bucket, N buckets
equal-finish (tie-break by ring order), skewed finish, idle re-anchor,
snapshot rollback, cap over-cap mix, interleaved cap/no-cap, drain_all
residual order, no-snapshot parity, full TX_BATCH_SIZE batch, and a
40-seed randomized sequence test (~240 mixed ops each, N=14 regime). All
11 pass; the differential **proves identical selection order**.

## Test plan

- `cargo build --release` clean (warning count unchanged vs baseline).
- `cargo test --release` full suite green (1729 + integration);
  5x flake clean on `fused_diff` + `flow_fair` CoS tests.
- Go suite green (short TMPDIR; long unix socket paths >108 chars are an
  env artifact).
- Smoke matrix on loss userspace cluster (CoS off + per-class CoS on,
  v4+v6, push+`-R`) + per-flow CoV-neutrality check (`-P12 -p5210`).
- Perf re-profile under `-P48 -p5210` CoS-on: confirm pop self-time drops.
- `make test-failover` (exact-queue HA sync).

Perf delta, CoV result, smoke, and failover results posted below once the
cluster runs land.

Closes #1763
Part of #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)