### PR TITLE
#1961: fix Go↔Rust snapshot wire-type bug (DSCP/code-point base64) that disabled forwarding

### DIFF
--- a/docs/research/1961-wire-type-dscp/agy-plan-r1.md
+++ b/docs/research/1961-wire-type-dscp/agy-plan-r1.md
@@ -1,0 +1,100 @@
+# AGY Adversarial Plan Review
+
+**Verdict:** **PLAN-READY** (with recommendation to collapse directly to `/engineer` implementation).
+
+Below is the adversarial review of the proposed [plan.md](file:///home/ps/git/bpfrx/.claude/worktrees/1961-research-wire-type/docs/research/1961-wire-type-dscp/plan.md) (branch `research/1961-wire-type-dscp`).
+
+---
+
+### 1. Root Cause Validation & Rust Serde Adapter Check
+
+The hypothesis that the `virtio no transit` issue is caused by a JSON wire-type mismatch is **correct**. 
+* **Go encoding:** In Go, the default JSON encoding for `[]byte` and `[]uint8` is a base64-encoded string (e.g., `"dscp_values":"Lg=="`).
+* **Rust expectations:** Standard Rust Serde sequence types expect a JSON array/sequence of values (e.g. `[46]`) when deserializing into `Vec<u8>`.
+* **Serde adapter check:** A grep search for `deserialize_with` or custom `Deserialize` traits in `userspace-dp` returned **0 results**. There is no base64 adapter logic or dependency configured on the Rust helper side.
+* **Failure vector:** As shown in [mod.rs:L66-67](file:///home/ps/git/bpfrx/userspace-dp/src/server/handlers/mod.rs#L66-L67):
+  ```rust
+  let request: ControlRequest =
+      serde_json::from_str(line.trim_end()).map_err(|e| format!("decode request: {e}"))?;
+  ```
+  Since standard `serde` receives `"Lg=="` instead of a sequence, deserialization fails, throwing `invalid type: string "Lg==", expected a sequence`. This error is returned as `Err` from `handle_stream` and discarded at the accept loops in [lifecycle.rs:L220-221](file:///home/ps/git/bpfrx/userspace-dp/src/server/lifecycle.rs#L220-L221) and [lifecycle.rs:L239](file:///home/ps/git/bpfrx/userspace-dp/src/server/lifecycle.rs#L239):
+  ```rust
+  let _ = handle_stream(stream, &state_file, state.clone(), running.clone());
+  ```
+  The socket closes immediately with zero response bytes, which triggers the Go decoder EOF in [process.go:L208](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/process.go#L208).
+
+### 2. Field Audit Completeness
+
+A search for literal `[]` slices in [protocol.go](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/protocol.go) and primitive numeric slice fields in the entire Go dataplane was conducted. The audit of 3 affected fields is **100% complete**:
+1. `CoSDSCPClassifierEntrySnapshot.DSCPValues` in [protocol.go:L191-195](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/protocol.go#L191-L195):
+   ```go
+   type CoSDSCPClassifierEntrySnapshot struct {
+   	ForwardingClass string  `json:"forwarding_class,omitempty"`
+   	LossPriority    string  `json:"loss_priority,omitempty"`
+   	DSCPValues      []uint8 `json:"dscp_values,omitempty"`
+   }
+   ```
+2. `CoSIEEE8021ClassifierEntrySnapshot.CodePoints` in [protocol.go:L202-206](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/protocol.go#L202-L206):
+   ```go
+   type CoSIEEE8021ClassifierEntrySnapshot struct {
+   	ForwardingClass string  `json:"forwarding_class,omitempty"`
+   	LossPriority    string  `json:"loss_priority,omitempty"`
+   	CodePoints      []uint8 `json:"code_points,omitempty"`
+   }
+   ```
+3. `FirewallTermSnapshot.DSCPValues` in [protocol.go:L410-418](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/protocol.go#L410-L418):
+   ```go
+   type FirewallTermSnapshot struct {
+       ...
+   	DSCPValues      []uint8  `json:"dscp_values,omitempty"`
+   ```
+
+No other `[]byte` or `[]uint8` fields exist on the control plane wire interface.
+
+### 3. Q1: Treating Virtio Forwarding as "UNPROVEN"
+
+Treating the virtio forwarding path as **UNPROVEN** is **correct and critical**. 
+* **Reasoning:** Since `apply_snapshot` failed on bootstrap configurations containing classifiers/firewall filters, the helper has never transitioned to `enabled:true` or `forwarding_armed` on virtio VMs. Thus, the packet-loop binding and rx/tx logic have never successfully run on virtio.
+* **Risk:** Virtio-net uses `XDP_COPY` mode (or auto-mode falling back to copy) where kernel NAPI drives packet delivery. We must prove via a live transit test that standard forwarding actually delivers packets on copy-mode virtio interfaces once armed, rather than silently failing due to driver/NAPI issues.
+
+### 4. Fix Shape & Wire Compatibility
+
+#### Fix Shape: **Option A (Named Custom Type) is Superior**
+We strongly recommend implementing **Option A**:
+```go
+type DSCPValueList []uint8
+```
+* **Why Option A is better:** Go assignability rules permit direct assignment of unnamed slice types (such as `[]uint8` literals or return values from `append`) to a named type if their underlying types are identical. Consequently, changing the type in [protocol.go](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/protocol.go) requires **zero code modifications** in assignment files such as [cos.go](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/cos.go) and [filters.go](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/filters.go).
+* **Option B (`[]uint16`) Disadvantages:** Option B forces element-wise conversions across all Go builders and tests, and does not allow decoding base64-encoded strings if reading legacy state/configurations.
+
+#### Wire Compatibility & HA Upgrade (#1917)
+* **New Go $\rightarrow$ Old Rust:** Works. The old Rust helper already expects a sequence (`Vec<u8>`) on [security.rs:L104-105](file:///home/ps/git/bpfrx/userspace-dp/src/protocol/security.rs#L104-L105) and [cos.rs:L46-47](file:///home/ps/git/bpfrx/userspace-dp/src/protocol/cos.rs#L46-L47).
+* **Old Go $\rightarrow$ New Rust:** Fails (helper rejects base64 string). However, this combination was already broken.
+* **Defensive Unmarshaler:** Implementing custom `UnmarshalJSON` for the named type `DSCPValueList` in Go to tolerate both base64 strings (for backwards compatibility) and numeric arrays ensures any persisted state files (which store `ConfigSnapshot` via [helpers.rs:L847](file:///home/ps/git/bpfrx/userspace-dp/src/server/helpers.rs#L847)) can be loaded without issues.
+
+### 5. Test Design Gaps
+
+* **Gap:** The Go-side unit tests in [protocol_test.go](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/protocol_test.go) should explicitly assert both roundtrip directions:
+  1. Marshaling a snapshot results in a numeric JSON array (`"dscp_values":[46]`) rather than a base64 string.
+  2. Unmarshaling a legacy JSON payload containing a base64 string (`"dscp_values":"Lg=="`) succeeds and decodes to `[]uint8{46}`.
+* **Rust integration test:** A test payload with inline JSON should be added to `userspace-dp` asserting that `ControlRequest` containing numeric lists for these fields parses correctly.
+
+### 6. Actionable Error and Logging Hardening
+
+1. **Q3 (Rust Logging):** The accept loop must print or log errors from `handle_stream` rather than discarding them:
+   ```rust
+   if let Err(err) = handle_stream(stream, &state_file, state.clone(), running.clone()) {
+       eprintln!("xpf-userspace-dp: handle stream error: {err}");
+   }
+   ```
+2. **Q4 (Go Client Error):** When Go processes a socket disconnect (`io.EOF`) without receiving response bytes, it should enrich the error message:
+   ```go
+   if errors.Is(err, io.EOF) {
+       return ControlResponse{}, fmt.Errorf("control socket closed without response (EOF); check helper logs for panics or deserialization errors: %w", err)
+   }
+   ```
+
+### 7. Verdict & Path Selection (Q8)
+
+* **Verdict:** **PLAN-READY**
+* **Recommendation:** Skip the rest of `/research` and collapse the work into `/engineer`. The root cause is completely verified, the implementation details are mechanical, and the live transit test can be incorporated as the final validation step of the engineering PR.

--- a/docs/research/1961-wire-type-dscp/agy-plan-r1.md
+++ b/docs/research/1961-wire-type-dscp/agy-plan-r1.md
@@ -8,7 +8,7 @@ Below is the adversarial review of the proposed [plan.md](file:///home/ps/git/bp
 
 ### 1. Root Cause Validation & Rust Serde Adapter Check
 
-The hypothesis that the `virtio no transit` issue is caused by a JSON wire-type mismatch is **correct**. 
+The hypothesis that the `virtio no transit` issue is caused by a JSON wire-type mismatch is **correct**.
 * **Go encoding:** In Go, the default JSON encoding for `[]byte` and `[]uint8` is a base64-encoded string (e.g., `"dscp_values":"Lg=="`).
 * **Rust expectations:** Standard Rust Serde sequence types expect a JSON array/sequence of values (e.g. `[46]`) when deserializing into `Vec<u8>`.
 * **Serde adapter check:** A grep search for `deserialize_with` or custom `Deserialize` traits in `userspace-dp` returned **0 results**. There is no base64 adapter logic or dependency configured on the Rust helper side.
@@ -29,31 +29,31 @@ A search for literal `[]` slices in [protocol.go](file:///home/ps/git/bpfrx/pkg/
 1. `CoSDSCPClassifierEntrySnapshot.DSCPValues` in [protocol.go:L191-195](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/protocol.go#L191-L195):
    ```go
    type CoSDSCPClassifierEntrySnapshot struct {
-   	ForwardingClass string  `json:"forwarding_class,omitempty"`
-   	LossPriority    string  `json:"loss_priority,omitempty"`
-   	DSCPValues      []uint8 `json:"dscp_values,omitempty"`
+	ForwardingClass string  `json:"forwarding_class,omitempty"`
+	LossPriority    string  `json:"loss_priority,omitempty"`
+	DSCPValues      []uint8 `json:"dscp_values,omitempty"`
    }
    ```
 2. `CoSIEEE8021ClassifierEntrySnapshot.CodePoints` in [protocol.go:L202-206](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/protocol.go#L202-L206):
    ```go
    type CoSIEEE8021ClassifierEntrySnapshot struct {
-   	ForwardingClass string  `json:"forwarding_class,omitempty"`
-   	LossPriority    string  `json:"loss_priority,omitempty"`
-   	CodePoints      []uint8 `json:"code_points,omitempty"`
+	ForwardingClass string  `json:"forwarding_class,omitempty"`
+	LossPriority    string  `json:"loss_priority,omitempty"`
+	CodePoints      []uint8 `json:"code_points,omitempty"`
    }
    ```
 3. `FirewallTermSnapshot.DSCPValues` in [protocol.go:L410-418](file:///home/ps/git/bpfrx/pkg/dataplane/userspace/protocol.go#L410-L418):
    ```go
    type FirewallTermSnapshot struct {
        ...
-   	DSCPValues      []uint8  `json:"dscp_values,omitempty"`
+	DSCPValues      []uint8  `json:"dscp_values,omitempty"`
    ```
 
 No other `[]byte` or `[]uint8` fields exist on the control plane wire interface.
 
 ### 3. Q1: Treating Virtio Forwarding as "UNPROVEN"
 
-Treating the virtio forwarding path as **UNPROVEN** is **correct and critical**. 
+Treating the virtio forwarding path as **UNPROVEN** is **correct and critical**.
 * **Reasoning:** Since `apply_snapshot` failed on bootstrap configurations containing classifiers/firewall filters, the helper has never transitioned to `enabled:true` or `forwarding_armed` on virtio VMs. Thus, the packet-loop binding and rx/tx logic have never successfully run on virtio.
 * **Risk:** Virtio-net uses `XDP_COPY` mode (or auto-mode falling back to copy) where kernel NAPI drives packet delivery. We must prove via a live transit test that standard forwarding actually delivers packets on copy-mode virtio interfaces once armed, rather than silently failing due to driver/NAPI issues.
 

--- a/docs/research/1961-wire-type-dscp/claude-smr-code-r1.md
+++ b/docs/research/1961-wire-type-dscp/claude-smr-code-r1.md
@@ -1,0 +1,68 @@
+# Claude SMR — #1961 wire-type fix, code review (PR #1976)
+
+**Posture:** hostile domain SMR (serialization / Go-Rust interop). 4th reviewer.
+
+**Verdict: MERGE-READY** (functional code), conditional on the plan's live Q1
+gate. Codex MERGE-NEEDS-MINOR (whitespace nit — fixed) + AGY MERGE-READY +
+Copilot COMMENTED (one real doc nit fixed; three assignability claims refuted).
+
+## What I verified directly
+
+- **MarshalJSON never base64s.** `wire_uint8list.go:40` builds the array with
+  `strconv.AppendUint` and never calls `json.Marshal([]uint8)` (which would
+  re-trigger the stdlib base64 special-case and recreate the bug). nil/empty →
+  `[]`, which is *safer* than Go's default nil-`[]uint8` → `null` (a `Vec<u8>`
+  with `#[serde(default)]` decodes `[]` but not `null`). Verified by test.
+- **`omitempty` preserved.** `encoding/json` checks slice length before invoking
+  a field's MarshalJSON, so an empty `WireUint8List` is still dropped — minimal
+  configs keep publishing. Confirmed by `TestWireUint8ListMarshalsNumericArray`
+  + the integration test omitting empties.
+- **UnmarshalJSON** handles numeric array (via `[]uint16` + `>255` reject),
+  legacy base64, `null`, and leading whitespace. The `case 'n'` → null is safe:
+  the only valid JSON value starting with `n` is `null`, and `json.Unmarshal`
+  only invokes the method on a validated complete value.
+- **All three typed fields converted** (protocol.go:194/205/417); assignment
+  sites unchanged because unnamed `[]uint8` is assignable to a named slice type
+  with the same underlying type. Proven by `go build` + full Go suite green.
+- **Reflection guard** walks the real `ControlRequest`/`ControlResponse` graph,
+  is cycle-safe (visited set), and skips only the `ConfigSnapshot.Config`
+  passthrough (Rust `serde_json::Value`, untyped → base64 harmless). It already
+  earned its keep: it surfaced the config-package DSCP `[]uint8` reachable via
+  the passthrough, which I confirmed is decoded as an opaque Value and excluded.
+- **Rust tests** decode a *full* `ControlRequest` (not leaf structs) and the
+  negative test proves a base64 string aborts the whole-request decode.
+- **Hardening** is behavior-preserving: lifecycle.rs only adds logging; the Go
+  EOF enrichment wraps `io.EOF`/`io.ErrUnexpectedEOF` with `%w`, no import cycle.
+
+## Hostile findings (all resolved)
+
+1. Copilot's three "must update assignment sites" comments are **false
+   positives** — Go named-type assignability makes them unnecessary, proven by a
+   clean build + full suite + Codex + AGY both confirming. Refuted, not actioned.
+2. Copilot's base64 doc-example inconsistency (`"LAo="` ≠ [46,10]) — **real,
+   fixed** (`6df92a8c5`).
+3. Codex whitespace `git diff --check` nit in the saved AGY doc — **fixed**
+   (`52a982df3`); `git diff --check` now clean.
+4. The pre-existing flake `concurrent_recovery_processes_each_command_exactly_once`
+   (worker_queue, untouched here) passed 3/3 + 5/5 clean — not a regression.
+
+## Q5 audit outcome (the one thing reviewers should weigh)
+
+The plan-mandated Go↔Rust type-parity audit (19-agent workflow) found **12
+FATAL_DECODE siblings** — Go signed `int` → Rust `u16`/`u32`/`u64` across 9 flow/
+flow-export fields — where an out-of-range value (e.g. an operator typo
+`tcp-mss-gre-in 70000`) triggers the *same* whole-snapshot decode abort, with no
+commit-time validation. These are a **distinct class** (numeric range, not
+base64) triggered by *abnormal* values, vs this PR's `[]uint8` bug which triggers
+on a *normal* config. Scoped out to **#1977** with full evidence, keeping this PR
+focused on the reported #1961 root cause. This is a deliberate split, not an
+oversight.
+
+## Outstanding gate
+
+Q1 (live): does virtio actually forward once `apply_snapshot` publishes? The fix
+is proven necessary (VM-free repro + suites + new tests) but its *sufficiency*
+for transit is the plan's hard gate — to be confirmed on a 26.04 plain-virtio VM
+before declaring #1961 fixed. The code is mergeable independent of Q1's outcome
+(Q1=fail would reopen the XSK-delivery plan as a separate follow-up, not revert
+this fix).

--- a/docs/research/1961-wire-type-dscp/claude-smr-plan-r1.md
+++ b/docs/research/1961-wire-type-dscp/claude-smr-plan-r1.md
@@ -1,0 +1,64 @@
+# Claude SMR — #1961 wire-type plan review, round 1
+
+**Posture:** hostile domain SMR (CPU/serialization/Go-Rust interop). Verdict
+below is deliberately NOT a self-rubber-stamp of my own plan.
+
+**Verdict: PLAN-NEEDS-MINOR** — the root cause is proven and the design is
+sound, but three strengthening items should be folded before `/engineer`.
+
+## What holds up under hostile inspection
+
+- **Root cause rests on ground truth, not on the EOF-vs-timeout argument.** The
+  34,895-byte `apply_snapshot` JSON, built from `test/incus/xpf-test.conf` via
+  the *real* `buildSnapshot()` path, makes `serde_json::from_str::<ControlRequest>`
+  fail at `dscp_values` (`invalid type: string "Lg==", expected a sequence`),
+  and rewriting that field to a numeric array makes the full request decode.
+  This is reproducible and independent of any reasoning about socket deadlines.
+  The live xpf-fwd journal (`publish userspace snapshot: EOF` repeatedly, then
+  `apply_snapshot generation=3` only after the DSCP filter was stripped)
+  corroborates it. Confidence in the cause: very high.
+- **Audit is complete for the `[]uint8` class.** Exactly three `[]uint8` json
+  wire fields in `pkg/dataplane/userspace` (protocol.go:194/205/417), each with
+  a matching Rust `Vec<u8>` (cos.rs:47/64, security.rs:105). No `deny_unknown_fields`
+  anywhere in `protocol/`, so the failure is a *type* rejection, not a missing
+  field — consistent with the observed error.
+- **Wire-compat reasoning is sound.** Every combination that changes goes
+  broken→working: old-Go-base64 always failed for a populated field; new-Go
+  numeric works against both old and new Rust (Rust always wanted a sequence).
+  No persisted base64 blob exists for Go to read back (configstore stores Junos
+  text; `ProcessStatus` carries none of these fields). No regression path.
+
+## Required minor strengthening (fold into v2)
+
+1. **Add a class-level regression guard, not just a value test.** A round-trip
+   test on the three known fields prevents *this* regression, but a fourth
+   `[]uint8` json wire field added later reintroduces the exact bug silently.
+   Add a Go test (reflection over the snapshot wire structs) that fails if any
+   exported field is `[]uint8`/`[]byte` with a `json:` tag — the project's
+   "compile-time invariant" idiom. Cheap, and it closes the whole class.
+2. **Actually perform the Q5 type-parity audit during `/engineer`, don't just
+   list it.** `[]uint8` is one mismatch family; there may be a *second* latent
+   wire-type mismatch (enum variant, int-vs-string, option handling) that only
+   surfaces on a config no current smoke exercises. A bounded Go-struct↔Rust-
+   struct field-by-field parity pass is in-scope, because shipping the DSCP fix
+   and then hitting a different decode-EOF on the next config would be a poor
+   outcome.
+3. **Keep the superseded XSK-delivery plan referenced (not deleted) until
+   §8.3 passes.** Q1 (does virtio forward once the snapshot publishes?) is
+   genuinely open until the live transit test on a config with zones+policies.
+   The plan says this; make it a hard gate — if §8.3 still shows 0 sessions
+   after a clean publish, the XSK-delivery investigation reopens rather than the
+   issue being declared fixed.
+
+## Notes (non-blocking)
+
+- Q8 (is a `/research` round warranted?) — honestly borderline for the code
+  change alone; justified by the verification + guard + audit design. The user
+  has already elected to re-plan, so this is moot, but I won't pretend the code
+  diff is large.
+- The pure-read `status` instrumentation (§3) is genuinely useful and should be
+  folded into the fix PR, with the childless-leaf dispatch quirk fixed and
+  `socket_queue_id` added to `FormatBindings` — but it is not on the critical
+  path and must not gate the fix.
+- §8.3 live verification must run on **Ubuntu 26.04** (production parity), not
+  the ad-hoc 25.10 `xpf-fwd` VM — recreate it per `feedback_ubuntu_vms_always_2604`.

--- a/docs/research/1961-wire-type-dscp/codex-plan-r1.md
+++ b/docs/research/1961-wire-type-dscp/codex-plan-r1.md
@@ -1,0 +1,52 @@
+# Codex adversarial plan review — #1961 wire-type, round 1
+
+**Task:** task-mqjjyebz-g13x12 (3m6s). **Verdict: PLAN-KILL** — "Not because
+the premise is wrong. The premise is correct. Kill the research loop and send
+this straight to /engineer."
+
+## Findings
+- **Process:** more /research adds little; the remaining decisive question is
+  live behavior after the wire fix, which needs implementation. Keep the PR
+  scoped to wire fix + focused regression tests + helper decode-error logging +
+  live virtio validation. Do not drag the status instrumentation in unless
+  strictly needed for validation.
+- **Overclaim:** title/early framing says XSK delivery is "refuted" / virtio
+  "unblocked" before the post-fix transit test exists; later text correctly
+  treats it as unproven. Reword early language to "proven current blocker", not
+  "the only root cause".
+- **Compat wording bug:** "Old Go -> any Rust already always failed" is too
+  broad — it failed only when one of these []uint8 fields was populated;
+  empty/omitted configs worked. Engineering conclusion (new Go numeric works
+  with existing Rust Vec<u8>) still holds.
+
+## Verification (root cause confirmed)
+- Go encoding/json special-cases []uint8 -> base64 (encode.go); byte == uint8;
+  base64("." ) == "Lg==" == DSCP EF 46.
+- Rust expects plain Vec<u8> (cos.rs:46,63; security.rs:104) — no
+  deserialize_with, no base64 adapter.
+- Whole request dies before any response (from_str at handlers/mod.rs:66);
+  accept loops discard the Err (lifecycle.rs:220,239); Go wraps as
+  "publish userspace snapshot: EOF" (process.go:208, manager.go:678).
+- Field audit complete: only []uint8 json wire fields are protocol.go:194,205,
+  417. InjectPacketRequest is scalar metadata on both sides.
+
+## Fix direction
+- Option A, but name it generically (carries 802.1p code points too) — e.g.
+  wireUint8List, not dscpByteList.
+- MarshalJSON must NOT convert to []uint8 + json.Marshal (recreates the bug);
+  convert to []uint16/[]int or write the array directly. Keep UnmarshalJSON;
+  accepting legacy base64 on unmarshal is harmless.
+
+## Test requirements
+- Rust test must deserialize a full ControlRequest (not leaf structs).
+- Go test must assert JSON token type is array (not substring contains).
+- Inline JSON fine; separate Go-emits-arrays + Rust-decodes-full-request tests
+  are enough.
+
+## Q3/Q4
+In scope as small hardening: log handle_stream decode errors in Rust in the
+same PR; improve bare EOF if cheap, without expanding the fix.
+
+**Final instruction:** implement now, then run the live virtio transit test. If
+transit still fails after a successful apply_snapshot, resurrect the
+XSK-delivery plan.

--- a/docs/research/1961-wire-type-dscp/plan.md
+++ b/docs/research/1961-wire-type-dscp/plan.md
@@ -1,0 +1,225 @@
+# #1961 — virtio "no transit" is a Go↔Rust snapshot wire-type bug (not XSK delivery)
+
+**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
+**Base:** origin/master (`fc4ba8eb7`)
+**Issue:** #1961 (plain-virtio AF_XDP firewall does not forward transit). This
+plan **supersedes** the prior converged plan
+`docs/research/1961-virtio-xsk-delivery/plan.md` (PLAN-READY v1.3), whose
+XSK-delivery / queue-bound / NAPI hypothesis is **refuted** by the diagnosis
+below. `/research` only — no production code in this branch.
+
+## 1. Issue framing
+
+On a plain virtio incus VM the firewall does not forward transit. The prior
+research localized this to "the redirect→XSK delivery layer" and proposed
+diagnosing *which shim gate* drops the frame. That framing was **wrong**.
+
+This session reproduced the failure end-to-end and found the real cause is
+**upstream of the dataplane entirely**: the Go control plane's `apply_snapshot`
+control-socket request **fails to deserialize on the Rust helper**, so the
+helper never leaves bootstrap (`enabled:false`) and **no packet path is ever
+armed**. The "virtio delivers 0 packets to the XSK" observation is an artifact
+of measuring a dataplane that was never enabled.
+
+### Proven root cause: `[]uint8` ⇒ base64 string vs Rust `Vec<u8>` ⇒ sequence
+
+- Go's snapshot structs carry DSCP/code-point lists as `[]uint8`. Go's
+  `encoding/json` **special-cases `[]uint8`/`[]byte` and emits a base64
+  string**, e.g. `"dscp_values":"Lg=="` (`Lg==` = base64 of byte `46` = DSCP
+  EF).
+- The Rust `ConfigSnapshot` expects these as `Vec<u8>` — a **numeric JSON
+  array** (a serde *sequence*).
+- serde therefore rejects the value:
+  `invalid type: string "Lg==", expected a sequence`. The failure aborts the
+  **entire** `apply_snapshot` decode (not just the one field).
+- `userspace-dp/src/server/handlers/mod.rs:66` returns `Err` from
+  `handle_stream` *before writing any response*; the accept loop discards it
+  (`let _ = handle_stream(...)`, `server/lifecycle.rs:221,239`) and the socket
+  closes. The Go side (`pkg/dataplane/userspace/process.go:208`,
+  `json.Decoder.Decode`) reads a clean FIN with no bytes → **`EOF`**, surfaced
+  as `WARN "failed to compile dataplane" err="publish userspace snapshot: EOF"`.
+- The `,omitempty` json tag is why this is config-dependent: an empty list is
+  omitted from the wire, so a **stripped/minimal config publishes fine**, while
+  any config that populates one of these fields fails **silently and totally**.
+
+### The three affected wire fields (complete audit)
+
+| Go struct (`pkg/dataplane/userspace/protocol.go`) | Field | Rust (`Vec<u8>`) |
+|---|---|---|
+| `CoSDSCPClassifierEntrySnapshot` (:194) | `DSCPValues []uint8` `json:"dscp_values"` | `protocol/cos.rs:47` |
+| `CoSIEEE8021ClassifierEntrySnapshot` (:205) | `CodePoints []uint8` `json:"code_points"` | `protocol/cos.rs:64` |
+| `FirewallTermSnapshot` (:417) | `DSCPValues []uint8` `json:"dscp_values"` | `protocol/security.rs:105` |
+
+These are the **only** `[]uint8`/`[]byte` json wire fields in
+`pkg/dataplane/userspace`. (`inject_packet` does not use a `[]byte` json field —
+to be re-confirmed at implementation, see Q6.)
+
+### Evidence (all reproduced VM-free + corroborated live)
+
+1. Dumped the exact 34,895-byte `apply_snapshot` ControlRequest JSON the daemon
+   builds from `test/incus/xpf-test.conf` (the config xpf-fwd ran) via the real
+   `buildSnapshot()` path.
+2. `serde_json::from_str::<ControlRequest>` panics at the `dscp_values` field
+   (column 10081): `invalid type: string "Lg==", expected a sequence`.
+3. Rewriting that one field to a numeric array → the **full request decodes
+   OK** → `dscp_values` is the sole blocker for this config.
+4. Live journal on xpf-fwd: repeated `publish userspace snapshot: EOF`; the
+   first `CTRL_REQ: apply_snapshot generation=3` succeeded only **after** the
+   config was stripped of the DSCP filter.
+5. `xpf-test.conf:397` `filter dscp-filter { term mark-ef { ... dscp ef } }`
+   populates `FirewallTermSnapshot.DSCPValues=[46]`. `cos-iperf-config.set`
+   (loss cluster) defines **no** classifier/dscp/code-points → none of the 3
+   fields populated → the loss cluster always published & forwarded fine. This
+   is why the bug was invisible on the only smoke environment.
+
+## 2. Honest scope / value framing
+
+The win is large and was badly mislabeled:
+- It unblocks **plain-virtio as a forwarding venue** (every default
+  incus/qemu/cloud VM), which is high value for image validation and
+  bare-metal-ish testing.
+- It fixes a **general latent bug**: any production config with a DSCP firewall
+  filter, a DSCP classifier, or an 802.1p classifier silently fails to forward
+  **anything**, with only a misleading `EOF` in the log. This is not
+  virtio-specific.
+- It retires a multi-session false trail (#1928 "rx=0 invariant across
+  kernels/bind-modes"; the helper was never enabled).
+
+*If reviewers conclude the code fix is mechanical enough that a research round
+adds no value, that is a fair verdict — but the value here is the **regression
+test + verification design + error-visibility hardening**, not the one-line
+type change. PLAN-KILL is acceptable if reviewers think even those are
+unjustified; the diagnosis stands regardless.*
+
+## 3. What is already done / carried forward
+
+- **Diagnosis** (this session): root cause proven; the prior XSK-delivery plan
+  is superseded by this doc.
+- **Pure-read `status` instrumentation** (uncommitted on
+  `engineer/1961-virtio-xsk-delivery`): a `request chassis cluster data-plane
+  userspace status` subcommand (`pkg/cli/cli_request.go`) + cmdtree leaf
+  (`pkg/cmdtree/tree.go`) that surface the binding/XSK inventory + degraded-path
+  counters without mutating dataplane state. Useful observability — proposed to
+  carry into the fix PR (with the childless-leaf dispatch quirk fixed and
+  `socket_queue_id` added to `FormatBindings`). Reviewers: in or out of scope?
+
+## 4. Concrete design (fix shape deferred to quad-review)
+
+Rust stays `Vec<u8>` (already correct — it always wanted a numeric array). The
+fix is on the **Go** side so it stops emitting base64 for these 3 fields.
+
+- **Option A — named type + custom (Un)MarshalJSON.** Define one Go type over
+  `[]uint8` (e.g. `type dscpByteList []uint8`) with `MarshalJSON` that emits a
+  numeric array `[46]` and `UnmarshalJSON` that parses one (and, defensively,
+  still accepts a base64 string so Go's own round-trip / any persisted blob is
+  tolerant). Change the 3 fields to that type. Assignment sites
+  (`filters.go:89,91`, `cos.go:58`) keep assigning `[]uint8{…}` (assignable to a
+  named type with that underlying type → no caller churn). Self-documenting,
+  type-safe, uniform.
+- **Option B — `[]uint16`.** Change the 3 fields to `[]uint16`; Go marshals
+  **and** unmarshals these as numeric arrays natively (no custom marshaler).
+  Rust `Vec<u8>` decodes `[46]` cleanly (values ≤ 63). Mechanical churn at
+  assignment sites (`[]uint8{val}` → `[]uint16{uint16(val)}`) and any readers.
+
+Both keep the Rust side untouched. **The quad-review picks** (Q2).
+
+Separately, two hardening items the bug exposed:
+- The helper **silently discards** `handle_stream` errors (`let _ =` at
+  `lifecycle.rs:221,239`). Logging that `Err` (decode/read failure) would have
+  collapsed this multi-session chase to one line. Proposed: log it (Q3).
+- The Go side surfaces a bare `EOF`. Proposed: when the control socket closes
+  with no response, emit a more actionable hint (Q4).
+
+## 5. Public API / wire-compat preservation
+
+The wire encoding of these 3 fields changes from base64-string to
+numeric-array. Compatibility analysis (reviewers verify, Q7):
+- **Old Go (base64) → any Rust**: already always failed (the bug). No working
+  combination is regressed.
+- **New Go (numeric) → old Rust**: old Rust already expects a sequence →
+  **works** (this is in fact the first time it works).
+- **Rust → Go direction**: these fields are Go→Rust only (CoS/firewall
+  snapshots). `ProcessStatus` (Rust→Go) does not carry them. No reverse path.
+- **Mixed-version HA rolling upgrade (#1917)**: must confirm a node pinned to an
+  old helper binary isn't newly broken. Argued safe (old helper wanted a
+  sequence anyway), but this is an explicit review item.
+
+## 6. Hidden invariants the change must preserve
+
+- DSCP (6-bit, 0–63) and 802.1p code-points fit in `u8`/`u16` — no truncation.
+- List **ordering** must be preserved (classifier/rewrite semantics depend on
+  entry order, though the per-entry list is a set of code-points).
+- Go round-trip: if Option A adds `MarshalJSON`, it MUST add a matching
+  `UnmarshalJSON` or Go-side round-trip tests / state reload break.
+- No hot-path impact: these are compiled once per config commit, never
+  per-packet.
+
+## 7. Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression | LOW | Mechanical wire-encoding fix; Rust unchanged; covered by a round-trip test. |
+| Lifetime / borrow-checker | N/A | No Rust change. |
+| Performance regression | LOW | Config-commit-time only, not per-packet. |
+| Architectural mismatch (#961/#946-P2 dead-end) | LOW | Not a refactor; a correctness fix to a proven bug. |
+| Wire/mixed-version | MED | Encoding change — §5/Q7 must be verified, not assumed. |
+
+## 8. Test plan
+
+1. **Self-contained Go↔Rust round-trip regression** (the headline gap — the
+   prior bug shipped because no test exercised a populated `dscp_values` over
+   the wire):
+   - Go: build a `ConfigSnapshot` with a firewall term + a DSCP classifier + an
+     802.1p classifier all populated; `json.Marshal`; assert each field is a
+     numeric array (not a base64 string).
+   - Rust: deserialize the **same bytes** into `ControlRequest`; assert the
+     three fields equal the expected `Vec<u8>`. Embed the JSON inline (no
+     `/tmp` dependency).
+2. `cargo test --release` full suite + 5× flake on the new test; `go test ./...`.
+3. **Live virtio verification on xpf-fwd** (standalone, plain virtio):
+   - Restore the full `xpf-test.conf`; confirm `apply_snapshot` now publishes
+     (`enabled:true`, generation increments, no `EOF` in the journal).
+   - **Run a real transit-forwarding test** through a zone pair with a permit
+     policy and confirm sessions are created + bytes forwarded. This is the
+     decisive answer to the residual question (Q1): does virtio actually forward
+     once the snapshot publishes, or is there *also* an XSK-delivery issue
+     underneath?
+4. **Loss-cluster smoke (no regression)**: standard Pass A (CoS off) + Pass B
+   (CoS on), v4+v6, push+reverse. Additionally exercise fields 194/205 by
+   adding a DSCP/802.1p classifier to a smoke config and confirming it publishes
+   and forwards.
+
+## 9. Out of scope (explicitly)
+
+- The XSK-delivery / queue-bound-stranding / NAPI investigation from the prior
+  plan. Only reopen if §8.3's transit test **still** fails after the snapshot
+  publishes (Q1). Captured as a fallback, not the primary work.
+- The `status` instrumentation polish (childless-leaf dispatch, `socket_queue_id`)
+  unless reviewers fold it in (§3).
+- A broad serde/JSON fuzz of the whole wire surface (Q5 is a targeted audit, not
+  a fuzz campaign).
+
+## 10. Open questions for adversarial review (invite PLAN-KILL on any)
+
+- **Q1 (decisive):** Once `apply_snapshot` publishes on virtio, does the
+  dataplane actually forward transit, or is there a *second*, independent
+  XSK-delivery bug? The plan assumes the wire fix is sufficient but mandates a
+  live transit test to prove it. If reviewers believe a residual XSK bug is
+  likely, the plan should keep the old diagnosis plan armed.
+- **Q2:** Fix shape — Option A (named type + Marshal/Unmarshal) vs Option B
+  (`[]uint16`)? Round-trip and mixed-version implications.
+- **Q3:** Should the helper stop silently discarding `handle_stream` `Err`
+  (`lifecycle.rs let _ =`)? In scope for this PR or a separate hardening issue?
+- **Q4:** Should Go translate a "socket closed with no response" into a more
+  actionable error than bare `EOF`?
+- **Q5:** Beyond `[]uint8`, are there other Go↔Rust **type-parity** mismatches
+  on the snapshot wire (enum variants, int-vs-string, optional handling) that
+  could fail the same way on some unexercised config? Worth a bounded parity
+  audit?
+- **Q6:** Confirm `inject_packet` (and any other control verb) has no
+  base64-by-design `[]byte` field that the fix would wrongly "correct," and no
+  symmetric field that *should* stay base64.
+- **Q7:** Mixed-version HA rolling upgrade (#1917): is a node pinned to an old
+  helper binary regressed by the encoding change? (Argued no in §5.)
+- **Q8:** Is a full `/research` round even warranted for a mechanical wire fix,
+  or should this collapse straight to `/engineer`? (Honest self-check per §2.)

--- a/docs/research/1961-wire-type-dscp/plan.md
+++ b/docs/research/1961-wire-type-dscp/plan.md
@@ -1,6 +1,13 @@
 # #1961 — virtio "no transit" is a Go↔Rust snapshot wire-type bug (not XSK delivery)
 
-**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
+**Status:** PLAN-READY v2 (converged 2026-06-18). **Codex PLAN-KILL** — "premise
+is correct; kill the research *loop* and send straight to `/engineer`" (not a
+premise rejection; a Q8 vote that more research rounds add nothing). **Claude
+SMR PLAN-NEEDS-MINOR** (3 strengthening items, folded below). **AGY
+infra-blocked** — companion timed out `queued` without starting (consistent
+all-session failure; one documented retry, `adversarial-review-mqjk9cff-z56ylw`).
+Sanctioned infra-blocked convergence on Codex + Claude SMR per
+`feedback_codex_infra_must_retry`. All r1 feedback folded into v2.
 **Base:** origin/master (`fc4ba8eb7`)
 **Issue:** #1961 (plain-virtio AF_XDP firewall does not forward transit). This
 plan **supersedes** the prior converged plan
@@ -14,12 +21,20 @@ On a plain virtio incus VM the firewall does not forward transit. The prior
 research localized this to "the redirect→XSK delivery layer" and proposed
 diagnosing *which shim gate* drops the frame. That framing was **wrong**.
 
-This session reproduced the failure end-to-end and found the real cause is
-**upstream of the dataplane entirely**: the Go control plane's `apply_snapshot`
-control-socket request **fails to deserialize on the Rust helper**, so the
-helper never leaves bootstrap (`enabled:false`) and **no packet path is ever
-armed**. The "virtio delivers 0 packets to the XSK" observation is an artifact
-of measuring a dataplane that was never enabled.
+This session reproduced the failure end-to-end and found the **proven current
+blocker** is **upstream of the dataplane entirely**: the Go control plane's
+`apply_snapshot` control-socket request **fails to deserialize on the Rust
+helper**, so the helper never leaves bootstrap (`enabled:false`) and **no
+packet path is ever armed**. The "virtio delivers 0 packets to the XSK"
+observation is an artifact of measuring a dataplane that was never enabled.
+
+> **Precision (Codex r1):** what is *refuted* is the prior plan's claim that the
+> EOF / no-transit is explained by an XSK redirect→delivery-layer drop. The
+> wire-type bug is the **proven current blocker**, not necessarily the *only*
+> root cause. Whether virtio's XSK actually delivers once the snapshot publishes
+> is **still unproven** and is gated by the live transit test (§8.3, Q1). Until
+> that test passes, the superseded XSK-delivery plan stays referenced, not
+> deleted.
 
 ### Proven root cause: `[]uint8` ⇒ base64 string vs Rust `Vec<u8>` ⇒ sequence
 
@@ -99,9 +114,11 @@ unjustified; the diagnosis stands regardless.*
   `engineer/1961-virtio-xsk-delivery`): a `request chassis cluster data-plane
   userspace status` subcommand (`pkg/cli/cli_request.go`) + cmdtree leaf
   (`pkg/cmdtree/tree.go`) that surface the binding/XSK inventory + degraded-path
-  counters without mutating dataplane state. Useful observability — proposed to
-  carry into the fix PR (with the childless-leaf dispatch quirk fixed and
-  `socket_queue_id` added to `FormatBindings`). Reviewers: in or out of scope?
+  counters without mutating dataplane state. Useful observability, but **out of
+  scope for the fix PR unless the §8.3 live validation actually needs it**
+  (Codex r1: do not drag it in otherwise). If kept for validation, fix the
+  childless-leaf dispatch quirk and add `socket_queue_id` to `FormatBindings`;
+  otherwise it lands as its own follow-up. It must not gate or expand the fix.
 
 ## 4. Concrete design (fix shape deferred to quad-review)
 
@@ -109,13 +126,18 @@ Rust stays `Vec<u8>` (already correct — it always wanted a numeric array). The
 fix is on the **Go** side so it stops emitting base64 for these 3 fields.
 
 - **Option A — named type + custom (Un)MarshalJSON.** Define one Go type over
-  `[]uint8` (e.g. `type dscpByteList []uint8`) with `MarshalJSON` that emits a
-  numeric array `[46]` and `UnmarshalJSON` that parses one (and, defensively,
-  still accepts a base64 string so Go's own round-trip / any persisted blob is
-  tolerant). Change the 3 fields to that type. Assignment sites
-  (`filters.go:89,91`, `cos.go:58`) keep assigning `[]uint8{…}` (assignable to a
-  named type with that underlying type → no caller churn). Self-documenting,
-  type-safe, uniform.
+  `[]uint8` with `MarshalJSON` that emits a numeric array `[46]` and
+  `UnmarshalJSON` that parses one (and, defensively, still accepts a base64
+  string so Go's own round-trip / any persisted blob is tolerant — Codex:
+  accepting legacy base64 on unmarshal is harmless). Change the 3 fields to that
+  type. Assignment sites (`filters.go:89,91`, `cos.go:58`) keep assigning
+  `[]uint8{…}` (assignable to a named type with that underlying type → no caller
+  churn). Self-documenting, type-safe, uniform.
+  - **Name it generically** (Codex r1): the type carries both DSCP values *and*
+    802.1p code points, so call it e.g. `wireUint8List`, not `dscpByteList`.
+  - **`MarshalJSON` must NOT** convert back to `[]uint8` and call
+    `json.Marshal` — that re-triggers the base64 special-case and recreates the
+    bug. Convert to `[]uint16`/`[]int`, or write the numeric array directly.
 - **Option B — `[]uint16`.** Change the 3 fields to `[]uint16`; Go marshals
   **and** unmarshals these as numeric arrays natively (no custom marshaler).
   Rust `Vec<u8>` decodes `[46]` cleanly (values ≤ 63). Mechanical churn at
@@ -123,19 +145,23 @@ fix is on the **Go** side so it stops emitting base64 for these 3 fields.
 
 Both keep the Rust side untouched. **The quad-review picks** (Q2).
 
-Separately, two hardening items the bug exposed:
-- The helper **silently discards** `handle_stream` errors (`let _ =` at
-  `lifecycle.rs:221,239`). Logging that `Err` (decode/read failure) would have
-  collapsed this multi-session chase to one line. Proposed: log it (Q3).
-- The Go side surfaces a bare `EOF`. Proposed: when the control socket closes
-  with no response, emit a more actionable hint (Q4).
+Separately, two hardening items the bug exposed (Codex r1: both in scope as
+small hardening in the same PR):
+- **In scope:** the helper **silently discards** `handle_stream` errors (`let _
+  =` at `lifecycle.rs:220,239`). Logging that `Err` (decode/read failure) would
+  have collapsed this multi-session chase to one line. **Log it (Q3).**
+- **In scope if cheap:** the Go side surfaces a bare `EOF`. When the control
+  socket closes with no response, emit a more actionable hint (Q4) — but do not
+  let it expand the fix.
 
 ## 5. Public API / wire-compat preservation
 
 The wire encoding of these 3 fields changes from base64-string to
 numeric-array. Compatibility analysis (reviewers verify, Q7):
-- **Old Go (base64) → any Rust**: already always failed (the bug). No working
-  combination is regressed.
+- **Old Go → any Rust**: failed **only when one of these `[]uint8` fields was
+  populated** (Codex r1 — the earlier "always failed" wording was too broad;
+  empty/omitted configs worked, which is why the loss cluster and minimal
+  configs were fine). No working combination is regressed.
 - **New Go (numeric) → old Rust**: old Rust already expects a sequence →
   **works** (this is in fact the first time it works).
 - **Rust → Go direction**: these fields are Go→Rust only (CoS/firewall
@@ -168,15 +194,26 @@ numeric-array. Compatibility analysis (reviewers verify, Q7):
 
 1. **Self-contained Go↔Rust round-trip regression** (the headline gap — the
    prior bug shipped because no test exercised a populated `dscp_values` over
-   the wire):
+   the wire). Codex r1 tightenings folded:
    - Go: build a `ConfigSnapshot` with a firewall term + a DSCP classifier + an
-     802.1p classifier all populated; `json.Marshal`; assert each field is a
-     numeric array (not a base64 string).
-   - Rust: deserialize the **same bytes** into `ControlRequest`; assert the
-     three fields equal the expected `Vec<u8>`. Embed the JSON inline (no
-     `/tmp` dependency).
+     802.1p classifier all populated; `json.Marshal`; assert each field's JSON
+     **token type is an array** (parse and type-check, not a `strings.Contains`
+     substring match — the existing default fixtures only ever exercise empty
+     vectors).
+   - Rust: deserialize a **full `ControlRequest`** (not the leaf structs in
+     isolation — the failure is at whole-request decode); assert the three
+     fields equal the expected `Vec<u8>`. Embed the JSON inline (no `/tmp`
+     dependency). Separate Go-emits-arrays + Rust-decodes-full-request tests are
+     acceptable; "same bytes" need not be mechanically identical.
+   - **Class-level guard (SMR r1):** add a Go reflection test that walks the
+     snapshot wire structs and **fails if any exported field is `[]uint8`/
+     `[]byte` with a `json:` tag**. The per-field test prevents *this*
+     regression; the guard prevents a *fourth* such field silently
+     reintroducing the whole bug class.
 2. `cargo test --release` full suite + 5× flake on the new test; `go test ./...`.
-3. **Live virtio verification on xpf-fwd** (standalone, plain virtio):
+3. **Live virtio verification on a plain-virtio VM** — **recreated on Ubuntu
+   26.04** (production parity, per `feedback_ubuntu_vms_always_2604`; the ad-hoc
+   `xpf-fwd` was 25.10 and must not be the verification venue):
    - Restore the full `xpf-test.conf`; confirm `apply_snapshot` now publishes
      (`enabled:true`, generation increments, no `EOF` in the journal).
    - **Run a real transit-forwarding test** through a zone pair with a permit
@@ -184,6 +221,10 @@ numeric-array. Compatibility analysis (reviewers verify, Q7):
      decisive answer to the residual question (Q1): does virtio actually forward
      once the snapshot publishes, or is there *also* an XSK-delivery issue
      underneath?
+   - **Hard gate (SMR r1):** if transit still shows 0 sessions after a *clean*
+     publish, the fix is necessary-but-not-sufficient — **reopen the
+     XSK-delivery investigation** (resurrect the superseded plan); do not
+     declare #1961 fixed.
 4. **Loss-cluster smoke (no regression)**: standard Pass A (CoS off) + Pass B
    (CoS on), v4+v6, push+reverse. Additionally exercise fields 194/205 by
    adding a DSCP/802.1p classifier to a smoke config and confirming it publishes
@@ -212,10 +253,12 @@ numeric-array. Compatibility analysis (reviewers verify, Q7):
   (`lifecycle.rs let _ =`)? In scope for this PR or a separate hardening issue?
 - **Q4:** Should Go translate a "socket closed with no response" into a more
   actionable error than bare `EOF`?
-- **Q5:** Beyond `[]uint8`, are there other Go↔Rust **type-parity** mismatches
-  on the snapshot wire (enum variants, int-vs-string, optional handling) that
-  could fail the same way on some unexercised config? Worth a bounded parity
-  audit?
+- **Q5 (resolved → DO it):** Beyond `[]uint8`, there may be other Go↔Rust
+  **type-parity** mismatches on the snapshot wire (enum variants, int-vs-string,
+  optional handling) that fail the same way on some unexercised config. SMR r1:
+  perform a **bounded Go-struct↔Rust-struct field-by-field parity pass** during
+  `/engineer` — shipping the DSCP fix and then hitting a different decode-EOF on
+  the next config would be a poor outcome. In scope for the fix PR.
 - **Q6:** Confirm `inject_packet` (and any other control verb) has no
   base64-by-design `[]byte` field that the fix would wrongly "correct," and no
   symmetric field that *should* stay base64.

--- a/docs/research/1961-wire-type-dscp/reviewer-ids.md
+++ b/docs/research/1961-wire-type-dscp/reviewer-ids.md
@@ -1,6 +1,15 @@
-# #1961 wire-type plan — reviewer task IDs
+# #1961 wire-type plan — reviewer task IDs + verdicts
 
-## Round 1 (plan v1, commit 3f72abb1f)
-- Codex: task-mqjjyebz-g13x12 (background)
-- AGY:   adversarial-review-mqjjzkul-tr3b5h (background, --model pro-3)
-- Claude SMR: docs/research/1961-wire-type-dscp/claude-smr-plan-r1.md (PLAN-NEEDS-MINOR)
+## Round 1 (plan v1 -> v2, commit 3f72abb1f / d3b3cb6a1)
+- Codex: task-mqjjyebz-g13x12 (3m6s) -> **PLAN-KILL** = "premise correct, kill
+  the research loop, go straight to /engineer". codex-plan-r1.md
+- AGY:   adversarial-review-mqjjzkul-tr3b5h -> infra-timeout (queued, never
+  started). Retry adversarial-review-mqjk9cff-z56ylw -> **PLAN-READY** =
+  "collapse to /engineer; root cause completely verified". agy-plan-r1.md
+- Claude SMR: claude-smr-plan-r1.md -> **PLAN-NEEDS-MINOR** (3 items folded v2)
+
+## Convergence
+Unanimous: diagnosis correct + plan sound; fold the minors (done in v2); proceed
+to /engineer. All three independently verified: Go []uint8->base64 vs Rust
+Vec<u8>->sequence, 3 affected fields, no serde base64 adapter, no regression
+path. Awaiting manual approval via /engineer 1961.

--- a/docs/research/1961-wire-type-dscp/reviewer-ids.md
+++ b/docs/research/1961-wire-type-dscp/reviewer-ids.md
@@ -1,0 +1,6 @@
+# #1961 wire-type plan — reviewer task IDs
+
+## Round 1 (plan v1, commit 3f72abb1f)
+- Codex: task-mqjjyebz-g13x12 (background)
+- AGY:   adversarial-review-mqjjzkul-tr3b5h (background, --model pro-3)
+- Claude SMR: docs/research/1961-wire-type-dscp/claude-smr-plan-r1.md (PLAN-NEEDS-MINOR)

--- a/pkg/dataplane/userspace/process.go
+++ b/pkg/dataplane/userspace/process.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"os"
@@ -206,6 +207,17 @@ func (m *Manager) requestDetailedLocked(req ControlRequest) (ControlResponse, er
 	}
 	var resp ControlResponse
 	if err := json.NewDecoder(bufio.NewReader(conn)).Decode(&resp); err != nil {
+		// A bare EOF here means the helper closed the socket without writing a
+		// response — it rejected the request before replying (e.g. a request
+		// that failed to decode, like the #1961 wire-type mismatch). Surface an
+		// actionable hint instead of the opaque "EOF" that masked #1961 across
+		// multiple sessions.
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return ControlResponse{}, fmt.Errorf(
+				"control socket closed with no response to %q request (EOF); the "+
+					"helper rejected it before replying — check the helper log "+
+					"for a decode/handler error: %w", req.Type, err)
+		}
 		return ControlResponse{}, err
 	}
 	if !resp.OK {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -189,9 +189,9 @@ type CoSDSCPClassifierSnapshot struct {
 }
 
 type CoSDSCPClassifierEntrySnapshot struct {
-	ForwardingClass string  `json:"forwarding_class,omitempty"`
-	LossPriority    string  `json:"loss_priority,omitempty"`
-	DSCPValues      []uint8 `json:"dscp_values,omitempty"`
+	ForwardingClass string        `json:"forwarding_class,omitempty"`
+	LossPriority    string        `json:"loss_priority,omitempty"`
+	DSCPValues      WireUint8List `json:"dscp_values,omitempty"`
 }
 
 type CoSIEEE8021ClassifierSnapshot struct {
@@ -200,9 +200,9 @@ type CoSIEEE8021ClassifierSnapshot struct {
 }
 
 type CoSIEEE8021ClassifierEntrySnapshot struct {
-	ForwardingClass string  `json:"forwarding_class,omitempty"`
-	LossPriority    string  `json:"loss_priority,omitempty"`
-	CodePoints      []uint8 `json:"code_points,omitempty"`
+	ForwardingClass string        `json:"forwarding_class,omitempty"`
+	LossPriority    string        `json:"loss_priority,omitempty"`
+	CodePoints      WireUint8List `json:"code_points,omitempty"`
 }
 
 type CoSDSCPRewriteRuleSnapshot struct {
@@ -408,20 +408,20 @@ type FirewallFilterSnapshot struct {
 }
 
 type FirewallTermSnapshot struct {
-	Name            string   `json:"name"`
-	SourceAddresses []string `json:"source_addresses,omitempty"`
-	DestAddresses   []string `json:"destination_addresses,omitempty"`
-	Protocols       []string `json:"protocols,omitempty"`
-	SourcePorts     []string `json:"source_ports,omitempty"` // "80" or "1024-65535"
-	DestPorts       []string `json:"destination_ports,omitempty"`
-	DSCPValues      []uint8  `json:"dscp_values,omitempty"`
-	Action          string   `json:"action"` // "accept", "discard", "reject"
-	Count           string   `json:"count,omitempty"`
-	Log             bool     `json:"log,omitempty"`
-	PolicerName     string   `json:"policer,omitempty"`
-	RoutingInstance string   `json:"routing_instance,omitempty"`
-	ForwardingClass string   `json:"forwarding_class,omitempty"`
-	DSCPRewrite     *uint8   `json:"dscp_rewrite,omitempty"`
+	Name            string        `json:"name"`
+	SourceAddresses []string      `json:"source_addresses,omitempty"`
+	DestAddresses   []string      `json:"destination_addresses,omitempty"`
+	Protocols       []string      `json:"protocols,omitempty"`
+	SourcePorts     []string      `json:"source_ports,omitempty"` // "80" or "1024-65535"
+	DestPorts       []string      `json:"destination_ports,omitempty"`
+	DSCPValues      WireUint8List `json:"dscp_values,omitempty"`
+	Action          string        `json:"action"` // "accept", "discard", "reject"
+	Count           string        `json:"count,omitempty"`
+	Log             bool          `json:"log,omitempty"`
+	PolicerName     string        `json:"policer,omitempty"`
+	RoutingInstance string        `json:"routing_instance,omitempty"`
+	ForwardingClass string        `json:"forwarding_class,omitempty"`
+	DSCPRewrite     *uint8        `json:"dscp_rewrite,omitempty"`
 }
 
 type PolicerSnapshot struct {
@@ -651,14 +651,14 @@ type ProcessStatus struct {
 	// default — an empty slice (and an absent gauge family) does NOT mean
 	// the mirror is empty, only that the debug dump was not enabled. All
 	// are omitempty for wire-compat with older helpers.
-	NegNeighFastFailTotal           uint64   `json:"neg_neigh_fast_fail_total,omitempty"`
-	PendingNeighDuplicateDropsTotal uint64   `json:"pending_neigh_duplicate_drops_total,omitempty"`
+	NegNeighFastFailTotal           uint64 `json:"neg_neigh_fast_fail_total,omitempty"`
+	PendingNeighDuplicateDropsTotal uint64 `json:"pending_neigh_duplicate_drops_total,omitempty"`
 	// #1902: GRE-decapped MissingNeighbor packets refused pending_neigh
 	// admission — buffering the outer UMEM frame with the post-decap
 	// inner meta would retry-TX a mis-rewritten outer packet once the
 	// neighbor resolves.
 	PendingNeighDecapDropsTotal uint64   `json:"pending_neigh_decap_drops_total,omitempty"`
-	DynamicNeighborKeys             []string `json:"dynamic_neighbor_keys,omitempty"`
+	DynamicNeighborKeys         []string `json:"dynamic_neighbor_keys,omitempty"`
 	// #1789: total failed USERSPACE_SESSIONS BPF-map publishes (per-binding
 	// worker-poll sites summed with the shared no-binding sites: HA upsert,
 	// session-glue worker publish, post-reconcile replay, activation/reverse
@@ -1370,37 +1370,37 @@ type BindingStatus struct {
 	// Together: VMinThrottles = "fairness brake fired",
 	// VMinThrottleHardCapOverrides = "brake too tight, escape hatch
 	// rescued throughput". Ratio is the LAG_THRESHOLD diagnostic.
-	VMinThrottleHardCapOverrides      uint64 `json:"v_min_throttle_hard_cap_overrides,omitempty"`
-	VMinThrottles                     uint64 `json:"v_min_throttles,omitempty"`
-	SessionHits                       uint64 `json:"session_hits,omitempty"`
-	SessionMisses                     uint64 `json:"session_misses,omitempty"`
-	SessionCreates                    uint64 `json:"session_creates,omitempty"`
-	SessionExpires                    uint64 `json:"session_expires,omitempty"`
-	SessionDeltaPending               uint64 `json:"session_delta_pending,omitempty"`
-	SessionDeltaGenerated             uint64 `json:"session_delta_generated,omitempty"`
-	SessionDeltaDropped               uint64 `json:"session_delta_dropped,omitempty"`
-	SessionDeltaDrained               uint64 `json:"session_delta_drained,omitempty"`
-	PolicyDeniedPackets               uint64 `json:"policy_denied_packets,omitempty"`
-	ScreenDrops                       uint64 `json:"screen_drops,omitempty"`
-	SYNCookieChallenges               uint64 `json:"syn_cookie_challenges,omitempty"`
-	SYNCookieSecretUnavailable        uint64 `json:"syn_cookie_secret_unavailable,omitempty"`
-	SYNCookieSynAckSent               uint64 `json:"syn_cookie_syn_ack_sent,omitempty"`
-	SYNCookieAckRstSent               uint64 `json:"syn_cookie_ack_rst_sent,omitempty"`
-	SYNCookieReplyBudgetDrops         uint64 `json:"syn_cookie_reply_budget_drops,omitempty"`
-	SYNCookieAckValid                 uint64 `json:"syn_cookie_ack_valid,omitempty"`
-	SYNCookieAckInvalid               uint64 `json:"syn_cookie_ack_invalid,omitempty"`
-	SYNCookieBypass                   uint64 `json:"syn_cookie_bypass,omitempty"`
-	SNATPackets                       uint64 `json:"snat_packets,omitempty"`
-	DNATPackets                       uint64 `json:"dnat_packets,omitempty"`
-	SlowPathPackets                   uint64 `json:"slow_path_packets,omitempty"`
-	SlowPathBytes                     uint64 `json:"slow_path_bytes,omitempty"`
-	SlowPathLocalDeliveryPackets      uint64 `json:"slow_path_local_delivery_packets,omitempty"`
-	SlowPathMissingNeighborPackets    uint64 `json:"slow_path_missing_neighbor_packets,omitempty"`
-	SlowPathNoRoutePackets            uint64 `json:"slow_path_no_route_packets,omitempty"`
-	SlowPathNextTablePackets          uint64 `json:"slow_path_next_table_packets,omitempty"`
-	SlowPathForwardBuildPackets       uint64 `json:"slow_path_forward_build_packets,omitempty"`
-	SlowPathDrops                     uint64 `json:"slow_path_drops,omitempty"`
-	SlowPathRateLimited               uint64 `json:"slow_path_rate_limited,omitempty"`
+	VMinThrottleHardCapOverrides   uint64 `json:"v_min_throttle_hard_cap_overrides,omitempty"`
+	VMinThrottles                  uint64 `json:"v_min_throttles,omitempty"`
+	SessionHits                    uint64 `json:"session_hits,omitempty"`
+	SessionMisses                  uint64 `json:"session_misses,omitempty"`
+	SessionCreates                 uint64 `json:"session_creates,omitempty"`
+	SessionExpires                 uint64 `json:"session_expires,omitempty"`
+	SessionDeltaPending            uint64 `json:"session_delta_pending,omitempty"`
+	SessionDeltaGenerated          uint64 `json:"session_delta_generated,omitempty"`
+	SessionDeltaDropped            uint64 `json:"session_delta_dropped,omitempty"`
+	SessionDeltaDrained            uint64 `json:"session_delta_drained,omitempty"`
+	PolicyDeniedPackets            uint64 `json:"policy_denied_packets,omitempty"`
+	ScreenDrops                    uint64 `json:"screen_drops,omitempty"`
+	SYNCookieChallenges            uint64 `json:"syn_cookie_challenges,omitempty"`
+	SYNCookieSecretUnavailable     uint64 `json:"syn_cookie_secret_unavailable,omitempty"`
+	SYNCookieSynAckSent            uint64 `json:"syn_cookie_syn_ack_sent,omitempty"`
+	SYNCookieAckRstSent            uint64 `json:"syn_cookie_ack_rst_sent,omitempty"`
+	SYNCookieReplyBudgetDrops      uint64 `json:"syn_cookie_reply_budget_drops,omitempty"`
+	SYNCookieAckValid              uint64 `json:"syn_cookie_ack_valid,omitempty"`
+	SYNCookieAckInvalid            uint64 `json:"syn_cookie_ack_invalid,omitempty"`
+	SYNCookieBypass                uint64 `json:"syn_cookie_bypass,omitempty"`
+	SNATPackets                    uint64 `json:"snat_packets,omitempty"`
+	DNATPackets                    uint64 `json:"dnat_packets,omitempty"`
+	SlowPathPackets                uint64 `json:"slow_path_packets,omitempty"`
+	SlowPathBytes                  uint64 `json:"slow_path_bytes,omitempty"`
+	SlowPathLocalDeliveryPackets   uint64 `json:"slow_path_local_delivery_packets,omitempty"`
+	SlowPathMissingNeighborPackets uint64 `json:"slow_path_missing_neighbor_packets,omitempty"`
+	SlowPathNoRoutePackets         uint64 `json:"slow_path_no_route_packets,omitempty"`
+	SlowPathNextTablePackets       uint64 `json:"slow_path_next_table_packets,omitempty"`
+	SlowPathForwardBuildPackets    uint64 `json:"slow_path_forward_build_packets,omitempty"`
+	SlowPathDrops                  uint64 `json:"slow_path_drops,omitempty"`
+	SlowPathRateLimited            uint64 `json:"slow_path_rate_limited,omitempty"`
 	// TunnelEncapUnresolvedDrops counts tunnel-marked inner packets
 	// dropped at the slow-path chokepoint / pending-neigh exclusion
 	// instead of plaintext kernel reinjection (#1873 R-C/R-E).
@@ -1411,7 +1411,7 @@ type BindingStatus struct {
 	// fabric XSK binding, or the forward-frame build/enqueue failed)
 	// instead of being reinjected to the local kernel FIB (#1946).
 	// Wire-additive: older helpers omit it.
-	FabricRedirectUnsendableDrops uint64 `json:"fabric_redirect_unsendable_drops,omitempty"`
+	FabricRedirectUnsendableDrops     uint64 `json:"fabric_redirect_unsendable_drops,omitempty"`
 	KernelRXDropped                   uint64 `json:"kernel_rx_dropped,omitempty"`
 	KernelRXInvalidDescs              uint64 `json:"kernel_rx_invalid_descs,omitempty"`
 	TXPackets                         uint64 `json:"tx_packets,omitempty"`

--- a/pkg/dataplane/userspace/wire_uint8list.go
+++ b/pkg/dataplane/userspace/wire_uint8list.go
@@ -1,0 +1,110 @@
+package userspace
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// WireUint8List is a list of small unsigned integers (DSCP code points 0-63
+// and 802.1p code points) carried on the userspace-dp control-socket snapshot
+// wire.
+//
+// It exists solely to override Go's default `encoding/json` behavior for
+// `[]uint8`/`[]byte`: the standard library special-cases byte slices and
+// marshals them as a base64 STRING (e.g. DSCP EF 46 -> "Lg=="). The Rust
+// helper's `ConfigSnapshot` deserializes these fields as `Vec<u8>` — a numeric
+// JSON ARRAY (a serde sequence) — with no base64 adapter. A base64 string
+// therefore fails serde with `invalid type: string "...", expected a sequence`,
+// which aborts the ENTIRE `apply_snapshot` decode on the Rust side. The helper
+// returns an error before writing any response and closes the control socket;
+// the Go side sees a bare EOF, the helper never leaves bootstrap
+// (`enabled:false`), and the dataplane forwards nothing. Because the affected
+// fields carry `,omitempty`, an empty list is dropped from the wire entirely,
+// so the failure only manifests on configs that actually set DSCP/code-point
+// values (a DSCP firewall filter, or a DSCP/802.1p CoS classifier) — which is
+// why it stayed hidden on the loss-cluster smoke config. See #1961.
+//
+// MarshalJSON emits a numeric array and never base64. UnmarshalJSON accepts a
+// numeric array (the canonical form) and, defensively, a legacy base64 string
+// so any older persisted blob still loads.
+type WireUint8List []uint8
+
+// MarshalJSON renders the list as a numeric JSON array, e.g. [46,10]. It builds
+// the array text directly and MUST NOT delegate to json.Marshal on a []uint8 /
+// []byte value — that re-triggers the stdlib base64 special-case and recreates
+// the #1961 bug. An empty or nil list renders as `[]` (always a valid serde
+// sequence) rather than `null`, so the Rust `Vec<u8>` decodes it cleanly even
+// if a caller drops `,omitempty`.
+func (w WireUint8List) MarshalJSON() ([]byte, error) {
+	if len(w) == 0 {
+		return []byte("[]"), nil
+	}
+	b := make([]byte, 0, 2+len(w)*4)
+	b = append(b, '[')
+	for i, v := range w {
+		if i > 0 {
+			b = append(b, ',')
+		}
+		b = strconv.AppendUint(b, uint64(v), 10)
+	}
+	b = append(b, ']')
+	return b, nil
+}
+
+// UnmarshalJSON accepts the canonical numeric array form ([46,10]) and, for
+// backward compatibility with any blob written by the old default marshaler, a
+// base64 string ("LAo="). A JSON null decodes to a nil list.
+func (w *WireUint8List) UnmarshalJSON(data []byte) error {
+	// Trim leading ASCII whitespace without pulling in bytes just for this.
+	i := 0
+	for i < len(data) {
+		switch data[i] {
+		case ' ', '\t', '\n', '\r':
+			i++
+			continue
+		}
+		break
+	}
+	rest := data[i:]
+	if len(rest) == 0 {
+		*w = nil
+		return nil
+	}
+	switch rest[0] {
+	case 'n': // null
+		*w = nil
+		return nil
+	case '[':
+		// Canonical numeric array. Decode through []uint16 so an out-of-range
+		// element is rejected explicitly rather than silently wrapping.
+		var nums []uint16
+		if err := json.Unmarshal(rest, &nums); err != nil {
+			return fmt.Errorf("wire uint8 list: %w", err)
+		}
+		out := make(WireUint8List, len(nums))
+		for j, n := range nums {
+			if n > 255 {
+				return fmt.Errorf("wire uint8 list: element %d out of range: %d", j, n)
+			}
+			out[j] = uint8(n)
+		}
+		*w = out
+		return nil
+	case '"':
+		// Legacy base64 string emitted by the pre-#1961 default marshaler.
+		var s string
+		if err := json.Unmarshal(rest, &s); err != nil {
+			return fmt.Errorf("wire uint8 list: %w", err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return fmt.Errorf("wire uint8 list: invalid legacy base64 %q: %w", s, err)
+		}
+		*w = WireUint8List(decoded)
+		return nil
+	default:
+		return fmt.Errorf("wire uint8 list: expected array, base64 string, or null; got %q", rest[0])
+	}
+}

--- a/pkg/dataplane/userspace/wire_uint8list.go
+++ b/pkg/dataplane/userspace/wire_uint8list.go
@@ -55,7 +55,8 @@ func (w WireUint8List) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON accepts the canonical numeric array form ([46,10]) and, for
 // backward compatibility with any blob written by the old default marshaler, a
-// base64 string ("LAo="). A JSON null decodes to a nil list.
+// base64 string ("Lgo=" is the base64 of bytes 46,10). A JSON null decodes to a
+// nil list.
 func (w *WireUint8List) UnmarshalJSON(data []byte) error {
 	// Trim leading ASCII whitespace without pulling in bytes just for this.
 	i := 0

--- a/pkg/dataplane/userspace/wire_uint8list_test.go
+++ b/pkg/dataplane/userspace/wire_uint8list_test.go
@@ -1,0 +1,184 @@
+package userspace
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestWireUint8ListMarshalsNumericArray is the core #1961 regression: the wire
+// form MUST be a numeric JSON array, never a base64 string (which Go's default
+// []uint8 marshaler would emit and the Rust Vec<u8> deserializer would reject).
+func TestWireUint8ListMarshalsNumericArray(t *testing.T) {
+	cases := map[string]struct {
+		in   WireUint8List
+		want string
+	}{
+		"ef":    {WireUint8List{46}, "[46]"},
+		"multi": {WireUint8List{46, 10, 0, 63}, "[46,10,0,63]"},
+		"empty": {WireUint8List{}, "[]"},
+		"nil":   {nil, "[]"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			b, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(b) != tc.want {
+				t.Fatalf("marshal = %s, want %s", b, tc.want)
+			}
+			// Hard guard: the value must not be a JSON string (base64).
+			if len(b) > 0 && b[0] == '"' {
+				t.Fatalf("marshal produced a base64 string %s — the #1961 bug", b)
+			}
+		})
+	}
+}
+
+func TestWireUint8ListUnmarshal(t *testing.T) {
+	// Canonical numeric array.
+	var w WireUint8List
+	if err := json.Unmarshal([]byte("[46,10,63]"), &w); err != nil {
+		t.Fatalf("numeric: %v", err)
+	}
+	if !reflect.DeepEqual(w, WireUint8List{46, 10, 63}) {
+		t.Fatalf("numeric decode = %v", w)
+	}
+	// Legacy base64 ("Lgo=" == bytes 0x2E,0x0A == 46,10) must still load so an
+	// older persisted blob is tolerated.
+	var legacy WireUint8List
+	if err := json.Unmarshal([]byte(`"Lgo="`), &legacy); err != nil {
+		t.Fatalf("legacy base64: %v", err)
+	}
+	if !reflect.DeepEqual(legacy, WireUint8List{46, 10}) {
+		t.Fatalf("legacy base64 decode = %v, want [46 10]", legacy)
+	}
+	// null -> nil.
+	w = WireUint8List{1}
+	if err := json.Unmarshal([]byte("null"), &w); err != nil || w != nil {
+		t.Fatalf("null decode: err=%v w=%v", err, w)
+	}
+	// Out-of-range element rejected.
+	if err := json.Unmarshal([]byte("[256]"), &w); err == nil {
+		t.Fatalf("expected error for out-of-range element")
+	}
+}
+
+// TestSnapshotWireStructsCarryNumericDSCP exercises the three real snapshot
+// structs end to end through the wire encoding.
+func TestSnapshotWireStructsCarryNumericDSCP(t *testing.T) {
+	for _, v := range []any{
+		CoSDSCPClassifierEntrySnapshot{ForwardingClass: "ef", DSCPValues: WireUint8List{46}},
+		CoSIEEE8021ClassifierEntrySnapshot{ForwardingClass: "ef", CodePoints: WireUint8List{5}},
+		FirewallTermSnapshot{Name: "mark-ef", DSCPValues: WireUint8List{46}, Action: "accept"},
+	} {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %T: %v", v, err)
+		}
+		s := string(b)
+		if strings.Contains(s, `"dscp_values":"`) || strings.Contains(s, `"code_points":"`) {
+			t.Fatalf("%T marshaled a base64 string (the #1961 bug): %s", v, s)
+		}
+		if !strings.Contains(s, "[46]") && !strings.Contains(s, "[5]") {
+			t.Fatalf("%T did not marshal a numeric array: %s", v, s)
+		}
+	}
+}
+
+var jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+
+// rawConfigPassthroughType is ConfigSnapshot.Config (`json:"config"`): the full
+// compiled Junos config carried verbatim on the wire. The Rust helper decodes
+// THIS field as an opaque `serde_json::Value` (snapshot.rs `pub config:
+// serde_json::Value`) and never re-parses it into typed structs, so a base64
+// []uint8 inside it (e.g. config.ClassOfService DSCP classifier values) is
+// harmless — it is never deserialized as a Rust Vec<u8>. The guard below skips
+// this subtree because it is not part of the typed wire contract; everything
+// else IS, and must stay numeric.
+var rawConfigPassthroughType = reflect.TypeOf((*config.Config)(nil))
+
+// TestNoRawUint8SliceWireFields is the class-level guard (#1961): walk the full
+// control-socket wire type graph (request + response) and fail if any field is
+// a raw []uint8/[]byte slice without a custom MarshalJSON. Such a field would
+// be base64-encoded by Go's default marshaler and rejected by the Rust Vec<u8>
+// deserializer, silently aborting apply_snapshot. WireUint8List passes because
+// it implements json.Marshaler; a future raw []byte field would fail here
+// instead of in production.
+func TestNoRawUint8SliceWireFields(t *testing.T) {
+	seen := map[reflect.Type]bool{}
+	var bad []string
+	var walk func(t reflect.Type, path string)
+	walk = func(rt reflect.Type, path string) {
+		if rt == nil || seen[rt] {
+			return
+		}
+		seen[rt] = true
+		switch rt.Kind() {
+		case reflect.Pointer:
+			walk(rt.Elem(), path)
+		case reflect.Map:
+			walk(rt.Elem(), path+"[]")
+		case reflect.Slice, reflect.Array:
+			if rt.Elem().Kind() == reflect.Uint8 && !rt.Implements(jsonMarshalerType) {
+				bad = append(bad, path+" ("+rt.String()+")")
+				return
+			}
+			walk(rt.Elem(), path+"[]")
+		case reflect.Struct:
+			for i := 0; i < rt.NumField(); i++ {
+				f := rt.Field(i)
+				if f.PkgPath != "" { // unexported — not on the wire
+					continue
+				}
+				if f.Tag.Get("json") == "-" {
+					continue
+				}
+				if f.Type == rawConfigPassthroughType {
+					continue // opaque serde_json::Value on the Rust side — see above
+				}
+				walk(f.Type, path+"."+f.Name)
+			}
+		}
+	}
+	walk(reflect.TypeOf(ControlRequest{}), "ControlRequest")
+	walk(reflect.TypeOf(ControlResponse{}), "ControlResponse")
+	if len(bad) > 0 {
+		t.Fatalf("raw []uint8/[]byte wire field(s) found — these base64-encode and "+
+			"break the Rust Vec<u8> decode (#1961). Wrap with WireUint8List or a "+
+			"json.Marshaler:\n  %s", strings.Join(bad, "\n  "))
+	}
+}
+
+// TestBuildSnapshotFromFullConfigDecodes is the integration regression: build
+// the apply_snapshot request from the real standalone config (which carries a
+// DSCP firewall filter) and confirm the dscp_values land as a numeric array,
+// not the base64 string that aborted the Rust decode in #1961.
+func TestBuildSnapshotFromFullConfigDecodes(t *testing.T) {
+	content, err := os.ReadFile("../../../test/incus/xpf-test.conf")
+	if err != nil {
+		t.Skipf("config fixture unavailable: %v", err)
+	}
+	tree, _ := config.NewParser(string(content)).Parse()
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	snap := buildSnapshot(cfg, config.UserspaceConfig{Workers: 4, RingEntries: 1024}, 3, 3)
+	buf, err := json.Marshal(&ControlRequest{Type: "apply_snapshot", Snapshot: snap})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	s := string(buf)
+	if !strings.Contains(s, `"dscp_values":[`) {
+		t.Fatalf("expected a numeric dscp_values array in the snapshot; got none")
+	}
+	if strings.Contains(s, `"dscp_values":"`) || strings.Contains(s, `"code_points":"`) {
+		t.Fatalf("snapshot still emits a base64 dscp_values/code_points string (#1961)")
+	}
+}

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1567,3 +1567,72 @@ fn process_status_wg_tunnels_roundtrip_and_compat() {
     assert_eq!(future_row.tunnel, "wg9");
     assert_eq!(future_row.hs_send_errors, 0);
 }
+
+// #1961: a full apply_snapshot ControlRequest carrying DSCP/code-point lists as
+// numeric arrays must decode, and the three Vec<u8> fields must carry the
+// values. The Go control plane emits these as numeric arrays via the
+// WireUint8List type; before #1961 it emitted base64 strings, which serde
+// rejects (the whole-request decode aborts — see the negative test below). The
+// JSON is a full ControlRequest, not leaf structs, because the failure was at
+// whole-request decode.
+#[test]
+fn apply_snapshot_decodes_numeric_dscp_lists_1961() {
+    let json = r#"{
+      "type": "apply_snapshot",
+      "snapshot": {
+        "version": 3,
+        "generation": 7,
+        "generated_at": "2026-06-18T00:00:00Z",
+        "summary": {"host_name":"fw","dataplane_type":"userspace","interface_count":0,"zone_count":0,"policy_count":0,"scheduler_count":0,"ha_enabled":false},
+        "class_of_service": {
+          "dscp_classifiers": [
+            {"name": "dc", "entries": [{"forwarding_class": "ef", "dscp_values": [46, 10]}]}
+          ],
+          "ieee8021_classifiers": [
+            {"name": "ic", "entries": [{"forwarding_class": "ef", "code_points": [5]}]}
+          ]
+        },
+        "filters": [
+          {"name": "f", "family": "inet", "terms": [
+            {"name": "mark-ef", "protocols": [], "dscp_values": [46],
+             "action": "accept", "count": "", "log": false, "policer": ""}
+          ]}
+        ]
+      }
+    }"#;
+    let req: ControlRequest = serde_json::from_str(json).expect("full apply_snapshot decodes");
+    assert_eq!(req.request_type, "apply_snapshot");
+    let snap = req.snapshot.expect("snapshot present");
+    let cos = snap.class_of_service.expect("class_of_service present");
+    assert_eq!(cos.dscp_classifiers[0].entries[0].dscp_values, vec![46u8, 10]);
+    assert_eq!(cos.ieee8021_classifiers[0].entries[0].code_points, vec![5u8]);
+    assert_eq!(snap.filters[0].terms[0].dscp_values, vec![46u8]);
+}
+
+// #1961 negative: a base64 STRING for dscp_values (what Go's default []uint8
+// marshaler emitted pre-fix) must FAIL the whole-request decode — this is the
+// exact mechanism that left the helper disabled. Guards against anyone
+// "helpfully" adding a base64 adapter on the Rust side instead of the numeric
+// wire contract.
+#[test]
+fn apply_snapshot_rejects_base64_dscp_string_1961() {
+    let json = r#"{
+      "type": "apply_snapshot",
+      "snapshot": {
+        "version": 3, "generation": 7, "generated_at": "2026-06-18T00:00:00Z", "summary": {"host_name":"fw","dataplane_type":"userspace","interface_count":0,"zone_count":0,"policy_count":0,"scheduler_count":0,"ha_enabled":false},
+        "filters": [
+          {"name": "f", "family": "inet", "terms": [
+            {"name": "mark-ef", "protocols": [], "dscp_values": "Lg==",
+             "action": "accept", "count": "", "log": false, "policer": ""}
+          ]}
+        ]
+      }
+    }"#;
+    let err = serde_json::from_str::<ControlRequest>(json)
+        .expect_err("base64 dscp_values string must be rejected");
+    assert!(
+        err.to_string().contains("expected a sequence")
+            || err.to_string().contains("invalid type"),
+        "unexpected error: {err}"
+    );
+}

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -217,8 +217,18 @@ pub(crate) fn run() -> Result<(), String> {
                 while running.load(Ordering::SeqCst) {
                     match session_listener.accept() {
                         Ok((stream, _)) => {
-                            let _ =
-                                handle_stream(stream, &state_file, state.clone(), running.clone());
+                            // Log handle_stream failures rather than discarding
+                            // them: a request that fails to decode (e.g. a
+                            // wire-type mismatch) closes the socket with no
+                            // response, and the Go side sees only a bare EOF.
+                            // Surfacing the error here turns a silent
+                            // multi-session debugging chase into one log line
+                            // (#1961).
+                            if let Err(err) =
+                                handle_stream(stream, &state_file, state.clone(), running.clone())
+                            {
+                                eprintln!("xpf-userspace-dp: session request failed: {err}");
+                            }
                         }
                         Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
                             thread::sleep(Duration::from_millis(10));
@@ -236,7 +246,15 @@ pub(crate) fn run() -> Result<(), String> {
     while running.load(Ordering::SeqCst) {
         match listener.accept() {
             Ok((stream, _)) => {
-                let _ = handle_stream(stream, &args.state_file, state.clone(), running.clone());
+                // See the session-socket note above: surface decode/handler
+                // failures instead of discarding them. This is the socket that
+                // carries apply_snapshot, where a wire-type mismatch silently
+                // left the helper disabled and forwarding nothing (#1961).
+                if let Err(err) =
+                    handle_stream(stream, &args.state_file, state.clone(), running.clone())
+                {
+                    eprintln!("xpf-userspace-dp: control request failed: {err}");
+                }
             }
             Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
                 thread::sleep(Duration::from_millis(50));


### PR DESCRIPTION
## Summary

`apply_snapshot` carried DSCP and 802.1p code-point lists as Go `[]uint8`.
Go's `encoding/json` special-cases byte slices and marshals them as a **base64
string** (`"dscp_values":"Lg=="`), but the Rust helper's `ConfigSnapshot`
deserializes these as `Vec<u8>` — a **numeric array** — with no base64 adapter.
serde rejected the value, aborting the **entire** `apply_snapshot` decode; the
helper returned an error before responding and closed the socket; Go logged a
bare `publish userspace snapshot: EOF`; the helper stayed `enabled:false` in
bootstrap and **forwarded nothing**. `,omitempty` hid it — only configs with a
DSCP firewall filter or DSCP/802.1p CoS classifier failed, which is why
plain-virtio VMs never forwarded while the loss cluster (no such config) was
fine. This confounded the prior "rx=0 at the XSK, invariant across kernels"
trail: the helper was never enabled.

Fix is Go-side only (Rust already wanted a numeric array): a `WireUint8List`
named type over `[]uint8` whose `MarshalJSON` emits a numeric array (never
re-marshalling `[]uint8`, which would recreate the bug) and whose
`UnmarshalJSON` accepts numeric arrays and, defensively, legacy base64. The
three affected fields change to it; `[]uint8`-literal assignment sites are
unchanged (named-type assignability).

## Plan + adversarial review (research converged)

Plan: `docs/research/1961-wire-type-dscp/plan.md` (PLAN-READY v2).
- Codex: PLAN-KILL = "premise correct, go straight to /engineer"
- AGY: PLAN-READY = "root cause completely verified"
- Claude SMR: PLAN-NEEDS-MINOR (folded: class-level guard, type-parity audit, 26.04 verification gate)

## What's in the PR

1. `WireUint8List` + the 3 field changes (the fix).
2. Go regression tests: marshal-emits-array, legacy-base64 unmarshal, the three
   real structs, an integration test from `test/incus/xpf-test.conf`, and a
   **reflection guard** that fails if any wire field is a raw `[]uint8`/`[]byte`
   without a custom marshaler (closes the whole class).
3. Rust regression tests: full-`ControlRequest` numeric decode + a negative test
   asserting a base64 string is rejected.
4. Observability hardening: the helper accept loops now log the previously
   discarded `handle_stream` error (this would have surfaced #1961 in one line),
   and the Go client enriches a bare control-socket EOF.

## Test plan

- [x] `cargo build` + `go build ./...` clean
- [x] `cargo test --release`: full suite pass (incl. 2 new #1961 tests)
- [x] `go test ./...`: full suite pass (incl. new wire tests + reflection guard)
- [x] Reproduced VM-free: `xpf-test.conf` apply_snapshot now marshals
  `dscp_values` as a numeric array; Rust decodes the full request.
- [ ] Live virtio transit verification on **Ubuntu 26.04** (Q1 — does virtio
  forward once `apply_snapshot` publishes?) — in progress.
- [ ] Q5 Go↔Rust type-parity audit (other mismatch classes) — in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)