### PR TITLE
#1977: coerce flow/flow-export wire fields into Rust ranges (NUM_WIDTH sibling of #1961)

### DIFF
--- a/docs/pr/1977-numwidth-wire/claude-smr-code-r1.md
+++ b/docs/pr/1977-numwidth-wire/claude-smr-code-r1.md
@@ -1,0 +1,39 @@
+# Claude SMR — #1977 code review (PR #1978)
+
+**Verdict: MERGE-READY** (4th reviewer; verified the diff against the converged plan).
+
+## Verified directly
+
+- **All 11 fields coerced** at the build boundary (flow.go): 4 MSS
+  (IPsecVPN/GreIn/GreOut in the struct literal + AllTCP via the defensive line)
+  → `coerceWireU16`; 3 session timeouts (TCP/UDP/ICMP) → `coerceWireSessionTimeout`;
+  CollectorPort → skip-and-continue; SamplingRate → `<=0→1` + cap u32max;
+  Active/InactiveTimeout → `coerceWireU32Timeout`. None passed through raw.
+- **Overflow-safe session cap**: caps at `config.MaxDurationSeconds`
+  (=`MaxInt64/1e9`≈9.22e9); `int(MaxDurationSeconds)` is exact on amd64 (int=int64),
+  and `9.22e9 × 1e9 ≈ 9.22e18 < u64::MAX` — so Rust `from_seconds`'s unchecked
+  `secs*1e9` cannot overflow (Codex r2 confirmed the arithmetic).
+- **CollectorPort**: `port==0` keeps the benign "absent" skip (no warn);
+  `port<0 || >65535` warns + skips THAT server and continues scanning the
+  remaining flow-servers — does not abort the whole export. Correct.
+- **SamplingRate**: keeps the existing `<=0→1` normalization, adds the
+  `>u32max` cap. `int64(rate) > math.MaxUint32` is the right comparison on a
+  64-bit int.
+- **Sole chokepoint**: `buildFlowSnapshot`/`buildFlowExportSnapshot` are called
+  only from `buildSnapshot` (verified at plan time) → covers all input paths.
+- **Logging**: `slog.Warn` fires only inside the builders (per config commit),
+  never per-packet/poll — complies with the project logging rules.
+- **Tests**: drive the REAL builders with out-of-range configs and assert
+  in-range for all 11 + in-range passthrough unchanged + out-of-range port
+  skips + helper tables (incl. TCPMSSAllTCP); Rust decodes a full ControlRequest
+  with max-range numbers and rejects a negative (the defended mechanism).
+- **In-range behavior**: unchanged (passthrough assertions).
+
+## Notes
+
+- Full Go suite green; full Rust suite has 1 pre-existing flake
+  (`concurrent_recovery_processes_each_command_exactly_once`, worker_queue —
+  untouched by this PR; passed 3/3+5/5 during #1976) — re-rerun to confirm
+  not a regression.
+- Layer B (commit-time `ValidateInteger`) correctly deferred to a follow-up;
+  Layer A alone closes the safety hole on all paths.

--- a/docs/pr/1977-numwidth-wire/claude-smr-plan-r1.md
+++ b/docs/pr/1977-numwidth-wire/claude-smr-plan-r1.md
@@ -1,0 +1,58 @@
+# Claude SMR — #1977 NUM_WIDTH plan review, round 1
+
+**Posture:** hostile domain SMR (serialization / Go-Rust interop). Not a self-rubber-stamp.
+
+**Verdict: PLAN-NEEDS-MINOR** — design is sound and the load-bearing assumption
+verified; three folds before `/engineer`.
+
+## Verified directly
+
+- **Chokepoint (Q5) — CONFIRMED.** `buildFlowSnapshot` (flow.go:5) and
+  `buildFlowExportSnapshot` (flow.go:24) are called ONLY from `buildSnapshot`
+  (builder.go:45,59), which is the sole `ConfigSnapshot` constructor that feeds
+  `m.lastSnapshot` (the published snapshot). `FlowExportSnapshot{}` is
+  constructed only inside `buildFlowExportSnapshot` (flow.go:53). So Layer A at
+  these two functions covers **every** config-derived snapshot regardless of how
+  the config arrived (CLI, gRPC, file). Layer A's "covers all input paths" claim
+  is true, not aspirational. This is the strongest part of the design.
+- **Mechanism** matches #1961: the whole `ControlRequest` decodes in one
+  `serde_json::from_str` (server/handlers/mod.rs), so one out-of-range numeric
+  aborts the entire `apply_snapshot`. The fields are Go `int`
+  (types_security.go:68-72,110; types_system.go:501-502,515-516) → emitted as
+  signed JSON numbers; Rust expects unsigned. Sound.
+
+## Required minor folds (into v2)
+
+1. **Re-confirm the field set (Q4) at implementation start, not just trust the
+   audit.** The Q5 audit predates the #1976 merge; #1976 didn't touch these
+   structs, but the implementer must diff current `protocol.go`
+   FlowSnapshot/FlowExportSnapshot int fields against the Rust
+   `snapshot.rs`/`security.rs` unsigned fields and confirm exactly these 9 (and
+   no int→unsigned field in any OTHER snapshot struct slipped past the audit's
+   would_fail_decode filter). Cheap; closes the "is the audit complete" gap.
+2. **Frame Layer A as the must-have, Layer B as optional.** Layer A (build-
+   boundary coercion) is the *guarantee* — it alone makes the decode abort
+   impossible on every path. Layer B (commit-time `ValidateInteger`) is operator
+   UX (a clear `commit check` error vs silent coercion). If reviewers push back
+   on scope (Codex's #1961 "don't over-scope" instinct), ship Layer A and file
+   Layer B separately — do NOT ship Layer B without Layer A (Layer B alone
+   leaves the gRPC/file paths exposed).
+3. **Ranges = the Rust wire-type bounds suffice for THIS fix.** The goal is
+   preventing the decode abort, so u16 fields validate/coerce to `[0,65535]`,
+   u32/u64 to `[0,typeMax]`. A tighter Junos-correct bound (MSS MTU-derived,
+   port `[1,65535]`, sane timeout caps) is a *config-correctness* improvement,
+   not required to stop the abort — call it out as optional so the PR doesn't
+   balloon into MSS-semantics debates. (Exception: CollectorPort should use
+   `[1,65535]` since port 0 is already the skip sentinel.)
+
+## Non-blocking notes
+
+- Coercion semantics (Q1): MSS→0 (=disabled), port→skip-export, timeout→0/clamp
+  are each the safe degradation. With Layer B present, the CLI rejects so the
+  operator sees the error; Layer A's silent coercion only fires on non-CLI
+  paths, where coerce+`slog.Warn` beats a dead dataplane. Good.
+- A class-level guard (Q5 of the plan): a Go test asserting every numeric
+  snapshot field placed by the builders is within its Rust type's range would
+  catch a future int→unsigned field — worth it but lighter-weight than #1961's
+  reflection guard (cross-language range isn't reflectable, so it'd be a
+  hand-maintained table). Optional; reviewers decide.

--- a/docs/pr/1977-numwidth-wire/claude-smr-plan-r2.md
+++ b/docs/pr/1977-numwidth-wire/claude-smr-plan-r2.md
@@ -1,0 +1,28 @@
+# Claude SMR — #1977 NUM_WIDTH plan review, round 2
+
+**Verdict: PLAN-READY.**
+
+v2 folds every r1 finding, and I verified the two load-bearing items myself:
+
+- **Chokepoint (r1):** `buildFlowSnapshot`/`buildFlowExportSnapshot` are the sole
+  pre-wire constructor (called only from `buildSnapshot`), so Layer A covers all
+  input paths. Confirmed by Codex r1 #6 + AGY r1 + me.
+- **Inventory completeness (r2, Q1):** the two missed fields (`TCPMSSAllTCP`,
+  `SamplingRate`) are folded → 11. I cross-checked ALL other request-side `int`
+  json fields: topology/NAT/CoS use Rust **signed** types (`vlan_id`/`mtu`/
+  `ttl`/`ifindex`/`parent_ifindex`/`queue` = `i32`, NAT timeouts `i64`); the only
+  other unsigned request-side field is `address_count: usize`, a builder-computed
+  count that is never negative/out-of-range. ⇒ 11 is the complete
+  reachable-FATAL set.
+- **Overflow cap (Codex r1 #3):** session timeouts capped at `MaxDurationSeconds`
+  (= `MaxInt64/1e9` ≈ 9.2e9) — `× 1e9` stays within u64, so Rust
+  `from_seconds`'s unchecked multiply is safe. Correct.
+- **SamplingRate:** reachable via `inst.InputRate` (flow.go:56); Layer A caps
+  `>u32max` and keeps `<=0→1`. Correct.
+- **Layer B deferred:** sound — the target schema nodes are `children: nil`, so
+  commit-time validation needs a separate schema-expansion design; Layer A alone
+  closes the safety hole on all paths. Layer B is operator UX, tracked as a
+  follow-up.
+
+Coercion semantics are safe fail-open (MSS→0 incl GRE-out-0⇒MTU-derived; port
+skip-and-continue; u32/u64 caps). Ship Layer A.

--- a/docs/pr/1977-numwidth-wire/plan.md
+++ b/docs/pr/1977-numwidth-wire/plan.md
@@ -1,164 +1,171 @@
 # #1977 — NUM_WIDTH Go↔Rust snapshot wire mismatches (flow/flow-export)
 
-**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
+**Status:** PLAN v2 — pending re-review. Folds Codex r1 PLAN-NEEDS-MAJOR + AGY r1
+PLAN-NEEDS-MINOR + Claude SMR r1 PLAN-NEEDS-MINOR. Key changes: inventory
+corrected to **11** fields (both reviewers caught `TCPMSSAllTCP` +
+`SamplingRate`); session-timeout cap is `MaxDurationSeconds` not u64-max (Rust
+`from_seconds` does `secs*1e9` unchecked → overflow); per-field coercion made
+explicit; **Layer B (commit-time validation) deferred to a follow-up** because
+the target schema nodes are `children: nil` and need non-trivial expansion —
+Layer A alone is the dataplane-safety guarantee.
 **Base:** origin/master (`28e7309f7`, post-#1976)
 **Issue:** #1977 (sibling class of #1961, found by the #1961 Q5 type-parity audit)
 
 ## 1. Issue framing
 
-#1961 fixed the `[]uint8`→base64 wire-type bug. The Q5 audit that accompanied it
-found a **second fatal-decode class**: nine `FlowSnapshot` / `FlowExportSnapshot`
-fields are Go signed `int` on the wire but Rust **unsigned** `u16`/`u32`/`u64`.
-A negative or out-of-range value serializes fine from Go but makes
-`serde_json::from_str::<ControlRequest>` ERROR (`invalid value: integer X,
-expected uN`). Because the helper decodes the whole request in one `from_str`
-(`server/handlers/mod.rs`), the entire `apply_snapshot` is rejected before
-`snapshot::apply` runs — the exact #1961 failure mode (helper unconfigured,
-forwarding silently broken, Go sees a bare EOF — now logged after #1961's Q3
-hardening).
+#1961 fixed the `[]uint8`→base64 wire class. The Q5 audit found a second
+fatal-decode class: `FlowSnapshot`/`FlowExportSnapshot` fields that are Go
+signed `int` on the wire but Rust **unsigned**. A negative or out-of-range value
+serializes fine from Go but makes `serde_json::from_str::<ControlRequest>` ERROR
+(`invalid value: integer X, expected uN`); because the helper decodes the whole
+request in one `from_str` (`server/handlers/mod.rs`), the entire `apply_snapshot`
+is rejected — the #1961 failure (helper unconfigured, forwarding silently
+broken; now logged after #1961's Q3 hardening).
 
-### The nine fields
+### The eleven fields (corrected from 9 — Codex + AGY r1)
 
-| Go (`pkg/dataplane/userspace/protocol.go`) | Rust | wire range | source |
+| Go (`pkg/dataplane/userspace/protocol.go`) | Rust | wire range | builder-reachable? |
 |---|---|---|---|
-| `FlowSnapshot.TCPMSSIPsecVPN` (int) | `u16` | 0–65535 | `cfg.Security.Flow.TCPMSSIPsecVPN` |
-| `FlowSnapshot.TCPMSSGreIn` (int) | `u16` | 0–65535 | `cfg.Security.Flow.TCPMSSGreIn` |
-| `FlowSnapshot.TCPMSSGreOut` (int) | `u16` | 0–65535 | `cfg.Security.Flow.TCPMSSGreOut` |
-| `FlowSnapshot.TCPSessionTimeout` (int) | `u64` | ≥0 | `cfg.Security.Flow.TCPSession.EstablishedTimeout` |
-| `FlowSnapshot.UDPSessionTimeout` (int) | `u64` | ≥0 | `cfg.Security.Flow.UDPSessionTimeout` |
-| `FlowSnapshot.ICMPSessionTimeout` (int) | `u64` | ≥0 | `cfg.Security.Flow.ICMPSessionTimeout` |
-| `FlowExportSnapshot.CollectorPort` (int) | `u16` | 1–65535 | sampling `flow-server` port |
-| `FlowExportSnapshot.ActiveTimeout` (int) | `u32` | ≥0 | v9 template `flow-active-timeout` |
-| `FlowExportSnapshot.InactiveTimeout` (int) | `u32` | ≥0 | v9 template `flow-inactive-timeout` |
+| `FlowSnapshot.TCPMSSIPsecVPN` (int) | `u16` (snapshot.rs:140) | 0–65535 | yes (`cfg.Security.Flow.TCPMSSIPsecVPN`) |
+| `FlowSnapshot.TCPMSSGreIn` (int) | `u16` (146) | 0–65535 | yes |
+| `FlowSnapshot.TCPMSSGreOut` (int) | `u16` (148) | 0–65535 | yes (Rust 0 ⇒ MTU-derived MSS, not pure-disabled — forwarding/mod.rs:784) |
+| `FlowSnapshot.TCPMSSAllTCP` (int) | `u16` (143) | 0–65535 | **no** (not set by `buildFlowSnapshot` today ⇒ always 0; coerced defensively) |
+| `FlowSnapshot.TCPSessionTimeout` (int) | `u64` (150) | 0–`MaxDurationSeconds` | yes (`TCPSession.EstablishedTimeout`) |
+| `FlowSnapshot.UDPSessionTimeout` (int) | `u64` (152) | 0–`MaxDurationSeconds` | yes |
+| `FlowSnapshot.ICMPSessionTimeout` (int) | `u64` (154) | 0–`MaxDurationSeconds` | yes |
+| `FlowExportSnapshot.CollectorPort` (int) | `u16` (security.rs:157) | 1–65535 | yes (sampling flow-server port) |
+| `FlowExportSnapshot.SamplingRate` (int) | `u32` (158) | 1–4294967295 | **yes, reachable** (`inst.InputRate`, only `<=0→1` today — `flow.go:56`) |
+| `FlowExportSnapshot.ActiveTimeout` (int) | `u32` (161) | 0–4294967295 | yes (v9 `flow-active-timeout`) |
+| `FlowExportSnapshot.InactiveTimeout` (int) | `u32` (163) | 0–4294967295 | yes (v9 `flow-inactive-timeout`) |
 
-The most operator-reachable triggers are the **u16** fields with a value
-`>65535` (a plausible typo, e.g. `set services flow tcp-mss-gre-in 70000` or
-`flow-server <addr> port 70000`). Negatives need a more contrived path. None of
-these leaves currently carry a commit-time validator (the project pattern
-`ValidateInteger(min,max)` exists — e.g. `schema_chassis.go` — but is absent
-here; `compiler_services.go` parses with `strconv.Atoi` and no range check).
+Most operator-reachable: the **u16** fields with a value `>65535` (typo, e.g.
+`tcp-mss-gre-in 70000`, `flow-server … port 70000`) and a `sampling input rate`
+exceeding u32. No commit-time validator exists on these leaves today
+(`compiler_services.go` parses with `strconv.Atoi`, no range check).
 
 ## 2. Honest scope/value framing
 
-Closes a latent class that silently disables the entire dataplane on a
-plausible operator typo, with only a (now-logged) EOF as the signal. The win is
-correctness + operator UX (a clear commit error instead of a dead dataplane).
-*If reviewers conclude the build-boundary guard alone suffices and the
-per-leaf commit validation is not worth the churn — or vice-versa — narrowing
-to one layer is an acceptable outcome.*
+Closes a latent class that silently disables the entire dataplane on a plausible
+operator typo. *If reviewers conclude even Layer A is unjustified at the current
+incidence, PLAN-KILL is acceptable — but the dataplane-disable blast radius
+(total forwarding loss, no clean error pre-#1961) argues for the guard.*
 
 ## 3. What's already shipped
 
-#1961 (merged): the `[]uint8`/base64 fix, the reflection guard (catches the
-`[]uint8` class only — it cannot see the int→unsigned class), and the helper
-decode-error logging (so a recurrence of THIS class now logs `control request
-failed: ... invalid value: integer ...` instead of a silent EOF).
+#1961 (merged): the `[]uint8` fix, the reflection guard (catches `[]uint8`
+only — cannot see int→unsigned), and helper decode-error logging (so a
+recurrence of THIS class now logs `control request failed: … invalid value:
+integer …` instead of a silent EOF).
 
-## 4. Concrete design (two complementary layers; reviewers weigh)
+## 4. Concrete design — Layer A (build-boundary coercion), the guarantee
 
-### Layer A — build-boundary guard (the guarantee)
+`buildFlowSnapshot` / `buildFlowExportSnapshot` (`flow.go`) are the **sole**
+pre-wire constructor of these structs (verified: called only from
+`buildSnapshot`/`buildSnapshotWithSchedulerState`, builder.go:45,59;
+`FlowExportSnapshot{}` built only at flow.go:53 — confirmed by Codex r1 #6, AGY
+r1, Claude SMR r1). Coercing here covers **every** input path (CLI, gRPC, file).
+A small helper coerces each field to its Rust wire range and `slog.Warn`s once
+when it clamps, naming the field + offending value:
 
-`buildFlowSnapshot` / `buildFlowExportSnapshot` (`flow.go`) are the single
-chokepoint before the wire, covering **every** input path (CLI, gRPC config,
-file load, future). Coerce each of the nine fields into its Rust wire range
-before it is placed on the snapshot, so a bad value can never abort the decode:
+- **u16 MSS** (IPsecVPN, GreIn, GreOut, AllTCP): `v<0 || v>65535` → `0` (=
+  disabled; for GRE-out, Rust 0 means MTU-derived MSS — acceptable fail-open).
+  AllTCP is not builder-populated today; coerced defensively in case it is wired
+  later.
+- **u16 CollectorPort**: `v<1 || v>65535` → **skip that server, continue
+  scanning** the remaining flow-servers (matches the existing `server.Port == 0`
+  skip; do not abort the whole export).
+- **u32 SamplingRate**: keep the current `<=0 → 1` normalization; additionally
+  `v>4294967295` → `4294967295` (cap) + warn.
+- **u32 ActiveTimeout / InactiveTimeout**: `v<0` → `0` (= default); `v>4294967295`
+  → `4294967295`. (u32max × 1e9 fits in u64, so no Rust-side overflow.)
+- **u64 session timeouts** (TCP/UDP/ICMP): `v<0` → `0` (= default); `v >
+  MaxDurationSeconds` → `MaxDurationSeconds`. **Not u64-max**: Rust
+  `SessionTimeouts::from_seconds` multiplies `secs * 1_000_000_000` **unchecked**
+  (session/mod.rs:75); `MaxDurationSeconds` (= `MaxInt64/1e9` ≈ 9.2e9) keeps the
+  product within u64 (Codex r1 #3).
 
-- **u16 MSS** (`TCPMSS*`): out-of-range → treat as `0` (= "disabled", the
-  field's documented zero-default; dropped by `,omitempty`). A negative or
-  `>65535` MSS is meaningless anyway.
-- **u16 CollectorPort**: out-of-range (`<1` or `>65535`) → **skip the
-  flow-export feature** for that server (extend the existing `server.Port == 0`
-  skip), since exporting to an invalid port is wrong, not clampable.
-- **u32/u64 timeouts**: negative → `0` (= "use built-in default"); `>` the Rust
-  type max → clamp to the max. (u32 max for Active/Inactive; u64 for session
-  timeouts — realistically unreachable, but the guard makes it total.)
-- Log a single `slog.Warn` when a value is coerced, naming the field + the
-  offending value, so the operator sees it even on a non-CLI path.
+This is behavior-preserving for every in-range config and is the property the
+regression test pins.
 
-This is behavior-preserving for every in-range config (the vast majority) and is
-the property the regression test pins.
+### Layer B (commit-time `ValidateInteger`) — DEFERRED to a follow-up
 
-### Layer B — commit-time validation (operator UX)
-
-Add `ValidateInteger` typed-leaf validators to the config schema leaves so the
-CLI rejects the bad value at `commit check` with a clear message (the project
-pattern), instead of relying on silent coercion:
-
-- `security flow tcp-mss {ipsec-vpn|gre-in|gre-out|all-tcp}` → `ValidateInteger(0, 65535)`
-  (`schema_security.go`)
-- `security flow tcp-session established-timeout`, and the udp/icmp session
-  timeouts → `ValidateInteger(0, MaxDurationSeconds)` (locate exact leaves)
-- `services …/forwarding-options sampling … flow-server <addr> port` →
-  `ValidateInteger(1, 65535)` (`schema_routing.go`)
-- `services flow-monitoring … flow-active-timeout` / `flow-inactive-timeout`
-  → `ValidateInteger(0, <u32 max or a sane cap>)` (`schema_system.go:434/443`)
+Both reviewers (Codex r1 #4, AGY r1 #2) found the target schema nodes
+(`security flow tcp-session`/`udp-session`/`icmp-session`/`tcp-mss`,
+`forwarding-options sampling …`/`flow-server`) are modeled `children: nil`
+(opaque/free-form) — the schema walker does not descend into them, so attaching
+`ValidateInteger` requires first expanding each node to define its child
+keywords (or adding a custom strict validator). That is a non-trivial schema
+restructuring and is **operator UX, not dataplane safety** (Layer A already
+makes the decode abort impossible). Ship Layer A here; file Layer B as a
+follow-up issue. Layer B must NOT ship without Layer A (it would leave the
+gRPC/file paths exposed).
 
 ## 5. Public API / wire preservation
 
-No wire-shape change — these stay numeric JSON. The fix only ensures the value
-is always in the Rust type's range. New Go → old Rust and old Go → new Rust are
-both unaffected for in-range configs (the only ones that ever worked). Mixed
-HA (#1917): no change to session-sync wire.
+No wire-shape change — fields stay numeric JSON, only guaranteed in-range. New
+Go → old Rust and old Go → new Rust unaffected for in-range configs (the only
+ones that ever worked). No HA session-sync wire change (#1917).
 
 ## 6. Hidden invariants
 
-- Zero-value semantics preserved: `0` means "disabled"/"use default" for these
-  fields; the guard must not turn a valid `0` into anything else.
-- `,omitempty` still drops zero values (minimal-config publish unchanged).
-- The build-boundary coercion must be deterministic and allocation-free on the
-  config-commit path (not hot path; trivial).
+- Zero-value semantics preserved: `0` = "disabled"/"use default"; the guard must
+  not turn a valid `0` into anything else, nor a valid in-range value.
+- `,omitempty` still drops zero values (minimal-config publish unchanged). Note
+  `sampling_rate` has no `omitempty` and is always emitted ≥1 (existing
+  `<=0→1`), so the cap is the only added behavior.
+- Coercion is deterministic, allocation-free, config-commit-time only.
 
 ## 7. Risk assessment
 
 | Class | Level | Notes |
 |---|---|---|
-| Behavioral regression | LOW | In-range configs unchanged; only out-of-range values (previously fatal) are coerced/rejected. |
+| Behavioral regression | LOW | In-range configs unchanged; only previously-fatal out-of-range values are coerced. |
 | Lifetime/borrow | N/A | No Rust change. |
 | Performance | NONE | Config-commit time only. |
-| Architectural mismatch | LOW | Adds validation + a guard; no structural change. |
+| Architectural mismatch | LOW | Adds a coercion helper at the existing chokepoint. |
 
 ## 8. Test plan
 
-1. Go unit tests: for each of the 9 fields, a config with an out-of-range value
-   (`-1` and `70000` where the type is u16) → `buildFlowSnapshot` /
-   `buildFlowExportSnapshot` produces a snapshot whose marshaled JSON has the
-   field in range (or the feature skipped for CollectorPort), and `json.Marshal`
-   of the full `ControlRequest` decodes... (Go can't run serde, so) assert the
-   numeric value is within `[0, typeMax]`.
-2. Go schema test: `commit check` (SchemaValidate) **rejects** `tcp-mss-gre-in
-   70000`, `flow-server … port 70000`, `flow-active-timeout -1`, etc. with a
-   clear error (Layer B).
-3. Rust test: extend the #1961-style full-`ControlRequest` decode test with a
-   FlowSnapshot/FlowExportSnapshot carrying max-range values (65535 / u32 max)
-   — confirm they decode; and a negative value is rejected (documents the
-   mechanism this PR defends against).
-4. `cargo test --release` + `go test ./...` full suites.
-5. Loss-cluster smoke (CoS off + on, v4+v6, push+reverse multi-stream) — no
-   regression. The loss config exercises flow/CoS; confirm publish + line rate.
-   Optionally add an out-of-range flow value to a scratch config and confirm
-   `commit check` now rejects it (Layer B) live.
+1. Go unit tests covering **all 11 fields**: a config with `-1` and (for u16)
+   `70000` / (for SamplingRate) `>u32max` / (for session timeouts) `>
+   MaxDurationSeconds` → build via the **real** `buildFlowSnapshot` /
+   `buildFlowExportSnapshot`, marshal the full `ControlRequest`, assert each
+   numeric is within `[0, typeMax]` (and ≤ `MaxDurationSeconds` for u64
+   timeouts), and that an out-of-range CollectorPort skips that server.
+2. Rust test (extends the #1961 full-`ControlRequest` decode test): a
+   FlowSnapshot/FlowExportSnapshot with max-valid values (65535, u32max,
+   MaxDurationSeconds) decodes; a negative `sampling_rate`/timeout is rejected
+   (documents the mechanism this PR defends against).
+3. `cargo test --release` + `go test ./...` full suites.
+4. Loss-cluster smoke (CoS off + on, v4+v6, push+reverse multi-stream) — the
+   loss config exercises flow + CoS; confirm publish + line rate, no regression.
 
 ## 9. Out of scope
 
-- A general "audit every Go int↔Rust unsigned wire field" sweep beyond the 9
-  confirmed (the Q5 audit covered the snapshot surface; these 9 are the
-  confirmed FATAL_DECODE set).
-- Changing the Rust types (they are correctly bounded; the fix is input-side).
+- **Layer B** (commit-time `ValidateInteger` + schema-node expansion) → follow-up
+  issue.
+- Tighter-than-wire Junos semantic ranges (MSS MTU-derived min/max, etc.) — a
+  config-correctness improvement, not needed to stop the decode abort.
+- Changing the Rust types (correctly bounded; the fix is input-side).
 
 ## 10. Open questions for adversarial review
 
-- **Q1:** Layer A coercion semantics per field — is `0`/skip/clamp the right
-  choice for each (MSS→0, port→skip, timeout→0/clamp)? Any field where silent
-  coercion hides a real operator error worse than a commit rejection?
-- **Q2:** Do we need BOTH layers, or is the build-boundary guard (which covers
-  all input paths) sufficient, with commit-time validation as a separate
-  follow-up? (Codex #1961 leaned "don't over-scope.")
-- **Q3:** Exact ranges — MSS min (0 vs 64/536 per Junos), port min (0 vs 1),
-  timeout caps. Should MSS validate against the IP-MTU-derived max rather than
-  the u16 max?
-- **Q4:** Are there MORE than these 9 int→unsigned wire fields once #1961
-  merged? Re-confirm against current `protocol.go` vs the Rust structs (the Q5
-  audit predates the merge but #1976 didn't touch these fields).
-- **Q5:** Should a class-level guard (analogous to #1961's reflection test) be
-  added — e.g. a Go↔Rust contract test or a build-boundary assertion that every
-  numeric snapshot field is range-checked? Or is that over-engineering?
+- **Q1:** Inventory completeness. SMR re-checked all other request-side `int`
+  json fields: the topology/NAT/CoS ones use Rust **signed** types — `vlan_id`,
+  `mtu`, `ttl`, `ifindex`, `parent_ifindex`, `queue` are all `i32`, NAT
+  timeouts `i64` (no mismatch). The only other unsigned request-side field is
+  `SourceNatPoolSnapshot.address_count` → Rust `usize`, but it is a
+  builder-computed count (never negative or > usize), so not reachable
+  out-of-range. ⇒ the 11 flow/flow-export fields are the complete
+  **reachable-FATAL** set. Reviewers: confirm or refute this cross-domain check.
+- **Q2:** Coercion semantics per field (§4) — all safe fail-open? Any field
+  where clamping silently corrupts worse than the (deferred) commit rejection?
+  Specifically: SamplingRate cap vs reject; GRE-out 0⇒MTU-derived.
+- **Q3:** Is deferring Layer B acceptable, given Layer A closes the safety hole
+  on all paths and Layer B needs a separate schema-expansion design?
+- **Q4:** `MaxDurationSeconds` (≈9.2e9 s) as the u64 session-timeout cap — does
+  any other Rust consumer of these seconds do arithmetic that overflows even at
+  that cap? (from_seconds × 1e9 is safe; verify no further unchecked scaling.)
+- **Q5:** Should a lightweight Go range-table guard test be added so a future
+  int→unsigned snapshot field is caught (analogous to #1961's reflection guard,
+  but hand-maintained since cross-language range isn't reflectable)?

--- a/docs/pr/1977-numwidth-wire/plan.md
+++ b/docs/pr/1977-numwidth-wire/plan.md
@@ -1,13 +1,14 @@
 # #1977 — NUM_WIDTH Go↔Rust snapshot wire mismatches (flow/flow-export)
 
-**Status:** PLAN v2 — pending re-review. Folds Codex r1 PLAN-NEEDS-MAJOR + AGY r1
-PLAN-NEEDS-MINOR + Claude SMR r1 PLAN-NEEDS-MINOR. Key changes: inventory
-corrected to **11** fields (both reviewers caught `TCPMSSAllTCP` +
-`SamplingRate`); session-timeout cap is `MaxDurationSeconds` not u64-max (Rust
-`from_seconds` does `secs*1e9` unchecked → overflow); per-field coercion made
-explicit; **Layer B (commit-time validation) deferred to a follow-up** because
-the target schema nodes are `children: nil` and need non-trivial expansion —
-Layer A alone is the dataplane-safety guarantee.
+**Status:** PLAN-READY v2.1 (converged 2026-06-18). AGY r2 PLAN-READY + Codex r2
+PLAN-NEEDS-MINOR (3 doc-precision minors — Q1 usize-count wording,
+`address_count` is status-side, `TCPMSSAllTCP` test via helper — all folded) +
+Claude SMR r2 PLAN-READY. Design unanimously sound. Inventory **11** fields
+(`TCPMSSAllTCP` + `SamplingRate` added in r1); session-timeout cap
+`MaxDurationSeconds` (Codex r2 confirmed `9.22e9 × 1e9 < u64max`, saturating
+downstream); per-field coercion explicit; **Layer B (commit-time validation)
+deferred to a follow-up** (target schema nodes are `children: nil`; Layer A
+alone is the dataplane-safety guarantee on all paths).
 **Base:** origin/master (`28e7309f7`, post-#1976)
 **Issue:** #1977 (sibling class of #1961, found by the #1961 Q5 type-parity audit)
 
@@ -126,12 +127,15 @@ ones that ever worked). No HA session-sync wire change (#1917).
 
 ## 8. Test plan
 
-1. Go unit tests covering **all 11 fields**: a config with `-1` and (for u16)
-   `70000` / (for SamplingRate) `>u32max` / (for session timeouts) `>
-   MaxDurationSeconds` → build via the **real** `buildFlowSnapshot` /
-   `buildFlowExportSnapshot`, marshal the full `ControlRequest`, assert each
-   numeric is within `[0, typeMax]` (and ≤ `MaxDurationSeconds` for u64
-   timeouts), and that an out-of-range CollectorPort skips that server.
+1. Go unit tests covering **all 11 fields**. For the 10 builder-populated fields,
+   feed a config with `-1` and (for u16) `70000` / (for SamplingRate) `>u32max` /
+   (for session timeouts) `> MaxDurationSeconds` through the **real**
+   `buildFlowSnapshot` / `buildFlowExportSnapshot`, marshal the full
+   `ControlRequest`, and assert each numeric is within `[0, typeMax]` (≤
+   `MaxDurationSeconds` for u64 timeouts), and that an out-of-range CollectorPort
+   skips that server. `TCPMSSAllTCP` is NOT populated by `buildFlowSnapshot`
+   today (Codex r2 #3) — cover its coercion with a direct helper/table test
+   (contract-only defensive coverage), not via the real builder.
 2. Rust test (extends the #1961 full-`ControlRequest` decode test): a
    FlowSnapshot/FlowExportSnapshot with max-valid values (65535, u32max,
    MaxDurationSeconds) decodes; a negative `sampling_rate`/timeout is rejected
@@ -150,14 +154,18 @@ ones that ever worked). No HA session-sync wire change (#1917).
 
 ## 10. Open questions for adversarial review
 
-- **Q1:** Inventory completeness. SMR re-checked all other request-side `int`
-  json fields: the topology/NAT/CoS ones use Rust **signed** types — `vlan_id`,
-  `mtu`, `ttl`, `ifindex`, `parent_ifindex`, `queue` are all `i32`, NAT
-  timeouts `i64` (no mismatch). The only other unsigned request-side field is
-  `SourceNatPoolSnapshot.address_count` → Rust `usize`, but it is a
-  builder-computed count (never negative or > usize), so not reachable
-  out-of-range. ⇒ the 11 flow/flow-export fields are the complete
-  **reachable-FATAL** set. Reviewers: confirm or refute this cross-domain check.
+- **Q1:** Inventory completeness — RESOLVED (Codex r1/r2 + AGY + SMR). Other
+  request-side `int` json fields split into: (a) Rust **signed** (`vlan_id`,
+  `mtu`, `ttl`, `ifindex`, `parent_ifindex`, `queue` = `i32`; no mismatch); and
+  (b) Rust **usize** but **builder-derived counts** that are never negative or
+  out-of-range — `SnapshotSummary` interface/zone/policy/scheduler counts
+  (protocol.go:115 → snapshot.rs:25), `InterfaceSnapshot.RXQueues`/`UnitCount`
+  (snapshot.rs:50), `FabricSnapshot.RXQueues` (snapshot.rs:298). None are
+  operator-controlled, so none is reachable-FATAL. (`SourceNatPoolSnapshot.
+  address_count` is **status-side**, not a `ControlRequest` field — out of scope
+  for the decode path.) ⇒ the 11 flow/flow-export fields are the complete
+  **reachable-FATAL** set; the usize count fields are a non-reachable theoretical
+  tail noted for the record.
 - **Q2:** Coercion semantics per field (§4) — all safe fail-open? Any field
   where clamping silently corrupts worse than the (deferred) commit rejection?
   Specifically: SamplingRate cap vs reject; GRE-out 0⇒MTU-derived.

--- a/docs/pr/1977-numwidth-wire/plan.md
+++ b/docs/pr/1977-numwidth-wire/plan.md
@@ -1,0 +1,164 @@
+# #1977 — NUM_WIDTH Go↔Rust snapshot wire mismatches (flow/flow-export)
+
+**Status:** DRAFT v1 — pending adversarial plan review (Codex + AGY + Claude SMR)
+**Base:** origin/master (`28e7309f7`, post-#1976)
+**Issue:** #1977 (sibling class of #1961, found by the #1961 Q5 type-parity audit)
+
+## 1. Issue framing
+
+#1961 fixed the `[]uint8`→base64 wire-type bug. The Q5 audit that accompanied it
+found a **second fatal-decode class**: nine `FlowSnapshot` / `FlowExportSnapshot`
+fields are Go signed `int` on the wire but Rust **unsigned** `u16`/`u32`/`u64`.
+A negative or out-of-range value serializes fine from Go but makes
+`serde_json::from_str::<ControlRequest>` ERROR (`invalid value: integer X,
+expected uN`). Because the helper decodes the whole request in one `from_str`
+(`server/handlers/mod.rs`), the entire `apply_snapshot` is rejected before
+`snapshot::apply` runs — the exact #1961 failure mode (helper unconfigured,
+forwarding silently broken, Go sees a bare EOF — now logged after #1961's Q3
+hardening).
+
+### The nine fields
+
+| Go (`pkg/dataplane/userspace/protocol.go`) | Rust | wire range | source |
+|---|---|---|---|
+| `FlowSnapshot.TCPMSSIPsecVPN` (int) | `u16` | 0–65535 | `cfg.Security.Flow.TCPMSSIPsecVPN` |
+| `FlowSnapshot.TCPMSSGreIn` (int) | `u16` | 0–65535 | `cfg.Security.Flow.TCPMSSGreIn` |
+| `FlowSnapshot.TCPMSSGreOut` (int) | `u16` | 0–65535 | `cfg.Security.Flow.TCPMSSGreOut` |
+| `FlowSnapshot.TCPSessionTimeout` (int) | `u64` | ≥0 | `cfg.Security.Flow.TCPSession.EstablishedTimeout` |
+| `FlowSnapshot.UDPSessionTimeout` (int) | `u64` | ≥0 | `cfg.Security.Flow.UDPSessionTimeout` |
+| `FlowSnapshot.ICMPSessionTimeout` (int) | `u64` | ≥0 | `cfg.Security.Flow.ICMPSessionTimeout` |
+| `FlowExportSnapshot.CollectorPort` (int) | `u16` | 1–65535 | sampling `flow-server` port |
+| `FlowExportSnapshot.ActiveTimeout` (int) | `u32` | ≥0 | v9 template `flow-active-timeout` |
+| `FlowExportSnapshot.InactiveTimeout` (int) | `u32` | ≥0 | v9 template `flow-inactive-timeout` |
+
+The most operator-reachable triggers are the **u16** fields with a value
+`>65535` (a plausible typo, e.g. `set services flow tcp-mss-gre-in 70000` or
+`flow-server <addr> port 70000`). Negatives need a more contrived path. None of
+these leaves currently carry a commit-time validator (the project pattern
+`ValidateInteger(min,max)` exists — e.g. `schema_chassis.go` — but is absent
+here; `compiler_services.go` parses with `strconv.Atoi` and no range check).
+
+## 2. Honest scope/value framing
+
+Closes a latent class that silently disables the entire dataplane on a
+plausible operator typo, with only a (now-logged) EOF as the signal. The win is
+correctness + operator UX (a clear commit error instead of a dead dataplane).
+*If reviewers conclude the build-boundary guard alone suffices and the
+per-leaf commit validation is not worth the churn — or vice-versa — narrowing
+to one layer is an acceptable outcome.*
+
+## 3. What's already shipped
+
+#1961 (merged): the `[]uint8`/base64 fix, the reflection guard (catches the
+`[]uint8` class only — it cannot see the int→unsigned class), and the helper
+decode-error logging (so a recurrence of THIS class now logs `control request
+failed: ... invalid value: integer ...` instead of a silent EOF).
+
+## 4. Concrete design (two complementary layers; reviewers weigh)
+
+### Layer A — build-boundary guard (the guarantee)
+
+`buildFlowSnapshot` / `buildFlowExportSnapshot` (`flow.go`) are the single
+chokepoint before the wire, covering **every** input path (CLI, gRPC config,
+file load, future). Coerce each of the nine fields into its Rust wire range
+before it is placed on the snapshot, so a bad value can never abort the decode:
+
+- **u16 MSS** (`TCPMSS*`): out-of-range → treat as `0` (= "disabled", the
+  field's documented zero-default; dropped by `,omitempty`). A negative or
+  `>65535` MSS is meaningless anyway.
+- **u16 CollectorPort**: out-of-range (`<1` or `>65535`) → **skip the
+  flow-export feature** for that server (extend the existing `server.Port == 0`
+  skip), since exporting to an invalid port is wrong, not clampable.
+- **u32/u64 timeouts**: negative → `0` (= "use built-in default"); `>` the Rust
+  type max → clamp to the max. (u32 max for Active/Inactive; u64 for session
+  timeouts — realistically unreachable, but the guard makes it total.)
+- Log a single `slog.Warn` when a value is coerced, naming the field + the
+  offending value, so the operator sees it even on a non-CLI path.
+
+This is behavior-preserving for every in-range config (the vast majority) and is
+the property the regression test pins.
+
+### Layer B — commit-time validation (operator UX)
+
+Add `ValidateInteger` typed-leaf validators to the config schema leaves so the
+CLI rejects the bad value at `commit check` with a clear message (the project
+pattern), instead of relying on silent coercion:
+
+- `security flow tcp-mss {ipsec-vpn|gre-in|gre-out|all-tcp}` → `ValidateInteger(0, 65535)`
+  (`schema_security.go`)
+- `security flow tcp-session established-timeout`, and the udp/icmp session
+  timeouts → `ValidateInteger(0, MaxDurationSeconds)` (locate exact leaves)
+- `services …/forwarding-options sampling … flow-server <addr> port` →
+  `ValidateInteger(1, 65535)` (`schema_routing.go`)
+- `services flow-monitoring … flow-active-timeout` / `flow-inactive-timeout`
+  → `ValidateInteger(0, <u32 max or a sane cap>)` (`schema_system.go:434/443`)
+
+## 5. Public API / wire preservation
+
+No wire-shape change — these stay numeric JSON. The fix only ensures the value
+is always in the Rust type's range. New Go → old Rust and old Go → new Rust are
+both unaffected for in-range configs (the only ones that ever worked). Mixed
+HA (#1917): no change to session-sync wire.
+
+## 6. Hidden invariants
+
+- Zero-value semantics preserved: `0` means "disabled"/"use default" for these
+  fields; the guard must not turn a valid `0` into anything else.
+- `,omitempty` still drops zero values (minimal-config publish unchanged).
+- The build-boundary coercion must be deterministic and allocation-free on the
+  config-commit path (not hot path; trivial).
+
+## 7. Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression | LOW | In-range configs unchanged; only out-of-range values (previously fatal) are coerced/rejected. |
+| Lifetime/borrow | N/A | No Rust change. |
+| Performance | NONE | Config-commit time only. |
+| Architectural mismatch | LOW | Adds validation + a guard; no structural change. |
+
+## 8. Test plan
+
+1. Go unit tests: for each of the 9 fields, a config with an out-of-range value
+   (`-1` and `70000` where the type is u16) → `buildFlowSnapshot` /
+   `buildFlowExportSnapshot` produces a snapshot whose marshaled JSON has the
+   field in range (or the feature skipped for CollectorPort), and `json.Marshal`
+   of the full `ControlRequest` decodes... (Go can't run serde, so) assert the
+   numeric value is within `[0, typeMax]`.
+2. Go schema test: `commit check` (SchemaValidate) **rejects** `tcp-mss-gre-in
+   70000`, `flow-server … port 70000`, `flow-active-timeout -1`, etc. with a
+   clear error (Layer B).
+3. Rust test: extend the #1961-style full-`ControlRequest` decode test with a
+   FlowSnapshot/FlowExportSnapshot carrying max-range values (65535 / u32 max)
+   — confirm they decode; and a negative value is rejected (documents the
+   mechanism this PR defends against).
+4. `cargo test --release` + `go test ./...` full suites.
+5. Loss-cluster smoke (CoS off + on, v4+v6, push+reverse multi-stream) — no
+   regression. The loss config exercises flow/CoS; confirm publish + line rate.
+   Optionally add an out-of-range flow value to a scratch config and confirm
+   `commit check` now rejects it (Layer B) live.
+
+## 9. Out of scope
+
+- A general "audit every Go int↔Rust unsigned wire field" sweep beyond the 9
+  confirmed (the Q5 audit covered the snapshot surface; these 9 are the
+  confirmed FATAL_DECODE set).
+- Changing the Rust types (they are correctly bounded; the fix is input-side).
+
+## 10. Open questions for adversarial review
+
+- **Q1:** Layer A coercion semantics per field — is `0`/skip/clamp the right
+  choice for each (MSS→0, port→skip, timeout→0/clamp)? Any field where silent
+  coercion hides a real operator error worse than a commit rejection?
+- **Q2:** Do we need BOTH layers, or is the build-boundary guard (which covers
+  all input paths) sufficient, with commit-time validation as a separate
+  follow-up? (Codex #1961 leaned "don't over-scope.")
+- **Q3:** Exact ranges — MSS min (0 vs 64/536 per Junos), port min (0 vs 1),
+  timeout caps. Should MSS validate against the IP-MTU-derived max rather than
+  the u16 max?
+- **Q4:** Are there MORE than these 9 int→unsigned wire fields once #1961
+  merged? Re-confirm against current `protocol.go` vs the Rust structs (the Q5
+  audit predates the merge but #1976 didn't touch these fields).
+- **Q5:** Should a class-level guard (analogous to #1961's reflection test) be
+  added — e.g. a Go↔Rust contract test or a build-boundary assertion that every
+  numeric snapshot field is range-checked? Or is that over-engineering?

--- a/docs/pr/1977-numwidth-wire/reviewer-ids.md
+++ b/docs/pr/1977-numwidth-wire/reviewer-ids.md
@@ -1,6 +1,16 @@
-# #1977 NUM_WIDTH plan — reviewer task IDs
+# #1977 NUM_WIDTH plan — reviewer task IDs + verdicts
 
-## Round 1 (plan v1, commit 566d9edd1)
-- Codex: task-mqjniy9k-1zl7a6 (background)
-- AGY:   adversarial-review-mqjnj7rz-cnem56 (background, --model pro-3)
-- Claude SMR: claude-smr-plan-r1.md (PLAN-NEEDS-MINOR; chokepoint VERIFIED)
+## Round 1 (plan v1, 566d9edd1)
+- Codex task-mqjniy9k-1zl7a6 -> PLAN-NEEDS-MAJOR (11 not 9; sampling_rate; timeout overflow cap; Layer B under-specified)
+- AGY adversarial-review-mqjnj7rz-cnem56 -> PLAN-NEEDS-MINOR (11 not 9; schema nodes children:nil)
+- Claude SMR claude-smr-plan-r1.md -> PLAN-NEEDS-MINOR (chokepoint VERIFIED)
+
+## Round 2 (plan v2, 7f1ad9702)
+- Codex task-mqjnu4x5-1piqjq -> PLAN-NEEDS-MINOR (3 doc-precision: usize-count wording, address_count status-side, TCPMSSAllTCP test-via-helper; confirmed overflow math + Layer-B deferral OK)
+- AGY adversarial-review-mqjnud7x-hw3rke -> PLAN-READY
+- Claude SMR claude-smr-plan-r2.md -> PLAN-READY
+
+## Convergence (v2.1)
+All 3 doc-precision minors folded. Design unanimously sound: Layer A
+build-boundary coercion (11 fields, overflow-safe MaxDurationSeconds cap) is the
+dataplane-safety guarantee; Layer B deferred to a follow-up. Proceed to implement.

--- a/docs/pr/1977-numwidth-wire/reviewer-ids.md
+++ b/docs/pr/1977-numwidth-wire/reviewer-ids.md
@@ -1,0 +1,6 @@
+# #1977 NUM_WIDTH plan — reviewer task IDs
+
+## Round 1 (plan v1, commit 566d9edd1)
+- Codex: task-mqjniy9k-1zl7a6 (background)
+- AGY:   adversarial-review-mqjnj7rz-cnem56 (background, --model pro-3)
+- Claude SMR: claude-smr-plan-r1.md (PLAN-NEEDS-MINOR; chokepoint VERIFIED)

--- a/pkg/dataplane/userspace/flow.go
+++ b/pkg/dataplane/userspace/flow.go
@@ -1,22 +1,95 @@
 package userspace
 
-import "github.com/psaab/xpf/pkg/config"
+import (
+	"log/slog"
+	"math"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #1977: several FlowSnapshot/FlowExportSnapshot fields are Go signed `int` on
+// the control-socket snapshot wire but Rust **unsigned** (u16/u32/u64). A
+// negative or out-of-range value (e.g. an operator typo `tcp-mss-gre-in 70000`,
+// or a sampling input-rate exceeding u32) serializes fine from Go but makes
+// `serde_json::from_str::<ControlRequest>` ERROR on the helper, aborting the
+// ENTIRE apply_snapshot decode — the helper stays unconfigured and forwarding
+// silently breaks (the #1961 failure class). `buildFlowSnapshot` /
+// `buildFlowExportSnapshot` are the sole pre-wire constructor of these structs
+// (called only from `buildSnapshot`), so coercing each field into its Rust wire
+// range here guards every input path (CLI, gRPC, file). In-range values pass
+// through unchanged; out-of-range values are coerced to a safe sentinel and a
+// single warning is logged (this runs once per config commit, never per
+// packet). The complementary commit-time CLI validation (a clear `commit check`
+// error instead of silent coercion) is tracked as a follow-up; this guard is
+// the dataplane-safety guarantee.
+
+// coerceWireU16 clamps an int destined for a Rust u16 wire field. Out-of-range
+// (negative or >65535) becomes 0 — the "disabled"/"use default" sentinel these
+// MSS fields already use (for GRE-out, Rust 0 means MTU-derived MSS).
+func coerceWireU16(field string, v int) int {
+	if v < 0 || v > math.MaxUint16 {
+		slog.Warn("userspace: out-of-range u16 wire value coerced to 0 (#1977)",
+			"field", field, "value", v)
+		return 0
+	}
+	return v
+}
+
+// coerceWireU32Timeout clamps an int destined for a Rust u32 timeout field:
+// negative -> 0 (= use default), >u32max -> u32max. u32max*1e9 fits in u64, so
+// there is no Rust-side multiplication overflow at the cap.
+func coerceWireU32Timeout(field string, v int) int {
+	if v < 0 {
+		slog.Warn("userspace: negative u32 wire timeout coerced to 0 (#1977)",
+			"field", field, "value", v)
+		return 0
+	}
+	if int64(v) > math.MaxUint32 {
+		slog.Warn("userspace: out-of-range u32 wire timeout capped to u32 max (#1977)",
+			"field", field, "value", v)
+		return math.MaxUint32
+	}
+	return v
+}
+
+// coerceWireSessionTimeout clamps an int destined for a Rust u64 session-timeout
+// field. The cap is MaxDurationSeconds (= MaxInt64/1e9), NOT u64 max, because
+// the helper's SessionTimeouts::from_seconds multiplies seconds*1e9 without
+// checked arithmetic; MaxDurationSeconds keeps the product within u64.
+func coerceWireSessionTimeout(field string, v int) int {
+	if v < 0 {
+		slog.Warn("userspace: negative session timeout coerced to 0 (#1977)",
+			"field", field, "value", v)
+		return 0
+	}
+	if int64(v) > config.MaxDurationSeconds {
+		slog.Warn("userspace: session timeout capped to MaxDurationSeconds (#1977)",
+			"field", field, "value", v, "cap", config.MaxDurationSeconds)
+		return int(config.MaxDurationSeconds)
+	}
+	return v
+}
 
 func buildFlowSnapshot(cfg *config.Config) FlowSnapshot {
 	snap := FlowSnapshot{
 		AllowDNSReply:      cfg.Security.Flow.AllowDNSReply,
 		AllowEmbeddedICMP:  cfg.Security.Flow.AllowEmbeddedICMP,
-		TCPMSSIPsecVPN:     cfg.Security.Flow.TCPMSSIPsecVPN,
-		TCPMSSGreIn:        cfg.Security.Flow.TCPMSSGreIn,
-		TCPMSSGreOut:       cfg.Security.Flow.TCPMSSGreOut,
-		UDPSessionTimeout:  cfg.Security.Flow.UDPSessionTimeout,
-		ICMPSessionTimeout: cfg.Security.Flow.ICMPSessionTimeout,
+		TCPMSSIPsecVPN:     coerceWireU16("tcp_mss_ipsec_vpn", cfg.Security.Flow.TCPMSSIPsecVPN),
+		TCPMSSGreIn:        coerceWireU16("tcp_mss_gre_in", cfg.Security.Flow.TCPMSSGreIn),
+		TCPMSSGreOut:       coerceWireU16("tcp_mss_gre_out", cfg.Security.Flow.TCPMSSGreOut),
+		UDPSessionTimeout:  coerceWireSessionTimeout("udp_session_timeout", cfg.Security.Flow.UDPSessionTimeout),
+		ICMPSessionTimeout: coerceWireSessionTimeout("icmp_session_timeout", cfg.Security.Flow.ICMPSessionTimeout),
 		GREAcceleration:    cfg.Security.Flow.GREPerformanceAcceleration,
 		Lo0FilterInputV4:   cfg.System.Lo0FilterInputV4,
 		Lo0FilterInputV6:   cfg.System.Lo0FilterInputV6,
 	}
+	// TCPMSSAllTCP is in the wire contract (Rust u16) but is not populated by
+	// this builder today; coerce defensively so it stays safe if it is ever
+	// wired from config (#1977, Codex r2). No-op while it remains zero.
+	snap.TCPMSSAllTCP = coerceWireU16("tcp_mss_all_tcp", snap.TCPMSSAllTCP)
 	if cfg.Security.Flow.TCPSession != nil {
-		snap.TCPSessionTimeout = cfg.Security.Flow.TCPSession.EstablishedTimeout
+		snap.TCPSessionTimeout = coerceWireSessionTimeout(
+			"tcp_session_timeout", cfg.Security.Flow.TCPSession.EstablishedTimeout)
 	}
 	return snap
 }
@@ -41,13 +114,32 @@ func buildFlowExportSnapshot(cfg *config.Config) *FlowExportSnapshot {
 		if rate <= 0 {
 			rate = 1
 		}
+		// #1977: SamplingRate is a Rust u32; cap an out-of-range input rate so
+		// it cannot abort the apply_snapshot decode.
+		if int64(rate) > math.MaxUint32 {
+			slog.Warn("userspace: sampling input rate capped to u32 max (#1977)",
+				"value", inst.InputRate)
+			rate = math.MaxUint32
+		}
 		families := []*config.SamplingFamily{inst.FamilyInet, inst.FamilyInet6}
 		for _, fam := range families {
 			if fam == nil {
 				continue
 			}
 			for _, server := range fam.FlowServers {
-				if server == nil || server.Address == "" || server.Port == 0 {
+				if server == nil || server.Address == "" {
+					continue
+				}
+				// #1977: CollectorPort is a Rust u16. Port 0 is the existing
+				// "absent" sentinel (skip silently); a negative or >65535 port
+				// is invalid — skip that server (do not abort the whole export)
+				// and warn so it is visible on a non-CLI path.
+				if server.Port == 0 {
+					continue
+				}
+				if server.Port < 0 || server.Port > math.MaxUint16 {
+					slog.Warn("userspace: skipping flow-server with out-of-range port (#1977)",
+						"address", server.Address, "port", server.Port)
 					continue
 				}
 				snap := &FlowExportSnapshot{
@@ -58,8 +150,10 @@ func buildFlowExportSnapshot(cfg *config.Config) *FlowExportSnapshot {
 				// Use template config if the server references one
 				if server.Version9Template != "" && fm.Version9.Templates != nil {
 					if tmpl, ok := fm.Version9.Templates[server.Version9Template]; ok {
-						snap.ActiveTimeout = tmpl.FlowActiveTimeout
-						snap.InactiveTimeout = tmpl.FlowInactiveTimeout
+						snap.ActiveTimeout = coerceWireU32Timeout(
+							"active_timeout", tmpl.FlowActiveTimeout)
+						snap.InactiveTimeout = coerceWireU32Timeout(
+							"inactive_timeout", tmpl.FlowInactiveTimeout)
 					}
 				}
 				return snap

--- a/pkg/dataplane/userspace/flow_wire_coerce_test.go
+++ b/pkg/dataplane/userspace/flow_wire_coerce_test.go
@@ -157,3 +157,34 @@ func TestFullSnapshotMarshalsInRange_1977(t *testing.T) {
 	assertInRange(t, "Flow.TCPMSSGreIn", snap.Flow.TCPMSSGreIn, math.MaxUint16)
 	assertInRange(t, "Flow.TCPSessionTimeout", snap.Flow.TCPSessionTimeout, config.MaxDurationSeconds)
 }
+
+// TestFlowExportSkipsInvalidPortContinuesToValid_1977 pins the skip-and-continue
+// semantics (Codex r-code hardening): an out-of-range flow-server is skipped and
+// scanning continues to the next valid server, rather than aborting the export.
+func TestFlowExportSkipsInvalidPortContinuesToValid_1977(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Services.FlowMonitoring = &config.FlowMonitoringConfig{
+		Version9: &config.NetFlowV9Config{
+			Templates: map[string]*config.NetFlowV9Template{
+				"t1": {Name: "t1", FlowActiveTimeout: 60, FlowInactiveTimeout: 15},
+			},
+		},
+	}
+	cfg.ForwardingOptions.Sampling = &config.SamplingConfig{
+		Instances: map[string]*config.SamplingInstance{
+			"i1": {Name: "i1", InputRate: 1000, FamilyInet: &config.SamplingFamily{
+				FlowServers: []*config.FlowServer{
+					{Address: "10.0.0.1", Port: 70000, Version9Template: "t1"}, // invalid -> skip
+					{Address: "10.0.0.2", Port: 9995, Version9Template: "t1"},  // valid -> use
+				},
+			}},
+		},
+	}
+	snap := buildFlowExportSnapshot(cfg)
+	if snap == nil {
+		t.Fatal("expected the valid second server to be used after skipping the invalid first")
+	}
+	if snap.CollectorAddress != "10.0.0.2" || snap.CollectorPort != 9995 {
+		t.Fatalf("expected 10.0.0.2:9995, got %s:%d", snap.CollectorAddress, snap.CollectorPort)
+	}
+}

--- a/pkg/dataplane/userspace/flow_wire_coerce_test.go
+++ b/pkg/dataplane/userspace/flow_wire_coerce_test.go
@@ -1,0 +1,159 @@
+package userspace
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #1977: these snapshot fields are Go int on the wire but Rust unsigned
+// (u16/u32/u64); an out-of-range value would abort the whole apply_snapshot
+// serde decode and silently disable the dataplane. The build-boundary guard in
+// buildFlowSnapshot/buildFlowExportSnapshot must coerce every such field into
+// its Rust wire range. These tests pin that for all 11 fields.
+
+func assertInRange(t *testing.T, name string, v int, max int64) {
+	t.Helper()
+	if int64(v) < 0 || int64(v) > max {
+		t.Fatalf("%s = %d, out of wire range [0,%d] (#1977 decode-abort risk)", name, v, max)
+	}
+}
+
+func TestBuildFlowSnapshotCoercesOutOfRange_1977(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Flow.TCPMSSIPsecVPN = 70000             // > u16 max
+	cfg.Security.Flow.TCPMSSGreIn = -5                   // < 0
+	cfg.Security.Flow.TCPMSSGreOut = math.MaxUint16 + 1  // > u16 max
+	cfg.Security.Flow.UDPSessionTimeout = -1             // < 0
+	cfg.Security.Flow.ICMPSessionTimeout = math.MaxInt64 // > MaxDurationSeconds
+	cfg.Security.Flow.TCPSession = &config.TCPSessionConfig{EstablishedTimeout: -7}
+
+	snap := buildFlowSnapshot(cfg)
+	assertInRange(t, "TCPMSSIPsecVPN", snap.TCPMSSIPsecVPN, math.MaxUint16)
+	assertInRange(t, "TCPMSSGreIn", snap.TCPMSSGreIn, math.MaxUint16)
+	assertInRange(t, "TCPMSSGreOut", snap.TCPMSSGreOut, math.MaxUint16)
+	assertInRange(t, "TCPMSSAllTCP", snap.TCPMSSAllTCP, math.MaxUint16)
+	assertInRange(t, "UDPSessionTimeout", snap.UDPSessionTimeout, config.MaxDurationSeconds)
+	assertInRange(t, "ICMPSessionTimeout", snap.ICMPSessionTimeout, config.MaxDurationSeconds)
+	assertInRange(t, "TCPSessionTimeout", snap.TCPSessionTimeout, config.MaxDurationSeconds)
+	// Specific coercions: out-of-range MSS -> 0; huge timeout -> MaxDurationSeconds.
+	if snap.TCPMSSIPsecVPN != 0 || snap.TCPMSSGreIn != 0 || snap.TCPMSSGreOut != 0 {
+		t.Fatalf("out-of-range MSS not coerced to 0: %+v", snap)
+	}
+	if int64(snap.ICMPSessionTimeout) != config.MaxDurationSeconds {
+		t.Fatalf("huge ICMP timeout not capped to MaxDurationSeconds: %d", snap.ICMPSessionTimeout)
+	}
+	if snap.TCPSessionTimeout != 0 || snap.UDPSessionTimeout != 0 {
+		t.Fatalf("negative timeouts not coerced to 0: %+v", snap)
+	}
+
+	// In-range values pass through unchanged (behavior-preserving).
+	cfg2 := &config.Config{}
+	cfg2.Security.Flow.TCPMSSGreIn = 1400
+	cfg2.Security.Flow.UDPSessionTimeout = 90
+	cfg2.Security.Flow.TCPSession = &config.TCPSessionConfig{EstablishedTimeout: 1800}
+	snap2 := buildFlowSnapshot(cfg2)
+	if snap2.TCPMSSGreIn != 1400 || snap2.UDPSessionTimeout != 90 || snap2.TCPSessionTimeout != 1800 {
+		t.Fatalf("in-range values altered: %+v", snap2)
+	}
+}
+
+func TestBuildFlowExportSnapshotCoercesOutOfRange_1977(t *testing.T) {
+	mk := func(port int) *config.Config {
+		cfg := &config.Config{}
+		cfg.Services.FlowMonitoring = &config.FlowMonitoringConfig{
+			Version9: &config.NetFlowV9Config{
+				Templates: map[string]*config.NetFlowV9Template{
+					"t1": {Name: "t1", FlowActiveTimeout: -1, FlowInactiveTimeout: math.MaxInt64},
+				},
+			},
+		}
+		cfg.ForwardingOptions.Sampling = &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"i1": {Name: "i1", InputRate: math.MaxInt64, FamilyInet: &config.SamplingFamily{
+					FlowServers: []*config.FlowServer{
+						{Address: "10.0.0.1", Port: port, Version9Template: "t1"},
+					},
+				}},
+			},
+		}
+		return cfg
+	}
+
+	snap := buildFlowExportSnapshot(mk(9995))
+	if snap == nil {
+		t.Fatal("expected a snapshot for a valid port")
+	}
+	assertInRange(t, "SamplingRate", snap.SamplingRate, math.MaxUint32)
+	assertInRange(t, "ActiveTimeout", snap.ActiveTimeout, math.MaxUint32)
+	assertInRange(t, "InactiveTimeout", snap.InactiveTimeout, math.MaxUint32)
+	assertInRange(t, "CollectorPort", snap.CollectorPort, math.MaxUint16)
+	if int64(snap.SamplingRate) != math.MaxUint32 {
+		t.Fatalf("huge InputRate not capped to u32 max: %d", snap.SamplingRate)
+	}
+	if snap.ActiveTimeout != 0 {
+		t.Fatalf("negative ActiveTimeout not coerced to 0: %d", snap.ActiveTimeout)
+	}
+	if int64(snap.InactiveTimeout) != math.MaxUint32 {
+		t.Fatalf("huge InactiveTimeout not capped to u32 max: %d", snap.InactiveTimeout)
+	}
+	if snap.CollectorPort != 9995 {
+		t.Fatalf("valid port altered: %d", snap.CollectorPort)
+	}
+
+	// Out-of-range port -> that server is skipped; no other server -> nil.
+	if got := buildFlowExportSnapshot(mk(70000)); got != nil {
+		t.Fatalf("out-of-range port should skip the server, got %+v", got)
+	}
+	if got := buildFlowExportSnapshot(mk(-1)); got != nil {
+		t.Fatalf("negative port should skip the server, got %+v", got)
+	}
+}
+
+func TestCoerceWireHelpers_1977(t *testing.T) {
+	// u16 (covers TCPMSSAllTCP, which the builder does not populate today).
+	for _, tc := range []struct{ in, want int }{
+		{70000, 0}, {-1, 0}, {math.MaxUint16 + 1, 0}, {math.MaxUint16, math.MaxUint16}, {0, 0}, {1400, 1400},
+	} {
+		if got := coerceWireU16("tcp_mss_all_tcp", tc.in); got != tc.want {
+			t.Fatalf("coerceWireU16(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+	// u32 timeout.
+	if coerceWireU32Timeout("x", -1) != 0 {
+		t.Fatal("negative u32 timeout should coerce to 0")
+	}
+	if int64(coerceWireU32Timeout("x", math.MaxInt64)) != math.MaxUint32 {
+		t.Fatal("huge u32 timeout should cap to u32 max")
+	}
+	if coerceWireU32Timeout("x", 60) != 60 {
+		t.Fatal("in-range u32 timeout altered")
+	}
+	// u64 session timeout.
+	if coerceWireSessionTimeout("x", -1) != 0 {
+		t.Fatal("negative session timeout should coerce to 0")
+	}
+	if int64(coerceWireSessionTimeout("x", math.MaxInt64)) != config.MaxDurationSeconds {
+		t.Fatal("huge session timeout should cap to MaxDurationSeconds")
+	}
+	if coerceWireSessionTimeout("x", 1800) != 1800 {
+		t.Fatal("in-range session timeout altered")
+	}
+}
+
+// TestFullSnapshotMarshalsInRange_1977 builds a full apply_snapshot from a
+// config carrying out-of-range flow values and confirms the marshaled wire JSON
+// keeps the flow/flow-export numerics within their Rust type ranges.
+func TestFullSnapshotMarshalsInRange_1977(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Flow.TCPMSSGreIn = 70000
+	cfg.Security.Flow.TCPSession = &config.TCPSessionConfig{EstablishedTimeout: math.MaxInt64}
+	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	if _, err := json.Marshal(&ControlRequest{Type: "apply_snapshot", Snapshot: snap}); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	assertInRange(t, "Flow.TCPMSSGreIn", snap.Flow.TCPMSSGreIn, math.MaxUint16)
+	assertInRange(t, "Flow.TCPSessionTimeout", snap.Flow.TCPSessionTimeout, config.MaxDurationSeconds)
+}

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1687,3 +1687,24 @@ fn apply_snapshot_rejects_negative_flow_number_1977() {
         "unexpected error: {err}"
     );
 }
+
+// #1977: a collector_port exceeding u16 (what Go would emit pre-#1977 for a
+// `port 70000` typo) must abort the whole apply_snapshot decode — the mechanism
+// the Go-side skip-and-coerce guard defends against.
+#[test]
+fn apply_snapshot_rejects_oversize_collector_port_1977() {
+    let json = r#"{
+      "type": "apply_snapshot",
+      "snapshot": {
+        "version": 3, "generation": 1, "generated_at": "2026-06-18T00:00:00Z",
+        "summary": {"host_name":"fw","dataplane_type":"userspace","interface_count":0,"zone_count":0,"policy_count":0,"scheduler_count":0,"ha_enabled":false},
+        "flow_export": { "collector_address": "10.0.0.1", "collector_port": 70000, "sampling_rate": 1000 }
+      }
+    }"#;
+    let err = serde_json::from_str::<ControlRequest>(json)
+        .expect_err("collector_port > u16 max must abort the whole-request decode");
+    assert!(
+        err.to_string().contains("invalid value") || err.to_string().contains("expected"),
+        "unexpected error: {err}"
+    );
+}

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1636,3 +1636,54 @@ fn apply_snapshot_rejects_base64_dscp_string_1961() {
         "unexpected error: {err}"
     );
 }
+
+// #1977: NUM_WIDTH sibling of #1961. FlowSnapshot/FlowExportSnapshot carry Go
+// `int` fields that are Rust unsigned (u16/u32/u64). A max-range value must
+// decode; a negative value must abort the whole apply_snapshot decode (the
+// mechanism the Go-side build-boundary guard in flow.go defends against).
+#[test]
+fn apply_snapshot_decodes_max_range_flow_numbers_1977() {
+    let json = r#"{
+      "type": "apply_snapshot",
+      "snapshot": {
+        "version": 3, "generation": 1, "generated_at": "2026-06-18T00:00:00Z",
+        "summary": {"host_name":"fw","dataplane_type":"userspace","interface_count":0,"zone_count":0,"policy_count":0,"scheduler_count":0,"ha_enabled":false},
+        "flow": {
+          "tcp_mss_gre_in": 65535, "tcp_mss_all_tcp": 65535,
+          "tcp_session_timeout": 9223372036, "udp_session_timeout": 9223372036,
+          "icmp_session_timeout": 9223372036
+        },
+        "flow_export": {
+          "collector_address": "10.0.0.1", "collector_port": 65535,
+          "sampling_rate": 4294967295, "active_timeout": 4294967295,
+          "inactive_timeout": 4294967295
+        }
+      }
+    }"#;
+    let req: ControlRequest = serde_json::from_str(json).expect("max-range flow numbers decode");
+    let snap = req.snapshot.expect("snapshot present");
+    assert_eq!(snap.flow.tcp_mss_gre_in, 65535);
+    assert_eq!(snap.flow.tcp_session_timeout, 9_223_372_036);
+    let fe = snap.flow_export.expect("flow_export present");
+    assert_eq!(fe.sampling_rate, 4_294_967_295);
+    assert_eq!(fe.collector_port, 65535);
+    assert_eq!(fe.inactive_timeout, 4_294_967_295);
+}
+
+#[test]
+fn apply_snapshot_rejects_negative_flow_number_1977() {
+    let json = r#"{
+      "type": "apply_snapshot",
+      "snapshot": {
+        "version": 3, "generation": 1, "generated_at": "2026-06-18T00:00:00Z",
+        "summary": {"host_name":"fw","dataplane_type":"userspace","interface_count":0,"zone_count":0,"policy_count":0,"scheduler_count":0,"ha_enabled":false},
+        "flow": { "tcp_session_timeout": -1 }
+      }
+    }"#;
+    let err = serde_json::from_str::<ControlRequest>(json)
+        .expect_err("negative u64 session timeout must abort the whole-request decode");
+    assert!(
+        err.to_string().contains("invalid value") || err.to_string().contains("expected"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Sibling class of #1961 (found by its Q5 type-parity audit). Eleven
`FlowSnapshot`/`FlowExportSnapshot` fields are Go signed `int` on the
`apply_snapshot` wire but Rust **unsigned** (u16/u32/u64). A negative or
out-of-range value (e.g. operator typo `tcp-mss-gre-in 70000`, or a sampling
input-rate exceeding u32) serializes fine from Go but makes the helper's
`serde_json::from_str` abort the **whole** `apply_snapshot` decode → helper
unconfigured, forwarding silently broken (the #1961 failure mode; now logged
after #1961's hardening).

Fix = **build-boundary coercion** in `buildFlowSnapshot`/`buildFlowExportSnapshot`
— the sole pre-wire constructor of these structs (called only from
`buildSnapshot`), so it covers every input path (CLI, gRPC, file). Per field:
u16 MSS out-of-range → 0; CollectorPort out-of-range → skip that server; u32
SamplingRate keeps `<=0→1` and caps `>u32max`; u32 timeouts negative→0/cap; **u64
session timeouts capped at `MaxDurationSeconds`** (not u64-max — Rust
`from_seconds` does `secs*1e9` unchecked → overflow). Each coercion logs one
`slog.Warn` (config-commit time). In-range values unchanged.

Commit-time CLI validation (a clear `commit check` error) needs schema-node
expansion (the nodes are `children: nil`) and is **deferred to a follow-up**;
this guard is the dataplane-safety guarantee.

## Plan + adversarial review (3-way converged)

Plan: `docs/pr/1977-numwidth-wire/plan.md` (PLAN-READY v2.1).
- Codex r2: PLAN-NEEDS-MINOR (3 doc minors folded; confirmed overflow math + Layer-B deferral)
- AGY r2: PLAN-READY
- Claude SMR r2: PLAN-READY (verified chokepoint + inventory completeness)

The inventory was corrected 9→**11** during review (both reviewers caught
`TCPMSSAllTCP` + `SamplingRate`).

## Test plan

- [x] `go build ./...` + `cargo build` clean
- [x] Go: out-of-range configs through the real builders land in range for all
  11 fields; in-range unchanged; out-of-range port skips the server; helper
  table tests (incl. `TCPMSSAllTCP`)
- [x] Rust: full `ControlRequest` with max-range flow numbers decodes; a
  negative session timeout aborts the decode (the defended mechanism)
- [ ] `go test ./...` + `cargo test --release` full suites — running
- [ ] Loss-cluster smoke (CoS off + on, v4+v6, push+reverse) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)