### PR TITLE
#1962: push the xpf-userspace-dp helper in standalone setup.sh deploy (+ hash-verify)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -5941,3 +5941,20 @@ top.
 ## 2026-06-17 — #1967 PR #1974 review round 4
 - **Codex r4 NEEDS-CHANGES (TEST-only, prod code confirmed correct)**: TestVerifyFailCleanup_SaveJournalFailureKeepsSnapshot chmod'd VersionsDir read-only, but JournalPath lived UNDER VersionsDir (testEnv), so it blocked BOTH the version-dir removal AND the snapshot removal — the old buggy code would have "passed" for the wrong reason (not a true regression test). FIX: build a custom Runner with JournalPath in a SEPARATE dir; chmod ONLY the journal dir read-only, leaving VersionsDir writable. Now the version dir IS removed (unlink branch proven), saveJournal fails, and the snapshot survives. Codex confirmed the production fix (return-before-snapshot-remove) closes the window by inspection.
 - Also rebased onto origin/master (PR #1973 #1964 follow-up merged): resolved append-only _Log.md + the postrm downgrade-branch conflict (my shared remove_runtime_dropin helper subsumes #1973's rmdir-dirname change).
+
+## 2026-06-18 — #1962 standalone deploy pushes the userspace-dp helper
+- **Timestamp**: 2026-06-18 10:53
+- **Action**: Fix #1962 — `test/incus/setup.sh cmd_deploy()` never built/pushed
+  the Rust `xpf-userspace-dp` helper, so standalone test VMs came up with no
+  dataplane (xpfd execs the helper from a search path that includes
+  `filepath.Dir(os.Args[0])` = `/usr/local/sbin/xpf-userspace-dp`; the helper
+  is not linked into xpfd). The deploy even removed the OLD `bpfrx-userspace-dp`
+  without installing the new binary.
+- **Change**: After `make build build-ctl`, build the helper via
+  `make build-userspace-dp` (guarded on cargo presence, mirroring
+  cluster-setup.sh). After pushing xpfd+cli, push
+  `$PROJECT_ROOT/xpf-userspace-dp` to `/usr/local/sbin/xpf-userspace-dp --mode
+  0755`, then verify the on-VM sha256 matches the local binary and `die` loudly
+  on mismatch/empty-readback (a push can silently no-op / the build can be
+  stale). Existing `bpfrx-userspace-dp` cleanup + pkill kept.
+- **File(s)**: test/incus/setup.sh

--- a/docs/test_env.md
+++ b/docs/test_env.md
@@ -588,7 +588,8 @@ sg incus-admin -c 'incus exec xpf-fw0 -- grep -l OriginalName /etc/systemd/netwo
 ```
 make test-env-init   # Install incus, create networks + profiles
 make test-vm         # Create Ubuntu 26.04 VM with FRR, strongSwan
-make test-deploy     # Build -> push binary + config + unit -> systemctl enable --now
+make test-deploy     # Build -> push xpfd + cli + xpf-userspace-dp helper
+                     #   (sha256-verified) + config + unit -> systemctl enable --now
 make test-ssh        # Shell into VM
 make test-status     # Instance + service + network info
 make test-logs       # journalctl -u xpfd -n 50

--- a/test/incus/setup.sh
+++ b/test/incus/setup.sh
@@ -448,6 +448,19 @@ cmd_deploy() {
 	info "Building xpfd and cli..."
 	make -C "$PROJECT_ROOT" build build-ctl
 
+	# Build the Rust AF_XDP helper. xpfd is NOT statically linked against it;
+	# it execs xpf-userspace-dp from a search path that includes
+	# filepath.Dir(os.Args[0]) — i.e. /usr/local/sbin/xpf-userspace-dp next to
+	# the daemon (pkg/dataplane/userspace/process.go findBinary). Without it the
+	# standalone VM comes up with no dataplane (#1962). Mirror the cluster-setup
+	# guard: skip cleanly if no Rust toolchain is present.
+	if [[ -x "$HOME/.cargo/bin/cargo" || -n "$(command -v cargo 2>/dev/null)" ]]; then
+		info "Building xpf-userspace-dp helper..."
+		make -C "$PROJECT_ROOT" build-userspace-dp
+	else
+		warn "Rust toolchain not found; skipping xpf-userspace-dp build"
+	fi
+
 	# Migrate from old bpfrxd naming if present.
 	incus exec "$INSTANCE_NAME" -- systemctl stop bpfrxd 2>/dev/null || true
 	incus exec "$INSTANCE_NAME" -- /usr/local/sbin/bpfrxd cleanup 2>/dev/null || true
@@ -474,6 +487,28 @@ cmd_deploy() {
 
 	info "Pushing cli to $INSTANCE_NAME..."
 	incus file push "$PROJECT_ROOT/cli" "$INSTANCE_NAME/usr/local/sbin/cli" --mode 0755
+
+	# Push the Rust AF_XDP helper next to xpfd (see the findBinary search path
+	# above), then verify the on-VM sha256 matches the local binary. A push can
+	# silently no-op and the build can be stale, either of which leaves xpfd
+	# without a working dataplane — fail the deploy loudly if they differ (#1962).
+	if [[ -f "$PROJECT_ROOT/xpf-userspace-dp" ]]; then
+		info "Pushing xpf-userspace-dp to $INSTANCE_NAME..."
+		incus file push "$PROJECT_ROOT/xpf-userspace-dp" "$INSTANCE_NAME/usr/local/sbin/xpf-userspace-dp" --mode 0755
+
+		local local_sum vm_sum
+		local_sum=$(sha256sum "$PROJECT_ROOT/xpf-userspace-dp" | awk '{print $1}')
+		vm_sum=$(incus exec "$INSTANCE_NAME" -- sha256sum /usr/local/sbin/xpf-userspace-dp 2>/dev/null | awk '{print $1}')
+		if [[ -z "$vm_sum" ]]; then
+			die "xpf-userspace-dp not present on $INSTANCE_NAME after push (sha256 readback empty)"
+		fi
+		if [[ "$local_sum" != "$vm_sum" ]]; then
+			die "xpf-userspace-dp sha256 mismatch after push to $INSTANCE_NAME (local=$local_sum vm=$vm_sum) — push silently no-op'd or the build is stale"
+		fi
+		info "Verified xpf-userspace-dp sha256 on $INSTANCE_NAME ($local_sum)."
+	else
+		warn "xpf-userspace-dp not found locally ($PROJECT_ROOT/xpf-userspace-dp); helper not pushed — xpfd will have no dataplane"
+	fi
 
 	# Push test config if it exists
 	if [[ -f "${SCRIPT_DIR}/xpf-test.conf" ]]; then

--- a/test/incus/setup.sh
+++ b/test/incus/setup.sh
@@ -498,7 +498,7 @@ cmd_deploy() {
 
 		local local_sum vm_sum
 		local_sum=$(sha256sum "$PROJECT_ROOT/xpf-userspace-dp" | awk '{print $1}')
-		vm_sum=$(incus exec "$INSTANCE_NAME" -- sha256sum /usr/local/sbin/xpf-userspace-dp 2>/dev/null | awk '{print $1}')
+		vm_sum=$(incus exec "$INSTANCE_NAME" -- sha256sum /usr/local/sbin/xpf-userspace-dp 2>/dev/null | awk '{print $1}' || true)
 		if [[ -z "$vm_sum" ]]; then
 			die "xpf-userspace-dp not present on $INSTANCE_NAME after push (sha256 readback empty)"
 		fi


### PR DESCRIPTION
## Summary

`test/incus/setup.sh` `cmd_deploy()` built+pushed xpfd/cli/config/unit but never
built or pushed the Rust `xpf-userspace-dp` helper (it even removed the old
`bpfrx-userspace-dp`). xpfd is not linked against the helper — it execs it from a
search path including `filepath.Dir(os.Args[0])` = `/usr/local/sbin/xpf-userspace-dp`
(`pkg/dataplane/userspace/process.go` `findBinary`). So standalone test VMs came
up with **no dataplane** (#1962).

Fix: build the helper (`make build-userspace-dp`, cargo-guarded like
`cluster-setup.sh`), push it next to xpfd, and **verify the on-VM sha256 matches
local — `die` loudly on mismatch/empty readback** (a push can silently no-op /
the build can be stale). Existing `bpfrx-userspace-dp` cleanup preserved.

## Test plan

- [x] `bash -n` + `shellcheck -S warning` pass on `setup.sh`
- [x] `make build-userspace-dp` produces `$PROJECT_ROOT/xpf-userspace-dp` (the
  exact path the push reads); sha256 is the comparable hash the verify uses
- [x] Logic mirrors the live-validated `cluster-setup.sh` helper-push path; adds
  the sha256 readback on top
- [ ] Live `make test-deploy` against a fresh standalone VM (helper present +
  `enabled:true`) — not run here (xpf-fwd in use by the #1961 agent; loss
  cluster lock-protected); will be exercised on the next standalone deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)