### PR TITLE
#1918: real ICMP liveness probe for tunnel keepalive

### DIFF
--- a/docs/pr/1918-probe-real-liveness/reviewer-ids.md
+++ b/docs/pr/1918-probe-real-liveness/reviewer-ids.md
@@ -19,11 +19,20 @@ Real ICMP liveness probe for tunnel keepalive.
 | AGY | `adversarial-review-mqhq593d-l5lmox` | CLEAN — fixes safe; flagged the same probe-reason actionability gap Copilot did (fixed in 9da9e14cc) |
 | Copilot | (review on PR) | 4 comments: probe-reason actionability ×2, KeepaliveUp tri-state doc, missing v6 test — all fixed in 9da9e14cc |
 
-## Round 3 (final rev @ 9da9e14cc — Copilot fixes)
+## Round 3 (rev @ 9da9e14cc — Copilot r1/r2 fixes)
 
 | Reviewer | ID | Verdict |
 |----------|----|---------|
 | Codex | `a8bb8219fdfa9ed20` | MERGE-READY — delta verified, no new issues |
 | AGY | (covered by r2 — its sole improvement note WAS the reason plumbing, now implemented) | clean |
 | Claude SMR | in-conversation | clean |
-| Copilot | re-requested @ 9da9e14cc | pending |
+| Copilot | review @ 07:19:24Z | 1 comment (r3): recreate LinkDel-failure drops keepalive — fixed in 81088afa0 |
+
+## Round 4 (final rev @ 81088afa0 — Copilot r3 fix: restart KA on LinkDel failure)
+
+| Reviewer | ID | Verdict |
+|----------|----|---------|
+| Codex | `bghcy9ovw` (thread 019ed47d-f600...) | MERGE-READY — restart correct, no F7 regression, gen captured, no deadlock, test correct, no new bugs |
+| AGY | covered by r2 (production delta is the LinkDel-failure restart only; F7 ordering preserved) | clean |
+| Claude SMR | in-conversation | clean — drain still precedes the recreate ATTEMPT; restart only on the not-recreated survivor path |
+| Copilot | re-requested @ 81088afa0 | pending |

--- a/docs/pr/1918-probe-real-liveness/reviewer-ids.md
+++ b/docs/pr/1918-probe-real-liveness/reviewer-ids.md
@@ -11,10 +11,19 @@ Real ICMP liveness probe for tunnel keepalive.
 | Claude SMR | (in-conversation) | clean | Reviewed reuse-vs-recreate gen bump, startup posture, nonce-per-tick cost, LinkDel-failure window — acceptable. |
 | Copilot | pending | | |
 
-## Round 2 (post-fix re-review @ 22e4c6b72)
+## Round 2 (post-Codex-fix re-review @ 22e4c6b72)
 
 | Reviewer | ID | Verdict |
 |----------|----|---------|
-| Codex | (resumed agent a2de27069d925925a) | |
-| AGY | | |
-| Copilot | | |
+| Codex | `019ed464-af4c-7623-8619-a57e0280bb9f` (agent a6b204b6499b62719) | MERGE-READY — both r1 HIGH fixes correct, no new bugs |
+| AGY | `adversarial-review-mqhq593d-l5lmox` | CLEAN — fixes safe; flagged the same probe-reason actionability gap Copilot did (fixed in 9da9e14cc) |
+| Copilot | (review on PR) | 4 comments: probe-reason actionability ×2, KeepaliveUp tri-state doc, missing v6 test — all fixed in 9da9e14cc |
+
+## Round 3 (final rev @ 9da9e14cc — Copilot fixes)
+
+| Reviewer | ID | Verdict |
+|----------|----|---------|
+| Codex | `a8bb8219fdfa9ed20` | MERGE-READY — delta verified, no new issues |
+| AGY | (covered by r2 — its sole improvement note WAS the reason plumbing, now implemented) | clean |
+| Claude SMR | in-conversation | clean |
+| Copilot | re-requested @ 9da9e14cc | pending |

--- a/docs/pr/1918-probe-real-liveness/reviewer-ids.md
+++ b/docs/pr/1918-probe-real-liveness/reviewer-ids.md
@@ -1,0 +1,20 @@
+# #1918 / PR #1947 — reviewer task IDs
+
+Real ICMP liveness probe for tunnel keepalive.
+
+## Round 1
+
+| Reviewer | ID | Verdict | Notes |
+|----------|----|---------|-------|
+| Codex | `019ed45c-9636-7f23-99e3-66c82177728f` (agent `a2de27069d925925a`) | CHANGES-REQUESTED | Two HIGH: (1) transient LinkByName treated as absent → drains live runner + EEXIST; (2) WriteTo ENOBUFS misclassified as Dead. Both fixed in `22e4c6b72`. |
+| AGY | `adversarial-review-mqhptss6-qglj26` | CLEAN (no findings) | Verified all 4 axes: commit-after-success, drain+linkGen+no-deadlock, errno classification, Seq+nonce. |
+| Claude SMR | (in-conversation) | clean | Reviewed reuse-vs-recreate gen bump, startup posture, nonce-per-tick cost, LinkDel-failure window — acceptable. |
+| Copilot | pending | | |
+
+## Round 2 (post-fix re-review @ 22e4c6b72)
+
+| Reviewer | ID | Verdict |
+|----------|----|---------|
+| Codex | (resumed agent a2de27069d925925a) | |
+| AGY | | |
+| Copilot | | |

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -116,11 +116,62 @@ existing kernel link is genuinely incompatible:
   the claimed RI's `vrf-` device; transient errors retain the claim
   for retry.
 - **Keepalives** (legacy branch only — anchors never probe): runners
-  are reconciled by normalized identity `(remote, interval,
+  are reconciled by normalized identity `(remote, source, interval,
   retry<=0→3)` and survive unrelated applies; `LinkSetUp` is SKIPPED
   when a retained runner holds the tunnel down (the down-transition in
   `keepaliveLoop` is gated on `state.Up`, so re-upping would strand
-  the link admin UP).
+  the link admin UP). A change to the tunnel SOURCE restarts the runner
+  (#1918 §5c): the source is the probe bind address.
+
+## Keepalive liveness probing (`tunnel_keepalive.go`, #1918)
+
+The keepalive performs a **real ICMP echo round-trip** — it is a
+liveness check, not a route-existence check. (The pre-#1918 `probeICMP`
+opened a socket and returned `true` without sending anything, so a dead
+peer behind a valid route read up forever and the fail-safe
+`LinkSetDown` was unreachable.)
+
+- **Mechanism**: unprivileged datagram ICMP (`udp4`/`udp6` via
+  `golang.org/x/net/icmp`), the same mechanism as the tested
+  `pkg/cluster/monitor.go` precedent. Requires `net.ipv4.ping_group_range`
+  to admit the daemon gid (or `CAP_NET_RAW`); when it does not, the probe
+  is **ProbeUnsupported** and the link is HELD (never torn down — see
+  hold-on-unknown).
+- **Reply match**: `Seq` + a per-probe random **Data-nonce** — NOT the
+  ICMP ID. Datagram ("ping") sockets rewrite the outbound id to the
+  socket source port, so id is advisory only.
+- **Probe target / table**: the underlay `Destination`, routed in the
+  GLOBAL/underlay FIB (no `SO_BINDTODEVICE` to an overlay VRF) — exactly
+  where the tunnel's encapsulated packets resolve.
+- **Source bind**: the probe binds the tunnel's local `Source` IP so the
+  echo egresses from, and the reply returns to, the tunnel endpoint
+  (multi-homed / policy-routed correctness). Empty source → wildcard.
+- **Typed result** (`ProbeResult`): `ProbeAlive | ProbeDead |
+  ProbeUnsupported`. The old `bool` erased "could not probe".
+- **Hold-on-unknown** (Axis C): on `ProbeUnsupported` the loop does NOT
+  change `Failures` and does NOT transition the link; it holds the prior
+  `Up` and reports `KeepaliveUp == nil` with `KeepaliveInfo = "unknown
+  (...)"`. Structural causes (missing `ping_group_range`/cap, bound
+  source not local) hold indefinitely with a one-shot `slog.Warn`;
+  transient causes (FD/memory exhaustion, unrecognized errno) hold but
+  escalate to `slog.Error` after `MaxRetries` consecutive unknown ticks
+  so a real peer death is never silently masked. Tearing the link down
+  because the daemon cannot probe would be a self-inflicted outage.
+- **Commit-after-success / lock scope** (Axis D): the tick classifies the
+  probe and computes the transition INTENT under `state.mu`, releases the
+  lock, performs the single `LinkSetUp`/`LinkSetDown` OUTSIDE the lock,
+  and commits `state.Up` ONLY if the netlink op succeeded. A
+  `LinkByName`/`LinkSet*` error leaves `Up` unchanged so the transition
+  retries next tick (never a lost or half-applied transition), and a
+  racing `GetStatus` never blocks behind a slow netlink op nor observes
+  an uncommitted `Up`.
+- **Recreate safety**: `applyKernelTunnelLocked` cancels + DRAINS the
+  existing keepalive runner BEFORE it deletes/recreates the kernel link
+  (drain-before-recreate), so no stale runner can issue a `LinkSet*`
+  against a recreated link that reused the ifindex. A per-tunnel
+  `linkGen` (`*atomic.Uint64`, read LOCK-FREE by the runner — it never
+  takes `t.mu`) is the defense-in-depth backstop; the runner drops any
+  transition whose captured generation no longer matches.
 
 `Clear()`/`ClearTunnels` keep delete-everything semantics and reset the
 reconcile state. Restart residuals (documented): anchors/addresses/RI

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -891,17 +891,13 @@ func TestBuildPBRRules(t *testing.T) {
 	})
 }
 
-func TestProbeICMP(t *testing.T) {
-	// localhost should always be reachable (via UDP fallback at minimum)
-	if !probeICMP("127.0.0.1") {
-		t.Error("expected probe to 127.0.0.1 to succeed")
-	}
-
-	// Invalid address should fail
-	if probeICMP("not-an-ip") {
-		t.Error("expected probe to invalid address to fail")
-	}
-}
+// NOTE (#1918): the former TestProbeICMP asserted probeICMP("127.0.0.1")
+// returns true (route exists) and probeICMP("not-an-ip") returns false.
+// Both encoded the bug — the old prober returned true on socket-open
+// without any echo round-trip, i.e. a route-existence check, not a
+// liveness check. probeICMP is deleted; the real prober (icmpProber) and
+// its consumer (keepaliveLoop) are now covered by deterministic,
+// injected-prober tests in tunnel_keepalive_test.go.
 
 func TestKeepaliveState(t *testing.T) {
 	state := &KeepaliveState{

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -548,14 +548,29 @@ func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
 	// existed inside startKeepalive but ran AFTER the recreate. After the
 	// drain the old runner's goroutine has returned and cannot issue any
 	// further LinkSet*. linkGen is the defense-in-depth backstop.
+	//
+	// A lookup error must be classified (Codex PR #1947 r1 HIGH): only a
+	// genuine NOT-FOUND means "absent → create". Any OTHER lookup error
+	// (EBUSY / transport hiccup) is TRANSIENT — it does NOT mean the link
+	// is gone, so we must NOT drain the live keepalive runner and must NOT
+	// fall through to a LinkAdd that would EEXIST. Abort and retry next
+	// apply, exactly like a transient LinkDel failure below.
 	willRecreate := false
 	var existing netlink.Link
-	if e, lookupErr := t.ops.LinkByName(tc.Name); lookupErr == nil {
+	e, lookupErr := t.ops.LinkByName(tc.Name)
+	switch {
+	case lookupErr == nil:
 		existing = e
 		willRecreate = !legacyTunnelMatches(e, desired)
-	} else {
-		// No existing link → a create (LinkAdd) below is a (re)create.
+	case isLinkNotFound(lookupErr):
+		// Absent → the LinkAdd below is a (re)create.
 		willRecreate = true
+	default:
+		// Transient lookup error: leave the runner and any live link
+		// untouched; retry on the next apply.
+		slog.Warn("tunnel lookup failed transiently; deferring apply",
+			"name", tc.Name, "err", lookupErr)
+		return
 	}
 	if willRecreate {
 		// Drain the stale runner first; bump the generation so any runner

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -124,12 +124,18 @@ func (r *keepaliveRunner) matches(tc *config.TunnelConfig) bool {
 
 // TunnelStatus holds the status of a tunnel interface.
 type TunnelStatus struct {
-	Name          string
-	Source        string
-	Destination   string
-	State         string // "up" or "down"
-	Addresses     []string
-	KeepaliveUp   *bool  // nil if no keepalive configured
+	Name        string
+	Source      string
+	Destination string
+	State       string // "up" or "down"
+	Addresses   []string
+	// KeepaliveUp is tri-state (#1918): non-nil true/false when liveness is
+	// KNOWN (probe succeeded/failed), and nil when EITHER no keepalive is
+	// configured OR liveness is currently UNKNOWN (ProbeUnsupported —
+	// hold-on-unknown). The two nil cases are distinguished by
+	// KeepaliveInfo: "" → not configured; "unknown (...)" → configured but
+	// liveness unknown.
+	KeepaliveUp   *bool
 	KeepaliveInfo string // human-readable keepalive status
 }
 
@@ -1162,7 +1168,7 @@ func (t *tunnelManager) keepaliveTick(tunnelName string, state *KeepaliveState, 
 	deadline := keepaliveProbeDeadline(state.Interval)
 	seq := nextSeq(state)
 	nonce := makeNonce()
-	result, kind := prober.Probe(state.SourceAddr, state.RemoteAddr, seq, nonce, deadline)
+	result, kind, reason := prober.Probe(state.SourceAddr, state.RemoteAddr, seq, nonce, deadline)
 
 	// ---- Step 1: classify + commit counters, compute intent ----
 	state.mu.Lock()
@@ -1185,8 +1191,14 @@ func (t *tunnelManager) keepaliveTick(tunnelName string, state *KeepaliveState, 
 	case ProbeUnsupported:
 		// Hold-on-unknown (§6 Axis C, C1): do NOT touch Failures,
 		// do NOT transition the link. Surface as unknown; escalate a
-		// sustained TRANSIENT unknown after MaxRetries ticks.
-		state.markUnknownLocked(tunnelName, kind, classifyErrnoString(kind))
+		// sustained TRANSIENT unknown after MaxRetries ticks. The prober's
+		// reason (real syscall/config detail) is recorded so the status and
+		// escalation log are actionable (Copilot PR #1947).
+		detail := reason
+		if detail == "" {
+			detail = classifyErrnoString(kind)
+		}
+		state.markUnknownLocked(tunnelName, kind, detail)
 	}
 	state.mu.Unlock()
 
@@ -1429,11 +1441,17 @@ func (t *tunnelManager) GetStatus() ([]TunnelStatus, error) {
 				// the operator why so they can fix the sysctl/caps. A
 				// sustained transient unknown carries the escalated errno.
 				ts.KeepaliveUp = nil
-				if ks.UnknownKind == UnsupportedTransient {
+				switch {
+				case ks.UnknownKind == UnsupportedTransient:
 					ts.KeepaliveInfo = fmt.Sprintf(
 						"unknown (%s; %d consecutive)",
 						ks.UnknownErrno, ks.unknownStreak)
-				} else {
+				case ks.UnknownErrno != "":
+					// Structural with a captured reason (the real syscall/config
+					// detail): show it so the operator can fix the root cause.
+					ts.KeepaliveInfo = fmt.Sprintf(
+						"unknown (ICMP probe unavailable: %s)", ks.UnknownErrno)
+				default:
 					ts.KeepaliveInfo = "unknown (ICMP probe unavailable)"
 				}
 			default:

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -595,6 +595,17 @@ func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
 			if delErr := t.ops.LinkDel(existing); delErr != nil {
 				slog.Warn("failed to replace existing tunnel link",
 					"name", tc.Name, "existing_type", existing.Type(), "err", delErr)
+				// The recreate failed but the OLD link is still live. We
+				// already drained its keepalive runner before the LinkDel
+				// (F7 ordering). Restart it against the surviving link so a
+				// transient LinkDel failure does not silently leave the
+				// tunnel running with NO keepalive until the next successful
+				// apply (Copilot PR #1947 r3). Safe because the link was NOT
+				// recreated — the restarted runner captures the just-bumped
+				// generation and probes the same device.
+				if tc.Keepalive > 0 {
+					t.startKeepalive(tc.Name, tc.Source, tc.Destination, tc.Keepalive, tc.KeepaliveRetry)
+				}
 				return
 			}
 			slog.Info("replaced tunnel link with changed parameters",

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -47,9 +48,31 @@ type KeepaliveState struct {
 	Failures    int  // consecutive probe failures
 	LastSuccess time.Time
 	LastFailure time.Time
-	RemoteAddr  string // remote endpoint being probed
+	RemoteAddr  string // underlay remote endpoint being probed
+	SourceAddr  string // tunnel local endpoint IP bound for the probe (§5c)
 	Interval    int    // probe interval in seconds
 	MaxRetries  int    // failures before declaring down
+
+	// #1918 hold-on-unknown bookkeeping. When the prober cannot perform a
+	// probe (ProbeUnsupported), the loop holds the prior Up value and
+	// reports the link liveness as unknown (KeepaliveUp == nil) rather
+	// than tearing the link down for a self-inflicted reason.
+	//   Unknown       — last tick could not probe (status renders "unknown").
+	//   UnknownKind   — structural (hold indefinitely) vs transient.
+	//   UnknownErrno  — human errno string for the escalated status.
+	//   unknownStreak — consecutive unknown ticks; gates transient
+	//                   escalation after MaxRetries consecutive ticks.
+	//   warnedUnknown — one-shot guard for the structural slog.Warn.
+	Unknown       bool
+	UnknownKind   UnsupportedKind
+	UnknownErrno  string
+	unknownStreak int
+	warnedUnknown bool
+
+	// seq is the monotonic 16-bit ICMP echo sequence counter (§5a). Each
+	// probe increments it; the reply must match Seq AND the per-probe
+	// Data-nonce.
+	seq int
 }
 
 // keepaliveRunner manages the goroutine for a single tunnel's keepalive.
@@ -67,20 +90,34 @@ type keepaliveRunner struct {
 	// unchanged runner alive across applies instead of restarting it
 	// (which would reset probe state every commit).
 	remote     string
+	source     string // tunnel local endpoint IP probed-from (#1918 §5c)
 	interval   int
 	maxRetries int // normalized: <=0 config value stored as 3
+
+	// linkGen is the per-tunnel generation token captured at start
+	// (#1918 §6 Axis D, defense-in-depth). The runner reads it LOCK-FREE
+	// (.Load()) before each netlink op and drops the action if it no
+	// longer matches the manager's current generation — so a stale runner
+	// cannot down/up a recreated link. The runner NEVER takes t.mu (AGY
+	// r5 deadlock note: a tick blocked on t.mu while Apply blocks on the
+	// drain would deadlock).
+	linkGen  *atomic.Uint64
+	startGen uint64
 }
 
 // matches reports whether the runner's identity equals the config's
 // NORMALIZED keepalive parameters. KeepaliveRetry <= 0 normalizes to 3
 // BEFORE comparison (#1884 r1 Codex F5: comparing a raw config 0
 // against the stored default 3 would restart the runner every apply).
+// The tunnel SOURCE is part of the identity (#1918 §5c): a source-only
+// change must restart the runner so the probe binds the new endpoint.
 func (r *keepaliveRunner) matches(tc *config.TunnelConfig) bool {
 	retries := tc.KeepaliveRetry
 	if retries <= 0 {
 		retries = 3
 	}
 	return r.remote == tc.Destination &&
+		r.source == tc.Source &&
 		r.interval == tc.Keepalive &&
 		r.maxRetries == retries
 }
@@ -105,9 +142,23 @@ type tunnelManager struct {
 	ops       linkOps
 	vrfBinder vrfBinder
 
+	// prober performs the keepalive ICMP echo. nil → the production
+	// icmpProber (lazily resolved by keepaliveProber). Tests inject a
+	// deterministic fake (#1918).
+	prober tunnelProber
+
 	mu         sync.Mutex
 	tunnels    []string                    // tunnels successfully applied this round (GetStatus source)
 	keepalives map[string]*keepaliveRunner // tunnel name -> runner
+
+	// linkGen is the per-tunnel monotonic generation counter (#1918 §6
+	// Axis D, defense-in-depth recreate guard). The MAP structure is
+	// mutated only under mu (by Apply, via bumpLinkGenLocked); the counter
+	// values are *atomic.Uint64 so a keepalive runner can Load() them
+	// lock-free at tick time without ever taking mu (AGY r5 deadlock
+	// note). Apply bumps the counter on a tunnel link create/recreate so a
+	// stale runner captured at the old generation drops its LinkSet*.
+	linkGen map[string]*atomic.Uint64
 
 	// Reconcile-in-place state (#1884). All lazily initialized by Apply.
 	//
@@ -149,6 +200,38 @@ func (t *tunnelManager) ensureReconcileStateLocked() {
 	if t.keepalives == nil {
 		t.keepalives = map[string]*keepaliveRunner{}
 	}
+	if t.linkGen == nil {
+		t.linkGen = map[string]*atomic.Uint64{}
+	}
+}
+
+// linkGenForLocked returns the (lazily created) generation counter for a
+// tunnel name. Caller MUST hold mu.
+func (t *tunnelManager) linkGenForLocked(name string) *atomic.Uint64 {
+	g, ok := t.linkGen[name]
+	if !ok {
+		g = &atomic.Uint64{}
+		t.linkGen[name] = g
+	}
+	return g
+}
+
+// bumpLinkGenLocked advances a tunnel's generation token. Called by
+// Apply whenever it CREATES or RECREATES the kernel link for a tunnel,
+// so any keepalive runner still holding the previous generation drops
+// its netlink op (#1918 §6 Axis D defense-in-depth). Caller MUST hold
+// mu.
+func (t *tunnelManager) bumpLinkGenLocked(name string) {
+	t.linkGenForLocked(name).Add(1)
+}
+
+// keepaliveProber resolves the prober used by keepalive goroutines: the
+// injected test fake when set, else the production datagram-ICMP prober.
+func (t *tunnelManager) keepaliveProber() tunnelProber {
+	if t.prober != nil {
+		return t.prober
+	}
+	return icmpProber{}
 }
 
 // Apply reconciles the kernel tunnel devices against the desired
@@ -456,10 +539,35 @@ func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
 	isIPv6 := localIP.To4() == nil
 	desired := buildKernelTunnelLink(tc, localIP, remoteIP, uint8(ttl), isIPv6)
 
+	// #1918 §6 Axis D F7 — drain-before-recreate. Decide up front whether
+	// this apply will recreate (delete + re-add) the kernel link. If so,
+	// CANCEL + DRAIN any existing keepalive runner BEFORE the LinkDel /
+	// LinkAdd, so no stale runner goroutine can be mid-LinkSet* while the
+	// link is recreated and the kernel reuses its ifindex (the F7
+	// counterexample). The drain is the real serializer; it already
+	// existed inside startKeepalive but ran AFTER the recreate. After the
+	// drain the old runner's goroutine has returned and cannot issue any
+	// further LinkSet*. linkGen is the defense-in-depth backstop.
+	willRecreate := false
+	var existing netlink.Link
+	if e, lookupErr := t.ops.LinkByName(tc.Name); lookupErr == nil {
+		existing = e
+		willRecreate = !legacyTunnelMatches(e, desired)
+	} else {
+		// No existing link → a create (LinkAdd) below is a (re)create.
+		willRecreate = true
+	}
+	if willRecreate {
+		// Drain the stale runner first; bump the generation so any runner
+		// that somehow survives (future code paths) drops its netlink op.
+		t.stopKeepaliveLocked(tc.Name)
+		t.bumpLinkGenLocked(tc.Name)
+	}
+
 	var link netlink.Link
 	created := false
-	if existing, lookupErr := t.ops.LinkByName(tc.Name); lookupErr == nil {
-		if legacyTunnelMatches(existing, desired) {
+	if existing != nil {
+		if !willRecreate {
 			link = existing // kernel-fetched, real ifindex (#1706)
 			slog.Debug("tunnel reused", "name", tc.Name)
 		} else {
@@ -543,8 +651,8 @@ func (t *tunnelManager) applyKernelTunnelLocked(tc *config.TunnelConfig) {
 		if restartKA {
 			// startKeepalive stops+drains any predecessor itself;
 			// runs AFTER a recreate so the fresh runner probes the
-			// new device.
-			t.startKeepalive(tc.Name, tc.Destination, tc.Keepalive, tc.KeepaliveRetry)
+			// new device. tc.Source is the bind endpoint (#1918 §5c).
+			t.startKeepalive(tc.Name, tc.Source, tc.Destination, tc.Keepalive, tc.KeepaliveRetry)
 		}
 	} else if hasRunner {
 		t.stopKeepaliveLocked(tc.Name)
@@ -942,8 +1050,9 @@ func (t *tunnelManager) stopKeepaliveLocked(name string) {
 }
 
 // startKeepalive starts a keepalive probe goroutine for a tunnel.
-// Caller MUST hold mu.
-func (t *tunnelManager) startKeepalive(tunnelName, remoteAddr string, interval, maxRetries int) {
+// source is the tunnel local endpoint IP the probe binds to (#1918
+// §5c); "" → wildcard. Caller MUST hold mu.
+func (t *tunnelManager) startKeepalive(tunnelName, source, remoteAddr string, interval, maxRetries int) {
 	// Stop existing keepalive for this tunnel if any. Drain on done
 	// so the replacement doesn't race the old goroutine on the handle.
 	t.stopKeepaliveLocked(tunnelName)
@@ -955,9 +1064,16 @@ func (t *tunnelManager) startKeepalive(tunnelName, remoteAddr string, interval, 
 	state := &KeepaliveState{
 		Up:         true,
 		RemoteAddr: remoteAddr,
+		SourceAddr: source,
 		Interval:   interval,
 		MaxRetries: maxRetries,
 	}
+
+	// Capture the current generation token (#1918 §6 Axis D
+	// defense-in-depth). The runner reads it LOCK-FREE — it never takes
+	// t.mu — so an Apply blocked on the drain can never deadlock a tick.
+	gen := t.linkGenForLocked(tunnelName)
+	startGen := gen.Load()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -966,18 +1082,49 @@ func (t *tunnelManager) startKeepalive(tunnelName, remoteAddr string, interval, 
 		state:      state,
 		done:       done,
 		remote:     remoteAddr,
+		source:     source,
 		interval:   interval,
 		maxRetries: maxRetries,
+		linkGen:    gen,
+		startGen:   startGen,
 	}
 
-	go t.keepaliveLoop(ctx, done, tunnelName, state)
+	prober := t.keepaliveProber()
+	go t.keepaliveLoop(ctx, done, tunnelName, state, prober, gen, startGen)
 	slog.Info("started keepalive", "tunnel", tunnelName,
-		"remote", remoteAddr, "interval", interval, "retries", maxRetries)
+		"source", source, "remote", remoteAddr, "interval", interval, "retries", maxRetries)
 }
 
-// keepaliveLoop runs periodic ICMP probes to the tunnel remote endpoint.
+// keepaliveProbeDeadline returns the per-probe round-trip budget: a
+// fraction of the interval, capped at 800ms (R5). Keeps the probe well
+// inside the tick so a slow/lost reply cannot overrun the next tick.
+func keepaliveProbeDeadline(intervalSec int) time.Duration {
+	const maxDeadline = 800 * time.Millisecond
+	half := time.Duration(intervalSec) * time.Second / 2
+	if half <= 0 || half > maxDeadline {
+		return maxDeadline
+	}
+	return half
+}
+
+// keepaliveLoop runs periodic ICMP echo probes to the tunnel underlay
+// endpoint and drives the link admin state off REAL liveness (#1918).
 // Closes `done` when it returns so stopAll can drain.
-func (t *tunnelManager) keepaliveLoop(ctx context.Context, done chan struct{}, tunnelName string, state *KeepaliveState) {
+//
+// Tick body is the §6 Axis D COMMIT-AFTER-SUCCESS sequence:
+//  1. Under state.mu: classify the probe; commit pure counters
+//     (Failures/LastSuccess/LastFailure/unknown bookkeeping); compute
+//     the transition INTENT (wantUp/wantDown) WITHOUT writing Up; Unlock.
+//     A racing GetStatus/Apply therefore never observes an uncommitted Up.
+//  2. No intent → done (no netlink, no Up write).
+//  3. LinkByName; on error do nothing (Up unchanged → retried next tick).
+//  4. Lock-free gen.Load() guard: if the generation changed, the link
+//     was recreated under us → DROP the action (do not down/up the
+//     replacement). Never takes t.mu (AGY r5).
+//  5. The single LinkSetUp/LinkSetDown, OUTSIDE state.mu, capturing err.
+//  6. Commit Up ONLY on netlink success; on error leave Up unchanged so
+//     the transition retries.
+func (t *tunnelManager) keepaliveLoop(ctx context.Context, done chan struct{}, tunnelName string, state *KeepaliveState, prober tunnelProber, gen *atomic.Uint64, startGen uint64) {
 	defer close(done)
 	ticker := time.NewTicker(time.Duration(state.Interval) * time.Second)
 	defer ticker.Stop()
@@ -987,67 +1134,164 @@ func (t *tunnelManager) keepaliveLoop(ctx context.Context, done chan struct{}, t
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			ok := probeICMP(state.RemoteAddr)
-			state.mu.Lock()
-			if ok {
-				state.LastSuccess = time.Now()
-				if !state.Up {
-					slog.Info("tunnel keepalive recovered", "tunnel", tunnelName,
-						"remote", state.RemoteAddr)
-					state.Up = true
-					state.Failures = 0
-					// Bring tunnel back up
-					if link, err := t.ops.LinkByName(tunnelName); err == nil {
-						t.ops.LinkSetUp(link)
-					}
-				}
-				state.Failures = 0
-			} else {
-				state.Failures++
-				state.LastFailure = time.Now()
-				if state.Up && state.Failures >= state.MaxRetries {
-					slog.Warn("tunnel keepalive failed, marking down",
-						"tunnel", tunnelName, "remote", state.RemoteAddr,
-						"failures", state.Failures)
-					state.Up = false
-					// Bring tunnel down
-					if link, err := t.ops.LinkByName(tunnelName); err == nil {
-						t.ops.LinkSetDown(link)
-					}
-				}
-			}
-			state.mu.Unlock()
+			t.keepaliveTick(tunnelName, state, prober, gen, startGen)
 		}
 	}
 }
 
-// probeICMP sends a single ICMP echo request and returns true if the host responds.
-func probeICMP(addr string) bool {
-	ip := net.ParseIP(addr)
-	if ip == nil {
-		return false
-	}
+// keepaliveTick runs one §6 Axis D commit-after-success probe cycle. It
+// is the per-tick body of keepaliveLoop, extracted so tests can drive a
+// single deterministic tick without a real ticker. It NEVER takes t.mu
+// (AGY r5): only state.mu (two short sections) and a lock-free gen.Load().
+func (t *tunnelManager) keepaliveTick(tunnelName string, state *KeepaliveState, prober tunnelProber, gen *atomic.Uint64, startGen uint64) {
+	deadline := keepaliveProbeDeadline(state.Interval)
+	seq := nextSeq(state)
+	nonce := makeNonce()
+	result, kind := prober.Probe(state.SourceAddr, state.RemoteAddr, seq, nonce, deadline)
 
-	network := "ip4:icmp"
-	if ip.To4() == nil {
-		network = "ip6:ipv6-icmp"
-	}
-
-	conn, err := net.DialTimeout(network, addr, 3*time.Second)
-	if err != nil {
-		// Fallback: use UDP dial as a reachability check when raw socket
-		// is not available (no CAP_NET_RAW). A successful UDP dial only
-		// means the route exists, but for keepalive purposes this is
-		// close enough. ping utility would be better but adds exec overhead.
-		conn2, err2 := net.DialTimeout("udp", net.JoinHostPort(addr, "1"), 3*time.Second)
-		if err2 != nil {
-			return false
+	// ---- Step 1: classify + commit counters, compute intent ----
+	state.mu.Lock()
+	var wantUp, wantDown bool
+	switch result {
+	case ProbeAlive:
+		state.LastSuccess = time.Now()
+		state.clearUnknownLocked()
+		if !state.Up {
+			wantUp = true // recovery edge
 		}
-		conn2.Close()
-		return true
+		state.Failures = 0
+	case ProbeDead:
+		state.LastFailure = time.Now()
+		state.clearUnknownLocked()
+		state.Failures++
+		if state.Up && state.Failures >= state.MaxRetries {
+			wantDown = true
+		}
+	case ProbeUnsupported:
+		// Hold-on-unknown (§6 Axis C, C1): do NOT touch Failures,
+		// do NOT transition the link. Surface as unknown; escalate a
+		// sustained TRANSIENT unknown after MaxRetries ticks.
+		state.markUnknownLocked(tunnelName, kind, classifyErrnoString(kind))
 	}
-	conn.Close()
-	return true
+	state.mu.Unlock()
+
+	// ---- Step 2: no transition intent → nothing to do ----
+	if !wantUp && !wantDown {
+		return
+	}
+
+	// ---- Step 3: resolve the link; error → retry next tick ----
+	link, err := t.ops.LinkByName(tunnelName)
+	if err != nil {
+		// Do NOT write Up; the guard in step 1 fires again next
+		// tick (Up unchanged). No spurious latch from a transient
+		// netlink lookup hiccup (§4.6).
+		slog.Debug("keepalive transition deferred: link lookup failed",
+			"tunnel", tunnelName, "err", err)
+		return
+	}
+
+	// ---- Step 4: lock-free generation guard (defense-in-depth) --
+	if gen.Load() != startGen {
+		// The link was recreated by Apply since this runner started.
+		// Drop the action so we never down/up the replacement link.
+		slog.Debug("keepalive transition dropped: link generation changed",
+			"tunnel", tunnelName)
+		return
+	}
+
+	// ---- Step 5: the single netlink op, OUTSIDE state.mu --------
+	var nlErr error
+	if wantUp {
+		nlErr = t.ops.LinkSetUp(link)
+	} else {
+		nlErr = t.ops.LinkSetDown(link)
+	}
+
+	// ---- Step 6: commit Up only on netlink success -------------
+	if nlErr != nil {
+		// Up retains its pre-transition value → the transition is
+		// retried next tick until the kernel op succeeds. Never a
+		// lost transition (Codex r3 counterexample).
+		slog.Warn("keepalive netlink transition failed; will retry",
+			"tunnel", tunnelName, "want_up", wantUp, "err", nlErr)
+		return
+	}
+	state.mu.Lock()
+	if wantUp {
+		state.Up = true
+		state.Failures = 0
+		slog.Info("tunnel keepalive recovered", "tunnel", tunnelName,
+			"remote", state.RemoteAddr)
+	} else {
+		state.Up = false
+		slog.Warn("tunnel keepalive failed, marking down",
+			"tunnel", tunnelName, "remote", state.RemoteAddr,
+			"failures", state.Failures)
+	}
+	state.mu.Unlock()
+}
+
+// nextSeq returns a fresh monotonic 16-bit sequence number for a probe
+// (§5a). Wraps at 0xffff; the per-probe nonce disambiguates a wrapped
+// collision. Mutates Failures-adjacent state under its own lock.
+func nextSeq(state *KeepaliveState) int {
+	state.mu.Lock()
+	state.seq = (state.seq + 1) & 0xffff
+	s := state.seq
+	state.mu.Unlock()
+	return s
+}
+
+// clearUnknownLocked resets the hold-on-unknown bookkeeping after a
+// definitive Alive/Dead probe. Caller MUST hold state.mu.
+func (s *KeepaliveState) clearUnknownLocked() {
+	s.Unknown = false
+	s.UnknownKind = UnsupportedNone
+	s.UnknownErrno = ""
+	s.unknownStreak = 0
+	s.warnedUnknown = false
+}
+
+// markUnknownLocked records a ProbeUnsupported tick. Structural emits a
+// one-shot Warn and holds indefinitely; transient holds but escalates to
+// slog.Error after MaxRetries consecutive unknown ticks (§6 Axis C,
+// transient escalation). Never changes Up or Failures. Caller MUST hold
+// state.mu.
+func (s *KeepaliveState) markUnknownLocked(tunnelName string, kind UnsupportedKind, errStr string) {
+	s.Unknown = true
+	s.UnknownKind = kind
+	s.UnknownErrno = errStr
+	s.unknownStreak++
+	switch kind {
+	case UnsupportedStructural:
+		if !s.warnedUnknown {
+			s.warnedUnknown = true
+			slog.Warn("tunnel keepalive cannot probe (ICMP unavailable); holding prior state",
+				"tunnel", tunnelName, "remote", s.RemoteAddr,
+				"hint", "set net.ipv4.ping_group_range or grant CAP_NET_RAW")
+		}
+	case UnsupportedTransient:
+		if s.unknownStreak >= s.MaxRetries && !s.warnedUnknown {
+			s.warnedUnknown = true
+			slog.Error("tunnel keepalive probe failing on local resource error; cannot verify peer liveness",
+				"tunnel", tunnelName, "remote", s.RemoteAddr,
+				"errno", errStr, "consecutive", s.unknownStreak)
+		}
+	}
+}
+
+// classifyErrnoString renders a short label for the unknown kind used in
+// the status string.
+func classifyErrnoString(kind UnsupportedKind) string {
+	switch kind {
+	case UnsupportedTransient:
+		return "probe socket error"
+	case UnsupportedStructural:
+		return "ICMP probe unavailable"
+	default:
+		return "unknown"
+	}
 }
 
 // GetKeepaliveState returns the keepalive state for a tunnel, or nil
@@ -1109,6 +1353,11 @@ func (t *tunnelManager) clearLocked() error {
 	t.ownedNames = nil
 	t.appliedAddrs = nil
 	t.appliedRI = nil
+	// clearLocked drains every keepalive runner first
+	// (stopAllKeepalivesLocked above), so no live runner holds a stale
+	// linkGen pointer; dropping the map is safe and prevents removed names
+	// from leaking generation counters (#1918).
+	t.linkGen = nil
 	return nil
 }
 
@@ -1154,17 +1403,34 @@ func (t *tunnelManager) GetStatus() ([]TunnelStatus, error) {
 			}
 		}
 
-		// Add keepalive info
+		// Add keepalive info.
 		if ks := t.GetKeepaliveState(name); ks != nil {
 			ks.mu.Lock()
-			up := ks.Up
-			ts.KeepaliveUp = &up
-			if up {
-				ts.KeepaliveInfo = fmt.Sprintf("up (interval %ds, %d retries)",
-					ks.Interval, ks.MaxRetries)
-			} else {
-				ts.KeepaliveInfo = fmt.Sprintf("down (%d consecutive failures)",
-					ks.Failures)
+			switch {
+			case ks.Unknown:
+				// Hold-on-unknown (#1918 §6 Axis C): the prober could not
+				// verify liveness. KeepaliveUp stays nil ("liveness
+				// unknown") — never reported up — and the info string tells
+				// the operator why so they can fix the sysctl/caps. A
+				// sustained transient unknown carries the escalated errno.
+				ts.KeepaliveUp = nil
+				if ks.UnknownKind == UnsupportedTransient {
+					ts.KeepaliveInfo = fmt.Sprintf(
+						"unknown (%s; %d consecutive)",
+						ks.UnknownErrno, ks.unknownStreak)
+				} else {
+					ts.KeepaliveInfo = "unknown (ICMP probe unavailable)"
+				}
+			default:
+				up := ks.Up
+				ts.KeepaliveUp = &up
+				if up {
+					ts.KeepaliveInfo = fmt.Sprintf("up (interval %ds, %d retries)",
+						ks.Interval, ks.MaxRetries)
+				} else {
+					ts.KeepaliveInfo = fmt.Sprintf("down (%d consecutive failures)",
+						ks.Failures)
+				}
 			}
 			ks.mu.Unlock()
 		}

--- a/pkg/routing/tunnel_keepalive.go
+++ b/pkg/routing/tunnel_keepalive.go
@@ -66,8 +66,13 @@ const (
 // traffic (§5b — NO overlay-VRF bind). seq + nonce uniquely key the
 // reply to THIS probe (§5a — NOT the ICMP ID, which datagram sockets
 // rewrite to the socket source port).
+// The reason return is a short human-readable detail for a
+// ProbeUnsupported result (the actual syscall errno / config failure),
+// surfaced in KeepaliveInfo and the escalation log so the operator sees
+// WHY the probe could not run — not just a generic label (Copilot PR
+// #1947). Empty for Alive/Dead.
 type tunnelProber interface {
-	Probe(source, dst string, seq int, nonce []byte, deadline time.Duration) (ProbeResult, UnsupportedKind)
+	Probe(source, dst string, seq int, nonce []byte, deadline time.Duration) (result ProbeResult, kind UnsupportedKind, reason string)
 }
 
 // icmpProber is the production tunnelProber. It uses unprivileged
@@ -100,12 +105,12 @@ var listenICMP = func(network, source string) (probeConn, error) {
 }
 
 // Probe sends one ICMP echo to dst and reports the typed result.
-func (icmpProber) Probe(source, dst string, seq int, nonce []byte, deadline time.Duration) (ProbeResult, UnsupportedKind) {
+func (icmpProber) Probe(source, dst string, seq int, nonce []byte, deadline time.Duration) (ProbeResult, UnsupportedKind, string) {
 	ip := net.ParseIP(dst)
 	if ip == nil {
 		// A non-parseable destination is a configuration error, not a
 		// transient resource problem: hold-on-unknown structural.
-		return ProbeUnsupported, UnsupportedStructural
+		return ProbeUnsupported, UnsupportedStructural, "destination not an IP: " + dst
 	}
 
 	isIPv6 := ip.To4() == nil
@@ -135,7 +140,7 @@ func (icmpProber) Probe(source, dst string, seq int, nonce []byte, deadline time
 
 	conn, err := listenICMP(network, listen)
 	if err != nil {
-		return ProbeUnsupported, classifyListenErr(err)
+		return ProbeUnsupported, classifyListenErr(err), "listen " + network + " " + listen + ": " + err.Error()
 	}
 	defer conn.Close()
 
@@ -155,12 +160,12 @@ func (icmpProber) Probe(source, dst string, seq int, nonce []byte, deadline time
 	if err != nil {
 		// Marshal of a fixed-shape echo should never fail; treat a failure
 		// as a structural (non-flapping) unknown.
-		return ProbeUnsupported, UnsupportedStructural
+		return ProbeUnsupported, UnsupportedStructural, "echo marshal: " + err.Error()
 	}
 
 	abs := time.Now().Add(deadline)
 	if err := conn.SetReadDeadline(abs); err != nil {
-		return ProbeUnsupported, classifyListenErr(err)
+		return ProbeUnsupported, classifyListenErr(err), "set deadline: " + err.Error()
 	}
 	if _, err := conn.WriteTo(b, &net.UDPAddr{IP: ip}); err != nil {
 		// Classify a write error (Codex PR #1947 r1 HIGH). A path/route
@@ -171,9 +176,9 @@ func (icmpProber) Probe(source, dst string, seq int, nonce []byte, deadline time
 		// self-inflict a tunnel down. Route it through hold-on-unknown
 		// (transient) instead, mirroring the ListenPacket classifier.
 		if kind := classifyWriteErr(err); kind != UnsupportedNone {
-			return ProbeUnsupported, kind
+			return ProbeUnsupported, kind, "write echo: " + err.Error()
 		}
-		return ProbeDead, UnsupportedNone
+		return ProbeDead, UnsupportedNone, ""
 	}
 
 	reply := make([]byte, 1500)
@@ -181,12 +186,12 @@ func (icmpProber) Probe(source, dst string, seq int, nonce []byte, deadline time
 		// R4: re-check the absolute deadline each iteration so a datagram
 		// flood cannot extend a probe past its budget.
 		if remaining := time.Until(abs); remaining <= 0 {
-			return ProbeDead, UnsupportedNone
+			return ProbeDead, UnsupportedNone, ""
 		}
 		n, _, err := conn.ReadFrom(reply)
 		if err != nil {
 			// Deadline exceeded or read error → no matching reply → Dead.
-			return ProbeDead, UnsupportedNone
+			return ProbeDead, UnsupportedNone, ""
 		}
 		parsed, perr := icmp.ParseMessage(proto, reply[:n])
 		if perr != nil || parsed.Type != replyType {
@@ -199,7 +204,7 @@ func (icmpProber) Probe(source, dst string, seq int, nonce []byte, deadline time
 		// §5a authoritative match: Seq AND Data-nonce. ID is ignored
 		// (kernel-substituted on datagram sockets).
 		if echo.Seq == seq && bytesEqual(echo.Data, nonce) {
-			return ProbeAlive, UnsupportedNone
+			return ProbeAlive, UnsupportedNone, ""
 		}
 		// A stale/foreign reply (different probe) — keep reading until the
 		// deadline.

--- a/pkg/routing/tunnel_keepalive.go
+++ b/pkg/routing/tunnel_keepalive.go
@@ -163,11 +163,16 @@ func (icmpProber) Probe(source, dst string, seq int, nonce []byte, deadline time
 		return ProbeUnsupported, classifyListenErr(err)
 	}
 	if _, err := conn.WriteTo(b, &net.UDPAddr{IP: ip}); err != nil {
-		// A write error after a successful socket open is most plausibly a
-		// path/route problem (ENETUNREACH/EHOSTUNREACH/no route): that IS a
-		// liveness signal, so report Dead rather than Unsupported. Resource
-		// errnos on write are rare; bucketing them Dead at worst costs one
-		// retry, never a silent forever-hold.
+		// Classify a write error (Codex PR #1947 r1 HIGH). A path/route
+		// problem (ENETUNREACH/EHOSTUNREACH/ENETDOWN — no route to the
+		// underlay peer) IS a real liveness signal → Dead. A LOCAL RESOURCE
+		// fault (ENOBUFS/ENOMEM/EAGAIN — transmit buffer pressure) is NOT
+		// peer death; bucketing it Dead would let a local resource storm
+		// self-inflict a tunnel down. Route it through hold-on-unknown
+		// (transient) instead, mirroring the ListenPacket classifier.
+		if kind := classifyWriteErr(err); kind != UnsupportedNone {
+			return ProbeUnsupported, kind
+		}
 		return ProbeDead, UnsupportedNone
 	}
 
@@ -241,6 +246,32 @@ func classifyListenErr(err error) UnsupportedKind {
 	default:
 		// Total default — UNRECOGNIZED → TRANSIENT (escalate).
 		return UnsupportedTransient
+	}
+}
+
+// classifyWriteErr buckets a WriteTo error. A LOCAL RESOURCE fault
+// (transmit-buffer pressure) returns UnsupportedTransient so the loop
+// holds-on-unknown rather than self-inflicting a down. Anything else
+// (path/route unreachable — ENETUNREACH/EHOSTUNREACH/ENETDOWN — or an
+// unclassifiable error) returns UnsupportedNone, telling the caller to
+// treat it as a real Dead liveness signal. NOTE the asymmetry with
+// classifyListenErr's "unrecognized → transient" default: a ListenPacket
+// failure means we could not probe at all (hold), but a WriteTo failure
+// to a specific destination is most plausibly that destination being
+// unreachable (Dead), so an unrecognized write error counts toward the
+// real-death path.
+func classifyWriteErr(err error) UnsupportedKind {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return UnsupportedNone // not an errno → treat as Dead
+	}
+	switch errno {
+	case syscall.ENOBUFS, syscall.ENOMEM, syscall.EAGAIN, syscall.EINTR, syscall.EMFILE, syscall.ENFILE:
+		return UnsupportedTransient
+	default:
+		// ENETUNREACH, EHOSTUNREACH, ENETDOWN, EADDRNOTAVAIL, etc. — a real
+		// path/liveness signal.
+		return UnsupportedNone
 	}
 }
 

--- a/pkg/routing/tunnel_keepalive.go
+++ b/pkg/routing/tunnel_keepalive.go
@@ -1,0 +1,258 @@
+package routing
+
+import (
+	"crypto/rand"
+	"errors"
+	"net"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+)
+
+// ProbeResult is the typed outcome of a single tunnel keepalive probe
+// (#1918, Axis B1). It carries the "could not probe" signal the old
+// bool return destroyed: a route-existence check is NOT a liveness
+// check, and the loop must distinguish "confirmed dead" from "unable to
+// probe" so it can hold-on-unknown instead of defaulting to up.
+type ProbeResult int
+
+const (
+	// ProbeAlive: an ICMP echo reply matching THIS probe (Seq + nonce)
+	// was received within the deadline.
+	ProbeAlive ProbeResult = iota
+	// ProbeDead: the echo was sent but no matching reply arrived before
+	// the deadline. This is a real liveness signal and counts toward
+	// MaxRetries.
+	ProbeDead
+	// ProbeUnsupported: the probe could not be performed at all (socket
+	// could not be opened/bound, marshal failure, etc.). The loop applies
+	// hold-on-unknown (§6 Axis C, C1) — it never tears the link down
+	// purely because the daemon cannot probe.
+	ProbeUnsupported
+)
+
+// UnsupportedKind sub-classifies a ProbeUnsupported result (#1918 Axis
+// C). Structural = a configuration/capability problem (missing
+// ping_group_range, bound source not local) that holds indefinitely
+// with a one-shot warning. Transient = a local resource problem
+// (FD/memory exhaustion) that holds but escalates to a loud status +
+// slog.Error after a sustained window so a real peer death is never
+// silently masked by a local resource storm.
+type UnsupportedKind int
+
+const (
+	// UnsupportedNone is the zero value used when the result is not
+	// ProbeUnsupported.
+	UnsupportedNone UnsupportedKind = iota
+	// UnsupportedStructural: config/capability error — hold indefinitely,
+	// one-shot Warn.
+	UnsupportedStructural
+	// UnsupportedTransient: local resource error — hold but escalate after
+	// a sustained-unknown window.
+	UnsupportedTransient
+)
+
+// tunnelProber performs one ICMP echo round-trip to a tunnel's underlay
+// peer. The production implementation is icmpProber; tests inject a
+// deterministic fake on tunnelManager.prober.
+//
+// source is the tunnel's local endpoint IP (TunnelConfig.Source) bound
+// as the ICMP listen address (§5c) so the echo egresses from the tunnel
+// endpoint; "" → wildcard bind. dst is the underlay Destination, routed
+// in the GLOBAL/underlay FIB exactly like the tunnel's encapsulated
+// traffic (§5b — NO overlay-VRF bind). seq + nonce uniquely key the
+// reply to THIS probe (§5a — NOT the ICMP ID, which datagram sockets
+// rewrite to the socket source port).
+type tunnelProber interface {
+	Probe(source, dst string, seq int, nonce []byte, deadline time.Duration) (ProbeResult, UnsupportedKind)
+}
+
+// icmpProber is the production tunnelProber. It uses unprivileged
+// datagram ICMP ("udp4"/"udp6" via x/net/icmp), the same mechanism as
+// the tested pkg/cluster/monitor.go precedent, with the precedent's two
+// gaps fixed: reply matching on Seq + Data-nonce (§5a) and binding to
+// the tunnel source IP (§5c). No SO_BINDTODEVICE — the probe routes in
+// the global/underlay table (§5b).
+type icmpProber struct{}
+
+// probeConn is the narrow ICMP socket surface icmpProber needs, so tests
+// can substitute a fake without real network I/O. Mirrors
+// pkg/cluster/monitor.go's icmpConn.
+type probeConn interface {
+	WriteTo(b []byte, dst net.Addr) (int, error)
+	ReadFrom(b []byte) (int, net.Addr, error)
+	SetReadDeadline(t time.Time) error
+	Close() error
+}
+
+// listenICMP opens a datagram ICMP socket bound to source (or wildcard
+// when source==""). Indirection point for tests of the production
+// prober.
+var listenICMP = func(network, source string) (probeConn, error) {
+	c, err := icmp.ListenPacket(network, source)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Probe sends one ICMP echo to dst and reports the typed result.
+func (icmpProber) Probe(source, dst string, seq int, nonce []byte, deadline time.Duration) (ProbeResult, UnsupportedKind) {
+	ip := net.ParseIP(dst)
+	if ip == nil {
+		// A non-parseable destination is a configuration error, not a
+		// transient resource problem: hold-on-unknown structural.
+		return ProbeUnsupported, UnsupportedStructural
+	}
+
+	isIPv6 := ip.To4() == nil
+	var (
+		network   string
+		echoType  icmp.Type
+		replyType icmp.Type
+		proto     int
+		listen    string
+	)
+	if isIPv6 {
+		network, echoType, replyType, proto = "udp6", ipv6.ICMPTypeEchoRequest, ipv6.ICMPTypeEchoReply, 58
+		listen = "::"
+	} else {
+		network, echoType, replyType, proto = "udp4", ipv4.ICMPTypeEcho, ipv4.ICMPTypeEchoReply, 1
+		listen = "0.0.0.0"
+	}
+	// §5c: bind to the tunnel source IP so the echo egresses from the
+	// tunnel endpoint and the reply routes back to it. Empty source →
+	// wildcard (auto-selected tunnels). A family-mismatched source (e.g.
+	// a v4 Source against a v6 dst) would EAFNOSUPPORT/EADDRNOTAVAIL on
+	// ListenPacket → classified structural below; that is correct (a
+	// misconfigured source pair cannot probe).
+	if source != "" {
+		listen = source
+	}
+
+	conn, err := listenICMP(network, listen)
+	if err != nil {
+		return ProbeUnsupported, classifyListenErr(err)
+	}
+	defer conn.Close()
+
+	msg := icmp.Message{
+		Type: echoType,
+		Code: 0,
+		Body: &icmp.Echo{
+			// ID is advisory only: datagram sockets overwrite it with the
+			// socket source port (§5a). The authoritative match is Seq +
+			// Data-nonce.
+			ID:   0,
+			Seq:  seq,
+			Data: nonce,
+		},
+	}
+	b, err := msg.Marshal(nil)
+	if err != nil {
+		// Marshal of a fixed-shape echo should never fail; treat a failure
+		// as a structural (non-flapping) unknown.
+		return ProbeUnsupported, UnsupportedStructural
+	}
+
+	abs := time.Now().Add(deadline)
+	if err := conn.SetReadDeadline(abs); err != nil {
+		return ProbeUnsupported, classifyListenErr(err)
+	}
+	if _, err := conn.WriteTo(b, &net.UDPAddr{IP: ip}); err != nil {
+		// A write error after a successful socket open is most plausibly a
+		// path/route problem (ENETUNREACH/EHOSTUNREACH/no route): that IS a
+		// liveness signal, so report Dead rather than Unsupported. Resource
+		// errnos on write are rare; bucketing them Dead at worst costs one
+		// retry, never a silent forever-hold.
+		return ProbeDead, UnsupportedNone
+	}
+
+	reply := make([]byte, 1500)
+	for {
+		// R4: re-check the absolute deadline each iteration so a datagram
+		// flood cannot extend a probe past its budget.
+		if remaining := time.Until(abs); remaining <= 0 {
+			return ProbeDead, UnsupportedNone
+		}
+		n, _, err := conn.ReadFrom(reply)
+		if err != nil {
+			// Deadline exceeded or read error → no matching reply → Dead.
+			return ProbeDead, UnsupportedNone
+		}
+		parsed, perr := icmp.ParseMessage(proto, reply[:n])
+		if perr != nil || parsed.Type != replyType {
+			continue // not an echo reply we recognize; keep reading
+		}
+		echo, ok := parsed.Body.(*icmp.Echo)
+		if !ok {
+			continue
+		}
+		// §5a authoritative match: Seq AND Data-nonce. ID is ignored
+		// (kernel-substituted on datagram sockets).
+		if echo.Seq == seq && bytesEqual(echo.Data, nonce) {
+			return ProbeAlive, UnsupportedNone
+		}
+		// A stale/foreign reply (different probe) — keep reading until the
+		// deadline.
+	}
+}
+
+// bytesEqual is a small constant-shape comparison (the nonce is ~8
+// bytes); avoids importing bytes for one call.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// classifyListenErr buckets a ListenPacket/socket errno into structural
+// (config/capability — hold indefinitely, one-shot Warn) vs transient
+// (local resource — hold but escalate after the sustained-unknown
+// window). The default for any UNRECOGNIZED errno is TRANSIENT (§6 Axis
+// C, Codex r2 NF4): a resource storm must never be silently mis-bucketed
+// as a held structural.
+func classifyListenErr(err error) UnsupportedKind {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		// Non-errno error (e.g. a parse/address-format error from the
+		// library before the syscall) → treat as a config problem.
+		return UnsupportedStructural
+	}
+	switch errno {
+	case syscall.EPERM, syscall.EACCES,
+		syscall.EAFNOSUPPORT, syscall.EPROTONOSUPPORT,
+		syscall.EPROTOTYPE, syscall.EADDRNOTAVAIL:
+		// Capability / configuration: no ping_group_range or cap, wrong
+		// family, or the bound tc.Source is not a local address.
+		return UnsupportedStructural
+	case syscall.EMFILE, syscall.ENFILE,
+		syscall.ENOBUFS, syscall.ENOMEM, syscall.EINTR:
+		return UnsupportedTransient
+	default:
+		// Total default — UNRECOGNIZED → TRANSIENT (escalate).
+		return UnsupportedTransient
+	}
+}
+
+// makeNonce returns a fresh per-probe random nonce (§5a). 8 bytes is
+// small enough that responders echo it faithfully (R3) yet wide enough
+// to make a cross-probe collision negligible.
+func makeNonce() []byte {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failure is effectively impossible on Linux; fall back
+		// to a fixed marker so the probe still has a stable Data field.
+		copy(b, []byte("xpf-ka00"))
+	}
+	return b
+}

--- a/pkg/routing/tunnel_keepalive_test.go
+++ b/pkg/routing/tunnel_keepalive_test.go
@@ -1,0 +1,417 @@
+package routing
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// fakeProber is a deterministic tunnelProber for keepalive tests. It
+// returns a scripted sequence of results, recording the bind source it
+// was asked to probe from (§5c assertions).
+type fakeProber struct {
+	mu      sync.Mutex
+	results []probeOutcome
+	idx     int
+	// lastSource records the most recent source bind argument.
+	lastSource string
+	sources    []string
+	calls      int
+}
+
+type probeOutcome struct {
+	result ProbeResult
+	kind   UnsupportedKind
+}
+
+func (p *fakeProber) Probe(source, dst string, seq int, nonce []byte, deadline time.Duration) (ProbeResult, UnsupportedKind) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	p.lastSource = source
+	p.sources = append(p.sources, source)
+	if len(p.results) == 0 {
+		return ProbeAlive, UnsupportedNone
+	}
+	o := p.results[p.idx%len(p.results)]
+	p.idx++
+	return o.result, o.kind
+}
+
+// kaOps is a controllable linkOps for keepalive tick tests: it counts
+// LinkSetUp/LinkSetDown, can inject errors on them, can block inside one
+// of them (for lock-scope / drain tests), and can fail LinkByName.
+type kaOps struct {
+	mu sync.Mutex
+
+	setUps   int
+	setDowns int
+
+	setUpErr   error
+	setDownErr error
+
+	byNameErr error
+
+	// blockDown, when non-nil, makes LinkSetDown block until released is
+	// closed; entered is closed once LinkSetDown is inside the block.
+	blockDown chan struct{}
+	entered   chan struct{}
+}
+
+func newKaOps() *kaOps { return &kaOps{} }
+
+func (o *kaOps) LinkByName(name string) (netlink.Link, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.byNameErr != nil {
+		return nil, o.byNameErr
+	}
+	return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name, Index: 1}}, nil
+}
+
+func (o *kaOps) LinkAdd(netlink.Link) error                     { return nil }
+func (o *kaOps) LinkDel(netlink.Link) error                     { return nil }
+func (o *kaOps) LinkSetMaster(netlink.Link, netlink.Link) error { return nil }
+func (o *kaOps) LinkSetNoMaster(netlink.Link) error             { return nil }
+func (o *kaOps) LinkSetMTU(netlink.Link, int) error             { return nil }
+func (o *kaOps) LinkList() ([]netlink.Link, error)              { return nil, nil }
+func (o *kaOps) AddrAdd(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *kaOps) AddrDel(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *kaOps) AddrList(netlink.Link, int) ([]netlink.Addr, error) {
+	return nil, nil
+}
+
+func (o *kaOps) LinkSetUp(netlink.Link) error {
+	o.mu.Lock()
+	o.setUps++
+	err := o.setUpErr
+	o.mu.Unlock()
+	return err
+}
+
+func (o *kaOps) LinkSetDown(netlink.Link) error {
+	o.mu.Lock()
+	o.setDowns++
+	block := o.blockDown
+	entered := o.entered
+	err := o.setDownErr
+	o.mu.Unlock()
+	if block != nil {
+		if entered != nil {
+			close(entered)
+		}
+		<-block
+	}
+	return err
+}
+
+func (o *kaOps) ups() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.setUps
+}
+
+func (o *kaOps) downs() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.setDowns
+}
+
+// newKAState builds a KeepaliveState and a fresh gen token for tick
+// tests.
+func newKAState(up bool, maxRetries, interval int) (*KeepaliveState, *atomic.Uint64) {
+	return &KeepaliveState{
+		Up:         up,
+		RemoteAddr: "203.0.113.1",
+		SourceAddr: "198.51.100.1",
+		Interval:   interval,
+		MaxRetries: maxRetries,
+	}, &atomic.Uint64{}
+}
+
+func tickN(t *tunnelManager, name string, state *KeepaliveState, prober tunnelProber, gen *atomic.Uint64, startGen uint64, n int) {
+	for i := 0; i < n; i++ {
+		t.keepaliveTick(name, state, prober, gen, startGen)
+	}
+}
+
+// --- §9 Alive: stays up, zero LinkSet* ---
+func TestKeepaliveAliveStaysUp(t *testing.T) {
+	ops := newKaOps()
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 3, 1)
+	prober := &fakeProber{results: []probeOutcome{{ProbeAlive, UnsupportedNone}}}
+
+	tickN(tm, "gr0", state, prober, gen, 0, 5)
+
+	if ops.ups() != 0 || ops.downs() != 0 {
+		t.Fatalf("alive ticks must issue no LinkSet*: ups=%d downs=%d", ops.ups(), ops.downs())
+	}
+	if !state.Up {
+		t.Fatal("state should remain up")
+	}
+	if state.Failures != 0 {
+		t.Fatalf("failures should be 0, got %d", state.Failures)
+	}
+}
+
+// --- §9 Dead × MaxRetries: exactly one LinkSetDown, Up=false ---
+func TestKeepaliveDeadGoesDownOnce(t *testing.T) {
+	ops := newKaOps()
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 3, 1)
+	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+
+	// First two dead ticks: increment failures, no transition.
+	tickN(tm, "gr0", state, prober, gen, 0, 2)
+	if ops.downs() != 0 {
+		t.Fatalf("no down before MaxRetries: downs=%d", ops.downs())
+	}
+	if !state.Up {
+		t.Fatal("still up before MaxRetries")
+	}
+	// Third dead tick crosses the threshold.
+	tm.keepaliveTick("gr0", state, prober, gen, 0)
+	if ops.downs() != 1 {
+		t.Fatalf("expected exactly one LinkSetDown, got %d", ops.downs())
+	}
+	if state.Up {
+		t.Fatal("expected Up=false after MaxRetries dead")
+	}
+	if state.Failures != 3 {
+		t.Fatalf("expected Failures=3, got %d", state.Failures)
+	}
+	// Further dead ticks: no additional LinkSetDown (already down).
+	tickN(tm, "gr0", state, prober, gen, 0, 3)
+	if ops.downs() != 1 {
+		t.Fatalf("expected still exactly one LinkSetDown, got %d", ops.downs())
+	}
+}
+
+// --- §9 Dead then Alive: exactly one LinkSetUp on recovery ---
+func TestKeepaliveRecoversUpOnce(t *testing.T) {
+	ops := newKaOps()
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 3, 1)
+	dead := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+	tickN(tm, "gr0", state, dead, gen, 0, 3) // down
+	if state.Up || ops.downs() != 1 {
+		t.Fatalf("precondition: want down once; up=%v downs=%d", state.Up, ops.downs())
+	}
+
+	alive := &fakeProber{results: []probeOutcome{{ProbeAlive, UnsupportedNone}}}
+	tm.keepaliveTick("gr0", state, alive, gen, 0)
+	if ops.ups() != 1 {
+		t.Fatalf("expected exactly one LinkSetUp on recovery, got %d", ops.ups())
+	}
+	if !state.Up || state.Failures != 0 {
+		t.Fatalf("expected up + failures reset; up=%v failures=%d", state.Up, state.Failures)
+	}
+	// Further alive ticks: no extra up.
+	tickN(tm, "gr0", state, alive, gen, 0, 3)
+	if ops.ups() != 1 {
+		t.Fatalf("expected still one LinkSetUp, got %d", ops.ups())
+	}
+}
+
+// --- §9 Unsupported(structural): never LinkSet*, KeepaliveUp nil, info "unknown" ---
+func TestKeepaliveStructuralUnsupportedHolds(t *testing.T) {
+	ops := newKaOps()
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 3, 1)
+	prober := &fakeProber{results: []probeOutcome{{ProbeUnsupported, UnsupportedStructural}}}
+
+	tickN(tm, "gr0", state, prober, gen, 0, 5)
+	if ops.ups() != 0 || ops.downs() != 0 {
+		t.Fatalf("structural unsupported must not LinkSet*: ups=%d downs=%d", ops.ups(), ops.downs())
+	}
+	if state.Failures != 0 {
+		t.Fatalf("structural unsupported must not increment Failures, got %d", state.Failures)
+	}
+	if !state.Unknown {
+		t.Fatal("expected Unknown=true")
+	}
+	if state.Up != true {
+		t.Fatal("prior Up should be held (true)")
+	}
+}
+
+// --- §9 Unsupported(transient) sustained: escalated status, still no down ---
+func TestKeepaliveTransientUnsupportedEscalates(t *testing.T) {
+	ops := newKaOps()
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 3, 1)
+	prober := &fakeProber{results: []probeOutcome{{ProbeUnsupported, UnsupportedTransient}}}
+
+	tickN(tm, "gr0", state, prober, gen, 0, 4)
+	if ops.downs() != 0 {
+		t.Fatalf("transient unsupported must never LinkSetDown, got %d", ops.downs())
+	}
+	if state.UnknownKind != UnsupportedTransient {
+		t.Fatalf("expected transient kind, got %v", state.UnknownKind)
+	}
+	if state.unknownStreak < state.MaxRetries {
+		t.Fatalf("expected streak >= MaxRetries, got %d", state.unknownStreak)
+	}
+}
+
+// --- §9 LinkByName error on transition: Up not latched, retried ---
+func TestKeepaliveLinkByNameErrorNoLatch(t *testing.T) {
+	ops := newKaOps()
+	ops.byNameErr = errors.New("transient netlink error")
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 3, 1)
+	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+
+	tickN(tm, "gr0", state, prober, gen, 0, 5)
+	// LinkByName keeps failing → no down committed, Up stays true.
+	if state.Up != true {
+		t.Fatal("Up must not latch false on LinkByName error")
+	}
+	if ops.downs() != 0 {
+		t.Fatalf("no LinkSetDown should be issued, got %d", ops.downs())
+	}
+	// Failures still climb (committed in step 1).
+	if state.Failures < state.MaxRetries {
+		t.Fatalf("failures should climb, got %d", state.Failures)
+	}
+	// Now lookup recovers → exactly one down on the next tick.
+	ops.mu.Lock()
+	ops.byNameErr = nil
+	ops.mu.Unlock()
+	tm.keepaliveTick("gr0", state, prober, gen, 0)
+	if ops.downs() != 1 {
+		t.Fatalf("expected exactly one LinkSetDown after lookup recovers, got %d", ops.downs())
+	}
+	if state.Up {
+		t.Fatal("expected Up=false after the transition lands")
+	}
+}
+
+// --- §9 LinkSet* error retry (Codex r3 blocker) ---
+func TestKeepaliveLinkSetDownErrorRetries(t *testing.T) {
+	ops := newKaOps()
+	ops.setDownErr = errors.New("netlink busy")
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 3, 1)
+	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+
+	tickN(tm, "gr0", state, prober, gen, 0, 4)
+	// Down keeps erroring → Up must NOT be committed false.
+	if state.Up != true {
+		t.Fatal("Up must stay true while LinkSetDown errors (commit-after-success)")
+	}
+	if ops.downs() < 2 {
+		t.Fatalf("expected repeated LinkSetDown attempts, got %d", ops.downs())
+	}
+	// Now LinkSetDown succeeds → exactly one effective down.
+	ops.mu.Lock()
+	ops.setDownErr = nil
+	beforeDowns := ops.setDowns
+	ops.mu.Unlock()
+	tm.keepaliveTick("gr0", state, prober, gen, 0)
+	if state.Up {
+		t.Fatal("expected Up=false after LinkSetDown succeeds")
+	}
+	if ops.downs() != beforeDowns+1 {
+		t.Fatalf("expected one more LinkSetDown on the successful tick, got %d -> %d", beforeDowns, ops.downs())
+	}
+}
+
+// --- §9 NF3 generation guard: bump gen → action dropped ---
+func TestKeepaliveGenerationGuardDropsAction(t *testing.T) {
+	ops := newKaOps()
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 1, 1) // MaxRetries=1 → dead immediately transitions
+	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+
+	startGen := gen.Load()
+	// Bump the generation (simulating Apply recreate) before the tick.
+	gen.Add(1)
+	tm.keepaliveTick("gr0", state, prober, gen, startGen)
+	if ops.downs() != 0 {
+		t.Fatalf("stale-generation runner must drop LinkSetDown, got %d", ops.downs())
+	}
+	// Up not committed false (the action was dropped after intent).
+	if state.Up != true {
+		t.Fatal("Up must not be committed when the action is dropped")
+	}
+}
+
+// --- §9 lock-scope regression: GetStatus must not block behind a parked LinkSetDown ---
+func TestKeepaliveStatusNotBlockedByNetlink(t *testing.T) {
+	ops := newKaOps()
+	ops.blockDown = make(chan struct{})
+	ops.entered = make(chan struct{})
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 1, 1)
+	// Register the runner in the manager so GetKeepaliveState finds it.
+	tm.ensureReconcileStateLocked()
+	tm.keepalives["gr0"] = &keepaliveRunner{state: state, remote: state.RemoteAddr}
+	tm.tunnels = []string{"gr0"}
+
+	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+
+	// Run a tick in a goroutine; it will park inside LinkSetDown.
+	go tm.keepaliveTick("gr0", state, prober, gen, 0)
+	select {
+	case <-ops.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("LinkSetDown never entered")
+	}
+
+	// While LinkSetDown is parked, GetStatus must return promptly — it
+	// must NOT hold state.mu across the netlink op (Axis D).
+	doneCh := make(chan struct{})
+	go func() {
+		_, _ = tm.GetStatus()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		close(ops.blockDown)
+		t.Fatal("GetStatus blocked behind parked LinkSetDown — Axis D lock-scope violated")
+	}
+	close(ops.blockDown)
+}
+
+// --- §9 source bind (§5c): prober receives tc.Source; matches() on source change ---
+func TestKeepaliveSourceBindAndMatches(t *testing.T) {
+	ops := newKaOps()
+	tm := &tunnelManager{ops: ops}
+	state, gen := newKAState(true, 3, 1)
+	prober := &fakeProber{results: []probeOutcome{{ProbeAlive, UnsupportedNone}}}
+	tm.keepaliveTick("gr0", state, prober, gen, 0)
+	if prober.lastSource != state.SourceAddr {
+		t.Fatalf("prober bind source = %q, want %q", prober.lastSource, state.SourceAddr)
+	}
+
+	// matches(): a source-only change must restart the runner.
+	r := &keepaliveRunner{
+		remote:     "203.0.113.1",
+		source:     "198.51.100.1",
+		interval:   5,
+		maxRetries: 3,
+	}
+	same := &config.TunnelConfig{Destination: "203.0.113.1", Source: "198.51.100.1", Keepalive: 5, KeepaliveRetry: 3}
+	if !r.matches(same) {
+		t.Fatal("matches must be true when identity unchanged")
+	}
+	srcChanged := &config.TunnelConfig{Destination: "203.0.113.1", Source: "192.0.2.9", Keepalive: 5, KeepaliveRetry: 3}
+	if r.matches(srcChanged) {
+		t.Fatal("matches must be false when only the source changed (§5c)")
+	}
+}
+
+// --- prober errno classification ---
+func TestClassifyListenErr(t *testing.T) {
+	if got := classifyListenErr(errors.New("plain")); got != UnsupportedStructural {
+		t.Fatalf("non-errno → structural, got %v", got)
+	}
+}

--- a/pkg/routing/tunnel_keepalive_test.go
+++ b/pkg/routing/tunnel_keepalive_test.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -27,20 +28,21 @@ type fakeProber struct {
 type probeOutcome struct {
 	result ProbeResult
 	kind   UnsupportedKind
+	reason string
 }
 
-func (p *fakeProber) Probe(source, dst string, seq int, nonce []byte, deadline time.Duration) (ProbeResult, UnsupportedKind) {
+func (p *fakeProber) Probe(source, dst string, seq int, nonce []byte, deadline time.Duration) (ProbeResult, UnsupportedKind, string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.calls++
 	p.lastSource = source
 	p.sources = append(p.sources, source)
 	if len(p.results) == 0 {
-		return ProbeAlive, UnsupportedNone
+		return ProbeAlive, UnsupportedNone, ""
 	}
 	o := p.results[p.idx%len(p.results)]
 	p.idx++
-	return o.result, o.kind
+	return o.result, o.kind, o.reason
 }
 
 // kaOps is a controllable linkOps for keepalive tick tests: it counts
@@ -145,7 +147,7 @@ func TestKeepaliveAliveStaysUp(t *testing.T) {
 	ops := newKaOps()
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 3, 1)
-	prober := &fakeProber{results: []probeOutcome{{ProbeAlive, UnsupportedNone}}}
+	prober := &fakeProber{results: []probeOutcome{{result: ProbeAlive, kind: UnsupportedNone}}}
 
 	tickN(tm, "gr0", state, prober, gen, 0, 5)
 
@@ -165,7 +167,7 @@ func TestKeepaliveDeadGoesDownOnce(t *testing.T) {
 	ops := newKaOps()
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 3, 1)
-	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+	prober := &fakeProber{results: []probeOutcome{{result: ProbeDead, kind: UnsupportedNone}}}
 
 	// First two dead ticks: increment failures, no transition.
 	tickN(tm, "gr0", state, prober, gen, 0, 2)
@@ -198,13 +200,13 @@ func TestKeepaliveRecoversUpOnce(t *testing.T) {
 	ops := newKaOps()
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 3, 1)
-	dead := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+	dead := &fakeProber{results: []probeOutcome{{result: ProbeDead, kind: UnsupportedNone}}}
 	tickN(tm, "gr0", state, dead, gen, 0, 3) // down
 	if state.Up || ops.downs() != 1 {
 		t.Fatalf("precondition: want down once; up=%v downs=%d", state.Up, ops.downs())
 	}
 
-	alive := &fakeProber{results: []probeOutcome{{ProbeAlive, UnsupportedNone}}}
+	alive := &fakeProber{results: []probeOutcome{{result: ProbeAlive, kind: UnsupportedNone}}}
 	tm.keepaliveTick("gr0", state, alive, gen, 0)
 	if ops.ups() != 1 {
 		t.Fatalf("expected exactly one LinkSetUp on recovery, got %d", ops.ups())
@@ -224,7 +226,7 @@ func TestKeepaliveStructuralUnsupportedHolds(t *testing.T) {
 	ops := newKaOps()
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 3, 1)
-	prober := &fakeProber{results: []probeOutcome{{ProbeUnsupported, UnsupportedStructural}}}
+	prober := &fakeProber{results: []probeOutcome{{result: ProbeUnsupported, kind: UnsupportedStructural}}}
 
 	tickN(tm, "gr0", state, prober, gen, 0, 5)
 	if ops.ups() != 0 || ops.downs() != 0 {
@@ -246,7 +248,7 @@ func TestKeepaliveTransientUnsupportedEscalates(t *testing.T) {
 	ops := newKaOps()
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 3, 1)
-	prober := &fakeProber{results: []probeOutcome{{ProbeUnsupported, UnsupportedTransient}}}
+	prober := &fakeProber{results: []probeOutcome{{result: ProbeUnsupported, kind: UnsupportedTransient}}}
 
 	tickN(tm, "gr0", state, prober, gen, 0, 4)
 	if ops.downs() != 0 {
@@ -266,7 +268,7 @@ func TestKeepaliveLinkByNameErrorNoLatch(t *testing.T) {
 	ops.byNameErr = errors.New("transient netlink error")
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 3, 1)
-	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+	prober := &fakeProber{results: []probeOutcome{{result: ProbeDead, kind: UnsupportedNone}}}
 
 	tickN(tm, "gr0", state, prober, gen, 0, 5)
 	// LinkByName keeps failing → no down committed, Up stays true.
@@ -299,7 +301,7 @@ func TestKeepaliveLinkSetDownErrorRetries(t *testing.T) {
 	ops.setDownErr = errors.New("netlink busy")
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 3, 1)
-	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+	prober := &fakeProber{results: []probeOutcome{{result: ProbeDead, kind: UnsupportedNone}}}
 
 	tickN(tm, "gr0", state, prober, gen, 0, 4)
 	// Down keeps erroring → Up must NOT be committed false.
@@ -328,7 +330,7 @@ func TestKeepaliveGenerationGuardDropsAction(t *testing.T) {
 	ops := newKaOps()
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 1, 1) // MaxRetries=1 → dead immediately transitions
-	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+	prober := &fakeProber{results: []probeOutcome{{result: ProbeDead, kind: UnsupportedNone}}}
 
 	startGen := gen.Load()
 	// Bump the generation (simulating Apply recreate) before the tick.
@@ -355,7 +357,7 @@ func TestKeepaliveStatusNotBlockedByNetlink(t *testing.T) {
 	tm.keepalives["gr0"] = &keepaliveRunner{state: state, remote: state.RemoteAddr}
 	tm.tunnels = []string{"gr0"}
 
-	prober := &fakeProber{results: []probeOutcome{{ProbeDead, UnsupportedNone}}}
+	prober := &fakeProber{results: []probeOutcome{{result: ProbeDead, kind: UnsupportedNone}}}
 
 	// Run a tick in a goroutine; it will park inside LinkSetDown.
 	go tm.keepaliveTick("gr0", state, prober, gen, 0)
@@ -386,7 +388,7 @@ func TestKeepaliveSourceBindAndMatches(t *testing.T) {
 	ops := newKaOps()
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 3, 1)
-	prober := &fakeProber{results: []probeOutcome{{ProbeAlive, UnsupportedNone}}}
+	prober := &fakeProber{results: []probeOutcome{{result: ProbeAlive, kind: UnsupportedNone}}}
 	tm.keepaliveTick("gr0", state, prober, gen, 0)
 	if prober.lastSource != state.SourceAddr {
 		t.Fatalf("prober bind source = %q, want %q", prober.lastSource, state.SourceAddr)
@@ -445,6 +447,59 @@ func TestApplyTransientLookupKeepsRunner(t *testing.T) {
 	}
 	if gen.Load() != startGen {
 		t.Fatalf("transient lookup error must NOT bump the generation: %d -> %d", startGen, gen.Load())
+	}
+}
+
+// --- Copilot PR #1947: the prober reason (real syscall/config detail)
+// must propagate to KeepaliveInfo, not a generic label. ---
+func TestKeepaliveUnknownReasonSurfacedInStatus(t *testing.T) {
+	ops := newKaOps()
+	tm := &tunnelManager{ops: ops}
+	tm.ensureReconcileStateLocked()
+	state, gen := newKAState(true, 3, 1)
+	tm.keepalives["gr0"] = &keepaliveRunner{state: state, remote: state.RemoteAddr}
+	tm.tunnels = []string{"gr0"}
+
+	// A transient unsupported with a concrete reason.
+	prober := &fakeProber{results: []probeOutcome{{
+		result: ProbeUnsupported, kind: UnsupportedTransient,
+		reason: "listen udp4 198.51.100.1: too many open files",
+	}}}
+	tickN(tm, "gr0", state, prober, gen, 0, 4)
+
+	statuses, err := tm.GetStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var info string
+	var kaUp *bool
+	for _, s := range statuses {
+		if s.Name == "gr0" {
+			info = s.KeepaliveInfo
+			kaUp = s.KeepaliveUp
+		}
+	}
+	if kaUp != nil {
+		t.Fatalf("KeepaliveUp must be nil on unknown, got %v", *kaUp)
+	}
+	if !strings.Contains(info, "too many open files") {
+		t.Fatalf("status must carry the real probe reason, got %q", info)
+	}
+
+	// A structural unsupported with a reason → reason shown too.
+	state2, gen2 := newKAState(true, 3, 1)
+	tm.keepalives["gr1"] = &keepaliveRunner{state: state2, remote: state2.RemoteAddr}
+	tm.tunnels = append(tm.tunnels, "gr1")
+	prober2 := &fakeProber{results: []probeOutcome{{
+		result: ProbeUnsupported, kind: UnsupportedStructural,
+		reason: "listen udp4 198.51.100.99: cannot assign requested address",
+	}}}
+	tm.keepaliveTick("gr1", state2, prober2, gen2, 0)
+	statuses, _ = tm.GetStatus()
+	for _, s := range statuses {
+		if s.Name == "gr1" && !strings.Contains(s.KeepaliveInfo, "cannot assign requested address") {
+			t.Fatalf("structural status must carry the reason, got %q", s.KeepaliveInfo)
+		}
 	}
 }
 

--- a/pkg/routing/tunnel_keepalive_test.go
+++ b/pkg/routing/tunnel_keepalive_test.go
@@ -58,6 +58,7 @@ type kaOps struct {
 	setDownErr error
 
 	byNameErr error
+	delErr    error
 
 	// blockDown, when non-nil, makes LinkSetDown block until released is
 	// closed; entered is closed once LinkSetDown is inside the block.
@@ -76,8 +77,12 @@ func (o *kaOps) LinkByName(name string) (netlink.Link, error) {
 	return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name, Index: 1}}, nil
 }
 
-func (o *kaOps) LinkAdd(netlink.Link) error                     { return nil }
-func (o *kaOps) LinkDel(netlink.Link) error                     { return nil }
+func (o *kaOps) LinkAdd(netlink.Link) error { return nil }
+func (o *kaOps) LinkDel(netlink.Link) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.delErr
+}
 func (o *kaOps) LinkSetMaster(netlink.Link, netlink.Link) error { return nil }
 func (o *kaOps) LinkSetNoMaster(netlink.Link) error             { return nil }
 func (o *kaOps) LinkSetMTU(netlink.Link, int) error             { return nil }
@@ -501,6 +506,46 @@ func TestKeepaliveUnknownReasonSurfacedInStatus(t *testing.T) {
 			t.Fatalf("structural status must carry the reason, got %q", s.KeepaliveInfo)
 		}
 	}
+}
+
+// --- Copilot PR #1947 r3: a present-but-changed link whose LinkDel
+// fails transiently must NOT silently leave the tunnel with no keepalive
+// — the runner is restarted against the surviving link. ---
+func TestApplyRecreateDelFailRestartsKeepalive(t *testing.T) {
+	ops := newKaOps()
+	ops.delErr = errors.New("transient LinkDel failure") // recreate aborts
+	tm := &tunnelManager{ops: ops, vrfBinder: noopVRFBinder{}}
+	tm.ensureReconcileStateLocked()
+
+	// Seed a live keepalive runner. LinkByName returns a *netlink.Dummy,
+	// which legacyTunnelMatches(Dummy, Gretun) treats as CHANGED → recreate
+	// path → drain → LinkDel (fails).
+	state, gen := newKAState(true, 3, 5)
+	tm.linkGen["gr0"] = gen
+	// Seed with a pre-closed done so stopKeepaliveLocked's drain returns
+	// immediately (no real goroutine backs this fake runner).
+	seededDone := make(chan struct{})
+	close(seededDone)
+	tm.keepalives["gr0"] = &keepaliveRunner{
+		cancel: func() {}, state: state, done: seededDone,
+		remote: "203.0.113.1", source: "198.51.100.1", interval: 5, maxRetries: 3,
+		linkGen: gen,
+	}
+
+	tc := &config.TunnelConfig{
+		Name: "gr0", Mode: "gre",
+		Source: "198.51.100.1", Destination: "203.0.113.1",
+		Keepalive: 5, KeepaliveRetry: 3,
+	}
+	tm.applyKernelTunnelLocked(tc)
+
+	if _, ok := tm.keepalives["gr0"]; !ok {
+		t.Fatal("LinkDel failure on recreate must restart the keepalive, not leave it absent")
+	}
+	// Drain the restarted runner so the goroutine does not leak into other
+	// tests (it uses the real prober but a 5s interval, so it parks on the
+	// ticker; cancel it).
+	tm.stopKeepaliveLocked("gr0")
 }
 
 // --- prober errno classification ---

--- a/pkg/routing/tunnel_keepalive_test.go
+++ b/pkg/routing/tunnel_keepalive_test.go
@@ -409,6 +409,45 @@ func TestKeepaliveSourceBindAndMatches(t *testing.T) {
 	}
 }
 
+// --- Finding 1 (Codex PR #1947 r1 HIGH): a TRANSIENT LinkByName error
+// during apply must NOT drain the live keepalive runner nor bump the
+// generation; only a genuine NOT-FOUND or a present-but-changed link is
+// a recreate. ---
+func TestApplyTransientLookupKeepsRunner(t *testing.T) {
+	ops := newKaOps()
+	ops.byNameErr = errors.New("transient netlink transport error") // NOT a LinkNotFound
+	tm := &tunnelManager{ops: ops, vrfBinder: noopVRFBinder{}}
+	tm.ensureReconcileStateLocked()
+
+	// Seed a live keepalive runner + its generation token.
+	state, gen := newKAState(true, 3, 5)
+	tm.linkGen["gr0"] = gen
+	startGen := gen.Load()
+	tm.keepalives["gr0"] = &keepaliveRunner{
+		cancel:   func() {},
+		state:    state,
+		done:     make(chan struct{}),
+		remote:   "203.0.113.1",
+		source:   "198.51.100.1",
+		interval: 5, maxRetries: 3,
+		linkGen: gen, startGen: startGen,
+	}
+
+	tc := &config.TunnelConfig{
+		Name: "gr0", Mode: "gre",
+		Source: "198.51.100.1", Destination: "203.0.113.1",
+		Keepalive: 5, KeepaliveRetry: 3,
+	}
+	tm.applyKernelTunnelLocked(tc)
+
+	if _, ok := tm.keepalives["gr0"]; !ok {
+		t.Fatal("transient lookup error must NOT drain the keepalive runner")
+	}
+	if gen.Load() != startGen {
+		t.Fatalf("transient lookup error must NOT bump the generation: %d -> %d", startGen, gen.Load())
+	}
+}
+
 // --- prober errno classification ---
 func TestClassifyListenErr(t *testing.T) {
 	if got := classifyListenErr(errors.New("plain")); got != UnsupportedStructural {

--- a/pkg/routing/tunnel_keepalive_test.go
+++ b/pkg/routing/tunnel_keepalive_test.go
@@ -358,9 +358,13 @@ func TestKeepaliveStatusNotBlockedByNetlink(t *testing.T) {
 	tm := &tunnelManager{ops: ops}
 	state, gen := newKAState(true, 1, 1)
 	// Register the runner in the manager so GetKeepaliveState finds it.
+	// Setup mutates manager state guarded by mu in production, so hold mu
+	// for the setup block (Copilot PR #1947 r4 — test/contract alignment).
+	tm.mu.Lock()
 	tm.ensureReconcileStateLocked()
 	tm.keepalives["gr0"] = &keepaliveRunner{state: state, remote: state.RemoteAddr}
 	tm.tunnels = []string{"gr0"}
+	tm.mu.Unlock()
 
 	prober := &fakeProber{results: []probeOutcome{{result: ProbeDead, kind: UnsupportedNone}}}
 
@@ -424,6 +428,10 @@ func TestApplyTransientLookupKeepsRunner(t *testing.T) {
 	ops := newKaOps()
 	ops.byNameErr = errors.New("transient netlink transport error") // NOT a LinkNotFound
 	tm := &tunnelManager{ops: ops, vrfBinder: noopVRFBinder{}}
+	// applyKernelTunnelLocked + the helpers below all require mu held in
+	// production; hold it for the whole body (Copilot PR #1947 r4).
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
 	tm.ensureReconcileStateLocked()
 
 	// Seed a live keepalive runner + its generation token.
@@ -460,10 +468,14 @@ func TestApplyTransientLookupKeepsRunner(t *testing.T) {
 func TestKeepaliveUnknownReasonSurfacedInStatus(t *testing.T) {
 	ops := newKaOps()
 	tm := &tunnelManager{ops: ops}
+	// Setup mutates mu-guarded state (Copilot PR #1947 r4); GetStatus later
+	// takes mu, so lock only the setup block, not the read.
+	tm.mu.Lock()
 	tm.ensureReconcileStateLocked()
 	state, gen := newKAState(true, 3, 1)
 	tm.keepalives["gr0"] = &keepaliveRunner{state: state, remote: state.RemoteAddr}
 	tm.tunnels = []string{"gr0"}
+	tm.mu.Unlock()
 
 	// A transient unsupported with a concrete reason.
 	prober := &fakeProber{results: []probeOutcome{{
@@ -493,8 +505,10 @@ func TestKeepaliveUnknownReasonSurfacedInStatus(t *testing.T) {
 
 	// A structural unsupported with a reason → reason shown too.
 	state2, gen2 := newKAState(true, 3, 1)
+	tm.mu.Lock()
 	tm.keepalives["gr1"] = &keepaliveRunner{state: state2, remote: state2.RemoteAddr}
 	tm.tunnels = append(tm.tunnels, "gr1")
+	tm.mu.Unlock()
 	prober2 := &fakeProber{results: []probeOutcome{{
 		result: ProbeUnsupported, kind: UnsupportedStructural,
 		reason: "listen udp4 198.51.100.99: cannot assign requested address",
@@ -515,6 +529,10 @@ func TestApplyRecreateDelFailRestartsKeepalive(t *testing.T) {
 	ops := newKaOps()
 	ops.delErr = errors.New("transient LinkDel failure") // recreate aborts
 	tm := &tunnelManager{ops: ops, vrfBinder: noopVRFBinder{}}
+	// applyKernelTunnelLocked + stopKeepaliveLocked require mu in
+	// production; hold it for the whole body (Copilot PR #1947 r4).
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
 	tm.ensureReconcileStateLocked()
 
 	// Seed a live keepalive runner. LinkByName returns a *netlink.Dummy,

--- a/pkg/routing/tunnel_prober_test.go
+++ b/pkg/routing/tunnel_prober_test.go
@@ -177,6 +177,30 @@ func TestProberUnknownErrnoIsTransient(t *testing.T) {
 	})
 }
 
+// WriteTo local-resource errors must NOT be reported as Dead (Codex PR
+// #1947 r1 HIGH): a transmit-buffer storm would otherwise self-inflict a
+// tunnel down.
+func TestProberWriteResourceErrorIsTransient(t *testing.T) {
+	conn := &fakeProbeConn{writeErr: &os.SyscallError{Syscall: "sendto", Err: syscall.ENOBUFS}}
+	withListenICMP(conn, nil, func() {
+		res, kind := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		if res != ProbeUnsupported || kind != UnsupportedTransient {
+			t.Fatalf("ENOBUFS on WriteTo must be Unsupported/Transient, got %v/%v", res, kind)
+		}
+	})
+}
+
+// WriteTo path-unreachable errors ARE a real liveness signal → Dead.
+func TestProberWritePathUnreachableIsDead(t *testing.T) {
+	conn := &fakeProbeConn{writeErr: &os.SyscallError{Syscall: "sendto", Err: syscall.EHOSTUNREACH}}
+	withListenICMP(conn, nil, func() {
+		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		if res != ProbeDead {
+			t.Fatalf("EHOSTUNREACH on WriteTo must be Dead, got %v", res)
+		}
+	})
+}
+
 func TestProberBadDestStructural(t *testing.T) {
 	res, kind := icmpProber{}.Probe("198.51.100.1", "not-an-ip", 7, []byte("n"), 50*time.Millisecond)
 	if res != ProbeUnsupported || kind != UnsupportedStructural {

--- a/pkg/routing/tunnel_prober_test.go
+++ b/pkg/routing/tunnel_prober_test.go
@@ -1,0 +1,185 @@
+package routing
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+)
+
+// fakeProbeConn is an in-memory probeConn driven by a scripted reply
+// builder, so the production icmpProber can be exercised with no real
+// network. The replyFn is called with the just-sent echo (Seq, nonce) so
+// a test can echo a matching, mismatched, or foreign reply.
+type fakeProbeConn struct {
+	replies  [][]byte // queued replies (icmp.ParseMessage-parseable bytes)
+	writeErr error
+	readErr  error
+	sentSeq  int
+	sentData []byte
+	replyFn  func(seq int, data []byte) [][]byte
+}
+
+func (c *fakeProbeConn) WriteTo(b []byte, dst net.Addr) (int, error) {
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
+	// Parse the echo we are sending so the test reply builder can mirror it.
+	if m, err := icmp.ParseMessage(1, b); err == nil {
+		if e, ok := m.Body.(*icmp.Echo); ok {
+			c.sentSeq = e.Seq
+			c.sentData = append([]byte(nil), e.Data...)
+		}
+	}
+	if c.replyFn != nil {
+		c.replies = append(c.replies, c.replyFn(c.sentSeq, c.sentData)...)
+	}
+	return len(b), nil
+}
+
+func (c *fakeProbeConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	if c.readErr != nil {
+		return 0, nil, c.readErr
+	}
+	if len(c.replies) == 0 {
+		// Mimic a read deadline expiry.
+		return 0, nil, &timeoutErr{}
+	}
+	r := c.replies[0]
+	c.replies = c.replies[1:]
+	n := copy(b, r)
+	return n, &net.UDPAddr{IP: net.ParseIP("203.0.113.1")}, nil
+}
+
+func (c *fakeProbeConn) SetReadDeadline(t time.Time) error { return nil }
+func (c *fakeProbeConn) Close() error                      { return nil }
+
+type timeoutErr struct{}
+
+func (*timeoutErr) Error() string   { return "i/o timeout" }
+func (*timeoutErr) Timeout() bool   { return true }
+func (*timeoutErr) Temporary() bool { return true }
+
+// buildEchoReply marshals an ICMPv4 echo reply with the given seq/data.
+func buildEchoReply(seq int, data []byte) []byte {
+	m := icmp.Message{
+		Type: ipv4.ICMPTypeEchoReply,
+		Code: 0,
+		Body: &icmp.Echo{ID: 1234, Seq: seq, Data: data},
+	}
+	b, _ := m.Marshal(nil)
+	return b
+}
+
+func withListenICMP(conn probeConn, err error, fn func()) {
+	orig := listenICMP
+	listenICMP = func(network, source string) (probeConn, error) {
+		if err != nil {
+			return nil, err
+		}
+		return conn, nil
+	}
+	defer func() { listenICMP = orig }()
+	fn()
+}
+
+func TestProberMatchingReplyAlive(t *testing.T) {
+	conn := &fakeProbeConn{replyFn: func(seq int, data []byte) [][]byte {
+		return [][]byte{buildEchoReply(seq, data)}
+	}}
+	withListenICMP(conn, nil, func() {
+		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 200*time.Millisecond)
+		if res != ProbeAlive {
+			t.Fatalf("matching reply must be Alive, got %v", res)
+		}
+	})
+}
+
+func TestProberWrongSeqIsDead(t *testing.T) {
+	conn := &fakeProbeConn{replyFn: func(seq int, data []byte) [][]byte {
+		return [][]byte{buildEchoReply(seq+1, data)} // wrong seq
+	}}
+	withListenICMP(conn, nil, func() {
+		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 200*time.Millisecond)
+		if res != ProbeDead {
+			t.Fatalf("wrong-seq reply must be Dead, got %v", res)
+		}
+	})
+}
+
+func TestProberWrongNonceIsDead(t *testing.T) {
+	conn := &fakeProbeConn{replyFn: func(seq int, data []byte) [][]byte {
+		return [][]byte{buildEchoReply(seq, []byte("different"))} // wrong nonce
+	}}
+	withListenICMP(conn, nil, func() {
+		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 200*time.Millisecond)
+		if res != ProbeDead {
+			t.Fatalf("wrong-nonce reply must be Dead, got %v", res)
+		}
+	})
+}
+
+func TestProberForeignReplySkippedThenMatch(t *testing.T) {
+	conn := &fakeProbeConn{replyFn: func(seq int, data []byte) [][]byte {
+		// A foreign reply first, then the matching one — the read loop must
+		// skip the foreign datagram and match ours.
+		return [][]byte{
+			buildEchoReply(seq+99, []byte("foreign!")),
+			buildEchoReply(seq, data),
+		}
+	}}
+	withListenICMP(conn, nil, func() {
+		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 500*time.Millisecond)
+		if res != ProbeAlive {
+			t.Fatalf("foreign-then-matching must be Alive, got %v", res)
+		}
+	})
+}
+
+func TestProberNoReplyIsDead(t *testing.T) {
+	conn := &fakeProbeConn{} // no replyFn → read times out
+	withListenICMP(conn, nil, func() {
+		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 50*time.Millisecond)
+		if res != ProbeDead {
+			t.Fatalf("no reply must be Dead, got %v", res)
+		}
+	})
+}
+
+func TestProberListenErrorStructural(t *testing.T) {
+	withListenICMP(nil, &os.SyscallError{Syscall: "socket", Err: syscall.EPERM}, func() {
+		res, kind := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		if res != ProbeUnsupported || kind != UnsupportedStructural {
+			t.Fatalf("EPERM must be Unsupported/Structural, got %v/%v", res, kind)
+		}
+	})
+}
+
+func TestProberListenErrorTransient(t *testing.T) {
+	withListenICMP(nil, &os.SyscallError{Syscall: "socket", Err: syscall.EMFILE}, func() {
+		res, kind := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		if res != ProbeUnsupported || kind != UnsupportedTransient {
+			t.Fatalf("EMFILE must be Unsupported/Transient, got %v/%v", res, kind)
+		}
+	})
+}
+
+func TestProberUnknownErrnoIsTransient(t *testing.T) {
+	withListenICMP(nil, &os.SyscallError{Syscall: "socket", Err: syscall.ENOMEM}, func() {
+		_, kind := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		if kind != UnsupportedTransient {
+			t.Fatalf("ENOMEM must be Transient, got %v", kind)
+		}
+	})
+}
+
+func TestProberBadDestStructural(t *testing.T) {
+	res, kind := icmpProber{}.Probe("198.51.100.1", "not-an-ip", 7, []byte("n"), 50*time.Millisecond)
+	if res != ProbeUnsupported || kind != UnsupportedStructural {
+		t.Fatalf("unparseable dst must be Unsupported/Structural, got %v/%v", res, kind)
+	}
+}

--- a/pkg/routing/tunnel_prober_test.go
+++ b/pkg/routing/tunnel_prober_test.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 )
 
 // fakeProbeConn is an in-memory probeConn driven by a scripted reply
@@ -22,14 +23,21 @@ type fakeProbeConn struct {
 	sentSeq  int
 	sentData []byte
 	replyFn  func(seq int, data []byte) [][]byte
+	// parseProto is the IANA proto the fake uses to parse the SENT echo (1
+	// for ICMPv4, 58 for ICMPv6). Defaults to 1.
+	parseProto int
 }
 
 func (c *fakeProbeConn) WriteTo(b []byte, dst net.Addr) (int, error) {
 	if c.writeErr != nil {
 		return 0, c.writeErr
 	}
+	proto := c.parseProto
+	if proto == 0 {
+		proto = 1
+	}
 	// Parse the echo we are sending so the test reply builder can mirror it.
-	if m, err := icmp.ParseMessage(1, b); err == nil {
+	if m, err := icmp.ParseMessage(proto, b); err == nil {
 		if e, ok := m.Body.(*icmp.Echo); ok {
 			c.sentSeq = e.Seq
 			c.sentData = append([]byte(nil), e.Data...)
@@ -92,9 +100,55 @@ func TestProberMatchingReplyAlive(t *testing.T) {
 		return [][]byte{buildEchoReply(seq, data)}
 	}}
 	withListenICMP(conn, nil, func() {
-		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 200*time.Millisecond)
+		res, _, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 200*time.Millisecond)
 		if res != ProbeAlive {
 			t.Fatalf("matching reply must be Alive, got %v", res)
+		}
+	})
+}
+
+// buildEchoReplyV6 marshals an ICMPv6 echo reply. ICMPv6 checksums need
+// a pseudo-header; icmp.Message.Marshal(psh) with a nil psh leaves the
+// checksum zero, but ParseMessage(58, ...) does not verify it, so a nil
+// psh is fine for the round-trip-match test.
+func buildEchoReplyV6(seq int, data []byte) []byte {
+	m := icmp.Message{
+		Type: ipv6.ICMPTypeEchoReply,
+		Code: 0,
+		Body: &icmp.Echo{ID: 1234, Seq: seq, Data: data},
+	}
+	b, _ := m.Marshal(nil)
+	return b
+}
+
+// IPv6 path coverage (Copilot PR #1947): exercise the v6-specific
+// constants/parsing with a real round-trip match.
+func TestProberIPv6MatchingReplyAlive(t *testing.T) {
+	conn := &fakeProbeConn{
+		parseProto: 58,
+		replyFn: func(seq int, data []byte) [][]byte {
+			return [][]byte{buildEchoReplyV6(seq, data)}
+		},
+	}
+	withListenICMP(conn, nil, func() {
+		res, _, _ := icmpProber{}.Probe("2001:db8::1", "2001:db8::2", 11, []byte("v6nonce0"), 200*time.Millisecond)
+		if res != ProbeAlive {
+			t.Fatalf("v6 matching reply must be Alive, got %v", res)
+		}
+	})
+}
+
+func TestProberIPv6WrongNonceIsDead(t *testing.T) {
+	conn := &fakeProbeConn{
+		parseProto: 58,
+		replyFn: func(seq int, data []byte) [][]byte {
+			return [][]byte{buildEchoReplyV6(seq, []byte("OTHER!!!"))}
+		},
+	}
+	withListenICMP(conn, nil, func() {
+		res, _, _ := icmpProber{}.Probe("2001:db8::1", "2001:db8::2", 11, []byte("v6nonce0"), 200*time.Millisecond)
+		if res != ProbeDead {
+			t.Fatalf("v6 wrong-nonce reply must be Dead, got %v", res)
 		}
 	})
 }
@@ -104,7 +158,7 @@ func TestProberWrongSeqIsDead(t *testing.T) {
 		return [][]byte{buildEchoReply(seq+1, data)} // wrong seq
 	}}
 	withListenICMP(conn, nil, func() {
-		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 200*time.Millisecond)
+		res, _, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 200*time.Millisecond)
 		if res != ProbeDead {
 			t.Fatalf("wrong-seq reply must be Dead, got %v", res)
 		}
@@ -116,7 +170,7 @@ func TestProberWrongNonceIsDead(t *testing.T) {
 		return [][]byte{buildEchoReply(seq, []byte("different"))} // wrong nonce
 	}}
 	withListenICMP(conn, nil, func() {
-		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 200*time.Millisecond)
+		res, _, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 200*time.Millisecond)
 		if res != ProbeDead {
 			t.Fatalf("wrong-nonce reply must be Dead, got %v", res)
 		}
@@ -133,7 +187,7 @@ func TestProberForeignReplySkippedThenMatch(t *testing.T) {
 		}
 	}}
 	withListenICMP(conn, nil, func() {
-		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 500*time.Millisecond)
+		res, _, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 500*time.Millisecond)
 		if res != ProbeAlive {
 			t.Fatalf("foreign-then-matching must be Alive, got %v", res)
 		}
@@ -143,7 +197,7 @@ func TestProberForeignReplySkippedThenMatch(t *testing.T) {
 func TestProberNoReplyIsDead(t *testing.T) {
 	conn := &fakeProbeConn{} // no replyFn → read times out
 	withListenICMP(conn, nil, func() {
-		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 50*time.Millisecond)
+		res, _, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("nonce123"), 50*time.Millisecond)
 		if res != ProbeDead {
 			t.Fatalf("no reply must be Dead, got %v", res)
 		}
@@ -152,7 +206,7 @@ func TestProberNoReplyIsDead(t *testing.T) {
 
 func TestProberListenErrorStructural(t *testing.T) {
 	withListenICMP(nil, &os.SyscallError{Syscall: "socket", Err: syscall.EPERM}, func() {
-		res, kind := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		res, kind, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
 		if res != ProbeUnsupported || kind != UnsupportedStructural {
 			t.Fatalf("EPERM must be Unsupported/Structural, got %v/%v", res, kind)
 		}
@@ -161,7 +215,7 @@ func TestProberListenErrorStructural(t *testing.T) {
 
 func TestProberListenErrorTransient(t *testing.T) {
 	withListenICMP(nil, &os.SyscallError{Syscall: "socket", Err: syscall.EMFILE}, func() {
-		res, kind := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		res, kind, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
 		if res != ProbeUnsupported || kind != UnsupportedTransient {
 			t.Fatalf("EMFILE must be Unsupported/Transient, got %v/%v", res, kind)
 		}
@@ -170,7 +224,7 @@ func TestProberListenErrorTransient(t *testing.T) {
 
 func TestProberUnknownErrnoIsTransient(t *testing.T) {
 	withListenICMP(nil, &os.SyscallError{Syscall: "socket", Err: syscall.ENOMEM}, func() {
-		_, kind := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		_, kind, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
 		if kind != UnsupportedTransient {
 			t.Fatalf("ENOMEM must be Transient, got %v", kind)
 		}
@@ -183,7 +237,7 @@ func TestProberUnknownErrnoIsTransient(t *testing.T) {
 func TestProberWriteResourceErrorIsTransient(t *testing.T) {
 	conn := &fakeProbeConn{writeErr: &os.SyscallError{Syscall: "sendto", Err: syscall.ENOBUFS}}
 	withListenICMP(conn, nil, func() {
-		res, kind := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		res, kind, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
 		if res != ProbeUnsupported || kind != UnsupportedTransient {
 			t.Fatalf("ENOBUFS on WriteTo must be Unsupported/Transient, got %v/%v", res, kind)
 		}
@@ -194,7 +248,7 @@ func TestProberWriteResourceErrorIsTransient(t *testing.T) {
 func TestProberWritePathUnreachableIsDead(t *testing.T) {
 	conn := &fakeProbeConn{writeErr: &os.SyscallError{Syscall: "sendto", Err: syscall.EHOSTUNREACH}}
 	withListenICMP(conn, nil, func() {
-		res, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
+		res, _, _ := icmpProber{}.Probe("198.51.100.1", "203.0.113.1", 7, []byte("n"), 50*time.Millisecond)
 		if res != ProbeDead {
 			t.Fatalf("EHOSTUNREACH on WriteTo must be Dead, got %v", res)
 		}
@@ -202,7 +256,7 @@ func TestProberWritePathUnreachableIsDead(t *testing.T) {
 }
 
 func TestProberBadDestStructural(t *testing.T) {
-	res, kind := icmpProber{}.Probe("198.51.100.1", "not-an-ip", 7, []byte("n"), 50*time.Millisecond)
+	res, kind, _ := icmpProber{}.Probe("198.51.100.1", "not-an-ip", 7, []byte("n"), 50*time.Millisecond)
 	if res != ProbeUnsupported || kind != UnsupportedStructural {
 		t.Fatalf("unparseable dst must be Unsupported/Structural, got %v/%v", res, kind)
 	}


### PR DESCRIPTION
## Summary

`probeICMP` (`pkg/routing/tunnel.go`) opened an ICMP/UDP socket and returned `true` on socket-open **without ever sending or receiving an echo** — a route-existence check, not a liveness check. A dead GRE/IPIP peer behind a valid route was reported up forever and the fail-safe `LinkSetDown` was structurally unreachable. Secondary: `keepaliveLoop` held `state.mu` across the netlink `LinkSetUp/Down`, so a slow netlink op blocked status reads.

Implements the 3-way converged plan (`docs/research/1918-probe-real-liveness/plan.md`, r6).

## What changed

- **Real datagram-ICMP echo prober** (`tunnel_keepalive.go`) modeled on the tested `pkg/cluster/monitor.go` precedent, with the two precedent gaps fixed:
  - **Reply match on Seq + a per-probe Data-nonce, NOT the ICMP ID** (datagram "ping" sockets rewrite the id to the socket source port).
  - **Bind to the tunnel local Source IP** (§5c); probe the **underlay Destination in the GLOBAL FIB** (§5b — no overlay-VRF bind).
- **Typed result** `ProbeAlive | ProbeDead | ProbeUnsupported` replaces the bool.
- **Commit-after-success tick (Axis D)**: classify + compute intent under `state.mu`, release the lock, do the single `LinkSet*` outside the lock, commit `Up` only on netlink success. A `LinkByName`/`LinkSet*` error leaves `Up` unchanged so the transition retries — no lost/half-applied transition, no uncommitted `Up` observable by a racing `GetStatus`, no lock held across netlink.
- **Hold-on-unknown (Axis C)**: `ProbeUnsupported` never touches `Failures` and never transitions the link. Structural → hold indefinitely + one-shot Warn; transient/unrecognized errno → hold but escalate to `slog.Error` after `MaxRetries` consecutive unknown ticks. Status renders `KeepaliveUp=nil` + `"unknown (...)"`.
- **Recreate safety (Axis D F7)**: `applyKernelTunnelLocked` now cancels + **drains the existing keepalive runner BEFORE the LinkDel/LinkAdd recreate**, so no stale runner `LinkSet*`s a recreated link that reused the ifindex. A per-tunnel `linkGen` (`*atomic.Uint64`, read **lock-free** — the runner never takes `t.mu`, AGY r5 deadlock note) is the defense-in-depth backstop. Tunnel `Source` joins the runner identity (`matches()`).

## Testing

- Deterministic injected-prober tick tests: alive / dead-once / recovery-once / structural-hold / transient-escalate / LinkByName-no-latch / LinkSet*-error-retry / generation-guard-drop / status-not-blocked-by-netlink / source-bind.
- Production-prober tests over a fake socket: Seq+nonce match, wrong-seq/nonce → Dead, foreign-reply skip, no-reply → Dead, errno structural/transient classification.
- `go build ./...` clean; `go vet ./pkg/routing` clean; `go test -race ./pkg/routing` 5x clean; full `go test ./...` green.
- The former `TestProbeICMP` encoded the bug (asserted route-existence == liveness) and is removed.

Closes #1918

🤖 Generated with [Claude Code](https://claude.com/claude-code)