### PR TITLE
daemon: clear FRR managed section on compile-failed unarmed boot (#1993)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -70,6 +70,20 @@
   test/incus/test_mouse_latency_shell_test.py,
   test/incus/test-mouse-latency.sh, docs/fairness-regimes.md, _Log.md
 
+## 2026-06-20 — #1993 review follow-up on FRR clear guard
+
+- **Timestamp**: 2026-06-20
+- **Action**: Addressed review feedback on the compile-failed boot FRR clear.
+  The original `configCompileFailed` gate also fired on daemon restarts,
+  which could drop FRR peerings even when hitless-restart pinned XDP links
+  showed the last-known-good dataplane was still live. Added a pinned-link
+  probe (`/sys/fs/bpf/xpf/links`, `xdp_*`) so the managed-section clear now
+  runs only when the boot is compile-failed AND unarmed. Also hedged the
+  degraded/write-failure warning text and added restart/probe-error
+  regression tests. Updated `pkg/daemon/README.md`.
+- **File(s)**: pkg/daemon/bootstrap.go, pkg/daemon/daemon_run.go,
+  pkg/daemon/frr_failclosed_boot_test.go, pkg/daemon/README.md, _Log.md
+
 ## 2026-06-19 — #1993 clear FRR managed section on compile-failed cold boot
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -70,6 +70,26 @@
   test/incus/test_mouse_latency_shell_test.py,
   test/incus/test-mouse-latency.sh, docs/fairness-regimes.md, _Log.md
 
+## 2026-06-19 — #1993 clear FRR managed section on compile-failed cold boot
+
+- **Timestamp**: 2026-06-19
+- **Action**: On a compile-failure cold-boot bootstrap (the #1960
+  fail-closed tuple), the last-good `frr.conf` managed section is still on
+  disk and FRR (an independent service) re-advertises last-good prefixes
+  for routes this unarmed node cannot forward — a transit blackhole.
+  Added `clearFRRForFailClosedBoot(compileFailed)` (reuses the
+  `enterBootstrapMode()` `d.frr.Clear()` primitive, managed-section only)
+  and wired it into the boot path right after `d.frr = frr.New()`, gated
+  on `configCompileFailed`. Preserves freeze-in-last-known-good mgmt (no
+  networkd/.link removal, no link-cycle); does NOT change the
+  daemon-restart freeze. Added a cross-package `pkg/frr` test seam
+  (`NewForTest`, `RecordingExecutor`, `ManagedSectionMarkersForTest`) so
+  the daemon unit tests drive the real Clear() wiring against a temp
+  frr.conf without shelling out. Updated `pkg/daemon/README.md`.
+- **File(s)**: pkg/daemon/bootstrap.go, pkg/daemon/daemon_run.go,
+  pkg/daemon/frr_failclosed_boot_test.go, pkg/frr/testseam.go,
+  pkg/daemon/README.md, _Log.md
+
 ## 2026-06-19 — #2000 review follow-up on postinst test harness
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,34 @@
 # Action Log
 
+## 2026-06-20 — #1993 FRR clear MAJOR fix: require LIVE forwarding, not just pins
+
+- **Timestamp**: 2026-06-20
+- **Action**: Fixed the PR #2041 MAJOR review finding. The pin-only restart
+  guard preserved FRR whenever `xdp_*` pins existed, but pins only prove a
+  link is ATTACHED, not that forwarding is LIVE — a graceful hitless shutdown
+  preserves the pins while `Close()` stops forwarding, so the pin-only guard
+  recreated the blackhole on a graceful restart. Added a control-socket armed
+  probe as the authoritative restart-preserve signal: a lightweight one-shot
+  `status` query against any PRE-EXISTING helper, preserving FRR only when it
+  reports `Enabled && ForwardingArmed`. New `pkg/dataplane/userspace`
+  `ProbeForwardingArmed` + `DefaultControlSocketPath` (reuse
+  `deriveUserspaceConfig` for the path). Reworked
+  `clearFRRForFailClosedBoot` into a two-stage decision behind the pure,
+  testable `failClosedBootShouldClearFRR`: pins absent → CLEAR (cheap
+  pre-filter, skip the probe); pins present (or pin-probe error) → consult
+  the armed probe; preserve only when armed, else CLEAR (fail toward
+  fail-over on socket-missing / refused / timeout / not-armed / error).
+  Added `failClosedBootForwardingArmed` package-var seam. Tests:
+  pins-present-but-NOT-armed → CLEAR (the exact gap; proven to FAIL against
+  pin-only code), pins-present+armed → PRESERVE, armed-probe-unreachable →
+  CLEAR, pin-error-falls-through-to-armed, plus 8 probe unit tests
+  (armed/enabled-only/armed-only/!ok/missing/empty + default-path
+  resolution). Updated `pkg/daemon/README.md`.
+- **File(s)**: pkg/daemon/bootstrap.go,
+  pkg/daemon/frr_failclosed_boot_test.go,
+  pkg/dataplane/userspace/boot_probe.go,
+  pkg/dataplane/userspace/boot_probe_test.go, pkg/daemon/README.md, _Log.md
+
 ## 2026-06-20 — #2034 RA link-local review follow-up (regression test)
 
 - **Timestamp**: 2026-06-20

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -116,29 +116,30 @@ never lock an operator out of a remote box it manages.
     `show | compare rollback N` reach prior good configs, and a
     `commit confirmed` of either promotes a working config. Repairing/removing
     the on-disk DB remains the out-of-band fallback.
-  - **FRR managed section is cleared on a compile-failed cold boot (#1993).**
+  - **FRR managed section is cleared on a compile-failed unarmed boot (#1993).**
     `frr` is an independent service that starts from its persisted `frr.conf`
     (the managed section from the last good `applyConfig`), which freeze-in-last-
-    known-good leaves intact. On a *cold reboot* with a compile-failed config
-    the dataplane is unarmed (no transit) yet FRR would otherwise still form
-    peerings and advertise the last-good prefixes — so peers route transit to
+    known-good leaves intact. On a compile-failed boot where NO pinned XDP links
+    survive (the dataplane is unarmed, so no transit), FRR would otherwise still
+    form peerings and advertise the last-good prefixes — peers route transit to
     this node's physical IPs and it blackholes them rather than failing over to
     the HA partner. To close that cross-daemon gap, the compile-failure boot
     path calls `clearFRRForFailClosedBoot(configCompileFailed)` immediately
-    after the FRR manager is constructed (`d.frr = frr.New()`), which runs
-    `d.frr.Clear()` to strip ONLY the managed section and reload FRR. Dropping
-    those peerings makes upstream/peers fail over to the HA partner instead of
-    blackholing transit. This is the SAME primitive `enterBootstrapMode()` uses,
-    but it deliberately runs *only* the FRR-clear step — NOT the `.network`/
-    `.link` removal or link-cycle — so freeze-in-last-known-good MANAGEMENT
-    reachability (the existing mgmt IP) is preserved. It is gated strictly on
-    `configCompileFailed`, so a normal or fresh-install boot is byte-identical
-    (a normal boot must never wipe a healthy node's FRR config), and it is fully
-    reversible: the first compilable `commit confirmed` (or a cluster
-    `SyncApply`) re-renders FRR via `applyFRRConfig` and re-installs the managed
-    section. A degraded reload (`ErrFRRReloadDegraded`) is logged, not fatal —
-    `Clear()` has already written the empty managed section to disk, so a later
-    FRR restart converges. The VIP/RETH data path already failed over before
+    after the FRR manager is constructed (`d.frr = frr.New()`). The helper first
+    probes `/sys/fs/bpf/xpf/links`: if pinned `xdp_*` links still exist, xpfd is
+    in a hitless-restart shape with the last-known-good dataplane still attached,
+    so FRR is preserved; if no pinned XDP links exist, it runs `d.frr.Clear()` to
+    strip ONLY the managed section and reload FRR. Dropping those peerings makes
+    upstream/peers fail over to the HA partner instead of blackholing transit.
+    This is the SAME primitive `enterBootstrapMode()` uses, but it deliberately
+    runs *only* the FRR-clear step — NOT the `.network`/`.link` removal or
+    link-cycle — so freeze-in-last-known-good MANAGEMENT reachability (the
+    existing mgmt IP) is preserved. Normal/fresh-install boots remain
+    byte-identical, and it is fully reversible: the first compilable
+    `commit confirmed` (or a cluster `SyncApply`) re-renders FRR via
+    `applyFRRConfig` and re-installs the managed section. A degraded reload
+    (`ErrFRRReloadDegraded`) is logged, not fatal — `Clear()` has already
+    written the empty managed section to disk, so a later FRR restart converges. The VIP/RETH data path already failed over before
     this fix because #1960 suppresses this node's VRRP/cluster.
     - **Residual (cross-daemon ordering):** FRR is an independent systemd
       service and may advertise last-good prefixes from its OWN start before

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -116,19 +116,36 @@ never lock an operator out of a remote box it manages.
     `show | compare rollback N` reach prior good configs, and a
     `commit confirmed` of either promotes a working config. Repairing/removing
     the on-disk DB remains the out-of-band fallback.
-  - **Known limitation (#1993) — FRR keeps advertising on a cold boot.** `frr`
-    is an independent service that starts from its persisted `frr.conf` (the
-    managed section from the last good `applyConfig`), which freeze-in-last-
+  - **FRR managed section is cleared on a compile-failed cold boot (#1993).**
+    `frr` is an independent service that starts from its persisted `frr.conf`
+    (the managed section from the last good `applyConfig`), which freeze-in-last-
     known-good leaves intact. On a *cold reboot* with a compile-failed config
-    the dataplane is unarmed (no transit) yet FRR still forms peerings and
-    advertises the last-good prefixes, so peers route transit to this node's
-    physical IPs and it blackholes them rather than failing over to the HA
-    partner. This is a pre-existing cross-daemon gap (FRR is independent of the
-    xpfd boot class; the pre-#1960 claim-all path advertised the same way and
-    was otherwise worse), and the VIP/RETH data path already fails over because
-    #1960 suppresses this node's VRRP/cluster. Tracked in #1993; the likely fix
-    is to clear/suppress only the FRR managed section on compile-failure
-    bootstrap while leaving networkd/mgmt intact.
+    the dataplane is unarmed (no transit) yet FRR would otherwise still form
+    peerings and advertise the last-good prefixes — so peers route transit to
+    this node's physical IPs and it blackholes them rather than failing over to
+    the HA partner. To close that cross-daemon gap, the compile-failure boot
+    path calls `clearFRRForFailClosedBoot(configCompileFailed)` immediately
+    after the FRR manager is constructed (`d.frr = frr.New()`), which runs
+    `d.frr.Clear()` to strip ONLY the managed section and reload FRR. Dropping
+    those peerings makes upstream/peers fail over to the HA partner instead of
+    blackholing transit. This is the SAME primitive `enterBootstrapMode()` uses,
+    but it deliberately runs *only* the FRR-clear step — NOT the `.network`/
+    `.link` removal or link-cycle — so freeze-in-last-known-good MANAGEMENT
+    reachability (the existing mgmt IP) is preserved. It is gated strictly on
+    `configCompileFailed`, so a normal or fresh-install boot is byte-identical
+    (a normal boot must never wipe a healthy node's FRR config), and it is fully
+    reversible: the first compilable `commit confirmed` (or a cluster
+    `SyncApply`) re-renders FRR via `applyFRRConfig` and re-installs the managed
+    section. A degraded reload (`ErrFRRReloadDegraded`) is logged, not fatal —
+    `Clear()` has already written the empty managed section to disk, so a later
+    FRR restart converges. The VIP/RETH data path already failed over before
+    this fix because #1960 suppresses this node's VRRP/cluster.
+    - **Residual (cross-daemon ordering):** FRR is an independent systemd
+      service and may advertise last-good prefixes from its OWN start before
+      xpfd reaches the clear. The clear collapses that window once the peerings
+      drop (peer hold-down then carries transit on the partner). A unit-ordering
+      change (`xpfd` clears FRR before FRR forms peerings) would shrink the
+      window further but is a separable follow-up, not required for the Go fix.
 - **Bootstrap mode** (`d.bootstrapMode` atomic): runs gRPC/REST/CLI normally
   but SUPPRESSES interface takeover ACTIONS — the full rename loop, host
   tunables, `enableForwarding`, dataplane arm (`dp.Start`), and boot-time

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -116,31 +116,59 @@ never lock an operator out of a remote box it manages.
     `show | compare rollback N` reach prior good configs, and a
     `commit confirmed` of either promotes a working config. Repairing/removing
     the on-disk DB remains the out-of-band fallback.
-  - **FRR managed section is cleared on a compile-failed unarmed boot (#1993).**
-    `frr` is an independent service that starts from its persisted `frr.conf`
-    (the managed section from the last good `applyConfig`), which freeze-in-last-
-    known-good leaves intact. On a compile-failed boot where NO pinned XDP links
-    survive (the dataplane is unarmed, so no transit), FRR would otherwise still
-    form peerings and advertise the last-good prefixes — peers route transit to
-    this node's physical IPs and it blackholes them rather than failing over to
-    the HA partner. To close that cross-daemon gap, the compile-failure boot
-    path calls `clearFRRForFailClosedBoot(configCompileFailed)` immediately
-    after the FRR manager is constructed (`d.frr = frr.New()`). The helper first
-    probes `/sys/fs/bpf/xpf/links`: if pinned `xdp_*` links still exist, xpfd is
-    in a hitless-restart shape with the last-known-good dataplane still attached,
-    so FRR is preserved; if no pinned XDP links exist, it runs `d.frr.Clear()` to
-    strip ONLY the managed section and reload FRR. Dropping those peerings makes
-    upstream/peers fail over to the HA partner instead of blackholing transit.
-    This is the SAME primitive `enterBootstrapMode()` uses, but it deliberately
-    runs *only* the FRR-clear step — NOT the `.network`/`.link` removal or
-    link-cycle — so freeze-in-last-known-good MANAGEMENT reachability (the
-    existing mgmt IP) is preserved. Normal/fresh-install boots remain
-    byte-identical, and it is fully reversible: the first compilable
-    `commit confirmed` (or a cluster `SyncApply`) re-renders FRR via
-    `applyFRRConfig` and re-installs the managed section. A degraded reload
-    (`ErrFRRReloadDegraded`) is logged, not fatal — `Clear()` has already
-    written the empty managed section to disk, so a later FRR restart converges. The VIP/RETH data path already failed over before
-    this fix because #1960 suppresses this node's VRRP/cluster.
+  - **FRR managed section is cleared on a compile-failed boot unless forwarding
+    is genuinely live (#1993).** `frr` is an independent service that starts from
+    its persisted `frr.conf` (the managed section from the last good
+    `applyConfig`), which freeze-in-last-known-good leaves intact. On a
+    compile-failed boot where the dataplane is unarmed (no transit), FRR would
+    otherwise still form peerings and advertise the last-good prefixes — peers
+    route transit to this node's physical IPs and it blackholes them rather than
+    failing over to the HA partner. To close that cross-daemon gap, the
+    compile-failure boot path calls
+    `clearFRRForFailClosedBoot(configCompileFailed)` immediately after the FRR
+    manager is constructed (`d.frr = frr.New()`).
+    - **The preserve decision requires LIVE FORWARDING, not just pins.** Pins on
+      `/sys/fs/bpf/xpf/links` prove only that an XDP link is *attached*, not that
+      forwarding is *live*: a graceful hitless shutdown (`dp.Close()` →
+      helper `Close()` → `stopLocked` disables `ctrl.enabled`; the BPF `Close()`
+      deliberately leaves pinned maps/links for the next daemon to reuse) leaves
+      the pins in place while forwarding is STOPPED. A pin-only guard would read
+      "pins exist" and wrongly preserve FRR on a graceful restart, recreating the
+      blackhole. The decision is therefore two stages: (1) **pins are a cheap
+      pre-filter** — no `xdp_*` pins (e.g. a cold reboot cleared the bpffs tmpfs)
+      ⇒ no surviving dataplane ⇒ CLEAR, skipping the socket probe (a pin-probe
+      *error* does not preserve; it falls through to stage 2); (2) **the
+      authoritative signal** is a lightweight one-shot status query against any
+      PRE-EXISTING helper on its control socket
+      (`dpuserspace.ProbeForwardingArmed` → `ProcessStatus.Enabled &&
+      ForwardingArmed`, the same pair the runtime gates forwarding on). FRR is
+      preserved **only** when that probe says forwarding is live. Every other
+      outcome — socket missing / connect-refused / timeout / `Enabled=false` /
+      `ForwardingArmed=false` / probe error — **clears** (fail toward fail-over:
+      an unarmed/unknown helper is not forwarding). The control-socket path is
+      resolved the same way the runtime Manager resolves it
+      (`DefaultControlSocketPath` → `deriveUserspaceConfig`); a compile-failed
+      boot has a nil active config, so it uses the default path (matching a
+      surviving helper from a default-config deployment), and a custom-path
+      deployment falls back to the default → probe finds nothing → clears
+      (safe direction). Both the pin pre-filter
+      (`failClosedBootHasPinnedXDPLinks`) and the armed probe
+      (`failClosedBootForwardingArmed`) are package-var seams so the decision is
+      unit-tested without a real helper; the pure decision is
+      `failClosedBootShouldClearFRR`.
+    - When the decision is CLEAR, `d.frr.Clear()` strips ONLY the managed
+      section and reloads FRR. Dropping those peerings makes upstream/peers fail
+      over to the HA partner instead of blackholing transit. This is the SAME
+      primitive `enterBootstrapMode()` uses, but it deliberately runs *only* the
+      FRR-clear step — NOT the `.network`/`.link` removal or link-cycle — so
+      freeze-in-last-known-good MANAGEMENT reachability (the existing mgmt IP) is
+      preserved. Normal/fresh-install boots remain byte-identical, and it is
+      fully reversible: the first compilable `commit confirmed` (or a cluster
+      `SyncApply`) re-renders FRR via `applyFRRConfig` and re-installs the
+      managed section. A degraded reload (`ErrFRRReloadDegraded`) is logged, not
+      fatal — `Clear()` has already written the empty managed section to disk, so
+      a later FRR restart converges. The VIP/RETH data path already failed over
+      before this fix because #1960 suppresses this node's VRRP/cluster.
     - **Residual (cross-daemon ordering):** FRR is an independent systemd
       service and may advertise last-good prefixes from its OWN start before
       xpfd reaches the clear. The clear collapses that window once the peerings

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -146,7 +146,12 @@ var failClosedBootForwardingArmed = detectFailClosedBootForwardingArmed
 
 func detectFailClosedBootForwardingArmed() (bool, error) {
 	// Active config is nil on a compile-failed boot; DefaultControlSocketPath
-	// returns the default control-socket path in that case.
+	// returns the default control-socket path in that case. A surviving helper
+	// that the previous (now-uncompilable) config had pointed at a NON-default
+	// control-socket path is therefore not probed here and reads as not-armed,
+	// which CLEARS FRR. That is the fail-safe direction (peers fail over rather
+	// than blackhole): this can only over-clear on an exotic custom-socket
+	// config, never wrongly preserve FRR for a dead dataplane.
 	sock := dpuserspace.DefaultControlSocketPath(nil)
 	return dpuserspace.ProbeForwardingArmed(sock, failClosedBootArmedProbeTimeout)
 }

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -89,6 +89,31 @@ const lifelineRecordFile = "/etc/xpf/lifeline-interface"
 // valve).
 const defaultMgmtInterface = "fxp0"
 
+// userspaceShimLinkPinDir carries the pinned XDP links that survive a hitless
+// daemon restart. On a compile-failed restart where those links still exist,
+// the last-known-good dataplane is still attached and forwarding; clearing FRR
+// there would drop peerings despite live forwarding. The #1993 FRR clear is
+// therefore restricted to the unarmed/no-pins case.
+const userspaceShimLinkPinDir = "/sys/fs/bpf/xpf/links"
+
+var failClosedBootHasPinnedXDPLinks = detectFailClosedBootPinnedXDPLinks
+
+func detectFailClosedBootPinnedXDPLinks() (bool, error) {
+	entries, err := os.ReadDir(userspaceShimLinkPinDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "xdp_") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // bootClass is the result of the #1922 five-case boot predicate. Each value
 // maps to exactly one of {bootstrap, normal, fail-safe}.
 type bootClass int
@@ -303,16 +328,17 @@ func (d *Daemon) enterBootstrapMode() {
 		"system is back in bootstrap mode — 'commit confirmed' a corrected config")
 }
 
-// clearFRRForFailClosedBoot is the #1993 cold-boot refinement: on a boot where
-// the previously-committed config no longer COMPILES (the #1960 fail-closed
-// tuple — ActiveConfig()==nil + everCommitted=true → bootClassBootstrap), the
-// last-good `! BEGIN/END BPFRX MANAGED CONFIG` section is STILL on disk in
-// /etc/frr/frr.conf. FRR is an independent systemd service: it starts from that
-// persisted file, forms BGP/OSPF/IS-IS peerings, and re-advertises last-good
-// prefixes for routes this (unarmed, no-dataplane) node cannot forward — a
-// silent transit blackhole. Clearing ONLY the managed section drops those
-// peerings so upstream/peers fail over to the HA partner instead of routing
-// transit into a blackhole.
+// clearFRRForFailClosedBoot is the #1993 fail-closed boot refinement: on a
+// boot where the previously-committed config no longer COMPILES (the #1960
+// fail-closed tuple — ActiveConfig()==nil + everCommitted=true →
+// bootClassBootstrap), the last-good `! BEGIN/END BPFRX MANAGED CONFIG`
+// section may still be on disk in /etc/frr/frr.conf. FRR is an independent
+// systemd service: if the node comes up with NO live dataplane attachments, it
+// starts from that persisted file, forms BGP/OSPF/IS-IS peerings, and
+// re-advertises last-good prefixes for routes this unarmed node cannot
+// forward — a silent transit blackhole. Clearing ONLY the managed section
+// drops those peerings so upstream/peers fail over to the HA partner instead
+// of routing transit into a blackhole.
 //
 // This deliberately runs JUST the FRR-clear step of enterBootstrapMode()'s
 // teardown — NOT the .network/.link removal or the link-cycle. The cold-boot
@@ -325,9 +351,11 @@ func (d *Daemon) enterBootstrapMode() {
 // SyncApply) re-renders FRR through applyConfigLocked → applyFRRConfig, which
 // re-installs the managed section. So this clear is fully reversible.
 //
-// Scope: gated strictly on compileFailed so a fresh/no-config bootstrap (which
-// has no last-good managed section) and every NORMAL boot are byte-identical to
-// before — a NORMAL boot must NEVER wipe a healthy node's FRR config. The
+// Scope: gated on compileFailed AND on the absence of pinned XDP links. A
+// fresh/no-config bootstrap (which has no last-good managed section) and every
+// NORMAL boot are byte-identical to before, and a compile-failed daemon
+// RESTART that still has pinned XDP links preserves the last-known-good live
+// forwarding state instead of dropping peerings under active transit. The
 // d.frr != nil guard tolerates NoDataplane daemons (FRR is constructed only
 // inside the !NoDataplane manager-init block).
 //
@@ -340,12 +368,24 @@ func (d *Daemon) clearFRRForFailClosedBoot(compileFailed bool) {
 	if !compileFailed || d.frr == nil {
 		return
 	}
+	pinnedXDPLinks, err := failClosedBootHasPinnedXDPLinks()
+	if err != nil {
+		slog.Warn("fail-closed boot: skipping FRR managed-section clear because the pinned-XDP restart probe failed",
+			"pin_dir", userspaceShimLinkPinDir, "err", err)
+		return
+	}
+	if pinnedXDPLinks {
+		slog.Info("fail-closed boot: preserving FRR managed section because pinned XDP links indicate live dataplane attachments",
+			"pin_dir", userspaceShimLinkPinDir)
+		return
+	}
 	if err := d.frr.Clear(); err != nil {
 		// Includes ErrFRRReloadDegraded — log, do not abort boot.
 		slog.Warn("fail-closed boot: failed to clear FRR managed section; node may still "+
 			"advertise last-good routes to peers until the operator fixes the config and "+
-			"'commit confirmed' (or FRR restarts and re-reads the now-empty managed section)",
-			"err", err)
+			"'commit confirmed'; if the managed section was already stripped on disk, a later "+
+			"FRR restart will still converge",
+			"err", err, "pin_dir", userspaceShimLinkPinDir)
 		return
 	}
 	slog.Warn("fail-closed boot: cleared FRR managed section so peers fail over to the HA " +

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -303,6 +303,56 @@ func (d *Daemon) enterBootstrapMode() {
 		"system is back in bootstrap mode — 'commit confirmed' a corrected config")
 }
 
+// clearFRRForFailClosedBoot is the #1993 cold-boot refinement: on a boot where
+// the previously-committed config no longer COMPILES (the #1960 fail-closed
+// tuple — ActiveConfig()==nil + everCommitted=true → bootClassBootstrap), the
+// last-good `! BEGIN/END BPFRX MANAGED CONFIG` section is STILL on disk in
+// /etc/frr/frr.conf. FRR is an independent systemd service: it starts from that
+// persisted file, forms BGP/OSPF/IS-IS peerings, and re-advertises last-good
+// prefixes for routes this (unarmed, no-dataplane) node cannot forward — a
+// silent transit blackhole. Clearing ONLY the managed section drops those
+// peerings so upstream/peers fail over to the HA partner instead of routing
+// transit into a blackhole.
+//
+// This deliberately runs JUST the FRR-clear step of enterBootstrapMode()'s
+// teardown — NOT the .network/.link removal or the link-cycle. The cold-boot
+// fail-closed path is intentionally freeze-in-last-known-good for MANAGEMENT
+// reachability (#1960): the operator stays connected on the existing mgmt IP.
+// Removing networkd files / link-cycling toward bootstrap fxp0-DHCP here could
+// change the mgmt IP out from under a connected operator, so it is excluded.
+//
+// Reversibility: the first compilable `commit confirmed` (or a cluster
+// SyncApply) re-renders FRR through applyConfigLocked → applyFRRConfig, which
+// re-installs the managed section. So this clear is fully reversible.
+//
+// Scope: gated strictly on compileFailed so a fresh/no-config bootstrap (which
+// has no last-good managed section) and every NORMAL boot are byte-identical to
+// before — a NORMAL boot must NEVER wipe a healthy node's FRR config. The
+// d.frr != nil guard tolerates NoDataplane daemons (FRR is constructed only
+// inside the !NoDataplane manager-init block).
+//
+// A degraded reload (ErrFRRReloadDegraded, e.g. frr-reload.py unavailable) is
+// LOGGED, not fatal: Clear() has already written the empty managed section to
+// disk (so a later FRR restart converges) and the degraded-retry loop
+// re-attempts. Management reachability beats a perfectly-clean FRR reload, so
+// boot must proceed regardless.
+func (d *Daemon) clearFRRForFailClosedBoot(compileFailed bool) {
+	if !compileFailed || d.frr == nil {
+		return
+	}
+	if err := d.frr.Clear(); err != nil {
+		// Includes ErrFRRReloadDegraded — log, do not abort boot.
+		slog.Warn("fail-closed boot: failed to clear FRR managed section; node may still "+
+			"advertise last-good routes to peers until the operator fixes the config and "+
+			"'commit confirmed' (or FRR restarts and re-reads the now-empty managed section)",
+			"err", err)
+		return
+	}
+	slog.Warn("fail-closed boot: cleared FRR managed section so peers fail over to the HA " +
+		"partner instead of blackholing transit to this unarmed node. The first compilable " +
+		"'commit confirmed' re-installs the managed section.")
+}
+
 // lifelineRecord is the persisted management-NIC identity.
 type lifelineRecord struct {
 	PCIAddr string // PCI bus address (e.g. "0000:05:00.0"); primary key

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -14,11 +14,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/psaab/xpf/pkg/fsatomic"
 	"github.com/vishvananda/netlink"
 
 	"github.com/psaab/xpf/pkg/configstore"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 // loadErrorClass categorizes a Store.Load error for the boot path (#1917 D1
@@ -89,12 +91,23 @@ const lifelineRecordFile = "/etc/xpf/lifeline-interface"
 // valve).
 const defaultMgmtInterface = "fxp0"
 
-// userspaceShimLinkPinDir carries the pinned XDP links that survive a hitless
-// daemon restart. On a compile-failed restart where those links still exist,
-// the last-known-good dataplane is still attached and forwarding; clearing FRR
-// there would drop peerings despite live forwarding. The #1993 FRR clear is
-// therefore restricted to the unarmed/no-pins case.
+// userspaceShimLinkPinDir carries the pinned XDP links that survive a daemon
+// restart. Pins are a CHEAP PRE-FILTER ONLY (#1993 review): their presence
+// proves "an XDP link is attached", NOT "forwarding is live". On a graceful
+// hitless shutdown the pins are intentionally preserved while forwarding is
+// STOPPED (dp.Close → helper Close leaves pinned maps/links for reuse), so a
+// pin-only guard would wrongly preserve FRR on a graceful restart and recreate
+// the blackhole. Absence of pins is still a reliable "definitely not live"
+// signal (a cold reboot clears the bpffs tmpfs), so it short-circuits to CLEAR
+// without the socket probe. The authoritative live-forwarding decision for the
+// pins-present case is failClosedBootForwardingArmed below.
 const userspaceShimLinkPinDir = "/sys/fs/bpf/xpf/links"
+
+// failClosedBootArmedProbeTimeout bounds the early-boot control-socket probe.
+// Short on purpose: a surviving helper answers status in well under a second,
+// and on a cold boot the socket is absent (immediate ENOENT) — boot must not
+// stall waiting on a dead path.
+const failClosedBootArmedProbeTimeout = 2 * time.Second
 
 var failClosedBootHasPinnedXDPLinks = detectFailClosedBootPinnedXDPLinks
 
@@ -112,6 +125,30 @@ func detectFailClosedBootPinnedXDPLinks() (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// failClosedBootForwardingArmed reports whether a PRE-EXISTING userspace helper
+// is reachable on its control socket AND reports Enabled && ForwardingArmed —
+// i.e. forwarding is genuinely LIVE right now. This is the authoritative
+// restart-preserve signal (#1993 review MAJOR): unlike the pin pre-filter, it
+// distinguishes a daemon CRASH (helper survives, still forwarding) from a
+// graceful hitless STOP (pins remain, forwarding off). A package-var seam so
+// unit tests drive the decision without a real helper.
+//
+// The control socket is resolved exactly as the runtime Manager resolves it
+// (DefaultControlSocketPath → deriveUserspaceConfig). At a compile-failed boot
+// the active config is nil, so this is the default path — which matches a
+// surviving helper from a default-config deployment. A deployment that set a
+// custom control-socket path resolves to the default here (config is
+// uncompilable), the probe finds nothing, and the caller fails toward CLEARING
+// FRR — the safe direction (treat unknown as not-forwarding).
+var failClosedBootForwardingArmed = detectFailClosedBootForwardingArmed
+
+func detectFailClosedBootForwardingArmed() (bool, error) {
+	// Active config is nil on a compile-failed boot; DefaultControlSocketPath
+	// returns the default control-socket path in that case.
+	sock := dpuserspace.DefaultControlSocketPath(nil)
+	return dpuserspace.ProbeForwardingArmed(sock, failClosedBootArmedProbeTimeout)
 }
 
 // bootClass is the result of the #1922 five-case boot predicate. Each value
@@ -351,13 +388,28 @@ func (d *Daemon) enterBootstrapMode() {
 // SyncApply) re-renders FRR through applyConfigLocked → applyFRRConfig, which
 // re-installs the managed section. So this clear is fully reversible.
 //
-// Scope: gated on compileFailed AND on the absence of pinned XDP links. A
-// fresh/no-config bootstrap (which has no last-good managed section) and every
-// NORMAL boot are byte-identical to before, and a compile-failed daemon
-// RESTART that still has pinned XDP links preserves the last-known-good live
-// forwarding state instead of dropping peerings under active transit. The
-// d.frr != nil guard tolerates NoDataplane daemons (FRR is constructed only
-// inside the !NoDataplane manager-init block).
+// Scope: gated on compileFailed AND on LIVE FORWARDING. The restart-preserve
+// decision requires the helper to be genuinely forwarding, not merely
+// "pins exist" (#1993 review MAJOR): on a graceful hitless shutdown the pins
+// are preserved while forwarding is STOPPED, so a pin-only guard would wrongly
+// preserve FRR and recreate the blackhole. The decision is therefore two-stage:
+//
+//  1. Pins are a CHEAP PRE-FILTER. No pins (e.g. a cold reboot cleared the
+//     bpffs tmpfs) ⇒ no surviving dataplane ⇒ CLEAR, and skip the socket probe.
+//     A pin-probe error is conservatively treated as "may have pins" → fall
+//     through to the authoritative socket probe rather than guessing.
+//  2. With pins present, query the helper control socket
+//     (failClosedBootForwardingArmed): PRESERVE FRR only if it reports
+//     Enabled && ForwardingArmed (a genuine crash-survivor still forwarding).
+//     In EVERY other case — socket missing / connect-refused / timeout /
+//     Enabled=false / ForwardingArmed=false / probe error — CLEAR. An
+//     unarmed/unknown helper means no live forwarding, so peers must fail over
+//     (fail toward clearing).
+//
+// A fresh/no-config bootstrap (which has no last-good managed section) and every
+// NORMAL boot are byte-identical to before. The d.frr != nil guard tolerates
+// NoDataplane daemons (FRR is constructed only inside the !NoDataplane
+// manager-init block).
 //
 // A degraded reload (ErrFRRReloadDegraded, e.g. frr-reload.py unavailable) is
 // LOGGED, not fatal: Clear() has already written the empty managed section to
@@ -368,15 +420,7 @@ func (d *Daemon) clearFRRForFailClosedBoot(compileFailed bool) {
 	if !compileFailed || d.frr == nil {
 		return
 	}
-	pinnedXDPLinks, err := failClosedBootHasPinnedXDPLinks()
-	if err != nil {
-		slog.Warn("fail-closed boot: skipping FRR managed-section clear because the pinned-XDP restart probe failed",
-			"pin_dir", userspaceShimLinkPinDir, "err", err)
-		return
-	}
-	if pinnedXDPLinks {
-		slog.Info("fail-closed boot: preserving FRR managed section because pinned XDP links indicate live dataplane attachments",
-			"pin_dir", userspaceShimLinkPinDir)
+	if !d.failClosedBootShouldClearFRR() {
 		return
 	}
 	if err := d.frr.Clear(); err != nil {
@@ -391,6 +435,54 @@ func (d *Daemon) clearFRRForFailClosedBoot(compileFailed bool) {
 	slog.Warn("fail-closed boot: cleared FRR managed section so peers fail over to the HA " +
 		"partner instead of blackholing transit to this unarmed node. The first compilable " +
 		"'commit confirmed' re-installs the managed section.")
+}
+
+// failClosedBootShouldClearFRR is the pure two-stage decision behind
+// clearFRRForFailClosedBoot (extracted so the exact #1993-review gap — pins
+// present but forwarding NOT live — is unit-testable without touching frr.conf).
+// Returns true to CLEAR, false to PRESERVE.
+//
+// Stage 1 (cheap pre-filter): no pinned XDP links ⇒ no surviving dataplane ⇒
+// CLEAR (and skip the control-socket probe). A pin-probe error does NOT itself
+// preserve FRR — it is conservatively treated as "pins may exist" and falls
+// through to the authoritative socket probe (fail toward the live check, not
+// toward a stale guess).
+//
+// Stage 2 (authoritative): with pins present, PRESERVE only if the helper
+// control socket reports forwarding is genuinely live (Enabled &&
+// ForwardingArmed). Every other outcome — unreachable socket, timeout, probe
+// error, or armed=false — CLEARS, because an unarmed/unknown helper is not
+// forwarding and peers must fail over.
+func (d *Daemon) failClosedBootShouldClearFRR() bool {
+	pinnedXDPLinks, pinErr := failClosedBootHasPinnedXDPLinks()
+	if pinErr != nil {
+		slog.Warn("fail-closed boot: pinned-XDP pre-filter probe failed; "+
+			"falling through to the control-socket armed probe",
+			"pin_dir", userspaceShimLinkPinDir, "err", pinErr)
+	} else if !pinnedXDPLinks {
+		slog.Info("fail-closed boot: no pinned XDP links — last-known-good dataplane is "+
+			"gone (e.g. cold reboot); clearing FRR managed section",
+			"pin_dir", userspaceShimLinkPinDir)
+		return true
+	}
+
+	armed, armErr := failClosedBootForwardingArmed()
+	if armErr != nil {
+		// Unreachable socket / timeout / decode error: NOT live forwarding.
+		// Fail toward clearing so peers fail over rather than blackhole.
+		slog.Warn("fail-closed boot: control-socket forwarding-armed probe failed; "+
+			"treating the dataplane as NOT forwarding and clearing FRR managed section",
+			"err", armErr)
+		return true
+	}
+	if armed {
+		slog.Info("fail-closed boot: helper reports forwarding is live (enabled+armed); " +
+			"preserving FRR managed section across the restart")
+		return false
+	}
+	slog.Info("fail-closed boot: helper is reachable but reports forwarding NOT armed; " +
+		"clearing FRR managed section so peers fail over")
+	return true
 }
 
 // lifelineRecord is the persisted management-NIC identity.

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -426,10 +426,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// routes this unarmed node cannot forward — a transit blackhole. Clear
 		// ONLY the managed section, right after the manager exists and BEFORE
 		// the run loop settles, so peers fail over to the HA partner. The
-		// helper itself further skips hitless-restart cases where pinned XDP
-		// links show the last-known-good dataplane is still live. Freeze-in-
-		// last-known-good for management (#1960) is preserved: no
-		// .network/.link removal, no link-cycle.
+		// predicate PRESERVES the managed section on a hitless restart only when
+		// the helper control socket reports forwarding is genuinely live
+		// (enabled+armed); pinned XDP links are merely a cheap pre-filter, NOT
+		// proof of live forwarding (a graceful stop leaves the pins but disarms
+		// forwarding). Freeze-in-last-known-good for management (#1960) is
+		// preserved: no .network/.link removal, no link-cycle.
 		d.clearFRRForFailClosedBoot(configCompileFailed)
 		d.ipsec = ipsec.New()
 		d.ra = ra.New()

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -420,15 +420,16 @@ func (d *Daemon) Run(ctx context.Context) error {
 			}
 		}
 		d.frr = frr.New()
-		// #1993: on a compile-failure COLD boot the last-good frr.conf managed
-		// section is still on disk and FRR (an independent service) will form
-		// peerings + re-advertise prefixes for routes this unarmed node cannot
-		// forward — a transit blackhole. Clear ONLY the managed section, right
-		// after the manager exists and BEFORE the run loop settles, so peers
-		// fail over to the HA partner. Gated on configCompileFailed so a normal
-		// or fresh-install boot is untouched (a normal boot must NOT wipe a
-		// healthy node's FRR config). Freeze-in-last-known-good for management
-		// (#1960) is preserved: no .network/.link removal, no link-cycle.
+		// #1993: on a compile-failure boot with NO preserved XDP attachments,
+		// the last-good frr.conf managed section is still on disk and FRR (an
+		// independent service) will form peerings + re-advertise prefixes for
+		// routes this unarmed node cannot forward — a transit blackhole. Clear
+		// ONLY the managed section, right after the manager exists and BEFORE
+		// the run loop settles, so peers fail over to the HA partner. The
+		// helper itself further skips hitless-restart cases where pinned XDP
+		// links show the last-known-good dataplane is still live. Freeze-in-
+		// last-known-good for management (#1960) is preserved: no
+		// .network/.link removal, no link-cycle.
 		d.clearFRRForFailClosedBoot(configCompileFailed)
 		d.ipsec = ipsec.New()
 		d.ra = ra.New()

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -420,6 +420,16 @@ func (d *Daemon) Run(ctx context.Context) error {
 			}
 		}
 		d.frr = frr.New()
+		// #1993: on a compile-failure COLD boot the last-good frr.conf managed
+		// section is still on disk and FRR (an independent service) will form
+		// peerings + re-advertise prefixes for routes this unarmed node cannot
+		// forward — a transit blackhole. Clear ONLY the managed section, right
+		// after the manager exists and BEFORE the run loop settles, so peers
+		// fail over to the HA partner. Gated on configCompileFailed so a normal
+		// or fresh-install boot is untouched (a normal boot must NOT wipe a
+		// healthy node's FRR config). Freeze-in-last-known-good for management
+		// (#1960) is preserved: no .network/.link removal, no link-cycle.
+		d.clearFRRForFailClosedBoot(configCompileFailed)
 		d.ipsec = ipsec.New()
 		d.ra = ra.New()
 		d.networkd = networkd.New()

--- a/pkg/daemon/frr_failclosed_boot_test.go
+++ b/pkg/daemon/frr_failclosed_boot_test.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/frr"
+)
+
+// seededFRRConf writes a temp frr.conf carrying an xpf-managed section with a
+// sentinel route line, and returns the conf path plus the sentinel so a test
+// can assert the section was (or was not) stripped. The base "log syslog
+// informational" line stands in for operator-owned content outside the markers,
+// which must always survive.
+func seededFRRConf(t *testing.T) (path, sentinel string) {
+	t.Helper()
+	begin, end := frr.ManagedSectionMarkersForTest()
+	sentinel = "ip route 10.99.0.0/24 192.0.2.1"
+	content := "log syslog informational\n" +
+		begin + "\n" +
+		sentinel + "\n" +
+		end + "\n"
+	path = filepath.Join(t.TempDir(), "frr.conf")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("seed frr.conf: %v", err)
+	}
+	return path, sentinel
+}
+
+func readConf(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read frr.conf: %v", err)
+	}
+	return string(b)
+}
+
+// TestColdBootCompileFailedClearsFRR proves the #1993 fix: on a compile-failure
+// cold boot (configCompileFailed=true), the daemon strips the last-good
+// xpf-managed section from frr.conf and reloads FRR exactly once, so peers fail
+// over to the HA partner instead of routing transit into this unarmed node.
+//
+// Non-tautological: without the clearFRRForFailClosedBoot call wired into the
+// boot path the managed section survives, so this test fails on the unpatched
+// tree.
+func TestColdBootCompileFailedClearsFRR(t *testing.T) {
+	confPath, sentinel := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{} // healthy reload (nil error)
+	d := &Daemon{frr: frr.NewForTest(confPath, rec)}
+
+	d.clearFRRForFailClosedBoot(true)
+
+	got := readConf(t, confPath)
+	if strings.Contains(got, sentinel) {
+		t.Fatalf("compile-failed cold boot must strip the managed section; frr.conf still has %q:\n%s", sentinel, got)
+	}
+	begin, _ := frr.ManagedSectionMarkersForTest()
+	if strings.Contains(got, begin) {
+		t.Fatalf("managed begin marker must be gone after clear; frr.conf:\n%s", got)
+	}
+	if !strings.Contains(got, "log syslog informational") {
+		t.Fatalf("operator content outside the managed section must survive the clear; frr.conf:\n%s", got)
+	}
+	if rec.ReloadCalls != 1 {
+		t.Fatalf("expected exactly one FRR reload, got %d", rec.ReloadCalls)
+	}
+}
+
+// TestColdBootNormalDoesNotClearFRR is the critical "don't wipe a healthy node"
+// guard: on a normal / no-config bootstrap boot (configCompileFailed=false) the
+// managed section must be UNTOUCHED and FRR must NOT be reloaded.
+func TestColdBootNormalDoesNotClearFRR(t *testing.T) {
+	confPath, sentinel := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{}
+	d := &Daemon{frr: frr.NewForTest(confPath, rec)}
+
+	d.clearFRRForFailClosedBoot(false)
+
+	got := readConf(t, confPath)
+	if !strings.Contains(got, sentinel) {
+		t.Fatalf("a normal boot must NOT touch the managed section; sentinel %q missing:\n%s", sentinel, got)
+	}
+	if rec.ReloadCalls != 0 {
+		t.Fatalf("a normal boot must NOT reload FRR; got %d reloads", rec.ReloadCalls)
+	}
+}
+
+// TestColdBootCompileFailedNilFRRIsSafe guards the NoDataplane / pre-manager
+// path: clearing with a nil d.frr must not panic and must be a no-op.
+func TestColdBootCompileFailedNilFRRIsSafe(t *testing.T) {
+	d := &Daemon{} // d.frr == nil
+	// Must not panic.
+	d.clearFRRForFailClosedBoot(true)
+}
+
+// TestClearFRRReloadDegradedDoesNotAbortBoot proves a degraded reload
+// (frr-reload.py unavailable → ErrFRRReloadDegraded) is tolerated: the on-disk
+// managed section is still stripped (Clear writes before it reloads) and the
+// helper returns normally so boot proceeds. The on-disk strip is what lets a
+// later FRR restart converge even when the live reload degraded.
+func TestClearFRRReloadDegradedDoesNotAbortBoot(t *testing.T) {
+	confPath, sentinel := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{ReloadErr: frr.ErrFRRReloadDegraded}
+	d := &Daemon{frr: frr.NewForTest(confPath, rec)}
+
+	// Returns normally (no panic / no propagated error path) even on degraded.
+	d.clearFRRForFailClosedBoot(true)
+
+	got := readConf(t, confPath)
+	if strings.Contains(got, sentinel) {
+		t.Fatalf("degraded reload must still strip the managed section on disk; frr.conf:\n%s", got)
+	}
+	if rec.ReloadCalls != 1 {
+		t.Fatalf("expected one reload attempt on the degraded path, got %d", rec.ReloadCalls)
+	}
+}

--- a/pkg/daemon/frr_failclosed_boot_test.go
+++ b/pkg/daemon/frr_failclosed_boot_test.go
@@ -46,6 +46,17 @@ func withFailClosedBootPinnedXDPProbe(t *testing.T, fn func() (bool, error)) {
 	t.Cleanup(func() { failClosedBootHasPinnedXDPLinks = prev })
 }
 
+// withFailClosedBootArmedProbe overrides the authoritative live-forwarding
+// probe (control-socket Enabled && ForwardingArmed). The default probe dials a
+// real unix socket that does not exist in the test sandbox, so every test that
+// reaches stage 2 MUST set this seam to make the decision deterministic.
+func withFailClosedBootArmedProbe(t *testing.T, fn func() (bool, error)) {
+	t.Helper()
+	prev := failClosedBootForwardingArmed
+	failClosedBootForwardingArmed = fn
+	t.Cleanup(func() { failClosedBootForwardingArmed = prev })
+}
+
 // TestColdBootCompileFailedClearsFRR proves the #1993 fix: on a compile-failure
 // cold boot (configCompileFailed=true), the daemon strips the last-good
 // xpf-managed section from frr.conf and reloads FRR exactly once, so peers fail
@@ -106,8 +117,13 @@ func TestColdBootCompileFailedNilFRRIsSafe(t *testing.T) {
 	d.clearFRRForFailClosedBoot(true)
 }
 
-func TestCompileFailedRestartWithPinnedXDPLinksKeepsFRR(t *testing.T) {
+// TestCompileFailedRestartWithLiveForwardingKeepsFRR is the genuine
+// crash-survivor case: pins are present AND the helper control socket reports
+// forwarding is live (Enabled && ForwardingArmed). Only then is the managed
+// section preserved across the restart.
+func TestCompileFailedRestartWithLiveForwardingKeepsFRR(t *testing.T) {
 	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) { return true, nil })
+	withFailClosedBootArmedProbe(t, func() (bool, error) { return true, nil })
 	confPath, sentinel := seededFRRConf(t)
 	rec := &frr.RecordingExecutor{}
 	d := &Daemon{frr: frr.NewForTest(confPath, rec)}
@@ -116,16 +132,55 @@ func TestCompileFailedRestartWithPinnedXDPLinksKeepsFRR(t *testing.T) {
 
 	got := readConf(t, confPath)
 	if !strings.Contains(got, sentinel) {
-		t.Fatalf("pinned XDP links must preserve the managed section on restart; sentinel %q missing:\n%s", sentinel, got)
+		t.Fatalf("live forwarding must preserve the managed section on restart; sentinel %q missing:\n%s", sentinel, got)
 	}
 	if rec.ReloadCalls != 0 {
-		t.Fatalf("pinned XDP links must suppress FRR reloads; got %d reloads", rec.ReloadCalls)
+		t.Fatalf("live forwarding must suppress FRR reloads; got %d reloads", rec.ReloadCalls)
 	}
 }
 
-func TestCompileFailedProbeErrorKeepsFRR(t *testing.T) {
-	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) {
-		return false, errors.New("probe failed")
+// TestCompileFailedRestartPinsPresentButNotArmedClearsFRR is the EXACT
+// #1993-review gap the pin-only guard missed: on a GRACEFUL hitless shutdown the
+// pinned XDP links are intentionally preserved while forwarding is STOPPED. A
+// pin-only guard reads "pins exist" and wrongly PRESERVES FRR, recreating the
+// blackhole. The armed probe (helper reachable but ForwardingArmed=false) is
+// the authoritative signal: pins present + NOT armed MUST CLEAR.
+//
+// Non-tautological against the pin-only code: the pre-fix
+// clearFRRForFailClosedBoot returns early on pinnedXDPLinks==true WITHOUT
+// consulting any forwarding signal, so it would PRESERVE here and this test
+// would FAIL. It only passes once the armed probe gates the preserve decision.
+func TestCompileFailedRestartPinsPresentButNotArmedClearsFRR(t *testing.T) {
+	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) { return true, nil })
+	withFailClosedBootArmedProbe(t, func() (bool, error) { return false, nil }) // helper up, not forwarding
+	confPath, sentinel := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{}
+	d := &Daemon{frr: frr.NewForTest(confPath, rec)}
+
+	d.clearFRRForFailClosedBoot(true)
+
+	got := readConf(t, confPath)
+	if strings.Contains(got, sentinel) {
+		t.Fatalf("pins present but forwarding NOT armed must CLEAR the managed section "+
+			"(graceful-stop false positive); frr.conf still has %q:\n%s", sentinel, got)
+	}
+	begin, _ := frr.ManagedSectionMarkersForTest()
+	if strings.Contains(got, begin) {
+		t.Fatalf("managed begin marker must be gone after clear; frr.conf:\n%s", got)
+	}
+	if rec.ReloadCalls != 1 {
+		t.Fatalf("expected exactly one FRR reload, got %d", rec.ReloadCalls)
+	}
+}
+
+// TestCompileFailedRestartPinsPresentArmedProbeUnreachableClearsFRR covers a
+// crash-or-graceful case where the pins survive but the control socket is gone
+// (probe error: socket missing / connect-refused / timeout). Fail toward
+// clearing: an unknown helper means no live forwarding, so peers must fail over.
+func TestCompileFailedRestartPinsPresentArmedProbeUnreachableClearsFRR(t *testing.T) {
+	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) { return true, nil })
+	withFailClosedBootArmedProbe(t, func() (bool, error) {
+		return false, errors.New("dial unix control.sock: connect: no such file or directory")
 	})
 	confPath, sentinel := seededFRRConf(t)
 	rec := &frr.RecordingExecutor{}
@@ -134,11 +189,35 @@ func TestCompileFailedProbeErrorKeepsFRR(t *testing.T) {
 	d.clearFRRForFailClosedBoot(true)
 
 	got := readConf(t, confPath)
+	if strings.Contains(got, sentinel) {
+		t.Fatalf("an unreachable armed probe must CLEAR (fail toward fail-over), not preserve; frr.conf still has %q:\n%s", sentinel, got)
+	}
+	if rec.ReloadCalls != 1 {
+		t.Fatalf("expected exactly one FRR reload, got %d", rec.ReloadCalls)
+	}
+}
+
+// TestCompileFailedPinProbeErrorFallsThroughToArmedProbe verifies a pin
+// pre-filter error does NOT short-circuit to preserve (the old behavior). It is
+// conservatively treated as "pins may exist" and the authoritative armed probe
+// decides: armed → preserve.
+func TestCompileFailedPinProbeErrorFallsThroughToArmedProbe(t *testing.T) {
+	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) {
+		return false, errors.New("pin readdir failed")
+	})
+	withFailClosedBootArmedProbe(t, func() (bool, error) { return true, nil }) // forwarding live
+	confPath, sentinel := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{}
+	d := &Daemon{frr: frr.NewForTest(confPath, rec)}
+
+	d.clearFRRForFailClosedBoot(true)
+
+	got := readConf(t, confPath)
 	if !strings.Contains(got, sentinel) {
-		t.Fatalf("probe failure must preserve the managed section rather than guess; sentinel %q missing:\n%s", sentinel, got)
+		t.Fatalf("pin-probe error + live forwarding must preserve via the armed probe; sentinel %q missing:\n%s", sentinel, got)
 	}
 	if rec.ReloadCalls != 0 {
-		t.Fatalf("probe failure must suppress FRR reloads; got %d reloads", rec.ReloadCalls)
+		t.Fatalf("pin-probe error + live forwarding must suppress FRR reloads; got %d reloads", rec.ReloadCalls)
 	}
 }
 

--- a/pkg/daemon/frr_failclosed_boot_test.go
+++ b/pkg/daemon/frr_failclosed_boot_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,13 @@ func readConf(t *testing.T, path string) string {
 	return string(b)
 }
 
+func withFailClosedBootPinnedXDPProbe(t *testing.T, fn func() (bool, error)) {
+	t.Helper()
+	prev := failClosedBootHasPinnedXDPLinks
+	failClosedBootHasPinnedXDPLinks = fn
+	t.Cleanup(func() { failClosedBootHasPinnedXDPLinks = prev })
+}
+
 // TestColdBootCompileFailedClearsFRR proves the #1993 fix: on a compile-failure
 // cold boot (configCompileFailed=true), the daemon strips the last-good
 // xpf-managed section from frr.conf and reloads FRR exactly once, so peers fail
@@ -47,6 +55,7 @@ func readConf(t *testing.T, path string) string {
 // boot path the managed section survives, so this test fails on the unpatched
 // tree.
 func TestColdBootCompileFailedClearsFRR(t *testing.T) {
+	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) { return false, nil })
 	confPath, sentinel := seededFRRConf(t)
 	rec := &frr.RecordingExecutor{} // healthy reload (nil error)
 	d := &Daemon{frr: frr.NewForTest(confPath, rec)}
@@ -91,9 +100,46 @@ func TestColdBootNormalDoesNotClearFRR(t *testing.T) {
 // TestColdBootCompileFailedNilFRRIsSafe guards the NoDataplane / pre-manager
 // path: clearing with a nil d.frr must not panic and must be a no-op.
 func TestColdBootCompileFailedNilFRRIsSafe(t *testing.T) {
+	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) { return false, nil })
 	d := &Daemon{} // d.frr == nil
 	// Must not panic.
 	d.clearFRRForFailClosedBoot(true)
+}
+
+func TestCompileFailedRestartWithPinnedXDPLinksKeepsFRR(t *testing.T) {
+	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) { return true, nil })
+	confPath, sentinel := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{}
+	d := &Daemon{frr: frr.NewForTest(confPath, rec)}
+
+	d.clearFRRForFailClosedBoot(true)
+
+	got := readConf(t, confPath)
+	if !strings.Contains(got, sentinel) {
+		t.Fatalf("pinned XDP links must preserve the managed section on restart; sentinel %q missing:\n%s", sentinel, got)
+	}
+	if rec.ReloadCalls != 0 {
+		t.Fatalf("pinned XDP links must suppress FRR reloads; got %d reloads", rec.ReloadCalls)
+	}
+}
+
+func TestCompileFailedProbeErrorKeepsFRR(t *testing.T) {
+	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) {
+		return false, errors.New("probe failed")
+	})
+	confPath, sentinel := seededFRRConf(t)
+	rec := &frr.RecordingExecutor{}
+	d := &Daemon{frr: frr.NewForTest(confPath, rec)}
+
+	d.clearFRRForFailClosedBoot(true)
+
+	got := readConf(t, confPath)
+	if !strings.Contains(got, sentinel) {
+		t.Fatalf("probe failure must preserve the managed section rather than guess; sentinel %q missing:\n%s", sentinel, got)
+	}
+	if rec.ReloadCalls != 0 {
+		t.Fatalf("probe failure must suppress FRR reloads; got %d reloads", rec.ReloadCalls)
+	}
 }
 
 // TestClearFRRReloadDegradedDoesNotAbortBoot proves a degraded reload
@@ -102,6 +148,7 @@ func TestColdBootCompileFailedNilFRRIsSafe(t *testing.T) {
 // helper returns normally so boot proceeds. The on-disk strip is what lets a
 // later FRR restart converge even when the live reload degraded.
 func TestClearFRRReloadDegradedDoesNotAbortBoot(t *testing.T) {
+	withFailClosedBootPinnedXDPProbe(t, func() (bool, error) { return false, nil })
 	confPath, sentinel := seededFRRConf(t)
 	rec := &frr.RecordingExecutor{ReloadErr: frr.ErrFRRReloadDegraded}
 	d := &Daemon{frr: frr.NewForTest(confPath, rec)}

--- a/pkg/dataplane/userspace/boot_probe.go
+++ b/pkg/dataplane/userspace/boot_probe.go
@@ -1,0 +1,69 @@
+package userspace
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"net"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// DefaultControlSocketPath returns the control-socket path the userspace
+// helper listens on, resolved exactly the way the runtime Manager resolves it
+// (deriveUserspaceConfig): the operator-configured
+// `system services userspace-dataplane control-socket` when set, else the
+// default under os.TempDir(). cfg may be nil (e.g. a compile-failed boot has no
+// active config), in which case the default path is returned — which matches
+// what a surviving helper from a default-config deployment is listening on.
+func DefaultControlSocketPath(cfg *config.Config) string {
+	return deriveUserspaceConfig(cfg).ControlSocket
+}
+
+// ProbeForwardingArmed performs a lightweight, one-shot status query against a
+// PRE-EXISTING userspace helper on its control socket, WITHOUT standing up a
+// Manager or starting a helper. It is used early in boot (#1993) to decide
+// whether a previous daemon's dataplane is genuinely still forwarding.
+//
+// It returns true only when the helper is reachable AND reports both
+// Enabled && ForwardingArmed — the authoritative "forwarding is live" signal
+// (ProcessStatus.Enabled / ForwardingArmed, the same pair manager.go and
+// process.go gate forwarding on). Every failure mode — socket missing,
+// connect-refused, timeout, malformed/!ok response, Enabled=false, or
+// ForwardingArmed=false — returns false. The boolean is the decision; the
+// error is informational only (connect/decode failures are returned with
+// armed=false so the caller can log the cause but must still treat the helper
+// as NOT armed).
+//
+// This deliberately does NOT distinguish "no helper" from "helper present but
+// unarmed": both mean no live forwarding, and the #1993 caller fails toward
+// clearing FRR in either case.
+func ProbeForwardingArmed(controlSocket string, timeout time.Duration) (bool, error) {
+	if controlSocket == "" {
+		return false, errors.New("userspace dataplane control socket not configured")
+	}
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+	conn, err := net.DialTimeout("unix", controlSocket, timeout)
+	if err != nil {
+		// No surviving helper (ENOENT / ECONNREFUSED) or it is not accepting:
+		// not armed.
+		return false, err
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	if err := json.NewEncoder(conn).Encode(&ControlRequest{Type: "status"}); err != nil {
+		return false, err
+	}
+	var resp ControlResponse
+	if err := json.NewDecoder(bufio.NewReader(conn)).Decode(&resp); err != nil {
+		return false, err
+	}
+	if !resp.OK || resp.Status == nil {
+		return false, nil
+	}
+	return resp.Status.Enabled && resp.Status.ForwardingArmed, nil
+}

--- a/pkg/dataplane/userspace/boot_probe_test.go
+++ b/pkg/dataplane/userspace/boot_probe_test.go
@@ -1,0 +1,136 @@
+package userspace
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// fakeHelperSocket starts a one-shot unix-socket server that answers a single
+// "status" request with the given status (or !ok when status is nil). It mimics
+// the real helper's JSON request/response framing. Returns the socket path.
+func fakeHelperSocket(t *testing.T, status *ProcessStatus, ok bool) string {
+	t.Helper()
+	// Keep the path short (<108 bytes for sun_path) — t.TempDir is under /tmp.
+	sock := filepath.Join(t.TempDir(), "c.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var req ControlRequest
+		if err := json.NewDecoder(bufio.NewReader(conn)).Decode(&req); err != nil {
+			return
+		}
+		resp := ControlResponse{OK: ok, Status: status}
+		_ = json.NewEncoder(conn).Encode(&resp)
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+	})
+	return sock
+}
+
+func TestProbeForwardingArmedReportsLiveForwarding(t *testing.T) {
+	sock := fakeHelperSocket(t, &ProcessStatus{Enabled: true, ForwardingArmed: true}, true)
+	armed, err := ProbeForwardingArmed(sock, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !armed {
+		t.Fatal("Enabled && ForwardingArmed must report armed=true")
+	}
+}
+
+func TestProbeForwardingArmedEnabledButNotArmed(t *testing.T) {
+	sock := fakeHelperSocket(t, &ProcessStatus{Enabled: true, ForwardingArmed: false}, true)
+	armed, err := ProbeForwardingArmed(sock, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if armed {
+		t.Fatal("ForwardingArmed=false must report armed=false (forwarding not live)")
+	}
+}
+
+func TestProbeForwardingArmedArmedButNotEnabled(t *testing.T) {
+	sock := fakeHelperSocket(t, &ProcessStatus{Enabled: false, ForwardingArmed: true}, true)
+	armed, err := ProbeForwardingArmed(sock, time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if armed {
+		t.Fatal("Enabled=false must report armed=false (helper disabled)")
+	}
+}
+
+func TestProbeForwardingArmedNotOK(t *testing.T) {
+	sock := fakeHelperSocket(t, nil, false) // helper rejected the request
+	armed, err := ProbeForwardingArmed(sock, time.Second)
+	if err != nil {
+		t.Fatalf("a !ok response is a clean armed=false, not an error: %v", err)
+	}
+	if armed {
+		t.Fatal("a !ok / nil-status response must report armed=false")
+	}
+}
+
+func TestProbeForwardingArmedSocketMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent.sock")
+	if _, err := os.Stat(missing); err == nil {
+		t.Fatal("test setup: socket must not exist")
+	}
+	armed, err := ProbeForwardingArmed(missing, time.Second)
+	if err == nil {
+		t.Fatal("a missing socket must surface a dial error")
+	}
+	if armed {
+		t.Fatal("a missing socket must report armed=false")
+	}
+}
+
+func TestProbeForwardingArmedEmptyPath(t *testing.T) {
+	armed, err := ProbeForwardingArmed("", time.Second)
+	if err == nil {
+		t.Fatal("an empty control socket must surface a configuration error")
+	}
+	if armed {
+		t.Fatal("an empty control socket must report armed=false")
+	}
+}
+
+func TestDefaultControlSocketPathNilConfigUsesDefault(t *testing.T) {
+	got := DefaultControlSocketPath(nil)
+	want := deriveUserspaceConfig(nil).ControlSocket
+	if got != want {
+		t.Fatalf("nil config: got %q, want default %q", got, want)
+	}
+	if got == "" {
+		t.Fatal("default control socket path must be non-empty")
+	}
+}
+
+func TestDefaultControlSocketPathHonorsConfiguredOverride(t *testing.T) {
+	custom := "/run/xpf/custom-control.sock"
+	cfg := &config.Config{}
+	cfg.System.UserspaceDataplane = &config.UserspaceConfig{ControlSocket: custom}
+	if got := DefaultControlSocketPath(cfg); got != custom {
+		t.Fatalf("configured override: got %q, want %q", got, custom)
+	}
+}

--- a/pkg/frr/testseam.go
+++ b/pkg/frr/testseam.go
@@ -1,0 +1,65 @@
+package frr
+
+import "context"
+
+// This file exposes a narrow, EXPORTED test seam so packages outside pkg/frr
+// (notably pkg/daemon, which owns the boot path that calls Clear()) can drive a
+// Manager against a temp frr.conf WITHOUT shelling out to vtysh/frr-reload.py.
+// Production code never references these symbols; they exist only so the
+// #1993 fail-closed-boot FRR-clear can be unit-tested at the daemon layer.
+
+// RecordingExecutor is an exported frrExecutor double for cross-package tests.
+// It records FrrReloadPy invocations and returns a programmable error so a test
+// can simulate a healthy reload (nil) or a degraded one (ErrFRRReloadDegraded)
+// without running any external process. It is NOT safe for concurrent use
+// beyond the single reload commitManagedSection performs synchronously under
+// reloadMu (Clear's only call site).
+type RecordingExecutor struct {
+	// ReloadErr is returned by FrrReloadPy on every call.
+	ReloadErr error
+	// ReloadCalls counts FrrReloadPy invocations.
+	ReloadCalls int
+	// LastConf is the conf path of the most recent FrrReloadPy call.
+	LastConf string
+}
+
+func (r *RecordingExecutor) Vtysh(string) (string, error) { return "", nil }
+
+func (r *RecordingExecutor) FrrReloadPy(_ context.Context, conf string) error {
+	r.ReloadCalls++
+	r.LastConf = conf
+	return r.ReloadErr
+}
+
+func (r *RecordingExecutor) VtyshLoad(_ context.Context, conf string) ([]byte, error) {
+	// The degraded fallback path; the daemon-layer test does not assert on it,
+	// but it must not shell out, so return a benign success.
+	return nil, nil
+}
+
+// ManagedSectionMarkersForTest returns the begin/end markers that bracket the
+// xpf-managed section in frr.conf, so cross-package tests can seed a realistic
+// frr.conf and assert the section was stripped without hardcoding the marker
+// text (which is an on-disk contract owned by this package).
+func ManagedSectionMarkersForTest() (begin, end string) {
+	return markerBegin, markerEnd
+}
+
+// NewForTest constructs a Manager that writes/reads frr.conf at confPath and
+// routes every reload through exec instead of the real frr-reload.py. The
+// degraded-retry loop is DISABLED so the test does not spawn a background
+// goroutine. Pass a *RecordingExecutor to observe reload calls.
+//
+// This mirrors how same-package tests build `&Manager{frrConf: ..., exec: ...}`
+// directly, but keeps the unexported fields private while still letting the
+// daemon package exercise the real Clear() → writeManagedSection → reload
+// wiring against a temp file.
+func NewForTest(confPath string, exec frrExecutor) *Manager {
+	m := New()
+	m.frrConf = confPath
+	if exec != nil {
+		m.exec = exec
+	}
+	m.DisableDegradedRetry()
+	return m
+}


### PR DESCRIPTION
## What

On a compile-failure boot (the #1960 fail-closed tuple: present,
previously-committed `active.json` that no longer compiles →
`ActiveConfig()==nil` + `EverCommitted()==true` → `bootClassBootstrap`), the
daemon freezes in last-known-good for management reachability and may not arm
the dataplane. But `frr` is an **independent systemd service** that starts from
its persisted `/etc/frr/frr.conf` — whose managed section was written by the
last successful `applyConfig` and is left intact by the freeze. In the **unarmed**
case, FRR forms BGP/OSPF/IS-IS peerings and re-advertises last-good prefixes
for routes this node cannot forward: peers route transit to this node's
**physical interface IPs** and it **silently blackholes 100% of it** instead of
failing over to the HA partner.

`#1922`'s `enterBootstrapMode()` already clears the managed section, but it is
only called from the Item-1b confirmed-commit rollback; the compile-failed boot
path set the bootstrap flag directly and never ran it.

## Fix (research plan Option A, refined by review feedback)

Add `clearFRRForFailClosedBoot(compileFailed)` and call it on the boot path
**right after `d.frr = frr.New()`** (and before the run loop settles). It still
reuses the exact primitive `enterBootstrapMode()` uses (`d.frr.Clear()`,
managed-section only) so peerings drop and upstream/peers fail over to the
partner — **but only when the boot is compile-failed and the dataplane is not
still attached**.

The helper now probes `/sys/fs/bpf/xpf/links` for pinned `xdp_*` links:

- **No pinned XDP links** → treat the node as unarmed and clear the FRR managed
  section.
- **Pinned XDP links present** → preserve FRR, because this is a hitless-restart
  shape where the last-known-good dataplane is still attached and forwarding.

This deliberately runs **only the FRR-clear step** — NOT the `.network`/`.link`
removal or the link-cycle that `enterBootstrapMode()` also performs. The
compile-failed fail-closed path is intentionally **freeze-in-last-known-good for
management** (#1960): removing networkd files / link-cycling toward bootstrap
fxp0-DHCP could change the mgmt IP out from under a connected operator.

- **Daemon-restart behavior preserved:** a compile-failed restart with live
  pinned XDP links no longer clears FRR, so the PR does not drop peerings while
  last-known-good forwarding is still attached.
- **Reversible:** the first compilable `commit confirmed` (or a cluster
  `SyncApply`) re-renders FRR via `applyFRRConfig` and re-installs the managed
  section.
- **Degraded-tolerant:** a degraded reload (`ErrFRRReloadDegraded`) is logged,
  not fatal — `Clear()` writes the empty managed section to disk before it
  reloads, so a later FRR restart converges; mgmt reachability is never traded
  for a clean reload.
- **Scope guard:** normal/fresh-install boots remain byte-identical (a normal
  boot must NEVER wipe a healthy node's FRR config); the `d.frr != nil` guard
  tolerates `NoDataplane` daemons.
- **Log accuracy:** the failure warning is now hedged so it is correct both for
  reload-degraded cases and for failures that occur before the managed section
  is rewritten on disk.

## Files

- `pkg/daemon/bootstrap.go` — `clearFRRForFailClosedBoot` helper plus pinned
  XDP link probe and corrected warning text.
- `pkg/daemon/daemon_run.go` — call site after `d.frr = frr.New()`.
- `pkg/frr/testseam.go` — exported cross-package test seam (`NewForTest`,
  `RecordingExecutor`, `ManagedSectionMarkersForTest`) so the daemon test
  drives the real `Clear()` wiring against a temp `frr.conf` without shelling
  out. Production never references these.
- `pkg/daemon/frr_failclosed_boot_test.go` — regression tests.
- `pkg/daemon/README.md` — updates the daemon bootstrap docs to describe the
  unarmed-boot clear and pinned-link restart guard.
- `_Log.md`.

## Tests

`pkg/daemon` unit tests (no lab needed for correctness):

- `TestColdBootCompileFailedClearsFRR` — strips the managed section, preserves
  operator content outside the markers, exactly one reload.
- `TestColdBootNormalDoesNotClearFRR` — the critical *don't wipe a healthy
  node* guard: managed section untouched + zero reloads.
- `TestColdBootCompileFailedNilFRRIsSafe` — NoDataplane / nil-frr no-op (no
  panic).
- `TestClearFRRReloadDegradedDoesNotAbortBoot` — degraded reload still strips
  on disk; boot proceeds.
- `TestCompileFailedRestartWithPinnedXDPLinksKeepsFRR` — compile-failed restart
  with live pinned XDP links preserves the managed section and does not reload
  FRR.
- `TestCompileFailedProbeErrorKeepsFRR` — probe failure fails safe by preserving
  FRR rather than guessing that the dataplane is unarmed.

Non-tautology proven: the clear path still fails on the unpatched tree, and the
new restart-specific tests pin the review fix so the managed section is not
cleared when pinned XDP links show the dataplane is still attached.
`go build ./...` and `go test ./pkg/daemon/...` pass.

## Lab gate (confirmatory, before merge)

This touches the **boot/failover** path. It needs a **cold-boot +
partner-failover** check on the loss userspace cluster: verify (a) the managed
section is cleared + FRR reloaded when the node is compile-failed and unarmed,
(b) mgmt still reachable at the existing address, (c) the partner attracts
transit, and a `make test-failover` no-regression pass. Also confirm the
**daemon-RESTART** path is unchanged when pinned XDP links keep the dataplane
live. Per the research plan, the lab pass is confirmatory-not-gating for the
unit-closeable logic, but should run before final sign-off.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>