### PR TITLE
#2003: split afxdp/bpf_map/mod.rs into pin/metrics/ha

### DIFF
--- a/userspace-dp/src/afxdp/bpf_map/ha.rs
+++ b/userspace-dp/src/afxdp/bpf_map/ha.rs
@@ -1,0 +1,155 @@
+// Redundancy-group active-validation / liveness slot helpers.
+//
+// Pure code motion out of `bpf_map/mod.rs` (#2003): the XSK-slot and
+// per-binding heartbeat-slot map writes that gate active-binding state
+// now live here. These functions write the `xsks_map` and `heartbeat`
+// BPF maps the XDP shim consults to decide whether a binding is live,
+// so they back the HA "is this redundancy-group member active" check.
+//
+// Behaviour-preserving: signatures, side effects, error/log strings, and
+// the `HEARTBEAT_UPDATE_INTERVAL_NS` / `HEARTBEAT_STALE_AFTER` gating are
+// unchanged from the pre-split orchestrator. The orchestrator-level call
+// sites resolve these via the `bpf_map` re-export, exactly as before.
+//
+// Precedent: the sibling `publish_conntrack.rs` split (#1356).
+
+use super::*;
+
+pub(in crate::afxdp) fn register_xsk_slot(
+    map_fd: c_int,
+    slot: u32,
+    sock_fd: c_int,
+) -> io::Result<()> {
+    let rc = unsafe {
+        libbpf_sys::bpf_map_update_elem(
+            map_fd,
+            (&slot as *const u32).cast::<c_void>(),
+            (&sock_fd as *const c_int).cast::<c_void>(),
+            libbpf_sys::BPF_ANY as u64,
+        )
+    };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+pub(in crate::afxdp) fn update_heartbeat_slot(
+    map_fd: c_int,
+    slot: u32,
+    timestamp_ns: u64,
+) -> io::Result<()> {
+    let rc = unsafe {
+        libbpf_sys::bpf_map_update_elem(
+            map_fd,
+            (&slot as *const u32).cast::<c_void>(),
+            (&timestamp_ns as *const u64).cast::<c_void>(),
+            libbpf_sys::BPF_ANY as u64,
+        )
+    };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+pub(in crate::afxdp) fn delete_xsk_slot(map_fd: c_int, slot: u32) -> io::Result<()> {
+    let rc =
+        unsafe { libbpf_sys::bpf_map_delete_elem(map_fd, (&slot as *const u32).cast::<c_void>()) };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+pub(in crate::afxdp) fn delete_heartbeat_slot(map_fd: c_int, slot: u32) -> io::Result<()> {
+    let rc =
+        unsafe { libbpf_sys::bpf_map_delete_elem(map_fd, (&slot as *const u32).cast::<c_void>()) };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+pub(in crate::afxdp) fn maybe_touch_heartbeat(binding: &mut BindingWorker, now_ns: u64) {
+    // The fill ring is primed before bind, so the driver's initial NAPI
+    // posts WQEs immediately. All queues should be ready to receive.
+    // No xsk_rx_confirmed gating needed.
+    let age_ns = now_ns.saturating_sub(binding.timers.last_heartbeat_update_ns);
+    if age_ns < HEARTBEAT_UPDATE_INTERVAL_NS {
+        return;
+    }
+    match touch_heartbeat(
+        binding.bpf_maps.heartbeat_map_fd,
+        binding.slot,
+        &binding.live,
+        now_ns,
+    ) {
+        Ok(()) => {
+            if cfg!(feature = "debug-log") {
+                thread_local! {
+                    static HB_LOG_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+                }
+                let age_ms = age_ns / 1_000_000;
+                if age_ms > 1000 {
+                    debug_log!(
+                        "HB_UPDATE slot={} fd={} age={}ms now_ns={} LATE",
+                        binding.slot,
+                        binding.bpf_maps.heartbeat_map_fd,
+                        age_ms,
+                        now_ns,
+                    );
+                }
+                HB_LOG_COUNT.with(|c| {
+                    let n = c.get();
+                    if n < 5 {
+                        c.set(n + 1);
+                        debug_log!(
+                            "HB_UPDATE[{}] slot={} fd={} age={}ms now_ns={} OK",
+                            n,
+                            binding.slot,
+                            binding.bpf_maps.heartbeat_map_fd,
+                            age_ms,
+                            now_ns,
+                        );
+                    }
+                });
+            }
+            binding.timers.last_heartbeat_update_ns = now_ns;
+        }
+        Err(err) => {
+            eprintln!(
+                "HB_UPDATE_ERR slot={} fd={} age={}ms err={}",
+                binding.slot,
+                binding.bpf_maps.heartbeat_map_fd,
+                age_ns / 1_000_000,
+                err,
+            );
+            binding
+                .live
+                .set_error(format!("update heartbeat slot: {err}"));
+        }
+    }
+}
+
+pub(in crate::afxdp) fn touch_heartbeat(
+    map_fd: c_int,
+    slot: u32,
+    live: &BindingLiveState,
+    now_ns: u64,
+) -> io::Result<()> {
+    update_heartbeat_slot(map_fd, slot, now_ns)?;
+    live.set_last_heartbeat_at(now_ns);
+    Ok(())
+}
+
+pub(in crate::afxdp) fn heartbeat_fresh(last_heartbeat: Option<chrono::DateTime<Utc>>) -> bool {
+    match last_heartbeat {
+        Some(last) => Utc::now()
+            .signed_duration_since(last)
+            .to_std()
+            .map(|age| age <= HEARTBEAT_STALE_AFTER)
+            .unwrap_or(true),
+        None => false,
+    }
+}

--- a/userspace-dp/src/afxdp/bpf_map/metrics.rs
+++ b/userspace-dp/src/afxdp/bpf_map/metrics.rs
@@ -1,0 +1,244 @@
+// Telemetry / ring-metrics publishing for the BPF session map.
+//
+// Pure code motion out of `bpf_map/mod.rs` (#2003): the raw XDP ring
+// state probe, the USERSPACE_SESSIONS entry count/dump diagnostics, and
+// the always-on / debug-gated publish counters now live here. None of
+// these touch the forwarding decision; they exist purely to surface map
+// occupancy and publish health to the CLI / Prometheus collectors.
+//
+// Behaviour-preserving: signatures, the getsockopt/mmap raw-ring probe,
+// the bpf_map_get_next_key iteration, the 10000-entry safety limit, and
+// the debug-log gating are unchanged from the pre-split orchestrator.
+//
+// Precedent: the sibling `publish_conntrack.rs` split (#1356).
+
+use super::*;
+
+pub(in crate::afxdp) fn diagnose_raw_ring_state(
+    sock_fd: c_int,
+) -> Option<(u32, u32, u32, u32, u32, u32, u32, u32)> {
+    // SOL_XDP (283) comes from afxdp/mod.rs via `use super::*` —
+    // #1826 deduplicated the former local copy.
+    const XDP_MMAP_OFFSETS: i32 = 1;
+    const XDP_PGOFF_RX_RING: i64 = 0;
+    const XDP_PGOFF_TX_RING: i64 = 0x80000000;
+    const XDP_UMEM_PGOFF_FILL_RING: i64 = 0x100000000;
+    const XDP_UMEM_PGOFF_COMPLETION_RING: i64 = 0x180000000;
+
+    // xdp_mmap_offsets_v2 (kernel >= 5.4): 4 rings × 4 fields × u64 each
+    #[repr(C)]
+    #[derive(Default)]
+    struct XdpRingOffset {
+        producer: u64,
+        consumer: u64,
+        desc: u64,
+        flags: u64,
+    }
+    #[repr(C)]
+    #[derive(Default)]
+    struct XdpMmapOffsets {
+        rx: XdpRingOffset,
+        tx: XdpRingOffset,
+        fr: XdpRingOffset,
+        cr: XdpRingOffset,
+    }
+
+    let mut off = XdpMmapOffsets::default();
+    let mut optlen = core::mem::size_of::<XdpMmapOffsets>() as libc::socklen_t;
+    let rc = unsafe {
+        libc::getsockopt(
+            sock_fd,
+            SOL_XDP,
+            XDP_MMAP_OFFSETS,
+            (&mut off as *mut XdpMmapOffsets).cast::<libc::c_void>(),
+            &mut optlen,
+        )
+    };
+    if rc != 0 {
+        return None;
+    }
+
+    fn read_ring_pair(sock_fd: c_int, off: &XdpRingOffset, pgoff: i64) -> (u32, u32) {
+        let map_len = (off.desc.max(off.consumer).max(off.producer) + 8) as usize;
+        let mmap_ptr = unsafe {
+            libc::mmap(
+                core::ptr::null_mut(),
+                map_len,
+                libc::PROT_READ,
+                libc::MAP_SHARED,
+                sock_fd,
+                pgoff,
+            )
+        };
+        if mmap_ptr == libc::MAP_FAILED {
+            return (0, 0);
+        }
+        let prod = unsafe { *(mmap_ptr.byte_add(off.producer as usize) as *const u32) };
+        let cons = unsafe { *(mmap_ptr.byte_add(off.consumer as usize) as *const u32) };
+        unsafe { libc::munmap(mmap_ptr, map_len) };
+        (prod, cons)
+    }
+
+    let (rx_prod, rx_cons) = read_ring_pair(sock_fd, &off.rx, XDP_PGOFF_RX_RING);
+    let (fr_prod, fr_cons) = read_ring_pair(sock_fd, &off.fr, XDP_UMEM_PGOFF_FILL_RING);
+    let (tx_prod, tx_cons) = read_ring_pair(sock_fd, &off.tx, XDP_PGOFF_TX_RING);
+    let (cr_prod, cr_cons) = read_ring_pair(sock_fd, &off.cr, XDP_UMEM_PGOFF_COMPLETION_RING);
+
+    Some((
+        rx_prod, rx_cons, fr_prod, fr_cons, tx_prod, tx_cons, cr_prod, cr_cons,
+    ))
+}
+
+/// Count total entries in the BPF USERSPACE_SESSIONS map.
+pub(in crate::afxdp) fn count_bpf_session_entries(map_fd: c_int) -> u32 {
+    let mut count = 0u32;
+    let key_size = core::mem::size_of::<UserspaceSessionMapKey>();
+    let mut key = vec![0u8; key_size];
+    let mut next_key = vec![0u8; key_size];
+    // First key
+    let rc = unsafe {
+        libbpf_sys::bpf_map_get_next_key(
+            map_fd,
+            core::ptr::null(),
+            next_key.as_mut_ptr().cast::<c_void>(),
+        )
+    };
+    if rc != 0 {
+        return 0;
+    }
+    count += 1;
+    key.copy_from_slice(&next_key);
+    loop {
+        let rc = unsafe {
+            libbpf_sys::bpf_map_get_next_key(
+                map_fd,
+                key.as_ptr().cast::<c_void>(),
+                next_key.as_mut_ptr().cast::<c_void>(),
+            )
+        };
+        if rc != 0 {
+            break;
+        }
+        count += 1;
+        key.copy_from_slice(&next_key);
+        if count > 10000 {
+            break; // safety limit
+        }
+    }
+    count
+}
+
+/// Dump first N entries from the BPF USERSPACE_SESSIONS map for debugging.
+#[allow(unused_variables)]
+pub(in crate::afxdp) fn dump_bpf_session_entries(map_fd: c_int, max_entries: u32) {
+    let key_size = core::mem::size_of::<UserspaceSessionMapKey>();
+    let mut key_bytes = vec![0u8; key_size];
+    let mut next_key_bytes = vec![0u8; key_size];
+    let mut value = 0u8;
+    let mut count = 0u32;
+    // First key
+    let rc = unsafe {
+        libbpf_sys::bpf_map_get_next_key(
+            map_fd,
+            core::ptr::null(),
+            next_key_bytes.as_mut_ptr().cast::<c_void>(),
+        )
+    };
+    if rc != 0 {
+        debug_log!("BPF_MAP_DUMP: empty (no entries)");
+        return;
+    }
+    loop {
+        // Read the key as UserspaceSessionMapKey
+        let map_key: UserspaceSessionMapKey =
+            unsafe { core::ptr::read(next_key_bytes.as_ptr().cast()) };
+        let _ = unsafe {
+            libbpf_sys::bpf_map_lookup_elem(
+                map_fd,
+                next_key_bytes.as_ptr().cast::<c_void>(),
+                (&mut value as *mut u8).cast::<c_void>(),
+            )
+        };
+        #[cfg(feature = "debug-log")]
+        {
+            let src_ip = if map_key.addr_family == libc::AF_INET as u8 {
+                format!(
+                    "{}.{}.{}.{}",
+                    map_key.src_addr[0],
+                    map_key.src_addr[1],
+                    map_key.src_addr[2],
+                    map_key.src_addr[3]
+                )
+            } else {
+                format!(
+                    "v6[{:02x}{:02x}::{:02x}{:02x}]",
+                    map_key.src_addr[0],
+                    map_key.src_addr[1],
+                    map_key.src_addr[14],
+                    map_key.src_addr[15]
+                )
+            };
+            let dst_ip = if map_key.addr_family == libc::AF_INET as u8 {
+                format!(
+                    "{}.{}.{}.{}",
+                    map_key.dst_addr[0],
+                    map_key.dst_addr[1],
+                    map_key.dst_addr[2],
+                    map_key.dst_addr[3]
+                )
+            } else {
+                format!(
+                    "v6[{:02x}{:02x}::{:02x}{:02x}]",
+                    map_key.dst_addr[0],
+                    map_key.dst_addr[1],
+                    map_key.dst_addr[14],
+                    map_key.dst_addr[15]
+                )
+            };
+            debug_log!(
+                "BPF_MAP_DUMP[{}]: af={} proto={} {}:{} -> {}:{} val={}",
+                count,
+                map_key.addr_family,
+                map_key.protocol,
+                src_ip,
+                map_key.src_port,
+                dst_ip,
+                map_key.dst_port,
+                value,
+            );
+        }
+        count += 1;
+        if count >= max_entries {
+            break;
+        }
+        key_bytes.copy_from_slice(&next_key_bytes);
+        let rc = unsafe {
+            libbpf_sys::bpf_map_get_next_key(
+                map_fd,
+                key_bytes.as_ptr().cast::<c_void>(),
+                next_key_bytes.as_mut_ptr().cast::<c_void>(),
+            )
+        };
+        if rc != 0 {
+            break;
+        }
+    }
+    debug_log!("BPF_MAP_DUMP: total={count} entries");
+}
+
+pub(in crate::afxdp) static SESSION_PUBLISH_VERIFY_OK: AtomicU64 = AtomicU64::new(0);
+pub(in crate::afxdp) static SESSION_PUBLISH_VERIFY_FAIL: AtomicU64 = AtomicU64::new(0);
+/// #1789: failed USERSPACE_SESSIONS BPF-map publishes from call sites
+/// that have no per-binding context (HA `upsert_synced_session`,
+/// session-glue worker publishes, post-reconcile `replay_synced_sessions`,
+/// activation/reverse prewarm). Always-on (NOT debug-gated, unlike the
+/// VERIFY counters above which only move under `debug-log`): a swallowed
+/// publish `Err` means the XDP shim never learns the key and the flow
+/// takes the NO_SESSION degraded path. Per-binding worker poll sites use
+/// `BindingLiveState::session_publish_errors` instead; the two are summed
+/// by `Coordinator::session_publish_errors_total()` and surfaced as
+/// `xpf_userspace_session_publish_errors_total`.
+pub(in crate::afxdp) static SESSION_PUBLISH_ERRORS_SHARED: AtomicU64 = AtomicU64::new(0);
+pub(in crate::afxdp) static SESSION_CREATIONS_LOGGED: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "debug-log")]
+pub(in crate::afxdp) static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -11,28 +11,6 @@ pub(super) fn uses_kernel_local_session_map_entry(
         && decision.resolution.tunnel_endpoint_id == 0
 }
 
-pub(super) struct OwnedFd {
-    pub(super) fd: c_int,
-}
-
-impl OwnedFd {
-    pub(super) fn open_bpf_map(path: &str) -> io::Result<Self> {
-        let path = CString::new(path)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid map path"))?;
-        let fd = unsafe { libbpf_sys::bpf_obj_get(path.as_ptr()) };
-        if fd < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(Self { fd })
-    }
-}
-
-impl Drop for OwnedFd {
-    fn drop(&mut self) {
-        let _ = unsafe { libc::close(self.fd) };
-    }
-}
-
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub(super) struct UserspaceSessionMapKey {
@@ -533,60 +511,6 @@ pub(super) fn verify_session_key_in_bpf(map_fd: c_int, key: &SessionKey) -> bool
     rc == 0
 }
 
-// The pinned map path keeps the historical "fallback" spelling for
-// mixed-version shim compatibility. Operator-facing names use
-// degraded-path terminology.
-//
-// #1776: the only production reader (the per-second degraded-path
-// dump in worker/loop_body/debug_report.rs) is debug-log-gated, so
-// these items are cfg-gated to match (REASON_NAMES is also asserted
-// by unit tests, hence `any(test, ...)`).
-#[cfg(feature = "debug-log")]
-pub(super) const DEGRADED_PATH_STATS_PIN_PATH: &str = "/sys/fs/bpf/xpf/userspace_fallback_stats";
-#[cfg(any(test, feature = "debug-log"))]
-pub(super) const DEGRADED_PATH_REASON_NAMES: &[&str] = &[
-    "ctrl_disabled",            // 0
-    "parse_fail",               // 1
-    "binding_missing",          // 2
-    "binding_not_ready",        // 3
-    "heartbeat_missing",        // 4
-    "heartbeat_stale",          // 5
-    "icmp",                     // 6
-    "early_filter",             // 7
-    "adjust_meta",              // 8
-    "meta_bounds",              // 9
-    "redirect_err",             // 10
-    "interface_nat_no_session", // 11
-    "no_session",               // 12
-    "strict_drop",              // 13
-    "pass_to_kernel",           // 14
-    "transit_drop",             // 15
-];
-
-#[cfg(feature = "debug-log")]
-pub(super) fn read_degraded_path_stats() -> Option<Vec<(String, u64)>> {
-    let fd = OwnedFd::open_bpf_map(DEGRADED_PATH_STATS_PIN_PATH).ok()?;
-    let mut result = Vec::new();
-    for idx in 0u32..16 {
-        let mut value = 0u64;
-        let rc = unsafe {
-            libbpf_sys::bpf_map_lookup_elem(
-                fd.fd,
-                (&idx as *const u32).cast::<c_void>(),
-                (&mut value as *mut u64).cast::<c_void>(),
-            )
-        };
-        if rc == 0 && value > 0 {
-            let name = DEGRADED_PATH_REASON_NAMES
-                .get(idx as usize)
-                .copied()
-                .unwrap_or("unknown");
-            result.push((name.to_string(), value));
-        }
-    }
-    Some(result)
-}
-
 pub(super) fn delete_live_session_key(map_fd: c_int, key: &SessionKey) {
     let map_key = session_map_key(key);
     let _ = unsafe {
@@ -717,13 +641,17 @@ mod publish_conntrack;
 // #2003: behaviour-preserving code motion. Each submodule owns one
 // cluster — `ha.rs` the HA liveness-slot writes (XSK + heartbeat map
 // updates that gate active-binding state), `metrics.rs` the telemetry
-// counters plus the raw-ring / session-map diagnostics. Items keep their
-// original `pub(in crate::afxdp)` visibility and are re-exported so the
-// parent `afxdp` glob (`use self::bpf_map::*`) and the relocated
-// `bpf_map_tests.rs` (`use super::*`) resolve them by bare name exactly as
-// before. Mirrors the `publish_conntrack.rs` precedent (#1356).
+// counters plus the raw-ring / session-map diagnostics, `pin.rs` the
+// libbpf fd-pinning RAII wrapper and the pinned degraded-path stats
+// reader. Items keep their original `pub(in crate::afxdp)` visibility and
+// are re-exported so the parent `afxdp` glob (`use self::bpf_map::*`) and
+// the relocated `bpf_map_tests.rs` (`use super::*`) resolve them by bare
+// name exactly as before. Mirrors the `publish_conntrack.rs` precedent
+// (#1356).
 mod ha;
 mod metrics;
+mod pin;
 
 pub(in crate::afxdp) use ha::*;
 pub(in crate::afxdp) use metrics::*;
+pub(in crate::afxdp) use pin::*;

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -86,137 +86,6 @@ pub(super) fn diagnose_raw_ring_state(
     ))
 }
 
-pub(super) fn register_xsk_slot(map_fd: c_int, slot: u32, sock_fd: c_int) -> io::Result<()> {
-    let rc = unsafe {
-        libbpf_sys::bpf_map_update_elem(
-            map_fd,
-            (&slot as *const u32).cast::<c_void>(),
-            (&sock_fd as *const c_int).cast::<c_void>(),
-            libbpf_sys::BPF_ANY as u64,
-        )
-    };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-pub(super) fn update_heartbeat_slot(map_fd: c_int, slot: u32, timestamp_ns: u64) -> io::Result<()> {
-    let rc = unsafe {
-        libbpf_sys::bpf_map_update_elem(
-            map_fd,
-            (&slot as *const u32).cast::<c_void>(),
-            (&timestamp_ns as *const u64).cast::<c_void>(),
-            libbpf_sys::BPF_ANY as u64,
-        )
-    };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-pub(super) fn delete_xsk_slot(map_fd: c_int, slot: u32) -> io::Result<()> {
-    let rc =
-        unsafe { libbpf_sys::bpf_map_delete_elem(map_fd, (&slot as *const u32).cast::<c_void>()) };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-pub(super) fn delete_heartbeat_slot(map_fd: c_int, slot: u32) -> io::Result<()> {
-    let rc =
-        unsafe { libbpf_sys::bpf_map_delete_elem(map_fd, (&slot as *const u32).cast::<c_void>()) };
-    if rc != 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-pub(super) fn maybe_touch_heartbeat(binding: &mut BindingWorker, now_ns: u64) {
-    // The fill ring is primed before bind, so the driver's initial NAPI
-    // posts WQEs immediately. All queues should be ready to receive.
-    // No xsk_rx_confirmed gating needed.
-    let age_ns = now_ns.saturating_sub(binding.timers.last_heartbeat_update_ns);
-    if age_ns < HEARTBEAT_UPDATE_INTERVAL_NS {
-        return;
-    }
-    match touch_heartbeat(
-        binding.bpf_maps.heartbeat_map_fd,
-        binding.slot,
-        &binding.live,
-        now_ns,
-    ) {
-        Ok(()) => {
-            if cfg!(feature = "debug-log") {
-                thread_local! {
-                    static HB_LOG_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-                }
-                let age_ms = age_ns / 1_000_000;
-                if age_ms > 1000 {
-                    debug_log!(
-                        "HB_UPDATE slot={} fd={} age={}ms now_ns={} LATE",
-                        binding.slot,
-                        binding.bpf_maps.heartbeat_map_fd,
-                        age_ms,
-                        now_ns,
-                    );
-                }
-                HB_LOG_COUNT.with(|c| {
-                    let n = c.get();
-                    if n < 5 {
-                        c.set(n + 1);
-                        debug_log!(
-                            "HB_UPDATE[{}] slot={} fd={} age={}ms now_ns={} OK",
-                            n,
-                            binding.slot,
-                            binding.bpf_maps.heartbeat_map_fd,
-                            age_ms,
-                            now_ns,
-                        );
-                    }
-                });
-            }
-            binding.timers.last_heartbeat_update_ns = now_ns;
-        }
-        Err(err) => {
-            eprintln!(
-                "HB_UPDATE_ERR slot={} fd={} age={}ms err={}",
-                binding.slot,
-                binding.bpf_maps.heartbeat_map_fd,
-                age_ns / 1_000_000,
-                err,
-            );
-            binding
-                .live
-                .set_error(format!("update heartbeat slot: {err}"));
-        }
-    }
-}
-
-pub(super) fn touch_heartbeat(
-    map_fd: c_int,
-    slot: u32,
-    live: &BindingLiveState,
-    now_ns: u64,
-) -> io::Result<()> {
-    update_heartbeat_slot(map_fd, slot, now_ns)?;
-    live.set_last_heartbeat_at(now_ns);
-    Ok(())
-}
-
-pub(super) fn heartbeat_fresh(last_heartbeat: Option<chrono::DateTime<Utc>>) -> bool {
-    match last_heartbeat {
-        Some(last) => Utc::now()
-            .signed_duration_since(last)
-            .to_std()
-            .map(|age| age <= HEARTBEAT_STALE_AFTER)
-            .unwrap_or(true),
-        None => false,
-    }
-}
-
 pub(super) struct OwnedFd {
     pub(super) fd: c_int,
 }
@@ -1073,3 +942,13 @@ pub(super) fn delete_session_map_entry_for_removed_session_with_origin(
 mod tests;
 
 mod publish_conntrack;
+
+// #2003: behaviour-preserving code motion. The HA liveness-slot cluster
+// (XSK + heartbeat map writes that gate active-binding state) lives in
+// `ha.rs`; items keep their original `pub(in crate::afxdp)` visibility and
+// are re-exported so the parent `afxdp` glob (`use self::bpf_map::*`)
+// resolves them by bare name exactly as before. Mirrors the
+// `publish_conntrack.rs` precedent (#1356).
+mod ha;
+
+pub(in crate::afxdp) use ha::*;

--- a/userspace-dp/src/afxdp/bpf_map/mod.rs
+++ b/userspace-dp/src/afxdp/bpf_map/mod.rs
@@ -11,81 +11,6 @@ pub(super) fn uses_kernel_local_session_map_entry(
         && decision.resolution.tunnel_endpoint_id == 0
 }
 
-pub(super) fn diagnose_raw_ring_state(
-    sock_fd: c_int,
-) -> Option<(u32, u32, u32, u32, u32, u32, u32, u32)> {
-    // SOL_XDP (283) comes from afxdp/mod.rs via `use super::*` —
-    // #1826 deduplicated the former local copy.
-    const XDP_MMAP_OFFSETS: i32 = 1;
-    const XDP_PGOFF_RX_RING: i64 = 0;
-    const XDP_PGOFF_TX_RING: i64 = 0x80000000;
-    const XDP_UMEM_PGOFF_FILL_RING: i64 = 0x100000000;
-    const XDP_UMEM_PGOFF_COMPLETION_RING: i64 = 0x180000000;
-
-    // xdp_mmap_offsets_v2 (kernel >= 5.4): 4 rings × 4 fields × u64 each
-    #[repr(C)]
-    #[derive(Default)]
-    struct XdpRingOffset {
-        producer: u64,
-        consumer: u64,
-        desc: u64,
-        flags: u64,
-    }
-    #[repr(C)]
-    #[derive(Default)]
-    struct XdpMmapOffsets {
-        rx: XdpRingOffset,
-        tx: XdpRingOffset,
-        fr: XdpRingOffset,
-        cr: XdpRingOffset,
-    }
-
-    let mut off = XdpMmapOffsets::default();
-    let mut optlen = core::mem::size_of::<XdpMmapOffsets>() as libc::socklen_t;
-    let rc = unsafe {
-        libc::getsockopt(
-            sock_fd,
-            SOL_XDP,
-            XDP_MMAP_OFFSETS,
-            (&mut off as *mut XdpMmapOffsets).cast::<libc::c_void>(),
-            &mut optlen,
-        )
-    };
-    if rc != 0 {
-        return None;
-    }
-
-    fn read_ring_pair(sock_fd: c_int, off: &XdpRingOffset, pgoff: i64) -> (u32, u32) {
-        let map_len = (off.desc.max(off.consumer).max(off.producer) + 8) as usize;
-        let mmap_ptr = unsafe {
-            libc::mmap(
-                core::ptr::null_mut(),
-                map_len,
-                libc::PROT_READ,
-                libc::MAP_SHARED,
-                sock_fd,
-                pgoff,
-            )
-        };
-        if mmap_ptr == libc::MAP_FAILED {
-            return (0, 0);
-        }
-        let prod = unsafe { *(mmap_ptr.byte_add(off.producer as usize) as *const u32) };
-        let cons = unsafe { *(mmap_ptr.byte_add(off.consumer as usize) as *const u32) };
-        unsafe { libc::munmap(mmap_ptr, map_len) };
-        (prod, cons)
-    }
-
-    let (rx_prod, rx_cons) = read_ring_pair(sock_fd, &off.rx, XDP_PGOFF_RX_RING);
-    let (fr_prod, fr_cons) = read_ring_pair(sock_fd, &off.fr, XDP_UMEM_PGOFF_FILL_RING);
-    let (tx_prod, tx_cons) = read_ring_pair(sock_fd, &off.tx, XDP_PGOFF_TX_RING);
-    let (cr_prod, cr_cons) = read_ring_pair(sock_fd, &off.cr, XDP_UMEM_PGOFF_COMPLETION_RING);
-
-    Some((
-        rx_prod, rx_cons, fr_prod, fr_cons, tx_prod, tx_cons, cr_prod, cr_cons,
-    ))
-}
-
 pub(super) struct OwnedFd {
     pub(super) fd: c_int,
 }
@@ -608,160 +533,6 @@ pub(super) fn verify_session_key_in_bpf(map_fd: c_int, key: &SessionKey) -> bool
     rc == 0
 }
 
-/// Count total entries in the BPF USERSPACE_SESSIONS map.
-pub(super) fn count_bpf_session_entries(map_fd: c_int) -> u32 {
-    let mut count = 0u32;
-    let key_size = core::mem::size_of::<UserspaceSessionMapKey>();
-    let mut key = vec![0u8; key_size];
-    let mut next_key = vec![0u8; key_size];
-    // First key
-    let rc = unsafe {
-        libbpf_sys::bpf_map_get_next_key(
-            map_fd,
-            core::ptr::null(),
-            next_key.as_mut_ptr().cast::<c_void>(),
-        )
-    };
-    if rc != 0 {
-        return 0;
-    }
-    count += 1;
-    key.copy_from_slice(&next_key);
-    loop {
-        let rc = unsafe {
-            libbpf_sys::bpf_map_get_next_key(
-                map_fd,
-                key.as_ptr().cast::<c_void>(),
-                next_key.as_mut_ptr().cast::<c_void>(),
-            )
-        };
-        if rc != 0 {
-            break;
-        }
-        count += 1;
-        key.copy_from_slice(&next_key);
-        if count > 10000 {
-            break; // safety limit
-        }
-    }
-    count
-}
-
-/// Dump first N entries from the BPF USERSPACE_SESSIONS map for debugging.
-#[allow(unused_variables)]
-pub(super) fn dump_bpf_session_entries(map_fd: c_int, max_entries: u32) {
-    let key_size = core::mem::size_of::<UserspaceSessionMapKey>();
-    let mut key_bytes = vec![0u8; key_size];
-    let mut next_key_bytes = vec![0u8; key_size];
-    let mut value = 0u8;
-    let mut count = 0u32;
-    // First key
-    let rc = unsafe {
-        libbpf_sys::bpf_map_get_next_key(
-            map_fd,
-            core::ptr::null(),
-            next_key_bytes.as_mut_ptr().cast::<c_void>(),
-        )
-    };
-    if rc != 0 {
-        debug_log!("BPF_MAP_DUMP: empty (no entries)");
-        return;
-    }
-    loop {
-        // Read the key as UserspaceSessionMapKey
-        let map_key: UserspaceSessionMapKey =
-            unsafe { core::ptr::read(next_key_bytes.as_ptr().cast()) };
-        let _ = unsafe {
-            libbpf_sys::bpf_map_lookup_elem(
-                map_fd,
-                next_key_bytes.as_ptr().cast::<c_void>(),
-                (&mut value as *mut u8).cast::<c_void>(),
-            )
-        };
-        #[cfg(feature = "debug-log")]
-        {
-            let src_ip = if map_key.addr_family == libc::AF_INET as u8 {
-                format!(
-                    "{}.{}.{}.{}",
-                    map_key.src_addr[0],
-                    map_key.src_addr[1],
-                    map_key.src_addr[2],
-                    map_key.src_addr[3]
-                )
-            } else {
-                format!(
-                    "v6[{:02x}{:02x}::{:02x}{:02x}]",
-                    map_key.src_addr[0],
-                    map_key.src_addr[1],
-                    map_key.src_addr[14],
-                    map_key.src_addr[15]
-                )
-            };
-            let dst_ip = if map_key.addr_family == libc::AF_INET as u8 {
-                format!(
-                    "{}.{}.{}.{}",
-                    map_key.dst_addr[0],
-                    map_key.dst_addr[1],
-                    map_key.dst_addr[2],
-                    map_key.dst_addr[3]
-                )
-            } else {
-                format!(
-                    "v6[{:02x}{:02x}::{:02x}{:02x}]",
-                    map_key.dst_addr[0],
-                    map_key.dst_addr[1],
-                    map_key.dst_addr[14],
-                    map_key.dst_addr[15]
-                )
-            };
-            debug_log!(
-                "BPF_MAP_DUMP[{}]: af={} proto={} {}:{} -> {}:{} val={}",
-                count,
-                map_key.addr_family,
-                map_key.protocol,
-                src_ip,
-                map_key.src_port,
-                dst_ip,
-                map_key.dst_port,
-                value,
-            );
-        }
-        count += 1;
-        if count >= max_entries {
-            break;
-        }
-        key_bytes.copy_from_slice(&next_key_bytes);
-        let rc = unsafe {
-            libbpf_sys::bpf_map_get_next_key(
-                map_fd,
-                key_bytes.as_ptr().cast::<c_void>(),
-                next_key_bytes.as_mut_ptr().cast::<c_void>(),
-            )
-        };
-        if rc != 0 {
-            break;
-        }
-    }
-    debug_log!("BPF_MAP_DUMP: total={count} entries");
-}
-
-pub(super) static SESSION_PUBLISH_VERIFY_OK: AtomicU64 = AtomicU64::new(0);
-pub(super) static SESSION_PUBLISH_VERIFY_FAIL: AtomicU64 = AtomicU64::new(0);
-/// #1789: failed USERSPACE_SESSIONS BPF-map publishes from call sites
-/// that have no per-binding context (HA `upsert_synced_session`,
-/// session-glue worker publishes, post-reconcile `replay_synced_sessions`,
-/// activation/reverse prewarm). Always-on (NOT debug-gated, unlike the
-/// VERIFY counters above which only move under `debug-log`): a swallowed
-/// publish `Err` means the XDP shim never learns the key and the flow
-/// takes the NO_SESSION degraded path. Per-binding worker poll sites use
-/// `BindingLiveState::session_publish_errors` instead; the two are summed
-/// by `Coordinator::session_publish_errors_total()` and surfaced as
-/// `xpf_userspace_session_publish_errors_total`.
-pub(super) static SESSION_PUBLISH_ERRORS_SHARED: AtomicU64 = AtomicU64::new(0);
-pub(super) static SESSION_CREATIONS_LOGGED: AtomicU64 = AtomicU64::new(0);
-#[cfg(feature = "debug-log")]
-pub(super) static ICMPV6_EMBED_LOGGED: AtomicU32 = AtomicU32::new(0);
-
 // The pinned map path keeps the historical "fallback" spelling for
 // mixed-version shim compatibility. Operator-facing names use
 // degraded-path terminology.
@@ -943,12 +714,16 @@ mod tests;
 
 mod publish_conntrack;
 
-// #2003: behaviour-preserving code motion. The HA liveness-slot cluster
-// (XSK + heartbeat map writes that gate active-binding state) lives in
-// `ha.rs`; items keep their original `pub(in crate::afxdp)` visibility and
-// are re-exported so the parent `afxdp` glob (`use self::bpf_map::*`)
-// resolves them by bare name exactly as before. Mirrors the
-// `publish_conntrack.rs` precedent (#1356).
+// #2003: behaviour-preserving code motion. Each submodule owns one
+// cluster — `ha.rs` the HA liveness-slot writes (XSK + heartbeat map
+// updates that gate active-binding state), `metrics.rs` the telemetry
+// counters plus the raw-ring / session-map diagnostics. Items keep their
+// original `pub(in crate::afxdp)` visibility and are re-exported so the
+// parent `afxdp` glob (`use self::bpf_map::*`) and the relocated
+// `bpf_map_tests.rs` (`use super::*`) resolve them by bare name exactly as
+// before. Mirrors the `publish_conntrack.rs` precedent (#1356).
 mod ha;
+mod metrics;
 
 pub(in crate::afxdp) use ha::*;
+pub(in crate::afxdp) use metrics::*;

--- a/userspace-dp/src/afxdp/bpf_map/pin.rs
+++ b/userspace-dp/src/afxdp/bpf_map/pin.rs
@@ -1,0 +1,95 @@
+// libbpf fd pinning + pinned degraded-path stats reader.
+//
+// Pure code motion out of `bpf_map/mod.rs` (#2003): the RAII wrapper that
+// opens a pinned BPF object by sysfs path (`bpf_obj_get`) and closes the
+// fd on drop, plus the debug-gated reader for the pinned
+// `userspace_fallback_stats` map, now live here. These are the only
+// items that talk to the bpffs pin paths directly.
+//
+// Behaviour-preserving: `OwnedFd::open_bpf_map` keeps the same
+// `CString`/`bpf_obj_get`/`last_os_error` contract, `Drop` still closes
+// the fd, and `read_degraded_path_stats` keeps the same 16-slot scan and
+// debug-log gating. The pin-path constant and reason-name table move with
+// the reader. The orchestrator and tests resolve these via the `bpf_map`
+// re-export, exactly as before.
+//
+// Precedent: the sibling `publish_conntrack.rs` split (#1356).
+
+use super::*;
+
+pub(in crate::afxdp) struct OwnedFd {
+    pub(in crate::afxdp) fd: c_int,
+}
+
+impl OwnedFd {
+    pub(in crate::afxdp) fn open_bpf_map(path: &str) -> io::Result<Self> {
+        let path = CString::new(path)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid map path"))?;
+        let fd = unsafe { libbpf_sys::bpf_obj_get(path.as_ptr()) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self { fd })
+    }
+}
+
+impl Drop for OwnedFd {
+    fn drop(&mut self) {
+        let _ = unsafe { libc::close(self.fd) };
+    }
+}
+
+// The pinned map path keeps the historical "fallback" spelling for
+// mixed-version shim compatibility. Operator-facing names use
+// degraded-path terminology.
+//
+// #1776: the only production reader (the per-second degraded-path
+// dump in worker/loop_body/debug_report.rs) is debug-log-gated, so
+// these items are cfg-gated to match (REASON_NAMES is also asserted
+// by unit tests, hence `any(test, ...)`).
+#[cfg(feature = "debug-log")]
+pub(in crate::afxdp) const DEGRADED_PATH_STATS_PIN_PATH: &str =
+    "/sys/fs/bpf/xpf/userspace_fallback_stats";
+#[cfg(any(test, feature = "debug-log"))]
+pub(in crate::afxdp) const DEGRADED_PATH_REASON_NAMES: &[&str] = &[
+    "ctrl_disabled",            // 0
+    "parse_fail",               // 1
+    "binding_missing",          // 2
+    "binding_not_ready",        // 3
+    "heartbeat_missing",        // 4
+    "heartbeat_stale",          // 5
+    "icmp",                     // 6
+    "early_filter",             // 7
+    "adjust_meta",              // 8
+    "meta_bounds",              // 9
+    "redirect_err",             // 10
+    "interface_nat_no_session", // 11
+    "no_session",               // 12
+    "strict_drop",              // 13
+    "pass_to_kernel",           // 14
+    "transit_drop",             // 15
+];
+
+#[cfg(feature = "debug-log")]
+pub(in crate::afxdp) fn read_degraded_path_stats() -> Option<Vec<(String, u64)>> {
+    let fd = OwnedFd::open_bpf_map(DEGRADED_PATH_STATS_PIN_PATH).ok()?;
+    let mut result = Vec::new();
+    for idx in 0u32..16 {
+        let mut value = 0u64;
+        let rc = unsafe {
+            libbpf_sys::bpf_map_lookup_elem(
+                fd.fd,
+                (&idx as *const u32).cast::<c_void>(),
+                (&mut value as *mut u64).cast::<c_void>(),
+            )
+        };
+        if rc == 0 && value > 0 {
+            let name = DEGRADED_PATH_REASON_NAMES
+                .get(idx as usize)
+                .copied()
+                .unwrap_or("unknown");
+            result.push((name.to_string(), value));
+        }
+    }
+    Some(result)
+}


### PR DESCRIPTION
## Summary

Pure code-motion refactor (#2003). Splits `userspace-dp/src/afxdp/bpf_map/mod.rs`
(~1063 LOC → ~640 LOC) into three focused submodules, following the existing
sibling `publish_conntrack.rs` precedent (#1356). **No behavior change** — every
function, struct, static, and const is moved verbatim with its signature, logic,
side effects, log/error strings, and cfg gating intact.

## New submodules

| File | Cluster | Items moved |
|------|---------|-------------|
| `bpf_map/ha.rs` | HA liveness slots (XSK + heartbeat map writes that gate active-binding state) | `register_xsk_slot`, `update_heartbeat_slot`, `delete_xsk_slot`, `delete_heartbeat_slot`, `maybe_touch_heartbeat`, `touch_heartbeat`, `heartbeat_fresh` |
| `bpf_map/metrics.rs` | Telemetry counters + diagnostics | `diagnose_raw_ring_state`, `count_bpf_session_entries`, `dump_bpf_session_entries`, `SESSION_PUBLISH_VERIFY_OK/FAIL`, `SESSION_PUBLISH_ERRORS_SHARED`, `SESSION_CREATIONS_LOGGED`, `ICMPV6_EMBED_LOGGED` |
| `bpf_map/pin.rs` | libbpf fd pinning + pinned degraded-path reader | `OwnedFd` (+ `open_bpf_map`/`Drop`), `DEGRADED_PATH_STATS_PIN_PATH`, `DEGRADED_PATH_REASON_NAMES`, `read_degraded_path_stats` |

`mod.rs` remains the coordinator over the session-map publish/delete core, the
conntrack-mirror orchestrators, and the BPF conntrack struct definitions.

## API surface preserved exactly

The original items were `pub(super)` (= `pub(in crate::afxdp)`). Moved items keep
that exact visibility via an explicit `pub(in crate::afxdp)` declaration, and
`mod.rs` re-exports each submodule with `pub(in crate::afxdp) use {ha,metrics,pin}::*;`.
This keeps every consumer resolving unchanged:

- the parent `afxdp` glob (`use self::bpf_map::*`) and all bare-name call sites
- the explicit paths `crate::afxdp::bpf_map::OwnedFd` (coordinator) and
  `crate::afxdp::bpf_map::SESSION_PUBLISH_ERRORS_SHARED` (session_glue / forwarding)
- the relocated `bpf_map_tests.rs` (`use super::*`), which references many moved
  items by bare name

No public API of `crate::afxdp::bpf_map` changed (same names, same visibility).

## Visibility notes

- No widening required. Items keep `pub(in crate::afxdp)` (semantically identical
  to the original `pub(super)` for this file). The pre-existing `private_interfaces`
  lint on the `pub(crate)` `BpfMaps` fields that hold `OwnedFd` is unchanged in
  severity — only the type's display path moved from `bpf_map::OwnedFd` to
  `bpf_map::pin::OwnedFd`.

## Validation

```
cargo build --release   # clean (pre-existing warnings only)
cargo test  --release   # lib: 2057 passed, 0 failed; + 46 + 8 + 16 + 1 across
                        # the other test binaries, 0 failed
```

The diff touches only the `bpf_map/` directory (+512 / -436; the net is the
per-file module doc headers + the `mod`/re-export wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)