### PR TITLE
#1800 U1: fix doc drift — retirement framing, node1 FPC-7 names, smoke target, pre-#1771 comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 > Dataplane notice (#1373, complete): the eBPF dataplane retirement is done.
 > The Rust AF_XDP userspace dataplane is the only runtime forwarding path.
 > The legacy BPF source was deleted in #1476; explicit `system dataplane-type
-> ebpf` is hard-rejected at commit (`ErrEBPFDataplaneRetired`) and at runtime
-> (`ErrEBPFBackendRetired`, `pkg/dataplane/dataplane.go`).
+> ebpf` is hard-rejected at commit (`ErrEBPFDataplaneRetired`, `pkg/config`
+> compiler) and at runtime (`ErrEBPFBackendRetired`, `pkg/dataplane/dataplane.go`).
 
 ## Working Style
 - Think before acting. Read existing files before writing code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # xpf - Junos-Style Firewall With AF_XDP Userspace Dataplane
 
-> Deprecation notice (#1373): the Rust AF_XDP userspace dataplane is now the
-> primary/default target for dataplane development, validation, and omitted
-> runtime configuration. The legacy eBPF dataplane remains in-tree for explicit
-> compatibility and regression coverage during the staged retirement. Later
-> phases own source, loader, build, and CLI removals.
+> Dataplane notice (#1373, complete): the eBPF dataplane retirement is done.
+> The Rust AF_XDP userspace dataplane is the only runtime forwarding path.
+> The legacy BPF source was deleted in #1476; explicit `system dataplane-type
+> ebpf` is hard-rejected at commit (`ErrEBPFDataplaneRetired`) and at runtime
+> (`ErrEBPFBackendRetired`, `pkg/dataplane/dataplane.go`).
 
 ## Working Style
 - Think before acting. Read existing files before writing code.
@@ -46,9 +46,10 @@ gotchas that repeatedly bite (deploy wipes CoS, iperf3 target, etc.).
 ## What This Is
 A Junos-style firewall that clones Juniper vSRX capabilities using native
 Junos configuration syntax. The primary dataplane target is the Rust AF_XDP
-userspace helper (`userspace-dp`) driven by the Go control plane. The original
-XDP/TC eBPF dataplane remains as the legacy compatibility and regression path
-while #1373 retirement blockers are being closed.
+userspace helper (`userspace-dp`) driven by the Go control plane. The eBPF
+dataplane retirement (#1373) is complete: the legacy XDP/TC source was deleted
+in #1476 and the eBPF backend is hard-rejected at commit and runtime — the
+userspace helper is the only runtime forwarding path.
 
 ## Quick Start
 ```bash
@@ -56,7 +57,7 @@ make generate        # Build retained Rust AF_XDP shim (post-#1476)
 make build           # Build xpfd daemon
 make build-ctl       # Build remote CLI client
 make build-userspace-dp # Build the primary Rust AF_XDP dataplane helper
-make test            # Run Go tests (640+ tests across 20 packages)
+make test            # Run Go tests
 ```
 
 ## Test Environment (Incus VM)
@@ -238,7 +239,7 @@ in git history; `git log -- bpf/xdp/ bpf/tc/` walks the deleted source.
 - **Failback timing**: ~130ms (daemon startup + dataplane load + sync hold release)
 - **VRRP advertisement**: RETH instances default 30ms; `AdvertiseInterval` is milliseconds internally, centiseconds on wire per RFC 5798
 - **Async GARP**: `becomeMaster()` runs GARP in a goroutine — first pair <1ms, remaining at 50ms intervals in background. Critical path: addVIPs → sendAdvert → emitEvent (sync), then go sendGARP() (async)
-- **Fabric forwarding**: `try_fabric_redirect()` in xdp_zone redirects to fabric peer when `bpf_fib_lookup` fails for synced sessions — prevents TCP death on VRRP failback
+- **Fabric forwarding**: the userspace dataplane redirects packets for peer-owned synced sessions over the fabric link — `resolve_fabric_redirect()` / `ingress_is_fabric()` in `userspace-dp/src/afxdp/forwarding/mod.rs` (see `docs/fabric-cross-chassis-fwd.md`) — prevents TCP death on VRRP failback. The pre-#1476 eBPF mechanism (`try_fabric_redirect()` in xdp_zone) is historical
 - **RETH virtual MAC**: per-node `02:bf:72:CC:RR:NN`; `programRethMAC()` does link DOWN→set MAC→link UP
 - **VIP reconciliation**: `ReconcileVIPs()` re-adds VRRP VIPs after `programRethMAC` link DOWN/UP (which removes all kernel addresses)
 - **Sync hold**: VRRP starts with `preempt=false`; released after bulk session sync (or 10s timeout); `preemptNowCh` triggers instant preemption
@@ -288,13 +289,17 @@ Test containers:
 
 **HA cluster on `loss:xpf-userspace-fw0/fw1`** — different topology from
 the standalone VM above. Do NOT extrapolate the standalone PCI map to
-the loss userspace cluster; the WAN interface there is `ge-0-0-2`, not
-`ge-0-0-3`, and `ge-0-0-0` is the fabric IPVLAN parent (not WAN). The
+the loss userspace cluster; the WAN interface there is `ge-0-0-2` (node 0
+name — node 1 uses FPC 7, i.e. `ge-7-0-2`), not `ge-0-0-3`, and
+`ge-0-0-0` is the fabric IPVLAN parent (not WAN). The
 per-cluster wiring is canonical in `docs/ha-cluster-userspace.conf` +
 `test/incus/loss-userspace-cluster.env`. Summary:
 
 ```
 loss:xpf-userspace-fw{0,1} — node-id 0 / 1, /etc/xpf/node-id present:
+  NOTE: ge-* names below are node 0; node 1 substitutes FPC 7
+  (ge-7-0-1 / ge-7-0-2) per pkg/daemon/linksetup.go (fpc=7 for node 1)
+  and docs/ha-cluster-userspace.conf (node1: ge-7/0/1, ge-7/0/2).
   Virtio (PCI bus 05-07, lower bus → lower vSRX name):
     enp5s0  → fxp0       DHCP                          — mgmt zone (SSH + ping)
     enp6s0  → em0        10.99.{0..12}.{1,2}           — cluster control plane / heartbeat
@@ -307,7 +312,7 @@ loss:xpf-userspace-fw{0,1} — node-id 0 / 1, /etc/xpf/node-id present:
 
 Smoke iperf3 target: 172.16.80.200 / 2001:559:8585:80::200 (on reth0.80
 WAN path, AF_XDP zero-copy fast path). Per-class iperf3 servers live on
-ports 5201-5211 matching `test/incus/cos-iperf-config.set`. Do NOT use
+ports 5200-5211 matching `test/incus/cos-iperf-config.set`. Do NOT use
 172.16.100.x — that reaches a different `loss:` uplink path capped at
 ~9-10 Gb/s and was the misdiagnosed "cluster ceiling" in #1578.
 ```

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -96,7 +96,7 @@ the mechanics, so this section is sequencing only.
    | What changed | Deploy | Validation | Pass criteria |
    |---|---|---|---|
    | Any change | `make test-deploy` (standalone) | ping between zones | 0% loss |
-   | Any change | `make test-deploy` | `iperf3 -P 16 -t 30 -p 5203` → 172.16.80.200 | ≥ 23 Gbit/s, no regression vs previous run |
+   | Any change | `make cluster-deploy` (loss userspace cluster) + re-apply CoS (`./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0` — deploy wipes CoS) | `iperf3 -P 16 -t 30 -p 5203` → 172.16.80.200 | ≥ 23 Gbit/s, no regression vs previous run |
    | Admission / DSCP / scheduler / queueing | above + re-apply CoS (`./test/incus/apply-cos-config.sh <target>`) | `show class-of-service interface` | targeted counter (`flow_share`, `buffer`, `ecn_marked`) moves in the predicted direction — see [`cos-validation-notes.md`](cos-validation-notes.md) |
    | NAT / screens / filter / VLAN / IPsec | above | exercise that feature end-to-end from a test host | session / hit counters advance; negative case drops |
    | HA / VRRP / session sync / fabric | `make cluster-deploy` | `make test-failover` + `make test-ha-crash` | 0 / very low packet loss across failover/failback, both nodes converge |

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -1,21 +1,22 @@
 # userspace-dp/
 
-> #1373 status: this Rust AF_XDP dataplane is the target path for new dataplane
-> development and routine validation while the legacy eBPF dataplane is being
-> retired. Phase 1 updates active docs and migration targeting only; no BPF
-> source, loader code, or CLI surface is removed yet.
+> #1373 status (complete): the eBPF dataplane retirement is done. This Rust
+> AF_XDP dataplane is the only runtime forwarding path. The legacy BPF source
+> (`bpf/xdp/*.c`, `bpf/tc/*.c`) was deleted in #1476, and `pkg/dataplane`
+> hard-rejects the eBPF backend at commit (`ErrEBPFDataplaneRetired`) and
+> runtime (`ErrEBPFBackendRetired`).
 
 Standalone Rust AF_XDP dataplane that mirrors the BPF pipeline
 (screen → zone → conntrack → policy → NAT → forward) but in userspace.
 Runs as a separate `xpf-userspace-dp` binary the Go daemon spawns over a
 Unix-socket control protocol.
 
-This crate is the primary AF_XDP backend for #1373 and is now the default
-runtime: an empty / omitted `system dataplane-type` resolves to userspace in
+This crate is the only runtime dataplane backend: an empty / omitted
+`system dataplane-type` resolves to userspace in
 `pkg/dataplane.EffectiveType`. Operators can still pin the selection
 explicitly with `set system dataplane-type userspace`. The legacy eBPF
-backend (`pkg/dataplane`) remains available for compatibility and regression
-coverage; the DPDK backend is retired under #1525.
+backend is retired (#1373/#1476) and hard-rejected by `pkg/dataplane`;
+the DPDK backend is retired under #1525.
 
 ## Crate entry
 

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -2,9 +2,10 @@
 
 > #1373 status (complete): the eBPF dataplane retirement is done. This Rust
 > AF_XDP dataplane is the only runtime forwarding path. The legacy BPF source
-> (`bpf/xdp/*.c`, `bpf/tc/*.c`) was deleted in #1476, and `pkg/dataplane`
-> hard-rejects the eBPF backend at commit (`ErrEBPFDataplaneRetired`) and
-> runtime (`ErrEBPFBackendRetired`).
+> (`bpf/xdp/*.c`, `bpf/tc/*.c`) was deleted in #1476; the eBPF backend is
+> hard-rejected at commit by the config compiler (`ErrEBPFDataplaneRetired`,
+> `pkg/config`) and at runtime by the dataplane factory
+> (`ErrEBPFBackendRetired`, `pkg/dataplane`).
 
 Standalone Rust AF_XDP dataplane that mirrors the BPF pipeline
 (screen → zone → conntrack → policy → NAT → forward) but in userspace.
@@ -15,7 +16,8 @@ This crate is the only runtime dataplane backend: an empty / omitted
 `system dataplane-type` resolves to userspace in
 `pkg/dataplane.EffectiveType`. Operators can still pin the selection
 explicitly with `set system dataplane-type userspace`. The legacy eBPF
-backend is retired (#1373/#1476) and hard-rejected by `pkg/dataplane`;
+backend is retired (#1373/#1476) and hard-rejected (commit: `pkg/config`
+compiler; runtime: `pkg/dataplane` factory);
 the DPDK backend is retired under #1525.
 
 ## Crate entry

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -330,18 +330,23 @@ const XDP_OPTIONS: c_int = 8;
 const XDP_OPTIONS_ZEROCOPY: u32 = 1;
 
 const PENDING_NEIGH_TIMEOUT_NS: u64 = 2_000_000_000; // 2 seconds
-// GEMINI-NEXT.md Section 3 cold start: admission cap bumped 64 → 4096 so a
-// per-binding burst of new connections during the ARP/NDP probe window
-// doesn't drop frames. PendingNeighPacket is 264 B on x86_64 (XdpDesc +
-// UserspaceDpMeta + SessionDecision + flow key + queued_ns + probe_attempts),
-// so worst-case per binding when the queue is fully populated is ~1.0 MiB.
-// To avoid paying that ~1.0 MiB up front per binding × N bindings, the
-// underlying VecDeque is now constructed with `VecDeque::new()` (zero
-// capacity) at worker init — see worker/mod.rs.
-// The buffer grows on push only when traffic actually queues up, and the
-// 4096 admission check in poll_descriptor.rs enforces the upper bound.
-// This unblocks parallel-connect storms during cluster failback while
-// keeping idle-binding RSS near zero.
+// #1771 §2.2: `pending_neigh` is a FastMap keyed by `(egress_ifindex,
+// next_hop)` holding ONE representative packet per unresolved next-hop —
+// not a packet FIFO. Admission keeps the OLDEST packet for a key (it
+// drives the probe/dwell clock); later packets to the same hop are
+// dropped + recycled and counted via `pending_neigh_duplicate_drops`
+// (the #1782 H5 sibling-drop signal). This cap therefore bounds DISTINCT
+// unresolved next-hops per binding, and pins at most one UMEM frame per
+// hop — a SYN flood to one dead host holds 1 entry, not 4096.
+// PendingNeighPacket is 264 B on x86_64 (XdpDesc + UserspaceDpMeta +
+// SessionDecision + flow key + queued_ns + probe_attempts), so the
+// worst case is ~1.0 MiB per binding — but reaching it now requires
+// 4096 *distinct* unresolved hops (a scan-shaped workload), not a
+// connect burst. The map is lazily allocated (`FastMap::default()` at
+// worker init — see worker/mod.rs), keeping idle-binding RSS near zero.
+// History: pre-#1771 this was a per-packet VecDeque whose cap was bumped
+// 64 → 4096 (GEMINI-NEXT.md Section 3) so failback connect storms didn't
+// drop frames; post-#1771 sibling drops are by design and counted.
 const MAX_PENDING_NEIGH: usize = 4096;
 
 // #1651 B3: dead-host negative neighbor cache (per binding). When a

--- a/userspace-dp/src/afxdp/neg_neigh.rs
+++ b/userspace-dp/src/afxdp/neg_neigh.rs
@@ -6,10 +6,17 @@
 //! fast-fail (recycle) at the buffer site instead of each consuming a
 //! `pending_neigh` slot for the full timeout window.
 //!
-//! This is the AGY-r1 HIGH starvation defense from the reopened-#1651
-//! research: a dead-host SYN storm can otherwise saturate the bounded
-//! `pending_neigh` queue (cap `MAX_PENDING_NEIGH`, 800 ms hold each) and
-//! starve LIVE cold connects at the full-queue gate.
+//! Historical motivation (AGY-r1 HIGH, reopened-#1651 research, when
+//! `pending_neigh` was still a per-packet FIFO): a dead-host SYN storm
+//! could saturate the bounded queue (cap `MAX_PENDING_NEIGH`) and starve
+//! LIVE cold connects at the full-queue gate. Post-#1771 §2.2 the map
+//! holds ONE representative packet per `(egress_ifindex, next_hop)`, so
+//! a single dead host pins ≤1 entry; the residual threat this cache
+//! defends against is a multi-hop scan exhausting the distinct-hop cap.
+//! The pending hold per hop is dynamic — `pending_neigh_timeout_ns`
+//! (800 ms with confirmed kernel fast-retrans, else 2000 ms; fallback
+//! `PENDING_NEIGH_TIMEOUT_NS` = 2 s) per `neighbor_dispatch.rs` — not a
+//! fixed 800 ms each.
 //!
 //! ## Invalidation
 //! - **RTM_NEWNEIGH (host recovered):** lazy resolved-neighbor-wins. The


### PR DESCRIPTION
## Summary

Unit **U1** (docs/comments only, zero behavior change) of the [#1800 plan](https://github.com/psaab/xpf/issues/1800). Three logical commits:

1. **#1784** — CLAUDE.md: stale "#1373 staged retirement" framing → the completed-retirement reality (hard-rejected at commit + runtime); node1 FPC-7 interface names annotated in the cluster topology block and prose; "640+/20" test count dropped; the deleted `try_fabric_redirect()`/xdp_zone fabric bullet rewritten around the current `resolve_fabric_redirect()` in `forwarding/mod.rs`; per-class port range corrected to 5200-5211 (verified against `cos-iperf-config.set`). Same stale banner fixed in `userspace-dp/README.md`.
2. **#1785** — `docs/engineering-style.md:99`: throughput-validation row now deploys with `make cluster-deploy` (the 172.16.80.200 / ≥23 Gbit/s endpoint is loss-cluster-only) + re-apply-CoS reminder.
3. **#1788** — `MAX_PENDING_NEIGH` + `neg_neigh.rs` module docs rewritten to the current #1771 §2.2 one-representative-per-hop semantics (mechanically verified comment-only: the non-comment diff is empty).

Closes #1784. Closes #1785. Closes #1788.

## Validation
`go build ./...` + `cargo build --release` clean; Rust diff is comment-only by construction. Gate: build-only per plan §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)