### PR TITLE
#2006: group pkg/vrrp into manager/instance/packet/track

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,23 @@
 # Action Log
 
+## 2026-06-18 — #2006 group pkg/vrrp into manager/instance/packet/track
+
+- **Timestamp**: 2026-06-18
+- **Action**: Pure code-motion refactor of the flat `pkg/vrrp` package
+  (same package, no import-path or visibility change). Extracted the
+  interface-tracking cluster (#1814) into a new `track.go`: the
+  per-instance effective-priority primitives `getPriority`,
+  `setTrackDown`, `trackedInterface` (from `instance.go`) and the
+  manager-side singleton link-watcher / poller `ensureLinkWatcherLocked`,
+  `runLinkWatcher`, `runLinkPoller`, `pollTrackedLinks`,
+  `applyTrackedLinkState`, `seedTrackState`, `netlinkLinkState`,
+  `linkAttrsUp` (from `manager.go`). Function bodies moved byte-identical
+  (verified by awk-extract diff). gofmt re-aligned a few struct-comment
+  columns in the touched files (cosmetic, tokens unchanged). README
+  updated with a file-layout section and track.go references.
+- **File(s)**: pkg/vrrp/track.go (new), pkg/vrrp/instance.go,
+  pkg/vrrp/manager.go, pkg/vrrp/README.md, _Log.md
+
 ## 2026-06-17 — #1956 startup naming helper coverage
 
 - **Timestamp**: 2026-06-17

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -27,6 +27,22 @@ This is the package that drives chassis-cluster failover.
 - `ResignRG(rgID int)` — `manager.go`. Forces this node out of master
   for the given redundancy group ID.
 
+## File layout
+
+- `manager.go` — redundancy-group coordinator: `Manager`, instance
+  diff/lifecycle, sync-hold, RG force/resign helpers, socket helpers.
+- `instance.go` — per-instance state machine, RX receivers, advert
+  send, VIP add/remove, GARP/NA.
+- `packet.go` — VRRPv3 advert parser/builder + IPv4/IPv6 checksums.
+- `track.go` — interface tracking (#1814): the per-instance
+  effective-priority primitives (`getPriority`, `setTrackDown`,
+  `trackedInterface`) and the manager-side singleton link-watcher /
+  poller (`runLinkWatcher`, `runLinkPoller`, `pollTrackedLinks`,
+  `applyTrackedLinkState`, `seedTrackState`, `netlinkLinkState`,
+  `linkAttrsUp`).
+- `vrrp.go` — `Instance` config type plus `CollectInstances` /
+  `CollectRethInstances` config extraction.
+
 ## Callers
 
 `pkg/daemon`, `pkg/api`, `pkg/grpcapi`, `pkg/cli`.
@@ -57,7 +73,7 @@ present. Multiple `track-interface` statements in one group are rejected
 at commit (strict) and first-wins with a warning on the tolerant
 load/peer-sync compile paths.
 
-- **Effective priority** — `getPriority()` (`instance.go`) returns
+- **Effective priority** — `getPriority()` (`track.go`) returns
   `Priority - TrackPriorityCost` clamped to **[1, 254]** while the
   tracked link is down. Tracking can never fabricate the priority-0
   resignation sentinel (priority 0 passes through unchanged), and
@@ -65,7 +81,7 @@ load/peer-sync compile paths.
   while still holding the address invites duplicate-IP conflicts; the
   compiler warns instead.
 - **Link watcher** — ONE singleton goroutine per Manager
-  (`runLinkWatcher`, `manager.go`), started lazily when an instance
+  (`runLinkWatcher`, `track.go`), started lazily when an instance
   tracks an interface; latched under the manager mutex so
   `UpdateInstances` churn never spawns a second. Subscribes via
   `netlink.LinkSubscribe` with done-channel cancellation closed from

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -85,9 +85,9 @@ type vrrpInstance struct {
 	stopped chan struct{}
 
 	// RX backpressure counters (atomic).
-	rxDrops    atomic.Uint64 // packets dropped due to full rxCh
-	rxReceived atomic.Uint64 // total packets delivered to rxCh
-	lastDropWarn time.Time    // last time we logged a drop warning (rate-limited)
+	rxDrops      atomic.Uint64 // packets dropped due to full rxCh
+	rxReceived   atomic.Uint64 // total packets delivered to rxCh
+	lastDropWarn time.Time     // last time we logged a drop warning (rate-limited)
 
 	// GARP suppression for strict-vip-ownership mode.
 	suppressGARP  atomic.Bool   // when true, becomeMaster() skips GARP/NA
@@ -247,69 +247,6 @@ func (vi *vrrpInstance) triggerResign() {
 	case vi.resignCh <- struct{}{}:
 	default:
 	}
-}
-
-// getPriority returns the effective advertised priority (#1814).
-//   - cfg.Priority 0 is the resignation sentinel (ResignRG / shutdown
-//     burst) and passes through UNCHANGED — the tracking clamp must
-//     never apply to it.
-//   - cfg.Priority 255 is the IP address owner: tracking is ignored
-//     (an owner stepping down while still holding the address invites
-//     duplicate-IP conflicts; the compiler warns at commit).
-//   - Otherwise, while the tracked interface is down, TrackPriorityCost
-//     is subtracted and the result clamped to [1, 254] so tracking can
-//     never fabricate the priority-0 resignation sentinel.
-//
-// The no-track path returns cfg.Priority unchanged. Called from the
-// advert path and masterDownInterval computation — keep it lock-cheap.
-func (vi *vrrpInstance) getPriority() int {
-	vi.mu.RLock()
-	defer vi.mu.RUnlock()
-	p := vi.cfg.Priority
-	if p == 0 || p == 255 {
-		return p
-	}
-	if vi.trackDown && vi.cfg.TrackInterface != "" {
-		p -= vi.cfg.TrackPriorityCost
-		if p < 1 {
-			p = 1
-		} else if p > 254 {
-			p = 254
-		}
-	}
-	return p
-}
-
-// setTrackDown records the tracked interface's link state. Logs only on
-// transition — never per-event.
-//
-// The state machine needs no kick. A MASTER keeps advertising at the
-// new (lower) effective priority via getPriority(); a preempt-enabled
-// backup hearing that LOWER advert IGNORES it and lets its masterDown
-// timer expire (handleBackupRx tail — instance.go:737 at plan time:
-// "If preempt is true and incoming priority < ours, ignore — let timer
-// expire"). So takeover after a tracked-link demotion lands in
-// ~masterDownInterval (3×advert+skew: ≈97ms at 30ms adverts, ≈3.3s at
-// 1s adverts) — RFC 5798 behavior, no forced abdication.
-func (vi *vrrpInstance) setTrackDown(down bool) {
-	vi.mu.Lock()
-	changed := vi.trackDown != down
-	vi.trackDown = down
-	trackIface := vi.cfg.TrackInterface
-	vi.mu.Unlock()
-	if changed && trackIface != "" {
-		slog.Info("vrrp: tracked interface state change",
-			"key", vi.key(), "track_interface", trackIface,
-			"down", down, "effective_priority", vi.getPriority())
-	}
-}
-
-// trackedInterface returns the tracked Linux interface name, or "" when
-// tracking is not configured.
-func (vi *vrrpInstance) trackedInterface() string {
-	vi.mu.RLock()
-	defer vi.mu.RUnlock()
-	return vi.cfg.TrackInterface
 }
 
 func (vi *vrrpInstance) getPreempt() bool {

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -25,15 +25,15 @@ type instanceKey struct {
 
 // Manager manages all VRRP instances.
 type Manager struct {
-	mu              sync.RWMutex
-	instances       map[instanceKey]*vrrpInstance
-	eventCh         chan VRRPEvent
-	closeEventOnce  sync.Once   // guards closing eventCh
-	cancel          context.CancelFunc
-	syncHold        bool        // suppress preemption until session sync completes
-	syncHoldTimer   *time.Timer // safety timeout to release hold
-	syncHoldReason  string      // "bulk-sync-complete" or "timeout-degraded"
-	onEventDrop     func()      // called when an event is dropped (full channel)
+	mu             sync.RWMutex
+	instances      map[instanceKey]*vrrpInstance
+	eventCh        chan VRRPEvent
+	closeEventOnce sync.Once // guards closing eventCh
+	cancel         context.CancelFunc
+	syncHold       bool        // suppress preemption until session sync completes
+	syncHoldTimer  *time.Timer // safety timeout to release hold
+	syncHoldReason string      // "bulk-sync-complete" or "timeout-degraded"
+	onEventDrop    func()      // called when an event is dropped (full channel)
 
 	// Interface tracking (#1814): ONE singleton link-watcher goroutine
 	// feeds trackDown into instances whose cfg.TrackInterface matches.
@@ -285,154 +285,6 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 	}
 
 	return nil
-}
-
-// ensureLinkWatcherLocked starts the singleton link-watcher goroutine.
-// Caller MUST hold m.mu: watcherRunning latches under the manager mutex
-// so UpdateInstances churn can never spawn a second watcher (#1814).
-func (m *Manager) ensureLinkWatcherLocked() {
-	if m.watcherRunning {
-		return
-	}
-	m.watcherRunning = true
-	m.watcherStarts++
-	go m.runLinkWatcher()
-}
-
-// runLinkWatcher is the singleton tracked-link watcher (#1814). It
-// subscribes to netlink link updates and pushes trackDown into every
-// instance tracking the affected interface. The tracked-ifname →
-// instance mapping is re-read from the manager under lock on EVERY
-// event — instance churn is never captured stale. Cancellation follows
-// the done-channel pattern (pkg/daemon/daemon_flow.go): m.watcherStop
-// is closed from Manager.Stop and the netlink subscription observes the
-// same channel. On subscribe failure (or unexpected subscription close)
-// it degrades to a 1 s poll that runs only while tracked instances
-// exist.
-func (m *Manager) runLinkWatcher() {
-	ch := make(chan netlink.LinkUpdate, 64)
-	if err := m.subscribeLinks(ch, m.watcherStop); err != nil {
-		slog.Warn("vrrp: link subscribe failed, falling back to 1s link polling", "err", err)
-		m.runLinkPoller()
-		return
-	}
-	slog.Info("vrrp: link watcher started (interface tracking)")
-	for {
-		select {
-		case <-m.watcherStop:
-			return
-		case u, ok := <-ch:
-			if !ok {
-				select {
-				case <-m.watcherStop:
-					return
-				default:
-				}
-				slog.Warn("vrrp: link subscription closed, falling back to 1s link polling")
-				m.runLinkPoller()
-				return
-			}
-			attrs := u.Attrs()
-			if attrs == nil {
-				continue
-			}
-			up := u.Header.Type != unix.RTM_DELLINK && linkAttrsUp(attrs)
-			m.applyTrackedLinkState(attrs.Name, up)
-		}
-	}
-}
-
-// runLinkPoller is the subscribe-failure fallback: poll tracked link
-// state at 1 s. pollTrackedLinks performs no netlink queries while no
-// instance tracks an interface.
-func (m *Manager) runLinkPoller() {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-m.watcherStop:
-			return
-		case <-ticker.C:
-			m.pollTrackedLinks()
-		}
-	}
-}
-
-// pollTrackedLinks queries link state once for each distinct tracked
-// interface and applies it to the tracking instances.
-func (m *Manager) pollTrackedLinks() {
-	m.mu.RLock()
-	tracked := make(map[string][]*vrrpInstance)
-	for _, vi := range m.instances {
-		if name := vi.trackedInterface(); name != "" {
-			tracked[name] = append(tracked[name], vi)
-		}
-	}
-	m.mu.RUnlock()
-	for name, vis := range tracked {
-		up, err := m.linkState(name)
-		down := err != nil || !up
-		for _, vi := range vis {
-			vi.setTrackDown(down)
-		}
-	}
-}
-
-// applyTrackedLinkState updates trackDown on every instance tracking
-// ifName. Takes only the manager read lock; setTrackDown takes the
-// per-instance lock (no reverse ordering exists — instances never take
-// m.mu).
-func (m *Manager) applyTrackedLinkState(ifName string, up bool) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	for _, vi := range m.instances {
-		if vi.trackedInterface() == ifName {
-			vi.setTrackDown(!up)
-		}
-	}
-}
-
-// seedTrackState initializes an instance's trackDown from current
-// kernel link state at instance create/update time (the netlink
-// subscription only streams future updates). A missing tracked
-// interface counts as down.
-func (m *Manager) seedTrackState(vi *vrrpInstance, trackIface string) {
-	if trackIface == "" {
-		vi.setTrackDown(false)
-		return
-	}
-	up, err := m.linkState(trackIface)
-	if err != nil {
-		slog.Warn("vrrp: tracked interface lookup failed, treating as down",
-			"key", vi.key(), "track_interface", trackIface, "err", err)
-		vi.setTrackDown(true)
-		return
-	}
-	vi.setTrackDown(!up)
-}
-
-// netlinkLinkState is the production linkState seam: report whether the
-// named link is operationally up.
-func netlinkLinkState(name string) (bool, error) {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return false, err
-	}
-	return linkAttrsUp(link.Attrs()), nil
-}
-
-// linkAttrsUp interprets link operational state. OperUnknown is common
-// on virtual devices that report no carrier state — fall back to the
-// IFF_UP admin flag there.
-func linkAttrsUp(attrs *netlink.LinkAttrs) bool {
-	switch attrs.OperState {
-	case netlink.OperUp:
-		return true
-	case netlink.OperUnknown:
-		return attrs.Flags&net.FlagUp != 0
-	default:
-		return false
-	}
 }
 
 // ResignRG forces all VRRP instances for the given redundancy group
@@ -750,36 +602,36 @@ func openAfPacketReceiver(ifIndex int) (int, error) {
 	//
 	// Jump offsets (Jt/Jf) are relative to the NEXT instruction.
 	filter := []unix.SockFilter{
-		{Code: 0x28, K: 12},                     //  0: ldh [12] — ethertype
+		{Code: 0x28, K: 12},                    //  0: ldh [12] — ethertype
 		{Code: 0x15, Jt: 7, Jf: 0, K: 0x0800},  //  1: jeq 0x0800 → 9 (check_ipv4)
 		{Code: 0x15, Jt: 10, Jf: 0, K: 0x86DD}, //  2: jeq 0x86DD → 13 (check_ipv6)
 		{Code: 0x15, Jt: 1, Jf: 0, K: 0x8100},  //  3: jeq 0x8100 → 5 (check_vlan); else reject
-		{Code: 0x06, K: 0},                      //  4: ret reject
+		{Code: 0x06, K: 0},                     //  4: ret reject
 		// check_vlan:
-		{Code: 0x28, K: 16},                     //  5: ldh [16] — real ethertype
+		{Code: 0x28, K: 16},                    //  5: ldh [16] — real ethertype
 		{Code: 0x15, Jt: 10, Jf: 0, K: 0x0800}, //  6: jeq 0x0800 → 17 (check_ipv4_vlan)
 		{Code: 0x15, Jt: 13, Jf: 0, K: 0x86DD}, //  7: jeq 0x86DD → 21 (check_ipv6_vlan)
-		{Code: 0x06, K: 0},                      //  8: ret reject
+		{Code: 0x06, K: 0},                     //  8: ret reject
 		// check_ipv4: proto at 14+9=23
-		{Code: 0x30, K: 23},                     //  9: ldb [23]
-		{Code: 0x15, Jt: 0, Jf: 1, K: 112},     // 10: jeq 112 → accept; else reject
-		{Code: 0x06, K: 0xFFFFFFFF},             // 11: ret accept
-		{Code: 0x06, K: 0},                      // 12: ret reject
+		{Code: 0x30, K: 23},                //  9: ldb [23]
+		{Code: 0x15, Jt: 0, Jf: 1, K: 112}, // 10: jeq 112 → accept; else reject
+		{Code: 0x06, K: 0xFFFFFFFF},        // 11: ret accept
+		{Code: 0x06, K: 0},                 // 12: ret reject
 		// check_ipv6: next-header at 14+6=20
-		{Code: 0x30, K: 20},                     // 13: ldb [20]
-		{Code: 0x15, Jt: 0, Jf: 1, K: 112},     // 14: jeq 112 → accept; else reject
-		{Code: 0x06, K: 0xFFFFFFFF},             // 15: ret accept
-		{Code: 0x06, K: 0},                      // 16: ret reject
+		{Code: 0x30, K: 20},                // 13: ldb [20]
+		{Code: 0x15, Jt: 0, Jf: 1, K: 112}, // 14: jeq 112 → accept; else reject
+		{Code: 0x06, K: 0xFFFFFFFF},        // 15: ret accept
+		{Code: 0x06, K: 0},                 // 16: ret reject
 		// check_ipv4_vlan: proto at 18+9=27
-		{Code: 0x30, K: 27},                     // 17: ldb [27]
-		{Code: 0x15, Jt: 0, Jf: 1, K: 112},     // 18: jeq 112 → accept; else reject
-		{Code: 0x06, K: 0xFFFFFFFF},             // 19: ret accept
-		{Code: 0x06, K: 0},                      // 20: ret reject
+		{Code: 0x30, K: 27},                // 17: ldb [27]
+		{Code: 0x15, Jt: 0, Jf: 1, K: 112}, // 18: jeq 112 → accept; else reject
+		{Code: 0x06, K: 0xFFFFFFFF},        // 19: ret accept
+		{Code: 0x06, K: 0},                 // 20: ret reject
 		// check_ipv6_vlan: next-header at 18+6=24
-		{Code: 0x30, K: 24},                     // 21: ldb [24]
-		{Code: 0x15, Jt: 0, Jf: 1, K: 112},     // 22: jeq 112 → accept; else reject
-		{Code: 0x06, K: 0xFFFFFFFF},             // 23: ret accept
-		{Code: 0x06, K: 0},                      // 24: ret reject
+		{Code: 0x30, K: 24},                // 21: ldb [24]
+		{Code: 0x15, Jt: 0, Jf: 1, K: 112}, // 22: jeq 112 → accept; else reject
+		{Code: 0x06, K: 0xFFFFFFFF},        // 23: ret accept
+		{Code: 0x06, K: 0},                 // 24: ret reject
 	}
 	if err := unix.SetsockoptSockFprog(fd, unix.SOL_SOCKET, unix.SO_ATTACH_FILTER, &unix.SockFprog{
 		Len:    uint16(len(filter)),

--- a/pkg/vrrp/track.go
+++ b/pkg/vrrp/track.go
@@ -1,0 +1,228 @@
+package vrrp
+
+import (
+	"log/slog"
+	"net"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/vishvananda/netlink"
+)
+
+// Interface tracking (#1814). Single-interface tracking per VRRP group
+// lowers the advertised priority while the tracked link is down so a
+// healthy peer can take over. This file owns both the per-instance
+// effective-priority primitives and the manager-side singleton
+// link-watcher / poller that feeds link state into tracking instances.
+
+// getPriority returns the effective advertised priority (#1814).
+//   - cfg.Priority 0 is the resignation sentinel (ResignRG / shutdown
+//     burst) and passes through UNCHANGED — the tracking clamp must
+//     never apply to it.
+//   - cfg.Priority 255 is the IP address owner: tracking is ignored
+//     (an owner stepping down while still holding the address invites
+//     duplicate-IP conflicts; the compiler warns at commit).
+//   - Otherwise, while the tracked interface is down, TrackPriorityCost
+//     is subtracted and the result clamped to [1, 254] so tracking can
+//     never fabricate the priority-0 resignation sentinel.
+//
+// The no-track path returns cfg.Priority unchanged. Called from the
+// advert path and masterDownInterval computation — keep it lock-cheap.
+func (vi *vrrpInstance) getPriority() int {
+	vi.mu.RLock()
+	defer vi.mu.RUnlock()
+	p := vi.cfg.Priority
+	if p == 0 || p == 255 {
+		return p
+	}
+	if vi.trackDown && vi.cfg.TrackInterface != "" {
+		p -= vi.cfg.TrackPriorityCost
+		if p < 1 {
+			p = 1
+		} else if p > 254 {
+			p = 254
+		}
+	}
+	return p
+}
+
+// setTrackDown records the tracked interface's link state. Logs only on
+// transition — never per-event.
+//
+// The state machine needs no kick. A MASTER keeps advertising at the
+// new (lower) effective priority via getPriority(); a preempt-enabled
+// backup hearing that LOWER advert IGNORES it and lets its masterDown
+// timer expire (handleBackupRx tail — instance.go:737 at plan time:
+// "If preempt is true and incoming priority < ours, ignore — let timer
+// expire"). So takeover after a tracked-link demotion lands in
+// ~masterDownInterval (3×advert+skew: ≈97ms at 30ms adverts, ≈3.3s at
+// 1s adverts) — RFC 5798 behavior, no forced abdication.
+func (vi *vrrpInstance) setTrackDown(down bool) {
+	vi.mu.Lock()
+	changed := vi.trackDown != down
+	vi.trackDown = down
+	trackIface := vi.cfg.TrackInterface
+	vi.mu.Unlock()
+	if changed && trackIface != "" {
+		slog.Info("vrrp: tracked interface state change",
+			"key", vi.key(), "track_interface", trackIface,
+			"down", down, "effective_priority", vi.getPriority())
+	}
+}
+
+// trackedInterface returns the tracked Linux interface name, or "" when
+// tracking is not configured.
+func (vi *vrrpInstance) trackedInterface() string {
+	vi.mu.RLock()
+	defer vi.mu.RUnlock()
+	return vi.cfg.TrackInterface
+}
+
+// ensureLinkWatcherLocked starts the singleton link-watcher goroutine.
+// Caller MUST hold m.mu: watcherRunning latches under the manager mutex
+// so UpdateInstances churn can never spawn a second watcher (#1814).
+func (m *Manager) ensureLinkWatcherLocked() {
+	if m.watcherRunning {
+		return
+	}
+	m.watcherRunning = true
+	m.watcherStarts++
+	go m.runLinkWatcher()
+}
+
+// runLinkWatcher is the singleton tracked-link watcher (#1814). It
+// subscribes to netlink link updates and pushes trackDown into every
+// instance tracking the affected interface. The tracked-ifname →
+// instance mapping is re-read from the manager under lock on EVERY
+// event — instance churn is never captured stale. Cancellation follows
+// the done-channel pattern (pkg/daemon/daemon_flow.go): m.watcherStop
+// is closed from Manager.Stop and the netlink subscription observes the
+// same channel. On subscribe failure (or unexpected subscription close)
+// it degrades to a 1 s poll that runs only while tracked instances
+// exist.
+func (m *Manager) runLinkWatcher() {
+	ch := make(chan netlink.LinkUpdate, 64)
+	if err := m.subscribeLinks(ch, m.watcherStop); err != nil {
+		slog.Warn("vrrp: link subscribe failed, falling back to 1s link polling", "err", err)
+		m.runLinkPoller()
+		return
+	}
+	slog.Info("vrrp: link watcher started (interface tracking)")
+	for {
+		select {
+		case <-m.watcherStop:
+			return
+		case u, ok := <-ch:
+			if !ok {
+				select {
+				case <-m.watcherStop:
+					return
+				default:
+				}
+				slog.Warn("vrrp: link subscription closed, falling back to 1s link polling")
+				m.runLinkPoller()
+				return
+			}
+			attrs := u.Attrs()
+			if attrs == nil {
+				continue
+			}
+			up := u.Header.Type != unix.RTM_DELLINK && linkAttrsUp(attrs)
+			m.applyTrackedLinkState(attrs.Name, up)
+		}
+	}
+}
+
+// runLinkPoller is the subscribe-failure fallback: poll tracked link
+// state at 1 s. pollTrackedLinks performs no netlink queries while no
+// instance tracks an interface.
+func (m *Manager) runLinkPoller() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.watcherStop:
+			return
+		case <-ticker.C:
+			m.pollTrackedLinks()
+		}
+	}
+}
+
+// pollTrackedLinks queries link state once for each distinct tracked
+// interface and applies it to the tracking instances.
+func (m *Manager) pollTrackedLinks() {
+	m.mu.RLock()
+	tracked := make(map[string][]*vrrpInstance)
+	for _, vi := range m.instances {
+		if name := vi.trackedInterface(); name != "" {
+			tracked[name] = append(tracked[name], vi)
+		}
+	}
+	m.mu.RUnlock()
+	for name, vis := range tracked {
+		up, err := m.linkState(name)
+		down := err != nil || !up
+		for _, vi := range vis {
+			vi.setTrackDown(down)
+		}
+	}
+}
+
+// applyTrackedLinkState updates trackDown on every instance tracking
+// ifName. Takes only the manager read lock; setTrackDown takes the
+// per-instance lock (no reverse ordering exists — instances never take
+// m.mu).
+func (m *Manager) applyTrackedLinkState(ifName string, up bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, vi := range m.instances {
+		if vi.trackedInterface() == ifName {
+			vi.setTrackDown(!up)
+		}
+	}
+}
+
+// seedTrackState initializes an instance's trackDown from current
+// kernel link state at instance create/update time (the netlink
+// subscription only streams future updates). A missing tracked
+// interface counts as down.
+func (m *Manager) seedTrackState(vi *vrrpInstance, trackIface string) {
+	if trackIface == "" {
+		vi.setTrackDown(false)
+		return
+	}
+	up, err := m.linkState(trackIface)
+	if err != nil {
+		slog.Warn("vrrp: tracked interface lookup failed, treating as down",
+			"key", vi.key(), "track_interface", trackIface, "err", err)
+		vi.setTrackDown(true)
+		return
+	}
+	vi.setTrackDown(!up)
+}
+
+// netlinkLinkState is the production linkState seam: report whether the
+// named link is operationally up.
+func netlinkLinkState(name string) (bool, error) {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return false, err
+	}
+	return linkAttrsUp(link.Attrs()), nil
+}
+
+// linkAttrsUp interprets link operational state. OperUnknown is common
+// on virtual devices that report no carrier state — fall back to the
+// IFF_UP admin flag there.
+func linkAttrsUp(attrs *netlink.LinkAttrs) bool {
+	switch attrs.OperState {
+	case netlink.OperUp:
+		return true
+	case netlink.OperUnknown:
+		return attrs.Flags&net.FlagUp != 0
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Pure code-motion refactor of the flat `pkg/vrrp` package (#2006). Same
package — intra-package file reorganization only, so NO import-path
churn, NO visibility change, NO cycle risk.

## What moved

The interface-tracking subsystem (#1814) was split across two files and
is now collected into a new `track.go` (same `package vrrp`):

- From `instance.go` → `track.go`: `getPriority`, `setTrackDown`,
  `trackedInterface` (per-instance effective-priority primitives).
- From `manager.go` → `track.go`: `ensureLinkWatcherLocked`,
  `runLinkWatcher`, `runLinkPoller`, `pollTrackedLinks`,
  `applyTrackedLinkState`, `seedTrackState`, `netlinkLinkState`,
  `linkAttrsUp` (singleton link watcher / poll fallback).

The `Manager` struct's tracking fields stay in `manager.go` and the
`vrrpInstance.trackDown` field stays in `instance.go` (struct
definitions are single-file). `packet.go` and `vrrp.go` are unchanged.

## Byte-preserving

Function bodies were moved byte-identical (verified by extracting each
moved function from `HEAD` and diffing against `track.go` — empty diff).
Nothing changed in the priority-cost demotion clamp `[1,254]`, the
priority-0 resignation passthrough, the priority-255 owner exemption,
the singleton-watcher latch under `m.mu`, the 1s poll fallback, GARP, or
any timing. gofmt re-aligned a few struct-comment columns in the two
touched files (cosmetic; code tokens unchanged).

## Line counts

| file | before | after |
|------|--------|-------|
| instance.go | 1266 | 1203 |
| manager.go | 872 | 724 |
| packet.go | 205 | 205 |
| vrrp.go | 250 | 250 |
| track.go | — | 228 (new) |

## Validation

- `go build ./...` clean
- `go test ./pkg/vrrp/...` → `ok` (pre-existing `track_test.go` suite —
  `TestGetPriority_TrackMatrix`, `TestSetTrackDown_Transition`,
  `TestLinkWatcher_*`, `TestPollTrackedLinks` — passes unchanged)
- `go vet ./pkg/vrrp/...` clean

Docs: `pkg/vrrp/README.md` gains a File layout section and repoints the
tracking entries to `track.go`; `_Log.md` records the change.

NEEDS LAB: make test-failover (cluster) + full quad review before merge (failover-sensitive, queued by campaign owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)