### PR TITLE
#1960: fail closed (bootstrap/lifeline) when a committed config no longer compiles

### DIFF
--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -178,6 +178,14 @@ persistence failures on every persist path;
   and enters the #1922 bootstrap/lifeline safe state (mgmt preserved, no
   claim-all, control plane up) instead of exiting (a hard exit would also
   strand mgmt). See `pkg/daemon` `classifyLoadError` / `computeBootClass`.
+  - **`Load` still populates for in-band recovery.** `compiled` MUST stay nil
+    (that is the bootstrap signal), but on this path `Load` assigns the
+    parsed-but-broken tree to `active` and calls `loadRollbackHistory()`
+    anyway. So the operator's recovery is real: `EnterConfigure` clones the
+    broken tree (the candidate shows the config to fix, not an empty tree),
+    and `Rollback(n)` reaches the on-disk history. `active` is always non-nil
+    (the constructor seeds an empty tree), so `(active non-nil, compiled nil)`
+    here is the same shape a fresh boot already has — no new invariant.
 - **any other error** — logged as a warning; the daemon proceeds and the
   boot predicate decides bootstrap vs normal as usual.
 

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -157,6 +157,32 @@ persistence failures on every persist path;
 `SetWriteActiveMarkerForTesting` observes the step-0 committed bit;
 `SetPersistRetryBackoffForTesting` makes the retry loop deterministic.
 
+### `Store.Load` error sentinels (fail-closed boot)
+
+`Load` returns one of three error shapes the daemon distinguishes with
+`errors.Is`:
+
+- **`ErrConfigDBUnreadable` (#1917 D1)** — a PRESENT `active.json` whose
+  bytes cannot be read (JSON parse error, decrypt failure, or a too-new
+  compatibility envelope). The daemon FAILS CLOSED by exiting `Run`, so an
+  unreadable/too-new DB is never overwritten by a blind bootstrap.
+- **`ErrConfigCompile` (#1960)** — a PRESENT `active.json` that read+parsed
+  fine but no longer COMPILES, even through the tolerant `compileTreeLenient`
+  path (e.g. a committed config whose referenced apply-group was later
+  deleted in a partially-edited DB). `Load` has already set
+  `everCommitted=true` from the on-disk `committed=` marker but leaves
+  `compiled` nil, so `ActiveConfig()` returns nil. Without a guard that
+  tuple (`ActiveConfig()==nil` + `EverCommitted()==true`) drives the daemon
+  boot predicate to NORMAL and positional claim-all interface naming. The
+  daemon detects `ErrConfigCompile`, skips the text-config bootstrap import,
+  and enters the #1922 bootstrap/lifeline safe state (mgmt preserved, no
+  claim-all, control plane up) instead of exiting (a hard exit would also
+  strand mgmt). See `pkg/daemon` `classifyLoadError` / `computeBootClass`.
+- **any other error** — logged as a warning; the daemon proceeds and the
+  boot predicate decides bootstrap vs normal as usual.
+
+An ABSENT DB is NOT an error (`Load` returns nil; start-fresh).
+
 ## Audit journal (#1896)
 
 `.config.journal` (next to the config file) is a JSONL audit trail

--- a/pkg/configstore/envelope.go
+++ b/pkg/configstore/envelope.go
@@ -12,10 +12,27 @@ import (
 // unreadable active.json — a JSON parse error, a decrypt failure, or a
 // config compatibility envelope that this build cannot read (too-new
 // min-reader / format). It is distinct from an absent DB (start-fresh) and
-// from a compile error (handled leniently). The daemon makes this FATAL at
-// startup so an unparseable or too-new DB is never silently overwritten by
-// a blind bootstrap (#1917 increment B, plan §6.4 / D1 fatal-on-parse).
+// from a compile error (ErrConfigCompile, below). The daemon makes this
+// FATAL at startup so an unparseable or too-new DB is never silently
+// overwritten by a blind bootstrap (#1917 increment B, plan §6.4 / D1
+// fatal-on-parse).
 var ErrConfigDBUnreadable = errors.New("config DB present but unreadable")
+
+// ErrConfigCompile tags a Store.Load failure where a PRESENT active.json
+// read+parsed fine but the persisted tree failed to COMPILE (even through
+// the tolerant compileTreeLenient path). It is distinct from
+// ErrConfigDBUnreadable (the bytes were fine) and from an absent DB
+// (start-fresh, no error).
+//
+// This is the #1960 fail-closed signal: a previously-committed config that
+// no longer compiles must NOT silently fall back to positional claim-all
+// interface naming. The daemon distinguishes this case with errors.Is so it
+// can refuse takeover and enter the #1922 bootstrap/lifeline safe state
+// (mgmt preserved, no claim-all, control plane up) instead of treating the
+// store as "no active config => normal boot". A daemon hard-exit is the
+// wrong remedy: it also strands management, which this sentinel exists to
+// avoid. See pkg/daemon/daemon_run.go.
+var ErrConfigCompile = errors.New("config DB present but does not compile")
 
 // Config-DB compatibility envelope (#1917 increment B, plan §6.4 / D1).
 //

--- a/pkg/configstore/load_compile_fail_test.go
+++ b/pkg/configstore/load_compile_fail_test.go
@@ -2,7 +2,9 @@ package configstore
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -88,6 +90,90 @@ func TestLoadCommittedConfigCompileFailureFailsClosed(t *testing.T) {
 	if !st.EverCommitted() {
 		t.Fatal("EverCommitted() == false after loading a committed DB; " +
 			"want true (this is the dangerous tuple #1960 fixes)")
+	}
+}
+
+// TestCompileFailureRetainsTreeAndHistoryForRecovery proves the #1960 recovery
+// path advertised in the daemon log and READMEs is real (Codex #1991 r1): a
+// compile-failed Load must keep ActiveConfig() nil (the fail-closed signal) but
+// STILL retain the parsed-but-broken tree as the active tree and load the
+// on-disk rollback history, so an operator can fix the config from the CLI or
+// roll back — in band, without hand-repairing the DB.
+//
+// Without the fix, Store.Load returned before assigning s.active and before
+// loadRollbackHistory(): `configure` cloned the empty New() tree (operator saw
+// an EMPTY config, not the broken one to fix) and `rollback`/`show rollback`
+// saw NO history.
+func TestCompileFailureRetainsTreeAndHistoryForRecovery(t *testing.T) {
+	dir := t.TempDir()
+
+	const brokenConfig = "apply-groups badgroup;\nsystem {\n  host-name box;\n}\n"
+	tree, errs := config.NewParser(brokenConfig).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse broken config: %v", errs[0])
+	}
+	db, err := NewDB(filepath.Join(dir, ".configdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetWriterVersion("test-1.0")
+	if err := db.WriteActive(tree); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+
+	// Seed one on-disk rollback file (xpf.conf.1) — the last good config the
+	// operator would want to roll back to. loadRollbackHistory reads
+	// <dir>/xpf.conf.<n>; it must pick this up even on the compile-failed path.
+	const priorGood = "system {\n  host-name was-good;\n}\n"
+	if err := os.WriteFile(filepath.Join(dir, "xpf.conf.1"), []byte(priorGood), 0o600); err != nil {
+		t.Fatalf("seed rollback file: %v", err)
+	}
+
+	st, err := New(filepath.Join(dir, "xpf.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Load(); !errors.Is(err, ErrConfigCompile) {
+		t.Fatalf("Load error = %v; want ErrConfigCompile", err)
+	}
+
+	// Fail-closed signal intact: nothing compiled/promoted.
+	if st.ActiveConfig() != nil {
+		t.Fatal("ActiveConfig() != nil after compile failure; the bootstrap " +
+			"signal would be lost")
+	}
+
+	// Recovery 1: the active TREE is the broken committed config, so
+	// EnterConfigure clones it into the candidate and the operator can see and
+	// fix the offending stanza — not the empty New() tree.
+	active := st.ActiveTree()
+	if active == nil {
+		t.Fatal("ActiveTree() == nil after compile failure; `configure` would " +
+			"clone an empty tree and the operator could not see the broken config")
+	}
+	if got := active.Format(); got == "" || !strings.Contains(got, "host-name box") ||
+		!strings.Contains(got, "badgroup") {
+		t.Fatalf("ActiveTree() does not contain the broken committed config; got:\n%s", got)
+	}
+	// Concretely confirm the configure candidate is seeded from it.
+	if err := st.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure after compile failure: %v", err)
+	}
+	if cand := st.ShowCandidate(); !strings.Contains(cand, "host-name box") {
+		t.Fatalf("configure candidate not seeded from the broken active tree; got:\n%s", cand)
+	}
+
+	// Recovery 2: the on-disk rollback history loaded, so `rollback 1` reaches
+	// the last good config.
+	if n := st.history.Len(); n < 1 {
+		t.Fatalf("rollback history Len()=%d after compile failure; want >=1 "+
+			"(the seeded xpf.conf.1 must load so `rollback` works)", n)
+	}
+	if err := st.Rollback(1); err != nil {
+		t.Fatalf("Rollback(1) after compile failure: %v", err)
+	}
+	if cand := st.ShowCandidate(); !strings.Contains(cand, "host-name was-good") {
+		t.Fatalf("Rollback(1) did not load the seeded prior-good config; got:\n%s", cand)
 	}
 }
 

--- a/pkg/configstore/load_compile_fail_test.go
+++ b/pkg/configstore/load_compile_fail_test.go
@@ -22,8 +22,8 @@ import (
 // That (ActiveConfig()==nil, EverCommitted()==true) tuple is exactly the
 // state that, before #1960, drove the boot predicate to NORMAL boot and the
 // positional claim-all interface rename. The daemon-side test
-// (TestBootCompileFailureEntersBootstrap) proves the boot path now refuses
-// takeover; this test proves the signal those decisions rely on.
+// (TestCompileFailureForcesBootstrapNotClaimAll) proves the boot path now
+// refuses takeover; this test proves the signal those decisions rely on.
 func TestLoadCommittedConfigCompileFailureFailsClosed(t *testing.T) {
 	dir := t.TempDir()
 

--- a/pkg/configstore/load_compile_fail_test.go
+++ b/pkg/configstore/load_compile_fail_test.go
@@ -1,0 +1,149 @@
+package configstore
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestLoadCommittedConfigCompileFailureFailsClosed pins the #1960 fail-closed
+// contract at the configstore layer: a PRESENT, previously-committed
+// active.json that is valid JSON but no longer COMPILES (even through the
+// tolerant compileTreeLenient path) must:
+//
+//   - make Store.Load return an error that errors.Is(ErrConfigCompile) — so
+//     the daemon can distinguish it from an absent DB (no error) and from
+//     ErrConfigDBUnreadable (the bytes were fine here),
+//   - leave ActiveConfig() == nil (compile failed, nothing promoted),
+//   - leave EverCommitted() == true (the on-disk committed=1 marker stands).
+//
+// That (ActiveConfig()==nil, EverCommitted()==true) tuple is exactly the
+// state that, before #1960, drove the boot predicate to NORMAL boot and the
+// positional claim-all interface rename. The daemon-side test
+// (TestBootCompileFailureEntersBootstrap) proves the boot path now refuses
+// takeover; this test proves the signal those decisions rely on.
+func TestLoadCommittedConfigCompileFailureFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+
+	// Produce a committed DB (committed=1) whose tree no longer compiles.
+	// `apply-groups badgroup` references an undefined group, which is a hard
+	// error even on the lenient Load/SyncApply compile path — the realistic
+	// regression is a committed config whose referenced group was later
+	// deleted from a partially-edited DB.
+	const brokenConfig = "apply-groups badgroup;\nsystem {\n  host-name box;\n}\n"
+	tree, errs := config.NewParser(brokenConfig).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse broken config: %v", errs[0])
+	}
+	// Sanity: it really must fail the tolerant compile (otherwise the test
+	// would silently stop exercising the fail-closed path).
+	if _, err := config.CompileConfigLenient(tree); err == nil {
+		t.Fatal("test precondition: broken config compiled cleanly through " +
+			"CompileConfigLenient; it must fail to exercise the #1960 path")
+	}
+
+	db, err := NewDB(filepath.Join(dir, ".configdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetWriterVersion("test-1.0")
+	// WriteActive stamps committed=1 — the previously-committed case.
+	if err := db.WriteActive(tree); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+	// Confirm the on-disk marker is committed=1 (the precondition that makes
+	// the boot predicate dangerous: everCommitted=true with nil compiled).
+	if _, committed, err := db.ReadActiveMeta(); err != nil || !committed {
+		t.Fatalf("on-disk DB: committed=%v err=%v; want committed=true", committed, err)
+	}
+
+	// Load the same DB through a fresh store (a daemon restart).
+	st, err := New(filepath.Join(dir, "xpf.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = st.Load()
+	if err == nil {
+		t.Fatal("Load of a committed, non-compiling DB returned nil error; " +
+			"want an ErrConfigCompile-tagged error (fail closed)")
+	}
+	if !errors.Is(err, ErrConfigCompile) {
+		t.Fatalf("Load error not tagged ErrConfigCompile: %v", err)
+	}
+	// It must NOT be misclassified as the unreadable-bytes case (which is
+	// fatal at the daemon and points the operator at the wrong remedy).
+	if errors.Is(err, ErrConfigDBUnreadable) {
+		t.Fatalf("Load error wrongly tagged ErrConfigDBUnreadable (bytes were "+
+			"fine; this is a compile failure): %v", err)
+	}
+
+	// The compile failed, so nothing was promoted: ActiveConfig() is nil.
+	if st.ActiveConfig() != nil {
+		t.Fatal("ActiveConfig() != nil after a compile failure; want nil " +
+			"(nothing promoted)")
+	}
+	// The committed marker still stands: this is a previously-committed box.
+	if !st.EverCommitted() {
+		t.Fatal("EverCommitted() == false after loading a committed DB; " +
+			"want true (this is the dangerous tuple #1960 fixes)")
+	}
+}
+
+// TestLoadAbsentDBIsNotCompileError guards the boundary: an ABSENT DB
+// (start-fresh) must NOT report ErrConfigCompile — it returns no error and
+// the daemon proceeds to its normal fresh-boot / bootstrap-from-file path.
+// This keeps the #1960 fail-closed signal scoped to a genuinely present,
+// non-compiling committed config.
+func TestLoadAbsentDBIsNotCompileError(t *testing.T) {
+	dir := t.TempDir()
+	st, err := New(filepath.Join(dir, "xpf.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Load(); err != nil {
+		t.Fatalf("Load of an absent DB returned an error: %v", err)
+	}
+	if st.EverCommitted() {
+		t.Fatal("absent DB: EverCommitted()=true; want false")
+	}
+	if st.ActiveConfig() != nil {
+		t.Fatal("absent DB: ActiveConfig() != nil; want nil")
+	}
+}
+
+// TestLoadValidCommittedConfigStillWorks is the no-regression guard: a
+// committed DB that DOES compile loads normally — no ErrConfigCompile, a
+// non-nil ActiveConfig, EverCommitted true. Without this, a too-aggressive
+// fail-closed tag could break every normal boot.
+func TestLoadValidCommittedConfigStillWorks(t *testing.T) {
+	dir := t.TempDir()
+
+	tree, errs := config.NewParser("system {\n  host-name box;\n}\n").Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs[0])
+	}
+	db, err := NewDB(filepath.Join(dir, ".configdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetWriterVersion("test-1.0")
+	if err := db.WriteActive(tree); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+
+	st, err := New(filepath.Join(dir, "xpf.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Load(); err != nil {
+		t.Fatalf("Load of a valid committed DB returned an error: %v", err)
+	}
+	if st.ActiveConfig() == nil {
+		t.Fatal("valid committed DB: ActiveConfig()==nil; want non-nil")
+	}
+	if !st.EverCommitted() {
+		t.Fatal("valid committed DB: EverCommitted()=false; want true")
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -238,7 +238,23 @@ func (s *Store) Load() error {
 		// and resolve to NORMAL boot — positional claim-all interface naming.
 		// Tag the error with ErrConfigCompile so the daemon can detect this
 		// edge with errors.Is and refuse takeover (enter the #1922
-		// bootstrap/lifeline safe state) instead. s.compiled stays nil.
+		// bootstrap/lifeline safe state) instead.
+		//
+		// s.compiled MUST stay nil — ActiveConfig() returns s.compiled, and
+		// nil is precisely the signal that forces bootstrap (computeBootClass).
+		// BUT retain the parsed-but-broken tree as s.active and load rollback
+		// history, so the recovery the daemon advertises ("fix the config from
+		// the CLI/gRPC and commit, or roll back") actually works (Codex #1991
+		// r1): EnterConfigure clones s.active into the candidate, so `configure`
+		// + `show | compare` surface the broken stanza for the operator to fix,
+		// and Rollback(n) / `show | compare rollback n` reach the on-disk
+		// history. Without this, s.active stayed the empty New() tree and the
+		// history was never loaded — the operator saw an empty config and no
+		// rollbacks, with no in-band way to recover. s.active is always non-nil
+		// (New seeds an empty tree), so the (active non-nil, compiled nil) shape
+		// here is the same one a fresh boot already has — no new invariant.
+		s.active = tree
+		s.loadRollbackHistory()
 		return fmt.Errorf("compile config: %w: %w", ErrConfigCompile, err)
 	}
 

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -231,7 +231,15 @@ func (s *Store) Load() error {
 	// (see compileTreeLenient for the validator downgrades).
 	compiled, err := s.compileTreeLenient(tree)
 	if err != nil {
-		return fmt.Errorf("compile config: %w", err)
+		// #1960 fail-closed: the bytes read+parsed fine (this is NOT
+		// ErrConfigDBUnreadable) but a PRESENT, previously-committed config
+		// no longer compiles. s.everCommitted was already set true above, so
+		// the daemon could otherwise see ActiveConfig()==nil + everCommitted
+		// and resolve to NORMAL boot — positional claim-all interface naming.
+		// Tag the error with ErrConfigCompile so the daemon can detect this
+		// edge with errors.Is and refuse takeover (enter the #1922
+		// bootstrap/lifeline safe state) instead. s.compiled stays nil.
+		return fmt.Errorf("compile config: %w: %w", ErrConfigCompile, err)
 	}
 
 	s.active = tree

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -116,6 +116,19 @@ never lock an operator out of a remote box it manages.
     `show | compare rollback N` reach prior good configs, and a
     `commit confirmed` of either promotes a working config. Repairing/removing
     the on-disk DB remains the out-of-band fallback.
+  - **Known limitation (#1993) — FRR keeps advertising on a cold boot.** `frr`
+    is an independent service that starts from its persisted `frr.conf` (the
+    managed section from the last good `applyConfig`), which freeze-in-last-
+    known-good leaves intact. On a *cold reboot* with a compile-failed config
+    the dataplane is unarmed (no transit) yet FRR still forms peerings and
+    advertises the last-good prefixes, so peers route transit to this node's
+    physical IPs and it blackholes them rather than failing over to the HA
+    partner. This is a pre-existing cross-daemon gap (FRR is independent of the
+    xpfd boot class; the pre-#1960 claim-all path advertised the same way and
+    was otherwise worse), and the VIP/RETH data path already fails over because
+    #1960 suppresses this node's VRRP/cluster. Tracked in #1993; the likely fix
+    is to clear/suppress only the FRR managed section on compile-failure
+    bootstrap while leaving networkd/mgmt intact.
 - **Bootstrap mode** (`d.bootstrapMode` atomic): runs gRPC/REST/CLI normally
   but SUPPRESSES interface takeover ACTIONS — the full rename loop, host
   tunables, `enableForwarding`, dataplane arm (`dp.Start`), and boot-time

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -75,9 +75,9 @@ never lock an operator out of a remote box it manages.
 - **Fail-closed on compile failure (#1960):** a PRESENT, previously-committed
   `active.json` that is valid JSON but no longer COMPILES (even through the
   tolerant `compileTreeLenient` path) is the dangerous tuple
-  `ActiveConfig()==nil` + `EverCommitted()==true` — without a guard that
-  resolves to **normal** and runs the positional claim-all rename on a box
-  whose intended config is unknown. `Store.Load` now tags this error with
+  `ActiveConfig()==nil` + `EverCommitted()==true`. Without a guard, that
+  tuple resolves to **normal** and runs the positional claim-all rename on a
+  box whose intended config is unknown. `Store.Load` now tags this error with
   `configstore.ErrConfigCompile`; `Run` classifies it via `classifyLoadError`,
   logs it loudly (Error), SKIPS `bootstrapFromFile` (so the text `xpf.conf` is
   not blind-imported over the broken DB), and passes `configCompileFailed=true`

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -82,11 +82,30 @@ never lock an operator out of a remote box it manages.
   logs it loudly (Error), SKIPS `bootstrapFromFile` (so the text `xpf.conf` is
   not blind-imported over the broken DB), and passes `configCompileFailed=true`
   to `computeBootClass`, which forces **bootstrap** — overriding even the
-  HA-node guard. The control plane stays up and the lifeline/protected set keep
-  mgmt reachable; the operator fixes the config and `commit confirmed`s, or
-  repairs/removes the on-disk DB. A daemon hard-exit is deliberately NOT used
-  (it would also strand mgmt). Distinct from `ErrConfigDBUnreadable` (#1917 D1,
-  which IS a fatal exit because the bytes themselves cannot be read).
+  HA-node guard. The control plane stays up so the operator can recover
+  in-band. A daemon hard-exit is deliberately NOT used (it would also strand
+  mgmt). Distinct from `ErrConfigDBUnreadable` (#1917 D1, which IS a fatal exit
+  because the bytes themselves cannot be read).
+  - **Why mgmt stays reachable — freeze in last-known-good, not a wipe.** This
+    path does NOT run the `enterBootstrapMode()` teardown (which removes the
+    `10-xpf-*` `.network`/`.link` files, clears the FRR managed section, and
+    tears down the dataplane); that teardown is reserved for confirmed-commit
+    rollback. On a previously-committed box the last-good networkd + FRR state
+    therefore persists untouched, so mgmt — and any already-forwarding data
+    path — keeps working while the operator fixes the config. That is a
+    deliberate choice: the only thing the box must NOT do on an uncompilable
+    config is the *new* takeover (positional claim-all / fresh apply), which
+    bootstrap suppresses. The lifeline/protected set govern the rename + apply
+    sweeps and the fresh-install case; they are not what keeps a *previously*
+    managed box reachable here.
+  - **In-band recovery is real (not just "repair the DB").** On compile failure
+    `Store.Load` keeps `compiled` nil (the fail-closed signal) but retains the
+    parsed-but-broken tree as the active tree and loads the on-disk rollback
+    history. So `configure` clones the broken config into the candidate (the
+    operator can `show`/edit the offending stanza), `rollback N` /
+    `show | compare rollback N` reach prior good configs, and a
+    `commit confirmed` of either promotes a working config. Repairing/removing
+    the on-disk DB remains the out-of-band fallback.
 - **Bootstrap mode** (`d.bootstrapMode` atomic): runs gRPC/REST/CLI normally
   but SUPPRESSES interface takeover ACTIONS — the full rename loop, host
   tunables, `enableForwarding`, dataplane arm (`dp.Start`), and boot-time

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -91,13 +91,23 @@ never lock an operator out of a remote box it manages.
     `10-xpf-*` `.network`/`.link` files, clears the FRR managed section, and
     tears down the dataplane); that teardown is reserved for confirmed-commit
     rollback. On a previously-committed box the last-good networkd + FRR state
-    therefore persists untouched, so mgmt — and any already-forwarding data
-    path — keeps working while the operator fixes the config. That is a
-    deliberate choice: the only thing the box must NOT do on an uncompilable
-    config is the *new* takeover (positional claim-all / fresh apply), which
-    bootstrap suppresses. The lifeline/protected set govern the rename + apply
-    sweeps and the fresh-install case; they are not what keeps a *previously*
-    managed box reachable here.
+    therefore persists untouched, so the box stays reachable at its EXISTING
+    management address (rather than dropping to bootstrap fxp0-DHCP and
+    possibly changing the IP out from under a connected operator) while the
+    config is fixed. That is a deliberate choice: the only thing the box must
+    NOT do on an uncompilable config is the *new* takeover (positional
+    claim-all / fresh apply), which bootstrap suppresses. The lifeline/protected
+    set govern the rename + apply sweeps and the fresh-install case; they are
+    not what keeps a *previously* managed box reachable here.
+    - **Transit is still fail-closed** — do not read "freeze" as "the firewall
+      keeps forwarding." Bootstrap mode suppresses `enableForwarding` and the
+      dataplane arm (`dp.Start`), so the daemon itself forwards no transit in
+      this state. A cold reboot therefore carries NO transit until the operator
+      commits a compilable config; only a daemon *restart* that leaves an
+      already-armed dataplane process running keeps enforcing the
+      last-known-good policy in the interim. Either way no traffic is forwarded
+      under an unknown/no policy — what persists is interface identity + mgmt
+      reachability, not unpoliced forwarding.
   - **In-band recovery is real (not just "repair the DB").** On compile failure
     `Store.Load` keeps `compiled` nil (the fail-closed signal) but retains the
     parsed-but-broken tree as the active tree and loads the on-disk rollback

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -72,6 +72,21 @@ never lock an operator out of a remote box it manages.
   fatal via #1917 D1). The **HA-node guard** keys on `/etc/xpf/node-id` FILE
   presence (NOT the config-derived `clusterMode`): a node-id node always
   resolves NOT-bootstrap.
+- **Fail-closed on compile failure (#1960):** a PRESENT, previously-committed
+  `active.json` that is valid JSON but no longer COMPILES (even through the
+  tolerant `compileTreeLenient` path) is the dangerous tuple
+  `ActiveConfig()==nil` + `EverCommitted()==true` — without a guard that
+  resolves to **normal** and runs the positional claim-all rename on a box
+  whose intended config is unknown. `Store.Load` now tags this error with
+  `configstore.ErrConfigCompile`; `Run` classifies it via `classifyLoadError`,
+  logs it loudly (Error), SKIPS `bootstrapFromFile` (so the text `xpf.conf` is
+  not blind-imported over the broken DB), and passes `configCompileFailed=true`
+  to `computeBootClass`, which forces **bootstrap** — overriding even the
+  HA-node guard. The control plane stays up and the lifeline/protected set keep
+  mgmt reachable; the operator fixes the config and `commit confirmed`s, or
+  repairs/removes the on-disk DB. A daemon hard-exit is deliberately NOT used
+  (it would also strand mgmt). Distinct from `ErrConfigDBUnreadable` (#1917 D1,
+  which IS a fatal exit because the bytes themselves cannot be read).
 - **Bootstrap mode** (`d.bootstrapMode` atomic): runs gRPC/REST/CLI normally
   but SUPPRESSES interface takeover ACTIONS — the full rename loop, host
   tunables, `enableForwarding`, dataplane arm (`dp.Start`), and boot-time

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -8,6 +8,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,7 +17,48 @@ import (
 
 	"github.com/psaab/xpf/pkg/fsatomic"
 	"github.com/vishvananda/netlink"
+
+	"github.com/psaab/xpf/pkg/configstore"
 )
+
+// loadErrorClass categorizes a Store.Load error for the boot path (#1917 D1
+// fatal-on-parse + #1960 fail-closed-on-compile). Keeping the classification
+// in one pure helper makes the boot decision unit-testable without standing
+// up the whole daemon.
+type loadErrorClass int
+
+const (
+	// loadOK — Load returned nil (absent DB start-fresh, or a valid loaded
+	// config). The caller proceeds with bootstrapFromFile / normal boot.
+	loadOK loadErrorClass = iota
+	// loadFatalUnreadable — ErrConfigDBUnreadable (#1917 D1): present but
+	// unparseable/too-new bytes. The daemon must FAIL CLOSED by exiting Run,
+	// so the unreadable DB is never overwritten by a blind bootstrap.
+	loadFatalUnreadable
+	// loadCompileFailed — ErrConfigCompile (#1960): present, valid bytes,
+	// previously committed, but the tree no longer compiles. The daemon must
+	// NOT exit (that strands mgmt too) and must NOT positional-claim-all;
+	// instead it enters the #1922 bootstrap/lifeline safe state.
+	loadCompileFailed
+	// loadOtherError — any other Load error (logged as a warning; the daemon
+	// proceeds and the boot predicate decides bootstrap vs normal as usual).
+	loadOtherError
+)
+
+// classifyLoadError maps a Store.Load error to its boot-path class. err==nil
+// returns loadOK.
+func classifyLoadError(err error) loadErrorClass {
+	switch {
+	case err == nil:
+		return loadOK
+	case errors.Is(err, configstore.ErrConfigDBUnreadable):
+		return loadFatalUnreadable
+	case errors.Is(err, configstore.ErrConfigCompile):
+		return loadCompileFailed
+	default:
+		return loadOtherError
+	}
+}
 
 // lifelineRecordFile persists the management-NIC identity (PCI bus address +
 // MAC) so the protected set (Item 4) survives the rename that turns the
@@ -86,10 +128,29 @@ func hasNodeIDFile() bool {
 //     loaded (case 2 import-clean or case 3 valid-active.json).
 //   - everCommitted: store.EverCommitted() — the #1922 step-0 marker.
 //   - nodeID: /etc/xpf/node-id presence (the HA-node guard, C2/C8).
+//   - configCompileFailed: a PRESENT, previously-committed active.json
+//     read+parsed fine but no longer COMPILES (#1960, Store.Load returned
+//     ErrConfigCompile). This is the highest-priority signal — see below.
 //
 // Case 4 (corrupt/too-new) is handled by #1917 D1 fatal-on-parse in Run
 // BEFORE this is called, so it never reaches here.
-func computeBootClass(hasActiveConfig, everCommitted, nodeIDPresent bool) bootClass {
+func computeBootClass(hasActiveConfig, everCommitted, nodeIDPresent, configCompileFailed bool) bootClass {
+	// #1960 fail-closed (checked FIRST, before the HA-node guard): a config
+	// that was previously committed but no longer compiles must NEVER drive a
+	// full takeover. With everCommitted=true and ActiveConfig()==nil (compiled
+	// stayed nil), every other branch below resolves to bootClassNormal —
+	// positional claim-all interface naming on a box whose intended config is
+	// unknown. That can mis-bind interfaces and strand management. Refusing
+	// takeover (bootstrap mode + lifeline + protected set) keeps mgmt
+	// reachable and leaves the control plane up so the operator can fix the
+	// config. This overrides EVEN the HA-node guard: claiming all NICs on a
+	// broken config is the exact lockout this issue closes, and an HA node
+	// with an uncompilable config is safer in the lifeline state than
+	// mis-binding (HA availability was already not promised in that state).
+	if configCompileFailed {
+		return bootClassBootstrap
+	}
+
 	// HA-node guard (C2 + C8): a node with /etc/xpf/node-id is HA-managed.
 	// It resolves NOT-bootstrap via its own DB/xpf.conf (case 2/3). If it
 	// has node-id but NEITHER a DB nor an importable xpf.conf, it is

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -60,6 +60,22 @@ func classifyLoadError(err error) loadErrorClass {
 	}
 }
 
+// shouldBootstrapFromFile reports whether Run should import the text config
+// file (xpf.conf) after Store.Load. The import runs only when there is no
+// active config to boot from AND the Load did not fail closed on a compile
+// error.
+//
+// #1960: the `!configCompileFailed` clause is load-bearing, not cosmetic. On a
+// compile-failed load ActiveConfig() is nil (compiled stayed nil), so without
+// this guard the import would fire — silently swapping a DIFFERENT config
+// (whatever xpf.conf holds) in over the broken committed DB and then taking
+// over interfaces from it, defeating the fail-closed intent. This predicate is
+// the single source of truth for that decision (daemon_run.go calls it) so the
+// guard cannot be dropped without TestShouldBootstrapFromFile failing.
+func shouldBootstrapFromFile(hasActiveConfig, configCompileFailed bool) bool {
+	return !hasActiveConfig && !configCompileFailed
+}
+
 // lifelineRecordFile persists the management-NIC identity (PCI bus address +
 // MAC) so the protected set (Item 4) survives the rename that turns the
 // recorded kernel name (enp5s0) into fxp0, AND survives daemon restarts and

--- a/pkg/daemon/bootstrap_test.go
+++ b/pkg/daemon/bootstrap_test.go
@@ -65,6 +65,46 @@ func TestCompileFailureForcesBootstrapNotClaimAll(t *testing.T) {
 	}
 }
 
+// TestShouldBootstrapFromFile pins the daemon's import gate (the Run branch at
+// daemon_run.go that imports the text xpf.conf after Load). It exists because
+// the helper-level computeBootClass test cannot catch a regression in the
+// SEPARATE Run-level decision to skip bootstrapFromFile on compile failure
+// (Codex #1991 r2): removing the `!configCompileFailed` guard would still pass
+// every computeBootClass case yet would silently import a different config over
+// a broken committed DB. The (no-active, compile-failed) cell below is the one
+// that flips false→true if the guard is dropped, failing this test.
+func TestShouldBootstrapFromFile(t *testing.T) {
+	tests := []struct {
+		name          string
+		hasActive     bool
+		compileFailed bool
+		want          bool
+	}{
+		// No active config and no compile failure: fresh / never-committed
+		// boot imports the text xpf.conf (the long-standing behavior).
+		{"no-active-no-compile-failure", false, false, true},
+		// A valid active config is loaded: never import over it.
+		{"active-loaded", true, false, false},
+		// #1960 the load-bearing cell: no active config (compiled stayed nil)
+		// but the committed DB failed to compile. The import MUST be skipped —
+		// importing xpf.conf here swaps in a different config and then takes
+		// over interfaces, defeating the fail-closed intent. Dropping the
+		// `!configCompileFailed` guard flips this to true and fails the test.
+		{"no-active-compile-failed", false, true, false},
+		// Defensive: even if a compiled config were somehow present, a
+		// compile-failed load never imports.
+		{"active-and-compile-failed", true, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldBootstrapFromFile(tt.hasActive, tt.compileFailed); got != tt.want {
+				t.Fatalf("shouldBootstrapFromFile(hasActive=%v, compileFailed=%v) = %v; want %v",
+					tt.hasActive, tt.compileFailed, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestComputeBootClass covers the #1922 five-case boot predicate table.
 // Case 4 (corrupt/too-new) is fatal via #1917 D1 before the predicate runs,
 // so it is not represented as a predicate input.

--- a/pkg/daemon/bootstrap_test.go
+++ b/pkg/daemon/bootstrap_test.go
@@ -1,8 +1,69 @@
 package daemon
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
 )
+
+// TestClassifyLoadError pins the #1917 D1 / #1960 boot-path classification of
+// a Store.Load error. This is the seam the daemon's Run uses to decide
+// fatal-exit (unreadable) vs fail-closed-bootstrap (compile failure) vs
+// warn-and-proceed (other) vs normal (nil).
+func TestClassifyLoadError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want loadErrorClass
+	}{
+		{"nil", nil, loadOK},
+		// #1917 D1: present-but-unreadable bytes => fatal exit.
+		{"unreadable", fmt.Errorf("read config: %w: boom", configstore.ErrConfigDBUnreadable), loadFatalUnreadable},
+		// #1960: present, valid bytes, previously committed, no longer compiles
+		// => fail-closed bootstrap, NOT a fatal exit (which would strand mgmt).
+		{"compile-failed", fmt.Errorf("compile config: %w: undefined group", configstore.ErrConfigCompile), loadCompileFailed},
+		// A plain wrapped compile error (the Load wrap chains both sentinels in
+		// other paths; ensure the compile tag is still detected through %w).
+		{"compile-failed-wrapped", fmt.Errorf("outer: %w", fmt.Errorf("compile config: %w: x", configstore.ErrConfigCompile)), loadCompileFailed},
+		{"other", fmt.Errorf("some unrelated failure"), loadOtherError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyLoadError(tt.err); got != tt.want {
+				t.Fatalf("classifyLoadError(%v) = %v; want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCompileFailureForcesBootstrapNotClaimAll ties the two halves together:
+// when classifyLoadError reports loadCompileFailed, the boot predicate (fed
+// configCompileFailed=true) MUST resolve to bootClassBootstrap — i.e. the
+// daemon enters the lifeline safe state and does NOT run the positional
+// claim-all interface rename. This mirrors the exact inputs daemon_run.go
+// computes after an ErrConfigCompile Load: ActiveConfig()==nil
+// (hasActive=false), EverCommitted()==true, and the compile-failed flag set.
+// It is checked for both standalone and HA-node (node-id present) boxes,
+// since the compile-failure override must beat the HA-node guard.
+func TestCompileFailureForcesBootstrapNotClaimAll(t *testing.T) {
+	compileFailErr := fmt.Errorf("compile config: %w: undefined group", configstore.ErrConfigCompile)
+	if classifyLoadError(compileFailErr) != loadCompileFailed {
+		t.Fatal("precondition: compile error not classified as loadCompileFailed")
+	}
+
+	for _, nodeID := range []bool{false, true} {
+		t.Run(fmt.Sprintf("nodeID=%v", nodeID), func(t *testing.T) {
+			// hasActive=false (compile failed → compiled stayed nil),
+			// everCommitted=true (committed DB), configCompileFailed=true.
+			got := computeBootClass(false, true, nodeID, true)
+			if got != bootClassBootstrap {
+				t.Fatalf("compile-failed committed config (nodeID=%v) classified %v; "+
+					"want bootClassBootstrap (no positional claim-all)", nodeID, got)
+			}
+		})
+	}
+}
 
 // TestComputeBootClass covers the #1922 five-case boot predicate table.
 // Case 4 (corrupt/too-new) is fatal via #1917 D1 before the predicate runs,
@@ -13,37 +74,51 @@ func TestComputeBootClass(t *testing.T) {
 		hasActive     bool
 		everCommitted bool
 		nodeID        bool
+		compileFailed bool
 		want          bootClass
 	}{
 		// Case 1: fresh / no config, no node-id => bootstrap.
-		{"fresh-no-config", false, false, false, bootClassBootstrap},
+		{"fresh-no-config", false, false, false, false, bootClassBootstrap},
 		// Case 2/3: a valid active config is loaded => normal.
-		{"valid-active", true, true, false, bootClassNormal},
+		{"valid-active", true, true, false, false, bootClassNormal},
 		// Case 2: day-0 import-clean (compiled present, committed via Commit).
-		{"day0-import", true, true, false, bootClassNormal},
+		{"day0-import", true, true, false, false, bootClassNormal},
 		// Case 5 committed-empty: no active config, but everCommitted => normal.
-		{"committed-empty", false, true, false, bootClassNormal},
+		{"committed-empty", false, true, false, false, bootClassNormal},
 		// Case 5 never-committed: no active config, never committed => bootstrap.
-		{"never-committed", false, false, false, bootClassBootstrap},
+		{"never-committed", false, false, false, false, bootClassBootstrap},
 		// AGY r1 CRITICAL: post-first-commit-rollback restart. The empty tree
 		// on disk (committed=0) compiles to a NON-nil config, so
 		// hasActiveConfig is TRUE — but everCommitted is FALSE, so the box
 		// must stay in bootstrap, NOT misclassify as normal.
-		{"post-rollback-restart-empty-compiled", true, false, false, bootClassBootstrap},
+		{"post-rollback-restart-empty-compiled", true, false, false, false, bootClassBootstrap},
 		// HA-node guard (C2/C8): node-id present always resolves NOT-bootstrap,
 		// even with no active config and never committed.
-		{"ha-node-no-config", false, false, true, bootClassNormal},
-		{"ha-node-with-config", true, true, true, bootClassNormal},
+		{"ha-node-no-config", false, false, true, false, bootClassNormal},
+		{"ha-node-with-config", true, true, true, false, bootClassNormal},
 		// node-id present + never committed still NOT bootstrap (loud-error
 		// handled at call site, but predicate must not enter bootstrap).
-		{"ha-node-never-committed", false, false, true, bootClassNormal},
+		{"ha-node-never-committed", false, false, true, false, bootClassNormal},
+
+		// #1960 fail-closed: a previously-committed config that no longer
+		// compiles must enter bootstrap, NOT positional claim-all. Store.Load
+		// sets everCommitted=true but leaves compiled nil (hasActive=false),
+		// which without the override resolves to NORMAL.
+		{"compile-failed-committed", false, true, false, true, bootClassBootstrap},
+		// The compile-failure override beats EVEN the HA-node guard: claiming
+		// all NICs on a broken config is the exact lockout this fixes.
+		{"compile-failed-ha-node", false, true, true, true, bootClassBootstrap},
+		// Compile failure also overrides a (defensively) non-nil active config
+		// — the daemon only sets this flag when compiled stayed nil, but the
+		// predicate must be safe regardless.
+		{"compile-failed-has-active", true, true, false, true, bootClassBootstrap},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := computeBootClass(tt.hasActive, tt.everCommitted, tt.nodeID)
+			got := computeBootClass(tt.hasActive, tt.everCommitted, tt.nodeID, tt.compileFailed)
 			if got != tt.want {
-				t.Fatalf("computeBootClass(active=%v, committed=%v, nodeID=%v) = %v; want %v",
-					tt.hasActive, tt.everCommitted, tt.nodeID, got, tt.want)
+				t.Fatalf("computeBootClass(active=%v, committed=%v, nodeID=%v, compileFailed=%v) = %v; want %v",
+					tt.hasActive, tt.everCommitted, tt.nodeID, tt.compileFailed, got, tt.want)
 			}
 		})
 	}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -23,7 +23,6 @@ import (
 	"github.com/psaab/xpf/pkg/cli"
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
-	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/dhcp"
@@ -222,26 +221,54 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// lifeline keeps mgmt reachable through a fail-closed boot; #1922 hardens
 	// the foreign/non-appliance host case (noted in the PR; not implemented
 	// here).
-	if err := d.store.Load(); err != nil {
-		if errors.Is(err, configstore.ErrConfigDBUnreadable) {
-			// Point recovery at the actual unreadable artifact — the config
-			// DB under .configdb/, NOT the text config file (Copilot).
-			dbPath := filepath.Join(filepath.Dir(d.opts.ConfigFile), ".configdb", "active.json")
-			return fmt.Errorf("config DB is present but unreadable; refusing to "+
-				"start and overwrite it (fail closed). Inspect/repair %s (the on-disk "+
-				"config DB, NOT the text config file) or roll the xpf binary forward "+
-				"to a build that can read it: %w",
-				dbPath, err)
-		}
-		slog.Warn("failed to load config from db", "err", err)
+	// configCompileFailed records the #1960 fail-closed case: a PRESENT,
+	// previously-committed active.json read+parsed fine but no longer
+	// compiles. It must NOT fall back to bootstrapFromFile() (which would
+	// blind-import the text config file over a broken-but-present committed
+	// DB — the same silently-wrong takeover this issue closes) and it forces
+	// bootstrap mode below regardless of computeBootClass's other inputs.
+	configCompileFailed := false
+	switch loadErr := d.store.Load(); classifyLoadError(loadErr) {
+	case loadFatalUnreadable:
+		// Point recovery at the actual unreadable artifact — the config
+		// DB under .configdb/, NOT the text config file (Copilot).
+		dbPath := filepath.Join(filepath.Dir(d.opts.ConfigFile), ".configdb", "active.json")
+		return fmt.Errorf("config DB is present but unreadable; refusing to "+
+			"start and overwrite it (fail closed). Inspect/repair %s (the on-disk "+
+			"config DB, NOT the text config file) or roll the xpf binary forward "+
+			"to a build that can read it: %w",
+			dbPath, loadErr)
+	case loadCompileFailed:
+		// #1960 fail-closed: a previously-committed config no longer
+		// compiles. Store.Load set everCommitted=true but left compiled
+		// nil, so without this the boot predicate would resolve to NORMAL
+		// (ActiveConfig()==nil + everCommitted) and run the positional
+		// claim-all interface rename — exactly the safety hole this fixes.
+		// Surface it LOUDLY (Error, not the ignored Warn) and route into
+		// the #1922 bootstrap/lifeline safe state below.
+		configCompileFailed = true
+		dbPath := filepath.Join(filepath.Dir(d.opts.ConfigFile), ".configdb", "active.json")
+		slog.Error("active config DB is present but no longer compiles; refusing interface "+
+			"takeover and entering BOOTSTRAP/lifeline safe state (management preserved, NO "+
+			"positional claim-all). Fix the config from the CLI/gRPC and 'commit confirmed', "+
+			"or repair/remove the on-disk config DB",
+			"db_path", dbPath, "err", loadErr)
+	case loadOtherError:
+		slog.Warn("failed to load config from db", "err", loadErr)
+	case loadOK:
+		// nil error: absent DB (start-fresh) or a valid loaded config.
 	}
 
-	// If DB had no active config, bootstrap from the text config file
-	if d.store.ActiveConfig() == nil {
+	// If DB had no active config, bootstrap from the text config file.
+	//
+	// #1960: but NOT when a present committed config failed to compile —
+	// importing the text xpf.conf there would silently swap in a different
+	// config and then take over interfaces, defeating the fail-closed intent.
+	if d.store.ActiveConfig() == nil && !configCompileFailed {
 		if err := d.bootstrapFromFile(); err != nil {
 			slog.Warn("failed to bootstrap config from file", "err", err)
 		}
-	} else {
+	} else if d.store.ActiveConfig() != nil {
 		slog.Info("configuration loaded from db")
 	}
 
@@ -252,15 +279,27 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// TAKEOVER actions (but not the management control surfaces or manager
 	// construction — C1). Every existing deployment resolves NOT-bootstrap
 	// (case 2/3, or case 5 committed-empty) → zero behavior change.
+	//
+	// #1960: configCompileFailed forces bootstrap here — a previously-committed
+	// config that no longer compiles must fail closed (no positional claim-all)
+	// regardless of the other inputs, including the HA-node guard.
 	nodeIDPresent := hasNodeIDFile()
-	bootClass := computeBootClass(d.store.ActiveConfig() != nil, d.store.EverCommitted(), nodeIDPresent)
+	bootClass := computeBootClass(d.store.ActiveConfig() != nil, d.store.EverCommitted(), nodeIDPresent, configCompileFailed)
 	if bootClass == bootClassBootstrap {
 		d.bootstrapMode.Store(true)
-		slog.Warn("xpf daemon entering BOOTSTRAP mode: no committed configuration found",
-			"detail", "management control plane (gRPC/REST/CLI) runs normally, but interface "+
-				"rename/takeover, dataplane arm, and FRR/VRRP takeover are SUPPRESSED until the "+
-				"first 'commit confirmed' (+ confirm) or cluster config sync. This keeps a "+
-				"foreign/non-appliance host reachable on its existing management NIC.")
+		detail := "management control plane (gRPC/REST/CLI) runs normally, but interface " +
+			"rename/takeover, dataplane arm, and FRR/VRRP takeover are SUPPRESSED until the " +
+			"first 'commit confirmed' (+ confirm) or cluster config sync. This keeps a " +
+			"foreign/non-appliance host reachable on its existing management NIC."
+		if configCompileFailed {
+			// #1960: distinct cause — not "no config", but "committed config no
+			// longer compiles". The Error log above already named the DB path.
+			slog.Warn("xpf daemon entering BOOTSTRAP mode: committed configuration no longer compiles",
+				"detail", detail)
+		} else {
+			slog.Warn("xpf daemon entering BOOTSTRAP mode: no committed configuration found",
+				"detail", detail)
+		}
 	} else if nodeIDPresent && d.store.ActiveConfig() == nil {
 		// HA-node guard (C2/C8): node-id present but NEITHER a DB nor an
 		// importable xpf.conf. Resolved to NOT-bootstrap so takeover is not

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -264,7 +264,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// #1960: but NOT when a present committed config failed to compile —
 	// importing the text xpf.conf there would silently swap in a different
 	// config and then take over interfaces, defeating the fail-closed intent.
-	if d.store.ActiveConfig() == nil && !configCompileFailed {
+	if shouldBootstrapFromFile(d.store.ActiveConfig() != nil, configCompileFailed) {
 		if err := d.bootstrapFromFile(); err != nil {
 			slog.Warn("failed to bootstrap config from file", "err", err)
 		}


### PR DESCRIPTION
## Summary

If the persisted active DB is valid JSON but `compileTreeLenient` fails on boot,
xpfd left `compiled` nil while `everCommitted=true`, the Load error was only
`slog.Warn`'d, the daemon proceeded, and interface naming fell back to
**positional claim-all** — fail-OPEN (can mis-bind NICs / strand mgmt) (#1960,
found by AGY adversarial review on PR #1959; pre-existing, predates #1956).

Fix — fail **closed** into the existing #1922 bootstrap/lifeline safe state:
- New `configstore.ErrConfigCompile` sentinel; `Store.Load` tags the
  lenient-compile failure with it (keeps `compiled` nil; `everCommitted` already set).
- `classifyLoadError` (pure, unit-tested) maps Load errors: `ErrConfigDBUnreadable`
  → fatal exit (#1917 D1, bytes unreadable); **`ErrConfigCompile` → bootstrap**;
  else warn+proceed.
- `computeBootClass` takes `configCompileFailed`, checked **first** (overrides even
  the HA-node guard) → `bootClassBootstrap`: no `enumerateAndRenameInterfaces`
  claim-all; mgmt stays reachable via the lifeline + protected set; dataplane not
  armed; FRR/VRRP takeover suppressed; gRPC/REST/CLI stay up so the operator can
  fix the config (or repair/remove the DB). Surfaced via `slog.Error`.
- `Run` skips `bootstrapFromFile` on compile-failure (no blind-import of the text
  config over the broken DB).

A hard daemon exit was deliberately rejected — it also strands mgmt and is worse
than the lifeline state (distinct from the genuinely-unreadable #1917 D1 case).

## Provenance / note
Implemented by an agent that committed on a stale base; salvaged by cherry-picking
the 3 logical commits onto current master (`a963273e8`) — diff is scoped to
configstore/daemon only (verified: no userspace-dp/other files).

## Test plan
- [x] `go build ./...` clean on current master
- [x] `go test ./pkg/configstore/... ./pkg/daemon/...` pass
- [x] New tests: `TestLoadCommittedConfigCompileFailureFailsClosed` (Load returns
  ErrConfigCompile, not ErrConfigDBUnreadable; ActiveConfig nil; EverCommitted
  true), `TestClassifyLoadError`, `TestCompileFailureForcesBootstrapNotClaimAll`,
  +3 `TestComputeBootClass` compile-failed cases
- [ ] Codex + AGY code review — deferred until the in-flight research-012 agent
  frees the shared companions (single-job-global); Copilot requested now

🤖 Generated with [Claude Code](https://claude.com/claude-code)