### PR TITLE
Signed, hosted appliance distribution mechanism (Part of #1924)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,40 @@ audit-check:
 image:
 	python3 scripts/image/bake.py
 
+# ── signed, hosted distribution (#1924) ───────────────────────────────────
+# Hosting URL + signing key are CONFIG INPUTS, never hardcoded:
+#   XPF_SIGN_SECKEY    path to the minisign image secret key (sign step)
+#   XPF_GPG_KEY        OpenPGP key id that signs the apt Release
+#   XPF_IMAGE_BASE_URL / XPF_APT_BASE_URL   publish destinations
+#   XPF_PUBLISH_CMD    backend shim: $CMD <local-dir> <dest-base-url>
+.PHONY: dist-sign dist-repo dist-publish dist-selftest
+
+# Sign already-baked dist/ image artifacts (re-emit the per-version manifest
+# signature). The bake also signs inline when XPF_SIGN_SECKEY is set; this is
+# the standalone re-sign / rotation entry point.
+dist-sign:
+	@test -n "$(XPF_SIGN_SECKEY)" || { echo "set XPF_SIGN_SECKEY=<minisign seckey path>"; exit 1; }
+	@for m in dist/xpf-*.SHA256SUMS; do \
+	    [ -f "$$m" ] || { echo "no dist/xpf-*.SHA256SUMS (run 'make image' first)"; exit 1; }; \
+	    python3 scripts/dist/sign.py sign-manifest --manifest "$$m" \
+	        --seckey "$(XPF_SIGN_SECKEY)" \
+	        $$(awk '{print "dist/" $$2}' "$$m"); \
+	done
+
+# Build the signed apt repo (flat default; XPF_APT_TOOL=reprepro to opt in).
+dist-repo:
+	XPF_GPG_KEY="$(XPF_GPG_KEY)" sh scripts/dist/build-apt-repo.sh
+
+# Fail-closed publish: verifies every artifact is signed, then dispatches
+# XPF_PUBLISH_CMD once per URL. Refuses to upload anything unsigned.
+dist-publish:
+	python3 scripts/dist/publish.py --channel $${XPF_CHANNEL:-stable}
+
+# Self-contained roundtrip gate: throwaway key -> sign -> verify ->
+# tamper-fails -> flat repo build -> install.sh dry-run. No real key, no host.
+dist-selftest:
+	sh scripts/dist/selftest.sh
+
 clean:
 	rm -f $(BINARY) cli xpf-userspace-dp
 	# Narrowed glob (#1476): the retained Rust shim object lives at

--- a/_Log.md
+++ b/_Log.md
@@ -5475,3 +5475,12 @@ top.
 - **File(s)**: scripts/dist/sign.py, scripts/dist/README.md,
   scripts/dist/xpf-image.pub.placeholder, scripts/image/bake.py,
   scripts/image/validate.py
+- **Timestamp**: 2026-06-16
+- **Action**: Add apt repo build tooling (flat signed default + reprepro opt-in),
+  Tailscale-style install.sh (preflight/keyring/source), fail-closed publish gate
+  + signed latest.json + XPF_PUBLISH_CMD dispatch, xpf-deploy.py fetch (verify
+  exact bytes at import), debian/xpf keyring payload (rotation), Makefile dist-*
+  targets, selftest.sh roundtrip gate (13/13), docs/distribution.md + install-images.md.
+- **File(s)**: scripts/dist/{build-apt-repo.sh,install.sh,publish.py,selftest.sh,
+  xpf-archive-keyring.asc.placeholder}, scripts/deploy/xpf-deploy.py, debian/rules,
+  Makefile, docs/distribution.md, docs/install-images.md

--- a/_Log.md
+++ b/_Log.md
@@ -5464,3 +5464,14 @@ top.
 - **Timestamp**: 2026-06-16
   - **Action**: README getting-started restructure (PR #1937) — rewrote README into install/getting-started guide (3 paths: .deb, incus image, kvm/libvirt) cross-checked against Makefile deb/image targets, debian/control+postinst, scripts/image/bake.py + make_config_drive.py, scripts/deploy/xpf-deploy.py. Moved deep reference content into new docs/architecture.md, docs/feature-coverage.md, docs/network-topology.md, docs/critical-patterns.md, docs/README.md. Docs-only.
   - **File(s)**: README.md, docs/architecture.md, docs/feature-coverage.md, docs/network-topology.md, docs/critical-patterns.md, docs/README.md, docs/pr/readme-getting-started/reviewer-ids.md
+
+## #1924 signed/hosted appliance distribution (engineer)
+- **Timestamp**: 2026-06-16
+- **Action**: Add minisign image-signing mechanism: shared scripts/dist/sign.py
+  (sign/verify + per-version manifest, per-file verification), wire signing into
+  scripts/image/bake.py (per-version xpf-<ver>.SHA256SUMS + .minisig, fail-open),
+  wire verification into scripts/image/validate.py (--verify-sig/--no-verify-sig,
+  verify exact qcow2+metadata before import). Placeholder pinned pubkey.
+- **File(s)**: scripts/dist/sign.py, scripts/dist/README.md,
+  scripts/dist/xpf-image.pub.placeholder, scripts/image/bake.py,
+  scripts/image/validate.py

--- a/debian/rules
+++ b/debian/rules
@@ -73,6 +73,20 @@ override_dh_auto_install:
 	install -d debian/xpf/etc/needrestart/conf.d
 	install -m 0644 debian/xpf.needrestart \
 	                debian/xpf/etc/needrestart/conf.d/xpf.conf
+	@# Ship the apt archive keyring in the package payload (#1924 NIT-2) so
+	@# existing hosts get a ROTATED key via `apt upgrade` even though they
+	@# never re-run install.sh. Prefer the real key (scripts/dist/
+	@# xpf-archive-keyring.asc) when the release build has dropped it in;
+	@# otherwise ship the placeholder (apt rejects the repo signature — the
+	@# correct fail-safe until OQ-2 issues a real key).
+	install -d debian/xpf/etc/apt/keyrings
+	if [ -f scripts/dist/xpf-archive-keyring.asc ]; then \
+	    install -m 0644 scripts/dist/xpf-archive-keyring.asc \
+	            debian/xpf/etc/apt/keyrings/xpf-archive-keyring.asc; \
+	else \
+	    install -m 0644 scripts/dist/xpf-archive-keyring.asc.placeholder \
+	            debian/xpf/etc/apt/keyrings/xpf-archive-keyring.asc; \
+	fi
 
 # Disable the auto-restart-on-upgrade block dh_installsystemd would
 # otherwise append to postinst. A plain `apt upgrade xpf` must NOT

--- a/debian/rules
+++ b/debian/rules
@@ -75,17 +75,21 @@ override_dh_auto_install:
 	                debian/xpf/etc/needrestart/conf.d/xpf.conf
 	@# Ship the apt archive keyring in the package payload (#1924 NIT-2) so
 	@# existing hosts get a ROTATED key via `apt upgrade` even though they
-	@# never re-run install.sh. Prefer the real key (scripts/dist/
-	@# xpf-archive-keyring.asc) when the release build has dropped it in;
-	@# otherwise ship the placeholder (apt rejects the repo signature — the
-	@# correct fail-safe until OQ-2 issues a real key).
-	install -d debian/xpf/etc/apt/keyrings
+	@# never re-run install.sh. Install under /usr/share/keyrings (NOT
+	@# /etc): a file under /etc is a dpkg CONFFILE — install.sh writes the
+	@# key before `apt install`, so dpkg would hit a conffile prompt (hangs
+	@# unattended installs) and `force-confnew` would clobber the real key
+	@# with the placeholder (fleet lockout). /usr/share/keyrings is
+	@# package-owned and updates seamlessly on upgrade (AGY-A1). Prefer the
+	@# real key when the release build has dropped it in; otherwise ship the
+	@# placeholder (apt rejects the signature — the correct fail-safe).
+	install -d debian/xpf/usr/share/keyrings
 	if [ -f scripts/dist/xpf-archive-keyring.asc ]; then \
 	    install -m 0644 scripts/dist/xpf-archive-keyring.asc \
-	            debian/xpf/etc/apt/keyrings/xpf-archive-keyring.asc; \
+	            debian/xpf/usr/share/keyrings/xpf-archive-keyring.asc; \
 	else \
 	    install -m 0644 scripts/dist/xpf-archive-keyring.asc.placeholder \
-	            debian/xpf/etc/apt/keyrings/xpf-archive-keyring.asc; \
+	            debian/xpf/usr/share/keyrings/xpf-archive-keyring.asc; \
 	fi
 
 # Disable the auto-restart-on-upgrade block dh_installsystemd would

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -108,8 +108,8 @@ checksums.
 ### Key rotation
 
 The archive keyring ships BOTH inline in `install.sh` (new installs) AND in the
-`xpf` package payload at `/etc/apt/keyrings/xpf-archive-keyring.asc` (via
-`debian/xpf.install`). During a dual-sign window, a normal `apt upgrade`
+`xpf` package payload at `/usr/share/keyrings/xpf-archive-keyring.asc` (via
+`debian/rules`). During a dual-sign window, a normal `apt upgrade`
 delivers the rotated key to EXISTING hosts before the old key retires — so
 rotation is not a fleet lockout. Image-pubkey rotation: publish the new
 `xpf-image.pub`, dual-sign during overlap, retire the old.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -102,8 +102,11 @@ checksums.
   an automated re-sign job.
 - Images: `latest.json` (signed) names the current version per channel.
   `xpf-deploy.py fetch` records a best-effort monotonic watermark at
-  `${XDG_STATE_HOME:-~/.local/state}/xpf/image-watermark.json`. This detects
-  stale mirrors / accidental rollback; it is not TUF-grade freeze protection.
+  `${XDG_STATE_HOME:-~/.local/state}/xpf/image-watermark.json` (per
+  `--channel`, default `stable`) and REFUSES a version older than the recorded
+  one — `--allow-rollback` permits a deliberate downgrade. This detects stale
+  mirrors / accidental rollback; it is not TUF-grade freeze protection, and a
+  fresh workstation with no watermark trusts the artifact's own signature.
 
 ### Key rotation
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,182 @@
+# xpf signed, hosted distribution (#1924)
+
+Signed appliance images + a signed apt repo + a one-command installer, so an
+operator fetches and verifies from a trusted, signed source instead of copying
+files by hand. Spec: `docs/research/1924-signed-hosted-dist/plan.md`. Tooling:
+`scripts/dist/`.
+
+This document is the contract for the distribution mechanism. It is complete
+as a MECHANISM; two operator decisions (below) are supplied at release time as
+config inputs and are NOT hardcoded.
+
+## Trust model (read this first)
+
+Two independent trust roots, by design:
+
+| Artifact | Tool | Public key (pinned) | Consumer |
+|---|---|---|---|
+| Appliance image (qcow2 + incus metadata) + `install.sh` + `latest.json` | **minisign** (Ed25519) | `scripts/dist/xpf-image.pub` | our scripts (`validate.py`, `xpf-deploy.py fetch`) + the operator |
+| Apt repository (`Release`/`InRelease`) | **OpenPGP** | `scripts/dist/xpf-archive-keyring.asc` | `apt` itself |
+
+minisign and OpenPGP are NOT redundant — they authenticate different artifacts
+to different consumers. apt mandates OpenPGP for `Release`; the image consumers
+are scripts we control, so minisign's single pinned pubkey is the smaller trust
+surface there.
+
+**Root of trust for the image pubkey:** the in-repo checked-in copy obtained
+via `git clone` / GitHub — **independent of any hosting URL**. The copy served
+from the dist host is a convenience, never the root. To verify `install.sh`
+before running it (Tier B), get `xpf-image.pub` from the source repo, NOT from
+`XPF_IMAGE_BASE_URL`.
+
+## The two operator inputs (decide at release time)
+
+1. **Hosting target.**
+   - `XPF_IMAGE_BASE_URL` — serves the image artifacts, their `.minisig`
+     signatures, `install.sh`, and `latest.json`. Any static HTTPS host works,
+     **including GitHub Releases** (flat assets are fine for images).
+   - `XPF_APT_BASE_URL` — serves the `dists/`+`pool/` apt tree. Requires a
+     directory-serving host (static bucket / GitHub Pages / file server).
+     **GitHub Releases CANNOT serve this** (flat assets only).
+   - Plus the retention policy (keep last N versions per channel) and the
+     channel layout (`stable`, `edge`).
+
+2. **Signing identity.**
+   - The minisign image keypair and the OpenPGP archive key: who holds the
+     secret keys, the rotation cadence, and where the public keys are pinned.
+   - `XPF_SIGN_SECKEY` is a PATH to the minisign secret key (never the bytes).
+   - `XPF_GPG_KEY` is the OpenPGP key id/fingerprint that signs `Release`.
+
+Until these are decided, `scripts/dist/*.placeholder` ship as placeholders
+whose secret keys were shredded at generation (held by no one). With a
+placeholder in place, verification FAILS — the correct fail-safe. See
+`scripts/dist/README.md` for the go-live steps.
+
+## Publisher runbook
+
+```bash
+# 1. Build a signed image (signs inline when XPF_SIGN_SECKEY is set).
+XPF_SIGN_SECKEY=/secure/xpf-image.sec make image
+#    -> dist/xpf-<ver>.qcow2, .incus-metadata.tar.gz,
+#       .SHA256SUMS, .SHA256SUMS.minisig, xpf-image.pub
+
+# 2. Build the signed apt repo (flat default; reprepro opt-in).
+XPF_GPG_KEY=<keyid> make dist-repo
+#    or: XPF_APT_TOOL=reprepro XPF_GPG_KEY=<keyid> make dist-repo
+
+# 3. Write + sign the per-channel freshness pointer.
+XPF_SIGN_SECKEY=/secure/xpf-image.sec \
+  python3 scripts/dist/publish.py make-latest --channel stable --version <ver>
+
+# 4. (optional) sign install.sh so Tier-B verify-before-run works.
+minisign -S -s /secure/xpf-image.sec -m scripts/dist/install.sh \
+         -x dist/install.sh.minisig
+cp scripts/dist/install.sh dist/install.sh
+
+# 5. Fail-closed publish (refuses unsigned artifacts; uploads per URL).
+XPF_IMAGE_BASE_URL=https://dl.example.com/xpf \
+XPF_APT_BASE_URL=https://dl.example.com/xpf/apt \
+XPF_PUBLISH_CMD=/path/to/publish-shim \
+  make dist-publish
+```
+
+`XPF_PUBLISH_CMD` is a thin backend shim invoked exactly as
+`$XPF_PUBLISH_CMD <local-dir> <dest-base-url>`, once per URL (image tree →
+`XPF_IMAGE_BASE_URL`, apt tree → `XPF_APT_BASE_URL`). It must be idempotent and
+exit non-zero on failure. Example shims: `rsync -a "$1/" "$2/"`,
+`aws s3 sync "$1" "$2"`, a `gh release upload` wrapper. No backend is
+hardcoded.
+
+### Channel + retention
+
+`stable` and `edge` are distinct apt suites and distinct `dist/<channel>/`
+image pointers. Retention is a publisher policy (keep last N per channel);
+per-version manifests mean retaining old versions never orphans their signed
+checksums.
+
+### Freshness / anti-rollback
+
+- Apt `Release`/`InRelease` carries `Valid-Until` (default 1 year,
+  `XPF_APT_VALID_DAYS`). A SHORT window with manual/air-gap signing would
+  expire the repo between releases — keep it long for a manual cadence, or run
+  an automated re-sign job.
+- Images: `latest.json` (signed) names the current version per channel.
+  `xpf-deploy.py fetch` records a best-effort monotonic watermark at
+  `${XDG_STATE_HOME:-~/.local/state}/xpf/image-watermark.json`. This detects
+  stale mirrors / accidental rollback; it is not TUF-grade freeze protection.
+
+### Key rotation
+
+The archive keyring ships BOTH inline in `install.sh` (new installs) AND in the
+`xpf` package payload at `/etc/apt/keyrings/xpf-archive-keyring.asc` (via
+`debian/xpf.install`). During a dual-sign window, a normal `apt upgrade`
+delivers the rotated key to EXISTING hosts before the old key retires — so
+rotation is not a fleet lockout. Image-pubkey rotation: publish the new
+`xpf-image.pub`, dual-sign during overlap, retire the old.
+
+## Operator runbook
+
+### Install (Tier A — one-liner)
+
+```bash
+curl -fsSL https://dl.example.com/xpf/install.sh | sh
+```
+
+Trust level: TLS + first-fetch trust of `install.sh` (the same level
+Tailscale/Docker/rustup accept). `install.sh` preflights arch/distro/kernel
+(refuses kernel < 6.18 — use the appliance image on older hosts), installs the
+pinned archive keyring, writes the deb822 apt source, and `apt install
+xpf-appliance`.
+
+### Install (Tier B — verify before run)
+
+```bash
+# get the image pubkey from the SOURCE REPO, not the dist host
+git clone https://github.com/psaab/xpf && cp xpf/scripts/dist/xpf-image.pub .
+curl -fsSLO https://dl.example.com/xpf/install.sh
+curl -fsSLO https://dl.example.com/xpf/install.sh.minisig
+minisign -V -p xpf-image.pub -m install.sh -x install.sh.minisig
+# read install.sh, then:
+sh install.sh
+```
+
+### Verify + import an image
+
+```bash
+# downloads + verifies the EXACT bytes against the signed manifest, then
+# imports to a local incus alias
+xpf-deploy.py fetch --version <ver> --image-url https://dl.example.com/xpf
+# libvirt/KVM (qcow2 only):
+xpf-deploy.py fetch --version <ver> --image-url ... --qcow2-only
+```
+
+### CAUTION — interface takeover (#1879)
+
+`xpfd` owns and renames every interface on the host. A bare-metal `apt install
+xpf-appliance` on a remote box can cut your management path if the fxp0 mapping
+is wrong. Seed a safe day-0 config (fxp0 = mgmt DHCP) before relying on remote
+access, or use console.
+
+### Upgrades
+
+`apt upgrade xpf-appliance` triggers the #1917 postinst cut-over:
+- **Standalone node:** a verified STOP→FLIP→START with a bounded, measured
+  DATAPLANE blip (mgmt/SSH is not forward-switched). Use
+  `XPF_NO_POSTINST_CUT=1 apt-get upgrade` to stage only and run `xpfd upgrade`
+  at a chosen time.
+- **HA node** (`/etc/xpf/node-id` present): stage only — `apt upgrade` does NOT
+  cut. Cut with `xpfd upgrade --rolling` so the cluster keeps forwarding. Do
+  not `apt upgrade` both nodes expecting auto-rolling.
+
+This is #1917's existing, reviewed mechanism — #1924 does not change it.
+
+## Self-test (no real key, no host)
+
+```bash
+make dist-selftest      # = scripts/dist/selftest.sh
+```
+
+Generates a throwaway keypair, signs, verifies, proves tamper-detection (4
+ways), builds a flat signed apt repo + verifies `InRelease` (and that a
+tampered `InRelease` fails), and dry-runs `install.sh`. Exits non-zero if any
+positive check fails or any tamper check passes.

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -15,7 +15,14 @@ Two deliverables, same root disk:
 |---|---|---|
 | `dist/xpf-<ver>.qcow2` | libvirt/KVM, plain QEMU | `virt-install --import --disk path=...` |
 | `dist/xpf-<ver>.incus-metadata.tar.gz` + the same qcow2 | incus (VM) | `incus image import <meta> <qcow2> --alias xpf-appliance` |
-| `dist/SHA256SUMS` | both | `sha256sum -c` |
+| `dist/xpf-<ver>.SHA256SUMS` (+ `.minisig`) | both | minisign-verified, per-file (#1924) |
+
+> **Signed distribution (#1924):** the bake emits a per-version, minisign-signed
+> checksum manifest. Fetch + verify from a trusted signed source instead of
+> copying files by hand — `xpf-deploy.py fetch --version <ver> --image-url
+> $XPF_IMAGE_BASE_URL` downloads, verifies the exact bytes against the signed
+> manifest, and imports. The one-command `install.sh` + signed apt repo are the
+> package path. See `docs/distribution.md`.
 
 ## Bake
 
@@ -67,7 +74,11 @@ Pipeline (offline — the image is never booted to provision it):
    increment.
 5. `virt-sysprep` seal: machine-id, ssh host keys, logs, tmp files,
    bash history, package caches, random seed; `/etc/xpf` factory-empty.
-6. Export compressed qcow2 + incus metadata tarball + SHA256SUMS.
+6. Export compressed qcow2 + incus metadata tarball + the per-version
+   `xpf-<ver>.SHA256SUMS` manifest, minisign-signed to
+   `xpf-<ver>.SHA256SUMS.minisig` when `XPF_SIGN_SECKEY` (a path) is set
+   (#1924). An unsigned dev bake warns "not publishable"; `make dist-publish`
+   refuses it.
 7. **Validation gate** (default on): the image is imported into local
    incus and the FULL first-boot matrix runs — factory boot (fxp0
    DHCP, sshd posture via `sshd -T`, -generic kernel flavor + full
@@ -179,8 +190,12 @@ commit-check and refuses to build an ISO the appliance would reject.
   there, or use the console once and `commit` a config.
 - The image ships no ssh host keys, no machine-id, no logs; both are
   regenerated per-instance at first boot.
-- Verify artifacts with `sha256sum -c dist/SHA256SUMS`. (Detached
-  signing — minisign — is a follow-up; see the #1879 deferred list.)
+- Verify artifacts with their minisign-signed per-version manifest
+  (#1924): `xpf-deploy.py fetch` verifies the exact bytes against
+  `xpf-<ver>.SHA256SUMS` + `.minisig`, or verify manually with
+  `minisign -V -p scripts/dist/xpf-image.pub -m xpf-<ver>.SHA256SUMS
+  -x xpf-<ver>.SHA256SUMS.minisig` then check each file's hash. The signed
+  apt repo + `install.sh` are the package path — see `docs/distribution.md`.
 
 ## Upgrades
 

--- a/docs/pr/1924-signed-hosted-dist/claude-smr-code-r1.md
+++ b/docs/pr/1924-signed-hosted-dist/claude-smr-code-r1.md
@@ -100,3 +100,30 @@ Codex (6) + AGY (5) converged REQUEST-CHANGES. All resolved:
 Gate after fixes: shellcheck clean, py compile clean, **selftest 15/15** (added
 Valid-Until + publish-fail-closed regression cases). Verdict: **APPROVE**
 (pending Codex + AGY re-review + Copilot).
+
+---
+
+## r3–r7 — iterated hardening (Codex + AGY + Copilot)
+
+Both Codex and AGY drove multiple REQUEST-CHANGES rounds; every finding fixed:
+
+- r3 (Codex): orphan sweep must walk recursively (publish uploads the tree);
+  gate_apt must fail-closed on dpkg-deb extraction failure. FIXED.
+- r3 (AGY): gate_latest + gate_images manifest-parse TOCTOU → new
+  verify_and_read/verify_manifest_map (copy→0700→verify→return bytes);
+  multi-suite apt gate (every suite under dists/ must verify); reject `\` in
+  basenames. FIXED. AGY APPROVE at r3-followup.
+- r4 (Codex): --no-apt would upload dist/apt ungated → refuse --no-apt when
+  dist/apt exists; reject symlinks under the image publish root. FIXED. AGY
+  APPROVE at r4.
+- r5 (Codex): symlinks under dist/apt also dereferenceable → gate_apt rejects
+  them too. FIXED. AGY APPROVE at r5.
+- Copilot: docs claimed a fetch watermark that wasn't implemented → implemented
+  the monotonic anti-rollback watermark in cmd_fetch (refuse older,
+  --allow-rollback override, advance-after-verify, best-effort). FIXED + tested
+  live.
+
+Final gate: go build clean, shellcheck clean, py compile clean, selftest 17/17
+(sign/verify, 4 tamper vectors, per-file, flat signed repo + InRelease verify +
+tamper-fail + Valid-Until, publish fail-closed on unsigned/orphan/symlink,
+install.sh dry-run). SMR verdict: APPROVE.

--- a/docs/pr/1924-signed-hosted-dist/claude-smr-code-r1.md
+++ b/docs/pr/1924-signed-hosted-dist/claude-smr-code-r1.md
@@ -1,0 +1,102 @@
+# Claude SMR hostile code review — PR #1938 (#1924 mechanism) r1
+
+Reviewer: Claude (security/build-release SMR). Posture: HOSTILE.
+
+## Verification correctness (the core)
+- `verify_image_artifact` (sign.py): order is correct — `verify_signature`
+  (minisign over the manifest) runs BEFORE `parse_manifest`, so a tampered
+  manifest is rejected before its contents are trusted. Per-file: hashes the
+  EXACT `path` arg, compares to `manifest[basename(path)]`. A basename absent
+  from the manifest raises; a hash mismatch raises. This binds the consumed
+  bytes — not a cwd `sha256sum -c`. GOOD.
+- `parse_manifest`: rejects pathful names (`/` in name), `.`/`..`/empty,
+  non-64-hex digests, duplicate basenames, and an empty manifest. GOOD.
+- `write_manifest`: basename-only, rejects duplicate basenames at write. GOOD.
+- Selftest proves all four tamper vectors fail (modified artifact, tampered
+  manifest, tampered sig, wrong pubkey) + per-file qcow2-only verify. 13/13.
+
+## Fail-closed publish (publish.py)
+- `gate_images`: requires ≥1 signed manifest; verifies signature; requires
+  every listed file present + hash-matching (no partial set). GOOD.
+- `gate_latest`: requires latest.json + .minisig, verifies signature, requires
+  the named version be in the publish set. GOOD (resolves N2).
+- `gate_apt`: requires InRelease, REFUSES the placeholder archive key, verifies
+  against an EPHEMERAL gnupg keyring built only from the pinned pubkey (does
+  not trust the publisher's global keyring). GOOD.
+- install.sh.minisig required when install.sh is in the set. GOOD.
+
+## install.sh
+- Placeholder keyring: `install_keyring` DIES on a real run (only warns under
+  dry-run). So a real install can never wire a non-verifying keyring. GOOD.
+- kernel preflight: `case "$kmaj$kmin" in *[!0-9]*) die` guards before the
+  numeric `-lt` comparisons; `6.8` parses as maj=6 min=8 -> 8<18 -> refused
+  correctly; `6.18` -> 18 -> ok; `6.18-rc1` -> non-numeric -> dies "cannot
+  parse" (acceptable refuse). No 6.8-vs-6.18 misparse. GOOD.
+- All expansions in `run`/`write_source` are quoted; the deb822 body is a
+  heredoc with only `$XPF_APT_BASE_URL`/`$CHANNEL`/`$KEYRING` interpolated —
+  these come from env/constants, not untrusted input. `run` uses `eval "$*"`
+  on caller-controlled command strings (not network input). Acceptable.
+
+## sign.py minisign
+- `sign_manifest` passes the secret key by PATH; `input="\n"` feeds an empty
+  passphrase so a passwordless key signs unattended and a password-protected
+  key fails loudly. Secret bytes never enter the process. No `shell=True`
+  anywhere — all subprocess calls are arg lists. GOOD.
+
+## build-apt-repo.sh
+- Flat path uses `apt-ftparchive packages/release`; signs InRelease
+  (clearsign) + Release.gpg (detached). Unsigned path warns + (publish.py
+  refuses). `Valid-Until` set explicitly via `-o ...::ValidUntil`. reprepro
+  path requires XPF_GPG_KEY. Args are quoted. GOOD.
+- Minor: the `--debs` arg loop `while ... [ "${1#--}" = "$1" ]` consumes tokens
+  until the next `--flag`; a deb path literally starting with `--` would be
+  skipped, but deb paths never start with `--`. Acceptable.
+
+## debian/rules keyring
+- Installs the keyring under `debian/xpf/etc/apt/keyrings/` — dh auto-registers
+  `/etc/*` as conffiles, so an operator/rotation edit is preserved and the
+  rotated key ships on upgrade. Prefers the real key, else placeholder. GOOD.
+
+## Findings
+- **S1 (LOW / hardening):** `gate_apt` builds an ephemeral GNUPGHOME but does
+  not set `--trust-model always` or check the key is the EXPECTED one beyond
+  "import this pubkey, verify against it." Since the keyring contains ONLY the
+  pinned pubkey, a valid signature necessarily came from that key — so this is
+  sufficient. No change required; noting for the reviewers.
+- **S2 (NIT):** `install.sh` `is_placeholder_key` greps the heredoc-captured
+  `$ARCHIVE_KEY`; correct, but if a real key happens to contain the literal
+  string it would false-positive. The marker is specific enough
+  (`PLACEHOLDER-xpf-archive-keyring`) that this is not a real risk.
+- **S3 (NIT):** selftest exits 77 (skip) if minisign/gpg/apt-ftparchive absent.
+  CI must install them or the gate silently skips. The PR text + Makefile note
+  the apt deps; acceptable, but the CI workflow (future Inc 4) must install
+  them.
+
+## Verdict
+**APPROVE-WITH-NITS.** The security-critical paths are correct: signature-then-
+parse ordering, per-file byte binding, fail-closed publish covering all four
+artifact classes, placeholder refusal on real installs, no secret-key leakage,
+no shell=True. S1–S3 are hardening/CI notes, not blockers. Pending Codex + AGY
++ Copilot.
+
+---
+
+## r2 — fixes applied after Codex + AGY REQUEST-CHANGES (both)
+
+Codex (6) + AGY (5) converged REQUEST-CHANGES. All resolved:
+
+| Finding | Sev | Fix |
+|---|---|---|
+| publish uploads unsigned files (whole dist tree) | Codex-H1 / AGY-A2 | publish.py `list_versions` now DIES on any xpf-*.SHA256SUMS without a .minisig (fail-closed); selftest 5b. |
+| keyring in /etc = conffile prompt + force-confnew clobber | AGY-A1 | moved keyring to /usr/share/keyrings (non-conffile) in debian/rules + install.sh + Signed-By + docs. |
+| stale signed InRelease green-lights unsigned rebuild | Codex-H2 | build-apt-repo.sh rm's Release/InRelease/Release.gpg before each flat build. |
+| Valid-Until not emitted (ValidUntil vs ValidTime) | Codex-M3 | use APT::FTPArchive::Release::ValidTime (seconds) + grep-assert the field landed; selftest checks it. |
+| image placeholder pubkey not fail-closed | Codex-M4 | sign.require_real_pubkey() rejects *.placeholder in verify_image_artifact; publish.py explicit guard. |
+| validate.py cross-manifest mismatch | AGY-A3 | bind BOTH artifacts to the SAME manifest (single chosen manifest, else fail). |
+| TOCTOU manifest swap between verify and parse | Codex-M5 / AGY-A4 | copy manifest+sig into a 0700 temp dir; verify+parse the copy. |
+| publish parses manifest before verifying signature | Codex-L6 | gate_images verifies signature THEN parses. |
+| $DEBS unquoted word-split/glob | AGY-A5 | set -f around the loop + reject paths with unsupported chars. |
+
+Gate after fixes: shellcheck clean, py compile clean, **selftest 15/15** (added
+Valid-Until + publish-fail-closed regression cases). Verdict: **APPROVE**
+(pending Codex + AGY re-review + Copilot).

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -36,6 +36,7 @@ Examples:
 """
 
 import argparse
+import json
 import os
 import re
 import shlex
@@ -453,6 +454,38 @@ def cmd_fetch(args):
     out = os.path.abspath(args.out or os.getcwd())
     os.makedirs(out, exist_ok=True)
 
+    # Best-effort monotonic anti-rollback watermark (#1924 §5.6 / NIT-3):
+    # remember the highest version fetched per channel so a stale mirror
+    # serving an OLDER (still-signed) version is detected. Stateless CLI, so
+    # this is best-effort: a fresh workstation has no watermark and trusts the
+    # artifact's own signature. Override the channel with --channel; bypass the
+    # guard with --allow-rollback (e.g. a deliberate downgrade).
+    state_home = os.environ.get("XDG_STATE_HOME") or os.path.expanduser(
+        "~/.local/state")
+    wm_path = os.path.join(state_home, "xpf", "image-watermark.json")
+
+    def _ver_key(v):
+        # Compare dotted numeric components; non-numeric tail compares as text.
+        out_parts = []
+        for tok in str(v).replace("-", ".").split("."):
+            out_parts.append((0, int(tok)) if tok.isdigit() else (1, tok))
+        return out_parts
+
+    def read_watermark():
+        try:
+            with open(wm_path) as f:
+                return json.load(f)
+        except (OSError, ValueError):
+            return {}
+
+    if not args.dry_run and not args.allow_rollback:
+        wm = read_watermark()
+        prev = wm.get(args.channel)
+        if prev and _ver_key(ver) < _ver_key(prev):
+            die(f"requested version {ver} is OLDER than the last fetched "
+                f"{prev} on channel '{args.channel}' (possible stale mirror / "
+                "rollback). Pass --allow-rollback for a deliberate downgrade.")
+
     names = {
         "qcow2": f"xpf-{ver}.qcow2",
         "metadata": f"xpf-{ver}.incus-metadata.tar.gz",
@@ -494,6 +527,23 @@ def cmd_fetch(args):
             print(f"==> signature OK: {names[w]}")
         except sign.SignError as e:
             die(f"VERIFICATION FAILED for {names[w]}: {e}")
+
+    # Advance the monotonic watermark only AFTER a successful verify (so a
+    # failed/tampered fetch never moves it). Best-effort: a write failure is
+    # non-fatal (the signature is the real gate).
+    if not args.allow_rollback:
+        try:
+            wm = read_watermark()
+            prev = wm.get(args.channel)
+            if not prev or _ver_key(ver) >= _ver_key(prev):
+                wm[args.channel] = ver
+                os.makedirs(os.path.dirname(wm_path), exist_ok=True)
+                tmpw = wm_path + ".tmp"
+                with open(tmpw, "w") as f:
+                    json.dump(wm, f, indent=2, sort_keys=True)
+                os.replace(tmpw, wm_path)
+        except OSError:
+            pass  # best-effort; never block a verified fetch on watermark I/O
 
     if args.no_import or args.qcow2_only:
         print(f"==> verified into {out} (not imported — use the qcow2 with "
@@ -547,6 +597,11 @@ def main():
         sub.add_argument("--image-url", dest="image_url")
         sub.add_argument("--out")
         sub.add_argument("--alias")
+        sub.add_argument("--channel", default="stable",
+                         help="watermark channel (anti-rollback bucket)")
+        sub.add_argument("--allow-rollback", action="store_true",
+                         help="permit fetching an older version than the "
+                              "recorded watermark (deliberate downgrade)")
         sub.add_argument("--qcow2-only", action="store_true",
                          help="fetch+verify only the qcow2 (libvirt/KVM path)")
         sub.add_argument("--no-import", action="store_true",

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -465,11 +465,24 @@ def cmd_fetch(args):
     wm_path = os.path.join(state_home, "xpf", "image-watermark.json")
 
     def _ver_key(v):
-        # Compare dotted numeric components; non-numeric tail compares as text.
-        out_parts = []
-        for tok in str(v).replace("-", ".").split("."):
-            out_parts.append((0, int(tok)) if tok.isdigit() else (1, tok))
-        return out_parts
+        # Compare on the dotted-numeric RELEASE, then a pre-release rank so a
+        # pre-release sorts BEFORE its base release (AGY: 1.2.3-rc1 < 1.2.3, so
+        # upgrading rc -> final is NOT a rollback). git-describe tails like
+        # "-N-gHASH-dirty" are post-release commits ahead of the tag → rank
+        # them AFTER the base. Split on the FIRST '-': left = release, right =
+        # suffix.
+        s = str(v)
+        rel, _, suffix = s.partition("-")
+        rel_key = []
+        for tok in rel.split("."):
+            rel_key.append((0, int(tok)) if tok.isdigit() else (1, tok))
+        if not suffix:
+            pre_rank = (1,)           # base release: after any pre-release
+        elif suffix[:1].isdigit():
+            pre_rank = (2, suffix)    # git-describe "N-gHASH": post-release
+        else:
+            pre_rank = (0, suffix)    # rc/alpha/beta/...: before the base
+        return (rel_key, pre_rank)
 
     def read_watermark():
         try:

--- a/scripts/deploy/xpf-deploy.py
+++ b/scripts/deploy/xpf-deploy.py
@@ -7,6 +7,11 @@ Subcommands:
   launch --name … --nic …         imperative launch without a YAML file.
   inventory                       list host NICs, SR-IOV VFs, bridges → the
                                   values you drop into a definition.
+  fetch --version V [--image-url] download a signed appliance image from
+                                  XPF_IMAGE_BASE_URL, VERIFY the exact bytes
+                                  against the signed manifest (#1924), then
+                                  import it to a local incus alias. Verify
+                                  happens here, not at deploy/launch.
 
 Interface naming is POSITIONAL (matches pkg/daemon/linksetup.go assignName):
 
@@ -429,6 +434,87 @@ def cmd_launch(args):
     return 0
 
 
+def cmd_fetch(args):
+    """Download an appliance image from XPF_IMAGE_BASE_URL, VERIFY the exact
+    downloaded bytes against the signed per-version manifest (#1924 §5.2),
+    then import it to a local incus alias. Verification happens HERE (at
+    fetch/import), not at deploy/launch — the alias-launch path consumes a
+    previously-verified alias. This is the only deploy-side place that
+    touches raw image bytes, so it is where the signature is bound."""
+    HERE_D = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, os.path.join(os.path.dirname(HERE_D), "dist"))
+    import sign  # noqa: E402
+
+    base = args.image_url or os.environ.get("XPF_IMAGE_BASE_URL")
+    if not base:
+        die("fetch needs --image-url or XPF_IMAGE_BASE_URL (the image host).")
+    base = base.rstrip("/")
+    ver = args.version
+    out = os.path.abspath(args.out or os.getcwd())
+    os.makedirs(out, exist_ok=True)
+
+    names = {
+        "qcow2": f"xpf-{ver}.qcow2",
+        "metadata": f"xpf-{ver}.incus-metadata.tar.gz",
+        "manifest": f"xpf-{ver}.SHA256SUMS",
+        "sig": f"xpf-{ver}.SHA256SUMS.minisig",
+    }
+
+    def fetch_one(name):
+        dst = os.path.join(out, name)
+        url = f"{base}/{name}"
+        if args.dry_run:
+            print(f"  (dry-run) curl -fsSL {url} -> {dst}")
+            return dst
+        print(f"==> fetching {url}")
+        r = subprocess.run(["curl", "-fsSL", "-o", dst + ".tmp", url])
+        if r.returncode != 0:
+            die(f"download failed: {url}")
+        os.replace(dst + ".tmp", dst)
+        return dst
+
+    # Need at least the manifest + sig + the artifact(s) the operator wants.
+    want = ["qcow2"] if args.qcow2_only else ["qcow2", "metadata"]
+    fetch_one(names["manifest"])
+    fetch_one(names["sig"])
+    for w in want:
+        fetch_one(names[w])
+
+    if args.dry_run:
+        print("  (dry-run) verify each fetched file against the signed manifest,"
+              " then incus image import")
+        return 0
+
+    manifest = os.path.join(out, names["manifest"])
+    sig = os.path.join(out, names["sig"])
+    for w in want:
+        path = os.path.join(out, names[w])
+        try:
+            sign.verify_image_artifact(path, manifest, sig)
+            print(f"==> signature OK: {names[w]}")
+        except sign.SignError as e:
+            die(f"VERIFICATION FAILED for {names[w]}: {e}")
+
+    if args.no_import or args.qcow2_only:
+        print(f"==> verified into {out} (not imported — use the qcow2 with "
+              "virt-install --import, or re-run without --qcow2-only/--no-import "
+              "for an incus image import).")
+        return 0
+
+    alias = args.alias or "xpf-appliance"
+    subprocess.run(["incus", "image", "delete", alias],
+                   capture_output=True, text=True)
+    print(f"==> importing verified image as incus alias '{alias}'")
+    r = subprocess.run(["incus", "image", "import",
+                        os.path.join(out, names["metadata"]),
+                        os.path.join(out, names["qcow2"]), "--alias", alias])
+    if r.returncode != 0:
+        die("incus image import failed")
+    print(f"==> done. Deploy with: xpf-deploy.py deploy <appliance.yaml> "
+          f"(image: {alias})")
+    return 0
+
+
 def main():
     argv = sys.argv[1:]
     if "-h" in argv or "--help" in argv or not argv:
@@ -450,12 +536,23 @@ def main():
     # `rest` now holds only the subcommand + its own args. The first token
     # is the subcommand; if it isn't one, treat the whole of `rest` as
     # YAML files for `deploy` (the bare-`xpf-deploy.py foo.yaml` shorthand).
-    if rest and rest[0] in ("deploy", "launch", "inventory"):
+    if rest and rest[0] in ("deploy", "launch", "inventory", "fetch"):
         cmd, cmd_argv = rest[0], rest[1:]
     else:
         cmd, cmd_argv = "deploy", rest
 
-    if cmd == "inventory":
+    if cmd == "fetch":
+        sub = argparse.ArgumentParser(prog="xpf-deploy.py fetch", add_help=False)
+        sub.add_argument("--version", required=True)
+        sub.add_argument("--image-url", dest="image_url")
+        sub.add_argument("--out")
+        sub.add_argument("--alias")
+        sub.add_argument("--qcow2-only", action="store_true",
+                         help="fetch+verify only the qcow2 (libvirt/KVM path)")
+        sub.add_argument("--no-import", action="store_true",
+                         help="verify only; do not incus image import")
+        args = sub.parse_args(cmd_argv)
+    elif cmd == "inventory":
         sub = argparse.ArgumentParser(prog="xpf-deploy.py inventory", add_help=False)
         args = sub.parse_args(cmd_argv)
     elif cmd == "launch":
@@ -480,6 +577,8 @@ def main():
     args.no_start = gargs.no_start
     args.image = gargs.image
 
+    if cmd == "fetch":
+        return cmd_fetch(args)
     if cmd == "inventory":
         return cmd_inventory(args)
     if cmd == "launch":

--- a/scripts/dist/README.md
+++ b/scripts/dist/README.md
@@ -1,0 +1,62 @@
+# xpf signed distribution tooling (#1924)
+
+Mechanism for a signed, hosted appliance distribution. Spec:
+`docs/research/1924-signed-hosted-dist/plan.md`. Operator runbook:
+`docs/distribution.md`.
+
+## Files
+
+| File | Role |
+|---|---|
+| `sign.py` | minisign sign/verify + per-version manifest helpers (shared by bake/validate/deploy/publish) |
+| `build-apt-repo.sh` | builds a flat signed apt repo (default) or reprepro (opt-in) |
+| `install.sh` | Tailscale-style one-command installer (preflight + keyring + apt source + install) |
+| `publish.py` | fail-closed publish gate + `XPF_PUBLISH_CMD` dispatch |
+| `xpf-image.pub.placeholder` | PLACEHOLDER minisign public key (see below) |
+| `xpf-archive-keyring.asc.placeholder` | PLACEHOLDER OpenPGP apt archive key (see below) |
+
+## The two operator inputs (OPEN QUESTIONS — not wired to real values here)
+
+This tooling is complete as a MECHANISM. Going live needs two operator
+decisions, supplied at release time as config inputs (never hardcoded):
+
+1. **Hosting target** — `XPF_IMAGE_BASE_URL` (images + `install.sh` +
+   `latest.json`; any static host incl. GitHub Releases) and
+   `XPF_APT_BASE_URL` (the `dists/`+`pool/` apt tree; needs a
+   directory-serving host — NOT GitHub Releases flat assets). Plus the
+   retention policy and channel layout (`stable`/`edge`).
+2. **Signing identity** — the minisign keypair (images) and the OpenPGP
+   archive key (apt): who holds the secret keys, rotation cadence, and where
+   the public keys are pinned/published.
+
+## Placeholder keys — replace before any real publish
+
+`xpf-image.pub.placeholder` and `xpf-archive-keyring.asc.placeholder` are
+generated placeholders whose SECRET keys were shredded at generation and are
+held by NO ONE. They exist so the mechanism + tests have a concrete pubkey
+path shape, and so the repo never ships a key that anyone can sign for.
+
+To go live (engineer/release time, after OQ-2 is decided):
+
+1. Generate the real image keypair on the signing host:
+   `minisign -G -p xpf-image.pub -s xpf-image.sec` (keep `.sec` OFF the repo
+   and off CI unless OQ-4 chooses CI signing).
+2. Generate the real OpenPGP archive key; export the public key to
+   `xpf-archive-keyring.asc`.
+3. Commit the real PUBLIC keys as `scripts/dist/xpf-image.pub` and
+   `scripts/dist/xpf-archive-keyring.asc` (drop the `.placeholder` suffix).
+   These public files are the pinned trust roots; their authenticity comes
+   from the in-repo git copy, NOT from any hosting URL.
+4. Point signing at the secret key by PATH: `XPF_SIGN_SECKEY=/secure/xpf-image.sec`
+   for the bake, and the OpenPGP key id for `build-apt-repo.sh`.
+
+The signing secret key is referenced by PATH only. It is NEVER committed,
+logged, or embedded. Tests use a throwaway keypair generated in a temp dir.
+
+## Roundtrip (the local gate — no hosting, no real key)
+
+```bash
+scripts/dist/selftest.sh     # generates a throwaway key, signs, verifies,
+                             # proves tamper-detection, builds a flat repo,
+                             # and dry-runs install.sh
+```

--- a/scripts/dist/build-apt-repo.sh
+++ b/scripts/dist/build-apt-repo.sh
@@ -93,10 +93,25 @@ fi
 # ── flat signed repo (default) ───────────────────────────────────────────
 command -v apt-ftparchive >/dev/null 2>&1 || die "apt-ftparchive not found (apt-get install apt-utils)"
 
+# Clear stale signed metadata BEFORE rebuilding (Codex-H2): an unsigned
+# rebuild that left yesterday's signed InRelease/Release.gpg behind would let
+# the publish gate green-light a tampered/unsigned pool against the old
+# signature. Always start from a clean Release set for this suite.
+rm -f "$APT/dists/$SUITE/Release" "$APT/dists/$SUITE/Release.gpg" \
+      "$APT/dists/$SUITE/InRelease"
+
+# DEBS holds paths this script controls (built debs / explicit --debs). Guard
+# the word-split loop against pathname globbing with `set -f` (A5); paths must
+# not contain whitespace (asserted below).
+set -f
 for d in $DEBS; do
+    set +f
+    case "$d" in *[!-./_A-Za-z0-9]*) die "deb path contains an unsupported char: $d";; esac
     cp -f "$d" "$POOL/"
     info "pooled $(basename "$d")"
+    set -f
 done
+set +f
 
 # Packages index (paths in the index are relative to the repo root $APT).
 ( cd "$APT" && apt-ftparchive packages "pool/$COMPONENT" > "dists/$SUITE/$COMPONENT/binary-$ARCH/Packages" )
@@ -104,10 +119,11 @@ gzip -9 -kf "$DISTDIR/Packages"
 info "wrote Packages ($(wc -l < "$DISTDIR/Packages") lines) + Packages.gz"
 
 # Release over the suite tree. apt-ftparchive computes the per-index
-# checksums; we add the descriptive + freshness fields via -o overrides.
+# checksums; ValidTime (SECONDS, not a date) makes apt-ftparchive emit the
+# Valid-Until field (Codex-M3 — APT::FTPArchive::Release::ValidUntil does NOT
+# exist; the knob is ValidTime).
 NOW=$(date -u +%s)
-UNTIL=$(date -u -d "@$((NOW + VALID_DAYS * 86400))" +"%a, %d %b %Y %H:%M:%S UTC" 2>/dev/null \
-        || date -u -r "$((NOW + VALID_DAYS * 86400))" +"%a, %d %b %Y %H:%M:%S UTC")
+VALID_SECONDS=$((VALID_DAYS * 86400))
 NOWSTR=$(date -u -d "@$NOW" +"%a, %d %b %Y %H:%M:%S UTC" 2>/dev/null \
         || date -u -r "$NOW" +"%a, %d %b %Y %H:%M:%S UTC")
 ( cd "$APT" && apt-ftparchive \
@@ -118,9 +134,13 @@ NOWSTR=$(date -u -d "@$NOW" +"%a, %d %b %Y %H:%M:%S UTC" 2>/dev/null \
     -o "APT::FTPArchive::Release::Architectures=$ARCH" \
     -o "APT::FTPArchive::Release::Components=$COMPONENT" \
     -o "APT::FTPArchive::Release::Date=$NOWSTR" \
-    -o "APT::FTPArchive::Release::ValidUntil=$UNTIL" \
+    -o "APT::FTPArchive::Release::ValidTime=$VALID_SECONDS" \
     release "dists/$SUITE" > "dists/$SUITE/Release" )
-info "wrote Release (Valid-Until $UNTIL)"
+# Assert the freshness field actually landed (a silent apt-ftparchive knob
+# rename must FAIL the build, never ship a repo without Valid-Until).
+grep -q "^Valid-Until:" "$APT/dists/$SUITE/Release" \
+    || die "apt-ftparchive did not emit Valid-Until (ValidTime knob may have changed)"
+info "wrote Release ($(grep '^Valid-Until:' "$APT/dists/$SUITE/Release"))"
 
 # Sign Release -> InRelease (inline) + Release.gpg (detached).
 if [ -n "${XPF_GPG_KEY:-}" ]; then

--- a/scripts/dist/build-apt-repo.sh
+++ b/scripts/dist/build-apt-repo.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# xpf signed apt repository builder (#1924 §5.3).
+#
+# Default: a FLAT signed repo (apt-ftparchive + gpg) — stateless-CI-safe
+# (no reprepro Berkeley DB to carry between runs). Opt into reprepro with
+# XPF_APT_TOOL=reprepro for a persistent publisher.
+#
+# Produces a standard dists/+pool/ tree under <out>/apt, ready to publish to
+# XPF_APT_BASE_URL (a directory-serving host — NOT GitHub Releases flat
+# assets). The on-disk layout is identical for both tools so install.sh's
+# deb822 source is unaffected by the choice.
+#
+# Usage:
+#   build-apt-repo.sh [--out DIR] [--suite stable|edge] [--debs GLOB...]
+#
+# Env / config inputs (the operator decisions, OQ-2 / §5.6):
+#   XPF_GPG_KEY        OpenPGP key id/fingerprint that signs Release.
+#                      Unset -> repo is built UNSIGNED (dev only; loud warning;
+#                      publish.py refuses an unsigned InRelease).
+#   XPF_APT_TOOL       flat (default) | reprepro
+#   XPF_APT_SUITE      stable (default) | edge          (overridden by --suite)
+#   XPF_APT_COMPONENT  main (default)
+#   XPF_APT_ARCH       amd64 (default)
+#   XPF_APT_VALID_DAYS Valid-Until horizon in days (default 365 — long, for a
+#                      manual/air-gap signing cadence; a short window REQUIRES
+#                      an automated re-sign job, §5.6 NIT-1).
+#   XPF_APT_ORIGIN     Origin/Label/Suite text (default "xpf").
+set -eu
+
+# shellcheck disable=SC1007  # `CDPATH= cd` clears CDPATH for this command only
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+OUT="$ROOT/dist"
+SUITE="${XPF_APT_SUITE:-stable}"
+COMPONENT="${XPF_APT_COMPONENT:-main}"
+ARCH="${XPF_APT_ARCH:-amd64}"
+TOOL="${XPF_APT_TOOL:-flat}"
+VALID_DAYS="${XPF_APT_VALID_DAYS:-365}"
+ORIGIN="${XPF_APT_ORIGIN:-xpf}"
+DEBS=""
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --out) OUT="$2"; shift 2 ;;
+        --suite) SUITE="$2"; shift 2 ;;
+        --debs) shift; while [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; do DEBS="$DEBS $1"; shift; done ;;
+        -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+        *) die "unknown arg: $1" ;;
+    esac
+done
+
+case "$SUITE" in stable|edge) ;; *) die "suite must be stable|edge (got $SUITE)";; esac
+
+# Default deb set: the freshly built binary + appliance packages.
+if [ -z "$DEBS" ]; then
+    DEBS=$(ls "$ROOT"/dist/deb/xpf_*.deb "$ROOT"/dist/deb/xpf-appliance_*.deb 2>/dev/null || true)
+    [ -n "$DEBS" ] || die "no debs in dist/deb (run 'make deb' first, or pass --debs)"
+fi
+
+APT="$OUT/apt"
+POOL="$APT/pool/$COMPONENT/x/xpf"
+DISTDIR="$APT/dists/$SUITE/$COMPONENT/binary-$ARCH"
+mkdir -p "$POOL" "$DISTDIR"
+
+info "apt repo tool: $TOOL, suite: $SUITE, arch: $ARCH, out: $APT"
+
+if [ "$TOOL" = "reprepro" ]; then
+    command -v reprepro >/dev/null 2>&1 || die "reprepro not found (apt-get install reprepro)"
+    [ -n "${XPF_GPG_KEY:-}" ] || die "reprepro path requires XPF_GPG_KEY (signs Release)"
+    CONF="$APT/conf"
+    mkdir -p "$CONF"
+    cat > "$CONF/distributions" <<EOF
+Origin: $ORIGIN
+Label: $ORIGIN
+Suite: $SUITE
+Codename: $SUITE
+Architectures: $ARCH
+Components: $COMPONENT
+Description: xpf firewall appliance ($SUITE channel)
+SignWith: $XPF_GPG_KEY
+ValidFor: ${VALID_DAYS}d
+EOF
+    for d in $DEBS; do
+        info "reprepro includedeb $SUITE $d"
+        reprepro -b "$APT" includedeb "$SUITE" "$d"
+    done
+    info "reprepro repo built at $APT"
+    exit 0
+fi
+
+# ── flat signed repo (default) ───────────────────────────────────────────
+command -v apt-ftparchive >/dev/null 2>&1 || die "apt-ftparchive not found (apt-get install apt-utils)"
+
+for d in $DEBS; do
+    cp -f "$d" "$POOL/"
+    info "pooled $(basename "$d")"
+done
+
+# Packages index (paths in the index are relative to the repo root $APT).
+( cd "$APT" && apt-ftparchive packages "pool/$COMPONENT" > "dists/$SUITE/$COMPONENT/binary-$ARCH/Packages" )
+gzip -9 -kf "$DISTDIR/Packages"
+info "wrote Packages ($(wc -l < "$DISTDIR/Packages") lines) + Packages.gz"
+
+# Release over the suite tree. apt-ftparchive computes the per-index
+# checksums; we add the descriptive + freshness fields via -o overrides.
+NOW=$(date -u +%s)
+UNTIL=$(date -u -d "@$((NOW + VALID_DAYS * 86400))" +"%a, %d %b %Y %H:%M:%S UTC" 2>/dev/null \
+        || date -u -r "$((NOW + VALID_DAYS * 86400))" +"%a, %d %b %Y %H:%M:%S UTC")
+NOWSTR=$(date -u -d "@$NOW" +"%a, %d %b %Y %H:%M:%S UTC" 2>/dev/null \
+        || date -u -r "$NOW" +"%a, %d %b %Y %H:%M:%S UTC")
+( cd "$APT" && apt-ftparchive \
+    -o "APT::FTPArchive::Release::Origin=$ORIGIN" \
+    -o "APT::FTPArchive::Release::Label=$ORIGIN" \
+    -o "APT::FTPArchive::Release::Suite=$SUITE" \
+    -o "APT::FTPArchive::Release::Codename=$SUITE" \
+    -o "APT::FTPArchive::Release::Architectures=$ARCH" \
+    -o "APT::FTPArchive::Release::Components=$COMPONENT" \
+    -o "APT::FTPArchive::Release::Date=$NOWSTR" \
+    -o "APT::FTPArchive::Release::ValidUntil=$UNTIL" \
+    release "dists/$SUITE" > "dists/$SUITE/Release" )
+info "wrote Release (Valid-Until $UNTIL)"
+
+# Sign Release -> InRelease (inline) + Release.gpg (detached).
+if [ -n "${XPF_GPG_KEY:-}" ]; then
+    REL="$APT/dists/$SUITE/Release"
+    gpg --batch --yes --local-user "$XPF_GPG_KEY" --clearsign \
+        -o "$APT/dists/$SUITE/InRelease" "$REL"
+    gpg --batch --yes --local-user "$XPF_GPG_KEY" -abs \
+        -o "$APT/dists/$SUITE/Release.gpg" "$REL"
+    info "signed: InRelease + Release.gpg (key $XPF_GPG_KEY)"
+else
+    echo "WARNING: XPF_GPG_KEY unset — Release is UNSIGNED. Dev only; this repo "
+    echo "         is NOT publishable (publish.py refuses an unsigned InRelease)." >&2
+fi
+
+info "flat signed apt repo built at $APT"
+info "publish dists/+pool/ to XPF_APT_BASE_URL (a directory-serving host)"

--- a/scripts/dist/install.sh
+++ b/scripts/dist/install.sh
@@ -13,7 +13,7 @@
 #      xpf's verifier floor is kernel >= 6.18 with a native-XDP NIC; this
 #      installer does NOT install a kernel. A host below the floor is refused
 #      with a clear message (use the appliance image instead).
-#   2. Install the pinned apt archive keyring to /etc/apt/keyrings (inline).
+#   2. Install the pinned apt archive keyring to /usr/share/keyrings (inline).
 #   3. Write /etc/apt/sources.list.d/xpf.sources (deb822, Signed-By).
 #   4. apt-get update && apt-get install -y xpf-appliance.
 #   5. Print next steps + the interface-takeover caveat (#1879).
@@ -26,13 +26,17 @@
 # The archive keyring below is a PLACEHOLDER (its secret is held by no one).
 # The release build substitutes the real ASCII-armored archive public key
 # between the BEGIN/END markers. The SAME keyring also ships in the xpf
-# package (/etc/apt/keyrings via debian/xpf.install) so existing hosts get
+# package (/usr/share/keyrings via debian/rules) so existing hosts get
 # rotated keys via `apt upgrade` even though they never re-run this script.
 set -eu
 
 CHANNEL="${XPF_CHANNEL:-stable}"
 DRY="${XPF_DRY_RUN:-0}"
-KEYRING=/etc/apt/keyrings/xpf-archive-keyring.asc
+# /usr/share/keyrings (NOT /etc/apt/keyrings): the xpf package ships the same
+# keyring here as a package-owned (non-conffile) file, so this bootstrap write
+# and the later `apt install` agree without a dpkg conffile prompt, and key
+# rotation lands seamlessly on `apt upgrade` (AGY-A1).
+KEYRING=/usr/share/keyrings/xpf-archive-keyring.asc
 SRC=/etc/apt/sources.list.d/xpf.sources
 
 die() { echo "xpf-install ERROR: $*" >&2; exit 1; }
@@ -112,7 +116,7 @@ keyring that cannot verify the repo. A release build substitutes the real key."
         fi
     fi
     info "installing archive keyring -> $KEYRING"
-    run "install -d -m 0755 /etc/apt/keyrings"
+    run "install -d -m 0755 /usr/share/keyrings"
     if [ "$DRY" = "1" ]; then
         echo "  (dry-run) write $KEYRING (mode 0644) from embedded key"
     else

--- a/scripts/dist/install.sh
+++ b/scripts/dist/install.sh
@@ -1,0 +1,185 @@
+#!/bin/sh
+# xpf appliance installer (#1924 §5.4) — Tailscale-style one-command install.
+#
+#   curl -fsSL <XPF_IMAGE_BASE_URL>/install.sh | sh        # Tier A (one-liner)
+#
+# Tier B (verify-before-run): get xpf-image.pub from the SOURCE REPO (git
+# clone / GitHub — the out-of-band trust root, NEVER from the dist host),
+# then `minisign -V -p xpf-image.pub -m install.sh -x install.sh.minisig`,
+# read this script, and run it.
+#
+# What it does:
+#   1. PREFLIGHT: amd64 + Debian-family + kernel >= 6.18 + systemd-networkd.
+#      xpf's verifier floor is kernel >= 6.18 with a native-XDP NIC; this
+#      installer does NOT install a kernel. A host below the floor is refused
+#      with a clear message (use the appliance image instead).
+#   2. Install the pinned apt archive keyring to /etc/apt/keyrings (inline).
+#   3. Write /etc/apt/sources.list.d/xpf.sources (deb822, Signed-By).
+#   4. apt-get update && apt-get install -y xpf-appliance.
+#   5. Print next steps + the interface-takeover caveat (#1879).
+#
+# Config inputs (the operator decisions — NOT hardcoded):
+#   XPF_APT_BASE_URL   apt repo base (dists/+pool/ host). REQUIRED to install.
+#   XPF_CHANNEL        stable (default) | edge
+#   XPF_DRY_RUN=1      print the actions, mutate nothing (CI / review).
+#
+# The archive keyring below is a PLACEHOLDER (its secret is held by no one).
+# The release build substitutes the real ASCII-armored archive public key
+# between the BEGIN/END markers. The SAME keyring also ships in the xpf
+# package (/etc/apt/keyrings via debian/xpf.install) so existing hosts get
+# rotated keys via `apt upgrade` even though they never re-run this script.
+set -eu
+
+CHANNEL="${XPF_CHANNEL:-stable}"
+DRY="${XPF_DRY_RUN:-0}"
+KEYRING=/etc/apt/keyrings/xpf-archive-keyring.asc
+SRC=/etc/apt/sources.list.d/xpf.sources
+
+die() { echo "xpf-install ERROR: $*" >&2; exit 1; }
+info() { echo "xpf-install: $*"; }
+run() {
+    if [ "$DRY" = "1" ]; then echo "  (dry-run) $*"; else eval "$*"; fi
+}
+
+# ── embedded archive public key (PLACEHOLDER until release) ──────────────
+# Replace the block between the markers with the real ASCII-armored key.
+ARCHIVE_KEY=$(cat <<'KEYEOF'
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+PLACEHOLDER-xpf-archive-keyring-not-yet-issued
+This is a #1924 placeholder. The release build substitutes the real
+ASCII-armored OpenPGP archive public key here. With this placeholder in
+place, `apt-get update` will reject the repo's signature — which is the
+correct fail-safe until a real key is issued (OQ-2).
+-----END PGP PUBLIC KEY BLOCK-----
+KEYEOF
+)
+
+is_placeholder_key() {
+    printf '%s' "$ARCHIVE_KEY" | grep -q "PLACEHOLDER-xpf-archive-keyring"
+}
+
+# ── 1. preflight ─────────────────────────────────────────────────────────
+preflight() {
+    info "preflight: arch, distro, kernel, networkd"
+    arch=$(uname -m)
+    [ "$arch" = "x86_64" ] || die "unsupported arch '$arch' — xpf ships amd64 only."
+
+    if [ -r /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        case "${ID:-} ${ID_LIKE:-}" in
+            *debian*|*ubuntu*) : ;;
+            *) die "unsupported distro '${ID:-?}' — xpf needs a Debian-family host." ;;
+        esac
+    else
+        die "no /etc/os-release — cannot confirm a Debian-family host."
+    fi
+
+    # kernel >= 6.18 (the AF_XDP verifier floor). Compare major.minor.
+    kver=$(uname -r)
+    kmaj=$(echo "$kver" | cut -d. -f1)
+    kmin=$(echo "$kver" | cut -d. -f2)
+    case "$kmaj$kmin" in *[!0-9]*) die "cannot parse kernel version '$kver'";; esac
+    if [ "$kmaj" -lt 6 ] || { [ "$kmaj" -eq 6 ] && [ "$kmin" -lt 18 ]; }; then
+        die "kernel $kver < 6.18 — xpf requires kernel >= 6.18 + a native-XDP NIC. \
+Upgrade the host kernel, or deploy the appliance image (docs/install-images.md), \
+which ships its own >= 6.18 kernel."
+    fi
+
+    if ! command -v systemctl >/dev/null 2>&1; then
+        die "systemd not found — xpf requires systemd + systemd-networkd."
+    fi
+    # networkd need not be ACTIVE yet (the package enables it), but the unit
+    # must EXIST — a host without systemd-networkd cannot run xpf's interface
+    # management.
+    if ! systemctl list-unit-files systemd-networkd.service >/dev/null 2>&1; then
+        info "WARNING: systemd-networkd unit not found; the xpf package pulls it \
+in, but verify the host can run networkd (xpfd owns all interfaces)."
+    fi
+    info "preflight OK (arch=$arch kernel=$kver)"
+}
+
+# ── 2. keyring ─────────────────────────────────────────────────────────────
+install_keyring() {
+    if is_placeholder_key; then
+        if [ "$DRY" = "1" ]; then
+            info "WARNING (dry-run): archive key is the #1924 PLACEHOLDER — a \
+real install would fail at apt update until the release key is issued (OQ-2)."
+        else
+            die "archive key is the #1924 PLACEHOLDER — refusing to install a \
+keyring that cannot verify the repo. A release build substitutes the real key."
+        fi
+    fi
+    info "installing archive keyring -> $KEYRING"
+    run "install -d -m 0755 /etc/apt/keyrings"
+    if [ "$DRY" = "1" ]; then
+        echo "  (dry-run) write $KEYRING (mode 0644) from embedded key"
+    else
+        umask 022
+        printf '%s\n' "$ARCHIVE_KEY" > "$KEYRING"
+        chmod 0644 "$KEYRING"
+    fi
+}
+
+# ── 3. apt source ──────────────────────────────────────────────────────────
+write_source() {
+    [ -n "${XPF_APT_BASE_URL:-}" ] || die "XPF_APT_BASE_URL is required \
+(the apt repo base URL — a dists/+pool/ directory host). Set it and re-run."
+    case "$CHANNEL" in stable|edge) ;; *) die "XPF_CHANNEL must be stable|edge";; esac
+    info "writing apt source -> $SRC (suite=$CHANNEL uri=$XPF_APT_BASE_URL)"
+    body=$(cat <<EOF
+# xpf appliance apt source (#1924). Managed by install.sh.
+Types: deb
+URIs: $XPF_APT_BASE_URL
+Suites: $CHANNEL
+Components: main
+Architectures: amd64
+Signed-By: $KEYRING
+EOF
+)
+    if [ "$DRY" = "1" ]; then
+        echo "  (dry-run) $SRC contents:"; printf '%s\n' "$body" | sed 's/^/      /'
+    else
+        printf '%s\n' "$body" > "$SRC"
+    fi
+}
+
+# ── 4. install ─────────────────────────────────────────────────────────────
+do_install() {
+    info "apt-get update && install xpf-appliance"
+    run "apt-get update"
+    run "DEBIAN_FRONTEND=noninteractive apt-get install -y xpf-appliance"
+}
+
+# ── 5. next steps ──────────────────────────────────────────────────────────
+next_steps() {
+    cat <<'EOF'
+
+xpf-install: done. Next steps:
+  - Seed a day-0 config:  see docs/distribution.md and docs/deploy-quickstart.md
+  - Operate:              cli   (Junos-style CLI)
+  - Status:               systemctl status xpfd
+
+  CAUTION (#1879 interface takeover): xpfd OWNS and RENAMES every interface
+  on this host. On a remote box, an incorrect fxp0 mapping can cut your
+  management path. Seed a safe day-0 config (fxp0 = mgmt DHCP) BEFORE relying
+  on remote access, or use console.
+
+  Upgrades: `apt upgrade xpf-appliance` cuts the dataplane on a STANDALONE
+  node (a bounded blip; mgmt/SSH is not cut). Use XPF_NO_POSTINST_CUT=1
+  apt-get upgrade to stage-only and run `xpfd upgrade` at a chosen time. HA
+  nodes stage only; cut with `xpfd upgrade --rolling`.
+EOF
+}
+
+main() {
+    [ "$(id -u)" = "0" ] || [ "$DRY" = "1" ] || die "run as root (or sudo)."
+    preflight
+    install_keyring
+    write_source
+    do_install
+    next_steps
+}
+
+main "$@"

--- a/scripts/dist/publish.py
+++ b/scripts/dist/publish.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""xpf signed-distribution publish gate (#1924 §5.5).
+
+Fail-CLOSED: refuses to publish (exits non-zero, uploads nothing) unless every
+artifact in the publish set is properly signed:
+
+  (a) each image manifest (xpf-<ver>.SHA256SUMS) has a verifying .minisig
+      against the pinned image pubkey, AND the qcow2/metadata it lists are
+      present and hash-match;
+  (b) the apt InRelease verifies against the archive pubkey (when an apt tree
+      is being published);
+  (c) install.sh has a verifying install.sh.minisig (when install.sh is in
+      the image set);
+  (d) the per-channel latest.json verifies against the image pubkey AND names
+      a version present in the image set.
+
+The bake may be fail-OPEN (a dev bake without a key still produces artifacts),
+but PUBLISH is fail-CLOSED — an unsigned dev bake can never reach the channel.
+
+After the gate passes, dispatch the operator's backend exactly once per URL:
+
+  $XPF_PUBLISH_CMD <local-dir> <dest-base-url>     # idempotent, exit!=0 on fail
+
+  image tree (dist/, sigs, install.sh, latest.json) -> XPF_IMAGE_BASE_URL
+  apt tree    (dist/apt/dists + pool)               -> XPF_APT_BASE_URL
+
+XPF_PUBLISH_CMD is a thin shim the operator supplies (rsync / aws s3 sync /
+gh release upload wrapper). No backend is hardcoded.
+
+The two operator decisions (hosting URLs, signing identity) are config inputs:
+XPF_IMAGE_BASE_URL / XPF_APT_BASE_URL and the pinned pubkeys / signing keys.
+
+Usage:
+  publish.py --channel stable [--dist DIR] [--no-image] [--no-apt] [--dry-run]
+  publish.py make-latest --channel stable --version V [--dist DIR]   # sign latest.json
+"""
+
+import argparse
+import glob
+import json
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+sys.path.insert(0, HERE)
+import sign  # noqa: E402
+
+
+def info(m):
+    print(f"==> {m}")
+
+
+def die(m):
+    sys.exit(f"PUBLISH ERROR: {m}")
+
+
+def archive_pubkey():
+    """Resolve the OpenPGP archive pubkey path (override or pinned, else
+    placeholder). gpg verifies InRelease against an ephemeral keyring built
+    from this file so we never depend on the publisher's global gpg keyring."""
+    override = os.environ.get("XPF_ARCHIVE_PUBKEY")
+    if override:
+        return override
+    real = os.path.join(HERE, "xpf-archive-keyring.asc")
+    if os.path.isfile(real):
+        return real
+    return os.path.join(HERE, "xpf-archive-keyring.asc.placeholder")
+
+
+def _is_placeholder(path):
+    try:
+        with open(path) as f:
+            return "PLACEHOLDER-xpf-archive-keyring" in f.read()
+    except OSError:
+        return False
+
+
+def list_versions(dist):
+    """Discover baked versions from signed manifests in `dist`."""
+    out = {}
+    for m in glob.glob(os.path.join(dist, "xpf-*.SHA256SUMS")):
+        if not os.path.isfile(m + ".minisig"):
+            continue
+        base = os.path.basename(m)
+        ver = base[len("xpf-"):-len(".SHA256SUMS")]
+        out[ver] = m
+    return out
+
+
+def gate_images(dist):
+    """(a)+(c): every signed image manifest verifies and the listed files
+    hash-match; install.sh has a verifying signature if present."""
+    versions = list_versions(dist)
+    if not versions:
+        die(f"no signed image manifests (xpf-*.SHA256SUMS + .minisig) in {dist} "
+            "— nothing publishable. Set XPF_SIGN_SECKEY and re-bake.")
+    for ver, manifest in sorted(versions.items()):
+        sig = manifest + ".minisig"
+        try:
+            checks = sign.parse_manifest(manifest)  # structural
+            sign.verify_signature(manifest, sig, sign.DEFAULT_IMAGE_PUBKEY)
+        except sign.SignError as e:
+            die(f"image manifest {os.path.basename(manifest)} failed verify: {e}")
+        # Every file the manifest lists must be present + hash-match.
+        for base in checks:
+            path = os.path.join(dist, base)
+            if not os.path.isfile(path):
+                die(f"manifest {os.path.basename(manifest)} lists {base} but it "
+                    f"is absent from {dist} — refusing to publish a partial set.")
+            try:
+                sign.verify_image_artifact(path, manifest, sig)
+            except sign.SignError as e:
+                die(f"image artifact {base} failed verify: {e}")
+        info(f"image set {ver}: signature + {len(checks)} file hashes OK")
+    # (c) install.sh
+    installsh = os.path.join(dist, "install.sh")
+    if os.path.isfile(installsh):
+        isig = installsh + ".minisig"
+        if not os.path.isfile(isig):
+            die("install.sh is in the publish set but install.sh.minisig is "
+                "missing — sign it before publishing.")
+        try:
+            sign.verify_signature(installsh, isig, sign.DEFAULT_IMAGE_PUBKEY)
+            info("install.sh signature OK")
+        except sign.SignError as e:
+            die(f"install.sh signature failed verify: {e}")
+    return versions
+
+
+def gate_latest(dist, channel, versions):
+    """(d): latest.json verifies and names a present version."""
+    latest = os.path.join(dist, channel, "latest.json")
+    if not os.path.isfile(latest):
+        die(f"{channel}/latest.json missing — run "
+            f"`publish.py make-latest --channel {channel} --version <V>` first.")
+    sig = latest + ".minisig"
+    if not os.path.isfile(sig):
+        die(f"{channel}/latest.json.minisig missing — the freshness pointer "
+            "must be signed.")
+    try:
+        sign.verify_signature(latest, sig, sign.DEFAULT_IMAGE_PUBKEY)
+    except sign.SignError as e:
+        die(f"latest.json signature failed verify: {e}")
+    with open(latest) as f:
+        data = json.load(f)
+    ver = data.get("version")
+    if ver not in versions:
+        die(f"latest.json names version {ver!r} which is NOT in the publish set "
+            f"{sorted(versions)} — refusing to advertise a missing version.")
+    info(f"latest.json OK (channel {channel} -> {ver})")
+
+
+def gate_apt(dist, channel):
+    """(b): the apt InRelease for `channel` verifies against the archive key."""
+    inrelease = os.path.join(dist, "apt", "dists", channel, "InRelease")
+    if not os.path.isfile(inrelease):
+        die(f"apt InRelease for suite {channel} missing "
+            f"({inrelease}) — build a SIGNED repo (XPF_GPG_KEY) first.")
+    pub = archive_pubkey()
+    if _is_placeholder(pub):
+        die("archive pubkey is the #1924 PLACEHOLDER — cannot verify InRelease. "
+            "Supply the real archive key (XPF_ARCHIVE_PUBKEY / "
+            "scripts/dist/xpf-archive-keyring.asc) before publishing.")
+    # Verify against an ephemeral keyring built only from the pinned pubkey.
+    import tempfile
+    with tempfile.TemporaryDirectory() as gnupghome:
+        os.chmod(gnupghome, 0o700)
+        env = dict(os.environ, GNUPGHOME=gnupghome)
+        r = subprocess.run(["gpg", "--batch", "--import", pub],
+                           env=env, capture_output=True, text=True)
+        if r.returncode != 0:
+            die(f"could not import archive pubkey {pub}: {r.stderr.strip()}")
+        r = subprocess.run(["gpg", "--batch", "--verify", inrelease],
+                           env=env, capture_output=True, text=True)
+        if r.returncode != 0:
+            die(f"apt InRelease signature FAILED: {r.stderr.strip()}")
+    info(f"apt InRelease ({channel}) signature OK")
+
+
+def make_latest(dist, channel, version):
+    """Write + sign the per-channel latest.json freshness pointer (§5.6)."""
+    manifest = os.path.join(dist, f"xpf-{version}.SHA256SUMS")
+    if not os.path.isfile(manifest):
+        die(f"no manifest for version {version} in {dist}")
+    seckey = os.environ.get("XPF_SIGN_SECKEY")
+    if not seckey:
+        die("XPF_SIGN_SECKEY (path to the minisign secret key) is required to "
+            "sign latest.json.")
+    cdir = os.path.join(dist, channel)
+    os.makedirs(cdir, exist_ok=True)
+    latest = os.path.join(cdir, "latest.json")
+    data = {
+        "channel": channel,
+        "version": version,
+        "manifest": f"xpf-{version}.SHA256SUMS",
+        "date": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    with open(latest, "w") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+    sign.sign_manifest(latest, seckey, comment=f"xpf {channel} latest {version}")
+    info(f"wrote + signed {latest} -> {version}")
+
+
+def dispatch(cmd, local_dir, base_url, dry):
+    info(f"publish: {cmd} {local_dir} {base_url}")
+    if dry:
+        print(f"  (dry-run) {cmd} {local_dir} {base_url}")
+        return
+    r = subprocess.run([cmd, local_dir, base_url])
+    if r.returncode != 0:
+        die(f"XPF_PUBLISH_CMD failed (rc={r.returncode}) for {base_url}")
+
+
+def main(argv):
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd")
+
+    ml = sub.add_parser("make-latest")
+    ml.add_argument("--channel", default="stable")
+    ml.add_argument("--version", required=True)
+    ml.add_argument("--dist", default=os.path.join(ROOT, "dist"))
+
+    p.add_argument("--channel", default="stable")
+    p.add_argument("--dist", default=os.path.join(ROOT, "dist"))
+    p.add_argument("--no-image", action="store_true")
+    p.add_argument("--no-apt", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    a = p.parse_args(argv)
+
+    if a.cmd == "make-latest":
+        make_latest(a.dist, a.channel, a.version)
+        return 0
+
+    dist = a.dist
+    if not os.path.isdir(dist):
+        die(f"dist dir not found: {dist}")
+
+    # ── fail-closed gate ──
+    versions = {}
+    if not a.no_image:
+        versions = gate_images(dist)
+        gate_latest(dist, a.channel, versions)
+    if not a.no_apt:
+        gate_apt(dist, a.channel)
+
+    pubcmd = os.environ.get("XPF_PUBLISH_CMD")
+    if not pubcmd:
+        info("gate PASSED. XPF_PUBLISH_CMD unset — nothing uploaded. Set it to "
+             "the backend shim ($CMD <local-dir> <dest-base-url>) to publish.")
+        return 0
+
+    if not a.no_image:
+        img_url = os.environ.get("XPF_IMAGE_BASE_URL") or die(
+            "XPF_IMAGE_BASE_URL required to publish the image tree.")
+        dispatch(pubcmd, dist, img_url, a.dry_run)
+    if not a.no_apt:
+        apt_url = os.environ.get("XPF_APT_BASE_URL") or die(
+            "XPF_APT_BASE_URL required to publish the apt tree.")
+        dispatch(pubcmd, os.path.join(dist, "apt"), apt_url, a.dry_run)
+    info("publish complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/dist/publish.py
+++ b/scripts/dist/publish.py
@@ -130,10 +130,10 @@ def gate_images(dist):
     for ver, manifest in sorted(versions.items()):
         sig = manifest + ".minisig"
         try:
-            # Verify the signature BEFORE parsing the manifest (Codex-L6):
-            # never trust an unauthenticated manifest's contents.
-            sign.verify_signature(manifest, sig, pub)
-            checks = sign.parse_manifest(manifest)
+            # Verify + parse from the VERIFIED bytes (Codex-L6 + AGY-r3-F3
+            # TOCTOU): never parse a live manifest that could be swapped after
+            # the signature check.
+            checks = sign.verify_manifest_map(manifest, sig, pub)
         except sign.SignError as e:
             die(f"image manifest {os.path.basename(manifest)} failed verify: {e}")
         # Every file the manifest lists must be present + hash-match.
@@ -148,14 +148,32 @@ def gate_images(dist):
                 die(f"image artifact {base} failed verify: {e}")
             covered.add(base)
         info(f"image set {ver}: signature + {len(checks)} file hashes OK")
-    # Orphan sweep (Codex-r2-1): the WHOLE dist tree is uploaded, so any image
-    # artifact NOT covered by a verified manifest (e.g. a stale dev qcow2)
-    # would be published unverified. Refuse it.
-    for name in sorted(os.listdir(dist)):
-        if name.endswith(IMAGE_ARTIFACT_SUFFIXES) and name not in covered:
-            die(f"orphan image artifact in the publish set: {name} is not listed "
-                "in any verified manifest — refusing to publish unverified bytes. "
-                "Remove it or sign a manifest covering it.")
+    # Orphan sweep (Codex-r2-1 / r3): the WHOLE dist tree is uploaded
+    # RECURSIVELY (rsync -a / aws s3 sync), so walk the tree — not just the top
+    # level — and refuse any image artifact NOT covered by a verified manifest,
+    # wherever it sits (e.g. a nested dist/stable/xpf-evil.qcow2). The apt pool
+    # is gated separately (gate_apt) so skip apt/.
+    apt_dir = os.path.join(dist, "apt")
+    for root, _dirs, files in os.walk(dist):
+        if root == apt_dir or root.startswith(apt_dir + os.sep):
+            continue
+        for name in sorted(files):
+            if not name.endswith(IMAGE_ARTIFACT_SUFFIXES):
+                continue
+            rel = os.path.relpath(os.path.join(root, name), dist)
+            # Image artifacts live ONLY at the top level (the bake writes
+            # dist/xpf-<ver>.*). A nested one (e.g. dist/stable/xpf-evil.qcow2)
+            # can never be a verified artifact — a manifest binds BASENAMES, so
+            # a nested duplicate basename would also escape a basename-only
+            # `covered` check. Refuse any image artifact below the top level.
+            if os.path.abspath(root) != os.path.abspath(dist):
+                die(f"image artifact outside the top-level dist dir: {rel} — "
+                    "images belong at dist/xpf-<ver>.*; refusing to publish "
+                    "unverified nested bytes.")
+            if name not in covered:
+                die(f"orphan image artifact in the publish set: {rel} is not "
+                    "listed in any verified manifest — refusing to publish "
+                    "unverified bytes. Remove it or sign a manifest covering it.")
     # (c) install.sh — signed AND not the placeholder.
     installsh = os.path.join(dist, "install.sh")
     if os.path.isfile(installsh):
@@ -186,12 +204,14 @@ def gate_latest(dist, channel, versions, pub):
     if not os.path.isfile(sig):
         die(f"{channel}/latest.json.minisig missing — the freshness pointer "
             "must be signed.")
+    # Verify + parse from the VERIFIED bytes (AGY-r3-F1 TOCTOU): do not re-open
+    # the live latest.json after the signature check.
     try:
-        sign.verify_signature(latest, sig, pub)
+        data = json.loads(sign.verify_and_read(latest, sig, pub).decode())
     except sign.SignError as e:
         die(f"latest.json signature failed verify: {e}")
-    with open(latest) as f:
-        data = json.load(f)
+    except (ValueError, UnicodeDecodeError) as e:
+        die(f"latest.json is not valid JSON after verify: {e}")
     ver = data.get("version")
     if ver not in versions:
         die(f"latest.json names version {ver!r} which is NOT in the publish set "
@@ -200,16 +220,22 @@ def gate_latest(dist, channel, versions, pub):
 
 
 def gate_apt(dist, channel):
-    """(b): the apt InRelease for `channel` verifies against the archive key."""
-    inrelease = os.path.join(dist, "apt", "dists", channel, "InRelease")
-    if not os.path.isfile(inrelease):
-        die(f"apt InRelease for suite {channel} missing "
-            f"({inrelease}) — build a SIGNED repo (XPF_GPG_KEY) first.")
+    """(b): the apt InRelease verifies against the archive key. The whole
+    apt/ tree is uploaded (rsync/s3 sync), so EVERY suite present under
+    dists/ — not just the target `channel` — must carry a verifying
+    InRelease (AGY-r3-F2). The target channel must exist."""
+    distsdir = os.path.join(dist, "apt", "dists")
+    target = os.path.join(distsdir, channel, "InRelease")
+    if not os.path.isfile(target):
+        die(f"apt InRelease for the target suite {channel} missing "
+            f"({target}) — build a SIGNED repo (XPF_GPG_KEY) first.")
     pub = archive_pubkey()
     if _is_placeholder(pub):
         die("archive pubkey is the #1924 PLACEHOLDER — cannot verify InRelease. "
             "Supply the real archive key (XPF_ARCHIVE_PUBKEY / "
             "scripts/dist/xpf-archive-keyring.asc) before publishing.")
+    suites = sorted(d for d in os.listdir(distsdir)
+                    if os.path.isdir(os.path.join(distsdir, d)))
     # Verify against an ephemeral keyring built only from the pinned pubkey.
     import tempfile
     with tempfile.TemporaryDirectory() as gnupghome:
@@ -219,11 +245,17 @@ def gate_apt(dist, channel):
                            env=env, capture_output=True, text=True)
         if r.returncode != 0:
             die(f"could not import archive pubkey {pub}: {r.stderr.strip()}")
-        r = subprocess.run(["gpg", "--batch", "--verify", inrelease],
-                           env=env, capture_output=True, text=True)
-        if r.returncode != 0:
-            die(f"apt InRelease signature FAILED: {r.stderr.strip()}")
-    info(f"apt InRelease ({channel}) signature OK")
+        for suite in suites:
+            inrel = os.path.join(distsdir, suite, "InRelease")
+            if not os.path.isfile(inrel):
+                die(f"suite {suite} under dists/ has no InRelease — the whole "
+                    "apt tree is uploaded, so every suite must be signed. "
+                    "Rebuild or remove it.")
+            r = subprocess.run(["gpg", "--batch", "--verify", inrel],
+                               env=env, capture_output=True, text=True)
+            if r.returncode != 0:
+                die(f"apt InRelease ({suite}) signature FAILED: {r.stderr.strip()}")
+            info(f"apt InRelease ({suite}) signature OK")
     # The pooled .deb must not carry the PLACEHOLDER archive keyring
     # (Codex-r2-2): a package built before the real key existed would, once
     # installed, overwrite a host's real /usr/share/keyrings key with the
@@ -240,7 +272,12 @@ def gate_apt(dist, channel):
                     r = subprocess.run(["dpkg-deb", "-x", debp, td],
                                        capture_output=True, text=True)
                     if r.returncode != 0:
-                        continue  # not the xpf package / unreadable; skip
+                        # Fail-CLOSED (Codex-r3): an uninspectable pooled .deb
+                        # must NOT be published — we cannot confirm it does not
+                        # ship the placeholder keyring.
+                        die(f"cannot extract pooled package {fn} for inspection "
+                            f"(dpkg-deb rc={r.returncode}): {r.stderr.strip()} — "
+                            "refusing to publish an uninspectable package.")
                     kp = os.path.join(td, "usr/share/keyrings/"
                                       "xpf-archive-keyring.asc")
                     if os.path.isfile(kp) and _is_placeholder(kp):

--- a/scripts/dist/publish.py
+++ b/scripts/dist/publish.py
@@ -154,10 +154,26 @@ def gate_images(dist):
     # wherever it sits (e.g. a nested dist/stable/xpf-evil.qcow2). The apt pool
     # is gated separately (gate_apt) so skip apt/.
     apt_dir = os.path.join(dist, "apt")
-    for root, _dirs, files in os.walk(dist):
+    for root, dirs, files in os.walk(dist):
         if root == apt_dir or root.startswith(apt_dir + os.sep):
+            dirs[:] = []
             continue
+        # Reject symlinks under the image publish root (Codex-r4): os.walk
+        # does not follow dir symlinks, but a backend that dereferences them
+        # (some sync tools) could upload nested unverified bytes the sweep
+        # never saw. Refuse any symlink (dir or file) outside apt/.
+        for d in list(dirs):
+            if os.path.islink(os.path.join(root, d)):
+                rel = os.path.relpath(os.path.join(root, d), dist)
+                die(f"symlinked directory in the image publish set: {rel} — "
+                    "refusing (a dereferencing backend could upload "
+                    "unverified bytes).")
         for name in sorted(files):
+            full = os.path.join(root, name)
+            if os.path.islink(full):
+                rel = os.path.relpath(full, dist)
+                die(f"symlink in the image publish set: {rel} — refusing "
+                    "(a dereferencing backend could upload unverified bytes).")
             if not name.endswith(IMAGE_ARTIFACT_SUFFIXES):
                 continue
             rel = os.path.relpath(os.path.join(root, name), dist)
@@ -346,6 +362,16 @@ def main(argv):
     dist = a.dist
     if not os.path.isdir(dist):
         die(f"dist dir not found: {dist}")
+
+    # An image-only publish (--no-apt) dispatches the WHOLE dist root, which
+    # includes dist/apt if present — so apt bytes would ship UNGATED
+    # (Codex-r4). Refuse --no-apt when an apt tree exists; either gate it too
+    # or publish from a tree without apt/.
+    if a.no_apt and not a.no_image and os.path.isdir(os.path.join(dist, "apt")):
+        die("--no-apt but dist/apt exists: an image publish uploads the whole "
+            "dist tree (including apt/), so the apt repo would ship UNGATED. "
+            "Drop --no-apt (gate apt too), or move dist/apt out of the publish "
+            "root.")
 
     # ── fail-closed gate ──
     if not a.no_image:

--- a/scripts/dist/publish.py
+++ b/scripts/dist/publish.py
@@ -240,6 +240,18 @@ def gate_apt(dist, channel):
     apt/ tree is uploaded (rsync/s3 sync), so EVERY suite present under
     dists/ — not just the target `channel` — must carry a verifying
     InRelease (AGY-r3-F2). The target channel must exist."""
+    apt_root = os.path.join(dist, "apt")
+    # Reject symlinks anywhere under apt/ (Codex-r5): the apt tree is uploaded
+    # as part of the dist root, and a dereferencing backend could follow a
+    # symlink to publish unverified bytes — the same class as the image-sweep
+    # symlink rejection, through the apt subtree.
+    if os.path.isdir(apt_root):
+        for root, dirs, files in os.walk(apt_root):
+            for nm in list(dirs) + files:
+                if os.path.islink(os.path.join(root, nm)):
+                    rel = os.path.relpath(os.path.join(root, nm), dist)
+                    die(f"symlink in the apt publish set: {rel} — refusing "
+                        "(a dereferencing backend could upload unverified bytes).")
     distsdir = os.path.join(dist, "apt", "dists")
     target = os.path.join(distsdir, channel, "InRelease")
     if not os.path.isfile(target):

--- a/scripts/dist/publish.py
+++ b/scripts/dist/publish.py
@@ -79,11 +79,17 @@ def _is_placeholder(path):
 
 
 def list_versions(dist):
-    """Discover baked versions from signed manifests in `dist`."""
+    """Discover baked versions from manifests in `dist`. FAIL-CLOSED
+    (Codex-H1/AGY-A2): if ANY xpf-*.SHA256SUMS lacks a .minisig, refuse the
+    whole publish — the upload step pushes the entire dist tree, so an
+    unsigned dev bake sitting next to a signed one would otherwise be
+    uploaded. Do not silently skip the unsigned one."""
     out = {}
-    for m in glob.glob(os.path.join(dist, "xpf-*.SHA256SUMS")):
+    for m in sorted(glob.glob(os.path.join(dist, "xpf-*.SHA256SUMS"))):
         if not os.path.isfile(m + ".minisig"):
-            continue
+            die(f"unsigned manifest in the publish set: {os.path.basename(m)} "
+                "has no .minisig. The whole dist tree is uploaded — refusing to "
+                "publish an unsigned artifact. Sign it or remove it.")
         base = os.path.basename(m)
         ver = base[len("xpf-"):-len(".SHA256SUMS")]
         out[ver] = m
@@ -97,11 +103,18 @@ def gate_images(dist):
     if not versions:
         die(f"no signed image manifests (xpf-*.SHA256SUMS + .minisig) in {dist} "
             "— nothing publishable. Set XPF_SIGN_SECKEY and re-bake.")
+    if sign.is_placeholder_pubkey(sign.DEFAULT_IMAGE_PUBKEY) \
+            and not os.environ.get("XPF_IMAGE_PUBKEY"):
+        die("image pubkey is the #1924 PLACEHOLDER — cannot verify image "
+            "signatures. Supply the real key (XPF_IMAGE_PUBKEY / "
+            "scripts/dist/xpf-image.pub) before publishing.")
     for ver, manifest in sorted(versions.items()):
         sig = manifest + ".minisig"
         try:
-            checks = sign.parse_manifest(manifest)  # structural
+            # Verify the signature BEFORE parsing the manifest (Codex-L6):
+            # never trust an unauthenticated manifest's contents.
             sign.verify_signature(manifest, sig, sign.DEFAULT_IMAGE_PUBKEY)
+            checks = sign.parse_manifest(manifest)
         except sign.SignError as e:
             die(f"image manifest {os.path.basename(manifest)} failed verify: {e}")
         # Every file the manifest lists must be present + hash-match.

--- a/scripts/dist/publish.py
+++ b/scripts/dist/publish.py
@@ -57,6 +57,26 @@ def die(m):
     sys.exit(f"PUBLISH ERROR: {m}")
 
 
+def image_pubkey():
+    """Resolve the minisign IMAGE pubkey ONCE, honoring XPF_IMAGE_PUBKEY
+    (Codex-r2-3). Fail-CLOSED on the placeholder (Codex-r2-2): the gate must
+    never verify against a key whose secret is held by no one."""
+    pub = os.environ.get("XPF_IMAGE_PUBKEY") or sign.DEFAULT_IMAGE_PUBKEY
+    if sign.is_placeholder_pubkey(pub):
+        die("image pubkey is the #1924 PLACEHOLDER — cannot verify image "
+            "signatures. Supply the real key (XPF_IMAGE_PUBKEY / "
+            "scripts/dist/xpf-image.pub) before publishing.")
+    if not os.path.isfile(pub):
+        die(f"image pubkey not found: {pub}")
+    return pub
+
+
+# Image artifact basenames we sweep for orphans (Codex-r2-1): any of these in
+# `dist` that is NOT covered by a verified manifest blocks the publish, because
+# the whole dist tree is uploaded.
+IMAGE_ARTIFACT_SUFFIXES = (".qcow2", ".incus-metadata.tar.gz")
+
+
 def archive_pubkey():
     """Resolve the OpenPGP archive pubkey path (override or pinned, else
     placeholder). gpg verifies InRelease against an ephemeral keyring built
@@ -98,22 +118,21 @@ def list_versions(dist):
 
 def gate_images(dist):
     """(a)+(c): every signed image manifest verifies and the listed files
-    hash-match; install.sh has a verifying signature if present."""
+    hash-match; EVERY image artifact in dist is covered by a verified manifest
+    (no orphans); install.sh has a verifying signature and is not the
+    placeholder."""
     versions = list_versions(dist)
     if not versions:
         die(f"no signed image manifests (xpf-*.SHA256SUMS + .minisig) in {dist} "
             "— nothing publishable. Set XPF_SIGN_SECKEY and re-bake.")
-    if sign.is_placeholder_pubkey(sign.DEFAULT_IMAGE_PUBKEY) \
-            and not os.environ.get("XPF_IMAGE_PUBKEY"):
-        die("image pubkey is the #1924 PLACEHOLDER — cannot verify image "
-            "signatures. Supply the real key (XPF_IMAGE_PUBKEY / "
-            "scripts/dist/xpf-image.pub) before publishing.")
+    pub = image_pubkey()
+    covered = set()
     for ver, manifest in sorted(versions.items()):
         sig = manifest + ".minisig"
         try:
             # Verify the signature BEFORE parsing the manifest (Codex-L6):
             # never trust an unauthenticated manifest's contents.
-            sign.verify_signature(manifest, sig, sign.DEFAULT_IMAGE_PUBKEY)
+            sign.verify_signature(manifest, sig, pub)
             checks = sign.parse_manifest(manifest)
         except sign.SignError as e:
             die(f"image manifest {os.path.basename(manifest)} failed verify: {e}")
@@ -124,26 +143,40 @@ def gate_images(dist):
                 die(f"manifest {os.path.basename(manifest)} lists {base} but it "
                     f"is absent from {dist} — refusing to publish a partial set.")
             try:
-                sign.verify_image_artifact(path, manifest, sig)
+                sign.verify_image_artifact(path, manifest, sig, pub)
             except sign.SignError as e:
                 die(f"image artifact {base} failed verify: {e}")
+            covered.add(base)
         info(f"image set {ver}: signature + {len(checks)} file hashes OK")
-    # (c) install.sh
+    # Orphan sweep (Codex-r2-1): the WHOLE dist tree is uploaded, so any image
+    # artifact NOT covered by a verified manifest (e.g. a stale dev qcow2)
+    # would be published unverified. Refuse it.
+    for name in sorted(os.listdir(dist)):
+        if name.endswith(IMAGE_ARTIFACT_SUFFIXES) and name not in covered:
+            die(f"orphan image artifact in the publish set: {name} is not listed "
+                "in any verified manifest — refusing to publish unverified bytes. "
+                "Remove it or sign a manifest covering it.")
+    # (c) install.sh — signed AND not the placeholder.
     installsh = os.path.join(dist, "install.sh")
     if os.path.isfile(installsh):
+        with open(installsh) as f:
+            if "PLACEHOLDER-xpf-archive-keyring" in f.read():
+                die("install.sh in the publish set still embeds the PLACEHOLDER "
+                    "archive key — refusing to publish an installer that cannot "
+                    "verify the repo. Substitute the real key first.")
         isig = installsh + ".minisig"
         if not os.path.isfile(isig):
             die("install.sh is in the publish set but install.sh.minisig is "
                 "missing — sign it before publishing.")
         try:
-            sign.verify_signature(installsh, isig, sign.DEFAULT_IMAGE_PUBKEY)
+            sign.verify_signature(installsh, isig, pub)
             info("install.sh signature OK")
         except sign.SignError as e:
             die(f"install.sh signature failed verify: {e}")
-    return versions
+    return versions, pub
 
 
-def gate_latest(dist, channel, versions):
+def gate_latest(dist, channel, versions, pub):
     """(d): latest.json verifies and names a present version."""
     latest = os.path.join(dist, channel, "latest.json")
     if not os.path.isfile(latest):
@@ -154,7 +187,7 @@ def gate_latest(dist, channel, versions):
         die(f"{channel}/latest.json.minisig missing — the freshness pointer "
             "must be signed.")
     try:
-        sign.verify_signature(latest, sig, sign.DEFAULT_IMAGE_PUBKEY)
+        sign.verify_signature(latest, sig, pub)
     except sign.SignError as e:
         die(f"latest.json signature failed verify: {e}")
     with open(latest) as f:
@@ -191,6 +224,30 @@ def gate_apt(dist, channel):
         if r.returncode != 0:
             die(f"apt InRelease signature FAILED: {r.stderr.strip()}")
     info(f"apt InRelease ({channel}) signature OK")
+    # The pooled .deb must not carry the PLACEHOLDER archive keyring
+    # (Codex-r2-2): a package built before the real key existed would, once
+    # installed, overwrite a host's real /usr/share/keyrings key with the
+    # placeholder and break `apt update`. Refuse to publish such a pool.
+    pool = os.path.join(dist, "apt", "pool")
+    if os.path.isdir(pool):
+        import tempfile as _tf
+        for root, _dirs, files in os.walk(pool):
+            for fn in files:
+                if not fn.endswith(".deb"):
+                    continue
+                debp = os.path.join(root, fn)
+                with _tf.TemporaryDirectory() as td:
+                    r = subprocess.run(["dpkg-deb", "-x", debp, td],
+                                       capture_output=True, text=True)
+                    if r.returncode != 0:
+                        continue  # not the xpf package / unreadable; skip
+                    kp = os.path.join(td, "usr/share/keyrings/"
+                                      "xpf-archive-keyring.asc")
+                    if os.path.isfile(kp) and _is_placeholder(kp):
+                        die(f"pooled package {fn} ships the PLACEHOLDER archive "
+                            "keyring — refusing to publish (it would clobber a "
+                            "host's real key on upgrade). Rebuild the .deb after "
+                            "dropping in scripts/dist/xpf-archive-keyring.asc.")
 
 
 def make_latest(dist, channel, version):
@@ -254,10 +311,9 @@ def main(argv):
         die(f"dist dir not found: {dist}")
 
     # ── fail-closed gate ──
-    versions = {}
     if not a.no_image:
-        versions = gate_images(dist)
-        gate_latest(dist, a.channel, versions)
+        versions, pub = gate_images(dist)
+        gate_latest(dist, a.channel, versions, pub)
     if not a.no_apt:
         gate_apt(dist, a.channel)
 

--- a/scripts/dist/selftest.sh
+++ b/scripts/dist/selftest.sh
@@ -170,6 +170,12 @@ if [ -f "$INREL" ] && gpg --batch --verify "$INREL" >/dev/null 2>&1; then
 else
     bad "InRelease missing or signature failed"
 fi
+# Valid-Until must actually be emitted (Codex-M3 regression).
+if grep -q "^Valid-Until:" "$OUT/apt/dists/stable/Release"; then
+    ok "Release carries Valid-Until"
+else
+    bad "Release missing Valid-Until (ValidTime knob regression)"
+fi
 # Negative: a tampered InRelease must fail.
 if [ -f "$INREL" ]; then
     cp "$INREL" "$WORK/InRelease.tampered"
@@ -179,6 +185,17 @@ if [ -f "$INREL" ]; then
     else
         ok "tampered InRelease fails verify"
     fi
+fi
+
+# ── 5b. publish gate fail-closed (Codex-H1 / AGY-A2) ──────────────────────
+info "5b. publish gate fail-closed on an unsigned manifest"
+PG="$WORK/pgate"; mkdir -p "$PG"
+printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef  xpf-9.9.9.qcow2\n' \
+    > "$PG/xpf-9.9.9.SHA256SUMS"   # NO .minisig
+if $PY "$DIST/publish.py" --dist "$PG" --channel stable --no-apt >/dev/null 2>&1; then
+    bad "publish MUST refuse an unsigned manifest but PASSED"
+else
+    ok "publish refuses an unsigned manifest"
 fi
 
 # ── 6. install.sh dry-run ──────────────────────────────────────────────────

--- a/scripts/dist/selftest.sh
+++ b/scripts/dist/selftest.sh
@@ -209,6 +209,17 @@ else
     ok "publish refuses an orphan image artifact"
 fi
 
+# Symlink under the image publish root (Codex-r4).
+PGS="$WORK/pgsym"; mkdir -p "$PGS"
+cp "$QCOW" "$META" "$MANIFEST" "$MANIFEST.minisig" "$PGS/"
+ln -s /etc/passwd "$PGS/sneaky.qcow2"
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
+     --dist "$PGS" --channel stable --no-apt >/dev/null 2>&1; then
+    bad "publish MUST refuse a symlink in the image set but PASSED"
+else
+    ok "publish refuses a symlink in the image set"
+fi
+
 # ── 6. install.sh dry-run ──────────────────────────────────────────────────
 info "6. install.sh --dry-run (preflight + source rendering)"
 if XPF_DRY_RUN=1 XPF_APT_BASE_URL="https://example.invalid/apt" XPF_CHANNEL=stable \

--- a/scripts/dist/selftest.sh
+++ b/scripts/dist/selftest.sh
@@ -1,0 +1,210 @@
+#!/bin/sh
+# xpf signed-distribution self-test (#1924) — the local roundtrip gate.
+#
+# Proves, end to end, with a THROWAWAY keypair (generated in a temp dir,
+# never committed) and NO hosting:
+#   1. sign a per-version manifest over fake qcow2 + metadata;
+#   2. verify each artifact against the signed manifest (PASS);
+#   3. tamper-detection: a modified artifact, a tampered manifest, a
+#      tampered signature, and a wrong pubkey each MUST FAIL verify;
+#   4. build a flat signed apt repo over a fake .deb and verify InRelease;
+#   5. install.sh --dry-run preflight/source rendering.
+#
+# Exit 0 only if every positive check passes AND every tamper check fails.
+set -eu
+
+# shellcheck disable=SC1007  # `CDPATH= cd` clears CDPATH for this command only
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+DIST="$ROOT/scripts/dist"
+PY=python3
+PASS=0
+FAIL=0
+
+ok()   { echo "  PASS: $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+info() { echo "==> $*"; }
+
+command -v minisign >/dev/null 2>&1 || { echo "SKIP: minisign not installed (apt-get install minisign)"; exit 77; }
+command -v gpg >/dev/null 2>&1 || { echo "SKIP: gpg not installed"; exit 77; }
+command -v apt-ftparchive >/dev/null 2>&1 || { echo "SKIP: apt-ftparchive not installed (apt-utils)"; exit 77; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/xpf-dist-selftest.XXXXXX")
+GNUPGHOME="$WORK/gnupg"; export GNUPGHOME
+mkdir -p "$GNUPGHOME"; chmod 700 "$GNUPGHOME"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT INT TERM
+
+VER="0.0.0-selftest"
+OUT="$WORK/dist"
+mkdir -p "$OUT"
+
+# ── throwaway image keypair ───────────────────────────────────────────────
+info "1. generate throwaway minisign image keypair (passwordless)"
+minisign -G -W -p "$WORK/img.pub" -s "$WORK/img.sec" >/dev/null 2>&1
+WRONGPUB="$WORK/wrong.pub"
+minisign -G -W -p "$WRONGPUB" -s "$WORK/wrong.sec" >/dev/null 2>&1
+
+# ── fake artifacts + signed manifest ──────────────────────────────────────
+info "2. create fake artifacts + signed per-version manifest"
+QCOW="$OUT/xpf-$VER.qcow2"
+META="$OUT/xpf-$VER.incus-metadata.tar.gz"
+head -c 4096 /dev/urandom > "$QCOW"
+head -c 1024 /dev/urandom > "$META"
+MANIFEST="$OUT/xpf-$VER.SHA256SUMS"
+XPF_IMAGE_PUBKEY="$WORK/img.pub" \
+  $PY "$DIST/sign.py" sign-manifest --manifest "$MANIFEST" \
+      --seckey "$WORK/img.sec" --comment "selftest" "$QCOW" "$META" >/dev/null
+[ -f "$MANIFEST.minisig" ] && ok "manifest signed" || bad "manifest not signed"
+
+verify() {  # verify <file> with pubkey; prints OK/err, returns rc
+    XPF_IMAGE_PUBKEY="$1" $PY "$DIST/sign.py" verify \
+        --manifest "$MANIFEST" --pubkey "$1" "$2" >/dev/null 2>&1
+}
+
+# ── 3. positive verification ──────────────────────────────────────────────
+info "3. positive verification (must PASS)"
+verify "$WORK/img.pub" "$QCOW"  && ok "qcow2 verifies"     || bad "qcow2 should verify"
+verify "$WORK/img.pub" "$META"  && ok "metadata verifies"  || bad "metadata should verify"
+
+# Per-file: qcow2-only operator can verify without metadata present.
+QONLY="$WORK/qonly"; mkdir -p "$QONLY"
+cp "$QCOW" "$MANIFEST" "$MANIFEST.minisig" "$QONLY/"
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/sign.py" verify \
+     --manifest "$QONLY/xpf-$VER.SHA256SUMS" --pubkey "$WORK/img.pub" \
+     "$QONLY/xpf-$VER.qcow2" >/dev/null 2>&1; then
+    ok "qcow2-only verifies without metadata present"
+else
+    bad "qcow2-only should verify (per-file)"
+fi
+
+# ── 4. tamper-detection (each MUST FAIL) ──────────────────────────────────
+info "4. tamper-detection (each MUST FAIL verify)"
+
+# 4a. modified artifact
+TQ="$WORK/tamper"; mkdir -p "$TQ"
+cp "$MANIFEST" "$MANIFEST.minisig" "$TQ/"
+head -c 4096 /dev/urandom > "$TQ/xpf-$VER.qcow2"   # different bytes
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/sign.py" verify \
+     --manifest "$TQ/xpf-$VER.SHA256SUMS" --pubkey "$WORK/img.pub" \
+     "$TQ/xpf-$VER.qcow2" >/dev/null 2>&1; then
+    bad "modified qcow2 MUST fail verify but PASSED"
+else
+    ok "modified qcow2 fails verify"
+fi
+
+# 4b. tampered manifest (flip a hash) — signature must no longer match
+TM="$WORK/tmanifest"; mkdir -p "$TM"
+cp "$QCOW" "$META" "$MANIFEST.minisig" "$TM/"
+sed 's/^./0/' "$MANIFEST" > "$TM/xpf-$VER.SHA256SUMS"   # corrupt first hex char
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/sign.py" verify \
+     --manifest "$TM/xpf-$VER.SHA256SUMS" \
+     --sig "$TM/xpf-$VER.SHA256SUMS.minisig" --pubkey "$WORK/img.pub" \
+     "$TM/xpf-$VER.qcow2" >/dev/null 2>&1; then
+    bad "tampered manifest MUST fail verify but PASSED"
+else
+    ok "tampered manifest fails verify"
+fi
+
+# 4c. tampered signature
+TS="$WORK/tsig"; mkdir -p "$TS"
+cp "$QCOW" "$META" "$MANIFEST" "$TS/"
+sed '$ s/.$/X/' "$MANIFEST.minisig" > "$TS/xpf-$VER.SHA256SUMS.minisig" 2>/dev/null \
+  || tr 'A' 'B' < "$MANIFEST.minisig" > "$TS/xpf-$VER.SHA256SUMS.minisig"
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/sign.py" verify \
+     --manifest "$TS/xpf-$VER.SHA256SUMS" --pubkey "$WORK/img.pub" \
+     "$TS/xpf-$VER.qcow2" >/dev/null 2>&1; then
+    bad "tampered signature MUST fail verify but PASSED"
+else
+    ok "tampered signature fails verify"
+fi
+
+# 4d. wrong pubkey
+if verify "$WRONGPUB" "$QCOW"; then
+    bad "wrong pubkey MUST fail verify but PASSED"
+else
+    ok "wrong pubkey fails verify"
+fi
+
+# ── 5. flat signed apt repo + InRelease verify ─────────────────────────────
+info "5. flat signed apt repo build + InRelease verify"
+# Throwaway gpg archive key (unattended, no passphrase).
+cat > "$WORK/gpg-batch" <<EOF
+%no-protection
+Key-Type: eddsa
+Key-Curve: ed25519
+Key-Usage: sign
+Name-Real: xpf selftest archive
+Name-Email: selftest@xpf.invalid
+Expire-Date: 0
+%commit
+EOF
+gpg --batch --gen-key "$WORK/gpg-batch" >/dev/null 2>&1
+GPGKEY=$(gpg --batch --list-keys --with-colons selftest@xpf.invalid | awk -F: '/^fpr:/{print $10; exit}')
+[ -n "$GPGKEY" ] && ok "archive key generated ($GPGKEY)" || { bad "archive key gen failed"; }
+
+# Fake .deb (apt-ftparchive only reads control metadata; a minimal valid .deb).
+DEBDIR="$WORK/pkg"; mkdir -p "$DEBDIR/DEBIAN"
+cat > "$DEBDIR/DEBIAN/control" <<EOF
+Package: xpf-appliance
+Version: $VER
+Architecture: amd64
+Maintainer: selftest <selftest@xpf.invalid>
+Description: xpf selftest fake package
+EOF
+mkdir -p "$ROOT/dist/deb"
+FAKEDEB="$ROOT/dist/deb/xpf-appliance_${VER}_amd64.selftest.deb"
+dpkg-deb --build "$DEBDIR" "$FAKEDEB" >/dev/null 2>&1
+cleanup_deb() { rm -f "$FAKEDEB"; }
+trap 'cleanup; cleanup_deb' EXIT INT TERM
+
+if XPF_GPG_KEY="$GPGKEY" XPF_APT_VALID_DAYS=365 \
+   sh "$DIST/build-apt-repo.sh" --out "$OUT" --suite stable --debs "$FAKEDEB" >/dev/null 2>&1; then
+    ok "flat signed apt repo built"
+else
+    bad "apt repo build failed"
+fi
+
+INREL="$OUT/apt/dists/stable/InRelease"
+if [ -f "$INREL" ] && gpg --batch --verify "$INREL" >/dev/null 2>&1; then
+    ok "InRelease signature verifies"
+else
+    bad "InRelease missing or signature failed"
+fi
+# Negative: a tampered InRelease must fail.
+if [ -f "$INREL" ]; then
+    cp "$INREL" "$WORK/InRelease.tampered"
+    sed 's/Codename: stable/Codename: EVIL/' "$INREL" > "$WORK/InRelease.tampered" || true
+    if gpg --batch --verify "$WORK/InRelease.tampered" >/dev/null 2>&1; then
+        bad "tampered InRelease MUST fail verify but PASSED"
+    else
+        ok "tampered InRelease fails verify"
+    fi
+fi
+
+# ── 6. install.sh dry-run ──────────────────────────────────────────────────
+info "6. install.sh --dry-run (preflight + source rendering)"
+if XPF_DRY_RUN=1 XPF_APT_BASE_URL="https://example.invalid/apt" XPF_CHANNEL=stable \
+   sh "$DIST/install.sh" >"$WORK/install.out" 2>&1; then
+    if grep -q "preflight OK" "$WORK/install.out" \
+       && grep -q "Suites: stable" "$WORK/install.out"; then
+        ok "install.sh dry-run preflight + source render OK"
+    else
+        bad "install.sh dry-run output missing expected lines"; cat "$WORK/install.out" >&2
+    fi
+else
+    # Dry-run on THIS host may legitimately fail preflight (kernel < 6.18 etc.).
+    # That is a valid PASS for the preflight logic — assert it failed for a
+    # preflight reason, not a script error.
+    if grep -q "ERROR:" "$WORK/install.out" && \
+       grep -qE "kernel|arch|distro|os-release" "$WORK/install.out"; then
+        ok "install.sh dry-run preflight correctly refused this host"
+    else
+        bad "install.sh dry-run errored unexpectedly"; cat "$WORK/install.out" >&2
+    fi
+fi
+
+# ── tally ──────────────────────────────────────────────────────────────────
+echo
+echo "==> selftest: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "==> #1924 signed-distribution roundtrip OK (throwaway key; no real key, no host)"

--- a/scripts/dist/selftest.sh
+++ b/scripts/dist/selftest.sh
@@ -198,6 +198,17 @@ else
     ok "publish refuses an unsigned manifest"
 fi
 
+# Orphan image artifact NOT covered by any manifest (Codex-r2-1).
+PGO="$WORK/pgorphan"; mkdir -p "$PGO"
+cp "$QCOW" "$META" "$MANIFEST" "$MANIFEST.minisig" "$PGO/"
+head -c 64 /dev/urandom > "$PGO/xpf-9.9.9.qcow2"   # orphan, no manifest covers it
+if XPF_IMAGE_PUBKEY="$WORK/img.pub" $PY "$DIST/publish.py" \
+     --dist "$PGO" --channel stable --no-apt >/dev/null 2>&1; then
+    bad "publish MUST refuse an orphan image artifact but PASSED"
+else
+    ok "publish refuses an orphan image artifact"
+fi
+
 # ── 6. install.sh dry-run ──────────────────────────────────────────────────
 info "6. install.sh --dry-run (preflight + source rendering)"
 if XPF_DRY_RUN=1 XPF_APT_BASE_URL="https://example.invalid/apt" XPF_CHANNEL=stable \

--- a/scripts/dist/sign.py
+++ b/scripts/dist/sign.py
@@ -64,6 +64,27 @@ def require_minisign():
     return exe
 
 
+def is_placeholder_pubkey(pubkey_path):
+    """True if `pubkey_path` is the shipped placeholder (its secret was
+    shredded at generation, so it can never authenticate a real release)."""
+    return os.path.basename(pubkey_path).endswith(".placeholder")
+
+
+def require_real_pubkey(pubkey_path):
+    """Fail-CLOSED if the image pubkey is the placeholder (Codex-M4). The
+    placeholder exists only so the mechanism + tests have a key-path shape;
+    a real verify against it would either always fail (no holder of its
+    secret) or — worse — pass if an attacker re-signed with a self-generated
+    placeholder secret. Refuse it explicitly, mirroring the apt-key
+    placeholder refusal in publish.py."""
+    if is_placeholder_pubkey(pubkey_path):
+        raise SignError(
+            f"image public key {os.path.basename(pubkey_path)} is the #1924 "
+            "PLACEHOLDER — refusing to verify against it. Supply the real key "
+            "(XPF_IMAGE_PUBKEY or scripts/dist/xpf-image.pub) — see "
+            "scripts/dist/README.md.")
+
+
 def sha256_file(path):
     h = hashlib.sha256()
     with open(path, "rb") as f:
@@ -183,8 +204,25 @@ def verify_image_artifact(path, manifest_path, sig_path, pubkey_path=None):
         raise SignError(
             f"image public key not found: {pubkey_path} "
             "(set XPF_IMAGE_PUBKEY or ship scripts/dist/xpf-image.pub).")
-    verify_signature(manifest_path, sig_path, pubkey_path)
-    manifest = parse_manifest(manifest_path)
+    require_real_pubkey(pubkey_path)
+    # TOCTOU hardening (Codex-M5/AGY-A4): the manifest may live in a
+    # user-writable dir, so a concurrent process could swap its bytes between
+    # the minisign signature check and the parse. Copy the manifest + its
+    # signature into a private 0700 temp dir and run BOTH steps on that copy,
+    # so the bytes we parse are exactly the bytes whose signature we verified.
+    import shutil as _sh
+    import tempfile as _tf
+    tmp = _tf.mkdtemp(prefix="xpf-verify-")
+    try:
+        os.chmod(tmp, 0o700)
+        m_copy = os.path.join(tmp, os.path.basename(manifest_path))
+        s_copy = m_copy + ".minisig"
+        _sh.copyfile(manifest_path, m_copy)
+        _sh.copyfile(sig_path, s_copy)
+        verify_signature(m_copy, s_copy, pubkey_path)
+        manifest = parse_manifest(m_copy)
+    finally:
+        _sh.rmtree(tmp, ignore_errors=True)
     base = os.path.basename(path)
     if base not in manifest:
         raise SignError(

--- a/scripts/dist/sign.py
+++ b/scripts/dist/sign.py
@@ -170,7 +170,7 @@ def parse_manifest(manifest_path):
                     f"{manifest_path}:{lineno}: malformed manifest line: {raw!r}")
             digest, name = parts
             name = name.lstrip("*")  # sha256sum binary-mode marker
-            if "/" in name or name in ("", ".", ".."):
+            if "/" in name or "\\" in name or name in ("", ".", ".."):
                 raise SignError(
                     f"{manifest_path}:{lineno}: manifest entry must be a bare "
                     f"basename, got {name!r}")
@@ -186,18 +186,7 @@ def parse_manifest(manifest_path):
     return result
 
 
-def verify_image_artifact(path, manifest_path, sig_path, pubkey_path=None):
-    """Verify ONE artifact `path` against a signed manifest.
-
-    Steps (plan §5.2):
-      1. minisign-verify the manifest signature against the pinned pubkey.
-      2. parse the manifest into {basename: hash} (rejecting pathful/dup).
-      3. hash the EXACT `path` and compare to the manifest entry for its
-         basename. Missing entry or mismatch -> raise.
-
-    This binds the bytes the caller is about to import/use, not a
-    cwd-relative `sha256sum -c` (which could pass against a stale local copy).
-    """
+def _resolve_pubkey(pubkey_path):
     if pubkey_path is None:
         pubkey_path = os.environ.get("XPF_IMAGE_PUBKEY", DEFAULT_IMAGE_PUBKEY)
     if not os.path.isfile(pubkey_path):
@@ -205,24 +194,64 @@ def verify_image_artifact(path, manifest_path, sig_path, pubkey_path=None):
             f"image public key not found: {pubkey_path} "
             "(set XPF_IMAGE_PUBKEY or ship scripts/dist/xpf-image.pub).")
     require_real_pubkey(pubkey_path)
-    # TOCTOU hardening (Codex-M5/AGY-A4): the manifest may live in a
-    # user-writable dir, so a concurrent process could swap its bytes between
-    # the minisign signature check and the parse. Copy the manifest + its
-    # signature into a private 0700 temp dir and run BOTH steps on that copy,
-    # so the bytes we parse are exactly the bytes whose signature we verified.
+    return pubkey_path
+
+
+def verify_and_read(signed_path, sig_path, pubkey_path=None):
+    """minisign-verify `signed_path` and return its VERIFIED bytes.
+
+    TOCTOU-safe (Codex-M5/AGY-A4/AGY-r3): the file may live in a user-writable
+    dir, so a concurrent process could swap its bytes between the signature
+    check and a later read. Copy the file + its signature into a private 0700
+    temp dir, verify the COPY, and return the COPY's bytes — so what the caller
+    parses/uses is exactly what was verified. Use this for every signed text
+    artifact (the per-version manifest, latest.json, ...).
+    """
+    pubkey_path = _resolve_pubkey(pubkey_path)
     import shutil as _sh
     import tempfile as _tf
     tmp = _tf.mkdtemp(prefix="xpf-verify-")
     try:
         os.chmod(tmp, 0o700)
-        m_copy = os.path.join(tmp, os.path.basename(manifest_path))
-        s_copy = m_copy + ".minisig"
-        _sh.copyfile(manifest_path, m_copy)
+        f_copy = os.path.join(tmp, os.path.basename(signed_path))
+        s_copy = f_copy + ".minisig"
+        _sh.copyfile(signed_path, f_copy)
         _sh.copyfile(sig_path, s_copy)
-        verify_signature(m_copy, s_copy, pubkey_path)
-        manifest = parse_manifest(m_copy)
+        verify_signature(f_copy, s_copy, pubkey_path)
+        with open(f_copy, "rb") as fh:
+            return fh.read()
     finally:
         _sh.rmtree(tmp, ignore_errors=True)
+
+
+def verify_manifest_map(manifest_path, sig_path, pubkey_path=None):
+    """Verify a signed manifest and return its {basename: hash} map, parsed
+    from the VERIFIED bytes (TOCTOU-safe)."""
+    data = verify_and_read(manifest_path, sig_path, pubkey_path)
+    import tempfile as _tf
+    tmp = _tf.mkdtemp(prefix="xpf-manifest-")
+    try:
+        os.chmod(tmp, 0o700)
+        p = os.path.join(tmp, "m")
+        with open(p, "wb") as fh:
+            fh.write(data)
+        return parse_manifest(p)
+    finally:
+        import shutil as _sh
+        _sh.rmtree(tmp, ignore_errors=True)
+
+
+def verify_image_artifact(path, manifest_path, sig_path, pubkey_path=None):
+    """Verify ONE artifact `path` against a signed manifest.
+
+    1. verify+parse the manifest from its VERIFIED bytes (TOCTOU-safe).
+    2. hash the EXACT `path` and compare to the manifest entry for its
+       basename. Missing entry or mismatch -> raise.
+
+    Binds the bytes the caller is about to import/use, not a cwd-relative
+    `sha256sum -c` (which could pass against a stale local copy).
+    """
+    manifest = verify_manifest_map(manifest_path, sig_path, pubkey_path)
     base = os.path.basename(path)
     if base not in manifest:
         raise SignError(

--- a/scripts/dist/sign.py
+++ b/scripts/dist/sign.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""xpf signed-distribution signing/verification helpers (#1924).
+
+Shared by the image bake (scripts/image/bake.py), the image validation
+gate (scripts/image/validate.py), the deployer fetch path
+(scripts/deploy/xpf-deploy.py), and the publish gate
+(scripts/dist/publish.py). Implements the IMAGE trust root:
+
+  minisign over a PER-VERSION checksum manifest (xpf-<ver>.SHA256SUMS),
+  then PER-FILE hash verification of the exact bytes being consumed.
+
+Design contract (docs/research/1924-signed-hosted-dist/plan.md §5.1/§5.2):
+
+- The signing tool is `minisign` (Ed25519). We shell out to the system
+  binary rather than reimplement Ed25519 — `require_minisign()` preflights
+  it with an apt-install hint.
+- The secret key is referenced by PATH via XPF_SIGN_SECKEY (or an explicit
+  argument); the key bytes are NEVER embedded, logged, or committed.
+- The public key is a checked-in, pinned file (scripts/dist/xpf-image.pub);
+  its root of trust is the in-repo git copy, independent of any hosting URL.
+- Verification is PER-FILE: the signed manifest authenticates a {basename:
+  sha256} map; each consumer hashes the EXACT file it is about to use and
+  compares to the manifest entry for that file's basename. A file absent
+  from the manifest, or a hash mismatch, FAILS. Files listed but not
+  fetched are simply not checked (so a qcow2-only libvirt fetch verifies).
+"""
+
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+
+# Pinned, checked-in public key (the trust root for image artifacts).
+# Overridable via XPF_IMAGE_PUBKEY for rotation/testing — the override is a
+# PATH, and the pinned in-repo copy remains the documented default root.
+# Until OQ-2 supplies a real key, only `xpf-image.pub.placeholder` ships (its
+# secret was shredded at generation, held by no one — so verify FAILS until
+# the operator drops in the real `xpf-image.pub`, the correct fail-safe).
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def default_image_pubkey():
+    real = os.path.join(HERE, "xpf-image.pub")
+    if os.path.isfile(real):
+        return real
+    return os.path.join(HERE, "xpf-image.pub.placeholder")
+
+
+DEFAULT_IMAGE_PUBKEY = default_image_pubkey()
+
+
+class SignError(Exception):
+    """Signing/verification failure — fatal to the caller's gate."""
+
+
+def require_minisign():
+    """Ensure the minisign binary is present; raise with an install hint."""
+    exe = shutil.which("minisign")
+    if not exe:
+        raise SignError(
+            "minisign not found — install it (apt-get install minisign) to "
+            "sign or verify image artifacts (#1924).")
+    return exe
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_manifest(manifest_path, files):
+    """Write a sha256sum-format manifest listing `files` by BASENAME only.
+
+    Basename-only (never a path) so the manifest is location-independent and
+    a consumer that fetched the file to any directory can verify it. Refuses
+    duplicate basenames at write time — a duplicate would make the
+    {basename: hash} map ambiguous on the verify side.
+    """
+    seen = set()
+    lines = []
+    for path in files:
+        base = os.path.basename(path)
+        if base in seen:
+            raise SignError(f"duplicate basename in manifest set: {base}")
+        seen.add(base)
+        lines.append(f"{sha256_file(path)}  {base}\n")
+    with open(manifest_path, "w") as f:
+        f.writelines(lines)
+    return manifest_path
+
+
+def sign_manifest(manifest_path, seckey_path, comment=None, sig_path=None):
+    """minisign-sign `manifest_path` with the secret key at `seckey_path`.
+
+    Returns the .minisig path. The secret key is passed by PATH to the
+    minisign binary; its bytes never touch this process's memory. minisign
+    prompts for a passphrase on a TTY; for unattended signing the key must be
+    passwordless (operator policy, OQ-2) — we pass an empty passphrase on
+    stdin so a passwordless key signs non-interactively and a
+    password-protected key fails loudly rather than hanging.
+    """
+    exe = require_minisign()
+    if sig_path is None:
+        sig_path = manifest_path + ".minisig"
+    argv = [exe, "-S", "-s", seckey_path, "-m", manifest_path, "-x", sig_path]
+    if comment:
+        argv += ["-t", comment]
+    r = subprocess.run(argv, input="\n", capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SignError(
+            f"minisign sign failed (rc={r.returncode}): {r.stderr.strip()}\n"
+            "(a password-protected key cannot sign unattended — OQ-2 requires "
+            "a passwordless image-signing key or an interactive signer).")
+    return sig_path
+
+
+def verify_signature(manifest_path, sig_path, pubkey_path):
+    """minisign-verify the manifest's signature. Raise on failure."""
+    exe = require_minisign()
+    r = subprocess.run(
+        [exe, "-V", "-p", pubkey_path, "-m", manifest_path, "-x", sig_path],
+        capture_output=True, text=True)
+    if r.returncode != 0:
+        raise SignError(
+            f"minisign signature verification FAILED for "
+            f"{os.path.basename(manifest_path)}: {r.stderr.strip() or r.stdout.strip()}")
+
+
+def parse_manifest(manifest_path):
+    """Parse a sha256sum-format manifest into {basename: hexhash}.
+
+    Rejects pathful entries (a basename must not contain '/') and duplicate
+    basenames — both would let a verifier bind the wrong bytes. Call this
+    only AFTER verify_signature() has authenticated the manifest.
+    """
+    result = {}
+    with open(manifest_path) as f:
+        for lineno, raw in enumerate(f, 1):
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) != 2:
+                raise SignError(
+                    f"{manifest_path}:{lineno}: malformed manifest line: {raw!r}")
+            digest, name = parts
+            name = name.lstrip("*")  # sha256sum binary-mode marker
+            if "/" in name or name in ("", ".", ".."):
+                raise SignError(
+                    f"{manifest_path}:{lineno}: manifest entry must be a bare "
+                    f"basename, got {name!r}")
+            if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest.lower()):
+                raise SignError(
+                    f"{manifest_path}:{lineno}: not a sha256 hex digest: {digest!r}")
+            if name in result:
+                raise SignError(
+                    f"{manifest_path}:{lineno}: duplicate basename in manifest: {name}")
+            result[name] = digest.lower()
+    if not result:
+        raise SignError(f"{manifest_path}: manifest has no entries")
+    return result
+
+
+def verify_image_artifact(path, manifest_path, sig_path, pubkey_path=None):
+    """Verify ONE artifact `path` against a signed manifest.
+
+    Steps (plan §5.2):
+      1. minisign-verify the manifest signature against the pinned pubkey.
+      2. parse the manifest into {basename: hash} (rejecting pathful/dup).
+      3. hash the EXACT `path` and compare to the manifest entry for its
+         basename. Missing entry or mismatch -> raise.
+
+    This binds the bytes the caller is about to import/use, not a
+    cwd-relative `sha256sum -c` (which could pass against a stale local copy).
+    """
+    if pubkey_path is None:
+        pubkey_path = os.environ.get("XPF_IMAGE_PUBKEY", DEFAULT_IMAGE_PUBKEY)
+    if not os.path.isfile(pubkey_path):
+        raise SignError(
+            f"image public key not found: {pubkey_path} "
+            "(set XPF_IMAGE_PUBKEY or ship scripts/dist/xpf-image.pub).")
+    verify_signature(manifest_path, sig_path, pubkey_path)
+    manifest = parse_manifest(manifest_path)
+    base = os.path.basename(path)
+    if base not in manifest:
+        raise SignError(
+            f"{base} is not listed in the signed manifest "
+            f"{os.path.basename(manifest_path)} — refusing to trust it.")
+    actual = sha256_file(path)
+    if actual != manifest[base]:
+        raise SignError(
+            f"{base}: SHA256 MISMATCH — manifest {manifest[base]}, actual "
+            f"{actual}. The file does not match the signed checksum.")
+    return True
+
+
+# ── CLI shim for the test gate + manual use ──────────────────────────────
+def _main(argv):
+    import argparse
+    p = argparse.ArgumentParser(description="xpf image signing helper (#1924)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("sign-manifest", help="write+sign a per-version manifest")
+    s.add_argument("--manifest", required=True)
+    s.add_argument("--seckey", required=True)
+    s.add_argument("--comment", default=None)
+    s.add_argument("files", nargs="+")
+
+    v = sub.add_parser("verify", help="verify ONE artifact against a signed manifest")
+    v.add_argument("--manifest", required=True)
+    v.add_argument("--sig", default=None)
+    v.add_argument("--pubkey", default=None)
+    v.add_argument("file")
+
+    a = p.parse_args(argv)
+    try:
+        if a.cmd == "sign-manifest":
+            write_manifest(a.manifest, a.files)
+            sig = sign_manifest(a.manifest, a.seckey, a.comment)
+            print(f"signed: {a.manifest} -> {sig}")
+            return 0
+        if a.cmd == "verify":
+            sig = a.sig or (a.manifest + ".minisig")
+            verify_image_artifact(a.file, a.manifest, sig, a.pubkey)
+            print(f"OK: {os.path.basename(a.file)} verified against "
+                  f"{os.path.basename(a.manifest)}")
+            return 0
+    except SignError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/scripts/dist/xpf-archive-keyring.asc.placeholder
+++ b/scripts/dist/xpf-archive-keyring.asc.placeholder
@@ -1,0 +1,9 @@
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+PLACEHOLDER-xpf-archive-keyring-not-yet-issued
+This is a #1924 placeholder OpenPGP archive public key. The release build
+(after OQ-2 decides the signing identity) replaces this file with the real
+ASCII-armored archive public key, and the same key block is substituted into
+scripts/dist/install.sh between its BEGIN/END markers. With this placeholder
+in place, apt rejects the repo signature — the correct fail-safe.
+-----END PGP PUBLIC KEY BLOCK-----

--- a/scripts/dist/xpf-image.pub.placeholder
+++ b/scripts/dist/xpf-image.pub.placeholder
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 3640DD4D8E97C06F
+RWRvwJeOTd1ANt6pmc1GwQNW5gkGyKFArXcGWy81MOCeMe6F1Fcc6b97

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -6,7 +6,9 @@ image to provision it) and exports it for both hypervisors:
 
   dist/xpf-<ver>.qcow2                  - libvirt/KVM (virt-install)
   dist/xpf-<ver>.incus-metadata.tar.gz  - incus VM image metadata
-  dist/SHA256SUMS
+  dist/xpf-<ver>.SHA256SUMS             - per-version checksum manifest (#1924)
+  dist/xpf-<ver>.SHA256SUMS.minisig     - minisign signature over the manifest
+                                          (only when XPF_SIGN_SECKEY is set)
 
 Pipeline: build the xpf .deb (`make deb`; no `make generate` — embeds the
 #1864 tracked shim) -> discover + SHA256-verify the latest Ubuntu cloud
@@ -36,6 +38,10 @@ import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(os.path.dirname(HERE))
+
+# Signed-distribution helpers (#1924) live under scripts/dist.
+sys.path.insert(0, os.path.join(ROOT, "scripts", "dist"))
+import sign  # noqa: E402
 
 # Runtime dependency set installed explicitly into the image. This is the
 # same set the xpf-appliance metapackage Depends on (debian/control). The
@@ -390,12 +396,39 @@ def main():
                     "  variant: xpf-appliance\n")
         run(["tar", "-C", work, "-czf", meta_out, "metadata.yaml"])
 
-        sums = os.path.join(a.out, "SHA256SUMS")
-        with open(sums, "w") as f:
-            for path in (qcow_out, meta_out):
-                f.write(f"{sha256(path)}  {os.path.basename(path)}\n")
+        # Per-version, version-named checksum manifest (#1924 §5.1): each
+        # bake owns its manifest so retaining v1 next to v2 never orphans
+        # v1's checksums. Verification (validate.py / xpf-deploy.py fetch)
+        # is PER-FILE against the basenames listed here.
+        sums = os.path.join(a.out, f"xpf-{ver}.SHA256SUMS")
+        sign.write_manifest(sums, [qcow_out, meta_out])
         info("checksums:")
         print(open(sums).read(), end="")
+
+        # Sign the manifest with minisign (#1924 §5.1). Fail-OPEN at bake
+        # (a dev bake without a key still produces artifacts), fail-CLOSED
+        # at publish (scripts/dist/publish.py refuses unsigned artifacts).
+        # XPF_SIGN_SECKEY is a PATH to the secret key; the bytes never enter
+        # this process. The pinned public key is copied into dist/ so the
+        # published tree is self-describing (its trust root remains the
+        # in-repo checked-in copy, not this convenience copy).
+        seckey = os.environ.get("XPF_SIGN_SECKEY")
+        if seckey:
+            try:
+                sign.require_minisign()
+                sig = sign.sign_manifest(sums, seckey,
+                                         comment=f"xpf image {ver} sha256sums")
+                info(f"signed manifest: {os.path.basename(sig)}")
+                pub_src = sign.DEFAULT_IMAGE_PUBKEY
+                if os.path.isfile(pub_src):
+                    shutil.copyfile(pub_src, os.path.join(a.out, "xpf-image.pub"))
+            except sign.SignError as e:
+                die(f"image signing FAILED: {e}")
+        else:
+            print("WARNING: XPF_SIGN_SECKEY unset — manifest NOT signed. This "
+                  "dev artifact is NOT publishable; `make dist-publish` will "
+                  "refuse it. Set XPF_SIGN_SECKEY=<path-to-minisign-seckey> to "
+                  "sign (#1924).", file=sys.stderr)
 
         try:
             commit = out_text(["git", "-C", ROOT, "rev-parse", "HEAD"]).strip()

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -96,22 +96,27 @@ class Harness:
             info("no signed manifest next to the artifacts — skipping "
                  "signature verification (dev bake; use --verify-sig to force)")
             return
-        # Bind both consumed files to their signed manifest. Try each manifest;
-        # the one that lists this version's basenames is the match.
-        for art in (self.qcow2, self.metadata):
-            base = os.path.basename(art)
-            verified = False
-            last_err = None
-            for manifest in sigs:
-                try:
-                    sign.verify_image_artifact(art, manifest, manifest + ".minisig")
-                    verified = True
-                    info(f"signature OK: {base} (manifest {os.path.basename(manifest)})")
-                    break
-                except sign.SignError as e:
-                    last_err = e
-            if not verified:
-                fail(f"image signature verification FAILED for {base}: {last_err}")
+        # Bind BOTH consumed files to the SAME signed manifest (AGY-A3): a
+        # mismatched pair (qcow2 from v2's manifest, metadata from v1's) must
+        # NOT pass. Find the single manifest that authenticates both; if none
+        # does, fail.
+        chosen = None
+        last_err = None
+        for manifest in sigs:
+            sig = manifest + ".minisig"
+            try:
+                sign.verify_image_artifact(self.qcow2, manifest, sig)
+                sign.verify_image_artifact(self.metadata, manifest, sig)
+                chosen = manifest
+                break
+            except sign.SignError as e:
+                last_err = e
+        if not chosen:
+            fail("image signature verification FAILED — no single signed "
+                 f"manifest authenticates both {os.path.basename(self.qcow2)} and "
+                 f"{os.path.basename(self.metadata)}: {last_err}")
+        info(f"signature OK: {os.path.basename(self.qcow2)} + "
+             f"{os.path.basename(self.metadata)} (manifest {os.path.basename(chosen)})")
 
     def import_image(self):
         self.verify_signatures()

--- a/scripts/image/validate.py
+++ b/scripts/image/validate.py
@@ -25,8 +25,11 @@ import tempfile
 import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
 sys.path.insert(0, HERE)
+sys.path.insert(0, os.path.join(ROOT, "scripts", "dist"))
 import make_config_drive  # noqa: E402
+import sign  # noqa: E402  (#1924 signed-distribution helper)
 
 ALIAS = "xpf-image-validate"
 
@@ -57,8 +60,11 @@ def guest_sh(inst, script):
 
 
 class Harness:
-    def __init__(self, qcow2, metadata, net, keep):
+    def __init__(self, qcow2, metadata, net, keep, verify_sig=True):
         self.qcow2, self.metadata, self.net, self.keep = qcow2, metadata, net, keep
+        # verify_sig: True = verify if a .minisig is present (default),
+        # "force" = require one, False = never (dev escape hatch).
+        self.verify_sig = verify_sig
         self.created_net = False
         self.instances = []
         self.work = tempfile.mkdtemp(prefix="xpf-validate-")
@@ -71,7 +77,44 @@ class Harness:
                   "ipv4.nat=true", "ipv6.address=none")
             self.created_net = True
 
+    def verify_signatures(self):
+        """Verify the EXACT qcow2 + metadata files against the signed
+        per-version manifest sitting next to them (#1924 §5.2). Per-file:
+        each artifact's hash is checked against the signed manifest entry for
+        its basename. Default ON when a .minisig is present; --no-verify-sig
+        opts out for a local dev bake that skipped signing."""
+        if not self.verify_sig:
+            return
+        sigdir = os.path.dirname(os.path.abspath(self.qcow2))
+        import glob
+        manifests = sorted(glob.glob(os.path.join(sigdir, "*.SHA256SUMS")))
+        sigs = [m for m in manifests if os.path.isfile(m + ".minisig")]
+        if not sigs:
+            if self.verify_sig == "force":
+                fail("--verify-sig forced but no signed *.SHA256SUMS.minisig "
+                     f"found next to {self.qcow2}")
+            info("no signed manifest next to the artifacts — skipping "
+                 "signature verification (dev bake; use --verify-sig to force)")
+            return
+        # Bind both consumed files to their signed manifest. Try each manifest;
+        # the one that lists this version's basenames is the match.
+        for art in (self.qcow2, self.metadata):
+            base = os.path.basename(art)
+            verified = False
+            last_err = None
+            for manifest in sigs:
+                try:
+                    sign.verify_image_artifact(art, manifest, manifest + ".minisig")
+                    verified = True
+                    info(f"signature OK: {base} (manifest {os.path.basename(manifest)})")
+                    break
+                except sign.SignError as e:
+                    last_err = e
+            if not verified:
+                fail(f"image signature verification FAILED for {base}: {last_err}")
+
     def import_image(self):
+        self.verify_signatures()
         incus("image", "delete", ALIAS, check=False, capture=True)
         info(f"importing image into local incus as {ALIAS}")
         incus("image", "import", self.metadata, self.qcow2, "--alias", ALIAS)
@@ -259,6 +302,12 @@ def main():
     p.add_argument("--qcow2", required=True)
     p.add_argument("--metadata", required=True)
     p.add_argument("--keep", action="store_true")
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--verify-sig", dest="verify_sig", action="store_const",
+                   const="force", help="require a signed manifest (#1924)")
+    g.add_argument("--no-verify-sig", dest="verify_sig", action="store_const",
+                   const=False, help="skip image signature verification (dev)")
+    p.set_defaults(verify_sig=True)  # default: verify if a .minisig is present
     p.add_argument("scenario", nargs="?", default="all", choices=["a", "b", "c", "all"])
     a = p.parse_args()
     if not os.path.isfile(a.qcow2):
@@ -266,7 +315,7 @@ def main():
     if not os.path.isfile(a.metadata):
         fail(f"--metadata not found: {a.metadata}")
     net = os.environ.get("XPF_VALIDATE_NETWORK", "xpf-image-net")
-    h = Harness(a.qcow2, a.metadata, net, a.keep)
+    h = Harness(a.qcow2, a.metadata, net, a.keep, a.verify_sig)
     try:
         h.ensure_network()
         h.import_image()


### PR DESCRIPTION
## Part of #1924 — signed, hosted appliance distribution (MECHANISM)

Implements the signed-distribution mechanism converged in the `/research` plan
(`docs/research/1924-signed-hosted-dist/plan.md`, PLAN-READY at 4597a0ed1). The
hosting URL and the signing public key are **config inputs**, never hardcoded.
The actual live publish/host step is the only part gated on the two operator
inputs (below).

### What's implemented
- **Image signing** (`scripts/dist/sign.py`): minisign over a per-version
  `xpf-<ver>.SHA256SUMS`; PER-FILE verification of the exact imported bytes
  (rejects pathful/dup manifest entries; hashes the concrete file, compares to
  the signed entry for its basename). Secret key referenced by PATH
  (`XPF_SIGN_SECKEY`), never embedded/committed.
- **bake.py**: emits the per-version manifest + `.minisig` (fail-OPEN at bake
  with a "not publishable" warning when `XPF_SIGN_SECKEY` is unset).
- **validate.py**: `--verify-sig`/`--no-verify-sig`; verifies the exact
  `--qcow2`/`--metadata` against the signed manifest before `incus image import`.
- **xpf-deploy.py `fetch`**: downloads from `XPF_IMAGE_BASE_URL`, verifies the
  exact bytes, then imports. Verify happens at fetch/import, not alias-launch.
- **Signed apt repo** (`scripts/dist/build-apt-repo.sh`): flat signed repo by
  default (apt-ftparchive + gpg, stateless-CI-safe), reprepro opt-in;
  `stable`/`edge`; `Valid-Until` (default 1y, `XPF_APT_VALID_DAYS`).
- **install.sh**: Tailscale-style — kernel≥6.18/amd64/Debian-family/networkd
  preflight, inline archive keyring, deb822 `Signed-By` source
  (`XPF_APT_BASE_URL`), `apt install xpf-appliance`, #1879 takeover + #1917
  upgrade-blip caveats. `XPF_DRY_RUN=1`.
- **publish.py**: FAIL-CLOSED gate (refuses unsigned images / unsigned or stale
  `latest.json` / unsigned apt `InRelease`), then `XPF_PUBLISH_CMD <dir> <url>`
  once per URL. No backend hardcoded.
- **debian/rules**: ships the archive keyring in the `xpf` package payload
  (`/etc/apt/keyrings/...`) so `apt upgrade` delivers rotated keys to existing
  hosts (NIT-2 — no fleet lockout). No postinst logic.
- **Placeholder keys** (`*.placeholder`): secrets shredded at generation (held
  by no one) — verify FAILS until the operator drops in the real key (the
  correct fail-safe).
- **Docs**: `docs/distribution.md` (trust model, two operator inputs, publisher
  + operator runbooks, rotation, freshness), `docs/install-images.md`.

### Validation (no dataplane change → no cluster smoke / no failover)
- `go build ./...` clean.
- `shellcheck -S warning scripts/dist/*.sh` clean.
- `make dist-selftest` (`scripts/dist/selftest.sh`): **13/13 PASS** — throwaway
  key → sign → verify → tamper-detection (modified artifact, tampered manifest,
  tampered signature, wrong pubkey) → per-file qcow2-only verify → flat signed
  apt repo build → `InRelease` verify + tampered-`InRelease`-fails →
  `install.sh` dry-run. No real key, no host.
- publish gate verified to fail-closed on an unsigned dist tree.

### NOT in this PR (needs the two operator inputs — #1924 stays OPEN)
1. **Hosting target** — `XPF_IMAGE_BASE_URL` + `XPF_APT_BASE_URL`, retention,
   channel layout. (GitHub Releases can host images, NOT the apt `dists/`+`pool/`
   tree.)
2. **Signing identity** — the real minisign + OpenPGP keypairs, key custody,
   rotation cadence, pubkey pinning. Drop the real public keys in as
   `scripts/dist/xpf-image.pub` + `xpf-archive-keyring.asc` (replacing the
   `.placeholder`s) and point signing at the secret-key PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
