### PR TITLE
#1968: upgrade latent defensive hardening (sync-link parse scope/exact + copyTree dir fsync)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -5850,3 +5850,4 @@ top.
 - **Edit**: pkg/upgrade/cluster_cli_test.go — TestSyncParser_ScopedAndExact + at-most-one-Status assertion in TestParsers_AgainstRealFormatInformation.
 - **Edit**: pkg/upgrade/runner.go — copyTree: fsync each copied directory (deepest-first) so nested entries survive power loss.
 - **Edit**: pkg/upgrade/runner_test.go — TestCopyTree_NestedDirsDurable.
+- **Edit** (r1 review fixes): runner.go — extract fsyncDirsDeepestFirst (true depth via separator count, not string length) + copyTreeSyncDir test seam; runner_test.go — TestCopyTree_FsyncsEachDirDeepestFirst (recorder proves loop runs + deepest-first) + TestCopyTree_FsyncDirErrorPropagates; cluster_cli_test.go — Not-configured-then-later-Status fixture.

--- a/_Log.md
+++ b/_Log.md
@@ -5844,3 +5844,9 @@ top.
 - **Timestamp**: 2026-06-17
   - **Action**: #1956 boot-path investigation — REFUTED the stale-ActiveConfig() bug (device-map applies on every boot path; proven on live xpf-devmap VM + Codex code trace). Added testable seam `deviceMapNamingActive` + startup-decision regression test (the gap that let the feature "look dead" on the demo's pre-commit boot).
   - **File(s)**: pkg/daemon/device_map.go, pkg/daemon/daemon_run.go, pkg/daemon/device_map_startup_test.go, docs/pr/1956-device-map/reviewers.md
+
+## 2026-06-17 — #1968 upgrade latent defensive hardening (AGY review-011 Part I)
+- **Edit**: pkg/upgrade/cluster_cli.go — parseSyncEstablished: scope Status match to sync/fabric link section + require exact "up" (was first-status-anywhere + contains("up")).
+- **Edit**: pkg/upgrade/cluster_cli_test.go — TestSyncParser_ScopedAndExact + at-most-one-Status assertion in TestParsers_AgainstRealFormatInformation.
+- **Edit**: pkg/upgrade/runner.go — copyTree: fsync each copied directory (deepest-first) so nested entries survive power loss.
+- **Edit**: pkg/upgrade/runner_test.go — TestCopyTree_NestedDirsDurable.

--- a/pkg/upgrade/cluster_cli.go
+++ b/pkg/upgrade/cluster_cli.go
@@ -181,14 +181,36 @@ func parseSyncEstablished(s string) bool {
 	if !lineHasAll(s, "Remote node:", "healthy") {
 		return false
 	}
-	// Find the sync-link "Status:" line.
+	// Find the sync-link "Status:" line, SCOPED to the sync/fabric link
+	// section. FormatInformation renders the section under a "Fabric link
+	// statistics:" or "Sync link statistics (control-link):" header and ends
+	// it with a blank line (status.go). Scoping (vs the first "status:"
+	// anywhere) means a future pre-sync section that also emits "Status:"
+	// (e.g. IP-monitoring, FormatIPMonitoringStatus) can never be mis-read as
+	// the sync link — which would wrongly green-light a drain (AGY review-011
+	// Part I). Within the section, require the value to be EXACTLY "up", not a
+	// substring, so a future "Status: startup" is not accepted as up.
+	inSync := false
 	for _, line := range strings.Split(s, "\n") {
 		ll := strings.ToLower(strings.TrimSpace(line))
+		if !inSync {
+			if strings.HasPrefix(ll, "sync link statistics") ||
+				strings.HasPrefix(ll, "fabric link statistics") {
+				inSync = true
+			}
+			continue
+		}
+		if ll == "" {
+			// Reached the end of the sync section with no Status line (e.g.
+			// "Not configured"): fail closed.
+			break
+		}
 		if strings.HasPrefix(ll, "status:") {
-			return strings.Contains(ll, "up")
+			val := strings.TrimSpace(strings.TrimPrefix(ll, "status:"))
+			return val == "up"
 		}
 	}
-	// No Status line rendered: fail closed (do not assume sync is up).
+	// No sync-link Status line rendered: fail closed (do not assume sync is up).
 	return false
 }
 

--- a/pkg/upgrade/cluster_cli_test.go
+++ b/pkg/upgrade/cluster_cli_test.go
@@ -43,6 +43,31 @@ func TestParsers_AgainstRealFormatInformation(t *testing.T) {
 		t.Fatalf("FormatInformation() lacks 'Local state:' line the parsers key on:\n%s", info)
 	}
 
+	// parseSyncEstablished scopes its Status match to the sync/fabric link
+	// section. That scoping assumes FormatInformation never emits MORE than one
+	// "Status:" line (here sync is unconfigured → "Not configured" → zero; with
+	// sync configured it renders exactly one). Assert at-most-one so the day a
+	// second "Status:" section (e.g. IP monitoring) is folded into
+	// FormatInformation, THIS test fails loudly — forcing a re-check of the
+	// drain gate (AGY review-011 Part I) rather than a silent mis-read.
+	statusLines := 0
+	for _, line := range strings.Split(info, "\n") {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "status:") {
+			statusLines++
+		}
+	}
+	if statusLines > 1 {
+		t.Fatalf("FormatInformation() emits %d 'Status:' lines, want at most 1 (the sync "+
+			"link); parseSyncEstablished's section scoping assumes a single Status — a "+
+			"second breaks the drain gate:\n%s", statusLines, info)
+	}
+
+	// Real-format coverage of the drain gate: sync is unconfigured here, so
+	// the sync link is not established and a drain must NOT be green-lit.
+	if parseSyncEstablished(info) {
+		t.Errorf("parseSyncEstablished true with sync unconfigured (no Status line):\n%s", info)
+	}
+
 	// No peer configured => remote lost => peer not alive.
 	if parsePeerAlive(info) {
 		t.Errorf("parsePeerAlive true with no peer (remote should be lost):\n%s", info)
@@ -213,6 +238,63 @@ func TestSyncParser_Fixtures(t *testing.T) {
 	}
 	if parseSyncEstablished(noStatus) {
 		t.Error("missing Status line must fail closed")
+	}
+}
+
+// TestSyncParser_ScopedAndExact covers the AGY review-011 Part I hardening:
+// the Status match is scoped to the sync/fabric link section (so a pre-sync
+// section that also emits "Status:" cannot be mis-read), and the value is
+// matched EXACTLY as "up" (so "startup" is not accepted). Both are latent on
+// today's FormatInformation (single sync "Status:" line) but guard against
+// format drift that would otherwise wrongly green-light a drain.
+func TestSyncParser_ScopedAndExact(t *testing.T) {
+	// A pre-sync section emitting "Status: up" must NOT be read as the sync
+	// link when the actual sync link is Down. The old first-"status:"-wins
+	// parser would have returned true here and drained with sync down.
+	preSyncUp := strings.Join([]string{
+		"  Remote node: healthy (node1)",
+		"IP monitoring:",
+		"  Status: up",
+		"",
+		"Sync link statistics (control-link):",
+		"  Status: Down",
+	}, "\n")
+	if parseSyncEstablished(preSyncUp) {
+		t.Error("a pre-sync 'Status: up' must not be read as the sync link when sync is Down")
+	}
+
+	// Exact-match: "startup" must not satisfy the up gate.
+	startup := strings.Join([]string{
+		"  Remote node: healthy (node1)",
+		"Sync link statistics (control-link):",
+		"  Status: startup",
+	}, "\n")
+	if parseSyncEstablished(startup) {
+		t.Error("'Status: startup' must not be read as up (exact match required)")
+	}
+
+	// Scoping still finds the sync Status when a benign pre-sync Status
+	// precedes it and the sync link is genuinely Up.
+	preSyncThenUp := strings.Join([]string{
+		"  Remote node: healthy (node1)",
+		"IP monitoring:",
+		"  Status: unreachable",
+		"",
+		"Sync link statistics (control-link):",
+		"  Status: Up",
+	}, "\n")
+	if !parseSyncEstablished(preSyncThenUp) {
+		t.Error("sync 'Status: Up' must be read as established despite a pre-sync Status line")
+	}
+
+	// The fabric-link header variant is honored too.
+	fabricUp := strings.Join([]string{
+		"  Remote node: healthy (node1)",
+		"Fabric link statistics:",
+		"  Status: Up",
+	}, "\n")
+	if !parseSyncEstablished(fabricUp) {
+		t.Error("'Fabric link statistics:' + 'Status: Up' must read as established")
 	}
 }
 

--- a/pkg/upgrade/cluster_cli_test.go
+++ b/pkg/upgrade/cluster_cli_test.go
@@ -296,6 +296,21 @@ func TestSyncParser_ScopedAndExact(t *testing.T) {
 	if !parseSyncEstablished(fabricUp) {
 		t.Error("'Fabric link statistics:' + 'Status: Up' must read as established")
 	}
+
+	// An UNCONFIGURED sync section ("Not configured", no Status) ends at its
+	// blank line; a later out-of-section "Status: Up" must NOT be adopted as
+	// the sync status (Codex r1). Sync is not established here → fail closed.
+	notConfiguredThenLaterUp := strings.Join([]string{
+		"  Remote node: healthy (node1)",
+		"Fabric link statistics:",
+		"  Not configured",
+		"",
+		"Some later section:",
+		"  Status: Up",
+	}, "\n")
+	if parseSyncEstablished(notConfiguredThenLaterUp) {
+		t.Error("unconfigured sync section must fail closed even if a later section says Status: Up")
+	}
 }
 
 // TestParseRGIDs proves ResetFailover enumerates ALL configured RGs

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -263,6 +263,7 @@ func copyTree(src, dst string) (string, error) {
 	}
 	sort.Slice(ents, func(i, j int) bool { return ents[i].rel < ents[j].rel })
 
+	var createdDirs []string
 	for _, e := range ents {
 		target := filepath.Join(dst, e.rel)
 		switch {
@@ -270,6 +271,7 @@ func copyTree(src, dst string) (string, error) {
 			if err := os.MkdirAll(target, 0755); err != nil {
 				return "", fmt.Errorf("mkdir %s: %w", target, err)
 			}
+			createdDirs = append(createdDirs, target)
 		case e.info.Mode().IsRegular():
 			if err := copyFileFsync(e.path, target, e.info.Mode()); err != nil {
 				return "", err
@@ -286,6 +288,24 @@ func copyTree(src, dst string) (string, error) {
 			f.Close()
 		default:
 			return "", fmt.Errorf("copyTree: unsupported file type for %s", e.path)
+		}
+	}
+	// Fsync every copied directory. copyFileFsync commits file *contents*, but
+	// a newly-created directory entry (a file or a nested subdir) is durable
+	// only once its parent directory fd is fsynced. Callers fsync only the
+	// top-level copy root (SyncDir(partial)/SyncDir(snapPartial)); nested dirs
+	// are NOT covered there, so a power loss after the atomic rename could
+	// orphan nested entries and a later rollback would restore a corrupt
+	// snapshot. Latent today (.configdb and staged are both flat — AGY
+	// review-011 Part I) but this makes copyTree durable for any future
+	// nesting. Deepest-first so each child dir's entries are committed before
+	// the parent dir entry that references it.
+	sort.Slice(createdDirs, func(i, j int) bool {
+		return len(createdDirs[i]) > len(createdDirs[j])
+	})
+	for _, d := range createdDirs {
+		if err := fsatomic.SyncDir(d); err != nil {
+			return "", fmt.Errorf("fsync copied dir %s: %w", d, err)
 		}
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -298,17 +298,42 @@ func copyTree(src, dst string) (string, error) {
 	// orphan nested entries and a later rollback would restore a corrupt
 	// snapshot. Latent today (.configdb and staged are both flat — AGY
 	// review-011 Part I) but this makes copyTree durable for any future
-	// nesting. Deepest-first so each child dir's entries are committed before
-	// the parent dir entry that references it.
-	sort.Slice(createdDirs, func(i, j int) bool {
-		return len(createdDirs[i]) > len(createdDirs[j])
-	})
-	for _, d := range createdDirs {
-		if err := fsatomic.SyncDir(d); err != nil {
-			return "", fmt.Errorf("fsync copied dir %s: %w", d, err)
-		}
+	// nesting.
+	if err := fsyncDirsDeepestFirst(createdDirs); err != nil {
+		return "", err
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// copyTreeSyncDir is the directory-fsync primitive used by
+// fsyncDirsDeepestFirst. It is a package var so tests can substitute a
+// recorder and prove copyTree actually fsyncs each copied directory (and in
+// deepest-first order, and that an error propagates) — otherwise deleting the
+// fsync loop would not fail any test (Codex/Copilot r1).
+var copyTreeSyncDir = fsatomic.SyncDir
+
+// fsyncDirsDeepestFirst fsyncs each directory deepest-first (by path-component
+// depth, NOT string length — a deeper path can be shorter, Copilot r1) so a
+// child dir's entries are committed before the parent dir entry that
+// references it. Correctness does not depend on order (every dir is fsynced,
+// so every dentry becomes durable); the ordering only tightens the crash
+// window.
+func fsyncDirsDeepestFirst(dirs []string) error {
+	ordered := append([]string(nil), dirs...)
+	sort.Slice(ordered, func(i, j int) bool {
+		di := strings.Count(ordered[i], string(os.PathSeparator))
+		dj := strings.Count(ordered[j], string(os.PathSeparator))
+		if di != dj {
+			return di > dj
+		}
+		return ordered[i] > ordered[j]
+	})
+	for _, d := range ordered {
+		if err := copyTreeSyncDir(d); err != nil {
+			return fmt.Errorf("fsync copied dir %s: %w", d, err)
+		}
+	}
+	return nil
 }
 
 // copyFileFsync copies src -> dst with mode, fsyncing dst before close.

--- a/pkg/upgrade/runner_test.go
+++ b/pkg/upgrade/runner_test.go
@@ -551,3 +551,59 @@ func assertOrder(t *testing.T, calls []string, before, after string) {
 		t.Errorf("%q (idx %d) did not happen before %q (idx %d); calls=%v", before, bi, after, ai, calls)
 	}
 }
+
+// TestCopyTree_NestedDirsDurable exercises the copyTree directory-fsync path
+// (AGY review-011 Part I): a NESTED source tree must copy completely, with
+// every file and intermediate directory present and contents intact, and the
+// content checksum must be deterministic. The .configdb/staged trees are flat
+// today, so this is the only coverage of the nested branch (the new
+// createdDirs fsync loop). A bug in that loop — e.g. erroring on a nested dir
+// — fails here rather than silently shipping.
+func TestCopyTree_NestedDirsDurable(t *testing.T) {
+	src := t.TempDir()
+	files := map[string]string{
+		"top.txt":        "root file",
+		"a/d.txt":        "mid file",
+		"a/b/c.txt":      "deep file",
+		"a/b/e/leaf.txt": "leaf file",
+	}
+	for rel, content := range files {
+		full := filepath.Join(src, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir src %s: %v", full, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatalf("write src %s: %v", full, err)
+		}
+	}
+
+	dst := filepath.Join(t.TempDir(), "copy1")
+	sum1, err := copyTree(src, dst)
+	if err != nil {
+		t.Fatalf("copyTree nested tree: %v", err)
+	}
+	if sum1 == "" {
+		t.Fatal("copyTree returned empty checksum")
+	}
+
+	// Every file (and thus every intermediate dir) must be present + intact.
+	for rel, want := range files {
+		got, rerr := os.ReadFile(filepath.Join(dst, rel))
+		if rerr != nil {
+			t.Fatalf("nested entry %s not copied: %v", rel, rerr)
+		}
+		if string(got) != want {
+			t.Errorf("nested entry %s = %q, want %q", rel, got, want)
+		}
+	}
+
+	// Checksum is deterministic for the same source tree.
+	dst2 := filepath.Join(t.TempDir(), "copy2")
+	sum2, err := copyTree(src, dst2)
+	if err != nil {
+		t.Fatalf("copyTree second pass: %v", err)
+	}
+	if sum1 != sum2 {
+		t.Errorf("copyTree checksum non-deterministic: %s != %s", sum1, sum2)
+	}
+}

--- a/pkg/upgrade/runner_test.go
+++ b/pkg/upgrade/runner_test.go
@@ -607,3 +607,78 @@ func TestCopyTree_NestedDirsDurable(t *testing.T) {
 		t.Errorf("copyTree checksum non-deterministic: %s != %s", sum1, sum2)
 	}
 }
+
+// TestCopyTree_FsyncsEachDirDeepestFirst proves copyTree actually fsyncs every
+// copied directory, deepest-first (Codex/Copilot r1: the durability test must
+// fail if the fsync loop is removed). It substitutes the copyTreeSyncDir hook
+// with a recorder and asserts every nested dir is synced and that depth is
+// non-increasing across the recorded order.
+func TestCopyTree_FsyncsEachDirDeepestFirst(t *testing.T) {
+	src := t.TempDir()
+	for _, rel := range []string{"top.txt", "a/d.txt", "a/b/c.txt", "a/b/e/leaf.txt"} {
+		full := filepath.Join(src, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir src: %v", err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0644); err != nil {
+			t.Fatalf("write src: %v", err)
+		}
+	}
+
+	var synced []string
+	orig := copyTreeSyncDir
+	copyTreeSyncDir = func(d string) error { synced = append(synced, d); return nil }
+	defer func() { copyTreeSyncDir = orig }()
+
+	dst := filepath.Join(t.TempDir(), "copy")
+	if _, err := copyTree(src, dst); err != nil {
+		t.Fatalf("copyTree: %v", err)
+	}
+
+	// Every created directory must have been fsynced (root + a + a/b + a/b/e).
+	wantDirs := []string{dst, filepath.Join(dst, "a"), filepath.Join(dst, "a/b"), filepath.Join(dst, "a/b/e")}
+	syncedSet := map[string]bool{}
+	for _, d := range synced {
+		syncedSet[d] = true
+	}
+	for _, d := range wantDirs {
+		if !syncedSet[d] {
+			t.Errorf("copied dir %s was not fsynced (synced=%v)", d, synced)
+		}
+	}
+	if len(synced) == 0 {
+		t.Fatal("copyTree fsynced no directories — the durability loop did not run")
+	}
+
+	// Depth (path-separator count) must be non-increasing across the order.
+	prevDepth := strings.Count(synced[0], string(os.PathSeparator))
+	for _, d := range synced[1:] {
+		depth := strings.Count(d, string(os.PathSeparator))
+		if depth > prevDepth {
+			t.Errorf("fsync order not deepest-first: %s (depth %d) followed a shallower dir (depth %d): %v",
+				d, depth, prevDepth, synced)
+		}
+		prevDepth = depth
+	}
+}
+
+// TestCopyTree_FsyncDirErrorPropagates proves a directory-fsync failure aborts
+// copyTree (so a non-durable copy never silently becomes a rollback target).
+func TestCopyTree_FsyncDirErrorPropagates(t *testing.T) {
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "a/b"), 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "a/b/c.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	orig := copyTreeSyncDir
+	copyTreeSyncDir = func(d string) error { return fmt.Errorf("injected fsync failure") }
+	defer func() { copyTreeSyncDir = orig }()
+
+	dst := filepath.Join(t.TempDir(), "copy")
+	if _, err := copyTree(src, dst); err == nil {
+		t.Fatal("copyTree returned nil despite a directory-fsync failure")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1968 — two latent defensive-hardening fixes in `pkg/upgrade` surfaced by AGY review-011 Part I. **Neither is a live bug on the current tree**; both harden against format/schema drift. Behavior is identical on today's inputs.

1. **`parseSyncEstablished` scope + exact-match** (`cluster_cli.go`). The rolling-upgrade drain gate found the *first* `status:` line anywhere in `show chassis cluster information` and accepted it via `strings.Contains(ll, "up")`. Scoped the match to the sync/fabric link section (so a future pre-sync `Status:` section — e.g. folding in `FormatIPMonitoringStatus` — can't be mis-read and wrongly green-light a drain) and require the value to equal exactly `up` (so a future `Status: startup` isn't accepted). The `unsynced` / `Remote node: healthy` guards and fail-closed default are unchanged.

2. **`copyTree` nested-directory fsync** (`runner.go`). `copyTree` fsynced file *contents* but never the nested parent directories it created; callers fsync only the top-level copy root. A power loss after the atomic rename could orphan nested entries → a later auto-rollback could restore a corrupt config-DB snapshot. Latent because both copyTree sources (`.configdb` snapshot, staged→versions) are flat today; the fix makes copyTree durable for any future nesting. Additive — checksum/rename/caller-SyncDir behavior unchanged.

## Plan + research

Plan doc: `docs/research/agy-review-011/plan.md` (3-way converged PLAN-READY at `/research`). SMR + AGY PLAN-READY; Codex PLAN-NEEDS-MINOR → all 5 accuracy fixes folded (incl. the exact-`up` requirement in fix 1).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/upgrade/` clean
- [x] Full Go suite (`go test ./...`): no failures
- [x] `pkg/upgrade` suite: pass
- [x] New tests 5/5 flake-clean: `TestSyncParser_ScopedAndExact`, `TestParsers_AgainstRealFormatInformation` (extended), `TestCopyTree_NestedDirsDurable`
- [x] Behavior-preservation: existing `TestSyncParser_Fixtures` (Up→true / Down→false / missing→false) still passes unchanged

**Why no iperf3 CoS smoke matrix:** this is a Go-only change in `pkg/upgrade` (config-DB copy + cluster-status text parser) — it touches **no** dataplane/forwarding/CoS code, so the loss-cluster iperf matrix would exercise none of it.

**Why `make test-failover` is not the gate here:** `parseSyncEstablished` gates the **rolling-upgrade drain** (`xpfd upgrade --rolling`), not the VRRP failover path that `make test-failover` (reboot-during-iperf) exercises — so test-failover would not touch this code. The change is behavior-preserving on the current `FormatInformation` output (proven by the unchanged `TestSyncParser_Fixtures` + the real-format test) and unit-covered for the new scoping/exact-match and nested-fsync paths. Happy to run a rolling-drain integration check if a reviewer wants it.

**Docs:** no operator-facing behavior change; the *why* is captured in code comments. No doc update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)