### PR TITLE
#2036: fail closed on overlength LLDP TLVs instead of masking length

### DIFF
--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -53,15 +53,15 @@ const (
 
 // Neighbor represents a discovered LLDP neighbor on an interface.
 type Neighbor struct {
-	ChassisID   string // chassis identifier (MAC or string)
-	PortID      string // port identifier (interface name)
-	TTL         int    // advertised hold time in seconds
-	SystemName  string
-	SystemDesc  string
-	PortDesc    string
-	LastSeen    time.Time
-	ExpiresAt   time.Time
-	Interface   string // local interface where neighbor was seen
+	ChassisID  string // chassis identifier (MAC or string)
+	PortID     string // port identifier (interface name)
+	TTL        int    // advertised hold time in seconds
+	SystemName string
+	SystemDesc string
+	PortDesc   string
+	LastSeen   time.Time
+	ExpiresAt  time.Time
+	Interface  string // local interface where neighbor was seen
 }
 
 // LLDPInterface holds per-interface LLDP configuration.
@@ -209,7 +209,13 @@ func (m *Manager) txLoop(ctx context.Context, iface *net.Interface, interval tim
 
 // sendFrame builds and sends a single LLDP frame on the interface.
 func (m *Manager) sendFrame(iface *net.Interface, ttl int, sysName, sysDesc string) {
-	frame := BuildFrame(iface.HardwareAddr, iface.Name, ttl, sysName, sysDesc)
+	frame, err := BuildFrame(iface.HardwareAddr, iface.Name, ttl, sysName, sysDesc)
+	if err != nil {
+		// Fail closed: skip this advertisement rather than send a malformed
+		// frame with a wrapped TLV length (#2036).
+		slog.Warn("LLDP TX: skipping frame with overlength TLV", "interface", iface.Name, "err", err)
+		return
+	}
 
 	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
 	if err != nil {
@@ -311,22 +317,38 @@ func (m *Manager) expiryLoop(ctx context.Context) {
 	}
 }
 
-// BuildFrame constructs a complete LLDP Ethernet frame.
-func BuildFrame(srcMAC net.HardwareAddr, portName string, ttl int, sysName, sysDesc string) []byte {
+// BuildFrame constructs a complete LLDP Ethernet frame. It fails closed if any
+// variable-length identity TLV (system name/description, port description)
+// exceeds the 9-bit TLV length limit, rather than emitting a malformed
+// advertisement (#2036).
+func BuildFrame(srcMAC net.HardwareAddr, portName string, ttl int, sysName, sysDesc string) ([]byte, error) {
 	var tlvs []byte
-	tlvs = append(tlvs, EncodeTLV(tlvChassisID, encodeChassisID(srcMAC))...)
-	tlvs = append(tlvs, EncodeTLV(tlvPortID, encodePortID(portName))...)
-	tlvs = append(tlvs, EncodeTLV(tlvTTL, encodeTTL(ttl))...)
-	if sysName != "" {
-		tlvs = append(tlvs, EncodeTLV(tlvSystemName, []byte(sysName))...)
+	// Fixed / OS-bounded TLVs (chassis ID = MAC, port ID = ifname, TTL, End).
+	tlvs = append(tlvs, mustEncodeTLV(tlvChassisID, encodeChassisID(srcMAC))...)
+	tlvs = append(tlvs, mustEncodeTLV(tlvPortID, encodePortID(portName))...)
+	tlvs = append(tlvs, mustEncodeTLV(tlvTTL, encodeTTL(ttl))...)
+	// Variable-length identity TLVs: fail closed on overlength rather than
+	// shipping a frame whose wrapped 9-bit length desynchronizes the receiver.
+	optional := []struct {
+		typ int
+		val []byte
+		on  bool
+	}{
+		{tlvSystemName, []byte(sysName), sysName != ""},
+		{tlvSystemDesc, []byte(sysDesc), sysDesc != ""},
+		{tlvPortDesc, []byte(portName), portName != ""},
 	}
-	if sysDesc != "" {
-		tlvs = append(tlvs, EncodeTLV(tlvSystemDesc, []byte(sysDesc))...)
+	for _, o := range optional {
+		if !o.on {
+			continue
+		}
+		enc, err := EncodeTLV(o.typ, o.val)
+		if err != nil {
+			return nil, err
+		}
+		tlvs = append(tlvs, enc...)
 	}
-	if portName != "" {
-		tlvs = append(tlvs, EncodeTLV(tlvPortDesc, []byte(portName))...)
-	}
-	tlvs = append(tlvs, EncodeTLV(tlvEnd, nil)...) // End TLV
+	tlvs = append(tlvs, mustEncodeTLV(tlvEnd, nil)...) // End TLV
 
 	// Build Ethernet frame: dst(6) + src(6) + ethertype(2) + payload.
 	frame := make([]byte, 0, ethHdrLen+len(tlvs))
@@ -338,17 +360,42 @@ func BuildFrame(srcMAC net.HardwareAddr, portName string, ttl int, sysName, sysD
 	}
 	frame = append(frame, byte(etherTypeLLDP>>8), byte(etherTypeLLDP&0xff))
 	frame = append(frame, tlvs...)
-	return frame
+	return frame, nil
 }
 
-// EncodeTLV encodes a single LLDP TLV (type-length-value).
+// maxTLVValueLen is the largest value an LLDP TLV can carry: the length field
+// is 9 bits, so 511 bytes. A larger value would wrap the header length while
+// the full payload stayed in the frame, so a receiver would misparse the
+// overflow as following TLVs — a malformed advertisement (#2036).
+const maxTLVValueLen = 0x1ff
+
+// EncodeTLV encodes a single LLDP TLV (type-length-value). It FAILS CLOSED on
+// an overlength value rather than masking the 9-bit length and emitting a
+// malformed frame — advertised identity must not be silently lossy.
 // TLV header: 7 bits type + 9 bits length = 2 bytes.
-func EncodeTLV(tlvType int, value []byte) []byte {
+func EncodeTLV(tlvType int, value []byte) ([]byte, error) {
 	length := len(value)
+	if length > maxTLVValueLen {
+		return nil, fmt.Errorf("lldp: TLV type %d value is %d bytes, exceeds the %d-byte (9-bit) length limit",
+			tlvType, length, maxTLVValueLen)
+	}
 	header := uint16(tlvType&0x7f)<<9 | uint16(length&0x1ff)
 	out := make([]byte, 2+length)
 	binary.BigEndian.PutUint16(out[:2], header)
 	copy(out[2:], value)
+	return out, nil
+}
+
+// mustEncodeTLV is EncodeTLV for callers whose value length is bounded at
+// compile time (the End TLV) or by a hard OS limit (chassis ID = MAC, port ID =
+// interface name, TTL = 2 bytes) and so can never exceed the 9-bit limit. It
+// panics if that invariant is ever violated rather than returning a malformed
+// frame.
+func mustEncodeTLV(tlvType int, value []byte) []byte {
+	out, err := EncodeTLV(tlvType, value)
+	if err != nil {
+		panic(err)
+	}
 	return out
 }
 

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -323,9 +323,15 @@ func (m *Manager) expiryLoop(ctx context.Context) {
 // advertisement (#2036).
 func BuildFrame(srcMAC net.HardwareAddr, portName string, ttl int, sysName, sysDesc string) ([]byte, error) {
 	var tlvs []byte
-	// Fixed / OS-bounded TLVs (chassis ID = MAC, port ID = ifname, TTL, End).
+	// Chassis ID (MAC = 7 bytes) and TTL (2 bytes) are compile-time bounded.
 	tlvs = append(tlvs, mustEncodeTLV(tlvChassisID, encodeChassisID(srcMAC))...)
-	tlvs = append(tlvs, mustEncodeTLV(tlvPortID, encodePortID(portName))...)
+	// Port ID carries portName which is caller-supplied: propagate error rather
+	// than panic so BuildFrame stays consistently fail-closed (#2036).
+	portIDEnc, err := EncodeTLV(tlvPortID, encodePortID(portName))
+	if err != nil {
+		return nil, err
+	}
+	tlvs = append(tlvs, portIDEnc...)
 	tlvs = append(tlvs, mustEncodeTLV(tlvTTL, encodeTTL(ttl))...)
 	// Variable-length identity TLVs: fail closed on overlength rather than
 	// shipping a frame whose wrapped 9-bit length desynchronizes the receiver.
@@ -387,10 +393,10 @@ func EncodeTLV(tlvType int, value []byte) ([]byte, error) {
 }
 
 // mustEncodeTLV is EncodeTLV for callers whose value length is bounded at
-// compile time (the End TLV) or by a hard OS limit (chassis ID = MAC, port ID =
-// interface name, TTL = 2 bytes) and so can never exceed the 9-bit limit. It
-// panics if that invariant is ever violated rather than returning a malformed
-// frame.
+// compile time (the End TLV) or by a hard OS/protocol limit (chassis ID = MAC
+// = 7 bytes, TTL = 2 bytes) and so can never exceed the 9-bit limit. It panics
+// if that invariant is ever violated rather than returning a malformed frame.
+// Caller-supplied strings such as port ID must use EncodeTLV directly.
 func mustEncodeTLV(tlvType int, value []byte) []byte {
 	out, err := EncodeTLV(tlvType, value)
 	if err != nil {

--- a/pkg/lldp/lldp_test.go
+++ b/pkg/lldp/lldp_test.go
@@ -70,6 +70,11 @@ func TestBuildFrame_FailsClosedOnOverlengthIdentity(t *testing.T) {
 	if _, err := BuildFrame(mac, "trust0", 120, "xpf", huge); err == nil {
 		t.Fatal("BuildFrame must fail closed on an overlength system-description TLV")
 	}
+	// An overlength port name must also fail closed (not panic), since portName
+	// is caller-supplied and BuildFrame now routes it through EncodeTLV (#2036).
+	if _, err := BuildFrame(mac, huge, 120, "xpf", "ok"); err == nil {
+		t.Fatal("BuildFrame must fail closed on an overlength port name TLV")
+	}
 	// A bounded frame still builds cleanly.
 	if _, err := BuildFrame(mac, "trust0", 120, "xpf", "ok"); err != nil {
 		t.Fatalf("bounded frame should build, got: %v", err)

--- a/pkg/lldp/lldp_test.go
+++ b/pkg/lldp/lldp_test.go
@@ -9,7 +9,10 @@ import (
 
 func TestEncodeTLV(t *testing.T) {
 	// End TLV: type=0, length=0 → 0x0000
-	end := EncodeTLV(tlvEnd, nil)
+	end, err := EncodeTLV(tlvEnd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(end) != 2 {
 		t.Fatalf("expected 2 bytes, got %d", len(end))
 	}
@@ -18,7 +21,10 @@ func TestEncodeTLV(t *testing.T) {
 	}
 
 	// System Name TLV: type=5, value="test"
-	name := EncodeTLV(tlvSystemName, []byte("test"))
+	name, err := EncodeTLV(tlvSystemName, []byte("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(name) != 6 {
 		t.Fatalf("expected 6 bytes, got %d", len(name))
 	}
@@ -33,6 +39,40 @@ func TestEncodeTLV(t *testing.T) {
 	}
 	if string(name[2:]) != "test" {
 		t.Errorf("expected value 'test', got %q", string(name[2:]))
+	}
+}
+
+func TestEncodeTLV_FailsClosedOnOverlength(t *testing.T) {
+	// 511 bytes: the maximum a 9-bit length can express — accepted, and the
+	// encoded header length matches.
+	maxVal := make([]byte, maxTLVValueLen) // 511
+	enc, err := EncodeTLV(tlvSystemDesc, maxVal)
+	if err != nil {
+		t.Fatalf("511-byte value should encode, got: %v", err)
+	}
+	if got := int(binary.BigEndian.Uint16(enc[:2]) & 0x1ff); got != maxTLVValueLen {
+		t.Fatalf("encoded length should be %d, got %d", maxTLVValueLen, got)
+	}
+	// 512 and 600 bytes: would wrap the 9-bit length field — must be REJECTED,
+	// not silently masked into a malformed frame (#2036).
+	for _, n := range []int{maxTLVValueLen + 1, 600} {
+		if _, err := EncodeTLV(tlvSystemDesc, make([]byte, n)); err == nil {
+			t.Errorf("a %d-byte value must be rejected (would wrap the 9-bit length), got nil error", n)
+		}
+	}
+}
+
+func TestBuildFrame_FailsClosedOnOverlengthIdentity(t *testing.T) {
+	mac := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	// An overlength variable-length identity TLV (system description) must fail
+	// the whole frame rather than emit a malformed advertisement.
+	huge := string(make([]byte, 600))
+	if _, err := BuildFrame(mac, "trust0", 120, "xpf", huge); err == nil {
+		t.Fatal("BuildFrame must fail closed on an overlength system-description TLV")
+	}
+	// A bounded frame still builds cleanly.
+	if _, err := BuildFrame(mac, "trust0", 120, "xpf", "ok"); err != nil {
+		t.Fatalf("bounded frame should build, got: %v", err)
 	}
 }
 
@@ -76,7 +116,10 @@ func TestEncodeTTL(t *testing.T) {
 
 func TestBuildFrame(t *testing.T) {
 	mac := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
-	frame := BuildFrame(mac, "trust0", 120, "xpf", "stateful firewall")
+	frame, err := BuildFrame(mac, "trust0", 120, "xpf", "stateful firewall")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Check Ethernet header.
 	if len(frame) < ethHdrLen {
@@ -130,9 +173,9 @@ func TestParseTLVs_Incomplete(t *testing.T) {
 	// Missing Port ID — should return nil.
 	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
 	var data []byte
-	data = append(data, EncodeTLV(tlvChassisID, encodeChassisID(mac))...)
-	data = append(data, EncodeTLV(tlvTTL, encodeTTL(60))...)
-	data = append(data, EncodeTLV(tlvEnd, nil)...)
+	data = append(data, mustEncodeTLV(tlvChassisID, encodeChassisID(mac))...)
+	data = append(data, mustEncodeTLV(tlvTTL, encodeTTL(60))...)
+	data = append(data, mustEncodeTLV(tlvEnd, nil)...)
 
 	n := ParseTLVs(data)
 	if n != nil {
@@ -142,7 +185,10 @@ func TestParseTLVs_Incomplete(t *testing.T) {
 
 func TestParseTLVs_Truncated(t *testing.T) {
 	// Header says 100 bytes but only 2 bytes available.
-	data := EncodeTLV(tlvSystemName, []byte("test"))
+	data, err := EncodeTLV(tlvSystemName, []byte("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Corrupt the length to be larger than available.
 	binary.BigEndian.PutUint16(data[:2], uint16(tlvSystemName)<<9|100)
 
@@ -241,7 +287,10 @@ func TestNeighborExpiry(t *testing.T) {
 func TestRoundTripTLVs(t *testing.T) {
 	// Build a frame and parse it back — full round-trip test.
 	mac := net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01}
-	frame := BuildFrame(mac, "ge-0/0/1", 300, "switch1", "Juniper EX4300")
+	frame, err := BuildFrame(mac, "ge-0/0/1", 300, "switch1", "Juniper EX4300")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	n := ParseTLVs(frame[ethHdrLen:])
 	if n == nil {


### PR DESCRIPTION
## Summary
`EncodeTLV` masked the value length into the 9-bit TLV length field but still appended the full value, so an overlength value (>511 bytes) wrapped the header length while the full payload stayed in the frame — receivers misparse the overflow as following TLVs (malformed advertisements). The codec is a protocol boundary; it now fails closed.

## Changes (pkg/lldp, codec-only)
- `EncodeTLV` returns `([]byte, error)`, rejects values >511 bytes (`maxTLVValueLen=0x1ff`).
- `mustEncodeTLV` for the compile-time/OS-bounded TLVs (chassis ID, port ID=ifname, TTL, End) — panics if the impossible happens.
- `BuildFrame` returns `([]byte, error)`; variable-length identity TLVs (system name/desc, port desc) propagate the error.
- `sendFrame` fails closed (logs + skips) rather than sending a malformed frame.

## Test plan
- [x] `EncodeTLV` 511 encodes (header length matches), 512 + 600 rejected (not masked)
- [x] `BuildFrame` fails closed on an overlength system-description TLV; bounded frame still builds
- [x] existing codec test callers updated; `go test ./pkg/lldp/` passes; `go build ./...` clean

## Disposition
engineer-now (codex-review-014 finding 4). Scope is the codec fail-closed (the protocol bug). The optional LLDP timing-leaf schema bounds noted in #2036 are a separate smaller hardening — the string TLVs are system-derived and now protected by the codec regardless.

Closes #2036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)