### PR TITLE
#1979: Layer-B commit-time NUM_WIDTH validation (flow/flow-export, tcp-mss)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -321,3 +321,76 @@ reserved for whole-dataplane selection where a rewrite shim
     fails at commit; `allow-duplicates` is an explicit presence-only flag.
   Pure schema hardening — no runtime behavior change. Regression coverage:
   `pkg/config/schema_validate_2008_test.go`.
+
+### #1979 — flow / flow-export NUM_WIDTH commit-time validation (Layer B)
+
+Layer A (#1977, `pkg/dataplane/userspace/flow.go` `buildFlowSnapshot` /
+`buildFlowExportSnapshot`) coerces every flow/flow-export wire field into its
+Rust `u16`/`u32`/`u64` range at the snapshot boundary so an out-of-range value
+cannot abort the `apply_snapshot` decode (the #1961 failure class). Layer B
+adds the commit-time companion: reject the bad value at `commit check` with a
+clear range error instead of silently coercing it. The bounds equal the
+Layer-A caps EXACTLY (a value Layer B accepts is one Layer A leaves unchanged;
+a value Layer B rejects is one Layer A would have coerced).
+
+Layer B uses BOTH commit-check validation families, chosen per leaf by whether
+the value sits in a single typed slot:
+
+- **Typed `setSchema` leaves (Tiers 1+2 — the declarative `#1319` path):**
+  - `services flow-monitoring version9 template <t> flow-active-timeout` /
+    `flow-inactive-timeout` — `ValidateInteger(0, maxWireU32)` (Rust u32
+    ActiveTimeout/InactiveTimeout). The parallel `version-ipfix` pair is typed
+    identically for UX parity even though it does NOT reach the wire
+    (`buildFlowExportSnapshot` reads `fm.Version9` only).
+  - `security flow tcp-session` expanded to a container: `established-timeout`
+    (Rust u64 TCPSessionTimeout), `initial-timeout`, `closing-timeout`,
+    `time-wait-timeout` (config-only, not wire-reaching) all
+    `ValidateInteger(0, MaxDurationSeconds)` — the Duration-overflow ceiling,
+    NOT u64-max, because the helper multiplies `secs*1e9` unchecked; plus the
+    presence flags `no-syn-check`, `no-syn-check-in-tunnel`,
+    `rst-invalidate-session` declared presence-only for completion parity.
+  - `security flow udp-session` / `icmp-session` expanded to a container with a
+    typed `timeout` (`ValidateInteger(0, MaxDurationSeconds)`).
+  - `forwarding-options sampling instance <i> input rate` —
+    `ValidateInteger(0, maxWireU32)`. **0 is accepted** (the documented
+    `0 = sample all` sentinel, `types_system.go`; Layer A normalizes
+    `rate<=0 -> 1`) — EXACT Layer-A agreement, rejecting only the
+    decode-aborting `>u32max`.
+  - `forwarding-options sampling … output flow-server <addr> port` —
+    `ValidateInteger(1, maxWireU16)` (Rust u16 CollectorPort; Layer A skips a
+    server whose port is `<1` or `>65535`). `flow-server` keeps `args:1` for
+    the collector address and gains a children map (the typed `port` plus the
+    other compiler-read children `version9-template`, `version9 { template }`,
+    `source-address`), which deliberately flips a BARE `flow-server <addr>`
+    from single-value REPLACE to named-container APPEND — benign: a bare
+    no-port server compiles `Port==0` and the snapshot builder skips it, and
+    real multi-collector configs already take the container path.
+
+- **Compiler AST pre-walk (Tier 3 — the `validateVRRPTrackInterfaceAST`
+  precedent):** `security flow tcp-mss {ipsec-vpn|gre-in|gre-out|all-tcp}`
+  stays OPAQUE in `setSchema` because its MSS value can live in EITHER the
+  kind node's flat `Keys[1]` (`gre-in 1400`) OR a hierarchical `mss` sub-child
+  (`gre-in { mss 1360; }`) — a dual value-location the declarative walker
+  cannot express. `validateTCPMSSRanges` (`compiler_security.go`, wired into
+  `compileExpanded` next to the VRRP pre-walk) range-checks the
+  COMPILER-SELECTED token via `selectMSSToken` (shared with `parseMSSValue` so
+  it can never diverge: `mss` child first, flat fallback) against
+  `[0, 65535]`. A mixed shape `gre-in 70000 { mss 1360; }` therefore PASSES
+  (the compiler selects the child 1360 and discards the flat 70000).
+
+**Strict vs lenient (boot/HA safety):** Tiers 1+2 get the strict/lenient split
+for free (a typed-leaf `SchemaValidate` violation hard-rejects on the strict
+commit path and downgrades to a warning on `Store.Load` / `Store.SyncApply`,
+`configstore.compileTreeLenient`). Tier 3's `validateTCPMSSRanges` takes a
+`lenient` flag (the `lenientTCPMSSRange` `compileOpt`, set by
+`CompileConfigLenient` / `CompileConfigForNodeLenient`) exactly like the VRRP
+validator: strict commit hard-rejects, but the tolerant load/peer-sync path
+WARNS and lets Layer A coerce, so an upgraded node loading a legacy
+`tcp-mss gre-in 70000` (a value an older binary accepted) still boots.
+
+Pure commit-time validation — no Layer A / Rust / wire change. Regression
+coverage: `pkg/config/schema_validate_flow_numwidth_test.go` (Tiers 1+2 via
+`SchemaValidate`), `pkg/config/compiler_tcp_mss_range_test.go` (Tier 3 via
+`CompileConfig`, dual-shape + mixed-shape precedence + strict/lenient), and
+`pkg/dataplane/userspace/flow_numwidth_agreement_test.go` (the directional
+Layer-A agreement property).

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -95,6 +95,20 @@ type compileOpts struct {
 	// SyncApply admission gate (V-1), not by this compile flag.
 	lenientDeviceMap bool
 
+	// lenientTCPMSSRange (#1979 Layer B Tier 3) downgrades the tcp-mss
+	// commit-time range gate (validateTCPMSSRanges) from a hard compile
+	// error to a cfg.Warnings entry. Set ONLY on the tolerant load /
+	// peer-sync paths (CompileConfigLenient / CompileConfigForNodeLenient):
+	// a persisted or peer-synced config carrying an out-of-range MSS value
+	// an OLDER binary accepted (before this gate existed) must still boot,
+	// not blackout the upgraded node — the dataplane coerces it safely
+	// (Layer A, flow.go coerceWireU16) and the operator's next strict commit
+	// rejects it loudly. Same doctrine as lenientVRRPTrackDuplicates. Like
+	// the other lenient gates this is an AST-level compile decision (the MSS
+	// value can live in two positions) and deliberately does NOT live in
+	// SchemaValidate (tcp-mss stays opaque there).
+	lenientTCPMSSRange bool
+
 	// lenientPolicyMatchAddress (#2008) downgrades the policy match-
 	// address validator (validatePolicyMatchAddressesStrict) from a hard
 	// compile error to a cfg.Warnings entry. The strict commit /
@@ -136,6 +150,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientVRRPTrackDuplicates:   true,
 		lenientDeviceMap:             true,
 		lenientPolicyMatchAddress:    true,
+		lenientTCPMSSRange:           true,
 	})
 }
 
@@ -202,6 +217,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientVRRPTrackDuplicates:   true,
 		lenientDeviceMap:             true,
 		lenientPolicyMatchAddress:    true,
+		lenientTCPMSSRange:           true,
 	})
 }
 
@@ -262,6 +278,20 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 
+	// #1979 Layer B Tier 3: tcp-mss range AST pre-walk. tcp-mss carries its
+	// MSS value in either the kind node's flat Keys[1] or a hierarchical
+	// `mss` child — a dual value-location the declarative SchemaValidate
+	// walker cannot express, so it stays opaque in setSchema and is
+	// range-checked here on the group-expanded tree (apply-groups-inherited
+	// values covered), BEFORE the snapshot builder's Layer-A coercion would
+	// see it. Strict (commit / commit-check): out-of-range hard-rejects.
+	// Lenient (load / peer-sync): warn + let Layer A coerce so an upgraded
+	// node loading a legacy out-of-range MSS still boots.
+	mssWarnings, err := validateTCPMSSRanges(tree.Children, "", opts.lenientTCPMSSRange)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		Security: SecurityConfig{
 			Zones:  make(map[string]*ZoneConfig),
@@ -285,6 +315,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	}
 	cfg.Warnings = append(cfg.Warnings, ctrlCharWarnings...)
 	cfg.Warnings = append(cfg.Warnings, trackWarnings...)
+	cfg.Warnings = append(cfg.Warnings, mssWarnings...)
 
 	for _, node := range tree.Children {
 		switch node.Name() {

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -725,20 +725,36 @@ func parseTunnelWireguardPeer(tc *TunnelConfig, peerNode *Node) {
 	}
 }
 
-// parseMSSValue extracts MSS value from either "node { mss VALUE; }" or "node VALUE;" syntax.
-func parseMSSValue(node *Node) int {
+// selectMSSToken returns the raw MSS token the compiler would actually
+// select for a tcp-mss kind node (ipsec-vpn / gre-in / gre-out / all-tcp),
+// using the SAME precedence as parseMSSValue: the hierarchical `mss` child's
+// Keys[1] FIRST (if present), else the node's own flat Keys[1]. The bool is
+// false when neither position carries a token. #1979 Layer B shares this so
+// the Tier-3 commit-time validator (validateTCPMSSRanges) can never diverge
+// from what the compiler reads — it must range-check the SELECTED value, not
+// "both positions" (a mixed shape like `gre-in 70000 { mss 1360; }` compiles
+// the child 1360 and discards the flat 70000, so validating both would
+// wrongly reject it).
+func selectMSSToken(node *Node) (string, bool) {
 	// Hierarchical: ipsec-vpn { mss 1360; } or gre-in { mss 1360; }
-	mssChild := node.FindChild("mss")
-	if mssChild != nil && len(mssChild.Keys) >= 2 {
-		if v, err := strconv.Atoi(mssChild.Keys[1]); err == nil {
-			return v
-		}
+	if mssChild := node.FindChild("mss"); mssChild != nil && len(mssChild.Keys) >= 2 {
+		return mssChild.Keys[1], true
 	}
 	// Flat: ipsec-vpn 1360; (set syntax)
 	if len(node.Keys) >= 2 {
-		if v, err := strconv.Atoi(node.Keys[1]); err == nil {
-			return v
-		}
+		return node.Keys[1], true
+	}
+	return "", false
+}
+
+// parseMSSValue extracts MSS value from either "node { mss VALUE; }" or "node VALUE;" syntax.
+func parseMSSValue(node *Node) int {
+	tok, ok := selectMSSToken(node)
+	if !ok {
+		return 0
+	}
+	if v, err := strconv.Atoi(tok); err == nil {
+		return v
 	}
 	return 0
 }

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -736,9 +736,17 @@ func parseTunnelWireguardPeer(tc *TunnelConfig, peerNode *Node) {
 // the child 1360 and discards the flat 70000, so validating both would
 // wrongly reject it).
 func selectMSSToken(node *Node) (string, bool) {
-	// Hierarchical: ipsec-vpn { mss 1360; } or gre-in { mss 1360; }
+	// Hierarchical: ipsec-vpn { mss 1360; } or gre-in { mss 1360; }.
+	// Prefer the child ONLY when it parses — an unparseable child
+	// (e.g. `gre-in 1360 { mss bogus; }`) must fall through to the flat
+	// token so the value selected here matches what parseMSSValue/the
+	// compiler actually use (the flat 1360), not the discarded child.
+	// Returning the unparseable child unconditionally was a precedence
+	// regression vs the original parseMSSValue (#1979).
 	if mssChild := node.FindChild("mss"); mssChild != nil && len(mssChild.Keys) >= 2 {
-		return mssChild.Keys[1], true
+		if _, err := strconv.Atoi(mssChild.Keys[1]); err == nil {
+			return mssChild.Keys[1], true
+		}
 	}
 	// Flat: ipsec-vpn 1360; (set syntax)
 	if len(node.Keys) >= 2 {

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -572,6 +572,84 @@ func compileLog(node *Node, sec *SecurityConfig) error {
 	return nil
 }
 
+// tcpMSSKinds are the four tcp-mss sub-kinds the compiler reads
+// (compileFlow MSS switch). Each carries a u16 MSS value that lands in a
+// Rust u16 wire field (TCPMSS{IPsecVPN,GreIn,GreOut}; all-tcp fans out into
+// all three) via buildFlowSnapshot (Layer A coerceWireU16, #1977).
+var tcpMSSKinds = []string{"ipsec-vpn", "gre-in", "gre-out", "all-tcp"}
+
+// validateTCPMSSRanges is the #1979 Layer-B Tier-3 commit-time range gate
+// for `security flow tcp-mss {ipsec-vpn|gre-in|gre-out|all-tcp} <n>`. It is
+// the compiler AST pre-walk counterpart of validateVRRPTrackInterfaceAST:
+// tcp-mss's MSS value can live in EITHER the kind node's own flat Keys[1]
+// (`gre-in 1400`) OR a hierarchical `mss` sub-child (`gre-in { mss 1360; }`),
+// a dual value-location the declarative schema walker (SchemaValidate)
+// cannot express — so tcp-mss stays OPAQUE in setSchema and is validated
+// here instead.
+//
+// It range-checks the COMPILER-SELECTED token (selectMSSToken, shared with
+// parseMSSValue) against [0, 65535] — the same Layer-A bound (coerceWireU16
+// out-of-range -> 0). Validating only the selected value means a mixed shape
+// like `gre-in 70000 { mss 1360; }` PASSES (the compiler selects the child
+// 1360; the flat 70000 is discarded), exactly matching what compileFlow
+// reads.
+//
+// Strict path (commit / commit-check, lenient=false): an out-of-range or
+// non-integer selected value is a hard compile error. Lenient path (load /
+// peer-sync, lenient=true): it is downgraded to a warning and Layer A coerces
+// it — a legacy persisted/peer config carrying `tcp-mss gre-in 70000` (a
+// value an older binary accepted) must still boot, exactly like the VRRP
+// lenient gate. Runs on the group-expanded tree so apply-groups-inherited
+// MSS values are covered.
+func validateTCPMSSRanges(nodes []*Node, prefix string, lenient bool) ([]string, error) {
+	var warnings []string
+	for _, n := range nodes {
+		nodePath := joinNodePath(prefix, n.Keys)
+		if n.Name() == "security" {
+			for _, flow := range n.FindChildren("flow") {
+				flowPath := joinNodePath(nodePath, []string{"flow"})
+				for _, mss := range flow.FindChildren("tcp-mss") {
+					mssPath := joinNodePath(flowPath, []string{"tcp-mss"})
+					for _, kind := range tcpMSSKinds {
+						for _, kn := range mss.FindChildren(kind) {
+							w, err := checkTCPMSSKind(kn, joinNodePath(mssPath, []string{kind}), lenient)
+							warnings = append(warnings, w...)
+							if err != nil {
+								return nil, err
+							}
+						}
+					}
+				}
+			}
+		}
+		w, err := validateTCPMSSRanges(n.Children, nodePath, lenient)
+		warnings = append(warnings, w...)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return warnings, nil
+}
+
+// checkTCPMSSKind range-checks one tcp-mss kind node's compiler-selected MSS
+// value. See validateTCPMSSRanges.
+func checkTCPMSSKind(node *Node, nodePath string, lenient bool) ([]string, error) {
+	tok, ok := selectMSSToken(node)
+	if !ok {
+		// No value token in either position — the compiler reads 0 (the
+		// "unset" sentinel). Not a range violation; leave it.
+		return nil, nil
+	}
+	if err := ValidateInteger(0, maxWireU16)(tok, nil); err != nil {
+		msg := fmt.Sprintf("%s: invalid tcp-mss value: %v", nodePath, err)
+		if !lenient {
+			return nil, fmt.Errorf("%s", msg)
+		}
+		return []string{msg + " (kept; the dataplane coerces it — a strict commit would reject this)"}, nil
+	}
+	return nil, nil
+}
+
 func compileFlow(node *Node, sec *SecurityConfig) error {
 	// Aggressive session aging
 	if agingNode := node.FindChild("aging"); agingNode != nil {

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -645,7 +645,16 @@ func checkTCPMSSKind(node *Node, nodePath string, lenient bool) ([]string, error
 		if !lenient {
 			return nil, fmt.Errorf("%s", msg)
 		}
-		return []string{msg + " (kept; the dataplane coerces it — a strict commit would reject this)"}, nil
+		// Tailor the lenient suffix to the failure kind (Copilot review):
+		// an out-of-RANGE integer is clamped by Layer A at the wire
+		// boundary (flow.go coerceWireU16), so "the dataplane coerces it"
+		// is accurate; a NON-INTEGER token never yields a value — the
+		// compiler reads 0 (unset) — so claiming coercion would mislead.
+		suffix := " (kept; the dataplane coerces it — a strict commit would reject this)"
+		if _, perr := strconv.Atoi(tok); perr != nil {
+			suffix = " (treated as unset/0 by the compiler — a strict commit would reject this)"
+		}
+		return []string{msg + suffix}, nil
 	}
 	return nil, nil
 }

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -645,13 +645,15 @@ func checkTCPMSSKind(node *Node, nodePath string, lenient bool) ([]string, error
 		if !lenient {
 			return nil, fmt.Errorf("%s", msg)
 		}
-		// Tailor the lenient suffix to the failure kind (Copilot review):
-		// an out-of-RANGE integer is clamped by Layer A at the wire
-		// boundary (flow.go coerceWireU16), so "the dataplane coerces it"
-		// is accurate; a NON-INTEGER token never yields a value — the
-		// compiler reads 0 (unset) — so claiming coercion would mislead.
+		// Tailor the lenient suffix to the failure kind (Codex/Copilot
+		// review). Only a parseable POSITIVE-but-too-large integer reaches
+		// Layer A to be clamped (flow.go coerceWireU16) — compileFlow only
+		// assigns the MSS when v > 0. A non-integer token OR a negative
+		// value yields no MSS: the compiler reads 0 (unset), nothing
+		// reaches the dataplane, so "the dataplane coerces it" would
+		// mislead. Branch on the parsed value, not just parseability.
 		suffix := " (kept; the dataplane coerces it — a strict commit would reject this)"
-		if _, perr := strconv.Atoi(tok); perr != nil {
+		if v, perr := strconv.Atoi(tok); perr != nil || v < 0 {
 			suffix = " (treated as unset/0 by the compiler — a strict commit would reject this)"
 		}
 		return []string{msg + suffix}, nil

--- a/pkg/config/compiler_tcp_mss_range_test.go
+++ b/pkg/config/compiler_tcp_mss_range_test.go
@@ -238,4 +238,16 @@ func TestTCPMSSRange_LenientWarningKind(t *testing.T) {
 	if !strings.Contains(w, "unset") || strings.Contains(w, "coerces") {
 		t.Fatalf("non-integer lenient warning should say unset/0 and NOT claim coercion, got: %q", w)
 	}
+
+	// Negative integer -> unset/0 wording too (Codex re-review): -1 parses
+	// but compileFlow only assigns MSS when v > 0, so it never reaches Layer
+	// A — "coerces" would be wrong. Strict still rejects (< min 0).
+	neg := mssFlatTree(t, "set security flow tcp-mss gre-in -1")
+	if _, err := config.CompileConfig(neg); err == nil {
+		t.Fatal("strict must REJECT a negative tcp-mss token")
+	}
+	wn := mssWarn(t, neg)
+	if !strings.Contains(wn, "unset") || strings.Contains(wn, "coerces") {
+		t.Fatalf("negative lenient warning should say unset/0 and NOT claim coercion, got: %q", wn)
+	}
 }

--- a/pkg/config/compiler_tcp_mss_range_test.go
+++ b/pkg/config/compiler_tcp_mss_range_test.go
@@ -129,6 +129,33 @@ func TestTCPMSSRange_MixedShapePrecedence(t *testing.T) {
 }`))
 }
 
+// --- The parse-failure fallback (Codex r2 MAJOR): an unparseable mss CHILD
+// must fall through to the flat token, matching parseMSSValue's original
+// precedence ("child only if it parses, else flat"). selectMSSToken returning
+// the unparseable child unconditionally regressed the compiled value to 0 and
+// made strict validation reject a config the old compiler accepted. ---
+
+func TestTCPMSSRange_UnparseableChildFallsBackToFlat(t *testing.T) {
+	// gre-in 1360 { mss bogus; }: the child "bogus" does not parse, so both
+	// the compiler and the validator must fall back to the flat 1360 (exactly
+	// as the pre-#1979 parseMSSValue did). Must NOT false-reject, and the
+	// compiled value is the flat 1360 — NOT 0.
+	tree := mssHierTree(t, `security {
+    flow { tcp-mss { gre-in 1360 { mss bogus; } } }
+}`)
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("gre-in 1360 { mss bogus } must fall back to the flat 1360, not reject: %v", err)
+	}
+	if cfg.Security.Flow.TCPMSSGreIn != 1360 {
+		t.Fatalf("unparseable mss child must fall back to flat 1360, got %d", cfg.Security.Flow.TCPMSSGreIn)
+	}
+	// Lenient (boot/HA) path also accepts the fallback cleanly.
+	if _, err := config.CompileConfigLenient(tree); err != nil {
+		t.Fatalf("lenient compile of the unparseable-child fallback must succeed: %v", err)
+	}
+}
+
 // --- Strict vs lenient (boot/HA safety — MANDATORY per plan §6) ---
 
 func TestTCPMSSRange_StrictVsLenient(t *testing.T) {

--- a/pkg/config/compiler_tcp_mss_range_test.go
+++ b/pkg/config/compiler_tcp_mss_range_test.go
@@ -201,3 +201,41 @@ func TestTCPMSSRange_StrictVsLenient(t *testing.T) {
 		t.Fatalf("lenient must WARN-LOAD hierarchical out-of-range MSS: %v", err)
 	}
 }
+
+// --- Lenient warning wording distinguishes out-of-range vs non-integer
+// (Copilot review): an out-of-range INTEGER is coerced by Layer A, but a
+// NON-INTEGER token is read as unset/0 and never reaches the dataplane, so
+// the warning must not claim "the dataplane coerces it" for that case. ---
+
+func TestTCPMSSRange_LenientWarningKind(t *testing.T) {
+	mssWarn := func(t *testing.T, tree *config.ConfigTree) string {
+		t.Helper()
+		cfg, err := config.CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("lenient compile must not hard-fail: %v", err)
+		}
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "tcp-mss") {
+				return w
+			}
+		}
+		t.Fatalf("expected a tcp-mss lenient warning, got: %v", cfg.Warnings)
+		return ""
+	}
+
+	// Out-of-range integer -> coercion wording; strict rejects.
+	oor := mssWarn(t, mssFlatTree(t, "set security flow tcp-mss gre-in 70000"))
+	if !strings.Contains(oor, "coerces") {
+		t.Fatalf("out-of-range lenient warning should mention dataplane coercion, got: %q", oor)
+	}
+
+	// Non-integer token -> unset/0 wording (NOT coercion); strict rejects.
+	nonInt := mssFlatTree(t, "set security flow tcp-mss gre-in bogus")
+	if _, err := config.CompileConfig(nonInt); err == nil {
+		t.Fatal("strict must REJECT a non-integer tcp-mss token")
+	}
+	w := mssWarn(t, nonInt)
+	if !strings.Contains(w, "unset") || strings.Contains(w, "coerces") {
+		t.Fatalf("non-integer lenient warning should say unset/0 and NOT claim coercion, got: %q", w)
+	}
+}

--- a/pkg/config/compiler_tcp_mss_range_test.go
+++ b/pkg/config/compiler_tcp_mss_range_test.go
@@ -1,0 +1,176 @@
+package config_test
+
+// #1979 Layer B — Tier 3: tcp-mss commit-time range validation.
+//
+// tcp-mss stays OPAQUE in setSchema by design (its MSS value can live in
+// either the kind node's flat Keys[1] OR a hierarchical `mss` sub-child — a
+// dual value-location the declarative SchemaValidate walker cannot express),
+// so its accept/reject is validated by the compiler AST pre-walk
+// validateTCPMSSRanges and asserted here through CompileConfig (strict) /
+// CompileConfigLenient (boot/HA-safe). NOT through SchemaValidate.
+//
+// Per the dual-AST rule (CLAUDE.md): flat set-syntax via ParseSetCommand +
+// tree.SetPath; hierarchical via NewParser().Parse().
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func mssFlatTree(t *testing.T, cmds ...string) *config.ConfigTree {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+func mssHierTree(t *testing.T, input string) *config.ConfigTree {
+	t.Helper()
+	tree, errs := config.NewParser(input).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	return tree
+}
+
+func mssAcceptStrict(t *testing.T, tree *config.ConfigTree) {
+	t.Helper()
+	if _, err := config.CompileConfig(tree); err != nil {
+		t.Fatalf("expected strict ACCEPT, got: %v", err)
+	}
+}
+
+func mssRejectStrict(t *testing.T, tree *config.ConfigTree) {
+	t.Helper()
+	_, err := config.CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected strict REJECT, got nil")
+	}
+	if !strings.Contains(err.Error(), "tcp-mss") || !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("error should reference tcp-mss out-of-range: %v", err)
+	}
+}
+
+// --- Flat shape (the issue headline: `tcp-mss gre-in 70000` typo) ---
+
+func TestTCPMSSRange_FlatShape(t *testing.T) {
+	// Valid flat values accepted.
+	for _, kind := range []string{"ipsec-vpn", "gre-in", "gre-out", "all-tcp"} {
+		mssAcceptStrict(t, mssFlatTree(t, "set security flow tcp-mss "+kind+" 1400"))
+	}
+	// all-tcp 1396 (docs/ha-cluster.conf value) accepted.
+	mssAcceptStrict(t, mssFlatTree(t, "set security flow tcp-mss all-tcp 1396"))
+	// Boundary: 65535 accepted, 65536 rejected.
+	mssAcceptStrict(t, mssFlatTree(t, "set security flow tcp-mss gre-in 65535"))
+	mssRejectStrict(t, mssFlatTree(t, "set security flow tcp-mss gre-in 65536"))
+
+	// The headline typo: every kind out-of-range flat is rejected.
+	for _, kind := range []string{"ipsec-vpn", "gre-in", "gre-out", "all-tcp"} {
+		mssRejectStrict(t, mssFlatTree(t, "set security flow tcp-mss "+kind+" 70000"))
+	}
+}
+
+// --- Hierarchical shape (`gre-in { mss <n>; }`) ---
+
+func TestTCPMSSRange_HierarchicalShape(t *testing.T) {
+	// Valid hierarchical accepted (matches TestTCPMSSHierarchical).
+	mssAcceptStrict(t, mssHierTree(t, `security {
+    flow { tcp-mss {
+        ipsec-vpn { mss 1360; }
+        gre-in { mss 1360; }
+        gre-out { mss 1360; }
+    } }
+}`))
+	// Out-of-range in the mss child rejected.
+	mssRejectStrict(t, mssHierTree(t, `security {
+    flow { tcp-mss { gre-in { mss 70000; } } }
+}`))
+}
+
+// --- The precedence trap (Codex r1 #3): the compiler selects the mss child
+// FIRST; a mixed shape must validate ONLY the selected value. ---
+
+func TestTCPMSSRange_MixedShapePrecedence(t *testing.T) {
+	// gre-in 70000 { mss 1360 }: compiler selects the child 1360 and DISCARDS
+	// the flat 70000 -> must NOT false-reject (this is the converged-plan
+	// acceptance requirement). Verify both that it compiles AND that the
+	// compiled value is the selected 1360.
+	tree := mssHierTree(t, `security {
+    flow { tcp-mss { gre-in 70000 { mss 1360; } } }
+}`)
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("mixed shape gre-in 70000 { mss 1360 } must NOT false-reject: %v", err)
+	}
+	if cfg.Security.Flow.TCPMSSGreIn != 1360 {
+		t.Fatalf("compiler should select the mss child 1360, got %d", cfg.Security.Flow.TCPMSSGreIn)
+	}
+
+	// gre-in 1360 { mss 70000 }: compiler selects the child 70000 -> REJECT
+	// (the selected value is out of range).
+	mssRejectStrict(t, mssHierTree(t, `security {
+    flow { tcp-mss { gre-in 1360 { mss 70000; } } }
+}`))
+
+	// gre-in 1400 (flat) + gre-in { mss 1360 } both pass independently.
+	mssAcceptStrict(t, mssFlatTree(t, "set security flow tcp-mss gre-in 1400"))
+	mssAcceptStrict(t, mssHierTree(t, `security {
+    flow { tcp-mss { gre-in { mss 1360; } } }
+}`))
+}
+
+// --- Strict vs lenient (boot/HA safety — MANDATORY per plan §6) ---
+
+func TestTCPMSSRange_StrictVsLenient(t *testing.T) {
+	// Flat out-of-range.
+	flat := mssFlatTree(t, "set security flow tcp-mss gre-in 70000")
+	if _, err := config.CompileConfig(flat); err == nil {
+		t.Fatal("strict CompileConfig must REJECT tcp-mss gre-in 70000")
+	}
+	cfg, err := config.CompileConfigLenient(flat)
+	if err != nil {
+		t.Fatalf("lenient CompileConfigLenient must WARN-LOAD (not error) a legacy out-of-range MSS: %v", err)
+	}
+	foundWarn := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "tcp-mss") {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("lenient load should emit a tcp-mss warning, got warnings: %v", cfg.Warnings)
+	}
+	// The lenient COMPILE retains the raw value (the compiler does not
+	// coerce — Layer A coerces at the snapshot/wire boundary,
+	// pkg/dataplane/userspace/flow.go coerceWireU16, NOT at compile time).
+	// The point of the lenient path is that the node still BOOTS (no
+	// hard-fail), with the dataplane safe via Layer A. So we assert only
+	// that compile succeeded and warned — not that the value was changed.
+
+	// Node-aware lenient sibling (Store.SyncApply path) also warn-loads.
+	if _, err := config.CompileConfigForNodeLenient(flat, 0); err != nil {
+		t.Fatalf("CompileConfigForNodeLenient must WARN-LOAD: %v", err)
+	}
+
+	// Hierarchical out-of-range: strict reject, lenient warn-load.
+	hier := mssHierTree(t, `security {
+    flow { tcp-mss { gre-in { mss 70000; } } }
+}`)
+	if _, err := config.CompileConfig(hier); err == nil {
+		t.Fatal("strict CompileConfig must REJECT hierarchical out-of-range MSS")
+	}
+	if _, err := config.CompileConfigLenient(hier); err != nil {
+		t.Fatalf("lenient must WARN-LOAD hierarchical out-of-range MSS: %v", err)
+	}
+}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -6,6 +6,36 @@ package config
 // `bridge-domains`, and `routing-instances`. The root composition, the
 // schemaNode type, and the split rationale live in schema.go.
 
+// samplingFlowServerNode builds the typed `flow-server <address>` leaf for
+// a sampling output block (#1979 Layer B, Tier 2). It is a fresh node per
+// call so the inet and inet6 families own independent subtrees (mirrors
+// syslogFacilitySeverityLeaf). flow-server KEEPS args:1 for the collector
+// address; adding a children map deliberately flips its bare-terminal
+// `set ... flow-server <addr>` behaviour from single-value REPLACE to
+// named-container APPEND (ast_edit.go) — benign: a bare no-port server
+// compiles Port==0 and the snapshot builder skips it, and real collectors
+// carry `port` (taking the container path already). The `port` value feeds
+// the Rust u16 CollectorPort wire field; Layer A skips a server whose port
+// is <1 or >65535, so the bound is [1, 65535]. version9-template /
+// version9 { template } / source-address are the other children the
+// sampling compiler reads (compiler_services.go compileSamplingFamily) —
+// declared so completion does not silently drop them.
+func samplingFlowServerNode() *schemaNode {
+	return &schemaNode{
+		desc: "Flow collector address", args: 1, placeholder: "<address>",
+		children: map[string]*schemaNode{
+			"port": {desc: "Flow collector UDP port", args: 1, placeholder: "<port>",
+				valueType: ValueInteger, valueDesc: "Flow collector UDP port (1..65535)",
+				valueExamples: []string{"2055", "9995"}, validator: ValidateInteger(1, maxWireU16), children: nil},
+			"version9-template": {desc: "NetFlow v9 template name for this collector", args: 1, placeholder: "<template-name>", children: nil},
+			"version9": {desc: "NetFlow v9 export options", children: map[string]*schemaNode{
+				"template": {desc: "NetFlow v9 template name", args: 1, placeholder: "<template-name>", children: nil},
+			}},
+			"source-address": {desc: "Source address for exported flows", args: 1, placeholder: "<address>", children: nil},
+		},
+	}
+}
+
 var schemaRoutingOptions = &schemaNode{desc: "Routing options", children: map[string]*schemaNode{
 	"static": {desc: "Static routes", children: map[string]*schemaNode{
 		"route": {desc: "Static route", args: 1, placeholder: "<destination>", children: nil},
@@ -299,17 +329,27 @@ var schemaForwardingOptions = &schemaNode{desc: "Packet forwarding options", chi
 	}},
 	"sampling": {desc: "Traffic sampling for flow export", children: map[string]*schemaNode{
 		"instance": {desc: "Sampling instance", args: 1, placeholder: "<instance-name>", children: map[string]*schemaNode{
-			"input": {desc: "Sampling input properties (rate)", children: nil},
+			// #1979 Layer B (Tier 2): `input rate <n>` feeds the Rust u32
+			// SamplingRate wire field (buildFlowExportSnapshot, Layer A caps
+			// >u32max). Q3 DECISION: bound is [0, u32max] — EXACT Layer-A
+			// agreement. Accept 0 (the documented `0 = sample all` sentinel,
+			// types_system.go; Layer A normalizes rate<=0 -> 1), reject only
+			// the decode-aborting >u32max.
+			"input": {desc: "Sampling input properties (rate)", children: map[string]*schemaNode{
+				"rate": {desc: "Sample 1-in-N packets (0 = sample all)", args: 1, placeholder: "<rate>",
+					valueType: ValueInteger, valueDesc: "Sampling rate 1-in-N (0..4294967295; 0 = sample all)",
+					valueExamples: []string{"1", "1000"}, validator: ValidateInteger(0, maxWireU32), children: nil},
+			}},
 			"family": {desc: "Address family to sample", compoundKey: true, children: map[string]*schemaNode{
 				"inet": {desc: "IPv4 flow sampling", children: map[string]*schemaNode{
 					"output": {desc: "Sampling output configuration", children: map[string]*schemaNode{
-						"flow-server":  {desc: "Flow collector address", args: 1, placeholder: "<address>", children: nil},
+						"flow-server":  samplingFlowServerNode(),
 						"inline-jflow": {desc: "Inline flow export (jflow)", children: nil},
 					}},
 				}},
 				"inet6": {desc: "IPv6 flow sampling", children: map[string]*schemaNode{
 					"output": {desc: "Sampling output configuration", children: map[string]*schemaNode{
-						"flow-server":  {desc: "Flow collector address", args: 1, placeholder: "<address>", children: nil},
+						"flow-server":  samplingFlowServerNode(),
 						"inline-jflow": {desc: "Inline flow export (jflow)", children: nil},
 					}},
 				}},

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -214,10 +214,52 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		}},
 	}},
 	"flow": {desc: "Flow and session settings", children: map[string]*schemaNode{
-		"aging":                        {desc: "Aggressive session aging thresholds", children: nil},
-		"tcp-session":                  {desc: "TCP session options (timeouts, SYN checks)", children: nil},
-		"udp-session":                  {desc: "UDP session timeout (default 60 seconds)", children: nil},
-		"icmp-session":                 {desc: "ICMP session timeout (default 60 seconds)", children: nil},
+		"aging": {desc: "Aggressive session aging thresholds", children: nil},
+		// #1979 Layer B (Tier 2): expand the opaque session-timeout
+		// containers to real containers whose value-bearing sub-leaves are
+		// typed. The compiler reads tcp-session's four `<kind>-timeout`
+		// sub-leaves (compiler_security.go) + three presence flags;
+		// EstablishedTimeout reaches the Rust u64 TCPSessionTimeout wire
+		// field, the other three are stored only in TCPSessionConfig (not
+		// wire-reaching) but share the same Duration-overflow ceiling and
+		// declaring them is required for completion parity anyway. The bound
+		// is MaxDurationSeconds (NOT u64-max): Rust SessionTimeouts::
+		// from_seconds multiplies secs*1e9 unchecked (Layer A,
+		// coerceWireSessionTimeout). The presence flags are declared
+		// presence-only so completion still offers them.
+		"tcp-session": {desc: "TCP session options (timeouts, SYN checks)", children: map[string]*schemaNode{
+			"established-timeout": {desc: "Established TCP session timeout in seconds", args: 1, placeholder: "<seconds>",
+				valueType: ValueInteger, valueDesc: "Established TCP session timeout in seconds (0..9223372036)",
+				valueExamples: []string{"1800"}, validator: ValidateInteger(0, MaxDurationSeconds), children: nil},
+			"initial-timeout": {desc: "Initial (pre-established) TCP session timeout in seconds", args: 1, placeholder: "<seconds>",
+				valueType: ValueInteger, valueDesc: "Initial TCP session timeout in seconds (0..9223372036)",
+				valueExamples: []string{"20"}, validator: ValidateInteger(0, MaxDurationSeconds), children: nil},
+			"closing-timeout": {desc: "Closing TCP session timeout in seconds", args: 1, placeholder: "<seconds>",
+				valueType: ValueInteger, valueDesc: "Closing TCP session timeout in seconds (0..9223372036)",
+				valueExamples: []string{"4"}, validator: ValidateInteger(0, MaxDurationSeconds), children: nil},
+			"time-wait-timeout": {desc: "TIME_WAIT TCP session timeout in seconds", args: 1, placeholder: "<seconds>",
+				valueType: ValueInteger, valueDesc: "TIME_WAIT TCP session timeout in seconds (0..9223372036)",
+				valueExamples: []string{"150"}, validator: ValidateInteger(0, MaxDurationSeconds), children: nil},
+			"no-syn-check":           {desc: "Disable SYN check for TCP sessions", children: nil},
+			"no-syn-check-in-tunnel": {desc: "Disable SYN check for tunneled TCP sessions", children: nil},
+			"rst-invalidate-session": {desc: "Invalidate session on TCP RST", children: nil},
+		}},
+		"udp-session": {desc: "UDP session timeout (default 60 seconds)", children: map[string]*schemaNode{
+			"timeout": {desc: "UDP session timeout in seconds", args: 1, placeholder: "<seconds>",
+				valueType: ValueInteger, valueDesc: "UDP session timeout in seconds (0..9223372036)",
+				valueExamples: []string{"60"}, validator: ValidateInteger(0, MaxDurationSeconds), children: nil},
+		}},
+		"icmp-session": {desc: "ICMP session timeout (default 60 seconds)", children: map[string]*schemaNode{
+			"timeout": {desc: "ICMP session timeout in seconds", args: 1, placeholder: "<seconds>",
+				valueType: ValueInteger, valueDesc: "ICMP session timeout in seconds (0..9223372036)",
+				valueExamples: []string{"60"}, validator: ValidateInteger(0, MaxDurationSeconds), children: nil},
+		}},
+		// #1979 Layer B (Tier 3): tcp-mss stays OPAQUE here by design. Its
+		// MSS value can live in EITHER position (flat `gre-in 1400` OR
+		// hierarchical `gre-in { mss 1360; }`), which the declarative schema
+		// walker cannot express. Validation runs in the compiler AST pre-walk
+		// validateTCPMSSRanges (compiler.go), modeled on
+		// validateVRRPTrackInterfaceAST. See compiler_security.go.
 		"tcp-mss":                      {desc: "TCP MSS clamping (ipsec-vpn|gre-in|gre-out|all-tcp)", children: nil},
 		"allow-dns-reply":              {desc: "Allow unsolicited DNS reply packets", children: nil},
 		"allow-embedded-icmp":          {desc: "Allow ICMP error packets for existing sessions", children: nil},

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -475,8 +475,17 @@ var schemaServices = &schemaNode{desc: "Services configuration", children: map[s
 	"flow-monitoring": {desc: "Flow export (NetFlow v9 / IPFIX) template configuration", children: map[string]*schemaNode{
 		"version9": {desc: "NetFlow version 9 export", children: map[string]*schemaNode{
 			"template": {desc: "NetFlow v9 flow record template", args: 1, placeholder: "<template-name>", children: map[string]*schemaNode{
-				"flow-active-timeout":   {desc: "Active flow export timeout in seconds (default 60)", args: 1, placeholder: "<seconds>", children: nil},
-				"flow-inactive-timeout": {desc: "Inactive flow export timeout in seconds (default 15)", args: 1, placeholder: "<seconds>", children: nil},
+				// #1979 Layer B (Tier 1): FlowActiveTimeout/InactiveTimeout
+				// reach the Rust u32 ActiveTimeout/InactiveTimeout wire fields
+				// via buildFlowExportSnapshot (Layer A caps <0->0, >u32max->
+				// u32max, flow.go coerceWireU32Timeout). Reject the out-of-
+				// range value at commit instead of silently coercing it.
+				"flow-active-timeout": {desc: "Active flow export timeout in seconds (default 60)", args: 1, placeholder: "<seconds>",
+					valueType: ValueInteger, valueDesc: "Active flow export timeout in seconds (0..4294967295)",
+					valueExamples: []string{"60"}, validator: ValidateInteger(0, maxWireU32), children: nil},
+				"flow-inactive-timeout": {desc: "Inactive flow export timeout in seconds (default 15)", args: 1, placeholder: "<seconds>",
+					valueType: ValueInteger, valueDesc: "Inactive flow export timeout in seconds (0..4294967295)",
+					valueExamples: []string{"15"}, validator: ValidateInteger(0, maxWireU32), children: nil},
 				"template-refresh-rate": {desc: "Interval between template re-exports", children: map[string]*schemaNode{
 					"seconds": {desc: "Template refresh interval in seconds (default 60)", args: 1, placeholder: "<seconds>", children: nil},
 				}},
@@ -484,8 +493,18 @@ var schemaServices = &schemaNode{desc: "Services configuration", children: map[s
 		}},
 		"version-ipfix": {desc: "IPFIX flow export", children: map[string]*schemaNode{
 			"template": {desc: "IPFIX flow record template", args: 1, placeholder: "<template-name>", children: map[string]*schemaNode{
-				"flow-active-timeout":   {desc: "Active flow export timeout in seconds (default 60)", args: 1, placeholder: "<seconds>", children: nil},
-				"flow-inactive-timeout": {desc: "Inactive flow export timeout in seconds (default 15)", args: 1, placeholder: "<seconds>", children: nil},
+				// #1979 Layer B (Tier 1, §4b): the IPFIX timeouts do NOT reach
+				// the wire (buildFlowExportSnapshot reads only fm.Version9,
+				// flow.go), so this is UX parity only — but typing them is the
+				// same one-line change and keeps the two template families
+				// consistent. The Layer-A-agreement property test EXCLUDES
+				// these (not wire-reaching); plain accept/reject covers them.
+				"flow-active-timeout": {desc: "Active flow export timeout in seconds (default 60)", args: 1, placeholder: "<seconds>",
+					valueType: ValueInteger, valueDesc: "Active flow export timeout in seconds (0..4294967295)",
+					valueExamples: []string{"60"}, validator: ValidateInteger(0, maxWireU32), children: nil},
+				"flow-inactive-timeout": {desc: "Inactive flow export timeout in seconds (default 15)", args: 1, placeholder: "<seconds>",
+					valueType: ValueInteger, valueDesc: "Inactive flow export timeout in seconds (0..4294967295)",
+					valueExamples: []string{"15"}, validator: ValidateInteger(0, maxWireU32), children: nil},
 				"template-refresh-rate": {desc: "Interval between template re-exports", children: map[string]*schemaNode{
 					"seconds": {desc: "Template refresh interval in seconds (default 60)", args: 1, placeholder: "<seconds>", children: nil},
 				}},

--- a/pkg/config/schema_validate_flow_numwidth_test.go
+++ b/pkg/config/schema_validate_flow_numwidth_test.go
@@ -1,0 +1,268 @@
+package config_test
+
+// #1979 Layer B — commit-time NUM_WIDTH range validation for the
+// flow/flow-export fields that Layer A (#1977,
+// pkg/dataplane/userspace/flow.go) coerces to Rust u16/u32/u64.
+//
+// Tier 1 (version9 / version-ipfix flow-active/inactive-timeout) and Tier 2
+// (tcp-session / udp-session / icmp-session timeouts, sampling input rate,
+// flow-server port) are TYPED setSchema leaves, so accept/reject is asserted
+// here through SchemaValidate. Tier 3 (tcp-mss) stays opaque in setSchema and
+// is validated by the compiler AST pre-walk — its accept/reject is in
+// compiler_tcp_mss_range_test.go via CompileConfig, NOT SchemaValidate.
+//
+// Per the dual-AST testing rule (CLAUDE.md) flat set-syntax is driven via
+// ParseSetCommand + tree.SetPath (flatSchemaCheck), hierarchical via
+// NewParser().Parse() (schemaCheck) — NEVER NewParser for set-syntax.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// rangeAccept asserts SchemaValidate accepts a set-syntax config.
+func rangeAccept(t *testing.T, cmds ...string) {
+	t.Helper()
+	if err := flatSchemaCheck(t, cmds...); err != nil {
+		t.Fatalf("expected ACCEPT for %v, got: %v", cmds, err)
+	}
+}
+
+// rangeReject asserts SchemaValidate rejects a set-syntax config with a
+// range/out-of-range error that quotes the leaf keyword.
+func rangeReject(t *testing.T, leaf string, cmds ...string) {
+	t.Helper()
+	err := flatSchemaCheck(t, cmds...)
+	if err == nil {
+		t.Fatalf("expected REJECT for %v, got nil", cmds)
+	}
+	if !strings.Contains(err.Error(), "out of range") && !strings.Contains(err.Error(), "not an integer") {
+		t.Fatalf("error should be a range/integer error for %v: %v", cmds, err)
+	}
+	if leaf != "" && !strings.Contains(err.Error(), leaf) {
+		t.Fatalf("error should reference leaf %q for %v: %v", leaf, cmds, err)
+	}
+}
+
+// --- Tier 1: version9 / version-ipfix flow-active/inactive-timeout (u32) ---
+
+func TestNumWidth_Tier1_Version9Timeouts(t *testing.T) {
+	base := "set services flow-monitoring version9 template t1 "
+	rangeAccept(t, base+"flow-active-timeout 60")
+	rangeAccept(t, base+"flow-inactive-timeout 15")
+	rangeAccept(t, base+"flow-active-timeout 0")          // lower bound
+	rangeAccept(t, base+"flow-active-timeout 4294967295") // u32 max
+	rangeReject(t, "flow-active-timeout", base+"flow-active-timeout -1")
+	rangeReject(t, "flow-active-timeout", base+"flow-active-timeout 4294967296") // u32 max+1
+	rangeReject(t, "flow-inactive-timeout", base+"flow-inactive-timeout 5000000000")
+
+	// Hierarchical shape must accept/reject identically.
+	if err := schemaCheck(t, `services {
+    flow-monitoring {
+        version9 { template t1 { flow-active-timeout 60; } }
+    }
+}`); err != nil {
+		t.Fatalf("hierarchical valid: %v", err)
+	}
+	if err := schemaCheck(t, `services {
+    flow-monitoring {
+        version9 { template t1 { flow-active-timeout 5000000000; } }
+    }
+}`); err == nil {
+		t.Fatal("hierarchical out-of-range version9 flow-active-timeout should reject")
+	}
+}
+
+func TestNumWidth_Tier1_VersionIPFIXTimeouts(t *testing.T) {
+	// UX parity only (these do NOT reach the wire — buildFlowExportSnapshot
+	// reads fm.Version9 only). Plain accept/reject still applies.
+	base := "set services flow-monitoring version-ipfix template t1 "
+	rangeAccept(t, base+"flow-active-timeout 60")
+	rangeAccept(t, base+"flow-inactive-timeout 4294967295")
+	rangeReject(t, "flow-active-timeout", base+"flow-active-timeout 4294967296")
+}
+
+// --- Tier 2: session timeouts (u64, cap MaxDurationSeconds) ---
+
+func TestNumWidth_Tier2_SessionTimeouts(t *testing.T) {
+	max := config.MaxDurationSeconds // 9223372036
+
+	// tcp-session: all four typed timeouts (only established reaches wire,
+	// the rest share the Duration-overflow ceiling).
+	for _, kind := range []string{"established-timeout", "initial-timeout", "closing-timeout", "time-wait-timeout"} {
+		rangeAccept(t, "set security flow tcp-session "+kind+" 1800")
+		rangeAccept(t, "set security flow tcp-session "+kind+" 0")
+		rangeReject(t, kind, "set security flow tcp-session "+kind+" -1")
+		// MaxDurationSeconds+1 overflows the secs*1e9 product.
+		rangeReject(t, kind, "set security flow tcp-session "+kind+" 9223372037")
+	}
+	// Exactly MaxDurationSeconds is accepted (Layer A leaves it unchanged).
+	rangeAccept(t, "set security flow tcp-session established-timeout 9223372036")
+	if max != 9223372036 {
+		t.Fatalf("MaxDurationSeconds drifted from 9223372036: %d", max)
+	}
+
+	// tcp-session presence flags still accepted (declared presence-only).
+	rangeAccept(t, "set security flow tcp-session no-syn-check")
+	rangeAccept(t, "set security flow tcp-session rst-invalidate-session")
+
+	// udp-session / icmp-session timeout.
+	rangeAccept(t, "set security flow udp-session timeout 60")
+	rangeReject(t, "timeout", "set security flow udp-session timeout 9223372037")
+	rangeAccept(t, "set security flow icmp-session timeout 60")
+	rangeReject(t, "timeout", "set security flow icmp-session timeout -1")
+
+	// Hierarchical shape parity.
+	if err := schemaCheck(t, `security {
+    flow {
+        tcp-session { established-timeout 1800; no-syn-check; }
+        udp-session { timeout 60; }
+        icmp-session { timeout 60; }
+    }
+}`); err != nil {
+		t.Fatalf("hierarchical valid session timeouts: %v", err)
+	}
+	if err := schemaCheck(t, `security {
+    flow { udp-session { timeout 9223372037; } }
+}`); err == nil {
+		t.Fatal("hierarchical out-of-range udp-session timeout should reject")
+	}
+}
+
+// --- Tier 2: sampling input rate (u32) — Q3 = [0, u32max], accept 0 ---
+
+func TestNumWidth_Tier2_SamplingRate(t *testing.T) {
+	base := "set forwarding-options sampling instance i1 input rate "
+	// Q3 DECISION: accept 0 (the documented `0 = sample all` sentinel;
+	// Layer A normalizes rate<=0 -> 1). This is the EXACT Layer-A mirror.
+	rangeAccept(t, base+"0")
+	rangeAccept(t, base+"1")
+	rangeAccept(t, base+"1000")
+	rangeAccept(t, base+"4294967295") // u32 max
+	rangeReject(t, "rate", base+"-1")
+	rangeReject(t, "rate", base+"4294967296") // u32 max+1
+
+	if err := schemaCheck(t, `forwarding-options {
+    sampling { instance i1 { input { rate 1000; } } }
+}`); err != nil {
+		t.Fatalf("hierarchical valid sampling rate: %v", err)
+	}
+	if err := schemaCheck(t, `forwarding-options {
+    sampling { instance i1 { input { rate 4294967296; } } }
+}`); err == nil {
+		t.Fatal("hierarchical out-of-range sampling rate should reject")
+	}
+}
+
+// --- Tier 2: flow-server port (u16, [1,65535]) ---
+
+func TestNumWidth_Tier2_FlowServerPort(t *testing.T) {
+	for _, fam := range []string{"inet", "inet6"} {
+		base := "set forwarding-options sampling instance i1 family " + fam + " output flow-server 10.0.0.1 "
+		if fam == "inet6" {
+			base = "set forwarding-options sampling instance i1 family " + fam + " output flow-server 2001:db8::1 "
+		}
+		rangeAccept(t, base+"port 2055")
+		rangeAccept(t, base+"port 65535")
+		rangeReject(t, "port", base+"port 0")     // [1,65535]: Layer A skips port 0 / <1
+		rangeReject(t, "port", base+"port 65536") // >u16
+		rangeReject(t, "port", base+"port -1")
+	}
+
+	// Bare flow-server (no port) still accepted; the other declared
+	// children (version9-template, source-address) still accepted.
+	rangeAccept(t, "set forwarding-options sampling instance i1 family inet output flow-server 10.0.0.1")
+	rangeAccept(t, "set forwarding-options sampling instance i1 family inet output flow-server 10.0.0.1 version9-template t1")
+	rangeAccept(t, "set forwarding-options sampling instance i1 family inet output flow-server 10.0.0.1 source-address 10.0.0.9")
+
+	if err := schemaCheck(t, `forwarding-options {
+    sampling { instance i1 { family inet { output { flow-server 10.0.0.1 { port 2055; } } } } }
+}`); err != nil {
+		t.Fatalf("hierarchical valid flow-server port: %v", err)
+	}
+	if err := schemaCheck(t, `forwarding-options {
+    sampling { instance i1 { family inet { output { flow-server 10.0.0.1 { port 65536; } } } } }
+}`); err == nil {
+		t.Fatal("hierarchical out-of-range flow-server port should reject")
+	}
+}
+
+// --- Round-trip stability: an expanded container must not corrupt grouping ---
+
+func TestNumWidth_RoundTripStable(t *testing.T) {
+	tree := &config.ConfigTree{}
+	cmds := []string{
+		"set services flow-monitoring version9 template t1 flow-active-timeout 60",
+		"set services flow-monitoring version9 template t1 flow-inactive-timeout 15",
+		"set security flow tcp-session established-timeout 1800",
+		"set security flow tcp-session no-syn-check",
+		"set security flow udp-session timeout 60",
+		"set security flow icmp-session timeout 60",
+		"set forwarding-options sampling instance i1 input rate 1000",
+		"set forwarding-options sampling instance i1 family inet output flow-server 10.0.0.1 port 2055",
+	}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	const golden = `set services flow-monitoring version9 template t1 flow-active-timeout 60
+set services flow-monitoring version9 template t1 flow-inactive-timeout 15
+set security flow tcp-session established-timeout 1800
+set security flow tcp-session no-syn-check
+set security flow udp-session timeout 60
+set security flow icmp-session timeout 60
+set forwarding-options sampling instance i1 input rate 1000
+set forwarding-options sampling instance i1 family inet output flow-server 10.0.0.1 port 2055
+`
+	if got := tree.FormatSet(); got != golden {
+		t.Fatalf("flow numwidth grouping changed:\n--- got ---\n%s\n--- want ---\n%s", got, golden)
+	}
+
+	// Two flow-servers must APPEND (multiple collectors valid), not replace.
+	for _, cmd := range []string{
+		"set forwarding-options sampling instance i1 family inet output flow-server 10.0.0.2 port 2056",
+	} {
+		path, _ := config.ParseSetCommand(cmd)
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	out := tree.FormatSet()
+	if strings.Count(out, "flow-server 10.0.0.1") == 0 || strings.Count(out, "flow-server 10.0.0.2") == 0 {
+		t.Fatalf("expected both flow-servers to survive (APPEND, not replace):\n%s", out)
+	}
+}
+
+// --- Completion parity: every compiler-read child of an expanded container
+// must still be offered (no silent drop after the container expansion). ---
+
+func TestNumWidth_CompletionParity(t *testing.T) {
+	want := func(t *testing.T, tokens []string, expected ...string) {
+		t.Helper()
+		got := config.CompleteSetPath(tokens)
+		set := map[string]bool{}
+		for _, g := range got {
+			set[g] = true
+		}
+		for _, e := range expected {
+			if !set[e] {
+				t.Fatalf("completion at %v missing %q (got %v)", tokens, e, got)
+			}
+		}
+	}
+	want(t, []string{"security", "flow", "tcp-session"},
+		"established-timeout", "initial-timeout", "closing-timeout", "time-wait-timeout",
+		"no-syn-check", "no-syn-check-in-tunnel", "rst-invalidate-session")
+	want(t, []string{"security", "flow", "udp-session"}, "timeout")
+	want(t, []string{"security", "flow", "icmp-session"}, "timeout")
+	want(t, []string{"forwarding-options", "sampling", "instance", "i1", "input"}, "rate")
+	want(t, []string{"forwarding-options", "sampling", "instance", "i1", "family", "inet", "output", "flow-server", "10.0.0.1"},
+		"port", "version9-template", "version9", "source-address")
+}

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -131,6 +131,19 @@ const MaxDurationMillis = int64(math.MaxInt64) / int64(time.Millisecond)
 // invert the damping behaviour).
 const MaxDurationSeconds = int64(math.MaxInt64) / int64(time.Second)
 
+// maxWireU16 / maxWireU32 are the inclusive ceilings for typed leaves
+// whose value lands in a Rust u16 / u32 wire field. #1979 Layer B uses
+// these so the commit-time range gate agrees EXACTLY with the build-time
+// coercion in pkg/dataplane/userspace/flow.go (Layer A, #1977): a value
+// Layer B accepts is one Layer A leaves unchanged, and a value Layer B
+// rejects is one Layer A would have coerced. (math.MaxUint16 /
+// math.MaxUint32 are untyped constants; naming them keeps the schema
+// aspect files import-free and the bound self-documenting.)
+const (
+	maxWireU16 = int64(math.MaxUint16)
+	maxWireU32 = int64(math.MaxUint32)
+)
+
 // ValidateIntegerMin returns a closure that accepts any bare integer
 // >= min — the "no upper bound" spelling for typed leaves whose runtime
 // consumes the full integer range. The representational maximum is

--- a/pkg/dataplane/userspace/flow_numwidth_agreement_test.go
+++ b/pkg/dataplane/userspace/flow_numwidth_agreement_test.go
@@ -1,0 +1,143 @@
+package userspace
+
+// #1979 Layer B / Layer A agreement (the directional invariant, plan §8 item
+// 5). Layer A (#1977, flow.go coerceWire*) coerces every flow/flow-export
+// wire field into its Rust range at the snapshot boundary; Layer B (#1979,
+// config.setSchema typed leaves + validateTCPMSSRanges) rejects out-of-range
+// values at commit. The two MUST agree:
+//
+//	Layer B never REJECTS a value Layer A ACCEPTS (leaves unchanged), and
+//	every value Layer B rejects is one Layer A would have coerced.
+//
+// Asymmetry (Q3 = [0, u32max]): Layer B ACCEPTS sampling rate 0 but Layer A
+// NORMALIZES 0 -> 1 (a sentinel, not a clamp). So the invariant is "does not
+// reject what Layer A accepts", NOT "leaves accepted values unchanged" —
+// sampling 0 is the documented exception.
+//
+// Scope: ONLY the wire-reaching fields (the 11 fields / Layer-A coercions).
+// version-ipfix timeouts do NOT reach Layer A (buildFlowExportSnapshot reads
+// fm.Version9 only), so they are EXCLUDED — their typing is UX parity only.
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// layerBField pairs a Layer-B validator with the Layer-A coercion it must
+// agree with, plus a name for diagnostics.
+type layerBField struct {
+	name string
+	// validate runs the Layer-B commit-time validator (nil error = accept).
+	validate func(int64) error
+	// coerce runs the Layer-A build-time coercion and returns the resulting
+	// wire value (already in range).
+	coerce func(int) int
+	// accept0AsSentinel: Layer A accepts the input but normalizes it to a
+	// different value (the sampling 0 -> 1 sentinel). When true, an
+	// "accepted-but-changed" 0 is the documented exception, not a violation.
+	zeroIsSentinel bool
+}
+
+func intValidator(min, max int64) func(int64) error {
+	v := config.ValidateInteger(min, max)
+	return func(n int64) error { return v(strconv.FormatInt(n, 10), nil) }
+}
+
+func numwidthFields() []layerBField {
+	return []layerBField{
+		{
+			name:     "tcp_mss_u16",
+			validate: intValidator(0, math.MaxUint16),
+			coerce:   func(v int) int { return coerceWireU16("t", v) },
+		},
+		{
+			name:     "active_inactive_timeout_u32",
+			validate: intValidator(0, math.MaxUint32),
+			coerce:   func(v int) int { return coerceWireU32Timeout("t", v) },
+		},
+		{
+			name:     "session_timeout_u64",
+			validate: intValidator(0, config.MaxDurationSeconds),
+			coerce:   func(v int) int { return coerceWireSessionTimeout("t", v) },
+		},
+		{
+			name:     "collector_port_u16",
+			validate: intValidator(1, math.MaxUint16),
+			// Layer A FORWARDS a server only when its port is in [1, 65535];
+			// port 0 is the absent sentinel (skipped) and <1 / >u16 are
+			// skipped too (flow.go: server.Port==0 -> continue; <0||>u16 ->
+			// continue). So the "accepts unchanged" set is exactly [1, 65535].
+			// Model coerce to return the value for an in-range port and a
+			// distinct sentinel (-2) for a skipped one, so layerAUnchanged is
+			// false (and invariant #2 correctly does not apply) outside range.
+			coerce: func(v int) int {
+				if v >= 1 && v <= math.MaxUint16 {
+					return v
+				}
+				return -2
+			},
+		},
+		{
+			name:           "sampling_rate_u32",
+			validate:       intValidator(0, math.MaxUint32), // Q3 = [0, u32max]
+			coerce:         coerceSamplingRate,
+			zeroIsSentinel: true,
+		},
+	}
+}
+
+// coerceSamplingRate mirrors buildFlowExportSnapshot's rate handling
+// (rate<=0 -> 1, >u32max -> u32max).
+func coerceSamplingRate(v int) int {
+	if v <= 0 {
+		return 1
+	}
+	if int64(v) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return v
+}
+
+func TestNumWidth_LayerAB_Agreement(t *testing.T) {
+	// Boundary values spanning every wire width.
+	values := []int64{
+		-1, 0, 1,
+		65535, 65536, // u16 boundary
+		math.MaxUint32, math.MaxUint32 + 1, // u32 boundary
+		config.MaxDurationSeconds, config.MaxDurationSeconds + 1, // u64 session cap
+	}
+
+	for _, f := range numwidthFields() {
+		for _, v := range values {
+			// All test values fit in a 64-bit int (the Layer-A coercion
+			// signature). int is 64-bit on the supported platforms.
+			bAccepts := f.validate(v) == nil
+			got := int64(f.coerce(int(v)))
+			layerAUnchanged := got == v
+
+			// Directional invariant #1: if Layer B accepts v, Layer A must
+			// leave it unchanged — UNLESS it is the sampling-0 sentinel, the
+			// one documented exception (Layer A normalizes 0 -> 1).
+			if bAccepts && !layerAUnchanged {
+				if f.zeroIsSentinel && v == 0 {
+					if got != 1 {
+						t.Fatalf("%s: sampling 0 should normalize to 1, got %d", f.name, got)
+					}
+				} else {
+					t.Fatalf("%s: Layer B accepted %d but Layer A changed it to %d (Layer B must not accept a value Layer A coerces)", f.name, v, got)
+				}
+			}
+
+			// Directional invariant #2 (the headline, plan §8 item 5): Layer B
+			// must NEVER reject a value Layer A leaves unchanged. (Where Layer
+			// A changes the value — out-of-range, or the sampling-0 sentinel —
+			// there is nothing to assert in this direction.)
+			if layerAUnchanged && !bAccepts {
+				t.Fatalf("%s: Layer A left %d unchanged but Layer B REJECTED it (Layer B must not reject what Layer A accepts)", f.name, v)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Layer B of #1977 — commit-time range validation for the flow/flow-export
fields that Layer A (#1977, `buildFlowSnapshot` / `buildFlowExportSnapshot`
in `pkg/dataplane/userspace/flow.go`) coerces to Rust `u16`/`u32`/`u64`.
Layer A already makes every value SAFE at the wire boundary; Layer B is the
operator-UX companion — a clear `commit check` error instead of silent
coercion. Implemented exactly per the 3-way converged plan
(`docs/research/1979-layerb-validate/plan.md`, PLAN v3).

## Three tiers

**Tier 1 — typed `setSchema` leaves (declarative #1319 path):**
`services flow-monitoring version9 template <t> flow-active-timeout` /
`flow-inactive-timeout` → `ValidateInteger(0, maxWireU32)` (Rust u32). The
parallel `version-ipfix` pair is typed identically for UX parity (it does
NOT reach the wire — `buildFlowExportSnapshot` reads `fm.Version9` only).

**Tier 2 — opaque containers → typed-child containers:**
- `security flow tcp-session`: `established-timeout` (Rust u64
  TCPSessionTimeout) + `initial`/`closing`/`time-wait-timeout` (config-only)
  all `ValidateInteger(0, MaxDurationSeconds)` (the Duration-overflow
  ceiling, NOT u64-max — the helper multiplies `secs*1e9` unchecked); plus
  the three presence flags declared presence-only for completion parity.
- `udp-session` / `icmp-session`: typed `timeout` (same bound).
- sampling `input rate`: `ValidateInteger(0, maxWireU32)`.
- `flow-server port`: `ValidateInteger(1, maxWireU16)` (Rust u16
  CollectorPort; Layer A skips a server with port `<1`/`>65535`).
  `flow-server` gains a children map → deliberate bare-terminal
  REPLACE→APPEND flip (benign; pinned by a golden).

**Tier 3 — compiler AST pre-walk (`validateVRRPTrackInterfaceAST` precedent):**
`tcp-mss` stays OPAQUE in `setSchema` because its MSS value can live in
EITHER the kind node's flat `Keys[1]` OR a hierarchical `mss` sub-child — a
dual value-location the declarative walker cannot express. New
`validateTCPMSSRanges` (`compiler_security.go`, wired into `compileExpanded`)
range-checks the **compiler-selected** token at `[0, 65535]` via
`selectMSSToken` (extracted from and SHARED with `parseMSSValue` so they can
never diverge). The mixed shape `gre-in 70000 { mss 1360; }` therefore does
NOT false-reject (the compiler selects the child 1360).

## Q3 decision = `[0, u32max]` (sampling 0 accepted)

Sampling `input rate` 0 is the documented `0 = sample all` sentinel
(`types_system.go`); Layer A normalizes `rate<=0 -> 1`. The bound is the
EXACT Layer-A mirror, rejecting only the decode-aborting `>u32max`.

## Strict vs lenient (boot/HA safety)

Tiers 1+2 get the strict/lenient split for free (typed-leaf
`SchemaValidate` violations hard-reject on strict commit, downgrade to a
warning on `Store.Load`/`Store.SyncApply` via `compileTreeLenient`). Tier 3
takes a `lenient` flag (new `lenientTCPMSSRange` `compileOpt`, set by
`CompileConfigLenient`/`CompileConfigForNodeLenient`) exactly like the VRRP
validator: strict commit hard-rejects, but the tolerant load/peer-sync path
WARNS and lets Layer A coerce, so an upgraded node loading a legacy
`tcp-mss gre-in 70000` still boots.

## Tests (per plan §8)

- `pkg/config/schema_validate_flow_numwidth_test.go` — Tiers 1+2 via
  `SchemaValidate` (flat + hierarchical accept/reject), round-trip golden,
  completion parity, sampling-0 accepted.
- `pkg/config/compiler_tcp_mss_range_test.go` — Tier 3 via `CompileConfig` /
  `CompileConfigLenient`: flat/hierarchical reject, mixed-shape precedence
  (`gre-in 70000 { mss 1360 }` PASSES, value 1360; `gre-in 1360 { mss 70000 }`
  REJECTS), `all-tcp 1396` passes, strict-vs-lenient.
- `pkg/dataplane/userspace/flow_numwidth_agreement_test.go` — the
  directional Layer-A agreement invariant (Layer B never rejects what Layer A
  accepts; sampling-0 the documented exception), scoped to wire-reaching
  fields.

`docs/config-schema.md` gains a #1979 section. `docs/ha-cluster.conf` +
`test/incus/xpf-test.conf` still pass strict commit-check unchanged.
`go build ./...` and `go test ./...` green (45 ok, 0 FAIL). No Layer A /
Rust / wire change.

Converged plan: `docs/research/1979-layerb-validate/plan.md` (PLAN v3,
3-way PLAN-READY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)