### PR TITLE
#1983: reject non-default --unit for rolling/kernel-drain cluster control

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -5958,3 +5958,21 @@ top.
   on mismatch/empty-readback (a push can silently no-op / the build can be
   stale). Existing `bpfrx-userspace-dp` cleanup + pkill kept.
 - **File(s)**: test/incus/setup.sh
+
+- **Timestamp**: 2026-06-18 (#1983)
+- **Action**: Fix #1983 — `xpfd upgrade --rolling --unit <name>` (and `upgrade
+  kernel drain`/`rejoin`) applied systemd stop/start/flip to the SELECTED
+  unit but always drove the cluster control RPCs (PeerAlive / SyncEstablished /
+  DrainComplete / ForceSecondary / ResetFailover) against the DEFAULT daemon at
+  hard-coded `127.0.0.1:50051`. `NewCLICluster(unit)` silently DISCARDED the
+  unit param, so a non-default `--unit` would cut one daemon while forcing-
+  secondary another — wrong-daemon control.
+- **Change**: `NewCLICluster` now returns `(RollingCluster, error)` and REJECTS
+  any non-default unit at the single construction chokepoint (covers all three
+  callers: RunRolling + the two `upgrade kernel` sub-verbs + any future caller).
+  Default unit (and empty-string normalized to it) is unchanged. Endpoint
+  mapping (#1983 §4.2) is a tracked follow-up. Control-TARGET + CLI validation
+  only — NO failover/VRRP/session-sync runtime change.
+- **File(s)**: pkg/upgrade/cluster_cli.go, pkg/upgrade/rolling.go,
+  cmd/xpfd/upgrade_kernel.go, pkg/upgrade/cluster_cli_test.go,
+  docs/in-place-upgrade.md

--- a/cmd/xpfd/upgrade_kernel.go
+++ b/cmd/xpfd/upgrade_kernel.go
@@ -152,7 +152,11 @@ func runUpgradeKernelSubcommand(args []string) {
 		// gRPC SystemAction) and CONFIRMS the STRONG drain predicate (peer holds
 		// the RGs + sync clean) before reporting success — so the orchestrator
 		// never arms+reboots an undrained primary.
-		cl := upgrade.NewCLICluster(*unit)
+		cl, err := upgrade.NewCLICluster(*unit)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "upgrade kernel drain: %v\n", err)
+			os.Exit(1)
+		}
 		if err := upgrade.DrainAndConfirm(cl, *drainDeadline, *allowMixedHA); err != nil {
 			fmt.Fprintf(os.Stderr, "upgrade kernel drain: %v\n", err)
 			os.Exit(1)
@@ -164,7 +168,11 @@ func runUpgradeKernelSubcommand(args []string) {
 		// the node is back as an eligible cluster member with sync re-established
 		// (so the orchestrator never advances to the peer until this node is
 		// fully rejoined — r1 Codex Critical "never both down").
-		cl := upgrade.NewCLICluster(*unit)
+		cl, err := upgrade.NewCLICluster(*unit)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "upgrade kernel rejoin: %v\n", err)
+			os.Exit(1)
+		}
 		if err := upgrade.RejoinAndConfirm(cl, *drainDeadline); err != nil {
 			fmt.Fprintf(os.Stderr, "upgrade kernel rejoin: %v\n", err)
 			os.Exit(1)

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -284,6 +284,30 @@ both); exactly one node is primary throughout.
    post-promotion check (`make test-failover`) — a passive node
    structurally cannot forward, so it is never "verified while passive".
 
+### `--unit` and the cluster control endpoint (#1983)
+
+`--unit <name>` (default `xpfd`) selects the systemd unit the
+stop/start/flip actions target. The cluster control RPCs the rolling
+driver uses — `PeerAlive` / `SyncEstablished` / `DrainComplete` /
+`ForceSecondary` / `ResetFailover`, and the same RPCs in `xpfd upgrade
+kernel drain`/`rejoin` — all dial a single hard-coded LOCAL endpoint,
+`127.0.0.1:50051`. There is no unit→endpoint mapping yet, so a
+non-default `--unit` would cut ONE daemon (systemd actions honor the
+unit) while driving cluster failover against ANOTHER (the default daemon
+on `127.0.0.1:50051`) — wrong-daemon control.
+
+To keep that contract honest, `upgrade.NewCLICluster` — the single
+construction chokepoint for all three callers — REJECTS any unit other
+than the default (`xpfd`) with a clear error rather than silently
+dialing the default endpoint. `--unit` takes the BARE unit name; the
+systemd layer appends `.service` itself, so `--unit xpfd.service` is a
+non-default spelling and is rejected. Mapping a selected unit to its own
+control endpoint (so an alternate unit can be driven safely, e.g. for
+integration tests, with an explicit `--grpc-addr` override) is a tracked
+follow-up enhancement (#1983 §4.2 / a future `pkg/upgrade/clusterclient`)
+— not implemented here. This is a CLI control-TARGET + validation change
+only; it does not alter VRRP / session-sync / cluster RUNTIME behavior.
+
 ## Config compatibility envelope (D1, `pkg/configstore`)
 
 `active.json` carries a magic header LINE

--- a/pkg/upgrade/cluster_cli.go
+++ b/pkg/upgrade/cluster_cli.go
@@ -57,8 +57,8 @@ type grpcCluster struct {
 // non-default spelling and is rejected.
 func NewCLICluster(unit string) (RollingCluster, error) {
 	if unit != "" && unit != DefaultUnit {
-		return nil, fmt.Errorf("rolling/kernel-drain cluster control for "+
-			"systemd unit %q is unsupported: the control RPCs target the "+
+		return nil, fmt.Errorf("cluster control for systemd unit %q is "+
+			"unsupported: the rolling/kernel upgrade control RPCs target the "+
 			"default daemon at 127.0.0.1:50051, so a non-default --unit would "+
 			"drive cluster failover against the WRONG daemon while systemd "+
 			"actions hit %q (a per-unit control endpoint is not yet mapped; "+

--- a/pkg/upgrade/cluster_cli.go
+++ b/pkg/upgrade/cluster_cli.go
@@ -37,11 +37,34 @@ type grpcCluster struct {
 	dialTimeout time.Duration
 }
 
-// NewCLICluster returns a RollingCluster driving the local node's xpfd via
-// gRPC. The name is retained for the cmd wiring; the implementation is the
-// gRPC client (not the interactive `cli`).
-func NewCLICluster(unit string) RollingCluster {
-	return &grpcCluster{addr: "127.0.0.1:50051", dialTimeout: 5 * time.Second}
+// NewCLICluster returns a RollingCluster driving the SELECTED systemd unit's
+// xpfd via gRPC. The name is retained for the cmd wiring; the implementation
+// is the gRPC client (not the interactive `cli`).
+//
+// The cluster control RPCs (PeerAlive / SyncEstablished / DrainComplete /
+// ForceSecondary / ResetFailover) target a single hard-coded local endpoint
+// (127.0.0.1:50051). The systemd action side (stop/start/flip) honors the
+// --unit selection, so a non-default --unit would cut one daemon while the
+// drain predicate and ForceSecondary control ANOTHER — wrong-daemon control
+// (#1983). Until a unit->endpoint mapping exists, only the default unit is
+// supported; any other unit is REJECTED here at the single construction
+// chokepoint so cluster RPCs can never silently target the wrong daemon
+// while systemd actions hit a different one. Centralizing the guard in the
+// constructor covers ALL callers (RunRolling + `xpfd upgrade kernel
+// drain`/`rejoin`, which also pass --unit through) and any future caller
+// automatically. --unit takes the BARE unit name (e.g. "xpfd"); the systemd
+// layer appends ".service" itself (system_linux.go), so "xpfd.service" is a
+// non-default spelling and is rejected.
+func NewCLICluster(unit string) (RollingCluster, error) {
+	if unit != "" && unit != DefaultUnit {
+		return nil, fmt.Errorf("rolling/kernel-drain cluster control for "+
+			"systemd unit %q is unsupported: the control RPCs target the "+
+			"default daemon at 127.0.0.1:50051, so a non-default --unit would "+
+			"drive cluster failover against the WRONG daemon while systemd "+
+			"actions hit %q (a per-unit control endpoint is not yet mapped; "+
+			"use the default unit %q)", unit, unit, DefaultUnit)
+	}
+	return &grpcCluster{addr: "127.0.0.1:50051", dialTimeout: 5 * time.Second}, nil
 }
 
 func (g *grpcCluster) dial() (pb.BpfrxServiceClient, func(), error) {

--- a/pkg/upgrade/cluster_cli_test.go
+++ b/pkg/upgrade/cluster_cli_test.go
@@ -362,3 +362,68 @@ func TestStatusEmitsProtocolLines(t *testing.T) {
 		t.Fatalf("FormatStatus lacks 'HA protocol version:' the parser keys on:\n%s", st)
 	}
 }
+
+// TestNewCLICluster_RejectsNonDefaultUnit is the #1983 regression: the
+// rolling/kernel-drain cluster control RPCs target a hard-coded
+// 127.0.0.1:50051, but the systemd action side honors --unit. A non-default
+// --unit therefore would cut one daemon while driving cluster failover
+// against ANOTHER (wrong-daemon control). NewCLICluster is the single
+// construction chokepoint for all three callers (RunRolling + `upgrade
+// kernel drain`/`rejoin`), so the guard lives here. The seam used by the
+// rolling tests (runRollingWith) injects a fake cluster and bypasses
+// construction, so this MUST be exercised at the constructor directly
+// (Codex plan fold).
+func TestNewCLICluster_RejectsNonDefaultUnit(t *testing.T) {
+	// A non-default unit must be REJECTED — no cluster, an error, and the
+	// error must NOT silently hand back a client pointed at the default
+	// endpoint. This is the core invariant the bug violated.
+	for _, unit := range []string{
+		"xpfd-test",    // an alternate unit an integration test would pass
+		"xpfd.service", // --unit takes the BARE name; ".service" is non-default
+		"xpfd-staging",
+	} {
+		cl, err := NewCLICluster(unit)
+		if err == nil {
+			t.Fatalf("NewCLICluster(%q): want error, got nil (would silently "+
+				"control the default daemon while systemd hits %q)", unit, unit)
+		}
+		if cl != nil {
+			t.Fatalf("NewCLICluster(%q): want nil cluster on reject, got %#v "+
+				"(a non-nil client could dial 127.0.0.1:50051)", unit, cl)
+		}
+		// The error must name the offending unit so the operator knows what
+		// was rejected and why.
+		if !strings.Contains(err.Error(), unit) {
+			t.Errorf("NewCLICluster(%q) error must name the unit; got: %v", unit, err)
+		}
+		if !strings.Contains(err.Error(), "127.0.0.1:50051") {
+			t.Errorf("NewCLICluster(%q) error must explain the hard-coded "+
+				"control endpoint; got: %v", unit, err)
+		}
+	}
+}
+
+// TestNewCLICluster_AcceptsDefaultUnit confirms the default unit (and the
+// empty-string shorthand the cmd layer normalizes to DefaultUnit) still
+// constructs a working client pointed at the local control endpoint —
+// default-unit rolling behavior is unchanged (#1983 invariant 8).
+func TestNewCLICluster_AcceptsDefaultUnit(t *testing.T) {
+	for _, unit := range []string{"", DefaultUnit} {
+		cl, err := NewCLICluster(unit)
+		if err != nil {
+			t.Fatalf("NewCLICluster(%q): want a client, got error: %v", unit, err)
+		}
+		if cl == nil {
+			t.Fatalf("NewCLICluster(%q): want a non-nil client, got nil", unit)
+		}
+		// The accepted client targets the local control endpoint. Inspect the
+		// concrete type's addr WITHOUT dialing (no daemon runs under test).
+		g, ok := cl.(*grpcCluster)
+		if !ok {
+			t.Fatalf("NewCLICluster(%q): want *grpcCluster, got %T", unit, cl)
+		}
+		if g.addr != "127.0.0.1:50051" {
+			t.Errorf("NewCLICluster(%q): addr = %q, want 127.0.0.1:50051", unit, g.addr)
+		}
+	}
+}

--- a/pkg/upgrade/rolling.go
+++ b/pkg/upgrade/rolling.go
@@ -93,7 +93,10 @@ func RunRolling(r *Runner, cfg Config) error {
 	}
 	defer func() { _ = h.Release() }()
 
-	cl := NewCLICluster(cfg.Unit)
+	cl, err := NewCLICluster(cfg.Unit)
+	if err != nil {
+		return fmt.Errorf("upgrade --rolling: %w", err)
+	}
 	return runRollingWith(r, cl, RollingConfig{})
 }
 


### PR DESCRIPTION
## Summary

`xpfd upgrade --rolling --unit <name>` (and `xpfd upgrade kernel drain`/`rejoin`) applied the systemd stop/start/flip actions to the SELECTED unit, but the cluster control RPCs (`PeerAlive` / `SyncEstablished` / `DrainComplete` / `ForceSecondary` / `ResetFailover`) always dialed the hard-coded default daemon at `127.0.0.1:50051`. `NewCLICluster(unit)` silently discarded its `unit` parameter, so a non-default `--unit` would force-secondary / evaluate the drain predicate against the WRONG daemon while cutting another (wrong-daemon control).

This ships the converged-plan MVP: `NewCLICluster` now returns `(RollingCluster, error)` and **rejects any non-default unit at the single construction chokepoint** (covers `RunRolling` + both `kernel` sub-verbs + any future caller). The default unit (and the empty string normalized to it) is unchanged. The unit->endpoint mapping (#1983 §4.2 / a future `pkg/upgrade/clusterclient`) is a tracked follow-up.

## Failover-runtime assessment

**Control-TARGET selection + CLI validation only.** This changes which daemon the upgrade CLI dials and adds an input guard. It does NOT touch VRRP / session-sync / cluster failover RUNTIME behavior. The default-unit rolling path is byte-for-byte unchanged, so `make test-failover` is not gated by this change.

## Plan + adversarial review

Plan: docs/research/1983-rolling-unit-endpoint/plan.md — converged on the issue (engineer-now):
- Claude SMR: PLAN READY (4.1 reject; 4.2 endpoint mapping follow-up)
- AGY: PLAN NEEDS-MAJOR -> folded (guard moved INTO `NewCLICluster` so `kernel drain`/`rejoin` are covered, not just `RunRolling`)
- Codex: PLAN YES (constructor chokepoint is the right place; test must hit `NewCLICluster` directly; `--unit` takes the bare name)

## Test plan

- [x] `go build ./pkg/upgrade/... ./cmd/xpfd/...` clean
- [x] `go vet` clean
- [x] `go test ./pkg/upgrade/...` pass, incl. the two new constructor tests
  - `TestNewCLICluster_RejectsNonDefaultUnit` — `xpfd-test`, `xpfd.service`, `xpfd-staging` all return `(nil, error)`; never a client pointed at `127.0.0.1:50051`
  - `TestNewCLICluster_AcceptsDefaultUnit` — `""` and `xpfd` return a client targeting `127.0.0.1:50051`, inspected without dialing
- [x] Full Go suite (`go test ./...`) in the worktree
- [ ] Loss-cluster smoke: **NOT required** — this is a control-plane CLI target-selection + validation change with no dataplane or forwarding-path effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)