### PR TITLE
ipsec: fix nil-deref in effectiveTrafficSelectors vpn==nil branch

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,24 @@
 # Action Log
 
+## 2026-06-19 — #2022 ipsec effectiveTrafficSelectors nil-deref guard
+
+- **Timestamp**: 2026-06-19
+- **Action**: Fix the latent nil-pointer dereference in
+  `effectiveTrafficSelectors` (`pkg/ipsec/policy.go`). The defensive
+  `vpn == nil` guard short-circuited into a branch that immediately read
+  `vpn.LocalID`/`vpn.RemoteID`, panicking whenever the nil branch was
+  reached. Split the cases: `vpn == nil` now returns `nil` (no children);
+  the non-nil zero-traffic-selector case keeps the single default child
+  built from `LocalID`/`RemoteID`. Behavior-preserving for every reachable
+  path (the sole caller iterates non-nil config VPN map values). Added
+  `TestEffectiveTrafficSelectors_NilVPN` (recover-on-panic → fails, not
+  crashes, against pre-fix code) and `TestEffectiveTrafficSelectors_NoSelectors`
+  (default-child fallback not regressed). Verified the nil test FAILS on the
+  pre-fix file before applying the fix. No doc change: defensive-only fix to
+  an unexported helper with no reachable behavior change; README covers
+  traffic selectors only at the feature level.
+- **File(s)**: pkg/ipsec/policy.go, pkg/ipsec/ipsec_test.go, _Log.md
+
 ## 2026-06-19 — #1387 DDNS PR #2043: Copilot findings (dual-family merge, version, comments)
 
 - **Timestamp**: 2026-06-19

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -876,6 +876,38 @@ func TestGenerateConfig_TrafficSelectors(t *testing.T) {
 	}
 }
 
+// TestEffectiveTrafficSelectors_NilVPN guards the #2022 nil-deref: the
+// vpn==nil branch previously dereferenced vpn.LocalID/vpn.RemoteID and
+// panicked. A nil VPN must yield no children, not a panic. Run with
+// t.Fatalf-on-panic so the test fails (not crashes) against pre-fix code.
+func TestEffectiveTrafficSelectors_NilVPN(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("effectiveTrafficSelectors(nil) panicked: %v", r)
+		}
+	}()
+	got := effectiveTrafficSelectors("tun", nil)
+	if len(got) != 0 {
+		t.Fatalf("nil VPN: want no children, got %d: %+v", len(got), got)
+	}
+}
+
+// TestEffectiveTrafficSelectors_NoSelectors confirms the non-nil VPN with
+// zero traffic selectors still falls back to a single default child built
+// from LocalID/RemoteID — the behavior the broken nil-OR-empty guard used
+// to share. The #2022 fix must not regress this path.
+func TestEffectiveTrafficSelectors_NoSelectors(t *testing.T) {
+	vpn := &config.IPsecVPN{LocalID: "10.0.1.0/24", RemoteID: "10.10.1.0/24"}
+	got := effectiveTrafficSelectors("tun", vpn)
+	if len(got) != 1 {
+		t.Fatalf("want 1 default child, got %d: %+v", len(got), got)
+	}
+	c := got[0]
+	if c.Name != "tun" || c.LocalTS != "10.0.1.0/24" || c.RemoteTS != "10.10.1.0/24" {
+		t.Fatalf("unexpected default child: %+v", c)
+	}
+}
+
 func TestPrepareConfig_ExternalInterfaceLocalAddress(t *testing.T) {
 	cfg := &config.Config{
 		Interfaces: config.InterfacesConfig{

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -207,7 +207,14 @@ func sortedVPNNames(vpns map[string]*config.IPsecVPN) []string {
 }
 
 func effectiveTrafficSelectors(connName string, vpn *config.IPsecVPN) []childSelector {
-	if vpn == nil || len(vpn.TrafficSelectors) == 0 {
+	// A nil VPN has no traffic selectors and no LocalID/RemoteID to fall
+	// back to — return no children rather than dereferencing vpn. The
+	// sole caller iterates non-nil config VPN map values, so this guard
+	// is defensive, but the previous nil branch panicked on vpn.LocalID.
+	if vpn == nil {
+		return nil
+	}
+	if len(vpn.TrafficSelectors) == 0 {
 		return []childSelector{{
 			Name:     connName,
 			LocalTS:  vpn.LocalID,


### PR DESCRIPTION
## Summary

Fixes #2022. `effectiveTrafficSelectors` (`pkg/ipsec/policy.go`) had a
defensive `if vpn == nil || len(vpn.TrafficSelectors) == 0` guard that
short-circuited into a branch which immediately dereferenced
`vpn.LocalID`/`vpn.RemoteID` — so reaching the `vpn == nil` case would
panic with a nil-pointer dereference instead of failing safe.

This is a latent defect surfaced by Copilot during the #1989 pure-motion
refactor (the code was moved `ipsec.go` -> `policy.go` unchanged; #1989
did not introduce it). The sole caller iterates non-nil config VPN map
values, so the nil branch is unreachable today, but the guard is still a
real correctness defect.

## Fix

Split the two cases:
- `vpn == nil` -> return `nil` (no children; there is no
  `LocalID`/`RemoteID` to fall back to).
- non-nil VPN with zero traffic selectors -> unchanged: emit one default
  child built from `LocalID`/`RemoteID`.

Reachable behavior is unchanged.

## Tests

- `TestEffectiveTrafficSelectors_NilVPN` — recovers from a panic and
  reports it as a failure, so it **fails (not crashes)** against the
  pre-fix code. Verified: the test panics/fails on the pre-fix
  `policy.go`, passes with the fix (non-tautological).
- `TestEffectiveTrafficSelectors_NoSelectors` — pins the non-nil
  empty-selector default-child fallback so the split does not regress it.

## Validation (in worktree)

```
GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./pkg/ipsec/   # OK
go vet ./pkg/ipsec/                                              # OK
go test ./pkg/ipsec/ -count=1                                    # ok
```

## Docs

No doc change: defensive-only fix to an unexported helper with no
reachable behavior change; `pkg/ipsec/README.md` covers traffic
selectors only at the feature level. `_Log.md` updated per project
logging rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)