### PR TITLE
#1965: serialize host-local upgrade mutators with a shared lock

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -5851,3 +5851,13 @@ top.
 - **Edit**: pkg/upgrade/runner.go — copyTree: fsync each copied directory (deepest-first) so nested entries survive power loss.
 - **Edit**: pkg/upgrade/runner_test.go — TestCopyTree_NestedDirsDurable.
 - **Edit** (r1 review fixes): runner.go — extract fsyncDirsDeepestFirst (true depth via separator count, not string length) + copyTreeSyncDir test seam; runner_test.go — TestCopyTree_FsyncsEachDirDeepestFirst (recorder proves loop runs + deepest-first) + TestCopyTree_FsyncDirErrorPropagates; cluster_cli_test.go — Not-configured-then-later-Status fixture.
+
+## 2026-06-18 — #1965 host-wide upgrade lock (finish + quad review, PR #1971)
+- **Timestamp**: 2026-06-18
+- **Action**: Finish #1965 (host-wide advisory upgrade lock) — committed the crash-point pending maintainer-script + docs work, drove the 4-way review, and fixed two review findings.
+- **Edit**: debian/xpf.preinst (new) — pre-unpack `flock -n /run/xpf/upgrade.lock` gate; exits non-zero on busy so apt aborts before any mutation. No systemctl.
+- **Edit**: debian/xpf.postinst — TOCTOU contention residual (drop /run/xpf/upgrade-deferred, exit 0, never non-zero) + boot-guard the failed-cut systemctl with `[ -d /run/systemd/system ]`; later also drop the deferred marker when the inner cut fails busy (Codex MINOR).
+- **Edit**: docs/in-place-upgrade.md — document the lock contract, rolling re-entrancy, cluster-lock-OUTSIDE/host-lock-INSIDE order, dpkg-vs-operator staged-source race + verify-dataplane backstop.
+- **Edit**: pkg/upgrade/lock/lock.go — make owner-metadata write strictly best-effort (Codex MAJOR/Copilot): on writeOwnerFn failure log to stderr and return (handle, nil), never a held-handle-plus-error pair that callers would drop (fd leak). Added writeOwnerFn test seam.
+- **Edit**: pkg/upgrade/lock/lock_test.go — TestMetadataWriteFailureStillHoldsLock (held lock + nil error + busy second acquire + release/reacquire).
+- **Validation**: go build/vet clean; full Go suite green; lock tests pass 5x; sh -n clean on both maintainer scripts. Quad review: Claude SMR MERGE-READY, AGY MERGE-READY (r2), Codex MERGE-READY (r2, no findings), Copilot single finding fixed.

--- a/cmd/xpfd/upgrade_kernel.go
+++ b/cmd/xpfd/upgrade_kernel.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/upgrade"
+	"github.com/psaab/xpf/pkg/upgrade/lock"
 )
 
 // runUpgradeKernelSubcommand implements `xpfd upgrade kernel ...` — the LANE-1
@@ -47,6 +48,26 @@ func runUpgradeKernelSubcommand(args []string) {
 	unit := fs.String("unit", "xpfd", "systemd unit (cluster gRPC target)")
 	if err := fs.Parse(args[1:]); err != nil {
 		os.Exit(1)
+	}
+
+	// Serialize the MUTATING kernel sub-verbs (arm/promote/drain/rejoin)
+	// against every other host-local upgrade mutator via the host-wide
+	// upgrade lock (#1965). `status` is read-only and stays lock-free.
+	// Release on every return path; note that `arm` reboots on success and
+	// does not return — the reboot clears /run tmpfs so the lock is gone
+	// either way.
+	switch verb {
+	case "arm", "promote", "drain", "rejoin":
+		target := ""
+		if verb == "arm" && len(fs.Args()) == 1 {
+			target = fs.Args()[0]
+		}
+		h, lerr := lock.Acquire("upgrade kernel "+verb, target)
+		if lerr != nil {
+			fmt.Fprintf(os.Stderr, "upgrade kernel %s: %v\n", verb, lerr)
+			os.Exit(1)
+		}
+		defer func() { _ = h.Release() }()
 	}
 
 	cfg := upgrade.KernelConfig{

--- a/debian/xpf.postinst
+++ b/debian/xpf.postinst
@@ -117,6 +117,20 @@ case "$1" in
                 # re-run xpf-upgrade); surface it loudly instead.
                 if ! "$STAGED/xpfd" upgrade; then
                     echo "xpf: WARNING in-place cut-over did not complete." >&2
+                    # #1965 (Codex MINOR): an operator could have acquired the
+                    # host-wide lock AFTER the shell precheck above but BEFORE
+                    # this inner cut, so the cut aborted busy. Drop the same
+                    # deferred marker the explicit contention branch drops so
+                    # the residual is recorded consistently regardless of which
+                    # window the contention landed in. Best-effort: if the lock
+                    # is still busy now, mark it deferred.
+                    if [ -e /run/xpf/upgrade.lock ] && \
+                       ! flock -n /run/xpf/upgrade.lock true 2>/dev/null; then
+                        mkdir -p /run/xpf
+                        : > /run/xpf/upgrade-deferred 2>/dev/null || true
+                        echo "xpf: another upgrade is in progress — staged only;" \
+                             "run 'xpfd upgrade' after it completes." >&2
+                    fi
                     # Safety net (Copilot): the cut STOPs the unit before it
                     # FLIPs. Most failures (preflight/copy/verify) abort
                     # BEFORE the stop and leave the daemon running; the

--- a/debian/xpf.postinst
+++ b/debian/xpf.postinst
@@ -87,15 +87,34 @@ case "$1" in
             elif [ "${XPF_NO_POSTINST_CUT:-}" = "1" ]; then
                 echo "xpf: XPF_NO_POSTINST_CUT=1 — staged only;" \
                      "cut over with: xpfd upgrade" >&2
+            elif ! flock -n /run/xpf/upgrade.lock true 2>/dev/null && [ -e /run/xpf/upgrade.lock ]; then
+                # #1965 postinst contention residual: in the rare TOCTOU
+                # case where the host-wide upgrade lock became busy between
+                # the preinst gate (which released its fd at preinst exit)
+                # and now, another upgrade is in progress. The new binary
+                # set is already staged. Do NOT cut (that would race the
+                # other mutator's journal/symlink state) and do NOT fail the
+                # postinst (a non-zero postinst leaves dpkg half-configured,
+                # worse than a deferred cut on a host still running the old
+                # in-memory daemon). Log loudly, drop a deferred marker, and
+                # exit 0; the operator runs `xpfd upgrade` once the other
+                # operation completes.
+                mkdir -p /run/xpf
+                : > /run/xpf/upgrade-deferred 2>/dev/null || true
+                echo "xpf: another upgrade is in progress — staged only;" \
+                     "run 'xpfd upgrade' after it completes." >&2
+                cat /run/xpf/upgrade.lock 2>/dev/null >&2 || true
             else
                 echo "xpf: standalone node — performing verified in-place cut-over" >&2
                 # Run the staged binary's upgrade subcommand: it copies
                 # staging into the versioned runtime dir, runs the kernel
                 # verify-dataplane gate, and on PASS does the atomic
-                # STOP->FLIP->START with rollback. A REJECT/abort leaves the
-                # running daemon untouched. We do NOT fail the package
-                # install on a cut-over abort (the operator can re-run
-                # xpf-upgrade); surface it loudly instead.
+                # STOP->FLIP->START with rollback. The binary itself takes
+                # the host-wide upgrade lock (#1965); the flock pre-check
+                # above only narrows the TOCTOU window. A REJECT/abort
+                # leaves the running daemon untouched. We do NOT fail the
+                # package install on a cut-over abort (the operator can
+                # re-run xpf-upgrade); surface it loudly instead.
                 if ! "$STAGED/xpfd" upgrade; then
                     echo "xpf: WARNING in-place cut-over did not complete." >&2
                     # Safety net (Copilot): the cut STOPs the unit before it
@@ -106,7 +125,10 @@ case "$1" in
                     # and START could leave the unit stopped. If it is not
                     # active, try to bring it back up so the node is not left
                     # offline after `apt upgrade`.
-                    if ! systemctl is-active --quiet xpfd; then
+                    # Boot-guard the systemctl calls (#1965): in a
+                    # non-booted env (docker/chroot/bake) systemctl exits
+                    # non-zero and, under set -e, would fail the postinst.
+                    if [ -d /run/systemd/system ] && ! systemctl is-active --quiet xpfd; then
                         echo "xpf: unit not active after a failed cut-over; restarting" >&2
                         systemctl start xpfd 2>/dev/null || \
                             echo "xpf: WARNING could not restart xpfd; run: xpfd upgrade" >&2

--- a/debian/xpf.preinst
+++ b/debian/xpf.preinst
@@ -1,0 +1,55 @@
+#!/bin/sh
+# xpf preinst (#1965 — host-wide upgrade-lock gate, before unpack).
+#
+# A concurrent operator `xpfd upgrade` (or `xpfd upgrade --rolling`, or a
+# `xpfd upgrade kernel arm`) holds the host-wide advisory lock
+# /run/xpf/upgrade.lock for its whole cut. If apt unpacked the new package
+# while one of those was mid-copy, dpkg would overwrite the dpkg-staged
+# binary set under /usr/local/share/xpf/staged/ that the operator's cut is
+# reading — a torn source. The preinst runs BEFORE unpack (Debian Policy
+# §6.5/§6.6), so this is the correct place to FAIL the package operation
+# loudly and atomically (apt aborts before any mutation) if an upgrade is
+# already in progress.
+#
+# This is a non-blocking gate, not full serialization: a flock fd dies when
+# preinst exits, so the lock is NOT held during dpkg's unpack, and an
+# operator who acquires the (now-free) lock DURING unpack could still read a
+# torn staged tree. The torn-binary backstop is the `verify-dataplane`
+# kernel gate the in-place cut runs against the COPIED binary before
+# StopUnit (a torn/non-execable ELF fails verify and aborts the cut while
+# the daemon is still up). Operator guidance: do not run `xpfd upgrade`
+# during `apt upgrade`.
+
+set -e
+
+LOCK=/run/xpf/upgrade.lock
+
+case "$1" in
+    upgrade)
+        # /run is tmpfs and may lack our subdir on a fresh boot.
+        mkdir -p /run/xpf
+
+        # Non-blocking exclusive lock. If another upgrade holds it, flock
+        # exits non-zero and (under set -e) fails the preinst, so apt aborts
+        # BEFORE unpacking — the system is left untouched. We immediately
+        # release (the subshell exits); the gate only needs to PROVE the
+        # lock is free at this instant, not hold it through the unpack (which
+        # a preinst fd cannot do across the dpkg boundary anyway).
+        if ! flock -n "$LOCK" true; then
+            echo "xpf: another in-place upgrade is in progress (holds $LOCK)." >&2
+            echo "xpf: refusing to unpack — wait for it to finish, then re-run apt." >&2
+            cat "$LOCK" 2>/dev/null >&2 || true
+            exit 1
+        fi
+        ;;
+    install|abort-upgrade)
+        ;;
+    *)
+        echo "preinst called with unknown argument \`$1'" >&2
+        exit 1
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -133,6 +133,51 @@ raw push+restart path (and `XPF_DEPLOY_FAST`) is unchanged for the dev
 inner loop. The deb path is opt-in until validated live; it then becomes
 the CI/smoke default.
 
+## Host-wide upgrade lock (#1965)
+
+Every MUTATING upgrade operation on a host takes one host-wide advisory
+lock — `/run/xpf/upgrade.lock`, a non-blocking exclusive `flock(2)`
+(`pkg/upgrade/lock`). It serializes the standalone binary cut
+(`xpfd upgrade`), the rolling driver (`xpfd upgrade --rolling`), the
+postinst auto-cut, and the mutating `xpfd upgrade kernel`
+sub-verbs (`arm`/`promote`/`drain`/`rejoin`). Without it two mutators
+silently corrupt the crash-safe journal: both load the same snapshot,
+modify independent copies, and last-write-wins, losing the rollback
+target. Read-only status (`xpfd upgrade kernel status`) stays lock-free.
+
+- `/run` is tmpfs and reboot-clearing — exactly right: the lock guards
+  CONCURRENT mutators, while crash recovery stays journal-driven (the
+  durable journal lives under `/var/lib/xpf`). A reboot mid-upgrade
+  leaves no stale lock; the resume reads the journal, not the lock.
+  `mkdir -p /run/xpf` runs before every acquire (a fresh boot's tmpfs may
+  lack the dir).
+- Owner metadata (PID, subcommand, target, start time) is written into
+  the lock file after the flock succeeds, so a busy acquirer's error
+  NAMES the current owner.
+- The lock is released on every exit path (normal/error/panic) via defer;
+  the kernel also drops the flock on process exit, so a crashed holder
+  never wedges the host.
+- **Rolling re-entrancy:** `RunRolling` takes the lock at entry and holds
+  it through rejoin (covering the peer-check + `ForceSecondary` + drain
+  window, not just the inner cut). The inner `r.Run()` runs with
+  `Options{LockAlreadyHeld: true}` so it does NOT re-flock the same file
+  (a second flock on a fresh fd of the same path returns `EWOULDBLOCK`
+  and would abort the rolling upgrade).
+- **Lock ordering vs the `/tmp/xpf-cluster.lock` deploy lock (#1875):**
+  the cluster/deploy lock is taken OUTSIDE, the host upgrade lock INSIDE.
+  No deadlock — the two never nest in the opposite order.
+- **dpkg-vs-operator staged-source race:** `debian/xpf.preinst` runs
+  BEFORE unpack and `flock -n /run/xpf/upgrade.lock`-gates the package
+  operation, failing apt loudly (non-zero, system untouched) if an
+  operator upgrade already holds the lock. This is a fail-loud gate, not
+  full unpack serialization: a preinst fd dies at preinst exit, so the
+  lock is not held DURING dpkg's unpack. The torn-binary backstop is the
+  `verify-dataplane` kernel gate the cut runs against the COPIED binary
+  before `StopUnit`. The postinst standalone path re-checks the lock and,
+  on the narrow TOCTOU residual, drops `/run/xpf/upgrade-deferred`, logs
+  loudly, and exits 0 (a non-zero postinst leaves dpkg half-configured).
+  Operator guidance: do not run `xpfd upgrade` during `apt upgrade`.
+
 ## Peer-takeover-readiness is best-effort; DrainComplete is authoritative
 
 The local control socket renders the LOCAL node's view, so the

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -21,6 +21,16 @@ type Options struct {
 	// drained to its peer via the cluster state machine, so the cluster
 	// keeps forwarding regardless.
 	UnitAlreadyStopped bool
+
+	// LockAlreadyHeld tells Run NOT to acquire the host-wide upgrade lock
+	// because a caller higher in the stack already holds it (#1965). The
+	// `--rolling` driver (RunRolling) acquires the lock at its entry and
+	// holds it through the peer-check + drain + cut + rejoin; the inner
+	// r.Run() it invokes MUST set this, because a second flock on a fresh
+	// fd of the same file returns EWOULDBLOCK and would abort the rolling
+	// upgrade. The standalone single-node flow (and the postinst cut) leave
+	// it false so Run owns the lock.
+	LockAlreadyHeld bool
 }
 
 // Run executes (or resumes) the cut-over to the staged version. It is
@@ -29,6 +39,22 @@ type Options struct {
 // The standalone single-node flow. The HA rolling driver wraps this with
 // a controlled drain (rolling.go).
 func (r *Runner) Run(opts Options) (err error) {
+	// Acquire the host-wide upgrade lock BEFORE any journal read or live
+	// mutation, unless a caller higher in the stack already holds it (the
+	// --rolling driver — #1965). Holding the lock from here through return
+	// serializes this cut against a concurrent operator cut, the postinst
+	// cut, and a `kernel arm`. Release on every exit path (normal, error,
+	// panic) via defer. The standalone single-node flow owns the lock; the
+	// rolling driver sets LockAlreadyHeld so the inner cut does not try to
+	// re-flock the same file (which would EWOULDBLOCK and abort).
+	if !opts.LockAlreadyHeld {
+		h, lerr := acquireUpgradeLock("upgrade", "")
+		if lerr != nil {
+			return fmt.Errorf("upgrade: %w", lerr)
+		}
+		defer func() { _ = h.Release() }()
+	}
+
 	j, err := r.loadJournal()
 	if err != nil {
 		return err

--- a/pkg/upgrade/lock/lock.go
+++ b/pkg/upgrade/lock/lock.go
@@ -110,8 +110,13 @@ func IsBusy(err error) bool {
 // Handle whose Release drops it. It is a non-blocking exclusive flock: if
 // another process holds the lock, it returns an *ErrBusy naming the owner.
 //
-// The owner metadata (PID, subcommand, target, start time) is recorded in
-// the lock file after the flock succeeds.
+// On success Acquire returns (handle, nil): once the flock is held, the
+// returned error is always nil. The owner metadata (PID, subcommand,
+// target, start time) is recorded in the lock file best-effort AFTER the
+// flock succeeds; a metadata-write failure is logged to stderr and never
+// surfaced as an Acquire error (it would otherwise tempt callers to discard
+// the held handle and leak the fd). A nil error therefore unambiguously
+// means "lock held".
 func Acquire(subcommand, target string) (*Handle, error) {
 	return AcquireAt(DefaultPath, subcommand, target)
 }
@@ -145,19 +150,24 @@ func AcquireAt(path, subcommand, target string) (*Handle, error) {
 	h := &Handle{f: f}
 
 	// We hold the lock — record owner metadata. Truncate first so a stale
-	// (larger) prior record never leaves trailing bytes. A metadata-write
-	// failure is non-fatal to holding the lock (the lock is the flock, not
-	// the file contents) — we keep the lock but surface the write error so
-	// the caller can log it; the busy path then degrades to a nil Owner.
-	if err := writeOwner(f, Owner{
+	// (larger) prior record never leaves trailing bytes. The metadata write
+	// is TRULY best-effort: a write failure is non-fatal to holding the lock
+	// (the lock is the flock, not the file contents), so we must NOT return a
+	// non-nil error here. Callers uniformly treat a non-nil Acquire error as
+	// "lock not held" and return WITHOUT deferring Release — returning the
+	// held handle alongside an error would leak the held fd until process
+	// exit (Codex MAJOR #1). Instead we swallow the write error and log it to
+	// stderr; the busy path then simply degrades to a nil Owner (busy, owner
+	// unknown). The flock — the actual mutual exclusion — is fully held.
+	if werr := writeOwnerFn(f, Owner{
 		PID:        os.Getpid(),
 		Subcommand: subcommand,
 		Target:     target,
 		StartedAt:  time.Now(),
-	}); err != nil {
-		// Keep the lock; report a non-fatal metadata error wrapped so the
-		// caller may log it but the Handle is still valid.
-		return h, fmt.Errorf("upgrade lock: acquired but failed to record owner metadata: %w", err)
+	}); werr != nil {
+		fmt.Fprintf(os.Stderr,
+			"upgrade lock: held %s but failed to record owner metadata (busy errors will not name this owner): %v\n",
+			path, werr)
 	}
 	return h, nil
 }
@@ -177,6 +187,12 @@ func (h *Handle) Release() error {
 	_ = unix.Flock(int(h.f.Fd()), unix.LOCK_UN)
 	return h.f.Close()
 }
+
+// writeOwnerFn is the seam through which AcquireAt records owner metadata.
+// Production uses writeOwner; tests substitute a failing writer to prove the
+// best-effort contract (a metadata-write failure still yields a held lock and
+// a nil Acquire error).
+var writeOwnerFn = writeOwner
 
 // writeOwner truncates the lock file and writes the owner metadata as
 // pretty JSON. The fd already holds the flock.

--- a/pkg/upgrade/lock/lock.go
+++ b/pkg/upgrade/lock/lock.go
@@ -1,0 +1,212 @@
+// Package lock provides a host-wide advisory lock that serializes every
+// mutating xpf upgrade operation on a single host (#1965).
+//
+// Background: the upgrade subsystem (pkg/upgrade, cmd/xpfd/upgrade*.go,
+// debian/*) durably writes a crash-safe journal, repoints symlinks, and
+// installs systemd drop-ins with NO host-local serialization. Two
+// mutators racing (operator `xpfd upgrade` vs the Debian postinst cut, a
+// binary cut vs `xpfd upgrade kernel arm`, a `--rolling` driver vs a local
+// cut) silently corrupt that state: both loadJournal() the same snapshot,
+// modify independent copies, and saveJournal() last-write-wins, losing the
+// PreviousVersion / rollback target. Unlike a fixed-name temp-symlink
+// collision (which errors cleanly via EEXIST), the journal race is silent.
+//
+// The fix is one host-wide advisory lock taken by every MUTATING upgrade
+// entry point — binary cut, rolling driver, postinst cut, and the mutating
+// `xpfd upgrade kernel` sub-verbs (arm/promote/drain/rejoin). Read-only
+// status commands stay lock-free.
+//
+// Design:
+//   - The lock is an exclusive non-blocking BSD advisory lock
+//     (flock(2), LOCK_EX|LOCK_NB) on /run/xpf/upgrade.lock.
+//   - /run is tmpfs and reboot-clearing, which is exactly right: the lock
+//     guards against CONCURRENT mutators, while crash recovery is journal-
+//     driven (the durable journal lives under /var/lib/xpf). A reboot that
+//     interrupts an upgrade leaves no stale lock; the resume reads the
+//     journal, not the lock.
+//   - /run/xpf is created (mkdir -p) before the acquire — a fresh boot's
+//     tmpfs may not have it yet.
+//   - Owner metadata (PID, subcommand, target version/kernel, start time)
+//     is written into the lock file AFTER the flock succeeds, so a busy
+//     error can name the CURRENT owner instead of merely reporting "busy".
+//   - flock is advisory and tied to the OPEN FILE DESCRIPTION, not the
+//     path: a second open()+flock() on the same path returns EWOULDBLOCK
+//     while another fd holds LOCK_EX. The lock is released by closing the
+//     fd (Handle.Release), and the kernel also releases it on process
+//     exit, so a crashed holder never wedges the host.
+package lock
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// DefaultPath is the host-wide upgrade lock file. /run is tmpfs (reboot-
+// clearing) — see the package doc for why that is correct.
+const DefaultPath = "/run/xpf/upgrade.lock"
+
+// Owner is the metadata persisted into the lock file by the current
+// holder. It is written after the flock succeeds and read back by a
+// would-be acquirer so a busy error names the owner.
+type Owner struct {
+	// PID is the holding process id.
+	PID int `json:"pid"`
+	// Subcommand is the mutating operation, e.g. "upgrade",
+	// "upgrade --rolling", "upgrade kernel arm".
+	Subcommand string `json:"subcommand"`
+	// Target is the target version or kernel (best-effort, may be empty
+	// when not yet known at acquire time).
+	Target string `json:"target,omitempty"`
+	// StartedAt is when the holder acquired the lock.
+	StartedAt time.Time `json:"started_at"`
+}
+
+func (o Owner) String() string {
+	tgt := o.Target
+	if tgt == "" {
+		tgt = "(unknown)"
+	}
+	return fmt.Sprintf("pid=%d subcommand=%q target=%s started=%s",
+		o.PID, o.Subcommand, tgt, o.StartedAt.Format(time.RFC3339))
+}
+
+// Handle is a held upgrade lock. Release MUST be called (via defer) on
+// every exit path — normal, error, and panic — to drop the lock; the
+// kernel also drops it on process exit as a backstop.
+type Handle struct {
+	f        *os.File
+	released bool
+}
+
+// ErrBusy is returned by Acquire when another process holds the lock. The
+// error text names the current owner (read from the lock file) when it is
+// readable.
+type ErrBusy struct {
+	Path  string
+	Owner *Owner // nil if owner metadata could not be read
+}
+
+func (e *ErrBusy) Error() string {
+	if e.Owner != nil {
+		return fmt.Sprintf("another upgrade is in progress (holds %s): %s",
+			e.Path, e.Owner.String())
+	}
+	return fmt.Sprintf("another upgrade is in progress (holds %s; owner metadata unavailable)", e.Path)
+}
+
+// IsBusy reports whether err is (or wraps) an ErrBusy.
+func IsBusy(err error) bool {
+	var b *ErrBusy
+	return errors.As(err, &b)
+}
+
+// Acquire takes the host-wide upgrade lock at DefaultPath, returning a
+// Handle whose Release drops it. It is a non-blocking exclusive flock: if
+// another process holds the lock, it returns an *ErrBusy naming the owner.
+//
+// The owner metadata (PID, subcommand, target, start time) is recorded in
+// the lock file after the flock succeeds.
+func Acquire(subcommand, target string) (*Handle, error) {
+	return AcquireAt(DefaultPath, subcommand, target)
+}
+
+// AcquireAt is Acquire against an explicit path (for tests; production
+// always uses DefaultPath via Acquire).
+func AcquireAt(path, subcommand, target string) (*Handle, error) {
+	// /run is tmpfs and may lack our subdir on a fresh boot.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("upgrade lock: create %s: %w", filepath.Dir(path), err)
+	}
+
+	// O_CREATE so the first acquirer makes the file; no O_TRUNC so a busy
+	// acquirer can still read the holder's metadata.
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("upgrade lock: open %s: %w", path, err)
+	}
+
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		// Busy (EWOULDBLOCK) — read the holder's metadata so the error
+		// names the owner. Any read failure degrades to a nil Owner.
+		owner := readOwner(f)
+		f.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) {
+			return nil, &ErrBusy{Path: path, Owner: owner}
+		}
+		return nil, fmt.Errorf("upgrade lock: flock %s: %w", path, err)
+	}
+
+	h := &Handle{f: f}
+
+	// We hold the lock — record owner metadata. Truncate first so a stale
+	// (larger) prior record never leaves trailing bytes. A metadata-write
+	// failure is non-fatal to holding the lock (the lock is the flock, not
+	// the file contents) — we keep the lock but surface the write error so
+	// the caller can log it; the busy path then degrades to a nil Owner.
+	if err := writeOwner(f, Owner{
+		PID:        os.Getpid(),
+		Subcommand: subcommand,
+		Target:     target,
+		StartedAt:  time.Now(),
+	}); err != nil {
+		// Keep the lock; report a non-fatal metadata error wrapped so the
+		// caller may log it but the Handle is still valid.
+		return h, fmt.Errorf("upgrade lock: acquired but failed to record owner metadata: %w", err)
+	}
+	return h, nil
+}
+
+// Release drops the lock and closes the fd. It is idempotent and safe to
+// call from a defer on every path (normal, error, panic). Closing the fd
+// releases the flock; the kernel also releases on process exit.
+func (h *Handle) Release() error {
+	if h == nil || h.released {
+		return nil
+	}
+	h.released = true
+	// Closing the fd releases the flock (the lock is tied to the open file
+	// description). Explicitly LOCK_UN first is redundant but harmless and
+	// makes the release intent obvious; ignore its error since Close is the
+	// authoritative drop.
+	_ = unix.Flock(int(h.f.Fd()), unix.LOCK_UN)
+	return h.f.Close()
+}
+
+// writeOwner truncates the lock file and writes the owner metadata as
+// pretty JSON. The fd already holds the flock.
+func writeOwner(f *os.File, o Owner) error {
+	data, err := json.MarshalIndent(o, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := f.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := f.WriteAt(data, 0); err != nil {
+		return err
+	}
+	// Best-effort durability; the lock's correctness does not depend on the
+	// metadata reaching disk (tmpfs anyway).
+	_ = f.Sync()
+	return nil
+}
+
+// readOwner reads and parses the owner metadata from an open lock file.
+// Returns nil on any read/parse failure (degrade to "busy, owner unknown").
+func readOwner(f *os.File) *Owner {
+	data, err := os.ReadFile(f.Name())
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+	var o Owner
+	if err := json.Unmarshal(data, &o); err != nil {
+		return nil
+	}
+	return &o
+}

--- a/pkg/upgrade/lock/lock_test.go
+++ b/pkg/upgrade/lock/lock_test.go
@@ -159,6 +159,46 @@ func TestReleaseOnProcessExit(t *testing.T) {
 	}
 }
 
+// TestMetadataWriteFailureStillHoldsLock proves the best-effort contract
+// (Codex MAJOR #1): when recording owner metadata fails, Acquire must STILL
+// return a held lock with a NIL error, because callers treat a non-nil
+// Acquire error as "lock not held" and return WITHOUT deferring Release — a
+// (held handle, non-nil error) pair would leak the fd until process exit.
+func TestMetadataWriteFailureStillHoldsLock(t *testing.T) {
+	p := lockPath(t)
+
+	prev := writeOwnerFn
+	writeOwnerFn = func(*os.File, Owner) error {
+		return os.ErrInvalid // force the metadata write to fail
+	}
+	t.Cleanup(func() { writeOwnerFn = prev })
+
+	h, err := AcquireAt(p, "upgrade", "meta-fail")
+	if err != nil {
+		t.Fatalf("metadata-write failure must NOT fail Acquire (would tempt callers to leak the held fd); got err=%v", err)
+	}
+	if h == nil {
+		t.Fatal("Acquire returned a nil handle on a successful flock")
+	}
+
+	// The lock must genuinely be held: a second acquire is busy. Restore the
+	// real writer first so the busy probe behaves normally.
+	writeOwnerFn = prev
+	if _, err2 := AcquireAt(p, "upgrade", "second"); !IsBusy(err2) {
+		t.Fatalf("lock not actually held after a metadata-write failure; second acquire err=%v", err2)
+	}
+
+	// Releasing the held handle frees the lock.
+	if rerr := h.Release(); rerr != nil {
+		t.Fatalf("release: %v", rerr)
+	}
+	h2, err := AcquireAt(p, "upgrade", "after-release")
+	if err != nil {
+		t.Fatalf("reacquire after release: %v", err)
+	}
+	_ = h2.Release()
+}
+
 func TestMkdirCreatesRunDir(t *testing.T) {
 	// Point at a nested non-existent dir; Acquire must mkdir -p it.
 	p := filepath.Join(t.TempDir(), "xpf", "nested", "upgrade.lock")

--- a/pkg/upgrade/lock/lock_test.go
+++ b/pkg/upgrade/lock/lock_test.go
@@ -1,0 +1,173 @@
+package lock
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// lockPath returns a short tmpdir lock path. We deliberately avoid /dev/shm
+// TMPDIR collisions; t.TempDir() is process-scoped and cleaned per test.
+func lockPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "upgrade.lock")
+}
+
+func TestAcquireAndRelease(t *testing.T) {
+	p := lockPath(t)
+	h, err := AcquireAt(p, "upgrade", "1.2.3")
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// The lock file must carry the owner metadata.
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read lock file: %v", err)
+	}
+	if !strings.Contains(string(data), `"subcommand": "upgrade"`) ||
+		!strings.Contains(string(data), `"target": "1.2.3"`) {
+		t.Fatalf("owner metadata missing/incorrect: %s", data)
+	}
+
+	if err := h.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	// Release is idempotent.
+	if err := h.Release(); err != nil {
+		t.Fatalf("second release should be a no-op: %v", err)
+	}
+
+	// After release the lock is reacquirable.
+	h2, err := AcquireAt(p, "upgrade", "1.2.4")
+	if err != nil {
+		t.Fatalf("reacquire after release: %v", err)
+	}
+	_ = h2.Release()
+}
+
+func TestSecondAcquireIsBusy(t *testing.T) {
+	p := lockPath(t)
+	h, err := AcquireAt(p, "upgrade --rolling", "2.0.0")
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer h.Release()
+
+	// flock is tied to the open file description; a second open()+flock()
+	// on the SAME path from the SAME process still returns EWOULDBLOCK.
+	_, err = AcquireAt(p, "upgrade", "2.0.1")
+	if err == nil {
+		t.Fatal("second acquire should fail while the lock is held")
+	}
+	if !IsBusy(err) {
+		t.Fatalf("second acquire should be ErrBusy, got %T: %v", err, err)
+	}
+	// The busy error must NAME the owner, not just say "busy".
+	if !strings.Contains(err.Error(), "rolling") || !strings.Contains(err.Error(), "2.0.0") {
+		t.Fatalf("busy error should name the owner subcommand/target: %v", err)
+	}
+}
+
+func TestReleaseOnPanicViaDefer(t *testing.T) {
+	p := lockPath(t)
+
+	func() {
+		defer func() {
+			_ = recover()
+		}()
+		h, err := AcquireAt(p, "upgrade", "panic-test")
+		if err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+		defer h.Release() // must run on panic unwind
+		panic("boom")
+	}()
+
+	// After the panic unwound through the deferred Release, the lock is
+	// reacquirable.
+	h, err := AcquireAt(p, "upgrade", "after-panic")
+	if err != nil {
+		t.Fatalf("lock not released after panic: %v", err)
+	}
+	_ = h.Release()
+}
+
+func TestReleaseOnErrorPath(t *testing.T) {
+	p := lockPath(t)
+
+	// Simulate a mutator that acquires, hits an error, and returns through
+	// a deferred Release.
+	run := func() (err error) {
+		h, aerr := AcquireAt(p, "upgrade", "err-test")
+		if aerr != nil {
+			return aerr
+		}
+		defer h.Release()
+		return os.ErrInvalid // simulated downstream error
+	}
+	if err := run(); err == nil {
+		t.Fatal("expected the simulated error to propagate")
+	}
+	// Lock must be free now.
+	h, err := AcquireAt(p, "upgrade", "after-err")
+	if err != nil {
+		t.Fatalf("lock not released after error path: %v", err)
+	}
+	_ = h.Release()
+}
+
+// TestReleaseOnProcessExit proves the kernel drops the flock when the
+// holding PROCESS exits even without an explicit Release — the crash
+// backstop. A child process acquires the lock and exits; the parent then
+// acquires it.
+func TestReleaseOnProcessExit(t *testing.T) {
+	if os.Getenv("XPF_LOCK_CHILD") == "1" {
+		// Child: acquire and exit immediately WITHOUT releasing.
+		p := os.Getenv("XPF_LOCK_PATH")
+		if _, err := AcquireAt(p, "upgrade", "child"); err != nil {
+			os.Exit(2)
+		}
+		os.Exit(0)
+	}
+
+	p := lockPath(t)
+	cmd := exec.Command(os.Args[0], "-test.run", "TestReleaseOnProcessExit")
+	cmd.Env = append(os.Environ(), "XPF_LOCK_CHILD=1", "XPF_LOCK_PATH="+p)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("child failed to acquire/exit: %v\n%s", err, out)
+	}
+
+	// Child has exited; the kernel released its flock. We can acquire.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h, err := AcquireAt(p, "upgrade", "parent")
+		if err == nil {
+			_ = h.Release()
+			return
+		}
+		if !IsBusy(err) {
+			t.Fatalf("unexpected acquire error: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("lock not released after child exit within deadline")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestMkdirCreatesRunDir(t *testing.T) {
+	// Point at a nested non-existent dir; Acquire must mkdir -p it.
+	p := filepath.Join(t.TempDir(), "xpf", "nested", "upgrade.lock")
+	h, err := AcquireAt(p, "upgrade", "mkdir")
+	if err != nil {
+		t.Fatalf("acquire should create the parent dir: %v", err)
+	}
+	defer h.Release()
+	if _, err := os.Stat(filepath.Dir(p)); err != nil {
+		t.Fatalf("parent dir not created: %v", err)
+	}
+}

--- a/pkg/upgrade/lock_integration_test.go
+++ b/pkg/upgrade/lock_integration_test.go
@@ -1,0 +1,157 @@
+package upgrade
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRun_TakesAndReleasesLock proves the standalone cut acquires the
+// host-wide upgrade lock exactly once and releases it on normal exit
+// (#1965).
+func TestRun_TakesAndReleasesLock(t *testing.T) {
+	st := &fakeUpgradeLockState{}
+	st.install(t)
+
+	fs := newFakeSystem(t, "2.0.0")
+	r, _ := testEnv(t, fs)
+
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt32(&st.acquires); got != 1 {
+		t.Fatalf("expected exactly 1 acquire, got %d", got)
+	}
+	if got := atomic.LoadInt32(&st.releases); got != 1 {
+		t.Fatalf("expected exactly 1 release, got %d", got)
+	}
+	if got := atomic.LoadInt32(&st.held); got != 0 {
+		t.Fatalf("lock still held after Run: held=%d", got)
+	}
+}
+
+// TestRun_BusyLockAbortsBeforeAnyMutation proves a busy lock aborts the
+// cut BEFORE any live mutation: no StopUnit, no flip, no verify, and no
+// journal file written. This is the core #1965 guarantee — the second
+// concurrent mutator exits before touching journal/symlink/systemd state.
+func TestRun_BusyLockAbortsBeforeAnyMutation(t *testing.T) {
+	st := &fakeUpgradeLockState{}
+	st.busy.Store(true)
+	st.install(t)
+
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+
+	err := r.Run(Options{})
+	if err == nil {
+		t.Fatal("expected Run to fail while the lock is busy")
+	}
+
+	// No System calls at all — the lock is taken before loadJournal and
+	// before reading the staged version.
+	if len(fs.calls) != 0 {
+		t.Fatalf("busy lock must abort before any System mutation; calls=%v", fs.calls)
+	}
+	// No journal written.
+	if _, statErr := os.Stat(cfg.JournalPath); statErr == nil {
+		t.Fatalf("busy lock must abort before writing the journal at %s", cfg.JournalPath)
+	}
+	// The unit must still be running (we never stopped it).
+	if !fs.unitRunning {
+		t.Fatal("busy lock must not stop the unit")
+	}
+	// The (failed) acquire was attempted; no release of a lock we never held.
+	if got := atomic.LoadInt32(&st.releases); got != 0 {
+		t.Fatalf("busy path must not release a lock it never held; releases=%d", got)
+	}
+}
+
+// TestRun_ReleasesLockOnError proves the lock is released even when the cut
+// fails AFTER acquiring (deferred Release on the error path).
+func TestRun_ReleasesLockOnError(t *testing.T) {
+	st := &fakeUpgradeLockState{}
+	st.install(t)
+
+	fs := newFakeSystem(t, "2.0.0")
+	fs.verifyErr = os.ErrInvalid // force a failure in the VERIFY phase
+	r, _ := testEnv(t, fs)
+
+	if err := r.Run(Options{}); err == nil {
+		t.Fatal("expected Run to fail at verify")
+	}
+	if got := atomic.LoadInt32(&st.releases); got != 1 {
+		t.Fatalf("lock must be released on the error path; releases=%d", got)
+	}
+	if got := atomic.LoadInt32(&st.held); got != 0 {
+		t.Fatalf("lock still held after failed Run; held=%d", got)
+	}
+}
+
+// TestRolling_HoldsLockAcrossDrainAndInnerCutDoesNotReacquire proves the
+// rolling driver takes the lock ONCE at entry, holds it across the whole
+// window (peer-check + drain + cut + rejoin), the inner r.Run() does NOT
+// re-acquire (no EWOULDBLOCK self-deadlock), and the lock is released once
+// at the end. The held count never exceeds 1 (#1965, plan §5).
+func TestRolling_HoldsLockAcrossDrainAndInnerCutDoesNotReacquire(t *testing.T) {
+	st := &fakeUpgradeLockState{}
+	st.install(t)
+
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+
+	cl := &fakeCluster{
+		peerAlive:  true,
+		synced:     true,
+		compatible: true,
+		peerReady:  true,
+		drainAfter: 1,
+		localPri:   false,
+	}
+
+	// Drive the full rolling path with the lock held by RunRolling. We call
+	// RunRolling (the lock acquirer) and inject the fake cluster via the
+	// runRollingWith core through a thin shim: RunRolling builds its own
+	// CLICluster, so instead we replicate RunRolling's acquire+inner-core
+	// here to exercise the SAME lock contract with the injected cluster.
+	err := runRollingWithLock(t, r, cfg, cl)
+	if err != nil {
+		t.Fatalf("rolling: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&st.acquires); got != 1 {
+		t.Fatalf("rolling must acquire the lock exactly once (inner cut must NOT re-acquire); acquires=%d", got)
+	}
+	if got := atomic.LoadInt32(&st.maxHeld); got > 1 {
+		t.Fatalf("lock held count exceeded 1 (inner cut re-acquired — EWOULDBLOCK risk); maxHeld=%d", got)
+	}
+	if got := atomic.LoadInt32(&st.releases); got != 1 {
+		t.Fatalf("rolling must release the lock exactly once; releases=%d", got)
+	}
+	if got := atomic.LoadInt32(&st.held); got != 0 {
+		t.Fatalf("lock still held after rolling; held=%d", got)
+	}
+	// The cut actually happened (the inner r.Run ran).
+	if !cl.forced || !cl.resetCalled {
+		t.Fatalf("rolling did not run the full path: forced=%v reset=%v", cl.forced, cl.resetCalled)
+	}
+}
+
+// runRollingWithLock mirrors RunRolling's lock contract (acquire at entry,
+// hold through the injected-cluster core, release on return) so the test
+// can inject a fakeCluster while still exercising the real acquire +
+// LockAlreadyHeld inner-cut path. This is the same two-line wrapper as the
+// production RunRolling, minus the NewCLICluster construction.
+func runRollingWithLock(t *testing.T, r *Runner, _ Config, cl RollingCluster) (err error) {
+	t.Helper()
+	h, lerr := acquireUpgradeLock("upgrade --rolling", "")
+	if lerr != nil {
+		return lerr
+	}
+	defer func() { _ = h.Release() }()
+	return runRollingWith(r, cl, RollingConfig{
+		DrainDeadline:  time.Second,
+		RejoinDeadline: time.Second,
+		PollInterval:   time.Millisecond,
+	})
+}

--- a/pkg/upgrade/lock_seam_test.go
+++ b/pkg/upgrade/lock_seam_test.go
@@ -1,0 +1,67 @@
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeUpgradeLockState records acquire/release activity on the indirected
+// upgrade-lock seam (acquireUpgradeLock) so tests can assert that mutating
+// flows take the lock exactly once, release it, and that a forced-busy
+// acquire aborts BEFORE any live mutation (#1965).
+type fakeUpgradeLockState struct {
+	acquires int32
+	releases int32
+	held     int32 // current held count (must never exceed 1)
+	maxHeld  int32
+	// busy, when set, makes the next acquire fail as if another holder
+	// owns the lock.
+	busy atomic.Bool
+}
+
+type fakeLockHandle struct {
+	st *fakeUpgradeLockState
+}
+
+func (h *fakeLockHandle) Release() error {
+	atomic.AddInt32(&h.st.releases, 1)
+	atomic.AddInt32(&h.st.held, -1)
+	return nil
+}
+
+// install swaps acquireUpgradeLock to this fake for the duration of the
+// test and returns a restore func (registered via t.Cleanup).
+func (st *fakeUpgradeLockState) install(t *testing.T) {
+	t.Helper()
+	prev := acquireUpgradeLock
+	acquireUpgradeLock = func(subcommand, target string) (lockHandle, error) {
+		if st.busy.Load() {
+			atomic.AddInt32(&st.acquires, 1)
+			return nil, fmt.Errorf("simulated busy: another upgrade holds the lock")
+		}
+		atomic.AddInt32(&st.acquires, 1)
+		h := atomic.AddInt32(&st.held, 1)
+		if h > atomic.LoadInt32(&st.maxHeld) {
+			atomic.StoreInt32(&st.maxHeld, h)
+		}
+		return &fakeLockHandle{st: st}, nil
+	}
+	t.Cleanup(func() { acquireUpgradeLock = prev })
+}
+
+// TestMain installs a no-op upgrade-lock seam by DEFAULT for the whole
+// package so the many existing tests that call r.Run(Options{}) /
+// runRollingWith do NOT touch the real /run/xpf/upgrade.lock path. Tests
+// that want to assert lock behavior install their own fakeUpgradeLockState.
+func TestMain(m *testing.M) {
+	acquireUpgradeLock = func(string, string) (lockHandle, error) {
+		return noopLockHandle{}, nil
+	}
+	os.Exit(m.Run())
+}
+
+type noopLockHandle struct{}
+
+func (noopLockHandle) Release() error { return nil }

--- a/pkg/upgrade/rolling.go
+++ b/pkg/upgrade/rolling.go
@@ -80,11 +80,27 @@ func (c *RollingConfig) withDefaults() {
 // If the drain predicate cannot be met within the deadline, ABORT WITHOUT
 // cutting — the node is still forwarding, so no harm.
 func RunRolling(r *Runner, cfg Config) error {
+	// Acquire the host-wide upgrade lock at the rolling-driver ENTRY and
+	// hold it through rejoin (#1965, plan §5). This covers the whole
+	// window — peer-check + ForceSecondary + the drain wait + the cut +
+	// the rejoin — not just the inner r.Run(). The inner r.Run() is
+	// invoked with LockAlreadyHeld so it does NOT re-flock the same file
+	// (a second flock on a fresh fd of the same path returns EWOULDBLOCK
+	// and would abort the rolling upgrade). Release on every exit path.
+	h, err := acquireUpgradeLock("upgrade --rolling", "")
+	if err != nil {
+		return fmt.Errorf("upgrade --rolling: %w", err)
+	}
+	defer func() { _ = h.Release() }()
+
 	cl := NewCLICluster(cfg.Unit)
 	return runRollingWith(r, cl, RollingConfig{})
 }
 
-// runRollingWith is the testable core (cluster + timing injected).
+// runRollingWith is the testable core (cluster + timing injected). It does
+// NOT acquire the upgrade lock — its only caller, RunRolling, holds it for
+// the whole rolling window, and the inner r.Run() it invokes runs with
+// LockAlreadyHeld so it does not re-flock (#1965).
 func runRollingWith(r *Runner, cl RollingCluster, rc RollingConfig) error {
 	rc.withDefaults()
 	logf := r.logf
@@ -149,7 +165,10 @@ func runRollingWith(r *Runner, cl RollingCluster, rc RollingConfig) error {
 
 	// 5. Single-node cut on the fully-drained node. Auto-rollback is
 	//    DISABLED: HA rollback is operator-driven (plan §8 inv. 8).
-	if err := r.Run(Options{SkipStartHealthRollback: true}); err != nil {
+	//    LockAlreadyHeld: RunRolling holds the host-wide upgrade lock for
+	//    the whole rolling window, so the inner cut must NOT re-flock the
+	//    same file (it would EWOULDBLOCK and abort) — #1965.
+	if err := r.Run(Options{SkipStartHealthRollback: true, LockAlreadyHeld: true}); err != nil {
 		return fmt.Errorf("rolling: single-node cut failed (HA rollback is "+
 			"operator-driven — inspect the node): %w", err)
 	}

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -13,7 +13,17 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/fsatomic"
+	"github.com/psaab/xpf/pkg/upgrade/lock"
 )
+
+// upgradeLock is the host-wide advisory lock surface, indirected through a
+// package var so tests can substitute a fake that records acquire/release
+// ordering and can be forced busy (#1965). Production calls lock.Acquire.
+type lockHandle interface{ Release() error }
+
+var acquireUpgradeLock = func(subcommand, target string) (lockHandle, error) {
+	return lock.Acquire(subcommand, target)
+}
 
 // Default filesystem layout (plan §6.1). Overridable in Config for tests.
 const (

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -16,9 +16,10 @@ import (
 	"github.com/psaab/xpf/pkg/upgrade/lock"
 )
 
-// upgradeLock is the host-wide advisory lock surface, indirected through a
-// package var so tests can substitute a fake that records acquire/release
-// ordering and can be forced busy (#1965). Production calls lock.Acquire.
+// lockHandle is the host-wide advisory lock surface used by the upgrade
+// runner. acquireUpgradeLock is indirected through a package var so tests
+// can substitute a fake that records acquire/release ordering and can be
+// forced busy (#1965). Production calls lock.Acquire.
 type lockHandle interface{ Release() error }
 
 var acquireUpgradeLock = func(subcommand, target string) (lockHandle, error) {


### PR DESCRIPTION
## Summary

Every MUTATING upgrade operation on a host now takes one host-wide
advisory lock — `/run/xpf/upgrade.lock`, a non-blocking exclusive
`flock(2)` (`pkg/upgrade/lock`). It serializes the standalone binary cut
(`xpfd upgrade`), the rolling driver (`xpfd upgrade --rolling`), the
postinst auto-cut, and the mutating `xpfd upgrade kernel`
(`arm`/`promote`/`drain`/`rejoin`) sub-verbs. Without it two mutators
silently corrupt the crash-safe journal (both load the same snapshot,
modify independent copies, last-write-wins → the rollback target is
lost). Read-only `xpfd upgrade kernel status` stays lock-free.

Implements plan §5 of `docs/research/upgrade-hardening-review-011`
(F2/#1965). #1964 (versions/ seed) and #1967 (annex) are separate
issues and intentionally out of scope here.

### What's in the change
- **`pkg/upgrade/lock`** — `Acquire`/`Release` with `LOCK_EX|LOCK_NB`,
  `mkdir -p /run/xpf` before acquire, owner metadata (PID, subcommand,
  target, start time) written into the file after the flock so a busy
  acquirer's `*ErrBusy` NAMES the owner. Release on every exit path via
  defer; the kernel also drops the flock on process exit.
- **Entry points** — `Runner.Run` acquires the lock unless
  `Options.LockAlreadyHeld` (rolling re-entrancy); `RunRolling` acquires
  at entry and holds it through rejoin (covers peer-check + ForceSecondary
  + drain), passing `LockAlreadyHeld: true` to the inner cut so a second
  flock on a fresh fd of the same path does not `EWOULDBLOCK` and abort.
  The mutating `kernel` verbs take the lock in `cmd/xpfd`.
- **`debian/xpf.preinst` (new)** — `flock -n` gate BEFORE unpack (Policy
  6.5/6.6): busy → print owner + exit 1, apt aborts with the system
  untouched. No `systemctl`, so no boot-guard needed.
- **`debian/xpf.postinst`** — narrow TOCTOU residual: if the lock went
  busy between the preinst gate and the cut, drop
  `/run/xpf/upgrade-deferred`, log loudly, exit 0 (never non-zero — a
  non-zero postinst leaves dpkg half-configured). Boot-guard the
  failed-cut `systemctl` calls with `[ -d /run/systemd/system ]`.
- **`docs/in-place-upgrade.md`** — the lock contract, re-entrancy, the
  cluster-lock-OUTSIDE / host-lock-INSIDE ordering, and the
  dpkg-vs-operator staged-source race + `verify-dataplane` backstop.

## Test plan
- `go build ./...` clean; `go vet ./pkg/upgrade/... ./cmd/xpfd/` clean.
- Full Go suite green.
- `pkg/upgrade/lock` unit tests: acquire/release idempotent, busy-names-
  owner, release-on-panic (defer), release-on-error, release-on-process-
  exit (kernel backstop, child process), mkdir-creates-/run/xpf.
- `pkg/upgrade` seam/integration tests: standalone cut acquires exactly
  once + releases; a busy lock ABORTS before any System mutation or
  journal write (the core #1965 guarantee); release on the error path;
  rolling holds the lock once across drain + inner cut (maxHeld ≤ 1, no
  re-acquire). Lock tests pass 5× with no flakes.
- `sh -n` clean on both maintainer scripts; flock create / contention /
  missing-dir semantics verified empirically to match the postinst
  `elif` branch logic.

**Smoke N/A:** no dataplane surface — iperf/CoS smoke is not applicable.
`make test-failover` exercises VRRP failover, not the rolling-drain lock
path. Per user approval this change uses a Go-gate-only auto-merge on a
clean quad-review.

Closes #1965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)