### PR TITLE
#1780 Path A: stall-harden the Go periodic neighbor-resolution loop

### DIFF
--- a/docs/pr/1780-path-a/claude-smr-code-r1.md
+++ b/docs/pr/1780-path-a/claude-smr-code-r1.md
@@ -1,0 +1,89 @@
+# Claude SMR hostile code review — PR #1781 r1 (`803638c91`)
+
+**Verdict: MERGE-NEEDS-MINOR**
+
+Domain SMR (HA neighbor maintenance / dataplane) + concurrency + Go API
+layering review. One must-fix behavior-preservation delta; the rest of the
+change holds up under hostile inspection.
+
+## Finding 1 (MINOR, must-fix) — `maintainClusterNeighborReadiness` lost its config gate
+
+The plan's contract is strict: *"DO NOT change WHAT is warmed/cleaned … only
+HOW the loop is supervised."*
+
+Old `runPeriodicNeighborResolution`:
+```go
+// immediate pass
+if cfg := d.store.ActiveConfig(); cfg != nil {
+    d.resolveNeighbors(cfg)
+    d.maintainClusterNeighborReadiness()   // <-- inside cfg != nil
+}
+d.cleanFailedNeighbors()
+// 15s tick
+if cfg := d.store.ActiveConfig(); cfg != nil {
+    d.resolveNeighbors(cfg)
+    d.forceProbeNeighbors(cfg)
+    d.maintainClusterNeighborReadiness()   // <-- inside cfg != nil
+}
+```
+
+New code calls `d.maintainClusterNeighborReadiness()` **unconditionally** on
+both the immediate pass (daemon_neighbor.go:424) and the 15s tick (:444).
+`maintainClusterNeighborReadiness` self-gates on `d.cluster == nil`
+(:455) but **not** on config, so the new code can run it when
+`ActiveConfig() == nil`.
+
+Practical blast radius is near-zero (`d.cluster != nil` implies a config was
+applied, so the `cluster!=nil && cfg==nil` window is essentially empty, and
+`warmNeighborCache` over an empty session table is a near-no-op). But it is a
+WHAT-change the plan forbids, and the fix is one guard. **Restore the cfg gate
+on both call sites.**
+
+## Finding 2 (NOTE, no change) — `maintain` is called inline, not guarded
+
+AGY check D will raise this: `maintainClusterNeighborReadiness` is the one
+periodic action NOT wrapped in `runGuardedNeighborPhase`, so in principle a
+hang inside it would still freeze the loop. Verified it cannot: maintain's
+only pre-spawn work is the `d.cluster == nil` check and a `CompareAndSwap` on
+`neighborWarmupInFlight`; the actual heavy work (`warmNeighborCache`, the
+session-table walk + per-IP UDP probes) already runs in maintain's own
+goroutine guarded by `neighborWarmupInFlight` (:462-471). maintain returns in
+O(1) non-blocking work, so leaving it inline cannot freeze the for-select
+loop. No change needed; documented so the reviewer convergence is explicit.
+
+## Axes verified clean
+
+- **Concurrency (the big one).** Phases were serialized inline before; they now
+  run concurrently in guarded goroutines. Verified `resolveNeighbors` /
+  `resolveNeighborsInner` / `forceProbeNeighbors` / `cleanFailedNeighbors`
+  write **no** shared mutable daemon state (grep for `d.field =` / `.Lock` /
+  shared-map mutation: empty). They touch the **kernel** neighbor table via
+  netlink (`NeighList`/`NeighDel`) — kernel-serialized — and spawn
+  fire-and-forget ICMP/NS probe goroutines. No Go-level data race introduced by
+  the concurrency. (Bonus: `resolveNeighborsInner`'s inline
+  `time.Sleep(500ms)` no longer blocks the loop — it runs in the goroutine.)
+- **Guard correctness.** `runGuardedNeighborPhase` CAS(false→true) gate;
+  `defer{ lastSuccess.Store(now); inFlight.Store(false) }`. No path leaves
+  `inFlight` stuck true except an infinitely-hung `fn()` — which is the
+  intended watchdog signal (age climbs). `defer` stores "success" on panic too,
+  but an unrecovered goroutine panic crashes the process, so the stale gauge
+  value is moot.
+- **Metric wiring.** `xpf_daemon_neighbor_periodic_last_success_age_seconds`
+  declared in `Describe()` (metrics.go), emitted in `collectSystemMetrics` only
+  when `neighborPhaseAgeFn != nil` (nil-safe), and **registered in the #1726
+  whole-collector descriptor-coverage canary** — so a future drop fails the
+  test. Label cardinality bounded to 4 phases. Follows the existing
+  `xpf_daemon_*` injection pattern (api below daemon → `api.Config` func field).
+- **`NeighborPeriodicPhaseAges`.** `age()` returns `now - startTime` when
+  `lastNanos == 0`, so a never-run phase flags rather than reading 0.
+  `startTime` is set in the Daemon. No nil-deref.
+- **Test quality.** `neighbor_periodic_guard_test.go` exercises the actual
+  no-block property (spawns the guarded call, asserts `callReturned` before a
+  2s timeout while the phase body is still blocked), the skip-while-in-flight +
+  self-heal-relaunch, and the gauge advance. Race-clean (`go test -race`),
+  waits are deadline-polled not fixed-sleep so non-flaky.
+
+## Required action
+Fix Finding 1 (restore cfg gate on both `maintain` call sites), re-run
+`go test -race ./pkg/daemon -run guard` + the api coverage canary, fold into
+one r1-fixes commit alongside any Codex/AGY findings.

--- a/docs/pr/1780-path-a/reviewer-ids.md
+++ b/docs/pr/1780-path-a/reviewer-ids.md
@@ -1,0 +1,27 @@
+# #1780 Path A — reviewer task IDs (PR #1781)
+
+Commit under review: `803638c91` (branch `engineer/1780-path-a`)
+Base: `ecdc16f2e` (master)
+
+## Round 1
+- **Codex**: `task-mq5ath66-j09hk2` — hostile code review
+  - fetch: `node /home/ps/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs result task-mq5ath66-j09hk2`
+- **AGY**: `adversarial-review-mq5atwbu-ejkkw5` — adversarial code review
+  - fetch: `node /home/ps/.claude/plugins/cache/claude-code-agy/agy/0.1.0/scripts/agy-companion.mjs result adversarial-review-mq5atwbu-ejkkw5`
+- **Claude SMR**: in-conversation (this session) — see `claude-smr-code-r1.md`
+- **Copilot**: triggered via `@copilot review` PR comment; poll `gh api repos/psaab/xpf/pulls/1781/reviews`
+
+### Round 1 outcome
+- Codex `task-mq5ath66-j09hk2`: **MERGE-NEEDS-MINOR** — warm/loop-start false positives; test only exercised the helper.
+- AGY `adversarial-review-mq5atwbu-ejkkw5`: **MERGE-NEEDS-MINOR** — shared-config append data race in `collectNeighborProbeTargets`.
+- Claude SMR: **MERGE-NEEDS-MINOR** — `maintain` lost its `ActiveConfig()!=nil` gate.
+- Copilot (`803638c9`): **clean** — 9/9 files, no comments.
+- All folded into `fbd159e55`.
+
+## Round 2 (commit `fbd159e55`)
+- **Codex**: `task-mq5bbicx-012hla`
+  - fetch: `node /home/ps/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs result task-mq5bbicx-012hla`
+- **AGY**: `adversarial-review-mq5bburw-py8i4a`
+  - fetch: `node /home/ps/.claude/plugins/cache/claude-code-agy/agy/0.1.0/scripts/agy-companion.mjs result adversarial-review-mq5bburw-py8i4a`
+- **Claude SMR**: MERGE-READY (verified inline) — loop-started flag is the first statement of `runPeriodicNeighborResolution` (set before any return); accessor returns nil pre-start and 3-key map standalone (range over nil/short map in `collectSystemMetrics` is safe); `warm` cluster-gate matches `maintainClusterNeighborReadiness`'s `d.cluster==nil` no-op; append fix builds fresh pre-sized `[]*config.StaticRoute` slices (pointers shared but traversal is read-only — `sr.Discard`/`sr.NextHops`), config backing array untouched; extracted `neighborPeriodicLoop` is structurally identical to the old inline for-select.
+- **Copilot**: re-triggered via `@copilot review` on `fbd159e55`; poll for a review on the new SHA.

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -78,6 +78,9 @@ type xpfCollector struct {
 	daemonUptime *prometheus.Desc
 	daemonMemRSS *prometheus.Desc
 
+	// #1780: per-phase age of the Go periodic neighbor-maintenance loop.
+	neighborPeriodicAge *prometheus.Desc
+
 	// #709: CoS owner-profile telemetry (userspace dataplane only).
 	// Cardinality estimate per plan §5: num_queues (≤ 64) × num_interfaces
 	// (≤ 8) × DRAIN_HIST_BUCKETS (16) = ≤ 8192 series for each of the
@@ -280,6 +283,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.sysMemAvail
 	ch <- c.daemonUptime
 	ch <- c.daemonMemRSS
+	ch <- c.neighborPeriodicAge
 	ch <- c.cosDrainLatencyBucket
 	ch <- c.cosDrainInvocationsTotal
 	ch <- c.cosRedirectAcquireBucket

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -310,6 +310,17 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		store:     store,
 		gc:        gc,
 		startTime: time.Now(),
+		// #1780: wire a non-nil neighbor-phase age source so the
+		// neighbor_periodic_last_success_age_seconds family emits and the
+		// canary covers its descriptor declaration.
+		neighborPhaseAgeFn: func() map[string]float64 {
+			return map[string]float64{
+				"resolve":      1.0,
+				"force_probe":  2.0,
+				"clean_failed": 3.0,
+				"warm":         4.0,
+			}
+		},
 	}
 	// dhcp.New opens a netlink handle, which a restricted sandbox may
 	// refuse ("operation not permitted"). The DHCP family is one of many;
@@ -377,6 +388,7 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_nat_pool_total_ports",                        // collectNATPoolMetrics
 		"xpf_sessions_active",                             // collectSessionGauges
 		"xpf_daemon_uptime_seconds",                       // collectSystemMetrics
+		"xpf_daemon_neighbor_periodic_last_success_age_seconds", // #1780 neighbor watchdog
 		"xpf_userspace_worker_dead",                       // emitWorkerRuntime
 		"xpf_userspace_worker_cold_path_samples_v3_total", // cold-path v3
 		"xpf_cos_drain_invocations_total",                 // CoS owner profile

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -232,6 +232,14 @@ func newCollector(srv *Server) *xpfCollector {
 			"Daemon resident set size in bytes.",
 			nil, nil,
 		),
+		neighborPeriodicAge: prometheus.NewDesc(
+			"xpf_daemon_neighbor_periodic_last_success_age_seconds",
+			"Seconds since each Go periodic neighbor-maintenance phase "+
+				"last completed. A monotonically climbing value means that "+
+				"phase's guarded goroutine is wedged on a stuck netlink/probe "+
+				"syscall (#1780).",
+			[]string{"phase"}, nil,
+		),
 
 		// #709: owner-profile telemetry. Labels:
 		//   ifindex:      interface ifindex as string

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -35,6 +35,17 @@ func (c *xpfCollector) collectSystemMetrics(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.daemonUptime, prometheus.GaugeValue,
 		time.Since(c.srv.startTime).Seconds())
 
+	// #1780: per-phase age of the Go periodic neighbor-maintenance loop.
+	// A monotonically climbing age for any phase is the watchdog signal
+	// that the phase's guarded goroutine is wedged on a stuck
+	// netlink/probe syscall (the idle/overnight cold-connect hang).
+	if c.srv.neighborPhaseAgeFn != nil {
+		for phase, age := range c.srv.neighborPhaseAgeFn() {
+			ch <- prometheus.MustNewConstMetric(c.neighborPeriodicAge,
+				prometheus.GaugeValue, age, phase)
+		}
+	}
+
 	// Daemon RSS from /proc/self/statm (field 1 = RSS in pages)
 	if data, err := os.ReadFile("/proc/self/statm"); err == nil {
 		fields := strings.Fields(string(data))

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -67,6 +67,14 @@ type Config struct {
 	// instead of reading "status: ok" alongside a one-shot WARN in the
 	// journal. Optional; if nil, /health keeps the pre-#758 behaviour.
 	CompileHealthFn func() CompileHealthSnapshot
+	// NeighborPhaseAgeFn surfaces the age (seconds) since each Go
+	// periodic neighbor-maintenance phase last completed (#1780 Path A).
+	// Keys: resolve/force_probe/clean_failed/warm. A monotonically
+	// climbing age for any phase means that phase's guarded goroutine
+	// is wedged (a stuck netlink/probe syscall), which is the signature
+	// of the idle/overnight cold-connect hang. Optional; if nil, the
+	// neighbor_periodic_last_success_age_seconds gauge is not emitted.
+	NeighborPhaseAgeFn func() map[string]float64
 }
 
 // Server is the HTTP API server.
@@ -82,10 +90,11 @@ type Server struct {
 	ipsec       *ipsec.Manager
 	dhcp        *dhcp.Manager
 	vrrpMgr           *vrrp.Manager
-	commitFn          func(ctx context.Context, comment string) (*config.Config, error)
-	commitConfirmedFn func(ctx context.Context, minutes int) (*config.Config, error)
-	compileHealthFn   func() CompileHealthSnapshot
-	startTime         time.Time
+	commitFn           func(ctx context.Context, comment string) (*config.Config, error)
+	commitConfirmedFn  func(ctx context.Context, minutes int) (*config.Config, error)
+	compileHealthFn    func() CompileHealthSnapshot
+	neighborPhaseAgeFn func() map[string]float64
+	startTime          time.Time
 }
 
 // NewServer creates a new API server.
@@ -100,10 +109,11 @@ func NewServer(cfg Config) *Server {
 		ipsec:     cfg.IPsec,
 		dhcp:      cfg.DHCP,
 		vrrpMgr:           cfg.VRRPMgr,
-		commitFn:          cfg.CommitFn,
-		commitConfirmedFn: cfg.CommitConfirmedFn,
-		compileHealthFn:   cfg.CompileHealthFn,
-		startTime:         time.Now(),
+		commitFn:           cfg.CommitFn,
+		commitConfirmedFn:  cfg.CommitConfirmedFn,
+		compileHealthFn:    cfg.CompileHealthFn,
+		neighborPhaseAgeFn: cfg.NeighborPhaseAgeFn,
+		startTime:          time.Now(),
 	}
 
 	mux := http.NewServeMux()

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -123,6 +123,12 @@ type Daemon struct {
 	forceProbeLastSuccessNanos  atomic.Int64
 	cleanFailedLastSuccessNanos atomic.Int64
 	warmLastSuccessNanos        atomic.Int64
+	// neighborPeriodicLoopStarted gates the phase-age gauge: it is set
+	// once runPeriodicNeighborResolution actually starts (the loop only
+	// runs when the dataplane is enabled with active config). Without it,
+	// a daemon that never starts the loop would report every phase as a
+	// forever-climbing "wedged" age — a false positive (Codex #1781 r1).
+	neighborPeriodicLoopStarted atomic.Bool
 	hbSuppressStart             atomic.Int64 // UnixNano of first heartbeat suppression; 0 = inactive
 	syncPrimeRetryGen           atomic.Uint64
 	syncReadyTimerGen           atomic.Uint64

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -64,15 +64,15 @@ const nodeIDFile = "/etc/xpf/node-id"
 
 // Daemon is the main xpf daemon.
 type Daemon struct {
-	opts                       Options
-	store                      *configstore.Store
-	dp                         dataplane.RuntimeDataPlane
-	networkd                   *networkd.Manager
-	routing                    *routing.Manager
-	frr                        *frr.Manager
-	ipsec                      *ipsec.Manager
-	ra                         *ra.Manager
-	dhcp                       *dhcp.Manager
+	opts     Options
+	store    *configstore.Store
+	dp       dataplane.RuntimeDataPlane
+	networkd *networkd.Manager
+	routing  *routing.Manager
+	frr      *frr.Manager
+	ipsec    *ipsec.Manager
+	ra       *ra.Manager
+	dhcp     *dhcp.Manager
 	// dnsBootDone gates the #1715 DNS boot policy. It is false during the
 	// single boot-time applyConfig (which runs before DHCP clients start,
 	// so the lease set is empty) and set true immediately after. While
@@ -106,22 +106,39 @@ type Daemon struct {
 	syncPeerConnected          atomic.Bool
 	lastStandbyNeighborRefresh atomic.Int64
 	neighborWarmupInFlight     atomic.Bool
-	hbSuppressStart            atomic.Int64 // UnixNano of first heartbeat suppression; 0 = inactive
-	syncPrimeRetryGen          atomic.Uint64
-	syncReadyTimerGen          atomic.Uint64
-	syncReadyTimerMu           sync.Mutex
-	syncReadyTimer             *time.Timer
-	syncReadyTimeout           time.Duration
-	slogHandler                *logging.SyslogSlogHandler
-	traceWriter                *logging.TraceWriter
-	eventBuf                   *logging.EventBuffer
-	eventReader                *logging.EventReader
-	eventEngine                *eventengine.Engine
-	aggregator                 *logging.SessionAggregator
-	aggCancel                  context.CancelFunc
-	vrrpMgr                    *vrrp.Manager
-	gc                         *conntrack.GC
-	startTime                  time.Time // daemon start time; used to suppress stale config sync
+	// #1780 Path A: per-phase supervision of runPeriodicNeighborResolution.
+	// Each periodic phase runs in a guarded goroutine so a hung netlink/probe
+	// syscall in one phase can never freeze the for-select loop (the observed
+	// 17.5h stall). In-flight bools skip a phase while a prior pass is still
+	// running (no overlap / netlink-socket leak — a stuck syscall can't be
+	// cancelled, so we leak at most one goroutine per phase, never a growing
+	// pile). The last-success UnixNano feeds the
+	// neighbor_periodic_last_success_age_seconds{phase} gauge so a stalled
+	// phase is observable. neighborWarmupInFlight (above) already follows this
+	// pattern for warmNeighborCache.
+	resolveNeighborsInFlight    atomic.Bool
+	forceProbeInFlight          atomic.Bool
+	cleanFailedInFlight         atomic.Bool
+	resolveLastSuccessNanos     atomic.Int64
+	forceProbeLastSuccessNanos  atomic.Int64
+	cleanFailedLastSuccessNanos atomic.Int64
+	warmLastSuccessNanos        atomic.Int64
+	hbSuppressStart             atomic.Int64 // UnixNano of first heartbeat suppression; 0 = inactive
+	syncPrimeRetryGen           atomic.Uint64
+	syncReadyTimerGen           atomic.Uint64
+	syncReadyTimerMu            sync.Mutex
+	syncReadyTimer              *time.Timer
+	syncReadyTimeout            time.Duration
+	slogHandler                 *logging.SyslogSlogHandler
+	traceWriter                 *logging.TraceWriter
+	eventBuf                    *logging.EventBuffer
+	eventReader                 *logging.EventReader
+	eventEngine                 *eventengine.Engine
+	aggregator                  *logging.SessionAggregator
+	aggCancel                   context.CancelFunc
+	vrrpMgr                     *vrrp.Manager
+	gc                          *conntrack.GC
+	startTime                   time.Time // daemon start time; used to suppress stale config sync
 
 	// #846: applySem (capacity 1) serializes applyConfig + the
 	// commit→apply pair across all entry points (HTTP/gRPC commits,

--- a/pkg/daemon/daemon_neighbor.go
+++ b/pkg/daemon/daemon_neighbor.go
@@ -383,11 +383,21 @@ func (d *Daemon) NeighborPeriodicPhaseAges() map[string]float64 {
 		return nil
 	}
 	now := time.Now()
+	// Clamp to >= 0: ages are wall-clock subtractions, so a backward clock
+	// step (NTP/RTC adjustment) could otherwise emit a negative age, which is
+	// nonsensical for a watchdog gauge (Copilot #1781 r2; mirrors the
+	// clock-step floor in shouldScheduleStandbyNeighborRefresh).
 	age := func(lastNanos int64) float64 {
+		var sec float64
 		if lastNanos == 0 {
-			return now.Sub(d.startTime).Seconds()
+			sec = now.Sub(d.startTime).Seconds()
+		} else {
+			sec = now.Sub(time.Unix(0, lastNanos)).Seconds()
 		}
-		return now.Sub(time.Unix(0, lastNanos)).Seconds()
+		if sec < 0 {
+			sec = 0
+		}
+		return sec
 	}
 	ages := map[string]float64{
 		"resolve":      age(d.resolveLastSuccessNanos.Load()),

--- a/pkg/daemon/daemon_neighbor.go
+++ b/pkg/daemon/daemon_neighbor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/psaab/xpf/pkg/cluster"
@@ -349,18 +350,56 @@ func (d *Daemon) cleanFailedNeighbors() int {
 //
 // Runs once immediately at start to avoid a blind spot.
 // Fetches fresh active config on each tick so config changes take effect.
-func (d *Daemon) runPeriodicNeighborResolution(ctx context.Context) {
-	// Immediate first run — don't wait for first tick.
-	// resolveNeighbors handles cold-start configured targets;
-	// forceProbeNeighbors handles stale snapshot keys (only
-	// useful once a snapshot exists, which it doesn't yet at
-	// startup). On the first 15s tick once snapshot is warm,
-	// both run with non-overlapping target sets.
-	if cfg := d.store.ActiveConfig(); cfg != nil {
-		d.resolveNeighbors(cfg)
-		d.maintainClusterNeighborReadiness()
+// runGuardedNeighborPhase runs one periodic neighbor-maintenance phase in a
+// guarded goroutine so a hung netlink/probe syscall in that phase can NEVER
+// freeze the runPeriodicNeighborResolution for-select loop (#1780 Path A: a
+// blocking synchronous handler was observed wedging the whole loop ~17.5h,
+// aging out data-path next-hops and causing cold-connect hangs). If a prior
+// pass is still in flight, the tick is skipped rather than launching an
+// overlapping pass — a stuck netlink syscall cannot be cancelled, so a second
+// goroutine would only leak another socket; skipping caps the leak at one
+// goroutine per phase, and the stalled phase becomes observable via its
+// growing last-success-age gauge while every OTHER phase keeps running. On
+// normal completion the phase records its success timestamp; a transient hang
+// self-heals because the next tick relaunches once the prior pass returns.
+func (d *Daemon) runGuardedNeighborPhase(inFlight *atomic.Bool, lastSuccess *atomic.Int64, fn func()) {
+	if !inFlight.CompareAndSwap(false, true) {
+		return
 	}
-	d.cleanFailedNeighbors()
+	go func() {
+		defer func() {
+			lastSuccess.Store(time.Now().UnixNano())
+			inFlight.Store(false)
+		}()
+		fn()
+	}()
+}
+
+func (d *Daemon) runPeriodicNeighborResolution(ctx context.Context) {
+	// #1780 Path A: each phase runs via runGuardedNeighborPhase (a guarded
+	// goroutine) so one hung netlink/probe phase cannot freeze this loop.
+	// WHAT each phase does is unchanged — only HOW it is supervised.
+	resolvePass := func() {
+		if cfg := d.store.ActiveConfig(); cfg != nil {
+			d.resolveNeighbors(cfg)
+		}
+	}
+	// #1197: force-probe ALL monitored neighbors (including STALE/DELAY/PROBE)
+	// so the kernel re-validates entries resolveNeighbors would skip. Replies
+	// update kernel ARP → RTM_NEWNEIGH → listener regenerates snapshot.
+	forceProbePass := func() {
+		if cfg := d.store.ActiveConfig(); cfg != nil {
+			d.forceProbeNeighbors(cfg)
+		}
+	}
+	// cleanFailedNeighbors returns a count; discard it for the void phase fn.
+	cleanPass := func() { d.cleanFailedNeighbors() }
+	// Immediate first run — don't wait for first tick. forceProbeNeighbors is
+	// intentionally skipped here (it needs a snapshot that doesn't exist yet
+	// at startup; it joins on the first 15s tick with a non-overlapping set).
+	d.runGuardedNeighborPhase(&d.resolveNeighborsInFlight, &d.resolveLastSuccessNanos, resolvePass)
+	d.maintainClusterNeighborReadiness()
+	d.runGuardedNeighborPhase(&d.cleanFailedInFlight, &d.cleanFailedLastSuccessNanos, cleanPass)
 
 	const (
 		cleanInterval   = 5 * time.Second
@@ -375,18 +414,11 @@ func (d *Daemon) runPeriodicNeighborResolution(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-cleanTicker.C:
-			d.cleanFailedNeighbors()
+			d.runGuardedNeighborPhase(&d.cleanFailedInFlight, &d.cleanFailedLastSuccessNanos, cleanPass)
 		case <-resolveTicker.C:
-			if cfg := d.store.ActiveConfig(); cfg != nil {
-				d.resolveNeighbors(cfg)
-				// #1197: force-probe ALL monitored neighbors
-				// (including STALE/DELAY/PROBE) so kernel
-				// re-validates entries that resolveNeighbors
-				// would skip. Replies update kernel ARP →
-				// RTM_NEWNEIGH → listener regenerates snapshot.
-				d.forceProbeNeighbors(cfg)
-				d.maintainClusterNeighborReadiness()
-			}
+			d.runGuardedNeighborPhase(&d.resolveNeighborsInFlight, &d.resolveLastSuccessNanos, resolvePass)
+			d.runGuardedNeighborPhase(&d.forceProbeInFlight, &d.forceProbeLastSuccessNanos, forceProbePass)
+			d.maintainClusterNeighborReadiness()
 		}
 	}
 }
@@ -409,7 +441,10 @@ func (d *Daemon) maintainClusterNeighborReadiness() {
 		return
 	}
 	go func() {
-		defer d.neighborWarmupInFlight.Store(false)
+		defer func() {
+			d.warmLastSuccessNanos.Store(time.Now().UnixNano())
+			d.neighborWarmupInFlight.Store(false)
+		}()
 		d.warmNeighborCache()
 	}()
 }

--- a/pkg/daemon/daemon_neighbor.go
+++ b/pkg/daemon/daemon_neighbor.go
@@ -349,7 +349,29 @@ func (d *Daemon) cleanFailedNeighbors() int {
 //     without activation-time warmup.
 //
 // Runs once immediately at start to avoid a blind spot.
-// Fetches fresh active config on each tick so config changes take effect.
+// NeighborPeriodicPhaseAges returns, per periodic-neighbor-maintenance phase,
+// the seconds since that phase last completed successfully — the #1780 Path A
+// stall diagnostic. A phase frozen by a hung netlink/probe syscall shows a
+// growing age while the healthy phases stay near 0; a phase that has never
+// completed reports its age since daemon start so a never-running phase still
+// flags. Surfaced as the xpf_daemon_neighbor_periodic_last_success_age_seconds
+// {phase} gauge.
+func (d *Daemon) NeighborPeriodicPhaseAges() map[string]float64 {
+	now := time.Now()
+	age := func(lastNanos int64) float64 {
+		if lastNanos == 0 {
+			return now.Sub(d.startTime).Seconds()
+		}
+		return now.Sub(time.Unix(0, lastNanos)).Seconds()
+	}
+	return map[string]float64{
+		"resolve":      age(d.resolveLastSuccessNanos.Load()),
+		"force_probe":  age(d.forceProbeLastSuccessNanos.Load()),
+		"clean_failed": age(d.cleanFailedLastSuccessNanos.Load()),
+		"warm":         age(d.warmLastSuccessNanos.Load()),
+	}
+}
+
 // runGuardedNeighborPhase runs one periodic neighbor-maintenance phase in a
 // guarded goroutine so a hung netlink/probe syscall in that phase can NEVER
 // freeze the runPeriodicNeighborResolution for-select loop (#1780 Path A: a

--- a/pkg/daemon/daemon_neighbor.go
+++ b/pkg/daemon/daemon_neighbor.go
@@ -142,8 +142,18 @@ func (d *Daemon) collectNeighborProbeTargets(cfg *config.Config) []neighborProbe
 		}
 	}
 
-	// 1. Static route next-hops
-	allStaticRoutes := append(cfg.RoutingOptions.StaticRoutes, cfg.RoutingOptions.Inet6StaticRoutes...)
+	// 1. Static route next-hops.
+	// Build the combined list in a fresh slice — appending Inet6StaticRoutes
+	// onto cfg.RoutingOptions.StaticRoutes directly would write into that
+	// slice's backing array when it has spare capacity (cap > len), mutating
+	// the shared active-config object. resolveNeighbors runs concurrently with
+	// VRRP-transition and config-apply callers (and, post-#1780, in a guarded
+	// goroutine), so that in-place append is a data race on shared config
+	// (AGY #1781 r1). A pre-sized copy avoids touching the config's arrays.
+	allStaticRoutes := make([]*config.StaticRoute, 0,
+		len(cfg.RoutingOptions.StaticRoutes)+len(cfg.RoutingOptions.Inet6StaticRoutes))
+	allStaticRoutes = append(allStaticRoutes, cfg.RoutingOptions.StaticRoutes...)
+	allStaticRoutes = append(allStaticRoutes, cfg.RoutingOptions.Inet6StaticRoutes...)
 	for _, sr := range allStaticRoutes {
 		if sr.Discard {
 			continue
@@ -160,7 +170,13 @@ func (d *Daemon) collectNeighborProbeTargets(cfg *config.Config) []neighborProbe
 		}
 	}
 	for _, ri := range cfg.RoutingInstances {
-		for _, sr := range append(ri.StaticRoutes, ri.Inet6StaticRoutes...) {
+		// Same copy-safety as above: never append onto the config's own
+		// StaticRoutes backing array (AGY #1781 r1).
+		riStaticRoutes := make([]*config.StaticRoute, 0,
+			len(ri.StaticRoutes)+len(ri.Inet6StaticRoutes))
+		riStaticRoutes = append(riStaticRoutes, ri.StaticRoutes...)
+		riStaticRoutes = append(riStaticRoutes, ri.Inet6StaticRoutes...)
+		for _, sr := range riStaticRoutes {
 			if sr.Discard {
 				continue
 			}
@@ -348,15 +364,24 @@ func (d *Daemon) cleanFailedNeighbors() int {
 //     session-derived neighbor cache entries so standby forwarding stays ready
 //     without activation-time warmup.
 //
-// Runs once immediately at start to avoid a blind spot.
 // NeighborPeriodicPhaseAges returns, per periodic-neighbor-maintenance phase,
 // the seconds since that phase last completed successfully — the #1780 Path A
 // stall diagnostic. A phase frozen by a hung netlink/probe syscall shows a
 // growing age while the healthy phases stay near 0; a phase that has never
-// completed reports its age since daemon start so a never-running phase still
-// flags. Surfaced as the xpf_daemon_neighbor_periodic_last_success_age_seconds
-// {phase} gauge.
+// completed reports its age since the loop started so a never-running phase
+// still flags. Surfaced as the
+// xpf_daemon_neighbor_periodic_last_success_age_seconds{phase} gauge.
+//
+// To avoid false positives (Codex #1781 r1), it reports nothing until the
+// periodic loop has actually started (the loop only runs when the dataplane
+// is enabled with active config), and it omits the "warm" phase on a
+// standalone firewall, since warmNeighborCache only runs under HA
+// (maintainClusterNeighborReadiness no-ops when d.cluster == nil and so never
+// updates warmLastSuccessNanos).
 func (d *Daemon) NeighborPeriodicPhaseAges() map[string]float64 {
+	if !d.neighborPeriodicLoopStarted.Load() {
+		return nil
+	}
 	now := time.Now()
 	age := func(lastNanos int64) float64 {
 		if lastNanos == 0 {
@@ -364,12 +389,17 @@ func (d *Daemon) NeighborPeriodicPhaseAges() map[string]float64 {
 		}
 		return now.Sub(time.Unix(0, lastNanos)).Seconds()
 	}
-	return map[string]float64{
+	ages := map[string]float64{
 		"resolve":      age(d.resolveLastSuccessNanos.Load()),
 		"force_probe":  age(d.forceProbeLastSuccessNanos.Load()),
 		"clean_failed": age(d.cleanFailedLastSuccessNanos.Load()),
-		"warm":         age(d.warmLastSuccessNanos.Load()),
 	}
+	// The warm phase only exists under HA; reporting it standalone would be a
+	// forever-climbing false "wedge".
+	if d.cluster != nil {
+		ages["warm"] = age(d.warmLastSuccessNanos.Load())
+	}
+	return ages
 }
 
 // runGuardedNeighborPhase runs one periodic neighbor-maintenance phase in a
@@ -398,6 +428,11 @@ func (d *Daemon) runGuardedNeighborPhase(inFlight *atomic.Bool, lastSuccess *ato
 }
 
 func (d *Daemon) runPeriodicNeighborResolution(ctx context.Context) {
+	// Mark the loop live so NeighborPeriodicPhaseAges reports phase ages only
+	// once supervision is actually running (avoids the never-started false
+	// positive — Codex #1781 r1).
+	d.neighborPeriodicLoopStarted.Store(true)
+
 	// #1780 Path A: each phase runs via runGuardedNeighborPhase (a guarded
 	// goroutine) so one hung netlink/probe phase cannot freeze this loop.
 	// WHAT each phase does is unchanged — only HOW it is supervised.
@@ -416,17 +451,55 @@ func (d *Daemon) runPeriodicNeighborResolution(ctx context.Context) {
 	}
 	// cleanFailedNeighbors returns a count; discard it for the void phase fn.
 	cleanPass := func() { d.cleanFailedNeighbors() }
-	// Immediate first run — don't wait for first tick. forceProbeNeighbors is
+	// maintainClusterNeighborReadiness self-gates on d.cluster, but the prior
+	// (pre-#1780) loop only invoked it when ActiveConfig() != nil; preserve
+	// that gate exactly so this change stays HOW-only, not WHAT (Claude SMR
+	// #1781 r1). It is called inline rather than via runGuardedNeighborPhase
+	// because its only synchronous work is a nil check + a CAS — the heavy
+	// session-walk warmNeighborCache already runs in its own goroutine guarded
+	// by neighborWarmupInFlight, so maintain cannot freeze this loop.
+	maintainPass := func() {
+		if cfg := d.store.ActiveConfig(); cfg != nil {
+			d.maintainClusterNeighborReadiness()
+		}
+	}
+
+	// resolveTick is the 15s pass: resolve + force-probe (both guarded) +
+	// maintain. cleanTick is the 5s pass: clean (guarded).
+	resolveTick := func() {
+		d.runGuardedNeighborPhase(&d.resolveNeighborsInFlight, &d.resolveLastSuccessNanos, resolvePass)
+		d.runGuardedNeighborPhase(&d.forceProbeInFlight, &d.forceProbeLastSuccessNanos, forceProbePass)
+		maintainPass()
+	}
+	cleanTick := func() {
+		d.runGuardedNeighborPhase(&d.cleanFailedInFlight, &d.cleanFailedLastSuccessNanos, cleanPass)
+	}
+
+	// Immediate first run — don't wait for first tick. force-probe is
 	// intentionally skipped here (it needs a snapshot that doesn't exist yet
-	// at startup; it joins on the first 15s tick with a non-overlapping set).
+	// at startup; it joins on the first 15s tick with a non-overlapping set),
+	// so the immediate pass is resolve + maintain + clean, matching the
+	// pre-#1780 startup sequence exactly.
 	d.runGuardedNeighborPhase(&d.resolveNeighborsInFlight, &d.resolveLastSuccessNanos, resolvePass)
-	d.maintainClusterNeighborReadiness()
-	d.runGuardedNeighborPhase(&d.cleanFailedInFlight, &d.cleanFailedLastSuccessNanos, cleanPass)
+	maintainPass()
+	cleanTick()
 
 	const (
 		cleanInterval   = 5 * time.Second
 		resolveInterval = 15 * time.Second
 	)
+	d.neighborPeriodicLoop(ctx, cleanInterval, resolveInterval, cleanTick, resolveTick)
+}
+
+// neighborPeriodicLoop is the supervised for-select core of
+// runPeriodicNeighborResolution, split out so a unit test can drive it with
+// fast intervals and synthetic phase closures and prove the no-freeze
+// invariant end-to-end: a wedged resolveTick phase must not stop cleanTick
+// from firing (Codex #1781 r1). The loop itself never blocks — each tick
+// callback is expected to dispatch its work via runGuardedNeighborPhase (a
+// guarded goroutine) or be O(1) — so the select keeps servicing both tickers
+// regardless of any single phase hanging.
+func (d *Daemon) neighborPeriodicLoop(ctx context.Context, cleanInterval, resolveInterval time.Duration, cleanTick, resolveTick func()) {
 	cleanTicker := time.NewTicker(cleanInterval)
 	resolveTicker := time.NewTicker(resolveInterval)
 	defer cleanTicker.Stop()
@@ -436,11 +509,9 @@ func (d *Daemon) runPeriodicNeighborResolution(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-cleanTicker.C:
-			d.runGuardedNeighborPhase(&d.cleanFailedInFlight, &d.cleanFailedLastSuccessNanos, cleanPass)
+			cleanTick()
 		case <-resolveTicker.C:
-			d.runGuardedNeighborPhase(&d.resolveNeighborsInFlight, &d.resolveLastSuccessNanos, resolvePass)
-			d.runGuardedNeighborPhase(&d.forceProbeInFlight, &d.forceProbeLastSuccessNanos, forceProbePass)
-			d.maintainClusterNeighborReadiness()
+			resolveTick()
 		}
 	}
 }

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -804,6 +804,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 					LastErrorUnixSec: h.LastErrorUnixSec,
 				}
 			},
+			// #1780 Path A: expose the per-phase age of the Go periodic
+			// neighbor-maintenance loop so a wedged guarded goroutine
+			// (stuck netlink/probe syscall) is observable as a climbing
+			// gauge before it manifests as the cold-connect hang.
+			NeighborPhaseAgeFn: d.NeighborPeriodicPhaseAges,
 		}
 		// Resolve interface bindings from web-management config
 		if cfg := d.store.ActiveConfig(); cfg != nil && cfg.System.Services != nil &&

--- a/pkg/daemon/neighbor_periodic_guard_test.go
+++ b/pkg/daemon/neighbor_periodic_guard_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -8,17 +9,20 @@ import (
 )
 
 // #1780 Path A: the periodic neighbor-maintenance loop must survive a phase
-// whose netlink/probe syscall wedges. These tests pin the three guarantees the
-// fix rests on:
+// whose netlink/probe syscall wedges. These tests pin the guarantees the fix
+// rests on:
 //
 //   1. runGuardedNeighborPhase NEVER blocks its caller — the phase body runs in
 //      a goroutine, so a hung phase cannot freeze the for-select loop.
 //   2. While a phase is in flight the guard SKIPS relaunch (no overlapping
 //      pass, no per-tick goroutine/socket leak), and relaunches once the prior
 //      pass returns.
-//   3. NeighborPeriodicPhaseAges advances for a stalled phase (its last-success
-//      timestamp stops updating) while a healthy phase stays near zero — the
-//      observable watchdog signal.
+//   3. End-to-end, neighborPeriodicLoop keeps firing the clean ticker while a
+//      resolve phase is wedged — the real no-freeze property, not just the
+//      helper in isolation (Codex #1781 r1).
+//   4. NeighborPeriodicPhaseAges advances for a stalled phase, reports nothing
+//      until the loop has started, and omits the HA-only warm phase when not
+//      clustered (Codex #1781 r1).
 
 // waitFor polls cond until true or the deadline elapses; fatals on timeout.
 func waitFor(t *testing.T, d time.Duration, what string, cond func() bool) {
@@ -99,19 +103,74 @@ func TestRunGuardedNeighborPhaseDoesNotBlockCaller(t *testing.T) {
 	}
 }
 
+// TestNeighborPeriodicLoopKeepsTickingWhilePhaseWedged drives the real loop
+// core with fast intervals and a resolve phase that wedges forever (via the
+// real guard), and asserts the clean ticker keeps firing — the end-to-end
+// no-freeze property a stuck phase must not break.
+func TestNeighborPeriodicLoopKeepsTickingWhilePhaseWedged(t *testing.T) {
+	d := &Daemon{startTime: time.Now()}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var cleanCount atomic.Int64
+	var resolveStarted atomic.Bool
+	release := make(chan struct{})
+
+	// resolveTick dispatches a phase that wedges forever (models a stuck
+	// netlink syscall) through the real guarded-goroutine helper.
+	resolveTick := func() {
+		d.runGuardedNeighborPhase(&d.resolveNeighborsInFlight, &d.resolveLastSuccessNanos, func() {
+			resolveStarted.Store(true)
+			<-release
+		})
+	}
+	cleanTick := func() { cleanCount.Add(1) }
+
+	go d.neighborPeriodicLoop(ctx, 5*time.Millisecond, 8*time.Millisecond, cleanTick, resolveTick)
+
+	// Even though the resolve phase wedges on its first fire, the clean ticker
+	// must keep firing: the loop is not frozen.
+	waitFor(t, 2*time.Second, "clean ticks to accumulate while resolve is wedged", func() bool {
+		return cleanCount.Load() >= 5
+	})
+	if !resolveStarted.Load() {
+		t.Fatal("resolve phase never started")
+	}
+	// The wedged resolve phase stayed in flight — no relaunch, no panic, and
+	// crucially the loop kept servicing the clean ticker.
+	if !d.resolveNeighborsInFlight.Load() {
+		t.Fatal("expected the wedged resolve phase to remain in-flight")
+	}
+
+	cancel()
+	close(release)
+}
+
 func TestNeighborPeriodicPhaseAgesReflectsStall(t *testing.T) {
 	// startTime in the past so a never-run phase reports a non-trivial age.
 	d := &Daemon{startTime: time.Now().Add(-30 * time.Second)}
 
+	// Before the loop starts, the accessor reports nothing — a daemon that
+	// never starts the loop must not surface forever-climbing false "wedges".
+	if ages := d.NeighborPeriodicPhaseAges(); ages != nil {
+		t.Fatalf("expected nil phase ages before loop start, got %v", ages)
+	}
+
+	d.neighborPeriodicLoopStarted.Store(true)
+
 	// All phases never-run: each reports ~age-since-start (~30s), proving a
-	// phase that never completes still flags rather than reading zero.
+	// phase that never completes still flags rather than reading zero. warm is
+	// omitted because d.cluster == nil (HA-only phase).
 	ages := d.NeighborPeriodicPhaseAges()
-	for _, phase := range []string{"resolve", "force_probe", "clean_failed", "warm"} {
+	for _, phase := range []string{"resolve", "force_probe", "clean_failed"} {
 		if a, ok := ages[phase]; !ok {
 			t.Fatalf("phase %q missing from age map", phase)
 		} else if a < 25 {
 			t.Fatalf("never-run phase %q reported age %.1fs; want ~30s since start", phase, a)
 		}
+	}
+	if _, ok := ages["warm"]; ok {
+		t.Fatal("warm phase reported on a non-clustered daemon; it is HA-only")
 	}
 
 	// Mark resolve just-completed; its age drops near zero while the others

--- a/pkg/daemon/neighbor_periodic_guard_test.go
+++ b/pkg/daemon/neighbor_periodic_guard_test.go
@@ -1,0 +1,128 @@
+package daemon
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #1780 Path A: the periodic neighbor-maintenance loop must survive a phase
+// whose netlink/probe syscall wedges. These tests pin the three guarantees the
+// fix rests on:
+//
+//   1. runGuardedNeighborPhase NEVER blocks its caller — the phase body runs in
+//      a goroutine, so a hung phase cannot freeze the for-select loop.
+//   2. While a phase is in flight the guard SKIPS relaunch (no overlapping
+//      pass, no per-tick goroutine/socket leak), and relaunches once the prior
+//      pass returns.
+//   3. NeighborPeriodicPhaseAges advances for a stalled phase (its last-success
+//      timestamp stops updating) while a healthy phase stays near zero — the
+//      observable watchdog signal.
+
+// waitFor polls cond until true or the deadline elapses; fatals on timeout.
+func waitFor(t *testing.T, d time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for: %s", d, what)
+}
+
+func TestRunGuardedNeighborPhaseDoesNotBlockCaller(t *testing.T) {
+	d := &Daemon{startTime: time.Now()}
+	var inFlight atomic.Bool
+	var lastSuccess atomic.Int64
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+
+	// A phase that blocks until released models a wedged netlink syscall.
+	callReturned := make(chan struct{})
+	go func() {
+		d.runGuardedNeighborPhase(&inFlight, &lastSuccess, func() {
+			close(started)
+			<-release
+		})
+		close(callReturned)
+	}()
+
+	// The call itself must return immediately even though the phase body is
+	// still blocked — that is the whole point: the for-select loop is freed.
+	select {
+	case <-callReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runGuardedNeighborPhase blocked its caller on a hung phase")
+	}
+
+	// The phase body is running and in-flight is held.
+	<-started
+	if !inFlight.Load() {
+		t.Fatal("in-flight flag not set while phase body runs")
+	}
+	if lastSuccess.Load() != 0 {
+		t.Fatal("last-success recorded before the phase completed")
+	}
+
+	// A second call while in flight must SKIP: no new goroutine, fn not run.
+	var secondRan atomic.Bool
+	d.runGuardedNeighborPhase(&inFlight, &lastSuccess, func() { secondRan.Store(true) })
+	time.Sleep(20 * time.Millisecond)
+	if secondRan.Load() {
+		t.Fatal("overlapping pass launched while prior pass still in flight")
+	}
+
+	// Release the stuck phase; in-flight clears and last-success records.
+	close(release)
+	waitFor(t, 2*time.Second, "in-flight to clear after phase returns", func() bool {
+		return !inFlight.Load()
+	})
+	if lastSuccess.Load() == 0 {
+		t.Fatal("last-success not recorded after the phase completed")
+	}
+
+	// Now a subsequent call relaunches (guard self-healed).
+	var thirdRan atomic.Bool
+	var wg sync.WaitGroup
+	wg.Add(1)
+	d.runGuardedNeighborPhase(&inFlight, &lastSuccess, func() {
+		thirdRan.Store(true)
+		wg.Done()
+	})
+	wg.Wait()
+	if !thirdRan.Load() {
+		t.Fatal("guard did not relaunch the phase after the prior pass returned")
+	}
+}
+
+func TestNeighborPeriodicPhaseAgesReflectsStall(t *testing.T) {
+	// startTime in the past so a never-run phase reports a non-trivial age.
+	d := &Daemon{startTime: time.Now().Add(-30 * time.Second)}
+
+	// All phases never-run: each reports ~age-since-start (~30s), proving a
+	// phase that never completes still flags rather than reading zero.
+	ages := d.NeighborPeriodicPhaseAges()
+	for _, phase := range []string{"resolve", "force_probe", "clean_failed", "warm"} {
+		if a, ok := ages[phase]; !ok {
+			t.Fatalf("phase %q missing from age map", phase)
+		} else if a < 25 {
+			t.Fatalf("never-run phase %q reported age %.1fs; want ~30s since start", phase, a)
+		}
+	}
+
+	// Mark resolve just-completed; its age drops near zero while the others
+	// keep climbing from start — the healthy-vs-stalled contrast operators
+	// read off the gauge.
+	d.resolveLastSuccessNanos.Store(time.Now().UnixNano())
+	ages = d.NeighborPeriodicPhaseAges()
+	if ages["resolve"] > 2 {
+		t.Fatalf("just-completed resolve phase reported age %.1fs; want ~0", ages["resolve"])
+	}
+	if ages["force_probe"] < 25 {
+		t.Fatalf("stalled force_probe phase reported age %.1fs; want ~30s", ages["force_probe"])
+	}
+}

--- a/pkg/daemon/neighbor_periodic_guard_test.go
+++ b/pkg/daemon/neighbor_periodic_guard_test.go
@@ -184,4 +184,11 @@ func TestNeighborPeriodicPhaseAgesReflectsStall(t *testing.T) {
 	if ages["force_probe"] < 25 {
 		t.Fatalf("stalled force_probe phase reported age %.1fs; want ~30s", ages["force_probe"])
 	}
+
+	// A last-success timestamp in the future (models a backward clock step)
+	// must clamp to 0, not report a negative age (Copilot #1781 r2).
+	d.cleanFailedLastSuccessNanos.Store(time.Now().Add(10 * time.Second).UnixNano())
+	if got := d.NeighborPeriodicPhaseAges()["clean_failed"]; got < 0 {
+		t.Fatalf("backward-clock-step age not clamped: got %.3fs, want >= 0", got)
+	}
 }


### PR DESCRIPTION
## Summary

Path A of #1780 (idle/overnight cold-connect hang to `172.16.80.200`). A
single synchronous phase in the Go periodic neighbor-maintenance loop
(`runPeriodicNeighborResolution`) could wedge on a stuck netlink/probe
syscall and freeze the entire for-select loop — observed wedging ~17.5h,
aging out data-path next-hops and producing the cold-connect-hang-then-recover
signature. This change makes the loop **structurally unfreezable** and adds an
observable watchdog. It is root-cause-independent: it does not depend on
naming *why* a given phase hangs (that resolver/probe fix is deferred and
capture-gated — see "Out of scope").

This is the **Go daemon-side** fix. No Rust/dataplane changes.

## What changed

**Commit 1 — supervise periodic phases (`649b0bee4`)**
- Each periodic phase (`resolveNeighbors`, `forceProbeNeighbors`,
  `cleanFailedNeighbors`) now runs via `runGuardedNeighborPhase`: a guarded
  goroutine with a per-phase in-flight atomic + last-success timestamp.
- A hung phase can no longer block the for-select loop — the loop keeps
  ticking and every *other* phase keeps running.
- While a pass is in flight the guard **skips** relaunch (a stuck netlink
  syscall cannot be cancelled, so launching a second goroutine would only leak
  another socket); it self-heals on the next tick once the prior pass returns.
- **WHAT** is warmed/cleaned is unchanged — standby-RG skip, the 5s/15s
  cadences, and the per-phase target sets are all preserved. Only **HOW** the
  loop is supervised changed.

**Commit 2 — watchdog gauge + guard tests (`803638c91`)**
- New metric `xpf_daemon_neighbor_periodic_last_success_age_seconds{phase}`
  (phase ∈ {resolve, force_probe, clean_failed, warm}): seconds since each
  phase last completed. A stalled phase shows a monotonically climbing age
  while healthy phases stay flat — the stall is visible *before* it becomes a
  hang. A never-completed phase reports age-since-start so it still flags.
- Wired through the existing `xpf_daemon_*` collector pattern
  (`Config.NeighborPhaseAgeFn` → `Server.neighborPhaseAgeFn` →
  `collectSystemMetrics`); descriptor declared in `Describe()` and registered
  in the #1726 whole-collector coverage canary.
- `neighbor_periodic_guard_test.go` (race-clean) pins: caller never blocks on
  a hung phase; guard skips overlapping passes and self-heals; gauge advances
  for a stalled phase vs. ~0 for a healthy one.

## Validation
- `go build ./...` clean; `go vet` clean on changed files.
- `go test -race ./pkg/daemon -run guard` — pass.
- `go test ./pkg/api` descriptor-coverage canaries — pass.
- The lone daemon-suite failure (`TestWireUserspaceEventStream...`) is the
  pre-existing `sun_path>108` unix-socket artifact from the long test name —
  confirmed failing **identically** on the master base `ecdc16f2e`, untouched
  by this diff.
- Pending: loss-cluster smoke (v4+v6 × push+reverse × CoS off/on) +
  `make test-failover` (this touches HA neighbor maintenance).

## Out of scope (deferred)
- The resolver/probe fix that pins the *multi-second* resolution delay source
  (silent peer vs probe-loss vs monitor/HA) — **capture-gated**; needs the
  escalating-idle capture to name the dominant delay before it can be scoped.
- `regenDebouncer` hardening + `warmNeighborCache` UDP-flood scoping —
  separate follow-ups.

Closes #1780

🤖 Generated with [Claude Code](https://claude.com/claude-code)