### PR TITLE
#1984: truncate upgrade lock under flock on acquire and release

### DIFF
--- a/pkg/upgrade/lock/lock.go
+++ b/pkg/upgrade/lock/lock.go
@@ -41,7 +41,10 @@
 // as if it were the current holder's, misreporting a long-exited process.
 // The mutual exclusion (the flock) is unaffected — this is diagnostics
 // correctness. Two truncations, both performed WHILE THE FLOCK IS HELD,
-// keep the file empty across the entire ownerless interval:
+// keep the file empty across the entire ownerless interval (best-effort: a
+// truncate failure is logged/ignored, never failing acquire or release —
+// the other truncate and the next acquirer's truncate are the backstops, so
+// the worst case degrades to the pre-fix stale read, never a mutex fault):
 //   - truncate-on-acquire: the instant AcquireAt holds the flock it
 //     Truncate(0)s the file, so the acquire->write window (before the new
 //     owner records its own metadata) and a swallowed metadata-write
@@ -231,14 +234,33 @@ func (h *Handle) Release() error {
 	// let a fresh O_CREAT acquirer flock a different inode and split the
 	// mutex (the #1875 lesson). The truncate error is ignored — release must
 	// not fail on a best-effort metadata clear, and the kernel drops the
-	// flock on Close regardless.
-	_ = h.f.Truncate(0)
-	// Closing the fd releases the flock (the lock is tied to the open file
-	// description). Explicitly LOCK_UN first is redundant but harmless and
-	// makes the release intent obvious; ignore its error since Close is the
-	// authoritative drop.
-	_ = unix.Flock(int(h.f.Fd()), unix.LOCK_UN)
+	// flock on Close regardless. We still log a failure so an operator can
+	// see the (rare) case where the next owner's busy errors could name us.
+	if terr := h.f.Truncate(0); terr != nil {
+		fmt.Fprintf(os.Stderr,
+			"upgrade lock: failed to clear owner metadata on release (the next owner's busy errors may briefly name this one): %v\n",
+			terr)
+	}
+	// releaseUnlockFn is the seam through which Release drops the flock. It
+	// runs AFTER the truncate and BEFORE Close, so a test can assert the file
+	// is already empty at the instant ownership is about to be handed off —
+	// proving the truncate happened under the held flock (not after unlock).
+	releaseUnlockFn(h.f)
 	return h.f.Close()
+}
+
+// releaseUnlockFn drops the flock during Release. Production uses
+// releaseUnlock (an explicit LOCK_UN); tests substitute a hook that first
+// asserts the file is already empty, proving Release truncates BEFORE it
+// unlocks (i.e. while the flock is still held).
+var releaseUnlockFn = releaseUnlock
+
+// releaseUnlock drops the BSD advisory lock. Explicit LOCK_UN is redundant
+// with the Close that follows (closing the fd releases the lock tied to the
+// open file description) but makes the release intent obvious; its error is
+// ignored since Close is the authoritative drop.
+func releaseUnlock(f *os.File) {
+	_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
 }
 
 // writeOwnerFn is the seam through which AcquireAt records owner metadata.

--- a/pkg/upgrade/lock/lock.go
+++ b/pkg/upgrade/lock/lock.go
@@ -34,6 +34,30 @@
 //     while another fd holds LOCK_EX. The lock is released by closing the
 //     fd (Handle.Release), and the kernel also releases it on process
 //     exit, so a crashed holder never wedges the host.
+//
+// Stale-owner-metadata correctness (#1984): the owner metadata is the only
+// thing a busy acquirer reads to NAME the holder, and it is written AFTER
+// the flock. Without care a busy acquirer can read a PREVIOUS owner's JSON
+// as if it were the current holder's, misreporting a long-exited process.
+// The mutual exclusion (the flock) is unaffected — this is diagnostics
+// correctness. Two truncations, both performed WHILE THE FLOCK IS HELD,
+// keep the file empty across the entire ownerless interval:
+//   - truncate-on-acquire: the instant AcquireAt holds the flock it
+//     Truncate(0)s the file, so the acquire->write window (before the new
+//     owner records its own metadata) and a swallowed metadata-write
+//     failure both leave an EMPTY file rather than stale JSON. readOwner
+//     returns nil on an empty file, so a concurrent busy reader degrades
+//     to "busy, owner unknown".
+//   - truncate-on-release-under-lock: Release Truncate(0)s the file BEFORE
+//     dropping the flock, so the file is already empty the instant the
+//     NEXT acquirer can flock it — closing the flock->truncate scheduling
+//     gap that truncate-on-acquire alone would leave open.
+// Both are f.Truncate(0) on the HELD fd. os.Remove is deliberately NOT
+// used: flock binds the inode (open file description), so unlinking the
+// path while another fd has it open / awaits it lets a fresh O_CREAT
+// acquirer flock a DIFFERENT inode — a split mutex (the #1875 "never rm
+// the lock file" lesson). /run is tmpfs (reboot-clearing), so a lingering
+// zero-length lock file is harmless.
 package lock
 
 import (
@@ -149,6 +173,22 @@ func AcquireAt(path, subcommand, target string) (*Handle, error) {
 
 	h := &Handle{f: f}
 
+	// We hold the flock. Zero the file IMMEDIATELY, before recording our own
+	// metadata (#1984). Any concurrent busy reader that races into the
+	// acquire->write window now sees an EMPTY file (readOwner returns nil),
+	// degrading to "busy, owner unknown" rather than naming the PREVIOUS
+	// owner. This also closes the write-failure window below: if writeOwnerFn
+	// fails, the file is already empty instead of holding stale JSON. The
+	// truncate is on the HELD fd, so no concurrent writer can race it. It is
+	// non-fatal — the lock is the flock, not the file contents — so a failure
+	// is logged and execution continues (writeOwner's own Truncate(0) retries
+	// the clear, and a Release-time truncate is the final backstop).
+	if terr := f.Truncate(0); terr != nil {
+		fmt.Fprintf(os.Stderr,
+			"upgrade lock: held %s but failed to clear stale owner metadata: %v\n",
+			path, terr)
+	}
+
 	// We hold the lock — record owner metadata. Truncate first so a stale
 	// (larger) prior record never leaves trailing bytes. The metadata write
 	// is TRULY best-effort: a write failure is non-fatal to holding the lock
@@ -180,6 +220,19 @@ func (h *Handle) Release() error {
 		return nil
 	}
 	h.released = true
+	// Zero the file BEFORE dropping the flock (#1984). The next acquirer can
+	// only flock this inode after we LOCK_UN/Close, so truncating here means
+	// the file is already empty the instant ownership becomes available —
+	// closing the flock->truncate scheduling gap that truncate-on-acquire
+	// alone would leave (a racing reader in the next owner's acquire->write
+	// window would otherwise read OUR now-stale metadata). We still hold the
+	// flock, so no concurrent writer can race this truncate. This is
+	// f.Truncate(0) on the HELD fd, NOT os.Remove: unlinking the path would
+	// let a fresh O_CREAT acquirer flock a different inode and split the
+	// mutex (the #1875 lesson). The truncate error is ignored — release must
+	// not fail on a best-effort metadata clear, and the kernel drops the
+	// flock on Close regardless.
+	_ = h.f.Truncate(0)
 	// Closing the fd releases the flock (the lock is tied to the open file
 	// description). Explicitly LOCK_UN first is redundant but harmless and
 	// makes the release intent obvious; ignore its error since Close is the

--- a/pkg/upgrade/lock/lock_test.go
+++ b/pkg/upgrade/lock/lock_test.go
@@ -1,6 +1,7 @@
 package lock
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -197,6 +198,214 @@ func TestMetadataWriteFailureStillHoldsLock(t *testing.T) {
 		t.Fatalf("reacquire after release: %v", err)
 	}
 	_ = h2.Release()
+}
+
+// staleOwnerJSON is a plausible previous-owner record used to seed the lock
+// file in the stale-read regression tests. It mimics what a crashed holder
+// (kernel-released flock, file never truncated) leaves behind.
+const staleOwnerJSON = `{
+  "pid": 424242,
+  "subcommand": "upgrade --rolling",
+  "target": "9.9.9-stale",
+  "started_at": "2000-01-01T00:00:00Z"
+}`
+
+// TestReleaseTruncatesUnderLock proves Release zeroes the lock file BEFORE
+// dropping the flock (#1984). After a normal acquire+release the file must be
+// empty so the NEXT acquirer's busy readers never name the just-released
+// owner. This test FAILS if the release-time Truncate(0) is removed — the
+// file would still hold the released owner's JSON.
+func TestReleaseTruncatesUnderLock(t *testing.T) {
+	p := lockPath(t)
+
+	h, err := AcquireAt(p, "upgrade", "1.0.0")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	// Sanity: while held, the file carries this owner's metadata.
+	if data, rerr := os.ReadFile(p); rerr != nil || len(data) == 0 {
+		t.Fatalf("held lock file should carry owner metadata; len=%d err=%v", len(data), rerr)
+	}
+
+	if rerr := h.Release(); rerr != nil {
+		t.Fatalf("release: %v", rerr)
+	}
+
+	// The released file must be empty (the inode is kept; only contents are
+	// cleared). os.Remove is intentionally NOT used, so the file still exists.
+	data, rerr := os.ReadFile(p)
+	if rerr != nil {
+		t.Fatalf("lock file should still exist after release (os.Remove must NOT be used): %v", rerr)
+	}
+	if len(data) != 0 {
+		t.Fatalf("release must truncate the lock file under the flock; file still holds %d bytes: %q", len(data), data)
+	}
+
+	// Cross-check the diagnostic consequence: a fresh busy reader sees no
+	// owner. Hold the lock again and probe it from a second acquire.
+	h2, err := AcquireAt(p, "upgrade", "2.0.0")
+	if err != nil {
+		t.Fatalf("reacquire after release: %v", err)
+	}
+	defer h2.Release()
+	// h2 has written its OWN metadata by now, so a busy probe names h2 — that
+	// is correct (current holder), not the released owner. Confirm it never
+	// names the released "1.0.0".
+	_, berr := AcquireAt(p, "upgrade", "3.0.0")
+	if !IsBusy(berr) {
+		t.Fatalf("expected busy, got %v", berr)
+	}
+	if strings.Contains(berr.Error(), "1.0.0") {
+		t.Fatalf("busy error named the RELEASED owner instead of the current holder: %v", berr)
+	}
+}
+
+// TestAcquireTruncatesStaleMetadataBeforeWrite proves the acquire-time
+// Truncate(0) (#1984): a NEW holder zeroes the file the instant it holds the
+// flock, BEFORE recording its own metadata, so a concurrent busy reader in
+// the acquire->write window never reads a PREVIOUS owner's JSON.
+//
+// The file is seeded directly with stale JSON (simulating a crashed holder
+// whose flock the kernel released but whose metadata was never cleared — the
+// case the release-truncate cannot cover). A blocking writeOwnerFn seam pins
+// the new holder between the acquire-truncate and the metadata write while a
+// second acquire probes the file.
+//
+// This test FAILS if the acquire-time Truncate(0) is removed: the seeded
+// stale owner would still be in the file when the probe reads it, so ErrBusy
+// would name pid=424242 / "9.9.9-stale".
+func TestAcquireTruncatesStaleMetadataBeforeWrite(t *testing.T) {
+	p := lockPath(t)
+
+	// Seed stale metadata as if a crashed prior holder left it. Create the
+	// file with no flock held so the new holder below can acquire it.
+	if err := os.WriteFile(p, []byte(staleOwnerJSON), 0o644); err != nil {
+		t.Fatalf("seed stale metadata: %v", err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	prev := writeOwnerFn
+	writeOwnerFn = func(f *os.File, o Owner) error {
+		// We are now PAST the acquire-truncate and the flock is held. Signal
+		// the probe, then block before writing this holder's metadata so the
+		// probe observes the acquire->write window.
+		close(entered)
+		<-release
+		return prev(f, o)
+	}
+	t.Cleanup(func() { writeOwnerFn = prev })
+
+	acquired := make(chan *Handle, 1)
+	acqErr := make(chan error, 1)
+	go func() {
+		h, err := AcquireAt(p, "upgrade", "new-holder")
+		if err != nil {
+			acqErr <- err
+			return
+		}
+		acquired <- h
+	}()
+
+	select {
+	case <-entered:
+	case err := <-acqErr:
+		t.Fatalf("new holder failed to acquire: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the new holder to enter writeOwner")
+	}
+
+	// The new holder now HOLDS the flock and has run the acquire-truncate but
+	// has NOT yet written its metadata. Probe it: ErrBusy with a NIL owner.
+	_, berr := AcquireAt(p, "upgrade", "probe")
+	if !IsBusy(berr) {
+		t.Fatalf("expected ErrBusy during acquire->write window, got %T: %v", berr, berr)
+	}
+	var be *ErrBusy
+	if !errors.As(berr, &be) {
+		t.Fatalf("expected *ErrBusy, got %T: %v", berr, berr)
+	}
+	if be.Owner != nil {
+		t.Fatalf("busy read in the acquire->write window must NOT name an owner; got %s", be.Owner.String())
+	}
+	// Specifically: it must never report the seeded stale owner.
+	if strings.Contains(berr.Error(), "424242") || strings.Contains(berr.Error(), "9.9.9-stale") {
+		t.Fatalf("acquire-truncate failed: busy read named the STALE previous owner: %v", berr)
+	}
+
+	// Let the new holder finish writing its metadata, then confirm a busy
+	// read now correctly names IT.
+	close(release)
+	select {
+	case h := <-acquired:
+		defer h.Release()
+	case err := <-acqErr:
+		t.Fatalf("new holder acquire returned error after unblock: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the new holder to finish acquiring")
+	}
+	_, berr2 := AcquireAt(p, "upgrade", "probe2")
+	if !IsBusy(berr2) {
+		t.Fatalf("expected busy after metadata written, got %v", berr2)
+	}
+	if !strings.Contains(berr2.Error(), "new-holder") {
+		t.Fatalf("busy error should now name the new holder; got %v", berr2)
+	}
+}
+
+// TestAcquireClearsStaleMetadataOnWriteFailure proves window 2 (#1984): when
+// the metadata write fails AFTER the acquire-truncate, the file is left EMPTY
+// (already cleared by the acquire-truncate) rather than holding the previous
+// owner's JSON. A busy read therefore degrades to "owner unknown", never the
+// stale owner.
+//
+// This test FAILS if the acquire-time Truncate(0) is removed: with a failing
+// writeOwnerFn the seeded stale JSON would survive and a busy read would name
+// it.
+func TestAcquireClearsStaleMetadataOnWriteFailure(t *testing.T) {
+	p := lockPath(t)
+
+	if err := os.WriteFile(p, []byte(staleOwnerJSON), 0o644); err != nil {
+		t.Fatalf("seed stale metadata: %v", err)
+	}
+
+	prev := writeOwnerFn
+	writeOwnerFn = func(*os.File, Owner) error {
+		return os.ErrInvalid // fail the metadata write AFTER acquire-truncate
+	}
+	t.Cleanup(func() { writeOwnerFn = prev })
+
+	h, err := AcquireAt(p, "upgrade", "write-fails")
+	if err != nil {
+		// Best-effort contract: a metadata-write failure must NOT fail Acquire.
+		t.Fatalf("metadata-write failure must not fail Acquire: %v", err)
+	}
+	defer h.Release()
+
+	// The on-disk file must be empty: the acquire-truncate cleared the stale
+	// JSON and the failed write left nothing behind.
+	data, rerr := os.ReadFile(p)
+	if rerr != nil {
+		t.Fatalf("read lock file: %v", rerr)
+	}
+	if len(data) != 0 {
+		t.Fatalf("acquire-truncate should have cleared stale metadata before the failed write; file holds %d bytes: %q", len(data), data)
+	}
+
+	// Restore the real writer so the busy probe behaves normally, then confirm
+	// a busy read reports owner-unknown, NOT the seeded stale owner.
+	writeOwnerFn = prev
+	_, berr := AcquireAt(p, "upgrade", "probe")
+	if !IsBusy(berr) {
+		t.Fatalf("expected busy, got %v", berr)
+	}
+	if strings.Contains(berr.Error(), "424242") || strings.Contains(berr.Error(), "9.9.9-stale") {
+		t.Fatalf("write-failure path leaked the stale owner into the busy error: %v", berr)
+	}
+	var be *ErrBusy
+	if errors.As(berr, &be) && be.Owner != nil {
+		t.Fatalf("busy read after a swallowed write failure must report owner-unknown; got %s", be.Owner.String())
+	}
 }
 
 func TestMkdirCreatesRunDir(t *testing.T) {

--- a/pkg/upgrade/lock/lock_test.go
+++ b/pkg/upgrade/lock/lock_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -211,10 +212,14 @@ const staleOwnerJSON = `{
 }`
 
 // TestReleaseTruncatesUnderLock proves Release zeroes the lock file BEFORE
-// dropping the flock (#1984). After a normal acquire+release the file must be
-// empty so the NEXT acquirer's busy readers never name the just-released
-// owner. This test FAILS if the release-time Truncate(0) is removed — the
-// file would still hold the released owner's JSON.
+// dropping the flock (#1984), and that it does so WHILE THE FLOCK IS STILL
+// HELD (not merely "empty after Release returns"). After a normal
+// acquire+release the file must be empty so the NEXT acquirer's busy readers
+// never name the just-released owner. This test FAILS if the release-time
+// Truncate(0) is removed — the file would still hold the released owner's
+// JSON — AND, via the releaseUnlockFn seam, FAILS if the truncate were
+// reordered to AFTER the flock drop (a plain "read after Release" assertion
+// could not catch that reordering — Codex review #1995).
 func TestReleaseTruncatesUnderLock(t *testing.T) {
 	p := lockPath(t)
 
@@ -227,9 +232,30 @@ func TestReleaseTruncatesUnderLock(t *testing.T) {
 		t.Fatalf("held lock file should carry owner metadata; len=%d err=%v", len(data), rerr)
 	}
 
+	// Intercept the flock drop: at the instant Release is about to unlock, the
+	// truncate must already have run (file empty) — proving the truncate is
+	// under the held flock, before the next acquirer can ever flock the inode.
+	prevUnlock := releaseUnlockFn
+	var emptyAtUnlock, unlockSeen bool
+	releaseUnlockFn = func(f *os.File) {
+		unlockSeen = true
+		if data, rerr := os.ReadFile(f.Name()); rerr == nil && len(data) == 0 {
+			emptyAtUnlock = true
+		}
+		prevUnlock(f)
+	}
+	t.Cleanup(func() { releaseUnlockFn = prevUnlock })
+
 	if rerr := h.Release(); rerr != nil {
 		t.Fatalf("release: %v", rerr)
 	}
+	if !unlockSeen {
+		t.Fatal("releaseUnlockFn was not invoked — Release no longer drops the flock through the seam")
+	}
+	if !emptyAtUnlock {
+		t.Fatal("Release dropped the flock with the file still non-empty — the truncate must run BEFORE unlock, under the held flock")
+	}
+	releaseUnlockFn = prevUnlock
 
 	// The released file must be empty (the inode is kept; only contents are
 	// cleared). os.Remove is intentionally NOT used, so the file still exists.
@@ -285,6 +311,14 @@ func TestAcquireTruncatesStaleMetadataBeforeWrite(t *testing.T) {
 
 	entered := make(chan struct{})
 	release := make(chan struct{})
+	// unblock frees the blocked holder goroutine. Wrapped in sync.Once so the
+	// happy-path close and the t.Cleanup safety close are both safe — without
+	// the deferred cleanup a t.Fatalf before the happy-path close would leak
+	// the goroutine blocked on <-release (Codex/AGY review #1995).
+	var unblockOnce sync.Once
+	unblock := func() { unblockOnce.Do(func() { close(release) }) }
+	t.Cleanup(unblock)
+
 	prev := writeOwnerFn
 	writeOwnerFn = func(f *os.File, o Owner) error {
 		// We are now PAST the acquire-truncate and the flock is held. Signal
@@ -335,7 +369,7 @@ func TestAcquireTruncatesStaleMetadataBeforeWrite(t *testing.T) {
 
 	// Let the new holder finish writing its metadata, then confirm a busy
 	// read now correctly names IT.
-	close(release)
+	unblock()
 	select {
 	case h := <-acquired:
 		defer h.Release()


### PR DESCRIPTION
## Summary

The upgrade lock (`pkg/upgrade/lock`) writes owner metadata (PID,
subcommand, target, start time) into the lock file AFTER the flock
succeeds, and a busy acquirer reads that file to NAME the holder. Three
windows let a busy acquirer read a PREVIOUS owner's JSON as if it were
the current holder's, so `ErrBusy` can misreport a long-exited process:
the acquire->write gap, a swallowed metadata-write failure, and the
fact that `Release` never cleared the file. The flock mutual exclusion
itself is sound — this is diagnostics correctness only.

Fix: two `f.Truncate(0)` calls, both on the HELD fd while the flock is
owned — truncate-on-acquire (the instant the flock is held, before
recording our own metadata) and truncate-on-release-under-lock (before
dropping the flock). Together they keep the file empty across the whole
ownerless interval, so a concurrent busy reader degrades to "busy, owner
unknown" (already a supported `ErrBusy` rendering) instead of naming a
stale owner. `os.Remove` is deliberately NOT used: flock binds the inode,
so unlinking the path could split the mutex (the #1875 "never rm the lock
file" lesson). `/run` is tmpfs, so a lingering zero-length file is
harmless.

## Plan + adversarial review

Plan doc: `docs/research/1984-upgrade-lock-stale-owner/plan.md` (research
phase, converged engineer-now).

- Claude SMR: PLAN READY; `os.Remove`-on-release correctly rejected.
- AGY: PLAN YES — "correct, robust; deep understanding of Unix locking
  semantics"; endorsed rejecting `os.Remove` (split-mutex on inode-bound
  flock).
- Codex: PLAN NEEDS-MAJOR -> folded. truncate-on-acquire alone leaves a
  flock->truncate scheduling gap; "never previous owner" REQUIRES
  truncate-on-release while still holding the flock. Added.

## Test plan

This is a control-plane, host-local diagnostics fix. **No loss-cluster
smoke is required** (no dataplane/forwarding/CoS/HA path is touched).

- [x] `go build` / `go vet` clean
- [x] Full Go suite in the worktree: 43 packages ok, 0 fail, 5 no-test-files
- [x] Three new regression tests pass and FAIL if either truncate is removed:
  - `TestReleaseTruncatesUnderLock` — fails if release-truncate dropped
    (file still holds released owner JSON)
  - `TestAcquireTruncatesStaleMetadataBeforeWrite` — blocking-seam test;
    fails if acquire-truncate dropped (busy read names seeded stale owner)
  - `TestAcquireClearsStaleMetadataOnWriteFailure` — fails if
    acquire-truncate dropped (stale JSON survives the failed write)
- [x] 5x `-race` flake check on the concurrency test: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)