### PR TITLE
#1800 U4: count swallowed USERSPACE_SESSIONS publish failures (#1789)

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -136,6 +136,9 @@ type xpfCollector struct {
 	userspaceSessionTableEntries             *prometheus.Desc
 	userspaceSessionTableCapacity            *prometheus.Desc
 	userspaceNatReverseKeyCollisions         *prometheus.Desc
+	// #1789: total failed USERSPACE_SESSIONS BPF-map publishes — the
+	// cause-side signal for rising XDP-shim NO_SESSION fallbacks.
+	userspaceSessionPublishErrors            *prometheus.Desc
 	userspaceFlowCacheActiveFlows            *prometheus.Desc
 	userspaceFlowCacheCapacity               *prometheus.Desc
 	// #1379: daemon-side userspace event-stream transport counters.
@@ -331,6 +334,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.userspaceSessionTableEntries
 	ch <- c.userspaceSessionTableCapacity
 	ch <- c.userspaceNatReverseKeyCollisions
+	ch <- c.userspaceSessionPublishErrors
 	ch <- c.userspaceFlowCacheActiveFlows
 	ch <- c.userspaceFlowCacheCapacity
 	ch <- c.userspaceEventStreamFramesTotal

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -282,6 +282,8 @@ func populatedCoverageStatus() dpuserspace.ProcessStatus {
 		NegNeighFastFailTotal:             3,
 		PendingNeighDuplicateDropsTotal:   4,
 		DynamicNeighborKeys:               []string{"7 10.0.61.1", "9 172.16.80.200"},
+		// #1789: failed USERSPACE_SESSIONS publish counter (always emits).
+		SessionPublishErrorsTotal: 5,
 		NeighborResolverQueueDepth:        3,
 		NeighborResolverEnqueueDropsTotal: 1,
 		NeighborResolverGetAttemptsTotal:  5,
@@ -404,6 +406,7 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_userspace_neg_neigh_fast_fail_total",               // #1782 cold-start H1
 		"xpf_userspace_pending_neigh_duplicate_drops_total",     // #1782 cold-start H5
 		"xpf_userspace_dynamic_neighbor_present",                // #1782 cold-start H2 dump
+		"xpf_userspace_session_publish_errors_total",            // #1789 publish failures
 	}
 	if ifaceResolvable {
 		want = append(want, "xpf_interface_packets_total") // collectInterfaceCounters (lo)

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -452,6 +452,18 @@ func newCollector(srv *Server) *xpfCollector {
 				"research.",
 			nil, nil,
 		),
+		userspaceSessionPublishErrors: prometheus.NewDesc(
+			"xpf_userspace_session_publish_errors_total",
+			"Failed USERSPACE_SESSIONS BPF-map publishes across all helper "+
+				"paths (worker poll, HA upsert, session-glue, post-reconcile "+
+				"replay, activation/reverse prewarm). A failed publish means "+
+				"the XDP shim never learns the session key and takes the "+
+				"NO_SESSION degraded path (drop in STRICT mode); a rising "+
+				"value attributes shim no-session fallbacks to publish "+
+				"failures (session map at capacity, stale fd after "+
+				"reconcile) (#1789).",
+			nil, nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"Aggregate active userspace flow-cache entries across bindings.",

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -645,6 +645,12 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 			nil,
 			nil,
 		),
+		userspaceSessionPublishErrors: prometheus.NewDesc(
+			"xpf_userspace_session_publish_errors_total",
+			"session publish errors",
+			nil,
+			nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"flow-cache active flows",
@@ -667,6 +673,8 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	status := dpuserspace.ProcessStatus{
 		SessionTableEntries: 77,
 		MaxSessions:         100,
+		// #1789: publish-error counter emitted unconditionally.
+		SessionPublishErrorsTotal: 6,
 		Bindings: []dpuserspace.BindingStatus{
 			{
 				Slot:              0,
@@ -696,8 +704,8 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	for m := range ch {
 		got = append(got, m)
 	}
-	if len(got) != 7 {
-		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 7 metrics, got %d", len(got))
+	if len(got) != 8 {
+		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 8 metrics, got %d", len(got))
 	}
 
 	assertGaugeClose(t, got, c.userspaceSessionTableEntries, nil, 77)
@@ -705,6 +713,8 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	// #1760: collision counter emitted unconditionally (0 with no
 	// collisions configured in this fixture).
 	assertCounterClose(t, got, c.userspaceNatReverseKeyCollisions, nil, 0)
+	// #1789: publish-error counter emitted unconditionally.
+	assertCounterClose(t, got, c.userspaceSessionPublishErrors, nil, 6)
 	assertGaugeClose(t, got, c.userspaceFlowCacheActiveFlows, nil, 12)
 	assertGaugeClose(t, got, c.userspaceFlowCacheCapacity, nil, 20)
 	assertGaugeClose(t, got, c.bindingFlowCacheCapacity, map[string]string{

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -308,6 +308,15 @@ func (c *xpfCollector) emitUserspaceDynamicBufferMetrics(ch chan<- prometheus.Me
 		float64(status.NatReverseKeyCollisions),
 	)
 
+	// #1789: failed USERSPACE_SESSIONS BPF-map publishes. Also emitted
+	// unconditionally so a 0 is a real "no publish failures" signal
+	// rather than an absent series.
+	ch <- prometheus.MustNewConstMetric(
+		c.userspaceSessionPublishErrors,
+		prometheus.CounterValue,
+		float64(status.SessionPublishErrorsTotal),
+	)
+
 	var activeFlows, flowCapacity uint64
 	for _, b := range status.Bindings {
 		activeFlows += uint64(b.ActiveFlowCount)

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -640,6 +640,16 @@ type ProcessStatus struct {
 	NegNeighFastFailTotal           uint64   `json:"neg_neigh_fast_fail_total,omitempty"`
 	PendingNeighDuplicateDropsTotal uint64   `json:"pending_neigh_duplicate_drops_total,omitempty"`
 	DynamicNeighborKeys             []string `json:"dynamic_neighbor_keys,omitempty"`
+	// #1789: total failed USERSPACE_SESSIONS BPF-map publishes (per-binding
+	// worker-poll sites summed with the shared no-binding sites: HA upsert,
+	// session-glue worker publish, post-reconcile replay, activation/reverse
+	// prewarm). A failed publish means the XDP shim never learns the session
+	// key and takes the NO_SESSION degraded path (drop in STRICT mode), so a
+	// rising value is the cause-side signal for rising shim no-session
+	// fallbacks (session map at capacity, stale fd after reconcile). Surfaced
+	// as xpf_userspace_session_publish_errors_total. Omitempty for wire
+	// compat with older helpers.
+	SessionPublishErrorsTotal uint64 `json:"session_publish_errors_total,omitempty"`
 	// #1769: on-demand neighbor-resolver telemetry. The resolver fires
 	// when a MissingNeighbor negative-cache fast-fail nudges a wedged dst
 	// (single-key RTM_GETNEIGH + epoch-guarded cache or probe-on-stale).

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -866,6 +866,17 @@ pub(super) fn dump_bpf_session_entries(map_fd: c_int, max_entries: u32) {
 
 pub(super) static SESSION_PUBLISH_VERIFY_OK: AtomicU64 = AtomicU64::new(0);
 pub(super) static SESSION_PUBLISH_VERIFY_FAIL: AtomicU64 = AtomicU64::new(0);
+/// #1789: failed USERSPACE_SESSIONS BPF-map publishes from call sites
+/// that have no per-binding context (HA `upsert_synced_session`,
+/// session-glue worker publishes, post-reconcile `replay_synced_sessions`,
+/// activation/reverse prewarm). Always-on (NOT debug-gated, unlike the
+/// VERIFY counters above which only move under `debug-log`): a swallowed
+/// publish `Err` means the XDP shim never learns the key and the flow
+/// takes the NO_SESSION degraded path. Per-binding worker poll sites use
+/// `BindingLiveState::session_publish_errors` instead; the two are summed
+/// by `Coordinator::session_publish_errors_total()` and surfaced as
+/// `xpf_userspace_session_publish_errors_total`.
+pub(super) static SESSION_PUBLISH_ERRORS_SHARED: AtomicU64 = AtomicU64::new(0);
 pub(super) static SESSION_CREATIONS_LOGGED: AtomicU64 = AtomicU64::new(0);
 #[cfg(feature = "debug-log")]
 pub(super) static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -367,12 +367,19 @@ impl Coordinator {
         }
         let worker_queues = worker_command_queues.values().cloned().collect::<Vec<_>>();
         for entry in entries {
-            let _ = publish_live_session_entry(
+            // #1789: a failed replay publish silently loses an arbitrary
+            // prefix of synced state after reconcile (was `let _ =`). No
+            // binding context here — shared counter.
+            if publish_live_session_entry(
                 session_map_fd,
                 &entry.key,
                 entry.decision.nat,
                 entry.metadata.is_reverse,
-            );
+            )
+            .is_err()
+            {
+                SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
+            }
             replicate_session_upsert(&worker_queues, entry);
         }
         entries.len()

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -59,6 +59,26 @@ impl super::Coordinator {
             .sum()
     }
 
+    /// #1789: total failed USERSPACE_SESSIONS BPF-map publishes. Sum of
+    /// the per-binding `session_publish_errors` atomics (worker poll
+    /// sites, mirroring `neg_neigh_fast_fail_total`) plus the shared
+    /// `SESSION_PUBLISH_ERRORS_SHARED` static (HA upsert, session-glue
+    /// worker publish, post-reconcile replay, activation/reverse prewarm
+    /// — sites with no binding context). A nonzero value is the
+    /// cause-side signal for rising XDP-shim NO_SESSION degraded-path
+    /// fallbacks (session map at capacity, stale/invalid fd after
+    /// reconcile). Surfaced as
+    /// `xpf_userspace_session_publish_errors_total`.
+    pub fn session_publish_errors_total(&self) -> u64 {
+        let per_binding: u64 = self
+            .workers
+            .live
+            .values()
+            .map(|live| live.session_publish_errors.load(Ordering::Relaxed))
+            .sum();
+        per_binding.saturating_add(SESSION_PUBLISH_ERRORS_SHARED.load(Ordering::Relaxed))
+    }
+
     /// #1782: debug dump of every key currently present in the userspace
     /// `dynamic_neighbors` mirror, as `(ifindex, ip)` pairs. The
     /// cold-start capture harness reads this at the pre-connect t0'

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1103,8 +1103,14 @@ pub(super) fn install_helper_local_session_on_miss(
         protocol,
         tcp_flags,
     };
-    let _ =
-        publish_session_map_entry_for_session(session_map_fd, key, decision, &local_entry.metadata);
+    // #1789: count a failed helper-local session publish (same
+    // shim-missing-key consequence as every other publish site).
+    if publish_session_map_entry_for_session(session_map_fd, key, decision, &local_entry.metadata)
+        .is_err()
+    {
+        crate::afxdp::bpf_map::SESSION_PUBLISH_ERRORS_SHARED
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
     true
 }
 

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -279,12 +279,19 @@ impl super::Coordinator {
             now_secs,
         ) && let Some(session_map_fd) = self.bpf_maps.session_map_fd.as_ref()
         {
-            let _ = publish_live_session_entry(
+            // #1789: a failed HA-upsert publish silently loses synced
+            // state (the shim takes the NO_SESSION degraded path). No
+            // binding context here, so bump the shared counter.
+            if publish_live_session_entry(
                 session_map_fd.fd,
                 &entry.key,
                 entry.decision.nat,
                 entry.metadata.is_reverse,
-            );
+            )
+            .is_err()
+            {
+                SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
+            }
         }
         refresh_reverse_prewarm_owner_rg_indexes(
             &self.sessions.owner_rg_indexes.reverse_prewarm_sessions,
@@ -307,12 +314,18 @@ impl super::Coordinator {
                 now_secs,
             ) && let Some(session_map_fd) = self.bpf_maps.session_map_fd.as_ref()
             {
-                let _ = publish_live_session_entry(
+                // #1789: same accounting for the synthesized reverse
+                // entry (was `let _ =`).
+                if publish_live_session_entry(
                     session_map_fd.fd,
                     &reverse.key,
                     reverse.decision.nat,
                     true,
-                );
+                )
+                .is_err()
+                {
+                    SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
+                }
             }
         }
         for handle in self.workers.handles.values() {

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -467,12 +467,24 @@ pub(super) fn poll_binding_process_descriptor(
                                         meta.protocol,
                                         meta.tcp_flags,
                                     ) {
-                                        let _ = publish_live_session_entry(
+                                        // #1789: a failed publish leaves the
+                                        // shim without this key (NO_SESSION
+                                        // degraded path). Count it; one
+                                        // Relaxed fetch_add on the rare error
+                                        // branch only.
+                                        if publish_live_session_entry(
                                             binding.bpf_maps.session_map_fd,
                                             &flow.forward_key,
                                             NatDecision::default(),
                                             true,
-                                        );
+                                        )
+                                        .is_err()
+                                        {
+                                            binding
+                                                .live
+                                                .session_publish_errors
+                                                .fetch_add(1, Ordering::Relaxed);
+                                        }
                                     }
                                     binding.scratch.scratch_forwards.push(request);
                                     continue;
@@ -1244,12 +1256,23 @@ pub(super) fn poll_binding_process_descriptor(
                                                 protocol: meta.protocol,
                                                 tcp_flags: meta.tcp_flags,
                                             };
-                                            let _ = publish_live_session_entry(
+                                            // #1789: count failed publishes so
+                                            // map-at-capacity / stale-fd
+                                            // failures are visible in release
+                                            // builds (was `let _ =`).
+                                            if publish_live_session_entry(
                                                 binding.bpf_maps.session_map_fd,
                                                 &flow.forward_key,
                                                 decision.nat,
                                                 false,
-                                            );
+                                            )
+                                            .is_err()
+                                            {
+                                                binding
+                                                    .live
+                                                    .session_publish_errors
+                                                    .fetch_add(1, Ordering::Relaxed);
+                                            }
                                             publish_shared_session(
                                                 worker_ctx.shared_sessions,
                                                 worker_ctx.shared_nat_sessions,
@@ -1385,10 +1408,21 @@ pub(super) fn poll_binding_process_descriptor(
                                                 meta.tcp_flags,
                                             )
                                         {
-                                            let _ = publish_live_session_key(
+                                            // #1789: count failed reverse-key
+                                            // publishes (was `let _ =`; the
+                                            // debug-only verify below re-reads
+                                            // the map and cannot see the Err).
+                                            if publish_live_session_key(
                                                 binding.bpf_maps.session_map_fd,
                                                 &reverse_key,
-                                            );
+                                            )
+                                            .is_err()
+                                            {
+                                                binding
+                                                    .live
+                                                    .session_publish_errors
+                                                    .fetch_add(1, Ordering::Relaxed);
+                                            }
                                             // Verify session keys and log creations (debug-only: BPF syscalls)
                                             if cfg!(feature = "debug-log") {
                                                 if verify_session_key_in_bpf(

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2419,12 +2419,22 @@ pub(super) fn poll_binding_process_descriptor(
                                             &worker_ctx.shared_owner_rg_indexes,
                                             &entry,
                                         );
-                                        let _ = publish_session_map_entry_for_session(
+                                        // #1789: count a failed publish
+                                        // (shim misses the key -> NO_SESSION
+                                        // degraded path for the seeded flow).
+                                        if publish_session_map_entry_for_session(
                                             binding.bpf_maps.session_map_fd,
                                             &flow.forward_key,
                                             pending_decision,
                                             &entry.metadata,
-                                        );
+                                        )
+                                        .is_err()
+                                        {
+                                            binding
+                                                .live
+                                                .session_publish_errors
+                                                .fetch_add(1, Ordering::Relaxed);
+                                        }
                                         publish_bpf_conntrack_entry(
                                             conntrack_v4_fd,
                                             conntrack_v6_fd,

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -254,12 +254,18 @@ pub(super) fn republish_local_delivery_sessions_for_lo0_filter(
             return;
         }
         if session_map_fd >= 0 {
-            let _ = publish_live_session_entry(
+            // #1789: count failed lo0-filter republishes (was `let _ =`).
+            // No binding context in this glue path — shared counter.
+            if publish_live_session_entry(
                 session_map_fd,
                 key,
                 decision.nat,
                 metadata.is_reverse,
-            );
+            )
+            .is_err()
+            {
+                SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
+            }
         }
         republished += 1;
     });
@@ -340,10 +346,20 @@ pub(in crate::afxdp::session_glue) fn publish_worker_session_map_entry(
         // filters. Keep the packet visible to the helper while lo0
         // filtering is configured; the session-hit path enforces the
         // current lo0 terms before reinjection.
-        let _ = publish_live_session_entry(session_map_fd, key, decision.nat, metadata.is_reverse);
+        //
+        // #1789: count failed publishes (was `let _ =`). No binding
+        // context in this glue path — shared counter.
+        if publish_live_session_entry(session_map_fd, key, decision.nat, metadata.is_reverse)
+            .is_err()
+        {
+            SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
+        }
         return;
     }
-    let _ = if force_live_redirect_for_worker_synced_entry(
+    // #1789: capture the previously-discarded publish result. Only the
+    // publish outcome is counted; `delete_live_session_entry` below is a
+    // removal, not a publish, and keeps its existing semantics.
+    let publish_result = if force_live_redirect_for_worker_synced_entry(
         decision,
         metadata,
         origin,
@@ -362,6 +378,9 @@ pub(in crate::afxdp::session_glue) fn publish_worker_session_map_entry(
             origin,
         )
     };
+    if publish_result.is_err() {
+        SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 pub(super) fn delete_terminal_filtered_session(

--- a/userspace-dp/src/afxdp/session_glue/promote.rs
+++ b/userspace-dp/src/afxdp/session_glue/promote.rs
@@ -105,7 +105,14 @@ pub(in crate::afxdp::session_glue) fn maybe_promote_synced_session(
         protocol,
         tcp_flags,
     }) {
-        let _ = publish_session_map_entry_for_session(session_map_fd, key, decision, &promoted);
+        // #1789: count a failed shared-promote publish (shim would miss the
+        // key -> NO_SESSION degraded path for the promoted flow).
+        if publish_session_map_entry_for_session(session_map_fd, key, decision, &promoted)
+            .is_err()
+        {
+            crate::afxdp::bpf_map::SESSION_PUBLISH_ERRORS_SHARED
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
         let promoted_entry = SyncedSessionEntry {
             key: key.clone(),
             decision,

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -168,6 +168,13 @@ pub(super) fn prewarm_reverse_synced_sessions_for_owner_rgs(
             .is_err()
         {
             fwd_publish_errors += 1;
+            // #1789: fold the activation-prewarm forward publish failures
+            // into the global publish-error total. Semantically identical
+            // to every other counted site (a USERSPACE_SESSIONS publish
+            // that returned Err); the local fwd_publish_errors count is
+            // kept only for the existing one-shot eprintln below, so this
+            // is one increment per failure, not a double count.
+            SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
         }
         for commands in worker_commands {
             if let Ok(mut pending) = commands.lock() {
@@ -191,12 +198,19 @@ pub(super) fn prewarm_reverse_synced_sessions_for_owner_rgs(
             &reverse,
         );
         if publish_session_map {
-            let _ = publish_session_map_entry_for_session(
+            // #1789: the reverse-prewarm publish in the same activation
+            // path was still swallowed with `let _ =`; count it like the
+            // forward loop above.
+            if publish_session_map_entry_for_session(
                 session_map_fd,
                 &reverse.key,
                 reverse.decision,
                 &reverse.metadata,
-            );
+            )
+            .is_err()
+            {
+                SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
+            }
         }
         for commands in worker_commands {
             if let Ok(mut pending) = commands.lock() {
@@ -599,7 +613,13 @@ pub(super) fn install_reverse_session_from_forward_match(
         protocol,
         tcp_flags,
     ) {
-        let _ = publish_live_session_entry(session_map_fd, reverse_key, reverse.decision.nat, true);
+        // #1789: count failed reverse-install publishes (was `let _ =`).
+        // No binding context in this shared-ops path — shared counter.
+        if publish_live_session_entry(session_map_fd, reverse_key, reverse.decision.nat, true)
+            .is_err()
+        {
+            SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
+        }
         let reverse_entry = SyncedSessionEntry {
             key: reverse_key.clone(),
             decision: reverse.decision,

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -266,6 +266,9 @@ pub(super) fn republish_bpf_session_entries_for_owner_rgs(
             published += 1;
         } else {
             errors += 1;
+            // #1789: feed the activation-republish failures into the same
+            // always-on total as every other USERSPACE_SESSIONS publish site.
+            SESSION_PUBLISH_ERRORS_SHARED.fetch_add(1, Ordering::Relaxed);
         }
     }
     if errors > 0 {

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -469,6 +469,21 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// `Coordinator::pending_neigh_duplicate_drops_total()` (Prometheus
     /// `xpf_userspace_pending_neigh_duplicate_drops_total`).
     pub(super) pending_neigh_duplicate_drops: AtomicU64,
+    /// #1789: per-binding count of failed USERSPACE_SESSIONS BPF-map
+    /// publishes (`publish_live_session_entry` /
+    /// `publish_live_session_key` returning `Err`) on the worker poll
+    /// paths that previously discarded the result with `let _ =`. A
+    /// failed publish means the XDP shim never learns the session key
+    /// and takes the NO_SESSION degraded path (drop in STRICT mode), so
+    /// this is the cause-side signal for rising shim no-session
+    /// fallbacks (map at capacity, stale fd after reconcile). One
+    /// Relaxed fetch_add on the existing (rare) error branch — no new
+    /// hot-path work. Call sites without a binding context (HA upsert,
+    /// session-glue worker publish, replay, prewarm) bump the shared
+    /// `SESSION_PUBLISH_ERRORS_SHARED` static instead; both are summed
+    /// by `Coordinator::session_publish_errors_total()` (Prometheus
+    /// `xpf_userspace_session_publish_errors_total`).
+    pub(super) session_publish_errors: AtomicU64,
     /// #709 / #746: owner-written telemetry, cacheline-isolated.
     /// `drain_latency_hist` buckets sum to `drain_invocations` (pinned
     /// in unit tests); `drain_noop_invocations` is a subset counter
@@ -705,6 +720,7 @@ impl BindingLiveState {
             no_owner_binding_drops: AtomicU64::new(0),
             neg_neigh_fast_fail: AtomicU64::new(0),
             pending_neigh_duplicate_drops: AtomicU64::new(0),
+            session_publish_errors: AtomicU64::new(0),
             // #709 / #746: owner-profile telemetry, split by writer
             // into two cacheline-isolated groups. Histograms are zero-
             // init fixed-cap arrays; sum of buckets == drain_invocations

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -166,6 +166,16 @@ pub(crate) struct ProcessStatus {
     pub neg_neigh_fast_fail_total: u64,
     #[serde(rename = "pending_neigh_duplicate_drops_total", default)]
     pub pending_neigh_duplicate_drops_total: u64,
+    /// #1789: total failed USERSPACE_SESSIONS BPF-map publishes
+    /// (per-binding worker-poll sites summed with the shared no-binding
+    /// sites: HA upsert, session-glue worker publish, post-reconcile
+    /// replay, activation/reverse prewarm). Always-on cause-side signal
+    /// for rising XDP-shim NO_SESSION degraded-path fallbacks (session
+    /// map at capacity, stale fd after reconcile). Surfaced as the
+    /// Prometheus counter `xpf_userspace_session_publish_errors_total`.
+    /// Additive / defaulted for backward compatibility.
+    #[serde(rename = "session_publish_errors_total", default)]
+    pub session_publish_errors_total: u64,
     /// #1782 cold-start capture instrumentation. Debug dump of every key
     /// present in the userspace `dynamic_neighbors` mirror, rendered as
     /// `"ifindex ip"` strings. The capture harness greps this at the

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -43,6 +43,10 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     state.status.neg_neigh_fast_fail_total = state.afxdp.neg_neigh_fast_fail_total();
     state.status.pending_neigh_duplicate_drops_total =
         state.afxdp.pending_neigh_duplicate_drops_total();
+    // #1789: total failed USERSPACE_SESSIONS BPF-map publishes
+    // (per-binding worker-poll sites + shared no-binding sites). The
+    // cause-side signal for rising XDP-shim NO_SESSION fallbacks.
+    state.status.session_publish_errors_total = state.afxdp.session_publish_errors_total();
     // The per-key dynamic_neighbors dump is a high-cardinality
     // (ifindex,ip)-labelled debug surface used only by the #1782 cold-start
     // capture. Gate it behind XPF_DEBUG_NEIGHBOR_KEYS so it is OFF by default:

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -107,6 +107,7 @@ pub(crate) fn run() -> Result<(), String> {
             neighbor_warm_disconnected_total: 0,
             neg_neigh_fast_fail_total: 0,
             pending_neigh_duplicate_drops_total: 0,
+            session_publish_errors_total: 0,
             dynamic_neighbor_keys: Vec::new(),
             neighbor_resolver_queue_depth: 0,
             neighbor_resolver_enqueue_drops_total: 0,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -760,6 +760,7 @@
     "recent_session_deltas": [],
     "ring_entries": 0,
     "route_entries": 0,
+    "session_publish_errors_total": 0,
     "session_table_entries": 0,
     "slow_path": {
       "active": false,


### PR DESCRIPTION
## Summary

Unit **U4** of the [#1800 plan](https://github.com/psaab/xpf/issues/1800). Observability-only, perf-neutral: every `let _ =`-swallowed `USERSPACE_SESSIONS` BPF-map publish failure is now counted and surfaced as **`xpf_userspace_session_publish_errors_total`** — the cause-side signal for rising XDP-shim NO_SESSION degraded-path fallbacks (map at capacity, stale fd after reconcile).

- Per-binding `AtomicU64` for the 3 worker poll sites (fabric-return, forward create, reverse key) — exact `neg_neigh_fast_fail` (#1782) pattern; single `Relaxed fetch_add` on the **error branch only**.
- One always-on shared static for the no-binding-context sites (HA `upsert_synced_session` fwd+reverse, session-glue publishes, `replay_synced_sessions`, activation/reverse prewarm); `session_publish_errors_total()` sums both.
- The pre-existing `fwd_publish_errors` prewarm counting is folded in (same failure class, single increment, no double count) and the previously-uncounted reverse-prewarm `let _ =` is now counted too.
- Plumbed status → `ProcessStatus` → Prometheus; descriptor registered in the #1726 coverage canary; wire fixture regenerated (drift = the one new always-serialized key at 0).

Closes #1789.

## Validation
- `cargo build --release` clean; `cargo test` 1752 passed (only the two known pre-existing `session::tests::inplace_*` failures; one load-induced timing-test flake passed 5/5 isolated + clean full re-run).
- `go build ./...` + `go test ./pkg/api/ ./pkg/dataplane/...` green; descriptor-coverage canary passes with the new family.
- Pending (gate): loss-cluster smoke, perf-neutral check (counters on error branches only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)