### PR TITLE
userspace-dp: UpsertLocal joins the uncapped sync-family install (#1870)

### DIFF
--- a/docs/pr/1870-local-tunnel/agy-code-r1.md
+++ b/docs/pr/1870-local-tunnel/agy-code-r1.md
@@ -1,0 +1,79 @@
+Task b8b32547-bf70-4385-a545-320b174c1684/task-88 has completed.
+Task status: completed
+Task output:
+...
+test afxdp::session_glue::tests::purge_sessions_for_input_dscp_filter_revalidation_removes_family ... ok
+test afxdp::session_glue::tests::cached_session_resolution_skips_fabric_redirect ... ok
+test afxdp::session_glue::tests::maybe_promote_synced_session_skips_worker_local_import ... ok
+test afxdp::session_glue::tests::resolve_flow_session_decision_promotes_stale_fabric_shared_hit_to_local_owner_path ... ok
+test afxdp::session_glue::tests::lookup_forward_nat_across_scopes_returns_shared_nat_entry ... ok
+test afxdp::session_glue::tests::lookup_session_across_scopes_returns_shared_forward_wire_entry ... ok
+test afxdp::session_glue::tests::session_key_has_lo0_filter_matches_packet_family ... ok
+test afxdp::session_glue::tests::republish_local_delivery_sessions_for_lo0_filter_selects_existing_hits ... ok
+test afxdp::session_glue::tests::lookup_session_across_scopes_returns_shared_entry ... ok
+test afxdp::session_glue::tests::lookup_session_across_scopes_preserves_local_synced_origin ... ok
+test afxdp::session_glue::tests::lookup_session_across_scopes_preserves_local_forward_wire_synced_origin ... ok
+test afxdp::session_glue::tests::lookup_session_across_scopes_prefers_shared_entry_over_fabric_wire_placeholder ... ok
+test afxdp::session_glue::tests::lookup_forward_nat_across_scopes_prefers_shared_entry_over_fabric_wire_placeholder ... ok
+test afxdp::session_glue::tests::upsert_local_at_cap_replaces_existing_local_entry_without_growth ... ok
+test afxdp::session_glue::tests::upsert_local_below_cap_replaces_existing_local_entry ... ok
+test afxdp::session_glue::tests::upsert_local_entries_stay_out_of_owner_rg_bulk_export ... ok
+test afxdp::session_glue::tests::upsert_local_fanout_diverged_workers_converge ... ok
+test afxdp::session_glue::tests::upsert_local_pair_installs_at_cap ... ok
+test afxdp::session_glue::tests::upsert_local_pair_no_partial_at_cap_minus_one ... ok
+test afxdp::worker_runtime_tests::tests::local_tunnel_prewarm_is_not_prevented_by_worker_max_sessions ... ok
+test session::tests::upsert_synced_allow_replace_is_infallible_at_cap ... ok
+test session::tests::admission_refused_and_install_partial_counters_accumulate ... ok
+
+test result: ok. 217 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.05s
+
+   Doc-tests userspace-dp
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+### Finding 1 (Low): Exact Alignment of `WorkerCommand::UpsertLocal` with Path A
+The implementation of the `WorkerCommand::UpsertLocal` arm in [userspace-dp/src/afxdp/session_glue/mod.rs:586-597](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/session_glue/mod.rs#L586-L597) matches Section 4 Path A of the converged plan exactly:
+```rust
+586:                 let installed = sessions.upsert_synced_with_origin(
+587:                     SessionInstall {
+588:                         key: entry.key,
+589:                         decision: entry.decision,
+590:                         metadata: entry.metadata,
+591:                         origin: entry.origin,
+592:                         now_ns,
+593:                         protocol: entry.protocol,
+594:                         tcp_flags: entry.tcp_flags,
+595:                     },
+596:                     /* allow_replace_local = */ true,
+597:                 );
+```
+No fields are lost during construction. All seven fields defined in the `SessionInstall` struct at [userspace-dp/src/session/ctx.rs:31-39](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/session/ctx.rs#L31-L39) (`key`, `decision`, `metadata`, `origin`, `now_ns`, `protocol`, `tcp_flags`) are mapped directly from the received command payload.
+
+### Finding 2 (Low): Below-Cap Behavioral Identity Verified
+Comparing the capped install path at [userspace-dp/src/session/mod.rs:748-806](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/session/mod.rs#L748-L806) against the new uncapped `upsert_synced_with_origin` path at [userspace-dp/src/session/mod.rs:834-883](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/session/mod.rs#L834-L883) confirms they are behaviorally identical below capacity limit for `SyncImport` entries:
+- Below cap, the capacity check at line `758` is bypassed.
+- Passing `allow_replace_local = true` bypasses the local-clobber guard at line `850`.
+- Both paths perform the exact same mutations: key removal (`remove_entry`), epoch generation, `SessionRecord`/`SessionEntry` initialization (matching closing/timeout/tick defaults), slab insertion, handle map indexing (`index_forward_nat_key`), and wheel scheduling (`push_to_wheel`).
+- Because `SyncImport` returns `true` for `origin.is_peer_synced()`, both paths skip delta pushing (line `795` condition evaluates to `false`).
+
+### Finding 3 (Low): Producer Origin Sanity Guard
+All production commands for `UpsertLocal` are generated within `maybe_enqueue_local_tunnel_session` in [userspace-dp/src/afxdp/tunnel.rs:329-331](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/tunnel.rs#L329-L331). The entries are constructed in `build_local_origin_tunnel_tx_request` (lines `191` and `212`) and carry `SessionOrigin::SyncImport` (as defined in [userspace-dp/src/afxdp/tunnel.rs:202](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/tunnel.rs#L202) and [userspace-dp/src/afxdp/shared_ops.rs:668](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/shared_ops.rs#L668)). 
+`SyncImport` correctly satisfies `entry.origin.is_peer_synced()`. Thus, no current producer path can violate the safety constraint and trigger the `debug_assert!` at [userspace-dp/src/afxdp/session_glue/mod.rs:580](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/session_glue/mod.rs#L580) in debug builds.
+
+### Finding 4 (Low): Robustness of Test Fixtures and Assertions
+The test fixtures and assertions have been validated to ensure they are non-vacuous and enforce the contract:
+- **Port Collisions:** Filler key ports generated in `rig_capped_table` start at `40_000 + i` ([userspace-dp/src/afxdp/session_glue/tests.rs:4421](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/session_glue/tests.rs#L4421)) and only span `40000 - 40007`. These are disjoint from the forward key's `55068` ([userspace-dp/src/afxdp/session_glue/tests.rs:319](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/session_glue/tests.rs#L319)) and the reverse key's `5201`, ensuring no false collisions occur.
+- **Bulk-Export Verification:** The bulk-export exclusion test is non-vacuous because the forward entry's metadata carries `owner_rg_id: 1` and is successfully indexed under RG 1 in the session table. The only reason it is excluded from export is the explicit origin check in `export_forward_sessions_for_owner_rgs` at [userspace-dp/src/afxdp/session_glue/mod.rs:440](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/session_glue/mod.rs#L440).
+- **Assertions:** The new tests in both `session_glue/tests.rs` and `session/tests.rs` exclusively use release-effective `assert!` and `assert_eq!`. There are no `debug_assert!` macros used for test outcomes.
+
+### Finding 5 (Low): Docs and Metric Alignment
+Documentation accuracy has been corrected to reflect that `UpsertLocal` no longer contributes to `create_drops`:
+- The README in [userspace-dp/src/session/README.md:95](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/session/README.md#L95) was modified to remove `UpsertLocal` from the list of capped install sites.
+- The Prometheus help-text descriptor at [pkg/api/metrics_descriptors.go:558](file:///home/ps/git/bpfrx/.claude/worktrees/1870-engineer/pkg/api/metrics_descriptors.go#L558) was updated to explicitly document that `UpsertLocal replicas moved to the uncapped sync-family install in #1870 and no longer contribute.`
+- Both Go and Rust test suites pass cleanly.
+
+***
+
+### Verdict
+MERGE-READY

--- a/docs/pr/1870-local-tunnel/claude-smr-code-r1.md
+++ b/docs/pr/1870-local-tunnel/claude-smr-code-r1.md
@@ -1,0 +1,104 @@
+# Claude SMR hostile code review — PR #1877 (#1870), round 1
+
+**Reviewer:** Claude (domain SMR: session tables, HA replication, Rust)
+**Head:** `f21255768` (3 commits over origin/master `9a536f810`)
+**Stance:** hostile-verify against the converged plan
+(`research/1870-local-tunnel-pair` plan v5) and the code itself.
+
+## Worked trace 1 — the exact at-cap UpsertLocal interleaving through the fixed arm
+
+Preconditions: worker table at `max_sessions` (`len() == cap`), local TUN
+endpoint active, tunnel resolution `ForwardCandidate`.
+
+1. TUN read → `build_local_origin_tunnel_tx_request` → plan with
+   `session_entry` (origin `SyncImport`, `NatDecision::default()`) and
+   synthesized reverse (`is_reverse`, `SyncImport`).
+2. `maybe_enqueue_local_tunnel_session`: per-key window check passes →
+   `publish_shared_session` ×2 (shared maps + owner-RG indexes hold both) →
+   `UpsertLocal(forward)`, `UpsertLocal(reverse)` pushed to every worker
+   queue → 1 ms drain wait.
+3. Worker tick, `apply_worker_commands` pops `UpsertLocal(forward)`:
+   - `debug_assert!(entry.origin.is_peer_synced())` — true (`SyncImport`),
+     and it executes BEFORE the field-by-field move of `entry` into
+     `SessionInstall` (no use-after-move; release builds compile both
+     asserts out).
+   - `upsert_synced_with_origin(…, true)`: the local-clobber guard
+     (`session/mod.rs:855-860`) is bypassed by the flag; `remove_entry`
+     (no-op for a fresh key, replace for same-key); `next_epoch`; record
+     with identical `closing`/timeout/wheel fields as the old install;
+     slab insert; `key_to_handle`; `index_forward_nat_key` (owner-RG index
+     yes — `owner_rg_id == 1`-style metadata; NO forward-wire alias since
+     default NAT ⇒ `wire_key == key`, `session/mod.rs:1478-1481`);
+     `push_to_wheel`; returns `true`. `len() == cap + 1`.
+4. `UpsertLocal(reverse)`: same; `len() == cap + 2`. No `create_drops`, no
+   `admission_refused`, no deltas (`upsert` path pushes none; the old
+   install would also have suppressed them for peer-synced origin).
+5. Drain wait returns with the prewarm actually in place; the first reply
+   hits the worker table directly — no shared-mutex traversal, no
+   reactive materialization needed.
+6. Convergence: entries expire via the wheel like any session; peer-synced
+   expiry emits no Close delta (`session/mod.rs:524` guard) — unchanged.
+   `max_sessions` remains the new-flow admission bound via the #1871
+   `can_admit` preflight, which this PR does not touch.
+
+Pinned end-to-end by `upsert_local_pair_installs_at_cap` (and the cap-1 /
+two-worker variants). Trace verified against the diff: PASS.
+
+## Worked trace 2 — the HA variant
+
+- **Standby / inactive RG:** `build_local_origin_tunnel_tx_request` errors
+  unless the (HA-enforced) tunnel resolution is `ForwardCandidate`
+  (`tunnel.rs:171-175`), so the producer does not run and the arm is never
+  reached — except the deliberate `allow_unseeded_tunnel_local` prewarm
+  window, where the entries are still locally generated and replace-local
+  remains correct (no peer-vs-local arbitration exists for data this node
+  authored).
+- **Failover (RG demote/refresh):** `demote_owner_rg` skips already
+  peer-synced entries; `RefreshOwnerRGs` re-resolves them
+  origin-preserving. Identical handling to the pre-change healed end-state
+  (where the reverse sat as `SharedMaterialize` — residency-equivalent,
+  verified in plan rounds 2-3 by all three reviewers).
+- **HA sync surfaces:** `push_delta` suppressed for `SyncImport` in BOTH
+  the old and new install paths; owner-RG bulk export skips
+  `is_peer_synced()` origins (`session_glue/mod.rs:439-441`) — now pinned
+  non-vacuously: the entries ARE in the owner-RG index (`owner_rg_id = 1`
+  via `index_forward_nat_key`), so `export_forward_sessions_for_owner_rgs`
+  visits and origin-skips them; the pin would fail if either the indexing
+  or the skip changed.
+
+No HA-visible state transition differs from pre-change behavior. PASS.
+
+## Hostile checks on the implementation details
+
+- **Fixture collision audit:** filler keys (`src_port 40000+i`, src
+  `10.0.61.102` → dst `172.16.80.200:5201`) collide with neither the
+  forward key (`src_port 55068`) nor the reverse key (src/dst swapped:
+  src `172.16.80.200:5201` → dst `10.0.61.102:55068` — different src IP
+  entirely). PASS.
+- **Producer audit for the origin assert:** the only production
+  `UpsertLocal` producer is `maybe_enqueue_local_tunnel_session`
+  (`tunnel.rs:329-331`), whose entries are `SyncImport` (forward,
+  `tunnel.rs:202`) and the synthesized reverse (`shared_ops.rs:668`).
+  No other producer exists (grep). The debug assert cannot fire today.
+  PASS.
+- **Plan conformance:** arm matches plan §4 Path A field-for-field (key,
+  decision, metadata, origin, now_ns, protocol, tcp_flags;
+  `allow_replace_local=true`; both asserts). Test 1 uses exact
+  forward-key lookups, not `find_forward_wire_match`, per the plan-v4
+  correction. Two-worker fan-out pin present. Tests use `assert!` on
+  outcomes (AGY plan r1 finding). PASS.
+- **Docs:** README list drops "UpsertLocal replica sites"; new #1870
+  subsection records the family move + I11 centralization; descriptor
+  help-text updated with no series/label change (`prometheus.NewDesc`
+  name and label set untouched). Grep finds no remaining in-tree claim
+  that UpsertLocal contributes to `create_drops`. PASS.
+- **`_Log.md`:** not updated in this PR by design — it lives dirty in the
+  main checkout across concurrent sessions and would conflict; the PR
+  docs trail (plan + reviewer docs) is the durable record.
+
+## Verdict
+
+**MERGE-READY** — no findings. The change is the plan's Path A verbatim,
+the seven pins cover every interleaving the five plan rounds surfaced, and
+both worked traces pass through the fixed code without a behavioral
+surprise.

--- a/docs/pr/1870-local-tunnel/codex-code-r1.md
+++ b/docs/pr/1870-local-tunnel/codex-code-r1.md
@@ -1,0 +1,13 @@
+===RESULT===
+1. No Critical/High/Medium/Low findings.
+
+I hostile-verified the requested surfaces. The `UpsertLocal` arm constructs `SessionInstall` with all old positional fields preserved and uses `allow_replace_local=true`: [mod.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/session_glue/mod.rs:556). Below cap, the old install and new upsert share remove/reinsert/index/wheel behavior; the new path only removes the cap check and delta push path: [session/mod.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/session/mod.rs:748), [session/mod.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/session/mod.rs:834).
+
+The debug assert is currently safe: production `UpsertLocal` producers are only in `tunnel.rs`, with forward `SyncImport` and reverse `SyncImport`: [tunnel.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/tunnel.rs:191), [shared_ops.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/shared_ops.rs:664), [tunnel.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/tunnel.rs:329). The seven pins cover at-cap pair install, two-worker divergence, cap-1 partial prevention, below-cap replacement, at-cap replacement, owner-RG bulk-export exclusion, and session-level infallibility: [tests.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/session_glue/tests.rs:4470), [tests.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/session/tests.rs:2612). The filler keys do not collide with forward or reverse pair keys: [tests.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/afxdp/session_glue/tests.rs:4416), [key.rs](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/session/key.rs:154).
+
+Docs and metric help text no longer claim `UpsertLocal` contributes to `create_drops`: [README.md](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/userspace-dp/src/session/README.md:94), [metrics_descriptors.go](/home/ps/git/bpfrx/.claude/worktrees/1870-engineer/pkg/api/metrics_descriptors.go:553). I ran static diff/grep verification and `git diff --check`; I did not run cargo/go tests because this review worktree/sandbox is read-only.
+
+Verdict: MERGE-READY
+
+Codex session ID: 019eb8cc-14f4-7ee2-9096-538680186475
+Resume in Codex: codex resume 019eb8cc-14f4-7ee2-9096-538680186475

--- a/docs/pr/1870-local-tunnel/reviewer-ids.md
+++ b/docs/pr/1870-local-tunnel/reviewer-ids.md
@@ -1,0 +1,10 @@
+# Reviewer ledger — PR #1877 (#1870)
+
+## Research phase (branch research/1870-local-tunnel-pair, 5 rounds → PLAN-READY 3-of-3)
+See docs/research/1870-local-tunnel-pair/reviewer-ids.md on that branch.
+
+## Code review round 1 (head f21255768)
+- Codex: session 019eb8cc-14f4-7ee2-9096-538680186475 — MERGE-READY (no findings)
+- AGY: adversarial-review-mqa2itgd-g9t4f2 — MERGE-READY (5 confirmatory Low findings, all verification PASSes)
+- Claude SMR: claude-smr-code-r1.md — MERGE-READY (worked traces: at-cap interleaving + HA variant)
+- Copilot: UNAVAILABLE — quota limit, 3 documented request attempts (3 "reached their quota limit" review entries on the PR). 3-of-4 merge gate applies per policy (precedent: PR #1873/#1863 c8fc3cd16).

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -555,8 +555,10 @@ func newCollector(srv *Server) *xpfCollector {
 			"Cumulative session installs refused at the max_sessions cap on "+
 				"this userspace worker's session table (#1861 — previously "+
 				"counted internally but never exported). Covers every "+
-				"install site (new-flow, reply repair, seed, fabric-return, "+
-				"LocalMiss helper, UpsertLocal replicas).",
+				"capped install site (new-flow, reply repair, seed, "+
+				"fabric-return, LocalMiss helper). UpsertLocal replicas "+
+				"moved to the uncapped sync-family install in #1870 and "+
+				"no longer contribute.",
 			[]string{"worker_id"}, nil,
 		),
 		workerSessionInstallAdmissionRefused: prometheus.NewDesc(

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -554,18 +554,56 @@ pub(super) fn apply_worker_commands(
                 );
             }
             WorkerCommand::UpsertLocal(entry) => {
-                // Trivial variant — kept inline (#1346 plan v2 §4.1):
-                // lifting a 3-line delegate to its own sibling file is
-                // negative value.
-                sessions.install_with_protocol_with_origin(
-                    entry.key,
-                    entry.decision,
-                    entry.metadata,
-                    entry.origin,
-                    now_ns,
-                    entry.protocol,
-                    entry.tcp_flags,
+                // Kept inline (#1346 plan v2 §4.1): lifting a short
+                // delegate to its own sibling file is negative value.
+                //
+                // #1870: local-tunnel pair entries are coordinator-
+                // authoritative replicas of state ALREADY published to
+                // the shared maps (the tunnel.rs publish precedes the
+                // enqueue). Routing them through the capped
+                // install_with_protocol_with_origin let max_sessions
+                // refuse the worker-table copy while the reactive
+                // shared-hit materialization
+                // (materialize_shared_session_hit) reinstalls the
+                // reverse entry uncapped on the next reply packet — a
+                // futile cap that only polluted create_drops and
+                // delayed/voided the prewarm. Use the uncapped
+                // sync-family install these SyncImport-origin entries
+                // belong to. allow_replace_local=true preserves the
+                // pre-#1870 replace semantics (the capped install
+                // clobbered any same-key entry below cap); the data is
+                // locally generated — the producer only runs when the
+                // tunnel resolution is ForwardCandidate
+                // (build_local_origin_tunnel_tx_request) — so the
+                // "don't let peer data clobber local sessions" guard
+                // does not apply.
+                debug_assert!(
+                    entry.origin.is_peer_synced(),
+                    "UpsertLocal entries must carry a sync-family origin; a \
+                     local origin would have pushed an HA delta on the old \
+                     install path"
                 );
+                let installed = sessions.upsert_synced_with_origin(
+                    SessionInstall {
+                        key: entry.key,
+                        decision: entry.decision,
+                        metadata: entry.metadata,
+                        origin: entry.origin,
+                        now_ns,
+                        protocol: entry.protocol,
+                        tcp_flags: entry.tcp_flags,
+                    },
+                    /* allow_replace_local = */ true,
+                );
+                // The only false exit is the local-clobber guard, which
+                // allow_replace_local=true bypasses — infallible by
+                // construction (#1855 contract: assert in debug, inert
+                // in release).
+                debug_assert!(
+                    installed,
+                    "upsert_synced_with_origin(_, true) is infallible"
+                );
+                let _ = installed;
             }
             WorkerCommand::DeleteSynced(key) => {
                 commands::handle_delete_synced(sessions, session_map_fd, key, now_ns);

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -4373,3 +4373,252 @@ fn nat_reverse_key_warn_throttle_claims_once_per_window() {
         "claim at the window boundary must win"
     );
 }
+
+// ── #1870: UpsertLocal joins the uncapped sync-family install ────────
+//
+// Deterministic at-cap pins for the local-tunnel prewarm pair. The
+// coordinator publishes the forward + synthesized-reverse pair to the
+// shared maps unconditionally and fans `WorkerCommand::UpsertLocal` ×2
+// out to every worker; routing the apply side through the CAPPED
+// install let max_sessions silently refuse the worker-table copy while
+// the shared maps kept both entries. These pins run in debug AND
+// release profiles (#1855 contract) and use `assert!` on outcomes —
+// the production arm's `debug_assert!`s compile out in release.
+
+/// Mirror the producer's pair shape (`build_local_origin_tunnel_tx_request`
+/// + `synthesized_synced_reverse_entry`): SyncImport origin, default NAT
+/// (no rewrites — so no forward-wire alias exists), forward + reverse.
+fn local_tunnel_pair() -> (SyncedSessionEntry, SyncedSessionEntry) {
+    let forwarding = test_forwarding_state();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    let forward = SyncedSessionEntry {
+        key: test_key(),
+        decision: test_decision(),
+        metadata: test_metadata(),
+        origin: SessionOrigin::SyncImport,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_ACK,
+    };
+    let reverse = synthesized_synced_reverse_entry(
+        &forwarding,
+        &BTreeMap::new(),
+        &dynamic_neighbors,
+        &forward,
+        1,
+    )
+    .expect("reverse companion");
+    (forward, reverse)
+}
+
+/// Shrink the cap and fill the table with `fill` distinct local entries
+/// whose keys cannot collide with the local-tunnel pair (filler src
+/// ports start at 40000; the pair uses 55068/5201).
+fn rig_capped_table(cap: usize, fill: usize) -> SessionTable {
+    let mut sessions = SessionTable::new();
+    sessions.set_max_sessions_for_test(cap);
+    for i in 0..fill {
+        let key = SessionKey {
+            src_port: 40_000 + i as u16,
+            ..test_key()
+        };
+        assert!(sessions.install_with_protocol(
+            key,
+            test_decision(),
+            test_metadata(),
+            1_000_000,
+            PROTO_TCP,
+            TCP_FLAG_ACK,
+        ));
+    }
+    assert_eq!(sessions.len(), fill);
+    // Discard the fillers' open deltas so later assertions on the delta
+    // ring observe only the behavior under test.
+    let _ = sessions.drain_deltas(usize::MAX);
+    sessions
+}
+
+fn apply_upsert_local_pair(
+    sessions: &mut SessionTable,
+    forward: &SyncedSessionEntry,
+    reverse: &SyncedSessionEntry,
+) -> WorkerCommandResults {
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    {
+        let mut pending = commands.lock().expect("commands lock");
+        pending.push_back(WorkerCommand::UpsertLocal(forward.clone()));
+        pending.push_back(WorkerCommand::UpsertLocal(reverse.clone()));
+    }
+    let forwarding = test_forwarding_state();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    apply_worker_commands(
+        &commands,
+        sessions,
+        -1,
+        -1,
+        -1,
+        &forwarding,
+        &BTreeMap::new(),
+        &dynamic_neighbors,
+    )
+}
+
+/// §2.2 interleaving through the fixed arm: a table AT max_sessions
+/// admits the full pair (uncapped sync-family semantics) and no
+/// refusal counter moves. Pre-#1870 both installs were silently
+/// refused (create_drops += 2) while the shared maps held the pair.
+#[test]
+fn upsert_local_pair_installs_at_cap() {
+    let cap = 4;
+    let mut sessions = rig_capped_table(cap, cap);
+    let (forward, reverse) = local_tunnel_pair();
+
+    apply_upsert_local_pair(&mut sessions, &forward, &reverse);
+
+    // Exact forward-key lookups — NOT find_forward_wire_match: with
+    // default NAT, wire_key == key and the forward-wire index never
+    // holds these entries (index_forward_nat_key only inserts when
+    // they differ).
+    let (_, _, fwd_origin) = sessions
+        .entry_with_origin(&forward.key)
+        .expect("forward entry installed at cap");
+    assert_eq!(fwd_origin, SessionOrigin::SyncImport);
+    let (_, rev_metadata, rev_origin) = sessions
+        .entry_with_origin(&reverse.key)
+        .expect("reverse entry installed at cap");
+    assert_eq!(rev_origin, SessionOrigin::SyncImport);
+    assert!(rev_metadata.is_reverse);
+    assert_eq!(sessions.len(), cap + 2, "pair admitted past the cap");
+    assert_eq!(sessions.create_drops(), 0, "no longer counted as drops");
+    assert_eq!(sessions.admission_refused(), 0);
+    assert_eq!(sessions.install_partial(), 0);
+    // SyncImport installs must not enqueue HA deltas.
+    assert!(sessions.drain_deltas(usize::MAX).is_empty());
+}
+
+/// Producer fan-out pin (Codex #1870 plan r2): worker tables are
+/// independent — one at cap, one below — and both must converge to
+/// holding the full pair after the same fan-out.
+#[test]
+fn upsert_local_fanout_diverged_workers_converge() {
+    let (forward, reverse) = local_tunnel_pair();
+    let mut at_cap = rig_capped_table(2, 2);
+    let mut below_cap = rig_capped_table(8, 2);
+
+    for sessions in [&mut at_cap, &mut below_cap] {
+        apply_upsert_local_pair(sessions, &forward, &reverse);
+        assert!(sessions.entry_with_origin(&forward.key).is_some());
+        assert!(sessions.entry_with_origin(&reverse.key).is_some());
+        assert_eq!(sessions.create_drops(), 0);
+    }
+    assert_eq!(at_cap.len(), 4);
+    assert_eq!(below_cap.len(), 4);
+}
+
+/// Exactly one free slot: pre-#1870 the forward install succeeded and
+/// the reverse was refused (partial pair — worker held forward only
+/// while the shared maps held both). The fixed arm admits both.
+#[test]
+fn upsert_local_pair_no_partial_at_cap_minus_one() {
+    let cap = 4;
+    let mut sessions = rig_capped_table(cap, cap - 1);
+    let (forward, reverse) = local_tunnel_pair();
+
+    apply_upsert_local_pair(&mut sessions, &forward, &reverse);
+
+    assert!(sessions.entry_with_origin(&forward.key).is_some());
+    assert!(
+        sessions.entry_with_origin(&reverse.key).is_some(),
+        "reverse half must not be dropped when only one slot is free"
+    );
+    assert_eq!(sessions.len(), cap + 1);
+    assert_eq!(sessions.create_drops(), 0);
+}
+
+/// Below cap, `allow_replace_local=true` preserves the pre-#1870
+/// replace semantics of the capped install (which clobbered any
+/// same-key entry below cap). Guards against a future "tidy-up" to
+/// `allow_replace_local=false` or a revert to the capped install.
+#[test]
+fn upsert_local_below_cap_replaces_existing_local_entry() {
+    let mut sessions = SessionTable::new();
+    let (forward, reverse) = local_tunnel_pair();
+    assert!(sessions.install_with_protocol(
+        forward.key.clone(),
+        test_decision(),
+        test_metadata(),
+        1_000_000,
+        PROTO_TCP,
+        TCP_FLAG_ACK,
+    ));
+    let _ = sessions.drain_deltas(usize::MAX);
+
+    apply_upsert_local_pair(&mut sessions, &forward, &reverse);
+
+    let (_, _, origin) = sessions
+        .entry_with_origin(&forward.key)
+        .expect("replaced entry");
+    assert_eq!(
+        origin,
+        SessionOrigin::SyncImport,
+        "local same-key entry must be replaced by the tunnel decision"
+    );
+    assert_eq!(sessions.len(), 2, "replace + reverse install");
+    assert_eq!(sessions.create_drops(), 0);
+}
+
+/// At cap, same-key replacement is a deliberate #1870 semantic change:
+/// the old capped install refused BEFORE reaching remove_entry, so a
+/// stale same-key local entry could never be replaced at cap (and a
+/// local hit shadows the shared scope, blocking reactive
+/// materialization until expiry). The new arm replaces it without
+/// growing the table.
+#[test]
+fn upsert_local_at_cap_replaces_existing_local_entry_without_growth() {
+    let cap = 4;
+    let mut sessions = rig_capped_table(cap, cap - 1);
+    let (forward, reverse) = local_tunnel_pair();
+    assert!(sessions.install_with_protocol(
+        forward.key.clone(),
+        test_decision(),
+        test_metadata(),
+        1_000_000,
+        PROTO_TCP,
+        TCP_FLAG_ACK,
+    ));
+    assert_eq!(sessions.len(), cap, "table rigged to cap incl. stale key");
+    let _ = sessions.drain_deltas(usize::MAX);
+
+    apply_upsert_local_pair(&mut sessions, &forward, &reverse);
+
+    let (_, _, origin) = sessions
+        .entry_with_origin(&forward.key)
+        .expect("replaced entry at cap");
+    assert_eq!(origin, SessionOrigin::SyncImport);
+    assert_eq!(
+        sessions.len(),
+        cap + 1,
+        "same-key replace must not grow; only the reverse adds a slot"
+    );
+    assert_eq!(sessions.create_drops(), 0);
+}
+
+/// Pins the expected (permanent, by-origin) bulk-export behavior:
+/// local-tunnel entries carry SyncImport and are skipped by
+/// export_forward_sessions_for_owner_rgs at ANY occupancy — their
+/// exclusion is origin design, not a cap artifact (Codex #1870 plan
+/// r1 finding 3; refuted v1's "at-cap bulk-export gap" claim).
+#[test]
+fn upsert_local_entries_stay_out_of_owner_rg_bulk_export() {
+    let mut sessions = SessionTable::new();
+    let (forward, reverse) = local_tunnel_pair();
+    apply_upsert_local_pair(&mut sessions, &forward, &reverse);
+    assert!(sessions.entry_with_origin(&forward.key).is_some());
+    assert!(sessions.drain_deltas(usize::MAX).is_empty());
+
+    export_forward_sessions_for_owner_rgs(&mut sessions, &[1]);
+
+    assert!(
+        sessions.drain_deltas(usize::MAX).is_empty(),
+        "peer-synced-origin local-tunnel entries must not bulk-export"
+    );
+}

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -92,13 +92,30 @@ since #1861 via the worker-runtime status path as
 `xpf_userspace[_worker]_session_*_total`):
 
 - `create_drops` — at-cap refusals from the install itself (repair,
-  seed, fabric-return, LocalMiss, UpsertLocal replica sites);
+  seed, fabric-return, LocalMiss sites);
 - `admission_refused` — preflight refusals (one per refused flow);
 - `install_partial` — post-preflight residuals, expected 0 forever
   (the call sites pair the count with `debug_assert!` per the #1855
   contract above).
 
 Decision record: `docs/research/1861-install-txn/plan.md`.
+
+### UpsertLocal is in the uncapped sync family (#1870)
+
+`upsert_synced_with_origin` has NO cap check (the #1861 plan's row
+I11): HA sync, replica fan-out, and reactive shared-hit
+materialization all install past `max_sessions` by design. Since
+#1870 the local-tunnel prewarm (`WorkerCommand::UpsertLocal`,
+`session_glue`) joins that family with `allow_replace_local=true` —
+the entries are coordinator-authoritative `SyncImport` replicas of
+state already published to the shared maps, and the capped install
+previously refused the worker-table copy at cap while the reactive
+materializer reinstalled the reverse entry uncapped on the next reply
+packet anyway (futile cap; polluted `create_drops`; cap-1 partial
+pairs). Consequently `create_drops` no longer counts `UpsertLocal`
+installs — they cannot fail. The future cap arbitration for the sync
+family (row I11) now covers `UpsertLocal` automatically. Decision
+record: `docs/research/1870-local-tunnel-pair/plan.md`.
 
 ## Why a slab + integer handles
 

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -2599,3 +2599,57 @@ fn admission_refused_and_install_partial_counters_accumulate() {
     assert_eq!(table.admission_refused(), 2);
     assert_eq!(table.install_partial(), 1);
 }
+
+// ── #1870: sync-family upsert infallibility at max_sessions ─────────
+//
+// The UpsertLocal arm (session_glue) relies on
+// `upsert_synced_with_origin(_, allow_replace_local=true)` having no
+// failure mode: no cap check, and the only `false` exit (the
+// local-clobber guard) is bypassed. Pin both at-cap shapes in a
+// release-effective `assert!` (the arm's own debug_assert!s compile
+// out — #1855 contract).
+#[test]
+fn upsert_synced_allow_replace_is_infallible_at_cap() {
+    let mut table = SessionTable::new();
+    table.set_max_sessions_for_test(1);
+    let key = key_v4();
+    let now = 1_000_000_000u64;
+    assert!(table.install_with_protocol(key.clone(), decision(), metadata(), now, PROTO_TCP, 0x10));
+    assert_eq!(table.len(), 1, "table at cap");
+
+    // Same-key replace at cap: succeeds without growth.
+    assert!(
+        table.upsert_synced(
+            key.clone(),
+            decision(),
+            metadata(),
+            now + 1,
+            PROTO_TCP,
+            0x10,
+            true,
+        ),
+        "same-key upsert at cap must succeed"
+    );
+    assert_eq!(table.len(), 1);
+
+    // New-key insert at cap: the sync family is uncapped by design
+    // (#1861 row I11) — succeeds and grows past max_sessions.
+    let second = SessionKey {
+        src_port: key.src_port.wrapping_add(1),
+        ..key
+    };
+    assert!(
+        table.upsert_synced(
+            second.clone(),
+            decision(),
+            metadata(),
+            now + 2,
+            PROTO_TCP,
+            0x10,
+            true,
+        ),
+        "new-key upsert at cap must succeed (uncapped sync family)"
+    );
+    assert_eq!(table.len(), 2, "table exceeds max_sessions by design");
+    assert_eq!(table.create_drops(), 0, "no install-path drop counted");
+}


### PR DESCRIPTION
Closes #1870

## What

`WorkerCommand::UpsertLocal` (the local-tunnel forward + synthesized-reverse prewarm pair) now installs via the **uncapped** sync-family `upsert_synced_with_origin(…, allow_replace_local=true)` instead of the capped `install_with_protocol_with_origin` whose result was discarded.

## Why

The coordinator publishes the pair to the shared maps unconditionally, then fans `UpsertLocal` ×2 to every worker. At `max_sessions` the worker-table copy was silently refused — a shared-map/worker-table divergence with a cap-1 partial (forward-only) variant — while the reactive shared-hit materialization (`materialize_shared_session_hit`) reinstalls the reverse entry **uncapped** on the next reply packet anyway. The cap on the proactive prewarm was futile: it polluted `create_drops` with self-reversing non-drops, voided the prewarm, and blocked at-cap same-key replacement (the old install refused before `remove_entry`, so a stale local entry could shadow the shared scope until expiry).

Below cap the change is behavior-identical: same remove/insert/index/wheel sequence, the delta push was already suppressed for the pair's `SyncImport` origin, and the only `false` exit of the upsert (local-clobber guard) is bypassed by `allow_replace_local=true` — correct because the data is locally generated (the producer only runs under a `ForwardCandidate` tunnel resolution).

## Residue vs #1871 (honest scope)

#1871 already closed the *silence* half: the at-cap drop was counted via the exported `create_drops`. This PR closes the *behavior* half: the capped-proactive/uncapped-reactive incoherence, the cap-1 partial pair, and the counter pollution. No HA consequence either way — `SyncImport` entries are delta-suppressed AND permanently excluded from owner-RG bulk export by origin (pinned by a dedicated test).

## Research

Converged plan (PLAN-READY 3-of-3 after 5 hostile rounds: Codex, AGY, Claude SMR): `docs/research/1870-local-tunnel-pair/plan.md` on branch `research/1870-local-tunnel-pair`. Key plan-phase corrections folded: the v1 "HA bulk-export gap" claim was refuted by all three reviewers; the self-heal is reverse-half-only; `find_forward_wire_match` can never observe these entries (default NAT ⇒ no forward-wire alias).

## Changes

- `userspace-dp/src/afxdp/session_glue/mod.rs` — the `UpsertLocal` arm (+`debug_assert!` origin guard + infallibility assert, both release-inert per #1855).
- `userspace-dp/src/afxdp/session_glue/tests.rs` — 6 deterministic at-cap pins (pair-at-cap, two-worker fan-out convergence, cap-1 no-partial, below-cap replace, at-cap replace-without-growth, bulk-export exclusion).
- `userspace-dp/src/session/tests.rs` — table-level `upsert_synced` infallibility-at-cap pin.
- `userspace-dp/src/session/README.md` + `pkg/api/metrics_descriptors.go` — `create_drops` no longer covers `UpsertLocal`; help-text only, **no wire/series/label change**.

## Validation

- `cargo build --release` — clean
- `cargo test --release` — **2001 passed, 0 failed** (aggregated over all targets; includes the 7 new pins)
- debug `cargo test session::` — 79 passed, 0 failed; all new pins also pass by name in debug
- `go test ./...` — all packages ok

Not deployed/smoked from this branch — parent runs smoke; failover smoke recommended since a session-install path changes (verified HA delta/export surfaces untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)