### PR TITLE
cleanup: DRY ip_proto consts + O(1) SNMP getCommunity (#2016)

### DIFF
--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -536,12 +536,8 @@ func (a *Agent) getCommunity(community string) *config.SNMPCommunity {
 	if cfg == nil || cfg.Communities == nil {
 		return nil
 	}
-	for _, c := range cfg.Communities {
-		if c.Name == community {
-			return c
-		}
-	}
-	return nil
+	// Communities is keyed by community name, so look it up directly.
+	return cfg.Communities[community]
 }
 
 // isValidCommunity checks if the given community string is configured.

--- a/userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs
+++ b/userspace-dp/src/afxdp/bpf_map/publish_conntrack.rs
@@ -22,6 +22,7 @@ use super::{
     BpfSessionKeyV4, BpfSessionKeyV6, BpfSessionValueV4, BpfSessionValueV6, SESS_STATE_ESTABLISHED,
     SessionDecision, SessionKey, SessionMetadata, reverse_session_key,
 };
+use crate::ip_proto::{PROTO_TCP, PROTO_UDP};
 use core::ffi::{c_int, c_void};
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -39,9 +40,6 @@ const ALG_DISABLE_SIP: u8 = 0x04;
 // bit layout consistently across Go and Rust; intentionally unused.
 #[allow(dead_code)]
 const ALG_DISABLE_TFTP: u8 = 0x08;
-
-const PROTO_TCP: u8 = 6;
-const PROTO_UDP: u8 = 17;
 
 // alg_type codes written into the conntrack session value, matching
 // bpf/headers/xpf_conntrack.h: 0=none, 1=FTP, 2=SIP, 3=DNS.


### PR DESCRIPTION
Closes #2016. Two deferred cosmetic nits from the #2008 Tier-1 merges, batched into one no-behavior-change cleanup.

## (a) userspace-dp `publish_conntrack.rs` — DRY the PROTO_* consts
The module re-declared local `const PROTO_TCP: u8 = 6;` / `const PROTO_UDP: u8 = 17;` instead of using the crate-wide canonical home in `userspace-dp/src/ip_proto.rs` (consolidated in #1826). Replaced the two local definitions with `use crate::ip_proto::{PROTO_TCP, PROTO_UDP};` — the same pattern already used by `session/`, `filter/`, `nat/`, `screen/`, `policy/`, `nat64.rs`, and the other dataplane modules.

The values are identical (IANA TCP=6 / UDP=17), so `alg_type_for_session` is bit-identical. The `alg_type_tests` child module continues to reach the constants via `super::`.

## (b) `pkg/snmp/agent.go` `getCommunity` — O(1) map lookup
`getCommunity` scanned `cfg.Communities` with an O(n) for-range loop comparing `c.Name == community`, but `cfg.Communities` is a `map[string]*SNMPCommunity` keyed by community name (populated as `snmp.Communities[comm.Name] = comm` in `compiler_system.go`). Replaced the scan with the direct `cfg.Communities[community]` lookup. The map key is exactly the name the loop matched on, so the result (the matching `*SNMPCommunity`, or nil when absent) is unchanged.

## Validation
- Full Go suite (`go test ./...`) passes, including `pkg/snmp`.
- Full Rust binary suite (`cargo test --bin xpf-userspace-dp`): 2058 passed / 0 failed, including the 10 `publish_conntrack` `alg_type` tests.
- `gofmt` + `go vet` clean on `agent.go`; `cargo build` clean with no new unused-import warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)