### PR TITLE
#1800 U5b: fix the five dual-AST gaps the differential harness pinned

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4641,3 +4641,22 @@ top.
   DemoteOwnerRGS + VacateAllSharedExactSlots, shared-session demotion runs,
   rg_epochs bumped, Ok returned. Extracted test_worker_handle() helper.
   **File(s)**: userspace-dp/src/afxdp/ha.rs, userspace-dp/src/afxdp/ha_tests.rs
+
+- **Timestamp**: 2026-06-09
+  **Action**: #1800 U5b — fixed the 5 dual-AST expectedFail harness cases,
+  one logical commit each, flipping each marker to expectedFail:false.
+  #1796 vrrp-group: setSchema subtree under interfaces unit family inet
+  address + compileVRRPGroup block reads Keys[2:]-packed properties and
+  merges repeated instances. #1797 dhcp-relay: setSchema subtree under
+  forwarding-options (server-group named container, group with
+  active-server-group + multi interface) + compileDHCPRelay inline-keys
+  dual-shape and instance merge. #1808 SNAT pool address block: inline
+  branch reads prop.Keys[1] directly instead of nodeVal's Children[0]
+  fallback (no more double-append; nodeVal contract untouched).
+  #1809 CoS classifier: collectCoSDSCPCodePoints/collectCoS8021CodePoints
+  also scan the loss-priority node's own Keys for the inline
+  "code-points" leaf spelling. #1810: system name-server marked
+  multi:true so SetPath appends instead of replacing.
+  **File(s)**: pkg/config/{schema.go, compiler_interfaces.go,
+  compiler_services.go, compiler_nat.go, compiler_class_of_service.go,
+  dual_ast_differential_test.go}, _Log.md

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -513,15 +513,29 @@ func parseCoSTransmitRate(node *Node) (uint64, bool) {
 func collectCoSDSCPCodePoints(node *Node) []uint8 {
 	var values []uint8
 	seen := make(map[uint8]struct{})
+	add := func(raw string) {
+		for _, value := range expandCoSCodePointToken(raw) {
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			values = append(values, value)
+		}
+	}
 	for _, child := range node.FindChildren("code-points") {
 		for _, raw := range child.Keys[1:] {
-			for _, value := range expandCoSCodePointToken(raw) {
-				if _, ok := seen[value]; ok {
-					continue
-				}
-				seen[value] = struct{}{}
-				values = append(values, value)
+			add(raw)
+		}
+	}
+	// Inline leaf spelling (#1809): "loss-priority low code-points ef;"
+	// packs the code points into the loss-priority node's own Keys after
+	// the "code-points" token (bracketed lists arrive bracket-stripped).
+	for i := 2; i < len(node.Keys); i++ {
+		if node.Keys[i] == "code-points" {
+			for _, raw := range node.Keys[i+1:] {
+				add(raw)
 			}
+			break
 		}
 	}
 	return values
@@ -530,22 +544,36 @@ func collectCoSDSCPCodePoints(node *Node) []uint8 {
 func collectCoS8021CodePoints(node *Node) []uint8 {
 	var values []uint8
 	seen := make(map[uint8]struct{})
+	add := func(raw string) {
+		raw = strings.TrimSpace(strings.ToLower(raw))
+		if raw == "" {
+			return
+		}
+		v, err := strconv.Atoi(raw)
+		if err != nil || v < 0 || v > 7 {
+			return
+		}
+		value := uint8(v)
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
 	for _, child := range node.FindChildren("code-points") {
 		for _, raw := range child.Keys[1:] {
-			raw = strings.TrimSpace(strings.ToLower(raw))
-			if raw == "" {
-				continue
+			add(raw)
+		}
+	}
+	// Inline leaf spelling (#1809): "loss-priority low code-points 3;"
+	// packs the code points into the loss-priority node's own Keys after
+	// the "code-points" token.
+	for i := 2; i < len(node.Keys); i++ {
+		if node.Keys[i] == "code-points" {
+			for _, raw := range node.Keys[i+1:] {
+				add(raw)
 			}
-			v, err := strconv.Atoi(raw)
-			if err != nil || v < 0 || v > 7 {
-				continue
-			}
-			value := uint8(v)
-			if _, ok := seen[value]; ok {
-				continue
-			}
-			seen[value] = struct{}{}
-			values = append(values, value)
+			break
 		}
 	}
 	return values

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -317,16 +317,78 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 							if addrInst.node.FindChild("preferred") != nil {
 								unit.PreferredAddress = addrInst.name
 							}
-							// Parse VRRP groups under address
+							// Parse VRRP groups under address. Handles both AST
+							// shapes (#1796): properties as child nodes
+							// (hierarchical blocks + schema-structured flat-set)
+							// AND properties packed into the instance node's
+							// Keys[2:] (legacy flat-set leaves, one leaf per
+							// `set ... vrrp-group <id> <prop> <value>` line —
+							// merged into one group instead of last-leaf-wins).
 							for _, vrrpInst := range namedInstances(addrInst.node.FindChildren("vrrp-group")) {
 								groupID, err := strconv.Atoi(vrrpInst.name)
 								if err != nil {
 									continue
 								}
-								vg := &VRRPGroup{
-									ID:       groupID,
-									Priority: 100, // default
+								if unit.VRRPGroups == nil {
+									unit.VRRPGroups = make(map[string]*VRRPGroup)
 								}
+								key := fmt.Sprintf("%s_grp%d", addrInst.name, groupID)
+								vg := unit.VRRPGroups[key]
+								if vg == nil {
+									vg = &VRRPGroup{
+										ID:       groupID,
+										Priority: 100, // default
+									}
+									unit.VRRPGroups[key] = vg
+								}
+								// Keys-encoded properties (flat-set leaf shape):
+								// Keys = ["vrrp-group", "<id>", prop, value, ...].
+								keys := vrrpInst.node.Keys
+								for i := 2; i < len(keys); i++ {
+									switch keys[i] {
+									case "virtual-address":
+										if i+1 < len(keys) {
+											i++
+											vg.VirtualAddresses = append(vg.VirtualAddresses, keys[i])
+										}
+									case "priority":
+										if i+1 < len(keys) {
+											i++
+											vg.Priority, _ = strconv.Atoi(keys[i])
+										}
+									case "preempt":
+										vg.Preempt = true
+									case "accept-data":
+										vg.AcceptData = true
+									case "advertise-interval":
+										if i+1 < len(keys) {
+											i++
+											vg.AdvertiseInterval, _ = strconv.Atoi(keys[i])
+										}
+									case "authentication-type":
+										if i+1 < len(keys) {
+											i++
+											vg.AuthType = keys[i]
+										}
+									case "authentication-key":
+										if i+1 < len(keys) {
+											i++
+											vg.AuthKey = keys[i]
+										}
+									case "track-interface":
+										if i+1 < len(keys) {
+											i++
+											vg.TrackInterface = keys[i]
+										}
+									case "track-priority-cost":
+										if i+1 < len(keys) {
+											i++
+											vg.TrackPriorityDelta, _ = strconv.Atoi(keys[i])
+										}
+									}
+								}
+								// Child-node properties (hierarchical blocks and
+								// schema-structured flat-set containers).
 								for _, prop := range vrrpInst.node.Children {
 									switch prop.Name() {
 									case "virtual-address":
@@ -357,11 +419,6 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 										}
 									}
 								}
-								if unit.VRRPGroups == nil {
-									unit.VRRPGroups = make(map[string]*VRRPGroup)
-								}
-								key := fmt.Sprintf("%s_grp%d", addrInst.name, groupID)
-								unit.VRRPGroups[key] = vg
 							}
 						}
 						if dhcpNode := afNode.FindChild("dhcp"); dhcpNode != nil {

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -6,6 +6,21 @@ import (
 	"strings"
 )
 
+// vrrpGroupPropertyKeywords are the property keywords recognized inside
+// a vrrp-group block. Used to delimit multi-value runs (virtual-address)
+// when properties are packed into a single node's Keys (#1813).
+var vrrpGroupPropertyKeywords = map[string]bool{
+	"virtual-address":     true,
+	"priority":            true,
+	"preempt":             true,
+	"accept-data":         true,
+	"advertise-interval":  true,
+	"authentication-type": true,
+	"authentication-key":  true,
+	"track-interface":     true,
+	"track-priority-cost": true,
+}
+
 func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 	for _, child := range node.Children {
 		if child.IsLeaf {
@@ -347,7 +362,13 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 								for i := 2; i < len(keys); i++ {
 									switch keys[i] {
 									case "virtual-address":
-										if i+1 < len(keys) {
+										// Multi-value (#1813): consume every
+										// following token up to the next
+										// recognized property keyword —
+										// `vrrp-group 1 virtual-address
+										// [ a b ];` packs all addresses
+										// inline.
+										for i+1 < len(keys) && !vrrpGroupPropertyKeywords[keys[i+1]] {
 											i++
 											vg.VirtualAddresses = append(vg.VirtualAddresses, keys[i])
 										}
@@ -392,8 +413,21 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 								for _, prop := range vrrpInst.node.Children {
 									switch prop.Name() {
 									case "virtual-address":
-										if v := nodeVal(prop); v != "" {
-											vg.VirtualAddresses = append(vg.VirtualAddresses, v)
+										// Multi-value spellings (#1813):
+										// bracketed `virtual-address [ a b ];`
+										// packs all addresses into Keys[1:]
+										// (flat-set replay may carry trailing
+										// values as children); braced block
+										// `virtual-address { a; b; }` holds
+										// one child per address. nodeVal kept
+										// only the first of each.
+										for _, k := range prop.Keys[1:] {
+											vg.VirtualAddresses = append(vg.VirtualAddresses, k)
+										}
+										for _, child := range prop.Children {
+											if v := child.Name(); v != "" {
+												vg.VirtualAddresses = append(vg.VirtualAddresses, v)
+											}
 										}
 									case "priority":
 										if v := nodeVal(prop); v != "" {

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -210,8 +210,12 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 						return fmt.Errorf("pool %q address range: %w", pool.Name, err)
 					}
 					pool.Addresses = append(pool.Addresses, expanded...)
-				} else if v := nodeVal(prop); v != "" {
-					pool.Addresses = append(pool.Addresses, v)
+				} else if len(prop.Keys) >= 2 && prop.Keys[1] != "" {
+					// Inline value form ("address <prefix>;" / flat set).
+					// Deliberately NOT nodeVal: its Children[0] fallback
+					// would double-append the block form, whose children
+					// are walked below (#1808).
+					pool.Addresses = append(pool.Addresses, prop.Keys[1])
 				}
 				// Also handle children for hierarchical syntax
 				for _, addrChild := range prop.Children {

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -590,17 +590,46 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 	}
 
 	for _, sgInst := range namedInstances(node.FindChildren("server-group")) {
-		sg := &DHCPRelayServerGroup{Name: sgInst.name}
+		sg := relay.ServerGroups[sgInst.name]
+		if sg == nil {
+			sg = &DHCPRelayServerGroup{Name: sgInst.name}
+			relay.ServerGroups[sg.Name] = sg
+		}
+		// Inline keys (#1797 dual-AST): "server-group sg1 10.1.1.1;" packs
+		// the server addresses into Keys[2:].
+		for i := 2; i < len(sgInst.node.Keys); i++ {
+			sg.Servers = append(sg.Servers, sgInst.node.Keys[i])
+		}
 		for _, child := range sgInst.node.Children {
 			if len(child.Keys) >= 1 {
 				sg.Servers = append(sg.Servers, child.Keys[0])
 			}
 		}
-		relay.ServerGroups[sg.Name] = sg
 	}
 
 	for _, gInst := range namedInstances(node.FindChildren("group")) {
-		g := &DHCPRelayGroup{Name: gInst.name}
+		g := relay.Groups[gInst.name]
+		if g == nil {
+			g = &DHCPRelayGroup{Name: gInst.name}
+			relay.Groups[g.Name] = g
+		}
+		// Inline keys (#1797 dual-AST): "group lan interface ge-0/0/0.0;"
+		// packs the properties into Keys[2:].
+		keys := gInst.node.Keys
+		for i := 2; i < len(keys); i++ {
+			switch keys[i] {
+			case "interface":
+				if i+1 < len(keys) {
+					i++
+					g.Interfaces = append(g.Interfaces, keys[i])
+				}
+			case "active-server-group":
+				if i+1 < len(keys) {
+					i++
+					g.ActiveServerGroup = keys[i]
+				}
+			}
+		}
 		for _, prop := range gInst.node.Children {
 			switch prop.Name() {
 			case "interface":
@@ -611,7 +640,6 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 				g.ActiveServerGroup = nodeVal(prop)
 			}
 		}
-		relay.Groups[g.Name] = g
 	}
 
 	fo.DHCPRelay = relay

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -600,10 +600,10 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 		for i := 2; i < len(sgInst.node.Keys); i++ {
 			sg.Servers = append(sg.Servers, sgInst.node.Keys[i])
 		}
+		// Block form: every child is a server address; a child line may
+		// itself carry several addresses in its Keys (#1813).
 		for _, child := range sgInst.node.Children {
-			if len(child.Keys) >= 1 {
-				sg.Servers = append(sg.Servers, child.Keys[0])
-			}
+			sg.Servers = append(sg.Servers, child.Keys...)
 		}
 	}
 
@@ -619,7 +619,12 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 		for i := 2; i < len(keys); i++ {
 			switch keys[i] {
 			case "interface":
-				if i+1 < len(keys) {
+				// Multi-value (#1813): consume every following token up
+				// to the next recognized property keyword —
+				// `group lan interface [ a b ];` packs all interfaces
+				// inline.
+				for i+1 < len(keys) && keys[i+1] != "interface" &&
+					keys[i+1] != "active-server-group" {
 					i++
 					g.Interfaces = append(g.Interfaces, keys[i])
 				}
@@ -633,8 +638,19 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 		for _, prop := range gInst.node.Children {
 			switch prop.Name() {
 			case "interface":
-				if v := nodeVal(prop); v != "" {
-					g.Interfaces = append(g.Interfaces, v)
+				// Multi-value spellings (#1813): bracketed
+				// `interface [ a b ];` packs all interfaces into
+				// Keys[1:] (flat-set replay may carry trailing values
+				// as children); braced block `interface { a; b; }`
+				// holds one child per interface. nodeVal kept only the
+				// first of each.
+				for _, k := range prop.Keys[1:] {
+					g.Interfaces = append(g.Interfaces, k)
+				}
+				for _, child := range prop.Children {
+					if v := child.Name(); v != "" {
+						g.Interfaces = append(g.Interfaces, v)
+					}
 				}
 			case "active-server-group":
 				g.ActiveServerGroup = nodeVal(prop)

--- a/pkg/config/dual_ast_differential_test.go
+++ b/pkg/config/dual_ast_differential_test.go
@@ -110,10 +110,9 @@ var dualASTCases = []dualASTCase{
         }
     }
 }`,
-		expectedFail: true,
-		failureClass: "compiler dual-AST",
-		reason: "#1796: compileVRRPGroup reads only node.Children; flat-set " +
-			"encodes each property in Keys, so virtual-address/priority/... are dropped",
+		// Fixed in U5b (#1796): vrrp-group subtree added to setSchema and
+		// the compiler now reads properties from both Children and Keys[2:].
+		expectedFail: false,
 	},
 	{
 		name: "security-zones-address-book",

--- a/pkg/config/dual_ast_differential_test.go
+++ b/pkg/config/dual_ast_differential_test.go
@@ -115,6 +115,51 @@ var dualASTCases = []dualASTCase{
 		expectedFail: false,
 	},
 	{
+		// Junos multi-value bracketed list spelling: every address in
+		// `virtual-address [ a b ];` must survive both AST shapes
+		// (AGY review on PR #1813 — nodeVal kept only the first).
+		name: "interfaces-vrrp-group-bracketed-virtual-address",
+		hier: `interfaces {
+    reth1 {
+        unit 0 {
+            family inet {
+                address 10.0.61.1/24 {
+                    vrrp-group 1 {
+                        virtual-address [ 10.0.61.3 10.0.61.4 ];
+                        priority 200;
+                    }
+                }
+            }
+        }
+    }
+}`,
+		expectedFail: false,
+	},
+	{
+		// Braced block spelling: `virtual-address { a; b; }` holds one
+		// child per address (AGY review on PR #1813 — nodeVal's
+		// Children[0] fallback dropped all but the first).
+		name: "interfaces-vrrp-group-virtual-address-block",
+		hier: `interfaces {
+    reth1 {
+        unit 0 {
+            family inet {
+                address 10.0.61.1/24 {
+                    vrrp-group 1 {
+                        virtual-address {
+                            10.0.61.3;
+                            10.0.61.4;
+                        }
+                        priority 200;
+                    }
+                }
+            }
+        }
+    }
+}`,
+		expectedFail: false,
+	},
+	{
 		name: "security-zones-address-book",
 		hier: `security {
     zones {
@@ -644,6 +689,30 @@ services {
 }`,
 		// Fixed in U5b (#1797): dhcp-relay subtree added to setSchema and
 		// compileDHCPRelay also reads inline Keys-encoded properties.
+		expectedFail: false,
+	},
+	{
+		// Braced block spelling: `interface { a; b; }` holds one child
+		// per interface (AGY review on PR #1813 — nodeVal's Children[0]
+		// fallback compiled 1 interface hierarchically vs 2 flat, a real
+		// dual-AST divergence).
+		name: "forwarding-options-dhcp-relay-interface-block",
+		hier: `forwarding-options {
+    dhcp-relay {
+        server-group {
+            sg1 {
+                10.1.1.1;
+            }
+        }
+        group lan {
+            active-server-group sg1;
+            interface {
+                ge-0/0/0.0;
+                ge-0/0/1.0;
+            }
+        }
+    }
+}`,
 		expectedFail: false,
 	},
 	{

--- a/pkg/config/dual_ast_differential_test.go
+++ b/pkg/config/dual_ast_differential_test.go
@@ -648,10 +648,9 @@ services {
         }
     }
 }`,
-		expectedFail: true,
-		failureClass: "compiler dual-AST",
-		reason: "#1797: dhcp-relay missing from setSchema (flat-set collapses to one " +
-			"leaf) and compileDHCPRelay reads only Children — relay compiles empty",
+		// Fixed in U5b (#1797): dhcp-relay subtree added to setSchema and
+		// compileDHCPRelay also reads inline Keys-encoded properties.
+		expectedFail: false,
 	},
 	{
 		name: "protocols-ospf-bgp",

--- a/pkg/config/dual_ast_differential_test.go
+++ b/pkg/config/dual_ast_differential_test.go
@@ -294,11 +294,10 @@ var dualASTCases = []dualASTCase{
         }
     }
 }`,
-		expectedFail: true,
-		failureClass: "compiler dual-AST",
-		reason: "compileNATSource pool address block form double-appends: nodeVal() " +
-			"falls back to Children[0].Name() AND the explicit Children loop appends " +
-			"again, so hierarchical compiles Addresses=[x x] vs flat-set [x]",
+		// Fixed in U5b (#1808): the inline-value path reads prop.Keys[1]
+		// directly instead of nodeVal's Children[0] fallback, so the block
+		// form is appended only by the children walk.
+		expectedFail: false,
 	},
 	{
 		name: "security-screen",

--- a/pkg/config/dual_ast_differential_test.go
+++ b/pkg/config/dual_ast_differential_test.go
@@ -569,11 +569,9 @@ system {
         2001:4860:4860::8888;
     }
 }`,
-		expectedFail: true,
-		failureClass: "round-trip infidelity (content)",
-		reason: "round-trip infidelity: setSchema models name-server as a " +
-			"single-value leaf (args:1, no multi), so SetPath REPLACES on the " +
-			"second `set system name-server <addr>` — last value wins, first lost",
+		// Fixed in U5b (#1810): name-server is multi in setSchema, so
+		// SetPath appends distinct values instead of replacing.
+		expectedFail: false,
 	},
 	{
 		name: "chassis-cluster",

--- a/pkg/config/dual_ast_differential_test.go
+++ b/pkg/config/dual_ast_differential_test.go
@@ -441,12 +441,9 @@ system {
 system {
     dataplane-type userspace;
 }`,
-		expectedFail: true,
-		failureClass: "compiler dual-AST",
-		reason: "reverse dual-AST gap: compileClassOfService reads only the braced " +
-			"loss-priority container shape; the inline hierarchical leaf " +
-			"(Keys-encoded) is silently dropped, while the flat-set replay is " +
-			"structured by setSchema and compiles — hierarchical loses the classifier",
+		// Fixed in U5b (#1809): the classifier code-point collectors also
+		// scan the loss-priority node's own Keys for the inline leaf form.
+		expectedFail: false,
 	},
 	{
 		name: "firewall-filters",

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -1043,7 +1043,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 		"domain-search": {desc: "Domain search list", args: 1, multi: true, placeholder: "<domain>", children: nil},
 		"time-zone":     {desc: "System time zone", args: 1, placeholder: "<timezone>", children: nil},
 		"no-redirects":  {desc: "Disable ICMP redirects", children: nil},
-		"name-server":   {desc: "DNS name server", args: 1, placeholder: "<address>", children: nil},
+		"name-server":   {desc: "DNS name server", args: 1, multi: true, placeholder: "<address>", children: nil},
 		"backup-router": {desc: "Backup router", args: 1, placeholder: "<address>", children: map[string]*schemaNode{
 			"destination": {desc: "Destination network", args: 1, placeholder: "<network>", children: nil},
 		}},

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -1242,6 +1242,16 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 				"output": {children: nil},
 			}},
 		}},
+		"dhcp-relay": {desc: "DHCP relay", children: map[string]*schemaNode{
+			// server-group is a named container whose children are the
+			// free-form server address leaves (same modeling as the
+			// sampling flow-server node above).
+			"server-group": {desc: "DHCP server group", args: 1, placeholder: "<name>", children: nil},
+			"group": {desc: "DHCP relay group", args: 1, placeholder: "<name>", children: map[string]*schemaNode{
+				"active-server-group": {desc: "Active server group", args: 1, placeholder: "<server-group>", children: nil},
+				"interface":           {desc: "Interface to relay on", args: 1, multi: true, placeholder: "<interface>", children: nil},
+			}},
+		}},
 	}},
 	"bridge-domains": {wildcard: &schemaNode{desc: "Bridge domain name", children: map[string]*schemaNode{
 		"vlan-id-list":      {args: 1, multi: true, desc: "VLAN IDs in this bridge domain", children: nil},

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -422,6 +422,17 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 					"address": {desc: "IPv4 address", args: 1, placeholder: "<address>", children: map[string]*schemaNode{
 						"primary":   {desc: "Primary address", children: nil},
 						"preferred": {desc: "Preferred address", children: nil},
+						"vrrp-group": {desc: "VRRP group", args: 1, placeholder: "<group-id>", children: map[string]*schemaNode{
+							"virtual-address":     {desc: "Virtual IP address", args: 1, multi: true, placeholder: "<address>", children: nil},
+							"priority":            {desc: "VRRP priority", args: 1, placeholder: "<1..255>", children: nil},
+							"preempt":             {desc: "Allow preemption", children: nil},
+							"accept-data":         {desc: "Accept packets sent to the virtual address", children: nil},
+							"advertise-interval":  {desc: "Advertisement interval", args: 1, placeholder: "<seconds>", children: nil},
+							"authentication-type": {desc: "Authentication type", args: 1, placeholder: "<type>", children: nil},
+							"authentication-key":  {desc: "Authentication key", args: 1, placeholder: "<key>", children: nil},
+							"track-interface":     {desc: "Interface to track", args: 1, placeholder: "<interface>", children: nil},
+							"track-priority-cost": {desc: "Priority cost when tracked interface fails", args: 1, placeholder: "<cost>", children: nil},
+						}},
 					}},
 					"dhcp": {desc: "DHCP client", children: map[string]*schemaNode{
 						"lease-time":              {desc: "Lease time", args: 1, placeholder: "<seconds>", children: nil},


### PR DESCRIPTION
## Summary

Unit **U5b** of the [#1800 plan](https://github.com/psaab/xpf/issues/1800) (§5.1) — one logical commit per harness-pinned gap, each flipping its `expectedFail` marker (the U5a harness fails on an unflipped marker, so the suite enforces the contract):

1. **vrrp-group flat-set silently dropped** — setSchema subtree added (9 property leaves, `virtual-address` multi) + `compileVRRPGroup` reads Keys-packed properties and merges repeated group instances.
2. **dhcp-relay flat-set non-functional** — setSchema `forwarding-options dhcp-relay` subtree + `compileDHCPRelay` dual-shape with named-instance merging.
3. **SNAT pool address-block double-append** — the inline branch now reads `prop.Keys[1]` directly instead of `nodeVal` (whose `Children[0]` fallback fired for the block form that the children walk also appends). `nodeVal` itself untouched — its contract for all other callers verified and preserved.
4. **CoS classifier inline loss-priority leaf dropped** — both code-points collectors also accept the Keys-packed inline spelling through the shared dedup/expand path.
5. **system name-server second-set replace** — `multi: true` (same modeling as other repeatable leaves); SetPath now appends.

Closes #1796. Closes #1797. Closes #1808. Closes #1809. Closes #1810.

## Validation
- DualAST harness: all 20 cases PASS, zero `expectedFail` markers remain.
- Full `go test ./pkg/config/ ./pkg/grpcapi/ ./pkg/cli/` ok (independently re-run); vet/gofmt clean on touched files (the `pkg/cli` vet nit + 2 gofmt files are pre-existing on master with zero diff here).
- Pending (gates): **`make test-failover`** (vrrp-group is HA-adjacent) + cluster smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)