### PR TITLE
#1800 U7: reject/sanitize control characters in config free-text — fixes networkd directive injection (#1798)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4663,3 +4663,7 @@ top.
 - **Timestamp**: 2026-06-09
   **Action**: U10 (#1792) monotonic HA liveness — 4 commits on engineer/1800-u10-liveness
   **File(s)**: pkg/cluster/{heartbeat,heartbeat_manager,hooks,manager,sync,sync_conn,sync_protocol,sync_test,heartbeat_liveness_test}.go, pkg/daemon/{daemon,daemon_ha_sync,daemon_ha_sync_test}.go, pkg/vrrp/{instance,instance_garp_test}.go, docs/bug-heartbeat-vrf-rebind-split-brain.md
+
+- **Timestamp**: 2026-06-09
+  **Action**: #1798 U7 layer 1+2 — strict commit-path control-char validation (compileOpts.sanitizeFreeTextControlChars gate in compileExpanded) + lenient sanitize-with-warning; Store.Load/SyncApply tree scrub via config.SanitizeTreeControlChars
+  **File(s)**: pkg/config/freetext.go (new), pkg/config/compiler.go, pkg/configstore/store.go

--- a/_Log.md
+++ b/_Log.md
@@ -4667,3 +4667,7 @@ top.
 - **Timestamp**: 2026-06-09
   **Action**: #1798 U7 layer 1+2 — strict commit-path control-char validation (compileOpts.sanitizeFreeTextControlChars gate in compileExpanded) + lenient sanitize-with-warning; Store.Load/SyncApply tree scrub via config.SanitizeTreeControlChars
   **File(s)**: pkg/config/freetext.go (new), pkg/config/compiler.go, pkg/configstore/store.go
+
+- **Timestamp**: 2026-06-09
+  **Action**: #1798 U7 layer 3 — render-side control-char sanitizers at every free-text file interpolation (networkd units, frr.conf, swanctl.conf) + audit of Kea/linksetup/ast_format (deliberately left, reasons in commit msg)
+  **File(s)**: pkg/networkd/networkd.go, pkg/frr/policy_render.go, pkg/ipsec/ipsec.go

--- a/_Log.md
+++ b/_Log.md
@@ -4671,3 +4671,7 @@ top.
 - **Timestamp**: 2026-06-09
   **Action**: #1798 U7 layer 3 — render-side control-char sanitizers at every free-text file interpolation (networkd units, frr.conf, swanctl.conf) + audit of Kea/linksetup/ast_format (deliberately left, reasons in commit msg)
   **File(s)**: pkg/networkd/networkd.go, pkg/frr/policy_render.go, pkg/ipsec/ipsec.go
+
+- **Timestamp**: 2026-06-09
+  **Action**: #1798 U7 gate tests — strict reject (flat-set + hierarchical + annotation), lenient sanitize+warn, Load boots on persisted bad config + next commit succeeds, SyncApply tolerance, renderer belt tests (networkd/frr/ipsec)
+  **File(s)**: pkg/config/freetext_test.go (new), pkg/configstore/freetext_store_test.go (new), pkg/networkd/networkd_test.go, pkg/frr/frr_test.go, pkg/ipsec/ipsec_test.go

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -58,6 +58,20 @@ type compileOpts struct {
 	// / commit-check stay strict (lenient stays false there) so new
 	// operator edits hard-reject loudly.
 	lenientEqualFlowWorkerCap bool
+
+	// sanitizeFreeTextControlChars (#1798) downgrades the control-
+	// character gate from a hard compile error to sanitize-in-place
+	// plus a cfg.Warnings entry. The strict commit / commit-check path
+	// rejects any value or annotation containing ASCII control
+	// characters — the lexer maps "\n" inside a quoted string to a
+	// real newline, which injects arbitrary directives into generated
+	// networkd/FRR/strongSwan files. The tolerant load / peer-sync /
+	// peer-display paths must instead scrub the value and keep going
+	// so an already-persisted bad config cannot blackout-boot a node
+	// or alarm-loop HA config sync. This check deliberately does NOT
+	// live in SchemaValidate, which also runs on the lenient paths.
+	// See freetext.go for the full three-layer design.
+	sanitizeFreeTextControlChars bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -77,7 +91,10 @@ func CompileConfig(tree *ConfigTree) (*Config, error) {
 // hard-reject. The node-aware sibling CompileConfigForNodeLenient covers
 // the cluster paths (Store.SyncApply, peer-interface display).
 func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
-	return compileConfigWithOpts(tree, compileOpts{lenientEqualFlowWorkerCap: true})
+	return compileConfigWithOpts(tree, compileOpts{
+		lenientEqualFlowWorkerCap:    true,
+		sanitizeFreeTextControlChars: true,
+	})
 }
 
 func compileConfigWithOpts(tree *ConfigTree, opts compileOpts) (*Config, error) {
@@ -126,7 +143,10 @@ func CompileConfigForNode(tree *ConfigTree, nodeID int) (*Config, error) {
 // (cli_show_interfaces.go, server_show_interfaces.go). MUST NOT be used on
 // the candidate-commit path — see CompileConfigLenient.
 func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) {
-	return compileConfigForNodeWithOpts(tree, nodeID, compileOpts{lenientEqualFlowWorkerCap: true})
+	return compileConfigForNodeWithOpts(tree, nodeID, compileOpts{
+		lenientEqualFlowWorkerCap:    true,
+		sanitizeFreeTextControlChars: true,
+	})
 }
 
 func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts) (*Config, error) {
@@ -143,6 +163,22 @@ func compileConfigForNodeWithOpts(tree *ConfigTree, nodeID int, opts compileOpts
 // compileExpanded compiles an already-expanded (groups resolved) ConfigTree
 // into a typed Config. Shared by CompileConfig and CompileConfigForNode.
 func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
+	// #1798 free-text control-character gate. Strict (commit /
+	// commit-check): hard-reject. Lenient (load / peer-sync / peer
+	// display): scrub in place on this already-cloned tree and warn.
+	// Runs on the group-expanded tree so values inherited via
+	// apply-groups are covered, and BEFORE section compilation so the
+	// lenient path's typed Config is built from the scrubbed values.
+	var ctrlCharWarnings []string
+	if opts.sanitizeFreeTextControlChars {
+		for _, p := range sanitizeNodesControlChars(tree.Children, "") {
+			ctrlCharWarnings = append(ctrlCharWarnings, fmt.Sprintf(
+				"sanitized control characters in configuration value at %q (#1798)", p))
+		}
+	} else if err := validateNodesControlChars(tree.Children, ""); err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		Security: SecurityConfig{
 			Zones:  make(map[string]*ZoneConfig),
@@ -164,6 +200,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 			Interfaces:        make(map[string]*CoSInterface),
 		},
 	}
+	cfg.Warnings = append(cfg.Warnings, ctrlCharWarnings...)
 
 	for _, node := range tree.Children {
 		switch node.Name() {

--- a/pkg/config/freetext.go
+++ b/pkg/config/freetext.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// #1798: free-text config values (interface/zone/policy descriptions,
+// annotations, auth keys, IKE secrets) flow verbatim into generated
+// config files — systemd-networkd units, frr.conf, swanctl.conf. The
+// lexer maps the `\n` escape inside a quoted string to a real newline
+// (lexer.go readString), so a value like "lan\nDHCP=ipv4" injects an
+// arbitrary directive into the generated file. Two config-level layers
+// defend against this:
+//
+//   - The STRICT compile path (CompileConfig / CompileConfigForNode,
+//     reached only via commit / commit-check — Store.compileTree)
+//     hard-rejects any tree value or annotation containing an ASCII
+//     control character, so a new operator edit fails loudly at commit
+//     time. This check deliberately does NOT live in SchemaValidate:
+//     SchemaValidate also runs on the lenient boot/peer-sync paths and
+//     a strict reject there would make a box with a bad persisted
+//     config fail to boot.
+//
+//   - The LENIENT compile path (CompileConfigLenient /
+//     CompileConfigForNodeLenient — Store.Load, Store.SyncApply, and
+//     read-only peer-interface display) sanitizes the values in place
+//     with a warning instead, and the configstore migration helper
+//     SanitizeTreeControlChars cleans the stored tree itself so an
+//     already-persisted bad value can neither fail boot nor make the
+//     operator's next unrelated commit fail mysteriously.
+//
+// The render-side belt (sanitizers in pkg/networkd, pkg/frr, pkg/ipsec
+// at each free-text file interpolation) is the third, independent
+// layer.
+
+// hasControlChars reports whether s contains any ASCII control
+// character: the full C0 set (0x00–0x1F, which includes \n, \r and \t)
+// or DEL (0x7F). The byte-wise scan is correct for UTF-8 input because
+// multi-byte sequences never contain bytes below 0x80.
+func hasControlChars(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+// sanitizeControlChars returns s with every ASCII control character
+// (C0 set and DEL) replaced by a single space. Replacing rather than
+// deleting keeps adjacent words readable ("lan\nDHCP=ipv4" becomes
+// "lan DHCP=ipv4", not "lanDHCP=ipv4").
+func sanitizeControlChars(s string) string {
+	if !hasControlChars(s) {
+		return s
+	}
+	b := []byte(s)
+	for i := range b {
+		if b[i] < 0x20 || b[i] == 0x7f {
+			b[i] = ' '
+		}
+	}
+	return string(b)
+}
+
+// joinNodePath builds a human-readable config path for error/warning
+// messages. Key values are sanitized for display so a path containing
+// the offending newline does not itself produce a multi-line message.
+func joinNodePath(prefix string, keys []string) string {
+	clean := make([]string, len(keys))
+	for i, k := range keys {
+		clean[i] = sanitizeControlChars(k)
+	}
+	joined := strings.Join(clean, " ")
+	if prefix == "" {
+		return joined
+	}
+	return prefix + " " + joined
+}
+
+// validateNodesControlChars walks the (group-expanded) AST and returns
+// an error for the first value or annotation containing a control
+// character. Strict commit-path only — see the package comment above.
+func validateNodesControlChars(nodes []*Node, prefix string) error {
+	for _, n := range nodes {
+		nodePath := joinNodePath(prefix, n.Keys)
+		for _, k := range n.Keys {
+			if hasControlChars(k) {
+				return fmt.Errorf("%s: value %q contains control characters (newlines and other control characters are not allowed in configuration values)", nodePath, k)
+			}
+		}
+		if hasControlChars(n.Annotation) {
+			return fmt.Errorf("%s: annotation %q contains control characters (newlines and other control characters are not allowed in annotations)", nodePath, n.Annotation)
+		}
+		if err := validateNodesControlChars(n.Children, nodePath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// sanitizeNodesControlChars walks the AST replacing control characters
+// in values and annotations in place, returning one human-readable
+// config path per modified node. Lenient-path counterpart of
+// validateNodesControlChars.
+func sanitizeNodesControlChars(nodes []*Node, prefix string) []string {
+	var warnings []string
+	for _, n := range nodes {
+		changed := false
+		for i, k := range n.Keys {
+			if hasControlChars(k) {
+				n.Keys[i] = sanitizeControlChars(k)
+				changed = true
+			}
+		}
+		if hasControlChars(n.Annotation) {
+			n.Annotation = sanitizeControlChars(n.Annotation)
+			changed = true
+		}
+		nodePath := joinNodePath(prefix, n.Keys)
+		if changed {
+			warnings = append(warnings, nodePath)
+		}
+		warnings = append(warnings, sanitizeNodesControlChars(n.Children, nodePath)...)
+	}
+	return warnings
+}
+
+// SanitizeTreeControlChars replaces ASCII control characters (C0 set
+// and DEL) with spaces in every value and annotation of the tree, in
+// place, and returns one human-readable config path per modified node.
+//
+// This is the #1798 migration helper for the tolerant ingest paths
+// (Store.Load on boot, Store.SyncApply on HA peer-sync): it cleans the
+// tree that will become the active/candidate config so an
+// already-persisted bad value cannot fail boot now or fail the
+// operator's next unrelated strict commit later. Callers should log
+// each returned path as a warning.
+func SanitizeTreeControlChars(tree *ConfigTree) []string {
+	if tree == nil {
+		return nil
+	}
+	return sanitizeNodesControlChars(tree.Children, "")
+}

--- a/pkg/config/freetext_test.go
+++ b/pkg/config/freetext_test.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1798 regression tests: a free-text config value carrying an embedded
+// newline (the lexer maps the "\n" escape inside a quoted string to a
+// real newline) must be rejected by the strict commit-path compile and
+// sanitized-with-warning by the lenient load/peer-sync compile.
+
+// newlineDescTree builds a tree via the flat-set path (ParseSetCommand +
+// SetPath, per the project testing rule) whose interface description
+// contains a real newline.
+func newlineDescTree(t *testing.T) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	path, err := ParseSetCommand(`set interfaces ge-0-0-0 description "lan\nDHCP=ipv4"`)
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	// The lexer must have produced a REAL newline in the value — that
+	// is the injection primitive under test.
+	if want := "lan\nDHCP=ipv4"; path[len(path)-1] != want {
+		t.Fatalf("lexer escape mapping changed: got %q, want %q", path[len(path)-1], want)
+	}
+	if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	return tree
+}
+
+// findDescriptionValue walks the tree and returns the first key
+// containing the injected marker, independent of how SetPath grouped
+// the flat-set tokens into nodes.
+func findDescriptionValue(nodes []*Node) string {
+	for _, n := range nodes {
+		for _, k := range n.Keys {
+			if strings.Contains(k, "DHCP=ipv4") {
+				return k
+			}
+		}
+		if v := findDescriptionValue(n.Children); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func TestCompileConfigRejectsNewlineDescription(t *testing.T) {
+	tree := newlineDescTree(t)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("strict CompileConfig must reject a description containing a newline")
+	}
+	if !strings.Contains(err.Error(), "control characters") {
+		t.Fatalf("error should mention control characters: %v", err)
+	}
+	if !strings.Contains(err.Error(), "description") {
+		t.Fatalf("error should name the offending path: %v", err)
+	}
+}
+
+func TestCompileConfigForNodeRejectsNewlineDescription(t *testing.T) {
+	tree := newlineDescTree(t)
+	if _, err := CompileConfigForNode(tree, 0); err == nil {
+		t.Fatal("strict CompileConfigForNode must reject a description containing a newline")
+	}
+}
+
+// TestCompileConfigRejectsHierarchicalQuotedNewline exercises the
+// issue's exact reproduction path: hierarchical config text whose
+// quoted string carries the "\n" escape through the parser/lexer.
+func TestCompileConfigRejectsHierarchicalQuotedNewline(t *testing.T) {
+	text := "interfaces {\n" +
+		"    ge-0-0-0 {\n" +
+		"        description \"lan\\nDHCP=ipv4\";\n" +
+		"    }\n" +
+		"}\n"
+	tree, errs := NewParser(text).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("strict CompileConfig must reject the hierarchical quoted-newline description")
+	}
+}
+
+func TestCompileConfigRejectsControlCharAnnotation(t *testing.T) {
+	tree := &ConfigTree{}
+	path, err := ParseSetCommand("set interfaces ge-0-0-0 mtu 1500")
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	tree.Children[0].Annotation = "note\nAddress=10.0.0.1/24"
+	_, err = CompileConfig(tree)
+	if err == nil {
+		t.Fatal("strict CompileConfig must reject an annotation containing a newline")
+	}
+	if !strings.Contains(err.Error(), "annotation") {
+		t.Fatalf("error should mention the annotation: %v", err)
+	}
+}
+
+func TestCompileConfigLenientSanitizesNewlineDescription(t *testing.T) {
+	tree := newlineDescTree(t)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must tolerate a persisted newline description: %v", err)
+	}
+	ifc := cfg.Interfaces.Interfaces["ge-0-0-0"]
+	if ifc == nil {
+		t.Fatal("interface ge-0-0-0 missing from compiled config")
+	}
+	if ifc.Description != "lan DHCP=ipv4" {
+		t.Errorf("description not sanitized: got %q", ifc.Description)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "control characters") && strings.Contains(w, "#1798") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("lenient compile should surface a #1798 warning, got %v", cfg.Warnings)
+	}
+	// The caller's tree must be untouched (compile works on a clone);
+	// scrubbing the stored tree is the configstore's job.
+	if got := findDescriptionValue(tree.Children); got != "lan\nDHCP=ipv4" {
+		t.Errorf("lenient compile must not mutate the caller's tree, got %q", got)
+	}
+}
+
+func TestSanitizeTreeControlChars(t *testing.T) {
+	tree := newlineDescTree(t)
+	tree.Children[0].Annotation = "x\ry"
+	warnings := SanitizeTreeControlChars(tree)
+	if len(warnings) != 2 {
+		t.Fatalf("expected 2 warnings (value + annotation nodes), got %d: %v", len(warnings), warnings)
+	}
+	if got := findDescriptionValue(tree.Children); got != "lan DHCP=ipv4" {
+		t.Errorf("tree value not sanitized in place: %q", got)
+	}
+	if tree.Children[0].Annotation != "x y" {
+		t.Errorf("annotation not sanitized in place: %q", tree.Children[0].Annotation)
+	}
+	// Idempotent: a second pass finds nothing.
+	if again := SanitizeTreeControlChars(tree); len(again) != 0 {
+		t.Errorf("second sanitize pass should be a no-op, got %v", again)
+	}
+	// A clean tree compiles strictly after sanitization.
+	if _, err := CompileConfig(tree); err != nil {
+		t.Errorf("sanitized tree must pass strict compile: %v", err)
+	}
+}
+
+func TestControlCharHelpers(t *testing.T) {
+	cases := []struct {
+		in       string
+		has      bool
+		sanitize string
+	}{
+		{"plain description", false, "plain description"},
+		{"lan\nDHCP=ipv4", true, "lan DHCP=ipv4"},
+		{"a\rb", true, "a b"},
+		{"a\tb", true, "a b"},
+		{"del\x7fchar", true, "del char"},
+		{"nul\x00byte", true, "nul byte"},
+		// Multi-byte UTF-8 must pass through untouched (no byte of a
+		// UTF-8 continuation sequence is below 0x80).
+		{"héllo — wörld", false, "héllo — wörld"},
+		{"", false, ""},
+	}
+	for _, c := range cases {
+		if got := hasControlChars(c.in); got != c.has {
+			t.Errorf("hasControlChars(%q) = %v, want %v", c.in, got, c.has)
+		}
+		if got := sanitizeControlChars(c.in); got != c.sanitize {
+			t.Errorf("sanitizeControlChars(%q) = %q, want %q", c.in, got, c.sanitize)
+		}
+	}
+}

--- a/pkg/configstore/freetext_store_test.go
+++ b/pkg/configstore/freetext_store_test.go
@@ -1,0 +1,129 @@
+package configstore
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #1798 regression gates:
+//  (a) a PERSISTED config containing a newline description must Load()
+//      and boot — the lenient path sanitizes with a warning;
+//  (b) re-introducing the value must be REJECTED at strict commit;
+//  (c) after a sanitized Load, the operator's next unrelated commit
+//      must succeed (the stored tree was scrubbed, not just the
+//      compiled view).
+
+const injectedSetCmd = `set interfaces ge-0-0-0 description "lan\nDHCP=ipv4"`
+
+func newlinePersistedTree(t *testing.T) *config.ConfigTree {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	path, err := config.ParseSetCommand(injectedSetCmd)
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	return tree
+}
+
+func TestLoadBootsAndSanitizesPersistedNewlineDescription(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+
+	// Persist a bad tree directly (bypassing commit, as a pre-gate
+	// daemon would have): the DB stores the tree as JSON, so the real
+	// newline round-trips exactly.
+	s1 := New(path)
+	if err := s1.db.WriteActive(newlinePersistedTree(t)); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+
+	// Gate (a): the box must boot.
+	s2 := New(path)
+	if err := s2.Load(); err != nil {
+		t.Fatalf("Load must boot on a persisted control-char config: %v", err)
+	}
+	cfg := s2.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("loaded config is nil")
+	}
+	ifc := cfg.Interfaces.Interfaces["ge-0-0-0"]
+	if ifc == nil {
+		t.Fatal("interface ge-0-0-0 missing from loaded config")
+	}
+	if strings.ContainsAny(ifc.Description, "\n\r") {
+		t.Fatalf("loaded description still carries control chars: %q", ifc.Description)
+	}
+	if ifc.Description != "lan DHCP=ipv4" {
+		t.Errorf("loaded description not sanitized as expected: %q", ifc.Description)
+	}
+
+	// Gate (c): the stored ACTIVE TREE was scrubbed too, so the next
+	// unrelated commit cannot mysteriously fail on the old value.
+	if err := s2.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s2.SetFromInput("security zones security-zone trust interfaces ge-0-0-0.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s2.Commit(); err != nil {
+		t.Fatalf("next unrelated commit after sanitized Load must succeed: %v", err)
+	}
+}
+
+func TestCommitRejectsNewlineDescription(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput(`interfaces ge-0-0-0 description "lan\nDHCP=ipv4"`); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	// Gate (b): strict commit-check and commit both reject.
+	if _, err := s.CommitCheck(); err == nil {
+		t.Fatal("CommitCheck must reject a newline description")
+	} else if !strings.Contains(err.Error(), "control characters") {
+		t.Fatalf("CommitCheck error should mention control characters: %v", err)
+	}
+	if _, err := s.Commit(); err == nil {
+		t.Fatal("Commit must reject a newline description")
+	}
+}
+
+func TestSyncApplySanitizesNewlineDescription(t *testing.T) {
+	s := newTestStore(t)
+	// Hierarchical text as pushed by a (possibly un-upgraded) cluster
+	// primary; the quoted "\n" escape becomes a real newline in the
+	// parsed tree.
+	content := "interfaces {\n" +
+		"    ge-0-0-0 {\n" +
+		"        description \"lan\\nDHCP=ipv4\";\n" +
+		"    }\n" +
+		"}\n"
+	compiled, err := s.SyncApply(content, nil)
+	if err != nil {
+		t.Fatalf("SyncApply must tolerate a peer-synced control-char config: %v", err)
+	}
+	ifc := compiled.Interfaces.Interfaces["ge-0-0-0"]
+	if ifc == nil {
+		t.Fatal("interface ge-0-0-0 missing from synced config")
+	}
+	if strings.ContainsAny(ifc.Description, "\n\r") {
+		t.Fatalf("synced description still carries control chars: %q", ifc.Description)
+	}
+	// The stored active tree must be clean for any later strict commit.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if err := s.SetFromInput("security zones security-zone trust interfaces ge-0-0-0.0"); err != nil {
+		t.Fatalf("SetFromInput: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("commit after sanitized SyncApply must succeed: %v", err)
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -102,6 +102,18 @@ func (s *Store) Load() error {
 	// up so the operator can fix the config from CLI.
 	rewriteRetiredDataplaneType(tree, LoadCaller)
 
+	// #1798 migration: a persisted free-text value carrying control
+	// characters (e.g. a "lan\nDHCP=ipv4" description committed before
+	// the strict commit-time gate landed) must neither fail boot now
+	// nor make the operator's next unrelated commit fail mysteriously.
+	// Scrub the tree in place with a warning — this tree becomes the
+	// active config (and the candidate clones from it), so the next
+	// strict commit sees only clean values.
+	for _, p := range config.SanitizeTreeControlChars(tree) {
+		slog.Warn("sanitized control characters in persisted config value",
+			"path", p, "issue", "#1798")
+	}
+
 	// #1733: tolerate (warn, don't reject) an already-persisted
 	// workers>32 + equal-flow-enforcement config on local boot so an
 	// upgraded node does not blackout-boot. See compileTreeLenient.
@@ -256,6 +268,16 @@ func (s *Store) SyncApply(content string, chassisPreserve func(*config.ConfigTre
 	// retired leaf so the standby boots through cleanly while the
 	// operator updates the primary.
 	rewriteRetiredDataplaneType(tree, SyncCaller)
+
+	// #1798 migration: same tolerance as Load — a peer-synced config
+	// from a possibly-un-upgraded primary may carry control characters
+	// in free-text values. Scrub the tree in place with a warning so
+	// HA config sync does not alarm-loop and the standby's stored tree
+	// stays clean for any later strict commit.
+	for _, p := range config.SanitizeTreeControlChars(tree) {
+		slog.Warn("sanitized control characters in peer-synced config value",
+			"path", p, "issue", "#1798")
+	}
 
 	// #1733: tolerate (warn, don't reject) a workers>32 + equal-flow
 	// config peer-synced from a possibly-un-upgraded primary so HA config

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -2588,3 +2588,34 @@ func TestPerInstanceInet6StaticRoutes(t *testing.T) {
 		t.Errorf("expected per-VRF IPv6 static route, got:\n%s", got)
 	}
 }
+
+// #1798 belt test: BGP free-text values (neighbor description,
+// password) and IGP auth keys must not inject extra frr.conf lines
+// even if commit-time validation were bypassed.
+func TestGenerateProtocols_NewlineFreeTextDoesNotInject(t *testing.T) {
+	m := New()
+	bgp := &config.BGPConfig{
+		LocalAS: 65000,
+		Neighbors: []*config.BGPNeighbor{
+			{
+				Address:      "10.0.0.1",
+				PeerAS:       65001,
+				Description:  "peer\nno router bgp 65000",
+				AuthPassword: "pw\nagentx",
+			},
+		},
+	}
+	got := m.generateProtocols(nil, nil, bgp, nil, nil, "", 0, nil)
+	for _, line := range strings.Split(got, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "no router bgp 65000" || trimmed == "agentx" {
+			t.Fatalf("injected frr.conf line leaked:\n%s", got)
+		}
+	}
+	if !strings.Contains(got, " neighbor 10.0.0.1 description peer no router bgp 65000\n") {
+		t.Errorf("sanitized description missing:\n%s", got)
+	}
+	if !strings.Contains(got, " neighbor 10.0.0.1 password pw agentx\n") {
+		t.Errorf("sanitized password missing:\n%s", got)
+	}
+}

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -25,6 +25,34 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
+// sanitizeFRRValue strips ASCII control characters — the C0 set
+// (0x00-0x1F, including newline) and DEL (0x7F), each replaced by a
+// space — from a free-text config value (description, auth key,
+// password) before it is interpolated into a generated frr.conf line.
+// Render-side belt for #1798: a BGP neighbor description or auth key
+// containing an embedded newline must not be able to inject extra
+// frr.conf commands even if the commit-time validation layer were
+// bypassed.
+func sanitizeFRRValue(s string) string {
+	clean := true
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return s
+	}
+	b := []byte(s)
+	for i := range b {
+		if b[i] < 0x20 || b[i] == 0x7f {
+			b[i] = ' '
+		}
+	}
+	return string(b)
+}
+
 // knownRedistProtocols are the FRR redistribute protocol keywords.
 var knownRedistProtocols = map[string]bool{
 	"connected": true, "static": true, "ospf": true, "bgp": true,
@@ -170,10 +198,10 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 					if keyID == 0 {
 						keyID = 1
 					}
-					fmt.Fprintf(&b, " ip ospf message-digest-key %d md5 %s\n", keyID, iface.AuthKey)
+					fmt.Fprintf(&b, " ip ospf message-digest-key %d md5 %s\n", keyID, sanitizeFRRValue(iface.AuthKey))
 				} else if iface.AuthType == "simple" {
 					b.WriteString(" ip ospf authentication\n")
-					fmt.Fprintf(&b, " ip ospf authentication-key %s\n", iface.AuthKey)
+					fmt.Fprintf(&b, " ip ospf authentication-key %s\n", sanitizeFRRValue(iface.AuthKey))
 				}
 				if iface.BFD {
 					if iface.BFDInterval > 0 || iface.BFDMultiplier > 0 {
@@ -259,13 +287,13 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 		for _, n := range bgp.Neighbors {
 			fmt.Fprintf(&b, " neighbor %s remote-as %d\n", n.Address, n.PeerAS)
 			if n.Description != "" {
-				fmt.Fprintf(&b, " neighbor %s description %s\n", n.Address, n.Description)
+				fmt.Fprintf(&b, " neighbor %s description %s\n", n.Address, sanitizeFRRValue(n.Description))
 			}
 			if n.MultihopTTL > 0 {
 				fmt.Fprintf(&b, " neighbor %s ebgp-multihop %d\n", n.Address, n.MultihopTTL)
 			}
 			if n.AuthPassword != "" {
-				fmt.Fprintf(&b, " neighbor %s password %s\n", n.Address, n.AuthPassword)
+				fmt.Fprintf(&b, " neighbor %s password %s\n", n.Address, sanitizeFRRValue(n.AuthPassword))
 			}
 			if n.BFD {
 				fmt.Fprintf(&b, " neighbor %s bfd\n", n.Address)
@@ -361,7 +389,7 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 				} else {
 					b.WriteString(" ip rip authentication mode text\n")
 				}
-				fmt.Fprintf(&b, " ip rip authentication string %s\n", rip.AuthKey)
+				fmt.Fprintf(&b, " ip rip authentication string %s\n", sanitizeFRRValue(rip.AuthKey))
 				b.WriteString("exit\n!\n")
 			}
 		}
@@ -395,11 +423,11 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 		}
 		if isis.AuthKey != "" {
 			if isis.AuthType == "md5" {
-				fmt.Fprintf(&b, " area-password md5 %s\n", isis.AuthKey)
-				fmt.Fprintf(&b, " domain-password md5 %s\n", isis.AuthKey)
+				fmt.Fprintf(&b, " area-password md5 %s\n", sanitizeFRRValue(isis.AuthKey))
+				fmt.Fprintf(&b, " domain-password md5 %s\n", sanitizeFRRValue(isis.AuthKey))
 			} else {
-				fmt.Fprintf(&b, " area-password clear %s\n", isis.AuthKey)
-				fmt.Fprintf(&b, " domain-password clear %s\n", isis.AuthKey)
+				fmt.Fprintf(&b, " area-password clear %s\n", sanitizeFRRValue(isis.AuthKey))
+				fmt.Fprintf(&b, " domain-password clear %s\n", sanitizeFRRValue(isis.AuthKey))
 			}
 		}
 		b.WriteString("exit\n!\n")
@@ -414,9 +442,9 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			}
 			if iface.AuthKey != "" {
 				if iface.AuthType == "md5" {
-					fmt.Fprintf(&b, " isis password md5 %s\n", iface.AuthKey)
+					fmt.Fprintf(&b, " isis password md5 %s\n", sanitizeFRRValue(iface.AuthKey))
 				} else {
-					fmt.Fprintf(&b, " isis password clear %s\n", iface.AuthKey)
+					fmt.Fprintf(&b, " isis password clear %s\n", sanitizeFRRValue(iface.AuthKey))
 				}
 			}
 			b.WriteString("exit\n!\n")

--- a/pkg/ipsec/ipsec.go
+++ b/pkg/ipsec/ipsec.go
@@ -112,7 +112,7 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 	b.WriteString("connections {\n")
 	for _, name := range sortedVPNNames(ipsecCfg.VPNs) {
 		vpn := ipsecCfg.VPNs[name]
-		fmt.Fprintf(&b, "  %s {\n", name)
+		fmt.Fprintf(&b, "  %s {\n", sanitizeSwanctlValue(name))
 
 		// Resolve gateway reference
 		remoteAddr := vpn.Gateway
@@ -181,10 +181,10 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 		b.WriteString("    local {\n")
 		fmt.Fprintf(&b, "      auth = %s\n", authMethod)
 		if gw != nil && gw.LocalCertificate != "" {
-			fmt.Fprintf(&b, "      certs = %s\n", gw.LocalCertificate)
+			fmt.Fprintf(&b, "      certs = %s\n", sanitizeSwanctlValue(gw.LocalCertificate))
 		}
 		if gw != nil && gw.LocalIDValue != "" {
-			fmt.Fprintf(&b, "      id = %s\n", formatIdentity(gw.LocalIDType, gw.LocalIDValue))
+			fmt.Fprintf(&b, "      id = %s\n", sanitizeSwanctlValue(formatIdentity(gw.LocalIDType, gw.LocalIDValue)))
 		}
 		b.WriteString("    }\n")
 
@@ -192,7 +192,7 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 		b.WriteString("    remote {\n")
 		fmt.Fprintf(&b, "      auth = %s\n", authMethod)
 		if gw != nil && gw.RemoteIDValue != "" {
-			fmt.Fprintf(&b, "      id = %s\n", formatIdentity(gw.RemoteIDType, gw.RemoteIDValue))
+			fmt.Fprintf(&b, "      id = %s\n", sanitizeSwanctlValue(formatIdentity(gw.RemoteIDType, gw.RemoteIDValue)))
 		}
 		b.WriteString("    }\n")
 
@@ -214,7 +214,7 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 
 		fmt.Fprintf(&b, "    children {\n")
 		for _, child := range effectiveTrafficSelectors(name, vpn) {
-			fmt.Fprintf(&b, "      %s {\n", child.Name)
+			fmt.Fprintf(&b, "      %s {\n", sanitizeSwanctlValue(child.Name))
 			if child.LocalTS != "" {
 				fmt.Fprintf(&b, "        local_ts = %s\n", child.LocalTS)
 			}
@@ -267,8 +267,8 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("vpn %s: %w", name, err)
 			}
-			fmt.Fprintf(&b, "  ike-%s {\n", name)
-			fmt.Fprintf(&b, "    secret = \"%s\"\n", decoded)
+			fmt.Fprintf(&b, "  ike-%s {\n", sanitizeSwanctlValue(name))
+			fmt.Fprintf(&b, "    secret = \"%s\"\n", sanitizeSwanctlValue(decoded))
 			fmt.Fprintf(&b, "  }\n")
 		}
 	}
@@ -438,7 +438,36 @@ func hasIKEChain(cfg *config.IPsecConfig, ikePolicyName string) bool {
 	return ok
 }
 
+// sanitizeSwanctlValue strips ASCII control characters — the C0 set
+// (0x00-0x1F, including newline) and DEL (0x7F), each replaced by a
+// space — from a free-text config value (connection name, IKE
+// identity, certificate name, pre-shared key) before it is
+// interpolated into a generated swanctl.conf line. Render-side belt
+// for #1798: an embedded newline must not be able to inject extra
+// swanctl sections/keys even if the commit-time validation layer were
+// bypassed.
+func sanitizeSwanctlValue(s string) string {
+	clean := true
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return s
+	}
+	b := []byte(s)
+	for i := range b {
+		if b[i] < 0x20 || b[i] == 0x7f {
+			b[i] = ' '
+		}
+	}
+	return string(b)
+}
+
 // formatIdentity formats an IKE identity for strongSwan.
+
 func formatIdentity(idType, idValue string) string {
 	switch idType {
 	case "hostname", "fqdn":

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -912,3 +912,30 @@ func TestPrepareConfig_ExternalInterfaceLocalAddress(t *testing.T) {
 		t.Fatalf("resolved local-address = %q, want 198.51.100.1", prepared.Gateways["gw"].LocalAddress)
 	}
 }
+
+// #1798 belt test: a pre-shared key (or identity) carrying an embedded
+// newline must not inject extra swanctl.conf sections/keys even if
+// commit-time validation were bypassed.
+func TestGenerateConfig_NewlineSecretDoesNotInject(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"site-a": {
+				LocalAddr:     "10.0.1.1",
+				Gateway:       "10.0.2.1",
+				PSK:           "secret\ninclude /etc/evil.conf",
+				BindInterface: "st0.0",
+			},
+		},
+		Proposals: map[string]*config.IPsecProposal{},
+	}
+	got := m.generateConfig(cfg)
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "include ") {
+			t.Fatalf("injected swanctl directive leaked:\n%s", got)
+		}
+	}
+	if !strings.Contains(got, `secret = "secret include /etc/evil.conf"`) {
+		t.Errorf("sanitized secret missing:\n%s", got)
+	}
+}

--- a/pkg/networkd/networkd.go
+++ b/pkg/networkd/networkd.go
@@ -285,6 +285,34 @@ func (m *Manager) findExternallyManaged() map[string]bool {
 	return FindExternallyManaged(m.networkDir)
 }
 
+// sanitizeUnitValue strips ASCII control characters — the C0 set
+// (0x00-0x1F, including newline) and DEL (0x7F), each replaced by a
+// space — from a free-text config value before it is interpolated into
+// a generated systemd unit line. Render-side belt for #1798: a
+// description like "lan\nDHCP=ipv4" must not be able to inject extra
+// directives into a .network/.netdev/.link unit even if the
+// commit-time validation layer were bypassed (e.g. an old persisted
+// value reaching the renderer ahead of the load-time sanitizer).
+func sanitizeUnitValue(s string) string {
+	clean := true
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return s
+	}
+	b := []byte(s)
+	for i := range b {
+		if b[i] < 0x20 || b[i] == 0x7f {
+			b[i] = ' '
+		}
+	}
+	return string(b)
+}
+
 func (m *Manager) generateNetdev(ifc InterfaceConfig) string {
 	var b strings.Builder
 	b.WriteString("# Managed by xpfd — do not edit\n")
@@ -292,7 +320,7 @@ func (m *Manager) generateNetdev(ifc InterfaceConfig) string {
 	fmt.Fprintf(&b, "Name=%s\n", ifc.Name)
 	b.WriteString("Kind=bond\n")
 	if ifc.Description != "" {
-		fmt.Fprintf(&b, "Description=%s\n", ifc.Description)
+		fmt.Fprintf(&b, "Description=%s\n", sanitizeUnitValue(ifc.Description))
 	}
 	if ifc.MTU > 0 {
 		fmt.Fprintf(&b, "MTUBytes=%d\n", ifc.MTU)
@@ -328,7 +356,7 @@ func (m *Manager) generateBridgeNetdev(ifc InterfaceConfig) string {
 	fmt.Fprintf(&b, "Name=%s\n", ifc.Name)
 	b.WriteString("Kind=bridge\n")
 	if ifc.Description != "" {
-		fmt.Fprintf(&b, "Description=%s\n", ifc.Description)
+		fmt.Fprintf(&b, "Description=%s\n", sanitizeUnitValue(ifc.Description))
 	}
 	if ifc.MTU > 0 {
 		fmt.Fprintf(&b, "MTUBytes=%d\n", ifc.MTU)
@@ -359,7 +387,7 @@ func (m *Manager) generateLink(ifc InterfaceConfig) string {
 		fmt.Fprintf(&b, "Duplex=%s\n", ifc.Duplex)
 	}
 	if ifc.Description != "" {
-		fmt.Fprintf(&b, "Description=%s\n", ifc.Description)
+		fmt.Fprintf(&b, "Description=%s\n", sanitizeUnitValue(ifc.Description))
 	}
 	return b.String()
 }

--- a/pkg/networkd/networkd_test.go
+++ b/pkg/networkd/networkd_test.go
@@ -594,3 +594,38 @@ func TestApply_BridgeExpectedFiles(t *testing.T) {
 		t.Error("missing bridge member .network file")
 	}
 }
+
+// #1798 belt test: a description carrying an embedded newline must not
+// inject extra directives into any generated unit, even if commit-time
+// validation were bypassed.
+func TestGenerateUnits_NewlineDescriptionDoesNotInject(t *testing.T) {
+	m := New()
+	desc := "lan\nDHCP=ipv4"
+
+	cases := map[string]string{
+		"netdev": m.generateNetdev(InterfaceConfig{Name: "reth0", Description: desc}),
+		"bridge": m.generateBridgeNetdev(InterfaceConfig{Name: "br0", Description: desc}),
+		"link": m.generateLink(InterfaceConfig{
+			Name: "trust0", MACAddress: "52:54:00:aa:bb:cc", Description: desc,
+		}),
+	}
+	for name, got := range cases {
+		for _, line := range strings.Split(got, "\n") {
+			if strings.TrimSpace(line) == "DHCP=ipv4" {
+				t.Errorf("%s: injected directive leaked into unit:\n%s", name, got)
+			}
+		}
+		if !strings.Contains(got, "Description=lan DHCP=ipv4\n") {
+			t.Errorf("%s: sanitized description missing:\n%s", name, got)
+		}
+	}
+}
+
+func TestSanitizeUnitValue(t *testing.T) {
+	if got := sanitizeUnitValue("plain"); got != "plain" {
+		t.Errorf("clean value altered: %q", got)
+	}
+	if got := sanitizeUnitValue("a\nb\rc\x7f"); got != "a b c " {
+		t.Errorf("control chars not stripped: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Unit **U7** of the [#1800 plan](https://github.com/psaab/xpf/issues/1800) (§5.3). A newline in a quoted config string (e.g. interface description `"lan\nDHCP=ipv4"`) rendered verbatim into generated systemd-networkd units, injecting arbitrary directives. Three layers + migration, exactly per the converged plan:

1. **Strict-path-only commit rejection:** `compileExpanded` hard-rejects the full C0 set + DEL in all tree values/annotations, gated by a `compileOpts` flag set **only** in the lenient constructors' absence — verified configstore is the sole strict-`CompileConfig*` caller (Commit/CommitCheck paths). **`SchemaValidate` untouched** — the lenient path `Load()` runs it too, and rejecting there would brick boot (the AGY plan constraint).
2. **Sanitize-with-warning on Load/SyncApply:** the lenient compile scrubs the clone + warns, and the *stored tree* is scrubbed via `config.SanitizeTreeControlChars` so the next unrelated commit can't mysteriously fail (the Codex migration requirement — proven by test).
3. **Render-side belt:** sanitizers at networkd Description= writers (.netdev/.link), 11 FRR free-text sites (BGP/OSPF/RIP/IS-IS descriptions+passwords), and swanctl section-names/ids/PSKs. Kea (JSON-escaped) and linksetup (kernel-validated ifnames) audited and left with reasons.
4. **Regression gates:** persisted-newline config Loads+boots+warns; strict commit rejects (flat, hierarchical, annotation); belt tests prove no injected directive even with validation bypassed.

Closes #1798.

**Release note:** commit now rejects control characters (C0+DEL, incl. tab) in any config value; pre-existing persisted values are sanitized with a warning at load.

## Validation
`go build ./...` clean; config/configstore/networkd/frr/ipsec/daemon tests ok; DualAST harness green; independently re-run. Gate: batch smoke post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)