### PR TITLE
#1966: debian/control — document postinst-driven standalone cut-over

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,9 +19,17 @@ Description: Junos-style firewall with AF_XDP userspace dataplane
  This package ships the binary set (xpfd, xpf-userspace-dp, cli),
  the day-0 config-drive loader, and the systemd units. Binaries are
  installed to a dpkg-static staging path; the live /usr/local/sbin
- symlinks are created on first install (the in-place upgrade cut-over
- mechanism that flips them after a verify gate is a separate increment
- and is intentionally not part of this package's postinst).
+ symlinks are created on first install.
+ .
+ On UPGRADE the postinst behaviour depends on the node role. A
+ STANDALONE node (no /etc/xpf/node-id) performs an automatic verified
+ in-place cut-over from postinst by invoking `xpfd upgrade` — the
+ atomic, rollback-capable STOP->FLIP->START cut to the staged version,
+ gated by the kernel verify-dataplane check. Set XPF_NO_POSTINST_CUT=1
+ to suppress the auto-cut and run `xpfd upgrade` manually. A CLUSTERED
+ node (/etc/xpf/node-id present) is staged only: the postinst never cuts
+ a clustered node, which is cut over with `xpfd upgrade --rolling` so
+ the cluster keeps forwarding through a controlled per-node drain.
  .
  The AF_XDP shim is embedded into the xpfd binary (go:embed), so no
  separate shim object is shipped.


### PR DESCRIPTION
## Summary

`debian/control` lines ~19-24 claimed the in-place upgrade cut-over
"is a separate increment and is intentionally not part of this
package's postinst." That is **stale**: `debian/xpf.postinst`
(increment B of #1917) DOES drive the cut-over from postinst — on
upgrade it invokes `"$STAGED/xpfd" upgrade` for standalone nodes,
performing the verified, rollback-capable STOP->FLIP->START cut.

This updates the package Description to match the actual postinst
behaviour:

- Binaries install to the dpkg-static staging path; live
  `/usr/local/sbin` symlinks are created on first install.
- On **UPGRADE**, a **standalone** node (no `/etc/xpf/node-id`) performs
  an automatic verified in-place cut-over from postinst via
  `xpfd upgrade`, suppressible with `XPF_NO_POSTINST_CUT=1`.
- A **clustered** node (`/etc/xpf/node-id` present) is staged only and
  is cut over with `xpfd upgrade --rolling` (controlled per-node drain).

Wording was confirmed against `debian/xpf.postinst`.

## Other stale references

`debian/changelog` (increment-A entry, line 7) also says the cut-over
"is a separate increment." That is **left as-is**: a debian changelog
entry is a historical release-log record and was accurate for increment
A — the postinst cut-over hook landed later in increment B. Rewriting a
past changelog entry to describe later behaviour would be historically
inaccurate. The forward-looking package documentation lives in the
`Description` field, which is what this PR fixes.

## Validation

Doc-only change.
- `go build ./...` clean (no Go impact).
- `debian/control` parses as three well-formed RFC822 stanzas.
- `dpkg-parsechangelog` OK.

Closes #1966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)