### PR TITLE
#1985: postrm exec-free downgrade detection (incoming-version floor, no staged-binary exec)

### DIFF
--- a/cmd/xpfd/seed_runtime.go
+++ b/cmd/xpfd/seed_runtime.go
@@ -23,14 +23,21 @@ func runSeedRuntimeSubcommand(args []string) {
 	stagedDir := fs.String("staged-dir", upgrade.DefaultStagedDir, "dpkg-staged binary set dir")
 	versionsDir := fs.String("versions-dir", upgrade.DefaultVersionsDir, "runtime versioned dir")
 	sbinDir := fs.String("sbin-dir", upgrade.DefaultSbinDir, "operator-tool symlink dir")
-	// --capability-check is a pure, side-effect-free probe used by the .deb
-	// postrm to tell whether the newly-unpacked staged binary supports the
-	// #1964 hardened versioned-runtime layout. A hardened xpfd exits 0
-	// without touching the filesystem; a pre-#1964 binary has no
+	// --capability-check is a pure, side-effect-free probe: a hardened xpfd
+	// exits 0 without touching the filesystem; a pre-#1964 binary has no
 	// seed-runtime subcommand at all and exits non-zero ("unknown command").
-	// The postrm downgrade cleanup keys on this so it ONLY tears down the
-	// hardened layout when downgrading to a package that genuinely lacks it
-	// (never when downgrading hardened->hardened).
+	//
+	// HISTORICAL (#1985): the .deb postrm USED to gate the downgrade teardown
+	// on this probe, but EXECUTING the staged binary conflated "new binary
+	// lacks the layout" with "new binary cannot run" (link/corruption/arch
+	// errors), tearing the versioned runtime down on a real UPGRADE. The
+	// postrm now keys the decision on the dpkg-supplied INCOMING version
+	// (`$2` compared against the hardened-layout floor, exec-free) and never
+	// runs this probe. The flag is RETAINED because dpkg runs the OLD
+	// package's postrm during an upgrade, so a pre-#1985 postrm still invokes
+	// it during the one-hop buggy->fixed transition; removing it would break
+	// that call. See docs/in-place-upgrade.md ("Downgrade detection is
+	// exec-free and version-keyed").
 	capCheck := fs.Bool("capability-check", false,
 		"probe-only: exit 0 if this binary supports the #1964 versioned-runtime "+
 			"layout, without touching the filesystem")

--- a/debian/xpf.postrm
+++ b/debian/xpf.postrm
@@ -62,15 +62,22 @@ SBIN=/usr/local/sbin
 VERSIONS=/var/lib/xpf/versions
 CURRENT="$VERSIONS/current"
 DROPIN=/etc/systemd/system/xpfd.service.d/10-xpf-version.conf
-# #1985 hardened-layout version floor. The #1964 versioned-runtime layout
-# (versions/current + the unit drop-in this postrm manages) first shipped in
-# the debian maintainer scripts at commit `ef9525e70` ("#1964: postrm
-# versioned-link cleanup, purge tree removal, downgrade"), whose `git
-# rev-list --count` is 4104. The .deb version scheme is `0.0.<commit-count>+g<sha>`
-# (Makefile DEB_VERSION), monotonic in commit count, so any incoming package
-# with version < 0.0.4104 PREDATES the layout and is a genuine pre-#1964
-# downgrade. This is a HISTORICAL fixed point (the layout already shipped), not
-# a value that drifts per build — do not bump it with new releases.
+# #1985 hardened-layout version floor. This is the first package whose postrm
+# manages the #1964 versioned-runtime layout (versions/current + the unit
+# drop-in) on downgrade and whose xpfd answers `seed-runtime
+# --capability-check` — i.e. the first package that can be classified as
+# hardened by this teardown contract. That commit is `ef9525e70` ("#1964:
+# postrm versioned-link cleanup, purge tree removal, downgrade"), whose `git
+# rev-list --count` is 4104. (Earlier #1964 commits added the postinst seed at
+# 4102 and the preinst migration at 4103, but the postrm downgrade handling
+# this floor protects landed at 4104.) The .deb version scheme is
+# `0.0.<commit-count>+g<sha>` (Makefile DEB_VERSION), monotonic in commit
+# count, so any incoming package with version < 0.0.4104 PREDATES the contract
+# and is a genuine pre-#1964 downgrade; >= 0.0.4104 (incl. the floor version
+# 0.0.4104+g<sha>, which sorts ABOVE the bare 0.0.4104 floor since `+...`
+# sorts after the empty string) is hardened. This is a HISTORICAL fixed point
+# (the contract already shipped), not a value that drifts per build — do
+# not bump it with new releases.
 HARDENED_LAYOUT_FLOOR="0.0.4104"
 # Managed-binary set (#1982). The single source of truth is the Go manifest
 # pkg/upgrade/manifest; this literal is kept self-contained on purpose (no
@@ -156,10 +163,12 @@ repoint_owned_sbin_to_staged() {
 incoming_predates_hardened_layout() {
     _v="$1"
     [ -n "$_v" ] || return 1
-    # `dpkg --compare-versions` returns 2 (not 1) on an UNPARSABLE version;
-    # only a clean 0 (true: _v lt floor) counts as a confirmed pre-#1964
-    # downgrade. Any other status (1 = not-less, 2 = parse error) => keep.
-    dpkg --compare-versions "$_v" lt "$HARDENED_LAYOUT_FLOOR" 2>/dev/null
+    # `dpkg --compare-versions` returns 0 (true: _v lt floor), 1 (not-less),
+    # or 2 (UNPARSABLE version). Only a clean 0 counts as a confirmed
+    # pre-#1964 downgrade; map anything else to return 1 (keep). The explicit
+    # `|| return 1` also keeps this helper safe under `set -e` if it is ever
+    # called outside an `if`/`&&` condition in a future edit (AGY).
+    dpkg --compare-versions "$_v" lt "$HARDENED_LAYOUT_FLOOR" 2>/dev/null || return 1
 }
 
 case "$1" in

--- a/debian/xpf.postrm
+++ b/debian/xpf.postrm
@@ -16,10 +16,35 @@
 # staged/ and does not manage versions/, so a lingering hardened drop-in +
 # versions/current would keep the unit running the NEWER binaries (the
 # drop-in ExecStart pins the concrete newer version dir) — a silent version
-# mismatch. This postrm detects that case (the new staged xpfd does not
-# support the #1964 layout) and cleans up: remove the runtime drop-in,
-# repoint sbin back to staged atomically, DELETE versions/current, and
-# boot-guarded daemon-reload.
+# mismatch. This postrm detects that case and cleans up: remove the runtime
+# drop-in, repoint sbin back to staged atomically, DELETE versions/current,
+# and boot-guarded daemon-reload.
+#
+# #1985: detection keys on the dpkg-supplied INCOMING version ($2), NOT on an
+# exec of the staged binary. The original code probed
+# `"$STAGED/xpfd" seed-runtime --capability-check` and treated ANY non-zero
+# exit as "pre-#1964, tear the layout down". The `&&` short-circuited to false
+# whenever the staged xpfd could not EXEC at all (dynamic-link error during
+# unpack, corruption, libc/ABI conflict, arch mismatch) — not only when it
+# genuinely lacked the subcommand. That conflated "new binary lacks the
+# layout" with "new binary cannot run", so a non-execable staged xpfd on a
+# real UPGRADE ran the destructive teardown and broke the daemon on next boot.
+#
+# The sound, exec-free signal is the version: dpkg passes $2 = the version
+# being installed. A genuine pre-#1964 downgrade has $2 < the layout floor;
+# an upgrade or a hardened->hardened downgrade has $2 >= the floor. We compare
+# with `dpkg --compare-versions` (always present in a maintainer script).
+# A presence-only file marker was rejected: dpkg removes a file that exists
+# ONLY in the old package AFTER old-postrm runs (Debian Policy 6.6 unpack
+# order), so a marker shipped by the hardened package LINGERS on disk at
+# old-postrm time during a genuine pre-#1964 downgrade and would mis-signal
+# "incoming is hardened" — skipping the teardown that the downgrade needs.
+# The version arg has no such staleness.
+#
+# Safe-fallback posture (mirrors the sibling preinst migrate_legacy_layout):
+# if $2 is empty or unparsable we LEAVE the hardened layout intact rather than
+# destroy it — the verify-dataplane cut gate / refuse-before-STOP guard is
+# the backstop. We tear down ONLY when $2 is a confirmed pre-#1964 version.
 #
 # REMOVE/PURGE drop-in cleanup (#1967): on remove/purge the runtime unit
 # drop-in /etc/systemd/system/xpfd.service.d/10-xpf-version.conf (written by
@@ -37,6 +62,16 @@ SBIN=/usr/local/sbin
 VERSIONS=/var/lib/xpf/versions
 CURRENT="$VERSIONS/current"
 DROPIN=/etc/systemd/system/xpfd.service.d/10-xpf-version.conf
+# #1985 hardened-layout version floor. The #1964 versioned-runtime layout
+# (versions/current + the unit drop-in this postrm manages) first shipped in
+# the debian maintainer scripts at commit `ef9525e70` ("#1964: postrm
+# versioned-link cleanup, purge tree removal, downgrade"), whose `git
+# rev-list --count` is 4104. The .deb version scheme is `0.0.<commit-count>+g<sha>`
+# (Makefile DEB_VERSION), monotonic in commit count, so any incoming package
+# with version < 0.0.4104 PREDATES the layout and is a genuine pre-#1964
+# downgrade. This is a HISTORICAL fixed point (the layout already shipped), not
+# a value that drifts per build — do not bump it with new releases.
+HARDENED_LAYOUT_FLOOR="0.0.4104"
 # Managed-binary set (#1982). The single source of truth is the Go manifest
 # pkg/upgrade/manifest; this literal is kept self-contained on purpose (no
 # build-time sed into the tracked checkout). The drift canary
@@ -110,6 +145,23 @@ repoint_owned_sbin_to_staged() {
     done
 }
 
+# incoming_predates_hardened_layout VERSION reports (exit 0) whether the
+# INCOMING package version VERSION ($2 on `postrm upgrade`) predates the #1964
+# hardened layout floor — i.e. this is a genuine pre-#1964 downgrade that
+# must tear the hardened artifacts down. It is EXEC-FREE (the #1985 fix: never
+# run the staged binary) and staleness-free (uses the dpkg version, not an
+# on-disk file). Empty or unparsable VERSION returns NON-zero (false) so the
+# caller takes the SAFE branch (leave the layout intact) rather than destroy
+# it on ambiguity — mirroring the preinst migrate_legacy_layout posture.
+incoming_predates_hardened_layout() {
+    _v="$1"
+    [ -n "$_v" ] || return 1
+    # `dpkg --compare-versions` returns 2 (not 1) on an UNPARSABLE version;
+    # only a clean 0 (true: _v lt floor) counts as a confirmed pre-#1964
+    # downgrade. Any other status (1 = not-less, 2 = parse error) => keep.
+    dpkg --compare-versions "$_v" lt "$HARDENED_LAYOUT_FLOOR" 2>/dev/null
+}
+
 case "$1" in
     remove|purge)
         remove_owned_sbin_links
@@ -128,18 +180,15 @@ case "$1" in
         # predates the #1964 hardened layout, tear our hardened artifacts
         # down so the downgraded package's direct-staged links take effect.
         #
-        # Detection is a capability probe of the NEWLY-UNPACKED staged xpfd
-        # (already on disk at old-postrm `upgrade` time, per the dpkg
-        # downgrade call order: new-preinst, unpack, OLD-postrm upgrade,
-        # new-postinst configure). A hardened xpfd supports
-        # `seed-runtime --capability-check` (exit 0, no side effects); a
-        # pre-#1964 binary has no seed-runtime subcommand and exits non-zero.
-        # We ONLY clean up when the probe says the new binary lacks the
-        # layout — never on a hardened->hardened downgrade.
-        if [ -x "$STAGED/xpfd" ] && \
-           "$STAGED/xpfd" seed-runtime --capability-check >/dev/null 2>&1; then
-            : # downgrading to another hardened package — leave the layout.
-        elif [ -L "$CURRENT" ] || [ -e "$CURRENT" ]; then
+        # Detection is the EXEC-FREE incoming-version compare (#1985): tear
+        # down ONLY when $2 is a confirmed pre-#1964 version (below the layout
+        # floor) AND a hardened layout is present (versions/current). An
+        # upgrade or a hardened->hardened downgrade ($2 >= floor) — and an
+        # empty/unparsable $2 — leave the layout intact. Never exec the
+        # staged binary (the old probe tore the layout down on ANY exec
+        # failure of a hardened-but-unrunnable binary, #1985).
+        if incoming_predates_hardened_layout "$2" && \
+           { [ -L "$CURRENT" ] || [ -e "$CURRENT" ]; }; then
             echo "xpf: #1964 downgrade to a pre-hardened package — removing the" \
                  "versioned-runtime drop-in and repointing sbin back to staged." >&2
             # 1. repoint OWNED sbin links back to staged (atomic) so the

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -215,12 +215,18 @@ fi
 ```
 
 `HARDENED_LAYOUT_FLOOR` is `0.0.4104` — the `.deb` version
-(`0.0.<commit-count>+g<sha>`, `Makefile` `DEB_VERSION`) of the commit
-(`ef9525e70`) where the versioned-runtime layout first shipped in the debian
-maintainer scripts. Any incoming version `< 0.0.4104` predates the layout and
-is a genuine pre-#1964 downgrade; `>= 0.0.4104` (upgrade OR hardened->hardened
-downgrade) leaves the layout alone. The floor is a HISTORICAL fixed point (the
-layout already shipped), not a per-release value — it is never bumped.
+(`0.0.<commit-count>+g<sha>`, `Makefile` `DEB_VERSION`) of commit `ef9525e70`,
+the first package whose postrm manages the versioned-runtime layout on
+downgrade and whose `xpfd` answers `seed-runtime --capability-check` — i.e.
+the first package classifiable as hardened by this teardown contract. (Earlier
+#1964 commits added the postinst seed at count 4102 and the preinst migration
+at 4103; the postrm downgrade handling this floor protects landed at 4104.)
+Any incoming version `< 0.0.4104` predates the contract and is a genuine
+pre-#1964 downgrade; `>= 0.0.4104` (upgrade OR hardened->hardened downgrade,
+including the floor version `0.0.4104+g<sha>` which sorts above the bare
+`0.0.4104` floor) leaves the layout alone. The floor is a HISTORICAL fixed
+point (the contract already shipped), not a per-release value — it is
+never bumped.
 
 - The teardown runs ONLY when `$2` is a confirmed pre-#1964 version AND a
   hardened layout is present (`versions/current`).

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -184,11 +184,71 @@ drop-in removal is safe on legacy/never-seeded hosts (absent file) and leaves a
 non-empty `.service.d` (a foreign operator drop-in) intact. `versions/` is left
 on `remove` (a reinstall reuses it) and removed on `purge` (it is copied
 binaries, not operator config — Policy §6.8). A downgrade to a package
-predating this layout (detected via a `seed-runtime --capability-check` probe
-of the newly-unpacked staged `xpfd`) repoints sbin back to `staged/`
-atomically, deletes `versions/current`, then removes the runtime unit drop-in
-+ boot-guarded `daemon-reload` (shared helper) — so the downgraded binaries
-actually take effect.
+predating this layout repoints sbin back to `staged/` atomically, deletes
+`versions/current`, then removes the runtime unit drop-in + boot-guarded
+`daemon-reload` (shared helper) — so the downgraded binaries actually take
+effect.
+
+### Downgrade detection is exec-free and version-keyed (#1985)
+
+The postrm must decide whether the package being installed predates the #1964
+hardened layout (and so the lingering `versions/current` + drop-in must be torn
+down). It originally did this by EXECUTING the staged binary
+(`"$STAGED/xpfd" seed-runtime --capability-check`) and treating any non-zero
+exit as "pre-hardened, tear the layout down". That conflated two different
+things: a binary that genuinely lacks the subcommand, and a binary that cannot
+EXEC AT ALL (dynamic-link error during unpack, corruption, libc/ABI conflict,
+architecture mismatch). On a genuine UPGRADE where the new staged `xpfd`
+happened to be non-execable, the `&&` short-circuited to false and the
+destructive branch ran — deleting `versions/current`, repointing sbin to
+`staged/`, and removing the drop-in — breaking the daemon on next boot.
+
+The decision is now keyed on the dpkg-supplied INCOMING version (`$2`), which
+is exec-free and has no staleness hazard:
+
+```sh
+if incoming_predates_hardened_layout "$2" \
+   && { [ -L "$CURRENT" ] || [ -e "$CURRENT" ]; }; then
+    ... tear down ...
+fi
+# incoming_predates_hardened_layout: dpkg --compare-versions "$2" lt FLOOR
+```
+
+`HARDENED_LAYOUT_FLOOR` is `0.0.4104` — the `.deb` version
+(`0.0.<commit-count>+g<sha>`, `Makefile` `DEB_VERSION`) of the commit
+(`ef9525e70`) where the versioned-runtime layout first shipped in the debian
+maintainer scripts. Any incoming version `< 0.0.4104` predates the layout and
+is a genuine pre-#1964 downgrade; `>= 0.0.4104` (upgrade OR hardened->hardened
+downgrade) leaves the layout alone. The floor is a HISTORICAL fixed point (the
+layout already shipped), not a per-release value — it is never bumped.
+
+- The teardown runs ONLY when `$2` is a confirmed pre-#1964 version AND a
+  hardened layout is present (`versions/current`).
+- An empty or unparsable `$2` (`dpkg --compare-versions` exits 2) leaves the
+  layout intact — the safe default, never a teardown on ambiguity. This
+  mirrors the sibling `preinst migrate_legacy_layout` posture
+  (skip-don't-destroy). The verify-dataplane cut gate / refuse-before-STOP
+  guard (`pkg/upgrade/cutover.go`) is the backstop for a hardened-but-
+  unrunnable staged binary.
+
+A presence-only file marker (a sentinel the hardened package ships) was
+considered and REJECTED: dpkg removes a file present ONLY in the old package
+AFTER the old-postrm runs (Debian Policy 6.6 unpack order), so a marker shipped
+by the hardened package LINGERS on disk at old-postrm time during a genuine
+pre-#1964 downgrade and would mis-signal "incoming is hardened", skipping the
+teardown the downgrade needs. The version argument has no such staleness.
+
+**One-time buggy->fixed exposure.** dpkg runs the OLD package's `postrm
+upgrade <new>` during an upgrade. Upgrading FROM a pre-#1985 (exec-probe)
+package therefore still runs that OLD buggy postrm; the version-floor gate
+cannot protect its own rollout for that single hop — the fix cannot run
+before it is installed. The exposure fires ONLY if, at OLD-postrm time, the
+new staged `xpfd` is non-execable AND `versions/current` exists. The realistic
+trigger is an OS/libc bump in the SAME apt transaction making the new binary
+temporarily unloadable; stage xpf upgrades separately from OS/libc bumps.
+**Recovery** if the old postrm did tear the layout down: re-run `xpfd
+seed-runtime` (or reinstall the package) to rebuild `versions/current` + the
+unit drop-in before the next cut.
 
 ## HA rolling upgrade (`xpfd upgrade --rolling`)
 

--- a/test/debian/postrm-test.sh
+++ b/test/debian/postrm-test.sh
@@ -142,9 +142,10 @@ scenario_remove_no_dropin_ok() {
 # downgrade to a pre-hardened package: drop-in removed, sbin repointed to
 # staged, current deleted.
 scenario_downgrade_to_prehardened() {
-    build_hardened "2.0.0"
+    build_hardened "0.0.5000+gaaaa"
     make_staged_prehardened
-    "$ROOT/postrm" upgrade "0.9.0"
+    # $2 is a pre-#1964 version (< the 0.0.4104 floor) -> genuine downgrade.
+    "$ROOT/postrm" upgrade "0.0.4000+gbbbb"
     [ -e "$DROPIN" ] && { echo "FAIL: drop-in not removed"; exit 1; } || true
     # The .d dir must be rmdir'd when empty (exercises dirname "$DROPIN").
     [ -e "$(dirname "$DROPIN")" ] && { echo "FAIL: empty drop-in .d dir not removed"; exit 1; } || true
@@ -155,11 +156,11 @@ scenario_downgrade_to_prehardened() {
     [ -e "$CURRENT" ] && { echo "FAIL: current not deleted"; exit 1; } || true
 }
 
-# downgrade/upgrade to ANOTHER hardened package: layout untouched.
+# upgrade to a newer hardened package ($2 >= floor): layout untouched.
 scenario_upgrade_to_hardened_noop() {
-    build_hardened "1.0.0"
-    # staged xpfd still supports the capability check (build_hardened set it).
-    "$ROOT/postrm" upgrade "0.9.0"
+    build_hardened "0.0.5000+gaaaa"
+    # $2 is a post-#1964 version (>= the 0.0.4104 floor) -> NOT a downgrade.
+    "$ROOT/postrm" upgrade "0.0.5500+gbbbb"
     [ -e "$DROPIN" ] || { echo "FAIL: drop-in removed on hardened->hardened"; exit 1; }
     for b in $BINS; do
         tgt=$(readlink "$SBIN/$b")
@@ -188,15 +189,107 @@ scenario_remove_legacy_links() {
 
 # downgrade must NOT clobber a foreign/operator-repointed sbin link (Codex).
 scenario_downgrade_skips_foreign_link() {
-    build_hardened "2.0.0"
+    build_hardened "0.0.5000+gaaaa"
     make_staged_prehardened
     # Operator repointed xpfd elsewhere; the others stay package-owned.
     ln -sf "/opt/custom/xpfd" "$SBIN/xpfd"
-    "$ROOT/postrm" upgrade "0.9.0"
+    # $2 < floor -> genuine pre-#1964 downgrade.
+    "$ROOT/postrm" upgrade "0.0.4000+gbbbb"
     [ "$(readlink "$SBIN/xpfd")" = "/opt/custom/xpfd" ] || { echo "FAIL: downgrade clobbered a foreign sbin link"; exit 1; }
     # The owned ones are repointed to staged.
     for b in cli xpf-userspace-dp xpf-day0-config; do
         [ "$(readlink "$SBIN/$b")" = "$STAGED/$b" ] || { echo "FAIL: owned sbin $b not repointed to staged"; exit 1; }
+    done
+}
+
+# === #1985 regression scenarios: downgrade decision is EXEC-FREE + version-keyed ===
+
+# CORE #1985 BUG CASE: a real UPGRADE ($2 >= the 0.0.4104 floor) whose staged
+# xpfd cannot EXEC (dynamic-link error / corruption / arch mismatch) must NOT
+# be misclassified as a pre-#1964 downgrade. The version arg says "upgrade",
+# so the layout MUST survive regardless of the staged binary's health. The old
+# exec-probe gate tore the runtime down here.
+scenario_upgrade_nonexecable_staged_survives() {
+    build_hardened "0.0.5000+gaaaa"
+    # Staged xpfd present but non-executable (exec would ENOEXEC). The gate
+    # never execs it; only $2 matters.
+    : > "$STAGED/xpfd"
+    chmod -x "$STAGED/xpfd"
+    "$ROOT/postrm" upgrade "0.0.5500+gbbbb"
+    [ -e "$DROPIN" ] || { echo "FAIL: drop-in removed on upgrade w/ non-execable staged xpfd"; exit 1; }
+    [ -e "$(dirname "$DROPIN")" ] || { echo "FAIL: .service.d removed on upgrade w/ non-execable staged xpfd"; exit 1; }
+    [ -L "$CURRENT" ] || { echo "FAIL: current deleted on upgrade w/ non-execable staged xpfd"; exit 1; }
+    for b in $BINS; do
+        tgt=$(readlink "$SBIN/$b")
+        [ "$tgt" = "$CURRENT/$b" ] || { echo "FAIL: sbin $b repointed on upgrade ($tgt) w/ non-execable staged xpfd"; exit 1; }
+    done
+}
+
+# A hardened->hardened DOWNGRADE ($2 lower but still >= floor) where the staged
+# xpfd cannot exec also keeps the layout: $2 is above the floor, so it is not a
+# pre-#1964 downgrade.
+scenario_downgrade_hardened_nonexecable_survives() {
+    build_hardened "0.0.5500+gaaaa"
+    : > "$STAGED/xpfd"
+    chmod -x "$STAGED/xpfd"
+    "$ROOT/postrm" upgrade "0.0.5000+gbbbb"
+    [ -e "$DROPIN" ] || { echo "FAIL: drop-in removed on hardened->hardened downgrade w/ non-execable staged xpfd"; exit 1; }
+    [ -L "$CURRENT" ] || { echo "FAIL: current deleted on hardened->hardened downgrade w/ non-execable staged xpfd"; exit 1; }
+}
+
+# A genuine pre-#1964 downgrade is detected by $2 < floor even when the staged
+# binary EXECs fine -- the gate no longer trusts (or runs) exec at all. The
+# staged xpfd here is a perfectly runnable pre-hardened binary; the layout must
+# still be torn down because $2 is below the floor.
+scenario_downgrade_below_floor_execable_tears_down() {
+    build_hardened "0.0.5000+gaaaa"
+    make_staged_prehardened   # runnable pre-hardened binary
+    [ -x "$STAGED/xpfd" ] || { echo "FAIL: precondition: staged xpfd should be execable"; exit 1; }
+    "$ROOT/postrm" upgrade "0.0.4000+gbbbb"
+    [ -e "$DROPIN" ] && { echo "FAIL: drop-in not removed on below-floor downgrade"; exit 1; } || true
+    [ -e "$(dirname "$DROPIN")" ] && { echo "FAIL: empty .service.d not removed on below-floor downgrade"; exit 1; } || true
+    for b in $BINS; do
+        tgt=$(readlink "$SBIN/$b")
+        [ "$tgt" = "$STAGED/$b" ] || { echo "FAIL: sbin $b -> $tgt, want staged on below-floor downgrade"; exit 1; }
+    done
+    [ -e "$CURRENT" ] && { echo "FAIL: current not deleted on below-floor downgrade"; exit 1; } || true
+}
+
+# Boundary: $2 exactly AT the floor is the first hardened version -> NOT a
+# pre-#1964 downgrade -> layout survives (the comparison is strictly less-than).
+scenario_upgrade_at_floor_survives() {
+    build_hardened "0.0.5000+gaaaa"
+    "$ROOT/postrm" upgrade "0.0.4104"
+    [ -e "$DROPIN" ] || { echo "FAIL: drop-in removed at exactly the floor version"; exit 1; }
+    [ -L "$CURRENT" ] || { echo "FAIL: current deleted at exactly the floor version"; exit 1; }
+}
+
+# Empty $2 (should not happen on a normal upgrade, but be defensive): SAFE
+# default is to leave the layout intact, never tear down.
+scenario_upgrade_empty_version_survives() {
+    build_hardened "0.0.5000+gaaaa"
+    "$ROOT/postrm" upgrade ""
+    [ -e "$DROPIN" ] || { echo "FAIL: drop-in removed on empty \$2"; exit 1; }
+    [ -L "$CURRENT" ] || { echo "FAIL: current deleted on empty \$2"; exit 1; }
+}
+
+# Unparsable $2: dpkg --compare-versions errors (status 2); SAFE default is to
+# leave the layout intact (only a confirmed lt comparison tears down).
+scenario_upgrade_unparsable_version_survives() {
+    build_hardened "0.0.5000+gaaaa"
+    "$ROOT/postrm" upgrade "not a version!!"
+    [ -e "$DROPIN" ] || { echo "FAIL: drop-in removed on unparsable \$2"; exit 1; }
+    [ -L "$CURRENT" ] || { echo "FAIL: current deleted on unparsable \$2"; exit 1; }
+}
+
+# Below-floor $2 but NO hardened layout present (legacy/never-seeded host, no
+# versions/current): the AND guard short-circuits -> clean no-op under set -e.
+scenario_downgrade_below_floor_no_layout_noop() {
+    mkdir -p "$STAGED" "$SBIN"
+    for b in $BINS; do echo x > "$STAGED/$b"; ln -sf "$STAGED/$b" "$SBIN/$b"; done
+    "$ROOT/postrm" upgrade "0.0.4000+gbbbb"
+    for b in $BINS; do
+        [ "$(readlink "$SBIN/$b")" = "$STAGED/$b" ] || { echo "FAIL: legacy sbin $b disturbed on below-floor no-layout upgrade"; exit 1; }
     done
 }
 
@@ -207,6 +300,13 @@ run_scenario remove_no_dropin_ok
 run_scenario downgrade_to_prehardened
 run_scenario downgrade_skips_foreign_link
 run_scenario upgrade_to_hardened_noop
+run_scenario upgrade_nonexecable_staged_survives
+run_scenario downgrade_hardened_nonexecable_survives
+run_scenario downgrade_below_floor_execable_tears_down
+run_scenario upgrade_at_floor_survives
+run_scenario upgrade_empty_version_survives
+run_scenario upgrade_unparsable_version_survives
+run_scenario downgrade_below_floor_no_layout_noop
 run_scenario remove_skips_foreign_link
 run_scenario remove_legacy_links
 echo "ALL POSTRM SCENARIOS PASSED"

--- a/test/debian/postrm-test.sh
+++ b/test/debian/postrm-test.sh
@@ -211,10 +211,16 @@ scenario_downgrade_skips_foreign_link() {
 # exec-probe gate tore the runtime down here.
 scenario_upgrade_nonexecable_staged_survives() {
     build_hardened "0.0.5000+gaaaa"
-    # Staged xpfd present but non-executable (exec would ENOEXEC). The gate
-    # never execs it; only $2 matters.
-    : > "$STAGED/xpfd"
-    chmod -x "$STAGED/xpfd"
+    # Staged xpfd present and STILL marked executable, but unrunnable: a file
+    # with a bogus ELF magic + the exec bit set exec()s to ENOEXEC ("Exec
+    # format error") (Copilot). This is the true #1985 failure mode -- a
+    # binary the OLD code probed with `[ -x ] && "$STAGED/xpfd" ...` that
+    # PASSES the -x test but fails to actually run (dynamic-link error /
+    # corruption / arch mismatch). The version-floor gate never execs it;
+    # only $2 matters.
+    printf '\177ELF\001bogus-unrunnable' > "$STAGED/xpfd"
+    chmod +x "$STAGED/xpfd"
+    [ -x "$STAGED/xpfd" ] || { echo "FAIL: precondition: staged xpfd should be -x (executable bit set)"; exit 1; }
     "$ROOT/postrm" upgrade "0.0.5500+gbbbb"
     [ -e "$DROPIN" ] || { echo "FAIL: drop-in removed on upgrade w/ non-execable staged xpfd"; exit 1; }
     [ -e "$(dirname "$DROPIN")" ] || { echo "FAIL: .service.d removed on upgrade w/ non-execable staged xpfd"; exit 1; }
@@ -230,8 +236,11 @@ scenario_upgrade_nonexecable_staged_survives() {
 # pre-#1964 downgrade.
 scenario_downgrade_hardened_nonexecable_survives() {
     build_hardened "0.0.5500+gaaaa"
-    : > "$STAGED/xpfd"
-    chmod -x "$STAGED/xpfd"
+    # Executable bit set but unrunnable (bogus ELF magic -> ENOEXEC), same as
+    # the upgrade scenario (Copilot): exercises the real "executable but
+    # cannot exec" case, not the [ -x ] short-circuit.
+    printf '\177ELF\001bogus-unrunnable' > "$STAGED/xpfd"
+    chmod +x "$STAGED/xpfd"
     "$ROOT/postrm" upgrade "0.0.5000+gbbbb"
     [ -e "$DROPIN" ] || { echo "FAIL: drop-in removed on hardened->hardened downgrade w/ non-execable staged xpfd"; exit 1; }
     [ -L "$CURRENT" ] || { echo "FAIL: current deleted on hardened->hardened downgrade w/ non-execable staged xpfd"; exit 1; }


### PR DESCRIPTION
## Summary

`debian/xpf.postrm` (case `upgrade`) decided whether the package being
installed predated the #1964 hardened versioned-runtime layout by EXECUTING
the staged binary (`"$STAGED/xpfd" seed-runtime --capability-check`). The
`&&` short-circuited to false whenever the staged xpfd failed to exec for ANY
reason (dynamic-link error during unpack, corruption, libc/ABI conflict, arch
mismatch) — not only when it genuinely lacked the subcommand. On a real
UPGRADE with a non-execable staged xpfd, the destructive branch then deleted
`versions/current`, repointed sbin to `staged/`, and removed the
`10-xpf-version.conf` drop-in — breaking the daemon on next boot.

This keys the downgrade decision on the **dpkg-supplied incoming version
(`$2`)** instead, which is exec-free and has no staleness hazard. A new helper
`incoming_predates_hardened_layout()` runs
`dpkg --compare-versions "$2" lt "$HARDENED_LAYOUT_FLOOR"`. The teardown runs
ONLY when `$2` is a confirmed pre-#1964 version (below the floor) AND a
hardened layout is present (`versions/current`); an upgrade or
hardened→hardened downgrade (`$2 >= floor`), and an empty/unparsable `$2`,
leave the layout intact (the safe default, mirroring the sibling preinst
`migrate_legacy_layout` skip-don't-destroy posture; the verify-dataplane cut
gate / refuse-before-STOP guard is the backstop).

## Downgrade-detection mechanism + why (changed from the initial marker pivot)

The converged /research plan pivoted to an exec-free **file marker**
(`staged/.layout-version`). During implementation I found — and Codex r1
(MERGE-NEEDS-MAJOR, citing Debian Policy 6.6) independently confirmed — that a
presence-only marker is **unsound for the downgrade direction**: dpkg removes
a file present ONLY in the old package AFTER the old-postrm runs, so a marker
shipped by the hardened package LINGERS on disk at old-postrm time during a
genuine pre-#1964 downgrade and would mis-signal "incoming is hardened",
skipping the teardown the downgrade needs. I verified this empirically with a
sandboxed dpkg downgrade (`DPKG_ROOT` instdir inspection): on a genuine
downgrade the old hardened `.layout-version` is still present at old-postrm
time.

The sound exec-free signal is the **incoming version**. `dpkg
--compare-versions` is always available in a maintainer script and is immune
to file staleness. `HARDENED_LAYOUT_FLOOR` is `0.0.4104` — the `.deb` version
(`0.0.<commit-count>+g<sha>`, `Makefile` `DEB_VERSION`) of commit `ef9525e70`,
where the versioned-runtime layout first shipped in the debian maintainer
scripts. It is a historical fixed point (the layout already shipped), never
bumped per release. This resolves the plan's "unanchored floor" concern: the
version scheme is monotonic in commit count, so a one-time historical floor is
exact. Empirically validated correct across all three dpkg directions
(upgrade → keep, hardened→hardened downgrade → keep, genuine pre-#1964
downgrade → tear down).

## Plan + adversarial review

Plan doc (converged, engineer-now): `docs/research/1985-postrm-exec-failure-downgrade/plan.md`

- Claude SMR (plan): PLAN READY
- AGY round 1 (plan): PLAN NEEDS-MAJOR (buggy→fixed transition) → folded (documented exposure; sed-patch remedy rejected)
- Codex round 1 (plan): PLAN NEEDS-MAJOR (unanchored floor / unenforceable cooperative marker) → folded (marker pivot)
- **Codex round 1 (code, MERGE-NEEDS-MAJOR)**: caught the marker-staleness hole → implementation pivoted from marker to incoming-version floor (this PR head)

## Files

- `debian/xpf.postrm` — replace the exec probe with `incoming_predates_hardened_layout()` (`dpkg --compare-versions "$2" lt 0.0.4104`)
- `test/debian/postrm-test.sh` — version-keyed fixtures + 7 new regression scenarios (incl. the core bug case, the floor boundary, and empty/unparsable `$2`)
- `cmd/xpfd/seed_runtime.go` — comment-only: `--capability-check` is no longer the postrm gate (retained for the old-postrm buggy→fixed transition)
- `docs/in-place-upgrade.md` — exec-free version-floor contract, why the marker was rejected (Policy 6.6), one-time exposure + recovery note

(No `debian/rules` or drift-canary change — the version-floor approach ships no marker.)

## Test plan

debian maintainer-script (shell) + packaging work. Loss-cluster smoke is NOT
applicable (control-plane / packaging only — no dataplane code path changes).

- [x] `sh -n` / `dash -n` clean on `debian/xpf.postrm`
- [x] `shellcheck -s sh` clean on all three maintainer scripts. The only postrm-test.sh finding (SC1007 line 15) is pre-existing on origin/master (the intentional `CDPATH= cd` idiom)
- [x] `test/debian/postrm-test.sh` — all 16 scenarios pass under **both** `sh` and `dash`
- [x] **Regression guard proven non-tautological**: `upgrade_nonexecable_staged_survives` FAILS against origin/master's old exec-probe postrm (tore the drop-in down — the #1985 bug) and PASSES against the version-floor gate
- [x] **Empirical dpkg validation** (sandboxed instdir): version-floor logic correct in all three directions; marker approach proven holed
- [x] Sibling harnesses `preinst-besteffort-test.sh` + `preinst-migrate-test.sh` still pass
- [x] `go build ./...` clean; full Go suite (`go test ./...`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)