### PR TITLE
#1875: serialize shared-cluster ownership — lock cells, self-locking deploys, holder visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,14 @@ The Makefile `cluster-*` targets now default to that userspace cluster via
 older loss cluster, and set `CLUSTER_ENV=` only when intentionally exercising
 the original local `xpf-fw0/xpf-fw1` regression environment.
 
+**Cluster ownership (#1875):** the loss cluster is SHARED. Deploys and
+`apply-cos-config.sh` self-lock `/tmp/xpf-cluster.lock` (they may
+visibly queue behind another agent — wait, NEVER kill another holder,
+NEVER `rm` the lock file). Wrap multi-command work in a lock cell:
+`./test/incus/with-cluster.sh "purpose" -- cmd...`. NEVER hand-roll
+`incus file push` binary deploys — they bypass the lock and the
+verify-dataplane gate. Full protocol: `docs/engineering-style.md`.
+
 ```bash
 # === SMOKE (loss userspace cluster, default for all userspace-dp validation) ===
 make cluster-deploy

--- a/_Log.md
+++ b/_Log.md
@@ -5141,3 +5141,7 @@ top.
 - **Timestamp**: 2026-06-11
   **Action**: "#1736 P6-flush second choreography trap fixed — the unconditional runbook flush after a SUCCESSFUL P6-noflush recovery (the expected sane-clock branch) wiped the peer under a live confirmed session, manufacturing the same S5 confirmed-but-dead blackhole the P6-pre fix removed (engine has no rekey/retry timers until S5, wg/peer.rs TODO; a confirmed engine never re-initiates). The runbook flush now runs only when the no-flush recovery fails (replay-guard/clock-step case), matching the runbook's own wording; pass message records which branch ran. Runbook updated: flush is conditional, plus an explicit do-NOT-flush-under-live-session warning"
   **File(s)**: test/incus/wg-interop.sh, docs/wg-interop-runbook.md
+
+- **Timestamp**: 2026-06-11 ~15:45 PT
+  **Action**: #1875 /research (PLAN-READY 3-of-3, branch research/1875-cluster-ownership) + /engineer → PR #1878 (cluster lock cells: cluster-lock.sh, with-cluster.sh, self-locking cluster-setup/apply-cos verbs, marker-aware wg-interop inc(), 10-case selftest, docs protocol). Live guarded deploy + CoS re-apply + iperf3 validated on loss cluster. Quad review: Codex+AGY+SMR MERGE-READY, Copilot 3x quota-limited.
+  **File(s)**: test/incus/{cluster-lock.sh,with-cluster.sh,with-cluster-selftest.sh,cluster-setup.sh,apply-cos-config.sh,wg-interop.sh,reverse-key-collision-probe.sh}, docs/engineering-style.md, CLAUDE.md, docs/wg-interop-runbook.md, docs/pr/1875-cluster-ownership/

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -362,6 +362,40 @@ they repeatedly bite:
 - **Deploy wipes CoS config.** After `cluster-setup.sh deploy`, re-run
   `./test/incus/apply-cos-config.sh <target>` before running iperf3
   for any #706 / #707 / #708 / #709 / #718 validation.
+- **Shared-cluster lock protocol (#1875).** The loss userspace cluster
+  is shared by concurrent agents; ownership is serialized by the
+  advisory flock on `/tmp/xpf-cluster.lock` with holder metadata in
+  `/tmp/xpf-cluster.owner`. Who locks what:
+  | Actor | Protocol |
+  |---|---|
+  | `cluster-setup.sh` deploy/start/stop/restart/create/destroy/init | self-locks (re-execs through `with-cluster.sh`; the build stays outside the lock) |
+  | `apply-cos-config.sh` | self-locks the same way |
+  | Multi-command measurement cells (deploy → apply-cos → measure) | wrap the WHOLE cell: `./test/incus/with-cluster.sh "purpose" -- cmd...` |
+  | `wg-interop.sh` | self-locks per command standalone; runs lock-free inside a cell (marker-aware) |
+  | Ad-hoc one-liners around commands that do NOT self-lock | `flock /tmp/xpf-cluster.lock sg incus-admin -c "..."` still valid |
+  Rules that keep the mutex sound:
+  - **Never wrap a self-locking script in a raw outer
+    `flock /tmp/xpf-cluster.lock`** — it deadlocks (the inner acquire
+    cannot see a raw caller's lock). Use `with-cluster.sh`, whose
+    `XPF_CLUSTER_LOCK_HELD=<lockpath>:<pid>` marker (validated by
+    path + pid liveness + ancestry) makes nesting safe.
+  - **Never `rm` the lock or owner files.** flock binds the inode —
+    deleting the path silently splits the mutex into two "owners".
+    Stuck holder recovery is `kill <holder-pid>` (kernel releases the
+    lock on fd close), and only for YOUR OWN holders.
+  - **Never kill another agent's holder.** The lock serializes you:
+    wait (the wait loop prints who holds it, since when, and why,
+    every 30s) or coordinate. `XPF_CLUSTER_LOCK_TIMEOUT=<s>` opts a
+    cell into fail-fast instead of waiting forever.
+  - **Never hand-roll binary deploys** (`incus file push` + restart
+    loops) to the cluster — they bypass the lock AND the #1864/#1869
+    verify-dataplane gate. Deploys go through `cluster-setup.sh
+    deploy` / `make cluster-deploy`.
+  - Queue diagnosis: `cat /tmp/xpf-cluster.owner` +
+    `fuser -v /tmp/xpf-cluster.lock`. A dead recorded pid with the
+    lock still held means a child inherited the fd (pre-#1875 raw
+    holders only; `with-cluster.sh` runs cells with the lock fd
+    closed, so killing a cell's tree releases instantly).
 - **Always `source ~/.sshrc` before `git push`.** The user's SSH agent
   config lives there.
 - **172.16.80.200 is the iperf3 test endpoint.** Not 172.16.50.x.

--- a/docs/pr/1875-cluster-ownership/agy-code-r1.md
+++ b/docs/pr/1875-cluster-ownership/agy-code-r1.md
@@ -1,0 +1,54 @@
+*   **Case (a)**: Waiter blocks, reports holder PID + purpose, timeout honors `XPF_CLUSTER_LOCK_TIMEOUT`.
+*   **Case (b)**: Kill -9 of cell tree releases the lock.
+*   **Case (c)**: Nested cell is reentrant; outer owner metadata survives.
+*   **Case (d)**: Forged/stale/garbage markers rejected, normal acquire proceeds.
+*   **Case (e)**: Stale/corrupt/empty owner files tolerated under `set -euo pipefail`.
+*   **Case (f)**: Cell exit status propagates (3), owner file cleaned.
+*   **Case (g)**: Split-mutex: `rm` lock while held fails closed with SPLIT MUTEX diagnosis, reclaim works after holder exits.
+*   **Case (h)**: Marker survives `sg`-shaped re-exec command string.
+
+I am waiting for the background selftest script to complete. Once done, I will examine the results and provide the final detailed report.
+Here is the hostile adversarial review of the PR implementation against the converged plan (`docs/pr/1875-cluster-ownership/plan.md`).
+
+---
+
+### 1. Shell Correctness Under `set -euo pipefail`
+Every new/changed shell path was analyzed for robustness under strict error-handling:
+* **Ancestry status check** ([cluster-lock.sh:53](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/cluster-lock.sh#L53)): The ancestry walk uses `2>/dev/null || true` inside the `ppid` subshell assignment. If the status file does not exist (due to process termination mid-check), it exits `0` returning an empty string. The following numeric match check ([cluster-lock.sh:54](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/cluster-lock.sh#L54)) is correctly guarded, returning `1` rather than aborting.
+* **Corrupt/stale owner file read** ([cluster-lock.sh:77](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/cluster-lock.sh#L77)): Sourcing `read -r ... <<<"$owner" || true` prevents a shell abort under `set -e` if the metadata line is empty or short, and subsequent parameter references are safely defaulted (e.g., `${opid:-}`).
+* **flock wait-loop arithmetic** ([with-cluster.sh:70-87](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh#L70-L87)): The `REMAIN` arithmetic is protected by checking if `TIMEOUT` is numeric and greater than `0`. If `TIMEOUT` is `0` (default, wait forever), `WINDOW` stays `30` and no subtraction occurs. If `flock -w` times out, its exit status is correctly caught by the `if` condition on line 81 without triggering a `set -e` abort.
+* **Lock file permissions** ([with-cluster.sh:64](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh#L64)): The `chmod 0666` call is guarded by `2>/dev/null || true` to prevent aborts if the lock file is owned by another cooperating user in `/tmp`.
+
+### 2. Reentrancy Chain End-to-End
+* **sg env forwarding** ([cluster-setup.sh:50-58](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/cluster-setup.sh#L50-L58)): The shadow group re-exec loop parses `${!BPFRX_@}` and `${!XPF_@}` to dynamically build `local_env`. Because the variables are parsed from existing names, they are guaranteed to exist, preventing any `set -u` issues on indirect expansions.
+* **Double build prevention** ([cluster-setup.sh:612-621](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/cluster-setup.sh#L612-L621)): Inside `cmd_deploy`, the code builds the local binaries first, and then execs `with-cluster.sh` with `env XPF_CLUSTER_SKIP_BUILD=1`. The re-execed child skips the build block, avoiding duplicate compiles.
+* **Reentrant marker resolution**: Sourcing `cluster-lock.sh` correctly resolves the marker `XPF_CLUSTER_LOCK_HELD` to check if the current process's ancestor is the holder. This prevents a deadlock when `cluster-setup.sh` re-invokes itself.
+
+### 3. `with-cluster.sh` Edge Cases
+* **Purpose strings with spaces/quotes** ([with-cluster.sh:109-111](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh#L109-L111)): The owner metadata contains space-separated fields where the 6th field is the purpose string. When read via `read -r OPID _ _ _ OINO _ <<<"$OWNER_LINE"`, Bash correctly maps the first 5 words and groups all remaining text (including all spaces in the purpose) into the final discard variable `_`. Thus, `OINO` and `OPID` are parsed correctly regardless of spaces/quotes.
+* **FD 9 closure** ([with-cluster.sh:144](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh#L144)): The command runs as `"$@" 9>&-`. Since `with-cluster.sh` is an executable process, the command is always an external program. It runs with the lock descriptor closed, ensuring no descendant process inherits it.
+* **Split-mutex probe false-positive surface** ([with-cluster.sh:112-120](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh#L112-L120)): The probe checks `/proc/${OPID}/fd/9` against `OINO`. For a false-positive to trigger on a recycled PID, the unrelated recycled process must have fd 9 open, and that fd must point to the *exact* inode that was deleted. This is virtually impossible under standard system conditions.
+
+### 4. `wg-interop.sh` Integration
+* **Standalone behavior** ([wg-interop.sh:77-85](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/wg-interop.sh#L77-L85)): If run standalone, `xpf_cluster_lock_held` is false, and it falls back to the original `flock "${WG_CLUSTER_LOCK}" sg incus-admin ...` command. The behavior is byte-identical.
+* **Lock path binding** ([wg-interop.sh:42](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/wg-interop.sh#L42)): Binding `XPF_CLUSTER_LOCK="${WG_CLUSTER_LOCK}"` before sourcing `cluster-lock.sh` guarantees that the ancestry marker checks the correct lock file. If a custom cell overrides the default lock file path, `wg-interop.sh` correctly falls back to locking its own path rather than bypassing.
+
+### 5. `apply-cos-config.sh` Re-exec
+* **Argv preservation** ([apply-cos-config.sh:48-53](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/apply-cos-config.sh#L48-L53)): The re-exec block is located at the top of the file before any flag processing or positional shifting. The arguments are preserved exactly with `"$@"` when passed to `with-cluster.sh`.
+* **Zero arguments check**: Under `set -u`, `"apply-cos-config $*"` with zero arguments does not throw an unbound error in Bash. The recursion guard functions correctly.
+
+### 6. Selftest Validity
+* **Case (b) `pkill -P` optimization dependency** ([with-cluster-selftest.sh:50](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster-selftest.sh#L50)): The test case runs `bash -c 'echo started >...; sleep 60'`. Since `sleep 60` is the last command in the string, Bash applies a tail-call `exec` optimization, making the `sleep` process a direct child of the wrapper (`B_PID`). 
+  > [!NOTE]
+  > If the command string contained trailing commands (e.g. `sleep 60; echo done`), the `sleep` command would run as a grandchild. `pkill -9 -P "$B_PID"` would kill only the parent shell, leaving `sleep` orphaned. However, since children run with fd 9 closed, the lock itself would still release immediately, keeping the test behavior sound.
+* **Case (h) re-exec simulation**: Properly simulates the dynamic prefix-matching shadow re-exec using `local_env` variables.
+
+### 7. Docs Accuracy
+* The instructions in [engineering-style.md:365-398](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/docs/engineering-style.md#L365-L398), [CLAUDE.md:91-97](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/CLAUDE.md#L91-L97), and [wg-interop-runbook.md:48-60](file:///home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/docs/wg-interop-runbook.md#L48-L60) are completely accurate and reflect the implemented codebase changes.
+
+---
+
+### Verdict
+The implementation satisfies all requirements, resolves locking asymmetries, and passes the test matrix.
+
+**VERDICT: MERGE-READY**

--- a/docs/pr/1875-cluster-ownership/agy-code-r2.md
+++ b/docs/pr/1875-cluster-ownership/agy-code-r2.md
@@ -1,0 +1,56 @@
+I will start by listing my permissions to understand what directories I can read.
+I will run a git command to view the diff between `280e73a6f16c` and `b24f28a3fc44` in the target worktree directory to see the exact changes that need to be reviewed.
+I will view the `test/incus/with-cluster.sh` file to see the implementation of the wrapper script.
+I will view the `with-cluster.sh` file inside the worktree path `/home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh`.
+I will view `cluster-lock.sh` to see the helper function definitions, in particular `xpf_cluster_lock_held`.
+I will list the files in the repository using `git ls-files` to locate `cluster-setup.sh`, `apply-cos`, etc.
+I will search for the relevant cluster setup and config files in the repository.
+I will view the contents of `apply-cos-config.sh` to understand how it uses the locking mechanism.
+I will view `cluster-setup.sh` to see how it locks/runs with-cluster.sh.
+I will run a quick verification command to confirm how `env --` behaves when nesting another `env` with variable definitions.
+I will run a quick verification command to confirm that exit status propagation with `|| rc=$?` behaves correctly under `set -euo pipefail`.
+I will search for all references to `with-cluster.sh` in the repository to check if there are other callers.
+I will view `wg-interop.sh` to check if and how it calls `with-cluster.sh`.
+I will view the `reverse-key-collision-probe.sh` script to verify how it uses the locking mechanism.
+I will view lines 61-120 of `reverse-key-collision-probe.sh`.
+I will run the selftests for `with-cluster.sh` to confirm that all 10 cases pass successfully in the local worktree environment.
+I will pause and wait for the background selftest task to complete.
+I will run a command to verify the process tree structure when using `env --` to show that the `env` process replaces itself and does not remain in the tree as an intermediate parent of the target command.
+I will run a command using `ps` to inspect the parent-child relationship and see if `env` stays in the process tree.
+### Adversarial Review Delta Confirmation
+
+We have verified the delta between commits `280e73a6f16c` and `b24f28a3fc44` in the target worktree at `/home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock`. The analysis indicates that the modifications are robust, address the targeted failure modes successfully, and do not regress the locking protocol or process mechanics.
+
+---
+
+### Key Areas Investigated
+
+#### 1. Command Pinning with `env --` (Codex F1)
+* **Reentrant & Acquiring Path Execution**: Running the target cell via `env -- "$@"` guarantees that the target is resolved and executed as an external binary. 
+* **Builtin Rejection (Case i)**: Shell builtins (like `exec`, `eval`, etc.) are successfully rejected with exit status `127` because `env` cannot execute them. This prevents a command like `exec some-long-running-command` from replacing the wrapper shell process directly, which would have closed the lock file descriptor early and bypassed the `EXIT` cleanup trap.
+* **Process Image Replacement (No Parent Bloat)**: Since `env` performs an `execve(2)` system call to launch the target command, it replaces its own process image rather than remaining in the process tree as a child. Our verification confirms that the target command runs as a **direct child** of the `with-cluster.sh` wrapper (PID-wise), preserving standard signal propagation and exit-status mapping exactly as if the command were executed directly.
+* **Signal/Kill Behavior**: Because there is no intermediate `env` process left alive during execution, signals (e.g. `SIGINT`, `SIGTERM`, `SIGKILL`) sent to the child PID target the cell process directly.
+
+#### 2. Composition with Script-Path Cells and Nested `env` Calls
+* **`env -- env ...` Composition (Case h)**: In `cluster-setup.sh`, the re-exec boundary prepends an extra environment assignment `env XPF_CLUSTER_SKIP_BUILD=1`.
+  * The outer `with-cluster.sh` executes: `env -- env XPF_CLUSTER_SKIP_BUILD=1 ...`
+  * The first `env` treats the second `env` as the target command.
+  * The second `env` parses the `XPF_CLUSTER_SKIP_BUILD=1` argument as an environment assignment, sets it, and executes the script.
+  * This nested composition is standard, POSIX-compliant, and behaves correctly (verified in Case h).
+* **Script-Path Cells**: For `apply-cos-config.sh`, `env --` resolves the script path, reads the shebang (`#!/usr/bin/env bash`), and spawns the shell interpreter as expected.
+
+#### 3. Timeout Normalization (Codex F2)
+* **The Octal Trap**: Restricting the `XPF_CLUSTER_LOCK_TIMEOUT` input to `^[0-9]{1,7}$` and prepending `10#` base-10 conversion prevents bash from interpreting values with leading zeros (like `08` or `09`) as invalid octal numbers.
+* **Safe Degradation (Case j)**: Garbage inputs or absurdly large numbers (which could otherwise cause integer overflow in bash) fail the regex check and degrade cleanly to `0` (wait forever), which is the safest failure direction.
+
+#### 4. Live Selftest Execution
+We executed `./test/incus/with-cluster-selftest.sh` in the local worktree, and all 10 test cases passed successfully, confirming the live behavior of the new tests:
+* **Case h**: Verifies marker + skip-build propagation across the `sg` re-exec boundary.
+* **Case i**: Verifies shell builtins are rejected (127) without leaking owner metadata.
+* **Case j**: Verifies timeout normalization (base-10 forcing and huge value degradation).
+
+---
+
+### Verdict
+
+**VERDICT: MERGE-READY**

--- a/docs/pr/1875-cluster-ownership/claude-smr-code-r1.md
+++ b/docs/pr/1875-cluster-ownership/claude-smr-code-r1.md
@@ -1,0 +1,68 @@
+# Claude SMR hostile code review — PR #1878 r1 (head 280e73a6f16c)
+
+Reviewer: Claude (in-conversation SMR). Implementation vs converged
+plan docs/pr/1875-cluster-ownership/plan.md.
+
+## Verdict: MERGE-READY (no blocking findings; 3 observations recorded)
+
+Hostile walk, every new/changed path under `set -euo pipefail`:
+
+- **Marker validation** (cluster-lock.sh): `${marker%:*}`/`${marker##*:}`
+  split is safe for paths without colons (canonical /tmp paths);
+  numeric guard precedes `kill -0`; the PPid walk regex-guards each
+  hop and any failure returns 1 — degrade direction is always
+  *waiting*. Verified by selftest d1-d4 (live non-ancestor, dead,
+  wrong-path, garbage).
+- **Wait loop**: WINDOW = min(30, remaining-timeout) — the selftest
+  caught the original fixed-30s-window bug (sub-30s timeouts couldn't
+  fire); the fix is correct and case (a) pins it (exit 75 at ~1s).
+  WAITED accumulates across revalidation retries, which is the right
+  timeout semantics.
+- **Acquire sequence ordering**: flock → dev:ino revalidation →
+  split-mutex probe → atomic owner write (tmp+mv) → trap → marker
+  export → `"$@" 9>&-`. The reentrant path execs BEFORE any trap is
+  installed, so a nested exit can never remove the outer owner file
+  (selftest c pins owner survival).
+- **Split-mutex probe**: aborts only when the recorded pid is alive
+  AND its `/proc/<pid>/fd/9` still resolves to the recorded dev:ino —
+  exactly the plan's adopted Codex/AGY r3 mechanism. Selftest g pins
+  abort (70) + inode naming + post-holder reclaim. False-negative
+  surface: a pre-#1875 raw-flock holder has no owner file — correctly
+  reported as "no owner metadata", not aborted (raw holders contend
+  via the kernel lock itself, so no split is possible unless someone
+  rm'd the path, which the docs now forbid loudly).
+- **Reentrancy chain live**: `cluster-setup.sh deploy all` →
+  build → exec with-cluster.sh → `env XPF_CLUSTER_SKIP_BUILD=1
+  cluster-setup.sh deploy all` → marker valid → suppress + rolling
+  deploy — ran against the real loss cluster, lock+purpose visible,
+  RC=0, both nodes at this branch's exact HEAD sha. No double build
+  (the locked re-invocation skipped it — verified in the deploy log:
+  single build phase).
+- **ORIG_ARGS**: captured at top level from the script argv; quick
+  verbs re-exec the *original* argv so `${2:-all}` defaulting is
+  applied identically in the re-invocation. deploy passes the
+  resolved target explicitly.
+- **sg forwarding**: `"${!BPFRX_@}" "${!XPF_@}"` lists only set
+  scalars; XPF_CLUSTER_LOCK/OWNER are always set post-source so the
+  loop body is exercised on every sg re-exec; printf %q makes values
+  shell-safe across the rebuilt command string (selftest h pins the
+  boundary shape).
+- **wg-interop**: `XPF_CLUSTER_LOCK="${WG_CLUSTER_LOCK}"` before
+  sourcing binds the marker check to the path `inc()` actually flocks
+  — one cell covers cluster-setup, apply-cos, and wg-interop because
+  all three resolve to /tmp/xpf-cluster.lock. The else-branch is
+  byte-identical to the previous `inc()`.
+- **apply-cos-config.sh**: header sits before flag parsing, re-execs
+  with the untouched `"$@"`; `$*` in the purpose string is safe under
+  `set -u` with zero args.
+
+## Observations (non-blocking)
+
+1. A waiter that starts between a holder's flock success and its
+   owner write reports the *previous* holder for <1ms. Diagnostics
+   only; not worth a barrier.
+2. `fuser` (psmisc) may be absent on minimal hosts — all call sites
+   are `|| true`-guarded; the report degrades gracefully.
+3. Selftest case (e) corrupt-owner emits a cosmetic bash "ignored
+   null byte" warning on stderr; the case still proves no-crash under
+   `set -e`, which is the requirement.

--- a/docs/pr/1875-cluster-ownership/claude-smr-code-r2.md
+++ b/docs/pr/1875-cluster-ownership/claude-smr-code-r2.md
@@ -1,0 +1,41 @@
+# Claude SMR hostile code review — PR #1878 r2 (delta over b24f28a3fc44)
+
+Reviewer: Claude (in-conversation SMR). Scope: the Codex code-r1 fix
+commit. Honest note first: SMR r1 passed both paths Codex F1/F2
+flagged — the builtin-cell escape and the octal timeout — which is
+exactly the SMR-soft-pass pattern this project documents. The r2 walk
+below was done against that bias.
+
+## Verdict: MERGE-READY
+
+- **`env --` pinning (F1)**: checked every in-tree cell producer for
+  regression: cluster-setup's re-exec cell becomes `env -- env
+  XPF_CLUSTER_SKIP_BUILD=1 cluster-setup.sh deploy <t>` (nested env is
+  well-defined); apply-cos passes an absolute script path; the
+  selftest passes `bash -c`/`sg`/`true`/`sleep`; the runbook examples
+  pass `env`/`bash -c`. No caller relied on builtin/function
+  execution (impossible by design — a cell is a process). The
+  reentrant path's `exec env -- "$@"` keeps reentrant and acquiring
+  semantics identical. Selftest (i) pins the 127-with-lock-intact
+  contract, including post-rejection reclaim.
+- **Timeout normalization (F2)**: `^[0-9]{1,7}$` then `10#` — "08"
+  becomes 8 (case j proves acquire succeeds at the 4s holder exit and
+  no arithmetic error text leaks); a 20-digit value degrades to
+  wait-forever and case j proves it cannot block a free lock. The
+  degrade direction (wait, never skip/crash) matches invariant §7.3.
+- **Selftest h (F3)**: the inner block is a verbatim transplant of
+  cluster-setup.sh's forwarding loop, and on this host it crossed a
+  REAL `sg incus-admin -c` boundary (verified in the live run — the
+  host has the group, so the sg branch executed). Asserts all three
+  classes of forwarded state: the marker, the skip-build flag, and a
+  BPFRX_* variable.
+- **Case b comment (F4)**: now states exactly what is proven
+  (wrapper death = lock release; deep orphans cannot hold).
+- Full selftest re-ran live post-fix: ALL 10 CASES PASS. bash -n +
+  shellcheck -x clean.
+
+No new findings. The live-cluster validation from r1 (self-locking
+deploy, build identity g280e73a6f, CoS re-apply, shaped/uncapped
+iperf3) predates the fix commit but the fix touches only with-cluster
+internals + selftest, both re-proven by the matrix; the deploy path's
+behavior is unchanged (env-- composes transparently).

--- a/docs/pr/1875-cluster-ownership/codex-code-r1.md
+++ b/docs/pr/1875-cluster-ownership/codex-code-r1.md
@@ -1,0 +1,16 @@
+**Findings**
+
+1. [with-cluster.sh](/home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh:144): direct shell builtins can break the lock-cell contract. `"$@" 9>&-` executes builtins in the wrapper shell; `with-cluster.sh "p" -- exec sleep 60` replaces the wrapper, closes fd 9, releases the flock immediately, and skips the EXIT trap, leaving stale owner metadata while the command keeps running outside the lock. Reentrant mode also uses `exec "$@"` at [line 53](/home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh:53), so builtin-only commands/functions behave differently from non-reentrant mode. This is a real edge in the advertised arbitrary `<cmd> [args...]` API.
+
+2. [with-cluster.sh](/home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh:58): timeout validation accepts strings Bash later interprets as octal or overflowing signed arithmetic. `XPF_CLUSTER_LOCK_TIMEOUT=08` passes the regex, then `[[ "$TIMEOUT" -gt 0 ]]` at [line 72](/home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster.sh:72) emits an arithmetic error and effectively disables the timeout. Very large values wrap. This violates the “garbage env degrades safely” requirement.
+
+3. [with-cluster-selftest.sh](/home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster-selftest.sh:127): case h does not test what the plan claims. It uses a hand-built `bash -c` env prefix for three `XPF_CLUSTER_*` vars, but does not exercise the actual `cluster-setup.sh` `sg incus-admin -c "${local_env}$(printf '%q ' ...)"` path, the `${!BPFRX_@}/${!XPF_@}` forwarding loop, or `XPF_CLUSTER_SKIP_BUILD`. That leaves the most important deadlock/double-build regression path untested.
+
+4. [with-cluster-selftest.sh](/home/ps/git/bpfrx/.claude/worktrees/1875-engineer-lock/test/incus/with-cluster-selftest.sh:55): case b says it kills the whole cell tree, but `pkill -P "$B_PID"` only targets direct children. It still proves “wrapper death releases the lock” for this fixture, but not the stated whole-tree behavior.
+
+Syntax checks passed. I could not rerun the selftest here because the sandbox is read-only and `mktemp /tmp/xpf-lock-selftest.XXXXXX` fails. `shellcheck` is installed; it only surfaced source-follow noise plus pre-existing warnings in `apply-cos-config.sh`.
+
+VERDICT: NEEDS-CHANGES (findings 1-3)
+
+Codex session ID: 019eb8ce-665f-72d0-a1f8-83a85063ef7a
+Resume in Codex: codex resume 019eb8ce-665f-72d0-a1f8-83a85063ef7a

--- a/docs/pr/1875-cluster-ownership/codex-code-r2.md
+++ b/docs/pr/1875-cluster-ownership/codex-code-r2.md
@@ -1,0 +1,18 @@
+No blocking findings.
+
+I reviewed the requested delta `280e73a6f16c..b24f28a3fc44`. The fixes address F1-F4: `env --` closes the builtin escape, timeout parsing is base-10 and bounded, case (h) now exercises the real `cluster-setup.sh` sg/env-forwarding shape, and the case (b) comment is corrected.
+
+Caller audit is clean: `cluster-setup.sh` deploy becoming `env -- env XPF_CLUSTER_SKIP_BUILD=1 ...` is fine, `apply-cos-config.sh` passes a script path, and selftest callers use external commands (`bash`, `sg`, `true`, `env`). I found no in-tree caller relying on bare builtins/functions.
+
+Validation:
+- `bash -n` passed for both changed scripts.
+- `git diff --check 280e73a6f16c..b24f28a3fc44` passed.
+- Focused probes confirmed `env -- exec true` returns `127`, nested `env -- env ...` works, and timeout normalization maps `08` to decimal `8` while huge/non-numeric values degrade to `0`.
+- I could not rerun the full selftest here because this sandbox is read-only and `mktemp /tmp/...` fails.
+
+Note: the worktree HEAD has advanced past `b24f28a3` to docs/review commits, but there are no code diffs above `b24f28a3` in the relevant files.
+
+VERDICT: MERGE-READY
+
+Codex session ID: 019eb8d7-6d05-75f0-82c0-b18aa6d9c635
+Resume in Codex: codex resume 019eb8d7-6d05-75f0-82c0-b18aa6d9c635

--- a/docs/pr/1875-cluster-ownership/plan.md
+++ b/docs/pr/1875-cluster-ownership/plan.md
@@ -1,0 +1,514 @@
+# #1875 — Cluster ownership serialization for the loss userspace cluster
+
+**Status: v4 — r3 verdicts: AGY PLAN-READY
+(adversarial-review-mqa1ibg7-5uanbl), Claude SMR PLAN-READY, Codex
+PLAN-NEEDS-REVISION on one residual §5/§7.2 text contradiction (fixed
+here) + the optional /proc/<pid>/fd/9 hardening (adopted — AGY r3
+proposed the identical mechanism independently). Pending final Codex
+delta confirmation.**
+
+## 1. Status
+
+v4 — PLAN-READY (converged 3-of-3: Codex r4, AGY r3, Claude SMR r3).
+Research-only branch `research/1875-cluster-ownership`. No
+production code; this is TEST-INFRA / process hardening. PLAN-KILL or a
+docs-only close remain acceptable verdicts, though all three r1
+reviewers independently answered §11 Q1 "Path C is not sufficient".
+
+## 2. Issue framing
+
+During the 2026-06-11 multi-agent session, the #1736 S2b closure run on
+`loss:xpf-userspace-fw{0,1}` was repeatedly destroyed by a concurrent
+agent's deploy-iterate loop: `/usr/local/sbin/{xpfd,xpf-userspace-dp}`
+were replaced and xpfd restarted at ~5-10 minute cadence. Consequences
+observed live (issue body):
+
+- Two "deterministic wedge on PR head" diagnosis runs actually executed
+  a foreign `g7b076ee2e` build — hours spent chasing a stale-binary
+  artifact presented as an engine bug.
+- A closure attempt with a verified-quiet 15-minute window still lost
+  the race to a mid-phase foreign deploy (caught only because PR #1868
+  had just added `check_build_identity`).
+- Every foreign restart flipped VRRP mastership and wiped CoS.
+
+Root cause is structural, not behavioral: the project has an advisory
+`/tmp/xpf-cluster.lock` flock convention, but
+
+1. **nothing forces deploys to take it** — `cluster-setup.sh deploy`
+   (and the `make cluster-deploy` alias every agent uses) touches the
+   cluster lock-free;
+2. **the convention is per-command**, so a multi-minute measurement
+   phase is a sieve: each individual `incus` call is serialized but the
+   *cell* (deploy → apply-cos → measure) is not;
+3. **lock-usage is asymmetric across scripts**: `wg-interop.sh`
+   self-locks per cluster command inside `inc()` (wg-interop.sh:64-71),
+   so outer-wrapping it in `flock /tmp/xpf-cluster.lock` **deadlocks**
+   (the inner `flock` opens a new open file description and blocks on
+   the caller's own lock — Codex r1 reproduced this locally). Other
+   scripts (`reverse-key-collision-probe.sh:47`) document "caller must
+   wrap me in the flock". A third (`test-mouse-latency-matrix.sh:54`)
+   self-locks a *different* file with `flock -n`. An agent cannot know
+   which protocol a given harness speaks without reading it;
+4. **lock holders are invisible**: a bare `flock` wait gives no
+   holder identity; in a prior session a killed flocked pipeline left
+   an orphaned child holding the inherited lock fd and the queue
+   behind it was undiagnosable for ~3 hours.
+
+## 3. Honest scope/value framing
+
+This is process/test-infra work. Zero packets, zero production code.
+The win is measured in *operator-days not wasted*: the 2026-06-11
+incident burned most of a day on a misdiagnosed "wedge" plus a failed
+closure run, and the same clobber class has recurred across the
+fairness campaigns (deploy wipes CoS mid-measurement). The cost is
+~200 lines of shell + docs. The counter-position was put to all three
+r1 reviewers — PR #1868's `check_build_identity` already converts
+silent clobbers into loud, attributable aborts; maybe detection +
+codified convention suffices — and all three rejected it (§11 Q1):
+the convention already existed in three script headers and MEMORY when
+the incident happened, the *default tooling path* (`make
+cluster-deploy` → lock-free `cmd_deploy`, Makefile:211 →
+cluster-setup.sh:580) violates it, and convention text is
+context-fragile for LLM agents (MEMORY.md is only partially loaded —
+its own header warns so). Detection without serialization retries
+forever on a busy cluster.
+
+Honesty boundary, unchanged from v1: among *cooperating same-host
+agents* an advisory lock is the entire requirement. Adversarial
+robustness (fencing, leases, cross-host coordination) is explicitly
+NOT needed and plan drift in that direction is over-engineering. The
+mechanism *narrows* the bypass surface (a hand-rolled `incus file
+push` loop still bypasses it); #1868 detection remains the backstop
+for non-cooperating paths, and A5 adds an explicit CLAUDE.md
+prohibition on hand-rolled binary pushes.
+
+## 4. What's already shipped (verified on master @ 9a536f810)
+
+| Mechanism | Where | What it covers | Gap left |
+|---|---|---|---|
+| Advisory flock convention `/tmp/xpf-cluster.lock` | wg-interop.sh `inc()` (lines 64-71, `WG_CLUSTER_LOCK` in wg-interop.env:56); comment-documented in reverse-key-collision-probe.sh:47-49; docs/wg-interop-runbook.md:49 | Serializes individual incus commands among lock-takers | Voluntary; per-command not per-cell; deploys don't take it; no holder identity |
+| `check_build_identity` (PR #1868) | wg-interop.sh:240-265 — fail-closed, `-dirty`-aware, prefix-matches running `Software version: ...-g<sha>` against checkout HEAD; called at preflight, P1, and mid-wait | Detects foreign builds in-flight, names the SHA | Detection only, wg-interop-only; the run still dies; other harnesses have no equivalent |
+| `verify-dataplane` deploy pre-flight (#1864/#1869) | cluster-setup.sh deploy_vm (~lines 660-720) | New binary's shim verified before touching the live daemon | Protects against *bad* binaries, not *foreign* ones |
+| Mouse-latency matrix mutex | test-mouse-latency-matrix.sh:54-62, `flock -n` on `/tmp/test-mouse-latency-matrix.lock` | Two matrix invocations can't interleave | Different lock file; doesn't compose with the cluster lock |
+| Smoke serialization discipline | MEMORY `feedback_smoke_serialized_single_agent` | One smoke at a time via agent protocol | Memory-resident convention; the 2026-06-11 deploy loop ignored it because *deploy* isn't *smoke* |
+
+Conclusion: detection is shipped (#1868), per-binary safety is shipped
+(#1869), but **acquisition is still 100% voluntary and the two most
+damaging writers — `cluster-setup.sh deploy` and multi-minute
+measurement cells — have no lock integration at all.**
+
+## 5. Concrete design — paths
+
+### Path A (recommended, revised in v2): one acquire point + codification
+
+The v1 shape had two independent acquire implementations (with-cluster
+wrapper + in-process acquire in cluster-setup.sh). r1 killed the
+in-process variant twice over: Codex F2 showed `deploy_vm`'s many
+post-acquire `incus` children (cluster-setup.sh:674, :734, :743)
+inherit the lock fd, so a killed deploy shell leaves an `incus` child
+as a zombie holder — the exact 3-hour bug; AGY showed sourced-library
+EXIT traps clobber consumer traps and double-release owner metadata
+from bypassed nested acquires. **v2+ therefore has exactly ONE
+long-lived, self-locking, marker-exporting holder:
+`with-cluster.sh`** (standalone per-command `flock` holders —
+wg-interop's `inc()` else-branch, ad-hoc one-liners — legitimately
+persist and never export the marker; see invariant §7.2). Every
+self-locking script either re-execs through `with-cluster.sh` or
+honors its reentrancy marker.
+
+**A1. Shared helper library `test/incus/cluster-lock.sh`** (sourced).
+Canonical paths are hard-coded defaults (`/tmp/xpf-cluster.lock`,
+`/tmp/xpf-cluster.owner`); `XPF_CLUSTER_LOCK`/`XPF_CLUSTER_OWNER` env
+overrides exist for the dry-run test matrix only. Provides two
+functions, installs no traps, has no global side effects:
+
+- `xpf_cluster_lock_held()` — returns 0 iff the reentrancy marker is
+  valid **for this lock path**. Marker format (Codex F4 + AGY §3 + SMR
+  F2 converged): `XPF_CLUSTER_LOCK_HELD="<lockpath>:<holderpid>"`.
+  Valid iff: lockpath component equals this consumer's lock path, AND
+  holderpid is numeric, alive (`kill -0` inside a guarded
+  conditional), AND an ancestor of the current process (PPid walk via
+  `/proc/<pid>/status`, AGY's `is_lock_holder_ancestor` sketch —
+  closes the backgrounded-daemon env-leak false-skip). On any parse
+  failure: returns 1 (treat as not held; worst case is a blocking
+  wait, never an unserialized run).
+- `xpf_cluster_owner_report()` — diagnostics-only, `set -e`-safe by
+  construction (AGY §4: `owner=$(cat "$OWNER" 2>/dev/null || true)`,
+  here-string `read -r`, regex-guard pid before `kill -0`,
+  `fuser -v "$LOCK" 2>&1 || true`). Reports holder pid + liveness +
+  user + branch + purpose + acquire timestamp + **lock-path inode**
+  (`stat -c %i`, SMR F1: makes a split-lock from a deleted/recreated
+  lock file diagnosable). A dead recorded pid prints an explicit
+  orphan/SIGKILL diagnosis line with the fuser output.
+
+**A2. Lock-cell wrapper `test/incus/with-cluster.sh`** (executable —
+the single acquire point):
+
+```
+./test/incus/with-cluster.sh "purpose string" -- cmd args...
+```
+
+Acquire sequence (all r1 mechanics findings folded in):
+1. If `xpf_cluster_lock_held` → exec the command directly (reentrant
+   cell-in-cell; no trap installed, no owner write — AGY's
+   acquired-only-trap rule).
+2. `exec 9>>"$LOCK"` (append — never truncate; 0666 best-effort on
+   create), then a wait loop of `flock -w 30 9` iterations (SMR F3:
+   contends immediately instead of sleeping through free windows);
+   between iterations print `xpf_cluster_owner_report` to stderr.
+   Default: wait forever (§11 Q2 resolution, 2-of-3 reviewers);
+   `XPF_CLUSTER_LOCK_TIMEOUT=<s>` opts into a bounded wait that aborts
+   loudly with the holder report.
+3. Post-acquire **dev:inode** revalidation (SMR F1; Codex r2: compare
+   `%d:%i`, not inode alone): `stat -c %d:%i` of the path vs
+   `stat -L -c %d:%i /proc/$$/fd/9`; mismatch (file unlinked/replaced
+   between open and lock — agent "cleanup" reflex or systemd-tmpfiles
+   /tmp aging) → close fd, reopen, retry.
+3b. **Split-mutex assertion** (SMR r2 S2 — the §12 Q4 counter-example
+   was real: holder A on inode I, path rm'd, B acquires fresh inode J
+   and step 3 passes since path==fd==J): the owner record includes the
+   holder's lock `dev:ino`; if at acquire time the owner file names a
+   LIVE pid with a lock dev:ino different from B's own fd, mutual
+   exclusion has been split — **fail closed** with a diagnosis naming
+   both inodes (mirrors #1868 fail-closed philosophy). This is the one
+   deliberate exception to "owner file never gates execution": it errs
+   toward refusing to run, never toward clobbering. Pid-recycling
+   false positives are defeated by the **fd-9 probe** (Codex r3 + AGY
+   r3 converged independently on the identical mechanism): before
+   aborting, check `stat -L -c %d:%i /proc/<recorded-pid>/fd/9` — only
+   abort if it still resolves to the recorded dev:ino (the recorded
+   holder provably still holds the old lock fd); a recycled pid
+   without fd 9 on that inode clears the stale owner path and acquire
+   proceeds. Same-user cooperating agents make /proc readable.
+4. Atomic owner write: temp file + `mv` onto `$OWNER` containing
+   `<pid> <iso8601> <user> <git-branch> <lock-dev:ino> <purpose>`;
+   EXIT trap (own dedicated process, nothing to clobber) removes it.
+5. `export XPF_CLUSTER_LOCK_HELD="$LOCK:$$"`, then run the command
+   with **fd 9 closed** (`"$@" 9>&-`) so no child or grandchild ever
+   inherits the lock fd — killing a cell's process tree releases the
+   lock immediately (AGY §1B verified the mechanics incl. subshells).
+   Exit status is captured (`rc=0; "$@" 9>&- || rc=$?`) and propagated
+   after the trap-driven owner cleanup.
+
+No process-group management in v1 (§11 Q3 resolution, Codex + SMR;
+AGY's `trap 'kill -TERM -$$' EXIT` counter-proposal is unsound as
+written — `with-cluster.sh` is not a process-group leader, so `-$$`
+would signal the *caller's* group including the invoking agent shell).
+
+Standard measurement-cell usage:
+
+```bash
+./test/incus/with-cluster.sh "1736 S2b closure" -- bash -c '
+    make cluster-deploy &&
+    ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0 &&
+    WG_PEER_TYPE=container ./test/incus/wg-interop.sh all'
+```
+
+**A3. `cluster-setup.sh` mutating verbs re-exec through A2.**
+Mutating verbs are `deploy`, `start`, `stop`, `restart`, `create`,
+`destroy`, **and `init`** (Codex F5: `cmd_init` creates/deletes
+networks and profiles, cluster-setup.sh:199/:205/:234). Dispatch shape:
+
+```bash
+# inside cmd_deploy: pre-lock work is target validation + local make
+# build ONLY (the multi-minute build must never hold the lock):
+if ! xpf_cluster_lock_held; then
+    exec "$SCRIPT_DIR/with-cluster.sh" \
+        "cluster-setup deploy ${target} ($(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?'))" \
+        -- env XPF_CLUSTER_SKIP_BUILD=1 "$SCRIPT_DIR/cluster-setup.sh" deploy "$target"
+fi
+# reentrant path: suppress_host_parent_ipv6_ra + deploy_vm/deploy_rolling
+```
+
+**Lock-boundary rule (Codex r2 F1):** everything that mutates shared
+state runs *inside* the lock. v2 had `suppress_host_parent_ipv6_ra`
+(cluster-setup.sh:583 → sysctl/addr-flush/route-flush on the shared
+SR-IOV host parent, :126/:130/:135) running pre-lock; v3 moves it (and
+any future host-side mutation) into the reentrant continuation. The
+re-exec target is `"$SCRIPT_DIR/cluster-setup.sh"`, not `"$0"` (Codex
+r2: avoids PATH/symlink oddities).
+
+`XPF_CLUSTER_SKIP_BUILD=1` makes the re-invoked `cmd_deploy` skip the
+already-done build. The re-exec gives the fd-close-for-children
+property to the whole deploy for free (Codex F2 resolved), installs
+zero traps in cluster-setup.sh (AGY trap-clobber resolved), and the
+marker makes the nested invocation lock-free. The quick verbs
+(start/stop/restart/create/destroy/init) re-exec the same way without
+the skip-build env. Read-only verbs (`status`, `logs`, `journal`,
+`ssh`) stay lock-free — `ssh` is interactive and must never hold the
+cluster lock. `BPFRX_CLUSTER_ENV` and the rest of the caller env pass
+through `with-cluster.sh` untouched (it adds exactly one variable).
+
+**sg re-exec marker forwarding (SMR r2 S1 + AGY r2 + Codex r2 F3):**
+the group re-exec at cluster-setup.sh:41-50 rebuilds the command
+string and explicitly re-prefixes only `BPFRX_CLUSTER_ENV` — evidence
+the author did not trust `sg` env preservation. Codex r2 verified
+util-linux/shadow `sg` 2.41.3 *does* preserve exported env on this
+host, but the cell-from-non-incus-admin-shell path would deadlock on
+any platform where it doesn't (inner deploy loses the marker → blocks
+on its own ancestor's lock). v3: the `local_env` prefix dynamically
+forwards all exported `XPF_*` and `BPFRX_*` variables (printf %q
+loop over `${!XPF_@}` / `${!BPFRX_@}`), and §9.2d pins the *actual*
+`exec sg incus-admin -c "${local_env}$(printf '%q ' ...)"` shape —
+verifying both marker survival and skip-build (no double build).
+
+**A3b. `apply-cos-config.sh` self-locks the same way** (AGY r2
+recommendation, adopted): it commits cluster config and is routinely
+run standalone right after deploys; the marker-guarded
+`exec with-cluster.sh "apply-cos <target>" -- <self> <args>` header is
+~4 lines, has no build step, and is reentrancy-transparent inside
+cells.
+
+**A4. `wg-interop.sh` `inc()` honors the marker** — resolves the
+self-lock asymmetry:
+
+```bash
+inc() {
+    local q; q=$(printf '%q ' incus "$@")
+    if xpf_cluster_lock_held; then
+        sg incus-admin -c "$q"
+    else
+        flock "${WG_CLUSTER_LOCK}" sg incus-admin -c "$q"
+    fi
+}
+```
+
+Standalone invocation keeps today's per-command locking byte-for-byte
+(the else-branch is today's code); cell invocation gets whole-run
+ownership with no deadlock.
+
+**A5. Docs codification** (the Path-C content, folded in):
+
+- `docs/engineering-style.md` cluster-discipline section — the lock
+  protocol table (*who locks what*): deploys self-lock via re-exec;
+  measurement cells use `with-cluster.sh`; scripts must either honor
+  the marker via `cluster-lock.sh` or document "caller locks"; never
+  kill another holder (the lock serializes you — wait or coordinate);
+  **never `rm` the lock or owner files** (SMR F1: flock binds the
+  inode — deleting the path silently splits the mutex, reintroducing
+  the incident; recovery is `kill <holder-pid>`, never `rm`); queue
+  diagnosis recipe: `cat /tmp/xpf-cluster.owner` + `fuser -v
+  /tmp/xpf-cluster.lock`.
+- **Raw outer-flock one-liners are deprecated for self-locking verbs**
+  (Codex F3): `flock /tmp/xpf-cluster.lock bash -c "make
+  cluster-deploy"` now self-waits (the inner re-exec can't see a raw
+  caller's lock). Update the two places that teach the raw pattern —
+  reverse-key-collision-probe.sh:47-49 comment and
+  docs/wg-interop-runbook.md:49 — to point at `with-cluster.sh`. Raw
+  per-command flock around *non-self-locking* commands (plain `incus
+  exec` one-liners) remains valid and contends correctly.
+- `CLAUDE.md` cluster test-environment section: 3-4 lines — use
+  `with-cluster.sh` for any multi-command cluster work; deploys
+  self-lock and may visibly queue; **never hand-roll `incus file
+  push` binary deploys to the loss cluster** (SMR F4); never kill
+  other holders; never rm the lock file.
+- `docs/wg-interop-runbook.md`: note the cell-mode marker bypass.
+
+### Path B: ownership lease file with TTL + identity gates everywhere
+
+Rejected (unchanged from v1, unchallenged in r1). flock already gives
+the one property a lease buys — no stale lock survives a crashed
+holder — without TTL's false-expiry hazard mid-long-measurement and
+renewal plumbing in every harness. Identity gates everywhere is
+shotgun duplication of #1868; gates detect, they don't prevent.
+Cooperating agents don't need steal semantics.
+
+### Path C: docs-only close
+
+Rejected by all three r1 reviewers independently (Codex: "the
+convention already exists ... while `make cluster-deploy` still
+reaches lock-free `cmd_deploy` today"; AGY: "a convention that is not
+enforced by the default tooling is not a convention"; SMR: convention
+text is context-fragile — MEMORY.md partial loading). Kept here as the
+documented kill-path: if r2 reverses, A5 ships alone and the issue
+closes.
+
+### Path D: A + B hybrids
+
+Any TTL/lease addition on top of A remains over-engineering per §3.
+The only B element worth keeping is already in A: holder *identity*
+metadata (owner file), without TTL semantics.
+
+## 6. Public API preservation
+
+- `cluster-setup.sh` verb set and arguments unchanged; `make
+  cluster-deploy` unchanged. Behavior delta: mutating verbs may now
+  *block* (with a visible held-by report on stderr) instead of
+  clobbering — that is the feature. Internal-only addition:
+  `XPF_CLUSTER_SKIP_BUILD` env.
+- `wg-interop.sh` CLI unchanged; standalone behavior byte-identical.
+- `/tmp/xpf-cluster.lock` path and meaning unchanged. Existing raw
+  per-command `flock /tmp/xpf-cluster.lock <non-self-locking-cmd>`
+  one-liners keep working and contend correctly with the new
+  acquirers. **Exception (breaking, deliberate, documented):** raw
+  *outer-wrapping of the now-self-locking verbs* self-waits; A5
+  updates the two in-tree teachers of that pattern (Codex F3).
+- New surface: `with-cluster.sh`, `cluster-lock.sh`, the
+  `XPF_CLUSTER_LOCK_HELD=<lockpath>:<pid>` marker contract,
+  `/tmp/xpf-cluster.owner`. Lock/owner files created 0666 best-effort
+  (AGY Q6: lets a second cooperating user contend on the same lock
+  under /tmp's sticky bit).
+
+## 7. Hidden invariants the change must preserve
+
+1. **Lock is never held across `make build`** — `cmd_deploy` builds
+   first, then re-execs into the lock. A cell that builds *inside*
+   `with-cluster.sh` holds the lock during the build; that is the
+   caller's explicit choice (sometimes wanted for closure runs).
+2. **`with-cluster.sh` is the only long-lived / self-locking /
+   marker-exporting holder** (restated per Codex r2 F2: standalone
+   per-command `flock` holders — wg-interop's `inc()` else-branch, ad
+   hoc one-liners — legitimately persist and must NEVER set the
+   marker). No other *script* may `exec 9>>` the canonical lock and
+   hold it across commands; with-cluster.sh runs its child with fd 9
+   closed, making kill-the-tree equal release-the-lock (Codex F2).
+3. **Marker validity is path+pid+ancestry, never a bare boolean**
+   (Codex F4, AGY §3, SMR F2). Any validation failure degrades to
+   *waiting*, never to *skipping*.
+4. **Owner file is diagnostics only** — no code path may block on
+   owner-file state; all reads are `set -e`-tolerant (AGY §4A/§4C);
+   writes are atomic (tmp+mv) and happen only while holding the lock;
+   only the acquiring process installs the cleanup trap (AGY §2).
+5. **`set -euo pipefail` discipline is a testable requirement, not a
+   warning** (Codex F6): §9.2 exercises stale-owner, corrupt-owner,
+   absent-owner, and dead-pid paths under `set -euo pipefail`.
+6. **sg re-exec transparency**: the marker must survive
+   `exec sg incus-admin -c` (cluster-setup.sh:41-50) — exported env
+   does; proven by §9.2d rather than assumed.
+7. **Append-only open of the lock file; never truncate, never rm**
+   (SMR F1) — inode identity is the mutex; post-acquire inode
+   revalidation closes the unlink race.
+8. **Remote-host reality**: the lock is host-local on the dev box; all
+   agents drive `loss:` from this box, so /tmp is the correct shared
+   namespace. Driving the cluster from a second machine bypasses
+   everything (documented, out of scope, cooperating-agents
+   assumption).
+
+## 8. Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression | LOW | Worst credible bug: a deadlock (self-wait) from a marker-validation bug — caught by the §9.2 matrix; recoverable by killing own process; degraded mode is *waiting*, never unserialized clobbering. No dataplane code touched. |
+| Lifetime/borrow-checker | N/A | Shell + docs only. |
+| Performance regression | LOW | Deploys may queue behind a measurement cell — intended. A hung holder blocking everyone is mitigated by the named-holder report + liveness flag; operator decides (never auto-steal, no force-bypass env — a bypass flag is exactly what an impatient agent would reach for). |
+| Architectural mismatch | LOW-MED | The honest hazard is *adoption*: hand-rolled deploy loops bypass the hook (SMR F4). Mitigated three ways: the default path (`make cluster-deploy`) is the safe path; CLAUDE.md prohibits hand-rolled pushes; #1868 detection backstops non-cooperators. Residual risk accepted and documented. |
+
+## 9. Test plan
+
+1. `bash -n` on all touched scripts; `shellcheck` if available.
+2. **Dry-run contention matrix on /tmp** (no cluster, overridden lock
+   path), all under `set -euo pipefail`:
+   (a) cell A holds via `with-cluster.sh "A" -- sleep 30`; cell B
+   blocks and prints A's pid/purpose/timestamp/inode;
+   (b) `kill -9` cell A's whole tree → B acquires within one `flock
+   -w` window (orphan-release proof);
+   (c) nested `with-cluster.sh` inside a cell runs immediately
+   (reentrancy), installs no second trap, and does NOT remove the
+   owner file on exit (AGY double-release check: owner file still
+   present until the outer cell exits);
+   (d) marker + `XPF_CLUSTER_SKIP_BUILD` survive the *actual*
+   `exec sg incus-admin -c "${local_env}$(printf '%q ' ...)"` re-exec
+   shape on this host (Codex r2 F3 — no deadlock, no double build) and
+   a `bash -c` boundary; a *forged/stale* marker (live but
+   non-ancestor pid; dead pid; mismatched lock path) is rejected →
+   acquire proceeds normally;
+   (e) stale owner file + free lock → acquire proceeds, report flags
+   dead pid; corrupt/empty owner file → no crash under `set -e`;
+   (f) exit-status propagation: cell command exiting 3 →
+   `with-cluster.sh` exits 3, owner file removed (SMR F9);
+   (g) unlink race: delete the lock file while A holds → a new
+   acquirer B fails closed via the split-mutex assertion (A2 step 3b),
+   naming both dev:inodes; with A gone (dead recorded pid) B acquires
+   normally on the new inode;
+   (h) `XPF_CLUSTER_LOCK_TIMEOUT=5` against a held lock → loud abort
+   with holder report, non-zero exit.
+3. `wg-interop.sh` `inc()` smoke (read-only `inc info` path) with and
+   without a valid marker.
+4. ONE live guarded `cluster-setup.sh deploy` on the loss userspace
+   cluster through the new re-exec path (the lock serializes against
+   any concurrent holder — wait, never kill), followed by
+   `./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0` (deploy
+   wipes CoS) and the standard iperf3 sanity check.
+5. No Go/Rust changes expected; if any land, `go build ./...`.
+
+## 10. Out of scope (explicitly)
+
+- Per-harness `check_build_identity` rollout to fairness/mouse-latency
+  scripts (worthy follow-up; detection layer, separable).
+- Cross-host locking, lease/steal semantics, CI enforcement,
+  force-bypass escape hatches.
+- Process-group/session management in `with-cluster.sh` (v2 keeps
+  close-fd only; revisit only if the wrapper-SIGKILL-children-survive
+  edge is ever actually hit).
+- Retrofitting every existing script to take cells automatically —
+  only `cluster-setup.sh` (the universal writer) and `wg-interop.sh`
+  (the asymmetry exemplar) change; others adopt via docs + the helper.
+- The smoke-runner agent-protocol (`feedback_smoke_serialized_single_agent`)
+  — unchanged; this mechanism is the OS-level backstop beneath it.
+
+## 11. r1 open questions — resolutions (for r2 ratification)
+
+1. **Path C sufficiency** — NO, 3-of-3 (Codex: default path reaches
+   lock-free `cmd_deploy` today; AGY: unenforced convention is not a
+   convention; SMR: context-fragility + the convention failed twice in
+   the same incident).
+2. **Blocking vs fail-fast deploy** — block by default with periodic
+   held-by reports; optional `XPF_CLUSTER_LOCK_TIMEOUT`. 2-of-3
+   (Codex + SMR); AGY preferred `flock -w 300` fail-fast. Rationale
+   for overriding AGY: a measurement cell legitimately holds for
+   25-40 min, so any short default timeout makes spurious aborts the
+   *common* case, and an aborting deploy invites exactly the
+   lock-bypass retry behavior the mechanism exists to prevent; the
+   periodic stderr report is the agent-visible affordance AGY's
+   timeout was reaching for. **Resolved 3-of-3 at r2**: both AGY r2
+   and Codex r2 explicitly re-judged in favor of block-by-default
+   with the optional timeout override.
+3. **fd-close tradeoff** — close-fd, no process-group kill in v1
+   (Codex + SMR; AGY's `kill -TERM -$$` is unsound as written — see
+   A2 note).
+4. **Marker hardening** — adopted beyond Codex's stated minimum:
+   path-bound `<lockpath>:<pid>` + liveness + ancestor walk (AGY §3
+   leak scenario judged real; the check is ~12 lines and failure
+   degrades to waiting, never skipping).
+5. **create/destroy/init locking** — lock all three (Codex found
+   `init` missing in v1). No `XPF_CLUSTER_FORCE` bypass (AGY's
+   suggestion declined: the named-holder report + `kill <pid>` is the
+   operator recovery path; a bypass env is an attractive nuisance for
+   agents).
+6. **Location/permissions** — /tmp retained (path is load-bearing in
+   three shipped scripts + runbook); 0666 best-effort creation (AGY);
+   never-rm rule + inode report (SMR F1).
+
+## 12. r2 open questions — resolutions (all folded into v3 above)
+
+1. **Inode revalidation** — KEEP, 3-of-3 (AGY: "prevents silent
+   concurrent executions"; Codex: compare `dev:ino` not bare inode —
+   adopted; SMR: extend with the owner-recorded-inode split-mutex
+   assertion — adopted as A2 step 3b).
+2. **Re-exec holes** — two found, both folded: (a) the sg re-exec
+   env-forwarding gap (SMR S1 + AGY "critical"; Codex verified sg
+   2.41.3 preserves env on this host but agreed to pin the actual
+   shape in §9.2d) → dynamic `XPF_*`/`BPFRX_*` forwarding in
+   `local_env`; (b) `suppress_host_parent_ipv6_ra` mutated shared
+   host state pre-lock (Codex r2 F1) → moved inside the reentrant
+   continuation. Plus `"$SCRIPT_DIR/cluster-setup.sh"` over `"$0"`.
+3. **Raw outer-flock deprecation** — acceptable 3-of-3, no compat
+   shim; a `flock -n` probe cannot distinguish "my caller holds it"
+   from "someone else holds it" (Codex) — rejected permanently.
+4. **Two-holders counter-example** — exists only via rm-while-held
+   (SMR S2's inode-split scenario); v3 fails closed on it (A2 3b).
+   Codex: with the same-path + never-rm assumptions held, kernel
+   exclusive flock guarantees a single holder. Residual (accepted,
+   documented): wrapper-only SIGKILL while children continue is
+   concurrent mutation by a *non-holder*, not two holders — out of
+   scope per §10.
+
+## 13. Remaining question for r3 (ratification round)
+
+r3 is a delta-ratification of the v2→v3 fold (sections 5.A2 steps
+3/3b/4, 5.A3, 5.A3b, 7.2, 9.2d/g, 11.2, 12). One genuinely new design
+element invites scrutiny: the A2-3b split-mutex **fail-closed abort**
+is the single exception to "owner file never gates execution" — is
+the false-positive surface (stale owner record naming a live recycled
+pid + old inode) acceptably rare, given the failure direction is
+refuse-and-diagnose rather than clobber?

--- a/docs/pr/1875-cluster-ownership/reviewer-ids.md
+++ b/docs/pr/1875-cluster-ownership/reviewer-ids.md
@@ -19,3 +19,13 @@
   F1/F2 caught edges SMR missed)
 - Copilot: request 1 quota-limited (PR review states it verbatim);
   re-requested at b24f28a3fc44 (retry 2 of 3)
+
+## Code phase round 2 (delta over fix commit b24f28a3fc44)
+- Codex code r2: session 019eb8d7-6d05-75f0-82c0-b18aa6d9c635 — MERGE-READY
+  (caller audit clean; probed env--/timeout normalization independently)
+- AGY code r2: adversarial-review-mqa32wuk-fcmnfa — MERGE-READY
+  (re-ran the selftest itself: ALL 10 CASES PASS)
+- Claude SMR code r2: claude-smr-code-r2.md — MERGE-READY
+- Copilot: quota-limited on ALL THREE documented retries (review
+  comments on the PR state it verbatim, timestamps 2026-06-11) →
+  3-of-4 exception per feedback_codex_infra_must_retry applies.

--- a/docs/pr/1875-cluster-ownership/reviewer-ids.md
+++ b/docs/pr/1875-cluster-ownership/reviewer-ids.md
@@ -1,0 +1,21 @@
+# PR #1878 (#1875) reviewer task-id ledger
+
+## Research phase (branch research/1875-cluster-ownership, converged 33cc213a7f06)
+- Codex plan r1: task-mqa0tpqd-em6hzd (PLAN-NEEDS-REVISION)
+- Codex plan r2: session 019eb8ab-7fb8-71c2-8e2c-9255767e746c (PLAN-NEEDS-REVISION)
+- Codex plan r3: session 019eb8b2-dfe2-7602-b453-3479ae2711a4 (PLAN-NEEDS-REVISION, text residual)
+- Codex plan r4: session 019eb8ba-0ee9-7dd2-af3f-0008a2b7cc00 (PLAN-READY)
+- AGY plan r1: adversarial-review-mqa0rv7z-t9pfyg (PLAN-NEEDS-REVISION)
+- AGY plan r2: adversarial-review-mqa18s13-hgimly (PLAN-READY)
+- AGY plan r3: adversarial-review-mqa1ibg7-5uanbl (PLAN-READY)
+- Claude SMR plan r1-r3: docs/research/1875-cluster-ownership/claude-smr-plan-r{1,2,3}.md (r3 PLAN-READY)
+
+## Code phase (PR #1878)
+- Codex code r1: session 019eb8ce-665f-72d0-a1f8-83a85063ef7a — NEEDS-CHANGES
+  (F1 builtin cells, F2 octal timeout, F3 selftest h not real sg path,
+  F4-info pkill -P comment) → all fixed in b24f28a3fc44
+- AGY code r1: adversarial-review-mqa2jyet-48fdcy — MERGE-READY
+- Claude SMR code r1: claude-smr-code-r1.md — MERGE-READY (pre-fix; Codex
+  F1/F2 caught edges SMR missed)
+- Copilot: request 1 quota-limited (PR review states it verbatim);
+  re-requested at b24f28a3fc44 (retry 2 of 3)

--- a/docs/wg-interop-runbook.md
+++ b/docs/wg-interop-runbook.md
@@ -45,9 +45,18 @@ WG outer transport: UDP 51820 over the VLAN-3667 LAN. Inner subnets:
 ```
 
 Evidence lands in `/tmp/wg-interop-<timestamp>/` (override with
-`WG_EVIDENCE_DIR`). Every cluster command runs under
+`WG_EVIDENCE_DIR`). Standalone, every cluster command runs under
 `flock /tmp/xpf-cluster.lock sg incus-admin`; long traffic runs detached
-inside the instances so the lock is never held across a phase.
+inside the instances so the lock is never held across a phase. Inside a
+`test/incus/with-cluster.sh` lock cell (#1875) the per-command flock is
+skipped — the cell already owns the cluster for the whole run. Do NOT
+wrap this script in a raw outer `flock /tmp/xpf-cluster.lock` — that
+deadlocks; use `with-cluster.sh`:
+
+```
+./test/incus/with-cluster.sh "1736 wg-interop" -- \
+    env WG_PEER_TYPE=container ./test/incus/wg-interop.sh all
+```
 
 Phase order is `P0 P1 P2 P4a P3 P4b P5 P6 P7` (P4a needs the
 xpf-initiated session from P1; P4b needs the kernel-initiated session

--- a/test/incus/apply-cos-config.sh
+++ b/test/incus/apply-cos-config.sh
@@ -45,6 +45,19 @@
 #
 set -euo pipefail
 
+# #1875: this script commits config on the SHARED loss userspace
+# cluster — serialize against other agents. Inside a with-cluster.sh
+# cell (valid marker from a live ancestor holder) it runs directly;
+# standalone it re-execs through with-cluster.sh, which blocks with a
+# named-holder report until the cluster is ours.
+_LOCK_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-lock.sh
+source "${_LOCK_SCRIPT_DIR}/cluster-lock.sh"
+if ! xpf_cluster_lock_held; then
+    exec "${_LOCK_SCRIPT_DIR}/with-cluster.sh" "apply-cos-config $*" \
+        -- "${_LOCK_SCRIPT_DIR}/apply-cos-config.sh" "$@"
+fi
+
 # #929 compatibility: --same-class still selects
 # cos-iperf-same-class.set for older callers. That fixture mirrors the
 # default 520x/620x map and also preserves the legacy destination-port

--- a/test/incus/cluster-lock.sh
+++ b/test/incus/cluster-lock.sh
@@ -1,0 +1,88 @@
+# shellcheck shell=bash
+#
+# #1875 — shared-cluster lock helpers (sourced, never executed).
+#
+# The loss userspace cluster (loss:xpf-userspace-fw0/fw1) is shared by
+# multiple cooperating agents on this dev box. Mutual exclusion is the
+# advisory flock on /tmp/xpf-cluster.lock; ownership *visibility* is
+# the metadata in /tmp/xpf-cluster.owner. Protocol (converged plan,
+# docs/pr/1875-cluster-ownership/plan.md):
+#
+#   - test/incus/with-cluster.sh is the ONLY long-lived, self-locking,
+#     marker-exporting holder. It exports
+#         XPF_CLUSTER_LOCK_HELD="<lockpath>:<holderpid>"
+#     while a lock cell is active.
+#   - Scripts that self-lock (cluster-setup.sh mutating verbs,
+#     apply-cos-config.sh) re-exec through with-cluster.sh when the
+#     marker is absent and run lock-free when it is valid.
+#   - Standalone per-command `flock /tmp/xpf-cluster.lock <cmd>`
+#     holders (wg-interop.sh inc(), ad-hoc one-liners around commands
+#     that do NOT self-lock) remain valid and never set the marker.
+#   - NEVER `rm` the lock or owner files: flock binds the inode, so
+#     deleting the path silently splits the mutex. Recovery from a
+#     stuck holder is `kill <holder-pid>` (the kernel releases the
+#     lock when its fd closes), never `rm`.
+#
+# Everything here must be safe under `set -euo pipefail` in consumers:
+# no unguarded reads, no unguarded kill -0, no traps, no global state
+# beyond the two XPF_CLUSTER_* path variables.
+
+XPF_CLUSTER_LOCK="${XPF_CLUSTER_LOCK:-/tmp/xpf-cluster.lock}"
+XPF_CLUSTER_OWNER="${XPF_CLUSTER_OWNER:-/tmp/xpf-cluster.owner}"
+
+# True (0) iff XPF_CLUSTER_LOCK_HELD names THIS lock path and a holder
+# pid that is alive AND an ancestor of the current process. Any parse
+# or validation failure returns 1: the caller then waits for the lock,
+# which is always safe — the failure direction is never "skip the
+# lock". The ancestry walk defeats the stale-marker leak (a cell's
+# backgrounded daemon that outlives the cell inherits the env but is
+# no longer a descendant of a live holder).
+xpf_cluster_lock_held() {
+	local marker="${XPF_CLUSTER_LOCK_HELD:-}"
+	[[ -n "$marker" ]] || return 1
+	local mpath="${marker%:*}" mpid="${marker##*:}"
+	[[ "$mpath" == "$XPF_CLUSTER_LOCK" ]] || return 1
+	[[ "$mpid" =~ ^[0-9]+$ ]] || return 1
+	kill -0 "$mpid" 2>/dev/null || return 1
+	# Ancestry: walk PPid from $$ up to init.
+	local cur=$$ ppid
+	while [[ "$cur" -gt 1 ]]; do
+		if [[ "$cur" -eq "$mpid" ]]; then
+			return 0
+		fi
+		ppid=$(awk '/^PPid:/ {print $2}' "/proc/${cur}/status" 2>/dev/null || true)
+		[[ "$ppid" =~ ^[0-9]+$ ]] || return 1
+		cur="$ppid"
+	done
+	return 1
+}
+
+# Print a one-line-per-fact ownership report to stdout. Diagnostics
+# only — callers must not gate execution on this output (the single
+# fail-closed exception lives in with-cluster.sh's split-mutex
+# assertion, which re-derives state itself). Tolerates absent, empty,
+# corrupt, and stale owner files.
+xpf_cluster_owner_report() {
+	local lock_ino
+	lock_ino=$(stat -c %d:%i "$XPF_CLUSTER_LOCK" 2>/dev/null || echo "?")
+	echo "cluster lock: ${XPF_CLUSTER_LOCK} (dev:ino ${lock_ino})"
+	local owner
+	owner=$(cat "$XPF_CLUSTER_OWNER" 2>/dev/null || true)
+	if [[ -z "$owner" ]]; then
+		echo "  no owner metadata (raw-flock holder, or holder predates the owner protocol)"
+		fuser -v "$XPF_CLUSTER_LOCK" 2>&1 | sed 's/^/  fuser: /' || true
+		return 0
+	fi
+	local opid otime ouser obranch oino opurpose
+	read -r opid otime ouser obranch oino opurpose <<<"$owner" || true
+	echo "  held by pid ${opid:-?} (${ouser:-?}) since ${otime:-?}"
+	echo "  branch: ${obranch:-?}  lock dev:ino at acquire: ${oino:-?}"
+	echo "  purpose: ${opurpose:-?}"
+	if [[ "${opid:-}" =~ ^[0-9]+$ ]] && kill -0 "$opid" 2>/dev/null; then
+		echo "  holder is ALIVE — wait for it or coordinate; NEVER kill another agent's holder, NEVER rm the lock file"
+	else
+		echo "  holder pid is DEAD — stale metadata (holder was SIGKILLed?); the flock itself is released on fd close."
+		echo "  if the lock still appears held, a child inherited the fd; diagnose with:"
+		fuser -v "$XPF_CLUSTER_LOCK" 2>&1 | sed 's/^/  fuser: /' || true
+	fi
+}

--- a/test/incus/cluster-setup.sh
+++ b/test/incus/cluster-setup.sh
@@ -30,22 +30,50 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+# #1875: shared-cluster lock protocol (marker validation + owner
+# reporting). Mutating verbs serialize through with-cluster.sh — see
+# require_cluster_cell below and the protocol header in cluster-lock.sh.
+# shellcheck source=cluster-lock.sh
+source "${SCRIPT_DIR}/cluster-lock.sh"
+
 # Source env file for custom deployments (remote, SR-IOV config, etc.)
 if [[ -n "${BPFRX_CLUSTER_ENV:-}" && -f "$BPFRX_CLUSTER_ENV" ]]; then
 	# shellcheck disable=SC1090
 	source "$BPFRX_CLUSTER_ENV"
 fi
 
-# Re-exec under incus-admin group if needed (preserve BPFRX_CLUSTER_ENV)
+# Re-exec under incus-admin group if needed. Forward ALL BPFRX_*/XPF_*
+# scalar vars, not just BPFRX_CLUSTER_ENV: sg's env preservation is
+# not guaranteed on every platform, and losing XPF_CLUSTER_LOCK_HELD
+# here would deadlock a deploy running inside a with-cluster.sh cell
+# (#1875 plan A3 / SMR r2 S1).
 if ! incus list &>/dev/null 2>&1; then
 	if getent group incus-admin &>/dev/null && id -nG | grep -qw incus-admin; then
 		local_env=""
-		if [[ -n "${BPFRX_CLUSTER_ENV:-}" ]]; then
-			local_env="BPFRX_CLUSTER_ENV=$(printf '%q' "$BPFRX_CLUSTER_ENV") "
-		fi
+		for _v in "${!BPFRX_@}" "${!XPF_@}"; do
+			local_env+="${_v}=$(printf '%q' "${!_v}") "
+		done
 		exec sg incus-admin -c "${local_env}$(printf '%q ' "$0" "$@")"
 	fi
 fi
+
+# #1875: serialize a mutating verb against other agents. Either we are
+# already inside a valid lock cell (marker from a live ancestor holder
+# — return immediately and run lock-free), or we re-exec this whole
+# invocation through with-cluster.sh, which blocks with a named-holder
+# report until the cluster is ours and re-runs us with the marker set.
+# The re-exec'd child runs with the lock fd closed, so killing the
+# verb's process tree releases the lock instantly. ORIG_ARGS preserves
+# the exact argv for the re-exec ("$SCRIPT_DIR/cluster-setup.sh", not
+# "$0", to dodge PATH/symlink oddities — Codex r2).
+ORIG_ARGS=("$@")
+require_cluster_cell() { # require_cluster_cell <purpose words...>
+	if xpf_cluster_lock_held; then
+		return 0
+	fi
+	exec "${SCRIPT_DIR}/with-cluster.sh" "cluster-setup $*" \
+		-- "${SCRIPT_DIR}/cluster-setup.sh" "${ORIG_ARGS[@]}"
+}
 
 # ── Defaults (local cluster values if no env file) ───────────────────
 
@@ -580,24 +608,48 @@ cmd_destroy() {
 cmd_deploy() {
 	local target="${1:-all}"
 
-	if [[ -n "${SRIOV_LAN_PARENT:-}" ]]; then
-		suppress_host_parent_ipv6_ra "$SRIOV_LAN_PARENT"
+	case "$target" in
+		0|1|all) ;;
+		*) die "Usage: $0 deploy [0|1|all]" ;;
+	esac
+
+	# #1875: build OUTSIDE the lock — it is multi-minute and purely
+	# local, and holding the shared-cluster lock across it would
+	# starve other agents for no reason. The locked re-invocation
+	# below skips the rebuild via XPF_CLUSTER_SKIP_BUILD.
+	if [[ -z "${XPF_CLUSTER_SKIP_BUILD:-}" ]]; then
+		info "Building xpfd and cli..."
+		make -C "$PROJECT_ROOT" build build-ctl
+		if [[ -x "$HOME/.cargo/bin/cargo" || -n "$(command -v cargo 2>/dev/null)" ]]; then
+			info "Building xpf-userspace-dp helper..."
+			make -C "$PROJECT_ROOT" build-userspace-dp
+		else
+			warn "Rust toolchain not found; skipping xpf-userspace-dp build"
+		fi
 	fi
 
-	info "Building xpfd and cli..."
-	make -C "$PROJECT_ROOT" build build-ctl
-	if [[ -x "$HOME/.cargo/bin/cargo" || -n "$(command -v cargo 2>/dev/null)" ]]; then
-		info "Building xpf-userspace-dp helper..."
-		make -C "$PROJECT_ROOT" build-userspace-dp
-	else
-		warn "Rust toolchain not found; skipping xpf-userspace-dp build"
+	# #1875: everything past this point mutates shared state —
+	# including the host-parent IPv6-RA suppression (sysctl + addr +
+	# route flush on the shared SR-IOV parent, Codex r2 F1) — and runs
+	# under the cluster lock. Concurrent agents queue here with a
+	# visible named-holder report instead of clobbering each other's
+	# validation runs mid-phase (the #1875 incident).
+	if ! xpf_cluster_lock_held; then
+		_branch=$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')
+		exec "${SCRIPT_DIR}/with-cluster.sh" \
+			"cluster-setup deploy ${target} (${_branch})" \
+			-- env XPF_CLUSTER_SKIP_BUILD=1 \
+			"${SCRIPT_DIR}/cluster-setup.sh" deploy "$target"
+	fi
+
+	if [[ -n "${SRIOV_LAN_PARENT:-}" ]]; then
+		suppress_host_parent_ipv6_ra "$SRIOV_LAN_PARENT"
 	fi
 
 	case "$target" in
 		0)   deploy_vm 0 ;;
 		1)   deploy_vm 1 ;;
 		all) deploy_rolling ;;
-		*)   die "Usage: $0 deploy [0|1|all]" ;;
 	esac
 }
 
@@ -902,17 +954,23 @@ usage() {
 	exit 1
 }
 
+# #1875: mutating verbs serialize via require_cluster_cell (init
+# creates/deletes networks+profiles; create/destroy launch/remove
+# instances; start/stop/restart flip the daemon and VRRP mastership).
+# deploy locks itself inside cmd_deploy (the build stays outside the
+# lock). Read-only verbs (ssh/status/logs/journal) stay lock-free —
+# ssh is interactive and must never hold the cluster lock.
 case "${1:-}" in
-	init)       cmd_init ;;
-	create)     cmd_create ;;
-	destroy)    cmd_destroy ;;
+	init)       require_cluster_cell init; cmd_init ;;
+	create)     require_cluster_cell create; cmd_create ;;
+	destroy)    require_cluster_cell destroy; cmd_destroy ;;
 	deploy)     cmd_deploy "${2:-all}" ;;
 	ssh)        cmd_ssh "${2:-}" ;;
 	status)     cmd_status ;;
 	logs)       cmd_logs "${2:-}" ;;
 	journal)    cmd_journal "${2:-}" ;;
-	start)      cmd_start "${2:-all}" ;;
-	stop)       cmd_stop "${2:-all}" ;;
-	restart)    cmd_restart "${2:-all}" ;;
+	start)      require_cluster_cell start "${2:-all}"; cmd_start "${2:-all}" ;;
+	stop)       require_cluster_cell stop "${2:-all}"; cmd_stop "${2:-all}" ;;
+	restart)    require_cluster_cell restart "${2:-all}"; cmd_restart "${2:-all}" ;;
 	*)          usage ;;
 esac

--- a/test/incus/reverse-key-collision-probe.sh
+++ b/test/incus/reverse-key-collision-probe.sh
@@ -44,9 +44,11 @@
 # Usage:
 #   ./test/incus/reverse-key-collision-probe.sh [warm|cold]
 #
-# Run under the shared-cluster flock per project convention:
-#   flock /tmp/xpf-cluster.lock sg incus-admin -c \
-#     "./test/incus/reverse-key-collision-probe.sh warm"
+# Run inside a shared-cluster lock cell (#1875 — the raw outer-flock
+# pattern is deprecated; with-cluster.sh adds holder visibility and is
+# nesting-safe):
+#   ./test/incus/with-cluster.sh "reverse-key probe" -- \
+#     sg incus-admin -c "./test/incus/reverse-key-collision-probe.sh warm"
 set -euo pipefail
 
 VARIANT="${1:-warm}"

--- a/test/incus/wg-interop.sh
+++ b/test/incus/wg-interop.sh
@@ -36,6 +36,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=wg-interop.env
 source "${SCRIPT_DIR}/wg-interop.env"
+# #1875: marker-aware locking. Bind the marker check to the SAME path
+# inc() flocks, so a cell holding a different lock can never bypass
+# this script's per-command serialization.
+XPF_CLUSTER_LOCK="${WG_CLUSTER_LOCK}"
+# shellcheck source=cluster-lock.sh
+source "${SCRIPT_DIR}/cluster-lock.sh"
 
 R="${WG_REMOTE}"
 FW0="${R}:${WG_FW0}"
@@ -64,10 +70,18 @@ warn() { log "WARN: $*"; }
 # Cluster command plumbing. flock serializes against other agents; sg
 # grants the incus-admin group. printf %q-quoting survives the sg -c
 # string boundary. stdin passes through (used for cli heredocs).
+# #1875: inside a with-cluster.sh cell (valid marker from a live
+# ancestor holder) the per-command flock is skipped — the cell already
+# owns the cluster, and flocking the same file would deadlock against
+# our own ancestor. Standalone behavior is byte-identical to before.
 inc() {
     local q
     q=$(printf '%q ' incus "$@")
-    flock "${WG_CLUSTER_LOCK}" sg incus-admin -c "$q"
+    if xpf_cluster_lock_held; then
+        sg incus-admin -c "$q"
+    else
+        flock "${WG_CLUSTER_LOCK}" sg incus-admin -c "$q"
+    fi
 }
 
 # Run a shell snippet inside an instance.

--- a/test/incus/with-cluster-selftest.sh
+++ b/test/incus/with-cluster-selftest.sh
@@ -46,18 +46,19 @@ grep -q "held by pid" "$T/a.out" || fail "(a) waiter report missing holder pid"
 ok "waiter blocks and reports holder pid+purpose, timeout honors XPF_CLUSTER_LOCK_TIMEOUT"
 wait "$A_PID" || true
 
-# ── (b) kill -9 of the whole cell tree releases the lock immediately
+# ── (b) kill -9 of the wrapper (the SOLE fd-9 holder) plus its direct
+#        children releases the lock immediately. Deeper grandchildren
+#        may survive as orphans, but they run with fd 9 closed and can
+#        never hold the lock — wrapper death IS lock release.
 "$WC" "case-b victim" -- bash -c 'echo started >"'"$T"'/b.start"; sleep 60' &
 B_PID=$!
 waitfor 5 "cell B started" test -f "$T/b.start"
-# Kill the wrapper and every descendant (children run with fd 9 closed,
-# the wrapper holds the only lock fd).
 pkill -9 -P "$B_PID" 2>/dev/null || true
 kill -9 "$B_PID" 2>/dev/null || true
 wait "$B_PID" 2>/dev/null || true
 XPF_CLUSTER_LOCK_TIMEOUT=35 "$WC" "case-b reclaim" -- true \
-	|| fail "(b) lock not reclaimable after kill -9 of holder tree"
-ok "kill -9 of cell tree releases the lock (no orphan holder)"
+	|| fail "(b) lock not reclaimable after kill -9 of holder"
+ok "kill -9 of the wrapper releases the lock (no orphan holder)"
 
 # ── (c) nested cell is reentrant; outer owner metadata survives the
 #        inner cell's exit (acquired-only trap rule)
@@ -124,13 +125,60 @@ wait "$G_PID" || true
 "$WC" "case-g reclaim" -- true || fail "(g) post-holder reclaim failed"
 ok "rm-while-held fails closed with SPLIT MUTEX diagnosis; reclaim works after holder exits"
 
-# ── (h) marker survives an env-preserving re-exec boundary (sg-shaped:
-#        rebuilt command string, env vars forwarded explicitly)
+# ── (h) marker + XPF_CLUSTER_SKIP_BUILD survive the EXACT
+#        cluster-setup.sh sg re-exec shape: the same ${!BPFRX_@}/${!XPF_@}
+#        forwarding loop, the same rebuilt-%q-command-string boundary,
+#        and real `sg` when this host has the incus-admin group
+#        (bash -c stands in otherwise). This pins the
+#        deadlock/double-build regression path (Codex code-r1 F3).
 # shellcheck disable=SC2016  # single quotes deliberate: expansion happens inside the cell
-"$WC" "case-h outer" -- bash -c '
-	local_env="XPF_CLUSTER_LOCK=$(printf %q "$XPF_CLUSTER_LOCK") XPF_CLUSTER_OWNER=$(printf %q "$XPF_CLUSTER_OWNER") XPF_CLUSTER_LOCK_HELD=$(printf %q "$XPF_CLUSTER_LOCK_HELD")"
-	bash -c "${local_env} \"'"$WC"'\" case-h-inner -- true"
-' || fail "(h) marker did not survive the rebuilt-command-string boundary"
-ok "marker survives an sg-shaped rebuilt-command re-exec boundary"
+"$WC" "case-h outer" -- env XPF_CLUSTER_SKIP_BUILD=1 BPFRX_CLUSTER_ENV=/tmp/fake.env bash -c '
+	# Replicate cluster-setup.sh lines 39-60 verbatim: dynamic prefix
+	# forwarding + printf %q command rebuild + group re-exec.
+	local_env=""
+	for _v in "${!BPFRX_@}" "${!XPF_@}"; do
+		local_env+="${_v}=$(printf "%q" "${!_v}") "
+	done
+	inner="${local_env}$(printf "%q " "'"$WC"'" case-h-inner -- bash -c "[ \"\${XPF_CLUSTER_SKIP_BUILD:-}\" = 1 ] && [ \"\${BPFRX_CLUSTER_ENV:-}\" = /tmp/fake.env ]")"
+	if command -v sg >/dev/null 2>&1 && id -nG | grep -qw incus-admin; then
+		sg incus-admin -c "$inner"
+	else
+		bash -c "$inner"
+	fi
+' || fail "(h) marker/skip-build/env did not survive the sg-shaped forwarding re-exec"
+ok "marker + skip-build survive the real \${!XPF_@} forwarding loop across the sg boundary"
+
+# ── (i) builtins cannot subvert the cell: `exec` is not an external
+#        command, the cell fails (127) without releasing early or
+#        leaking owner metadata (env -- contract, Codex code-r1 F1)
+set +e
+"$WC" "case-i builtin" -- exec true 2>/dev/null
+I_RC=$?
+set -e
+[[ $I_RC -eq 127 ]] || fail "(i) builtin cell expected 127, got $I_RC"
+[[ ! -f "$XPF_CLUSTER_OWNER" ]] || fail "(i) owner file leaked after builtin rejection"
+"$WC" "case-i reclaim" -- true || fail "(i) lock not clean after builtin rejection"
+ok "shell builtins are rejected (127) without breaking the lock or leaking owner state"
+
+# ── (j) timeout normalization: leading-zero values are base-10, not a
+#        silent octal arithmetic error (Codex code-r1 F2); absurd
+#        values degrade to wait-forever instead of overflowing
+"$WC" "case-j holder" -- bash -c 'echo started >"'"$T"'/j.start"; sleep 4' &
+J_PID=$!
+waitfor 5 "cell J started" test -f "$T/j.start"
+set +e
+XPF_CLUSTER_LOCK_TIMEOUT=08 "$WC" "case-j octal" -- true >"$T/j.out" 2>&1
+J_RC=$?
+set -e
+# "08" must behave as 8 seconds: holder exits at ~4s, so the waiter
+# ACQUIRES (rc 0) — an octal error would have produced arithmetic
+# noise; a disabled timeout is indistinguishable here, so also check
+# no arithmetic error text leaked.
+[[ $J_RC -eq 0 ]] || fail "(j) leading-zero timeout broke acquire (rc=$J_RC)"
+grep -qi "value too great\|arithmetic" "$T/j.out" && fail "(j) octal arithmetic error leaked"
+wait "$J_PID" || true
+XPF_CLUSTER_LOCK_TIMEOUT=99999999999999999999 "$WC" "case-j huge" -- true \
+	|| fail "(j) absurd timeout value broke acquire"
+ok "timeout env normalizes base-10 and degrades absurd values safely"
 
 echo "ALL ${PASS} CASES PASS"

--- a/test/incus/with-cluster-selftest.sh
+++ b/test/incus/with-cluster-selftest.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# #1875 — dry-run contention matrix for the shared-cluster lock cell
+# (plan §9.2). Exercises with-cluster.sh + cluster-lock.sh against a
+# PRIVATE lock path under /tmp — never touches the real
+# /tmp/xpf-cluster.lock, no cluster access, safe to run anywhere.
+#
+#   ./test/incus/with-cluster-selftest.sh
+#
+# Exits 0 with "ALL n CASES PASS" or non-zero naming the failed case.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WC="${SCRIPT_DIR}/with-cluster.sh"
+
+T=$(mktemp -d /tmp/xpf-lock-selftest.XXXXXX)
+trap 'rm -rf "$T"' EXIT
+export XPF_CLUSTER_LOCK="$T/lock"
+export XPF_CLUSTER_OWNER="$T/owner"
+
+PASS=0
+ok()   { PASS=$((PASS + 1)); echo "PASS ($PASS): $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Wait (bounded) for a condition.
+waitfor() { # waitfor <seconds> <desc> <cmd...>
+	local n=$(( $1 * 10 )) desc="$2"; shift 2
+	while (( n-- > 0 )); do
+		if "$@" 2>/dev/null; then return 0; fi
+		sleep 0.1
+	done
+	fail "timeout waiting for: $desc"
+}
+
+# ── (a) holder blocks a second cell; waiter prints the named-holder report
+"$WC" "case-a holder" -- bash -c 'echo started >"'"$T"'/a.start"; sleep 6' &
+A_PID=$!
+waitfor 5 "cell A started" test -f "$T/a.start"
+set +e
+XPF_CLUSTER_LOCK_TIMEOUT=1 "$WC" "case-a waiter" -- true >"$T/a.out" 2>&1
+A_RC=$?
+set -e
+[[ $A_RC -eq 75 ]] || fail "(a) waiter expected timeout exit 75, got $A_RC"
+grep -q "case-a holder" "$T/a.out" || fail "(a) waiter report missing holder purpose"
+grep -q "held by pid" "$T/a.out" || fail "(a) waiter report missing holder pid"
+ok "waiter blocks and reports holder pid+purpose, timeout honors XPF_CLUSTER_LOCK_TIMEOUT"
+wait "$A_PID" || true
+
+# ── (b) kill -9 of the whole cell tree releases the lock immediately
+"$WC" "case-b victim" -- bash -c 'echo started >"'"$T"'/b.start"; sleep 60' &
+B_PID=$!
+waitfor 5 "cell B started" test -f "$T/b.start"
+# Kill the wrapper and every descendant (children run with fd 9 closed,
+# the wrapper holds the only lock fd).
+pkill -9 -P "$B_PID" 2>/dev/null || true
+kill -9 "$B_PID" 2>/dev/null || true
+wait "$B_PID" 2>/dev/null || true
+XPF_CLUSTER_LOCK_TIMEOUT=35 "$WC" "case-b reclaim" -- true \
+	|| fail "(b) lock not reclaimable after kill -9 of holder tree"
+ok "kill -9 of cell tree releases the lock (no orphan holder)"
+
+# ── (c) nested cell is reentrant; outer owner metadata survives the
+#        inner cell's exit (acquired-only trap rule)
+"$WC" "case-c outer" -- bash -c '
+	"'"$WC"'" "case-c inner" -- true || exit 40
+	[ -f "'"$T"'/owner" ] || exit 41          # inner exit must NOT remove owner
+	grep -q "case-c outer" "'"$T"'/owner" || exit 42
+' || fail "(c) nested reentrancy / owner-preservation failed (rc=$?)"
+[[ ! -f "$T/owner" ]] || fail "(c) outer cell did not clean owner on exit"
+ok "nested cell runs lock-free; inner exit preserves outer owner metadata"
+
+# ── (d) forged/stale markers are rejected (acquire proceeds normally)
+# d1: live but non-ancestor pid
+sleep 30 & NONANC=$!
+XPF_CLUSTER_LOCK_HELD="$XPF_CLUSTER_LOCK:$NONANC" "$WC" "case-d1" -- true \
+	|| fail "(d1) live non-ancestor marker did not degrade to acquire"
+kill "$NONANC" 2>/dev/null || true
+# d2: dead pid (spawn+reap a short-lived sleep)
+sleep 0.01 & DEAD=$!; wait "$DEAD" || true
+XPF_CLUSTER_LOCK_HELD="$XPF_CLUSTER_LOCK:$DEAD" "$WC" "case-d2" -- true \
+	|| fail "(d2) dead-pid marker did not degrade to acquire"
+# d3: mismatched lock path with a real ancestor pid ($$ IS our ancestor)
+XPF_CLUSTER_LOCK_HELD="/tmp/some-other.lock:$$" "$WC" "case-d3" -- true \
+	|| fail "(d3) wrong-path marker did not degrade to acquire"
+# d4: garbage marker
+XPF_CLUSTER_LOCK_HELD="garbage" "$WC" "case-d4" -- true \
+	|| fail "(d4) garbage marker did not degrade to acquire"
+ok "forged/stale/wrong-path/garbage markers all rejected; acquire proceeds"
+
+# ── (e) stale + corrupt owner files never crash or block an acquire
+echo "999999999 2020-01-01T00:00:00 nobody dead-branch 1:1 stale" >"$XPF_CLUSTER_OWNER"
+"$WC" "case-e stale" -- true || fail "(e) stale owner file broke acquire"
+printf '\0\0garbage\n' >"$XPF_CLUSTER_OWNER"
+"$WC" "case-e corrupt" -- true || fail "(e) corrupt owner file broke acquire"
+: >"$XPF_CLUSTER_OWNER"
+"$WC" "case-e empty" -- true || fail "(e) empty owner file broke acquire"
+ok "stale/corrupt/empty owner files tolerated under set -euo pipefail"
+
+# ── (f) exit-status propagation + owner cleanup on failure
+set +e
+"$WC" "case-f" -- bash -c 'exit 3'
+F_RC=$?
+set -e
+[[ $F_RC -eq 3 ]] || fail "(f) expected exit 3, got $F_RC"
+[[ ! -f "$XPF_CLUSTER_OWNER" ]] || fail "(f) owner file leaked after failing cell"
+ok "cell exit status propagates (3) and owner file is cleaned"
+
+# ── (g) split-mutex: rm the lock while held → fail-closed abort naming inodes
+"$WC" "case-g holder" -- bash -c 'echo started >"'"$T"'/g.start"; sleep 8' &
+G_PID=$!
+waitfor 5 "cell G started" test -f "$T/g.start"
+OLD_INO=$(stat -c %d:%i "$XPF_CLUSTER_LOCK")
+rm -f "$XPF_CLUSTER_LOCK"        # the documented NEVER-do — simulate it
+set +e
+"$WC" "case-g intruder" -- true >"$T/g.out" 2>&1
+G_RC=$?
+set -e
+[[ $G_RC -eq 70 ]] || fail "(g) expected split-mutex abort 70, got $G_RC (out: $(cat "$T/g.out"))"
+grep -q "SPLIT MUTEX" "$T/g.out" || fail "(g) abort missing SPLIT MUTEX diagnosis"
+grep -q "$OLD_INO" "$T/g.out" || fail "(g) abort does not name the held inode"
+wait "$G_PID" || true
+# After the real holder exits, acquire on the new inode must succeed
+# (dead recorded pid → stale metadata path).
+"$WC" "case-g reclaim" -- true || fail "(g) post-holder reclaim failed"
+ok "rm-while-held fails closed with SPLIT MUTEX diagnosis; reclaim works after holder exits"
+
+# ── (h) marker survives an env-preserving re-exec boundary (sg-shaped:
+#        rebuilt command string, env vars forwarded explicitly)
+# shellcheck disable=SC2016  # single quotes deliberate: expansion happens inside the cell
+"$WC" "case-h outer" -- bash -c '
+	local_env="XPF_CLUSTER_LOCK=$(printf %q "$XPF_CLUSTER_LOCK") XPF_CLUSTER_OWNER=$(printf %q "$XPF_CLUSTER_OWNER") XPF_CLUSTER_LOCK_HELD=$(printf %q "$XPF_CLUSTER_LOCK_HELD")"
+	bash -c "${local_env} \"'"$WC"'\" case-h-inner -- true"
+' || fail "(h) marker did not survive the rebuilt-command-string boundary"
+ok "marker survives an sg-shaped rebuilt-command re-exec boundary"
+
+echo "ALL ${PASS} CASES PASS"

--- a/test/incus/with-cluster.sh
+++ b/test/incus/with-cluster.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# #1875 — run a command as an exclusive "lock cell" on the shared
+# loss userspace cluster.
+#
+#   ./test/incus/with-cluster.sh "<purpose>" -- <cmd> [args...]
+#
+# Examples:
+#   ./test/incus/with-cluster.sh "1736 S2b closure" -- bash -c '
+#       make cluster-deploy &&
+#       ./test/incus/apply-cos-config.sh loss:xpf-userspace-fw0 &&
+#       WG_PEER_TYPE=container ./test/incus/wg-interop.sh all'
+#
+# This is the ONLY process that holds /tmp/xpf-cluster.lock across
+# commands (protocol header in cluster-lock.sh). Properties:
+#   - Blocks until the lock is free, printing a named-holder report
+#     every 30s (who, since when, what for). Set
+#     XPF_CLUSTER_LOCK_TIMEOUT=<seconds> to abort loudly instead of
+#     waiting forever.
+#   - Reentrant: inside a valid cell (XPF_CLUSTER_LOCK_HELD marker
+#     from a live ancestor holder) the command just runs — cells nest
+#     and self-locking scripts (cluster-setup.sh, apply-cos-config.sh)
+#     do not deadlock.
+#   - The command runs with the lock fd CLOSED (9>&-): killing the
+#     cell's whole process tree releases the lock immediately; no
+#     orphaned child can become an invisible holder.
+#   - Fail-closed split-mutex assertion: if the owner file names a
+#     LIVE holder whose recorded lock dev:ino differs from ours AND
+#     that holder still has the old inode open on fd 9, someone
+#     deleted/recreated the lock file mid-hold — refuse to run.
+#   - Exit status of the command is propagated.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cluster-lock.sh
+source "${SCRIPT_DIR}/cluster-lock.sh"
+
+usage() {
+	echo "Usage: $0 \"<purpose>\" -- <cmd> [args...]" >&2
+	exit 2
+}
+
+[[ $# -ge 3 ]] || usage
+PURPOSE="$1"
+shift
+[[ "$1" == "--" ]] || usage
+shift
+
+# Reentrant case: a live ancestor cell already holds the lock. Run the
+# command directly — no second acquire, no owner write, no trap (the
+# outer cell owns cleanup).
+if xpf_cluster_lock_held; then
+	exec "$@"
+fi
+
+WAITED=0
+TIMEOUT="${XPF_CLUSTER_LOCK_TIMEOUT:-0}"  # 0 = wait forever
+[[ "$TIMEOUT" =~ ^[0-9]+$ ]] || TIMEOUT=0
+
+while :; do
+	# Append-only open: NEVER truncate (a concurrent holder's inode
+	# must not be disturbed) and never rm (cluster-lock.sh header).
+	exec 9>>"$XPF_CLUSTER_LOCK"
+	chmod 0666 "$XPF_CLUSTER_LOCK" 2>/dev/null || true
+
+	# Contend in (up to) 30s flock windows so a holder release is
+	# picked up immediately, while still reporting the named holder
+	# periodically. The window is capped at the remaining timeout so
+	# sub-30s XPF_CLUSTER_LOCK_TIMEOUT values fire on time.
+	while :; do
+		WINDOW=30
+		if [[ "$TIMEOUT" -gt 0 ]]; then
+			REMAIN=$((TIMEOUT - WAITED))
+			if [[ "$REMAIN" -le 0 ]]; then
+				echo "[with-cluster] ABORT: lock not acquired within XPF_CLUSTER_LOCK_TIMEOUT=${TIMEOUT}s" >&2
+				xpf_cluster_owner_report >&2
+				exit 75  # EX_TEMPFAIL
+			fi
+			[[ "$REMAIN" -lt "$WINDOW" ]] && WINDOW=$REMAIN
+		fi
+		if flock -w "$WINDOW" 9; then
+			break
+		fi
+		WAITED=$((WAITED + WINDOW))
+		echo "[with-cluster $(date +%H:%M:%S)] waiting for cluster lock (${WAITED}s, purpose: ${PURPOSE})" >&2
+		xpf_cluster_owner_report >&2
+	done
+
+	# Post-acquire dev:ino revalidation: if the path was unlinked or
+	# replaced between our open and our flock, we locked a dead inode.
+	# Close and retry on the current path.
+	PATH_INO=$(stat -c %d:%i "$XPF_CLUSTER_LOCK" 2>/dev/null || true)
+	FD_INO=$(stat -L -c %d:%i "/proc/$$/fd/9" 2>/dev/null || true)
+	if [[ -z "$PATH_INO" || "$PATH_INO" != "$FD_INO" ]]; then
+		echo "[with-cluster] lock file changed under us (path ${PATH_INO:-gone} vs fd ${FD_INO:-?}) — reacquiring" >&2
+		exec 9>&-
+		continue
+	fi
+	break
+done
+
+# Split-mutex assertion (fail-closed, the one owner-file check that
+# gates execution): a LIVE recorded holder with a DIFFERENT lock
+# dev:ino that it provably still holds on its fd 9 means the lock
+# path was deleted/recreated while held — two "holders" would both
+# believe they own the cluster. Refuse and diagnose. The fd-9 probe
+# defeats pid-recycling false positives (a recycled pid won't have
+# the old inode open on fd 9).
+OWNER_LINE=$(cat "$XPF_CLUSTER_OWNER" 2>/dev/null || true)
+if [[ -n "$OWNER_LINE" ]]; then
+	read -r OPID _ _ _ OINO _ <<<"$OWNER_LINE" || true
+	if [[ "${OPID:-}" =~ ^[0-9]+$ && -n "${OINO:-}" && "$OINO" != "$FD_INO" ]] \
+		&& kill -0 "$OPID" 2>/dev/null; then
+		HOLDER_FD_INO=$(stat -L -c %d:%i "/proc/${OPID}/fd/9" 2>/dev/null || true)
+		if [[ -n "$HOLDER_FD_INO" && "$HOLDER_FD_INO" == "$OINO" ]]; then
+			echo "[with-cluster] ABORT: SPLIT MUTEX — pid ${OPID} still holds lock inode ${OINO} but the path now resolves to ${FD_INO}." >&2
+			echo "  Someone deleted/recreated ${XPF_CLUSTER_LOCK} while it was held (never rm the lock file)." >&2
+			echo "  Wait for pid ${OPID} to finish; both runs proceeding would clobber each other." >&2
+			exit 70  # EX_SOFTWARE
+		fi
+	fi
+fi
+
+# Acquired. Publish owner metadata atomically (tmp + mv), clean it up
+# on exit. Only THIS process (the successful acquirer) installs the
+# trap.
+OWNER_TMP=$(mktemp "${XPF_CLUSTER_OWNER}.XXXXXX")
+BRANCH=$(git -C "$SCRIPT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+printf '%s %s %s %s %s %s\n' \
+	"$$" "$(date -Is)" "${USER:-$(id -un)}" "$BRANCH" "$FD_INO" "$PURPOSE" \
+	>"$OWNER_TMP"
+chmod 0666 "$OWNER_TMP" 2>/dev/null || true
+mv -f "$OWNER_TMP" "$XPF_CLUSTER_OWNER"
+trap 'rm -f "$XPF_CLUSTER_OWNER" 2>/dev/null || true' EXIT
+
+export XPF_CLUSTER_LOCK_HELD="${XPF_CLUSTER_LOCK}:$$"
+
+echo "[with-cluster $(date +%H:%M:%S)] lock acquired (pid $$, purpose: ${PURPOSE})" >&2
+
+# Run the cell with the lock fd closed: children never inherit fd 9,
+# so killing the cell's tree releases the lock the instant this
+# process dies.
+rc=0
+"$@" 9>&- || rc=$?
+exit "$rc"

--- a/test/incus/with-cluster.sh
+++ b/test/incus/with-cluster.sh
@@ -48,14 +48,26 @@ shift
 
 # Reentrant case: a live ancestor cell already holds the lock. Run the
 # command directly — no second acquire, no owner write, no trap (the
-# outer cell owns cleanup).
+# outer cell owns cleanup). `env --` pins the command to an EXTERNAL
+# binary: a shell builtin like `exec` would otherwise run inside this
+# wrapper shell, drop the lock early, and skip the cleanup trap (Codex
+# code-r1 F1). Cells are processes by contract.
 if xpf_cluster_lock_held; then
-	exec "$@"
+	exec env -- "$@"
 fi
 
 WAITED=0
-TIMEOUT="${XPF_CLUSTER_LOCK_TIMEOUT:-0}"  # 0 = wait forever
-[[ "$TIMEOUT" =~ ^[0-9]+$ ]] || TIMEOUT=0
+# Timeout: digits only, forced base-10 (a leading zero like "08" must
+# not become an octal arithmetic error that silently disables the
+# timeout — Codex code-r1 F2), length-capped so absurd values cannot
+# overflow signed arithmetic. Anything else degrades to 0 = wait
+# forever, the safe direction.
+TIMEOUT="${XPF_CLUSTER_LOCK_TIMEOUT:-0}"
+if [[ "$TIMEOUT" =~ ^[0-9]{1,7}$ ]]; then
+	TIMEOUT=$((10#$TIMEOUT))
+else
+	TIMEOUT=0
+fi
 
 while :; do
 	# Append-only open: NEVER truncate (a concurrent holder's inode
@@ -139,7 +151,9 @@ echo "[with-cluster $(date +%H:%M:%S)] lock acquired (pid $$, purpose: ${PURPOSE
 
 # Run the cell with the lock fd closed: children never inherit fd 9,
 # so killing the cell's tree releases the lock the instant this
-# process dies.
+# process dies. `env --` pins the cell to an external command — a
+# builtin (`exec`, `eval`, ...) would mutate THIS wrapper instead of
+# running as a child (Codex code-r1 F1).
 rc=0
-"$@" 9>&- || rc=$?
+env -- "$@" 9>&- || rc=$?
 exit "$rc"


### PR DESCRIPTION
Closes #1875

## What

Implements Path A of the converged research plan (PLAN-READY 3-of-3 after 4 Codex / 3 AGY / 3 Claude SMR rounds — see the trail on #1875 and `docs/pr/1875-cluster-ownership/plan.md`): the 2026-06-11 incident class where a concurrent agent's deploy loop swapped binaries mid-phase under another agent's validation run on `loss:xpf-userspace-fw{0,1}`.

- **`test/incus/cluster-lock.sh`** (new, sourced): marker validation — `XPF_CLUSTER_LOCK_HELD=<lockpath>:<pid>` honored only for a matching lock path with a live **ancestor** pid (a leaked env marker in a backgrounded daemon can never skip locking) — plus the `set -e`-safe named-holder report.
- **`test/incus/with-cluster.sh`** (new): the ONLY long-lived lock holder. Blocking `flock -w` windows with a holder report (pid/user/branch/purpose/inode) every 30s; optional `XPF_CLUSTER_LOCK_TIMEOUT`; post-acquire dev:ino revalidation; **fail-closed split-mutex assertion** with a `/proc/<pid>/fd/9` probe (rm-while-held is detected, pid recycling can't false-positive); atomic owner metadata; children run with the lock fd **closed** — killing a cell's tree releases the lock instantly (kills the 3-hour invisible-queue failure mode).
- **`cluster-setup.sh`**: `deploy/start/stop/restart/create/destroy/init` re-exec through `with-cluster.sh`. The multi-minute build stays OUTSIDE the lock (`XPF_CLUSTER_SKIP_BUILD` skips the rebuild in the locked re-invocation); everything mutating shared state — including the host-parent IPv6-RA sysctl/addr/route flushes — runs inside. The `sg incus-admin` re-exec now forwards all `BPFRX_*`/`XPF_*` scalars so a cell-launched deploy can't deadlock on its own ancestor's lock.
- **`apply-cos-config.sh`**: self-locks the same way.
- **`wg-interop.sh` `inc()`**: skips its per-command flock inside a valid cell (resolves the self-lock asymmetry where outer-wrapping the script deadlocked); standalone behavior byte-identical.
- **Docs**: `engineering-style.md` who-locks-what table + mutex-soundness rules (never raw-outer-flock a self-locking script; never `rm` the lock file — flock binds the inode; never kill another agent's holder; never hand-roll `incus file push` deploys); CLAUDE.md agent-facing summary; runbook + probe-script headers updated off the deprecated raw outer-flock pattern.

## Validation

**Dry-run contention matrix** — `test/incus/with-cluster-selftest.sh` (committed; private lock path, no cluster access) — `ALL 8 CASES PASS`:
1. waiter blocks and reports holder pid+purpose; sub-30s `XPF_CLUSTER_LOCK_TIMEOUT` fires on time (exit 75)
2. `kill -9` of a cell's whole tree releases the lock immediately (no orphan holder)
3. nested cell runs lock-free; inner exit preserves outer owner metadata (acquired-only trap rule)
4. forged markers rejected: live non-ancestor pid, dead pid, wrong lock path, garbage — all degrade to *waiting*, never skipping
5. stale/corrupt/empty owner files tolerated under `set -euo pipefail`
6. cell exit status propagates; owner file cleaned on failure
7. rm-while-held → fail-closed `SPLIT MUTEX` abort (exit 70) naming both dev:inodes; reclaim works after the holder exits
8. marker survives an sg-shaped rebuilt-command re-exec boundary

The matrix caught one real bug during bring-up (fixed): the fixed 30s flock window swallowed sub-30s timeout values.

**Live guarded validation on the loss userspace cluster** (the plan's §9.4):
- `cluster-setup.sh deploy all` through the NEW self-locking path: `lock acquired (pid 3723300, purpose: cluster-setup deploy all (engineer/1875-cluster-ownership))` → rolling deploy complete, verify-dataplane preflight intact, RC=0.
- Build identity live: both nodes report `Software version: ...-g280e73a6f` == this branch HEAD.
- `apply-cos-config.sh` through its new self-lock: `lock acquired (... purpose: apply-cos-config loss:xpf-userspace-fw0)` → atomic commit + verification OK (deploy wipes CoS — re-applied per the standing rule).
- iperf3 sanity through lock cells: port 5203 (3.0g-exact shaper) → 2.86 Gbit/s (correct shaped behavior); port 5211 (uncapped) → 20.7 Gbit/s.

**Gates**: `bash -n` clean on all 7 touched/new scripts; `shellcheck -x` clean on the new scripts (the 7 pre-existing info-level findings in cluster-setup.sh are in untouched regions); no Go/Rust changes (binaries are master-equivalent — `go build` not applicable).

@copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)