### PR TITLE
#1831: export V_min throttle counters; equal-flow smoke injector

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -4786,3 +4786,7 @@ top.
 - **Timestamp**: 2026-06-10
   **Action**: "#1819 commit 2 — api sibling alignment: pingHandler 30s → pingExecTimeout(count) (same formula copy in pkg/api/exec_timeout.go, cross-referenced), tracerouteHandler 60s → shared diagTracerouteTimeout constant; mirror table tests, README sentence"
   **File(s)**: pkg/api/exec_timeout.go, pkg/api/exec_timeout_test.go, pkg/api/system.go, pkg/api/README.md
+
+- **Timestamp**: 2026-06-10
+  **Action**: "#1831 commit 1 — export the per-binding V_min throttle counters (#941/#943, already on the BindingStatus wire since protocol.go:1197-1198; verified Rust serializes them in protocol/binding.rs — no Rust change) to Prometheus following the #1771-§2.6/#1807 pattern: two NewDesc with {binding_slot,queue_id,worker_id,iface} labels + Describe + emitBindingVMinThrottleCounters per-binding loop (emits 0s, counters CounterValue); descriptor-coverage canary fixture+want-list extended; emit-level label/value/type pin test incl. zero-binding; fairness-regimes.md metric catalog entries"
+  **File(s)**: pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go, pkg/api/metrics_descriptor_coverage_test.go, pkg/api/metrics_test.go, docs/fairness-regimes.md

--- a/_Log.md
+++ b/_Log.md
@@ -4790,3 +4790,7 @@ top.
 - **Timestamp**: 2026-06-10
   **Action**: "#1831 commit 1 — export the per-binding V_min throttle counters (#941/#943, already on the BindingStatus wire since protocol.go:1197-1198; verified Rust serializes them in protocol/binding.rs — no Rust change) to Prometheus following the #1771-§2.6/#1807 pattern: two NewDesc with {binding_slot,queue_id,worker_id,iface} labels + Describe + emitBindingVMinThrottleCounters per-binding loop (emits 0s, counters CounterValue); descriptor-coverage canary fixture+want-list extended; emit-level label/value/type pin test incl. zero-binding; fairness-regimes.md metric catalog entries"
   **File(s)**: pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go, pkg/api/metrics_descriptor_coverage_test.go, pkg/api/metrics_test.go, docs/fairness-regimes.md
+
+- **Timestamp**: 2026-06-10
+  **Action**: "#1831 commit 2 — apply-cos-config.sh opt-in equal-flow injector: COS_EQUAL_FLOW=1 env var appends `set class-of-service schedulers <name> equal-flow-enforcement` (knob spelling per schema.go:880 / compiler_equal_flow_worker_cap_test.go) for every transmit-rate-exact scheduler in the selected fixture, mirroring the --surplus-sharing awk injector; fail-fast exit 2 on COS_EQUAL_FLOW=1 + --surplus-sharing (compiler rejects both knobs on one scheduler, compiler.go:573); default behavior unchanged; usage header + cos-validation-notes.md injector paragraph"
+  **File(s)**: test/incus/apply-cos-config.sh, docs/cos-validation-notes.md

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -620,6 +620,19 @@ than re-running. The accompanying fixture at
 `test/incus/cos-iperf-config.set` covers both `family inet` and
 `family inet6` classifier state.
 
+Opt-in injectors layered onto the selected fixture: the
+`--surplus-sharing` flag (#915) and `COS_EQUAL_FLOW=1` (#1831,
+follow-up to #1766/#1745) each append one presence-only scheduler
+flag line — `surplus-sharing` or `equal-flow-enforcement` (#1304)
+respectively — per transmit-rate-exact scheduler. They are mutually
+exclusive (the compiler rejects a scheduler carrying both). Default
+invocations apply the fixture unchanged; equal-flow enforcement stays
+default-OFF unless `COS_EQUAL_FLOW=1` is exported:
+
+```bash
+COS_EQUAL_FLOW=1 ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
+```
+
 See also the "CoS deploy preserves config" bullet in
 [`engineering-style.md`](engineering-style.md#project-specific-reminders).
 

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -862,6 +862,20 @@ the sweep exit `2`; they do not produce a false-green fairness verdict.
   from pure RSS/flow-placement skew. Like the current-value gauge, this
   is reset after each publish and should be interpreted alongside the
   per-binding completion rate.
+- **`xpf_userspace_binding_v_min_throttles_total{binding_slot=..., queue_id=..., worker_id=..., iface=...}`**
+  counter (#1831, follow-up to #1766): V_min fairness-brake throttle
+  decisions on the binding's shared-exact CoS queues — a drain batch
+  early-broke because the queue's virtual time ran more than
+  LAG_THRESHOLD ahead of the slowest participating peer worker's V_min
+  (#917/#943). Non-zero under load confirms the cross-worker brake is
+  engaged.
+- **`xpf_userspace_binding_v_min_throttle_hard_cap_overrides_total{binding_slot=..., queue_id=..., worker_id=..., iface=...}`**
+  counter (#1831): V_MIN_CONSECUTIVE_SKIP_HARD_CAP escape-hatch
+  activations — after that many back-to-back throttle decisions the
+  drain force-continues and arms suspension (#941 work item D).
+  Counted distinctly from (not a subset of) the throttle counter; the
+  overrides/throttles ratio is the diagnostic for LAG_THRESHOLD tuned
+  too tight.
 
 Operators tracking this contract in production monitor the gap
 `(observed_cov - cstruct)` and the starved-flow counter. A

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -199,6 +199,14 @@ type xpfCollector struct {
 	bindingTXCompletions                *prometheus.Desc
 	bindingTXCompletionRingAvailable    *prometheus.Desc
 	bindingTXCompletionRingAvailableMax *prometheus.Desc
+	// #1831 (follow-up to #1766): per-binding V_min fairness-throttle
+	// counters (#941 work item D / #943). Already on the wire in
+	// BindingStatus; these export them to Prometheus. v_min_throttles
+	// is "fairness brake fired"; hard-cap overrides is "brake too
+	// tight, escape hatch rescued throughput" — the ratio is the
+	// LAG_THRESHOLD diagnostic.
+	bindingVMinThrottles                *prometheus.Desc
+	bindingVMinThrottleHardCapOverrides *prometheus.Desc
 	// #1248: class-specific active flow distribution by egress CoS
 	// queue. This is the production/mixed-workload {a_i} source.
 	cosActiveFlowCount *prometheus.Desc
@@ -392,6 +400,8 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.bindingTXCompletions
 	ch <- c.bindingTXCompletionRingAvailable
 	ch <- c.bindingTXCompletionRingAvailableMax
+	ch <- c.bindingVMinThrottles
+	ch <- c.bindingVMinThrottleHardCapOverrides
 	ch <- c.cosActiveFlowCount
 	ch <- c.fairnessCstruct
 	ch <- c.fairnessActiveWorkers

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -245,6 +245,9 @@ func populatedCoverageStatus() dpuserspace.ProcessStatus {
 				TXCompletions:                123,
 				TXCompletionRingAvailable:    10,
 				TXCompletionRingAvailableMax: 20,
+				// #1831: per-binding V_min throttle counters (always emit).
+				VMinThrottles:                51,
+				VMinThrottleHardCapOverrides: 2,
 			},
 		},
 		CoSActiveFlowCounts: []dpuserspace.CoSActiveFlowCountStatus{
@@ -425,6 +428,9 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_userspace_neighbor_netlink_redump_upserts_total",
 		"xpf_userspace_neighbor_pending_keys",
 		"xpf_userspace_neg_neigh_keys",
+		// #1831: per-binding V_min fairness-throttle counters (#941/#943)
+		"xpf_userspace_binding_v_min_throttles_total",
+		"xpf_userspace_binding_v_min_throttle_hard_cap_overrides_total",
 	}
 	if ifaceResolvable {
 		want = append(want, "xpf_interface_packets_total") // collectInterfaceCounters (lo)

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -696,6 +696,30 @@ func newCollector(srv *Server) *xpfCollector {
 			"Maximum sampled AF_XDP TX completion-ring descriptors available in the last debug window (#1241).",
 			[]string{"binding_slot", "queue_id", "worker_id", "iface"}, nil,
 		),
+		// #1831 (follow-up to #1766): per-binding V_min fairness-throttle
+		// counters (#941 work item D / #943), already carried in
+		// BindingStatus on the wire but previously unexported.
+		bindingVMinThrottles: prometheus.NewDesc(
+			"xpf_userspace_binding_v_min_throttles_total",
+			"V_min fairness-brake throttle decisions on this binding's "+
+				"shared-exact CoS queues: a drain batch early-broke because the "+
+				"queue's virtual time ran more than LAG_THRESHOLD ahead of the "+
+				"slowest participating peer worker's V_min (#917/#943). Non-zero "+
+				"under load confirms the cross-worker brake is engaged; the "+
+				"hard-cap-overrides / throttles ratio is the diagnostic for "+
+				"LAG_THRESHOLD tuned too tight.",
+			[]string{"binding_slot", "queue_id", "worker_id", "iface"}, nil,
+		),
+		bindingVMinThrottleHardCapOverrides: prometheus.NewDesc(
+			"xpf_userspace_binding_v_min_throttle_hard_cap_overrides_total",
+			"V_MIN_CONSECUTIVE_SKIP_HARD_CAP escape-hatch activations on this "+
+				"binding: after that many back-to-back V_min throttle decisions "+
+				"the drain force-continues and arms suspension — 'brake too "+
+				"tight, escape hatch rescued throughput' (#941 work item D). "+
+				"Counted distinctly from (not a subset of) "+
+				"xpf_userspace_binding_v_min_throttles_total.",
+			[]string{"binding_slot", "queue_id", "worker_id", "iface"}, nil,
+		),
 		cosActiveFlowCount: prometheus.NewDesc(
 			"xpf_userspace_cos_active_flow_count",
 			"Distinct active flows observed for this egress CoS queue on this worker "+

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1232,6 +1232,77 @@ func TestEmitBindingTXCompletionTelemetry_LabelsAndValues(t *testing.T) {
 	assertGaugeClose(t, got, c.bindingTXCompletionRingAvailableMax, labels, 29)
 }
 
+// #1831: value + type pin for the per-binding V_min fairness-throttle
+// counters (#941 work item D / #943) emitted by
+// emitBindingVMinThrottleCounters. assertCounterClose checks the
+// concrete dto type, so a Counter→Gauge mixup here fails the test.
+// Both series must emit even at 0 (second binding) so "brake never
+// fired" is a real 0 rather than an absent series.
+func TestEmitBindingVMinThrottleCounters_LabelsAndValues(t *testing.T) {
+	bindingLabels := []string{"binding_slot", "queue_id", "worker_id", "iface"}
+	c := &xpfCollector{
+		bindingVMinThrottles: prometheus.NewDesc(
+			"xpf_userspace_binding_v_min_throttles_total",
+			"test desc", bindingLabels, nil,
+		),
+		bindingVMinThrottleHardCapOverrides: prometheus.NewDesc(
+			"xpf_userspace_binding_v_min_throttle_hard_cap_overrides_total",
+			"test desc", bindingLabels, nil,
+		),
+	}
+
+	status := dpuserspace.ProcessStatus{
+		Bindings: []dpuserspace.BindingStatus{
+			{
+				Slot:                         2,
+				QueueID:                      5,
+				WorkerID:                     7,
+				Interface:                    "ge-0-0-1",
+				VMinThrottles:                67,
+				VMinThrottleHardCapOverrides: 59,
+			},
+			{
+				Slot:      3,
+				QueueID:   0,
+				WorkerID:  1,
+				Interface: "ge-0-0-2",
+				// zero counters must still emit
+			},
+		},
+	}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.emitBindingVMinThrottleCounters(ch, status)
+		close(ch)
+	}()
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+	if len(got) != 4 {
+		t.Fatalf("emitBindingVMinThrottleCounters: want 4 metrics (2 bindings x 2 counters), got %d", len(got))
+	}
+
+	labels := map[string]string{
+		"binding_slot": "2",
+		"queue_id":     "5",
+		"worker_id":    "7",
+		"iface":        "ge-0-0-1",
+	}
+	assertCounterClose(t, got, c.bindingVMinThrottles, labels, 67)
+	assertCounterClose(t, got, c.bindingVMinThrottleHardCapOverrides, labels, 59)
+
+	zeroLabels := map[string]string{
+		"binding_slot": "3",
+		"queue_id":     "0",
+		"worker_id":    "1",
+		"iface":        "ge-0-0-2",
+	}
+	assertCounterClose(t, got, c.bindingVMinThrottles, zeroLabels, 0)
+	assertCounterClose(t, got, c.bindingVMinThrottleHardCapOverrides, zeroLabels, 0)
+}
+
 func TestEmitCoSActiveFlowCount_LabelsAndValue(t *testing.T) {
 	c := &xpfCollector{
 		cosActiveFlowCount: prometheus.NewDesc(

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -35,6 +35,7 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp ap
 	c.emitUserspaceEventStream(ch, status)
 	c.emitBindingActiveFlowCount(ch, status)
 	c.emitBindingTXCompletionTelemetry(ch, status)
+	c.emitBindingVMinThrottleCounters(ch, status)
 	c.emitCoSActiveFlowCount(ch, status)
 	c.emitThreeColorPolicerCounters(ch, status)
 	c.emitUserspaceSourceNATPoolMetrics(ch, status)
@@ -437,6 +438,32 @@ func (c *xpfCollector) emitBindingTXCompletionTelemetry(ch chan<- prometheus.Met
 			c.bindingTXCompletionRingAvailableMax,
 			prometheus.GaugeValue,
 			float64(b.TXCompletionRingAvailableMax),
+			slot, queueID, workerID, b.Interface,
+		)
+	}
+}
+
+// #1831 (follow-up to #1766): emit the per-binding V_min
+// fairness-throttle counters (#941 work item D / #943). Both have been
+// on the BindingStatus wire since #941/#943 (flushed from per-queue
+// scratch fields at the helper's ~65ms debug tick) but were never
+// exported. Emitted unconditionally per binding so a 0 is a real
+// "brake never fired" signal rather than an absent series.
+func (c *xpfCollector) emitBindingVMinThrottleCounters(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	for _, b := range status.Bindings {
+		slot := strconv.FormatUint(uint64(b.Slot), 10)
+		queueID := strconv.FormatUint(uint64(b.QueueID), 10)
+		workerID := strconv.FormatUint(uint64(b.WorkerID), 10)
+		ch <- prometheus.MustNewConstMetric(
+			c.bindingVMinThrottles,
+			prometheus.CounterValue,
+			float64(b.VMinThrottles),
+			slot, queueID, workerID, b.Interface,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			c.bindingVMinThrottleHardCapOverrides,
+			prometheus.CounterValue,
+			float64(b.VMinThrottleHardCapOverrides),
 			slot, queueID, workerID, b.Interface,
 		)
 	}

--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -6,7 +6,15 @@
 #   ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
 #   ./test/incus/apply-cos-config.sh --symmetric loss:xpf-userspace-fw0
 #   ./test/incus/apply-cos-config.sh --surplus-sharing loss:xpf-userspace-fw0
+#   COS_EQUAL_FLOW=1 ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0
 #   ./test/incus/apply-cos-config.sh                     # defaults to xpf-userspace-fw0
+#
+# COS_EQUAL_FLOW=1 (#1831, follow-up to #1766/#1745) opts every
+# transmit-rate-exact scheduler in the selected fixture into
+# `equal-flow-enforcement` (#1304) by appending the set lines to the
+# candidate — same injection pattern as --surplus-sharing. Default
+# (unset/0) leaves the fixture untouched. Mutually exclusive with
+# --surplus-sharing: the compiler rejects a scheduler with both knobs.
 #
 # Only the RG0 primary needs the config applied — it replicates to the
 # secondary via config sync. Run against the primary.
@@ -55,6 +63,19 @@ if [[ "$SAME_CLASS" -eq 1 && "$SYMMETRIC" -eq 1 ]]; then
 	exit 2
 fi
 
+# #1831: opt-in equal-flow-enforcement injector. Env var (not a flag)
+# so harness callers can layer it onto any fixture selection without
+# touching positional args. Normalized to 0/1; anything other than
+# literal "1" means off.
+COS_EQUAL_FLOW="${COS_EQUAL_FLOW:-0}"
+if [[ "$COS_EQUAL_FLOW" != "1" ]]; then
+	COS_EQUAL_FLOW=0
+fi
+if [[ "$COS_EQUAL_FLOW" -eq 1 && "$SURPLUS_SHARING" -eq 1 ]]; then
+	echo "error: COS_EQUAL_FLOW=1 and --surplus-sharing are mutually exclusive (the compiler rejects a scheduler with both equal-flow-enforcement and surplus-sharing)" >&2
+	exit 2
+fi
+
 TARGET="${1:-loss:xpf-userspace-fw0}"
 # Copilot D.2: shift past TARGET and reject extra positional
 # arguments so a typo or duplicated argument fails loudly
@@ -97,6 +118,29 @@ if [[ "$SURPLUS_SHARING" -eq 1 ]]; then
 		END {
 			for (sched in exact) {
 				printf "set class-of-service schedulers %s surplus-sharing\n", sched
+			}
+		}
+	' "$SETS_TMP" | sort >> "$SETS_TMP"
+fi
+# #1831: equal-flow-enforcement injection mirrors the surplus-sharing
+# injector above — one presence-only flag line per transmit-rate-exact
+# scheduler (#1304 scopes the knob to positive transmit-rate exact
+# schedulers, which is every `transmit-rate ... exact` line in these
+# fixtures). The atomic commit-check phase below still validates the
+# combined candidate, so an unsupported combination fails before
+# anything live changes.
+if [[ "$COS_EQUAL_FLOW" -eq 1 ]]; then
+	awk '
+		$1 == "set" &&
+		$2 == "class-of-service" &&
+		$3 == "schedulers" &&
+		$5 == "transmit-rate" &&
+		$NF == "exact" {
+			exact[$4] = 1
+		}
+		END {
+			for (sched in exact) {
+				printf "set class-of-service schedulers %s equal-flow-enforcement\n", sched
 			}
 		}
 	' "$SETS_TMP" | sort >> "$SETS_TMP"


### PR DESCRIPTION
Closes #1831 (the two optional follow-ups recorded at #1766's close-out).

**Metrics:** `v_min_throttles` and `hard_cap_overrides` were already on the wire (both BindingStatus views, with round-trip + key-absent pins) but never exported. Added `xpf_userspace_binding_v_min_throttles_total` and `xpf_userspace_binding_v_min_throttle_hard_cap_overrides_total` (per-binding counters, established label set, emitted unconditionally so 0 means the brake never fired) on the #1771/#1807 pattern with descriptor-coverage + emit-level label/value/dto-type tests. Help text corrected against the code: the two counters are disjoint (`v_min.rs:213-229`), not subset-related. Catalog entries added to docs/fairness-regimes.md.

**Injector:** `COS_EQUAL_FLOW=1 ./test/incus/apply-cos-config.sh …` appends `equal-flow-enforcement` (schema.go:880 spelling) to every transmit-rate-exact scheduler in the selected fixture, mirroring the `--surplus-sharing` awk shape, with an exit-2 guard for the mutually-exclusive pair (compiler.go:573) verified live. Defaults unchanged.

go build/tests/gofmt/bash -n all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)