### PR TITLE
#1865: operator-visible WireGuard telemetry — counters, drop reasons, Prometheus, show security wireguard

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -5173,3 +5173,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: #1865 engineer — Codex code-r1 fixes: plan-faithful name fallback chain (TunnelEndpoint.interface_label middle layer) + summary wording 'initiations created'
   **File(s)**: userspace-dp/src/afxdp/types/forwarding.rs, userspace-dp/src/afxdp/forwarding_build/tunnels.rs, userspace-dp/src/afxdp/coordinator/status.rs, pkg/dataplane/userspace/{wgfmt.go,wgfmt_test.go}
+
+- **Timestamp**: 2026-06-11
+  **Action**: #1865 engineer — MERGE-READY convergence (Codex r3 + AGY r2 + SMR; Copilot quota x3 -> 3-of-4); live evidence posted; awaiting parent smoke + merge
+  **File(s)**: docs/pr/1865-wg-telemetry/{reviewer-ids.md,codex-code-r3.md}

--- a/_Log.md
+++ b/_Log.md
@@ -5157,3 +5157,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: #1865 engineer — commit 4: Prometheus xpf_userspace_wg_* family (12 descriptors, reason/role/direction/kind labels) + emitter + canary fixture row + series-set tests
   **File(s)**: pkg/api/{metrics.go,metrics_descriptors.go,metrics_userspace.go,metrics_descriptor_coverage_test.go,metrics_wireguard_test.go}
+
+- **Timestamp**: 2026-06-11
+  **Action**: #1865 engineer — commit 5: show security wireguard [detail] (cmdtree node, shared FormatWireguardStatus formatter, local CLI + gRPC + remote CLI wiring, tests)
+  **File(s)**: pkg/cmdtree/tree.go, pkg/dataplane/userspace/{wgfmt.go,wgfmt_test.go}, pkg/cli/{cli_show_security_dispatch.go,cli_show_security_wireguard.go}, pkg/grpcapi/{server_show.go,server_show_security_text.go,server_show_security_wireguard_test.go}, cmd/cli/show.go

--- a/_Log.md
+++ b/_Log.md
@@ -5141,3 +5141,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: "#1736 P6-flush second choreography trap fixed — the unconditional runbook flush after a SUCCESSFUL P6-noflush recovery (the expected sane-clock branch) wiped the peer under a live confirmed session, manufacturing the same S5 confirmed-but-dead blackhole the P6-pre fix removed (engine has no rekey/retry timers until S5, wg/peer.rs TODO; a confirmed engine never re-initiates). The runbook flush now runs only when the no-flush recovery fails (replay-guard/clock-step case), matching the runbook's own wording; pass message records which branch ran. Runbook updated: flush is conditional, plus an explicit do-NOT-flush-under-live-session warning"
   **File(s)**: test/incus/wg-interop.sh, docs/wg-interop-runbook.md
+
+- **Timestamp**: 2026-06-11
+  **Action**: #1865 engineer — commit 1: per-engine WgCounters + engine/call-site increments + keepalive classification + 10 telemetry tests
+  **File(s)**: userspace-dp/src/afxdp/wg/{counters.rs,mod.rs,engine.rs,handshake_session.rs,tests.rs}, userspace-dp/src/afxdp/coordinator/wg_control.rs, userspace-dp/src/afxdp/frame/wg.rs

--- a/_Log.md
+++ b/_Log.md
@@ -5145,3 +5145,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: #1865 engineer — commit 1: per-engine WgCounters + engine/call-site increments + keepalive classification + 10 telemetry tests
   **File(s)**: userspace-dp/src/afxdp/wg/{counters.rs,mod.rs,engine.rs,handshake_session.rs,tests.rs}, userspace-dp/src/afxdp/coordinator/wg_control.rs, userspace-dp/src/afxdp/frame/wg.rs
+
+- **Timestamp**: 2026-06-11
+  **Action**: #1865 engineer — commit 2: wg_tunnels wire rows (WgTunnelStatus) + coordinator status accessor + helpers populate + wire pins
+  **File(s)**: userspace-dp/src/protocol/{control.rs,tests.rs}, userspace-dp/src/afxdp/coordinator/status.rs, userspace-dp/src/server/{helpers.rs,lifecycle.rs}

--- a/_Log.md
+++ b/_Log.md
@@ -5153,3 +5153,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: #1865 engineer — commit 3: Go WgTunnelStatus DTO mirror + cross-language wire pins (1..35 counter ladder)
   **File(s)**: pkg/dataplane/userspace/protocol.go, pkg/dataplane/userspace/wg_status_test.go
+
+- **Timestamp**: 2026-06-11
+  **Action**: #1865 engineer — commit 4: Prometheus xpf_userspace_wg_* family (12 descriptors, reason/role/direction/kind labels) + emitter + canary fixture row + series-set tests
+  **File(s)**: pkg/api/{metrics.go,metrics_descriptors.go,metrics_userspace.go,metrics_descriptor_coverage_test.go,metrics_wireguard_test.go}

--- a/_Log.md
+++ b/_Log.md
@@ -5169,3 +5169,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: #1865 engineer — SMR code review r1 (MERGE-READY; worked traces A/B) + cosmetic keepalive-line dedup in detail view
   **File(s)**: docs/pr/1865-wg-telemetry/claude-smr-code-r1.md, pkg/dataplane/userspace/wgfmt.go
+
+- **Timestamp**: 2026-06-11
+  **Action**: #1865 engineer — Codex code-r1 fixes: plan-faithful name fallback chain (TunnelEndpoint.interface_label middle layer) + summary wording 'initiations created'
+  **File(s)**: userspace-dp/src/afxdp/types/forwarding.rs, userspace-dp/src/afxdp/forwarding_build/tunnels.rs, userspace-dp/src/afxdp/coordinator/status.rs, pkg/dataplane/userspace/{wgfmt.go,wgfmt_test.go}

--- a/_Log.md
+++ b/_Log.md
@@ -5161,3 +5161,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: #1865 engineer — commit 5: show security wireguard [detail] (cmdtree node, shared FormatWireguardStatus formatter, local CLI + gRPC + remote CLI wiring, tests)
   **File(s)**: pkg/cmdtree/tree.go, pkg/dataplane/userspace/{wgfmt.go,wgfmt_test.go}, pkg/cli/{cli_show_security_dispatch.go,cli_show_security_wireguard.go}, pkg/grpcapi/{server_show.go,server_show_security_text.go,server_show_security_wireguard_test.go}, cmd/cli/show.go
+
+- **Timestamp**: 2026-06-11
+  **Action**: #1865 engineer — commit 6: docs — runbook triage step 0 (local counters as primary oracle), resolved-limitation row, interop assert note
+  **File(s)**: docs/wg-interop-runbook.md, docs/wireguard-interop.md

--- a/_Log.md
+++ b/_Log.md
@@ -5165,3 +5165,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: #1865 engineer — commit 6: docs — runbook triage step 0 (local counters as primary oracle), resolved-limitation row, interop assert note
   **File(s)**: docs/wg-interop-runbook.md, docs/wireguard-interop.md
+
+- **Timestamp**: 2026-06-11
+  **Action**: #1865 engineer — SMR code review r1 (MERGE-READY; worked traces A/B) + cosmetic keepalive-line dedup in detail view
+  **File(s)**: docs/pr/1865-wg-telemetry/claude-smr-code-r1.md, pkg/dataplane/userspace/wgfmt.go

--- a/_Log.md
+++ b/_Log.md
@@ -5149,3 +5149,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: #1865 engineer — commit 2: wg_tunnels wire rows (WgTunnelStatus) + coordinator status accessor + helpers populate + wire pins
   **File(s)**: userspace-dp/src/protocol/{control.rs,tests.rs}, userspace-dp/src/afxdp/coordinator/status.rs, userspace-dp/src/server/{helpers.rs,lifecycle.rs}
+
+- **Timestamp**: 2026-06-11
+  **Action**: #1865 engineer — commit 3: Go WgTunnelStatus DTO mirror + cross-language wire pins (1..35 counter ladder)
+  **File(s)**: pkg/dataplane/userspace/protocol.go, pkg/dataplane/userspace/wg_status_test.go

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -414,6 +414,11 @@ func (c *ctl) handleShowSecurity(args []string) error {
 		return c.showMatchPolicies(args[1:])
 	case "vrrp":
 		return c.showVRRP()
+	case "wireguard":
+		if len(args) >= 2 && args[1] == "detail" {
+			return c.showText("wireguard-detail")
+		}
+		return c.showText("wireguard")
 	case "alarms":
 		if len(args) >= 2 && args[1] == "detail" {
 			return c.showText("security-alarms-detail")

--- a/docs/pr/1865-wg-telemetry/agy-code-r1.md
+++ b/docs/pr/1865-wg-telemetry/agy-code-r1.md
@@ -125,7 +125,7 @@ Every single counter is accounted for, maps exactly to the design inventory, and
 The persistent keepalive check (`n == 0`) is correctly classified at [engine.rs:958-961](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L958-L960):
 *   It sits **after** `session.mark_confirmed()` at [engine.rs:920](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L920) and the replay window check `check_and_update` at [engine.rs:928](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L928).
 *   It sits **before** AllowedIPs lookup and inner IP parsing at [engine.rs:983](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L983).
-*   **Parity Proof:** Under both pre- and post-PR code, a zero-length transport record returns `Err(DecapError::MalformedInner)`. 
+*   **Parity Proof:** Under both pre- and post-PR code, a zero-length transport record returns `Err(DecapError::MalformedInner)`.
 *   **Out-Buffer Wipe Contract:** In the original code, the error resulted in taking the `Err(e)` branch of the inner closure, executing `out[..0].fill(0)` (a no-op since length is zero). The new code returns `Err(DecapError::MalformedInner)` immediately without calling `out[..0].fill(0)`, maintaining identical behavior with zero leakage risk.
 
 ---

--- a/docs/pr/1865-wg-telemetry/agy-code-r1.md
+++ b/docs/pr/1865-wg-telemetry/agy-code-r1.md
@@ -1,0 +1,180 @@
+I will begin by listing the current permissions to see what actions and directories I have access to.
+I will request read permissions for the target worktree directory so that I can view files directly.
+I will run a command to inspect the git log of the target range in the worktree to understand the six commits.
+I will read the plan file at `docs/pr/1865-wg-telemetry/plan.md` to understand the expected behavior and counters inventory.
+I will run a command to list the files changed in the commits of interest.
+I will run a command to count the lines in the git diff to understand its size.
+I will view `userspace-dp/src/afxdp/wg/counters.rs` to inspect the counter definitions and helpers.
+I will run a command to view the diff for `userspace-dp/src/afxdp/wg/engine.rs`.
+I will search for `try_encap` in the engine file to get its exact line range.
+I will view lines 690 to 860 of `userspace-dp/src/afxdp/wg/engine.rs` to review the full `try_encap` body.
+I will view lines 851 to 1050 of `userspace-dp/src/afxdp/wg/engine.rs` to review the full `try_decap` function body.
+I will run a command to view the git diff for `userspace-dp/src/afxdp/wg/handshake_session.rs`.
+I will run a command to view the git diff for `userspace-dp/src/afxdp/coordinator/wg_control.rs`.
+I will search for `hs_requests_armed` in the codebase to find where it is incremented and ensure it matches the plan inventory.
+I will view `userspace-dp/src/afxdp/wg/engine.rs` around line 402 to inspect the `hs_requests_armed` increment site.
+I will search for `encap_mtu_drops` in the codebase to find both of its increment sites.
+I will view lines 75 to 105 of `userspace-dp/src/afxdp/frame/wg.rs` to review the transit MTU guard counter increment.
+I will view lines 106 to 140 of `userspace-dp/src/afxdp/frame/wg.rs` to see what happens on the success path of transit encap.
+I will run a command to view the git diff for `userspace-dp/src/afxdp/coordinator/status.rs`.
+I will grep search for `linux_name` in coordinator files to see the row-label fallback convention mentioned in the plan.
+I will view lines 820 to 835 of `userspace-dp/src/afxdp/coordinator/mod.rs` to see how the fallback label is constructed there.
+I will search for the definition of the `TunnelEndpoint` struct to see what fields are available on it.
+I will search for `struct TunnelEndpoint` in the Rust files.
+I will view `userspace-dp/src/afxdp/types/forwarding.rs` around line 166 to see the fields of `TunnelEndpoint`.
+I will search for `ifindex_to_name` to see how it is populated and if it reflects the `linux_name` else `interface` convention.
+I will view lines 680 to 695 of `userspace-dp/src/afxdp/coordinator/mod.rs` to see how `ifindex_to_name` is populated.
+I will search for insertions or mutations of `ifindex_to_name` in the coordinator module to understand how the map gets its values.
+I will search for `ifindex_to_name` across all Rust source files to see where it gets populated or updated.
+I will view lines 35 to 60 of `userspace-dp/src/afxdp/forwarding_build/interfaces.rs` to see how `ifindex_to_name` is populated.
+I will view `userspace-dp/src/protocol/control.rs` around the definition of `WgTunnelStatus`.
+I will search for `WgTunnelStatus` in `userspace-dp/src/protocol/control.rs` to see its definition.
+I will view lines 300 to 335 of `userspace-dp/src/protocol/control.rs` to inspect the `wg_tunnels` field on `ProcessStatus`.
+I will view lines 445 to 580 of `userspace-dp/src/protocol/control.rs` to review the fields of `WgTunnelStatus`.
+I will search for the struct definition in the Go protocol file to compare it with the Rust counterpart.
+I will view lines 720 to 815 of `pkg/dataplane/userspace/protocol.go` to inspect the Go struct definition.
+I will view lines 60 to 90 of `userspace-dp/src/server/lifecycle.rs` to verify that the new field is properly initialized in the `ProcessStatus` initializer.
+I will view lines 90 to 130 of `userspace-dp/src/server/lifecycle.rs` to see the complete initialization of `ProcessStatus`.
+I will view lines 130 to 160 of `userspace-dp/src/server/lifecycle.rs` to see if the new fields are properly initialized.
+I will run a command to view the git diff for `userspace-dp/src/server/helpers.rs`.
+I will run a command to view the git diff for `pkg/api/metrics.go`.
+I will run a command to view the git diff for `pkg/api/metrics_descriptors.go`.
+I will run a command to view the git diff for `pkg/api/metrics_userspace.go`.
+I will run a command to view the git diff for `pkg/api/metrics_descriptor_coverage_test.go`.
+I will search for `func TestCollectorDescriptorCoverage` to locate and examine the coverage test code.
+I will view lines 364 to 520 of `pkg/api/metrics_descriptor_coverage_test.go` to inspect the coverage test logic.
+I will run a command to view `pkg/api/metrics_wireguard_test.go`.
+I will run a command to view the git diff for `pkg/cmdtree/tree.go`.
+I will run a command to view the git diff for `cmd/cli/show.go`.
+I will view lines 390 to 430 of `cmd/cli/show.go` to see how other subcommands of `show security` are dispatched and if prefix resolution is handled.
+I will view `pkg/cli/cli_show_security_dispatch.go` to see how subcommands are dispatched or matched.
+I will view `pkg/cli/cli_show_security_wireguard.go` to inspect the local CLI formatting, timestamp logic, and edge cases.
+I will view `pkg/dataplane/userspace/wgfmt.go` to inspect the formatting logic.
+I will run a command to view the git diff for `pkg/grpcapi/server_show.go`.
+I will run a command to view the git diff for `pkg/grpcapi/server_show_security_text.go`.
+I will run a command to view the git diff for `pkg/dataplane/userspace/wg_status_test.go`.
+I will search for the matching Rust-side wire pin in `protocol/tests.rs` to verify compatibility.
+I will view lines 1410 to 1500 of `userspace-dp/src/protocol/tests.rs` to review the Rust-side wire-pin compatibility test.
+I will run a command to view the git diff for `userspace-dp/src/afxdp/wg/tests.rs`.
+I will run a command to view the diff for the docs files.
+I will run a command to view the diff for these CLI/formatter tests.
+I will run a command to view the git diff for `userspace-dp/src/afxdp/wg/mod.rs`.
+I will run a command to view the git diff for `_Log.md`.
+I will view the git log in detail to see all commits.
+I will check the files in `docs/pr/1865-wg-telemetry/` to see if there is any other review log or files we should be aware of.
+I will read `docs/pr/1865-wg-telemetry/claude-smr-code-r1.md` to see what findings were reported in the SMR r1 review.
+I will run the Rust tests in the userspace-dp crate to confirm they all compile and pass successfully.
+I will run the Go tests for the modified packages in the worktree.
+I will run the WG and protocol unit tests specifically to verify that all tests in the telemetry and protocol submodules pass.
+I will run the Rust WG unit tests specifically.
+I will run the Rust protocol unit tests specifically.
+# Code Review Verdict: MERGE-READY
+
+After performing a rigorous, hostile, line-by-line audit of the implementation branch `engineer/1865-wg-telemetry` against the converged design plan in [plan.md](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/plan.md), I have found **zero** logical, safety, wire, performance, or semantic defects. The test suites compile and pass successfully, and the telemetry surface maps exactly to the expected specifications.
+
+Below is the detailed review report organized by the seven items on the hostile hunt list.
+
+---
+
+### 1. Counter Inventory and Increment Verification
+
+Every single counter is accounted for, maps exactly to the design inventory, and covers all return paths with no double-counting.
+
+*   **Encap Paths (`try_encap` in [engine.rs](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs)):**
+    *   **`EncapError::UnknownPeer`** is mapped to `encap_drops_other` via the `count_encap_err` helper at [engine.rs:720](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L720).
+    *   **`EncapError::NoSession` (no current session)** increments `encap_drops_no_session` inline at [engine.rs:725](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L725) and returns early.
+    *   **`EncapError::NoSession` (unconfirmed session)** increments `encap_drops_unconfirmed` inline at [engine.rs:742](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L742) and returns early.
+        *   *Audit:* This preserves the wire error code `NoSession` while successfully creating a counter-only split to isolate the transient responder confirmation window.
+    *   **`EncapError::BufferTooSmall`** (stack bounds checks and header serialization check) is mapped via the helper to `encap_drops_other` at [engine.rs:764](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L764), [engine.rs:767](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L767), and [engine.rs:773](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L773).
+    *   **`EncapError::RekeyRequired`** is mapped via the helper to `encap_drops_rekey_required` at [engine.rs:771](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L771).
+    *   **`EncapError::CryptoFailed`** is mapped via the helper to `encap_drops_other` at [engine.rs:837](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L837).
+    *   **Success Path** bumps `encap_packets` and adds unpadded bytes to `encap_bytes` at [engine.rs:840-843](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L840-L843).
+*   **Decap Paths (`try_decap` in [engine.rs](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs)):**
+    *   Structural header parse failures are mapped to `decap_drops_malformed_header` at [engine.rs:863](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L863).
+    *   Counter limits (`REJECT_AFTER_MESSAGES`) map to `decap_drops_counter_ceiling` at [engine.rs:870-872](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L870-L872).
+    *   Session lookups map to `decap_drops_unknown_session` at [engine.rs:880](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L880).
+    *   Truncated packets (`ShortRecord`) map to `decap_drops_malformed_header` at [engine.rs:896](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L896).
+    *   Scratch size constraints map to `decap_drops_buffer` at [engine.rs:900](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L900).
+    *   Initial replay window checks map to `decap_drops_replay` at [engine.rs:905](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L905).
+    *   AEAD failures (`CryptoFailed`) map to `decap_drops_crypto` at [engine.rs:911](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L911).
+    *   Replay state machine updates (`Repeat` / `OutOfWindow`) map to `decap_drops_replay` at [engine.rs:938](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L938) and [engine.rs:942](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L942).
+    *   **Keepalive check (`n == 0`)** bumps `decap_keepalives` inline and returns `MalformedInner` directly at [engine.rs:959-960](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L959-L960). It bypasses the mapper so that keepalives never register as drops.
+    *   **Inner Policy Closure Errors** are mapped uniformly in the `Err(e)` branch via the `count_decap_err` helper at [engine.rs:1021](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L1021) (which handles `AllowedIpsViolation`, `MalformedInner`, and `UnknownSession`).
+    *   **Success Path** bumps `decap_packets` and increments `decap_bytes` at [engine.rs:1007-1010](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L1007-L1010).
+*   **Handshake Wrappers (`consume_*` / `create_*` in [handshake_session.rs](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/handshake_session.rs)):**
+    *   `create_initiation` bumps `hs_initiations_created` on Ok and `hs_initiation_build_failures` on Err at [handshake_session.rs:556-560](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/handshake_session.rs#L556-L560).
+    *   `consume_response` bumps `hs_completions_initiator` and stamps the handshake completion on Ok at [handshake_session.rs:570-572](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/handshake_session.rs#L570-L572). Errors are mapped to `hs_rx_drops_*` at [handshake_session.rs:575](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/handshake_session.rs#L575).
+    *   `consume_initiation_create_response` bumps `hs_responses_created` and stamps the handshake completion on Ok at [handshake_session.rs:596-598](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/handshake_session.rs#L596-L598). Errors are mapped to `hs_rx_drops_*` at [handshake_session.rs:601](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/handshake_session.rs#L601).
+        *   *Audit:* The single `hs_responses_created` increment site acts as the responder-side completion event (no double-counting).
+*   **Call Sites:**
+    *   `tun_rx_drops_no_endpoint` is correctly bumped when draining TUN frames off an unconfigured responder in [wg_control.rs:251](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/wg_control.rs#L251).
+    *   `hs_send_errors` is incremented for both initiation and response socket send errors in [wg_control.rs:436](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/wg_control.rs#L436) and [wg_control.rs:481](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/wg_control.rs#L481).
+    *   `hs_rx_cookie_unsupported` is incremented on type-3 cookie packets in [wg_control.rs:505](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/wg_control.rs#L505).
+    *   `tun_write_errors` is incremented when packet delivery to the TUN fails in [wg_control.rs:517](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/wg_control.rs#L517).
+    *   `rx_unknown_type` is incremented when the type byte is invalid in [wg_control.rs:536](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/wg_control.rs#L536).
+        *   *Audit:* Zero-length UDP packets are consumed by the `Ok(_) => break` recv arm at [wg_control.rs:197](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/wg_control.rs#L197) prior to type dispatch, so they are cleanly excluded from `rx_unknown_type`.
+    *   `encap_mtu_drops` is incremented at both MTU guards:
+        *   Control egress guard at [wg_control.rs:572](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/wg_control.rs#L572).
+        *   Transit egress guard at [wg.rs:89](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/frame/wg.rs#L89).
+    *   `transport_send_errors` is incremented on transport send errors in [wg_control.rs:581](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/wg_control.rs#L581).
+
+---
+
+### 2. Keepalive Classification Placement and Parity
+
+The persistent keepalive check (`n == 0`) is correctly classified at [engine.rs:958-961](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L958-L960):
+*   It sits **after** `session.mark_confirmed()` at [engine.rs:920](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L920) and the replay window check `check_and_update` at [engine.rs:928](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L928).
+*   It sits **before** AllowedIPs lookup and inner IP parsing at [engine.rs:983](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L983).
+*   **Parity Proof:** Under both pre- and post-PR code, a zero-length transport record returns `Err(DecapError::MalformedInner)`. 
+*   **Out-Buffer Wipe Contract:** In the original code, the error resulted in taking the `Err(e)` branch of the inner closure, executing `out[..0].fill(0)` (a no-op since length is zero). The new code returns `Err(DecapError::MalformedInner)` immediately without calling `out[..0].fill(0)`, maintaining identical behavior with zero leakage risk.
+
+---
+
+### 3. Wire Format Compatibility
+
+*   **Empty-Vec Skip Invariant:** In [control.rs:320](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/protocol/control.rs#L320), the `wg_tunnels` field is decorated with `#[serde(rename = "wg_tunnels", default, skip_serializing_if = "Vec::is_empty")]`. On the Go side in [protocol.go:739](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/protocol.go#L739), it is mirrored as `json:"wg_tunnels,omitempty"`. When no WG tunnels are configured, the key is omitted entirely, guaranteeing that non-WG wire structures remain byte-identical.
+*   **Tag Matching:** All 35 counters and 6 state fields match character-for-character between Rust serde renames and Go tags. This is fully validated by `TestProcessStatusWgTunnelsPopulatedDecode` in [wg_status_test.go:20](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wg_status_test.go#L20) and `process_status_wg_tunnels_roundtrip_and_compat` in [tests.rs:1418](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/protocol/tests.rs#L1418) using a matching 1..35 value ladder.
+*   **Lifecycle Initializer:** In [lifecycle.rs:141](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/server/lifecycle.rs#L141), `wg_tunnels` is correctly initialized as `Vec::new()`.
+
+---
+
+### 4. Coordinator Status Mapping and Fallback
+
+*   **Stamp-0 Guard:** The wall-clock conversion in [status.rs:670-676](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/status.rs#L670-L676) checks `if stamp == 0 { 0 }`. Monotonic-to-wall conversion does not run on stamp 0, preventing boot-relative timestamp leakage.
+*   **Pre-Epoch Clamp:** The conversion maps negative timestamps to 0 via `.map(|dt| dt.timestamp().max(0) as u64)` at [status.rs:674](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/status.rs#L674), avoiding underflow and wrapped values.
+*   **Ordering / Cardinality:** Rows are sorted by tunnel ID for deterministic serialization at [status.rs:643](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/status.rs#L643).
+*   **Fallback Name:** Missing names are safely mapped to `wg-endpoint-{id}` at [status.rs:666](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/status.rs#L666), ensuring rows are never silently discarded.
+
+---
+
+### 5. Prometheus Modeling and Descriptor Coverage
+
+*   **Label Sets:** All metrics are properly collapsed under the `{tunnel}` label plus appropriate `{role}`, `{direction}`, `{reason}`, and `{kind}` enums.
+*   **Never-Handshaked Gauge Gating:** The collector only emits the `xpf_userspace_wg_last_handshake_time_seconds` gauge if `t.LastHandshakeUnixSecs > 0` at [metrics_userspace.go:139-147](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/api/metrics_userspace.go#L139-L147), preventing display churn of epoch 0.
+*   **Descriptor Coverage:** Verified via `TestEmitWireguardTelemetryNeverHandshakedGauge` in [metrics_wireguard_test.go:189](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/api/metrics_wireguard_test.go#L189) and registration in `TestCollectorDescriptorCoverage` in [metrics_descriptor_coverage_test.go:491](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/api/metrics_descriptor_coverage_test.go#L491).
+
+---
+
+### 6. CLI Dispatch and Presenter Formatting
+
+*   **Prefix Resolution:** Handled correctly via the `resolveCommand` lookup at [cli_show_security_dispatch.go:100](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/cli/cli_show_security_dispatch.go#L100).
+*   **Nil-Config Allowlist:** `wireguard` is added to the `cfg == nil` allowlist at [cli_show_security_dispatch.go:107](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/cli/cli_show_security_dispatch.go#L107), allowing tunnel diagnostics to be queried on a broken/unconfigured node.
+*   **Remote Topic Mapping:** Mapped to `"wireguard"` and `"wireguard-detail"` topics at [server_show.go:412-417](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/grpcapi/server_show.go#L412-L417).
+*   **Formatter Edge Cases:**
+    *   Empty endpoint string prints `(responder-only; learned at runtime)` at [wgfmt.go:35-37](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt.go#L35-L37).
+    *   Future timestamps are clamped to `0 seconds ago` at [wgfmt.go:139-141](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt.go#L139-L141).
+
+---
+
+### 7. Hot-Path Performance
+
+*   **Zero Non-WG Traffic Cost:** Gated behind the existing `tunnel_endpoint_id != 0` check in transit forwarding. Non-WG traffic is completely unaffected.
+*   **Zero New Allocations:** Telemetry counts use `AtomicU64` increments (`Ordering::Relaxed`). `try_encap` leverages stack-allocated `MaybeUninit` structures at [engine.rs:792](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/wg/engine.rs#L792) to avoid heap allocation. No new heap allocations are introduced.
+
+---
+
+### Summary of Verification Output
+
+All tests passed successfully on the worktree.
+*   **Rust tests:** 128 `afxdp::wg` unit tests and 41 `protocol` tests pass successfully.
+*   **Go tests:** `pkg/dataplane/userspace`, `pkg/api`, and `pkg/grpcapi` pass successfully (including the cross-language wire pins and Prometheus emitters).

--- a/docs/pr/1865-wg-telemetry/agy-code-r2.md
+++ b/docs/pr/1865-wg-telemetry/agy-code-r2.md
@@ -1,0 +1,13 @@
+I will wait for the `cargo check` background task to finish.
+I will wait for the `cargo test` background task to finish.
+I have completed the Round 2 adversarial review of the telemetry deltas between commits `a8c98cb1f` and `832514fdc`.
+
+The verdict is **`MERGE-READY`**.
+
+I have created a detailed report in the artifact: [adversarial_review_r2.md](file:///home/ps/.gemini/antigravity-cli/brain/bef0a78a-d81e-486f-82c5-186762012dc3/adversarial_review_r2.md).
+
+### Summary of Key Findings:
+- **`Debug` Safety**: [TunnelEndpoint](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/types/forwarding.rs#L195-225)'s `Debug` implementation is safe. The new `interface_label` field contains only non-secret, configured interface names (like `wg0` or `tunnel1`), while the private key `wg_local_privkey` remains correctly redacted as `<redacted>`.
+- **Fallback Ordering**: The fallback chain in [status.rs](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/status.rs#L664-679) correctly uses the live OS-level name first, then the snapshot-level configured name (`interface_label`), and defaults to `wg-endpoint-<id>` only if both are unavailable. This ensures robust telemetry even during broken bring-up.
+- **Go Test Verification**: The updated wording ("initiations created") in [wgfmt.go](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt.go#L48) matches its test pin in [wgfmt_test.go](file:///home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt_test.go#L45). Go tests pass successfully.
+- **Rust Test verification**: A pre-existing flaky test (`concurrent_recovery_processes_each_command_exactly_once`) was verified to be unrelated to the changes and passes cleanly when isolated.

--- a/docs/pr/1865-wg-telemetry/claude-smr-code-r1.md
+++ b/docs/pr/1865-wg-telemetry/claude-smr-code-r1.md
@@ -1,0 +1,114 @@
+# PR #1876 (#1865 WG telemetry) — Claude SMR hostile code review, round 1
+
+Reviewer: Claude SMR. Contract: hostile, full-function-body reads
+(feedback_verify_whole_function_body), worked trace mandatory.
+
+## Verdict: MERGE-READY (one cosmetic fix applied during review)
+
+## Worked trace A — one full handshake + first round-trip (xpf initiator)
+
+1. `wg_control_loop` bring-up → `drive_initiation` →
+   `engine.create_initiation` (counting wrapper,
+   handshake_session.rs tail impl) → `create_initiation_inner` Ok ⇒
+   `hs_initiations_created` 0→1; `hs_initiation_build_failures`
+   stays 0; `last_handshake_complete_ns` stays 0 (creation ≠
+   completion — pinned by the framed-handshake test).
+2. `wg_send_to` Ok ⇒ no counter. (EINVAL variant: `hs_send_errors`
+   0→1 + exception ring — the #1736 fingerprint
+   `created↑ + send_errors↑ + completions flat`.)
+3. Peer msg2 arrives → `dispatch_inbound` type 2 →
+   `consume_response` wrapper → inner Ok ⇒
+   `hs_completions_initiator` 0→1 AND
+   `record_handshake_complete(monotonic_now_ns())` ⇒ stamp > 0
+   (max(1) guard); `authenticated=true` → endpoint learning
+   unchanged from pre-PR behavior.
+4. TUN read → `encap_and_send`: MTU guard passes (no counter) →
+   `try_encap`: peer found → session present (initiator role,
+   pre-confirmed) → confirmation gate passes → bounds pass → counter
+   consumed → `write_message` Ok ⇒ `encap_packets` 0→1,
+   `encap_bytes` += inner len (un-padded — pinned). `wg_send_to` Ok.
+5. Peer transport record → `dispatch_inbound` type 4 → `try_decap`:
+   `parse_data_header` Ok → ceiling pass → demux hit → tag-length
+   pass → precheck pass → AEAD Ok (n>0) → `mark_confirmed` (no-op
+   for initiator role) → `check_and_update` Accept → n>0 (keepalive
+   peel not taken) → inner parse + AllowedIPs Ok ⇒ `decap_packets`
+   0→1, `decap_bytes` += inner_len → TUN write Ok (no counter).
+6. Status poll → `wg_tunnel_statuses`: row keyed by name; stamp ≠ 0 ⇒
+   monotonic→wall conversion (stamp-0 guard NOT taken);
+   `session_confirmed=true`; Prometheus emits
+   `handshakes_completed{role=initiator}=1`,
+   `transport_packets{encap}=1,{decap}=1`, all drop reasons = 0
+   (emitted — 0 is a real signal), `last_handshake_time_seconds`
+   present.
+
+## Worked trace B — one dropped packet (replayed transport record)
+
+Peer replays the identical datagram → `try_decap`: header/ceiling/
+demux/tag/precheck pass (precheck window may or may not catch — both
+arms counted identically) → AEAD Ok (stateless transport re-decrypts)
+→ `mark_confirmed` no-op → `check_and_update` ⇒ `Repeat` → `out[..n]`
+wiped → `Err(count_decap_err(ReplayDuplicate))` ⇒
+`decap_drops_replay` 0→1, exactly one counter, no packet/byte
+movement, `authenticated=false` (no endpoint learn). Prometheus:
+`transport_drops{direction=decap,reason=replay}=1`.
+
+Replayed KEEPALIVE corner: the replay gate fires BEFORE the n==0
+peel, so a replayed keepalive counts `replay`, not a second
+`keepalive` — pinned by
+`zero_length_record_counts_keepalive_not_malformed_inner`.
+
+## Full-body audit of every counted function
+
+- `try_encap` (engine.rs): 8 return paths — UnknownPeer→other(mapper),
+  no-session(inline), unconfirmed(inline, same wire error),
+  BufferTooSmall ×2→other(mapper), RekeyRequired(mapper),
+  encode-header BufferTooSmall(mapper), CryptoFailed(mapper),
+  success(packets+bytes). No path uncounted; the two inline NoSession
+  arms cannot reach the mapper (mapper's NoSession arm is defensive
+  and documented). No double count.
+- `try_decap`: 12 return paths — MalformedHeader, ceiling,
+  UnknownSession, ShortRecord, BufferTooSmall, precheck
+  OutOfWindow, CryptoFailed, Repeat, post-AEAD OutOfWindow (all
+  mapper), keepalive (inline, deliberately NOT a drop counter),
+  closure Err (single mapper site), success. Every post-AEAD error
+  path retains the `out` wipe contract (keepalive returns with n==0 —
+  nothing to wipe).
+- Handshake wrappers: single increment per outcome; responder
+  completion = `hs_responses_created` (one site, role-mapped at emit;
+  no double count by construction).
+- Call sites: both MTU guards hit the SAME `encap_mtu_drops`
+  (frame/wg.rs fetches the engine before its guard — verified
+  ordering at frame/wg.rs:53 vs :85); the previously discarded
+  responder msg2 send error now counted + exception-ringed;
+  cookie/unknown-type/runt semantics match the plan (runt excluded
+  with rationale, not fictionally counted).
+
+## Findings
+
+1. **COSMETIC (fixed in-review)**: `FormatWireguardStatus` printed the
+   keepalive line twice in detail view (conditional summary line +
+   unconditional detail line). Summary form now suppressed when
+   `detail` — tests re-run green.
+2. **Noted, acceptable**: `peer_endpoint` shows the CONFIGURED
+   endpoint only (learned endpoint is control-thread-local) —
+   documented on the wire struct and rendered as
+   "(responder-only; learned at runtime)" when empty.
+3. **Noted, acceptable**: encap of a zero-length inner counts
+   `encap_packets` with 0 bytes — unreachable in production until S5
+   sends keepalives; semantics will be "keepalives sent count as
+   packets", consistent with kernel wg.
+
+## Wire / Prometheus / CLI audit
+
+- serde renames vs Go json tags compared field-by-field — identical
+  (35 counters + 6 identity/state fields). Empty-vec skip invariant
+  pinned on both sides; `protocol_wire_v1.json` unchanged by
+  construction (skip-if-empty default) — the populated pins close the
+  fixture's optional-field gap exactly as Codex plan-r1 F5 required.
+- Emitter label arities match descriptor variable-label lists; the
+  series-set test pins all 37 populated series + the 36-series
+  zeroed emission with the gauge absent.
+- CLI prefix resolution: "w" uniquely resolves to wireguard among the
+  security children; nil-cfg allowlist extended (status-only command).
+
+MERGE-READY.

--- a/docs/pr/1865-wg-telemetry/codex-code-r1.md
+++ b/docs/pr/1865-wg-telemetry/codex-code-r1.md
@@ -48,13 +48,13 @@ poll 15: - task-mqa32z7a-vrz9qs | completed | rescue | Codex Task
 **Verdict: NEEDS-CHANGES**
 
 **Findings**
-1. **Plan-required tunnel name fallback is not implemented.**  
-   Plan requires `ifindex_to_name`, then snapshot row-label fallback `linux_name` else `interface`, then last resort `wg-endpoint-<id>`: [plan.md:202](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/plan.md:202).  
-   Implementation only does `ifindex_to_name` then `wg-endpoint-<id>`: [status.rs:664](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/status.rs:664). The endpoint type does not retain `interface`/`linux_name`: [forwarding.rs:166](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/types/forwarding.rs:166), and tunnel build drops that row-label data: [tunnels.rs:72](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/forwarding_build/tunnels.rs:72).  
+1. **Plan-required tunnel name fallback is not implemented.**
+   Plan requires `ifindex_to_name`, then snapshot row-label fallback `linux_name` else `interface`, then last resort `wg-endpoint-<id>`: [plan.md:202](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/plan.md:202).
+   Implementation only does `ifindex_to_name` then `wg-endpoint-<id>`: [status.rs:664](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/status.rs:664). The endpoint type does not retain `interface`/`linux_name`: [forwarding.rs:166](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/types/forwarding.rs:166), and tunnel build drops that row-label data: [tunnels.rs:72](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/forwarding_build/tunnels.rs:72).
    Result: broken bring-up cases can emit unstable `wg-endpoint-<id>` labels even when the snapshot had a stable logical interface name. That violates the converged keying invariant and weakens the #1873 mitigation.
 
-2. **CLI summary mislabels `hs_initiations_created` as sent.**  
-   The summary formatter prints `initiations sent` while passing `t.HsInitiationsCreated`: [wgfmt.go:48](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt.go:48). The test pins the wrong wording: [wgfmt_test.go:45](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt_test.go:45).  
+2. **CLI summary mislabels `hs_initiations_created` as sent.**
+   The summary formatter prints `initiations sent` while passing `t.HsInitiationsCreated`: [wgfmt.go:48](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt.go:48). The test pins the wrong wording: [wgfmt_test.go:45](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt_test.go:45).
    This is operator-visible and contradicts the plan’s distinction between “created” and send failures. Detail mode already uses “initiations created”, so summary should match.
 
 **What Checked Out**

--- a/docs/pr/1865-wg-telemetry/codex-code-r1.md
+++ b/docs/pr/1865-wg-telemetry/codex-code-r1.md
@@ -1,0 +1,75 @@
+=== dispatch 22:43:09 ===
+Codex Task started in the background as task-mqa32z7a-vrz9qs. Check /codex:status task-mqa32z7a-vrz9qs for progress.
+TASK_ID=task-mqa32z7a-vrz9qs
+poll 1: | task-mqa32z7a-vrz9qs | rescue | running | running | 25s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 2: | task-mqa32z7a-vrz9qs | rescue | running | running | 50s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 3: | task-mqa32z7a-vrz9qs | rescue | running | running | 1m 16s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 4: | task-mqa32z7a-vrz9qs | rescue | running | verifying | 1m 41s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 5: | task-mqa32z7a-vrz9qs | rescue | running | running | 2m 6s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 6: | task-mqa32z7a-vrz9qs | rescue | running | running | 2m 32s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 7: | task-mqa32z7a-vrz9qs | rescue | running | running | 2m 57s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 8: | task-mqa32z7a-vrz9qs | rescue | running | verifying | 3m 22s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 9: | task-mqa32z7a-vrz9qs | rescue | running | running | 3m 47s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 10: | task-mqa32z7a-vrz9qs | rescue | running | verifying | 4m 13s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 11: | task-mqa32z7a-vrz9qs | rescue | running | running | 4m 38s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 12: | task-mqa32z7a-vrz9qs | rescue | running | running | 5m 3s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 13: | task-mqa32z7a-vrz9qs | rescue | running | running | 5m 29s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 14: | task-mqa32z7a-vrz9qs | rescue | running | running | 5m 54s | 019eb8da-9214-7c21-88b2-631f057cbe43 | HOSTILE code review of PR #1876 (xpf repo, issue #1865: operator-visible WireGuard telemetry)... | `/codex:status task-mqa32z7a-vrz9qs`<br>`/codex:cancel task-mqa32z7a-vrz9qs` |
+- task-mqa32z7a-vrz9qs | running | rescue | Codex Task
+  Log: /home/ps/.claude/plugins/data/gemini-abiswas97-gemini/state/1865-engineer-wg-a50663075c897d51/jobs/task-mqa32z7a-vrz9qs.log
+poll 15: - task-mqa32z7a-vrz9qs | completed | rescue | Codex Task
+=== result 22:49:29 ===
+**Verdict: NEEDS-CHANGES**
+
+**Findings**
+1. **Plan-required tunnel name fallback is not implemented.**  
+   Plan requires `ifindex_to_name`, then snapshot row-label fallback `linux_name` else `interface`, then last resort `wg-endpoint-<id>`: [plan.md:202](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/plan.md:202).  
+   Implementation only does `ifindex_to_name` then `wg-endpoint-<id>`: [status.rs:664](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/status.rs:664). The endpoint type does not retain `interface`/`linux_name`: [forwarding.rs:166](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/types/forwarding.rs:166), and tunnel build drops that row-label data: [tunnels.rs:72](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/forwarding_build/tunnels.rs:72).  
+   Result: broken bring-up cases can emit unstable `wg-endpoint-<id>` labels even when the snapshot had a stable logical interface name. That violates the converged keying invariant and weakens the #1873 mitigation.
+
+2. **CLI summary mislabels `hs_initiations_created` as sent.**  
+   The summary formatter prints `initiations sent` while passing `t.HsInitiationsCreated`: [wgfmt.go:48](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt.go:48). The test pins the wrong wording: [wgfmt_test.go:45](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt_test.go:45).  
+   This is operator-visible and contradicts the plan’s distinction between “created” and send failures. Detail mode already uses “initiations created”, so summary should match.
+
+**What Checked Out**
+- `try_encap`, `try_decap`, and the three handshake wrappers appear to count exactly once per intended return path. Keepalive replay is gated correctly: replayed keepalives are rejected before `decap_keepalives` increments, and `decap_packets`/`decap_bytes` only move on delivered inner packets.
+- `wg_control.rs` call-site counters use the correct engine in the paths I checked. Both MTU guards increment `encap_mtu_drops`.
+- Wire JSON names match between Rust and Go by inspection. Empty `wg_tunnels` skip behavior and lifecycle initialization are present.
+- Prometheus descriptor label arities match emission calls, and never-handshaked last-handshake gauge gating is present.
+- CLI prefix resolution should allow local `show security w` to resolve uniquely to `wireguard`.
+
+**Validation**
+- `git diff --check 9a536f810..HEAD` passed.
+- Could not run the requested targeted tests because the sandbox is read-only:
+  - `cargo test --release --bin xpf-userspace-dp telemetry_counters` failed opening `target/release/.cargo-build-lock`.
+  - `go test ./pkg/api -run TestEmitWireguard` failed creating `/tmp/go-build...`.
+
+Codex session ID: 019eb8da-9214-7c21-88b2-631f057cbe43
+Resume in Codex: codex resume 019eb8da-9214-7c21-88b2-631f057cbe43
+=== done ===

--- a/docs/pr/1865-wg-telemetry/codex-code-r2.md
+++ b/docs/pr/1865-wg-telemetry/codex-code-r2.md
@@ -1,0 +1,28 @@
+=== result 23:07:09 ===
+**Findings**
+
+1. **NEEDS-CHANGES:** final ledger docs commit `832514fdc` introduces trailing whitespace and makes `git diff --check HEAD^..HEAD` fail:
+   - [agy-code-r1.md:128](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/agy-code-r1.md:128)
+   - [codex-code-r1.md:51](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/codex-code-r1.md:51)
+   - [codex-code-r1.md:52](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/codex-code-r1.md:52)
+   - [codex-code-r1.md:53](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/codex-code-r1.md:53)
+   - [codex-code-r1.md:56](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/codex-code-r1.md:56)
+   - [codex-code-r1.md:57](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/docs/pr/1865-wg-telemetry/codex-code-r1.md:57)
+
+**Fold Verification**
+
+F1 is correctly folded in code: `TunnelEndpoint.interface_label` exists at [forwarding.rs:174](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/types/forwarding.rs:174), is populated as `linux_name` else `interface` at [tunnels.rs:80](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/forwarding_build/tunnels.rs:80), and status falls back `ifindex_to_name -> interface_label -> wg-endpoint-<id>` at [status.rs:670](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/coordinator/status.rs:670). `interface_label` in `Debug` is not a secret; key redaction remains intact at [forwarding.rs:211](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/userspace-dp/src/afxdp/types/forwarding.rs:211).
+
+F2 is correctly folded: summary wording now says `initiations created` at [wgfmt.go:48](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt.go:48), with the test pin updated at [wgfmt_test.go:45](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt_test.go:45).
+
+Keepalive dedup looks correct: summary keepalive prints only in non-detail mode at [wgfmt.go:53](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt.go:53), while detail still prints the single unconditional line at [wgfmt.go:113](/home/ps/git/bpfrx/.claude/worktrees/1865-engineer-wg/pkg/dataplane/userspace/wgfmt.go:113).
+
+There is still no direct Rust regression test for the `wg_tunnel_statuses` `interface_label` fallback; I’m not making that a separate blocker, but it is a residual coverage gap.
+
+**Verdict: NEEDS-CHANGES**
+
+Code folds are correct, but the new docs/ledger commit needs whitespace cleanup before merge.
+
+Codex session ID: 019eb8ee-30ea-7851-bd4c-e52d1c2a600d
+Resume in Codex: codex resume 019eb8ee-30ea-7851-bd4c-e52d1c2a600d
+=== done ===

--- a/docs/pr/1865-wg-telemetry/codex-code-r3.md
+++ b/docs/pr/1865-wg-telemetry/codex-code-r3.md
@@ -1,0 +1,10 @@
+=== result 23:08:31 ===
+Confirmed.
+
+Head is `6511b9c94893c83d8c8e75368149e6dccc50a6c5`, worktree status is clean, `git diff --check HEAD^..HEAD` is clean, and `git diff --check 9a536f810..HEAD` is clean. The latest commit only touches the stated review/docs files under `docs/pr/1865-wg-telemetry/`.
+
+MERGE-READY
+
+Codex session ID: 019eb8f1-5f6e-7343-88e0-51d2d64f082a
+Resume in Codex: codex resume 019eb8f1-5f6e-7343-88e0-51d2d64f082a
+=== done ===

--- a/docs/pr/1865-wg-telemetry/plan.md
+++ b/docs/pr/1865-wg-telemetry/plan.md
@@ -1,0 +1,600 @@
+# #1865 — Operator-visible WireGuard telemetry (plan)
+
+Revision: v2-final (round-2 converged)
+Issue: #1865 (#1703 S6 adjacency; refs #1736 #1434 #1873)
+Branch: research/1865-wg-telemetry
+Status: **PLAN-READY** — round-2 unanimous (Codex PLAN-READY
+task-mqa0pcn3-347u73; AGY PLAN-READY adversarial-review-mqa0ovaw-q6zx2t,
+round-1 finding 1 formally withdrawn with proof; Claude SMR PLAN-READY
+claude-smr-plan-r2.md). Ship Path B per §4.
+
+Round-1 verdicts: Codex PLAN-NEEDS-MAJOR-REVISION (codex-plan-r1.md),
+AGY PLAN-NEEDS-MAJOR-REVISION (agy-plan-r1.md), Claude SMR
+PLAN-NEEDS-MINOR-REVISION (claude-smr-plan-r1.md). v2 deltas:
+
+- **Keepalive counter added** (Codex F1 + SMR F1, independent
+  convergence): authenticated zero-length transport records currently
+  exit `try_decap` through `MalformedInner` (engine.rs:887→933→1036);
+  a peer with `persistent_keepalive` would emit steady false-alarm
+  "malformed" drops. v2 adds `decap_keepalives`, classified after the
+  replay gate and before the inner parse, all external behavior
+  unchanged (§3.3 #17).
+- **created-vs-sent honesty** (Codex F2 + SMR F2): handshake build
+  counters renamed `*_created`; BOTH send sites instrumented,
+  including the discarded `let _ = wg_send_to(...)` response send at
+  wg_control.rs:466; `hs_initiation_build_failures` added for the
+  `if let Ok` -discarded `create_initiation` errors at
+  wg_control.rs:427 (Codex F3).
+- **Absolute handshake timestamp** (AGY F2+F3 + Codex F5 + SMR F3):
+  `last_handshake_age_secs` replaced by `last_handshake_unix_secs`
+  (u64; 0 = never — unambiguous, no Option/pointer needed),
+  monotonic→wall converted at snapshot time via the existing
+  `monotonic_timestamp_to_datetime` helper; Prometheus exposes
+  `..._last_handshake_time_seconds`, PromQL computes age.
+- **Hex pubkey** (AGY F4 + Codex F6 + SMR F4): `peer_pubkey_hex`,
+  matching `wg_peer_pubkey_hex` house convention; no base64 dep.
+- **Name fallback** (Codex F4 + SMR F6): status rows fall back to the
+  snapshot row-label convention, last resort `wg-endpoint-<id>`;
+  never drop a row.
+- **Explicit exclusions** (Codex F3): zero-length UDP datagrams are
+  consumed by the `Ok(_) => break` arm at wg_control.rs:197 before
+  any type dispatch — documented as excluded (no counter), so
+  `rx_unknown_type` fires only on type bytes ∉ {1,2,3,4}.
+- **Tests tightened** (Codex F5 + SMR F5): populated round-trip
+  fixtures BOTH sides; parity-pin overpromise replaced by a Go
+  emitter label-set test; hot-path claim re-phrased (Codex F7);
+  non-transactional multi-counter snapshots documented.
+- **AGY finding 1 REFUTED** (stale-TUN via missing `logical_ifindex`
+  in `wg_identity_unchanged`): TUN-attachment changes are handled by
+  the #1872 `attachment_changed` stale-prune in
+  `spawn_wg_control_threads` (coordinator/mod.rs:566-595 — `attach_ok`
+  checks `ep.logical_ifindex == entry.spawned_ifindex` AND the
+  resolved name), which stops + respawns the thread on the new TUN
+  while deliberately preserving the engine and its sessions (#1866
+  D5). Adding `logical_ifindex` to `wg_identity_unchanged` would
+  REBUILD the engine and kill live transport sessions on a mere
+  rename — a regression against #1866 D5. Codex's independent
+  lifecycle audit confirms ("attachment changes are pruned at
+  coordinator/mod.rs:570"). Not a telemetry defect; no plan change.
+
+Reviewers: PLAN-KILL is an acceptable outcome. If you believe the
+telemetry surface is wrong (wrong keying, wrong cardinality, wrong
+layer), kill the plan rather than patching it.
+
+## 1. Problem
+
+The S2a WireGuard datapath has ZERO operator-visible telemetry. Every
+drop diagnostic is `debug_log!`-gated (compiled out in release):
+
+- `coordinator/wg_control.rs:470,478,485,505,511,539,563` — initiation/
+  response/cookie/transport/unknown-type/oversize-inner/encap drops are
+  all `debug_log!` only.
+- `frame/wg.rs:85-91` — the transit-egress MTU guard literally carries
+  the comment "wg_mtu_drops would be incremented on a real counter
+  store here; ... Telemetry consolidation is on the engine in a
+  follow-up." This plan is that follow-up.
+- The engine (`wg/engine.rs`) returns rich error enums (`EncapError` 5
+  variants, `DecapError` 10 variants, `HandshakeError` 9 variants,
+  `FramingError` 5 variants) and every single one is dropped on the
+  floor at the call sites in release builds.
+
+The only release-visible signals are `RecentExceptions` (bind/TUN/send
+errno strings) and traffic-level observation.
+
+Why this matters (the #1736 receipts): the P1/P6 no-handshake debugging
+in the S2b interop campaign burned hours precisely because of this gap.
+The v4-initiation `sendto = EINVAL` bug was silent — every initiation
+toward a configured v4 endpoint failed and NOTHING counted it; it took
+strace to find. The v4-mapped MTU-guard blackhole dropped every
+1409..=1425-byte inner packet silently — pings passed, full-MSS TCP
+moved zero bytes; it took tcpdump on both ends plus the KERNEL PEER's
+`wg show` as oracle. An operator running a real tunnel does not have a
+cooperating kernel peer to interrogate. Both bugs would have been
+one-glance diagnoses with `encap_mtu_drops` / `handshake_send_errors`
+counters.
+
+Adjacent context:
+- #1872 added teardown/respawn transition LOGS but no counters.
+- #1873: `tunnel_endpoint_id` is POSITIONAL — add/remove of one tunnel
+  renumbers the others. Telemetry keying must be robust against this
+  (see §4 keying decision and §7 R2).
+- #1434 (S6) owns multi-tunnel + the full CLI surface
+  (`show security wireguard public-key`, key generation).
+
+## 2. Current code inventory (verified on origin/master 6a11c52f5)
+
+Datapath shape (S2a): ALL WG RX (handshake + transport decap) happens
+on the per-tunnel control thread (`wg_control_loop`) via a kernel UDP
+socket — slow path. Encap has two sites: the control thread's TUN-read
+loop (primary; slow path) and `frame/wg.rs::wg_encap_frame` (transit
+AF_XDP egress; worker context but rarely hit, and it already does two
+heap allocations per packet). **No new code runs on the non-WG forward
+path under any path option below.**
+
+Error/drop sites that need counting (exhaustive walk):
+
+| Site | Today | Reasons available |
+|---|---|---|
+| `engine.try_decap` | Err → debug_log at wg_control.rs:505 | `DecapError`: MalformedHeader, UnknownSession, ShortRecord, CounterRejectAfterMessages, CryptoFailed, ReplayDuplicate, ReplayOutOfWindow, MalformedInner, AllowedIpsViolation, BufferTooSmall |
+| `engine.try_encap` | Err → debug_log (control) / `None` (frame/wg.rs) | `EncapError`: UnknownPeer, NoSession, BufferTooSmall, CryptoFailed, RekeyRequired. NOTE: the unconfirmed-responder egress gate (engine.rs:720) is folded into `NoSession` — AGY r2 on #1736 requires it be DISTINGUISHABLE |
+| `consume_initiation_create_response` | Err → debug_log :470 | `HandshakeError` incl. `Framing(Mac1Mismatch)`, UnknownInitiator, Crypto, IndexExhausted |
+| `consume_response` | Err → debug_log :478 | `HandshakeError`: NoPendingHandshake, ReceiverIndexMismatch, Crypto, Framing(...) |
+| `create_initiation` Ok / send | send err → exception only | initiations-sent count missing |
+| cookie (type 3) | debug_log :485 (S7) | fixed reason |
+| unknown type / runt datagram | debug_log :511 | fixed reason |
+| MTU guard (control egress) | debug_log :539 | fixed reason |
+| MTU guard (transit egress, frame/wg.rs:85) | silent `None` | fixed reason |
+| socket send errors (handshake + transport) | exception ring only | count + keep exception |
+| TUN write errors | exception ring only | count + keep exception |
+| responder-no-endpoint TUN drain (wg_control.rs:247) | silent | fixed reason |
+| successful decap/encap | nothing | packets + bytes, both directions |
+| handshake completions | nothing | by role (initiator = `consume_response` Ok; responder = `consume_initiation_create_response` Ok) |
+| session confirmed (`mark_confirmed`) | nothing | gauge + transition stamp |
+
+Counters the ISSUE asks for that have NO increment site today (must
+NOT be invented): TAI64N-replay rejects (S1 explicitly does not enforce
+per-peer TAI64N anti-replay yet — handshake_session.rs:452-457) and
+under-load rate-limit rejects (cookie/MAC2 is S7). The plan reserves
+the reason names but ships no dead counters; they ride with responder
+hardening.
+
+Status plumbing precedent (#1769/#1771/#1782 neighbor-resolver family —
+the wire-additive template this plan copies mechanically):
+Rust atomics → `coordinator/status.rs` accessor →
+`server/helpers.rs` (fills `ProcessStatus`) →
+`protocol/control.rs` serde `default` fields →
+fixture `userspace-dp/tests/fixtures/protocol_wire_v1.json`
+(regen via `XPF_PROTOCOL_WIRE_REGEN=1`, key-absent pins in
+`protocol/tests.rs`) → `pkg/dataplane/userspace/protocol.go` →
+`pkg/api/metrics.go` descriptors + `metrics_userspace.go` emitters →
+`metrics_descriptor_coverage_test.go` pedantic-registry canary.
+
+## 3. Design decisions
+
+### 3.1 Where counters live: on the `WgEngine` (per-engine struct of relaxed atomics)
+
+A `WgCounters` struct (all `AtomicU64`, `Ordering::Relaxed`) owned by
+`WgEngine`, created in `WgEngine::new`. Rationale:
+
+- One engine == one tunnel (S2a) == the natural aggregation unit. The
+  engine `Arc` is shared by the control thread, the transit-egress
+  worker path, and the coordinator — every increment site can reach it
+  without new plumbing.
+- Engine-internal increments at the `try_encap`/`try_decap`/
+  `consume_*` return boundaries cover BOTH encap sites and BOTH
+  consume sites automatically — no per-call-site drift. The
+  wg_control.rs:521 comment already promises exactly this
+  ("telemetry is consolidated on the engine, not per call site").
+- Counters survive the control thread's #1872 teardown/respawn
+  tombstone cycle (the engine Arc outlives the thread).
+- `populate_wg_engines` reuses the engine Arc when
+  `wg_identity_unchanged` — counters survive unrelated commits for
+  free. An identity-CHANGING commit rebuilds the engine and resets
+  counters to zero; Prometheus `rate()` tolerates monotonic resets and
+  the reset itself is a faithful signal that the crypto identity (and
+  therefore all sessions) was rebuilt. We deliberately do NOT carry
+  counters across a rebuild: under #1873's positional renumbering,
+  `prev_state.wg_engines.get(&id)` at a SHIFTED id is a *different
+  tunnel*, and inheriting its counters would misattribute (§7 R2).
+- Call-site-only counters (the rows in §2 that fire before/outside the
+  engine: MTU guards, send/TUN errors, cookie/unknown-type, responder
+  drain) increment through the same struct via a public accessor
+  (`engine.counters()`).
+
+Hot-path cost, phrased precisely (Codex r1 F7): **no new allocation
+and no non-WG branch cost.** Non-WG traffic is untouched (the WG
+branch is gated at `tunnel_endpoint_id != 0`, frame/mod.rs:264). For
+WG traffic the additions are relaxed `fetch_add`s on paths that are
+either control-thread slow path or the transit path in frame/wg.rs —
+which ALREADY heap-allocates twice per packet (frame/wg.rs:97,111),
+a pre-existing style-guide deviation this plan neither fixes nor
+worsens (out of scope; noted so the claim is honest rather than
+"hot-path compliant").
+
+### 3.2 Keying / cardinality: per-TUNNEL rows keyed by tunnel NAME
+
+`ProcessStatus` gains `wg_tunnels: Vec<WgTunnelStatus>`
+(`skip_serializing_if = "Vec::is_empty"` — non-WG deployments are
+wire-byte-identical, same invariant discipline as #1621/#1635).
+
+Each row carries identification + state + flat counters:
+
+- `tunnel` (string, the wgN interface name from `ifindex_to_name`) —
+  the PRIMARY key. Stable across commits; robust against #1873 id
+  renumbering. This is also the only Prometheus label. Missing-name
+  fallback (Codex r1 F4 / SMR F6): reuse the snapshot row-label
+  convention (`linux_name`, else `interface`, mirroring
+  `wg_tombstone_respawn_coherent` at coordinator/mod.rs:827-831),
+  last resort `wg-endpoint-<id>` — a row is NEVER dropped for a
+  missing name (broken bring-up is exactly when telemetry matters).
+- `tunnel_endpoint_id` (u16, informational cross-ref; documented as
+  unstable per #1873 — never used as a join key by consumers).
+- `listen_port` (u16), `peer_pubkey_hex` (hex — matches the
+  `wg_peer_pubkey_hex` house convention on the config/snapshot wire
+  (protocol/snapshot.rs:361, protocol.go:310) and the value the
+  operator configured into xpf; no base64 dependency. The divergence
+  from `wg show`'s base64 rendering is noted in CLI help/docs).
+- `session_confirmed` (bool — `peer_has_confirmed_session`).
+- `last_handshake_unix_secs` (u64 epoch seconds; **0 = never** — see
+  §3.3 State. Replaces v1's age-secs field: an age gauge churns every
+  scrape and a Go `uint64,omitempty` mirror would conflate
+  "0 seconds ago" with "never" (AGY r1 F2+F3, Codex r1 F5, SMR F3)).
+- ~29 flat `u64` counter fields (§3.3). Flat named fields with serde
+  `default`, matching house wire style (no maps/enums on the wire).
+
+Per-PEER rows are NOT in scope: S2a is single-peer-per-tunnel, so
+per-tunnel == per-peer today; the multi-peer split is #1434 S6 work and
+the wire shape stays additive for it (S6 adds `peers: Vec<...>` inside
+the row when it lands).
+
+Cardinality: bounded by configured WG tunnels (today: 1; S6: small
+config-bounded N). No per-flow, per-session, or per-source state.
+
+### 3.3 Counter inventory (exact, every one has a live increment site)
+
+Handshake (per tunnel):
+1. `hs_initiations_created` — `create_initiation` Ok
+   (engine-internal). NOT named "sent": the UDP send happens later in
+   `drive_initiation` (wg_control.rs:427-435) and can fail — the
+   #1736 EINVAL fingerprint becomes `created↑ + send_errors↑ +
+   completions flat`.
+2. `hs_initiation_build_failures` — `create_initiation` Err, all
+   variants folded (today discarded by the `if let Ok` at
+   wg_control.rs:427). Engine-internal.
+3. `hs_responses_created` — `consume_initiation_create_response` Ok
+   (responder accepted msg1, built msg2, installed the unconfirmed
+   session — handshake_session.rs:517). This single increment site is
+   ALSO the responder-completion event; the Prometheus completions
+   metric emits it under `role="responder"` (no second counter, no
+   double count).
+4. `hs_completions_initiator` — `consume_response` Ok.
+5. `hs_rx_drops_mac1_mismatch` — `Framing(Mac1Mismatch)` from either
+   consume path.
+6. `hs_rx_drops_malformed` — `Framing(WrongLength|BadType|BadNoiseLen
+   |OutputTooSmall)`.
+7. `hs_rx_drops_crypto` — `Crypto | Internal`.
+8. `hs_rx_drops_unknown_peer` — `UnknownInitiator | UnknownPeer`.
+9. `hs_rx_drops_stale_response` — `NoPendingHandshake |
+   ReceiverIndexMismatch`.
+10. `hs_rx_drops_index_exhausted` — `IndexExhausted` (expected ~never).
+11. `hs_rx_cookie_unsupported` — type-3 datagrams (S7 placeholder).
+12. `rx_unknown_type` — type byte ∉ {1,2,3,4}. Explicit exclusion:
+    zero-length UDP datagrams never reach dispatch (`Ok(_) => break`
+    at wg_control.rs:197 consumes them before any type read), so the
+    `datagram.first() == None` arm is unreachable for counting
+    purposes and runts are NOT counted — documented, not invented.
+13. `hs_send_errors` — initiation AND response `wg_send_to` Err at
+    BOTH call sites (the response send at wg_control.rs:466 is
+    currently `let _ =` -discarded and must be routed through this
+    counter; exception-ring entries retained).
+14. `hs_requests_armed` — `request_handshake` returned true (the
+    NoSession worker→control edge; ties an encap drop burst to the
+    re-init it triggered).
+
+Transport decap (engine-internal in `try_decap`):
+15. `decap_packets`, 16. `decap_bytes` (inner-IP bytes, `outcome.len`).
+17. `decap_keepalives` — authenticated ZERO-length transport records
+    (WG persistent keepalives: `pad_to_16(0) == 0`, snow yields
+    `n == 0`). Classified after the replay gate and BEFORE the inner
+    parse; all external behavior unchanged (still no TUN write, still
+    `Err` to the caller, still `authenticated=false` at the dispatch
+    site). Without this counter a keepalive peer emits steady
+    `decap_drops_malformed_inner` false alarms — the exact
+    trust-destroying noise this plan exists to kill.
+18. `decap_drops_malformed_header` (MalformedHeader | ShortRecord —
+    both "structurally bogus record").
+19. `decap_drops_unknown_session` (UnknownSession).
+20. `decap_drops_counter_ceiling` (CounterRejectAfterMessages).
+21. `decap_drops_crypto` (CryptoFailed).
+22. `decap_drops_replay` (ReplayDuplicate | ReplayOutOfWindow).
+23. `decap_drops_allowed_ips` (AllowedIpsViolation).
+24. `decap_drops_malformed_inner` (MalformedInner, n > 0 only — the
+    keepalive class is peeled off in #17).
+25. `decap_drops_buffer` (BufferTooSmall — expected ~never; a nonzero
+    value means a sizing bug).
+
+Transport encap (engine-internal in `try_encap`, plus call-site MTU):
+26. `encap_packets`, 27. `encap_bytes` (inner-IP bytes — symmetric
+    with decap so the pair is comparable).
+28. `encap_drops_no_session` (NoSession from the no-current-session
+    arm ONLY).
+29. `encap_drops_unconfirmed` (NoSession from the `is_confirmed()`
+    gate arm — the AGY-r2-mandated distinction. Implementation:
+    increment a different counter inside `try_encap` before returning
+    the same `EncapError::NoSession`; the error enum and every caller
+    contract stay untouched).
+30. `encap_drops_rekey_required` (RekeyRequired — nonce ceiling).
+31. `encap_drops_other` (UnknownPeer | CryptoFailed | BufferTooSmall —
+    all "should never happen" classes, folded; split later if ever
+    nonzero).
+32. `encap_mtu_drops` — call-site, BOTH guards (wg_control.rs
+    `encap_and_send` + frame/wg.rs `wg_encap_frame`). The #1736
+    blackhole counter.
+33. `transport_send_errors` — encap'd datagram `wg_send_to` Err.
+34. `tun_write_errors` — decap'd inner `tun.write_all` Err.
+35. `tun_rx_drops_no_endpoint` — responder-without-endpoint TUN drain.
+
+State (not counters): `session_confirmed` bool;
+`last_handshake_complete_ns` AtomicU64 stamped (monotonic
+`monotonic_nanos` domain) at the two completion sites (#3, #4),
+converted at status-snapshot time to `last_handshake_unix_secs` (u64
+wall-clock epoch seconds; **0 = never** — unambiguous without
+Option/pointer plumbing, since epoch 0 is not a reachable handshake
+time) via the existing `monotonic_timestamp_to_datetime` helper (the
+worker-heartbeat conversion, coordinator/status.rs:414-429). GUARD
+(SMR r2): the conversion runs ONLY when the stored stamp is nonzero —
+feeding stamp 0 through the helper would compute a boot-relative
+wall time (a valid-looking past date), silently breaking the
+0-as-never contract. `stamp == 0 → last_handshake_unix_secs = 0`,
+no conversion. Codex r2 note: when converting the resulting
+`DateTime<Utc>` to u64, do not blindly cast — a pre-epoch/failed
+conversion maps to 0 (never), not a wrapped huge value. An NTP step skews the DISPLAYED wall time but fences
+nothing (#1792 lesson: the stored stamp stays monotonic). Asymmetry
+note: responder-side "completion" stamps at msg2 creation +
+unconfirmed-session install — if the msg2 send fails the peer never
+completes; the `session_confirmed` gauge (not the completion stamp)
+is the liveness signal, documented in the CLI help.
+
+Snapshot coherence note (Codex r1): the status poll reads each atomic
+independently while the control thread increments — multi-counter
+reads are NOT transactional (e.g. `decap_packets` may be one ahead of
+`decap_bytes` within a snapshot). Documented on the accessor; fine
+for observability counters, same posture as every existing counter
+family.
+
+Reserved (NOT shipped — no increment site): tai64n-replay,
+rate-limited. Documented in the module doc as riding with responder
+hardening.
+
+### 3.4 Prometheus surface (Go side)
+
+New descriptors in `pkg/api/metrics.go`, emitted from a new
+`emitWireguardTelemetry` in `metrics_userspace.go` (wired into
+`collectUserspaceStatus`), label `{tunnel}` (+ a small fixed enum
+label where it collapses descriptor count):
+
+- `xpf_userspace_wg_handshakes_completed_total{tunnel,role}` —
+  role="initiator" ← #4 `hs_completions_initiator`;
+  role="responder" ← #3 `hs_responses_created` (single increment
+  site; no double count).
+- `xpf_userspace_wg_handshake_initiations_created_total{tunnel}`
+- `xpf_userspace_wg_handshake_initiation_build_failures_total{tunnel}`
+- `xpf_userspace_wg_handshake_rx_drops_total{tunnel,reason}` (reasons:
+  mac1_mismatch, malformed, crypto, unknown_peer, stale_response,
+  index_exhausted, cookie_unsupported, unknown_type)
+- `xpf_userspace_wg_handshake_requests_armed_total{tunnel}`
+- `xpf_userspace_wg_transport_packets_total{tunnel,direction}` (encap/decap)
+- `xpf_userspace_wg_transport_bytes_total{tunnel,direction}`
+- `xpf_userspace_wg_keepalives_received_total{tunnel}`
+- `xpf_userspace_wg_transport_drops_total{tunnel,direction,reason}`
+  (decap: malformed_header, unknown_session, counter_ceiling, crypto,
+  replay, allowed_ips, malformed_inner, buffer; encap: no_session,
+  unconfirmed, rekey_required, mtu, other)
+- `xpf_userspace_wg_send_errors_total{tunnel,kind}` (handshake,
+  transport, tun_write, tun_rx_no_endpoint)
+- `xpf_userspace_wg_session_confirmed{tunnel}` gauge (0/1)
+- `xpf_userspace_wg_last_handshake_time_seconds{tunnel}` gauge —
+  absolute epoch seconds (AGY r1 F3: an age gauge churns every scrape
+  and compresses poorly; PromQL computes age as
+  `time() - xpf_userspace_wg_last_handshake_time_seconds`). Emitted
+  only when nonzero (never-handshaked emits no series).
+
+All series emitted per configured tunnel (zeros emitted, not omitted —
+"0 drops" is a real signal, per the #1771 §2.6 convention), EXCEPT the
+never-handshaked age gauge. `descriptorCoverageDP`'s fake
+`ProcessStatus` gains a populated `WgTunnels` row so the #1726
+pedantic-registry canary actually exercises the family (the lesson
+from the zone/policy families at metrics_descriptor_coverage_test.go:48).
+
+## 4. Paths
+
+### Path A — counters + status DTO + Prometheus (no CLI)
+
+Everything in §3. Exposure is Prometheus + the raw status JSON
+(`xpfd` debug surfaces). `show security wireguard` deferred to #1434
+S6 wholesale.
+
+- (+) Smallest blast radius; no cmdtree/grpc/cli changes.
+- (−) The #1736 pain story is an operator at a CLI. Junos operators
+  type `show security ...` first; Prometheus second. Leaves the
+  primary UX gap open and #1434 S6 is not scheduled.
+
+### Path B — Path A + minimal `show security wireguard` (RECOMMENDED)
+
+Adds the operational command on top of A, following the
+`show system buffers` pattern exactly (cmdtree node + local CLI
+handler + gRPC server handler, both reading the SAME
+`dpuserspace.ProcessStatus.WgTunnels` — no new RPC, no proto change):
+
+- `pkg/cmdtree/tree.go`: `show security wireguard` node (Desc:
+  "Show WireGuard tunnel status"), child `detail`.
+- `pkg/cli/cli_show_security_wireguard.go` (new, per the
+  module/aspect-file layout rule): summary renders per tunnel —
+  interface, listen port, peer key, configured endpoint, session
+  state, latest handshake, transfer (encap/decap pkts+bytes), total
+  drops; `detail` adds the full per-reason drop table (the
+  one-glance view for the #1736 class of failures).
+- `pkg/grpcapi/server_show_security_wireguard.go`: same rendering for
+  the remote CLI (mirrors `server_show_system_buffers` flow).
+
+Scope guard: this is a STATUS command only. Key generation,
+public-key display sourced from config, and multi-tunnel selection
+arguments remain #1434.
+
+- (+) Closes the actual operator gap the issue narrates; mechanical
+  (~3 files + tests) on a proven pattern; both CLIs covered.
+- (−) Touches the operational tree → larger review surface; partial
+  overlap with #1434's eventual command (mitigated: #1434 extends
+  this node rather than conflicting — `public-key`/`generate` are
+  sibling leaves).
+
+### Path C — Path A/B + bounded drop-EVENT ring
+
+A per-engine ring of the last N (64) drop events with timestamp /
+reason / peer endpoint / counter value, surfaced like
+`recent_exceptions`.
+
+- (+) Answers "WHICH endpoint sent the garbage" without tcpdump.
+- (−) Wire + status-size growth; allocation and formatting on drop
+  paths (a hostile flood formats strings); `RecentExceptions` already
+  covers the errno class; counters cover the rate class. Poor
+  cost/benefit now. **Offered for explicit kill** — recommend
+  deferring until a live incident shows counters alone insufficient.
+
+Recommendation: **Path B**, commits structured A-first (Rust counters →
+wire → Go DTO → Prometheus → CLI) so the CLI commit is separable if
+review stalls it.
+
+## 5. Wire-additive discipline (mandatory checklist)
+
+1. `protocol/control.rs`: `WgTunnelStatus` struct + `wg_tunnels` field,
+   serde `default` + `skip_serializing_if = "Vec::is_empty"`. The
+   explicit `ProcessStatus` initializer at server/lifecycle.rs:73 uses
+   struct-literal + defaults — verify the new field is covered (Codex
+   r1 F5).
+2. Key-absent pins (Rust `protocol/tests.rs`): pre-#1865 payload with
+   the key absent decodes to empty vec; a default `ProcessStatus`
+   serializes byte-identical to pre-#1865 (the §3.2 invariant).
+3. POPULATED round-trip pins BOTH sides (Codex r1 F5: the fixture
+   canary has a residual gap for optional populated fields,
+   protocol/tests.rs:1060): a `WgTunnelStatus` with every field
+   nonzero round-trips Rust→JSON→Rust and unmarshals identically in
+   Go.
+4. Fixture: `XPF_PROTOCOL_WIRE_REGEN=1 cargo test --bin
+   xpf-userspace-dp` regen + manual diff review of
+   `tests/fixtures/protocol_wire_v1.json`.
+5. `pkg/dataplane/userspace/protocol.go`: mirrored struct, json tags
+   identical to the serde renames (grep BOTH sides per
+   feedback_wire_protocol_both_sides).
+6. Go-side key-absent pin: old JSON without `wg_tunnels` unmarshals to
+   nil slice; emitter skips cleanly.
+7. `pkg/api`: descriptors + Describe() + emitter + canary fixture row.
+
+## 6. Tests
+
+Rust (wg module, plain debug + release):
+- Full IK handshake between two engines → assert
+  initiations_created=1, responses_created=1, completions both roles,
+  last_handshake stamp set, session_confirmed transitions after first
+  decap.
+- Authenticated zero-length transport record (keepalive) →
+  `decap_keepalives` increments, `decap_drops_malformed_inner` does
+  NOT, replay window advanced, behavior otherwise unchanged (still
+  Err to the caller).
+- `create_initiation` toward an unknown peer →
+  `hs_initiation_build_failures`.
+- MAC1-corrupted initiation → `hs_rx_drops_mac1_mismatch` (the
+  wrong-key-peer case used in live validation).
+- Replayed counter → `decap_drops_replay`; AllowedIPs-violating inner
+  → `decap_drops_allowed_ips`; truncated record →
+  `decap_drops_malformed_header`.
+- Unconfirmed responder egress → `encap_drops_unconfirmed` (NOT
+  `encap_drops_no_session`) and error still `NoSession` (caller
+  contract pinned).
+- Counter survival across `reconcile_peers` with unchanged identity
+  (engine reuse path).
+- wg_control loop-level: MTU-oversize inner → `encap_mtu_drops`
+  (pure-function guard already unit-tested; counter assert rides the
+  existing tests).
+- Wire round-trip + key-absent pins (§5).
+
+Go:
+- Emitter unit test: populated `WgTunnels` row → assert the FULL
+  expected series set with exact label values (the reason label list
+  is compile-visible in the emitter; the wire itself is flat named
+  u64 fields, so cross-language drift is structurally impossible
+  without an explicit two-sided field addition — v1's "parity-pin
+  test" promise was unguardable theater and is dropped, SMR F5).
+- Descriptor-coverage canary (extended fixture row).
+- protocol.go unmarshal pin (absent + populated).
+
+Live (loss cluster, Phase 2): deploy → bring up interop peer via
+`test/incus/wg-interop.sh` provision/configure → assert (a) handshake
+counters move on bring-up, (b) transport pkts/bytes move under iperf3
+through the tunnel, (c) wrong-key peer → mac1_mismatch increments,
+(d) `show security wireguard` renders (Path B), (e) Prometheus scrape
+carries the family. Re-apply CoS after deploy.
+
+## 7. Risks
+
+- **R1 — wire bloat / status-poll cost.** ~30 u64 + 3 strings per
+  configured tunnel, only when WG is configured; empty-vec skip keeps
+  non-WG deployments byte-identical. Status poll is 1/s; negligible.
+- **R2 — #1873 id instability.** Mitigated by name-keying (§3.2) and
+  by NOT inheriting counters across engine rebuilds. Residual: an
+  id-shift commit resets the shifted tunnel's counters (alongside its
+  sessions, which #1873 already resets) — visible as a counter reset,
+  which is itself diagnostic. Fixing the renumbering is #1873, not
+  this issue.
+- **R3 — reason-enum drift between Rust and Go.** Mitigated by the
+  parity-pin test (§6) and by folding only stable classes.
+- **R4 — hot-path regression.** No non-WG path is touched; transit
+  encap adds 2 relaxed fetch_adds to a path with 2 heap allocations.
+  Gate: `cargo build --release` + the existing perf posture; no
+  flamegraph gate needed at this cost class (consistent with how the
+  #1769 resolver counters shipped).
+- **R5 — counter semantics under respawn.** Control-thread respawn
+  (#1872 tombstone) keeps the engine Arc → counters continuous. A
+  spawn-FAILED window drops TUN traffic invisibly to these counters
+  (nothing is reading the TUN) — that window is already covered by
+  RecentExceptions + #1872 transition logs; documented, not counted.
+
+## 8. Docs
+
+- `userspace-dp/src/afxdp/wg/mod.rs` module doc: telemetry section
+  (what is counted where, reset semantics, reserved reasons).
+- `docs/wireguard-interop.md` + `docs/wg-interop-runbook.md`: replace
+  the "peer `wg show` is the primary oracle" guidance with the local
+  counters as primary oracle (peer-side stays as cross-check).
+- `docs/config-schema.md`: NOT touched (no config leaf).
+- cmdtree/CLI docs (Path B): command reference entry.
+
+## 9. Out of scope
+
+- TAI64N anti-replay + under-load rate limiting (responder hardening;
+  reasons reserved).
+- Cookie/MAC2 (S7), rekey/retry timers (S5), multi-tunnel + key
+  management CLI (#1434), tunnel-id stabilization (#1873).
+- Drop-event ring (Path C, unless reviewers overrule).
+- Per-peer rows (S6 multi-peer).
+- Latent gap noted during the keepalive analysis (SMR r1 F1), NOT
+  fixed here: an authenticated keepalive currently exits `try_decap`
+  via `Err`, so `dispatch_inbound` returns `authenticated=false` and
+  keepalives neither refresh endpoint-learning nor count as
+  authentication for roaming purposes (wg_control.rs:181-195). A
+  keepalive-only roaming peer would not be re-learned until its next
+  data/handshake packet. File as a follow-up issue at /engineer time;
+  changing it is behavior, not telemetry.
+- The pre-existing per-packet allocations on the transit encap path
+  (frame/wg.rs:97,111) — noted in §3.1, untouched.
+
+## 10. Deliverable
+
+Phase 2 (`/engineer`) PR closing #1865: Rust `WgCounters` + increment
+sites + status plumbing + wire-additive `wg_tunnels` + Go DTO +
+Prometheus family (+ Path B CLI command), tests per §6, live evidence
+per §6, docs per §8. Logical commits in dependency order (counters →
+wire → Go → Prometheus → CLI).
+
+## 11. Decision asked of reviewers
+
+Round-1 resolutions (all three reviewers answered; unanimous):
+
+1. Path A vs B vs C → **Path B**, Path C killed (Codex: "too broad";
+   AGY: kill, allocation/formatting on drop paths violates
+   latency-first; SMR: defer/kill).
+2. Keying → per-tunnel rows keyed by name, id informational,
+   unanimous (now with the F4/F6 missing-name fallback).
+3. Inventory → unanimous yes on `encap_drops_other` folding and the
+   counter-only unconfirmed split; Codex+SMR additions (keepalives,
+   build-failures, response-send instrumentation, runt exclusion)
+   folded into §3.3.
+4. No-carry-across-rebuild → unanimous yes.
+5. Bytes → inner-IP both directions, unanimous; v2 documents that
+   these are logical tunnel payload bytes and will NOT match a kernel
+   peer's `wg show` transfer numbers (which include WG overhead).
+
+Round-2 question: any objection to the v2-specific choices —
+`last_handshake_unix_secs` with 0-as-never (vs Option/pointer), and
+the keepalive counter being classified inside `try_decap` with
+unchanged external behavior?

--- a/docs/pr/1865-wg-telemetry/reviewer-ids.md
+++ b/docs/pr/1865-wg-telemetry/reviewer-ids.md
@@ -28,5 +28,17 @@
   ifindex_to_name first preserves today's primary path; wording pin
   updated; whitespace fix is docs-only)
 
-## Code round 3 (whitespace fix)
-- pending Codex re-attest
+## Code round 3 (head 6511b9c94 — whitespace fix only)
+- Codex: session 019eb8f1-5f6e-7343-88e0-51d2d64f082a — MERGE-READY
+  (verified git diff --check clean across the full PR range) —
+  codex-code-r3.md
+
+## Convergence
+- Codex MERGE-READY (r3) + AGY MERGE-READY (r2) + Claude SMR
+  MERGE-READY (r1 + delta re-attest). Copilot: quota-limited on all
+  THREE documented retries (22:16 / 23:01 / 23:07 UTC review stubs on
+  the PR) -> 3-of-4 path per feedback_codex_infra_must_retry.
+- Live validation evidence on the PR (handshake counters, keepalive
+  classification, mac1-mismatch=5 forced drops, 37 Prometheus series,
+  show security wireguard detail).
+- NOT merged: parent runs final smoke + merge.

--- a/docs/pr/1865-wg-telemetry/reviewer-ids.md
+++ b/docs/pr/1865-wg-telemetry/reviewer-ids.md
@@ -1,0 +1,15 @@
+# PR #1876 (#1865) reviewer task-id ledger
+
+## Plan rounds (research phase — research/1865-wg-telemetry branch)
+- r1: Codex task-mqa0ade4-1mtshv NEEDS-MAJOR; AGY adversarial-review-mqa09l7f-a4rixg NEEDS-MAJOR (f1 refuted); SMR NEEDS-MINOR
+- r2: Codex task-mqa0pcn3-347u73 PLAN-READY; AGY adversarial-review-mqa0ovaw-q6zx2t PLAN-READY (f1 withdrawn); SMR PLAN-READY
+
+## Code round 1 (head a8c98cb1f)
+- Codex: session 019eb8da-9214-7c21-88b2-631f057cbe43 — NEEDS-CHANGES
+  (F1 name-fallback chain incomplete; F2 'initiations sent' wording) — codex-code-r1.md
+- AGY: adversarial-review-mqa32eme-2ia15q — MERGE-READY — agy-code-r1.md
+- Claude SMR: claude-smr-code-r1.md — MERGE-READY (worked traces A/B; cosmetic keepalive dedup applied)
+- Copilot: quota-limited (retry 1 documented)
+
+## Code round 2 (head 65a84eecc — Codex F1+F2 folded)
+- pending

--- a/docs/pr/1865-wg-telemetry/reviewer-ids.md
+++ b/docs/pr/1865-wg-telemetry/reviewer-ids.md
@@ -13,3 +13,20 @@
 
 ## Code round 2 (head 65a84eecc — Codex F1+F2 folded)
 - pending
+
+## Code round 2 (head 832514fdc)
+- Codex: session 019eb8ee-30ea-7851-bd4c-e52d1c2a600d — NEEDS-CHANGES
+  (ONLY trailing whitespace in the copied round-1 review-record .md
+  files; both code folds verified correct; residual note: no direct
+  Rust unit test for the interface_label fallback — accepted as a
+  coverage gap, the fallback is exercised by compile + the live
+  name-resolution evidence) — codex-code-r2.md
+- AGY: adversarial-review-mqa3r7h5-ajp16u — MERGE-READY (deltas safe;
+  interface_label non-secret in Debug) — agy-code-r2.md
+- Claude SMR: re-attest MERGE-READY (delta audit: interface_label is
+  an interface-name string, Debug-safe; fallback tier ordering
+  ifindex_to_name first preserves today's primary path; wording pin
+  updated; whitespace fix is docs-only)
+
+## Code round 3 (whitespace fix)
+- pending Codex re-attest

--- a/docs/wg-interop-runbook.md
+++ b/docs/wg-interop-runbook.md
@@ -103,7 +103,7 @@ that fw1 has neither a `wg0` netdev nor a `:51820` bind, and fails hard
 | xpf never initiates time-based rekey; on an xpf-initiated session the tunnel recovers via the peer's expiry-driven re-handshake at REJECT_AFTER_TIME (~180 s) with a small bounded gap | REKEY/REJECT timers unimplemented | S5 |
 | brief egress drop right after a peer-initiated rekey | stricter-than-spec unconfirmed-responder TX gate (`engine.rs` try_encap; no `peer.previous` TX fallback) — ms-scale vs kernel wg | file if >1 s measured |
 | keys are hex in xpf config, base64 in `wg` | minimal S2a grammar | S6 (#1434) |
-| no `wg show`-equivalent / WG counters on the xpf side | telemetry not wired into status/Prometheus | S6 follow-up issue |
+| ~~no `wg show`-equivalent / WG counters on the xpf side~~ | RESOLVED by #1865: `show security wireguard [detail]` + `xpf_userspace_wg_*` Prometheus family + `wg_tunnels` status rows | done (#1865) |
 | cookie (type 3) messages dropped | cookie/MAC2 consume unimplemented | S7 |
 | PSK must be absent/zero on the peer | PSK plumbing unimplemented | S4 |
 | WG tunnel removed from config leaks the wgN TUN until `ip link del`/restart | S2a persistent-TUN tradeoff | S6; harness teardown deletes it |
@@ -153,10 +153,24 @@ that fw1 has neither a `wg0` netdev nor a `:51820` bind, and fails hard
 
 ## Failure triage
 
+0. **Start with the local counters (#1865)** — `show security
+   wireguard detail` on fw0 (or the `xpf_userspace_wg_*` Prometheus
+   family) is now the PRIMARY oracle; the peer-side `wg show` and
+   tcpdump steps below are cross-checks, not first resort:
+   - initiations created ↑ + `handshake-send` I/O errors ↑ +
+     completions flat = the silent-send class (the #1736 EINVAL bug).
+   - `mac1-mismatch` ↑ = key mismatch (wrong/garbled peer key).
+   - handshakes complete but transmit drops `mtu-exceeded` ↑ = the
+     pad-aware MTU guard (the #1736 v4-mapped blackhole class).
+   - transmit drops `unconfirmed-session` ↑ = transient responder
+     key-confirmation window (expected blip at rekey, not a fault).
+   - receive drops `allowed-ips-violation` ↑ = inner-source gate
+     (triage step 3).
 1. P1 no handshake: tcpdump UDP 51820 on the peer — msg1 arriving?
    If NOTHING leaves fw0, strace the `xpf-wg-control-` thread for
    `sendto` errors (the dual-stack v4-mapped send bug fixed in this PR
-   showed exactly one silent EINVAL per initiator tick).
+   showed exactly one silent EINVAL per initiator tick — now also
+   visible without strace as `hs_send_errors` per triage step 0).
    xpf side: `journalctl -u xpfd | grep -i wg`, check the wg0 TUN exists
    and `:51820` is bound on fw0; check the peer's `wg show wgref` for
    key mismatch (hex↔base64 conversion).

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -75,7 +75,9 @@ ip link set wgref up
 
 # Direction A: xpf create_initiation -> UDP <peer_vm_ip>:<P>; kernel wg
 #   verifies MAC1 + decrypts the TAI64N + replies type-2; xpf
-#   consume_response derives the session. Assert via `wg show wgref`.
+#   consume_response derives the session. Assert via `wg show wgref`
+#   (peer-side cross-check) and `show security wireguard` on xpf
+#   (#1865 — local handshake counters are the primary oracle).
 # Direction B: kernel wg initiates (persistent-keepalive 1); xpf
 #   consume_initiation_create_response replies; assert `wg show` completes.
 ```

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -319,6 +319,23 @@ type xpfCollector struct {
 	neighborNetlinkRedumpUpsertsTotal       *prometheus.Desc
 	neighborPendingKeys                     *prometheus.Desc
 	negNeighKeys                            *prometheus.Desc
+	// #1865: operator-visible WireGuard telemetry — per-tunnel
+	// handshake/encap/decap counters + drop reasons from the helper's
+	// wg_tunnels status rows. Label sets: {tunnel} (+ role / direction
+	// / reason / kind bounded enums). The tunnel label is the tunnel
+	// NAME (stable across commits; #1873 ids are not).
+	wgHandshakesCompletedTotal              *prometheus.Desc
+	wgHandshakeInitiationsCreatedTotal      *prometheus.Desc
+	wgHandshakeInitiationBuildFailuresTotal *prometheus.Desc
+	wgHandshakeRxDropsTotal                 *prometheus.Desc
+	wgHandshakeRequestsArmedTotal           *prometheus.Desc
+	wgTransportPacketsTotal                 *prometheus.Desc
+	wgTransportBytesTotal                   *prometheus.Desc
+	wgKeepalivesReceivedTotal               *prometheus.Desc
+	wgTransportDropsTotal                   *prometheus.Desc
+	wgSendErrorsTotal                       *prometheus.Desc
+	wgSessionConfirmed                      *prometheus.Desc
+	wgLastHandshakeTimeSeconds              *prometheus.Desc
 }
 
 func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -521,6 +538,18 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.neighborNetlinkRedumpUpsertsTotal
 	ch <- c.neighborPendingKeys
 	ch <- c.negNeighKeys
+	ch <- c.wgHandshakesCompletedTotal
+	ch <- c.wgHandshakeInitiationsCreatedTotal
+	ch <- c.wgHandshakeInitiationBuildFailuresTotal
+	ch <- c.wgHandshakeRxDropsTotal
+	ch <- c.wgHandshakeRequestsArmedTotal
+	ch <- c.wgTransportPacketsTotal
+	ch <- c.wgTransportBytesTotal
+	ch <- c.wgKeepalivesReceivedTotal
+	ch <- c.wgTransportDropsTotal
+	ch <- c.wgSendErrorsTotal
+	ch <- c.wgSessionConfirmed
+	ch <- c.wgLastHandshakeTimeSeconds
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -217,6 +217,26 @@ func populatedCoverageStatus() dpuserspace.ProcessStatus {
 		MaxSessions:         1000,
 		FlowCacheCapacity:   4096,
 		CoSInterfaces:       []dpuserspace.CoSInterfaceStatus{cosIface},
+		// #1865: one populated WG tunnel row so emitWireguardTelemetry's
+		// whole descriptor family is exercised by the canary (the
+		// zone/policy lesson at the top of this file: families that
+		// need fixture data silently fall out of coverage without it).
+		// LastHandshakeUnixSecs is nonzero so the gated gauge emits.
+		WgTunnels: []dpuserspace.WgTunnelStatus{
+			{
+				Tunnel:                "wg0",
+				TunnelEndpointID:      9,
+				ListenPort:            51820,
+				PeerPubkeyHex:         "ab",
+				SessionConfirmed:      true,
+				LastHandshakeUnixSecs: 1_770_000_000,
+				HsInitiationsCreated:  3,
+				DecapPackets:          5,
+				EncapPackets:          6,
+				EncapMtuDrops:         1,
+				HsSendErrors:          2,
+			},
+		},
 		WorkerRuntime: []dpuserspace.WorkerRuntimeStatus{
 			{
 				WorkerID: 0,
@@ -437,30 +457,30 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 	// a single desc) also fails this canary.
 	names := gatheredNames(mfs)
 	want := []string{
-		"xpf_packets_total",                                          // collectGlobalCounters
-		"xpf_zone_packets_total",                                     // collectZoneCounters
-		"xpf_policy_hits_total",                                      // collectPolicyCounters
-		"xpf_filter_hits_total",                                      // collectFilterCounters
-		"xpf_nat_pool_total_ports",                                   // collectNATPoolMetrics
-		"xpf_sessions_active",                                        // collectSessionGauges
-		"xpf_daemon_uptime_seconds",                                  // collectSystemMetrics
-		"xpf_daemon_neighbor_periodic_last_success_age_seconds",      // #1780 neighbor watchdog
-		"xpf_ipmon_policy_failed",                                    // #1827 ip-monitoring
-		"xpf_userspace_worker_dead",                                  // emitWorkerRuntime
-		"xpf_userspace_worker_cold_path_samples_v3_total",            // cold-path v3
-		"xpf_cos_drain_invocations_total",                            // CoS owner profile
-		"xpf_userspace_three_color_policer_drops_total",              // three-color policer
-		"xpf_userspace_source_nat_pool_live_flows",                   // userspace SNAT pool
-		"xpf_userspace_neighbor_warm_drops_total",                    // neighbor-warm
-		"xpf_userspace_neg_neigh_fast_fail_total",                    // #1782 cold-start H1
-		"xpf_userspace_worker_cos_wheel_ticks_advanced_total",        // #1782 Step-1 (i) wheel sum
-		"xpf_userspace_worker_cos_wheel_ticks_advanced_max",          // #1782 Step-1 (i) wheel max
-		"xpf_userspace_worker_cos_queue_lease_undergrant_total",      // #1782 Step-1 (ii) per-cause
-		"xpf_userspace_pending_neigh_duplicate_drops_total",          // #1782 cold-start H5
-		"xpf_userspace_dynamic_neighbor_present",                     // #1782 cold-start H2 dump
-		"xpf_userspace_session_publish_errors_total",                 // #1789 publish failures
+		"xpf_packets_total",                                                // collectGlobalCounters
+		"xpf_zone_packets_total",                                           // collectZoneCounters
+		"xpf_policy_hits_total",                                            // collectPolicyCounters
+		"xpf_filter_hits_total",                                            // collectFilterCounters
+		"xpf_nat_pool_total_ports",                                         // collectNATPoolMetrics
+		"xpf_sessions_active",                                              // collectSessionGauges
+		"xpf_daemon_uptime_seconds",                                        // collectSystemMetrics
+		"xpf_daemon_neighbor_periodic_last_success_age_seconds",            // #1780 neighbor watchdog
+		"xpf_ipmon_policy_failed",                                          // #1827 ip-monitoring
+		"xpf_userspace_worker_dead",                                        // emitWorkerRuntime
+		"xpf_userspace_worker_cold_path_samples_v3_total",                  // cold-path v3
+		"xpf_cos_drain_invocations_total",                                  // CoS owner profile
+		"xpf_userspace_three_color_policer_drops_total",                    // three-color policer
+		"xpf_userspace_source_nat_pool_live_flows",                         // userspace SNAT pool
+		"xpf_userspace_neighbor_warm_drops_total",                          // neighbor-warm
+		"xpf_userspace_neg_neigh_fast_fail_total",                          // #1782 cold-start H1
+		"xpf_userspace_worker_cos_wheel_ticks_advanced_total",              // #1782 Step-1 (i) wheel sum
+		"xpf_userspace_worker_cos_wheel_ticks_advanced_max",                // #1782 Step-1 (i) wheel max
+		"xpf_userspace_worker_cos_queue_lease_undergrant_total",            // #1782 Step-1 (ii) per-cause
+		"xpf_userspace_pending_neigh_duplicate_drops_total",                // #1782 cold-start H5
+		"xpf_userspace_dynamic_neighbor_present",                           // #1782 cold-start H2 dump
+		"xpf_userspace_session_publish_errors_total",                       // #1789 publish failures
 		"xpf_userspace_session_nat_reverse_key_shared_displacements_total", // #1760 W3' shared displacements
-		"xpf_userspace_worker_command_queue_poison_recoveries_total", // #1807 poison recoveries
+		"xpf_userspace_worker_command_queue_poison_recoveries_total",       // #1807 poison recoveries
 		// #1771 §2.6 resolver backoff + §2.5 ENOBUFS/re-dump + key gauges
 		"xpf_userspace_neighbor_resolver_get_backoff_attempts_total",
 		"xpf_userspace_neighbor_netlink_enobufs_total",
@@ -468,6 +488,14 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_userspace_neighbor_netlink_redump_upserts_total",
 		"xpf_userspace_neighbor_pending_keys",
 		"xpf_userspace_neg_neigh_keys",
+		// #1865 WireGuard telemetry family (emitWireguardTelemetry)
+		"xpf_userspace_wg_handshakes_completed_total",
+		"xpf_userspace_wg_handshake_rx_drops_total",
+		"xpf_userspace_wg_transport_packets_total",
+		"xpf_userspace_wg_transport_drops_total",
+		"xpf_userspace_wg_send_errors_total",
+		"xpf_userspace_wg_session_confirmed",
+		"xpf_userspace_wg_last_handshake_time_seconds",
 		// #1830 (g): bucket-vs-flow occupancy gauges
 		"xpf_userspace_cos_flow_fair_buckets_occupied",
 		"xpf_userspace_cos_flow_fair_flows_active",

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1137,5 +1137,70 @@ func newCollector(srv *Server) *xpfCollector {
 			"Keys currently held in the per-binding negative neighbor caches, summed across bindings (gauge; lazy-TTL upper bound — an expired entry stays counted until its next access) (#1771 §2.6).",
 			nil, nil,
 		),
+		// #1865: per-tunnel WireGuard telemetry. The tunnel label is
+		// the tunnel interface NAME (stable across commits — #1873
+		// positional ids renumber and are never a label). Counters
+		// reset when a commit changes the tunnel's crypto identity
+		// (engine rebuild); rate() handles the monotonic reset.
+		wgHandshakesCompletedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshakes_completed_total",
+			"WireGuard handshake completions by role: initiator = a consumed response promoted our initiation; responder = we accepted an initiation and created (and installed the session for) the response (#1865).",
+			[]string{"tunnel", "role"}, nil,
+		),
+		wgHandshakeInitiationsCreatedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_initiations_created_total",
+			"WireGuard handshake initiations BUILT (not necessarily sent — a failing socket send counts in xpf_userspace_wg_send_errors_total{kind=\"handshake\"}; created rising with completions flat and send errors rising is the silent-send fingerprint from #1736) (#1865).",
+			[]string{"tunnel"}, nil,
+		),
+		wgHandshakeInitiationBuildFailuresTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_initiation_build_failures_total",
+			"WireGuard initiation build failures (engine could not construct msg1 — unknown peer, index exhaustion, crypto/internal error; all folded) (#1865).",
+			[]string{"tunnel"}, nil,
+		),
+		wgHandshakeRxDropsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_rx_drops_total",
+			"Inbound WireGuard handshake-path datagrams dropped, by reason (mac1_mismatch | malformed | crypto | unknown_peer | stale_response | index_exhausted | cookie_unsupported | unknown_type). mac1_mismatch is the wrong-key-peer signature (#1865).",
+			[]string{"tunnel", "reason"}, nil,
+		),
+		wgHandshakeRequestsArmedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_requests_armed_total",
+			"Accepted NoSession worker→control handshake-request edges (rate-limited to 1/s) — ties an encap-drop burst to the re-initiation it triggered (#1865).",
+			[]string{"tunnel"}, nil,
+		),
+		wgTransportPacketsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_transport_packets_total",
+			"WireGuard transport packets successfully processed, by direction (encap = egress encrypt, decap = ingress decrypt+deliver) (#1865).",
+			[]string{"tunnel", "direction"}, nil,
+		),
+		wgTransportBytesTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_transport_bytes_total",
+			"WireGuard transport INNER-IP bytes by direction (logical tunnel payload bytes, excluding WG+outer overhead — will not match a kernel peer's `wg show` transfer numbers) (#1865).",
+			[]string{"tunnel", "direction"}, nil,
+		),
+		wgKeepalivesReceivedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_keepalives_received_total",
+			"Authenticated zero-length WireGuard transport records (peer persistent keepalives). Classified separately so keepalive traffic never inflates the malformed_inner drop reason (#1865).",
+			[]string{"tunnel"}, nil,
+		),
+		wgTransportDropsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_transport_drops_total",
+			"WireGuard transport drops by direction and reason. decap: malformed_header | unknown_session | counter_ceiling | crypto | replay | allowed_ips | malformed_inner | buffer. encap: no_session | unconfirmed | rekey_required | mtu | other. `unconfirmed` is the responder key-confirmation window (transient at rekey — distinct from no_session so operators do not tcpdump a blip); `mtu` is the exact pad-aware guard at BOTH egress sites (the #1736 v4-mapped blackhole class) (#1865).",
+			[]string{"tunnel", "direction", "reason"}, nil,
+		),
+		wgSendErrorsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_send_errors_total",
+			"WireGuard I/O errors by kind: handshake = msg1/msg2 socket send failed (the #1736 EINVAL class); transport = encap'd datagram send failed; tun_write = decap'd inner delivery to the wgN TUN failed; tun_rx_no_endpoint = inner packets drained+dropped while a responder-only peer has no learned endpoint (#1865).",
+			[]string{"tunnel", "kind"}, nil,
+		),
+		wgSessionConfirmed: prometheus.NewDesc(
+			"xpf_userspace_wg_session_confirmed",
+			"Whether the tunnel's peer currently holds a CONFIRMED (egress-usable) transport session (1/0 gauge). The liveness signal — a responder-side handshake completion alone does not imply the peer ever received our response (#1865).",
+			[]string{"tunnel"}, nil,
+		),
+		wgLastHandshakeTimeSeconds: prometheus.NewDesc(
+			"xpf_userspace_wg_last_handshake_time_seconds",
+			"Wall-clock epoch seconds of the most recent WireGuard handshake completion (either role). Absent until the first handshake completes; compute age as time() - this (#1865).",
+			[]string{"tunnel"}, nil,
+		),
 	}
 }

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -46,6 +46,109 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp ap
 	c.emitFairnessThroughputGauges(ch, status)
 	c.emitNeighborWarmCounters(ch, status)
 	c.emitNeighborColdStartCapture(ch, status)
+	c.emitWireguardTelemetry(ch, status)
+}
+
+// emitWireguardTelemetry exposes the #1865 per-WG-tunnel telemetry
+// rows. Every counter series is emitted unconditionally per configured
+// tunnel — a 0 is a real "no drops" signal, not an absent series
+// (matching the #1771 §2.6 convention) — EXCEPT the last-handshake
+// gauge, which is absent until the first handshake completes (0 is the
+// in-band "never" sentinel on the wire). The tunnel label is the
+// tunnel NAME: stable across commits, unlike the positional
+// tunnel_endpoint_id (#1873).
+func (c *xpfCollector) emitWireguardTelemetry(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	for _, t := range status.WgTunnels {
+		counter := func(desc *prometheus.Desc, v uint64, labels ...string) {
+			ch <- prometheus.MustNewConstMetric(
+				desc, prometheus.CounterValue, float64(v), labels...)
+		}
+		// Completions by role: role=responder is the helper's
+		// hs_responses_created (the single responder-completion
+		// increment site — session installed at msg2 creation).
+		counter(c.wgHandshakesCompletedTotal, t.HsCompletionsInitiator, t.Tunnel, "initiator")
+		counter(c.wgHandshakesCompletedTotal, t.HsResponsesCreated, t.Tunnel, "responder")
+		counter(c.wgHandshakeInitiationsCreatedTotal, t.HsInitiationsCreated, t.Tunnel)
+		counter(c.wgHandshakeInitiationBuildFailuresTotal, t.HsInitiationBuildFailures, t.Tunnel)
+		counter(c.wgHandshakeRequestsArmedTotal, t.HsRequestsArmed, t.Tunnel)
+
+		for _, r := range []struct {
+			reason string
+			v      uint64
+		}{
+			{"mac1_mismatch", t.HsRxDropsMac1Mismatch},
+			{"malformed", t.HsRxDropsMalformed},
+			{"crypto", t.HsRxDropsCrypto},
+			{"unknown_peer", t.HsRxDropsUnknownPeer},
+			{"stale_response", t.HsRxDropsStaleResponse},
+			{"index_exhausted", t.HsRxDropsIndexExhausted},
+			{"cookie_unsupported", t.HsRxCookieUnsupported},
+			{"unknown_type", t.RxUnknownType},
+		} {
+			counter(c.wgHandshakeRxDropsTotal, r.v, t.Tunnel, r.reason)
+		}
+
+		counter(c.wgTransportPacketsTotal, t.EncapPackets, t.Tunnel, "encap")
+		counter(c.wgTransportPacketsTotal, t.DecapPackets, t.Tunnel, "decap")
+		counter(c.wgTransportBytesTotal, t.EncapBytes, t.Tunnel, "encap")
+		counter(c.wgTransportBytesTotal, t.DecapBytes, t.Tunnel, "decap")
+		counter(c.wgKeepalivesReceivedTotal, t.DecapKeepalives, t.Tunnel)
+
+		for _, r := range []struct {
+			reason string
+			v      uint64
+		}{
+			{"malformed_header", t.DecapDropsMalformedHeader},
+			{"unknown_session", t.DecapDropsUnknownSession},
+			{"counter_ceiling", t.DecapDropsCounterCeiling},
+			{"crypto", t.DecapDropsCrypto},
+			{"replay", t.DecapDropsReplay},
+			{"allowed_ips", t.DecapDropsAllowedIPs},
+			{"malformed_inner", t.DecapDropsMalformedInner},
+			{"buffer", t.DecapDropsBuffer},
+		} {
+			counter(c.wgTransportDropsTotal, r.v, t.Tunnel, "decap", r.reason)
+		}
+		for _, r := range []struct {
+			reason string
+			v      uint64
+		}{
+			{"no_session", t.EncapDropsNoSession},
+			{"unconfirmed", t.EncapDropsUnconfirmed},
+			{"rekey_required", t.EncapDropsRekeyRequired},
+			{"mtu", t.EncapMtuDrops},
+			{"other", t.EncapDropsOther},
+		} {
+			counter(c.wgTransportDropsTotal, r.v, t.Tunnel, "encap", r.reason)
+		}
+
+		for _, k := range []struct {
+			kind string
+			v    uint64
+		}{
+			{"handshake", t.HsSendErrors},
+			{"transport", t.TransportSendErrors},
+			{"tun_write", t.TunWriteErrors},
+			{"tun_rx_no_endpoint", t.TunRxDropsNoEndpoint},
+		} {
+			counter(c.wgSendErrorsTotal, k.v, t.Tunnel, k.kind)
+		}
+
+		confirmed := 0.0
+		if t.SessionConfirmed {
+			confirmed = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.wgSessionConfirmed, prometheus.GaugeValue, confirmed, t.Tunnel)
+		if t.LastHandshakeUnixSecs > 0 {
+			ch <- prometheus.MustNewConstMetric(
+				c.wgLastHandshakeTimeSeconds,
+				prometheus.GaugeValue,
+				float64(t.LastHandshakeUnixSecs),
+				t.Tunnel,
+			)
+		}
+	}
 }
 
 // emitNeighborColdStartCapture exposes the #1782 cold-start capture

--- a/pkg/api/metrics_wireguard_test.go
+++ b/pkg/api/metrics_wireguard_test.go
@@ -1,0 +1,249 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #1865: full series-set + label-value pin for emitWireguardTelemetry.
+// Drives the emitter directly with one populated tunnel row (the 1..35
+// ladder mirroring the cross-language wire pins) and asserts:
+//   - the exact set of emitted series (name + labels), so a dropped
+//     reason/kind/role/direction label value fails here;
+//   - counter-vs-gauge dto types;
+//   - the never-handshaked gating of the last-handshake gauge;
+//   - zero-valued reasons are EMITTED (0 is a real signal).
+func TestEmitWireguardTelemetrySeriesSet(t *testing.T) {
+	c := &xpfCollector{
+		wgHandshakesCompletedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshakes_completed_total", "t", []string{"tunnel", "role"}, nil),
+		wgHandshakeInitiationsCreatedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_initiations_created_total", "t", []string{"tunnel"}, nil),
+		wgHandshakeInitiationBuildFailuresTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_initiation_build_failures_total", "t", []string{"tunnel"}, nil),
+		wgHandshakeRxDropsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_rx_drops_total", "t", []string{"tunnel", "reason"}, nil),
+		wgHandshakeRequestsArmedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_requests_armed_total", "t", []string{"tunnel"}, nil),
+		wgTransportPacketsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_transport_packets_total", "t", []string{"tunnel", "direction"}, nil),
+		wgTransportBytesTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_transport_bytes_total", "t", []string{"tunnel", "direction"}, nil),
+		wgKeepalivesReceivedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_keepalives_received_total", "t", []string{"tunnel"}, nil),
+		wgTransportDropsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_transport_drops_total", "t", []string{"tunnel", "direction", "reason"}, nil),
+		wgSendErrorsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_send_errors_total", "t", []string{"tunnel", "kind"}, nil),
+		wgSessionConfirmed: prometheus.NewDesc(
+			"xpf_userspace_wg_session_confirmed", "t", []string{"tunnel"}, nil),
+		wgLastHandshakeTimeSeconds: prometheus.NewDesc(
+			"xpf_userspace_wg_last_handshake_time_seconds", "t", []string{"tunnel"}, nil),
+	}
+	status := dpuserspace.ProcessStatus{
+		WgTunnels: []dpuserspace.WgTunnelStatus{{
+			Tunnel:                    "wg0",
+			SessionConfirmed:          true,
+			LastHandshakeUnixSecs:     1770000000,
+			HsInitiationsCreated:      1,
+			HsInitiationBuildFailures: 2,
+			HsResponsesCreated:        3,
+			HsCompletionsInitiator:    4,
+			HsRxDropsMac1Mismatch:     5,
+			HsRxDropsMalformed:        6,
+			HsRxDropsCrypto:           7,
+			HsRxDropsUnknownPeer:      8,
+			HsRxDropsStaleResponse:    9,
+			HsRxDropsIndexExhausted:   10,
+			HsRxCookieUnsupported:     11,
+			RxUnknownType:             12,
+			HsSendErrors:              13,
+			HsRequestsArmed:           14,
+			DecapPackets:              15,
+			DecapBytes:                16,
+			DecapKeepalives:           17,
+			DecapDropsMalformedHeader: 18,
+			DecapDropsUnknownSession:  19,
+			DecapDropsCounterCeiling:  20,
+			DecapDropsCrypto:          21,
+			DecapDropsReplay:          22,
+			DecapDropsAllowedIPs:      23,
+			DecapDropsMalformedInner:  24,
+			DecapDropsBuffer:          25,
+			EncapPackets:              26,
+			EncapBytes:                27,
+			EncapDropsNoSession:       28,
+			EncapDropsUnconfirmed:     29,
+			EncapDropsRekeyRequired:   30,
+			EncapDropsOther:           31,
+			EncapMtuDrops:             32,
+			TransportSendErrors:       33,
+			TunWriteErrors:            34,
+			TunRxDropsNoEndpoint:      0, // zero on purpose: must still emit
+		}},
+	}
+
+	ch := make(chan prometheus.Metric, 256)
+	c.emitWireguardTelemetry(ch, status)
+	close(ch)
+
+	got := map[string]float64{}
+	gotType := map[string]string{}
+	for m := range ch {
+		var d dto.Metric
+		if err := m.Write(&d); err != nil {
+			t.Fatalf("metric Write: %v", err)
+		}
+		key := m.Desc().String()
+		// Build a stable key: fqName is embedded in Desc().String();
+		// append sorted label pairs from the dto.
+		lbl := ""
+		for _, lp := range d.GetLabel() {
+			lbl += "," + lp.GetName() + "=" + lp.GetValue()
+		}
+		key = descFQName(key) + lbl
+		switch {
+		case d.Counter != nil:
+			got[key] = d.Counter.GetValue()
+			gotType[key] = "counter"
+		case d.Gauge != nil:
+			got[key] = d.Gauge.GetValue()
+			gotType[key] = "gauge"
+		default:
+			t.Fatalf("unexpected metric type for %s", key)
+		}
+	}
+
+	want := map[string]float64{
+		"xpf_userspace_wg_handshakes_completed_total,role=initiator,tunnel=wg0":                     4,
+		"xpf_userspace_wg_handshakes_completed_total,role=responder,tunnel=wg0":                     3,
+		"xpf_userspace_wg_handshake_initiations_created_total,tunnel=wg0":                           1,
+		"xpf_userspace_wg_handshake_initiation_build_failures_total,tunnel=wg0":                     2,
+		"xpf_userspace_wg_handshake_requests_armed_total,tunnel=wg0":                                14,
+		"xpf_userspace_wg_handshake_rx_drops_total,reason=mac1_mismatch,tunnel=wg0":                 5,
+		"xpf_userspace_wg_handshake_rx_drops_total,reason=malformed,tunnel=wg0":                     6,
+		"xpf_userspace_wg_handshake_rx_drops_total,reason=crypto,tunnel=wg0":                        7,
+		"xpf_userspace_wg_handshake_rx_drops_total,reason=unknown_peer,tunnel=wg0":                  8,
+		"xpf_userspace_wg_handshake_rx_drops_total,reason=stale_response,tunnel=wg0":                9,
+		"xpf_userspace_wg_handshake_rx_drops_total,reason=index_exhausted,tunnel=wg0":               10,
+		"xpf_userspace_wg_handshake_rx_drops_total,reason=cookie_unsupported,tunnel=wg0":            11,
+		"xpf_userspace_wg_handshake_rx_drops_total,reason=unknown_type,tunnel=wg0":                  12,
+		"xpf_userspace_wg_transport_packets_total,direction=encap,tunnel=wg0":                       26,
+		"xpf_userspace_wg_transport_packets_total,direction=decap,tunnel=wg0":                       15,
+		"xpf_userspace_wg_transport_bytes_total,direction=encap,tunnel=wg0":                         27,
+		"xpf_userspace_wg_transport_bytes_total,direction=decap,tunnel=wg0":                         16,
+		"xpf_userspace_wg_keepalives_received_total,tunnel=wg0":                                     17,
+		"xpf_userspace_wg_transport_drops_total,direction=decap,reason=malformed_header,tunnel=wg0": 18,
+		"xpf_userspace_wg_transport_drops_total,direction=decap,reason=unknown_session,tunnel=wg0":  19,
+		"xpf_userspace_wg_transport_drops_total,direction=decap,reason=counter_ceiling,tunnel=wg0":  20,
+		"xpf_userspace_wg_transport_drops_total,direction=decap,reason=crypto,tunnel=wg0":           21,
+		"xpf_userspace_wg_transport_drops_total,direction=decap,reason=replay,tunnel=wg0":           22,
+		"xpf_userspace_wg_transport_drops_total,direction=decap,reason=allowed_ips,tunnel=wg0":      23,
+		"xpf_userspace_wg_transport_drops_total,direction=decap,reason=malformed_inner,tunnel=wg0":  24,
+		"xpf_userspace_wg_transport_drops_total,direction=decap,reason=buffer,tunnel=wg0":           25,
+		"xpf_userspace_wg_transport_drops_total,direction=encap,reason=no_session,tunnel=wg0":       28,
+		"xpf_userspace_wg_transport_drops_total,direction=encap,reason=unconfirmed,tunnel=wg0":      29,
+		"xpf_userspace_wg_transport_drops_total,direction=encap,reason=rekey_required,tunnel=wg0":   30,
+		"xpf_userspace_wg_transport_drops_total,direction=encap,reason=mtu,tunnel=wg0":              32,
+		"xpf_userspace_wg_transport_drops_total,direction=encap,reason=other,tunnel=wg0":            31,
+		"xpf_userspace_wg_send_errors_total,kind=handshake,tunnel=wg0":                              13,
+		"xpf_userspace_wg_send_errors_total,kind=transport,tunnel=wg0":                              33,
+		"xpf_userspace_wg_send_errors_total,kind=tun_write,tunnel=wg0":                              34,
+		"xpf_userspace_wg_send_errors_total,kind=tun_rx_no_endpoint,tunnel=wg0":                     0,
+		"xpf_userspace_wg_session_confirmed,tunnel=wg0":                                             1,
+		"xpf_userspace_wg_last_handshake_time_seconds,tunnel=wg0":                                   1770000000,
+	}
+	if len(got) != len(want) {
+		t.Errorf("emitted %d series, want %d", len(got), len(want))
+	}
+	for k, v := range want {
+		gv, ok := got[k]
+		if !ok {
+			t.Errorf("missing series %s", k)
+			continue
+		}
+		if gv != v {
+			t.Errorf("series %s = %v, want %v", k, gv, v)
+		}
+	}
+	for k := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("unexpected series %s", k)
+		}
+	}
+	if gotType["xpf_userspace_wg_session_confirmed,tunnel=wg0"] != "gauge" {
+		t.Errorf("session_confirmed must be a gauge")
+	}
+	if gotType["xpf_userspace_wg_transport_packets_total,direction=encap,tunnel=wg0"] != "counter" {
+		t.Errorf("transport packets must be a counter")
+	}
+}
+
+// Never-handshaked: the last-handshake gauge is ABSENT (0 is the
+// in-band wire sentinel for never, not a valid gauge sample), while
+// every counter series still emits with value 0.
+func TestEmitWireguardTelemetryNeverHandshakedGauge(t *testing.T) {
+	c := &xpfCollector{
+		wgHandshakesCompletedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshakes_completed_total", "t", []string{"tunnel", "role"}, nil),
+		wgHandshakeInitiationsCreatedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_initiations_created_total", "t", []string{"tunnel"}, nil),
+		wgHandshakeInitiationBuildFailuresTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_initiation_build_failures_total", "t", []string{"tunnel"}, nil),
+		wgHandshakeRxDropsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_rx_drops_total", "t", []string{"tunnel", "reason"}, nil),
+		wgHandshakeRequestsArmedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_handshake_requests_armed_total", "t", []string{"tunnel"}, nil),
+		wgTransportPacketsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_transport_packets_total", "t", []string{"tunnel", "direction"}, nil),
+		wgTransportBytesTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_transport_bytes_total", "t", []string{"tunnel", "direction"}, nil),
+		wgKeepalivesReceivedTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_keepalives_received_total", "t", []string{"tunnel"}, nil),
+		wgTransportDropsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_transport_drops_total", "t", []string{"tunnel", "direction", "reason"}, nil),
+		wgSendErrorsTotal: prometheus.NewDesc(
+			"xpf_userspace_wg_send_errors_total", "t", []string{"tunnel", "kind"}, nil),
+		wgSessionConfirmed: prometheus.NewDesc(
+			"xpf_userspace_wg_session_confirmed", "t", []string{"tunnel"}, nil),
+		wgLastHandshakeTimeSeconds: prometheus.NewDesc(
+			"xpf_userspace_wg_last_handshake_time_seconds", "t", []string{"tunnel"}, nil),
+	}
+	status := dpuserspace.ProcessStatus{
+		WgTunnels: []dpuserspace.WgTunnelStatus{{Tunnel: "wg1"}},
+	}
+	ch := make(chan prometheus.Metric, 256)
+	c.emitWireguardTelemetry(ch, status)
+	close(ch)
+	count := 0
+	for m := range ch {
+		count++
+		if descFQName(m.Desc().String()) == "xpf_userspace_wg_last_handshake_time_seconds" {
+			t.Errorf("last-handshake gauge emitted for a never-handshaked tunnel")
+		}
+	}
+	// 2 completions + 3 singles + 8 hs reasons + 2 pkts + 2 bytes +
+	// 1 keepalive + 13 drop reasons + 4 send kinds + 1 confirmed = 36.
+	if count != 36 {
+		t.Errorf("emitted %d series for a zeroed tunnel, want 36 (zeros are real signals)", count)
+	}
+}
+
+// descFQName extracts the fqName from prometheus.Desc.String(), which
+// renders as `Desc{fqName: "name", help: ...}`.
+func descFQName(s string) string {
+	const pfx = `Desc{fqName: "`
+	i := len(pfx)
+	j := i
+	for j < len(s) && s[j] != '"' {
+		j++
+	}
+	if i >= len(s) {
+		return s
+	}
+	return s[i:j]
+}

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -104,12 +104,17 @@ func (c *CLI) handleShowSecurity(args []string) error {
 	args[0] = resolved
 
 	cfg := c.store.ActiveConfig()
-	if cfg == nil && args[0] != "statistics" && args[0] != "ipsec" && args[0] != "alarms" {
+	if cfg == nil && args[0] != "statistics" && args[0] != "ipsec" && args[0] != "alarms" && args[0] != "wireguard" {
 		fmt.Println("no active configuration")
 		return nil
 	}
 
 	switch args[0] {
+	case "wireguard":
+		// #1865: dataplane WG telemetry — works without an active
+		// config (reads helper status only, like statistics).
+		return c.showSecurityWireguard(len(args) >= 2 && args[1] == "detail")
+
 	case "zones":
 		detail := false
 		filterZone := ""

--- a/pkg/cli/cli_show_security_wireguard.go
+++ b/pkg/cli/cli_show_security_wireguard.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// showSecurityWireguard renders `show security wireguard [detail]`
+// from the userspace helper's per-tunnel telemetry rows (#1865). The
+// rendering is shared with the remote CLI via
+// dpuserspace.FormatWireguardStatus (the FormatSystemBuffers pattern),
+// so local and gRPC output are identical.
+func (c *CLI) showSecurityWireguard(detail bool) error {
+	if c.dp == nil {
+		fmt.Println("Dataplane not loaded")
+		return nil
+	}
+	provider, ok := c.dp.(cliUserspaceStatusProvider)
+	if !ok {
+		fmt.Println("WireGuard telemetry requires the userspace dataplane")
+		return nil
+	}
+	status, err := provider.Status()
+	if err != nil {
+		fmt.Printf("WireGuard telemetry unavailable: %v\n", err)
+		return nil
+	}
+	fmt.Print(dpuserspace.FormatWireguardStatus(status, detail, time.Now()))
+	return nil
+}

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -437,7 +437,10 @@ var OperationalTree = map[string]*Node{
 				"security-associations": {Desc: "Show IPsec SAs"},
 				"statistics":            {Desc: "Show IPsec statistics"},
 			}},
-			"vrrp":           {Desc: "Show VRRP high availability status"},
+			"vrrp": {Desc: "Show VRRP high availability status"},
+			"wireguard": {Desc: "Show WireGuard tunnel status", Children: map[string]*Node{
+				"detail": {Desc: "Show per-reason drop counters and handshake activity"},
+			}},
 			"match-policies": {Desc: "Match 5-tuple against policies"},
 		}},
 		"services": {Desc: "Show services information", Children: map[string]*Node{

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -731,6 +731,76 @@ type ProcessStatus struct {
 	NeighborNetlinkRedumpUpsertsTotal       uint64 `json:"neighbor_netlink_redump_upserts_total,omitempty"`
 	NeighborPendingKeys                     uint64 `json:"neighbor_pending_keys,omitempty"`
 	NegNeighKeys                            uint64 `json:"neg_neigh_keys,omitempty"`
+	// WgTunnels carries the #1865 per-WG-tunnel telemetry rows. Keyed
+	// by tunnel NAME (Tunnel) — TunnelEndpointID is informational only
+	// (#1873: positional ids renumber across commits). Absent/empty for
+	// non-WG deployments and for older helpers (key omitted on the
+	// Rust side when no tunnel is configured).
+	WgTunnels []WgTunnelStatus `json:"wg_tunnels,omitempty"`
+}
+
+// WgTunnelStatus mirrors the Rust WgTunnelStatus in
+// userspace-dp/src/protocol/control.rs — keep json tags identical on
+// BOTH sides (feedback_wire_protocol_both_sides). Counter semantics
+// and the reset rules live in userspace-dp/src/afxdp/wg/counters.rs;
+// the Prometheus emitters are in pkg/api/metrics_userspace.go.
+type WgTunnelStatus struct {
+	// Tunnel is the interface name (e.g. "wg0") — the PRIMARY key and
+	// the only Prometheus label. Helper falls back to
+	// "wg-endpoint-<id>" when the ifindex has no resolved name.
+	Tunnel           string `json:"tunnel,omitempty"`
+	TunnelEndpointID uint16 `json:"tunnel_endpoint_id,omitempty"`
+	ListenPort       uint16 `json:"listen_port,omitempty"`
+	// PeerPubkeyHex is the peer static public key, 64-char lowercase
+	// hex (same rendering as the config-side wg_peer_pubkey_hex; note
+	// `wg show` renders base64 — xpf surfaces are uniformly hex).
+	PeerPubkeyHex string `json:"peer_pubkey_hex,omitempty"`
+	// PeerEndpoint is the CONFIGURED endpoint (empty for a
+	// responder-only peer; the learned endpoint is not surfaced yet).
+	PeerEndpoint     string `json:"peer_endpoint,omitempty"`
+	SessionConfirmed bool   `json:"session_confirmed,omitempty"`
+	// LastHandshakeUnixSecs is wall-clock epoch seconds of the most
+	// recent handshake completion (either role); 0 = never (epoch 0 is
+	// unreachable, so the in-band sentinel is unambiguous).
+	LastHandshakeUnixSecs uint64 `json:"last_handshake_unix_secs,omitempty"`
+
+	HsInitiationsCreated      uint64 `json:"hs_initiations_created,omitempty"`
+	HsInitiationBuildFailures uint64 `json:"hs_initiation_build_failures,omitempty"`
+	HsResponsesCreated        uint64 `json:"hs_responses_created,omitempty"`
+	HsCompletionsInitiator    uint64 `json:"hs_completions_initiator,omitempty"`
+	HsRxDropsMac1Mismatch     uint64 `json:"hs_rx_drops_mac1_mismatch,omitempty"`
+	HsRxDropsMalformed        uint64 `json:"hs_rx_drops_malformed,omitempty"`
+	HsRxDropsCrypto           uint64 `json:"hs_rx_drops_crypto,omitempty"`
+	HsRxDropsUnknownPeer      uint64 `json:"hs_rx_drops_unknown_peer,omitempty"`
+	HsRxDropsStaleResponse    uint64 `json:"hs_rx_drops_stale_response,omitempty"`
+	HsRxDropsIndexExhausted   uint64 `json:"hs_rx_drops_index_exhausted,omitempty"`
+	HsRxCookieUnsupported     uint64 `json:"hs_rx_cookie_unsupported,omitempty"`
+	RxUnknownType             uint64 `json:"rx_unknown_type,omitempty"`
+	HsSendErrors              uint64 `json:"hs_send_errors,omitempty"`
+	HsRequestsArmed           uint64 `json:"hs_requests_armed,omitempty"`
+
+	DecapPackets              uint64 `json:"decap_packets,omitempty"`
+	DecapBytes                uint64 `json:"decap_bytes,omitempty"`
+	DecapKeepalives           uint64 `json:"decap_keepalives,omitempty"`
+	DecapDropsMalformedHeader uint64 `json:"decap_drops_malformed_header,omitempty"`
+	DecapDropsUnknownSession  uint64 `json:"decap_drops_unknown_session,omitempty"`
+	DecapDropsCounterCeiling  uint64 `json:"decap_drops_counter_ceiling,omitempty"`
+	DecapDropsCrypto          uint64 `json:"decap_drops_crypto,omitempty"`
+	DecapDropsReplay          uint64 `json:"decap_drops_replay,omitempty"`
+	DecapDropsAllowedIPs      uint64 `json:"decap_drops_allowed_ips,omitempty"`
+	DecapDropsMalformedInner  uint64 `json:"decap_drops_malformed_inner,omitempty"`
+	DecapDropsBuffer          uint64 `json:"decap_drops_buffer,omitempty"`
+
+	EncapPackets            uint64 `json:"encap_packets,omitempty"`
+	EncapBytes              uint64 `json:"encap_bytes,omitempty"`
+	EncapDropsNoSession     uint64 `json:"encap_drops_no_session,omitempty"`
+	EncapDropsUnconfirmed   uint64 `json:"encap_drops_unconfirmed,omitempty"`
+	EncapDropsRekeyRequired uint64 `json:"encap_drops_rekey_required,omitempty"`
+	EncapDropsOther         uint64 `json:"encap_drops_other,omitempty"`
+	EncapMtuDrops           uint64 `json:"encap_mtu_drops,omitempty"`
+	TransportSendErrors     uint64 `json:"transport_send_errors,omitempty"`
+	TunWriteErrors          uint64 `json:"tun_write_errors,omitempty"`
+	TunRxDropsNoEndpoint    uint64 `json:"tun_rx_drops_no_endpoint,omitempty"`
 }
 
 // MarshalJSON intentionally uses a value receiver so both ProcessStatus values

--- a/pkg/dataplane/userspace/wg_status_test.go
+++ b/pkg/dataplane/userspace/wg_status_test.go
@@ -1,0 +1,157 @@
+package userspace
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// #1865: cross-language wire pin for the per-WG-tunnel telemetry rows.
+// The JSON literal below uses the EXACT key set the Rust side emits
+// (userspace-dp/src/protocol/control.rs WgTunnelStatus serde renames;
+// pinned there by process_status_wg_tunnels_roundtrip_and_compat with
+// the same 1..35 counter ladder). A key drift on either side breaks
+// one of the two pins.
+func TestProcessStatusWgTunnelsPopulatedDecode(t *testing.T) {
+	payload := `{
+		"pid": 1,
+		"started_at": "2026-06-11T00:00:00Z",
+		"control_socket": "", "state_file": "",
+		"workers": 0, "ring_entries": 0, "helper_mode": "",
+		"io_uring_planned": false, "enabled": true,
+		"last_snapshot_generation": 0,
+		"wg_tunnels": [{
+			"tunnel": "wg0",
+			"tunnel_endpoint_id": 7,
+			"listen_port": 51820,
+			"peer_pubkey_hex": "` + strings.Repeat("ab", 32) + `",
+			"peer_endpoint": "192.0.2.10:51820",
+			"session_confirmed": true,
+			"last_handshake_unix_secs": 1770000000,
+			"hs_initiations_created": 1,
+			"hs_initiation_build_failures": 2,
+			"hs_responses_created": 3,
+			"hs_completions_initiator": 4,
+			"hs_rx_drops_mac1_mismatch": 5,
+			"hs_rx_drops_malformed": 6,
+			"hs_rx_drops_crypto": 7,
+			"hs_rx_drops_unknown_peer": 8,
+			"hs_rx_drops_stale_response": 9,
+			"hs_rx_drops_index_exhausted": 10,
+			"hs_rx_cookie_unsupported": 11,
+			"rx_unknown_type": 12,
+			"hs_send_errors": 13,
+			"hs_requests_armed": 14,
+			"decap_packets": 15,
+			"decap_bytes": 16,
+			"decap_keepalives": 17,
+			"decap_drops_malformed_header": 18,
+			"decap_drops_unknown_session": 19,
+			"decap_drops_counter_ceiling": 20,
+			"decap_drops_crypto": 21,
+			"decap_drops_replay": 22,
+			"decap_drops_allowed_ips": 23,
+			"decap_drops_malformed_inner": 24,
+			"decap_drops_buffer": 25,
+			"encap_packets": 26,
+			"encap_bytes": 27,
+			"encap_drops_no_session": 28,
+			"encap_drops_unconfirmed": 29,
+			"encap_drops_rekey_required": 30,
+			"encap_drops_other": 31,
+			"encap_mtu_drops": 32,
+			"transport_send_errors": 33,
+			"tun_write_errors": 34,
+			"tun_rx_drops_no_endpoint": 35
+		}]
+	}`
+	var status ProcessStatus
+	if err := json.Unmarshal([]byte(payload), &status); err != nil {
+		t.Fatalf("unmarshal populated wg_tunnels payload: %v", err)
+	}
+	if len(status.WgTunnels) != 1 {
+		t.Fatalf("WgTunnels rows = %d, want 1", len(status.WgTunnels))
+	}
+	row := status.WgTunnels[0]
+	if row.Tunnel != "wg0" || row.TunnelEndpointID != 7 || row.ListenPort != 51820 {
+		t.Fatalf("identity fields = %+v", row)
+	}
+	if row.PeerPubkeyHex != strings.Repeat("ab", 32) {
+		t.Fatalf("PeerPubkeyHex = %q", row.PeerPubkeyHex)
+	}
+	if row.PeerEndpoint != "192.0.2.10:51820" || !row.SessionConfirmed {
+		t.Fatalf("endpoint/confirmed = %q/%v", row.PeerEndpoint, row.SessionConfirmed)
+	}
+	if row.LastHandshakeUnixSecs != 1770000000 {
+		t.Fatalf("LastHandshakeUnixSecs = %d", row.LastHandshakeUnixSecs)
+	}
+	// The 1..35 counter ladder: every field carries its ordinal, so a
+	// swapped/mistagged field shows up as the wrong value.
+	ladder := []struct {
+		name string
+		got  uint64
+		want uint64
+	}{
+		{"HsInitiationsCreated", row.HsInitiationsCreated, 1},
+		{"HsInitiationBuildFailures", row.HsInitiationBuildFailures, 2},
+		{"HsResponsesCreated", row.HsResponsesCreated, 3},
+		{"HsCompletionsInitiator", row.HsCompletionsInitiator, 4},
+		{"HsRxDropsMac1Mismatch", row.HsRxDropsMac1Mismatch, 5},
+		{"HsRxDropsMalformed", row.HsRxDropsMalformed, 6},
+		{"HsRxDropsCrypto", row.HsRxDropsCrypto, 7},
+		{"HsRxDropsUnknownPeer", row.HsRxDropsUnknownPeer, 8},
+		{"HsRxDropsStaleResponse", row.HsRxDropsStaleResponse, 9},
+		{"HsRxDropsIndexExhausted", row.HsRxDropsIndexExhausted, 10},
+		{"HsRxCookieUnsupported", row.HsRxCookieUnsupported, 11},
+		{"RxUnknownType", row.RxUnknownType, 12},
+		{"HsSendErrors", row.HsSendErrors, 13},
+		{"HsRequestsArmed", row.HsRequestsArmed, 14},
+		{"DecapPackets", row.DecapPackets, 15},
+		{"DecapBytes", row.DecapBytes, 16},
+		{"DecapKeepalives", row.DecapKeepalives, 17},
+		{"DecapDropsMalformedHeader", row.DecapDropsMalformedHeader, 18},
+		{"DecapDropsUnknownSession", row.DecapDropsUnknownSession, 19},
+		{"DecapDropsCounterCeiling", row.DecapDropsCounterCeiling, 20},
+		{"DecapDropsCrypto", row.DecapDropsCrypto, 21},
+		{"DecapDropsReplay", row.DecapDropsReplay, 22},
+		{"DecapDropsAllowedIPs", row.DecapDropsAllowedIPs, 23},
+		{"DecapDropsMalformedInner", row.DecapDropsMalformedInner, 24},
+		{"DecapDropsBuffer", row.DecapDropsBuffer, 25},
+		{"EncapPackets", row.EncapPackets, 26},
+		{"EncapBytes", row.EncapBytes, 27},
+		{"EncapDropsNoSession", row.EncapDropsNoSession, 28},
+		{"EncapDropsUnconfirmed", row.EncapDropsUnconfirmed, 29},
+		{"EncapDropsRekeyRequired", row.EncapDropsRekeyRequired, 30},
+		{"EncapDropsOther", row.EncapDropsOther, 31},
+		{"EncapMtuDrops", row.EncapMtuDrops, 32},
+		{"TransportSendErrors", row.TransportSendErrors, 33},
+		{"TunWriteErrors", row.TunWriteErrors, 34},
+		{"TunRxDropsNoEndpoint", row.TunRxDropsNoEndpoint, 35},
+	}
+	for _, c := range ladder {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d (json tag drift?)", c.name, c.got, c.want)
+		}
+	}
+}
+
+// Pre-#1865 helper payload: key absent entirely → nil slice, and a
+// re-marshal of a WG-less status must NOT introduce the key (the
+// non-WG wire stays byte-identical — mirror of the Rust
+// empty-invariant pin).
+func TestProcessStatusWgTunnelsAbsentAndOmitted(t *testing.T) {
+	var status ProcessStatus
+	if err := json.Unmarshal([]byte(`{"pid":1,"started_at":"2026-06-11T00:00:00Z","control_socket":"","state_file":"","workers":0,"ring_entries":0,"helper_mode":"","io_uring_planned":false,"last_snapshot_generation":0}`), &status); err != nil {
+		t.Fatalf("unmarshal legacy payload: %v", err)
+	}
+	if status.WgTunnels != nil {
+		t.Fatalf("WgTunnels = %v, want nil for absent key", status.WgTunnels)
+	}
+	out, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "wg_tunnels") {
+		t.Fatalf("re-marshal of WG-less status must omit wg_tunnels: %s", out)
+	}
+}

--- a/pkg/dataplane/userspace/wgfmt.go
+++ b/pkg/dataplane/userspace/wgfmt.go
@@ -1,0 +1,148 @@
+package userspace
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FormatWireguardStatus renders the #1865 per-WG-tunnel telemetry rows
+// for `show security wireguard [detail]`. Shared by the local CLI
+// (pkg/cli) and the gRPC text server (pkg/grpcapi) so both surfaces
+// render identically — the FormatSystemBuffers pattern.
+//
+// `now` is passed explicitly (rather than read inside) so the
+// handshake-age rendering is testable; callers pass time.Now().
+//
+// The summary view is the wg-show-shaped operator glance: identity,
+// session state, latest handshake, transfer, and a drop TOTAL. The
+// detail view adds the full per-reason drop tables — the one-glance
+// diagnosis for the #1736 class of failures (silent sends, MTU
+// blackholes, wrong-key peers).
+func FormatWireguardStatus(status ProcessStatus, detail bool, now time.Time) string {
+	if len(status.WgTunnels) == 0 {
+		return "No WireGuard tunnels configured\n"
+	}
+	var b strings.Builder
+	for i, t := range status.WgTunnels {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "Tunnel: %s (endpoint id %d)\n", t.Tunnel, t.TunnelEndpointID)
+		fmt.Fprintf(&b, "  Listen port:        %d\n", t.ListenPort)
+		fmt.Fprintf(&b, "  Peer public key:    %s\n", t.PeerPubkeyHex)
+		endpoint := t.PeerEndpoint
+		if endpoint == "" {
+			endpoint = "(responder-only; learned at runtime)"
+		}
+		fmt.Fprintf(&b, "  Peer endpoint:      %s\n", endpoint)
+		state := "no session"
+		if t.SessionConfirmed {
+			state = "session confirmed"
+		} else if t.LastHandshakeUnixSecs > 0 {
+			state = "handshake completed, unconfirmed"
+		}
+		fmt.Fprintf(&b, "  Session:            %s\n", state)
+		fmt.Fprintf(&b, "  Latest handshake:   %s\n",
+			formatHandshakeAge(t.LastHandshakeUnixSecs, now))
+		fmt.Fprintf(&b, "  Handshakes:         %d initiator, %d responder (initiations sent %d, send errors %d)\n",
+			t.HsCompletionsInitiator, t.HsResponsesCreated,
+			t.HsInitiationsCreated, t.HsSendErrors)
+		fmt.Fprintf(&b, "  Transfer:           %d pkts / %d bytes received, %d pkts / %d bytes sent (inner IP)\n",
+			t.DecapPackets, t.DecapBytes, t.EncapPackets, t.EncapBytes)
+		if t.DecapKeepalives > 0 {
+			fmt.Fprintf(&b, "  Keepalives:         %d received\n", t.DecapKeepalives)
+		}
+		decapDrops := t.DecapDropsMalformedHeader + t.DecapDropsUnknownSession +
+			t.DecapDropsCounterCeiling + t.DecapDropsCrypto + t.DecapDropsReplay +
+			t.DecapDropsAllowedIPs + t.DecapDropsMalformedInner + t.DecapDropsBuffer
+		encapDrops := t.EncapDropsNoSession + t.EncapDropsUnconfirmed +
+			t.EncapDropsRekeyRequired + t.EncapDropsOther + t.EncapMtuDrops
+		hsDrops := t.HsRxDropsMac1Mismatch + t.HsRxDropsMalformed + t.HsRxDropsCrypto +
+			t.HsRxDropsUnknownPeer + t.HsRxDropsStaleResponse + t.HsRxDropsIndexExhausted +
+			t.HsRxCookieUnsupported + t.RxUnknownType
+		ioErrors := t.HsSendErrors + t.TransportSendErrors + t.TunWriteErrors +
+			t.TunRxDropsNoEndpoint
+		fmt.Fprintf(&b, "  Drops:              %d receive, %d transmit, %d handshake, %d I/O errors\n",
+			decapDrops, encapDrops, hsDrops, ioErrors)
+		if !detail {
+			continue
+		}
+		b.WriteString("  Receive drops by reason:\n")
+		writeWgReasonRows(&b, []wgReasonRow{
+			{"malformed-header", t.DecapDropsMalformedHeader},
+			{"unknown-session", t.DecapDropsUnknownSession},
+			{"counter-ceiling", t.DecapDropsCounterCeiling},
+			{"decrypt-failed", t.DecapDropsCrypto},
+			{"replay", t.DecapDropsReplay},
+			{"allowed-ips-violation", t.DecapDropsAllowedIPs},
+			{"malformed-inner", t.DecapDropsMalformedInner},
+			{"buffer", t.DecapDropsBuffer},
+		})
+		b.WriteString("  Transmit drops by reason:\n")
+		writeWgReasonRows(&b, []wgReasonRow{
+			{"no-session", t.EncapDropsNoSession},
+			{"unconfirmed-session", t.EncapDropsUnconfirmed},
+			{"rekey-required", t.EncapDropsRekeyRequired},
+			{"mtu-exceeded", t.EncapMtuDrops},
+			{"other", t.EncapDropsOther},
+		})
+		b.WriteString("  Handshake drops by reason:\n")
+		writeWgReasonRows(&b, []wgReasonRow{
+			{"mac1-mismatch", t.HsRxDropsMac1Mismatch},
+			{"malformed", t.HsRxDropsMalformed},
+			{"crypto", t.HsRxDropsCrypto},
+			{"unknown-peer", t.HsRxDropsUnknownPeer},
+			{"stale-response", t.HsRxDropsStaleResponse},
+			{"index-exhausted", t.HsRxDropsIndexExhausted},
+			{"cookie-unsupported", t.HsRxCookieUnsupported},
+			{"unknown-type", t.RxUnknownType},
+		})
+		b.WriteString("  I/O errors:\n")
+		writeWgReasonRows(&b, []wgReasonRow{
+			{"handshake-send", t.HsSendErrors},
+			{"transport-send", t.TransportSendErrors},
+			{"tun-write", t.TunWriteErrors},
+			{"tun-read-no-endpoint", t.TunRxDropsNoEndpoint},
+		})
+		fmt.Fprintf(&b, "  Handshake activity: %d initiations created, %d build failures, %d requests armed\n",
+			t.HsInitiationsCreated, t.HsInitiationBuildFailures, t.HsRequestsArmed)
+		fmt.Fprintf(&b, "  Keepalives:         %d received\n", t.DecapKeepalives)
+	}
+	return b.String()
+}
+
+type wgReasonRow struct {
+	reason string
+	count  uint64
+}
+
+func writeWgReasonRows(b *strings.Builder, rows []wgReasonRow) {
+	for _, r := range rows {
+		fmt.Fprintf(b, "    %-24s %d\n", r.reason, r.count)
+	}
+}
+
+// formatHandshakeAge renders the last-handshake timestamp like wg
+// show's "latest handshake" line. 0 means never (the in-band wire
+// sentinel). A timestamp in the future (clock step between helper
+// conversion and this render) clamps to "0 seconds ago" rather than
+// going negative.
+func formatHandshakeAge(unixSecs uint64, now time.Time) string {
+	if unixSecs == 0 {
+		return "never"
+	}
+	age := now.Unix() - int64(unixSecs)
+	if age < 0 {
+		age = 0
+	}
+	d := time.Duration(age) * time.Second
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%d seconds ago", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm%ds ago", int(d.Minutes()), int(d.Seconds())%60)
+	default:
+		return fmt.Sprintf("%dh%dm ago", int(d.Hours()), int(d.Minutes())%60)
+	}
+}

--- a/pkg/dataplane/userspace/wgfmt.go
+++ b/pkg/dataplane/userspace/wgfmt.go
@@ -50,7 +50,10 @@ func FormatWireguardStatus(status ProcessStatus, detail bool, now time.Time) str
 			t.HsInitiationsCreated, t.HsSendErrors)
 		fmt.Fprintf(&b, "  Transfer:           %d pkts / %d bytes received, %d pkts / %d bytes sent (inner IP)\n",
 			t.DecapPackets, t.DecapBytes, t.EncapPackets, t.EncapBytes)
-		if t.DecapKeepalives > 0 {
+		if !detail && t.DecapKeepalives > 0 {
+			// Detail view prints the unconditional keepalive line at
+			// the bottom; suppress the summary form there to avoid a
+			// duplicate row.
 			fmt.Fprintf(&b, "  Keepalives:         %d received\n", t.DecapKeepalives)
 		}
 		decapDrops := t.DecapDropsMalformedHeader + t.DecapDropsUnknownSession +

--- a/pkg/dataplane/userspace/wgfmt.go
+++ b/pkg/dataplane/userspace/wgfmt.go
@@ -45,7 +45,7 @@ func FormatWireguardStatus(status ProcessStatus, detail bool, now time.Time) str
 		fmt.Fprintf(&b, "  Session:            %s\n", state)
 		fmt.Fprintf(&b, "  Latest handshake:   %s\n",
 			formatHandshakeAge(t.LastHandshakeUnixSecs, now))
-		fmt.Fprintf(&b, "  Handshakes:         %d initiator, %d responder (initiations sent %d, send errors %d)\n",
+		fmt.Fprintf(&b, "  Handshakes:         %d initiator, %d responder (initiations created %d, send errors %d)\n",
 			t.HsCompletionsInitiator, t.HsResponsesCreated,
 			t.HsInitiationsCreated, t.HsSendErrors)
 		fmt.Fprintf(&b, "  Transfer:           %d pkts / %d bytes received, %d pkts / %d bytes sent (inner IP)\n",

--- a/pkg/dataplane/userspace/wgfmt_test.go
+++ b/pkg/dataplane/userspace/wgfmt_test.go
@@ -1,0 +1,106 @@
+package userspace
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func wgFmtFixture() ProcessStatus {
+	return ProcessStatus{
+		WgTunnels: []WgTunnelStatus{{
+			Tunnel:                 "wg0",
+			TunnelEndpointID:       3,
+			ListenPort:             51820,
+			PeerPubkeyHex:          strings.Repeat("ab", 32),
+			PeerEndpoint:           "192.0.2.10:51820",
+			SessionConfirmed:       true,
+			LastHandshakeUnixSecs:  1_770_000_000,
+			HsCompletionsInitiator: 2,
+			HsResponsesCreated:     1,
+			HsInitiationsCreated:   4,
+			HsSendErrors:           1,
+			DecapPackets:           100,
+			DecapBytes:             5000,
+			EncapPackets:           90,
+			EncapBytes:             4500,
+			DecapKeepalives:        7,
+			DecapDropsReplay:       2,
+			EncapMtuDrops:          3,
+			HsRxDropsMac1Mismatch:  5,
+		}},
+	}
+}
+
+func TestFormatWireguardStatusSummary(t *testing.T) {
+	now := time.Unix(1_770_000_090, 0) // 90s after the handshake
+	out := FormatWireguardStatus(wgFmtFixture(), false, now)
+	for _, want := range []string{
+		"Tunnel: wg0 (endpoint id 3)",
+		"Listen port:        51820",
+		"Peer public key:    " + strings.Repeat("ab", 32),
+		"Peer endpoint:      192.0.2.10:51820",
+		"Session:            session confirmed",
+		"Latest handshake:   1m30s ago",
+		"Handshakes:         2 initiator, 1 responder (initiations sent 4, send errors 1)",
+		"Transfer:           100 pkts / 5000 bytes received, 90 pkts / 4500 bytes sent (inner IP)",
+		"Keepalives:         7 received",
+		"Drops:              2 receive, 3 transmit, 5 handshake, 1 I/O errors",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "by reason") {
+		t.Errorf("summary must not include the detail reason tables:\n%s", out)
+	}
+}
+
+func TestFormatWireguardStatusDetailReasonTables(t *testing.T) {
+	now := time.Unix(1_770_000_090, 0)
+	out := FormatWireguardStatus(wgFmtFixture(), true, now)
+	for _, want := range []string{
+		"Receive drops by reason:",
+		"replay                   2",
+		"Transmit drops by reason:",
+		"mtu-exceeded             3",
+		"Handshake drops by reason:",
+		"mac1-mismatch            5",
+		"I/O errors:",
+		"handshake-send           1",
+		"Handshake activity: 4 initiations created, 0 build failures, 0 requests armed",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("detail missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatWireguardStatusNeverAndEmpty(t *testing.T) {
+	out := FormatWireguardStatus(ProcessStatus{}, false, time.Now())
+	if !strings.Contains(out, "No WireGuard tunnels configured") {
+		t.Errorf("empty status rendering = %q", out)
+	}
+	status := ProcessStatus{WgTunnels: []WgTunnelStatus{{Tunnel: "wg1"}}}
+	out = FormatWireguardStatus(status, false, time.Now())
+	if !strings.Contains(out, "Latest handshake:   never") {
+		t.Errorf("never-handshaked tunnel must render 'never':\n%s", out)
+	}
+	if !strings.Contains(out, "Session:            no session") {
+		t.Errorf("no-session state missing:\n%s", out)
+	}
+	if !strings.Contains(out, "(responder-only; learned at runtime)") {
+		t.Errorf("empty endpoint placeholder missing:\n%s", out)
+	}
+}
+
+// A future timestamp (clock step between the helper's conversion and
+// this render) clamps to "0 seconds ago", never negative.
+func TestFormatHandshakeAgeClamps(t *testing.T) {
+	if got := formatHandshakeAge(2_000_000_000, time.Unix(1_900_000_000, 0)); got != "0 seconds ago" {
+		t.Errorf("future stamp = %q, want clamp to 0 seconds ago", got)
+	}
+	if got := formatHandshakeAge(0, time.Now()); got != "never" {
+		t.Errorf("zero stamp = %q, want never", got)
+	}
+}

--- a/pkg/dataplane/userspace/wgfmt_test.go
+++ b/pkg/dataplane/userspace/wgfmt_test.go
@@ -42,7 +42,7 @@ func TestFormatWireguardStatusSummary(t *testing.T) {
 		"Peer endpoint:      192.0.2.10:51820",
 		"Session:            session confirmed",
 		"Latest handshake:   1m30s ago",
-		"Handshakes:         2 initiator, 1 responder (initiations sent 4, send errors 1)",
+		"Handshakes:         2 initiator, 1 responder (initiations created 4, send errors 1)",
 		"Transfer:           100 pkts / 5000 bytes received, 90 pkts / 4500 bytes sent (inner IP)",
 		"Keepalives:         7 received",
 		"Drops:              2 receive, 3 transmit, 5 handshake, 1 I/O errors",

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -409,6 +409,13 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 	case "buffers-detail":
 		s.showBuffersDetail(cfg, &buf)
 
+	case "wireguard":
+		// #1865: WG tunnel telemetry (summary).
+		s.showWireguard(&buf, false)
+
+	case "wireguard-detail":
+		s.showWireguard(&buf, true)
+
 	case "bfd-peers":
 		if err := s.showBFDPeers(&buf); err != nil {
 			return nil, err

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -867,3 +867,25 @@ func writeRPMConfig(buf *strings.Builder, cfg *config.Config) {
 		}
 	}
 }
+
+// showWireguard renders `show security wireguard [detail]` for the
+// remote CLI from the userspace helper's per-tunnel telemetry rows
+// (#1865). Shared rendering with the local CLI via
+// dpuserspace.FormatWireguardStatus.
+func (s *Server) showWireguard(buf *strings.Builder, detail bool) {
+	if s.dp == nil {
+		buf.WriteString("Dataplane not loaded\n")
+		return
+	}
+	provider, ok := s.dp.(userspaceStatusProvider)
+	if !ok {
+		buf.WriteString("WireGuard telemetry requires the userspace dataplane\n")
+		return
+	}
+	status, err := provider.Status()
+	if err != nil {
+		fmt.Fprintf(buf, "WireGuard telemetry unavailable: %v\n", err)
+		return
+	}
+	buf.WriteString(dpuserspace.FormatWireguardStatus(status, detail, time.Now()))
+}

--- a/pkg/grpcapi/server_show_security_wireguard_test.go
+++ b/pkg/grpcapi/server_show_security_wireguard_test.go
@@ -1,0 +1,99 @@
+package grpcapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+type wireguardUserspaceDP struct {
+	*dataplane.Manager
+	status dpuserspace.ProcessStatus
+}
+
+func (f *wireguardUserspaceDP) Status() (dpuserspace.ProcessStatus, error) {
+	return f.status, nil
+}
+
+// #1865: the `wireguard` / `wireguard-detail` ShowText topics render
+// the helper's per-tunnel telemetry rows via FormatWireguardStatus —
+// the same shared formatter the local CLI uses.
+func TestShowTextWireguardTopics(t *testing.T) {
+	s := &Server{
+		store: configstore.New(t.TempDir() + "/xpf.conf"),
+		dp: &wireguardUserspaceDP{
+			Manager: dataplane.New(),
+			status: dpuserspace.ProcessStatus{
+				WgTunnels: []dpuserspace.WgTunnelStatus{{
+					Tunnel:                "wg0",
+					TunnelEndpointID:      2,
+					ListenPort:            51820,
+					PeerPubkeyHex:         strings.Repeat("cd", 32),
+					PeerEndpoint:          "198.51.100.7:51820",
+					SessionConfirmed:      true,
+					HsRxDropsMac1Mismatch: 4,
+					EncapMtuDrops:         9,
+					DecapPackets:          11,
+					EncapPackets:          12,
+				}},
+			},
+		},
+	}
+
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "wireguard"})
+	if err != nil {
+		t.Fatalf("ShowText(wireguard) error = %v", err)
+	}
+	out := resp.GetOutput()
+	for _, want := range []string{
+		"Tunnel: wg0 (endpoint id 2)",
+		"Peer endpoint:      198.51.100.7:51820",
+		"Session:            session confirmed",
+		"Latest handshake:   never",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("ShowText(wireguard) missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "by reason") {
+		t.Fatalf("summary topic must not render detail tables:\n%s", out)
+	}
+
+	resp, err = s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "wireguard-detail"})
+	if err != nil {
+		t.Fatalf("ShowText(wireguard-detail) error = %v", err)
+	}
+	out = resp.GetOutput()
+	for _, want := range []string{
+		"Handshake drops by reason:",
+		"mac1-mismatch            4",
+		"mtu-exceeded             9",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("ShowText(wireguard-detail) missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// No WG tunnels configured: both topics render the explicit empty
+// message rather than nothing.
+func TestShowTextWireguardEmpty(t *testing.T) {
+	s := &Server{
+		store: configstore.New(t.TempDir() + "/xpf.conf"),
+		dp: &wireguardUserspaceDP{
+			Manager: dataplane.New(),
+		},
+	}
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "wireguard"})
+	if err != nil {
+		t.Fatalf("ShowText(wireguard) error = %v", err)
+	}
+	if !strings.Contains(resp.GetOutput(), "No WireGuard tunnels configured") {
+		t.Fatalf("empty output = %q", resp.GetOutput())
+	}
+}

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -661,11 +661,21 @@ impl super::Coordinator {
             let Some(engine) = self.forwarding.wg_engines.get(&id) else {
                 continue;
             };
+            // Name fallback chain (plan §3.2 / Codex code-r1 F1):
+            // ifindex_to_name → the snapshot row's attachment label →
+            // wg-endpoint-<id>. A row is never dropped, and the
+            // stable logical name wins over the positional id even
+            // when the live ifindex map has no entry (broken
+            // bring-up — exactly when telemetry matters).
             let tunnel = self
                 .forwarding
                 .ifindex_to_name
                 .get(&endpoint.logical_ifindex)
                 .cloned()
+                .or_else(|| {
+                    (!endpoint.interface_label.is_empty())
+                        .then(|| endpoint.interface_label.clone())
+                })
                 .unwrap_or_else(|| format!("wg-endpoint-{id}"));
             let c = engine.counters();
             // Stamp-0 guard (plan §3.3 / SMR r2): a zero stamp means

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -629,6 +629,126 @@ impl super::Coordinator {
             .collect()
     }
 
+    /// #1865: per-WG-tunnel telemetry rows for `ProcessStatus.wg_tunnels`.
+    /// One row per `mode == "wireguard"` tunnel endpoint with a live
+    /// engine, sorted by endpoint id for deterministic wire output but
+    /// KEYED by tunnel name (`ifindex_to_name`; positional ids renumber
+    /// across commits — #1873). A missing name falls back to
+    /// `wg-endpoint-<id>` rather than dropping the row: broken bring-up
+    /// is exactly when telemetry matters. Counter loads are relaxed and
+    /// NOT transactional across fields (each atomic is read
+    /// independently while the control thread increments — fine for
+    /// observability, same posture as every other counter family).
+    pub fn wg_tunnel_statuses(&self) -> Vec<crate::protocol::WgTunnelStatus> {
+        let mut ids: Vec<u16> = self
+            .forwarding
+            .tunnel_endpoints
+            .iter()
+            .filter(|(_, ep)| ep.mode == "wireguard")
+            .map(|(id, _)| *id)
+            .collect();
+        ids.sort_unstable();
+        if ids.is_empty() {
+            return Vec::new();
+        }
+        let now_wall = Utc::now();
+        let now_mono = monotonic_nanos();
+        let mut out = Vec::with_capacity(ids.len());
+        for id in ids {
+            let Some(endpoint) = self.forwarding.tunnel_endpoints.get(&id) else {
+                continue;
+            };
+            let Some(engine) = self.forwarding.wg_engines.get(&id) else {
+                continue;
+            };
+            let tunnel = self
+                .forwarding
+                .ifindex_to_name
+                .get(&endpoint.logical_ifindex)
+                .cloned()
+                .unwrap_or_else(|| format!("wg-endpoint-{id}"));
+            let c = engine.counters();
+            // Stamp-0 guard (plan §3.3 / SMR r2): a zero stamp means
+            // "never" and must NOT run through the monotonic→wall
+            // conversion (which would render ~boot time as a
+            // valid-looking date). A pre-epoch/failed conversion also
+            // maps to 0, never a wrapped huge value (Codex r2 note).
+            let stamp = c.last_handshake_complete_ns.load(Ordering::Relaxed);
+            let last_handshake_unix_secs = if stamp == 0 {
+                0
+            } else {
+                monotonic_timestamp_to_datetime(stamp, now_mono, now_wall)
+                    .map(|dt| dt.timestamp().max(0) as u64)
+                    .unwrap_or(0)
+            };
+            out.push(crate::protocol::WgTunnelStatus {
+                tunnel,
+                tunnel_endpoint_id: id,
+                listen_port: endpoint.wg_listen_port,
+                peer_pubkey_hex: crate::afxdp::wg::encode_wg_key_hex(&endpoint.wg_peer_pubkey),
+                peer_endpoint: endpoint
+                    .wg_endpoint
+                    .map(|ep| ep.to_string())
+                    .unwrap_or_default(),
+                session_confirmed: engine
+                    .peer_has_confirmed_session(&endpoint.wg_peer_pubkey),
+                last_handshake_unix_secs,
+                hs_initiations_created: c.hs_initiations_created.load(Ordering::Relaxed),
+                hs_initiation_build_failures: c
+                    .hs_initiation_build_failures
+                    .load(Ordering::Relaxed),
+                hs_responses_created: c.hs_responses_created.load(Ordering::Relaxed),
+                hs_completions_initiator: c.hs_completions_initiator.load(Ordering::Relaxed),
+                hs_rx_drops_mac1_mismatch: c.hs_rx_drops_mac1_mismatch.load(Ordering::Relaxed),
+                hs_rx_drops_malformed: c.hs_rx_drops_malformed.load(Ordering::Relaxed),
+                hs_rx_drops_crypto: c.hs_rx_drops_crypto.load(Ordering::Relaxed),
+                hs_rx_drops_unknown_peer: c.hs_rx_drops_unknown_peer.load(Ordering::Relaxed),
+                hs_rx_drops_stale_response: c
+                    .hs_rx_drops_stale_response
+                    .load(Ordering::Relaxed),
+                hs_rx_drops_index_exhausted: c
+                    .hs_rx_drops_index_exhausted
+                    .load(Ordering::Relaxed),
+                hs_rx_cookie_unsupported: c.hs_rx_cookie_unsupported.load(Ordering::Relaxed),
+                rx_unknown_type: c.rx_unknown_type.load(Ordering::Relaxed),
+                hs_send_errors: c.hs_send_errors.load(Ordering::Relaxed),
+                hs_requests_armed: c.hs_requests_armed.load(Ordering::Relaxed),
+                decap_packets: c.decap_packets.load(Ordering::Relaxed),
+                decap_bytes: c.decap_bytes.load(Ordering::Relaxed),
+                decap_keepalives: c.decap_keepalives.load(Ordering::Relaxed),
+                decap_drops_malformed_header: c
+                    .decap_drops_malformed_header
+                    .load(Ordering::Relaxed),
+                decap_drops_unknown_session: c
+                    .decap_drops_unknown_session
+                    .load(Ordering::Relaxed),
+                decap_drops_counter_ceiling: c
+                    .decap_drops_counter_ceiling
+                    .load(Ordering::Relaxed),
+                decap_drops_crypto: c.decap_drops_crypto.load(Ordering::Relaxed),
+                decap_drops_replay: c.decap_drops_replay.load(Ordering::Relaxed),
+                decap_drops_allowed_ips: c.decap_drops_allowed_ips.load(Ordering::Relaxed),
+                decap_drops_malformed_inner: c
+                    .decap_drops_malformed_inner
+                    .load(Ordering::Relaxed),
+                decap_drops_buffer: c.decap_drops_buffer.load(Ordering::Relaxed),
+                encap_packets: c.encap_packets.load(Ordering::Relaxed),
+                encap_bytes: c.encap_bytes.load(Ordering::Relaxed),
+                encap_drops_no_session: c.encap_drops_no_session.load(Ordering::Relaxed),
+                encap_drops_unconfirmed: c.encap_drops_unconfirmed.load(Ordering::Relaxed),
+                encap_drops_rekey_required: c
+                    .encap_drops_rekey_required
+                    .load(Ordering::Relaxed),
+                encap_drops_other: c.encap_drops_other.load(Ordering::Relaxed),
+                encap_mtu_drops: c.encap_mtu_drops.load(Ordering::Relaxed),
+                transport_send_errors: c.transport_send_errors.load(Ordering::Relaxed),
+                tun_write_errors: c.tun_write_errors.load(Ordering::Relaxed),
+                tun_rx_drops_no_endpoint: c.tun_rx_drops_no_endpoint.load(Ordering::Relaxed),
+            });
+        }
+        out
+    }
+
     pub fn identity_count(&self) -> usize {
         self.workers.identities.len()
     }

--- a/userspace-dp/src/afxdp/coordinator/wg_control.rs
+++ b/userspace-dp/src/afxdp/coordinator/wg_control.rs
@@ -37,6 +37,7 @@
 //!     (frame/mod.rs).
 
 use super::*;
+use crate::afxdp::wg::counters::WgCounters;
 use crate::afxdp::wg::{POLY1305_TAG_LEN, WG_DATA_HEADER_LEN};
 use std::io::{Read, Write};
 use std::net::{SocketAddr, UdpSocket};
@@ -246,7 +247,12 @@ pub(super) fn wg_control_loop(
             // stop/join during reconcile).
             for _ in 0..WG_RX_BURST {
                 match tun.read(&mut tun_buf) {
-                    Ok(len) if len > 0 => did_work = true,
+                    Ok(len) if len > 0 => {
+                        // #1865: inner packet drained + dropped — no
+                        // learned endpoint to send to yet.
+                        WgCounters::bump(&engine.counters().tun_rx_drops_no_endpoint);
+                        did_work = true;
+                    }
                     _ => break,
                 }
             }
@@ -424,9 +430,14 @@ fn drive_initiation(
     tunnel_name: &str,
     recent_exceptions: &Arc<Mutex<VecDeque<ExceptionStatus>>>,
 ) {
+    // #1865: create_initiation Ok/Err accounting is engine-internal
+    // (hs_initiations_created / hs_initiation_build_failures); the
+    // send failure is OURS to count — created↑ + send_errors↑ +
+    // completions flat is the #1736 EINVAL fingerprint.
     if let Ok(_local_index) = engine.create_initiation(peer_pubkey, out) {
         let len = crate::afxdp::wg::WG_MSG_INIT_LEN;
         if let Err(e) = wg_send_to(socket, socket_is_v6, &out[..len], endpoint) {
+            WgCounters::bump(&engine.counters().hs_send_errors);
             record_local_tunnel_exception(
                 recent_exceptions,
                 tunnel_name,
@@ -463,7 +474,19 @@ fn dispatch_inbound(
             match engine.consume_initiation_create_response(datagram, response_buf) {
                 Ok((_peer_pubkey, _local_index)) => {
                     let len = crate::afxdp::wg::WG_MSG_RESPONSE_LEN;
-                    let _ = wg_send_to(socket, socket_is_v6, &response_buf[..len], from);
+                    // #1865: the response send error was silently
+                    // discarded (`let _ =`) — the responder mirror of
+                    // the #1736 initiator-EINVAL class. Count + record.
+                    if let Err(e) =
+                        wg_send_to(socket, socket_is_v6, &response_buf[..len], from)
+                    {
+                        WgCounters::bump(&engine.counters().hs_send_errors);
+                        record_local_tunnel_exception(
+                            recent_exceptions,
+                            tunnel_name,
+                            format!("wg_response_send:{from}:{e}"),
+                        );
+                    }
                     true
                 }
                 Err(_e) => {
@@ -482,6 +505,7 @@ fn dispatch_inbound(
         crate::afxdp::wg::WG_TYPE_COOKIE => {
             // Cookie/MAC2 reply handling is S7; drop for now. Not
             // authenticated for endpoint-learning purposes.
+            WgCounters::bump(&engine.counters().hs_rx_cookie_unsupported);
             debug_log!("WG[{}]: drop cookie (S7)", tunnel_name);
             false
         }
@@ -493,6 +517,7 @@ fn dispatch_inbound(
                     // engine — the AllowedIPs gate inside try_decap is
                     // S2a's inner-src control).
                     if let Err(e) = tun.write_all(&decap_buf[..outcome.len]) {
+                        WgCounters::bump(&engine.counters().tun_write_errors);
                         record_local_tunnel_exception(
                             recent_exceptions,
                             tunnel_name,
@@ -508,6 +533,11 @@ fn dispatch_inbound(
             }
         }
         _ => {
+            // #1865: type byte outside {1,2,3,4}. Zero-length
+            // datagrams never reach here (the recv loop's
+            // `Ok(_) => break` arm consumes them), so this counter is
+            // exactly "well-formed UDP, non-WG type byte".
+            WgCounters::bump(&engine.counters().rx_unknown_type);
             debug_log!("WG[{}]: drop unknown type {}", tunnel_name, wg_type);
             false
         }
@@ -536,6 +566,10 @@ fn encap_and_send(
     // TUN MTU (Go-side) is the first line; this is defense-in-depth for a
     // mis-set MTU or a jumbo inner read off the TUN.
     if wg_encapped_size(inner_ip.len(), endpoint.is_ipv6()) > WG_OUTER_MTU {
+        // #1865: the #1736 v4-mapped blackhole class — full-MSS inner
+        // packets silently vanishing here moved ZERO bytes of forward
+        // TCP while pings passed. Now release-visible.
+        WgCounters::bump(&engine.counters().encap_mtu_drops);
         debug_log!(
             "WG[{}]: drop oversize inner {} (encapped > {})",
             tunnel_name,
@@ -547,6 +581,7 @@ fn encap_and_send(
     match engine.try_encap(peer_pubkey, inner_ip, out) {
         Ok(outcome) => {
             if let Err(e) = wg_send_to(socket, socket_is_v6, &out[..outcome.len], endpoint) {
+                WgCounters::bump(&engine.counters().transport_send_errors);
                 record_local_tunnel_exception(
                     recent_exceptions,
                     tunnel_name,

--- a/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
@@ -74,6 +74,14 @@ pub(super) fn populate_tunnel_endpoints(
             TunnelEndpoint {
                 id: endpoint.id,
                 logical_ifindex: endpoint.ifindex,
+                // #1865: attachment label for the telemetry-row name
+                // fallback (linux_name, else logical name — mirrors
+                // wg_tombstone_respawn_coherent's row_label).
+                interface_label: if endpoint.linux_name.is_empty() {
+                    endpoint.interface.clone()
+                } else {
+                    endpoint.linux_name.clone()
+                },
                 redundancy_group: endpoint.redundancy_group,
                 mode: endpoint.mode.clone(),
                 outer_family,

--- a/userspace-dp/src/afxdp/frame/wg.rs
+++ b/userspace-dp/src/afxdp/frame/wg.rs
@@ -83,10 +83,10 @@ pub(super) fn wg_encap_frame(
         .unwrap_or(1500);
     let wg_record_len = WG_DATA_HEADER_LEN + pad_to_16(inner_packet.len()) + POLY1305_TAG_LEN;
     if wg_encapped_size(inner_packet.len(), outer_v6) > outer_mtu {
-        // wg_mtu_drops would be incremented on a real counter store here;
-        // S2a surfaces this via the explicit drop (None) + the control
-        // thread's symmetric guard. Telemetry consolidation is on the
-        // engine in a follow-up.
+        // #1865: the promised "follow-up" counter store — same
+        // `encap_mtu_drops` counter as the control thread's symmetric
+        // guard (the plan's both-guards requirement).
+        crate::afxdp::wg::counters::WgCounters::bump(&engine.counters().encap_mtu_drops);
         return None;
     }
 

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -166,6 +166,12 @@ pub(in crate::afxdp) struct EgressInterface {
 pub(in crate::afxdp) struct TunnelEndpoint {
     pub(in crate::afxdp) id: u16,
     pub(in crate::afxdp) logical_ifindex: i32,
+    /// #1865: the snapshot row's attachment label (linux_name, else
+    /// the logical interface name) carried so the telemetry row name
+    /// fallback chain matches the plan: ifindex_to_name -> this ->
+    /// wg-endpoint-<id>. Same convention as
+    /// `wg_tombstone_respawn_coherent`'s row_label.
+    pub(in crate::afxdp) interface_label: String,
     pub(in crate::afxdp) redundancy_group: i32,
     pub(in crate::afxdp) mode: String,
     pub(in crate::afxdp) outer_family: i32,
@@ -192,6 +198,7 @@ impl std::fmt::Debug for TunnelEndpoint {
         f.debug_struct("TunnelEndpoint")
             .field("id", &self.id)
             .field("logical_ifindex", &self.logical_ifindex)
+            .field("interface_label", &self.interface_label)
             .field("redundancy_group", &self.redundancy_group)
             .field("mode", &self.mode)
             .field("outer_family", &self.outer_family)

--- a/userspace-dp/src/afxdp/wg/counters.rs
+++ b/userspace-dp/src/afxdp/wg/counters.rs
@@ -1,0 +1,296 @@
+//! #1865: operator-visible WireGuard telemetry counters.
+//!
+//! One `WgCounters` per `WgEngine` (== per tunnel in S2a). All fields
+//! are relaxed `AtomicU64`s: increment sites are either the per-tunnel
+//! control thread (slow path) or the rarely-hit transit encap path in
+//! `frame/wg.rs` (which already heap-allocates per packet), and the
+//! single reader is the 1/s status poll. Multi-counter snapshots are
+//! NOT transactional — the poll reads each atomic independently while
+//! the control thread increments, so e.g. `decap_packets` may be one
+//! ahead of `decap_bytes` within one snapshot. Fine for observability.
+//!
+//! Counter lifetime follows the engine `Arc`:
+//!   - survives control-thread tombstone/respawn cycles (#1872) and
+//!     unrelated commits (engine reuse via `wg_identity_unchanged`);
+//!   - resets to zero when a commit CHANGES the crypto identity and
+//!     `populate_wg_engines` rebuilds the engine. Deliberate: under
+//!     #1873's positional id renumbering, inheriting the same-id
+//!     previous engine's counters would attribute a DIFFERENT
+//!     tunnel's history to this one. Prometheus `rate()` tolerates
+//!     monotonic resets, and the reset is itself a faithful signal
+//!     that every session was rebuilt.
+//!
+//! Reason mapping is consolidated here (`count_decap_err`,
+//! `count_encap_err`, `count_handshake_rx_err`) so the engine return
+//! sites stay one-liners and a future error-variant addition fails
+//! compilation here rather than silently going uncounted.
+//!
+//! Reserved reason names with NO increment site today (do not invent
+//! counters for them): TAI64N-replay rejects and under-load rate-limit
+//! rejects — S1 explicitly defers per-peer TAI64N anti-replay and
+//! cookie/MAC2 (S7) to responder hardening (handshake_session.rs,
+//! "does not yet enforce per-peer TAI64N anti-replay").
+
+use super::engine::{DecapError, EncapError};
+use super::handshake::FramingError;
+use super::handshake_session::HandshakeError;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, Default)]
+pub(crate) struct WgCounters {
+    // --- handshake ---
+    /// `create_initiation` Ok — msg1 BUILT (not necessarily sent; a
+    /// failed send shows in `hs_send_errors`, so the #1736 EINVAL
+    /// fingerprint is `created↑ + send_errors↑ + completions flat`).
+    pub(crate) hs_initiations_created: AtomicU64,
+    /// `create_initiation` Err, all variants folded (previously
+    /// discarded by the `if let Ok` at the drive_initiation call site).
+    pub(crate) hs_initiation_build_failures: AtomicU64,
+    /// `consume_initiation_create_response` Ok — responder accepted
+    /// msg1, built msg2, installed the (unconfirmed) session. This is
+    /// ALSO the responder-completion event (single increment site; the
+    /// Prometheus completions metric emits it under role="responder").
+    pub(crate) hs_responses_created: AtomicU64,
+    /// `consume_response` Ok — initiator-side handshake completion.
+    pub(crate) hs_completions_initiator: AtomicU64,
+    /// Inbound handshake-message drops by reason (msg1 + msg2 paths).
+    pub(crate) hs_rx_drops_mac1_mismatch: AtomicU64,
+    pub(crate) hs_rx_drops_malformed: AtomicU64,
+    pub(crate) hs_rx_drops_crypto: AtomicU64,
+    pub(crate) hs_rx_drops_unknown_peer: AtomicU64,
+    pub(crate) hs_rx_drops_stale_response: AtomicU64,
+    pub(crate) hs_rx_drops_index_exhausted: AtomicU64,
+    /// Type-3 (cookie) datagrams — S7 placeholder, dropped today.
+    pub(crate) hs_rx_cookie_unsupported: AtomicU64,
+    /// Type byte ∉ {1,2,3,4}. Zero-length UDP datagrams never reach
+    /// type dispatch (consumed by the `Ok(_) => break` recv arm in
+    /// wg_control), so runts are deliberately NOT counted here.
+    pub(crate) rx_unknown_type: AtomicU64,
+    /// `wg_send_to` failures for handshake messages — BOTH the
+    /// initiation send and the (previously `let _ =`-discarded)
+    /// response send.
+    pub(crate) hs_send_errors: AtomicU64,
+    /// `request_handshake` accepted a NoSession edge (rate-limited
+    /// worker→control "please initiate"). Ties an encap-drop burst to
+    /// the re-initiation it triggered.
+    pub(crate) hs_requests_armed: AtomicU64,
+
+    // --- transport decap (inbound) ---
+    pub(crate) decap_packets: AtomicU64,
+    /// Inner-IP bytes (un-padded), symmetric with `encap_bytes`. These
+    /// are logical tunnel payload bytes — they will NOT match a kernel
+    /// peer's `wg show` transfer numbers (which include WG overhead).
+    pub(crate) decap_bytes: AtomicU64,
+    /// Authenticated ZERO-length transport records (WG persistent
+    /// keepalives: pad_to_16(0) == 0 ⇒ snow yields n == 0). Counted
+    /// after the replay gate, before the inner parse — withOUT this
+    /// class peel a keepalive peer would emit steady
+    /// `decap_drops_malformed_inner` false alarms. NOT a drop counter.
+    pub(crate) decap_keepalives: AtomicU64,
+    pub(crate) decap_drops_malformed_header: AtomicU64,
+    pub(crate) decap_drops_unknown_session: AtomicU64,
+    pub(crate) decap_drops_counter_ceiling: AtomicU64,
+    pub(crate) decap_drops_crypto: AtomicU64,
+    pub(crate) decap_drops_replay: AtomicU64,
+    pub(crate) decap_drops_allowed_ips: AtomicU64,
+    /// MalformedInner with n > 0 only — the n == 0 keepalive class is
+    /// peeled off into `decap_keepalives` above.
+    pub(crate) decap_drops_malformed_inner: AtomicU64,
+    pub(crate) decap_drops_buffer: AtomicU64,
+
+    // --- transport encap (egress) ---
+    pub(crate) encap_packets: AtomicU64,
+    pub(crate) encap_bytes: AtomicU64,
+    /// `EncapError::NoSession` from the no-current-session arm ONLY.
+    pub(crate) encap_drops_no_session: AtomicU64,
+    /// `EncapError::NoSession` from the `is_confirmed()` gate arm —
+    /// the responder key-confirmation window. Distinguishable so an
+    /// operator does not tcpdump a transient rekey blip (#1736 AGY
+    /// r2). Counter-only split: the returned error stays `NoSession`
+    /// and every caller contract is untouched.
+    pub(crate) encap_drops_unconfirmed: AtomicU64,
+    pub(crate) encap_drops_rekey_required: AtomicU64,
+    /// UnknownPeer | CryptoFailed | BufferTooSmall — all
+    /// "structurally impossible unless bug" classes, folded. Split if
+    /// ever nonzero in the field.
+    pub(crate) encap_drops_other: AtomicU64,
+    /// Exact pad-aware MTU-guard drops, BOTH egress sites (control
+    /// thread TUN-read + frame/wg.rs transit). The #1736 v4-mapped
+    /// blackhole counter.
+    pub(crate) encap_mtu_drops: AtomicU64,
+    /// `wg_send_to` failures for encap'd transport datagrams.
+    pub(crate) transport_send_errors: AtomicU64,
+    /// `tun.write_all` failures delivering decap'd inner packets.
+    pub(crate) tun_write_errors: AtomicU64,
+    /// Inner packets drained (and dropped) off the TUN while a
+    /// responder-only peer has no learned endpoint to send to.
+    pub(crate) tun_rx_drops_no_endpoint: AtomicU64,
+
+    // --- state (not a counter) ---
+    /// Monotonic (CLOCK_MONOTONIC ns) stamp of the most recent
+    /// handshake completion, either role. 0 = never. Converted to
+    /// wall-clock epoch seconds at status-snapshot time; the stored
+    /// stamp stays monotonic so an NTP step fences nothing (#1792).
+    pub(crate) last_handshake_complete_ns: AtomicU64,
+}
+
+impl WgCounters {
+    #[inline]
+    pub(crate) fn bump(counter: &AtomicU64) {
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Count a decap failure by reason and hand the error back, so the
+    /// engine's return sites stay `Err(self.counters.count_decap_err(e))`
+    /// one-liners. The keepalive class never routes through here (it is
+    /// counted at its dedicated site inside `try_decap`).
+    pub(crate) fn count_decap_err(&self, e: DecapError) -> DecapError {
+        let c = match e {
+            DecapError::MalformedHeader | DecapError::ShortRecord => {
+                &self.decap_drops_malformed_header
+            }
+            DecapError::UnknownSession => &self.decap_drops_unknown_session,
+            DecapError::CounterRejectAfterMessages => &self.decap_drops_counter_ceiling,
+            DecapError::CryptoFailed => &self.decap_drops_crypto,
+            DecapError::ReplayDuplicate | DecapError::ReplayOutOfWindow => {
+                &self.decap_drops_replay
+            }
+            DecapError::AllowedIpsViolation => &self.decap_drops_allowed_ips,
+            DecapError::MalformedInner => &self.decap_drops_malformed_inner,
+            DecapError::BufferTooSmall => &self.decap_drops_buffer,
+        };
+        Self::bump(c);
+        e
+    }
+
+    /// Count an encap failure by reason and hand the error back. The
+    /// two `NoSession` arms inside `try_encap` do NOT route through
+    /// here — they bump `encap_drops_no_session` /
+    /// `encap_drops_unconfirmed` directly at their distinct sites (the
+    /// returned variant is the same `NoSession`, so this mapper cannot
+    /// tell them apart).
+    pub(crate) fn count_encap_err(&self, e: EncapError) -> EncapError {
+        let c = match e {
+            EncapError::RekeyRequired => &self.encap_drops_rekey_required,
+            // Defensive: NoSession should never reach this mapper (see
+            // doc above); attribute to no_session rather than lose it.
+            EncapError::NoSession => &self.encap_drops_no_session,
+            EncapError::UnknownPeer
+            | EncapError::CryptoFailed
+            | EncapError::BufferTooSmall => &self.encap_drops_other,
+        };
+        Self::bump(c);
+        e
+    }
+
+    /// Count an inbound handshake-message drop by reason (msg1 + msg2
+    /// consume paths) and hand the error back.
+    pub(crate) fn count_handshake_rx_err(&self, e: HandshakeError) -> HandshakeError {
+        let c = match &e {
+            HandshakeError::Framing(FramingError::Mac1Mismatch) => {
+                &self.hs_rx_drops_mac1_mismatch
+            }
+            HandshakeError::Framing(_) | HandshakeError::OutputTooSmall => {
+                &self.hs_rx_drops_malformed
+            }
+            HandshakeError::Crypto | HandshakeError::Internal => &self.hs_rx_drops_crypto,
+            HandshakeError::UnknownInitiator | HandshakeError::UnknownPeer => {
+                &self.hs_rx_drops_unknown_peer
+            }
+            HandshakeError::NoPendingHandshake | HandshakeError::ReceiverIndexMismatch => {
+                &self.hs_rx_drops_stale_response
+            }
+            HandshakeError::IndexExhausted => &self.hs_rx_drops_index_exhausted,
+        };
+        Self::bump(c);
+        e
+    }
+
+    /// Stamp a handshake completion (either role) at `now_ns`
+    /// (CLOCK_MONOTONIC). `max(1)` keeps a (test-clock) completion at
+    /// t=0 distinguishable from "never".
+    pub(crate) fn record_handshake_complete(&self, now_ns: u64) {
+        self.last_handshake_complete_ns
+            .store(now_ns.max(1), Ordering::Relaxed);
+    }
+}
+
+/// CLOCK_MONOTONIC nanoseconds. Same clock domain (and same
+/// implementation) as `crate::afxdp::neighbor::monotonic_nanos` — the
+/// status snapshot converts stamps recorded here using that helper's
+/// `now_mono`, so the domains MUST match. Duplicated (6 lines) rather
+/// than imported to preserve the wg module's documented isolation from
+/// the wider afxdp web (wg/mod.rs "Why this module exists in
+/// isolation").
+pub(crate) fn monotonic_now_ns() -> u64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
+    if rc != 0 || ts.tv_sec < 0 || ts.tv_nsec < 0 {
+        return 0;
+    }
+    (ts.tv_sec as u64)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(ts.tv_nsec as u64)
+}
+
+#[cfg(test)]
+mod counters_tests {
+    use super::*;
+
+    #[test]
+    fn decap_err_mapping_covers_every_variant() {
+        let c = WgCounters::default();
+        for e in [
+            DecapError::MalformedHeader,
+            DecapError::ShortRecord,
+            DecapError::UnknownSession,
+            DecapError::CounterRejectAfterMessages,
+            DecapError::CryptoFailed,
+            DecapError::ReplayDuplicate,
+            DecapError::ReplayOutOfWindow,
+            DecapError::AllowedIpsViolation,
+            DecapError::MalformedInner,
+            DecapError::BufferTooSmall,
+        ] {
+            let back = c.count_decap_err(e.clone());
+            assert_eq!(back, e, "mapper must hand the error back unchanged");
+        }
+        assert_eq!(c.decap_drops_malformed_header.load(Ordering::Relaxed), 2);
+        assert_eq!(c.decap_drops_replay.load(Ordering::Relaxed), 2);
+        assert_eq!(c.decap_drops_unknown_session.load(Ordering::Relaxed), 1);
+        assert_eq!(c.decap_drops_counter_ceiling.load(Ordering::Relaxed), 1);
+        assert_eq!(c.decap_drops_crypto.load(Ordering::Relaxed), 1);
+        assert_eq!(c.decap_drops_allowed_ips.load(Ordering::Relaxed), 1);
+        assert_eq!(c.decap_drops_malformed_inner.load(Ordering::Relaxed), 1);
+        assert_eq!(c.decap_drops_buffer.load(Ordering::Relaxed), 1);
+        // The keepalive class never routes through the mapper.
+        assert_eq!(c.decap_keepalives.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn handshake_rx_err_mapping_distinguishes_mac1() {
+        let c = WgCounters::default();
+        c.count_handshake_rx_err(HandshakeError::Framing(FramingError::Mac1Mismatch));
+        c.count_handshake_rx_err(HandshakeError::Framing(FramingError::WrongLength));
+        c.count_handshake_rx_err(HandshakeError::OutputTooSmall);
+        c.count_handshake_rx_err(HandshakeError::NoPendingHandshake);
+        assert_eq!(c.hs_rx_drops_mac1_mismatch.load(Ordering::Relaxed), 1);
+        assert_eq!(c.hs_rx_drops_malformed.load(Ordering::Relaxed), 2);
+        assert_eq!(c.hs_rx_drops_stale_response.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn handshake_complete_stamp_never_zero() {
+        let c = WgCounters::default();
+        assert_eq!(c.last_handshake_complete_ns.load(Ordering::Relaxed), 0);
+        c.record_handshake_complete(0);
+        assert_eq!(
+            c.last_handshake_complete_ns.load(Ordering::Relaxed),
+            1,
+            "a t=0 completion must remain distinguishable from never"
+        );
+    }
+}

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -53,6 +53,7 @@
 //!     mutex before snow.read_message.)
 
 use super::allowed_ips::AllowedIps;
+use super::counters::WgCounters;
 use super::framing::{encode_data_header, parse_data_header};
 // PendingHandshake is defined alongside the handshake orchestration in
 // handshake_session.rs (same `wg` module); the engine struct holds a map of
@@ -321,6 +322,11 @@ pub(crate) struct WgEngine {
     /// so a request at `now_ns == 0` (tests) is not confused with "no
     /// request".
     pub(in crate::afxdp::wg) handshake_request_last_ns: std::sync::atomic::AtomicU64,
+    /// #1865: per-engine telemetry counters (relaxed atomics). Bound
+    /// to the engine Arc: survives control-thread respawns and
+    /// unrelated commits (engine reuse); resets with the engine on an
+    /// identity-changing rebuild — see counters.rs.
+    pub(in crate::afxdp::wg) counters: WgCounters,
 }
 
 /// Minimum spacing between worker-driven "please initiate" edges
@@ -358,6 +364,7 @@ impl WgEngine {
             sessions_by_local_index: RwLock::new(FxHashMap::default()),
             handshake_request_pending: std::sync::atomic::AtomicBool::new(false),
             handshake_request_last_ns: std::sync::atomic::AtomicU64::new(0),
+            counters: WgCounters::default(),
         };
         engine.reconcile_peers(&config.peers);
         engine
@@ -392,7 +399,15 @@ impl WgEngine {
             return false;
         }
         self.handshake_request_pending.store(true, Ordering::Relaxed);
+        WgCounters::bump(&self.counters.hs_requests_armed);
         true
+    }
+
+    /// #1865: the engine's telemetry counters. Call-site counters
+    /// (MTU guards, send/TUN errors, cookie/unknown-type) increment
+    /// through this accessor; engine-internal paths count directly.
+    pub(crate) fn counters(&self) -> &WgCounters {
+        &self.counters
     }
 
     /// Control side of the NoSession edge. Returns `true` if a handshake
@@ -700,13 +715,16 @@ impl WgEngine {
         // Cryptokey-routing safety: the forwarding decision tells
         // us which peer to encrypt to. We do NOT consult
         // AllowedIPs to pick a peer on egress.
-        let peer = self.peer_arc(peer_pubkey).ok_or(EncapError::UnknownPeer)?;
-        let session = peer
-            .current
-            .read()
-            .unwrap()
-            .clone()
-            .ok_or(EncapError::NoSession)?;
+        let peer = self
+            .peer_arc(peer_pubkey)
+            .ok_or_else(|| self.counters.count_encap_err(EncapError::UnknownPeer))?;
+        let Some(session) = peer.current.read().unwrap().clone() else {
+            // #1865: the no-current-session arm — distinct from the
+            // unconfirmed gate below (same wire error, different
+            // counter; AGY r2 #1736 mandated the split be visible).
+            WgCounters::bump(&self.counters.encap_drops_no_session);
+            return Err(EncapError::NoSession);
+        };
         // WG key-confirmation: the responder MUST NOT send transport
         // data on a fresh session until it has authenticated the
         // initiator's first data packet. Treat an unconfirmed session
@@ -718,6 +736,10 @@ impl WgEngine {
         // `WgSession::confirmed` doc for the rationale and Codex
         // final pre-merge finding 2 for the missed invariant.
         if !session.is_confirmed() {
+            // #1865: counter-only split — the returned variant stays
+            // `NoSession` so every caller contract (request_handshake
+            // kick + drop) is untouched; only the attribution differs.
+            WgCounters::bump(&self.counters.encap_drops_unconfirmed);
             return Err(EncapError::NoSession);
         }
 
@@ -739,14 +761,16 @@ impl WgEngine {
         let padded_len = pad_to_16(inner_ip.len());
         let required = WG_DATA_HEADER_LEN + padded_len + POLY1305_TAG_LEN;
         if out.len() < required {
-            return Err(EncapError::BufferTooSmall);
+            return Err(self.counters.count_encap_err(EncapError::BufferTooSmall));
         }
         if padded_len > PADDED_PLAINTEXT_MAX {
-            return Err(EncapError::BufferTooSmall);
+            return Err(self.counters.count_encap_err(EncapError::BufferTooSmall));
         }
-        let counter = session.next_tx_counter().ok_or(EncapError::RekeyRequired)?;
+        let counter = session
+            .next_tx_counter()
+            .ok_or_else(|| self.counters.count_encap_err(EncapError::RekeyRequired))?;
         let _ = encode_data_header(out, session.peer_index, counter)
-            .ok_or(EncapError::BufferTooSmall)?;
+            .ok_or_else(|| self.counters.count_encap_err(EncapError::BufferTooSmall))?;
         // Stage the padded plaintext on the stack. We use
         // `MaybeUninit` to skip the 4096-byte zero-init that a
         // `[0u8; PADDED_PLAINTEXT_MAX]` literal would force on every
@@ -810,7 +834,13 @@ impl WgEngine {
         let n = session
             .transport
             .write_message(counter, plaintext, payload)
-            .map_err(|_| EncapError::CryptoFailed)?;
+            .map_err(|_| self.counters.count_encap_err(EncapError::CryptoFailed))?;
+        // #1865: success accounting — inner-IP (un-padded) bytes,
+        // symmetric with the decap side.
+        WgCounters::bump(&self.counters.encap_packets);
+        self.counters
+            .encap_bytes
+            .fetch_add(inner_ip.len() as u64, std::sync::atomic::Ordering::Relaxed);
         Ok(EncapOutcome {
             len: WG_DATA_HEADER_LEN + n,
             receiver_index: session.peer_index,
@@ -829,14 +859,17 @@ impl WgEngine {
         wg_record: &[u8],
         out: &mut [u8],
     ) -> Result<DecapOutcome, DecapError> {
-        let hdr = parse_data_header(wg_record).ok_or(DecapError::MalformedHeader)?;
+        let hdr = parse_data_header(wg_record)
+            .ok_or_else(|| self.counters.count_decap_err(DecapError::MalformedHeader))?;
         // WG spec §6.5: drop inbound data packets whose counter is
         // at or above REJECT_AFTER_MESSAGES without doing AEAD. The
         // counter-space ceiling is symmetric across encap/decap;
         // the encap-side guard alone is not sufficient because a
         // malicious or buggy sender may send arbitrary high counters.
         if hdr.counter >= REJECT_AFTER_MESSAGES {
-            return Err(DecapError::CounterRejectAfterMessages);
+            return Err(self
+                .counters
+                .count_decap_err(DecapError::CounterRejectAfterMessages));
         }
         let session = self
             .sessions_by_local_index
@@ -844,7 +877,7 @@ impl WgEngine {
             .unwrap()
             .get(&hdr.receiver_index)
             .cloned()
-            .ok_or(DecapError::UnknownSession)?;
+            .ok_or_else(|| self.counters.count_decap_err(DecapError::UnknownSession))?;
         // Truncated-record DoS guard. `parse_data_header` only checks
         // that the buffer has at least WG_DATA_HEADER_LEN (16) bytes;
         // it does not enforce that the trailing ciphertext field is
@@ -860,22 +893,22 @@ impl WgEngine {
         // r-final-2 review (the truncated-record class was missed by
         // all 9 prior review rounds).
         if hdr.ciphertext.len() < POLY1305_TAG_LEN {
-            return Err(DecapError::ShortRecord);
+            return Err(self.counters.count_decap_err(DecapError::ShortRecord));
         }
         let plaintext_len_max = hdr.ciphertext.len() - POLY1305_TAG_LEN;
         if out.len() < plaintext_len_max {
-            return Err(DecapError::BufferTooSmall);
+            return Err(self.counters.count_decap_err(DecapError::BufferTooSmall));
         }
         {
             let replay = session.replay.lock().unwrap();
             if replay.definitely_out_of_window(hdr.counter) {
-                return Err(DecapError::ReplayOutOfWindow);
+                return Err(self.counters.count_decap_err(DecapError::ReplayOutOfWindow));
             }
         }
         let n = session
             .transport
             .read_message(hdr.counter, hdr.ciphertext, out)
-            .map_err(|_| DecapError::CryptoFailed)?;
+            .map_err(|_| self.counters.count_decap_err(DecapError::CryptoFailed))?;
         // WG key-confirmation: a successful AEAD authenticate is
         // proof that the peer has the session keys, so a responder-
         // role session can now be used for egress. Initiator-role
@@ -902,13 +935,29 @@ impl WgEngine {
                     // plaintext upstream. Cost is one memset per
                     // replay-reject — the rare path.
                     out[..n].fill(0);
-                    return Err(DecapError::ReplayDuplicate);
+                    return Err(self.counters.count_decap_err(DecapError::ReplayDuplicate));
                 }
                 ReplayDecision::OutOfWindow => {
                     out[..n].fill(0);
-                    return Err(DecapError::ReplayOutOfWindow);
+                    return Err(self.counters.count_decap_err(DecapError::ReplayOutOfWindow));
                 }
             }
+        }
+        // #1865: authenticated ZERO-length transport record == WG
+        // persistent keepalive (pad_to_16(0) == 0, so snow yields
+        // n == 0). It has done its protocol work above (AEAD
+        // authenticated, session confirmed, replay window advanced) but
+        // carries no inner packet to deliver. Count it as a keepalive
+        // and exit through the SAME error the inner-parse would have
+        // produced - external behavior is byte-identical to pre-#1865
+        // (no TUN write, caller treats it as unauthenticated for
+        // endpoint-learning; see plan §9 for that latent gap) - but
+        // the telemetry no longer reports a steady stream of false
+        // "malformed inner" drops for a keepalive peer (Codex r1 F1 +
+        // SMR r1 F1, independent convergence).
+        if n == 0 {
+            WgCounters::bump(&self.counters.decap_keepalives);
+            return Err(DecapError::MalformedInner);
         }
         // AllowedIPs gate on the inner src IP. WG spec §5.4.6:
         // "After decryption, the receiver verifies that the source
@@ -953,6 +1002,12 @@ impl WgEngine {
         match outcome {
             Ok((_inner_src, _peer_idx, inner_len)) => {
                 debug_assert!(inner_len <= n);
+                // #1865: success accounting - inner-IP (un-padded)
+                // bytes, symmetric with the encap side.
+                WgCounters::bump(&self.counters.decap_packets);
+                self.counters
+                    .decap_bytes
+                    .fetch_add(inner_len as u64, std::sync::atomic::Ordering::Relaxed);
                 Ok(DecapOutcome {
                     len: inner_len,
                     peer_pubkey: session.peer_pubkey,
@@ -963,7 +1018,7 @@ impl WgEngine {
                 // but cannot deliver. Covers MalformedInner,
                 // UnknownSession, and AllowedIpsViolation uniformly.
                 out[..n].fill(0);
-                Err(e)
+                Err(self.counters.count_decap_err(e))
             }
         }
     }

--- a/userspace-dp/src/afxdp/wg/handshake_session.rs
+++ b/userspace-dp/src/afxdp/wg/handshake_session.rs
@@ -262,7 +262,7 @@ impl WgEngine {
     /// zeros). On any failure after reservation the reservation is released.
     /// Writes the 148-byte message at `out[0..148]` and returns the chosen
     /// sender_index.
-    pub(crate) fn create_initiation(
+    fn create_initiation_inner(
         &self,
         peer_pubkey: &[u8; WG_KEY_LEN],
         out: &mut [u8],
@@ -350,7 +350,7 @@ impl WgEngine {
     ///     symmetric state on a failed read, so we put the borrowed
     ///     `HandshakeState` back and keep waiting for a valid (or
     ///     retransmitted) response.
-    pub(crate) fn consume_response(&self, msg: &[u8]) -> Result<u32, HandshakeError> {
+    fn consume_response_inner(&self, msg: &[u8]) -> Result<u32, HandshakeError> {
         let parsed = handshake::parse_response(msg, &self.local_public_key)?;
         let local_index = parsed.receiver_index;
 
@@ -431,7 +431,7 @@ impl WgEngine {
     /// session. Writes the 92-byte response at `out[0..92]` and returns
     /// `(peer_pubkey, our_sender_index)` — pubkey first, matching the return
     /// expression below.
-    pub(crate) fn consume_initiation_create_response(
+    fn consume_initiation_create_response_inner(
         &self,
         msg: &[u8],
         out: &mut [u8],
@@ -534,6 +534,76 @@ impl WgEngine {
         Ok((peer_pubkey, local_index))
     }
 
+}
+
+// ===================================================================
+// #1865: telemetry-counting wrappers around the three slow-path
+// handshake entry points. The *_inner bodies above are unchanged; the
+// wrappers own the Result -> counter mapping so a call site can never
+// bypass accounting. Completion stamps use the wg-local
+// CLOCK_MONOTONIC reader (counters::monotonic_now_ns — same domain as
+// the coordinator's monotonic_nanos, which the status snapshot uses
+// for the wall-clock conversion).
+// ===================================================================
+impl WgEngine {
+    /// Build a framed WG type-1 initiation toward `peer_pubkey`.
+    /// Counted: Ok → `hs_initiations_created` ("created", NOT "sent" —
+    /// the UDP send happens at the call site and can fail; see
+    /// `hs_send_errors`); Err → `hs_initiation_build_failures` (all
+    /// variants folded; previously discarded entirely by the
+    /// `if let Ok` at the drive_initiation call site).
+    pub(crate) fn create_initiation(
+        &self,
+        peer_pubkey: &[u8; WG_KEY_LEN],
+        out: &mut [u8],
+    ) -> Result<u32, HandshakeError> {
+        let res = self.create_initiation_inner(peer_pubkey, out);
+        match &res {
+            Ok(_) => super::counters::WgCounters::bump(&self.counters.hs_initiations_created),
+            Err(_) => super::counters::WgCounters::bump(
+                &self.counters.hs_initiation_build_failures,
+            ),
+        }
+        res
+    }
+
+    /// Initiator path: consume a framed WG type-2 response. Counted:
+    /// Ok → `hs_completions_initiator` + completion stamp; Err →
+    /// per-reason `hs_rx_drops_*`.
+    pub(crate) fn consume_response(&self, msg: &[u8]) -> Result<u32, HandshakeError> {
+        match self.consume_response_inner(msg) {
+            Ok(idx) => {
+                super::counters::WgCounters::bump(&self.counters.hs_completions_initiator);
+                self.counters
+                    .record_handshake_complete(super::counters::monotonic_now_ns());
+                Ok(idx)
+            }
+            Err(e) => Err(self.counters.count_handshake_rx_err(e)),
+        }
+    }
+
+    /// Responder path: consume a framed WG type-1 initiation and build
+    /// the type-2 response. Counted: Ok → `hs_responses_created` +
+    /// completion stamp (this single increment site is ALSO the
+    /// responder-completion event — the Prometheus completions metric
+    /// emits it under role="responder"; the UDP response send and its
+    /// failure are the call site's `hs_send_errors`); Err →
+    /// per-reason `hs_rx_drops_*`.
+    pub(crate) fn consume_initiation_create_response(
+        &self,
+        msg: &[u8],
+        out: &mut [u8],
+    ) -> Result<([u8; WG_KEY_LEN], u32), HandshakeError> {
+        match self.consume_initiation_create_response_inner(msg, out) {
+            Ok(ok) => {
+                super::counters::WgCounters::bump(&self.counters.hs_responses_created);
+                self.counters
+                    .record_handshake_complete(super::counters::monotonic_now_ns());
+                Ok(ok)
+            }
+            Err(e) => Err(self.counters.count_handshake_rx_err(e)),
+        }
+    }
 }
 
 /// Allocate a non-zero pseudo-random u32 for a handshake index. WG indices

--- a/userspace-dp/src/afxdp/wg/mod.rs
+++ b/userspace-dp/src/afxdp/wg/mod.rs
@@ -33,6 +33,13 @@
 #![allow(dead_code)] // Most of this module is not yet wired into the hot path.
 
 pub(crate) mod allowed_ips;
+// #1865: operator-visible telemetry counters — one `WgCounters` per
+// engine (relaxed atomics). See counters.rs for the lifetime/reset
+// semantics (engine-Arc-bound; reset on identity rebuild, NEVER
+// inherited across #1873 positional-id renumbering) and the
+// reserved-reason list (tai64n-replay, rate-limit — no increment
+// sites until responder hardening).
+pub(crate) mod counters;
 pub(crate) mod dscp;
 pub(crate) mod engine;
 pub(crate) mod framing;
@@ -70,6 +77,21 @@ pub(crate) use engine::{
     WgEngineConfig, WgPeerConfig,
 };
 pub(crate) use scratch::WgWorkerScratch;
+
+/// Render a 32-byte WG key as the 64-char lowercase hex string used
+/// across xpf's WG config/wire surfaces (`wg_peer_pubkey_hex`,
+/// protocol/snapshot.rs). The inverse of
+/// `forwarding_build::tunnels::decode_wg_key_hex`. PUBLIC keys only —
+/// never call this on private key material.
+pub(crate) fn encode_wg_key_hex(key: &[u8; WG_KEY_LEN]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(WG_KEY_LEN * 2);
+    for b in key {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
 
 /// Canonicalize a WG peer endpoint address: unmap a V4-MAPPED IPv6
 /// (`::ffff:a.b.c.d`) to its canonical V4 form so overhead math

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -2196,3 +2196,332 @@ fn wg_request_handshake_single_edge_under_concurrent_callers() {
     );
     assert!(engine.take_handshake_request(), "the winning edge is pending");
 }
+
+// ===================================================================
+// #1865: operator-visible telemetry counter tests. Each asserts the
+// EXACT counter that must move (and key neighbors that must NOT) for
+// the plan §6 scenarios, plus the keepalive classification regression.
+// ===================================================================
+mod telemetry_counters {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    /// Full framed handshake: created/completed counters both roles,
+    /// completion stamp set, and the responder confirmation flip via
+    /// the first inbound record.
+    #[test]
+    fn framed_handshake_moves_handshake_counters() {
+        let (init, resp, _init_pub, resp_pub) = framed_engine_pair();
+
+        let mut msg1 = [0u8; crate::afxdp::wg::WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1).unwrap();
+        let ic = init.counters();
+        assert_eq!(ic.hs_initiations_created.load(Ordering::Relaxed), 1);
+        assert_eq!(ic.hs_initiation_build_failures.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            ic.last_handshake_complete_ns.load(Ordering::Relaxed),
+            0,
+            "creation alone is NOT completion"
+        );
+
+        let mut msg2 = [0u8; crate::afxdp::wg::WG_MSG_RESPONSE_LEN];
+        resp.consume_initiation_create_response(&msg1, &mut msg2)
+            .unwrap();
+        let rc = resp.counters();
+        assert_eq!(rc.hs_responses_created.load(Ordering::Relaxed), 1);
+        assert!(
+            rc.last_handshake_complete_ns.load(Ordering::Relaxed) > 0,
+            "responder completion stamps the handshake time"
+        );
+
+        init.consume_response(&msg2).unwrap();
+        assert_eq!(ic.hs_completions_initiator.load(Ordering::Relaxed), 1);
+        assert!(ic.last_handshake_complete_ns.load(Ordering::Relaxed) > 0);
+
+        // Transport round-trip moves packet/byte counters symmetrically.
+        let inner = ipv4_packet(Ipv4Addr::new(10, 1, 1, 1), Ipv4Addr::new(10, 1, 1, 2));
+        let mut wire = [0u8; 2048];
+        let enc = init.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+        let mut plain = [0u8; 2048];
+        resp.try_decap(&wire[..enc.len], &mut plain).unwrap();
+        assert_eq!(ic.encap_packets.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            ic.encap_bytes.load(Ordering::Relaxed),
+            inner.len() as u64,
+            "encap bytes are inner-IP (un-padded) bytes"
+        );
+        assert_eq!(rc.decap_packets.load(Ordering::Relaxed), 1);
+        assert_eq!(rc.decap_bytes.load(Ordering::Relaxed), inner.len() as u64);
+    }
+
+    /// The keepalive regression (Codex r1 F1 + SMR r1 F1): an
+    /// authenticated ZERO-length transport record counts as
+    /// `decap_keepalives` — NOT `decap_drops_malformed_inner` — while
+    /// the external contract (Err, replay window advanced) and the
+    /// confirmation side-effect are unchanged.
+    #[test]
+    fn zero_length_record_counts_keepalive_not_malformed_inner() {
+        let (init_engine, resp_engine, init_pub, resp_pub) = established_pair(
+            vec!["0.0.0.0/0".parse().unwrap()],
+            vec!["0.0.0.0/0".parse().unwrap()],
+        );
+        let mut wire = [0u8; 256];
+        let enc = init_engine.try_encap(&resp_pub, &[], &mut wire).unwrap();
+        // pad_to_16(0) == 0: header + tag only.
+        assert_eq!(
+            enc.len,
+            crate::afxdp::wg::WG_DATA_HEADER_LEN + crate::afxdp::wg::POLY1305_TAG_LEN
+        );
+        let mut plain = [0u8; 256];
+        let err = resp_engine
+            .try_decap(&wire[..enc.len], &mut plain)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            DecapError::MalformedInner,
+            "external error contract unchanged (keepalive still not deliverable)"
+        );
+        let rc = resp_engine.counters();
+        assert_eq!(rc.decap_keepalives.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            rc.decap_drops_malformed_inner.load(Ordering::Relaxed),
+            0,
+            "keepalives must NOT inflate the malformed-inner drop counter"
+        );
+        // Replay window advanced: replaying the identical record is a
+        // replay drop, not a second keepalive.
+        let err2 = resp_engine
+            .try_decap(&wire[..enc.len], &mut plain)
+            .unwrap_err();
+        assert!(matches!(
+            err2,
+            DecapError::ReplayDuplicate | DecapError::ReplayOutOfWindow
+        ));
+        assert_eq!(rc.decap_keepalives.load(Ordering::Relaxed), 1);
+        assert_eq!(rc.decap_drops_replay.load(Ordering::Relaxed), 1);
+        let _ = (init_pub, init_engine);
+    }
+
+    /// MAC1-corrupted initiation → hs_rx_drops_mac1_mismatch (the
+    /// wrong-key-peer live-validation case).
+    #[test]
+    fn mac1_mismatch_counts_on_responder() {
+        let (init, _resp, _init_pub, resp_pub) = framed_engine_pair();
+        let mut msg1 = [0u8; crate::afxdp::wg::WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1).unwrap();
+        // A responder with a DIFFERENT static key: mac1 keys on the
+        // recipient pubkey, so this is the wrong-key-peer shape.
+        let (other_priv, _) = keypair();
+        let (_, init2_pub) = keypair();
+        let other = WgEngine::new(WgEngineConfig {
+            local_private_key: other_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: init2_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+            }],
+        });
+        let mut msg2 = [0u8; crate::afxdp::wg::WG_MSG_RESPONSE_LEN];
+        let _ = other
+            .consume_initiation_create_response(&msg1, &mut msg2)
+            .unwrap_err();
+        assert_eq!(
+            other.counters().hs_rx_drops_mac1_mismatch.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(other.counters().hs_responses_created.load(Ordering::Relaxed), 0);
+    }
+
+    /// AllowedIPs-violating inner → decap_drops_allowed_ips.
+    #[test]
+    fn allowed_ips_violation_counts() {
+        let (init_engine, resp_engine, _init_pub, resp_pub) = established_pair(
+            vec!["0.0.0.0/0".parse().unwrap()],
+            // Responder only accepts 10.7.0.0/16 from the initiator.
+            vec!["10.7.0.0/16".parse().unwrap()],
+        );
+        let inner = ipv4_packet(Ipv4Addr::new(192, 168, 1, 1), Ipv4Addr::new(10, 7, 0, 2));
+        let mut wire = [0u8; 2048];
+        let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+        let mut plain = [0u8; 2048];
+        let err = resp_engine
+            .try_decap(&wire[..enc.len], &mut plain)
+            .unwrap_err();
+        assert_eq!(err, DecapError::AllowedIpsViolation);
+        assert_eq!(
+            resp_engine
+                .counters()
+                .decap_drops_allowed_ips
+                .load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    /// Truncated (sub-tag) record → decap_drops_malformed_header
+    /// (ShortRecord folds into the malformed-header class).
+    #[test]
+    fn short_record_counts_malformed_header() {
+        let (init_engine, resp_engine, _init_pub, resp_pub) = established_pair(
+            vec!["0.0.0.0/0".parse().unwrap()],
+            vec!["0.0.0.0/0".parse().unwrap()],
+        );
+        let inner = ipv4_packet(Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2));
+        let mut wire = [0u8; 2048];
+        let enc = init_engine.try_encap(&resp_pub, &inner, &mut wire).unwrap();
+        let mut plain = [0u8; 2048];
+        // Header intact, ciphertext truncated below the Poly1305 tag.
+        let truncated = &wire[..crate::afxdp::wg::WG_DATA_HEADER_LEN + 8];
+        let err = resp_engine.try_decap(truncated, &mut plain).unwrap_err();
+        assert_eq!(err, DecapError::ShortRecord);
+        assert_eq!(
+            resp_engine
+                .counters()
+                .decap_drops_malformed_header
+                .load(Ordering::Relaxed),
+            1
+        );
+        let _ = enc;
+    }
+
+    /// The unconfirmed-vs-no-session split (AGY r2 #1736): the
+    /// responder key-confirmation gate bumps `encap_drops_unconfirmed`
+    /// (NOT no_session) while still returning `NoSession`; an engine
+    /// with a peer but no session at all bumps `encap_drops_no_session`.
+    #[test]
+    fn encap_no_session_vs_unconfirmed_split() {
+        // Unconfirmed: drive the framed handshake so the responder
+        // holds a real (unconfirmed) session, then encap from it.
+        let (init, resp, init_pub, resp_pub) = framed_engine_pair();
+        let mut msg1 = [0u8; crate::afxdp::wg::WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1).unwrap();
+        let mut msg2 = [0u8; crate::afxdp::wg::WG_MSG_RESPONSE_LEN];
+        resp.consume_initiation_create_response(&msg1, &mut msg2)
+            .unwrap();
+        let inner = ipv4_packet(Ipv4Addr::new(10, 2, 2, 1), Ipv4Addr::new(10, 2, 2, 2));
+        let mut wire = [0u8; 2048];
+        let err = resp.try_encap(&init_pub, &inner, &mut wire).unwrap_err();
+        assert_eq!(err, EncapError::NoSession, "wire error contract unchanged");
+        let rc = resp.counters();
+        assert_eq!(rc.encap_drops_unconfirmed.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            rc.encap_drops_no_session.load(Ordering::Relaxed),
+            0,
+            "the unconfirmed gate must NOT masquerade as no-session"
+        );
+
+        // No session at all: fresh engine, configured peer, no handshake.
+        let (fresh, _resp2, _ip2, rp2) = framed_engine_pair();
+        let err2 = fresh.try_encap(&rp2, &inner, &mut wire).unwrap_err();
+        assert_eq!(err2, EncapError::NoSession);
+        assert_eq!(
+            fresh.counters().encap_drops_no_session.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            fresh.counters().encap_drops_unconfirmed.load(Ordering::Relaxed),
+            0
+        );
+    }
+
+    /// create_initiation toward an unconfigured peer →
+    /// hs_initiation_build_failures (previously discarded by the
+    /// `if let Ok` at the drive_initiation call site).
+    #[test]
+    fn initiation_build_failure_counts() {
+        let (init, _resp, _init_pub, _resp_pub) = framed_engine_pair();
+        let (_, stranger_pub) = keypair();
+        let mut msg1 = [0u8; crate::afxdp::wg::WG_MSG_INIT_LEN];
+        let _ = init.create_initiation(&stranger_pub, &mut msg1).unwrap_err();
+        let ic = init.counters();
+        assert_eq!(ic.hs_initiation_build_failures.load(Ordering::Relaxed), 1);
+        assert_eq!(ic.hs_initiations_created.load(Ordering::Relaxed), 0);
+    }
+
+    /// request_handshake edge accounting: exactly the accepted edges
+    /// count (the rate-limited duplicates do not).
+    #[test]
+    fn handshake_request_edges_count_accepted_only() {
+        let (init, _resp, _init_pub, _resp_pub) = framed_engine_pair();
+        assert!(init.request_handshake(10));
+        assert!(!init.request_handshake(20), "inside the rate window");
+        assert_eq!(
+            init.counters().hs_requests_armed.load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    /// Counters survive an identity-UNCHANGED reconcile (same engine
+    /// object; reconcile_peers must not disturb telemetry).
+    #[test]
+    fn counters_survive_identity_unchanged_reconcile() {
+        let (init, _resp, _init_pub, resp_pub) = framed_engine_pair();
+        let mut msg1 = [0u8; crate::afxdp::wg::WG_MSG_INIT_LEN];
+        init.create_initiation(&resp_pub, &mut msg1).unwrap();
+        assert_eq!(init.counters().hs_initiations_created.load(Ordering::Relaxed), 1);
+        init.reconcile_peers(&[WgPeerConfig {
+            pubkey: resp_pub,
+            endpoint: None,
+            persistent_keepalive: 0,
+            allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+        }]);
+        assert_eq!(
+            init.counters().hs_initiations_created.load(Ordering::Relaxed),
+            1,
+            "reconcile with unchanged identity must not disturb counters"
+        );
+    }
+
+    /// Hex render of a pubkey matches the house wire convention
+    /// (lowercase, 64 chars; inverse of decode_wg_key_hex).
+    #[test]
+    fn encode_wg_key_hex_roundtrip_shape() {
+        let (_, pubkey) = keypair();
+        let hex = crate::afxdp::wg::encode_wg_key_hex(&pubkey);
+        assert_eq!(hex.len(), 64);
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        let mut nib = 0u8;
+        for (i, c) in hex.bytes().enumerate() {
+            let v = match c {
+                b'0'..=b'9' => c - b'0',
+                b'a'..=b'f' => c - b'a' + 10,
+                _ => unreachable!(),
+            };
+            if i % 2 == 0 {
+                nib = v << 4;
+            } else {
+                assert_eq!(pubkey[i / 2], nib | v);
+            }
+        }
+    }
+
+    /// Local copy of framed_handshake::engine_pair (that helper is
+    /// mod-private): two engines that know each other, 0.0.0.0/0.
+    fn framed_engine_pair() -> (WgEngine, WgEngine, [u8; 32], [u8; 32]) {
+        let (init_priv, init_pub) = keypair();
+        let (resp_priv, resp_pub) = keypair();
+        let any_v4: Vec<ipnet::IpNet> = vec!["0.0.0.0/0".parse().unwrap()];
+        let init = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: resp_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: any_v4.clone(),
+            }],
+        });
+        let resp = WgEngine::new(WgEngineConfig {
+            local_private_key: resp_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: init_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: any_v4,
+            }],
+        });
+        (init, resp, init_pub, resp_pub)
+    }
+}

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -311,6 +311,14 @@ pub(crate) struct ProcessStatus {
     /// it as a parallel field (rather than only embedded in
     /// `bindings[].*`) lets the daemon pull just the triage counters on
     /// its poll path without deserializing every field on `BindingStatus`.
+    /// #1865: per-WG-tunnel operator telemetry rows. Keyed by tunnel
+    /// NAME (`tunnel`) — `tunnel_endpoint_id` is informational only
+    /// because positional ids renumber across commits (#1873). Empty
+    /// (and omitted — `skip_serializing_if`) when no WG tunnel is
+    /// configured, so non-WG deployments stay wire-byte-identical to
+    /// pre-#1865. Additive / defaulted for mixed-version compat.
+    #[serde(rename = "wg_tunnels", default, skip_serializing_if = "Vec::is_empty")]
+    pub wg_tunnels: Vec<WgTunnelStatus>,
     #[serde(rename = "per_binding", default, skip_serializing_if = "Vec::is_empty")]
     pub per_binding: Vec<BindingCountersSnapshot>,
     /// #1249: low-frequency debug snapshot mapping active flow-cache
@@ -429,6 +437,124 @@ impl From<crate::slowpath::SlowPathStatus> for SlowPathStatus {
             write_errors: value.write_errors,
         }
     }
+}
+
+/// #1865: one WG tunnel's telemetry row inside `ProcessStatus`.
+/// Counter semantics, lifetime, and the reserved-reason list live in
+/// `afxdp/wg/counters.rs` (the single source of truth this mirrors);
+/// the Go mirror is `WgTunnelStatus` in
+/// `pkg/dataplane/userspace/protocol.go` — keep json tags identical
+/// on BOTH sides (feedback_wire_protocol_both_sides). All fields are
+/// serde-defaulted; rows are additive for mixed-version compat.
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub(crate) struct WgTunnelStatus {
+    /// Tunnel interface name (e.g. "wg0") — the PRIMARY key and the
+    /// only Prometheus label. Falls back to `wg-endpoint-<id>` when
+    /// the ifindex has no resolved name (a row is never dropped).
+    #[serde(default)]
+    pub tunnel: String,
+    /// Positional endpoint id — informational cross-ref ONLY (#1873:
+    /// renumbers when tunnels are added/removed; never a join key).
+    #[serde(rename = "tunnel_endpoint_id", default)]
+    pub tunnel_endpoint_id: u16,
+    #[serde(rename = "listen_port", default)]
+    pub listen_port: u16,
+    /// Peer static public key, 64-char lowercase hex (the same
+    /// rendering as the config-side `wg_peer_pubkey_hex`). Public by
+    /// definition. NOTE: `wg show` renders base64; xpf surfaces are
+    /// uniformly hex.
+    #[serde(rename = "peer_pubkey_hex", default)]
+    pub peer_pubkey_hex: String,
+    /// Configured peer endpoint (empty for a responder-only peer).
+    /// The control thread's LEARNED endpoint is thread-local and not
+    /// surfaced in this revision.
+    #[serde(rename = "peer_endpoint", default)]
+    pub peer_endpoint: String,
+    /// Whether the peer currently holds a CONFIRMED (egress-usable)
+    /// transport session. The liveness signal — see
+    /// `last_handshake_unix_secs` for why completion alone is not.
+    #[serde(rename = "session_confirmed", default)]
+    pub session_confirmed: bool,
+    /// Wall-clock epoch seconds of the most recent handshake
+    /// completion (either role). 0 = never (epoch 0 is unreachable, so
+    /// the sentinel is unambiguous without Option plumbing). Converted
+    /// from the engine's monotonic stamp at snapshot time; an NTP step
+    /// skews the display, never the stored stamp.
+    #[serde(rename = "last_handshake_unix_secs", default)]
+    pub last_handshake_unix_secs: u64,
+    // --- handshake counters ---
+    #[serde(rename = "hs_initiations_created", default)]
+    pub hs_initiations_created: u64,
+    #[serde(rename = "hs_initiation_build_failures", default)]
+    pub hs_initiation_build_failures: u64,
+    #[serde(rename = "hs_responses_created", default)]
+    pub hs_responses_created: u64,
+    #[serde(rename = "hs_completions_initiator", default)]
+    pub hs_completions_initiator: u64,
+    #[serde(rename = "hs_rx_drops_mac1_mismatch", default)]
+    pub hs_rx_drops_mac1_mismatch: u64,
+    #[serde(rename = "hs_rx_drops_malformed", default)]
+    pub hs_rx_drops_malformed: u64,
+    #[serde(rename = "hs_rx_drops_crypto", default)]
+    pub hs_rx_drops_crypto: u64,
+    #[serde(rename = "hs_rx_drops_unknown_peer", default)]
+    pub hs_rx_drops_unknown_peer: u64,
+    #[serde(rename = "hs_rx_drops_stale_response", default)]
+    pub hs_rx_drops_stale_response: u64,
+    #[serde(rename = "hs_rx_drops_index_exhausted", default)]
+    pub hs_rx_drops_index_exhausted: u64,
+    #[serde(rename = "hs_rx_cookie_unsupported", default)]
+    pub hs_rx_cookie_unsupported: u64,
+    #[serde(rename = "rx_unknown_type", default)]
+    pub rx_unknown_type: u64,
+    #[serde(rename = "hs_send_errors", default)]
+    pub hs_send_errors: u64,
+    #[serde(rename = "hs_requests_armed", default)]
+    pub hs_requests_armed: u64,
+    // --- transport decap ---
+    #[serde(rename = "decap_packets", default)]
+    pub decap_packets: u64,
+    #[serde(rename = "decap_bytes", default)]
+    pub decap_bytes: u64,
+    #[serde(rename = "decap_keepalives", default)]
+    pub decap_keepalives: u64,
+    #[serde(rename = "decap_drops_malformed_header", default)]
+    pub decap_drops_malformed_header: u64,
+    #[serde(rename = "decap_drops_unknown_session", default)]
+    pub decap_drops_unknown_session: u64,
+    #[serde(rename = "decap_drops_counter_ceiling", default)]
+    pub decap_drops_counter_ceiling: u64,
+    #[serde(rename = "decap_drops_crypto", default)]
+    pub decap_drops_crypto: u64,
+    #[serde(rename = "decap_drops_replay", default)]
+    pub decap_drops_replay: u64,
+    #[serde(rename = "decap_drops_allowed_ips", default)]
+    pub decap_drops_allowed_ips: u64,
+    #[serde(rename = "decap_drops_malformed_inner", default)]
+    pub decap_drops_malformed_inner: u64,
+    #[serde(rename = "decap_drops_buffer", default)]
+    pub decap_drops_buffer: u64,
+    // --- transport encap ---
+    #[serde(rename = "encap_packets", default)]
+    pub encap_packets: u64,
+    #[serde(rename = "encap_bytes", default)]
+    pub encap_bytes: u64,
+    #[serde(rename = "encap_drops_no_session", default)]
+    pub encap_drops_no_session: u64,
+    #[serde(rename = "encap_drops_unconfirmed", default)]
+    pub encap_drops_unconfirmed: u64,
+    #[serde(rename = "encap_drops_rekey_required", default)]
+    pub encap_drops_rekey_required: u64,
+    #[serde(rename = "encap_drops_other", default)]
+    pub encap_drops_other: u64,
+    #[serde(rename = "encap_mtu_drops", default)]
+    pub encap_mtu_drops: u64,
+    #[serde(rename = "transport_send_errors", default)]
+    pub transport_send_errors: u64,
+    #[serde(rename = "tun_write_errors", default)]
+    pub tun_write_errors: u64,
+    #[serde(rename = "tun_rx_drops_no_endpoint", default)]
+    pub tun_rx_drops_no_endpoint: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1409,3 +1409,108 @@ fn cos_queue_status_lease_claim_flow_roundtrip_1863() {
     assert!(back.lease_v8_worker_requested_bytes.is_empty());
     assert!(back.lease_v8_worker_granted_bytes.is_empty());
 }
+
+// #1865: round-trip + backward-compat + EMPTY-INVARIANT pins for the
+// per-WG-tunnel telemetry rows. The wire keys feed
+// pkg/dataplane/userspace/protocol.go (WgTunnelStatus) and the
+// Prometheus family `xpf_userspace_wg_*`.
+#[test]
+fn process_status_wg_tunnels_roundtrip_and_compat() {
+    // POPULATED round-trip (Codex plan-r1 F5: the Default-based wire
+    // fixture cannot see skip-if-empty fields, so the populated pin is
+    // the guard for this family). Every field nonzero/nonempty.
+    let row = WgTunnelStatus {
+        tunnel: "wg0".to_string(),
+        tunnel_endpoint_id: 7,
+        listen_port: 51820,
+        peer_pubkey_hex: "ab".repeat(32),
+        peer_endpoint: "192.0.2.10:51820".to_string(),
+        session_confirmed: true,
+        last_handshake_unix_secs: 1_770_000_000,
+        hs_initiations_created: 1,
+        hs_initiation_build_failures: 2,
+        hs_responses_created: 3,
+        hs_completions_initiator: 4,
+        hs_rx_drops_mac1_mismatch: 5,
+        hs_rx_drops_malformed: 6,
+        hs_rx_drops_crypto: 7,
+        hs_rx_drops_unknown_peer: 8,
+        hs_rx_drops_stale_response: 9,
+        hs_rx_drops_index_exhausted: 10,
+        hs_rx_cookie_unsupported: 11,
+        rx_unknown_type: 12,
+        hs_send_errors: 13,
+        hs_requests_armed: 14,
+        decap_packets: 15,
+        decap_bytes: 16,
+        decap_keepalives: 17,
+        decap_drops_malformed_header: 18,
+        decap_drops_unknown_session: 19,
+        decap_drops_counter_ceiling: 20,
+        decap_drops_crypto: 21,
+        decap_drops_replay: 22,
+        decap_drops_allowed_ips: 23,
+        decap_drops_malformed_inner: 24,
+        decap_drops_buffer: 25,
+        encap_packets: 26,
+        encap_bytes: 27,
+        encap_drops_no_session: 28,
+        encap_drops_unconfirmed: 29,
+        encap_drops_rekey_required: 30,
+        encap_drops_other: 31,
+        encap_mtu_drops: 32,
+        transport_send_errors: 33,
+        tun_write_errors: 34,
+        tun_rx_drops_no_endpoint: 35,
+    };
+    let status = ProcessStatus {
+        wg_tunnels: vec![row],
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize ProcessStatus");
+    let wire_row = &value["wg_tunnels"][0];
+    assert_eq!(wire_row["tunnel"], "wg0");
+    assert_eq!(wire_row["tunnel_endpoint_id"], 7);
+    assert_eq!(wire_row["listen_port"], 51820);
+    assert_eq!(wire_row["peer_pubkey_hex"], "ab".repeat(32));
+    assert_eq!(wire_row["peer_endpoint"], "192.0.2.10:51820");
+    assert_eq!(wire_row["session_confirmed"], true);
+    assert_eq!(wire_row["last_handshake_unix_secs"], 1_770_000_000u64);
+    assert_eq!(wire_row["decap_keepalives"], 17);
+    assert_eq!(wire_row["encap_drops_unconfirmed"], 29);
+    assert_eq!(wire_row["encap_mtu_drops"], 32);
+    let back: ProcessStatus =
+        serde_json::from_value(value).expect("deserialize ProcessStatus");
+    assert_eq!(back.wg_tunnels.len(), 1);
+    let b = &back.wg_tunnels[0];
+    assert_eq!(b.tunnel, "wg0");
+    assert_eq!(b.hs_initiations_created, 1);
+    assert_eq!(b.decap_drops_buffer, 25);
+    assert_eq!(b.tun_rx_drops_no_endpoint, 35);
+
+    // EMPTY-INVARIANT: a ProcessStatus with no WG tunnels serializes
+    // with NO `wg_tunnels` key at all — non-WG deployments stay
+    // wire-byte-identical to pre-#1865 (plan §3.2).
+    let empty_value = serde_json::to_value(ProcessStatus::default())
+        .expect("serialize default ProcessStatus");
+    assert!(
+        empty_value.get("wg_tunnels").is_none(),
+        "empty wg_tunnels must be omitted from the wire entirely"
+    );
+
+    // Pre-#1865 payload (key absent) must decode with an empty vec.
+    let legacy: ProcessStatus =
+        serde_json::from_value(empty_value).expect("pre-#1865 payload decodes");
+    assert!(legacy.wg_tunnels.is_empty());
+
+    // A pre-#1865 ROW shape is impossible (the whole array is new),
+    // but a NEWER peer adding fields inside a row must not break us:
+    // unknown keys are ignored by serde's default behavior.
+    let future_row: WgTunnelStatus = serde_json::from_str(
+        r#"{"tunnel":"wg9","future_field_from_s6":42}"#,
+    )
+    .expect("row with unknown future key decodes");
+    assert_eq!(future_row.tunnel, "wg9");
+    assert_eq!(future_row.hs_send_errors, 0);
+}

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -120,6 +120,9 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     state.status.neighbor_resolver_get_rtt_buckets = lat.resolver_get_rtt.buckets.to_vec();
     state.status.neighbor_resolver_get_rtt_sum_ns = lat.resolver_get_rtt.sum_ns;
     state.status.neighbor_resolver_get_rtt_count = lat.resolver_get_rtt.count;
+    // #1865: per-WG-tunnel telemetry rows (empty — and omitted from
+    // the wire — when no WG tunnel is configured).
+    state.status.wg_tunnels = state.afxdp.wg_tunnel_statuses();
     state.status.neighbor_pending_timeout_drops_total = lat.pending_timeout_drops;
     state.status.neighbor_pending_max_depth = lat.pending_max_depth;
     state.status.route_entries = state.snapshot.as_ref().map(|s| s.routes.len()).unwrap_or(0);

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -136,6 +136,9 @@ pub(crate) fn run() -> Result<(), String> {
             neighbor_netlink_redump_upserts_total: 0,
             neighbor_pending_keys: 0,
             neg_neigh_keys: 0,
+            // #1865: WG telemetry rows arrive on the first
+            // refresh_status; empty start keeps the wire omitted.
+            wg_tunnels: Vec::new(),
             per_binding: Vec::new(),
             flow_worker_map: Vec::new(),
             flow_worker_map_truncated: false,


### PR DESCRIPTION
Closes #1865.

Implements the converged 3/3 PLAN-READY research plan
(`docs/research/1865-wg-telemetry/plan.md` on `research/1865-wg-telemetry`,
copied into `docs/pr/1865-wg-telemetry/plan.md`): **Path B** — per-engine
counters + wire-additive status rows + Prometheus family + a minimal
`show security wireguard [detail]` operational command.

## Why

The S2a WG datapath had ZERO release-visible telemetry; every drop
diagnostic was `debug_log!`-gated. The #1736 interop campaign paid for
this twice: the v4-initiation `sendto=EINVAL` bug needed strace, and the
v4-mapped MTU-guard blackhole needed tcpdump on both ends plus the
KERNEL PEER's `wg show` as oracle. Both are now one-glance counter
diagnoses.

## What

- **`wg/counters.rs`** — one `WgCounters` per `WgEngine` (relaxed
  atomics; engine-Arc lifetime: survives #1872 tombstone respawns and
  unrelated commits; resets on identity rebuild — deliberately NOT
  inherited so #1873 positional renumbering can never misattribute).
  Engine-internal increments at the `try_encap`/`try_decap`/`consume_*`
  boundaries via consolidated reason mappers; call-site counters for
  both MTU guards (including the frame/wg.rs one whose comment promised
  this), send errors (incl. the previously `let _ =`-discarded responder
  msg2 send), TUN errors, cookie/unknown-type, responder-drain drops.
- **Keepalive classification** (Codex r1 F1 + Claude SMR F1 independent
  convergence): authenticated zero-length records count as
  `decap_keepalives` instead of polluting `malformed_inner`; external
  behavior byte-identical.
- **Unconfirmed-vs-no-session encap split** (AGY r2 on #1736):
  counter-only — the returned `EncapError::NoSession` and every caller
  contract untouched.
- **Wire**: `ProcessStatus.wg_tunnels` (skip-if-empty — non-WG
  deployments stay wire-byte-identical; `protocol_wire_v1.json`
  unchanged by construction), keyed by tunnel NAME; populated +
  key-absent + empty-invariant pins on BOTH sides
  (`protocol/tests.rs` + `pkg/dataplane/userspace/wg_status_test.go`
  share a 1..35 value ladder as a cross-language key pin).
- **Prometheus**: 12-descriptor `xpf_userspace_wg_*` family
  ({tunnel} + bounded role/direction/reason/kind labels; zeros emitted —
  0 is a real signal; `last_handshake_time_seconds` is an absolute
  epoch gauge, absent until first handshake). Descriptor-coverage
  canary extended with a populated fixture row + 7 family sentinels.
- **CLI**: `show security wireguard [detail]` on the
  show-system-buffers pattern — shared `FormatWireguardStatus`
  formatter, cmdtree node, local CLI + gRPC topics + remote CLI.
  STATUS only; key management/multi-tunnel selectors remain #1434 S6.
- **Docs**: runbook failure-triage step 0 makes the local counters the
  primary oracle (peer `wg show`/tcpdump demoted to cross-checks).
  `docs/config-schema.md` untouched — no config leaf in this PR.

## Validation

- `cargo build --release` clean.
- FULL `cargo test --release`: **2008 passed / 0 failed** aggregated
  over all 5 "test result" lines (no flakes this run).
- Plain debug `cargo test` wg module: 128 passed (10 new telemetry
  tests: full-handshake counter walk, keepalive regression + replay
  advance, mac1-mismatch wrong-key shape, AllowedIPs violation,
  ShortRecord, no-session/unconfirmed split, build-failure,
  request-edge accounting, reconcile survival, hex render).
- `go test ./...`: all packages ok (new: wire pins, formatter tests,
  gRPC topic tests, emitter series-set pin, extended canary).
- Live validation on the loss userspace cluster: in progress; evidence
  will be posted as a PR comment.

@copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)