### PR TITLE
xpf .deb: declare runtime library deps (${shlibs:Depends}) — follow-up to #1931

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Rules-Requires-Root: no
 
 Package: xpf
 Architecture: amd64
-Depends: ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Junos-style firewall with AF_XDP userspace dataplane
  xpf is a Junos-style stateful firewall that clones Juniper vSRX
  capabilities using native Junos configuration syntax. The runtime


### PR DESCRIPTION
## What
The merged `xpf` Debian package (#1931) declared `Depends: ${misc:Depends}` only, omitting `${shlibs:Depends}` — so the shipped `.deb` declared **no runtime library dependencies** despite `xpf-userspace-dp` being dynamically linked (`libc.so.6` + `libgcc_s.so.1`). `dpkg-gencontrol` warned `substitution variable ${shlibs:Depends} unused, but is defined`. Without it the `.deb` can install on an incompatible-glibc host and fail at **runtime** instead of failing closed at **install/apt-resolve** time.

Surfaced by AGY round-3 on #1931 (landed post-merge).

## Fix
One line: `Depends: ${shlibs:Depends}, ${misc:Depends}` on the `xpf` package. The `xpf-appliance` metapackage has no binaries and is unchanged.

## Validation
- `make deb` builds clean; the `dpkg-gencontrol` unused-substvar warning is gone.
- Built `xpf` `.deb` now declares `Depends: libc6 (>= 2.38), libgcc-s1 (>= 4.2)`.

Part of #1917 (increment A follow-up). Trivial packaging-correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)