### PR TITLE
test/incus: refuse multiple firewalls on the gateway bridges (#1992)

### DIFF
--- a/docs/network-topology.md
+++ b/docs/network-topology.md
@@ -38,6 +38,16 @@ No `/etc/xpf/node-id`, no `em0`:
     dmz-host      10.0.30.101 (2001:559:8585:bf03::101)  — xpf-dmz bridge
 ```
 
+> **DUT isolation (#1992).** The `10.0.1.10` / `10.0.2.10` gateway IPs above
+> are static and identical on every standalone firewall, and the test hosts
+> default-route through them. Only ONE firewall may be attached to the
+> trust/untrust bridges at a time — a second firewall claims the same gateway
+> IPs and the hosts' gateway ARP flips nondeterministically, producing false
+> "stall" readings (this caused the #1961 misdiagnosis). `setup.sh`
+> create-vm/create-ct/deploy refuse to run while another firewall holds these
+> gateways (override: `XPF_FORCE_TEARDOWN_PEERS=1`). See the "DUT Isolation"
+> section of [`testing.md`](testing.md).
+
 ## HA cluster (`loss:xpf-userspace-fw0/fw1`)
 
 Different topology from the standalone VM above. Do NOT extrapolate the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,6 +58,51 @@ VM:   Ubuntu 26.04, stock kernel >= 6.18 (#1943; bake.py parity)
 
 All interfaces renamed at boot by `xpf-link-setup.service` (PCI bus order → vSRX names), configured via `.network` files by xpfd.
 
+### DUT Isolation — Exactly One Firewall Per Gateway (#1992)
+
+**Before any forwarding or stall measurement, isolate the DUT: exactly ONE
+firewall may answer the dataplane gateway IPs at a time.**
+
+The standalone firewall claims the SAME static gateway IPs on every run —
+`10.0.1.10` on `ge-0-0-0` (trust bridge) and `10.0.2.10` on `ge-0-0-1`
+(untrust bridge), per `test/incus/xpf-test.conf`. The `trust-host` and
+`untrust-host` test containers default-route through those IPs. If a SECOND
+firewall VM is attached to the same trust/untrust bridges, it claims the same
+gateway IPs, and the test hosts' gateway ARP resolves **nondeterministically
+to whichever firewall last answered or GARP'd**.
+
+During a sustained flow the gateway MAC can flip mid-stream to a firewall that
+is not forwarding to the other side, producing a classic "~4 Gbps → 0 for
+several seconds → recover with a retransmit burst" pattern and making the
+intended DUT's RX-queue irq counter read 0 (the traffic went elsewhere). This
+was **misdiagnosed as a virtio_net per-queue NAPI-quiesce kernel bug** in
+#1961 before an isolated run — stop the other firewalls, only the DUT
+answering, kernel `ip_forward=0` — proved plain-virtio forwards rock-steady at
+~4 Gbit/s, 0 stalls, both directions.
+
+`test/incus/setup.sh` now enforces this: `create-vm`, `create-ct`, and
+`deploy` call `assert_sole_dataplane_owner` first and **refuse to proceed**
+when another instance is attached to BOTH the trust and untrust bridges
+(single-sided test hosts like `trust-host`/`untrust-host` are not flagged —
+they do not claim the gateway IP). Set `XPF_FORCE_TEARDOWN_PEERS=1` to stop and
+delete the conflicting firewall(s) automatically:
+
+```bash
+# Refused with guidance if another firewall holds the gateways:
+make test-deploy
+
+# Or remove the colliding firewall(s) and proceed:
+XPF_FORCE_TEARDOWN_PEERS=1 ./test/incus/setup.sh deploy
+
+# Manual isolation:
+incus stop <other-firewall> && incus delete --force <other-firewall>
+```
+
+When you cannot tear a peer down, pin static ARP for the gateway to the DUT's
+MAC on the test host (or assert exactly one ARP answerer for the gateway)
+before measuring — never trust a forwarding/stall number taken while two
+firewalls share the gateway.
+
 ### WAN Interface (PF Passthrough)
 - Intel X710 PF (enp10s0f0np0 on host) passed through via PCI/VFIO
 - i40e driver has **native XDP** — no generic mode overhead

--- a/test/incus/setup.sh
+++ b/test/incus/setup.sh
@@ -103,8 +103,12 @@ die()   { echo "ERROR: $*" >&2; exit 1; }
 # not exist.
 instances_on_bridge() {
 	local bridge="$1"
+	# Tolerate leading whitespace: some incus/YAML renderings indent the
+	# used_by list items (`  - /1.0/instances/...`). Anchoring at column 0
+	# would silently emit nothing and disable the isolation guard (Copilot
+	# #2018). Allow optional indentation.
 	incus network show "$bridge" 2>/dev/null \
-		| sed -n 's#^- /1\.0/instances/##p'
+		| sed -n 's#^[[:space:]]*- /1\.0/instances/##p'
 }
 
 # Refuse to bring up / deploy to $INSTANCE_NAME while ANOTHER instance is

--- a/test/incus/setup.sh
+++ b/test/incus/setup.sh
@@ -12,6 +12,14 @@
 #   ./test/incus/setup.sh deploy      # Build xpf, push binary to instance
 #   ./test/incus/setup.sh ssh         # Shell into the instance
 #   ./test/incus/setup.sh status      # Show instance and network status
+#
+# DUT isolation (#1992): exactly ONE firewall may answer the dataplane gateway
+# IPs (10.0.1.10 / 10.0.2.10) on the trust/untrust bridges at a time. create-vm,
+# create-ct, and deploy refuse to run while another firewall is attached to both
+# gateway bridges (it would race for the gateway ARP and produce false "stall"
+# readings — see #1961). Set XPF_FORCE_TEARDOWN_PEERS=1 to remove the
+# conflicting firewall(s) automatically. ALWAYS isolate the DUT before any
+# forwarding or stall measurement.
 
 set -euo pipefail
 
@@ -61,9 +69,107 @@ NETWORKS=(
 	"xpf-dmz:none:false"
 )
 
+# Dataplane gateway bridges (#1992). The firewall claims the SAME static
+# gateway IPs on these bridges every time — ge-0/0/0 = 10.0.1.10 on trust,
+# ge-0/0/1 = 10.0.2.10 on untrust (xpf-test.conf) — and the trust-host /
+# untrust-host test containers default-route via those IPs. If a SECOND
+# firewall is attached to BOTH of these bridges it claims the same gateway
+# IPs, so the test hosts' gateway ARP resolves nondeterministically to
+# whichever firewall last answered or GARP'd. Mid-stream the gateway MAC can
+# flip to a firewall that is not forwarding, producing a false "~4 Gbps -> 0
+# for several seconds -> recover with a retransmit burst" stall and an
+# RX-queue irq=0 reading on the intended DUT. This was misdiagnosed as a
+# virtio_net NAPI-quiesce kernel bug in #1961 before an isolated run (stop the
+# other firewalls; only the DUT answering; ip_forward=0) proved plain-virtio
+# forwards rock-steady at ~4 Gbit/s, 0 stalls, both directions.
+#
+# LESSON: isolate the DUT (exactly ONE firewall answering each gateway IP)
+# before any forwarding/stall measurement. create-vm / create-ct / deploy call
+# assert_sole_dataplane_owner first and refuse to proceed when another
+# firewall holds these gateways, unless XPF_FORCE_TEARDOWN_PEERS=1 is set (then
+# the conflicting firewall instances are stopped and deleted).
+DATAPLANE_GW_BRIDGES=(xpf-trust xpf-untrust)
+
 info()  { echo "==> $*"; }
 warn()  { echo "WARNING: $*" >&2; }
 die()   { echo "ERROR: $*" >&2; exit 1; }
+
+# ── DUT isolation guard (#1992) ───────────────────────────────────────
+
+# List instance names attached to an incus network bridge. Parses the
+# `used_by:` block of `incus network show` (entries look like
+# `- /1.0/instances/<name>` and `- /1.0/profiles/<name>`); profile entries
+# are skipped — only instances answer ARP. Emits nothing if the bridge does
+# not exist.
+instances_on_bridge() {
+	local bridge="$1"
+	incus network show "$bridge" 2>/dev/null \
+		| sed -n 's#^- /1\.0/instances/##p'
+}
+
+# Refuse to bring up / deploy to $INSTANCE_NAME while ANOTHER instance is
+# attached to BOTH dataplane gateway bridges. An instance on both gateway
+# bridges behaves like a firewall: it claims the same static gateway IPs
+# (10.0.1.10 / 10.0.2.10) the test hosts default-route through, so two such
+# instances race for the gateway ARP. Single-sided test containers
+# (trust-host on trust only, untrust-host on untrust only) are NOT flagged —
+# they do not claim the gateway IP. Set XPF_FORCE_TEARDOWN_PEERS=1 to stop and
+# delete the conflicting instances automatically instead of aborting.
+assert_sole_dataplane_owner() {
+	# If neither gateway bridge exists yet, there is nothing to collide with.
+	local any_bridge=0 b
+	for b in "${DATAPLANE_GW_BRIDGES[@]}"; do
+		if incus network show "$b" &>/dev/null 2>&1; then
+			any_bridge=1
+		fi
+	done
+	[[ "$any_bridge" -eq 1 ]] || return 0
+
+	# An instance is a gateway peer when it is attached to EVERY gateway
+	# bridge. Count per-instance bridge attachments and select those that
+	# reach the full count, excluding $INSTANCE_NAME itself.
+	local -A seen=()
+	for b in "${DATAPLANE_GW_BRIDGES[@]}"; do
+		local inst
+		while IFS= read -r inst; do
+			[[ -n "$inst" ]] || continue
+			seen["$inst"]=$(( ${seen["$inst"]:-0} + 1 ))
+		done < <(instances_on_bridge "$b")
+	done
+
+	local need="${#DATAPLANE_GW_BRIDGES[@]}"
+	local peers=() name
+	for name in "${!seen[@]}"; do
+		[[ "$name" == "$INSTANCE_NAME" ]] && continue
+		if [[ "${seen[$name]}" -ge "$need" ]]; then
+			peers+=("$name")
+		fi
+	done
+
+	[[ "${#peers[@]}" -eq 0 ]] && return 0
+
+	if [[ "${XPF_FORCE_TEARDOWN_PEERS:-0}" == "1" ]]; then
+		warn "Tearing down conflicting firewall instance(s) on ${DATAPLANE_GW_BRIDGES[*]}: ${peers[*]} (XPF_FORCE_TEARDOWN_PEERS=1)"
+		for name in "${peers[@]}"; do
+			info "Removing $name (holds the dataplane gateway IPs)..."
+			incus stop "$name" --force 2>/dev/null || true
+			incus delete "$name" --force
+		done
+		return 0
+	fi
+
+	warn "Another firewall is attached to the dataplane gateway bridges (${DATAPLANE_GW_BRIDGES[*]}):"
+	for name in "${peers[@]}"; do
+		warn "  - $name"
+	done
+	warn "Those instances claim the SAME gateway IPs (10.0.1.10 / 10.0.2.10) that"
+	warn "the test hosts default-route through, so gateway ARP resolves"
+	warn "nondeterministically and forwarding/stall measurements are invalid"
+	warn "(see #1992 / #1961). Isolate the DUT first:"
+	warn "  incus stop ${peers[*]}            # or 'incus delete --force ...'"
+	warn "  XPF_FORCE_TEARDOWN_PEERS=1 $0 ${1:-<command>}   # remove them automatically"
+	die "refusing to run with multiple firewalls on the gateway bridges"
+}
 
 # ── Install & Initialize ──────────────────────────────────────────────
 
@@ -214,6 +320,7 @@ cmd_create_vm() {
 	if incus info "$INSTANCE_NAME" &>/dev/null 2>&1; then
 		die "Instance $INSTANCE_NAME already exists. Run '$0 destroy' first."
 	fi
+	assert_sole_dataplane_owner create-vm
 	info "Launching VM $INSTANCE_NAME..."
 	incus launch "$IMAGE_VM" "$INSTANCE_NAME" --vm --profile "$VM_PROFILE"
 
@@ -401,6 +508,7 @@ cmd_create_ct() {
 	if incus info "$INSTANCE_NAME" &>/dev/null 2>&1; then
 		die "Instance $INSTANCE_NAME already exists. Run '$0 destroy' first."
 	fi
+	assert_sole_dataplane_owner create-ct
 	info "Launching container $INSTANCE_NAME..."
 	incus launch "$IMAGE_CT" "$INSTANCE_NAME" --profile "$CT_PROFILE"
 	info "Waiting for container to start..."
@@ -444,6 +552,7 @@ cmd_deploy() {
 	if ! incus info "$INSTANCE_NAME" &>/dev/null 2>&1; then
 		die "Instance $INSTANCE_NAME does not exist. Run '$0 create-vm' or '$0 create-ct' first."
 	fi
+	assert_sole_dataplane_owner deploy
 
 	info "Building xpfd and cli..."
 	make -C "$PROJECT_ROOT" build build-ctl
@@ -613,6 +722,11 @@ usage() {
 	echo "  restart     Restart xpfd service"
 	echo "  logs        Show recent xpfd logs"
 	echo "  journal     Follow xpfd logs (live)"
+	echo ""
+	echo "Env:"
+	echo "  XPF_FORCE_TEARDOWN_PEERS=1  On create-vm/create-ct/deploy, remove any"
+	echo "                              OTHER firewall holding the dataplane gateway"
+	echo "                              IPs instead of aborting (DUT isolation, #1992)"
 	exit 1
 }
 


### PR DESCRIPTION
## Summary
Closes #1992 (test-env only — no production code).

The standalone firewall claims the **same static gateway IPs** on every run —
`ge-0/0/0 = 10.0.1.10` on the trust bridge, `ge-0/0/1 = 10.0.2.10` on the
untrust bridge (`test/incus/xpf-test.conf`) — and the `trust-host` /
`untrust-host` test containers default-route through those IPs. When a SECOND
firewall VM was attached to the same trust/untrust bridges it claimed the same
gateway IPs, so the hosts' gateway ARP resolved **nondeterministically** to
whichever firewall last answered or GARP'd. Mid-stream the gateway MAC could
flip to a firewall that was not forwarding, producing a false
`~4 Gbps -> 0 for several seconds -> recover with a retransmit burst` stall and
an RX-queue `irq=0` reading on the intended DUT. This was misdiagnosed as a
virtio_net NAPI-quiesce kernel bug in #1961 before an isolated run proved
plain-virtio forwards rock-steady.

## Change (shell + docs only)
`test/incus/setup.sh`:
- New `assert_sole_dataplane_owner()` parses the `used_by:` instances of each
  dataplane gateway bridge (`DATAPLANE_GW_BRIDGES = xpf-trust xpf-untrust`) and
  flags any **other** instance attached to **both** gateway bridges — one that
  behaves like a firewall claiming both gateway IPs. Single-sided test
  containers (trust-host on trust only, untrust-host on untrust only) are not
  flagged because they do not claim the gateway IP. When the gateway bridges
  don't exist yet the guard is a no-op (a fresh host is unaffected).
- `create-vm`, `create-ct`, and `deploy` call the guard first. By default it
  **refuses** with isolation guidance; `XPF_FORCE_TEARDOWN_PEERS=1` stops and
  deletes the conflicting firewall(s) automatically.

Docs: the isolation requirement (exactly one firewall answering each gateway
before any forwarding/stall measurement) is documented in the `setup.sh`
header + usage text, a new **DUT Isolation** section in `docs/testing.md`, and a
standalone-topology note in `docs/network-topology.md`.

## Path drift corrected
The issue names the bridges `bpfrx-trust`/`bpfrx-untrust`; current
`setup.sh` (master) creates and attaches to `xpf-trust`/`xpf-untrust`. The
guard keys off the bridge set the script actually owns (`DATAPLANE_GW_BRIDGES`),
so it protects whatever names the script uses. The live incus host still has
the older `bpfrx-*` bridges (the exact 3-firewall collision the issue
describes), which is what the guard was exercised against.

## Validation
- `bash -n` clean; `shellcheck -S warning` clean. The 5 remaining `SC2016`
  info findings are pre-existing single-quoted remote-exec strings (identical
  count before and after this change).
- Exercised the guard logic end-to-end against the live incus host: with three
  firewalls attached to both bridges it refuses and lists exactly the
  dual-attached instances (not the single-sided test hosts);
  `XPF_FORCE_TEARDOWN_PEERS=1` reports the teardown set; with the gateway
  bridges absent it passes.
- Full Go test suite passes (`go test ./...`) — shell + docs only, no Go
  touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)