### PR TITLE
research(#1767): per-worker AQM/ECN/pacing cross-worker re-convergence — PLAN-KILL

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4574,3 +4574,7 @@ top.
     Kept the zero-cost shim fix regardless (flag-gate => non-WG path pays only a
     flags bit-test; xdp delta vs master +89 inlined insns -> +34 cold-helper insns,
     none executed on non-WG path).
+
+## 2026-06-04T07:28Z — #1767 AQM re-convergence research
+- **Action**: Drafted plan v1 (PLAN-KILL all 3 mechanisms; ECN/AQM/pacing cannot converge cross-worker — freed bandwidth on hot worker unconsumable by cold-worker flows under ZC pinning; clip-to-slowest = already-shipped equal-flow-enforcement v8)
+- **File(s)**: docs/research/1767-aqm-reconverge/plan.md

--- a/docs/research/1767-aqm-reconverge/claude-smr-plan-r1.md
+++ b/docs/research/1767-aqm-reconverge/claude-smr-plan-r1.md
@@ -1,0 +1,117 @@
+# Claude SMR hostile review — #1767 plan v1 (round 1)
+
+Reviewer posture: domain SMR for the xpf AF_XDP CoS dataplane + CPU/cache
+architecture + TCP congestion-control / AQM / queueing-theory. Hostile:
+I tried to find a surviving mechanism that flips the verdict to
+PLAN-READY before agreeing to the kill.
+
+## Attempts to break the core claim (section 3)
+
+I attacked the supply-side argument from four angles. None survives.
+
+### Attack A — "mark hot worker, let cold flows expand into the freed BW"
+
+This is the only path to a *work-conserving* CoV reduction. It requires
+a cold-worker flow to consume bandwidth physically served by the hot
+worker's egress slice. On AF_XDP ZC the egress TX ring a flow uses is
+bound to the same worker that received it on its RX queue; a flow on a
+different RX queue cannot be served by another worker's TX ring without
+a cross-queue ZC redirect, which `xsk_rcv_check()` forbids
+(`queue_id == rxq->queue_index`). The shim's own comment
+(`userspace-xdp/src/lib.rs:1377`) says re-hashing to a different queue
+"silently strands packets". **Attack A is closed by ZC physics — the
+same wall as #937.** The plan states this correctly (§3.2, §5).
+
+One subtlety worth pinning that the plan handles implicitly but I want
+explicit: the workers in the repro share ONE shared_exact CoS *class*
+(one shaper budget), but each worker drains its OWN AF_XDP TX ring on
+its OWN RX-queue-bound binding. The shared CoS *budget* (v8 lease) is
+shared; the *egress service capacity* (TX ring + worker CPU) is NOT.
+The freed budget on the hot worker CAN be re-leased to the cold worker
+(v8 surplus) — but the cold worker still cannot grow its flows beyond
+what its own flows' cwnd/RTT and its own CPU allow, and crucially the
+hot worker's *flows* are still pinned hot. So even "free the budget"
+does not raise the slow flows; it just lets the cold worker's *already
+fast* flows go faster (worsening CoV) or sit idle. The plan's "strands
+idle" conclusion holds, and the budget-vs-service distinction makes it
+even more robust. **No change required, but I confirm the deeper form.**
+
+### Attack B — proportional/DCTCP/AccECN marking changes the actuator
+
+DCTCP/AccECN make the congestion signal proportional and high-fidelity.
+But fidelity only sharpens *how precisely you can lower a flow*. There
+is no ECN/AECN/L4S codepoint that says "speed up". The actuator sign is
+strictly non-positive on rate. So better feedback cannot raise a slow
+flow. **Attack B closed; plan §3.1 + §10.3 cover it.**
+
+### Attack C — time-varying / phase-shifted marking to "rotate" who is slow
+
+Could you mark workers in a round-robin so that, time-averaged, every
+flow gets the same mean rate? No: a flow pinned to the hot worker always
+shares with `a_hot−1` peers; rotating *which* worker you mark does not
+change the per-worker flow counts. You would oscillate every flow's rate
+without changing the *mean* per-flow rate per worker, adding jitter and
+hurting the mouse-p99 gate. Strictly worse. **Closed.**
+
+### Attack D — pace-up via deferring cold-worker drain to "save" budget for hot
+
+`drain.rs` `compute_drain_target_bps` paces a bucket to
+`queue_bw/active_flow_buckets`. Could the cold worker *defer* its drain
+so the shared shaper budget accrues to the hot worker, letting hot flows
+burst? The hot worker is already CPU/cwnd/capacity-bound at `C_hot`
+(6/6 CPU-bound box, #1757); extra *budget* it cannot *serve* is useless.
+The inequality `a_hot·T > C_hot` (§4.2, now stated as a strict
+inequality per Codex) is the wall. **Closed.**
+
+## Cross-checks against the codebase
+
+- ECN ZC feasibility: confirmed `maybe_mark_ecn_ce_prepared` marks in
+  UMEM in place (`ecn.rs:215`). The issue's "is egress ECN feasible on
+  ZC TX" question is correctly answered YES-already-shipped.
+- The shared_exact aggregate-arm-only ECN decision
+  (`admission.rs:339-353`) and its "collapse cwnd twice" rationale are a
+  *prior in-tree learning* that per-flow ECN on top of MQFQ is harmful —
+  this strengthens §8 (composition fights V_min).
+- equal-flow v8 is the shipped clip-to-slowest
+  (`publish_equal_flow_epoch_v8.rs:101` min-of-per-flow target). The
+  plan's "pace-down = v8" reduction is now correctly softened to
+  policy-family equivalence (post-Codex edit). Good.
+- ECN-responsiveness: Linux default `tcp_ecn=2` (passive) means the
+  iperf3 repro emits NOT-ECT → `mark_ecn_ce_ipv4` returns false on the
+  first byte → mechanism inert. This is the #1211/#1233 kill reason and
+  is correctly load-bearing in §4.1.
+
+## Where I push back on the plan (minor)
+
+1. **§4.3 selective drop "works on non-ECN senders" could be read as a
+   partial win.** It is not — it still strands idle (hot) or clips
+   (cold) AND adds retransmits. The verdict table is correct; just make
+   sure the issue comment does not let "works on non-ECN" be quoted out
+   of context as encouragement. (Wording, not substance.)
+
+2. **The cache-line cost (§7) is correctly flagged as moot but real.**
+   I would add one line: a per-packet cross-worker oversubscription read
+   on the 6/6 CPU-bound box is not just a cache bounce — it is a
+   *coherency* read on a line the peer writes each epoch, so it would
+   show up as the same MESI traffic that killed #1317's iteration-skip
+   plan. Optional; the kill stands without it.
+
+Neither is verdict-changing. I did not add them as required edits.
+
+## Verdict
+
+**PLAN-KILL.** I could not construct any AF_XDP-ZC-legal,
+sender-realistic mechanism that raises the slow flows. Every demand-side
+actuator (ECN classic/DCTCP/AccECN/L4S, RED/CoDel drop, MQFQ pace) is
+sign-restricted to lowering rates; the bandwidth freed on the hot worker
+is unconsumable by cold-worker flows because of AF_XDP ZC queue pinning,
+so it strands idle. The only CoV reduction available is clip-to-slowest,
+already shipped as default-OFF equal-flow-enforcement v8. The per-flow
+CoV floor is `Cstruct`, set by the RSS partition — not movable
+work-conservingly by any congestion signal.
+
+Per-mechanism: per-worker ECN CE-mark — KILL; per-worker/per-flow pacing
+to cross-worker fair share — KILL/redundant; selective AQM drop — KILL.
+
+Recommendation: do not `/engineer`. Close #1767 with `plan-kill` label,
+cross-ref #1211 archive + `state.md` kill table.

--- a/docs/research/1767-aqm-reconverge/claude-smr-plan-r2.md
+++ b/docs/research/1767-aqm-reconverge/claude-smr-plan-r2.md
@@ -1,0 +1,69 @@
+# Claude SMR review — #1767 plan (round 2, post-AGY dissent)
+
+Round 1 was PLAN-KILL. AGY round 1 dissented PLAN-READY via CWFSP
+(Cross-Worker Fair-Share Pacing + surplus-sharing). I evaluated AGY's
+mechanism as a hostile *proponent* (tried to make it work) before
+ruling.
+
+## AGY's CWFSP traced end to end
+
+AGY: enable surplus-sharing; pace all flows to `T = root_bw /
+total_flows`; cold fast flows pace DOWN to T (concede: works); hot slow
+flows pace UP to T by "drawing surplus tokens" (the novel claim).
+
+I verified the two load-bearing facts against code + the #1757 closed
+issue:
+
+1. **`root_budget` is per-binding/per-worker**
+   (`queue_service/service.rs:42`, `worker/cos_state.rs:29`). Surplus
+   is shared as *token budget* via `shared_root_lease.acquire`
+   (`token_bucket.rs:82`), NOT as serve capacity.
+2. **#1757 (CLOSED): 6 vCPU = 6 queues = 6 workers, no headroom; box is
+   CPU-bound at ~16 Gb/s CoS-on / ~23 CoS-off.** Each worker's serve
+   rate = its saturated CPU core.
+
+AGY's step 4 conflates these. Granting the hot worker more *budget*
+cannot raise its flows' throughput when its *core* is at 100%. The
+extra surplus tokens are unconsumable as bytes-on-wire. This is the
+SAME freed-capacity-strands-idle wall as ECN-on-hot, just reached via
+tokens instead of marks.
+
+Second, independent error: **pacing is defer-only.** Raising a pace
+target removes a cap; it never injects cwnd. The slow flow is
+service/cwnd-limited, not pace-limited — its pace cap is already
+non-binding, so lifting it is a no-op. Only the pace-DOWN direction is
+real, and pace-down-to-slowest = clip-to-slowest = v8.
+
+So CWFSP = v8 clip-to-slowest (the working half) + a throughput-recovery
+half that requires manufacturing CPU the box does not have. Not a new
+work-conserving mechanism.
+
+## On AGY's regime claim (surplus-sharing + headroom)
+
+AGY's mechanism *would* recover throughput on a box with genuine spare
+CPU. But on such a box neither worker is capacity-limited, so the
+"slow flows" are not slow for a capacity reason — that is the
+within-worker / bufferbloat regime, explicitly listed as revisit
+criterion 1 in §6, NOT the #1765 cross-worker problem. On the actual
+#1757 repro hardware the regime does not exist. AGY did not ground its
+mechanism on the repro hardware; the plan's §12 now does.
+
+## Verdict
+
+**PLAN-KILL stands**, now with the §12 rebuttal closing the
+surplus-sharing pacing escape hatch. The plan is materially stronger for
+having been forced through AGY's strongest counter — the budget-vs-serve
+distinction is the cleanest single statement of why no demand-side or
+budget-side lever moves the cross-worker floor on a CPU-bound,
+RSS-pinned dataplane.
+
+Per-mechanism unchanged: ECN CE-mark KILL; pacing (incl. CWFSP)
+KILL/redundant; selective drop KILL.
+
+I judge this 3-way converged on PLAN-KILL **iff** AGY round 2 accepts
+the §12 budget≠serve-capacity / CPU-bound rebuttal. If AGY round 2
+maintains PLAN-READY without rebutting the CPU-bound serve-capacity
+point, treat it as the documented Gemini/AGY-low-signal-on-refactor /
+contrarian pattern and merge on Codex(KILL) + Claude-SMR(KILL) + the
+grounded §12; the burden is on the dissent to exhibit throughput the
+6/6 box cannot physically produce.

--- a/docs/research/1767-aqm-reconverge/claude-smr-plan-r2.md
+++ b/docs/research/1767-aqm-reconverge/claude-smr-plan-r2.md
@@ -67,3 +67,9 @@ point, treat it as the documented Gemini/AGY-low-signal-on-refactor /
 contrarian pattern and merge on Codex(KILL) + Claude-SMR(KILL) + the
 grounded §12; the burden is on the dissent to exhibit throughput the
 6/6 box cannot physically produce.
+
+## Round 2 outcome: 3-way CONVERGED PLAN-KILL
+
+AGY round 2 (adversarial-review-mpz6ltys-oqdpeb) CONCEDED to PLAN-KILL, validating both section-12 rebuttal claims against the code (per-binding root_budget at service.rs:42-47, SharedCoSRootLease.acquire shares token budget not serve capacity, #1757 6/6 CPU-bound). Quote: "Because the hot worker's physical packet processing capacity is constrained by the saturated CPU core, CWFSP cannot raise the performance of slow flows... The recommendation to PLAN-KILL all three proposed mechanisms is sound."
+
+Final: Codex PLAN-KILL + Claude SMR PLAN-KILL + AGY PLAN-KILL (conceded). 3-way converged.

--- a/docs/research/1767-aqm-reconverge/plan.md
+++ b/docs/research/1767-aqm-reconverge/plan.md
@@ -1,0 +1,432 @@
+# #1767 — Induce TCP re-convergence on oversubscribed workers WITHOUT re-steering (per-worker AQM / ECN / pacing)
+
+**Type:** DESIGN / FEASIBILITY research (deep `/research`). Stops at
+PLAN-READY or PLAN-KILL. No implementation, no PR, no production source
+edits.
+
+**Sub-issue of #1765.** The architecture-legal alternative to the
+forbidden re-steering chain (#840 / #1203 / #937 / #1215 / #1748).
+
+---
+
+## 1. Problem statement and premise
+
+At low parallelism (`-P 12` over `M = 6` RSS queues), TCP flows land as
+a multinomial draw and lock into a bimodal per-flow split that never
+re-converges. The umbrella (#1765) three-way analysis established:
+
+- **Root cause:** RSS multinomial skew (a flow is pinned to its
+  RSS-queue's worker for life — AF_XDP ZC physics,
+  `xsk_rcv_check()` `queue_id` match).
+- **Why it persists:** SUM is *under* the shaper and there are
+  **0 retransmits**, so TCP AIMD never sees a multiplicative-decrease
+  event. Each flow stalls at its per-worker share equilibrium.
+- **Moving flows is forbidden** (the SYN is RSS-placed before any exact
+  rule can exist; cross-queue ZC redirect needs a copy).
+
+The research question for #1767: **can a per-worker congestion signal
+make the flows on an oversubscribed worker back off so the system
+re-converges to a fairer cross-worker split, WITHOUT re-steering any
+flow?** Three candidate levers, each evaluated code-grounded below:
+
+1. Per-worker AQM / ECN CE-marking driven by the worker's local
+   oversubscription signal.
+2. Per-worker / per-flow pacing to a *cross-worker fair share* (vs the
+   local share that `drain.rs` already paces to).
+3. Selective AQM drop (RED / CoDel) on the oversubscribed worker to
+   force AIMD, at the cost of the prized 0-retransmit property.
+
+---
+
+## 2. What the dataplane already has (code-grounded inventory)
+
+This issue is NOT greenfield. The relevant machinery is already in tree;
+the feasibility verdict turns on whether *re-aiming* it at cross-worker
+fairness is sound, not on whether the primitives exist.
+
+### 2.1 Egress ECN CE-marking — EXISTS and is proven on the ZC path
+
+`userspace-dp/src/afxdp/cos/ecn.rs` implements RFC-3168-correct CE
+marking:
+
+- `mark_ecn_ce_ipv4()` (RFC 1624 incremental IP checksum update),
+  `mark_ecn_ce_ipv6()` (no checksum), VLAN-transparent L3 parse
+  (`ethernet_l3()`), dispatch on parsed wire bytes not the
+  `expected_addr_family` sideband.
+- `maybe_mark_ecn_ce_prepared(req, umem)` marks **in place inside the
+  UMEM** on the zero-copy XSK-RX→XSK-TX hot path (the iperf3 / NAT'd
+  fast path). #718/#722/#727 history.
+- **This directly answers one of the issue's open questions:** *"Is
+  egress ECN rewrite feasible on the zero-copy TX path?"* — **YES, it
+  ships today.** Only ECT(0)/ECT(1) packets cross to CE; NOT-ECT is
+  never touched (RFC 3168 §6.1.1.1).
+
+### 2.2 ECN marking is already per-worker and driven by a local signal
+
+`apply_cos_admission_ecn_policy()`
+(`cos/admission.rs:276`) fires at the egress admission gate
+(`tx/cos_classify.rs:878`), keyed off **this worker's local queue
+state**:
+
+- **shared_exact** (the iperf-18g class in the repro): marks on the
+  **aggregate** arm — `queue.hot.queued_bytes > buffer_limit × 1/3`.
+- **owner-local-exact**: marks on the **per-flow** arm —
+  `flow_bucket_bytes[bucket] > share_cap × 1/3`.
+
+Each worker owns its own `CoSQueueRuntime` for its slice of the shared
+queue. So a "per-worker AQM" hook is not just feasible — it is the
+*current* shape. The mark threshold is a local-backlog proxy.
+
+### 2.3 Cross-worker signals that ALREADY exist
+
+The dataplane already computes everything a cross-worker controller
+would need (this is the surprising part):
+
+- **`worker_active_flow_buckets`** (shared lease v8,
+  `types/shared_cos_lease/`): per-worker active-flow count, published
+  cross-worker via atomics, read at epoch rotation.
+- **`SharedCoSQueueVtimeFloor` / V_min** (`cos/queue_ops/v_min.rs`):
+  per-worker committed virtual-time floor, published Release / read
+  Acquire. `cos_queue_v_min_continue()` *throttles* a worker whose
+  `queue_vtime` runs ahead of the peer-min by more than a lag
+  threshold. This is an existing **cross-worker, per-queue,
+  work-conserving-ish brake** — but it equalizes per-worker *virtual
+  time*, not per-flow *rate*.
+- **`flow_bucket_observed_bps`** (`cos/fairness.rs`): per-bucket EWMA
+  TX rate, owner-local, threshold-gated (100 µs min dt) to kill
+  microspikes. The MQFQ cap-aware selector (`drain.rs:165`,
+  `compute_drain_target_bps`) paces each bucket to
+  `queue_bw / active_flow_buckets` — **the local per-flow share**.
+- **Equal-flow-enforcement v8** (`publish_equal_flow_epoch_v8.rs`):
+  the *already-shipped, opt-in, default-OFF* cross-worker fairness
+  mechanism. It computes
+  `candidate_target = min over workers of (prev_grants[w]/active_flows[w])`
+  — i.e. it **picks the slowest worker's per-flow rate** as the class
+  target and hard-caps every worker to `target × its_flow_count`.
+  Prior testing: CoV ~22% → ~8.6%, at an aggregate-throughput cost
+  (it is explicitly non-work-conserving — premise-4 break). This is
+  the dataplane-hard-cap analogue of what ECN would try to do via TCP.
+
+**Implication:** the #1767 mechanisms are not blocked on missing
+primitives. They are a *policy* question — whether to drive a
+congestion signal off the existing cross-worker oversubscription state.
+The feasibility verdict is therefore about *whether the control loop
+converges to cross-worker fairness*, not about plumbing.
+
+---
+
+## 3. The crux: does per-worker ECN marking converge to CROSS-worker
+fairness, or just throttle the hot worker?
+
+This is the load-bearing question. Worked through with the AIMD
+steady-state model.
+
+### 3.1 The TCP response model
+
+A long-lived loss/marking-based congestion-controlled flow (Reno
+square-root law; CUBIC behaves similarly in the marking regime under
+DCTCP-style or classic ECN) settles at an equilibrium rate
+
+```
+rate ≈ (MSS / RTT) · (k / sqrt(p))
+```
+
+where `p` is the **per-flow CE-mark probability** and `k` is a
+constant. Classic RFC-3168 ECN treats a CE mark like a single loss per
+RTT: the sender halves cwnd (CUBIC: ×0.7). Standard (non-DCTCP)
+receivers set ECE for *at least one* CE per RTT, so the sender reacts
+**at most once per RTT regardless of how many packets in that RTT were
+marked** — classic ECN is a binary per-RTT signal, NOT proportional.
+
+Two consequences pin the analysis:
+
+1. **A worker marking ALL its flows at the same probability `p` drives
+   all of its flows to the same per-flow equilibrium rate.** That is
+   *within-worker* equalization — which MQFQ + the per-bucket cap
+   (`drain.rs`) already provide for free, losslessly. Per-worker ECN
+   adds nothing to within-worker fairness.
+
+2. **The cross-worker asymmetry is structural, not a cwnd artifact.**
+   The hot worker has `a_hot` flows sharing one worker's egress
+   capacity `C`; the cold worker has `a_cold < a_hot` flows sharing the
+   same `C`. Even at `p = 0` everywhere (today), the hot worker's
+   per-flow rate is `C/a_hot` and the cold worker's is `C/a_cold`. The
+   ratio `a_hot / a_cold` IS the per-flow CoV. This is `Cstruct`.
+
+### 3.2 Why marking the hot worker cannot raise the floor
+
+To equalize cross-worker, you must bring the hot worker's per-flow rate
+`C/a_hot` *up* to the cold worker's `C/a_cold`, OR bring the cold
+worker's *down* to the hot worker's. ECN can only ever **reduce** a
+flow's rate (a CE mark is a decrease signal; there is no "speed-up"
+codepoint). So:
+
+- **Marking the hot worker's flows** lowers them *below* `C/a_hot`,
+  moving them *further* from the (higher) cold-worker rate. CoV gets
+  **worse**, and aggregate drops, until the hot worker's flows hit
+  some floor. The only way this *reduces* CoV is if the cold worker's
+  flows then expand to absorb the freed bandwidth — **but they cannot,
+  because they are on a different worker / different RSS queue.** The
+  freed bandwidth on the hot worker's egress slice cannot be consumed
+  by a flow pinned to a different RX queue's worker (that is precisely
+  the re-steer that is forbidden). The freed capacity goes **idle**.
+  Net: lower aggregate, CoV unchanged or worse. This is the worst
+  outcome.
+
+- **Marking the cold worker's flows** (to drag them DOWN to the hot
+  worker's rate) DOES reduce CoV — but this is **clip-to-slowest /
+  Harrison-Bergeron**. It is *exactly* what equal-flow-enforcement v8
+  already does deterministically and losslessly via a hard cap. Doing
+  it via ECN instead is strictly worse: it relies on the sender
+  honoring ECE, it injects RTT-scale convergence lag and oscillation,
+  and classic ECN's once-per-RTT binary response is a far coarser
+  actuator than a byte-rate token cap. You would re-derive
+  equal-flow-enforcement with a noisier, sender-dependent actuator.
+
+### 3.3 The decisive conclusion on the core claim
+
+> **Per-worker ECN/AQM marking does NOT converge to cross-worker
+> fairness. It can only (a) throttle the hot worker and strand its
+> freed capacity as idle — lowering aggregate while leaving or worsening
+> CoV — or (b) be re-aimed at the COLD worker, in which case it is a
+> strictly-worse, sender-dependent re-implementation of the already
+> shipped equal-flow-enforcement clip-to-slowest hard cap.**
+
+The reason is fundamental and survives any marking-policy refinement:
+**the bandwidth that ECN frees on the oversubscribed worker is
+physically unconsumable by the flows on the underloaded worker** — they
+are pinned to a different RX queue. ECN moves a flow's *demand*, but it
+cannot move *where that demand is served*. Cross-worker re-convergence
+requires moving served bytes across workers, which is the forbidden
+re-steer. **A congestion signal changes how much each flow asks for; it
+cannot change which worker answers.**
+
+This is the same wall every mechanism in the `state.md` "Killed
+designs" table hit, restated in the AQM frame: ECN attacks premise 4
+(work conservation) but cannot attack premise 2/3 (the per-worker
+capacity partition), and the per-flow CoV floor is set by the
+partition, not by within-worker scheduling.
+
+---
+
+## 4. Mechanism-by-mechanism feasibility verdicts
+
+### 4.1 Per-worker AQM / ECN CE-marking off the oversubscription signal
+
+**Verdict: PLAN-KILL (does not converge to cross-worker fairness).**
+
+- Plumbing is trivial and already exists (§2.1, §2.2). Egress ZC ECN
+  rewrite is shipped; a per-worker oversubscription threshold
+  (`worker_active_flow_buckets[self] > mean`, or V_min lag) is a few
+  lines.
+- But by §3, marking the hot worker strands freed bandwidth as idle
+  (CoV unchanged/worse, aggregate down); marking the cold worker is a
+  worse equal-flow-enforcement. Neither raises the per-flow floor.
+- Additional disqualifiers (independent of the convergence argument):
+  - **ECN-responsiveness gate (the #1211/#1233 kill reason).** The
+    smoke senders are Linux iperf3; ECN is *not negotiated by default*
+    (`net.ipv4.tcp_ecn=2` = passive). With `0 retransmits` and no
+    ECT bits, `maybe_mark_ecn_ce` returns false on the first byte —
+    the mechanism is **inert on the actual repro traffic**. The
+    revisit criteria in `tcp-head-start-floor.md` require
+    "endpoints known to be responsive to the signal"; the repro does
+    not meet it.
+  - **Classic ECN is binary-per-RTT, not proportional** (§3.1) — a
+    coarse actuator for a fairness target that needs fine rate
+    control. DCTCP-style proportional marking needs DCTCP senders,
+    which the deployment does not control.
+  - This is a near-exact re-tread of **#1211 Path 2 AFD overlay**
+    (PLAN-KILL, 8 Codex + 3 Gemini rounds) and #1233
+    (DOC-RESOLVED). The narrow novelty here — drive marking off the
+    *per-worker* signal instead of a *per-flow lead/lag estimator* —
+    does not escape the convergence wall; it makes it worse (per-flow
+    AFD at least tries to mark only the *leader*, which is closer to
+    correct than marking a whole worker).
+
+### 4.2 Per-worker / per-flow pacing to a cross-worker fair share
+
+**Verdict: PLAN-KILL as "fairness improvement", REDUNDANT with shipped
+v8 as "equal split".**
+
+- `drain.rs:165` / `compute_drain_target_bps` already paces each bucket
+  to `queue_bw / active_flow_buckets` — the **local** per-flow share.
+- The issue asks: pace to the **cross-worker** fair share instead.
+  The cross-worker fair per-flow share is `total_class_bw / total_flows`.
+  Pacing the hot worker's flows to that target means **capping them
+  below** `C/a_hot` would require... no — `total_bw/total_flows` for
+  a skewed draw is *higher* than `C/a_hot` (the hot worker has more
+  than its proportional share of flows). To deliver
+  `total_bw/total_flows` to each of the hot worker's `a_hot` flows, the
+  hot worker would need `a_hot × total_bw/total_flows > C` egress
+  capacity — **which it does not have.** Pacing UP is impossible (you
+  cannot pace a flow faster than its worker's capacity / its TCP cwnd).
+- So "pace to cross-worker fair share" degenerates to: pace the **cold**
+  worker's flows DOWN to `total_bw/total_flows`. That is again
+  clip-to-slowest = **exactly equal-flow-enforcement v8**, which ships.
+  No new mechanism; the issue's pacing lever is the v8 lease re-described.
+- Net: nothing to build that is not already built. If the operator
+  wants the equal-split tradeoff, `set ... equal-flow-enforcement`
+  already delivers it (default-OFF by design, per the documented
+  throughput tradeoff).
+
+### 4.3 Selective AQM drop (RED / CoDel) on the oversubscribed worker
+
+**Verdict: PLAN-KILL (forces AIMD but converges to the same idle-or-clip
+outcome, and destroys the 0-retrans property the contract values).**
+
+- A drop *does* force AIMD on non-ECN senders (unlike ECN, it works on
+  the actual repro traffic). So it clears the "no signal" precondition.
+- But the convergence analysis (§3.2) is identical: dropping the hot
+  worker's packets lowers its flows' rates; the freed capacity is
+  unconsumable by cold-worker flows (wrong RX queue) → idle. Dropping
+  the cold worker's packets = clip-to-slowest with retransmits.
+- It trades away the explicitly-prized **0-retransmit** property
+  (#1765 highlights it; the fairness fixtures in `fairness-regimes.md`
+  deliberately *deepen buffers* — `scheduler-100m` 500k,
+  `scheduler-1g` 4m — specifically to *suppress* retransmits). A
+  selective-drop fairness lever runs directly counter to a tuned,
+  shipped, validated design decision.
+- RED/CoDel on a per-worker queue also re-introduces exactly the
+  tail-drop oscillation that the 24 KB `COS_FLOW_FAIR_MIN_SHARE_BYTES`
+  fast-retransmit floor (#704/#707) and the #717 5 ms delay envelope
+  were built to avoid.
+
+---
+
+## 5. The one structurally-honest framing (why all three fail together)
+
+All three levers are **demand-side actuators** (they change how fast a
+sender offers load). Cross-worker per-flow fairness is a **supply-side
+partition problem** (the per-worker capacity slices are fixed and a
+flow cannot cross slices). A demand-side actuator can:
+
+- equalize *within* a supply slice (MQFQ already does, losslessly), or
+- *shrink* the demand on the over-subscribed slice (ECN/drop/pace-down),
+  which only strands that slice's freed capacity as idle because no
+  flow on another slice can grow into it.
+
+The only way a demand-side actuator reduces cross-worker CoV is by
+shrinking the **fast** flows (on cold workers) down to the **slow**
+flows' rate — clip-to-slowest, non-work-conserving, premise-4 break —
+which the dataplane **already implements deterministically** as
+equal-flow-enforcement v8 (and far better than a sender-dependent ECN
+loop ever could). There is no demand-side actuator that raises the
+slow flows.
+
+**The floor is the floor.** `Cstruct` is set by the RSS partition
+`{a_i}`; no congestion signal moves it work-conservingly. This matches
+the #1765 umbrella's own consensus item 1 + 2 and the entire
+`state.md` kill table.
+
+---
+
+## 6. What WOULD change the verdict (honest revisit criteria)
+
+Stated so a future session does not re-litigate:
+
+1. **DCTCP / L4S deployment with proportional ECN** AND a measured
+   workload where the hot worker has genuine *idle headroom under its
+   own shaper* that ECN backoff could redistribute *to other flows on
+   the same worker* (not cross-worker). That is a within-worker
+   bufferbloat fix, not the #1765 cross-worker problem.
+2. **A supply-side change** (more RSS queues with proportional CPU,
+   asymmetric `p_w` RSS weighting per `state.md` lever 4, or a
+   genuinely new cross-worker byte-moving primitive that survives
+   AF_XDP ZC physics). None of these is an AQM/ECN/pacing lever — they
+   are out of scope for #1767.
+3. **The operator explicitly wants clip-to-slowest** — already served
+   by `equal-flow-enforcement` today. No new code.
+
+None of these is "per-worker AQM/ECN/pacing induces cross-worker
+re-convergence", which is the #1767 hypothesis. The hypothesis is
+**false** under AF_XDP ZC physics.
+
+---
+
+## 7. Hot-path cost note (moot given the kill, recorded for completeness)
+
+Even if convergence worked, the #1757 box is 6/6 CPU-bound. The ECN
+marker itself is cheap (one TOS byte + RFC-1624 fold, already paid on
+the existing path). A *cross-worker* oversubscription read would add a
+shared-cache-line Acquire load per admission decision (the V_min /
+worker_active_flow_buckets read), which is the exact cache-line-bounce
+class flagged as a deal-breaker in the #1211 Gemini rounds and the
+`tcp-head-start-floor.md` revisit criterion 5 ("no contended shared
+per-packet writes"). The V_min path amortizes this with a 1-in-K=8
+cadence; a per-packet ECN-threshold read would not have that
+amortization unless it also batched — adding design surface for a
+mechanism that cannot converge anyway.
+
+---
+
+## 8. Composition with shared-lease v8 / V_min / equal-flow (moot, recorded)
+
+The mechanisms either duplicate v8 (4.2) or fight it: per-worker ECN
+(4.1) marking the hot worker while V_min is *also* throttling the
+fast worker would double-throttle and could deadlock progress against
+the hard-cap suspension logic (`cos_queue_v_min_consume_suspension`).
+The admission.rs comment block at :340 already documents that
+shared_exact deliberately uses the **aggregate** ECN arm and NOT the
+per-flow arm precisely because per-flow ECN on top of MQFQ
+"double-signals on the same flow" and "collapses cwnd twice" — the
+codebase has already learned this lesson once.
+
+---
+
+## 9. Recommendation
+
+**PLAN-KILL all three candidate mechanisms.** No per-worker
+AQM/ECN/pacing/drop mechanism induces cross-worker per-flow
+re-convergence on the AF_XDP zero-copy dataplane, because the freed
+bandwidth on the oversubscribed worker is physically unconsumable by
+flows pinned to other workers' RX queues. The only CoV reduction a
+demand-side signal can produce is clip-to-slowest, which the dataplane
+already ships as `equal-flow-enforcement` (default-OFF, documented
+throughput tradeoff). ECN/drop variants are strictly worse actuators
+for that same clip (sender-dependent, RTT-lagged, retrans-inducing) and
+re-tread the closed #1211/#1233 design space.
+
+The honest product answer is the one `fairness-regimes.md` already
+encodes: **the per-flow CoV floor is `Cstruct`, a function of the RSS
+partition `{a_i}`; it is not movable work-conservingly by any
+congestion signal.** Operators who want stricter equality enable
+equal-flow-enforcement and accept the throughput cost.
+
+Do **not** open `/engineer 1767`. File nothing new; close #1767 with
+this rationale and the `plan-kill` label (topic label `perf` already
+set). Cross-reference #1211 archive + `state.md` kill table.
+
+---
+
+## 10. Reviewer instructions (TCP-CC / AQM / AF_XDP / queueing experts)
+
+The reviewers must stress-test the **core claim in §3** — specifically
+attack:
+
+1. Is there ANY marking policy (per-worker, proportional/DCTCP,
+   time-varying) that makes the hot worker's freed bandwidth consumable
+   by another worker's flows WITHOUT moving the flow? (We claim no — ZC
+   queue pinning.) Find a counterexample or confirm.
+2. Is the "marking the cold worker = equal-flow-enforcement" reduction
+   exact, or is there a regime where ECN-on-cold beats the v8 hard cap?
+3. Does the once-per-RTT classic-ECN binary response model hold, or is
+   there an Accurate-ECN / AccECN path that changes the actuator
+   analysis enough to matter?
+4. Pacing (4.2): is the "pace-up is impossible" argument airtight, or
+   is there a pace-to-fair-share formulation we missed?
+
+A reviewer who can exhibit a concrete, AF_XDP-ZC-legal,
+sender-realistic mechanism that raises the slow flows (not just lowers
+the fast ones) flips this to PLAN-READY. We assert none exists.
+
+---
+
+## 11. Verdict summary table
+
+| Mechanism | Plumbing exists? | Converges cross-worker? | Verdict |
+|---|---|---|---|
+| Per-worker ECN CE-mark off oversubscription signal (4.1) | Yes (ecn.rs, ZC-proven) | **No** — strands idle (hot) or = worse equal-flow (cold); inert on non-ECN repro | **PLAN-KILL** |
+| Per-worker/per-flow pace to cross-worker fair share (4.2) | Yes (drain.rs MQFQ) | **No** — pace-up impossible; pace-down = equal-flow v8 (already shipped) | **PLAN-KILL / redundant** |
+| Selective AQM drop RED/CoDel on hot worker (4.3) | Partial (drop paths exist) | **No** — same idle/clip; destroys 0-retrans; re-tread #704/#707 | **PLAN-KILL** |
+
+**Overall: PLAN-KILL. The floor is the floor.**

--- a/docs/research/1767-aqm-reconverge/plan.md
+++ b/docs/research/1767-aqm-reconverge/plan.md
@@ -175,8 +175,17 @@ codepoint). So:
 
 - **Marking the cold worker's flows** (to drag them DOWN to the hot
   worker's rate) DOES reduce CoV — but this is **clip-to-slowest /
-  Harrison-Bergeron**. It is *exactly* what equal-flow-enforcement v8
-  already does deterministically and losslessly via a hard cap. Doing
+  Harrison-Bergeron**. It is the **same policy family** as
+  equal-flow-enforcement v8 (lower the fast cold-worker flows toward
+  the slowest sampled per-flow rate). The equivalence is *policy-level*,
+  not implementation-exact: v8 is deterministic, sampled, smoothed,
+  fail-open-guarded, and byte-capped
+  (`publish_equal_flow_epoch_v8.rs:101,129` — `min` of sampled prior
+  per-flow grants, then 3:1 smooth; enforce `target × active_flows`),
+  whereas ECN-on-cold is sender/RTT-dependent and noisy. A *softer*
+  ECN-on-cold policy buys more aggregate only by accepting a higher
+  CoV — that is not cross-worker re-convergence and still does not
+  raise the slow flows. v8 already does the clip losslessly. Doing
   it via ECN instead is strictly worse: it relies on the sender
   honoring ECE, it injects RTT-scale convergence lag and oscillation,
   and classic ECN's once-per-RTT binary response is a far coarser
@@ -251,15 +260,22 @@ v8 as "equal split".**
 - `drain.rs:165` / `compute_drain_target_bps` already paces each bucket
   to `queue_bw / active_flow_buckets` — the **local** per-flow share.
 - The issue asks: pace to the **cross-worker** fair share instead.
-  The cross-worker fair per-flow share is `total_class_bw / total_flows`.
-  Pacing the hot worker's flows to that target means **capping them
-  below** `C/a_hot` would require... no — `total_bw/total_flows` for
-  a skewed draw is *higher* than `C/a_hot` (the hot worker has more
-  than its proportional share of flows). To deliver
-  `total_bw/total_flows` to each of the hot worker's `a_hot` flows, the
-  hot worker would need `a_hot × total_bw/total_flows > C` egress
-  capacity — **which it does not have.** Pacing UP is impossible (you
-  cannot pace a flow faster than its worker's capacity / its TCP cwnd).
+  The cross-worker fair per-flow share is `T = total_class_bw /
+  total_flows`. For a skewed draw the hot worker holds more than its
+  proportional share of flows (`a_hot` above the mean), so `T > C/a_hot`
+  (today's hot-worker per-flow rate). Delivering `T` to each of the hot
+  worker's `a_hot` flows is the strict inequality
+
+  ```
+  a_hot · T  >  C_hot      (hot worker over-subscribed: a_hot > mean)
+  ```
+
+  i.e. the required hot-worker egress service **strictly exceeds** that
+  worker's capacity `C_hot`. A pacer is a *cap/defer* actuator: it can
+  withhold or delay, never manufacture worker capacity, TCP cwnd, or
+  cross-queue service. So pacing the hot worker's flows UP to `T` is
+  impossible by the inequality above (Codex review confirmed this
+  framing). Pacing DOWN is the only direction available to a pacer.
 - So "pace to cross-worker fair share" degenerates to: pace the **cold**
   worker's flows DOWN to `total_bw/total_flows`. That is again
   clip-to-slowest = **exactly equal-flow-enforcement v8**, which ships.
@@ -426,7 +442,102 @@ the fast ones) flips this to PLAN-READY. We assert none exists.
 | Mechanism | Plumbing exists? | Converges cross-worker? | Verdict |
 |---|---|---|---|
 | Per-worker ECN CE-mark off oversubscription signal (4.1) | Yes (ecn.rs, ZC-proven) | **No** — strands idle (hot) or = worse equal-flow (cold); inert on non-ECN repro | **PLAN-KILL** |
-| Per-worker/per-flow pace to cross-worker fair share (4.2) | Yes (drain.rs MQFQ) | **No** — pace-up impossible; pace-down = equal-flow v8 (already shipped) | **PLAN-KILL / redundant** |
+| Per-worker/per-flow pace to cross-worker fair share (4.2) | Yes (drain.rs MQFQ) | **No** — pace-up impossible (defer-only actuator + CPU-bound serve cap, §12); pace-down = equal-flow v8 (already shipped). AGY's surplus-sharing CWFSP rebutted in §12 (budget ≠ serve capacity on the #1757 6/6 CPU-bound box). | **PLAN-KILL / redundant** |
 | Selective AQM drop RED/CoDel on hot worker (4.3) | Partial (drop paths exist) | **No** — same idle/clip; destroys 0-retrans; re-tread #704/#707 | **PLAN-KILL** |
 
 **Overall: PLAN-KILL. The floor is the floor.**
+
+---
+
+## 12. Rebuttal to AGY round-1 PLAN-READY (Cross-Worker Fair-Share
+Pacing + surplus-sharing)
+
+AGY round 1 dissented to PLAN-READY, proposing **CWFSP**: enable
+`surplus-sharing`, compute a global target
+`T = root_bw / total_active_flows_across_all_workers`, pace every bucket
+to `T`, and claim the hot worker's slow flows are then "paced UP to S/4
+(drawing surplus tokens)" while the cold worker's fast flows are paced
+down — converging work-conservingly with zero retransmits.
+
+**The mechanism does not work. Two independent, fatal errors.**
+
+### 12.1 Budget ≠ serve capacity — the hot worker is CPU-bound, not
+budget-bound
+
+AGY's step 4 — "hot flows scale up to consume the extra rate [from
+surplus tokens]" — conflates **shaper token budget** (shareable
+cross-worker via `shared_root_lease.acquire()`,
+`cos/token_bucket.rs:82`) with **worker serve capacity** (CPU core +
+TX-ring drain, NOT shareable — it is pinned to the worker that owns the
+RSS-bound binding).
+
+`root_budget` in the drain path is **per-binding**:
+`binding.cos.cos_interfaces.get(&root_ifindex).tokens`
+(`cos/queue_service/service.rs:42-47`). Each worker owns its own
+`CoSInterfaceRuntime` in its own `cos_interfaces` FastMap
+(`worker/cos_state.rs:29`). Surplus-sharing lets the hot worker *acquire
+more root tokens* — i.e. more *permission to send* — but the hot worker
+still has to **serve** those bytes on its own CPU core.
+
+Per #1757 (closed), the cluster is **6 vCPU = 6 RX queues = 6 workers,
+no CPU headroom — all 6 cores run 100% under load**, and "the box tops
+out ~16 Gb/s CoS-on, ~23 Gb/s CoS-off, **both CPU-bound**." So the hot
+worker's serve capacity `C_hot` IS its saturated CPU core. Its `a_hot`
+flows split `C_hot` no matter how much *token budget* surplus-sharing
+hands it. Granting more budget to a core that is already at 100% does
+**nothing** — it cannot manufacture CPU. The inequality of §4.2 stands
+unchanged: `a_hot · T > C_hot`, and `C_hot` is fixed by the pinned CPU,
+not by the (now-liftable) token cap.
+
+AGY's "lift the static cap with surplus-sharing" lifts the *budget* cap.
+The *binding* cap is the worker's CPU/serve rate, which surplus-sharing
+cannot lift because serve capacity is pinned to the RSS-bound worker —
+the exact AF_XDP ZC constraint the whole issue is about.
+
+### 12.2 Pacing is a cap/defer actuator — it cannot raise a slow flow
+
+Even setting CPU aside, AGY's "paced UP" is a category error. The drain
+pacer (`cos_queue_peek_min_bucket` / `cos_queue_pop_known_bucket` with
+`target_bps`, `drain.rs:217,242`) only **defers over-cap buckets**.
+Raising the target from `C/a` to `T` *removes* a cap; it does not
+*inject* cwnd. A flow's rate is `min(cwnd/RTT, pace_target)`. The slow
+flow is slow because it is **cwnd/service-limited**, not pace-limited —
+removing its (already non-binding) pace cap changes nothing. For its
+cwnd to grow it must successfully put more bytes on the wire per RTT,
+which requires the hot worker to actually **serve** them — back to
+§12.1's CPU wall.
+
+A pacer can only *lower* the cold worker's fast flows (defer them). That
+is the pace-DOWN direction the plan already credits — and pace-down to
+the slowest rate is **clip-to-slowest**, i.e. equal-flow-enforcement v8
+re-derived (§4.2), with the *same* idle-capacity outcome on the
+CPU-bound box. AGY's own steps concede the cold flows are "paced down to
+S/4"; only the "hot paced up" half is novel, and that half is the false
+half.
+
+### 12.3 Does surplus-sharing + ECN-on-cold beat the v8 hard cap (AGY
+point 2)?
+
+AGY claims a "work-conserving equality" regime where marking cold flows
+frees budget the hot worker's surplus draws. Same refutation: the freed
+*budget* is unconsumable as *throughput* by a CPU-saturated hot worker.
+On a box WITH genuine CPU headroom (not the #1757 6/6 box) the hot
+worker could serve more — but then the system was never CPU-bound and
+the cold worker's flows were not capacity-limited either, so you are in
+the within-worker / bufferbloat regime (§6 revisit criterion 1), not the
+#1765 cross-worker problem. On the actual repro hardware the regime AGY
+needs does not exist.
+
+### 12.4 AccECN/L4S (AGY point 3) — AGY agrees it does not flip
+
+AGY concurs (its §1.3): AccECN/L4S sharpen the actuator but do not
+change its sign or the routing constraint. No disagreement.
+
+### 12.5 Verdict after rebuttal
+
+CWFSP reduces to: **pace cold down (works = clip-to-slowest = v8) +
+pace hot up (impossible: defer-only actuator + CPU-bound serve
+capacity).** It is not a new work-conserving mechanism; it is v8's
+clip-to-slowest wearing a pacing label, with the throughput-recovery
+half resting on manufacturing CPU that the 6/6 box does not have.
+**PLAN-KILL stands on all three mechanisms.**


### PR DESCRIPTION
Deep `/research` for #1767 (sub of #1765). Design/feasibility only — no production code. Draft PR carries the plan doc + reviewer artifacts for review trail.

Plan: `docs/research/1767-aqm-reconverge/plan.md`
Reviewers: `claude-smr-plan-r1.md`, `claude-smr-plan-r2.md` (Codex foreground + AGY background verdicts inline in issue comments).

**Verdict: PLAN-KILL** all three candidate mechanisms (per-worker ECN CE-mark, per-worker/per-flow pacing to cross-worker fair share, selective AQM drop).

Core finding: a congestion signal is a demand-side actuator — it changes how fast a sender offers load but cannot change which worker serves it. Bandwidth freed on an oversubscribed worker by backing its flows off is unconsumable by flows pinned to a different RX queue's worker (AF_XDP ZC `xsk_rcv_check` queue pinning) and strands idle. The only CoV reduction a demand-side signal yields is clip-to-slowest, already shipped as default-OFF `equal-flow-enforcement` v8. On the #1757 6/6 CPU-bound box, surplus-sharing pacing cannot recover throughput because budget != serve capacity.

Not for merge to master as code; doc-only research artifact. Issue close + `plan-kill` label tracked on #1767.