### PR TITLE
snmp: enforce community authorization with a SET handler (#2008 H17)

### DIFF
--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -459,7 +459,16 @@ var schemaServices = &schemaNode{desc: "Services configuration", children: map[s
 
 var schemaSNMP = &schemaNode{desc: "SNMP configuration", children: map[string]*schemaNode{
 	"community": {desc: "SNMP community", args: 1, placeholder: "<community-name>", children: map[string]*schemaNode{
-		"authorization": {desc: "Authorization level", args: 1, placeholder: "<level>", children: nil},
+		"authorization": {
+			desc:          "Authorization level",
+			args:          1,
+			placeholder:   "<level>",
+			valueType:     ValueEnumOf,
+			valueDesc:     "Access level granted to the community (read-only | read-write)",
+			valueExamples: []string{"read-only", "read-write"},
+			validator:     ValidateEnum([]string{"read-only", "read-write"}),
+			children:      nil,
+		},
 	}},
 	"trap-group": {desc: "Trap group", args: 1, placeholder: "<group-name>", children: nil},
 	"v3": {desc: "SNMPv3", children: map[string]*schemaNode{

--- a/pkg/config/schema_validate_system_test.go
+++ b/pkg/config/schema_validate_system_test.go
@@ -180,6 +180,16 @@ var systemLeafMatrix = []systemLeafCase{
 		accept:   []string{"0", "10"},
 		reject:   []string{"-1", "asd", ""},
 	},
+	{
+		// #2008 H17: only read-only / read-write are honored at runtime;
+		// any other value silently defaulted to read-only before the enum
+		// gate, masking operator typos like "read-wrote".
+		name:     "snmp-community-authorization",
+		leaf:     "authorization",
+		template: "set snmp community public authorization %s",
+		accept:   []string{"read-only", "read-write"},
+		reject:   []string{"read-wrote", "rw", "full", "asd", ""},
+	},
 }
 
 func TestSchemaValidate_SystemServices_Matrix(t *testing.T) {

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -338,6 +338,35 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		return nil
 	}
 
+	// Reconcile the SNMP agent's live authorization/identity config FIRST
+	// (#2008 H17, Codex r2). The agent is created once at startup
+	// (daemon_run.go) and keeps serving on UDP/161; without this step a
+	// commit that flips a community read-write -> read-only, deletes a
+	// community, or changes the v3 user set would not reach the running agent
+	// until a daemon restart, leaving the SET access-control gate reading
+	// stale authorization.
+	//
+	// This MUST run before any reconcile step that can abort applyConfigLocked
+	// early — specifically the dataplane apply below, which returns early on
+	// ErrPolicySchedulerProtocolIncompatible (compileErrorMustAbortApply).
+	// Store.Commit() has ALREADY promoted and persisted this compiled config
+	// before applyConfigLocked runs, so the committed authorization is live
+	// regardless of whether the later dataplane apply succeeds. Reconciling
+	// only at the tail would leave a committed-downgraded community serving
+	// the OLD (read-write) gate on an apply that aborts early. Placed here it
+	// is unconditionally before every early-return path in the body (the only
+	// aborting one is the dataplane apply at compileErrorMustAbortApply).
+	//
+	// The swap is in-place (UpdateConfig holds the agent's cfgMu) so the UDP
+	// listener and in-flight polls are not interrupted, and it is idempotent —
+	// an atomic pointer/table swap, safe to call once per apply. Guarded on a
+	// non-nil agent: if SNMP was not enabled at startup there is no running
+	// listener to reconcile (enabling SNMP for the first time still requires a
+	// restart, matching the other start-once subsystems).
+	if d.snmpAgent != nil {
+		d.snmpAgent.UpdateConfig(cfg.System.SNMP)
+	}
+
 	// #1922 Item 2 bootstrap exit: the FIRST apply of a non-empty config
 	// (an interface-claiming confirmed commit, or a cluster SyncApply from
 	// the primary) leaves bootstrap mode and runs the one-time startup
@@ -1147,21 +1176,6 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 
 	// 16. Update flow traceoptions (trace file + filters)
 	d.updateFlowTrace(cfg)
-
-	// 16b. Reconcile the SNMP agent's live authorization/identity config
-	// (#2008 H17). The agent is created once at startup (daemon_run.go) and
-	// keeps serving on UDP/161; without this step a commit that flips a
-	// community read-write -> read-only, deletes a community, or changes the
-	// v3 user set would not reach the running agent until a daemon restart,
-	// leaving the SET access-control gate reading stale authorization. The
-	// swap is in-place (UpdateConfig holds the agent's cfgMu) so the UDP
-	// listener and in-flight polls are not interrupted. Guarded on a
-	// non-nil agent: if SNMP was not enabled at startup there is no running
-	// listener to reconcile (enabling SNMP for the first time still requires
-	// a restart, matching the other start-once subsystems).
-	if d.snmpAgent != nil {
-		d.snmpAgent.UpdateConfig(cfg.System.SNMP)
-	}
 
 	// 17. Update event-options policies (RPM-driven failover)
 	if d.eventEngine != nil {

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1148,6 +1148,21 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	// 16. Update flow traceoptions (trace file + filters)
 	d.updateFlowTrace(cfg)
 
+	// 16b. Reconcile the SNMP agent's live authorization/identity config
+	// (#2008 H17). The agent is created once at startup (daemon_run.go) and
+	// keeps serving on UDP/161; without this step a commit that flips a
+	// community read-write -> read-only, deletes a community, or changes the
+	// v3 user set would not reach the running agent until a daemon restart,
+	// leaving the SET access-control gate reading stale authorization. The
+	// swap is in-place (UpdateConfig holds the agent's cfgMu) so the UDP
+	// listener and in-flight polls are not interrupted. Guarded on a
+	// non-nil agent: if SNMP was not enabled at startup there is no running
+	// listener to reconcile (enabling SNMP for the first time still requires
+	// a restart, matching the other start-once subsystems).
+	if d.snmpAgent != nil {
+		d.snmpAgent.UpdateConfig(cfg.System.SNMP)
+	}
+
 	// 17. Update event-options policies (RPM-driven failover)
 	if d.eventEngine != nil {
 		d.eventEngine.Apply(cfg.EventOptions)

--- a/pkg/daemon/daemon_snmp_reconcile_test.go
+++ b/pkg/daemon/daemon_snmp_reconcile_test.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/snmp"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// snmpDowngradeConfig returns a compiled config whose only SNMP community is
+// authorized read-only. Reconciling the running agent onto it must flip the
+// live SET access-control gate from read-write to read-only.
+func snmpDowngradeConfig() *config.Config {
+	return &config.Config{
+		System: config.SystemConfig{
+			SNMP: &config.SNMPConfig{
+				Communities: map[string]*config.SNMPCommunity{
+					"private": {Name: "private", Authorization: "read-only"},
+				},
+			},
+		},
+	}
+}
+
+// TestApplyConfigLockedReconcilesSNMPAuthorization proves the daemon WIRING:
+// applyConfigLocked must call snmpAgent.UpdateConfig so a committed community
+// downgrade (read-write -> read-only) reaches the live agent. This drives the
+// REAL applyConfigLocked body (not the applyBodyForTest seam), so it fails if
+// the UpdateConfig call is removed from applyConfigLocked — the package-level
+// snmp tests exercise UpdateConfig directly and would NOT catch that.
+//
+// Mutation check: delete the `d.snmpAgent.UpdateConfig(...)` line from
+// applyConfigLocked and this test fails — the agent keeps its read-write gate
+// and SETAuthorized("private") stays true after the apply.
+func TestApplyConfigLockedReconcilesSNMPAuthorization(t *testing.T) {
+	agent := snmp.NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"private": {Name: "private", Authorization: "read-write"},
+		},
+	})
+	if !agent.SETAuthorized("private") {
+		t.Fatal("precondition: agent should start read-write")
+	}
+
+	installFakeNetworkctl(t)
+	d := &Daemon{
+		applySem:  semaphore.NewWeighted(1),
+		snmpAgent: agent,
+		dp:        &runtimeOnlyApplyTestDP{},
+		vrrpMgr:   vrrp.NewManager(),
+		store:     newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		opts:      Options{NoDataplane: true},
+	}
+
+	if err := d.applyConfigLocked(snmpDowngradeConfig()); err != nil {
+		t.Fatalf("applyConfigLocked: %v", err)
+	}
+
+	if agent.SETAuthorized("private") {
+		t.Fatal("applyConfigLocked did not reconcile SNMP authorization: " +
+			"community is still read-write after a read-only commit " +
+			"(missing snmpAgent.UpdateConfig wiring)")
+	}
+}
+
+// TestApplyConfigLockedReconcilesSNMPBeforeDataplaneAbort is the Codex r2
+// regression: the SNMP reconcile must run BEFORE the dataplane apply, which
+// aborts applyConfigLocked early on ErrPolicySchedulerProtocolIncompatible
+// (compileErrorMustAbortApply). Store.Commit() has already promoted/persisted
+// the compiled config, so the committed authorization is live regardless of
+// whether the dataplane apply later fails. If the reconcile is placed AFTER the
+// abort (the original step-16b position), an early-aborting apply leaves the
+// downgraded community still serving the stale read-write gate.
+//
+// The fake dataplane returns the aborting sentinel from ApplyConfig, so the
+// call returns that error (proving the early-return fired). The assertion is
+// that despite the abort the live SNMP gate reflects the downgrade.
+//
+// Mutation check: move the snmpAgent.UpdateConfig call back below the dataplane
+// apply (step 16b) and this test fails — the early return skips it and the gate
+// stays read-write.
+func TestApplyConfigLockedReconcilesSNMPBeforeDataplaneAbort(t *testing.T) {
+	agent := snmp.NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"private": {Name: "private", Authorization: "read-write"},
+		},
+	})
+	if !agent.SETAuthorized("private") {
+		t.Fatal("precondition: agent should start read-write")
+	}
+
+	dp := &runtimeOnlyApplyTestDP{
+		applyErr: dpuserspace.ErrPolicySchedulerProtocolIncompatible,
+	}
+	d := &Daemon{
+		applySem:  semaphore.NewWeighted(1),
+		snmpAgent: agent,
+		dp:        dp,
+		store:     newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		opts:      Options{NoDataplane: true},
+	}
+
+	err := d.applyConfigLocked(snmpDowngradeConfig())
+	if !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
+		t.Fatalf("applyConfigLocked error = %v, want early abort on "+
+			"ErrPolicySchedulerProtocolIncompatible (the early-return path "+
+			"this test exercises)", err)
+	}
+	if dp.applyCalls != 1 {
+		t.Fatalf("dataplane ApplyConfig calls = %d, want 1 (abort path not reached)", dp.applyCalls)
+	}
+
+	if agent.SETAuthorized("private") {
+		t.Fatal("SNMP authorization was NOT reconciled before the dataplane " +
+			"abort: a committed read-write -> read-only downgrade is still " +
+			"serving the stale read-write gate because applyConfigLocked " +
+			"aborted early before reaching the SNMP reconcile")
+	}
+}

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -4,6 +4,25 @@ SNMPv2c and SNMPv3 agent. Responds to GET / GETNEXT / GETBULK on
 ifTable, ifXTable, and a small set of system OIDs. Also sends link-up /
 link-down traps. ASN.1 BER encoding is hand-coded, no external library.
 
+## Community authorization (SET access control)
+
+A v2c community carries an `authorization` level (`read-only` /
+`read-write`, default `read-only`). `getCommunity` resolves the community
+struct; SET requests (`pduSetRequest`, 0xa3) are gated on it:
+
+- A community without `read-write` authorization is denied with `noAccess`
+  (RFC 3416 error-status 6) before any write is attempted — this is the
+  security boundary set by `set snmp community <name> authorization
+  read-write`.
+- A `read-write` community passes the gate, but the agent exposes only
+  read-only MIB objects, so the write is refused per-varbind with
+  `notWritable` (17). No served object is mutable, so a SET never succeeds;
+  the read-only vs read-write distinction is enforced and observable in the
+  response error-status.
+
+SNMPv3 SET requests are uniformly refused with `notWritable` (the USM users
+in this config carry no read-write authorization).
+
 ## Entry points
 
 - `Agent` — `agent.go`.

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -23,6 +23,26 @@ struct; SET requests (`pduSetRequest`, 0xa3) are gated on it:
 SNMPv3 SET requests are uniformly refused with `notWritable` (the USM users
 in this config carry no read-write authorization).
 
+## Live reconfigure (commit-time reconcile)
+
+The agent is created once at daemon startup and keeps serving on UDP/161.
+`UpdateConfig(cfg *config.SNMPConfig)` swaps the live authorization/identity
+config and rederives the USM v3 user table in place, so a commit that changes
+community authorization (`read-write` -> `read-only`, or a deleted community)
+or the v3 user set reaches the running agent without a restart — restarting
+would drop the UDP listener and interrupt in-flight polls. The daemon calls it
+from `applyConfigLocked` (guarded on a non-nil agent; enabling SNMP for the
+first time still requires a restart, like the other start-once subsystems).
+
+Concurrency: `cfg` and the derived `v3Users` are guarded by `cfgMu`
+(`sync.RWMutex`). The request-serving goroutine reads them through
+`snapshotCfg` / `snapshotV3User` / `hasV3Users` under `RLock`; `UpdateConfig`
+swaps both under `Lock`, so a request never observes a half-applied config
+(new community map with stale v3 users, or vice versa). `engineID` /
+`engineBoots` / `startTime` are the agent's stable identity and are never
+swapped. A `nil` cfg (the whole `snmp` stanza removed) disables the agent's
+authorization surface: every request is dropped because no community matches.
+
 ## Entry points
 
 - `Agent` — `agent.go`.

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -34,6 +34,18 @@ would drop the UDP listener and interrupt in-flight polls. The daemon calls it
 from `applyConfigLocked` (guarded on a non-nil agent; enabling SNMP for the
 first time still requires a restart, like the other start-once subsystems).
 
+The reconcile runs **early** in `applyConfigLocked` — before the dataplane
+apply, which can abort the reconcile pipeline early (it returns on
+`ErrPolicySchedulerProtocolIncompatible`). `Store.Commit()` has already
+promoted and persisted the compiled config by the time `applyConfigLocked`
+runs, so the committed authorization is live regardless of whether the later
+dataplane apply succeeds. Reconciling only at the tail would let an
+early-aborting apply leave a committed-downgraded community still serving the
+old (read-write) SET gate. The daemon-package test
+`TestApplyConfigLockedReconcilesSNMPBeforeDataplaneAbort` pins this ordering
+(it drives `applyConfigLocked` with a dataplane that returns the aborting
+sentinel and asserts the live gate still reflects the downgrade).
+
 Concurrency: `cfg` and the derived `v3Users` are guarded by `cfgMu`
 (`sync.RWMutex`). The request-serving goroutine reads them through
 `snapshotCfg` / `snapshotV3User` / `hasV3Users` under `RLock`; `UpdateConfig`

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -123,16 +123,25 @@ type IfData struct {
 
 // Agent is an SNMP v2c/v3 agent that serves the system MIB and ifTable.
 type Agent struct {
-	cfg         *config.SNMPConfig
 	conn        *net.UDPConn
 	startTime   time.Time
 	ifDataFn    func() []IfData // callback for live interface data
 	mu          sync.Mutex
 	stopped     bool
-	engineID    []byte               // SNMPv3 engine ID
-	engineBoots int                  // SNMPv3 engine boots counter
-	v3Users     map[string]*usmUser  // SNMPv3 USM users (keyed by name)
-	lastPacket  []byte               // raw packet for v3 auth verification
+	engineID    []byte // SNMPv3 engine ID (immutable after initEngine)
+	engineBoots int    // SNMPv3 engine boots counter (immutable after initEngine)
+	lastPacket  []byte // raw packet for v3 auth verification
+
+	// cfgMu guards the live authorization/identity configuration (cfg) and
+	// the derived USM user table (v3Users). The request-serving goroutine
+	// reads both under RLock; UpdateConfig swaps both under Lock so a commit
+	// that changes community authorization or v3 users takes effect on the
+	// running agent without dropping the UDP listener. Keeping this separate
+	// from mu (which guards conn/stopped/ifDataFn) avoids holding the
+	// listener lock across config reads on every request.
+	cfgMu   sync.RWMutex
+	cfg     *config.SNMPConfig  // authorization + sysContact/Location/Description
+	v3Users map[string]*usmUser // SNMPv3 USM users (keyed by name)
 }
 
 // NewAgent creates a new SNMP agent with the given configuration.
@@ -144,6 +153,51 @@ func NewAgent(cfg *config.SNMPConfig) *Agent {
 	a.initEngine()
 	a.initV3Users()
 	return a
+}
+
+// UpdateConfig atomically swaps the agent's live authorization/identity
+// configuration and rederives the USM v3 user table to match. It is the
+// commit-time reconcile entry point (called from the daemon's
+// applyConfigLocked) so that a config change to community authorization
+// (read-write -> read-only, or a deleted community) or to the v3 user set
+// reaches the running agent without a restart.
+//
+// In-place reconfigure is preferred over restart: restarting the agent would
+// tear down the UDP/161 listener and interrupt in-flight polls. The swap is
+// done under cfgMu.Lock so the request-serving goroutine (which reads cfg and
+// v3Users under cfgMu.RLock) always observes a consistent pair: it never sees
+// the new community map with the stale v3 users, or vice versa.
+//
+// engineID/engineBoots/startTime are intentionally NOT touched — they are the
+// agent's stable identity. The v3 user keys are re-localized against the
+// existing engineID, matching how initV3Users derived them at startup.
+func (a *Agent) UpdateConfig(cfg *config.SNMPConfig) {
+	v3 := a.deriveV3Users(cfg)
+	a.cfgMu.Lock()
+	a.cfg = cfg
+	a.v3Users = v3
+	a.cfgMu.Unlock()
+}
+
+// snapshotCfg returns the live config pointer under cfgMu.RLock.
+func (a *Agent) snapshotCfg() *config.SNMPConfig {
+	a.cfgMu.RLock()
+	defer a.cfgMu.RUnlock()
+	return a.cfg
+}
+
+// snapshotV3User looks up a USM user by name under cfgMu.RLock.
+func (a *Agent) snapshotV3User(name string) *usmUser {
+	a.cfgMu.RLock()
+	defer a.cfgMu.RUnlock()
+	return a.v3Users[name]
+}
+
+// hasV3Users reports whether any USM user is configured, under cfgMu.RLock.
+func (a *Agent) hasV3Users() bool {
+	a.cfgMu.RLock()
+	defer a.cfgMu.RUnlock()
+	return len(a.v3Users) > 0
 }
 
 // initEngine generates a deterministic engine ID from the hostname.
@@ -261,7 +315,7 @@ func (a *Agent) handlePacket(data []byte) []byte {
 	case snmpVersion2c:
 		return a.handleV2cPacket(rest)
 	case snmpVersion3:
-		if len(a.v3Users) == 0 {
+		if !a.hasV3Users() {
 			slog.Debug("SNMP: v3 not configured")
 			return nil
 		}
@@ -463,10 +517,11 @@ func (a *Agent) handleGetBulk(community []byte, pduBody []byte) []byte {
 // nil if none matches. The returned struct carries the authorization level
 // (read-only / read-write) used to gate SET requests.
 func (a *Agent) getCommunity(community string) *config.SNMPCommunity {
-	if a.cfg == nil || a.cfg.Communities == nil {
+	cfg := a.snapshotCfg()
+	if cfg == nil || cfg.Communities == nil {
 		return nil
 	}
-	for _, c := range a.cfg.Communities {
+	for _, c := range cfg.Communities {
 		if c.Name == community {
 			return c
 		}
@@ -481,11 +536,12 @@ func (a *Agent) isValidCommunity(community string) bool {
 
 // getOIDValue returns the encoded value and BER tag for a given OID.
 func (a *Agent) getOIDValue(oid []int) ([]byte, byte) {
+	cfg := a.snapshotCfg()
 	// System MIB group
 	if oidEqual(oid, oidSysDescr) {
 		desc := "xpf stateful firewall"
-		if a.cfg != nil && a.cfg.Description != "" {
-			desc = a.cfg.Description
+		if cfg != nil && cfg.Description != "" {
+			desc = cfg.Description
 		}
 		return []byte(desc), tagOctetString
 	}
@@ -499,8 +555,8 @@ func (a *Agent) getOIDValue(oid []int) ([]byte, byte) {
 	}
 	if oidEqual(oid, oidSysContact) {
 		contact := ""
-		if a.cfg != nil {
-			contact = a.cfg.Contact
+		if cfg != nil {
+			contact = cfg.Contact
 		}
 		return []byte(contact), tagOctetString
 	}
@@ -513,8 +569,8 @@ func (a *Agent) getOIDValue(oid []int) ([]byte, byte) {
 	}
 	if oidEqual(oid, oidSysLocation) {
 		location := ""
-		if a.cfg != nil {
-			location = a.cfg.Location
+		if cfg != nil {
+			location = cfg.Location
 		}
 		return []byte(location), tagOctetString
 	}

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -24,13 +24,16 @@ const (
 	pduGetRequest     = 0xa0
 	pduGetNextRequest = 0xa1
 	pduGetResponse    = 0xa2
+	pduSetRequest     = 0xa3
 	pduGetBulkRequest = 0xa5
 
-	// SNMP error codes.
-	errNoError    = 0
-	errTooBig     = 1
-	errNoSuchName = 2
-	errGenErr     = 5
+	// SNMP error codes (RFC 3416 error-status values).
+	errNoError     = 0
+	errTooBig      = 1
+	errNoSuchName  = 2
+	errGenErr      = 5
+	errNoAccess    = 6
+	errNotWritable = 17
 
 	// Implicit tags for exception values (context-specific, primitive).
 	tagNoSuchObject   = 0x80
@@ -278,8 +281,9 @@ func (a *Agent) handleV2cPacket(rest []byte) []byte {
 		return nil
 	}
 
-	// Verify community string.
-	if !a.isValidCommunity(string(community)) {
+	// Verify community string and resolve its authorization level.
+	comm := a.getCommunity(string(community))
+	if comm == nil {
 		slog.Debug("SNMP: invalid community", "community", string(community))
 		return nil
 	}
@@ -298,10 +302,67 @@ func (a *Agent) handleV2cPacket(rest []byte) []byte {
 		return a.handleGetNext(community, pduBody)
 	case pduGetBulkRequest:
 		return a.handleGetBulk(community, pduBody)
+	case pduSetRequest:
+		return a.handleSet(community, comm, pduBody)
 	default:
 		slog.Debug("SNMP: unsupported PDU type", "type", pduTag)
 		return nil
 	}
+}
+
+// communityCanWrite reports whether the community is authorized for SET
+// (write) operations. Only "read-write" grants write access; the compiler
+// defaults an unspecified authorization to "read-only".
+func communityCanWrite(c *config.SNMPCommunity) bool {
+	return c != nil && c.Authorization == "read-write"
+}
+
+// handleSet processes a SET request (RFC 3416 pduSetRequest, 0xa3).
+//
+// Access control comes first: a community without "read-write" authorization
+// is denied with noAccess before any write is attempted. This is the
+// security boundary the operator configures with
+// `set snmp community <name> authorization read-write` — without this gate
+// the agent would honor SET from any valid community regardless of the
+// configured authorization (a Junos divergence).
+//
+// A read-write community passes the authorization gate, but the agent serves
+// only read-only MIB objects (system group, ifTable, ifXTable), so the write
+// itself is refused per-varbind with notWritable. No served object is
+// mutable, so a successful SET is never produced here — but the read-only vs
+// read-write distinction is enforced and observable in the error-status.
+func (a *Agent) handleSet(community []byte, comm *config.SNMPCommunity, pduBody []byte) []byte {
+	requestID, _, _, oids, err := decodePDUFields(pduBody)
+	if err != nil {
+		slog.Debug("SNMP: failed to decode SET PDU", "err", err)
+		return nil
+	}
+
+	// Echo the requested OIDs back in the response varbind list (with null
+	// values) so the response is well-formed regardless of outcome.
+	var varbinds []varbind
+	for _, oid := range oids {
+		varbinds = append(varbinds, varbind{oid: oid, tag: tagNull, value: nil})
+	}
+
+	if !communityCanWrite(comm) {
+		// Read-only (or unspecified) community: deny write access.
+		slog.Debug("SNMP: SET denied, community not authorized read-write",
+			"community", string(community), "authorization", comm.Authorization)
+		errIdx := 0
+		if len(oids) > 0 {
+			errIdx = 1
+		}
+		return a.buildResponse(community, requestID, errNoAccess, errIdx, varbinds)
+	}
+
+	// Authorized for write, but the agent exposes no writable objects. Refuse
+	// the first varbind with notWritable per RFC 3416.
+	errIdx := 0
+	if len(oids) > 0 {
+		errIdx = 1
+	}
+	return a.buildResponse(community, requestID, errNotWritable, errIdx, varbinds)
 }
 
 // handleGet processes a GET request.
@@ -398,17 +459,24 @@ func (a *Agent) handleGetBulk(community []byte, pduBody []byte) []byte {
 	return a.buildResponse(community, requestID, errNoError, 0, varbinds)
 }
 
-// isValidCommunity checks if the given community string is configured.
-func (a *Agent) isValidCommunity(community string) bool {
+// getCommunity returns the configured community matching the given string, or
+// nil if none matches. The returned struct carries the authorization level
+// (read-only / read-write) used to gate SET requests.
+func (a *Agent) getCommunity(community string) *config.SNMPCommunity {
 	if a.cfg == nil || a.cfg.Communities == nil {
-		return false
+		return nil
 	}
 	for _, c := range a.cfg.Communities {
 		if c.Name == community {
-			return true
+			return c
 		}
 	}
-	return false
+	return nil
+}
+
+// isValidCommunity checks if the given community string is configured.
+func (a *Agent) isValidCommunity(community string) bool {
+	return a.getCommunity(community) != nil
 }
 
 // getOIDValue returns the encoded value and BER tag for a given OID.

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -371,6 +371,21 @@ func communityCanWrite(c *config.SNMPCommunity) bool {
 	return c != nil && c.Authorization == "read-write"
 }
 
+// SETAuthorized reports whether the named community would pass the SET
+// access-control gate against the agent's CURRENTLY LIVE config — i.e. it
+// resolves the community from the same snapshotCfg() the request-serving path
+// uses (getCommunity) and applies the same communityCanWrite predicate
+// handleSet enforces. An unknown community returns false (handleSet drops it).
+//
+// This is a read-only observation of the live authorization gate, exported so
+// the daemon-package reconcile wiring test can assert that a committed
+// read-write -> read-only downgrade actually reached the running agent via
+// applyConfigLocked -> UpdateConfig. It takes no listener lock (getCommunity
+// reads cfg under cfgMu.RLock), so it is safe to call while the agent serves.
+func (a *Agent) SETAuthorized(community string) bool {
+	return communityCanWrite(a.getCommunity(community))
+}
+
 // handleSet processes a SET request (RFC 3416 pduSetRequest, 0xa3).
 //
 // Access control comes first: a community without "read-write" authorization

--- a/pkg/snmp/agent_set_test.go
+++ b/pkg/snmp/agent_set_test.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -139,6 +140,204 @@ func TestSetRequest_UnknownCommunityDropped(t *testing.T) {
 	if resp := a.handlePacket(pkt); resp != nil {
 		t.Errorf("SET from unknown community should be dropped, got %d-byte response", len(resp))
 	}
+}
+
+// TestUpdateConfig_AuthorizationDowngradeEnforced is the gating regression for
+// issue #2008 H17 / PR #2009: the SNMP agent is created once at daemon startup
+// and keeps serving on UDP/161; the daemon's applyConfigLocked must call
+// Agent.UpdateConfig on commit so a community that is downgraded read-write ->
+// read-only takes effect on the live agent. Before the reconcile call the agent
+// served from a stale community map, so a SET that should now be denied with
+// noAccess would still pass the authorization gate (notWritable).
+//
+// Mutation check: if the UpdateConfig call is removed from applyConfigLocked
+// (or UpdateConfig is made a no-op), the agent keeps its read-write community
+// and the post-reconcile SET returns notWritable, failing the noAccess
+// assertion below. This test exercises UpdateConfig directly (the daemon apply
+// path is covered by the daemon package), so it fails if UpdateConfig does not
+// swap the live config.
+func TestUpdateConfig_AuthorizationDowngradeEnforced(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"private": {Name: "private", Authorization: "read-write"},
+		},
+	})
+
+	// Sanity: while read-write, the SET passes the authorization gate and is
+	// refused only by the no-writable-object rule (notWritable).
+	resp := a.handlePacket(buildV2cSetRequest("private", 1, oidSysContact))
+	if resp == nil {
+		t.Fatal("pre-reconcile read-write SET produced no response")
+	}
+	if got := decodeResponseErrorStatus(t, resp); got != errNotWritable {
+		t.Fatalf("pre-reconcile read-write SET error-status = %d, want notWritable (%d)", got, errNotWritable)
+	}
+
+	// Simulate a commit that downgrades the community to read-only.
+	a.UpdateConfig(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"private": {Name: "private", Authorization: "read-only"},
+		},
+	})
+
+	// The live agent must now deny the SET at the authorization gate.
+	resp = a.handlePacket(buildV2cSetRequest("private", 2, oidSysContact))
+	if resp == nil {
+		t.Fatal("post-reconcile read-only SET produced no response (PDU dropped)")
+	}
+	if got := decodeResponseErrorStatus(t, resp); got != errNoAccess {
+		t.Errorf("post-reconcile read-only SET error-status = %d, want noAccess (%d); "+
+			"UpdateConfig did not swap the live authorization config", got, errNoAccess)
+	}
+}
+
+// TestUpdateConfig_CommunityDeletionEnforced verifies that deleting a community
+// on commit makes a subsequent SET from that (now-unknown) community be dropped
+// silently, matching the read-path behavior for unknown communities. Before the
+// reconcile, the agent would still recognize the deleted community.
+func TestUpdateConfig_CommunityDeletionEnforced(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"gone": {Name: "gone", Authorization: "read-write"},
+		},
+	})
+
+	// Commit that removes the community entirely.
+	a.UpdateConfig(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{},
+	})
+
+	if resp := a.handlePacket(buildV2cSetRequest("gone", 5, oidSysContact)); resp != nil {
+		t.Errorf("SET from deleted community should be dropped, got %d-byte response", len(resp))
+	}
+}
+
+// TestUpdateConfig_NilConfigSafe verifies that reconciling to a nil SNMP config
+// (the operator removed the whole `snmp` stanza) does not panic and disables
+// the agent's authorization surface: every v2c request is then dropped because
+// no community is configured.
+func TestUpdateConfig_NilConfigSafe(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+
+	a.UpdateConfig(nil)
+
+	if resp := a.handlePacket(buildV2cSetRequest("public", 6, oidSysContact)); resp != nil {
+		t.Errorf("after nil reconcile, SET should be dropped (no community), got %d-byte response", len(resp))
+	}
+}
+
+// TestUpdateConfig_RaceWithServe exercises the reconcile-vs-serve path: one
+// goroutine repeatedly calls UpdateConfig (swapping the community map and the
+// USM user table) while another repeatedly drives requests through
+// handlePacket. With -race this fails if the cfg/v3Users reads on the serving
+// path are not synchronized with the UpdateConfig swap (the data race the
+// cfgMu RWMutex closes). Run under: go test -race ./pkg/snmp/.
+func TestUpdateConfig_RaceWithServe(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+		V3Users: map[string]*config.SNMPv3User{
+			"admin": {Name: "admin", AuthProtocol: "sha", AuthPassword: "pw-pw-pw-pw-pw"},
+		},
+	})
+
+	const iters = 500
+	var wg sync.WaitGroup
+
+	// Writer: alternate the live config between two shapes.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rw := &config.SNMPConfig{
+			Communities: map[string]*config.SNMPCommunity{
+				"public": {Name: "public", Authorization: "read-write"},
+			},
+			V3Users: map[string]*config.SNMPv3User{
+				"admin": {Name: "admin", AuthProtocol: "md5", AuthPassword: "other-pw-1234"},
+			},
+		}
+		ro := &config.SNMPConfig{
+			Communities: map[string]*config.SNMPCommunity{
+				"public": {Name: "public", Authorization: "read-only"},
+			},
+		}
+		for i := 0; i < iters; i++ {
+			if i%2 == 0 {
+				a.UpdateConfig(rw)
+			} else {
+				a.UpdateConfig(ro)
+			}
+		}
+	}()
+
+	// Reader: drive v2c GET, v2c SET, and a v3 discovery through the agent.
+	getPkt := buildV2cGetRequest("public", 1, oidSysContact)
+	setPkt := buildV2cSetRequest("public", 2, oidSysContact)
+	v3Disc := buildV3DiscoveryRequest()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_ = a.handlePacket(getPkt)
+			_ = a.handlePacket(setPkt)
+			_ = a.handlePacket(v3Disc)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// buildV2cGetRequest builds a minimal v2c GET for one OID (helper for the race
+// test; the SET helper already lives above).
+func buildV2cGetRequest(community string, requestID int, oid []int) []byte {
+	oidBytes := berEncodeTLV(tagObjectIdentifier, berEncodeOID(oid))
+	valBytes := berEncodeTLV(tagNull, nil)
+	vb := berEncodeTLV(tagSequence, append(oidBytes, valBytes...))
+	vbList := berEncodeTLV(tagSequence, vb)
+	pduBody := berEncodeIntegerTLV(requestID)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, vbList...)
+	pdu := berEncodeTLV(pduGetRequest, pduBody)
+	msg := berEncodeIntegerTLV(snmpVersion2c)
+	msg = append(msg, berEncodeTLV(tagOctetString, []byte(community))...)
+	msg = append(msg, pdu...)
+	return berEncodeTLV(tagSequence, msg)
+}
+
+// buildV3DiscoveryRequest builds a v3 engine-ID discovery message (empty
+// userName) that exercises the v3 entry in handlePacket without needing an
+// authenticated packet.
+func buildV3DiscoveryRequest() []byte {
+	usmFields := berEncodeTLV(tagOctetString, nil) // engineID (empty -> discovery)
+	usmFields = append(usmFields, berEncodeIntegerTLV(0)...)
+	usmFields = append(usmFields, berEncodeIntegerTLV(0)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...) // userName (empty)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...) // authParams
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...) // privParams
+	usmOctet := berEncodeTLV(tagOctetString, berEncodeTLV(tagSequence, usmFields))
+
+	hdr := berEncodeIntegerTLV(7)
+	hdr = append(hdr, berEncodeIntegerTLV(maxPacketSize)...)
+	hdr = append(hdr, berEncodeTLV(tagOctetString, []byte{msgFlagReport})...)
+	hdr = append(hdr, berEncodeIntegerTLV(usmSecurityModel)...)
+	hdrSeq := berEncodeTLV(tagSequence, hdr)
+
+	scopedBody := berEncodeTLV(tagOctetString, nil)
+	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, nil)...)
+	scopedBody = append(scopedBody, berEncodeTLV(pduGetRequest, nil)...)
+	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
+
+	msgBody := berEncodeIntegerTLV(snmpVersion3)
+	msgBody = append(msgBody, hdrSeq...)
+	msgBody = append(msgBody, usmOctet...)
+	msgBody = append(msgBody, scopedPDU...)
+	return berEncodeTLV(tagSequence, msgBody)
 }
 
 // TestGetCommunity_Authorization verifies getCommunity returns the community

--- a/pkg/snmp/agent_set_test.go
+++ b/pkg/snmp/agent_set_test.go
@@ -340,6 +340,51 @@ func buildV3DiscoveryRequest() []byte {
 	return berEncodeTLV(tagSequence, msgBody)
 }
 
+// TestSETAuthorized_MatchesLiveHandlerGate verifies that the exported
+// SETAuthorized observation matches what the actual SET handler decides against
+// the live config — across an UpdateConfig downgrade. This makes SETAuthorized
+// a faithful proxy for the live SET access-control gate, which the daemon
+// package's reconcile-wiring test relies on (it cannot reach the unexported
+// handlePacket / packet builders). For each community state the two must agree:
+// SETAuthorized == (handleSet did NOT return noAccess).
+func TestSETAuthorized_MatchesLiveHandlerGate(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"c": {Name: "c", Authorization: "read-write"},
+		},
+	})
+
+	check := func(stage string, wantAuthorized bool) {
+		t.Helper()
+		gotAuthorized := a.SETAuthorized("c")
+		if gotAuthorized != wantAuthorized {
+			t.Fatalf("%s: SETAuthorized(c) = %v, want %v", stage, gotAuthorized, wantAuthorized)
+		}
+		resp := a.handlePacket(buildV2cSetRequest("c", 1, oidSysContact))
+		if resp == nil {
+			t.Fatalf("%s: SET produced no response", stage)
+		}
+		handlerAllowed := decodeResponseErrorStatus(t, resp) != errNoAccess
+		if handlerAllowed != gotAuthorized {
+			t.Fatalf("%s: live handler allowed=%v but SETAuthorized=%v (proxy diverged from gate)",
+				stage, handlerAllowed, gotAuthorized)
+		}
+	}
+
+	check("read-write", true)
+
+	a.UpdateConfig(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"c": {Name: "c", Authorization: "read-only"},
+		},
+	})
+	check("downgraded-read-only", false)
+
+	if a.SETAuthorized("missing") {
+		t.Error("SETAuthorized(missing) = true, want false for unknown community")
+	}
+}
+
 // TestGetCommunity_Authorization verifies getCommunity returns the community
 // struct with its authorization level intact, the lookup that backs the SET
 // access-control gate.

--- a/pkg/snmp/agent_set_test.go
+++ b/pkg/snmp/agent_set_test.go
@@ -1,0 +1,164 @@
+package snmp
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// buildV2cSetRequest constructs a minimal SNMP v2c SET request packet for a
+// single OID with a null value. It mirrors buildResponse but emits a
+// pduSetRequest PDU so the agent's SET path can be exercised end to end.
+func buildV2cSetRequest(community string, requestID int, oid []int) []byte {
+	// Single varbind: SEQUENCE { OID, NULL }.
+	oidBytes := berEncodeTLV(tagObjectIdentifier, berEncodeOID(oid))
+	valBytes := berEncodeTLV(tagNull, nil)
+	vb := berEncodeTLV(tagSequence, append(oidBytes, valBytes...))
+	vbList := berEncodeTLV(tagSequence, vb)
+
+	// PDU body: request-id, error-status(0), error-index(0), varbind-list.
+	pduBody := berEncodeIntegerTLV(requestID)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, vbList...)
+	pdu := berEncodeTLV(pduSetRequest, pduBody)
+
+	// Message: version(v2c), community, PDU.
+	msg := berEncodeIntegerTLV(snmpVersion2c)
+	msg = append(msg, berEncodeTLV(tagOctetString, []byte(community))...)
+	msg = append(msg, pdu...)
+	return berEncodeTLV(tagSequence, msg)
+}
+
+// decodeResponseErrorStatus parses a SNMP v2c GetResponse packet and returns
+// its error-status field. It walks SEQUENCE -> version -> community -> PDU ->
+// request-id -> error-status.
+func decodeResponseErrorStatus(t *testing.T, resp []byte) int {
+	t.Helper()
+	tag, body, err := berDecodeHeader(resp)
+	if err != nil || tag != tagSequence {
+		t.Fatalf("response: not a SEQUENCE (tag=0x%02x err=%v)", tag, err)
+	}
+	// version
+	_, rest, err := berDecodeInteger(body)
+	if err != nil {
+		t.Fatalf("response: decode version: %v", err)
+	}
+	// community
+	_, rest, err = berDecodeOctetString(rest)
+	if err != nil {
+		t.Fatalf("response: decode community: %v", err)
+	}
+	// PDU
+	pduTag, pduBody, err := berDecodeHeader(rest)
+	if err != nil {
+		t.Fatalf("response: decode PDU header: %v", err)
+	}
+	if pduTag != pduGetResponse {
+		t.Fatalf("response: PDU tag = 0x%02x, want GetResponse (0x%02x)", pduTag, pduGetResponse)
+	}
+	// request-id
+	_, pduRest, err := berDecodeInteger(pduBody)
+	if err != nil {
+		t.Fatalf("response: decode request-id: %v", err)
+	}
+	// error-status
+	errStatus, _, err := berDecodeInteger(pduRest)
+	if err != nil {
+		t.Fatalf("response: decode error-status: %v", err)
+	}
+	return errStatus
+}
+
+// TestSetRequest_ReadOnlyCommunityDenied verifies that a SET request from a
+// read-only community is rejected with noAccess. This is the authorization
+// gate added for issue #2008 H17: prior to the fix the agent had no SET
+// handler at all (the default case dropped the PDU and returned nil), so a
+// read-only community's configured authorization was never enforced.
+//
+// Mutation check: if communityCanWrite always returned true (gate removed),
+// a read-only SET would be answered with notWritable like a read-write SET,
+// and this test would fail on the errNoAccess assertion.
+func TestSetRequest_ReadOnlyCommunityDenied(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-only"},
+		},
+	})
+
+	pkt := buildV2cSetRequest("public", 7, oidSysContact)
+	resp := a.handlePacket(pkt)
+	if resp == nil {
+		t.Fatal("SET from read-only community produced no response (PDU was dropped)")
+	}
+	if got := decodeResponseErrorStatus(t, resp); got != errNoAccess {
+		t.Errorf("read-only SET error-status = %d, want noAccess (%d)", got, errNoAccess)
+	}
+}
+
+// TestSetRequest_ReadWriteCommunityPassesGate verifies that a read-write
+// community is NOT denied at the authorization gate. The agent exposes no
+// writable objects, so the write itself is refused with notWritable rather
+// than noAccess. The distinction (notWritable != noAccess) is exactly what
+// the authorization gate produces; removing the gate would yield noAccess for
+// both communities (failing the read-only test) or notWritable for both
+// (failing nothing here but failing the read-only test's noAccess assertion).
+func TestSetRequest_ReadWriteCommunityPassesGate(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"private": {Name: "private", Authorization: "read-write"},
+		},
+	})
+
+	pkt := buildV2cSetRequest("private", 9, oidSysContact)
+	resp := a.handlePacket(pkt)
+	if resp == nil {
+		t.Fatal("SET from read-write community produced no response")
+	}
+	got := decodeResponseErrorStatus(t, resp)
+	if got == errNoAccess {
+		t.Errorf("read-write SET was denied at authorization gate (noAccess); "+
+			"authorization read-write must pass the gate, got error-status %d", got)
+	}
+	if got != errNotWritable {
+		t.Errorf("read-write SET error-status = %d, want notWritable (%d)", got, errNotWritable)
+	}
+}
+
+// TestSetRequest_UnknownCommunityDropped verifies that a SET from an
+// unconfigured community is dropped (no response), matching the read path's
+// silent-drop behavior for invalid communities.
+func TestSetRequest_UnknownCommunityDropped(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"public": {Name: "public", Authorization: "read-write"},
+		},
+	})
+
+	pkt := buildV2cSetRequest("nope", 3, oidSysContact)
+	if resp := a.handlePacket(pkt); resp != nil {
+		t.Errorf("SET from unknown community should be dropped, got %d-byte response", len(resp))
+	}
+}
+
+// TestGetCommunity_Authorization verifies getCommunity returns the community
+// struct with its authorization level intact, the lookup that backs the SET
+// access-control gate.
+func TestGetCommunity_Authorization(t *testing.T) {
+	a := NewAgent(&config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"ro": {Name: "ro", Authorization: "read-only"},
+			"rw": {Name: "rw", Authorization: "read-write"},
+		},
+	})
+
+	if c := a.getCommunity("ro"); c == nil || communityCanWrite(c) {
+		t.Errorf("getCommunity(ro): want non-nil read-only, communityCanWrite=%v", communityCanWrite(c))
+	}
+	if c := a.getCommunity("rw"); c == nil || !communityCanWrite(c) {
+		t.Errorf("getCommunity(rw): want non-nil read-write, communityCanWrite=%v", communityCanWrite(c))
+	}
+	if c := a.getCommunity("missing"); c != nil {
+		t.Errorf("getCommunity(missing) = %v, want nil", c)
+	}
+}

--- a/pkg/snmp/traps.go
+++ b/pkg/snmp/traps.go
@@ -131,9 +131,9 @@ func (a *Agent) NotifyLinkUp(ifindex int, ifname string) {
 
 // sendLinkTraps builds and sends link traps to all configured trap group targets.
 func (a *Agent) sendLinkTraps(linkUp bool, ifindex int, ifname string) {
-	a.mu.Lock()
-	cfg := a.cfg
-	a.mu.Unlock()
+	// Read the live config under cfgMu — the same lock UpdateConfig swaps it
+	// under — so a commit-time reconcile cannot race trap delivery.
+	cfg := a.snapshotCfg()
 
 	if cfg == nil || len(cfg.TrapGroups) == 0 {
 		return

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -359,6 +359,25 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 			}
 		}
 
+	case pduSetRequest:
+		// The agent exposes no writable objects; refuse SET with notWritable
+		// rather than silently dropping the request. SNMPv3 access control is
+		// per-USM-user and carries no read-write authorization in this config,
+		// so every SET is refused uniformly.
+		var oids [][]int
+		requestID, _, _, oids, err = decodePDUFields(pduBody)
+		if err != nil {
+			return nil
+		}
+		for _, oid := range oids {
+			respVarbinds = append(respVarbinds, varbind{oid: oid, tag: tagNull})
+		}
+		errIdx := 0
+		if len(oids) > 0 {
+			errIdx = 1
+		}
+		return a.buildV3Response(msgID, msgFlags, user, requestID, errNotWritable, errIdx, respVarbinds)
+
 	default:
 		slog.Debug("SNMPv3: unsupported PDU type", "type", pduTag)
 		return nil

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -42,13 +42,23 @@ type usmUser struct {
 	privKey   []byte
 }
 
-// initV3Users builds USM user entries from config, localizing passwords with the engine ID.
+// initV3Users builds USM user entries from a.cfg at agent construction,
+// localizing passwords with the engine ID. It is the startup-only seam;
+// commit-time reconfigure goes through UpdateConfig -> deriveV3Users.
 func (a *Agent) initV3Users() {
-	if a.cfg == nil || len(a.cfg.V3Users) == 0 {
-		return
+	a.v3Users = a.deriveV3Users(a.cfg)
+}
+
+// deriveV3Users builds the USM user table from cfg, localizing each user's
+// auth/priv passwords against the agent's engine ID. It does NOT touch agent
+// state, so UpdateConfig can compute the new table before taking cfgMu and
+// swap it in atomically. Returns nil when no v3 users are configured.
+func (a *Agent) deriveV3Users(cfg *config.SNMPConfig) map[string]*usmUser {
+	if cfg == nil || len(cfg.V3Users) == 0 {
+		return nil
 	}
-	a.v3Users = make(map[string]*usmUser, len(a.cfg.V3Users))
-	for _, cu := range a.cfg.V3Users {
+	users := make(map[string]*usmUser, len(cfg.V3Users))
+	for _, cu := range cfg.V3Users {
 		u := &usmUser{name: cu.Name, authProto: cu.AuthProtocol, privProto: cu.PrivProtocol}
 		hashFn, hashLen := authHashFunc(cu.AuthProtocol)
 		if hashFn != nil && cu.AuthPassword != "" {
@@ -57,8 +67,9 @@ func (a *Agent) initV3Users() {
 		if hashFn != nil && cu.PrivPassword != "" {
 			u.privKey = passwordToKey(cu.PrivPassword, a.engineID, hashFn, hashLen)
 		}
-		a.v3Users[cu.Name] = u
+		users[cu.Name] = u
 	}
+	return users
 }
 
 // authHashFunc returns the hash constructor and key length for an auth protocol.
@@ -218,8 +229,9 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 		return a.buildV3Discovery(msgID)
 	}
 
-	// Lookup user.
-	user := a.v3Users[userName]
+	// Lookup user (under cfgMu so a commit-time UpdateConfig can't race the
+	// USM user-table swap mid-request).
+	user := a.snapshotV3User(userName)
 	if user == nil {
 		slog.Debug("SNMPv3: unknown user", "user", userName)
 		return nil

--- a/pkg/snmp/v3_set_test.go
+++ b/pkg/snmp/v3_set_test.go
@@ -1,0 +1,181 @@
+package snmp
+
+import (
+	"crypto/hmac"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// buildV3AuthSetPacket constructs a complete SNMPv3 authNoPriv SET request for
+// a single OID with a NULL value, authenticated with the given user's key. It
+// mirrors buildV3AuthPacket but emits a pduSetRequest (0xA3) carrying one
+// varbind so handleV3Packet's SET branch runs end to end (decodePDUFields must
+// see at least one OID for the agent to set errIdx and build a response).
+func buildV3AuthSetPacket(t *testing.T, authProto, userName string, engineID, authKey []byte, oid []int) []byte {
+	t.Helper()
+
+	hashFn, _ := authHashFunc(authProto)
+	if hashFn == nil {
+		t.Fatalf("unknown auth proto %q", authProto)
+	}
+	truncLen := authTruncLen(authProto)
+
+	// USM security parameters with a zeroed authParams placeholder.
+	authPlaceholder := make([]byte, truncLen)
+	usmFields := berEncodeTLV(tagOctetString, engineID)
+	usmFields = append(usmFields, berEncodeIntegerTLV(1)...) // engineBoots
+	usmFields = append(usmFields, berEncodeIntegerTLV(2)...) // engineTime
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, []byte(userName))...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, authPlaceholder)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...) // privParams (empty)
+	usmOctet := berEncodeTLV(tagOctetString, berEncodeTLV(tagSequence, usmFields))
+
+	// Global header (msgID, maxSize, flags=auth, securityModel=USM).
+	hdr := berEncodeIntegerTLV(42)
+	hdr = append(hdr, berEncodeIntegerTLV(maxPacketSize)...)
+	hdr = append(hdr, berEncodeTLV(tagOctetString, []byte{msgFlagAuth})...)
+	hdr = append(hdr, berEncodeIntegerTLV(usmSecurityModel)...)
+	hdrSeq := berEncodeTLV(tagSequence, hdr)
+
+	// SET PDU: request-id, error-status(0), error-index(0), varbind-list.
+	oidBytes := berEncodeTLV(tagObjectIdentifier, berEncodeOID(oid))
+	valBytes := berEncodeTLV(tagNull, nil)
+	vb := berEncodeTLV(tagSequence, append(oidBytes, valBytes...))
+	vbList := berEncodeTLV(tagSequence, vb)
+	pduBody := berEncodeIntegerTLV(101) // request-id
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, vbList...)
+	setPDU := berEncodeTLV(pduSetRequest, pduBody)
+
+	// Scoped PDU (plaintext) — contextEngineID, contextName, SET PDU.
+	scopedBody := berEncodeTLV(tagOctetString, engineID)
+	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, nil)...)
+	scopedBody = append(scopedBody, setPDU...)
+	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
+
+	// Assemble the whole message.
+	msgBody := berEncodeIntegerTLV(snmpVersion3)
+	msgBody = append(msgBody, hdrSeq...)
+	msgBody = append(msgBody, usmOctet...)
+	msgBody = append(msgBody, scopedPDU...)
+	wholeMsg := berEncodeTLV(tagSequence, msgBody)
+
+	// Locate the authParams field (still zeroed), compute the HMAC over the
+	// zeroed-placeholder form, then splice it in — exactly as a conformant
+	// manager would so verifyAuth accepts the request.
+	start, end, ok := usmAuthParamsRange(wholeMsg)
+	if !ok {
+		t.Fatalf("usmAuthParamsRange failed on freshly built SET packet")
+	}
+	mac := hmac.New(hashFn, authKey)
+	mac.Write(wholeMsg)
+	computed := mac.Sum(nil)
+	if len(computed) > truncLen {
+		computed = computed[:truncLen]
+	}
+	copy(wholeMsg[start:end], computed)
+	return wholeMsg
+}
+
+// decodeV3ResponseErrorStatus walks an SNMPv3 authNoPriv GetResponse and
+// returns its PDU error-status. The response carries a plaintext scopedPDU
+// (no priv), so the walk is: outer SEQUENCE -> version -> msgGlobalData
+// SEQUENCE -> msgSecurityParameters OCTET STRING -> scopedPDU SEQUENCE ->
+// contextEngineID, contextName, responsePDU -> request-id -> error-status.
+func decodeV3ResponseErrorStatus(t *testing.T, resp []byte) int {
+	t.Helper()
+
+	tag, msgBody, err := berDecodeHeader(resp)
+	if err != nil || tag != tagSequence {
+		t.Fatalf("v3 response: not a SEQUENCE (tag=0x%02x err=%v)", tag, err)
+	}
+	// version
+	_, rest, err := berDecodeInteger(msgBody)
+	if err != nil {
+		t.Fatalf("v3 response: decode version: %v", err)
+	}
+	// msgGlobalData header SEQUENCE — skip the whole TLV.
+	hdrLen := berEncodedLen(rest)
+	if hdrLen <= 0 || hdrLen > len(rest) {
+		t.Fatalf("v3 response: bad msgGlobalData length %d", hdrLen)
+	}
+	rest = rest[hdrLen:]
+	// msgSecurityParameters OCTET STRING — skip past it.
+	_, afterSec, err := berDecodeOctetString(rest)
+	if err != nil {
+		t.Fatalf("v3 response: decode securityParameters: %v", err)
+	}
+	// scopedPDU SEQUENCE (plaintext for authNoPriv).
+	tag, scopedBody, err := berDecodeHeader(afterSec)
+	if err != nil || tag != tagSequence {
+		t.Fatalf("v3 response: scopedPDU not a SEQUENCE (tag=0x%02x err=%v)", tag, err)
+	}
+	// contextEngineID, contextName.
+	_, scopedRest, err := berDecodeOctetString(scopedBody)
+	if err != nil {
+		t.Fatalf("v3 response: decode contextEngineID: %v", err)
+	}
+	_, scopedRest, err = berDecodeOctetString(scopedRest)
+	if err != nil {
+		t.Fatalf("v3 response: decode contextName: %v", err)
+	}
+	// response PDU.
+	pduTag, pduBody, err := berDecodeHeader(scopedRest)
+	if err != nil {
+		t.Fatalf("v3 response: decode PDU header: %v", err)
+	}
+	if pduTag != pduGetResponse {
+		t.Fatalf("v3 response: PDU tag = 0x%02x, want GetResponse (0x%02x)", pduTag, pduGetResponse)
+	}
+	// request-id, error-status.
+	_, pduRest, err := berDecodeInteger(pduBody)
+	if err != nil {
+		t.Fatalf("v3 response: decode request-id: %v", err)
+	}
+	errStatus, _, err := berDecodeInteger(pduRest)
+	if err != nil {
+		t.Fatalf("v3 response: decode error-status: %v", err)
+	}
+	return errStatus
+}
+
+// TestV3SetRequest_NotWritable verifies that an authenticated SNMPv3 SET is
+// refused with notWritable (Codex review Low for #2008). The agent exposes no
+// writable objects and SNMPv3 USM carries no read-write authorization in this
+// config, so every SET must be uniformly refused — not silently dropped — so a
+// manager sees the standard error-status rather than a timeout.
+//
+// The packet is authenticated end to end (real HMAC), so it exercises the SET
+// branch of handleV3Packet after verifyAuth, not an early auth-failure drop.
+func TestV3SetRequest_NotWritable(t *testing.T) {
+	const (
+		userName = "admin"
+		authPW   = "the-auth-password-1234"
+		authPro  = "sha"
+	)
+
+	a := NewAgent(&config.SNMPConfig{
+		V3Users: map[string]*config.SNMPv3User{
+			userName: {Name: userName, AuthProtocol: authPro, AuthPassword: authPW},
+		},
+	})
+
+	// Derive the localized auth key against the agent's engine ID so the
+	// packet authenticates against the live user table.
+	hashFn, hashLen := authHashFunc(authPro)
+	authKey := passwordToKey(authPW, a.engineID, hashFn, hashLen)
+	if authKey == nil {
+		t.Fatal("passwordToKey returned nil")
+	}
+
+	pkt := buildV3AuthSetPacket(t, authPro, userName, a.engineID, authKey, oidSysContact)
+	resp := a.handlePacket(pkt)
+	if resp == nil {
+		t.Fatal("authenticated v3 SET produced no response (was dropped); want a notWritable response")
+	}
+	if got := decodeV3ResponseErrorStatus(t, resp); got != errNotWritable {
+		t.Errorf("v3 SET error-status = %d, want notWritable (%d)", got, errNotWritable)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **#2008 H17**: SNMP community `authorization read-write` was
parsed/compiled/stored but **never enforced**. There was no SET PDU
handler at all — the v2c dispatch only matched GET / GETNEXT / GETBULK,
and the default case silently dropped the PDU. `isValidCommunity()`
checked only the community name. The agent was therefore effectively
read-only regardless of the configured authorization, and an operator
restricting a community to read-only (or granting read-write) had **zero
runtime effect** — a silent divergence from Junos.

## Fix

`pkg/snmp/agent.go` / `pkg/snmp/v3.go`:

- `getCommunity()` resolves the configured community struct (carrying the
  authorization level); `isValidCommunity()` now delegates to it.
- New `pduSetRequest` (0xa3) handler with an access-control gate:
  - A community **without** `read-write` authorization is denied with
    `noAccess` (RFC 3416 error-status 6) **before any write is
    attempted** — the security boundary the operator configures.
  - A `read-write` community **passes the gate**. The agent exposes only
    read-only MIB objects (system group, ifTable, ifXTable), so the write
    itself is refused per-varbind with `notWritable` (17). No served
    object is mutable, so a SET never succeeds, but the read-only vs
    read-write distinction is enforced and observable in the response
    error-status.
  - SNMPv3 SET is uniformly refused with `notWritable` rather than
    silently dropped (USM users carry no read-write authorization here).

`pkg/config/schema_system.go`: harden the `snmp community <name>
authorization` leaf with a `read-only | read-write` enum so a commit-time
typo (e.g. `read-wrote`) is rejected instead of silently defaulting to
read-only.

## Regression test

`pkg/snmp/agent_set_test.go` builds real v2c SET packets end to end
through `handlePacket`:

- `TestSetRequest_ReadOnlyCommunityDenied` — read-only community SET
  returns `noAccess`.
- `TestSetRequest_ReadWriteCommunityPassesGate` — read-write community
  SET returns `notWritable` (passes the authorization gate, distinct from
  `noAccess`).
- `TestSetRequest_UnknownCommunityDropped` — unknown community SET is
  dropped (no response).
- `TestGetCommunity_Authorization` — lookup returns the struct with
  authorization intact.

**Mutation-verified**: with the authorization gate removed
(`communityCanWrite` forced to return true), the read-only test fails
(returns `notWritable` instead of `noAccess`).

`pkg/config/schema_validate_system_test.go` gains an
`snmp-community-authorization` matrix case asserting the enum accepts the
two valid levels and rejects others (`read-wrote`, `rw`, `full`, etc.).

## Validation

Full Go suite passes (`go test ./...`). This is a control-plane + SNMP
agent-handler fix; loss-cluster smoke is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)