### PR TITLE
#1741: clamp out-of-window flow-cache stamps to kill epoch-wrap ghost flows

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -5094,3 +5094,12 @@ top.
 - **Timestamp**: 2026-06-10
   **Action**: "#1855 PR #1858 review round complete — Codex r1 NEEDS-CHANGES (1 MEDIUM: session README still said the timer-wheel sweep runs 'by the coordinator', inconsistent with the corrected per-worker ownership) fixed in 71f845fe5 (wheel.rs bullet -> each worker sweeps its own table from its poll loop via expire_stale_entries; GC section -> single-threaded per-worker); Codex r2 MERGE-READY (docs-only confirmed, zero coordinator matches remain); AGY MERGE-READY (5 verified findings incl. per-arm panic trace + both-profile runs); Claude SMR MERGE-READY (worked trace in docs/pr/1855-inplace-contract/claude-smr-review.md); Copilot quota-blocked 3 documented attempts -> 3-of-4. Named tests re-spot-checked green on final head in both profiles (14/14 each)"
   **File(s)**: userspace-dp/src/session/README.md, docs/pr/1855-inplace-contract/{claude-smr-review.md,reviewer-ids.md}, _Log.md
+
+- **Timestamp**: 2026-06-10 ~23:10 PDT
+  **Action**: #1741 fix — sentinel-clear out-of-window flow-cache activity
+  stamps in the debug-cadence scan so u16 epoch-wrap can no longer
+  resurrect dead flows into the active-flow telemetry ("ghost
+  over-count"); 4 pinned regression tests; fairness-regimes gauge
+  contract note.
+  **File(s)**: userspace-dp/src/afxdp/flow_cache.rs,
+  userspace-dp/src/afxdp/flow_cache_tests.rs, docs/fairness-regimes.md

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -367,7 +367,16 @@ Any fairness measurement run MUST report:
    "active" as a flow-cache entry touched within the active-flow
    recency window, currently 10 debug epochs (about 650 ms), so `{a_i}`
    is an operational proxy for worker/RSS placement rather than a
-   throughput-derived ≥1% cutoff.
+   throughput-derived ≥1% cutoff. Since #1741 this definition holds
+   with no wrap exception: the per-scan clamp sentinel-clears stamps
+   that leave the window, so dead flows can no longer "ghost" back
+   into the count when the u16 epoch counter wraps (~65535 ticks).
+   The remaining caveats are (a) the window is elastic — the hot-path
+   epoch tick is call-count-based, so its wall-clock length shrinks
+   under load — and (b) flows whose packets arrive slower than the
+   window (e.g. heavily shaped streams) legitimately drop out of
+   `{a_i}` between packets. Consumers (#1746) get a trustworthy
+   "recently-seen flows" gauge, not a session count.
 5. **Computed `Cstruct`**: the structural CoV ceiling for the
    observed `{aᵢ}`.
 6. **Saturation determination**: which regime the run is in (per

--- a/docs/pr/1741-flow-count/agy-impl-r1.md
+++ b/docs/pr/1741-flow-count/agy-impl-r1.md
@@ -1,0 +1,64 @@
+# PR #1860 — AGY adversarial implementation review (round 1)
+
+Job: adversarial-review-mq92irda-6cp7ob — verdict MERGE-READY (review-only, no writes)
+
+I will search for the definition of the flow cache within `BindingWorker` or related structs to verify its ownership model and thread-safety properties.
+I will search for `active_entry_age` in the codebase to verify that it is only called in test code.
+I will search for `count_active_flows` in the codebase to make sure it is only called in test files or under test configurations.
+I will view `docs/per-5-tuple/state.md` around line 57 to see if there is any outdated mention of `count_active_flows()` or if it accurately reflects the architecture.
+I will run `cargo check --release` in the userspace-dp directory to verify that the codebase compiles cleanly with no errors or unexpected warnings.
+Task 883bc3cb-a15f-406d-bcfb-e88ae7e1d2fc/task-36 has finished. Let's see the output.
+I will run `cargo test --release` in the userspace-dp directory to verify that all the unit tests, including the four new regression tests, pass successfully.
+I will run only the failing wireguard engine test to see if the failure is a flaky test.
+I will run `go test ./...` to check the Go test suite.
+I will search for all references to `tick_advance_epoch` to verify it is only ever called immediately before the scan.
+I will search for all calls to `insert` on `flow_cache` to understand how entries are populated.
+I will view `userspace-dp/src/afxdp/poll_descriptor/mod.rs` around line 2016 to verify the production insert path.
+I will view lines 150 to 180 of `userspace-dp/src/afxdp/flow_cache_tests.rs` using `view_file` to inspect the test at line 166.
+I will view lines 130 to 149 of `userspace-dp/src/afxdp/flow_cache_tests.rs` using `view_file` to check the mutability of `cache`.
+I will view the `count_active_flows_handles_epoch_wraparound` test in `userspace-dp/src/afxdp/flow_cache_tests.rs` to understand how the epoch wraparound is tested and handled.
+I will view lines 1871 to 1905 of `userspace-dp/src/afxdp/flow_cache_tests.rs` using `view_file`.
+I will read `_Log.md` using `view_file` to see the developer log or PR status context.
+I will search for `active_entry_age` across the entire worktree repository to ensure no other component relies on it.
+I will create a comprehensive, adversarial review report as an artifact to outline my findings, verification steps, and verdict.
+An adversarial review has been conducted on the xpf PR #1860 implementation. The complete review has been documented in the markdown artifact [adversarial_review.md](file:///home/ps/.gemini/antigravity-cli/brain/883bc3cb-a15f-406d-bcfb-e88ae7e1d2fc/adversarial_review.md).
+
+Here is a summary of the analysis and findings:
+
+### Verdict: **MERGE-READY**
+
+---
+
+### Detailed Findings & Evidence
+
+#### 1. Correctness of the Clamp
+*   **Boundary Conditions (Age 9 vs 10)**: The clamp logic in [flow_cache.rs:L514-521](file:///home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs#L514-L521) uses `age_epochs >= ACTIVE_WINDOW_EPOCHS` where `ACTIVE_WINDOW_EPOCHS` is 10. Under this condition, age 9 entries are correctly identified as active (not clamped), while age 10 entries trigger the clamp (sentinel-cleared to `0` and skipped via `continue`).
+*   **Interaction with Row Limits**: In [flow_cache.rs:L507-548](file:///home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs#L507-L548), the loop processes *all* entries in `self.entries.iter_mut()`. Even when the row limit is reached (`rows.len() >= limit`), the code sets `truncated = true` and `continue`s, meaning the remaining slots in the flow cache are still scanned and clamped, and their active status is still added to the total `active` count and CoS-specific active counts.
+*   **Sentinel Skip**: Entries with `last_used_epoch == 0` (indicating freshly-inserted or previously-clamped entries) are correctly skipped at [flow_cache.rs:L511-513](file:///home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs#L511-L513) to avoid redundant writes.
+*   **In-Window Parity**: Inside the recency window, the counting semantics remain byte-identical to the original logic.
+
+#### 2. The `&mut` Borrow Fan-Out
+*   The single production caller in [debug_state.rs:L230-234](file:///home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/umem/debug_state.rs#L230-L234) successfully compiles because `binding` is passed as a mutable reference (`&mut BindingWorker`), which mutably owns the flow cache. No other production callers exist. All test callers in [flow_cache_tests.rs](file:///home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache_tests.rs) have been updated to use `&mut cache`.
+
+#### 3. Hot-Path Discipline
+*   **Zero Packet Cost**: The clamp resides entirely within the periodic status/debug cadence scan (`active_flow_debug_entries`), which runs at ~15 Hz (every ~65ms). The hot packet path (`lookup_counted`, `lookup`, and `insert`) is untouched.
+*   **No New Allocations**: The scan allocations (`rows` vector and `cos_counts` map) are identical to master. Writing to `entry.last_used_epoch` is done in-place on cache lines already loaded for reading.
+
+#### 4. The `#[cfg(test)]` Move of `active_entry_age`
+*   No non-test consumers of `active_entry_age` or `count_active_flows` exist in the codebase. Release compilation passes cleanly with no warnings introduced by the change.
+
+#### 5. Regression Tests
+*   The four tests added to [flow_cache_tests.rs:L1906-2076](file:///home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache_tests.rs#L1906-L2076) effectively pin the bug:
+    *   `issue_1741_epoch_wrap_dead_entry_never_resurrects` simulates a wrap-around event and asserts that without the clamp, the entry would resurrect.
+    *   `issue_1741_clean_close_choreography_never_ghosts` accurately models the TCP closing sequence (re-inserting the FIN resets the stamp; the final ACK stamps it with `current_epoch`; and the clamp clears it).
+    *   `issue_1741_window_boundary_counts_age_9_clamps_age_10` verifies the boundary condition.
+    *   `issue_1741_clamped_entry_recoverable_by_hit` confirms that a clamped entry is not evicted and remains hit-recoverable, preserving its telemetry (observed bytes).
+
+#### 6. Docs Accuracy
+*   The contract update in [fairness-regimes.md:L367-378](file:///home/ps/git/bpfrx/.claude/worktrees/1741-engineer/docs/fairness-regimes.md#L367-L378) accurately describes the restored invariant and clarifies the caveats (elastic window under load and shaped/slow-rate streams dropping out).
+
+---
+
+### Residual Design Comments
+
+*   **Finding 1 (Low Severity)**: The test-only helper `count_active_flows()` takes `&self` and does *not* clamp out-of-window entries. While harmless in production (where `tick_advance_epoch` and `active_flow_debug_entries` are always run together), any test simulating large epoch advances (> 65535 ticks) must call `active_flow_debug_entries` to perform the clamp and prevent test-only resurrection false-positives.

--- a/docs/pr/1741-flow-count/claude-smr-impl-r1.md
+++ b/docs/pr/1741-flow-count/claude-smr-impl-r1.md
@@ -1,0 +1,62 @@
+# PR #1860 — Claude SMR hostile implementation review (round 1)
+
+Head reviewed: d199d1767c34. Stance: hostile, line-level.
+
+## Attacks
+
+1. **In-window behavior parity vs master.** The rewritten loop's
+   predicate chain (`None` slot skip → `last_used_epoch == 0` skip →
+   `wrapping_sub` age → `age < ACTIVE_WINDOW_EPOCHS` to count) is the
+   exact De Morgan expansion of master's `active_entry_age` filter;
+   rows/limit/truncated/cos_counts logic is untouched. For any entry
+   with age in [0, 10) the function's outputs are byte-identical to
+   master. The only behavioral delta is the new store for age >= 10
+   entries, which master already excluded from every output.
+   **No regression found.**
+
+2. **Boundary.** Counted iff `age < 10`; clamped iff `age >= 10`. An
+   entry hit at epoch E is counted for current_epoch in [E, E+9] (ages
+   0..9 — 10 epochs ≈ 650 ms) exactly as on master, and cleared at the
+   first scan where age = 10 — the same scan that already excluded it.
+   Pinned by `issue_1741_window_boundary_counts_age_9_clamps_age_10`,
+   which also asserts the in-window stamp is NOT mutated. **Holds.**
+
+3. **Wrap safety of the clamp itself.** Could a stamp survive from age
+   10 up through the wrap because scans stopped running? No: the only
+   way `current_epoch` advances is `tick_advance_epoch`, whose single
+   production call site is immediately followed by this scan
+   (`umem/debug_state.rs:230/234`). No tick, no wrap; tick implies
+   clamp scan. **Airtight.**
+
+4. **&mut fan-out.** Callers: `umem/debug_state.rs:234` (method call on
+   `binding.flow.flow_cache`, `binding: &mut BindingWorker` — auto-ref
+   &mut, compiles) and test code. Full suite compiled and ran: 1943/0.
+   `active_entry_age` is now `#[cfg(test)]`; its only remaining caller
+   `count_active_flows` is already `#[cfg(test)]`. Release warning
+   count == base 138 (checked before/after). **Clean.**
+
+5. **Hot-path discipline.** `lookup`/`insert`/packet path untouched.
+   The clamp adds one compare + conditional u16 store per expired entry
+   in the existing O(4096) debug-cadence scan. No new allocations
+   (rows/cos_counts allocations are master's). **Zero per-packet cost.**
+
+6. **Tests pin the bug.** Mutation check run: with the flow_cache.rs
+   fix reverted (tests kept), `issue_1741_epoch_wrap_dead_entry_never_
+   resurrects`, `issue_1741_clean_close_choreography_never_ghosts`, and
+   the boundary test FAIL (resurrections / missing clamp); the
+   recoverable-by-hit test passes both ways by design (pins the
+   no-eviction + observed_bytes-preservation semantics). The
+   choreography test asserts the FIN re-insert sentinel-clear and the
+   final-ACK re-stamp individually before the wrap loop — faithful to
+   the production close path established in the research round
+   (packet_eligible gate at poll_descriptor/mod.rs:209; slow-path
+   insert at poll_descriptor/mod.rs:1992-2016). **Adequate.**
+
+7. **Docs.** fairness-regimes.md states the restored invariant plus the
+   two honest caveats (elastic window, slower-than-window flows drop
+   out) — no over-claim; matches what #1746 needs. Module comments
+   updated on the field, the helper, and the scan. **Adequate.**
+
+## Verdict
+
+**MERGE-READY.** No findings of any severity.

--- a/docs/pr/1741-flow-count/codex-impl-r1.md
+++ b/docs/pr/1741-flow-count/codex-impl-r1.md
@@ -1,0 +1,25 @@
+=== ATTEMPT 1 ===
+task id: task-mq92ky56-mmfhu4
+--- RESULT ---
+**Findings**
+None.
+
+**Verdict**
+MERGE-READY for `origin/master...d199d1767c34`. Note: the local worktree is currently at `bcbc4823`, one commit past the requested head, but I reviewed the requested diff.
+
+Evidence checked:
+
+- Clamp correctness: [flow_cache.rs:511](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs:511) skips sentinel `0`; [flow_cache.rs:514](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs:514)-[519] clamps `age >= ACTIVE_WINDOW_EPOCHS` before count/export. Age 9 counts, age 10 clears.
+- Limit/truncation safe: active count and `cos_counts` happen before the row-limit branch at [flow_cache.rs:522](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs:522)-[529](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs:529), so all entries are scanned and clamped regardless of `limit`.
+- In-window parity: age math is still `current_epoch.wrapping_sub(last_used_epoch)` with `< ACTIVE_WINDOW_EPOCHS`; only out-of-window entries mutate.
+- `&mut` fan-out: one production caller, [debug_state.rs:230](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/umem/debug_state.rs:230)-[234](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/umem/debug_state.rs:234), already has `&mut BindingWorker`.
+- Hot path: packet path still only reaches lookup at [flow_cache_hit.rs:94](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs:94); clamp runs only from debug publish cadence.
+- `active_entry_age`: now test-only at [flow_cache.rs:465](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs:465); no non-test consumer remains.
+- Tests pin the bug: wrap tests at [flow_cache_tests.rs:1945](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache_tests.rs:1945) and [flow_cache_tests.rs:1973](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache_tests.rs:1973) fail on master behavior; boundary test asserts the clear at [flow_cache_tests.rs:2037](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache_tests.rs:2037)-[2046](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache_tests.rs:2046). The recoverability test is correctly a non-eviction/bytes-preservation guard.
+- Close choreography is faithful: FIN misses fast path because `packet_eligible` requires pure ACK at [flow_cache.rs:221](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs:221)-[223](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs:223), slow path inserts at [poll_descriptor/mod.rs:1995](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/poll_descriptor/mod.rs:1995)-[2017](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/poll_descriptor/mod.rs:2017), and new entries start sentinel-cleared at [flow_cache.rs:376](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs:376)-[379](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/userspace-dp/src/afxdp/flow_cache.rs:379).
+- Docs do not over-claim: [fairness-regimes.md:370](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/docs/fairness-regimes.md:370)-[379](/home/ps/git/bpfrx/.claude/worktrees/1741-engineer/docs/fairness-regimes.md:379) states “recently-seen flows,” not sessions, and keeps the elastic-window caveats.
+
+I did not rerun the full cargo/go gates in this read-only review. `git diff --check origin/master...d199d1767c34` was clean.
+
+Codex session ID: 019eb533-16d7-7a71-8512-c20bd375341d
+Resume in Codex: codex resume 019eb533-16d7-7a71-8512-c20bd375341d

--- a/docs/pr/1741-flow-count/reviewer-ids.md
+++ b/docs/pr/1741-flow-count/reviewer-ids.md
@@ -11,5 +11,5 @@
 ## Implementation phase (this PR)
 - Copilot: (recorded on review)
 - Codex: (recorded on dispatch)
-- AGY: (recorded on dispatch)
+- AGY: adversarial-review-mq92irda-6cp7ob (MERGE-READY r1)
 - Claude SMR: docs/pr/1741-flow-count/claude-smr-impl-r1.md

--- a/docs/pr/1741-flow-count/reviewer-ids.md
+++ b/docs/pr/1741-flow-count/reviewer-ids.md
@@ -1,0 +1,15 @@
+# #1741 reviewer task-id ledger
+
+## Research phase (branch research/1741-flow-count, plan v2 @ e7c739019)
+- Round 1: Codex task-mq91a0ad-k0yqfk (PLAN-NEEDS-MAJOR — close-path
+  taxonomy HIGHs, folded in v2); AGY adversarial-review-mq910zxw-43nr7g
+  (PLAN-READY, independently reproduced); Claude SMR r1 (PLAN-READY).
+- Round 2 (convergence): Codex task-mq91ul6e-5ylq0v (PLAN-READY);
+  AGY adversarial-review-mq91os4y-mkv4iw (PLAN-READY); Claude SMR r2
+  (PLAN-READY). Convergence commit b4ad1811a.
+
+## Implementation phase (this PR)
+- Copilot: (recorded on review)
+- Codex: (recorded on dispatch)
+- AGY: (recorded on dispatch)
+- Claude SMR: docs/pr/1741-flow-count/claude-smr-impl-r1.md

--- a/docs/pr/1741-flow-count/reviewer-ids.md
+++ b/docs/pr/1741-flow-count/reviewer-ids.md
@@ -9,7 +9,7 @@
   (PLAN-READY). Convergence commit b4ad1811a.
 
 ## Implementation phase (this PR)
-- Copilot: (recorded on review)
-- Codex: (recorded on dispatch)
+- Copilot: QUOTA-BLOCKED — 5 quota refusals on PR #1860, 3 documented re-request retries 22:42-22:44 PDT 2026-06-10; proceeding 3-of-4 per feedback_codex_infra_must_retry
+- Codex: task-mq92ky56-mmfhu4 (MERGE-READY r1; first dispatch task-mq92ir3r-qs29cw killed by competing session dispatch, re-dispatched under flock)
 - AGY: adversarial-review-mq92irda-6cp7ob (MERGE-READY r1)
 - Claude SMR: docs/pr/1741-flow-count/claude-smr-impl-r1.md

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -155,6 +155,12 @@ pub(super) struct FlowCacheEntry {
     /// minutes, far past any concern. Value 0 = "never touched" sentinel
     /// (epoch 0 is skipped by `tick_advance_epoch`); freshly inserted entries
     /// carry 0 until their first lookup hit.
+    ///
+    /// #1741: entries are NOT removed when a flow dies, so this stamp can
+    /// freeze at a nonzero value. The per-scan clamp in
+    /// `active_flow_debug_entries` sentinel-clears stamps that leave the
+    /// active window, so a wrapped `current_epoch` can never re-match a
+    /// dead flow ("ghost resurrection" over-count).
     pub(super) last_used_epoch: u16,
 }
 
@@ -450,6 +456,13 @@ impl FlowCache {
         active
     }
 
+    /// Age predicate for the test-only `count_active_flows` counter.
+    /// The production scan (`active_flow_debug_entries`) inlines the
+    /// same math so it can clamp under the `iter_mut` borrow.
+    /// NOTE (#1741): this helper does NOT clamp; the wrap-ghost
+    /// protection lives in `active_flow_debug_entries`, which
+    /// sentinel-clears out-of-window stamps on every scan.
+    #[cfg(test)]
     fn active_entry_age(&self, entry: &FlowCacheEntry) -> Option<u16> {
         // last_used_epoch == 0 marks "never touched"; skip.
         if entry.last_used_epoch == 0 {
@@ -462,8 +475,24 @@ impl FlowCache {
     /// #1249: return a bounded active-flow debug map from the same
     /// owner-only scan that backs `count_active_flows`. This runs on
     /// the worker's debug/status cadence, not in the packet path.
+    ///
+    /// #1741: the scan also SENTINEL-CLEARS (`last_used_epoch = 0`) every
+    /// entry whose age has left the `ACTIVE_WINDOW_EPOCHS` window. Both
+    /// stamps are u16 with a 65535-tick cycle, so without the clamp a
+    /// dead entry's frozen stamp re-enters the window for exactly
+    /// `ACTIVE_WINDOW_EPOCHS` ticks once per wrap ("ghost resurrection"),
+    /// intermittently inflating `cos_active_flow_count` and every derived
+    /// fairness gauge. The clamp is airtight because `tick_advance_epoch`
+    /// and this scan are co-located at the single production call site
+    /// (`umem/debug_state.rs::publish_binding_debug_state`, reached from
+    /// both the hot mask path and the #1294 idle wall-clock path): an
+    /// entry is cleared on the first scan after leaving the window and a
+    /// wrapped `current_epoch` can never re-match it. A clamped entry is
+    /// NOT evicted — a later lookup hit re-stamps it and it counts again.
+    /// Restored invariant: counted active ⇔ hit within the last
+    /// `ACTIVE_WINDOW_EPOCHS` ticks, with no wrap exception.
     pub(super) fn active_flow_debug_entries(
-        &self,
+        &mut self,
         limit: usize,
     ) -> (u32, Vec<FlowCacheDebugEntry>, Vec<CoSActiveFlowCount>, bool) {
         let limit = limit.min(FLOW_CACHE_SIZE);
@@ -471,13 +500,25 @@ impl FlowCache {
         let mut truncated = false;
         let mut rows = Vec::with_capacity(limit.min(64));
         let mut cos_counts = BTreeMap::<(i32, u8), u32>::new();
-        for slot in self.entries.iter() {
+        // Copy the epoch to a local: the age math must run inside the
+        // `iter_mut` borrow below, where `self.active_entry_age` (a
+        // `&self` method) is not callable.
+        let current_epoch = self.current_epoch;
+        for slot in self.entries.iter_mut() {
             let Some(entry) = slot else {
                 continue;
             };
-            let Some(age_epochs) = self.active_entry_age(entry) else {
+            if entry.last_used_epoch == 0 {
                 continue;
-            };
+            }
+            let age_epochs = current_epoch.wrapping_sub(entry.last_used_epoch);
+            if age_epochs >= ACTIVE_WINDOW_EPOCHS {
+                // #1741: out of the active window — sentinel-clear so the
+                // u16 wrap can never resurrect this stamp. Owner-only
+                // store on the debug cadence; not on the packet path.
+                entry.last_used_epoch = 0;
+                continue;
+            }
             active = active.saturating_add(1);
             if let Some(queue_id) = entry.descriptor.tx_selection.queue_id {
                 let key = (entry.descriptor.egress_ifindex, queue_id);

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -1906,3 +1906,170 @@ fn count_active_flows_entry_at_epoch_max_not_confused_with_sentinel() {
     cache.tick_advance_epoch(); // skips 0 → 1
     assert_eq!(cache.count_active_flows(), 1, "entry at epoch MAX must be active after 1-tick advance");
 }
+
+// ----------------------------------------------------------------
+// (#1741) u16 epoch-wrap ghost resurrection — the production scan
+// must sentinel-clear out-of-window stamps so dead entries can never
+// re-enter the active window at the 65535-tick wrap. These four tests
+// pin the bug shape found in the research round (deterministic repro:
+// pre-fix, a dead entry resurrected for exactly ACTIVE_WINDOW_EPOCHS
+// ticks per cycle, first at tick 65519).
+// ----------------------------------------------------------------
+
+fn issue_1741_stamp_and_lookup() -> (FlowCache, crate::session::SessionKey, FlowCacheLookup) {
+    let cache = FlowCache::new();
+    let key = make_key();
+    let lookup = FlowCacheLookup {
+        ingress_ifindex: 7,
+        config_generation: 5,
+        fib_generation: 3,
+    };
+    (cache, key, lookup)
+}
+
+fn issue_1741_stamp() -> FlowCacheStamp {
+    FlowCacheStamp {
+        config_generation: 5,
+        fib_generation: 3,
+        owner_rg_id: 1,
+        owner_rg_epoch: 0,
+        owner_rg_lease_until: 0,
+    }
+}
+
+/// Single stamped entry, then idle across the full u16 wrap with the
+/// production scan running every tick (as it does at the single
+/// production call site). Pre-fix this resurrected 10 times starting
+/// at tick 65519; post-fix the count must stay 0 forever.
+#[test]
+fn issue_1741_epoch_wrap_dead_entry_never_resurrects() {
+    let rg_epochs = default_rg_epochs();
+    let (mut cache, key, lookup) = issue_1741_stamp_and_lookup();
+    cache.insert(make_entry(key.clone(), issue_1741_stamp(), 1));
+    assert!(cache.lookup(&key, lookup, 0, &rg_epochs).is_some());
+    // Flow dies; entry persists (no FIN/GC eviction of cache entries).
+    let mut resurrections = 0u32;
+    for tick in 0..70_000u32 {
+        cache.tick_advance_epoch();
+        let (active, _, _, _) = cache.active_flow_debug_entries(8);
+        // The entry legitimately stays active for the remainder of the
+        // window right after its last hit; only count post-window hits.
+        if tick >= u32::from(ACTIVE_WINDOW_EPOCHS) && active != 0 {
+            resurrections += 1;
+        }
+    }
+    assert_eq!(
+        resurrections, 0,
+        "dead entry re-entered the active window across the u16 wrap"
+    );
+}
+
+/// Production clean client-initiated close choreography (iperf3 shape):
+/// data ACKs stamp; the FIN takes the slow path and re-INSERTS the
+/// entry (sentinel-cleared); the final pure ACK fast-path hit re-stamps
+/// nonzero. The closed flow must then never count again across the
+/// wrap. Pre-fix: 10 resurrections per cycle.
+#[test]
+fn issue_1741_clean_close_choreography_never_ghosts() {
+    let rg_epochs = default_rg_epochs();
+    let (mut cache, key, lookup) = issue_1741_stamp_and_lookup();
+    // Established: insert + data-ACK hits.
+    cache.insert(make_entry(key.clone(), issue_1741_stamp(), 1));
+    assert!(cache.lookup(&key, lookup, 0, &rg_epochs).is_some());
+    cache.tick_advance_epoch();
+    assert!(cache.lookup(&key, lookup, 0, &rg_epochs).is_some());
+    // Client FIN: slow-path re-insert replaces the entry with the
+    // last_used_epoch = 0 sentinel (dedup-on-insert path).
+    cache.insert(make_entry(key.clone(), issue_1741_stamp(), 1));
+    assert_eq!(
+        cache.count_active_flows(),
+        0,
+        "FIN re-insert must sentinel-clear the stamp"
+    );
+    // Final client ACK (pure ACK, packet_eligible): fast-path hit
+    // re-stamps nonzero.
+    assert!(cache.lookup(&key, lookup, 0, &rg_epochs).is_some());
+    assert_eq!(cache.count_active_flows(), 1, "final ACK re-stamps");
+    // Fully closed; idle across the wrap with the production scan.
+    let mut resurrections = 0u32;
+    for tick in 0..70_000u32 {
+        cache.tick_advance_epoch();
+        let (active, _, _, _) = cache.active_flow_debug_entries(8);
+        if tick >= u32::from(ACTIVE_WINDOW_EPOCHS) && active != 0 {
+            resurrections += 1;
+        }
+    }
+    assert_eq!(
+        resurrections, 0,
+        "clean-closed (FIN + final ACK) flow resurrected across the wrap"
+    );
+}
+
+/// Window boundary: age ACTIVE_WINDOW_EPOCHS - 1 is counted and NOT
+/// clamped; age ACTIVE_WINDOW_EPOCHS is uncounted AND sentinel-cleared
+/// by the same scan.
+#[test]
+fn issue_1741_window_boundary_counts_age_9_clamps_age_10() {
+    let rg_epochs = default_rg_epochs();
+    let (mut cache, key, lookup) = issue_1741_stamp_and_lookup();
+    cache.insert(make_entry(key.clone(), issue_1741_stamp(), 1));
+    assert!(cache.lookup(&key, lookup, 0, &rg_epochs).is_some());
+    let stamped_epoch = cache.current_epoch;
+    // Advance to age = ACTIVE_WINDOW_EPOCHS - 1: still counted, stamp intact.
+    for _ in 0..(ACTIVE_WINDOW_EPOCHS - 1) {
+        cache.tick_advance_epoch();
+        let (active, _, _, _) = cache.active_flow_debug_entries(8);
+        assert_eq!(active, 1, "in-window entry must stay counted");
+    }
+    let stamp_after_window = cache
+        .entries
+        .iter()
+        .flatten()
+        .map(|entry| entry.last_used_epoch)
+        .next()
+        .expect("entry present");
+    assert_eq!(
+        stamp_after_window, stamped_epoch,
+        "in-window stamp must not be clamped"
+    );
+    // One more tick: age = ACTIVE_WINDOW_EPOCHS -> uncounted + cleared.
+    cache.tick_advance_epoch();
+    let (active, _, _, _) = cache.active_flow_debug_entries(8);
+    assert_eq!(active, 0, "age == window must be uncounted");
+    let stamp_after_expiry = cache
+        .entries
+        .iter()
+        .flatten()
+        .map(|entry| entry.last_used_epoch)
+        .next()
+        .expect("entry still cached (clamp must not evict)");
+    assert_eq!(stamp_after_expiry, 0, "expired stamp must be sentinel-cleared");
+}
+
+/// A clamped entry is not evicted: a later fast-path hit re-stamps it,
+/// it counts as active again, and its accumulated observed_bytes
+/// telemetry is preserved across the clamp.
+#[test]
+fn issue_1741_clamped_entry_recoverable_by_hit() {
+    let rg_epochs = default_rg_epochs();
+    let (mut cache, key, lookup) = issue_1741_stamp_and_lookup();
+    cache.insert(make_entry(key.clone(), issue_1741_stamp(), 1));
+    assert!(cache
+        .lookup_counted(&key, lookup, 0, &rg_epochs, 1500)
+        .is_some());
+    // Age out + clamp.
+    for _ in 0..(ACTIVE_WINDOW_EPOCHS + 2) {
+        cache.tick_advance_epoch();
+        let _ = cache.active_flow_debug_entries(8);
+    }
+    let (active, _, _, _) = cache.active_flow_debug_entries(8);
+    assert_eq!(active, 0);
+    // Returning flow: hit re-stamps; counted again; bytes preserved.
+    let hit = cache
+        .lookup_counted(&key, lookup, 0, &rg_epochs, 900)
+        .expect("clamped entry must still be a cache hit");
+    assert_eq!(hit.observed_bytes, 2400, "observed_bytes preserved across clamp");
+    let (active, rows, _, _) = cache.active_flow_debug_entries(8);
+    assert_eq!(active, 1, "re-hit entry counts as active again");
+    assert_eq!(rows.len(), 1);
+}


### PR DESCRIPTION
Closes #1741

## Bug (found + deterministically reproduced in the /research round)

`xpf_userspace_cos_active_flow_count` — and every gauge derived from the same per-binding flow-cache scan (`binding_active_flow_count`, the #1247 `fairness_cstruct`/CoV gauges, the #1830 `flow_fair_flows_active` overlay) — intermittently **over-counted** active flows (issue's 62/49/75 for 48 pinned streams). The activity stamp `last_used_epoch` and the scan's `current_epoch` are both **u16** aged with `wrapping_sub`, and dead flows are never removed from the cache, so every dead entry whose stamp froze nonzero re-entered the 10-epoch active window for exactly 10 ticks once per 65535-tick wrap cycle (**ghost resurrection**). A run of K flows that ended together resurrected as a +K cohort on any scrape landing in the window — explaining both the intermittency and why the symptom resisted on-demand reproduction (prior plan-kill round).

Research trail: branch `research/1741-flow-count` (plan v2 + 2 deterministic repro patches + round docs); 3-way convergence Codex task-mq91ul6e-5ylq0v + AGY adversarial-review-mq91os4y-mkv4iw + Claude SMR all PLAN-READY on this exact fix (Path A).

## Fix (telemetry-only, zero packet-path cost)

`active_flow_debug_entries` takes `&mut self` and **sentinel-clears** (`last_used_epoch = 0`) entries whose age leaves the window, during the same owner-only ~65 ms debug-cadence scan that computes the counts. Airtight: `tick_advance_epoch` and the scan are co-located at the single production call site (`publish_binding_debug_state`, hot + #1294 idle paths), so a stamp is cleared on the first scan after leaving the window — a wrap can never re-match it. A clamped entry is NOT evicted: a later hit re-stamps it (counts again, `observed_bytes` preserved). In-window counting semantics unchanged. `active_entry_age` becomes test-only (scan inlines the age math to clamp under the `iter_mut` borrow); release warning count stays at base (138).

**Restored invariant** (now documented in `docs/fairness-regimes.md`): counted active ⇔ hit within the last 10 ticks, no wrap exception. Remaining honest caveats documented: elastic window under load; slower-than-window flows legitimately drop out. This is the gauge contract #1746 should evaluate against.

## Validation

- 4 pinned regression tests; **mutation check: 3/4 FAIL with the clamp reverted** (10 resurrections/cycle, first at tick 65519), all pass with it. The choreography test models the production clean client-initiated close (FIN slow-path re-insert sentinel-clears — asserted; final pure ACK re-stamps — asserted), answering the research round's Codex HIGH-1.
- Full `cargo test --release`: **1943 passed / 0 failed** (awk-aggregated). `go test ./...`: green. `cargo build --release` warnings == base (138).
- Live (research round, loss userspace cluster): metric exact mid-run (24 pinned streams → sum 25 = 24 + control, stable ×3 scrapes), rows vanish ≤1 s post-stop. A supplementary live wrap-resonance watch is running; outcome will be posted here.

Do NOT merge — parent session smokes on the loss userspace cluster and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)