### PR TITLE
#1914: three-view union tunnel-endpoint collision gate (wildcard false-accept fix)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,24 @@
 # Action Log
 
+## 2026-06-17 — #1914 tunnel-endpoint collision gate three-view union (Path 1)
+
+- **Timestamp**: 2026-06-17
+- **Action**: Implement Path 1 for Defect A — close the wildcard
+  apply-groups false-accept in the #1873 tunnel-endpoint id collision
+  gate. Add the config-pure SSOT emitter `EmitTunnelEndpointNames`;
+  refactor `buildTunnelEndpointSnapshots` onto it; extend
+  `validateTunnelEndpointIDCollisionAST` to a three-view union (V1
+  pre-expansion presence union UNCHANGED + V2/V3 post-expansion node0/node1
+  emitted names via clone+ExpandGroupsWithVars+compileInterfaces+emitter,
+  recursion-free, pre-usedIDs, per-node expansion error → empty set).
+  Defect B is document-only (in-code contract on the gate). Add tests:
+  wildcard reject/lenient-warn/symmetric, View-1 byte-identity preserved,
+  Defect-B residual pinned, single-iface clean, non-fatal undefined peer
+  group, no-recursion, and emitter↔builder parity.
+- **File(s)**: pkg/config/tunnelemit.go (new), pkg/config/tunnelid.go,
+  pkg/config/tunnelid_test.go, pkg/dataplane/userspace/tunnels.go,
+  pkg/dataplane/userspace/tunnels_test.go
+
 ## 2026-06-17 — #1919 WireGuard removal address-prune (implement converged r3 plan)
 
 - **Timestamp**: 2026-06-17

--- a/docs/pr/1914-collision-gate/reviewer-ids.md
+++ b/docs/pr/1914-collision-gate/reviewer-ids.md
@@ -1,0 +1,29 @@
+# #1914 tunnel-endpoint-id collision gate — reviewer ledger
+
+PR: #1952  •  final rev: `e954ba4bd`  •  branch: `engineer/1914-collision-gate`
+
+## Quad-review verdicts (final rev e954ba4bd)
+
+| Reviewer | Task / ref | Verdict |
+|----------|-----------|---------|
+| Claude SMR | in-conversation (domain SMR: config-compiler + HA-symmetry + dataplane parity) | **MERGE-READY** |
+| Codex | `task-mqi3lk7p-lq319j` (session 019ed5bc-e8b7-7ae1-9f62-c2c248980f81) | **MERGE-READY** (read-only-sandbox caveat: could not run Go build/test itself; run clean inline) |
+| Antigravity | `adversarial-review-mqi3lwg2-r8wip9` | **MERGE-READY** (all 6 hostile checks confirmed) |
+| Copilot | review @ e954ba4bd | infra error ("Copilot encountered an error and was unable to review"); re-requested; no findings — merged on 3-of-4 clean + Copilot-infra exception |
+
+## Invariants verified (all three reviewers convergent)
+
+- **A Recursion-free**: gate called only from compiler.go:115/176; emitNodeExpandedTunnelNames → compileInterfaces + EmitTunnelEndpointNames never reach the gate.
+- **B HA cross-node symmetry (#1873)**: gate always computes View2(node0)+View3(node1) regardless of compiling node; pure fn of (tree, nodeID); no hostname/node-id/env read.
+- **C Parity**: buildTunnelEndpointSnapshots drives off config.EmitTunnelEndpointNames; pinned by TestEmitTunnelEndpointNamesMatchesBuilder (differential).
+- **D Monotonicity**: View 1 byte-identical to pre-#1914; Views 2/3 only add map keys → only add rejects. Pinned by TestTunnelEndpointIDView1PresenceUnionPreserved.
+- **E node1-undefined-group expansion**: non-fatal empty-set, no panic, View 1 rejects preserved.
+- **F StableTunnelEndpointID fold unchanged** (wire-adjacent, #1873). Pinned by TestStableTunnelEndpointIDHashFreeze.
+- **G Defect B (documented accept)**: presence-only View 1 phantom non-WG ref ~1/65535 false reject; mutually exclusive with the Defect-A fix; safe failure mode (commit reject + rename remediation). Pinned by TestTunnelEndpointIDDefectBIncompleteGREStillRejects.
+
+## Validation (run inline on e954ba4bd)
+
+- `go build ./...` clean; `go vet ./pkg/config/... ./pkg/dataplane/userspace/...` clean.
+- `go test ./...` full suite: pass (0 failures).
+- `TestTunnelEndpointID*` 5×: 0 flakes. `TestEmitTunnelEndpointNamesMatchesBuilder` 5×: 0 flakes.
+- Control-plane-only change (Go config compiler + Go snapshot builder; no Rust dataplane). No cluster smoke required; functional coverage is the new unit/differential/parity tests.

--- a/pkg/config/tunnelemit.go
+++ b/pkg/config/tunnelemit.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// TunnelEndpointName pairs the unit-qualified tunnel endpoint name the
+// dataplane snapshot builder would emit with the matching TunnelConfig.
+//
+// The Name is the CANONICAL "%s.%d" (or bare interface) ref keyed by the
+// builder's per-interface emission rules; the Tunnel is the same
+// *TunnelConfig the builder reads to populate the snapshot row. The
+// builder consumes the {Name, Tunnel} set, intersects it with the runtime
+// InterfaceSnapshot rows, and applies the usedIDs collision drop — none of
+// which this emitter does. The commit-time collision gate
+// (validateTunnelEndpointIDCollisionAST) uses only the Name field.
+type TunnelEndpointName struct {
+	Name   string
+	Tunnel *TunnelConfig
+}
+
+// EmitTunnelEndpointNames is the single source of truth for the set of
+// CONFIGURED tunnel endpoints the dataplane snapshot builder
+// (buildTunnelEndpointSnapshots) would emit from a typed, already-expanded
+// *Config. It is a pure function of the typed config:
+//
+//   - it does NOT consult runtime InterfaceSnapshot rows (those do not
+//     exist at commit time);
+//   - it does NOT apply the StableTunnelEndpointID usedIDs collision drop
+//     (the builder owns that fail-closed belt);
+//   - it applies the same non-WireGuard source/destination gate the
+//     builder's addEndpoint applies (drop a non-WG tunnel with empty
+//     Source or Destination);
+//   - it applies the same interface-level-WireGuard single-lowest-unit
+//     pick (#1910): one persistent TUN per interface-level WG tunnel, keyed
+//     by the lowest configured unit ref;
+//   - it formats every ref as the canonical "%s.%d" the builder formats
+//     from the int-keyed Units map (leading-zero / overflow / last-wins
+//     unit canonicalization is already resolved by compileInterfaces when
+//     it built the int-keyed map, so it is inherited for free).
+//
+// The result is sorted by Name for deterministic iteration. The collision
+// gate's per-node views (View 2 / View 3) feed an expanded candidate
+// through compileInterfaces into a throwaway InterfacesConfig and then
+// through this emitter, so the gate sees exactly the names the builder
+// would publish — without ever calling CompileConfig* (which would recurse
+// into the gate) and without consulting the post-usedIDs snapshot.
+//
+// buildTunnelEndpointSnapshots is refactored to source its configured-name
+// set from this emitter; a differential parity test
+// (TestEmitTunnelEndpointNamesMatchesBuilder) pins the two to one another
+// so the gate and the builder can never drift (#1910 r2-r6 drift class).
+func EmitTunnelEndpointNames(cfg *Config) []TunnelEndpointName {
+	if cfg == nil || len(cfg.Interfaces.Interfaces) == 0 {
+		return nil
+	}
+	ifaceNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		ifaceNames = append(ifaceNames, name)
+	}
+	sort.Strings(ifaceNames)
+
+	out := make([]TunnelEndpointName, 0)
+	add := func(name string, tunnel *TunnelConfig) {
+		if tunnel == nil {
+			return
+		}
+		// Mirror addEndpoint's non-WG source/destination gate: a
+		// non-WireGuard tunnel without both endpoints is never emitted.
+		// WireGuard carries its peer in WgEndpoint and needs no
+		// Source/Destination (#1432 S2a).
+		if tunnel.Mode != "wireguard" && (tunnel.Source == "" || tunnel.Destination == "") {
+			return
+		}
+		out = append(out, TunnelEndpointName{Name: name, Tunnel: tunnel})
+	}
+
+	for _, name := range ifaceNames {
+		iface := cfg.Interfaces.Interfaces[name]
+		if iface == nil {
+			continue
+		}
+		if iface.Tunnel != nil {
+			if len(iface.Units) == 0 {
+				add(name, iface.Tunnel)
+				continue
+			}
+			unitNums := make([]int, 0, len(iface.Units))
+			for unitNum := range iface.Units {
+				unitNums = append(unitNums, unitNum)
+			}
+			sort.Ints(unitNums)
+			if iface.Tunnel.Mode == "wireguard" {
+				// Interface-level WireGuard is ONE persistent TUN; the
+				// builder emits exactly one endpoint keyed by the lowest
+				// configured unit ref (#1910). Mirror that here.
+				add(fmt.Sprintf("%s.%d", name, unitNums[0]), iface.Tunnel)
+				continue
+			}
+			for _, unitNum := range unitNums {
+				add(fmt.Sprintf("%s.%d", name, unitNum), iface.Tunnel)
+			}
+			continue
+		}
+		if len(iface.Units) == 0 {
+			continue
+		}
+		unitNums := make([]int, 0, len(iface.Units))
+		for unitNum := range iface.Units {
+			unitNums = append(unitNums, unitNum)
+		}
+		sort.Ints(unitNums)
+		for _, unitNum := range unitNums {
+			unit := iface.Units[unitNum]
+			if unit == nil || unit.Tunnel == nil {
+				continue
+			}
+			add(fmt.Sprintf("%s.%d", name, unitNum), unit.Tunnel)
+		}
+	}
+	return out
+}

--- a/pkg/config/tunnelid.go
+++ b/pkg/config/tunnelid.go
@@ -143,16 +143,93 @@ func astTunnelModeWireguard(tunnelNode *Node) bool {
 	return false
 }
 
-// validateTunnelEndpointIDCollisionAST checks the UNION of tunnel
-// endpoint names across the main "interfaces" hierarchy AND every
-// "groups" block for StableTunnelEndpointID collisions (#1873 R-B).
+// emitNodeExpandedTunnelNames returns the concrete tunnel-endpoint names
+// the snapshot builder would emit after expanding the candidate tree for
+// chassis-cluster node nodeID. It is the #1914 post-expansion view (View 2
+// for node0, View 3 for node1) used by validateTunnelEndpointIDCollisionAST.
 //
-// The union (rather than the per-node effective config) keeps the
-// accept/reject decision identical on both chassis-cluster nodes: a
-// collision involving a `groups node0`-scoped tunnel must fail commit
-// on node1 too, or config-sync would split (originator accepts, peer
-// rejects). It runs on the PRE-expansion tree because ExpandGroups
-// removes the groups stanza.
+// It is RECURSION-FREE by construction: it clones the candidate, expands
+// groups for the node, runs the gate-free interfaces sub-compiler
+// (compileInterfaces — which does NOT call this collision gate) into a
+// throwaway InterfacesConfig, and feeds that typed config through the SSOT
+// emitter EmitTunnelEndpointNames. It NEVER calls CompileConfig* (which
+// would call the gate first and recurse) and NEVER consults the
+// post-usedIDs snapshot (the builder's collision drop has not run, so both
+// colliding refs are present).
+//
+// Per-node expansion or compile errors are NON-FATAL: the view contributes
+// the EMPTY set. A config that defines only `groups node0` and references
+// `${node}` legitimately has no `groups node1`, so expanding for node1
+// hits `undefined group "node1"`; that is a separate, already-handled
+// condition on the real per-node compile path (CompileConfig falls back to
+// node0 for an undefined ${node}), and the collision gate must not turn it
+// into a spurious commit failure. View 1's pre-expansion presence union
+// still covers any collision inside the un-expandable group, so dropping
+// the failed node's view loses no real coverage and keeps the verdict a
+// pure function of the candidate config (both nodes compute identical
+// error-to-empty-set handling).
+func emitNodeExpandedTunnelNames(tree *ConfigTree, nodeID int, out map[string]struct{}) {
+	clone := tree.Clone()
+	vars := map[string]string{"node": fmt.Sprintf("node%d", nodeID)}
+	if err := clone.ExpandGroupsWithVars(vars); err != nil {
+		return
+	}
+	ifacesNode := clone.FindChild("interfaces")
+	if ifacesNode == nil {
+		return
+	}
+	ifaces := InterfacesConfig{Interfaces: make(map[string]*InterfaceConfig)}
+	if err := compileInterfaces(ifacesNode, &ifaces); err != nil {
+		return
+	}
+	cfg := &Config{Interfaces: ifaces}
+	for _, ep := range EmitTunnelEndpointNames(cfg) {
+		out[ep.Name] = struct{}{}
+	}
+}
+
+// validateTunnelEndpointIDCollisionAST checks the UNION of tunnel
+// endpoint names across three views of the candidate config for
+// StableTunnelEndpointID collisions (#1873 R-B, #1914):
+//
+//	View 1 — the PRE-expansion presence union across the main
+//	  "interfaces" hierarchy AND every "groups" block (unchanged since
+//	  #1873). It runs on the pre-expansion tree because ExpandGroups
+//	  removes the groups stanza, and it keeps the accept/reject decision
+//	  identical on both chassis-cluster nodes: a collision involving a
+//	  `groups node0`-scoped tunnel must fail commit on node1 too, or
+//	  config-sync would split (originator accepts, peer rejects).
+//	View 2 — the concrete tunnel names the builder would emit after
+//	  expanding the candidate for node0 (emitNodeExpandedTunnelNames).
+//	View 3 — the same for node1.
+//
+// Views 2/3 (added in #1914) close Defect A: a wildcard apply-group
+// (`groups g interfaces <*> unit 0 tunnel mode wireguard`) registers only
+// the literal `<*>.0` in View 1, never the post-expansion concrete
+// `wg78.0` / `wg1408.0` that fold to the same id — so View 1 alone falsely
+// ACCEPTS a builder-emitted collision that the runtime usedIDs belt then
+// drops with a loud slog.Error. Views 2/3 expand the wildcard onto the
+// real applying interfaces, see both concrete refs, and reject at commit.
+// Because all three views are pure functions of the SAME candidate config
+// (View 2/3 both expand the shared candidate for a fixed node, computed on
+// BOTH nodes), the union stays a pure function of config — HA symmetry is
+// preserved. The union is monotone over View 1 (adding Views 2/3 only ADDS
+// rejects), so every reject View 1 produced today is preserved.
+//
+// DOCUMENTED LIMITATION (Defect B, #1914): View 1 registers a ref from
+// tunnel-node presence alone with NO source/destination check, while the
+// builder drops a non-WireGuard tunnel whose Source or Destination is empty
+// (tunnels.go addEndpoint). So a half-configured non-WG tunnel (e.g.
+// `gr-0/0/0 unit 0 tunnel mode gre` with no source/dest) registers a
+// phantom View-1 ref the builder never emits; if that phantom folds onto a
+// real emitted ref (≈1/65535 per pair) the commit is FALSELY REJECTED. This
+// is accepted, not fixed: View 1 MUST stay presence-only or the Defect-A
+// fix re-opens a false ACCEPT (a group can SUPPLY src/dst later, and an
+// un-applied nested-apply-groups group is never expanded by Views 2/3, so a
+// complete-only View 1 would under-register and miss a real cross-node
+// collision). Narrowing View 1 is mutually exclusive with the Defect-A fix;
+// the runtime usedIDs slog.Error belt and the printed "rename one
+// interface" remediation are the operator's recourse for the residual.
 //
 // Strict (commit / commit-check) returns an error; lenient (load /
 // peer-sync of an already-active config) returns a warning so an
@@ -161,6 +238,7 @@ func astTunnelModeWireguard(tunnelNode *Node) bool {
 // buildTunnelEndpointSnapshots).
 func validateTunnelEndpointIDCollisionAST(tree *ConfigTree, lenient bool) ([]string, error) {
 	names := make(map[string]struct{})
+	// View 1 — pre-expansion presence union (UNCHANGED, #1873).
 	collectTunnelEndpointNamesAST(tree.FindChild("interfaces"), names)
 	for _, child := range tree.Children {
 		if child.Name() != "groups" {
@@ -176,6 +254,12 @@ func validateTunnelEndpointIDCollisionAST(tree *ConfigTree, lenient bool) ([]str
 			collectTunnelEndpointNamesAST(group.FindChild("interfaces"), names)
 		}
 	}
+	// Views 2/3 — post-expansion emitted names for node0 and node1
+	// (#1914). Both computed on both nodes from the shared candidate, so
+	// the union stays HA-symmetric; per-node expansion errors contribute
+	// the empty set (non-fatal).
+	emitNodeExpandedTunnelNames(tree, 0, names)
+	emitNodeExpandedTunnelNames(tree, 1, names)
 	if len(names) < 2 {
 		return nil, nil
 	}

--- a/pkg/config/tunnelid_test.go
+++ b/pkg/config/tunnelid_test.go
@@ -255,3 +255,179 @@ func TestTunnelEndpointIDNoFalsePositive(t *testing.T) {
 		}
 	}
 }
+
+// #1914 Defect A: a WILDCARD apply-group splices `unit 0 tunnel mode
+// wireguard` onto the interfaces that reference it. The pre-expansion
+// View-1 collector hashes only the LITERAL group ref `<*>.0` (50477) — it
+// never sees the concrete post-expansion `wg78.0`/`wg1408.0`, both folding
+// to 824 — so View 1 alone FALSELY ACCEPTS a builder-emitted collision the
+// runtime usedIDs belt then drops with a loud slog.Error. The post-expansion
+// Views 2/3 expand the wildcard onto wg78 + wg1408, see both concrete refs,
+// and must REJECT the commit (strict path).
+func TestTunnelEndpointIDWildcardApplyGroupsCollisionRejected(t *testing.T) {
+	// Frozen-fold preconditions: the literal wildcard ref does NOT collide
+	// with the concrete refs, but the two concrete refs collide with each
+	// other (so only the post-expansion views can catch it).
+	if got := StableTunnelEndpointID("<*>.0"); got != 50477 {
+		t.Fatalf("precondition: <*>.0=%d, want 50477 (frozen fold)", got)
+	}
+	if a, b := StableTunnelEndpointID("wg78.0"), StableTunnelEndpointID("wg1408.0"); a != b || a != 824 {
+		t.Fatalf("precondition: wg78.0=%d wg1408.0=%d, want both 824 (frozen fold)", a, b)
+	}
+	tree := buildTree(t, []string{
+		"set groups wgtun interfaces <*> unit 0 tunnel mode wireguard",
+		"set interfaces wg78 apply-groups wgtun",
+		"set interfaces wg1408 unit 0 tunnel mode wireguard",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("CompileConfig accepted a wildcard-apply-groups builder-emitted collision (wg78.0 vs wg1408.0)")
+	}
+	for _, want := range []string{"wg78.0", "wg1408.0", "collision", "rename"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("collision error %q does not mention %q", err.Error(), want)
+		}
+	}
+}
+
+// #1914 Defect A lenient: the same wildcard-apply-groups collision must
+// WARN (not error) on the tolerant load/peer-sync path.
+func TestTunnelEndpointIDWildcardApplyGroupsCollisionLenientWarns(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set groups wgtun interfaces <*> unit 0 tunnel mode wireguard",
+		"set interfaces wg78 apply-groups wgtun",
+		"set interfaces wg1408 unit 0 tunnel mode wireguard",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected a wildcard-apply-groups collision: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "collision") && strings.Contains(w, "wg78.0") && strings.Contains(w, "wg1408.0") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile carried no wildcard-collision warning: %v", cfg.Warnings)
+	}
+}
+
+// #1914 Defect A symmetry: the wildcard-apply-groups collision must reject
+// IDENTICALLY under both per-node compiles, or config-sync would split.
+func TestTunnelEndpointIDWildcardApplyGroupsCollisionSymmetric(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set groups wgtun interfaces <*> unit 0 tunnel mode wireguard",
+		"set interfaces wg78 apply-groups wgtun",
+		"set interfaces wg1408 unit 0 tunnel mode wireguard",
+	})
+	if _, err := CompileConfigForNode(tree, 0); err == nil {
+		t.Fatalf("node0 compile accepted a wildcard-apply-groups collision")
+	}
+	if _, err := CompileConfigForNode(tree, 1); err == nil {
+		t.Fatalf("node1 compile accepted a wildcard-apply-groups collision")
+	}
+}
+
+// #1914 View-1 byte-identity / cross-node symmetry: the #1873 guarantee
+// that a collision hidden in a `groups node1` block (never applied on
+// node0's effective config) still rejects on BOTH nodes must survive the
+// addition of Views 2/3 — Views 2/3 never expand the un-applied group, so
+// only the UNCHANGED presence union (View 1) catches it. This is the
+// regression guard for "don't narrow View 1".
+func TestTunnelEndpointIDView1PresenceUnionPreserved(t *testing.T) {
+	tree := buildTree(t, []string{
+		// Collision hidden in an UN-APPLIED groups node1 block; node0
+		// never applies it (no apply-groups "${node}"). Views 2/3 expand
+		// to empty for this group, so only View 1's presence union can
+		// reject — proving View 1 was not narrowed.
+		"set groups node1 interfaces wg1408 unit 0 tunnel mode wireguard",
+		"set interfaces wg78 unit 0 tunnel mode wireguard",
+	})
+	if _, err := CompileConfigForNode(tree, 0); err == nil {
+		t.Fatalf("node0 compile accepted a collision hidden in un-applied groups node1 (View 1 was narrowed?)")
+	}
+	if _, err := CompileConfigForNode(tree, 1); err == nil {
+		t.Fatalf("node1 compile accepted a collision hidden in groups node1")
+	}
+}
+
+// #1914 Defect B (DOCUMENTED LIMITATION — pin CURRENT behavior): View 1
+// registers a non-WG tunnel ref from presence alone, with no src/dest
+// check, while the builder drops an incomplete non-WG tunnel. A
+// half-configured GRE whose unit ref folds onto a real emitted ref still
+// REJECTS — the accepted residual. This test pins the limitation so a
+// future reader knows it is intentional (Defect B is mutually exclusive
+// with the Defect-A fix), not a new bug. Frozen collision:
+// gr-0/0/0.0 == wg29715.0 == 44687.
+func TestTunnelEndpointIDDefectBIncompleteGREStillRejects(t *testing.T) {
+	if a, b := StableTunnelEndpointID("gr-0/0/0.0"), StableTunnelEndpointID("wg29715.0"); a != b || a != 44687 {
+		t.Fatalf("precondition: gr-0/0/0.0=%d wg29715.0=%d, want both 44687 (frozen fold)", a, b)
+	}
+	tree := buildTree(t, []string{
+		// Incomplete GRE: no source/dest. The builder drops it, but View 1
+		// registers it (presence-only). It folds onto the real wg29715.0.
+		"set interfaces gr-0/0/0 unit 0 tunnel mode gre",
+		"set interfaces wg29715 unit 0 tunnel mode wireguard",
+	})
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("Defect B residual changed: incomplete-GRE phantom no longer rejects (View 1 was narrowed?)")
+	}
+}
+
+// #1914 no false positive: a WG wildcard apply-group applied to a SINGLE
+// interface (no second colliding ref) must compile clean — Views 2/3 add
+// exactly one concrete ref, no collision.
+func TestTunnelEndpointIDWildcardApplyGroupsSingleInterfaceClean(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set groups wgtun interfaces <*> unit 0 tunnel mode wireguard",
+		"set interfaces wg78 apply-groups wgtun",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig rejected a single-interface wildcard WG group: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "tunnel endpoint id collision") {
+			t.Fatalf("unexpected collision warning: %q", w)
+		}
+	}
+}
+
+// #1914 non-fatal peer-group expansion: a config that defines only
+// `groups node0` and applies "${node}" has NO `groups node1`, so View 3
+// (node1 expansion) hits `undefined group "node1"`. That MUST be non-fatal
+// (View 3 contributes the empty set) and the config must COMMIT cleanly —
+// the gate must not turn a valid-on-the-local-node config into a spurious
+// failure.
+func TestTunnelEndpointIDNonFatalUndefinedPeerGroup(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set groups node0 interfaces wg0 unit 0 tunnel mode wireguard",
+		`set apply-groups "${node}"`,
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig (generic, node0 fallback) failed on undefined peer group: %v", err)
+	}
+	if _, err := CompileConfigForNode(tree, 0); err != nil {
+		t.Fatalf("node0 compile failed on a config with only groups node0: %v", err)
+	}
+}
+
+// #1914 no-recursion regression: the gate on a wildcard / multi-node config
+// must return in bounded time. If a future edit reintroduces a
+// CompileConfig* call from the gate it recurses to stack overflow; this
+// test guards the recursion-free invariant by simply requiring the gate to
+// terminate (a recursion would panic/hang well before this returns).
+func TestTunnelEndpointIDGateTerminatesNoRecursion(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set groups wgtun interfaces <*> unit 0 tunnel mode wireguard",
+		"set interfaces wg78 apply-groups wgtun",
+		"set interfaces wg1408 unit 0 tunnel mode wireguard",
+		"set groups node0 interfaces gr-0/0/0 unit 0 tunnel mode gre",
+		`set apply-groups "${node}"`,
+	})
+	// Direct gate call: must terminate (and reject the real wg collision).
+	if _, err := validateTunnelEndpointIDCollisionAST(tree, false); err == nil {
+		t.Fatalf("gate accepted a wildcard collision (or recursed before returning)")
+	}
+}

--- a/pkg/dataplane/userspace/tunnels.go
+++ b/pkg/dataplane/userspace/tunnels.go
@@ -35,11 +35,6 @@ func buildTunnelEndpointSnapshots(cfg *config.Config, interfaces []InterfaceSnap
 	if len(ifaceByName) == 0 {
 		return nil
 	}
-	names := make([]string, 0, len(cfg.Interfaces.Interfaces))
-	for name := range cfg.Interfaces.Interfaces {
-		names = append(names, name)
-	}
-	sort.Strings(names)
 	out := make([]TunnelEndpointSnapshot, 0)
 	// #1873: ids are content-derived (config.StableTunnelEndpointID of
 	// the unit-qualified interface name), NOT positional — adding or
@@ -58,6 +53,11 @@ func buildTunnelEndpointSnapshots(cfg *config.Config, interfaces []InterfaceSnap
 		// WireGuard endpoints carry the peer in WgEndpoint and need no
 		// Source/Destination (#1432 S2a); a WG endpoint configured with
 		// only WgEndpoint must not be dropped by the GRE source/dest gate.
+		// The non-WG source/dest gate and the interface-level-WG
+		// single-lowest-unit pick now live in the SSOT emitter
+		// (config.EmitTunnelEndpointNames), so addEndpoint trusts the
+		// emitter's filtering; the redundant guard is retained as a
+		// defense-in-depth no-op against future call paths.
 		isWireguard := tunnel.Mode == "wireguard"
 		if !isWireguard && (tunnel.Source == "" || tunnel.Destination == "") {
 			return
@@ -130,65 +130,18 @@ func buildTunnelEndpointSnapshots(cfg *config.Config, interfaces []InterfaceSnap
 		out = append(out, snap)
 		usedIDs[id] = ifName
 	}
-	for _, name := range names {
-		iface := cfg.Interfaces.Interfaces[name]
-		if iface == nil {
-			continue
-		}
-		if iface.Tunnel != nil {
-			if len(iface.Units) == 0 {
-				addEndpoint(name, iface.Tunnel)
-				continue
-			}
-			unitNums := make([]int, 0, len(iface.Units))
-			for unitNum := range iface.Units {
-				unitNums = append(unitNums, unitNum)
-			}
-			sort.Ints(unitNums)
-			if iface.Tunnel.Mode == "wireguard" {
-				// Interface-level WireGuard is ONE persistent TUN with
-				// ONE listen port shared by every unit (#1910 r2 Codex
-				// High): now that TunnelNameMap resolves every unit ref
-				// of an interface-level wg to the base device, per-unit
-				// emission would produce N live endpoints with the SAME
-				// ifindex + listen port — the Rust side overwrites
-				// tunnel_endpoint_by_ifindex with the later id and the
-				// second control thread tombstones on the duplicate UDP
-				// bind, so routes can select an engine whose control
-				// thread never came up. Emit exactly one endpoint,
-				// keyed by the LOWEST CONFIGURED unit ref — a pure
-				// function of config, never of runtime snapshot rows,
-				// so both HA nodes compute the same endpoint id from
-				// the same config (#1873) and the commit-time collision
-				// gate (collectTunnelEndpointNamesAST) can mirror the
-				// selection exactly. The common single-unit-0 shape
-				// keeps its existing stable id. Rows for every unit of
-				// an interface-level wg share one LinuxName/ifindex, so
-				// row presence is all-or-nothing: if the device is
-				// absent, addEndpoint drops the ref like it always did.
-				addEndpoint(fmt.Sprintf("%s.%d", name, unitNums[0]), iface.Tunnel)
-				continue
-			}
-			for _, unitNum := range unitNums {
-				addEndpoint(fmt.Sprintf("%s.%d", name, unitNum), iface.Tunnel)
-			}
-			continue
-		}
-		if len(iface.Units) == 0 {
-			continue
-		}
-		unitNums := make([]int, 0, len(iface.Units))
-		for unitNum := range iface.Units {
-			unitNums = append(unitNums, unitNum)
-		}
-		sort.Ints(unitNums)
-		for _, unitNum := range unitNums {
-			unit := iface.Units[unitNum]
-			if unit == nil || unit.Tunnel == nil {
-				continue
-			}
-			addEndpoint(fmt.Sprintf("%s.%d", name, unitNum), unit.Tunnel)
-		}
+	// #1914: the configured tunnel-endpoint NAME set (which refs the
+	// builder would emit, including the interface-level-WG
+	// single-lowest-unit pick and the non-WG source/dest gate) is owned by
+	// the SSOT emitter config.EmitTunnelEndpointNames. The builder then
+	// intersects with the runtime InterfaceSnapshot rows (addEndpoint's
+	// ifaceByName lookup) and applies the usedIDs collision drop. The
+	// commit-time collision gate (validateTunnelEndpointIDCollisionAST)
+	// drives its per-node views through the same emitter, so the gate and
+	// the builder can never drift (parity-pinned by
+	// TestEmitTunnelEndpointNamesMatchesBuilder).
+	for _, ep := range config.EmitTunnelEndpointNames(cfg) {
+		addEndpoint(ep.Name, ep.Tunnel)
 	}
 	return out
 }

--- a/pkg/dataplane/userspace/tunnels_test.go
+++ b/pkg/dataplane/userspace/tunnels_test.go
@@ -268,3 +268,122 @@ func TestBuildTunnelEndpointSnapshotsDropsLaterSortingCollider(t *testing.T) {
 		t.Fatalf("kept id %d, want %d", endpoints[0].ID, config.StableTunnelEndpointID("wg1408.0"))
 	}
 }
+
+// #1914 SSOT parity: the builder's configured-name set MUST equal the
+// emitter's Name set (before runtime-iface intersect + usedIDs). This pins
+// buildTunnelEndpointSnapshots to config.EmitTunnelEndpointNames so the
+// commit-time collision gate (which drives Views 2/3 through the emitter)
+// and the dataplane builder can never drift (the #1910 r2-r6 drift class).
+//
+// Methodology: for each corpus config, take the emitter's Name set, build a
+// runtime InterfaceSnapshot for every emitted ref (distinct ifindex, no
+// fold collision among the corpus names) so the builder's runtime intersect
+// is a no-op and no usedIDs drop fires, then assert the builder's emitted
+// Interface set equals the emitter's Name set exactly.
+func TestEmitTunnelEndpointNamesMatchesBuilder(t *testing.T) {
+	mkIface := func(name string, tun *config.TunnelConfig, units map[int]*config.InterfaceUnit) *config.InterfaceConfig {
+		return &config.InterfaceConfig{Name: name, Tunnel: tun, Units: units}
+	}
+	wg := func() *config.TunnelConfig { return &config.TunnelConfig{Mode: "wireguard", WgListenPort: 51820} }
+	greComplete := func() *config.TunnelConfig {
+		return &config.TunnelConfig{Mode: "gre", Source: "10.0.0.1", Destination: "10.0.0.2"}
+	}
+	greIncomplete := func() *config.TunnelConfig { return &config.TunnelConfig{Mode: "gre"} }
+
+	corpus := []struct {
+		name  string
+		cfg   *config.Config
+		wantN int // sanity: expected emitted count
+	}{
+		{
+			name: "interface-level-wg-multi-unit-lowest-only",
+			cfg: cfgWith(map[string]*config.InterfaceConfig{
+				"wg0": mkIface("wg0", wg(), map[int]*config.InterfaceUnit{
+					0: {Number: 0}, 1: {Number: 1}, 2: {Number: 2},
+				}),
+			}),
+			wantN: 1, // only wg0.0
+		},
+		{
+			name: "interface-level-wg-no-units-bare",
+			cfg: cfgWith(map[string]*config.InterfaceConfig{
+				"wg5": mkIface("wg5", wg(), nil),
+			}),
+			wantN: 1, // bare "wg5"
+		},
+		{
+			name: "non-wg-multi-unit-complete-per-unit",
+			cfg: cfgWith(map[string]*config.InterfaceConfig{
+				"gr-0/0/0": mkIface("gr-0/0/0", greComplete(), map[int]*config.InterfaceUnit{
+					0: {Number: 0}, 3: {Number: 3},
+				}),
+			}),
+			wantN: 2, // gr-0/0/0.0, gr-0/0/0.3
+		},
+		{
+			name: "non-wg-incomplete-dropped",
+			cfg: cfgWith(map[string]*config.InterfaceConfig{
+				"gr-1/0/0": mkIface("gr-1/0/0", greIncomplete(), nil),
+			}),
+			wantN: 0, // dropped by src/dest gate
+		},
+		{
+			name: "per-unit-tunnels-mixed",
+			cfg: cfgWith(map[string]*config.InterfaceConfig{
+				"gr-2/0/0": mkIface("gr-2/0/0", nil, map[int]*config.InterfaceUnit{
+					0: {Number: 0, Tunnel: greComplete()},
+					1: {Number: 1}, // no tunnel — not emitted
+					2: {Number: 2, Tunnel: greIncomplete()}, // dropped
+				}),
+			}),
+			wantN: 1, // only gr-2/0/0.0
+		},
+		{
+			name: "no-tunnels",
+			cfg: cfgWith(map[string]*config.InterfaceConfig{
+				"ge-0/0/0": mkIface("ge-0/0/0", nil, map[int]*config.InterfaceUnit{0: {Number: 0}}),
+			}),
+			wantN: 0,
+		},
+	}
+
+	for _, tc := range corpus {
+		t.Run(tc.name, func(t *testing.T) {
+			emitted := config.EmitTunnelEndpointNames(tc.cfg)
+			emitNames := make(map[string]struct{}, len(emitted))
+			ifaces := make([]InterfaceSnapshot, 0, len(emitted))
+			idx := 100
+			for _, ep := range emitted {
+				emitNames[ep.Name] = struct{}{}
+				ifaces = append(ifaces, InterfaceSnapshot{
+					Name:      ep.Name,
+					LinuxName: ep.Name,
+					Ifindex:   idx,
+				})
+				idx++
+			}
+			if len(emitNames) != tc.wantN {
+				t.Fatalf("emitter produced %d names %v, want %d", len(emitNames), emitNames, tc.wantN)
+			}
+			snaps := buildTunnelEndpointSnapshots(tc.cfg, ifaces)
+			builderNames := make(map[string]struct{}, len(snaps))
+			for _, s := range snaps {
+				builderNames[s.Interface] = struct{}{}
+			}
+			if len(builderNames) != len(emitNames) {
+				t.Fatalf("builder names %v != emitter names %v", builderNames, emitNames)
+			}
+			for n := range emitNames {
+				if _, ok := builderNames[n]; !ok {
+					t.Fatalf("emitter ref %q missing from builder set %v", n, builderNames)
+				}
+			}
+		})
+	}
+}
+
+func cfgWith(ifaces map[string]*config.InterfaceConfig) *config.Config {
+	c := &config.Config{}
+	c.Interfaces.Interfaces = ifaces
+	return c
+}


### PR DESCRIPTION
Closes #1914

Implements Path 1 from the converged research plan
(`docs/research/1914-tunnel-endpoint-collision-gate/plan.md`, r3 PLAN-READY
across Claude SMR + Codex + AGY).

## Defect A (High) — fixed

The #1873 commit-time tunnel-endpoint id collision gate hashed the LITERAL
pre-expansion group AST interface name. A wildcard apply-group registered
only `<*>.0` (id 50477), never the concrete post-expansion `wg78.0` /
`wg1408.0` (both fold to 824), so the gate falsely ACCEPTED a
builder-emitted collision that the runtime `usedIDs` belt then dropped with
a loud `slog.Error`.

The gate now rejects on a fold collision in the UNION of three views, all
pure functions of the candidate config (HA symmetry preserved):

- **View 1** — pre-expansion presence union over `interfaces` + every
  `groups` block. **UNCHANGED** — preserves the #1873 cross-node symmetry
  (`TestTunnelEndpointIDCollisionAcrossGroupsIsSymmetric`).
- **View 2 / View 3** — concrete names the builder would emit after
  expanding the candidate for node0 / node1 (`emitNodeExpandedTunnelNames`).

Views 2/3 are **recursion-free**: clone → `ExpandGroupsWithVars(node)` →
gate-free `compileInterfaces` → `config.EmitTunnelEndpointNames`. They never
call `CompileConfig*` (which calls the gate first → recursion) and never
read the post-`usedIDs` snapshot. Per-node expansion/compile errors are
**non-fatal** (that view → empty set), so a config with only `groups node0`
applying `"${node}"` still commits cleanly.

## SSOT emitter + builder refactor (kills the #1910 drift class)

New config-pure `config.EmitTunnelEndpointNames` returns the
`{Name, *TunnelConfig}` set the builder would emit (same non-WG src/dest
gate, same interface-level-WG single-lowest-unit pick, canonical `%s.%d`),
pre-`usedIDs`, no runtime snapshot. `buildTunnelEndpointSnapshots` is
refactored onto it; `TestEmitTunnelEndpointNamesMatchesBuilder` pins the two
together over a corpus so the gate and builder can never drift.

## Defect B (Medium) — documented limitation, NOT fixed

View 1 over-registers an incomplete non-WG tunnel (presence-only, no
src/dest check) the builder would drop, so a ~1/65535 phantom fold-collision
falsely REJECTS. This is mutually exclusive with the Defect-A fix (narrowing
View 1 re-opens a false ACCEPT via group-supplied src/dst and un-applied
nested-apply-groups). Documented in the gate doc-comment; pinned by
`TestTunnelEndpointIDDefectBIncompleteGREStillRejects`; runtime `usedIDs`
`slog.Error` + "rename one interface" remediation is the operator recourse.

`StableTunnelEndpointID` is byte-frozen and untouched — no wire/sync change,
no cross-node renumbering. Commit-path only.

## Validation

- `go build ./...` clean, `go vet`, full `go test ./...` green.
- 5x flake on new + `pkg/config` / `pkg/dataplane/userspace` tunnel tests.
- New tests: wildcard reject (strict) / lenient-warn / per-node symmetric;
  View-1 presence-union preserved; Defect-B residual pinned; single-iface
  wildcard clean; non-fatal undefined peer group; no-recursion; emitter↔
  builder parity. All 13 existing tunnelid tests + frozen folds stay green.
- No cluster smoke (commit-path-only; no dataplane/VRRP/sync code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)