### PR TITLE
#1988: decompose pkg/flowexport into manager/netflow/ipfix/transport

### DIFF
--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -6,12 +6,29 @@ session sampling. Wired off `pkg/logging.EventReader` SESSION_CLOSE
 events in `pkg/daemon/daemon_flow.go`, not the conntrack GC delete
 callback. No per-packet sampling path.
 
+## File layout
+
+The package is split by responsibility (#1988):
+
+- `manager.go` — resolved export config (`ExportConfig`,
+  `CollectorConfig`, `SamplingDir`), the sampling scheduler
+  (`ShouldExport`), the shared `FlowRecord`/`SessionCloseData` shapes,
+  and the `BuildExportConfig` / `BuildIPFIXExportConfig` /
+  `BuildSamplingZones` config resolvers.
+- `netflow.go` — NetFlow v9 template/record encoding and the `Exporter`
+  that drives it.
+- `ipfix.go` — IPFIX (v10) template/record encoding and the
+  `IPFIXExporter` that drives it.
+- `transport.go` — shared collector connection management
+  (`collectorConns`: dial / fan-out write / close) and the per-family
+  batch accumulator (`flowBatch`) used by both exporters.
+
 ## Entry points
 
 NetFlow v9:
-- `Exporter` — `exporter.go`.
-- `NewExporter(cfg ExportConfig) (*Exporter, error)` — `exporter.go`.
-- `Run(ctx context.Context)` — `exporter.go`. Main export loop.
+- `Exporter` — `netflow.go`.
+- `NewExporter(cfg ExportConfig) (*Exporter, error)` — `netflow.go`.
+- `Run(ctx context.Context)` — `netflow.go`. Main export loop.
 - `Exporter.ExportSessionClose(rec, evt)` — emit one record.
 
 IPFIX:
@@ -21,11 +38,13 @@ IPFIX:
 - `IPFIXExporter.ExportSessionClose(rec, evt)` — emit one record.
 
 Shared:
-- `ExportConfig` — `exporter.go`. Resolved per-collector config.
-- `BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig` — `exporter.go`.
-- `SamplingDir` — `exporter.go`. Direction enum.
-- `SessionCloseData` — wire shape built from `logging.EventReader`
-  SESSION_CLOSE records (in `pkg/daemon/daemon_flow.go`).
+- `ExportConfig` — `manager.go`. Resolved per-collector config.
+- `BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig` — `manager.go`.
+- `BuildIPFIXExportConfig(...)` / `BuildSamplingZones(...)` — `manager.go`.
+- `SamplingDir` — `manager.go`. Direction enum.
+- `SessionCloseData` — `manager.go`. Wire shape built from
+  `logging.EventReader` SESSION_CLOSE records (in
+  `pkg/daemon/daemon_flow.go`).
 
 ## Callers
 
@@ -46,9 +65,9 @@ the `logging.EventReader` SESSION_CLOSE callback.
 - NetFlow v9 templates refresh every 60 s. If a collector restarts and
   misses a refresh it sees opaque records until the next cycle —
   configure the collector to handle template re-resolution.
-- Two batches are maintained: `batchV4` and `batchV6` (split by
-  family, not by zone). Both flush on a 100 ms ticker or on
-  shutdown.
+- Two batches are maintained inside `flowBatch` (`v4` and `v6`, split
+  by family, not by zone — `transport.go`). Both flush on a 100 ms
+  ticker or on shutdown.
 - `ExportSessionClose` builds the flow record synchronously from the
   event-reader callback. The export goroutine (started in `Run(ctx)`)
   is what actually transmits and refreshes templates; record assembly

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -1,17 +1,13 @@
-// Package flowexport implements IPFIX (RFC 7011 / NetFlow v10) flow data export.
 package flowexport
 
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
-	"log/slog"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/logging"
 )
 
@@ -293,11 +289,9 @@ type IPFIXExporter struct {
 
 	mu    sync.Mutex
 	seq   uint32 // cumulative data record count
-	conns []net.Conn
+	conns *collectorConns
 
-	batchMu sync.Mutex
-	batchV4 []FlowRecord
-	batchV6 []FlowRecord
+	batch flowBatch
 
 	exportedFlows atomic.Uint64
 	exportedPkts  atomic.Uint64
@@ -311,27 +305,11 @@ func NewIPFIXExporter(cfg ExportConfig) (*IPFIXExporter, error) {
 		templateSet: encodeIPFIXTemplateSet(),
 	}
 
-	for _, cc := range cfg.Collectors {
-		var conn net.Conn
-		var err error
-		if cc.SourceAddress != "" {
-			laddr, _ := net.ResolveUDPAddr("udp", cc.SourceAddress+":0")
-			raddr, err2 := net.ResolveUDPAddr("udp", cc.Address)
-			if err2 != nil {
-				return nil, fmt.Errorf("resolve collector %s: %w", cc.Address, err2)
-			}
-			conn, err = net.DialUDP("udp", laddr, raddr)
-		} else {
-			conn, err = net.Dial("udp", cc.Address)
-		}
-		if err != nil {
-			for _, c := range e.conns {
-				c.Close()
-			}
-			return nil, fmt.Errorf("dial collector %s: %w", cc.Address, err)
-		}
-		e.conns = append(e.conns, conn)
+	conns, err := dialCollectors(cfg.Collectors)
+	if err != nil {
+		return nil, err
 	}
+	e.conns = conns
 
 	return e, nil
 }
@@ -374,13 +352,7 @@ func (e *IPFIXExporter) ExportSessionClose(rec logging.EventRecord, evt SessionC
 		IsIPv6:    evt.IsIPv6,
 	}
 
-	e.batchMu.Lock()
-	if fr.IsIPv6 {
-		e.batchV6 = append(e.batchV6, fr)
-	} else {
-		e.batchV4 = append(e.batchV4, fr)
-	}
-	e.batchMu.Unlock()
+	e.batch.add(fr)
 }
 
 // Stats returns export statistics.
@@ -390,9 +362,7 @@ func (e *IPFIXExporter) Stats() (flows, packets uint64) {
 
 // Close shuts down all collector connections.
 func (e *IPFIXExporter) Close() {
-	for _, c := range e.conns {
-		c.Close()
-	}
+	e.conns.close()
 }
 
 func (e *IPFIXExporter) sendTemplates() {
@@ -408,20 +378,11 @@ func (e *IPFIXExporter) sendTemplates() {
 	pkt := make([]byte, 16+len(e.templateSet))
 	encodeIPFIXHeaderInto(pkt[:16], hdr)
 	copy(pkt[16:], e.templateSet)
-	for _, c := range e.conns {
-		if _, err := c.Write(pkt); err != nil {
-			slog.Debug("ipfix template send failed", "err", err)
-		}
-	}
+	e.conns.writeAll(pkt, "ipfix template send failed")
 }
 
 func (e *IPFIXExporter) flushBatches() {
-	e.batchMu.Lock()
-	v4 := e.batchV4
-	v6 := e.batchV6
-	e.batchV4 = nil
-	e.batchV6 = nil
-	e.batchMu.Unlock()
+	v4, v6 := e.batch.drain()
 
 	if len(v4) > 0 {
 		e.sendRecords(v4)
@@ -480,96 +441,9 @@ func (e *IPFIXExporter) sendRecords(records []FlowRecord) {
 		pkt := make([]byte, 16+dataLen)
 		encodeIPFIXHeaderInto(pkt[:16], hdr)
 		encodeIPFIXDataSetInto(pkt[16:], batch, tmplID, recSize)
-		for _, c := range e.conns {
-			if _, err := c.Write(pkt); err != nil {
-				slog.Debug("ipfix data send failed", "err", err)
-			}
-		}
+		e.conns.writeAll(pkt, "ipfix data send failed")
 
 		e.exportedFlows.Add(uint64(len(batch)))
 		e.exportedPkts.Add(1)
 	}
-}
-
-// BuildIPFIXExportConfig resolves IPFIX config into an ExportConfig.
-// Falls back to v9 collectors/sampling if no IPFIX-specific overrides.
-func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig {
-	if fo == nil || fo.Sampling == nil || len(fo.Sampling.Instances) == 0 {
-		return nil
-	}
-	if svc == nil || svc.FlowMonitoring == nil || svc.FlowMonitoring.VersionIPFIX == nil {
-		return nil
-	}
-
-	activeTimeout := 60 * time.Second
-	inactiveTimeout := 15 * time.Second
-	refreshRate := 60 * time.Second
-
-	for _, tmpl := range svc.FlowMonitoring.VersionIPFIX.Templates {
-		if tmpl.FlowActiveTimeout > 0 {
-			activeTimeout = time.Duration(tmpl.FlowActiveTimeout) * time.Second
-		}
-		if tmpl.FlowInactiveTimeout > 0 {
-			inactiveTimeout = time.Duration(tmpl.FlowInactiveTimeout) * time.Second
-		}
-		if tmpl.TemplateRefreshRate > 0 {
-			refreshRate = time.Duration(tmpl.TemplateRefreshRate) * time.Second
-		}
-		break // use first template
-	}
-
-	ec := &ExportConfig{
-		FlowActiveTimeout:   activeTimeout,
-		FlowInactiveTimeout: inactiveTimeout,
-		TemplateRefreshRate: refreshRate,
-	}
-
-	// Reuse same sampling rate + collectors as v9 (shared forwarding-options)
-	for _, inst := range fo.Sampling.Instances {
-		if inst.InputRate > 0 {
-			ec.SamplingRate = inst.InputRate
-			break
-		}
-	}
-
-	for _, inst := range fo.Sampling.Instances {
-		families := []*config.SamplingFamily{inst.FamilyInet, inst.FamilyInet6}
-		for _, fam := range families {
-			if fam == nil {
-				continue
-			}
-			for _, fs := range fam.FlowServers {
-				addr := fs.Address
-				if fs.Port > 0 {
-					addr = fmt.Sprintf("%s:%d", fs.Address, fs.Port)
-				}
-				srcAddr := fam.SourceAddress
-				if srcAddr == "" {
-					srcAddr = fam.InlineJflowSourceAddress
-				}
-				ec.Collectors = append(ec.Collectors, CollectorConfig{
-					Address:       addr,
-					SourceAddress: srcAddr,
-				})
-			}
-		}
-	}
-
-	if len(ec.Collectors) == 0 {
-		return nil
-	}
-
-	// Deduplicate collectors
-	seen := make(map[string]bool)
-	deduped := ec.Collectors[:0]
-	for _, c := range ec.Collectors {
-		key := collectorKey(c)
-		if !seen[key] {
-			seen[key] = true
-			deduped = append(deduped, c)
-		}
-	}
-	ec.Collectors = deduped
-
-	return ec
 }

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -1,16 +1,27 @@
+// Package flowexport implements NetFlow v9 and IPFIX (NetFlow v10) flow
+// data export. Session-close events are turned into flow records and
+// shipped to remote collectors over UDP, with per-zone direction
+// filtering and 1-in-N session sampling.
+//
+// The package is split by responsibility:
+//   - manager.go   — resolved export config, sampling scheduler, the
+//     shared FlowRecord shape, and the BuildExportConfig family of
+//     config resolvers.
+//   - netflow.go   — NetFlow v9 template/record encoding and the
+//     Exporter that drives it.
+//   - ipfix.go     — IPFIX (v10) template/record encoding and the
+//     IPFIXExporter that drives it.
+//   - transport.go — collector connection management and per-family
+//     batch accumulation shared by both exporters.
 package flowexport
 
 import (
-	"context"
 	"fmt"
-	"log/slog"
 	"net"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
-	"github.com/psaab/xpf/pkg/logging"
 )
 
 // SamplingDir tracks per-zone sampling direction flags.
@@ -129,6 +140,89 @@ func BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsC
 	return ec
 }
 
+// BuildIPFIXExportConfig resolves IPFIX config into an ExportConfig.
+// Falls back to v9 collectors/sampling if no IPFIX-specific overrides.
+func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig {
+	if fo == nil || fo.Sampling == nil || len(fo.Sampling.Instances) == 0 {
+		return nil
+	}
+	if svc == nil || svc.FlowMonitoring == nil || svc.FlowMonitoring.VersionIPFIX == nil {
+		return nil
+	}
+
+	activeTimeout := 60 * time.Second
+	inactiveTimeout := 15 * time.Second
+	refreshRate := 60 * time.Second
+
+	for _, tmpl := range svc.FlowMonitoring.VersionIPFIX.Templates {
+		if tmpl.FlowActiveTimeout > 0 {
+			activeTimeout = time.Duration(tmpl.FlowActiveTimeout) * time.Second
+		}
+		if tmpl.FlowInactiveTimeout > 0 {
+			inactiveTimeout = time.Duration(tmpl.FlowInactiveTimeout) * time.Second
+		}
+		if tmpl.TemplateRefreshRate > 0 {
+			refreshRate = time.Duration(tmpl.TemplateRefreshRate) * time.Second
+		}
+		break // use first template
+	}
+
+	ec := &ExportConfig{
+		FlowActiveTimeout:   activeTimeout,
+		FlowInactiveTimeout: inactiveTimeout,
+		TemplateRefreshRate: refreshRate,
+	}
+
+	// Reuse same sampling rate + collectors as v9 (shared forwarding-options)
+	for _, inst := range fo.Sampling.Instances {
+		if inst.InputRate > 0 {
+			ec.SamplingRate = inst.InputRate
+			break
+		}
+	}
+
+	for _, inst := range fo.Sampling.Instances {
+		families := []*config.SamplingFamily{inst.FamilyInet, inst.FamilyInet6}
+		for _, fam := range families {
+			if fam == nil {
+				continue
+			}
+			for _, fs := range fam.FlowServers {
+				addr := fs.Address
+				if fs.Port > 0 {
+					addr = fmt.Sprintf("%s:%d", fs.Address, fs.Port)
+				}
+				srcAddr := fam.SourceAddress
+				if srcAddr == "" {
+					srcAddr = fam.InlineJflowSourceAddress
+				}
+				ec.Collectors = append(ec.Collectors, CollectorConfig{
+					Address:       addr,
+					SourceAddress: srcAddr,
+				})
+			}
+		}
+	}
+
+	if len(ec.Collectors) == 0 {
+		return nil
+	}
+
+	// Deduplicate collectors
+	seen := make(map[string]bool)
+	deduped := ec.Collectors[:0]
+	for _, c := range ec.Collectors {
+		key := collectorKey(c)
+		if !seen[key] {
+			seen[key] = true
+			deduped = append(deduped, c)
+		}
+	}
+	ec.Collectors = deduped
+
+	return ec
+}
+
 // BuildSamplingZones builds a map of zone ID to sampling direction flags.
 // For each zone, it checks whether any interface in that zone has
 // sampling input or output enabled on its unit.
@@ -207,117 +301,26 @@ func parseIfaceRef(ref string) (string, int) {
 	return ref, 0
 }
 
-// Exporter sends NetFlow v9 packets to configured collectors.
-type Exporter struct {
-	cfg             ExportConfig
-	bootTime        time.Time
-	sourceID        uint32
-	fieldsV4        []templateField
-	fieldsV6        []templateField
-	recSizeV4       int
-	recSizeV6       int
-	templateFlowSet []byte
-
-	mu    sync.Mutex
-	seq   uint32
-	conns []net.Conn
-
-	// Batching: accumulate records, flush periodically
-	batchMu sync.Mutex
-	batchV4 []FlowRecord
-	batchV6 []FlowRecord
-
-	// Stats
-	exportedFlows atomic.Uint64
-	exportedPkts  atomic.Uint64
-}
-
-// NewExporter creates a new NetFlow v9 exporter.
-func NewExporter(cfg ExportConfig) (*Exporter, error) {
-	e := &Exporter{
-		cfg:      cfg,
-		bootTime: time.Now(),
-		sourceID: 1,
-		fieldsV4: buildTemplateFieldsV4(cfg.V9TemplateOpts),
-		fieldsV6: buildTemplateFieldsV6(cfg.V9TemplateOpts),
-	}
-	e.recSizeV4 = recordSize(e.fieldsV4)
-	e.recSizeV6 = recordSize(e.fieldsV6)
-	e.templateFlowSet = encodeTemplateFlowSet(cfg.V9TemplateOpts)
-
-	for _, cc := range cfg.Collectors {
-		var conn net.Conn
-		var err error
-		if cc.SourceAddress != "" {
-			laddr, _ := net.ResolveUDPAddr("udp", cc.SourceAddress+":0")
-			raddr, err2 := net.ResolveUDPAddr("udp", cc.Address)
-			if err2 != nil {
-				return nil, fmt.Errorf("resolve collector %s: %w", cc.Address, err2)
-			}
-			conn, err = net.DialUDP("udp", laddr, raddr)
-		} else {
-			conn, err = net.Dial("udp", cc.Address)
-		}
-		if err != nil {
-			// Close already-opened connections
-			for _, c := range e.conns {
-				c.Close()
-			}
-			return nil, fmt.Errorf("dial collector %s: %w", cc.Address, err)
-		}
-		e.conns = append(e.conns, conn)
-	}
-
-	return e, nil
-}
-
-// Run starts the exporter's background goroutines. Blocks until ctx is cancelled.
-func (e *Exporter) Run(ctx context.Context) {
-	// Send initial template
-	e.sendTemplates()
-
-	templateTicker := time.NewTicker(e.cfg.TemplateRefreshRate)
-	defer templateTicker.Stop()
-
-	batchTicker := time.NewTicker(100 * time.Millisecond)
-	defer batchTicker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			// Flush remaining batches
-			e.flushBatches()
-			return
-		case <-templateTicker.C:
-			e.sendTemplates()
-		case <-batchTicker.C:
-			e.flushBatches()
-		}
-	}
-}
-
-// ExportSessionClose converts a session-close event into a flow record and queues it.
-func (e *Exporter) ExportSessionClose(rec logging.EventRecord, evt SessionCloseData) {
-	fr := FlowRecord{
-		SrcIP:     evt.SrcIP,
-		DstIP:     evt.DstIP,
-		SrcPort:   evt.SrcPort,
-		DstPort:   evt.DstPort,
-		Protocol:  evt.Protocol,
-		Packets:   rec.SessionPkts,
-		Bytes:     rec.SessionBytes,
-		StartTime: rec.Time.Add(-estimateSessionDuration(rec.SessionPkts, evt.Protocol)),
-		EndTime:   rec.Time,
-		IsIPv6:    evt.IsIPv6,
-	}
-
-	e.batchMu.Lock()
-	if fr.IsIPv6 {
-		e.batchV6 = append(e.batchV6, fr)
-	} else {
-		e.batchV4 = append(e.batchV4, fr)
-	}
-	e.batchMu.Unlock()
+// FlowRecord holds the data for a single flow, shared by the NetFlow v9
+// and IPFIX encoders.
+type FlowRecord struct {
+	SrcIP     net.IP
+	DstIP     net.IP
+	SrcPort   uint16
+	DstPort   uint16
+	Protocol  uint8
+	TOS       uint8
+	TCPFlags  uint8
+	Direction uint8
+	InIf      uint32
+	OutIf     uint32
+	Packets   uint64
+	Bytes     uint64
+	StartTime time.Time
+	EndTime   time.Time
+	SrcMask   uint8
+	DstMask   uint8
+	IsIPv6    bool
 }
 
 // SessionCloseData holds parsed session data for flow export.
@@ -328,126 +331,6 @@ type SessionCloseData struct {
 	DstPort  uint16
 	Protocol uint8
 	IsIPv6   bool
-}
-
-// Stats returns export statistics.
-func (e *Exporter) Stats() (flows, packets uint64) {
-	return e.exportedFlows.Load(), e.exportedPkts.Load()
-}
-
-// Close shuts down all collector connections.
-func (e *Exporter) Close() {
-	for _, c := range e.conns {
-		c.Close()
-	}
-}
-
-func (e *Exporter) sendTemplates() {
-	e.mu.Lock()
-	seq := e.seq
-	e.seq++
-	e.mu.Unlock()
-
-	now := time.Now()
-	hdr := nfHeader{
-		Version:   9,
-		Count:     2, // 2 templates
-		SysUptime: uptimeMs(e.bootTime, now),
-		UnixSecs:  uint32(now.Unix()),
-		SeqNumber: seq,
-		SourceID:  e.sourceID,
-	}
-
-	pkt := make([]byte, 20+len(e.templateFlowSet))
-	encodeHeaderInto(pkt[:20], hdr)
-	copy(pkt[20:], e.templateFlowSet)
-	for _, c := range e.conns {
-		if _, err := c.Write(pkt); err != nil {
-			slog.Debug("netflow template send failed", "err", err)
-		}
-	}
-}
-
-func (e *Exporter) flushBatches() {
-	e.batchMu.Lock()
-	v4 := e.batchV4
-	v6 := e.batchV6
-	e.batchV4 = nil
-	e.batchV6 = nil
-	e.batchMu.Unlock()
-
-	if len(v4) > 0 {
-		e.sendRecords(v4)
-	}
-	if len(v6) > 0 {
-		e.sendRecords(v6)
-	}
-}
-
-func (e *Exporter) sendRecords(records []FlowRecord) {
-	if len(records) == 0 {
-		return
-	}
-
-	isV6 := records[0].IsIPv6
-	var (
-		fields  []templateField
-		recSize int
-		tmplID  uint16
-	)
-	if isV6 {
-		fields = e.fieldsV6
-		recSize = e.recSizeV6
-		tmplID = templateIDv6
-	} else {
-		fields = e.fieldsV4
-		recSize = e.recSizeV4
-		tmplID = templateIDv4
-	}
-
-	// Split into chunks that fit in maxPayload
-	// Reserve 20 bytes for header + 4 bytes for flowset header
-	maxRecords := (maxPayload - 20 - 4) / recSize
-	if maxRecords < 1 {
-		maxRecords = 1
-	}
-
-	for i := 0; i < len(records); i += maxRecords {
-		end := i + maxRecords
-		if end > len(records) {
-			end = len(records)
-		}
-		batch := records[i:end]
-		dataLen := dataFlowSetLen(len(batch), recSize)
-
-		e.mu.Lock()
-		seq := e.seq
-		e.seq++
-		e.mu.Unlock()
-
-		now := time.Now()
-		hdr := nfHeader{
-			Version:   9,
-			Count:     uint16(len(batch)),
-			SysUptime: uptimeMs(e.bootTime, now),
-			UnixSecs:  uint32(now.Unix()),
-			SeqNumber: seq,
-			SourceID:  e.sourceID,
-		}
-
-		pkt := make([]byte, 20+dataLen)
-		encodeHeaderInto(pkt[:20], hdr)
-		encodeDataFlowSetInto(pkt[20:], batch, e.bootTime,
-			tmplID, fields, recSize)
-		for _, c := range e.conns {
-			if _, err := c.Write(pkt); err != nil {
-				slog.Debug("netflow data send failed", "err", err)
-			}
-		}
-
-		e.exportedFlows.Add(uint64(len(batch)))
-		e.exportedPkts.Add(1)
-	}
 }
 
 // estimateSessionDuration provides a rough duration estimate based on packet count.

--- a/pkg/flowexport/netflow.go
+++ b/pkg/flowexport/netflow.go
@@ -1,10 +1,14 @@
-// Package flowexport implements NetFlow v9 flow data export.
 package flowexport
 
 import (
+	"context"
 	"encoding/binary"
 	"net"
+	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/psaab/xpf/pkg/logging"
 )
 
 // NetFlow v9 field type IDs (RFC 3954).
@@ -158,27 +162,6 @@ func recordSize(fields []templateField) int {
 	// Pad to 4-byte boundary
 	pad := (4 - size%4) % 4
 	return size + pad
-}
-
-// FlowRecord holds the data for a single NetFlow record.
-type FlowRecord struct {
-	SrcIP     net.IP
-	DstIP     net.IP
-	SrcPort   uint16
-	DstPort   uint16
-	Protocol  uint8
-	TOS       uint8
-	TCPFlags  uint8
-	Direction uint8
-	InIf      uint32
-	OutIf     uint32
-	Packets   uint64
-	Bytes     uint64
-	StartTime time.Time
-	EndTime   time.Time
-	SrcMask   uint8
-	DstMask   uint8
-	IsIPv6    bool
 }
 
 // nfHeader is the 20-byte NetFlow v9 packet header.
@@ -410,4 +393,197 @@ func uptimeMs(boot, t time.Time) uint32 {
 		return 0
 	}
 	return uint32(d.Milliseconds())
+}
+
+// Exporter sends NetFlow v9 packets to configured collectors.
+type Exporter struct {
+	cfg             ExportConfig
+	bootTime        time.Time
+	sourceID        uint32
+	fieldsV4        []templateField
+	fieldsV6        []templateField
+	recSizeV4       int
+	recSizeV6       int
+	templateFlowSet []byte
+
+	mu    sync.Mutex
+	seq   uint32
+	conns *collectorConns
+
+	// Batching: accumulate records, flush periodically
+	batch flowBatch
+
+	// Stats
+	exportedFlows atomic.Uint64
+	exportedPkts  atomic.Uint64
+}
+
+// NewExporter creates a new NetFlow v9 exporter.
+func NewExporter(cfg ExportConfig) (*Exporter, error) {
+	e := &Exporter{
+		cfg:      cfg,
+		bootTime: time.Now(),
+		sourceID: 1,
+		fieldsV4: buildTemplateFieldsV4(cfg.V9TemplateOpts),
+		fieldsV6: buildTemplateFieldsV6(cfg.V9TemplateOpts),
+	}
+	e.recSizeV4 = recordSize(e.fieldsV4)
+	e.recSizeV6 = recordSize(e.fieldsV6)
+	e.templateFlowSet = encodeTemplateFlowSet(cfg.V9TemplateOpts)
+
+	conns, err := dialCollectors(cfg.Collectors)
+	if err != nil {
+		return nil, err
+	}
+	e.conns = conns
+
+	return e, nil
+}
+
+// Run starts the exporter's background goroutines. Blocks until ctx is cancelled.
+func (e *Exporter) Run(ctx context.Context) {
+	// Send initial template
+	e.sendTemplates()
+
+	templateTicker := time.NewTicker(e.cfg.TemplateRefreshRate)
+	defer templateTicker.Stop()
+
+	batchTicker := time.NewTicker(100 * time.Millisecond)
+	defer batchTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Flush remaining batches
+			e.flushBatches()
+			return
+		case <-templateTicker.C:
+			e.sendTemplates()
+		case <-batchTicker.C:
+			e.flushBatches()
+		}
+	}
+}
+
+// ExportSessionClose converts a session-close event into a flow record and queues it.
+func (e *Exporter) ExportSessionClose(rec logging.EventRecord, evt SessionCloseData) {
+	fr := FlowRecord{
+		SrcIP:     evt.SrcIP,
+		DstIP:     evt.DstIP,
+		SrcPort:   evt.SrcPort,
+		DstPort:   evt.DstPort,
+		Protocol:  evt.Protocol,
+		Packets:   rec.SessionPkts,
+		Bytes:     rec.SessionBytes,
+		StartTime: rec.Time.Add(-estimateSessionDuration(rec.SessionPkts, evt.Protocol)),
+		EndTime:   rec.Time,
+		IsIPv6:    evt.IsIPv6,
+	}
+
+	e.batch.add(fr)
+}
+
+// Stats returns export statistics.
+func (e *Exporter) Stats() (flows, packets uint64) {
+	return e.exportedFlows.Load(), e.exportedPkts.Load()
+}
+
+// Close shuts down all collector connections.
+func (e *Exporter) Close() {
+	e.conns.close()
+}
+
+func (e *Exporter) sendTemplates() {
+	e.mu.Lock()
+	seq := e.seq
+	e.seq++
+	e.mu.Unlock()
+
+	now := time.Now()
+	hdr := nfHeader{
+		Version:   9,
+		Count:     2, // 2 templates
+		SysUptime: uptimeMs(e.bootTime, now),
+		UnixSecs:  uint32(now.Unix()),
+		SeqNumber: seq,
+		SourceID:  e.sourceID,
+	}
+
+	pkt := make([]byte, 20+len(e.templateFlowSet))
+	encodeHeaderInto(pkt[:20], hdr)
+	copy(pkt[20:], e.templateFlowSet)
+	e.conns.writeAll(pkt, "netflow template send failed")
+}
+
+func (e *Exporter) flushBatches() {
+	v4, v6 := e.batch.drain()
+
+	if len(v4) > 0 {
+		e.sendRecords(v4)
+	}
+	if len(v6) > 0 {
+		e.sendRecords(v6)
+	}
+}
+
+func (e *Exporter) sendRecords(records []FlowRecord) {
+	if len(records) == 0 {
+		return
+	}
+
+	isV6 := records[0].IsIPv6
+	var (
+		fields  []templateField
+		recSize int
+		tmplID  uint16
+	)
+	if isV6 {
+		fields = e.fieldsV6
+		recSize = e.recSizeV6
+		tmplID = templateIDv6
+	} else {
+		fields = e.fieldsV4
+		recSize = e.recSizeV4
+		tmplID = templateIDv4
+	}
+
+	// Split into chunks that fit in maxPayload
+	// Reserve 20 bytes for header + 4 bytes for flowset header
+	maxRecords := (maxPayload - 20 - 4) / recSize
+	if maxRecords < 1 {
+		maxRecords = 1
+	}
+
+	for i := 0; i < len(records); i += maxRecords {
+		end := i + maxRecords
+		if end > len(records) {
+			end = len(records)
+		}
+		batch := records[i:end]
+		dataLen := dataFlowSetLen(len(batch), recSize)
+
+		e.mu.Lock()
+		seq := e.seq
+		e.seq++
+		e.mu.Unlock()
+
+		now := time.Now()
+		hdr := nfHeader{
+			Version:   9,
+			Count:     uint16(len(batch)),
+			SysUptime: uptimeMs(e.bootTime, now),
+			UnixSecs:  uint32(now.Unix()),
+			SeqNumber: seq,
+			SourceID:  e.sourceID,
+		}
+
+		pkt := make([]byte, 20+dataLen)
+		encodeHeaderInto(pkt[:20], hdr)
+		encodeDataFlowSetInto(pkt[20:], batch, e.bootTime,
+			tmplID, fields, recSize)
+		e.conns.writeAll(pkt, "netflow data send failed")
+
+		e.exportedFlows.Add(uint64(len(batch)))
+		e.exportedPkts.Add(1)
+	}
 }

--- a/pkg/flowexport/transport.go
+++ b/pkg/flowexport/transport.go
@@ -1,0 +1,98 @@
+package flowexport
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+)
+
+// collectorConns owns the set of UDP connections to the configured
+// collectors. Both the NetFlow v9 and IPFIX exporters share this
+// connection-management code: the dial loop, the per-packet fan-out
+// write, and teardown are identical between the two protocols.
+type collectorConns struct {
+	conns []net.Conn
+}
+
+// dialCollectors opens a UDP connection to every collector in the list.
+// When a collector specifies a SourceAddress the local bind address is
+// pinned; otherwise the OS selects it. On any dial error all already
+// opened connections are closed and the error is returned.
+func dialCollectors(collectors []CollectorConfig) (*collectorConns, error) {
+	cc := &collectorConns{}
+	for _, c := range collectors {
+		var conn net.Conn
+		var err error
+		if c.SourceAddress != "" {
+			laddr, _ := net.ResolveUDPAddr("udp", c.SourceAddress+":0")
+			raddr, err2 := net.ResolveUDPAddr("udp", c.Address)
+			if err2 != nil {
+				return nil, fmt.Errorf("resolve collector %s: %w", c.Address, err2)
+			}
+			conn, err = net.DialUDP("udp", laddr, raddr)
+		} else {
+			conn, err = net.Dial("udp", c.Address)
+		}
+		if err != nil {
+			// Close already-opened connections.
+			for _, opened := range cc.conns {
+				opened.Close()
+			}
+			return nil, fmt.Errorf("dial collector %s: %w", c.Address, err)
+		}
+		cc.conns = append(cc.conns, conn)
+	}
+	return cc, nil
+}
+
+// writeAll transmits pkt to every collector connection. Write failures
+// are logged at debug level using errMsg; a failure to one collector
+// does not stop delivery to the others.
+func (cc *collectorConns) writeAll(pkt []byte, errMsg string) {
+	for _, c := range cc.conns {
+		if _, err := c.Write(pkt); err != nil {
+			slog.Debug(errMsg, "err", err)
+		}
+	}
+}
+
+// close shuts down all collector connections.
+func (cc *collectorConns) close() {
+	for _, c := range cc.conns {
+		c.Close()
+	}
+}
+
+// flowBatch accumulates flow records pending export, split by address
+// family. The export loop drains it on a periodic ticker (and on
+// shutdown) and hands each non-empty slice to the protocol-specific
+// send path. The split is by family, not by zone.
+type flowBatch struct {
+	mu sync.Mutex
+	v4 []FlowRecord
+	v6 []FlowRecord
+}
+
+// add queues a record into the appropriate per-family batch.
+func (b *flowBatch) add(fr FlowRecord) {
+	b.mu.Lock()
+	if fr.IsIPv6 {
+		b.v6 = append(b.v6, fr)
+	} else {
+		b.v4 = append(b.v4, fr)
+	}
+	b.mu.Unlock()
+}
+
+// drain atomically removes and returns the accumulated v4 and v6
+// records, resetting both batches to empty.
+func (b *flowBatch) drain() (v4, v6 []FlowRecord) {
+	b.mu.Lock()
+	v4 = b.v4
+	v6 = b.v6
+	b.v4 = nil
+	b.v6 = nil
+	b.mu.Unlock()
+	return v4, v6
+}


### PR DESCRIPTION
## Summary

Decomposes `pkg/flowexport` into responsibility-scoped files and dedups
the UDP transport code that the NetFlow v9 and IPFIX exporters each
carried a private copy of. Closes #1988 (AGY review 012 Part II.3
modularity backlog).

This is **pure code motion plus the extraction of two shared transport
helpers**. The public API is unchanged and the encoding/config logic is
byte-identical to before the split.

## New layout

| File | Responsibility |
|------|----------------|
| `manager.go` | Resolved `ExportConfig`/`CollectorConfig`/`SamplingDir`, the shared `FlowRecord` + `SessionCloseData` shapes, the sampling scheduler (`ShouldExport`), and the `BuildExportConfig` / `BuildIPFIXExportConfig` / `BuildSamplingZones` resolvers. |
| `netflow.go` | Renamed from `netflow9.go`. NetFlow v9 template/record encoding (unchanged) plus the `Exporter`. |
| `ipfix.go` | IPFIX (v10) template/record encoding (unchanged) plus the `IPFIXExporter`; its config resolver moved to `manager.go`. |
| `transport.go` | New. `collectorConns` owns the dial loop, the per-packet fan-out write, and teardown that were duplicated line-for-line across `NewExporter`/`NewIPFIXExporter` and their send paths. `flowBatch` owns the per-family (v4/v6) record accumulation and atomic drain. |

`exporter.go` is removed; its content is split between `manager.go`
(config/scheduler/shared types) and `netflow.go` (the `Exporter`).

## Behavior preservation

- Both exporters now hold a `*collectorConns` and a `flowBatch` instead
  of open-coding `conns` / `batchMu` / `batchV4` / `batchV6`. The dial,
  write-to-all-collectors, and per-family batch/flush semantics are
  identical (the distinct debug log strings — `netflow ... send failed`
  vs `ipfix ... send failed` — are preserved via the `errMsg` argument).
- `dialCollectors` takes `[]CollectorConfig` (not the whole
  `ExportConfig`) so the shared helper does not copy the atomic
  `sampleCounter`. `go vet` on the package is unchanged from master: the
  two pre-existing "passes lock by value" warnings on
  `NewExporter`/`NewIPFIXExporter` remain; **no new warnings** are
  introduced.
- The encode and config-resolver function bodies were verified
  byte-identical to `origin/master` via per-function diff.

## Validation

- `go test ./...` green (the one intermittent `pkg/dataplane/userspace`
  flake is pre-existing on clean master, does not import `flowexport`,
  and reproduces only under parallel-load timing).
- `pkg/flowexport` package tests pass.
- `gofmt -l` clean; `go vet` clean (no new findings) on the changed
  files.
- `pkg/flowexport/README.md` updated with the new file map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
