### PR TITLE
#1800 U8: DHCP client lifecycle reconcile-on-apply (#1793)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4644,3 +4644,18 @@ top.
 - **Timestamp**: 2026-06-09
   **Action**: U10 (#1792) monotonic HA liveness — 4 commits on engineer/1800-u10-liveness
   **File(s)**: pkg/cluster/{heartbeat,heartbeat_manager,hooks,manager,sync,sync_conn,sync_protocol,sync_test,heartbeat_liveness_test}.go, pkg/daemon/{daemon,daemon_ha_sync,daemon_ha_sync_test}.go, pkg/vrrp/{instance,instance_garp_test}.go, docs/bug-heartbeat-vrf-rebind-split-brain.md
+
+- **Timestamp**: 2026-06-09
+  **Action**: U8 (#1793 of #1800 plan) — DHCP client lifecycle reconcile-on-apply.
+  pkg/dhcp: per-client config-identity fingerprint + Manager.Reconcile
+  (start new / stop removed / restart option-changed; diff keys NEVER on
+  lease state), finishClient defer deregisters on ALL terminal run-goroutine
+  exits and removes residual lease+address; StopAll registry now self-clears.
+  pkg/daemon: buildDHCPClientSpecs + reconcileDHCPClients (lazy manager,
+  needsDHCP startup-only gate dropped) wired into applyConfigLocked step 7b
+  next to the Kea block; startup call is now a redundant safety net.
+  Tests: reconcile add/remove/option-change-restart/DUID-change-restart/
+  lease-change-no-restart, terminal-exit deregister + restartable, StopAll
+  clear; daemon-level spec building + commit enable/disable lifecycle +
+  lease-change-no-restart. README reconcile-lifecycle section added.
+  **File(s)**: pkg/dhcp/{dhcp,reconcile,test_seams,reconcile_test}.go, pkg/dhcp/README.md, pkg/daemon/{daemon_dhcp,daemon_apply,daemon_run,dhcp_reconcile_test}.go

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -880,6 +880,16 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		}
 	}
 
+	// 7b. Reconcile DHCP clients (#1793): start clients for units that
+	// gained dhcp/dhcpv6 in this commit, stop clients for units that
+	// lost it, restart clients whose options changed. The diff keys on
+	// config identity only (interface, family, options) — never lease
+	// state — so the DHCP lease-change callback re-entering applyConfig
+	// (onDHCPAddressChange) cannot restart clients in a loop. Runs after
+	// the dataplane compile (step 2) so HOST_INBOUND_DHCP flags are
+	// active before a newly started client puts DHCP packets on the wire.
+	d.reconcileDHCPClients(cfg)
+
 	// 8. Apply VRRP config — merge user VRRP + RETH VRRP instances
 	vrrpInstances := vrrp.CollectInstances(cfg)
 	if d.cluster != nil {

--- a/pkg/daemon/daemon_dhcp.go
+++ b/pkg/daemon/daemon_dhcp.go
@@ -2,7 +2,6 @@
 package daemon
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"net"
@@ -12,97 +11,119 @@ import (
 	"github.com/psaab/xpf/pkg/dhcp"
 )
 
-// startDHCPClients iterates the config and starts DHCP/DHCPv6 clients
-// for interfaces that have family inet { dhcp; } or family inet6 { dhcpv6; }.
-func (d *Daemon) startDHCPClients(ctx context.Context, cfg *config.Config) {
-	// Check if any interface needs DHCP
-	needsDHCP := false
-	for _, ifc := range cfg.Interfaces.Interfaces {
-		for _, unit := range ifc.Units {
-			if unit.DHCP || unit.DHCPv6 {
-				needsDHCP = true
-				break
-			}
-		}
-	}
-	if !needsDHCP {
-		return
-	}
-
-	// State dir for DUID persistence — same directory as config file
-	stateDir := filepath.Dir(d.opts.ConfigFile)
-
-	dm, err := dhcp.New(stateDir, func() {
-		// Full recompile is safe: heartbeat sockets survive VRF rebind
-		// (RestartHeartbeat), RETH MAC is set live (no XSK rebind), and
-		// BPF compile skips reconcile when the binding plan is unchanged.
-		if activeCfg := d.store.ActiveConfig(); activeCfg != nil {
-			if d.dhcpLeaseChangeRequiresRecompile(activeCfg) {
-				slog.Info("DHCP address changed, recompiling dataplane")
-				// applyConfig runs reconcileDNSLocked, so DNS is
-				// reconciled with the new lease set on this path.
-				d.applyConfig(activeCfg)
-			} else {
-				slog.Info("DHCP address changed on management-only interface, refreshing management routes")
-				d.applyMgmtVRFRoutes()
-				// #1715 (fw0 class): a management-only interface (e.g.
-				// fxp0 DHCPv4) takes this branch and does NOT recompile,
-				// so DNS would never reconcile without this call. Route
-				// the DHCP-learned DNS through the locked reconciler so
-				// the box always picks up DHCP nameservers, not just on
-				// dataplane-relevant interfaces.
-				d.reconcileDNSFromDHCP()
-			}
-		}
-	})
-	if err != nil {
-		slog.Warn("failed to create DHCP manager", "err", err)
-		return
-	}
-	d.dhcp = dm
-
+// buildDHCPClientSpecs computes the desired DHCP client set from the
+// config: one spec per unit with family inet { dhcp; } or family inet6
+// { dhcpv6; }. Specs carry config identity only (interface, family,
+// client options) — never lease or address state — so the reconcile
+// diff is stable across lease changes (#1793, plan §5.4).
+func buildDHCPClientSpecs(cfg *config.Config) []dhcp.ClientSpec {
+	var specs []dhcp.ClientSpec
 	for ifName, ifc := range cfg.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
 		for _, unit := range ifc.Units {
+			if unit == nil || (!unit.DHCP && !unit.DHCPv6) {
+				continue
+			}
 			// Use VLAN sub-interface name when unit has a VLAN ID
 			dhcpIface := config.LinuxIfName(ifName)
 			if unit.VlanID > 0 {
 				dhcpIface = fmt.Sprintf("%s.%d", dhcpIface, unit.VlanID)
 			}
 			if unit.DHCP {
+				spec := dhcp.ClientSpec{Iface: dhcpIface, Family: dhcp.AFInet}
 				if unit.DHCPOptions != nil {
-					dm.SetDHCPv4Options(dhcpIface, &dhcp.DHCPv4Options{
+					spec.V4 = &dhcp.DHCPv4Options{
 						LeaseTime:              unit.DHCPOptions.LeaseTime,
 						RetransmissionAttempt:  unit.DHCPOptions.RetransmissionAttempt,
 						RetransmissionInterval: unit.DHCPOptions.RetransmissionInterval,
 						ForceDiscover:          unit.DHCPOptions.ForceDiscover,
-					})
+					}
 				}
-				slog.Info("starting DHCPv4 client", "interface", dhcpIface)
-				dm.Start(ctx, dhcpIface, dhcp.AFInet)
+				specs = append(specs, spec)
 			}
 			if unit.DHCPv6 {
-				// Configure DUID type from dhcpv6-client stanza
-				if unit.DHCPv6Client != nil && unit.DHCPv6Client.DUIDType != "" {
-					dm.SetDUIDType(dhcpIface, unit.DHCPv6Client.DUIDType)
-				} else {
-					dm.SetDUIDType(dhcpIface, "duid-ll") // default
+				spec := dhcp.ClientSpec{
+					Iface:    dhcpIface,
+					Family:   dhcp.AFInet6,
+					DUIDType: "duid-ll", // default
 				}
-				// Configure DHCPv6 PD and other options
 				if unit.DHCPv6Client != nil {
-					dm.SetDHCPv6Options(dhcpIface, &dhcp.DHCPv6Options{
+					if unit.DHCPv6Client.DUIDType != "" {
+						spec.DUIDType = unit.DHCPv6Client.DUIDType
+					}
+					spec.V6 = &dhcp.DHCPv6Options{
 						Stateless:  unit.DHCPv6Client.ClientType == "stateless",
 						IATypes:    unit.DHCPv6Client.ClientIATypes,
 						PDPrefLen:  unit.DHCPv6Client.PrefixDelegatingPrefixLen,
 						PDSubLen:   unit.DHCPv6Client.PrefixDelegatingSubPrefLen,
 						ReqOptions: unit.DHCPv6Client.ReqOptions,
 						RAIface:    unit.DHCPv6Client.UpdateRAInterface,
-					})
+					}
 				}
-				slog.Info("starting DHCPv6 client", "interface", dhcpIface)
-				dm.Start(ctx, dhcpIface, dhcp.AFInet6)
+				specs = append(specs, spec)
 			}
 		}
 	}
+	return specs
+}
+
+// onDHCPAddressChange is the (debounced) lease-change callback for the
+// DHCP manager. It re-enters applyConfig, which is why the client
+// reconcile must key on config identity only — see reconcileDHCPClients.
+func (d *Daemon) onDHCPAddressChange() {
+	// Full recompile is safe: heartbeat sockets survive VRF rebind
+	// (RestartHeartbeat), RETH MAC is set live (no XSK rebind), and
+	// BPF compile skips reconcile when the binding plan is unchanged.
+	if activeCfg := d.store.ActiveConfig(); activeCfg != nil {
+		if d.dhcpLeaseChangeRequiresRecompile(activeCfg) {
+			slog.Info("DHCP address changed, recompiling dataplane")
+			// applyConfig runs reconcileDNSLocked, so DNS is
+			// reconciled with the new lease set on this path.
+			d.applyConfig(activeCfg)
+		} else {
+			slog.Info("DHCP address changed on management-only interface, refreshing management routes")
+			d.applyMgmtVRFRoutes()
+			// #1715 (fw0 class): a management-only interface (e.g.
+			// fxp0 DHCPv4) takes this branch and does NOT recompile,
+			// so DNS would never reconcile without this call. Route
+			// the DHCP-learned DNS through the locked reconciler so
+			// the box always picks up DHCP nameservers, not just on
+			// dataplane-relevant interfaces.
+			d.reconcileDNSFromDHCP()
+		}
+	}
+}
+
+// reconcileDHCPClients converges running DHCP/DHCPv6 clients with the
+// given config (#1793): newly enabled units get a client, units whose
+// dhcp/dhcpv6 stanza was deleted get their client stopped (stop renewing
+// + remove the leased address; no protocol RELEASE), and option changes
+// restart the affected client. Called from applyConfigLocked on every
+// apply, so commit-time enable/disable behaves like Junos instead of
+// boot-time-only. The DHCP manager is created lazily on first need —
+// a startup config without DHCP no longer disables DHCP for the life
+// of the process.
+func (d *Daemon) reconcileDHCPClients(cfg *config.Config) {
+	if d.opts.NoDataplane {
+		return
+	}
+	specs := buildDHCPClientSpecs(cfg)
+	if len(specs) == 0 && d.dhcp == nil {
+		return // nothing desired, nothing running
+	}
+	if d.dhcp == nil {
+		// State dir for DUID persistence — same directory as config file
+		stateDir := filepath.Dir(d.opts.ConfigFile)
+		dm, err := dhcp.New(stateDir, d.onDHCPAddressChange)
+		if err != nil {
+			slog.Warn("failed to create DHCP manager", "err", err)
+			return
+		}
+		d.dhcp = dm
+	}
+	d.dhcp.Reconcile(specs)
 }
 
 func (d *Daemon) dhcpLeaseChangeRequiresRecompile(cfg *config.Config) bool {

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -575,12 +575,15 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.startClusterComms(ctx)
 	}
 
-	// Start DHCP clients for interfaces configured with dhcp/dhcpv6.
-	// This must happen after BPF load + config compile so HOST_INBOUND_DHCP
-	// flags are active before DHCP packets start flowing.
+	// Reconcile DHCP clients for interfaces configured with dhcp/dhcpv6.
+	// The startup applyConfig above already reconciled them (#1793), so
+	// this is normally a no-op; it is kept as a safety net to preserve
+	// the documented ordering guarantee: clients run only after BPF load
+	// + config compile, so HOST_INBOUND_DHCP flags are active before
+	// DHCP packets start flowing.
 	if !d.opts.NoDataplane {
 		if cfg := d.store.ActiveConfig(); cfg != nil {
-			d.startDHCPClients(ctx, cfg)
+			d.reconcileDHCPClients(cfg)
 		}
 	}
 

--- a/pkg/daemon/dhcp_reconcile_test.go
+++ b/pkg/daemon/dhcp_reconcile_test.go
@@ -1,0 +1,190 @@
+package daemon
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dhcp"
+)
+
+func dhcpTestConfig() *config.Config {
+	return &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/3": {
+					Name: "ge-0/0/3",
+					Units: map[int]*config.InterfaceUnit{
+						0: {
+							DHCP:        true,
+							DHCPOptions: &config.DHCPInetOptions{LeaseTime: 300},
+						},
+						50: {
+							VlanID: 50,
+							DHCPv6: true,
+							DHCPv6Client: &config.DHCPv6ClientConfig{
+								ClientType: "stateless",
+								DUIDType:   "duid-llt",
+								ReqOptions: []string{"dns-server"},
+							},
+						},
+					},
+				},
+				"ge-0/0/1": {
+					Name: "ge-0/0/1",
+					Units: map[int]*config.InterfaceUnit{
+						0: {Addresses: []string{"10.0.61.1/24"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestBuildDHCPClientSpecs(t *testing.T) {
+	specs := buildDHCPClientSpecs(dhcpTestConfig())
+	if len(specs) != 2 {
+		t.Fatalf("got %d specs, want 2: %+v", len(specs), specs)
+	}
+	byKey := make(map[string]dhcp.ClientSpec)
+	for _, s := range specs {
+		byKey[s.Iface] = s
+	}
+
+	v4, ok := byKey["ge-0-0-3"]
+	if !ok {
+		t.Fatalf("no spec for ge-0-0-3: %+v", specs)
+	}
+	if v4.Family != dhcp.AFInet || v4.V4 == nil || v4.V4.LeaseTime != 300 {
+		t.Errorf("v4 spec wrong: %+v", v4)
+	}
+
+	v6, ok := byKey["ge-0-0-3.50"]
+	if !ok {
+		t.Fatalf("no spec for VLAN sub-interface ge-0-0-3.50: %+v", specs)
+	}
+	if v6.Family != dhcp.AFInet6 || v6.DUIDType != "duid-llt" ||
+		v6.V6 == nil || !v6.V6.Stateless {
+		t.Errorf("v6 spec wrong: %+v", v6)
+	}
+}
+
+func TestBuildDHCPClientSpecsDefaults(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"fxp0": {
+					Name: "fxp0",
+					Units: map[int]*config.InterfaceUnit{
+						0: {DHCPv6: true},
+					},
+				},
+			},
+		},
+	}
+	specs := buildDHCPClientSpecs(cfg)
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+	if specs[0].DUIDType != "duid-ll" {
+		t.Errorf("DUIDType = %q, want default duid-ll", specs[0].DUIDType)
+	}
+	if specs[0].V6 != nil {
+		t.Errorf("V6 opts = %+v, want nil for bare dhcpv6", specs[0].V6)
+	}
+}
+
+// TestReconcileDHCPClientsNoDHCPNoManager: a config without DHCP units
+// must not lazily create the manager (nothing desired, nothing running).
+func TestReconcileDHCPClientsNoDHCPNoManager(t *testing.T) {
+	d := &Daemon{}
+	cfg := &config.Config{}
+	d.reconcileDHCPClients(cfg)
+	if d.dhcp != nil {
+		t.Fatal("DHCP manager created for a config without DHCP units")
+	}
+}
+
+func TestReconcileDHCPClientsNoDataplaneGate(t *testing.T) {
+	d := &Daemon{opts: Options{NoDataplane: true}}
+	d.reconcileDHCPClients(dhcpTestConfig())
+	if d.dhcp != nil {
+		t.Fatal("DHCP manager created in NoDataplane mode")
+	}
+}
+
+// TestReconcileDHCPClientsCommitLifecycle covers #1793 defects 1 and 2
+// at the daemon level: a commit that enables dhcp/dhcpv6 starts clients
+// on a running daemon, and a commit that deletes them stops the clients.
+func TestReconcileDHCPClientsCommitLifecycle(t *testing.T) {
+	mgr := dhcp.NewManagerForTesting(
+		func(ctx context.Context, iface string, af dhcp.AddressFamily) {
+			<-ctx.Done()
+		})
+	defer mgr.StopAll()
+	d := &Daemon{dhcp: mgr}
+
+	// Commit 1: no DHCP anywhere — nothing starts.
+	d.reconcileDHCPClients(&config.Config{})
+	if h := mgr.RunningClientHandlesForTesting(); len(h) != 0 {
+		t.Fatalf("clients running before DHCP enabled: %v", h)
+	}
+
+	// Commit 2: enable dhcp + dhcpv6 — clients must start (previously a
+	// silent no-op until daemon restart).
+	d.reconcileDHCPClients(dhcpTestConfig())
+	handles := mgr.RunningClientHandlesForTesting()
+	if len(handles) != 2 {
+		t.Fatalf("got %d running clients after enable commit, want 2: %v",
+			len(handles), handles)
+	}
+
+	// Commit 3: delete DHCP from the config — clients must stop
+	// (previously kept renewing forever).
+	d.reconcileDHCPClients(&config.Config{})
+	if h := mgr.RunningClientHandlesForTesting(); len(h) != 0 {
+		t.Fatalf("clients still running after DHCP deleted: %v", h)
+	}
+}
+
+// TestReconcileDHCPClientsLeaseChangeNoRestart models the lease-change
+// callback path: onDHCPAddressChange re-enters applyConfig with the SAME
+// active config but NEW lease state. The reconcile must not restart any
+// client (config identity unchanged) or the daemon would loop:
+// lease change -> callback -> applyConfig -> restart -> lease change.
+func TestReconcileDHCPClientsLeaseChangeNoRestart(t *testing.T) {
+	mgr := dhcp.NewManagerForTesting(
+		func(ctx context.Context, iface string, af dhcp.AddressFamily) {
+			<-ctx.Done()
+		})
+	defer mgr.StopAll()
+	d := &Daemon{dhcp: mgr}
+	cfg := dhcpTestConfig()
+
+	d.reconcileDHCPClients(cfg)
+	before := mgr.RunningClientHandlesForTesting()
+	if len(before) != 2 {
+		t.Fatalf("got %d running clients, want 2", len(before))
+	}
+
+	// New lease lands (this is what fires the callback).
+	mgr.SeedLeaseForTesting("ge-0-0-3", dhcp.AFInet, &dhcp.Lease{
+		Interface: "ge-0-0-3",
+		Family:    dhcp.AFInet,
+		Address:   netip.MustParsePrefix("172.16.50.5/24"),
+		Obtained:  time.Now(),
+	})
+	d.reconcileDHCPClients(cfg)
+
+	after := mgr.RunningClientHandlesForTesting()
+	if len(after) != 2 {
+		t.Fatalf("got %d running clients after lease change, want 2", len(after))
+	}
+	for k := range before {
+		if before[k] != after[k] {
+			t.Errorf("client %s restarted by lease-change reconcile", k)
+		}
+	}
+}

--- a/pkg/dhcp/README.md
+++ b/pkg/dhcp/README.md
@@ -12,15 +12,54 @@ restarts so the same client identifier returns to the same lease.
   when any client's lease changes.
 - `Lease` — `dhcp.go`. Result of one DHCP negotiation.
 - `DelegatedPrefix` — `dhcp.go`. From DHCPv6 PD.
+- `ClientSpec` — `reconcile.go`. One desired client derived from
+  config (interface, family, options). Config identity only — never
+  lease/address state.
+- `Reconcile(specs []ClientSpec)` — `reconcile.go`. Converge running
+  clients with the desired set (#1793): start missing clients, stop
+  removed ones, restart clients whose option identity changed. Called
+  by the daemon on every config apply.
 - `Start(ctx context.Context, ifaceName string, af AddressFamily)` —
   `dhcp.go`. Spawn a per-interface client goroutine.
 - `Renew(ifaceName string) error` — `dhcp.go`.
 - `StopAll()` — `dhcp.go`.
 - `DelegatedPrefixes() []DelegatedPrefix` — `dhcp.go`.
 
+## Reconcile lifecycle (#1793)
+
+The daemon calls `reconcileDHCPClients` from `applyConfigLocked` on
+every commit/apply, so enabling `family inet { dhcp; }` / `family inet6
+{ dhcpv6; }` on a running daemon starts a client, and deleting the
+stanza stops it — Junos apply-on-commit semantics, not boot-time-only.
+The DHCP `Manager` is created lazily on first need; a startup config
+without DHCP no longer disables DHCP for the daemon's lifetime.
+
+- **Diff key is config identity**: (interface, family, client options
+  including DHCPv6 `stateless` and DUID type), captured as a
+  fingerprint when the client starts. An option change on the same
+  (interface, family) stops the old client and starts a new one
+  (options are read at goroutine start, so a restart is required).
+- **Never keyed on lease state**: lease changes fire `onAddressChange`,
+  which re-enters the daemon's `applyConfig` and thus `Reconcile`. If
+  the diff observed lease/address state, every lease event would
+  restart its client and loop forever. There is a regression test
+  proving a lease change does not restart clients
+  (`TestReconcileLeaseChangeDoesNotRestart`).
+- **Stop semantics**: an explicit stop cancels the client's context,
+  stops renewals, and removes the leased address from the interface.
+  No protocol RELEASE is sent — matching interface-deconfiguration
+  behavior elsewhere in the daemon.
+- **Registry hygiene**: the run goroutine deregisters itself (and
+  cleans residual lease/address state) in a defer on every exit path —
+  cancellation, DHCPv4 max-retransmissions, DHCPv6 link-local abort —
+  so a dead client can never permanently block a future `Start` for
+  the same key.
+
 ## Callers
 
-`pkg/daemon` (lifecycle).
+`pkg/daemon` (lifecycle: `reconcileDHCPClients` in
+`daemon_dhcp.go`, invoked from `applyConfigLocked` step 7b and once at
+startup after dataplane load).
 
 ## Dependencies
 
@@ -31,7 +70,9 @@ External only: `github.com/insomniacslk/dhcp`, `github.com/vishvananda/netlink`.
 - Each DHCP client uses `context.Background()`, not the daemon context.
   On graceful SIGTERM the daemon exits without calling `StopAll()`,
   intentionally leaving the lease in place so the next daemon process
-  reuses it (no DAD storm, no DHCP renew at startup).
+  reuses it (no DAD storm, no DHCP renew at startup). Only an explicit
+  stop — `Reconcile` removal/option change, `Renew`, `StopAll` —
+  cancels a client.
 - The lease-change callback is debounced 2 seconds to avoid floods during
   config apply.
 - DUID is cached per-interface in the state directory with type hints

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -50,6 +50,12 @@ type clientKey struct {
 type dhcpClient struct {
 	cancel context.CancelFunc
 	done   chan struct{}
+	// fingerprint is the client's config identity (options/DUID type)
+	// captured at Start time. Reconcile compares it against the
+	// fingerprint of the newly committed config to decide whether the
+	// client must be restarted. It NEVER includes lease or address
+	// state — see Reconcile.
+	fingerprint string
 }
 
 // DHCPv4Options holds client behavior options for DHCPv4.
@@ -97,6 +103,11 @@ type Manager struct {
 	nlHandle        *netlink.Handle
 	recompileTimer  *time.Timer
 	stateDir        string
+
+	// runClientForTest replaces the per-family run goroutine body in
+	// tests so reconcile/registry behavior can be exercised without
+	// real DHCP traffic. nil in production.
+	runClientForTest func(ctx context.Context, ifaceName string, af AddressFamily)
 }
 
 // New creates a DHCP manager. stateDir is where DUID files are persisted.
@@ -199,20 +210,35 @@ func (m *Manager) Start(ctx context.Context, ifaceName string, af AddressFamily)
 	}
 
 	// Use an independent context so DHCP clients are decoupled from the
-	// daemon lifecycle. Only explicit StopAll() triggers lease release and
-	// address removal. During graceful restart (SIGTERM), the process exits
-	// without calling StopAll(), so addresses stay on interfaces for the
-	// next daemon to reuse.
+	// daemon lifecycle. Only an explicit stop (Reconcile removal, Renew,
+	// StopAll) cancels a client. During graceful restart (SIGTERM), the
+	// process exits without calling StopAll(), so addresses stay on
+	// interfaces for the next daemon to reuse.
 	cctx, cancel := context.WithCancel(context.Background())
 	dc := &dhcpClient{
-		cancel: cancel,
-		done:   make(chan struct{}),
+		cancel:      cancel,
+		done:        make(chan struct{}),
+		fingerprint: m.configFingerprintLocked(key),
 	}
 	m.clients[key] = dc
+	runFn := m.runClientForTest
 	m.mu.Unlock()
 
+	slog.Info("DHCP: starting client", "interface", ifaceName, "family", af)
+
 	go func() {
+		// Defer order matters: finishClient (deregister + lease/address
+		// cleanup) runs BEFORE close(done), so anyone waiting on done
+		// observes a clean registry. The deregistration covers ALL
+		// terminal exits (#1793) — cancellation, DHCPv4 max
+		// retransmissions, DHCPv6 link-local abort — not just Renew,
+		// so a future Start for this key is never a permanent no-op.
 		defer close(dc.done)
+		defer m.finishClient(key, dc)
+		if runFn != nil {
+			runFn(cctx, ifaceName, af)
+			return
+		}
 		switch af {
 		case AFInet:
 			m.runDHCPv4(cctx, ifaceName)
@@ -220,6 +246,30 @@ func (m *Manager) Start(ctx context.Context, ifaceName string, af AddressFamily)
 			m.runDHCPv6(cctx, ifaceName)
 		}
 	}()
+}
+
+// finishClient runs in the client goroutine's defer on every exit path.
+// It deregisters the registry entry (only if it still maps to this exact
+// client — Renew deletes/re-adds entries, so a pointer compare guards
+// against clobbering a successor) and cleans up any lease record and
+// interface address the run loop left behind (some cancellation
+// interleavings exit the run loop without hitting its own ctx.Done
+// cleanup branches).
+func (m *Manager) finishClient(key clientKey, dc *dhcpClient) {
+	m.mu.Lock()
+	if cur, ok := m.clients[key]; ok && cur == dc {
+		delete(m.clients, key)
+	}
+	lease := m.leases[key]
+	delete(m.leases, key)
+	if key.family == AFInet6 {
+		delete(m.delegatedPDs, key.iface)
+	}
+	m.mu.Unlock()
+
+	if lease != nil && lease.Address.IsValid() {
+		m.removeAddress(key.iface, lease)
+	}
 }
 
 // Renew restarts the DHCP client for the specified interface and address
@@ -256,7 +306,10 @@ func (m *Manager) Renew(ifaceName string) error {
 	return nil
 }
 
-// StopAll stops all running DHCP clients and releases leases.
+// StopAll stops all running DHCP clients and releases leases. Registry
+// entries are cleared by each client's finishClient defer, which runs
+// before its done channel closes, so the registry is empty when StopAll
+// returns.
 func (m *Manager) StopAll() {
 	m.mu.Lock()
 	clients := make(map[clientKey]*dhcpClient, len(m.clients))
@@ -811,8 +864,8 @@ func (m *Manager) runDHCPv6(ctx context.Context, ifaceName string) {
 
 // dhcpv6Result holds results from a DHCPv6 exchange including both IA_NA and IA_PD.
 type dhcpv6Result struct {
-	lease      *Lease
-	prefixes   []DelegatedPrefix
+	lease    *Lease
+	prefixes []DelegatedPrefix
 }
 
 // doDHCPv6 performs a single DHCPv6 solicit/request exchange.
@@ -1151,6 +1204,9 @@ func (m *Manager) applyAddress(ifaceName string, lease *Lease) error {
 
 // removeAddress removes the DHCP address and default route from the interface.
 func (m *Manager) removeAddress(ifaceName string, lease *Lease) {
+	if m.nlHandle == nil {
+		return // test-constructed Manager without netlink
+	}
 	link, err := m.nlHandle.LinkByName(ifaceName)
 	if err != nil {
 		return

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -200,13 +200,35 @@ func (m *Manager) DelegatedPrefixesForRA() []PDRAMapping {
 }
 
 // Start begins a DHCP client for the given interface and address family.
-func (m *Manager) Start(ctx context.Context, ifaceName string, af AddressFamily) {
+// Start reports whether a client for the key is registered when it
+// returns: true if this call started one or one was already running,
+// false if the key has no option state (the desired-config signal —
+// SetDHCPv*Options/Reconcile install it, Reconcile prunes it for
+// removed clients). The membership check lives INSIDE the registration
+// lock so check-and-register is atomic: a Renew racing a removal
+// Reconcile cannot observe membership, lose the lock, and register a
+// client for a key the Reconcile just deconfigured (Codex review on
+// PR #1815, round 5).
+func (m *Manager) Start(ctx context.Context, ifaceName string, af AddressFamily) bool {
 	key := clientKey{iface: ifaceName, family: af}
 
 	m.mu.Lock()
 	if _, exists := m.clients[key]; exists {
 		m.mu.Unlock()
-		return
+		return true
+	}
+	desired := false
+	switch af {
+	case AFInet:
+		_, desired = m.v4opts[ifaceName]
+	case AFInet6:
+		_, desired = m.v6opts[ifaceName]
+	}
+	if !desired {
+		m.mu.Unlock()
+		slog.Info("DHCP: start refused; no option state for client",
+			"interface", ifaceName, "family", af)
+		return false
 	}
 
 	// Use an independent context so DHCP clients are decoupled from the
@@ -246,6 +268,7 @@ func (m *Manager) Start(ctx context.Context, ifaceName string, af AddressFamily)
 			m.runDHCPv6(cctx, ifaceName)
 		}
 	}()
+	return true
 }
 
 // finishClient runs in the client goroutine's defer on every exit path.
@@ -306,34 +329,19 @@ func (m *Manager) Renew(ifaceName string) error {
 		dc.cancel()
 		<-dc.done
 
-		// Re-check config membership before restarting: Renew is
-		// reachable from gRPC outside applySem, so a concurrent
-		// Reconcile may have removed this client from config after we
-		// captured dc above. Reconcile prunes the option-state map
-		// entries for ALL undesired keys under m.mu — including keys
-		// whose client already deregistered via finishClient — so
-		// membership here is exactly the desired-set signal in every
-		// interleaving. Restarting unconditionally would resurrect a
-		// client the operator just deconfigured (Codex review on PR
-		// #1815, rounds 3-4).
-		m.mu.Lock()
-		stillDesired := false
-		switch af {
-		case AFInet:
-			_, stillDesired = m.v4opts[ifaceName]
-		case AFInet6:
-			_, stillDesired = m.v6opts[ifaceName]
-		}
-		m.mu.Unlock()
-		if !stillDesired {
+		// Restart. Renew is reachable from gRPC outside applySem, so a
+		// concurrent Reconcile may have removed this client from
+		// config after we captured dc above; Start performs the
+		// desired-set membership check atomically with registration
+		// (under m.mu) and refuses to resurrect a deconfigured client
+		// — a check here would go stale before Start takes the lock
+		// (Codex review on PR #1815, rounds 3-5).
+		if !m.Start(context.Background(), ifaceName, af) {
 			slog.Info("DHCP: renew skipped restart; client removed from config",
 				"interface", ifaceName, "family", af)
 			continue
 		}
 		renewed = true
-
-		// Restart
-		m.Start(context.Background(), ifaceName, af)
 		slog.Info("DHCP client renewed", "interface", ifaceName, "family", af)
 	}
 	if !renewed {

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -309,11 +309,13 @@ func (m *Manager) Renew(ifaceName string) error {
 		// Re-check config membership before restarting: Renew is
 		// reachable from gRPC outside applySem, so a concurrent
 		// Reconcile may have removed this client from config after we
-		// captured dc above. Reconcile deletes the option-state map
-		// entry under m.mu before stopping the client, so membership
-		// here is the desired-set signal — restarting unconditionally
-		// would resurrect a client the operator just deconfigured
-		// (Codex review on PR #1815).
+		// captured dc above. Reconcile prunes the option-state map
+		// entries for ALL undesired keys under m.mu — including keys
+		// whose client already deregistered via finishClient — so
+		// membership here is exactly the desired-set signal in every
+		// interleaving. Restarting unconditionally would resurrect a
+		// client the operator just deconfigured (Codex review on PR
+		// #1815, rounds 3-4).
 		m.mu.Lock()
 		stillDesired := false
 		switch af {

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -290,16 +290,19 @@ func (m *Manager) Renew(ifaceName string) error {
 		key := clientKey{iface: ifaceName, family: af}
 		m.mu.Lock()
 		dc, exists := m.clients[key]
-		if exists {
-			delete(m.clients, key)
-		}
 		m.mu.Unlock()
 
 		if !exists {
 			continue
 		}
 
-		// Stop existing client
+		// Stop the existing client. Do NOT pre-delete the registry
+		// entry: finishClient owns deregistration and the lease /
+		// delegated-PD / address cleanup, and its pointer guard
+		// early-returns when the entry is already gone — a pre-delete
+		// here would skip that cleanup entirely when cancellation
+		// lands mid-exchange (Codex review on PR #1815). Waiting on
+		// done guarantees finishClient has completed before restart.
 		dc.cancel()
 		<-dc.done
 		renewed = true

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -257,9 +257,17 @@ func (m *Manager) Start(ctx context.Context, ifaceName string, af AddressFamily)
 // cleanup branches).
 func (m *Manager) finishClient(key clientKey, dc *dhcpClient) {
 	m.mu.Lock()
-	if cur, ok := m.clients[key]; ok && cur == dc {
-		delete(m.clients, key)
+	cur, ok := m.clients[key]
+	if !ok || cur != dc {
+		// A successor client already replaced (or removed) this key.
+		// Its lease / delegated-PD records belong to the successor —
+		// a delayed defer from the OLD client must not delete them
+		// (AGY review on PR #1815: unguarded cleanup let a slow old
+		// defer clobber the new client's lease).
+		m.mu.Unlock()
+		return
 	}
+	delete(m.clients, key)
 	lease := m.leases[key]
 	delete(m.leases, key)
 	if key.family == AFInet6 {
@@ -1024,7 +1032,7 @@ func (m *Manager) doDHCPv6(ctx context.Context, ifaceName string) (*dhcpv6Result
 
 	// DHCPv6 doesn't provide a default router — discover it from the
 	// kernel's IPv6 neighbor table (entries learned via Router Advertisements).
-	if gw := m.discoverIPv6Router(ifaceName); gw.IsValid() {
+	if gw := m.discoverIPv6Router(ctx, ifaceName); gw.IsValid() {
 		lease.Gateway = gw
 	}
 
@@ -1116,7 +1124,7 @@ func extractDelegatedPrefixes(msg *dhcpv6.Message, ifaceName string, now time.Ti
 // given interface by inspecting the kernel neighbor table for entries with
 // the NTF_ROUTER flag (learned from Router Advertisements).
 // Retries a few times since RAs may not have been processed yet.
-func (m *Manager) discoverIPv6Router(ifaceName string) netip.Addr {
+func (m *Manager) discoverIPv6Router(ctx context.Context, ifaceName string) netip.Addr {
 	link, err := m.nlHandle.LinkByName(ifaceName)
 	if err != nil {
 		return netip.Addr{}
@@ -1124,7 +1132,15 @@ func (m *Manager) discoverIPv6Router(ifaceName string) netip.Addr {
 
 	for attempt := 0; attempt < 10; attempt++ {
 		if attempt > 0 {
-			time.Sleep(time.Second)
+			// Context-aware: Reconcile cancels clients and waits on
+			// done while applyConfigLocked holds applySem — a blind
+			// 10x1s sleep here wedged every commit for up to 10s
+			// (AGY review on PR #1815).
+			select {
+			case <-ctx.Done():
+				return netip.Addr{}
+			case <-time.After(time.Second):
+			}
 		}
 
 		neighbors, err := m.nlHandle.NeighList(link.Attrs().Index, netlink.FAMILY_V6)

--- a/pkg/dhcp/dhcp.go
+++ b/pkg/dhcp/dhcp.go
@@ -305,6 +305,29 @@ func (m *Manager) Renew(ifaceName string) error {
 		// done guarantees finishClient has completed before restart.
 		dc.cancel()
 		<-dc.done
+
+		// Re-check config membership before restarting: Renew is
+		// reachable from gRPC outside applySem, so a concurrent
+		// Reconcile may have removed this client from config after we
+		// captured dc above. Reconcile deletes the option-state map
+		// entry under m.mu before stopping the client, so membership
+		// here is the desired-set signal — restarting unconditionally
+		// would resurrect a client the operator just deconfigured
+		// (Codex review on PR #1815).
+		m.mu.Lock()
+		stillDesired := false
+		switch af {
+		case AFInet:
+			_, stillDesired = m.v4opts[ifaceName]
+		case AFInet6:
+			_, stillDesired = m.v6opts[ifaceName]
+		}
+		m.mu.Unlock()
+		if !stillDesired {
+			slog.Info("DHCP: renew skipped restart; client removed from config",
+				"interface", ifaceName, "family", af)
+			continue
+		}
 		renewed = true
 
 		// Restart

--- a/pkg/dhcp/reconcile.go
+++ b/pkg/dhcp/reconcile.go
@@ -1,0 +1,134 @@
+package dhcp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// ClientSpec describes one desired DHCP client, derived purely from the
+// committed configuration. It carries config identity only — never
+// lease, address, or other runtime state.
+type ClientSpec struct {
+	Iface    string
+	Family   AddressFamily
+	DUIDType string         // DHCPv6 only; "" defaults to duid-ll
+	V4       *DHCPv4Options // DHCPv4 only; nil = defaults
+	V6       *DHCPv6Options // DHCPv6 only; nil = defaults
+}
+
+// fingerprintV4 encodes the config identity of a DHCPv4 client.
+func fingerprintV4(o *DHCPv4Options) string {
+	if o == nil {
+		return "v4"
+	}
+	return fmt.Sprintf("v4|lt=%d|ra=%d|ri=%d|fd=%t",
+		o.LeaseTime, o.RetransmissionAttempt,
+		o.RetransmissionInterval, o.ForceDiscover)
+}
+
+// fingerprintV6 encodes the config identity of a DHCPv6 client,
+// including the DUID type and the Stateless flag (both captured by the
+// run goroutine at start, so a change requires a restart).
+func fingerprintV6(duidType string, o *DHCPv6Options) string {
+	if duidType == "" {
+		duidType = "duid-ll"
+	}
+	if o == nil {
+		return "v6|duid=" + duidType
+	}
+	return fmt.Sprintf("v6|duid=%s|sl=%t|ia=%s|pl=%d|sub=%d|req=%s|ra=%s",
+		duidType, o.Stateless, strings.Join(o.IATypes, ","),
+		o.PDPrefLen, o.PDSubLen, strings.Join(o.ReqOptions, ","),
+		o.RAIface)
+}
+
+// configFingerprintLocked computes the config-identity fingerprint for
+// a client key from the manager's currently installed option state.
+// Caller must hold m.mu.
+func (m *Manager) configFingerprintLocked(key clientKey) string {
+	if key.family == AFInet {
+		return fingerprintV4(m.v4opts[key.iface])
+	}
+	return fingerprintV6(m.duidTypes[key.iface], m.v6opts[key.iface])
+}
+
+// Reconcile diffs the desired client set against running clients and
+// converges: clients removed from config are stopped (stop renewing +
+// remove the leased address; no protocol RELEASE — matching interface
+// deconfiguration semantics elsewhere), clients whose option identity
+// changed are restarted, and missing clients are started.
+//
+// The diff keys STRICTLY on config identity (interface, family,
+// options/DUID type). It must never key on lease or address state:
+// lease changes fire the onAddressChange callback, which re-enters the
+// daemon's applyConfig and thus this Reconcile — keying on lease state
+// would restart the client on every lease event and loop forever
+// (#1793, plan §5.4).
+func (m *Manager) Reconcile(specs []ClientSpec) {
+	desired := make(map[clientKey]ClientSpec, len(specs))
+	for _, s := range specs {
+		desired[clientKey{iface: s.Iface, family: s.Family}] = s
+	}
+
+	type stopEntry struct {
+		key    clientKey
+		dc     *dhcpClient
+		reason string
+	}
+	var stops []stopEntry
+
+	m.mu.Lock()
+	// Install the desired option state first so fingerprint comparison
+	// below sees the new config identity. Running clients re-read the
+	// option maps mid-cycle, but any client observing changed options
+	// is about to be restarted by the fingerprint mismatch anyway.
+	for key, s := range desired {
+		switch key.family {
+		case AFInet:
+			m.v4opts[key.iface] = s.V4
+		case AFInet6:
+			dt := s.DUIDType
+			if dt == "" {
+				dt = "duid-ll"
+			}
+			m.duidTypes[key.iface] = dt
+			m.v6opts[key.iface] = s.V6
+		}
+	}
+	for key, dc := range m.clients {
+		if _, ok := desired[key]; !ok {
+			stops = append(stops, stopEntry{key, dc, "removed from config"})
+			// Drop option state for fully removed clients.
+			switch key.family {
+			case AFInet:
+				delete(m.v4opts, key.iface)
+			case AFInet6:
+				delete(m.v6opts, key.iface)
+				delete(m.duidTypes, key.iface)
+			}
+			continue
+		}
+		if dc.fingerprint != m.configFingerprintLocked(key) {
+			stops = append(stops, stopEntry{key, dc, "client options changed"})
+		}
+	}
+	m.mu.Unlock()
+
+	for _, s := range stops {
+		slog.Info("DHCP: stopping client",
+			"interface", s.key.iface, "family", s.key.family,
+			"reason", s.reason)
+		s.dc.cancel()
+		// finishClient (the goroutine's defer) deregisters the entry and
+		// removes the leased address before done closes.
+		<-s.dc.done
+	}
+
+	for key := range desired {
+		// No-op for clients still running with an unchanged fingerprint;
+		// starts new and option-changed (just stopped) clients.
+		m.Start(context.Background(), key.iface, key.family)
+	}
+}

--- a/pkg/dhcp/reconcile.go
+++ b/pkg/dhcp/reconcile.go
@@ -100,18 +100,28 @@ func (m *Manager) Reconcile(specs []ClientSpec) {
 	for key, dc := range m.clients {
 		if _, ok := desired[key]; !ok {
 			stops = append(stops, stopEntry{key, dc, "removed from config"})
-			// Drop option state for fully removed clients.
-			switch key.family {
-			case AFInet:
-				delete(m.v4opts, key.iface)
-			case AFInet6:
-				delete(m.v6opts, key.iface)
-				delete(m.duidTypes, key.iface)
-			}
 			continue
 		}
 		if dc.fingerprint != m.configFingerprintLocked(key) {
 			stops = append(stops, stopEntry{key, dc, "client options changed"})
+		}
+	}
+	// Prune option state for every key absent from desired, regardless
+	// of whether a client is currently registered. Renew's membership
+	// guard treats these maps as the desired-config signal, and a
+	// renewing client may already be deregistered (cancel +
+	// finishClient) by the time this Reconcile runs — pruning only for
+	// registered clients would leave a stale entry that lets Renew
+	// resurrect the removed client (Codex review on PR #1815, round 4).
+	for iface := range m.v4opts {
+		if _, ok := desired[clientKey{iface: iface, family: AFInet}]; !ok {
+			delete(m.v4opts, iface)
+		}
+	}
+	for iface := range m.v6opts {
+		if _, ok := desired[clientKey{iface: iface, family: AFInet6}]; !ok {
+			delete(m.v6opts, iface)
+			delete(m.duidTypes, iface)
 		}
 	}
 	m.mu.Unlock()

--- a/pkg/dhcp/reconcile_test.go
+++ b/pkg/dhcp/reconcile_test.go
@@ -334,3 +334,50 @@ func TestRenewDoesNotResurrectRemovedClient(t *testing.T) {
 		t.Fatalf("running clients = %v, want none", h)
 	}
 }
+
+// TestReconcilePrunesOptionStateForDeregisteredClients pins the
+// round-4 interleaving from the Codex review on PR #1815: by the time
+// a removal Reconcile runs, the renewing client may already be
+// deregistered (Renew cancelled it and finishClient deleted the
+// registry entry), so the registered-clients loop never visits the
+// key. Reconcile must still prune the option-state entry — Renew's
+// membership guard reads it as the desired-config signal, and a stale
+// entry would let Renew resurrect the removed client.
+func TestReconcilePrunesOptionStateForDeregisteredClients(t *testing.T) {
+	fr := newFakeRunner(false)
+	m := NewManagerForTesting(fr.run)
+
+	m.Reconcile([]ClientSpec{
+		{Iface: "fxp0", Family: AFInet},
+		{Iface: "fxp0", Family: AFInet6, V6: &DHCPv6Options{Stateless: true}},
+	})
+	waitForRunning(t, m, 2)
+
+	// Deregister both clients without a Reconcile (models the
+	// mid-Renew window where finishClient already ran): cancel and
+	// wait for done via StopAll, which leaves option state behind.
+	m.StopAll()
+	waitForRunning(t, m, 0)
+	if !m.HasOptionStateForTesting("fxp0", AFInet) ||
+		!m.HasOptionStateForTesting("fxp0", AFInet6) {
+		t.Fatal("precondition: option state should survive StopAll")
+	}
+
+	// Removal Reconcile with no registered clients must still prune.
+	m.Reconcile(nil)
+	if m.HasOptionStateForTesting("fxp0", AFInet) {
+		t.Fatal("v4 option state not pruned for deregistered client")
+	}
+	if m.HasOptionStateForTesting("fxp0", AFInet6) {
+		t.Fatal("v6 option state not pruned for deregistered client")
+	}
+
+	// And the Renew guard therefore cannot restart: no client, no
+	// membership — Renew reports an error and starts nothing.
+	if err := m.Renew("fxp0"); err == nil {
+		t.Fatal("Renew should fail after removal")
+	}
+	if got := fr.startCount("fxp0", AFInet); got != 1 {
+		t.Fatalf("v4 starts = %d, want 1 (no resurrection)", got)
+	}
+}

--- a/pkg/dhcp/reconcile_test.go
+++ b/pkg/dhcp/reconcile_test.go
@@ -223,6 +223,7 @@ func TestReconcileLeaseChangeDoesNotRestart(t *testing.T) {
 func TestTerminalExitDeregistersAndAllowsRestart(t *testing.T) {
 	fr := newFakeRunner(true) // exits immediately = terminal failure
 	m := NewManagerForTesting(fr.run)
+	m.SetDHCPv4Options("ge-0-0-3", &DHCPv4Options{})
 
 	m.Start(context.Background(), "ge-0-0-3", AFInet)
 	waitForRunning(t, m, 0) // terminal exit must clear the registry
@@ -380,4 +381,36 @@ func TestReconcilePrunesOptionStateForDeregisteredClients(t *testing.T) {
 	if got := fr.startCount("fxp0", AFInet); got != 1 {
 		t.Fatalf("v4 starts = %d, want 1 (no resurrection)", got)
 	}
+}
+
+// TestStartRefusesUnconfiguredClient pins the invariant that closes
+// the round-5 TOCTOU from the Codex review on PR #1815: the
+// desired-set membership check is inside Start's registration lock,
+// so Start refuses to register a client for a key with no option
+// state. Renew relies on this — its own membership view can go stale
+// between the done-wait and the Start call, but Start's cannot.
+func TestStartRefusesUnconfiguredClient(t *testing.T) {
+	fr := newFakeRunner(false)
+	m := NewManagerForTesting(fr.run)
+
+	if m.Start(context.Background(), "fxp0", AFInet) {
+		t.Fatal("Start should refuse a v4 client with no option state")
+	}
+	if m.Start(context.Background(), "fxp0", AFInet6) {
+		t.Fatal("Start should refuse a v6 client with no option state")
+	}
+	if h := m.RunningClientHandlesForTesting(); len(h) != 0 {
+		t.Fatalf("registry should be empty, got %v", h)
+	}
+	if got := fr.startCount("fxp0", AFInet); got != 0 {
+		t.Fatalf("runner invoked %d times, want 0", got)
+	}
+
+	// With option state installed, the same Start succeeds.
+	m.SetDHCPv4Options("fxp0", &DHCPv4Options{})
+	if !m.Start(context.Background(), "fxp0", AFInet) {
+		t.Fatal("Start should run a configured client")
+	}
+	waitForRunning(t, m, 1)
+	m.StopAll()
 }

--- a/pkg/dhcp/reconcile_test.go
+++ b/pkg/dhcp/reconcile_test.go
@@ -273,3 +273,64 @@ func TestReconcileEmptyStopsEverything(t *testing.T) {
 		t.Fatalf("clients still running after empty reconcile: %v", h)
 	}
 }
+
+// TestRenewDoesNotResurrectRemovedClient pins the Renew-vs-Reconcile
+// removal race (Codex review on PR #1815): Renew is reachable from
+// gRPC outside applySem, so it can capture a client pointer, cancel
+// it, and block on done while a concurrent Reconcile removes the key
+// from config. Renew must then NOT restart the client — restarting
+// would resurrect a client the operator just deconfigured.
+//
+// Interleaving is made deterministic by a run func that signals when
+// cancellation reached it and then holds the client "running" (done
+// not yet closed) until released, freezing Renew inside its wait
+// window while Reconcile([]) deletes the option state.
+func TestRenewDoesNotResurrectRemovedClient(t *testing.T) {
+	fr := newFakeRunner(false)
+	cancelled := make(chan struct{})
+	release := make(chan struct{})
+	m := NewManagerForTesting(func(ctx context.Context, iface string, af AddressFamily) {
+		fr.run(ctx, iface, af) // records the start, returns on ctx.Done()
+		close(cancelled)
+		<-release // hold done open so Renew stays in its wait window
+	})
+
+	m.Reconcile([]ClientSpec{{Iface: "fxp0", Family: AFInet}})
+	waitForRunning(t, m, 1)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- m.Renew("fxp0") }()
+
+	// Renew has captured dc and cancelled it; it is now blocked on
+	// dc.done, which stays open until release closes.
+	<-cancelled
+
+	// Concurrent removal: Reconcile deletes the option state under
+	// m.mu synchronously in its first section, then blocks on the
+	// same done channel in its stop loop.
+	recDone := make(chan struct{})
+	go func() { m.Reconcile(nil); close(recDone) }()
+	deadline := time.Now().Add(5 * time.Second)
+	for m.HasOptionStateForTesting("fxp0", AFInet) {
+		if time.Now().After(deadline) {
+			t.Fatal("Reconcile(nil) never removed option state")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	close(release)
+	<-recDone
+	if err := <-errCh; err == nil {
+		t.Fatal("Renew should report failure when the client was removed from config mid-renew")
+	}
+
+	// The client must NOT have been restarted: exactly the original
+	// start, and an empty registry.
+	if got := fr.startCount("fxp0", AFInet); got != 1 {
+		t.Fatalf("starts = %d, want 1 (no resurrection)", got)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if h := m.RunningClientHandlesForTesting(); len(h) != 0 {
+		t.Fatalf("running clients = %v, want none", h)
+	}
+}

--- a/pkg/dhcp/reconcile_test.go
+++ b/pkg/dhcp/reconcile_test.go
@@ -1,0 +1,275 @@
+package dhcp
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeRunner stands in for the per-client run goroutine: it records
+// every start and blocks until cancellation (terminal=false) or exits
+// immediately (terminal=true).
+type fakeRunner struct {
+	mu       sync.Mutex
+	starts   map[string]int
+	terminal bool
+}
+
+func newFakeRunner(terminal bool) *fakeRunner {
+	return &fakeRunner{starts: make(map[string]int), terminal: terminal}
+}
+
+func runnerKey(iface string, af AddressFamily) string {
+	return fmt.Sprintf("%s/%d", iface, af)
+}
+
+func (f *fakeRunner) run(ctx context.Context, iface string, af AddressFamily) {
+	f.mu.Lock()
+	f.starts[runnerKey(iface, af)]++
+	f.mu.Unlock()
+	if f.terminal {
+		return
+	}
+	<-ctx.Done()
+}
+
+func (f *fakeRunner) startCount(iface string, af AddressFamily) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.starts[runnerKey(iface, af)]
+}
+
+// waitStartCount polls until the runner has seen at least want starts
+// for the key (start counting happens inside the client goroutine, so
+// it lags Start's synchronous registration), then asserts exactness.
+func waitStartCount(t *testing.T, fr *fakeRunner, iface string, af AddressFamily, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for fr.startCount(iface, af) < want && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := fr.startCount(iface, af); got != want {
+		t.Fatalf("starts(%s/%d) = %d, want %d", iface, af, got, want)
+	}
+}
+
+func waitForRunning(t *testing.T, m *Manager, want int) map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		h := m.RunningClientHandlesForTesting()
+		if len(h) == want {
+			return h
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("running clients = %d, want %d (handles: %v)",
+				len(h), want, h)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestReconcileStartsNewClients(t *testing.T) {
+	fr := newFakeRunner(false)
+	m := NewManagerForTesting(fr.run)
+	defer m.StopAll()
+
+	m.Reconcile([]ClientSpec{
+		{Iface: "ge-0-0-3", Family: AFInet},
+		{Iface: "ge-0-0-3", Family: AFInet6, V6: &DHCPv6Options{Stateless: true}},
+	})
+
+	waitForRunning(t, m, 2)
+	waitStartCount(t, fr, "ge-0-0-3", AFInet, 1)
+	waitStartCount(t, fr, "ge-0-0-3", AFInet6, 1)
+}
+
+func TestReconcileStopsRemovedClients(t *testing.T) {
+	fr := newFakeRunner(false)
+	m := NewManagerForTesting(fr.run)
+	defer m.StopAll()
+
+	specs := []ClientSpec{
+		{Iface: "ge-0-0-3", Family: AFInet, V4: &DHCPv4Options{LeaseTime: 300}},
+		{Iface: "fxp0", Family: AFInet},
+	}
+	m.Reconcile(specs)
+	waitForRunning(t, m, 2)
+
+	// Seed lease state for the client about to be removed so the stop
+	// path's lease/address cleanup is exercised (nil netlink handle is
+	// guarded in removeAddress).
+	m.SeedLeaseForTesting("ge-0-0-3", AFInet, &Lease{
+		Interface: "ge-0-0-3",
+		Family:    AFInet,
+		Address:   netip.MustParsePrefix("10.0.0.5/24"),
+	})
+
+	// Drop ge-0-0-3 from config; fxp0 stays.
+	m.Reconcile(specs[1:])
+
+	handles := waitForRunning(t, m, 1)
+	if _, ok := handles["fxp0/4"]; !ok {
+		t.Fatalf("fxp0 client missing after reconcile: %v", handles)
+	}
+	waitStartCount(t, fr, "fxp0", AFInet, 1)
+	if l := m.LeaseFor("ge-0-0-3", AFInet); l != nil {
+		t.Errorf("lease record for stopped client not cleared: %+v", l)
+	}
+	m.mu.Lock()
+	_, optsLeft := m.v4opts["ge-0-0-3"]
+	m.mu.Unlock()
+	if optsLeft {
+		t.Error("v4opts for removed client not cleared")
+	}
+}
+
+func TestReconcileOptionChangeRestartsClient(t *testing.T) {
+	fr := newFakeRunner(false)
+	m := NewManagerForTesting(fr.run)
+	defer m.StopAll()
+
+	m.Reconcile([]ClientSpec{
+		{Iface: "ge-0-0-3", Family: AFInet6,
+			V6: &DHCPv6Options{Stateless: false, IATypes: []string{"ia-na"}}},
+	})
+	before := waitForRunning(t, m, 1)
+
+	// Same (iface, family), changed option identity: stateless flip.
+	// Stateless is captured at run-goroutine start, so this MUST
+	// restart the client (#1793 / plan §5.4 item 1).
+	m.Reconcile([]ClientSpec{
+		{Iface: "ge-0-0-3", Family: AFInet6,
+			V6: &DHCPv6Options{Stateless: true}},
+	})
+	after := waitForRunning(t, m, 1)
+
+	waitStartCount(t, fr, "ge-0-0-3", AFInet6, 2)
+	if before["ge-0-0-3/6"] == after["ge-0-0-3/6"] {
+		t.Fatal("client handle unchanged — option change did not restart client")
+	}
+}
+
+func TestReconcileDUIDTypeChangeRestartsClient(t *testing.T) {
+	fr := newFakeRunner(false)
+	m := NewManagerForTesting(fr.run)
+	defer m.StopAll()
+
+	m.Reconcile([]ClientSpec{{Iface: "ge-0-0-3", Family: AFInet6}})
+	waitForRunning(t, m, 1)
+
+	m.Reconcile([]ClientSpec{
+		{Iface: "ge-0-0-3", Family: AFInet6, DUIDType: "duid-llt"},
+	})
+	waitForRunning(t, m, 1)
+	waitStartCount(t, fr, "ge-0-0-3", AFInet6, 2)
+}
+
+// TestReconcileLeaseChangeDoesNotRestart is the no-restart-on-lease-change
+// invariant (AGY r3, plan §5.4 item 3): lease changes fire the
+// onAddressChange callback, which re-enters applyConfig and thus
+// Reconcile. If the diff keyed on lease/address state, every lease event
+// would restart the client and loop forever. A reconcile with an
+// unchanged config but changed lease state MUST be a no-op.
+func TestReconcileLeaseChangeDoesNotRestart(t *testing.T) {
+	fr := newFakeRunner(false)
+	m := NewManagerForTesting(fr.run)
+	defer m.StopAll()
+
+	specs := []ClientSpec{
+		{Iface: "ge-0-0-3", Family: AFInet, V4: &DHCPv4Options{LeaseTime: 300}},
+		{Iface: "ge-0-0-3", Family: AFInet6,
+			V6: &DHCPv6Options{IATypes: []string{"ia-na", "ia-pd"}}},
+	}
+	m.Reconcile(specs)
+	before := waitForRunning(t, m, 2)
+
+	// Simulate a lease change (what the real run goroutine does when a
+	// DORA/solicit completes or a renewal moves the address).
+	m.SeedLeaseForTesting("ge-0-0-3", AFInet, &Lease{
+		Interface: "ge-0-0-3",
+		Family:    AFInet,
+		Address:   netip.MustParsePrefix("10.0.0.5/24"),
+		Obtained:  time.Now(),
+	})
+	m.Reconcile(specs)
+
+	// And again with a different address — still no restart.
+	m.SeedLeaseForTesting("ge-0-0-3", AFInet, &Lease{
+		Interface: "ge-0-0-3",
+		Family:    AFInet,
+		Address:   netip.MustParsePrefix("10.0.0.99/24"),
+		Obtained:  time.Now(),
+	})
+	m.Reconcile(specs)
+
+	after := waitForRunning(t, m, 2)
+	for k := range before {
+		if before[k] != after[k] {
+			t.Errorf("client %s restarted on lease-only change", k)
+		}
+	}
+	waitStartCount(t, fr, "ge-0-0-3", AFInet, 1)
+	waitStartCount(t, fr, "ge-0-0-3", AFInet6, 1)
+}
+
+// TestTerminalExitDeregistersAndAllowsRestart covers #1793 defect 3:
+// a run goroutine that exits terminally (DHCPv4 max retransmissions,
+// DHCPv6 link-local abort) must deregister itself so a later Start for
+// the same key is not a permanent no-op.
+func TestTerminalExitDeregistersAndAllowsRestart(t *testing.T) {
+	fr := newFakeRunner(true) // exits immediately = terminal failure
+	m := NewManagerForTesting(fr.run)
+
+	m.Start(context.Background(), "ge-0-0-3", AFInet)
+	waitForRunning(t, m, 0) // terminal exit must clear the registry
+
+	// A subsequent Start must actually start a new client.
+	m.Start(context.Background(), "ge-0-0-3", AFInet)
+	deadline := time.Now().Add(5 * time.Second)
+	for fr.startCount("ge-0-0-3", AFInet) != 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("starts = %d, want 2 — Start blocked by stale registry entry",
+				fr.startCount("ge-0-0-3", AFInet))
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	waitForRunning(t, m, 0)
+}
+
+func TestStopAllClearsRegistry(t *testing.T) {
+	fr := newFakeRunner(false)
+	m := NewManagerForTesting(fr.run)
+
+	m.Reconcile([]ClientSpec{
+		{Iface: "ge-0-0-3", Family: AFInet},
+		{Iface: "fxp0", Family: AFInet6},
+	})
+	waitForRunning(t, m, 2)
+
+	m.StopAll()
+	if h := m.RunningClientHandlesForTesting(); len(h) != 0 {
+		t.Fatalf("registry not cleared after StopAll: %v", h)
+	}
+
+	// Registry hygiene: a fresh Start after StopAll must work.
+	m.Start(context.Background(), "ge-0-0-3", AFInet)
+	waitForRunning(t, m, 1)
+	m.StopAll()
+}
+
+func TestReconcileEmptyStopsEverything(t *testing.T) {
+	fr := newFakeRunner(false)
+	m := NewManagerForTesting(fr.run)
+
+	m.Reconcile([]ClientSpec{{Iface: "ge-0-0-3", Family: AFInet}})
+	waitForRunning(t, m, 1)
+
+	m.Reconcile(nil)
+	if h := m.RunningClientHandlesForTesting(); len(h) != 0 {
+		t.Fatalf("clients still running after empty reconcile: %v", h)
+	}
+}

--- a/pkg/dhcp/test_seams.go
+++ b/pkg/dhcp/test_seams.go
@@ -1,5 +1,12 @@
 package dhcp
 
+import (
+	"context"
+	"fmt"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+)
+
 // Test-only helpers for pkg/dhcp.Manager. Lives in the production
 // package so external packages (e.g. pkg/api tests) can use these
 // without internal-export tricks. Not for production callers.
@@ -13,4 +20,36 @@ func (m *Manager) SeedLeaseForTesting(ifaceName string, af AddressFamily, lease 
 		m.leases = make(map[clientKey]*Lease)
 	}
 	m.leases[clientKey{iface: ifaceName, family: af}] = lease
+}
+
+// NewManagerForTesting builds a Manager without a netlink handle and
+// with the per-client run goroutine replaced by runClient, so reconcile
+// and registry behavior can be tested without real DHCP traffic or
+// netlink access. runClient should block on ctx.Done() to model a
+// long-running client, or return early to model a terminal exit.
+func NewManagerForTesting(runClient func(ctx context.Context, ifaceName string, af AddressFamily)) *Manager {
+	return &Manager{
+		clients:          make(map[clientKey]*dhcpClient),
+		leases:           make(map[clientKey]*Lease),
+		delegatedPDs:     make(map[string][]DelegatedPrefix),
+		duids:            make(map[string]dhcpv6.DUID),
+		duidTypes:        make(map[string]string),
+		v4opts:           make(map[string]*DHCPv4Options),
+		v6opts:           make(map[string]*DHCPv6Options),
+		runClientForTest: runClient,
+	}
+}
+
+// RunningClientHandlesForTesting returns an opaque handle per running
+// client keyed "iface/4" or "iface/6". Handles compare equal across
+// calls iff the same client goroutine is still registered — tests use
+// this to assert a reconcile did (or did not) restart a client.
+func (m *Manager) RunningClientHandlesForTesting() map[string]any {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]any, len(m.clients))
+	for k, dc := range m.clients {
+		out[fmt.Sprintf("%s/%d", k.iface, k.family)] = dc
+	}
+	return out
 }

--- a/pkg/dhcp/test_seams.go
+++ b/pkg/dhcp/test_seams.go
@@ -53,3 +53,18 @@ func (m *Manager) RunningClientHandlesForTesting() map[string]any {
 	}
 	return out
 }
+
+// HasOptionStateForTesting reports desired-set membership for a client
+// key (the option-state map entry Reconcile installs for desired
+// clients and deletes for removed ones). Tests use it to observe the
+// Renew-vs-Reconcile removal window deterministically.
+func (m *Manager) HasOptionStateForTesting(ifaceName string, af AddressFamily) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if af == AFInet {
+		_, ok := m.v4opts[ifaceName]
+		return ok
+	}
+	_, ok := m.v6opts[ifaceName]
+	return ok
+}


### PR DESCRIPTION
## Summary

Unit **U8** of the [#1800 plan](https://github.com/psaab/xpf/issues/1800) (§5.4). DHCP/DHCPv6 client state was startup-only: enabling via commit did nothing (manager never created without startup DHCP), deleting left the client renewing forever, and terminal exits left stale registry entries blocking restart.

- **Reconcile-on-apply**: `applyConfigLocked` step 7b diffs desired-vs-running clients on **config identity** — `(iface, family)` + an options fingerprint (v4 lease-time/retrans/force-discover; v6 duid/stateless/IA-types/PD/req-options) captured at start. **Lease/address state structurally excluded** — the AGY-mandated `TestReconcileLeaseChangeDoesNotRestart` (pkg/dhcp + daemon twin) proves the lease callback's re-entry into applyConfig cannot restart-loop.
- Start = lazy manager creation (the `needsDHCP` startup-only gate is gone); stop = the existing per-client cancel (registry retains it) + wait; option/DUID change = stop+start.
- **`finishClient` defer** deregisters on ALL terminal run-goroutine exits (pointer-guarded), cleans lease records + delegated PDs, and removes the leased address — covering cancellation interleavings and natural terminal exits; `StopAll` clears the registry.
- **Background root preserved** (`pkg/dhcp/README.md:31` lease-survival invariant — graceful daemon restart leaves leases; only explicit reconcile-stop cancels). No protocol RELEASE (plan-decided). README updated with the lifecycle contract.

Closes #1793.

## Reviewer notes (author-flagged behavior deltas)
- First DISCOVER now fires during the initial applyConfig (step 7b) instead of the later daemon_run call site (kept as a redundant no-op safety net) — still after dataplane start; #1715 DNS repair-only semantics hold.
- A terminal natural exit (v4 max-retransmissions with a previously applied lease) now removes the leftover address — previously it lingered unmanaged.

## Validation
`go build ./...` clean; `go test -count=1 -race ./pkg/dhcp/ ./pkg/daemon/` ok; new tests cover add/remove/option-change/DUID-change/lease-no-restart/terminal-exit-restartable/StopAll; independently re-run. Gate: batch smoke post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)