### PR TITLE
config: redact all secrets at JSON/YAML marshal time (#2053)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,41 @@
 # Action Log
 
+## 2026-06-19 — #2053 redact all config secrets at JSON/YAML marshal time
+
+- **Timestamp**: 2026-06-19
+- **Action**: Close the live plaintext-secret leak on `GET /api/v1/config`
+  (`pkg/api/config.go` `configHandler` JSON-encodes the full compiled
+  `*config.Config`). Introduced a type-enforced `config.Secret` named-string
+  type (`pkg/config/secret.go`) with value-receiver `MarshalJSON` /
+  `MarshalYAML` → `<redacted>` (empty → ""), `Reveal()` for the
+  render/reconcile cleartext path, redacting `String()`, and a fail-closed
+  `UnmarshalJSON` that refuses the sentinel. Converted 16 secret-bearing
+  config fields to `config.Secret` (IKE/IPsec PSK, OSPF/RIP/IS-IS-area/
+  IS-IS-iface/VRRP `AuthKey`, BGP `AuthPassword`, WireGuard privkey, root/
+  login crypt hashes, REST `Password` + `APIKeys` `[]Secret`, SNMPv3 auth/
+  priv passwords, TSIG secret). SNMP community string handled specially
+  (it is the secret AND the `Communities` map key): kept `SNMPCommunity.Name`
+  a plain string and added targeted `SNMPCommunity.MarshalJSON` (redacts the
+  Name field) + `SNMPConfig.MarshalJSON`/`MarshalYAML` (renders Communities
+  as a sorted slice so the secret never leaks as a JSON map key). Fixed all
+  compiler producers (`Secret(...)` wraps) and render/reconcile consumers
+  (`.Reveal()` in `pkg/ipsec`, `pkg/frr`, `pkg/snmp`, `pkg/vrrp`,
+  `pkg/dataplane/userspace`, `pkg/daemon`). `show configuration` / text
+  show paths unchanged (out of scope). Verified the leak-regression test
+  FAILS against simulated pre-fix marshalling (all 16 secrets dumped in
+  plaintext) and PASSES after the fix.
+- **File(s)**: pkg/config/secret.go (new), pkg/config/secret_test.go (new),
+  pkg/api/config_secret_redaction_test.go (new), pkg/config/types_security.go,
+  pkg/config/types_routing.go, pkg/config/types_interfaces.go,
+  pkg/config/types_system.go, pkg/config/compiler.go,
+  pkg/config/compiler_interfaces.go, pkg/config/compiler_ipsec.go,
+  pkg/config/compiler_protocols.go, pkg/config/compiler_system.go,
+  pkg/config/compiler_services.go, pkg/ipsec/policy.go,
+  pkg/frr/policy_render.go, pkg/snmp/v3.go, pkg/vrrp/vrrp.go,
+  pkg/dataplane/userspace/screens.go, pkg/dataplane/userspace/tunnels.go,
+  pkg/daemon/daemon_run.go, pkg/daemon/daemon_system.go,
+  docs/config-schema.md, _Log.md
+
 ## 2026-06-19 — #2022 ipsec effectiveTrafficSelectors nil-deref guard
 
 - **Timestamp**: 2026-06-19

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -347,14 +347,72 @@ reserved for whole-dataplane selection where a rewrite shim
   constrain `update-server` (host[:port]) lands in increment 2, and a
   hostname / base64 secret is not validatable by the existing IP/identifier
   validators without false-rejecting valid input. `tsig-secret` is
-  SENSITIVE: it is redacted in `DHCPDynamicDNSConfig.String()` and must
-  never be logged. Compile lives in `compileDHCPDynamicDNS`
+  SENSITIVE: it is redacted in `DHCPDynamicDNSConfig.String()` (logging) AND,
+  since #2053, by its `config.Secret` field type on every JSON/YAML marshal
+  (so the compiled-config dump on `GET /api/v1/config` never leaks it — see
+  "Config secret redaction" below). Compile lives in `compileDHCPDynamicDNS`
   (`compiler_services.go`), handling both the hierarchical and flat-set AST
   shapes (walk + first-value-wins, mirroring `collectDeviceMapProps`); an
   empty/garbage block returns nil (positional/disabled, closing the
   empty-tree-compiles-non-nil trap). Regression coverage:
   `pkg/config/compiler_dhcp_ddns_test.go` (dual-AST equality, absent-default,
   TSIG redaction, enum/ttl accept+reject).
+
+### #2053 — Config secret redaction at JSON/YAML marshal time
+
+The compiled `*config.Config` carries every operator secret verbatim in
+memory (it must — the reconciler/render paths need the cleartext). The
+hazard is that a *marshaller* of that struct leaks it. There was a live
+leak: `GET /api/v1/config` (`pkg/api/config.go` `configHandler` →
+`writeOK(w, store.ActiveConfig())`) JSON-encodes the whole compiled config,
+so before #2053 it returned every secret in plaintext to any authorized
+REST client (loopback by default, but bindable non-loopback over HTTPS via
+`web-management https interface`). The per-struct `String()` redaction
+(logging hygiene) did NOT close this — `encoding/json` ignores `Stringer`.
+
+The fix is type-enforced, not by-convention. **`config.Secret`**
+(`pkg/config/secret.go`) is a named `string` type whose value-receiver
+`MarshalJSON` / `MarshalYAML` emit the sentinel `config.SecretRedacted`
+(`<redacted>`) for a non-empty value and `""` for empty (so unset stays
+distinguishable). `Reveal()` returns the cleartext for render/reconcile
+sites; `String()` redacts for `%v`/`%s`/slog; `UnmarshalJSON` accepts a
+plain string but REFUSES the sentinel (fail-closed if a compiled-config
+JSON ingest is ever added — none exists today, the SSOT is the `*ConfigTree`
+AST). Because the receiver is a value, redaction fires for a `Secret` struct
+field, in a `[]Secret` slice (`APIKeys`), and as a map value.
+
+**Converted fields (16):** `IKEPolicy.PSK`, `IPsecVPN.PSK`
+(`types_security.go`); `OSPFInterface.AuthKey`, `RIPConfig.AuthKey`,
+`ISISConfig.AuthKey`, `ISISInterface.AuthKey`, `BGPNeighbor.AuthPassword`,
+`TunnelConfig.WgLocalPrivkeyHex` (`types_routing.go`); `VRRPGroup.AuthKey`
+(`types_interfaces.go`); `RootAuthConfig.EncryptedPassword`,
+`LoginUser.EncryptedPassword`, `APIAuthUser.Password`, `APIAuthConfig.APIKeys`
+(`[]Secret`), `SNMPv3User.AuthPassword`, `SNMPv3User.PrivPassword`,
+`DHCPDynamicDNSConfig.TSIGSecret` (`types_system.go`).
+
+**SNMP community string** is a special case: it is the secret AND the
+`SNMPConfig.Communities` map key, so `SNMPCommunity.Name` stays a plain
+`string` (map lookup in `pkg/snmp` is by the on-wire community string) and
+redaction is done with targeted marshallers — `SNMPCommunity.MarshalJSON`
+redacts the `Name` field, and `SNMPConfig.MarshalJSON` renders the
+`Communities` map as a sorted slice so the secret never leaks as a JSON
+object key. Text `show snmp` / `show configuration` print the map key, not
+the marshalled struct, and are deliberately OUT OF SCOPE (operators read
+their own secrets — Junos parity; `show configuration` redaction is a
+separate concern).
+
+**Borderline fields left as plain string** (rulings): `MasterPassword`
+(commit-encryption PRF selector, not a user secret), `ArchiveSitesWithPassword`
+(URLs whose inline password was already discarded), `SSHKeys` /
+`LoginUser.SSHKeys` (public keys). **Round-trip is safe** — nothing
+unmarshals a compiled `*config.Config` (persistence/HA-sync ship the AST
+tree, not the compiled struct), so a redacting marshaller cannot starve any
+consumer. **Adding a new secret config field is one annotation:** type it
+`config.Secret` and call `.Reveal()` at the render site (the compiler finds
+every reader). Do NOT feed `Reveal()` output into a log line. Regression
+coverage: `pkg/config/secret_test.go` (marshal/unmarshal/slice/map/SNMP) and
+`pkg/api/config_secret_redaction_test.go` (the live `GET /api/v1/config`
+leak net + in-memory-cleartext-preserved render guard).
 
 ### #1979 — flow / flow-export NUM_WIDTH commit-time validation (Layer B)
 

--- a/pkg/api/config_secret_redaction_test.go
+++ b/pkg/api/config_secret_redaction_test.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// secretSentinels is the set of distinctive cleartext secret values fed into
+// the candidate config below — one per secret-bearing config field (#2053).
+// The regression assertion is that NONE of these strings appears in the JSON
+// returned by GET /api/v1/config, while the redaction sentinel does. Each
+// value is unique so a single leaking field is identifiable.
+var secretSentinels = []string{
+	"LEAK-IKE-PSK",            // IKEPolicy.PSK
+	"LEAK-IPSEC-VPN-PSK",      // IPsecVPN.PSK (legacy vpn-level)
+	"LEAK-OSPF-AUTHKEY",       // OSPFInterface.AuthKey
+	"LEAK-RIP-AUTHKEY",        // RIPConfig.AuthKey
+	"LEAK-ISIS-AREA-AUTHKEY",  // ISISConfig.AuthKey
+	"LEAK-ISIS-IFACE-AUTHKEY", // ISISInterface.AuthKey
+	"LEAK-BGP-AUTHPW",         // BGPNeighbor.AuthPassword (group-level)
+	"LEAK-VRRP-AUTHKEY",       // VRRPGroup.AuthKey
+	"LEAK-API-USER-PW",        // APIAuthUser.Password
+	"LEAK-API-KEY-TOKEN",      // APIAuthConfig.APIKeys
+	"LEAK-SNMPV3-AUTHPW",      // SNMPv3User.AuthPassword
+	"LEAK-SNMPV3-PRIVPW",      // SNMPv3User.PrivPassword
+	"LEAK-SNMP-COMMUNITY",     // SNMPCommunity.Name (v1/v2c community string)
+}
+
+// crypt(3) hashes are validated by the commit gate, so the root/login
+// EncryptedPassword sentinels must be well-formed $6$ hashes. They are
+// still secrets that must not leak.
+const (
+	rootCryptSentinel  = "$6$LEAKsalt$rootHASHrootHASHrootHASHrootHASHrootHASHrootHASHrootHASHrootHASHro0"
+	loginCryptSentinel = "$6$LEAKsalt$loginHASHloginHASHloginHASHloginHASHloginHASHloginHASHloginHASHl1"
+	tsigSecretSentinel = "LEAKTSIGc2VjcmV0"                                                 // RFC2136 TSIG HMAC key (base64-ish)
+	wgPrivkeySentinel  = "a01010101010101010101010101010101010101010101010101010101010101a" // 64-hex X25519 privkey
+)
+
+// secretSetCommands stages every secret-bearing config leaf with a
+// distinctive cleartext sentinel so a single compile + GET /api/v1/config
+// round-trip exercises the whole redaction surface.
+var secretSetCommands = []string{
+	// IKE pre-shared key (policy-level).
+	"set security ike proposal ike-p1 authentication-method pre-shared-keys",
+	"set security ike proposal ike-p1 encryption-algorithm aes-256-cbc",
+	"set security ike proposal ike-p1 dh-group group14",
+	"set security ike policy pol1 mode main",
+	"set security ike policy pol1 proposals ike-p1",
+	"set security ike policy pol1 pre-shared-key ascii-text LEAK-IKE-PSK",
+	"set security ike gateway gw1 address 10.0.0.1",
+	"set security ike gateway gw1 ike-policy pol1",
+	"set security ike gateway gw1 external-interface ge-0-0-0",
+	// IPsec VPN with a legacy vpn-level PSK.
+	"set security ipsec proposal aes256 protocol esp",
+	"set security ipsec proposal aes256 encryption-algorithm aes-256-cbc",
+	"set security ipsec proposal aes256 authentication-algorithm hmac-sha-256",
+	"set security ipsec proposal aes256 dh-group 14",
+	"set security ipsec vpn site-a gateway 10.0.0.1",
+	"set security ipsec vpn site-a ipsec-policy aes256",
+	"set security ipsec vpn site-a pre-shared-key LEAK-IPSEC-VPN-PSK",
+	// OSPF interface auth key.
+	"set protocols ospf area 0.0.0.0 interface ge-0-0-1 authentication md5 1 key LEAK-OSPF-AUTHKEY",
+	// RIP auth key.
+	"set protocols rip neighbor ge-0-0-1",
+	"set protocols rip authentication-type md5",
+	"set protocols rip authentication-key LEAK-RIP-AUTHKEY",
+	// IS-IS area + per-interface auth keys.
+	"set protocols isis net 49.0001.0100.0000.0001.00",
+	"set protocols isis authentication-type md5",
+	"set protocols isis authentication-key LEAK-ISIS-AREA-AUTHKEY",
+	"set protocols isis interface ge-0-0-2 authentication-type md5",
+	"set protocols isis interface ge-0-0-2 authentication-key LEAK-ISIS-IFACE-AUTHKEY",
+	// BGP TCP-MD5 password (group-level).
+	"set protocols bgp local-as 65001",
+	"set protocols bgp group external peer-as 65002",
+	"set protocols bgp group external authentication-key LEAK-BGP-AUTHPW",
+	"set protocols bgp group external neighbor 10.0.2.1",
+	// VRRP auth key.
+	"set interfaces ge-0-0-3 unit 0 family inet address 10.0.3.1/24 vrrp-group 1 virtual-address 10.0.3.254/24",
+	"set interfaces ge-0-0-3 unit 0 family inet address 10.0.3.1/24 vrrp-group 1 authentication-type md5",
+	"set interfaces ge-0-0-3 unit 0 family inet address 10.0.3.1/24 vrrp-group 1 authentication-key LEAK-VRRP-AUTHKEY",
+	// REST API basic-auth password + API key.
+	"set system services web-management http",
+	"set system services web-management api-auth user admin password LEAK-API-USER-PW",
+	"set system services web-management api-auth api-key LEAK-API-KEY-TOKEN",
+	// SNMPv3 auth + priv passwords, and a v1/v2c community string (the secret).
+	"set snmp v3 usm local-engine user admin authentication-sha256 authentication-password LEAK-SNMPV3-AUTHPW",
+	"set snmp v3 usm local-engine user admin privacy-des privacy-password LEAK-SNMPV3-PRIVPW",
+	"set snmp community LEAK-SNMP-COMMUNITY authorization read-only",
+	// TSIG HMAC key.
+	"set system services dhcp-local-server dynamic-dns enable",
+	"set system services dhcp-local-server dynamic-dns domain corp.example.com",
+	"set system services dhcp-local-server dynamic-dns tsig-secret " + tsigSecretSentinel,
+	// WireGuard private key.
+	"set interfaces wg0 tunnel wireguard private-key " + wgPrivkeySentinel,
+	"set interfaces wg0 tunnel wireguard listen-port 51820",
+	// root + login crypt(3) hashes.
+	`set system root-authentication encrypted-password "` + rootCryptSentinel + `"`,
+	"set system login user op class read-only",
+	`set system login user op authentication encrypted-password "` + loginCryptSentinel + `"`,
+}
+
+// stageSecretConfig builds a Server whose active config has every secret
+// field populated with a distinctive sentinel, via the real LoadSet +
+// Commit compile path. Returns the server plus the compiled config so a
+// test can confirm the cleartext survived into memory (Reveal path) before
+// asserting the JSON surface redacts it.
+func stageSecretConfig(t *testing.T) (*Server, *config.Config) {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(secretSetCommands, "\n")); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	cfg, err := store.Commit()
+	if err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("Commit() returned nil config")
+	}
+	return &Server{store: store}, cfg
+}
+
+// TestConfigHandlerRedactsSecrets is the #2053 leak-regression net. It
+// drives the live GET /api/v1/config route (configHandler -> ActiveConfig
+// -> writeOK -> json.Encode of the compiled *config.Config) and asserts
+// that no cleartext secret appears in the response while the redaction
+// sentinel does. This FAILS against pre-#2053 code, where the secret fields
+// were plain strings and marshalled verbatim.
+func TestConfigHandlerRedactsSecrets(t *testing.T) {
+	s, _ := stageSecretConfig(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/config", nil)
+	s.configHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+
+	for _, leak := range secretSentinels {
+		if strings.Contains(body, leak) {
+			t.Errorf("GET /api/v1/config leaked plaintext secret %q in response body", leak)
+		}
+	}
+	for _, leak := range []string{rootCryptSentinel, loginCryptSentinel, tsigSecretSentinel, wgPrivkeySentinel} {
+		if strings.Contains(body, leak) {
+			t.Errorf("GET /api/v1/config leaked plaintext secret %q in response body", leak)
+		}
+	}
+	// writeOK uses json.NewEncoder which HTML-escapes the sentinel's
+	// "<"/">"; match the encoded form so the positive check tracks the
+	// real response bytes.
+	rb, _ := json.Marshal(config.SecretRedacted)
+	if !strings.Contains(body, strings.Trim(string(rb), `"`)) {
+		t.Errorf("response did not contain redaction sentinel %q; redaction not applied?\nbody: %s",
+			config.SecretRedacted, body)
+	}
+}
+
+// TestConfigHandlerPreservesCleartextInMemory proves the redaction is a
+// marshal-time concern only: the compiled config still carries the real
+// secrets for the reconciler/render paths (Reveal). This guards against an
+// over-eager fix that blanks the value in memory and silently breaks
+// IPsec/FRR/SNMP/etc. rendering.
+func TestConfigHandlerPreservesCleartextInMemory(t *testing.T) {
+	_, cfg := stageSecretConfig(t)
+
+	if got := cfg.Security.IPsec.IKEPolicies["pol1"].PSK.Reveal(); got != "LEAK-IKE-PSK" {
+		t.Errorf("in-memory IKE PSK = %q, want cleartext LEAK-IKE-PSK (render path broken)", got)
+	}
+	if cfg.System.SNMP == nil || cfg.System.SNMP.V3Users["admin"] == nil {
+		t.Fatal("SNMPv3 user not compiled")
+	}
+	if got := cfg.System.SNMP.V3Users["admin"].AuthPassword.Reveal(); got != "LEAK-SNMPV3-AUTHPW" {
+		t.Errorf("in-memory SNMPv3 auth-password = %q, want cleartext (render path broken)", got)
+	}
+	if cfg.System.RootAuthentication == nil ||
+		cfg.System.RootAuthentication.EncryptedPassword.Reveal() != rootCryptSentinel {
+		t.Errorf("in-memory root encrypted-password not preserved cleartext (chpasswd path broken)")
+	}
+	if cfg.System.Login == nil || len(cfg.System.Login.Users) == 0 {
+		t.Fatal("login user not compiled (the leak-test sentinel would never be set)")
+	}
+	if got := cfg.System.Login.Users[0].EncryptedPassword.Reveal(); got != loginCryptSentinel {
+		t.Errorf("in-memory login encrypted-password = %q, want cleartext sentinel "+
+			"(secret never set -> leak test would falsely pass)", got)
+	}
+}
+
+// TestConfigHandlerJSONStaysValid confirms the redacted response is still
+// well-formed JSON (a Marshaler that returns malformed bytes would corrupt
+// the whole envelope, not just the secret).
+func TestConfigHandlerJSONStaysValid(t *testing.T) {
+	s, _ := stageSecretConfig(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/config", nil)
+	s.configHandler(rr, req)
+
+	var envelope map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("response is not valid JSON after redaction: %v\nbody: %s", err, rr.Body.String())
+	}
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -927,7 +927,7 @@ func ValidateConfig(cfg *Config) []string {
 			// (any value beginning with "!", e.g. "!$6$salt$hash"). A
 			// leading "!" means the account cannot password-login until it
 			// is unlocked, so it does not count (Codex #1944 r1 Low).
-			pw := u.EncryptedPassword
+			pw := u.EncryptedPassword.Reveal()
 			usablePassword := pw != "" && pw != "*" && !strings.HasPrefix(pw, "!")
 			if len(u.SSHKeys) == 0 && !usablePassword {
 				warnings = append(warnings, fmt.Sprintf(

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -395,7 +395,7 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 									case "authentication-key":
 										if i+1 < len(keys) {
 											i++
-											vg.AuthKey = keys[i]
+											vg.AuthKey = Secret(keys[i])
 										}
 									case "track-interface":
 										if i+1 < len(keys) {
@@ -467,7 +467,7 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 									case "authentication-type":
 										vg.AuthType = nodeVal(prop)
 									case "authentication-key":
-										vg.AuthKey = nodeVal(prop)
+										vg.AuthKey = Secret(nodeVal(prop))
 									case "track-interface":
 										// The interface name lives in Keys[1]
 										// (NOT nodeVal — its Children[0]
@@ -692,7 +692,7 @@ func parseTunnelWireguard(tc *TunnelConfig, wgNode *Node) {
 			}
 		case "private-key":
 			if v := nodeVal(prop); v != "" {
-				tc.WgLocalPrivkeyHex = v
+				tc.WgLocalPrivkeyHex = Secret(v)
 			}
 		case "peer":
 			parseTunnelWireguardPeer(tc, prop)

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -56,11 +56,11 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 			case "pre-shared-key":
 				// "pre-shared-key ascii-text VALUE" or children
 				if len(p.Keys) >= 3 {
-					pol.PSK = p.Keys[2]
+					pol.PSK = Secret(p.Keys[2])
 				} else {
 					for _, c := range p.Children {
 						if c.Name() == "ascii-text" {
-							pol.PSK = nodeVal(c)
+							pol.PSK = Secret(nodeVal(c))
 						}
 					}
 				}
@@ -355,7 +355,7 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 			case "remote-identity":
 				vpn.RemoteID = v
 			case "pre-shared-key":
-				vpn.PSK = v
+				vpn.PSK = Secret(v)
 			case "local-address":
 				vpn.LocalAddr = v
 			}

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -105,12 +105,12 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 								}
 								for _, kc := range authChild.Children {
 									if kc.Name() == "key" {
-										iface.AuthKey = nodeVal(kc)
+										iface.AuthKey = Secret(nodeVal(kc))
 									}
 								}
 							case "simple-password":
 								iface.AuthType = "simple"
-								iface.AuthKey = nodeVal(authChild)
+								iface.AuthKey = Secret(nodeVal(authChild))
 							}
 						}
 					case "bfd-liveness-detection":
@@ -346,7 +346,7 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 							FamilyInet:       familyInet,
 							FamilyInet6:      familyInet6,
 							GroupName:        groupInst.name,
-							AuthPassword:     groupAuthKey,
+							AuthPassword:     Secret(groupAuthKey),
 							BFD:              groupBFD,
 							BFDInterval:      groupBFDInterval,
 							BFDMultiplier:    groupBFDMultiplier,
@@ -374,7 +374,7 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 									}
 								}
 							case "authentication-key":
-								neighbor.AuthPassword = nodeVal(prop)
+								neighbor.AuthPassword = Secret(nodeVal(prop))
 							case "route-reflector-client":
 								neighbor.RouteReflectorClient = true
 							case "default-originate":
@@ -517,7 +517,7 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 				}
 			case "authentication-key":
 				if v := nodeVal(child); v != "" {
-					proto.RIP.AuthKey = v
+					proto.RIP.AuthKey = Secret(v)
 				}
 			case "authentication-type":
 				if v := nodeVal(child); v != "" {
@@ -550,7 +550,7 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 				}
 			case "authentication-key":
 				if v := nodeVal(child); v != "" {
-					proto.ISIS.AuthKey = v
+					proto.ISIS.AuthKey = Secret(v)
 				}
 			case "authentication-type":
 				if v := nodeVal(child); v != "" {
@@ -578,7 +578,7 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 								}
 							}
 						case "authentication-key":
-							iface.AuthKey = nodeVal(prop)
+							iface.AuthKey = Secret(nodeVal(prop))
 						case "authentication-type":
 							iface.AuthType = nodeVal(prop)
 						case "bfd-liveness-detection":

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -304,7 +304,7 @@ func compileDHCPDynamicDNS(node *Node) *DHCPDynamicDNSConfig {
 	d.UpdateServer = props["update-server"]
 	d.TSIGKeyName = props["tsig-key"]
 	d.TSIGAlgorithm = props["tsig-algorithm"]
-	d.TSIGSecret = props["tsig-secret"]
+	d.TSIGSecret = Secret(props["tsig-secret"])
 	if v := props["ttl"]; v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			d.TTLSeconds = n

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -96,7 +96,7 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 						for _, authChild := range prop.Children {
 							switch authChild.Name() {
 							case "encrypted-password":
-								user.EncryptedPassword = nodeVal(authChild)
+								user.EncryptedPassword = Secret(nodeVal(authChild))
 							case "ssh-ed25519", "ssh-rsa", "ssh-dsa":
 								if v := nodeVal(authChild); v != "" {
 									user.SSHKeys = append(user.SSHKeys, v)
@@ -135,7 +135,7 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 			for _, prop := range child.Children {
 				switch prop.Name() {
 				case "encrypted-password":
-					sys.RootAuthentication.EncryptedPassword = nodeVal(prop)
+					sys.RootAuthentication.EncryptedPassword = Secret(nodeVal(prop))
 				case "ssh-ed25519", "ssh-rsa", "ssh-dsa":
 					if v := nodeVal(prop); v != "" {
 						sys.RootAuthentication.SSHKeys = append(sys.RootAuthentication.SSHKeys, v)
@@ -360,12 +360,12 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 					if pwNode := inst.node.FindChild("password"); pwNode != nil {
 						auth.Users = append(auth.Users, &APIAuthUser{
 							Username: inst.name,
-							Password: nodeVal(pwNode),
+							Password: Secret(nodeVal(pwNode)),
 						})
 					}
 				}
 				for _, ch := range authNode.FindChildren("api-key") {
-					auth.APIKeys = append(auth.APIKeys, nodeVal(ch))
+					auth.APIKeys = append(auth.APIKeys, Secret(nodeVal(ch)))
 				}
 				sys.Services.WebManagement.APIAuth = auth
 			}
@@ -785,27 +785,27 @@ func compileSNMPv3(node *Node, snmp *SNMPConfig) {
 			case "authentication-md5":
 				user.AuthProtocol = "md5"
 				if pw := prop.FindChild("authentication-password"); pw != nil {
-					user.AuthPassword = nodeVal(pw)
+					user.AuthPassword = Secret(nodeVal(pw))
 				}
 			case "authentication-sha":
 				user.AuthProtocol = "sha"
 				if pw := prop.FindChild("authentication-password"); pw != nil {
-					user.AuthPassword = nodeVal(pw)
+					user.AuthPassword = Secret(nodeVal(pw))
 				}
 			case "authentication-sha256":
 				user.AuthProtocol = "sha256"
 				if pw := prop.FindChild("authentication-password"); pw != nil {
-					user.AuthPassword = nodeVal(pw)
+					user.AuthPassword = Secret(nodeVal(pw))
 				}
 			case "privacy-des":
 				user.PrivProtocol = "des"
 				if pw := prop.FindChild("privacy-password"); pw != nil {
-					user.PrivPassword = nodeVal(pw)
+					user.PrivPassword = Secret(nodeVal(pw))
 				}
 			case "privacy-aes128":
 				user.PrivProtocol = "aes128"
 				if pw := prop.FindChild("privacy-password"); pw != nil {
-					user.PrivPassword = nodeVal(pw)
+					user.PrivPassword = Secret(nodeVal(pw))
 				}
 			}
 		}
@@ -823,27 +823,27 @@ func parseSNMPv3UserKeys(keys []string, user *SNMPv3User) {
 	case "authentication-md5":
 		user.AuthProtocol = "md5"
 		if len(keys) >= 3 && keys[1] == "authentication-password" {
-			user.AuthPassword = keys[2]
+			user.AuthPassword = Secret(keys[2])
 		}
 	case "authentication-sha":
 		user.AuthProtocol = "sha"
 		if len(keys) >= 3 && keys[1] == "authentication-password" {
-			user.AuthPassword = keys[2]
+			user.AuthPassword = Secret(keys[2])
 		}
 	case "authentication-sha256":
 		user.AuthProtocol = "sha256"
 		if len(keys) >= 3 && keys[1] == "authentication-password" {
-			user.AuthPassword = keys[2]
+			user.AuthPassword = Secret(keys[2])
 		}
 	case "privacy-des":
 		user.PrivProtocol = "des"
 		if len(keys) >= 3 && keys[1] == "privacy-password" {
-			user.PrivPassword = keys[2]
+			user.PrivPassword = Secret(keys[2])
 		}
 	case "privacy-aes128":
 		user.PrivProtocol = "aes128"
 		if len(keys) >= 3 && keys[1] == "privacy-password" {
-			user.PrivPassword = keys[2]
+			user.PrivPassword = Secret(keys[2])
 		}
 	}
 }

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -56,10 +56,11 @@ func (s Secret) String() string {
 	return SecretRedacted
 }
 
-// Reveal returns the real cleartext value. This is the ONLY way to read the
-// secret; render/reconcile paths must call it explicitly. The name is
-// deliberately greppable so an audit can find every cleartext access — do
-// not feed the result into a log line.
+// Reveal returns the real cleartext value. It is the canonical, audited way
+// to read the secret; render/reconcile paths must call it explicitly. (A raw
+// string(s) conversion also yields the cleartext — Secret is a string newtype
+// — but Reveal is deliberately greppable so an audit can find every cleartext
+// access; prefer it, and never feed the result into a log line.)
 func (s Secret) Reveal() string { return string(s) }
 
 // MarshalJSON redacts the secret. An empty Secret marshals to "" so that

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// errRedactedSecretIngest is returned by Secret.UnmarshalJSON when the
+// redaction sentinel is decoded — see UnmarshalJSON.
+var errRedactedSecretIngest = errors.New(
+	"config: refusing to ingest redacted secret sentinel \"" + SecretRedacted + "\"")
+
+// Secret is a config string whose cleartext value is preserved in memory
+// for the reconciler/render paths but is REDACTED on any JSON/YAML marshal
+// so a compiled-config serializer can never leak it (#2053).
+//
+// Why this exists: the compiled *config.Config carries every operator
+// secret verbatim (IKE/IPsec pre-shared keys, OSPF/IS-IS/RIP/VRRP/interface
+// auth keys, the TSIG HMAC key, SNMPv3 auth/priv passwords, root/login
+// crypt(3) hashes, the BGP TCP-MD5 password, REST basic-auth passwords +
+// API keys, the WireGuard private key). A registered production REST route,
+// GET /api/v1/config (pkg/api/config.go), JSON-encodes that whole struct.
+// Before #2053 it returned every secret in plaintext to any authorized
+// client (loopback by default, but bindable non-loopback over HTTPS via
+// `web-management https interface`). The pre-existing String() redaction on
+// a couple of structs only covers %v/%s/slog — encoding/json ignores
+// Stringer, so it did NOT close the marshal leak. Making the field type
+// itself enforce redaction means the guarantee is type-enforced, not
+// per-comment: any present or future marshal of a struct that contains a
+// Secret field redacts automatically, and adding a new secret field is a
+// single type annotation.
+//
+// Round-trip is safe: nothing in the tree unmarshals a compiled
+// *config.Config back from JSON/YAML (the persistence/sync SSOT is the
+// *ConfigTree AST, db.go / sync_conn.go). A redacting marshaller therefore
+// cannot starve any consumer of a secret. Render/reconcile sites read the
+// cleartext via Reveal(). UnmarshalJSON below additionally refuses the
+// redaction sentinel so that if a compiled-config JSON ingest is ever added
+// it fails loudly instead of silently loading "<redacted>" as a key.
+//
+// Secret keeps the underlying string kind (it is a named string type, not a
+// struct) so it stays comparable — usable as a map key and directly
+// comparable to "" for present/absent checks at call sites.
+type Secret string
+
+// SecretRedacted is the sentinel emitted in place of a non-empty Secret on
+// JSON/YAML marshal.
+const SecretRedacted = "<redacted>"
+
+// String redacts a non-empty Secret for %v/%s/slog formatting (logging
+// hygiene). An empty Secret renders as "" so absence stays distinguishable.
+func (s Secret) String() string {
+	if s == "" {
+		return ""
+	}
+	return SecretRedacted
+}
+
+// Reveal returns the real cleartext value. This is the ONLY way to read the
+// secret; render/reconcile paths must call it explicitly. The name is
+// deliberately greppable so an audit can find every cleartext access — do
+// not feed the result into a log line.
+func (s Secret) Reveal() string { return string(s) }
+
+// MarshalJSON redacts the secret. An empty Secret marshals to "" so that
+// unset/empty stays distinguishable from a present-but-redacted value; a
+// non-empty Secret marshals to the redaction sentinel. A value receiver is
+// required so redaction fires for a Secret used as a struct field, inside a
+// []Secret slice, and as a map value.
+func (s Secret) MarshalJSON() ([]byte, error) {
+	if s == "" {
+		return []byte(`""`), nil
+	}
+	return json.Marshal(SecretRedacted)
+}
+
+// UnmarshalJSON accepts a plain string so the type is a drop-in if a tree
+// value is ever decoded into it, but REFUSES the redaction sentinel: a
+// round-trip through the redacting marshaller must never silently reload
+// "<redacted>" as a real secret. The compiled-config SSOT is the AST tree,
+// not JSON, so this path should not be reached today; it fails closed if
+// that ever changes.
+func (s *Secret) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	if v == SecretRedacted {
+		return errRedactedSecretIngest
+	}
+	*s = Secret(v)
+	return nil
+}
+
+// MarshalYAML mirrors MarshalJSON for the gopkg.in/yaml.v3 marshaller. No
+// config YAML marshaller exists today, but the issue title names YAML and
+// the method is detected by interface so this future-proofs the YAML
+// surface at no cost. A value receiver keeps redaction firing in slices and
+// map values.
+func (s Secret) MarshalYAML() (any, error) {
+	if s == "" {
+		return "", nil
+	}
+	return SecretRedacted, nil
+}

--- a/pkg/config/secret_test.go
+++ b/pkg/config/secret_test.go
@@ -1,0 +1,180 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestSecretMarshalJSON covers the core redaction contract: a non-empty
+// Secret marshals to the sentinel, an empty Secret marshals to "" (so
+// absence stays distinguishable), and the real value never appears.
+func TestSecretMarshalJSON(t *testing.T) {
+	// json.Marshal HTML-escapes the sentinel's "<"/">"; compare against the
+	// encoder's own rendering so the test tracks the real wire bytes.
+	redactedJSON, _ := json.Marshal(SecretRedacted)
+	tests := []struct {
+		name string
+		s    Secret
+		want string
+	}{
+		{"non-empty redacts", Secret("supersecret"), string(redactedJSON)},
+		{"empty stays empty", Secret(""), `""`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.s)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			if string(b) != tc.want {
+				t.Errorf("Marshal() = %s, want %s", b, tc.want)
+			}
+			if strings.Contains(string(b), "supersecret") {
+				t.Errorf("Marshal() leaked cleartext: %s", b)
+			}
+		})
+	}
+}
+
+// TestSecretMarshalYAML mirrors MarshalJSON. The YAML marshaller is
+// interface-detected, so we exercise the method directly (no yaml encoder
+// dependency in this test): non-empty -> sentinel, empty -> "".
+func TestSecretMarshalYAML(t *testing.T) {
+	got, err := Secret("supersecret").MarshalYAML()
+	if err != nil {
+		t.Fatalf("MarshalYAML() error = %v", err)
+	}
+	if got != SecretRedacted {
+		t.Errorf("MarshalYAML() non-empty = %v, want %q", got, SecretRedacted)
+	}
+	got, err = Secret("").MarshalYAML()
+	if err != nil {
+		t.Fatalf("MarshalYAML() error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("MarshalYAML() empty = %v, want \"\"", got)
+	}
+}
+
+// TestSecretRedactsInContainers is the value-vs-pointer-receiver trap from
+// the plan (§6.5): redaction MUST fire for a Secret used as a struct field,
+// inside a []Secret slice, and as a map value. A pointer receiver would
+// silently NOT redact in a non-addressable slice/map element.
+func TestSecretRedactsInContainers(t *testing.T) {
+	type holder struct {
+		Field   Secret
+		Slice   []Secret
+		MapVals map[string]Secret
+	}
+	h := holder{
+		Field:   Secret("field-secret"),
+		Slice:   []Secret{Secret("slice-secret-a"), Secret("slice-secret-b")},
+		MapVals: map[string]Secret{"k": Secret("map-secret")},
+	}
+	b, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	out := string(b)
+	for _, leak := range []string{"field-secret", "slice-secret-a", "slice-secret-b", "map-secret"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("Marshal() leaked %q in %s", leak, out)
+		}
+	}
+	// Four secret positions present (field + 2 slice + 1 map) -> four
+	// redaction sentinels. Count the JSON-encoded (HTML-escaped) form.
+	rb, _ := json.Marshal(SecretRedacted)
+	redacted := strings.Trim(string(rb), `"`)
+	if n := strings.Count(out, redacted); n != 4 {
+		t.Errorf("expected 4 redaction sentinels (field + 2 slice + 1 map), got %d in %s", n, out)
+	}
+}
+
+// TestSecretString covers logging hygiene: %s/%v of a Secret redacts a
+// non-empty value and renders empty as "".
+func TestSecretString(t *testing.T) {
+	if got := Secret("x").String(); got != SecretRedacted {
+		t.Errorf("String() non-empty = %q, want %q", got, SecretRedacted)
+	}
+	if got := Secret("").String(); got != "" {
+		t.Errorf("String() empty = %q, want \"\"", got)
+	}
+}
+
+// TestSecretReveal confirms the render/reconcile escape hatch returns the
+// real cleartext value (the half of the contract the in-memory consumers
+// depend on).
+func TestSecretReveal(t *testing.T) {
+	if got := Secret("real-value").Reveal(); got != "real-value" {
+		t.Errorf("Reveal() = %q, want %q", got, "real-value")
+	}
+	if got := Secret("").Reveal(); got != "" {
+		t.Errorf("Reveal() empty = %q, want \"\"", got)
+	}
+}
+
+// TestSecretUnmarshalJSON documents the fail-closed round-trip guard: a
+// plain string ingests as-is, but the redaction sentinel is REFUSED so a
+// marshalled-then-reloaded compiled config can never silently turn
+// "<redacted>" into a live secret (the compiled-config SSOT is the AST
+// tree, not JSON — see secret.go).
+func TestSecretUnmarshalJSON(t *testing.T) {
+	var s Secret
+	if err := json.Unmarshal([]byte(`"plain"`), &s); err != nil {
+		t.Fatalf("Unmarshal(plain) error = %v", err)
+	}
+	if s.Reveal() != "plain" {
+		t.Errorf("Unmarshal(plain) = %q, want %q", s.Reveal(), "plain")
+	}
+
+	err := json.Unmarshal([]byte(`"`+SecretRedacted+`"`), &s)
+	if err == nil {
+		t.Fatal("Unmarshal(sentinel) succeeded; want refusal")
+	}
+	if !errors.Is(err, errRedactedSecretIngest) {
+		t.Errorf("Unmarshal(sentinel) err = %v, want errRedactedSecretIngest", err)
+	}
+}
+
+// TestSecretIsComparable confirms Secret stays usable as a map key and for
+// direct == "" present/absent checks at call sites (the named-string-type
+// property the design depends on).
+func TestSecretIsComparable(t *testing.T) {
+	m := map[Secret]int{Secret("a"): 1}
+	if m[Secret("a")] != 1 {
+		t.Error("Secret not usable as map key")
+	}
+	var unset Secret
+	if unset != "" {
+		t.Error("zero-value Secret should compare equal to \"\"")
+	}
+}
+
+// TestSNMPCommunityMarshalRedactsName covers the targeted struct marshaller
+// (#2053): SNMPCommunity keeps Name a plain string so it stays the map key
+// and the text show paths are unchanged, but its JSON/YAML form redacts the
+// community string (the secret) while leaving Authorization in the clear.
+func TestSNMPCommunityMarshalRedactsName(t *testing.T) {
+	c := SNMPCommunity{Name: "publiclikesecret", Authorization: "read-only"}
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	out := string(b)
+	if strings.Contains(out, "publiclikesecret") {
+		t.Errorf("SNMPCommunity JSON leaked community string: %s", out)
+	}
+	rb, _ := json.Marshal(SecretRedacted)
+	if !strings.Contains(out, strings.Trim(string(rb), `"`)) {
+		t.Errorf("SNMPCommunity JSON missing redaction sentinel: %s", out)
+	}
+	if !strings.Contains(out, "read-only") {
+		t.Errorf("SNMPCommunity JSON should keep Authorization in clear: %s", out)
+	}
+	// In-memory Name (the map key / render value) is untouched.
+	if c.Name != "publiclikesecret" {
+		t.Errorf("in-memory SNMPCommunity.Name mutated to %q", c.Name)
+	}
+}

--- a/pkg/config/types_interfaces.go
+++ b/pkg/config/types_interfaces.go
@@ -75,7 +75,7 @@ type VRRPGroup struct {
 	AcceptData         bool
 	AdvertiseInterval  int    // seconds, default 1
 	AuthType           string // "md5" or ""
-	AuthKey            string
+	AuthKey            Secret // VRRP auth key; redacted on JSON/YAML marshal (#2053)
 	TrackInterface     string // lower priority if interface is down
 	TrackPriorityDelta int    // how much to lower priority
 }

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -156,7 +156,7 @@ type RIPConfig struct {
 	Interfaces   []string // interfaces participating in RIP
 	Passive      []string // passive interfaces (receive only)
 	Redistribute []string // "connected", "static", "ospf"
-	AuthKey      string   // authentication key/password
+	AuthKey      Secret   // authentication key/password; redacted on marshal (#2053)
 	AuthType     string   // "md5" or "simple"
 }
 
@@ -166,7 +166,7 @@ type ISISConfig struct {
 	Level           string // "level-1", "level-2", "level-1-2" (default "level-2")
 	Interfaces      []*ISISInterface
 	Export          []string // "connected", "static", etc.
-	AuthKey         string   // area-level authentication key
+	AuthKey         Secret   // area-level authentication key; redacted on marshal (#2053)
 	AuthType        string   // "md5" or "simple" (plaintext)
 	WideMetricsOnly bool     // use wide (32-bit) metrics
 	Overload        bool     // set overload bit
@@ -178,7 +178,7 @@ type ISISInterface struct {
 	Level         string // override per-interface
 	Passive       bool
 	Metric        int    // 0 = default
-	AuthKey       string // per-interface authentication key
+	AuthKey       Secret // per-interface authentication key; redacted on marshal (#2053)
 	AuthType      string // "md5" or "simple"
 	BFD           bool   // enable BFD on this interface
 	BFDInterval   int    // BFD minimum-interval in ms (0 = default)
@@ -243,7 +243,7 @@ type OSPFInterface struct {
 	Cost          int    // OSPF cost, 0 = default
 	NetworkType   string // "point-to-point", "broadcast", "" (default)
 	AuthType      string // "md5", "simple", "" (none)
-	AuthKey       string // authentication key/password
+	AuthKey       Secret // authentication key/password; redacted on marshal (#2053)
 	AuthKeyID     int    // key-id for MD5 (1-255)
 	BFD           bool   // enable BFD on this interface
 	BFDInterval   int    // BFD minimum-interval in ms (0 = default)
@@ -278,7 +278,7 @@ type BGPNeighbor struct {
 	FamilyInet           bool     // activate under address-family ipv4 unicast
 	FamilyInet6          bool     // activate under address-family ipv6 unicast
 	GroupName            string   // BGP group name (for display)
-	AuthPassword         string   // TCP MD5 password for BGP session
+	AuthPassword         Secret   // TCP MD5 password for BGP session; redacted on marshal (#2053)
 	BFD                  bool     // enable BFD for this neighbor
 	BFDInterval          int      // BFD minimum interval in ms (0 = default 300)
 	BFDMultiplier        int      // BFD detect-multiplier (0 = default 3)
@@ -328,7 +328,7 @@ type TunnelConfig struct {
 	// full Junos wireguard grammar (S6). The engine keys encap on
 	// WgPeerPubkeyHex, NOT AllowedIPs LPM (cryptokey-routing safety).
 	WgListenPort      uint16   // local UDP listen port for inbound WG
-	WgLocalPrivkeyHex string   // local static X25519 private key (hex, 64 chars)
+	WgLocalPrivkeyHex Secret   // local static X25519 private key (hex, 64 chars); redacted on marshal (#2053)
 	WgPeerPubkeyHex   string   // peer static X25519 public key (hex)
 	WgAllowedIPs      []string // peer AllowedIPs (CIDR); decap inner-src gate only
 	WgEndpoint        string   // optional peer endpoint IP:port (initiator role)

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -472,7 +472,7 @@ type IKEPolicy struct {
 	Name      string
 	Mode      string // "main" or "aggressive"
 	Proposals string // IKE proposal reference
-	PSK       string // pre-shared key
+	PSK       Secret // pre-shared key; redacted on JSON/YAML marshal (#2053)
 }
 
 // IPsecProposal defines Phase 2 (ESP) encryption and authentication parameters.
@@ -526,7 +526,7 @@ type IPsecVPN struct {
 	IPsecPolicy      string // IPsec policy reference
 	LocalID          string // local traffic selector (CIDR)
 	RemoteID         string // remote traffic selector (CIDR)
-	PSK              string // pre-shared key (legacy, prefer IKE policy)
+	PSK              Secret // pre-shared key (legacy, prefer IKE policy); redacted on marshal (#2053)
 	LocalAddr        string // local address
 	BindInterface    string // tunnel interface (e.g. "st0.0") — creates xfrmi with if_id
 	DFBit            string // "copy", "set", "clear"

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -1,6 +1,10 @@
 package config
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
 
 // System and platform-services configuration: system stanza, userspace
 // dataplane, syslog, SNMP, login, REST API auth, RPM, flow-monitoring,
@@ -151,7 +155,7 @@ type SharedUMEMConfig struct {
 
 // RootAuthConfig holds root-authentication settings.
 type RootAuthConfig struct {
-	EncryptedPassword string
+	EncryptedPassword Secret // crypt(3) hash; redacted on JSON/YAML marshal (#2053)
 	SSHKeys           []string
 }
 
@@ -202,13 +206,13 @@ type WebManagementConfig struct {
 // APIAuthConfig holds REST API authentication settings.
 type APIAuthConfig struct {
 	Users   []*APIAuthUser // basic auth users
-	APIKeys []string       // bearer/X-API-Key tokens
+	APIKeys []Secret       // bearer/X-API-Key tokens; redacted on marshal (#2053)
 }
 
 // APIAuthUser defines a basic auth user for the REST API.
 type APIAuthUser struct {
 	Username string
-	Password string
+	Password Secret // redacted on JSON/YAML marshal (#2053)
 }
 
 // SystemSyslogConfig holds traditional Junos system syslog config.
@@ -255,10 +259,113 @@ type SNMPConfig struct {
 	V3Users     map[string]*SNMPv3User
 }
 
+// MarshalJSON redacts the SNMPv1/v2c community strings on the JSON surface
+// (#2053). The community string is the secret AND the Communities map key,
+// so a plain map marshal would leak it as a JSON object key regardless of
+// SNMPCommunity.MarshalJSON (which only redacts the value's Name field). To
+// avoid emitting secret keys, the Communities map is rendered as a sorted
+// slice of (already-redacting) SNMPCommunity values — dropping the
+// secret-equals-the-key. V3Users/TrapGroups keys are usernames/group names
+// (not secrets) and pass through unchanged. The in-memory map (and its
+// lookup-by-community-string in pkg/snmp) is untouched.
+func (s SNMPConfig) MarshalJSON() ([]byte, error) {
+	type snmpAlias struct {
+		Location    string
+		Contact     string
+		Description string
+		Communities []*SNMPCommunity
+		TrapGroups  map[string]*SNMPTrapGroup
+		V3Users     map[string]*SNMPv3User
+	}
+	a := snmpAlias{
+		Location:    s.Location,
+		Contact:     s.Contact,
+		Description: s.Description,
+		TrapGroups:  s.TrapGroups,
+		V3Users:     s.V3Users,
+	}
+	if len(s.Communities) > 0 {
+		names := make([]string, 0, len(s.Communities))
+		for name := range s.Communities {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		a.Communities = make([]*SNMPCommunity, 0, len(names))
+		for _, name := range names {
+			a.Communities = append(a.Communities, s.Communities[name])
+		}
+	}
+	return json.Marshal(a)
+}
+
+// MarshalYAML mirrors MarshalJSON for the gopkg.in/yaml.v3 marshaller,
+// redacting the community-string map keys by rendering Communities as a
+// sorted slice (future-proofing; no config YAML marshaller exists today —
+// #2053).
+func (s SNMPConfig) MarshalYAML() (any, error) {
+	type snmpAlias struct {
+		Location    string
+		Contact     string
+		Description string
+		Communities []*SNMPCommunity
+		TrapGroups  map[string]*SNMPTrapGroup
+		V3Users     map[string]*SNMPv3User
+	}
+	a := snmpAlias{
+		Location:    s.Location,
+		Contact:     s.Contact,
+		Description: s.Description,
+		TrapGroups:  s.TrapGroups,
+		V3Users:     s.V3Users,
+	}
+	if len(s.Communities) > 0 {
+		names := make([]string, 0, len(s.Communities))
+		for name := range s.Communities {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		a.Communities = make([]*SNMPCommunity, 0, len(names))
+		for _, name := range names {
+			a.Communities = append(a.Communities, s.Communities[name])
+		}
+	}
+	return a, nil
+}
+
 // SNMPCommunity defines an SNMP community string.
+//
+// Name is the SNMPv1/v2c community string, which IS the shared secret (it
+// authorizes the request on the wire). It is also the key of the
+// SNMPConfig.Communities map, so it stays a plain string (the map lookup in
+// pkg/snmp/agent.go is by the on-wire community string). Redaction is
+// applied only on the JSON/YAML surface via the targeted MarshalJSON /
+// MarshalYAML below — keeping it a string means the map key, the compiler
+// assignment, and the text `show snmp` / `show configuration` render paths
+// (which print the map key, not this field, and are out of scope for the
+// #2053 marshal leak) are all unchanged.
 type SNMPCommunity struct {
 	Name          string
 	Authorization string // "read-only" or "read-write"
+}
+
+// MarshalJSON redacts the community string (the secret) on the JSON
+// surface, e.g. GET /api/v1/config, while leaving Authorization in the
+// clear. See the type doc for why Name stays a plain string (#2053).
+func (c SNMPCommunity) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		Name          Secret
+		Authorization string
+	}
+	return json.Marshal(alias{Name: Secret(c.Name), Authorization: c.Authorization})
+}
+
+// MarshalYAML mirrors MarshalJSON for the gopkg.in/yaml.v3 marshaller
+// (future-proofing; no config YAML marshaller exists today — #2053).
+func (c SNMPCommunity) MarshalYAML() (any, error) {
+	return struct {
+		Name          Secret
+		Authorization string
+	}{Name: Secret(c.Name), Authorization: c.Authorization}, nil
 }
 
 // SNMPTrapGroup defines an SNMP trap destination group.
@@ -271,9 +378,9 @@ type SNMPTrapGroup struct {
 type SNMPv3User struct {
 	Name         string
 	AuthProtocol string // "md5", "sha", "sha256"
-	AuthPassword string
+	AuthPassword Secret // redacted on JSON/YAML marshal (#2053)
 	PrivProtocol string // "des", "aes128"
-	PrivPassword string
+	PrivPassword Secret // redacted on JSON/YAML marshal (#2053)
 }
 
 // LoginClassPermission defines what a login class can do.
@@ -305,7 +412,7 @@ type LoginUser struct {
 	Name              string
 	UID               int
 	Class             string   // "super-user", "read-only", etc.
-	EncryptedPassword string   // crypt(3) hash; applied via `chpasswd -e` (#1944)
+	EncryptedPassword Secret   // crypt(3) hash; applied via `chpasswd -e` (#1944); redacted on marshal (#2053)
 	SSHKeys           []string // authorized SSH public keys
 }
 
@@ -725,18 +832,15 @@ type DHCPDynamicDNSConfig struct {
 	// increment-2 backend.
 	UpdateServer string
 	// TSIGKeyName / TSIGAlgorithm / TSIGSecret are the TSIG credentials
-	// for authenticated RFC 2136 updates. TSIGSecret is sensitive and is
-	// redacted by String() (so a %v/%s/slog of this struct never leaks the
-	// HMAC key — see String below). It is NOT redacted by JSON/YAML
-	// marshalling: like every other config secret (IKE pre-shared keys,
-	// OSPF auth keys — see freetext.go), the field is stored verbatim in the
-	// compiled config, which must never be serialized onto a user-facing
-	// surface. The only compiled-config marshaller, Store.ExportJSON, is a
-	// debug-only helper with no production callers. Cross-cutting
-	// marshal-time redaction for all config secrets is tracked separately.
+	// for authenticated RFC 2136 updates. TSIGSecret is the sensitive HMAC
+	// key. It is redacted by String() (so a %v/%s/slog of this struct never
+	// leaks the key — see String below) AND, since #2053, by its Secret
+	// type on every JSON/YAML marshal (so the compiled-config dump on
+	// GET /api/v1/config never leaks it either). The reconciler/render paths
+	// read the cleartext via Reveal().
 	TSIGKeyName   string
 	TSIGAlgorithm string
-	TSIGSecret    string
+	TSIGSecret    Secret
 }
 
 // String redacts TSIGSecret so a %v/%s/slog format of a

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -35,7 +35,13 @@ type SystemConfig struct {
 	Login                    *LoginConfig
 	RootAuthentication       *RootAuthConfig
 	Archival                 *ArchivalConfig
-	MasterPassword           string   // pseudorandom-function value
+	// MasterPassword is a misnomer kept for the Junos token: it holds the
+	// `system master-password pseudorandom-function <fn>` value, i.e. the PRF
+	// ALGORITHM-SELECTOR NAME (e.g. hmac-sha256), NOT key material. The actual
+	// master key is node-local + HKDF-derived and never stored in config (see
+	// compiler_system.go / configstore/crypto.go), so this field is not a
+	// secret and is intentionally a plain string, not config.Secret (#2053).
+	MasterPassword           string   // PRF algorithm-selector name (not a secret)
 	LicenseAutoUpdate        string   // license autoupdate URL
 	DisabledProcesses        []string // processes marked "disable"
 	PersistGroupsInheritance bool     // system commit persist-groups-inheritance (syntax accepted, runtime no-op)
@@ -269,6 +275,9 @@ type SNMPConfig struct {
 // (not secrets) and pass through unchanged. The in-memory map (and its
 // lookup-by-community-string in pkg/snmp) is untouched.
 func (s SNMPConfig) MarshalJSON() ([]byte, error) {
+	// NOTE: the snmpAlias projection below is intentionally duplicated in
+	// MarshalYAML; the two MUST stay in sync. If you add/rename a field here,
+	// mirror it in MarshalYAML or the JSON and YAML redaction surfaces diverge.
 	type snmpAlias struct {
 		Location    string
 		Contact     string
@@ -303,6 +312,8 @@ func (s SNMPConfig) MarshalJSON() ([]byte, error) {
 // sorted slice (future-proofing; no config YAML marshaller exists today —
 // #2053).
 func (s SNMPConfig) MarshalYAML() (any, error) {
+	// Keep this projection in sync with MarshalJSON above (same snmpAlias +
+	// Communities map->sorted-slice redaction).
 	type snmpAlias struct {
 		Location    string
 		Contact     string

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1167,10 +1167,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 					APIKeys: make(map[string]bool),
 				}
 				for _, u := range wm.APIAuth.Users {
-					authCfg.Users[u.Username] = u.Password
+					authCfg.Users[u.Username] = u.Password.Reveal()
 				}
 				for _, k := range wm.APIAuth.APIKeys {
-					authCfg.APIKeys[k] = true
+					authCfg.APIKeys[k.Reveal()] = true
 				}
 				apiCfg.Auth = authCfg
 				slog.Info("HTTP API authentication enabled", "users", len(wm.APIAuth.Users), "api_keys", len(wm.APIAuth.APIKeys))

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -822,7 +822,7 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 //     credential — but only for the exact xpf-provisioned account (marker
 //     UID matches the current UID) and never on a shadow read error.
 func (d *Daemon) reconcileUserPassword(user *config.LoginUser) {
-	desired := user.EncryptedPassword
+	desired := user.EncryptedPassword.Reveal()
 	curUID, uidOK := lookupUID(user.Name)
 	cur, ok := currentShadowHash(user.Name)
 
@@ -950,11 +950,11 @@ func (d *Daemon) applyRootAuth(cfg *config.Config) {
 		// skip+warn so "plaintext never reaches /etc/shadow" holds for root
 		// on every path too, without bricking boot. SSH keys below are
 		// still applied regardless.
-		if err := config.ValidateCryptHash(ra.EncryptedPassword, nil); err != nil {
+		if err := config.ValidateCryptHash(ra.EncryptedPassword.Reveal(), nil); err != nil {
 			slog.Warn("refusing to apply invalid root encrypted-password to /etc/shadow", "err", err)
 		} else {
 			// Use chpasswd -e to set pre-hashed password
-			stdin := strings.NewReader("root:" + ra.EncryptedPassword + "\n")
+			stdin := strings.NewReader("root:" + ra.EncryptedPassword.Reveal() + "\n")
 			if out, err := runCommandStdinTimeout(stdin, "chpasswd", "-e"); err != nil {
 				slog.Warn("failed to set root password", "err", err, "output", string(out))
 			} else {

--- a/pkg/dataplane/userspace/screens.go
+++ b/pkg/dataplane/userspace/screens.go
@@ -120,7 +120,7 @@ func synCookieSecretMaterial(cfg *config.Config) string {
 	// Use already cluster-synced secret material. Do not use
 	// system master-password: it is a PRF selector for configstore
 	// at-rest encryption, not a dataplane secret.
-	return cfg.System.RootAuthentication.EncryptedPassword
+	return cfg.System.RootAuthentication.EncryptedPassword.Reveal()
 }
 
 func userspaceSynCookieProtectionActive(cfg *config.Config) bool {

--- a/pkg/dataplane/userspace/tunnels.go
+++ b/pkg/dataplane/userspace/tunnels.go
@@ -121,7 +121,7 @@ func buildTunnelEndpointSnapshots(cfg *config.Config, interfaces []InterfaceSnap
 		}
 		if isWireguard {
 			snap.WgListenPort = tunnel.WgListenPort
-			snap.WgLocalPrivkeyHex = tunnel.WgLocalPrivkeyHex
+			snap.WgLocalPrivkeyHex = tunnel.WgLocalPrivkeyHex.Reveal()
 			snap.WgPeerPubkeyHex = tunnel.WgPeerPubkeyHex
 			snap.WgAllowedIPs = tunnel.WgAllowedIPs
 			snap.WgEndpoint = tunnel.WgEndpoint

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -197,10 +197,10 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 					if keyID == 0 {
 						keyID = 1
 					}
-					fmt.Fprintf(&b, " ip ospf message-digest-key %d md5 %s\n", keyID, sanitizeFRRValue(iface.AuthKey))
+					fmt.Fprintf(&b, " ip ospf message-digest-key %d md5 %s\n", keyID, sanitizeFRRValue(iface.AuthKey.Reveal()))
 				} else if iface.AuthType == "simple" {
 					b.WriteString(" ip ospf authentication\n")
-					fmt.Fprintf(&b, " ip ospf authentication-key %s\n", sanitizeFRRValue(iface.AuthKey))
+					fmt.Fprintf(&b, " ip ospf authentication-key %s\n", sanitizeFRRValue(iface.AuthKey.Reveal()))
 				}
 				if iface.BFD {
 					if iface.BFDInterval > 0 || iface.BFDMultiplier > 0 {
@@ -292,7 +292,7 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 				fmt.Fprintf(&b, " neighbor %s ebgp-multihop %d\n", n.Address, n.MultihopTTL)
 			}
 			if n.AuthPassword != "" {
-				fmt.Fprintf(&b, " neighbor %s password %s\n", n.Address, sanitizeFRRValue(n.AuthPassword))
+				fmt.Fprintf(&b, " neighbor %s password %s\n", n.Address, sanitizeFRRValue(n.AuthPassword.Reveal()))
 			}
 			if n.BFD {
 				fmt.Fprintf(&b, " neighbor %s bfd\n", n.Address)
@@ -388,7 +388,7 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 				} else {
 					b.WriteString(" ip rip authentication mode text\n")
 				}
-				fmt.Fprintf(&b, " ip rip authentication string %s\n", sanitizeFRRValue(rip.AuthKey))
+				fmt.Fprintf(&b, " ip rip authentication string %s\n", sanitizeFRRValue(rip.AuthKey.Reveal()))
 				b.WriteString("exit\n!\n")
 			}
 		}
@@ -422,11 +422,11 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 		}
 		if isis.AuthKey != "" {
 			if isis.AuthType == "md5" {
-				fmt.Fprintf(&b, " area-password md5 %s\n", sanitizeFRRValue(isis.AuthKey))
-				fmt.Fprintf(&b, " domain-password md5 %s\n", sanitizeFRRValue(isis.AuthKey))
+				fmt.Fprintf(&b, " area-password md5 %s\n", sanitizeFRRValue(isis.AuthKey.Reveal()))
+				fmt.Fprintf(&b, " domain-password md5 %s\n", sanitizeFRRValue(isis.AuthKey.Reveal()))
 			} else {
-				fmt.Fprintf(&b, " area-password clear %s\n", sanitizeFRRValue(isis.AuthKey))
-				fmt.Fprintf(&b, " domain-password clear %s\n", sanitizeFRRValue(isis.AuthKey))
+				fmt.Fprintf(&b, " area-password clear %s\n", sanitizeFRRValue(isis.AuthKey.Reveal()))
+				fmt.Fprintf(&b, " domain-password clear %s\n", sanitizeFRRValue(isis.AuthKey.Reveal()))
 			}
 		}
 		b.WriteString("exit\n!\n")
@@ -441,9 +441,9 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			}
 			if iface.AuthKey != "" {
 				if iface.AuthType == "md5" {
-					fmt.Fprintf(&b, " isis password md5 %s\n", sanitizeFRRValue(iface.AuthKey))
+					fmt.Fprintf(&b, " isis password md5 %s\n", sanitizeFRRValue(iface.AuthKey.Reveal()))
 				} else {
-					fmt.Fprintf(&b, " isis password clear %s\n", sanitizeFRRValue(iface.AuthKey))
+					fmt.Fprintf(&b, " isis password clear %s\n", sanitizeFRRValue(iface.AuthKey.Reveal()))
 				}
 			}
 			b.WriteString("exit\n!\n")

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -173,12 +173,12 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 	b.WriteString("secrets {\n")
 	for _, name := range sortedVPNNames(ipsecCfg.VPNs) {
 		vpn := ipsecCfg.VPNs[name]
-		secret := vpn.PSK
+		secret := vpn.PSK.Reveal()
 		// Resolve PSK from IKE policy chain: VPN -> gateway -> IKE policy -> PSK
 		if secret == "" {
 			if gw, ok := ipsecCfg.Gateways[vpn.Gateway]; ok {
 				if ikePol, ok := ipsecCfg.IKEPolicies[gw.IKEPolicy]; ok {
-					secret = ikePol.PSK
+					secret = ikePol.PSK.Reveal()
 				}
 			}
 		}

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -62,10 +62,10 @@ func (a *Agent) deriveV3Users(cfg *config.SNMPConfig) map[string]*usmUser {
 		u := &usmUser{name: cu.Name, authProto: cu.AuthProtocol, privProto: cu.PrivProtocol}
 		hashFn, hashLen := authHashFunc(cu.AuthProtocol)
 		if hashFn != nil && cu.AuthPassword != "" {
-			u.authKey = passwordToKey(cu.AuthPassword, a.engineID, hashFn, hashLen)
+			u.authKey = passwordToKey(cu.AuthPassword.Reveal(), a.engineID, hashFn, hashLen)
 		}
 		if hashFn != nil && cu.PrivPassword != "" {
-			u.privKey = passwordToKey(cu.PrivPassword, a.engineID, hashFn, hashLen)
+			u.privKey = passwordToKey(cu.PrivPassword.Reveal(), a.engineID, hashFn, hashLen)
 		}
 		users[cu.Name] = u
 	}

--- a/pkg/vrrp/vrrp.go
+++ b/pkg/vrrp/vrrp.go
@@ -43,7 +43,7 @@ func CollectInstances(cfg *config.Config) []*Instance {
 					AdvertiseInterval: vg.AdvertiseInterval,
 					VirtualAddresses:  vg.VirtualAddresses,
 					AuthType:          vg.AuthType,
-					AuthKey:           vg.AuthKey,
+					AuthKey:           vg.AuthKey.Reveal(),
 					// TrackInterface arrives as a Junos name
 					// (ge-0/0/1); normalize to the Linux name
 					// (ge-0-0-1) so netlink lookups and link-watcher


### PR DESCRIPTION
## Summary

Closes the **live plaintext-secret leak** on `GET /api/v1/config`. The
handler (`pkg/api/config.go` `configHandler` → `writeOK(w, store.ActiveConfig())`)
JSON-encodes the entire compiled `*config.Config`, so before this change it
returned every operator secret — IKE/IPsec PSKs, OSPF/RIP/IS-IS/VRRP/interface
auth keys, the TSIG HMAC key, SNMPv3 auth/priv passwords, root/login `crypt(3)`
hashes, the BGP TCP-MD5 password, REST basic-auth passwords + API keys, the
WireGuard private key, and the SNMP v1/v2c community string — **in plaintext**
to any authorized REST client (loopback by default, but bindable non-loopback
over HTTPS via `web-management https interface`). The per-struct `String()`
redaction is logging-only; `encoding/json` ignores `Stringer`, so it never
closed the marshal leak.

## Mechanism (type-enforced, not by-convention)

`config.Secret` (`pkg/config/secret.go`) is a named `string` type whose
value-receiver `MarshalJSON` / `MarshalYAML` emit `<redacted>` for a non-empty
value and `""` for empty. `Reveal()` returns the cleartext for render/reconcile
paths; `String()` redacts for `%v`/`%s`/slog; `UnmarshalJSON` accepts a plain
string but **fails closed** on the sentinel (a marshalled-then-reloaded config
can never silently turn `<redacted>` into a live secret). A value receiver
ensures redaction fires for a struct field, in a `[]Secret` slice (`APIKeys`),
and as a map value. Adding a new secret config field is now one annotation.

**16 fields converted** to `config.Secret` across `types_security.go`,
`types_routing.go`, `types_interfaces.go`, `types_system.go`. Compiler
producers wrap with `Secret(...)`; render/reconcile consumers read `.Reveal()`
(`pkg/ipsec`, `pkg/frr`, `pkg/snmp`, `pkg/vrrp`, `pkg/dataplane/userspace`,
`pkg/daemon`).

### SNMP community string (the secret IS the map key)

The community string is both the secret and the `SNMPConfig.Communities` map
key, so a plain map marshal leaks it as a JSON object key regardless of the
value's redaction. `SNMPCommunity.Name` stays a plain `string` (keeps the
map lookup by on-wire community string in `pkg/snmp` and the text `show` paths
unchanged) and redaction is done with **targeted struct marshallers**:
`SNMPCommunity.MarshalJSON` redacts the `Name` field, and
`SNMPConfig.MarshalJSON` / `MarshalYAML` render the `Communities` map as a
sorted slice so the secret never appears as a JSON key.

## Out of scope / left as-is

- `show configuration` / `show snmp` text output is **unchanged** (operators
  read their own secrets — Junos parity; a separate concern).
- `MasterPassword` (commit-encryption PRF selector), `ArchiveSitesWithPassword`
  (URLs whose inline password was already discarded), and `SSHKeys` (public
  keys) are left as plain `string` per the plan's rulings.

## Round-trip safety

Nothing unmarshals a compiled `*config.Config` back from JSON/YAML — the
persistence/HA-sync SSOT is the `*ConfigTree` AST (`db.go` / `sync_conn.go`;
the old audit-journal full-config marshal was already removed in #1896). A
redacting marshaller therefore cannot starve any consumer.

## Tests

- `pkg/api/config_secret_redaction_test.go` — the leak-regression net: stages
  every secret via the real `LoadSet` + `Commit` path, drives the live
  `GET /api/v1/config` handler, and asserts **no cleartext sentinel** appears
  while the redaction sentinel does. **Verified this FAILS against pre-fix
  marshalling** (temporarily disabled the `Secret`/`SNMPConfig` marshallers →
  all 16 secrets dumped in plaintext) and PASSES after the fix. Companion tests
  confirm the in-memory cleartext is preserved (`Reveal` path intact) and the
  redacted response is still valid JSON.
- `pkg/config/secret_test.go` — marshal/unmarshal (sentinel refusal), the
  value-receiver-in-containers trap (field + slice + map), `String`, `Reveal`,
  comparability, and the SNMP targeted marshaller.

## Validation

`go build ./...`, `go vet ./pkg/config ./pkg/api ./pkg/daemon` (only
pre-existing `daemon_flow.go` lock-copy warnings), `go test ./...` — 46
packages green.

Closes #2053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)