### PR TITLE
docs: README getting-started restructure + move reference content to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ by a Go control plane.
 
 ## Getting started
 
-There are three ways to get a running firewall. **(C) the prebuilt
-appliance image is the recommended path** — it is the dependency closure
-(kernel ≥ 6.18, FRR, strongSwan, Kea, the xpf binaries and units) baked
-into one bootable disk, deployable on incus or libvirt/KVM/QEMU. Install
-the `.deb` on a host you already manage; build from source for
-development.
+There are three ways to get a running firewall. **The prebuilt appliance
+image (paths B and C) is the recommended path** — it is the dependency
+closure (kernel ≥ 6.18, FRR, strongSwan, Kea, the xpf binaries and units)
+baked into one bootable disk, deployable on incus (B) or
+libvirt/KVM/QEMU (C). Install the `.deb` (A) on a host you already manage;
+build from source for development.
 
 | Path | Use when | Jump to |
 |------|----------|---------|
@@ -176,7 +176,7 @@ security {
     zones {
         security-zone trust {
             interfaces {
-                ge-0/0/0.0;
+                ge-0/0/0;
             }
             host-inbound-traffic {
                 system-services {
@@ -207,7 +207,7 @@ The same thing as flat `set` commands:
 
 ```
 set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24
-set security zones security-zone trust interfaces ge-0/0/0.0
+set security zones security-zone trust interfaces ge-0/0/0
 set security policies from-zone trust to-zone untrust policy allow-all match source-address any destination-address any application any
 set security policies from-zone trust to-zone untrust policy allow-all then permit
 ```

--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ your day-0 config sets credentials) or via the hypervisor console. First
 contact is always `cli`.
 
 > **Interface naming is positional, like vSRX.** The first vNIC is `fxp0`
-> (out-of-band mgmt); the rest map to `ge-0/0/N` in attach order
-> (cluster nodes insert `em0` for HA control at position 2). The order
-> you attach NICs is the order they are named — see the contract in
+> (out-of-band mgmt); the rest map to `ge-0/0/N` in attach order (cluster
+> nodes insert `em0` for HA control at position 2). The order you attach
+> NICs is the order they are named, with one wrinkle: enumeration sorts
+> virtio NICs ahead of other drivers and then by PCI bus address
+> (`enumerateAndRenameInterfaces()` in `pkg/daemon/linksetup.go`), so a
+> virtio mgmt NIC stays `fxp0`/`em0` even when dataplane ports are
+> SR-IOV/passthrough. In a normal layout this is identical to pure attach
+> order; verify with `show interfaces terse`. Full contract in
 > [`docs/deploy-quickstart.md`](docs/deploy-quickstart.md).
 
 ### (A) Debian package (.deb)
@@ -49,7 +54,7 @@ make deb                       # builds xpfd + xpf-userspace-dp + cli,
                                # packages them into dist/deb/xpf_<ver>_amd64.deb
                                # (+ the xpf-appliance metapackage)
 
-# On the target host:
+# Copy dist/deb/xpf_<ver>_amd64.deb to the target host, then there:
 sudo apt install ./xpf_<ver>_amd64.deb     # ${shlibs:Depends} pulled in by apt
 ```
 
@@ -126,10 +131,11 @@ Plain QEMU works the same way: `-drive file=dist/xpf-<ver>.qcow2`
 
 You can also drive libvirt through the same deployer used for incus —
 `scripts/deploy/xpf-deploy.py --hypervisor libvirt deploy <file>.yaml`
-emits the `virt-install` command, including SR-IOV VF-pool and
-PCI-passthrough wiring. **vNIC / SR-IOV mapping:** the order NICs appear
-on the guest PCI bus is the order they are named (`fxp0`, then
-`ge-0/0/N`). For line-rate dataplane ports, pass through a whole PF
+builds the day-0 drive and runs `virt-install`, including SR-IOV VF-pool
+and PCI-passthrough wiring (add `--dry-run` to print the command instead
+of running it). **vNIC / SR-IOV mapping:** the order NICs appear on the
+guest PCI bus is the order they are named (`fxp0`, then `ge-0/0/N`),
+subject to the virtio-first tiebreaker noted above. For line-rate dataplane ports, pass through a whole PF
 (i40e/ice/mlx5, native XDP) or an **mlx5** VF (also native XDP); Intel
 VFs fall back to generic-mode XDP (~3-4× slower); virtio/bridge is fine
 for mgmt and modest WANs. The backing matrix is in

--- a/README.md
+++ b/README.md
@@ -1,211 +1,164 @@
 # xpf
 
-Stateful firewall with native Junos configuration syntax.
+xpf is a high-performance, Junos-style stateful firewall that replicates
+Juniper vSRX capabilities. It uses the familiar Junos hierarchical
+configuration syntax and a full interactive CLI (tab completion, `?`
+help), and forwards packets on a Rust AF_XDP userspace dataplane driven
+by a Go control plane.
 
-> Dataplane notice (#1373, complete): the eBPF dataplane retirement is done.
-> The Rust AF_XDP userspace dataplane is the only runtime forwarding path.
-> Explicit `system dataplane-type ebpf` is hard-rejected at commit
-> (`ErrEBPFDataplaneRetired`) and at runtime (`ErrEBPFBackendRetired`); use
-> `set system dataplane-type userspace`, or omit the knob for the default.
-> The legacy BPF source (`bpf/xdp/*.c`, `bpf/tc/*.c`) was deleted in #1476;
-> the only retained eBPF artifacts are the userspace XDP shim
-> (`userspace-xdp/`) and the shared `bpf/headers/*.h` map/struct bootstrap.
+> Dataplane: the Rust AF_XDP userspace dataplane is the **only** runtime
+> forwarding path (eBPF retired in #1373/#1476, DPDK in #1525). See
+> [`docs/architecture.md`](docs/architecture.md).
 
-xpf is a high-performance stateful firewall that replicates Juniper vSRX
-capabilities. It uses the familiar Junos hierarchical configuration syntax and
-provides a full interactive CLI with tab completion and `?` help.
+---
 
-## Dataplane Architecture
+## Getting started
 
-xpf has a single runtime forwarding path: the Rust AF_XDP userspace dataplane.
-It is driven by the Go control plane (config, HA, routing, CLI, APIs).
+There are three ways to get a running firewall. **(C) the prebuilt
+appliance image is the recommended path** — it is the dependency closure
+(kernel ≥ 6.18, FRR, strongSwan, Kea, the xpf binaries and units) baked
+into one bootable disk, deployable on incus or libvirt/KVM/QEMU. Install
+the `.deb` on a host you already manage; build from source for
+development.
 
-The userspace AF_XDP backend is selected by `set system dataplane-type
-userspace`, or by omitting the knob entirely (the default). The legacy eBPF
-forwarding backend was retired in #1373/#1476: explicit `system dataplane-type
-ebpf` is hard-rejected at commit time with `ErrEBPFDataplaneRetired` and at
-runtime with `ErrEBPFBackendRetired`. The parser still *accepts* the `ebpf`
-token so that `load merge`/`load override` of a pre-retirement config does not
-syntax-error during a rolling upgrade — but `commit check` then fails with the
-retirement error, and the remediation is `set system dataplane-type userspace`.
-If a persisted config still names `ebpf` on startup, the daemon runs in
-config-only mode until the operator updates it. The current userspace admission
-boundary is tracked in
-[`docs/userspace-dataplane-gaps.md`](docs/userspace-dataplane-gaps.md).
+| Path | Use when | Jump to |
+|------|----------|---------|
+| **(A) Debian package** | You have a Debian/Ubuntu host (kernel ≥ 6.18) and want xpf on it | [below](#a-debian-package-deb) |
+| **(B) Incus appliance image** | You run incus and want a VM appliance | [below](#b-incus-appliance-image) |
+| **(C) KVM / QEMU / libvirt** | You run libvirt/KVM/QEMU | [below](#c-kvm--qemu--libvirt) |
 
-### Userspace Dataplane (the runtime forwarding path)
+All paths give you the same firewall. After it boots, the **mgmt
+interface `fxp0` comes up on DHCP** and you reach the box over SSH (once
+your day-0 config sets credentials) or via the hypervisor console. First
+contact is always `cli`.
 
-A Rust-based forwarding engine receives packets via AF_XDP sockets and
-processes them in userspace. A Rust XDP shim stamps metadata, redirects transit
-traffic into AF_XDP, and still hands proven local/control traffic back to the
-kernel when needed. If helper/XSK forwarding is degraded, non-local transit
-fails closed in both compat and strict modes instead of bypassing policy, NAT,
-or conntrack.
+> **Interface naming is positional, like vSRX.** The first vNIC is `fxp0`
+> (out-of-band mgmt); the rest map to `ge-0/0/N` in attach order
+> (cluster nodes insert `em0` for HA control at position 2). The order
+> you attach NICs is the order they are named — see the contract in
+> [`docs/deploy-quickstart.md`](docs/deploy-quickstart.md).
 
-```
-NIC → XDP shim (redirect transit, pass local/control, drop degraded transit)
-    → AF_XDP socket
-    → Rust worker thread (session → policy → NAT → FIB → TX)
-    → AF_XDP TX ring → NIC
-```
+### (A) Debian package (.deb)
 
-- **Per-worker architecture**: one worker per queue shard, with session/NAT/policy/FIB handled in Rust
-- **AF_XDP fast path**: current code supports both copy and zero-copy modes depending on driver/path behavior
-- **Kernel pass-through**: cpumap-assisted delivery keeps local/kernel-owned traffic out of the AF_XDP fast path
-- **Fail-closed admission**: unsupported userspace configs are gated or
-  fail closed rather than bypassing policy, NAT, or conntrack
-- **Degraded mode**: when helper/XSK forwarding is unavailable, the shim
-  keeps non-local transit out of the kernel forwarding path, passes only
-  proven local/control traffic, and drops degraded transit
-- **Best for**: all dataplane forwarding — there is no other runtime backend
-- **See**: [`docs/userspace-dataplane-architecture.md`](docs/userspace-dataplane-architecture.md) for the current architecture and [`docs/userspace-debug-map.md`](docs/userspace-debug-map.md) for the active debugging map
-
-**To tune the userspace dataplane:**
-
-```junos
-system {
-    dataplane {
-        binary /usr/local/sbin/xpf-userspace-dp;
-        workers 6;
-        ring-entries 8192;
-    }
-}
-```
-
-### Historical note: the retired eBPF dataplane
-
-The original dataplane ran in-kernel using 14 BPF programs chained via tail
-calls (XDP ingress `main -> screen -> zone -> conntrack -> policy -> nat ->
-nat64 -> forward`; TC egress `main -> screen_egress -> conntrack -> nat ->
-forward`) and reached 25+ Gbps on native XDP (mlx5, i40e, ice). That source
-(`bpf/xdp/*.c`, `bpf/tc/*.c`) was deleted in #1476; the pipeline is preserved
-only in git history (`git log -- bpf/xdp/ bpf/tc/`). It is no longer a
-selectable backend — see the hard-reject contract above.
-
-### Userspace Dataplane Capabilities
-
-| Capability | Userspace AF_XDP (the runtime path) |
-|------------|-----------|
-| Stateful forwarding | Yes |
-| Zone + global policies | Yes |
-| Application matching | Yes |
-| Source NAT (interface + pool) | Interface and pool mode yes; userspace `address-persistent` uses a documented userspace-v1 hash. Non-HA per-pool `persistent-nat` lease reuse and pool exhaustion counters are implemented in helper-local runtime state; HA/restart persistence and cross-backend new-flow parity remain outside the current contract |
-| Destination NAT | Yes |
-| Static NAT (1:1) | Yes |
-| NAT64 (IPv6↔IPv4) | Yes |
-| NPTv6 (RFC 6296) | Yes |
-| Screen/IDS (11 checks) | Yes; userspace SYN-cookie runtime is wired |
-| Firewall filters + policers | Filters yes; three-color policers admitted for the reviewed color-blind `then discard` slice; broader color-aware and non-drop action work is tracked as production hardening |
-| TCP MSS clamping | Yes |
-| GRE tunnel transit | Yes (passthrough) |
-| IPsec / XFRM | Yes (passthrough) |
-| VLANs (802.1Q) | Yes |
-| Flow export (NetFlow v9) | Yes |
-| HA cluster + session sync | Integrated; HA hardening tracked in open issues |
-| SYN cookie flood protection | Yes |
-| Throughput (25G mlx5) | See validation/perf docs for current results |
-
-The userspace dataplane covers the transit feature set in native Rust.
-SYN-cookie-dependent screen behavior runs in userspace with bounded
-SYN-ACK/RST replies and userspace status counters (#1374 closed). Port
-mirroring has bounded userspace runtime admission (#1376 closed). Three-color
-policers are admitted for the bounded color-blind `then discard` runtime
-slice (#1375 closed); remaining color-aware, non-drop action, and HA/restart
-continuity work is production hardening tracked in open issues such as
-[#1614](https://github.com/psaab/xpf/issues/1614) (CoS regression) and
-[#1608](https://github.com/psaab/xpf/issues/1608) (cold-path hardening), not
-the closed #1373 feature-gap trackers. Pool-mode SNAT is admitted,
-#1385 added userspace-v1
-`address-persistent` selection, and the runtime fails closed for unusable
-or exhausted source-NAT pool rules before forwarding. Non-HA per-pool
-`persistent-nat` lease reuse is helper-local userspace state; it does not
-survive helper restart and HA persistent-NAT configs remain gated. The exact
-admission boundary is documented in
-[`docs/userspace-dataplane-gaps.md`](docs/userspace-dataplane-gaps.md).
-
-## Architecture
-
-- **Go control plane** handles config compilation, session GC, management APIs, HA cluster, and routing
-- **Rust AF_XDP userspace dataplane** owns the only packet-forwarding path
-- **Retained eBPF surface** is the userspace XDP shim (`userspace-xdp/`) plus the shared `bpf/headers/*.h` map/struct bootstrap — not a forwarding backend
-- **Dual session entries** (forward + reverse) in the shared conntrack hash map
-- **Three-phase config compilation**: Junos AST → typed Go structs → userspace-dp control messages
-
-## Features
-
-### Firewall & Security
-- **Zone-based policies** with stateful inspection, address books, application matching, global policies
-- **NAT**: source (interface + pool, userspace-v1 address-persistent), destination (with hit counters), static 1:1, NAT64, NPTv6 (RFC 6296 stateless prefix translation)
-- **Dual-stack**: IPv4 + IPv6, DHCPv4/v6 clients, embedded Router Advertisement sender (replaces radvd), SLAAC
-- **Screen/IDS**: 11 checks (land, SYN flood, ping of death, teardrop, SYN-FIN, no-flag, winnuke, FIN-no-ACK, rate-limiting), SYN cookie flood protection (userspace-minted/validated SYN-ACK cookies replied through the AF_XDP TX path)
-- **Firewall filters**: policer (token bucket + three-color), lo0 filter, flexible match, port ranges, hit counters, logging, forwarding-class DSCP rewrite
-
-### Flow Processing
-- **TCP MSS clamping** in the userspace AF_XDP dataplane (all-tcp, ipsec-vpn, and GRE gre-in/gre-out)
-- **ALG control**, allow-dns-reply, allow-embedded-icmp
-- **Configurable timeouts** (per-application inactivity)
-- **Session management**: filtered clearing, idle time tracking, brief tabular view, aggregation reporting
-
-### Routing & Networking
-- **FRR integration**: static, OSPF, BGP, IS-IS, RIP, ECMP multipath, export/redistribute
-- **VRFs** with inter-VRF route leaking (next-table + rib-group)
-- **GRE tunnels**, XFRM interfaces, PBR (policy-based routing)
-- **VLANs**: 802.1Q tagging, trunk ports
-- **IPsec**: strongSwan config generation, IKE proposals, gateway compilation
-- **Full interface management**: xpfd owns ALL interfaces — renames via `.link` files, configures addresses/DHCP via `.network` files, brings down unconfigured interfaces
-
-### High Availability
-- **Chassis cluster** with ~60ms failover (30ms VRRP intervals)
-- **Native VRRPv3**: Go state machine, AF_PACKET, per-instance sockets, IPv6 NODAD, 30ms RETH advertisements, async GARP burst
-- **Bondless RETH**: VRRP on physical member interfaces, per-node virtual MAC (`02:bf:72:CC:RR:NN`), no Linux bonding required
-- **Session sync**: incremental 1s sweep + ring buffer + GC delete callbacks, TCP on fabric link
-- **Config sync**: primary → secondary with `${node}` variable expansion, reverse-sync on reconnect
-- **IPsec SA sync**: shared IKE/ESP state across cluster nodes
-- **Dual fabric links**: independent fab0/fab1 for redundancy (no bonding)
-- **Fabric cross-chassis forwarding**: `try_fabric_redirect()` redirects to peer when FIB fails for synced sessions
-- **Dataplane watchdogs**: userspace heartbeat checks fail closed on daemon/helper failure; if a persisted config still names the retired `ebpf` backend, the daemon runs in config-only mode until it is updated
-- **Readiness gate**: per-RG readiness (interfaces + VRRP) + hold timer gates election
-- **Planned shutdown**: near-instant takeover (priority-0 burst), failback ~130ms
-- **ISSU**: in-service software upgrade with rolling deploy
-- **RA lifecycle**: goodbye RAs (lifetime=0) on failover/startup to prevent stale IPv6 ECMP routes
-
-### Observability
-- **Syslog**: facility/severity/category filtering, structured RT_FLOW format, TCP/TLS transport, event mode local file
-- **NetFlow v9**: 1-in-N sampling
-- **Prometheus metrics** (`/metrics` endpoint)
-- **SNMP**: system + ifTable MIB
-- **RPM probes**, dynamic address feeds
-- **Dataplane buffer utilization** (`show system buffers`): AF_XDP UMEM/TX-ring capacity, CoS queued-byte capacity, helper-published session-table and flow-cache capacity
-- **LLDP**: link layer discovery protocol
-
-### Management
-- **Interactive CLI**: Junos-style prefix matching, tab completion, `?` help, pipe filters (`| match`, `| count`, `| except`)
-- **Remote CLI**: `cli` binary connects via gRPC with full tab/`?` parity
-- **gRPC API**: 48+ RPCs (config, sessions, stats, routes, IPsec, DHCP, cluster)
-- **REST API**: HTTP on port 8080 (health, Prometheus, config, full gRPC parity)
-- **Config management**: candidate/active with commit model, 50 rollback slots, `load override`/`load merge`, `show | display set`
-- **Configure mode protection**: blocked on secondary cluster nodes (RG0 primary is config authority)
-- **DHCP server**: Kea integration with lease display
-- **DHCP relay**: Option 82 support
-- **Event engine**: event-driven automation
-
-## Quick Start
+Install xpf onto an existing Debian/Ubuntu host. **Requires kernel ≥
+6.18** (the AF_XDP shim's verifier floor; ≥ 6.18 also gives full NAT64).
 
 ```bash
-make generate           # Generate the retained Rust AF_XDP userspace XDP shim object (post-#1476; no legacy bpf2go)
-make build              # Build xpfd daemon (embeds version from git)
-make build-ctl          # Build remote CLI client
-make build-userspace-dp # Build Rust AF_XDP dataplane binary (requires cargo)
-make test               # Run 1020+ tests across 24 packages
+# On the build host (Go + cargo toolchain):
+make deb                       # builds xpfd + xpf-userspace-dp + cli,
+                               # packages them into dist/deb/xpf_<ver>_amd64.deb
+                               # (+ the xpf-appliance metapackage)
+
+# On the target host:
+sudo apt install ./xpf_<ver>_amd64.deb     # ${shlibs:Depends} pulled in by apt
 ```
+
+The `xpf` package ships the binary set (`xpfd`, `xpf-userspace-dp`,
+`cli`), the day-0 config-drive loader, and the systemd units. The
+`postinst` stages the binaries and, on first install, creates the live
+`/usr/local/sbin/{xpfd,cli,xpf-userspace-dp}` symlinks and enables
+`xpfd`. For the full runtime stack (FRR, strongSwan, Kea, chrony,
+networking tooling) in one shot, install the **`xpf-appliance`**
+metapackage instead — e.g. `sudo apt install xpf-appliance` from a hosted
+apt repo.
+
+Then configure the firewall (see [Configuration](#configuration)) and:
+
+```bash
+sudo systemctl status xpfd
+cli                            # interactive Junos-style CLI
+```
+
+### (B) Incus appliance image
+
+Build (or fetch) the appliance image and deploy an instance from a YAML
+definition. The image carries everything xpf needs; there is no
+dependency matrix to install.
+
+```bash
+# 1. Build the image (or obtain dist/xpf-<ver>.{qcow2,incus-metadata.tar.gz}):
+make image                     # = python3 scripts/image/bake.py
+
+# 2. Import it into incus:
+incus image import dist/xpf-<ver>.incus-metadata.tar.gz \
+    dist/xpf-<ver>.qcow2 --alias xpf-appliance
+
+# 3. See your host NICs, then deploy from a definition:
+scripts/deploy/xpf-deploy.py inventory
+scripts/deploy/xpf-deploy.py deploy examples/deploy/standalone.yaml
+```
+
+`examples/deploy/standalone.yaml` is a working 3-NIC LAN→WAN NAT firewall
+(mgmt, LAN, WAN). The deployer validates the role↔position match, builds
+the day-0 config drive from the referenced `xpf.conf`, and launches the
+VM with the NICs attached in order. Then:
+
+```bash
+incus exec <name> -- cli       # reach the CLI immediately (incus-agent loader)
+```
+
+For HA pairs, SR-IOV/passthrough backings, the `launch` (no-YAML) form,
+and the fleet pattern, see
+[`docs/deploy-quickstart.md`](docs/deploy-quickstart.md) and
+[`examples/deploy/README.md`](examples/deploy/README.md). The image bake
+itself is documented in [`docs/install-images.md`](docs/install-images.md).
+
+### (C) KVM / QEMU / libvirt
+
+The baked qcow2 boots directly under libvirt/KVM or plain QEMU (UEFI or
+BIOS). The day-0 config is supplied as a CD-ROM ISO.
+
+```bash
+# Build the day-0 config drive from your xpf.conf (optional but recommended;
+# the builder runs the real commit-check and refuses an invalid config):
+python3 scripts/image/make_config_drive.py [-n 0|1] -o day0.iso my-xpf.conf
+
+# Boot directly with libvirt (NIC order = positional interface names):
+virt-install --name xpf1 --memory 4096 --vcpus 4 \
+    --import --disk path=dist/xpf-<ver>.qcow2 \
+    --disk path=day0.iso,device=cdrom \
+    --network bridge=br-mgmt --network bridge=br-trust \
+    --osinfo ubuntu26.04 --noautoconsole
+```
+
+Plain QEMU works the same way: `-drive file=dist/xpf-<ver>.qcow2`
+`-cdrom day0.iso`.
+
+You can also drive libvirt through the same deployer used for incus —
+`scripts/deploy/xpf-deploy.py --hypervisor libvirt deploy <file>.yaml`
+emits the `virt-install` command, including SR-IOV VF-pool and
+PCI-passthrough wiring. **vNIC / SR-IOV mapping:** the order NICs appear
+on the guest PCI bus is the order they are named (`fxp0`, then
+`ge-0/0/N`). For line-rate dataplane ports, pass through a whole PF
+(i40e/ice/mlx5, native XDP) or an **mlx5** VF (also native XDP); Intel
+VFs fall back to generic-mode XDP (~3-4× slower); virtio/bridge is fine
+for mgmt and modest WANs. The backing matrix is in
+[`docs/deploy-quickstart.md`](docs/deploy-quickstart.md) and the SR-IOV
+caveats in [`docs/critical-patterns.md`](docs/critical-patterns.md).
+
+### Day-0 config & first login
+
+Every path uses the same **day-0 config drive**: a volume labeled
+`xpf-config` (or any ISO9660 medium) with `xpf.conf` at its root
+(`juniper.conf` accepted as an alias), plus an optional `node-id` file
+(`0`/`1`) for cluster members. At first boot the loader re-validates it
+with the real commit-check gate and installs it as `/etc/xpf/xpf.conf`. A
+rejected config logs loudly (`journalctl -u xpf-day0-config`) and leaves
+the box factory-default (fxp0 DHCP + console login). Set SSH credentials
+via `system root-authentication` / `system login user ...` in that
+config. Full first-boot, credentials, upgrade, and recovery contract:
+[`docs/install-images.md`](docs/install-images.md).
+
+---
 
 ## Configuration
 
-xpf uses Junos-style configuration syntax:
+xpf uses Junos-style configuration syntax — both hierarchical `{ }`
+blocks and flat `set` commands:
 
 ```junos
 interfaces {
-    trust0 {
+    ge-0/0/0 {
         unit 0 {
             family inet {
                 address 10.0.1.1/24;
@@ -217,7 +170,7 @@ security {
     zones {
         security-zone trust {
             interfaces {
-                trust0;
+                ge-0/0/0.0;
             }
             host-inbound-traffic {
                 system-services {
@@ -244,151 +197,117 @@ security {
 }
 ```
 
-The config supports both hierarchical `{ }` blocks and flat `set` commands:
+The same thing as flat `set` commands:
 
 ```
-set interfaces trust0 unit 0 family inet address 10.0.1.1/24
-set security zones security-zone trust interfaces trust0
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24
+set security zones security-zone trust interfaces ge-0/0/0.0
 set security policies from-zone trust to-zone untrust policy allow-all match source-address any destination-address any application any
 set security policies from-zone trust to-zone untrust policy allow-all then permit
 ```
 
-## Management Interfaces
+Pre-flight any config on a build host with
+`xpfd check-config [-node-id 0|1] my-xpf.conf` (exit 0 PASS / 2 reject).
 
-- **Local CLI**: run `xpfd` in a TTY for interactive Junos-style shell
-- **Remote CLI**: `cli -addr <host>:50051` connects via gRPC
-- **gRPC API**: 48+ RPCs on port 50051 (config, sessions, stats, routes, IPsec, DHCP, cluster)
-- **REST API**: HTTP on port 8080 (health, Prometheus `/metrics`, config endpoints)
+## Management interfaces
 
-## Performance
+- **Local CLI**: run `cli` on the firewall for the interactive
+  Junos-style shell.
+- **Remote CLI**: `cli -addr <host>:50051` connects via gRPC with full
+  tab/`?` parity.
+- **gRPC API**: 48+ RPCs on port 50051 (config, sessions, stats, routes,
+  IPsec, DHCP, cluster).
+- **REST API**: HTTP on port 8080 (health, Prometheus `/metrics`, config
+  endpoints).
 
-- **Userspace dataplane** (the runtime path)
-  - **AF_XDP-based forwarding** with per-worker Rust session/NAT/policy/FIB processing
-  - **Copy or zero-copy mode** depending on NIC driver/path behavior
-  - **Kernel pass-through via cpumap** for local and other kernel-owned traffic
-  - **See** [`docs/userspace-ha-validation.md`](docs/userspace-ha-validation.md) and [`docs/userspace-perf-compare.md`](docs/userspace-perf-compare.md) for current validation and profiling workflow
-- **Cluster / control plane**
-  - **Hitless restarts** with zero packet loss
-  - **~60ms cluster failover** (30ms VRRP, ~97ms masterDown interval)
-  - **Near-instant planned shutdown** (priority-0 burst, peer takes over in ~1ms)
-- **Historical (retired eBPF dataplane, git history only)**
-  - **25+ Gbps** with native XDP (i40e/ice PF passthrough), **15.6 Gbps** with virtio-net
+---
 
-## Test Environment
-
-An Incus-based test environment provisions Debian VMs with FRR, strongSwan, and test containers:
+## Build from source (development)
 
 ```bash
-# Single VM (standalone firewall)
-make test-env-init   # One-time setup
-make test-vm         # Create VM
-make test-deploy     # Build + deploy + restart service
-make test-logs       # View daemon logs
-
-# Two-VM HA cluster (defaults to loss userspace cluster)
-make cluster-init    # Create networks + profile
-make cluster-create  # Launch xpf-userspace-fw0 + xpf-userspace-fw1 + LAN host
-make cluster-deploy  # Rolling deploy: secondary first, then primary (preserves traffic)
+make generate           # Rebuild the retained Rust AF_XDP shim — ONLY when
+                        # userspace-xdp/ changed (pinned toolchain + kernel
+                        # verifier gate, #1864)
+make build              # Build xpfd daemon (uses the git-tracked shim object;
+                        # does NOT require make generate)
+make build-ctl          # Build remote CLI client
+make build-userspace-dp # Build the Rust AF_XDP dataplane binary (needs cargo)
+make test               # Run the Go test suite
+make deb                # Package the binaries into a .deb
+make image              # Bake the appliance image (qcow2 + incus metadata)
 ```
 
-Userspace dataplane testing (requires mlx5 NICs on loss cluster):
+Requirements: Linux kernel ≥ 6.18, Go 1.22+, Rust stable, clang/llvm
+(only for `make generate`), FRR (routing), strongSwan (IPsec, optional),
+Kea (DHCP server, optional).
+
+The full development process (plan → review → code → review → merge) is
+in [`docs/development-workflow.md`](docs/development-workflow.md); the
+coding/review discipline is in
+[`docs/engineering-style.md`](docs/engineering-style.md).
+
+## Test environment
+
+An Incus-based test environment provisions Debian VMs with FRR,
+strongSwan, and test containers, plus a two-VM HA cluster.
 
 ```bash
-# Userspace HA cluster
-make cluster-deploy
-./scripts/userspace-ha-validation.sh --env test/incus/loss-userspace-cluster.env
-./scripts/userspace-perf-compare.sh
+make test-env-init      # One-time setup
+make test-vm            # Create a standalone VM
+make test-deploy        # Build + deploy + restart service
+
+make cluster-init       # HA: create networks + profile
+make cluster-create     # HA: launch fw0 + fw1 + LAN host
+make cluster-deploy     # HA: rolling deploy (secondary first)
+make test-failover      # iperf3 survives fw0 reboot (session sync + VRRP)
 ```
 
-### Cluster Deployment
+The test topology (standalone + HA interface maps) is in
+[`docs/network-topology.md`](docs/network-topology.md); test categories,
+procedures, and userspace validation are in
+[`docs/testing-procedures.md`](docs/testing-procedures.md) and
+[`docs/userspace-ha-validation.md`](docs/userspace-ha-validation.md).
 
-`make cluster-deploy` performs a **rolling deploy** to maintain traffic continuity:
+---
 
-1. Determines which node is currently secondary
-2. Deploys to the secondary (primary continues forwarding traffic)
-3. Waits for the secondary to sync sessions from the primary
-4. Deploys to the primary (upgraded secondary takes over via VRRP failover)
+## Where to go next
 
-To deploy to a single node: `make cluster-deploy NODE=0` or `make cluster-deploy NODE=1`.
+**Operating xpf**
 
-### Test Suite
+- [`docs/install-images.md`](docs/install-images.md) — appliance image
+  bake, first-boot contract, credentials, upgrades, recovery.
+- [`docs/deploy-quickstart.md`](docs/deploy-quickstart.md) +
+  [`examples/deploy/README.md`](examples/deploy/README.md) — the
+  positional naming contract, the YAML deployer, SR-IOV/passthrough,
+  standalone + HA examples, the fleet pattern.
+- [`docs/feature-coverage.md`](docs/feature-coverage.md) — the full
+  feature matrix (firewall, NAT, routing, HA, observability, management)
+  and the userspace dataplane capability/admission boundary.
 
-| Test | Command | Description |
-|------|---------|-------------|
-| Unit tests | `make test` | 1020+ Go tests across 24 packages |
-| Connectivity | `make test-connectivity` | End-to-end IPv4/IPv6 routing and SNAT |
-| Failover | `make test-failover` | iperf3 survives fw0 reboot (session sync + VRRP) |
-| Hard crash | `make test-ha-crash` | Force-stop, daemon stop, multi-cycle crash recovery |
-| Restart | `make test-restart-connectivity` | Zero packet loss during daemon restart |
-| Private RG | `./test/incus/test-private-rg.sh` | VRRP elimination via private-rg-election |
+**Understanding xpf**
 
-## Code Layout
+- [`docs/architecture.md`](docs/architecture.md) — control plane +
+  dataplane architecture, key design patterns, and the code layout.
+- [`docs/network-topology.md`](docs/network-topology.md) — test-VM and
+  HA-cluster interface maps.
+- [`docs/userspace-dataplane-architecture.md`](docs/userspace-dataplane-architecture.md)
+  — the comprehensive AF_XDP dataplane design.
+- [`docs/sync-protocol.md`](docs/sync-protocol.md) /
+  [`docs/fabric-cross-chassis-fwd.md`](docs/fabric-cross-chassis-fwd.md)
+  — HA session-sync wire protocol and fabric cross-chassis forwarding.
 
-| Path | Description |
-|------|-------------|
-| `bpf/headers/*.h` | Shared C structs/constants consumed by the retained Rust AF_XDP shim build and userspace-dp parity tests. The legacy `bpf/xdp/*.c` and `bpf/tc/*.c` source were deleted in #1476 |
-| `pkg/config/` | Junos parser, AST, typed config, compiler |
-| `pkg/cmdtree/` | Single source of truth for all CLI command trees |
-| `pkg/configstore/` | Candidate/active/commit/rollback, atomic DB persistence |
-| `pkg/dataplane/` | Runtime contracts, retained userspace shim embed/loader, and eBPF/DPDK retirement-error sentinels (#1476/#1525) |
-| `pkg/dataplane/userspace/` | Go manager for the Rust userspace dataplane |
-| `userspace-xdp/` | Retained Rust XDP shim that redirects packets into the AF_XDP userspace runtime |
-| `pkg/daemon/` | Daemon lifecycle, reconciliation, interface management |
-| `pkg/cluster/` | Chassis cluster HA (state machine, session sync, config sync) |
-| `pkg/vrrp/` | Native VRRPv3 state machine (30ms RETH advertisements) |
-| `pkg/ra/` | Embedded RA sender (replaces radvd) |
-| `pkg/cli/` | Interactive Junos-style CLI |
-| `pkg/conntrack/` | Session garbage collection (with HA delete sync) |
-| `pkg/logging/` | Ring buffer reader, event buffer, syslog client |
-| `pkg/dhcp/` | DHCPv4/DHCPv6 clients |
-| `pkg/frr/` | FRR config generation + managed section in frr.conf |
-| `pkg/networkd/` | systemd-networkd .link/.network file generation |
-| `pkg/routing/` | GRE tunnels, VRFs, XFRM interfaces, route leaking |
-| `pkg/ipsec/` | strongSwan config + SA queries |
-| `pkg/api/` | HTTP REST API + Prometheus collector |
-| `pkg/grpcapi/` | gRPC server + protobuf bindings |
-| `pkg/flowexport/` | NetFlow v9 exporter |
-| `pkg/feeds/` | Dynamic address feed fetcher |
-| `pkg/dhcpserver/` | Kea DHCP server management |
-| `pkg/dhcprelay/` | DHCP relay with Option 82 |
-| `pkg/eventengine/` | Event-driven automation engine |
-| `pkg/rpm/` | RPM probe manager |
-| `pkg/snmp/` | SNMP agent (system + ifTable MIB) |
-| `pkg/lldp/` | LLDP protocol |
-| `proto/xpf/v1/` | Protobuf service definition |
-| `cmd/xpfd/` | Daemon main binary |
-| `cmd/cli/` | Remote CLI client binary |
-| `userspace-dp/` | Rust AF_XDP userspace dataplane binary |
-| `docs/` | Protocol docs, test plans, feature gaps |
-| `test/incus/` | Test environment scripts and configs |
+**Developing xpf**
 
-## Documentation
+- [`docs/development-workflow.md`](docs/development-workflow.md) — how
+  changes land.
+- [`docs/engineering-style.md`](docs/engineering-style.md) +
+  [`docs/critical-patterns.md`](docs/critical-patterns.md) — coding/review
+  discipline and the project-specific gotchas (byte order, struct
+  alignment, BPF verifier, SR-IOV/XDP, interface management).
+- [`docs/config-schema.md`](docs/config-schema.md) — how to add a
+  config-mode typed leaf.
+- [`docs/feature-gaps.md`](docs/feature-gaps.md) — vSRX feature parity
+  tracking.
 
-See `docs/` for detailed design documents:
-- `sync-protocol.md` — Cluster session sync wire protocol and algorithms
-- `fabric-cross-chassis-fwd.md` — Fabric link cross-chassis forwarding design
-- `ha-cluster.conf` — Unified HA cluster config with `${node}` variable expansion
-- `testing-procedures.md` — Test categories, procedures, and debugging tips
-- `phases.md` — Development phase history (40+ sprints)
-- `bugs.md` — Bug tracker with root cause analysis
-- `optimizations.md` — Performance profiling and optimization notes
-- `test_env.md` — Test topology and validation steps
-- `feature-gaps.md` — vSRX feature parity tracking
-- `userspace-dataplane-architecture.md` — Comprehensive userspace AF_XDP dataplane architecture
-- `userspace-debug-map.md` — Active file/function map for userspace forwarding and debugging
-- `xdp-io-uring-userspace-dataplane.md` — Original userspace dataplane design document
-- `shared-umem-plan.md` — Cross-NIC shared UMEM design and validation plan
-- `userspace-ha-validation.md` — HA failover validation procedures
-- `userspace-perf-compare.md` — Throughput benchmarking methodology
-- `userspace-dnat-plan.md` — Destination NAT implementation plan for userspace dataplane
-- `userspace-dataplane-gaps.md` — Current userspace AF_XDP capability/admission boundary
-
-## Requirements
-
-- Linux kernel 6.12+ (6.18+ recommended for full NAT64 support)
-- Go 1.22+
-- clang/llvm (for generating the retained Rust AF_XDP userspace XDP shim object)
-- Rust stable (for the primary userspace dataplane)
-- FRR (for routing protocol integration)
-- strongSwan (for IPsec, optional)
-- Kea (for DHCP server, optional)
+A fuller index of design docs is in
+[`docs/README.md`](docs/README.md).

--- a/_Log.md
+++ b/_Log.md
@@ -5460,3 +5460,7 @@ top.
   pkg/dataplane/compiler_iface.go, protected_iface_test.go;
   pkg/config/types_system.go; pkg/configstore/README.md;
   docs/refactoring-audit-current.txt.
+
+- **Timestamp**: 2026-06-16
+  - **Action**: README getting-started restructure (PR #1937) — rewrote README into install/getting-started guide (3 paths: .deb, incus image, kvm/libvirt) cross-checked against Makefile deb/image targets, debian/control+postinst, scripts/image/bake.py + make_config_drive.py, scripts/deploy/xpf-deploy.py. Moved deep reference content into new docs/architecture.md, docs/feature-coverage.md, docs/network-topology.md, docs/critical-patterns.md, docs/README.md. Docs-only.
+  - **File(s)**: README.md, docs/architecture.md, docs/feature-coverage.md, docs/network-topology.md, docs/critical-patterns.md, docs/README.md, docs/pr/readme-getting-started/reviewer-ids.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,88 @@
+# xpf documentation index
+
+Start with the top-level [`../README.md`](../README.md) for getting
+started (install/run via the `.deb`, an incus appliance image, or
+KVM/QEMU/libvirt). This index points at the focused reference and design
+docs.
+
+## Getting started / operating
+
+- [`install-images.md`](install-images.md) — appliance image bake,
+  first-boot contract, credentials, upgrades, recovery.
+- [`deploy-quickstart.md`](deploy-quickstart.md) — the positional naming
+  contract and the YAML deployer (`scripts/deploy/xpf-deploy.py`),
+  standalone + HA, incus + libvirt, SR-IOV/passthrough.
+  ([`../examples/deploy/README.md`](../examples/deploy/README.md) is the
+  full reference.)
+- [`image-validation.md`](image-validation.md) — image validation runbook.
+
+## Reference
+
+- [`architecture.md`](architecture.md) — control plane + dataplane
+  architecture, key design patterns, code layout.
+- [`feature-coverage.md`](feature-coverage.md) — full feature matrix +
+  userspace dataplane capability/admission boundary.
+- [`network-topology.md`](network-topology.md) — test-VM and HA-cluster
+  interface maps.
+- [`critical-patterns.md`](critical-patterns.md) — project-specific
+  gotchas (byte order, struct alignment, BPF verifier, SR-IOV/XDP,
+  interface management, HA timing).
+- [`config-schema.md`](config-schema.md) — config-mode set/delete grammar
+  and how to add a typed leaf.
+- [`feature-gaps.md`](feature-gaps.md) / [`vsrx-gaps.md`](vsrx-gaps.md) —
+  vSRX feature parity tracking.
+
+## Dataplane (userspace AF_XDP)
+
+- [`userspace-dataplane-architecture.md`](userspace-dataplane-architecture.md)
+  — comprehensive AF_XDP dataplane architecture.
+- [`userspace-debug-map.md`](userspace-debug-map.md) — active
+  file/function map for forwarding and debugging.
+- [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md) — current
+  capability/admission boundary.
+- [`xdp-io-uring-userspace-dataplane.md`](xdp-io-uring-userspace-dataplane.md)
+  — original userspace dataplane design.
+- [`shared-umem-plan.md`](shared-umem-plan.md) — cross-NIC shared UMEM
+  design.
+
+## High availability
+
+- [`sync-protocol.md`](sync-protocol.md) — cluster session-sync wire
+  protocol and algorithms.
+- [`session-sync-architecture.md`](session-sync-architecture.md) /
+  [`session-sync-design.md`](session-sync-design.md) — session sync
+  design.
+- [`fabric-cross-chassis-fwd.md`](fabric-cross-chassis-fwd.md) — fabric
+  link cross-chassis forwarding.
+- [`in-place-upgrade.md`](in-place-upgrade.md) — in-service upgrade.
+- [`userspace-ha-validation.md`](userspace-ha-validation.md) — HA
+  failover validation procedures.
+
+## Performance & CoS
+
+- [`userspace-perf-compare.md`](userspace-perf-compare.md) — throughput
+  benchmarking methodology.
+- [`fairness-regimes.md`](fairness-regimes.md) — per-flow fairness
+  regimes and CoV floors.
+- [`cos-traffic-shaping.md`](cos-traffic-shaping.md) — class-of-service
+  traffic shaping.
+- [`optimizations.md`](optimizations.md) — performance profiling and
+  optimization notes.
+
+## Development & process
+
+- [`development-workflow.md`](development-workflow.md) — plan → review →
+  code → review → merge.
+- [`engineering-style.md`](engineering-style.md) — coding/review
+  discipline, hot-path rules, review severity.
+- [`testing-procedures.md`](testing-procedures.md) /
+  [`testing.md`](testing.md) — test categories and procedures.
+- [`phases.md`](phases.md) — development phase history.
+- [`bugs.md`](bugs.md) — bug tracker with root-cause analysis.
+
+## CLI reference
+
+- [`junos-cli-reference.md`](junos-cli-reference.md) — operational CLI
+  reference.
+- [`junos-config-display-reference.md`](junos-config-display-reference.md)
+  — config display reference.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ docs.
   userspace dataplane capability/admission boundary.
 - [`network-topology.md`](network-topology.md) — test-VM and HA-cluster
   interface maps.
+- [`test_env.md`](test_env.md) — test topology and validation steps.
 - [`critical-patterns.md`](critical-patterns.md) — project-specific
   gotchas (byte order, struct alignment, BPF verifier, SR-IOV/XDP,
   interface management, HA timing).
@@ -40,6 +41,8 @@ docs.
   file/function map for forwarding and debugging.
 - [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md) — current
   capability/admission boundary.
+- [`userspace-dnat-plan.md`](userspace-dnat-plan.md) — destination NAT
+  implementation plan for the userspace dataplane.
 - [`xdp-io-uring-userspace-dataplane.md`](xdp-io-uring-userspace-dataplane.md)
   — original userspace dataplane design.
 - [`shared-umem-plan.md`](shared-umem-plan.md) — cross-NIC shared UMEM
@@ -57,6 +60,8 @@ docs.
 - [`in-place-upgrade.md`](in-place-upgrade.md) — in-service upgrade.
 - [`userspace-ha-validation.md`](userspace-ha-validation.md) — HA
   failover validation procedures.
+- `ha-cluster-userspace.conf` — the unified HA cluster config with
+  `${node}` variable expansion (used by the loss userspace cluster).
 
 ## Performance & CoS
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,182 @@
+# xpf architecture
+
+xpf is a Junos-style stateful firewall that replicates Juniper vSRX
+capabilities. It has two halves:
+
+- A **Go control plane** (`xpfd`) that compiles Junos configuration,
+  manages sessions, drives HA, programs routing, and serves the CLI and
+  APIs.
+- A **Rust AF_XDP userspace dataplane** (`xpf-userspace-dp`) that is the
+  only runtime packet-forwarding path.
+
+## Dataplane: the runtime forwarding path
+
+> Dataplane notice (#1373, complete): the eBPF dataplane retirement is
+> done. The Rust AF_XDP userspace dataplane is the only runtime
+> forwarding path. Explicit `system dataplane-type ebpf` is hard-rejected
+> at commit (`ErrEBPFDataplaneRetired`) and at runtime
+> (`ErrEBPFBackendRetired`); use `set system dataplane-type userspace`, or
+> omit the knob for the default. The legacy BPF source (`bpf/xdp/*.c`,
+> `bpf/tc/*.c`) was deleted in #1476; the only retained eBPF artifacts are
+> the userspace XDP shim (`userspace-xdp/`) and the shared
+> `bpf/headers/*.h` map/struct bootstrap.
+
+A Rust forwarding engine receives packets via AF_XDP sockets and
+processes them in userspace. A Rust XDP shim stamps metadata, redirects
+transit traffic into AF_XDP, and hands proven local/control traffic back
+to the kernel. If helper/XSK forwarding is degraded, non-local transit
+fails closed in both compat and strict modes instead of bypassing
+policy, NAT, or conntrack.
+
+```
+NIC → XDP shim (redirect transit, pass local/control, drop degraded transit)
+    → AF_XDP socket
+    → Rust worker thread (session → policy → NAT → FIB → TX)
+    → AF_XDP TX ring → NIC
+```
+
+- **Per-worker architecture**: one worker per queue shard, with
+  session/NAT/policy/FIB handled in Rust.
+- **AF_XDP fast path**: supports both copy and zero-copy modes depending
+  on driver/path behavior.
+- **Kernel pass-through**: cpumap-assisted delivery keeps local/kernel-owned
+  traffic out of the AF_XDP fast path.
+- **Fail-closed admission**: unsupported userspace configs are gated or
+  fail closed rather than bypassing policy, NAT, or conntrack.
+- **Degraded mode**: when helper/XSK forwarding is unavailable, the shim
+  keeps non-local transit out of the kernel forwarding path, passes only
+  proven local/control traffic, and drops degraded transit.
+
+The parser still *accepts* the `ebpf` token so that
+`load merge`/`load override` of a pre-retirement config does not
+syntax-error during a rolling upgrade — but `commit check` then fails
+with the retirement error, and the remediation is
+`set system dataplane-type userspace`. If a persisted config still names
+`ebpf` on startup, the daemon runs in config-only mode until the operator
+updates it.
+
+To tune the userspace dataplane:
+
+```junos
+system {
+    dataplane {
+        binary /usr/local/sbin/xpf-userspace-dp;
+        workers 6;
+        ring-entries 8192;
+    }
+}
+```
+
+See [`userspace-dataplane-architecture.md`](userspace-dataplane-architecture.md)
+for the full architecture and [`userspace-debug-map.md`](userspace-debug-map.md)
+for the active debugging map. The current admission boundary is tracked
+in [`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md).
+
+### Historical note: the retired eBPF dataplane
+
+The original dataplane ran in-kernel using 14 BPF programs chained via
+tail calls (XDP ingress `main → screen → zone → conntrack → policy →
+nat → nat64 → forward`; TC egress `main → screen_egress → conntrack →
+nat → forward`) and reached 25+ Gbps on native XDP (mlx5, i40e, ice).
+That source (`bpf/xdp/*.c`, `bpf/tc/*.c`) was deleted in #1476; the
+pipeline is preserved only in git history (`git log -- bpf/xdp/ bpf/tc/`).
+It is no longer a selectable backend.
+
+> DPDK dataplane retired in #1525. Do not add new DPDK code. The
+> `dpdk_worker/` C tree and `pkg/dataplane/dpdk/` Go manager were removed
+> in #1527/#1528.
+
+## Key design patterns
+
+- **Go control plane** handles config compilation, session GC, management
+  APIs, HA cluster, and routing.
+- **Rust AF_XDP userspace dataplane** owns the only packet-forwarding path.
+- **Retained eBPF surface** is the userspace XDP shim (`userspace-xdp/`)
+  plus the shared `bpf/headers/*.h` map/struct bootstrap — not a
+  forwarding backend.
+- **Userspace AF_XDP shim** (`userspace-xdp/src/lib.rs`): per-CPU binding
+  arrays steer packets from native XDP to userspace queues.
+- **Dual session entries** (forward + reverse) in the shared conntrack
+  hash map back HA session-sync.
+- **Three-phase config compilation**: Junos AST → typed Go structs →
+  userspace-dp control messages (no eBPF map writes after #1476).
+- **FRR-managed routing**: all routes (static, DHCP, per-VRF) live in a
+  managed section in `/etc/frr/frr.conf`.
+- **Full interface management**: xpfd owns ALL interfaces on the firewall
+  — renames them via `.link` files, configures addresses/DHCP via
+  `.network` files, and brings down unconfigured interfaces.
+
+## Command trees (two-SSOT split, #1319)
+
+`pkg/cmdtree/tree.go` is the single source of truth for the
+**operational** tree (`run`/`show`/`clear`/`request`/…): tab completion
+and `?` help across local CLI, remote CLI, and gRPC. The **config-mode
+`set`/`delete`/`show`/`edit` grammar** (structural completion, flat-set
+token grouping, value-slot `?` completion, and commit-check typed-leaf
+validation) is owned by `config.setSchema` in `pkg/config/schema.go`
+(completion helpers in `pkg/config/schema_complete.go`) plus
+`config.SchemaValidate` in `pkg/config/schema_walk.go` — NOT cmdtree.
+Add a config-mode typed leaf by editing `setSchema` (see
+[`config-schema.md`](config-schema.md)); add an operational command by
+editing cmdtree.
+
+## APIs
+
+- **gRPC** on `127.0.0.1:50051` — 48+ RPCs (config, sessions, stats,
+  routes, IPsec, DHCP, cluster).
+- **HTTP REST** on `127.0.0.1:8080` — health, Prometheus `/metrics`,
+  config endpoints, full gRPC parity.
+- **CLI** — interactive Junos-style with tab completion, `?` help, pipe
+  filters (`| match`, `| count`, `| except`).
+- **Remote CLI** — the `cli` binary connects via gRPC with full tab/`?`
+  parity.
+
+## Code layout
+
+| Path | Description |
+|------|-------------|
+| `bpf/headers/*.h` | Shared C structs/constants consumed by the retained Rust AF_XDP shim build and userspace-dp parity tests. The legacy `bpf/xdp/*.c` and `bpf/tc/*.c` source were deleted in #1476 |
+| `pkg/config/` | Junos parser, AST, typed config, compiler |
+| `pkg/cmdtree/` | Single source of truth for the operational CLI command tree |
+| `pkg/configstore/` | Candidate/active/commit/rollback, atomic DB persistence, JSONL audit journal |
+| `pkg/dataplane/` | Runtime contracts, retained userspace shim embed/loader, eBPF/DPDK retirement-error sentinels (#1476/#1525) |
+| `pkg/dataplane/userspace/` | Go manager for the Rust userspace dataplane |
+| `userspace-xdp/` | Retained Rust XDP shim that redirects packets into the AF_XDP userspace runtime |
+| `userspace-dp/` | Rust AF_XDP userspace dataplane binary |
+| `pkg/daemon/` | Daemon lifecycle, reconciliation, interface management |
+| `pkg/cluster/` | Chassis cluster HA (state machine, session sync, config sync, IPsec SA sync) |
+| `pkg/vrrp/` | Native VRRPv3 state machine (30ms RETH advertisements) |
+| `pkg/ra/` | Embedded RA sender (replaces radvd) |
+| `pkg/cli/` | Interactive Junos-style CLI |
+| `pkg/conntrack/` | Session garbage collection (with HA delete sync) |
+| `pkg/logging/` | Ring buffer reader, event buffer, syslog client |
+| `pkg/dhcp/` | DHCPv4/DHCPv6 clients |
+| `pkg/frr/` | FRR config generation + managed section in frr.conf |
+| `pkg/networkd/` | systemd-networkd .link/.network file generation |
+| `pkg/routing/` | GRE tunnels, VRFs, XFRM interfaces, rib-group + next-table route leaking |
+| `pkg/ipsec/` | strongSwan config + SA queries |
+| `pkg/api/` | HTTP REST API + Prometheus collector |
+| `pkg/grpcapi/` | gRPC server + protobuf bindings |
+| `pkg/flowexport/` | NetFlow v9 exporter |
+| `pkg/feeds/` | Dynamic address feed fetcher |
+| `pkg/dhcpserver/` | Kea DHCP server management |
+| `pkg/dhcprelay/` | DHCP relay with Option 82 |
+| `pkg/eventengine/` | Event-driven automation engine |
+| `pkg/rpm/` | RPM probe manager |
+| `pkg/snmp/` | SNMP agent (system + ifTable MIB) |
+| `pkg/lldp/` | LLDP protocol |
+| `proto/xpf/v1/` | Protobuf service definition |
+| `cmd/xpfd/` | Daemon main binary |
+| `cmd/cli/` | Remote CLI client binary |
+| `docs/` | Protocol docs, design notes, test plans, feature gaps |
+| `test/incus/` | Test environment scripts and configs |
+
+## See also
+
+- [`engineering-style.md`](engineering-style.md) — coding/review
+  discipline, hot-path allocation rules, and the project-specific gotchas
+  (byte order, struct alignment, BPF verifier, SR-IOV/XDP, interface
+  management) that repeatedly bite.
+- [`network-topology.md`](network-topology.md) — test-VM and HA-cluster
+  interface maps.
+- [`feature-coverage.md`](feature-coverage.md) — the full feature matrix.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,9 +174,10 @@ editing cmdtree.
 ## See also
 
 - [`engineering-style.md`](engineering-style.md) — coding/review
-  discipline, hot-path allocation rules, and the project-specific gotchas
-  (byte order, struct alignment, BPF verifier, SR-IOV/XDP, interface
-  management) that repeatedly bite.
+  discipline and hot-path allocation rules.
+- [`critical-patterns.md`](critical-patterns.md) — the project-specific
+  gotchas (byte order, struct alignment, BPF verifier, SR-IOV/XDP,
+  interface management) that repeatedly bite.
 - [`network-topology.md`](network-topology.md) — test-VM and HA-cluster
   interface maps.
 - [`feature-coverage.md`](feature-coverage.md) — the full feature matrix.

--- a/docs/critical-patterns.md
+++ b/docs/critical-patterns.md
@@ -1,0 +1,136 @@
+# xpf critical patterns / gotchas
+
+Project-specific traps that repeatedly bite when working on xpf. The
+broader coding and review discipline (hot-path allocation rules, review
+severity, PR discipline) lives in
+[`engineering-style.md`](engineering-style.md) — read that first for
+non-trivial code. This page is the quick-reference gotcha list.
+
+## Byte order
+
+- Use `binary.NativeEndian.Uint32(ip4)` for BPF `__be32` fields — **NOT**
+  `BigEndian`.
+- cilium/ebpf serializes map values in native endian; IP bytes are
+  already in network order.
+
+## C/Go struct alignment
+
+- When mirroring C structs in Go for cilium/ebpf, always match `sizeof`
+  in C.
+- Add trailing `Pad [N]byte` fields to reach the C compiler's struct
+  alignment.
+
+## Parser dual AST shape & set-syntax testing
+
+- Hierarchical `family inet { dhcp; }` → `Node{Keys:["family","inet"]}`
+  with children.
+- Flat `set interfaces eth0 unit 0 family inet dhcp` →
+  `Node{Keys:["family"]}` with child `Node{Keys:["inet"]}`.
+- The compiler must handle **both** shapes.
+- **Testing flat set syntax:** ALWAYS use `ParseSetCommand()` +
+  `tree.SetPath()` loop, NEVER `NewParser()` — the parser treats newlines
+  as whitespace and will merge all set lines into one giant node.
+
+## BPF verifier (retained AF_XDP shim)
+
+- Branch merges lose packet range — re-read `ctx->data`/`ctx->data_end`
+  after branches.
+- Combined stack limit is 512 bytes across call frames — use
+  `__noinline` and scratch maps.
+- Variable-offset pkt pointer: the verifier refuses range tracking when
+  `var_off` is wide (0xffff) — use a constant-offset from a validated
+  pointer instead.
+- **Narrowing meta offsets**: when using `meta->l3_offset` (u16) for
+  packet pointer math, mask with `& 0x3F` to narrow `var_off` so the
+  verifier can track range.
+- `__u16` causes sign-extension (`smin=-32768`) — fails for pkt pointer
+  math.
+- `iter.Next(&key, nil)` crashes in cilium/ebpf v0.20 — always use
+  `var val []byte`.
+- The shim's verifier floor is kernel ≥ 6.18 (NAT64 complexity fails on
+  6.12). The image bake asserts this (#1864).
+
+## TTY detection
+
+- Use `unix.IoctlGetTermios(fd, TCGETS)` — **not** `os.ModeCharDevice`
+  (`/dev/null` is a CharDevice).
+
+## Interface management (networkd)
+
+- **xpfd manages ALL interfaces** on the firewall — no external networkd
+  configs needed. Every interface must be defined in the config and
+  assigned to a security zone; interfaces not in the config are brought
+  down (`ActivationPolicy=always-down`).
+- VRF devices and tunnel interfaces created by the daemon are excluded
+  from unmanaged detection.
+- **`.link` files** (prefix `10-xpf-`) rename kernel names
+  (`enp7s0` → `ge-0-0-0`). Startup naming is
+  `enumerateAndRenameInterfaces()` in `pkg/daemon/linksetup.go`.
+  - Non-RETH interfaces match by `MACAddress=` (MAC is stable).
+  - RETH member interfaces match by `OriginalName=` (PCI kernel name) —
+    MAC alternates between physical (boot) and virtual (daemon), so
+    `MACAddress=` is unreliable. `ensureRethLinkOriginalName()`
+    auto-fixes stale files.
+- **`.network` files** configure addresses, DHCP avoidance, RA disable,
+  VLAN parent flags. `KeepConfiguration=static` on RETH interfaces
+  preserves VRRP VIPs across `networkctl reload`.
+- DHCP interfaces: the daemon's DHCP client manages the address; address
+  reconciliation is skipped. DHCP-learned default routes get admin
+  distance 200 in FRR.
+
+## XDP on SR-IOV interfaces
+
+The line-rate behavior is coupled to the NIC driver exposed to the VM.
+
+- **iavf (Intel VF driver) has NO native XDP support** — only
+  generic/SKB mode works (full `sk_buff` per packet, ~16% CPU overhead).
+  Throughput drops from 25+ Gbps to ~6.8 Gbps.
+- **i40e/ice/mlx5 (PF driver) have native XDP** — driver-mode XDP
+  processes packets before SKB allocation.
+- **`bpf_redirect_map` requires `ndo_xdp_xmit` on the target** — you
+  cannot redirect from native XDP to an interface that lacks native XDP;
+  the redirect silently fails. Mixing native+generic interfaces in a
+  redirect set does not work.
+- **XDP on a PF does NOT see VF traffic** — SR-IOV hardware switching
+  delivers VF packets directly to VFs, bypassing the PF's XDP program.
+- **mlx5 SR-IOV VFs DO support native XDP** and exact/masked ntuple
+  steering — this is the loss-cluster reference shape (each VF exposes 6
+  combined RX queues → 6 workers).
+- **PF passthrough claims the whole NIC** — no VFs available to other
+  VMs. For multi-VM setups, VF passthrough is the only option (mlx5 VFs
+  keep native XDP; Intel VFs fall to generic).
+
+See the deploy backing table in
+[`deploy-quickstart.md`](deploy-quickstart.md) for which backing to pick.
+
+## Chassis cluster (HA)
+
+- **Failover timing**: ~60ms with 30ms VRRP intervals
+  (`masterDownInterval` ~97ms); configurable via
+  `set chassis cluster reth-advertise-interval <ms>`.
+- **Planned shutdown**: burst of 3× priority-0 adverts; peer takes over
+  in ~1ms.
+- **VRRP advertisement**: RETH instances default 30ms; `AdvertiseInterval`
+  is milliseconds internally, centiseconds on wire per RFC 5798.
+- **Async GARP**: `becomeMaster()` runs GARP in a goroutine; critical
+  path is addVIPs → sendAdvert → emitEvent (sync), then `go sendGARP()`.
+- **Fabric forwarding**: the userspace dataplane redirects packets for
+  peer-owned synced sessions over the fabric link
+  (`resolve_fabric_redirect()` / `ingress_is_fabric()` in
+  `userspace-dp/src/afxdp/forwarding/mod.rs`; see
+  [`fabric-cross-chassis-fwd.md`](fabric-cross-chassis-fwd.md)).
+- **RETH virtual MAC**: per-node `02:bf:72:CC:RR:NN`; `programRethMAC()`
+  does link DOWN → set MAC → link UP, then `ReconcileVIPs()` re-adds
+  VRRP VIPs.
+- **Sync hold**: VRRP starts with `preempt=false`, released after bulk
+  session sync (or 10s timeout); `preemptNowCh` triggers instant
+  preemption.
+- **Heartbeat**: 200ms interval, threshold 5 (1s detection).
+
+## Shutdown
+
+- FRR reloads run `frr-reload.py` DIRECTLY (15s context per leg) — NEVER
+  `systemctl reload frr`: FRR 10.6's ExecReload bounces watchfrr and ends
+  with systemd SIGKILLing FRR (#1880).
+- The systemd unit has `TimeoutStopSec=20` as a safety net,
+  `RestartSec=1`.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,10 +1,11 @@
 # Development workflow — plan, review, code, review, merge
 
-> Deprecation notice (#1373): new dataplane work and routine forwarding
-> validation target the Rust AF_XDP userspace dataplane by default. Omitted
-> runtime configuration now selects userspace. The legacy eBPF dataplane
-> remains in-tree for explicit compatibility and regression coverage during the
-> staged retirement. Later phases own source, loader, build, and CLI removals.
+> Retirement notice (#1373, complete): all dataplane work targets the Rust
+> AF_XDP userspace dataplane — it is the only runtime forwarding path.
+> Omitted runtime configuration selects userspace. The legacy eBPF backend
+> is retired: its XDP/TC source was deleted in #1476 and `system
+> dataplane-type ebpf` is hard-rejected at commit and runtime. The only
+> retained eBPF artifact is the userspace XDP shim (`userspace-xdp/`).
 
 How non-trivial changes land in this repo. Roles and agent-boundary
 rules are in `AGENTS.md`; read that first. This doc is the process

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -1,0 +1,151 @@
+# xpf feature coverage
+
+xpf replicates the Juniper vSRX feature set on a Rust AF_XDP userspace
+dataplane driven by a Go control plane. vSRX parity tracking lives in
+[`feature-gaps.md`](feature-gaps.md) and [`vsrx-gaps.md`](vsrx-gaps.md);
+the userspace dataplane admission boundary is in
+[`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md).
+
+## Firewall & security
+
+- **Zone-based policies** with stateful inspection, address books,
+  application matching (multi-term apps), global policies, filtered
+  session clearing.
+- **NAT**: source (interface + pool, userspace-v1 address-persistent),
+  destination (with hit counters), static 1:1, NAT64, NPTv6 (RFC 6296
+  stateless prefix translation).
+- **Dual-stack**: IPv4 + IPv6, DHCPv4/v6 clients, embedded Router
+  Advertisement sender (replaces radvd), SLAAC.
+- **Screen/IDS**: 11 checks (land, SYN flood, ping of death, teardrop,
+  SYN-FIN, no-flag, winnuke, FIN-no-ACK, rate-limiting), SYN cookie flood
+  protection (userspace-minted/validated SYN-ACK cookies replied through
+  the AF_XDP TX path).
+- **Firewall filters**: policer (token bucket + three-color), lo0 filter,
+  flexible match, port ranges, hit counters, logging, forwarding-class
+  DSCP rewrite.
+
+## Flow processing
+
+- **TCP MSS clamping** in the userspace AF_XDP dataplane (all-tcp,
+  ipsec-vpn, and GRE gre-in/gre-out).
+- **ALG control**, allow-dns-reply, allow-embedded-icmp.
+- **Configurable timeouts** (per-application inactivity).
+- **Session management**: filtered clearing, idle time tracking, brief
+  tabular view, aggregation reporting.
+
+## Routing & networking
+
+- **FRR integration**: static, OSPF, BGP, IS-IS, RIP, ECMP multipath,
+  export/redistribute.
+- **VRFs** with inter-VRF route leaking (next-table + rib-group).
+- **GRE tunnels**, XFRM interfaces, PBR (policy-based routing).
+- **Probe-driven WAN failover** (`services ip-monitoring` preferred-route
+  injection, #1827).
+- **VLANs**: 802.1Q tagging, trunk ports.
+- **IPsec**: strongSwan config generation, IKE proposals, gateway
+  compilation.
+- **Full interface management**: xpfd owns ALL interfaces — renames via
+  `.link` files, configures addresses/DHCP via `.network` files, brings
+  down unconfigured interfaces (see
+  [`network-topology.md`](network-topology.md) and the interface-management
+  notes in [`engineering-style.md`](engineering-style.md)).
+
+## High availability
+
+- **Chassis cluster** with ~60ms failover (30ms VRRP intervals).
+- **Native VRRPv3**: Go state machine, AF_PACKET, per-instance sockets,
+  IPv6 NODAD, 30ms RETH advertisements, async GARP burst, single-interface
+  tracking (nested `track-interface <if> priority-cost <n>`).
+- **Bondless RETH**: VRRP on physical member interfaces, per-node virtual
+  MAC (`02:bf:72:CC:RR:NN`), no Linux bonding required.
+- **Session sync**: incremental 1s sweep + ring buffer + GC delete
+  callbacks, TCP on fabric link.
+- **Config sync**: primary → secondary with `${node}` variable expansion,
+  reverse-sync on reconnect.
+- **IPsec SA sync**: shared IKE/ESP state across cluster nodes.
+- **Dual fabric links**: independent fab0/fab1 for redundancy (no
+  bonding).
+- **Fabric cross-chassis forwarding**: redirects to peer when FIB fails
+  for synced sessions — prevents TCP death on VRRP failback (see
+  [`fabric-cross-chassis-fwd.md`](fabric-cross-chassis-fwd.md)).
+- **Dataplane watchdogs**: userspace heartbeat fails closed on
+  daemon/helper failure; config naming the retired `ebpf` backend runs in
+  config-only mode until updated.
+- **Readiness gate**: per-RG readiness (interfaces + VRRP) + hold timer
+  gates election.
+- **Planned shutdown**: near-instant takeover (priority-0 burst);
+  failback ~130ms.
+- **ISSU**: in-service software upgrade with rolling deploy.
+- **RA lifecycle**: goodbye RAs (lifetime=0) on failover/startup to
+  prevent stale IPv6 ECMP routes.
+
+## Observability
+
+- **Syslog**: facility/severity/category filtering, structured RT_FLOW
+  format, TCP/TLS transport, event mode local file.
+- **NetFlow v9**: 1-in-N sampling.
+- **Prometheus metrics** (`/metrics` endpoint).
+- **SNMP**: system + ifTable MIB.
+- **RPM probes**, dynamic address feeds.
+- **Dataplane buffer utilization** (`show system buffers`): AF_XDP
+  UMEM/TX-ring capacity, CoS queued-byte capacity, helper-published
+  session-table and flow-cache capacity.
+- **LLDP**: link layer discovery protocol.
+
+## Management
+
+- **Interactive CLI**: Junos-style prefix matching, tab completion, `?`
+  help, pipe filters (`| match`, `| count`, `| except`).
+- **Remote CLI**: `cli` binary connects via gRPC with full tab/`?` parity.
+- **gRPC API**: 48+ RPCs (config, sessions, stats, routes, IPsec, DHCP,
+  cluster).
+- **REST API**: HTTP on port 8080 (health, Prometheus, config, full gRPC
+  parity).
+- **Config management**: candidate/active with commit model, 50 rollback
+  slots, `load override`/`load merge`, `show | display set`.
+- **Configure mode protection**: blocked on secondary cluster nodes (RG0
+  primary is config authority).
+- **DHCP server**: Kea integration with lease display.
+- **DHCP relay**: Option 82 support.
+- **Event engine**: event-driven automation.
+
+## Userspace dataplane capability matrix
+
+The userspace dataplane covers the transit feature set in native Rust.
+The exact admission boundary is documented in
+[`userspace-dataplane-gaps.md`](userspace-dataplane-gaps.md).
+
+| Capability | Userspace AF_XDP (the runtime path) |
+|------------|-----------|
+| Stateful forwarding | Yes |
+| Zone + global policies | Yes |
+| Application matching | Yes |
+| Source NAT (interface + pool) | Interface and pool mode yes; userspace `address-persistent` uses a documented userspace-v1 hash. Non-HA per-pool `persistent-nat` lease reuse and pool exhaustion counters are implemented in helper-local runtime state; HA/restart persistence and cross-backend new-flow parity remain outside the current contract |
+| Destination NAT | Yes |
+| Static NAT (1:1) | Yes |
+| NAT64 (IPv6↔IPv4) | Yes |
+| NPTv6 (RFC 6296) | Yes |
+| Screen/IDS (11 checks) | Yes; userspace SYN-cookie runtime is wired |
+| Firewall filters + policers | Filters yes; three-color policers admitted for the reviewed color-blind `then discard` slice; broader color-aware and non-drop action work is tracked as production hardening |
+| TCP MSS clamping | Yes |
+| GRE tunnel transit | Yes (passthrough) |
+| IPsec / XFRM | Yes (passthrough) |
+| VLANs (802.1Q) | Yes |
+| Flow export (NetFlow v9) | Yes |
+| HA cluster + session sync | Integrated; HA hardening tracked in open issues |
+| SYN cookie flood protection | Yes |
+| Throughput (25G mlx5) | See validation/perf docs for current results |
+
+SYN-cookie-dependent screen behavior runs in userspace with bounded
+SYN-ACK/RST replies and userspace status counters (#1374 closed). Port
+mirroring has bounded userspace runtime admission (#1376 closed).
+Three-color policers are admitted for the bounded color-blind
+`then discard` runtime slice (#1375 closed); remaining color-aware,
+non-drop action, and HA/restart continuity work is production hardening
+tracked in open issues such as
+[#1614](https://github.com/psaab/xpf/issues/1614) (CoS regression) and
+[#1608](https://github.com/psaab/xpf/issues/1608) (cold-path hardening),
+not the closed #1373 feature-gap trackers. Pool-mode SNAT is admitted,
+#1385 added userspace-v1 `address-persistent` selection, and the runtime
+fails closed for unusable or exhausted source-NAT pool rules before
+forwarding.

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -48,7 +48,7 @@ the userspace dataplane admission boundary is in
   `.link` files, configures addresses/DHCP via `.network` files, brings
   down unconfigured interfaces (see
   [`network-topology.md`](network-topology.md) and the interface-management
-  notes in [`engineering-style.md`](engineering-style.md)).
+  notes in [`critical-patterns.md`](critical-patterns.md)).
 
 ## High availability
 

--- a/docs/network-topology.md
+++ b/docs/network-topology.md
@@ -43,9 +43,10 @@ per-cluster wiring is canonical in `docs/ha-cluster-userspace.conf` and
 
 ```
 loss:xpf-userspace-fw{0,1} — node-id 0 / 1, /etc/xpf/node-id present:
-  NOTE: ge-* names below are node 0; node 1 substitutes FPC 7
-  (ge-7-0-1 / ge-7-0-2) per pkg/daemon/linksetup.go (fpc=7 for node 1)
-  and docs/ha-cluster-userspace.conf (node1: ge-7/0/1, ge-7/0/2).
+  NOTE: ge-* names below are node 0; node 1 substitutes FPC 7 for ALL
+  ge-* interfaces — the fabric parent ge-0-0-0 becomes ge-7-0-0, and the
+  dataplane VFs become ge-7-0-1 / ge-7-0-2 — per pkg/daemon/linksetup.go
+  (fpc=7 for node 1) and docs/ha-cluster-userspace.conf.
   Virtio (PCI bus 05-07, lower bus → lower vSRX name):
     enp5s0  → fxp0       DHCP                          — mgmt zone (SSH + ping)
     enp6s0  → em0        10.99.{0..12}.{1,2}           — cluster control plane / heartbeat

--- a/docs/network-topology.md
+++ b/docs/network-topology.md
@@ -4,8 +4,8 @@ This documents the interface maps for the two test environments. For how
 *deployed* appliances map vNICs/SR-IOV to interface names, see the
 positional naming contract in [`deploy-quickstart.md`](deploy-quickstart.md)
 and [`../examples/deploy/README.md`](../examples/deploy/README.md). For
-the SR-IOV/XDP driver caveats, see the "XDP on SR-IOV Interfaces" section
-of [`engineering-style.md`](engineering-style.md).
+the SR-IOV/XDP driver caveats, see the "XDP on SR-IOV interfaces" section
+of [`critical-patterns.md`](critical-patterns.md).
 
 All interfaces are managed by xpfd — renamed via `.link` files,
 configured via `.network` files. Startup naming by

--- a/docs/network-topology.md
+++ b/docs/network-topology.md
@@ -12,6 +12,12 @@ configured via `.network` files. Startup naming by
 `enumerateAndRenameInterfaces()` (`pkg/daemon/linksetup.go`) assigns
 vSRX names based on PCI bus order.
 
+> **Name form.** The interface maps below use the **Linux link / dash
+> form** (`ge-0-0-0`) — what `ip link` and `enumerateAndRenameInterfaces()`
+> produce. The **config and CLI use the slash form** (`ge-0/0/0`); the
+> config layer translates between the two. Use the slash form in `cli`
+> and in `xpf.conf`, the dash form in `ip`/`ethtool` on the box.
+
 ## Standalone VM (xpf-fw)
 
 No `/etc/xpf/node-id`, no `em0`:

--- a/docs/network-topology.md
+++ b/docs/network-topology.md
@@ -1,0 +1,64 @@
+# xpf test network topology
+
+This documents the interface maps for the two test environments. For how
+*deployed* appliances map vNICs/SR-IOV to interface names, see the
+positional naming contract in [`deploy-quickstart.md`](deploy-quickstart.md)
+and [`../examples/deploy/README.md`](../examples/deploy/README.md). For
+the SR-IOV/XDP driver caveats, see the "XDP on SR-IOV Interfaces" section
+of [`engineering-style.md`](engineering-style.md).
+
+All interfaces are managed by xpfd — renamed via `.link` files,
+configured via `.network` files. Startup naming by
+`enumerateAndRenameInterfaces()` (`pkg/daemon/linksetup.go`) assigns
+vSRX names based on PCI bus order.
+
+## Standalone VM (xpf-fw)
+
+No `/etc/xpf/node-id`, no `em0`:
+
+```
+  Virtio (PCI bus 05-08):
+    enp5s0  → fxp0       DHCP          — mgmt zone (SSH + ping)
+    enp6s0  → ge-0-0-0   10.0.1.10     — trust zone
+    enp7s0  → ge-0-0-1   10.0.2.10     — untrust zone
+    enp8s0  → ge-0-0-2   10.0.30.10    — dmz zone
+  i40e PCI passthrough (PCI bus 09+, always higher than virtio):
+    enp9s0f0np0   → ge-0-0-3  172.16.50.5  — wan zone (VLAN 50, IPv6)
+    enp101s0f1np1 → ge-0-0-4               — loss zone
+
+  Test containers:
+    trust-host    10.0.1.102  (2001:559:8585:bf01::102)  — xpf-trust bridge
+    untrust-host  10.0.2.102  (2001:559:8585:bf02::102)  — xpf-untrust bridge
+    dmz-host      10.0.30.101 (2001:559:8585:bf03::101)  — xpf-dmz bridge
+```
+
+## HA cluster (`loss:xpf-userspace-fw0/fw1`)
+
+Different topology from the standalone VM above. Do NOT extrapolate the
+standalone PCI map to the loss userspace cluster: the WAN interface there
+is `ge-0-0-2` (node 0 name — node 1 uses FPC 7, i.e. `ge-7-0-2`), not
+`ge-0-0-3`, and `ge-0-0-0` is the fabric IPVLAN parent (not WAN). The
+per-cluster wiring is canonical in `docs/ha-cluster-userspace.conf` and
+`test/incus/loss-userspace-cluster.env`.
+
+```
+loss:xpf-userspace-fw{0,1} — node-id 0 / 1, /etc/xpf/node-id present:
+  NOTE: ge-* names below are node 0; node 1 substitutes FPC 7
+  (ge-7-0-1 / ge-7-0-2) per pkg/daemon/linksetup.go (fpc=7 for node 1)
+  and docs/ha-cluster-userspace.conf (node1: ge-7/0/1, ge-7/0/2).
+  Virtio (PCI bus 05-07, lower bus → lower vSRX name):
+    enp5s0  → fxp0       DHCP                          — mgmt zone (SSH + ping)
+    enp6s0  → em0        10.99.{0..12}.{1,2}           — cluster control plane / heartbeat
+    enp7s0  → ge-0-0-0   fab0 IPVLAN parent            — fabric (xdpgeneric — fabric path only)
+  mlx5 SR-IOV VF (PCI bus 08-09 — native XDP):
+    enp8s0  → ge-0-0-1   reth1.0 (LAN, 10.0.61.1/24)   — LAN-side, mlx5_core xdp native
+    enp9s0  → ge-0-0-2   reth0 (WAN; VLAN 50 + 80)     — WAN-side, mlx5_core xdp native
+                         reth0.50  172.16.50.8/24      —   transit
+                         reth0.80  172.16.80.8/24      —   data path target VLAN
+```
+
+Smoke iperf3 target: `172.16.80.200` / `2001:559:8585:80::200` (on
+reth0.80 WAN path, AF_XDP zero-copy fast path). Per-class iperf3 servers
+live on ports 5200-5211 matching `test/incus/cos-iperf-config.set`. Do
+NOT use `172.16.100.x` — that reaches a different `loss:` uplink path
+capped at ~9-10 Gb/s.

--- a/docs/pr/readme-getting-started/reviewer-ids.md
+++ b/docs/pr/readme-getting-started/reviewer-ids.md
@@ -1,0 +1,9 @@
+# PR #1937 — reviewer task IDs
+
+DOCS-ONLY: README getting-started restructure + move reference content to docs/.
+
+- **AGY adversarial-review**: `adversarial-review-mqh8v4z5-l38w5l`
+  (background, base origin/master, cwd = worktree readme-gs).
+  Result: `~/.claude/plugins/data/agy-claude-code-agy/state/jobs/adversarial-review-mqh8v4z5-l38w5l.result.md`
+- **Codex**: codex-review plugin (impl review round) — see below for task id.
+- **Copilot**: requested via `gh pr edit 1937 --add-reviewer Copilot`.

--- a/docs/pr/readme-getting-started/reviewer-ids.md
+++ b/docs/pr/readme-getting-started/reviewer-ids.md
@@ -2,8 +2,14 @@
 
 DOCS-ONLY: README getting-started restructure + move reference content to docs/.
 
-- **AGY adversarial-review**: `adversarial-review-mqh8v4z5-l38w5l`
-  (background, base origin/master, cwd = worktree readme-gs).
-  Result: `~/.claude/plugins/data/agy-claude-code-agy/state/jobs/adversarial-review-mqh8v4z5-l38w5l.result.md`
-- **Codex**: codex-review plugin (impl review round) — see below for task id.
-- **Copilot**: requested via `gh pr edit 1937 --add-reviewer Copilot`.
+- **AGY adversarial-review**:
+  - round 1: `adversarial-review-mqh8v4z5-l38w5l`
+  - round 2 (re-review after fixes): `adversarial-review-mqh96ku5-9qlg7o`
+  - (background, base origin/master, cwd = worktree readme-gs). Results
+    under `~/.claude/plugins/data/agy-claude-code-agy/state/jobs/<id>.result.md`.
+- **Codex**: run non-interactively via the `codex` CLI (`codex exec
+  --skip-git-repo-check -C <worktree> < prompt`); the run is not a
+  codex-review-plugin workflow, so it has no plugin task id. Round-1
+  verdict and findings are recorded in the PR review-response comment.
+- **Copilot**: requested via `gh pr edit 1937 --add-reviewer Copilot`
+  (rounds 1 and 2).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,14 +1,14 @@
 # Testing & Performance Guide
 
-> Deprecation notice (#1373): routine dataplane validation now targets the
-> userspace AF_XDP cluster by default, and omitted runtime configuration now
-> selects userspace. The legacy eBPF dataplane remains available for explicit
-> compatibility and regression coverage during the staged retirement. Later
-> phases own source, loader, build, and CLI removals.
+> Retirement notice (#1373, complete): the eBPF dataplane retirement is
+> done — the Rust AF_XDP userspace dataplane is the only runtime forwarding
+> path, the legacy XDP/TC source was deleted in #1476, and `system
+> dataplane-type ebpf` is hard-rejected at commit and runtime. The eBPF
+> standalone/HA procedures and performance notes below are HISTORICAL: they
+> describe a backend that is no longer selectable and are preserved only as
+> context. For current validation, use the userspace path.
 
-This page still contains legacy eBPF standalone/HA procedures and historical
-performance notes. Treat them as regression context unless a workstream
-explicitly calls for legacy coverage. For current userspace validation, use
+For current userspace validation, use
 [`userspace-ha-validation.md`](userspace-ha-validation.md) and the
 `loss:xpf-userspace-fw0/fw1` cluster.
 


### PR DESCRIPTION
## Summary

Restructures the top-level `README.md` into a **getting-started guide**
and moves the deep reference content into focused `docs/` subdocuments,
with clear pointers from the README to those + the existing design docs.
The README previously led with dataplane architecture, the full feature
matrix, code layout, and test-VM topology — burying "how do I run this?"
— and duplicated content already in `docs/install-images.md` /
`docs/deploy-quickstart.md`.

**Docs-only — no code change. No cluster smoke required** (per the
triple-review skill's "when NOT to use": this changes no production code,
no dataplane, no HA path).

## Install paths (all cross-checked against the real tooling)

- **(A) Debian package** — `make deb` → `apt install ./xpf_<ver>_amd64.deb`
  (+ the `xpf-appliance` metapackage), grounded in `debian/control`,
  `debian/xpf.postinst`, and the `deb` Makefile target.
- **(B) Incus image** — `make image` (`scripts/image/bake.py`) →
  `incus image import` → `scripts/deploy/xpf-deploy.py deploy
  examples/deploy/standalone.yaml`.
- **(C) KVM/QEMU/libvirt** — boot the baked qcow2 with `virt-install`,
  day-0 ISO via `scripts/image/make_config_drive.py`; or
  `xpf-deploy.py --hypervisor libvirt` for SR-IOV/passthrough.

Every command is taken from the actual tooling; environment-specific
values (image version, NIC sources) are shown as placeholders.

## Moved-content map (relocated, not deleted)

| From (old README section) | To |
|---|---|
| Dataplane Architecture, Architecture, Code Layout, command-tree split, APIs | `docs/architecture.md` (new) |
| Features, Userspace Dataplane Capabilities matrix | `docs/feature-coverage.md` (new) |
| Network Topology (test VM + HA cluster) | `docs/network-topology.md` (new) |
| Byte-order / verifier / SR-IOV / interface-mgmt / HA-timing gotchas (from CLAUDE.md, now operator-readable) | `docs/critical-patterns.md` (new) |
| (new documentation index) | `docs/README.md` (new) |

Stale references corrected during the move: eBPF dataplane retired
(#1373/#1476), DPDK retired (#1525) — framed as historical, not
selectable backends.

## Verification

- All new markdown links resolve (checked every `docs/*.md` and
  `examples/deploy/README.md` target).
- `go build ./...` clean (no code touched).
- `make audit-check` keys on Go-source counts via
  `scripts/refactoring-audit.sh`, unaffected by docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)