### PR TITLE
#1787: cheap-first pre-check in learn_dynamic_neighbor

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4703,3 +4703,16 @@ top.
   persist_failure_test.go (new), README.md}, pkg/api/{server.go, health.go,
   health_test.go, metrics.go, metrics_descriptors.go,
   metrics_persist_degraded_test.go (new), README.md}, pkg/daemon/daemon_run.go
+
+- **Timestamp**: 2026-06-10
+  **Action**: #1787 Stage 1 — cheap-first RX learn: stack key array + `pair_write_needed` pure helper + per-key get() pre-check before the #949 bulk insert; linearization + dedup-window semantics documented at the call site; `learn_precheck_tests` unit matrix appended
+  **File(s)**: userspace-dp/src/afxdp/neighbor_dispatch.rs
+- **Timestamp**: 2026-06-10
+  **Action**: #1787 — export `pair_write_needed` under cfg(test) alongside `learn_dynamic_neighbor`
+  **File(s)**: userspace-dp/src/afxdp/mod.rs
+- **Timestamp**: 2026-06-10
+  **Action**: #1787 — integration tests: single-key first-learn (placeholder key never written), vlan pair first-learn, same-MAC no-op pre-check, MAC flip updates both keys, removed-key re-learn
+  **File(s)**: userspace-dp/src/afxdp/forwarding/tests.rs
+- **Timestamp**: 2026-06-10
+  **Action**: #1787 — module header note: learn upsert is cheap-first (write elided when all keys current)
+  **File(s)**: userspace-dp/src/afxdp/neighbor_dispatch.rs

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -2124,6 +2124,118 @@ fn learned_vlan_ingress_neighbor_maps_to_logical_ifindex() {
     );
 }
 
+// #1787: end-state assertions for the cheap-first learn rework. The
+// elision decision itself is covered by the pure-helper matrix in
+// neighbor_dispatch::learn_precheck_tests (map contents cannot
+// distinguish an elided write from an idempotent overwrite).
+
+const LEARN_MAC_A: [u8; 6] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+const LEARN_MAC_B: [u8; 6] = [0x66, 0x55, 0x44, 0x33, 0x22, 0x11];
+
+#[test]
+fn learn_dynamic_neighbor_first_learn_inserts_single_key_without_vlan() {
+    let state = build_forwarding_state(&nat_snapshot());
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100));
+    // reth1.0 has no parent: (24, 0) resolves to logical 24 ==
+    // ingress, so exactly one key is written.
+    learn_dynamic_neighbor(&state, &dynamic_neighbors, 24, 0, ip, LEARN_MAC_A);
+    assert_eq!(
+        dynamic_neighbors.get(&(24, ip)).map(|e| e.mac),
+        Some(LEARN_MAC_A)
+    );
+    // The unused stack-array placeholder key (0, ip) must never leak
+    // into the map.
+    assert!(dynamic_neighbors.get(&(0, ip)).is_none());
+    assert_eq!(dynamic_neighbors.len(), 1);
+}
+
+#[test]
+fn learn_dynamic_neighbor_vlan_first_learn_inserts_both_keys() {
+    let state = build_forwarding_state(&nat_snapshot());
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    let ip = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200));
+    // (11, vlan 80) resolves to logical sub-interface 12: the #949
+    // pair — physical 11 AND logical 12 — is written together.
+    learn_dynamic_neighbor(&state, &dynamic_neighbors, 11, 80, ip, LEARN_MAC_A);
+    assert_eq!(
+        dynamic_neighbors.get(&(11, ip)).map(|e| e.mac),
+        Some(LEARN_MAC_A)
+    );
+    assert_eq!(
+        dynamic_neighbors.get(&(12, ip)).map(|e| e.mac),
+        Some(LEARN_MAC_A)
+    );
+    assert_eq!(dynamic_neighbors.len(), 2);
+}
+
+#[test]
+fn learn_dynamic_neighbor_same_mac_relearn_is_noop_precheck() {
+    let state = build_forwarding_state(&nat_snapshot());
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    let ip = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200));
+    learn_dynamic_neighbor(&state, &dynamic_neighbors, 11, 80, ip, LEARN_MAC_A);
+    // After the first learn, the pre-check decision for the same MAC
+    // must be "no write needed" — this is the steady-state elision.
+    let current = [
+        dynamic_neighbors.get(&(11, ip)).map(|e| e.mac),
+        dynamic_neighbors.get(&(12, ip)).map(|e| e.mac),
+    ];
+    assert!(!pair_write_needed(&current, LEARN_MAC_A));
+    // A second identical learn leaves contents unchanged.
+    learn_dynamic_neighbor(&state, &dynamic_neighbors, 11, 80, ip, LEARN_MAC_A);
+    assert_eq!(
+        dynamic_neighbors.get(&(11, ip)).map(|e| e.mac),
+        Some(LEARN_MAC_A)
+    );
+    assert_eq!(
+        dynamic_neighbors.get(&(12, ip)).map(|e| e.mac),
+        Some(LEARN_MAC_A)
+    );
+    assert_eq!(dynamic_neighbors.len(), 2);
+}
+
+#[test]
+fn learn_dynamic_neighbor_mac_flip_updates_both_keys() {
+    let state = build_forwarding_state(&nat_snapshot());
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    let ip = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200));
+    learn_dynamic_neighbor(&state, &dynamic_neighbors, 11, 80, ip, LEARN_MAC_A);
+    learn_dynamic_neighbor(&state, &dynamic_neighbors, 11, 80, ip, LEARN_MAC_B);
+    assert_eq!(
+        dynamic_neighbors.get(&(11, ip)).map(|e| e.mac),
+        Some(LEARN_MAC_B)
+    );
+    assert_eq!(
+        dynamic_neighbors.get(&(12, ip)).map(|e| e.mac),
+        Some(LEARN_MAC_B)
+    );
+    assert_eq!(dynamic_neighbors.len(), 2);
+}
+
+#[test]
+fn learn_dynamic_neighbor_relearns_removed_key() {
+    let state = build_forwarding_state(&nat_snapshot());
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    let ip = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200));
+    learn_dynamic_neighbor(&state, &dynamic_neighbors, 11, 80, ip, LEARN_MAC_A);
+    // A remove (netlink delete / resolver revoke / manager replace)
+    // takes one half of the pair out. The next learn that reaches
+    // this function pre-check-misses and restores BOTH keys via the
+    // bulk path.
+    dynamic_neighbors.remove(&(12, ip));
+    assert!(dynamic_neighbors.get(&(12, ip)).is_none());
+    learn_dynamic_neighbor(&state, &dynamic_neighbors, 11, 80, ip, LEARN_MAC_A);
+    assert_eq!(
+        dynamic_neighbors.get(&(11, ip)).map(|e| e.mac),
+        Some(LEARN_MAC_A)
+    );
+    assert_eq!(
+        dynamic_neighbors.get(&(12, ip)).map(|e| e.mac),
+        Some(LEARN_MAC_A)
+    );
+}
+
 #[test]
 fn forwarding_resolution_rejects_next_table_loop() {
     let state = build_forwarding_state(&forwarding_snapshot_with_next_table_loop());

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -630,11 +630,12 @@ use neighbor_dispatch::{
     build_missing_neighbor_session_metadata, learn_dynamic_neighbor_from_packet,
     retry_pending_neigh,
 };
-// `learn_dynamic_neighbor` is only referenced by tests in
-// afxdp/forwarding/tests.rs and afxdp/tests.rs; gate its import behind
-// cfg(test) so non-test builds don't trip `unused_imports`.
+// `learn_dynamic_neighbor` / `pair_write_needed` are only referenced
+// by tests in afxdp/forwarding/tests.rs and afxdp/tests.rs; gate the
+// imports behind cfg(test) so non-test builds don't trip
+// `unused_imports`.
 #[cfg(test)]
-use neighbor_dispatch::learn_dynamic_neighbor;
+use neighbor_dispatch::{learn_dynamic_neighbor, pair_write_needed};
 
 // Issue 67.3: disposition / telemetry recording extracted into
 // afxdp/disposition.rs.

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -8,6 +8,9 @@
 // `learn_dynamic_neighbor*` are called from the RX descriptor
 // path when an inbound ARP/NDP advert resolves a previously
 // missing neighbor — they upsert into the dynamic neighbor map.
+// #1787: the upsert is cheap-first — 1-2 single-shard reads elide
+// the write entirely when every key already maps to src_mac, so
+// the 64-shard bulk lock is only taken for genuine changes.
 //
 // `build_missing_neighbor_session_metadata` constructs the
 // SessionMetadata stub used while the neighbor is unresolved
@@ -320,6 +323,17 @@ pub(super) fn learn_dynamic_neighbor_from_packet(
     *last_learned_neighbor = Some(learned);
 }
 
+/// #1787: pure decision helper for the cheap-first RX learn pre-check.
+/// `current` holds the pre-read MAC (or `None` on miss) for each
+/// candidate key; a bulk write is needed iff ANY entry is missing or
+/// differs from `src_mac`. Factored out so the elision decision is
+/// unit-testable directly — an elided write and an idempotent
+/// overwrite leave identical map contents (RX learn bumps no
+/// generation), so map-state comparison alone cannot prove elision.
+pub(super) fn pair_write_needed(current: &[Option<[u8; 6]>], src_mac: [u8; 6]) -> bool {
+    current.iter().any(|mac| *mac != Some(src_mac))
+}
+
 pub(super) fn learn_dynamic_neighbor(
     forwarding: &ForwardingState,
     dynamic_neighbors: &Arc<ShardedNeighborMap>,
@@ -328,21 +342,58 @@ pub(super) fn learn_dynamic_neighbor(
     src_ip: IpAddr,
     src_mac: [u8; 6],
 ) {
-    let mut ifindexes = vec![ingress_ifindex];
+    // #1787: stack array, no per-packet heap alloc. At most 2 keys:
+    // the physical ingress ifindex plus the resolved logical (VLAN
+    // sub-) ifindex when it differs. keys[1] stays an unused
+    // placeholder when n == 1.
+    let mut keys: [(i32, IpAddr); 2] = [(ingress_ifindex, src_ip), (0, src_ip)];
+    let mut n = 1usize;
     if let Some(logical_ifindex) =
         resolve_ingress_logical_ifindex(forwarding, ingress_ifindex, ingress_vlan_id)
     {
         if logical_ifindex > 0 && logical_ifindex != ingress_ifindex {
-            ifindexes.push(logical_ifindex);
+            keys[1] = (logical_ifindex, src_ip);
+            n = 2;
         }
+    }
+    // #1787 cheap-first pre-check: 1-2 single-shard reads replace the
+    // unconditional 64-shard bulk acquisition in the steady state
+    // (every key already maps to src_mac → return with no write, no
+    // bulk lock, no alloc).
+    //
+    // Linearization semantics: a no-op learn linearizes at this
+    // pre-check read. A concurrent remove (netlink FAILED/delete,
+    // resolver authoritative-FAILED revoke, manager replace/bulk
+    // remove) that lands AFTER the read wins — the elided write does
+    // not re-create the entry — and the next packet from this source
+    // that REACHES this function pre-check-misses and re-learns via
+    // the bulk path below.
+    //
+    // Dedup window: the caller sets the per-binding
+    // last_learned_neighbor dedup after this returns (including after
+    // an elided no-op), so identical follow-up packets may not reach
+    // this function until the dedup key changes. That dedup-delayed
+    // re-learn is PRE-EXISTING behavior — a write also set the dedup,
+    // so a remove landing after the write was equally suppressed.
+    // Recovery comes from the same paths as before: a second source
+    // key evicting the 1-entry dedup, the ARP/NDP learn stage
+    // (poll_stages.rs), and the #1769 resolver probe on forwarding
+    // miss.
+    let mut current: [Option<[u8; 6]>; 2] = [None, None];
+    for (slot, key) in current.iter_mut().zip(keys[..n].iter()) {
+        *slot = dynamic_neighbors.get(key).map(|entry| entry.mac);
+    }
+    if !pair_write_needed(&current[..n], src_mac) {
+        return;
     }
     // #949: multi-ifindex insert atomically vs readers — both
     // ingress_ifindex and the resolved logical (VLAN sub-) ifindex
     // get the same MAC under one bulk acquisition so a reader sees
-    // either both or neither, never a stale half.
+    // either both or neither, never a stale half. Genuine changes
+    // (first sighting, MAC flip, removed key) keep this exact path.
     dynamic_neighbors.with_all_shards(|bulk| {
-        for ifindex in ifindexes {
-            bulk.insert((ifindex, src_ip), NeighborEntry { mac: src_mac });
+        for key in &keys[..n] {
+            bulk.insert(*key, NeighborEntry { mac: src_mac });
         }
     });
 }
@@ -901,4 +952,51 @@ mod cold_start_probe_schedule_tests {
     // sweep (incl. the iface-miss no-advance branch) by the
     // `retry_pending_*` dispatch tests in `mirror_tests`. Removed rather than
     // left asserting impossible multi-packet-same-key state (Codex r2).
+}
+
+#[cfg(test)]
+mod learn_precheck_tests {
+    use super::pair_write_needed;
+
+    const MAC: [u8; 6] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+    const OTHER: [u8; 6] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+
+    #[test]
+    fn single_key_current_needs_no_write() {
+        assert!(!pair_write_needed(&[Some(MAC)], MAC));
+    }
+
+    #[test]
+    fn single_key_miss_needs_write() {
+        assert!(pair_write_needed(&[None], MAC));
+    }
+
+    #[test]
+    fn single_key_stale_needs_write() {
+        assert!(pair_write_needed(&[Some(OTHER)], MAC));
+    }
+
+    #[test]
+    fn pair_matrix_any_miss_or_stale_needs_write() {
+        // Full 3x3 matrix over {current, stale, miss} per slot: a
+        // write is needed unless BOTH slots already carry src_mac.
+        let states: [Option<[u8; 6]>; 3] = [Some(MAC), Some(OTHER), None];
+        for a in states {
+            for b in states {
+                let expected = !(a == Some(MAC) && b == Some(MAC));
+                assert_eq!(
+                    pair_write_needed(&[a, b], MAC),
+                    expected,
+                    "slots {a:?}/{b:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn empty_slice_needs_no_write() {
+        // Degenerate: learn_dynamic_neighbor always passes n >= 1.
+        // Pinned so the `any`-over-slice semantics stay explicit.
+        assert!(!pair_write_needed(&[], MAC));
+    }
 }


### PR DESCRIPTION
Closes #1787. Converged plan (3 hostile rounds: Codex ×3, AGY consumer audit, Claude SMR) at docs/research/1787-neighbor-learn/plan.md on branch research/1787-neighbor-learn.

## What

`learn_dynamic_neighbor` ran per validated RX packet and, whenever ≥2 source keys interleaved on a binding (ordinary multi-host traffic — the 1-entry per-binding dedup only absorbs a single key), performed two heap allocations and locked all 64 shards of the neighbor map per packet for a write that almost never changed anything, serializing every other worker's neighbor lookups.

Stage 1 of the plan: a stack key array (`[(i32, IpAddr); 2]` + length) replaces `vec![...]`, and a cheap-first pre-check (1–2 single-shard `get()` reads through the pure, unit-tested `pair_write_needed` helper) elides the write entirely in the steady state. Genuine changes — first sighting, MAC flip, removed key — keep the exact `with_all_shards` bulk pair write, preserving the #949 atomic-pair contract (correctly scoped to this function's writes).

Linearization semantics are documented at the call site: a no-op learn linearizes at the pre-check read, a later-landing remove wins, and the next packet reaching the function re-learns via the miss path. The per-binding dedup-delayed re-learn window is pre-existing (a write also set the dedup) — verified against master and documented, with the recovery paths enumerated.

## Tests

5 unit tests for the decision helper (full {current, stale, miss}² matrix) + 5 integration tests asserting end-state map contents (single-key first-learn with placeholder-leak check, VLAN pair learn, same-MAC no-op, MAC flip updates both keys, removed-key re-learn). Full `cargo test --release`: 1766 passed / 0 failed; 5× flake loop on the learn filter green. The one flake encountered (`wg::engine` snapshot test) was proven pre-existing: 5/20 failures at base `f96290a98` in an untouched module.

Expected perf note: invisible in single-source smoke by design; the win is removing per-packet allocs + the 64-shard serialization point under multi-host traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)