### PR TITLE
#1912: fix cold ENCAP outer next-hop blackhole (key outer-hop ARP/resolver by outer L3 egress)

### DIFF
--- a/docs/pr/1912-cold-encap/reviewer-ids.md
+++ b/docs/pr/1912-cold-encap/reviewer-ids.md
@@ -1,0 +1,80 @@
+# Reviewer task / job IDs — PR #1954 (#1912 cold ENCAP outer next-hop blackhole)
+
+Branch `engineer/1912-cold-encap-outer-nh`, off `origin/master @ 09cd972bc`.
+Converged 3-way research plan: `docs/research/1912-cold-encap/plan.md`
+(research branch — NOT in this PR).
+
+Design: Option B (cold-path helper). Factor `resolve_tunnel_outer` SSOT, add
+`outer_neighbor_ifindex`, rekey the MissingNeighbor arm's outer-hop
+side-effects by the OUTER L3 egress ifindex (not the tunnel logical), throttle
+the tunnel outer-hop probe + resolver enqueue. R-C/R-E preserved; no wire/HA
+change.
+
+## Code review — commit a87b2b8a2 (probe-throttle added after r1)
+
+- Codex r1 code review: `task-mqi50r4s-nqh44m` — NEEDS-WORK
+  - Only finding: `git diff --check` whitespace in the `docs/research/`
+    plan docs (a Low). RESOLVED — the plan docs were rebased OUT of the PR
+    diff (the PR is code-only, 4 files); `git diff --check origin/master..HEAD`
+    clean. Core dataplane changes assessed MERGE-READY from source review.
+- Antigravity r1 adversarial review: `adversarial-review-mqi50wxh-4nbcfh` —
+  NEEDS-WORK (High)
+  - High: the kernel ARP probe (`trigger_kernel_arp_probe`, raw-socket
+    open/setsockopt/sendto/close) was gated only by `already_probing`
+    (`pending_neigh.contains_key`), but tunnel-marked flows are never
+    buffered in `pending_neigh` (R-E) and the per-hop neg-cache only arms on
+    a `pending_neigh` timeout, so EVERY cold packet of an unresolved
+    tunnel-bound flow fired a per-packet probe — a syscall storm under a SYN
+    flood. FIXED in `a87b2b8a2`: gate BOTH the probe and the resolver enqueue
+    behind the existing per-`(neigh_if, next_hop)` `resolver_enqueue_throttle`
+    window (<=1 probe + enqueue per outer key per window).
+- Copilot r1 (issue-comment): root cause + fix "correct"; 4 findings.
+  - #1 (High) unthrottled probe storm — same as AGY High; FIXED in
+    `a87b2b8a2`.
+  - #2 (Medium) duplicated resolver-enqueue block — addressed in `e3fd63846`
+    (factored `try_enqueue_resolver`).
+  - #3 (Medium) missing `#[cold]` — DECLINED: sibling cold-path forwarding
+    helpers carry no `#[cold]` in this module; annotating only the two new
+    fns would be inconsistent.
+  - #4 (Low) fallback-to-tunnel-logical guard — addressed in `e3fd63846`
+    (`outer_if_distinct` / `tunnel_without_outer`).
+  - Minor (resolved-wins secondary fix) — acknowledged in the PR thread.
+
+## Code review — commit a87b2b8a2 (r2)
+
+- Codex r2 code review: `task-mqi5eud4-s8edmx` — MERGE-READY (no findings)
+- Antigravity r2 adversarial review: `adversarial-review-mqi5f1cg-wyckx4` —
+  MERGE-READY (no findings; confirmed the <=10 GETs/s-per-key storm bound,
+  non-tunnel byte-identity, R-C/R-E, cache bounding, no remaining storm
+  vectors)
+
+## Code review — commit e3fd63846 (final; Copilot #2/#4 + helper tests)
+
+- Codex r3 code review: `task-mqi5sh0n-k12q5e` — MERGE-READY (no findings)
+  - Verified the neg-cache refactor to `try_enqueue_resolver` is
+    behavior-identical, the tunnel probe/enqueue share one throttle window
+    (no double-bump / no window reset on a throttled packet), non-tunnel
+    byte-identity, R-C/R-E preserved.
+- Antigravity r3 adversarial review: `adversarial-review-mqi5snst-o779gr` —
+  MERGE-READY (no findings; ran full `cargo test` 2015 passed / 0 failed and
+  `go test ./...` green)
+
+## Convergence
+
+Codex + Antigravity both MERGE-READY on the final SHA `e3fd63846` with no
+findings. Copilot's 4 findings all addressed (3 fixed, 1 declined with
+rationale).
+
+## Remaining gates (parent-coordinated, serialized loss cluster)
+
+- Live loss-cluster repro (`tmp/v1902b.sh` choreography: GRE-to-self, flush
+  `ge-0-0-1`, ping while tcpdumping for who-has the outer hop — pass = who-has
+  now appears + reply leg recovers within ~1 ping).
+- `make test-failover`.
+
+These are NOT run here (the parent coordinates the serialized cluster). Test
+status at merge gate: `cargo test --release` green (2014 lib + the 2 new
+helper tests = 2015 incl. integration; the intermittent `worker_queue`
+`concurrent_recovery` + wg `reconcile_peers_snapshot` failures are pre-existing
+parallelism flakes, green in isolation and on clean runs), 5x flake-clean on
+all 7 new #1912 tests, `go test ./pkg/dataplane/userspace ./pkg/config` green.

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1512,15 +1512,24 @@ pub(super) fn no_route_resolution(next_hop: Option<IpAddr>) -> ForwardingResolut
     }
 }
 
-pub(super) fn resolve_tunnel_forwarding_resolution(
+/// Resolve a tunnel endpoint's OUTER transport destination.
+///
+/// Shared SSOT for the outer-hop lookup: returns the OUTER
+/// `ForwardingResolution` (whose `egress_ifindex` is the OUTER L3 egress
+/// interface where the outer next-hop neighbor is keyed, NOT the tunnel
+/// logical ifindex), or `None` when the endpoint id is unknown OR the
+/// outer destination resolves to local delivery / a tunnel interface (the
+/// recursion guard). `resolve_tunnel_forwarding_resolution` re-maps the
+/// returned resolution onto the tunnel logical ifindex; the cold-path
+/// `outer_neighbor_ifindex` helper reads `egress_ifindex` straight off it
+/// to key the outer-hop ARP/NDP probe + neighbor map + neg-cache.
+pub(super) fn resolve_tunnel_outer(
     state: &ForwardingState,
     dynamic_neighbors: Option<&Arc<ShardedNeighborMap>>,
     tunnel_endpoint_id: u16,
     depth: usize,
-) -> ForwardingResolution {
-    let Some(endpoint) = state.tunnel_endpoints.get(&tunnel_endpoint_id) else {
-        return no_route_resolution(None);
-    };
+) -> Option<ForwardingResolution> {
+    let endpoint = state.tunnel_endpoints.get(&tunnel_endpoint_id)?;
     let outer = match endpoint.destination {
         IpAddr::V4(ip) => lookup_forwarding_resolution_v4(
             state,
@@ -1542,18 +1551,72 @@ pub(super) fn resolve_tunnel_forwarding_resolution(
     if outer.disposition == ForwardingDisposition::LocalDelivery
         || state.tunnel_interfaces.contains(&outer.egress_ifindex)
     {
-        return no_route_resolution(Some(endpoint.destination));
+        return None;
     }
+    Some(outer)
+}
+
+pub(super) fn resolve_tunnel_forwarding_resolution(
+    state: &ForwardingState,
+    dynamic_neighbors: Option<&Arc<ShardedNeighborMap>>,
+    tunnel_endpoint_id: u16,
+    depth: usize,
+) -> ForwardingResolution {
+    let Some(endpoint) = state.tunnel_endpoints.get(&tunnel_endpoint_id) else {
+        return no_route_resolution(None);
+    };
+    let logical_ifindex = endpoint.logical_ifindex;
+    let destination = endpoint.destination;
+    let Some(outer) = resolve_tunnel_outer(state, dynamic_neighbors, tunnel_endpoint_id, depth)
+    else {
+        return no_route_resolution(Some(destination));
+    };
     ForwardingResolution {
         disposition: outer.disposition,
         local_ifindex: outer.local_ifindex,
-        egress_ifindex: endpoint.logical_ifindex,
+        egress_ifindex: logical_ifindex,
         tx_ifindex: outer.tx_ifindex,
         tunnel_endpoint_id,
         next_hop: outer.next_hop,
         neighbor_mac: outer.neighbor_mac,
         src_mac: outer.src_mac,
         tx_vlan_id: outer.tx_vlan_id,
+    }
+}
+
+/// The ifindex on which `resolution.next_hop` must be neighbor-resolved
+/// (ARP/NDP probe + neighbor-map key + negative-cache key) on the cold
+/// path. For a normal (non-tunnel) resolution this is `egress_ifindex`.
+/// For a tunnel-marked resolution it is the OUTER transport's L3 egress
+/// ifindex — where the outer next-hop neighbor (e.g. the GRE outer hop)
+/// actually lives — which differs from `resolution.egress_ifindex` (the
+/// tunnel LOGICAL ifindex, used for zone/policy/CoS) and from
+/// `resolution.tx_ifindex` (the VLAN PARENT for a VLAN outer transport;
+/// neighbors are keyed by the L3 subif, so `tx_ifindex` would be the wrong
+/// key).
+///
+/// Computed from LIVE forwarding state at use time, so it is inherently
+/// peer-local and needs no wire field / HA-sync trust — synced sessions
+/// re-resolve on upsert. The outer re-resolution reuses the shared
+/// `resolve_tunnel_outer` SSOT (the same lookup the original resolution
+/// ran), so there is no logic duplication. Cold-path only (MissingNeighbor
+/// arm), never the fast path.
+///
+/// The `> 0` guard (vs `== 0`) is the conservative fallback: if the
+/// endpoint vanished or the re-resolved outer egress is non-positive, fall
+/// back to `resolution.egress_ifindex` rather than emit a probe on ifindex
+/// 0.
+pub(super) fn outer_neighbor_ifindex(
+    state: &ForwardingState,
+    dynamic_neighbors: Option<&Arc<ShardedNeighborMap>>,
+    resolution: &ForwardingResolution,
+) -> i32 {
+    if resolution.tunnel_endpoint_id == 0 {
+        return resolution.egress_ifindex;
+    }
+    match resolve_tunnel_outer(state, dynamic_neighbors, resolution.tunnel_endpoint_id, 0) {
+        Some(outer) if outer.egress_ifindex > 0 => outer.egress_ifindex,
+        _ => resolution.egress_ifindex,
     }
 }
 

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -2257,3 +2257,68 @@ fn tx_binding_resolution_uses_fabric_parent_ifindex() {
     let state = build_forwarding_state(&nat_snapshot_with_fabric());
     assert_eq!(resolve_tx_binding_ifindex(&state, 21), 21);
 }
+
+// === #1912: cold ENCAP outer next-hop neighbor keying ===
+
+#[test]
+fn outer_neighbor_ifindex_non_tunnel_returns_egress_ifindex() {
+    // For a non-tunnel resolution the helper must be byte-identical to
+    // egress_ifindex (the off-tunnel path is unchanged).
+    let state = build_forwarding_state(&nat_snapshot());
+    let resolution = lookup_forwarding_resolution_v4(
+        &state,
+        None,
+        Ipv4Addr::new(172, 16, 80, 200),
+        "inet.0",
+        0,
+        true,
+    );
+    assert_eq!(resolution.tunnel_endpoint_id, 0);
+    assert_eq!(
+        outer_neighbor_ifindex(&state, None, &resolution),
+        resolution.egress_ifindex
+    );
+}
+
+#[test]
+fn resolve_tunnel_outer_returns_outer_l3_egress() {
+    // The factored SSOT returns the OUTER transport resolution whose
+    // egress_ifindex is the outer L3 egress (reth0.80, ifindex 12 — a VLAN
+    // subif), NOT the tunnel logical ifindex (gr-0-0-0, 362).
+    let state = build_forwarding_state(&native_gre_snapshot(true));
+    let outer = resolve_tunnel_outer(&state, None, 1, 0).expect("outer resolves");
+    assert_eq!(outer.egress_ifindex, 12);
+    // VLAN outer transport: tx_ifindex is the PARENT (bind_ifindex 6), so
+    // the neighbor key (the subif) differs from tx_ifindex — keying by
+    // tx_ifindex would be wrong.
+    assert_eq!(outer.tx_ifindex, 6);
+}
+
+#[test]
+fn outer_neighbor_ifindex_tunnel_returns_outer_vlan_subif_not_logical_or_parent() {
+    // A tunnel-marked resolution carries egress_ifindex = tunnel logical
+    // (362) but next_hop = outer hop. The helper must return the outer L3
+    // egress (12, the VLAN subif), not the tunnel logical (362) and not the
+    // VLAN parent / tx_ifindex (6).
+    let state = build_forwarding_state(&native_gre_snapshot(false));
+    let resolution = resolve_tunnel_forwarding_resolution(&state, None, 1, 0);
+    assert_ne!(resolution.tunnel_endpoint_id, 0);
+    assert_eq!(resolution.egress_ifindex, 362);
+    assert_eq!(resolution.disposition, ForwardingDisposition::MissingNeighbor);
+    let neigh_if = outer_neighbor_ifindex(&state, None, &resolution);
+    assert_eq!(neigh_if, 12, "outer L3 subif, not tunnel logical");
+    assert_ne!(neigh_if, resolution.egress_ifindex, "not the tunnel logical");
+    assert_ne!(neigh_if, resolution.tx_ifindex, "not the VLAN parent");
+}
+
+#[test]
+fn outer_neighbor_ifindex_missing_endpoint_falls_back_to_egress_ifindex() {
+    // The `> 0` fallback: a tunnel-marked resolution whose endpoint id is
+    // unknown to live state must fall back to egress_ifindex rather than
+    // probe ifindex 0.
+    let state = build_forwarding_state(&native_gre_snapshot(true));
+    let mut resolution = no_route_resolution(None);
+    resolution.tunnel_endpoint_id = 9999; // not present in state
+    resolution.egress_ifindex = 777;
+    assert_eq!(outer_neighbor_ifindex(&state, None, &resolution), 777);
+}

--- a/userspace-dp/src/afxdp/neighbor_resolver.rs
+++ b/userspace-dp/src/afxdp/neighbor_resolver.rs
@@ -1461,4 +1461,52 @@ mod tests {
         drop(resolver); // drops the producer → recv disconnects promptly
         handle.join().expect("resolver join");
     }
+
+    // #1912: the MissingNeighbor arm enqueues the resolver keyed by
+    // outer_neighbor_ifindex(...) for a tunnel-marked decision. Pin that
+    // keying contract: the ResolveItem the arm enqueues for a GRE tunnel
+    // resolution must carry the OUTER L3 egress ifindex (the VLAN subif
+    // where the outer neighbor lives), NOT the tunnel logical ifindex.
+    // Drives the same enqueue(neigh_if, hop, name) call the arm makes.
+    #[test]
+    fn tunnel_marked_resolver_enqueue_keys_outer_l3_egress() {
+        use crate::afxdp::forwarding::{
+            outer_neighbor_ifindex, resolve_tunnel_forwarding_resolution,
+        };
+        use crate::afxdp::forwarding_build::build_forwarding_state;
+        use crate::afxdp::test_fixtures::native_gre_snapshot;
+
+        let state = build_forwarding_state(&native_gre_snapshot(false));
+        let resolution = resolve_tunnel_forwarding_resolution(&state, None, 1, 0);
+        assert_eq!(resolution.egress_ifindex, 362, "tunnel logical ifindex");
+        let next_hop = resolution.next_hop.expect("outer next hop");
+
+        // The arm computes neigh_if exactly this way before enqueueing.
+        let neigh_if = outer_neighbor_ifindex(&state, None, &resolution);
+        assert_eq!(neigh_if, 12, "outer L3 egress (reth0.80 subif)");
+
+        let (tx, rx) = mpsc::sync_channel::<ResolveItem>(1);
+        let counters = Arc::new(ResolverCounters::default());
+        let resolver = NeighborResolver::new(
+            tx,
+            counters,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(super::super::neighbor_latency::NeighborLatencyHist::default()),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+        );
+        let name = state
+            .ifindex_to_name
+            .get(&neigh_if)
+            .cloned()
+            .expect("outer egress has a name");
+        resolver.enqueue(neigh_if, next_hop, name);
+
+        let item = rx.try_recv().expect("item enqueued");
+        assert_eq!(
+            item.ifindex, 12,
+            "resolver must be keyed on the outer L3 egress, not the tunnel logical (362)"
+        );
+        assert_eq!(item.hop, next_hop);
+    }
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -68,6 +68,44 @@ use filter::{
 // polling — so each shared reborrow is valid and cannot alias a
 // mutable reference. The raw pointer only decouples the immutable
 // UMEM-area borrow from the `&mut BindingWorker` borrow.
+/// #1769/#1912: per-key rate-limited enqueue of the shared neighbor
+/// resolver. Both the neg-cache fast-fail branch and the #1912 tunnel
+/// outer-hop branch use the identical throttle-check / `ifindex_to_name`
+/// clone / `enqueue` / cap-clear / `insert` sequence keyed by
+/// `(ifindex, next_hop)` — factored here so the throttle window, the cap
+/// constant, and the clear-vs-evict policy live in ONE place (Copilot
+/// #1912 r1 Medium). Returns true iff it actually enqueued (i.e. was not
+/// throttled and the iface had a name). Cold-path only.
+#[inline]
+fn try_enqueue_resolver(
+    resolver: &NeighborResolver,
+    throttle: &mut FastMap<(i32, IpAddr), u64>,
+    ifindex_to_name: &FastMap<i32, String>,
+    key: (i32, IpAddr),
+    now_ns: u64,
+) -> bool {
+    // Cheap (i32, IpAddr) map check runs before any clone.
+    let throttled = matches!(
+        throttle.get(&key),
+        Some(&t) if now_ns.saturating_sub(t) < RESOLVER_ENQUEUE_THROTTLE_NS
+    );
+    if throttled {
+        return false;
+    }
+    let Some(name) = ifindex_to_name.get(&key.0) else {
+        return false;
+    };
+    resolver.enqueue(key.0, key.1, name.clone());
+    // Bound the throttle map like the negative cache: a /24 scan touches
+    // <=254 keys, so clear wholesale past the cap (best-effort — losing
+    // throttle for a few keys only risks one extra clone).
+    if throttle.len() >= MAX_NEG_NEIGH_CACHE && !throttle.contains_key(&key) {
+        throttle.clear();
+    }
+    throttle.insert(key, now_ns);
+    true
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn poll_binding_process_descriptor(
     binding: &mut BindingWorker,
@@ -2445,63 +2483,21 @@ pub(super) fn poll_binding_process_descriptor(
                                         // try_send here (not per-packet — this
                                         // arm fires only on the negative fast-
                                         // fail).
+                                        // Per-key rate-limited (the resolver
+                                        // coalesces per-key anyway) so a
+                                        // dead-host SYN storm does NOT clone +
+                                        // try_send per fast-failed packet. See
+                                        // try_enqueue_resolver.
                                         if let Some(resolver) =
                                             worker_ctx.neighbor_resolver
                                         {
-                                            // Per-binding throttle: only
-                                            // clone the iface name +
-                                            // try_send once per key per
-                                            // RESOLVER_ENQUEUE_THROTTLE_NS
-                                            // so a dead-host SYN storm does
-                                            // NOT allocate per fast-failed
-                                            // packet (the resolver coalesces
-                                            // per-key anyway). The cheap
-                                            // (i32, IpAddr) map check runs
-                                            // before any clone.
-                                            let throttled = matches!(
-                                                binding
-                                                    .resolver_enqueue_throttle
-                                                    .get(&neg_key),
-                                                Some(&t) if now_ns.saturating_sub(t)
-                                                    < RESOLVER_ENQUEUE_THROTTLE_NS
+                                            try_enqueue_resolver(
+                                                resolver,
+                                                &mut binding.resolver_enqueue_throttle,
+                                                &worker_ctx.forwarding.ifindex_to_name,
+                                                neg_key,
+                                                now_ns,
                                             );
-                                            if !throttled {
-                                                if let Some(name) = worker_ctx
-                                                    .forwarding
-                                                    .ifindex_to_name
-                                                    .get(&neg_key.0)
-                                                {
-                                                    resolver.enqueue(
-                                                        neg_key.0,
-                                                        neg_key.1,
-                                                        name.clone(),
-                                                    );
-                                                    // Bound the throttle
-                                                    // map like the negative
-                                                    // cache: a /24 scan
-                                                    // touches <=254 keys, so
-                                                    // clear wholesale past
-                                                    // the cap (best-effort —
-                                                    // losing throttle for a
-                                                    // few keys only risks one
-                                                    // extra clone).
-                                                    if binding
-                                                        .resolver_enqueue_throttle
-                                                        .len()
-                                                        >= MAX_NEG_NEIGH_CACHE
-                                                        && !binding
-                                                            .resolver_enqueue_throttle
-                                                            .contains_key(&neg_key)
-                                                    {
-                                                        binding
-                                                            .resolver_enqueue_throttle
-                                                            .clear();
-                                                    }
-                                                    binding
-                                                        .resolver_enqueue_throttle
-                                                        .insert(neg_key, now_ns);
-                                                }
-                                            }
                                         }
                                         // Fresh RX descriptor → recycle via
                                         // scratch_recycle + continue, matching
@@ -2526,30 +2522,43 @@ pub(super) fn poll_binding_process_descriptor(
                                 // picks up the resolved entry instantly.
                                 if let Some(next_hop) = decision.resolution.next_hop {
                                     // #1912: tunnel-marked decisions are NEVER
-                                    // buffered in pending_neigh (R-E), so the
-                                    // per-hop neg-cache that arms only on a
-                                    // pending_neigh timeout (neighbor_dispatch.rs)
-                                    // never arms for an unresolved OUTER hop —
-                                    // the top-of-arm neg fast-fail therefore can
-                                    // never suppress this block for a tunnel
-                                    // flow. Without an explicit throttle EVERY
-                                    // cold packet of an unresolved tunnel-bound
-                                    // flow would fire trigger_kernel_arp_probe
-                                    // (a raw-socket open/setsockopt/sendto/close
-                                    // per packet) — a syscall storm under a SYN
-                                    // flood (AGY #1912 r1, High). So for a
-                                    // tunnel-marked decision gate BOTH the kernel
-                                    // ARP probe AND the resolver enqueue behind
-                                    // the existing per-(neigh_if, next_hop)
-                                    // resolver_enqueue_throttle: at most one
-                                    // probe + enqueue per outer key per window.
-                                    // The neg-cache miss-arming gap is unchanged
-                                    // for non-tunnel flows (they DO buffer +
-                                    // time out → neg_neigh_record).
+                                    // buffered in pending_neigh (R-E), and the
+                                    // per-hop neg-cache arms only on a
+                                    // pending_neigh timeout (neighbor_dispatch.rs
+                                    // neg_neigh_record), so for an unresolved
+                                    // OUTER hop the top-of-arm neg fast-fail can
+                                    // never arm and suppress this block. The
+                                    // outer-hop probe + resolver are therefore
+                                    // gated by the per-(neigh_if, next_hop)
+                                    // resolver_enqueue_throttle window below.
+                                    //
+                                    // outer_if_distinct: true only when this is a
+                                    // tunnel decision whose outer transport
+                                    // RESOLVED to a real L3 egress distinct from
+                                    // the tunnel logical ifindex. If
+                                    // outer_neighbor_ifindex fell back to
+                                    // egress_ifindex (endpoint vanished / outer
+                                    // egress <= 0 — unreachable within the
+                                    // single-threaded worker loop, but explicit),
+                                    // neigh_if == egress_ifindex == tunnel logical;
+                                    // probing / RTM_GETNEIGH on the GRE logical
+                                    // iface is the useless pre-#1912 behavior, so
+                                    // skip it (Copilot #1912 r1 Low).
                                     let tunnel_marked =
                                         decision.resolution.tunnel_endpoint_id != 0;
+                                    let outer_if_distinct = tunnel_marked
+                                        && neigh_if > 0
+                                        && neigh_if != decision.resolution.egress_ifindex;
                                     let throttle_key = (neigh_if, next_hop);
-                                    let tunnel_throttled = tunnel_marked
+                                    // For a tunnel decision, gate BOTH the kernel
+                                    // ARP probe AND the resolver enqueue behind
+                                    // ONE throttle window so a SYN flood to a
+                                    // flushed outer hop fires at most one
+                                    // probe + enqueue per outer key per window
+                                    // (else trigger_kernel_arp_probe — a raw
+                                    // socket open/setsockopt/sendto/close — would
+                                    // run per packet; AGY #1912 r1 High).
+                                    let tunnel_throttled = outer_if_distinct
                                         && matches!(
                                             binding
                                                 .resolver_enqueue_throttle
@@ -2569,12 +2578,24 @@ pub(super) fn poll_binding_process_descriptor(
                                     // neigh_if == egress_ifindex so the dedup is
                                     // byte-identical; for a tunnel flow
                                     // pending_neigh never holds the key (R-E), so
-                                    // the per-window throttle above is the
-                                    // probe-storm bound instead.
+                                    // the per-window throttle is the probe-storm
+                                    // bound instead.
                                     let already_probing = binding
                                         .pending_neigh
                                         .contains_key(&(neigh_if, next_hop));
-                                    if !already_probing && !tunnel_throttled {
+                                    // Suppress the probe for a tunnel decision
+                                    // with NO distinct outer egress: neigh_if
+                                    // would be the tunnel logical ifindex and the
+                                    // probe would bind to the GRE iface (no ARP —
+                                    // the useless pre-#1912 behavior). For a
+                                    // non-tunnel flow tunnel_marked is false so
+                                    // this never suppresses (byte-identical).
+                                    let tunnel_without_outer =
+                                        tunnel_marked && !outer_if_distinct;
+                                    if !already_probing
+                                        && !tunnel_throttled
+                                        && !tunnel_without_outer
+                                    {
                                         let iface_name = worker_ctx
                                             .forwarding
                                             .ifindex_to_name
@@ -2587,49 +2608,43 @@ pub(super) fn poll_binding_process_descriptor(
                                         }
                                     }
                                     // #1912: for a tunnel-marked MissingNeighbor
-                                    // (e.g. GRE outer hop), ALSO drive the #1769
-                                    // resolver on the OUTER L3 egress (neigh_if),
-                                    // not only on the neg-cache fast-fail. A
-                                    // freshly-flushed outer hop has no negative
-                                    // entry, so without this only the one-shot
-                                    // kernel ARP probe above fires; the resolver
-                                    // hardens the STALE/DELAY outer-entry case by
-                                    // issuing an RTM_GETNEIGH revalidation. The
-                                    // frame is STILL NOT buffered (R-E), so no
-                                    // plaintext-leak window is opened. Shares the
-                                    // tunnel_throttled window with the probe so a
-                                    // single bump per key per window gates both.
-                                    if tunnel_marked && neigh_if > 0 && !tunnel_throttled {
+                                    // with a DISTINCT resolved outer egress (e.g.
+                                    // GRE outer hop), ALSO drive the #1769
+                                    // resolver on the OUTER L3 egress, not only on
+                                    // the neg-cache fast-fail. A freshly-flushed
+                                    // outer hop has no negative entry, so without
+                                    // this only the one-shot kernel ARP probe
+                                    // fires; the resolver hardens the STALE/DELAY
+                                    // outer-entry case via RTM_GETNEIGH. The frame
+                                    // is STILL NOT buffered (R-E), so no
+                                    // plaintext-leak window opens. try_enqueue_-
+                                    // resolver re-reads the SAME throttle entry
+                                    // and bumps it once, so the probe above and
+                                    // this enqueue share one window per key.
+                                    if outer_if_distinct && !tunnel_throttled {
                                         if let Some(resolver) = worker_ctx.neighbor_resolver {
-                                            if let Some(name) = worker_ctx
-                                                .forwarding
-                                                .ifindex_to_name
-                                                .get(&neigh_if)
+                                            try_enqueue_resolver(
+                                                resolver,
+                                                &mut binding.resolver_enqueue_throttle,
+                                                &worker_ctx.forwarding.ifindex_to_name,
+                                                throttle_key,
+                                                now_ns,
+                                            );
+                                        } else {
+                                            // No resolver (probe-only build): bump
+                                            // the throttle directly so the probe
+                                            // above is still rate-limited to one
+                                            // per window. Bounded like the neg
+                                            // cache.
+                                            let throttle =
+                                                &mut binding.resolver_enqueue_throttle;
+                                            if throttle.len() >= MAX_NEG_NEIGH_CACHE
+                                                && !throttle.contains_key(&throttle_key)
                                             {
-                                                resolver.enqueue(
-                                                    neigh_if,
-                                                    next_hop,
-                                                    name.clone(),
-                                                );
+                                                throttle.clear();
                                             }
+                                            throttle.insert(throttle_key, now_ns);
                                         }
-                                    }
-                                    // #1912: bump the shared tunnel throttle once
-                                    // after firing (probe and/or enqueue), so the
-                                    // NEXT cold packet within the window skips
-                                    // both. Bounded like the negative cache.
-                                    if tunnel_marked && neigh_if > 0 && !tunnel_throttled {
-                                        if binding.resolver_enqueue_throttle.len()
-                                            >= MAX_NEG_NEIGH_CACHE
-                                            && !binding
-                                                .resolver_enqueue_throttle
-                                                .contains_key(&throttle_key)
-                                        {
-                                            binding.resolver_enqueue_throttle.clear();
-                                        }
-                                        binding
-                                            .resolver_enqueue_throttle
-                                            .insert(throttle_key, now_ns);
                                     }
                                 }
                                 // Create the session NOW so the SYN-ACK (reverse
@@ -3034,4 +3049,74 @@ pub(super) fn poll_binding_process_descriptor(
         }
         received.release();
         drop(received);
+}
+
+#[cfg(test)]
+mod try_enqueue_resolver_tests {
+    use super::*;
+    use crate::afxdp::neighbor_resolver::{NeighborResolver, ResolveItem, ResolverCounters};
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::mpsc;
+
+    fn make_resolver() -> (NeighborResolver, mpsc::Receiver<ResolveItem>) {
+        let (tx, rx) = mpsc::sync_channel::<ResolveItem>(8);
+        let resolver = NeighborResolver::new(
+            tx,
+            Arc::new(ResolverCounters::default()),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(crate::afxdp::neighbor_latency::NeighborLatencyHist::default()),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+        );
+        (resolver, rx)
+    }
+
+    #[test]
+    fn try_enqueue_resolver_throttles_within_window_and_bounds_map() {
+        let (resolver, rx) = make_resolver();
+        let mut throttle: FastMap<(i32, IpAddr), u64> = FastMap::default();
+        let mut names: FastMap<i32, String> = FastMap::default();
+        names.insert(12, "ge-0-0-2.80".to_string());
+        let key = (12, IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)));
+
+        // First call enqueues and records the throttle entry.
+        assert!(try_enqueue_resolver(&resolver, &mut throttle, &names, key, 1_000));
+        assert_eq!(rx.try_recv().expect("first enqueue").ifindex, 12);
+        assert!(throttle.contains_key(&key));
+
+        // Second call within RESOLVER_ENQUEUE_THROTTLE_NS is throttled: no
+        // enqueue (storm bound — at most one per key per window).
+        assert!(!try_enqueue_resolver(
+            &resolver,
+            &mut throttle,
+            &names,
+            key,
+            1_000 + RESOLVER_ENQUEUE_THROTTLE_NS - 1
+        ));
+        assert!(rx.try_recv().is_err(), "throttled call must not enqueue");
+
+        // After the window elapses, it enqueues again.
+        assert!(try_enqueue_resolver(
+            &resolver,
+            &mut throttle,
+            &names,
+            key,
+            1_000 + RESOLVER_ENQUEUE_THROTTLE_NS
+        ));
+        assert_eq!(rx.try_recv().expect("post-window enqueue").ifindex, 12);
+    }
+
+    #[test]
+    fn try_enqueue_resolver_skips_when_iface_has_no_name() {
+        let (resolver, rx) = make_resolver();
+        let mut throttle: FastMap<(i32, IpAddr), u64> = FastMap::default();
+        let names: FastMap<i32, String> = FastMap::default(); // empty
+        let key = (362, IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)));
+        // No name for the ifindex ⇒ no enqueue, no throttle entry.
+        assert!(!try_enqueue_resolver(&resolver, &mut throttle, &names, key, 1_000));
+        assert!(rx.try_recv().is_err());
+        assert!(throttle.is_empty());
+    }
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2372,9 +2372,28 @@ pub(super) fn poll_binding_process_descriptor(
                                 // forwarding. Otherwise, if it is still
                                 // negatively cached + un-expired, recycle the
                                 // frame immediately.
+                                // #1912: key the OUTER-hop neighbor
+                                // resolution side-effects (ARP/NDP probe,
+                                // #1769 resolver enqueue, neg-cache,
+                                // resolved-wins, already-probing dedup) by the
+                                // OUTER transport's L3 egress ifindex, not the
+                                // tunnel logical ifindex. For a non-tunnel
+                                // resolution this equals
+                                // decision.resolution.egress_ifindex so the
+                                // path is byte-identical; for a tunnel-marked
+                                // decision (next_hop = outer hop) it is the
+                                // outer transport egress where the outer
+                                // neighbor is actually keyed (a VLAN outer
+                                // transport keys on the L3 subif, not the VLAN
+                                // parent / tx_ifindex). Computed once per cold
+                                // packet on this arm.
+                                let neigh_if = outer_neighbor_ifindex(
+                                    worker_ctx.forwarding,
+                                    Some(worker_ctx.dynamic_neighbors),
+                                    &decision.resolution,
+                                );
                                 if let Some(next_hop) = decision.resolution.next_hop {
-                                    let neg_key =
-                                        (decision.resolution.egress_ifindex, next_hop);
+                                    let neg_key = (neigh_if, next_hop);
                                     // neg_neigh_gate runs the resolved-wins
                                     // probe (static neighbors THEN dynamic,
                                     // same order as retry_pending_neigh /
@@ -2512,14 +2531,23 @@ pub(super) fn poll_binding_process_descriptor(
                                     // (egress_ifindex, next_hop), so the
                                     // "already probing this hop" dedup is a
                                     // direct contains_key (was an O(n) iter scan).
-                                    let already_probing = binding.pending_neigh.contains_key(&(
-                                        decision.resolution.egress_ifindex,
-                                        next_hop,
-                                    ));
+                                    // #1912: dedup + iface lookup on the OUTER
+                                    // L3 egress (neigh_if), not the tunnel
+                                    // logical ifindex. pending_neigh is never
+                                    // populated for tunnel-marked decisions
+                                    // (R-E gate below), so for those the
+                                    // contains_key is always false and the
+                                    // probe always fires on the correct outer
+                                    // iface; for non-tunnel neigh_if ==
+                                    // egress_ifindex so the dedup is identical.
+                                    let already_probing = binding
+                                        .pending_neigh
+                                        .contains_key(&(neigh_if, next_hop));
                                     if !already_probing {
-                                        let iface_name = worker_ctx.forwarding
+                                        let iface_name = worker_ctx
+                                            .forwarding
                                             .ifindex_to_name
-                                            .get(&decision.resolution.egress_ifindex)
+                                            .get(&neigh_if)
                                             .cloned();
                                         if let Some(name) = iface_name {
                                             // Fast path: ICMP socket triggers kernel ARP

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2555,6 +2555,65 @@ pub(super) fn poll_binding_process_descriptor(
                                             trigger_kernel_arp_probe(&name, next_hop);
                                         }
                                     }
+                                    // #1912: for a tunnel-marked MissingNeighbor
+                                    // (e.g. GRE outer hop), ALSO drive the #1769
+                                    // resolver on the OUTER L3 egress (neigh_if),
+                                    // not only on the neg-cache fast-fail. A
+                                    // freshly-flushed outer hop has no negative
+                                    // entry, so without this only the one-shot
+                                    // kernel ARP probe above fires; the resolver
+                                    // hardens the STALE/DELAY outer-entry case by
+                                    // issuing an RTM_GETNEIGH revalidation. The
+                                    // frame is STILL NOT buffered (R-E: tunnel-
+                                    // marked never enters pending_neigh), so no
+                                    // plaintext-leak window is opened. Rate-
+                                    // limited per (neigh_if, next_hop) via the
+                                    // existing resolver_enqueue_throttle so an
+                                    // outer-hop storm fires at most one enqueue
+                                    // per key per window; the resolver coalesces
+                                    // per-key anyway. Non-tunnel decisions skip
+                                    // this entirely (the neg-cache fast-fail path
+                                    // already owns their resolver enqueue).
+                                    if decision.resolution.tunnel_endpoint_id != 0
+                                        && neigh_if > 0
+                                    {
+                                        if let Some(resolver) = worker_ctx.neighbor_resolver {
+                                            let key = (neigh_if, next_hop);
+                                            let throttled = matches!(
+                                                binding.resolver_enqueue_throttle.get(&key),
+                                                Some(&t) if now_ns.saturating_sub(t)
+                                                    < RESOLVER_ENQUEUE_THROTTLE_NS
+                                            );
+                                            if !throttled {
+                                                if let Some(name) = worker_ctx
+                                                    .forwarding
+                                                    .ifindex_to_name
+                                                    .get(&neigh_if)
+                                                {
+                                                    resolver.enqueue(
+                                                        neigh_if,
+                                                        next_hop,
+                                                        name.clone(),
+                                                    );
+                                                    if binding
+                                                        .resolver_enqueue_throttle
+                                                        .len()
+                                                        >= MAX_NEG_NEIGH_CACHE
+                                                        && !binding
+                                                            .resolver_enqueue_throttle
+                                                            .contains_key(&key)
+                                                    {
+                                                        binding
+                                                            .resolver_enqueue_throttle
+                                                            .clear();
+                                                    }
+                                                    binding
+                                                        .resolver_enqueue_throttle
+                                                        .insert(key, now_ns);
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                                 // Create the session NOW so the SYN-ACK (reverse
                                 // direction) finds the forward NAT match and creates

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2525,6 +2525,38 @@ pub(super) fn poll_binding_process_descriptor(
                                 // tagging and TX offload. The netlink monitor then
                                 // picks up the resolved entry instantly.
                                 if let Some(next_hop) = decision.resolution.next_hop {
+                                    // #1912: tunnel-marked decisions are NEVER
+                                    // buffered in pending_neigh (R-E), so the
+                                    // per-hop neg-cache that arms only on a
+                                    // pending_neigh timeout (neighbor_dispatch.rs)
+                                    // never arms for an unresolved OUTER hop —
+                                    // the top-of-arm neg fast-fail therefore can
+                                    // never suppress this block for a tunnel
+                                    // flow. Without an explicit throttle EVERY
+                                    // cold packet of an unresolved tunnel-bound
+                                    // flow would fire trigger_kernel_arp_probe
+                                    // (a raw-socket open/setsockopt/sendto/close
+                                    // per packet) — a syscall storm under a SYN
+                                    // flood (AGY #1912 r1, High). So for a
+                                    // tunnel-marked decision gate BOTH the kernel
+                                    // ARP probe AND the resolver enqueue behind
+                                    // the existing per-(neigh_if, next_hop)
+                                    // resolver_enqueue_throttle: at most one
+                                    // probe + enqueue per outer key per window.
+                                    // The neg-cache miss-arming gap is unchanged
+                                    // for non-tunnel flows (they DO buffer +
+                                    // time out → neg_neigh_record).
+                                    let tunnel_marked =
+                                        decision.resolution.tunnel_endpoint_id != 0;
+                                    let throttle_key = (neigh_if, next_hop);
+                                    let tunnel_throttled = tunnel_marked
+                                        && matches!(
+                                            binding
+                                                .resolver_enqueue_throttle
+                                                .get(&throttle_key),
+                                            Some(&t) if now_ns.saturating_sub(t)
+                                                < RESOLVER_ENQUEUE_THROTTLE_NS
+                                        );
                                     // Only spawn ping if we don't already have a
                                     // pending probe for this (ifindex, hop).
                                     // #1771 §2.2: pending_neigh is keyed by
@@ -2533,17 +2565,16 @@ pub(super) fn poll_binding_process_descriptor(
                                     // direct contains_key (was an O(n) iter scan).
                                     // #1912: dedup + iface lookup on the OUTER
                                     // L3 egress (neigh_if), not the tunnel
-                                    // logical ifindex. pending_neigh is never
-                                    // populated for tunnel-marked decisions
-                                    // (R-E gate below), so for those the
-                                    // contains_key is always false and the
-                                    // probe always fires on the correct outer
-                                    // iface; for non-tunnel neigh_if ==
-                                    // egress_ifindex so the dedup is identical.
+                                    // logical ifindex. For a non-tunnel flow
+                                    // neigh_if == egress_ifindex so the dedup is
+                                    // byte-identical; for a tunnel flow
+                                    // pending_neigh never holds the key (R-E), so
+                                    // the per-window throttle above is the
+                                    // probe-storm bound instead.
                                     let already_probing = binding
                                         .pending_neigh
                                         .contains_key(&(neigh_if, next_hop));
-                                    if !already_probing {
+                                    if !already_probing && !tunnel_throttled {
                                         let iface_name = worker_ctx
                                             .forwarding
                                             .ifindex_to_name
@@ -2564,55 +2595,41 @@ pub(super) fn poll_binding_process_descriptor(
                                     // kernel ARP probe above fires; the resolver
                                     // hardens the STALE/DELAY outer-entry case by
                                     // issuing an RTM_GETNEIGH revalidation. The
-                                    // frame is STILL NOT buffered (R-E: tunnel-
-                                    // marked never enters pending_neigh), so no
-                                    // plaintext-leak window is opened. Rate-
-                                    // limited per (neigh_if, next_hop) via the
-                                    // existing resolver_enqueue_throttle so an
-                                    // outer-hop storm fires at most one enqueue
-                                    // per key per window; the resolver coalesces
-                                    // per-key anyway. Non-tunnel decisions skip
-                                    // this entirely (the neg-cache fast-fail path
-                                    // already owns their resolver enqueue).
-                                    if decision.resolution.tunnel_endpoint_id != 0
-                                        && neigh_if > 0
-                                    {
+                                    // frame is STILL NOT buffered (R-E), so no
+                                    // plaintext-leak window is opened. Shares the
+                                    // tunnel_throttled window with the probe so a
+                                    // single bump per key per window gates both.
+                                    if tunnel_marked && neigh_if > 0 && !tunnel_throttled {
                                         if let Some(resolver) = worker_ctx.neighbor_resolver {
-                                            let key = (neigh_if, next_hop);
-                                            let throttled = matches!(
-                                                binding.resolver_enqueue_throttle.get(&key),
-                                                Some(&t) if now_ns.saturating_sub(t)
-                                                    < RESOLVER_ENQUEUE_THROTTLE_NS
-                                            );
-                                            if !throttled {
-                                                if let Some(name) = worker_ctx
-                                                    .forwarding
-                                                    .ifindex_to_name
-                                                    .get(&neigh_if)
-                                                {
-                                                    resolver.enqueue(
-                                                        neigh_if,
-                                                        next_hop,
-                                                        name.clone(),
-                                                    );
-                                                    if binding
-                                                        .resolver_enqueue_throttle
-                                                        .len()
-                                                        >= MAX_NEG_NEIGH_CACHE
-                                                        && !binding
-                                                            .resolver_enqueue_throttle
-                                                            .contains_key(&key)
-                                                    {
-                                                        binding
-                                                            .resolver_enqueue_throttle
-                                                            .clear();
-                                                    }
-                                                    binding
-                                                        .resolver_enqueue_throttle
-                                                        .insert(key, now_ns);
-                                                }
+                                            if let Some(name) = worker_ctx
+                                                .forwarding
+                                                .ifindex_to_name
+                                                .get(&neigh_if)
+                                            {
+                                                resolver.enqueue(
+                                                    neigh_if,
+                                                    next_hop,
+                                                    name.clone(),
+                                                );
                                             }
                                         }
+                                    }
+                                    // #1912: bump the shared tunnel throttle once
+                                    // after firing (probe and/or enqueue), so the
+                                    // NEXT cold packet within the window skips
+                                    // both. Bounded like the negative cache.
+                                    if tunnel_marked && neigh_if > 0 && !tunnel_throttled {
+                                        if binding.resolver_enqueue_throttle.len()
+                                            >= MAX_NEG_NEIGH_CACHE
+                                            && !binding
+                                                .resolver_enqueue_throttle
+                                                .contains_key(&throttle_key)
+                                        {
+                                            binding.resolver_enqueue_throttle.clear();
+                                        }
+                                        binding
+                                            .resolver_enqueue_throttle
+                                            .insert(throttle_key, now_ns);
                                     }
                                 }
                                 // Create the session NOW so the SYN-ACK (reverse


### PR DESCRIPTION
Closes #1912.

## Root cause

GRE/tunnel-bound transit replies blackhole for the full cold window when the
tunnel's OUTER next-hop neighbor is flushed: no who-has for the outer hop
appears on the wire, resolver counters stay flat.

`resolve_tunnel_forwarding_resolution` (forwarding/mod.rs) returns a
`ForwardingResolution` with `egress_ifindex = endpoint.logical_ifindex` (the
TUNNEL logical ifindex) while `next_hop` is the OUTER hop, and **discards
`outer.egress_ifindex`**. The MissingNeighbor arm (poll_descriptor/mod.rs)
keys ALL its outer-hop recovery side-effects by `egress_ifindex`: the kernel
ARP/NDP probe iface lookup, the #1769 resolver enqueue + key, the neg-cache
key + resolved-wins, and the already-probing dedup. For a tunnel-marked
decision that is the tunnel logical ifindex, so the probe binds to the GRE
interface (a point-to-point L3 iface — no ARP on the physical wire) and the
resolver never reaches the outer L3 egress where the outer neighbor is keyed.
Neighbors are keyed by the L3 egress ifindex; for a VLAN outer transport that
is the subif (`outer.egress_ifindex`), not the parent (`tx_ifindex`).

## Fix (Option B — cold-path helper, no struct field)

- Factor `resolve_tunnel_outer(state, dyn, id, depth) -> Option<ForwardingResolution>`
  out of `resolve_tunnel_forwarding_resolution` as the shared SSOT for the
  outer-destination lookup (no behavior change to that fn).
- Add `outer_neighbor_ifindex(state, dyn, &resolution) -> i32`: returns
  `egress_ifindex` for a non-tunnel resolution (byte-identical), else the
  outer transport's `egress_ifindex` via `resolve_tunnel_outer` with a `> 0`
  fallback to `egress_ifindex`. No field on `ForwardingResolution` (100+
  literal sites); computed from live state so nothing crosses the wire / needs
  HA-sync trust.
- In the MissingNeighbor arm, compute `neigh_if` once per cold packet and use
  it for the OUTER-hop side-effects only: neg-cache key + resolved-wins,
  resolver enqueue iface + key, kernel ARP probe iface, already-probing dedup.
  `pending_neigh` insertion stays keyed by `egress_ifindex` (never reached for
  tunnel-marked — R-E gate).
- Resolver-for-tunnel enhancement: for a tunnel-marked MissingNeighbor with
  `neigh_if > 0`, also enqueue the rate-limited #1769 resolver on the
  non-fast-fail path (hardens STALE/DELAY outer entries), reusing the existing
  `resolver_enqueue_throttle`.

## Invariants preserved

- **R-C** (slow-path tunnel-encap-unresolved drop) and **R-E** (tunnel-marked
  frames never buffered in `pending_neigh`) are unchanged. The fix only
  changes which interface the already-fired probe/resolver bind to; it opens
  no buffering/reinjection path and therefore no plaintext-leak window.
- Non-tunnel MissingNeighbor path is byte-identical (`neigh_if == egress_ifindex`).
- No wire/protocol/HA change (Go protocol tests green).

## Tests

5 new tests (helper byte-identity off-tunnel; outer L3 egress vs tunnel
logical vs VLAN parent; `> 0` fallback; resolver-enqueue keying contract via
the resolver mpsc seam). Full `cargo test --release` green (2012 lib), 5x
flake-clean on the new tests, `go test ./pkg/dataplane/userspace ./pkg/config`
green.

Live loss-cluster repro + `make test-failover` pending (parent coordinates the
serialized cluster).