### PR TITLE
#2033: serialize RA goodbye-withdraw with sender shutdown

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -82,6 +82,45 @@
   scripts/image/bake.py, scripts/image/validate.py,
   docs/install-images.md, docs/image-validation.md
 
+## 2026-06-19 — #2033 Codex re-review: two graceful-goodbye MAJORs (dead sender + restart window)
+
+- **Timestamp**: 2026-06-19
+- **Action**: Rebased fix/2033 onto current origin/master (e33b401ef). Fixed
+  two remaining graceful-goodbye MAJORs. ROOT CAUSE: once a sender has run
+  `finishShutdown` (read modeHard, emitted no goodbye, exited), it is DEAD —
+  `signalStop(modeGraceful)` cannot resurrect it. So `claimGracefulLocked`'s
+  upgrade is a no-op on a dead sender and the goodbye was dropped. Decoupled
+  the goodbye guarantee from the live-sender lifecycle: added
+  `sender.goodbyeEmitted atomic.Bool` set in `finishShutdown` BEFORE
+  `close(stopped)`; the manager checks it after the join and, if a graceful
+  withdrawal was intended but no goodbye went out, emits a STANDALONE goodbye
+  via `sendOneGoodbye` (the WithdrawOnce path). Replaced `joinDraining` with
+  `finishGraceful`; `claimGracefulLocked` now returns `gracefulTarget`s
+  capturing the sender pointer under m.mu (so the post-mortem read does not
+  depend on the draining-map entry surviving the restart loop's delete).
+  MAJOR 2 (Clear-first, sender already finished hard): standalone backstop.
+  NEW MAJOR (graceful Withdraw racing the changed-config restart stop-to-start
+  window): standalone backstop for the withdrawn interface; the restart still
+  aborts on the bumped epoch. Guarantees EXACTLY ONE goodbye per withdrawn
+  interface (owner's if the upgrade landed, else standalone; suppressed if the
+  owner already emitted one or a live sender re-claimed the interface) and
+  ZERO for a pure changed-config replace. Folded #2034's procfs-free
+  `ensureLinkLocal` on rebase.
+- **File(s)**: pkg/ra/sender.go, pkg/ra/ra.go, pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-06-19
+- **Action**: Added three non-tautological regression tests to
+  `pkg/ra/serialize_test.go` (fakeListen now tracks every conn per interface
+  for cross-conn goodbye accounting). `TestT7c` — Clear-first where the
+  sender finishes its hard stop before Withdraw runs (dead-sender upgrade is a
+  no-op) asserts a STANDALONE goodbye is still emitted; `TestT2b` — graceful
+  Withdraw racing the changed-config restart stop-to-start window asserts a
+  goodbye IS emitted and NO replacement starts; `TestT7d` — exactly-one
+  goodbye when the upgrade lands in time (no double goodbye). Mutation-
+  verified: a no-standalone mutant fails T7c+T2b; an always-standalone mutant
+  fails T7d (double goodbye).
+- **File(s)**: pkg/ra/serialize_test.go, _Log.md
+
 ## 2026-06-20 — #1993 FRR clear MAJOR fix: require LIVE forwarding, not just pins
 
 - **Timestamp**: 2026-06-20

--- a/_Log.md
+++ b/_Log.md
@@ -285,6 +285,46 @@
   pkg/config/inactive_test.go, pkg/config/README.md, docs/config-schema.md,
   docs/feature-gaps.md, _Log.md
 
+## 2026-06-19 — #2033 serialize RA goodbye-withdraw with sender shutdown
+
+- **Timestamp**: 2026-06-19
+- **Action**: Path A single-owner RA refactor. Rewrote `sender.go` so the
+  per-interface `run()` goroutine is the sole writer/closer of the NDP
+  conn: added an `ndpConn` compile-time seam (mdlayher/ndp v1.1.0
+  signatures — `ndp.Message`/`*ipv6.ControlMessage`/`netip.Addr`),
+  `shutdownMode` (hard/graceful) published before a `sync.Once`-guarded
+  `close(stopCh)`, `finishShutdown` as the ONLY goodbye-emit + conn-close
+  site (graceful upgrades hard, owner closes after the goodbye),
+  interruptible startup/re-burst via `burstCh`, bounded writes
+  (`SetWriteDeadline`), `rsReceiver` error backoff, `lastRA` under
+  `lastRAMu` (W4 race fix), and a no-link-toggle `sendGoodbyeStandalone`
+  for `WithdrawOnce`. Rewrote `ra.go` with a draining-tombstone manager
+  (`m.draining` + `epoch`): `Withdraw`/`WithdrawInterfaces`/`Clear` move
+  senders to a tombstone under `m.mu` then join outside the lock; `Apply`
+  defers + epoch-guards interfaces blocked by a tombstone; `WithdrawOnce`
+  claims via the tombstone; `ResendBurst` goes through the owner.
+  Added a `State` field to `SenderInfo` ("active"/"draining"). Updated the
+  grpcapi show-RA text formatter to surface the draining state.
+- **File(s)**: pkg/ra/sender.go, pkg/ra/ra.go,
+  pkg/grpcapi/server_show_interfaces_text.go, _Log.md
+
+- **Timestamp**: 2026-06-19
+- **Action**: Added `pkg/ra/serialize_test.go`: a `fakeConn` recorder/
+  injector behind the `ndpConn` seam plus T1 (forced RS interleave) and
+  T1b ordering proofs of "no lifetime>0 RA after the first goodbye"; a
+  non-tautological negative arm; a `<=1 live conn per interface` tombstone
+  invariant (serial + concurrent Apply/Withdraw/WithdrawOnce/ResendBurst);
+  T3 (WithdrawOnce goodbye-only, no burst, no link toggle), T4a, T5, T6,
+  T7 (graceful-upgrades-hard, both orderings), T9, and a Status-draining
+  test. Mutation-verified: a normal-RA-after-goodbye mutant fails T1/T1b;
+  a missing-tombstone mutant trips the live-conn invariant.
+- **File(s)**: pkg/ra/serialize_test.go, _Log.md
+
+- **Timestamp**: 2026-06-19
+- **Action**: Documented the single-owner + draining-tombstone shutdown
+  contract and the Status "draining" state in the module README.
+- **File(s)**: pkg/ra/README.md, _Log.md
+
 ## 2026-06-19 — #2000 review follow-up on postinst test harness
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -81,6 +81,40 @@
   scripts/image/xpf-grow-root.service, scripts/image/test-grow-root.sh,
   scripts/image/bake.py, scripts/image/validate.py,
   docs/install-images.md, docs/image-validation.md
+## 2026-06-19 — #2033 Codex round-5: replacement decision atomic under the act-lock
+
+- **Timestamp**: 2026-06-19
+- **Action**: Fixed the last check-then-act in releaseDrain. It computed
+  `startReplacement` (epoch unchanged AND !goodbyeWanted) under the first lock,
+  UNLOCKED (to join/emit), then RE-LOCKED and acted on the STALE boolean — a
+  concurrent Withdraw/Clear in the gap (bump epoch / flip goodbyeWanted) was
+  ignored, re-arming RA after a newer withdraw/clear. Fix: re-evaluate the
+  decision against the LIVE tombstone UNDER the act-lock with fresh state — no
+  cached boolean. Restructured releaseDrain into a short loop: the only unlock
+  is for the blocking standalone emit (after claiming goodbyeClaimed once); the
+  loop re-acquires and re-reads epoch + goodbyeWanted before the
+  replacement decision+act, all under one lock hold. goodbyeWanted is monotonic
+  (false→true) and epoch monotonic, so a "start" observed under the act-lock
+  cannot be invalidated while held; a late Withdraw that flips goodbyeWanted in
+  the emit gap is caught on the re-lock (suppresses replace, emits the owed
+  goodbye). Documented the pre-existing startLocked-under-m.mu blocking cost in
+  the README (not a correctness issue; not introduced here).
+- **File(s)**: pkg/ra/ra.go, pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-06-19
+- **Action**: Added two round-5 regression tests (TestRound5_Withdraw... and
+  TestRound5_Clear...DuringRestartDecision...) that race a superseding
+  Withdraw/Clear against a restart releaseDrain and assert onProvenClose never
+  runs after a supersession is visible at the act moment (epoch advanced /
+  goodbyeWanted flipped). Mutation-verified non-tautological against a
+  gap-widened cached-boolean mutant (the exact pre-fix shape): both FAIL
+  ("replacement started despite supersession"). Also made TestT7c deterministic
+  — it drove Clear with two senders and depended on Clear's nondeterministic
+  per-interface release order (flaky on the pre-round-5 code too); rewrote it to
+  drive releaseDrain directly on a constructed dead-hard tombstone. Kept
+  Race1/Race3/Race2 + restart-timeout + T2a/T2b/T7b/T7d/T1 + ≤1-conn invariant.
+- **File(s)**: pkg/ra/serialize_test.go, _Log.md
+
 ## 2026-06-19 — #2033 Codex round-4: unify the changed-config restart through releaseDrain
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -81,6 +81,47 @@
   scripts/image/xpf-grow-root.service, scripts/image/test-grow-root.sh,
   scripts/image/bake.py, scripts/image/validate.py,
   docs/install-images.md, docs/image-validation.md
+## 2026-06-19 — #2033 Codex round-3: structural claim-and-hold for the goodbye
+
+- **Timestamp**: 2026-06-19
+- **Action**: Rebased onto current origin/master (e33b401ef). Replaced the
+  ad-hoc standalone-goodbye decision (which had three check-then-act /
+  happens-before races) with a STRUCTURAL fix: the draining tombstone is now a
+  `drainEntry{sender, cfg, goodbyeWanted, goodbyeClaimed}` (all fields under
+  `m.mu`) that is the single atomic claim-and-hold for the goodbye. Added one
+  `releaseDrain(name, sender)` exit path used by Withdraw (active-sender owner),
+  Clear (`clearLocked`), and Apply removal; the Apply changed-config restart has
+  an inline equivalent. It (1) JOINS the sender and reads `goodbyeEmitted` ONLY
+  on the `<-stopped` arm (race 2: timeout NEVER emits — owner may be live;
+  bounded writes make a timeout pathological), (2) under `m.mu` takes the
+  goodbye EXACTLY ONCE via `goodbyeClaimed` (race 1: concurrent Withdraws just
+  flip `goodbyeWanted`; one owner emits), (3) HOLDS the entry across the whole
+  standalone emit so a concurrent Apply DEFERS — no clobber, ≤1 live conn
+  (race 3: the tombstone is the mutual exclusion, no check-then-act on
+  `m.senders`). Removed `gracefulTarget`/`finishGraceful`/
+  `emitStandaloneGoodbye`; `claimGracefulLocked` now returns only the
+  interfaces THIS Withdraw owns the release for, and flips `goodbyeWanted` on
+  entries owned by a racing Clear/restart. `WithdrawOnce` pre-marks
+  `goodbyeClaimed` (it emits its own goodbye) and holds the entry across its
+  emit. `claimWaitTimeout` is now a package var (test seam). Net contract:
+  EXACTLY ONE goodbye per withdrawn interface, ZERO for a pure replace, never a
+  double, never a clobber.
+- **File(s)**: pkg/ra/ra.go, pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-06-19
+- **Action**: Added three round-3 race regression tests to
+  `pkg/ra/serialize_test.go` (fakeConn gains a `beforeClose` hook; fakeListen
+  tracks every conn per interface). `TestRace1` — concurrent Withdraws on the
+  same dead-hard tombstone → EXACTLY one goodbye (1 conn / goodbyeCount writes).
+  `TestRace3` — a concurrent Apply during the held standalone emit DEFERS (no
+  live sender, ≤1 conn) then proceeds after release. `TestRace2` — the join
+  timeout path emits NO standalone (drives `releaseDrain` with a wedged sender +
+  shortened `claimWaitTimeout`). Each is deterministic (drives `releaseDrain`
+  directly to avoid Clear's nondeterministic per-interface order) and
+  mutation-verified to FAIL against the matching pre-fix defect (no-claim-once →
+  double-send; tombstone-released-before-emit → clobber; emit-on-timeout →
+  goodbye on the wedged path). Kept T7c/T2b/T7d/T1/T2a/T7b + ≤1-conn invariant.
+- **File(s)**: pkg/ra/serialize_test.go, _Log.md
 
 ## 2026-06-19 — #2033 Codex re-review: two graceful-goodbye MAJORs (dead sender + restart window)
 

--- a/_Log.md
+++ b/_Log.md
@@ -81,6 +81,44 @@
   scripts/image/xpf-grow-root.service, scripts/image/test-grow-root.sh,
   scripts/image/bake.py, scripts/image/validate.py,
   docs/install-images.md, docs/image-validation.md
+## 2026-06-19 — #2033 Codex round-4: unify the changed-config restart through releaseDrain
+
+- **Timestamp**: 2026-06-19
+- **Action**: The round-3 `releaseDrain` discipline was correct, but the
+  changed-config restart kept a DIVERGENT inline copy of the stop-then-act
+  logic that re-introduced two of the exact bugs releaseDrain fixed: on a join
+  TIMEOUT it (MAJOR 1) still read `oldS.goodbyeEmitted` unordered and emitted a
+  standalone, and (MAJOR 2) fell through to `startLocked` while the old conn may
+  be live (2 live conns). Unified: `releaseDrain(name, s, startEpoch,
+  onProvenClose)` is now the SOLE "stop → emit-exactly-once → start-on-proven-
+  close → release" path, used by Withdraw/WithdrawInterfaces/Clear/Apply-removal
+  (onProvenClose=nil) AND the Apply changed-config restart (onProvenClose =
+  startLocked closure). The replacement opens ONLY on the proven-closed
+  (`<-stopped`) arm, under m.mu, tombstone held, and only if epoch unchanged AND
+  no goodbye wanted. On TIMEOUT it emits nothing, starts nothing, LEAVES the
+  tombstone held (so a future Apply defers, never 2 conns), and detaches
+  `reclaimTombstoneWhenStopped` to remove it once the wedged owner exits.
+  Deleted the inline restart block. Audited: no other stop-then-act path remains
+  (the only other `.stopped` join is the reclaim cleanup which never emits/
+  starts; `applyDeferred`'s startLocked runs only AFTER a tombstone is gone =
+  proven closed). `claimWaitTimeout` already a package-var seam.
+- **File(s)**: pkg/ra/ra.go, pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-06-19
+- **Action**: Added two round-4 restart-timeout regression tests to
+  `pkg/ra/serialize_test.go`. `TestRestartTimeoutNoGoodbyeNoReplacement` —
+  changed-config restart whose old sender WEDGES + a racing graceful Withdraw +
+  join timeout → asserts NO standalone goodbye AND no replacement started AND
+  tombstone left held (reclaimed after the owner exits).
+  `TestRestartTimeoutNoReplacementWhenNoGoodbye` — wedged restart timeout, no
+  goodbye wanted → asserts peak live-conn ≤ 1 (replacement never opens while the
+  old conn may be live). Both mutation-verified to FAIL against the old inline-
+  timeout fall-through (MAJOR 1 emits a goodbye; MAJOR 2 reaches peak 2 conns).
+  Updated TestRace2's assertion to the new timeout-leaves-tombstone-held +
+  reclaim-on-exit behavior. Kept Race1/Race3/Race2 + T7c/T2b/T7d/T1/T2a/T7b +
+  ≤1-conn invariant.
+- **File(s)**: pkg/ra/serialize_test.go, _Log.md
+
 ## 2026-06-19 — #2033 Codex round-3: structural claim-and-hold for the goodbye
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -145,6 +145,39 @@
   pkg/config/README.md, pkg/configstore/store.go,
   pkg/configstore/inactive_test.go, docs/config-schema.md, _Log.md
 
+## 2026-06-20 — #2033 Codex review: fix two manager-level coordination MAJORs
+
+- **Timestamp**: 2026-06-20
+- **Action**: Rebased fix/2033 onto current origin/master (folding #2034's
+  procfs-free `ensureLinkLocal` into the single-owner sender). Fixed two
+  Codex MAJORs in `pkg/ra/ra.go`. MAJOR 1: `Apply`'s changed-config path
+  opened the replacement NDP conn BEFORE stopping the old sender (two live
+  conns → a goodbye-after-normal-RA inversion). Now every remove/replace
+  installs a draining tombstone under `m.mu`, stops the old sender
+  (conn closed) OUTSIDE the lock, and only then opens the replacement
+  (epoch-guarded restart), so at no point are two conns live for one
+  interface. MAJOR 2: `Withdraw`/`WithdrawInterfaces` bumped the epoch then
+  UNLOCKED before claiming, letting a racing `Clear` install a hard
+  tombstone and drop the goodbye. Now the graceful intent
+  (tombstone + `signalStop(modeGraceful)`) is recorded atomically under the
+  same lock; `claimGracefulLocked` also UPGRADES an already-hard-draining
+  sender to graceful (the draining map now stores the `*sender`), and
+  `Withdraw` includes already-draining interfaces. `clearLocked` stores the
+  sender so a racing graceful Withdraw can upgrade it.
+- **File(s)**: pkg/ra/ra.go, pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-06-20
+- **Action**: Added two non-tautological regression tests to
+  `pkg/ra/serialize_test.go` (with `beforeClose`/`beforeWrite` fakeConn
+  hooks): `TestT2a_ChangedConfigApplyNeverTwoLiveConns` (holds the old
+  conn's close open and asserts the live-conn count never exceeds 1 across a
+  changed-config Apply — fails against start-new-before-stop-old) and
+  `TestT7b_ManagerHardFirstThenGracefulStillGoodbye` (parks the owner in its
+  burst, runs Clear-hard then Withdraw-graceful, asserts the goodbye is
+  still emitted — fails against the bump-then-unlock gap). Mutation-verified
+  both fail against the respective pre-fix code.
+- **File(s)**: pkg/ra/serialize_test.go, _Log.md
+
 ## 2026-06-20 — #2034 RA link-local review follow-up (regression test)
 
 - **Timestamp**: 2026-06-20

--- a/pkg/grpcapi/server_show_interfaces_text.go
+++ b/pkg/grpcapi/server_show_interfaces_text.go
@@ -346,9 +346,16 @@ func (s *Server) showIPv6RouterAdvertisement(cfg *config.Config, buf *strings.Bu
 		if len(senders) == 0 {
 			fmt.Fprintln(buf, "Router Advertisements: no active senders")
 		} else {
-			fmt.Fprintf(buf, "Router Advertisement: %d active sender(s)\n\n", len(senders))
+			fmt.Fprintf(buf, "Router Advertisement: %d sender(s)\n\n", len(senders))
 			for _, info := range senders {
 				fmt.Fprintf(buf, "Interface: %s\n", info.Interface)
+				if info.State == "draining" {
+					// A withdrawing router (emitting its lifetime-0 goodbye);
+					// no longer advertising. Report state and move on.
+					fmt.Fprintln(buf, "  State:              draining (withdrawing)")
+					fmt.Fprintln(buf)
+					continue
+				}
 				fmt.Fprintf(buf, "  Source address:     %s\n", info.SrcAddr)
 				fmt.Fprintf(buf, "  Router lifetime:    %ds\n", info.Lifetime)
 				fmt.Fprintf(buf, "  Preference:         %s\n", info.Preference)

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -23,22 +23,36 @@ after HA failover. To make that **structural**, not flag-defended:
   lifetime-zero goodbye as its FINAL write when the mode is graceful,
   then closes the conn. A normal RA can never follow the goodbye because
   the goodbye is emitted structurally after the loop.
-- **Graceful upgrades hard, even mid-drain.** In cluster mode RA
+- **Graceful upgrades hard, with a standalone-goodbye backstop (exactly one
+  goodbye per withdrawn interface).** In cluster mode RA
   `Apply`/`Withdraw`/`Clear` for the same sender are serialized ONLY by the
-  manager mutex (no `applySem`). A graceful withdraw therefore beats a
-  racing hard `Clear`: `signalStop` stores graceful unconditionally and
-  hard only via compare-and-swap from "none" — never a downgrade. The
-  manager records the graceful intent ATOMICALLY: `Withdraw`/
-  `WithdrawInterfaces` install the tombstone AND call
-  `signalStop(modeGraceful)` under the SAME lock that bumps the epoch and
-  snapshots the senders, so a racing `Clear` cannot slip a hard stop into a
-  gap. And if a `Clear` got there first (the sender is already draining
-  hard), a subsequent `Withdraw` finds it in the draining map and UPGRADES
-  it to graceful — the draining map therefore stores the `*sender` (not a
-  bare marker) so the still-running owner can be re-signalled. The
-  draining-map value is `nil` only for a `WithdrawOnce` claim (no owner to
-  upgrade). Because the owner closes the conn AFTER the goodbye, a racing
-  hard close cannot suppress it.
+  manager mutex (no `applySem`). A graceful withdraw beats a racing hard
+  `Clear`: `signalStop` stores graceful unconditionally and hard only via
+  compare-and-swap from "none" — never a downgrade. The manager records the
+  graceful intent ATOMICALLY: `Withdraw`/`WithdrawInterfaces` install the
+  tombstone AND call `signalStop(modeGraceful)` under the SAME lock that
+  bumps the epoch and snapshots, so a racing `Clear` cannot slip a hard stop
+  into a gap. If a `Clear` (or a changed-config restart) got there first, the
+  `Withdraw` finds the sender in the draining map and UPGRADES it to graceful
+  (the draining map stores the `*sender`, nil only for a `WithdrawOnce`
+  claim). BUT an "upgrade" only works while the owner is still alive — once a
+  sender has run `finishShutdown` (read modeHard, emitted no goodbye, exited)
+  it is DEAD and cannot be resurrected. So the withdrawal guarantee is
+  decoupled from the live-sender lifecycle: each `sender` records whether
+  `finishShutdown` actually emitted a goodbye (`goodbyeEmitted`), and after
+  the owner joins, the manager checks that fact. If a goodbye was owed (a
+  graceful withdrawal was intended) but the owner emitted none — it lost the
+  upgrade race, or it was already a stopped Clear / changed-config-restart
+  tombstone — the manager emits a STANDALONE goodbye via the WithdrawOnce
+  mechanism (`sendOneGoodbye`: open conn, 3× lifetime-0 RA, close; no burst,
+  no link toggle). This yields **exactly one goodbye per withdrawn
+  interface**: the owner's if the upgrade landed, otherwise a standalone; the
+  standalone is suppressed if the owner already emitted one
+  (`goodbyeEmitted`) or if a LIVE sender has since re-claimed the interface (a
+  new MASTER `Apply` won it back — do not clobber it with a lifetime-0 RA).
+  A pure changed-config replace (no withdraw) emits ZERO goodbyes (the router
+  is not going away). Because the owner closes the conn AFTER its goodbye, a
+  racing hard close cannot suppress it.
 - **Draining tombstone — one live conn per interface, including replaces.**
   Every transition that removes OR replaces a sender installs a
   per-interface DRAINING tombstone under the manager mutex BEFORE releasing

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -4,20 +4,81 @@ Embedded IPv6 Router Advertisement sender. Replaces external `radvd`
 with per-interface goroutines built on `mdlayher/ndp`. Handles startup
 burst, goodbye RAs, and re-burst recovery after RETH MAC link-cycle.
 
+## Shutdown contract (single-owner + draining tombstone, #2033)
+
+The lifetime-zero **goodbye** RA (router withdraw) MUST be the last RA on
+the wire for an interface — otherwise a host keeps a dead default route
+after HA failover. To make that **structural**, not flag-defended:
+
+- **Single-owner emission.** Per interface, exactly ONE goroutine
+  (`sender.run`) writes the NDP connection — startup burst, periodic RAs,
+  RS-triggered replies AND the goodbye. No other goroutine calls
+  `conn.WriteTo` or `conn.Close`. `ResendBurst` routes the re-burst
+  through the owner via a buffered `burstCh` (no second writer).
+- **Goodbye is owner-emitted on exit.** Shutdown is signalled via
+  `signalStop(mode)`: it publishes an atomic `shutdownMode`
+  (`hard`/`graceful`), then closes `stopCh` once (`sync.Once`). The owner
+  wakes, leaves the loop, and in `finishShutdown` (the ONLY place a
+  goodbye is sent and the ONLY place the conn is closed) emits the
+  lifetime-zero goodbye as its FINAL write when the mode is graceful,
+  then closes the conn. A normal RA can never follow the goodbye because
+  the goodbye is emitted structurally after the loop.
+- **Graceful upgrades hard.** In cluster mode RA `Apply`/`Withdraw`/`Clear`
+  for the same sender are serialized ONLY by the manager mutex (no
+  `applySem`). A graceful withdraw therefore beats a racing hard `Clear`:
+  `signalStop` stores graceful unconditionally and hard only via
+  compare-and-swap from "none" — never a downgrade. Because the owner
+  closes the conn AFTER the goodbye, a racing hard close cannot suppress
+  the goodbye.
+- **Draining tombstone.** `Withdraw`/`WithdrawInterfaces`/`Clear` move the
+  sender to a per-interface DRAINING tombstone under the manager mutex,
+  then join the owner OUTSIDE the lock (so multi-interface demotion does
+  not stall `Status`/`Apply` on the failover hot path). While the
+  tombstone is present the interface is NOT absent: a concurrent `Apply`
+  or `WithdrawOnce` treats it as a claim and defers — it never starts a
+  second NDP connection on the same interface. This guarantees **at most
+  one live NDP conn per interface** at any time (no `ndp.Listen`
+  collision, no goodbye-after-new-burst inversion).
+- **Deferred Apply is epoch-guarded.** A deferred `Apply` waiting for a
+  tombstone to clear captures the manager epoch; if a newer
+  `Withdraw`/`Clear`/`Apply` bumped the epoch in the interim, the deferred
+  start is aborted (it must not re-arm RA on a node that has since
+  transitioned to BACKUP).
+- **Bounded writes.** Every owner `WriteTo` sets a 1 s write deadline so a
+  stuck socket cannot wedge withdrawal; the owner always returns promptly,
+  which is what makes owner-performs-the-close safe for both modes.
+- **rsReceiver backoff.** The RS receiver polls with a read deadline and
+  backs off on a persistent non-deadline read error (so it cannot
+  hot-loop at 100% CPU if the interface dies while `stopCh` is still
+  open). It is a detached goroutine unblocked by the owner's `conn.Close`.
+
+`WithdrawOnce` (boot-as-secondary stale-route withdraw) uses a
+goodbye-ONLY path (`sendGoodbyeStandalone`) that never launches an owner
+or a startup burst (so it cannot re-advertise the router it withdraws)
+and never toggles the link (no `ensureLinkLocal` link-cycle on a demoting
+interface — if no usable link-local exists the goodbye is skipped
+best-effort).
+
 ## Entry points
 
 - `Manager` — `ra.go`.
 - `New()` — `ra.go`.
 - `Apply(configs []*config.RAInterfaceConfig) error` — `ra.go`.
-  Starts/stops per-interface senders.
-- `Withdraw() error` — `ra.go`. Stops every sender.
+  Starts/stops per-interface senders; defers + retries (epoch-guarded)
+  any interface that is currently draining.
+- `Withdraw() error` — `ra.go`. Graceful goodbye + stop on every sender.
 - `ResendBurst()` — `ra.go`. Re-sends the startup burst (used after a
-  link cycle) on every active sender.
-- `WithdrawInterfaces(names []string)` — `ra.go`. Stops senders by
-  interface name.
+  link cycle) on every active sender, via the owner goroutine.
+- `WithdrawInterfaces(names []string)` — `ra.go`. Graceful goodbye + stop
+  by interface name.
 - `WithdrawOnce(configs []*config.RAInterfaceConfig)` — `ra.go`.
-  Sends a single goodbye RA (lifetime=0) on each listed interface.
-- `Status()` — `ra.go`. Per-interface SenderInfo.
+  Goodbye-only (no burst, no link toggle); skips busy interfaces.
+- `Clear() error` — `ra.go`. Hard stop (no goodbye) of every sender.
+- `Status()` — `ra.go`. Per-interface `SenderInfo`. A running sender has
+  `State == "active"`; an interface whose sender is tearing down /
+  emitting its goodbye is reported with `State == "draining"` (distinct
+  from active, so a withdrawing router is neither read as still
+  advertising nor silently invisible).
 
 ## Callers
 
@@ -34,7 +95,9 @@ burst, goodbye RAs, and re-burst recovery after RETH MAC link-cycle.
   outage from the moment of the link cycle until the next periodic RA.
 - The goodbye RA carries router lifetime 0, telling hosts to drop this
   router as default gateway. Send one when explicitly withdrawing a zone
-  or shutting down.
+  or shutting down. It is emitted by the per-interface owner goroutine as
+  its last write (see the shutdown contract above) so a normal RA can
+  never follow it on the wire.
 - IPv6 NODAD is set on the per-instance NDP socket so it doesn't fight
   the kernel's own duplicate-address detection on the link-local
   address.

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -23,27 +23,39 @@ after HA failover. To make that **structural**, not flag-defended:
   lifetime-zero goodbye as its FINAL write when the mode is graceful,
   then closes the conn. A normal RA can never follow the goodbye because
   the goodbye is emitted structurally after the loop.
-- **Graceful upgrades hard.** In cluster mode RA `Apply`/`Withdraw`/`Clear`
-  for the same sender are serialized ONLY by the manager mutex (no
-  `applySem`). A graceful withdraw therefore beats a racing hard `Clear`:
-  `signalStop` stores graceful unconditionally and hard only via
-  compare-and-swap from "none" — never a downgrade. Because the owner
-  closes the conn AFTER the goodbye, a racing hard close cannot suppress
-  the goodbye.
-- **Draining tombstone.** `Withdraw`/`WithdrawInterfaces`/`Clear` move the
-  sender to a per-interface DRAINING tombstone under the manager mutex,
-  then join the owner OUTSIDE the lock (so multi-interface demotion does
-  not stall `Status`/`Apply` on the failover hot path). While the
-  tombstone is present the interface is NOT absent: a concurrent `Apply`
-  or `WithdrawOnce` treats it as a claim and defers — it never starts a
-  second NDP connection on the same interface. This guarantees **at most
-  one live NDP conn per interface** at any time (no `ndp.Listen`
-  collision, no goodbye-after-new-burst inversion).
-- **Deferred Apply is epoch-guarded.** A deferred `Apply` waiting for a
-  tombstone to clear captures the manager epoch; if a newer
-  `Withdraw`/`Clear`/`Apply` bumped the epoch in the interim, the deferred
-  start is aborted (it must not re-arm RA on a node that has since
-  transitioned to BACKUP).
+- **Graceful upgrades hard, even mid-drain.** In cluster mode RA
+  `Apply`/`Withdraw`/`Clear` for the same sender are serialized ONLY by the
+  manager mutex (no `applySem`). A graceful withdraw therefore beats a
+  racing hard `Clear`: `signalStop` stores graceful unconditionally and
+  hard only via compare-and-swap from "none" — never a downgrade. The
+  manager records the graceful intent ATOMICALLY: `Withdraw`/
+  `WithdrawInterfaces` install the tombstone AND call
+  `signalStop(modeGraceful)` under the SAME lock that bumps the epoch and
+  snapshots the senders, so a racing `Clear` cannot slip a hard stop into a
+  gap. And if a `Clear` got there first (the sender is already draining
+  hard), a subsequent `Withdraw` finds it in the draining map and UPGRADES
+  it to graceful — the draining map therefore stores the `*sender` (not a
+  bare marker) so the still-running owner can be re-signalled. The
+  draining-map value is `nil` only for a `WithdrawOnce` claim (no owner to
+  upgrade). Because the owner closes the conn AFTER the goodbye, a racing
+  hard close cannot suppress it.
+- **Draining tombstone — one live conn per interface, including replaces.**
+  Every transition that removes OR replaces a sender installs a
+  per-interface DRAINING tombstone under the manager mutex BEFORE releasing
+  it, stops the old sender (closing its conn) OUTSIDE the lock, and only
+  THEN opens any replacement conn. A changed-config `Apply` is a hard
+  replace (no goodbye — the router is not going away) but still goes
+  stop-old → start-new with the tombstone covering the whole window — it
+  never opens the replacement while the old conn is live. While the
+  tombstone is present the interface is NOT absent: a concurrent `Apply` or
+  `WithdrawOnce` treats it as a claim and defers. This guarantees **at most
+  one live NDP conn per interface** at any time (no `ndp.Listen` collision,
+  no goodbye-after-new-burst inversion).
+- **Deferred / restart Apply is epoch-guarded.** An `Apply` start that
+  waits behind a tombstone (a pre-existing drain, or its own changed-config
+  stop) captures the manager epoch; if a newer `Withdraw`/`Clear`/`Apply`
+  bumped the epoch in the interim, the deferred/restart start is aborted
+  (it must not re-arm RA on a node that has since transitioned to BACKUP).
 - **Bounded writes.** Every owner `WriteTo` sets a 1 s write deadline so a
   stuck socket cannot wedge withdrawal; the owner always returns promptly,
   which is what makes owner-performs-the-close safe for both modes.

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -82,10 +82,27 @@ after HA failover. To make that **structural**, not flag-defended:
   removal and the changed-config **restart**) all route through it. The restart
   passes an `onProvenClose` callback that opens the replacement conn — it runs
   ONLY on the proven-closed (`<-stopped`) arm, under `m.mu`, with the tombstone
-  still held, and only if no graceful withdraw superseded the replace (epoch
-  unchanged AND no goodbye wanted). There is no divergent inline copy of these
-  rules, so the timeout / happens-before / ≤1-conn class cannot reappear in a
-  third path.
+  still held, and only if no graceful withdraw superseded the replace. There is
+  no divergent inline copy of these rules, so the timeout / happens-before /
+  ≤1-conn class cannot reappear in a third path.
+- **Replacement decision is atomic under the act-lock (round-5).** The
+  "start the replacement?" test (epoch still `startEpoch` AND `!goodbyeWanted`)
+  is re-evaluated against the LIVE tombstone under the SAME lock hold that
+  performs the start — never a boolean computed before an unlock and trusted
+  after. `goodbyeWanted` is monotonic (false→true) and `epoch` only increases,
+  so a "start" decision observed under the act-lock cannot be invalidated while
+  the lock is held; a racing `Withdraw`/`Clear` that lands before the act-lock
+  is seen (decision aborts, the withdraw's goodbye is emitted), and one that
+  lands after is harmless (no supersession existed at the act moment). The only
+  unlock inside `releaseDrain` is for the blocking standalone-goodbye send; the
+  loop re-acquires and re-evaluates fresh state before touching the replacement.
+  NOTE: `onProvenClose` calls `startLocked`, which does blocking setup
+  (`InterfaceByName`, link-local add, `ndp.Listen` with retry) UNDER `m.mu` —
+  this can hold the manager mutex for up to ~2s and is pre-existing (plain
+  `Apply` also calls `startLocked` under `m.mu`). It is a known cost, not a
+  correctness issue; the tombstone (held) is what provides mutual exclusion, so
+  moving the start just after the unlock is possible but was left as-is to avoid
+  reintroducing a check-then-act.
 - **Draining tombstone — one live conn per interface, including replaces.**
   Every transition that removes OR replaces a sender installs a
   per-interface DRAINING tombstone under the manager mutex BEFORE releasing

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -23,36 +23,52 @@ after HA failover. To make that **structural**, not flag-defended:
   lifetime-zero goodbye as its FINAL write when the mode is graceful,
   then closes the conn. A normal RA can never follow the goodbye because
   the goodbye is emitted structurally after the loop.
-- **Graceful upgrades hard, with a standalone-goodbye backstop (exactly one
-  goodbye per withdrawn interface).** In cluster mode RA
+- **The draining tombstone is the single atomic claim-and-hold for the
+  goodbye (exactly one per withdrawn interface).** In cluster mode RA
   `Apply`/`Withdraw`/`Clear` for the same sender are serialized ONLY by the
-  manager mutex (no `applySem`). A graceful withdraw beats a racing hard
-  `Clear`: `signalStop` stores graceful unconditionally and hard only via
-  compare-and-swap from "none" — never a downgrade. The manager records the
-  graceful intent ATOMICALLY: `Withdraw`/`WithdrawInterfaces` install the
-  tombstone AND call `signalStop(modeGraceful)` under the SAME lock that
-  bumps the epoch and snapshots, so a racing `Clear` cannot slip a hard stop
-  into a gap. If a `Clear` (or a changed-config restart) got there first, the
-  `Withdraw` finds the sender in the draining map and UPGRADES it to graceful
-  (the draining map stores the `*sender`, nil only for a `WithdrawOnce`
-  claim). BUT an "upgrade" only works while the owner is still alive — once a
-  sender has run `finishShutdown` (read modeHard, emitted no goodbye, exited)
-  it is DEAD and cannot be resurrected. So the withdrawal guarantee is
-  decoupled from the live-sender lifecycle: each `sender` records whether
-  `finishShutdown` actually emitted a goodbye (`goodbyeEmitted`), and after
-  the owner joins, the manager checks that fact. If a goodbye was owed (a
-  graceful withdrawal was intended) but the owner emitted none — it lost the
-  upgrade race, or it was already a stopped Clear / changed-config-restart
-  tombstone — the manager emits a STANDALONE goodbye via the WithdrawOnce
-  mechanism (`sendOneGoodbye`: open conn, 3× lifetime-0 RA, close; no burst,
-  no link toggle). This yields **exactly one goodbye per withdrawn
-  interface**: the owner's if the upgrade landed, otherwise a standalone; the
-  standalone is suppressed if the owner already emitted one
-  (`goodbyeEmitted`) or if a LIVE sender has since re-claimed the interface (a
-  new MASTER `Apply` won it back — do not clobber it with a lifetime-0 RA).
-  A pure changed-config replace (no withdraw) emits ZERO goodbyes (the router
-  is not going away). Because the owner closes the conn AFTER its goodbye, a
-  racing hard close cannot suppress it.
+  manager mutex (no `applySem`). Each draining interface has ONE `drainEntry`
+  in `m.draining` (all fields read/written only under `m.mu`), owned by
+  exactly ONE goroutine — the one that joins its sender (or the
+  `WithdrawOnce`/standalone claimant). That single owner is the SOLE emitter
+  of any standalone goodbye and HOLDS the entry across the whole emit. This
+  makes "this interface owes a goodbye" a state CLAIMED ONCE and HELD, so
+  there is no check-then-act anywhere:
+    - **Graceful intent is atomic.** A graceful withdraw beats a racing hard
+      `Clear`: `signalStop` stores graceful unconditionally and hard only via
+      compare-and-swap from "none" — never a downgrade. `Withdraw`/
+      `WithdrawInterfaces` install the entry (active-sender case) or flip
+      `goodbyeWanted` on an existing one, AND `signalStop(modeGraceful)`,
+      under the SAME lock that bumps the epoch — a racing `Clear` cannot slip
+      a hard stop into a gap.
+    - **An upgrade only works while the owner is alive.** Once a sender has
+      run `finishShutdown` (read modeHard, emitted no goodbye, exited) it is
+      DEAD and cannot be resurrected. So the guarantee is decoupled from the
+      live-sender lifecycle: each `sender` records `goodbyeEmitted` (set in
+      `finishShutdown` before `close(stopped)`). The entry's single owner, in
+      `releaseDrain`, JOINS the sender (`<-stopped`, which orders the
+      `goodbyeEmitted` read) and then, UNDER `m.mu`, takes the goodbye
+      EXACTLY ONCE (`!goodbyeClaimed` → set it) if one is wanted and the
+      owner emitted none.
+    - **Claim-once (closes the concurrent-Withdraw double-send):** only the
+      one owner releases the entry; concurrent Withdraws merely flip
+      `goodbyeWanted`. `goodbyeClaimed` under `m.mu` ensures a single emit.
+    - **Held-across-emit (closes the live-sender clobber):** the owner keeps
+      the entry in `m.draining` for the ENTIRE standalone emit (open conn → 3×
+      lifetime-0 RA → close), removing it only afterward. A concurrent `Apply`
+      sees the tombstone and DEFERS — no new sender starts during the emit, so
+      the standalone never clobbers a re-claimed master and ≤1 live conn holds.
+      The tombstone IS the mutual exclusion; there is no separate check-then-act
+      on `m.senders`.
+    - **Timeout never emits (closes the happens-before break):** `releaseDrain`
+      reads `goodbyeEmitted` ONLY after a successful `<-stopped`. If the join
+      times out (`claimWaitTimeout` — pathological, since owner writes are
+      bounded by `SetWriteDeadline`), it logs and does NOT emit a standalone
+      (the owner may still be live; the read would be unordered). We accept a
+      theoretical dropped goodbye on a wedged owner over a double-send/clobber.
+  Net: EXACTLY ONE goodbye per withdrawn interface — the owner's if the
+  upgrade landed, otherwise one standalone — and ZERO for a pure changed-config
+  replace. Because the owner closes the conn AFTER its goodbye, a racing hard
+  close cannot suppress it.
 - **Draining tombstone — one live conn per interface, including replaces.**
   Every transition that removes OR replaces a sender installs a
   per-interface DRAINING tombstone under the manager mutex BEFORE releasing

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -59,16 +59,33 @@ after HA failover. To make that **structural**, not flag-defended:
       the standalone never clobbers a re-claimed master and ≤1 live conn holds.
       The tombstone IS the mutual exclusion; there is no separate check-then-act
       on `m.senders`.
-    - **Timeout never emits (closes the happens-before break):** `releaseDrain`
-      reads `goodbyeEmitted` ONLY after a successful `<-stopped`. If the join
-      times out (`claimWaitTimeout` — pathological, since owner writes are
-      bounded by `SetWriteDeadline`), it logs and does NOT emit a standalone
-      (the owner may still be live; the read would be unordered). We accept a
-      theoretical dropped goodbye on a wedged owner over a double-send/clobber.
+    - **Timeout never emits AND never starts a replacement (closes the
+      happens-before break AND the ≤1-conn break on the restart path):**
+      `releaseDrain` reads `goodbyeEmitted` ONLY after a successful `<-stopped`.
+      If the join times out (`claimWaitTimeout` — pathological, since owner
+      writes are bounded by `SetWriteDeadline`), it does NOT emit a standalone
+      (the read would be unordered; the owner may be live) AND does NOT start
+      the changed-config replacement (the old conn may still be live → would
+      break ≤1-conn). It LEAVES the tombstone held — so any future
+      `Apply`/reconcile defers, never opening a second conn — and detaches a
+      reclaimer that removes the tombstone once the wedged owner finally exits.
+      The safe degraded state is "old sender lingers, no replacement, tombstone
+      held," never two conns and never an unordered emit.
   Net: EXACTLY ONE goodbye per withdrawn interface — the owner's if the
   upgrade landed, otherwise one standalone — and ZERO for a pure changed-config
   replace. Because the owner closes the conn AFTER its goodbye, a racing hard
   close cannot suppress it.
+- **Single stop-then-act path (round-4 unification).** `releaseDrain` is the
+  SOLE owner of "stop the old sender (join-or-timeout) → optionally emit
+  exactly-once → optionally start a replacement on PROVEN-close → release
+  tombstone." `Withdraw`, `WithdrawInterfaces`, `Clear` and `Apply` (both the
+  removal and the changed-config **restart**) all route through it. The restart
+  passes an `onProvenClose` callback that opens the replacement conn — it runs
+  ONLY on the proven-closed (`<-stopped`) arm, under `m.mu`, with the tombstone
+  still held, and only if no graceful withdraw superseded the replace (epoch
+  unchanged AND no goodbye wanted). There is no divergent inline copy of these
+  rules, so the timeout / happens-before / ≤1-conn class cannot reappear in a
+  third path.
 - **Draining tombstone — one live conn per interface, including replaces.**
   Every transition that removes OR replaces a sender installs a
   per-interface DRAINING tombstone under the manager mutex BEFORE releasing

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -37,11 +37,16 @@ type Manager struct {
 	senders map[string]*sender // active senders, keyed by Linux interface name
 
 	// draining holds interfaces whose senders are tearing down (graceful
-	// withdraw or hard stop). The entry is a tombstone: while present, the
-	// interface is NOT absent — a concurrent Apply/WithdrawOnce must treat it
-	// as a claim and defer rather than start a new sender (#2033 I16). It is
-	// removed once the sender's goroutine has joined.
-	draining map[string]struct{}
+	// withdraw or hard stop) or are otherwise claimed (a WithdrawOnce goodbye,
+	// or an Apply restart between stop-old and start-new). The entry is a
+	// tombstone: while present, the interface is NOT absent — a concurrent
+	// Apply/WithdrawOnce must treat it as a claim and defer rather than start a
+	// new sender (#2033 I16). The value is the draining *sender when one exists
+	// (so a later graceful Withdraw can UPGRADE a still-draining hard stop to
+	// emit a goodbye — #2033 MAJOR 2), or nil for a claim with no live sender
+	// (WithdrawOnce, or after the sender has joined). It is removed once the
+	// sender's goroutine has joined.
+	draining map[string]*sender
 
 	// epoch is bumped on every state-mutating call (Apply, Withdraw,
 	// WithdrawInterfaces, WithdrawOnce, Clear). A deferred Apply captures the
@@ -55,7 +60,7 @@ type Manager struct {
 func New() *Manager {
 	return &Manager{
 		senders:  make(map[string]*sender),
-		draining: make(map[string]struct{}),
+		draining: make(map[string]*sender),
 	}
 }
 
@@ -75,9 +80,18 @@ func (m *Manager) interfaceBusy(name string) bool {
 // Apply diffs the current senders against the desired set and starts/stops/
 // updates as needed. Unchanged configs are left running without RA gap.
 //
-// Interfaces that are currently DRAINING (a graceful withdraw or hard stop is
-// in flight, or a WithdrawOnce goodbye holds a claim) are NOT started in this
-// pass — that would race a second NDP connection against the one tearing down.
+// INVARIANT (#2033 MAJOR 1): at no point are two live NDP conns present for one
+// interface. Every transition that replaces or removes a sender installs a
+// draining tombstone for that interface BEFORE releasing m.mu and stops the old
+// sender (closing its conn) BEFORE any replacement conn is opened. The
+// tombstone covers the whole stop→start window, so a concurrent
+// Apply/Withdraw/WithdrawOnce that sees it defers instead of opening a second
+// conn. A CHANGED config is a hard replace (no goodbye — the router is not
+// going away); a REMOVED config is a hard stop (no goodbye).
+//
+// Interfaces that are ALREADY draining when this Apply runs (a prior
+// withdraw/stop or a WithdrawOnce claim still tearing down) are NOT started in
+// this pass — that would race a second conn against the one tearing down.
 // Instead they are deferred: Apply releases m.mu, waits (bounded) for the
 // tombstone to clear, then re-acquires m.mu and starts them — but ONLY if the
 // manager epoch has not changed in the meantime (a newer Withdraw/Clear would
@@ -99,35 +113,58 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 		desired[cfg.Interface] = cfg
 	}
 
+	// A pending stop. tomb=true means a tombstone was installed for the
+	// interface and must be cleared after the join (removal) or after the
+	// replacement starts (restart).
+	type stopReq struct {
+		name string
+		s    *sender
+	}
+	var toStop []stopReq
+
 	// Remove senders not in the desired set (hard stop, no goodbye — a config
-	// change must not blackhole hosts).
-	var toStop []*sender
+	// change must not blackhole hosts). Install a tombstone so a concurrent
+	// WithdrawOnce/Apply does not start a sender on the same interface while the
+	// old one is still tearing down.
 	for name, s := range m.senders {
 		if _, ok := desired[name]; !ok {
 			slog.Info("ra: removing sender", "interface", name)
-			toStop = append(toStop, s)
 			delete(m.senders, name)
+			m.draining[name] = s
+			s.signalStop(modeHard)
+			toStop = append(toStop, stopReq{name, s})
 		}
 	}
 
-	// Add or update senders.
+	// Classify desired interfaces: unchanged (left running), changed (hard
+	// replace — tombstone + stop old, defer the start), or already-draining /
+	// new (deferred or started directly).
 	var firstErr error
-	var deferred []*config.RAInterfaceConfig // interfaces blocked by a tombstone
+	var deferred []*config.RAInterfaceConfig // already-draining when we held the lock
+	var toRestart []*config.RAInterfaceConfig // changed config: old stopped, start after join
 	for name, cfg := range desired {
 		existing, ok := m.senders[name]
 		if ok && configEqual(existing.cfg, cfg) {
 			continue // No change — keep running, no RA gap.
 		}
 
-		// Changed config: hard-stop the old sender, then (re)start.
+		// Changed config: hard-replace. Install a tombstone, stop the old
+		// sender, and DEFER the start until the old conn is closed (the
+		// tombstone covers the whole window). Never open the new conn while the
+		// old one is live (#2033 MAJOR 1).
 		if ok {
 			slog.Info("ra: restarting sender", "interface", name)
-			toStop = append(toStop, existing)
 			delete(m.senders, name)
+			m.draining[name] = existing
+			existing.signalStop(modeHard)
+			toStop = append(toStop, stopReq{name, existing})
+			toRestart = append(toRestart, cfg)
+			continue
 		}
 
-		// If a tombstone is present (a prior withdraw/stop or a WithdrawOnce
-		// claim is still tearing down), defer — do not start a second conn.
+		// New interface. If a tombstone is already present (a prior withdraw/
+		// stop or a WithdrawOnce claim is still tearing down), defer — do not
+		// start a second conn.
 		if _, draining := m.draining[name]; draining {
 			deferred = append(deferred, cfg)
 			continue
@@ -141,13 +178,57 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	epoch := m.epoch
 	m.mu.Unlock()
 
-	// Hard-stop removed/changed senders OUTSIDE the lock (#2033 I16): a stop
-	// joins the owner (~best-effort) and we must not hold m.mu across it.
-	for _, s := range toStop {
-		s.stop()
+	// Join the stopped (removed + changed) senders OUTSIDE the lock (#2033 I16):
+	// a stop joins the owner and we must not hold m.mu across it. The conn is
+	// closed by the owner in finishShutdown before stop() returns.
+	for _, req := range toStop {
+		<-req.s.stopped
 	}
 
-	// Second pass for interfaces that were draining when we held the lock.
+	// Now every old conn is closed. Clear the REMOVAL tombstones (their
+	// interfaces have no replacement); restart tombstones stay until the
+	// replacement starts.
+	if len(toStop) > 0 {
+		restartSet := make(map[string]struct{}, len(toRestart))
+		for _, cfg := range toRestart {
+			restartSet[cfg.Interface] = struct{}{}
+		}
+		m.mu.Lock()
+		for _, req := range toStop {
+			if _, isRestart := restartSet[req.name]; !isRestart {
+				delete(m.draining, req.name)
+			}
+		}
+		m.mu.Unlock()
+	}
+
+	// Start the replacements for changed configs now that the old conns are
+	// closed. Epoch-guarded: a concurrent Withdraw/Clear that bumped the epoch
+	// wins (it will have already moved/handled the interface), so we abort the
+	// stale restart and clear our tombstone.
+	for _, cfg := range toRestart {
+		m.mu.Lock()
+		if m.epoch != epoch {
+			// Superseded — a newer call owns this interface now. Drop our
+			// restart tombstone only if no newer owner re-installed it; the
+			// newer call manages its own tombstone, so only remove ours if it
+			// is still the placeholder we set and no sender exists.
+			delete(m.draining, cfg.Interface)
+			m.mu.Unlock()
+			slog.Debug("ra: restart superseded by newer epoch, skipping",
+				"interface", cfg.Interface)
+			continue
+		}
+		err := m.startLocked(cfg)
+		delete(m.draining, cfg.Interface)
+		m.mu.Unlock()
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	// Second pass for interfaces that were ALREADY draining when we held the
+	// lock (not our own restart tombstones — those are handled above).
 	if len(deferred) > 0 {
 		if err := m.applyDeferred(deferred, epoch); err != nil && firstErr == nil {
 			firstErr = err
@@ -233,6 +314,13 @@ func (m *Manager) startLocked(cfg *config.RAInterfaceConfig) error {
 	return nil
 }
 
+// drainingSender pairs a draining interface name with its sender for the
+// join-outside-the-lock phase.
+type drainingSender struct {
+	name string
+	s    *sender
+}
+
 // Withdraw sends goodbye RAs (lifetime=0) on all interfaces, then stops all
 // senders. This tells hosts to immediately remove this router as a default
 // gateway. The goodbye is the LAST RA each sender emits (owner-emitted on
@@ -244,8 +332,22 @@ func (m *Manager) Withdraw() error {
 	for name := range m.senders {
 		names = append(names, name)
 	}
+	// Also include interfaces already DRAINING (e.g. a Clear acquired m.mu
+	// first and hard-stopped them). claimGracefulLocked UPGRADES any such
+	// hard-draining sender to graceful so a "withdraw everything" still emits
+	// every goodbye (#2033 MAJOR 2); nil-sender claims (WithdrawOnce) are
+	// no-ops there.
+	for name := range m.draining {
+		names = append(names, name)
+	}
+	// Record the graceful intent ATOMICALLY with the epoch bump and the
+	// snapshot (#2033 MAJOR 2): tombstone + signalStop(modeGraceful) happen
+	// under the SAME m.mu hold, so a racing Clear that acquires m.mu afterward
+	// sees the sender already draining-graceful and cannot drop the goodbye
+	// (signalStop is idempotent + graceful never downgrades to hard).
+	ps := m.claimGracefulLocked(names)
 	m.mu.Unlock()
-	m.withdrawNamesGraceful(names)
+	m.joinDraining(ps)
 	return nil
 }
 
@@ -254,35 +356,48 @@ func (m *Manager) Withdraw() error {
 func (m *Manager) WithdrawInterfaces(names []string) {
 	m.mu.Lock()
 	m.bumpEpoch()
+	ps := m.claimGracefulLocked(names)
 	m.mu.Unlock()
-	m.withdrawNamesGraceful(names)
+	m.joinDraining(ps)
 }
 
-// withdrawNamesGraceful moves each named sender to a draining tombstone under
-// m.mu, releases the lock, then joins each (emitting its goodbye) OUTSIDE the
-// lock (#2033 I16) so multi-interface demotion does not stall Status/Apply on
-// the failover hot path. The tombstone is removed when the join completes.
-func (m *Manager) withdrawNamesGraceful(names []string) {
-	type pending struct {
-		name string
-		s    *sender
-	}
-	var ps []pending
-
-	m.mu.Lock()
+// claimGracefulLocked, under m.mu, moves each named active sender to a graceful
+// draining tombstone and signals it to emit its goodbye on exit. Doing the
+// tombstone install AND signalStop(modeGraceful) under the lock makes the
+// graceful intent atomic (#2033 MAJOR 2) — a later Clear cannot delete the
+// sender and install a hard tombstone in a gap, because by the time the lock is
+// released the sender is already gone from m.senders and already modeGraceful.
+// Callers must hold m.mu. Returns the senders to join outside the lock.
+func (m *Manager) claimGracefulLocked(names []string) []drainingSender {
+	var ps []drainingSender
 	for _, name := range names {
-		s, ok := m.senders[name]
-		if !ok {
+		if s, ok := m.senders[name]; ok {
+			slog.Info("ra: sending goodbye RA", "interface", name)
+			delete(m.senders, name)
+			m.draining[name] = s
+			s.signalStop(modeGraceful)
+			ps = append(ps, drainingSender{name, s})
 			continue
 		}
-		slog.Info("ra: sending goodbye RA", "interface", name)
-		delete(m.senders, name)
-		m.draining[name] = struct{}{}
-		s.signalStop(modeGraceful)
-		ps = append(ps, pending{name, s})
+		// Not active. If a sender is already DRAINING (e.g. a Clear acquired
+		// m.mu first and set a hard tombstone), UPGRADE it to graceful so the
+		// goodbye is still emitted (#2033 MAJOR 2). signalStop is idempotent and
+		// graceful never downgrades; the existing Clear/Apply join will emit the
+		// upgraded goodbye, so we do NOT add it to our own join list (avoid a
+		// double <-stopped on the same sender).
+		if s := m.draining[name]; s != nil {
+			slog.Info("ra: upgrading draining sender to graceful goodbye",
+				"interface", name)
+			s.signalStop(modeGraceful)
+		}
 	}
-	m.mu.Unlock()
+	return ps
+}
 
+// joinDraining joins each draining sender (emitting its goodbye) OUTSIDE m.mu
+// (#2033 I16) so multi-interface demotion does not stall Status/Apply on the
+// failover hot path, then removes each tombstone when its join completes.
+func (m *Manager) joinDraining(ps []drainingSender) {
 	for _, p := range ps {
 		<-p.s.stopped // owner emits the goodbye then closes the conn
 		m.mu.Lock()
@@ -332,8 +447,9 @@ func (m *Manager) WithdrawOnce(configs []*config.RAInterfaceConfig) {
 			continue
 		}
 		// Claim the interface so a concurrent Apply defers instead of starting
-		// a real sender during the goodbye.
-		m.draining[cfg.Interface] = struct{}{}
+		// a real sender during the goodbye. nil sender: the standalone goodbye
+		// is emitted synchronously below, there is no run() loop to upgrade.
+		m.draining[cfg.Interface] = nil
 		toGoodbye = append(toGoodbye, claimed{cfg})
 	}
 	m.mu.Unlock()
@@ -386,7 +502,10 @@ func (m *Manager) clearLocked() error {
 	var ps []pending
 	for name, s := range m.senders {
 		delete(m.senders, name)
-		m.draining[name] = struct{}{}
+		// Store the sender (not nil) so a racing graceful Withdraw can UPGRADE
+		// this hard stop to emit a goodbye (#2033 MAJOR 2). signalStop is
+		// idempotent; graceful never downgrades.
+		m.draining[name] = s
 		s.signalStop(modeHard)
 		ps = append(ps, pending{name, s})
 	}

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -94,51 +94,67 @@ func (m *Manager) interfaceBusy(name string) bool {
 	return ok
 }
 
-// releaseDrain is the SINGLE exit path for a draining sender (#2033 structural
-// fix). The caller is the sole owner of name's drainEntry and has just stopped
-// the sender. releaseDrain joins the sender (ordered read of goodbyeEmitted),
-// then under m.mu decides — claim-once — whether a standalone goodbye is owed;
-// if so it marks the entry claimed, HOLDS it, emits the standalone OUTSIDE the
-// lock (so a concurrent Apply keeps deferring for the whole emit — no clobber),
-// then removes the entry. If no goodbye is owed it removes the entry directly.
+// releaseDrain is the SINGLE exit path for a draining sender, used by Withdraw,
+// Clear, Apply removal AND Apply's changed-config restart (#2033 structural fix;
+// round-4 unification). The caller is the sole owner of name's drainEntry and
+// has just signalled the sender to stop. releaseDrain owns the whole
+// "stop the old sender (join-or-timeout) → optionally emit exactly-once →
+// optionally start a replacement on PROVEN-close → release tombstone" sequence,
+// so no divergent inline copy of these rules can drift (closes round-4 MAJOR
+// 1 + 2). Must be called WITHOUT m.mu held.
 //
-// Timeout discipline (closes race 2): goodbyeEmitted is read ONLY after a
-// successful <-stopped. If the join times out (the owner is wedged despite the
-// bounded SetWriteDeadline — something is badly wrong), releaseDrain does NOT
-// emit a standalone (it cannot safely read goodbyeEmitted, and the owner may
-// still be live); it logs and removes the entry. We accept a theoretical
-// dropped goodbye on a pathological hang over a double-send/clobber.
+//   - onProvenClose, if non-nil, is the changed-config replacement starter. It
+//     runs ONLY on the proven-closed (<-stopped) arm, while the tombstone is
+//     still HELD (a concurrent Apply defers), and ONLY if no graceful withdraw
+//     superseded the replace (epoch unchanged AND no goodbye wanted). It opens
+//     the replacement conn — guaranteed AFTER the old conn is proven closed
+//     (≤1 live conn). It runs under m.mu and returns any start error.
+//   - startEpoch is the manager epoch captured by the caller when it claimed the
+//     interface; a changed epoch means a newer Withdraw/Clear/Apply superseded
+//     this op, so the replacement is aborted.
 //
-// Must be called WITHOUT m.mu held. s may be nil only for a pure standalone
-// claim that never had a sender (handled by emitStandaloneClaimed directly).
-func (m *Manager) releaseDrain(name string, s *sender) {
-	joined := false
+// Timeout discipline (closes race 2 AND round-4 MAJOR 1/2): goodbyeEmitted is
+// read ONLY after a successful <-stopped. On a join TIMEOUT (owner wedged
+// despite bounded SetWriteDeadline) releaseDrain does NOT read goodbyeEmitted,
+// does NOT emit a standalone, and does NOT start the replacement — the old conn
+// may still be live, so opening a replacement would break ≤1-conn and an emit
+// would be unordered. It LEAVES the tombstone in place (so any future
+// Apply/reconcile defers — never 2 conns) and starts a detached reclaimer that
+// removes the tombstone once the wedged owner finally exits. The degraded
+// state is "old sender lingers, no replacement, tombstone held" — never 2
+// conns, never an unordered emit, never a dropped-into-double goodbye.
+func (m *Manager) releaseDrain(name string, s *sender, startEpoch uint64, onProvenClose func() error) error {
 	if s != nil {
 		select {
 		case <-s.stopped:
-			joined = true
+			// proven closed — fall through to the ordered decision below.
 		case <-time.After(claimWaitTimeout):
 			slog.Warn("ra: timed out joining draining sender; not emitting a "+
-				"standalone goodbye (owner may still be live)", "interface", name)
+				"standalone goodbye and not starting a replacement (owner may "+
+				"still hold a live conn); leaving tombstone held", "interface", name)
+			m.reclaimTombstoneWhenStopped(name, s)
+			return nil
 		}
 	}
 
+	// Proven closed (or s==nil). Decide the goodbye claim-once under m.mu.
 	m.mu.Lock()
 	e := m.draining[name]
 	if e == nil {
-		// Should not happen (owner holds it), but be defensive.
 		m.mu.Unlock()
-		return
+		return nil // defensive; owner holds it
 	}
 	emit := false
-	if joined && e.goodbyeWanted && !e.goodbyeClaimed && s != nil &&
-		!s.goodbyeEmitted.Load() {
-		// The owner emitted no goodbye but one was wanted: claim it ONCE and
-		// keep the entry held across the emit below.
+	if e.goodbyeWanted && !e.goodbyeClaimed && s != nil && !s.goodbyeEmitted.Load() {
 		e.goodbyeClaimed = true
 		emit = true
 	}
 	cfg := e.cfg
+	// A replacement starts ONLY if nothing superseded the replace: epoch
+	// unchanged AND no goodbye was wanted (a graceful withdraw overrides a
+	// replace — the route is being withdrawn, not replaced).
+	superseded := m.epoch != startEpoch
+	startReplacement := onProvenClose != nil && !superseded && !e.goodbyeWanted
 	m.mu.Unlock()
 
 	if emit {
@@ -149,9 +165,36 @@ func (m *Manager) releaseDrain(name string, s *sender) {
 		}
 	}
 
+	var startErr error
 	m.mu.Lock()
+	if startReplacement {
+		// Old conn is PROVEN closed and the tombstone is still held → safe to
+		// open the replacement (≤1 live conn) before releasing.
+		startErr = onProvenClose()
+	}
 	delete(m.draining, name)
 	m.mu.Unlock()
+	return startErr
+}
+
+// reclaimTombstoneWhenStopped detaches a goroutine that waits for a wedged
+// owner to finally exit, then removes its tombstone under m.mu. This self-heals
+// the degraded "tombstone held forever after a join timeout" state without ever
+// opening a second conn while the old one may be live. No goodbye and no
+// replacement are emitted/started here — the timeout already declined both.
+func (m *Manager) reclaimTombstoneWhenStopped(name string, s *sender) {
+	go func() {
+		<-s.stopped
+		m.mu.Lock()
+		// Only remove if it is still the SAME entry we left (a newer call may
+		// have replaced it; that newer owner manages its own lifecycle).
+		if e := m.draining[name]; e != nil && e.sender == s {
+			delete(m.draining, name)
+			slog.Info("ra: reclaimed tombstone after wedged owner finally exited",
+				"interface", name)
+		}
+		m.mu.Unlock()
+	}()
 }
 
 // Apply diffs the current senders against the desired set and starts/stops/
@@ -255,85 +298,31 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	epoch := m.epoch
 	m.mu.Unlock()
 
-	restartSet := make(map[string]struct{}, len(toRestart))
+	restartSet := make(map[string]*config.RAInterfaceConfig, len(toRestart))
 	for _, cfg := range toRestart {
-		restartSet[cfg.Interface] = struct{}{}
+		restartSet[cfg.Interface] = cfg
 	}
 
-	// REMOVAL tombstones (no replacement): release each via releaseDrain, which
-	// joins the sender and — if a racing graceful Withdraw flipped goodbyeWanted
-	// — emits a standalone goodbye while holding the entry, then removes it.
+	// All stopped (removal AND changed-config restart) senders go through the
+	// SAME releaseDrain discipline (round-4 unification): join-or-timeout →
+	// exactly-once goodbye if owed → for a restart, start the replacement ONLY
+	// on the proven-closed arm while the tombstone is held (≤1 live conn) and
+	// only if a graceful withdraw did not supersede the replace. A removal
+	// passes onProvenClose=nil (no replacement).
 	for _, req := range toStop {
-		if _, isRestart := restartSet[req.name]; isRestart {
-			continue // restart entries are handled below (keep them held)
-		}
-		m.releaseDrain(req.name, req.s)
-	}
-
-	// RESTART tombstones (changed config): join the old sender, then either
-	// start the replacement (pure replace, no goodbye) or — if a graceful
-	// Withdraw superseded us (epoch changed AND goodbyeWanted) — emit a
-	// standalone goodbye via the release path and do NOT start a replacement.
-	for _, cfg := range toRestart {
-		name := cfg.Interface
-		// Find the old sender we stopped for this restart.
-		var oldS *sender
-		for _, req := range toStop {
-			if req.name == name {
-				oldS = req.s
-				break
-			}
-		}
-		// Join the old sender first (ordered; conn closed) before deciding.
-		if oldS != nil {
-			select {
-			case <-oldS.stopped:
-			case <-time.After(claimWaitTimeout):
-				slog.Warn("ra: timed out joining old sender for restart",
-					"interface", name)
-			}
-		}
-
-		m.mu.Lock()
-		e := m.draining[name]
-		superseded := m.epoch != epoch
-		wantGoodbye := e != nil && e.goodbyeWanted
-		if superseded || wantGoodbye {
-			// A newer call (graceful Withdraw / Clear) owns this interface's
-			// fate; do NOT start the replacement. If a goodbye is wanted and the
-			// old sender emitted none, claim it ONCE and hold the entry across
-			// the emit.
-			emit := false
-			if e != nil && e.goodbyeWanted && !e.goodbyeClaimed &&
-				oldS != nil && !oldS.goodbyeEmitted.Load() {
-				e.goodbyeClaimed = true
-				emit = true
-			}
-			var cfgEmit *config.RAInterfaceConfig
-			if e != nil {
-				cfgEmit = e.cfg
-			}
-			m.mu.Unlock()
-			if emit {
-				slog.Info("ra: restart superseded by withdraw; emitting "+
-					"standalone goodbye (claim held)", "interface", name)
-				if cfgEmit != nil {
-					m.sendOneGoodbye(cfgEmit)
+		name := req.name
+		var onProvenClose func() error
+		if cfg, isRestart := restartSet[name]; isRestart {
+			cfg := cfg // capture
+			onProvenClose = func() error {
+				// Runs under m.mu, tombstone held, old conn proven closed.
+				if err := m.startLocked(cfg); err != nil {
+					return err
 				}
-			} else {
-				slog.Debug("ra: restart superseded, no goodbye owed",
-					"interface", name)
+				return nil
 			}
-			m.mu.Lock()
-			delete(m.draining, name)
-			m.mu.Unlock()
-			continue
 		}
-		// Pure replace: start the new sender, drop the tombstone.
-		err := m.startLocked(cfg)
-		delete(m.draining, name)
-		m.mu.Unlock()
-		if err != nil && firstErr == nil {
+		if err := m.releaseDrain(name, req.s, epoch, onProvenClose); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -453,9 +442,11 @@ func (m *Manager) Withdraw() error {
 		names = append(names, name)
 	}
 	owned := m.claimGracefulLocked(names)
+	epoch := m.epoch
 	m.mu.Unlock()
 	for _, o := range owned {
-		m.releaseDrain(o.name, o.s)
+		// nil onProvenClose: a withdraw never starts a replacement.
+		m.releaseDrain(o.name, o.s, epoch, nil)
 	}
 	return nil
 }
@@ -466,9 +457,10 @@ func (m *Manager) WithdrawInterfaces(names []string) {
 	m.mu.Lock()
 	m.bumpEpoch()
 	owned := m.claimGracefulLocked(names)
+	epoch := m.epoch
 	m.mu.Unlock()
 	for _, o := range owned {
-		m.releaseDrain(o.name, o.s)
+		m.releaseDrain(o.name, o.s, epoch, nil)
 	}
 }
 
@@ -632,14 +624,16 @@ func (m *Manager) clearLocked() error {
 		s.signalStop(modeHard)
 		ps = append(ps, pending{name, s})
 	}
+	epoch := m.epoch
 
 	// Join + release each OUTSIDE the lock so Clear of many interfaces does not
 	// stall other callers; re-acquire before returning (caller expects m.mu
 	// held). releaseDrain handles the claim-once + held-across-emit standalone
-	// goodbye if a racing Withdraw wanted one.
+	// goodbye if a racing Withdraw wanted one. nil onProvenClose: Clear never
+	// starts a replacement.
 	m.mu.Unlock()
 	for _, p := range ps {
-		m.releaseDrain(p.name, p.s)
+		m.releaseDrain(p.name, p.s, epoch, nil)
 	}
 	m.mu.Lock()
 	return nil

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -1,6 +1,15 @@
 // Package ra implements an embedded Router Advertisement sender using
 // mdlayher/ndp. It replaces the external radvd binary with per-interface
 // sender goroutines that build and send RA packets directly.
+//
+// Shutdown contract (#2033): each interface has at most ONE live NDP
+// connection at any time. A sender being withdrawn/stopped moves to a DRAINING
+// TOMBSTONE (m.draining) under m.mu while it joins OUTSIDE the lock, so a
+// concurrent Apply/WithdrawOnce never starts a second sender on the same
+// interface (which would race the goodbye or collide on ndp.Listen). All RA
+// emission — including the lifetime-0 goodbye — is performed by the per-sender
+// owner goroutine (see sender.run / finishShutdown), so a normal RA can never
+// follow the goodbye on the wire.
 package ra
 
 import (
@@ -13,27 +22,75 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
+// claimWaitPoll is how often a deferred Apply re-checks whether a draining
+// tombstone (or WithdrawOnce claim) for an interface has cleared.
+const claimWaitPoll = 5 * time.Millisecond
+
+// claimWaitTimeout bounds how long a deferred Apply waits for a draining
+// tombstone to clear before giving up on that interface (the standalone
+// goodbye / graceful join is ~100 ms, so this is generous).
+const claimWaitTimeout = 5 * time.Second
+
 // Manager manages per-interface RA sender goroutines.
 type Manager struct {
 	mu      sync.Mutex
-	senders map[string]*sender // keyed by Linux interface name
+	senders map[string]*sender // active senders, keyed by Linux interface name
+
+	// draining holds interfaces whose senders are tearing down (graceful
+	// withdraw or hard stop). The entry is a tombstone: while present, the
+	// interface is NOT absent — a concurrent Apply/WithdrawOnce must treat it
+	// as a claim and defer rather than start a new sender (#2033 I16). It is
+	// removed once the sender's goroutine has joined.
+	draining map[string]struct{}
+
+	// epoch is bumped on every state-mutating call (Apply, Withdraw,
+	// WithdrawInterfaces, WithdrawOnce, Clear). A deferred Apply captures the
+	// epoch before releasing m.mu and ABORTS its deferred start if the epoch
+	// changed — a newer call (e.g. a BACKUP transition) superseded it (#2033
+	// I16b). This prevents a stale Apply from starting RA on a demoted node.
+	epoch uint64
 }
 
 // New creates a new RA manager.
 func New() *Manager {
 	return &Manager{
-		senders: make(map[string]*sender),
+		senders:  make(map[string]*sender),
+		draining: make(map[string]struct{}),
 	}
+}
+
+// bumpEpoch increments the manager epoch. Callers must hold m.mu.
+func (m *Manager) bumpEpoch() { m.epoch++ }
+
+// interfaceBusy reports whether the named interface currently has an active
+// sender or a draining tombstone. Callers must hold m.mu.
+func (m *Manager) interfaceBusy(name string) bool {
+	if _, ok := m.senders[name]; ok {
+		return true
+	}
+	_, ok := m.draining[name]
+	return ok
 }
 
 // Apply diffs the current senders against the desired set and starts/stops/
 // updates as needed. Unchanged configs are left running without RA gap.
+//
+// Interfaces that are currently DRAINING (a graceful withdraw or hard stop is
+// in flight, or a WithdrawOnce goodbye holds a claim) are NOT started in this
+// pass — that would race a second NDP connection against the one tearing down.
+// Instead they are deferred: Apply releases m.mu, waits (bounded) for the
+// tombstone to clear, then re-acquires m.mu and starts them — but ONLY if the
+// manager epoch has not changed in the meantime (a newer Withdraw/Clear would
+// have superseded this Apply; starting here would re-arm RA on a demoted node).
 func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
+
+	m.bumpEpoch()
 
 	if len(configs) == 0 {
-		return m.clearLocked()
+		err := m.clearLocked()
+		m.mu.Unlock()
+		return err
 	}
 
 	// Build desired map.
@@ -42,150 +99,308 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 		desired[cfg.Interface] = cfg
 	}
 
-	// Remove senders not in the desired set.
+	// Remove senders not in the desired set (hard stop, no goodbye — a config
+	// change must not blackhole hosts).
+	var toStop []*sender
 	for name, s := range m.senders {
 		if _, ok := desired[name]; !ok {
 			slog.Info("ra: removing sender", "interface", name)
-			s.stop()
+			toStop = append(toStop, s)
 			delete(m.senders, name)
 		}
 	}
 
 	// Add or update senders.
 	var firstErr error
+	var deferred []*config.RAInterfaceConfig // interfaces blocked by a tombstone
 	for name, cfg := range desired {
 		existing, ok := m.senders[name]
 		if ok && configEqual(existing.cfg, cfg) {
-			continue // No change.
+			continue // No change — keep running, no RA gap.
 		}
 
-		// Changed config or new interface — stop old, start new.
+		// Changed config: hard-stop the old sender, then (re)start.
 		if ok {
 			slog.Info("ra: restarting sender", "interface", name)
-			existing.stop()
+			toStop = append(toStop, existing)
 			delete(m.senders, name)
 		}
 
-		iface, err := net.InterfaceByName(name)
-		if err != nil {
-			slog.Warn("ra: interface not found, skipping",
-				"interface", name, "err", err)
-			if firstErr == nil {
-				firstErr = fmt.Errorf("interface %s: %w", name, err)
-			}
+		// If a tombstone is present (a prior withdraw/stop or a WithdrawOnce
+		// claim is still tearing down), defer — do not start a second conn.
+		if _, draining := m.draining[name]; draining {
+			deferred = append(deferred, cfg)
 			continue
 		}
 
-		s := newSender(cfg, iface)
-		if err := s.start(); err != nil {
-			slog.Warn("ra: failed to start sender",
-				"interface", name, "err", err)
-			if firstErr == nil {
-				firstErr = fmt.Errorf("start %s: %w", name, err)
-			}
-			continue
+		if err := m.startLocked(cfg); err != nil && firstErr == nil {
+			firstErr = err
 		}
+	}
 
-		m.senders[name] = s
-		slog.Info("ra: sender started", "interface", name,
-			"prefixes", len(cfg.Prefixes))
+	epoch := m.epoch
+	m.mu.Unlock()
+
+	// Hard-stop removed/changed senders OUTSIDE the lock (#2033 I16): a stop
+	// joins the owner (~best-effort) and we must not hold m.mu across it.
+	for _, s := range toStop {
+		s.stop()
+	}
+
+	// Second pass for interfaces that were draining when we held the lock.
+	if len(deferred) > 0 {
+		if err := m.applyDeferred(deferred, epoch); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
 
 	return firstErr
 }
 
-// Withdraw sends goodbye RAs (lifetime=0) on all interfaces, then stops
-// all senders. This tells hosts to immediately remove this router as a
-// default gateway.
-func (m *Manager) Withdraw() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+// applyDeferred waits (bounded) for each deferred interface's tombstone to
+// clear, then re-acquires m.mu and starts it — but only if the manager epoch
+// still matches startEpoch (else a newer call superseded this Apply, #2033
+// I16b). It must be called WITHOUT m.mu held.
+func (m *Manager) applyDeferred(configs []*config.RAInterfaceConfig, startEpoch uint64) error {
+	var firstErr error
+	for _, cfg := range configs {
+		if !m.waitTombstoneClear(cfg.Interface) {
+			slog.Warn("ra: deferred Apply timed out waiting for drain",
+				"interface", cfg.Interface)
+			continue
+		}
 
-	for name, s := range m.senders {
-		slog.Info("ra: sending goodbye RA", "interface", name)
-		s.sendGoodbyeRA()
-		s.stop()
+		m.mu.Lock()
+		if m.epoch != startEpoch {
+			// A newer Withdraw/Clear/Apply superseded this start; abort.
+			slog.Debug("ra: deferred Apply superseded by newer epoch, skipping",
+				"interface", cfg.Interface)
+			m.mu.Unlock()
+			continue
+		}
+		if m.interfaceBusy(cfg.Interface) {
+			// Something else (re)claimed it; do not double-start.
+			m.mu.Unlock()
+			continue
+		}
+		err := m.startLocked(cfg)
+		m.mu.Unlock()
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// waitTombstoneClear polls until the interface has no draining tombstone, up to
+// claimWaitTimeout. Returns true if it cleared, false on timeout.
+func (m *Manager) waitTombstoneClear(name string) bool {
+	deadline := time.Now().Add(claimWaitTimeout)
+	for {
+		m.mu.Lock()
+		_, draining := m.draining[name]
+		m.mu.Unlock()
+		if !draining {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(claimWaitPoll)
+	}
+}
+
+// startLocked starts a sender for cfg and records it in m.senders. Callers must
+// hold m.mu.
+func (m *Manager) startLocked(cfg *config.RAInterfaceConfig) error {
+	iface, err := net.InterfaceByName(cfg.Interface)
+	if err != nil {
+		slog.Warn("ra: interface not found, skipping",
+			"interface", cfg.Interface, "err", err)
+		return fmt.Errorf("interface %s: %w", cfg.Interface, err)
 	}
 
-	m.senders = make(map[string]*sender)
+	s := newSender(cfg, iface)
+	if err := s.start(); err != nil {
+		slog.Warn("ra: failed to start sender",
+			"interface", cfg.Interface, "err", err)
+		return fmt.Errorf("start %s: %w", cfg.Interface, err)
+	}
+
+	m.senders[cfg.Interface] = s
+	slog.Info("ra: sender started", "interface", cfg.Interface,
+		"prefixes", len(cfg.Prefixes))
 	return nil
 }
 
-// ResendBurst tells all running senders to re-send their startup burst.
-// Used after RETH MAC link cycles that kill the NDP socket — the sender
-// restarts but the original startup burst was lost during the link DOWN.
+// Withdraw sends goodbye RAs (lifetime=0) on all interfaces, then stops all
+// senders. This tells hosts to immediately remove this router as a default
+// gateway. The goodbye is the LAST RA each sender emits (owner-emitted on
+// exit), so a normal RA can never follow it.
+func (m *Manager) Withdraw() error {
+	m.mu.Lock()
+	m.bumpEpoch()
+	var names []string
+	for name := range m.senders {
+		names = append(names, name)
+	}
+	m.mu.Unlock()
+	m.withdrawNamesGraceful(names)
+	return nil
+}
+
+// WithdrawInterfaces sends goodbye RAs and stops senders only for the named
+// interfaces. Other senders are left running.
+func (m *Manager) WithdrawInterfaces(names []string) {
+	m.mu.Lock()
+	m.bumpEpoch()
+	m.mu.Unlock()
+	m.withdrawNamesGraceful(names)
+}
+
+// withdrawNamesGraceful moves each named sender to a draining tombstone under
+// m.mu, releases the lock, then joins each (emitting its goodbye) OUTSIDE the
+// lock (#2033 I16) so multi-interface demotion does not stall Status/Apply on
+// the failover hot path. The tombstone is removed when the join completes.
+func (m *Manager) withdrawNamesGraceful(names []string) {
+	type pending struct {
+		name string
+		s    *sender
+	}
+	var ps []pending
+
+	m.mu.Lock()
+	for _, name := range names {
+		s, ok := m.senders[name]
+		if !ok {
+			continue
+		}
+		slog.Info("ra: sending goodbye RA", "interface", name)
+		delete(m.senders, name)
+		m.draining[name] = struct{}{}
+		s.signalStop(modeGraceful)
+		ps = append(ps, pending{name, s})
+	}
+	m.mu.Unlock()
+
+	for _, p := range ps {
+		<-p.s.stopped // owner emits the goodbye then closes the conn
+		m.mu.Lock()
+		delete(m.draining, p.name)
+		m.mu.Unlock()
+	}
+}
+
+// ResendBurst tells all running senders to re-send their startup burst. Used
+// after RETH MAC link cycles that kill the NDP socket — the sender restarts but
+// the original startup burst was lost during the link DOWN. The re-burst is
+// routed through the owner goroutine (non-blocking) so it serializes with the
+// owner's other writes (#2033 S2/I8) instead of racing a second writer.
 func (m *Manager) ResendBurst() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for name, s := range m.senders {
 		slog.Info("ra: re-sending startup burst after link cycle", "interface", name)
-		go s.sendStartupBurst()
-	}
-}
-
-// WithdrawInterfaces sends goodbye RAs and stops senders only for the
-// named interfaces. Other senders are left running.
-func (m *Manager) WithdrawInterfaces(names []string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	for _, name := range names {
-		if s, ok := m.senders[name]; ok {
-			slog.Info("ra: sending goodbye RA (per-RG)", "interface", name)
-			s.sendGoodbyeRA()
-			s.stop()
-			delete(m.senders, name)
-		}
+		s.requestBurst()
 	}
 }
 
 // WithdrawOnce sends a one-shot goodbye RA (router lifetime=0) on the given
-// interfaces. This is used on startup when a node boots as secondary to
-// withdraw stale RA routes from a previous primary run. Unlike Withdraw(),
-// this does NOT require a running sender — it creates a temporary NDP
-// connection, sends the goodbye RA, and closes it.
+// interfaces. Used on startup when a node boots as secondary to withdraw stale
+// RA routes from a previous primary run. Unlike Withdraw(), this does NOT
+// require a running sender — it opens a temporary NDP connection, sends the
+// goodbye, and closes it WITHOUT launching a sender goroutine or a startup
+// burst (so it never re-advertises the router it is withdrawing — #2033 S1).
 //
-// Skips interfaces that already have a running sender (the sender goroutine
-// handles its own RA lifecycle, and a goodbye RA would kill a live primary).
+// It claims the interface via a draining tombstone under m.mu so a concurrent
+// Apply does NOT start a real sender mid-goodbye (#2033 I4); the Apply defers
+// and starts after the claim clears (it must WAIT, not skip — dropping a MASTER
+// Apply would leave the interface with no sender). Interfaces with a live
+// sender (VRRP MASTER already won) or an existing tombstone are skipped — a
+// goodbye must not clobber a live primary.
 func (m *Manager) WithdrawOnce(configs []*config.RAInterfaceConfig) {
+	m.mu.Lock()
+	m.bumpEpoch()
+	type claimed struct {
+		cfg *config.RAInterfaceConfig
+	}
+	var toGoodbye []claimed
 	for _, cfg := range configs {
-		// Skip if a sender is already running (means VRRP MASTER won the
-		// race and started real RAs — don't clobber with lifetime=0).
-		m.mu.Lock()
-		_, running := m.senders[cfg.Interface]
-		m.mu.Unlock()
-		if running {
-			slog.Debug("ra: WithdrawOnce: sender already running, skipping", "interface", cfg.Interface)
+		if m.interfaceBusy(cfg.Interface) {
+			slog.Debug("ra: WithdrawOnce: interface busy, skipping",
+				"interface", cfg.Interface)
 			continue
 		}
+		// Claim the interface so a concurrent Apply defers instead of starting
+		// a real sender during the goodbye.
+		m.draining[cfg.Interface] = struct{}{}
+		toGoodbye = append(toGoodbye, claimed{cfg})
+	}
+	m.mu.Unlock()
 
-		iface, err := net.InterfaceByName(cfg.Interface)
-		if err != nil {
-			slog.Debug("ra: WithdrawOnce: interface not found", "interface", cfg.Interface, "err", err)
-			continue
-		}
-		s := newSender(cfg, iface)
-		if err := s.start(); err != nil {
-			slog.Debug("ra: WithdrawOnce: failed to start", "interface", cfg.Interface, "err", err)
-			continue
-		}
-		s.sendGoodbyeRA()
-		s.stop()
+	for _, c := range toGoodbye {
+		m.sendOneGoodbye(c.cfg)
+		m.mu.Lock()
+		delete(m.draining, c.cfg.Interface)
+		m.mu.Unlock()
+	}
+}
+
+// sendOneGoodbye opens a temporary sender for cfg, emits the standalone goodbye
+// (no burst, no link toggle — #2033 I12), and closes. m.mu must NOT be held.
+func (m *Manager) sendOneGoodbye(cfg *config.RAInterfaceConfig) {
+	iface, err := net.InterfaceByName(cfg.Interface)
+	if err != nil {
+		slog.Debug("ra: WithdrawOnce: interface not found",
+			"interface", cfg.Interface, "err", err)
+		return
+	}
+	s := newSender(cfg, iface)
+	if err := s.sendGoodbyeStandalone(); err != nil {
+		slog.Debug("ra: WithdrawOnce: failed to send goodbye",
+			"interface", cfg.Interface, "err", err)
 	}
 }
 
 // Clear stops all senders without sending goodbye RAs.
 func (m *Manager) Clear() error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.clearLocked()
+	m.bumpEpoch()
+	err := m.clearLocked()
+	m.mu.Unlock()
+	return err
 }
 
+// clearLocked hard-stops all active senders without a goodbye. Callers must
+// hold m.mu; it moves senders to draining tombstones, releases the lock to
+// join, then re-acquires — so it returns with m.mu held (matching its
+// callers). No goodbye is emitted (modeHard).
 func (m *Manager) clearLocked() error {
-	for _, s := range m.senders {
-		s.stop()
+	if len(m.senders) == 0 {
+		return nil
 	}
-	m.senders = make(map[string]*sender)
+	type pending struct {
+		name string
+		s    *sender
+	}
+	var ps []pending
+	for name, s := range m.senders {
+		delete(m.senders, name)
+		m.draining[name] = struct{}{}
+		s.signalStop(modeHard)
+		ps = append(ps, pending{name, s})
+	}
+
+	// Join outside the lock so Clear of many interfaces does not stall other
+	// callers; re-acquire before returning (caller expects m.mu held).
+	m.mu.Unlock()
+	for _, p := range ps {
+		<-p.s.stopped
+	}
+	m.mu.Lock()
+	for _, p := range ps {
+		delete(m.draining, p.name)
+	}
 	return nil
 }
 
@@ -204,9 +419,15 @@ type SenderInfo struct {
 	Managed     bool
 	Other       bool
 	LastRA      string // time since last RA
+	// State is "active" for a running sender or "draining" for an interface
+	// whose sender is tearing down / emitting its goodbye (#2033). A draining
+	// interface is deliberately reported as distinct from active so operators
+	// do not read a withdrawing router as still advertising.
+	State string
 }
 
-// Status returns information about all active RA senders.
+// Status returns information about all RA senders, including interfaces that
+// are currently draining (their State is "draining").
 func (m *Manager) Status() []SenderInfo {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -224,6 +445,7 @@ func (m *Manager) Status() []SenderInfo {
 			Other:       s.cfg.OtherStateful,
 			Preference:  s.cfg.Preference,
 			NAT64Prefix: s.cfg.NAT64Prefix,
+			State:       "active",
 		}
 		if info.Lifetime <= 0 {
 			info.Lifetime = defaultRouterLifetime
@@ -241,12 +463,22 @@ func (m *Manager) Status() []SenderInfo {
 			info.Prefixes = append(info.Prefixes, pfx.Prefix)
 		}
 		info.DNSServers = s.cfg.DNSServers
-		if !s.lastRA.IsZero() {
-			info.LastRA = fmt.Sprintf("%.0fs ago", time.Since(s.lastRA).Seconds())
+		if last := s.getLastRA(); !last.IsZero() {
+			info.LastRA = fmt.Sprintf("%.0fs ago", time.Since(last).Seconds())
 		} else {
 			info.LastRA = "never"
 		}
 		result = append(result, info)
+	}
+
+	// Surface draining interfaces so a withdrawing router is not silently
+	// invisible (it is no longer "active" but not yet gone).
+	for name := range m.draining {
+		result = append(result, SenderInfo{
+			Interface: name,
+			State:     "draining",
+			LastRA:    "n/a",
+		})
 	}
 	return result
 }

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -27,26 +27,43 @@ import (
 const claimWaitPoll = 5 * time.Millisecond
 
 // claimWaitTimeout bounds how long a deferred Apply waits for a draining
-// tombstone to clear before giving up on that interface (the standalone
-// goodbye / graceful join is ~100 ms, so this is generous).
-const claimWaitTimeout = 5 * time.Second
+// tombstone to clear, and how long releaseDrain waits to join a sender before
+// giving up (the standalone goodbye / graceful join is ~100 ms, so this is
+// generous). A package var so the timeout-arm test can shorten it.
+var claimWaitTimeout = 5 * time.Second
+
+// drainEntry is the single atomic claim-and-hold for a draining interface
+// (#2033, structural fix for the three standalone-goodbye races). Its presence
+// in m.draining is a tombstone: while it exists the interface is NOT absent, so
+// a concurrent Apply/WithdrawOnce/Withdraw treats it as a claim and defers
+// instead of opening a second NDP conn. ALL fields are read/written ONLY under
+// m.mu. The entry is owned (created and eventually removed) by exactly ONE
+// goroutine — the one that joins its sender (or the WithdrawOnce/standalone
+// claimant). That single owner is the SOLE emitter of any standalone goodbye,
+// and it HOLDS the entry across the whole emit, so:
+//   - the owner is the only one that can take the goodbye (no double-send),
+//   - the entry blocks any concurrent Apply for the entire emit (no clobber of
+//     a re-claimed live sender, ≤1 live conn preserved),
+//   - the goodbye decision reads sender.goodbyeEmitted only AFTER <-stopped
+//     (happens-before), never on the timeout path.
+type drainEntry struct {
+	sender        *sender                   // draining sender; nil for a standalone-only claim
+	cfg           *config.RAInterfaceConfig // config for a standalone goodbye, if owed
+	goodbyeWanted bool                      // a graceful Withdraw targeted this interface
+	goodbyeClaimed bool                     // the owner has taken responsibility to emit it
+}
 
 // Manager manages per-interface RA sender goroutines.
 type Manager struct {
 	mu      sync.Mutex
 	senders map[string]*sender // active senders, keyed by Linux interface name
 
-	// draining holds interfaces whose senders are tearing down (graceful
-	// withdraw or hard stop) or are otherwise claimed (a WithdrawOnce goodbye,
-	// or an Apply restart between stop-old and start-new). The entry is a
-	// tombstone: while present, the interface is NOT absent — a concurrent
-	// Apply/WithdrawOnce must treat it as a claim and defer rather than start a
-	// new sender (#2033 I16). The value is the draining *sender when one exists
-	// (so a later graceful Withdraw can UPGRADE a still-draining hard stop to
-	// emit a goodbye — #2033 MAJOR 2), or nil for a claim with no live sender
-	// (WithdrawOnce, or after the sender has joined). It is removed once the
-	// sender's goroutine has joined.
-	draining map[string]*sender
+	// draining holds the per-interface claim-and-hold tombstones (see
+	// drainEntry). While an entry is present the interface is claimed; a
+	// concurrent Apply/WithdrawOnce/Withdraw must defer rather than start a new
+	// sender (#2033 I16). The owner removes it (under m.mu) only AFTER any
+	// standalone goodbye it claimed has fully completed.
+	draining map[string]*drainEntry
 
 	// epoch is bumped on every state-mutating call (Apply, Withdraw,
 	// WithdrawInterfaces, WithdrawOnce, Clear). A deferred Apply captures the
@@ -60,7 +77,7 @@ type Manager struct {
 func New() *Manager {
 	return &Manager{
 		senders:  make(map[string]*sender),
-		draining: make(map[string]*sender),
+		draining: make(map[string]*drainEntry),
 	}
 }
 
@@ -75,6 +92,66 @@ func (m *Manager) interfaceBusy(name string) bool {
 	}
 	_, ok := m.draining[name]
 	return ok
+}
+
+// releaseDrain is the SINGLE exit path for a draining sender (#2033 structural
+// fix). The caller is the sole owner of name's drainEntry and has just stopped
+// the sender. releaseDrain joins the sender (ordered read of goodbyeEmitted),
+// then under m.mu decides — claim-once — whether a standalone goodbye is owed;
+// if so it marks the entry claimed, HOLDS it, emits the standalone OUTSIDE the
+// lock (so a concurrent Apply keeps deferring for the whole emit — no clobber),
+// then removes the entry. If no goodbye is owed it removes the entry directly.
+//
+// Timeout discipline (closes race 2): goodbyeEmitted is read ONLY after a
+// successful <-stopped. If the join times out (the owner is wedged despite the
+// bounded SetWriteDeadline — something is badly wrong), releaseDrain does NOT
+// emit a standalone (it cannot safely read goodbyeEmitted, and the owner may
+// still be live); it logs and removes the entry. We accept a theoretical
+// dropped goodbye on a pathological hang over a double-send/clobber.
+//
+// Must be called WITHOUT m.mu held. s may be nil only for a pure standalone
+// claim that never had a sender (handled by emitStandaloneClaimed directly).
+func (m *Manager) releaseDrain(name string, s *sender) {
+	joined := false
+	if s != nil {
+		select {
+		case <-s.stopped:
+			joined = true
+		case <-time.After(claimWaitTimeout):
+			slog.Warn("ra: timed out joining draining sender; not emitting a "+
+				"standalone goodbye (owner may still be live)", "interface", name)
+		}
+	}
+
+	m.mu.Lock()
+	e := m.draining[name]
+	if e == nil {
+		// Should not happen (owner holds it), but be defensive.
+		m.mu.Unlock()
+		return
+	}
+	emit := false
+	if joined && e.goodbyeWanted && !e.goodbyeClaimed && s != nil &&
+		!s.goodbyeEmitted.Load() {
+		// The owner emitted no goodbye but one was wanted: claim it ONCE and
+		// keep the entry held across the emit below.
+		e.goodbyeClaimed = true
+		emit = true
+	}
+	cfg := e.cfg
+	m.mu.Unlock()
+
+	if emit {
+		slog.Info("ra: emitting standalone goodbye (owner exited without one; "+
+			"claim held across emit)", "interface", name)
+		if cfg != nil {
+			m.sendOneGoodbye(cfg) // entry still held → Apply defers, no clobber
+		}
+	}
+
+	m.mu.Lock()
+	delete(m.draining, name)
+	m.mu.Unlock()
 }
 
 // Apply diffs the current senders against the desired set and starts/stops/
@@ -123,14 +200,14 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	var toStop []stopReq
 
 	// Remove senders not in the desired set (hard stop, no goodbye — a config
-	// change must not blackhole hosts). Install a tombstone so a concurrent
-	// WithdrawOnce/Apply does not start a sender on the same interface while the
-	// old one is still tearing down.
+	// change must not blackhole hosts). Install a drainEntry so a concurrent
+	// WithdrawOnce/Apply defers, and a racing graceful Withdraw can flip
+	// goodbyeWanted on it (the release path then emits the standalone).
 	for name, s := range m.senders {
 		if _, ok := desired[name]; !ok {
 			slog.Info("ra: removing sender", "interface", name)
 			delete(m.senders, name)
-			m.draining[name] = s
+			m.draining[name] = &drainEntry{sender: s, cfg: s.cfg}
 			s.signalStop(modeHard)
 			toStop = append(toStop, stopReq{name, s})
 		}
@@ -155,7 +232,7 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 		if ok {
 			slog.Info("ra: restarting sender", "interface", name)
 			delete(m.senders, name)
-			m.draining[name] = existing
+			m.draining[name] = &drainEntry{sender: existing, cfg: existing.cfg}
 			existing.signalStop(modeHard)
 			toStop = append(toStop, stopReq{name, existing})
 			toRestart = append(toRestart, cfg)
@@ -178,49 +255,83 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	epoch := m.epoch
 	m.mu.Unlock()
 
-	// Join the stopped (removed + changed) senders OUTSIDE the lock (#2033 I16):
-	// a stop joins the owner and we must not hold m.mu across it. The conn is
-	// closed by the owner in finishShutdown before stop() returns.
-	for _, req := range toStop {
-		<-req.s.stopped
+	restartSet := make(map[string]struct{}, len(toRestart))
+	for _, cfg := range toRestart {
+		restartSet[cfg.Interface] = struct{}{}
 	}
 
-	// Now every old conn is closed. Clear the REMOVAL tombstones (their
-	// interfaces have no replacement); restart tombstones stay until the
-	// replacement starts.
-	if len(toStop) > 0 {
-		restartSet := make(map[string]struct{}, len(toRestart))
-		for _, cfg := range toRestart {
-			restartSet[cfg.Interface] = struct{}{}
+	// REMOVAL tombstones (no replacement): release each via releaseDrain, which
+	// joins the sender and — if a racing graceful Withdraw flipped goodbyeWanted
+	// — emits a standalone goodbye while holding the entry, then removes it.
+	for _, req := range toStop {
+		if _, isRestart := restartSet[req.name]; isRestart {
+			continue // restart entries are handled below (keep them held)
 		}
-		m.mu.Lock()
+		m.releaseDrain(req.name, req.s)
+	}
+
+	// RESTART tombstones (changed config): join the old sender, then either
+	// start the replacement (pure replace, no goodbye) or — if a graceful
+	// Withdraw superseded us (epoch changed AND goodbyeWanted) — emit a
+	// standalone goodbye via the release path and do NOT start a replacement.
+	for _, cfg := range toRestart {
+		name := cfg.Interface
+		// Find the old sender we stopped for this restart.
+		var oldS *sender
 		for _, req := range toStop {
-			if _, isRestart := restartSet[req.name]; !isRestart {
-				delete(m.draining, req.name)
+			if req.name == name {
+				oldS = req.s
+				break
 			}
 		}
-		m.mu.Unlock()
-	}
+		// Join the old sender first (ordered; conn closed) before deciding.
+		if oldS != nil {
+			select {
+			case <-oldS.stopped:
+			case <-time.After(claimWaitTimeout):
+				slog.Warn("ra: timed out joining old sender for restart",
+					"interface", name)
+			}
+		}
 
-	// Start the replacements for changed configs now that the old conns are
-	// closed. Epoch-guarded: a concurrent Withdraw/Clear that bumped the epoch
-	// wins (it will have already moved/handled the interface), so we abort the
-	// stale restart and clear our tombstone.
-	for _, cfg := range toRestart {
 		m.mu.Lock()
-		if m.epoch != epoch {
-			// Superseded — a newer call owns this interface now. Drop our
-			// restart tombstone only if no newer owner re-installed it; the
-			// newer call manages its own tombstone, so only remove ours if it
-			// is still the placeholder we set and no sender exists.
-			delete(m.draining, cfg.Interface)
+		e := m.draining[name]
+		superseded := m.epoch != epoch
+		wantGoodbye := e != nil && e.goodbyeWanted
+		if superseded || wantGoodbye {
+			// A newer call (graceful Withdraw / Clear) owns this interface's
+			// fate; do NOT start the replacement. If a goodbye is wanted and the
+			// old sender emitted none, claim it ONCE and hold the entry across
+			// the emit.
+			emit := false
+			if e != nil && e.goodbyeWanted && !e.goodbyeClaimed &&
+				oldS != nil && !oldS.goodbyeEmitted.Load() {
+				e.goodbyeClaimed = true
+				emit = true
+			}
+			var cfgEmit *config.RAInterfaceConfig
+			if e != nil {
+				cfgEmit = e.cfg
+			}
 			m.mu.Unlock()
-			slog.Debug("ra: restart superseded by newer epoch, skipping",
-				"interface", cfg.Interface)
+			if emit {
+				slog.Info("ra: restart superseded by withdraw; emitting "+
+					"standalone goodbye (claim held)", "interface", name)
+				if cfgEmit != nil {
+					m.sendOneGoodbye(cfgEmit)
+				}
+			} else {
+				slog.Debug("ra: restart superseded, no goodbye owed",
+					"interface", name)
+			}
+			m.mu.Lock()
+			delete(m.draining, name)
+			m.mu.Unlock()
 			continue
 		}
+		// Pure replace: start the new sender, drop the tombstone.
 		err := m.startLocked(cfg)
-		delete(m.draining, cfg.Interface)
+		delete(m.draining, name)
 		m.mu.Unlock()
 		if err != nil && firstErr == nil {
 			firstErr = err
@@ -314,20 +425,13 @@ func (m *Manager) startLocked(cfg *config.RAInterfaceConfig) error {
 	return nil
 }
 
-// gracefulTarget is one interface a graceful Withdraw is tearing down. After
-// the owning goroutine joins its sender, the manager checks whether a goodbye
-// actually went out; if not, it OWES a standalone goodbye (the owner lost the
-// upgrade race or the sender was already a stopped restart tombstone). Fields:
-//   - owned: true if THIS Withdraw owns the join (active-sender case).
-//   - observe: the sender to read goodbyeEmitted from after it has stopped
-//     (always captured under m.mu at claim time, so it never depends on the
-//     draining-map entry surviving — closes the restart-window delete race).
-//   - cfg: config to build the standalone goodbye from if owed.
-type gracefulTarget struct {
-	name    string
-	owned   bool
-	observe *sender
-	cfg     *config.RAInterfaceConfig
+// ownedDrain is an interface whose draining sender THIS graceful Withdraw owns
+// the join+release for (the active-sender case). The single owner runs
+// releaseDrain, which is the sole emitter of any standalone goodbye and holds
+// the entry across the emit.
+type ownedDrain struct {
+	name string
+	s    *sender
 }
 
 // Withdraw sends goodbye RAs (lifetime=0) on all interfaces, then stops all
@@ -343,15 +447,16 @@ func (m *Manager) Withdraw() error {
 	}
 	// Also include interfaces already DRAINING (e.g. a Clear acquired m.mu
 	// first and hard-stopped them, or a changed-config restart is mid stop->
-	// start). claimGracefulLocked upgrades a still-running owner, and the
-	// post-join owes-a-goodbye check emits a standalone goodbye if the owner
-	// was already dead (#2033 MAJOR 2 / restart window).
+	// start). claimGracefulLocked flips goodbyeWanted on those entries; their
+	// existing owner's release path emits the standalone if owed.
 	for name := range m.draining {
 		names = append(names, name)
 	}
-	ts := m.claimGracefulLocked(names)
+	owned := m.claimGracefulLocked(names)
 	m.mu.Unlock()
-	m.finishGraceful(ts)
+	for _, o := range owned {
+		m.releaseDrain(o.name, o.s)
+	}
 	return nil
 }
 
@@ -360,121 +465,70 @@ func (m *Manager) Withdraw() error {
 func (m *Manager) WithdrawInterfaces(names []string) {
 	m.mu.Lock()
 	m.bumpEpoch()
-	ts := m.claimGracefulLocked(names)
+	owned := m.claimGracefulLocked(names)
 	m.mu.Unlock()
-	m.finishGraceful(ts)
+	for _, o := range owned {
+		m.releaseDrain(o.name, o.s)
+	}
 }
 
-// claimGracefulLocked, under m.mu, records the graceful withdrawal intent for
-// each named interface and returns the targets to finish outside the lock.
-//
-// Doing the tombstone install AND signalStop(modeGraceful) under the lock makes
-// the graceful intent atomic (#2033 MAJOR 2): a later Clear cannot delete the
-// sender and install a hard tombstone in a gap. Three cases per interface:
-//   - active sender: move to a graceful tombstone, signalStop(graceful), join
-//     it ourselves; the owner emits the goodbye on exit.
-//   - draining sender (non-nil): a Clear/restart already owns it. UPGRADE it to
-//     graceful (best-effort — works only if the owner has not yet read its
-//     mode). We do NOT join it (its owner does), but we still record cfg so the
-//     post-mortem check can emit a standalone goodbye if the upgrade lost the
-//     race (the owner already exited hard — a dead sender cannot be upgraded).
-//   - nil draining claim (a WithdrawOnce goodbye in flight): the interface is
-//     already getting exactly one goodbye; do nothing (no double goodbye).
+// claimGracefulLocked records the graceful withdrawal intent for each named
+// interface UNDER m.mu, and returns only the interfaces THIS Withdraw owns the
+// join+release for. Per interface (atomic under m.mu — #2033 MAJOR 2):
+//   - active sender: move it to a NEW drainEntry{goodbyeWanted:true},
+//     signalStop(graceful), and OWN the release (returned in ownedDrain). The
+//     owner emits the goodbye on exit; releaseDrain's standalone backstop
+//     covers the lost-upgrade case.
+//   - already draining (Clear/restart/WithdrawOnce owns it): just flip
+//     goodbyeWanted=true on the existing entry and upgrade the live sender (if
+//     any) via signalStop(graceful). We do NOT own its release; the existing
+//     owner's release path (releaseDrain / Apply restart) emits the standalone
+//     if owed — claim-once via goodbyeClaimed guarantees no double-send even if
+//     several Withdraws flip the same entry.
 // Callers must hold m.mu.
-func (m *Manager) claimGracefulLocked(names []string) []gracefulTarget {
-	var ts []gracefulTarget
+func (m *Manager) claimGracefulLocked(names []string) []ownedDrain {
+	var owned []ownedDrain
 	seen := make(map[string]struct{}, len(names))
 	for _, name := range names {
 		if _, dup := seen[name]; dup {
-			continue // dedup: each interface yields at most one target / goodbye
+			continue // dedup within this call
 		}
 		seen[name] = struct{}{}
 		if s, ok := m.senders[name]; ok {
 			slog.Info("ra: sending goodbye RA", "interface", name)
 			delete(m.senders, name)
-			m.draining[name] = s
+			m.draining[name] = &drainEntry{sender: s, cfg: s.cfg, goodbyeWanted: true}
 			s.signalStop(modeGraceful)
-			ts = append(ts, gracefulTarget{name: name, owned: true, observe: s, cfg: s.cfg})
+			owned = append(owned, ownedDrain{name: name, s: s})
 			continue
 		}
-		if s := m.draining[name]; s != nil {
-			// A Clear or a changed-config restart already owns this sender's
-			// join. Upgrade it (effective only if the owner has not read its
-			// mode yet). Capture the sender pointer NOW (under m.mu) so the
-			// post-mortem owes-a-goodbye check reads goodbyeEmitted directly and
-			// does NOT depend on the draining-map entry surviving (the restart
-			// loop may delete it) — owned=false so we do not double-join.
-			slog.Info("ra: upgrading draining sender to graceful goodbye",
-				"interface", name)
-			s.signalStop(modeGraceful)
-			ts = append(ts, gracefulTarget{name: name, owned: false, observe: s, cfg: s.cfg})
+		if e := m.draining[name]; e != nil {
+			// Another caller (Clear / changed-config restart / WithdrawOnce)
+			// owns this entry's release. Flip goodbyeWanted so that owner emits
+			// the standalone if owed, and upgrade the still-running sender (if
+			// any) so it may emit the goodbye itself. We do NOT take the release.
+			e.goodbyeWanted = true
+			if e.cfg == nil {
+				e.cfg = m.cfgForName(name)
+			}
+			if e.sender != nil {
+				slog.Info("ra: upgrading draining sender to graceful goodbye",
+					"interface", name)
+				e.sender.signalStop(modeGraceful)
+			}
 			continue
 		}
-		// nil draining claim == a WithdrawOnce standalone goodbye is already in
-		// flight for this interface; it will emit exactly one goodbye. Skip.
+		// No sender and no tombstone: nothing to withdraw (already fully gone).
 	}
-	return ts
+	return owned
 }
 
-// finishGraceful, OUTSIDE m.mu (#2033 I16 — do not stall Status/Apply on the
-// failover hot path), waits for each target's sender to stop, then guarantees
-// EXACTLY ONE goodbye per interface: if the owner did not emit one (it lost the
-// graceful upgrade race, or the sender was already a stopped restart/Clear
-// tombstone), the manager emits a standalone goodbye via the WithdrawOnce
-// mechanism. The owned tombstone is cleared as each interface completes.
-func (m *Manager) finishGraceful(ts []gracefulTarget) {
-	for _, t := range ts {
-		// Wait for the sender to finish (whoever owns the join). stopped closes
-		// exactly once; multiple readers are safe. goodbyeEmitted is stored by
-		// finishShutdown BEFORE close(stopped), so this read is ordered.
-		select {
-		case <-t.observe.stopped:
-		case <-time.After(claimWaitTimeout):
-			slog.Warn("ra: timed out waiting for sender to drain",
-				"interface", t.name)
-		}
-		owed := !t.observe.goodbyeEmitted.Load()
-
-		if owed {
-			slog.Info("ra: emitting standalone goodbye (owner exited without "+
-				"one — lost the upgrade race or was a hard restart/clear stop)",
-				"interface", t.name)
-			m.emitStandaloneGoodbye(t.name, t.cfg)
-		}
-
-		if t.owned {
-			// Clear OUR tombstone (active-sender case). The upgrade case is
-			// owned by the racing Clear/restart, which clears its own.
-			m.mu.Lock()
-			delete(m.draining, t.name)
-			m.mu.Unlock()
-		}
-	}
-}
-
-// emitStandaloneGoodbye emits a single standalone goodbye (no burst, no link
-// toggle) for an interface whose owner exited without one. It is a NO-OP only if
-// a LIVE sender exists for the interface (a newer MASTER Apply won it back — do
-// not clobber it with a lifetime-0 RA). It deliberately does NOT skip on a
-// present draining tombstone: the tombstone that brought us here is a HARD stop
-// (Clear / changed-config restart) whose owner will NOT emit a goodbye, and a
-// WithdrawOnce nil-claim is never routed here (claimGracefulLocked skips those).
-// It does not install its own tombstone — the goodbye is brief (~goodbyeCount ×
-// goodbyeDelay) and a concurrent Apply that starts a real sender during it is
-// the legitimate new-MASTER case (its own owner emits its RAs correctly). m.mu
-// must NOT be held.
-func (m *Manager) emitStandaloneGoodbye(name string, cfg *config.RAInterfaceConfig) {
-	if cfg == nil {
-		return
-	}
-	m.mu.Lock()
-	_, live := m.senders[name]
-	m.mu.Unlock()
-	if live {
-		return
-	}
-	m.sendOneGoodbye(cfg)
-}
+// cfgForName returns a config to build a standalone goodbye from for name, when
+// an existing drainEntry was a nil-cfg claim (e.g. a WithdrawOnce entry). Best
+// effort: a WithdrawOnce entry carries no cfg, so a graceful Withdraw that
+// races it cannot synthesize one — return nil and rely on the WithdrawOnce's
+// own goodbye (it emits exactly one). Callers hold m.mu.
+func (m *Manager) cfgForName(string) *config.RAInterfaceConfig { return nil }
 
 // ResendBurst tells all running senders to re-send their startup burst. Used
 // after RETH MAC link cycles that kill the NDP socket — the sender restarts but
@@ -506,28 +560,26 @@ func (m *Manager) ResendBurst() {
 func (m *Manager) WithdrawOnce(configs []*config.RAInterfaceConfig) {
 	m.mu.Lock()
 	m.bumpEpoch()
-	type claimed struct {
-		cfg *config.RAInterfaceConfig
-	}
-	var toGoodbye []claimed
+	var toGoodbye []*config.RAInterfaceConfig
 	for _, cfg := range configs {
 		if m.interfaceBusy(cfg.Interface) {
 			slog.Debug("ra: WithdrawOnce: interface busy, skipping",
 				"interface", cfg.Interface)
 			continue
 		}
-		// Claim the interface so a concurrent Apply defers instead of starting
-		// a real sender during the goodbye. nil sender: the standalone goodbye
-		// is emitted synchronously below, there is no run() loop to upgrade.
-		m.draining[cfg.Interface] = nil
-		toGoodbye = append(toGoodbye, claimed{cfg})
+		// Claim the interface (sender:nil — no run() loop) and pre-mark the
+		// goodbye as CLAIMED: WithdrawOnce emits exactly one goodbye below, so a
+		// racing graceful Withdraw that flips goodbyeWanted must NOT also emit.
+		// The entry is HELD across the emit so a concurrent Apply defers.
+		m.draining[cfg.Interface] = &drainEntry{cfg: cfg, goodbyeClaimed: true}
+		toGoodbye = append(toGoodbye, cfg)
 	}
 	m.mu.Unlock()
 
-	for _, c := range toGoodbye {
-		m.sendOneGoodbye(c.cfg)
+	for _, cfg := range toGoodbye {
+		m.sendOneGoodbye(cfg)
 		m.mu.Lock()
-		delete(m.draining, c.cfg.Interface)
+		delete(m.draining, cfg.Interface)
 		m.mu.Unlock()
 	}
 }
@@ -558,9 +610,11 @@ func (m *Manager) Clear() error {
 }
 
 // clearLocked hard-stops all active senders without a goodbye. Callers must
-// hold m.mu; it moves senders to draining tombstones, releases the lock to
-// join, then re-acquires — so it returns with m.mu held (matching its
-// callers). No goodbye is emitted (modeHard).
+// hold m.mu; it moves senders to drainEntry tombstones, releases the lock to
+// join+release each, then re-acquires — so it returns with m.mu held (matching
+// its callers). No goodbye is emitted for a pure Clear (modeHard); but if a
+// racing graceful Withdraw flipped goodbyeWanted on an entry, clearLocked's
+// release path emits the standalone goodbye (claim-once, held across the emit).
 func (m *Manager) clearLocked() error {
 	if len(m.senders) == 0 {
 		return nil
@@ -572,24 +626,22 @@ func (m *Manager) clearLocked() error {
 	var ps []pending
 	for name, s := range m.senders {
 		delete(m.senders, name)
-		// Store the sender (not nil) so a racing graceful Withdraw can UPGRADE
-		// this hard stop to emit a goodbye (#2033 MAJOR 2). signalStop is
-		// idempotent; graceful never downgrades.
-		m.draining[name] = s
+		// drainEntry with the sender so a racing graceful Withdraw can flip
+		// goodbyeWanted + upgrade the live sender (#2033 MAJOR 2).
+		m.draining[name] = &drainEntry{sender: s, cfg: s.cfg}
 		s.signalStop(modeHard)
 		ps = append(ps, pending{name, s})
 	}
 
-	// Join outside the lock so Clear of many interfaces does not stall other
-	// callers; re-acquire before returning (caller expects m.mu held).
+	// Join + release each OUTSIDE the lock so Clear of many interfaces does not
+	// stall other callers; re-acquire before returning (caller expects m.mu
+	// held). releaseDrain handles the claim-once + held-across-emit standalone
+	// goodbye if a racing Withdraw wanted one.
 	m.mu.Unlock()
 	for _, p := range ps {
-		<-p.s.stopped
+		m.releaseDrain(p.name, p.s)
 	}
 	m.mu.Lock()
-	for _, p := range ps {
-		delete(m.draining, p.name)
-	}
 	return nil
 }
 

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -106,9 +106,11 @@ func (m *Manager) interfaceBusy(name string) bool {
 //   - onProvenClose, if non-nil, is the changed-config replacement starter. It
 //     runs ONLY on the proven-closed (<-stopped) arm, while the tombstone is
 //     still HELD (a concurrent Apply defers), and ONLY if no graceful withdraw
-//     superseded the replace (epoch unchanged AND no goodbye wanted). It opens
-//     the replacement conn — guaranteed AFTER the old conn is proven closed
-//     (≤1 live conn). It runs under m.mu and returns any start error.
+//     superseded the replace (epoch unchanged AND no goodbye wanted), evaluated
+//     UNDER the lock that performs the start with FRESH state (no boolean cached
+//     across an unlock — round-5). It opens the replacement conn — guaranteed
+//     AFTER the old conn is proven closed (≤1 live conn). It runs under m.mu and
+//     returns any start error.
 //   - startEpoch is the manager epoch captured by the caller when it claimed the
 //     interface; a changed epoch means a newer Withdraw/Clear/Apply superseded
 //     this op, so the replacement is aborted.
@@ -123,6 +125,15 @@ func (m *Manager) interfaceBusy(name string) bool {
 // removes the tombstone once the wedged owner finally exits. The degraded
 // state is "old sender lingers, no replacement, tombstone held" — never 2
 // conns, never an unordered emit, never a dropped-into-double goodbye.
+//
+// Round-5 atomicity: the goodbye-vs-replace decision is re-evaluated against the
+// LIVE tombstone under the lock at the ACT point — never trusting a boolean
+// computed before the emit unlock. goodbyeWanted is monotonic (false→true only)
+// and epoch is monotonic increasing, so a "replace" decision observed under the
+// act-lock (epoch==startEpoch AND !goodbyeWanted AND same entry) cannot be
+// invalidated while the lock is held; conversely if a racing Withdraw flipped
+// goodbyeWanted in the emit gap, the act-lock re-check sees it, suppresses the
+// replace, AND emits the now-owed goodbye (the withdraw wins).
 func (m *Manager) releaseDrain(name string, s *sender, startEpoch uint64, onProvenClose func() error) error {
 	if s != nil {
 		select {
@@ -137,44 +148,48 @@ func (m *Manager) releaseDrain(name string, s *sender, startEpoch uint64, onProv
 		}
 	}
 
-	// Proven closed (or s==nil). Decide the goodbye claim-once under m.mu.
-	m.mu.Lock()
-	e := m.draining[name]
-	if e == nil {
-		m.mu.Unlock()
-		return nil // defensive; owner holds it
-	}
-	emit := false
-	if e.goodbyeWanted && !e.goodbyeClaimed && s != nil && !s.goodbyeEmitted.Load() {
-		e.goodbyeClaimed = true
-		emit = true
-	}
-	cfg := e.cfg
-	// A replacement starts ONLY if nothing superseded the replace: epoch
-	// unchanged AND no goodbye was wanted (a graceful withdraw overrides a
-	// replace — the route is being withdrawn, not replaced).
-	superseded := m.epoch != startEpoch
-	startReplacement := onProvenClose != nil && !superseded && !e.goodbyeWanted
-	m.mu.Unlock()
-
-	if emit {
-		slog.Info("ra: emitting standalone goodbye (owner exited without one; "+
-			"claim held across emit)", "interface", name)
-		if cfg != nil {
-			m.sendOneGoodbye(cfg) // entry still held → Apply defers, no clobber
+	// Proven closed (or s==nil). The goodbye claim and the replacement decision
+	// are made against FRESH state at the act point. Because goodbyeWanted only
+	// goes false→true and epoch only increases, we may need at most one emit
+	// pass (claim → unlock → blocking emit → re-lock); a late Withdraw that
+	// flips goodbyeWanted during that emit gap is caught on the re-lock, which
+	// re-runs the same claim-and-decide logic before acting on the replacement.
+	for {
+		m.mu.Lock()
+		e := m.draining[name]
+		if e == nil {
+			m.mu.Unlock()
+			return nil // defensive; owner holds it
 		}
-	}
 
-	var startErr error
-	m.mu.Lock()
-	if startReplacement {
-		// Old conn is PROVEN closed and the tombstone is still held → safe to
-		// open the replacement (≤1 live conn) before releasing.
-		startErr = onProvenClose()
+		// Decide goodbye claim-once with FRESH goodbyeWanted/goodbyeClaimed.
+		if e.goodbyeWanted && !e.goodbyeClaimed && s != nil && !s.goodbyeEmitted.Load() {
+			e.goodbyeClaimed = true
+			cfg := e.cfg
+			m.mu.Unlock()
+			slog.Info("ra: emitting standalone goodbye (owner exited without "+
+				"one; claim held across emit)", "interface", name)
+			if cfg != nil {
+				m.sendOneGoodbye(cfg) // entry still held → Apply defers, no clobber
+			}
+			// Re-loop: re-acquire the lock and re-evaluate against fresh state
+			// before deciding the replacement (the emit ran outside the lock).
+			continue
+		}
+
+		// No (further) goodbye owed. Decide the replacement under THIS lock with
+		// FRESH epoch + goodbyeWanted (round-5: no cached boolean). Start ONLY
+		// if epoch is still ours AND no goodbye was wanted (a withdraw overrides
+		// a replace). Neither can change while we hold the lock.
+		var startErr error
+		if onProvenClose != nil && m.epoch == startEpoch && !e.goodbyeWanted {
+			// Old conn PROVEN closed + tombstone still held → ≤1 live conn.
+			startErr = onProvenClose()
+		}
+		delete(m.draining, name)
+		m.mu.Unlock()
+		return startErr
 	}
-	delete(m.draining, name)
-	m.mu.Unlock()
-	return startErr
 }
 
 // reclaimTombstoneWhenStopped detaches a goroutine that waits for a wedged

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -314,11 +314,20 @@ func (m *Manager) startLocked(cfg *config.RAInterfaceConfig) error {
 	return nil
 }
 
-// drainingSender pairs a draining interface name with its sender for the
-// join-outside-the-lock phase.
-type drainingSender struct {
-	name string
-	s    *sender
+// gracefulTarget is one interface a graceful Withdraw is tearing down. After
+// the owning goroutine joins its sender, the manager checks whether a goodbye
+// actually went out; if not, it OWES a standalone goodbye (the owner lost the
+// upgrade race or the sender was already a stopped restart tombstone). Fields:
+//   - owned: true if THIS Withdraw owns the join (active-sender case).
+//   - observe: the sender to read goodbyeEmitted from after it has stopped
+//     (always captured under m.mu at claim time, so it never depends on the
+//     draining-map entry surviving — closes the restart-window delete race).
+//   - cfg: config to build the standalone goodbye from if owed.
+type gracefulTarget struct {
+	name    string
+	owned   bool
+	observe *sender
+	cfg     *config.RAInterfaceConfig
 }
 
 // Withdraw sends goodbye RAs (lifetime=0) on all interfaces, then stops all
@@ -333,21 +342,16 @@ func (m *Manager) Withdraw() error {
 		names = append(names, name)
 	}
 	// Also include interfaces already DRAINING (e.g. a Clear acquired m.mu
-	// first and hard-stopped them). claimGracefulLocked UPGRADES any such
-	// hard-draining sender to graceful so a "withdraw everything" still emits
-	// every goodbye (#2033 MAJOR 2); nil-sender claims (WithdrawOnce) are
-	// no-ops there.
+	// first and hard-stopped them, or a changed-config restart is mid stop->
+	// start). claimGracefulLocked upgrades a still-running owner, and the
+	// post-join owes-a-goodbye check emits a standalone goodbye if the owner
+	// was already dead (#2033 MAJOR 2 / restart window).
 	for name := range m.draining {
 		names = append(names, name)
 	}
-	// Record the graceful intent ATOMICALLY with the epoch bump and the
-	// snapshot (#2033 MAJOR 2): tombstone + signalStop(modeGraceful) happen
-	// under the SAME m.mu hold, so a racing Clear that acquires m.mu afterward
-	// sees the sender already draining-graceful and cannot drop the goodbye
-	// (signalStop is idempotent + graceful never downgrades to hard).
-	ps := m.claimGracefulLocked(names)
+	ts := m.claimGracefulLocked(names)
 	m.mu.Unlock()
-	m.joinDraining(ps)
+	m.finishGraceful(ts)
 	return nil
 }
 
@@ -356,54 +360,120 @@ func (m *Manager) Withdraw() error {
 func (m *Manager) WithdrawInterfaces(names []string) {
 	m.mu.Lock()
 	m.bumpEpoch()
-	ps := m.claimGracefulLocked(names)
+	ts := m.claimGracefulLocked(names)
 	m.mu.Unlock()
-	m.joinDraining(ps)
+	m.finishGraceful(ts)
 }
 
-// claimGracefulLocked, under m.mu, moves each named active sender to a graceful
-// draining tombstone and signals it to emit its goodbye on exit. Doing the
-// tombstone install AND signalStop(modeGraceful) under the lock makes the
-// graceful intent atomic (#2033 MAJOR 2) — a later Clear cannot delete the
-// sender and install a hard tombstone in a gap, because by the time the lock is
-// released the sender is already gone from m.senders and already modeGraceful.
-// Callers must hold m.mu. Returns the senders to join outside the lock.
-func (m *Manager) claimGracefulLocked(names []string) []drainingSender {
-	var ps []drainingSender
+// claimGracefulLocked, under m.mu, records the graceful withdrawal intent for
+// each named interface and returns the targets to finish outside the lock.
+//
+// Doing the tombstone install AND signalStop(modeGraceful) under the lock makes
+// the graceful intent atomic (#2033 MAJOR 2): a later Clear cannot delete the
+// sender and install a hard tombstone in a gap. Three cases per interface:
+//   - active sender: move to a graceful tombstone, signalStop(graceful), join
+//     it ourselves; the owner emits the goodbye on exit.
+//   - draining sender (non-nil): a Clear/restart already owns it. UPGRADE it to
+//     graceful (best-effort — works only if the owner has not yet read its
+//     mode). We do NOT join it (its owner does), but we still record cfg so the
+//     post-mortem check can emit a standalone goodbye if the upgrade lost the
+//     race (the owner already exited hard — a dead sender cannot be upgraded).
+//   - nil draining claim (a WithdrawOnce goodbye in flight): the interface is
+//     already getting exactly one goodbye; do nothing (no double goodbye).
+// Callers must hold m.mu.
+func (m *Manager) claimGracefulLocked(names []string) []gracefulTarget {
+	var ts []gracefulTarget
+	seen := make(map[string]struct{}, len(names))
 	for _, name := range names {
+		if _, dup := seen[name]; dup {
+			continue // dedup: each interface yields at most one target / goodbye
+		}
+		seen[name] = struct{}{}
 		if s, ok := m.senders[name]; ok {
 			slog.Info("ra: sending goodbye RA", "interface", name)
 			delete(m.senders, name)
 			m.draining[name] = s
 			s.signalStop(modeGraceful)
-			ps = append(ps, drainingSender{name, s})
+			ts = append(ts, gracefulTarget{name: name, owned: true, observe: s, cfg: s.cfg})
 			continue
 		}
-		// Not active. If a sender is already DRAINING (e.g. a Clear acquired
-		// m.mu first and set a hard tombstone), UPGRADE it to graceful so the
-		// goodbye is still emitted (#2033 MAJOR 2). signalStop is idempotent and
-		// graceful never downgrades; the existing Clear/Apply join will emit the
-		// upgraded goodbye, so we do NOT add it to our own join list (avoid a
-		// double <-stopped on the same sender).
 		if s := m.draining[name]; s != nil {
+			// A Clear or a changed-config restart already owns this sender's
+			// join. Upgrade it (effective only if the owner has not read its
+			// mode yet). Capture the sender pointer NOW (under m.mu) so the
+			// post-mortem owes-a-goodbye check reads goodbyeEmitted directly and
+			// does NOT depend on the draining-map entry surviving (the restart
+			// loop may delete it) — owned=false so we do not double-join.
 			slog.Info("ra: upgrading draining sender to graceful goodbye",
 				"interface", name)
 			s.signalStop(modeGraceful)
+			ts = append(ts, gracefulTarget{name: name, owned: false, observe: s, cfg: s.cfg})
+			continue
 		}
+		// nil draining claim == a WithdrawOnce standalone goodbye is already in
+		// flight for this interface; it will emit exactly one goodbye. Skip.
 	}
-	return ps
+	return ts
 }
 
-// joinDraining joins each draining sender (emitting its goodbye) OUTSIDE m.mu
-// (#2033 I16) so multi-interface demotion does not stall Status/Apply on the
-// failover hot path, then removes each tombstone when its join completes.
-func (m *Manager) joinDraining(ps []drainingSender) {
-	for _, p := range ps {
-		<-p.s.stopped // owner emits the goodbye then closes the conn
-		m.mu.Lock()
-		delete(m.draining, p.name)
-		m.mu.Unlock()
+// finishGraceful, OUTSIDE m.mu (#2033 I16 — do not stall Status/Apply on the
+// failover hot path), waits for each target's sender to stop, then guarantees
+// EXACTLY ONE goodbye per interface: if the owner did not emit one (it lost the
+// graceful upgrade race, or the sender was already a stopped restart/Clear
+// tombstone), the manager emits a standalone goodbye via the WithdrawOnce
+// mechanism. The owned tombstone is cleared as each interface completes.
+func (m *Manager) finishGraceful(ts []gracefulTarget) {
+	for _, t := range ts {
+		// Wait for the sender to finish (whoever owns the join). stopped closes
+		// exactly once; multiple readers are safe. goodbyeEmitted is stored by
+		// finishShutdown BEFORE close(stopped), so this read is ordered.
+		select {
+		case <-t.observe.stopped:
+		case <-time.After(claimWaitTimeout):
+			slog.Warn("ra: timed out waiting for sender to drain",
+				"interface", t.name)
+		}
+		owed := !t.observe.goodbyeEmitted.Load()
+
+		if owed {
+			slog.Info("ra: emitting standalone goodbye (owner exited without "+
+				"one — lost the upgrade race or was a hard restart/clear stop)",
+				"interface", t.name)
+			m.emitStandaloneGoodbye(t.name, t.cfg)
+		}
+
+		if t.owned {
+			// Clear OUR tombstone (active-sender case). The upgrade case is
+			// owned by the racing Clear/restart, which clears its own.
+			m.mu.Lock()
+			delete(m.draining, t.name)
+			m.mu.Unlock()
+		}
 	}
+}
+
+// emitStandaloneGoodbye emits a single standalone goodbye (no burst, no link
+// toggle) for an interface whose owner exited without one. It is a NO-OP only if
+// a LIVE sender exists for the interface (a newer MASTER Apply won it back — do
+// not clobber it with a lifetime-0 RA). It deliberately does NOT skip on a
+// present draining tombstone: the tombstone that brought us here is a HARD stop
+// (Clear / changed-config restart) whose owner will NOT emit a goodbye, and a
+// WithdrawOnce nil-claim is never routed here (claimGracefulLocked skips those).
+// It does not install its own tombstone — the goodbye is brief (~goodbyeCount ×
+// goodbyeDelay) and a concurrent Apply that starts a real sender during it is
+// the legitimate new-MASTER case (its own owner emits its RAs correctly). m.mu
+// must NOT be held.
+func (m *Manager) emitStandaloneGoodbye(name string, cfg *config.RAInterfaceConfig) {
+	if cfg == nil {
+		return
+	}
+	m.mu.Lock()
+	_, live := m.senders[name]
+	m.mu.Unlock()
+	if live {
+		return
+	}
+	m.sendOneGoodbye(cfg)
 }
 
 // ResendBurst tells all running senders to re-send their startup burst. Used

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -7,11 +7,14 @@ import (
 	"math/rand/v2"
 	"net"
 	"net/netip"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/mdlayher/ndp"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/net/ipv6"
 	"golang.org/x/sys/unix"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -39,27 +42,94 @@ const (
 	startupBurstDelay = 100 * time.Millisecond
 
 	// Default prefix lifetimes per RFC 4861.
-	defaultValidLifetime    = 2592000 // 30 days
+	defaultValidLifetime     = 2592000 // 30 days
 	defaultPreferredLifetime = 604800  // 7 days
+
+	// writeDeadline bounds every owner WriteTo so a stuck socket cannot wedge
+	// withdrawal (#2033 I18 / Codex r3 MODERATE #4). Because the owner always
+	// returns promptly, owner-performs-the-close (I17) is safe for both modes.
+	writeDeadline = 1 * time.Second
+
+	// rsReadDeadline bounds each rsReceiver ReadFrom so it can observe stopCh.
+	rsReadDeadline = 1 * time.Second
+	// rsErrBackoff is applied after a persistent (non-deadline) read error so
+	// rsReceiver cannot hot-loop at 100% CPU if the interface dies while stopCh
+	// is still open (#2033 I10 / AGY r4 MINOR #4).
+	rsErrBackoff = 200 * time.Millisecond
 )
 
+// shutdownMode is the arbitrated teardown intent for a sender. It is set
+// (atomically) BEFORE stopCh is closed, so any owner wakeup that observes the
+// closed channel also observes the mode. graceful UPGRADES hard (never the
+// reverse) — see signalStop (#2033 I13/I17).
+type shutdownMode int32
+
+const (
+	modeNone     shutdownMode = iota // running
+	modeHard                         // stop without a goodbye (Clear / Apply-remove)
+	modeGraceful                     // emit the lifetime-0 goodbye as the final write
+)
+
+// ndpConn is the minimal subset of *ndp.Conn that sender uses. It exists as a
+// compile-time seam so tests can substitute a recorder/injector (fakeConn)
+// without a live NDP socket. The signatures MUST match mdlayher/ndp v1.1.0
+// exactly: ndp.Message + *ipv6.ControlMessage + netip.Addr on WriteTo/ReadFrom,
+// *ipv6.ICMPFilter on SetICMPFilter, netip.Addr group on JoinGroup. Do not
+// widen this interface beyond what sender needs.
+type ndpConn interface {
+	WriteTo(m ndp.Message, cm *ipv6.ControlMessage, dst netip.Addr) error
+	ReadFrom() (ndp.Message, *ipv6.ControlMessage, netip.Addr, error)
+	Close() error
+	SetReadDeadline(t time.Time) error
+	SetWriteDeadline(t time.Time) error
+	JoinGroup(group netip.Addr) error
+	SetICMPFilter(f *ipv6.ICMPFilter) error
+}
+
+// listenFn opens an ndpConn for the interface. Overridable in tests; defaults
+// to the real mdlayher/ndp Listen.
+var listenFn = func(iface *net.Interface, addr ndp.Addr) (ndpConn, netip.Addr, error) {
+	return ndp.Listen(iface, addr)
+}
+
+// ensureLinkLocalFn lets tests stub the link-local setup (a pure netlink
+// AddrAdd after #2034) so the goodbye-only WithdrawOnce path can be asserted to
+// SKIP it entirely (#2033 I12 — it must not even attempt to add a link-local on
+// a demoting interface). Defaults to the real implementation.
+var ensureLinkLocalFn = ensureLinkLocal
+
 // sender is a per-interface RA sender goroutine.
+//
+// Single-owner contract (#2033, Path A): run() is the SOLE writer/closer of the
+// NDP connection — startup burst, periodic RAs, RS-triggered RAs AND the
+// goodbye all flow through it. No other goroutine calls conn.WriteTo or
+// conn.Close. Shutdown is signalled via signalStop (sets mode, closes stopCh
+// once); the owner reads mode after waking and, on modeGraceful, emits the
+// lifetime-0 goodbye as its FINAL action in finishShutdown — guaranteeing no
+// lifetime>0 RA follows the goodbye on the wire.
 type sender struct {
 	cfg     *config.RAInterfaceConfig
 	iface   *net.Interface
-	conn    *ndp.Conn
+	conn    ndpConn
 	srcAddr netip.Addr
-	stopCh  chan struct{}
-	stopped chan struct{}
-	lastRA  time.Time // rate-limit RS responses
+
+	mode     atomic.Int32 // shutdownMode; set BEFORE close(stopCh)
+	stopOnce sync.Once    // guards close(stopCh)
+	stopCh   chan struct{}
+	stopped  chan struct{}
+	burstCh  chan struct{} // buffered(1): request a re-burst (ResendBurst)
+
+	lastRAMu sync.Mutex
+	lastRA   time.Time // rate-limit RS responses; owner writes, Status reads
 }
 
 func newSender(cfg *config.RAInterfaceConfig, iface *net.Interface) *sender {
 	return &sender{
-		cfg:    cfg,
-		iface:  iface,
-		stopCh: make(chan struct{}),
+		cfg:     cfg,
+		iface:   iface,
+		stopCh:  make(chan struct{}),
 		stopped: make(chan struct{}),
+		burstCh: make(chan struct{}, 1),
 	}
 }
 
@@ -67,31 +137,11 @@ func newSender(cfg *config.RAInterfaceConfig, iface *net.Interface) *sender {
 // Ensures a link-local address exists (RETH interfaces suppress auto
 // link-local via addr_gen_mode=1, so we add one explicitly with NODAD).
 func (s *sender) start() error {
-	if err := ensureLinkLocal(s.iface); err != nil {
+	if err := ensureLinkLocalFn(s.iface); err != nil {
 		slog.Warn("ra: failed to ensure link-local", "interface", s.iface.Name, "err", err)
 	}
 
-	// Determine NDP bind address: use explicitly configured link-local if set,
-	// otherwise default to any link-local on the interface.
-	var bindAddr ndp.Addr = ndp.LinkLocal
-	if s.cfg.SourceLinkLocal != "" {
-		bindAddr = ndp.Addr(s.cfg.SourceLinkLocal)
-	}
-
-	var conn *ndp.Conn
-	var srcAddr netip.Addr
-	var err error
-	for attempt := 0; attempt < 10; attempt++ {
-		conn, srcAddr, err = ndp.Listen(s.iface, bindAddr)
-		if err == nil {
-			break
-		}
-		// Re-read interface (link-local may appear after addr add).
-		time.Sleep(200 * time.Millisecond)
-		if iface, e := net.InterfaceByName(s.iface.Name); e == nil {
-			s.iface = iface
-		}
-	}
+	conn, srcAddr, err := s.listen()
 	if err != nil {
 		return err
 	}
@@ -117,34 +167,131 @@ func (s *sender) start() error {
 	return nil
 }
 
-// stop signals the sender goroutine to exit and waits.
-func (s *sender) stop() {
-	close(s.stopCh)
-	if s.conn != nil {
-		s.conn.Close()
+// sendGoodbyeStandalone is the WithdrawOnce goodbye-only entry point. It opens
+// a connection, emits the lifetime-0 goodbye, and closes — WITHOUT launching
+// run() and WITHOUT the startup burst (so it never re-advertises the router it
+// is withdrawing — fixes S1). Per #2033 I12 it MUST NOT toggle the link: if no
+// usable link-local exists, ndp.Listen fails and the goodbye is skipped
+// best-effort rather than cycling a demoting interface (which may be mid-RETH-
+// MAC-cycle). Returns an error only when the conn could not be opened so the
+// caller can log; a goodbye is otherwise emitted and the conn closed here.
+func (s *sender) sendGoodbyeStandalone() error {
+	conn, srcAddr, err := s.listen()
+	if err != nil {
+		return err
 	}
-	<-s.stopped
+	s.conn = conn
+	s.srcAddr = srcAddr
+	defer s.conn.Close()
+	s.sendGoodbyeRA()
+	return nil
 }
 
-// run is the main sender loop.
+// listen opens the NDP connection with the configured bind address, retrying
+// while the link-local address settles after ensureLinkLocal.
+func (s *sender) listen() (ndpConn, netip.Addr, error) {
+	var bindAddr ndp.Addr = ndp.LinkLocal
+	if s.cfg.SourceLinkLocal != "" {
+		bindAddr = ndp.Addr(s.cfg.SourceLinkLocal)
+	}
+
+	var conn ndpConn
+	var srcAddr netip.Addr
+	var err error
+	for attempt := 0; attempt < 10; attempt++ {
+		conn, srcAddr, err = listenFn(s.iface, bindAddr)
+		if err == nil {
+			return conn, srcAddr, nil
+		}
+		// Re-read interface (link-local may appear after addr add).
+		time.Sleep(200 * time.Millisecond)
+		if iface, e := net.InterfaceByName(s.iface.Name); e == nil {
+			s.iface = iface
+		}
+	}
+	return nil, netip.Addr{}, err
+}
+
+// signalStop publishes the teardown intent then closes stopCh exactly once.
+//
+// The mode store happens-before the close (which in turn happens-before the
+// owner's wakeup on the closed channel — Go memory model), so the owner that
+// observes the closed stopCh also observes the mode.
+//
+// GRACEFUL UPGRADES HARD (#2033 I13/I17): in cluster mode a demotion Withdraw
+// (VRRP-event goroutine, no applySem) can race a config-apply Clear for the
+// same sender — pkg/ra's m.mu is the ONLY serialization. First-writer-wins
+// would let a benign Clear drop the demotion goodbye (the exact bug). So a
+// graceful request wins over a hard one: graceful is stored unconditionally,
+// hard only if nothing was set yet. NEVER downgrade graceful->hard. Because
+// the owner performs conn.Close AFTER emitting the goodbye (finishShutdown,
+// I17), a racing hard close can never kill the upgraded goodbye. The only
+// residual is the sub-microsecond window where the owner already read modeHard
+// before the upgrade store — accepted as best-effort (the new primary's RA is
+// the real recovery).
+func (s *sender) signalStop(m shutdownMode) {
+	if m == modeGraceful {
+		s.mode.Store(int32(modeGraceful))
+	} else {
+		s.mode.CompareAndSwap(int32(modeNone), int32(modeHard))
+	}
+	s.stopOnce.Do(func() { close(s.stopCh) })
+}
+
+// stop tears the sender down WITHOUT a goodbye (Clear / Apply-remove). The
+// owner closes the conn in finishShutdown.
+func (s *sender) stop() { s.signalStop(modeHard); <-s.stopped }
+
+// withdrawAndStop tears the sender down emitting the lifetime-0 goodbye as the
+// final write (graceful demotion).
+func (s *sender) withdrawAndStop() { s.signalStop(modeGraceful); <-s.stopped }
+
+// requestBurst asks the owner to re-emit the startup burst (after a RETH MAC
+// link cycle killed the socket). Non-blocking: if a burst is already queued or
+// the sender is draining, the request is dropped.
+func (s *sender) requestBurst() {
+	if s.draining() {
+		return
+	}
+	select {
+	case s.burstCh <- struct{}{}:
+	default:
+	}
+}
+
+// draining reports whether a shutdown has been signalled. It is a best-effort
+// early-out for the burst/RS paths; the correctness mechanism is that the
+// goodbye is owner-emitted on exit (so any in-flight normal RA necessarily
+// PRECEDES it).
+func (s *sender) draining() bool { return s.mode.Load() != int32(modeNone) }
+
+// run is the single-owner sender loop. It is the ONLY goroutine that writes or
+// closes the connection.
 func (s *sender) run() {
 	defer close(s.stopped)
 
-	// Send an initial burst so hosts do not wait for the periodic timer to
-	// relearn a default router after xpfd restarts or HA role changes.
-	s.sendStartupBurst()
+	// Interruptible startup burst so a withdraw during startup cannot leave a
+	// normal RA after the goodbye.
+	s.burstInterruptible()
+	if s.draining() {
+		s.finishShutdown()
+		return
+	}
 
 	advTimer := time.NewTimer(s.randomAdvInterval())
 	defer advTimer.Stop()
 
-	// Receiver goroutine forwards RS events.
 	rsCh := make(chan netip.Addr, 8)
 	go s.rsReceiver(rsCh)
 
 	for {
 		select {
 		case <-s.stopCh:
+			s.finishShutdown()
 			return
+
+		case <-s.burstCh:
+			s.burstInterruptible()
 
 		case <-advTimer.C:
 			s.sendRA()
@@ -152,50 +299,97 @@ func (s *sender) run() {
 
 		case _, ok := <-rsCh:
 			if !ok {
+				// rsReceiver only closes rsCh after observing stopCh (I14),
+				// so this implies shutdown is already in progress.
+				s.finishShutdown()
 				return
 			}
 			// Rate-limit multicast RA responses per RFC 4861 §6.2.6.
-			if time.Since(s.lastRA) < minRAMulticastDelay {
+			if time.Since(s.getLastRA()) < minRAMulticastDelay {
 				continue
 			}
-			// Random delay before responding.
-			delay := time.Duration(rand.IntN(int(maxRSDelay)))
-			time.Sleep(delay)
-			// Re-check after delay.
+			// Random delay before responding, interruptible by shutdown.
+			t := time.NewTimer(time.Duration(rand.IntN(int(maxRSDelay))))
 			select {
 			case <-s.stopCh:
+				t.Stop()
+				s.finishShutdown()
 				return
-			default:
+			case <-t.C:
 			}
 			s.sendRA()
-			// Reset periodic timer after RS-triggered RA.
 			advTimer.Reset(s.randomAdvInterval())
 		}
 	}
 }
 
-func (s *sender) sendStartupBurst() {
+// finishShutdown is the ONLY place the goodbye is emitted AND the ONLY place
+// the conn is closed (#2033 I17). It runs on the owner after the loop is gone,
+// so no normal RA can follow the goodbye. The mode is re-read here, honoring a
+// graceful upgrade that landed before the owner woke. The conn is closed AFTER
+// the goodbye, which also unblocks the detached rsReceiver's ReadFrom (I10).
+func (s *sender) finishShutdown() {
+	if shutdownMode(s.mode.Load()) == modeGraceful {
+		s.sendGoodbyeRA()
+	}
+	if s.conn != nil {
+		s.conn.Close()
+	}
+}
+
+// burstInterruptible emits the startup burst (startupBurstCount normal RAs),
+// checking draining()/stopCh between sends so a concurrent withdraw stops the
+// burst immediately. A legitimate start emits all RAs (I3); a draining sender
+// short-circuits (I11/I15).
+func (s *sender) burstInterruptible() {
 	for i := 0; i < startupBurstCount; i++ {
+		if s.draining() {
+			return
+		}
 		s.sendRA()
 		if i < startupBurstCount-1 {
-			time.Sleep(startupBurstDelay)
+			t := time.NewTimer(startupBurstDelay)
+			select {
+			case <-s.stopCh:
+				t.Stop()
+				return
+			case <-t.C:
+			}
 		}
 	}
 }
 
-// rsReceiver reads Router Solicitations and forwards them to the channel.
+// rsReceiver reads Router Solicitations and forwards them to the channel. It is
+// a detached goroutine bounded by the owner's conn.Close (I10): the owner exits
+// on stopCh regardless of rsCh state, then closes the conn, which unblocks this
+// ReadFrom within one deadline at worst. It backs off on a persistent
+// non-deadline read error so it cannot hot-loop if the interface dies while
+// stopCh is still open (I10 / AGY r4 MINOR #4). It returns (closing rsCh) ONLY
+// after observing stopCh (I14), so the owner's "rsCh closed" branch always
+// implies shutdown is already in progress.
 func (s *sender) rsReceiver(ch chan<- netip.Addr) {
 	defer close(ch)
 	for {
-		s.conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+		s.conn.SetReadDeadline(time.Now().Add(rsReadDeadline))
 		msg, _, src, err := s.conn.ReadFrom()
 		if err != nil {
 			select {
 			case <-s.stopCh:
 				return
 			default:
-				continue
 			}
+			// Not shutting down: a deadline timeout is the expected poll
+			// signal; any other persistent error must not hot-loop.
+			if !isTimeout(err) {
+				t := time.NewTimer(rsErrBackoff)
+				select {
+				case <-s.stopCh:
+					t.Stop()
+					return
+				case <-t.C:
+				}
+			}
+			continue
 		}
 
 		if _, ok := msg.(*ndp.RouterSolicitation); !ok {
@@ -209,26 +403,52 @@ func (s *sender) rsReceiver(ch chan<- netip.Addr) {
 	}
 }
 
-// sendRA sends a Router Advertisement to all-nodes multicast (ff02::1).
+// isTimeout reports whether err is an i/o deadline timeout (the expected
+// rsReceiver poll signal) rather than a genuine socket error.
+func isTimeout(err error) bool {
+	type timeout interface{ Timeout() bool }
+	te, ok := err.(timeout)
+	return ok && te.Timeout()
+}
+
+// getLastRA returns the last-RA timestamp under lastRAMu.
+func (s *sender) getLastRA() time.Time {
+	s.lastRAMu.Lock()
+	defer s.lastRAMu.Unlock()
+	return s.lastRA
+}
+
+// setLastRA records the last-RA timestamp under lastRAMu.
+func (s *sender) setLastRA(t time.Time) {
+	s.lastRAMu.Lock()
+	s.lastRA = t
+	s.lastRAMu.Unlock()
+}
+
+// sendRA sends a normal Router Advertisement to all-nodes multicast (ff02::1).
+// Owner-only.
 func (s *sender) sendRA() {
 	ra := s.buildRA()
 	allNodes := netip.MustParseAddr("ff02::1")
+	s.conn.SetWriteDeadline(time.Now().Add(writeDeadline))
 	if err := s.conn.WriteTo(ra, nil, allNodes); err != nil {
 		slog.Warn("ra: failed to send RA",
 			"interface", s.cfg.Interface, "err", err)
 		return
 	}
-	s.lastRA = time.Now()
+	s.setLastRA(time.Now())
 	slog.Debug("ra: sent RA", "interface", s.cfg.Interface)
 }
 
 // sendGoodbyeRA sends goodbye RAs (lifetime=0) multiple times for reliability.
+// Owner-only — emitted as the final write in finishShutdown.
 func (s *sender) sendGoodbyeRA() {
 	ra := s.buildRA()
 	ra.RouterLifetime = 0
 	allNodes := netip.MustParseAddr("ff02::1")
 
 	for i := 0; i < goodbyeCount; i++ {
+		s.conn.SetWriteDeadline(time.Now().Add(writeDeadline))
 		if err := s.conn.WriteTo(ra, nil, allNodes); err != nil {
 			slog.Warn("ra: failed to send goodbye RA",
 				"interface", s.cfg.Interface, "err", err)

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -119,6 +119,15 @@ type sender struct {
 	stopped  chan struct{}
 	burstCh  chan struct{} // buffered(1): request a re-burst (ResendBurst)
 
+	// goodbyeEmitted records whether finishShutdown actually emitted the
+	// lifetime-0 goodbye. The manager reads it AFTER the join (<-stopped) to
+	// decide whether it still OWES a standalone goodbye for a graceful
+	// withdrawal that lost the upgrade race (the owner already read modeHard
+	// and exited before the graceful upgrade landed — a dead sender cannot be
+	// resurrected). This makes "exactly one goodbye per withdrawn interface" a
+	// post-mortem fact, not a timing gamble (#2033 MAJOR 2 / restart window).
+	goodbyeEmitted atomic.Bool
+
 	lastRAMu sync.Mutex
 	lastRA   time.Time // rate-limit RS responses; owner writes, Status reads
 }
@@ -331,6 +340,10 @@ func (s *sender) run() {
 func (s *sender) finishShutdown() {
 	if shutdownMode(s.mode.Load()) == modeGraceful {
 		s.sendGoodbyeRA()
+		// Record the fact for the manager's post-join owes-a-goodbye check.
+		// Set AFTER the send and BEFORE close(s.stopped) (the caller's defer),
+		// so a manager that observes <-stopped also observes this store.
+		s.goodbyeEmitted.Store(true)
 	}
 	if s.conn != nil {
 		s.conn.Close()

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -327,6 +327,14 @@ func (s *sender) run() {
 			case <-t.C:
 			}
 			s.sendRA()
+			// Re-pace the unsolicited schedule off this solicited RA (RFC 4861
+			// §6.2.6). This Reset is not preceded by a drain of advTimer.C, so
+			// in the rare interleave where advTimer fired while this RS was being
+			// handled and select picked the RS arm, the next loop iteration may
+			// read a stale fire and emit one early unsolicited RA. That is a
+			// benign, idempotent extra RA (never a goodbye-ordering violation),
+			// so the drain dance is intentionally omitted in this single-owner
+			// loop.
 			advTimer.Reset(s.randomAdvInterval())
 		}
 	}
@@ -339,11 +347,19 @@ func (s *sender) run() {
 // the goodbye, which also unblocks the detached rsReceiver's ReadFrom (I10).
 func (s *sender) finishShutdown() {
 	if shutdownMode(s.mode.Load()) == modeGraceful {
-		s.sendGoodbyeRA()
-		// Record the fact for the manager's post-join owes-a-goodbye check.
+		// Record the fact for the manager's post-join owes-a-goodbye check, but
+		// ONLY if the goodbye actually went out. On a write failure (interface
+		// down mid-withdraw) leave goodbyeEmitted=false so the manager's
+		// release-time backstop (ra.go: !goodbyeEmitted) retries the goodbye on
+		// a FRESH conn (sendOneGoodbye -> newSender) — the owner's conn is
+		// closed just below and cannot be retried here. Goodbyes are idempotent
+		// (repeated lifetime=0) and the backstop emits only goodbyes, so the
+		// retry cannot violate the goodbye-is-last ordering invariant.
 		// Set AFTER the send and BEFORE close(s.stopped) (the caller's defer),
 		// so a manager that observes <-stopped also observes this store.
-		s.goodbyeEmitted.Store(true)
+		if s.sendGoodbyeRA() {
+			s.goodbyeEmitted.Store(true)
+		}
 	}
 	if s.conn != nil {
 		s.conn.Close()
@@ -454,8 +470,13 @@ func (s *sender) sendRA() {
 }
 
 // sendGoodbyeRA sends goodbye RAs (lifetime=0) multiple times for reliability.
-// Owner-only — emitted as the final write in finishShutdown.
-func (s *sender) sendGoodbyeRA() {
+// Owner-only — emitted as the final write in finishShutdown. It returns true
+// only when the full sequence was written without error; a write failure
+// returns false so finishShutdown leaves goodbyeEmitted=false and the manager's
+// release-time backstop retries the goodbye on a fresh conn. (The standalone
+// backstop path, sendGoodbyeStandalone, ignores the bool — it is itself the
+// retry, so there is no further fallback to arm.)
+func (s *sender) sendGoodbyeRA() bool {
 	ra := s.buildRA()
 	ra.RouterLifetime = 0
 	allNodes := netip.MustParseAddr("ff02::1")
@@ -465,13 +486,14 @@ func (s *sender) sendGoodbyeRA() {
 		if err := s.conn.WriteTo(ra, nil, allNodes); err != nil {
 			slog.Warn("ra: failed to send goodbye RA",
 				"interface", s.cfg.Interface, "err", err)
-			return
+			return false
 		}
 		if i < goodbyeCount-1 {
 			time.Sleep(goodbyeDelay)
 		}
 	}
 	slog.Info("ra: goodbye RA sent (lifetime=0)", "interface", s.cfg.Interface)
+	return true
 }
 
 // buildRA constructs a Router Advertisement from the config.

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -49,6 +49,11 @@ type fakeConn struct {
 	// block) does not deadlock against the recording lock, and so concurrent
 	// set-by-test / read-by-owner is race-free.
 	beforeWrite atomic.Pointer[func(lifetime time.Duration)]
+
+	// beforeClose, if non-nil, is invoked at the top of Close so a test can
+	// hold the conn LIVE (block the owner's finishShutdown close) to probe the
+	// stop->start window. Same race-free atomic.Pointer discipline.
+	beforeClose atomic.Pointer[func()]
 }
 
 func newFakeConn() *fakeConn {
@@ -62,6 +67,15 @@ func (f *fakeConn) setBeforeWrite(fn func(lifetime time.Duration)) {
 		return
 	}
 	f.beforeWrite.Store(&fn)
+}
+
+// setBeforeClose installs (or clears, with nil) the Close hook race-free.
+func (f *fakeConn) setBeforeClose(fn func()) {
+	if fn == nil {
+		f.beforeClose.Store(nil)
+		return
+	}
+	f.beforeClose.Store(&fn)
 }
 
 func (f *fakeConn) WriteTo(m ndp.Message, _ *ipv6.ControlMessage, _ netip.Addr) error {
@@ -115,6 +129,9 @@ func (f *fakeConn) injectRS(src netip.Addr) {
 }
 
 func (f *fakeConn) Close() error {
+	if hook := f.beforeClose.Load(); hook != nil {
+		(*hook)()
+	}
 	f.mu.Lock()
 	already := f.closed
 	f.closed = true
@@ -816,4 +833,197 @@ func TestStatusReportsDraining(t *testing.T) {
 			t.Fatalf("draining entry lingered after Withdraw completed: %+v", info)
 		}
 	}
+}
+
+// configChanged returns a testCfg for iface with a DIFFERENT prefix so
+// configEqual reports a change (forcing Apply down the replace path).
+func configChanged(iface string) *config.RAInterfaceConfig {
+	c := testCfg(iface)
+	c.Prefixes = []*config.RAPrefix{
+		{Prefix: "2001:db8:dead::/64", OnLink: true, Autonomous: true},
+	}
+	return c
+}
+
+// TestT2a_ChangedConfigApplyNeverTwoLiveConns is the #2033 MAJOR 1 regression.
+// A changed-config Apply must STOP the old sender (close its conn) BEFORE
+// opening the replacement conn — never two live conns for one interface. The
+// old sender's conn.Close is held open via beforeClose; while it is held, a
+// changed-config Apply runs and we assert the live-conn count never exceeds 1
+// (i.e. the replacement conn is NOT opened until the old one is gone).
+//
+// NON-TAUTOLOGY: against the pre-fix code (startLocked(cfg) opens the new conn
+// BEFORE s.stop() runs) the replacement conn is opened while the old is still
+// live, so liveCount reaches 2 during the hold and this test FAILS.
+func TestT2a_ChangedConfigApplyNeverTwoLiveConns(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	getConn, liveCount := installFakeListen(t)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	old := waitConn(t, getConn, "lo")
+	waitWrites(t, old, 1) // sender is up and writing
+
+	// Hold the OLD sender's conn.Close open so the old sender stays live.
+	release := make(chan struct{})
+	closing := make(chan struct{})
+	var once sync.Once
+	old.setBeforeClose(func() {
+		once.Do(func() { close(closing) })
+		<-release
+	})
+
+	// Run the changed-config Apply concurrently; it must block stopping the old
+	// sender (its owner is parked in beforeClose) and must NOT open a new conn
+	// while the old is live.
+	applyDone := make(chan error, 1)
+	go func() {
+		applyDone <- m.Apply([]*config.RAInterfaceConfig{configChanged("lo")})
+	}()
+
+	// Wait until the old sender's close is in flight (Apply has reached the
+	// stop/join of the old sender).
+	select {
+	case <-closing:
+	case <-time.After(2 * time.Second):
+		t.Fatal("changed-config Apply never reached the old sender's close")
+	}
+
+	// While the old conn is held live, sample the live-conn count repeatedly.
+	// With the fix it stays 1 (replacement not yet opened); pre-fix it is 2.
+	for i := 0; i < 50; i++ {
+		if lc := liveCount(); lc > 1 {
+			t.Fatalf("two live conns during changed-config Apply (live=%d): "+
+				"replacement opened before the old conn closed (#2033 MAJOR 1)", lc)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Release the old close; Apply completes and starts the replacement.
+	close(release)
+	select {
+	case err := <-applyDone:
+		if err != nil {
+			t.Fatalf("changed-config Apply returned: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("changed-config Apply did not complete after releasing the old close")
+	}
+
+	// Exactly one live conn (the replacement) and no lingering tombstone.
+	if lc := liveCount(); lc != 1 {
+		t.Fatalf("after replace: live conns = %d, want 1", lc)
+	}
+	for _, info := range m.Status() {
+		if info.State == "draining" {
+			t.Fatalf("draining tombstone lingered after replace: %+v", info)
+		}
+	}
+	_ = m.Clear()
+}
+
+// TestT7b_ManagerHardFirstThenGracefulStillGoodbye is the #2033 MAJOR 2
+// regression. A Clear (hard) can acquire m.mu first, delete the sender, install
+// a tombstone and signalStop(modeHard). A graceful Withdraw arriving afterward
+// must STILL cause the goodbye to be emitted — claimGracefulLocked UPGRADES the
+// still-draining hard sender to graceful, and signalStop's graceful-upgrades-
+// hard guarantees the owner emits the goodbye in finishShutdown.
+//
+// We force the interleave deterministically by PARKING the owner in its startup
+// burst (beforeWrite), i.e. BEFORE it ever reaches finishShutdown and reads its
+// mode. While parked: Clear signals hard, then Withdraw upgrades to graceful —
+// both Stores land before the owner reads the mode. Releasing the burst lets the
+// owner finish, see draining, and read the upgraded graceful mode → goodbye.
+//
+// NON-TAUTOLOGY: against the pre-fix code (Withdraw bumps epoch + unlocks, then
+// re-locks and sees no active sender → skips; Clear's hard tombstone is never
+// upgraded) NO goodbye is emitted and this test FAILS.
+func TestT7b_ManagerHardFirstThenGracefulStillGoodbye(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+
+	// Park the owner at its FIRST burst write, before it can reach the select
+	// loop or finishShutdown (where the mode is read). Pre-registered so it is
+	// in place before the owner's first write.
+	release := make(chan struct{})
+	parked := make(chan struct{})
+	var once sync.Once
+	fl.preHook("lo", func(lifetime time.Duration) {
+		if lifetime > 0 {
+			once.Do(func() { close(parked); <-release })
+		}
+	})
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	fc := waitConn(t, fl.getConn, "lo")
+
+	<-parked // owner is blocked in its first burst write (mode not read yet)
+
+	// Clear (hard) first: deletes the sender, installs a hard tombstone,
+	// signalStop(modeHard). Its join blocks on the parked owner, so run it in a
+	// goroutine.
+	clearDone := make(chan error, 1)
+	go func() { clearDone <- m.Clear() }()
+
+	// Then a graceful Withdraw for the same interface. With no active sender it
+	// must find the draining (hard) sender and UPGRADE it to graceful. Poll
+	// until the Clear has installed the tombstone (Withdraw's upgrade is a
+	// no-op until then), then issue the Withdraw.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		ts := false
+		for _, info := range m.Status() {
+			if info.Interface == "lo" && info.State == "draining" {
+				ts = true
+			}
+		}
+		if ts {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Clear never installed the draining tombstone")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	withdrawDone := make(chan error, 1)
+	go func() { withdrawDone <- m.Withdraw() }()
+	// Let the Withdraw acquire m.mu and upgrade the mode before we release.
+	time.Sleep(50 * time.Millisecond)
+
+	// Release the burst; the owner finishes it, sees draining, and reads the
+	// upgraded graceful mode in finishShutdown → emits the goodbye.
+	close(release)
+
+	select {
+	case <-clearDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Clear did not complete")
+	}
+	select {
+	case <-withdrawDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Withdraw did not complete")
+	}
+
+	writes := fc.snapshot()
+	var sawGoodbye bool
+	for _, w := range writes {
+		if w.lifetime == 0 {
+			sawGoodbye = true
+		}
+	}
+	if !sawGoodbye {
+		t.Fatalf("no goodbye emitted: a graceful Withdraw racing a hard Clear "+
+			"must still emit the goodbye (#2033 MAJOR 2); writes=%+v", writes)
+	}
+	assertGoodbyeIsLast(t, writes)
 }

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -1078,104 +1078,59 @@ func TestT7c_WithdrawAfterDeadHardSenderEmitsStandaloneGoodbye(t *testing.T) {
 		t.Skip("lo interface unavailable")
 	}
 	fl := newFakeListen(t)
-
 	m := New()
-	// Two senders: A (the one we withdraw) and B (used to hold clearLocked's
-	// join loop open). We need two real interface names; "lo" resolves, and a
-	// second resolvable name — reuse "lo" is not possible (same key), so drive A
-	// directly as a sender on a synthetic interface added to the manager, and
-	// use "lo" for B via Apply.
-	//
-	// Simpler: run BOTH through the manager using "lo" for A is impossible (one
-	// key). Instead start A as a real sender object inserted into m.senders
-	// under a synthetic name (manager Clear/Withdraw operate purely on the maps
-	// + sender objects; they only call net.InterfaceByName in startLocked /
-	// sendOneGoodbye). sendOneGoodbye for A WILL call net.InterfaceByName(A) —
-	// so A must be a resolvable name. Use "lo" for A (the withdrawn one, needs
-	// standalone goodbye) and a synthetic name for B (only needs to block the
-	// join; its sendOneGoodbye is never called).
-	ifaceB := &net.Interface{Name: "draintestB", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 2}}
-	sB := newSender(testCfg("draintestB"), ifaceB)
-	if err := sB.start(); err != nil {
-		t.Fatalf("start B: %v", err)
-	}
-	fcB := waitConn(t, fl.getConn, "draintestB")
-	_ = fcB
 
-	ifaceA := &net.Interface{Name: "lo", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
-	sA := newSender(testCfg("lo"), ifaceA)
-	if err := sA.start(); err != nil {
-		t.Fatalf("start A: %v", err)
+	// Construct the dead-hard-tombstone state DIRECTLY (deterministic — no
+	// dependence on Clear's nondeterministic per-interface release order): start
+	// a "lo" sender, hard-stop it, wait until it is fully DEAD (goodbyeEmitted=
+	// false, stopped closed), then install a drainEntry. This is exactly the
+	// state a completed hard Clear leaves while its tombstone is still held.
+	iface := &net.Interface{Name: "lo", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	s := newSender(testCfg("lo"), iface)
+	if err := s.start(); err != nil {
+		t.Fatalf("start: %v", err)
 	}
-	fcA := waitConn(t, fl.getConn, "lo")
-	waitWrites(t, fcA, 1)
+	fc := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, fc, 1)
+	s.signalStop(modeHard)
+	select {
+	case <-s.stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sender never stopped")
+	}
+	if s.goodbyeEmitted.Load() {
+		t.Fatal("precondition: hard stop should not have emitted a goodbye")
+	}
 
-	// Insert both into the manager's active set so Clear sees them.
+	// THIS test owns the dead entry's release. A racing graceful Withdraw flips
+	// goodbyeWanted (it owns no release for an already-draining entry); then the
+	// owner releases via releaseDrain. The dead sender cannot be upgraded, so a
+	// STANDALONE goodbye must be emitted.
 	m.mu.Lock()
-	m.senders["draintestB"] = sB
-	m.senders["lo"] = sA
+	m.draining["lo"] = &drainEntry{sender: s, cfg: s.cfg}
 	m.mu.Unlock()
 
-	// Gate B's Close so clearLocked blocks in its join loop (after A has fully
-	// finished). A emits no goodbye (hard) and fully exits; B's owner is parked
-	// in Close, so clearLocked has NOT yet removed any tombstones.
-	releaseB := make(chan struct{})
-	bClosing := make(chan struct{})
-	var once sync.Once
-	fcB.setBeforeClose(func() {
-		once.Do(func() { close(bClosing) })
-		<-releaseB
-	})
-
-	clearDone := make(chan error, 1)
-	go func() { clearDone <- m.Clear() }()
-
-	// Wait until B's close is in flight — by now A is fully stopped and its
-	// tombstone is still present (clearLocked removes tombstones only after the
-	// whole join loop).
-	select {
-	case <-bClosing:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Clear never reached B's close")
-	}
-	// Ensure A's owner has fully exited (stopped closed) and emitted no goodbye.
-	select {
-	case <-sA.stopped:
-	case <-time.After(2 * time.Second):
-		t.Fatal("A's sender never stopped")
-	}
-	if sA.goodbyeEmitted.Load() {
-		t.Fatal("precondition broken: A (hard Clear) should NOT have emitted a goodbye")
-	}
-
-	// Graceful Withdraw of A while A's dead sender is still in the draining map.
 	withdrawDone := make(chan error, 1)
 	go func() { withdrawDone <- m.Withdraw() }()
-	// Withdraw must emit a standalone goodbye for A; give it time.
-	time.Sleep(100 * time.Millisecond)
-
-	// Release B so Clear can finish.
-	close(releaseB)
 	select {
-	case <-clearDone:
+	case <-withdrawDone: // flips goodbyeWanted; owns no release here
 	case <-time.After(2 * time.Second):
-		t.Fatal("Clear did not complete")
-	}
-	select {
-	case <-withdrawDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Withdraw did not complete")
+		t.Fatal("Withdraw did not return")
 	}
 
-	// A must have received exactly one goodbye event (via the standalone path).
+	m.mu.Lock()
+	ep := m.epoch
+	m.mu.Unlock()
+	m.releaseDrain("lo", s, ep, nil)
+
 	total, conns := fl.goodbyeStats("lo")
 	if conns == 0 {
-		t.Fatalf("no goodbye emitted for the withdrawn interface (A); a dead "+
-			"hard sender must get a STANDALONE goodbye (#2033 MAJOR 2 dead-sender)")
+		t.Fatalf("no goodbye emitted for the withdrawn interface; a dead hard "+
+			"sender must get a STANDALONE goodbye (#2033 MAJOR 2 dead-sender)")
 	}
 	if conns != 1 || total != goodbyeCount {
-		t.Fatalf("expected exactly one goodbye event for A (1 conn, %d writes); "+
-			"got %d conns, %d writes", goodbyeCount, conns, total)
+		t.Fatalf("expected exactly one goodbye event (1 conn, %d writes); got "+
+			"%d conns, %d writes", goodbyeCount, conns, total)
 	}
 }
 
@@ -1770,4 +1725,167 @@ func TestRestartTimeoutNoReplacementWhenNoGoodbye(t *testing.T) {
 		t.Fatalf("pure restart emitted a goodbye (%d conns / %d writes); expected 0", conns, total)
 	}
 	close(wedge)
+}
+
+// --- #2033 round-5: replacement decision is atomic under the act-lock ---
+
+// installRestartEntry builds the state a changed-config restart reaches just
+// before releaseDrain's final decision: an OLD sender, fully hard-stopped and
+// dead (goodbyeEmitted=false, stopped closed), recorded in a drainEntry, plus
+// the startEpoch the restart captured. Returns the old sender, its config, and
+// the captured epoch. The caller drives releaseDrain(...) with an onProvenClose
+// that starts the replacement, racing a Withdraw/Clear that supersedes it.
+func installRestartEntry(t *testing.T, fl *fakeListen, m *Manager) (old *sender, cfg *config.RAInterfaceConfig, startEpoch uint64) {
+	t.Helper()
+	iface := &net.Interface{Name: "lo", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	old = newSender(testCfg("lo"), iface)
+	if err := old.start(); err != nil {
+		t.Fatalf("start old: %v", err)
+	}
+	fc := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, fc, 1)
+	old.signalStop(modeHard)
+	select {
+	case <-old.stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("old sender never stopped")
+	}
+	if old.goodbyeEmitted.Load() {
+		t.Fatal("precondition: old hard stop should not have emitted a goodbye")
+	}
+	m.mu.Lock()
+	m.draining["lo"] = &drainEntry{sender: old, cfg: old.cfg}
+	startEpoch = m.epoch // the restart captured THIS epoch before unlocking
+	m.mu.Unlock()
+	return old, testCfg("lo"), startEpoch
+}
+
+// TestRound5_WithdrawDuringRestartDecisionNoReplacementGoodbyeEmitted: a
+// graceful Withdraw that bumps the epoch AND flips goodbyeWanted BEFORE the
+// restart's releaseDrain reaches its act-lock must make the restart emit the
+// goodbye and NOT start the replacement (RA not re-armed). releaseDrain
+// re-evaluates epoch + goodbyeWanted UNDER the act-lock with fresh state — no
+// cached boolean — so the withdraw wins.
+//
+// NON-TAUTOLOGY: against the cached-boolean code (decision computed at the first
+// lock, trusted across the unlock) the restart starts the replacement (RA
+// re-armed after a newer withdraw) → a live sender exists → this test FAILS.
+// (Mutation-verified with a gap-widening cached-boolean mutant.)
+func TestRound5_WithdrawDuringRestartDecisionNoReplacementGoodbyeEmitted(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	old, cfg, startEpoch := installRestartEntry(t, fl, m)
+
+	// onProvenClose runs UNDER the act-lock. The fix's contract is that it is
+	// invoked ONLY when, AT THE ACT MOMENT, epoch==startEpoch AND !goodbyeWanted.
+	// Capture the LIVE epoch + goodbyeWanted observed at call time; a violation
+	// (called despite a supersession) is the cached-boolean bug.
+	var startedDespiteSupersede bool
+	startCalled := false
+	onProvenClose := func() error {
+		startCalled = true
+		// We hold m.mu here. Fresh epoch must still be ours and no goodbye
+		// wanted — otherwise a stale cached boolean started us after a newer op.
+		if m.epoch != startEpoch || m.draining["lo"].goodbyeWanted {
+			startedDespiteSupersede = true
+		}
+		return m.startLocked(cfg)
+	}
+
+	// Launch releaseDrain FIRST so it enters its decision; fire the superseding
+	// Withdraw shortly after, so on a cached-boolean impl with a widened gap the
+	// Withdraw lands in the decision→act window and the stale boolean re-arms RA.
+	// On the FIXED code decision+act are atomic under one lock, so the Withdraw
+	// lands strictly before or after — never mid-decision — and onProvenClose is
+	// never called after a supersession.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	relErr := make(chan error, 1)
+	go func() { defer wg.Done(); relErr <- m.releaseDrain("lo", old, startEpoch, onProvenClose) }()
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond) // try to land in the decision→act gap
+		_ = m.Withdraw()
+	}()
+	wg.Wait()
+	if err := <-relErr; err != nil {
+		t.Fatalf("releaseDrain: %v", err)
+	}
+
+	// The precise round-5 invariant: onProvenClose (start the replacement) must
+	// NEVER run after a supersession was already visible at the act moment. A
+	// cached-boolean impl violates this — it calls onProvenClose with the stale
+	// boolean while the live epoch has advanced / goodbyeWanted has flipped,
+	// re-arming RA after a newer withdraw. The fixed code re-reads epoch +
+	// goodbyeWanted UNDER the act-lock, so onProvenClose is reached only when the
+	// decision is still valid. (Whether the withdraw lands before or after the
+	// atomic decision is timing-dependent and both are correct; we assert ONLY
+	// the never-start-after-supersede property, which holds on every interleave.)
+	_ = startCalled
+	if startedDespiteSupersede {
+		t.Fatal("replacement started despite a newer Withdraw superseding the "+
+			"restart at the act moment — stale cached decision across the unlock "+
+			"— #2033 round-5")
+	}
+}
+
+// TestRound5_ClearDuringRestartDecisionNoReplacement: same gap, but a Clear
+// (epoch bump, NO goodbye wanted) supersedes the restart. The restart must NOT
+// start the replacement (RA stays cleared) and emit NO goodbye.
+//
+// NON-TAUTOLOGY: against the cached-boolean code the restart starts the
+// replacement (RA re-armed after a newer Clear) → FAILS.
+func TestRound5_ClearDuringRestartDecisionNoReplacement(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	old, cfg, startEpoch := installRestartEntry(t, fl, m)
+
+	// onProvenClose runs under the act-lock; it must be invoked ONLY when epoch
+	// is still startEpoch at the act moment. A Clear (epoch bump, no goodbye)
+	// races concurrently; if a stale cached boolean starts the replacement after
+	// the Clear advanced the epoch, that is the bug.
+	var startedDespiteSupersede bool
+	startCalled := false
+	onProvenClose := func() error {
+		startCalled = true
+		if m.epoch != startEpoch {
+			startedDespiteSupersede = true
+		}
+		return m.startLocked(cfg)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	relErr := make(chan error, 1)
+	go func() { defer wg.Done(); relErr <- m.releaseDrain("lo", old, startEpoch, onProvenClose) }()
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond) // try to land in the decision→act gap
+		_ = m.Clear()
+	}()
+	wg.Wait()
+	if err := <-relErr; err != nil {
+		t.Fatalf("releaseDrain: %v", err)
+	}
+
+	// Precise round-5 invariant: onProvenClose must NOT run after the Clear
+	// advanced the epoch at the act moment (a stale cached boolean would re-arm
+	// RA after a newer Clear). A Clear never wants a goodbye, so none is emitted.
+	_ = startCalled
+	_ = cfg
+	if startedDespiteSupersede {
+		t.Fatal("restart started a replacement after a newer Clear advanced the "+
+			"epoch at the act moment (stale cached decision) — #2033 round-5")
+	}
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 0 || total != 0 {
+		t.Fatalf("a Clear/restart race emitted a goodbye (%d conns / %d writes); "+
+			"expected 0", conns, total)
+	}
 }

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -1,6 +1,7 @@
 package ra
 
 import (
+	"errors"
 	"net"
 	"net/netip"
 	"sync"
@@ -54,6 +55,12 @@ type fakeConn struct {
 	// hold the conn LIVE (block the owner's finishShutdown close) to probe the
 	// stop->start window. Same race-free atomic.Pointer discipline.
 	beforeClose atomic.Pointer[func()]
+
+	// writeErr, if set, makes WriteTo return it WITHOUT recording the write —
+	// simulating a send failure (e.g. interface down mid-withdraw) so a test
+	// can prove finishShutdown leaves goodbyeEmitted=false on a failed graceful
+	// goodbye, arming the manager's release-time backstop. Guarded by f.mu.
+	writeErr error
 }
 
 func newFakeConn() *fakeConn {
@@ -87,10 +94,23 @@ func (f *fakeConn) WriteTo(m ndp.Message, _ *ipv6.ControlMessage, _ netip.Addr) 
 		(*hook)(ra.RouterLifetime)
 	}
 	f.mu.Lock()
+	if f.writeErr != nil {
+		err := f.writeErr
+		f.mu.Unlock()
+		return err
+	}
 	f.seq++
 	f.writes = append(f.writes, writeRec{lifetime: ra.RouterLifetime, seq: f.seq})
 	f.mu.Unlock()
 	return nil
+}
+
+// setWriteErr makes every subsequent WriteTo fail (returning err, recording
+// nothing) until cleared with nil.
+func (f *fakeConn) setWriteErr(err error) {
+	f.mu.Lock()
+	f.writeErr = err
+	f.mu.Unlock()
 }
 
 func (f *fakeConn) ReadFrom() (ndp.Message, *ipv6.ControlMessage, netip.Addr, error) {
@@ -516,7 +536,15 @@ type sentinelFatal struct{}
 // assertGoodbyeIsLastOn is assertGoodbyeIsLast against a minimal fatal-er so it
 // can be exercised by the negative arm. It recovers the sentinel panic.
 func assertGoodbyeIsLastOn(ft *fakeT, writes []writeRec) {
-	defer func() { _ = recover() }()
+	// Recover ONLY our own Fatalf sentinel; re-raise anything else so a real
+	// bug in this helper (e.g. a nil deref) is not silently swallowed.
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(sentinelFatal); !ok {
+				panic(r)
+			}
+		}
+	}()
 	firstGoodbye := -1
 	for _, w := range writes {
 		if w.lifetime == 0 {
@@ -533,6 +561,50 @@ func assertGoodbyeIsLastOn(ft *fakeT, writes []writeRec) {
 			ft.Fatalf("normal after goodbye")
 			return
 		}
+	}
+}
+
+// TestFinishShutdownGoodbyeSendOutcome proves finishShutdown records
+// goodbyeEmitted EXACTLY when the goodbye actually went out: true on a clean
+// send, false on a write failure. The false case is what arms the manager's
+// release-time backstop (ra.go releaseDrain: !goodbyeEmitted -> standalone
+// goodbye on a fresh conn). NON-TAUTOLOGY: against the pre-fix head
+// (goodbyeEmitted set unconditionally after the send) the failure arm of this
+// test reports goodbyeEmitted=true and fails — i.e. it pins the #2033
+// sender.go:347 fix, not merely the current behavior.
+func TestFinishShutdownGoodbyeSendOutcome(t *testing.T) {
+	iface := &net.Interface{Name: "tgb", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+
+	// Failed goodbye send -> emitted stays false so the backstop retries.
+	sFail := newSender(testCfg("tgbfail"), iface)
+	fcFail := newFakeConn()
+	fcFail.setWriteErr(errors.New("simulated goodbye send failure"))
+	sFail.conn = fcFail
+	sFail.mode.Store(int32(modeGraceful))
+	sFail.finishShutdown()
+	if sFail.goodbyeEmitted.Load() {
+		t.Fatal("goodbyeEmitted must stay FALSE when the goodbye send failed " +
+			"(the manager backstop must retry on a fresh conn)")
+	}
+
+	// Successful goodbye send -> emitted true so the backstop suppresses.
+	sOK := newSender(testCfg("tgbok"), iface)
+	fcOK := newFakeConn()
+	sOK.conn = fcOK
+	sOK.mode.Store(int32(modeGraceful))
+	sOK.finishShutdown()
+	if !sOK.goodbyeEmitted.Load() {
+		t.Fatal("goodbyeEmitted must be TRUE after a successful goodbye send")
+	}
+	// Sanity: the success path actually emitted goodbyeCount lifetime-0 writes.
+	n := 0
+	for _, w := range fcOK.snapshot() {
+		if w.lifetime == 0 {
+			n++
+		}
+	}
+	if n != goodbyeCount {
+		t.Fatalf("expected %d goodbye writes on success, got %d", goodbyeCount, n)
 	}
 }
 

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -1347,3 +1347,241 @@ func TestT7d_ExactlyOneGoodbyeWhenUpgradeAndStandaloneCouldRace(t *testing.T) {
 			goodbyeCount, conns, total)
 	}
 }
+
+// --- #2033 round-3: structural claim-and-hold race tests ---
+
+// TestRace1_ConcurrentWithdrawsExactlyOneGoodbye: two concurrent Withdraws
+// racing the SAME dead-hard tombstone must yield EXACTLY ONE goodbye (1 conn /
+// goodbyeCount writes), not two. Two concurrent graceful Withdraws on the SAME
+// interface serialize on m.mu in claimGracefulLocked: exactly one moves the
+// active sender to a drainEntry and OWNS the release (sole emitter); the other
+// finds the entry and only flips goodbyeWanted. claim-once via the single owner
+// + goodbyeClaimed guarantees one goodbye even when both observe the dead sender
+// (we hold the sender's conn.Close so it finishes its HARD-then-upgraded stop
+// while both Withdraws are in flight, exercising the standalone backstop).
+//
+// NON-TAUTOLOGY: against head 141eefb5 each Withdraw appended an owned=false
+// gracefulTarget and emitStandaloneGoodbye had no claim-once, so both opened a
+// standalone conn → 2 conns / 6 writes → this test FAILS.
+func TestRace1_ConcurrentWithdrawsExactlyOneGoodbye(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+
+	// Construct a held dead-hard tombstone for "lo" DIRECTLY (deterministic):
+	// start, hard-stop, wait fully dead, install drainEntry — but do NOT set
+	// goodbyeWanted yet; the racing Withdraws will set it.
+	iface := &net.Interface{Name: "lo", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	s := newSender(testCfg("lo"), iface)
+	if err := s.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	fc := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, fc, 1)
+	s.signalStop(modeHard)
+	select {
+	case <-s.stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sender never stopped")
+	}
+
+	// THIS test owns the entry's release (mimicking the Clear/restart owner).
+	// Two concurrent Withdraws flip goodbyeWanted; then the owner releases once.
+	m.mu.Lock()
+	m.draining["lo"] = &drainEntry{sender: s, cfg: s.cfg}
+	m.mu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() { defer wg.Done(); _ = m.Withdraw() }()
+	}
+	wg.Wait() // both Withdraws have flipped goodbyeWanted (they own no release)
+
+	// The single owner releases the entry: claim-once -> exactly one standalone.
+	m.releaseDrain("lo", s)
+
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 1 || total != goodbyeCount {
+		t.Fatalf("expected EXACTLY one goodbye (1 conn, %d writes); got %d conns, "+
+			"%d writes — concurrent Withdraws double-sent (#2033 race 1)",
+			goodbyeCount, conns, total)
+	}
+}
+
+// TestRace3_ApplyDuringStandaloneEmitDefersNoClobber: while a standalone
+// goodbye is mid-emit (its conn blocked in WriteTo), a concurrent Apply for the
+// same interface must DEFER (the held drainEntry blocks it) — it must NOT start
+// a live sender during the emit (no clobber, ≤1 live conn). After the standalone
+// finishes, the Apply proceeds.
+//
+// NON-TAUTOLOGY: against head 141eefb5 emitStandaloneGoodbye held NO tombstone
+// across the emit (check-then-act on m.senders), so the Apply could start a
+// live sender during the emit → ≥2 live conns during the window → FAILS.
+func TestRace3_ApplyDuringStandaloneEmitDefersNoClobber(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+
+	// Gate the STANDALONE goodbye conn's first (lifetime-0) write so we can hold
+	// the emit open. The standalone conn is opened by sendOneGoodbye; gate on
+	// lifetime==0 (only the goodbye writes lifetime 0).
+	standaloneBlocking := make(chan struct{})
+	releaseStandalone := make(chan struct{})
+	var sOnce sync.Once
+	fl.preHook("lo", func(lifetime time.Duration) {
+		if lifetime == 0 {
+			sOnce.Do(func() { close(standaloneBlocking); <-releaseStandalone })
+		}
+	})
+
+	// Construct the held dead-hard-tombstone state DIRECTLY (deterministic — no
+	// dependence on Clear's per-interface release order): start a "lo" sender,
+	// hard-stop it, wait until it is fully dead (goodbyeEmitted=false), install a
+	// drainEntry{goodbyeWanted:true}. This is exactly the state a Clear-first +
+	// graceful-Withdraw race produces.
+	iface := &net.Interface{Name: "lo", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	s := newSender(testCfg("lo"), iface)
+	if err := s.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	fc := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, fc, 1)
+	s.signalStop(modeHard)
+	select {
+	case <-s.stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sender never stopped")
+	}
+	if s.goodbyeEmitted.Load() {
+		t.Fatal("precondition: hard stop should not have emitted a goodbye")
+	}
+	m.mu.Lock()
+	m.draining["lo"] = &drainEntry{sender: s, cfg: s.cfg, goodbyeWanted: true}
+	m.mu.Unlock()
+
+	// Release the held tombstone via releaseDrain (the sole owner). It must emit
+	// the standalone WHILE holding the entry — the gated write blocks it there.
+	relDone := make(chan struct{})
+	go func() { m.releaseDrain("lo", s); close(relDone) }()
+
+	select {
+	case <-standaloneBlocking:
+	case <-time.After(2 * time.Second):
+		t.Fatal("standalone goodbye never reached its write gate")
+	}
+
+	// Concurrent Apply for "lo" must DEFER (held tombstone) — no live sender,
+	// ≤1 live conn — for the whole emit window.
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}) }()
+	for i := 0; i < 40; i++ {
+		m.mu.Lock()
+		_, live := m.senders["lo"]
+		m.mu.Unlock()
+		if live {
+			t.Fatal("Apply started a live sender DURING the standalone emit "+
+				"(clobber; tombstone did not block it) — #2033 race 3")
+		}
+		if lc := fl.liveCount(); lc > 1 {
+			t.Fatalf(">1 live conn during the standalone emit (%d) — #2033 race 3", lc)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Release the standalone; releaseDrain finishes (removes the tombstone);
+	// the deferred Apply then proceeds and starts a live sender.
+	close(releaseStandalone)
+	select {
+	case <-relDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("releaseDrain did not complete")
+	}
+	select {
+	case <-applyDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("deferred Apply did not complete after the emit released")
+	}
+
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 1 || total != goodbyeCount {
+		t.Fatalf("expected exactly one goodbye (1 conn, %d writes); got %d/%d",
+			goodbyeCount, conns, total)
+	}
+	m.mu.Lock()
+	_, live := m.senders["lo"]
+	m.mu.Unlock()
+	if !live {
+		t.Fatal("deferred Apply did not start a live sender after the emit")
+	}
+	_ = m.Clear()
+}
+
+// TestRace2_TimeoutDoesNotEmitWhileOwnerCouldBeLive: if releaseDrain cannot
+// join the sender within claimWaitTimeout (owner wedged), it must NOT read
+// goodbyeEmitted (unordered) and must NOT emit a standalone — the owner may
+// still be live. Drive releaseDrain directly with a wedged sender +
+// goodbyeWanted and a shortened timeout; assert zero goodbyes.
+//
+// NON-TAUTOLOGY: against head 141eefb5 finishGraceful fell through after the
+// timeout and read goodbyeEmitted anyway, then emitted a standalone → a goodbye
+// would appear here → FAILS.
+func TestRace2_TimeoutDoesNotEmitWhileOwnerCouldBeLive(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+
+	// A wedged sender whose stopped never closes: gate its conn.Close so the
+	// owner parks in finishShutdown before `defer close(stopped)` runs.
+	iface := &net.Interface{Name: "lo", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	s := newSender(testCfg("lo"), iface)
+	if err := s.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	fc := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, fc, 1)
+	wedge := make(chan struct{})
+	fc.setBeforeClose(func() { <-wedge }) // owner parks here forever
+
+	// Hard-stop it and install a drainEntry with goodbyeWanted (as a racing
+	// graceful Withdraw would have), then release with a SHORT timeout.
+	m.mu.Lock()
+	delete(m.senders, "lo")
+	m.draining["lo"] = &drainEntry{sender: s, cfg: s.cfg, goodbyeWanted: true}
+	s.signalStop(modeHard)
+	m.mu.Unlock()
+
+	orig := claimWaitTimeout
+	claimWaitTimeout = 150 * time.Millisecond
+	defer func() { claimWaitTimeout = orig }()
+
+	done := make(chan struct{})
+	go func() { m.releaseDrain("lo", s); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("releaseDrain did not return after the join timeout")
+	}
+
+	// No standalone goodbye must have been emitted on the timeout path.
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 0 || total != 0 {
+		t.Fatalf("releaseDrain emitted a goodbye on the TIMEOUT path (owner could "+
+			"be live) — got %d conns / %d writes; expected 0 (#2033 race 2)",
+			conns, total)
+	}
+	// Tombstone removed (entry released) despite no emit.
+	m.mu.Lock()
+	_, stillDraining := m.draining["lo"]
+	m.mu.Unlock()
+	if stillDraining {
+		t.Fatal("releaseDrain left the tombstone after the timeout")
+	}
+	close(wedge) // unwedge the parked owner so the goroutine can exit
+}

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -191,7 +191,8 @@ func testCfg(iface string) *config.RAInterfaceConfig {
 // fakeListen is the test harness wiring listenFn + ensureLinkLocalFn to fakes.
 type fakeListen struct {
 	mu       sync.Mutex
-	conns    map[string]*fakeConn
+	conns    map[string]*fakeConn   // most-recent conn per interface
+	allConns map[string][]*fakeConn // EVERY conn ever opened per interface
 	prehooks map[string]func(time.Duration) // installed at conn-creation time
 	live     int32
 	liveMu   sync.Mutex
@@ -214,6 +215,7 @@ func newFakeListen(t *testing.T) *fakeListen {
 
 	fl := &fakeListen{
 		conns:    map[string]*fakeConn{},
+		allConns: map[string][]*fakeConn{},
 		prehooks: map[string]func(time.Duration){},
 	}
 
@@ -230,6 +232,7 @@ func newFakeListen(t *testing.T) *fakeListen {
 			fc.setBeforeWrite(h) // attach BEFORE the owner can write
 		}
 		fl.conns[iface.Name] = fc
+		fl.allConns[iface.Name] = append(fl.allConns[iface.Name], fc)
 		fl.mu.Unlock()
 		return fc, netip.MustParseAddr("fe80::1"), nil
 	}
@@ -260,6 +263,32 @@ func (fl *fakeListen) liveCount() int32 {
 	fl.liveMu.Lock()
 	defer fl.liveMu.Unlock()
 	return fl.live
+}
+
+// goodbyeCountFor sums lifetime-0 (goodbye) writes across EVERY conn ever
+// opened for the interface — the owner's conn AND any standalone-goodbye conn
+// the manager opened via sendOneGoodbye. The standalone goodbye emits
+// goodbyeCount (3) lifetime-0 RAs on its own conn; an owner goodbye emits
+// goodbyeCount on the owner's conn. "Exactly one goodbye event" therefore means
+// exactly one conn carries goodbye writes (we assert both the per-conn count
+// and that only a single conn emitted any).
+func (fl *fakeListen) goodbyeStats(name string) (totalGoodbyeWrites, connsWithGoodbye int) {
+	fl.mu.Lock()
+	conns := append([]*fakeConn(nil), fl.allConns[name]...)
+	fl.mu.Unlock()
+	for _, c := range conns {
+		n := 0
+		for _, w := range c.snapshot() {
+			if w.lifetime == 0 {
+				n++
+			}
+		}
+		if n > 0 {
+			connsWithGoodbye++
+			totalGoodbyeWrites += n
+		}
+	}
+	return
 }
 
 // fakeIfaceByName must be set because startLocked calls net.InterfaceByName.
@@ -1026,4 +1055,295 @@ func TestT7b_ManagerHardFirstThenGracefulStillGoodbye(t *testing.T) {
 			"must still emit the goodbye (#2033 MAJOR 2); writes=%+v", writes)
 	}
 	assertGoodbyeIsLast(t, writes)
+}
+
+// TestT7c_WithdrawAfterDeadHardSenderEmitsStandaloneGoodbye is the #2033
+// MAJOR-2 (dead-sender) regression: a graceful Withdraw that targets an
+// interface whose sender has ALREADY finished its hard shutdown (finishShutdown
+// ran, read modeHard, emitted NO goodbye) — but whose draining tombstone is
+// still present — must STILL emit a goodbye. The dead sender cannot be
+// "upgraded"; the manager must emit a STANDALONE goodbye instead.
+//
+// Determinism: Clear two interfaces. Gate interface B's conn.Close so
+// clearLocked blocks in its join loop — clearLocked removes ALL tombstones only
+// AFTER every join, so interface A's sender is fully stopped (goodbyeEmitted
+// false) while A's tombstone is still present. The Withdraw of A then hits the
+// dead-sender path and must emit a standalone goodbye for A.
+//
+// NON-TAUTOLOGY: against the current head (which only signalStop(graceful)-
+// upgrades a draining sender, a no-op on a dead one, and has no standalone
+// owes-a-goodbye fallback) A gets NO goodbye and this test FAILS.
+func TestT7c_WithdrawAfterDeadHardSenderEmitsStandaloneGoodbye(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+
+	m := New()
+	// Two senders: A (the one we withdraw) and B (used to hold clearLocked's
+	// join loop open). We need two real interface names; "lo" resolves, and a
+	// second resolvable name — reuse "lo" is not possible (same key), so drive A
+	// directly as a sender on a synthetic interface added to the manager, and
+	// use "lo" for B via Apply.
+	//
+	// Simpler: run BOTH through the manager using "lo" for A is impossible (one
+	// key). Instead start A as a real sender object inserted into m.senders
+	// under a synthetic name (manager Clear/Withdraw operate purely on the maps
+	// + sender objects; they only call net.InterfaceByName in startLocked /
+	// sendOneGoodbye). sendOneGoodbye for A WILL call net.InterfaceByName(A) —
+	// so A must be a resolvable name. Use "lo" for A (the withdrawn one, needs
+	// standalone goodbye) and a synthetic name for B (only needs to block the
+	// join; its sendOneGoodbye is never called).
+	ifaceB := &net.Interface{Name: "draintestB", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 2}}
+	sB := newSender(testCfg("draintestB"), ifaceB)
+	if err := sB.start(); err != nil {
+		t.Fatalf("start B: %v", err)
+	}
+	fcB := waitConn(t, fl.getConn, "draintestB")
+	_ = fcB
+
+	ifaceA := &net.Interface{Name: "lo", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	sA := newSender(testCfg("lo"), ifaceA)
+	if err := sA.start(); err != nil {
+		t.Fatalf("start A: %v", err)
+	}
+	fcA := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, fcA, 1)
+
+	// Insert both into the manager's active set so Clear sees them.
+	m.mu.Lock()
+	m.senders["draintestB"] = sB
+	m.senders["lo"] = sA
+	m.mu.Unlock()
+
+	// Gate B's Close so clearLocked blocks in its join loop (after A has fully
+	// finished). A emits no goodbye (hard) and fully exits; B's owner is parked
+	// in Close, so clearLocked has NOT yet removed any tombstones.
+	releaseB := make(chan struct{})
+	bClosing := make(chan struct{})
+	var once sync.Once
+	fcB.setBeforeClose(func() {
+		once.Do(func() { close(bClosing) })
+		<-releaseB
+	})
+
+	clearDone := make(chan error, 1)
+	go func() { clearDone <- m.Clear() }()
+
+	// Wait until B's close is in flight — by now A is fully stopped and its
+	// tombstone is still present (clearLocked removes tombstones only after the
+	// whole join loop).
+	select {
+	case <-bClosing:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Clear never reached B's close")
+	}
+	// Ensure A's owner has fully exited (stopped closed) and emitted no goodbye.
+	select {
+	case <-sA.stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("A's sender never stopped")
+	}
+	if sA.goodbyeEmitted.Load() {
+		t.Fatal("precondition broken: A (hard Clear) should NOT have emitted a goodbye")
+	}
+
+	// Graceful Withdraw of A while A's dead sender is still in the draining map.
+	withdrawDone := make(chan error, 1)
+	go func() { withdrawDone <- m.Withdraw() }()
+	// Withdraw must emit a standalone goodbye for A; give it time.
+	time.Sleep(100 * time.Millisecond)
+
+	// Release B so Clear can finish.
+	close(releaseB)
+	select {
+	case <-clearDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Clear did not complete")
+	}
+	select {
+	case <-withdrawDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Withdraw did not complete")
+	}
+
+	// A must have received exactly one goodbye event (via the standalone path).
+	total, conns := fl.goodbyeStats("lo")
+	if conns == 0 {
+		t.Fatalf("no goodbye emitted for the withdrawn interface (A); a dead "+
+			"hard sender must get a STANDALONE goodbye (#2033 MAJOR 2 dead-sender)")
+	}
+	if conns != 1 || total != goodbyeCount {
+		t.Fatalf("expected exactly one goodbye event for A (1 conn, %d writes); "+
+			"got %d conns, %d writes", goodbyeCount, conns, total)
+	}
+}
+
+// TestT2b_WithdrawDuringRestartWindowEmitsGoodbye is the #2033 NEW-MAJOR
+// regression: a graceful Withdraw that races the changed-config restart
+// stop-to-start window (old sender hard-stopped, replacement not yet started)
+// must emit a goodbye for the withdrawn interface — the route is being
+// withdrawn, not replaced.
+//
+// Determinism: a changed-config Apply hard-stops the old sender, then BLOCKS
+// opening the replacement conn (gate the replacement listen via a prehook on
+// the NEW conn is not possible — the new conn is the one we want to block
+// BEFORE creation; instead we gate the replacement's FIRST write so the
+// replacement exists but a graceful Withdraw that bumps the epoch first aborts
+// it). To exercise the true stop-to-start window we instead gate the OLD
+// sender's Close so Apply's restart join blocks; while it blocks we issue the
+// Withdraw (which finds the old, stopped-pending sender), then release.
+//
+// NON-TAUTOLOGY: against the current head a Withdraw racing the restart bumps
+// the epoch, the restart aborts, and NO goodbye is emitted for the interface →
+// this test FAILS.
+func TestT2b_WithdrawDuringRestartWindowEmitsGoodbye(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	old := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, old, 1)
+
+	// Gate the OLD sender's Close so the changed-config Apply blocks in its
+	// restart join (old sender stopped-pending, replacement not started — the
+	// stop-to-start window).
+	releaseOld := make(chan struct{})
+	oldClosing := make(chan struct{})
+	var once sync.Once
+	old.setBeforeClose(func() {
+		once.Do(func() { close(oldClosing) })
+		<-releaseOld
+	})
+
+	applyDone := make(chan error, 1)
+	go func() {
+		applyDone <- m.Apply([]*config.RAInterfaceConfig{configChanged("lo")})
+	}()
+
+	select {
+	case <-oldClosing:
+	case <-time.After(2 * time.Second):
+		t.Fatal("changed-config Apply never reached the old sender's close")
+	}
+
+	// In the stop-to-start window, a graceful Withdraw arrives. It must bump the
+	// epoch (aborting the restart) AND guarantee a goodbye for the interface.
+	withdrawDone := make(chan error, 1)
+	go func() { withdrawDone <- m.Withdraw() }()
+	time.Sleep(100 * time.Millisecond)
+
+	// Release the old close so Apply's restart join completes (and then aborts
+	// the start because the epoch changed).
+	close(releaseOld)
+
+	select {
+	case err := <-applyDone:
+		_ = err // may be nil; the restart is aborted, not an error
+	case <-time.After(2 * time.Second):
+		t.Fatal("changed-config Apply did not complete")
+	}
+	select {
+	case <-withdrawDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Withdraw did not complete")
+	}
+
+	// The interface is withdrawn: exactly one goodbye event, and NO live sender
+	// (the restart was aborted).
+	total, conns := fl.goodbyeStats("lo")
+	if conns == 0 {
+		t.Fatalf("no goodbye emitted for the interface withdrawn during the "+
+			"restart window (#2033 NEW MAJOR)")
+	}
+	if conns != 1 || total != goodbyeCount {
+		t.Fatalf("expected exactly one goodbye event (1 conn, %d writes); got "+
+			"%d conns, %d writes", goodbyeCount, conns, total)
+	}
+	m.mu.Lock()
+	_, live := m.senders["lo"]
+	m.mu.Unlock()
+	if live {
+		t.Fatal("a replacement sender was started despite the graceful Withdraw "+
+			"aborting the restart")
+	}
+}
+
+// TestT7d_ExactlyOneGoodbyeWhenUpgradeAndStandaloneCouldRace asserts that even
+// when the graceful upgrade lands in time (owner emits the goodbye) the manager
+// does NOT also emit a standalone goodbye — exactly one goodbye event total.
+// This guards the exactly-once contract from the opposite side of T7c/T2b
+// (which prove AT LEAST one): here we prove NOT MORE THAN one.
+func TestT7d_ExactlyOneGoodbyeWhenUpgradeAndStandaloneCouldRace(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+
+	// Park the owner in its burst so both a Clear (hard) and a Withdraw
+	// (graceful upgrade) land before the owner reads its mode — the upgrade wins
+	// and the owner emits exactly one goodbye; the manager must NOT add a
+	// standalone.
+	release := make(chan struct{})
+	parked := make(chan struct{})
+	var once sync.Once
+	fl.preHook("lo", func(lifetime time.Duration) {
+		if lifetime > 0 {
+			once.Do(func() { close(parked); <-release })
+		}
+	})
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	_ = waitConn(t, fl.getConn, "lo")
+	<-parked
+
+	clearDone := make(chan error, 1)
+	go func() { clearDone <- m.Clear() }()
+	// Wait for Clear to install the tombstone.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		ts := false
+		for _, info := range m.Status() {
+			if info.Interface == "lo" && info.State == "draining" {
+				ts = true
+			}
+		}
+		if ts {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Clear never installed the tombstone")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	withdrawDone := make(chan error, 1)
+	go func() { withdrawDone <- m.Withdraw() }()
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	select {
+	case <-clearDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Clear did not complete")
+	}
+	select {
+	case <-withdrawDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Withdraw did not complete")
+	}
+
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 1 || total != goodbyeCount {
+		t.Fatalf("expected EXACTLY one goodbye event (1 conn, %d writes); got "+
+			"%d conns, %d writes — a double goodbye (owner + standalone) is a bug",
+			goodbyeCount, conns, total)
+	}
 }

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -1,0 +1,819 @@
+package ra
+
+import (
+	"net"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mdlayher/ndp"
+	"golang.org/x/net/ipv6"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// writeRec is one recorded RA write: its router lifetime and a monotonic
+// sequence number assigned in write order (NOT wall-clock — deterministic).
+type writeRec struct {
+	lifetime time.Duration
+	seq      int
+}
+
+// fakeConn is an ndpConn test double. It records every WriteTo (lifetime +
+// monotonic seq), serves injected Router Solicitations from a queue on
+// ReadFrom, and counts how many live conns exist (so the <=1-live-conn-per-
+// interface invariant can be asserted). All methods are safe for concurrent
+// use, matching the real conn's documented WriteTo concurrency.
+type fakeConn struct {
+	mu     sync.Mutex
+	writes []writeRec
+	seq    int
+	closed bool
+
+	// rsQueue holds injected RS source addresses. ReadFrom pops one per call;
+	// when empty it blocks until rsSignal fires or the conn is closed, then
+	// returns a timeout error so the receiver polls stopCh.
+	rsQueue  []netip.Addr
+	rsSignal chan struct{}
+
+	// liveCounter, if non-nil, is incremented on construction (by the
+	// listenFn) and decremented on Close — the invariant probe.
+	liveCounter *int32
+	liveMu      *sync.Mutex
+
+	// beforeWrite, if non-nil, is invoked at the top of every WriteTo so a
+	// test can block a specific send to force an interleave. Stored in an
+	// atomic.Pointer and read without holding f.mu so the hook (which may
+	// block) does not deadlock against the recording lock, and so concurrent
+	// set-by-test / read-by-owner is race-free.
+	beforeWrite atomic.Pointer[func(lifetime time.Duration)]
+}
+
+func newFakeConn() *fakeConn {
+	return &fakeConn{rsSignal: make(chan struct{}, 1)}
+}
+
+// setBeforeWrite installs (or clears, with nil) the WriteTo hook race-free.
+func (f *fakeConn) setBeforeWrite(fn func(lifetime time.Duration)) {
+	if fn == nil {
+		f.beforeWrite.Store(nil)
+		return
+	}
+	f.beforeWrite.Store(&fn)
+}
+
+func (f *fakeConn) WriteTo(m ndp.Message, _ *ipv6.ControlMessage, _ netip.Addr) error {
+	ra, ok := m.(*ndp.RouterAdvertisement)
+	if !ok {
+		return nil
+	}
+	if hook := f.beforeWrite.Load(); hook != nil {
+		(*hook)(ra.RouterLifetime)
+	}
+	f.mu.Lock()
+	f.seq++
+	f.writes = append(f.writes, writeRec{lifetime: ra.RouterLifetime, seq: f.seq})
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeConn) ReadFrom() (ndp.Message, *ipv6.ControlMessage, netip.Addr, error) {
+	for {
+		f.mu.Lock()
+		if f.closed {
+			f.mu.Unlock()
+			return nil, nil, netip.Addr{}, errClosed{}
+		}
+		if len(f.rsQueue) > 0 {
+			src := f.rsQueue[0]
+			f.rsQueue = f.rsQueue[1:]
+			f.mu.Unlock()
+			return &ndp.RouterSolicitation{}, nil, src, nil
+		}
+		f.mu.Unlock()
+		// No RS queued: wait for a signal or a short tick, then return a
+		// timeout so rsReceiver polls stopCh (matching the real read deadline).
+		select {
+		case <-f.rsSignal:
+			continue
+		case <-time.After(20 * time.Millisecond):
+			return nil, nil, netip.Addr{}, errTimeout{}
+		}
+	}
+}
+
+func (f *fakeConn) injectRS(src netip.Addr) {
+	f.mu.Lock()
+	f.rsQueue = append(f.rsQueue, src)
+	f.mu.Unlock()
+	select {
+	case f.rsSignal <- struct{}{}:
+	default:
+	}
+}
+
+func (f *fakeConn) Close() error {
+	f.mu.Lock()
+	already := f.closed
+	f.closed = true
+	f.mu.Unlock()
+	// Wake any blocked ReadFrom.
+	select {
+	case f.rsSignal <- struct{}{}:
+	default:
+	}
+	if !already && f.liveCounter != nil {
+		f.liveMu.Lock()
+		*f.liveCounter--
+		f.liveMu.Unlock()
+	}
+	return nil
+}
+
+func (f *fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (f *fakeConn) SetWriteDeadline(time.Time) error { return nil }
+func (f *fakeConn) JoinGroup(netip.Addr) error       { return nil }
+func (f *fakeConn) SetICMPFilter(*ipv6.ICMPFilter) error {
+	return nil
+}
+
+func (f *fakeConn) snapshot() []writeRec {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]writeRec, len(f.writes))
+	copy(out, f.writes)
+	return out
+}
+
+// errTimeout / errClosed implement net.Error-ish Timeout() for isTimeout.
+type errTimeout struct{}
+
+func (errTimeout) Error() string { return "i/o timeout" }
+func (errTimeout) Timeout() bool { return true }
+
+type errClosed struct{}
+
+func (errClosed) Error() string { return "use of closed connection" }
+func (errClosed) Timeout() bool { return false }
+
+// testCfg returns a minimal RA config for an interface.
+func testCfg(iface string) *config.RAInterfaceConfig {
+	return &config.RAInterfaceConfig{
+		Interface:      iface,
+		DefaultLifetime: 1800,
+		MaxAdvInterval:  600,
+		MinAdvInterval:  200,
+		Prefixes: []*config.RAPrefix{
+			{Prefix: "2001:db8::/64", OnLink: true, Autonomous: true},
+		},
+	}
+}
+
+// fakeListen is the test harness wiring listenFn + ensureLinkLocalFn to fakes.
+type fakeListen struct {
+	mu       sync.Mutex
+	conns    map[string]*fakeConn
+	prehooks map[string]func(time.Duration) // installed at conn-creation time
+	live     int32
+	liveMu   sync.Mutex
+}
+
+// installFakeListen wires listenFn + ensureLinkLocalFn to fakes for the
+// duration of the test and restores them on cleanup. getConn returns the
+// fakeConn most recently opened for an interface name; liveCount returns the
+// number of live (open) conns.
+func installFakeListen(t *testing.T) (getConn func(string) *fakeConn, liveCount func() int32) {
+	t.Helper()
+	fl := newFakeListen(t)
+	return fl.getConn, fl.liveCount
+}
+
+func newFakeListen(t *testing.T) *fakeListen {
+	t.Helper()
+	origListen := listenFn
+	origEnsure := ensureLinkLocalFn
+
+	fl := &fakeListen{
+		conns:    map[string]*fakeConn{},
+		prehooks: map[string]func(time.Duration){},
+	}
+
+	ensureLinkLocalFn = func(*net.Interface) error { return nil }
+	listenFn = func(iface *net.Interface, _ ndp.Addr) (ndpConn, netip.Addr, error) {
+		fc := newFakeConn()
+		fc.liveCounter = &fl.live
+		fc.liveMu = &fl.liveMu
+		fl.liveMu.Lock()
+		fl.live++
+		fl.liveMu.Unlock()
+		fl.mu.Lock()
+		if h := fl.prehooks[iface.Name]; h != nil {
+			fc.setBeforeWrite(h) // attach BEFORE the owner can write
+		}
+		fl.conns[iface.Name] = fc
+		fl.mu.Unlock()
+		return fc, netip.MustParseAddr("fe80::1"), nil
+	}
+
+	t.Cleanup(func() {
+		listenFn = origListen
+		ensureLinkLocalFn = origEnsure
+	})
+	return fl
+}
+
+// preHook registers a WriteTo hook that is attached to the next conn opened for
+// name, at conn-creation time, so it is in place before the owner's first
+// write (avoids a race between start() and a post-start setBeforeWrite).
+func (fl *fakeListen) preHook(name string, fn func(time.Duration)) {
+	fl.mu.Lock()
+	fl.prehooks[name] = fn
+	fl.mu.Unlock()
+}
+
+func (fl *fakeListen) getConn(name string) *fakeConn {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	return fl.conns[name]
+}
+
+func (fl *fakeListen) liveCount() int32 {
+	fl.liveMu.Lock()
+	defer fl.liveMu.Unlock()
+	return fl.live
+}
+
+// fakeIfaceByName must be set because startLocked calls net.InterfaceByName.
+// We can't stub that, so tests use a loopback-style interface that exists, or
+// rely on the manager path that does NOT resolve a real interface. To keep
+// these unit tests hermetic, we drive sender.start() directly with a synthetic
+// *net.Interface (bypassing net.InterfaceByName) where possible, and use the
+// Manager only in tests that go through real interface resolution via a name
+// guaranteed to exist ("lo").
+
+// startFakeSender builds a sender with a synthetic interface and the fake conn
+// machinery, starts it, and returns it plus its fakeConn.
+func startFakeSender(t *testing.T, getConn func(string) *fakeConn, name string) (*sender, *fakeConn) {
+	t.Helper()
+	iface := &net.Interface{Name: name, HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	s := newSender(testCfg(name), iface)
+	if err := s.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	// Give the owner a moment to open the conn via listenFn.
+	fc := waitConn(t, getConn, name)
+	return s, fc
+}
+
+func waitConn(t *testing.T, getConn func(string) *fakeConn, name string) *fakeConn {
+	t.Helper()
+	for i := 0; i < 200; i++ {
+		if fc := getConn(name); fc != nil {
+			return fc
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("conn for %s never opened", name)
+	return nil
+}
+
+// waitWrites blocks until fc has recorded at least n writes (or fails).
+func waitWrites(t *testing.T, fc *fakeConn, n int) {
+	t.Helper()
+	for i := 0; i < 500; i++ {
+		if len(fc.snapshot()) >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("only %d writes recorded, want >=%d", len(fc.snapshot()), n)
+}
+
+// assertGoodbyeIsLast asserts the #2033 invariant: no lifetime>0 write has a
+// seq greater than the FIRST lifetime-0 (goodbye) write. (Per Codex r3 MINOR
+// #5 — asserting against the FIRST goodbye, not merely "last write is a
+// goodbye," which a normal RA interleaved between goodbye packets would pass.)
+func assertGoodbyeIsLast(t *testing.T, writes []writeRec) {
+	t.Helper()
+	firstGoodbye := -1
+	for _, w := range writes {
+		if w.lifetime == 0 {
+			firstGoodbye = w.seq
+			break
+		}
+	}
+	if firstGoodbye < 0 {
+		t.Fatalf("no goodbye (lifetime=0) RA was emitted; writes=%+v", writes)
+	}
+	for _, w := range writes {
+		if w.lifetime > 0 && w.seq > firstGoodbye {
+			t.Fatalf("normal RA (lifetime=%v, seq=%d) emitted AFTER the first goodbye (seq=%d); writes=%+v",
+				w.lifetime, w.seq, firstGoodbye, writes)
+		}
+	}
+}
+
+// T1 — headline ordering proof under a FORCED bad interleave. An RS is queued
+// and the owner enters the RS random-sleep branch; the test holds the in-flight
+// normal RA WriteTo until AFTER the withdraw has been signalled, then releases
+// it. The invariant (no lifetime>0 after the first goodbye) must hold: the
+// in-flight normal RA precedes the goodbye because the goodbye is emitted by the
+// owner on exit (finishShutdown), structurally after the loop.
+func TestT1_GoodbyeIsLastUnderForcedRSInterleave(t *testing.T) {
+	getConn, _ := installFakeListen(t)
+
+	iface := &net.Interface{Name: "t1iface", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	cfg := testCfg("t1iface")
+	// Fresh sender: getLastRA() is zero so the RS rate-limit gate passes and
+	// the RS triggers a normal RA reply.
+	s := newSender(cfg, iface)
+
+	// Gate state: after the startup burst, the NEXT normal RA (the RS reply) is
+	// blocked until `released` so we can interleave the withdraw with it.
+	released := make(chan struct{})
+	blocked := make(chan struct{})
+	armNormalGate := make(chan struct{}) // closed once we want to start gating
+	var gateOnce sync.Once
+
+	if err := s.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	fc := waitConn(t, getConn, "t1iface")
+	// Let the startup burst complete so the next normal RA is the RS reply.
+	waitWrites(t, fc, startupBurstCount)
+
+	fc.setBeforeWrite(func(lifetime time.Duration) {
+		if lifetime <= 0 {
+			return // never block the goodbye
+		}
+		select {
+		case <-armNormalGate:
+			gateOnce.Do(func() {
+				close(blocked)
+				<-released
+			})
+		default:
+			// burst writes (gate not armed yet) pass through
+		}
+	})
+
+	// Push lastRA into the past so the RS rate-limit (minRAMulticastDelay)
+	// passes and the RS produces a reply (the startup burst just set lastRA to
+	// now, which would otherwise suppress the reply).
+	s.setLastRA(time.Now().Add(-2 * minRAMulticastDelay))
+
+	// Arm the gate, then inject an RS. The owner rate-checks (passes),
+	// random-sleeps, then sendRA -> WriteTo hits the gate and blocks.
+	close(armNormalGate)
+	fc.injectRS(netip.MustParseAddr("fe80::2"))
+
+	// Wait until the RS-reply normal RA is genuinely blocked in WriteTo.
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RS-reply normal RA never reached the write gate")
+	}
+
+	// The in-flight normal RA is blocked. Signal graceful withdraw NOW.
+	s.signalStop(modeGraceful)
+
+	// Release the blocked normal RA, then join. The goodbye is emitted by the
+	// owner on exit, structurally after this normal RA.
+	close(released)
+	<-s.stopped
+
+	assertGoodbyeIsLast(t, fc.snapshot())
+}
+
+// T1b — companion micro-test: force a periodic-timer-style normal RA concurrent
+// with the withdraw and assert the same seq-order property. We drive it by
+// blocking a normal write and signalling stop while it is in flight.
+func TestT1b_GoodbyeIsLastWithInFlightNormalRA(t *testing.T) {
+	fl := newFakeListen(t)
+	iface := &net.Interface{Name: "t1biface", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	s := newSender(testCfg("t1biface"), iface)
+
+	released := make(chan struct{})
+	blocked := make(chan struct{})
+	var once sync.Once
+
+	// Pre-register the gate so it is attached before the owner's first burst
+	// write (no race between start() and a post-start hook install).
+	fl.preHook("t1biface", func(lifetime time.Duration) {
+		if lifetime > 0 {
+			once.Do(func() {
+				close(blocked)
+				<-released
+			})
+		}
+	})
+
+	if err := s.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	fc := waitConn(t, fl.getConn, "t1biface")
+
+	// The startup burst's first normal RA hits the gate.
+	<-blocked
+	// Now a normal RA is in flight (blocked). Signal graceful withdraw.
+	s.signalStop(modeGraceful)
+	// Release it; owner finishes burst (short-circuited by draining), then
+	// finishShutdown emits the goodbye last.
+	close(released)
+	<-s.stopped
+
+	assertGoodbyeIsLast(t, fc.snapshot())
+}
+
+// TestNegativeArm proves the test is NOT tautological: a "buggy" sender that
+// emits a normal RA AFTER the goodbye must FAIL assertGoodbyeIsLast. We
+// construct the bad write sequence directly (simulating the pre-#2033 behavior
+// where a periodic RA followed the caller-emitted goodbye).
+func TestNegativeArm_NormalRAAfterGoodbyeFails(t *testing.T) {
+	bad := []writeRec{
+		{lifetime: 1800 * time.Second, seq: 1}, // normal
+		{lifetime: 0, seq: 2},                  // goodbye
+		{lifetime: 1800 * time.Second, seq: 3}, // BUG: normal after goodbye
+	}
+	// Run assertGoodbyeIsLast in a sub-test that is EXPECTED to fail; capture
+	// via a fake testing.T.
+	ft := &fakeT{}
+	assertGoodbyeIsLastOn(ft, bad)
+	if !ft.failed {
+		t.Fatal("negative arm did not fail: a normal RA after the goodbye must FAIL the invariant")
+	}
+
+	// And the good sequence must pass.
+	good := []writeRec{
+		{lifetime: 1800 * time.Second, seq: 1},
+		{lifetime: 0, seq: 2},
+		{lifetime: 0, seq: 3},
+	}
+	ft2 := &fakeT{}
+	assertGoodbyeIsLastOn(ft2, good)
+	if ft2.failed {
+		t.Fatal("good sequence wrongly failed the invariant")
+	}
+}
+
+// fakeT records whether Fatalf was called so the negative arm can assert the
+// invariant predicate FAILS on a bad sequence without aborting the real test.
+type fakeT struct{ failed bool }
+
+func (f *fakeT) Helper()                       {}
+func (f *fakeT) Fatalf(string, ...interface{}) { f.failed = true; panic(sentinelFatal{}) }
+
+type sentinelFatal struct{}
+
+// assertGoodbyeIsLastOn is assertGoodbyeIsLast against a minimal fatal-er so it
+// can be exercised by the negative arm. It recovers the sentinel panic.
+func assertGoodbyeIsLastOn(ft *fakeT, writes []writeRec) {
+	defer func() { _ = recover() }()
+	firstGoodbye := -1
+	for _, w := range writes {
+		if w.lifetime == 0 {
+			firstGoodbye = w.seq
+			break
+		}
+	}
+	if firstGoodbye < 0 {
+		ft.Fatalf("no goodbye")
+		return
+	}
+	for _, w := range writes {
+		if w.lifetime > 0 && w.seq > firstGoodbye {
+			ft.Fatalf("normal after goodbye")
+			return
+		}
+	}
+}
+
+// TestLiveConnInvariant proves at most one live NDP conn exists per interface
+// across start/withdraw/restart cycles. Uses the Manager so the draining
+// tombstone is exercised end-to-end. The interface name must resolve via
+// net.InterfaceByName, so we use "lo".
+func TestLiveConnInvariant(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	_, liveCount := installFakeListen(t)
+
+	m := New()
+	cfg := []*config.RAInterfaceConfig{testCfg("lo")}
+
+	for cycle := 0; cycle < 10; cycle++ {
+		if err := m.Apply(cfg); err != nil {
+			t.Fatalf("cycle %d Apply: %v", cycle, err)
+		}
+		// At most one live conn at any time.
+		if lc := liveCount(); lc > 1 {
+			t.Fatalf("cycle %d: %d live conns after Apply, want <=1", cycle, lc)
+		}
+		if err := m.Withdraw(); err != nil {
+			t.Fatalf("cycle %d Withdraw: %v", cycle, err)
+		}
+		if lc := liveCount(); lc != 0 {
+			t.Fatalf("cycle %d: %d live conns after Withdraw, want 0", cycle, lc)
+		}
+	}
+}
+
+// TestLiveConnInvariant_ConcurrentApplyWithdraw hammers Apply/Withdraw/
+// WithdrawOnce/ResendBurst concurrently and asserts the live-conn count never
+// exceeds 1 for the single interface. A design that allowed two live conns
+// (e.g. starting a new sender while the old one is still draining) would trip
+// the peak check.
+func TestLiveConnInvariant_ConcurrentApplyWithdraw(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	_, liveCount := installFakeListen(t)
+
+	m := New()
+	cfg := []*config.RAInterfaceConfig{testCfg("lo")}
+
+	stop := make(chan struct{})
+	var peak int32
+	var peakMu sync.Mutex
+	recordPeak := func() {
+		lc := liveCount()
+		peakMu.Lock()
+		if lc > peak {
+			peak = lc
+		}
+		peakMu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	worker := func(fn func()) {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			fn()
+			recordPeak()
+		}
+	}
+	wg.Add(4)
+	go worker(func() { _ = m.Apply(cfg) })
+	go worker(func() { _ = m.Withdraw() })
+	go worker(func() { m.WithdrawOnce(cfg) })
+	go worker(func() { m.ResendBurst() })
+
+	time.Sleep(300 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	// Drain to a known state.
+	_ = m.Clear()
+
+	peakMu.Lock()
+	p := peak
+	peakMu.Unlock()
+	if p > 1 {
+		t.Fatalf("peak live conns = %d, want <=1 (two live conns per interface)", p)
+	}
+	if lc := liveCount(); lc != 0 {
+		t.Fatalf("leaked %d live conns after Clear", lc)
+	}
+}
+
+// T3 — WithdrawOnce emits ONLY a goodbye (no startup burst) and never toggles
+// the link. ensureLinkLocalFn is stubbed to record calls; we assert it is NOT
+// invoked (the standalone path skips ensureLinkLocal entirely).
+func TestT3_WithdrawOnceGoodbyeOnlyNoBurstNoLinkToggle(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	getConn, _ := installFakeListen(t)
+
+	// Override ensureLinkLocalFn to record invocation (installFakeListen set it
+	// to a no-op; wrap that to detect calls).
+	var linkToggled bool
+	prev := ensureLinkLocalFn
+	ensureLinkLocalFn = func(i *net.Interface) error { linkToggled = true; return prev(i) }
+	t.Cleanup(func() { ensureLinkLocalFn = prev })
+
+	m := New()
+	m.WithdrawOnce([]*config.RAInterfaceConfig{testCfg("lo")})
+
+	fc := getConn("lo")
+	if fc == nil {
+		t.Fatal("no conn opened for WithdrawOnce")
+	}
+	writes := fc.snapshot()
+	if len(writes) != goodbyeCount {
+		t.Fatalf("WithdrawOnce wrote %d RAs, want exactly %d goodbyes", len(writes), goodbyeCount)
+	}
+	for _, w := range writes {
+		if w.lifetime != 0 {
+			t.Fatalf("WithdrawOnce emitted a lifetime>0 RA (%v) — startup burst leaked", w.lifetime)
+		}
+	}
+	if linkToggled {
+		t.Fatal("WithdrawOnce invoked ensureLinkLocal (link toggle) — violates I12 no-link-toggle")
+	}
+}
+
+// T4a — WithdrawOnce skips a running sender (does not clobber a live primary).
+func TestT4a_WithdrawOnceSkipsRunningSender(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	getConn, _ := installFakeListen(t)
+
+	m := New()
+	cfg := []*config.RAInterfaceConfig{testCfg("lo")}
+	if err := m.Apply(cfg); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	fc := waitConn(t, getConn, "lo")
+	waitWrites(t, fc, 1) // at least the first startup RA
+
+	before := fc.snapshot()
+	m.WithdrawOnce(cfg) // should be a no-op (sender running)
+	after := fc.snapshot()
+
+	for _, w := range after[len(before):] {
+		if w.lifetime == 0 {
+			t.Fatal("WithdrawOnce emitted a goodbye on a live primary's conn")
+		}
+	}
+	_ = m.Clear()
+}
+
+// T5 — Apply with an identical config keeps the sender (no stop/start, no
+// goodbye, same conn).
+func TestT5_ApplyConfigEqualKeepsSender(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	getConn, liveCount := installFakeListen(t)
+
+	m := New()
+	cfg := []*config.RAInterfaceConfig{testCfg("lo")}
+	if err := m.Apply(cfg); err != nil {
+		t.Fatalf("Apply1: %v", err)
+	}
+	fc1 := waitConn(t, getConn, "lo")
+
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply2: %v", err)
+	}
+	fc2 := getConn("lo")
+	if fc1 != fc2 {
+		t.Fatal("config-equal Apply restarted the sender (new conn)")
+	}
+	if lc := liveCount(); lc != 1 {
+		t.Fatalf("live conns = %d after config-equal Apply, want 1", lc)
+	}
+	for _, w := range fc1.snapshot() {
+		if w.lifetime == 0 {
+			t.Fatal("config-equal Apply emitted a goodbye")
+		}
+	}
+	_ = m.Clear()
+}
+
+// T6 — Clear / Apply-remove emit NO goodbye (modeHard).
+func TestT6_ClearEmitsNoGoodbye(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	getConn, _ := installFakeListen(t)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	fc := waitConn(t, getConn, "lo")
+	waitWrites(t, fc, 1)
+	if err := m.Clear(); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	for _, w := range fc.snapshot() {
+		if w.lifetime == 0 {
+			t.Fatal("Clear emitted a goodbye (lifetime=0); hard stop must not")
+		}
+	}
+}
+
+// T7 — idempotent / graceful-upgrades-hard. Both orderings must STILL produce
+// a goodbye (graceful wins; never downgrade), and a double signalStop must not
+// panic. Both signals are issued while the owner is PARKED at a write gate so
+// the two Stores complete (happen-before) the owner reading mode in
+// finishShutdown — testing the achievable, deterministic guarantee rather than
+// the documented sub-µs residual (which only exists when the owner has already
+// read modeHard before the upgrade Store; the manager serializes real callers
+// via m.mu so that residual is not on the production demotion path).
+func TestT7_GracefulUpgradesHard(t *testing.T) {
+	run := func(name string, first, second shutdownMode) {
+		fl := newFakeListen(t)
+		release := make(chan struct{})
+		parked := make(chan struct{})
+		var once sync.Once
+		// Park the owner at its FIRST write so both signalStops land before the
+		// owner ever reads mode.
+		fl.preHook(name, func(time.Duration) {
+			once.Do(func() { close(parked); <-release })
+		})
+
+		iface := &net.Interface{Name: name, HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+		s := newSender(testCfg(name), iface)
+		if err := s.start(); err != nil {
+			t.Fatalf("[%s] start: %v", name, err)
+		}
+		fc := waitConn(t, fl.getConn, name)
+
+		<-parked // owner is blocked in its first WriteTo
+		s.signalStop(first)
+		s.signalStop(second) // double signal must not panic (sync.Once)
+		close(release)       // owner now proceeds; reads the arbitrated mode
+		<-s.stopped
+
+		assertGoodbyeIsLast(t, fc.snapshot())
+	}
+
+	run("t7a", modeHard, modeGraceful)     // hard then graceful -> graceful wins
+	run("t7b", modeGraceful, modeHard)     // graceful then hard -> no downgrade
+}
+
+// T9 — startup burst preserved: a fresh start records exactly
+// startupBurstCount normal RAs (before any periodic fire).
+func TestT9_StartupBurstPreserved(t *testing.T) {
+	getConn, _ := installFakeListen(t)
+	iface := &net.Interface{Name: "t9", HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 1}}
+	s := newSender(testCfg("t9"), iface)
+	if err := s.start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	fc := waitConn(t, getConn, "t9")
+	waitWrites(t, fc, startupBurstCount)
+	writes := fc.snapshot()
+	// The first startupBurstCount writes must all be normal RAs.
+	for i := 0; i < startupBurstCount; i++ {
+		if writes[i].lifetime == 0 {
+			t.Fatalf("burst write %d was a goodbye, want normal RA", i)
+		}
+	}
+	s.stop()
+}
+
+// TestStatusReportsDraining verifies Status surfaces a draining interface with
+// State "draining" (distinct from "active"). We hold a sender in finishShutdown
+// by blocking its goodbye write, then snapshot Status while it drains.
+func TestStatusReportsDraining(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	getConn, _ := installFakeListen(t)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	fc := waitConn(t, getConn, "lo")
+	waitWrites(t, fc, 1)
+
+	// Block the goodbye so the sender lingers in the draining tombstone.
+	gate := make(chan struct{})
+	fc.setBeforeWrite(func(lifetime time.Duration) {
+		if lifetime == 0 {
+			<-gate
+		}
+	})
+
+	done := make(chan struct{})
+	go func() { _ = m.Withdraw(); close(done) }()
+
+	// Poll Status until the draining entry appears.
+	var sawDraining bool
+	for i := 0; i < 200; i++ {
+		for _, info := range m.Status() {
+			if info.Interface == "lo" && info.State == "draining" {
+				sawDraining = true
+			}
+		}
+		if sawDraining {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	close(gate)
+	<-done
+
+	if !sawDraining {
+		t.Fatal("Status never reported the withdrawing interface as draining")
+	}
+	// After drain, no draining entry remains.
+	for _, info := range m.Status() {
+		if info.State == "draining" {
+			t.Fatalf("draining entry lingered after Withdraw completed: %+v", info)
+		}
+	}
+}

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -1401,7 +1401,10 @@ func TestRace1_ConcurrentWithdrawsExactlyOneGoodbye(t *testing.T) {
 	wg.Wait() // both Withdraws have flipped goodbyeWanted (they own no release)
 
 	// The single owner releases the entry: claim-once -> exactly one standalone.
-	m.releaseDrain("lo", s)
+	m.mu.Lock()
+	ep := m.epoch
+	m.mu.Unlock()
+	m.releaseDrain("lo", s, ep, nil)
 
 	total, conns := fl.goodbyeStats("lo")
 	if conns != 1 || total != goodbyeCount {
@@ -1462,12 +1465,13 @@ func TestRace3_ApplyDuringStandaloneEmitDefersNoClobber(t *testing.T) {
 	}
 	m.mu.Lock()
 	m.draining["lo"] = &drainEntry{sender: s, cfg: s.cfg, goodbyeWanted: true}
+	ep := m.epoch
 	m.mu.Unlock()
 
 	// Release the held tombstone via releaseDrain (the sole owner). It must emit
 	// the standalone WHILE holding the entry — the gated write blocks it there.
 	relDone := make(chan struct{})
-	go func() { m.releaseDrain("lo", s); close(relDone) }()
+	go func() { m.releaseDrain("lo", s, ep, nil); close(relDone) }()
 
 	select {
 	case <-standaloneBlocking:
@@ -1555,6 +1559,7 @@ func TestRace2_TimeoutDoesNotEmitWhileOwnerCouldBeLive(t *testing.T) {
 	delete(m.senders, "lo")
 	m.draining["lo"] = &drainEntry{sender: s, cfg: s.cfg, goodbyeWanted: true}
 	s.signalStop(modeHard)
+	ep := m.epoch
 	m.mu.Unlock()
 
 	orig := claimWaitTimeout
@@ -1562,7 +1567,7 @@ func TestRace2_TimeoutDoesNotEmitWhileOwnerCouldBeLive(t *testing.T) {
 	defer func() { claimWaitTimeout = orig }()
 
 	done := make(chan struct{})
-	go func() { m.releaseDrain("lo", s); close(done) }()
+	go func() { m.releaseDrain("lo", s, ep, nil); close(done) }()
 	select {
 	case <-done:
 	case <-time.After(3 * time.Second):
@@ -1576,12 +1581,193 @@ func TestRace2_TimeoutDoesNotEmitWhileOwnerCouldBeLive(t *testing.T) {
 			"be live) — got %d conns / %d writes; expected 0 (#2033 race 2)",
 			conns, total)
 	}
-	// Tombstone removed (entry released) despite no emit.
+	// Tombstone is LEFT HELD after a timeout (the owner may still hold a live
+	// conn — a future Apply must defer, never open a 2nd conn). A detached
+	// reclaimer removes it only once the wedged owner finally exits.
 	m.mu.Lock()
 	_, stillDraining := m.draining["lo"]
 	m.mu.Unlock()
-	if stillDraining {
-		t.Fatal("releaseDrain left the tombstone after the timeout")
+	if !stillDraining {
+		t.Fatal("releaseDrain removed the tombstone after a timeout; it must be "+
+			"LEFT HELD (owner may still hold a live conn) — #2033 round-4")
 	}
-	close(wedge) // unwedge the parked owner so the goroutine can exit
+
+	// Now let the wedged owner exit; the reclaimer must remove the tombstone.
+	close(wedge)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		m.mu.Lock()
+		_, ok := m.draining["lo"]
+		m.mu.Unlock()
+		if !ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("reclaimer did not remove the tombstone after the owner exited")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// --- #2033 round-4: changed-config restart shares releaseDrain's discipline ---
+
+// TestRestartTimeoutNoGoodbyeNoReplacement (round-4 MAJOR 1+2): a changed-config
+// Apply whose OLD sender WEDGES (never closes stopped) must, on the join
+// timeout, NOT emit a standalone goodbye (even with a racing graceful Withdraw
+// that flipped goodbyeWanted — the read would be unordered, owner may be live)
+// AND must NOT start the replacement (the old conn may be live → would break
+// ≤1-conn). The tombstone is LEFT HELD.
+//
+// NON-TAUTOLOGY: against head 5d7ef206 the inline restart read oldS.goodbyeEmitted
+// after the timeout and emitted a standalone (MAJOR 1) — so a goodbye would
+// appear here → FAILS.
+func TestRestartTimeoutNoGoodbyeNoReplacement(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	old := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, old, 1)
+
+	// WEDGE the old sender: its conn.Close blocks forever, so its `stopped`
+	// never closes and the restart join will TIME OUT.
+	wedge := make(chan struct{})
+	old.setBeforeClose(func() { <-wedge })
+
+	orig := claimWaitTimeout
+	claimWaitTimeout = 150 * time.Millisecond
+	defer func() { claimWaitTimeout = orig }()
+
+	// Changed-config Apply (restart) runs concurrently; it will hard-stop the
+	// old sender and block joining it (wedged) until the short timeout.
+	applyDone := make(chan error, 1)
+	go func() {
+		applyDone <- m.Apply([]*config.RAInterfaceConfig{configChanged("lo")})
+	}()
+
+	// Race a graceful Withdraw in to flip goodbyeWanted on the restart entry.
+	// Poll until the restart tombstone exists, then Withdraw.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		m.mu.Lock()
+		_, draining := m.draining["lo"]
+		m.mu.Unlock()
+		if draining {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("restart never installed the tombstone")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	_ = m.Withdraw() // flips goodbyeWanted on the (wedged) restart entry
+
+	// Apply returns after the join timeout.
+	select {
+	case <-applyDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("changed-config Apply did not return after the join timeout")
+	}
+
+	// No standalone goodbye on the timeout path (owner could be live).
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 0 || total != 0 {
+		t.Fatalf("restart timeout emitted a goodbye (%d conns / %d writes); "+
+			"the timeout path must NOT read goodbyeEmitted/emit — #2033 round-4 MAJOR 1",
+			conns, total)
+	}
+	// No replacement started while the old conn may be live; ≤1 live conn.
+	m.mu.Lock()
+	_, live := m.senders["lo"]
+	m.mu.Unlock()
+	if live {
+		t.Fatal("restart timeout started a replacement sender while the old conn "+
+			"may be live — #2033 round-4 MAJOR 2 (≤1-conn)")
+	}
+	if lc := fl.liveCount(); lc > 1 {
+		t.Fatalf(">1 live conn after restart timeout (%d) — #2033 round-4 MAJOR 2", lc)
+	}
+	// Tombstone is left held; reclaimed once the wedged owner exits.
+	m.mu.Lock()
+	_, stillDraining := m.draining["lo"]
+	m.mu.Unlock()
+	if !stillDraining {
+		t.Fatal("restart timeout removed the tombstone; it must be LEFT HELD")
+	}
+	close(wedge) // let the owner exit so the reclaimer + test can finish
+}
+
+// TestRestartTimeoutNoReplacementWhenNoGoodbye (round-4 MAJOR 2): the same
+// wedged-old-sender restart timeout, but with NO racing Withdraw (no goodbye
+// wanted). startLocked must still NOT run while the old conn may be live — the
+// replacement opens ONLY on the proven-closed arm. ≤1 live conn always.
+//
+// NON-TAUTOLOGY: against head 5d7ef206 the inline restart fell through to
+// startLocked(cfg) after the timeout (MAJOR 2) → a replacement conn opened while
+// the old one was still live → >1 live conn → FAILS.
+func TestRestartTimeoutNoReplacementWhenNoGoodbye(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	old := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, old, 1)
+
+	wedge := make(chan struct{})
+	old.setBeforeClose(func() { <-wedge })
+
+	orig := claimWaitTimeout
+	claimWaitTimeout = 150 * time.Millisecond
+	defer func() { claimWaitTimeout = orig }()
+
+	// Sample the live-conn count throughout to catch a transient 2-conn window.
+	var peak int32
+	stopSampling := make(chan struct{})
+	sampleDone := make(chan struct{})
+	go func() {
+		defer close(sampleDone)
+		for {
+			select {
+			case <-stopSampling:
+				return
+			default:
+			}
+			if lc := fl.liveCount(); lc > peak {
+				peak = lc
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	err := m.Apply([]*config.RAInterfaceConfig{configChanged("lo")})
+	_ = err // restart aborts on timeout; not necessarily an error
+
+	close(stopSampling)
+	<-sampleDone
+
+	if peak > 1 {
+		t.Fatalf("peak live conns = %d during a wedged restart timeout; the "+
+			"replacement must open ONLY after the old conn is proven closed "+
+			"(≤1-conn) — #2033 round-4 MAJOR 2", peak)
+	}
+	m.mu.Lock()
+	_, live := m.senders["lo"]
+	m.mu.Unlock()
+	if live {
+		t.Fatal("restart timeout started a replacement while the old conn may be live")
+	}
+	// No goodbye for a pure (no-withdraw) restart.
+	total, conns := fl.goodbyeStats("lo")
+	if conns != 0 || total != 0 {
+		t.Fatalf("pure restart emitted a goodbye (%d conns / %d writes); expected 0", conns, total)
+	}
+	close(wedge)
 }


### PR DESCRIPTION
## Problem

The embedded IPv6 RA sender (`pkg/ra`) can race shutdown: the lifetime-zero
"goodbye" RA (router withdraw) must be the LAST RA on the wire for an
interface, but a normal periodic / RS-triggered RA goroutine could still emit
a normal RA AFTER the goodbye — re-advertising the demoting router. On HA
failover this left directly attached hosts holding a dead default route.

## Approach — Path A (single owner; goodbye emitted by the owner)

Implements the converged plan (`research/2033-ra-withdraw-serialize`).

- **Single-owner emission.** Per interface, exactly ONE goroutine
  (`sender.run`) writes/closes the NDP conn — startup burst, periodic RAs,
  RS replies AND the goodbye. `ResendBurst` routes the re-burst through the
  owner via a buffered `burstCh` (no second writer).
- **Goodbye emitted by the owner (I16/I17).** Shutdown signals the owner via a
  published atomic `shutdownMode` {graceful|hard} + a `sync.Once`-guarded
  `close(stopCh)`. `finishShutdown` is the ONLY goodbye-emit AND the ONLY
  conn-close site: on graceful it sends the lifetime-zero goodbye as its FINAL
  write, then closes the conn — so no normal RA can follow it, and a racing
  hard close cannot kill the upgraded goodbye. Graceful UPGRADES hard, never
  the reverse (cluster RA ops share only the manager mutex).
- **Draining tombstone (I16).** `Withdraw`/`WithdrawInterfaces`/`Clear` move a
  sender to a per-interface tombstone under `m.mu`, then join OUTSIDE the lock
  (no Status/Apply stall on the failover hot path). While the tombstone is
  present a concurrent `Apply`/`WithdrawOnce` treats it as a claim and defers —
  guaranteeing **at most one live NDP conn per interface**. Deferred `Apply` is
  epoch-guarded (I16b) so a stale Apply cannot re-arm RA on a node that has
  since gone BACKUP.
- **Owner-only `conn.Close` (I17)** + **bounded owner writes (I18,
  `SetWriteDeadline`)** so withdrawal never wedges on a stuck socket.
- **rsReceiver error backoff (I10)** — no 100% CPU hot-loop if the interface
  dies while `stopCh` is still open; cleanly exits on ctx/socket error.
- **`lastRA` data-race fix** — now guarded by `lastRAMu` (`getLastRA`/
  `setLastRA`); `Status` reads it under the lock.
- **`WithdrawOnce`** uses a goodbye-only path (no `run()`, no burst, no link
  toggle — I12) so it cannot re-advertise the router it withdraws.
- **Status()** reports a draining interface with `State == "draining"`
  (distinct from "active"); documented in code + README.

The `ndpConn` seam matches mdlayher/ndp v1.1.0 exactly
(`ndp.Message`/`*ipv6.ControlMessage`/`netip.Addr` on WriteTo/ReadFrom,
`*ipv6.ICMPFilter`, `netip.Addr` group). No public `Manager` signature or
observable semantics change; daemon/VRRP callers are untouched.

## Tests (`pkg/ra/serialize_test.go`)

- **T1 / T1b** — forced bad interleave (RS reply / burst RA held in `WriteTo`
  while a graceful withdraw is signalled); assert the achievable invariant **no
  lifetime>0 write has a seq greater than the FIRST goodbye**. Deterministic
  via a pre-registered seam hook (no flakiness).
- **Negative arm** — a constructed normal-RA-after-goodbye sequence MUST fail
  the predicate (non-tautological).
- **`<=1 live conn per interface` invariant** — serial + concurrent
  Apply/Withdraw/WithdrawOnce/ResendBurst hammer with a peak-count check.
- T3 (goodbye-only, no burst, no link toggle), T4a, T5, T6, T7
  (graceful-upgrades-hard both orderings), T9, Status-draining.
- **Mutation-verified:** a finishShutdown mutant that emits a normal RA after
  the goodbye fails T1/T1b; a withdraw mutant that omits the tombstone trips
  the live-conn invariant (peak=2).

## Validation

- `go build ./...` — clean
- `go vet ./pkg/ra/...` — clean
- `go test ./pkg/ra/...` — pass (31 PASS)
- `go test -race ./pkg/ra/...` — pass (also 10x for flakiness)
- `make test-failover` (loss cluster) is the maintainer's lab gate — not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)