### PR TITLE
#1964 follow-up: preinst symlink-only current gate + postrm dirname drop-in

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -5890,7 +5890,7 @@ top.
 - **Edit (r3 Copilot pass-2, 27e0ab1a9)**: flip.go clear journal after first-cut flip-failure restart (else re-run skips STOP→no-op commit); preinst+postrm atomic_symlink rm -rf stale .tmp; seed.go reference upgrade.Default* constants (dedup). Tests: FirstCutRestartsDaemon asserts journal cleared + re-run STOPs; preinst stale_tmp_dir scenario.
 - **Edit (r3 Copilot pass-3, cded94d63)**: seed.go atomicSymlink os.Remove->os.RemoveAll (stale-temp-dir tolerance, Go analog of the shell rm -rf fix); TestSeed_ToleratesStaleTempDir. AGY r4 MERGE-READY; Codex r4 in flight.
 
-## 2026-06-17 — #1964 post-merge follow-up (Copilot pass-7, PR TBD)
+## 2026-06-17 — #1964 post-merge follow-up (Copilot pass-7, PR #1973)
 - **Action**: Two post-merge Copilot robustness/maintainability findings on the #1964 maintainer scripts (PR #1972 merged d58a06783); fixed in a follow-up.
 - **Edit**: debian/xpf.preinst — migrate_legacy_layout fast-path requires `[ -L "$CURRENT" ]` (was `-L || -e`): a regular file/dir at $CURRENT (corruption) no longer repoints sbin to a non-resolving $CURRENT/<bin>; non-symlink → leave legacy links untouched (best-effort). Matches the Go seed's non-dir guard.
 - **Edit**: debian/xpf.postrm — downgrade rmdir uses `dirname "$DROPIN"` (was hard-coded /etc/systemd/system/xpfd.service.d) — single source of truth, no path drift.

--- a/_Log.md
+++ b/_Log.md
@@ -5889,3 +5889,10 @@ top.
 - **Verdicts r3**: Codex MERGE-READY, AGY MERGE-READY, Claude SMR MERGE-READY; Copilot setuid/setgid/sticky finding fixed, re-requested.
 - **Edit (r3 Copilot pass-2, 27e0ab1a9)**: flip.go clear journal after first-cut flip-failure restart (else re-run skips STOP→no-op commit); preinst+postrm atomic_symlink rm -rf stale .tmp; seed.go reference upgrade.Default* constants (dedup). Tests: FirstCutRestartsDaemon asserts journal cleared + re-run STOPs; preinst stale_tmp_dir scenario.
 - **Edit (r3 Copilot pass-3, cded94d63)**: seed.go atomicSymlink os.Remove->os.RemoveAll (stale-temp-dir tolerance, Go analog of the shell rm -rf fix); TestSeed_ToleratesStaleTempDir. AGY r4 MERGE-READY; Codex r4 in flight.
+
+## 2026-06-17 — #1964 post-merge follow-up (Copilot pass-7, PR TBD)
+- **Action**: Two post-merge Copilot robustness/maintainability findings on the #1964 maintainer scripts (PR #1972 merged d58a06783); fixed in a follow-up.
+- **Edit**: debian/xpf.preinst — migrate_legacy_layout fast-path requires `[ -L "$CURRENT" ]` (was `-L || -e`): a regular file/dir at $CURRENT (corruption) no longer repoints sbin to a non-resolving $CURRENT/<bin>; non-symlink → leave legacy links untouched (best-effort). Matches the Go seed's non-dir guard.
+- **Edit**: debian/xpf.postrm — downgrade rmdir uses `dirname "$DROPIN"` (was hard-coded /etc/systemd/system/xpfd.service.d) — single source of truth, no path drift.
+- **Edit**: test/debian/preinst-migrate-test.sh — current_is_regular_file + current_is_dir scenarios; postrm-test.sh — assert empty .d dir removed + drop obsolete sed special-case.
+- **Validation**: go build + upgrade tests green; all 3 shell harnesses 3x under sh+dash; sh -n/dash -n/shellcheck clean on all 3 scripts.

--- a/debian/xpf.postrm
+++ b/debian/xpf.postrm
@@ -115,8 +115,11 @@ case "$1" in
             # 1. remove the runtime unit drop-in (else systemd keeps the
             #    concrete newer-version ExecStart).
             rm -f "$DROPIN"
-            # rmdir the .d dir if it is now empty (best-effort).
-            rmdir /etc/systemd/system/xpfd.service.d 2>/dev/null || true
+            # rmdir the .d dir if it is now empty (best-effort). Derive it
+            # from $DROPIN (Copilot) so it tracks the single drop-in path
+            # definition and the test harness's $DROPIN rewrite, with no
+            # hard-coded path drift.
+            rmdir "$(dirname "$DROPIN")" 2>/dev/null || true
             # 2. repoint OWNED sbin links back to staged (atomic) so the
             #    daemon resolves the downgraded binaries — skipping any
             #    foreign/operator-repointed link (Codex).

--- a/debian/xpf.preinst
+++ b/debian/xpf.preinst
@@ -116,13 +116,26 @@ migrate_legacy_layout() {
     # Nothing to snapshot if there is no old staged tree (a pristine box).
     [ -d "$STAGED" ] || return 0
 
-    # ALWAYS ensure sbin resolves through versions/current when current
-    # exists — a crash AFTER current was created but BEFORE sbin was
+    # ALWAYS ensure sbin resolves through versions/current when current is a
+    # valid SYMLINK — a crash AFTER current was created but BEFORE sbin was
     # repointed must complete the repoint on retry (else unpack overwrites
-    # staged/ under a daemon still pointed at the staged path). Gate ONLY
-    # the snapshot-copy on current's absence.
-    if [ -L "$CURRENT" ] || [ -e "$CURRENT" ]; then
+    # staged/ under a daemon still pointed at the staged path). Gate ONLY the
+    # snapshot-copy on current's absence.
+    #
+    # Require current to be a SYMLINK, not merely -e (Copilot): if $CURRENT is
+    # a regular file or directory (corruption / manual edit), repointing sbin
+    # to "$CURRENT/<bin>" would yield links that do not resolve and break the
+    # operator tools. This is best-effort migration, so a non-symlink at
+    # $CURRENT means "layout is not ours / is broken" — leave the legacy
+    # direct-staged links untouched (the cut's refuse-before-STOP guard still
+    # protects the daemon, and the Go seed has the matching non-dir guard).
+    if [ -L "$CURRENT" ]; then
         sbin_points_through_current || repoint_sbin_through_current
+        return 0
+    fi
+    if [ -e "$CURRENT" ]; then
+        echo "xpf: #1964 legacy migration: $CURRENT exists but is not a symlink" \
+             "(corrupt layout); leaving the legacy sbin links untouched." >&2
         return 0
     fi
 

--- a/test/debian/postrm-test.sh
+++ b/test/debian/postrm-test.sh
@@ -26,7 +26,6 @@ patched_postrm() {
       -e "s#^VERSIONS=.*#VERSIONS=$ROOT/var/lib/xpf/versions#" \
       -e "s#^CURRENT=.*#CURRENT=\"\$VERSIONS/current\"#" \
       -e "s#^DROPIN=.*#DROPIN=$ROOT/etc/systemd/system/xpfd.service.d/10-xpf-version.conf#" \
-      -e "s#rmdir /etc/systemd/system/xpfd.service.d#rmdir $ROOT/etc/systemd/system/xpfd.service.d#" \
       -e "s#\\[ -d /run/systemd/system \\]#false#" \
       "$POSTRM" > "$ROOT/postrm"
     chmod +x "$ROOT/postrm"
@@ -116,6 +115,8 @@ scenario_downgrade_to_prehardened() {
     make_staged_prehardened
     "$ROOT/postrm" upgrade "0.9.0"
     [ -e "$DROPIN" ] && { echo "FAIL: drop-in not removed"; exit 1; } || true
+    # The .d dir must be rmdir'd when empty (exercises dirname "$DROPIN").
+    [ -e "$(dirname "$DROPIN")" ] && { echo "FAIL: empty drop-in .d dir not removed"; exit 1; } || true
     for b in $BINS; do
         tgt=$(readlink "$SBIN/$b")
         [ "$tgt" = "$STAGED/$b" ] || { echo "FAIL: sbin $b -> $tgt, want staged"; exit 1; }

--- a/test/debian/preinst-migrate-test.sh
+++ b/test/debian/preinst-migrate-test.sh
@@ -162,6 +162,31 @@ scenario_stale_tmp_dir() {
     done
 }
 
+# A non-symlink $CURRENT (corruption / manual edit) must NOT cause sbin to be
+# repointed to "$CURRENT/<bin>" (which would not resolve). Best-effort:
+# leave the legacy direct-staged links untouched (Copilot).
+scenario_current_is_regular_file() {
+    build_legacy "1.0.0"
+    mkdir -p "$VERSIONS"
+    : > "$CURRENT"   # a regular file where the symlink should be
+    migrate_legacy_layout upgrade "0.9.0"
+    # sbin must still point at staged (legacy), NOT at $CURRENT/<bin>.
+    for b in $BINS; do
+        [ "$(readlink "$SBIN/$b")" = "$STAGED/$b" ] || { echo "FAIL: sbin $b repointed despite non-symlink current ($(readlink "$SBIN/$b"))"; exit 1; }
+    done
+    # The bogus file is left as-is (we don't clobber unknown state).
+    [ -f "$CURRENT" ] || { echo "FAIL: removed the non-symlink current"; exit 1; }
+}
+
+scenario_current_is_dir() {
+    build_legacy "1.0.0"
+    mkdir -p "$CURRENT"   # a directory where the symlink should be
+    migrate_legacy_layout upgrade "0.9.0"
+    for b in $BINS; do
+        [ "$(readlink "$SBIN/$b")" = "$STAGED/$b" ] || { echo "FAIL: sbin $b repointed despite directory current"; exit 1; }
+    done
+}
+
 run_scenario basic
 run_scenario idempotent
 run_scenario resume_after_current
@@ -170,4 +195,6 @@ run_scenario fallback_dpkg_version
 run_scenario no_safe_version
 run_scenario no_staged
 run_scenario stale_tmp_dir
+run_scenario current_is_regular_file
+run_scenario current_is_dir
 echo "ALL PREINST-MIGRATE SCENARIOS PASSED"


### PR DESCRIPTION
## Summary

Two post-merge Copilot findings on the #1964 maintainer scripts (PR #1972, merged `d58a06783`). Both are small robustness/maintainability fixes; neither was a merge-blocker for #1972.

1. **`debian/xpf.preinst` (robustness):** `migrate_legacy_layout`'s "current exists" fast-path gated on `[ -L "$CURRENT" ] || [ -e "$CURRENT" ]`. If `$CURRENT` is a regular file/dir (corruption / manual edit), the `-e` branch would still repoint `/usr/local/sbin/*` to `$CURRENT/<bin>` — which doesn't resolve and breaks operator tools. The migration is best-effort, so require `$CURRENT` to be a **symlink**; on a non-symlink, log and leave the legacy direct-staged links untouched. This mirrors the Go seed's existing non-directory guard (`TestSeed_RejectsNonDirVersionPath`).

2. **`debian/xpf.postrm` (maintainability):** the downgrade cleanup `rmdir`'d the drop-in directory via a hard-coded `/etc/systemd/system/xpfd.service.d` instead of `dirname "$DROPIN"`. Derive it from `$DROPIN` (single source of truth, no path drift, tracks the test harness's `$DROPIN` rewrite).

## Test plan
- New `current_is_regular_file` + `current_is_dir` scenarios in `preinst-migrate-test.sh` assert sbin is NOT repointed and the legacy links survive when `$CURRENT` is a non-symlink.
- `postrm-test.sh` now asserts the empty `.d` dir is removed on downgrade (exercising `dirname "$DROPIN"`) and drops the obsolete sed special-case for the hard-coded path.
- Gates: `go build ./...` + `pkg/upgrade` tests green; all three shell harnesses 3× under `sh` + `dash`; `sh -n` / `dash -n` / `shellcheck` clean on all three maintainer scripts.

No Go production code changes; no dataplane surface (iperf/CoS smoke N/A). Baked-image dogfood is the ideal validation but isn't runnable here.

Refs #1964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)