### PR TITLE
#1990: group userspace formatters into a format/ subpackage (pure code motion)

### DIFF
--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 )
 
 func (s *Server) systemInfoHandler(w http.ResponseWriter, r *http.Request) {
@@ -203,7 +204,7 @@ func (s *Server) systemBuffersHandler(w http.ResponseWriter, _ *http.Request) {
 			writeError(w, http.StatusServiceUnavailable, msg)
 			return
 		}
-		rows := dpuserspace.StructuredSystemBufferRows(status, false)
+		rows := dpformat.StructuredSystemBufferRows(status, false)
 		if len(rows.Utilization) == 0 {
 			msg := "userspace buffer status missing bounded capacity fields"
 			writeError(w, http.StatusServiceUnavailable, msg)

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/cluster"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	"github.com/psaab/xpf/pkg/routing"
 )
 
@@ -755,9 +756,9 @@ func (c *CLI) handleRequestChassisClusterDataPlane(args []string) error {
 		writeCompletionHelp(os.Stdout, treeHelpCandidates(operationalTree["request"].Children["chassis"].Children["cluster"].Children["data-plane"].Children["userspace"].Children))
 		return nil
 	}
-	fmt.Print(dpuserspace.FormatStatusSummary(status))
+	fmt.Print(dpformat.FormatStatusSummary(status))
 	fmt.Println()
-	fmt.Print(dpuserspace.FormatBindings(status))
+	fmt.Print(dpformat.FormatBindings(status))
 	return nil
 }
 

--- a/pkg/cli/cli_show_cluster.go
+++ b/pkg/cli/cli_show_cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	"github.com/psaab/xpf/pkg/devicemap"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -182,7 +183,7 @@ func (c *CLI) showChassisCluster(args []string) error {
 				case "fairness":
 					return c.showChassisClusterDataPlaneFairness()
 				case "flows":
-					limit, err := dpuserspace.ParseFlowWorkerMapLimitSpec(strings.Join(args[2:], " "))
+					limit, err := dpformat.ParseFlowWorkerMapLimitSpec(strings.Join(args[2:], " "))
 					if err != nil {
 						return err
 					}
@@ -315,7 +316,7 @@ func (c *CLI) showChassisClusterDataPlaneStats() error {
 	fmt.Print(c.cluster.FormatDataPlaneStatistics())
 	if status, err := c.userspaceDataplaneStatus(); err == nil {
 		fmt.Println()
-		fmt.Print(dpuserspace.FormatStatusSummary(status))
+		fmt.Print(dpformat.FormatStatusSummary(status))
 	}
 	return nil
 }
@@ -328,7 +329,7 @@ func (c *CLI) showChassisClusterDataPlaneInterfaces() error {
 	fmt.Print(c.cluster.FormatDataPlaneInterfaces())
 	if status, err := c.userspaceDataplaneStatus(); err == nil {
 		fmt.Println()
-		fmt.Print(dpuserspace.FormatBindings(status))
+		fmt.Print(dpformat.FormatBindings(status))
 	}
 	return nil
 }
@@ -342,7 +343,7 @@ func (c *CLI) showChassisClusterDataPlaneFairness() error {
 	if err != nil {
 		return err
 	}
-	fmt.Print(dpuserspace.FormatFairnessRSS(status, dpuserspace.FairnessRSSExpectationsFromConfig(c.store.ActiveConfig())))
+	fmt.Print(dpformat.FormatFairnessRSS(status, dpuserspace.FairnessRSSExpectationsFromConfig(c.store.ActiveConfig())))
 	return nil
 }
 
@@ -355,7 +356,7 @@ func (c *CLI) showChassisClusterDataPlaneFlows(limit int) error {
 	if err != nil {
 		return err
 	}
-	fmt.Print(dpuserspace.FormatFlowWorkerMap(status, limit))
+	fmt.Print(dpformat.FormatFlowWorkerMap(status, limit))
 	return nil
 }
 

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -12,6 +12,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	"github.com/psaab/xpf/pkg/feeds"
 	"github.com/psaab/xpf/pkg/logging"
 )
@@ -778,7 +779,7 @@ func (c *CLI) screenSYNCookieCounterRows() string {
 	if err != nil {
 		return ""
 	}
-	return dpuserspace.FormatSYNCookieCounterRows(dpuserspace.SumSYNCookieCounters(status))
+	return dpformat.FormatSYNCookieCounterRows(dpformat.SumSYNCookieCounters(status))
 }
 
 func (c *CLI) showAddressBook(args []string) error {

--- a/pkg/cli/cli_show_security_wireguard.go
+++ b/pkg/cli/cli_show_security_wireguard.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"time"
 
-	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 )
 
 // showSecurityWireguard renders `show security wireguard [detail]`
 // from the userspace helper's per-tunnel telemetry rows (#1865). The
 // rendering is shared with the remote CLI via
-// dpuserspace.FormatWireguardStatus (the FormatSystemBuffers pattern),
+// dpformat.FormatWireguardStatus (the FormatSystemBuffers pattern),
 // so local and gRPC output are identical.
 func (c *CLI) showSecurityWireguard(detail bool) error {
 	if c.dp == nil {
@@ -27,6 +27,6 @@ func (c *CLI) showSecurityWireguard(detail bool) error {
 		fmt.Printf("WireGuard telemetry unavailable: %v\n", err)
 		return nil
 	}
-	fmt.Print(dpuserspace.FormatWireguardStatus(status, detail, time.Now()))
+	fmt.Print(dpformat.FormatWireguardStatus(status, detail, time.Now()))
 	return nil
 }

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -9,6 +9,7 @@ import (
 	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/cmdtree"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/dhcpserver"
 	"github.com/psaab/xpf/pkg/ipmon"
@@ -171,7 +172,7 @@ func (c *CLI) showClassOfServiceInterface(selector string) error {
 	if userspaceStatus, err := c.userspaceDataplaneStatus(); err == nil {
 		status = &userspaceStatus
 	}
-	fmt.Print(dpuserspace.FormatCoSInterfaceSummary(cfg, status, selector))
+	fmt.Print(dpformat.FormatCoSInterfaceSummary(cfg, status, selector))
 	return nil
 }
 

--- a/pkg/cli/cli_show_system.go
+++ b/pkg/cli/cli_show_system.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
-	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	"golang.org/x/sys/unix"
 )
 
@@ -29,7 +29,7 @@ func (c *CLI) showSystemBuffers() error {
 			fmt.Printf("Userspace buffer metrics unavailable: %v\n", err)
 			return nil
 		}
-		fmt.Print(dpuserspace.FormatSystemBuffers(status, false))
+		fmt.Print(dpformat.FormatSystemBuffers(status, false))
 		v4, v6 := c.dp.SessionCount()
 		if v4 > 0 || v6 > 0 {
 			fmt.Printf("\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
@@ -89,7 +89,7 @@ func (c *CLI) showSystemBuffersDetail() error {
 			fmt.Printf("Userspace buffer metrics unavailable: %v\n", err)
 			return nil
 		}
-		fmt.Print(dpuserspace.FormatSystemBuffers(status, true))
+		fmt.Print(dpformat.FormatSystemBuffers(status, true))
 		v4, v6 := c.dp.SessionCount()
 		if v4 > 0 || v6 > 0 {
 			fmt.Printf("\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)

--- a/pkg/dataplane/userspace/format/buffers.go
+++ b/pkg/dataplane/userspace/format/buffers.go
@@ -1,9 +1,11 @@
-package userspace
+package format
 
 import (
 	"fmt"
 	"sort"
 	"strings"
+
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 const (
@@ -125,14 +127,14 @@ type systemBufferCounterRow struct {
 // SystemBufferUtilizationRows returns the same bounded helper-status capacity
 // rows used by FormatSystemBuffers. Missing helper capacity fields produce no
 // synthetic fill rows rather than falling back to BPF map statistics.
-func SystemBufferUtilizationRows(status ProcessStatus, detail bool) []SystemBufferUtilizationRow {
+func SystemBufferUtilizationRows(status userspace.ProcessStatus, detail bool) []SystemBufferUtilizationRow {
 	return StructuredSystemBufferRows(status, detail).Utilization
 }
 
 // StructuredSystemBufferRows returns helper-backed userspace buffer rows and
 // unbounded status counters using the same sampling and fallback logic as the
 // CLI/gRPC text formatter.
-func StructuredSystemBufferRows(status ProcessStatus, detail bool) SystemBufferRows {
+func StructuredSystemBufferRows(status userspace.ProcessStatus, detail bool) SystemBufferRows {
 	samples := systemBufferSamples(status)
 	rows, knownUMEM, knownTX := systemBufferRows(status, samples, detail)
 	counterRows := systemBufferCounterRows(status, samples, detail)
@@ -176,7 +178,7 @@ func exportedSystemBufferCounterRows(rows []systemBufferCounterRow) []SystemBuff
 // `show system buffers`. Capacity rows only use bounded gauges published in
 // helper status; unbounded helper counters/gauges render in a separate section
 // so missing denominators are not mistaken for real fill percentages.
-func FormatSystemBuffers(status ProcessStatus, detail bool) string {
+func FormatSystemBuffers(status userspace.ProcessStatus, detail bool) string {
 	samples := systemBufferSamples(status)
 	rows, knownUMEM, knownTX := systemBufferRows(status, samples, detail)
 	counterRows := systemBufferCounterRows(status, samples, detail)
@@ -222,7 +224,7 @@ func FormatSystemBuffers(status ProcessStatus, detail bool) string {
 }
 
 func systemBufferRows(
-	status ProcessStatus,
+	status userspace.ProcessStatus,
 	samples []systemBufferSample,
 	detail bool,
 ) ([]systemBufferRow, int, int) {
@@ -320,7 +322,7 @@ func systemBufferRows(
 }
 
 func systemBufferFlowCacheAggregate(
-	status ProcessStatus,
+	status userspace.ProcessStatus,
 	samples []systemBufferSample,
 ) (uint64, uint64, int) {
 	var used, capacity uint64
@@ -360,7 +362,7 @@ func systemBufferUsage(row systemBufferRow) (float64, string) {
 	}
 }
 
-func systemBufferCoSRows(status ProcessStatus, detail bool) []systemBufferRow {
+func systemBufferCoSRows(status userspace.ProcessStatus, detail bool) []systemBufferRow {
 	var rows []systemBufferRow
 	var aggregateCap, aggregateUsed uint64
 	var queueCount int
@@ -402,7 +404,7 @@ func systemBufferCoSRows(status ProcessStatus, detail bool) []systemBufferRow {
 	return rows
 }
 
-func systemBufferCounterRows(status ProcessStatus, samples []systemBufferSample, detail bool) []systemBufferCounterRow {
+func systemBufferCounterRows(status userspace.ProcessStatus, samples []systemBufferSample, detail bool) []systemBufferCounterRow {
 	var activeFlowCount uint64
 	var flowCacheCollisionEvictions uint64
 	var debugPendingFillFrames uint64
@@ -536,8 +538,8 @@ func systemBufferCounterRows(status ProcessStatus, samples []systemBufferSample,
 	return rows
 }
 
-func systemBufferSamples(status ProcessStatus) []systemBufferSample {
-	bindings := make(map[systemBufferBindingKey]BindingStatus, len(status.Bindings))
+func systemBufferSamples(status userspace.ProcessStatus) []systemBufferSample {
+	bindings := make(map[systemBufferBindingKey]userspace.BindingStatus, len(status.Bindings))
 	for _, binding := range status.Bindings {
 		bindings[systemBufferBindingKey{
 			WorkerID: binding.WorkerID,
@@ -659,7 +661,7 @@ func systemBufferSamples(status ProcessStatus) []systemBufferSample {
 	return samples
 }
 
-func (sample *systemBufferSample) applyBindingStatusFallback(binding BindingStatus) {
+func (sample *systemBufferSample) applyBindingStatusFallback(binding userspace.BindingStatus) {
 	if sample.ActiveFlowCount == 0 {
 		sample.ActiveFlowCount = binding.ActiveFlowCount
 	}
@@ -753,7 +755,7 @@ func systemBufferSampleScope(sample systemBufferSample) string {
 	return strings.Join(parts, "/")
 }
 
-func systemBufferCoSQueueScope(iface CoSInterfaceStatus, queue CoSQueueStatus) string {
+func systemBufferCoSQueueScope(iface userspace.CoSInterfaceStatus, queue userspace.CoSQueueStatus) string {
 	var parts []string
 	if iface.InterfaceName != "" {
 		parts = append(parts, iface.InterfaceName)

--- a/pkg/dataplane/userspace/format/buffers_test.go
+++ b/pkg/dataplane/userspace/format/buffers_test.go
@@ -1,18 +1,20 @@
-package userspace
+package format
 
 import (
 	"fmt"
 	"strings"
 	"testing"
+
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 func TestFormatSystemBuffersUsesPerBindingAggregatesBeforeDetails(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{Slot: 10, WorkerID: 1, QueueID: 2, Ifindex: 7, Interface: "ge-0-0-1"},
 			{Slot: 11, WorkerID: 1, QueueID: 3, Ifindex: 8, Interface: "ge-0-0-2"},
 		},
-		PerBinding: []BindingCountersSnapshot{
+		PerBinding: []userspace.BindingCountersSnapshot{
 			{WorkerID: 1, QueueID: 2, Ifindex: 7, UmemTotalFrames: 1000, UmemInflightFrames: 800, TxRingCapacity: 100, OutstandingTX: 90},
 			{WorkerID: 1, QueueID: 3, Ifindex: 8, UmemTotalFrames: 1000, UmemInflightFrames: 100, TxRingCapacity: 100, OutstandingTX: 10},
 		},
@@ -47,8 +49,8 @@ func TestFormatSystemBuffersUsesPerBindingAggregatesBeforeDetails(t *testing.T) 
 }
 
 func TestFormatSystemBuffersFallsBackToBindingsAndWarnsAtEighty(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{Slot: 0, WorkerID: 0, QueueID: 0, Interface: "ge-0-0-0", UmemTotalFrames: 100, UmemInflightFrames: 80},
 		},
 	}
@@ -73,11 +75,11 @@ func TestFormatSystemBuffersFallsBackToBindingsAndWarnsAtEighty(t *testing.T) {
 }
 
 func TestFormatSystemBuffersFallsBackWhenPerBindingLacksCapacity(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{Slot: 2, WorkerID: 1, QueueID: 0, Interface: "ge-0-0-1", UmemTotalFrames: 256, UmemInflightFrames: 64},
 		},
-		PerBinding: []BindingCountersSnapshot{
+		PerBinding: []userspace.BindingCountersSnapshot{
 			{WorkerID: 1, QueueID: 0, OutstandingTX: 10},
 		},
 	}
@@ -96,12 +98,12 @@ func TestFormatSystemBuffersFallsBackWhenPerBindingLacksCapacity(t *testing.T) {
 }
 
 func TestFormatSystemBuffersFallsBackPerSparsePerBindingRow(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{Slot: 2, WorkerID: 1, QueueID: 0, Ifindex: 7, Interface: "ge-0-0-1", UmemTotalFrames: 256, UmemInflightFrames: 64},
 			{Slot: 3, WorkerID: 1, QueueID: 1, Ifindex: 8, Interface: "ge-0-0-2", UmemTotalFrames: 512, UmemInflightFrames: 128},
 		},
-		PerBinding: []BindingCountersSnapshot{
+		PerBinding: []userspace.BindingCountersSnapshot{
 			{WorkerID: 1, QueueID: 0, Ifindex: 7, UmemTotalFrames: 1000, UmemInflightFrames: 500},
 			{WorkerID: 1, QueueID: 1, Ifindex: 8, OutstandingTX: 10},
 		},
@@ -122,8 +124,8 @@ func TestFormatSystemBuffersFallsBackPerSparsePerBindingRow(t *testing.T) {
 }
 
 func TestFormatSystemBuffersDocumentsMissingStatusFields(t *testing.T) {
-	out := FormatSystemBuffers(ProcessStatus{
-		PerBinding: []BindingCountersSnapshot{{WorkerID: 0, QueueID: 0, OutstandingTX: 10}},
+	out := FormatSystemBuffers(userspace.ProcessStatus{
+		PerBinding: []userspace.BindingCountersSnapshot{{WorkerID: 0, QueueID: 0, OutstandingTX: 10}},
 	}, false)
 
 	for _, want := range []string{
@@ -141,9 +143,9 @@ func TestFormatSystemBuffersDocumentsMissingStatusFields(t *testing.T) {
 
 func TestFormatSystemBuffersIncludesCoSAndRuntimePressure(t *testing.T) {
 	owner := uint32(2)
-	status := ProcessStatus{
+	status := userspace.ProcessStatus{
 		NeighborEntries: 12,
-		Bindings: []BindingStatus{
+		Bindings: []userspace.BindingStatus{
 			{
 				Slot:                        4,
 				WorkerID:                    2,
@@ -170,11 +172,11 @@ func TestFormatSystemBuffersIncludesCoSAndRuntimePressure(t *testing.T) {
 				TxSubmitErrorDrops:          47,
 			},
 		},
-		CoSInterfaces: []CoSInterfaceStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				Ifindex:       9,
 				InterfaceName: "ge-0-0-9",
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:         2,
 						OwnerWorkerID:   &owner,
@@ -219,12 +221,12 @@ func TestFormatSystemBuffersIncludesCoSAndRuntimePressure(t *testing.T) {
 }
 
 func TestFormatSystemBuffersKeepsDynamicCountsOutOfUtilizationTable(t *testing.T) {
-	status := ProcessStatus{
+	status := userspace.ProcessStatus{
 		NeighborEntries: 42,
-		Bindings: []BindingStatus{
+		Bindings: []userspace.BindingStatus{
 			{Slot: 1, WorkerID: 0, QueueID: 0, Interface: "ge-0-0-0", UmemTotalFrames: 1000, UmemInflightFrames: 250},
 		},
-		PerBinding: []BindingCountersSnapshot{
+		PerBinding: []userspace.BindingCountersSnapshot{
 			{WorkerID: 0, QueueID: 0, ActiveFlowCount: 128},
 		},
 	}
@@ -249,12 +251,12 @@ func TestFormatSystemBuffersKeepsDynamicCountsOutOfUtilizationTable(t *testing.T
 }
 
 func TestFormatSystemBuffersUsesHelperPublishedDynamicCapacities(t *testing.T) {
-	status := ProcessStatus{
+	status := userspace.ProcessStatus{
 		SessionTableEntries:   90,
 		MaxSessions:           100,
 		NeighborEntries:       42,
 		NeighborCacheCapacity: 50,
-		PerBinding: []BindingCountersSnapshot{
+		PerBinding: []userspace.BindingCountersSnapshot{
 			{WorkerID: 0, QueueID: 0, ActiveFlowCount: 9, FlowCacheCapacity: 10},
 			{WorkerID: 1, QueueID: 0, ActiveFlowCount: 1, FlowCacheCapacity: 10},
 		},
@@ -301,9 +303,9 @@ func TestFormatSystemBuffersUsesHelperPublishedDynamicCapacities(t *testing.T) {
 }
 
 func TestFormatSystemBuffersUsesStatusFlowCacheCapacityFallback(t *testing.T) {
-	status := ProcessStatus{
+	status := userspace.ProcessStatus{
 		FlowCacheCapacity: 20,
-		PerBinding: []BindingCountersSnapshot{
+		PerBinding: []userspace.BindingCountersSnapshot{
 			{WorkerID: 0, QueueID: 0, ActiveFlowCount: 9},
 			{WorkerID: 1, QueueID: 0, ActiveFlowCount: 3},
 		},
@@ -330,8 +332,8 @@ func TestFormatSystemBuffersUsesStatusFlowCacheCapacityFallback(t *testing.T) {
 }
 
 func TestFormatSystemBuffersIncludesSYNCookieCounters(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{
 				Slot:                       0,
 				WorkerID:                   0,
@@ -392,12 +394,12 @@ func TestFormatSystemBuffersIncludesSYNCookieCounters(t *testing.T) {
 }
 
 func TestFormatSystemBuffersCoSAggregateSumsCapacityWithUsage(t *testing.T) {
-	status := ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				Ifindex:       80,
 				InterfaceName: "reth0.80",
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{QueueID: 4, ForwardingClass: "iperf-a", BufferBytes: 1000, QueuedBytes: 700},
 					{QueueID: 5, ForwardingClass: "iperf-b", BufferBytes: 1000, QueuedBytes: 100},
 				},

--- a/pkg/dataplane/userspace/format/cos.go
+++ b/pkg/dataplane/userspace/format/cos.go
@@ -1,4 +1,4 @@
-package userspace
+package format
 
 import (
 	"fmt"
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/psaab/xpf/pkg/config"
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 type cosInterfaceView struct {
@@ -16,7 +17,7 @@ type cosInterfaceView struct {
 	unit           int
 	cosUnit        *config.CoSInterfaceUnit
 	interfaceUnit  *config.InterfaceUnit
-	interfaceState *CoSInterfaceStatus
+	interfaceState *userspace.CoSInterfaceStatus
 }
 
 type cosQueueView struct {
@@ -87,7 +88,7 @@ type cosQueueView struct {
 	sojournWindowedMinNS uint64
 }
 
-func FormatCoSInterfaceSummary(cfg *config.Config, status *ProcessStatus, selector string) string {
+func FormatCoSInterfaceSummary(cfg *config.Config, status *userspace.ProcessStatus, selector string) string {
 	if cfg == nil {
 		return "No active configuration\n"
 	}
@@ -494,7 +495,7 @@ func bucketLowerBoundMicros(bucket int) string {
 	return fmt.Sprintf("%dus", us)
 }
 
-func configuredCoSInterfaceViews(cfg *config.Config, status *ProcessStatus, selector string) []cosInterfaceView {
+func configuredCoSInterfaceViews(cfg *config.Config, status *userspace.ProcessStatus, selector string) []cosInterfaceView {
 	runtimeIndex := buildCoSRuntimeIndex(status)
 	selector = strings.TrimSpace(selector)
 	views := make([]cosInterfaceView, 0)
@@ -524,15 +525,15 @@ func configuredCoSInterfaceViews(cfg *config.Config, status *ProcessStatus, sele
 }
 
 type cosRuntimeIndex struct {
-	byName               map[string]*CoSInterfaceStatus
-	byIfindex            map[int]*CoSInterfaceStatus
+	byName               map[string]*userspace.CoSInterfaceStatus
+	byIfindex            map[int]*userspace.CoSInterfaceStatus
 	bindingIfindexByName map[string]int
 }
 
-func buildCoSRuntimeIndex(status *ProcessStatus) cosRuntimeIndex {
+func buildCoSRuntimeIndex(status *userspace.ProcessStatus) cosRuntimeIndex {
 	idx := cosRuntimeIndex{
-		byName:               make(map[string]*CoSInterfaceStatus),
-		byIfindex:            make(map[int]*CoSInterfaceStatus),
+		byName:               make(map[string]*userspace.CoSInterfaceStatus),
+		byIfindex:            make(map[int]*userspace.CoSInterfaceStatus),
 		bindingIfindexByName: make(map[string]int),
 	}
 	if status == nil {
@@ -558,7 +559,7 @@ func buildCoSRuntimeIndex(status *ProcessStatus) cosRuntimeIndex {
 	return idx
 }
 
-func (idx cosRuntimeIndex) lookup(ifName, logicalName string, unitNum int, unit *config.InterfaceUnit) *CoSInterfaceStatus {
+func (idx cosRuntimeIndex) lookup(ifName, logicalName string, unitNum int, unit *config.InterfaceUnit) *userspace.CoSInterfaceStatus {
 	candidates := cosRuntimeCandidateNames(ifName, logicalName, unitNum, unit)
 	for _, name := range candidates {
 		if runtime := idx.byName[name]; runtime != nil {
@@ -690,7 +691,7 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 			qv.ownerPPS = runtimeQueue.OwnerPPS
 			qv.peerPPS = runtimeQueue.PeerPPS
 			// #760 copy-through. See field comments on cosQueueView
-			// and on the Rust CoSQueueStatus. A queue that never got
+			// and on the Rust userspace.CoSQueueStatus. A queue that never got
 			// drained leaves these at zero; the renderer gates on
 			// drainInvocations > 0 so a silent queue stays silent.
 			qv.drainSentBytes = runtimeQueue.DrainSentBytes
@@ -730,7 +731,7 @@ func buildCoSQueueViews(cfg *config.Config, view cosInterfaceView) []cosQueueVie
 	return out
 }
 
-func isOldJSONSyntheticDefaultQueue(view cosInterfaceView, runtimeQueue CoSQueueStatus, configuredQueueCount int) bool {
+func isOldJSONSyntheticDefaultQueue(view cosInterfaceView, runtimeQueue userspace.CoSQueueStatus, configuredQueueCount int) bool {
 	return configuredQueueCount == 0 &&
 		view.cosUnit != nil &&
 		view.cosUnit.ShapingRateBytes > 0 &&

--- a/pkg/dataplane/userspace/format/cos_test.go
+++ b/pkg/dataplane/userspace/format/cos_test.go
@@ -1,4 +1,4 @@
-package userspace
+package format
 
 import (
 	"encoding/json"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 func testCoSConfig() *config.Config {
@@ -61,7 +62,7 @@ func testCoSConfig() *config.Config {
 }
 
 func TestFormatCoSInterfaceSummaryPreservesOldJSONGuaranteeFallback(t *testing.T) {
-	var status ProcessStatus
+	var status userspace.ProcessStatus
 	raw := []byte(`{
 		"cos_interfaces": [{
 			"interface_name": "reth0.80",
@@ -108,7 +109,7 @@ func TestFormatCoSInterfaceSummaryRendersPercentBufferFromConfigPool(t *testing.
 	cfg.ClassOfService.Schedulers["10mb"].BufferSizePercent = 10
 	cfg.ClassOfService.Interfaces["reth0"].Units[80].BurstSizeBytes = 200_000
 
-	out := FormatCoSInterfaceSummary(cfg, &ProcessStatus{}, "reth0.80")
+	out := FormatCoSInterfaceSummary(cfg, &userspace.ProcessStatus{}, "reth0.80")
 	for _, want := range []string{"bandwidth-10mb", "19.53 KiB"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in output:\n%s", want, out)
@@ -120,7 +121,7 @@ func TestFormatCoSInterfaceSummaryOldJSONDoesNotInferGuaranteeFromEffectiveRate(
 	cfg := testCoSConfig()
 	cfg.ClassOfService.Schedulers["be"].TransmitRateBytes = 0
 
-	var status ProcessStatus
+	var status userspace.ProcessStatus
 	raw := []byte(`{
 		"cos_interfaces": [{
 			"interface_name": "reth0.80",
@@ -169,7 +170,7 @@ func TestFormatCoSInterfaceSummaryOldJSONInfersSyntheticDefaultQueueGuarantee(t 
 	cfg.ClassOfService.SchedulerMaps = nil
 	cfg.ClassOfService.Interfaces["reth0"].Units[80].SchedulerMap = ""
 
-	var status ProcessStatus
+	var status userspace.ProcessStatus
 	raw := []byte(`{
 		"cos_interfaces": [{
 			"interface_name": "reth0.80",
@@ -232,8 +233,8 @@ func TestFormatCoSInterfaceSummaryShowsConfigOnlyInterface(t *testing.T) {
 
 func TestFormatCoSInterfaceSummaryIncludesRuntimeQueueState(t *testing.T) {
 	owner := uint32(7)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:       "reth0.80",
 				OwnerWorkerID:       &owner,
@@ -242,7 +243,7 @@ func TestFormatCoSInterfaceSummaryIncludesRuntimeQueueState(t *testing.T) {
 				RunnableQueues:      1,
 				TimerLevel0Sleepers: 1,
 				TimerLevel1Sleepers: 0,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:             4,
 						OwnerWorkerID:       &owner,
@@ -322,11 +323,11 @@ func TestFormatCoSInterfaceSummaryJoinsUnitZeroRuntimeByIfindex(t *testing.T) {
 			},
 		},
 	}
-	status := &ProcessStatus{
-		Bindings: []BindingStatus{
+	status := &userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{Interface: "ge-0-0-1", Ifindex: 5, Bound: true},
 		},
-		CoSInterfaces: []CoSInterfaceStatus{{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{{
 			Ifindex:             5,
 			InterfaceName:       "reth0.80",
 			OwnerWorkerID:       &owner,
@@ -334,7 +335,7 @@ func TestFormatCoSInterfaceSummaryJoinsUnitZeroRuntimeByIfindex(t *testing.T) {
 			NonemptyQueues:      1,
 			RunnableQueues:      1,
 			TimerLevel0Sleepers: 2,
-			Queues: []CoSQueueStatus{{
+			Queues: []userspace.CoSQueueStatus{{
 				QueueID:                 5,
 				OwnerWorkerID:           &owner,
 				ForwardingClass:         "iperf-b",
@@ -410,17 +411,17 @@ func TestFormatCoSInterfaceSummaryPrefersVLANBindingIfindexForUnitZero(t *testin
 			},
 		},
 	}
-	status := &ProcessStatus{
-		Bindings: []BindingStatus{
+	status := &userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{Interface: "ge-0-0-1", Ifindex: 5, Bound: true},
 			{Interface: "ge-0-0-1.80", Ifindex: 10, Bound: true},
 		},
-		CoSInterfaces: []CoSInterfaceStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				Ifindex:       5,
 				InterfaceName: "reth-parent",
 				OwnerWorkerID: &parentOwner,
-				Queues: []CoSQueueStatus{{
+				Queues: []userspace.CoSQueueStatus{{
 					QueueID:              5,
 					OwnerWorkerID:        &parentOwner,
 					ForwardingClass:      "wrong-parent",
@@ -434,7 +435,7 @@ func TestFormatCoSInterfaceSummaryPrefersVLANBindingIfindexForUnitZero(t *testin
 				Ifindex:       10,
 				InterfaceName: "reth-vlan",
 				OwnerWorkerID: &vlanOwner,
-				Queues: []CoSQueueStatus{{
+				Queues: []userspace.CoSQueueStatus{{
 					QueueID:                 5,
 					OwnerWorkerID:           &vlanOwner,
 					ForwardingClass:         "iperf-b",
@@ -504,12 +505,12 @@ func TestFormatCoSInterfaceSummaryRendersSurplusSharingLineOnExactQueues(t *test
 		}},
 	}
 	owner := uint32(0)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{{
 			InterfaceName:   "reth0.80",
 			OwnerWorkerID:   &owner,
 			WorkerInstances: 1,
-			Queues: []CoSQueueStatus{
+			Queues: []userspace.CoSQueueStatus{
 				{QueueID: 4, OwnerWorkerID: &owner, ForwardingClass: "iperf-a", Priority: 5, Exact: true, TransmitRateBytes: 125_000_000, BufferBytes: 65536},
 				{QueueID: 5, OwnerWorkerID: &owner, ForwardingClass: "iperf-b", Priority: 5, Exact: true, TransmitRateBytes: 1_250_000_000, BufferBytes: 65536},
 				{QueueID: 0, OwnerWorkerID: &owner, ForwardingClass: "be", Priority: 5, Exact: false, TransmitRateBytes: 12_500_000, BufferBytes: 65536},
@@ -536,12 +537,12 @@ func TestFormatCoSInterfaceSummaryRendersEqualFlowEnforcementLine(t *testing.T) 
 	cfg := testCoSConfig()
 	cfg.ClassOfService.Schedulers["10mb"].EqualFlowEnforcement = true
 	owner := uint32(7)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{{
 			InterfaceName:   "reth0.80",
 			OwnerWorkerID:   &owner,
 			WorkerInstances: 1,
-			Queues: []CoSQueueStatus{{
+			Queues: []userspace.CoSQueueStatus{{
 				QueueID:                       4,
 				OwnerWorkerID:                 &owner,
 				ForwardingClass:               "bandwidth-10mb",
@@ -584,12 +585,12 @@ func TestFormatCoSInterfaceSummaryRendersEqualFlowTargetPolicy(t *testing.T) {
 	cfg := testCoSConfig()
 	cfg.ClassOfService.Schedulers["10mb"].EqualFlowEnforcement = true
 	owner := uint32(7)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{{
 			InterfaceName:   "reth0.80",
 			OwnerWorkerID:   &owner,
 			WorkerInstances: 1,
-			Queues: []CoSQueueStatus{{
+			Queues: []userspace.CoSQueueStatus{{
 				QueueID:               4,
 				OwnerWorkerID:         &owner,
 				ForwardingClass:       "bandwidth-10mb",
@@ -611,8 +612,8 @@ func TestFormatCoSInterfaceSummaryRendersEqualFlowTargetPolicy(t *testing.T) {
 }
 
 func TestFormatCoSInterfaceSummaryShowsUnknownOwnerAsDash(t *testing.T) {
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				WorkerInstances: 1,
@@ -638,13 +639,13 @@ func TestFormatCoSInterfaceSummaryFiltersByBaseInterface(t *testing.T) {
 // no way to tell which admission decision is firing on the live system.
 func TestFormatCoSInterfaceSummaryRendersAdmissionDropCounters(t *testing.T) {
 	owner := uint32(1)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				OwnerWorkerID:   &owner,
 				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:                 4,
 						OwnerWorkerID:           &owner,
@@ -678,13 +679,13 @@ func TestFormatCoSInterfaceSummaryRendersAdmissionDropCounters(t *testing.T) {
 // the single-queue tests above would still pass.
 func TestFormatCoSInterfaceSummaryInterleavesPerQueueDropsInOrder(t *testing.T) {
 	owner := uint32(1)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				OwnerWorkerID:   &owner,
 				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:                 0,
 						OwnerWorkerID:           &owner,
@@ -773,13 +774,13 @@ func TestFormatCoSInterfaceSummaryRendersOwnerProfileLineForExactQueues(t *testi
 	redirectHist := make([]uint64, 16)
 	redirectHist[2] = 10 // p99 of redirect-acquire → bucket 2 = ~2us
 
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				OwnerWorkerID:   &owner,
 				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:              4,
 						OwnerWorkerID:        &owner,
@@ -849,13 +850,13 @@ func TestFormatCoSInterfaceSummaryRendersDistinctPerQueueOwnerProfiles(t *testin
 	q6Hist := make([]uint64, 16)
 	q6Hist[5] = 200 // p50 & p99 in bucket 5 → "16us"
 
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				OwnerWorkerID:   &owner,
 				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:           4,
 						OwnerWorkerID:     &owner,
@@ -906,13 +907,13 @@ func TestFormatCoSInterfaceSummaryRendersDistinctPerQueueOwnerProfiles(t *testin
 // the Drops line still renders.
 func TestFormatCoSInterfaceSummaryOmitsOwnerProfileForQueuesWithoutOwner(t *testing.T) {
 	owner := uint32(2)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				OwnerWorkerID:   &owner,
 				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID: 4,
 						// OwnerWorkerID intentionally nil: shared_exact
@@ -956,13 +957,13 @@ func TestFormatCoSInterfaceSummaryOmitsOwnerProfileForQueuesWithoutOwner(t *test
 // catch it.
 func TestFormatCoSInterfaceSummarySuppressesZeroedOwnerProfile(t *testing.T) {
 	owner := uint32(1)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				OwnerWorkerID:   &owner,
 				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:           4,
 						OwnerWorkerID:     &owner,
@@ -994,12 +995,12 @@ func TestFormatCoSInterfaceSummarySuppressesZeroedOwnerProfile(t *testing.T) {
 }
 
 func TestFormatCoSInterfaceSummaryRendersDrainShapeForNonExactQueue(t *testing.T) {
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:                 0,
 						ForwardingClass:         "best-effort",
@@ -1033,13 +1034,13 @@ func TestFormatCoSInterfaceSummaryRendersDrainShapeForNonExactQueue(t *testing.T
 // "counter missing from the pipeline" when chasing #718 / #722.
 func TestFormatCoSInterfaceSummaryRendersZeroAdmissionCounters(t *testing.T) {
 	owner := uint32(1)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				OwnerWorkerID:   &owner,
 				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:         4,
 						OwnerWorkerID:   &owner,
@@ -1063,13 +1064,13 @@ func TestFormatCoSInterfaceSummaryRendersZeroAdmissionCounters(t *testing.T) {
 // noise line. win_min is the standing-queue gate metric.
 func TestFormatCoSInterfaceSummaryRendersSojournLine(t *testing.T) {
 	owner := uint32(1)
-	status := &ProcessStatus{
-		CoSInterfaces: []CoSInterfaceStatus{
+	status := &userspace.ProcessStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
 				InterfaceName:   "reth0.80",
 				OwnerWorkerID:   &owner,
 				WorkerInstances: 1,
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{
 						QueueID:              4,
 						OwnerWorkerID:        &owner,

--- a/pkg/dataplane/userspace/format/math.go
+++ b/pkg/dataplane/userspace/format/math.go
@@ -1,4 +1,4 @@
-package userspace
+package format
 
 // saturatingAddU64 avoids silent wraparound in telemetry renderers.
 // Hot-path this is not (called at status/scrape cadence), but

--- a/pkg/dataplane/userspace/format/status.go
+++ b/pkg/dataplane/userspace/format/status.go
@@ -1,4 +1,4 @@
-package userspace
+package format
 
 import (
 	"fmt"
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 const defaultFlowWorkerMapLimit = 128
@@ -36,7 +38,7 @@ func (c SYNCookieCounters) Any() bool {
 }
 
 // SumSYNCookieCounters sums SYN-cookie counters across all bindings in status.
-func SumSYNCookieCounters(status ProcessStatus) SYNCookieCounters {
+func SumSYNCookieCounters(status userspace.ProcessStatus) SYNCookieCounters {
 	var counters SYNCookieCounters
 	for _, binding := range status.Bindings {
 		counters.Challenges += binding.SYNCookieChallenges
@@ -70,7 +72,7 @@ func FormatSYNCookieCounterRows(counters SYNCookieCounters) string {
 	return b.String()
 }
 
-func localHAForwardingRole(status ProcessStatus) string {
+func localHAForwardingRole(status userspace.ProcessStatus) string {
 	if len(status.HAGroups) == 0 {
 		return ""
 	}
@@ -98,7 +100,7 @@ func formatStatusCounterMap(counters map[string]uint64) string {
 	return strings.Join(parts, " ")
 }
 
-func FormatStatusSummary(status ProcessStatus) string {
+func FormatStatusSummary(status userspace.ProcessStatus) string {
 	var b strings.Builder
 	now := time.Now()
 	readyQueues := 0
@@ -288,7 +290,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	currentRuntimeCoSAdmissionDrops := saturatingAddU64(currentRuntimeCoSFlowShareDrops, currentRuntimeCoSBufferDrops)
 	// The residual must use the binding-lifetime CoS subset counter, not
 	// current-runtime queue reason counters; CoS runtimes reset on config
-	// changes while BindingStatus.TXErrors does not.
+	// changes while userspace.BindingStatus.TXErrors does not.
 	nonAdmissionTXErrors := saturatingSubU64(txErrors, bindingLifetimeCoSQueueDrops)
 
 	fmt.Fprintln(&b, "Userspace dataplane helper:")
@@ -434,7 +436,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 	fmt.Fprintf(&b, "  SNAT packets:              %d\n", snatPackets)
 	fmt.Fprintf(&b, "  DNAT packets:              %d\n", dnatPackets)
 	if len(status.SourceNATPools) > 0 {
-		rows := append([]SourceNATPoolStatus(nil), status.SourceNATPools...)
+		rows := append([]userspace.SourceNATPoolStatus(nil), status.SourceNATPools...)
 		sort.Slice(rows, func(i, j int) bool {
 			if rows[i].PoolName != rows[j].PoolName {
 				return rows[i].PoolName < rows[j].PoolName
@@ -470,7 +472,7 @@ func FormatStatusSummary(status ProcessStatus) string {
 		fmt.Fprintf(&b, "  CoS ECN marked:            %d\n", cosAdmissionEcnMarked)
 	}
 	if len(status.ThreeColorPolicerCounters) > 0 {
-		rows := append([]ThreeColorPolicerStatus(nil), status.ThreeColorPolicerCounters...)
+		rows := append([]userspace.ThreeColorPolicerStatus(nil), status.ThreeColorPolicerCounters...)
 		sort.Slice(rows, func(i, j int) bool {
 			if rows[i].ID != rows[j].ID {
 				return rows[i].ID < rows[j].ID
@@ -596,9 +598,9 @@ func FormatStatusSummary(status ProcessStatus) string {
 	return b.String()
 }
 
-func FormatFairnessRSS(status ProcessStatus, expectations []FairnessRSSExpectation) string {
+func FormatFairnessRSS(status userspace.ProcessStatus, expectations []userspace.FairnessRSSExpectation) string {
 	var b strings.Builder
-	rows := CoSFairnessRSSSummaries(status)
+	rows := userspace.CoSFairnessRSSSummaries(status)
 	fmt.Fprintln(&b, "Userspace fairness RSS structure:")
 	if status.CoSActiveFlowCountsTruncated {
 		fmt.Fprintln(&b, "  warning: CoS active-flow snapshot truncated; derived values are partial")
@@ -620,7 +622,7 @@ func FormatFairnessRSS(status ProcessStatus, expectations []FairnessRSSExpectati
 			)
 		}
 	}
-	if results := EvaluateFairnessRSSExpectations(status, expectations); len(results) > 0 {
+	if results := userspace.EvaluateFairnessRSSExpectations(status, expectations); len(results) > 0 {
 		fmt.Fprintln(&b)
 		fmt.Fprintln(&b, "RSS expectations:")
 		fmt.Fprintf(&b, "  %-8s %-7s %-28s %-6s %-11s %-13s %-10s %s\n",
@@ -641,9 +643,9 @@ func FormatFairnessRSS(status ProcessStatus, expectations []FairnessRSSExpectati
 	return b.String()
 }
 
-func FormatFlowWorkerMap(status ProcessStatus, limit int) string {
+func FormatFlowWorkerMap(status userspace.ProcessStatus, limit int) string {
 	var b strings.Builder
-	rows := append([]FlowWorkerStatus(nil), status.FlowWorkerMap...)
+	rows := append([]userspace.FlowWorkerStatus(nil), status.FlowWorkerMap...)
 	sort.Slice(rows, func(i, j int) bool { return flowWorkerStatusLess(rows[i], rows[j]) })
 	if limit == 0 {
 		limit = defaultFlowWorkerMapLimit
@@ -731,7 +733,7 @@ func parsePositiveFlowWorkerMapLimit(value string) (int, error) {
 	return limit, nil
 }
 
-func flowWorkerStatusLess(a, b FlowWorkerStatus) bool {
+func flowWorkerStatusLess(a, b userspace.FlowWorkerStatus) bool {
 	if a.WorkerID != b.WorkerID {
 		return a.WorkerID < b.WorkerID
 	}
@@ -744,7 +746,7 @@ func flowWorkerStatusLess(a, b FlowWorkerStatus) bool {
 	return flowTupleLess(a.SessionKey, b.SessionKey)
 }
 
-func flowTupleLess(a, b FlowTupleStatus) bool {
+func flowTupleLess(a, b userspace.FlowTupleStatus) bool {
 	if a.Protocol != b.Protocol {
 		return a.Protocol < b.Protocol
 	}
@@ -760,7 +762,7 @@ func flowTupleLess(a, b FlowTupleStatus) bool {
 	return a.DstPort < b.DstPort
 }
 
-func FormatBindings(status ProcessStatus) string {
+func FormatBindings(status userspace.ProcessStatus) string {
 	var b strings.Builder
 
 	fmt.Fprintln(&b, "Userspace queues:")
@@ -877,7 +879,7 @@ func formatOptionalUint8(value *uint8) string {
 	return fmt.Sprintf("%d", *value)
 }
 
-func formatFlowTuple(tuple FlowTupleStatus) string {
+func formatFlowTuple(tuple userspace.FlowTupleStatus) string {
 	if tuple.SrcIP == "" && tuple.DstIP == "" && tuple.SrcPort == 0 && tuple.DstPort == 0 && tuple.Protocol == 0 {
 		return "-"
 	}

--- a/pkg/dataplane/userspace/format/status_test.go
+++ b/pkg/dataplane/userspace/format/status_test.go
@@ -1,15 +1,17 @@
-package userspace
+package format
 
 import (
 	"fmt"
 	"strings"
 	"testing"
 	"time"
+
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 func TestFormatStatusSummary(t *testing.T) {
 	now := time.Now().UTC()
-	status := ProcessStatus{
+	status := userspace.ProcessStatus{
 		PID:                    1234,
 		HelperMode:             "rust-bootstrap",
 		ForwardingArmed:        false,
@@ -25,35 +27,35 @@ func TestFormatStatusSummary(t *testing.T) {
 		MaxSessions:            100,
 		FlowCacheCapacity:      8192,
 		RouteEntries:           4,
-		HAGroups: []HAGroupStatus{
+		HAGroups: []userspace.HAGroupStatus{
 			{RGID: 0, Active: true, WatchdogTimestamp: 100},
 			{RGID: 1, Active: false, WatchdogTimestamp: 0},
 			{RGID: 2, Active: false, WatchdogTimestamp: 0},
 		},
-		Fabrics: []FabricSnapshot{
+		Fabrics: []userspace.FabricSnapshot{
 			{Name: "fab0", ParentLinuxName: "ge-0-0-0", ParentIfindex: 7, OverlayLinux: "fab0", OverlayIfindex: 17, RXQueues: 4, PeerAddress: "10.99.1.2"},
 		},
-		LastResolution: &PacketResolution{
+		LastResolution: &userspace.PacketResolution{
 			Disposition:   "forward_candidate",
 			EgressIfindex: 11,
 			NextHop:       "172.16.50.1",
 			NeighborMAC:   "00:10:db:ff:10:01",
 		},
 		WorkerHeartbeats: []time.Time{now.Add(-500 * time.Millisecond), now.Add(-700 * time.Millisecond)},
-		Queues: []QueueStatus{
+		Queues: []userspace.QueueStatus{
 			{QueueID: 0, Armed: false, Ready: true},
 			{QueueID: 1, Armed: false, Ready: false},
 		},
-		Bindings: []BindingStatus{
+		Bindings: []userspace.BindingStatus{
 			{Slot: 0, Armed: false, Ready: true, Bound: true, XSKRegistered: true, XSKBindMode: "zerocopy", ZeroCopy: true, SharedUMEMMode: "cross-nic", SharedUMEMSocketRole: "owner", SharedUMEMGroup: "cross-nic:w0:ge-0-0-1,ge-0-0-2", RXPackets: 10, ValidatedPackets: 8, ExceptionPackets: 1, ScreenDrops: 2, SYNCookieChallenges: 3, SYNCookieSecretUnavailable: 1, SYNCookieAckValid: 5, SYNCookieAckInvalid: 7, SYNCookieBypass: 11, TXPackets: 3, TXBytes: 420, TXCompletions: 2, MirroredPackets: 4, MirroredBytes: 512, MirrorDropsNoFrame: 1, KernelRXDropped: 9, KernelRXInvalidDescs: 1, DirectTXPackets: 2, InPlaceTXPackets: 1, InPlaceVLANPushDescPackets: 8, InPlaceVLANPopDescPackets: 9, InPlaceVLANPushNoHeadroomPackets: 10, InPlaceL2MemmoveFallbackPackets: 11, DirectTXNoFrameFallbackPackets: 5, DirectTXBuildFallbackPackets: 6, DebugPendingFillFrames: 10, DebugSpareFillFrames: 11, DebugFreeTXFrames: 12, DebugPendingTXPrepared: 13, DebugPendingTXLocal: 14, DebugOutstandingTX: 15, DebugInFlightRecycles: 16},
 			{Slot: 1, Armed: false, Ready: false, Bound: true, XSKRegistered: false, RXPackets: 5, ValidatedPackets: 4, ExceptionPackets: 2, ScreenDrops: 4, SYNCookieChallenges: 13, SYNCookieAckValid: 17, SYNCookieAckInvalid: 19, SYNCookieBypass: 23, TXErrors: 1, TXSharedRecycleUnknownSlotDrops: 1, TXCompletions: 3, MirroredPackets: 6, MirroredBytes: 768, MirrorDropsNoBinding: 2, MirrorDropsQueueFull: 3, KernelRXDropped: 4, KernelRXInvalidDescs: 2, CopyTXPackets: 4, InPlaceVLANPushDescPackets: 3, InPlaceVLANPopDescPackets: 4, InPlaceVLANPushNoHeadroomPackets: 5, InPlaceL2MemmoveFallbackPackets: 6, DirectTXDisallowedFallbackPackets: 7, DebugPendingFillFrames: 20, DebugSpareFillFrames: 21, DebugFreeTXFrames: 22, DebugPendingTXPrepared: 23, DebugPendingTXLocal: 24, DebugOutstandingTX: 25, DebugInFlightRecycles: 26},
 		},
-		RecentExceptions: []ExceptionStatus{
+		RecentExceptions: []userspace.ExceptionStatus{
 			{Timestamp: now, Slot: 1, QueueID: 0, Interface: "ge-0-0-2", Reason: "metadata_parse", PacketLength: 128},
 		},
 		EventStreamSent:    101,
 		EventStreamDropped: 7,
-		EventStream: &EventStreamStatus{
+		EventStream: &userspace.EventStreamStatus{
 			FramesRead:        11,
 			FramesWritten:     5,
 			DecodeErrors:      2,
@@ -138,8 +140,12 @@ func TestFormatStatusSummary(t *testing.T) {
 }
 
 func TestFormatStatusSummaryShowsPersistentSourceNATHABoundary(t *testing.T) {
-	status := ProcessStatus{
-		Capabilities: UserspaceCapabilities{
+	// Mirrors the unexported persistentSourceNATHAUnsupportedReason constant
+	// in the parent userspace package (manager.go); the formatter only echoes
+	// whatever UnsupportedReasons string the manager supplies.
+	const persistentSourceNATHAUnsupportedReason = "userspace persistent-nat source pool leases are not HA-synchronized"
+	status := userspace.ProcessStatus{
+		Capabilities: userspace.UserspaceCapabilities{
 			ForwardingSupported: false,
 			UnsupportedReasons:  []string{persistentSourceNATHAUnsupportedReason},
 		},
@@ -157,7 +163,7 @@ func TestFormatStatusSummaryShowsPersistentSourceNATHABoundary(t *testing.T) {
 }
 
 func TestFormatStatusSummaryShowsDegradedPathCounters(t *testing.T) {
-	status := ProcessStatus{
+	status := userspace.ProcessStatus{
 		DegradedPathCounters: map[string]uint64{
 			"transit_drop":  5,
 			"ctrl_disabled": 1,
@@ -176,8 +182,8 @@ func TestFormatStatusSummaryShowsDegradedPathCounters(t *testing.T) {
 }
 
 func TestFormatSYNCookieCounterRows(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{
 				SYNCookieChallenges:        3,
 				SYNCookieSecretUnavailable: 5,
@@ -226,8 +232,8 @@ func TestFormatStatusSummaryWorkerRuntimeRolling60sColumn(t *testing.T) {
 	// Three workers: w0 has a fully-populated window (45s CPU over 60s = 75%);
 	// w1 has only cumulative data and no rotation yet (window_ns=0, show "-");
 	// w2 is dead (windowed column suppressed by DEAD row).
-	status := ProcessStatus{
-		WorkerRuntime: []WorkerRuntimeStatus{
+	status := userspace.ProcessStatus{
+		WorkerRuntime: []userspace.WorkerRuntimeStatus{
 			{
 				WorkerID:       0,
 				TID:            111,
@@ -278,8 +284,8 @@ func TestFormatStatusSummaryWorkerRuntimeRolling60sColumn(t *testing.T) {
 }
 
 func TestFormatStatusSummaryIncludesThreeColorPolicerCounters(t *testing.T) {
-	status := ProcessStatus{
-		ThreeColorPolicerCounters: []ThreeColorPolicerStatus{
+	status := userspace.ProcessStatus{
+		ThreeColorPolicerCounters: []userspace.ThreeColorPolicerStatus{
 			{
 				ID:            2,
 				Name:          "wan-egress",
@@ -316,9 +322,9 @@ func TestFormatStatusSummaryIncludesThreeColorPolicerCounters(t *testing.T) {
 }
 
 func TestFormatStatusSummaryReportsStandbyArmedRole(t *testing.T) {
-	status := ProcessStatus{
+	status := userspace.ProcessStatus{
 		ForwardingArmed: true,
-		HAGroups: []HAGroupStatus{
+		HAGroups: []userspace.HAGroupStatus{
 			{RGID: 0, Active: false, WatchdogTimestamp: 100},
 			{RGID: 1, Active: false, WatchdogTimestamp: 0},
 			{RGID: 2, Active: false, WatchdogTimestamp: 0},
@@ -332,8 +338,8 @@ func TestFormatStatusSummaryReportsStandbyArmedRole(t *testing.T) {
 }
 
 func TestFormatStatusSummaryDoesNotCountDisabledSharedUMEMFallback(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{
 				SharedUMEMMode:           "cross-nic",
 				SharedUMEMSocketRole:     "owner",
@@ -353,13 +359,13 @@ func TestFormatStatusSummaryDoesNotCountDisabledSharedUMEMFallback(t *testing.T)
 }
 
 func TestFormatStatusSummaryAttributesCoSAdmissionTXErrors(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{TXErrors: 100, DbgCoSQueueOverflow: 50},
 		},
-		CoSInterfaces: []CoSInterfaceStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{AdmissionFlowShareDrops: 3, AdmissionBufferDrops: 2, AdmissionEcnMarked: 7},
 					{AdmissionFlowShareDrops: 1, AdmissionBufferDrops: 4, AdmissionEcnMarked: 11},
 				},
@@ -384,13 +390,13 @@ func TestFormatStatusSummaryAttributesCoSAdmissionTXErrors(t *testing.T) {
 }
 
 func TestFormatStatusSummaryUsesBindingLifetimeForCoSErrorResidual(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{TXErrors: 100, DbgCoSQueueOverflow: 80},
 		},
-		CoSInterfaces: []CoSInterfaceStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{AdmissionFlowShareDrops: 5, AdmissionBufferDrops: 5},
 				},
 			},
@@ -414,13 +420,13 @@ func TestFormatStatusSummaryUsesBindingLifetimeForCoSErrorResidual(t *testing.T)
 }
 
 func TestFormatStatusSummarySaturatesCoSAdmissionAttribution(t *testing.T) {
-	status := ProcessStatus{
-		Bindings: []BindingStatus{
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
 			{TXErrors: 1, DbgCoSQueueOverflow: 2},
 		},
-		CoSInterfaces: []CoSInterfaceStatus{
+		CoSInterfaces: []userspace.CoSInterfaceStatus{
 			{
-				Queues: []CoSQueueStatus{
+				Queues: []userspace.CoSQueueStatus{
 					{AdmissionFlowShareDrops: ^uint64(0) - 1, AdmissionBufferDrops: 10},
 				},
 			},
@@ -442,9 +448,9 @@ func TestFormatStatusSummarySaturatesCoSAdmissionAttribution(t *testing.T) {
 }
 
 func TestFormatFairnessRSS(t *testing.T) {
-	status := ProcessStatus{
+	status := userspace.ProcessStatus{
 		CoSActiveFlowCountsTruncated: true,
-		CoSActiveFlowCounts: []CoSActiveFlowCountStatus{
+		CoSActiveFlowCounts: []userspace.CoSActiveFlowCountStatus{
 			{Ifindex: 80, QueueID: 4, WorkerID: 0, ActiveFlowCount: 1},
 			{Ifindex: 80, QueueID: 4, WorkerID: 1, ActiveFlowCount: 3},
 			{Ifindex: 80, QueueID: 4, WorkerID: 2, ActiveFlowCount: 0},
@@ -453,7 +459,7 @@ func TestFormatFairnessRSS(t *testing.T) {
 		},
 	}
 
-	out := FormatFairnessRSS(status, []FairnessRSSExpectation{
+	out := FormatFairnessRSS(status, []userspace.FairnessRSSExpectation{
 		{Ifindex: 80, QueueID: 4, RSSExpectation: "balanced"},
 		{Ifindex: 80, QueueID: 5, RSSExpectation: "max-worker-flow-share:50%"},
 	})
@@ -478,7 +484,7 @@ func TestFormatFairnessRSS(t *testing.T) {
 }
 
 func TestFormatFairnessRSSShowsExpectationsWithoutRows(t *testing.T) {
-	out := FormatFairnessRSS(ProcessStatus{Workers: 4}, []FairnessRSSExpectation{
+	out := FormatFairnessRSS(userspace.ProcessStatus{Workers: 4}, []userspace.FairnessRSSExpectation{
 		{Ifindex: 80, QueueID: 4, RSSExpectation: "cstruct-max:0.25"},
 	})
 	for _, want := range []string{
@@ -498,9 +504,9 @@ func TestFormatFairnessRSSShowsExpectationsWithoutRows(t *testing.T) {
 func TestFormatFlowWorkerMap(t *testing.T) {
 	cosQueue := uint8(4)
 	dscpRewrite := uint8(46)
-	status := ProcessStatus{
+	status := userspace.ProcessStatus{
 		FlowWorkerMapTruncated: true,
-		FlowWorkerMap: []FlowWorkerStatus{
+		FlowWorkerMap: []userspace.FlowWorkerStatus{
 			{
 				Slot:           3,
 				QueueID:        2,
@@ -514,21 +520,21 @@ func TestFormatFlowWorkerMap(t *testing.T) {
 				DSCPRewrite:    &dscpRewrite,
 				AgeEpochs:      7,
 				ObservedBytes:  123456,
-				SessionKey: FlowTupleStatus{
+				SessionKey: userspace.FlowTupleStatus{
 					Protocol: 6,
 					SrcIP:    "172.16.80.10",
 					SrcPort:  40000,
 					DstIP:    "172.16.80.200",
 					DstPort:  5201,
 				},
-				ForwardWireKey: FlowTupleStatus{
+				ForwardWireKey: userspace.FlowTupleStatus{
 					Protocol: 6,
 					SrcIP:    "172.16.80.10",
 					SrcPort:  40000,
 					DstIP:    "172.16.80.200",
 					DstPort:  5201,
 				},
-				ReverseCanonicalKey: FlowTupleStatus{
+				ReverseCanonicalKey: userspace.FlowTupleStatus{
 					Protocol: 6,
 					SrcIP:    "172.16.80.200",
 					SrcPort:  5201,
@@ -540,7 +546,7 @@ func TestFormatFlowWorkerMap(t *testing.T) {
 				Slot:     1,
 				QueueID:  1,
 				WorkerID: 0,
-				SessionKey: FlowTupleStatus{
+				SessionKey: userspace.FlowTupleStatus{
 					Protocol: 17,
 					SrcIP:    "2001:db8::1",
 					SrcPort:  12345,
@@ -623,18 +629,18 @@ func TestParseFlowWorkerMapLimitSpec(t *testing.T) {
 }
 
 func TestFormatBindings(t *testing.T) {
-	status := ProcessStatus{
-		Fabrics: []FabricSnapshot{
+	status := userspace.ProcessStatus{
+		Fabrics: []userspace.FabricSnapshot{
 			{Name: "fab0", ParentLinuxName: "ge-0-0-0", ParentIfindex: 7, OverlayLinux: "fab0", OverlayIfindex: 17, RXQueues: 4, PeerAddress: "10.99.1.2"},
 		},
-		Queues: []QueueStatus{
+		Queues: []userspace.QueueStatus{
 			{QueueID: 0, WorkerID: 0, Interfaces: []string{"ge-0-0-1", "ge-0-0-2"}, Registered: true, Armed: false, Ready: false},
 		},
-		Bindings: []BindingStatus{
+		Bindings: []userspace.BindingStatus{
 			{Slot: 0, QueueID: 0, WorkerID: 0, Registered: true, Armed: false, Ready: false, Bound: true, XSKRegistered: true, XSKBindMode: "zerocopy", ZeroCopy: true, Ifindex: 5, Interface: "ge-0-0-1", SharedUMEMMode: "cross-nic", SharedUMEMSocketRole: "owner", SharedUMEMGroup: "cross-nic:w0:ge-0-0-1,ge-0-0-2", RXPackets: 99, TXPackets: 7, DirectTXPackets: 5, CopyTXPackets: 1, InPlaceTXPackets: 1, ExceptionPackets: 3},
 			{Slot: 1, QueueID: 0, WorkerID: 0, Registered: true, Armed: false, Ready: false, Bound: true, XSKRegistered: false, Ifindex: 6, Interface: "ge-0-0-2", ExceptionPackets: 1, LastError: "xsk map update failed"},
 		},
-		RecentExceptions: []ExceptionStatus{
+		RecentExceptions: []userspace.ExceptionStatus{
 			{Timestamp: time.Unix(0, 0).UTC(), Slot: 1, QueueID: 0, Interface: "ge-0-0-2", Reason: "fib_generation_mismatch", PacketLength: 512, AddrFamily: 10, Protocol: 6, ConfigGeneration: 11, FIBGeneration: 9, RuleName: "snat-a", PoolName: "pool-a"},
 		},
 	}

--- a/pkg/dataplane/userspace/format/wireguard.go
+++ b/pkg/dataplane/userspace/format/wireguard.go
@@ -1,9 +1,11 @@
-package userspace
+package format
 
 import (
 	"fmt"
 	"strings"
 	"time"
+
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 // FormatWireguardStatus renders the #1865 per-WG-tunnel telemetry rows
@@ -19,7 +21,7 @@ import (
 // detail view adds the full per-reason drop tables — the one-glance
 // diagnosis for the #1736 class of failures (silent sends, MTU
 // blackholes, wrong-key peers).
-func FormatWireguardStatus(status ProcessStatus, detail bool, now time.Time) string {
+func FormatWireguardStatus(status userspace.ProcessStatus, detail bool, now time.Time) string {
 	if len(status.WgTunnels) == 0 {
 		return "No WireGuard tunnels configured\n"
 	}

--- a/pkg/dataplane/userspace/format/wireguard_test.go
+++ b/pkg/dataplane/userspace/format/wireguard_test.go
@@ -1,14 +1,16 @@
-package userspace
+package format
 
 import (
 	"strings"
 	"testing"
 	"time"
+
+	userspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
-func wgFmtFixture() ProcessStatus {
-	return ProcessStatus{
-		WgTunnels: []WgTunnelStatus{{
+func wgFmtFixture() userspace.ProcessStatus {
+	return userspace.ProcessStatus{
+		WgTunnels: []userspace.WgTunnelStatus{{
 			Tunnel:                 "wg0",
 			TunnelEndpointID:       3,
 			ListenPort:             51820,
@@ -77,11 +79,11 @@ func TestFormatWireguardStatusDetailReasonTables(t *testing.T) {
 }
 
 func TestFormatWireguardStatusNeverAndEmpty(t *testing.T) {
-	out := FormatWireguardStatus(ProcessStatus{}, false, time.Now())
+	out := FormatWireguardStatus(userspace.ProcessStatus{}, false, time.Now())
 	if !strings.Contains(out, "No WireGuard tunnels configured") {
 		t.Errorf("empty status rendering = %q", out)
 	}
-	status := ProcessStatus{WgTunnels: []WgTunnelStatus{{Tunnel: "wg1"}}}
+	status := userspace.ProcessStatus{WgTunnels: []userspace.WgTunnelStatus{{Tunnel: "wg1"}}}
 	out = FormatWireguardStatus(status, false, time.Now())
 	if !strings.Contains(out, "Latest handshake:   never") {
 		t.Errorf("never-handshaked tunnel must render 'never':\n%s", out)

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -505,8 +505,34 @@ func TestStatusIPCRecordsSYNCookieBindingCounters(t *testing.T) {
 		t.Fatal("helper did not finish status response")
 	}
 
-	got := SumSYNCookieCounters(m.lastStatus)
-	want := SYNCookieCounters{
+	// Aggregate the per-binding SYN-cookie counters the manager recorded.
+	// The shared SumSYNCookieCounters/SYNCookieCounters helpers now live in
+	// the format subpackage (which imports this package), so this manager
+	// test sums inline to assert the recording behavior without creating an
+	// import cycle. The summation helper itself is covered by the format
+	// package tests.
+	type synCookieTotals struct {
+		Challenges        uint64
+		SecretUnavailable uint64
+		SynAckSent        uint64
+		AckRstSent        uint64
+		ReplyBudgetDrops  uint64
+		AckValid          uint64
+		AckInvalid        uint64
+		Bypass            uint64
+	}
+	var got synCookieTotals
+	for _, binding := range m.lastStatus.Bindings {
+		got.Challenges += binding.SYNCookieChallenges
+		got.SecretUnavailable += binding.SYNCookieSecretUnavailable
+		got.SynAckSent += binding.SYNCookieSynAckSent
+		got.AckRstSent += binding.SYNCookieAckRstSent
+		got.ReplyBudgetDrops += binding.SYNCookieReplyBudgetDrops
+		got.AckValid += binding.SYNCookieAckValid
+		got.AckInvalid += binding.SYNCookieAckInvalid
+		got.Bypass += binding.SYNCookieBypass
+	}
+	want := synCookieTotals{
 		Challenges:        20,
 		SecretUnavailable: 24,
 		SynAckSent:        36,

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -18,6 +18,7 @@ import (
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/psaab/xpf/pkg/monitoriface"
 	"golang.org/x/sys/unix"
@@ -919,7 +920,7 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 			if err != nil {
 				return nil, status.Errorf(codes.FailedPrecondition, "userspace inject: %v", err)
 			}
-			msg := dpuserspace.FormatStatusSummary(statusAfter) + "\n" + dpuserspace.FormatBindings(statusAfter)
+			msg := dpformat.FormatStatusSummary(statusAfter) + "\n" + dpformat.FormatBindings(statusAfter)
 			return &pb.SystemActionResponse{Message: msg}, nil
 		}
 		if strings.HasPrefix(req.Action, "userspace-forwarding:") {
@@ -935,7 +936,7 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 			if err != nil {
 				return nil, status.Errorf(codes.FailedPrecondition, "userspace forwarding control: %v", err)
 			}
-			msg := dpuserspace.FormatStatusSummary(statusAfter) + "\n" + dpuserspace.FormatBindings(statusAfter)
+			msg := dpformat.FormatStatusSummary(statusAfter) + "\n" + dpformat.FormatBindings(statusAfter)
 			return &pb.SystemActionResponse{Message: msg}, nil
 		}
 		if strings.HasPrefix(req.Action, "userspace-queue:") {
@@ -960,7 +961,7 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 			if err != nil {
 				return nil, status.Errorf(codes.FailedPrecondition, "userspace queue control: %v", err)
 			}
-			msg := dpuserspace.FormatStatusSummary(statusAfter) + "\n" + dpuserspace.FormatBindings(statusAfter)
+			msg := dpformat.FormatStatusSummary(statusAfter) + "\n" + dpformat.FormatBindings(statusAfter)
 			return &pb.SystemActionResponse{Message: msg}, nil
 		}
 		if strings.HasPrefix(req.Action, "userspace-binding:") {
@@ -985,7 +986,7 @@ func (s *Server) SystemAction(ctx context.Context, req *pb.SystemActionRequest) 
 			if err != nil {
 				return nil, status.Errorf(codes.FailedPrecondition, "userspace binding control: %v", err)
 			}
-			msg := dpuserspace.FormatStatusSummary(statusAfter) + "\n" + dpuserspace.FormatBindings(statusAfter)
+			msg := dpformat.FormatStatusSummary(statusAfter) + "\n" + dpformat.FormatBindings(statusAfter)
 			return &pb.SystemActionResponse{Message: msg}, nil
 		}
 		return nil, status.Errorf(codes.InvalidArgument, "unknown action: %s", req.Action)

--- a/pkg/grpcapi/server_show_cluster_text.go
+++ b/pkg/grpcapi/server_show_cluster_text.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -142,7 +143,7 @@ func (s *Server) showChassisClusterDataPlaneStatistics(buf *strings.Builder) {
 	buf.WriteString(s.cluster.FormatDataPlaneStatistics())
 	if status, err := s.userspaceDataplaneStatus(); err == nil {
 		buf.WriteString("\n")
-		buf.WriteString(dpuserspace.FormatStatusSummary(status))
+		buf.WriteString(dpformat.FormatStatusSummary(status))
 	}
 }
 
@@ -157,7 +158,7 @@ func (s *Server) showChassisClusterDataPlaneInterfaces(buf *strings.Builder) {
 	buf.WriteString(s.cluster.FormatDataPlaneInterfaces())
 	if status, err := s.userspaceDataplaneStatus(); err == nil {
 		buf.WriteString("\n")
-		buf.WriteString(dpuserspace.FormatBindings(status))
+		buf.WriteString(dpformat.FormatBindings(status))
 	}
 }
 
@@ -173,7 +174,7 @@ func (s *Server) showChassisClusterDataPlaneFairness(buf *strings.Builder) {
 		fmt.Fprintf(buf, "Userspace status unavailable: %v\n", err)
 		return
 	}
-	buf.WriteString(dpuserspace.FormatFairnessRSS(status, dpuserspace.FairnessRSSExpectationsFromConfig(s.store.ActiveConfig())))
+	buf.WriteString(dpformat.FormatFairnessRSS(status, dpuserspace.FairnessRSSExpectationsFromConfig(s.store.ActiveConfig())))
 }
 
 // showChassisClusterDataPlaneFlows renders the bounded active
@@ -183,7 +184,7 @@ func (s *Server) showChassisClusterDataPlaneFlows(filter string, buf *strings.Bu
 		fmt.Fprintln(buf, "Cluster not configured")
 		return
 	}
-	limit, err := dpuserspace.ParseFlowWorkerMapLimitSpec(filter)
+	limit, err := dpformat.ParseFlowWorkerMapLimitSpec(filter)
 	if err != nil {
 		fmt.Fprintf(buf, "syntax error: %v\n", err)
 		return
@@ -193,7 +194,7 @@ func (s *Server) showChassisClusterDataPlaneFlows(filter string, buf *strings.Bu
 		fmt.Fprintf(buf, "Userspace status unavailable: %v\n", err)
 		return
 	}
-	buf.WriteString(dpuserspace.FormatFlowWorkerMap(status, limit))
+	buf.WriteString(dpformat.FormatFlowWorkerMap(status, limit))
 }
 
 // showChassisClusterIPMonitoringStatus renders the IP-monitoring

--- a/pkg/grpcapi/server_show_interfaces_text.go
+++ b/pkg/grpcapi/server_show_interfaces_text.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/vishvananda/netlink"
 	"google.golang.org/grpc/codes"
@@ -277,7 +278,7 @@ func (s *Server) showClassOfService(req *pb.ShowTextRequest, cfg *config.Config,
 	if userspaceStatus, err := s.userspaceDataplaneStatus(); err == nil {
 		status = &userspaceStatus
 	}
-	buf.WriteString(dpuserspace.FormatCoSInterfaceSummary(cfg, status, selector))
+	buf.WriteString(dpformat.FormatCoSInterfaceSummary(cfg, status, selector))
 	return &pb.ShowTextResponse{Output: buf.String()}, nil
 }
 

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
-	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	"github.com/psaab/xpf/pkg/feeds"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/psaab/xpf/pkg/ipmon"
@@ -45,7 +45,7 @@ func (s *Server) screenSYNCookieCounterRows() string {
 	if err != nil {
 		return ""
 	}
-	return dpuserspace.FormatSYNCookieCounterRows(dpuserspace.SumSYNCookieCounters(status))
+	return dpformat.FormatSYNCookieCounterRows(dpformat.SumSYNCookieCounters(status))
 }
 
 // showIPsecStatistics renders the IPsec SA table with active-tunnel
@@ -871,7 +871,7 @@ func writeRPMConfig(buf *strings.Builder, cfg *config.Config) {
 // showWireguard renders `show security wireguard [detail]` for the
 // remote CLI from the userspace helper's per-tunnel telemetry rows
 // (#1865). Shared rendering with the local CLI via
-// dpuserspace.FormatWireguardStatus.
+// dpformat.FormatWireguardStatus.
 func (s *Server) showWireguard(buf *strings.Builder, detail bool) {
 	if s.dp == nil {
 		buf.WriteString("Dataplane not loaded\n")
@@ -887,5 +887,5 @@ func (s *Server) showWireguard(buf *strings.Builder, detail bool) {
 		fmt.Fprintf(buf, "WireGuard telemetry unavailable: %v\n", err)
 		return
 	}
-	buf.WriteString(dpuserspace.FormatWireguardStatus(status, detail, time.Now()))
+	buf.WriteString(dpformat.FormatWireguardStatus(status, detail, time.Now()))
 }

--- a/pkg/grpcapi/server_show_system.go
+++ b/pkg/grpcapi/server_show_system.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
-	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -418,7 +418,7 @@ func (s *Server) showBuffers(cfg *config.Config, buf *strings.Builder) {
 			if err != nil {
 				fmt.Fprintf(buf, "Userspace buffer metrics unavailable: %v\n", err)
 			} else {
-				buf.WriteString(dpuserspace.FormatSystemBuffers(status, false))
+				buf.WriteString(dpformat.FormatSystemBuffers(status, false))
 				v4, v6 := s.dp.SessionCount()
 				if v4 > 0 || v6 > 0 {
 					fmt.Fprintf(buf, "\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)
@@ -473,7 +473,7 @@ func (s *Server) showBuffersDetail(cfg *config.Config, buf *strings.Builder) {
 			if err != nil {
 				fmt.Fprintf(buf, "Userspace buffer metrics unavailable: %v\n", err)
 			} else {
-				buf.WriteString(dpuserspace.FormatSystemBuffers(status, true))
+				buf.WriteString(dpformat.FormatSystemBuffers(status, true))
 				v4, v6 := s.dp.SessionCount()
 				if v4 > 0 || v6 > 0 {
 					fmt.Fprintf(buf, "\nActive sessions: %d IPv4, %d IPv6, %d total\n", v4, v6, v4+v6)


### PR DESCRIPTION
## Summary

Closes #1990. Pure code motion: the `pkg/dataplane/userspace/` directory had grown into a ~70-file flat tree that mixed telemetry parse/format helpers with the core forwarding managers. Per the engineering-style "one responsibility per module" guideline, this relocates the output-presentation logic into a dedicated `pkg/dataplane/userspace/format` subpackage so the packet-processing directory carries only the manager logic.

## What moved (git renames, bodies unchanged)

| From | To |
|------|----|
| `cosfmt.go` | `format/cos.go` |
| `statusfmt.go` | `format/status.go` |
| `buffersfmt.go` | `format/buffers.go` |
| `wgfmt.go` | `format/wireguard.go` |
| `format_math.go` | `format/math.go` |

…plus the four matching `*_test.go` pairs. The `format_math.go` saturating-add/sub helpers are used only by the formatters, so they move too.

## Public API

Identical — only the import path changes. Callers now reference `dpformat.FormatStatusSummary` (etc.) instead of `dpuserspace.FormatStatusSummary` across `pkg/grpcapi`, `pkg/cli`, and `pkg/api`. The parent `userspace` package keeps the non-formatting fairness API (`CoSFairnessRSSSummaries`, `EvaluateFairnessRSSExpectations`, `FairnessRSSExpectationsFromConfig`), which several callers still use, so those files keep both imports.

## Mechanical adjustments required by the move (no behavior change)

- The moved files reference exported parent types (`ProcessStatus`, `BindingStatus`, `CoSInterfaceStatus`, `CoSQueueStatus`, …) and the two exported fairness functions; these are now qualified with the `userspace` package alias.
- `format/status_test.go` inlines the unexported `persistentSourceNATHAUnsupportedReason` constant (value-identical to `manager.go`) because a sibling package cannot reference it; the test asserts the exact same rendered line.
- `manager_test.go`'s SYN-cookie IPC test summed counters via the now-moved `SumSYNCookieCounters` helper. Importing the `format` subpackage from this internal (`package userspace`) test would create an import cycle (`format` imports `userspace`), so the test sums the per-binding counters inline. The summation helper itself remains covered by the `format` package tests.

## Validation

- `go build ./...` clean.
- `go vet` clean on all touched packages (no new warnings; the pre-existing `cli.go` unreachable-code note is unrelated).
- `gofmt` clean on all changed files.
- Full `go test ./...` green, including the new `pkg/dataplane/userspace/format` package and every importer (`pkg/api`, `pkg/cli`, `pkg/grpcapi`, `pkg/dataplane/userspace`).
- Verified pure motion by normalizing the moved files (strip the package decl + `userspace.` qualifiers) and diffing against `origin/master`: the formatter bodies are byte-identical save the added import line; `cos.go` and `math.go` are exactly identical.

No documentation update is needed: no living module/README doc names the moved files; the only references are point-in-time historical PR/research records under `docs/`, which should not be retroactively rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)