### PR TITLE
#2008 H3/H4: enforce security alg dns/ftp disable in the userspace dataplane

### DIFF
--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -216,6 +216,19 @@ xpf has TCP session timeouts (established, initial, closing, time-wait), UDP/ICM
 
 xpf has ALG disable flags for DNS, FTP, SIP, TFTP. The vSRX supports many more ALGs.
 
+The `security alg <proto> disable` knobs reach the userspace dataplane via
+`FlowSnapshot.alg_disable_flags` (#2008 H3/H4): the bitfield is packed by
+`pkg/dataplane/userspace.algDisableFlags` (DNS=0x01, FTP=0x02, SIP=0x04,
+TFTP=0x08) and read in the session-create path by
+`alg_type_for_session` (`userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs`).
+A session on a well-known ALG service port (DNS UDP/53, FTP TCP/21, SIP
+UDP+TCP/5060) is tagged with its ALG type in the conntrack `alg_type` field
+*unless* that ALG is disabled, in which case it is tagged `none`. This matches
+the Junos semantics of `alg disable` — the ALG is turned **off**, traffic is
+**never dropped**. (xpf does not yet implement the active ALG transforms
+themselves — payload doctoring / dynamic pinholes — so a non-disabled ALG only
+sets the type; see "DNS ALG with NAT" below.)
+
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
 | **H.323 ALG** | `security alg h323 ...` | VoIP: H.323 session tracking, media pinhole management, NAT for H.245/RAS | Low | Missing |

--- a/pkg/dataplane/userspace/flow.go
+++ b/pkg/dataplane/userspace/flow.go
@@ -91,7 +91,32 @@ func buildFlowSnapshot(cfg *config.Config) FlowSnapshot {
 		snap.TCPSessionTimeout = coerceWireSessionTimeout(
 			"tcp_session_timeout", cfg.Security.Flow.TCPSession.EstablishedTimeout)
 	}
+	snap.ALGDisableFlags = algDisableFlags(&cfg.Security.ALG)
 	return snap
+}
+
+// algDisableFlags packs the `security alg <proto> disable` knobs into the
+// bitfield the userspace dataplane consumes (#2008 H3/H4). The bit layout
+// MUST match pkg/dataplane/compiler.go's legacy flow_config_map encoding and
+// the Rust ALG_DISABLE_* constants: DNS=0x01, FTP=0x02, SIP=0x04, TFTP=0x08.
+func algDisableFlags(alg *config.ALGConfig) uint8 {
+	if alg == nil {
+		return 0
+	}
+	var flags uint8
+	if alg.DNSDisable {
+		flags |= 0x01
+	}
+	if alg.FTPDisable {
+		flags |= 0x02
+	}
+	if alg.SIPDisable {
+		flags |= 0x04
+	}
+	if alg.TFTPDisable {
+		flags |= 0x08
+	}
+	return flags
 }
 
 func buildFlowExportSnapshot(cfg *config.Config) *FlowExportSnapshot {

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -4058,6 +4058,60 @@ func TestBuildFlowSnapshotNilTCPSession(t *testing.T) {
 	}
 }
 
+// TestBuildFlowSnapshotPacksALGDisableFlags verifies the `security alg <proto>
+// disable` knobs reach the dataplane wire snapshot (#2008 H3/H4). Before the
+// fix the flags were written only to the legacy flow_config_map (no userspace
+// reader) and FlowSnapshot did not carry them at all, so `alg disable` was a
+// silent no-op. The bit layout MUST match pkg/dataplane/compiler.go and the
+// Rust ALG_DISABLE_* constants: DNS=0x01, FTP=0x02, SIP=0x04, TFTP=0x08.
+func TestBuildFlowSnapshotPacksALGDisableFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		set  func(*config.ALGConfig)
+		want uint8
+	}{
+		{"none", func(*config.ALGConfig) {}, 0x00},
+		{"dns", func(a *config.ALGConfig) { a.DNSDisable = true }, 0x01},
+		{"ftp", func(a *config.ALGConfig) { a.FTPDisable = true }, 0x02},
+		{"sip", func(a *config.ALGConfig) { a.SIPDisable = true }, 0x04},
+		{"tftp", func(a *config.ALGConfig) { a.TFTPDisable = true }, 0x08},
+		{"dns+ftp", func(a *config.ALGConfig) {
+			a.DNSDisable = true
+			a.FTPDisable = true
+		}, 0x03},
+		{"all", func(a *config.ALGConfig) {
+			a.DNSDisable = true
+			a.FTPDisable = true
+			a.SIPDisable = true
+			a.TFTPDisable = true
+		}, 0x0f},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			tc.set(&cfg.Security.ALG)
+			snap := buildFlowSnapshot(cfg)
+			if snap.ALGDisableFlags != tc.want {
+				t.Fatalf("ALGDisableFlags = 0x%02x, want 0x%02x", snap.ALGDisableFlags, tc.want)
+			}
+			// The flags must survive the JSON wire encoding the helper
+			// decodes; a missing/renamed tag would silently drop them
+			// (the #1961 failure class).
+			data, err := json.Marshal(snap)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var rt FlowSnapshot
+			if err := json.Unmarshal(data, &rt); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if rt.ALGDisableFlags != tc.want {
+				t.Fatalf("round-trip ALGDisableFlags = 0x%02x, want 0x%02x", rt.ALGDisableFlags, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildInterfaceSnapshotSetsTunnelFlag(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -107,6 +107,14 @@ type FlowSnapshot struct {
 	GREAcceleration    bool   `json:"gre_acceleration,omitempty"`     // extract GRE key into session ports
 	Lo0FilterInputV4   string `json:"lo0_filter_input_v4,omitempty"`  // lo0 inet input filter name
 	Lo0FilterInputV6   string `json:"lo0_filter_input_v6,omitempty"`  // lo0 inet6 input filter name
+	// ALGDisableFlags carries the `security alg <proto> disable` bitfield
+	// (bit 0: DNS, bit 1: FTP, bit 2: SIP, bit 3: TFTP — same layout as the
+	// legacy flow_config_map FlowConfigValue.ALGFlags). The userspace
+	// dataplane reads this to suppress ALG-type tagging for disabled ALGs
+	// (#2008 H3/H4). Junos `alg disable` turns the ALG off; it does NOT drop
+	// traffic, so the only enforced effect is that a session matching a
+	// disabled ALG is no longer tagged with that ALG type.
+	ALGDisableFlags uint8 `json:"alg_disable_flags,omitempty"`
 }
 
 type SnapshotSummary struct {

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -337,6 +337,10 @@ pub(super) struct ConntrackCtx<'a> {
     pub(super) v4_fd: c_int,
     pub(super) v6_fd: c_int,
     pub(super) zone_name_to_id: &'a FastMap<String, u16>,
+    /// `security alg <proto> disable` bitfield (#2008 H3/H4), carried from
+    /// ForwardingState so the mirrored conntrack entry's alg_type honours
+    /// the operator's disable knobs.
+    pub(super) alg_disable_flags: u8,
 }
 
 // ── BPF conntrack map structs (mirrors C struct session_key / session_value) ──
@@ -453,6 +457,10 @@ pub(super) fn publish_bpf_conntrack_entry(
     decision: SessionDecision,
     metadata: &SessionMetadata,
     _zone_name_to_id: &FastMap<String, u16>,
+    // `security alg <proto> disable` bitfield (#2008 H3/H4). Carried from
+    // ForwardingState so the session's alg_type honours the operator's
+    // disable knobs instead of being hardcoded to 0.
+    alg_disable_flags: u8,
 ) {
     // #919: zones are now u16 in SessionMetadata; the round-trip
     // name→id lookup the old code did is gone.
@@ -482,6 +490,7 @@ pub(super) fn publish_bpf_conntrack_entry(
                 ingress_zone_id,
                 egress_zone_id,
                 now_secs,
+                alg_disable_flags,
             );
         }
         (libc::AF_INET6, IpAddr::V6(src), IpAddr::V6(dst)) if conntrack_v6_fd >= 0 => {
@@ -496,6 +505,7 @@ pub(super) fn publish_bpf_conntrack_entry(
                 ingress_zone_id,
                 egress_zone_id,
                 now_secs,
+                alg_disable_flags,
             );
         }
         _ => {}
@@ -694,6 +704,7 @@ pub(super) fn publish_session_map_entry_for_session_with_conntrack(
                 decision,
                 metadata,
                 ctx.zone_name_to_id,
+                ctx.alg_disable_flags,
             );
         }
         return Ok(());
@@ -708,6 +719,7 @@ pub(super) fn publish_session_map_entry_for_session_with_conntrack(
             decision,
             metadata,
             ctx.zone_name_to_id,
+            ctx.alg_disable_flags,
         );
     }
     result

--- a/userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs
+++ b/userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs
@@ -26,6 +26,65 @@ use core::ffi::{c_int, c_void};
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+// `security alg <proto> disable` bitfield (#2008 H3/H4). Mirrors the Go
+// `algDisableFlags` encoding and the legacy flow_config_map ALGFlags layout.
+const ALG_DISABLE_DNS: u8 = 0x01;
+const ALG_DISABLE_FTP: u8 = 0x02;
+const ALG_DISABLE_SIP: u8 = 0x04;
+
+const PROTO_TCP: u8 = 6;
+const PROTO_UDP: u8 = 17;
+
+// alg_type codes written into the conntrack session value, matching
+// bpf/headers/xpf_conntrack.h: 0=none, 1=FTP, 2=SIP, 3=DNS.
+const ALG_TYPE_NONE: u8 = 0;
+const ALG_TYPE_FTP: u8 = 1;
+const ALG_TYPE_SIP: u8 = 2;
+const ALG_TYPE_DNS: u8 = 3;
+
+/// Derive the conntrack `alg_type` for a session from its forward 5-tuple,
+/// honouring the `security alg <proto> disable` bitfield (#2008 H3/H4).
+///
+/// Previously `alg_type` was hardcoded to 0, so the `alg disable` knob had
+/// zero runtime effect: it parsed and compiled into `flow_config_map` but no
+/// reader consumed it. This derives the ALG type from the well-known service
+/// port (FTP TCP/21, SIP UDP+TCP/5060, DNS UDP/53) UNLESS the matching ALG is
+/// disabled, in which case the session is tagged `none` (0) — exactly the
+/// Junos semantics of `alg disable` (the ALG is turned off; traffic is NOT
+/// dropped). The service port is the destination port for a forward session;
+/// the reverse direction's source port mirrors it, so both directions of an
+/// ALG session resolve to the same type.
+pub(super) fn alg_type_for_session(protocol: u8, src_port: u16, dst_port: u16, disable: u8) -> u8 {
+    // The well-known ALG service port can appear as either the forward dst
+    // (client -> server) or, for a session keyed in the reverse direction,
+    // the src. Treat a match on either port slot as the same ALG.
+    let on_port = |p: u16| src_port == p || dst_port == p;
+    match protocol {
+        PROTO_UDP if on_port(53) => {
+            if disable & ALG_DISABLE_DNS != 0 {
+                ALG_TYPE_NONE
+            } else {
+                ALG_TYPE_DNS
+            }
+        }
+        PROTO_TCP if on_port(21) => {
+            if disable & ALG_DISABLE_FTP != 0 {
+                ALG_TYPE_NONE
+            } else {
+                ALG_TYPE_FTP
+            }
+        }
+        PROTO_UDP | PROTO_TCP if on_port(5060) => {
+            if disable & ALG_DISABLE_SIP != 0 {
+                ALG_TYPE_NONE
+            } else {
+                ALG_TYPE_SIP
+            }
+        }
+        _ => ALG_TYPE_NONE,
+    }
+}
+
 pub(super) fn publish_v4_session(
     conntrack_v4_fd: c_int,
     key: &SessionKey,
@@ -37,7 +96,10 @@ pub(super) fn publish_v4_session(
     ingress_zone_id: u16,
     egress_zone_id: u16,
     now_secs: u64,
+    alg_disable_flags: u8,
 ) {
+    let alg_type =
+        alg_type_for_session(key.protocol, key.src_port, key.dst_port, alg_disable_flags);
     let bpf_key = BpfSessionKeyV4 {
         src_ip: src.octets(),
         dst_ip: dst.octets(),
@@ -102,7 +164,7 @@ pub(super) fn publish_v4_session(
         rev_packets: 0,
         rev_bytes: 0,
         reverse_key: rev_key,
-        alg_type: 0,
+        alg_type,
         log_flags: 0,
         app_id: 0,
         fib_ifindex: 0,
@@ -139,7 +201,10 @@ pub(super) fn publish_v6_session(
     ingress_zone_id: u16,
     egress_zone_id: u16,
     now_secs: u64,
+    alg_disable_flags: u8,
 ) {
+    let alg_type =
+        alg_type_for_session(key.protocol, key.src_port, key.dst_port, alg_disable_flags);
     let bpf_key = BpfSessionKeyV6 {
         src_ip: src.octets(),
         dst_ip: dst.octets(),
@@ -201,7 +266,7 @@ pub(super) fn publish_v6_session(
         rev_packets: 0,
         rev_bytes: 0,
         reverse_key: rev_key,
-        alg_type: 0,
+        alg_type,
         log_flags: 0,
         app_id: 0,
         fib_ifindex: 0,
@@ -224,5 +289,104 @@ pub(super) fn publish_v6_session(
             "xpf-ha: conntrack v6 map update failed: {}",
             io::Error::last_os_error()
         );
+    }
+}
+
+#[cfg(test)]
+mod alg_type_tests {
+    use super::{
+        ALG_DISABLE_DNS, ALG_DISABLE_FTP, ALG_DISABLE_SIP, ALG_TYPE_DNS, ALG_TYPE_FTP,
+        ALG_TYPE_NONE, ALG_TYPE_SIP, PROTO_TCP, PROTO_UDP, alg_type_for_session,
+    };
+
+    // #2008 H3/H4: with no ALG disabled, a session on a well-known ALG
+    // service port is tagged with its ALG type. The service port is the
+    // forward destination port (client -> server).
+    #[test]
+    fn dns_session_tagged_when_alg_enabled() {
+        // UDP/53 client (ephemeral src) -> server.
+        assert_eq!(
+            alg_type_for_session(PROTO_UDP, 41234, 53, 0),
+            ALG_TYPE_DNS,
+            "DNS session must be tagged DNS when the DNS ALG is enabled"
+        );
+    }
+
+    #[test]
+    fn ftp_session_tagged_when_alg_enabled() {
+        assert_eq!(
+            alg_type_for_session(PROTO_TCP, 51000, 21, 0),
+            ALG_TYPE_FTP,
+            "FTP session must be tagged FTP when the FTP ALG is enabled"
+        );
+    }
+
+    #[test]
+    fn sip_session_tagged_when_alg_enabled() {
+        assert_eq!(alg_type_for_session(PROTO_UDP, 5060, 5060, 0), ALG_TYPE_SIP);
+        assert_eq!(alg_type_for_session(PROTO_TCP, 40000, 5060, 0), ALG_TYPE_SIP);
+    }
+
+    // The enforcement under test (#2008 H3): when `security alg dns disable`
+    // is set, the DNS-disable bit (0x01) MUST suppress the DNS ALG type — the
+    // session is tagged `none`. This is the bit the audit found was written to
+    // flow_config_map but never read. If the flag read is removed from
+    // alg_type_for_session, this assertion regresses to ALG_TYPE_DNS.
+    #[test]
+    fn dns_session_not_tagged_when_alg_disabled() {
+        assert_eq!(
+            alg_type_for_session(PROTO_UDP, 41234, 53, ALG_DISABLE_DNS),
+            ALG_TYPE_NONE,
+            "`security alg dns disable` must turn the DNS ALG off (alg_type=none)"
+        );
+    }
+
+    // #2008 H4: `security alg ftp disable` -> FTP-disable bit (0x02) suppresses
+    // the FTP ALG type for TCP/21 sessions.
+    #[test]
+    fn ftp_session_not_tagged_when_alg_disabled() {
+        assert_eq!(
+            alg_type_for_session(PROTO_TCP, 51000, 21, ALG_DISABLE_FTP),
+            ALG_TYPE_NONE,
+            "`security alg ftp disable` must turn the FTP ALG off (alg_type=none)"
+        );
+    }
+
+    #[test]
+    fn sip_session_not_tagged_when_alg_disabled() {
+        assert_eq!(
+            alg_type_for_session(PROTO_UDP, 5060, 5060, ALG_DISABLE_SIP),
+            ALG_TYPE_NONE,
+            "`security alg sip disable` must turn the SIP ALG off (alg_type=none)"
+        );
+    }
+
+    // Disabling one ALG must NOT affect another: with only DNS disabled, an
+    // FTP session is still tagged FTP (proves the bits are read independently,
+    // not as an all-or-nothing gate).
+    #[test]
+    fn disabling_dns_does_not_affect_ftp() {
+        assert_eq!(
+            alg_type_for_session(PROTO_TCP, 51000, 21, ALG_DISABLE_DNS),
+            ALG_TYPE_FTP
+        );
+        assert_eq!(
+            alg_type_for_session(PROTO_UDP, 41234, 53, ALG_DISABLE_FTP),
+            ALG_TYPE_DNS
+        );
+    }
+
+    // Junos `alg disable` turns the ALG OFF; it never drops traffic. The
+    // dataplane has no DNS/FTP ALG transform, so a disabled ALG is simply not
+    // tagged — non-ALG ports are always `none` regardless of the flags.
+    #[test]
+    fn non_alg_port_is_always_none() {
+        assert_eq!(alg_type_for_session(PROTO_TCP, 12345, 443, 0), ALG_TYPE_NONE);
+        assert_eq!(
+            alg_type_for_session(PROTO_TCP, 12345, 443, 0xff),
+            ALG_TYPE_NONE
+        );
+        // Wrong protocol on an ALG port (e.g. TCP/53) is not the DNS ALG.
+        assert_eq!(alg_type_for_session(PROTO_TCP, 41234, 53, 0), ALG_TYPE_NONE);
     }
 }

--- a/userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs
+++ b/userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs
@@ -31,6 +31,14 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 const ALG_DISABLE_DNS: u8 = 0x01;
 const ALG_DISABLE_FTP: u8 = 0x02;
 const ALG_DISABLE_SIP: u8 = 0x04;
+// TFTP's disable bit is carried on the wire for layout parity with the Go
+// `algDisableFlags` packer (DNS 0x01 / FTP 0x02 / SIP 0x04 / TFTP 0x08), but
+// it has no consumer here: the dataplane has no TFTP conntrack alg_type to
+// suppress (`alg_type` is one of none/FTP/SIP/DNS — see xpf_conntrack.h), so
+// `alg_type_for_session` never reads this bit. Defined to document the full
+// bit layout consistently across Go and Rust; intentionally unused.
+#[allow(dead_code)]
+const ALG_DISABLE_TFTP: u8 = 0x08;
 
 const PROTO_TCP: u8 = 6;
 const PROTO_UDP: u8 = 17;
@@ -373,6 +381,43 @@ mod alg_type_tests {
         assert_eq!(
             alg_type_for_session(PROTO_UDP, 41234, 53, ALG_DISABLE_FTP),
             ALG_TYPE_DNS
+        );
+    }
+
+    // A session keyed in the REVERSE direction carries the well-known ALG
+    // service port in the SRC slot (server -> client), not the dst. The
+    // `on_port` helper checks `src_port == p || dst_port == p`, so the ALG
+    // type must still resolve. Both directions of one ALG session map to the
+    // same alg_type, which is required for the reverse conntrack entry the
+    // publisher installs alongside the forward entry.
+    #[test]
+    fn dns_reverse_keyed_session_tagged_on_src_port() {
+        // UDP 53 (server) -> ephemeral (client): well-known port in src slot.
+        assert_eq!(
+            alg_type_for_session(PROTO_UDP, 53, 41234, 0),
+            ALG_TYPE_DNS,
+            "reverse-keyed DNS session must match the well-known port on the src slot"
+        );
+        // The disable bit still suppresses it in the reverse direction.
+        assert_eq!(
+            alg_type_for_session(PROTO_UDP, 53, 41234, ALG_DISABLE_DNS),
+            ALG_TYPE_NONE,
+            "`security alg dns disable` must apply to reverse-keyed sessions too"
+        );
+    }
+
+    #[test]
+    fn ftp_reverse_keyed_session_tagged_on_src_port() {
+        // TCP 21 (server) -> ephemeral (client): well-known port in src slot.
+        assert_eq!(
+            alg_type_for_session(PROTO_TCP, 21, 51000, 0),
+            ALG_TYPE_FTP,
+            "reverse-keyed FTP session must match the well-known port on the src slot"
+        );
+        assert_eq!(
+            alg_type_for_session(PROTO_TCP, 21, 51000, ALG_DISABLE_FTP),
+            ALG_TYPE_NONE,
+            "`security alg ftp disable` must apply to reverse-keyed sessions too"
         );
     }
 

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -172,6 +172,7 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     )?;
     state.allow_dns_reply = snapshot.flow.allow_dns_reply;
     state.allow_embedded_icmp = snapshot.flow.allow_embedded_icmp;
+    state.alg_disable_flags = snapshot.flow.alg_disable_flags;
     state.session_timeouts = crate::session::SessionTimeouts::from_seconds(
         snapshot.flow.tcp_session_timeout,
         snapshot.flow.udp_session_timeout,

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -2433,3 +2433,29 @@ fn tunnel_remap_purge_ids_from_owners_semantics() {
     // Pristine first apply (empty owners + flag false): nothing purged.
     assert!(tunnel_remap_purge_ids_from_owners(&[], &next, false).is_empty());
 }
+
+// #2008 H3/H4: pin the snapshot -> runtime read of the ALG-disable
+// bitfield in forwarding_build/mod.rs (`state.alg_disable_flags =
+// snapshot.flow.alg_disable_flags`). Without this assertion the wire
+// plumbing is untested end to end: the Go-packing tests and the pure
+// `alg_type_for_session` tests both stay green even if the build step
+// is reverted to a hardcoded 0, so the flag would silently never reach
+// the conntrack publisher. MUTATION-VERIFY: hardcoding line 175 to 0
+// (or dropping the assignment) must fail this test.
+#[test]
+fn build_forwarding_state_carries_alg_disable_flags() {
+    // DNS (0x01) + FTP (0x02) disabled.
+    let flags: u8 = 0x01 | 0x02;
+    let snapshot = ConfigSnapshot {
+        flow: crate::FlowSnapshot {
+            alg_disable_flags: flags,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    assert_eq!(
+        state.alg_disable_flags, flags,
+        "ForwardingState.alg_disable_flags must equal snapshot.flow.alg_disable_flags"
+    );
+}

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -328,6 +328,7 @@ pub(super) fn poll_binding_process_descriptor(
                                     resolved.decision,
                                     &resolved.metadata,
                                     &worker_ctx.forwarding.zone_name_to_id,
+                                    worker_ctx.forwarding.alg_disable_flags,
                                 );
                             }
                             // Log first N session hits from WAN (return path)
@@ -907,6 +908,7 @@ pub(super) fn poll_binding_process_descriptor(
                                         decision,
                                         &local_metadata,
                                         &worker_ctx.forwarding.zone_name_to_id,
+                                        worker_ctx.forwarding.alg_disable_flags,
                                     );
                                 }
                             }
@@ -2805,6 +2807,7 @@ pub(super) fn poll_binding_process_descriptor(
                                             pending_decision,
                                             &entry.metadata,
                                             &worker_ctx.forwarding.zone_name_to_id,
+                                            worker_ctx.forwarding.alg_disable_flags,
                                         );
                                         publish_dnat_table_entry(
                                             &worker_ctx.dnat_fds,

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -48,6 +48,12 @@ pub(in crate::afxdp) struct ForwardingState {
     pub(in crate::afxdp) fabrics: Vec<FabricLink>,
     pub(in crate::afxdp) allow_dns_reply: bool,
     pub(in crate::afxdp) allow_embedded_icmp: bool,
+    /// `security alg <proto> disable` bitfield (#2008 H3/H4): bit 0 DNS,
+    /// bit 1 FTP, bit 2 SIP, bit 3 TFTP. Read at session-create time to
+    /// suppress ALG-type tagging for a disabled ALG. Junos `alg disable`
+    /// turns the ALG off; it never drops traffic, so a set bit only
+    /// changes the session's reported alg_type to 0 (none).
+    pub(in crate::afxdp) alg_disable_flags: u8,
     pub(in crate::afxdp) session_timeouts: crate::session::SessionTimeouts,
     pub(in crate::afxdp) policy: PolicyState,
     pub(in crate::afxdp) source_nat_rules: Vec<SourceNatRule>,

--- a/userspace-dp/src/protocol/snapshot.rs
+++ b/userspace-dp/src/protocol/snapshot.rs
@@ -159,6 +159,14 @@ pub(crate) struct FlowSnapshot {
     pub lo0_filter_input_v4: String,
     #[serde(rename = "lo0_filter_input_v6", default)]
     pub lo0_filter_input_v6: String,
+    /// `security alg <proto> disable` bitfield (#2008 H3/H4): bit 0 DNS,
+    /// bit 1 FTP, bit 2 SIP, bit 3 TFTP. Matches the Go `algDisableFlags`
+    /// encoding. Absent / 0 on snapshots from old Go binaries (additive
+    /// field). The dataplane reads this to suppress ALG-type tagging for a
+    /// disabled ALG; Junos `alg disable` turns the ALG off, it never drops
+    /// traffic.
+    #[serde(rename = "alg_disable_flags", default)]
+    pub alg_disable_flags: u8,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -204,6 +204,7 @@
     "fib_generation": 0,
     "filters": [],
     "flow": {
+      "alg_disable_flags": 0,
       "allow_dns_reply": false,
       "allow_embedded_icmp": false,
       "gre_acceleration": false,
@@ -485,6 +486,7 @@
     "sampling_rate": 0
   },
   "flow_snapshot": {
+    "alg_disable_flags": 0,
     "allow_dns_reply": false,
     "allow_embedded_icmp": false,
     "gre_acceleration": false,


### PR DESCRIPTION
## What

Implements the paired #2008 HIGH gaps **H3** (`security alg dns disable`) and
**H4** (`security alg ftp disable`), plus SIP/TFTP for free since they share
the same plumbing.

**The gap (confirmed real):** `security alg <proto> disable` parsed and
compiled into the legacy `flow_config_map` `ALGFlags` bitfield, but:

1. The userspace AF_XDP dataplane is driven by the JSON control-socket
   snapshot, **not** the eBPF `flow_config_map` (retired path) — and
   `FlowSnapshot` did not carry the ALG-disable flags at all.
2. No Rust reader consumed `alg_flags`.
3. The conntrack session value's `alg_type` was **hardcoded to `0`** at
   `publish_conntrack.rs`.

Net effect: `alg disable` was accepted at commit with **zero runtime effect**
— a silent Junos divergence (the audit's "stored-but-never-enforced" class).

## Junos semantics confirmed before coding

`alg disable` turns the ALG **off**; it does **not** drop traffic. The audit
fix-sketch's "reject/again on UDP/53" suggestion contradicts Junos and was
**not** implemented. The enforced effect here is: a session matching a
well-known ALG service port is tagged with its ALG type in the conntrack
`alg_type` field *unless* that ALG is disabled, in which case it is tagged
`none`. (xpf does not yet run the active ALG transforms — payload doctoring /
dynamic pinholes — so a non-disabled ALG only sets the type today; the
transform work is the separate "DNS ALG with NAT" gap in `feature-gaps.md`.)

## The fix

- Go: add `ALGDisableFlags uint8` to `FlowSnapshot`; pack it in
  `buildFlowSnapshot` via `algDisableFlags` (DNS=0x01, FTP=0x02, SIP=0x04,
  TFTP=0x08 — same layout as the legacy `flow_config_map` encoding and the
  Rust constants). Plain `uint8` JSON number, immune to the #1961 base64
  `[]uint8` wire-type failure class.
- Rust: add `alg_disable_flags` to the wire `FlowSnapshot` and to
  `ForwardingState`; wire it in `forwarding_build`. New pure helper
  `alg_type_for_session` derives the `alg_type` (codes match
  `bpf/headers/xpf_conntrack.h`: FTP=1, SIP=2, DNS=3) from the session
  5-tuple, returning `none` when the matching disable bit is set. Threaded
  through `publish_bpf_conntrack_entry` and the `ConntrackCtx` mirror path so
  every session-publish site honours the knobs. The well-known port is matched
  on either the src or dst slot so a reverse-keyed session resolves to the same
  ALG.

## Regression tests

- Rust `alg_type_tests` (in `publish_conntrack.rs`): each ALG enabled vs
  disabled, **bit independence** (disabling DNS leaves FTP tagged), and
  non-ALG / wrong-protocol ports always `none`. **Mutation-verified**: removing
  the disable-bit read from the DNS arm makes
  `dns_session_not_tagged_when_alg_disabled` FAIL.
- Go `TestBuildFlowSnapshotPacksALGDisableFlags`: per-knob bit packing, a
  two-bit combination, all-on, plus a JSON round-trip that fails if the wire
  tag is dropped/renamed.
- Protocol wire fixture (`protocol_wire_v1.json`) regenerated for the additive
  `alg_disable_flags` field.

## Validation

- Full `go test ./...` — pass.
- Full `cargo test --bin xpf-userspace-dp` — 2032 pass, 0 fail.
- Mutation-verified the disabled-DNS assertion fails when the flag read is
  reverted.
- No loss-cluster smoke required: this is a control-plane snapshot field plus a
  dataplane session-handler change, not a forwarding-fast-path change.

## Notes for serial merge

Shared files that another #2008 bucket may also touch:
`pkg/dataplane/userspace/protocol.go` and `userspace-dp/src/protocol/snapshot.rs`
(both get a single additive `FlowSnapshot` field). `_Log.md` was intentionally
NOT edited (it is dirty WIP in the main checkout; editing it in the worktree
would conflict at merge time).

Refs #2008 (H3, H4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)