### PR TITLE
config: validate + schema static-NAT from-zone scope (#2008 H15)

### DIFF
--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -394,6 +394,18 @@ supports protocol + port ranges. `rule.inactive` is the policy-scheduler result
 published by the Go daemon; inactive scheduled rules are skipped before any
 match side effects or counters.
 
+#### Static NAT zone scoping (`nat/static_nat.rs`)
+
+A static 1:1 rule-set may carry a `from zone <name>` scope. The dataplane
+enforces it on the inbound (DNAT) direction only: `match_dnat` skips an entry
+whose `from_zone` does not exactly match the ingress zone name. The outbound
+(SNAT) direction is intentionally not zone-filtered — the internal-IP match is
+sufficient since the host originates the traffic regardless of ingress zone.
+Because a typo'd or undefined zone produces a rule that silently matches no
+inbound traffic, the Go compiler validates static-NAT `from-zone` references
+against the defined zones at commit and warns on an undefined zone (mirroring
+the source-NAT zone validation). Junos static NAT has no `to` clause.
+
 #### Slow Path (`slowpath.rs`)
 
 A TUN device (`xpf-usp0`) for packets that need kernel processing:
@@ -423,6 +435,7 @@ ConfigSnapshot {
     policies:        [{rule_id, from_zone, to_zone, src/dst, apps, action,
                        scheduler_name, inactive}]
     source_nat_rules:[{from_zone, to_zone, src/dst, interface/pool metadata}]
+    static_nat_rules:[{name, from_zone, external_ip, internal_ip}]
     flow:            {allow_dns_reply, allow_embedded_icmp}
     map_pins:        {xsk_map, heartbeat_map, sessions_map}
     ha_groups:       [{rg_id, active, watchdog_ts}]

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -986,6 +986,22 @@ func ValidateConfig(cfg *Config) []string {
 				"source-nat ruleset %q: to-zone %q not defined", rs.Name, rs.ToZone))
 		}
 	}
+	// Static NAT rule-sets carry a `from zone` scope that the dataplane
+	// enforces on the inbound (DNAT) direction (static_nat.rs match_dnat:
+	// the entry is skipped unless its from_zone matches the ingress zone
+	// name exactly). A typo'd or undefined zone therefore yields a rule
+	// that silently never matches, with no other operator signal — mirror
+	// the source-NAT zone validation above so the divergence surfaces at
+	// commit (#2008 H15).
+	for _, rs := range cfg.Security.NAT.Static {
+		if rs == nil {
+			continue
+		}
+		if rs.FromZone != "" && !zones[rs.FromZone] {
+			warnings = append(warnings, fmt.Sprintf(
+				"static-nat ruleset %q: from-zone %q not defined", rs.Name, rs.FromZone))
+		}
+	}
 
 	// Validate screen references in zones
 	for name, zone := range cfg.Security.Zones {

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -129,8 +129,21 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		}},
 		"static": {desc: "Static NAT configuration", children: map[string]*schemaNode{
 			"rule-set": {desc: "Static NAT rule-set name", args: 1, placeholder: "<rule-set-name>", children: map[string]*schemaNode{
+				// `from zone` scopes the rule-set to an ingress zone. The
+				// dataplane enforces it on the inbound (DNAT) direction
+				// (static_nat.rs match_dnat). Junos static NAT has no `to`
+				// clause (unlike source/destination NAT) — only `from`
+				// (zone | interface | routing-instance). xpf compiles the
+				// zone scope; declaring it here restores commit-time
+				// validation and CLI completion (#2008 H15).
+				"from": {desc: "Source of traffic to match", children: map[string]*schemaNode{
+					"zone": {desc: "Source zone name", args: 1, multi: true, valueHint: ValueHintZoneName, placeholder: "<zone-name>", children: nil},
+				}},
 				"rule": {desc: "Static NAT rule name", args: 1, placeholder: "<rule-name>", children: map[string]*schemaNode{
-					"match": {desc: "Match criteria", children: nil},
+					"match": {desc: "Match criteria", children: map[string]*schemaNode{
+						"source-address":      {desc: "Source address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
+						"destination-address": {desc: "Destination address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
+					}},
 					"then": {desc: "Static NAT action", children: map[string]*schemaNode{
 						"static-nat": {desc: "Static NAT translation (prefix|nptv6-prefix|inet)", children: nil},
 					}},

--- a/pkg/config/static_nat_zone_test.go
+++ b/pkg/config/static_nat_zone_test.go
@@ -1,0 +1,174 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// compileSetLines builds a ConfigTree from flat-set lines and compiles it,
+// returning the compiled config. It fails the test on parse/compile errors.
+func compileSetLines(t *testing.T, lines []string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	return cfg
+}
+
+// TestStaticNATFromZoneCompiles anchors the existing behavior: the static
+// NAT rule-set `from zone` is compiled onto StaticNATRuleSet.FromZone and
+// the rule body survives. This guards against a regression that would drop
+// the zone scoping the dataplane relies on (static_nat.rs match_dnat).
+func TestStaticNATFromZoneCompiles(t *testing.T) {
+	cfg := compileSetLines(t, []string{
+		"set security zones security-zone untrust",
+		"set security zones security-zone trust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+	})
+
+	if len(cfg.Security.NAT.Static) != 1 {
+		t.Fatalf("expected 1 static NAT rule-set, got %d", len(cfg.Security.NAT.Static))
+	}
+	rs := cfg.Security.NAT.Static[0]
+	if rs.FromZone != "untrust" {
+		t.Fatalf("expected FromZone=untrust, got %q", rs.FromZone)
+	}
+	if len(rs.Rules) != 1 || rs.Rules[0].Match != "203.0.113.5/32" {
+		t.Fatalf("rule body not compiled: %+v", rs.Rules)
+	}
+}
+
+// TestStaticNATFromZoneUndefinedWarns is the H15 regression: an undefined
+// from-zone on a static NAT rule-set silently produces a rule that the
+// dataplane will never match (static_nat.rs match_dnat requires an exact
+// ingress-zone string match), with no commit warning. Source NAT already
+// validates its from/to zones; static NAT did not. The validator must now
+// surface the typo'd zone the same way.
+//
+// Reverting the static-NAT branch in ValidateConfig's "Validate NAT zone
+// references" loop makes this test fail (no warning emitted).
+func TestStaticNATFromZoneUndefinedWarns(t *testing.T) {
+	cfg := compileSetLines(t, []string{
+		"set security zones security-zone untrust",
+		// Note: "untrsut" is a deliberate typo — not a defined zone.
+		"set security nat static rule-set rs1 from zone untrsut",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+	})
+
+	warnings := ValidateConfig(cfg)
+	var saw bool
+	for _, w := range warnings {
+		if strings.Contains(w, "static-nat") &&
+			strings.Contains(w, "untrsut") &&
+			strings.Contains(w, "not defined") {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatalf("expected static-nat undefined from-zone warning, got %v", warnings)
+	}
+}
+
+// TestStaticNATValidFromZoneNoWarn ensures a correctly-spelled from-zone
+// does NOT produce a spurious warning (the validator must only fire on
+// genuinely undefined zones).
+func TestStaticNATValidFromZoneNoWarn(t *testing.T) {
+	cfg := compileSetLines(t, []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+	})
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "static-nat") && strings.Contains(w, "not defined") {
+			t.Fatalf("unexpected static-nat zone warning for defined zone: %q", w)
+		}
+	}
+}
+
+// TestStaticNATSchemaAcceptsFromZone is the schema-hardening half of H15:
+// the static NAT rule-set schema node must declare `from { zone }` so the
+// from-zone slot gains CLI completion (`from` keyword + `zone` keyword +
+// zone-name value hint), matching destination/source NAT. Before the fix
+// the static-NAT rule-set was an opaque `children: nil` passthrough that
+// offered no completion for `from`.
+//
+// Reverting the schema fill drops the `from` completion under a static-NAT
+// rule-set and the `zone` completion under `from`, failing this test.
+func TestStaticNATSchemaAcceptsFromZone(t *testing.T) {
+	// `from` must be offered as a child of a static-NAT rule-set instance.
+	fromResults := CompleteSetPathWithValues(
+		[]string{"security", "nat", "static", "rule-set", "rs1"}, nil)
+	if !containsCompletionName(fromResults, "from") {
+		t.Fatalf("expected %q completion under static-nat rule-set, got %v",
+			"from", completionNames(fromResults))
+	}
+
+	// `zone` must be offered as a child of `from`.
+	zoneResults := CompleteSetPathWithValues(
+		[]string{"security", "nat", "static", "rule-set", "rs1", "from"}, nil)
+	if !containsCompletionName(zoneResults, "zone") {
+		t.Fatalf("expected %q completion under static-nat rule-set from, got %v",
+			"zone", completionNames(zoneResults))
+	}
+
+	// The zone value slot must surface the zone-name value hint so the CLI
+	// can complete configured zone names. The provider records the hint it
+	// is asked for.
+	var hints []ValueHint
+	provider := func(h ValueHint, _ []string) []SchemaCompletion {
+		hints = append(hints, h)
+		return nil
+	}
+	_ = CompleteSetPathWithValues(
+		[]string{"security", "nat", "static", "rule-set", "rs1", "from", "zone"}, provider)
+	sawZoneHint := false
+	for _, h := range hints {
+		if h == ValueHintZoneName {
+			sawZoneHint = true
+		}
+	}
+	if !sawZoneHint {
+		t.Fatalf("expected ValueHintZoneName for static-nat from zone value slot, got %v", hints)
+	}
+
+	// A fully-specified static-NAT rule-set with a defined from-zone must
+	// still pass schema validation (no false rejection from the new node).
+	good := &ConfigTree{}
+	for _, line := range []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.5/32",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := good.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(good)
+	if err != nil {
+		t.Fatalf("CompileConfig(good): %v", err)
+	}
+	if err := SchemaValidate(good, cfg); err != nil {
+		t.Fatalf("SchemaValidate(good) rejected a valid static-nat from-zone: %v", err)
+	}
+}
+


### PR DESCRIPTION
## Bucket: flow-misc (#2008 — H14 + H15)

### H15 — static-NAT `from`/`to` zone (FIXED)

The #2008 audit row claimed `compileStaticNAT` never reads `rs.FromZone`,
making static NAT "effectively global." On the current tree that headline
is **partially refuted**: the compiler sets `FromZone`, the Go builder
threads it into the `StaticNATRuleSnapshot` wire field, and the Rust
dataplane already enforces the zone on the inbound (DNAT) direction —
`nat/static_nat.rs` `match_dnat` skips an entry whose `from_zone` does not
exactly match the ingress zone name (shipped in #1542). The outbound
(SNAT) direction is intentionally not zone-filtered (the internal-IP match
is sufficient; documented in `static_nat.rs`).

Two **genuine residual gaps** remained, both fixed here:

1. **Missing commit validation.** Source NAT validates its from/to zones
   against the defined zones, but static NAT did not. A typo'd or
   undefined `from-zone` silently produces a rule that `match_dnat` never
   matches (exact-string compare) with no operator signal. `ValidateConfig`
   now warns `static-nat ruleset %q: from-zone %q not defined`, mirroring
   the source-NAT zone validation.

2. **Schema drift.** The static-nat rule-set `schemaNode` had no `from`
   child and a `children: nil` `match`, so `from zone` parsed by
   fallthrough with no CLI completion or commit-time structure. Added
   `from { zone }` (zone-name value hint, bracket-list capable) plus a
   `match { source-address destination-address }` body, matching the
   destination-NAT rule-set shape. Junos static NAT has no `to` clause, so
   only `from` is declared.

### H14 — `flow power-mode-disable` (NOT threaded — documented no-op)

The gap (display-only, absent from `FlowSnapshot`) is real, but the
"intended runtime semantics" the audit asked to confirm are vacuous in
xpf. Power-mode is the vSRX VPP + Intel AES-NI IPsec acceleration feature
(PowerMode IPsec), which the AF_XDP dataplane does not implement — there
is no acceleration to disable. Threading it "like GREAcceleration" would
only add another dead-code wire field: `gre_acceleration` is itself
`#[allow(dead_code)]` in `afxdp/types/forwarding.rs`, never assigned from
the snapshot and never read. That is not runtime enforcement, so per
HARD-RULE-4 (the test must exercise real enforcement) and the audit's own
"once intended runtime semantics are confirmed" caveat, H14 is left as a
display-only no-op pending the separate "accepted-but-unenforced"
commit-warning lint described in the issue's cross-cutting recommendation.
(Prior context: closed issue #149 reached the same conclusion.)

### Regression tests (`pkg/config/static_nat_zone_test.go`)

- `TestStaticNATFromZoneUndefinedWarns` — FAILS without the compiler
  change (no warning emitted). Mutation-verified.
- `TestStaticNATSchemaAcceptsFromZone` — FAILS without the schema change
  (no `from`/`zone` completion under a static-NAT rule-set; asserts the
  `ValueHintZoneName` value slot). Mutation-verified.
- `TestStaticNATFromZoneCompiles` / `TestStaticNATValidFromZoneNoWarn` —
  anchor the existing compile path and guard against spurious warnings.

### Validation

- Full Go suite passes: `GOCACHE=/dev/shm/... GOTMPDIR=/dev/shm go test -count=1 ./...`
- No Rust change (the dataplane zone-filter already exists). Loss-cluster
  smoke not required — this is a control-plane/config validation + schema
  fix.

### Files / coordination

`pkg/config/compiler.go`, `pkg/config/schema_security.go`,
`pkg/config/static_nat_zone_test.go`, `docs/userspace-dataplane-architecture.md`,
`_Log.md`. The bucket charter lists `pkg/dataplane/userspace/protocol.go` as
owned (FlowSnapshot, shared with the nat64-frag bucket) — this PR does **not**
touch it, since H14 is not threaded and H15's wire field already exists, so
there is no field-level coordination needed with another bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)