### PR TITLE
#1930 INC-0: hold the kernel + apt safety in the appliance bake

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -5468,3 +5468,7 @@ top.
 - **Timestamp**: 2026-06-16
   - **Action**: #1930 INC-0 (PR-1 first slice) — image kernel hold + apt safety. bake.py now `apt-mark hold`s the installed linux-* set (dpkg-query enumeration, not a bare glob; HARD-ASSERTs ≥2 held), writes an unattended-upgrades Package-Blacklist for linux-*, and a needrestart blacklist for xpfd + the runtime version dirs. Closes the "unattended apt moves the verifier floor" hole with no daemon code.
   - **File(s)**: scripts/image/bake.py, docs/install-images.md, _Log.md
+
+- **Timestamp**: 2026-06-16
+  - **Action**: #1930 INC-0 review round 1 (Codex) fixes — (1) DROPPED the bake-written /etc/needrestart/conf.d/99-xpf.conf: the package already ships the correct APPEND-form snippet (debian/xpf.needrestart -> .../xpf.conf via the .deb install); my whole-hash assignment would have wiped needrestart defaults and the write preceded the dir's creation. (2) Hardened the kernel-hold shell: `set -e` makes apt-mark failure fatal, and per-package verification against `apt-mark showhold` replaces the count>=2 check (a pre-existing unrelated hold could false-pass the count). Verified success + partial-hold cases.
+  - **File(s)**: scripts/image/bake.py, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -5464,3 +5464,7 @@ top.
 - **Timestamp**: 2026-06-16
   - **Action**: README getting-started restructure (PR #1937) — rewrote README into install/getting-started guide (3 paths: .deb, incus image, kvm/libvirt) cross-checked against Makefile deb/image targets, debian/control+postinst, scripts/image/bake.py + make_config_drive.py, scripts/deploy/xpf-deploy.py. Moved deep reference content into new docs/architecture.md, docs/feature-coverage.md, docs/network-topology.md, docs/critical-patterns.md, docs/README.md. Docs-only.
   - **File(s)**: README.md, docs/architecture.md, docs/feature-coverage.md, docs/network-topology.md, docs/critical-patterns.md, docs/README.md, docs/pr/readme-getting-started/reviewer-ids.md
+
+- **Timestamp**: 2026-06-16
+  - **Action**: #1930 INC-0 (PR-1 first slice) — image kernel hold + apt safety. bake.py now `apt-mark hold`s the installed linux-* set (dpkg-query enumeration, not a bare glob; HARD-ASSERTs ≥2 held), writes an unattended-upgrades Package-Blacklist for linux-*, and a needrestart blacklist for xpfd + the runtime version dirs. Closes the "unattended apt moves the verifier floor" hole with no daemon code.
+  - **File(s)**: scripts/image/bake.py, docs/install-images.md, _Log.md

--- a/docs/install-images.md
+++ b/docs/install-images.md
@@ -49,7 +49,12 @@ Pipeline (offline — the image is never booted to provision it):
    `linux-virtual` kernel replaced by `linux-generic` (full driver set
    — mlx5/i40e for passthrough NICs live in `linux-modules-extra`)
    with in-bake asserts that the kernel meets the >= 6.18 verifier
-   floor and the extra-modules tree is present, purge of cloud-init
+   floor and the extra-modules tree is present, **the kernel held
+   (`apt-mark hold`) + excluded from unattended-upgrades so an apt run
+   cannot move the verifier floor out from under the gated shim .o
+   (#1930) — kernel bumps go through the verify-gated LANE-1 channel, not
+   background apt; a `needrestart` blacklist keeps an apt run from
+   restarting xpfd mid-transaction**, purge of cloud-init
    (a competing network manager), snapd, and the virtual-kernel
    metapackages, systemd-networkd + resolved enabled, FRR + chrony
    enabled (default NTP pools neutered; xpfd manages

--- a/docs/pr/1930-inc0-kernel-hold/agy-review-r1.md
+++ b/docs/pr/1930-inc0-kernel-hold/agy-review-r1.md
@@ -1,0 +1,113 @@
+# Hostile Adversarial Code Review: PR #1939
+
+**Target Worktree**: `/home/ps/git/bpfrx/.claude/worktrees/1930-eng`  
+**Review Type**: Hostile Adversarial  
+**PR Context**: xpf, branch `engineer/1930-kernel-os`, Part of #1930 INC-0  
+**AGY Job ID**: `50c05783-d4fe-4e59-8afb-b1f1097388be`
+
+---
+
+## 1. Kernel-Hold Shell Correctness under `virt-customize --run-command`
+*Cite: [scripts/image/bake.py:255-269](file:///home/ps/git/bpfrx/.claude/worktrees/1930-eng/scripts/image/bake.py#L255-L269)*
+
+```bash
+set -e; export DEBIAN_FRONTEND=noninteractive; \
+pkgs=$(dpkg-query -W -f="${Package}\n" "linux-image-*" "linux-headers-*" "linux-modules-*" "linux-generic" 2>/dev/null | sort -u); \
+[ -n "$pkgs" ] || { echo "FATAL: no linux-* packages found to hold" >&2; exit 1; }; \
+apt-mark hold $pkgs; \
+hold_set=$(apt-mark showhold); \
+for p in $pkgs; do \
+    printf "%s\n" "$hold_set" | grep -qxF "$p" || \
+    { echo "FATAL: $p not held after apt-mark hold (held: $(printf %s "$hold_set" | tr "\n" " "))" >&2; exit 1; }; \
+done; \
+echo "#1930: held $(printf %s "$pkgs" | wc -w) linux-* packages: $(printf %s "$pkgs" | tr "\n" " ")"
+```
+
+### Analysis:
+- **Word-splitting on `$pkgs`**: `$pkgs` is expanded unquoted in `apt-mark hold $pkgs` and `for p in $pkgs`. Because package names are whitespace-separated (specifically newline-separated in this variable) and cannot contain whitespace or wildcards under Debian packaging rules, this word-splitting is safe and correct.
+- **Exit Code Masking**: The command `dpkg-query ... | sort -u` runs in a pipeline. In POSIX shell (and `dash`), the exit status of a pipeline is the exit status of its last command (`sort -u`), which is `0` even if `dpkg-query` exits `1` (which it does if any pattern matches nothing, e.g. if `linux-headers-*` is empty).
+  - This is **intentional** and **correct**: we do not want the bake to crash just because one category of package (like headers) is absent; we want to gather whatever packages *are* present and hold them.
+- **Database Corruption / Total Failure**: If `dpkg-query` fails completely and outputs nothing, `pkgs` becomes empty. The line `[ -n "$pkgs" ] || { ... exit 1; }` acts as a guard, outputting a fatal error and exiting `1`. Under `set -e`, this immediately aborts the subshell, which correctly propagates to `virt-customize` and fails the bake.
+- **Hold Verification Loop**: 
+  - `hold_set=$(apt-mark showhold)` fetches the currently held packages.
+  - `printf "%s\n" "$hold_set" | grep -qxF "$p"` checks if `$p` matches exactly a whole line (`-x`) in `$hold_set` treated as a literal fixed string (`-F`).
+  - Treating it as a fixed string (`-F`) is critical because kernel packages can contain regex-active characters like `+` (e.g. `linux-image-6.18.5+deb14-amd64`). This is correct.
+  - If a package is not held, the subshell aborts via `exit 1` within the block, failing the bake.
+  - Pre-existing holds do not mask failures because the loop iterates over `$pkgs` (the list of packages found and expected to be held) and verifies each one individually.
+
+---
+
+## 2. `dpkg-query` Pattern Coverage vs what the Bake Installs
+*Cite: [scripts/image/bake.py:210](file:///home/ps/git/bpfrx/.claude/worktrees/1930-eng/scripts/image/bake.py#L210) & [scripts/image/bake.py:257-258](file:///home/ps/git/bpfrx/.claude/worktrees/1930-eng/scripts/image/bake.py#L257-L258)*
+
+- The bake installs the meta-package `linux-generic` (line 210), which pulls:
+  - `linux-image-generic` (which pulls `linux-image-<version>-generic`)
+  - `linux-headers-generic` (which pulls `linux-headers-<version>-generic` and `linux-headers-<version>`)
+  - `linux-modules-extra-<version>-generic` (starts with `linux-modules-`)
+- The query patterns are: `"linux-image-*"`, `"linux-headers-*"`, `"linux-modules-*"`, and `"linux-generic"`.
+- **Coverage Check**:
+  - `linux-generic` matches `"linux-generic"` exactly.
+  - `linux-image-generic` and `linux-image-<version>-generic` (including unsigned variants) match `"linux-image-*"`.
+  - `linux-headers-generic` and `linux-headers-<version>-generic` match `"linux-headers-*"`.
+  - `linux-modules-<version>-generic` and `linux-modules-extra-<version>-generic` match `"linux-modules-*"`.
+- The coverage is 100% complete for all kernel-related packages installed in this image.
+
+---
+
+## 3. `unattended-upgrades` Package-Blacklist Regex Form
+*Cite: [scripts/image/bake.py:279-280](file:///home/ps/git/bpfrx/.claude/worktrees/1930-eng/scripts/image/bake.py#L279-L280)*
+
+```apt
+Unattended-Upgrade::Package-Blacklist { "linux-"; "linux-image-"; "linux-headers-"; "linux-modules-"; "linux-generic"; };
+```
+
+- `unattended-upgrades` matches these patterns using Python's regular expressions starting from the beginning of the package name (equivalent to `re.match`).
+- Because `"linux-"` matches any package starting with `linux-`, it successfully blacklists all kernel-related packages (including `linux-image-*`, `linux-headers-*`, `linux-modules-*`, `linux-generic`).
+- The other patterns (`"linux-image-"`, `"linux-headers-"`, etc.) are technically redundant due to the presence of `"linux-"`, but they are harmless.
+- This pattern will also match/blacklist other system packages starting with `linux-` (like `linux-libc-dev` or `linux-firmware`), which acts as an extra-safe blanket protection against any ambient OS-level kernel drift.
+
+---
+
+## 4. Ordering vs the `.deb` Install / `update-grub` / #1917 In-Place Upgrade
+*Cite: [scripts/image/bake.py:255-317](file:///home/ps/git/bpfrx/.claude/worktrees/1930-eng/scripts/image/bake.py#L255-L317)*
+
+- **Sequence of Operations**:
+  1. Install kernel (`linux-generic`)
+  2. Purge old kernels & assert exactly one remains
+  3. Apply kernel holds (`apt-mark hold`) & write `/etc/apt/apt.conf.d/99-xpf-kernel-hold`
+  4. Perform other package purges and updates
+  5. Install `xpf` `.deb` package
+  6. Write `/etc/default/grub.d/99-xpf.cfg` & run `update-grub`
+- **Safety / Conflicts**:
+  - **`.deb` installation**: `apt` allows installing packages while others are held. The `xpf` package's installation is not blocked by held kernel packages.
+  - **`update-grub`**: Runs correctly after the hold. It reads from `/boot` and is unaffected by packaging holds.
+  - **#1917 upgrade**: The in-place upgrade mechanism (`xpfd upgrade` in `postinst`) manages daemon staging/restart and does not trigger or require OS kernel package upgrades. It is completely safe.
+
+---
+
+## 5. needrestart Bake-Write Removal Confirmation
+*Cite: [scripts/image/bake.py:305-311](file:///home/ps/git/bpfrx/.claude/worktrees/1930-eng/scripts/image/bake.py#L305-L311) & [debian/rules:73-75](file:///home/ps/git/bpfrx/.claude/worktrees/1930-eng/debian/rules#L73-L75)*
+
+- The proposed inline write of `/etc/needrestart/conf.d/99-xpf.conf` has been successfully **DROPPED** from `bake.py`.
+- Instead, the needrestart override snippet is properly shipped in the package payload via `debian/rules`:
+  ```make
+  install -d debian/xpf/etc/needrestart/conf.d
+  install -m 0644 debian/xpf.needrestart \
+                  debian/xpf/etc/needrestart/conf.d/xpf.conf
+  ```
+- This uses the clean append form (`$nrconf{override_rc}{qr(^xpfd\.service$)} = 0;` inside [debian/xpf.needrestart](file:///home/ps/git/bpfrx/.claude/worktrees/1930-eng/debian/xpf.needrestart)) which preserves needrestart's defaults instead of doing a destructive whole-hash overwrite at bake time.
+
+---
+
+## 6. Idempotency / Re-Bake Safety
+*Cite: [scripts/image/bake.py:186-318](file:///home/ps/git/bpfrx/.claude/worktrees/1930-eng/scripts/image/bake.py#L186-L318)*
+
+- `bake.py` constructs a fresh copy/resize of the clean cached Ubuntu base cloud image every time it runs.
+- Because the image is provisioned from scratch on each run, the build commands are inherently idempotent and immune to state drift or leftover artifacts from prior bakes.
+
+---
+
+## Verdict
+**APPROVE**
+
+The kernel hold implementation is shell-safe, robustly verifies both successful and failed holds, covers all installed kernel meta-packages and concrete version packages, and successfully blocks unattended upgrades from moving the kernel verifier floor. The dropped needrestart inline bake-write has been verified to be fully removed and correctly packaged in the Debian package payload instead.

--- a/docs/pr/1930-inc0-kernel-hold/claude-smr-review-r1.md
+++ b/docs/pr/1930-inc0-kernel-hold/claude-smr-review-r1.md
@@ -1,0 +1,59 @@
+# Claude SMR — hostile code review r1, PR #1939 (#1930 INC-0)
+
+Reviewer: Claude SMR. Posture: HOSTILE. Scope: `git diff origin/master...HEAD` on
+`engineer/1930-kernel-os` (scripts/image/bake.py + docs/install-images.md +
+_Log.md). No daemon code, no boot channel.
+
+I verified the change against the real bake sequence and the existing packaging,
+and independently checked the interactions Codex/AGY did not (later autoremove,
+u-u presence, the .deb's own needrestart snippet).
+
+## Verified correct
+- **Hold shell:** `set -e` + per-package `grep -qxF` verification against
+  `apt-mark showhold` closes the count-based false-pass Codex flagged. `-F`
+  (fixed-string) + `-x` (whole-line) correctly handle `+` in version strings
+  (`linux-image-6.18.5+deb14-amd64`). Empty-`pkgs` guard fails the bake. Exercised
+  both the success case (6 host linux-* verified held) and a simulated partial
+  hold (correctly FATALs). Sound.
+- **dpkg-query coverage:** `linux-image-* / linux-headers-* / linux-modules-* /
+  linux-generic` covers what `apt install linux-generic` brings (concrete
+  versioned image/modules/headers + metas + `linux-modules-extra-*` via the
+  `modules-*` glob). Correct.
+- **u-u blacklist regex:** unattended-upgrades matches Package-Blacklist with
+  `re.match` (start-anchored), so `"linux-"` matches `linux-image-*`. The extra
+  specific entries are redundant-but-harmless. Correct.
+- **needrestart:** the bake-written file is GONE (replaced by an explanatory
+  comment); the package-owned append-form snippet (`debian/xpf.needrestart` →
+  `/etc/needrestart/conf.d/xpf.conf`, `debian/rules:73-75`) is the single source.
+  No default-clobber, no pre-create-dir bake failure. Correct.
+
+## Checks Codex/AGY did not raise — all PASS
+- **Hold vs the LATER `apt-get autoremove -y -qq` (bake.py:286, AFTER the hold at
+  :263):** a held package is not removed by autoremove, and the kernel is pulled
+  by the held `linux-generic` meta anyway, so it is never autoremove-eligible.
+  The hold survives every subsequent bake step (snapd/cloud-init purge, the .deb
+  install, autoremove, update-grub). No regression.
+- **u-u presence:** if the appliance image does not actually install
+  `unattended-upgrades`, the apt.conf.d file is an unread config — harmless. If it
+  IS present, the blacklist fires. Either way safe; the file is the correct
+  belt-and-braces.
+- **.deb install under hold (bake.py:303):** holding `linux-*` does not block
+  installing the unrelated `xpf` package; dpkg/apt allow installs while other
+  packages are held. No conflict.
+- **#1917 in-place upgrade:** kernel-hold-agnostic (it cuts the xpfd/helper
+  binary set, not the kernel). No interaction.
+
+## Nits (non-blocking)
+- **n1:** the `[ -n "$pkgs" ]` guard is slightly redundant with the per-package
+  loop (an empty `$pkgs` makes the loop a no-op and the `echo` would report "held
+  0"), but the explicit guard is clearer and fails earlier — keep it.
+- **n2:** the comment at bake.py:248 still references the bare-glob hazard as the
+  motivation; accurate, leave it. (Documents WHY dpkg-query, not a glob.)
+
+## Verdict
+APPROVE — INC-0 closes the "unattended apt moves the verifier floor" hole with no
+daemon code, the hold is verified per-package (no false-pass), the kernel survives
+every later bake step, the u-u blacklist is correct and harmless-if-absent, and
+the needrestart concern is correctly delegated to the existing package snippet.
+Proportionate validation (compile + functional hold sim) matches the no-boot-
+channel scope. Ready to merge on Copilot + green gates.

--- a/docs/pr/1930-inc0-kernel-hold/reviewer-ids.md
+++ b/docs/pr/1930-inc0-kernel-hold/reviewer-ids.md
@@ -1,0 +1,9 @@
+# PR #1939 (#1930 INC-0) reviewer ledger
+
+| Round | Reviewer | ID | Verdict |
+|-------|----------|-----|---------|
+| r1 | Codex | foreground codex exec (read-only) | REQUEST-CHANGES (needrestart hash-clobber HIGH; hold false-pass MED) |
+| r1-fix | (author) | commit 65ac48cdb | dropped bake needrestart write; per-package hold verify |
+| r1 | AGY | job 50c05783-d4fe-4e59-8afb-b1f1097388be (agy-rescue, in worktree) | APPROVE |
+| r1 | Claude SMR | (in-conversation) | APPROVE |
+| r1 | Copilot | (auto on PR open) | pending |

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -12,9 +12,10 @@ Pipeline: build the xpf .deb (`make deb`; no `make generate` — embeds the
 #1864 tracked shim) -> discover + SHA256-verify the latest Ubuntu cloud
 image (XPF_BASE_RELEASE pins) -> virt-resize root into a work disk ->
 virt-customize (runtime packages, linux-generic >= 6.18 with the full
-driver set, purge cloud-init/snapd/stale kernels, networkd,
-init_on_alloc=0, `apt-get install ./xpf.deb` which stages the binaries +
-creates the /usr/local/sbin symlinks + enables the units via its postinst)
+driver set, purge cloud-init/snapd/stale kernels, HOLD the kernel so apt
+cannot move the verifier floor (#1930), networkd, init_on_alloc=0,
+`apt-get install ./xpf.deb` which stages the binaries + creates the
+/usr/local/sbin symlinks + enables the units via its postinst)
 -> virt-sysprep seal -> virt-sparsify+compress export -> checksums +
 manifest -> in-guest verify-dataplane validation gate (validate.py).
 
@@ -237,6 +238,39 @@ def virt_customize(work_qcow, xpf_deb):
         "--run-command",
         'n=$(ls /lib/modules | wc -l); [ "$n" -eq 1 ] || '
         '{ echo "FATAL: $n kernels in /lib/modules after purge ($(ls /lib/modules | tr "\\n" " "))" >&2; exit 1; }',
+        # #1930 INC-0: HOLD the kernel so an unattended `apt upgrade` cannot move
+        # the running kernel out from under the verifier-gated shim .o (#1864).
+        # The embedded AF_XDP shim is kernel-space-verifier-gated; a kernel the
+        # .o has never been verified against can REJECT it at boot -> no
+        # dataplane. A kernel bump must be an explicit, verify-gated operator
+        # action (the LANE-1 channel, #1930), never silent apt drift.
+        #
+        # `apt-mark hold linux-*` MUST NOT be a bare glob: apt-mark does not
+        # expand wildcards, and the shell would expand `linux-*` against the cwd
+        # (holding nothing). Enumerate the installed kernel package set via
+        # dpkg-query instead. HARD-ASSERT at least the meta + image are held so a
+        # silent hold failure cannot ship an unprotected image.
+        "--run-command",
+        'export DEBIAN_FRONTEND=noninteractive; '
+        'pkgs=$(dpkg-query -W -f="${Package}\\n" "linux-image-*" "linux-headers-*" '
+        '"linux-modules-*" "linux-generic" 2>/dev/null | sort -u); '
+        '[ -n "$pkgs" ] || { echo "FATAL: no linux-* packages found to hold" >&2; exit 1; }; '
+        'apt-mark hold $pkgs >/dev/null; '
+        'held=$(apt-mark showhold | grep -c "^linux-"); '
+        '[ "$held" -ge 2 ] || '
+        '{ echo "FATAL: kernel hold did not take ($held linux-* held: $(apt-mark showhold | tr "\\n" " "))" >&2; exit 1; }; '
+        'echo "#1930: held $held linux-* packages"',
+        # Exclude linux-* from unattended-upgrades too: a hold protects an
+        # interactive `apt upgrade`, but unattended-upgrades can be configured to
+        # bypass holds for security. Kernel CVEs flow through the verify-gated
+        # LANE-1 channel (#1930), NOT unattended-upgrades.
+        "--write",
+        "/etc/apt/apt.conf.d/99-xpf-kernel-hold:"
+        "// xpf (#1930): never let unattended-upgrades move the kernel.\n"
+        "// The embedded AF_XDP shim is kernel-verifier-gated (#1864); kernel\n"
+        "// bumps go through the verify-gated LANE-1 channel, not background apt.\n"
+        'Unattended-Upgrade::Package-Blacklist { "linux-"; "linux-image-"; '
+        '"linux-headers-"; "linux-modules-"; "linux-generic"; };\n',
         "--run-command", "export DEBIAN_FRONTEND=noninteractive && apt-get purge -y -qq snapd "
                          "2>/dev/null || true; rm -rf /snap /var/snap /var/lib/snapd /var/cache/snapd",
         "--run-command", 'export DEBIAN_FRONTEND=noninteractive && apt-get purge -y -qq "cloud-init*" '
@@ -261,6 +295,17 @@ def virt_customize(work_qcow, xpf_deb):
         "--run-command", "export DEBIAN_FRONTEND=noninteractive && "
                          f"apt-get install -y -qq -o Acquire::Retries=5 /var/tmp/{deb_name} && "
                          f"rm -f /var/tmp/{deb_name}",
+        # #1930 INC-0: keep needrestart from auto-restarting xpfd mid-apt. On a
+        # base with needrestart installed, the end-of-transaction scan restarts
+        # processes running deleted binaries — which would cut the dataplane
+        # during a kernel install in the LANE-1 channel. Blacklist xpfd + the
+        # runtime version dirs (harmless no-op if needrestart is absent).
+        "--write",
+        "/etc/needrestart/conf.d/99-xpf.conf:"
+        "# xpf (#1930): never auto-restart the dataplane during an apt run.\n"
+        '$nrconf{override_rc} = { qr(^xpfd\\.service$) => 0 };\n'
+        "push @{$nrconf{blacklist}}, "
+        "qr(^/var/lib/xpf/versions/), qr(^/usr/local/share/xpf/staged/);\n",
         "--write", f"/etc/default/grub.d/99-xpf.cfg:{GRUB_DROPIN}",
         "--run-command", "update-grub",
         "--write", f"/etc/ssh/sshd_config.d/10-xpf-factory.conf:{SSHD_DROPIN}",

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -248,18 +248,25 @@ def virt_customize(work_qcow, xpf_deb):
         # `apt-mark hold linux-*` MUST NOT be a bare glob: apt-mark does not
         # expand wildcards, and the shell would expand `linux-*` against the cwd
         # (holding nothing). Enumerate the installed kernel package set via
-        # dpkg-query instead. HARD-ASSERT at least the meta + image are held so a
-        # silent hold failure cannot ship an unprotected image.
+        # dpkg-query instead. `set -e` makes an apt-mark failure fatal, and we
+        # then VERIFY every enumerated package is actually in `apt-mark showhold`
+        # (per-package, not a count) so neither a partial hold nor a pre-existing
+        # unrelated hold can ship an unprotected image.
         "--run-command",
-        'export DEBIAN_FRONTEND=noninteractive; '
+        'set -e; export DEBIAN_FRONTEND=noninteractive; '
         'pkgs=$(dpkg-query -W -f="${Package}\\n" "linux-image-*" "linux-headers-*" '
         '"linux-modules-*" "linux-generic" 2>/dev/null | sort -u); '
         '[ -n "$pkgs" ] || { echo "FATAL: no linux-* packages found to hold" >&2; exit 1; }; '
-        'apt-mark hold $pkgs >/dev/null; '
-        'held=$(apt-mark showhold | grep -c "^linux-"); '
-        '[ "$held" -ge 2 ] || '
-        '{ echo "FATAL: kernel hold did not take ($held linux-* held: $(apt-mark showhold | tr "\\n" " "))" >&2; exit 1; }; '
-        'echo "#1930: held $held linux-* packages"',
+        # apt-mark hold failure is fatal (set -e + no output swallow); then
+        # verify EACH enumerated package is actually in showhold, so a
+        # pre-existing unrelated hold cannot mask a partial/failed hold.
+        'apt-mark hold $pkgs; '
+        'hold_set=$(apt-mark showhold); '
+        'for p in $pkgs; do '
+        'printf "%s\\n" "$hold_set" | grep -qxF "$p" || '
+        '{ echo "FATAL: $p not held after apt-mark hold (held: $(printf %s "$hold_set" | tr "\\n" " "))" >&2; exit 1; }; '
+        'done; '
+        'echo "#1930: held $(printf %s "$pkgs" | wc -w) linux-* packages: $(printf %s "$pkgs" | tr "\\n" " ")"',
         # Exclude linux-* from unattended-upgrades too: a hold protects an
         # interactive `apt upgrade`, but unattended-upgrades can be configured to
         # bypass holds for security. Kernel CVEs flow through the verify-gated
@@ -295,17 +302,13 @@ def virt_customize(work_qcow, xpf_deb):
         "--run-command", "export DEBIAN_FRONTEND=noninteractive && "
                          f"apt-get install -y -qq -o Acquire::Retries=5 /var/tmp/{deb_name} && "
                          f"rm -f /var/tmp/{deb_name}",
-        # #1930 INC-0: keep needrestart from auto-restarting xpfd mid-apt. On a
-        # base with needrestart installed, the end-of-transaction scan restarts
-        # processes running deleted binaries — which would cut the dataplane
-        # during a kernel install in the LANE-1 channel. Blacklist xpfd + the
-        # runtime version dirs (harmless no-op if needrestart is absent).
-        "--write",
-        "/etc/needrestart/conf.d/99-xpf.conf:"
-        "# xpf (#1930): never auto-restart the dataplane during an apt run.\n"
-        '$nrconf{override_rc} = { qr(^xpfd\\.service$) => 0 };\n'
-        "push @{$nrconf{blacklist}}, "
-        "qr(^/var/lib/xpf/versions/), qr(^/usr/local/share/xpf/staged/);\n",
+        # #1930 INC-0: the needrestart blacklist for xpfd is ALREADY shipped by
+        # the package (debian/xpf.needrestart -> /etc/needrestart/conf.d/xpf.conf,
+        # installed by the .deb above) using the correct APPEND form
+        # ($nrconf{override_rc}{qr(...)} = 0), which preserves needrestart's
+        # default override_rc set. We do NOT add a second bake-written file: a
+        # whole-hash assignment would wipe those defaults, and writing into
+        # /etc/needrestart/conf.d before the .deb creates it would fail the bake.
         "--write", f"/etc/default/grub.d/99-xpf.cfg:{GRUB_DROPIN}",
         "--run-command", "update-grub",
         "--write", f"/etc/ssh/sshd_config.d/10-xpf-factory.conf:{SSHD_DROPIN}",


### PR DESCRIPTION
## Part of #1930 — INC-0: hold the kernel + apt safety in the appliance bake

The embedded AF_XDP shim `.o` is **kernel-space-verifier-gated** (#1864): a
kernel the `.o` has never been verified against can REJECT it at boot, leaving
the box with no dataplane (the exact 2026-06-10 incident that motivated #1864).
Today `bake.py` pins the image to one kernel ≥ 6.18 but nothing stops a later
`apt upgrade` from moving the running kernel out from under the gated shim.

This is the first, self-contained increment of #1930 (the kernel/OS-upgrade
umbrella). It closes the "unattended apt moves the verifier floor" hole with
**no daemon code** — the verify-gated in-place kernel **channel** itself (LANE 1)
is later #1930 work and is intentionally NOT in this PR.

### Changes (`scripts/image/bake.py`)
- **`apt-mark hold` the installed `linux-*` set.** `apt-mark` does not expand
  globs, and a bare `linux-*` would shell-expand against the cwd (holding
  nothing — empirically: in a dir containing `linux-DECOY`, `ls -d linux-*` →
  `linux-DECOY`). The set is therefore enumerated via
  `dpkg-query -W -f='${Package}\n' linux-image-* linux-headers-* linux-modules-*
  linux-generic` and **HARD-ASSERTED** (`apt-mark showhold | grep -c '^linux-'`
  ≥ 2) so a silent hold failure cannot ship an unprotected image.
- **`/etc/apt/apt.conf.d/99-xpf-kernel-hold`** blacklists `linux-*` from
  `unattended-upgrades` — a hold alone can be bypassed by u-u security upgrades.
  Kernel CVEs flow through the verify-gated LANE-1 channel (#1930), not
  background apt.
- **`/etc/needrestart/conf.d/99-xpf.conf`** keeps `needrestart` from
  auto-restarting `xpfd` (or anything under the runtime version dirs) mid-apt,
  which would cut the dataplane during a kernel install.

### Validation (proportionate — no boot channel, no cluster smoke)
- `python3 -m py_compile scripts/image/bake.py` → OK.
- `go build ./cmd/xpfd/` → OK (no Go changed; worktree builds clean).
- Functional check of the exact hold predicate on a real apt host: the
  dpkg-query enumeration lists the 6 installed `linux-*` packages; the ≥2-held
  assert math passes; the bare-glob mis-expansion was reproduced to confirm why
  dpkg-query enumeration (not a bare glob) is required.
- No live bake on this PR (libguestfs bake host); the hold/assert/blacklist are
  in-bake shell with explicit failure exits.

### Scope
- This PR is the kernel-pin/apt-safety increment ONLY.
- The verify-gated one-shot-boot kernel **channel** (A4: fixed A/B UEFI slots +
  `efibootmgr --bootnext` + `/etc/grub.d/09_xpf` `$cmdpath` branch + persistent
  watchdog), HA orchestration, and the base-OS/image-replace story are later
  #1930 PRs (held pending an operator decision on live-validation depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
