### PR TITLE
docs: record #1827 PR-4 load-share stage killed by research criteria

### DIFF
--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -1,12 +1,22 @@
 # Multi-WAN failover (services rpm + services ip-monitoring)
 
-Status: PR-1 + PR-2 + PR-3 of the #1827 multi-WAN program (plan:
-`docs/research/1827-multiwan/plan.md`). PR-1 delivers probe-driven
-route failover with Junos syntax; PR-2 adds per-policy uplink
-selection (FBF composition); PR-3 defines the NAT interplay
+Status: the #1827 multi-WAN program is COMPLETE at PR-1 + PR-2 + PR-3
+(plan: `docs/research/1827-multiwan/plan.md`). PR-1 delivers
+probe-driven route failover with Junos syntax; PR-2 adds per-policy
+uplink selection (FBF composition); PR-3 defines the NAT interplay
 (per-uplink SNAT pools via existing matchers + session-transition
-semantics, mini-plan: `docs/pr/1827-pr3-nat/plan.md`). Health-gated
-load-sharing is a later PR (§5 of the plan).
+semantics, mini-plan: `docs/pr/1827-pr3-nat/plan.md`). The PR-4
+weights/load-share stage was KILLED by its own research-gate criteria
+(audit of record: `docs/research/1827-pr4-loadshare/plan.md` on the
+`research/1827-pr4-loadshare` branch): the userspace dataplane has no
+ECMP next-hop selection to weight — the FIB flattens multi-next-hop
+routes to the first entry at build time — so any per-flow load-share
+(weighted or equal-cost) would be a new Rust hot-path program with new
+cross-node hash-symmetry invariants, unjustified at 2 uplinks given
+the FBF steering recipe below. Equal-cost or weighted per-flow
+load-balance parity remains unimplemented; if demand materializes it
+is its own issue with its own value case — it is not a multi-WAN
+failover deliverable.
 
 xpf models multi-WAN the way real SRX does — as the composition of
 existing subsystems, not an invented `services multi-wan` tree:


### PR DESCRIPTION
Part of #1827 (PR-4 stage close-out — doc-only).

The PR-4 weights/load-share stage was PLAN-KILLED by its mandated research round (3/3 convergence: Claude SMR + Codex + AGY, two rounds; audit of record at `docs/research/1827-pr4-loadshare/plan.md` on the `research/1827-pr4-loadshare` branch). This micro-PR is the mandatory close-out item from the converged plan (§5; Codex r1 finding 8): amend the `docs/multi-wan.md` status paragraph so the module contract stops promising a later load-share PR, and state explicitly that per-flow load-balance parity remains unimplemented.

Key audit facts behind the kill:
- The userspace dp has no ECMP next-hop selection at all (`forwarding_build/fib.rs:162,196` — `next_hops.first()` at FIB build; `RouteEntryV4/V6` single next-hop; no flow hash in route resolution).
- Synced sessions re-resolve locally (`upsert_synced.rs:39-60`), so any per-flow hash needs new cross-node hash-symmetry + transition-window invariants.
- At 2 uplinks with PR-1 failover + PR-2 health-gated FBF steering + PR-3 per-uplink SNAT shipped, weighted hashing (new-flow-only convergence under session pinning) does not justify a ~1.5-2.5k LOC Rust hot-path program + wire change. Weighted static ECMP has no Junos analog.

Prose-only; no code, no behavior change, no smoke needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
