### PR TITLE
config,frr: keep every protocol in routing-policy from-protocol (#2008 H18)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -6026,3 +6026,6 @@ top.
 - **Timestamp**: 2026-06-18
 - **Action**: Soften GC "chronological" comments to "usually chronological (wall-clock; NTP step can reorder, correctness independent)" for consistency with the GenID comment — comment-only.
 - **File(s)**: pkg/upgrade/stagedgen/stagedgen.go
+- **Timestamp**: 2026-06-18
+- **Action**: #2008 H18: routing-policy `from protocol [ ... ]` multi-protocol fix. PolicyTerm.FromProtocol (scalar) → FromProtocols ([]string); collectProtocolList flattens both AST shapes (block parse = all keys; flat-set SetPath = nested single-child chain); inline-keys path consumes consecutive protocol tokens; FRR render emits one `match source-protocol` per protocol (and the redistribute resolver iterates all). Show consumers (cli/grpc) render `[ ... ]` for multi. Regression tests: TestPolicyTermMultiProtocolFlatSet / TestPolicyTermMultiProtocolHierarchical (config compile), TestGeneratePolicyOptionsMultiProtocol (frr render) — all mutation-verified to fail on revert.
+- **File(s)**: pkg/config/types_routing.go, pkg/config/compiler_routing.go, pkg/frr/policy_render.go, pkg/cli/cli_show_routing.go, pkg/grpcapi/server_show_policies_text.go, pkg/config/parser_routing_test.go, pkg/frr/frr_test.go, pkg/config/parser_security_test.go, pkg/config/parser_ast_test.go

--- a/pkg/cli/cli_show_routing.go
+++ b/pkg/cli/cli_show_routing.go
@@ -783,8 +783,10 @@ func (c *CLI) showPolicyOptions() error {
 			fmt.Println()
 			for _, t := range ps.Terms {
 				fmt.Printf("    term %s:\n", t.Name)
-				if t.FromProtocol != "" {
-					fmt.Printf("      from protocol %s\n", t.FromProtocol)
+				if len(t.FromProtocols) == 1 {
+					fmt.Printf("      from protocol %s\n", t.FromProtocols[0])
+				} else if len(t.FromProtocols) > 1 {
+					fmt.Printf("      from protocol [ %s ]\n", strings.Join(t.FromProtocols, " "))
 				}
 				if t.PrefixList != "" {
 					fmt.Printf("      from prefix-list %s\n", t.PrefixList)

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -464,16 +464,22 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 	return nil
 }
 
-// collectProtocolList flattens a "from protocol [ ... ]" node into the full
-// list of protocol names. After the lexer strips the brackets, two AST shapes
-// reach the compiler:
-//   - block parse: every protocol is a key on the node itself
+// collectProtocolList flattens a single "from protocol ..." node into the
+// protocol names it carries. After the lexer strips the brackets, a protocol
+// node reaches the compiler in one of three shapes:
+//   - block parse, bracket list: every protocol is a key on the node itself
 //     (Keys = ["protocol", "bgp", "ospf", "static"]).
-//   - flat-set SetPath: the first protocol is Keys[1] and the remaining
-//     protocols hang off a nested single-child chain
+//   - flat-set SetPath, bracket list: the first protocol is Keys[1] and the
+//     remaining protocols hang off a nested single-child chain
 //     (Keys = ["protocol", "bgp"] -> child Keys = ["ospf", "static"] -> ...).
-// Both shapes (and arbitrarily long lists) are handled by taking Keys[1:] of
-// the protocol node, then appending every key of each descendant in the chain.
+//   - flat-set SetPath, separate "set ... from protocol <X>" commands: each
+//     command lands its own leaf (Keys = ["protocol", "<X>"]) as a sibling
+//     under the term's "from" block. The caller iterates those siblings and
+//     calls this helper once per node, which then returns the single protocol.
+//
+// All three shapes (and arbitrarily long lists) are handled by taking
+// Keys[1:] of the protocol node, then appending every key of each descendant
+// in the single-child chain.
 func collectProtocolList(protoNode *Node) []string {
 	var protocols []string
 	if len(protoNode.Keys) >= 2 {

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -464,6 +464,29 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 	return nil
 }
 
+// collectProtocolList flattens a "from protocol [ ... ]" node into the full
+// list of protocol names. After the lexer strips the brackets, two AST shapes
+// reach the compiler:
+//   - block parse: every protocol is a key on the node itself
+//     (Keys = ["protocol", "bgp", "ospf", "static"]).
+//   - flat-set SetPath: the first protocol is Keys[1] and the remaining
+//     protocols hang off a nested single-child chain
+//     (Keys = ["protocol", "bgp"] -> child Keys = ["ospf", "static"] -> ...).
+// Both shapes (and arbitrarily long lists) are handled by taking Keys[1:] of
+// the protocol node, then appending every key of each descendant in the chain.
+func collectProtocolList(protoNode *Node) []string {
+	var protocols []string
+	if len(protoNode.Keys) >= 2 {
+		protocols = append(protocols, protoNode.Keys[1:]...)
+	}
+	for n := protoNode; len(n.Children) > 0; {
+		child := n.Children[0]
+		protocols = append(protocols, child.Keys...)
+		n = child
+	}
+	return protocols
+}
+
 // parsePolicyTermChildren handles hierarchical form of policy term
 // where "from" and "then" are child nodes.
 func parsePolicyTermChildren(term *PolicyTerm, children []*Node) {
@@ -473,9 +496,17 @@ func parsePolicyTermChildren(term *PolicyTerm, children []*Node) {
 			for _, fc := range tc.Children {
 				switch fc.Name() {
 				case "protocol":
-					if len(fc.Keys) >= 2 {
-						term.FromProtocol = fc.Keys[1]
-					}
+					// Junos "from protocol [ bgp ospf static ]" matches any
+					// listed protocol. The lexer strips the brackets, so the
+					// protocol list arrives in one of two AST shapes:
+					//  - hierarchical block parse: all protocols land in
+					//    fc.Keys (Keys=["protocol","bgp","ospf","static"]);
+					//  - flat-set SetPath: the first protocol is fc.Keys[1]
+					//    and the rest form a nested child chain
+					//    (Keys=["protocol","bgp"] -> child Keys=["ospf","static"]).
+					// Collect every protocol from both shapes, not just the
+					// first (#2008 H18).
+					term.FromProtocols = append(term.FromProtocols, collectProtocolList(fc)...)
 				case "prefix-list":
 					if v := nodeVal(fc); v != "" {
 						term.PrefixList = v
@@ -540,6 +571,17 @@ func parsePolicyTermChildren(term *PolicyTerm, children []*Node) {
 	}
 }
 
+// policyTermInlineKeywords is the set of clause keywords recognized by
+// parsePolicyTermInlineKeys. It is used to find where a variable-length
+// value run (e.g. a multi-protocol "from protocol [ ... ]" list) ends.
+var policyTermInlineKeywords = map[string]bool{
+	"from": true, "then": true, "protocol": true, "prefix-list": true,
+	"route-filter": true, "next-hop": true, "load-balance": true,
+	"local-preference": true, "metric": true, "metric-type": true,
+	"community": true, "as-path": true, "origin": true,
+	"accept": true, "reject": true,
+}
+
 // parsePolicyTermInlineKeys handles flat set syntax where remaining keys
 // after the term name are inline key-value pairs like:
 // "from", "protocol", "direct" or "from", "route-filter", "10.0.0.0/8", "exact"
@@ -558,9 +600,13 @@ func parsePolicyTermInlineKeys(term *PolicyTerm, keys []string) {
 				term.Action = keys[i]
 			}
 		case "protocol":
-			if i+1 < len(keys) {
+			// "from protocol [ bgp ospf static ]" — the lexer strips the
+			// brackets, so every protocol arrives as a separate key. Consume
+			// all consecutive values until the next clause keyword, so a
+			// multi-protocol list keeps every protocol (not just the first).
+			for i+1 < len(keys) && !policyTermInlineKeywords[keys[i+1]] {
 				i++
-				term.FromProtocol = keys[i]
+				term.FromProtocols = append(term.FromProtocols, keys[i])
 			}
 		case "prefix-list":
 			if i+1 < len(keys) {

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -3514,8 +3514,8 @@ func TestMetricTypeAndCommunityListSetSyntax(t *testing.T) {
 		t.Fatalf("got %d terms, want 2", len(ps.Terms))
 	}
 	t1 := ps.Terms[0]
-	if t1.FromProtocol != "direct" {
-		t.Errorf("t1 from protocol = %q, want direct", t1.FromProtocol)
+	if len(t1.FromProtocols) != 1 || t1.FromProtocols[0] != "direct" {
+		t.Errorf("t1 from protocol = %v, want [direct]", t1.FromProtocols)
 	}
 	if t1.FromCommunity != "MY-COMM" {
 		t.Errorf("t1 from community = %q, want MY-COMM", t1.FromCommunity)

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -3299,5 +3300,84 @@ func TestWireGuardTunnelSetSyntax(t *testing.T) {
 	}
 	if tc.WgKeepaliveSecs != 25 {
 		t.Errorf("WgKeepaliveSecs = %d, want 25", tc.WgKeepaliveSecs)
+	}
+}
+
+// TestPolicyTermMultiProtocolFlatSet exercises the flat-set / inline-keys
+// compile path: "from protocol [ bgp ospf static ]" must keep ALL listed
+// protocols, not just the first. Regression for #2008 H18 — the old scalar
+// FromProtocol field silently discarded every protocol after the first.
+func TestPolicyTermMultiProtocolFlatSet(t *testing.T) {
+	tree := &ConfigTree{}
+	cmds := []string{
+		"set policy-options policy-statement EXPORT-ALL term t1 from protocol [ bgp ospf static ]",
+		"set policy-options policy-statement EXPORT-ALL term t1 then accept",
+	}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ps := cfg.PolicyOptions.PolicyStatements["EXPORT-ALL"]
+	if ps == nil {
+		t.Fatal("EXPORT-ALL policy-statement not found")
+	}
+	if len(ps.Terms) != 1 {
+		t.Fatalf("got %d terms, want 1", len(ps.Terms))
+	}
+	got := ps.Terms[0].FromProtocols
+	want := []string{"bgp", "ospf", "static"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FromProtocols (flat-set) = %v, want %v", got, want)
+	}
+	if ps.Terms[0].Action != "accept" {
+		t.Errorf("action = %q, want accept", ps.Terms[0].Action)
+	}
+}
+
+// TestPolicyTermMultiProtocolHierarchical exercises the hierarchical compile
+// path for the same multi-protocol "from protocol [ ... ]" list. Both the
+// flat-set and hierarchical walks must collect every protocol (#2008 H18).
+func TestPolicyTermMultiProtocolHierarchical(t *testing.T) {
+	input := `
+policy-options {
+    policy-statement EXPORT-ALL {
+        term t1 {
+            from {
+                protocol [ bgp ospf static ];
+            }
+            then accept;
+        }
+    }
+}
+`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("Parse: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	ps := cfg.PolicyOptions.PolicyStatements["EXPORT-ALL"]
+	if ps == nil {
+		t.Fatal("EXPORT-ALL policy-statement not found")
+	}
+	if len(ps.Terms) != 1 {
+		t.Fatalf("got %d terms, want 1", len(ps.Terms))
+	}
+	got := ps.Terms[0].FromProtocols
+	want := []string{"bgp", "ospf", "static"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FromProtocols (hierarchical) = %v, want %v", got, want)
 	}
 }

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -3381,3 +3381,54 @@ policy-options {
 		t.Errorf("FromProtocols (hierarchical) = %v, want %v", got, want)
 	}
 }
+
+// TestPolicyTermMultiProtocolSeparateSetCommands exercises the dual-AST
+// flat-set hazard called out by Copilot on #2011: an operator can add each
+// protocol with its own "set ... from protocol <X>" command rather than a
+// single bracket-list. Each separate SetPath lands a distinct
+// ["protocol","<X>"] node under the term's "from" block. Before the fix the
+// schema marked "from protocol" as a single-value leaf, so SetPath REPLACED
+// the previous protocol on each command and only the last one survived; the
+// term silently matched a single protocol instead of the operator's three.
+// With "from protocol" marked multi the protocols become sibling leaves and
+// the compiler collects every one.
+func TestPolicyTermMultiProtocolSeparateSetCommands(t *testing.T) {
+	tree := &ConfigTree{}
+	// IMPORTANT: build via ParseSetCommand + SetPath in a loop (the documented
+	// way to test flat-set syntax). NewParser() with newlines would merge all
+	// lines into one node and would not reproduce the separate-command shape.
+	cmds := []string{
+		"set policy-options policy-statement EXPORT-ALL term t1 from protocol bgp",
+		"set policy-options policy-statement EXPORT-ALL term t1 from protocol ospf",
+		"set policy-options policy-statement EXPORT-ALL term t1 from protocol static",
+		"set policy-options policy-statement EXPORT-ALL term t1 then accept",
+	}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ps := cfg.PolicyOptions.PolicyStatements["EXPORT-ALL"]
+	if ps == nil {
+		t.Fatal("EXPORT-ALL policy-statement not found")
+	}
+	if len(ps.Terms) != 1 {
+		t.Fatalf("got %d terms, want 1", len(ps.Terms))
+	}
+	got := ps.Terms[0].FromProtocols
+	want := []string{"bgp", "ospf", "static"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FromProtocols (separate set commands) = %v, want %v", got, want)
+	}
+	if ps.Terms[0].Action != "accept" {
+		t.Errorf("action = %q, want accept", ps.Terms[0].Action)
+	}
+}

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -2126,8 +2126,8 @@ func TestPolicyOptions(t *testing.T) {
 	if term.Name != "default_v4" {
 		t.Errorf("term name: got %q, want default_v4", term.Name)
 	}
-	if term.FromProtocol != "direct" {
-		t.Errorf("from protocol: got %q, want direct", term.FromProtocol)
+	if len(term.FromProtocols) != 1 || term.FromProtocols[0] != "direct" {
+		t.Errorf("from protocol: got %v, want [direct]", term.FromProtocols)
 	}
 	if len(term.RouteFilters) != 2 {
 		t.Fatalf("expected 2 route-filters, got %d", len(term.RouteFilters))
@@ -3071,8 +3071,8 @@ func TestPolicyStatementNextHopAndLoadBalance(t *testing.T) {
 		t.Fatalf("got %d terms, want 1", len(peer.Terms))
 	}
 	term := peer.Terms[0]
-	if term.FromProtocol != "direct" {
-		t.Errorf("from protocol = %q, want direct", term.FromProtocol)
+	if len(term.FromProtocols) != 1 || term.FromProtocols[0] != "direct" {
+		t.Errorf("from protocol = %v, want [direct]", term.FromProtocols)
 	}
 	if term.PrefixList != "management-hosts" {
 		t.Errorf("prefix-list = %q, want management-hosts", term.PrefixList)
@@ -3154,8 +3154,8 @@ func TestPolicyStatementRouteMapAttributesSetSyntax(t *testing.T) {
 		t.Fatalf("got %d terms, want 1", len(ps.Terms))
 	}
 	term := ps.Terms[0]
-	if term.FromProtocol != "bgp" {
-		t.Errorf("from protocol = %q, want bgp", term.FromProtocol)
+	if len(term.FromProtocols) != 1 || term.FromProtocols[0] != "bgp" {
+		t.Errorf("from protocol = %v, want [bgp]", term.FromProtocols)
 	}
 	if term.LocalPreference != 200 {
 		t.Errorf("local-preference = %d, want 200", term.LocalPreference)

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -45,7 +45,14 @@ var schemaPolicyOptions = &schemaNode{desc: "Policy options", children: map[stri
 	"policy-statement": {desc: "Policy statement", args: 1, placeholder: "<name>", children: map[string]*schemaNode{
 		"term": {desc: "Term name", args: 1, placeholder: "<term-name>", children: map[string]*schemaNode{
 			"from": {desc: "Match condition", children: map[string]*schemaNode{
-				"protocol":     {desc: "Protocol", args: 1, placeholder: "<protocol>", children: nil},
+				// "from protocol" is a multi-value match: Junos accepts
+				// "from protocol [ bgp ospf static ]" and, equivalently, a
+				// sequence of separate "set ... from protocol <X>" commands.
+				// Mark it multi so SetPath keeps every protocol as a sibling
+				// leaf instead of replacing the previous one (#2008 H18 /
+				// Copilot #2011). A single-value leaf collapses separate set
+				// commands down to only the last protocol.
+				"protocol":     {desc: "Protocol", args: 1, multi: true, placeholder: "<protocol>", children: nil},
 				"prefix-list":  {desc: "Prefix list", args: 1, placeholder: "<list-name>", children: nil},
 				"route-filter": {desc: "Route filter", args: 2, placeholder: "<prefix>", children: nil},
 				"community":    {desc: "Community", args: 1, placeholder: "<community>", children: nil},

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -41,8 +41,9 @@ type PolicyStatement struct {
 
 // PolicyTerm is a single match+action clause within a policy-statement.
 type PolicyTerm struct {
-	Name            string
-	FromProtocol    string         // "direct", "static", "bgp", "ospf"
+	Name          string
+	FromProtocols []string // "direct", "static", "bgp", "ospf" — Junos
+	// "from protocol [ bgp ospf static ]" matches ANY listed protocol.
 	PrefixList      string         // from prefix-list <name>
 	FromCommunity   string         // from community <name> (match against community-list)
 	FromASPath      string         // from as-path <name> (match against as-path access-list)

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -703,8 +703,8 @@ func TestGeneratePolicyOptions(t *testing.T) {
 				Name: "export-connected",
 				Terms: []*config.PolicyTerm{
 					{
-						Name:         "t1",
-						FromProtocol: "direct",
+						Name:          "t1",
+						FromProtocols: []string{"direct"},
 						RouteFilters: []*config.RouteFilter{
 							{Prefix: "10.0.0.0/8", MatchType: "exact"},
 						},
@@ -732,6 +732,49 @@ func TestGeneratePolicyOptions(t *testing.T) {
 	}
 }
 
+// TestGeneratePolicyOptionsMultiProtocol verifies that a term matching
+// multiple protocols ("from protocol [ bgp ospf static ]") renders a
+// "match source-protocol" line for EVERY protocol. Regression for #2008
+// H18 — the old single-FromProtocol render emitted only one match line, so
+// a multi-protocol policy silently matched only the first protocol.
+func TestGeneratePolicyOptionsMultiProtocol(t *testing.T) {
+	m := &Manager{frrConf: "/dev/null"}
+	po := &config.PolicyOptionsConfig{
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"EXPORT-ALL": {
+				Name: "EXPORT-ALL",
+				Terms: []*config.PolicyTerm{
+					{
+						Name:          "t1",
+						FromProtocols: []string{"bgp", "ospf", "direct"},
+						Action:        "accept",
+					},
+				},
+				DefaultAction: "reject",
+			},
+		},
+	}
+
+	got := m.generatePolicyOptions(po)
+
+	// "direct" maps to FRR "connected"; all three must render.
+	checks := []string{
+		"route-map EXPORT-ALL permit 10",
+		"match source-protocol bgp",
+		"match source-protocol ospf",
+		"match source-protocol connected",
+	}
+	for _, want := range checks {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	// Sanity: exactly three match lines (no extra, none dropped).
+	if n := strings.Count(got, "match source-protocol "); n != 3 {
+		t.Errorf("got %d match source-protocol lines, want 3:\n%s", n, got)
+	}
+}
+
 func TestGeneratePolicyOptionsRouteMapAttributes(t *testing.T) {
 	m := &Manager{frrConf: "/dev/null"}
 	po := &config.PolicyOptionsConfig{
@@ -741,7 +784,7 @@ func TestGeneratePolicyOptionsRouteMapAttributes(t *testing.T) {
 				Terms: []*config.PolicyTerm{
 					{
 						Name:            "t1",
-						FromProtocol:    "bgp",
+						FromProtocols:   []string{"bgp"},
 						Action:          "accept",
 						LocalPreference: 200,
 						Metric:          100,
@@ -1837,7 +1880,7 @@ func TestResolveRedistribute_PolicyStatement(t *testing.T) {
 			"export-connected": {
 				Name: "export-connected",
 				Terms: []*config.PolicyTerm{
-					{Name: "t1", FromProtocol: "direct", Action: "accept", PrefixList: "internal"},
+					{Name: "t1", FromProtocols: []string{"direct"}, Action: "accept", PrefixList: "internal"},
 				},
 			},
 		},
@@ -1856,8 +1899,8 @@ func TestResolveRedistribute_MultiProtocol(t *testing.T) {
 			"export-all": {
 				Name: "export-all",
 				Terms: []*config.PolicyTerm{
-					{Name: "connected", FromProtocol: "direct", Action: "accept"},
-					{Name: "static", FromProtocol: "static", Action: "accept"},
+					{Name: "connected", FromProtocols: []string{"direct"}, Action: "accept"},
+					{Name: "static", FromProtocols: []string{"static"}, Action: "accept"},
 				},
 			},
 		},
@@ -1882,7 +1925,7 @@ func TestGenerateProtocols_OSPFExportRouteMap(t *testing.T) {
 			"export-direct": {
 				Name: "export-direct",
 				Terms: []*config.PolicyTerm{
-					{Name: "t1", FromProtocol: "direct", PrefixList: "trusted-nets", Action: "accept"},
+					{Name: "t1", FromProtocols: []string{"direct"}, PrefixList: "trusted-nets", Action: "accept"},
 				},
 				DefaultAction: "reject",
 			},
@@ -1912,8 +1955,8 @@ func TestGenerateProtocols_BGPExportRouteMap(t *testing.T) {
 			"bgp-export": {
 				Name: "bgp-export",
 				Terms: []*config.PolicyTerm{
-					{Name: "connected", FromProtocol: "direct", Action: "accept"},
-					{Name: "static", FromProtocol: "static", Action: "accept"},
+					{Name: "connected", FromProtocols: []string{"direct"}, Action: "accept"},
+					{Name: "static", FromProtocols: []string{"static"}, Action: "accept"},
 				},
 			},
 		},
@@ -1942,7 +1985,7 @@ func TestGenerateProtocols_MixedBareAndRouteMap(t *testing.T) {
 			"filter-connected": {
 				Name: "filter-connected",
 				Terms: []*config.PolicyTerm{
-					{Name: "t1", FromProtocol: "direct", Action: "accept"},
+					{Name: "t1", FromProtocols: []string{"direct"}, Action: "accept"},
 				},
 			},
 		},
@@ -2069,7 +2112,7 @@ func TestGeneratePolicyOptionsCommunityListAndMetricType(t *testing.T) {
 				Terms: []*config.PolicyTerm{
 					{
 						Name:          "t1",
-						FromProtocol:  "direct",
+						FromProtocols: []string{"direct"},
 						FromCommunity: "MY-COMM",
 						Action:        "accept",
 						MetricType:    1,
@@ -2276,8 +2319,8 @@ func TestNextHopPeerAddress(t *testing.T) {
 				Name: "to-vpn-mesh",
 				Terms: []*config.PolicyTerm{
 					{
-						Name:         "v6",
-						FromProtocol: "direct",
+						Name:          "v6",
+						FromProtocols: []string{"direct"},
 						RouteFilters: []*config.RouteFilter{
 							{Prefix: "2001:559:8585::/48", MatchType: "exact"},
 						},
@@ -2285,8 +2328,8 @@ func TestNextHopPeerAddress(t *testing.T) {
 						Action:  "accept",
 					},
 					{
-						Name:         "v4",
-						FromProtocol: "direct",
+						Name:          "v4",
+						FromProtocols: []string{"direct"},
 						RouteFilters: []*config.RouteFilter{
 							{Prefix: "172.16.0.0/20", MatchType: "exact"},
 						},
@@ -2344,8 +2387,8 @@ func TestRouteFilterExactFRR(t *testing.T) {
 				Name: "to-firewall",
 				Terms: []*config.PolicyTerm{
 					{
-						Name:         "default_v4",
-						FromProtocol: "direct",
+						Name:          "default_v4",
+						FromProtocols: []string{"direct"},
 						RouteFilters: []*config.RouteFilter{
 							{Prefix: "192.168.50.0/24", MatchType: "exact"},
 							{Prefix: "192.168.99.0/24", MatchType: "exact"},

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -72,8 +72,7 @@ func (m *Manager) resolveRedistribute(export string, po *config.PolicyOptionsCon
 		if ps, ok := po.PolicyStatements[export]; ok {
 			protocols := make(map[string]bool)
 			for _, term := range ps.Terms {
-				if term.FromProtocol != "" {
-					proto := term.FromProtocol
+				for _, proto := range term.FromProtocols {
 					if proto == "direct" {
 						proto = "connected"
 					}
@@ -638,8 +637,11 @@ func (m *Manager) generatePolicyOptions(po *config.PolicyOptionsConfig) string {
 				fmt.Fprintf(&b, " match ip address prefix-list %s\n", term.PrefixList)
 			}
 
-			if term.FromProtocol != "" {
-				proto := term.FromProtocol
+			// Junos "from protocol [ bgp ospf static ]" matches ANY listed
+			// protocol. FRR's "match source-protocol" only accepts a single
+			// protocol per line, but repeated lines within one route-map entry
+			// are OR'd, so render one line per protocol.
+			for _, proto := range term.FromProtocols {
 				if proto == "direct" {
 					proto = "connected"
 				}

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -243,8 +243,10 @@ func (s *Server) showPolicyOptions(cfg *config.Config, buf *strings.Builder) {
 			buf.WriteString("\n")
 			for _, t := range ps.Terms {
 				fmt.Fprintf(buf, "    term %s:\n", t.Name)
-				if t.FromProtocol != "" {
-					fmt.Fprintf(buf, "      from protocol %s\n", t.FromProtocol)
+				if len(t.FromProtocols) == 1 {
+					fmt.Fprintf(buf, "      from protocol %s\n", t.FromProtocols[0])
+				} else if len(t.FromProtocols) > 1 {
+					fmt.Fprintf(buf, "      from protocol [ %s ]\n", strings.Join(t.FromProtocols, " "))
 				}
 				if t.PrefixList != "" {
 					fmt.Fprintf(buf, "      from prefix-list %s\n", t.PrefixList)


### PR DESCRIPTION
## Summary

Fixes **#2008 gap H18** — `policy-options policy-statement ... term ... from
protocol [ bgp ospf static ]` silently discarded every protocol after the
first. The list parses fine (the lexer strips the brackets), but
`PolicyTerm.FromProtocol` was a scalar `string`: the compiler stored only the
first protocol and the FRR renderer emitted a single `match source-protocol`
line. The operator's intent to match multiple source protocols was accepted at
commit with no error yet only the first protocol took effect — a silent Junos
divergence.

## Fix

- `PolicyTerm.FromProtocol` (scalar) → `FromProtocols` (`[]string`).
- `collectProtocolList` flattens the protocol list from both AST shapes that
  reach the compiler after bracket stripping:
  - **hierarchical block parse**: all protocols land in the node keys
    (`Keys=["protocol","bgp","ospf","static"]`);
  - **flat-set `SetPath`**: the first protocol is `Keys[1]` and the rest form a
    nested single-child chain (`Keys=["protocol","bgp"]` → child
    `Keys=["ospf","static"]` → ...).
- The inline-keys flat path consumes consecutive protocol tokens up to the next
  clause keyword (`policyTermInlineKeywords`).
- `pkg/frr/policy_render.go` now emits one `match source-protocol` line per
  protocol (repeated match lines within a route-map entry are OR'd by FRR), and
  the redistribute resolver iterates the whole list.
- CLI and gRPC `show` consumers render a single protocol bare, and multiple as
  `[ p1 p2 ... ]` (Junos display form).

## Regression tests (mutation-verified — fail when the fix is reverted)

- `TestPolicyTermMultiProtocolFlatSet` / `TestPolicyTermMultiProtocolHierarchical`
  (`pkg/config`): `from protocol [ bgp ospf static ]` compiles to all three
  protocols via both the flat-set and hierarchical walks.
- `TestGeneratePolicyOptionsMultiProtocol` (`pkg/frr`): a multi-protocol term
  renders exactly one `match source-protocol` line per protocol (with
  `direct` → `connected` mapping).

Confirmed each test fails against the pre-fix behavior and passes with the fix.

## Validation

- Full Go suite `go test ./...` passes; `gofmt` clean.
- Control-plane config/render fix — loss-cluster smoke is **not** required.
- No docs change: `docs/feature-gaps.md` already marks routing-policy
  enhancements "Partial" and that row remains accurate (other match/action
  types are still unsupported).

## Scope / shared files

Owns `pkg/config/{types_routing.go,compiler_routing.go}` + `pkg/frr/policy_render.go`
(plus the `show` consumers `pkg/cli/cli_show_routing.go`,
`pkg/grpcapi/server_show_policies_text.go`, which read the renamed field). No
overlap expected with other #2008 buckets beyond the shared `PolicyTerm` type
file, resolvable at serial-merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)