### PR TITLE
image: pin bake base release to Ubuntu 26.04 (drop auto-latest)

### DIFF
--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -145,9 +145,10 @@ def ensure_memlock():
 # cloud-images.ubuntu.com and took the highest-numbered listing, which silently
 # selects whatever the mirror lists as newest — a non-LTS (e.g. 26.10) or, when
 # an LTS image lags publication, the previous release (25.10). That drift is
-# exactly what the contract forbids, so the default is the pinned LTS. Set
-# XPF_BASE_RELEASE=<rel> for a reviewed bump, or XPF_UBUNTU_AUTODISCOVER=1 to
-# opt back into mirror-latest discovery.
+# exactly what the contract forbids, so the default is the pinned LTS. The
+# reviewed bump is a code change to PINNED_BASE_RELEASE below (lands via PR);
+# XPF_BASE_RELEASE=<rel> is a one-off runtime override, and
+# XPF_UBUNTU_AUTODISCOVER=1 opts back into mirror-latest discovery.
 PINNED_BASE_RELEASE = "26.04"
 
 

--- a/scripts/image/bake.py
+++ b/scripts/image/bake.py
@@ -138,9 +138,24 @@ def ensure_memlock():
             "(sudo prlimit --memlock=unlimited:unlimited --pid $$) and re-run")
 
 
+# The production appliance base is pinned to Ubuntu 26.04 LTS (#1943). Bumping
+# it is a DELIBERATE, REVIEWED decision — not auto-latest (CLAUDE.md "Ubuntu
+# 26.04 parity": "the test VM tracks whatever release production was last baked
+# at — a deliberate, reviewed bump, not auto-latest"). The old default scraped
+# cloud-images.ubuntu.com and took the highest-numbered listing, which silently
+# selects whatever the mirror lists as newest — a non-LTS (e.g. 26.10) or, when
+# an LTS image lags publication, the previous release (25.10). That drift is
+# exactly what the contract forbids, so the default is the pinned LTS. Set
+# XPF_BASE_RELEASE=<rel> for a reviewed bump, or XPF_UBUNTU_AUTODISCOVER=1 to
+# opt back into mirror-latest discovery.
+PINNED_BASE_RELEASE = "26.04"
+
+
 def discover_base_release():
     if os.environ.get("XPF_BASE_RELEASE"):
         return os.environ["XPF_BASE_RELEASE"]
+    if os.environ.get("XPF_UBUNTU_AUTODISCOVER") != "1":
+        return PINNED_BASE_RELEASE
     url = os.environ.get("XPF_UBUNTU_RELEASES_URL",
                          "https://cloud-images.ubuntu.com/releases")
     import re


### PR DESCRIPTION
## Problem

`scripts/image/bake.py:discover_base_release()` defaulted to scraping
`cloud-images.ubuntu.com/releases` and taking the highest-numbered listing
when `XPF_BASE_RELEASE` was unset. That silently selects whatever the mirror
lists as newest — a non-LTS interim (e.g. 26.10) or, when an LTS image lags
publication, the previous release (**25.10**). An ad-hoc test VM came up on
25.10 via this path.

This contradicts the already-documented contract (CLAUDE.md *Ubuntu 26.04
parity*: "a deliberate, reviewed bump, **not auto-latest**") and the matching
`XPF_BASE_RELEASE:-26.04` defaults already in `test/incus/setup.sh` and
`cluster-setup.sh`. `bake.py` was the lone outlier.

## Change

- Default to the pinned LTS: `PINNED_BASE_RELEASE = "26.04"` — one place to
  edit for a reviewed bump.
- `XPF_BASE_RELEASE=<rel>` still overrides for a one-off (no behavior change
  when set).
- `XPF_UBUNTU_AUTODISCOVER=1` opts back into the old mirror-latest scrape for
  anyone who explicitly wants it.

## Validation

`bake.py` parses; the resolver returns `26.04` when unset, honors an explicit
`XPF_BASE_RELEASE`, and only scrapes the mirror under `XPF_UBUNTU_AUTODISCOVER=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)