### PR TITLE
#1776: decompose worker_loop — extract setup and debug-report modules

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4757,3 +4757,12 @@ top.
 - **Timestamp**: 2026-06-10
   **Action**: "#1805 commit 2 — api bounded request-path exec: new exec_timeout.go (runTimeout only — sole raw sites are power actions; Output variants live in grpcapi sibling), converted system.go reboot/halt to runTimeout(context.Background()), WaitDelay=5s U3-parity on ping/traceroute handlers, tests, README gotcha"
   **File(s)**: pkg/api/exec_timeout.go, pkg/api/exec_timeout_test.go, pkg/api/system.go, pkg/api/README.md
+- **Timestamp**: 2026-06-10
+  **Action**: "#1776 commit 1 — extract one-shot worker_loop setup into loop_body/setup.rs (pure code motion, v3.1 narrowed plan): thread pin, TSC calibration, ArcSwap load_fulls, binding construction, CoS fast-interface wiring, interrupt pollfds, BPF-map-FD cache, initial cos_status publish, set_tid; returns WorkerLoopSetup destructured into same-named locals — loop body textually unchanged; only delta = 11 `let mut`→`let` (mut moved to destructure site)"
+  **File(s)**: userspace-dp/src/afxdp/worker/loop_body/setup.rs (new), userspace-dp/src/afxdp/worker/loop_body/mod.rs
+- **Timestamp**: 2026-06-10
+  **Action**: "#1776 commit 2 — extract cfg(debug-log) report + stall dump into loop_body/debug_report.rs (module cfg-gated at declaration, release-DCE'd): DbgCounters (44 per-interval fields, single-line default() reset) + accumulate() + emit_periodic_report() + check_and_dump_stall(); AGY CORRECTNESS-1 guard upheld — dbg_last_report_ns + stall_prev_fwd/stall_reported stay plain persistent locals, prev_rx/prev_fwd become scoped pre-reset snapshots; always-on binding_summary build + BindingLiveState publish loop stay inline (Codex r2-3 partition); residue: degraded-path items in bpf_map/mod.rs cfg-gated to match their only (now-gated) callers"
+  **File(s)**: userspace-dp/src/afxdp/worker/loop_body/debug_report.rs (new), userspace-dp/src/afxdp/worker/loop_body/mod.rs, userspace-dp/src/afxdp/bpf_map/mod.rs
+- **Timestamp**: 2026-06-10
+  **Action**: "#1776 commit 3 — module docs: loop_body/mod.rs header (Phase 2 scope + per-tick-stays-inline rationale), worker/README.md Files table rows for setup.rs/debug_report.rs"
+  **File(s)**: userspace-dp/src/afxdp/worker/loop_body/mod.rs, userspace-dp/src/afxdp/worker/README.md, _Log.md

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -884,7 +884,14 @@ pub(super) static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);
 // The pinned map path keeps the historical "fallback" spelling for
 // mixed-version shim compatibility. Operator-facing names use
 // degraded-path terminology.
+//
+// #1776: the only production reader (the per-second degraded-path
+// dump in worker/loop_body/debug_report.rs) is debug-log-gated, so
+// these items are cfg-gated to match (REASON_NAMES is also asserted
+// by unit tests, hence `any(test, ...)`).
+#[cfg(feature = "debug-log")]
 pub(super) const DEGRADED_PATH_STATS_PIN_PATH: &str = "/sys/fs/bpf/xpf/userspace_fallback_stats";
+#[cfg(any(test, feature = "debug-log"))]
 pub(super) const DEGRADED_PATH_REASON_NAMES: &[&str] = &[
     "ctrl_disabled",            // 0
     "parse_fail",               // 1
@@ -904,6 +911,7 @@ pub(super) const DEGRADED_PATH_REASON_NAMES: &[&str] = &[
     "transit_drop",             // 15
 ];
 
+#[cfg(feature = "debug-log")]
 pub(super) fn read_degraded_path_stats() -> Option<Vec<(String, u64)>> {
     let fd = OwnedFd::open_bpf_map(DEGRADED_PATH_STATS_PIN_PATH).ok()?;
     let mut result = Vec::new();

--- a/userspace-dp/src/afxdp/worker/README.md
+++ b/userspace-dp/src/afxdp/worker/README.md
@@ -8,9 +8,16 @@ binding per tick.
 
 `worker_loop` was extracted out of `worker/mod.rs` into `loop_body/`
 in #1326 Phase 1 (PR #1569) when `worker/mod.rs` crossed the 2000-LOC
-modularity gate. The fn body sits in `loop_body/mod.rs` today; the
-per-tick sub-stage decomposition (`setup.rs` / `tick.rs` /
-`poll_drive.rs` / `debug_report.rs`) is queued as follow-up PRs.
+modularity gate. #1776 (Phase 2, narrowed v3.1 scope) carved the two
+cold extractions out of the fn: `loop_body/setup.rs` (one-shot setup,
+returns the loop's initial `WorkerLoopSetup` state) and
+`loop_body/debug_report.rs` (the cfg(debug-log) verbose report /
+stall dump + `DbgCounters`, feature-gated at the `mod` declaration so
+release builds compile none of it). All per-tick logic — including
+the hot `poll_binding` sweep, the ArcSwap config refresh, command
+drain, and the always-on binding diagnostics + `BindingLiveState`
+publish — stays inline in `loop_body/mod.rs` by design (no call
+boundary added to the per-tick path; Codex r1-4).
 
 `BindingWorker` was decomposed into sub-structs in #959 (Phases 1–11).
 Each phase extracted one cluster of fields into a dedicated
@@ -22,7 +29,9 @@ each cluster has a clear ownership boundary.
 | File | Purpose |
 |------|---------|
 | `mod.rs` | `BindingWorker` struct + shared-binding helpers + `pub(crate) use loop_body::worker_loop` re-export. |
-| `loop_body/mod.rs` | `worker_loop` body (extracted in #1326 Phase 1). Per-tick orchestrator; calls `pin_current_thread` (defined in `afxdp/neighbor.rs`) at startup. The sub-stage carve into `setup.rs` / `tick.rs` / `poll_drive.rs` / `debug_report.rs` is a follow-up. |
+| `loop_body/mod.rs` | `worker_loop` body (extracted in #1326 Phase 1; decomposed in #1776). Per-tick orchestrator — all per-tick logic stays inline here. |
+| `loop_body/setup.rs` | #1776 — one-shot cold setup (`worker_loop_setup`): thread pin via `pin_current_thread` (defined in `afxdp/neighbor.rs`), TSC calibration, binding construction, BPF-map-FD cache; returns `WorkerLoopSetup`. |
+| `loop_body/debug_report.rs` | #1776 — cfg(debug-log)-only `DbgCounters` + per-second verbose report (`emit_periodic_report`) + stall dump (`check_and_dump_stall`). Compiled out of release builds. |
 | `lifecycle.rs` | `poll_binding` — the per-poll RX/TX orchestrator. The "central function" extracted in Issue 73 step 2. |
 | `cos.rs` | Per-worker CoS runtime helpers + shared-exact threshold (the empirical sustained per-worker exact throughput ceiling — see comment block in the file for the evidence basis). |
 | `cos_state.rs` | `WorkerCos` (#959 Phase 3) — per-binding CoS-engine state. |

--- a/userspace-dp/src/afxdp/worker/loop_body/debug_report.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/debug_report.rs
@@ -1,0 +1,365 @@
+// #1776 — cfg(debug-log) verbose periodic report + stall dump,
+// extracted from loop_body/mod.rs (pure code motion per the converged
+// v3.1 plan on research/1776-loop-body-decomp).
+//
+// This module holds ONLY the `debug-log`-feature subset of the
+// per-second report block: the `DbgCounters` per-interval counter
+// struct, the giant `DBG w{N}: ...` summary eprintln + degraded-path
+// dump, and the stall detector + per-binding stall dump. The whole
+// module is `#[cfg(feature = "debug-log")]`-gated at its `mod`
+// declaration, so release builds compile none of it — zero release-
+// path risk by construction.
+//
+// The ALWAYS-ON release parts of the original report block stay
+// inline in mod.rs (Codex r2-3 partition): the per-report-tick
+// `binding_summary` diagnostics build (statistics_v2 + SO_ERROR
+// getsockopt syscalls), the per-second `BindingLiveState`
+// publish/reset loop, and the always-on `dbg_last_report_ns`
+// report-cadence timestamp.
+//
+// PERSISTENT debug state (plan v3.1 AGY CORRECTNESS-1): the report
+// timestamp `dbg_last_report_ns` and the cross-interval stall
+// baselines `stall_prev_fwd` / `stall_reported` are deliberately NOT
+// fields of `DbgCounters` — they stay plain locals in `worker_loop`
+// so the interval `DbgCounters::default()` reset cannot wipe them.
+// `prev_rx_total` / `prev_fwd_total` are same-interval snapshots,
+// taken in mod.rs from `dbg` BEFORE the interval reset and consumed
+// by `check_and_dump_stall` in the same report tick.
+
+use super::*;
+
+/// Per-interval debug counters, zeroed each ~1s report tick via a
+/// single `DbgCounters::default()` assignment (replaces the old
+/// 40-line manual `dbg_* = 0` reset, which was a forget-a-counter
+/// hazard). Accumulated from `DebugPollCounters` once per loop tick
+/// by [`DbgCounters::accumulate`]; `tx_tcp_rst` is additionally fed
+/// from per-binding `WorkerTelemetry` inside the binding_summary
+/// build in mod.rs.
+///
+/// Field order mirrors the original `dbg_*` local declaration order.
+#[derive(Default)]
+pub(super) struct DbgCounters {
+    pub(super) rx_total: u64,
+    pub(super) tx_total: u64,
+    pub(super) forward_total: u64,
+    pub(super) local_total: u64,
+    pub(super) session_hit: u64,
+    pub(super) session_miss: u64,
+    pub(super) session_create: u64,
+    pub(super) no_route: u64,
+    pub(super) missing_neigh: u64,
+    /// #1651 B3: dead-host negative-cache fast-fail count.
+    pub(super) neg_neigh_fast_fail: u64,
+    pub(super) policy_deny: u64,
+    pub(super) ha_inactive: u64,
+    pub(super) no_egress_binding: u64,
+    pub(super) build_fail: u64,
+    pub(super) tx_err: u64,
+    pub(super) metadata_err: u64,
+    pub(super) disposition_other: u64,
+    pub(super) enqueue_ok: u64,
+    pub(super) enqueue_inplace: u64,
+    pub(super) enqueue_direct: u64,
+    pub(super) enqueue_copy: u64,
+    pub(super) rx_from_trust: u64,
+    pub(super) rx_from_wan: u64,
+    pub(super) fwd_trust_to_wan: u64,
+    pub(super) fwd_wan_to_trust: u64,
+    pub(super) nat_snat: u64,
+    pub(super) nat_dnat: u64,
+    pub(super) nat_none: u64,
+    pub(super) frame_build_none: u64,
+    pub(super) rx_tcp_rst: u64,
+    pub(super) tx_tcp_rst: u64,
+    pub(super) rx_tcp_fin: u64,
+    pub(super) rx_tcp_synack: u64,
+    pub(super) rx_tcp_zero_window: u64,
+    pub(super) fwd_tcp_fin: u64,
+    pub(super) fwd_tcp_rst: u64,
+    pub(super) fwd_tcp_zero_window: u64,
+    pub(super) rx_bytes_total: u64,
+    pub(super) tx_bytes_total: u64,
+    pub(super) rx_oversized: u64,
+    pub(super) rx_max_frame: u32,
+    pub(super) tx_max_frame: u32,
+    pub(super) seg_needed_but_none: u64,
+}
+
+impl DbgCounters {
+    /// Fold one tick's `DebugPollCounters` into the running interval
+    /// counters (moved verbatim from the post-poll `dbg_* +=
+    /// dbg_poll.*` blocks).
+    pub(super) fn accumulate(&mut self, dbg_poll: &DebugPollCounters) {
+        self.rx_total += dbg_poll.rx;
+        self.tx_total += dbg_poll.tx;
+        self.forward_total += dbg_poll.forward;
+        self.local_total += dbg_poll.local;
+        self.session_hit += dbg_poll.session_hit;
+        self.session_miss += dbg_poll.session_miss;
+        self.session_create += dbg_poll.session_create;
+        self.no_route += dbg_poll.no_route;
+        self.missing_neigh += dbg_poll.missing_neigh;
+        self.neg_neigh_fast_fail += dbg_poll.neg_neigh_fast_fail;
+        self.policy_deny += dbg_poll.policy_deny;
+        self.ha_inactive += dbg_poll.ha_inactive;
+        self.no_egress_binding += dbg_poll.no_egress_binding;
+        self.build_fail += dbg_poll.build_fail;
+        self.tx_err += dbg_poll.tx_err;
+        self.metadata_err += dbg_poll.metadata_err;
+        self.disposition_other += dbg_poll.disposition_other;
+        self.enqueue_ok += dbg_poll.enqueue_ok;
+        self.enqueue_inplace += dbg_poll.enqueue_inplace;
+        self.enqueue_direct += dbg_poll.enqueue_direct;
+        self.enqueue_copy += dbg_poll.enqueue_copy;
+        self.rx_from_trust += dbg_poll.rx_from_trust;
+        self.rx_from_wan += dbg_poll.rx_from_wan;
+        self.fwd_trust_to_wan += dbg_poll.fwd_trust_to_wan;
+        self.fwd_wan_to_trust += dbg_poll.fwd_wan_to_trust;
+        self.nat_snat += dbg_poll.nat_applied_snat;
+        self.nat_dnat += dbg_poll.nat_applied_dnat;
+        self.nat_none += dbg_poll.nat_applied_none;
+        self.frame_build_none += dbg_poll.frame_build_none;
+        self.rx_tcp_rst += dbg_poll.rx_tcp_rst;
+        self.rx_tcp_fin += dbg_poll.rx_tcp_fin;
+        self.rx_tcp_synack += dbg_poll.rx_tcp_synack;
+        self.rx_tcp_zero_window += dbg_poll.rx_tcp_zero_window;
+        self.fwd_tcp_fin += dbg_poll.fwd_tcp_fin;
+        self.fwd_tcp_rst += dbg_poll.fwd_tcp_rst;
+        self.fwd_tcp_zero_window += dbg_poll.fwd_tcp_zero_window;
+        self.rx_bytes_total += dbg_poll.rx_bytes_total;
+        self.tx_bytes_total += dbg_poll.tx_bytes_total;
+        self.rx_oversized += dbg_poll.rx_oversized;
+        if dbg_poll.rx_max_frame > self.rx_max_frame {
+            self.rx_max_frame = dbg_poll.rx_max_frame;
+        }
+        if dbg_poll.tx_max_frame > self.tx_max_frame {
+            self.tx_max_frame = dbg_poll.tx_max_frame;
+        }
+        self.seg_needed_but_none += dbg_poll.seg_needed_but_none;
+    }
+}
+
+/// The per-second verbose summary eprintln + retained-shim degraded-
+/// path dump (moved verbatim; `dbg_X` locals became `dbg.X` fields).
+/// Called once per report interval, before the interval-counter
+/// reset in mod.rs.
+#[inline(never)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit_periodic_report(
+    worker_id: u32,
+    elapsed: u64,
+    dbg: &DbgCounters,
+    session_count: usize,
+    bindings: &[BindingWorker],
+    binding_summary: &str,
+) {
+    let secs = elapsed as f64 / 1_000_000_000.0;
+    eprintln!(
+        "DBG w{}: {:.1}s rx={} tx={} fwd={} local={} sess_hit={} sess_miss={} sess_create={} \
+         no_route={} miss_neigh={} neg_ff={} pol_deny={} ha_inact={} no_egress={} build_fail={} \
+         tx_err={} meta_err={} other={} enq_ok={} enq_ip={} enq_dir={} enq_cp={} sessions={} \
+         DIR:trust_rx={}/wan_rx={}/t2w={}/w2t={} NAT:snat={}/dnat={}/none={}/bld_none={} RST:rx={}/tx={} \
+         SIZE:rx_avg={}/rx_max={}/tx_avg={}/tx_max={}/rx_over={}/seg_miss={} \
+         TCP_RX:fin={}/synack={}/zwin={} TCP_FWD:fin={}/rst={}/zwin={} \
+         CSUM:verified={}/bad_ip={}/bad_l4={} \
+         SESS_BPF:verify_ok={}/verify_fail={}/bpf_entries={} bindings:{}",
+        worker_id,
+        secs,
+        dbg.rx_total,
+        dbg.tx_total,
+        dbg.forward_total,
+        dbg.local_total,
+        dbg.session_hit,
+        dbg.session_miss,
+        dbg.session_create,
+        dbg.no_route,
+        dbg.missing_neigh,
+        dbg.neg_neigh_fast_fail,
+        dbg.policy_deny,
+        dbg.ha_inactive,
+        dbg.no_egress_binding,
+        dbg.build_fail,
+        dbg.tx_err,
+        dbg.metadata_err,
+        dbg.disposition_other,
+        dbg.enqueue_ok,
+        dbg.enqueue_inplace,
+        dbg.enqueue_direct,
+        dbg.enqueue_copy,
+        session_count,
+        dbg.rx_from_trust,
+        dbg.rx_from_wan,
+        dbg.fwd_trust_to_wan,
+        dbg.fwd_wan_to_trust,
+        dbg.nat_snat,
+        dbg.nat_dnat,
+        dbg.nat_none,
+        dbg.frame_build_none,
+        dbg.rx_tcp_rst,
+        dbg.tx_tcp_rst,
+        if dbg.rx_total > 0 {
+            dbg.rx_bytes_total / dbg.rx_total
+        } else {
+            0
+        },
+        dbg.rx_max_frame,
+        if dbg.enqueue_ok > 0 {
+            dbg.tx_bytes_total / dbg.enqueue_ok
+        } else {
+            0
+        },
+        dbg.tx_max_frame,
+        dbg.rx_oversized,
+        dbg.seg_needed_but_none,
+        dbg.rx_tcp_fin,
+        dbg.rx_tcp_synack,
+        dbg.rx_tcp_zero_window,
+        dbg.fwd_tcp_fin,
+        dbg.fwd_tcp_rst,
+        dbg.fwd_tcp_zero_window,
+        CSUM_VERIFIED_TOTAL.swap(0, Ordering::Relaxed),
+        CSUM_BAD_IP_TOTAL.swap(0, Ordering::Relaxed),
+        CSUM_BAD_L4_TOTAL.swap(0, Ordering::Relaxed),
+        SESSION_PUBLISH_VERIFY_OK.swap(0, Ordering::Relaxed),
+        SESSION_PUBLISH_VERIFY_FAIL.swap(0, Ordering::Relaxed),
+        if let Some(b) = bindings.first() {
+            count_bpf_session_entries(b.bpf_maps.session_map_fd)
+        } else {
+            0
+        },
+        binding_summary,
+    );
+    // Non-debug builds: no per-second stats dump (use debug-log feature for verbose output).
+    // Print retained-shim degraded-path stats — tells us WHY
+    // packets stop being redirected to XSK.
+    if let Some(stats) = read_degraded_path_stats() {
+        if !stats.is_empty() {
+            let s: Vec<String> =
+                stats.iter().map(|(n, v)| format!("{n}={v}")).collect();
+            eprintln!("DBG w{}: XDP_DEGRADED: {}", worker_id, s.join(" "));
+        }
+    }
+}
+
+/// Stall detector + per-binding stall dump (moved verbatim from the
+/// `if cfg!(feature = "debug-log")` stall block; the persistent
+/// cross-interval baselines `stall_prev_fwd` / `stall_reported` stay
+/// locals in `worker_loop` and are threaded through as `&mut`).
+///
+/// `prev_rx_total` / `prev_fwd_total` are THIS interval's totals
+/// (snapshotted in mod.rs before the interval-counter reset);
+/// `stall_prev_fwd` is the PREVIOUS interval's fwd count.
+#[inline(never)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn check_and_dump_stall(
+    worker_id: u32,
+    prev_rx_total: u64,
+    prev_fwd_total: u64,
+    stall_prev_fwd: &mut u64,
+    stall_reported: &mut bool,
+    session_count: usize,
+    bindings: &[BindingWorker],
+    sessions: &SessionTable,
+) {
+    if *stall_prev_fwd > 10 && prev_fwd_total == 0 && !*stall_reported {
+        *stall_reported = true;
+        eprintln!(
+            "DBG STALL_DETECTED: w{} two_ago_fwd={} this_interval_fwd={} this_interval_rx={} sessions={}",
+            worker_id, stall_prev_fwd, prev_fwd_total, prev_rx_total, session_count
+        );
+        // Dump comprehensive per-binding state at stall moment
+        for (si, sb) in bindings.iter().enumerate() {
+            use std::fmt::Write;
+            let fill_p = sb.xsk.device.pending();
+            let rx_a = sb.xsk.rx.available_relaxed();
+            let ifl = sb.tx_pipeline.in_flight_prepared_recycles.len() as u32;
+            let ptxp = sb.tx_pipeline.pending_tx_prepared.len() as u32;
+            let ptxl = sb.tx_pipeline.pending_tx_local.len() as u32;
+            let total = sb.tx_pipeline.pending_fill_frames.len() as u32
+                + fill_p
+                + rx_a
+                + sb.tx_pipeline.free_tx_frames.len() as u32
+                + sb.tx_pipeline.outstanding_tx
+                + ifl
+                + sb.scratch.scratch_recycle.len() as u32
+                + ptxp;
+            let raw = diagnose_raw_ring_state(sb.xsk.rx.as_raw_fd());
+            let mut stall_line = format!(
+                "DBG STALL_BINDING[{}]: if={} q={} pfill={} fring={} rxring={} free_tx={} otx={} ifl={} ptxp={} ptxl={} total={}/{}",
+                si,
+                sb.ifindex,
+                sb.queue_id,
+                sb.tx_pipeline.pending_fill_frames.len(),
+                fill_p,
+                rx_a,
+                sb.tx_pipeline.free_tx_frames.len(),
+                sb.tx_pipeline.outstanding_tx,
+                ifl,
+                ptxp,
+                ptxl,
+                total,
+                sb.umem.total_frames(),
+            );
+            if let Some((rxp, rxc, frp, frc, txp, txc, crp, crc)) = raw {
+                let _ = write!(
+                    stall_line,
+                    " RAW:rxP={rxp}/rxC={rxc}/frP={frp}/frC={frc}/txP={txp}/txC={txc}/crP={crp}/crC={crc}"
+                );
+            }
+            if let Ok(Some(stats)) = sb.xsk.device.statistics_v2().map(Some) {
+                let _ = write!(
+                    stall_line,
+                    " xsk:drop={}/rfull={}/fempty={}/tempty={}",
+                    stats.rx_dropped,
+                    stats.rx_ring_full,
+                    stats.rx_fill_ring_empty_descs,
+                    stats.tx_ring_empty_descs
+                );
+            }
+            eprintln!("{stall_line}");
+        }
+        // Dump all session keys for this worker
+        let mut sess_dump = String::new();
+        let mut count = 0;
+        sessions.iter_with_origin(|key, decision, metadata, origin| {
+            if count < 20 {
+                use std::fmt::Write;
+                let _ = write!(
+                    sess_dump,
+                    "\n  SESS: {}:{} -> {}:{} proto={} nat=({:?},{:?}) is_rev={} origin={}",
+                    key.src_ip,
+                    key.src_port,
+                    key.dst_ip,
+                    key.dst_port,
+                    key.protocol,
+                    decision.nat.rewrite_src,
+                    decision.nat.rewrite_dst,
+                    metadata.is_reverse,
+                    origin.as_str(),
+                );
+                count += 1;
+            }
+        });
+        if !sess_dump.is_empty() {
+            eprintln!("DBG STALL_SESSIONS:{sess_dump}");
+        }
+        // Dump degraded-path stats at stall time.
+        if let Some(stats) = read_degraded_path_stats() {
+            if !stats.is_empty() {
+                let s: Vec<String> =
+                    stats.iter().map(|(n, v)| format!("{n}={v}")).collect();
+                eprintln!("DBG STALL_DEGRADED: {}", s.join(" "));
+            }
+        }
+        // Also dump BPF session count
+        if let Some(b) = bindings.first() {
+            eprintln!(
+                "DBG STALL_BPF_SESSIONS: entries={}",
+                count_bpf_session_entries(b.bpf_maps.session_map_fd)
+            );
+        }
+    } else if prev_fwd_total > 0 {
+        *stall_reported = false;
+    }
+    *stall_prev_fwd = prev_fwd_total;
+}

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -16,6 +16,13 @@ use super::*;
 // cache, initial cos_status publish) lives in loop_body/setup.rs.
 mod setup;
 
+// #1776: the cfg(debug-log) verbose per-second report + stall dump +
+// per-interval DbgCounters live in loop_body/debug_report.rs. The
+// module is feature-gated at the declaration so release builds
+// compile none of it.
+#[cfg(feature = "debug-log")]
+mod debug_report;
+
 pub(crate) fn worker_loop(
     worker_id: u32,
     binding_plans: Vec<BindingPlan>,
@@ -108,94 +115,18 @@ pub(crate) fn worker_loop(
     let mut shared_recycles = Vec::with_capacity((RX_BATCH_SIZE as usize).saturating_mul(2));
     // Debug: periodic summary counters
     let mut dbg_last_report_ns = monotonic_nanos();
-    let mut dbg_rx_total = 0u64;
+    // #1776: the per-interval cfg(debug-log) dbg_* counters are
+    // consolidated into debug_report::DbgCounters (single-line
+    // default() reset each report tick). dbg_last_report_ns above and
+    // the stall baselines below are PERSISTENT debug state that
+    // survives across report intervals — deliberately NOT DbgCounters
+    // fields, so the interval reset cannot wipe them (plan v3.1 AGY
+    // CORRECTNESS-1).
     #[cfg(feature = "debug-log")]
-    let mut dbg_tx_total = 0u64;
-    let mut dbg_forward_total = 0u64;
+    let mut dbg = debug_report::DbgCounters::default();
     #[cfg(feature = "debug-log")]
-    let mut dbg_local_total = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_session_hit = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_session_miss = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_session_create = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_no_route = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_missing_neigh = 0u64;
-    // #1651 B3: dead-host negative-cache fast-fail count.
-    #[cfg(feature = "debug-log")]
-    let mut dbg_neg_neigh_fast_fail = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_policy_deny = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_ha_inactive = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_no_egress_binding = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_build_fail = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_tx_err = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_metadata_err = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_disposition_other = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_enqueue_ok = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_enqueue_inplace = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_enqueue_direct = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_enqueue_copy = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_rx_from_trust = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_rx_from_wan = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_fwd_trust_to_wan = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_fwd_wan_to_trust = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_nat_snat = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_nat_dnat = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_nat_none = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_frame_build_none = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_rx_tcp_rst = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_tx_tcp_rst = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_rx_tcp_fin = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_rx_tcp_synack = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_rx_tcp_zero_window = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_fwd_tcp_fin = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_fwd_tcp_rst = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_fwd_tcp_zero_window = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_rx_bytes_total = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_tx_bytes_total = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_rx_oversized = 0u64;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_rx_max_frame = 0u32;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_tx_max_frame = 0u32;
-    #[cfg(feature = "debug-log")]
-    let mut dbg_seg_needed_but_none = 0u64;
-    let mut prev_rx_total = 0u64;
-    let mut prev_fwd_total = 0u64;
     let mut stall_prev_fwd = 0u64;
+    #[cfg(feature = "debug-log")]
     let mut stall_reported = false;
     const DBG_REPORT_INTERVAL_NS: u64 = 1_000_000_000; // 1 second
     // Throttle for BPF conntrack last_seen refresh (~10s).
@@ -682,66 +613,9 @@ pub(crate) fn worker_loop(
             }
         }
         crate::filter::flush_recorded_filter_counters();
-        dbg_rx_total += dbg_poll.rx;
         #[cfg(feature = "debug-log")]
         {
-            dbg_tx_total += dbg_poll.tx;
-        }
-        dbg_forward_total += dbg_poll.forward;
-        #[cfg(feature = "debug-log")]
-        {
-            dbg_local_total += dbg_poll.local;
-            dbg_session_hit += dbg_poll.session_hit;
-            dbg_session_miss += dbg_poll.session_miss;
-            dbg_session_create += dbg_poll.session_create;
-            dbg_no_route += dbg_poll.no_route;
-            dbg_missing_neigh += dbg_poll.missing_neigh;
-            dbg_neg_neigh_fast_fail += dbg_poll.neg_neigh_fast_fail;
-            dbg_policy_deny += dbg_poll.policy_deny;
-            dbg_ha_inactive += dbg_poll.ha_inactive;
-            dbg_no_egress_binding += dbg_poll.no_egress_binding;
-            dbg_build_fail += dbg_poll.build_fail;
-            dbg_tx_err += dbg_poll.tx_err;
-            dbg_metadata_err += dbg_poll.metadata_err;
-        }
-        #[cfg(feature = "debug-log")]
-        {
-            dbg_disposition_other += dbg_poll.disposition_other;
-            dbg_enqueue_ok += dbg_poll.enqueue_ok;
-            dbg_enqueue_inplace += dbg_poll.enqueue_inplace;
-            dbg_enqueue_direct += dbg_poll.enqueue_direct;
-            dbg_enqueue_copy += dbg_poll.enqueue_copy;
-            dbg_rx_from_trust += dbg_poll.rx_from_trust;
-            dbg_rx_from_wan += dbg_poll.rx_from_wan;
-            dbg_fwd_trust_to_wan += dbg_poll.fwd_trust_to_wan;
-            dbg_fwd_wan_to_trust += dbg_poll.fwd_wan_to_trust;
-            dbg_nat_snat += dbg_poll.nat_applied_snat;
-            dbg_nat_dnat += dbg_poll.nat_applied_dnat;
-            dbg_nat_none += dbg_poll.nat_applied_none;
-            dbg_frame_build_none += dbg_poll.frame_build_none;
-        }
-        #[cfg(feature = "debug-log")]
-        {
-            dbg_rx_tcp_rst += dbg_poll.rx_tcp_rst;
-            dbg_rx_tcp_fin += dbg_poll.rx_tcp_fin;
-            dbg_rx_tcp_synack += dbg_poll.rx_tcp_synack;
-            dbg_rx_tcp_zero_window += dbg_poll.rx_tcp_zero_window;
-            dbg_fwd_tcp_fin += dbg_poll.fwd_tcp_fin;
-            dbg_fwd_tcp_rst += dbg_poll.fwd_tcp_rst;
-            dbg_fwd_tcp_zero_window += dbg_poll.fwd_tcp_zero_window;
-        }
-        #[cfg(feature = "debug-log")]
-        {
-            dbg_rx_bytes_total += dbg_poll.rx_bytes_total;
-            dbg_tx_bytes_total += dbg_poll.tx_bytes_total;
-            dbg_rx_oversized += dbg_poll.rx_oversized;
-            if dbg_poll.rx_max_frame > dbg_rx_max_frame {
-                dbg_rx_max_frame = dbg_poll.rx_max_frame;
-            }
-            if dbg_poll.tx_max_frame > dbg_tx_max_frame {
-                dbg_tx_max_frame = dbg_poll.tx_max_frame;
-            }
-            dbg_seg_needed_but_none += dbg_poll.seg_needed_but_none;
+            dbg.accumulate(&dbg_poll);
         }
         if !bindings.is_empty() {
             poll_start = (poll_start + 1) % bindings.len();
@@ -818,7 +692,6 @@ pub(crate) fn worker_loop(
             let elapsed = loop_now_ns.saturating_sub(dbg_last_report_ns);
             if elapsed >= DBG_REPORT_INTERVAL_NS {
                 #[cfg(feature = "debug-log")]
-                let secs = elapsed as f64 / 1_000_000_000.0;
                 let session_count = sessions.len();
                 let mut binding_summary = String::new();
                 for (i, b) in bindings.iter().enumerate() {
@@ -865,7 +738,7 @@ pub(crate) fn worker_loop(
                     // TX pipeline debug counters
                     #[cfg(feature = "debug-log")]
                     {
-                        dbg_tx_tcp_rst += b.telemetry.dbg_tx_tcp_rst;
+                        dbg.tx_tcp_rst += b.telemetry.dbg_tx_tcp_rst;
                     }
                     let _ = write!(
                         binding_summary,
@@ -945,266 +818,49 @@ pub(crate) fn worker_loop(
                     }
                     binding_summary.push(']');
                 }
+                // #1776: the cfg(debug-log) verbose per-second report —
+                // the giant DBG summary eprintln + degraded-path dump —
+                // lives in debug_report.rs. Release builds skip it, as
+                // before (the eprintln was already cfg-gated; the
+                // always-on binding_summary build above is unchanged).
                 #[cfg(feature = "debug-log")]
-                eprintln!(
-                    "DBG w{}: {:.1}s rx={} tx={} fwd={} local={} sess_hit={} sess_miss={} sess_create={} \
-                     no_route={} miss_neigh={} neg_ff={} pol_deny={} ha_inact={} no_egress={} build_fail={} \
-                     tx_err={} meta_err={} other={} enq_ok={} enq_ip={} enq_dir={} enq_cp={} sessions={} \
-                     DIR:trust_rx={}/wan_rx={}/t2w={}/w2t={} NAT:snat={}/dnat={}/none={}/bld_none={} RST:rx={}/tx={} \
-                     SIZE:rx_avg={}/rx_max={}/tx_avg={}/tx_max={}/rx_over={}/seg_miss={} \
-                     TCP_RX:fin={}/synack={}/zwin={} TCP_FWD:fin={}/rst={}/zwin={} \
-                     CSUM:verified={}/bad_ip={}/bad_l4={} \
-                     SESS_BPF:verify_ok={}/verify_fail={}/bpf_entries={} bindings:{}",
+                debug_report::emit_periodic_report(
                     worker_id,
-                    secs,
-                    dbg_rx_total,
-                    dbg_tx_total,
-                    dbg_forward_total,
-                    dbg_local_total,
-                    dbg_session_hit,
-                    dbg_session_miss,
-                    dbg_session_create,
-                    dbg_no_route,
-                    dbg_missing_neigh,
-                    dbg_neg_neigh_fast_fail,
-                    dbg_policy_deny,
-                    dbg_ha_inactive,
-                    dbg_no_egress_binding,
-                    dbg_build_fail,
-                    dbg_tx_err,
-                    dbg_metadata_err,
-                    dbg_disposition_other,
-                    dbg_enqueue_ok,
-                    dbg_enqueue_inplace,
-                    dbg_enqueue_direct,
-                    dbg_enqueue_copy,
+                    elapsed,
+                    &dbg,
                     session_count,
-                    dbg_rx_from_trust,
-                    dbg_rx_from_wan,
-                    dbg_fwd_trust_to_wan,
-                    dbg_fwd_wan_to_trust,
-                    dbg_nat_snat,
-                    dbg_nat_dnat,
-                    dbg_nat_none,
-                    dbg_frame_build_none,
-                    dbg_rx_tcp_rst,
-                    dbg_tx_tcp_rst,
-                    if dbg_rx_total > 0 {
-                        dbg_rx_bytes_total / dbg_rx_total
-                    } else {
-                        0
-                    },
-                    dbg_rx_max_frame,
-                    if dbg_enqueue_ok > 0 {
-                        dbg_tx_bytes_total / dbg_enqueue_ok
-                    } else {
-                        0
-                    },
-                    dbg_tx_max_frame,
-                    dbg_rx_oversized,
-                    dbg_seg_needed_but_none,
-                    dbg_rx_tcp_fin,
-                    dbg_rx_tcp_synack,
-                    dbg_rx_tcp_zero_window,
-                    dbg_fwd_tcp_fin,
-                    dbg_fwd_tcp_rst,
-                    dbg_fwd_tcp_zero_window,
-                    CSUM_VERIFIED_TOTAL.swap(0, Ordering::Relaxed),
-                    CSUM_BAD_IP_TOTAL.swap(0, Ordering::Relaxed),
-                    CSUM_BAD_L4_TOTAL.swap(0, Ordering::Relaxed),
-                    SESSION_PUBLISH_VERIFY_OK.swap(0, Ordering::Relaxed),
-                    SESSION_PUBLISH_VERIFY_FAIL.swap(0, Ordering::Relaxed),
-                    if let Some(b) = bindings.first() {
-                        count_bpf_session_entries(b.bpf_maps.session_map_fd)
-                    } else {
-                        0
-                    },
-                    binding_summary,
+                    &bindings,
+                    &binding_summary,
                 );
-                // Non-debug builds: no per-second stats dump (use debug-log feature for verbose output).
-                // Print retained-shim degraded-path stats — tells us WHY
-                // packets stop being redirected to XSK.
-                if cfg!(feature = "debug-log") {
-                    if let Some(stats) = read_degraded_path_stats() {
-                        if !stats.is_empty() {
-                            let s: Vec<String> =
-                                stats.iter().map(|(n, v)| format!("{n}={v}")).collect();
-                            eprintln!("DBG w{}: XDP_DEGRADED: {}", worker_id, s.join(" "));
-                        }
-                    }
-                }
                 // Save prev counters BEFORE reset for stall detection below
-                if cfg!(feature = "debug-log") {
-                    prev_rx_total = dbg_rx_total;
-                    prev_fwd_total = dbg_forward_total;
-                }
+                #[cfg(feature = "debug-log")]
+                let (prev_rx_total, prev_fwd_total) = (dbg.rx_total, dbg.forward_total);
                 dbg_last_report_ns = loop_now_ns;
-                dbg_rx_total = 0;
+                // #1776 (plan v3.1 AGY CORRECTNESS-1 guard): DbgCounters
+                // holds ONLY per-interval counters, so this single-line
+                // reset must NOT touch the persistent debug state —
+                // dbg_last_report_ns (re-armed above) and the cross-
+                // interval stall baselines stall_prev_fwd /
+                // stall_reported, which live in plain locals; the
+                // same-interval prev_rx_total / prev_fwd_total snapshot
+                // was taken from `dbg` above, BEFORE this reset.
                 #[cfg(feature = "debug-log")]
                 {
-                    dbg_tx_total = 0;
-                }
-                dbg_forward_total = 0;
-                #[cfg(feature = "debug-log")]
-                {
-                    dbg_local_total = 0;
-                    dbg_session_hit = 0;
-                    dbg_session_miss = 0;
-                    dbg_session_create = 0;
-                    dbg_no_route = 0;
-                    dbg_missing_neigh = 0;
-                    dbg_neg_neigh_fast_fail = 0;
-                    dbg_policy_deny = 0;
-                    dbg_ha_inactive = 0;
-                    dbg_no_egress_binding = 0;
-                    dbg_build_fail = 0;
-                    dbg_tx_err = 0;
-                    dbg_metadata_err = 0;
-                }
-                #[cfg(feature = "debug-log")]
-                {
-                    dbg_disposition_other = 0;
-                    dbg_enqueue_ok = 0;
-                    dbg_enqueue_inplace = 0;
-                    dbg_enqueue_direct = 0;
-                    dbg_enqueue_copy = 0;
-                    dbg_rx_from_trust = 0;
-                    dbg_rx_from_wan = 0;
-                    dbg_fwd_trust_to_wan = 0;
-                    dbg_fwd_wan_to_trust = 0;
-                }
-                #[cfg(feature = "debug-log")]
-                {
-                    dbg_rx_bytes_total = 0;
-                    dbg_tx_bytes_total = 0;
-                    dbg_rx_oversized = 0;
-                    dbg_rx_max_frame = 0;
-                    dbg_tx_max_frame = 0;
-                    dbg_seg_needed_but_none = 0;
+                    dbg = debug_report::DbgCounters::default();
                 }
                 // Stall detection: stall_prev_fwd is PREVIOUS interval's fwd count,
                 // prev_fwd_total is THIS interval's fwd count (saved before reset).
-                if cfg!(feature = "debug-log") {
-                    if stall_prev_fwd > 10 && prev_fwd_total == 0 && !stall_reported {
-                        stall_reported = true;
-                        eprintln!(
-                            "DBG STALL_DETECTED: w{} two_ago_fwd={} this_interval_fwd={} this_interval_rx={} sessions={}",
-                            worker_id, stall_prev_fwd, prev_fwd_total, prev_rx_total, session_count
-                        );
-                        // Dump comprehensive per-binding state at stall moment
-                        for (si, sb) in bindings.iter().enumerate() {
-                            use std::fmt::Write;
-                            let fill_p = sb.xsk.device.pending();
-                            let rx_a = sb.xsk.rx.available_relaxed();
-                            let ifl = sb.tx_pipeline.in_flight_prepared_recycles.len() as u32;
-                            let ptxp = sb.tx_pipeline.pending_tx_prepared.len() as u32;
-                            let ptxl = sb.tx_pipeline.pending_tx_local.len() as u32;
-                            let total = sb.tx_pipeline.pending_fill_frames.len() as u32
-                                + fill_p
-                                + rx_a
-                                + sb.tx_pipeline.free_tx_frames.len() as u32
-                                + sb.tx_pipeline.outstanding_tx
-                                + ifl
-                                + sb.scratch.scratch_recycle.len() as u32
-                                + ptxp;
-                            let raw = diagnose_raw_ring_state(sb.xsk.rx.as_raw_fd());
-                            let mut stall_line = format!(
-                                "DBG STALL_BINDING[{}]: if={} q={} pfill={} fring={} rxring={} free_tx={} otx={} ifl={} ptxp={} ptxl={} total={}/{}",
-                                si,
-                                sb.ifindex,
-                                sb.queue_id,
-                                sb.tx_pipeline.pending_fill_frames.len(),
-                                fill_p,
-                                rx_a,
-                                sb.tx_pipeline.free_tx_frames.len(),
-                                sb.tx_pipeline.outstanding_tx,
-                                ifl,
-                                ptxp,
-                                ptxl,
-                                total,
-                                sb.umem.total_frames(),
-                            );
-                            if let Some((rxp, rxc, frp, frc, txp, txc, crp, crc)) = raw {
-                                let _ = write!(
-                                    stall_line,
-                                    " RAW:rxP={rxp}/rxC={rxc}/frP={frp}/frC={frc}/txP={txp}/txC={txc}/crP={crp}/crC={crc}"
-                                );
-                            }
-                            if let Ok(Some(stats)) = sb.xsk.device.statistics_v2().map(Some) {
-                                let _ = write!(
-                                    stall_line,
-                                    " xsk:drop={}/rfull={}/fempty={}/tempty={}",
-                                    stats.rx_dropped,
-                                    stats.rx_ring_full,
-                                    stats.rx_fill_ring_empty_descs,
-                                    stats.tx_ring_empty_descs
-                                );
-                            }
-                            eprintln!("{stall_line}");
-                        }
-                        // Dump all session keys for this worker
-                        let mut sess_dump = String::new();
-                        let mut count = 0;
-                        sessions.iter_with_origin(|key, decision, metadata, origin| {
-                            if count < 20 {
-                                use std::fmt::Write;
-                                let _ = write!(
-                                    sess_dump,
-                                    "\n  SESS: {}:{} -> {}:{} proto={} nat=({:?},{:?}) is_rev={} origin={}",
-                                    key.src_ip,
-                                    key.src_port,
-                                    key.dst_ip,
-                                    key.dst_port,
-                                    key.protocol,
-                                    decision.nat.rewrite_src,
-                                    decision.nat.rewrite_dst,
-                                    metadata.is_reverse,
-                                    origin.as_str(),
-                                );
-                                count += 1;
-                            }
-                        });
-                        if !sess_dump.is_empty() {
-                            eprintln!("DBG STALL_SESSIONS:{sess_dump}");
-                        }
-                        // Dump degraded-path stats at stall time.
-                        if let Some(stats) = read_degraded_path_stats() {
-                            if !stats.is_empty() {
-                                let s: Vec<String> =
-                                    stats.iter().map(|(n, v)| format!("{n}={v}")).collect();
-                                eprintln!("DBG STALL_DEGRADED: {}", s.join(" "));
-                            }
-                        }
-                        // Also dump BPF session count
-                        if let Some(b) = bindings.first() {
-                            eprintln!(
-                                "DBG STALL_BPF_SESSIONS: entries={}",
-                                count_bpf_session_entries(b.bpf_maps.session_map_fd)
-                            );
-                        }
-                    } else if prev_fwd_total > 0 {
-                        stall_reported = false;
-                    }
-                    stall_prev_fwd = prev_fwd_total;
-                }
                 #[cfg(feature = "debug-log")]
-                {
-                    dbg_nat_snat = 0;
-                    dbg_nat_dnat = 0;
-                    dbg_nat_none = 0;
-                    dbg_frame_build_none = 0;
-                }
-                #[cfg(feature = "debug-log")]
-                {
-                    dbg_rx_tcp_rst = 0;
-                    dbg_tx_tcp_rst = 0;
-                    dbg_rx_tcp_fin = 0;
-                    dbg_rx_tcp_synack = 0;
-                    dbg_rx_tcp_zero_window = 0;
-                    dbg_fwd_tcp_fin = 0;
-                    dbg_fwd_tcp_rst = 0;
-                    dbg_fwd_tcp_zero_window = 0;
-                }
+                debug_report::check_and_dump_stall(
+                    worker_id,
+                    prev_rx_total,
+                    prev_fwd_total,
+                    &mut stall_prev_fwd,
+                    &mut stall_reported,
+                    session_count,
+                    &bindings,
+                    &sessions,
+                );
                 for b in bindings.iter_mut() {
                     // #802: publish ring-pressure counters into BindingLiveState
                     // BEFORE resetting the worker-local window. The worker-local

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -11,6 +11,11 @@
 
 use super::*;
 
+// #1776: the one-shot setup phase (thread pin, TSC calibration,
+// initial ArcSwap load_fulls, binding construction, BPF-map-FD
+// cache, initial cos_status publish) lives in loop_body/setup.rs.
+mod setup;
+
 pub(crate) fn worker_loop(
     worker_id: u32,
     binding_plans: Vec<BindingPlan>,
@@ -57,128 +62,47 @@ pub(crate) fn worker_loop(
     cold_path_atomics:
         Arc<crate::afxdp::cold_path_hist::WorkerColdPathAtomics>,
 ) {
-    pin_current_thread(worker_id);
-    // #1620: per-worker cold-path TSC calibration. Runs ONCE at
-    // worker_loop entry, AFTER pin_current_thread has pinned the
-    // worker to its core (so the Instant↔TSC ratio reflects this
-    // core's clock). The probe + calibrate together take ~10 ms
-    // (one-shot 10 ms sleep window + ~80 µs of back-to-back rdtscp
-    // pairs); workers calibrate concurrently across cores so the
-    // wall-clock startup overhead stays at ~10 ms total.
-    //
-    // Per plan v4 §4.6: probe_clock_source runs once; calibration is
-    // skipped (returning 0) when the clock source is not TSC, avoiding
-    // redundant /proc/cpuinfo + /sys probes inside the calibrators.
-    let cp_clock_source =
-        crate::afxdp::cold_path_hist::probe_clock_source();
-    let (cp_ns_per_tsc_q32, cp_wrapper_baseline) =
-        if cp_clock_source == crate::afxdp::cold_path_hist::ClockSource::Tsc {
-            let q32 =
-                crate::afxdp::cold_path_hist::calibrate_ns_per_tsc_q32();
-            let baseline =
-                crate::afxdp::cold_path_hist::calibrate_wrapper_baseline_ns(
-                    q32,
-                );
-            (q32, baseline)
-        } else {
-            (0, 0)
-        };
-    // Single-line startup log per worker (~6 lines total per daemon
-    // startup). Goes to journald via stderr per project logging rules.
-    eprintln!(
-        "xpf-cold-path: worker={} clock_source={} ns_per_tsc_q32={} wrapper_ns_baseline={}",
+    // #1776: one-shot setup moved verbatim to setup.rs. The returned
+    // WorkerLoopSetup is destructured into the same-named locals so
+    // the loop body below is textually unchanged.
+    let setup::WorkerLoopSetup {
+        ha_startup_grace_until_secs,
+        mut validation,
+        mut forwarding,
+        mut cos_owner_worker_by_queue,
+        mut cos_owner_live_by_queue,
+        mut cos_shared_root_leases,
+        mut cos_shared_exact_backlogs,
+        mut cos_shared_queue_leases,
+        mut cos_shared_queue_vtime_floors,
+        mut mirror_targets,
+        mut sessions,
+        mut screen_state,
+        mut bindings,
+        binding_lookup,
+        mut interrupt_poll_fds,
+        session_map_fd,
+        conntrack_v4_fd,
+        conntrack_v6_fd,
+        mut last_cos_status_ns,
+    } = setup::worker_loop_setup(
         worker_id,
-        cp_clock_source.as_str(),
-        cp_ns_per_tsc_q32,
-        cp_wrapper_baseline,
+        binding_plans,
+        &shared_validation,
+        &shared_forwarding,
+        &shared_cos_owner_worker_by_queue,
+        &shared_cos_owner_live_by_queue,
+        &shared_cos_root_leases,
+        &shared_cos_exact_backlogs,
+        &shared_cos_queue_leases,
+        &shared_cos_queue_vtime_floors,
+        &shared_mirror_targets,
+        poll_mode,
+        &cos_status,
+        &runtime_atomics,
+        &cold_path_atomics,
     );
     const COS_STATUS_INTERVAL_NS: u64 = 100_000_000;
-    let ha_startup_grace_until_secs =
-        (monotonic_nanos() / 1_000_000_000).saturating_add(TUNNEL_HA_STARTUP_GRACE_SECS);
-    let mut validation = **shared_validation.load();
-    let mut forwarding = shared_forwarding.load_full();
-    let mut cos_owner_worker_by_queue = shared_cos_owner_worker_by_queue.load_full();
-    let mut cos_owner_live_by_queue = shared_cos_owner_live_by_queue.load_full();
-    let mut cos_shared_root_leases = shared_cos_root_leases.load_full();
-    let mut cos_shared_exact_backlogs = shared_cos_exact_backlogs.load_full();
-    let mut cos_shared_queue_leases = shared_cos_queue_leases.load_full();
-    let mut cos_shared_queue_vtime_floors = shared_cos_queue_vtime_floors.load_full();
-    let mut mirror_targets = shared_mirror_targets.load_full();
-    let mut sessions = SessionTable::new();
-    let mut screen_state = ScreenState::new();
-    screen_state.update_profiles(forwarding.screen_profiles.clone());
-    screen_state.update_syn_cookie_master_key(forwarding.syn_cookie_master_key);
-    sessions.set_timeouts(forwarding.session_timeouts);
-    let mut bindings = Vec::with_capacity(binding_plans.len());
-    let (private_plans, shared_groups) = partition_binding_plans(binding_plans);
-    for plan in private_plans {
-        let live = plan.live.clone();
-        match create_private_binding_from_plan(plan) {
-            Ok(binding) => bindings.push(binding),
-            Err(err) => {
-                eprintln!("xpf-userspace-dp: private binding creation failed: {err}");
-                live.set_error(err.to_string());
-            }
-        }
-    }
-    for (group_key, plans) in shared_groups {
-        match create_shared_binding_group(&group_key, plans) {
-            Ok(mut group_bindings) => bindings.append(&mut group_bindings),
-            Err(err) => fallback_shared_group_to_private(err, &mut bindings),
-        }
-    }
-    bindings.sort_by_key(|binding| (binding.queue_id, binding.ifindex, binding.slot));
-    // #1620: install per-worker cold-path calibration into each
-    // binding's worker-local counters. The calibration values are
-    // shared across all bindings owned by this worker — they reflect
-    // the worker thread's pinned core, not the binding identity.
-    for binding in bindings.iter_mut() {
-        binding.cold_path.ns_per_tsc_q32 = cp_ns_per_tsc_q32;
-        binding.cold_path.wrapper_ns_baseline = cp_wrapper_baseline;
-        binding.cold_path.clock_source = cp_clock_source;
-    }
-    // #1621: install the same calibration into the sibling atomics
-    // so the first /metrics scrape sees q32 + clock_source even
-    // before the first publish-tick fires. install_calibration writes
-    // outside the cold_window_gen seqlock (calibration is set-once;
-    // readers always observe a consistent value).
-    cold_path_atomics.install_calibration(
-        cp_ns_per_tsc_q32,
-        cp_wrapper_baseline,
-        cp_clock_source,
-    );
-    let binding_lookup = WorkerBindingLookup::from_bindings(&bindings);
-    let cos_owner_live_by_tx_ifindex = build_worker_cos_owner_live_by_tx_ifindex(
-        bindings
-            .iter()
-            .map(|binding| (binding.ifindex, binding.live.clone())),
-    );
-    let cos_fast_interfaces = build_worker_cos_fast_interfaces(
-        forwarding.as_ref(),
-        worker_id,
-        &cos_owner_live_by_tx_ifindex,
-        cos_owner_worker_by_queue.as_ref(),
-        cos_owner_live_by_queue.as_ref(),
-        cos_shared_root_leases.as_ref(),
-        cos_shared_exact_backlogs.as_ref(),
-        cos_shared_queue_leases.as_ref(),
-        cos_shared_queue_vtime_floors.as_ref(),
-    );
-    for binding in bindings.iter_mut() {
-        binding.cos.cos_fast_interfaces = cos_fast_interfaces.clone();
-    }
-    let mut interrupt_poll_fds = if poll_mode == crate::PollMode::Interrupt {
-        bindings
-            .iter()
-            .map(|binding| libc::pollfd {
-                fd: binding.xsk.device.as_raw_fd(),
-                events: libc::POLLIN,
-                revents: 0,
-            })
-            .collect::<Vec<_>>()
-    } else {
-        Vec::new()
-    };
     let mut idle_iters = 0u32;
     let mut poll_start = 0usize;
     let mut shared_recycles = Vec::with_capacity((RX_BATCH_SIZE as usize).saturating_mul(2));
@@ -278,36 +202,17 @@ pub(crate) fn worker_loop(
     // Keeps `show security flow session` idle times accurate without
     // per-second syscall overhead per session.  See issue #333.
     const CT_REFRESH_INTERVAL_NS: u64 = 10_000_000_000;
-    // Cache BPF map FDs — they don't change during the worker's lifetime.
-    let session_map_fd = bindings
-        .first()
-        .map(|binding| binding.bpf_maps.session_map_fd)
-        .unwrap_or(-1);
-    let conntrack_v4_fd = bindings
-        .first()
-        .map(|binding| binding.bpf_maps.conntrack_v4_fd)
-        .unwrap_or(-1);
-    let conntrack_v6_fd = bindings
-        .first()
-        .map(|binding| binding.bpf_maps.conntrack_v6_fd)
-        .unwrap_or(-1);
     let mut last_ct_refresh_ns: u64 = 0;
-    cos_status.store(Arc::new(build_worker_cos_statuses(
-        &bindings,
-        forwarding.as_ref(),
-    )));
-    let mut last_cos_status_ns = monotonic_nanos();
     // #869: worker-runtime telemetry.  Local counters, published to
     // `runtime_atomics` on the ~1s cadence below.
     use crate::afxdp::worker_runtime::{
-        WorkerRuntimeCounters, WorkerRuntimeState, current_tid, sample_thread_cpu_ns,
+        WorkerRuntimeCounters, WorkerRuntimeState, sample_thread_cpu_ns,
     };
     let mut wr_counters = WorkerRuntimeCounters::default();
     let mut wr_state = WorkerRuntimeState::IdleBlock;
     let mut wr_last_loop_ns = monotonic_nanos();
     let mut wr_last_publish_ns = wr_last_loop_ns;
     const WR_PUBLISH_INTERVAL_NS: u64 = 1_000_000_000;
-    runtime_atomics.set_tid(current_tid());
     while !stop.load(Ordering::Relaxed) {
         let loop_now_ns = monotonic_nanos();
         // #869: attribute elapsed delta to the previous loop's state.

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -1,9 +1,19 @@
 // #1326 — extracted from worker/mod.rs (pure code motion).
 // The `worker_loop` per-tick orchestrator was previously a ~1278 LOC
-// function in worker/mod.rs (L995-L2273). It is moved here verbatim
-// as the first phase of the #1326 refactor; subsequent phases will
-// carve named tick sub-fns out of this file (setup/tick/poll_drive/
-// debug_report) per plan v4.0 (docs/pr/1326-worker-loop-extract/plan.md).
+// function in worker/mod.rs (L995-L2273), moved here verbatim as the
+// first phase of the #1326 refactor.
+//
+// #1776 (Phase 2, narrowed v3.1 scope) carved out the two cold
+// extractions: the one-shot setup phase (setup.rs) and the
+// cfg(debug-log) verbose report / stall dump (debug_report.rs).
+// Everything per-tick — telemetry publish, ArcSwap config refresh,
+// HA load, command drain, the hot `poll_binding` sweep, heartbeat,
+// the always-on binding diagnostics + BindingLiveState publish, and
+// idle regulation — deliberately stays INLINE in this file: the
+// round-1 plan review (Codex r1-4) established that an
+// #[inline(never)] call boundary in front of the per-tick
+// `load_arc_if_changed` path risks regressing the 10K-100K ticks/s
+// loop, so no call was added to the per-tick path.
 //
 // `use super::*;` brings every type, helper, and sibling-submodule
 // item from worker/mod.rs into scope — the same pattern lifecycle.rs

--- a/userspace-dp/src/afxdp/worker/loop_body/setup.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/setup.rs
@@ -1,0 +1,235 @@
+// #1776 — one-shot `worker_loop` setup, extracted from
+// loop_body/mod.rs (pure code motion per the converged v3.1 plan on
+// research/1776-loop-body-decomp).
+//
+// Everything here runs EXACTLY ONCE per worker thread, before the
+// main `loop {}` in `worker_loop`: thread pinning, cold-path TSC
+// calibration, the initial ArcSwap `load_full`s, binding
+// construction from plans, CoS fast-interface wiring, the
+// interrupt-mode pollfd set, the BPF-map-FD cache, and the initial
+// `cos_status` publish. The returned `WorkerLoopSetup` is
+// destructured back into the same-named locals in `worker_loop`, so
+// the loop body itself is textually unchanged.
+//
+// Cold by construction (`#[inline(never)]`): hoisting this out of
+// `worker_loop` shrinks the hot function without adding any call
+// boundary to the per-tick path.
+//
+// `use super::*;` chains through loop_body/mod.rs to worker/mod.rs —
+// the same glob pattern lifecycle.rs and loop_body/mod.rs use.
+
+use super::*;
+
+use crate::afxdp::worker_runtime::current_tid;
+
+/// Initial mutable state for the worker loop, produced once by
+/// [`worker_loop_setup`]. Field order mirrors construction order in
+/// the original inline setup block.
+pub(super) struct WorkerLoopSetup {
+    pub(super) ha_startup_grace_until_secs: u64,
+    pub(super) validation: ValidationState,
+    pub(super) forwarding: Arc<ForwardingState>,
+    pub(super) cos_owner_worker_by_queue: Arc<BTreeMap<(i32, u8), u32>>,
+    pub(super) cos_owner_live_by_queue: Arc<BTreeMap<(i32, u8), Arc<BindingLiveState>>>,
+    pub(super) cos_shared_root_leases: Arc<BTreeMap<i32, Arc<SharedCoSRootLease>>>,
+    pub(super) cos_shared_exact_backlogs: Arc<BTreeMap<i32, Arc<SharedCoSExactBacklog>>>,
+    pub(super) cos_shared_queue_leases: Arc<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>,
+    pub(super) cos_shared_queue_vtime_floors:
+        Arc<BTreeMap<(i32, u8), Arc<SharedCoSQueueVtimeFloor>>>,
+    pub(super) mirror_targets: Arc<MirrorTargetMap>,
+    pub(super) sessions: SessionTable,
+    pub(super) screen_state: ScreenState,
+    pub(super) bindings: Vec<BindingWorker>,
+    pub(super) binding_lookup: WorkerBindingLookup,
+    pub(super) interrupt_poll_fds: Vec<libc::pollfd>,
+    pub(super) session_map_fd: c_int,
+    pub(super) conntrack_v4_fd: c_int,
+    pub(super) conntrack_v6_fd: c_int,
+    pub(super) last_cos_status_ns: u64,
+}
+
+/// One-shot worker setup (moved verbatim from the head of
+/// `worker_loop`; only binding `mut`-ness and variable access
+/// changed — statements, order, and side-effect sequence are
+/// preserved).
+#[inline(never)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn worker_loop_setup(
+    worker_id: u32,
+    binding_plans: Vec<BindingPlan>,
+    shared_validation: &ArcSwap<ValidationState>,
+    shared_forwarding: &ArcSwap<ForwardingState>,
+    shared_cos_owner_worker_by_queue: &ArcSwap<BTreeMap<(i32, u8), u32>>,
+    shared_cos_owner_live_by_queue: &ArcSwap<BTreeMap<(i32, u8), Arc<BindingLiveState>>>,
+    shared_cos_root_leases: &ArcSwap<BTreeMap<i32, Arc<SharedCoSRootLease>>>,
+    shared_cos_exact_backlogs: &ArcSwap<BTreeMap<i32, Arc<SharedCoSExactBacklog>>>,
+    shared_cos_queue_leases: &ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueLease>>>,
+    shared_cos_queue_vtime_floors: &ArcSwap<BTreeMap<(i32, u8), Arc<SharedCoSQueueVtimeFloor>>>,
+    shared_mirror_targets: &ArcSwap<MirrorTargetMap>,
+    poll_mode: crate::PollMode,
+    cos_status: &ArcSwap<Vec<crate::protocol::CoSInterfaceStatus>>,
+    runtime_atomics: &crate::afxdp::worker_runtime::WorkerRuntimeAtomics,
+    cold_path_atomics: &crate::afxdp::cold_path_hist::WorkerColdPathAtomics,
+) -> WorkerLoopSetup {
+    pin_current_thread(worker_id);
+    // #1620: per-worker cold-path TSC calibration. Runs ONCE at
+    // worker_loop entry, AFTER pin_current_thread has pinned the
+    // worker to its core (so the Instant↔TSC ratio reflects this
+    // core's clock). The probe + calibrate together take ~10 ms
+    // (one-shot 10 ms sleep window + ~80 µs of back-to-back rdtscp
+    // pairs); workers calibrate concurrently across cores so the
+    // wall-clock startup overhead stays at ~10 ms total.
+    //
+    // Per plan v4 §4.6: probe_clock_source runs once; calibration is
+    // skipped (returning 0) when the clock source is not TSC, avoiding
+    // redundant /proc/cpuinfo + /sys probes inside the calibrators.
+    let cp_clock_source =
+        crate::afxdp::cold_path_hist::probe_clock_source();
+    let (cp_ns_per_tsc_q32, cp_wrapper_baseline) =
+        if cp_clock_source == crate::afxdp::cold_path_hist::ClockSource::Tsc {
+            let q32 =
+                crate::afxdp::cold_path_hist::calibrate_ns_per_tsc_q32();
+            let baseline =
+                crate::afxdp::cold_path_hist::calibrate_wrapper_baseline_ns(
+                    q32,
+                );
+            (q32, baseline)
+        } else {
+            (0, 0)
+        };
+    // Single-line startup log per worker (~6 lines total per daemon
+    // startup). Goes to journald via stderr per project logging rules.
+    eprintln!(
+        "xpf-cold-path: worker={} clock_source={} ns_per_tsc_q32={} wrapper_ns_baseline={}",
+        worker_id,
+        cp_clock_source.as_str(),
+        cp_ns_per_tsc_q32,
+        cp_wrapper_baseline,
+    );
+    let ha_startup_grace_until_secs =
+        (monotonic_nanos() / 1_000_000_000).saturating_add(TUNNEL_HA_STARTUP_GRACE_SECS);
+    let validation = **shared_validation.load();
+    let forwarding = shared_forwarding.load_full();
+    let cos_owner_worker_by_queue = shared_cos_owner_worker_by_queue.load_full();
+    let cos_owner_live_by_queue = shared_cos_owner_live_by_queue.load_full();
+    let cos_shared_root_leases = shared_cos_root_leases.load_full();
+    let cos_shared_exact_backlogs = shared_cos_exact_backlogs.load_full();
+    let cos_shared_queue_leases = shared_cos_queue_leases.load_full();
+    let cos_shared_queue_vtime_floors = shared_cos_queue_vtime_floors.load_full();
+    let mirror_targets = shared_mirror_targets.load_full();
+    let mut sessions = SessionTable::new();
+    let mut screen_state = ScreenState::new();
+    screen_state.update_profiles(forwarding.screen_profiles.clone());
+    screen_state.update_syn_cookie_master_key(forwarding.syn_cookie_master_key);
+    sessions.set_timeouts(forwarding.session_timeouts);
+    let mut bindings = Vec::with_capacity(binding_plans.len());
+    let (private_plans, shared_groups) = partition_binding_plans(binding_plans);
+    for plan in private_plans {
+        let live = plan.live.clone();
+        match create_private_binding_from_plan(plan) {
+            Ok(binding) => bindings.push(binding),
+            Err(err) => {
+                eprintln!("xpf-userspace-dp: private binding creation failed: {err}");
+                live.set_error(err.to_string());
+            }
+        }
+    }
+    for (group_key, plans) in shared_groups {
+        match create_shared_binding_group(&group_key, plans) {
+            Ok(mut group_bindings) => bindings.append(&mut group_bindings),
+            Err(err) => fallback_shared_group_to_private(err, &mut bindings),
+        }
+    }
+    bindings.sort_by_key(|binding| (binding.queue_id, binding.ifindex, binding.slot));
+    // #1620: install per-worker cold-path calibration into each
+    // binding's worker-local counters. The calibration values are
+    // shared across all bindings owned by this worker — they reflect
+    // the worker thread's pinned core, not the binding identity.
+    for binding in bindings.iter_mut() {
+        binding.cold_path.ns_per_tsc_q32 = cp_ns_per_tsc_q32;
+        binding.cold_path.wrapper_ns_baseline = cp_wrapper_baseline;
+        binding.cold_path.clock_source = cp_clock_source;
+    }
+    // #1621: install the same calibration into the sibling atomics
+    // so the first /metrics scrape sees q32 + clock_source even
+    // before the first publish-tick fires. install_calibration writes
+    // outside the cold_window_gen seqlock (calibration is set-once;
+    // readers always observe a consistent value).
+    cold_path_atomics.install_calibration(
+        cp_ns_per_tsc_q32,
+        cp_wrapper_baseline,
+        cp_clock_source,
+    );
+    let binding_lookup = WorkerBindingLookup::from_bindings(&bindings);
+    let cos_owner_live_by_tx_ifindex = build_worker_cos_owner_live_by_tx_ifindex(
+        bindings
+            .iter()
+            .map(|binding| (binding.ifindex, binding.live.clone())),
+    );
+    let cos_fast_interfaces = build_worker_cos_fast_interfaces(
+        forwarding.as_ref(),
+        worker_id,
+        &cos_owner_live_by_tx_ifindex,
+        cos_owner_worker_by_queue.as_ref(),
+        cos_owner_live_by_queue.as_ref(),
+        cos_shared_root_leases.as_ref(),
+        cos_shared_exact_backlogs.as_ref(),
+        cos_shared_queue_leases.as_ref(),
+        cos_shared_queue_vtime_floors.as_ref(),
+    );
+    for binding in bindings.iter_mut() {
+        binding.cos.cos_fast_interfaces = cos_fast_interfaces.clone();
+    }
+    let interrupt_poll_fds = if poll_mode == crate::PollMode::Interrupt {
+        bindings
+            .iter()
+            .map(|binding| libc::pollfd {
+                fd: binding.xsk.device.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    // Cache BPF map FDs — they don't change during the worker's lifetime.
+    let session_map_fd = bindings
+        .first()
+        .map(|binding| binding.bpf_maps.session_map_fd)
+        .unwrap_or(-1);
+    let conntrack_v4_fd = bindings
+        .first()
+        .map(|binding| binding.bpf_maps.conntrack_v4_fd)
+        .unwrap_or(-1);
+    let conntrack_v6_fd = bindings
+        .first()
+        .map(|binding| binding.bpf_maps.conntrack_v6_fd)
+        .unwrap_or(-1);
+    cos_status.store(Arc::new(build_worker_cos_statuses(
+        &bindings,
+        forwarding.as_ref(),
+    )));
+    let last_cos_status_ns = monotonic_nanos();
+    runtime_atomics.set_tid(current_tid());
+    WorkerLoopSetup {
+        ha_startup_grace_until_secs,
+        validation,
+        forwarding,
+        cos_owner_worker_by_queue,
+        cos_owner_live_by_queue,
+        cos_shared_root_leases,
+        cos_shared_exact_backlogs,
+        cos_shared_queue_leases,
+        cos_shared_queue_vtime_floors,
+        mirror_targets,
+        sessions,
+        screen_state,
+        bindings,
+        binding_lookup,
+        interrupt_poll_fds,
+        session_map_fd,
+        conntrack_v4_fd,
+        conntrack_v6_fd,
+        last_cos_status_ns,
+    }
+}


### PR DESCRIPTION
Closes #1776. Converged PLAN-READY plan (3-way, narrowed v3.1) at docs/research/1776-loop-body-decomp/plan.md on research/1776-loop-body-decomp.

## What

Pure code motion, exactly the narrowed scope: the one-shot setup phase (thread pin, TSC calibration, ArcSwap loads, binding construction, CoS wiring, pollfds, FD cache — 235 LOC) moves to `loop_body/setup.rs` behind a cold `#[inline(never)]` returning a struct destructured into same-named locals, and the cfg(debug-log) periodic report + stall dump (365 LOC, 44-field `DbgCounters`) moves to `loop_body/debug_report.rs` with the module cfg-gated at declaration so release builds compile none of it. All per-tick logic, the always-on binding diagnostics, and the per-second live-state publish stay inline per the plan's partition.

`loop_body/mod.rs`: 1462 → 1023 LOC; `worker_loop` ~1448 → 998.

## Neutrality evidence

Moved-region diffs are empty modulo 11 `let mut`→`let` (mut moved to the destructure) and the mechanical `dbg_X`→`dbg.X` renames; the release-view (cfg-stripped) loop-body diff is identical except 5 dead debug-only statements rustc already flagged; codegen: `worker_loop` 32,694→26,173 B with the setup split into a separate 7,125 B cold symbol and zero debug_report symbols in release; warning count exactly at the 139 baseline in both feature configs. Both plan guards verified: the DbgCounters reset cannot wipe `dbg_last_report_ns`/stall baselines (plain persistent locals; pre-reset snapshots), and the cfg line-partition is proven by the release-view diff.

## Tests

Full `cargo test --release` 1845/0; 5× flake loops on the worker and degraded-path filters green; Go suite 34 packages ok. Under debug-log, one unrelated flake (`worker_queue::concurrent_recovery…`, #1807's race test) reproduced 1/10 at base `a05a73694` — pre-existing, file untouched.

Post-merge: this rides the wave-end smoke (failover + Pass A line rate) before the campaign closes — worker-loop motion is gated on that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)