### PR TITLE
#1981: close dpkg-unpack vs operator-cut staged-source race (immutable versioned staging)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -5993,3 +5993,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Add #1981 cut-level regression tests (torn-source pin + counter-factual, no-source refusal, same-version recopy/refuse-on-live B-P3b, GC-vs-resume protection, aborted-unpack no-wedge, resume keeps pinned gen).
 - **File(s)**: pkg/upgrade/stagedgen_cut_test.go
+- **Timestamp**: 2026-06-18
+- **Action**: docs/in-place-upgrade.md — replace the dpkg-vs-operator caveat with the CLOSED-race contract (immutable versioned staging section: publish, pinned read, refuse-no-source, GC N=2, B-P3b OPT1, crash-safety, deferred-publish recovery, disk budget, one-time bootstrap caveat).
+- **File(s)**: docs/in-place-upgrade.md

--- a/_Log.md
+++ b/_Log.md
@@ -6023,3 +6023,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Address Codex r5 minor (comment-only): GenID doc comment no longer says "monotonic" — wall-clock UnixNano, GC ordering hint, correctness independent of genid order.
 - **File(s)**: pkg/upgrade/stagedgen/stagedgen.go
+- **Timestamp**: 2026-06-18
+- **Action**: Soften GC "chronological" comments to "usually chronological (wall-clock; NTP step can reorder, correctness independent)" for consistency with the GenID comment — comment-only.
+- **File(s)**: pkg/upgrade/stagedgen/stagedgen.go

--- a/_Log.md
+++ b/_Log.md
@@ -5996,3 +5996,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: docs/in-place-upgrade.md — replace the dpkg-vs-operator caveat with the CLOSED-race contract (immutable versioned staging section: publish, pinned read, refuse-no-source, GC N=2, B-P3b OPT1, crash-safety, deferred-publish recovery, disk budget, one-time bootstrap caveat).
 - **File(s)**: docs/in-place-upgrade.md
+- **Timestamp**: 2026-06-18
+- **Action**: SMR self-review fix: resolveSource must read the version-comparison source from current-gen (latest published), not the pinned old generation, so a new-version republish supersedes an abandoned cut. Added superseded-resume regression test.
+- **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/stagedgen_cut_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -5990,3 +5990,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: debian postinst publishes the staged generation after unpack before the cut (gates the cut on publish success/deferral); postrm removes staged-gen/ on purge + pre-B downgrade. rules unchanged (dpkg owns only staged/).
 - **File(s)**: debian/xpf.postinst, debian/xpf.postrm
+- **Timestamp**: 2026-06-18
+- **Action**: Add #1981 cut-level regression tests (torn-source pin + counter-factual, no-source refusal, same-version recopy/refuse-on-live B-P3b, GC-vs-resume protection, aborted-unpack no-wedge, resume keeps pinned gen).
+- **File(s)**: pkg/upgrade/stagedgen_cut_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -6014,3 +6014,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Address Codex r3 + Copilot 3rd review (GC current-gen protection): GC now resolves current-gen EXPLICITLY and protects it additively (never reaped even if not newest/mtime-skewed); orders by genid NAME (mtime-independent, deterministic); SKIPS non-ValidGenID stray dirs (no slot consumption, no deletion). Added 2 GC tests.
 - **File(s)**: pkg/upgrade/stagedgen/stagedgen.go, pkg/upgrade/stagedgen/stagedgen_test.go
+- **Timestamp**: 2026-06-18
+- **Action**: Address Codex r4 MERGE-NEEDS-MINOR (doc-only): in-place-upgrade.md no longer says current-gen "counts toward the window" (now additive) and no longer calls genid "monotonic" (wall-clock UnixNano, treated as a GC ordering hint; correctness never depends on genid order).
+- **File(s)**: docs/in-place-upgrade.md

--- a/_Log.md
+++ b/_Log.md
@@ -6017,3 +6017,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Address Codex r4 MERGE-NEEDS-MINOR (doc-only): in-place-upgrade.md no longer says current-gen "counts toward the window" (now additive) and no longer calls genid "monotonic" (wall-clock UnixNano, treated as a GC ordering hint; correctness never depends on genid order).
 - **File(s)**: docs/in-place-upgrade.md
+- **Timestamp**: 2026-06-18
+- **Action**: Address Copilot r4 (2 code findings): INIT B-P3b refusal uses authoritative `prev` (drops the error-discarding mustReadCurrentVersion which could skip the guard on a transient unreadable current → wedge); removed now-dead mustReadCurrentVersion. ResolveCurrent rejects a current-gen symlink target with path components (../<genid> escape) before base-naming. Added path-escape test.
+- **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/runner.go, pkg/upgrade/stagedgen/stagedgen.go, pkg/upgrade/stagedgen/stagedgen_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -5976,3 +5976,8 @@ top.
 - **File(s)**: pkg/upgrade/cluster_cli.go, pkg/upgrade/rolling.go,
   cmd/xpfd/upgrade_kernel.go, pkg/upgrade/cluster_cli_test.go,
   docs/in-place-upgrade.md
+
+## 2026-06-18 — #1981 Option B immutable versioned staging
+- **Timestamp**: 2026-06-18
+- **Action**: Add pkg/upgrade/stagedgen — Publish/ResolveCurrent/GC/RemoveAll for staged-gen/<genid> + current-gen, durable copy + atomic symlink. Foundation for #1981 Option B.
+- **File(s)**: pkg/upgrade/stagedgen/stagedgen.go, pkg/upgrade/stagedgen/fsutil.go, pkg/upgrade/stagedgen/stagedgen_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -6020,3 +6020,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Address Copilot r4 (2 code findings): INIT B-P3b refusal uses authoritative `prev` (drops the error-discarding mustReadCurrentVersion which could skip the guard on a transient unreadable current → wedge); removed now-dead mustReadCurrentVersion. ResolveCurrent rejects a current-gen symlink target with path components (../<genid> escape) before base-naming. Added path-escape test.
 - **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/runner.go, pkg/upgrade/stagedgen/stagedgen.go, pkg/upgrade/stagedgen/stagedgen_test.go
+- **Timestamp**: 2026-06-18
+- **Action**: Address Codex r5 minor (comment-only): GenID doc comment no longer says "monotonic" — wall-clock UnixNano, GC ordering hint, correctness independent of genid order.
+- **File(s)**: pkg/upgrade/stagedgen/stagedgen.go

--- a/_Log.md
+++ b/_Log.md
@@ -5981,3 +5981,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Add pkg/upgrade/stagedgen — Publish/ResolveCurrent/GC/RemoveAll for staged-gen/<genid> + current-gen, durable copy + atomic symlink. Foundation for #1981 Option B.
 - **File(s)**: pkg/upgrade/stagedgen/stagedgen.go, pkg/upgrade/stagedgen/fsutil.go, pkg/upgrade/stagedgen/stagedgen_test.go
+- **Timestamp**: 2026-06-18
+- **Action**: Wire stagedgen into the cut: Journal.SourceGeneration, resolveSource (pin genid at INIT, refuse if no published gen), copyStaged reads pinned generation + B-P3b OPT1 (.srcgen stamp, genid-aware skip, refuse-or-guarded-replace), GC staged-gen protecting journal gen, verify-fail cleanup re-resolves current-gen.
+- **File(s)**: pkg/upgrade/state.go, pkg/upgrade/runner.go, pkg/upgrade/cutover.go, pkg/upgrade/flip.go, pkg/upgrade/runner_test.go, pkg/upgrade/verify_cleanup_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -6005,3 +6005,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Address Copilot review (6 findings): split %w-with-nil Stat errors (resolveSource + copyStaged); fail-safe refuse on unreadable `current` in copyStaged replacement; GC protected (journal) generations are now ADDITIVE (don't consume the retention window) — current-gen counts in the window; seed runs staged-gen GC after publish. Added GC-window test.
 - **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/stagedgen/stagedgen.go, pkg/upgrade/stagedgen/stagedgen_test.go, pkg/upgrade/runtime/seed.go
+- **Timestamp**: 2026-06-18
+- **Action**: Address Codex r6 (1 MAJOR + minors): INIT pre-PREFLIGHT refusal now covers the UNSTAMPED-live same-version case (existingGen != srcGen, gated on dir existence) so it no longer falls to the post-PREFLIGHT backstop and re-wedges; doc updated for the #1981 staged-gen floor + additive-GC; postrm-test.sh covers the staged-gen floor (purge + pre-#1981 downgrade removes, at-floor/empty keeps).
+- **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/stagedgen_cut_test.go, docs/in-place-upgrade.md, test/debian/postrm-test.sh

--- a/_Log.md
+++ b/_Log.md
@@ -5999,3 +5999,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: SMR self-review fix: resolveSource must read the version-comparison source from current-gen (latest published), not the pinned old generation, so a new-version republish supersedes an abandoned cut. Added superseded-resume regression test.
 - **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/stagedgen_cut_test.go
+- **Timestamp**: 2026-06-18
+- **Action**: Address Codex r5 MERGE-NEEDS-MAJOR (5 findings): (1) unstamped STALE version dir now guarded-replaced not skipped; (2) live/rollback B-P3b refusal moved to INIT pre-PREFLIGHT (no journal/dbsnap/wedge); (3) publish-generation GC protects the on-disk journal's pinned generation (new ReadJournalSourceGeneration); (4) pre-#1981 pre-copy resume re-pinned to current-gen + preflight sizes the pinned source; (5) postrm staged-gen teardown gets its own #1981 floor (0.0.4200). Added 4 regression tests.
+- **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/runner.go, cmd/xpfd/publish_generation.go, debian/xpf.postrm, pkg/upgrade/stagedgen_cut_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -5984,3 +5984,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Wire stagedgen into the cut: Journal.SourceGeneration, resolveSource (pin genid at INIT, refuse if no published gen), copyStaged reads pinned generation + B-P3b OPT1 (.srcgen stamp, genid-aware skip, refuse-or-guarded-replace), GC staged-gen protecting journal gen, verify-fail cleanup re-resolves current-gen.
 - **File(s)**: pkg/upgrade/state.go, pkg/upgrade/runner.go, pkg/upgrade/cutover.go, pkg/upgrade/flip.go, pkg/upgrade/runner_test.go, pkg/upgrade/verify_cleanup_test.go
+- **Timestamp**: 2026-06-18
+- **Action**: Add `xpfd publish-generation` verb (lock-taking, GC; deferred-publish recovery) + register in main. Seed publishes initial generation on first install. Wire --staged-gen-dir flags through upgrade/seed-runtime.
+- **File(s)**: cmd/xpfd/publish_generation.go, cmd/xpfd/main.go, cmd/xpfd/upgrade.go, cmd/xpfd/seed_runtime.go, pkg/upgrade/runtime/seed.go, pkg/upgrade/runtime/seed_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -6011,3 +6011,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Address Copilot 2nd-review new findings: ReadJournalSourceGeneration now returns ("",nil) on a malformed journal (matches the best-effort docstring); stagedgen GC sort adds a genid name tie-breaker for deterministic retention on coarse-mtime ties.
 - **File(s)**: pkg/upgrade/runner.go, pkg/upgrade/stagedgen/stagedgen.go
+- **Timestamp**: 2026-06-18
+- **Action**: Address Codex r3 + Copilot 3rd review (GC current-gen protection): GC now resolves current-gen EXPLICITLY and protects it additively (never reaped even if not newest/mtime-skewed); orders by genid NAME (mtime-independent, deterministic); SKIPS non-ValidGenID stray dirs (no slot consumption, no deletion). Added 2 GC tests.
+- **File(s)**: pkg/upgrade/stagedgen/stagedgen.go, pkg/upgrade/stagedgen/stagedgen_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -6002,3 +6002,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Address Codex r5 MERGE-NEEDS-MAJOR (5 findings): (1) unstamped STALE version dir now guarded-replaced not skipped; (2) live/rollback B-P3b refusal moved to INIT pre-PREFLIGHT (no journal/dbsnap/wedge); (3) publish-generation GC protects the on-disk journal's pinned generation (new ReadJournalSourceGeneration); (4) pre-#1981 pre-copy resume re-pinned to current-gen + preflight sizes the pinned source; (5) postrm staged-gen teardown gets its own #1981 floor (0.0.4200). Added 4 regression tests.
 - **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/runner.go, cmd/xpfd/publish_generation.go, debian/xpf.postrm, pkg/upgrade/stagedgen_cut_test.go
+- **Timestamp**: 2026-06-18
+- **Action**: Address Copilot review (6 findings): split %w-with-nil Stat errors (resolveSource + copyStaged); fail-safe refuse on unreadable `current` in copyStaged replacement; GC protected (journal) generations are now ADDITIVE (don't consume the retention window) — current-gen counts in the window; seed runs staged-gen GC after publish. Added GC-window test.
+- **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/stagedgen/stagedgen.go, pkg/upgrade/stagedgen/stagedgen_test.go, pkg/upgrade/runtime/seed.go

--- a/_Log.md
+++ b/_Log.md
@@ -5987,3 +5987,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Add `xpfd publish-generation` verb (lock-taking, GC; deferred-publish recovery) + register in main. Seed publishes initial generation on first install. Wire --staged-gen-dir flags through upgrade/seed-runtime.
 - **File(s)**: cmd/xpfd/publish_generation.go, cmd/xpfd/main.go, cmd/xpfd/upgrade.go, cmd/xpfd/seed_runtime.go, pkg/upgrade/runtime/seed.go, pkg/upgrade/runtime/seed_test.go
+- **Timestamp**: 2026-06-18
+- **Action**: debian postinst publishes the staged generation after unpack before the cut (gates the cut on publish success/deferral); postrm removes staged-gen/ on purge + pre-B downgrade. rules unchanged (dpkg owns only staged/).
+- **File(s)**: debian/xpf.postinst, debian/xpf.postrm

--- a/_Log.md
+++ b/_Log.md
@@ -6008,3 +6008,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Address Codex r6 (1 MAJOR + minors): INIT pre-PREFLIGHT refusal now covers the UNSTAMPED-live same-version case (existingGen != srcGen, gated on dir existence) so it no longer falls to the post-PREFLIGHT backstop and re-wedges; doc updated for the #1981 staged-gen floor + additive-GC; postrm-test.sh covers the staged-gen floor (purge + pre-#1981 downgrade removes, at-floor/empty keeps).
 - **File(s)**: pkg/upgrade/cutover.go, pkg/upgrade/stagedgen_cut_test.go, docs/in-place-upgrade.md, test/debian/postrm-test.sh
+- **Timestamp**: 2026-06-18
+- **Action**: Address Copilot 2nd-review new findings: ReadJournalSourceGeneration now returns ("",nil) on a malformed journal (matches the best-effort docstring); stagedgen GC sort adds a genid name tie-breaker for deterministic retention on coarse-mtime ties.
+- **File(s)**: pkg/upgrade/runner.go, pkg/upgrade/stagedgen/stagedgen.go

--- a/cmd/xpfd/main.go
+++ b/cmd/xpfd/main.go
@@ -108,6 +108,18 @@ func main() {
 		return
 	}
 
+	// #1981 Option B: `xpfd publish-generation` copies the dpkg-staged binary
+	// set into an immutable staged-gen/<genid>/ and repoints current-gen, so a
+	// later cut reads a whole, single-generation source dpkg is not rewriting
+	// (closing the dpkg-unpack vs operator-cut torn-read race). The postinst
+	// runs it after a complete unpack before the cut; an operator runs it as
+	// the deferred-publish recovery verb (when the postinst deferred the
+	// publish because the upgrade lock was busy) before `xpfd upgrade`.
+	if len(os.Args) > 1 && os.Args[1] == "publish-generation" {
+		runPublishGenerationSubcommand(os.Args[2:])
+		return
+	}
+
 	// #1864 deploy-time pre-flight: run the kernel BPF verifier against
 	// the shim object EMBEDDED IN THIS BINARY without touching any
 	// production state (anonymous maps, no pins, no attach, nothing

--- a/cmd/xpfd/publish_generation.go
+++ b/cmd/xpfd/publish_generation.go
@@ -36,6 +36,7 @@ func runPublishGenerationSubcommand(args []string) {
 	fs := flag.NewFlagSet("publish-generation", flag.ContinueOnError)
 	stagedDir := fs.String("staged-dir", upgrade.DefaultStagedDir, "dpkg-staged binary set dir")
 	stagedGenDir := fs.String("staged-gen-dir", upgrade.DefaultStagedGenDir, "staged-generation root")
+	journalPath := fs.String("journal", upgrade.DefaultJournalPath, "upgrade journal path (its pinned generation is protected from GC)")
 	if err := fs.Parse(args); err != nil {
 		os.Exit(1)
 	}
@@ -67,10 +68,21 @@ func runPublishGenerationSubcommand(args []string) {
 		fmt.Fprintf(os.Stderr, "publish-generation: %v\n", err)
 		os.Exit(1)
 	}
-	// GC the staged-generation root (current + 1 prior). No active cut runs
-	// concurrently (we hold the lock), so no generation needs journal
-	// protection here; the cut's own GC protects its in-flight source.
-	if gcErr := cfg.GC(nil); gcErr != nil {
+	// GC the staged-generation root (current + 1 prior), PROTECTING any
+	// generation a crashed/resumable cut's journal still pins. The host-wide
+	// lock serializes us against a RUNNING cut, but a CRASHED cut leaves a
+	// durable journal with the lock released — so the GC must read the journal
+	// and protect its SourceGeneration, else a resume hard-fails on a GC'd
+	// source (and a crash-after-STOP would be left daemon-down with no
+	// recoverable cut). Best-effort: a journal read error does not block the
+	// publish (the cut's own GC also protects its source).
+	protected := map[string]bool{}
+	if pinned, jerr := upgrade.ReadJournalSourceGeneration(*journalPath); jerr != nil {
+		fmt.Fprintf(os.Stderr, "publish-generation: WARN read journal for GC protection: %v\n", jerr)
+	} else if pinned != "" {
+		protected[pinned] = true
+	}
+	if gcErr := cfg.GC(protected); gcErr != nil {
 		fmt.Fprintf(os.Stderr, "publish-generation: WARN gc: %v\n", gcErr)
 	}
 	fmt.Printf("publish-generation complete (generation %s)\n", genid)

--- a/cmd/xpfd/publish_generation.go
+++ b/cmd/xpfd/publish_generation.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/psaab/xpf/pkg/upgrade"
+	"github.com/psaab/xpf/pkg/upgrade/lock"
+	"github.com/psaab/xpf/pkg/upgrade/stagedgen"
+)
+
+// runPublishGenerationSubcommand implements `xpfd publish-generation` — the
+// #1981 Option B publish step: copy the dpkg-staged binary set into a fresh,
+// immutable staged-gen/<genid>/ and atomically repoint current-gen at it, so a
+// later cut reads a whole, single-generation source that dpkg is NOT rewriting.
+//
+// It is invoked:
+//   - by the .deb postinst (configure) AFTER a complete unpack, BEFORE the
+//     auto-cut, so every cut sees a fresh generation;
+//   - by an operator as the DEFERRED-PUBLISH RECOVERY verb (plan B-P2b): if the
+//     postinst deferred the publish because the host-wide upgrade lock was busy
+//     (another upgrade in progress), the new binaries are staged but
+//     unpublished and a bare `xpfd upgrade` would re-read the OLD current-gen
+//     and no-op. The operator runs `xpfd publish-generation` (which publishes
+//     the now-complete staged set) and THEN `xpfd upgrade`. (`dpkg-reconfigure
+//     xpf` is the equivalent — it re-runs the postinst publish + cut.)
+//
+// It takes the host-wide upgrade lock so it is mutually exclusive with an
+// operator cut (and so its GC cannot delete a generation a cut is reading). A
+// busy lock is reported and the publish is skipped (the prior generation stays
+// the cut source — never a torn read).
+//
+// Exit codes: 0 success, 1 error, 2 lock busy (publish deferred).
+func runPublishGenerationSubcommand(args []string) {
+	fs := flag.NewFlagSet("publish-generation", flag.ContinueOnError)
+	stagedDir := fs.String("staged-dir", upgrade.DefaultStagedDir, "dpkg-staged binary set dir")
+	stagedGenDir := fs.String("staged-gen-dir", upgrade.DefaultStagedGenDir, "staged-generation root")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+
+	// Take the host-wide upgrade lock so the publish (and its GC) is mutually
+	// exclusive with an operator cut. A busy lock means another upgrade
+	// operation owns it: defer (exit 2), do NOT publish — the prior generation
+	// remains a valid cut source.
+	h, lerr := lock.Acquire("publish-generation", "")
+	if lerr != nil {
+		if lock.IsBusy(lerr) {
+			fmt.Fprintf(os.Stderr,
+				"publish-generation: another upgrade holds the lock; deferred. "+
+					"Re-run after it completes: %v\n", lerr)
+			os.Exit(2)
+		}
+		fmt.Fprintf(os.Stderr, "publish-generation: acquire upgrade lock: %v\n", lerr)
+		os.Exit(1)
+	}
+	defer func() { _ = h.Release() }()
+
+	cfg := stagedgen.Config{
+		StagedDir: *stagedDir,
+		Dir:       *stagedGenDir,
+		Logf:      func(format string, a ...any) { fmt.Printf(format+"\n", a...) },
+	}
+	genid, err := cfg.Publish()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "publish-generation: %v\n", err)
+		os.Exit(1)
+	}
+	// GC the staged-generation root (current + 1 prior). No active cut runs
+	// concurrently (we hold the lock), so no generation needs journal
+	// protection here; the cut's own GC protects its in-flight source.
+	if gcErr := cfg.GC(nil); gcErr != nil {
+		fmt.Fprintf(os.Stderr, "publish-generation: WARN gc: %v\n", gcErr)
+	}
+	fmt.Printf("publish-generation complete (generation %s)\n", genid)
+}

--- a/cmd/xpfd/seed_runtime.go
+++ b/cmd/xpfd/seed_runtime.go
@@ -22,6 +22,8 @@ func runSeedRuntimeSubcommand(args []string) {
 	fs := flag.NewFlagSet("seed-runtime", flag.ContinueOnError)
 	stagedDir := fs.String("staged-dir", upgrade.DefaultStagedDir, "dpkg-staged binary set dir")
 	versionsDir := fs.String("versions-dir", upgrade.DefaultVersionsDir, "runtime versioned dir")
+	stagedGenDir := fs.String("staged-gen-dir", upgrade.DefaultStagedGenDir,
+		"staged-generation root to publish the initial generation into (#1981)")
 	sbinDir := fs.String("sbin-dir", upgrade.DefaultSbinDir, "operator-tool symlink dir")
 	// --capability-check is a pure, side-effect-free probe: a hardened xpfd
 	// exits 0 without touching the filesystem; a pre-#1964 binary has no
@@ -50,10 +52,11 @@ func runSeedRuntimeSubcommand(args []string) {
 	}
 
 	if err := upruntime.Seed(upruntime.Config{
-		StagedDir:   *stagedDir,
-		VersionsDir: *versionsDir,
-		SbinDir:     *sbinDir,
-		Logf:        func(format string, a ...any) { fmt.Printf(format+"\n", a...) },
+		StagedDir:    *stagedDir,
+		VersionsDir:  *versionsDir,
+		StagedGenDir: *stagedGenDir,
+		SbinDir:      *sbinDir,
+		Logf:         func(format string, a ...any) { fmt.Printf(format+"\n", a...) },
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "seed-runtime: %v\n", err)
 		os.Exit(1)

--- a/cmd/xpfd/upgrade.go
+++ b/cmd/xpfd/upgrade.go
@@ -32,6 +32,8 @@ func runUpgradeSubcommand(args []string) {
 			"cluster keeps forwarding (one node down at a time)")
 	stagedDir := fs.String("staged-dir", upgrade.DefaultStagedDir, "dpkg-staged binary set dir")
 	versionsDir := fs.String("versions-dir", upgrade.DefaultVersionsDir, "runtime versioned dir")
+	stagedGenDir := fs.String("staged-gen-dir", upgrade.DefaultStagedGenDir,
+		"staged-generation root the cut copies from (#1981 Option B)")
 	sbinDir := fs.String("sbin-dir", upgrade.DefaultSbinDir, "operator-tool symlink dir")
 	configDBDir := fs.String("configdb-dir", upgrade.DefaultConfigDBDir, "config DB dir (for rollback snapshot)")
 	journalPath := fs.String("journal", upgrade.DefaultJournalPath, "crash-safe state journal path")
@@ -45,6 +47,7 @@ func runUpgradeSubcommand(args []string) {
 	cfg := upgrade.Config{
 		StagedDir:           *stagedDir,
 		VersionsDir:         *versionsDir,
+		StagedGenDir:        *stagedGenDir,
 		SbinDir:             *sbinDir,
 		ConfigDBDir:         *configDBDir,
 		JournalPath:         *journalPath,

--- a/debian/xpf.postinst
+++ b/debian/xpf.postinst
@@ -89,6 +89,41 @@ case "$1" in
                 fi
             done
 
+            # === #1981 Option B: PUBLISH the staged generation BEFORE the cut.
+            #
+            # dpkg has finished unpacking staged/ (Debian Policy 6.7: postinst
+            # configure runs after a COMPLETE unpack, while the dpkg frontend
+            # lock serializes apt transactions), so the staged set is now whole.
+            # Publish it into an immutable staged-gen/<genid>/ and repoint
+            # current-gen so the cut reads a single-generation source dpkg is
+            # NOT rewriting — closing the dpkg-unpack vs operator-cut torn-read
+            # race for ALL FOUR managed binaries. `xpfd publish-generation`
+            # takes the host-wide upgrade lock itself; exit 0 = published, exit
+            # 2 = lock busy (deferred — another upgrade owns the lock), other =
+            # error. A failed/deferred publish must NOT run the auto-cut (the
+            # prior generation stays the source; the operator re-publishes and
+            # cuts). A publish failure does NOT fail configure (a non-zero
+            # postinst half-configures dpkg, worse than a deferred cut).
+            PUBLISH_OK=0
+            if "$STAGED/xpfd" publish-generation; then
+                PUBLISH_OK=1
+            else
+                rc=$?
+                if [ "$rc" = "2" ]; then
+                    # Lock busy: defer. Drop the same marker the cut-contention
+                    # branch drops so recovery is recorded consistently.
+                    mkdir -p /run/xpf
+                    : > /run/xpf/upgrade-deferred 2>/dev/null || true
+                    echo "xpf: staged-generation publish deferred (another upgrade" \
+                         "holds the lock) — staged only; after it completes run:" \
+                         "xpfd publish-generation && xpfd upgrade" >&2
+                else
+                    echo "xpf: WARNING staged-generation publish failed (rc=$rc) —" \
+                         "no new generation published; the cut will read the prior" \
+                         "generation or refuse. Re-run: xpfd publish-generation" >&2
+                fi
+            fi
+
             # === increment-B cut-over (HA-mode contract, plan §6.3) ===
             #
             # dpkg has refreshed the staging path. Whether we now CUT OVER
@@ -114,7 +149,14 @@ case "$1" in
             #    over a blind binary swap. The operator can suppress the
             #    auto-cut with XPF_NO_POSTINST_CUT=1 and run `xpfd upgrade`
             #    manually.
-            if [ -f /etc/xpf/node-id ]; then
+            if [ "$PUBLISH_OK" != "1" ]; then
+                # The staged generation was not published (failed or deferred,
+                # logged above). Do NOT cut: a cut now would read the PRIOR
+                # generation (not this upgrade) or refuse. The operator
+                # re-publishes + cuts once the blocker clears.
+                echo "xpf: staged generation not published — skipping the cut;" \
+                     "recover with: xpfd publish-generation && xpfd upgrade" >&2
+            elif [ -f /etc/xpf/node-id ]; then
                 echo "xpf: clustered node (node-id present) — staged only;" \
                      "cut over with: xpfd upgrade --rolling" >&2
             elif [ "${XPF_NO_POSTINST_CUT:-}" = "1" ]; then

--- a/debian/xpf.postrm
+++ b/debian/xpf.postrm
@@ -61,6 +61,11 @@ STAGED=/usr/local/share/xpf/staged
 SBIN=/usr/local/sbin
 VERSIONS=/var/lib/xpf/versions
 CURRENT="$VERSIONS/current"
+# #1981 Option B staged-generation root: maintainer-script-managed runtime
+# state (a sibling of versions/), NEVER a dpkg payload file — so dpkg never
+# removes it. We must remove it on purge (else an orphan dir survives, a Policy
+# violation) and on a pre-B downgrade (the old postrm never learns about it).
+STAGED_GEN=/var/lib/xpf/staged-gen
 DROPIN=/etc/systemd/system/xpfd.service.d/10-xpf-version.conf
 # #1985 hardened-layout version floor. This is the first package whose postrm
 # manages the #1964 versioned-runtime layout (versions/current + the unit
@@ -179,9 +184,12 @@ case "$1" in
         # leaves a broken unit. Safe if absent (legacy/never-seeded hosts).
         remove_runtime_dropin
         if [ "$1" = "purge" ]; then
-            # versions/ is package-derived (copied binaries), not operator
-            # config — remove the whole tree on purge.
+            # versions/ and staged-gen/ are package-derived (copied binaries),
+            # not operator config — remove the whole trees on purge. staged-gen/
+            # (#1981) is a never-recorded runtime dir, so dpkg's own cleanup
+            # never touches it; an orphan would survive purge (Policy 6.8).
             rm -rf "$VERSIONS"
+            rm -rf "$STAGED_GEN"
         fi
         ;;
     upgrade)
@@ -209,6 +217,12 @@ case "$1" in
             #    repoints sbin to a stale version dir (AGY-r4-1). Leave the
             #    versions/<ver> dirs (harmless; a reinstall's GC reaps them).
             rm -f "$CURRENT"
+            # 2b. remove the #1981 staged-generation tree (B-P6): the
+            #     downgraded pre-B package's postrm never learns about
+            #     staged-gen/, so it would leak permanently. The pre-B cut reads
+            #     live staged/ (its only source), so removing staged-gen/ does
+            #     not strip a source the downgraded package can use.
+            rm -rf "$STAGED_GEN"
             # 3. remove the runtime unit drop-in + empty .service.d dir, then
             #    boot-guarded daemon-reload (shared helper, #1967). Done LAST
             #    so the reload reflects the repointed sbin + removed drop-in

--- a/debian/xpf.postrm
+++ b/debian/xpf.postrm
@@ -84,6 +84,18 @@ DROPIN=/etc/systemd/system/xpfd.service.d/10-xpf-version.conf
 # (the contract already shipped), not a value that drifts per build — do
 # not bump it with new releases.
 HARDENED_LAYOUT_FLOOR="0.0.4104"
+# #1981 staged-generation floor. staged-gen/ (immutable versioned staging) is
+# written ONLY by a #1981+ package; a pre-#1981 package — whether pre- OR
+# post-#1964 — never manages it, so on a downgrade BELOW this floor we must
+# remove staged-gen/ (else it leaks permanently: the downgraded postrm never
+# learns about it). This is a SEPARATE, HIGHER floor than the #1964 layout
+# floor above, so a post-#1964-but-pre-#1981 downgrade still tears staged-gen/
+# down even though it leaves the #1964 versioned-runtime layout intact. The
+# value is a conservative LOWER BOUND: the last pre-#1981 master commit count
+# was 4199, so 0.0.4200 classifies every pre-#1981 build (<= 4199) as below the
+# floor while the first #1981 package (commit count well above 4200) sorts at
+# or above it. HISTORICAL fixed point — do not bump per build.
+STAGED_GEN_FLOOR="0.0.4200"
 # Managed-binary set (#1982). The single source of truth is the Go manifest
 # pkg/upgrade/manifest; this literal is kept self-contained on purpose (no
 # build-time sed into the tracked checkout). The drift canary
@@ -176,6 +188,17 @@ incoming_predates_hardened_layout() {
     dpkg --compare-versions "$_v" lt "$HARDENED_LAYOUT_FLOOR" 2>/dev/null || return 1
 }
 
+# incoming_predates_staged_gen VERSION reports (exit 0) whether the INCOMING
+# package version predates the #1981 staged-generation floor — a downgrade to a
+# package that does not manage staged-gen/, so we must remove it (else it leaks
+# permanently). Same exec-free, staleness-free, safe-on-ambiguity posture as
+# incoming_predates_hardened_layout, against the higher STAGED_GEN_FLOOR.
+incoming_predates_staged_gen() {
+    _v="$1"
+    [ -n "$_v" ] || return 1
+    dpkg --compare-versions "$_v" lt "$STAGED_GEN_FLOOR" 2>/dev/null || return 1
+}
+
 case "$1" in
     remove|purge)
         remove_owned_sbin_links
@@ -217,17 +240,22 @@ case "$1" in
             #    repoints sbin to a stale version dir (AGY-r4-1). Leave the
             #    versions/<ver> dirs (harmless; a reinstall's GC reaps them).
             rm -f "$CURRENT"
-            # 2b. remove the #1981 staged-generation tree (B-P6): the
-            #     downgraded pre-B package's postrm never learns about
-            #     staged-gen/, so it would leak permanently. The pre-B cut reads
-            #     live staged/ (its only source), so removing staged-gen/ does
-            #     not strip a source the downgraded package can use.
-            rm -rf "$STAGED_GEN"
             # 3. remove the runtime unit drop-in + empty .service.d dir, then
             #    boot-guarded daemon-reload (shared helper, #1967). Done LAST
             #    so the reload reflects the repointed sbin + removed drop-in
             #    together.
             remove_runtime_dropin
+        fi
+        # #1981 staged-generation teardown (B-P6) — a SEPARATE, HIGHER floor
+        # than the #1964 layout teardown above (Codex r5-#5): staged-gen/ is
+        # written only by a #1981+ package, so on a downgrade to ANY pre-#1981
+        # package — including a post-#1964-but-pre-#1981 one that keeps the
+        # versioned-runtime layout intact above — we remove staged-gen/ (else
+        # the downgraded postrm never learns about it and it leaks
+        # permanently). The pre-B cut reads live staged/ (its only source), so
+        # removing staged-gen/ strips nothing the downgraded package uses.
+        if incoming_predates_staged_gen "$2"; then
+            rm -rf "$STAGED_GEN"
         fi
         ;;
     failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -407,9 +407,15 @@ window for ALL FOUR managed binaries:
   transactions) runs `xpfd publish-generation`: it copies the staged set
   into an immutable `staged-gen/<genid>/` (via `.partial` + atomic rename
   + dir-fsync) and atomically repoints a `staged-gen/current-gen` symlink
-  (temp-symlink + rename, never `ln -sf`). `<genid>` is a monotonic
-  nanosecond timestamp + random suffix, so a same-version reinstall gets
-  a distinct generation.
+  (temp-symlink + rename, never `ln -sf`). `<genid>` is a zero-padded
+  nanosecond wall-clock timestamp (`time.Now().UnixNano()`) + random
+  suffix, so a same-version reinstall gets a distinct generation. The
+  timestamp is NOT strictly monotonic (an NTP step can move the wall
+  clock backward), so it is treated only as a generation key + a stable
+  GC ordering hint; correctness never depends on `genid` ordering — GC
+  protects `current-gen` and journal-referenced generations explicitly,
+  so a backward clock step at most affects which NON-protected, non-live
+  generation is reaped first, never the active source.
 - **The cut reads the PINNED generation, never live `staged/`.** `Run`
   resolves `current-gen` ONCE at INIT and records the genid in
   `Journal.SourceGeneration`; `copyStaged` copies from
@@ -434,11 +440,16 @@ window for ALL FOUR managed binaries:
   cut reads live `staged/` as its only source, so removing `staged-gen/`
   strips nothing it can use.
 - **GC retention N=2** (current + 1 prior — a superseded generation is
-  never read again, so keeping 3 is pure disk waste). GC keeps the newest
-  N generations (current-gen counts toward the window as the newest) PLUS,
-  ADDITIVELY, any genid an active/resumable journal references (the
-  GC-vs-resume race — a journal-pinned OLD generation never evicts an
-  in-window generation), and sweeps `.partial` orphans.
+  never read again, so keeping 3 is pure disk waste). GC orders valid
+  generation dirs by `genid` NAME (the zero-padded timestamp prefix makes
+  name order chronological and mtime-independent) and keeps the newest N
+  PLUS, ADDITIVELY, the explicitly-resolved `current-gen` generation AND
+  any genid an active/resumable journal references (the GC-vs-resume race
+  — a journal-pinned OLD generation never evicts an in-window generation,
+  and `current-gen` is never reaped even if it is not the newest by name
+  or mtimes are perturbed). It ignores (never counts, never deletes) any
+  directory whose name is not a valid `genid`, and sweeps `.partial`
+  orphans.
 - **Same-version replacement (B-P3b OPT1).** `versions/<ver>` carries a
   `.srcgen` stamp; the copy-skip is generation-aware. A same-version
   re-stage with NEW bytes (a new generation) RE-COPIES a stale, non-live

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -382,17 +382,94 @@ target. Read-only status (`xpfd upgrade kernel status`) stays lock-free.
 - **Lock ordering vs the `/tmp/xpf-cluster.lock` deploy lock (#1875):**
   the cluster/deploy lock is taken OUTSIDE, the host upgrade lock INSIDE.
   No deadlock — the two never nest in the opposite order.
-- **dpkg-vs-operator staged-source race:** `debian/xpf.preinst` runs
-  BEFORE unpack and `flock -n /run/xpf/upgrade.lock`-gates the package
-  operation, failing apt loudly (non-zero, system untouched) if an
-  operator upgrade already holds the lock. This is a fail-loud gate, not
-  full unpack serialization: a preinst fd dies at preinst exit, so the
-  lock is not held DURING dpkg's unpack. The torn-binary backstop is the
-  `verify-dataplane` kernel gate the cut runs against the COPIED binary
-  before `StopUnit`. The postinst standalone path re-checks the lock and,
-  on the narrow TOCTOU residual, drops `/run/xpf/upgrade-deferred`, logs
-  loudly, and exits 0 (a non-zero postinst leaves dpkg half-configured).
-  Operator guidance: do not run `xpfd upgrade` during `apt upgrade`.
+- **dpkg-vs-operator staged-source race — CLOSED by immutable versioned
+  staging (#1981 Option B).** The cut no longer reads the dpkg-owned
+  `staged/` path directly. `debian/xpf.preinst` still `flock`-gates the
+  package op (fail-loud if an operator cut already holds the lock), but
+  that was only a partial backstop — the preinst fd dies at preinst exit
+  so the lock is NOT held during dpkg's per-file unpack, and a cut
+  landing inside the unpack window could read a half-unpacked `staged/`
+  that mixes binaries from two dpkg generations. #1981 closes it by
+  construction; see "Immutable versioned staging" below.
+
+## Immutable versioned staging (#1981 Option B)
+
+dpkg unpacks the managed binaries into `staged/` one file at a time, so
+across an `apt upgrade` unpack window `staged/` holds a MIX of old and
+new binaries. A cut that copied directly from `staged/` could publish a
+`versions/<ver>` mixing two dpkg generations — a torn set whose
+`verify-dataplane` gate (xpfd+shim only) cannot detect a mismatched
+`xpf-userspace-dp` (a lockstep-cut dataplane binary). #1981 closes that
+window for ALL FOUR managed binaries:
+
+- **Publish after a complete unpack.** `postinst configure` (which runs
+  AFTER a complete unpack while the dpkg frontend lock serializes apt
+  transactions) runs `xpfd publish-generation`: it copies the staged set
+  into an immutable `staged-gen/<genid>/` (via `.partial` + atomic rename
+  + dir-fsync) and atomically repoints a `staged-gen/current-gen` symlink
+  (temp-symlink + rename, never `ln -sf`). `<genid>` is a monotonic
+  nanosecond timestamp + random suffix, so a same-version reinstall gets
+  a distinct generation.
+- **The cut reads the PINNED generation, never live `staged/`.** `Run`
+  resolves `current-gen` ONCE at INIT and records the genid in
+  `Journal.SourceGeneration`; `copyStaged` copies from
+  `staged-gen/<SourceGeneration>/` — the resolved DIRECTORY, never
+  re-reading the symlink — so a concurrent publish that advances
+  `current-gen` cannot redirect an in-flight cut. The source is a
+  generation dpkg is NOT touching, so it is internally a single
+  generation by construction.
+- **No published generation ⇒ refuse pre-PREFLIGHT.** A fresh cut with
+  `current-gen` absent refuses at INIT with NO journal written and NO DB
+  snapshot taken (the daemon is untouched). It never reads a torn
+  `staged/`.
+- **`staged-gen/` is maintainer-script-managed runtime state** under
+  `/var/lib/xpf` (a sibling of `versions/`), NEVER a dpkg payload file —
+  so dpkg never writes or removes it on unpack. The postrm removes it on
+  `purge` and on a pre-#1964 downgrade (the old package never learns
+  about it).
+- **GC retention N=2** (current + 1 prior — a superseded generation is
+  never read again, so keeping 3 is pure disk waste). GC protects
+  `current-gen` AND any genid an active/resumable journal references (the
+  GC-vs-resume race), and sweeps `.partial` orphans.
+- **Same-version replacement (B-P3b OPT1).** `versions/<ver>` carries a
+  `.srcgen` stamp; the copy-skip is generation-aware. A same-version
+  re-stage with NEW bytes (a new generation) RE-COPIES a stale, non-live
+  `versions/<ver>` (reusing the proven guarded-delete), or REFUSES
+  pre-PREFLIGHT if `versions/<ver>` is the live `current`/rollback target
+  (cannot safely mutate a live version dir mid-cut). Recovery on a
+  refusal: re-stage under a distinct version tag, or `dpkg-reconfigure
+  xpf` to realign the generation.
+- **Crash-safety.** A crash before the `staged-gen/<genid>` rename leaves
+  a `.partial` (pre-swept on the next publish); a crash after the dir
+  rename but before the `current-gen` repoint leaves a
+  complete-but-unreferenced generation (the PRIOR `current-gen` stays
+  valid; a re-publish is idempotent). An aborted/failed unpack publishes
+  NO new generation, so the prior generation stays the cut source — there
+  is NO permanent-wedge class.
+- **Deferred-publish recovery.** If the publish defers because the
+  host-wide upgrade lock is busy (another upgrade in progress), the
+  postinst drops `/run/xpf/upgrade-deferred`, skips the cut, and the
+  operator recovers with `xpfd publish-generation && xpfd upgrade`
+  (`dpkg-reconfigure xpf` is equivalent). A bare `xpfd upgrade` alone
+  would re-read the OLD `current-gen` and no-op, so the recovery MUST
+  publish first.
+- **Disk budget.** Each binary set is ~50-70 MB (dominated by `xpfd`
+  embedding the kernel-verified shim + `xpf-userspace-dp`). Steady-state
+  copies: `staged/` (1) + `staged-gen/` current+1 (2) + `versions/`
+  current+N=3 (4) ≈ **7 copies ≈ 350-490 MB**. A constrained appliance
+  `/var` MUST size for this; the publish's own GC + the `versions/` GC
+  bound it.
+- **One-time first-deploy bootstrap caveat (intrinsic).** #1981 only
+  protects cuts performed by a B-aware `xpfd`. During the very upgrade
+  that INSTALLS the first B-aware binary, the operator-visible
+  `xpfd upgrade` is still the OLD (pre-B) binary, which reads live
+  `staged/` — the fix cannot run before it is installed. That single hop
+  is covered by the existing backstops (the #1965 preinst lock gate +
+  the `verify-dataplane` gate against the copied xpfd + "do not run
+  `xpfd upgrade` during `apt upgrade`"). From the first B-aware version
+  onward the window is closed by construction. This is a documented,
+  bounded, one-time exposure, NOT a residual hole in the steady-state
+  guarantee.
 
 ## Peer-takeover-readiness is best-effort; DrainComplete is authoritative
 

--- a/docs/in-place-upgrade.md
+++ b/docs/in-place-upgrade.md
@@ -425,12 +425,20 @@ window for ALL FOUR managed binaries:
 - **`staged-gen/` is maintainer-script-managed runtime state** under
   `/var/lib/xpf` (a sibling of `versions/`), NEVER a dpkg payload file —
   so dpkg never writes or removes it on unpack. The postrm removes it on
-  `purge` and on a pre-#1964 downgrade (the old package never learns
-  about it).
+  `purge` and on a downgrade to ANY package below the #1981
+  staged-generation floor (`STAGED_GEN_FLOOR`, a SEPARATE, HIGHER floor
+  than the #1964 layout floor — so a post-#1964-but-pre-#1981 downgrade
+  still removes `staged-gen/` even though it keeps the #1964
+  versioned-runtime layout intact). The downgraded package never learns
+  about `staged-gen/`, so leaving it would leak permanently; the pre-B
+  cut reads live `staged/` as its only source, so removing `staged-gen/`
+  strips nothing it can use.
 - **GC retention N=2** (current + 1 prior — a superseded generation is
-  never read again, so keeping 3 is pure disk waste). GC protects
-  `current-gen` AND any genid an active/resumable journal references (the
-  GC-vs-resume race), and sweeps `.partial` orphans.
+  never read again, so keeping 3 is pure disk waste). GC keeps the newest
+  N generations (current-gen counts toward the window as the newest) PLUS,
+  ADDITIVELY, any genid an active/resumable journal references (the
+  GC-vs-resume race — a journal-pinned OLD generation never evicts an
+  in-window generation), and sweeps `.partial` orphans.
 - **Same-version replacement (B-P3b OPT1).** `versions/<ver>` carries a
   `.srcgen` stamp; the copy-skip is generation-aware. A same-version
   re-stage with NEW bytes (a new generation) RE-COPIES a stale, non-live

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -211,6 +211,21 @@ func (r *Runner) Run(opts Options) (err error) {
 		return srcErr
 	}
 
+	// Re-pin a pre-#1981 legacy resume that has NOT yet copied (Codex r5-#4):
+	// a journal at STAGED/PREFLIGHT with an empty SourceGeneration was written
+	// by an old (pre-B) binary. If a generation is now published, adopt it as
+	// the pinned source (and persist) so copyStaged reads the pinned generation
+	// rather than falling back to live staged/. A State >= COPIED legacy
+	// journal already copied from live staged/, so it keeps the legacy source
+	// (its bytes are already on disk); only the not-yet-copied case is re-pinned.
+	if srcGen != "" && j.SourceGeneration == "" && j.State.atLeast(StateStaged) && !j.State.atLeast(StateCopied) {
+		r.logf("upgrade: re-pinning a pre-#1981 resume (state %s) to published generation %s", j.State, srcGen)
+		j.SourceGeneration = srcGen
+		if serr := r.saveJournal(j); serr != nil {
+			return fmt.Errorf("persist re-pinned source generation: %w", serr)
+		}
+	}
+
 	// Identify the staged version from the RESOLVED source (the pinned
 	// generation, never live staged/). It keys versions/<ver> et al. on a
 	// fresh cut, so validate it as a safe single path segment BEFORE any path
@@ -323,6 +338,29 @@ func (r *Runner) Run(opts Options) (err error) {
 				"first cut; refusing the %s cut because a flip/start failure would leave "+
 				"the daemon offline with no recovery target. Seed the versioned runtime "+
 				"(xpfd seed-runtime), then re-run the upgrade", stagedVer)
+		}
+		// REFUSE-AT-INIT (#1981 B-P3b OPT1, Codex r5-#2): a same-version cut
+		// whose target version dir already exists, is the LIVE current or the
+		// rollback target, and carries a DIFFERENT source generation than this
+		// cut's source cannot be safely replaced (RemoveAll-ing a live/rollback
+		// dir mid-cut violates #1967). Refuse HERE, pre-PREFLIGHT, so no journal
+		// is persisted and no .dbsnap is taken — a re-run then starts fresh and
+		// re-resolves the source rather than RESUMING a journal that re-refuses
+		// forever. Only fires when the existing dir is STAMPED with a different
+		// generation; an unstamped (pre-#1981) or same-generation dir is handled
+		// in copyStaged.
+		if srcGen != "" {
+			existingGen, gerr := r.readSrcGen(stagedVer)
+			if gerr == nil && existingGen != "" && existingGen != srcGen &&
+				(stagedVer == prev || stagedVer == r.mustReadCurrentVersion()) {
+				if cerr := r.clearJournal(); cerr != nil {
+					r.logf("upgrade: WARN clear stale journal on live-dir-replace refuse: %v", cerr)
+				}
+				return fmt.Errorf("refuse-before-PREFLIGHT: cannot replace the live/rollback "+
+					"version dir %s (its bytes come from source generation %q but this cut pins "+
+					"%q); re-stage under a DISTINCT version tag, or `dpkg-reconfigure xpf` to "+
+					"realign the generation", r.versionDir(stagedVer), existingGen, srcGen)
+			}
 		}
 		j.TargetVersion = stagedVer
 		j.PreviousVersion = prev
@@ -553,7 +591,10 @@ func (r *Runner) preflight(j *Journal) error {
 	}
 	r.removeAllPartials()
 
-	stagedSize, err := dirSize(r.cfg.StagedDir)
+	// Size the ACTUAL copy source (the pinned generation, #1981), not live
+	// staged/ — the cut copies the pinned generation into versions/<ver>
+	// (Codex r5-#4b).
+	stagedSize, err := dirSize(r.sourceDir(j))
 	if err != nil {
 		return fmt.Errorf("size staged: %w", err)
 	}
@@ -624,16 +665,34 @@ func (r *Runner) preflight(j *Journal) error {
 // documented pre-B legacy/bootstrap fallback (copy from live staged/).
 //
 // Same-version destination identity + SAFE replacement (B-P3b OPT1): the
-// version-keyed skip is GENERATION-AWARE. An existing versions/<ver> whose
-// .srcgen matches this cut's SourceGeneration is a true resume — skip the copy.
-// An existing versions/<ver> from a DIFFERENT generation (a same-version
-// re-stage with new bytes) must be REPLACED: if it is the live `current` or
-// the rollback (`PreviousVersion`) target, REFUSE (cannot safely mutate a live
-// version dir mid-cut, #1967); otherwise it is a stale non-live dir and is
-// safe to RemoveAll + recopy via the proven guarded-delete in
-// cleanupFailedVerifyCopy. A pre-#1981 versions/<ver> has no .srcgen at all; we
-// treat an absent stamp as a true resume of the legacy copy (do not destroy a
-// live dir on a layout that predates the stamp).
+// version-keyed skip is GENERATION-AWARE.
+//
+//   - An existing versions/<ver> whose .srcgen MATCHES this cut's source
+//     generation (or both are empty on the legacy same-cut resume) is a true
+//     resume — skip the copy.
+//   - Otherwise the existing dir's bytes may NOT match this cut's source —
+//     whether it carries a different .srcgen stamp OR no stamp at all (a stale
+//     pre-#1981 dir, or a legacy cut over a now-stamped dir). It must be
+//     REPLACED. If it is the live `current` or rollback (PreviousVersion)
+//     target, REFUSE (cannot safely RemoveAll a live version dir mid-cut,
+//     #1967) — though the primary refusal for a stamped-different live dir is
+//     pre-PREFLIGHT at INIT; this is the backstop for a resume and for the
+//     unstamped-live case. Otherwise it is a stale non-live dir and is safe to
+//     RemoveAll + recopy via the proven guarded-delete shape (Codex r5-#1: an
+//     unstamped STALE dir must be replaced, NOT reused — a pre-fix torn
+//     versions/<ver> must not be committed under a fresh generation).
+//
+// sourceDir returns the directory the cut copies FROM for journal j: the
+// pinned staged-gen/<SourceGeneration>/ (#1981 Option B) or, on the pre-B
+// legacy path (empty SourceGeneration), live staged/. It does NOT validate
+// existence; copyStaged stats it.
+func (r *Runner) sourceDir(j *Journal) string {
+	if j.SourceGeneration != "" {
+		return r.stagedGenConfig().GenDir(j.SourceGeneration)
+	}
+	return r.cfg.StagedDir
+}
+
 func (r *Runner) copyStaged(j *Journal) error {
 	ver := j.TargetVersion
 	dst := r.versionDir(ver)
@@ -658,35 +717,28 @@ func (r *Runner) copyStaged(j *Journal) error {
 		if gerr != nil {
 			return fmt.Errorf("read source-generation stamp of %s: %w", dst, gerr)
 		}
-		switch {
-		case existingGen == j.SourceGeneration:
+		if existingGen == j.SourceGeneration {
 			// True resume (same generation, or both empty on the legacy path):
 			// the copy already landed; skip.
 			r.logf("upgrade: version dir %s already present (same source generation); skipping copy", dst)
 			return nil
-		case existingGen == "":
-			// A pre-#1981 version dir with no stamp. Treat as a legacy resume —
-			// do NOT destroy what may be a live dir on a layout predating the
-			// stamp. Skip the copy; verify still gates the bytes.
-			r.logf("upgrade: version dir %s present without a source-generation stamp "+
-				"(pre-#1981 layout); skipping copy", dst)
-			return nil
-		default:
-			// A same-version re-stage with DIFFERENT bytes (generation differs).
-			// Replace it ONLY if it is a stale, non-live dir; otherwise refuse.
-			cur, _ := r.readCurrentVersion()
-			if ver == cur || ver == j.PreviousVersion {
-				return fmt.Errorf("refuse-before-PREFLIGHT: cannot replace the live/rollback "+
-					"version dir %s (its bytes come from source generation %q but this cut pins "+
-					"%q); re-stage under a DISTINCT version tag, or `dpkg-reconfigure xpf` to "+
-					"realign the generation", dst, existingGen, j.SourceGeneration)
-			}
-			// Stale non-live: reuse the proven guarded delete, then recopy.
-			r.logf("upgrade: replacing stale version dir %s (source generation %q -> %q)",
-				dst, existingGen, j.SourceGeneration)
-			if rerr := r.removeStaleVersionDir(ver); rerr != nil {
-				return rerr
-			}
+		}
+		// The existing dir does NOT match this cut's source (different stamp, or
+		// an unstamped pre-#1981 dir vs a stamped cut, or vice-versa). Replace
+		// it — unless it is live/rollback, in which case refuse (backstop; the
+		// stamped-different live case is already refused at INIT).
+		cur, _ := r.readCurrentVersion()
+		if ver == cur || ver == j.PreviousVersion {
+			return fmt.Errorf("refuse: cannot replace the live/rollback version dir %s "+
+				"(its bytes come from source generation %q but this cut pins %q); re-stage "+
+				"under a DISTINCT version tag, or `dpkg-reconfigure xpf` to realign the "+
+				"generation", dst, existingGen, j.SourceGeneration)
+		}
+		// Stale non-live: reuse the proven guarded delete, then recopy.
+		r.logf("upgrade: replacing stale version dir %s (source generation %q -> %q)",
+			dst, existingGen, j.SourceGeneration)
+		if rerr := r.removeStaleVersionDir(ver); rerr != nil {
+			return rerr
 		}
 	}
 

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/fsatomic"
 	"github.com/psaab/xpf/pkg/upgrade/manifest"
+	"github.com/psaab/xpf/pkg/upgrade/stagedgen"
 )
 
 // Options modify a single Run.
@@ -50,6 +51,55 @@ type Options struct {
 	// the deliberate first-cut path (e.g. seeding failed and the operator
 	// chose to proceed), never by the routine postinst/operator cut.
 	AllowNoRollbackFirstCut bool
+}
+
+// errNoSourceGeneration is the INIT sentinel for "no published staged
+// generation to cut from" (#1981 Option B). The caller refuses pre-PREFLIGHT
+// with no journal written and no DB snapshot taken.
+var errNoSourceGeneration = fmt.Errorf("no published staged generation")
+
+// resolveSource determines the directory the cut copies FROM and the source
+// generation it pins (#1981 Option B). Resolution:
+//
+//   - A RESUMING B-aware journal (SourceGeneration != ""): use that pinned
+//     generation directory (validated; must exist) so the resume continues
+//     against its original source even if a concurrent publish advanced
+//     current-gen. Returns (genid, genDir, nil).
+//   - A RESUMING pre-#1981 journal that already COPIED from live staged/
+//     (State >= COPIED, empty SourceGeneration): back-compat — keep reading
+//     live staged/ so the runner never blocks recovery of an in-flight pre-B
+//     cut (plan §10 AGY r4). Returns ("", StagedDir, nil).
+//   - A FRESH cut (State below STAGED, or a recovery just reset j to INIT):
+//     resolve staged-gen/current-gen. Present -> (genid, genDir, nil); absent
+//     -> errNoSourceGeneration (the caller refuses pre-PREFLIGHT).
+func (r *Runner) resolveSource(j *Journal) (genid, dir string, err error) {
+	sg := r.stagedGenConfig()
+	if j.SourceGeneration != "" {
+		if !stagedgen.ValidGenID(j.SourceGeneration) {
+			return "", "", fmt.Errorf("journal source generation %q is not a safe path segment",
+				j.SourceGeneration)
+		}
+		d := sg.GenDir(j.SourceGeneration)
+		if fi, serr := os.Stat(d); serr != nil || !fi.IsDir() {
+			return "", "", fmt.Errorf("pinned source generation %s missing at %s: %w "+
+				"(re-run after re-publishing the staged set)", j.SourceGeneration, d, serr)
+		}
+		return j.SourceGeneration, d, nil
+	}
+	// Empty SourceGeneration on an already-copied journal is the pre-#1981
+	// legacy in-flight case: read from live staged/ (the original source).
+	if j.State.atLeast(StateCopied) {
+		return "", r.cfg.StagedDir, nil
+	}
+	// Fresh cut: resolve the published current generation.
+	cur, rerr := sg.ResolveCurrent()
+	if rerr != nil {
+		return "", "", fmt.Errorf("resolve staged generation: %w", rerr)
+	}
+	if cur == "" {
+		return "", "", errNoSourceGeneration
+	}
+	return cur, sg.GenDir(cur), nil
 }
 
 // Run executes (or resumes) the cut-over to the staged version. It is
@@ -109,11 +159,42 @@ func (r *Runner) Run(opts Options) (err error) {
 		return nil
 	}
 
-	// Identify the staged version. It keys versions/<ver> et al. on a fresh
-	// cut, so validate it as a safe single path segment BEFORE any path use
-	// (#1964 C1) — `git describe`-derived versions can carry a `/` (a
+	// Resolve the SOURCE the cut copies from (#1981 Option B). A B-aware cut
+	// reads a PINNED, immutable staged-gen/<genid>/ that dpkg is NOT rewriting,
+	// never live staged/. resolveSource returns:
+	//   - a non-empty srcGen + its directory when current-gen is present (a
+	//     fresh cut) or the journal already pinned a generation (a resume);
+	//   - ("", StagedDir, nil) for a pre-#1981 legacy in-flight journal that
+	//     was already copied from live staged/ — back-compat so a B-aware
+	//     runner never blocks recovery of an old cut (plan §10 AGY r4);
+	//   - noSrcGen for a fresh cut with NO published generation — the caller
+	//     refuses pre-PREFLIGHT (no journal, no DB snapshot).
+	srcGen, srcDir, srcErr := r.resolveSource(j)
+	if srcErr == errNoSourceGeneration {
+		// REFUSE-AT-INIT, no source generation: a fresh cut cannot proceed
+		// without a published staged-gen/current-gen. Refuse BEFORE any journal
+		// write or DB snapshot (Codex r1-#3 closed by construction). Clear any
+		// lingering on-disk journal from a just-completed resume-vs-fresh
+		// recovery so a re-run starts clean.
+		if cerr := r.clearJournal(); cerr != nil {
+			r.logf("upgrade: WARN clear stale journal on no-source refuse: %v", cerr)
+		}
+		return fmt.Errorf("refuse-before-PREFLIGHT: no published staged generation "+
+			"(%s/%s is absent); the package operation has not finished publishing the "+
+			"staged set, or the runtime needs seeding. Let `apt`/`dpkg` finish, run "+
+			"`xpfd publish-generation` (or `dpkg-reconfigure xpf`), then re-run the "+
+			"upgrade", r.cfg.StagedGenDir, stagedgen.CurrentGenLink)
+	}
+	if srcErr != nil {
+		return srcErr
+	}
+
+	// Identify the staged version from the RESOLVED source (the pinned
+	// generation, never live staged/). It keys versions/<ver> et al. on a
+	// fresh cut, so validate it as a safe single path segment BEFORE any path
+	// use (#1964 C1) — `git describe`-derived versions can carry a `/` (a
 	// branch-named tag), which would otherwise escape VersionsDir.
-	stagedXpfd := filepath.Join(r.cfg.StagedDir, "xpfd")
+	stagedXpfd := filepath.Join(srcDir, "xpfd")
 	stagedVer, err := r.cfg.Sys.BinaryVersion(stagedXpfd)
 	if err != nil {
 		return fmt.Errorf("read staged version (%s): %w", stagedXpfd, err)
@@ -224,6 +305,14 @@ func (r *Runner) Run(opts Options) (err error) {
 		j.TargetVersion = stagedVer
 		j.PreviousVersion = prev
 		j.StartedAtUnixNano = r.cfg.Sys.Now().UnixNano()
+		// Pin the source generation NOW (#1981 Option B, B-P3): the cut copies
+		// from staged-gen/<SourceGeneration>/ — the resolved DIRECTORY, never
+		// re-reading current-gen — so a concurrent publish that advances
+		// current-gen cannot redirect this in-flight cut. srcGen is "" only on
+		// the pre-#1981 legacy-staged fallback (no published generation exists
+		// yet on a freshly-seeded host whose seed predates B); in that case the
+		// copy reads live staged/, the documented one-hop bootstrap window.
+		j.SourceGeneration = srcGen
 		// Record the sanctioned-first-cut decision NOW (#1964 mechanism C,
 		// Codex r1): a no-previous cut is sanctioned only when the caller
 		// passes AllowNoRollbackFirstCut. Persisting it means a crash-resume
@@ -502,25 +591,88 @@ func (r *Runner) preflight(j *Journal) error {
 	return nil
 }
 
-// copyStaged copies staged/ -> .<ver>.partial/ then atomic-renames to
-// versions/<ver>/. Pure: leaves live untouched.
+// copyStaged copies the PINNED source generation
+// (staged-gen/<SourceGeneration>/, never live staged/) -> .<ver>.partial/ then
+// atomic-renames it to versions/<ver>/ and stamps the source generation into
+// versions/<ver>/.srcgen. Pure: leaves live untouched.
+//
+// Source resolution (#1981 Option B): the cut reads from the generation pinned
+// at INIT — a directory dpkg is NOT rewriting — so the copy is internally a
+// single generation by construction. j.SourceGeneration == "" is the
+// documented pre-B legacy/bootstrap fallback (copy from live staged/).
+//
+// Same-version destination identity + SAFE replacement (B-P3b OPT1): the
+// version-keyed skip is GENERATION-AWARE. An existing versions/<ver> whose
+// .srcgen matches this cut's SourceGeneration is a true resume — skip the copy.
+// An existing versions/<ver> from a DIFFERENT generation (a same-version
+// re-stage with new bytes) must be REPLACED: if it is the live `current` or
+// the rollback (`PreviousVersion`) target, REFUSE (cannot safely mutate a live
+// version dir mid-cut, #1967); otherwise it is a stale non-live dir and is
+// safe to RemoveAll + recopy via the proven guarded-delete in
+// cleanupFailedVerifyCopy. A pre-#1981 versions/<ver> has no .srcgen at all; we
+// treat an absent stamp as a true resume of the legacy copy (do not destroy a
+// live dir on a layout that predates the stamp).
 func (r *Runner) copyStaged(j *Journal) error {
 	ver := j.TargetVersion
 	dst := r.versionDir(ver)
 	partial := r.partialDir(ver)
 
-	// If the final dir already exists (resume after a crash post-rename),
-	// nothing to copy.
+	srcDir := r.cfg.StagedDir
+	if j.SourceGeneration != "" {
+		if !stagedgen.ValidGenID(j.SourceGeneration) {
+			return fmt.Errorf("journal source generation %q is not a safe path segment",
+				j.SourceGeneration)
+		}
+		srcDir = r.stagedGenConfig().GenDir(j.SourceGeneration)
+		if fi, serr := os.Stat(srcDir); serr != nil || !fi.IsDir() {
+			return fmt.Errorf("pinned source generation %s missing at %s: %w "+
+				"(it may have been GC'd — re-run after re-publishing)", j.SourceGeneration, srcDir, serr)
+		}
+	}
+
+	// Resume / same-version replacement decision (B-P3b OPT1).
 	if _, err := os.Stat(dst); err == nil {
-		r.logf("upgrade: version dir %s already present; skipping copy", dst)
-		return nil
+		existingGen, gerr := r.readSrcGen(ver)
+		if gerr != nil {
+			return fmt.Errorf("read source-generation stamp of %s: %w", dst, gerr)
+		}
+		switch {
+		case existingGen == j.SourceGeneration:
+			// True resume (same generation, or both empty on the legacy path):
+			// the copy already landed; skip.
+			r.logf("upgrade: version dir %s already present (same source generation); skipping copy", dst)
+			return nil
+		case existingGen == "":
+			// A pre-#1981 version dir with no stamp. Treat as a legacy resume —
+			// do NOT destroy what may be a live dir on a layout predating the
+			// stamp. Skip the copy; verify still gates the bytes.
+			r.logf("upgrade: version dir %s present without a source-generation stamp "+
+				"(pre-#1981 layout); skipping copy", dst)
+			return nil
+		default:
+			// A same-version re-stage with DIFFERENT bytes (generation differs).
+			// Replace it ONLY if it is a stale, non-live dir; otherwise refuse.
+			cur, _ := r.readCurrentVersion()
+			if ver == cur || ver == j.PreviousVersion {
+				return fmt.Errorf("refuse-before-PREFLIGHT: cannot replace the live/rollback "+
+					"version dir %s (its bytes come from source generation %q but this cut pins "+
+					"%q); re-stage under a DISTINCT version tag, or `dpkg-reconfigure xpf` to "+
+					"realign the generation", dst, existingGen, j.SourceGeneration)
+			}
+			// Stale non-live: reuse the proven guarded delete, then recopy.
+			r.logf("upgrade: replacing stale version dir %s (source generation %q -> %q)",
+				dst, existingGen, j.SourceGeneration)
+			if rerr := r.removeStaleVersionDir(ver); rerr != nil {
+				return rerr
+			}
+		}
 	}
 
 	_ = os.RemoveAll(partial)
-	sum, err := copyTree(r.cfg.StagedDir, partial)
+	sum, err := copyTree(srcDir, partial)
 	if err != nil {
 		_ = os.RemoveAll(partial)
-		return fmt.Errorf("copy staged -> partial: %w", err)
+		return fmt.Errorf("copy source -> partial: %w", err)
 	}
 	// Re-checksum the partial to confirm the copy is intact.
 	verifySum, err := copyTreeChecksum(partial)
@@ -532,6 +684,17 @@ func (r *Runner) copyStaged(j *Journal) error {
 		_ = os.RemoveAll(partial)
 		return fmt.Errorf("partial checksum mismatch (copy corrupted)")
 	}
+	// Stamp the source generation INSIDE the partial (B-P3b OPT1) so it lands
+	// atomically with the version dir and GC removes it with the dir. Skip the
+	// stamp on the legacy path (empty SourceGeneration) so a pre-B dir stays
+	// stamp-free and is recognized as legacy on a later resume.
+	if j.SourceGeneration != "" {
+		stampPath := filepath.Join(partial, stagedgen.SrcGenFile)
+		if werr := fsatomic.WriteFileDurable(stampPath, []byte(j.SourceGeneration+"\n"), 0o644); werr != nil {
+			_ = os.RemoveAll(partial)
+			return fmt.Errorf("stamp source generation into partial: %w", werr)
+		}
+	}
 	if err := fsatomic.SyncDir(partial); err != nil {
 		_ = os.RemoveAll(partial)
 		return fmt.Errorf("fsync partial: %w", err)
@@ -542,6 +705,20 @@ func (r *Runner) copyStaged(j *Journal) error {
 	}
 	if err := fsatomic.SyncDir(r.cfg.VersionsDir); err != nil {
 		return fmt.Errorf("fsync versions dir after rename: %w", err)
+	}
+	return nil
+}
+
+// removeStaleVersionDir removes a NON-live versions/<ver> (B-P3b OPT1
+// guarded-replace) so a same-version-different-generation cut can recopy. The
+// caller has ALREADY proven ver is neither `current` nor PreviousVersion; this
+// mirrors the durable-unlink shape of cleanupFailedVerifyCopy.
+func (r *Runner) removeStaleVersionDir(ver string) error {
+	if err := os.RemoveAll(r.versionDir(ver)); err != nil {
+		return fmt.Errorf("remove stale version dir %s: %w", r.versionDir(ver), err)
+	}
+	if serr := partialSweepSyncDir(r.cfg.VersionsDir); serr != nil {
+		r.logf("upgrade: WARN fsync versions dir after stale-version removal: %v", serr)
 	}
 	return nil
 }
@@ -589,15 +766,19 @@ func (r *Runner) verify(j *Journal) error {
 //   - RESET the journal so the next run re-runs copyStaged. After a successful
 //     COPY the journal is at StateCopied; if we delete the dir but leave the
 //     journal there, the next run SKIPS copyStaged (state already >= Copied)
-//     and VERIFY then fails file-not-found. We rewind BELOW PREFLIGHT (to
-//     StateStaged) and clear the DB-snapshot fields so the retry re-runs
-//     preflight and takes a FRESH config-DB snapshot. Rewinding only to
-//     PREFLIGHT would reuse the snapshot taken at the original preflight; but
-//     the daemon stays LIVE across a verify failure (verify is pure), so an
-//     operator may change the config DB before the retry — a later rollback
-//     would then restore the stale pre-failure snapshot and silently lose
-//     those changes (Codex r1 High). The orphan snapshot is removed here; GC
-//     also sweeps orphan .dbsnap dotfiles defensively.
+//     and VERIFY then fails file-not-found. We rewind to INIT and clear the
+//     DB-snapshot fields AND the pinned SourceGeneration so the retry re-runs
+//     INIT (re-resolving staged-gen/current-gen), preflight (FRESH config-DB
+//     snapshot), and copyStaged. Rewinding only to PREFLIGHT would reuse the
+//     snapshot taken at the original preflight; but the daemon stays LIVE
+//     across a verify failure (verify is pure), so an operator may change the
+//     config DB before the retry — a later rollback would then restore the
+//     stale pre-failure snapshot and silently lose those changes (Codex r1
+//     High). Clearing SourceGeneration is the #1981 addition: an operator who
+//     re-stages CORRECTED bytes publishes a NEW generation, so the retry must
+//     re-resolve current-gen rather than re-cutting the failed generation.
+//     The orphan snapshot is removed here; GC also sweeps orphan .dbsnap
+//     dotfiles defensively.
 //
 // Best-effort: a cleanup failure is logged, never masking the verify error
 // the caller is about to return. If the dir was protected (active), we still
@@ -626,16 +807,19 @@ func (r *Runner) cleanupFailedVerifyCopy(j *Journal) {
 		r.logf("upgrade: removed copied version dir %s after verify failure "+
 			"(a retry will recopy from staged)", r.versionDir(ver))
 	}
-	// Guard (b): rewind the journal BELOW PREFLIGHT so the retry re-runs BOTH
-	// preflight (fresh DB snapshot) AND copyStaged, and PERSIST it FIRST
-	// (Codex r2): the journal rewrite is the durable source of truth. If we
-	// instead removed the snapshot before persisting, a crash (or a
-	// saveJournal failure) in between would leave the persisted journal at
-	// StateCopied / AdvancedStateFloor=true pointing at an already-removed
-	// snapshot — exactly the stale-snapshot bug this fix targets. By clearing
-	// the fields and persisting first, the on-disk journal never references a
-	// snapshot we are about to delete.
-	j.State = StateStaged
+	// Guard (b): rewind the journal to INIT so the retry re-runs INIT
+	// (re-resolving current-gen), preflight (fresh DB snapshot), AND
+	// copyStaged, and PERSIST it FIRST (Codex r2): the journal rewrite is the
+	// durable source of truth. If we instead removed the snapshot before
+	// persisting, a crash (or a saveJournal failure) in between would leave the
+	// persisted journal at StateCopied / AdvancedStateFloor=true pointing at an
+	// already-removed snapshot — exactly the stale-snapshot bug this fix
+	// targets. By clearing the fields and persisting first, the on-disk journal
+	// never references a snapshot we are about to delete. SourceGeneration is
+	// cleared too (#1981): a corrected re-stage publishes a new generation, so
+	// the retry must re-resolve current-gen, not re-cut the failed generation.
+	j.State = StateInit
+	j.SourceGeneration = ""
 	j.DBSnapshotPath = ""
 	j.AdvancedStateFloor = false
 	if err := r.saveJournal(j); err != nil {

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -342,19 +342,24 @@ func (r *Runner) Run(opts Options) (err error) {
 				"the daemon offline with no recovery target. Seed the versioned runtime "+
 				"(xpfd seed-runtime), then re-run the upgrade", stagedVer)
 		}
-		// REFUSE-AT-INIT (#1981 B-P3b OPT1, Codex r5-#2): a same-version cut
-		// whose target version dir already exists, is the LIVE current or the
-		// rollback target, and carries a DIFFERENT source generation than this
-		// cut's source cannot be safely replaced (RemoveAll-ing a live/rollback
-		// dir mid-cut violates #1967). Refuse HERE, pre-PREFLIGHT, so no journal
-		// is persisted and no .dbsnap is taken — a re-run then starts fresh and
-		// re-resolves the source rather than RESUMING a journal that re-refuses
-		// forever. Only fires when the existing dir is STAMPED with a different
-		// generation; an unstamped (pre-#1981) or same-generation dir is handled
-		// in copyStaged.
-		if srcGen != "" {
+		// REFUSE-AT-INIT (#1981 B-P3b OPT1, Codex r5-#2 / r6): a same-version cut
+		// whose target version dir already EXISTS, is the LIVE current or the
+		// rollback target, and does NOT match this cut's source generation
+		// cannot be safely replaced (RemoveAll-ing a live/rollback dir mid-cut
+		// violates #1967). Refuse HERE, pre-PREFLIGHT, so no journal is persisted
+		// and no .dbsnap is taken — a re-run then starts fresh and re-resolves
+		// the source rather than RESUMING a journal that re-refuses forever.
+		//
+		// "Does not match" covers BOTH a different stamp AND an ABSENT stamp (a
+		// pre-#1981 live dir) when this cut pins a generation (srcGen != "").
+		// The previous `existingGen != ""` exclusion left the absent-stamp live
+		// case to the copyStaged backstop, which runs AFTER PREFLIGHT/.dbsnap and
+		// thus re-wedged on resume (Codex r6). A legacy cut (srcGen == "") over
+		// an unstamped live dir matches (existingGen == "" == srcGen) and is a
+		// true resume — not refused.
+		if _, statErr := os.Stat(r.versionDir(stagedVer)); statErr == nil {
 			existingGen, gerr := r.readSrcGen(stagedVer)
-			if gerr == nil && existingGen != "" && existingGen != srcGen &&
+			if gerr == nil && existingGen != srcGen &&
 				(stagedVer == prev || stagedVer == r.mustReadCurrentVersion()) {
 				if cerr := r.clearJournal(); cerr != nil {
 					r.logf("upgrade: WARN clear stale journal on live-dir-replace refuse: %v", cerr)

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -111,8 +111,11 @@ func (r *Runner) resolveSource(j *Journal) (genid, dir string, err error) {
 		if fi, serr := os.Stat(d); serr == nil && fi.IsDir() {
 			return j.SourceGeneration, d, nil
 		}
-		return "", "", fmt.Errorf("pinned source generation %s missing and no current-gen "+
-			"(re-run after re-publishing the staged set)", j.SourceGeneration)
+		// No %w-with-nil: the error is the same whether Stat failed or the path
+		// is not a directory — the pinned generation is unusable and there is no
+		// current-gen to fall back to.
+		return "", "", fmt.Errorf("pinned source generation %s missing or not a directory "+
+			"and no current-gen (re-run after re-publishing the staged set)", j.SourceGeneration)
 	}
 
 	// Pre-#1981 legacy in-flight journal that already copied from live staged/.
@@ -705,9 +708,14 @@ func (r *Runner) copyStaged(j *Journal) error {
 				j.SourceGeneration)
 		}
 		srcDir = r.stagedGenConfig().GenDir(j.SourceGeneration)
-		if fi, serr := os.Stat(srcDir); serr != nil || !fi.IsDir() {
+		fi, serr := os.Stat(srcDir)
+		if serr != nil {
 			return fmt.Errorf("pinned source generation %s missing at %s: %w "+
 				"(it may have been GC'd — re-run after re-publishing)", j.SourceGeneration, srcDir, serr)
+		}
+		if !fi.IsDir() {
+			return fmt.Errorf("pinned source generation %s at %s is not a directory",
+				j.SourceGeneration, srcDir)
 		}
 	}
 
@@ -727,7 +735,18 @@ func (r *Runner) copyStaged(j *Journal) error {
 		// an unstamped pre-#1981 dir vs a stamped cut, or vice-versa). Replace
 		// it — unless it is live/rollback, in which case refuse (backstop; the
 		// stamped-different live case is already refused at INIT).
-		cur, _ := r.readCurrentVersion()
+		//
+		// FAIL-SAFE on an unreadable `current` (Copilot): if we cannot determine
+		// the live version, REFUSE rather than risk RemoveAll-ing a dir that may
+		// be live — an ignored read error here could destroy the running
+		// daemon's binaries.
+		cur, curErr := r.readCurrentVersion()
+		if curErr != nil {
+			return fmt.Errorf("refuse: cannot determine the live `current` version while "+
+				"deciding whether to replace %s (its source generation %q differs from this "+
+				"cut's %q); refusing to risk deleting a live version dir: %w",
+				dst, existingGen, j.SourceGeneration, curErr)
+		}
 		if ver == cur || ver == j.PreviousVersion {
 			return fmt.Errorf("refuse: cannot replace the live/rollback version dir %s "+
 				"(its bytes come from source generation %q but this cut pins %q); re-stage "+

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -58,48 +58,70 @@ type Options struct {
 // with no journal written and no DB snapshot taken.
 var errNoSourceGeneration = fmt.Errorf("no published staged generation")
 
-// resolveSource determines the directory the cut copies FROM and the source
-// generation it pins (#1981 Option B). Resolution:
+// resolveSource determines the VERSION-COMPARISON source and the source
+// generation a FRESH cut would pin (#1981 Option B). The returned dir is used
+// only to read the staged version (which keys the resume-vs-fresh decision);
+// the COPY itself reads j.SourceGeneration (pinned at INIT) — copyStaged
+// resolves that independently. The returned genid is what the INIT block pins
+// into j.SourceGeneration for a fresh cut.
 //
-//   - A RESUMING B-aware journal (SourceGeneration != ""): use that pinned
-//     generation directory (validated; must exist) so the resume continues
-//     against its original source even if a concurrent publish advanced
-//     current-gen. Returns (genid, genDir, nil).
-//   - A RESUMING pre-#1981 journal that already COPIED from live staged/
-//     (State >= COPIED, empty SourceGeneration): back-compat — keep reading
-//     live staged/ so the runner never blocks recovery of an in-flight pre-B
-//     cut (plan §10 AGY r4). Returns ("", StagedDir, nil).
-//   - A FRESH cut (State below STAGED, or a recovery just reset j to INIT):
-//     resolve staged-gen/current-gen. Present -> (genid, genDir, nil); absent
-//     -> errNoSourceGeneration (the caller refuses pre-PREFLIGHT).
+// Resolution prefers the LATEST published generation (current-gen) for BOTH
+// fresh and resume, so that a newer apt install that PUBLISHED a new generation
+// is detected by the resume-vs-fresh version compare (a superseded cut then
+// recovers + starts fresh against the new generation) rather than silently
+// resuming the abandoned one. A same-version republish leaves the version
+// unchanged, so the resume-vs-fresh compare does NOT trip and the resume keeps
+// its ORIGINALLY-pinned generation (B-P3: a resume never switches sources
+// mid-cut — copyStaged still reads j.SourceGeneration).
+//
+//   - current-gen present: comparison source = current-gen dir; the genid a
+//     FRESH cut would pin = current-gen.
+//   - current-gen ABSENT but the journal pinned a generation that still exists
+//     (a resume whose generation has not been GC'd): comparison source = the
+//     pinned generation dir, so a resume is NOT blocked by a missing
+//     current-gen. genid = the pinned generation.
+//   - current-gen ABSENT, no pinned generation, but an already-COPIED journal:
+//     the pre-#1981 legacy in-flight case — comparison source = live staged/,
+//     genid = "" (copyStaged keeps reading live staged/). Back-compat so the
+//     runner never blocks recovery of an in-flight pre-B cut (plan §10 AGY r4).
+//   - current-gen ABSENT, fresh cut: errNoSourceGeneration (the caller refuses
+//     pre-PREFLIGHT — no journal, no DB snapshot).
 func (r *Runner) resolveSource(j *Journal) (genid, dir string, err error) {
 	sg := r.stagedGenConfig()
-	if j.SourceGeneration != "" {
-		if !stagedgen.ValidGenID(j.SourceGeneration) {
-			return "", "", fmt.Errorf("journal source generation %q is not a safe path segment",
-				j.SourceGeneration)
-		}
-		d := sg.GenDir(j.SourceGeneration)
-		if fi, serr := os.Stat(d); serr != nil || !fi.IsDir() {
-			return "", "", fmt.Errorf("pinned source generation %s missing at %s: %w "+
-				"(re-run after re-publishing the staged set)", j.SourceGeneration, d, serr)
-		}
-		return j.SourceGeneration, d, nil
+
+	if j.SourceGeneration != "" && !stagedgen.ValidGenID(j.SourceGeneration) {
+		return "", "", fmt.Errorf("journal source generation %q is not a safe path segment",
+			j.SourceGeneration)
 	}
-	// Empty SourceGeneration on an already-copied journal is the pre-#1981
-	// legacy in-flight case: read from live staged/ (the original source).
-	if j.State.atLeast(StateCopied) {
-		return "", r.cfg.StagedDir, nil
-	}
-	// Fresh cut: resolve the published current generation.
+
 	cur, rerr := sg.ResolveCurrent()
 	if rerr != nil {
 		return "", "", fmt.Errorf("resolve staged generation: %w", rerr)
 	}
-	if cur == "" {
-		return "", "", errNoSourceGeneration
+	if cur != "" {
+		// Latest published generation drives the version compare AND the
+		// fresh-INIT pin.
+		return cur, sg.GenDir(cur), nil
 	}
-	return cur, sg.GenDir(cur), nil
+
+	// No current-gen. Do not block a resume whose pinned generation still
+	// exists (defensive: it is protected from GC while journaled).
+	if j.SourceGeneration != "" {
+		d := sg.GenDir(j.SourceGeneration)
+		if fi, serr := os.Stat(d); serr == nil && fi.IsDir() {
+			return j.SourceGeneration, d, nil
+		}
+		return "", "", fmt.Errorf("pinned source generation %s missing and no current-gen "+
+			"(re-run after re-publishing the staged set)", j.SourceGeneration)
+	}
+
+	// Pre-#1981 legacy in-flight journal that already copied from live staged/.
+	if j.State.atLeast(StateCopied) {
+		return "", r.cfg.StagedDir, nil
+	}
+
+	// Fresh cut with no published generation.
+	return "", "", errNoSourceGeneration
 }
 
 // Run executes (or resumes) the cut-over to the staged version. It is

--- a/pkg/upgrade/cutover.go
+++ b/pkg/upgrade/cutover.go
@@ -357,10 +357,18 @@ func (r *Runner) Run(opts Options) (err error) {
 		// thus re-wedged on resume (Codex r6). A legacy cut (srcGen == "") over
 		// an unstamped live dir matches (existingGen == "" == srcGen) and is a
 		// true resume — not refused.
+		// `prev` was just read authoritatively from readCurrentVersion() above
+		// (errors handled), so it IS the live `current` version here (we hold
+		// the upgrade lock, so it cannot change under us). Use `prev` for the
+		// live/rollback test rather than re-reading via an error-discarding
+		// helper — that would return "" on a transient unreadable `current` and
+		// SKIP this guard, letting the run persist a journal + take a .dbsnap
+		// before refusing in copyStaged (re-introducing the wedge this guard
+		// prevents). `prev` is both the rollback target AND the live current
+		// here, so a single comparison covers both (Copilot r4).
 		if _, statErr := os.Stat(r.versionDir(stagedVer)); statErr == nil {
 			existingGen, gerr := r.readSrcGen(stagedVer)
-			if gerr == nil && existingGen != srcGen &&
-				(stagedVer == prev || stagedVer == r.mustReadCurrentVersion()) {
+			if gerr == nil && existingGen != srcGen && stagedVer == prev {
 				if cerr := r.clearJournal(); cerr != nil {
 					r.logf("upgrade: WARN clear stale journal on live-dir-replace refuse: %v", cerr)
 				}

--- a/pkg/upgrade/flip.go
+++ b/pkg/upgrade/flip.go
@@ -388,6 +388,19 @@ func (r *Runner) gc(j *Journal) error {
 		r.logf("upgrade: gc removing orphan DB snapshot %s", n)
 		_ = os.RemoveAll(filepath.Join(r.cfg.VersionsDir, n))
 	}
+
+	// GC the staged-generation root too (#1981 Option B): keep current-gen +
+	// 1 prior, protecting any generation THIS cut still references (its pinned
+	// SourceGeneration) so a commit/preflight GC cannot delete the source a
+	// resumable cut is reading (the GC-vs-resume race). Best-effort: a
+	// staged-gen GC failure is logged, never failing the cut.
+	protectedGens := map[string]bool{}
+	if j.SourceGeneration != "" {
+		protectedGens[j.SourceGeneration] = true
+	}
+	if sgErr := r.stagedGenConfig().GC(protectedGens); sgErr != nil {
+		r.logf("upgrade: WARN staged-gen gc failed: %v", sgErr)
+	}
 	return nil
 }
 

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -214,6 +214,14 @@ func (r *Runner) currentPath() string {
 	return filepath.Join(r.cfg.VersionsDir, currentLink)
 }
 
+// mustReadCurrentVersion resolves the `current` version, returning "" on any
+// error (used where a read failure should be treated as "no current version"
+// rather than aborting — e.g. the B-P3b live-dir guard).
+func (r *Runner) mustReadCurrentVersion() string {
+	cur, _ := r.readCurrentVersion()
+	return cur
+}
+
 // readCurrentVersion resolves the version the `current` symlink points at,
 // or "" if it does not exist (very first cut).
 func (r *Runner) readCurrentVersion() (string, error) {
@@ -260,6 +268,30 @@ func (r *Runner) saveJournal(j *Journal) error {
 		return fmt.Errorf("persist upgrade journal: %w", err)
 	}
 	return nil
+}
+
+// ReadJournalSourceGeneration returns the SourceGeneration recorded in the
+// upgrade journal at path, or "" if the journal is absent or has no pinned
+// generation. It is used by `xpfd publish-generation` to PROTECT a crashed/
+// resumable cut's pinned generation from the publish GC (the journal is
+// durable; the host-wide lock that would otherwise serialize the cut is NOT
+// held across a crash). A parse error returns "" (best-effort protection — the
+// cut's own GC also protects it, and a malformed journal can't name a genid to
+// protect). Validation of the returned genid is the caller's (it is only used
+// as a GC-protection key, never as a path).
+func ReadJournalSourceGeneration(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read upgrade journal: %w", err)
+	}
+	j := &Journal{}
+	if uerr := json.Unmarshal(data, j); uerr != nil {
+		return "", fmt.Errorf("parse upgrade journal: %w", uerr)
+	}
+	return j.SourceGeneration, nil
 }
 
 // clearJournal removes the journal on terminal success.

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -271,14 +271,20 @@ func (r *Runner) saveJournal(j *Journal) error {
 }
 
 // ReadJournalSourceGeneration returns the SourceGeneration recorded in the
-// upgrade journal at path, or "" if the journal is absent or has no pinned
-// generation. It is used by `xpfd publish-generation` to PROTECT a crashed/
-// resumable cut's pinned generation from the publish GC (the journal is
-// durable; the host-wide lock that would otherwise serialize the cut is NOT
-// held across a crash). A parse error returns "" (best-effort protection — the
-// cut's own GC also protects it, and a malformed journal can't name a genid to
-// protect). Validation of the returned genid is the caller's (it is only used
-// as a GC-protection key, never as a path).
+// upgrade journal at path, or "" if the journal is absent, unparsable, or has
+// no pinned generation. It is used by `xpfd publish-generation` to PROTECT a
+// crashed/resumable cut's pinned generation from the publish GC (the journal
+// is durable; the host-wide lock that would otherwise serialize the cut is NOT
+// held across a crash).
+//
+// Both a missing journal AND a malformed (unparsable) one return ("", nil): a
+// journal that does not parse cannot name a genid to protect, and this is a
+// best-effort GC-protection seam (the cut's own gc(j) protects its source from
+// the authoritative in-memory journal). Only a genuine READ error (I/O,
+// permission) surfaces — that is worth logging, and the caller treats it as
+// "no protection" without failing the publish. The returned genid is only ever
+// used as a GC-protection key, never as a path, so the caller need not
+// validate it.
 func ReadJournalSourceGeneration(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -289,7 +295,10 @@ func ReadJournalSourceGeneration(path string) (string, error) {
 	}
 	j := &Journal{}
 	if uerr := json.Unmarshal(data, j); uerr != nil {
-		return "", fmt.Errorf("parse upgrade journal: %w", uerr)
+		// A malformed journal names no genid to protect; degrade to "no
+		// protection" rather than surfacing an error a best-effort caller would
+		// only log-and-ignore.
+		return "", nil
 	}
 	return j.SourceGeneration, nil
 }

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -214,14 +214,6 @@ func (r *Runner) currentPath() string {
 	return filepath.Join(r.cfg.VersionsDir, currentLink)
 }
 
-// mustReadCurrentVersion resolves the `current` version, returning "" on any
-// error (used where a read failure should be treated as "no current version"
-// rather than aborting — e.g. the B-P3b live-dir guard).
-func (r *Runner) mustReadCurrentVersion() string {
-	cur, _ := r.readCurrentVersion()
-	return cur
-}
-
 // readCurrentVersion resolves the version the `current` symlink points at,
 // or "" if it does not exist (very first cut).
 func (r *Runner) readCurrentVersion() (string, error) {

--- a/pkg/upgrade/runner.go
+++ b/pkg/upgrade/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/psaab/xpf/pkg/fsatomic"
 	"github.com/psaab/xpf/pkg/upgrade/lock"
 	"github.com/psaab/xpf/pkg/upgrade/manifest"
+	"github.com/psaab/xpf/pkg/upgrade/stagedgen"
 )
 
 // lockHandle is the host-wide advisory lock surface used by the upgrade
@@ -29,12 +30,13 @@ var acquireUpgradeLock = func(subcommand, target string) (lockHandle, error) {
 
 // Default filesystem layout (plan §6.1). Overridable in Config for tests.
 const (
-	DefaultStagedDir   = "/usr/local/share/xpf/staged"
-	DefaultVersionsDir = "/var/lib/xpf/versions"
-	DefaultSbinDir     = "/usr/local/sbin"
-	DefaultConfigDBDir = "/etc/xpf/.configdb"
-	DefaultJournalPath = "/var/lib/xpf/upgrade.state"
-	DefaultUnit        = "xpfd"
+	DefaultStagedDir    = "/usr/local/share/xpf/staged"
+	DefaultVersionsDir  = "/var/lib/xpf/versions"
+	DefaultStagedGenDir = stagedgen.DefaultDir
+	DefaultSbinDir      = "/usr/local/sbin"
+	DefaultConfigDBDir  = "/etc/xpf/.configdb"
+	DefaultJournalPath  = "/var/lib/xpf/upgrade.state"
+	DefaultUnit         = "xpfd"
 
 	// currentLink is the bookkeeping pointer inside VersionsDir.
 	currentLink = "current"
@@ -93,10 +95,14 @@ type System interface {
 type Config struct {
 	StagedDir   string
 	VersionsDir string
-	SbinDir     string
-	ConfigDBDir string
-	JournalPath string
-	Unit        string
+	// StagedGenDir is the staged-generation root (#1981 Option B). The cut
+	// copies from staged-gen/<SourceGeneration>/ here, NEVER from live
+	// StagedDir, closing the dpkg-unpack torn-read window.
+	StagedGenDir string
+	SbinDir      string
+	ConfigDBDir  string
+	JournalPath  string
+	Unit         string
 
 	// DiskMarginBytes is the headroom required on /var beyond the staged
 	// size + DB snapshot size in PREFLIGHT.
@@ -119,6 +125,9 @@ func (c *Config) withDefaults() {
 	}
 	if c.VersionsDir == "" {
 		c.VersionsDir = DefaultVersionsDir
+	}
+	if c.StagedGenDir == "" {
+		c.StagedGenDir = DefaultStagedGenDir
 	}
 	if c.SbinDir == "" {
 		c.SbinDir = DefaultSbinDir
@@ -162,6 +171,37 @@ func (r *Runner) logf(format string, args ...any) { r.cfg.Logf(format, args...) 
 // versionDir returns the runtime dir for ver.
 func (r *Runner) versionDir(ver string) string {
 	return filepath.Join(r.cfg.VersionsDir, ver)
+}
+
+// stagedGenConfig builds the staged-generation surface (#1981 Option B) wired
+// to this runner's StagedDir + StagedGenDir + log sink.
+func (r *Runner) stagedGenConfig() stagedgen.Config {
+	return stagedgen.Config{
+		StagedDir: r.cfg.StagedDir,
+		Dir:       r.cfg.StagedGenDir,
+		Logf:      r.cfg.Logf,
+	}
+}
+
+// srcGenPath returns the path of the source-generation stamp inside
+// versions/<ver>/ (#1981 B-P3b OPT1). It lives INSIDE the version dir so GC
+// removes it with the dir (not a sibling dotfile).
+func (r *Runner) srcGenPath(ver string) string {
+	return filepath.Join(r.versionDir(ver), stagedgen.SrcGenFile)
+}
+
+// readSrcGen returns the source generation stamped into versions/<ver>/, or ""
+// if the stamp is absent (a pre-#1981 version dir, or one mid-copy). A read
+// error other than not-exist is reported.
+func (r *Runner) readSrcGen(ver string) (string, error) {
+	data, err := os.ReadFile(r.srcGenPath(ver))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
 }
 
 // partialDir returns the in-progress copy dir for ver.

--- a/pkg/upgrade/runner_test.go
+++ b/pkg/upgrade/runner_test.go
@@ -114,8 +114,10 @@ func (f *fakeSystem) HelperHealthy(ver string, _ time.Duration) error {
 }
 func (f *fakeSystem) Now() time.Time { return f.now }
 
-// testEnv builds a populated staged tree + config DB and returns a Runner
-// wired to the fake system.
+// testEnv builds a populated staged tree + config DB, PUBLISHES a staged
+// generation (mirroring the production postinst publish -> cut flow, #1981
+// Option B — the cut reads staged-gen/<genid>/, not live staged/), and returns
+// a Runner wired to the fake system.
 func testEnv(t *testing.T, fs *fakeSystem) (*Runner, Config) {
 	t.Helper()
 	root := t.TempDir()
@@ -129,6 +131,7 @@ func testEnv(t *testing.T, fs *fakeSystem) (*Runner, Config) {
 	cfg := Config{
 		StagedDir:           staged,
 		VersionsDir:         filepath.Join(root, "versions"),
+		StagedGenDir:        filepath.Join(root, "staged-gen"),
 		SbinDir:             filepath.Join(root, "sbin"),
 		ConfigDBDir:         cfgdb,
 		JournalPath:         filepath.Join(root, "versions", "upgrade.state"),
@@ -141,7 +144,21 @@ func testEnv(t *testing.T, fs *fakeSystem) (*Runner, Config) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Publish the initial generation so a fresh cut has a source (production
+	// does this in the postinst before the cut).
+	publishStagedGen(t, r)
 	return r, cfg
+}
+
+// publishStagedGen publishes a generation from the runner's current StagedDir,
+// returning the genid (mirrors the production postinst publish step).
+func publishStagedGen(t *testing.T, r *Runner) string {
+	t.Helper()
+	genid, err := r.stagedGenConfig().Publish()
+	if err != nil {
+		t.Fatalf("publish staged generation: %v", err)
+	}
+	return genid
 }
 
 func writeFakeBin(t *testing.T, path, content string) {

--- a/pkg/upgrade/runtime/seed.go
+++ b/pkg/upgrade/runtime/seed.go
@@ -37,6 +37,7 @@ import (
 	"github.com/psaab/xpf/pkg/fsatomic"
 	"github.com/psaab/xpf/pkg/upgrade"
 	"github.com/psaab/xpf/pkg/upgrade/manifest"
+	"github.com/psaab/xpf/pkg/upgrade/stagedgen"
 )
 
 // Default layout, shared with pkg/upgrade. Overridable in Config for tests.
@@ -44,9 +45,10 @@ import (
 // runtime package references them (Copilot) so a future layout change updates
 // both the cut machine and the first-install seed together.
 const (
-	defaultStagedDir   = upgrade.DefaultStagedDir
-	defaultVersionsDir = upgrade.DefaultVersionsDir
-	defaultSbinDir     = upgrade.DefaultSbinDir
+	defaultStagedDir    = upgrade.DefaultStagedDir
+	defaultVersionsDir  = upgrade.DefaultVersionsDir
+	defaultStagedGenDir = upgrade.DefaultStagedGenDir
+	defaultSbinDir      = upgrade.DefaultSbinDir
 
 	currentLink = "current"
 )
@@ -64,7 +66,11 @@ var managedBins = manifest.Names()
 type Config struct {
 	StagedDir   string
 	VersionsDir string
-	SbinDir     string
+	// StagedGenDir is the staged-generation root (#1981 Option B). Seed
+	// publishes an initial generation here so a first manual `xpfd upgrade`
+	// has a pinned source.
+	StagedGenDir string
+	SbinDir      string
 
 	// Logf is an optional progress sink (defaults to no-op).
 	Logf func(format string, args ...any)
@@ -80,6 +86,9 @@ func (c *Config) withDefaults() {
 	}
 	if c.VersionsDir == "" {
 		c.VersionsDir = defaultVersionsDir
+	}
+	if c.StagedGenDir == "" {
+		c.StagedGenDir = defaultStagedGenDir
 	}
 	if c.SbinDir == "" {
 		c.SbinDir = defaultSbinDir
@@ -163,6 +172,24 @@ func Seed(cfg Config) (err error) {
 		}
 	}
 	logf("seed: seeded versioned runtime %s (current + sbin resolve through versions/)", ver)
+
+	// 5. Publish the FIRST staged generation (#1981 Option B) so a first manual
+	//    `xpfd upgrade` has a pinned source even though first-install runs no
+	//    cut. dpkg has finished unpacking staged/ before the postinst configure
+	//    step runs, so this publishes a complete, single-generation source.
+	//    Idempotent: a re-run publishes a fresh (distinct) generation and the
+	//    GC keeps current + 1 prior. Best-effort idempotence aside, a publish
+	//    FAILURE here is fatal to seeding (the caller falls back to legacy
+	//    direct-staged links): a later cut then refuses safely with no source
+	//    rather than reading torn staged/.
+	if _, perr := (stagedgen.Config{
+		StagedDir: cfg.StagedDir,
+		Dir:       cfg.StagedGenDir,
+		Logf:      cfg.Logf,
+	}).Publish(); perr != nil {
+		return fmt.Errorf("seed: publish initial staged generation: %w", perr)
+	}
+	logf("seed: published the initial staged generation")
 	return nil
 }
 

--- a/pkg/upgrade/runtime/seed.go
+++ b/pkg/upgrade/runtime/seed.go
@@ -182,12 +182,21 @@ func Seed(cfg Config) (err error) {
 	//    FAILURE here is fatal to seeding (the caller falls back to legacy
 	//    direct-staged links): a later cut then refuses safely with no source
 	//    rather than reading torn staged/.
-	if _, perr := (stagedgen.Config{
+	sgCfg := stagedgen.Config{
 		StagedDir: cfg.StagedDir,
 		Dir:       cfg.StagedGenDir,
 		Logf:      cfg.Logf,
-	}).Publish(); perr != nil {
+	}
+	if _, perr := sgCfg.Publish(); perr != nil {
 		return fmt.Errorf("seed: publish initial staged generation: %w", perr)
+	}
+	// GC the staged-generation root (Copilot): a repeated seed (manual
+	// `xpfd seed-runtime` or repeated postinst retries) publishes a fresh
+	// generation each time, so without a GC they accumulate. Best-effort — a
+	// GC failure does not fail the seed (the publish already succeeded). No
+	// cut runs at first-install seed time, so no journal protection is needed.
+	if gcErr := sgCfg.GC(nil); gcErr != nil {
+		logf("seed: WARN staged-gen gc failed: %v", gcErr)
 	}
 	logf("seed: published the initial staged generation")
 	return nil

--- a/pkg/upgrade/runtime/seed_test.go
+++ b/pkg/upgrade/runtime/seed_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/upgrade/stagedgen"
 )
 
 // seedEnv builds a populated staged tree and returns a Config wired to
@@ -17,11 +19,12 @@ func seedEnv(t *testing.T, ver string) Config {
 		mkfile(t, filepath.Join(staged, b), "bin-"+b+"-"+ver)
 	}
 	return Config{
-		StagedDir:   staged,
-		VersionsDir: filepath.Join(root, "versions"),
-		SbinDir:     filepath.Join(root, "sbin"),
-		Logf:        func(format string, a ...any) { t.Logf("LOG "+format, a...) },
-		version:     ver,
+		StagedDir:    staged,
+		VersionsDir:  filepath.Join(root, "versions"),
+		StagedGenDir: filepath.Join(root, "staged-gen"),
+		SbinDir:      filepath.Join(root, "sbin"),
+		Logf:         func(format string, a ...any) { t.Logf("LOG "+format, a...) },
+		version:      ver,
 	}
 }
 
@@ -86,6 +89,33 @@ func TestSeed_FirstInstallLayout(t *testing.T) {
 		t.Fatalf("Seed: %v", err)
 	}
 	assertSeeded(t, cfg, "1.0.0")
+}
+
+// TestSeed_PublishesInitialGeneration proves the #1981 Option B seed step: a
+// first install publishes a resolvable staged generation containing the
+// staged bytes, so a first manual `xpfd upgrade` has a pinned source.
+func TestSeed_PublishesInitialGeneration(t *testing.T) {
+	cfg := seedEnv(t, "1.0.0")
+	if err := Seed(cfg); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	sg := stagedgen.Config{StagedDir: cfg.StagedDir, Dir: cfg.StagedGenDir}
+	genid, err := sg.ResolveCurrent()
+	if err != nil {
+		t.Fatalf("ResolveCurrent after seed: %v", err)
+	}
+	if genid == "" {
+		t.Fatal("seed did not publish an initial generation (current-gen absent)")
+	}
+	for _, b := range managedBins {
+		data, rerr := os.ReadFile(filepath.Join(sg.GenDir(genid), b))
+		if rerr != nil {
+			t.Fatalf("published generation missing %s: %v", b, rerr)
+		}
+		if string(data) != "bin-"+b+"-1.0.0" {
+			t.Errorf("published %s = %q, want seeded bytes", b, data)
+		}
+	}
 }
 
 // TestSeed_Idempotent re-runs Seed and asserts the layout is unchanged and

--- a/pkg/upgrade/stagedgen/fsutil.go
+++ b/pkg/upgrade/stagedgen/fsutil.go
@@ -1,0 +1,149 @@
+package stagedgen
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/psaab/xpf/pkg/fsatomic"
+)
+
+// copyTreeFsync recursively copies src into dst (which must not exist),
+// preserving file modes and fsyncing each file, then fsyncing each created
+// directory deepest-first so a child's entries are durable before the parent
+// entry referencing it. It mirrors the durability of pkg/upgrade.copyTree and
+// pkg/upgrade/runtime.copyTreeFsync; stagedgen keeps its own copy so the
+// package has no import cycle back into pkg/upgrade.
+func copyTreeFsync(src, dst string) error {
+	type ent struct {
+		rel  string
+		info os.FileInfo
+		path string
+	}
+	var ents []ent
+	err := filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rerr := filepath.Rel(src, p)
+		if rerr != nil {
+			return rerr
+		}
+		ents = append(ents, ent{rel: rel, info: info, path: p})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Slice(ents, func(i, j int) bool { return ents[i].rel < ents[j].rel })
+
+	var createdDirs []string
+	for _, e := range ents {
+		target := filepath.Join(dst, e.rel)
+		switch {
+		case e.info.IsDir():
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+			// Preserve the SOURCE dir's mode (MkdirAll applies the umask and
+			// won't chmod an existing dir) so a generation dir is not silently
+			// restricted under a tight operator umask, which would break
+			// non-root execution of the copied binaries.
+			if err := os.Chmod(target, preservedMode(e.info.Mode())); err != nil {
+				return fmt.Errorf("chmod %s: %w", target, err)
+			}
+			createdDirs = append(createdDirs, target)
+		case e.info.Mode().IsRegular():
+			if err := copyFileFsync(e.path, target, e.info.Mode()); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("copyTreeFsync: unsupported file type for %s", e.path)
+		}
+	}
+	// Fsync created dirs deepest-first (by path-component depth, not string
+	// length) so a child's entries are committed before the parent entry.
+	sort.Slice(createdDirs, func(i, j int) bool {
+		di := strings.Count(createdDirs[i], string(os.PathSeparator))
+		dj := strings.Count(createdDirs[j], string(os.PathSeparator))
+		if di != dj {
+			return di > dj
+		}
+		return createdDirs[i] > createdDirs[j]
+	})
+	for _, d := range createdDirs {
+		if err := fsatomic.SyncDir(d); err != nil {
+			return fmt.Errorf("fsync copied dir %s: %w", d, err)
+		}
+	}
+	return nil
+}
+
+// preservedMode returns the chmod-applicable mode bits of m: the rwx
+// permission bits PLUS setuid/setgid/sticky. m.Perm() alone masks the special
+// bits off. Staged content is 0755 today, so this is forward-looking
+// exactness rather than a current bug.
+func preservedMode(m os.FileMode) os.FileMode {
+	return m.Perm() | (m & (os.ModeSetuid | os.ModeSetgid | os.ModeSticky))
+}
+
+func copyFileFsync(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	// OpenFile applies the umask to the create mode, so chmod to the exact
+	// source mode — the staged binaries are 0755 and must stay executable
+	// through the generation dir regardless of the installing process's umask.
+	if err := out.Chmod(preservedMode(mode)); err != nil {
+		out.Close()
+		return fmt.Errorf("chmod %s: %w", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return fmt.Errorf("copy %s -> %s: %w", src, dst, err)
+	}
+	if err := out.Sync(); err != nil {
+		out.Close()
+		return fmt.Errorf("fsync %s: %w", dst, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", dst, err)
+	}
+	return nil
+}
+
+// atomicRelSymlink atomically points link at a RELATIVE target (a basename in
+// the same dir, e.g. current-gen -> <genid>) via temp+rename, then fsyncs the
+// dir. NOT `ln -sf`, which unlink-then-creates and leaves a window where the
+// link is absent (plan B-P2 / AGY r2-#1a).
+func atomicRelSymlink(link, relTarget string) error {
+	dir := filepath.Dir(link)
+	tmp := filepath.Join(dir, "."+filepath.Base(link)+".tmp")
+	// RemoveAll, not Remove: a stale directory at the temp path (manual
+	// intervention / a previous failed run) would make os.Remove fail and the
+	// subsequent Symlink fail EEXIST.
+	_ = os.RemoveAll(tmp)
+	if err := os.Symlink(relTarget, tmp); err != nil {
+		return fmt.Errorf("create temp symlink: %w", err)
+	}
+	if err := os.Rename(tmp, link); err != nil {
+		_ = os.RemoveAll(tmp)
+		return fmt.Errorf("rename symlink into place: %w", err)
+	}
+	if err := fsatomic.SyncDir(dir); err != nil {
+		return fmt.Errorf("fsync symlink dir: %w", err)
+	}
+	return nil
+}

--- a/pkg/upgrade/stagedgen/stagedgen.go
+++ b/pkg/upgrade/stagedgen/stagedgen.go
@@ -275,11 +275,15 @@ func (c Config) GenDir(genid string) string {
 	return c.genDir(genid)
 }
 
-// GC removes generation dirs beyond RetainGenerations (current + 1 prior),
-// NEVER removing the current-gen generation NOR any genid in protected (the
-// generations an active/resumable journal still references — plan §4.B.5 /
-// B-P3 GC-vs-resume protection). It also sweeps .partial orphans. A missing
-// staged-gen root is a no-op.
+// GC removes generation dirs beyond RetainGenerations, ordering by genid name
+// (mtime-independent, deterministic — GenID's zero-padded timestamp prefix
+// makes lexicographic name order chronological). It NEVER removes the
+// current-gen generation (resolved explicitly, protected additively) NOR any
+// genid in protected (the generations an active/resumable journal still
+// references — plan §4.B.5 / B-P3 GC-vs-resume protection), and it ignores
+// (never counts toward retention, never deletes) any directory whose name is
+// not a valid genid. It also sweeps .partial orphans. A missing staged-gen
+// root is a no-op.
 func (c Config) GC(protected map[string]bool) error {
 	c.withDefaults()
 	c.sweepPartials()
@@ -292,68 +296,55 @@ func (c Config) GC(protected map[string]bool) error {
 		return fmt.Errorf("stagedgen: read %s: %w", c.Dir, err)
 	}
 
-	// The caller's `protected` set (journal-referenced generations) is kept
-	// ADDITIVELY — outside and on top of the RetainGenerations window — so a
-	// journal-pinned OLD generation never pushes the immediate-prior-to-current
-	// generation out of the window (Copilot). The current generation is NOT in
-	// this additive set: it is naturally the newest and counts toward the
-	// window (RetainGenerations = current + N-1 prior).
+	// The caller's `protected` set (journal-referenced generations) PLUS the
+	// current generation are kept ADDITIVELY — outside and on top of the
+	// RetainGenerations window — so a journal-pinned OLD generation never
+	// pushes an in-window generation out, and the active cut source is never
+	// reaped even if directory mtimes are perturbed (Copilot). current-gen is
+	// resolved EXPLICITLY rather than relying on it being the newest by mtime.
 	extraProtected := map[string]bool{}
 	for g := range protected {
 		extraProtected[g] = true
 	}
-
-	type gen struct {
-		name string
-		mod  int64
+	if cur, rerr := c.ResolveCurrent(); rerr == nil && cur != "" {
+		extraProtected[cur] = true
 	}
-	var gens []gen
+
+	// Collect ONLY valid generation dirs (Copilot): a stray non-generation
+	// directory must neither consume a retention slot nor be deleted. Order by
+	// NAME, newest first — GenID prefixes a zero-padded nanosecond timestamp,
+	// so lexicographic name order is chronological and mtime-INDEPENDENT
+	// (deterministic even when coarse-resolution mtimes tie).
+	var gens []string
 	for _, e := range entries {
 		n := e.Name()
-		if n == CurrentGenLink {
+		if n == CurrentGenLink || strings.HasPrefix(n, ".") {
 			continue
 		}
-		if strings.HasPrefix(n, ".") { // .partial, temp symlinks
+		if !e.IsDir() || !ValidGenID(n) {
 			continue
 		}
-		if !e.IsDir() {
-			continue
-		}
-		info, ierr := e.Info()
-		if ierr != nil {
-			continue
-		}
-		gens = append(gens, gen{name: n, mod: info.ModTime().UnixNano()})
+		gens = append(gens, n)
 	}
-	// Newest first, with a genid (name) tie-breaker so retention is
-	// DETERMINISTIC when two generations share a coarse-resolution mtime
-	// (Copilot): GenID prefixes a zero-padded nanosecond timestamp, so the
-	// lexicographically-greater name is the chronologically-later generation —
-	// the right tie-break for "newest first".
-	sort.Slice(gens, func(i, j int) bool {
-		if gens[i].mod != gens[j].mod {
-			return gens[i].mod > gens[j].mod
-		}
-		return gens[i].name > gens[j].name
-	})
+	sort.Slice(gens, func(i, j int) bool { return gens[i] > gens[j] })
 
 	kept := 0
 	removedAny := false
 	for _, g := range gens {
-		// The RetainGenerations newest generations form the window (current-gen
-		// is naturally among them as the newest).
+		// The RetainGenerations newest generations form the window.
 		if kept < RetainGenerations {
 			kept++
 			continue
 		}
-		// Outside the window: keep ONLY if journal-referenced (additive
-		// protection — never reap a generation a resumable cut still pins).
-		if extraProtected[g.name] {
+		// Outside the window: keep ONLY if current-gen or journal-referenced
+		// (additive protection — never reap the active source or a generation a
+		// resumable cut still pins).
+		if extraProtected[g] {
 			continue
 		}
-		c.logf("stagedgen: gc removing old generation %s", g.name)
-		if rerr := os.RemoveAll(c.genDir(g.name)); rerr != nil {
-			c.logf("stagedgen: WARN gc remove %s: %v", g.name, rerr)
+		c.logf("stagedgen: gc removing old generation %s", g)
+		if rerr := os.RemoveAll(c.genDir(g)); rerr != nil {
+			c.logf("stagedgen: WARN gc remove %s: %v", g, rerr)
 			continue
 		}
 		removedAny = true

--- a/pkg/upgrade/stagedgen/stagedgen.go
+++ b/pkg/upgrade/stagedgen/stagedgen.go
@@ -292,13 +292,15 @@ func (c Config) GC(protected map[string]bool) error {
 		return fmt.Errorf("stagedgen: read %s: %w", c.Dir, err)
 	}
 
-	prot := map[string]bool{}
+	// The caller's `protected` set (journal-referenced generations) is kept
+	// ADDITIVELY — outside and on top of the RetainGenerations window — so a
+	// journal-pinned OLD generation never pushes the immediate-prior-to-current
+	// generation out of the window (Copilot). The current generation is NOT in
+	// this additive set: it is naturally the newest and counts toward the
+	// window (RetainGenerations = current + N-1 prior).
+	extraProtected := map[string]bool{}
 	for g := range protected {
-		prot[g] = true
-	}
-	// The current generation is always protected.
-	if cur, rerr := c.ResolveCurrent(); rerr == nil && cur != "" {
-		prot[cur] = true
+		extraProtected[g] = true
 	}
 
 	type gen struct {
@@ -329,12 +331,15 @@ func (c Config) GC(protected map[string]bool) error {
 	kept := 0
 	removedAny := false
 	for _, g := range gens {
-		if prot[g.name] {
+		// The RetainGenerations newest generations form the window (current-gen
+		// is naturally among them as the newest).
+		if kept < RetainGenerations {
 			kept++
 			continue
 		}
-		if kept < RetainGenerations {
-			kept++
+		// Outside the window: keep ONLY if journal-referenced (additive
+		// protection — never reap a generation a resumable cut still pins).
+		if extraProtected[g.name] {
 			continue
 		}
 		c.logf("stagedgen: gc removing old generation %s", g.name)

--- a/pkg/upgrade/stagedgen/stagedgen.go
+++ b/pkg/upgrade/stagedgen/stagedgen.go
@@ -254,7 +254,16 @@ func (c Config) ResolveCurrent() (string, error) {
 		}
 		return "", fmt.Errorf("stagedgen: read current-gen: %w", err)
 	}
-	genid := filepath.Base(target)
+	// current-gen MUST be a BARE in-tree generation name — a single path
+	// segment with NO directory components (Copilot r4). A corrupt/hand-edited
+	// symlink target like "../<genid>" or "/tmp/<genid>" would pass
+	// ValidGenID(filepath.Base(target)) yet escape the staged-gen root, so we
+	// require target == its own base (no separators) BEFORE deriving the genid.
+	if target != filepath.Base(target) {
+		return "", fmt.Errorf("stagedgen: current-gen target %q is not a bare in-tree "+
+			"generation name (must have no path components)", target)
+	}
+	genid := target
 	if !ValidGenID(genid) {
 		return "", fmt.Errorf("stagedgen: current-gen names an unsafe generation %q", genid)
 	}

--- a/pkg/upgrade/stagedgen/stagedgen.go
+++ b/pkg/upgrade/stagedgen/stagedgen.go
@@ -116,12 +116,16 @@ func (c *Config) withDefaults() {
 	}
 }
 
-// GenID returns a fresh generation identifier: a monotonic nanosecond
-// timestamp (zero-padded so lexicographic order matches chronological order)
-// joined with a random suffix. The timestamp keeps mtime-independent ordering
-// stable; the random suffix makes a same-version reinstall (or two publishes
-// in the same nanosecond) yield DISTINCT generations (plan B-P5). The result
-// is a safe single path segment (lowercase hex + a single '-').
+// GenID returns a fresh generation identifier: a zero-padded wall-clock
+// nanosecond timestamp (time.Now().UnixNano(), so lexicographic order USUALLY
+// matches chronological order) joined with a random suffix. The timestamp is
+// NOT strictly monotonic — an NTP step can move the wall clock backward — so
+// it is only a generation key + a stable, mtime-independent GC ordering hint;
+// correctness never depends on genid ordering (GC protects current-gen and
+// journal-referenced generations explicitly). The random suffix makes a
+// same-version reinstall (or two publishes in the same nanosecond) yield
+// DISTINCT generations (plan B-P5). The result is a safe single path segment
+// (lowercase hex + a single '-').
 func GenID() string {
 	var b [8]byte
 	// crypto/rand never fails on Linux; if it ever did, fall back to a

--- a/pkg/upgrade/stagedgen/stagedgen.go
+++ b/pkg/upgrade/stagedgen/stagedgen.go
@@ -1,0 +1,389 @@
+// Package stagedgen implements Option B of #1981 — immutable, versioned
+// publication of the dpkg-staged binary set into generation-keyed source
+// directories, so the in-place-upgrade cut reads a WHOLE, single-generation
+// source that dpkg is NOT actively rewriting.
+//
+// # The race this closes
+//
+// dpkg unpacks the managed binaries into the dpkg-owned staging path one file
+// at a time (write `<bin>.dpkg-new`, rename over `<bin>`). Across an `apt
+// upgrade` unpack window the staging dir therefore holds a MIX of old and new
+// binaries. The legacy cut (`copyStaged`, pkg/upgrade) copied directly from
+// that live staging dir, so a cut landing inside the unpack window could
+// publish a `versions/<ver>` mixing binaries from two dpkg generations — a
+// torn set whose verify-dataplane gate (xpfd+shim only) cannot detect a
+// mismatched `xpf-userspace-dp`. See #1981 / docs/in-place-upgrade.md.
+//
+// # The mechanism (Option B)
+//
+// After a COMPLETE unpack (Debian Policy §6.7: `postinst configure` runs after
+// all files are unpacked and the dpkg frontend lock serializes transactions),
+// the postinst PUBLISHES the staged tree into an immutable, generation-keyed
+// source directory:
+//
+//	staged-gen/<genid>/        # one immutable copy of the staged set
+//	staged-gen/current-gen     # atomic symlink naming the latest generation
+//
+// The publish is `.partial` + atomic-rename + dir-fsync, then an atomic
+// (temp-symlink + rename) repoint of `current-gen`. A crash before the dir
+// rename leaves a `.partial` (pre-swept on the next publish); a crash after
+// the dir rename but before the `current-gen` repoint leaves a
+// complete-but-unreferenced generation (the prior `current-gen` stays valid,
+// and the next publish re-publishes idempotently). There is NEVER a torn
+// published generation and NEVER an absent `current-gen`.
+//
+// The cut then resolves `current-gen` ONCE at INIT, records the genid in its
+// journal, and copies from the resolved `staged-gen/<genid>/` DIRECTORY (never
+// re-reading the symlink, never reading live staged/) — so a concurrent
+// publish cannot redirect an in-flight cut, and the copy is internally a
+// single generation by construction.
+//
+// # Lifecycle ownership
+//
+// staged-gen/ is maintainer-script-managed runtime state under /var/lib/xpf/
+// (a sibling of versions/), NEVER a dpkg payload file — so dpkg never writes
+// or removes it on unpack (it only touches its own recorded payload files).
+// The postrm removes it on purge and on a downgrade to a pre-B package.
+//
+// # GC
+//
+// GC mirrors the versions/ GC shape but with a SMALLER retention (N=2:
+// current + 1 prior). Unlike versions/ (which backs binary+DB rollback to N
+// prior versions), staged-gen/ is only ever a CUT SOURCE: once superseded by a
+// newer current-gen an older generation is never read again. GC protects
+// current-gen AND any genid an active/resumable journal still references
+// (the caller supplies the protected genid set), and sweeps .partial orphans.
+package stagedgen
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/psaab/xpf/pkg/fsatomic"
+	"github.com/psaab/xpf/pkg/upgrade/manifest"
+)
+
+const (
+	// DirName is the staged-generation root, a sibling of versions/ under
+	// /var/lib/xpf. The default absolute path is DefaultDir; tests override
+	// via Config.Dir.
+	DirName = "staged-gen"
+
+	// DefaultDir is the production staged-generation root.
+	DefaultDir = "/var/lib/xpf/" + DirName
+
+	// CurrentGenLink is the atomic symlink naming the latest complete
+	// generation, mirroring versions/current.
+	CurrentGenLink = "current-gen"
+
+	// SrcGenFile is the dotfile stamped INSIDE versions/<ver>/ recording the
+	// source generation a version dir was cut from (B-P3b OPT1 identity
+	// stamp). It lives inside the version dir so GC removes it with the dir.
+	SrcGenFile = ".srcgen"
+
+	// RetainGenerations is N in the staged-gen retention policy: keep the
+	// current generation + 1 prior. Smaller than versions/ N=3 because a
+	// superseded generation is never read again (B-P5 / plan §4.B.5).
+	RetainGenerations = 2
+
+	partialSuffix = ".partial"
+)
+
+// Config configures publish / resolve / GC against a staged-generation root.
+// Zero values fall back to the production layout.
+type Config struct {
+	// StagedDir is the dpkg-owned staging path to publish FROM (the source).
+	StagedDir string
+	// Dir is the staged-generation root to publish INTO. Defaults to
+	// DefaultDir.
+	Dir string
+	// Logf is an optional progress sink (defaults to no-op).
+	Logf func(format string, args ...any)
+}
+
+func (c *Config) withDefaults() {
+	if c.Dir == "" {
+		c.Dir = DefaultDir
+	}
+	if c.Logf == nil {
+		c.Logf = func(string, ...any) {}
+	}
+}
+
+// GenID returns a fresh generation identifier: a monotonic nanosecond
+// timestamp (zero-padded so lexicographic order matches chronological order)
+// joined with a random suffix. The timestamp keeps mtime-independent ordering
+// stable; the random suffix makes a same-version reinstall (or two publishes
+// in the same nanosecond) yield DISTINCT generations (plan B-P5). The result
+// is a safe single path segment (lowercase hex + a single '-').
+func GenID() string {
+	var b [8]byte
+	// crypto/rand never fails on Linux; if it ever did, fall back to a
+	// time-only suffix so the genid is still unique-enough and a publish is
+	// never blocked on entropy.
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%020d-%016x", time.Now().UnixNano(), time.Now().UnixNano())
+	}
+	return fmt.Sprintf("%020d-%s", time.Now().UnixNano(), hex.EncodeToString(b[:]))
+}
+
+// ValidGenID reports whether s is a syntactically valid generation id (the
+// shape GenID produces): non-empty, not current-gen, no '.' prefix (so it can
+// never collide with the current-gen temp file or a .partial), no path
+// separators or "..", and only lowercase-hex + a single '-'. A resolved genid
+// keys staged-gen/<genid>, so it MUST be a safe single path segment before any
+// path use.
+func ValidGenID(s string) bool {
+	if s == "" || s == CurrentGenLink {
+		return false
+	}
+	if strings.HasPrefix(s, ".") {
+		return false
+	}
+	if strings.ContainsAny(s, "/\x00") {
+		return false
+	}
+	if strings.Contains(s, "..") {
+		return false
+	}
+	dashes := 0
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r == '-':
+			dashes++
+		default:
+			return false
+		}
+	}
+	return dashes == 1
+}
+
+func (c Config) logf(format string, args ...any) { c.Logf(format, args...) }
+
+// genDir returns the directory for a generation id.
+func (c Config) genDir(genid string) string { return filepath.Join(c.Dir, genid) }
+
+// currentGenPath returns the path of the current-gen symlink.
+func (c Config) currentGenPath() string { return filepath.Join(c.Dir, CurrentGenLink) }
+
+// Publish copies the staged set into a fresh, immutable staged-gen/<genid>/
+// and atomically repoints current-gen at it. It returns the new genid.
+//
+// Steps (each crash-safe; plan B-P2):
+//  1. pre-sweep stale staged-gen/*.partial (a crashed prior publish must not
+//     accumulate half-copies that exhaust /var — B-P2b);
+//  2. copy staged/* -> staged-gen/<genid>.partial (durable per-file fsync);
+//  3. fsync the .partial, atomic-rename to staged-gen/<genid>, fsync Dir;
+//  4. repoint current-gen -> <genid> via temp-symlink + rename + dir-fsync.
+//
+// The caller is responsible for holding the host-wide upgrade lock (the
+// postinst path serializes publish against an operator cut so GC cannot
+// delete a generation a cut is reading). Publish does NOT take the lock
+// itself so it composes with a caller that already holds it.
+func (c Config) Publish() (genid string, err error) {
+	c.withDefaults()
+	if c.StagedDir == "" {
+		return "", fmt.Errorf("stagedgen: StagedDir is required")
+	}
+	if err := fsatomic.MkdirAllDurable(c.Dir, 0o755); err != nil {
+		return "", fmt.Errorf("stagedgen: create %s: %w", c.Dir, err)
+	}
+
+	// 1. Pre-sweep stale .partial dirs (B-P2b): a crashed prior publish leaves
+	// a half-copy that would otherwise leak /var space until the next GC.
+	c.sweepPartials()
+
+	genid = GenID()
+	// Defensive: GenID is internal, but a path is keyed by it, so validate.
+	if !ValidGenID(genid) {
+		return "", fmt.Errorf("stagedgen: generated an invalid genid %q (bug)", genid)
+	}
+
+	finalDir := c.genDir(genid)
+	partial := finalDir + partialSuffix
+
+	// 2. Copy staged/* -> <genid>.partial.
+	_ = os.RemoveAll(partial)
+	if err := copyTreeFsync(c.StagedDir, partial); err != nil {
+		_ = os.RemoveAll(partial)
+		return "", fmt.Errorf("stagedgen: copy staged -> %s: %w", partial, err)
+	}
+	// 3. Make the .partial contents durable, then atomic-rename it into place.
+	if err := fsatomic.SyncDir(partial); err != nil {
+		_ = os.RemoveAll(partial)
+		return "", fmt.Errorf("stagedgen: fsync partial: %w", err)
+	}
+	if err := os.Rename(partial, finalDir); err != nil {
+		_ = os.RemoveAll(partial)
+		return "", fmt.Errorf("stagedgen: atomic rename %s -> %s: %w", partial, finalDir, err)
+	}
+	if err := fsatomic.SyncDir(c.Dir); err != nil {
+		return "", fmt.Errorf("stagedgen: fsync %s after rename: %w", c.Dir, err)
+	}
+
+	// 4. Atomically repoint current-gen -> <genid>. A crash before this leaves
+	// the prior current-gen valid (the new gen dir is complete but
+	// unreferenced; a re-publish is idempotent, and the GC's protected set
+	// keeps the dir from being prematurely reaped if a journal references it).
+	if err := atomicRelSymlink(c.currentGenPath(), genid); err != nil {
+		return "", fmt.Errorf("stagedgen: repoint current-gen -> %s: %w", genid, err)
+	}
+	c.logf("stagedgen: published generation %s (current-gen -> %s)", genid, genid)
+	return genid, nil
+}
+
+// ResolveCurrent reads the current-gen symlink and returns the genid it names,
+// validated as a safe single path segment. It returns ("", nil) when
+// current-gen is absent (no generation published yet — the cut refuses with no
+// source). A current-gen present but naming an unsafe / missing generation is
+// an error (a corrupt layout must not key a path off it).
+func (c Config) ResolveCurrent() (string, error) {
+	c.withDefaults()
+	target, err := os.Readlink(c.currentGenPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("stagedgen: read current-gen: %w", err)
+	}
+	genid := filepath.Base(target)
+	if !ValidGenID(genid) {
+		return "", fmt.Errorf("stagedgen: current-gen names an unsafe generation %q", genid)
+	}
+	// The dir MUST exist — current-gen is only repointed AFTER the gen dir is
+	// renamed into place, so a dangling current-gen is a corrupt layout.
+	if fi, serr := os.Stat(c.genDir(genid)); serr != nil || !fi.IsDir() {
+		return "", fmt.Errorf("stagedgen: current-gen -> %s but %s is missing or not a directory",
+			genid, c.genDir(genid))
+	}
+	return genid, nil
+}
+
+// GenDir returns the absolute path of a published generation directory. The
+// caller MUST have validated genid (via ValidGenID) before use; this is the
+// directory the cut copies FROM.
+func (c Config) GenDir(genid string) string {
+	c.withDefaults()
+	return c.genDir(genid)
+}
+
+// GC removes generation dirs beyond RetainGenerations (current + 1 prior),
+// NEVER removing the current-gen generation NOR any genid in protected (the
+// generations an active/resumable journal still references — plan §4.B.5 /
+// B-P3 GC-vs-resume protection). It also sweeps .partial orphans. A missing
+// staged-gen root is a no-op.
+func (c Config) GC(protected map[string]bool) error {
+	c.withDefaults()
+	c.sweepPartials()
+
+	entries, err := os.ReadDir(c.Dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stagedgen: read %s: %w", c.Dir, err)
+	}
+
+	prot := map[string]bool{}
+	for g := range protected {
+		prot[g] = true
+	}
+	// The current generation is always protected.
+	if cur, rerr := c.ResolveCurrent(); rerr == nil && cur != "" {
+		prot[cur] = true
+	}
+
+	type gen struct {
+		name string
+		mod  int64
+	}
+	var gens []gen
+	for _, e := range entries {
+		n := e.Name()
+		if n == CurrentGenLink {
+			continue
+		}
+		if strings.HasPrefix(n, ".") { // .partial, temp symlinks
+			continue
+		}
+		if !e.IsDir() {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil {
+			continue
+		}
+		gens = append(gens, gen{name: n, mod: info.ModTime().UnixNano()})
+	}
+	// Newest first.
+	sort.Slice(gens, func(i, j int) bool { return gens[i].mod > gens[j].mod })
+
+	kept := 0
+	removedAny := false
+	for _, g := range gens {
+		if prot[g.name] {
+			kept++
+			continue
+		}
+		if kept < RetainGenerations {
+			kept++
+			continue
+		}
+		c.logf("stagedgen: gc removing old generation %s", g.name)
+		if rerr := os.RemoveAll(c.genDir(g.name)); rerr != nil {
+			c.logf("stagedgen: WARN gc remove %s: %v", g.name, rerr)
+			continue
+		}
+		removedAny = true
+	}
+	if removedAny {
+		if serr := fsatomic.SyncDir(c.Dir); serr != nil {
+			c.logf("stagedgen: WARN fsync %s after gc: %v", c.Dir, serr)
+		}
+	}
+	return nil
+}
+
+// RemoveAll removes the entire staged-generation root (postrm purge / pre-B
+// downgrade cleanup, B-P6). Best-effort; a missing root is a no-op.
+func (c Config) RemoveAll() error {
+	c.withDefaults()
+	if err := os.RemoveAll(c.Dir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("stagedgen: remove %s: %w", c.Dir, err)
+	}
+	return nil
+}
+
+// sweepPartials removes any staged-gen/*.partial dirs (a crashed publish), and
+// fsyncs Dir if it removed anything so the unlink cannot be resurrected.
+func (c Config) sweepPartials() {
+	entries, err := os.ReadDir(c.Dir)
+	if err != nil {
+		return
+	}
+	removedAny := false
+	for _, e := range entries {
+		n := e.Name()
+		if strings.HasSuffix(n, partialSuffix) {
+			_ = os.RemoveAll(filepath.Join(c.Dir, n))
+			removedAny = true
+		}
+	}
+	if removedAny {
+		if serr := fsatomic.SyncDir(c.Dir); serr != nil {
+			c.logf("stagedgen: WARN fsync %s after partial sweep: %v", c.Dir, serr)
+		}
+	}
+}
+
+// ManagedNames returns the managed-binary basenames a published generation
+// contains. Exposed so the cut and tests share the SSOT list.
+func ManagedNames() []string { return manifest.Names() }

--- a/pkg/upgrade/stagedgen/stagedgen.go
+++ b/pkg/upgrade/stagedgen/stagedgen.go
@@ -289,9 +289,11 @@ func (c Config) GenDir(genid string) string {
 }
 
 // GC removes generation dirs beyond RetainGenerations, ordering by genid name
-// (mtime-independent, deterministic — GenID's zero-padded timestamp prefix
-// makes lexicographic name order chronological). It NEVER removes the
-// current-gen generation (resolved explicitly, protected additively) NOR any
+// (mtime-independent and deterministic — GenID's zero-padded wall-clock
+// timestamp prefix makes lexicographic name order USUALLY chronological; an
+// NTP step can reorder, but correctness never depends on it — see below). It
+// NEVER removes the current-gen generation (resolved explicitly, protected
+// additively) NOR any
 // genid in protected (the generations an active/resumable journal still
 // references — plan §4.B.5 / B-P3 GC-vs-resume protection), and it ignores
 // (never counts toward retention, never deletes) any directory whose name is
@@ -325,9 +327,13 @@ func (c Config) GC(protected map[string]bool) error {
 
 	// Collect ONLY valid generation dirs (Copilot): a stray non-generation
 	// directory must neither consume a retention slot nor be deleted. Order by
-	// NAME, newest first — GenID prefixes a zero-padded nanosecond timestamp,
-	// so lexicographic name order is chronological and mtime-INDEPENDENT
-	// (deterministic even when coarse-resolution mtimes tie).
+	// NAME, greatest first — GenID prefixes a zero-padded wall-clock nanosecond
+	// timestamp, so lexicographic name order is mtime-INDEPENDENT and
+	// deterministic (even when coarse-resolution mtimes tie), and USUALLY
+	// chronological. A backward wall-clock step (NTP) can reorder, but
+	// correctness never depends on it: current-gen and journal-referenced
+	// generations are protected EXPLICITLY (below), so a misordering at most
+	// changes which NON-protected, non-live generation is reaped first.
 	var gens []string
 	for _, e := range entries {
 		n := e.Name()

--- a/pkg/upgrade/stagedgen/stagedgen.go
+++ b/pkg/upgrade/stagedgen/stagedgen.go
@@ -325,8 +325,17 @@ func (c Config) GC(protected map[string]bool) error {
 		}
 		gens = append(gens, gen{name: n, mod: info.ModTime().UnixNano()})
 	}
-	// Newest first.
-	sort.Slice(gens, func(i, j int) bool { return gens[i].mod > gens[j].mod })
+	// Newest first, with a genid (name) tie-breaker so retention is
+	// DETERMINISTIC when two generations share a coarse-resolution mtime
+	// (Copilot): GenID prefixes a zero-padded nanosecond timestamp, so the
+	// lexicographically-greater name is the chronologically-later generation —
+	// the right tie-break for "newest first".
+	sort.Slice(gens, func(i, j int) bool {
+		if gens[i].mod != gens[j].mod {
+			return gens[i].mod > gens[j].mod
+		}
+		return gens[i].name > gens[j].name
+	})
 
 	kept := 0
 	removedAny := false

--- a/pkg/upgrade/stagedgen/stagedgen_test.go
+++ b/pkg/upgrade/stagedgen/stagedgen_test.go
@@ -143,6 +143,31 @@ func TestPublishIsImmutableSource(t *testing.T) {
 	}
 }
 
+// TestResolveCurrentRejectsPathEscape pins the Copilot r4 hardening: a
+// current-gen symlink whose target carries path components (../<genid>,
+// /abs/<genid>) is rejected, not silently base-named into an in-tree genid.
+func TestResolveCurrentRejectsPathEscape(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+	genid, err := c.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range []string{"../" + genid, "/tmp/" + genid, "sub/" + genid} {
+		// Repoint current-gen at a path-bearing target.
+		link := filepath.Join(c.Dir, CurrentGenLink)
+		_ = os.Remove(link)
+		if err := os.Symlink(bad, link); err != nil {
+			t.Fatal(err)
+		}
+		if _, rerr := c.ResolveCurrent(); rerr == nil {
+			t.Errorf("ResolveCurrent accepted a path-escaping current-gen target %q", bad)
+		}
+	}
+}
+
 func TestResolveCurrentDanglingIsError(t *testing.T) {
 	root := t.TempDir()
 	staged := filepath.Join(root, "staged")

--- a/pkg/upgrade/stagedgen/stagedgen_test.go
+++ b/pkg/upgrade/stagedgen/stagedgen_test.go
@@ -1,0 +1,355 @@
+package stagedgen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeStaged builds a staged tree with one file per managed binary, each
+// carrying the given tag so a published generation's contents are
+// distinguishable.
+func writeStaged(t *testing.T, dir, tag string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range ManagedNames() {
+		p := filepath.Join(dir, b)
+		if err := os.WriteFile(p, []byte("binary-"+b+"-"+tag), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func newConfig(t *testing.T, staged string) Config {
+	t.Helper()
+	return Config{
+		StagedDir: staged,
+		Dir:       filepath.Join(t.TempDir(), "staged-gen"),
+		Logf:      func(f string, a ...any) { t.Logf("stagedgen: "+f, a...) },
+	}
+}
+
+func TestPublishAndResolve(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+
+	genid, err := c.Publish()
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !ValidGenID(genid) {
+		t.Fatalf("Publish returned an invalid genid %q", genid)
+	}
+
+	// current-gen resolves to the published genid.
+	got, err := c.ResolveCurrent()
+	if err != nil {
+		t.Fatalf("ResolveCurrent: %v", err)
+	}
+	if got != genid {
+		t.Fatalf("ResolveCurrent = %q, want %q", got, genid)
+	}
+
+	// The generation dir holds every managed binary with the v1 tag.
+	for _, b := range ManagedNames() {
+		data, rerr := os.ReadFile(filepath.Join(c.GenDir(genid), b))
+		if rerr != nil {
+			t.Fatalf("read published %s: %v", b, rerr)
+		}
+		if string(data) != "binary-"+b+"-v1" {
+			t.Fatalf("published %s = %q, want v1 tag", b, data)
+		}
+	}
+	// No .partial leaked.
+	assertNoPartials(t, c.Dir)
+}
+
+func TestResolveCurrentAbsent(t *testing.T) {
+	c := newConfig(t, t.TempDir())
+	got, err := c.ResolveCurrent()
+	if err != nil {
+		t.Fatalf("ResolveCurrent on absent: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("ResolveCurrent on absent = %q, want empty", got)
+	}
+}
+
+func TestPublishDistinctGenerations(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+
+	g1, err := c.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Re-publish the SAME staged bytes: a same-version reinstall must still
+	// yield a DISTINCT generation (B-P5 random suffix), and current-gen must
+	// advance to it.
+	g2, err := c.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g1 == g2 {
+		t.Fatalf("two publishes produced the same genid %q", g1)
+	}
+	cur, _ := c.ResolveCurrent()
+	if cur != g2 {
+		t.Fatalf("current-gen = %q after second publish, want %q", cur, g2)
+	}
+	// Both generation dirs survive (retention N=2 keeps current + 1 prior).
+	for _, g := range []string{g1, g2} {
+		if fi, err := os.Stat(c.GenDir(g)); err != nil || !fi.IsDir() {
+			t.Fatalf("generation dir %s missing after two publishes", g)
+		}
+	}
+}
+
+// TestPublishIsImmutableSource is the crux of #1981: a published generation is
+// a SNAPSHOT. Mutating live staged/ AFTER a publish must NOT change the
+// published generation's bytes — the cut reads the snapshot, not the live tree.
+func TestPublishIsImmutableSource(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "clean")
+	c := newConfig(t, staged)
+
+	genid, err := c.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tear the live staged tree: replace one binary with a "torn" payload, as
+	// dpkg would mid-unpack.
+	torn := filepath.Join(staged, "xpf-userspace-dp")
+	if err := os.WriteFile(torn, []byte("TORN-half-unpacked"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The published generation is unchanged.
+	data, err := os.ReadFile(filepath.Join(c.GenDir(genid), "xpf-userspace-dp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "binary-xpf-userspace-dp-clean" {
+		t.Fatalf("published generation was mutated by a live staged/ change: %q", data)
+	}
+}
+
+func TestResolveCurrentDanglingIsError(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+	genid, err := c.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Remove the gen dir but leave current-gen dangling — a corrupt layout.
+	if err := os.RemoveAll(c.GenDir(genid)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.ResolveCurrent(); err == nil {
+		t.Fatal("ResolveCurrent on a dangling current-gen should error")
+	}
+}
+
+// TestCrashBeforeCurrentGenRepoint simulates a publish crash after the gen dir
+// rename but before the current-gen repoint: the PRIOR current-gen stays
+// valid, and a re-publish converges.
+func TestCrashBeforeCurrentGenRepoint(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+	g1, err := c.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a crashed second publish: a complete-but-unreferenced gen dir
+	// exists, but current-gen still names g1.
+	orphan := filepath.Join(c.Dir, GenID())
+	if err := copyTreeFsync(staged, orphan); err != nil {
+		t.Fatal(err)
+	}
+	// current-gen must still resolve to g1 (prior generation valid).
+	cur, err := c.ResolveCurrent()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cur != g1 {
+		t.Fatalf("current-gen = %q, want the prior valid generation %q", cur, g1)
+	}
+	// A re-publish converges current-gen to a fresh generation.
+	g3, err := c.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cur, _ = c.ResolveCurrent()
+	if cur != g3 {
+		t.Fatalf("current-gen = %q after re-publish, want %q", cur, g3)
+	}
+}
+
+func TestSweepPartialsOnPublish(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+	if _, err := c.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	// Drop a stale .partial as a crashed prior publish would.
+	stale := filepath.Join(c.Dir, GenID()+partialSuffix)
+	if err := os.MkdirAll(stale, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stale, "junk"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The next publish pre-sweeps it.
+	if _, err := c.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	assertNoPartials(t, c.Dir)
+}
+
+func TestGCRetainsCurrentPlusOne(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+
+	var gens []string
+	for i := 0; i < 4; i++ {
+		g, err := c.Publish()
+		if err != nil {
+			t.Fatal(err)
+		}
+		gens = append(gens, g)
+		// Bump the mtime so the sort order is unambiguous (publishes can land
+		// in the same coarse mtime tick).
+		bumpMtime(t, c.GenDir(g), int64(i+1))
+	}
+	if err := c.GC(nil); err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	// Newest two survive (current + 1 prior); the older two are gone.
+	for i, g := range gens {
+		_, err := os.Stat(c.GenDir(g))
+		surviving := i >= len(gens)-RetainGenerations
+		if surviving && err != nil {
+			t.Errorf("generation %s should survive GC but is gone", g)
+		}
+		if !surviving && err == nil {
+			t.Errorf("generation %s should be GC'd but survives", g)
+		}
+	}
+}
+
+// TestGCProtectsJournalReferencedGen pins the GC-vs-resume race (plan §7.7): a
+// generation an in-flight cut still references must NOT be GC'd even when it is
+// older than the retention window.
+func TestGCProtectsJournalReferencedGen(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+
+	// g0 is the cut's pinned source; publish three newer generations so g0
+	// would normally fall outside the N=2 window.
+	g0, err := c.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bumpMtime(t, c.GenDir(g0), 1)
+	for i := 0; i < 3; i++ {
+		g, err := c.Publish()
+		if err != nil {
+			t.Fatal(err)
+		}
+		bumpMtime(t, c.GenDir(g), int64(i+2))
+	}
+	// Protect g0 as a journal-referenced generation.
+	if err := c.GC(map[string]bool{g0: true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(c.GenDir(g0)); err != nil {
+		t.Fatalf("GC removed a journal-referenced generation %s: %v", g0, err)
+	}
+
+	// Counter-factual: WITHOUT the protection, g0 is reaped.
+	if err := c.GC(nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(c.GenDir(g0)); err == nil {
+		t.Fatalf("g0 survived an unprotected GC — the protection test is tautological")
+	}
+}
+
+func TestRemoveAll(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+	if _, err := c.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RemoveAll(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(c.Dir); !os.IsNotExist(err) {
+		t.Fatalf("RemoveAll left %s present", c.Dir)
+	}
+	// Idempotent on an absent root.
+	if err := c.RemoveAll(); err != nil {
+		t.Fatalf("RemoveAll on absent root: %v", err)
+	}
+}
+
+func TestValidGenID(t *testing.T) {
+	if !ValidGenID(GenID()) {
+		t.Fatal("GenID produced an invalid id")
+	}
+	bad := []string{
+		"", "current-gen", "..", "../escape", "a/b", ".hidden",
+		"00000000000000000000-aabb-ccdd", // two dashes
+		"00000000000000000000-XYZ",       // uppercase / non-hex
+		"00000000000000000000",           // no dash
+	}
+	for _, s := range bad {
+		if ValidGenID(s) {
+			t.Errorf("ValidGenID(%q) = true, want false", s)
+		}
+	}
+}
+
+func assertNoPartials(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == partialSuffix {
+			t.Errorf("leftover partial %s", e.Name())
+		}
+	}
+}
+
+func bumpMtime(t *testing.T, path string, secs int64) {
+	t.Helper()
+	base := int64(1_700_000_000)
+	mt := time.Unix(base+secs, 0)
+	if err := os.Chtimes(path, mt, mt); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/upgrade/stagedgen/stagedgen_test.go
+++ b/pkg/upgrade/stagedgen/stagedgen_test.go
@@ -324,6 +324,72 @@ func TestGCProtectedDoesNotConsumeRetentionWindow(t *testing.T) {
 	}
 }
 
+// TestGCIgnoresNonGenerationDirs pins the Copilot fix: a stray non-genid
+// directory in the staged-gen root is neither counted toward retention nor
+// deleted by GC.
+func TestGCIgnoresNonGenerationDirs(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+
+	g0, _ := c.Publish()
+	g1, _ := c.Publish()
+	g2, _ := c.Publish() // current-gen
+	// A stray foreign directory (not a valid genid).
+	stray := filepath.Join(c.Dir, "operator-scratch")
+	if err := os.MkdirAll(stray, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.GC(nil); err != nil {
+		t.Fatal(err)
+	}
+	// The stray dir is untouched (not counted, not deleted).
+	if _, err := os.Stat(stray); err != nil {
+		t.Errorf("GC deleted a non-generation directory: %v", err)
+	}
+	// Retention is computed over generations only: newest 2 (g2,g1) survive,
+	// g0 reaped — the stray did NOT consume a slot that would save g0.
+	if _, err := os.Stat(c.GenDir(g0)); err == nil {
+		t.Errorf("g0 survived — a stray dir wrongly consumed a retention slot")
+	}
+	for _, g := range []string{g1, g2} {
+		if _, err := os.Stat(c.GenDir(g)); err != nil {
+			t.Errorf("in-window generation %s wrongly GC'd: %v", g, err)
+		}
+	}
+}
+
+// TestGCProtectsCurrentGenEvenIfNotNewest pins the Copilot fix: current-gen is
+// resolved EXPLICITLY and protected additively, so it survives GC even if it
+// is NOT the lexicographically-newest generation (e.g. current-gen was
+// repointed back to an older generation).
+func TestGCProtectsCurrentGenEvenIfNotNewest(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+
+	g0, _ := c.Publish() // oldest
+	c.Publish()          // g1
+	c.Publish()          // g2 (newest, current-gen now)
+	// Repoint current-gen back to the OLDEST generation g0 (atypical, but the
+	// GC must protect whatever current-gen names).
+	if err := atomicRelSymlink(filepath.Join(c.Dir, CurrentGenLink), g0); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.GC(nil); err != nil {
+		t.Fatal(err)
+	}
+	// g0 is current-gen — must survive even though it is the oldest (outside
+	// the newest-2 name window).
+	if _, err := os.Stat(c.GenDir(g0)); err != nil {
+		t.Fatalf("GC deleted current-gen (g0) because it was not the newest: %v", err)
+	}
+}
+
 func TestRemoveAll(t *testing.T) {
 	root := t.TempDir()
 	staged := filepath.Join(root, "staged")

--- a/pkg/upgrade/stagedgen/stagedgen_test.go
+++ b/pkg/upgrade/stagedgen/stagedgen_test.go
@@ -295,6 +295,35 @@ func TestGCProtectsJournalReferencedGen(t *testing.T) {
 	}
 }
 
+// TestGCProtectedDoesNotConsumeRetentionWindow pins the Copilot fix: a
+// protected (journal-pinned) OLD generation must NOT consume a retention slot,
+// so the immediate-prior-to-current generation still survives.
+func TestGCProtectedDoesNotConsumeRetentionWindow(t *testing.T) {
+	root := t.TempDir()
+	staged := filepath.Join(root, "staged")
+	writeStaged(t, staged, "v1")
+	c := newConfig(t, staged)
+
+	// Publish g0 (oldest), g1, g2 (newest = current-gen). Protect the OLDEST.
+	g0, _ := c.Publish()
+	bumpMtime(t, c.GenDir(g0), 1)
+	g1, _ := c.Publish()
+	bumpMtime(t, c.GenDir(g1), 2)
+	g2, _ := c.Publish()
+	bumpMtime(t, c.GenDir(g2), 3)
+
+	if err := c.GC(map[string]bool{g0: true}); err != nil {
+		t.Fatal(err)
+	}
+	// current-gen g2 always kept; g0 protected; AND g1 (the immediate prior to
+	// current) must survive because g0's protection did NOT eat its slot.
+	for _, g := range []string{g0, g1, g2} {
+		if _, err := os.Stat(c.GenDir(g)); err != nil {
+			t.Errorf("generation %s should survive (protected g0 must not push g1 out of the window): %v", g, err)
+		}
+	}
+}
+
 func TestRemoveAll(t *testing.T) {
 	root := t.TempDir()
 	staged := filepath.Join(root, "staged")

--- a/pkg/upgrade/stagedgen_cut_test.go
+++ b/pkg/upgrade/stagedgen_cut_test.go
@@ -149,6 +149,34 @@ func TestCut_SupersededByNewVersionGenerationStartsFresh(t *testing.T) {
 	}
 }
 
+// TestReadJournalSourceGeneration pins the GC-protection seam the
+// publish-generation verb uses (Codex r5-#3): the verb reads the on-disk
+// journal's pinned generation so its GC does not reap a crashed/resumable
+// cut's source.
+func TestReadJournalSourceGeneration(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+
+	// Absent journal -> "".
+	if g, err := ReadJournalSourceGeneration(cfg.JournalPath); err != nil || g != "" {
+		t.Fatalf("absent journal: got (%q,%v), want (\"\",nil)", g, err)
+	}
+	// A journal pinning g0 -> g0.
+	if err := r.saveJournal(&Journal{TargetVersion: "2.0.0", State: StateCopied, SourceGeneration: "g0-deadbeef"}); err != nil {
+		t.Fatal(err)
+	}
+	if g, err := ReadJournalSourceGeneration(cfg.JournalPath); err != nil || g != "g0-deadbeef" {
+		t.Fatalf("pinned journal: got (%q,%v), want (g0-deadbeef,nil)", g, err)
+	}
+	// A legacy journal with no pin -> "".
+	if err := r.saveJournal(&Journal{TargetVersion: "2.0.0", State: StateCopied}); err != nil {
+		t.Fatal(err)
+	}
+	if g, err := ReadJournalSourceGeneration(cfg.JournalPath); err != nil || g != "" {
+		t.Fatalf("legacy journal: got (%q,%v), want (\"\",nil)", g, err)
+	}
+}
+
 // TestCut_NoSourceGenerationRefusesAtInit pins plan §7.2: a fresh cut with NO
 // published generation refuses at INIT — no journal written, no DB snapshot
 // taken, daemon untouched.
@@ -253,11 +281,94 @@ func TestCut_SameVersionDifferentGenerationRefusesOnLive(t *testing.T) {
 	if !strings.Contains(err.Error(), "cannot replace the live/rollback version dir") {
 		t.Fatalf("error is not the live-dir replacement refusal: %v", err)
 	}
-	// No live mutation (pure pre-PREFLIGHT refusal).
+	// The refusal is pre-PREFLIGHT (Codex r5-#2): no journal, no .dbsnap, no
+	// live mutation — a re-run then re-resolves rather than resuming a journal
+	// that would re-refuse forever.
+	if _, serr := os.Stat(cfg.JournalPath); !os.IsNotExist(serr) {
+		t.Errorf("journal written on a pre-PREFLIGHT live-dir refusal: %v", serr)
+	}
+	if matches, _ := filepath.Glob(filepath.Join(cfg.VersionsDir, ".*.dbsnap")); len(matches) != 0 {
+		t.Errorf(".dbsnap taken on a pre-PREFLIGHT live-dir refusal: %v", matches)
+	}
 	for _, c := range fs.calls {
-		if c == "stop" || c == "dropin" {
-			t.Errorf("live mutation %q on a live-dir replacement refusal", c)
+		if c == "stop" || c == "dropin" || c == "verify" {
+			t.Errorf("phase %q ran on a pre-PREFLIGHT live-dir refusal", c)
 		}
+	}
+}
+
+// TestCut_UnstampedStaleVersionDirIsReplaced pins Codex r5-#1: a pre-#1981
+// versions/<ver> with NO .srcgen that is STALE (non-live) must be
+// guarded-replaced from the pinned generation, NOT reused — else a pre-fix
+// torn copy could be committed under a fresh generation.
+func TestCut_UnstampedStaleVersionDirIsReplaced(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0") // 1.0.0 is live; 2.0.0 is stale.
+
+	// A STALE, UNSTAMPED versions/2.0.0 (a pre-#1981 torn/abandoned copy).
+	staleDir := filepath.Join(cfg.VersionsDir, "2.0.0")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range managedBins {
+		if err := os.WriteFile(filepath.Join(staleDir, b), []byte("STALE-pre1981-"+b), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// No .srcgen stamp (pre-#1981 layout).
+
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("cut: %v", err)
+	}
+	// The committed dir must hold the FRESH published bytes (recopied), not the
+	// stale unstamped bytes.
+	got, err := os.ReadFile(filepath.Join(cfg.VersionsDir, "2.0.0", "xpfd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "binary-xpfd-2.0.0" {
+		t.Fatalf("cut REUSED a stale unstamped version dir: %q (want fresh recopy)", got)
+	}
+	// And it now carries the .srcgen stamp.
+	if _, serr := os.Stat(filepath.Join(cfg.VersionsDir, "2.0.0", stagedgen.SrcGenFile)); serr != nil {
+		t.Errorf("recopied dir missing .srcgen stamp: %v", serr)
+	}
+}
+
+// TestCut_RepinsPreB981ResumeBeforeCopy pins Codex r5-#4: a pre-#1981 journal
+// resumed at STAGED/PREFLIGHT (empty SourceGeneration, not yet COPIED) is
+// RE-PINNED to the published generation, so the copy reads the pinned
+// generation, not live staged/.
+func TestCut_RepinsPreB981ResumeBeforeCopy(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	// A pre-#1981 journal at STAGED with NO SourceGeneration (as the old binary
+	// would have written).
+	jLegacy := &Journal{TargetVersion: "2.0.0", PreviousVersion: "1.0.0", State: StateStaged}
+	if err := r.saveJournal(jLegacy); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tear live staged/ so a live-staged read would be detectable.
+	if err := os.WriteFile(filepath.Join(cfg.StagedDir, "xpf-userspace-dp"), []byte("TORN"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	// The committed dir must hold the CLEAN published bytes (re-pinned), not the
+	// torn live staged/ bytes.
+	got, _ := os.ReadFile(filepath.Join(cfg.VersionsDir, "2.0.0", "xpf-userspace-dp"))
+	if string(got) != "binary-xpf-userspace-dp-2.0.0" {
+		t.Fatalf("pre-#1981 resume read torn live staged/ instead of the re-pinned generation: %q", got)
+	}
+	// The version dir carries a .srcgen stamp (the resume was re-pinned).
+	if _, serr := os.Stat(filepath.Join(cfg.VersionsDir, "2.0.0", stagedgen.SrcGenFile)); serr != nil {
+		t.Errorf("re-pinned resume missing .srcgen stamp: %v", serr)
 	}
 }
 

--- a/pkg/upgrade/stagedgen_cut_test.go
+++ b/pkg/upgrade/stagedgen_cut_test.go
@@ -91,6 +91,64 @@ func TestCut_CounterFactual_LegacyReadsTornStaged(t *testing.T) {
 	}
 }
 
+// TestCut_SupersededByNewVersionGenerationStartsFresh pins the resume-vs-fresh
+// interplay with #1981: a journal pinned to an OLD generation/version is
+// SUPERSEDED when a newer apt install publishes a NEW-version generation. The
+// resume must detect the version mismatch (via current-gen, not the pinned
+// generation) and start fresh against the new generation — not silently resume
+// the abandoned cut.
+func TestCut_SupersededByNewVersionGenerationStartsFresh(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs) // publishes gen of 2.0.0
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	sg := r.stagedGenConfig()
+	gOld, _ := sg.ResolveCurrent()
+
+	// A pure-phase journal pinned to the OLD 2.0.0 generation (e.g. a cut that
+	// reached COPIED then was abandoned).
+	verDir := filepath.Join(cfg.VersionsDir, "2.0.0")
+	for _, b := range managedBins {
+		writeFakeBin(t, filepath.Join(verDir, b), "binary-"+b+"-2.0.0")
+	}
+	if err := os.WriteFile(filepath.Join(verDir, stagedgen.SrcGenFile), []byte(gOld+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jStale := &Journal{TargetVersion: "2.0.0", PreviousVersion: "1.0.0",
+		State: StateCopied, SourceGeneration: gOld}
+	if err := r.saveJournal(jStale); err != nil {
+		t.Fatal(err)
+	}
+
+	// A newer apt install stages + publishes a NEW-version generation (3.0.0).
+	fs.stagedVersion = "3.0.0"
+	for _, b := range managedBins {
+		writeFakeBin(t, filepath.Join(cfg.StagedDir, b), "binary-"+b+"-3.0.0")
+	}
+	gNew, err := sg.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gNew == gOld {
+		t.Fatal("publish did not advance the generation")
+	}
+
+	// Resume: the version compare (current-gen = 3.0.0 != journal 2.0.0)
+	// supersedes the stale cut and starts fresh against 3.0.0.
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("superseded resume: %v", err)
+	}
+	cur, _ := os.Readlink(filepath.Join(cfg.VersionsDir, currentLink))
+	if filepath.Base(cur) != "3.0.0" {
+		t.Fatalf("current = %q after superseded resume, want 3.0.0", cur)
+	}
+	// The 3.0.0 version dir's .srcgen names the NEW generation.
+	stamp, _ := os.ReadFile(filepath.Join(cfg.VersionsDir, "3.0.0", stagedgen.SrcGenFile))
+	if strings.TrimSpace(string(stamp)) != gNew {
+		t.Fatalf("3.0.0 .srcgen = %q, want the new generation %q", stamp, gNew)
+	}
+}
+
 // TestCut_NoSourceGenerationRefusesAtInit pins plan §7.2: a fresh cut with NO
 // published generation refuses at INIT — no journal written, no DB snapshot
 // taken, daemon untouched.

--- a/pkg/upgrade/stagedgen_cut_test.go
+++ b/pkg/upgrade/stagedgen_cut_test.go
@@ -1,0 +1,333 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/upgrade/stagedgen"
+)
+
+// TestCut_ReadsPinnedGenerationNotTornStaged is the #1981 acceptance pin: a cut
+// reads the PINNED, published staged generation, NEVER live staged/. We publish
+// a CLEAN generation, then tear live staged/ to a half-unpacked mix, then drive
+// a full cut and assert versions/<ver> holds the CLEAN bytes — proving the cut
+// never read the torn live tree.
+//
+// Non-tautological by construction: the COUNTER-FACTUAL below drives the
+// pre-fix behavior (copyStaged reading live staged/, modeled by an empty
+// SourceGeneration legacy cut) against the SAME torn staged/ and shows it
+// publishes the TORN bytes. So the assertion only passes because the cut is
+// pinned to the generation, not because the torn write was inert.
+func TestCut_ReadsPinnedGenerationNotTornStaged(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs) // publishes a clean gen of version 2.0.0
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	// Tear live staged/: replace the lockstep dataplane binary with a
+	// half-unpacked payload, as dpkg would mid-unpack. The CLEAN bytes were
+	// already captured in the published generation by testEnv's publish.
+	tornPath := filepath.Join(cfg.StagedDir, "xpf-userspace-dp")
+	if err := os.WriteFile(tornPath, []byte("TORN-half-unpacked-dp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("cut: %v", err)
+	}
+
+	// The committed version dir must hold the CLEAN published bytes, not the
+	// torn live staged/ bytes.
+	got, err := os.ReadFile(filepath.Join(cfg.VersionsDir, "2.0.0", "xpf-userspace-dp"))
+	if err != nil {
+		t.Fatalf("read committed binary: %v", err)
+	}
+	if string(got) != "binary-xpf-userspace-dp-2.0.0" {
+		t.Fatalf("cut consumed the TORN live staged/ bytes, not the pinned generation: %q", got)
+	}
+
+	// The version dir must carry a .srcgen stamp naming a valid generation.
+	stamp, serr := os.ReadFile(filepath.Join(cfg.VersionsDir, "2.0.0", stagedgen.SrcGenFile))
+	if serr != nil {
+		t.Fatalf("version dir missing .srcgen stamp: %v", serr)
+	}
+	if !stagedgen.ValidGenID(strings.TrimSpace(string(stamp))) {
+		t.Fatalf(".srcgen does not name a valid generation: %q", stamp)
+	}
+}
+
+// TestCut_CounterFactual_LegacyReadsTornStaged is the counter-factual that pins
+// the test above: with an empty SourceGeneration (the pre-#1981 legacy path
+// that reads live staged/), copyStaged DOES consume the torn bytes. This proves
+// the fixed path's clean read is the fix, not an inert torn write.
+func TestCut_CounterFactual_LegacyReadsTornStaged(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+
+	// Tear live staged/.
+	tornPath := filepath.Join(cfg.StagedDir, "xpf-userspace-dp")
+	if err := os.WriteFile(tornPath, []byte("TORN-half-unpacked-dp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drive copyStaged directly with an empty SourceGeneration (legacy path).
+	j := &Journal{TargetVersion: "2.0.0", State: StateStaged} // SourceGeneration == ""
+	if err := r.copyStaged(j); err != nil {
+		t.Fatalf("legacy copyStaged: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(cfg.VersionsDir, "2.0.0", "xpf-userspace-dp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "TORN-half-unpacked-dp" {
+		t.Fatalf("counter-factual did NOT read the torn live staged/ (got %q) — the "+
+			"regression test is tautological", got)
+	}
+	// The legacy path must NOT stamp a .srcgen (so a later resume recognizes it
+	// as a pre-#1981 dir).
+	if _, serr := os.Stat(filepath.Join(cfg.VersionsDir, "2.0.0", stagedgen.SrcGenFile)); !os.IsNotExist(serr) {
+		t.Errorf("legacy copyStaged stamped a .srcgen; want none on the empty-generation path")
+	}
+}
+
+// TestCut_NoSourceGenerationRefusesAtInit pins plan §7.2: a fresh cut with NO
+// published generation refuses at INIT — no journal written, no DB snapshot
+// taken, daemon untouched.
+func TestCut_NoSourceGenerationRefusesAtInit(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	// Remove the published generation so current-gen is absent.
+	if err := os.RemoveAll(cfg.StagedGenDir); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.Run(Options{})
+	if err == nil {
+		t.Fatal("expected a no-source refusal")
+	}
+	if !strings.Contains(err.Error(), "no published staged generation") {
+		t.Fatalf("error is not a no-source refusal: %v", err)
+	}
+	// No journal written.
+	if _, serr := os.Stat(cfg.JournalPath); !os.IsNotExist(serr) {
+		t.Errorf("journal written on a no-source refusal: %v", serr)
+	}
+	// No DB snapshot taken.
+	if matches, _ := filepath.Glob(filepath.Join(cfg.VersionsDir, ".*.dbsnap")); len(matches) != 0 {
+		t.Errorf("DB snapshot taken on a no-source refusal: %v", matches)
+	}
+	// No live mutation.
+	for _, c := range fs.calls {
+		if c == "stop" || c == "start" || c == "dropin" {
+			t.Errorf("live mutation %q on a no-source refusal", c)
+		}
+	}
+	// current still points at the seeded prior version.
+	cur, _ := os.Readlink(filepath.Join(cfg.VersionsDir, currentLink))
+	if filepath.Base(cur) != "1.0.0" {
+		t.Errorf("current moved off 1.0.0 on a no-source refusal: %q", cur)
+	}
+}
+
+// TestCut_SameVersionDifferentGenerationRecopies pins plan §7.8 (B-P3b OPT1):
+// a same-version re-stage with NEW bytes (a new generation) re-copies into a
+// STALE non-live versions/<ver> instead of skipping it. Counter-factual: a
+// version-only skip would ship the stale bytes.
+func TestCut_SameVersionDifferentGenerationRecopies(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	// Stage a STALE versions/2.0.0 from generation g1 (bytes "stale"), as a
+	// prior abandoned attempt would leave. It is NOT current (1.0.0 is) and not
+	// the rollback target, so it is a stale non-live dir.
+	staleDir := filepath.Join(cfg.VersionsDir, "2.0.0")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range managedBins {
+		if err := os.WriteFile(filepath.Join(staleDir, b), []byte("stale-"+b), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(staleDir, stagedgen.SrcGenFile), []byte("g1-stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The current published generation (from testEnv) holds the FRESH 2.0.0
+	// bytes ("binary-..."), with a DIFFERENT genid than the stale "g1-stale".
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("cut: %v", err)
+	}
+
+	// The committed version dir must hold the FRESH published bytes (recopied),
+	// not the stale ones — proving the generation-aware skip recopied.
+	got, err := os.ReadFile(filepath.Join(cfg.VersionsDir, "2.0.0", "xpfd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "binary-xpfd-2.0.0" {
+		t.Fatalf("cut shipped STALE bytes (version-only skip): %q", got)
+	}
+}
+
+// TestCut_SameVersionDifferentGenerationRefusesOnLive pins B-P3b OPT1's refusal
+// arm: a same-version-different-generation cut REFUSES when versions/<ver> is
+// the LIVE current target (cannot safely mutate a live version dir mid-cut).
+func TestCut_SameVersionDifferentGenerationRefusesOnLive(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	// Seed 2.0.0 as the LIVE current with a DIFFERENT-generation stamp so the
+	// cut's pinned generation differs from the live dir's.
+	seedInitialCurrent(t, r, cfg, "2.0.0")
+	liveStamp := filepath.Join(cfg.VersionsDir, "2.0.0", stagedgen.SrcGenFile)
+	if err := os.WriteFile(liveStamp, []byte("g-old-live\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.Run(Options{})
+	if err == nil {
+		t.Fatal("expected a refusal to replace the live version dir")
+	}
+	if !strings.Contains(err.Error(), "cannot replace the live/rollback version dir") {
+		t.Fatalf("error is not the live-dir replacement refusal: %v", err)
+	}
+	// No live mutation (pure pre-PREFLIGHT refusal).
+	for _, c := range fs.calls {
+		if c == "stop" || c == "dropin" {
+			t.Errorf("live mutation %q on a live-dir replacement refusal", c)
+		}
+	}
+}
+
+// TestCut_GCProtectsInFlightSourceGeneration pins plan §7.7 (GC-vs-resume) at
+// the cut level: a cut journaled with a pinned SourceGeneration must keep that
+// generation across a GC even when newer generations have been published and
+// the pinned one has fallen outside the N=2 retention window — so a resume can
+// still find its source.
+func TestCut_GCProtectsInFlightSourceGeneration(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	sg := r.stagedGenConfig()
+	// The cut pins g0 (current-gen at INIT) — model an in-flight journal.
+	g0, err := sg.ResolveCurrent()
+	if err != nil || g0 == "" {
+		t.Fatalf("resolve pinned generation: %v (%q)", err, g0)
+	}
+	j := &Journal{TargetVersion: "2.0.0", PreviousVersion: "1.0.0",
+		State: StateCopied, SourceGeneration: g0}
+
+	// Newer generations are published (a concurrent upgrade), advancing
+	// current-gen so g0 falls outside the N=2 retention window.
+	for i := 0; i < 2; i++ {
+		if _, perr := sg.Publish(); perr != nil {
+			t.Fatal(perr)
+		}
+	}
+
+	// The cut's GC (journal-protected) must keep g0.
+	if gcErr := r.gc(j); gcErr != nil {
+		t.Fatalf("gc: %v", gcErr)
+	}
+	if _, serr := os.Stat(sg.GenDir(g0)); serr != nil {
+		t.Fatalf("GC deleted the in-flight (journal-pinned) source generation %s: %v", g0, serr)
+	}
+
+	// Counter-factual: an unprotected GC (empty SourceGeneration) reaps g0.
+	jUnprotected := &Journal{TargetVersion: "2.0.0", PreviousVersion: "1.0.0", State: StateCopied}
+	if gcErr := r.gc(jUnprotected); gcErr != nil {
+		t.Fatal(gcErr)
+	}
+	if _, serr := os.Stat(sg.GenDir(g0)); serr == nil {
+		t.Fatal("g0 survived an unprotected GC — the protection test is tautological")
+	}
+}
+
+// TestCut_AbortedUnpackLeavesPriorGenerationValid pins plan §7.4: a failed/
+// aborted unpack simply does NOT publish a new generation; the PRIOR
+// generation stays valid and a cut from it succeeds. This is the test that
+// would FAIL under Option A (a stranded sentinel permanently wedges the host)
+// — Option B has the permanent-wedge class structurally absent.
+func TestCut_AbortedUnpackLeavesPriorGenerationValid(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs) // publishes the GOOD generation of version 2.0.0
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	sg := r.stagedGenConfig()
+	priorGen, _ := sg.ResolveCurrent()
+
+	// Model an aborted unpack: dpkg started rewriting staged/ (it is now torn)
+	// but the postinst NEVER published a new generation. current-gen still
+	// names the prior good generation.
+	if err := os.WriteFile(filepath.Join(cfg.StagedDir, "xpfd"), []byte("TORN-aborted-unpack"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A cut still succeeds, reading the PRIOR valid generation — no
+	// permanent-wedge, no torn read.
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("cut after an aborted unpack should succeed from the prior generation: %v", err)
+	}
+	if cur, _ := sg.ResolveCurrent(); cur != priorGen {
+		t.Fatalf("current-gen moved to %q; an aborted unpack must leave the prior %q", cur, priorGen)
+	}
+	got, _ := os.ReadFile(filepath.Join(cfg.VersionsDir, "2.0.0", "xpfd"))
+	if string(got) != "binary-xpfd-2.0.0" {
+		t.Fatalf("cut consumed torn aborted-unpack bytes: %q", got)
+	}
+}
+
+// TestCut_ResumePinnedGenerationAfterCurrentGenAdvances pins B-P3: a resuming
+// cut keeps reading its ORIGINALLY-pinned generation even if a concurrent
+// publish has advanced current-gen — the resume must not silently switch
+// sources mid-cut.
+func TestCut_ResumePinnedGenerationAfterCurrentGenAdvances(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	seedInitialCurrent(t, r, cfg, "1.0.0")
+
+	sg := r.stagedGenConfig()
+	g0, _ := sg.ResolveCurrent()
+
+	// Model a crash at StateCopied: journal the pinned state directly (a real
+	// run that crashed after COPY would leave exactly this).
+	jCopied := &Journal{TargetVersion: "2.0.0", PreviousVersion: "1.0.0",
+		State: StateCopied, SourceGeneration: g0}
+	// Stamp the copied dir with g0 so the resume's copyStaged sees a true
+	// same-generation resume (skip).
+	verDir := filepath.Join(cfg.VersionsDir, "2.0.0")
+	for _, b := range managedBins {
+		writeFakeBin(t, filepath.Join(verDir, b), "binary-"+b+"-2.0.0")
+	}
+	if err := os.WriteFile(filepath.Join(verDir, stagedgen.SrcGenFile), []byte(g0+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.saveJournal(jCopied); err != nil {
+		t.Fatal(err)
+	}
+
+	// A concurrent publish advances current-gen to a NEW generation.
+	gNew, err := sg.Publish()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gNew == g0 {
+		t.Fatal("publish did not advance the generation")
+	}
+
+	// Resume the cut. It must keep g0 (the journal pin), NOT switch to gNew.
+	if err := r.Run(Options{}); err != nil {
+		t.Fatalf("resume cut: %v", err)
+	}
+	// The committed version dir's stamp must still name g0 (the resume kept its
+	// pinned source, did not recopy from gNew).
+	stamp, _ := os.ReadFile(filepath.Join(verDir, stagedgen.SrcGenFile))
+	if strings.TrimSpace(string(stamp)) != g0 {
+		t.Fatalf("resume switched source generation to %q; must keep the pinned %q", stamp, g0)
+	}
+}

--- a/pkg/upgrade/stagedgen_cut_test.go
+++ b/pkg/upgrade/stagedgen_cut_test.go
@@ -297,6 +297,40 @@ func TestCut_SameVersionDifferentGenerationRefusesOnLive(t *testing.T) {
 	}
 }
 
+// TestCut_UnstampedLiveVersionDirRefusesAtInit pins Codex r6: a B-aware
+// same-version cut over an UNSTAMPED (pre-#1981) LIVE version dir must refuse
+// at INIT, pre-PREFLIGHT — NOT fall through to the copyStaged backstop (which
+// would write the journal + take a .dbsnap and then re-wedge on resume).
+func TestCut_UnstampedLiveVersionDirRefusesAtInit(t *testing.T) {
+	fs := newFakeSystem(t, "2.0.0")
+	r, cfg := testEnv(t, fs)
+	// 2.0.0 is the LIVE current with NO .srcgen stamp (a pre-#1981 layout).
+	seedInitialCurrent(t, r, cfg, "2.0.0")
+	// (seedInitialCurrent writes no .srcgen — the dir is unstamped.)
+
+	err := r.Run(Options{})
+	if err == nil {
+		t.Fatal("expected a pre-PREFLIGHT refusal over an unstamped live dir")
+	}
+	if !strings.Contains(err.Error(), "refuse-before-PREFLIGHT") ||
+		!strings.Contains(err.Error(), "cannot replace the live/rollback") {
+		t.Fatalf("error is not the pre-PREFLIGHT live-dir refusal: %v", err)
+	}
+	// No journal, no .dbsnap, no live mutation — so a re-run re-resolves rather
+	// than resuming a wedged journal (Codex r6).
+	if _, serr := os.Stat(cfg.JournalPath); !os.IsNotExist(serr) {
+		t.Errorf("journal written on the unstamped-live pre-PREFLIGHT refusal: %v", serr)
+	}
+	if matches, _ := filepath.Glob(filepath.Join(cfg.VersionsDir, ".*.dbsnap")); len(matches) != 0 {
+		t.Errorf(".dbsnap taken on the unstamped-live pre-PREFLIGHT refusal: %v", matches)
+	}
+	for _, c := range fs.calls {
+		if c == "stop" || c == "dropin" || c == "verify" {
+			t.Errorf("phase %q ran on the unstamped-live pre-PREFLIGHT refusal", c)
+		}
+	}
+}
+
 // TestCut_UnstampedStaleVersionDirIsReplaced pins Codex r5-#1: a pre-#1981
 // versions/<ver> with NO .srcgen that is STALE (non-live) must be
 // guarded-replaced from the pinned generation, NOT reused — else a pre-fix

--- a/pkg/upgrade/state.go
+++ b/pkg/upgrade/state.go
@@ -147,4 +147,19 @@ type Journal struct {
 	// this, a re-run without the flag would proceed past a STOPPED empty-prev
 	// journal on the original run's sanction alone, which it could not prove.
 	FirstCutSanctioned bool `json:"first_cut_sanctioned,omitempty"`
+
+	// SourceGeneration is the staged-gen/<genid> the cut copies FROM (#1981
+	// Option B). It is resolved ONCE at INIT (from staged-gen/current-gen) and
+	// recorded so copyStaged reads the PINNED generation directory — never live
+	// staged/ and never re-reading current-gen — closing the dpkg-unpack vs
+	// operator-cut torn-read window by construction. A resume keys the SAME
+	// genid, so the cut continues against its original source even if a
+	// concurrent publish has advanced current-gen.
+	//
+	// Empty is the legacy back-compat case: a pre-#1981 journal resumed under a
+	// B-aware runner has no SourceGeneration. The runner treats an empty
+	// SourceGeneration in an already-copied journal (State >= COPIED) as valid
+	// legacy state and copies from live staged/ only as the pre-B fallback —
+	// it never blocks recovery of an in-flight pre-B cut (plan §10 AGY r4).
+	SourceGeneration string `json:"source_generation,omitempty"`
 }

--- a/pkg/upgrade/verify_cleanup_test.go
+++ b/pkg/upgrade/verify_cleanup_test.go
@@ -51,11 +51,14 @@ func TestVerifyFailCleanup_RecopiesOnRetry(t *testing.T) {
 	}
 
 	// Operator drops a CORRECTED staged binary under the SAME version and the
-	// verifier now passes. The retry must recopy and complete the cut.
+	// verifier now passes. Under #1981 Option B a corrected re-stage PUBLISHES
+	// a NEW generation; the retry re-resolves current-gen, recopies the
+	// corrected bytes, and completes the cut.
 	fs.verifyPass = true
 	// Mark staged content as "corrected" so we can confirm the version dir was
 	// recopied from the fresh staged bytes (not a leftover).
 	writeFakeBin(t, filepath.Join(cfg.StagedDir, "xpfd"), "binary-xpfd-corrected")
+	publishStagedGen(t, r) // re-publish the corrected staged set (postinst step).
 
 	if err := r.Run(Options{}); err != nil {
 		t.Fatalf("retry after corrected staged should succeed: %v", err)

--- a/test/debian/postrm-test.sh
+++ b/test/debian/postrm-test.sh
@@ -25,6 +25,7 @@ patched_postrm() {
       -e "s#^SBIN=.*#SBIN=$ROOT/usr/local/sbin#" \
       -e "s#^VERSIONS=.*#VERSIONS=$ROOT/var/lib/xpf/versions#" \
       -e "s#^CURRENT=.*#CURRENT=\"\$VERSIONS/current\"#" \
+      -e "s#^STAGED_GEN=.*#STAGED_GEN=$ROOT/var/lib/xpf/staged-gen#" \
       -e "s#^DROPIN=.*#DROPIN=$ROOT/etc/systemd/system/xpfd.service.d/10-xpf-version.conf#" \
       -e "s#\\[ -d /run/systemd/system \\]#false#" \
       "$POSTRM" > "$ROOT/postrm"
@@ -38,6 +39,7 @@ run_scenario() {
     SBIN="$ROOT/usr/local/sbin"
     VERSIONS="$ROOT/var/lib/xpf/versions"
     CURRENT="$VERSIONS/current"
+    STAGED_GEN="$ROOT/var/lib/xpf/staged-gen"
     DROPIN="$ROOT/etc/systemd/system/xpfd.service.d/10-xpf-version.conf"
     BINS="xpfd cli xpf-userspace-dp xpf-day0-config"
     patched_postrm
@@ -75,6 +77,10 @@ EOF
         ln -sf "$CURRENT/$b" "$SBIN/$b"
     done
     echo "[Service]" > "$DROPIN"
+    # #1981 staged-generation tree (a published generation + current-gen).
+    mkdir -p "$STAGED_GEN/00000000000000000001-aabbccddeeff0011"
+    echo "bin" > "$STAGED_GEN/00000000000000000001-aabbccddeeff0011/xpfd"
+    ln -sf "00000000000000000001-aabbccddeeff0011" "$STAGED_GEN/current-gen"
 }
 
 # Replace staged/xpfd with a PRE-#1964 binary (no seed-runtime support).
@@ -104,7 +110,7 @@ scenario_remove_keeps_versions() {
 }
 
 # purge removes the through-current sbin links, the runtime drop-in (#1967),
-# AND the versions/ tree.
+# the versions/ tree, AND the #1981 staged-gen/ tree.
 scenario_purge_removes_versions() {
     build_hardened "1.0.0"
     "$ROOT/postrm" purge
@@ -112,7 +118,37 @@ scenario_purge_removes_versions() {
         [ -L "$SBIN/$b" ] && { echo "FAIL: sbin $b not removed"; exit 1; } || true
     done
     [ -e "$VERSIONS" ] && { echo "FAIL: versions/ not removed on purge"; exit 1; } || true
+    [ -e "$STAGED_GEN" ] && { echo "FAIL: staged-gen/ not removed on purge"; exit 1; } || true
     [ -e "$DROPIN" ] && { echo "FAIL: drop-in not removed on purge"; exit 1; } || true
+}
+
+# #1981 B-P6: a downgrade to a package BELOW the staged-gen floor (0.0.4200) —
+# including a post-#1964 (>= 0.0.4104) but pre-#1981 package, which keeps the
+# #1964 versioned-runtime layout intact — must remove staged-gen/.
+scenario_downgrade_removes_staged_gen_below_floor() {
+    build_hardened "1.0.0"
+    # Post-#1964 but pre-#1981 ($2 in [4104, 4200)): the #1964 layout survives,
+    # but staged-gen/ must be removed.
+    "$ROOT/postrm" upgrade "0.0.4150"
+    [ -e "$STAGED_GEN" ] && { echo "FAIL: staged-gen/ not removed on a pre-#1981 downgrade"; exit 1; } || true
+    # The #1964 layout is untouched (above the 0.0.4104 floor).
+    [ -L "$CURRENT" ] || { echo "FAIL: #1964 current wrongly deleted on a post-#1964 downgrade"; exit 1; }
+    [ -e "$DROPIN" ] || { echo "FAIL: #1964 drop-in wrongly removed on a post-#1964 downgrade"; exit 1; }
+}
+
+# A hardened->hardened downgrade at or above the staged-gen floor keeps
+# staged-gen/ (the incoming package manages it).
+scenario_downgrade_keeps_staged_gen_at_floor() {
+    build_hardened "1.0.0"
+    "$ROOT/postrm" upgrade "0.0.4200"
+    [ -d "$STAGED_GEN" ] || { echo "FAIL: staged-gen/ removed on an at-floor (>=#1981) downgrade"; exit 1; }
+}
+
+# An empty/unparsable $2 leaves staged-gen/ intact (safe-on-ambiguity).
+scenario_downgrade_empty_version_keeps_staged_gen() {
+    build_hardened "1.0.0"
+    "$ROOT/postrm" upgrade ""
+    [ -d "$STAGED_GEN" ] || { echo "FAIL: staged-gen/ removed on empty incoming version"; exit 1; }
 }
 
 # remove with a NON-empty .service.d (a foreign drop-in) removes only OUR
@@ -318,4 +354,7 @@ run_scenario upgrade_unparsable_version_survives
 run_scenario downgrade_below_floor_no_layout_noop
 run_scenario remove_skips_foreign_link
 run_scenario remove_legacy_links
+run_scenario downgrade_removes_staged_gen_below_floor
+run_scenario downgrade_keeps_staged_gen_at_floor
+run_scenario downgrade_empty_version_keeps_staged_gen
 echo "ALL POSTRM SCENARIOS PASSED"


### PR DESCRIPTION
## Summary

Closes the dpkg-unpack vs operator-cut staged-source race (#1981, HIGH)
via the user-approved converged plan: **Option B (immutable versioned
staging) + B-P3b OPT1**.

dpkg unpacks the managed binaries into `staged/` one file at a time, so
across an `apt upgrade` unpack window `staged/` holds a mix of old and
new binaries. The legacy cut copied directly from that live tree; a cut
landing inside the window could publish a `versions/<ver>` mixing two
dpkg generations — a torn set whose `verify-dataplane` gate (xpfd+shim
only) cannot detect a mismatched `xpf-userspace-dp`. This PR closes the
window by construction for all four managed binaries: the cut reads a
pinned, immutable `staged-gen/<genid>/` that dpkg is not rewriting,
never live `staged/`.

## Mechanism (Option B)

- `postinst configure` (after a complete unpack) runs `xpfd
  publish-generation`: copy `staged/` into `staged-gen/<genid>/`
  (`.partial` + atomic rename + dir-fsync) and atomically repoint
  `staged-gen/current-gen` (temp-symlink + rename).
- The cut resolves `current-gen` once at INIT, records the genid in
  `Journal.SourceGeneration`, and `copyStaged` copies from the resolved
  `staged-gen/<SourceGeneration>/` directory (never re-reading the
  symlink, never live `staged/`).
- No published generation ⇒ refuse pre-PREFLIGHT (no journal, no DB
  snapshot, daemon untouched).
- B-P3b OPT1: `versions/<ver>/.srcgen` stamp + generation-aware skip;
  a same-version re-stage with new bytes recopies a stale non-live dir
  (reusing the proven guarded-delete) or refuses if the dir is the live
  `current`/rollback target.
- GC: `staged-gen` retention N=2, protecting `current-gen` + any
  journal-referenced genid (GC-vs-resume); postrm removes `staged-gen/`
  on purge + pre-B downgrade. `debian/rules` unchanged (dpkg owns only
  `staged/`).

## Crash-safety

A crash before the gen-dir rename leaves a `.partial` (pre-swept on the
next publish); a crash after the dir rename but before the `current-gen`
repoint leaves a complete-but-unreferenced generation (prior
`current-gen` stays valid; re-publish is idempotent). An aborted/failed
unpack publishes no new generation — the prior generation stays the cut
source, so there is no permanent-wedge class.

## Plan + approval

Converged plan (r4, 3-way Codex + AGY + Claude SMR): PLAN-READY.
User-approved Option B + B-P3b OPT1. This PR implements that spec
verbatim (O1-O4 honored; legacy `SourceGeneration==""` back-compat; the
`publish-generation` verb + deferred-publish recovery; the intrinsic
one-time first-deploy bootstrap caveat documented).

## Test plan

- [x] `go build ./...` clean
- [x] Full Go suite (worktree): all 49 packages pass (44 ok + 5 no-test)
- [x] New `pkg/upgrade/stagedgen` unit tests (publish/resolve/GC/crash)
- [x] Cut-level torn-source regression + **counter-factual** (the
      pre-fix legacy path DOES read the torn bytes — non-tautological)
- [x] No-source refusal, same-version recopy/refuse-on-live (B-P3b),
      GC-vs-resume protection, aborted-unpack no-wedge, resume keeps
      pinned generation
- [x] Seed publishes the initial generation on first install
- [x] `sh -n` + `shellcheck` clean on `debian/xpf.{postinst,postrm}`
- [x] #1982 managed-binary drift canary still passes

Control-plane/packaging change — no dataplane/forwarding or
VRRP/session-sync failover runtime touched, so loss-cluster smoke is not
required.

Head: `8cd7c8db700db1c297d2ada7a68090f4c8144bcf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
