### PR TITLE
test/incus: guard mouse-latency settle gate against unsatisfiable ELEPHANT_PORT/SHAPER_BPS pairings (#1365)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -21,6 +21,29 @@
   address was added.
 - **File(s)**: pkg/ra/sender.go, _Log.md
 
+## 2026-06-19 — #1365 guard: Copilot review fixes (ceil floor, unscheduled-class error)
+
+- **Timestamp**: 2026-06-19
+- **Action**: Apply 4 Copilot findings on PR #2046. (1) Compute the
+  settle floor with `math.ceil(0.7 * SHAPER_BPS)` instead of `int(...)`
+  so the guard never under-reports the float threshold the real gate
+  uses; a borderline pairing whose threshold sits just above the integer
+  cap is now correctly rejected rather than passed by truncation. (2)
+  Raise `CoSFixtureError` when a classified port's forwarding-class has
+  no scheduler-map entry, instead of silently defaulting to the
+  interface-shaper cap (which masked fixture drift). (3) Rewrote the
+  boundary test to use the LARGEST `SHAPER_BPS` whose ceil-floor lands
+  exactly on the cap (true boundary, computed with the same float
+  arithmetic), asserting `floor_bps == cap`. (4) The over-boundary test
+  now bumps by EXACTLY 1 bps and asserts `floor_bps == cap + 1` →
+  unsatisfiable, proving the boundary is sharp to a single bps (this
+  assertion fails under the old `int()` truncation, so it is
+  non-tautological). Added a unit test for the unscheduled-class error
+  and a doc note on the ceil rounding + hard error.
+- **File(s)**: test/incus/mouse_latency_orchestrate.py,
+  test/incus/mouse_latency_orchestrate_test.py, docs/fairness-regimes.md,
+  _Log.md
+
 ## 2026-06-19 — #1365 mouse-latency env-shape consistency guard
 
 - **Timestamp**: 2026-06-19

--- a/_Log.md
+++ b/_Log.md
@@ -21,6 +21,32 @@
   address was added.
 - **File(s)**: pkg/ra/sender.go, _Log.md
 
+## 2026-06-19 — #1365 mouse-latency env-shape consistency guard
+
+- **Timestamp**: 2026-06-19
+- **Action**: Add an offline, statically-testable consistency guard for
+  the mouse-latency cwnd-settle gate. The gate requires the elephant
+  aggregate to reach `0.7 * SHAPER_BPS`, but the class implied by
+  `ELEPHANT_PORT` can only deliver up to its configured cap, so a
+  mismatched pairing (the #1365 footgun: port 5202 = 1 Gbps exact class
+  vs `SHAPER_BPS=10G`) is arithmetically unsatisfiable and INVALIDates
+  every loaded rep before the probe. Added `parse_cos_class_caps`
+  (derives the port->class cap table directly from
+  `cos-iperf-config.set` so it cannot drift) and
+  `check_settle_threshold_satisfiable` pure functions plus a
+  `check-env-consistency` CLI subcommand to
+  `mouse_latency_orchestrate.py`; wired the guard into
+  `test-mouse-latency.sh` before each rep (aborts with an actionable
+  message, no cluster contact); added non-tautological unit tests
+  (unsatisfiable->fail, satisfiable->pass, boundary, just-over-cap flip,
+  drift guard) and a shell-line assertion; documented the guard in
+  `docs/fairness-regimes.md`. The live fairness/throughput measurement
+  remains lab-gated (deferred).
+- **File(s)**: test/incus/mouse_latency_orchestrate.py,
+  test/incus/mouse_latency_orchestrate_test.py,
+  test/incus/test_mouse_latency_shell_test.py,
+  test/incus/test-mouse-latency.sh, docs/fairness-regimes.md, _Log.md
+
 ## 2026-06-19 — #2000 review follow-up on postinst test harness
 
 - **Timestamp**: 2026-06-19

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -676,7 +676,14 @@ table cannot drift from the fixture) and `ABORT`s with an actionable
 message — naming the class, its cap, the computed floor, and a hint to
 either set `SHAPER_BPS` to the class cap or pick a port whose class cap
 is `>= floor` — instead of burning a whole matrix cell on an impossible
-pairing. To exercise a genuinely high-rate class, point at a high-rate
+pairing. A classified port whose forwarding-class has no scheduler-map
+entry is treated as a hard fixture error (not silently defaulted to the
+interface shaper), keeping the table honest. The floor is computed with
+ceiling rounding (`ceil(0.7 * SHAPER_BPS)`) so the guard never
+under-reports it: the real gate compares the aggregate against the float
+threshold `0.7 * SHAPER_BPS`, and a borderline pairing whose threshold
+sits just above the integer cap is correctly rejected rather than passed
+by truncation. To exercise a genuinely high-rate class, point at a high-rate
 port with the matching bps, e.g. `ELEPHANT_PORT=5205 SHAPER_BPS=9000000000`
 (the 9 Gbps `iperf-9g` exact class). The guard is purely static (no
 cluster contact) and is covered by `mouse_latency_orchestrate_test.py`

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -652,6 +652,38 @@ root surplus arbitration or dataplane queue residence. The per-rep
 `cos-interface-post.txt` snapshots preserve the CoS queue counters needed
 for that cross-check.
 
+#### Env-shape consistency guard (#1365)
+
+`SHAPER_BPS` MUST move with `ELEPHANT_PORT`: the cwnd-settle gate
+requires the elephant aggregate to reach `0.7 * SHAPER_BPS`, but the
+forwarding class implied by `ELEPHANT_PORT` (per
+`test/incus/cos-iperf-config.set`) can only ever deliver up to its
+configured cap — the scheduler `transmit-rate` for `exact` classes, or
+the interface `shaping-rate` for the non-exact best-effort / uncapped
+classes. When the settle floor exceeds that cap the gate is
+*arithmetically unsatisfiable*: every loaded rep INVALIDates with
+`cwnd-not-settled` before the mouse probe ever starts, regardless of
+dataplane or scheduler health. That is the #1365 footgun — the matrix
+was run with `ELEPHANT_PORT=5202` (the 1 Gbps `iperf-1g` exact class)
+paired with `SHAPER_BPS=10000000000`, so the 7 Gbps floor could never
+be met against a 1 Gbps cap and the cell reported `INSUFFICIENT-DATA`.
+
+`test-mouse-latency.sh` now runs a static consistency guard before each
+rep:
+`mouse_latency_orchestrate.py check-env-consistency <port> <shaper_bps>`.
+It parses the applied CoS fixture as its single source of truth (so the
+table cannot drift from the fixture) and `ABORT`s with an actionable
+message — naming the class, its cap, the computed floor, and a hint to
+either set `SHAPER_BPS` to the class cap or pick a port whose class cap
+is `>= floor` — instead of burning a whole matrix cell on an impossible
+pairing. To exercise a genuinely high-rate class, point at a high-rate
+port with the matching bps, e.g. `ELEPHANT_PORT=5205 SHAPER_BPS=9000000000`
+(the 9 Gbps `iperf-9g` exact class). The guard is purely static (no
+cluster contact) and is covered by `mouse_latency_orchestrate_test.py`
+(`parse_cos_class_caps` / `check_settle_threshold_satisfiable`),
+including a drift guard that cross-checks the parsed table against the
+canonical port→rate map.
+
 ```bash
 MOUSE_COS_SURPLUS_SHARING=1 \
 MOUSE_LATENCY_CELLS=$'0 100\n100 100' \

--- a/test/incus/mouse_latency_orchestrate.py
+++ b/test/incus/mouse_latency_orchestrate.py
@@ -19,6 +19,7 @@ Subcommands:
 
 import argparse
 import json
+import math
 import os
 import re
 import statistics
@@ -174,6 +175,17 @@ def parse_cos_class_caps(set_text: str) -> dict:
     out: dict = {}
     for port, fc in port_to_class.items():
         sched = class_to_sched.get(fc)
+        if sched is None:
+            # A classified port whose forwarding-class has no scheduler-map
+            # entry would silently fall through to the interface-shaper cap
+            # below, masking fixture drift/misparse and yielding a wrong
+            # cap. The guard's whole point is that it cannot drift from the
+            # fixture, so refuse rather than guess.
+            raise CoSFixtureError(
+                f"port {port} class {fc} has no scheduler-map entry "
+                f"(forwarding-class is classified but unscheduled); the "
+                f"CoS fixture cannot resolve its rate cap"
+            )
         exact = bool(sched_exact.get(sched, False))
         if exact:
             cap = sched_rate.get(sched)
@@ -232,7 +244,15 @@ def check_settle_threshold_satisfiable(
             f"ELEPHANT_PORT={elephant_port} is not classified by the CoS "
             f"fixture; known ports: {sorted(caps)}"
         )
-    floor_bps = int(min_utilization * shaper_bps)
+    # The real cwnd-settle gate compares the aggregate against the FLOAT
+    # threshold `mn < min_utilization * shaper_bps`. Round the floor UP
+    # (ceil) so the guard never under-reports it: a borderline pairing
+    # whose true float threshold sits just above the integer cap must be
+    # called unsatisfiable, not "satisfiable" by truncation. The aggregate
+    # is an integer bps count, so the smallest aggregate that can clear a
+    # float threshold T is ceil(T) (the first integer >= T; for integer T
+    # an aggregate of exactly T also clears it since the gate uses `<`).
+    floor_bps = math.ceil(min_utilization * shaper_bps)
     cap_bps = info["cap_bps"]
     satisfiable = floor_bps <= cap_bps
     if satisfiable:

--- a/test/incus/mouse_latency_orchestrate.py
+++ b/test/incus/mouse_latency_orchestrate.py
@@ -19,12 +19,246 @@ Subcommands:
 
 import argparse
 import json
+import os
 import re
 import statistics
 import sys
 
 from cluster_status_parse import parse_cluster_status
 from iperf3_sum_parse import parse_sum_bps
+
+# The cwnd-settle gate (build_cwnd_settle_diagnostics) requires the
+# aggregate to reach 0.7 * SHAPER_BPS. Keep this in lockstep with
+# `min_aggregate_utilization` below; the env-consistency guard uses it
+# to decide whether a (ELEPHANT_PORT, SHAPER_BPS) pairing can ever pass.
+_SETTLE_MIN_UTILIZATION = 0.7
+
+# Junos transmit-rate / shaping-rate unit suffixes. Decimal SI
+# (1k = 1000), matching how iperf3 reports bits/sec and how the rest of
+# this harness (fairness-harness.sh) converts the fixture rates.
+_RATE_SUFFIX_MULTIPLIER = {
+    "": 1,
+    "k": 1_000,
+    "m": 1_000_000,
+    "g": 1_000_000_000,
+    "t": 1_000_000_000_000,
+}
+
+# Default location of the canonical CoS fixture relative to this file.
+_DEFAULT_COS_SET = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "cos-iperf-config.set"
+)
+
+
+def _parse_junos_rate(token: str) -> int | None:
+    """Convert a Junos rate token (e.g. '1.0g', '100m', '25g') to bps.
+
+    Returns None for tokens that are not a numeric-rate form (so the
+    caller can skip non-rate scheduler attributes like 'exact').
+    """
+    m = re.fullmatch(r"(\d+(?:\.\d+)?)([kmgt]?)", token.strip().lower())
+    if not m:
+        return None
+    value = float(m.group(1))
+    mult = _RATE_SUFFIX_MULTIPLIER[m.group(2)]
+    return int(value * mult)
+
+
+class CoSFixtureError(ValueError):
+    """Raised when the CoS fixture cannot resolve a port's class cap."""
+
+
+def parse_cos_class_caps(set_text: str) -> dict:
+    """Parse a cos-iperf-config.set fixture into a per-port rate table.
+
+    Returns a dict keyed by destination-port (int) with values:
+        {"forwarding_class": str,
+         "scheduler": str,
+         "cap_bps": int,          # achievable aggregate ceiling
+         "exact": bool}           # True if scheduler is transmit-rate exact
+
+    The ceiling is the scheduler's `transmit-rate` for `exact` classes
+    (the class is hard-capped at that aggregate per
+    docs/cos-traffic-shaping.md), and the interface `shaping-rate` for
+    non-exact classes (best-effort / uncapped), which can only ever burst
+    to the interface shaper. This is the single source of truth the
+    env-consistency guard compares SHAPER_BPS against — it is derived
+    directly from the applied fixture so it cannot drift from it.
+    """
+    # port -> forwarding-class, forwarding-class -> scheduler,
+    # scheduler -> (rate_bps, exact), plus the interface shaping-rate.
+    port_to_class: dict = {}
+    class_to_sched: dict = {}
+    sched_rate: dict = {}
+    sched_exact: dict = {}
+    iface_shaping_bps: int | None = None
+
+    term_class: dict = {}  # term-id -> forwarding-class
+    term_ports: dict = {}  # term-id -> list[int]
+
+    for raw in set_text.splitlines():
+        line = raw.strip()
+        if not line.startswith("set "):
+            continue
+        toks = line.split()
+
+        # set ... filter <name> term <id> from destination-port <port>
+        if "destination-port" in toks and "term" in toks:
+            try:
+                term = toks[toks.index("term") + 1]
+                port = int(toks[toks.index("destination-port") + 1])
+            except (ValueError, IndexError):
+                continue
+            term_ports.setdefault(term, []).append(port)
+            continue
+
+        # set ... filter <name> term <id> then forwarding-class <fc>
+        if "forwarding-class" in toks and "term" in toks and "then" in toks:
+            try:
+                term = toks[toks.index("term") + 1]
+                fc = toks[toks.index("forwarding-class") + 1]
+            except IndexError:
+                continue
+            term_class[term] = fc
+            continue
+
+        # set class-of-service scheduler-maps <map> forwarding-class <fc>
+        #     scheduler <sched>
+        if (
+            "scheduler-maps" in toks
+            and "forwarding-class" in toks
+            and "scheduler" in toks
+        ):
+            try:
+                fc = toks[toks.index("forwarding-class") + 1]
+                sched = toks[toks.index("scheduler") + 1]
+            except IndexError:
+                continue
+            class_to_sched[fc] = sched
+            continue
+
+        # set class-of-service schedulers <sched> transmit-rate <val|exact>
+        if "schedulers" in toks and "transmit-rate" in toks:
+            try:
+                sched = toks[toks.index("schedulers") + 1]
+                val = toks[toks.index("transmit-rate") + 1]
+            except IndexError:
+                continue
+            if val == "exact":
+                sched_exact[sched] = True
+            else:
+                rate = _parse_junos_rate(val)
+                if rate is not None:
+                    sched_rate[sched] = rate
+            continue
+
+        # set class-of-service interfaces <if> unit <u> shaping-rate <val>
+        if "interfaces" in toks and "shaping-rate" in toks:
+            try:
+                val = toks[toks.index("shaping-rate") + 1]
+            except IndexError:
+                continue
+            rate = _parse_junos_rate(val)
+            if rate is not None:
+                iface_shaping_bps = rate
+            continue
+
+    # Stitch term ports -> forwarding-class.
+    for term, ports in term_ports.items():
+        fc = term_class.get(term)
+        if fc is None:
+            continue
+        for port in ports:
+            port_to_class[port] = fc
+
+    out: dict = {}
+    for port, fc in port_to_class.items():
+        sched = class_to_sched.get(fc)
+        exact = bool(sched_exact.get(sched, False))
+        if exact:
+            cap = sched_rate.get(sched)
+            if cap is None:
+                raise CoSFixtureError(
+                    f"port {port} class {fc} scheduler {sched} is "
+                    f"transmit-rate exact but has no numeric transmit-rate"
+                )
+        else:
+            # Non-exact classes (best-effort / uncapped) are bounded only
+            # by the interface shaping-rate.
+            if iface_shaping_bps is None:
+                raise CoSFixtureError(
+                    f"port {port} class {fc} is non-exact but the fixture "
+                    f"defines no interface shaping-rate"
+                )
+            cap = iface_shaping_bps
+        out[port] = {
+            "forwarding_class": fc,
+            "scheduler": sched,
+            "cap_bps": cap,
+            "exact": exact,
+        }
+    return out
+
+
+def check_settle_threshold_satisfiable(
+    elephant_port: int,
+    shaper_bps: int,
+    *,
+    set_text: str | None = None,
+    min_utilization: float = _SETTLE_MIN_UTILIZATION,
+) -> dict:
+    """Decide whether the cwnd-settle gate can ever pass for a pairing.
+
+    The cwnd-settle gate requires the elephant aggregate to reach
+    `min_utilization * shaper_bps`. The class implied by `elephant_port`
+    can only ever deliver up to its configured cap (`cap_bps`). If the
+    floor exceeds that cap, the gate is arithmetically unsatisfiable
+    regardless of dataplane or scheduler health — exactly the #1365
+    misconfiguration (port 5202 = 1 Gbps exact class vs SHAPER_BPS=10G,
+    floor 7 Gbps > 1 Gbps cap).
+
+    Returns a dict with keys:
+        satisfiable (bool), reason (str), forwarding_class, scheduler,
+        cap_bps, floor_bps, shaper_bps, elephant_port.
+    Raises CoSFixtureError if the port is not present in the fixture.
+    """
+    if set_text is None:
+        with open(_DEFAULT_COS_SET) as f:
+            set_text = f.read()
+    caps = parse_cos_class_caps(set_text)
+    info = caps.get(elephant_port)
+    if info is None:
+        raise CoSFixtureError(
+            f"ELEPHANT_PORT={elephant_port} is not classified by the CoS "
+            f"fixture; known ports: {sorted(caps)}"
+        )
+    floor_bps = int(min_utilization * shaper_bps)
+    cap_bps = info["cap_bps"]
+    satisfiable = floor_bps <= cap_bps
+    if satisfiable:
+        reason = (
+            f"settle floor {floor_bps} bps <= class {info['forwarding_class']} "
+            f"cap {cap_bps} bps"
+        )
+    else:
+        reason = (
+            f"settle floor {floor_bps} bps "
+            f"({min_utilization:g} * SHAPER_BPS={shaper_bps}) exceeds class "
+            f"{info['forwarding_class']} cap {cap_bps} bps "
+            f"(scheduler {info['scheduler']}); the cwnd-settle gate can "
+            f"never pass for this ELEPHANT_PORT/SHAPER_BPS pairing"
+        )
+    return {
+        "satisfiable": satisfiable,
+        "reason": reason,
+        "forwarding_class": info["forwarding_class"],
+        "scheduler": info["scheduler"],
+        "cap_bps": cap_bps,
+        "floor_bps": floor_bps,
+        "shaper_bps": shaper_bps,
+        "elephant_port": elephant_port,
+        "min_utilization": min_utilization,
+    }
 
 _IPERF_INTERVAL_RE = re.compile(
     r"^\[\s*(?P<stream_id>SUM|\d+)\]\s+"
@@ -332,6 +566,38 @@ def cmd_check_collapse(args: argparse.Namespace) -> int:
     return 1
 
 
+def cmd_check_env_consistency(args: argparse.Namespace) -> int:
+    """Exit 0 if the ELEPHANT_PORT/SHAPER_BPS pairing can settle; 1 if not.
+
+    #1365: the canonical matrix run paired a 1 Gbps exact class port
+    (5202) with SHAPER_BPS=10G, so the cwnd-settle floor (7 Gbps) could
+    never be met and every loaded rep INVALIDated before reaching the
+    mouse probe. This guard catches that misconfiguration statically,
+    before the rep starts, with an actionable message.
+    """
+    set_text = None
+    if args.set_file:
+        with open(args.set_file) as f:
+            set_text = f.read()
+    try:
+        result = check_settle_threshold_satisfiable(
+            args.elephant_port, args.shaper_bps, set_text=set_text,
+        )
+    except CoSFixtureError as exc:
+        print(f"ABORT: {exc}", file=sys.stderr)
+        return 2
+    if result["satisfiable"]:
+        return 0
+    print(f"ABORT: {result['reason']}", file=sys.stderr)
+    print(
+        f"hint: set SHAPER_BPS to the {result['forwarding_class']} class cap "
+        f"({result['cap_bps']}) or pick an ELEPHANT_PORT whose class cap is "
+        f">= {result['floor_bps']} bps",
+        file=sys.stderr,
+    )
+    return 1
+
+
 def cmd_parse_cluster_state(args: argparse.Namespace) -> int:
     """Read cluster-status text from stdin, emit one line per triple."""
     text = sys.stdin.read()
@@ -410,6 +676,16 @@ def main() -> int:
         help="Skip this many leading [SUM] rows (settle warmup) before scanning.",
     )
     p2.set_defaults(func=cmd_check_collapse)
+
+    p_env = sub.add_parser("check-env-consistency")
+    p_env.add_argument("elephant_port", type=int)
+    p_env.add_argument("shaper_bps", type=int)
+    p_env.add_argument(
+        "--set-file",
+        help="Path to the CoS fixture (default: cos-iperf-config.set "
+        "next to this script).",
+    )
+    p_env.set_defaults(func=cmd_check_env_consistency)
 
     p3 = sub.add_parser("parse-cluster-state")
     p3.add_argument("ts_ms")

--- a/test/incus/mouse_latency_orchestrate_test.py
+++ b/test/incus/mouse_latency_orchestrate_test.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import pathlib
 import tempfile
@@ -317,6 +318,19 @@ class CoSFixtureParseTests(unittest.TestCase):
         # best-effort has no transmit-rate; ceiling is the 25g shaper.
         self.assertEqual(caps[5200]["cap_bps"], 25_000_000_000)
 
+    def test_classified_but_unscheduled_class_raises(self):
+        # A port classified into a forwarding-class that has no
+        # scheduler-map entry must NOT silently fall through to the
+        # interface-shaper cap (which would mask fixture drift/misparse).
+        broken = (
+            "set class-of-service forwarding-classes queue 2 cls-1g\n"
+            "set class-of-service interfaces reth0 unit 80 shaping-rate 25g\n"
+            "set firewall family inet filter f term 2 from destination-port 5202\n"
+            "set firewall family inet filter f term 2 then forwarding-class cls-1g\n"
+        )
+        with self.assertRaises(orch.CoSFixtureError):
+            orch.parse_cos_class_caps(broken)
+
     def test_real_fixture_grid_matches_canonical_rates(self):
         # Drift guard: the table parsed from the live fixture must agree
         # with the canonical port -> exact-class-rate map. If the fixture
@@ -378,29 +392,50 @@ class SettleThresholdSatisfiableTests(unittest.TestCase):
         )
         self.assertTrue(r["satisfiable"])
 
+    @staticmethod
+    def _largest_satisfiable_shaper(cap_bps: int, min_utilization: float) -> int:
+        # The largest SHAPER_BPS whose ceil(min_utilization * SHAPER_BPS)
+        # is still <= cap_bps — i.e. the TRUE settle-floor boundary under
+        # the guard's ceil semantics. Derived with the same float
+        # arithmetic the guard uses (math.ceil) so the boundary is exact
+        # on this platform rather than a hand-picked constant.
+        lo, hi = cap_bps, cap_bps * 2
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if math.ceil(min_utilization * mid) <= cap_bps:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo
+
     def test_boundary_floor_equals_cap_is_satisfiable(self):
-        # Floor exactly at the cap must PASS (<=, not <). For the 1g
-        # class, cap 1G == floor when SHAPER_BPS = 1G / 0.7.
-        shaper = 1_000_000_000 // 7 * 10  # floor rounds to <= 1G
+        # True boundary: the largest SHAPER_BPS whose ceil-floor lands
+        # EXACTLY on the 1G cap. floor == cap must PASS (<=, not <).
+        cap = 1_000_000_000
+        shaper = self._largest_satisfiable_shaper(cap, 0.7)
         r = orch.check_settle_threshold_satisfiable(
             5202, shaper, set_text=_COS_SET,
         )
-        self.assertLessEqual(r["floor_bps"], r["cap_bps"])
+        self.assertEqual(r["cap_bps"], cap)
+        self.assertEqual(r["floor_bps"], cap)  # exactly on the boundary
         self.assertTrue(r["satisfiable"])
 
-    def test_just_over_cap_is_unsatisfiable(self):
-        # One bps of shaper above the boundary flips it unsatisfiable,
-        # proving the guard is not a no-op rubber stamp.
-        shaper_ok = 1_000_000_000 // 7 * 10
+    def test_one_bps_over_boundary_is_unsatisfiable(self):
+        # One bps of SHAPER_BPS above the true boundary must flip the
+        # verdict to unsatisfiable, proving the guard is not a no-op
+        # rubber stamp and that the boundary is sharp to a single bps.
+        cap = 1_000_000_000
+        shaper_ok = self._largest_satisfiable_shaper(cap, 0.7)
         r_ok = orch.check_settle_threshold_satisfiable(
             5202, shaper_ok, set_text=_COS_SET,
         )
+        self.assertEqual(r_ok["floor_bps"], cap)
         self.assertTrue(r_ok["satisfiable"])
-        # Bump shaper so floor crosses 1G.
-        shaper_bad = (1_000_000_000 // 7 * 10) + 100_000_000
+        # Exactly +1 bps of shaper pushes the ceil-floor to cap + 1.
         r_bad = orch.check_settle_threshold_satisfiable(
-            5202, shaper_bad, set_text=_COS_SET,
+            5202, shaper_ok + 1, set_text=_COS_SET,
         )
+        self.assertEqual(r_bad["floor_bps"], cap + 1)
         self.assertGreater(r_bad["floor_bps"], r_bad["cap_bps"])
         self.assertFalse(r_bad["satisfiable"])
 

--- a/test/incus/mouse_latency_orchestrate_test.py
+++ b/test/incus/mouse_latency_orchestrate_test.py
@@ -1,9 +1,37 @@
 import json
 import os
+import pathlib
 import tempfile
 import unittest
 
 import mouse_latency_orchestrate as orch
+
+_ROOT = pathlib.Path(__file__).resolve().parent
+_COS_SET = (_ROOT / "cos-iperf-config.set").read_text()
+
+# A minimal synthetic fixture used to exercise the parser/guard in
+# isolation from the real fixture's port grid. Two exact classes plus a
+# non-exact best-effort class bounded by the interface shaping-rate.
+_SYNTH_SET = """\
+set class-of-service forwarding-classes queue 0 best-effort
+set class-of-service forwarding-classes queue 2 cls-1g
+set class-of-service forwarding-classes queue 5 cls-9g
+set class-of-service schedulers sched-be priority low
+set class-of-service schedulers sched-1g transmit-rate 1.0g
+set class-of-service schedulers sched-1g transmit-rate exact
+set class-of-service schedulers sched-9g transmit-rate 9.0g
+set class-of-service schedulers sched-9g transmit-rate exact
+set class-of-service scheduler-maps m forwarding-class best-effort scheduler sched-be
+set class-of-service scheduler-maps m forwarding-class cls-1g scheduler sched-1g
+set class-of-service scheduler-maps m forwarding-class cls-9g scheduler sched-9g
+set class-of-service interfaces reth0 unit 80 shaping-rate 25g
+set firewall family inet filter f term 0 from destination-port 5200
+set firewall family inet filter f term 0 then forwarding-class best-effort
+set firewall family inet filter f term 2 from destination-port 5202
+set firewall family inet filter f term 2 then forwarding-class cls-1g
+set firewall family inet filter f term 5 from destination-port 5205
+set firewall family inet filter f term 5 then forwarding-class cls-9g
+"""
 
 # Fixture rows use 120 KBytes and 180 KBytes in iperf3 output.
 _EXPECTED_MIN_CWND_KBYTES = 120
@@ -272,6 +300,157 @@ class RGStateFlappedTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as t:
             poll = _write(t, "rg.txt", "")
             self.assertEqual(orch.cmd_rg_state_flapped(self._make_args(poll)), 2)
+
+
+class CoSFixtureParseTests(unittest.TestCase):
+    def test_parses_exact_class_cap_from_scheduler_rate(self):
+        caps = orch.parse_cos_class_caps(_SYNTH_SET)
+        self.assertEqual(caps[5202]["forwarding_class"], "cls-1g")
+        self.assertEqual(caps[5202]["scheduler"], "sched-1g")
+        self.assertTrue(caps[5202]["exact"])
+        self.assertEqual(caps[5202]["cap_bps"], 1_000_000_000)
+        self.assertEqual(caps[5205]["cap_bps"], 9_000_000_000)
+
+    def test_non_exact_class_capped_at_interface_shaping_rate(self):
+        caps = orch.parse_cos_class_caps(_SYNTH_SET)
+        self.assertFalse(caps[5200]["exact"])
+        # best-effort has no transmit-rate; ceiling is the 25g shaper.
+        self.assertEqual(caps[5200]["cap_bps"], 25_000_000_000)
+
+    def test_real_fixture_grid_matches_canonical_rates(self):
+        # Drift guard: the table parsed from the live fixture must agree
+        # with the canonical port -> exact-class-rate map. If the fixture
+        # port grid changes, this test fails loudly rather than letting
+        # the guard silently compare against a stale cap.
+        caps = orch.parse_cos_class_caps(_COS_SET)
+        expected = {
+            5201: (100_000_000, True),
+            5202: (1_000_000_000, True),
+            5203: (3_000_000_000, True),
+            5204: (6_000_000_000, True),
+            5205: (9_000_000_000, True),
+            5206: (12_000_000_000, True),
+            5207: (15_000_000_000, True),
+            5208: (18_000_000_000, True),
+            5209: (21_000_000_000, True),
+            5210: (24_000_000_000, True),
+        }
+        for port, (rate, exact) in expected.items():
+            with self.subTest(port=port):
+                self.assertIn(port, caps)
+                self.assertEqual(caps[port]["exact"], exact)
+                self.assertEqual(caps[port]["cap_bps"], rate)
+        # Echo ports 620x mirror the same classes as 520x.
+        self.assertEqual(caps[6202]["cap_bps"], 1_000_000_000)
+        # Non-exact classes (best-effort 5200, uncapped 5211) ride the
+        # 25g interface shaper, not a per-class transmit-rate.
+        self.assertFalse(caps[5200]["exact"])
+        self.assertFalse(caps[5211]["exact"])
+        self.assertEqual(caps[5200]["cap_bps"], 25_000_000_000)
+        self.assertEqual(caps[5211]["cap_bps"], 25_000_000_000)
+
+
+class SettleThresholdSatisfiableTests(unittest.TestCase):
+    def test_reported_1365_misconfig_is_unsatisfiable(self):
+        # The exact #1365 footgun: port 5202 (1 Gbps exact class) paired
+        # with SHAPER_BPS=10G. Floor = 0.7 * 10G = 7G > 1G cap.
+        r = orch.check_settle_threshold_satisfiable(
+            5202, 10_000_000_000, set_text=_COS_SET,
+        )
+        self.assertFalse(r["satisfiable"])
+        self.assertEqual(r["forwarding_class"], "iperf-1g")
+        self.assertEqual(r["cap_bps"], 1_000_000_000)
+        self.assertEqual(r["floor_bps"], 7_000_000_000)
+
+    def test_matched_1g_pairing_is_satisfiable(self):
+        # Same port, matched bps. Floor = 0.7 * 1G = 700M <= 1G cap.
+        r = orch.check_settle_threshold_satisfiable(
+            5202, 1_000_000_000, set_text=_COS_SET,
+        )
+        self.assertTrue(r["satisfiable"])
+        self.assertEqual(r["floor_bps"], 700_000_000)
+
+    def test_high_rate_class_with_matched_bps_is_satisfiable(self):
+        # Port 5205 = 9 Gbps exact class, matched SHAPER_BPS=9G.
+        # Floor = 6.3G <= 9G cap.
+        r = orch.check_settle_threshold_satisfiable(
+            5205, 9_000_000_000, set_text=_COS_SET,
+        )
+        self.assertTrue(r["satisfiable"])
+
+    def test_boundary_floor_equals_cap_is_satisfiable(self):
+        # Floor exactly at the cap must PASS (<=, not <). For the 1g
+        # class, cap 1G == floor when SHAPER_BPS = 1G / 0.7.
+        shaper = 1_000_000_000 // 7 * 10  # floor rounds to <= 1G
+        r = orch.check_settle_threshold_satisfiable(
+            5202, shaper, set_text=_COS_SET,
+        )
+        self.assertLessEqual(r["floor_bps"], r["cap_bps"])
+        self.assertTrue(r["satisfiable"])
+
+    def test_just_over_cap_is_unsatisfiable(self):
+        # One bps of shaper above the boundary flips it unsatisfiable,
+        # proving the guard is not a no-op rubber stamp.
+        shaper_ok = 1_000_000_000 // 7 * 10
+        r_ok = orch.check_settle_threshold_satisfiable(
+            5202, shaper_ok, set_text=_COS_SET,
+        )
+        self.assertTrue(r_ok["satisfiable"])
+        # Bump shaper so floor crosses 1G.
+        shaper_bad = (1_000_000_000 // 7 * 10) + 100_000_000
+        r_bad = orch.check_settle_threshold_satisfiable(
+            5202, shaper_bad, set_text=_COS_SET,
+        )
+        self.assertGreater(r_bad["floor_bps"], r_bad["cap_bps"])
+        self.assertFalse(r_bad["satisfiable"])
+
+    def test_unknown_port_raises(self):
+        with self.assertRaises(orch.CoSFixtureError):
+            orch.check_settle_threshold_satisfiable(
+                9999, 1_000_000_000, set_text=_COS_SET,
+            )
+
+
+class CheckEnvConsistencyCmdTests(unittest.TestCase):
+    def _args(self, port, shaper, set_file=None):
+        class A: pass
+        a = A()
+        a.elephant_port = port
+        a.shaper_bps = shaper
+        a.set_file = set_file
+        return a
+
+    def test_cmd_returns_0_for_satisfiable(self):
+        with tempfile.TemporaryDirectory() as t:
+            sf = _write(t, "cos.set", _COS_SET)
+            self.assertEqual(
+                orch.cmd_check_env_consistency(self._args(5202, 1_000_000_000, sf)),
+                0,
+            )
+
+    def test_cmd_returns_1_for_unsatisfiable(self):
+        with tempfile.TemporaryDirectory() as t:
+            sf = _write(t, "cos.set", _COS_SET)
+            self.assertEqual(
+                orch.cmd_check_env_consistency(self._args(5202, 10_000_000_000, sf)),
+                1,
+            )
+
+    def test_cmd_returns_2_for_unknown_port(self):
+        with tempfile.TemporaryDirectory() as t:
+            sf = _write(t, "cos.set", _COS_SET)
+            self.assertEqual(
+                orch.cmd_check_env_consistency(self._args(9999, 1_000_000_000, sf)),
+                2,
+            )
+
+    def test_cmd_default_set_file_uses_real_fixture(self):
+        # No --set-file: must resolve the real cos-iperf-config.set and
+        # agree with the default harness pairing (5202 / 1G).
+        self.assertEqual(
+            orch.cmd_check_env_consistency(self._args(5202, 1_000_000_000)),
+            0,
+        )
 
 
 if __name__ == "__main__":

--- a/test/incus/test-mouse-latency.sh
+++ b/test/incus/test-mouse-latency.sh
@@ -73,6 +73,18 @@ case "$MOUSE_PROBE_CONNECTION_MODE" in
 esac
 [[ "$MOUSE_PROBE_MIN_INTERVAL_MS" =~ ^[0-9]+([.][0-9]+)?$ ]] \
     || { echo "ABORT: MOUSE_PROBE_MIN_INTERVAL_MS='$MOUSE_PROBE_MIN_INTERVAL_MS' must be a non-negative number" >&2; exit 1; }
+# #1365 env-shape consistency guard: the cwnd-settle gate requires the
+# elephant aggregate to reach 0.7 * SHAPER_BPS, but the class implied by
+# ELEPHANT_PORT (per cos-iperf-config.set) can only ever deliver up to
+# its configured cap. If the floor exceeds that cap the gate is
+# arithmetically unsatisfiable — every loaded rep INVALIDates before the
+# mouse probe ever starts (the reported #1365 symptom: port 5202 = 1 Gbps
+# exact class paired with SHAPER_BPS=10G). Fail fast with an actionable
+# message instead of burning a whole matrix cell on an impossible pairing.
+# (Static check; runs offline, no cluster contact.)
+python3 "${SCRIPT_DIR}/mouse_latency_orchestrate.py" check-env-consistency \
+    "$ELEPHANT_PORT" "$SHAPER_BPS" \
+    || { echo "ABORT: ELEPHANT_PORT=$ELEPHANT_PORT / SHAPER_BPS=$SHAPER_BPS is an unsatisfiable cwnd-settle pairing (see above)" >&2; exit 1; }
 SLACK=10
 CWND_SETTLE_OK="unknown"
 CWND_SETTLE_ELAPSED=0

--- a/test/incus/test_mouse_latency_shell_test.py
+++ b/test/incus/test_mouse_latency_shell_test.py
@@ -54,6 +54,21 @@ class MouseLatencyShellTests(unittest.TestCase):
         self.assertIn('"status": "INVALID"', SCRIPT)
         self.assertIn('write_invalid_manifest "$reason"', SCRIPT)
 
+    def test_env_consistency_guard_runs_before_rep(self):
+        # #1365: the harness must reject an ELEPHANT_PORT/SHAPER_BPS
+        # pairing whose cwnd-settle floor exceeds the class cap, before
+        # spending a whole matrix cell on an impossible pairing.
+        self.assertIn(
+            'check-env-consistency \\\n    "$ELEPHANT_PORT" "$SHAPER_BPS"',
+            SCRIPT,
+        )
+        self.assertIn("unsatisfiable cwnd-settle pairing", SCRIPT)
+        # Must fire before the rep does any cluster work (mkdir OUT_DIR is
+        # the first post-validation step).
+        guard_idx = SCRIPT.index("check-env-consistency")
+        mkdir_idx = SCRIPT.index('mkdir -p "$OUT_DIR"')
+        self.assertLess(guard_idx, mkdir_idx)
+
     def test_runtime_cos_and_settle_cpu_artifacts_are_cleared_and_captured(self):
         for artifact in (
             '"/cwnd-settle.json \\',


### PR DESCRIPTION
## What

Offline increment for #1365. The mouse-latency cwnd-settle gate requires
the elephant aggregate to reach `0.7 * SHAPER_BPS`, but the forwarding
class implied by `ELEPHANT_PORT` (per `cos-iperf-config.set`) can only
ever deliver up to its configured cap — the scheduler `transmit-rate` for
`exact` classes, or the interface `shaping-rate` for the non-exact
best-effort / uncapped classes. When the settle floor exceeds that cap
the gate is **arithmetically unsatisfiable**: every loaded rep
INVALIDates with `cwnd-not-settled` before the mouse probe ever starts,
regardless of dataplane or scheduler health.

That is the #1365 footgun — the canonical 100E100M matrix was run with
`ELEPHANT_PORT=5202` (the 1 Gbps `iperf-1g` exact class) paired with
`SHAPER_BPS=10000000000`, so the 7 Gbps floor could never be met against
a 1 Gbps cap and the cell reported `INSUFFICIENT-DATA`. The header
comment ("SHAPER_BPS MUST move with ELEPHANT_PORT") stated the rule the
run violated, but nothing enforced it.

## How

- `parse_cos_class_caps()` derives the port → class cap table **directly
  from `cos-iperf-config.set`**, so the guard is a single source of truth
  that cannot drift from the applied fixture.
- `check_settle_threshold_satisfiable()` computes the `0.7 * SHAPER_BPS`
  floor and compares it against the class cap.
- A `check-env-consistency` CLI subcommand wraps both;
  `test-mouse-latency.sh` runs it before each rep and `ABORT`s with an
  actionable message (class, cap, floor, and a hint to match `SHAPER_BPS`
  or pick a higher-rate port) instead of burning a whole matrix cell on
  an impossible pairing. The guard is purely static — no cluster contact.

## Scope

The live high-rate fairness/throughput measurement on the loss cluster
(acceptance items 2/3/4 of #1365) remains lab-gated and is **out of
scope** for this offline increment.

## Validation

Non-tautological unit tests in `mouse_latency_orchestrate_test.py`:

- the #1365 `5202`/`10G` pairing **FAILS** the guard
- matched `5202`/`1G` and high-rate `5205`/`9G` pairings **PASS**
- the floor==cap boundary **PASSES**; one bps over the boundary **flips
  it to FAIL** (proves the guard is not a no-op)
- a drift guard cross-checks the parsed table against the canonical
  port→rate map
- a shell-line assertion confirms the guard runs before any cluster work

All touched python suites pass. The three unrelated pre-existing failures
(`fairness_multi_sample`, `step1`/`step3` perf classifiers) are untouched
by this change. The guard is documented in `docs/fairness-regimes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)