### PR TITLE
#1800 U2: capture-harness per-node iface, third append-race site, per-tick log demotion

### DIFF
--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -452,7 +452,9 @@ func (s *SessionSync) syncSweep() int {
 		}
 	}
 	if count > 0 {
-		slog.Info("cluster sync: sweep synced sessions", "count", count)
+		// Debug, not Info: this fires on every 1s sweep tick under steady
+		// session churn (CLAUDE.md: never slog.Info per poll tick).
+		slog.Debug("cluster sync: sweep synced sessions", "count", count)
 	}
 	return count
 }

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -794,8 +794,17 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 
 	// 3b. Apply next-table policy routing rules (ip rule)
 	if d.routing != nil {
-		// Collect all static routes from main + per-rib
-		allRoutes := append(cfg.RoutingOptions.StaticRoutes, cfg.RoutingOptions.Inet6StaticRoutes...)
+		// Collect all static routes from main + per-rib. Build the combined
+		// list in a fresh slice — appending Inet6StaticRoutes onto
+		// cfg.RoutingOptions.StaticRoutes directly would write into that
+		// slice's backing array when it has spare capacity (cap > len),
+		// mutating the shared active-config object other goroutines read
+		// concurrently (same hazard fixed in collectNeighborProbeTargets,
+		// fbd159e55 / #1781 r1).
+		allRoutes := make([]*config.StaticRoute, 0,
+			len(cfg.RoutingOptions.StaticRoutes)+len(cfg.RoutingOptions.Inet6StaticRoutes))
+		allRoutes = append(allRoutes, cfg.RoutingOptions.StaticRoutes...)
+		allRoutes = append(allRoutes, cfg.RoutingOptions.Inet6StaticRoutes...)
 		if err := d.routing.ApplyNextTableRules(allRoutes, cfg.RoutingInstances); err != nil {
 			slog.Warn("failed to apply next-table rules", "err", err)
 		}

--- a/test/incus/capture-cold-stall.sh
+++ b/test/incus/capture-cold-stall.sh
@@ -101,14 +101,6 @@ cl() { sg incus-admin -c "incus exec $HOST -- $*"; }
 
 ts() { date -u +%Y-%m-%dT%H:%M:%S.%3NZ; }
 
-# Fail fast if DP_IFACE does not exist on the target node. Every
-# per-interface evidence channel below (neigh sysctls, the SYN-exchange
-# tcpdump, the ifindex-keyed membership check) tolerates errors with
-# `|| true`, so a wrong interface name would otherwise produce a quietly
-# hollow artifact — unacceptable for a one-shot overnight capture (#1786).
-fw "ip link show $DP_IFACE" >/dev/null 2>&1 \
-  || { echo "ERROR: DP_IFACE $DP_IFACE not present on $FW" >&2; exit 2; }
-
 # A reusable point-in-time sample of the cold-path state on the firewall.
 #   $1 = label (t0prime, t0, t1). Records keyed dynamic_neighbors
 # membership (item 3 / H2), `ip neigh` NUD/lladdr (item 2), and a full
@@ -284,6 +276,17 @@ reduce_deltas() {
 }
 
 trap 'stop_syn_tcpdump; stop_neigh_monitor' EXIT
+
+# Fail fast if DP_IFACE does not exist on the target node. Every
+# per-interface evidence channel below (neigh sysctls, the SYN-exchange
+# tcpdump, the ifindex-keyed membership check) tolerates errors with
+# `|| true`, so a wrong interface name would otherwise produce a quietly
+# hollow artifact — unacceptable for a one-shot overnight capture (#1786).
+# Placed AFTER the EXIT trap so a wrong-iface --connect resume cleanly
+# stops the overnight monitor (finalizing its log) instead of orphaning
+# it, and BEFORE the monitor/sysctl/tcpdump arming below.
+fw "ip link show $DP_IFACE" >/dev/null 2>&1 \
+  || { echo "ERROR: DP_IFACE $DP_IFACE not present on $FW" >&2; exit 2; }
 
 # Arm the monitor + capture sysctls first (item 4 / item 6). In --connect mode
 # resuming an overnight --monitor-only run, REUSE the existing monitor log —

--- a/test/incus/capture-cold-stall.sh
+++ b/test/incus/capture-cold-stall.sh
@@ -50,7 +50,8 @@
 #   SIBLINGS    parallel sibling streams (default 4 — exercises H5)
 #   NEXTHOP_V4  next-hop to grep for     (default = TARGET_V4, directly connected)
 #   NEXTHOP_V6  next-hop to grep for     (default = TARGET_V6, directly connected)
-#   DP_IFACE    data-path egress iface   (default ge-0-0-2 — reth0.80 WAN side)
+#   DP_IFACE    data-path egress iface   (default per-node: ge-0-0-2 on fw0,
+#               ge-7-0-2 on fw1 — reth0.80 WAN side, FPC 0 vs 7)
 #   METRICS_URL daemon Prometheus URL    (default http://127.0.0.1:8080/metrics)
 #   IDLE_SECONDS pre-connect idle wait   (default 0)
 #   ART         artifact dir             (default /tmp/cold-stall-<ts>)
@@ -65,7 +66,14 @@ PORT="${PORT:-5201}"
 SIBLINGS="${SIBLINGS:-4}"
 NEXTHOP_V4="${NEXTHOP_V4:-$TARGET_V4}"
 NEXTHOP_V6="${NEXTHOP_V6:-$TARGET_V6}"
-DP_IFACE="${DP_IFACE:-ge-0-0-2}"
+# The WAN-side VF name is per-node (ge-{FPC}-0-2, FPC 0 vs 7 — see
+# pkg/daemon/linksetup.go + docs/ha-cluster-userspace.conf), so derive the
+# default from the target node instead of hardcoding node 0's name (#1786).
+# An explicit DP_IFACE env override still wins.
+case "$FW" in
+  *fw1) DP_IFACE="${DP_IFACE:-ge-7-0-2}" ;;
+  *)    DP_IFACE="${DP_IFACE:-ge-0-0-2}" ;;
+esac
 METRICS_URL="${METRICS_URL:-http://127.0.0.1:8080/metrics}"
 IDLE_SECONDS="${IDLE_SECONDS:-0}"
 ART="${ART:-/tmp/cold-stall-$(date +%s)}"
@@ -92,6 +100,14 @@ fw() { sg incus-admin -c "incus exec $FW -- $*"; }
 cl() { sg incus-admin -c "incus exec $HOST -- $*"; }
 
 ts() { date -u +%Y-%m-%dT%H:%M:%S.%3NZ; }
+
+# Fail fast if DP_IFACE does not exist on the target node. Every
+# per-interface evidence channel below (neigh sysctls, the SYN-exchange
+# tcpdump, the ifindex-keyed membership check) tolerates errors with
+# `|| true`, so a wrong interface name would otherwise produce a quietly
+# hollow artifact — unacceptable for a one-shot overnight capture (#1786).
+fw "ip link show $DP_IFACE" >/dev/null 2>&1 \
+  || { echo "ERROR: DP_IFACE $DP_IFACE not present on $FW" >&2; exit 2; }
 
 # A reusable point-in-time sample of the cold-path state on the firewall.
 #   $1 = label (t0prime, t0, t1). Records keyed dynamic_neighbors


### PR DESCRIPTION
## Summary

Unit **U2** of the [#1800 sweep-remediation plan](https://github.com/psaab/xpf/issues/1800) (converged PLAN-READY v2.2 `57a5f8989`). Three scoped fixes, one logical commit each:

1. **#1786** — `capture-cold-stall.sh`: the data-path interface default is now derived per-node (`ge-0-0-2` on fw0, `ge-7-0-2` on fw1 — FPC 0 vs 7), and the script **fails fast** if `DP_IFACE` doesn't exist on the target, because every per-interface evidence channel is `|| true`-tolerant and a wrong name would silently hollow out the one-shot #1782 overnight capture.
2. **#1791** — `daemon_apply.go:795`: the next-table route list is built in a fresh pre-sized slice instead of appending in place onto the shared active-config `StaticRoutes` backing array — the third and last site of the hazard class fixed in #1781 r1 (`fbd159e55`).
3. **#1795** — `sync_conn.go:455`: the per-1s-sweep-tick `slog.Info` demoted to `Debug` per the CLAUDE.md per-poll-tick rule (~86K journal lines/day on a busy primary). Adjacent overflow/replay transition logs untouched.

Closes #1786. Closes #1791. Closes #1795.

## Validation
- `go build ./...` clean; `go test ./pkg/daemon/ ./pkg/cluster/` all pass (including the usually-flaky socket-path test this run); `go vet` clean except the two known pre-existing `daemon_flow.go` copylocks.
- `bash -n` + `shellcheck -S warning` clean on the harness.
- Pending (gate): loss-cluster smoke + **`make test-failover`** — #1795 touches `pkg/cluster`, and the CLAUDE.md failover rule has no triviality exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)