### PR TITLE
#1800 U10: monotonic HA peer-liveness — clock steps can no longer fence a healthy peer (#1792)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4641,3 +4641,6 @@ top.
   DemoteOwnerRGS + VacateAllSharedExactSlots, shared-session demotion runs,
   rg_epochs bumped, Ok returned. Extracted test_worker_handle() helper.
   **File(s)**: userspace-dp/src/afxdp/ha.rs, userspace-dp/src/afxdp/ha_tests.rs
+- **Timestamp**: 2026-06-09
+  **Action**: U10 (#1792) monotonic HA liveness — 4 commits on engineer/1800-u10-liveness
+  **File(s)**: pkg/cluster/{heartbeat,heartbeat_manager,hooks,manager,sync,sync_conn,sync_protocol,sync_test,heartbeat_liveness_test}.go, pkg/daemon/{daemon,daemon_ha_sync,daemon_ha_sync_test}.go, pkg/vrrp/{instance,instance_garp_test}.go, docs/bug-heartbeat-vrf-rebind-split-brain.md

--- a/docs/bug-heartbeat-vrf-rebind-split-brain.md
+++ b/docs/bug-heartbeat-vrf-rebind-split-brain.md
@@ -61,6 +61,44 @@ VRFs.
 Power cycle test: node0 crashed, node1 took primary. node0 recovered as
 secondary. No split-brain. Heartbeat survived two consecutive VRF rebinds.
 
+### Addendum (#1792, 2026-06): restart-window liveness hardening
+
+`RestartHeartbeat()` itself opened two liveness gaps that were closed as
+part of the #1800 §5.6 monotonic-liveness unit:
+
+1. **Peer side — no grace during our restart.** The bind-retry loop can
+   keep our UDP heartbeats silent for up to ~5 s, but the peer's
+   detection window is 5 × 100 ms. `RestartHeartbeat` now invokes a
+   notify hook (wired by the daemon to
+   `SessionSync.SendLivenessKeepalive`) before teardown and after each
+   failed bind retry. The keepalive refreshes the peer's
+   `LastPeerReceiveAge`, which its heartbeat-timeout suppression guard
+   (`shouldSuppressPeerHeartbeatTimeout`, 2 s recency window, 5 s
+   continuous-suppression cap) consults before electing/fencing. The
+   suppression is bounded and self-clearing, so a node that truly dies
+   mid-restart still fails over. **Residual gap:** if the sync TCP
+   connection is also down or silent for >2 s during a >500 ms restart,
+   the peer still declares peer-lost — indistinguishable from real node
+   death without a heartbeat wire-protocol change (out of scope). The
+   default 5 × 100 ms window is intentionally unchanged: with
+   `private-rg-election` compiled on by default, heartbeat detection
+   owns promotion latency.
+
+2. **Local side — peer death during restart was never detected.** The
+   replacement receiver started with `lastSeen=0`, whose timeout path
+   only invokes `handlePeerNeverSeen` (a no-op once `peerEverSeen` is
+   set). `RestartHeartbeat` now seeds the new receiver's `lastSeen`
+   from the old receiver (CLOCK_MONOTONIC nanos — comparable across an
+   in-process restart), so a peer that dies while our sockets are down
+   is detected once the post-restart 30 s startup grace expires. The
+   grace itself re-arms automatically: `StartHeartbeat` constructs a
+   fresh receiver and `start()` resets `startedAt`.
+
+All heartbeat/sync liveness timestamps were also moved off wall-clock
+`UnixNano` round-trips to `CLOCK_MONOTONIC` (`cluster.MonotonicNanos`)
+so NTP steps / VM pause-resume can no longer fire false peer-loss
+(#1792).
+
 ---
 
 ## Bug 2: XSK Rebind EBUSY After RETH MAC Programming — FIXED

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -306,7 +306,7 @@ type heartbeatReceiver struct {
 	interval   time.Duration
 	stopCh     chan struct{}
 	wg         sync.WaitGroup
-	lastSeen   atomic.Int64 // unix nano of last heartbeat
+	lastSeen   atomic.Int64 // CLOCK_MONOTONIC nanos of last heartbeat (MonotonicNanos)
 	received   atomic.Uint64
 	recvErrors atomic.Uint64
 	startedAt  time.Time // when receiver started (for initial peer-lost detection)
@@ -423,7 +423,9 @@ func (r *heartbeatReceiver) readLoop() {
 		}
 
 		r.received.Add(1)
-		r.lastSeen.Store(time.Now().UnixNano())
+		// Store CLOCK_MONOTONIC, not wall clock: the timeout comparison
+		// must be immune to wall-clock steps (#1792).
+		r.lastSeen.Store(MonotonicNanos())
 		r.mgr.handlePeerHeartbeat(pkt)
 	}
 }
@@ -450,21 +452,36 @@ func (r *heartbeatReceiver) timeoutLoop() {
 				}
 				continue
 			}
-			last := time.Unix(0, lastNano)
 			// During the first 30 seconds after startup, suppress
 			// peer-lost entirely. The config apply phase (VRF binding,
 			// FRR reload, fabric creation, RETH MAC) can disrupt the
 			// UDP receive path on the control link for 10-15+ seconds.
 			// Without this grace, the recovering node sees one peer
 			// heartbeat then declares peer lost — creating split-brain.
+			// (r.startedAt is a direct time.Time, so time.Since uses
+			// its embedded monotonic reading — already step-safe.)
 			if time.Since(r.startedAt) < 30*time.Second {
 				continue
 			}
-			if time.Since(last) > timeout {
+			// Compare in the CLOCK_MONOTONIC domain. The previous
+			// time.Unix(0, lastNano) round-trip produced a Time with
+			// no monotonic reading, making time.Since pure wall-clock
+			// — a forward step > timeout fired a false peer-lost on
+			// a healthy cluster (#1792).
+			if heartbeatStale(lastNano, MonotonicNanos(), timeout) {
 				r.mgr.handlePeerTimeout()
 			}
 		}
 	}
+}
+
+// heartbeatStale reports whether the last peer heartbeat is older than
+// timeout. Both timestamps are CLOCK_MONOTONIC nanoseconds (MonotonicNanos),
+// so the decision is immune to wall-clock steps. A nowMono earlier than
+// lastSeenMono (cannot happen on a correct monotonic clock, but cheap to
+// tolerate) yields a negative age and reports not-stale.
+func heartbeatStale(lastSeenMono, nowMono int64, timeout time.Duration) bool {
+	return time.Duration(nowMono-lastSeenMono) > timeout
 }
 
 func (r *heartbeatReceiver) stop() {

--- a/pkg/cluster/heartbeat_liveness_test.go
+++ b/pkg/cluster/heartbeat_liveness_test.go
@@ -1,0 +1,155 @@
+package cluster
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #1792: peer-liveness decisions must be made in the CLOCK_MONOTONIC
+// domain. These tests inject timestamps directly into the decision
+// helpers, simulating forward/backward wall-clock steps: because the
+// helpers take explicit monotonic readings, a wall-clock step cannot
+// influence the outcome by construction — the tests pin the arithmetic
+// so a regression back to wall-clock round-trips (which would need
+// time.Now().UnixNano() inputs) is caught at review and the boundary
+// semantics stay fixed.
+
+func TestMonotonicNanos(t *testing.T) {
+	a := MonotonicNanos()
+	if a <= 0 {
+		t.Fatalf("MonotonicNanos() = %d, want > 0", a)
+	}
+	b := MonotonicNanos()
+	if b < a {
+		t.Fatalf("MonotonicNanos went backwards: %d then %d", a, b)
+	}
+	// Same clock as monotonicSeconds (CLOCK_MONOTONIC), nanos vs seconds.
+	secs := int64(monotonicSeconds())
+	if diff := a/int64(time.Second) - secs; diff < -1 || diff > 1 {
+		t.Fatalf("MonotonicNanos (%d s) and monotonicSeconds (%d s) disagree", a/int64(time.Second), secs)
+	}
+}
+
+func TestHeartbeatStale(t *testing.T) {
+	const timeout = 500 * time.Millisecond
+	base := int64(1_000_000_000_000) // arbitrary monotonic reading
+
+	cases := []struct {
+		name string
+		last int64
+		now  int64
+		want bool
+	}{
+		{"fresh", base, base + (100 * time.Millisecond).Nanoseconds(), false},
+		{"exactly timeout", base, base + timeout.Nanoseconds(), false},
+		{"just past timeout", base, base + timeout.Nanoseconds() + 1, true},
+		{"long silent", base, base + (10 * time.Second).Nanoseconds(), true},
+		// A wall-clock forward step does not move CLOCK_MONOTONIC, so a
+		// heartbeat received 100ms ago stays fresh regardless of any
+		// wall-clock jump between store and check.
+		{"forward wall step is invisible", base, base + (100 * time.Millisecond).Nanoseconds(), false},
+		// now < last cannot happen on a correct monotonic clock; the
+		// helper tolerates it as not-stale rather than firing a timeout.
+		{"negative age tolerated", base, base - time.Second.Nanoseconds(), false},
+	}
+	for _, tc := range cases {
+		if got := heartbeatStale(tc.last, tc.now, timeout); got != tc.want {
+			t.Errorf("%s: heartbeatStale(%d, %d, %v) = %v, want %v",
+				tc.name, tc.last, tc.now, timeout, got, tc.want)
+		}
+	}
+}
+
+func TestLastPeerReceiveAgeMonotonic(t *testing.T) {
+	s := &SessionSync{}
+
+	if _, ok := s.LastPeerReceiveAge(); ok {
+		t.Fatal("expected no age before any peer traffic")
+	}
+
+	// 500ms-old monotonic timestamp reports an age near 500ms.
+	s.lastPeerRxMono.Store(MonotonicNanos() - (500 * time.Millisecond).Nanoseconds())
+	age, ok := s.LastPeerReceiveAge()
+	if !ok {
+		t.Fatal("expected age to be reported")
+	}
+	if age < 500*time.Millisecond || age > 2*time.Second {
+		t.Fatalf("age = %v, want ~500ms", age)
+	}
+
+	// A stored reading ahead of now (impossible on a correct monotonic
+	// clock, but the documented contract) clamps to 0 instead of going
+	// negative — a negative age would defeat recency guards.
+	s.lastPeerRxMono.Store(MonotonicNanos() + time.Minute.Nanoseconds())
+	age, ok = s.LastPeerReceiveAge()
+	if !ok {
+		t.Fatal("expected age to be reported")
+	}
+	if age != 0 {
+		t.Fatalf("age = %v, want clamp to 0", age)
+	}
+}
+
+// TestRestartHeartbeatSeedsLastSeenAndRearmsGrace exercises the #1792
+// restart protections: the notify hook fires before teardown, the
+// replacement receiver inherits the pre-restart lastSeen (so a peer that
+// dies during the restart window is still detected), and the receiver
+// startup grace (startedAt) re-arms.
+func TestRestartHeartbeatSeedsLastSeenAndRearmsGrace(t *testing.T) {
+	m := NewManager(0, 1)
+	if err := m.StartHeartbeat("127.0.0.1", "127.0.0.1", ""); err != nil {
+		t.Fatalf("StartHeartbeat: %v", err)
+	}
+	defer m.StopHeartbeat()
+
+	m.mu.RLock()
+	oldRecv := m.hbReceiver
+	m.mu.RUnlock()
+	if oldRecv == nil {
+		t.Fatal("no receiver after StartHeartbeat")
+	}
+
+	// Simulate a previously seen peer heartbeat.
+	seed := MonotonicNanos() - (250 * time.Millisecond).Nanoseconds()
+	oldRecv.lastSeen.Store(seed)
+
+	var notifyCalls atomic.Int64
+	m.SetHeartbeatRestartNotifyFunc(func() { notifyCalls.Add(1) })
+
+	beforeRestart := time.Now()
+	if !m.RestartHeartbeat() {
+		t.Fatal("RestartHeartbeat returned false while running")
+	}
+
+	m.mu.RLock()
+	newRecv := m.hbReceiver
+	m.mu.RUnlock()
+	if newRecv == nil {
+		t.Fatal("no receiver after RestartHeartbeat")
+	}
+	if newRecv == oldRecv {
+		t.Fatal("receiver was not replaced by RestartHeartbeat")
+	}
+	if got := newRecv.lastSeen.Load(); got != seed {
+		t.Errorf("lastSeen seed = %d, want %d (pre-restart timestamp must carry over)", got, seed)
+	}
+	if n := notifyCalls.Load(); n < 1 {
+		t.Errorf("restart notify hook called %d times, want >= 1", n)
+	}
+	if newRecv.startedAt.Before(beforeRestart) {
+		t.Errorf("startedAt = %v not re-armed (before restart at %v)", newRecv.startedAt, beforeRestart)
+	}
+}
+
+func TestRestartHeartbeatNotRunning(t *testing.T) {
+	m := NewManager(0, 1)
+	var notifyCalls atomic.Int64
+	m.SetHeartbeatRestartNotifyFunc(func() { notifyCalls.Add(1) })
+	if m.RestartHeartbeat() {
+		t.Fatal("RestartHeartbeat returned true with no heartbeat running")
+	}
+	if notifyCalls.Load() != 0 {
+		t.Fatal("notify hook fired for a no-op restart")
+	}
+}

--- a/pkg/cluster/heartbeat_manager.go
+++ b/pkg/cluster/heartbeat_manager.go
@@ -114,20 +114,56 @@ func (m *Manager) StopHeartbeat() {
 // DHCP-triggered recompile) which invalidates the existing UDP sockets.
 // Retries up to 5 times with 1s delay if the bind fails (address may briefly
 // disappear during VRF rebind). Returns false if heartbeat was not running.
+//
+// The restart window (worst case ~5s of bind retries) is longer than the
+// peer's default timeout (5 x 100ms), so two protections wrap it (#1792):
+//
+//   - Peer side: hbRestartNotifyFn fires before teardown and after each
+//     failed bind retry. The daemon wires it to
+//     SessionSync.SendLivenessKeepalive, which refreshes the peer's
+//     LastPeerReceiveAge — the signal its heartbeat-timeout suppression
+//     guard (shouldSuppressPeerHeartbeatTimeout, 2s recency window) checks
+//     before fencing/electing. Suppression on the peer is bounded by its
+//     existing 5s continuous-suppression cap and self-clearing (it derives
+//     purely from message recency — no sticky state), so a node that dies
+//     mid-restart still fails over.
+//
+//   - Local side: lastSeen carries over to the replacement receiver (same
+//     CLOCK_MONOTONIC domain, same process) so a peer that dies while our
+//     sockets are down is still detected once the post-restart 30s startup
+//     grace expires. Without the seed the new receiver starts at
+//     lastSeen=0, whose timeout path only invokes handlePeerNeverSeen — a
+//     no-op once peerEverSeen is set — and a peer death during the restart
+//     window would never be detected.
 func (m *Manager) RestartHeartbeat() bool {
 	m.mu.RLock()
 	running := m.hbSender != nil || m.hbReceiver != nil
 	localAddr := m.hbLocalAddr
 	peerAddr := m.hbPeerAddr
 	vrfDevice := m.hbVRFDevice
+	notify := m.hbRestartNotifyFn
+	receiver := m.hbReceiver
 	m.mu.RUnlock()
 
 	if !running || localAddr == "" {
 		return false
 	}
 
+	// Preserve the old receiver's last-seen heartbeat timestamp
+	// (CLOCK_MONOTONIC nanos — comparable across an in-process restart).
+	var lastSeenSeed int64
+	if receiver != nil {
+		lastSeenSeed = receiver.lastSeen.Load()
+	}
+
 	slog.Info("cluster: restarting heartbeat after VRF rebind",
 		"local", localAddr, "peer", peerAddr, "vrf", vrfDevice)
+
+	// Freshen the peer's sync-recency suppression guard before our UDP
+	// heartbeats go silent.
+	if notify != nil {
+		notify()
+	}
 
 	m.StopHeartbeat()
 
@@ -135,8 +171,23 @@ func (m *Manager) RestartHeartbeat() bool {
 		if err := m.StartHeartbeat(localAddr, peerAddr, vrfDevice); err != nil {
 			slog.Warn("cluster: heartbeat restart bind failed, retrying",
 				"err", err, "attempt", i+1)
+			// Keep the peer's suppression guard fed (2s recency window)
+			// through each 1s retry interval.
+			if notify != nil {
+				notify()
+			}
 			time.Sleep(1 * time.Second)
 			continue
+		}
+		// Seed the replacement receiver with the pre-restart timestamp
+		// unless it has already seen a live heartbeat.
+		if lastSeenSeed != 0 {
+			m.mu.RLock()
+			newReceiver := m.hbReceiver
+			m.mu.RUnlock()
+			if newReceiver != nil {
+				newReceiver.lastSeen.CompareAndSwap(0, lastSeenSeed)
+			}
 		}
 		return true
 	}

--- a/pkg/cluster/hooks.go
+++ b/pkg/cluster/hooks.go
@@ -72,3 +72,14 @@ func (m *Manager) SetPeerTimeoutGuard(fn func() (bool, string)) {
 	defer m.mu.Unlock()
 	m.peerTimeoutGuardFn = fn
 }
+
+// SetHeartbeatRestartNotifyFunc sets the callback invoked around the
+// RestartHeartbeat socket teardown/rebind window. The daemon wires it to
+// SessionSync.SendLivenessKeepalive so the peer's heartbeat-timeout
+// suppression guard keeps observing fresh sync traffic while this node's
+// UDP heartbeats are silent during the restart (#1792).
+func (m *Manager) SetHeartbeatRestartNotifyFunc(fn func()) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hbRestartNotifyFn = fn
+}

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -179,6 +179,13 @@ type Manager struct {
 	// session-sync traffic on the control link).
 	peerTimeoutGuardFn func() (suppress bool, reason string)
 
+	// hbRestartNotifyFn is invoked around RestartHeartbeat's socket
+	// teardown/rebind window (once before teardown, once after each failed
+	// bind retry). The daemon wires it to SessionSync.SendLivenessKeepalive
+	// so the peer's heartbeat-timeout suppression guard keeps seeing fresh
+	// sync traffic while our UDP heartbeats are silent (#1792).
+	hbRestartNotifyFn func()
+
 	// preManualFailoverFn runs before the local node resigns an RG.
 	// The daemon uses this to pre-stage userspace continuity before
 	// weight/state changes let the peer take over.

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -216,7 +216,7 @@ type SessionSync struct {
 	deleteJournalMu            sync.Mutex
 	deleteJournal              [][]byte
 	deleteJournalCap           int
-	lastPeerRxUnix             atomic.Int64
+	lastPeerRxMono             atomic.Int64 // CLOCK_MONOTONIC nanos of last inbound sync msg (#1792)
 	peerHeartbeatAckEver       atomic.Bool
 	readDeadline               time.Duration
 	peerSilenceLimit           time.Duration
@@ -485,13 +485,22 @@ func (s *SessionSync) ActiveFabric() int {
 }
 
 // LastPeerReceiveAge reports how long it has been since the last inbound sync
-// message was received from the peer.
+// message was received from the peer. The age is computed in the
+// CLOCK_MONOTONIC domain (#1792): the previous time.Unix(0, last) round-trip
+// stripped Go's monotonic reading, so a forward wall-clock step aged the
+// peer past maxPeerSyncSilence at exactly the moment the heartbeat-timeout
+// suppression guard needed it. Negative ages (impossible on a correct
+// monotonic clock) clamp to 0.
 func (s *SessionSync) LastPeerReceiveAge() (time.Duration, bool) {
-	last := s.lastPeerRxUnix.Load()
+	last := s.lastPeerRxMono.Load()
 	if last == 0 {
 		return 0, false
 	}
-	return time.Since(time.Unix(0, last)), true
+	age := time.Duration(MonotonicNanos() - last)
+	if age < 0 {
+		age = 0
+	}
+	return age, true
 }
 func (s *SessionSync) readDeadlineDuration() time.Duration {
 	if s.readDeadline > 0 {

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -184,7 +184,7 @@ func (s *SessionSync) handleNewConnection(ctx context.Context, fabricIdx int, co
 		activeAfter = 1
 	}
 	s.stats.Connected.Store(true)
-	s.lastPeerRxUnix.Store(time.Now().UnixNano())
+	s.lastPeerRxMono.Store(MonotonicNanos())
 	s.mu.Unlock()
 	becameActive := activeAfter == fabricIdx
 	slog.Info("cluster sync: handling new connection", "fabric", fabricIdx, "remote", connRemoteAddrString(conn), "was_disconnected", wasDisconnected, "active_before", activeBefore, "active_after", activeAfter, "became_active", becameActive, "had_conn0", hadConn0, "had_conn1", hadConn1)
@@ -745,7 +745,7 @@ func (s *SessionSync) receiveLoop(ctx context.Context, conn net.Conn) {
 			}
 		}
 		missedHeartbeats = 0
-		s.lastPeerRxUnix.Store(time.Now().UnixNano())
+		s.lastPeerRxMono.Store(MonotonicNanos())
 		s.handleMessage(conn, hdr.Type, payload)
 	}
 }

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -583,6 +583,32 @@ func (s *SessionSync) QueueConfig(configText string) {
 	slog.Info("cluster sync: config sent to peer", "size", len(payload))
 }
 
+// SendLivenessKeepalive writes a sync-level heartbeat to the active peer
+// connection so the peer's last-receive timestamp (lastPeerRxMono, read by
+// LastPeerReceiveAge) is refreshed immediately. Used around the local
+// heartbeat-socket restart window (Manager.RestartHeartbeat): while our UDP
+// heartbeat sockets are torn down and rebound, the peer's only evidence that
+// this node is still alive is sync traffic — and the sync-level heartbeat is
+// normally emitted only on the 10s read-timeout cadence, far coarser than
+// the 2s recency window of the peer's heartbeat-timeout suppression guard
+// (shouldSuppressPeerHeartbeatTimeout). Best-effort: a no-op when no peer
+// connection exists; a write error follows the standard sender pattern and
+// triggers reconnect via handleDisconnect.
+func (s *SessionSync) SendLivenessKeepalive() {
+	conn := s.getActiveConn()
+	if conn == nil {
+		return
+	}
+	s.writeMu.Lock()
+	err := writeMsg(conn, syncMsgHeartbeat, nil)
+	s.writeMu.Unlock()
+	if err != nil {
+		slog.Debug("cluster sync: liveness keepalive send error", "err", err)
+		s.stats.Errors.Add(1)
+		s.handleDisconnect(conn)
+	}
+}
+
 // sendClockSync exchanges the local monotonic clock over the sync channel.
 func (s *SessionSync) sendClockSync(conn net.Conn) {
 	var buf [8]byte

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -17,6 +17,21 @@ func monotonicSeconds() uint64 {
 	return uint64(ts.Sec)
 }
 
+// MonotonicNanos returns the monotonic clock (CLOCK_MONOTONIC) in
+// nanoseconds. Liveness timestamps must be stored and compared in this
+// domain instead of time.Now().UnixNano(): round-tripping wall-clock
+// nanos through time.Unix(0, n) strips Go's monotonic reading, so every
+// age computed from the stored value moves with wall-clock steps (NTP
+// makestep, manual date -s, VM pause/resume) — a forward step larger
+// than the heartbeat timeout falsely declares the peer lost (#1792).
+// Exported because pkg/daemon's heartbeat suppression guard lives in
+// the same liveness domain.
+func MonotonicNanos() int64 {
+	var ts unix.Timespec
+	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
+	return ts.Nano()
+}
+
 // rebaseTimestamp adjusts a peer timestamp to the local monotonic clock domain.
 func rebaseTimestamp(peerTS uint64, offset int64) uint64 {
 	v := int64(peerTS) + offset

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -174,7 +174,7 @@ func TestPeerRecentlyActive(t *testing.T) {
 		t.Fatal("expected false without peer activity")
 	}
 
-	s.lastPeerRxUnix.Store(time.Now().Add(-500 * time.Millisecond).UnixNano())
+	s.lastPeerRxMono.Store(MonotonicNanos() - (500 * time.Millisecond).Nanoseconds())
 	if !s.PeerRecentlyActive(time.Second) {
 		t.Fatal("expected recent peer activity to be reported")
 	}
@@ -195,12 +195,12 @@ func TestPeerHealthyRequiresRecentInboundAfterHeartbeatAckCapability(t *testing.
 	}
 
 	s.peerHeartbeatAckEver.Store(true)
-	s.lastPeerRxUnix.Store(time.Now().UnixNano())
+	s.lastPeerRxMono.Store(MonotonicNanos())
 	if !s.PeerHealthy() {
 		t.Fatal("expected recent peer activity to be healthy")
 	}
 
-	s.lastPeerRxUnix.Store(time.Now().Add(-2 * syncPeerSilenceTimeout).UnixNano())
+	s.lastPeerRxMono.Store(MonotonicNanos() - (2 * syncPeerSilenceTimeout).Nanoseconds())
 	if s.PeerHealthy() {
 		t.Fatal("expected stale peer activity to be unhealthy")
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -129,7 +129,7 @@ type Daemon struct {
 	// a daemon that never starts the loop would report every phase as a
 	// forever-climbing "wedged" age — a false positive (Codex #1781 r1).
 	neighborPeriodicLoopStarted atomic.Bool
-	hbSuppressStart             atomic.Int64 // UnixNano of first heartbeat suppression; 0 = inactive
+	hbSuppressStart             atomic.Int64 // CLOCK_MONOTONIC nanos of first heartbeat suppression; 0 = inactive (#1792)
 	syncPrimeRetryGen           atomic.Uint64
 	syncReadyTimerGen           atomic.Uint64
 	syncReadyTimerMu            sync.Mutex

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -145,18 +145,32 @@ func (d *Daemon) shouldSuppressPeerHeartbeatTimeout() (bool, string) {
 	// of seconds while heartbeats have already stopped. After 5s of
 	// continuous suppression, stop suppressing so the heartbeat timeout
 	// can fire and trigger failover.
+	//
+	// The window is measured in CLOCK_MONOTONIC nanos (#1792): with
+	// wall-clock UnixNano a backward step left suppression stuck on
+	// (blocking failover for the step duration) and a forward step cut
+	// it short.
 	const maxSuppressDuration = 5 * time.Second
-	now := time.Now().UnixNano()
+	now := cluster.MonotonicNanos()
 	start := d.hbSuppressStart.Load()
 	if start == 0 {
 		d.hbSuppressStart.Store(now)
 		start = now
 	}
-	if time.Duration(now-start) > maxSuppressDuration {
+	if hbSuppressCapExceeded(start, now, maxSuppressDuration) {
 		return false, ""
 	}
 
 	return true, fmt.Sprintf("session sync connected with recent peer traffic age=%s", age.Truncate(10*time.Millisecond))
+}
+
+// hbSuppressCapExceeded reports whether continuous heartbeat-timeout
+// suppression that began at startMono has lasted longer than cap by nowMono.
+// Both timestamps are CLOCK_MONOTONIC nanos (cluster.MonotonicNanos), so the
+// cap is immune to wall-clock steps (#1792). Split out so tests can inject
+// timestamps and exercise step scenarios directly.
+func hbSuppressCapExceeded(startMono, nowMono int64, capDur time.Duration) bool {
+	return time.Duration(nowMono-startMono) > capDur
 }
 
 func syncPrimeProgressObserved(current, baseline cluster.SyncStatsSnapshot) bool {

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -680,6 +680,12 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.cluster.SetLocalTransferCommitReadyHook(d.waitLocalFailoverCommitReady)
 			d.cluster.SetTransferReadinessFunc(d.userspaceTransferReadiness)
 			d.cluster.SetPeerTimeoutGuard(d.shouldSuppressPeerHeartbeatTimeout)
+			// #1792: while our heartbeat sockets restart (VRF rebind),
+			// keep the peer's suppression guard fed with fresh sync
+			// traffic so a >500ms restart does not fire a false
+			// peer-timeout/fence on the peer. Bounded by the peer's
+			// 5s continuous-suppression cap.
+			d.cluster.SetHeartbeatRestartNotifyFunc(d.sessionSync.SendLivenessKeepalive)
 
 			// Wire peer fencing: on heartbeat timeout, cluster sends
 			// fence via sync; on receive, disable all local RGs.

--- a/pkg/daemon/daemon_ha_sync_test.go
+++ b/pkg/daemon/daemon_ha_sync_test.go
@@ -1,0 +1,56 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+// #1792: the heartbeat-timeout suppression cap must be measured in the
+// CLOCK_MONOTONIC domain. The helper takes injected timestamps, so these
+// tests pin the boundary semantics that wall-clock steps used to break
+// (backward step → suppression stuck on, blocking failover; forward step
+// → suppression cut short).
+func TestHBSuppressCapExceeded(t *testing.T) {
+	const capDur = 5 * time.Second
+	base := int64(2_000_000_000_000) // arbitrary monotonic reading
+
+	cases := []struct {
+		name  string
+		start int64
+		now   int64
+		want  bool
+	}{
+		{"just started", base, base, false},
+		{"within cap", base, base + (4 * time.Second).Nanoseconds(), false},
+		{"exactly cap", base, base + capDur.Nanoseconds(), false},
+		{"just past cap", base, base + capDur.Nanoseconds() + 1, true},
+		// now < start cannot happen on a correct monotonic clock; the
+		// equivalent wall-clock state (backward step after suppression
+		// began) used to keep suppression alive for the step duration.
+		// In the monotonic domain the helper simply reports not-exceeded
+		// and the suppression window proceeds normally.
+		{"negative elapsed tolerated", base, base - time.Second.Nanoseconds(), false},
+	}
+	for _, tc := range cases {
+		if got := hbSuppressCapExceeded(tc.start, tc.now, capDur); got != tc.want {
+			t.Errorf("%s: hbSuppressCapExceeded(%d, %d, %v) = %v, want %v",
+				tc.name, tc.start, tc.now, capDur, got, tc.want)
+		}
+	}
+}
+
+// shouldSuppressPeerHeartbeatTimeout must reset its suppression-start
+// state when session sync is unavailable, so a later suppression window
+// re-arms from scratch instead of inheriting a stale cap start.
+func TestShouldSuppressPeerHeartbeatTimeoutResetsWhenSyncUnavailable(t *testing.T) {
+	d := &Daemon{}
+	d.hbSuppressStart.Store(123)
+
+	suppress, reason := d.shouldSuppressPeerHeartbeatTimeout()
+	if suppress {
+		t.Fatalf("suppress = true with nil session sync (reason %q)", reason)
+	}
+	if got := d.hbSuppressStart.Load(); got != 0 {
+		t.Fatalf("hbSuppressStart = %d after sync-unavailable check, want reset to 0", got)
+	}
+}

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -92,7 +92,7 @@ type vrrpInstance struct {
 	suppressGARP  atomic.Bool   // when true, becomeMaster() skips GARP/NA
 	garpEpoch     atomic.Uint64 // incremented on each becomeMaster() transition
 	lastGARPEpoch atomic.Uint64 // epoch of last completed sendGARP()
-	lastGARPTime  atomic.Int64  // Unix nanos of last GARP send (dampening)
+	lastGARPTime  atomic.Int64  // Unix nanos of last GARP send (dampening; see garpDampened)
 
 	// onEventDrop is called when an event is dropped due to a full eventCh.
 	// Set by the manager to trigger immediate reconciliation.
@@ -1059,6 +1059,24 @@ func (vi *vrrpInstance) removeVIPs() {
 	}
 }
 
+// minGARPInterval is the minimum spacing between GARP bursts (dampening).
+const minGARPInterval = 500 * time.Millisecond
+
+// garpDampened reports whether a GARP burst should be suppressed given the
+// wall-clock UnixNano of the previous burst and of now. A negative elapsed
+// (backward wall-clock step — time.Unix(0, last) carries no monotonic
+// reading) is treated as send-allowed: dampening for the step duration would
+// suppress failover GARP bursts and blackhole traffic right after becoming
+// MASTER (#1792). The storage stays wall-clock; the clamp alone closes the
+// hazard, and an extra GARP burst after a forward step is harmless.
+func garpDampened(lastNanos, nowNanos int64) bool {
+	if lastNanos <= 0 {
+		return false
+	}
+	elapsed := time.Duration(nowNanos - lastNanos)
+	return elapsed >= 0 && elapsed < minGARPInterval
+}
+
 // sendGARP sends gratuitous ARP (IPv4) and unsolicited NA (IPv6) for all VIPs.
 // Uses burst mode: one immediate pair then background follow-ups at 50ms intervals.
 // After each IPv4 GARP burst, also sends a standard ARP probe to the subnet's
@@ -1076,13 +1094,11 @@ func (vi *vrrpInstance) sendGARP() {
 	}
 	// Dampening: minimum 500ms between GARP bursts to avoid storms
 	// during rapid VRRP flaps.
-	const minGARPInterval = 500 * time.Millisecond
-	if last := vi.lastGARPTime.Load(); last > 0 {
-		if time.Since(time.Unix(0, last)) < minGARPInterval {
-			slog.Debug("vrrp: GARP dampened (too soon)",
-				"key", vi.key(), "elapsed", time.Since(time.Unix(0, last)))
-			return
-		}
+	now := time.Now().UnixNano()
+	if last := vi.lastGARPTime.Load(); garpDampened(last, now) {
+		slog.Debug("vrrp: GARP dampened (too soon)",
+			"key", vi.key(), "elapsed", time.Duration(now-last))
+		return
 	}
 	count := vi.cfg.GARPCount
 	if count <= 0 {

--- a/pkg/vrrp/instance_garp_test.go
+++ b/pkg/vrrp/instance_garp_test.go
@@ -1,0 +1,39 @@
+package vrrp
+
+import (
+	"testing"
+	"time"
+)
+
+// #1792: GARP dampening stores wall-clock UnixNano (time.Unix(0, last)
+// carries no monotonic reading), so a backward wall-clock step used to
+// make the elapsed time negative and suppress failover GARP bursts for
+// the step duration — a traffic blackhole right after becoming MASTER.
+// garpDampened clamps: negative elapsed is send-allowed.
+func TestGARPDampened(t *testing.T) {
+	now := time.Now().UnixNano()
+
+	cases := []struct {
+		name string
+		last int64
+		now  int64
+		want bool
+	}{
+		{"never sent", 0, now, false},
+		{"negative sentinel", -1, now, false},
+		{"recent burst dampened", now - (100 * time.Millisecond).Nanoseconds(), now, true},
+		{"just inside interval", now - minGARPInterval.Nanoseconds() + 1, now, true},
+		{"exactly interval", now - minGARPInterval.Nanoseconds(), now, false},
+		{"old burst allowed", now - time.Second.Nanoseconds(), now, false},
+		// Backward wall-clock step: last is "in the future" relative to
+		// now. Must be send-allowed — dampening here would suppress
+		// failover GARPs for the duration of the step.
+		{"backward step send-allowed", now + (3 * time.Second).Nanoseconds(), now, false},
+	}
+	for _, tc := range cases {
+		if got := garpDampened(tc.last, tc.now); got != tc.want {
+			t.Errorf("%s: garpDampened(%d, %d) = %v, want %v",
+				tc.name, tc.last, tc.now, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Unit **U10** of the [#1800 plan](https://github.com/psaab/xpf/issues/1800) (§5.6) — the liveness-critical unit. HA peer-loss detection, the sync suppress guard, and GARP dampening did wall-clock arithmetic via `UnixNano`→`time.Unix` round-trips (which strip Go's monotonic reading): a forward NTP step/VM resume >500ms falsely fired `handlePeerTimeout` on **both** nodes (split-brain + disable-rg fencing of a healthy peer); backward steps masked real loss and suppressed failover GARPs.

1. **Core:** `r.lastSeen` now stores `MonotonicNanos()` (CLOCK_MONOTONIC, new sibling of `monotonicSeconds` — seconds granularity unusable against a 500ms window); staleness via the injectable `heartbeatStale()`. All consumers audited (one store, one load). `startedAt` + the failover.go manual-transfer windows are direct `time.Time` (monotonic-retaining) — audited safe and untouched.
2. **Companions:** `lastPeerRxUnix`→`lastPeerRxMono` (rename makes stale wall-clock stores a compile error) feeding `LastPeerReceiveAge`/`PeerHealthy` with negative-age clamp; `hbSuppressStart` monotonic; VRRP GARP dampening clamps negative elapsed → send-allowed (backward step can no longer blackhole failover GARPs).
3. **RestartHeartbeat protection** (plan-decided: suppression required, window unchanged): the peer's existing `shouldSuppressPeerHeartbeatTimeout` guard is now actively fed during restarts via `SendLivenessKeepalive()` (existing `syncMsgHeartbeat` wire message — no protocol change) fired before teardown and on each bind retry. **Bonus real fix:** the replacement receiver started with `lastSeen=0`, whose timeout path only calls `handlePeerNeverSeen` (a no-op once the peer was ever seen) — a peer dying during our restart was never detected; the seed now carries over via CAS (valid since the domain is monotonic). **Documented residual:** if sync TCP is also silent >2s during a >500ms restart, the peer still fires — indistinguishable from real death without a wire-protocol change (out of scope per plan).
4. **Default window unchanged** (5×100ms): `PrivateRGElection` is compiled on by default and suppresses RETH VRRP, so heartbeat detection owns promotion — widening would silently slow failover.

Closes #1792.

## Validation
- `go build ./...` + `go test ./pkg/cluster/ ./pkg/vrrp/ ./pkg/daemon/` green; 9 new tests (staleness boundaries, step semantics, clamps, restart seed/notify/grace, GARP table) stable at `-count=5` + independently re-run.
- Pending (gates): live clock-step repro (`date -s ±5sec` under heartbeat monitoring), heartbeat-restart repro, **`make test-failover`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)