### PR TITLE
docs: correct stale virtio-no-forward venue warning (#1921 resolved)

### DIFF
--- a/docs/image-validation.md
+++ b/docs/image-validation.md
@@ -112,10 +112,11 @@ endpoint needs no route back.
 NIC order = interface name (positional contract). Names are shown in
 config/CLI slash form (`ge-0/0/0`); the Linux link name is the dash form
 (`ge-0-0-0`) that `assignName()` produces — the config layer translates
-between them. NOTE (per the venue warning above): on incus/virtio the
-AF_XDP dataplane does NOT converge its multi-queue bindings, so this
-topology validates control-plane + day-0 + interface bring-up, NOT
-transit forwarding. Run the forwarding assertions on mlx5-VF / i40e-PF.
+between them. NOTE (per the venue note above, #1921 resolved): incus/virtio
+multi-queue AF_XDP now converges and forwards, so this topology validates
+transit forwarding as well as control-plane + day-0 + interface bring-up.
+A virtio bind loop / 0-session transit here is a #1921 regression, not a
+venue limitation; mlx5-VF / i40e-PF remain the line-rate venues.
 
 ### Host networks
 
@@ -272,15 +273,19 @@ Delete `fw0`/`fw1` and the five `xpf-ha-*` networks.
 
 ## Honest scope
 
-- **virtio is NOT a forwarding venue.** On local incus/virtio bridges the
-  AF_XDP dataplane fails to bind virtio multi-queue (`Device or resource
-  busy`, verified 2026-06-15), so Tiers 2–3 on virtio validate only boot +
-  day-0 + interface bring-up + control-plane reachability — NOT transit
-  forwarding/NAT/HA. Functional forwarding (and line-rate numbers) require
-  a real AF_XDP NIC: the loss userspace cluster's mlx5 SR-IOV VFs, or i40e
-  PF passthrough on the standalone test VM. The loss SR-IOV smoke matrix
-  (`docs/`) tests the *deployed binaries*; an image-based forwarding test
-  needs the image booted on one of those NIC venues.
+- **virtio IS a forwarding venue (since #1921 fixed, 2026-06-17).** On local
+  incus/virtio bridges the AF_XDP dataplane now binds virtio multi-queue and
+  forwards transit traffic; the earlier `Device or resource busy` bind loop /
+  0-session transit (observed 2026-06-15) was the #1921 bug, fixed in #1927
+  (rebind double-stop + physical+unit double-bind) and #1929 (standalone
+  phantom-HA-group transit gate). So Tiers 2–3 on virtio validate boot +
+  day-0 + interface bring-up + control-plane reachability AND transit
+  forwarding/NAT/HA. *Line-rate* numbers still require a real AF_XDP NIC —
+  the loss userspace cluster's mlx5 SR-IOV VFs, or i40e PF passthrough on the
+  standalone test VM — because virtio caps below line rate; but functional
+  forwarding correctness is now testable on virtio. The loss SR-IOV smoke
+  matrix (`docs/`) tests the *deployed binaries*; an image-based forwarding
+  test can run on virtio for correctness and on a NIC venue for throughput.
 - The image is hardware-agnostic for these tiers: `verify-dataplane`
   and forwarding run against the image's own kernel + the userspace
   dataplane, so local KVM is a faithful functional venue.

--- a/docs/image-validation.md
+++ b/docs/image-validation.md
@@ -76,20 +76,23 @@ self-contained on one incus host: the appliance is the L3 gateway, the
 LAN/WAN segments are pure L2 bridges, and interface SNAT means the WAN
 endpoint needs no route back.
 
-> **VENUE WARNING (verified 2026-06-15 live run).** The AF_XDP userspace
-> dataplane does NOT forward over **virtio** NICs in a plain incus VM: the
-> helper loops on `libxdp private bind: Device or resource busy` against
-> virtio multi-queue and never converges (you can't even drop the channel
-> count — "too low for existing zerocopy AF_XDP sockets"). On virtio,
-> everything up to and including the control plane works — boot, day-0
-> install/commit, interface bring-up with the configured addresses, and
-> the gateway is pingable (host-inbound) — but **L3 transit forwarding
-> yields 0 sessions**. Run the *forwarding* assertions only on a venue
-> with a real AF_XDP NIC: **mlx5 SR-IOV VFs** (the loss userspace cluster)
-> or **i40e PF passthrough** (the standalone test VM). On incus/virtio,
-> treat Tier 2 as a **control-plane + day-0 + interface-bring-up** check
-> (steps through "confirm the interface map" below), not a forwarding
-> proof.
+> **VENUE NOTE (updated 2026-06-17, #1921 RESOLVED).** The earlier warning
+> here — that the AF_XDP userspace dataplane could not forward over
+> **virtio** NICs in a plain incus VM (helper looping on `libxdp private
+> bind: Device or resource busy` against virtio multi-queue, L3 transit
+> yielding 0 sessions) — described the **#1921 bug, now fixed**. The cause
+> was threefold: a rebind double-stop EBUSY loop and a physical+unit
+> candidate double-bind (#1927), plus the actual transit outage — a
+> standalone node replaying 16 phantom inactive HA groups so the helper
+> gated all transit as HA-inactive and dropped it after XSK RX (#1929,
+> guard startup HA replay behind `if m.clusterHA`). With both merged,
+> virtio multi-queue AF_XDP forwards on a plain incus VM (proven: AUTO
+> bind flags=0 + the HA-gate fix forwards 5000 pps). Tier 2 forwarding
+> assertions therefore now run on incus/virtio as well as on a real
+> AF_XDP NIC venue (**mlx5 SR-IOV VFs** — the loss userspace cluster — or
+> **i40e PF passthrough** — the standalone test VM). Treat a virtio
+> `Device or resource busy` rebind loop or `0 sessions` transit as a
+> regression of #1921, not an expected venue limitation.
 
 ### Topology
 


### PR DESCRIPTION
The `docs/image-validation.md` VENUE WARNING claimed the AF_XDP userspace dataplane cannot forward over virtio NICs in a plain incus VM (libxdp `Device or resource busy` rebind loop, 0-session transit). That described the **#1921 bug, now fixed** — the rebind double-stop + physical+unit double-bind (#1927) and the standalone 16-phantom-HA-group transit gate (#1929, guard startup HA replay behind `m.clusterHA`).

This rewrites the warning as a VENUE NOTE: virtio multi-queue AF_XDP now forwards on a plain incus VM, Tier 2 forwarding assertions run on incus/virtio too, and a virtio rebind loop / 0-session transit should be read as a #1921 regression rather than an expected venue limitation.

Pure doc accuracy fix (no code). Trivial follow-up from the #1944/#1943/#1921/#1919/#1918/#1916/#1915/#1914/#1913/#1912 batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)