### PR TITLE
#1805: bound gRPC/HTTP request-path exec sites

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4707,3 +4707,7 @@ top.
 - **Timestamp**: 2026-06-10
   **Action**: "#1805 commit 1 — grpcapi bounded request-path exec: new exec_timeout.go (outputTimeout/combinedOutputTimeout/runTimeout, 15s+5s WaitDelay, clampTailLines), converted 13 raw exec sites (server_show_status.go ×4 Output, server_show_system.go ×4 NTP chain w/ ctx plumb, server_show.go ×2 incl tail clamp, server_diag.go ×3 power + ×2 neigh flush), WaitDelay parity on streamDiagCmd, tests, README gotcha"
   **File(s)**: pkg/grpcapi/exec_timeout.go, pkg/grpcapi/exec_timeout_test.go, pkg/grpcapi/server_show_status.go, pkg/grpcapi/server_show_system.go, pkg/grpcapi/server_show.go, pkg/grpcapi/server_diag.go, pkg/grpcapi/README.md
+
+- **Timestamp**: 2026-06-10
+  **Action**: "#1805 commit 2 — api bounded request-path exec: new exec_timeout.go (runTimeout only — sole raw sites are power actions; Output variants live in grpcapi sibling), converted system.go reboot/halt to runTimeout(context.Background()), WaitDelay=5s U3-parity on ping/traceroute handlers, tests, README gotcha"
+  **File(s)**: pkg/api/exec_timeout.go, pkg/api/exec_timeout_test.go, pkg/api/system.go, pkg/api/README.md

--- a/_Log.md
+++ b/_Log.md
@@ -4703,3 +4703,7 @@ top.
   persist_failure_test.go (new), README.md}, pkg/api/{server.go, health.go,
   health_test.go, metrics.go, metrics_descriptors.go,
   metrics_persist_degraded_test.go (new), README.md}, pkg/daemon/daemon_run.go
+
+- **Timestamp**: 2026-06-10
+  **Action**: "#1805 commit 1 — grpcapi bounded request-path exec: new exec_timeout.go (outputTimeout/combinedOutputTimeout/runTimeout, 15s+5s WaitDelay, clampTailLines), converted 13 raw exec sites (server_show_status.go ×4 Output, server_show_system.go ×4 NTP chain w/ ctx plumb, server_show.go ×2 incl tail clamp, server_diag.go ×3 power + ×2 neigh flush), WaitDelay parity on streamDiagCmd, tests, README gotcha"
+  **File(s)**: pkg/grpcapi/exec_timeout.go, pkg/grpcapi/exec_timeout_test.go, pkg/grpcapi/server_show_status.go, pkg/grpcapi/server_show_system.go, pkg/grpcapi/server_show.go, pkg/grpcapi/server_diag.go, pkg/grpcapi/README.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -61,3 +61,15 @@ under the daemon's errgroup. Nothing else imports this package.
   design.
 - `CompileHealthFn` may be `nil` when the daemon is in `-no-dataplane`
   mode. All readyz code paths null-check it.
+- Request-path external commands must be time-bounded (#1805): the
+  deferred reboot/halt power actions go through `runTimeout` in
+  `exec_timeout.go` (15s timeout + 5s WaitDelay, mirroring the
+  apply-path contract in `pkg/daemon/exec_timeout.go`, #1794 — not
+  importable here because pkg/daemon imports this package; the
+  Output/CombinedOutput variants live in the pkg/grpcapi sibling copy).
+  Power actions take `context.Background()` — client disconnect must
+  not cancel a confirmed reboot — and keep ignoring errors. The
+  ping/traceroute handlers keep their own 30s/60s request-ctx bounds
+  but set `WaitDelay` so an inherited pipe cannot block past the kill.
+  Do not add raw `exec.Command` calls in handlers: a wedged binary pins
+  the handler goroutine and its HTTP connection.

--- a/pkg/api/exec_timeout.go
+++ b/pkg/api/exec_timeout.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+// Request-path exec bounding (#1805). This mirrors the apply-path helper
+// in pkg/daemon/exec_timeout.go (#1794), which is the contract reference
+// for the 15s/5s constants. It cannot be imported here: pkg/daemon
+// imports pkg/api (daemon_run.go), so a shared helper would create an
+// import cycle. pkg/grpcapi carries the sibling copy with the
+// Output/CombinedOutput variants; this package's only raw exec sites
+// are the deferred power actions, so only the Run variant exists here —
+// add the other variants from pkg/grpcapi/exec_timeout.go if a future
+// handler needs command output.
+
+// requestExecTimeout bounds the child process runtime; on expiry the
+// process is killed and the error reflects the context deadline.
+const requestExecTimeout = 15 * time.Second
+
+// requestExecWaitDelay caps the post-kill pipe-drain window (see the
+// WaitDelay rationale in pkg/daemon/exec_timeout.go): without it, Wait
+// blocks until every inherited write end of the output pipes closes,
+// which may be long after the main process dies. Hard ceiling per exec
+// becomes its context timeout + 5s.
+const requestExecWaitDelay = 5 * time.Second
+
+// runTimeout runs a command under the request-path bound, discarding
+// output (wraps cmd.Run()). Used by the deferred power-action
+// goroutines, which pass context.Background() — a client disconnect
+// must not cancel a confirmed reboot/halt — and ignore the returned
+// error exactly as the raw .Run() calls did.
+func runTimeout(ctx context.Context, name string, args ...string) error {
+	ctx, cancel := context.WithTimeout(ctx, requestExecTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = requestExecWaitDelay
+	return cmd.Run()
+}

--- a/pkg/api/exec_timeout_test.go
+++ b/pkg/api/exec_timeout_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// runTimeout derives its deadline from the parent ctx via
+// context.WithTimeout(parent, 15s) — the effective deadline is the
+// earlier of the two. The timeout test passes a short parent deadline
+// so the kill path is exercised without waiting out the real 15s
+// constant (same precedent as the pkg/grpcapi helper tests; the
+// pkg/daemon contract reference ships untested).
+
+func TestRunTimeoutSuccess(t *testing.T) {
+	if err := runTimeout(context.Background(), "true"); err != nil {
+		t.Fatalf("runTimeout(true): %v", err)
+	}
+}
+
+func TestRunTimeoutKillsHungCommand(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := runTimeout(parent, "sleep", "30")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("runTimeout: want error for killed command, got nil")
+	}
+	// Bound: 200ms deadline + 5s WaitDelay worst case, with slack.
+	if elapsed > 10*time.Second {
+		t.Fatalf("runTimeout took %v, command was not killed by the deadline", elapsed)
+	}
+}

--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -130,7 +130,11 @@ func (s *Server) pingHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, cmd[0], cmd[1:]...).CombinedOutput()
+	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	// U3 parity (#1805): cap the post-kill pipe-drain window so a child
+	// that inherited the output pipe cannot block Wait past the ctx kill.
+	c.WaitDelay = requestExecWaitDelay
+	out, err := c.CombinedOutput()
 	output := string(out)
 	if err != nil {
 		output += "\n" + err.Error()
@@ -168,7 +172,11 @@ func (s *Server) tracerouteHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, cmd[0], cmd[1:]...).CombinedOutput()
+	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	// U3 parity (#1805): cap the post-kill pipe-drain window so a child
+	// that inherited the output pipe cannot block Wait past the ctx kill.
+	c.WaitDelay = requestExecWaitDelay
+	out, err := c.CombinedOutput()
 	output := string(out)
 	if err != nil {
 		output += "\n" + err.Error()
@@ -258,14 +266,18 @@ func (s *Server) systemActionHandler(w http.ResponseWriter, r *http.Request) {
 	case "reboot":
 		go func() {
 			time.Sleep(1 * time.Second)
-			exec.Command("systemctl", "reboot").Run()
+			// context.Background(): a confirmed power action must not be
+			// cancelled by client disconnect. Errors ignored as before.
+			runTimeout(context.Background(), "systemctl", "reboot")
 		}()
 		writeOK(w, map[string]string{"message": "System going down for reboot NOW!"})
 
 	case "halt":
 		go func() {
 			time.Sleep(1 * time.Second)
-			exec.Command("systemctl", "halt").Run()
+			// context.Background(): a confirmed power action must not be
+			// cancelled by client disconnect. Errors ignored as before.
+			runTimeout(context.Background(), "systemctl", "halt")
 		}()
 		writeOK(w, map[string]string{"message": "System halting NOW!"})
 

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -61,3 +61,15 @@ contract.
 - Server-streaming RPCs (Ping, Traceroute, MonitorPacketDrop,
   MonitorInterface) must drain on client disconnect; cancel the context
   to free buffered output.
+- Request-path external commands (ps, df, ss, journalctl, chronyc,
+  ntpq, timedatectl, tail, ip neigh flush, systemctl power actions)
+  must go through the bounded helpers in `exec_timeout.go` (#1805):
+  `outputTimeout` / `combinedOutputTimeout` / `runTimeout` (15s timeout
+  + 5s WaitDelay, mirroring the apply-path contract in
+  `pkg/daemon/exec_timeout.go`, #1794 — not importable here because
+  pkg/daemon imports this package). Do not add raw `exec.Command` calls
+  in handlers: a wedged binary pins the handler goroutine and its gRPC
+  stream. Power actions take `context.Background()` (client disconnect
+  must not cancel a confirmed reboot); everything else derives from the
+  request ctx. Request-controlled `tail -n N` is additionally clamped
+  via `clampTailLines` — a time bound alone does not cap response bytes.

--- a/pkg/grpcapi/exec_timeout.go
+++ b/pkg/grpcapi/exec_timeout.go
@@ -1,0 +1,80 @@
+package grpcapi
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+// Request-path exec bounding (#1805). This mirrors the apply-path helper
+// in pkg/daemon/exec_timeout.go (#1794), which is the contract reference
+// for the 15s/5s constants. It cannot be imported here: pkg/daemon
+// imports pkg/grpcapi (daemon_run.go), so a shared helper would create
+// an import cycle. The gRPC handlers below external-exec on the request
+// path (ps/df/ss/journalctl/chronyc/ntpq/timedatectl/tail/ip neigh
+// flush/systemctl); without a bound, a wedged binary pins the handler
+// goroutine and its gRPC stream indefinitely.
+//
+// requestExecTimeout bounds the child process runtime; on expiry the
+// process is killed and the error reflects the context deadline.
+const requestExecTimeout = 15 * time.Second
+
+// requestExecWaitDelay caps the post-kill pipe-drain window (see the
+// WaitDelay rationale in pkg/daemon/exec_timeout.go): without it,
+// Output/CombinedOutput block until every inherited write end of the
+// output pipe closes, which may be long after the main process dies.
+// Hard ceiling per exec becomes 15s+5s=20s.
+const requestExecWaitDelay = 5 * time.Second
+
+// outputTimeout runs a command under the request-path bound and returns
+// stdout only (wraps cmd.Output()). Used by sites whose stdout feeds
+// user-visible responses directly — a CombinedOutput variant would leak
+// stderr into them.
+func outputTimeout(ctx context.Context, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, requestExecTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = requestExecWaitDelay
+	return cmd.Output()
+}
+
+// combinedOutputTimeout runs a command under the request-path bound and
+// returns combined stdout+stderr (wraps cmd.CombinedOutput()), for the
+// sites that already surface combined output today.
+func combinedOutputTimeout(ctx context.Context, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, requestExecTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = requestExecWaitDelay
+	return cmd.CombinedOutput()
+}
+
+// runTimeout runs a command under the request-path bound, discarding
+// output (wraps cmd.Run()). Used by the deferred power-action
+// goroutines, which pass context.Background() — a client disconnect
+// must not cancel a confirmed reboot/halt/poweroff — and ignore the
+// returned error exactly as the raw .Run() calls did.
+func runTimeout(ctx context.Context, name string, args ...string) error {
+	ctx, cancel := context.WithTimeout(ctx, requestExecTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = requestExecWaitDelay
+	return cmd.Run()
+}
+
+// clampTailLines bounds the request-controlled `tail -n N` line count to
+// [1, maxTailLines]. The time bound alone is insufficient here: N is
+// attacker/operator-controlled and a huge N against a large log file
+// completes well inside 15s while producing an unbounded response
+// allocation — the byte exposure must be capped independently of time.
+const maxTailLines = 10000
+
+func clampTailLines(n int) int {
+	if n < 1 {
+		return 1
+	}
+	if n > maxTailLines {
+		return maxTailLines
+	}
+	return n
+}

--- a/pkg/grpcapi/exec_timeout_test.go
+++ b/pkg/grpcapi/exec_timeout_test.go
@@ -1,0 +1,82 @@
+package grpcapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The helpers derive their deadline from the parent ctx via
+// context.WithTimeout(parent, 15s) — the effective deadline is the
+// earlier of the two. The timeout tests pass a short parent deadline so
+// the kill path is exercised without waiting out the real 15s constant
+// (pkg/daemon/exec_timeout.go, the contract reference, ships untested;
+// this is the precedent for both per-package helper copies).
+
+func TestOutputTimeoutStdoutOnly(t *testing.T) {
+	out, err := outputTimeout(context.Background(), "sh", "-c", "echo out; echo err 1>&2")
+	if err != nil {
+		t.Fatalf("outputTimeout: %v", err)
+	}
+	if string(out) != "out\n" {
+		t.Fatalf("outputTimeout = %q, want %q (stderr must not leak into stdout-only sites)", out, "out\n")
+	}
+}
+
+func TestCombinedOutputTimeoutMergesStderr(t *testing.T) {
+	out, err := combinedOutputTimeout(context.Background(), "sh", "-c", "echo out; echo err 1>&2")
+	if err != nil {
+		t.Fatalf("combinedOutputTimeout: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "out") || !strings.Contains(s, "err") {
+		t.Fatalf("combinedOutputTimeout = %q, want both stdout and stderr", s)
+	}
+}
+
+func TestCombinedOutputTimeoutKillsHungCommand(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := combinedOutputTimeout(parent, "sleep", "30")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("combinedOutputTimeout: want error for killed command, got nil")
+	}
+	// Bound: 200ms deadline + 5s WaitDelay worst case, with slack.
+	if elapsed > 10*time.Second {
+		t.Fatalf("combinedOutputTimeout took %v, command was not killed by the deadline", elapsed)
+	}
+}
+
+func TestRunTimeoutKillsHungCommand(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := runTimeout(parent, "sleep", "30")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("runTimeout: want error for killed command, got nil")
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("runTimeout took %v, command was not killed by the deadline", elapsed)
+	}
+}
+
+func TestClampTailLines(t *testing.T) {
+	cases := []struct{ in, want int }{
+		{-7, 1},
+		{0, 1},
+		{1, 1},
+		{50, 50},
+		{maxTailLines, maxTailLines},
+		{maxTailLines + 1, maxTailLines},
+		{1 << 30, maxTailLines},
+	}
+	for _, c := range cases {
+		if got := clampTailLines(c.in); got != c.want {
+			t.Errorf("clampTailLines(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/pkg/grpcapi/exec_timeout_test.go
+++ b/pkg/grpcapi/exec_timeout_test.go
@@ -80,3 +80,40 @@ func TestClampTailLines(t *testing.T) {
 		}
 	}
 }
+
+// TestWaitDelayBoundsInheritedPipeDrain pins the WaitDelay half of the
+// contract (Codex review on PR #1818): killing the direct child is not
+// enough — a grandchild that inherited the output pipe keeps
+// CombinedOutput blocked until every write end closes. `sleep 30 &`
+// backgrounds such a grandchild; after the 200ms parent deadline kills
+// the shell, only cmd.WaitDelay (5s) closes the pipes. Without the
+// WaitDelay assignment this test runs ~30s and fails the bound below;
+// with it, ~5.2s.
+func TestWaitDelayBoundsInheritedPipeDrain(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := combinedOutputTimeout(parent, "sh", "-c", "sleep 30 & exec sleep 30")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("want error for killed command, got nil")
+	}
+	if elapsed >= 15*time.Second {
+		t.Fatalf("pipe drain took %v — WaitDelay did not bound the grandchild-held pipe", elapsed)
+	}
+}
+
+// TestOutputTimeoutKillsHungCommand covers the kill path for the
+// stdout-only variant (previously only the fidelity path was tested).
+func TestOutputTimeoutKillsHungCommand(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := outputTimeout(parent, "sleep", "30")
+	if err == nil {
+		t.Fatal("want error for killed command, got nil")
+	}
+	if elapsed := time.Since(start); elapsed >= 10*time.Second {
+		t.Fatalf("kill took %v, want prompt", elapsed)
+	}
+}

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -130,6 +130,9 @@ func streamDiagCmd(ctx context.Context, cmd []string, sendFn func(string) error)
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	// U3 parity (#1805): cap the post-kill pipe-drain window so a child
+	// that inherited the output pipe cannot block Wait past the ctx kill.
+	c.WaitDelay = requestExecWaitDelay
 
 	// Merge stdout and stderr into a single pipe.
 	pr, pw := io.Pipe()
@@ -563,7 +566,9 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 		slog.Warn("system reboot requested via gRPC")
 		go func() {
 			time.Sleep(1 * time.Second)
-			exec.Command("systemctl", "reboot").Run()
+			// context.Background(): a confirmed power action must not be
+			// cancelled by client disconnect. Errors ignored as before.
+			runTimeout(context.Background(), "systemctl", "reboot")
 		}()
 		return &pb.SystemActionResponse{Message: "System going down for reboot NOW!"}, nil
 
@@ -571,7 +576,9 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 		slog.Warn("system halt requested via gRPC")
 		go func() {
 			time.Sleep(1 * time.Second)
-			exec.Command("systemctl", "halt").Run()
+			// context.Background(): a confirmed power action must not be
+			// cancelled by client disconnect. Errors ignored as before.
+			runTimeout(context.Background(), "systemctl", "halt")
 		}()
 		return &pb.SystemActionResponse{Message: "System halting NOW!"}, nil
 
@@ -579,7 +586,9 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 		slog.Warn("system power-off requested via gRPC")
 		go func() {
 			time.Sleep(1 * time.Second)
-			exec.Command("systemctl", "poweroff").Run()
+			// context.Background(): a confirmed power action must not be
+			// cancelled by client disconnect. Errors ignored as before.
+			runTimeout(context.Background(), "systemctl", "poweroff")
 		}()
 		return &pb.SystemActionResponse{Message: "System powering off NOW!"}, nil
 
@@ -613,7 +622,7 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 		return &pb.SystemActionResponse{Message: fmt.Sprintf("Configuration lock cleared (was held by %s)", holder)}, nil
 
 	case "clear-arp":
-		out, err := exec.Command("ip", "-4", "neigh", "flush", "all").CombinedOutput()
+		out, err := combinedOutputTimeout(ctx, "ip", "-4", "neigh", "flush", "all")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "flush ARP: %s", strings.TrimSpace(string(out)))
 		}
@@ -625,7 +634,7 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 		}, nil
 
 	case "clear-ipv6-neighbors":
-		out, err := exec.Command("ip", "-6", "neigh", "flush", "all").CombinedOutput()
+		out, err := combinedOutputTimeout(ctx, "ip", "-6", "neigh", "flush", "all")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "flush IPv6 neighbors: %s", strings.TrimSpace(string(out)))
 		}

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -2,7 +2,6 @@ package grpcapi
 
 import (
 	"context"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -336,7 +335,7 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 
 	case "ntp":
 		// #1043 Phase 7: case body extracted to server_show_system.go
-		s.showNTP(&buf)
+		s.showNTP(ctx, &buf)
 
 	case "system-syslog":
 		// #1043 Phase 7: case body extracted to server_show_system.go
@@ -387,7 +386,7 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		s.showScreen(cfg, &buf)
 
 	case "log":
-		out, err := exec.Command("journalctl", "-u", "xpfd", "-n", "50", "--no-pager").CombinedOutput()
+		out, err := combinedOutputTimeout(ctx, "journalctl", "-u", "xpfd", "-n", "50", "--no-pager")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "journalctl: %v", err)
 		}
@@ -435,14 +434,18 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 		} else if strings.HasPrefix(req.Topic, "log:") {
 			parts := strings.SplitN(req.Topic, ":", 3)
 			filename := filepath.Base(parts[1]) // sanitize path
-			n := "50"
+			n := 50
 			if len(parts) >= 3 {
-				if _, err := strconv.Atoi(parts[2]); err == nil {
-					n = parts[2]
+				if v, err := strconv.Atoi(parts[2]); err == nil {
+					n = v
 				}
 			}
+			// The line count is request-controlled; clamp it because
+			// the 15s exec bound does not limit how many bytes a fast
+			// tail of a huge N can return (see clampTailLines).
+			n = clampTailLines(n)
 			logPath := filepath.Join("/var/log", filename)
-			out, err := exec.Command("tail", "-n", n, logPath).CombinedOutput()
+			out, err := combinedOutputTimeout(ctx, "tail", "-n", strconv.Itoa(n), logPath)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "read %s: %v", logPath, err)
 			}

--- a/pkg/grpcapi/server_show_status.go
+++ b/pkg/grpcapi/server_show_status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -102,7 +101,7 @@ func (s *Server) GetGlobalStats(_ context.Context, _ *pb.GetGlobalStatsRequest) 
 	}, nil
 }
 
-func (s *Server) GetSystemInfo(_ context.Context, req *pb.GetSystemInfoRequest) (*pb.GetSystemInfoResponse, error) {
+func (s *Server) GetSystemInfo(ctx context.Context, req *pb.GetSystemInfoRequest) (*pb.GetSystemInfoResponse, error) {
 	var buf strings.Builder
 
 	switch req.Type {
@@ -166,16 +165,14 @@ func (s *Server) GetSystemInfo(_ context.Context, req *pb.GetSystemInfoRequest) 
 		}
 
 	case "processes":
-		cmd := exec.Command("ps", "aux", "--sort=-rss")
-		out, err := cmd.Output()
+		out, err := outputTimeout(ctx, "ps", "aux", "--sort=-rss")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "running ps: %v", err)
 		}
 		buf.Write(out)
 
 	case "storage":
-		cmd := exec.Command("df", "-h")
-		out, err := cmd.Output()
+		out, err := outputTimeout(ctx, "df", "-h")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "running df: %v", err)
 		}
@@ -220,16 +217,14 @@ func (s *Server) GetSystemInfo(_ context.Context, req *pb.GetSystemInfoRequest) 
 		}
 
 	case "boot-messages":
-		cmd := exec.Command("journalctl", "--boot", "-n", "100", "--no-pager")
-		out, err := cmd.Output()
+		out, err := outputTimeout(ctx, "journalctl", "--boot", "-n", "100", "--no-pager")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "running journalctl: %v", err)
 		}
 		buf.Write(out)
 
 	case "connections":
-		cmd := exec.Command("ss", "-tnp")
-		out, err := cmd.Output()
+		out, err := outputTimeout(ctx, "ss", "-tnp")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "running ss: %v", err)
 		}

--- a/pkg/grpcapi/server_show_system.go
+++ b/pkg/grpcapi/server_show_system.go
@@ -19,9 +19,9 @@
 package grpcapi
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -239,8 +239,10 @@ func (s *Server) showSystemServices(buf *strings.Builder) {
 	}
 }
 
-// showNTP renders configured NTP servers and chronyc/ntpq tracking.
-func (s *Server) showNTP(buf *strings.Builder) {
+// showNTP renders configured NTP servers and chronyc/ntpq tracking. The
+// handler ctx is plumbed in (#1805) so the NTP execs are bounded by the
+// request lifetime in addition to the per-exec timeout.
+func (s *Server) showNTP(ctx context.Context, buf *strings.Builder) {
 	cfg := s.store.ActiveConfig()
 	if cfg == nil {
 		fmt.Fprintln(buf, "No active configuration")
@@ -257,14 +259,21 @@ func (s *Server) showNTP(buf *strings.Builder) {
 	if cfg.System.NTPThreshold > 0 && cfg.System.NTPThresholdAction != "" {
 		fmt.Fprintf(buf, "  Threshold: %d seconds (%s)\n", cfg.System.NTPThreshold, cfg.System.NTPThresholdAction)
 	}
-	if out, err := exec.Command("chronyc", "tracking").CombinedOutput(); err == nil {
+	// Fallback chain: chronyc tracking → (success) chronyc sources;
+	// else ntpq; else timedatectl. Each exec carries its own 15s+5s
+	// bound, so the worst case for this handler is the timeouts
+	// stacking across the chain: 3×20s = 60s if every fallback wedges
+	// (40s on the chronyc success path). That is deliberate — each
+	// step only runs because the previous binary failed, and the
+	// request ctx still cancels the whole chain on client disconnect.
+	if out, err := combinedOutputTimeout(ctx, "chronyc", "tracking"); err == nil {
 		writeChronyTracking(buf, string(out))
-		if src, err := exec.Command("chronyc", "-n", "sources").CombinedOutput(); err == nil {
+		if src, err := combinedOutputTimeout(ctx, "chronyc", "-n", "sources"); err == nil {
 			fmt.Fprintf(buf, "\nNTP sources:\n%s", string(src))
 		}
-	} else if out, err := exec.Command("ntpq", "-pn").CombinedOutput(); err == nil {
+	} else if out, err := combinedOutputTimeout(ctx, "ntpq", "-pn"); err == nil {
 		fmt.Fprintf(buf, "\nNTP peers:\n%s\n", string(out))
-	} else if out, err := exec.Command("timedatectl", "show", "--property=NTPSynchronized", "--value").CombinedOutput(); err == nil {
+	} else if out, err := combinedOutputTimeout(ctx, "timedatectl", "show", "--property=NTPSynchronized", "--value"); err == nil {
 		fmt.Fprintf(buf, "\nNTP synchronized: %s\n", strings.TrimSpace(string(out)))
 	}
 }


### PR DESCRIPTION
Closes #1805. Follow-up to PR #1802 (U3/#1794): the apply-path exec sites are bounded; this bounds the request-reachable ones. Converged plan (3-way: Codex r2 PLAN-READY, AGY r1, Claude SMR) at docs/research/1805-request-execs/plan.md on branch research/1805-request-execs.

## What

A wedged external binary (journalctl on a broken journal, chronyc with a dead chronyd, ss on a stuck kernel) could pin gRPC/HTTP handler goroutines forever. All 17 raw `exec.Command` sites in pkg/grpcapi + pkg/api are now bounded with 15s CommandContext + WaitDelay=5s via per-package helpers (import cycle forbids reusing pkg/daemon's): `outputTimeout` (stdout-only — the 4 status sites feed stdout straight into responses; a CombinedOutput mirror would leak stderr), `combinedOutputTimeout`, and `runTimeout` (deferred power actions on context.Background — client disconnect must not cancel a confirmed reboot; errors stay ignored exactly as today). The three already-CommandContext sites (streamDiagCmd, ping, traceroute) gain WaitDelay for full parity. Request ctx is derived where in scope: showNTP gets a ctx parameter, GetSystemInfo stops discarding its ctx. The request-controlled `tail -n N` is clamped to [1,10000] — a time bound alone doesn't bound a huge fast read.

Every site keeps its exact current error disposition (gRPC-error returns, fallback-chain skips, ignored power errors) — only the unbounded wait changes.

## Tests

Helper tests in both packages drive the kill path via a short parent deadline (the daemon helper ships without tests, so this sets the shape): stdout-only no-stderr-leak, stderr-merge, hung-command kill ×3 variants, and a 7-case tail-clamp table. `go build ./...`, pkg/grpcapi + pkg/api + pkg/daemon suites, and go vet all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)