### PR TITLE
#1944: system login user encrypted-password (console login for non-root operators)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,22 @@
 # Action Log
 
+## 2026-06-17 — #1944 system login user encrypted-password (console login)
+
+- **Timestamp**: 2026-06-17
+- **Action**: Implement converged r5 plan — per-user
+  `authentication encrypted-password` reaches `/etc/shadow` via
+  `chpasswd -e`; shared `ValidateCryptHash` (rejects plaintext + DES,
+  accepts modular crypt + lock sentinels) wired to both per-user and
+  root-auth typed leaves; idempotent pure `passwordAction`; Path D2
+  lock-on-removal gated by a UID-keyed `/var/lib/xpf/provisioned-users`
+  marker; §5.8 no-usable-auth commit warning; docs/system-login.md.
+- **File(s)**: pkg/config/types_system.go, compiler_system.go,
+  schema_system.go, schema_validators.go, value_type.go, compiler.go,
+  pkg/daemon/login_password.go, daemon_system.go,
+  pkg/config/login_password_test.go,
+  pkg/daemon/login_password_test.go, parser_system_test.go,
+  docs/system-login.md, docs/feature-gaps.md
+
 ## 2026-06-17 — #1915 DHCP relay socket lifecycle (implement converged r4 plan)
 
 - **Timestamp**: 2026-06-17

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -404,7 +404,7 @@ xpf manages all interfaces with .link/.network files, supports VLANs, tunnel int
 
 ## 22. System Enhancements
 
-xpf has hostname, domain-name, domain-search, timezone, name-servers, NTP, services (SSH, web-management, DNS), syslog, SNMP, login users/classes, root-authentication, archival, internet-options, backup-router, DHCP server (Kea), and ~~DPDK~~ config (DPDK retired #1525, removed in #1527/#1528).
+xpf has hostname, domain-name, domain-search, timezone, name-servers, NTP, services (SSH, web-management, DNS), syslog, SNMP, login users/classes (including per-user `authentication encrypted-password` for console login — #1944, see [docs/system-login.md](system-login.md)), root-authentication, archival, internet-options, backup-router, DHCP server (Kea), and ~~DPDK~~ config (DPDK retired #1525, removed in #1527/#1528).
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|

--- a/docs/pr/1944-login-user-password/reviewer-ids.md
+++ b/docs/pr/1944-login-user-password/reviewer-ids.md
@@ -7,7 +7,43 @@ implementation 4-way review (Codex + AGY + Claude SMR + Copilot).
 
 | Reviewer | Task / ID | Round | Verdict |
 |----------|-----------|-------|---------|
-| Codex    | (recorded below) | r1 | pending |
-| AGY      | (recorded below) | r1 | pending |
-| Claude SMR | in-conversation | r1 | pending |
-| Copilot  | PR #1949 | r1 | pending |
+| Codex    | foreground codex exec (/tmp/codex-1944-out.txt) | r1 | CHANGES-REQUIRED |
+| AGY      | adversarial-review-mqhuid2o-edharg (timed out, full-explore); adversarial-review-mqhuwq5g-zivv2m | r1 | MERGE-READY |
+| Claude SMR | in-conversation | r1 | CHANGES-REQUIRED (concur Codex High #2) |
+| Copilot  | PR #1949 | r1 | requested |
+
+## Round 1 findings + dispositions
+
+Codex r1 (CHANGES-REQUIRED):
+- **High #1 — inline hierarchical `authentication encrypted-password "x";`
+  (no braces) bypasses the typed-leaf validator.** Verified PARTIALLY: in
+  that AST shape SchemaValidate returns nil BUT the compiler also reads
+  `encrypted-password` only as a CHILD of `authentication`, so the value
+  compiles to "" (empty) — plaintext is NOT stored or applied. Same
+  pre-existing shape behavior as `root-authentication`. The
+  plaintext-rejection SECURITY invariant holds (no plaintext reaches
+  /etc/shadow). The real residue is that a VALID hash written in that
+  unusual inline form is silently dropped — a config-silently-ignored
+  paper-cut, not a security break. Disposition: ACCEPT as a known
+  parser-shape limitation shared with root-auth; flat-set (the `set`
+  output) and braced hierarchical both work and are tested. Documented.
+- **High #2 — lenient Load/SyncApply path carries plaintext/DES into
+  `chpasswd -e`.** Verified TRUE: `CompileConfigLenient` keeps
+  `EncryptedPassword="password12345"` (the #1319 boot/peer-sync downgrade),
+  and `reconcileUserPassword` would write it to /etc/shadow literally.
+  This breaks "plaintext never reaches /etc/shadow" on the non-operator
+  ingress. Disposition: FIX — re-validate `ValidateCryptHash(desired)` at
+  the apply boundary in `reconcileUserPassword`; skip+warn on failure
+  (defense-in-depth credential gate). A persisted/synced bad value can no
+  longer be applied; boot still does not brick.
+- **High #3 — D2 lock `chpasswd` failure leaves the live hash.** Verified
+  TRUE but irreducible: if the OS `chpasswd` tool itself fails we cannot
+  edit /etc/shadow. Disposition: keep the loud warning (already present);
+  no silent orphan — operator sees the failure. Acceptable.
+- **Low — no-auth warning treats `!$6$…` (locked-but-restorable) as
+  usable.** Verified TRUE. Disposition: FIX — strip a leading `!`/`!!`
+  before the usable-password check so a locked-restorable hash with no ssh
+  keys still warns.
+
+AGY r1 (MERGE-READY): independently verified all three invariants on the
+strict path; did not exercise the lenient ingress (Codex High #2 gap).

--- a/docs/pr/1944-login-user-password/reviewer-ids.md
+++ b/docs/pr/1944-login-user-password/reviewer-ids.md
@@ -1,0 +1,13 @@
+# #1944 implementation reviewer IDs + verdicts
+
+PR: #1949 (engineer/1944-login-user-password)
+
+Plan converged at r5 (PLAN-READY: Claude SMR + Codex + AGY). This is the
+implementation 4-way review (Codex + AGY + Claude SMR + Copilot).
+
+| Reviewer | Task / ID | Round | Verdict |
+|----------|-----------|-------|---------|
+| Codex    | (recorded below) | r1 | pending |
+| AGY      | (recorded below) | r1 | pending |
+| Claude SMR | in-conversation | r1 | pending |
+| Copilot  | PR #1949 | r1 | pending |

--- a/docs/pr/1944-login-user-password/reviewer-ids.md
+++ b/docs/pr/1944-login-user-password/reviewer-ids.md
@@ -47,3 +47,25 @@ Codex r1 (CHANGES-REQUIRED):
 
 AGY r1 (MERGE-READY): independently verified all three invariants on the
 strict path; did not exercise the lenient ingress (Codex High #2 gap).
+
+## Round 2 (head 510523739 → 8f-fix)
+
+| Reviewer | Task / ID | Round | Verdict |
+|----------|-----------|-------|---------|
+| Codex    | foreground (/tmp/codex-1944-r2-out.txt) | r2 | CHANGES-REQUIRED → fixed |
+| AGY      | adversarial-review-mqhvi9y9-hvahz1 | r2 | (see below) |
+| Claude SMR | in-conversation | r2 | concur Codex r2 High |
+| Copilot  | PR #1949 | r2 | re-requested |
+
+Codex r2: confirmed the per-user apply-boundary guard + no-auth warning
+fixes are correct and complete, then found the SYMMETRIC **High**:
+`applyRootAuth` (root-authentication) had the same lenient-ingress hole —
+it sent `root:<value>` to `chpasswd -e` checking only non-empty, so a
+persisted/synced plaintext root password would be applied. Since #1944
+explicitly shares `ValidateCryptHash` with root-auth (E1), the
+apply-boundary guard belongs there too. FIXED: `applyRootAuth` now
+re-runs `config.ValidateCryptHash` before the root `chpasswd -e` and
+skips+warns on failure (SSH keys still applied). New test
+`TestRootAuthApplyBoundaryRevalidatesHash`. No-regression: per-user path,
+inline-form-compiles-to-"", and the no-auth warning all still verified by
+Codex r2.

--- a/docs/pr/1944-login-user-password/reviewer-ids.md
+++ b/docs/pr/1944-login-user-password/reviewer-ids.md
@@ -69,3 +69,30 @@ skips+warns on failure (SSH keys still applied). New test
 `TestRootAuthApplyBoundaryRevalidatesHash`. No-regression: per-user path,
 inline-form-compiles-to-"", and the no-auth warning all still verified by
 Codex r2.
+
+## Round 3 — FINAL (head 8cfdacf68 → +copilot-fix)
+
+| Reviewer | Task / ID | Round | Verdict |
+|----------|-----------|-------|---------|
+| Codex    | foreground (/tmp/codex-1944-r3-out.txt) | r3 | **MERGE-READY** |
+| AGY      | adversarial-review-mqhvqwzm-ubulh5 | r3 | **MERGE-READY** |
+| Claude SMR | in-conversation | r3 | **MERGE-READY** |
+| Copilot  | PR #1949 (reviews @ 09:37) | r2 | findings fixed → re-requested |
+
+Codex r3: no findings — r2 root-auth High closed; confirmed NO unvalidated
+value reaches `chpasswd -e` on any production path (per-user apply
+validates `desired`; per-user lock sends constant `!`; root apply
+validates `ra.EncryptedPassword`; no other chpasswd sites). All three
+invariants reconfirmed.
+
+AGY r3: MERGE-READY — independently reconfirmed lock-on-removal (locks /
+never-orphans / never-on-read-error / UID-keyed), the apply-boundary guard
+on all three chpasswd inputs, and empty-passwordless-shadow → D2 lock.
+
+Copilot (formal, 2 comments on the head): `ValidateCryptHash` accepted an
+empty INTERMEDIATE `$`-field (`$6$salt$$hash`, doubled `$`) — passes the
+alphabet-only check (no chars) but is malformed and fails at PAM. FIXED:
+reject any empty field in `fields[2:]`; added `$6$salt$$hash` and
+`$6$$$hash` to the TestValidateCryptHash reject table.
+
+All four reviewers clean / addressed on the final revision.

--- a/docs/pr/1944-login-user-password/validation.md
+++ b/docs/pr/1944-login-user-password/validation.md
@@ -1,0 +1,62 @@
+# #1944 validation — system login user encrypted-password
+
+## Unit (default `go test ./...` gate)
+
+- `go build ./...` clean; full `go test ./...` green.
+- New tests stable over `-count=5`.
+- `go vet ./pkg/config ./pkg/daemon` clean (the two daemon_flow.go
+  copylock warnings are pre-existing and unrelated to this change —
+  present on the merge base).
+- Key unit coverage:
+  - `TestValidateCryptHash` — accept (modular crypt incl. `rounds=`,
+    yescrypt, bcrypt, `!`/`!!` prefix, bare sentinels) / reject
+    (plaintext, 13-char DES-shape, empty, unknown id, empty salt, empty
+    checksum, colon, control char).
+  - `TestLoginUserEncryptedPasswordSchemaGate` — the REAL `SchemaValidate`
+    commit-check gate rejects plaintext per-user AND root, accepts a valid
+    hash and the root lock sentinel `*`. This is the live commit-check
+    rejection proof (c).
+  - Hierarchical + flat-set compile parity.
+  - `TestPasswordAction` — full fail-open/fail-closed table.
+  - `TestProvenanceMarkerUIDKeyed` — no-marker, match, UID-mismatch
+    cleanup, rejoin, corrupt-marker cleanup.
+  - `currentShadowHash` / `lookupUID` parse against sample files.
+
+## Functional (live, real /etc/shadow + chpasswd)
+
+Build-tagged harness `pkg/daemon/login_password_functional_test.go`
+(`-tags functional1944`), cross-compiled on the host and run as root in a
+throwaway privileged Debian 13 container (`t1944-shadow`). It drives the
+ACTUAL production paths: `reconcileUserPassword` → `passwordAction` +
+`currentShadowHash` + `chpasswd -e`, plus the UID-keyed marker.
+
+```
+=== RUN   TestFunctional1944
+INFO user encrypted-password applied user=op1944
+  (a) PASS: shadow field for op1944 equals the configured hash
+  (a) PASS: op1944 authenticates with the cleartext password
+  (d) PASS: unchanged re-commit is a noop (no chpasswd churn)
+INFO user password locked (no encrypted-password in config) user=op1944
+  (b) PASS: directive removal locked op1944 (shadow="!"), hash not orphaned
+  (b) PASS: locked account rejects the old password
+--- PASS: TestFunctional1944 (3.33s)
+PASS
+```
+
+- (a) set → hash IS in `/etc/shadow` field 2 → `op1944` authenticates
+  with the cleartext password `test123` (via `setpriv`-dropped `su`,
+  a real PAM auth; the same harness confirms a wrong password is rejected
+  with `su: Authentication failure`).
+- (b) remove the directive → commit → account LOCKED: shadow field is the
+  `!` lock sentinel, NOT the orphaned hash → old password rejected.
+- (c) plaintext / 13-char-DES / empty-checksum rejected at the real
+  `SchemaValidate` commit gate (unit, above).
+- (d) idempotent re-commit → `pwNoop`, no `chpasswd` churn.
+
+To reproduce:
+
+```
+go test -tags functional1944 -c -o /tmp/daemon_func.test ./pkg/daemon/
+# push into a privileged container with chpasswd/useradd, then as root:
+/tmp/daemon_func.test -test.run TestFunctional1944 -test.v
+```

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -1,0 +1,128 @@
+# System login & authentication
+
+This is the operator contract for `system login user` and
+`system root-authentication` password handling. It documents how a
+configured login password reaches the OS account database, the
+commit-time validation of the hash, and the declarative reconciliation
+behaviour when a password directive is removed. (#1944)
+
+## Per-user console login password
+
+```
+set system login user <name> class operator
+set system login user <name> authentication encrypted-password "<crypt-hash>"
+```
+
+On commit, xpf:
+
+1. Creates the OS account (`useradd`) if it does not already exist.
+2. Writes `<crypt-hash>` to `/etc/shadow` for `<name>` via
+   `chpasswd -e` (the same idiom `root-authentication` uses), so the
+   operator can log in on the **serial console** (and via SSH password
+   if `sshd` permits). Without this, a freshly created account has a
+   locked password field and cannot log in on the console at all — only
+   SSH-key login (`authentication ssh-ed25519 …`) worked previously.
+
+The password directive takes a **pre-computed crypt(3) hash**, never
+plaintext — exactly like `root-authentication encrypted-password`. xpf
+does not hash plaintext for you.
+
+### Generating a hash
+
+```
+openssl passwd -6                       # prompts; emits a $6$ sha512crypt hash
+mkpasswd -m sha512crypt                  # same, from the whois package
+openssl passwd -6 -salt "$(head -c12 /dev/urandom | base64 | tr -d '+/=')"
+```
+
+Paste the resulting `$6$…` string into `encrypted-password`. yescrypt
+(`$y$…`) and bcrypt (`$2b$…`) hashes are also accepted.
+
+## Accepted hash formats (commit-check)
+
+The value is validated at commit time by a shared validator
+(`ValidateCryptHash`, used for both per-user and root authentication).
+
+**Accepted:**
+
+- A modular crypt(3) hash `$<id>$<salt>$<checksum>` with a non-empty
+  salt and a non-empty final checksum, where `<id>` is one of
+  `1, 2a, 2b, 2y, 5, 6, 7, y, gy`. Parameter fields are allowed
+  (e.g. `$6$rounds=656000$salt$hash`, `$y$j9T$salt$hash`).
+- An optional leading `!` or `!!` (the locked-but-restorable form),
+  e.g. `!$6$salt$hash`.
+- A bare lock sentinel: `*`, `!`, or `!!`. This is the intentional Unix
+  way to lock an account, and the **only** way to lock root via config
+  (`set system root-authentication encrypted-password "*"`).
+
+**Rejected at commit:**
+
+- **Plaintext** — pasting a cleartext password is hard-rejected. This is
+  absolute: even a 13-character alphanumeric string (which a legacy DES
+  crypt would resemble) is rejected, because xpf does not accept legacy
+  DES hashes.
+- An empty value, an unknown `$<id>$`, an empty salt, an empty checksum
+  (`$6$salt$`), or a value containing `:` or a control character.
+
+### Strict vs lenient paths
+
+- **Operator commit / commit-check**: a bad value **hard-fails** the
+  commit (the `#1319` typed-leaf gate). The plaintext footgun is closed
+  at the entry point.
+- **Boot / peer-sync**: an already-persisted or peer-synced value that
+  fails validation is **downgraded to a warning** rather than failing
+  boot, so a bad stored value can never brick the daemon.
+
+## Removing the directive locks the account (declarative)
+
+When you remove `authentication encrypted-password` from a user that xpf
+provisioned, on the next commit xpf **locks** that account's password
+(`<user>:!` via `chpasswd -e`) instead of leaving the old hash in
+`/etc/shadow`. Removing the directive therefore disables password login
+rather than orphaning a live credential. Re-adding the directive
+restores the password.
+
+This password reconciliation is **declarative**; SSH keys
+(`authorized_keys`) and sudo (`/etc/sudoers.d/xpf-<name>`) remain
+additive and are independent of the password — a live password is a
+higher-severity orphan than a stale key, so the two are treated
+asymmetrically by design.
+
+### Scope — only xpf-managed accounts
+
+The lock-on-removal applies **only to the exact account xpf
+provisioned**, never root, and never to accounts absent from config
+(xpf does not deprovision/`userdel` accounts). Provenance is tracked by
+a per-user marker file under `/var/lib/xpf/provisioned-users/<name>`
+whose content is the account's numeric **UID** at the time xpf wrote
+its password (written on both `useradd` and a successful
+`encrypted-password` apply).
+
+- **Leave then rejoin the same account**: the UID is unchanged, so the
+  marker matches and the lock fires — the old password is revoked.
+- **`userdel` + out-of-band recreate with a new UID**: the marker's UID
+  no longer matches, so xpf leaves the out-of-band account untouched
+  (and opportunistically removes the stale marker).
+- **Edge case**: if an out-of-band recreate happens to reuse the *exact
+  same name and UID* xpf recorded, xpf treats it as the original managed
+  account and may lock it. Re-add `encrypted-password` to restore.
+
+A transient `/etc/shadow` read error never causes a lock (the lock
+decision fails closed on a read error), so a read hiccup can never lock
+out an operator.
+
+## Idempotency
+
+The password apply reads `/etc/shadow` directly and skips `chpasswd`
+when the on-disk hash already equals the configured hash, so an
+unchanged re-commit does not churn the account. It fails **open** toward
+applying (any read error / missing entry / mismatch → apply), so a first
+commit never silently skips the password.
+
+## #1916 interaction (file-atomic writes)
+
+The password path is a `chpasswd` **process** invocation (which performs
+its own `lckpwdf`-protected shadow update), not a direct file write, so
+the #1916 fsatomic file-write wrapper does not apply to it. The sudoers
+and `authorized_keys` writes in the same apply function are ordinary
+file writes and are unchanged.

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -707,6 +707,29 @@ func ValidateConfig(cfg *Config) []string {
 				"this warning.")
 	}
 
+	// #1944 §5.8: warn when a configured login user has no usable auth
+	// method — no ssh-* keys AND no usable encrypted-password (absent, or
+	// a bare lock sentinel which only locks the account). Mirrors the
+	// root-auth warning style above; directly addresses the "non-root
+	// operator cannot log in" bug class this issue closes.
+	if cfg.System.Login != nil {
+		for _, u := range cfg.System.Login.Users {
+			if u == nil || u.Name == "" || u.Name == "root" {
+				continue
+			}
+			pw := u.EncryptedPassword
+			usablePassword := pw != "" && pw != "*" && pw != "!" && pw != "!!"
+			if len(u.SSHKeys) == 0 && !usablePassword {
+				warnings = append(warnings, fmt.Sprintf(
+					"login user %s has no usable authentication method: no "+
+						"ssh keys and no encrypted-password (a bare lock "+
+						"sentinel does not count) — this account cannot log "+
+						"in. Set `authentication encrypted-password` (hash "+
+						"from `openssl passwd -6`) or an ssh key.", u.Name))
+			}
+		}
+	}
+
 	// Collect valid zone names
 	zones := make(map[string]bool)
 	for name := range cfg.Security.Zones {

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -717,8 +717,13 @@ func ValidateConfig(cfg *Config) []string {
 			if u == nil || u.Name == "" || u.Name == "root" {
 				continue
 			}
+			// A usable password is a non-empty value that is neither a bare
+			// lock sentinel ("*"/"!"/"!!") NOR a locked-but-restorable form
+			// (any value beginning with "!", e.g. "!$6$salt$hash"). A
+			// leading "!" means the account cannot password-login until it
+			// is unlocked, so it does not count (Codex #1944 r1 Low).
 			pw := u.EncryptedPassword
-			usablePassword := pw != "" && pw != "*" && pw != "!" && pw != "!!"
+			usablePassword := pw != "" && pw != "*" && !strings.HasPrefix(pw, "!")
 			if len(u.SSHKeys) == 0 && !usablePassword {
 				warnings = append(warnings, fmt.Sprintf(
 					"login user %s has no usable authentication method: no "+

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -95,6 +95,8 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 					case "authentication":
 						for _, authChild := range prop.Children {
 							switch authChild.Name() {
+							case "encrypted-password":
+								user.EncryptedPassword = nodeVal(authChild)
 							case "ssh-ed25519", "ssh-rsa", "ssh-dsa":
 								if v := nodeVal(authChild); v != "" {
 									user.SSHKeys = append(user.SSHKeys, v)

--- a/pkg/config/login_password_test.go
+++ b/pkg/config/login_password_test.go
@@ -46,6 +46,8 @@ func TestValidateCryptHash(t *testing.T) {
 		"$6$salt$ab cd",  // space
 		"$6$salt$ab\tcd", // tab control char
 		"$6salt$hash",    // missing $ after id
+		"$6$salt$$hash",  // empty intermediate field / doubled $ (Copilot review)
+		"$6$$$hash",      // empty salt AND empty param
 	}
 	for _, in := range reject {
 		if err := ValidateCryptHash(in, nil); err == nil {

--- a/pkg/config/login_password_test.go
+++ b/pkg/config/login_password_test.go
@@ -1,0 +1,207 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateCryptHash covers the crypt(3)-hash recognizer shared by
+// root-authentication and per-user authentication (#1944 §5.5). The
+// central guarantee is that plaintext is ABSOLUTELY rejected (legacy DES
+// is intentionally not accepted) while deliberate lock sentinels pass.
+func TestValidateCryptHash(t *testing.T) {
+	accept := []string{
+		"$6$salt$hash",
+		"$6$saltsalt$abc123def456",
+		"$6$rounds=656000$salt$hash", // sha512crypt rounds param ('=' case)
+		"$5$rounds=5000$salt$hash",
+		"$y$j9T$saltsalt$hashhash",   // yescrypt (Debian 13 default)
+		"$2b$10$abcdefghijklmnopqrst", // bcrypt
+		"$2a$10$abcdefghijklmnopqrst",
+		"$2y$10$abcdefghijklmnopqrst",
+		"$1$salt$hash",         // md5crypt
+		"$7$salt$hash",         // scrypt
+		"$gy$j9T$salt$hash",    // gost-yescrypt
+		"!$6$salt$hash",        // locked-but-restorable
+		"!!$6$salt$hash",       // locked-but-restorable (double bang)
+		"*",                    // bare lock sentinel
+		"!",                    // bare lock sentinel
+		"!!",                   // bare lock sentinel
+	}
+	for _, in := range accept {
+		if err := ValidateCryptHash(in, nil); err != nil {
+			t.Errorf("ValidateCryptHash(%q) = %v, want accept", in, err)
+		}
+	}
+
+	reject := []string{
+		"plaintext",      // the real footgun
+		"password12345",  // 13 alnum — the DES-drop case (r3 Major-2)
+		"",               // empty
+		"$99$bogus$x",    // unknown id
+		"$6$",            // no salt body / no checksum
+		"$6$salt$",       // empty checksum (r3 Major-3)
+		"$6$$hash",       // empty salt
+		"$6$salt:hash",   // colon would corrupt chpasswd stdin
+		"$6$salt$ab cd",  // space
+		"$6$salt$ab\tcd", // tab control char
+		"$6salt$hash",    // missing $ after id
+	}
+	for _, in := range reject {
+		if err := ValidateCryptHash(in, nil); err == nil {
+			t.Errorf("ValidateCryptHash(%q) = nil, want reject", in)
+		}
+	}
+}
+
+// TestParseLoginUserEncryptedPasswordHierarchical exercises the
+// hierarchical AST shape (#1944 §7.1).
+func TestParseLoginUserEncryptedPasswordHierarchical(t *testing.T) {
+	input := `system {
+    login {
+        user op {
+            class operator;
+            authentication {
+                encrypted-password "$6$salt$hash";
+                ssh-ed25519 "ssh-ed25519 AAAA op@host";
+            }
+        }
+    }
+}`
+	parser := NewParser(input)
+	tree, errs := parser.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	if cfg.System.Login == nil || len(cfg.System.Login.Users) != 1 {
+		t.Fatalf("expected 1 user, got %+v", cfg.System.Login)
+	}
+	u := cfg.System.Login.Users[0]
+	if u.EncryptedPassword != "$6$salt$hash" {
+		t.Errorf("EncryptedPassword = %q, want %q", u.EncryptedPassword, "$6$salt$hash")
+	}
+	if len(u.SSHKeys) != 1 || u.SSHKeys[0] != "ssh-ed25519 AAAA op@host" {
+		t.Errorf("SSHKeys = %v", u.SSHKeys)
+	}
+}
+
+// TestParseLoginUserEncryptedPasswordFlatSet exercises the flat-set AST
+// shape and asserts it compiles to the same struct as the hierarchical
+// shape (Codex M-3, dual-AST pin). Uses ParseSetCommand + SetPath, never
+// NewParser, per the project's set-syntax testing rule.
+func TestParseLoginUserEncryptedPasswordFlatSet(t *testing.T) {
+	cmds := []string{
+		"set system login user op class operator",
+		`set system login user op authentication encrypted-password "$6$salt$hash"`,
+		`set system login user op authentication ssh-ed25519 "ssh-ed25519 AAAA op@host"`,
+	}
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.System.Login == nil || len(cfg.System.Login.Users) != 1 {
+		t.Fatalf("expected 1 user, got %+v", cfg.System.Login)
+	}
+	u := cfg.System.Login.Users[0]
+	if u.Name != "op" || u.Class != "operator" {
+		t.Errorf("user = %q/%q", u.Name, u.Class)
+	}
+	if u.EncryptedPassword != "$6$salt$hash" {
+		t.Errorf("flat-set EncryptedPassword = %q, want %q", u.EncryptedPassword, "$6$salt$hash")
+	}
+	if len(u.SSHKeys) != 1 || u.SSHKeys[0] != "ssh-ed25519 AAAA op@host" {
+		t.Errorf("SSHKeys = %v", u.SSHKeys)
+	}
+}
+
+// TestLoginUserEncryptedPasswordSchemaGate proves the typed-leaf gate
+// hard-rejects a plaintext per-user encrypted-password at commit-check and
+// accepts a valid hash (#1944 §5.6 / §7.4), including the root-auth E1
+// parity (lock sentinel "*" accepted for root).
+func TestLoginUserEncryptedPasswordSchemaGate(t *testing.T) {
+	mustTree := func(t *testing.T, cmds ...string) *ConfigTree {
+		t.Helper()
+		tree := &ConfigTree{}
+		for _, cmd := range cmds {
+			path, err := ParseSetCommand(cmd)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath(%q): %v", cmd, err)
+			}
+		}
+		return tree
+	}
+
+	// Plaintext per-user → reject.
+	bad := mustTree(t, `set system login user op authentication encrypted-password "letmein"`)
+	if err := SchemaValidate(bad, nil); err == nil {
+		t.Error("SchemaValidate accepted plaintext per-user encrypted-password, want reject")
+	} else if !strings.Contains(err.Error(), "plaintext") {
+		t.Errorf("expected plaintext rejection, got %v", err)
+	}
+
+	// Valid hash per-user → accept.
+	good := mustTree(t, `set system login user op authentication encrypted-password "$6$salt$hash"`)
+	if err := SchemaValidate(good, nil); err != nil {
+		t.Errorf("SchemaValidate rejected a valid per-user hash: %v", err)
+	}
+
+	// Root-auth plaintext (E1 shared validator) → reject.
+	rootBad := mustTree(t, `set system root-authentication encrypted-password "letmein"`)
+	if err := SchemaValidate(rootBad, nil); err == nil {
+		t.Error("SchemaValidate accepted plaintext root encrypted-password, want reject")
+	}
+
+	// Root-auth lock sentinel "*" → accept (the only way to lock root).
+	rootLock := mustTree(t, `set system root-authentication encrypted-password "*"`)
+	if err := SchemaValidate(rootLock, nil); err != nil {
+		t.Errorf("SchemaValidate rejected root lock sentinel: %v", err)
+	}
+}
+
+// TestLoginUserNoAuthMethodWarning covers the §5.8 commit warning for a
+// user with no usable authentication method (no keys, no usable password).
+func TestLoginUserNoAuthMethodWarning(t *testing.T) {
+	cases := []struct {
+		name      string
+		user      *LoginUser
+		wantWarn  bool
+	}{
+		{"no auth at all", &LoginUser{Name: "op"}, true},
+		{"lock sentinel only", &LoginUser{Name: "op", EncryptedPassword: "!"}, true},
+		{"usable password", &LoginUser{Name: "op", EncryptedPassword: "$6$salt$hash"}, false},
+		{"ssh key only", &LoginUser{Name: "op", SSHKeys: []string{"ssh-ed25519 AAAA"}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{}
+			cfg.System.Login = &LoginConfig{Users: []*LoginUser{tc.user}}
+			warns := ValidateConfig(cfg)
+			found := false
+			for _, w := range warns {
+				if strings.Contains(w, "no usable authentication method") {
+					found = true
+				}
+			}
+			if found != tc.wantWarn {
+				t.Errorf("warning present = %v, want %v (warns: %v)", found, tc.wantWarn, warns)
+			}
+		})
+	}
+}

--- a/pkg/config/login_password_test.go
+++ b/pkg/config/login_password_test.go
@@ -185,6 +185,14 @@ func TestLoginUserNoAuthMethodWarning(t *testing.T) {
 	}{
 		{"no auth at all", &LoginUser{Name: "op"}, true},
 		{"lock sentinel only", &LoginUser{Name: "op", EncryptedPassword: "!"}, true},
+		{"double-bang sentinel only", &LoginUser{Name: "op", EncryptedPassword: "!!"}, true},
+		{"star sentinel only", &LoginUser{Name: "op", EncryptedPassword: "*"}, true},
+		// locked-but-restorable hash: cannot password-login until
+		// unlocked, so it is NOT a usable auth method (Codex r1 Low).
+		{"locked-restorable hash no ssh", &LoginUser{Name: "op", EncryptedPassword: "!$6$salt$hash"}, true},
+		{"double-bang restorable hash no ssh", &LoginUser{Name: "op", EncryptedPassword: "!!$6$salt$hash"}, true},
+		// locked-restorable hash + ssh key: ssh path is usable, no warning.
+		{"locked-restorable hash with ssh", &LoginUser{Name: "op", EncryptedPassword: "!$6$salt$hash", SSHKeys: []string{"ssh-ed25519 AAAA"}}, false},
 		{"usable password", &LoginUser{Name: "op", EncryptedPassword: "$6$salt$hash"}, false},
 		{"ssh key only", &LoginUser{Name: "op", SSHKeys: []string{"ssh-ed25519 AAAA"}}, false},
 	}

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -317,7 +317,7 @@ func TestSystemConfigRootAuthAndArchival(t *testing.T) {
 	input := `
 system {
     root-authentication {
-        encrypted-password "$6$abc123";
+        encrypted-password "$6$saltsalt$abc123def456";
         ssh-ed25519 "ssh-ed25519 AAAA... user@host";
         ssh-rsa "ssh-rsa AAAA... user@host";
     }
@@ -355,8 +355,8 @@ system {
 	if ra == nil {
 		t.Fatal("root-authentication is nil")
 	}
-	if ra.EncryptedPassword != "$6$abc123" {
-		t.Errorf("encrypted-password = %q, want %q", ra.EncryptedPassword, "$6$abc123")
+	if ra.EncryptedPassword != "$6$saltsalt$abc123def456" {
+		t.Errorf("encrypted-password = %q, want %q", ra.EncryptedPassword, "$6$saltsalt$abc123def456")
 	}
 	if len(ra.SSHKeys) != 2 {
 		t.Fatalf("ssh keys count = %d, want 2", len(ra.SSHKeys))
@@ -724,7 +724,7 @@ system {
 }
 
 func TestSystemConfigSetSyntax(t *testing.T) {
-	cmds := []string{"set system root-authentication encrypted-password \"$6$abc\"", "set system root-authentication ssh-ed25519 \"ssh-ed25519 AAAA\"", "set system master-password pseudorandom-function juniper-prf1", "set system license autoupdate url https://example.com/keys", "set system processes utmd disable", "set system services web-management https system-generated-certificate", "set system services web-management https interface fxp0.0", "set system syslog user * any emergency", "set system syslog host 10.0.0.1 any any", "set system syslog host 10.0.0.1 daemon info"}
+	cmds := []string{"set system root-authentication encrypted-password \"$6$abcsalt$hashhash\"", "set system root-authentication ssh-ed25519 \"ssh-ed25519 AAAA\"", "set system master-password pseudorandom-function juniper-prf1", "set system license autoupdate url https://example.com/keys", "set system processes utmd disable", "set system services web-management https system-generated-certificate", "set system services web-management https interface fxp0.0", "set system syslog user * any emergency", "set system syslog host 10.0.0.1 any any", "set system syslog host 10.0.0.1 daemon info"}
 	tree := &ConfigTree{}
 	for _, cmd := range cmds {
 		path, err := ParseSetCommand(cmd)
@@ -742,7 +742,7 @@ func TestSystemConfigSetSyntax(t *testing.T) {
 	if cfg.System.RootAuthentication == nil {
 		t.Fatal("root-authentication is nil")
 	}
-	if cfg.System.RootAuthentication.EncryptedPassword != "$6$abc" {
+	if cfg.System.RootAuthentication.EncryptedPassword != "$6$abcsalt$hashhash" {
 		t.Errorf("encrypted-password = %q", cfg.System.RootAuthentication.EncryptedPassword)
 	}
 	if len(cfg.System.RootAuthentication.SSHKeys) != 1 {

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -29,10 +29,14 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 		"destination": {desc: "Destination network", args: 1, placeholder: "<network>", children: nil},
 	}},
 	"root-authentication": {desc: "Root authentication", children: map[string]*schemaNode{
-		"encrypted-password": {desc: "Encrypted password", args: 1, placeholder: "<password>", children: nil},
-		"ssh-ed25519":        {desc: "SSH ED25519 public key", args: 1, placeholder: "<key>", children: nil},
-		"ssh-rsa":            {desc: "SSH RSA public key", args: 1, placeholder: "<key>", children: nil},
-		"ssh-dsa":            {desc: "SSH DSA public key", args: 1, placeholder: "<key>", children: nil},
+		// #1944 E1: share ValidateCryptHash with per-user
+		// authentication so root's identical plaintext footgun is
+		// closed (one validator, one error message).
+		"encrypted-password": {desc: "Encrypted password", args: 1, placeholder: "<crypt-hash>",
+			valueType: ValueCryptHash, validator: ValidateCryptHash, children: nil},
+		"ssh-ed25519": {desc: "SSH ED25519 public key", args: 1, placeholder: "<key>", children: nil},
+		"ssh-rsa":     {desc: "SSH RSA public key", args: 1, placeholder: "<key>", children: nil},
+		"ssh-dsa":     {desc: "SSH DSA public key", args: 1, placeholder: "<key>", children: nil},
 	}},
 	"archival": {desc: "Configuration archival", children: map[string]*schemaNode{
 		"configuration": {desc: "Configuration archival", children: map[string]*schemaNode{
@@ -65,9 +69,18 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 	}},
 	"login": {desc: "Login configuration", children: map[string]*schemaNode{
 		"user": {desc: "User name", args: 1, placeholder: "<username>", children: map[string]*schemaNode{
-			"uid":            {desc: "User ID", args: 1, placeholder: "<uid>", children: nil},
-			"class":          {desc: "Login class", args: 1, placeholder: "<class>", children: nil},
-			"authentication": {desc: "Authentication methods", children: nil},
+			"uid":   {desc: "User ID", args: 1, placeholder: "<uid>", children: nil},
+			"class": {desc: "Login class", args: 1, placeholder: "<class>", children: nil},
+			// #1944: close the schema asymmetry the compiler already
+			// half-implemented — give `authentication` a value-bearing
+			// children map (encrypted-password typed leaf + ssh-* keys).
+			"authentication": {desc: "Authentication methods", children: map[string]*schemaNode{
+				"encrypted-password": {desc: "Encrypted password", args: 1, placeholder: "<crypt-hash>",
+					valueType: ValueCryptHash, validator: ValidateCryptHash, children: nil},
+				"ssh-ed25519": {desc: "SSH ED25519 public key", args: 1, placeholder: "<key>", children: nil},
+				"ssh-rsa":     {desc: "SSH RSA public key", args: 1, placeholder: "<key>", children: nil},
+				"ssh-dsa":     {desc: "SSH DSA public key", args: 1, placeholder: "<key>", children: nil},
+			}},
 		}},
 	}},
 	"dataplane-type": {desc: "Dataplane type", args: 1, placeholder: "<type>", children: nil},

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -322,3 +322,113 @@ func ValidatePercent(min, max float64) LeafValidator {
 		return nil
 	}
 }
+
+// cryptModularIDs is the set of crypt(3) modular-hash identifiers xpf
+// accepts in an encrypted-password value. It is a permissive superset of
+// what Debian 13 glibc / libxcrypt actually verify against — the OS, not
+// this validator, is the final authority at PAM time, so we err toward
+// "clearly a hash" rather than a brittle per-id structural parse. yescrypt
+// ($y$) is the Debian 13 default; $6$ (sha512crypt) is universal; $2a$/
+// $2b$/$2y$ (bcrypt), $5$ (sha256crypt), $1$ (md5crypt), $7$ (scrypt) and
+// $gy$ (gost-yescrypt) are present via libxcrypt. #1944 §5.5.
+var cryptModularIDs = map[string]bool{
+	"1": true, "2a": true, "2b": true, "2y": true,
+	"5": true, "6": true, "7": true, "y": true, "gy": true,
+}
+
+// cryptFieldRune reports whether r is allowed inside a crypt(3) salt or
+// checksum field. The crypt-base64 alphabet is [./0-9A-Za-z]; modular
+// param fields (e.g. yescrypt $y$j9T$... or sha512crypt
+// $6$rounds=656000$...) additionally use '=' to introduce a parameter
+// value. We allow '=' here and reject ':' implicitly (not in the set) so
+// a value can never corrupt the `user:hash` chpasswd stdin line.
+func cryptFieldRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case r == '.' || r == '/' || r == '=':
+		return true
+	}
+	return false
+}
+
+// ValidateCryptHash accepts a crypt(3) modular password hash or an
+// explicit lock sentinel, and HARD-REJECTS plaintext. It is shared by
+// `system root-authentication encrypted-password` and `system login user
+// <name> authentication encrypted-password` (#1944, E1).
+//
+// Accepted:
+//   - A modular crypt hash: an optional leading "!" or "!!" (the
+//     locked-but-restorable form), then $<id>$<salt>$<checksum> where
+//     <id> ∈ cryptModularIDs, <salt> is non-empty (and may itself carry
+//     $-separated params such as rounds=N), and the FINAL $-field (the
+//     checksum) is non-empty. A trailing empty checksum ($6$salt$) is
+//     rejected — it writes a malformed shadow field PAM refuses.
+//   - A bare lock sentinel: "*", "!", or "!!". This is the intentional
+//     Unix way to lock an account and the only way to lock root via
+//     config (root is excluded from the per-user D2 auto-lock). Accepting
+//     a deliberate sentinel is NOT the plaintext footgun.
+//
+// Rejected: plaintext (no leading $-id, not a sentinel — the real
+// footgun), the empty string, an unknown $<id>$, an empty salt or empty
+// checksum, and any value carrying ':' (would corrupt chpasswd stdin) or
+// a control character. Legacy 13-char DES is deliberately NOT accepted so
+// that "reject plaintext" is an absolute guarantee (a 13-char alnum
+// password would otherwise pass).
+func ValidateCryptHash(raw string, _ *Config) error {
+	if raw == "" {
+		return fmt.Errorf("missing value (expected a crypt(3) hash, e.g. from `openssl passwd -6`)")
+	}
+	// Bare lock sentinels — deliberate, accepted as-is.
+	if raw == "*" || raw == "!" || raw == "!!" {
+		return nil
+	}
+	// Modular crypt hash, with an optional locked-but-restorable prefix.
+	body := raw
+	if strings.HasPrefix(body, "!!") {
+		body = body[2:]
+	} else if strings.HasPrefix(body, "!") {
+		body = body[1:]
+	}
+	if !strings.HasPrefix(body, "$") {
+		return fmt.Errorf("not an encrypted password hash (got %q) — plaintext is not "+
+			"allowed; generate a hash with `openssl passwd -6` or `mkpasswd -m sha512crypt`", raw)
+	}
+	// Split into $-separated fields: leading "$" yields an empty first
+	// element, so fields[0]=="" , fields[1]=<id>, fields[2..]=salt/params,
+	// fields[last]=checksum. Require at least id + salt + checksum.
+	fields := strings.Split(body, "$")
+	// fields[0] is the empty string before the first '$'.
+	if len(fields) < 4 {
+		return fmt.Errorf("malformed crypt hash %q — expected $<id>$<salt>$<checksum>", raw)
+	}
+	id := fields[1]
+	if !cryptModularIDs[id] {
+		return fmt.Errorf("unknown crypt hash id %q in %q — expected one of "+
+			"1, 2a, 2b, 2y, 5, 6, 7, y, gy", id, raw)
+	}
+	salt := fields[2]
+	checksum := fields[len(fields)-1]
+	if salt == "" {
+		return fmt.Errorf("empty salt in crypt hash %q", raw)
+	}
+	if checksum == "" {
+		return fmt.Errorf("empty checksum in crypt hash %q — a trailing $ "+
+			"with no checksum writes a malformed shadow field", raw)
+	}
+	// Every salt/param/checksum field must use only the crypt alphabet
+	// (which excludes ':' and whitespace), so the value can never corrupt
+	// the chpasswd `user:hash` stdin line or smuggle a separator.
+	for _, f := range fields[2:] {
+		for _, r := range f {
+			if !cryptFieldRune(r) {
+				return fmt.Errorf("invalid character %q in crypt hash %q", r, raw)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -420,10 +420,18 @@ func ValidateCryptHash(raw string, _ *Config) error {
 		return fmt.Errorf("empty checksum in crypt hash %q — a trailing $ "+
 			"with no checksum writes a malformed shadow field", raw)
 	}
-	// Every salt/param/checksum field must use only the crypt alphabet
-	// (which excludes ':' and whitespace), so the value can never corrupt
-	// the chpasswd `user:hash` stdin line or smuggle a separator.
+	// Every salt/param/checksum field must be NON-EMPTY and use only the
+	// crypt alphabet (which excludes ':' and whitespace), so the value can
+	// never corrupt the chpasswd `user:hash` stdin line or smuggle a
+	// separator. An empty intermediate field (e.g. "$6$salt$$hash", a
+	// doubled '$') is not a valid modular crypt hash — it would pass an
+	// alphabet-only check (no chars to reject) but fail at PAM, locking the
+	// operator out. Reject it at commit (Copilot #1944 review).
 	for _, f := range fields[2:] {
+		if f == "" {
+			return fmt.Errorf("empty field in crypt hash %q — a doubled "+
+				"'$' (e.g. $6$salt$$hash) is malformed", raw)
+		}
 		for _, r := range f {
 			if !cryptFieldRune(r) {
 				return fmt.Errorf("invalid character %q in crypt hash %q", r, raw)

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -300,10 +300,11 @@ type LoginConfig struct {
 
 // LoginUser defines a system user account.
 type LoginUser struct {
-	Name    string
-	UID     int
-	Class   string   // "super-user", "read-only", etc.
-	SSHKeys []string // authorized SSH public keys
+	Name              string
+	UID               int
+	Class             string   // "super-user", "read-only", etc.
+	EncryptedPassword string   // crypt(3) hash; applied via `chpasswd -e` (#1944)
+	SSHKeys           []string // authorized SSH public keys
 }
 
 // ServicesConfig holds service configuration (flow-monitoring, RPM, etc.).

--- a/pkg/config/value_type.go
+++ b/pkg/config/value_type.go
@@ -54,6 +54,12 @@ const (
 	// 10.0.1.10/24, 2001:db8::1/64). The accepted family is enforced by
 	// the leaf's validator (ValidateIPv4CIDR / ValidateIPv6CIDR).
 	ValueCIDR
+	// ValueCryptHash is a crypt(3) modular password hash (e.g.
+	// $6$salt$checksum) or an explicit lock sentinel (*, !, !!). The
+	// leaf's validator (ValidateCryptHash) rejects plaintext at commit
+	// check so an operator cannot paste cleartext into an
+	// encrypted-password directive. #1944.
+	ValueCryptHash
 )
 
 // Placeholder returns the angle-bracket placeholder name shown in `?`
@@ -80,6 +86,8 @@ func (v ValueType) Placeholder() string {
 		return "<address>"
 	case ValueCIDR:
 		return "<address/prefix-length>"
+	case ValueCryptHash:
+		return "<crypt-hash>"
 	}
 	return ""
 }

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -864,12 +864,27 @@ func (d *Daemon) applyRootAuth(cfg *config.Config) {
 
 	// Set root password from encrypted-password (crypt(3) hash)
 	if ra.EncryptedPassword != "" {
-		// Use chpasswd -e to set pre-hashed password
-		stdin := strings.NewReader("root:" + ra.EncryptedPassword + "\n")
-		if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
-			slog.Warn("failed to set root password", "err", err, "output", string(out))
+		// Defense-in-depth at the apply boundary, mirroring
+		// reconcileUserPassword (#1944 E1 shares ValidateCryptHash between
+		// root-auth and per-user auth). The strict operator-commit gate
+		// rejects plaintext/DES/empty-checksum/':' values, but the lenient
+		// Load/SyncApply ingress (pkg/configstore/store.go) only downgrades
+		// that to a warning, so a persisted/synced bad value would otherwise
+		// reach `chpasswd -e` verbatim — writing plaintext as root's password
+		// or corrupting the chpasswd stdin line via ':'. Re-check here and
+		// skip+warn so "plaintext never reaches /etc/shadow" holds for root
+		// on every path too, without bricking boot. SSH keys below are
+		// still applied regardless.
+		if err := config.ValidateCryptHash(ra.EncryptedPassword, nil); err != nil {
+			slog.Warn("refusing to apply invalid root encrypted-password to /etc/shadow", "err", err)
 		} else {
-			slog.Info("root encrypted-password applied")
+			// Use chpasswd -e to set pre-hashed password
+			stdin := strings.NewReader("root:" + ra.EncryptedPassword + "\n")
+			if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
+				slog.Warn("failed to set root password", "err", err, "output", string(out))
+			} else {
+				slog.Info("root encrypted-password applied")
+			}
 		}
 	}
 

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -680,7 +680,23 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 				continue
 			}
 			slog.Info("created system user", "user", user.Name, "uid", user.UID)
+			// Record provenance keyed by the account's actual UID so a
+			// later directive removal can lock THIS exact account (D2),
+			// while an out-of-band userdel+recreate with a different UID
+			// is left untouched (#1944 §5.4).
+			if uid, ok := lookupUID(user.Name); ok {
+				if err := markProvisioned(user.Name, uid); err != nil {
+					slog.Warn("failed to write provisioned-user marker",
+						"user", user.Name, "err", err)
+				}
+			}
 		}
+
+		// Apply / lock the login password (#1944). Mirrors applyRootAuth's
+		// `chpasswd -e` idiom; idempotent via a direct /etc/shadow read;
+		// D2-locks the account when the directive is removed but ONLY for
+		// the exact xpf-provisioned account (UID-keyed marker).
+		d.reconcileUserPassword(user)
 
 		// Grant sudo for super-user class
 		if user.Class == "super-user" {
@@ -718,6 +734,57 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 				}
 				slog.Info("SSH keys updated", "user", user.Name, "keys", len(user.SSHKeys))
 			}
+		}
+	}
+}
+
+// reconcileUserPassword applies, leaves, or locks a login user's OS
+// password per the declarative #1944 lifecycle. It runs inside
+// applySystemLogin (under the apply lock, so there is no marker/shadow
+// race) and never touches root (excluded by the applySystemLogin loop).
+//
+//   - encrypted-password set → write it via `chpasswd -e` unless the
+//     on-disk shadow hash already equals it (idempotent); a successful
+//     apply (re)records the UID-keyed provenance marker.
+//   - encrypted-password absent → LOCK the account (Path D2) so removing
+//     the directive disables password login instead of orphaning a live
+//     credential — but only for the exact xpf-provisioned account (marker
+//     UID matches the current UID) and never on a shadow read error.
+func (d *Daemon) reconcileUserPassword(user *config.LoginUser) {
+	desired := user.EncryptedPassword
+	curUID, uidOK := lookupUID(user.Name)
+	cur, ok := currentShadowHash(user.Name)
+
+	switch passwordAction(cur, ok, desired) {
+	case pwApply:
+		stdin := strings.NewReader(user.Name + ":" + desired + "\n")
+		if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
+			slog.Warn("failed to set user password",
+				"user", user.Name, "err", err, "output", strings.TrimSpace(string(out)))
+		} else {
+			// xpf now manages this exact account's password — mark it so a
+			// later directive removal locks it (covers a pre-existing or
+			// marker-wiped account, #1944 §5.4).
+			if uidOK {
+				if err := markProvisioned(user.Name, curUID); err != nil {
+					slog.Warn("failed to write provisioned-user marker",
+						"user", user.Name, "err", err)
+				}
+			}
+			slog.Info("user encrypted-password applied", "user", user.Name)
+		}
+	case pwLock:
+		// Only lock the exact account xpf provisioned (UID-keyed marker).
+		if !uidOK || !xpfProvisioned(user.Name, curUID) {
+			break
+		}
+		stdin := strings.NewReader(user.Name + ":!\n")
+		if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
+			slog.Warn("failed to lock user password",
+				"user", user.Name, "err", err, "output", strings.TrimSpace(string(out)))
+		} else {
+			slog.Info("user password locked (no encrypted-password in config)",
+				"user", user.Name)
 		}
 	}
 }

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -757,6 +757,24 @@ func (d *Daemon) reconcileUserPassword(user *config.LoginUser) {
 
 	switch passwordAction(cur, ok, desired) {
 	case pwApply:
+		// Defense-in-depth: re-validate the hash at the apply boundary
+		// before it reaches /etc/shadow. The strict operator commit gate
+		// (config.SchemaValidate → ValidateCryptHash) already rejects
+		// plaintext/DES/empty-checksum/':' values, BUT the lenient
+		// Load/SyncApply ingress (pkg/configstore/store.go
+		// compileTreeLenient, #1319 PR 2) only DOWNGRADES that violation
+		// to a warning so an older-binary persisted config or a synced
+		// peer value cannot brick boot. Without this guard, such a value
+		// would still be written to /etc/shadow verbatim — a plaintext
+		// password or a chpasswd-stdin-corrupting ':' (Codex #1944 r1
+		// High #2). Re-checking here makes "plaintext never reaches
+		// /etc/shadow" hold on EVERY path, while still not bricking boot
+		// (we skip+warn, leaving the existing shadow field untouched).
+		if err := config.ValidateCryptHash(desired, nil); err != nil {
+			slog.Warn("refusing to apply invalid login encrypted-password to /etc/shadow",
+				"user", user.Name, "err", err)
+			break
+		}
 		stdin := strings.NewReader(user.Name + ":" + desired + "\n")
 		if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
 			slog.Warn("failed to set user password",

--- a/pkg/daemon/login_password.go
+++ b/pkg/daemon/login_password.go
@@ -1,0 +1,182 @@
+// Package daemon implements the xpf daemon lifecycle.
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// login_password.go implements the `system login user <name> authentication
+// encrypted-password` apply + declarative-reconciliation lifecycle (#1944).
+//
+// The OS-account password for a configured non-root user must reach
+// /etc/shadow so the operator can log in on the serial console (SSH has the
+// authorized_keys path; the console has nothing without a password). This
+// mirrors applyRootAuth's `chpasswd -e` idiom, adds idempotency by reading
+// /etc/shadow directly, and — when the directive is REMOVED from config —
+// locks the account (Path D2) instead of orphaning a live credential, but
+// ONLY for accounts xpf actually provisioned, identified by a UID-keyed
+// provenance marker.
+
+// pwAction is the decision a pure helper makes about whether to (re)apply,
+// lock, or leave a user's password alone on a config apply.
+type pwAction int
+
+const (
+	pwNoop  pwAction = iota // leave /etc/shadow as-is
+	pwApply                 // write `desired` via chpasswd -e
+	pwLock                  // lock the account via chpasswd -e (<user>:!)
+)
+
+// provisionedUsersDir holds one marker file per xpf-provisioned account.
+// The marker's CONTENT is the numeric UID of the account at the time xpf
+// last wrote its password (or created it). Keying provenance by UID (not
+// name alone) lets removing the encrypted-password directive lock the SAME
+// account (leave-then-rejoin: UID unchanged → lock fires) while leaving an
+// out-of-band userdel+recreate alone (new UID → marker mismatch → skip),
+// with no separate garbage-collection pass. /var/lib/xpf is persistent (it
+// holds the config DB + archive). #1944 §5.4.
+var provisionedUsersDir = "/var/lib/xpf/provisioned-users"
+
+// shadowPath and passwdPath are the OS account databases the password
+// reconciler reads directly. They are package vars only so tests can
+// inject sample files; production never overrides them.
+var (
+	shadowPath = "/etc/shadow"
+	passwdPath = "/etc/passwd"
+)
+
+// passwordAction is PURE and table-tested. It is the central safety
+// invariant of #1944:
+//   - Fail-OPEN toward applying a real password: on any shadow read error /
+//     missing entry / mismatch, (re)apply, so a first commit never silently
+//     skips the password.
+//   - Fail-CLOSED (noop) in the lock branch on a read error, so a transient
+//     /etc/shadow read failure can NEVER lock out an operator.
+//
+// cur is the current shadow password field; ok is whether it was read
+// successfully; desired is the configured encrypted-password ("" when the
+// directive is absent).
+func passwordAction(cur string, ok bool, desired string) pwAction {
+	if desired != "" {
+		if !ok || cur != desired {
+			return pwApply // apply on read-fail / miss / mismatch (fail-open)
+		}
+		return pwNoop
+	}
+	// desired == "": Path D2 declarative lock.
+	if !ok {
+		return pwNoop // never lock on a read error
+	}
+	if isLockedShadow(cur) {
+		return pwNoop // already locked
+	}
+	return pwLock // empty (passwordless) OR a usable hash → lock
+}
+
+// isLockedShadow reports whether a /etc/shadow password field is in a
+// locked state. A bare "*" or any field beginning with "!" ("!", "!!",
+// "!$6$...") is locked. An EMPTY field is passwordless (`passwd -d`) — the
+// MOST permissive state, NOT locked — so D2 must lock it. #1944 §5.4.
+func isLockedShadow(s string) bool {
+	return s == "*" || strings.HasPrefix(s, "!")
+}
+
+// currentShadowHash reads /etc/shadow DIRECTLY (the daemon runs as root) and
+// returns the password field (field 2) for name, plus ok. It returns
+// ("", false) on any read/parse error or if the user is absent. A direct
+// read is used in preference to `getent shadow`, which shells out and is
+// subject to nscd/NSS caching → stale reads. #1944 §5.4.
+func currentShadowHash(name string) (string, bool) {
+	data, err := os.ReadFile(shadowPath)
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, ":", 3)
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[0] == name {
+			return fields[1], true
+		}
+	}
+	return "", false
+}
+
+// lookupUID returns the numeric UID for name by parsing /etc/passwd
+// directly (cgo-free, consistent with currentShadowHash). Returns
+// (uid, true) on success, (0, false) if absent or unparseable.
+func lookupUID(name string) (int, bool) {
+	data, err := os.ReadFile(passwdPath)
+	if err != nil {
+		return 0, false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, ":")
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[0] == name {
+			uid, err := strconv.Atoi(fields[2])
+			if err != nil {
+				return 0, false
+			}
+			return uid, true
+		}
+	}
+	return 0, false
+}
+
+// markerPath returns the provenance marker file path for name. names are
+// validated OS usernames here (created via useradd), but Clean+Base the
+// name defensively so a marker can never escape the directory.
+func markerPath(name string) string {
+	return filepath.Join(provisionedUsersDir, filepath.Base(filepath.Clean(name)))
+}
+
+// markProvisioned records that xpf manages this exact account's password by
+// writing the account's current UID into the per-user marker file. Called
+// on a successful useradd AND on a successful pwApply, so that once xpf has
+// written a password (even to a pre-existing or marker-wiped account),
+// removing the directive will lock it. Best-effort: a marker write failure
+// is logged by the caller, not fatal. #1944 §5.4.
+func markProvisioned(name string, uid int) error {
+	if err := os.MkdirAll(provisionedUsersDir, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(markerPath(name), []byte(strconv.Itoa(uid)), 0o600)
+}
+
+// xpfProvisioned reports whether xpf manages name's password for the
+// account that currently has UID curUID. It returns true ONLY if the marker
+// exists AND its recorded UID equals curUID. A marker whose UID no longer
+// matches (account deleted/recreated out of band with a different UID) is
+// opportunistically removed — no separate GC pass — and reports false, so a
+// pwLock decision never touches an out-of-band account. #1944 §5.4.
+func xpfProvisioned(name string, curUID int) bool {
+	data, err := os.ReadFile(markerPath(name))
+	if err != nil {
+		return false
+	}
+	recorded, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		// Corrupt marker — treat as not-ours and clean it up.
+		_ = os.Remove(markerPath(name))
+		return false
+	}
+	if recorded != curUID {
+		// Stale marker for a different (recreated) account: clean inline.
+		_ = os.Remove(markerPath(name))
+		return false
+	}
+	return true
+}

--- a/pkg/daemon/login_password_functional_test.go
+++ b/pkg/daemon/login_password_functional_test.go
@@ -1,0 +1,118 @@
+//go:build functional1944
+
+// This functional test proves the #1944 encrypted-password lifecycle
+// against a REAL /etc/shadow + chpasswd. It is build-tagged so it never
+// runs in the normal `go test ./...` gate; run it as root inside a
+// throwaway container:
+//
+//	go test -tags functional1944 -run TestFunctional1944 -v ./pkg/daemon/
+//
+// It exercises the actual production code paths: passwordAction +
+// currentShadowHash + chpasswd -e (apply, idempotent skip, D2 lock) and
+// the UID-keyed provenance marker.
+package daemon
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func TestFunctional1944(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("must run as root against a real /etc/shadow")
+	}
+	d := &Daemon{}
+	const name = "op1944"
+	// A known $6$ hash for the password "test123".
+	const hash = "$6$xpf1944salt$s8d7fYE06wZEyLJfvxc/JummvisDB5xVgxwC/uULzXz0a25H/ywrHJM4m6XKDJ2nEyW58IhFaXabC3PrR689K."
+
+	t.Cleanup(func() {
+		runCommandTimeout("userdel", "-r", name)
+		os.Remove(markerPath(name))
+	})
+
+	// Build the user struct the daemon would compile from config.
+	user := &config.LoginUser{Name: name, Class: "operator", EncryptedPassword: hash}
+
+	// (a) Create the account the way applySystemLogin does, then apply.
+	if out, err := runCommandTimeout("useradd", "-m", "-s", "/bin/bash", name); err != nil {
+		t.Fatalf("useradd: %v / %s", err, out)
+	}
+	if uid, ok := lookupUID(name); ok {
+		if err := markProvisioned(name, uid); err != nil {
+			t.Fatalf("markProvisioned: %v", err)
+		}
+	} else {
+		t.Fatal("lookupUID failed right after useradd")
+	}
+
+	d.reconcileUserPassword(user)
+
+	cur, ok := currentShadowHash(name)
+	if !ok || cur != hash {
+		t.Fatalf("(a) after apply: shadow field = %q ok=%v, want the hash", cur, ok)
+	}
+	t.Logf("(a) PASS: shadow field for %s equals the configured hash", name)
+
+	// Prove authentication actually works with the cleartext password via
+	// `su`. `su -c true` runs a PAM auth; pipe the password on stdin.
+	if !suAuthSucceeds(t, name, "test123") {
+		t.Fatal("(a) su auth with correct password failed")
+	}
+	t.Logf("(a) PASS: %s authenticates with the cleartext password", name)
+
+	// (d) Idempotent re-commit: same hash, must NOT churn. We assert the
+	// decision helper returns pwNoop given the now-on-disk hash.
+	if act := passwordAction(cur, ok, hash); act != pwNoop {
+		t.Fatalf("(d) idempotent re-commit decision = %v, want pwNoop", act)
+	}
+	t.Logf("(d) PASS: unchanged re-commit is a noop (no chpasswd churn)")
+
+	// (b) Remove the directive → D2 lock (not orphan). The marker UID
+	// matches the current account, so reconcileUserPassword must lock.
+	user.EncryptedPassword = ""
+	d.reconcileUserPassword(user)
+	cur, ok = currentShadowHash(name)
+	if !ok {
+		t.Fatal("(b) could not read shadow after lock")
+	}
+	if cur == hash {
+		t.Fatal("(b) FAIL: password is still the orphaned hash — D2 did not lock")
+	}
+	if !isLockedShadow(cur) {
+		t.Fatalf("(b) FAIL: shadow field %q is not a lock sentinel", cur)
+	}
+	t.Logf("(b) PASS: directive removal locked %s (shadow=%q), hash not orphaned", name, cur)
+
+	// Locked account must NOT authenticate with the old password.
+	if suAuthSucceeds(t, name, "test123") {
+		t.Fatal("(b) FAIL: locked account still authenticates")
+	}
+	t.Logf("(b) PASS: locked account rejects the old password")
+}
+
+// suAuthSucceeds runs `su <name> -c true` feeding password on stdin and
+// reports whether PAM authentication succeeded.
+func suAuthSucceeds(t *testing.T, name, password string) bool {
+	t.Helper()
+	// Use `su` with the target user; it prompts for the target's password
+	// when invoked by root? No — root's su does not prompt. Use `runuser`
+	// equivalence is not an auth test. Instead test PAM directly via
+	// `chage`-free path: spawn `su` as nobody is complex; rely on a small
+	// expect-free approach: `echo pw | su name -c true` only prompts when
+	// the caller is not root. So drop privileges via `setpriv` to a
+	// non-root uid first.
+	out, err := runCommandStdinTimeout(
+		strings.NewReader(password+"\n"),
+		"setpriv", "--reuid", "65534", "--regid", "65534", "--clear-groups",
+		"sh", "-c", "su "+name+" -c true",
+	)
+	if err != nil {
+		t.Logf("su auth attempt: err=%v out=%s", err, strings.TrimSpace(string(out)))
+		return false
+	}
+	return true
+}

--- a/pkg/daemon/login_password_test.go
+++ b/pkg/daemon/login_password_test.go
@@ -225,6 +225,44 @@ func TestReconcileApplyBoundaryRevalidatesHash(t *testing.T) {
 	}
 }
 
+// TestRootAuthApplyBoundaryRevalidatesHash mirrors the per-user apply-boundary
+// guard for `system root-authentication encrypted-password` (#1944 E1 shares
+// ValidateCryptHash with root-auth; Codex r2 High). The lenient Load/SyncApply
+// ingress can carry an invalid value, so applyRootAuth must re-validate before
+// `chpasswd -e` — skipping the exec for plaintext while still applying a valid
+// hash.
+func TestRootAuthApplyBoundaryRevalidatesHash(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "chpasswd-ran")
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\ntouch " + sentinel + "\ncat >/dev/null\n"
+	if err := os.WriteFile(filepath.Join(fakeBin, "chpasswd"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
+
+	d := &Daemon{}
+
+	// Invalid plaintext → no chpasswd.
+	cfgBad := &config.Config{}
+	cfgBad.System.RootAuthentication = &config.RootAuthConfig{EncryptedPassword: "password12345"}
+	d.applyRootAuth(cfgBad)
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Fatal("chpasswd ran for an INVALID root hash — apply-boundary guard missing")
+	}
+
+	// Valid hash → chpasswd runs.
+	cfgGood := &config.Config{}
+	cfgGood.System.RootAuthentication = &config.RootAuthConfig{EncryptedPassword: "$6$rootsalt$roothash"}
+	d.applyRootAuth(cfgGood)
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatal("chpasswd did NOT run for a VALID root hash — guard over-rejects")
+	}
+}
+
 // TestLookupUID exercises the direct /etc/passwd UID parse via the
 // injectable passwdPath.
 func TestLookupUID(t *testing.T) {

--- a/pkg/daemon/login_password_test.go
+++ b/pkg/daemon/login_password_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
 )
 
 // TestPasswordAction is the central #1944 safety-invariant table test
@@ -162,6 +164,64 @@ func TestCurrentShadowHashParse(t *testing.T) {
 	shadowPath = filepath.Join(dir, "does-not-exist")
 	if _, ok := currentShadowHash("op"); ok {
 		t.Error("currentShadowHash with missing file ok = true, want false")
+	}
+}
+
+// TestReconcileApplyBoundaryRevalidatesHash proves the defense-in-depth
+// re-validation in reconcileUserPassword (Codex #1944 r1 High #2): the
+// lenient Load/SyncApply ingress only downgrades a ValidateCryptHash
+// violation to a warning, so a persisted/synced plaintext value could
+// otherwise reach `chpasswd -e`. The apply boundary MUST re-check the hash
+// and skip the chpasswd exec for an invalid value, while still applying a
+// valid one. We detect whether chpasswd ran by shadowing it with a fake on
+// PATH that drops a sentinel file.
+func TestReconcileApplyBoundaryRevalidatesHash(t *testing.T) {
+	dir := t.TempDir()
+
+	// Temp /etc/shadow + /etc/passwd so passwordAction decides pwApply
+	// (op present with a DIFFERENT hash than desired) and lookupUID
+	// succeeds.
+	shadow := filepath.Join(dir, "shadow")
+	if err := os.WriteFile(shadow, []byte("op:$6$old$existinghash:19000:0:99999:7:::\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	passwd := filepath.Join(dir, "passwd")
+	if err := os.WriteFile(passwd, []byte("op:x:1001:1001:,,,:/home/op:/bin/bash\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oldShadow, oldPasswd, oldDir := shadowPath, passwdPath, provisionedUsersDir
+	shadowPath = shadow
+	passwdPath = passwd
+	provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+	t.Cleanup(func() { shadowPath, passwdPath, provisionedUsersDir = oldShadow, oldPasswd, oldDir })
+
+	// Fake chpasswd on PATH that records that it was invoked.
+	sentinel := filepath.Join(dir, "chpasswd-ran")
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\ntouch " + sentinel + "\ncat >/dev/null\n"
+	if err := os.WriteFile(filepath.Join(fakeBin, "chpasswd"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
+
+	d := &Daemon{}
+
+	// Invalid (plaintext) desired — guard must skip chpasswd entirely.
+	d.reconcileUserPassword(&config.LoginUser{Name: "op", EncryptedPassword: "password12345"})
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Fatal("chpasswd ran for an INVALID (plaintext) hash — apply-boundary guard missing")
+	}
+	if _, err := os.Stat(markerPath("op")); err == nil {
+		t.Fatal("provenance marker written despite skipped apply")
+	}
+
+	// Valid hash — chpasswd must run.
+	d.reconcileUserPassword(&config.LoginUser{Name: "op", EncryptedPassword: "$6$newsalt$newhash"})
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatal("chpasswd did NOT run for a VALID hash — guard over-rejects")
 	}
 }
 

--- a/pkg/daemon/login_password_test.go
+++ b/pkg/daemon/login_password_test.go
@@ -1,0 +1,192 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPasswordAction is the central #1944 safety-invariant table test
+// (§7.6): fail-OPEN toward applying a real password, fail-CLOSED (noop) on
+// a read error in the lock branch so a transient /etc/shadow read failure
+// can never lock out an operator.
+func TestPasswordAction(t *testing.T) {
+	cases := []struct {
+		name    string
+		cur     string
+		ok      bool
+		desired string
+		want    pwAction
+	}{
+		{"set, mismatch -> apply", "$6$old$x", true, "$6$new$y", pwApply},
+		{"set, match -> noop", "$6$same$z", true, "$6$same$z", pwNoop},
+		{"set, read-fail -> apply (fail-open)", "", false, "$6$new$y", pwApply},
+		{"set, missing entry -> apply", "", true, "$6$new$y", pwApply},
+		{"empty, passwordless -> lock", "", true, "", pwLock},
+		{"empty, usable hash -> lock", "$6$x$y", true, "", pwLock},
+		{"empty, locked ! -> noop", "!", true, "", pwNoop},
+		{"empty, locked !! -> noop", "!!", true, "", pwNoop},
+		{"empty, locked * -> noop", "*", true, "", pwNoop},
+		{"empty, locked !hash -> noop", "!$6$x$y", true, "", pwNoop},
+		{"empty, read-fail -> noop (no lockout)", "", false, "", pwNoop},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := passwordAction(tc.cur, tc.ok, tc.desired); got != tc.want {
+				t.Errorf("passwordAction(%q,%v,%q) = %v, want %v",
+					tc.cur, tc.ok, tc.desired, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsLockedShadow(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false}, // passwordless = most permissive, NOT locked
+		{"*", true},
+		{"!", true},
+		{"!!", true},
+		{"!$6$x$y", true},
+		{"$6$x$y", false},
+	}
+	for _, tc := range cases {
+		if got := isLockedShadow(tc.in); got != tc.want {
+			t.Errorf("isLockedShadow(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestProvenanceMarkerUIDKeyed covers the UID-keyed provenance marker that
+// dissolves the leave-rejoin vs out-of-band-recreate tension without any GC
+// pass (#1944 §5.4 / §7.9).
+func TestProvenanceMarkerUIDKeyed(t *testing.T) {
+	dir := t.TempDir()
+	old := provisionedUsersDir
+	provisionedUsersDir = filepath.Join(dir, "provisioned-users")
+	t.Cleanup(func() { provisionedUsersDir = old })
+
+	// No marker → not provisioned.
+	if xpfProvisioned("op", 1001) {
+		t.Error("xpfProvisioned with no marker = true, want false")
+	}
+
+	// markProvisioned then matching UID → provisioned.
+	if err := markProvisioned("op", 1001); err != nil {
+		t.Fatalf("markProvisioned: %v", err)
+	}
+	if !xpfProvisioned("op", 1001) {
+		t.Error("xpfProvisioned(op,1001) = false after mark, want true")
+	}
+
+	// Re-mark with same UID then UID mismatch (out-of-band recreate with a
+	// different UID) → not provisioned, and the stale marker is cleaned.
+	if err := markProvisioned("op", 1001); err != nil {
+		t.Fatalf("markProvisioned: %v", err)
+	}
+	if xpfProvisioned("op", 2002) {
+		t.Error("xpfProvisioned(op,2002) on UID mismatch = true, want false")
+	}
+	if _, err := os.Stat(markerPath("op")); !os.IsNotExist(err) {
+		t.Error("stale marker not removed on UID mismatch")
+	}
+
+	// Leave-then-rejoin same account: re-mark, same UID still matches.
+	if err := markProvisioned("op", 1001); err != nil {
+		t.Fatalf("markProvisioned: %v", err)
+	}
+	if !xpfProvisioned("op", 1001) {
+		t.Error("xpfProvisioned(op,1001) on rejoin = false, want true")
+	}
+
+	// Corrupt marker → not provisioned, cleaned.
+	if err := os.WriteFile(markerPath("op"), []byte("not-a-number"), 0o600); err != nil {
+		t.Fatalf("write corrupt marker: %v", err)
+	}
+	if xpfProvisioned("op", 1001) {
+		t.Error("xpfProvisioned with corrupt marker = true, want false")
+	}
+	if _, err := os.Stat(markerPath("op")); !os.IsNotExist(err) {
+		t.Error("corrupt marker not removed")
+	}
+}
+
+// TestMarkerPathContainment verifies a username can never escape the
+// provisioned-users directory (defensive Clean/Base).
+func TestMarkerPathContainment(t *testing.T) {
+	old := provisionedUsersDir
+	provisionedUsersDir = "/var/lib/xpf/provisioned-users"
+	t.Cleanup(func() { provisionedUsersDir = old })
+
+	for _, name := range []string{"../../etc/shadow", "/etc/passwd", "a/b/c"} {
+		got := markerPath(name)
+		if dir := filepath.Dir(got); dir != provisionedUsersDir {
+			t.Errorf("markerPath(%q) = %q escaped %q", name, got, provisionedUsersDir)
+		}
+	}
+}
+
+// TestCurrentShadowHashParse exercises the real currentShadowHash against a
+// sample /etc/shadow via the injectable shadowPath (#1944 §7.8). The
+// chpasswd exec itself is integration/live-only.
+func TestCurrentShadowHashParse(t *testing.T) {
+	dir := t.TempDir()
+	shadow := filepath.Join(dir, "shadow")
+	content := "root:$6$rootsalt$roothash:19000:0:99999:7:::\n" +
+		"op:$6$opsalt$ophash:19000:0:99999:7:::\n" +
+		"locked:!:19000:0:99999:7:::\n" +
+		"empty::19000:0:99999:7:::\n"
+	if err := os.WriteFile(shadow, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := shadowPath
+	shadowPath = shadow
+	t.Cleanup(func() { shadowPath = old })
+
+	if h, ok := currentShadowHash("op"); !ok || h != "$6$opsalt$ophash" {
+		t.Errorf("currentShadowHash(op) = %q,%v", h, ok)
+	}
+	if h, ok := currentShadowHash("locked"); !ok || h != "!" {
+		t.Errorf("currentShadowHash(locked) = %q,%v", h, ok)
+	}
+	if h, ok := currentShadowHash("empty"); !ok || h != "" {
+		t.Errorf("currentShadowHash(empty) = %q,%v", h, ok)
+	}
+	if _, ok := currentShadowHash("absent"); ok {
+		t.Error("currentShadowHash(absent) ok = true, want false")
+	}
+
+	// Read error → ("", false).
+	shadowPath = filepath.Join(dir, "does-not-exist")
+	if _, ok := currentShadowHash("op"); ok {
+		t.Error("currentShadowHash with missing file ok = true, want false")
+	}
+}
+
+// TestLookupUID exercises the direct /etc/passwd UID parse via the
+// injectable passwdPath.
+func TestLookupUID(t *testing.T) {
+	dir := t.TempDir()
+	passwd := filepath.Join(dir, "passwd")
+	content := "root:x:0:0:root:/root:/bin/bash\n" +
+		"op:x:1001:1001:,,,:/home/op:/bin/bash\n" +
+		"bad:x:notanumber:1002::/home/bad:/bin/bash\n"
+	if err := os.WriteFile(passwd, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := passwdPath
+	passwdPath = passwd
+	t.Cleanup(func() { passwdPath = old })
+
+	if uid, ok := lookupUID("op"); !ok || uid != 1001 {
+		t.Errorf("lookupUID(op) = %d,%v, want 1001,true", uid, ok)
+	}
+	if _, ok := lookupUID("absent"); ok {
+		t.Error("lookupUID(absent) ok = true, want false")
+	}
+	if _, ok := lookupUID("bad"); ok {
+		t.Error("lookupUID(bad) ok = true, want false (unparseable uid)")
+	}
+}


### PR DESCRIPTION
Closes #1944

## Problem
`system login user <name>` carried no password — only root got one
(`root-authentication encrypted-password` → `/etc/shadow` via
`chpasswd -e`). A non-root operator account created by xpf has a locked
shadow field, so on the **serial console** (no SSH-key path) it cannot
log in at all.

## Change (converged r5 plan — `docs/research/1944-login-user-password/plan.md`)
- **A1 apply**: parse `encrypted-password` under `user … authentication`;
  apply to `/etc/shadow` via `runCommandStdinTimeout(stdin, "chpasswd",
  "-e")`, mirroring `applyRootAuth`.
- **C1/E1 validator** (`ValidateCryptHash`, shared by per-user AND
  root-auth): accepts modular crypt (`$1/$2a/$2b/$2y/$5/$6/$7/$y/$gy`,
  non-empty salt + non-empty final checksum, optional `!`/`!!` prefix)
  and bare lock sentinels (`*`/`!`/`!!`); **hard-rejects plaintext**.
  Legacy DES dropped so plaintext rejection is absolute. Runs through the
  #1319 typed-leaf gate: hard-fail at commit, warning on boot/peer-sync.
- **B1 idempotent**: pure `passwordAction` reads `/etc/shadow` directly;
  skips `chpasswd` when unchanged; fail-OPEN toward applying, empty
  shadow field = passwordless (not locked).
- **D2 lock-on-removal**: removing the directive LOCKS the account
  (`<user>:!`) instead of orphaning the hash, gated by a **UID-keyed**
  provenance marker (`/var/lib/xpf/provisioned-users/<name>`, content =
  UID) — leave-rejoin (same UID) locks; out-of-band recreate (new UID) is
  left untouched; no GC pass. Never root; fail-CLOSED on a shadow read
  error so a transient read can never lock out an operator.
- §5.8 commit warning for a login user with no usable auth method.
- Docs: `docs/system-login.md` (incl. hash-gen example), feature-gaps.

## Gates
- `go build ./...` clean; full `go test ./...` green; new tests stable
  over `-count=5`; `go vet` clean (two pre-existing daemon_flow.go
  copylock warnings are unrelated/untouched).
- Functional shadow proof (set→shadow+login, remove→locked-not-orphaned,
  plaintext/DES/empty-checksum rejected, idempotent no-churn) pending on
  the standalone test VM — see PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)