### PR TITLE
#1387: DHCP server dynamic DNS (DDNS), increment 1 — config model + reconciler core

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -509,6 +509,31 @@
 - **Action**: Documented the single-owner + draining-tombstone shutdown
   contract and the Status "draining" state in the module README.
 - **File(s)**: pkg/ra/README.md, _Log.md
+## 2026-06-19 — #1387 DHCP dynamic-DNS (increment 1)
+
+- **Timestamp**: 2026-06-19
+- **Action**: Implement increment 1 of #1387 per
+  `docs/research/1387-dhcp-ddns/plan.md` (recommended Path C — pluggable
+  `DNSUpdater` backend, RFC 2136 first). Config model
+  (`config.DHCPDynamicDNSConfig`, nilable, default-off, dual-AST compile,
+  TSIG redaction) + typed schema leaves (enable/ttl/hostname-source/
+  conflict-policy/backend) + state-aware Kea lease parser
+  (state+expire+v6 DUID/IAID) + `DNSUpdater` interface + reconciler core
+  (build-desired/diff-owned/add-move-reassign-expire, retry-no-wedge) +
+  never-delete-non-owned ownership state store (JSON via
+  `fsatomic.WriteFileDurable`) + `DDNSManager.Stats()` counters. NO live
+  rfc2136 backend, NO HA wiring, NO Kea D2, NO daemon loop / show
+  plumbing / Prometheus emission (deferred to lab-/test-failover-gated
+  increments 2-4; the API collector is checked so an unemitted descriptor
+  would break the coverage canary). Net behaviour change with DDNS absent:
+  zero. 26 new tests (config dual-AST/redaction/schema; dhcpserver
+  hostname/PTR/parser/reconciler/state). Full `go test ./...` green.
+- **File(s)**: pkg/config/types_system.go, pkg/config/compiler_services.go,
+  pkg/config/schema_system.go, pkg/config/compiler_dhcp_ddns_test.go,
+  pkg/dhcpserver/ddns.go, pkg/dhcpserver/ddns_hostname.go,
+  pkg/dhcpserver/ddns_dns.go, pkg/dhcpserver/ddns_leases.go,
+  pkg/dhcpserver/ddns_state.go, pkg/dhcpserver/ddns_test.go,
+  pkg/dhcpserver/README.md, docs/config-schema.md, _Log.md
 
 ## 2026-06-19 — #2000 review follow-up on postinst test harness
 

--- a/_Log.md
+++ b/_Log.md
@@ -233,6 +233,36 @@
   verified: a no-standalone mutant fails T7c+T2b; an always-standalone mutant
   fails T7d (double goodbye).
 - **File(s)**: pkg/ra/serialize_test.go, _Log.md
+## 2026-06-19 — #1387 DDNS PR #2043: reject duplicate header columns (Codex r5)
+
+- **Timestamp**: 2026-06-19
+- **Action**: Fix Codex round-5's one MAJOR (same mass-delete class,
+  duplicate-column trigger). Building `cols` with
+  `for i,h := range records[0] { cols[lower(h)] = i }` OVERWRITES an earlier
+  index with a later duplicate name, and the required-column validation only
+  checked that the key EXISTS, not that it is unambiguous. A header with a
+  duplicated column (e.g. two "address" or two "state", or a corruption that
+  repeats a column) made cols[name] point at the LAST occurrence — possibly
+  the wrong/empty column → leases read empty/wrong → wrong desired set → the
+  destructive delete pass removed owned records. Fix (close the class, not
+  the trigger): while building cols, DETECT duplicates case-insensitively
+  and return a parse ERROR for ANY duplicate column name (not just required
+  ones) — a healthy Kea memfile has all-unique columns, so a header is
+  trusted only if it maps UNAMBIGUOUSLY; an ambiguous header → untrusted →
+  Reconcile SKIPS the destructive diff. Reasoned through the remaining
+  header shapes: extra/unknown columns (ignored by name) and reordered
+  columns (resolved by name) are tolerated; ragged rows are bounds-checked
+  in leaseColumnValue (idx < len(fields)). Assessment: the
+  mass-delete-via-header class is now FULLY CLOSED (missing column r3,
+  header-only/zero-row r4, duplicate column r5; extra/reorder/ragged all
+  non-destructive). Eight new tests: duplicate required (address/state),
+  case-insensitive duplicate, duplicate optional, v6 duplicate identity,
+  end-to-end no-mass-delete via Reconcile (all FAIL pre-fix 7708d1b40), plus
+  extra-column-tolerated + reordered-tolerated (pass pre+post, proving the
+  rejection is not over-broad). README updated.
+- **File(s)**: pkg/dhcpserver/ddns_leases.go,
+  pkg/dhcpserver/ddns_test.go, pkg/dhcpserver/README.md, _Log.md
+
 ## 2026-06-19 — #1387 DDNS PR #2043: validate header before empty return (Codex r4)
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -233,6 +233,36 @@
   verified: a no-standalone mutant fails T7c+T2b; an always-standalone mutant
   fails T7d (double goodbye).
 - **File(s)**: pkg/ra/serialize_test.go, _Log.md
+## 2026-06-19 — #1387 DDNS PR #2043: validate header before empty return (Codex r4)
+
+- **Timestamp**: 2026-06-19
+- **Action**: Fix Codex round-4's one MAJOR: the required-column validation
+  was BYPASSED for header-only / zero-data-row files. parseActiveLeases
+  returned `nil, nil` on `len(records) < 2` BEFORE building the cols map
+  and running the required-column check, so a file with ONLY a header (no
+  data rows) and a MANGLED header (missing hostname/identity) was treated
+  as a TRUSTED zero-lease result → Reconcile ran the destructive pass →
+  mass-delete of the family's owned records. Same destructive class,
+  header-only trigger. Fix: REORDER so a present header is ALWAYS validated
+  before any trusted-empty return. (1) A 0-record EXISTING file (no header
+  — Kea always writes one, so this is mid-write/corrupt) now ERRORS
+  (fail-safe untrusted), not trusted-empty; a genuinely MISSING file keeps
+  its `os.IsNotExist` → nil,nil. (2) Build cols + run required-column
+  validation FIRST; a mangled header errors with or without data rows. (3)
+  Only AFTER the header validates good is a header-with-zero-data-rows
+  returned as a legitimate trusted zero-lease (so a genuinely-drained Kea
+  still clears owned records). Net: trusted-empty (which permits deleting
+  owned records) is returned ONLY when the file is missing, OR the header
+  is present AND valid AND there are no active data rows. Five new
+  non-tautological tests (header-only mangled v4/v6 errors + end-to-end
+  no-mass-delete; valid header-only is trusted-empty + clears owned via
+  Reconcile; 0-byte existing file errors; missing file stays trusted).
+  The mangled/0-byte cases FAIL against pre-fix head b45c80c2; the
+  legitimate cases pass both pre- and post-fix (not over-broad). README
+  updated.
+- **File(s)**: pkg/dhcpserver/ddns_leases.go,
+  pkg/dhcpserver/ddns_test.go, pkg/dhcpserver/README.md, _Log.md
+
 ## 2026-06-19 — #1387 DDNS PR #2043: generalize header validation (Codex r3)
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,37 @@
 # Action Log
 
+## 2026-06-19 — #1387 DDNS PR #2043: per-row conformance check (Codex r6)
+
+- **Timestamp**: 2026-06-19
+- **Action**: Fix Codex round-6's one MAJOR — the row-level complement to
+  the now-complete header-schema validation. Row values are read via
+  leaseColumnValue, which returns "" when a data row is SHORTER than a
+  required column's index (FieldsPerRecord=-1 allows ragged rows). A
+  torn/truncated Kea memfile append leaves a row that does not reach a
+  required column → that column reads "" → the lease is mis-read (address=""
+  → row skipped; hostname="" → unnamed-skip) → it drops out of the desired
+  set → its owned DNS record is deleted. Bounds-safe but not delete-safe.
+  Fix: after the header validates, compute maxRequiredIdx = the max index
+  among the family's required columns; in the per-row loop, a row with
+  len(fields) <= maxRequiredIdx cannot supply a required column, so it makes
+  the SOURCE unreliable → return a parse error → Reconcile marks the family
+  untrusted → SKIPS the destructive diff. We do NOT silently skip just the
+  row (we cannot know which lease a torn row is, and skipping still drops
+  its record). A row with MORE fields than the header is tolerated (extra
+  trailing fields ignored by name-based lookup). Reasoned through remaining
+  structural shapes: extra/reordered columns (by-name, fine), comment/blank
+  lines (r.Comment + CSV skips them), garbage VALUES (per-row lenient data —
+  drops/mis-keys at most that one lease, not a structural class). Assessment:
+  the unreliable-source → destructive-delete class is now FULLY closed at
+  both header (required present, each once, no duplicates) AND row (every
+  data row long enough for every required column) level. Five new tests
+  (ragged v4 too-short, v4 missing trailing required col, v6 ragged,
+  end-to-end no-mass-delete via Reconcile — all FAIL pre-fix a107b90c3; plus
+  extra-trailing-field tolerated, passes pre+post proving not over-broad).
+  README updated.
+- **File(s)**: pkg/dhcpserver/ddns_leases.go,
+  pkg/dhcpserver/ddns_test.go, pkg/dhcpserver/README.md, _Log.md
+
 ## 2026-06-19 — #1925 review r2: declare growpart dep + mktemp guard
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -535,6 +535,19 @@
   pkg/dhcpserver/ddns_state.go, pkg/dhcpserver/ddns_test.go,
   pkg/dhcpserver/README.md, docs/config-schema.md, _Log.md
 
+## 2026-06-20 — #1387 DDNS review follow-up
+
+- **Timestamp**: 2026-06-20
+- **Action**: Address Copilot review on the DDNS increment-1 core. Make the
+  reconciler preserve the documented clean-old-owner-before-new ordering by
+  suppressing replacement upserts when the old owned delete fails, so the
+  next reconcile retries cleanup first. Teach the state-aware Kea lease
+  parser to use `fqdn_fwd` to distinguish the host-name option from a
+  client-supplied FQDN, and extend the DDNS unit tests to cover both
+  behaviors.
+- **File(s)**: pkg/dhcpserver/ddns.go, pkg/dhcpserver/ddns_leases.go,
+  pkg/dhcpserver/ddns_test.go, pkg/dhcpserver/README.md, _Log.md
+
 ## 2026-06-19 — #2000 review follow-up on postinst test harness
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -329,6 +329,40 @@
   still emitted — fails against the bump-then-unlock gap). Mutation-verified
   both fail against the respective pre-fix code.
 - **File(s)**: pkg/ra/serialize_test.go, _Log.md
+## 2026-06-19 — #1387 DDNS PR #2043 review: fix four MAJORs + one MINOR
+
+- **Timestamp**: 2026-06-19
+- **Action**: Address Codex's four MAJOR findings + one MINOR on the
+  #1387 DHCP DDNS increment-1 PR. (M1) Enforce zone-suffix containment
+  in `finalizeFQDN`: a client-offered dotted name that is not within the
+  configured domain is relabeled to `<first-label>.<domain>` (no domain
+  -> first label only), so a client can never publish outside the
+  configured zone (escape vectors: foreign TLD, trailing dot, double
+  dot, deep foreign subtree). (M2) Make a nil `DNSUpdater` a logged
+  `nopUpdater` (the increment-1 default — live backend deferred) instead
+  of a nil-pointer panic on first publish/withdraw; a no-op upsert does
+  NOT record phantom ownership, and a new `skippedNoBackend` counter
+  surfaces the no-op activity. (M3) Fix the Kea lease parser so an
+  active row reclaims an address that an earlier inactive/expired row
+  tombstoned (last-row-wins now lets active supersede a prior tombstone
+  and re-enter output order via an `inOrder` set; this also removed a
+  pre-fix duplicate-in-order bug). (M4) Make `Reconcile` fail-safe on a
+  lease-CSV parse error: the failing family is marked untrusted and its
+  destructive diff (deletes) is SKIPPED that cycle so a transient
+  malformed CSV can never mass-delete that family's owned records; the
+  parse error is surfaced to the caller. (m5) Reword the `backend`
+  schema help + type doc to say the value is parsed/validated but the
+  live updater is deferred, and emit a commit-time warning
+  (`validateDDNSDeferredBackendWarnings`) when DDNS is enabled (stronger
+  when an update-server / TSIG is configured). Six new
+  non-tautological tests (each proven to fail/panic against pre-fix
+  code). README + schema/type docs updated.
+- **File(s)**: pkg/dhcpserver/ddns_hostname.go,
+  pkg/dhcpserver/ddns_dns.go, pkg/dhcpserver/ddns.go,
+  pkg/dhcpserver/ddns_leases.go, pkg/dhcpserver/ddns_test.go,
+  pkg/dhcpserver/README.md, pkg/config/compiler.go,
+  pkg/config/schema_system.go, pkg/config/types_system.go,
+  pkg/config/compiler_dhcp_ddns_test.go, _Log.md
 
 ## 2026-06-20 — #2034 RA link-local review follow-up (regression test)
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,39 @@
 # Action Log
 
+## 2026-06-19 — #1387 DDNS PR #2043: Copilot findings (dual-family merge, version, comments)
+
+- **Timestamp**: 2026-06-19
+- **Action**: Fix Copilot's inline-review findings outside the (now-closed)
+  mass-delete-via-header class. (MAJOR) dynamic-dns block overwrite:
+  compileDHCPLocalServer did `dhcp.DynamicDNS = compileDHCPDynamicDNS(...)`
+  for whichever family it found, so when BOTH dhcp-local-server and
+  dhcpv6-local-server carried a block, the second whole-struct overwrote
+  the first — a PARTIAL second block (e.g. only `domain` under v6) compiled
+  to Enabled=false and cleared the v4 block's enable/server/ttl → DDNS
+  silently disabled. Fix: `mergeDHCPDynamicDNS` merges field-by-field — a
+  field set in either family wins (first-family-wins on a genuine conflict,
+  matching the intra-block first-value rule), presence-only `enable`
+  LATCHES on (a partial block can never flip it false). (ROBUSTNESS)
+  loadDDNSState now validates `ddnsStateFile.Version`: an unknown non-zero
+  version is treated like a corrupt store (fail-open to empty + error/warn)
+  so a future format bump can't be mis-decoded into wrong-tuple deletes;
+  version 0 (pre-versioning / zero-value) still loads. (COMMENTS, no logic
+  change) reworded the stale `addrOwner` tracker comment (reassignment is
+  handled by the owned-state delete pass + blocked maps), the nonexistent
+  `collectDHCPDDNSProps` reference (it is compileDHCPDynamicDNS's internal
+  walker), the corrupt-store "age out by TTL" claim (TTL is caching not
+  removal — records persist until authoritatively removed), and clarified
+  the nopUpdater deleteOwnedLocked comment (correct for inc-1; noted the
+  inc-2 downgrade-orphan caveat). REFUTED Copilot's "Pass 2 upserts when
+  Pass 1 delete failed" — already handled by blockedIdentity/Address/FQDN
+  (left unchanged). Three new non-tautological tests (dual-family merge
+  keeps enable+server+ttl+gains domain; enable-latch either order; state
+  version fail-open + v0 tolerated) — all FAIL against pre-fix. README
+  updated.
+- **File(s)**: pkg/config/compiler_services.go, pkg/dhcpserver/ddns.go,
+  pkg/dhcpserver/ddns_state.go, pkg/config/compiler_dhcp_ddns_test.go,
+  pkg/dhcpserver/ddns_test.go, pkg/dhcpserver/README.md, _Log.md
+
 ## 2026-06-19 — #1387 DDNS PR #2043: per-row conformance check (Codex r6)
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -233,6 +233,39 @@
   verified: a no-standalone mutant fails T7c+T2b; an always-standalone mutant
   fails T7d (double goodbye).
 - **File(s)**: pkg/ra/serialize_test.go, _Log.md
+## 2026-06-19 — #1387 DDNS PR #2043: generalize header validation (Codex r3)
+
+- **Timestamp**: 2026-06-19
+- **Action**: Fix Codex round-3's two MAJORs + one MINOR. The
+  `requiredLeaseColumns={address,state}` fix closed the address/state
+  trigger, but the mass-delete/record-loss class GENERALIZES to any header
+  column the reconciler depends on. (MAJOR A) A missing/renamed `hostname`
+  column parses with no error but empties HostName/ClientFQDN, so
+  `deriveFQDN` errors for every lease and the reconciler skips them all as
+  unnamed → empty desired set → Pass-1 mass-deletes all owned records.
+  (MAJOR B) Missing identity columns (v4 client_id/hwaddr, v6 duid/iaid)
+  collapse the identity to the address fallback → owned records keyed by
+  the prior identity no longer match → delete+re-add churn → record LOST
+  if the re-add upsert fails. (MINOR) the case-insensitivity fix
+  lower-cased the cols map keys but not the lookup name in get(), so the
+  invariant held only because callers pass lower-case literals. Fix: made
+  `requiredLeaseColumns` a FAMILY-SPECIFIC map (v4: address,state,
+  hostname,client_id,hwaddr; v6: address,state,hostname,duid,iaid) so a
+  missing column for that family errors → Reconcile marks the family
+  untrusted → SKIPS the destructive diff; extracted the column lookup into
+  `leaseColumnValue` which lower-cases the name argument (cols keys already
+  lower-cased), making the invariant hold at the call site and unit-
+  testable. fqdn_fwd / expire / subnet_id stay OPTIONAL with documented
+  non-destructive rationale (defaults to host-name; state still gates
+  active/tombstone; metadata not compared by recordsEqual). Five new
+  non-tautological tests (naming-required v4/v6 + end-to-end no-mass-
+  delete; identity-required v4/v6 + end-to-end no-churn; optional-degrade;
+  leaseColumnValue mixed-case lookup). All FAIL against pre-fix head
+  07ab9f5f. Adjusted one existing fixture (ClientIDPreferred) to carry the
+  now-required hostname column. README updated.
+- **File(s)**: pkg/dhcpserver/ddns_leases.go,
+  pkg/dhcpserver/ddns_test.go, pkg/dhcpserver/README.md, _Log.md
+
 ## 2026-06-19 — #1387 DDNS PR #2043: close MAJOR-4 header-validation re-open
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -233,6 +233,32 @@
   verified: a no-standalone mutant fails T7c+T2b; an always-standalone mutant
   fails T7d (double goodbye).
 - **File(s)**: pkg/ra/serialize_test.go, _Log.md
+## 2026-06-19 — #1387 DDNS PR #2043: close MAJOR-4 header-validation re-open
+
+- **Timestamp**: 2026-06-19
+- **Action**: Fix the AGY-found residual that re-opened the MAJOR-4
+  mass-delete vector through a different trigger. `parseActiveLeases`
+  built its header->index map from `records[0]` with raw, case-sensitive
+  keys and never validated that the columns it reads exist. A MANGLED Kea
+  memfile header — a required column missing/renamed, or a case
+  difference (`Address` vs `address`) — made `get(fields,"address")`
+  return "" for every row, so the main loop skipped all rows and returned
+  an EMPTY lease set with NO error. Reconcile's MAJOR-4 protection only
+  marks a family untrusted on a parse ERROR, so an empty-but-no-error
+  result was treated as "zero active leases" → the destructive delete
+  pass ran → ALL owned records for that family were mass-deleted. Fix:
+  (1) lower-case the header keys when building `cols` and the get()
+  lookup name (values stay verbatim) for case-insensitive matching;
+  (2) after building `cols`, validate `requiredLeaseColumns` (`address`,
+  `state`) are present and return a non-nil error if any is missing, so
+  Reconcile marks the family untrusted and SKIPS the destructive diff.
+  An empty FILE (`len(records) < 2`) is still a legitimate zero-lease,
+  no-error case; a present-but-mangled header now ERRORS. Two new
+  non-tautological tests (mangled header errors + does-not-mass-delete
+  via Reconcile; mixed-case header parses correctly) — both FAIL against
+  pre-fix head fd79778b8. README updated.
+- **File(s)**: pkg/dhcpserver/ddns_leases.go,
+  pkg/dhcpserver/ddns_test.go, pkg/dhcpserver/README.md, _Log.md
 
 ## 2026-06-20 — #1993 FRR clear MAJOR fix: require LIVE forwarding, not just pins
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -321,6 +321,40 @@ reserved for whole-dataplane selection where a rewrite shim
     fails at commit; `allow-duplicates` is an explicit presence-only flag.
   Pure schema hardening — no runtime behavior change. Regression coverage:
   `pkg/config/schema_validate_2008_test.go`.
+- **#1387 (DHCP dynamic-DNS, increment 1):** added an opt-in
+  `dynamic-dns` subtree under BOTH `services dhcp-local-server` and
+  `services dhcpv6-local-server` (a single shared `config.DHCPDynamicDNSConfig`
+  on `DHCPServerConfig`; absent block == nil == today's behaviour). The
+  schema tree is built by `dhcpDynamicDNSSchema()` in `schema_system.go`
+  and shared by both parents (returned fresh per call so the two parents
+  do not alias a mutable map). Typed leaves, validated where the
+  reconciler/runtime consume them:
+  - `enable` — presence-only flag (turns the reconciler on).
+  - `ttl` — `ValueInteger` + `ValidateIntegerMin(1)` (record TTL seconds;
+    the runtime defaults an unset/<=0 value to 300 in `policyFromConfig`,
+    so the schema enforces only the positive floor).
+  - `hostname-source` — `ValueEnumOf` + `ValidateEnum(client-hostname |
+    fqdn | mac-fallback)`, matching `deriveFQDN`'s three modes.
+  - `conflict-policy` — `ValueEnumOf` + `ValidateEnum(replace-owned |
+    skip-existing | strict-fail)`.
+  - `backend` — `ValueEnumOf` + `ValidateEnum(rfc2136 | kea-d2)`. `kea-d2`
+    is a RESERVED enum value (the live backend is `rfc2136`, increment 2;
+    Kea D2 is not in the image). The enum accepts it so a config naming it
+    commits, but increment 1 implements only `rfc2136`.
+  Deliberately UNTYPED (free-form `args:1` leaves), with reasons in
+  `schema_system.go`: `domain`, `update-server`, `tsig-key`,
+  `tsig-algorithm`, `tsig-secret`. The live rfc2136 backend that would
+  constrain `update-server` (host[:port]) lands in increment 2, and a
+  hostname / base64 secret is not validatable by the existing IP/identifier
+  validators without false-rejecting valid input. `tsig-secret` is
+  SENSITIVE: it is redacted in `DHCPDynamicDNSConfig.String()` and must
+  never be logged. Compile lives in `compileDHCPDynamicDNS`
+  (`compiler_services.go`), handling both the hierarchical and flat-set AST
+  shapes (walk + first-value-wins, mirroring `collectDeviceMapProps`); an
+  empty/garbage block returns nil (positional/disabled, closing the
+  empty-tree-compiles-non-nil trap). Regression coverage:
+  `pkg/config/compiler_dhcp_ddns_test.go` (dual-AST equality, absent-default,
+  TSIG redaction, enum/ttl accept+reject).
 
 ### #1979 — flow / flow-export NUM_WIDTH commit-time validation (Layer B)
 

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1525,7 +1525,39 @@ func ValidateConfig(cfg *Config) []string {
 	// commit time so the operator sees it before applying.
 	warnings = append(warnings, validateRoutingRuleWindowWarnings(cfg)...)
 
+	// #1387: DHCP dynamic-DNS is parsed and validated in this increment,
+	// but the live DNS-update backend is deferred — nothing is published to
+	// DNS yet. Warn at commit time so an operator who enables DDNS (and
+	// especially one who configures an update-server / TSIG key) is not
+	// surprised that no records appear.
+	warnings = append(warnings, validateDDNSDeferredBackendWarnings(cfg)...)
+
 	return warnings
+}
+
+// validateDDNSDeferredBackendWarnings emits a commit-time warning when DHCP
+// dynamic-DNS is enabled but no live DNS-update backend is wired (#1387
+// increment 1). The config grammar is accepted and the manager runs in a
+// no-op mode (records are logged-and-skipped), so an operator must be told
+// the feature does not yet publish to DNS. The warning is stronger when an
+// update-server or TSIG key is configured, since those signal an operator
+// expectation of live updates.
+func validateDDNSDeferredBackendWarnings(cfg *Config) []string {
+	d := cfg.System.DHCPServer.DynamicDNS
+	if d == nil || !d.Enabled {
+		return nil
+	}
+	hasUpdateTarget := d.UpdateServer != "" || d.TSIGKeyName != "" ||
+		d.TSIGAlgorithm != "" || d.TSIGSecret != ""
+	if hasUpdateTarget {
+		return []string{"dhcp dynamic-dns is enabled with an update-server / " +
+			"TSIG configured, but the live DNS-update backend is not yet wired " +
+			"(this increment parses and validates the config only); no records " +
+			"will be published to DNS until a later increment enables the backend"}
+	}
+	return []string{"dhcp dynamic-dns is enabled, but the live DNS-update " +
+		"backend is deferred to a later increment; the configuration is " +
+		"accepted and validated but no records are published to DNS yet"}
 }
 
 // validateRoutingRuleWindowWarnings emits commit-time warnings when a

--- a/pkg/config/compiler_dhcp_ddns_test.go
+++ b/pkg/config/compiler_dhcp_ddns_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1387 DHCP dynamic-dns config-model tests. All use the production
+// ParseSetCommand + SetPath path (buildTree), never NewParser (the
+// flat-set merge gotcha in CLAUDE.md). They prove the dual-AST compile,
+// the empty-block-is-absent guard, TSIG redaction, and the schema typed
+// leaves (enum + ttl validators) at commit check.
+
+func ddnsOf(t *testing.T, cfg *Config) *DHCPDynamicDNSConfig {
+	t.Helper()
+	return cfg.System.DHCPServer.DynamicDNS
+}
+
+func TestDHCPDDNSHierarchicalAndFlatSetCompileEqually(t *testing.T) {
+	// Dual-AST equality: the hierarchical block and the flat-set spelling
+	// must compile to the same typed DHCPDynamicDNSConfig (plan §5 inv 5).
+	flat := buildTree(t, []string{
+		"set system services dhcp-local-server dynamic-dns enable",
+		"set system services dhcp-local-server dynamic-dns domain corp.example.com",
+		"set system services dhcp-local-server dynamic-dns ttl 600",
+		"set system services dhcp-local-server dynamic-dns hostname-source fqdn",
+		"set system services dhcp-local-server dynamic-dns conflict-policy strict-fail",
+		"set system services dhcp-local-server dynamic-dns backend rfc2136",
+		"set system services dhcp-local-server dynamic-dns update-server 192.0.2.53",
+		"set system services dhcp-local-server dynamic-dns tsig-key xpf-key",
+		"set system services dhcp-local-server dynamic-dns tsig-algorithm hmac-sha256",
+		"set system services dhcp-local-server dynamic-dns tsig-secret c2VjcmV0",
+	})
+	cflat, err := CompileConfig(flat)
+	if err != nil {
+		t.Fatalf("CompileConfig(flat): %v", err)
+	}
+	df := ddnsOf(t, cflat)
+	if df == nil {
+		t.Fatal("flat-set DDNS compiled to nil")
+	}
+
+	want := &DHCPDynamicDNSConfig{
+		Enabled:        true,
+		Domain:         "corp.example.com",
+		TTLSeconds:     600,
+		HostnameSource: "fqdn",
+		ConflictPolicy: "strict-fail",
+		Backend:        "rfc2136",
+		UpdateServer:   "192.0.2.53",
+		TSIGKeyName:    "xpf-key",
+		TSIGAlgorithm:  "hmac-sha256",
+		TSIGSecret:     "c2VjcmV0",
+	}
+	if *df != *want {
+		t.Fatalf("flat-set DDNS mismatch:\n got %+v\nwant %+v", *df, *want)
+	}
+
+	// Hierarchical NewParser path: build the same content through the
+	// real parser to prove the hierarchical AST compiles identically.
+	hierSrc := `system {
+  services {
+    dhcp-local-server {
+      dynamic-dns {
+        enable;
+        domain corp.example.com;
+        ttl 600;
+        hostname-source fqdn;
+        conflict-policy strict-fail;
+        backend rfc2136;
+        update-server 192.0.2.53;
+        tsig-key xpf-key;
+        tsig-algorithm hmac-sha256;
+        tsig-secret c2VjcmV0;
+      }
+    }
+  }
+}`
+	hp := NewParser(hierSrc)
+	htree, perrs := hp.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("hierarchical Parse: %v", perrs)
+	}
+	chier, err := CompileConfig(htree)
+	if err != nil {
+		t.Fatalf("CompileConfig(hier): %v", err)
+	}
+	dh := ddnsOf(t, chier)
+	if dh == nil {
+		t.Fatal("hierarchical DDNS compiled to nil")
+	}
+	if *dh != *df {
+		t.Fatalf("hierarchical vs flat-set DDNS differ:\n hier %+v\n flat %+v", *dh, *df)
+	}
+}
+
+func TestDHCPDDNSAbsentByDefault(t *testing.T) {
+	// No dynamic-dns stanza => nil block => zero behaviour change.
+	cfg, err := CompileConfig(buildTree(t, []string{
+		"set system services dhcp-local-server group g0 interface ge-0/0/0",
+		"set system services dhcp-local-server group g0 pool p0 subnet 10.0.1.0/24",
+	}))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if ddnsOf(t, cfg) != nil {
+		t.Fatal("absent dynamic-dns must compile to nil DynamicDNS")
+	}
+}
+
+func TestDHCPDDNSV6BlockCompiles(t *testing.T) {
+	cfg, err := CompileConfig(buildTree(t, []string{
+		"set system services dhcpv6-local-server dynamic-dns enable",
+		"set system services dhcpv6-local-server dynamic-dns domain v6.example.com",
+	}))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	d := ddnsOf(t, cfg)
+	if d == nil || !d.Enabled || d.Domain != "v6.example.com" {
+		t.Fatalf("v6 dynamic-dns not compiled: %+v", d)
+	}
+}
+
+func TestDHCPDDNSStringRedactsTSIGSecret(t *testing.T) {
+	d := &DHCPDynamicDNSConfig{
+		Enabled:       true,
+		TSIGKeyName:   "k",
+		TSIGAlgorithm: "hmac-sha256",
+		TSIGSecret:    "TOPSECRET-base64==",
+	}
+	s := d.String()
+	if strings.Contains(s, "TOPSECRET") {
+		t.Fatalf("String() leaked TSIG secret: %q", s)
+	}
+	if !strings.Contains(s, "<redacted>") {
+		t.Fatalf("String() did not redact a set secret: %q", s)
+	}
+	// An unset secret renders empty, not <redacted>.
+	d.TSIGSecret = ""
+	if strings.Contains(d.String(), "<redacted>") {
+		t.Fatalf("String() redacted an empty secret: %q", d.String())
+	}
+}
+
+func TestDHCPDDNSSchemaAcceptsValidLeaves(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system services dhcp-local-server dynamic-dns enable",
+		"set system services dhcp-local-server dynamic-dns ttl 300",
+		"set system services dhcp-local-server dynamic-dns hostname-source client-hostname",
+		"set system services dhcp-local-server dynamic-dns conflict-policy replace-owned",
+		"set system services dhcp-local-server dynamic-dns backend rfc2136",
+	})
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("SchemaValidate rejected valid DDNS leaves: %v", err)
+	}
+}
+
+func TestDHCPDDNSSchemaRejectsBadEnumAndTTL(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"bad hostname-source", "set system services dhcp-local-server dynamic-dns hostname-source bogus"},
+		{"bad conflict-policy", "set system services dhcp-local-server dynamic-dns conflict-policy maybe"},
+		{"bad backend", "set system services dhcp-local-server dynamic-dns backend windows-dns"},
+		{"zero ttl", "set system services dhcp-local-server dynamic-dns ttl 0"},
+		{"garbage ttl", "set system services dhcp-local-server dynamic-dns ttl notanumber"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, []string{tc.line})
+			if err := SchemaValidate(tree, nil); err == nil {
+				t.Fatalf("SchemaValidate accepted invalid leaf %q", tc.line)
+			}
+		})
+	}
+}

--- a/pkg/config/compiler_dhcp_ddns_test.go
+++ b/pkg/config/compiler_dhcp_ddns_test.go
@@ -156,6 +156,81 @@ func TestDHCPDDNSSchemaAcceptsValidLeaves(t *testing.T) {
 	}
 }
 
+// TestDHCPDDNSEnabledWarnsBackendDeferred proves the #1387 MINOR-5 commit
+// warning: enabling DDNS (whose live backend is deferred to a later
+// increment) must surface a commit-time warning that nothing is published to
+// DNS yet, and the warning must be stronger when an update-server / TSIG is
+// also configured. An absent or disabled stanza emits no such warning.
+func TestDHCPDDNSEnabledWarnsBackendDeferred(t *testing.T) {
+	hasDeferredWarn := func(ws []string) (string, bool) {
+		for _, w := range ws {
+			if strings.Contains(w, "dhcp dynamic-dns") &&
+				strings.Contains(w, "backend") {
+				return w, true
+			}
+		}
+		return "", false
+	}
+
+	t.Run("enabled bare", func(t *testing.T) {
+		cfg, err := CompileConfig(buildTree(t, []string{
+			"set system services dhcp-local-server dynamic-dns enable",
+			"set system services dhcp-local-server dynamic-dns domain corp.example.com",
+		}))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		w, ok := hasDeferredWarn(ValidateConfig(cfg))
+		if !ok {
+			t.Fatal("enabling DDNS did not warn that the backend is deferred")
+		}
+		if strings.Contains(w, "update-server") {
+			t.Fatalf("bare-enable warning wrongly mentions update-server: %q", w)
+		}
+	})
+
+	t.Run("enabled with update-server warns stronger", func(t *testing.T) {
+		cfg, err := CompileConfig(buildTree(t, []string{
+			"set system services dhcp-local-server dynamic-dns enable",
+			"set system services dhcp-local-server dynamic-dns update-server 192.0.2.53",
+			"set system services dhcp-local-server dynamic-dns tsig-key xpf-key",
+		}))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		w, ok := hasDeferredWarn(ValidateConfig(cfg))
+		if !ok {
+			t.Fatal("enabling DDNS with update-server did not warn")
+		}
+		if !strings.Contains(w, "update-server") {
+			t.Fatalf("update-server warning did not call out the update target: %q", w)
+		}
+	})
+
+	t.Run("absent or disabled is silent", func(t *testing.T) {
+		// No stanza at all.
+		cfgAbsent, err := CompileConfig(buildTree(t, []string{
+			"set system services dhcp-local-server group g0 interface ge-0/0/0",
+		}))
+		if err != nil {
+			t.Fatalf("CompileConfig(absent): %v", err)
+		}
+		if _, ok := hasDeferredWarn(ValidateConfig(cfgAbsent)); ok {
+			t.Fatal("absent DDNS must not emit the deferred-backend warning")
+		}
+		// Stanza present but not enabled (only a domain set).
+		cfgDisabled, err := CompileConfig(buildTree(t, []string{
+			"set system services dhcp-local-server dynamic-dns domain corp.example.com",
+		}))
+		if err != nil {
+			t.Fatalf("CompileConfig(disabled): %v", err)
+		}
+		if _, ok := hasDeferredWarn(ValidateConfig(cfgDisabled)); ok {
+			t.Fatal("disabled DDNS must not emit the deferred-backend warning")
+		}
+	})
+}
+
 func TestDHCPDDNSSchemaRejectsBadEnumAndTTL(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/config/compiler_dhcp_ddns_test.go
+++ b/pkg/config/compiler_dhcp_ddns_test.go
@@ -122,6 +122,72 @@ func TestDHCPDDNSV6BlockCompiles(t *testing.T) {
 	}
 }
 
+// TestDHCPDDNSDualFamilyMergesFieldByField proves the Copilot/Codex MAJOR
+// fix: when BOTH dhcp-local-server AND dhcpv6-local-server carry a
+// dynamic-dns block, the compiler MERGES them field-by-field instead of
+// whole-struct overwrite. A partial second-family block (e.g. only domain
+// under v6) must NOT clear the first family's Enabled/server/ttl. Against
+// the pre-fix `dhcp.DynamicDNS = compileDHCPDynamicDNS(...)` overwrite, the
+// v6 block (Enabled=false, no server, no ttl) replaced the v4 block and
+// DDNS was silently disabled with its settings dropped — so this test
+// fails pre-fix.
+func TestDHCPDDNSDualFamilyMergesFieldByField(t *testing.T) {
+	// v4 compiles first (dst): enable + update-server + ttl. v6 compiles
+	// second (src): only domain. Merge must keep all v4 fields + gain domain.
+	cfg, err := CompileConfig(buildTree(t, []string{
+		"set system services dhcp-local-server dynamic-dns enable",
+		"set system services dhcp-local-server dynamic-dns update-server 192.0.2.53",
+		"set system services dhcp-local-server dynamic-dns ttl 600",
+		"set system services dhcpv6-local-server dynamic-dns domain corp.example.com",
+	}))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	d := ddnsOf(t, cfg)
+	if d == nil {
+		t.Fatal("dual-family DDNS compiled to nil")
+	}
+	if !d.Enabled {
+		t.Fatal("partial v6 block cleared v4 Enabled (whole-struct overwrite bug)")
+	}
+	if d.UpdateServer != "192.0.2.53" {
+		t.Fatalf("v4 update-server lost on merge: %q", d.UpdateServer)
+	}
+	if d.TTLSeconds != 600 {
+		t.Fatalf("v4 ttl lost on merge: %d", d.TTLSeconds)
+	}
+	if d.Domain != "corp.example.com" {
+		t.Fatalf("v6 domain not merged in: %q", d.Domain)
+	}
+}
+
+// TestDHCPDDNSDualFamilyEnableLatchesEitherOrder proves the Enabled latch is
+// order-robust: enabling DDNS in EITHER family enables it, and a partial
+// block in the other family cannot flip it off — regardless of which family
+// is the partial one.
+func TestDHCPDDNSDualFamilyEnableLatchesEitherOrder(t *testing.T) {
+	// v4 partial (only domain), v6 enables. Latch must hold (v6 is src; the
+	// merge ORs Enabled so dst v4 ends up Enabled too).
+	cfg, err := CompileConfig(buildTree(t, []string{
+		"set system services dhcp-local-server dynamic-dns domain corp.example.com",
+		"set system services dhcpv6-local-server dynamic-dns enable",
+		"set system services dhcpv6-local-server dynamic-dns update-server 2001:db8::53",
+	}))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	d := ddnsOf(t, cfg)
+	if d == nil || !d.Enabled {
+		t.Fatalf("enable in v6 did not latch when v4 was the partial block: %+v", d)
+	}
+	if d.Domain != "corp.example.com" {
+		t.Fatalf("v4 domain lost: %q", d.Domain)
+	}
+	if d.UpdateServer != "2001:db8::53" {
+		t.Fatalf("v6 update-server not merged: %q", d.UpdateServer)
+	}
+}
+
 func TestDHCPDDNSStringRedactsTSIGSecret(t *testing.T) {
 	d := &DHCPDynamicDNSConfig{
 		Enabled:       true,

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -121,6 +121,18 @@ func compileDHCPLocalServer(node *Node, dhcp *DHCPServerConfig, isV6 bool) error
 		dhcp.DHCPLocalServer = lsc
 	}
 
+	// #1387: the dynamic-dns block is a server-level policy shared by all
+	// pools of the family. It can appear under dhcp-local-server and/or
+	// dhcpv6-local-server; the typed model carries a single
+	// DHCPDynamicDNSConfig (the reconciler walks both families' leases).
+	// Either family's block populates it; a later non-empty block from
+	// the other family overrides (operators normally configure one).
+	if ddnsNode := node.FindChild("dynamic-dns"); ddnsNode != nil {
+		if ddns := compileDHCPDynamicDNS(ddnsNode); ddns != nil {
+			dhcp.DynamicDNS = ddns
+		}
+	}
+
 	for _, groupInst := range namedInstances(node.FindChildren("group")) {
 		group := &DHCPServerGroup{Name: groupInst.name}
 
@@ -171,6 +183,94 @@ func compileDHCPLocalServer(node *Node, dhcp *DHCPServerConfig, isV6 bool) error
 		lsc.Groups[group.Name] = group
 	}
 	return nil
+}
+
+// dhcpDDNSStringProps are the dynamic-dns leaves that carry a string
+// value (everything except the valueless `enable` flag and the integer
+// `ttl`). Used by collectDHCPDDNSProps to recognize a "<leaf> <value>"
+// pair at any depth regardless of the AST shape.
+var dhcpDDNSStringProps = map[string]bool{
+	"domain":          true,
+	"hostname-source": true,
+	"conflict-policy": true,
+	"backend":         true,
+	"update-server":   true,
+	"tsig-key":        true,
+	"tsig-algorithm":  true,
+	"tsig-secret":     true,
+}
+
+// compileDHCPDynamicDNS converts a parsed `dynamic-dns` subtree into a
+// typed *DHCPDynamicDNSConfig (#1387). It handles BOTH the hierarchical
+// shape (`dynamic-dns { enable; ttl 300; domain corp.example.com; }`,
+// each leaf a separate child node) and the flat-set shape
+// (`set ... dynamic-dns ttl 300`, where SetPath may pack trailing
+// property tokens into a single leaf node's Keys). Returns nil for a
+// truly empty block so an empty/garbage stanza does not force DDNS on;
+// the runtime keys "configured" on a non-nil block AND Enabled.
+func compileDHCPDynamicDNS(node *Node) *DHCPDynamicDNSConfig {
+	d := &DHCPDynamicDNSConfig{}
+	props := map[string]string{}
+	enabled := false
+
+	// Walk the subtree. A leaf can appear as a child node (Keys[0]==leaf,
+	// value at Keys[1]) or be packed into a parent node's Keys at any
+	// depth (e.g. flat-set `dynamic-dns ttl 300 domain x` collapses into
+	// one node with Keys=[..., ttl, 300, domain, x]). First value wins so
+	// a later malformed re-set cannot clobber a good one.
+	var walk func(n *Node, isRoot bool)
+	walk = func(n *Node, isRoot bool) {
+		start := 0
+		if isRoot {
+			start = 1 // skip the "dynamic-dns" identifier itself
+		}
+		for i := start; i < len(n.Keys); i++ {
+			k := n.Keys[i]
+			switch {
+			case k == "enable":
+				enabled = true
+			case k == "ttl" && i+1 < len(n.Keys):
+				if _, ok := props["ttl"]; !ok {
+					props["ttl"] = n.Keys[i+1]
+				}
+				i++
+			case dhcpDDNSStringProps[k] && i+1 < len(n.Keys):
+				if _, ok := props[k]; !ok {
+					props[k] = n.Keys[i+1]
+				}
+				i++
+			}
+		}
+		for _, c := range n.Children {
+			walk(c, false)
+		}
+	}
+	walk(node, true)
+
+	d.Enabled = enabled
+	d.Domain = props["domain"]
+	d.HostnameSource = props["hostname-source"]
+	d.ConflictPolicy = props["conflict-policy"]
+	d.Backend = props["backend"]
+	d.UpdateServer = props["update-server"]
+	d.TSIGKeyName = props["tsig-key"]
+	d.TSIGAlgorithm = props["tsig-algorithm"]
+	d.TSIGSecret = props["tsig-secret"]
+	if v := props["ttl"]; v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			d.TTLSeconds = n
+		}
+	}
+
+	// Empty block -> treat as absent (no DDNS). A block with only
+	// `enable` is meaningful (defaults apply), so check the union.
+	if !d.Enabled && d.Domain == "" && d.HostnameSource == "" &&
+		d.ConflictPolicy == "" && d.Backend == "" && d.UpdateServer == "" &&
+		d.TSIGKeyName == "" && d.TSIGAlgorithm == "" && d.TSIGSecret == "" &&
+		d.TTLSeconds == 0 {
+		return nil
+	}
+	return d
 }
 
 func compileDynamicAddress(node *Node, sec *SecurityConfig) error {

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -125,11 +125,14 @@ func compileDHCPLocalServer(node *Node, dhcp *DHCPServerConfig, isV6 bool) error
 	// pools of the family. It can appear under dhcp-local-server and/or
 	// dhcpv6-local-server; the typed model carries a single
 	// DHCPDynamicDNSConfig (the reconciler walks both families' leases).
-	// Either family's block populates it; a later non-empty block from
-	// the other family overrides (operators normally configure one).
+	// When BOTH families carry a block we MERGE field-by-field rather than
+	// whole-struct overwrite: a partial second block (e.g. only `domain`
+	// under v6) must NOT clear the v4 block's Enabled/server/ttl. A field
+	// set in either block wins; presence-only `enable` latches on (once any
+	// family enables DDNS it stays enabled). See mergeDHCPDynamicDNS.
 	if ddnsNode := node.FindChild("dynamic-dns"); ddnsNode != nil {
 		if ddns := compileDHCPDynamicDNS(ddnsNode); ddns != nil {
-			dhcp.DynamicDNS = ddns
+			dhcp.DynamicDNS = mergeDHCPDynamicDNS(dhcp.DynamicDNS, ddns)
 		}
 	}
 
@@ -185,10 +188,56 @@ func compileDHCPLocalServer(node *Node, dhcp *DHCPServerConfig, isV6 bool) error
 	return nil
 }
 
+// mergeDHCPDynamicDNS merges a freshly-compiled dynamic-dns block (src)
+// into the existing one (dst), field-by-field, so a partial block under the
+// second family does not clobber settings the first family established
+// (#1387). dst may be nil (first family seen). A field set in EITHER block
+// wins: for strings/ttl, a non-zero src value fills an empty dst field (dst
+// keeps its own non-zero value — first-family-wins on a genuine conflict,
+// matching compileDHCPDynamicDNS's first-value-wins intra-block rule). The
+// presence-only Enabled flag LATCHES: once any family enables DDNS it stays
+// enabled (a partial second block can never flip it false). src is non-nil
+// (compileDHCPDynamicDNS returned a real block).
+func mergeDHCPDynamicDNS(dst, src *DHCPDynamicDNSConfig) *DHCPDynamicDNSConfig {
+	if dst == nil {
+		return src
+	}
+	dst.Enabled = dst.Enabled || src.Enabled
+	if dst.Domain == "" {
+		dst.Domain = src.Domain
+	}
+	if dst.HostnameSource == "" {
+		dst.HostnameSource = src.HostnameSource
+	}
+	if dst.ConflictPolicy == "" {
+		dst.ConflictPolicy = src.ConflictPolicy
+	}
+	if dst.Backend == "" {
+		dst.Backend = src.Backend
+	}
+	if dst.UpdateServer == "" {
+		dst.UpdateServer = src.UpdateServer
+	}
+	if dst.TSIGKeyName == "" {
+		dst.TSIGKeyName = src.TSIGKeyName
+	}
+	if dst.TSIGAlgorithm == "" {
+		dst.TSIGAlgorithm = src.TSIGAlgorithm
+	}
+	if dst.TSIGSecret == "" {
+		dst.TSIGSecret = src.TSIGSecret
+	}
+	if dst.TTLSeconds == 0 {
+		dst.TTLSeconds = src.TTLSeconds
+	}
+	return dst
+}
+
 // dhcpDDNSStringProps are the dynamic-dns leaves that carry a string
 // value (everything except the valueless `enable` flag and the integer
-// `ttl`). Used by collectDHCPDDNSProps to recognize a "<leaf> <value>"
-// pair at any depth regardless of the AST shape.
+// `ttl`). Used by compileDHCPDynamicDNS's internal subtree walker to
+// recognize a "<leaf> <value>" pair at any depth regardless of the AST
+// shape.
 var dhcpDDNSStringProps = map[string]bool{
 	"domain":          true,
 	"hostname-source": true,

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -311,11 +311,13 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 			"group": {desc: "DHCP group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
 				"pool": {desc: "Address pool", args: 1, placeholder: "<pool-name>", children: nil},
 			}},
+			"dynamic-dns": dhcpDynamicDNSSchema(),
 		}},
 		"dhcpv6-local-server": {desc: "DHCPv6 local server", children: map[string]*schemaNode{
 			"group": {desc: "DHCPv6 group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
 				"pool": {desc: "Address pool", args: 1, placeholder: "<pool-name>", children: nil},
 			}},
+			"dynamic-dns": dhcpDynamicDNSSchema(),
 		}},
 	}},
 }}
@@ -519,6 +521,86 @@ var schemaServices = &schemaNode{desc: "Services configuration", children: map[s
 	}},
 	"application-identification": {desc: "Enable application identification against the predefined application catalog (port/protocol matching; no L7 DPI)", children: nil},
 }}
+
+// dhcpDynamicDNSSchema returns the typed-leaf schema for the #1387
+// DHCP dynamic-DNS block, shared by dhcp-local-server and
+// dhcpv6-local-server. Returned as a fresh tree per call so the two
+// parents do not share a mutable map. The enums + ttl carry validators
+// (the compiler/runtime consume them); the free-form credential and
+// target fields (domain, update-server, tsig-*) stay untyped so a valid
+// hostname / base64 secret is not rejected at commit — the live backend
+// that constrains them lands in increment 2.
+func dhcpDynamicDNSSchema() *schemaNode {
+	return &schemaNode{desc: "Dynamic DNS updates for DHCP leases (#1387)", children: map[string]*schemaNode{
+		"enable": {desc: "Enable dynamic DNS record publishing", children: nil},
+		"domain": {
+			desc:        "Default DNS domain appended to non-FQDN client names",
+			args:        1,
+			placeholder: "<domain>",
+			children:    nil,
+		},
+		"ttl": {
+			desc:          "TTL (seconds) for published A/AAAA/PTR records (default 300)",
+			args:          1,
+			valueType:     ValueInteger,
+			valueDesc:     "Record TTL in seconds (>= 1; default 300 when unset)",
+			valueExamples: []string{"300", "3600"},
+			validator:     ValidateIntegerMin(1),
+			children:      nil,
+		},
+		"hostname-source": {
+			desc:          "How the published label is derived from the lease",
+			args:          1,
+			valueType:     ValueEnumOf,
+			valueDesc:     "Label source (client-hostname | fqdn | mac-fallback)",
+			valueExamples: []string{"client-hostname", "fqdn", "mac-fallback"},
+			validator:     ValidateEnum([]string{"client-hostname", "fqdn", "mac-fallback"}),
+			children:      nil,
+		},
+		"conflict-policy": {
+			desc:          "Behaviour on a colliding existing record",
+			args:          1,
+			valueType:     ValueEnumOf,
+			valueDesc:     "Conflict policy (replace-owned | skip-existing | strict-fail)",
+			valueExamples: []string{"replace-owned", "skip-existing", "strict-fail"},
+			validator:     ValidateEnum([]string{"replace-owned", "skip-existing", "strict-fail"}),
+			children:      nil,
+		},
+		"backend": {
+			desc:          "DNS-update backend (increment 1 implements rfc2136 only)",
+			args:          1,
+			valueType:     ValueEnumOf,
+			valueDesc:     "Update backend (rfc2136 | kea-d2 [reserved])",
+			valueExamples: []string{"rfc2136"},
+			validator:     ValidateEnum([]string{"rfc2136", "kea-d2"}),
+			children:      nil,
+		},
+		"update-server": {
+			desc:        "Authoritative DNS target for RFC 2136 updates (host[:port])",
+			args:        1,
+			placeholder: "<host[:port]>",
+			children:    nil,
+		},
+		"tsig-key": {
+			desc:        "TSIG key name for authenticated updates",
+			args:        1,
+			placeholder: "<key-name>",
+			children:    nil,
+		},
+		"tsig-algorithm": {
+			desc:        "TSIG algorithm (e.g. hmac-sha256)",
+			args:        1,
+			placeholder: "<algorithm>",
+			children:    nil,
+		},
+		"tsig-secret": {
+			desc:        "TSIG shared secret (sensitive; redacted in show output)",
+			args:        1,
+			placeholder: "<secret>",
+			children:    nil,
+		},
+	}}
+}
 
 var schemaSNMP = &schemaNode{desc: "SNMP configuration", children: map[string]*schemaNode{
 	"community": {desc: "SNMP community", args: 1, placeholder: "<community-name>", children: map[string]*schemaNode{

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -567,10 +567,10 @@ func dhcpDynamicDNSSchema() *schemaNode {
 			children:      nil,
 		},
 		"backend": {
-			desc:          "DNS-update backend (increment 1 implements rfc2136 only)",
+			desc:          "DNS-update backend (parsed/validated; live updater deferred to a later increment)",
 			args:          1,
 			valueType:     ValueEnumOf,
-			valueDesc:     "Update backend (rfc2136 | kea-d2 [reserved])",
+			valueDesc:     "Update backend (rfc2136 | kea-d2 [reserved]) — config-only in this increment",
 			valueExamples: []string{"rfc2136"},
 			validator:     ValidateEnum([]string{"rfc2136", "kea-d2"}),
 			children:      nil,

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -1,5 +1,7 @@
 package config
 
+import "fmt"
+
 // System and platform-services configuration: system stanza, userspace
 // dataplane, syslog, SNMP, login, REST API auth, RPM, flow-monitoring,
 // forwarding-options, firewall filters/policers, and DHCP server/relay.
@@ -672,6 +674,81 @@ type PrefixListRef struct {
 type DHCPServerConfig struct {
 	DHCPLocalServer   *DHCPLocalServerConfig
 	DHCPv6LocalServer *DHCPLocalServerConfig
+	// DynamicDNS is the opt-in DHCP DDNS policy (#1387 increment 1).
+	// nil == disabled == today's behaviour byte-for-byte; the dataplane
+	// (Kea render, daemon wiring) ignores a nil block entirely.
+	DynamicDNS *DHCPDynamicDNSConfig
+}
+
+// DHCPDynamicDNSConfig is the opt-in dynamic-DNS policy for the DHCP
+// server (#1387). When DHCP clients take a lease, the firewall can
+// publish forward (A/AAAA) and reverse (PTR) records into an external
+// authoritative DNS server, and remove them again when the lease ends
+// (expire / release / decline / reclaim / reassign).
+//
+// This is the FIRST increment per docs/research/1387-dhcp-ddns/plan.md
+// (recommended Path C — pluggable backend, RFC 2136 first). Increment 1
+// ships the config model, the state-aware lease parser, the DNSUpdater
+// interface + reconciler core (fake-updater unit-tested), and the
+// never-delete-non-owned state store. The LIVE rfc2136 backend, the HA
+// ownership coupling, and the Kea D2 backend are deferred to later
+// lab-gated / test-failover-gated increments. An absent block (nil) is
+// the default and changes nothing.
+type DHCPDynamicDNSConfig struct {
+	// Enabled turns the reconciler on. A block that parses but never
+	// sets enable is still disabled — the operator opts in explicitly.
+	Enabled bool
+	// Domain is the default DNS suffix appended to a client name that is
+	// not already a FQDN (e.g. "corp.example.com").
+	Domain string
+	// TTLSeconds is the TTL applied to published records (default 300
+	// when zero, applied at render time, not here).
+	TTLSeconds int
+	// HostnameSource selects how the published label is derived from the
+	// lease: client-hostname (DHCP host-name option, default), fqdn (the
+	// client-supplied FQDN option), or mac-fallback (synthesize
+	// dhcp-<sanitized-id> when no name is offered).
+	HostnameSource string
+	// ConflictPolicy governs an existing record collision: replace-owned
+	// (default — only replace records this firewall owns per the state
+	// store), skip-existing, or strict-fail.
+	ConflictPolicy string
+	// Backend selects the DNS-update mechanism. Increment 1 implements
+	// only "rfc2136"; "kea-d2" is a reserved enum value for a later
+	// increment (Kea D2 is not in the image — bake.py). Default rfc2136.
+	Backend string
+	// UpdateServer is the RFC 2136 target authoritative DNS, host or
+	// host:port (Path A / rfc2136 backend). Not consumed by the live
+	// path in increment 1 (no live emission yet); carried for the
+	// increment-2 backend.
+	UpdateServer string
+	// TSIGKeyName / TSIGAlgorithm / TSIGSecret are the TSIG credentials
+	// for authenticated RFC 2136 updates. TSIGSecret is sensitive: it is
+	// redacted in String()/marshal echoes and must never be logged.
+	TSIGKeyName   string
+	TSIGAlgorithm string
+	TSIGSecret    string
+}
+
+// String redacts TSIGSecret so a %v/%s/slog format of a
+// DHCPDynamicDNSConfig never leaks the shared HMAC key (logging hygiene,
+// mirrors WireguardPeer in types_routing.go). The reconciler and render
+// paths read the field directly; only formatted/logged copies are
+// redacted.
+func (d *DHCPDynamicDNSConfig) String() string {
+	if d == nil {
+		return "<nil>"
+	}
+	secret := ""
+	if d.TSIGSecret != "" {
+		secret = "<redacted>"
+	}
+	return fmt.Sprintf("DHCPDynamicDNS{enabled=%t domain=%q ttl=%d "+
+		"hostname-source=%q conflict-policy=%q backend=%q update-server=%q "+
+		"tsig-key=%q tsig-alg=%q tsig-secret=%q}",
+		d.Enabled, d.Domain, d.TTLSeconds, d.HostnameSource,
+		d.ConflictPolicy, d.Backend, d.UpdateServer,
+		d.TSIGKeyName, d.TSIGAlgorithm, secret)
 }
 
 // DHCPLocalServerConfig holds per-group DHCP server settings.

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -725,8 +725,15 @@ type DHCPDynamicDNSConfig struct {
 	// increment-2 backend.
 	UpdateServer string
 	// TSIGKeyName / TSIGAlgorithm / TSIGSecret are the TSIG credentials
-	// for authenticated RFC 2136 updates. TSIGSecret is sensitive: it is
-	// redacted in String()/marshal echoes and must never be logged.
+	// for authenticated RFC 2136 updates. TSIGSecret is sensitive and is
+	// redacted by String() (so a %v/%s/slog of this struct never leaks the
+	// HMAC key — see String below). It is NOT redacted by JSON/YAML
+	// marshalling: like every other config secret (IKE pre-shared keys,
+	// OSPF auth keys — see freetext.go), the field is stored verbatim in the
+	// compiled config, which must never be serialized onto a user-facing
+	// surface. The only compiled-config marshaller, Store.ExportJSON, is a
+	// debug-only helper with no production callers. Cross-cutting
+	// marshal-time redaction for all config secrets is tracked separately.
 	TSIGKeyName   string
 	TSIGAlgorithm string
 	TSIGSecret    string

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -713,9 +713,11 @@ type DHCPDynamicDNSConfig struct {
 	// (default — only replace records this firewall owns per the state
 	// store), skip-existing, or strict-fail.
 	ConflictPolicy string
-	// Backend selects the DNS-update mechanism. Increment 1 implements
-	// only "rfc2136"; "kea-d2" is a reserved enum value for a later
-	// increment (Kea D2 is not in the image — bake.py). Default rfc2136.
+	// Backend selects the DNS-update mechanism. The value is PARSED and
+	// VALIDATED in this increment, but the live updater is DEFERRED to a
+	// later increment — nothing is published to DNS yet regardless of the
+	// backend chosen. "rfc2136" is the default; "kea-d2" is a reserved enum
+	// value for a later increment (Kea D2 is not in the image — bake.py).
 	Backend string
 	// UpdateServer is the RFC 2136 target authoritative DNS, host or
 	// host:port (Path A / rfc2136 backend). Not consumed by the live

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -108,9 +108,23 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   A present-but-mangled header errors WITH OR WITHOUT data rows (so a
   header-only mangled file cannot short-circuit to trusted-empty), and a
   0-record EXISTING file (no header at all — anomalous, mid-write/corrupt)
-  fails SAFE as an error rather than trusted-empty. The fail direction
+  fails SAFE as an error rather than trusted-empty. Per-ROW conformance
+  (Codex r6) complements the header-schema check: a DATA ROW too short to
+  supply every required column (a torn/truncated memfile append — the CSV
+  reader allows ragged rows) would otherwise read a required column as ""
+  (bounds-safe via `leaseColumnValue`'s `idx < len(fields)`, but NOT
+  delete-safe — the lease silently drops and its owned record is deleted).
+  So a row with `len(fields) <= maxRequiredIdx` (the max index among the
+  family's required columns) is a hard parse error → the whole family's
+  source is untrusted → the destructive diff is skipped; we do NOT silently
+  skip just the row (we cannot know which lease it is, and skipping still
+  drops its record). A row with MORE fields than the header is tolerated
+  (extra trailing fields ignored by name-based lookup). The fail direction
   (over-mark-untrusted for an exotic/unreadable file → no publish/clean,
-  operator-visible) is SAFE; silent mass-delete/record-loss is not.
+  operator-visible) is SAFE; silent mass-delete/record-loss is not. The
+  destructive-delete class is now closed at BOTH the header level (required
+  columns present, each once, no duplicates) and the row level (every data
+  row long enough to supply every required column).
 - **Hostname normalization** — `deriveFQDN` / `finalizeFQDN`
   (`ddns_hostname.go`) ALWAYS contains the published name in the configured
   zone: the client picks the host part, the firewall picks the domain. A

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -75,7 +75,16 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   `expire` epoch, and the `fqdn_fwd` split between host-name and
   client-supplied FQDN, and extracts the v6 DUID/IAID identity. SEPARATE
   from the display-only `parseLeaseCSV` (reusing that would publish/retain
-  stale records — the exact bug this feature fixes).
+  stale records — the exact bug this feature fixes). Header columns are
+  matched CASE-INSENSITIVELY (only the header keys / lookup names are
+  lower-cased; field values are data and stay verbatim). The header is
+  VALIDATED: if a required column (`requiredLeaseColumns` = `address`,
+  `state`) is missing or renamed, the parser returns an ERROR rather than a
+  silent empty lease set — a mangled header would otherwise read every row
+  as empty, look like "zero active leases", and let the reconciler
+  mass-delete the family's owned records (the MAJOR-4 vector reached through
+  the header gap). An empty FILE (no data rows) is still a legitimate
+  zero-lease, no-error case.
 - **Hostname normalization** — `deriveFQDN` / `finalizeFQDN`
   (`ddns_hostname.go`) ALWAYS contains the published name in the configured
   zone: the client picks the host part, the firewall picks the domain. A

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -53,13 +53,71 @@ parses a torn file, no fsync on the apply path.
   `systemctl` seams + config paths, per the `pkg/dhcp/test_seams.go`
   convention.
 
+## Dynamic DNS (DDNS) — #1387, increment 1
+
+Opt-in publishing of forward (`A`/`AAAA`) and reverse (`PTR`) DNS records
+for active DHCP leases, with stale-record cleanup on expire / release /
+decline / reclaim / reassign. Default OFF — an absent `dynamic-dns` block
+is byte-for-byte today's behaviour. This is the FIRST increment of the
+multi-increment plan in `docs/research/1387-dhcp-ddns/plan.md`
+(recommended Path C: a pluggable `DNSUpdater` backend, RFC 2136 first).
+
+What increment 1 ships (the fully unit-testable, lab-free slice):
+
+- **Config model** — `config.DHCPDynamicDNSConfig` (a nilable field on
+  `DHCPServerConfig`), compiled from both AST shapes by
+  `compileDHCPDynamicDNS` (`pkg/config/compiler_services.go`), typed
+  schema leaves under `dhcp-local-server`/`dhcpv6-local-server`
+  (`pkg/config/schema_system.go`). TSIG secret is redacted in
+  `DHCPDynamicDNSConfig.String()`.
+- **State-aware lease parser** — `parseActiveLeases4/6` (`ddns_leases.go`)
+  honors Kea's `state` column (default/declined/expired-reclaimed) and the
+  `expire` epoch, and extracts the v6 DUID/IAID identity. SEPARATE from
+  the display-only `parseLeaseCSV` (reusing that would publish/retain
+  stale records — the exact bug this feature fixes).
+- **`DNSUpdater` interface** (`ddns_dns.go`) + the pure record/PTR-name
+  construction. PTR names are built from the TEXTUAL address (reversed
+  octets / nibbles), NOT the dataplane native-endian `__be32` convention.
+- **Reconciler core** — `DDNSManager.reconcileOnceLocked` (`ddns.go`):
+  build-desired / diff-owned / add-move-reassign-expire transitions,
+  cleaning the old owner before the new one, with bounded retry that never
+  wedges the loop.
+- **Ownership state store** — `ddns_state.go`, JSON via
+  `fsatomic.WriteFileDurable` (fsync-on-write; slow-path). This is the
+  PROTECTION BOUNDARY for never-delete-a-record-xpf-did-not-create:
+  `deleteOwnedLocked` re-derives the EXACT (name, type, address) from the
+  store and is the sole delete authority. A corrupt store fails OPEN
+  (reset to empty + log), never blocking commit/boot/DHCP serving.
+- **Counters** via `DDNSManager.Stats()` (the future `show ... dynamic-dns`
+  + Prometheus surface reads this).
+
+DELIBERATELY DEFERRED to later increments (see plan §12):
+
+- The LIVE rfc2136 `DNSUpdater` backend — lab-gated (needs a throwaway
+  authoritative BIND/Knot + TSIG; no such fixture exists in CI yet).
+- HA ownership coupling to the per-RG VRRP MASTER/BACKUP gate — must pass
+  `make test-failover`. The deterministic owner-id watermark
+  (`ownerWatermark`) is laid down now so the state store is
+  forward-compatible.
+- The Kea D2 backend (reserved `backend kea-d2` enum; D2 is not in the
+  image, `bake.py`).
+- The daemon reconcile loop + `show ... dynamic-dns` CLI/gRPC plumbing +
+  Prometheus emission. (The API collector is a CHECKED collector — a
+  declared descriptor MUST be emitted or the descriptor-coverage canary
+  fails — so counters live in `DDNSManager` until increment 2 wires a
+  value source on the server.)
+
+Net behaviour change for existing users in increment 1: zero.
+
 ## Callers
 
-`pkg/daemon`, `pkg/cli`, `pkg/grpcapi`.
+`pkg/daemon`, `pkg/cli`, `pkg/grpcapi`. (The `DDNSManager` reconcile loop
+is wired into `pkg/daemon` in increment 2; increment 1 is library-level.)
 
 ## Dependencies
 
-`pkg/config` only.
+`pkg/config` and `pkg/fsatomic` (the latter for the Kea config writes and
+the #1387 DDNS ownership state store).
 
 ## Gotchas
 

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -69,7 +69,12 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   `compileDHCPDynamicDNS` (`pkg/config/compiler_services.go`), typed
   schema leaves under `dhcp-local-server`/`dhcpv6-local-server`
   (`pkg/config/schema_system.go`). TSIG secret is redacted in
-  `DHCPDynamicDNSConfig.String()`.
+  `DHCPDynamicDNSConfig.String()`. The block can appear under BOTH
+  families; the typed model carries a single config, and the two blocks are
+  MERGED field-by-field (`mergeDHCPDynamicDNS`) — a field set in either
+  family wins, `enable` latches on — so a partial second-family block never
+  clears the first family's settings (a whole-struct overwrite would
+  silently disable DDNS).
 - **State-aware lease parser** — `parseActiveLeases4/6` (`ddns_leases.go`)
   honors Kea's `state` column (default/declined/expired-reclaimed), the
   `expire` epoch, and the `fqdn_fwd` split between host-name and
@@ -152,7 +157,13 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   PROTECTION BOUNDARY for never-delete-a-record-xpf-did-not-create:
   `deleteOwnedLocked` re-derives the EXACT (name, type, address) from the
   store and is the sole delete authority. A corrupt store fails OPEN
-  (reset to empty + log), never blocking commit/boot/DHCP serving.
+  (reset to empty + log), never blocking commit/boot/DHCP serving. The
+  stored `version` is validated on load: an unknown (future) non-zero
+  version is treated like a corrupt store (fail-open to empty + warn), so a
+  later format bump cannot be mis-decoded into wrong-tuple deletes. (A
+  fail-open store may LEAK previously-owned records — they stay in DNS until
+  authoritatively removed; record TTL is resolver caching, not removal — but
+  never deletes records xpf did not create.)
 - **Counters** via `DDNSManager.Stats()` (the future `show ... dynamic-dns`
   + Prometheus surface reads this).
 

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -78,7 +78,14 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   stale records — the exact bug this feature fixes). Header columns are
   matched CASE-INSENSITIVELY (both the header keys AND the lookup name are
   lower-cased in `leaseColumnValue`; field values are data and stay
-  verbatim). The header is VALIDATED against a FAMILY-SPECIFIC
+  verbatim). A header maps to columns UNAMBIGUOUSLY: a DUPLICATE column name
+  (case-insensitive) is rejected with an error (Codex r5) — a healthy Kea
+  memfile has all-unique columns, and a duplicate would otherwise overwrite
+  the earlier index with the last occurrence, so a lookup could resolve to
+  the wrong/empty column → wrong desired set → destructive delete. We reject
+  ANY duplicate (not just duplicate required columns). Extra/unknown columns
+  and a reordered header are TOLERATED (lookups are by name, not position).
+  The header is VALIDATED against a FAMILY-SPECIFIC
   `requiredLeaseColumns` set: any column whose absence would silently change
   whether a lease is published (naming), how it is keyed for ownership
   (identity), or whether it is active (state) is REQUIRED, because a mangled

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -76,15 +76,27 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   client-supplied FQDN, and extracts the v6 DUID/IAID identity. SEPARATE
   from the display-only `parseLeaseCSV` (reusing that would publish/retain
   stale records — the exact bug this feature fixes). Header columns are
-  matched CASE-INSENSITIVELY (only the header keys / lookup names are
-  lower-cased; field values are data and stay verbatim). The header is
-  VALIDATED: if a required column (`requiredLeaseColumns` = `address`,
-  `state`) is missing or renamed, the parser returns an ERROR rather than a
-  silent empty lease set — a mangled header would otherwise read every row
-  as empty, look like "zero active leases", and let the reconciler
-  mass-delete the family's owned records (the MAJOR-4 vector reached through
-  the header gap). An empty FILE (no data rows) is still a legitimate
-  zero-lease, no-error case.
+  matched CASE-INSENSITIVELY (both the header keys AND the lookup name are
+  lower-cased in `leaseColumnValue`; field values are data and stay
+  verbatim). The header is VALIDATED against a FAMILY-SPECIFIC
+  `requiredLeaseColumns` set: any column whose absence would silently change
+  whether a lease is published (naming), how it is keyed for ownership
+  (identity), or whether it is active (state) is REQUIRED, because a mangled
+  header parses with no error and the reconciler then deletes/churns owned
+  records on the basis of an empty or wrongly-keyed desired set. If any
+  required column is missing/renamed the parser returns an ERROR, so
+  `Reconcile` marks the family untrusted and SKIPS the destructive diff —
+  never mass-delete or record-loss on an unrecognizable header. Required:
+  `address`, `state`, `hostname` (both families) + `client_id`,`hwaddr`
+  (v4 identity) / `duid`,`iaid` (v6 identity). Deliberately OPTIONAL
+  (absence degrades safely, no record loss): `fqdn_fwd` (defaults to
+  host-name semantics), `expire` (no expiry tombstoning — `state` still
+  gates active/tombstone; over-retain, not delete), `subnet_id` (pure
+  metadata, not compared by `recordsEqual`). An empty FILE (no data rows)
+  is still a legitimate zero-lease, no-error case; a present-but-mangled
+  header IS an error. The fail direction (over-mark-untrusted for an exotic
+  header → no publish/clean, operator-visible) is SAFE; silent
+  mass-delete/record-loss is not.
 - **Hostname normalization** — `deriveFQDN` / `finalizeFQDN`
   (`ddns_hostname.go`) ALWAYS contains the published name in the configured
   zone: the client picks the host part, the firewall picks the domain. A

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -71,9 +71,10 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   (`pkg/config/schema_system.go`). TSIG secret is redacted in
   `DHCPDynamicDNSConfig.String()`.
 - **State-aware lease parser** — `parseActiveLeases4/6` (`ddns_leases.go`)
-  honors Kea's `state` column (default/declined/expired-reclaimed) and the
-  `expire` epoch, and extracts the v6 DUID/IAID identity. SEPARATE from
-  the display-only `parseLeaseCSV` (reusing that would publish/retain
+  honors Kea's `state` column (default/declined/expired-reclaimed), the
+  `expire` epoch, and the `fqdn_fwd` split between host-name and
+  client-supplied FQDN, and extracts the v6 DUID/IAID identity. SEPARATE
+  from the display-only `parseLeaseCSV` (reusing that would publish/retain
   stale records — the exact bug this feature fixes).
 - **`DNSUpdater` interface** (`ddns_dns.go`) + the pure record/PTR-name
   construction. PTR names are built from the TEXTUAL address (reversed

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -76,13 +76,28 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   client-supplied FQDN, and extracts the v6 DUID/IAID identity. SEPARATE
   from the display-only `parseLeaseCSV` (reusing that would publish/retain
   stale records — the exact bug this feature fixes).
+- **Hostname normalization** — `deriveFQDN` / `finalizeFQDN`
+  (`ddns_hostname.go`) ALWAYS contains the published name in the configured
+  zone: the client picks the host part, the firewall picks the domain. A
+  client-offered dotted name (e.g. `host.attacker.tld`, a trailing-dot or
+  double-dot escape) that is not already within the configured domain is
+  relabeled to `<first-label>.<domain>`; a name already inside the zone is
+  kept verbatim. With no configured domain, only the first label is kept. A
+  client can never publish outside the configured zone.
 - **`DNSUpdater` interface** (`ddns_dns.go`) + the pure record/PTR-name
   construction. PTR names are built from the TEXTUAL address (reversed
-  octets / nibbles), NOT the dataplane native-endian `__be32` convention.
+  octets / nibbles), NOT the dataplane native-endian `__be32` convention. A
+  nil updater (the increment-1 default — the live backend is deferred) is
+  substituted with a `nopUpdater`: every upsert/delete is a LOGGED no-op,
+  never a panic, and a no-op upsert does NOT record phantom ownership (so a
+  later real backend still publishes the record).
 - **Reconciler core** — `DDNSManager.reconcileOnceLocked` (`ddns.go`):
   build-desired / diff-owned / add-move-reassign-expire transitions,
   cleaning the old owner before the new one, with bounded retry that never
-  wedges the loop.
+  wedges the loop. FAIL-SAFE: when a lease family's CSV cannot be
+  read/parsed, that family is marked untrusted and its destructive diff is
+  SKIPPED this cycle (a transient malformed CSV can never mass-delete a
+  family's owned records); the parse error is surfaced to the caller.
 - **Ownership state store** — `ddns_state.go`, JSON via
   `fsatomic.WriteFileDurable` (fsync-on-write; slow-path). This is the
   PROTECTION BOUNDARY for never-delete-a-record-xpf-did-not-create:
@@ -95,7 +110,13 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
 DELIBERATELY DEFERRED to later increments (see plan §12):
 
 - The LIVE rfc2136 `DNSUpdater` backend — lab-gated (needs a throwaway
-  authoritative BIND/Knot + TSIG; no such fixture exists in CI yet).
+  authoritative BIND/Knot + TSIG; no such fixture exists in CI yet). The
+  `backend` leaf (and `update-server` / TSIG leaves) are PARSED and
+  VALIDATED in this increment but NOT yet wired to a live updater — nothing
+  is published to DNS. Enabling DDNS emits a commit-time warning
+  (`config.ValidateConfig` → `validateDDNSDeferredBackendWarnings`), stronger
+  when an `update-server` / TSIG is configured, so the operator is not
+  surprised by the absence of records.
 - HA ownership coupling to the per-RG VRRP MASTER/BACKUP gate — must pass
   `make test-failover`. The deterministic owner-id watermark
   (`ownerWatermark`) is laid down now so the state store is

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -92,11 +92,18 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   (absence degrades safely, no record loss): `fqdn_fwd` (defaults to
   host-name semantics), `expire` (no expiry tombstoning — `state` still
   gates active/tombstone; over-retain, not delete), `subnet_id` (pure
-  metadata, not compared by `recordsEqual`). An empty FILE (no data rows)
-  is still a legitimate zero-lease, no-error case; a present-but-mangled
-  header IS an error. The fail direction (over-mark-untrusted for an exotic
-  header → no publish/clean, operator-visible) is SAFE; silent
-  mass-delete/record-loss is not.
+  metadata, not compared by `recordsEqual`). The header is validated BEFORE
+  the zero-data-row early return (Codex r4), so the trusted-empty result —
+  which is what PERMITS `Reconcile` to clear a family's owned records — is
+  returned ONLY when the lease set is provably empty: the file is genuinely
+  MISSING (`os.IsNotExist`, "no leases yet"), OR the header is present AND
+  valid AND there are simply no active data rows (a genuinely-drained Kea).
+  A present-but-mangled header errors WITH OR WITHOUT data rows (so a
+  header-only mangled file cannot short-circuit to trusted-empty), and a
+  0-record EXISTING file (no header at all — anomalous, mid-write/corrupt)
+  fails SAFE as an error rather than trusted-empty. The fail direction
+  (over-mark-untrusted for an exotic/unreadable file → no publish/clean,
+  operator-visible) is SAFE; silent mass-delete/record-loss is not.
 - **Hostname normalization** — `deriveFQDN` / `finalizeFQDN`
   (`ddns_hostname.go`) ALWAYS contains the published name in the configured
   zone: the client picks the host part, the firewall picks the domain. A

--- a/pkg/dhcpserver/ddns.go
+++ b/pkg/dhcpserver/ddns.go
@@ -255,8 +255,12 @@ func (m *DDNSManager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, l
 		seen bool
 	}
 	want := map[string]*desired{}
-	// addrOwner tracks which identity currently wants a given address, so
-	// a reassignment (new client, same address) cleans the old owner.
+	// Reassignment (a new client taking over an address a different client
+	// held) is cleaned by the owned-state delete pass below, NOT a separate
+	// tracker: the old owner's (identity,address) key is no longer in `want`
+	// (the new client has a different identity), so Pass 1 deletes the old
+	// owned record before Pass 2 adds the new one (delete-before-add on a
+	// shared address; a failed delete blocks the add via the blocked maps).
 	for _, l := range leases {
 		fqdn, err := deriveFQDN(l.HostName, l.ClientFQDN, l.Identity, pol.domain, source)
 		if err != nil {
@@ -429,9 +433,14 @@ func (m *DDNSManager) deleteOwnedLocked(ctx context.Context, owned ownedRecord) 
 	}
 	if isNopUpdater(m.updater) {
 		// No live backend: the delete was a logged no-op. Still drop the
-		// ownership entry so a disabled/withdrawn record does not linger in
-		// the store forever — the store tracks what xpf intends to own, and
-		// without a backend there is nothing in DNS to leak.
+		// ownership entry. For increment 1 this is CORRECT: nopUpdater never
+		// published anything, so there is nothing in DNS to orphan by
+		// forgetting ownership. CAVEAT (increment 2+): if a real backend is
+		// ever wired, publishes records, and is later removed (a downgrade
+		// back to no-backend), dropping ownership here would orphan those
+		// previously-published records in DNS. Handling that downgrade is an
+		// increment-2 concern; there is NO logic change for inc-1, where the
+		// store can only ever hold records nopUpdater "wrote" (i.e. none).
 		m.skippedNoBackend.Add(1)
 		m.state.delete(owned.Identity, owned.Address)
 		return nil

--- a/pkg/dhcpserver/ddns.go
+++ b/pkg/dhcpserver/ddns.go
@@ -77,14 +77,15 @@ func policyFromConfig(c *config.DHCPDynamicDNSConfig) ddnsPolicy {
 type DDNSStats struct {
 	Enabled        bool
 	Backend        string
-	UpsertOK       uint64
-	UpsertFail     uint64
-	DeleteOK       uint64
-	DeleteFail     uint64
-	SkippedNoName  uint64
-	OwnedRecords   int
-	LastReconcile  time.Time
-	LastReconcileN int // active leases seen on the last reconcile
+	UpsertOK         uint64
+	UpsertFail       uint64
+	DeleteOK         uint64
+	DeleteFail       uint64
+	SkippedNoName    uint64
+	SkippedNoBackend uint64 // records skipped because no live backend is wired
+	OwnedRecords     int
+	LastReconcile    time.Time
+	LastReconcileN   int // active leases seen on the last reconcile
 }
 
 // DDNSManager owns the DDNS reconcile loop and the ownership store. It is
@@ -110,11 +111,12 @@ type DDNSManager struct {
 	now func() time.Time
 
 	// counters
-	upsertOK      atomic.Uint64
-	upsertFail    atomic.Uint64
-	deleteOK      atomic.Uint64
-	deleteFail    atomic.Uint64
-	skippedNoName atomic.Uint64
+	upsertOK         atomic.Uint64
+	upsertFail       atomic.Uint64
+	deleteOK         atomic.Uint64
+	deleteFail       atomic.Uint64
+	skippedNoName    atomic.Uint64
+	skippedNoBackend atomic.Uint64 // upsert/delete skipped: no live backend wired
 
 	lastReconcile  atomic.Int64 // unix nanos
 	lastReconcileN atomic.Int64
@@ -131,6 +133,14 @@ func NewDDNSManager(updater DNSUpdater, nodeID string) *DDNSManager {
 	if err != nil {
 		slog.Warn("ddns: ownership state load failed; starting empty", "err", err)
 	}
+	if updater == nil {
+		// Increment 1 defers the live backend: a nil updater becomes a
+		// logged no-op rather than a nil-pointer panic on first publish or
+		// withdraw. The reconciler stays nil-safe end to end.
+		slog.Info("ddns: no DNS-update backend wired; running in no-op mode " +
+			"(record reconcile logged-and-skipped until a backend exists)")
+		updater = nopUpdater{}
+	}
 	return &DDNSManager{
 		state:      st,
 		updater:    updater,
@@ -146,6 +156,9 @@ func NewDDNSManager(updater DNSUpdater, nodeID string) *DDNSManager {
 // test_seams.go.
 func newDDNSManagerForTesting(updater DNSUpdater, statePath, leasePath4, leasePath6, nodeID string, now func() time.Time) *DDNSManager {
 	st, _ := loadDDNSState(statePath)
+	if updater == nil {
+		updater = nopUpdater{}
+	}
 	return &DDNSManager{
 		state:      st,
 		updater:    updater,
@@ -334,11 +347,21 @@ func (m *DDNSManager) withdrawAllLocked(ctx context.Context) error {
 	return firstErr
 }
 
-// upsertLocked publishes a record and records ownership on success.
+// upsertLocked publishes a record and records ownership on success. With no
+// live backend (nopUpdater), the upsert is a logged no-op AND ownership is
+// deliberately NOT recorded: recording ownership for a record that never
+// reached a real backend would (a) leave the store claiming records that do
+// not exist in DNS and (b) cause a later real backend to skip them as
+// "already owned". So the no-op path counts the skip and returns success
+// (reconcile must not wedge) without mutating the ownership store.
 func (m *DDNSManager) upsertLocked(ctx context.Context, rec LeaseDNSRecord, ow ownedRecord) error {
 	if err := m.updater.UpsertLease(ctx, rec); err != nil {
 		m.upsertFail.Add(1)
 		return err
+	}
+	if isNopUpdater(m.updater) {
+		m.skippedNoBackend.Add(1)
+		return nil
 	}
 	m.upsertOK.Add(1)
 	m.state.put(ow)
@@ -368,6 +391,15 @@ func (m *DDNSManager) deleteOwnedLocked(ctx context.Context, owned ownedRecord) 
 		m.deleteFail.Add(1)
 		return err
 	}
+	if isNopUpdater(m.updater) {
+		// No live backend: the delete was a logged no-op. Still drop the
+		// ownership entry so a disabled/withdrawn record does not linger in
+		// the store forever — the store tracks what xpf intends to own, and
+		// without a backend there is nothing in DNS to leak.
+		m.skippedNoBackend.Add(1)
+		m.state.delete(owned.Identity, owned.Address)
+		return nil
+	}
 	m.deleteOK.Add(1)
 	m.state.delete(owned.Identity, owned.Address)
 	return nil
@@ -391,13 +423,14 @@ func (m *DDNSManager) Stats() DDNSStats {
 	m.mu.Unlock()
 
 	st := DDNSStats{
-		UpsertOK:       m.upsertOK.Load(),
-		UpsertFail:     m.upsertFail.Load(),
-		DeleteOK:       m.deleteOK.Load(),
-		DeleteFail:     m.deleteFail.Load(),
-		SkippedNoName:  m.skippedNoName.Load(),
-		OwnedRecords:   n,
-		LastReconcileN: int(m.lastReconcileN.Load()),
+		UpsertOK:         m.upsertOK.Load(),
+		UpsertFail:       m.upsertFail.Load(),
+		DeleteOK:         m.deleteOK.Load(),
+		DeleteFail:       m.deleteFail.Load(),
+		SkippedNoName:    m.skippedNoName.Load(),
+		SkippedNoBackend: m.skippedNoBackend.Load(),
+		OwnedRecords:     n,
+		LastReconcileN:   int(m.lastReconcileN.Load()),
 	}
 	if ns := m.lastReconcile.Load(); ns > 0 {
 		st.LastReconcile = time.Unix(0, ns)

--- a/pkg/dhcpserver/ddns.go
+++ b/pkg/dhcpserver/ddns.go
@@ -206,6 +206,9 @@ func (m *DDNSManager) Reconcile(ctx context.Context, cfg *config.DHCPServerConfi
 // leases + a fakeUpdater.
 func (m *DDNSManager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, leases []ddnsLease) error {
 	source := hostnameSourceFor(&pol)
+	blockedIdentity := map[string]struct{}{}
+	blockedAddress := map[string]struct{}{}
+	blockedFQDN := map[string]struct{}{}
 
 	// desired[key] = the record we want owned for that identity+address.
 	type desired struct {
@@ -272,6 +275,9 @@ func (m *DDNSManager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, l
 		// EXACT owned tuple — never anything not in the store.
 		if err := m.deleteOwnedLocked(ctx, owned); err != nil {
 			noteErr(err)
+			blockedIdentity[owned.Identity] = struct{}{}
+			blockedAddress[owned.Address] = struct{}{}
+			blockedFQDN[owned.FQDN] = struct{}{}
 			// leave it in the store so a later reconcile retries the
 			// delete (bounded by the loop cadence; never wedges).
 			continue
@@ -282,6 +288,15 @@ func (m *DDNSManager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, l
 	// in its current exact form.
 	for _, d := range want {
 		if d.seen {
+			continue
+		}
+		if _, blocked := blockedIdentity[d.ow.Identity]; blocked {
+			continue
+		}
+		if _, blocked := blockedAddress[d.ow.Address]; blocked {
+			continue
+		}
+		if _, blocked := blockedFQDN[d.ow.FQDN]; blocked {
 			continue
 		}
 		if err := m.upsertLocked(ctx, d.rec, d.ow); err != nil {

--- a/pkg/dhcpserver/ddns.go
+++ b/pkg/dhcpserver/ddns.go
@@ -1,0 +1,395 @@
+package dhcpserver
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// ddns.go: the DHCP dynamic-DNS manager + reconciler core (#1387,
+// increment 1 per docs/research/1387-dhcp-ddns/plan.md). This is the
+// fully-unit-testable slice: config-driven policy, the state-aware lease
+// parser, the never-delete-non-owned ownership store, and the
+// build-desired / diff-owned / transition reconcile algorithm driven
+// through a pluggable DNSUpdater. Tests drive reconcileOnce directly with
+// synthetic leases and a fakeUpdater (zero network/DNS dependency).
+//
+// DELIBERATELY OUT OF SCOPE for increment 1 (deferred, see plan §12):
+//   - the LIVE rfc2136 DNSUpdater backend (lab-gated increment 2);
+//   - HA ownership coupling to VRRP MASTER/BACKUP (test-failover-gated
+//     increment 3);
+//   - the Kea D2 backend (reserved enum; increment 4);
+//   - Prometheus emission through pkg/api (the API collector is a CHECKED
+//     collector — declaring a desc without emitting it breaks the
+//     descriptor-coverage canary; counters live here and surface via
+//     Stats() until a value source on the server exists in increment 2).
+//
+// When DynamicDNS is nil or disabled the manager does nothing — net
+// behaviour change for existing users is zero.
+
+// ddnsPolicy is the resolved, runtime-shaped DDNS configuration the
+// reconciler consumes. It is derived from config.DHCPDynamicDNSConfig at
+// reconcile time so the reconciler never holds a stale captured cfg
+// (plan §5 invariant 1).
+type ddnsPolicy struct {
+	enabled        bool
+	domain         string
+	ttl            int
+	hostnameSource string
+	conflictPolicy string
+	backend        string
+}
+
+// policyFromConfig resolves a typed config block into a runtime policy,
+// applying defaults. A nil or disabled block yields enabled=false.
+func policyFromConfig(c *config.DHCPDynamicDNSConfig) ddnsPolicy {
+	if c == nil {
+		return ddnsPolicy{}
+	}
+	p := ddnsPolicy{
+		enabled:        c.Enabled,
+		domain:         c.Domain,
+		ttl:            c.TTLSeconds,
+		hostnameSource: c.HostnameSource,
+		conflictPolicy: c.ConflictPolicy,
+		backend:        c.Backend,
+	}
+	if p.ttl <= 0 {
+		p.ttl = defaultDDNSTTL
+	}
+	if p.backend == "" {
+		p.backend = "rfc2136"
+	}
+	if p.conflictPolicy == "" {
+		p.conflictPolicy = "replace-owned"
+	}
+	return p
+}
+
+// DDNSStats is the observable counter snapshot surfaced by `show` (and,
+// in increment 2, the Prometheus collector). All counters are monotonic.
+type DDNSStats struct {
+	Enabled        bool
+	Backend        string
+	UpsertOK       uint64
+	UpsertFail     uint64
+	DeleteOK       uint64
+	DeleteFail     uint64
+	SkippedNoName  uint64
+	OwnedRecords   int
+	LastReconcile  time.Time
+	LastReconcileN int // active leases seen on the last reconcile
+}
+
+// DDNSManager owns the DDNS reconcile loop and the ownership store. It is
+// a SEPARATE type from the Kea Manager (plan §7) so the generation-
+// ordered Kea applier is not perturbed.
+type DDNSManager struct {
+	mu      sync.Mutex
+	state   *ddnsState
+	updater DNSUpdater
+
+	// nodeID is the deterministic-owner-id seed (plan §5 invariant 2):
+	// the owner watermark is derived from the lease identity so EITHER HA
+	// node computes the same value, keeping cleanup safe across failover.
+	// The HA emission gating itself is increment 3; the watermark is
+	// laid down now so the state store is forward-compatible.
+	nodeID string
+
+	// lease file paths (overridable for tests).
+	leasePath4 string
+	leasePath6 string
+
+	// now is injectable for deterministic expiry tests.
+	now func() time.Time
+
+	// counters
+	upsertOK      atomic.Uint64
+	upsertFail    atomic.Uint64
+	deleteOK      atomic.Uint64
+	deleteFail    atomic.Uint64
+	skippedNoName atomic.Uint64
+
+	lastReconcile  atomic.Int64 // unix nanos
+	lastReconcileN atomic.Int64
+
+	// last resolved policy (for Stats()).
+	lastPolicy atomic.Pointer[ddnsPolicy]
+}
+
+// NewDDNSManager constructs a DDNS manager with the given updater backend
+// and node id. The ownership store is loaded from defaultDDNSStatePath; a
+// corrupt store is reset to empty (fail-open) and the error logged.
+func NewDDNSManager(updater DNSUpdater, nodeID string) *DDNSManager {
+	st, err := loadDDNSState(defaultDDNSStatePath)
+	if err != nil {
+		slog.Warn("ddns: ownership state load failed; starting empty", "err", err)
+	}
+	return &DDNSManager{
+		state:      st,
+		updater:    updater,
+		nodeID:     nodeID,
+		leasePath4: "/var/lib/kea/kea-leases4.csv",
+		leasePath6: "/var/lib/kea/kea-leases6.csv",
+		now:        time.Now,
+	}
+}
+
+// newDDNSManagerForTesting builds a manager with an in-memory state store
+// at statePath and injectable lease paths / clock. Exported-for-test via
+// test_seams.go.
+func newDDNSManagerForTesting(updater DNSUpdater, statePath, leasePath4, leasePath6, nodeID string, now func() time.Time) *DDNSManager {
+	st, _ := loadDDNSState(statePath)
+	return &DDNSManager{
+		state:      st,
+		updater:    updater,
+		nodeID:     nodeID,
+		leasePath4: leasePath4,
+		leasePath6: leasePath6,
+		now:        now,
+	}
+}
+
+// ownerWatermark is the deterministic, node-stable owner id for a lease
+// identity (plan §5 invariant 2). It is a hash of identity+address so
+// either HA node derives the same value; the node id is folded in only as
+// a TXT-marker hint (increment 3), NOT into the delete-matching key.
+func (m *DDNSManager) ownerWatermark(identity, address string) string {
+	h := sha256.Sum256([]byte(identity + "|" + address))
+	return "xpf-dhcp-ddns:" + hex.EncodeToString(h[:8])
+}
+
+// Reconcile resolves the policy from cfg and runs one reconcile pass over
+// the current lease files. It is the production entry point (the loop and
+// HA gating that call it are increment 2/3). A nil/disabled policy is a
+// no-op except for one-time cleanup of any previously-owned records when
+// the feature is turned OFF (so disabling DDNS withdraws its records).
+func (m *DDNSManager) Reconcile(ctx context.Context, cfg *config.DHCPServerConfig) error {
+	var ddns *config.DHCPDynamicDNSConfig
+	if cfg != nil {
+		ddns = cfg.DynamicDNS
+	}
+	pol := policyFromConfig(ddns)
+	m.lastPolicy.Store(&pol)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !pol.enabled {
+		return m.withdrawAllLocked(ctx)
+	}
+
+	now := m.now()
+	leases4, err4 := parseActiveLeases4(m.leasePath4, now)
+	if err4 != nil {
+		slog.Warn("ddns: parse v4 leases failed", "err", err4)
+	}
+	leases6, err6 := parseActiveLeases6(m.leasePath6, now)
+	if err6 != nil {
+		slog.Warn("ddns: parse v6 leases failed", "err", err6)
+	}
+	leases := append(leases4, leases6...)
+	return m.reconcileOnceLocked(ctx, pol, leases)
+}
+
+// reconcileOnceLocked is the pure reconcile algorithm (plan §4.5): build
+// the desired DNS state from active leases, diff against owned state, and
+// apply add / move / reassign / expire transitions — each reconciled
+// against owned state so the never-delete-non-owned boundary holds. Caller
+// holds m.mu. Exposed (unexported) so tests drive it with synthetic
+// leases + a fakeUpdater.
+func (m *DDNSManager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, leases []ddnsLease) error {
+	source := hostnameSourceFor(&pol)
+
+	// desired[key] = the record we want owned for that identity+address.
+	type desired struct {
+		rec  LeaseDNSRecord
+		ow   ownedRecord
+		seen bool
+	}
+	want := map[string]*desired{}
+	// addrOwner tracks which identity currently wants a given address, so
+	// a reassignment (new client, same address) cleans the old owner.
+	for _, l := range leases {
+		fqdn, err := deriveFQDN(l.HostName, l.ClientFQDN, l.Identity, pol.domain, source)
+		if err != nil {
+			m.skippedNoName.Add(1)
+			slog.Debug("ddns: skipping lease with no publishable name",
+				"address", l.Address, "err", err)
+			continue
+		}
+		rec, err := buildLeaseRecord(fqdn, l.Address, pol.ttl)
+		if err != nil {
+			slog.Warn("ddns: skipping lease with invalid address", "err", err)
+			continue
+		}
+		identity := l.Identity
+		if identity == "" {
+			// No stable identity: key ownership on the address alone so
+			// reassignment still cleans (the address is the reverse key).
+			identity = "addr:" + l.Address
+		}
+		ow := ownedRecord{
+			Family:      l.Family,
+			Identity:    identity,
+			SubnetID:    l.SubnetID,
+			Address:     l.Address,
+			FQDN:        rec.FQDN,
+			ForwardType: rec.ForwardType,
+			PTRName:     rec.PTRName,
+			TTL:         rec.TTL,
+			OwnerID:     m.ownerWatermark(identity, l.Address),
+		}
+		want[ownedRecordKey(identity, l.Address)] = &desired{rec: rec, ow: ow}
+	}
+
+	var firstErr error
+	noteErr := func(e error) {
+		if e != nil && firstErr == nil {
+			firstErr = e
+		}
+	}
+
+	// Pass 1 — expire / reassign: delete every owned record that is NOT
+	// in the desired set, OR whose desired record set changed (address
+	// moved, name changed). Cleaning before adding is what makes
+	// reassignment safe (delete the old owner first).
+	for _, owned := range m.state.all() {
+		key := ownedRecordKey(owned.Identity, owned.Address)
+		d, stillWanted := want[key]
+		if stillWanted && recordsEqual(owned, d.ow) {
+			d.seen = true // unchanged; no add needed below
+			continue
+		}
+		// Owned but not wanted (expired/released) OR wanted differently
+		// (the desired pass below re-adds the new form). Delete only the
+		// EXACT owned tuple — never anything not in the store.
+		if err := m.deleteOwnedLocked(ctx, owned); err != nil {
+			noteErr(err)
+			// leave it in the store so a later reconcile retries the
+			// delete (bounded by the loop cadence; never wedges).
+			continue
+		}
+	}
+
+	// Pass 2 — add / move: upsert every desired record not already owned
+	// in its current exact form.
+	for _, d := range want {
+		if d.seen {
+			continue
+		}
+		if err := m.upsertLocked(ctx, d.rec, d.ow); err != nil {
+			noteErr(err)
+			continue
+		}
+	}
+
+	if err := m.state.save(); err != nil {
+		slog.Warn("ddns: persist ownership state failed", "err", err)
+		noteErr(err)
+	}
+	m.lastReconcile.Store(m.now().UnixNano())
+	m.lastReconcileN.Store(int64(len(leases)))
+	return firstErr
+}
+
+// withdrawAllLocked deletes every owned record (feature disabled / config
+// removed) so turning DDNS off cleans the operator's zone. Records that
+// fail to delete stay in the store for a later retry. Caller holds m.mu.
+func (m *DDNSManager) withdrawAllLocked(ctx context.Context) error {
+	owned := m.state.all()
+	if len(owned) == 0 {
+		return nil
+	}
+	var firstErr error
+	for _, r := range owned {
+		if err := m.deleteOwnedLocked(ctx, r); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if err := m.state.save(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+// upsertLocked publishes a record and records ownership on success.
+func (m *DDNSManager) upsertLocked(ctx context.Context, rec LeaseDNSRecord, ow ownedRecord) error {
+	if err := m.updater.UpsertLease(ctx, rec); err != nil {
+		m.upsertFail.Add(1)
+		return err
+	}
+	m.upsertOK.Add(1)
+	m.state.put(ow)
+	return nil
+}
+
+// deleteOwnedLocked re-derives the EXACT record from owned state and
+// deletes it, removing the ownership entry on success. This is the sole
+// delete authority — it never constructs a delete from anything but the
+// store, so a record xpf did not create can never be deleted.
+func (m *DDNSManager) deleteOwnedLocked(ctx context.Context, owned ownedRecord) error {
+	rec, err := buildLeaseRecord(owned.FQDN, owned.Address, owned.TTL)
+	if err != nil {
+		// The stored address no longer parses (should not happen): drop
+		// the entry to avoid wedging, but do NOT issue a delete with a
+		// guessed name.
+		slog.Warn("ddns: owned record has unparseable address; dropping entry",
+			"address", owned.Address, "err", err)
+		m.state.delete(owned.Identity, owned.Address)
+		return nil
+	}
+	// Force the stored forward type / PTR name (re-derived above should
+	// match, but the store is authoritative for what was written).
+	rec.ForwardType = owned.ForwardType
+	rec.PTRName = owned.PTRName
+	if err := m.updater.DeleteLease(ctx, rec); err != nil {
+		m.deleteFail.Add(1)
+		return err
+	}
+	m.deleteOK.Add(1)
+	m.state.delete(owned.Identity, owned.Address)
+	return nil
+}
+
+// recordsEqual reports whether two owned records describe the same
+// published DNS state (name + type + address + ttl). Identity/subnet
+// metadata changes alone do not require a DNS re-write.
+func recordsEqual(a, b ownedRecord) bool {
+	return a.FQDN == b.FQDN &&
+		a.ForwardType == b.ForwardType &&
+		a.Address == b.Address &&
+		a.PTRName == b.PTRName &&
+		a.TTL == b.TTL
+}
+
+// Stats returns the current observable counters for `show ... dynamic-dns`.
+func (m *DDNSManager) Stats() DDNSStats {
+	m.mu.Lock()
+	n := len(m.state.records)
+	m.mu.Unlock()
+
+	st := DDNSStats{
+		UpsertOK:       m.upsertOK.Load(),
+		UpsertFail:     m.upsertFail.Load(),
+		DeleteOK:       m.deleteOK.Load(),
+		DeleteFail:     m.deleteFail.Load(),
+		SkippedNoName:  m.skippedNoName.Load(),
+		OwnedRecords:   n,
+		LastReconcileN: int(m.lastReconcileN.Load()),
+	}
+	if ns := m.lastReconcile.Load(); ns > 0 {
+		st.LastReconcile = time.Unix(0, ns)
+	}
+	if p := m.lastPolicy.Load(); p != nil {
+		st.Enabled = p.enabled
+		st.Backend = p.backend
+	}
+	return st
+}

--- a/pkg/dhcpserver/ddns.go
+++ b/pkg/dhcpserver/ddns.go
@@ -201,14 +201,34 @@ func (m *DDNSManager) Reconcile(ctx context.Context, cfg *config.DHCPServerConfi
 	now := m.now()
 	leases4, err4 := parseActiveLeases4(m.leasePath4, now)
 	if err4 != nil {
-		slog.Warn("ddns: parse v4 leases failed", "err", err4)
+		slog.Warn("ddns: parse v4 leases failed; suppressing v4 deletes this cycle", "err", err4)
 	}
 	leases6, err6 := parseActiveLeases6(m.leasePath6, now)
 	if err6 != nil {
-		slog.Warn("ddns: parse v6 leases failed", "err", err6)
+		slog.Warn("ddns: parse v6 leases failed; suppressing v6 deletes this cycle", "err", err6)
 	}
 	leases := append(leases4, leases6...)
-	return m.reconcileOnceLocked(ctx, pol, leases)
+
+	// Fail-safe: when a family's lease CSV cannot be read/parsed, its lease
+	// set is unreliable (nil/partial) and EVERY owned record of that family
+	// would look expired -> eligible for deletion. We must never delete owned
+	// records on the basis of an unreadable source of truth, so mark that
+	// family as untrusted and the reconciler skips its destructive diff this
+	// cycle. The error is surfaced to the caller so the loop logs/counts it.
+	untrusted := map[int]bool{}
+	if err4 != nil {
+		untrusted[4] = true
+	}
+	if err6 != nil {
+		untrusted[6] = true
+	}
+	if err := m.reconcileOnceLocked(ctx, pol, leases, untrusted); err != nil {
+		return err
+	}
+	if err4 != nil {
+		return err4
+	}
+	return err6
 }
 
 // reconcileOnceLocked is the pure reconcile algorithm (plan §4.5): build
@@ -217,7 +237,12 @@ func (m *DDNSManager) Reconcile(ctx context.Context, cfg *config.DHCPServerConfi
 // against owned state so the never-delete-non-owned boundary holds. Caller
 // holds m.mu. Exposed (unexported) so tests drive it with synthetic
 // leases + a fakeUpdater.
-func (m *DDNSManager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, leases []ddnsLease) error {
+// untrusted maps a lease family (4 or 6) to true when that family's lease
+// CSV could not be read/parsed this cycle. The reconciler skips the
+// destructive diff (deletes) for an untrusted family so a transient
+// malformed lease file can never mass-delete that family's owned records.
+// A nil map means all families are trusted.
+func (m *DDNSManager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, leases []ddnsLease, untrusted map[int]bool) error {
 	source := hostnameSourceFor(&pol)
 	blockedIdentity := map[string]struct{}{}
 	blockedAddress := map[string]struct{}{}
@@ -281,6 +306,17 @@ func (m *DDNSManager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, l
 		d, stillWanted := want[key]
 		if stillWanted && recordsEqual(owned, d.ow) {
 			d.seen = true // unchanged; no add needed below
+			continue
+		}
+		// Fail-safe (#1387 MAJOR-4): if this owned record's family had an
+		// unreadable/partial lease CSV this cycle, its "expired" appearance
+		// is untrustworthy — skip the delete entirely. Mark the record as
+		// seen so the add pass does not re-publish it either; leave the
+		// ownership entry intact for a later, trustworthy reconcile.
+		if untrusted[owned.Family] {
+			if stillWanted {
+				d.seen = true
+			}
 			continue
 		}
 		// Owned but not wanted (expired/released) OR wanted differently

--- a/pkg/dhcpserver/ddns_dns.go
+++ b/pkg/dhcpserver/ddns_dns.go
@@ -3,6 +3,7 @@ package dhcpserver
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/netip"
 	"strings"
 )
@@ -40,6 +41,39 @@ type LeaseDNSRecord struct {
 type DNSUpdater interface {
 	UpsertLease(ctx context.Context, rec LeaseDNSRecord) error
 	DeleteLease(ctx context.Context, rec LeaseDNSRecord) error
+}
+
+// nopUpdater is the no-op backend used when no live DNSUpdater is wired
+// (increment 1 defers the live rfc2136 backend; NewDDNSManager substitutes
+// this when nil is passed). Every call is a LOGGED no-op rather than a
+// crash: a missing backend must never turn lease processing into a panic.
+// Both methods return nil so the reconciler treats the (skipped) record as
+// processed — it does NOT record ownership for an upsert that never reached
+// a real backend (upsertLocked records ownership only on a nil-error return,
+// and a no-op upsert that recorded ownership would let a later real backend
+// believe it already published the record). To keep the never-publish/never-
+// orphan invariants intact, the nopUpdater reports success so reconcile does
+// not wedge, and the manager-level guard (see DDNSManager.upsertLocked) is
+// what keeps a no-op upsert from recording phantom ownership.
+type nopUpdater struct{}
+
+func (nopUpdater) UpsertLease(_ context.Context, rec LeaseDNSRecord) error {
+	slog.Debug("ddns: no DNS backend wired; skipping upsert (no-op)",
+		"fqdn", rec.FQDN, "addr", rec.Addr.String(), "type", rec.ForwardType)
+	return nil
+}
+
+func (nopUpdater) DeleteLease(_ context.Context, rec LeaseDNSRecord) error {
+	slog.Debug("ddns: no DNS backend wired; skipping delete (no-op)",
+		"fqdn", rec.FQDN, "addr", rec.Addr.String(), "type", rec.ForwardType)
+	return nil
+}
+
+// isNopUpdater reports whether the manager has no live backend wired, so the
+// reconciler can avoid recording phantom ownership for a no-op upsert.
+func isNopUpdater(u DNSUpdater) bool {
+	_, ok := u.(nopUpdater)
+	return ok
 }
 
 // buildLeaseRecord constructs the forward+reverse record for an address +

--- a/pkg/dhcpserver/ddns_dns.go
+++ b/pkg/dhcpserver/ddns_dns.go
@@ -1,0 +1,96 @@
+package dhcpserver
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// ddns_dns.go: the DNS-update backend interface (#1387 plan §4.4) plus the
+// pure record-construction helpers (forward A/AAAA + reverse PTR name).
+// Increment 1 ships the interface, the record model, and a fakeUpdater
+// (see ddns_test.go) so the reconciler is fully unit-testable with no
+// network or DNS dependency. The live rfc2136 backend is increment 2.
+
+// LeaseDNSRecord is the forward+reverse record set the reconciler wants
+// for one active lease. It is the unit both UpsertLease and DeleteLease
+// operate on; a delete re-derives the SAME record from owned state so the
+// backend only ever touches names this firewall created.
+type LeaseDNSRecord struct {
+	// FQDN is the forward name (already normalized + sanitized).
+	FQDN string
+	// Addr is the leased address.
+	Addr netip.Addr
+	// TTL is the record TTL in seconds.
+	TTL int
+	// ForwardType is "A" (v4) or "AAAA" (v6), derived from Addr.
+	ForwardType string
+	// PTRName is the reverse-zone name (in-addr.arpa / ip6.arpa).
+	PTRName string
+}
+
+// DNSUpdater is the pluggable DNS-update backend (plan §4.4). The
+// reconciler holds one and never assumes a concrete implementation, so
+// the live rfc2136 backend (increment 2), a future Kea-D2 shim, and the
+// test fakeUpdater are interchangeable.
+//
+// Both methods MUST be idempotent: UpsertLease is called every reconcile
+// for every still-active lease, and DeleteLease may be retried.
+type DNSUpdater interface {
+	UpsertLease(ctx context.Context, rec LeaseDNSRecord) error
+	DeleteLease(ctx context.Context, rec LeaseDNSRecord) error
+}
+
+// buildLeaseRecord constructs the forward+reverse record for an address +
+// FQDN + TTL. ttl <= 0 falls back to defaultDDNSTTL. Returns an error for
+// an invalid address so a malformed lease row never produces a record.
+func buildLeaseRecord(fqdn, addr string, ttl int) (LeaseDNSRecord, error) {
+	a, err := netip.ParseAddr(addr)
+	if err != nil {
+		return LeaseDNSRecord{}, fmt.Errorf("ddns: invalid lease address %q: %w", addr, err)
+	}
+	a = a.Unmap()
+	if ttl <= 0 {
+		ttl = defaultDDNSTTL
+	}
+	rec := LeaseDNSRecord{
+		FQDN:    fqdn,
+		Addr:    a,
+		TTL:     ttl,
+		PTRName: reversePTRName(a),
+	}
+	if a.Is4() {
+		rec.ForwardType = "A"
+	} else {
+		rec.ForwardType = "AAAA"
+	}
+	return rec, nil
+}
+
+// reversePTRName builds the reverse-DNS PTR name for an address.
+//
+// Byte-order note (plan §4.5): this is STRING manipulation on the textual
+// address form, NOT the native-endian __be32 BPF-map convention. For IPv4
+// the four decimal octets are reversed and suffixed .in-addr.arpa; for
+// IPv6 the 32 nibbles (low-to-high) are reversed and suffixed .ip6.arpa.
+// Deliberately independent of the dataplane byte-order habit — getting it
+// "consistent with the map" would be wrong for DNS.
+func reversePTRName(a netip.Addr) string {
+	a = a.Unmap()
+	if a.Is4() {
+		o := a.As4()
+		return fmt.Sprintf("%d.%d.%d.%d.in-addr.arpa", o[3], o[2], o[1], o[0])
+	}
+	b := a.As16()
+	// 32 nibbles, least-significant first.
+	var sb strings.Builder
+	sb.Grow(len(b)*4 + len("ip6.arpa"))
+	for i := len(b) - 1; i >= 0; i-- {
+		lo := b[i] & 0x0f
+		hi := b[i] >> 4
+		fmt.Fprintf(&sb, "%x.%x.", lo, hi)
+	}
+	sb.WriteString("ip6.arpa")
+	return sb.String()
+}

--- a/pkg/dhcpserver/ddns_hostname.go
+++ b/pkg/dhcpserver/ddns_hostname.go
@@ -1,0 +1,157 @@
+package dhcpserver
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ddns_hostname.go: deterministic hostname -> DNS-label normalization for
+// the #1387 DHCP DDNS feature (plan §4.3). Pure functions, no I/O — the
+// reconciler feeds a lease's offered name(s) and the configured policy in
+// and gets back a validated FQDN (or an error for an unpublishable name).
+
+const (
+	// maxDNSLabel is the RFC 1035 single-label limit (octets).
+	maxDNSLabel = 63
+	// maxDNSName is the RFC 1035 total name limit (octets, including dots
+	// but excluding the trailing root). 253 is the conventional textual
+	// ceiling (255 wire bytes minus the leading length + trailing root).
+	maxDNSName = 253
+)
+
+// hostnameSourceFor normalizes the configured hostname-source to one of
+// the three supported modes, defaulting to client-hostname when unset or
+// unrecognized (the schema validator already rejects unknown values at
+// commit; this is the runtime belt-and-braces default).
+func hostnameSourceFor(cfg *ddnsPolicy) string {
+	switch cfg.hostnameSource {
+	case "fqdn", "mac-fallback", "client-hostname":
+		return cfg.hostnameSource
+	default:
+		return "client-hostname"
+	}
+}
+
+// deriveFQDN builds the fully-qualified name to publish for a lease per
+// the configured hostname-source and default domain. It returns an error
+// (rather than a junk name) when no publishable label can be derived, so
+// the reconciler simply skips that lease instead of polluting the zone.
+//
+//   - fqdn:            prefer the client-supplied FQDN; if absent fall
+//     back to the host-name option + domain.
+//   - client-hostname: use the host-name option + domain (default).
+//   - mac-fallback:    as client-hostname, but synthesize dhcp-<id> from
+//     the hardware/DUID identity when no name is offered.
+//
+// label sanitization (lower-case, [a-z0-9-], strip illegal chars, trim
+// dashes, cap length) is applied to every derived label. An empty result
+// after sanitization is an error.
+func deriveFQDN(hostName, clientFQDN, identity, domain, source string) (string, error) {
+	domain = sanitizeDomain(domain)
+
+	switch source {
+	case "fqdn":
+		if clientFQDN != "" {
+			return finalizeFQDN(clientFQDN, domain)
+		}
+		// fall through to host-name handling
+	case "mac-fallback":
+		if hostName == "" && clientFQDN == "" {
+			lbl := sanitizeLabel("dhcp-" + identity)
+			if lbl == "" {
+				return "", fmt.Errorf("ddns: cannot synthesize mac-fallback label from identity %q", identity)
+			}
+			return joinLabelDomain(lbl, domain)
+		}
+	}
+
+	name := hostName
+	if name == "" {
+		name = clientFQDN
+	}
+	if name == "" {
+		return "", fmt.Errorf("ddns: lease offers no hostname (source=%s)", source)
+	}
+	return finalizeFQDN(name, domain)
+}
+
+// finalizeFQDN turns an offered name into a validated FQDN: if it already
+// contains a dot it is treated as fully qualified (each label sanitized);
+// otherwise the configured domain is appended.
+func finalizeFQDN(name, domain string) (string, error) {
+	name = strings.TrimSuffix(strings.TrimSpace(name), ".")
+	if strings.Contains(name, ".") {
+		fqdn := sanitizeFQDN(name)
+		if fqdn == "" {
+			return "", fmt.Errorf("ddns: name %q sanitizes to empty", name)
+		}
+		return fqdn, nil
+	}
+	lbl := sanitizeLabel(name)
+	if lbl == "" {
+		return "", fmt.Errorf("ddns: hostname %q sanitizes to empty label", name)
+	}
+	return joinLabelDomain(lbl, domain)
+}
+
+// joinLabelDomain appends domain to a single label (when domain is set),
+// enforcing the total-name length cap.
+func joinLabelDomain(label, domain string) (string, error) {
+	fqdn := label
+	if domain != "" {
+		fqdn = label + "." + domain
+	}
+	if len(fqdn) > maxDNSName {
+		return "", fmt.Errorf("ddns: name %q exceeds %d octets", fqdn, maxDNSName)
+	}
+	return fqdn, nil
+}
+
+// sanitizeFQDN sanitizes every label of a dotted name and rejoins them,
+// dropping labels that sanitize to empty.
+func sanitizeFQDN(name string) string {
+	parts := strings.Split(name, ".")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := sanitizeLabel(p)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	joined := strings.Join(out, ".")
+	if len(joined) > maxDNSName {
+		return ""
+	}
+	return joined
+}
+
+// sanitizeDomain sanitizes a default-domain suffix (dotted), returning ""
+// for an empty/invalid domain so a bare label is published un-suffixed.
+func sanitizeDomain(domain string) string {
+	domain = strings.TrimSuffix(strings.TrimSpace(domain), ".")
+	if domain == "" {
+		return ""
+	}
+	return sanitizeFQDN(domain)
+}
+
+// sanitizeLabel lower-cases a single label, keeps only [a-z0-9-], drops
+// every other rune, trims leading/trailing dashes, and caps the result
+// at maxDNSLabel octets. The empty string signals an unusable label.
+func sanitizeLabel(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		default:
+			// drop spaces, dots, underscores, and anything non-LDH
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > maxDNSLabel {
+		out = strings.Trim(out[:maxDNSLabel], "-")
+	}
+	return out
+}

--- a/pkg/dhcpserver/ddns_hostname.go
+++ b/pkg/dhcpserver/ddns_hostname.go
@@ -75,23 +75,81 @@ func deriveFQDN(hostName, clientFQDN, identity, domain, source string) (string, 
 	return finalizeFQDN(name, domain)
 }
 
-// finalizeFQDN turns an offered name into a validated FQDN: if it already
-// contains a dot it is treated as fully qualified (each label sanitized);
-// otherwise the configured domain is appended.
+// finalizeFQDN turns an offered name into a validated FQDN that is ALWAYS
+// contained in the configured zone (plan §4.3 + the never-publish-outside-
+// the-zone boundary). The client supplies the name; the firewall — not the
+// client — decides the zone, so a dotted name can never let a client escape
+// the configured domain:
+//
+//   - No domain configured: only the FIRST label of the offered name is
+//     kept (a dotted name has no zone to be contained in, so we refuse to
+//     publish the client-supplied suffix). The result is a bare label.
+//   - Domain configured, dotted name already within the zone (its sanitized
+//     form ends in ".<domain>" or equals the domain's host part): keep it
+//     as-is (e.g. host.sub.example.com under example.com).
+//   - Domain configured, dotted name OUTSIDE the zone (foreign TLD, trailing
+//     dot escapes, double-dot, etc.): take only the FIRST sanitized label of
+//     the offered name and re-append the configured domain, so the published
+//     name is forced back inside the zone (relabel, never reject — a usable
+//     name is still derived).
 func finalizeFQDN(name, domain string) (string, error) {
 	name = strings.TrimSuffix(strings.TrimSpace(name), ".")
+
+	// No configured zone: never honor a client-supplied dotted suffix.
+	// Reduce to the first non-empty sanitized label.
+	if domain == "" {
+		lbl := firstSanitizedLabel(name)
+		if lbl == "" {
+			return "", fmt.Errorf("ddns: hostname %q sanitizes to empty label", name)
+		}
+		return joinLabelDomain(lbl, "")
+	}
+
 	if strings.Contains(name, ".") {
+		// Sanitize the full dotted name, then enforce zone containment. A
+		// name that does not land inside the configured domain is relabeled
+		// to <first-label>.<domain> rather than published outside the zone.
 		fqdn := sanitizeFQDN(name)
-		if fqdn == "" {
+		if fqdn != "" && fqdnWithinDomain(fqdn, domain) {
+			return fqdn, nil
+		}
+		lbl := firstSanitizedLabel(name)
+		if lbl == "" {
 			return "", fmt.Errorf("ddns: name %q sanitizes to empty", name)
 		}
-		return fqdn, nil
+		return joinLabelDomain(lbl, domain)
 	}
+
 	lbl := sanitizeLabel(name)
 	if lbl == "" {
 		return "", fmt.Errorf("ddns: hostname %q sanitizes to empty label", name)
 	}
 	return joinLabelDomain(lbl, domain)
+}
+
+// fqdnWithinDomain reports whether the already-sanitized name is contained
+// in the (already-sanitized) configured domain: either it equals the domain
+// exactly (the zone apex) or it is a subdomain of it (ends in ".<domain>").
+// Both inputs are lower-case sanitized LDH forms, so a plain suffix compare
+// on label boundaries is sufficient and safe.
+func fqdnWithinDomain(name, domain string) bool {
+	if name == domain {
+		return true
+	}
+	return strings.HasSuffix(name, "."+domain)
+}
+
+// firstSanitizedLabel returns the first label of a (possibly dotted) name
+// that sanitizes to a non-empty LDH label, or "" if none do. This is the
+// "take only the first label" zone-containment fallback: the client picks
+// the host part, the firewall picks the zone.
+func firstSanitizedLabel(name string) string {
+	for _, p := range strings.Split(name, ".") {
+		if s := sanitizeLabel(p); s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 // joinLabelDomain appends domain to a single label (when domain is set),

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -21,6 +22,19 @@ const (
 	keaStateDeclined = 1
 	keaStateExpired  = 2 // expired-reclaimed
 )
+
+// requiredLeaseColumns are the Kea memfile header columns the reconciler
+// MUST be able to read to run a SAFE destructive diff. "address" keys
+// every lease; "state" separates an active lease from a declined /
+// expired-reclaimed one. If either is absent (missing or renamed), every
+// row reads empty and the parser would return a silent empty lease set —
+// which the reconciler would treat as "zero active leases" and mass-delete
+// the family's owned records. Their absence is therefore a hard parse
+// error so Reconcile marks the family untrusted instead. Names are matched
+// case-insensitively (see the lower-cased cols map). Other columns the
+// parser reads (expire, hostname, fqdn_fwd, subnet_id, duid/iaid,
+// client_id/hwaddr) are optional across Kea versions and degrade safely.
+var requiredLeaseColumns = []string{"address", "state"}
 
 // ddnsLease is one active lease as the reconciler needs it: a stable
 // owner identity, the address, the offered name(s), the subnet, and the
@@ -69,15 +83,43 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		return nil, nil
 	}
 
+	// Build the header->index map with CASE-INSENSITIVE keys. Kea's real
+	// memfile headers are lower-case, but normalizing defends against a
+	// mangled header ("Address"/"ADDRESS") silently resolving to no column.
+	// Only the header KEYS and the get() lookup name are lower-cased; field
+	// VALUES (addresses, identities, hostnames) are data and stay verbatim.
 	cols := make(map[string]int)
 	for i, h := range records[0] {
-		cols[h] = i
+		cols[strings.ToLower(strings.TrimSpace(h))] = i
 	}
 	get := func(fields []string, name string) string {
 		if idx, ok := cols[name]; ok && idx >= 0 && idx < len(fields) {
 			return fields[idx]
 		}
 		return ""
+	}
+
+	// Fail-safe header validation (#1387 MAJOR-4 / AGY MINOR-1+2): the
+	// reconciler's destructive delete pass treats an EMPTY lease set as
+	// "this family legitimately has zero active leases". If a required
+	// column is missing or renamed, every row's address/state reads as ""
+	// and the loop skips all rows, producing an empty set with no error —
+	// which would let Reconcile mass-delete every owned record for the
+	// family. So an unrecognizable header MUST error (Reconcile then marks
+	// the family untrusted and SKIPS the destructive diff), never silently
+	// return an empty set. "address" keys every lease; "state" is what
+	// separates an active lease from a declined/expired-reclaimed one, so
+	// without it active and tombstoned rows are indistinguishable. An empty
+	// FILE (handled above by len(records) < 2) is a legitimate zero-lease
+	// case and is NOT an error; a present-but-mangled header IS.
+	var missing []string
+	for _, req := range requiredLeaseColumns {
+		if _, ok := cols[req]; !ok {
+			missing = append(missing, req)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("parse %s: missing required column(s) %v in Kea lease header", path, missing)
 	}
 
 	// Kea appends rows; the LAST row for an address is authoritative (lease

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -191,6 +191,27 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 			path, missing, familyLabel(family))
 	}
 
+	// Per-row conformance bound (Codex r6): the header validation above
+	// guarantees the SCHEMA is sound, but a DATA ROW can still be too short
+	// to actually supply a required column (FieldsPerRecord=-1 allows ragged
+	// rows; a torn/truncated Kea append leaves a row that does not reach a
+	// required column's index). leaseColumnValue returns "" for an
+	// out-of-range index, so a ragged row would silently mis-read a required
+	// column (e.g. address="" → row dropped; hostname="" → unnamed-skip),
+	// dropping that lease from the desired set → its owned DNS record is
+	// deleted. We cannot tell WHICH lease a torn row is, so we must NOT just
+	// skip the row — that still drops its record. Instead, a row too short to
+	// supply every required column makes the SOURCE unreliable for this
+	// family: error → Reconcile marks the family untrusted → SKIPS the
+	// destructive diff. Compute the max index among the required columns; a
+	// row with len(fields) <= maxRequiredIdx cannot reliably be read.
+	maxRequiredIdx := -1
+	for _, req := range requiredLeaseColumns[family] {
+		if idx := cols[req]; idx > maxRequiredIdx {
+			maxRequiredIdx = idx
+		}
+	}
+
 	// Header is present AND valid. A file with only a header (zero data rows)
 	// is now a LEGITIMATE trusted zero-lease result — return early before the
 	// per-row loop so a genuinely-empty Kea correctly clears owned records.
@@ -218,7 +239,19 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 			order = append(order, addr)
 		}
 	}
-	for _, fields := range records[1:] {
+	for rowNum, fields := range records[1:] {
+		// Row-conformance (Codex r6): a row too short to supply every
+		// required column cannot be read reliably. Treat the whole family's
+		// source as unreliable (torn/truncated memfile) rather than silently
+		// mis-reading the row, which would drop a lease and delete its owned
+		// record. A row with MORE fields than the header is fine (extra
+		// trailing fields are ignored by name-based lookup). rowNum is
+		// 0-based over the data rows (records[1:]); +2 gives the 1-based file
+		// line number including the header.
+		if len(fields) <= maxRequiredIdx {
+			return nil, fmt.Errorf("parse %s: Kea %s lease row %d has %d field(s), too short for required columns (need > %d; ragged/truncated source)",
+				path, familyLabel(family), rowNum+2, len(fields), maxRequiredIdx)
+		}
 		addr := get(fields, "address")
 		if addr == "" {
 			continue

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -113,8 +113,31 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
-	if len(records) < 2 {
-		return nil, nil
+
+	// Fail-safe (#1387 + Codex r4): the trusted-empty result (nil, nil) is
+	// what PERMITS Reconcile to delete a family's owned records, so it must
+	// be returned ONLY when we can prove the lease set is genuinely empty —
+	// never when the header is unrecognizable. Order matters:
+	//
+	//   1. An existing-but-0-record file (no header at all) is anomalous —
+	//      Kea always writes a header line when it creates the memfile, so a
+	//      headerless existing file is a mid-write / truncated / corrupt read.
+	//      We cannot validate columns, so fail SAFE (error → untrusted →
+	//      Reconcile SKIPS the destructive diff), not trusted-empty. (A
+	//      genuinely MISSING file already returned nil,nil above via
+	//      os.IsNotExist — "no leases yet" is a legitimate trusted-empty.)
+	//   2. A present header is ALWAYS validated BEFORE any trusted-empty
+	//      return, so a mangled header (missing required column) errors even
+	//      for a header-only / zero-data-row file. This closes the Codex-r4
+	//      hole where len(records) < 2 short-circuited ahead of validation,
+	//      re-opening the mass-delete via a header-only mangled file.
+	//   3. Only AFTER the header validates as GOOD is a header-with-zero-data
+	//      -rows treated as a legitimate trusted zero-lease (nil, nil): a
+	//      healthy header + no active rows genuinely means "no active
+	//      leases", and clearing owned DNS records is then correct.
+	if len(records) == 0 {
+		return nil, fmt.Errorf("parse %s: Kea %s lease file has no header (anomalous: mid-write or corrupt)",
+			path, familyLabel(family))
 	}
 
 	// Build the header->index map with CASE-INSENSITIVE keys. Kea's real
@@ -130,18 +153,17 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		return leaseColumnValue(cols, fields, name)
 	}
 
-	// Fail-safe header validation (#1387 MAJOR-4 + Codex r3 MAJOR-A/B): the
+	// Header validation (#1387 MAJOR-4 + Codex r3 MAJOR-A/B + r4): the
 	// reconciler's destructive delete pass treats an EMPTY (or wrongly-keyed)
 	// desired set as ground truth. A mangled header — a required column
 	// missing or renamed — parses with NO error but silently changes whether
 	// leases are published (naming), how they are keyed (identity), or whether
 	// they are active (state), so Reconcile would mass-delete or churn
 	// (delete+re-add, losing the record on a failed re-add) owned records. So
-	// any MISSING required column for this family is a hard parse error;
-	// Reconcile then marks the family untrusted and SKIPS the destructive
-	// diff. An empty FILE (handled above by len(records) < 2) is a legitimate
-	// zero-lease case and is NOT an error; a present-but-mangled header IS.
-	// See requiredLeaseColumns for the per-column destructive-path rationale.
+	// any MISSING required column for this family is a hard parse error —
+	// checked BEFORE the zero-data-row return so a header-only mangled file
+	// also errors; Reconcile then marks the family untrusted and SKIPS the
+	// destructive diff. See requiredLeaseColumns for the per-column rationale.
 	var missing []string
 	for _, req := range requiredLeaseColumns[family] {
 		if _, ok := cols[req]; !ok {
@@ -151,6 +173,13 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("parse %s: missing required column(s) %v in Kea %s lease header",
 			path, missing, familyLabel(family))
+	}
+
+	// Header is present AND valid. A file with only a header (zero data rows)
+	// is now a LEGITIMATE trusted zero-lease result — return early before the
+	// per-row loop so a genuinely-empty Kea correctly clears owned records.
+	if len(records) < 2 {
+		return nil, nil
 	}
 
 	// Kea appends rows; the LAST row for an address is authoritative (lease

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -145,9 +145,25 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 	// mangled header ("Address"/"ADDRESS") silently resolving to no column.
 	// Only the header KEYS and the get() lookup name are lower-cased; field
 	// VALUES (addresses, identities, hostnames) are data and stay verbatim.
+	//
+	// DUPLICATE-column rejection (Codex r5): a name appearing more than once
+	// in the header would silently OVERWRITE the earlier index with the LAST
+	// occurrence, so cols[name] could point at the wrong/empty column and
+	// leases would read empty/wrong → wrong desired set → the destructive
+	// pass deletes owned records. A healthy Kea memfile has all-unique column
+	// names, so we reject ANY duplicate column name in the header (not just
+	// duplicates of the columns we read): a header is trusted only if it maps
+	// UNAMBIGUOUSLY. Reject before any column lookup so an ambiguous header
+	// can never drive a destructive diff. Names compared case-insensitively
+	// (two "Address"/"address" columns collide).
 	cols := make(map[string]int)
 	for i, h := range records[0] {
-		cols[strings.ToLower(strings.TrimSpace(h))] = i
+		key := strings.ToLower(strings.TrimSpace(h))
+		if _, dup := cols[key]; dup {
+			return nil, fmt.Errorf("parse %s: duplicate column %q in Kea %s lease header (ambiguous)",
+				path, key, familyLabel(family))
+		}
+		cols[key] = i
 	}
 	get := func(fields []string, name string) string {
 		return leaseColumnValue(cols, fields, name)

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -1,0 +1,177 @@
+package dhcpserver
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// ddns_leases.go: a STATE-AWARE Kea memfile lease parser for the #1387
+// DDNS reconciler (plan §5 invariant 3). The existing parseLeaseCSV is
+// display-only — it has no active/expired filtering, no Kea `state`
+// column, and no v6 DUID/IAID identity. Reusing it for DDNS would publish
+// or retain stale records, the exact bug this feature is about. This
+// parser is separate and intentionally does NOT replace the display one.
+
+// Kea lease state column values (memfile CSV `state`).
+const (
+	keaStateDefault  = 0 // active
+	keaStateDeclined = 1
+	keaStateExpired  = 2 // expired-reclaimed
+)
+
+// ddnsLease is one active lease as the reconciler needs it: a stable
+// owner identity, the address, the offered name(s), the subnet, and the
+// expiry. Inactive/expired/declined rows are dropped at parse time.
+type ddnsLease struct {
+	Family     int // 4 or 6
+	Address    string
+	Identity   string // v4: client-id||hwaddr ; v6: DUID/IAID
+	SubnetID   string
+	HostName   string // host-name option
+	ClientFQDN string // client-supplied FQDN option (fqdn_fwd implied)
+	Expire     int64  // unix epoch
+}
+
+// parseActiveLeases4 reads the Kea v4 memfile and returns only active
+// leases (state default, not yet expired). now is the reference time for
+// the expiry check (injected for tests).
+func parseActiveLeases4(path string, now time.Time) ([]ddnsLease, error) {
+	return parseActiveLeases(path, 4, now)
+}
+
+// parseActiveLeases6 reads the Kea v6 memfile and returns only active
+// leases (state default, not yet expired).
+func parseActiveLeases6(path string, now time.Time) ([]ddnsLease, error) {
+	return parseActiveLeases(path, 6, now)
+}
+
+func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.FieldsPerRecord = -1 // memfile rows vary across Kea versions
+	r.Comment = '#'
+	records, err := r.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if len(records) < 2 {
+		return nil, nil
+	}
+
+	cols := make(map[string]int)
+	for i, h := range records[0] {
+		cols[h] = i
+	}
+	get := func(fields []string, name string) string {
+		if idx, ok := cols[name]; ok && idx >= 0 && idx < len(fields) {
+			return fields[idx]
+		}
+		return ""
+	}
+
+	// Kea appends rows; the last row for an address is authoritative
+	// (lease renewal / state change). Keep the last seen row per address.
+	latest := map[string]ddnsLease{}
+	order := []string{}
+	for _, fields := range records[1:] {
+		addr := get(fields, "address")
+		if addr == "" {
+			continue
+		}
+
+		// State filter: only "default" (active) rows are publishable;
+		// declined / expired-reclaimed rows must NOT have DNS records.
+		// An unparseable/absent state is treated as active (Kea's
+		// default), matching the display parser's lenient stance.
+		if s := get(fields, "state"); s != "" {
+			if st, e := strconv.Atoi(s); e == nil && st != keaStateDefault {
+				// A non-default state for an address supersedes any
+				// earlier active row for it: drop it from the set.
+				if _, seen := latest[addr]; seen {
+					delete(latest, addr)
+				} else {
+					latest[addr] = ddnsLease{} // tombstone, filtered below
+				}
+				continue
+			}
+		}
+
+		var expire int64
+		if e := get(fields, "expire"); e != "" {
+			if v, err := strconv.ParseInt(e, 10, 64); err == nil {
+				expire = v
+			}
+		}
+		// Expiry filter: a lease whose expire epoch is in the past is
+		// stale regardless of state column lag.
+		if expire > 0 && now.Unix() >= expire {
+			delete(latest, addr)
+			continue
+		}
+
+		l := ddnsLease{
+			Family:     family,
+			Address:    addr,
+			SubnetID:   get(fields, "subnet_id"),
+			HostName:   get(fields, "hostname"),
+			ClientFQDN: get(fields, "hostname"), // memfile carries one name; fqdn_fwd flags whether the client supplied it
+			Expire:     expire,
+		}
+		if family == 6 {
+			l.Identity = identity6(get(fields, "duid"), get(fields, "iaid"))
+		} else {
+			l.Identity = identity4(get(fields, "client_id"), get(fields, "hwaddr"))
+		}
+		if _, seen := latest[addr]; !seen {
+			order = append(order, addr)
+		}
+		latest[addr] = l
+	}
+
+	out := make([]ddnsLease, 0, len(order))
+	for _, addr := range order {
+		l, ok := latest[addr]
+		if !ok || l.Address == "" {
+			continue // tombstoned by a later inactive/expired row
+		}
+		out = append(out, l)
+	}
+	return out, nil
+}
+
+// identity4 returns the stable v4 owner identity: client-id when present
+// (RFC 2131 client identifier survives a NIC swap), else the hardware
+// address. Empty inputs yield "" (the lease is then keyed on address
+// only by the caller, which still cleans on reassign because the address
+// is the reverse key).
+func identity4(clientID, hwaddr string) string {
+	if clientID != "" {
+		return "cid:" + clientID
+	}
+	if hwaddr != "" {
+		return "mac:" + hwaddr
+	}
+	return ""
+}
+
+// identity6 returns the stable v6 owner identity from DUID + IAID.
+func identity6(duid, iaid string) string {
+	if duid == "" {
+		return ""
+	}
+	if iaid != "" {
+		return "duid:" + duid + "/" + iaid
+	}
+	return "duid:" + duid
+}

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -120,12 +120,13 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 			continue
 		}
 
+		hostName, clientFQDN := splitLeaseNames(get(fields, "hostname"), get(fields, "fqdn_fwd"))
 		l := ddnsLease{
 			Family:     family,
 			Address:    addr,
 			SubnetID:   get(fields, "subnet_id"),
-			HostName:   get(fields, "hostname"),
-			ClientFQDN: get(fields, "hostname"), // memfile carries one name; fqdn_fwd flags whether the client supplied it
+			HostName:   hostName,
+			ClientFQDN: clientFQDN,
 			Expire:     expire,
 		}
 		if family == 6 {
@@ -148,6 +149,16 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		out = append(out, l)
 	}
 	return out, nil
+}
+
+func splitLeaseNames(hostname, fqdnFwd string) (hostName, clientFQDN string) {
+	if hostname == "" {
+		return "", ""
+	}
+	if v, err := strconv.Atoi(fqdnFwd); err == nil && v != 0 {
+		return "", hostname
+	}
+	return hostname, ""
 }
 
 // identity4 returns the stable v4 owner identity: client-id when present

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -23,18 +23,52 @@ const (
 	keaStateExpired  = 2 // expired-reclaimed
 )
 
-// requiredLeaseColumns are the Kea memfile header columns the reconciler
-// MUST be able to read to run a SAFE destructive diff. "address" keys
-// every lease; "state" separates an active lease from a declined /
-// expired-reclaimed one. If either is absent (missing or renamed), every
-// row reads empty and the parser would return a silent empty lease set —
-// which the reconciler would treat as "zero active leases" and mass-delete
-// the family's owned records. Their absence is therefore a hard parse
-// error so Reconcile marks the family untrusted instead. Names are matched
-// case-insensitively (see the lower-cased cols map). Other columns the
-// parser reads (expire, hostname, fqdn_fwd, subnet_id, duid/iaid,
-// client_id/hwaddr) are optional across Kea versions and degrade safely.
-var requiredLeaseColumns = []string{"address", "state"}
+// requiredLeaseColumns lists, per family, the Kea memfile header columns the
+// reconciler MUST be able to read to compute the desired DNS state and run a
+// SAFE destructive diff. The mass-delete / record-loss class is NOT specific
+// to address/state: ANY column whose absence silently changes whether a lease
+// is published, how it is keyed for ownership, or whether it is active is
+// destructive, because a mangled header parses with no error and the
+// reconciler then deletes owned records on the basis of an empty or
+// wrongly-keyed desired set. So the required set covers every such column; if
+// any is MISSING from the header the parser returns an error and Reconcile
+// marks the family untrusted and SKIPS the destructive diff. The fail
+// direction (over-mark-untrusted for an exotic header → no publish/clean,
+// operator-visible) is SAFE; silent mass-delete / record-loss is not.
+//
+// Required (both families):
+//   - address  — keys every lease AND is the ownership key fallback; absent ⇒
+//     every row reads "" ⇒ empty lease set ⇒ Pass-1 deletes all owned.
+//   - state    — separates an active lease from a declined/expired-reclaimed
+//     one; absent ⇒ active and tombstoned rows are indistinguishable (a
+//     reclaimed/declined address would be published or a publishable one lost).
+//   - hostname — the naming source; absent ⇒ deriveFQDN errors for every lease
+//     ⇒ all leases skipped as unnamed ⇒ empty desired set ⇒ mass-delete
+//     (MAJOR A). An empty hostname VALUE is fine; we require the COLUMN.
+//
+// Required (v4 identity): client_id AND hwaddr — the ownership key derives
+// from client-id||hwaddr; absent ⇒ identity collapses to the address-fallback
+// ⇒ owned records keyed by the prior real identity no longer match desired ⇒
+// delete + re-add churn; if the delete succeeds and the re-add upsert fails
+// the active record is LOST (MAJOR B).
+//
+// Required (v6 identity): duid AND iaid — same record-loss as v4 for the
+// DUID/IAID identity.
+//
+// Deliberately OPTIONAL (absence degrades safely, no record loss):
+//   - fqdn_fwd  — only routes the hostname value into HostName vs ClientFQDN;
+//     absent ⇒ splitLeaseNames defaults to host-name semantics, still named.
+//   - expire    — absent ⇒ no expiry-based tombstoning (state still gates
+//     active-vs-tombstone); over-RETAIN of a stale lease, never a delete.
+//   - subnet_id — pure metadata stored on the owned record; recordsEqual does
+//     NOT compare it, so its absence changes no destructive computation.
+//
+// Names are matched case-insensitively (cols keys + get() lookups are
+// lower-cased).
+var requiredLeaseColumns = map[int][]string{
+	4: {"address", "state", "hostname", "client_id", "hwaddr"},
+	6: {"address", "state", "hostname", "duid", "iaid"},
+}
 
 // ddnsLease is one active lease as the reconciler needs it: a stable
 // owner identity, the address, the offered name(s), the subnet, and the
@@ -93,33 +127,30 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		cols[strings.ToLower(strings.TrimSpace(h))] = i
 	}
 	get := func(fields []string, name string) string {
-		if idx, ok := cols[name]; ok && idx >= 0 && idx < len(fields) {
-			return fields[idx]
-		}
-		return ""
+		return leaseColumnValue(cols, fields, name)
 	}
 
-	// Fail-safe header validation (#1387 MAJOR-4 / AGY MINOR-1+2): the
-	// reconciler's destructive delete pass treats an EMPTY lease set as
-	// "this family legitimately has zero active leases". If a required
-	// column is missing or renamed, every row's address/state reads as ""
-	// and the loop skips all rows, producing an empty set with no error —
-	// which would let Reconcile mass-delete every owned record for the
-	// family. So an unrecognizable header MUST error (Reconcile then marks
-	// the family untrusted and SKIPS the destructive diff), never silently
-	// return an empty set. "address" keys every lease; "state" is what
-	// separates an active lease from a declined/expired-reclaimed one, so
-	// without it active and tombstoned rows are indistinguishable. An empty
-	// FILE (handled above by len(records) < 2) is a legitimate zero-lease
-	// case and is NOT an error; a present-but-mangled header IS.
+	// Fail-safe header validation (#1387 MAJOR-4 + Codex r3 MAJOR-A/B): the
+	// reconciler's destructive delete pass treats an EMPTY (or wrongly-keyed)
+	// desired set as ground truth. A mangled header — a required column
+	// missing or renamed — parses with NO error but silently changes whether
+	// leases are published (naming), how they are keyed (identity), or whether
+	// they are active (state), so Reconcile would mass-delete or churn
+	// (delete+re-add, losing the record on a failed re-add) owned records. So
+	// any MISSING required column for this family is a hard parse error;
+	// Reconcile then marks the family untrusted and SKIPS the destructive
+	// diff. An empty FILE (handled above by len(records) < 2) is a legitimate
+	// zero-lease case and is NOT an error; a present-but-mangled header IS.
+	// See requiredLeaseColumns for the per-column destructive-path rationale.
 	var missing []string
-	for _, req := range requiredLeaseColumns {
+	for _, req := range requiredLeaseColumns[family] {
 		if _, ok := cols[req]; !ok {
 			missing = append(missing, req)
 		}
 	}
 	if len(missing) > 0 {
-		return nil, fmt.Errorf("parse %s: missing required column(s) %v in Kea lease header", path, missing)
+		return nil, fmt.Errorf("parse %s: missing required column(s) %v in Kea %s lease header",
+			path, missing, familyLabel(family))
 	}
 
 	// Kea appends rows; the LAST row for an address is authoritative (lease
@@ -203,6 +234,27 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		out = append(out, l)
 	}
 	return out, nil
+}
+
+// leaseColumnValue looks up a field by header name, CASE-INSENSITIVELY. It
+// lower-cases the lookup name so the case-insensitivity invariant holds at the
+// call site (cols keys are already lower-cased when the map is built), not just
+// because callers happen to pass lower-case literals. Field VALUES are never
+// touched — only the header name is normalized. Returns "" when the column is
+// absent or the row is short.
+func leaseColumnValue(cols map[string]int, fields []string, name string) string {
+	if idx, ok := cols[strings.ToLower(name)]; ok && idx >= 0 && idx < len(fields) {
+		return fields[idx]
+	}
+	return ""
+}
+
+// familyLabel renders a family number for error messages.
+func familyLabel(family int) string {
+	if family == 6 {
+		return "v6"
+	}
+	return "v4"
 }
 
 func splitLeaseNames(hostname, fqdnFwd string) (hostName, clientFQDN string) {

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -80,15 +80,32 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		return ""
 	}
 
-	// Kea appends rows; the last row for an address is authoritative
-	// (lease renewal / state change). Keep the last seen row per address.
+	// Kea appends rows; the LAST row for an address is authoritative (lease
+	// renewal / state change). We keep the last seen row per address and
+	// emit in first-appearance order. The map value carries the row's final
+	// disposition: a non-empty Address is an active lease to publish, an
+	// empty (zero) value is a tombstone (the last row was inactive/expired)
+	// and is filtered from the output. CRITICAL (#1387 MAJOR-3): an active
+	// row must be able to RECLAIM an address that an earlier row tombstoned
+	// (declined/expired/reclaimed then re-allocated), so we recompute the
+	// disposition on every row and ensure the address is recorded in `order`
+	// whenever it first appears, tombstone or not. Output order is stable;
+	// the tombstone filter at emit time is what drops still-inactive ones.
 	latest := map[string]ddnsLease{}
 	order := []string{}
+	inOrder := map[string]struct{}{}
+	noteAddr := func(addr string) {
+		if _, ok := inOrder[addr]; !ok {
+			inOrder[addr] = struct{}{}
+			order = append(order, addr)
+		}
+	}
 	for _, fields := range records[1:] {
 		addr := get(fields, "address")
 		if addr == "" {
 			continue
 		}
+		noteAddr(addr)
 
 		// State filter: only "default" (active) rows are publishable;
 		// declined / expired-reclaimed rows must NOT have DNS records.
@@ -96,13 +113,10 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		// default), matching the display parser's lenient stance.
 		if s := get(fields, "state"); s != "" {
 			if st, e := strconv.Atoi(s); e == nil && st != keaStateDefault {
-				// A non-default state for an address supersedes any
-				// earlier active row for it: drop it from the set.
-				if _, seen := latest[addr]; seen {
-					delete(latest, addr)
-				} else {
-					latest[addr] = ddnsLease{} // tombstone, filtered below
-				}
+				// A non-default state for an address supersedes any earlier
+				// row for it: write a tombstone (the address stays in
+				// `order` so a LATER active row can reclaim it).
+				latest[addr] = ddnsLease{}
 				continue
 			}
 		}
@@ -114,9 +128,10 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 			}
 		}
 		// Expiry filter: a lease whose expire epoch is in the past is
-		// stale regardless of state column lag.
+		// stale regardless of state column lag. Tombstone it (a later
+		// active row with a future expire can still reclaim the address).
 		if expire > 0 && now.Unix() >= expire {
-			delete(latest, addr)
+			latest[addr] = ddnsLease{}
 			continue
 		}
 
@@ -134,9 +149,6 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 		} else {
 			l.Identity = identity4(get(fields, "client_id"), get(fields, "hwaddr"))
 		}
-		if _, seen := latest[addr]; !seen {
-			order = append(order, addr)
-		}
 		latest[addr] = l
 	}
 
@@ -144,7 +156,7 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 	for _, addr := range order {
 		l, ok := latest[addr]
 		if !ok || l.Address == "" {
-			continue // tombstoned by a later inactive/expired row
+			continue // tombstoned by the FINAL inactive/expired row
 		}
 		out = append(out, l)
 	}

--- a/pkg/dhcpserver/ddns_state.go
+++ b/pkg/dhcpserver/ddns_state.go
@@ -1,0 +1,164 @@
+package dhcpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/psaab/xpf/pkg/fsatomic"
+)
+
+// ddns_state.go: the persistent ownership state store for #1387 DDNS — the
+// PROTECTION BOUNDARY for the never-delete-a-record-xpf-did-not-create
+// invariant (plan §4.2, §5 invariant 1, risk table "cardinal sin"). Every
+// record this firewall publishes is recorded here with the EXACT
+// (name, type, address) it wrote; the reconciler issues a delete only for
+// an entry present in this store, re-deriving that exact tuple. Records
+// not in the store are never touched.
+//
+// Persisted as JSON via fsatomic.WriteFileDurable (fsync-on-write): the
+// reconciler is slow-path, so durability per write is affordable and the
+// store must survive restart / failover to keep the boundary intact.
+
+// defaultDDNSStatePath is the on-disk location of the ownership store.
+const defaultDDNSStatePath = "/var/lib/xpf/dhcp-ddns-state.json"
+
+// defaultDDNSTTL is the record TTL when the operator does not set one.
+const defaultDDNSTTL = 300
+
+// ownedRecord is the exact record set this firewall published for one
+// owner identity. A delete re-derives precisely these fields; a mismatch
+// (address moved, name changed) means the desired and owned differ and
+// the reconciler must clean the OLD owned tuple before adding the new one.
+type ownedRecord struct {
+	Family      int    `json:"family"`       // 4 or 6
+	Identity    string `json:"identity"`     // stable owner id (subnet+client/duid)
+	SubnetID    string `json:"subnet_id"`    // pool/subnet metadata
+	Address     string `json:"address"`      // textual leased address
+	FQDN        string `json:"fqdn"`         // forward name published
+	ForwardType string `json:"forward_type"` // "A" | "AAAA"
+	PTRName     string `json:"ptr_name"`     // reverse name published
+	TTL         int    `json:"ttl"`          // TTL written
+	OwnerID     string `json:"owner_id"`     // deterministic node-stable watermark
+}
+
+// ownedRecordKey is the in-memory map key for an owned record: a lease's
+// stable identity plus its address, so the same client moving to a new
+// address is a distinct entry (cleanup of the old address is explicit).
+func ownedRecordKey(identity, address string) string {
+	return identity + "|" + address
+}
+
+// ddnsState is the in-memory + on-disk ownership store. records is keyed
+// by ownedRecordKey. It is NOT goroutine-safe on its own; the DDNS
+// manager serializes all access under its own mutex.
+type ddnsState struct {
+	path    string
+	records map[string]ownedRecord
+}
+
+// ddnsStateFile is the serialized on-disk shape (a stable, sorted slice
+// so the JSON diffs cleanly across reconciles).
+type ddnsStateFile struct {
+	Version int           `json:"version"`
+	Records []ownedRecord `json:"records"`
+}
+
+const ddnsStateVersion = 1
+
+// loadDDNSState reads the ownership store from path. A missing file yields
+// an empty store (first run). A CORRUPT file is FAIL-OPEN per plan §5
+// invariant 4: log-and-reset to empty rather than wedge the reconciler —
+// the caller logs; this returns (emptyStore, err) so the caller can count
+// and warn without aborting.
+func loadDDNSState(path string) (*ddnsState, error) {
+	s := &ddnsState{path: path, records: map[string]ownedRecord{}}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return s, nil
+		}
+		return s, fmt.Errorf("read ddns state %s: %w", path, err)
+	}
+	var f ddnsStateFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		// Corrupt store: keep the empty (fresh) store; the boundary is
+		// only weakened to "may leak previously-owned records" (they age
+		// out of DNS by TTL), never to "deletes unowned records".
+		return s, fmt.Errorf("parse ddns state %s (resetting to empty): %w", path, err)
+	}
+	for _, r := range f.Records {
+		s.records[ownedRecordKey(r.Identity, r.Address)] = r
+	}
+	return s, nil
+}
+
+// save persists the store durably (fsync-on-write). Records are sorted by
+// key for a deterministic file.
+func (s *ddnsState) save() error {
+	keys := make([]string, 0, len(s.records))
+	for k := range s.records {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	recs := make([]ownedRecord, 0, len(keys))
+	for _, k := range keys {
+		recs = append(recs, s.records[k])
+	}
+	data, err := json.MarshalIndent(ddnsStateFile{
+		Version: ddnsStateVersion,
+		Records: recs,
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dirOf(s.path), 0o755); err != nil {
+		return fmt.Errorf("create ddns state dir: %w", err)
+	}
+	return fsatomic.WriteFileDurable(s.path, data, 0o600)
+}
+
+// put records ownership of a published record.
+func (s *ddnsState) put(r ownedRecord) {
+	s.records[ownedRecordKey(r.Identity, r.Address)] = r
+}
+
+// get returns the owned record for identity+address, if any.
+func (s *ddnsState) get(identity, address string) (ownedRecord, bool) {
+	r, ok := s.records[ownedRecordKey(identity, address)]
+	return r, ok
+}
+
+// delete removes an ownership entry (after a successful DNS delete).
+func (s *ddnsState) delete(identity, address string) {
+	delete(s.records, ownedRecordKey(identity, address))
+}
+
+// all returns a stable-ordered copy of every owned record.
+func (s *ddnsState) all() []ownedRecord {
+	out := make([]ownedRecord, 0, len(s.records))
+	for _, r := range s.records {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return ownedRecordKey(out[i].Identity, out[i].Address) <
+			ownedRecordKey(out[j].Identity, out[j].Address)
+	})
+	return out
+}
+
+// dirOf is filepath.Dir without importing path/filepath here twice; kept
+// local so the rest of the file reads cleanly.
+func dirOf(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' {
+			if i == 0 {
+				return "/"
+			}
+			return p[:i]
+		}
+	}
+	return "."
+}

--- a/pkg/dhcpserver/ddns_state.go
+++ b/pkg/dhcpserver/ddns_state.go
@@ -84,10 +84,22 @@ func loadDDNSState(path string) (*ddnsState, error) {
 	}
 	var f ddnsStateFile
 	if err := json.Unmarshal(data, &f); err != nil {
-		// Corrupt store: keep the empty (fresh) store; the boundary is
-		// only weakened to "may leak previously-owned records" (they age
-		// out of DNS by TTL), never to "deletes unowned records".
+		// Corrupt store: keep the empty (fresh) store. The boundary is only
+		// weakened to "may leak previously-owned records" — those records
+		// stay in DNS until something authoritatively removes them (TTL only
+		// controls resolver CACHING, not removal), so the worst case is
+		// stale-but-present records, never "deletes unowned records".
 		return s, fmt.Errorf("parse ddns state %s (resetting to empty): %w", path, err)
+	}
+	// Version validation: an unknown (future / unsupported) non-zero version
+	// means a format we cannot safely decode — its records may carry a
+	// different tuple shape, so trusting them could drive WRONG-tuple
+	// deletes. Treat it like a corrupt store: fail-open to an empty store +
+	// surface the error so the caller warns. Version 0 is tolerated as a
+	// pre-versioning / zero-value store (the field was absent or defaulted).
+	if f.Version != 0 && f.Version != ddnsStateVersion {
+		return s, fmt.Errorf("ddns state %s has unsupported version %d (want %d); resetting to empty",
+			path, f.Version, ddnsStateVersion)
 	}
 	for _, r := range f.Records {
 		s.records[ownedRecordKey(r.Identity, r.Address)] = r

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -1,0 +1,545 @@
+package dhcpserver
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #1387 DHCP DDNS reconciler unit tests (increment 1). Everything is
+// driven through fakeUpdater — no network, no DNS, no lab. These prove
+// the never-delete-non-owned boundary, the move/reassign/expire
+// transitions, the state-aware lease parser, hostname normalization,
+// PTR byte-order, retry-no-wedge, and withdraw-on-disable.
+
+// fakeUpdater records every upsert/delete and can be made to fail.
+type fakeUpdater struct {
+	mu        sync.Mutex
+	upserts   []LeaseDNSRecord
+	deletes   []LeaseDNSRecord
+	failUpd   map[string]bool // FQDN -> fail upsert
+	failDel   map[string]bool // FQDN -> fail delete
+	failEvery bool            // fail all ops (retry-no-wedge probe)
+}
+
+func newFakeUpdater() *fakeUpdater {
+	return &fakeUpdater{failUpd: map[string]bool{}, failDel: map[string]bool{}}
+}
+
+func (f *fakeUpdater) UpsertLease(_ context.Context, rec LeaseDNSRecord) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failEvery || f.failUpd[rec.FQDN] {
+		return fmt.Errorf("fake: upsert %s failed", rec.FQDN)
+	}
+	f.upserts = append(f.upserts, rec)
+	return nil
+}
+
+func (f *fakeUpdater) DeleteLease(_ context.Context, rec LeaseDNSRecord) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failEvery || f.failDel[rec.FQDN] {
+		return fmt.Errorf("fake: delete %s failed", rec.FQDN)
+	}
+	f.deletes = append(f.deletes, rec)
+	return nil
+}
+
+func (f *fakeUpdater) upsertNames() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, r := range f.upserts {
+		out = append(out, r.FQDN+"="+r.Addr.String())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (f *fakeUpdater) deleteNames() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, r := range f.deletes {
+		out = append(out, r.FQDN+"="+r.Addr.String())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func testDDNS(t *testing.T, up DNSUpdater) *DDNSManager {
+	t.Helper()
+	dir := t.TempDir()
+	return newDDNSManagerForTesting(
+		up,
+		filepath.Join(dir, "state.json"),
+		filepath.Join(dir, "leases4.csv"),
+		filepath.Join(dir, "leases6.csv"),
+		"node0",
+		func() time.Time { return time.Unix(1_700_000_000, 0) },
+	)
+}
+
+func enabledPolicy() ddnsPolicy {
+	return policyFromConfig(&config.DHCPDynamicDNSConfig{
+		Enabled:    true,
+		Domain:     "example.com",
+		TTLSeconds: 300,
+	})
+}
+
+func leaseV4(addr, ident, host string) ddnsLease {
+	return ddnsLease{Family: 4, Address: addr, Identity: ident, HostName: host, SubnetID: "1"}
+}
+
+func runReconcile(t *testing.T, m *DDNSManager, pol ddnsPolicy, leases []ddnsLease) error {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.reconcileOnceLocked(context.Background(), pol, leases)
+}
+
+// ---- hostname normalization ----
+
+func TestDeriveFQDN(t *testing.T) {
+	cases := []struct {
+		name                         string
+		host, clientFQDN, id, domain string
+		source                       string
+		want                         string
+		wantErr                      bool
+	}{
+		{"plain host + domain", "laptop", "", "mac:aa", "example.com", "client-hostname", "laptop.example.com", false},
+		{"uppercase sanitized", "LapTop", "", "mac:aa", "example.com", "client-hostname", "laptop.example.com", false},
+		{"already fqdn passes through", "host.sub.example.com", "", "mac:aa", "example.com", "client-hostname", "host.sub.example.com", false},
+		{"illegal chars stripped", "my_host!*", "", "mac:aa", "example.com", "client-hostname", "myhost.example.com", false},
+		{"no name no domain errors", "", "", "mac:aa", "example.com", "client-hostname", "", true},
+		{"fqdn source prefers client fqdn", "ignored", "real.example.org", "mac:aa", "example.com", "fqdn", "real.example.org", false},
+		{"mac-fallback synthesizes", "", "", "mac:aabbccddeeff", "example.com", "mac-fallback", "dhcp-macaabbccddeeff.example.com", false},
+		{"bare label no domain", "host", "", "mac:aa", "", "client-hostname", "host", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := deriveFQDN(tc.host, tc.clientFQDN, tc.id, tc.domain, tc.source)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("deriveFQDN = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeLabelTrimsAndCaps(t *testing.T) {
+	if got := sanitizeLabel("-foo-"); got != "foo" {
+		t.Fatalf("trim dashes: got %q", got)
+	}
+	long := ""
+	for i := 0; i < 80; i++ {
+		long += "a"
+	}
+	if got := sanitizeLabel(long); len(got) != maxDNSLabel {
+		t.Fatalf("cap: got len %d want %d", len(got), maxDNSLabel)
+	}
+	if got := sanitizeLabel("___"); got != "" {
+		t.Fatalf("all-illegal: got %q", got)
+	}
+}
+
+// ---- PTR byte-order ----
+
+func TestReversePTRName(t *testing.T) {
+	v4 := reversePTRName(netip.MustParseAddr("192.0.2.5"))
+	if v4 != "5.2.0.192.in-addr.arpa" {
+		t.Fatalf("v4 PTR = %q", v4)
+	}
+	// 2001:db8::1 -> 32 reversed nibbles + ip6.arpa
+	v6 := reversePTRName(netip.MustParseAddr("2001:db8::1"))
+	want := "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
+	if v6 != want {
+		t.Fatalf("v6 PTR =\n %q\nwant\n %q", v6, want)
+	}
+}
+
+func TestBuildLeaseRecordFamilyAndTTLDefault(t *testing.T) {
+	rec, err := buildLeaseRecord("h.example.com", "10.0.0.5", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.ForwardType != "A" || rec.TTL != defaultDDNSTTL {
+		t.Fatalf("v4 record wrong: %+v", rec)
+	}
+	rec6, err := buildLeaseRecord("h.example.com", "2001:db8::5", 120)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec6.ForwardType != "AAAA" || rec6.TTL != 120 {
+		t.Fatalf("v6 record wrong: %+v", rec6)
+	}
+	if _, err := buildLeaseRecord("h", "not-an-ip", 60); err == nil {
+		t.Fatal("expected error for invalid address")
+	}
+}
+
+// ---- reconciler transitions ----
+
+func TestReconcileAddsActiveLeases(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	if err := runReconcile(t, m, pol, []ddnsLease{
+		leaseV4("10.0.0.10", "mac:aa", "host-a"),
+		leaseV4("10.0.0.11", "mac:bb", "host-b"),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := up.upsertNames()
+	want := []string{"host-a.example.com=10.0.0.10", "host-b.example.com=10.0.0.11"}
+	if !equalStr(got, want) {
+		t.Fatalf("upserts = %v want %v", got, want)
+	}
+	// Idempotent: a second reconcile with the same leases adds nothing.
+	up.upserts = nil
+	if err := runReconcile(t, m, pol, []ddnsLease{
+		leaseV4("10.0.0.10", "mac:aa", "host-a"),
+		leaseV4("10.0.0.11", "mac:bb", "host-b"),
+	}); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	if n := len(up.upserts); n != 0 {
+		t.Fatalf("idempotent reconcile re-upserted %d records", n)
+	}
+}
+
+func TestReconcileExpireDeletesOwnedRecord(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatal(err)
+	}
+	// Lease gone -> record deleted.
+	if err := runReconcile(t, m, pol, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := up.deleteNames(); !equalStr(got, []string{"host-a.example.com=10.0.0.10"}) {
+		t.Fatalf("deletes = %v", got)
+	}
+	if n := len(m.state.records); n != 0 {
+		t.Fatalf("owned state not cleared after delete: %d", n)
+	}
+}
+
+func TestReconcileClientMovesAddress(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatal(err)
+	}
+	// Same client (mac:aa), new address.
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.20", "mac:aa", "host-a")}); err != nil {
+		t.Fatal(err)
+	}
+	if got := up.deleteNames(); !equalStr(got, []string{"host-a.example.com=10.0.0.10"}) {
+		t.Fatalf("old address not deleted on move: deletes=%v", got)
+	}
+	// New address added.
+	found := false
+	for _, r := range up.upserts {
+		if r.Addr.String() == "10.0.0.20" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("new address not added on move: upserts=%v", up.upsertNames())
+	}
+}
+
+func TestReconcileAddressReassignedToNewClient(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	// Client A holds 10.0.0.10.
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatal(err)
+	}
+	// Same address now leased to client B with a different name. Old
+	// owner must be cleaned before the new owner is added.
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:bb", "host-b")}); err != nil {
+		t.Fatal(err)
+	}
+	if got := up.deleteNames(); !equalStr(got, []string{"host-a.example.com=10.0.0.10"}) {
+		t.Fatalf("old owner not cleaned on reassign: deletes=%v", got)
+	}
+	gotUp := false
+	for _, r := range up.upserts {
+		if r.FQDN == "host-b.example.com" && r.Addr.String() == "10.0.0.10" {
+			gotUp = true
+		}
+	}
+	if !gotUp {
+		t.Fatalf("new owner not added on reassign: upserts=%v", up.upsertNames())
+	}
+}
+
+// TestReconcileNeverDeletesNonOwned proves the cardinal-sin boundary: a
+// record that was never recorded as owned is never deleted, even when a
+// lease for that address/name disappears between reconciles. We seed the
+// store via reconcile, then DELETE the store entry out from under the
+// manager (simulating a record the firewall does not own) and confirm a
+// subsequent expire issues NO delete for it.
+func TestReconcileNeverDeletesNonOwned(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatal(err)
+	}
+	// Forget ownership (as if this record belongs to someone else).
+	m.mu.Lock()
+	m.state.records = map[string]ownedRecord{}
+	m.mu.Unlock()
+	up.deletes = nil
+	// Lease disappears: with no owned entry, nothing must be deleted.
+	if err := runReconcile(t, m, pol, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(up.deletes); n != 0 {
+		t.Fatalf("deleted %d non-owned records (cardinal sin)", n)
+	}
+}
+
+// TestReconcileRetryDoesNotWedge proves a permanently-failing updater does
+// not wedge the loop: reconcile returns the error but completes, and a
+// later reconcile after the updater recovers makes progress.
+func TestReconcileRetryDoesNotWedge(t *testing.T) {
+	up := newFakeUpdater()
+	up.failEvery = true
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	lease := []ddnsLease{leaseV4("10.0.0.10", "mac:aa", "host-a")}
+
+	for i := 0; i < 3; i++ {
+		err := runReconcile(t, m, pol, lease)
+		if err == nil {
+			t.Fatalf("iter %d: expected error from failing updater", i)
+		}
+	}
+	if m.upsertFail.Load() < 3 {
+		t.Fatalf("upsertFail = %d, want >= 3", m.upsertFail.Load())
+	}
+	// Nothing got recorded as owned (no successful upsert).
+	if n := len(m.state.records); n != 0 {
+		t.Fatalf("owned state populated despite all upserts failing: %d", n)
+	}
+	// Updater recovers: now the record is published.
+	up.failEvery = false
+	if err := runReconcile(t, m, pol, lease); err != nil {
+		t.Fatalf("recovery reconcile: %v", err)
+	}
+	if n := len(m.state.records); n != 1 {
+		t.Fatalf("owned state not populated after recovery: %d", n)
+	}
+}
+
+// TestReconcileSkipsUnnamedLease: a lease with no host-name and the
+// default source is skipped (counted), not published with junk.
+func TestReconcileSkipsUnnamedLease(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:aa", "")}); err != nil {
+		t.Fatal(err)
+	}
+	if n := len(up.upserts); n != 0 {
+		t.Fatalf("published %d records for an unnamed lease", n)
+	}
+	if m.skippedNoName.Load() != 1 {
+		t.Fatalf("skippedNoName = %d, want 1", m.skippedNoName.Load())
+	}
+}
+
+// TestWithdrawOnDisable: when the feature is turned off, owned records are
+// withdrawn from DNS.
+func TestWithdrawOnDisable(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatal(err)
+	}
+	up.deletes = nil
+	// Disabled policy -> withdraw all.
+	m.mu.Lock()
+	err := m.withdrawAllLocked(context.Background())
+	m.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := up.deleteNames(); !equalStr(got, []string{"host-a.example.com=10.0.0.10"}) {
+		t.Fatalf("withdraw deletes = %v", got)
+	}
+	if n := len(m.state.records); n != 0 {
+		t.Fatalf("owned state not cleared on withdraw: %d", n)
+	}
+}
+
+// ---- state-aware lease parser ----
+
+func writeCSV(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseActiveLeases4FiltersStateAndExpiry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "leases4.csv")
+	// expire epoch far in the future for active rows; a past epoch for the
+	// stale row. now = 1_700_000_000.
+	writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state
+10.0.0.10,aa:bb:cc:dd:ee:01,,3600,1900000000,1,1,1,host-a,0
+10.0.0.11,aa:bb:cc:dd:ee:02,,3600,1900000000,1,1,1,host-b,1
+10.0.0.12,aa:bb:cc:dd:ee:03,,3600,1900000000,1,1,1,host-c,2
+10.0.0.13,aa:bb:cc:dd:ee:04,,3600,1600000000,1,1,1,host-d,0
+`)
+	now := time.Unix(1_700_000_000, 0)
+	leases, err := parseActiveLeases4(path, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("want 1 active lease, got %d: %+v", len(leases), leases)
+	}
+	if leases[0].Address != "10.0.0.10" || leases[0].HostName != "host-a" {
+		t.Fatalf("wrong active lease: %+v", leases[0])
+	}
+	if leases[0].Identity != "mac:aa:bb:cc:dd:ee:01" {
+		t.Fatalf("identity = %q", leases[0].Identity)
+	}
+}
+
+func TestParseActiveLeases4ClientIDPreferred(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "leases4.csv")
+	writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,state
+10.0.0.10,aa:bb:cc:dd:ee:01,01aabbcc,3600,1900000000,1,0
+`)
+	leases, err := parseActiveLeases4(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases) != 1 || leases[0].Identity != "cid:01aabbcc" {
+		t.Fatalf("client-id not preferred: %+v", leases)
+	}
+}
+
+func TestParseActiveLeases6DUIDIAID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "leases6.csv")
+	writeCSV(t, path, `address,duid,valid_lifetime,expire,subnet_id,pref_lifetime,lease_type,iaid,prefix_len,fqdn_fwd,fqdn_rev,hostname,hwaddr,state
+2001:db8::5,00:01:00:01:de:ad,3600,1900000000,1,1800,0,7,128,1,1,host-6,aa:bb,0
+2001:db8::6,00:01:00:01:be:ef,3600,1900000000,1,1800,0,8,128,1,1,host-7,aa:cc,2
+`)
+	leases, err := parseActiveLeases6(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("want 1 active v6 lease, got %d: %+v", len(leases), leases)
+	}
+	if leases[0].Identity != "duid:00:01:00:01:de:ad/7" {
+		t.Fatalf("v6 identity = %q", leases[0].Identity)
+	}
+	if leases[0].Family != 6 {
+		t.Fatalf("family = %d", leases[0].Family)
+	}
+}
+
+func TestParseActiveLeasesLastRowWins(t *testing.T) {
+	// A renewal appends a new row; the later row supersedes. An address
+	// whose final row is declined/expired must drop out entirely.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "leases4.csv")
+	writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,aa,,3600,1900000000,1,old-name,0
+10.0.0.10,aa,,3600,1900000000,1,new-name,0
+10.0.0.20,bb,,3600,1900000000,1,host-x,0
+10.0.0.20,bb,,3600,1900000000,1,host-x,1
+`)
+	leases, err := parseActiveLeases4(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("want 1 lease (10.0.0.10 with new-name), got %d: %+v", len(leases), leases)
+	}
+	if leases[0].Address != "10.0.0.10" || leases[0].HostName != "new-name" {
+		t.Fatalf("last-row-wins failed: %+v", leases[0])
+	}
+}
+
+// ---- state store persistence ----
+
+func TestStateStorePersistsAndReloads(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	s, err := loadDDNSState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.put(ownedRecord{Family: 4, Identity: "mac:aa", Address: "10.0.0.10", FQDN: "h.example.com", ForwardType: "A", PTRName: "10.0.0.10.in-addr.arpa", TTL: 300})
+	if err := s.save(); err != nil {
+		t.Fatal(err)
+	}
+	s2, err := loadDDNSState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r, ok := s2.get("mac:aa", "10.0.0.10"); !ok || r.FQDN != "h.example.com" {
+		t.Fatalf("reload lost record: %+v ok=%v", r, ok)
+	}
+}
+
+func TestStateStoreCorruptResetsEmptyFailOpen(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	writeCSV(t, statePath, "{ this is not json")
+	s, err := loadDDNSState(statePath)
+	if err == nil {
+		t.Fatal("expected an error for corrupt state")
+	}
+	if s == nil || len(s.records) != 0 {
+		t.Fatalf("corrupt store must reset to empty, got %+v", s)
+	}
+}
+
+func equalStr(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -299,6 +299,49 @@ func TestReconcileAddressReassignedToNewClient(t *testing.T) {
 	}
 }
 
+func TestReconcileDeleteFailureBlocksReplacementUpsert(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	pol := enabledPolicy()
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatal(err)
+	}
+
+	up.upserts = nil
+	up.deletes = nil
+	up.failDel["host-a.example.com"] = true
+	err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:bb", "host-b")})
+	if err == nil {
+		t.Fatal("expected delete failure")
+	}
+	if n := len(up.upserts); n != 0 {
+		t.Fatalf("replacement upserted despite failed cleanup: %v", up.upsertNames())
+	}
+	if n := len(up.deletes); n != 0 {
+		t.Fatalf("unexpected successful delete despite injected failure: %v", up.deleteNames())
+	}
+	if m.deleteFail.Load() != 1 {
+		t.Fatalf("deleteFail = %d, want 1", m.deleteFail.Load())
+	}
+	if _, ok := m.state.get("mac:aa", "10.0.0.10"); !ok {
+		t.Fatal("old ownership entry dropped after failed delete")
+	}
+
+	delete(up.failDel, "host-a.example.com")
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:bb", "host-b")}); err != nil {
+		t.Fatalf("retry reconcile: %v", err)
+	}
+	if got := up.deleteNames(); !equalStr(got, []string{"host-a.example.com=10.0.0.10"}) {
+		t.Fatalf("retry cleanup delete calls = %v", got)
+	}
+	if m.deleteOK.Load() != 1 {
+		t.Fatalf("deleteOK = %d, want 1", m.deleteOK.Load())
+	}
+	if got := up.upsertNames(); !equalStr(got, []string{"host-b.example.com=10.0.0.10"}) {
+		t.Fatalf("replacement upserts = %v", got)
+	}
+}
+
 // TestReconcileNeverDeletesNonOwned proves the cardinal-sin boundary: a
 // record that was never recorded as owned is never deleted, even when a
 // lease for that address/name disappears between reconciles. We seed the
@@ -416,10 +459,10 @@ func TestParseActiveLeases4FiltersStateAndExpiry(t *testing.T) {
 	// expire epoch far in the future for active rows; a past epoch for the
 	// stale row. now = 1_700_000_000.
 	writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state
-10.0.0.10,aa:bb:cc:dd:ee:01,,3600,1900000000,1,1,1,host-a,0
-10.0.0.11,aa:bb:cc:dd:ee:02,,3600,1900000000,1,1,1,host-b,1
-10.0.0.12,aa:bb:cc:dd:ee:03,,3600,1900000000,1,1,1,host-c,2
-10.0.0.13,aa:bb:cc:dd:ee:04,,3600,1600000000,1,1,1,host-d,0
+10.0.0.10,aa:bb:cc:dd:ee:01,,3600,1900000000,1,0,1,host-a,0
+10.0.0.11,aa:bb:cc:dd:ee:02,,3600,1900000000,1,0,1,host-b,1
+10.0.0.12,aa:bb:cc:dd:ee:03,,3600,1900000000,1,0,1,host-c,2
+10.0.0.13,aa:bb:cc:dd:ee:04,,3600,1600000000,1,0,1,host-d,0
 `)
 	now := time.Unix(1_700_000_000, 0)
 	leases, err := parseActiveLeases4(path, now)
@@ -449,6 +492,28 @@ func TestParseActiveLeases4ClientIDPreferred(t *testing.T) {
 	}
 	if len(leases) != 1 || leases[0].Identity != "cid:01aabbcc" {
 		t.Fatalf("client-id not preferred: %+v", leases)
+	}
+}
+
+func TestParseActiveLeases4FQDNForwardFlagSplitsNameSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "leases4.csv")
+	writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,hostname,state
+10.0.0.10,aa:bb:cc:dd:ee:01,,3600,1900000000,1,0,host-a,0
+10.0.0.11,aa:bb:cc:dd:ee:02,,3600,1900000000,1,1,client.example.com,0
+`)
+	leases, err := parseActiveLeases4(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases) != 2 {
+		t.Fatalf("want 2 active leases, got %d: %+v", len(leases), leases)
+	}
+	if leases[0].HostName != "host-a" || leases[0].ClientFQDN != "" {
+		t.Fatalf("hostname row parsed wrong: %+v", leases[0])
+	}
+	if leases[1].HostName != "" || leases[1].ClientFQDN != "client.example.com" {
+		t.Fatalf("fqdn row parsed wrong: %+v", leases[1])
 	}
 }
 

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -123,7 +124,8 @@ func TestDeriveFQDN(t *testing.T) {
 		{"already fqdn passes through", "host.sub.example.com", "", "mac:aa", "example.com", "client-hostname", "host.sub.example.com", false},
 		{"illegal chars stripped", "my_host!*", "", "mac:aa", "example.com", "client-hostname", "myhost.example.com", false},
 		{"no name no domain errors", "", "", "mac:aa", "example.com", "client-hostname", "", true},
-		{"fqdn source prefers client fqdn", "ignored", "real.example.org", "mac:aa", "example.com", "fqdn", "real.example.org", false},
+		{"fqdn source prefers client fqdn (relabeled into zone)", "ignored", "real.example.org", "mac:aa", "example.com", "fqdn", "real.example.com", false},
+		{"fqdn within zone kept", "ignored", "real.dept.example.com", "mac:aa", "example.com", "fqdn", "real.dept.example.com", false},
 		{"mac-fallback synthesizes", "", "", "mac:aabbccddeeff", "example.com", "mac-fallback", "dhcp-macaabbccddeeff.example.com", false},
 		{"bare label no domain", "host", "", "mac:aa", "", "client-hostname", "host", false},
 	}
@@ -143,6 +145,62 @@ func TestDeriveFQDN(t *testing.T) {
 				t.Fatalf("deriveFQDN = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestDeriveFQDNEnforcesZoneContainment proves a client can never publish a
+// name OUTSIDE the configured domain (the #1387 MAJOR-1 escape boundary).
+// Every escape vector — a dotted name in a foreign TLD, a trailing dot, a
+// double-dot, a deeper foreign subtree — must yield a name contained in the
+// configured zone. Non-tautological: against the pre-fix finalizeFQDN (which
+// returned sanitizeFQDN(name) for any dotted name) every one of these cases
+// publishes outside example.com and the containment assertion fails.
+func TestDeriveFQDNEnforcesZoneContainment(t *testing.T) {
+	const domain = "corp.example.com"
+	// Each input is a client-controlled name that tries to escape the zone.
+	escapeInputs := []struct {
+		name   string
+		offer  string // the client-controlled name fed to the active source
+		want   string // expected published FQDN (must be within domain)
+		source string
+	}{
+		{"foreign tld", "host.attacker.tld", "host.corp.example.com", "client-hostname"},
+		{"sibling public domain", "evil.example.net", "evil.corp.example.com", "client-hostname"},
+		{"trailing dot foreign", "evil.example.net.", "evil.corp.example.com", "client-hostname"},
+		{"double dot", "a..evil.net", "a.corp.example.com", "client-hostname"},
+		{"deep foreign subtree", "a.b.c.attacker.tld", "a.corp.example.com", "client-hostname"},
+		{"fqdn source foreign", "evil.attacker.tld", "evil.corp.example.com", "fqdn"},
+	}
+	for _, tc := range escapeInputs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Route the client-controlled name through whichever source is
+			// active: the client-FQDN option for source=fqdn, the host-name
+			// option otherwise.
+			host, clientFQDN := tc.offer, ""
+			if tc.source == "fqdn" {
+				host, clientFQDN = "ignored", tc.offer
+			}
+			got, err := deriveFQDN(host, clientFQDN, "mac:aa", domain, tc.source)
+			if err != nil {
+				t.Fatalf("deriveFQDN error: %v", err)
+			}
+			// The cardinal assertion: the result is contained in the zone.
+			if got != domain && !strings.HasSuffix(got, "."+domain) {
+				t.Fatalf("name %q ESCAPED zone %q (derived from %q)", got, domain, tc.offer)
+			}
+			if tc.want != "" && got != tc.want {
+				t.Fatalf("deriveFQDN = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	// A within-zone dotted name is preserved verbatim (no needless relabel).
+	got, err := deriveFQDN("host.dept.corp.example.com", "", "mac:aa", domain, "client-hostname")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "host.dept.corp.example.com" {
+		t.Fatalf("within-zone name relabeled: %q", got)
 	}
 }
 

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -106,7 +106,7 @@ func runReconcile(t *testing.T, m *DDNSManager, pol ddnsPolicy, leases []ddnsLea
 	t.Helper()
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.reconcileOnceLocked(context.Background(), pol, leases)
+	return m.reconcileOnceLocked(context.Background(), pol, leases, nil)
 }
 
 // ---- hostname normalization ----
@@ -562,6 +562,67 @@ func TestNilUpdaterIsNopNotPanic(t *testing.T) {
 	}
 	if _, ok := m.state.get("mac:bb", "10.0.0.20"); ok {
 		t.Fatal("withdraw did not drop the owned entry under no-backend mode")
+	}
+}
+
+// TestReconcileParseErrorSuppressesFamilyDeletes proves the #1387 MAJOR-4
+// fail-safe: when a family's lease CSV cannot be parsed, that family's lease
+// set is unreliable, so the reconciler must NOT delete its owned records (a
+// transient malformed CSV would otherwise mass-delete every valid record of
+// that family). The v6 family, whose CSV is fine, is unaffected. Against the
+// pre-fix Reconcile (which logged the parse error then reconciled with the
+// nil/partial set) the owned v4 record looks expired and is deleted, so this
+// test fails pre-fix.
+func TestReconcileParseErrorSuppressesFamilyDeletes(t *testing.T) {
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS: &config.DHCPDynamicDNSConfig{
+			Enabled:    true,
+			Domain:     "example.com",
+			TTLSeconds: 300,
+		},
+	}
+
+	// Cycle 1: a valid v4 lease and a valid v6 lease -> both published+owned.
+	writeCSV(t, m.leasePath4, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,aa,,3600,1900000000,1,host-a,0
+`)
+	writeCSV(t, m.leasePath6, `address,duid,valid_lifetime,expire,subnet_id,iaid,hostname,state
+2001:db8::5,00:01,3600,1900000000,1,7,host-6,0
+`)
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("cycle 1 reconcile: %v", err)
+	}
+	if n := len(m.state.records); n != 2 {
+		t.Fatalf("cycle 1 owned records = %d, want 2", n)
+	}
+
+	// Cycle 2: corrupt the v4 CSV (bare quote => csv parse error); leave the
+	// v6 CSV valid. The v4 owned record must be PRESERVED (no delete); the
+	// reconcile must surface the parse error.
+	up.deletes = nil
+	writeCSV(t, m.leasePath4, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,aa,,3600,1900000000,1,bad"name,0
+`)
+	err := m.Reconcile(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected the v4 parse error to be surfaced")
+	}
+	// No v4 deletes at all this cycle.
+	for _, d := range up.deletes {
+		if d.Addr.Is4() {
+			t.Fatalf("v4 record deleted despite unreadable lease CSV: %s", d.FQDN)
+		}
+	}
+	// The v4 owned record is still in the store.
+	if _, ok := m.state.get("mac:aa", "10.0.0.10"); !ok {
+		t.Fatal("v4 owned record dropped after a v4 parse error (mass-delete bug)")
+	}
+	// The healthy v6 owned record is also still present (active in its CSV).
+	if _, ok := m.state.get("duid:00:01/7", "2001:db8::5"); !ok {
+		t.Fatal("healthy v6 owned record lost while v4 was untrusted")
 	}
 }
 

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -962,6 +962,47 @@ func assertReconcilePreservesOwned(t *testing.T, family int, healthyHeader, heal
 	}
 }
 
+// assertReconcilePreservesOwnedRow is like assertReconcilePreservesOwned but
+// writes the mangled cycle-2 file as header-only when mangledRow is empty
+// (the Codex-r4 header-only trigger), avoiding an ambiguous trailing blank
+// line. A non-empty mangledRow is appended as a normal data row.
+func assertReconcilePreservesOwnedRow(t *testing.T, family int, healthyHeader, healthyRow, mangledHeader, mangledRow, ownIdentity, ownAddr string) {
+	t.Helper()
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS: &config.DHCPDynamicDNSConfig{
+			Enabled: true, Domain: "example.com", TTLSeconds: 300,
+		},
+	}
+	leasePath := m.leasePath4
+	if family == 6 {
+		leasePath = m.leasePath6
+	}
+	writeCSV(t, leasePath, healthyHeader+"\n"+healthyRow+"\n")
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("cycle 1 reconcile: %v", err)
+	}
+	if _, ok := m.state.get(ownIdentity, ownAddr); !ok {
+		t.Fatalf("cycle 1 did not record owned record %s|%s; state=%+v", ownIdentity, ownAddr, m.state.records)
+	}
+	up.deletes = nil
+	mangled := mangledHeader + "\n"
+	if mangledRow != "" {
+		mangled += mangledRow + "\n"
+	}
+	writeCSV(t, leasePath, mangled)
+	if err := m.Reconcile(context.Background(), cfg); err == nil {
+		t.Fatal("mangled header must surface a parse error from Reconcile")
+	}
+	if len(up.deletes) != 0 {
+		t.Fatalf("records deleted on a mangled header-only file (record loss): %v", up.deleteNames())
+	}
+	if _, ok := m.state.get(ownIdentity, ownAddr); !ok {
+		t.Fatalf("owned record %s|%s lost on a mangled header-only file", ownIdentity, ownAddr)
+	}
+}
+
 // TestParseActiveLeasesNamingColumnRequired proves Codex-r3 MAJOR-A: if the
 // naming column ("hostname") is missing while address+state remain, the
 // pre-fix parser SUCCEEDS with empty names, Reconcile skips every lease as
@@ -1102,6 +1143,137 @@ func TestLeaseColumnValueLowerCasesLookupName(t *testing.T) {
 			t.Fatalf("leaseColumnValue(%q) = %q, want %q (lookup name not lower-cased)", tc.name, got, tc.want)
 		}
 	}
+}
+
+// TestParseActiveLeasesHeaderOnlyValidatesBeforeEmptyReturn proves the
+// Codex-r4 MAJOR: the required-column validation must run BEFORE the
+// zero-data-row trusted-empty return, so a header-only file (1 record =
+// header, no data rows) with a MANGLED header still ERRORS instead of
+// short-circuiting to a trusted (nil, nil) empty result. Against the pre-fix
+// code the `len(records) < 2` early return fired first, returning trusted
+// empty for a mangled header-only file → Reconcile ran the destructive pass →
+// mass-delete. These sub-cases assert the parser errors and (end to end) no
+// owned record is deleted.
+func TestParseActiveLeasesHeaderOnlyValidatesBeforeEmptyReturn(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	// Direct parser: a header-only file with a mangled header errors.
+	t.Run("v4 header-only missing hostname errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		// Header line only (no data rows), missing the required "hostname".
+		writeCSV(t, path, "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,state\n")
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("header-only file with a mangled header must error (not trusted-empty)")
+		}
+	})
+	t.Run("v4 header-only missing identity errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		writeCSV(t, path, "address,valid_lifetime,expire,subnet_id,hostname,state\n")
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("header-only file missing identity columns must error")
+		}
+	})
+	t.Run("v6 header-only missing identity errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l6.csv")
+		writeCSV(t, path, "address,valid_lifetime,expire,subnet_id,hostname,state\n")
+		if _, err := parseActiveLeases6(path, now); err == nil {
+			t.Fatal("v6 header-only file missing identity columns must error")
+		}
+	})
+
+	// End to end: a header-only mangled file must NOT mass-delete owned
+	// records (the same destructive vector reached through the header-only
+	// trigger). assertReconcilePreservesOwned seeds via a healthy header then
+	// re-runs with the mangled (here: header-only) header.
+	t.Run("v4 header-only mangled does not mass-delete via Reconcile", func(t *testing.T) {
+		assertReconcilePreservesOwnedRow(t, 4,
+			"address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state",
+			"10.0.0.10,aa,,3600,1900000000,1,host-a,0",
+			"address,hwaddr,client_id,valid_lifetime,expire,subnet_id,state", // header-only, missing hostname
+			"", // no data row
+			"mac:aa", "10.0.0.10")
+	})
+}
+
+// TestParseActiveLeasesHeaderOnlyValidGoodIsTrustedEmpty proves the legitimate
+// case stays correct: a file with a VALID header and ZERO data rows is a
+// trusted zero-lease (nil, nil) — a genuinely-empty Kea, so clearing owned DNS
+// records is correct. End to end, an owned record IS removed when the lease
+// file becomes header-only-valid.
+func TestParseActiveLeasesHeaderOnlyValidGoodIsTrustedEmpty(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	t.Run("v4 valid header-only is trusted empty", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		writeCSV(t, path, "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state\n")
+		leases, err := parseActiveLeases4(path, now)
+		if err != nil {
+			t.Fatalf("valid header-only file must be trusted-empty, got error: %v", err)
+		}
+		if len(leases) != 0 {
+			t.Fatalf("valid header-only file should yield 0 leases, got %d", len(leases))
+		}
+	})
+	t.Run("v4 valid header-only clears owned record via Reconcile", func(t *testing.T) {
+		up := newFakeUpdater()
+		m := testDDNS(t, up)
+		cfg := &config.DHCPServerConfig{
+			DynamicDNS: &config.DHCPDynamicDNSConfig{
+				Enabled: true, Domain: "example.com", TTLSeconds: 300,
+			},
+		}
+		// Cycle 1: one active lease -> owned.
+		writeCSV(t, m.leasePath4, "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state\n"+
+			"10.0.0.10,aa,,3600,1900000000,1,host-a,0\n")
+		if err := m.Reconcile(context.Background(), cfg); err != nil {
+			t.Fatalf("cycle 1 reconcile: %v", err)
+		}
+		if _, ok := m.state.get("mac:aa", "10.0.0.10"); !ok {
+			t.Fatal("cycle 1 did not record owned record")
+		}
+		// Cycle 2: the lease genuinely drains -> valid header, no data rows.
+		// The owned record must be cleaned (trusted-empty permits deletion).
+		writeCSV(t, m.leasePath4, "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state\n")
+		if err := m.Reconcile(context.Background(), cfg); err != nil {
+			t.Fatalf("cycle 2 reconcile: %v", err)
+		}
+		if _, ok := m.state.get("mac:aa", "10.0.0.10"); ok {
+			t.Fatal("valid header-only (genuinely empty) did not clear the owned record")
+		}
+	})
+}
+
+// TestParseActiveLeasesEmptyFileIsUntrusted proves a 0-record EXISTING file
+// (no header at all — anomalous, e.g. mid-write/truncated) fails SAFE: it
+// errors rather than returning a trusted-empty result, so Reconcile does not
+// mass-delete on an unvalidatable file. A genuinely MISSING file stays a
+// trusted-empty (handled by os.IsNotExist, asserted separately).
+func TestParseActiveLeasesEmptyFileIsUntrusted(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	t.Run("zero-byte existing file errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		writeCSV(t, path, "") // exists, zero records
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("a 0-record existing lease file must error (fail-safe untrusted), not trusted-empty")
+		}
+	})
+
+	t.Run("missing file stays trusted-empty", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "does-not-exist.csv")
+		leases, err := parseActiveLeases4(path, now)
+		if err != nil {
+			t.Fatalf("a genuinely missing file must be trusted-empty, got error: %v", err)
+		}
+		if leases != nil {
+			t.Fatalf("missing file should yield nil leases, got %+v", leases)
+		}
+	})
 }
 
 // ---- state store persistence ----

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -1399,7 +1399,85 @@ func TestParseActiveLeasesExtraAndReorderedColumnsTolerated(t *testing.T) {
 	})
 }
 
-// ---- state store persistence ----
+// TestParseActiveLeasesRaggedRowUntrusted proves the Codex-r6 MAJOR: a data
+// row too SHORT to supply a required column makes the source unreliable, so
+// the parser errors (untrusted → Reconcile skips the destructive diff) rather
+// than silently mis-reading the row and dropping its lease. A torn/truncated
+// Kea memfile append leaves a ragged row; reading a required column past the
+// row's length returns "" (bounds-safe but NOT delete-safe), which would drop
+// the lease and delete its owned DNS record. Against the pre-fix code the
+// ragged row reads "" for the missing fields → lease dropped → record deleted.
+func TestParseActiveLeasesRaggedRowUntrusted(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	t.Run("v4 row too short for a required column errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		// Valid header; the data row is truncated before reaching hostname
+		// and state (a torn append). It contains address but not the later
+		// required columns.
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,aa,,3600
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("a ragged v4 row (too short for required columns) must error (untrusted)")
+		}
+	})
+
+	t.Run("v4 row reaches address but not state/hostname errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		// Required v4 columns include hostname (idx 6) and state (idx 7); a
+		// row of 7 fields (idx 0..6) reaches hostname but not state.
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,aa,,3600,1900000000,1,host-a
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("a row missing the trailing required 'state' column must error")
+		}
+	})
+
+	t.Run("v6 ragged row errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l6.csv")
+		writeCSV(t, path, `address,duid,valid_lifetime,expire,subnet_id,iaid,hostname,state
+2001:db8::5,00:01,3600
+`)
+		if _, err := parseActiveLeases6(path, now); err == nil {
+			t.Fatal("a ragged v6 row must error (untrusted)")
+		}
+	})
+
+	// End to end: a ragged row must NOT mass-delete owned records.
+	t.Run("ragged row does not mass-delete via Reconcile", func(t *testing.T) {
+		assertReconcilePreservesOwnedRow(t, 4,
+			"address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state",
+			"10.0.0.10,aa,,3600,1900000000,1,host-a,0",
+			"address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state", // valid header
+			"10.0.0.10,aa,,3600", // ragged data row
+			"mac:aa", "10.0.0.10")
+	})
+}
+
+// TestParseActiveLeasesExtraFieldRowTolerated proves the boundary is not
+// over-broad: a data row with MORE fields than the header (extra trailing
+// fields) is TOLERATED — only too-SHORT-for-a-required-column rows trigger
+// untrust. Lookups are by name/index, so trailing extras are ignored.
+func TestParseActiveLeasesExtraFieldRowTolerated(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "l4.csv")
+	// The data row has two extra trailing fields beyond the header width.
+	writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,aa,,3600,1900000000,1,host-a,0,extra1,extra2
+`)
+	leases, err := parseActiveLeases4(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("a row with extra trailing fields should be tolerated, got error: %v", err)
+	}
+	if len(leases) != 1 || leases[0].Address != "10.0.0.10" || leases[0].HostName != "host-a" {
+		t.Fatalf("extra-field row parsed wrong: %+v", leases)
+	}
+}
 
 // ---- state store persistence ----
 

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -665,8 +665,8 @@ func TestParseActiveLeases4FiltersStateAndExpiry(t *testing.T) {
 func TestParseActiveLeases4ClientIDPreferred(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "leases4.csv")
-	writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,state
-10.0.0.10,aa:bb:cc:dd:ee:01,01aabbcc,3600,1900000000,1,0
+	writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,aa:bb:cc:dd:ee:01,01aabbcc,3600,1900000000,1,host-a,0
 `)
 	leases, err := parseActiveLeases4(path, time.Unix(1_700_000_000, 0))
 	if err != nil {
@@ -918,6 +918,189 @@ func TestParseActiveLeasesCaseInsensitiveHeader(t *testing.T) {
 	}
 	if leases[0].Identity != "mac:aa:bb:cc:dd:ee:01" {
 		t.Fatalf("identity from mixed-case header = %q", leases[0].Identity)
+	}
+}
+
+// reconcileWithLeaseHeaders is a helper: seed an owned record from a healthy
+// lease file, then re-run Reconcile with a (possibly mangled) header and
+// assert the owned record is preserved + the reconcile surfaces an error.
+// Used by the Codex-r3 MAJOR-A (naming) and MAJOR-B (identity) tests.
+func assertReconcilePreservesOwned(t *testing.T, family int, healthyHeader, healthyRow, mangledHeader, mangledRow, ownIdentity, ownAddr string) {
+	t.Helper()
+	up := newFakeUpdater()
+	m := testDDNS(t, up)
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS: &config.DHCPDynamicDNSConfig{
+			Enabled:    true,
+			Domain:     "example.com",
+			TTLSeconds: 300,
+		},
+	}
+	leasePath := m.leasePath4
+	if family == 6 {
+		leasePath = m.leasePath6
+	}
+	// Cycle 1: healthy header -> the lease is published and owned.
+	writeCSV(t, leasePath, healthyHeader+"\n"+healthyRow+"\n")
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("cycle 1 reconcile: %v", err)
+	}
+	if _, ok := m.state.get(ownIdentity, ownAddr); !ok {
+		t.Fatalf("cycle 1 did not record owned record %s|%s; state=%+v", ownIdentity, ownAddr, m.state.records)
+	}
+	// Cycle 2: mangled header -> must error, must not delete the owned record.
+	up.deletes = nil
+	writeCSV(t, leasePath, mangledHeader+"\n"+mangledRow+"\n")
+	if err := m.Reconcile(context.Background(), cfg); err == nil {
+		t.Fatal("mangled header must surface a parse error from Reconcile")
+	}
+	if len(up.deletes) != 0 {
+		t.Fatalf("records deleted on a mangled header (record loss): %v", up.deleteNames())
+	}
+	if _, ok := m.state.get(ownIdentity, ownAddr); !ok {
+		t.Fatalf("owned record %s|%s lost on a mangled header", ownIdentity, ownAddr)
+	}
+}
+
+// TestParseActiveLeasesNamingColumnRequired proves Codex-r3 MAJOR-A: if the
+// naming column ("hostname") is missing while address+state remain, the
+// pre-fix parser SUCCEEDS with empty names, Reconcile skips every lease as
+// unnamed (empty desired set), and the destructive pass mass-deletes all
+// owned records. The naming column is now REQUIRED, so a header without it
+// errors and Reconcile marks the family untrusted. Against pre-fix code the
+// parser returns named=0 with no error -> the owned record is mass-deleted ->
+// this fails.
+func TestParseActiveLeasesNamingColumnRequired(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	// Direct parser: missing hostname errors (v4 and v6).
+	t.Run("v4 missing hostname errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,state
+10.0.0.10,aa,,3600,1900000000,1,0
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("v4 header missing 'hostname' must error")
+		}
+	})
+	t.Run("v6 missing hostname errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l6.csv")
+		writeCSV(t, path, `address,duid,valid_lifetime,expire,subnet_id,iaid,state
+2001:db8::5,00:01,3600,1900000000,1,7,0
+`)
+		if _, err := parseActiveLeases6(path, now); err == nil {
+			t.Fatal("v6 header missing 'hostname' must error")
+		}
+	})
+	// End-to-end: a missing hostname must not mass-delete owned records.
+	t.Run("v4 missing hostname does not mass-delete", func(t *testing.T) {
+		assertReconcilePreservesOwned(t, 4,
+			"address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state",
+			"10.0.0.10,aa,,3600,1900000000,1,host-a,0",
+			"address,hwaddr,client_id,valid_lifetime,expire,subnet_id,state",
+			"10.0.0.10,aa,,3600,1900000000,1,0",
+			"mac:aa", "10.0.0.10")
+	})
+}
+
+// TestParseActiveLeasesIdentityColumnRequired proves Codex-r3 MAJOR-B: if the
+// per-family identity columns disappear (v4: client_id+hwaddr; v6: duid+iaid)
+// while address/state/hostname remain, the pre-fix parser SUCCEEDS but the
+// identity collapses to the address fallback, so the owned record keyed by the
+// PRIOR real identity no longer matches desired -> delete + re-add churn (and
+// record loss if the re-add upsert fails). The identity columns are now
+// REQUIRED per family, so a header without them errors and Reconcile marks the
+// family untrusted. Against pre-fix code the parser succeeds and the owned
+// record is deleted+rekeyed -> this fails.
+func TestParseActiveLeasesIdentityColumnRequired(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	t.Run("v4 missing client_id+hwaddr errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		writeCSV(t, path, `address,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,3600,1900000000,1,host-a,0
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("v4 header missing identity columns must error")
+		}
+	})
+	t.Run("v6 missing duid+iaid errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l6.csv")
+		writeCSV(t, path, `address,valid_lifetime,expire,subnet_id,hostname,state
+2001:db8::5,3600,1900000000,1,host-6,0
+`)
+		if _, err := parseActiveLeases6(path, now); err == nil {
+			t.Fatal("v6 header missing identity columns must error")
+		}
+	})
+	// End-to-end: a v4 header losing its identity columns must not delete the
+	// record keyed by the prior real identity.
+	t.Run("v4 missing identity does not churn owned record", func(t *testing.T) {
+		assertReconcilePreservesOwned(t, 4,
+			"address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state",
+			"10.0.0.10,aa,,3600,1900000000,1,host-a,0",
+			"address,valid_lifetime,expire,subnet_id,hostname,state",
+			"10.0.0.10,3600,1900000000,1,host-a,0",
+			"mac:aa", "10.0.0.10")
+	})
+	// End-to-end: a v6 header losing its identity columns must not churn.
+	t.Run("v6 missing identity does not churn owned record", func(t *testing.T) {
+		assertReconcilePreservesOwned(t, 6,
+			"address,duid,valid_lifetime,expire,subnet_id,iaid,hostname,state",
+			"2001:db8::5,00:01,3600,1900000000,1,7,host-6,0",
+			"address,valid_lifetime,expire,subnet_id,hostname,state",
+			"2001:db8::5,3600,1900000000,1,host-6,0",
+			"duid:00:01/7", "2001:db8::5")
+	})
+}
+
+// TestParseActiveLeasesOptionalColumnsDegradeSafely proves the columns kept
+// OPTIONAL (fqdn_fwd, expire, subnet_id) do not error and degrade safely: a
+// healthy header without them still parses the lease (named, active). This
+// documents the deliberate boundary — only columns whose absence is
+// destructive are required.
+func TestParseActiveLeasesOptionalColumnsDegradeSafely(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "l4.csv")
+	// No fqdn_fwd, no expire, no subnet_id — all the required columns present.
+	writeCSV(t, path, `address,hwaddr,client_id,hostname,state
+10.0.0.10,aa,,host-a,0
+`)
+	leases, err := parseActiveLeases4(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("optional columns absent should still parse, got error: %v", err)
+	}
+	if len(leases) != 1 || leases[0].HostName != "host-a" || leases[0].Identity != "mac:aa" {
+		t.Fatalf("optional-absent lease parsed wrong: %+v", leases)
+	}
+}
+
+// TestLeaseColumnValueLowerCasesLookupName proves the Codex-r3 MINOR: the
+// column lookup lower-cases its NAME argument so the case-insensitivity
+// invariant holds at the call site, not merely because every caller passes a
+// lower-case literal. The cols map (built lower-cased) is queried with a
+// MIXED-case lookup name; it must still resolve. Against the pre-fix lookup
+// (cols[name], no lower-casing of name) a mixed-case lookup name misses and
+// returns "" — so this test fails pre-fix. This is the direct guard the
+// documented invariant requires.
+func TestLeaseColumnValueLowerCasesLookupName(t *testing.T) {
+	// cols keys are lower-case (as built from the header). Look them up with
+	// mixed/upper-case names — they must resolve.
+	cols := map[string]int{"address": 0, "client_id": 1, "hostname": 2}
+	fields := []string{"10.0.0.10", "01deadbeef", "host-a"}
+	cases := []struct{ name, want string }{
+		{"Address", "10.0.0.10"},
+		{"ADDRESS", "10.0.0.10"},
+		{"Client_ID", "01deadbeef"},
+		{"HostName", "host-a"},
+		{"absent", ""},
+	}
+	for _, tc := range cases {
+		if got := leaseColumnValue(cols, fields, tc.name); got != tc.want {
+			t.Fatalf("leaseColumnValue(%q) = %q, want %q (lookup name not lower-cased)", tc.name, got, tc.want)
+		}
 	}
 }
 

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -623,6 +623,75 @@ func TestParseActiveLeasesLastRowWins(t *testing.T) {
 	}
 }
 
+// TestParseActiveLeasesInactiveThenActiveReclaim proves the #1387 MAJOR-3
+// boundary: an inactive (declined/expired-reclaimed) row that PRECEDES a
+// later active row for the SAME address must NOT suppress that active row.
+// Last-row-wins means the final active allocation reclaims the address and
+// it appears in the output. Against the pre-fix parser (which tombstoned the
+// address out of the output order and never re-added it when a later active
+// row arrived) the reclaimed address is silently OMITTED, so this test fails
+// pre-fix.
+func TestParseActiveLeasesInactiveThenActiveReclaim(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Unix(1_700_000_000, 0)
+
+	t.Run("inactive then active", func(t *testing.T) {
+		path := filepath.Join(dir, "leases-ia.csv")
+		// 10.0.0.10: declined (state=1) THEN a fresh active allocation.
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,aa,,3600,1900000000,1,old-decl,1
+10.0.0.10,bb,,3600,1900000000,1,new-active,0
+`)
+		leases, err := parseActiveLeases4(path, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(leases) != 1 {
+			t.Fatalf("reclaimed active lease omitted: got %d leases %+v", len(leases), leases)
+		}
+		if leases[0].Address != "10.0.0.10" || leases[0].HostName != "new-active" {
+			t.Fatalf("wrong reclaimed lease: %+v", leases[0])
+		}
+	})
+
+	t.Run("active inactive active", func(t *testing.T) {
+		path := filepath.Join(dir, "leases-aia.csv")
+		// 10.0.0.20: active, then expired-reclaimed (state=2), then active
+		// again — the FINAL active row must win.
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.20,aa,,3600,1900000000,1,first,0
+10.0.0.20,aa,,3600,1900000000,1,gone,2
+10.0.0.20,cc,,3600,1900000000,1,final,0
+`)
+		leases, err := parseActiveLeases4(path, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(leases) != 1 {
+			t.Fatalf("final active row omitted: got %d leases %+v", len(leases), leases)
+		}
+		if leases[0].HostName != "final" {
+			t.Fatalf("active->inactive->active did not keep final: %+v", leases[0])
+		}
+	})
+
+	t.Run("inactive last row still drops", func(t *testing.T) {
+		path := filepath.Join(dir, "leases-final-inactive.csv")
+		// 10.0.0.30: active then declined — final row inactive => dropped.
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.30,aa,,3600,1900000000,1,was-active,0
+10.0.0.30,aa,,3600,1900000000,1,now-declined,1
+`)
+		leases, err := parseActiveLeases4(path, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(leases) != 0 {
+			t.Fatalf("address with final inactive row should drop: %+v", leases)
+		}
+	})
+}
+
 // ---- state store persistence ----
 
 func TestStateStorePersistsAndReloads(t *testing.T) {

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -340,6 +340,9 @@ func TestReconcileDeleteFailureBlocksReplacementUpsert(t *testing.T) {
 	if got := up.upsertNames(); !equalStr(got, []string{"host-b.example.com=10.0.0.10"}) {
 		t.Fatalf("replacement upserts = %v", got)
 	}
+	if _, ok := m.state.get("mac:aa", "10.0.0.10"); ok {
+		t.Fatal("old ownership entry still present after successful retry")
+	}
 }
 
 // TestReconcileNeverDeletesNonOwned proves the cardinal-sin boundary: a

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -505,6 +505,66 @@ func TestWithdrawOnDisable(t *testing.T) {
 	}
 }
 
+// TestNilUpdaterIsNopNotPanic proves the #1387 MAJOR-2 boundary: increment 1
+// defers the live backend, so a manager built with a nil DNSUpdater must run
+// as a logged no-op, NOT panic on the first publish or on a withdraw. Against
+// the pre-fix code (m.updater.UpsertLease called unguarded on a nil
+// interface) the enabled reconcile panics with a nil-pointer dereference, so
+// this test is non-tautological.
+func TestNilUpdaterIsNopNotPanic(t *testing.T) {
+	// Construction with nil must not panic and must substitute a no-op
+	// backend (the production constructor path).
+	prod := NewDDNSManager(nil, "node0")
+	if prod.updater == nil {
+		t.Fatal("NewDDNSManager(nil, ...) left a nil updater")
+	}
+	if !isNopUpdater(prod.updater) {
+		t.Fatalf("NewDDNSManager(nil, ...) did not install a nopUpdater: %T", prod.updater)
+	}
+
+	// Enabled reconcile + withdraw on a manager with no live backend: both
+	// must complete without panicking. Use the testing constructor so the
+	// state/lease paths are temp dirs.
+	m := testDDNS(t, nil) // nil -> nopUpdater
+	if !isNopUpdater(m.updater) {
+		t.Fatalf("nil updater not converted to nopUpdater: %T", m.updater)
+	}
+	pol := enabledPolicy()
+
+	// Publish path: an active lease must be processed (logged-skipped), with
+	// NO ownership recorded for a record that never reached a real backend.
+	if err := runReconcile(t, m, pol, []ddnsLease{leaseV4("10.0.0.10", "mac:aa", "host-a")}); err != nil {
+		t.Fatalf("reconcile with no backend errored: %v", err)
+	}
+	if n := len(m.state.records); n != 0 {
+		t.Fatalf("no-backend reconcile recorded %d phantom ownership entries", n)
+	}
+	if m.skippedNoBackend.Load() == 0 {
+		t.Fatal("no-backend upsert was not counted as skipped")
+	}
+	if m.upsertOK.Load() != 0 {
+		t.Fatalf("no-backend upsert counted as upsertOK = %d", m.upsertOK.Load())
+	}
+
+	// Withdraw path: disabling DDNS while owned state exists must also be a
+	// safe no-op. Seed a stale owned record (as if a prior backend wrote it),
+	// then run the disabled (withdraw-all) reconcile.
+	m.mu.Lock()
+	m.state.put(ownedRecord{
+		Family: 4, Identity: "mac:bb", Address: "10.0.0.20",
+		FQDN: "host-b.example.com", ForwardType: "A",
+		PTRName: "20.0.0.10.in-addr.arpa", TTL: 300,
+	})
+	err := m.withdrawAllLocked(context.Background())
+	m.mu.Unlock()
+	if err != nil {
+		t.Fatalf("withdraw with no backend errored: %v", err)
+	}
+	if _, ok := m.state.get("mac:bb", "10.0.0.20"); ok {
+		t.Fatal("withdraw did not drop the owned entry under no-backend mode")
+	}
+}
+
 // ---- state-aware lease parser ----
 
 func writeCSV(t *testing.T, path, content string) {

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -813,6 +813,114 @@ func TestParseActiveLeasesInactiveThenActiveReclaim(t *testing.T) {
 	})
 }
 
+// TestParseActiveLeasesMangledHeaderErrors proves the AGY MINOR-1 / MAJOR-4
+// re-open fix: a Kea memfile whose header is MANGLED (a required column
+// missing or renamed) must return a parse ERROR — not a silent empty lease
+// set — so the reconciler marks the family untrusted and SKIPS the
+// destructive delete pass. Otherwise every owned record of that family
+// looks expired and is mass-deleted, the exact failure MAJOR-4 prevents,
+// reached through the header-validation gap. The two sub-cases exercise the
+// header-mangle path end to end through Reconcile (owned records preserved)
+// and the direct-parser path (error returned). Against the pre-fix code the
+// parser returns 0 leases with no error, so the owned record is deleted and
+// these assertions fail.
+func TestParseActiveLeasesMangledHeaderErrors(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	t.Run("missing address column errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "leases-noaddr.csv")
+		// Header lacks "address"; the body row still carries a value where
+		// address would be. Pre-fix: every addr reads "" -> all rows skipped
+		// -> 0 leases, no error.
+		writeCSV(t, path, `hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+aa:bb:cc:dd:ee:01,,3600,1900000000,1,host-a,0
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("missing 'address' column must produce a parse error")
+		}
+	})
+
+	t.Run("missing state column errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "leases-nostate.csv")
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname
+10.0.0.10,aa:bb:cc:dd:ee:01,,3600,1900000000,1,host-a
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("missing 'state' column must produce a parse error")
+		}
+	})
+
+	t.Run("mangled header does not mass-delete via Reconcile", func(t *testing.T) {
+		up := newFakeUpdater()
+		m := testDDNS(t, up)
+		cfg := &config.DHCPServerConfig{
+			DynamicDNS: &config.DHCPDynamicDNSConfig{
+				Enabled:    true,
+				Domain:     "example.com",
+				TTLSeconds: 300,
+			},
+		}
+		// Cycle 1: a valid header -> the v4 lease is published and owned.
+		writeCSV(t, m.leasePath4, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.0.10,aa,,3600,1900000000,1,host-a,0
+`)
+		if err := m.Reconcile(context.Background(), cfg); err != nil {
+			t.Fatalf("cycle 1 reconcile: %v", err)
+		}
+		if _, ok := m.state.get("mac:aa", "10.0.0.10"); !ok {
+			t.Fatal("cycle 1 did not record the owned v4 record")
+		}
+		// Cycle 2: the v4 header is now mangled (no "state" column). The
+		// reconcile must surface an error and NOT delete the owned record.
+		up.deletes = nil
+		writeCSV(t, m.leasePath4, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname
+10.0.0.10,aa,,3600,1900000000,1,host-a
+`)
+		err := m.Reconcile(context.Background(), cfg)
+		if err == nil {
+			t.Fatal("mangled header must surface a parse error from Reconcile")
+		}
+		for _, d := range up.deletes {
+			if d.Addr.Is4() {
+				t.Fatalf("v4 record deleted on a mangled header: %s", d.FQDN)
+			}
+		}
+		if _, ok := m.state.get("mac:aa", "10.0.0.10"); !ok {
+			t.Fatal("v4 owned record mass-deleted on a mangled header (MAJOR-4 re-opened)")
+		}
+	})
+}
+
+// TestParseActiveLeasesCaseInsensitiveHeader proves AGY MINOR-2: header
+// column names are matched case-insensitively, so a memfile written with
+// mixed-case headers ("Address","State", ...) still resolves its columns
+// and parses leases correctly. Against the pre-fix case-sensitive cols map
+// the columns are not found, every row is skipped, and the parser returns 0
+// leases — so this test fails pre-fix.
+func TestParseActiveLeasesCaseInsensitiveHeader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "leases-mixedcase.csv")
+	writeCSV(t, path, `Address,HwAddr,Client_ID,Valid_Lifetime,Expire,Subnet_ID,Hostname,State
+10.0.0.10,aa:bb:cc:dd:ee:01,,3600,1900000000,1,host-a,0
+10.0.0.11,aa:bb:cc:dd:ee:02,,3600,1900000000,1,host-b,1
+`)
+	leases, err := parseActiveLeases4(path, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("mixed-case header should parse, got error: %v", err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("want 1 active lease from mixed-case header, got %d: %+v", len(leases), leases)
+	}
+	if leases[0].Address != "10.0.0.10" || leases[0].HostName != "host-a" {
+		t.Fatalf("mixed-case columns resolved wrong: %+v", leases[0])
+	}
+	if leases[0].Identity != "mac:aa:bb:cc:dd:ee:01" {
+		t.Fatalf("identity from mixed-case header = %q", leases[0].Identity)
+	}
+}
+
 // ---- state store persistence ----
 
 func TestStateStorePersistsAndReloads(t *testing.T) {

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -1276,6 +1276,131 @@ func TestParseActiveLeasesEmptyFileIsUntrusted(t *testing.T) {
 	})
 }
 
+// TestParseActiveLeasesDuplicateColumnErrors proves the Codex-r5 MAJOR: a
+// header with a DUPLICATED column name is AMBIGUOUS — building cols would
+// overwrite the earlier index with the last occurrence, so cols[name] could
+// point at the wrong/empty column → leases read empty/wrong → wrong desired
+// set → the destructive pass deletes owned records. A healthy Kea header has
+// all-unique column names, so the parser rejects ANY duplicate column (not
+// just duplicate required columns) BEFORE any lookup. Against the pre-fix code
+// the duplicate silently overwrites and parsing proceeds (no error), so these
+// assertions fail.
+func TestParseActiveLeasesDuplicateColumnErrors(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	t.Run("duplicate required column (two address) errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		// Two "address" columns; the second (empty) would win under overwrite.
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state,address
+10.0.0.10,aa,,3600,1900000000,1,host-a,0,
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("duplicate 'address' column must error (ambiguous header)")
+		}
+	})
+
+	t.Run("duplicate required column (two state) errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state,state
+10.0.0.10,aa,,3600,1900000000,1,host-a,0,2
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("duplicate 'state' column must error (ambiguous header)")
+		}
+	})
+
+	t.Run("duplicate case-insensitive (Address + address) errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		writeCSV(t, path, `Address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state,ADDRESS
+10.0.0.10,aa,,3600,1900000000,1,host-a,0,
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("case-insensitive duplicate 'address' columns must error")
+		}
+	})
+
+	t.Run("duplicate optional column also errors (reject ANY duplicate)", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		// subnet_id is OPTIONAL, but a duplicate makes the header ambiguous,
+		// so we reject ANY duplicate column name (not just required ones).
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state,subnet_id
+10.0.0.10,aa,,3600,1900000000,1,host-a,0,2
+`)
+		if _, err := parseActiveLeases4(path, now); err == nil {
+			t.Fatal("duplicate optional column must error (any duplicate => ambiguous)")
+		}
+	})
+
+	t.Run("v6 duplicate identity column errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l6.csv")
+		writeCSV(t, path, `address,duid,valid_lifetime,expire,subnet_id,iaid,hostname,state,duid
+2001:db8::5,00:01,3600,1900000000,1,7,host-6,0,bad
+`)
+		if _, err := parseActiveLeases6(path, now); err == nil {
+			t.Fatal("v6 duplicate 'duid' column must error")
+		}
+	})
+
+	// End to end: a duplicated required column must NOT mass-delete owned
+	// records (the same destructive vector, duplicate-column trigger).
+	t.Run("duplicate column does not mass-delete via Reconcile", func(t *testing.T) {
+		assertReconcilePreservesOwnedRow(t, 4,
+			"address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state",
+			"10.0.0.10,aa,,3600,1900000000,1,host-a,0",
+			"address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state,address", // dup address
+			"10.0.0.10,aa,,3600,1900000000,1,host-a,0,",
+			"mac:aa", "10.0.0.10")
+	})
+}
+
+// TestParseActiveLeasesExtraAndReorderedColumnsTolerated proves the deliberate
+// boundary: extra/unknown columns and a reordered header are TOLERATED (parse
+// succeeds) because lookups are by name, not position. Only ambiguity
+// (duplicate) and missing required columns are errors. This documents that the
+// duplicate rejection does not over-broadly reject healthy-but-unusual headers.
+func TestParseActiveLeasesExtraAndReorderedColumnsTolerated(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	t.Run("extra unknown column tolerated", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		writeCSV(t, path, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state,user_context,pool_id
+10.0.0.10,aa,,3600,1900000000,1,host-a,0,{},5
+`)
+		leases, err := parseActiveLeases4(path, now)
+		if err != nil {
+			t.Fatalf("extra columns should be tolerated, got error: %v", err)
+		}
+		if len(leases) != 1 || leases[0].HostName != "host-a" {
+			t.Fatalf("extra-column lease parsed wrong: %+v", leases)
+		}
+	})
+
+	t.Run("reordered columns tolerated", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l4.csv")
+		// Columns in a non-standard order; resolved by name.
+		writeCSV(t, path, `state,hostname,address,client_id,hwaddr,expire,subnet_id
+0,host-a,10.0.0.10,01cafe,aa,1900000000,1
+`)
+		leases, err := parseActiveLeases4(path, now)
+		if err != nil {
+			t.Fatalf("reordered columns should be tolerated, got error: %v", err)
+		}
+		if len(leases) != 1 || leases[0].Address != "10.0.0.10" ||
+			leases[0].HostName != "host-a" || leases[0].Identity != "cid:01cafe" {
+			t.Fatalf("reordered-column lease parsed wrong: %+v", leases)
+		}
+	})
+}
+
+// ---- state store persistence ----
+
 // ---- state store persistence ----
 
 func TestStateStorePersistsAndReloads(t *testing.T) {

--- a/pkg/dhcpserver/ddns_test.go
+++ b/pkg/dhcpserver/ddns_test.go
@@ -1514,6 +1514,43 @@ func TestStateStoreCorruptResetsEmptyFailOpen(t *testing.T) {
 	}
 }
 
+// TestStateStoreUnsupportedVersionFailsOpen proves the Copilot robustness
+// fix: a state file with an unknown (future) non-zero Version is treated
+// like a corrupt store — fail-open to an EMPTY store + surface an error (so
+// the caller warns), rather than silently decoding records that may carry a
+// different tuple shape into wrong-tuple deletes. No panic. Against the
+// pre-fix loader (which never checked Version) the records load and would be
+// trusted, so this test fails pre-fix.
+func TestStateStoreUnsupportedVersionFailsOpen(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	// A syntactically-valid state file from a FUTURE format version, with a
+	// record. The current loader must NOT trust it.
+	writeCSV(t, statePath, `{"version":99,"records":[{"family":4,"identity":"mac:aa","address":"10.0.0.10","fqdn":"h.example.com","forward_type":"A","ptr_name":"10.0.0.10.in-addr.arpa","ttl":300}]}`)
+	s, err := loadDDNSState(statePath)
+	if err == nil {
+		t.Fatal("expected an error for an unsupported state version")
+	}
+	if s == nil {
+		t.Fatal("loadDDNSState returned nil store on unsupported version (must be empty store)")
+	}
+	if len(s.records) != 0 {
+		t.Fatalf("unsupported version must reset to empty (no wrong-tuple records), got %d records", len(s.records))
+	}
+
+	// A version-0 (pre-versioning / zero-value) file is tolerated and its
+	// records load — the field was absent or defaulted, not a future format.
+	v0path := filepath.Join(dir, "state-v0.json")
+	writeCSV(t, v0path, `{"records":[{"family":4,"identity":"mac:bb","address":"10.0.0.20","fqdn":"h2.example.com","forward_type":"A","ptr_name":"20.0.0.10.in-addr.arpa","ttl":300}]}`)
+	s0, err := loadDDNSState(v0path)
+	if err != nil {
+		t.Fatalf("version-0 store must load, got error: %v", err)
+	}
+	if _, ok := s0.get("mac:bb", "10.0.0.20"); !ok {
+		t.Fatal("version-0 store should load its records")
+	}
+}
+
 func equalStr(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## #1387 — DHCP server dynamic DNS (DDNS), increment 1

Implements the **first shippable increment** of #1387 per the approved
research plan (`docs/research/1387-dhcp-ddns/plan.md`, **recommended Path C**:
a pluggable `DNSUpdater` backend, RFC 2136 first). This is a multi-increment
feature; this PR is the **config model + the fully unit-testable reconciler
core** — no live DNS emission, no HA wiring, no daemon loop. **Default OFF;
an absent `dynamic-dns` block is byte-for-byte today's behaviour.**

### What this PR ships (the lab-free, fully-tested slice)

- **Config model** — `config.DHCPDynamicDNSConfig`, a nilable field on
  `DHCPServerConfig` (nil == disabled). `String()` redacts `TSIGSecret`.
  `compileDHCPDynamicDNS` handles **both** the hierarchical and flat-set AST
  shapes; an empty/garbage block compiles to nil.
- **Typed schema leaves** under `dhcp-local-server` / `dhcpv6-local-server`:
  `enable`, `ttl` (`ValidateIntegerMin(1)`), `hostname-source` /
  `conflict-policy` / `backend` (`ValidateEnum`). `domain` / `update-server` /
  `tsig-*` stay free-form (the live backend that constrains them is
  increment 2; `tsig-secret` is redacted in `show`/marshal echoes).
- **State-aware Kea lease parser** (`parseActiveLeases4/6`) — honors Kea's
  `state` column (default/declined/expired-reclaimed) and the `expire` epoch,
  and extracts the v6 DUID/IAID identity. **Separate** from the display-only
  `parseLeaseCSV` (reusing that would publish/retain stale records — the exact
  bug this feature fixes).
- **`DNSUpdater` interface** + pure record/PTR construction. PTR names are
  built from the **textual** address (reversed octets/nibbles), not the
  dataplane native-endian `__be32` convention.
- **Reconciler core** (`DDNSManager.reconcileOnceLocked`) — build-desired /
  diff-owned / add-move-reassign-expire transitions, cleaning the old owner
  before the new one; bounded retry that never wedges the loop;
  withdraw-all-on-disable; `Stats()` counters.
- **Ownership state store** (JSON via `fsatomic.WriteFileDurable`) — the
  **never-delete-a-record-xpf-did-not-create** protection boundary:
  `deleteOwnedLocked` re-derives the exact `(name, type, address)` from the
  store and is the sole delete authority. A corrupt store **fails open**.

### Deliberately deferred (see plan §12 and `pkg/dhcpserver/README.md`)

- **Increment 2 (lab-gated):** the live `rfc2136` `DNSUpdater` backend +
  the daemon reconcile loop + `show ... dynamic-dns` CLI/gRPC plumbing +
  Prometheus emission. (The API collector is a **checked** collector — a
  declared descriptor must be emitted or the descriptor-coverage canary
  fails — so DDNS counters live in `DDNSManager.Stats()` until a value
  source on the server exists.)
- **Increment 3 (`make test-failover`-gated):** HA per-RG MASTER/BACKUP
  ownership coupling. The deterministic owner-id watermark is laid down now
  so the state store is forward-compatible.
- **Increment 4:** the Kea D2 backend (reserved `backend kea-d2` enum;
  D2 is not in the image).

### Tests (all pass; `go test ./...` green)

- `pkg/config/compiler_dhcp_ddns_test.go` — dual-AST compile equality
  (hierarchical vs flat-set), absent-default-nil, TSIG redaction, schema
  enum/ttl accept+reject.
- `pkg/dhcpserver/ddns_test.go` (20 tests, all through a `fakeUpdater`,
  zero network/DNS) — hostname normalization, PTR byte-order, the
  state-aware parser (state/expiry/last-row-wins, v4 client-id preference,
  v6 DUID/IAID), reconciler transitions (add/idempotent/expire/move/
  reassign), the **never-delete-non-owned** boundary, retry-no-wedge,
  skip-unnamed, withdraw-on-disable, state-store persist/corrupt-reset.

The reassign and never-delete-non-owned tests are non-tautological: they
fail if the clean-old-owner-before-add ordering or the store-is-sole-delete-
authority boundary is broken.

### Lab gate

**None for this increment** (control-plane only; unit tests + render/parser
assertions). The live rfc2136 backend in increment 2 will need a throwaway
authoritative BIND/Knot + TSIG fixture — that does not exist in CI yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
