### PR TITLE
config: activate/deactivate edits on all surfaces + load-set service parity (#2051, #2052)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,46 @@
 # Action Log
 
+## 2026-06-20 — #2051 + #2052 config-mode edit/load surface parity (one PR)
+
+- **Timestamp**: 2026-06-20
+- **Action**: #2051 expose `activate` / `deactivate` as first-class
+  config-mode edits across all four surfaces, building on the shipped
+  #2008 primitives (`ConfigTree.DeactivatePath` / `ActivatePath`,
+  `applyEditLine`). Added store wrappers `DeactivateFromInput` /
+  `ActivateFromInput` (route through `applyEditLine` so verb logic stays
+  in one place; NOT through `ParseSetCommand("set "+input)` which would
+  mangle the path into a junk node named "deactivate"). Wired local CLI
+  dispatch (`cli_dispatch.go`), remote CLI `dispatchConfig`
+  (`cmd/cli/shared.go`, rides the gRPC `Set` RPC with the verb kept as
+  input prefix), gRPC `Set` prefix-routing (`grpcapi/server_config.go`,
+  BEFORE the `SetFromInput` fall-through — the anti-mangling fix), and
+  REST `POST /api/v1/config/{deactivate,activate}` (`pkg/api/config.go` +
+  `server.go` routes). cmdtree `ConfigTopLevel` lists both verbs;
+  completion has schema parity with `delete` (reuses
+  `CompleteSetPathWithValues` in both `pkg/cli/completion.go` and
+  `grpcapi/server_cluster.go`). #2052 made `load set` a real service-mode
+  op: `mode == "set"` → `store.LoadSet` on gRPC `Load`
+  (`server_config.go`) and REST `configLoadHandler` (`pkg/api/config.go`),
+  applied-count log-only; widened remote CLI `handleLoad`
+  (`cmd/cli/main.go`) to accept `set` (terminal + file); fixed the proto
+  comment drift (`proto/xpf/v1/xpf.proto` LoadRequest.mode: drop the
+  nonexistent `replace`, document `set`) and regenerated `xpf.pb.go`
+  (comment-only diff, no wire change). Tests assert ACTUAL inactivation
+  (display-set `deactivate <path>` line, proxy for `node.Inactive`), not
+  no-error; the gRPC anti-mangling regression verified non-tautological
+  (fails when the prefix-route is removed → junk `set deactivate ...`
+  node). Docs: `docs/config-schema.md`, `pkg/config/README.md`.
+- **File(s)**: `pkg/configstore/store.go`, `pkg/cli/cli_dispatch.go`,
+  `pkg/cli/completion.go`, `cmd/cli/shared.go`, `cmd/cli/main.go`,
+  `pkg/grpcapi/server_config.go`, `pkg/grpcapi/server_cluster.go`,
+  `pkg/api/config.go`, `pkg/api/server.go`, `pkg/cmdtree/tree.go`,
+  `proto/xpf/v1/xpf.proto`, `pkg/grpcapi/xpfv1/xpf.pb.go`,
+  `docs/config-schema.md`, `pkg/config/README.md`,
+  `pkg/configstore/activate_test.go`,
+  `pkg/grpcapi/server_config_activate_test.go`,
+  `pkg/api/config_activate_test.go`, `pkg/cli/cli_activate_test.go`,
+  `pkg/cli/completion_activate_test.go`.
+
 ## 2026-06-19 — #2053 redact all config secrets at JSON/YAML marshal time
 
 - **Timestamp**: 2026-06-19

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -380,8 +380,8 @@ func (c *ctl) handleLoad(args []string) error {
 	}
 
 	mode := args[0]
-	if mode != "override" && mode != "merge" {
-		return fmt.Errorf("load: unknown mode %q (use 'override' or 'merge')", mode)
+	if mode != "override" && mode != "merge" && mode != "set" {
+		return fmt.Errorf("load: unknown mode %q (use 'override', 'merge', or 'set')", mode)
 	}
 
 	source := args[1]

--- a/cmd/cli/shared.go
+++ b/cmd/cli/shared.go
@@ -353,6 +353,23 @@ func (c *ctl) dispatchConfig(line string) error {
 		}
 		return nil
 
+	case "deactivate", "activate":
+		// #2051: activate/deactivate ride the Set RPC with the verb kept as
+		// the input prefix. The gRPC Set handler prefix-routes "deactivate "/
+		// "activate " to Deactivate/ActivateFromInput; sending the bare path
+		// (or using the Delete RPC) would mangle it into a junk "set" path.
+		if len(parts) < 2 {
+			return fmt.Errorf("%s: missing path", parts[0])
+		}
+		fullPath := append(append([]string{}, c.editPath...), parts[1:]...)
+		_, err := c.client.Set(c.ctx(), &pb.SetRequest{
+			Input: parts[0] + " " + strings.Join(fullPath, " "),
+		})
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return nil
+
 	case "copy", "rename":
 		toIdx := -1
 		for i, p := range parts {

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -553,3 +553,26 @@ replay paths (`LoadSet`, `LoadMerge`, and the hierarchical
 output round-trips: an inactive node reloads inactive rather than being
 skipped (and silently reactivated) or parsed as a junk path beginning
 "deactivate".
+
+**Interactive `activate` / `deactivate` config-mode verbs (#2051).** The two
+verbs are first-class config-mode edits on all four surfaces. The store
+exposes `DeactivateFromInput` / `ActivateFromInput` (`configstore/store.go`),
+thin wrappers that prepend the verb and route through the same
+`applyEditLine` switch the replay paths use, so the verb logic lives in one
+place. Local CLI (`cli_dispatch.go`) and remote CLI (`cmd/cli/shared.go`
+`dispatchConfig`) dispatch the verbs; the remote CLI rides the gRPC `Set` RPC
+with the verb kept as the input prefix, and `Server.Set`
+(`grpcapi/server_config.go`) prefix-routes `deactivate `/`activate ` to the
+store wrappers BEFORE the `SetFromInput` fall-through — otherwise the
+fall-through would parse `set deactivate <path>` and create a junk node named
+"deactivate". REST exposes `POST /api/v1/config/deactivate` and
+`/config/activate`. Path completion has schema parity with `delete` (paths to
+existing nodes via `CompleteSetPathWithValues`); cmdtree lists both verbs in
+`ConfigTopLevel`.
+
+**`load set` is a real service-mode op (#2052).** `load set` now works on the
+remote CLI, gRPC, and REST (previously local-CLI-only) via
+`LoadRequest.mode == "set"` → `store.LoadSet`. The applied-count is logged
+(no response field). This makes `show | display set` output — including the
+`deactivate <path>` lines above — round-trippable through every service
+surface.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -69,6 +70,47 @@ func (s *Server) configDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.store.DeleteFromInput(req.Input); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeOK(w, map[string]string{"status": "ok"})
+}
+
+// configDeactivateHandler marks a candidate node inactive (#2051), the REST
+// equivalent of the interactive `deactivate <path>` verb. The request body's
+// Input is the bare path (no verb), mirroring configSetHandler. It routes
+// through DeactivateFromInput so the verb logic stays in the store's
+// applyEditLine switch and the path is never mangled into a junk "set" node.
+func (s *Server) configDeactivateHandler(w http.ResponseWriter, r *http.Request) {
+	var req ConfigSetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Input == "" {
+		writeError(w, http.StatusBadRequest, "input required")
+		return
+	}
+	if err := s.store.DeactivateFromInput(req.Input); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeOK(w, map[string]string{"status": "ok"})
+}
+
+// configActivateHandler clears the inactive marker on a candidate node
+// (#2051), the REST equivalent of the interactive `activate <path>` verb.
+func (s *Server) configActivateHandler(w http.ResponseWriter, r *http.Request) {
+	var req ConfigSetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Input == "" {
+		writeError(w, http.StatusBadRequest, "input required")
+		return
+	}
+	if err := s.store.ActivateFromInput(req.Input); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -236,8 +278,19 @@ func (s *Server) configLoadHandler(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
+	case "set":
+		// #2052: make `load set` a real service-mode op (REST). LoadSet
+		// replays flat lines through applyEditLine so a body with
+		// `deactivate <path>` lines round-trips to inactive nodes (#2008 H1).
+		// Applied-count is log-only to keep the response shape stable.
+		count, err := s.store.LoadSet(req.Content)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		slog.Info("load set applied", "commands", count)
 	default:
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown load mode: %s (use 'override' or 'merge')", req.Mode))
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown load mode: %s (use 'override', 'merge', or 'set')", req.Mode))
 		return
 	}
 	writeOK(w, map[string]string{"status": "ok"})

--- a/pkg/api/config_activate_test.go
+++ b/pkg/api/config_activate_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// newAPIConfigStore stages an active system/name-server node in config mode for
+// the REST activate/deactivate handler tests.
+func newAPIConfigStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	for _, line := range []string{
+		"set system host-name keep",
+		"set system name-server 9.9.9.9",
+	} {
+		if _, err := store.LoadSet(line); err != nil {
+			t.Fatalf("LoadSet(%q) error = %v", line, err)
+		}
+	}
+	return store
+}
+
+// #2051: the REST deactivate handler must mark the candidate node actually
+// inactive. Assertion is on real inactivation (display-set emits the
+// `deactivate` line only for an Inactive node), not merely HTTP 200.
+func TestConfigDeactivateHandlerMarksInactive(t *testing.T) {
+	store := newAPIConfigStore(t)
+	s := &Server{store: store}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/deactivate",
+		strings.NewReader(`{"input":"system name-server 9.9.9.9"}`))
+	s.configDeactivateHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	out := store.ShowCandidateSet()
+	if !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("REST deactivate did not mark the node inactive:\n%s", out)
+	}
+	if strings.Contains(out, "set deactivate ") {
+		t.Fatalf("REST deactivate mangled input into a junk set path:\n%s", out)
+	}
+}
+
+func TestConfigActivateHandlerClearsInactive(t *testing.T) {
+	store := newAPIConfigStore(t)
+	if err := store.DeactivateFromInput("system name-server 9.9.9.9"); err != nil {
+		t.Fatalf("setup DeactivateFromInput: %v", err)
+	}
+	s := &Server{store: store}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/activate",
+		strings.NewReader(`{"input":"system name-server 9.9.9.9"}`))
+	s.configActivateHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	if out := store.ShowCandidateSet(); strings.Contains(out, "deactivate ") {
+		t.Fatalf("REST activate did not clear the marker:\n%s", out)
+	}
+}
+
+// #2052: the REST Load handler must accept mode=set and replay flat lines,
+// including `deactivate` lines, through LoadSet.
+func TestConfigLoadHandlerModeSet(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	s := &Server{store: store}
+
+	body := `{"mode":"set","content":"set system host-name keep\nset system name-server 9.9.9.9\ndeactivate system name-server 9.9.9.9"}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/config/load", strings.NewReader(body))
+	s.configLoadHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	out := store.ShowCandidateSet()
+	if !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("REST load mode=set did not preserve the deactivate marker:\n%s", out)
+	}
+	if !strings.Contains(out, "set system host-name keep") {
+		t.Fatalf("REST load mode=set dropped an active node:\n%s", out)
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -234,6 +234,8 @@ func NewServer(cfg Config) *Server {
 	mux.HandleFunc("GET /api/v1/config/status", s.configStatusHandler)
 	mux.HandleFunc("POST /api/v1/config/set", s.configSetHandler)
 	mux.HandleFunc("POST /api/v1/config/delete", s.configDeleteHandler)
+	mux.HandleFunc("POST /api/v1/config/deactivate", s.configDeactivateHandler)
+	mux.HandleFunc("POST /api/v1/config/activate", s.configActivateHandler)
 	mux.HandleFunc("POST /api/v1/config/load", s.configLoadHandler)
 	mux.HandleFunc("POST /api/v1/config/commit", s.configCommitHandler)
 	mux.HandleFunc("POST /api/v1/config/commit-check", s.configCommitCheckHandler)

--- a/pkg/cli/cli_activate_test.go
+++ b/pkg/cli/cli_activate_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+func newCLIConfigStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	for _, line := range []string{
+		"set system host-name keep",
+		"set system name-server 9.9.9.9",
+	} {
+		if _, err := store.LoadSet(line); err != nil {
+			t.Fatalf("LoadSet(%q) error = %v", line, err)
+		}
+	}
+	return store
+}
+
+// #2051: the local CLI dispatchConfig must route the `deactivate`/`activate`
+// verbs to the store wrappers. Asserts ACTUAL inactivation via display-set, not
+// merely a nil error.
+func TestCLIDispatchDeactivateActivate(t *testing.T) {
+	store := newCLIConfigStore(t)
+	c := &CLI{store: store}
+
+	if err := c.dispatchConfig("deactivate system name-server 9.9.9.9"); err != nil {
+		t.Fatalf("dispatchConfig(deactivate): %v", err)
+	}
+	out := store.ShowCandidateSet()
+	if !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("CLI deactivate did not mark the node inactive:\n%s", out)
+	}
+	if strings.Contains(out, "set deactivate ") {
+		t.Fatalf("CLI deactivate mangled into a junk set path:\n%s", out)
+	}
+
+	if err := c.dispatchConfig("activate system name-server 9.9.9.9"); err != nil {
+		t.Fatalf("dispatchConfig(activate): %v", err)
+	}
+	if out := store.ShowCandidateSet(); strings.Contains(out, "deactivate ") {
+		t.Fatalf("CLI activate did not clear the marker:\n%s", out)
+	}
+}
+
+// Edit-path-relative deactivate: with an edit context set, a relative path must
+// be prefixed with the edit path before routing to the store.
+func TestCLIDispatchDeactivateEditRelative(t *testing.T) {
+	store := newCLIConfigStore(t)
+	c := &CLI{store: store}
+
+	store.SetEditPath([]string{"system"})
+	if err := c.dispatchConfig("deactivate name-server 9.9.9.9"); err != nil {
+		t.Fatalf("dispatchConfig(deactivate relative): %v", err)
+	}
+	if out := store.ShowCandidateSet(); !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("edit-relative deactivate did not resolve under edit path:\n%s", out)
+	}
+}

--- a/pkg/cli/cli_dispatch.go
+++ b/pkg/cli/cli_dispatch.go
@@ -311,6 +311,18 @@ func (c *CLI) dispatchConfig(line string) error {
 		}
 		fullPath := append(c.store.GetEditPath(), parts[1:]...)
 		return c.store.DeleteFromInput(strings.Join(fullPath, " "))
+	case "deactivate":
+		if len(parts) < 2 {
+			return fmt.Errorf("deactivate: missing path")
+		}
+		fullPath := append(c.store.GetEditPath(), parts[1:]...)
+		return c.store.DeactivateFromInput(strings.Join(fullPath, " "))
+	case "activate":
+		if len(parts) < 2 {
+			return fmt.Errorf("activate: missing path")
+		}
+		fullPath := append(c.store.GetEditPath(), parts[1:]...)
+		return c.store.ActivateFromInput(strings.Join(fullPath, " "))
 	case "copy", "rename":
 		return c.handleCopyRename(parts)
 	case "insert":

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -140,7 +140,10 @@ func (c *CLI) completeConfigWithDesc(words []string, partial string) []completio
 	}
 
 	switch resolvedTop {
-	case "set", "delete", "show", "edit":
+	case "set", "delete", "activate", "deactivate", "show", "edit":
+		// #2051: activate/deactivate complete with schema parity to delete
+		// (paths to existing nodes); CompleteSetPathWithValues is the
+		// schema-driven completer all path verbs share.
 		pathWords := words[1:]
 		if resolvedPath, resolved := config.ResolveConsumedSetPathTokens(pathWords); resolved {
 			pathWords = resolvedPath

--- a/pkg/cli/completion_activate_test.go
+++ b/pkg/cli/completion_activate_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cmdtree"
+)
+
+// #2051: activate/deactivate must be offered as config-mode top-level commands
+// and complete their path argument with schema parity to delete (paths to
+// existing schema nodes), via the shared CompleteSetPathWithValues completer.
+
+func TestConfigTopLevelOffersActivateDeactivate(t *testing.T) {
+	for _, verb := range []string{"activate", "deactivate"} {
+		if _, ok := cmdtree.ConfigTopLevel[verb]; !ok {
+			t.Fatalf("cmdtree.ConfigTopLevel is missing %q", verb)
+		}
+	}
+}
+
+func TestCompleteConfig_DeactivatePathSchemaParity(t *testing.T) {
+	c := newTypedLeafCLI(t)
+	// `deactivate sys` must resolve to the same schema container `set sys`
+	// would (here: system). Asserts deactivate routes through the schema
+	// completer, not a dead path.
+	cands := c.completeConfigWithDesc([]string{"deactivate"}, "sys")
+	if !hasCand(cands, "system") {
+		t.Fatalf("expected schema completion `system` for deactivate, got %v", candNames(cands))
+	}
+}
+
+func TestCompleteConfig_ActivatePathSchemaParity(t *testing.T) {
+	c := newTypedLeafCLI(t)
+	cands := c.completeConfigWithDesc([]string{"activate"}, "sys")
+	if !hasCand(cands, "system") {
+		t.Fatalf("expected schema completion `system` for activate, got %v", candNames(cands))
+	}
+}

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -1020,10 +1020,12 @@ var ConfigSetDataplaneKnobs = map[string]*Node{
 
 // ConfigTopLevel defines tab completion for config mode top-level commands.
 var ConfigTopLevel = map[string]*Node{
-	"annotate": {Desc: "Annotate the configuration statement"},
-	"copy":     {Desc: "Copy a configuration statement"},
-	"insert":   {Desc: "Insert a new ordered configuration statement"},
-	"rename":   {Desc: "Rename a configuration statement"},
+	"activate":   {Desc: "Remove the inactive tag from a statement"},
+	"annotate":   {Desc: "Annotate the configuration statement"},
+	"copy":       {Desc: "Copy a configuration statement"},
+	"deactivate": {Desc: "Add the inactive tag to a statement"},
+	"insert":     {Desc: "Insert a new ordered configuration statement"},
+	"rename":     {Desc: "Rename a configuration statement"},
 	"set": {Desc: "Set a configuration parameter", Children: map[string]*Node{
 		"system": {Desc: "System configuration", Children: map[string]*Node{
 			// Codex M3: surface the #785/#801 dataplane knobs so `?`

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -117,10 +117,12 @@ nothing internal.
   `LoadSet` / `LoadMerge` replay loops), so an inactive node reloads inactive
   rather than being skipped (silently reactivated) or parsed as a junk path.
   Regression coverage: `pkg/config/inactive_test.go`,
-  `pkg/configstore/inactive_test.go`. NOTE: interactive standalone
-  `activate` / `deactivate` config-mode commands (a typed CLI verb that edits
-  the candidate directly, distinct from `load set` replay) remain a separate
-  increment.
+  `pkg/configstore/inactive_test.go`. The interactive standalone
+  `activate` / `deactivate` config-mode verbs (editing the candidate directly,
+  distinct from `load set` replay) shipped in #2051 across all four config
+  surfaces (local CLI, remote CLI, gRPC, REST) on top of these primitives —
+  the store wrappers `configstore.Store.DeactivateFromInput` /
+  `ActivateFromInput` route through the same `applyEditLine` verb switch.
 
 ## Callers
 

--- a/pkg/configstore/activate_test.go
+++ b/pkg/configstore/activate_test.go
@@ -1,0 +1,129 @@
+package configstore
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2051: the store DeactivateFromInput/ActivateFromInput wrappers must mark a
+// candidate node actually inactive (not create a junk node literally named
+// "deactivate"). ShowCandidateSet emits a `deactivate <path>` line ONLY for a
+// node whose Inactive flag is set (via FormatSet), so asserting that line is a
+// proxy for node.Inactive==true — a naive no-error test would also pass against
+// the broken mangling path, so these assert the inactivation itself.
+
+func seedActiveNameServer(t *testing.T, s *Store) {
+	t.Helper()
+	if err := s.SetFromInput("system host-name keep"); err != nil {
+		t.Fatalf("SetFromInput host-name: %v", err)
+	}
+	if err := s.SetFromInput("system name-server 9.9.9.9"); err != nil {
+		t.Fatalf("SetFromInput name-server: %v", err)
+	}
+}
+
+func TestDeactivateFromInputMarksInactive(t *testing.T) {
+	s := newTestStore(t)
+	enterCfg(t, s)
+	seedActiveNameServer(t, s)
+
+	// Before: the node is active, so display-set has no deactivate line.
+	if before := s.ShowCandidateSet(); strings.Contains(before, "deactivate ") {
+		t.Fatalf("name-server unexpectedly inactive before deactivate:\n%s", before)
+	}
+
+	if err := s.DeactivateFromInput("system name-server 9.9.9.9"); err != nil {
+		t.Fatalf("DeactivateFromInput: %v", err)
+	}
+
+	out := s.ShowCandidateSet()
+	// The node must be ACTUALLY inactive, not a junk "set deactivate ..." path.
+	if !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("DeactivateFromInput did not mark the node inactive:\n%s", out)
+	}
+	if strings.Contains(out, "set deactivate ") {
+		t.Fatalf("input was mangled into a junk set path:\n%s", out)
+	}
+	// The node itself (its set line) and the active sibling survive.
+	if !strings.Contains(out, "set system name-server 9.9.9.9") {
+		t.Fatalf("deactivate removed the node's set line:\n%s", out)
+	}
+	if !strings.Contains(out, "set system host-name keep") {
+		t.Fatalf("active sibling lost on deactivate:\n%s", out)
+	}
+}
+
+func TestActivateFromInputClearsInactive(t *testing.T) {
+	s := newTestStore(t)
+	enterCfg(t, s)
+	seedActiveNameServer(t, s)
+
+	if err := s.DeactivateFromInput("system name-server 9.9.9.9"); err != nil {
+		t.Fatalf("DeactivateFromInput: %v", err)
+	}
+	if out := s.ShowCandidateSet(); !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("setup deactivate did not take:\n%s", out)
+	}
+
+	if err := s.ActivateFromInput("system name-server 9.9.9.9"); err != nil {
+		t.Fatalf("ActivateFromInput: %v", err)
+	}
+
+	out := s.ShowCandidateSet()
+	if strings.Contains(out, "deactivate ") {
+		t.Fatalf("ActivateFromInput did not clear the inactive marker:\n%s", out)
+	}
+	if !strings.Contains(out, "set system name-server 9.9.9.9") {
+		t.Fatalf("activate dropped the node:\n%s", out)
+	}
+}
+
+// Idempotency: double-deactivate and double-activate are no-ops, not errors
+// (markMatchingNodeInactive just re-sets a bool).
+func TestDeactivateActivateIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	enterCfg(t, s)
+	seedActiveNameServer(t, s)
+
+	for i := 0; i < 2; i++ {
+		if err := s.DeactivateFromInput("system name-server 9.9.9.9"); err != nil {
+			t.Fatalf("DeactivateFromInput pass %d: %v", i, err)
+		}
+	}
+	if out := s.ShowCandidateSet(); !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("double-deactivate lost the marker:\n%s", out)
+	}
+	for i := 0; i < 2; i++ {
+		if err := s.ActivateFromInput("system name-server 9.9.9.9"); err != nil {
+			t.Fatalf("ActivateFromInput pass %d: %v", i, err)
+		}
+	}
+	if out := s.ShowCandidateSet(); strings.Contains(out, "deactivate ") {
+		t.Fatalf("double-activate left a marker:\n%s", out)
+	}
+}
+
+// Deactivate/activate of a path that does not exist must error (the verb
+// toggles an existing statement; it never creates one).
+func TestDeactivateMissingPathErrors(t *testing.T) {
+	s := newTestStore(t)
+	enterCfg(t, s)
+
+	if err := s.DeactivateFromInput("system name-server 1.2.3.4"); err == nil {
+		t.Fatal("DeactivateFromInput on a missing path must error")
+	}
+	if err := s.ActivateFromInput("system name-server 1.2.3.4"); err == nil {
+		t.Fatal("ActivateFromInput on a missing path must error")
+	}
+}
+
+// Outside config mode the wrappers must refuse (candidate is nil).
+func TestDeactivateNotInConfigMode(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.DeactivateFromInput("system name-server 9.9.9.9"); err == nil {
+		t.Fatal("DeactivateFromInput outside config mode must error")
+	}
+	if err := s.ActivateFromInput("system name-server 9.9.9.9"); err == nil {
+		t.Fatal("ActivateFromInput outside config mode must error")
+	}
+}

--- a/pkg/configstore/store.go
+++ b/pkg/configstore/store.go
@@ -863,6 +863,47 @@ func (s *Store) DeleteFromInput(input string) error {
 	return s.Delete(path)
 }
 
+// DeactivateFromInput marks the candidate node at the given path inactive
+// (#2051), implementing the interactive Junos `deactivate <path>` verb. input
+// is the bare path WITHOUT the verb (mirroring SetFromInput/DeleteFromInput).
+//
+// It routes through applyEditLine — the same centralized verb switch used by
+// LoadSet / LoadMerge flat-line replay (store.go applyEditLine) — so the verb
+// logic lives in exactly one place. It deliberately does NOT go through
+// ParseSetCommand("set "+input): that parser would build the junk path
+// "deactivate <path>" (a config node literally named "deactivate"), never
+// reaching DeactivatePath. The node must already exist; DeactivatePath on an
+// already-inactive node is idempotent (it re-sets a bool).
+func (s *Store) DeactivateFromInput(input string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.candidate == nil {
+		return fmt.Errorf("not in configuration mode")
+	}
+	if err := applyEditLine(s.candidate, "deactivate "+input); err != nil {
+		return err
+	}
+	s.dirty = true
+	return nil
+}
+
+// ActivateFromInput clears the inactive marker on the candidate node at the
+// given path (#2051), implementing the interactive Junos `activate <path>`
+// verb. Symmetric with DeactivateFromInput; ActivatePath on an already-active
+// node is idempotent.
+func (s *Store) ActivateFromInput(input string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.candidate == nil {
+		return fmt.Errorf("not in configuration mode")
+	}
+	if err := applyEditLine(s.candidate, "activate "+input); err != nil {
+		return err
+	}
+	s.dirty = true
+	return nil
+}
+
 // Copy duplicates a config subtree from srcPath to dstPath.
 func (s *Store) Copy(srcPath, dstPath []string) error {
 	s.mu.Lock()

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -573,7 +573,9 @@ func (s *Server) completeConfigPairs(words []string, partial string) []completio
 	}
 
 	switch resolvedTop {
-	case "set", "delete", "show", "edit":
+	case "set", "delete", "activate", "deactivate", "show", "edit":
+		// #2051: activate/deactivate complete with schema parity to delete
+		// (paths to existing nodes), reusing the shared schema completer.
 		pathWords := words[1:]
 		if resolvedPath, resolved := config.ResolveConsumedSetPathTokens(pathWords); resolved {
 			pathWords = resolvedPath

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -61,14 +61,26 @@ func (s *Server) Set(_ context.Context, req *pb.SetRequest) (*pb.SetResponse, er
 	// the junk path "set deactivate <path>" (a config node named after the
 	// verb) and the node is never marked inactive. The store wrappers strip
 	// the verb and route through applyEditLine (the centralized verb switch).
-	if rest, ok := strings.CutPrefix(input, "deactivate "); ok {
-		if err := s.store.DeactivateFromInput(rest); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	// Match the verb as the first whitespace-delimited token (not just an
+	// exact "deactivate "/"activate " prefix) so a tab separator or extra
+	// spaces still route, and a bare verb with no path returns an error
+	// instead of falling through to SetFromInput and creating a junk
+	// "deactivate"/"activate" node.
+	if fields := strings.Fields(input); len(fields) > 0 &&
+		(fields[0] == "deactivate" || fields[0] == "activate") {
+		verb := fields[0]
+		rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(input), verb))
+		if rest == "" {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"%s requires a configuration path", verb)
 		}
-		return &pb.SetResponse{}, nil
-	}
-	if rest, ok := strings.CutPrefix(input, "activate "); ok {
-		if err := s.store.ActivateFromInput(rest); err != nil {
+		var err error
+		if verb == "deactivate" {
+			err = s.store.DeactivateFromInput(rest)
+		} else {
+			err = s.store.ActivateFromInput(rest)
+		}
+		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		return &pb.SetResponse{}, nil

--- a/pkg/grpcapi/server_config.go
+++ b/pkg/grpcapi/server_config.go
@@ -3,6 +3,7 @@ package grpcapi
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -53,6 +54,24 @@ func (s *Server) Set(_ context.Context, req *pb.SetRequest) (*pb.SetResponse, er
 	}
 	if strings.HasPrefix(input, "insert ") {
 		return s.handleInsert(input)
+	}
+	// #2051: the remote CLI rides the Set RPC for activate/deactivate (no
+	// dedicated RPC). Prefix-route the verb to the store wrapper BEFORE the
+	// SetFromInput fall-through — otherwise the generic fall-through builds
+	// the junk path "set deactivate <path>" (a config node named after the
+	// verb) and the node is never marked inactive. The store wrappers strip
+	// the verb and route through applyEditLine (the centralized verb switch).
+	if rest, ok := strings.CutPrefix(input, "deactivate "); ok {
+		if err := s.store.DeactivateFromInput(rest); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		}
+		return &pb.SetResponse{}, nil
+	}
+	if rest, ok := strings.CutPrefix(input, "activate "); ok {
+		if err := s.store.ActivateFromInput(rest); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		}
+		return &pb.SetResponse{}, nil
 	}
 	if err := s.store.SetFromInput(input); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -135,8 +154,19 @@ func (s *Server) Load(_ context.Context, req *pb.LoadRequest) (*pb.LoadResponse,
 		if err := s.store.LoadMerge(req.Content); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
+	case "set":
+		// #2052: make `load set` a real service-mode op. LoadSet replays the
+		// flat command lines through applyEditLine, so a body containing
+		// `deactivate <path>` lines (emitted by `show | display set` for
+		// inactive nodes, #2008 H1) round-trips back to an inactive node.
+		// The applied-count is log-only (LoadResponse has no count field).
+		count, err := s.store.LoadSet(req.Content)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		}
+		slog.Info("load set applied", "commands", count)
 	default:
-		return nil, status.Errorf(codes.InvalidArgument, "unknown load mode: %s (use 'override' or 'merge')", req.Mode)
+		return nil, status.Errorf(codes.InvalidArgument, "unknown load mode: %s (use 'override', 'merge', or 'set')", req.Mode)
 	}
 	return &pb.LoadResponse{}, nil
 }

--- a/pkg/grpcapi/server_config_activate_test.go
+++ b/pkg/grpcapi/server_config_activate_test.go
@@ -112,3 +112,42 @@ func TestLoadRPCModeSetAppliesDeactivate(t *testing.T) {
 		t.Fatalf("Load mode=set dropped an active node:\n%s", out)
 	}
 }
+
+// #2059 (Copilot): the verb routing must match the first whitespace token, not
+// just an exact "deactivate "/"activate " prefix, so a bare verb errors instead
+// of falling through to SetFromInput (which would create a junk "deactivate"
+// node) and a tab-separated path still routes.
+func TestSetRPCDeactivateBareVerbErrorsNotMangled(t *testing.T) {
+	store := newGRPCConfigStore(t)
+	s := &Server{store: store}
+
+	// Bare verb, no path: must error, must NOT create a junk node.
+	if _, err := s.Set(context.Background(), &pb.SetRequest{Input: "deactivate"}); err == nil {
+		t.Fatal("Set(\"deactivate\") with no path must return an error")
+	}
+	out := store.ShowCandidateSet()
+	if strings.Contains(out, "set deactivate") || strings.Contains(out, "deactivate;") {
+		t.Fatalf("bare deactivate created a junk node:\n%s", out)
+	}
+	if !strings.Contains(out, "set system name-server 9.9.9.9") {
+		t.Fatalf("bare deactivate must not disturb existing config:\n%s", out)
+	}
+}
+
+func TestSetRPCDeactivateTabSeparatorRoutes(t *testing.T) {
+	store := newGRPCConfigStore(t)
+	s := &Server{store: store}
+
+	if _, err := s.Set(context.Background(), &pb.SetRequest{
+		Input: "deactivate\tsystem name-server 9.9.9.9",
+	}); err != nil {
+		t.Fatalf("Set(deactivate<tab>...) error = %v", err)
+	}
+	out := store.ShowCandidateSet()
+	if !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("tab-separated deactivate did not mark the node inactive:\n%s", out)
+	}
+	if strings.Contains(out, "set deactivate") {
+		t.Fatalf("tab-separated deactivate mangled into a junk set path:\n%s", out)
+	}
+}

--- a/pkg/grpcapi/server_config_activate_test.go
+++ b/pkg/grpcapi/server_config_activate_test.go
@@ -1,0 +1,114 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// newGRPCConfigStore returns a store in config mode with an active
+// system/name-server node staged, for activate/deactivate routing tests.
+func newGRPCConfigStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	for _, line := range []string{
+		"set system host-name keep",
+		"set system name-server 9.9.9.9",
+	} {
+		if _, err := store.LoadSet(line); err != nil {
+			t.Fatalf("LoadSet(%q) error = %v", line, err)
+		}
+	}
+	return store
+}
+
+// #2051 anti-mangling regression: the gRPC Set RPC must prefix-route a
+// `deactivate <path>` input to DeactivateFromInput so the node becomes ACTUALLY
+// inactive. Before the fix it fell through to SetFromInput, which parsed
+// `set deactivate <path>` and created a junk config node named "deactivate".
+// The assertion is on real inactivation (display-set emits `deactivate <path>`
+// only for an Inactive node), NOT merely a nil error — a no-error test would
+// have passed against the broken mangling behavior.
+func TestSetRPCDeactivateRoutesNotMangled(t *testing.T) {
+	store := newGRPCConfigStore(t)
+	s := &Server{store: store}
+
+	if _, err := s.Set(context.Background(), &pb.SetRequest{
+		Input: "deactivate system name-server 9.9.9.9",
+	}); err != nil {
+		t.Fatalf("Set(deactivate ...) error = %v", err)
+	}
+
+	out := store.ShowCandidateSet()
+	if !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("Set RPC did not actually mark the node inactive:\n%s", out)
+	}
+	// The smoking gun for the mangling regression: a node named "deactivate".
+	if strings.Contains(out, "set deactivate ") {
+		t.Fatalf("deactivate input mangled into a junk set path:\n%s", out)
+	}
+	if !strings.Contains(out, "set system host-name keep") {
+		t.Fatalf("active sibling lost:\n%s", out)
+	}
+}
+
+// The gRPC Set RPC must round-trip activate back to active.
+func TestSetRPCActivateRoutesNotMangled(t *testing.T) {
+	store := newGRPCConfigStore(t)
+	s := &Server{store: store}
+
+	if _, err := s.Set(context.Background(), &pb.SetRequest{
+		Input: "deactivate system name-server 9.9.9.9",
+	}); err != nil {
+		t.Fatalf("Set(deactivate ...) error = %v", err)
+	}
+	if _, err := s.Set(context.Background(), &pb.SetRequest{
+		Input: "activate system name-server 9.9.9.9",
+	}); err != nil {
+		t.Fatalf("Set(activate ...) error = %v", err)
+	}
+
+	out := store.ShowCandidateSet()
+	if strings.Contains(out, "deactivate ") {
+		t.Fatalf("activate via Set RPC did not clear the marker:\n%s", out)
+	}
+	if strings.Contains(out, "set activate ") {
+		t.Fatalf("activate input mangled into a junk set path:\n%s", out)
+	}
+}
+
+// #2052: the gRPC Load RPC with mode=="set" must replay flat lines through
+// LoadSet so a body containing `deactivate <path>` reconstructs an inactive
+// node. Before the fix mode=="set" hit the default branch and was rejected.
+func TestLoadRPCModeSetAppliesDeactivate(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	s := &Server{store: store}
+
+	body := strings.Join([]string{
+		"set system host-name keep",
+		"set system name-server 9.9.9.9",
+		"deactivate system name-server 9.9.9.9",
+	}, "\n")
+
+	if _, err := s.Load(context.Background(), &pb.LoadRequest{Mode: "set", Content: body}); err != nil {
+		t.Fatalf("Load(mode=set) error = %v", err)
+	}
+
+	out := store.ShowCandidateSet()
+	if !strings.Contains(out, "deactivate system name-server 9.9.9.9") {
+		t.Fatalf("Load mode=set did not preserve the deactivate marker:\n%s", out)
+	}
+	if !strings.Contains(out, "set system host-name keep") {
+		t.Fatalf("Load mode=set dropped an active node:\n%s", out)
+	}
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -587,7 +587,7 @@ func (*DeleteResponse) Descriptor() ([]byte, []int) {
 
 type LoadRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Mode          string                 `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`       // "override", "merge", or "replace"
+	Mode          string                 `protobuf:"bytes,1,opt,name=mode,proto3" json:"mode,omitempty"`       // "override", "merge", or "set" (#2052: set replays flat set/delete/deactivate/activate lines)
 	Content       string                 `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"` // full config text (hierarchical or set format)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -99,7 +99,7 @@ message DeleteRequest { string input = 1; }
 message DeleteResponse {}
 
 message LoadRequest {
-  string mode = 1;    // "override", "merge", or "replace"
+  string mode = 1;    // "override", "merge", or "set" (#2052: set replays flat set/delete/deactivate/activate lines)
   string content = 2; // full config text (hierarchical or set format)
 }
 message LoadResponse {}


### PR DESCRIPTION
Combined Batch B: completes the #2008 H1 `inactive:` marker by exposing the
interactive `activate`/`deactivate` verbs on every config surface (#2051) and
making `load set` a real service-mode op (#2052). Builds on the shipped,
idempotent primitives (`ConfigTree.DeactivatePath`/`ActivatePath`,
`applyEditLine`); no dataplane / per-packet / HA path touched.

## #2051 — activate/deactivate across all four surfaces

Store wrappers `DeactivateFromInput`/`ActivateFromInput`
(`pkg/configstore/store.go`) route through `applyEditLine` (the centralized
verb switch shared with `LoadSet`/`LoadMerge` replay) — NOT
`ParseSetCommand("set "+input)`, which would mangle the path into a junk node
named "deactivate". The four surfaces:

| Surface | Wiring |
|---|---|
| Local CLI | `pkg/cli/cli_dispatch.go` — two dispatch cases, prepend edit path |
| Remote CLI | `cmd/cli/shared.go` `dispatchConfig` — ride the `Set` RPC with the verb kept as input prefix |
| gRPC | `pkg/grpcapi/server_config.go` `Set` — prefix-route `deactivate `/`activate ` to the store wrappers BEFORE the `SetFromInput` fall-through (anti-mangling fix) |
| REST | `pkg/api/config.go` `configDeactivate/ActivateHandler` + `pkg/api/server.go` routes `POST /api/v1/config/{deactivate,activate}` |

cmdtree `ConfigTopLevel` lists both verbs; path completion has schema parity
with `delete` (reuses `CompleteSetPathWithValues` in `pkg/cli/completion.go`
and `pkg/grpcapi/server_cluster.go`).

**gRPC anti-mangling approach:** `Server.Set` checks `strings.CutPrefix(input,
"deactivate ")` / `"activate "` and routes to the store wrappers before the
generic `SetFromInput` fall-through. Without this, the fall-through parses
`set deactivate <path>` and creates a config node literally named
"deactivate". Verified non-tautological: removing the prefix-route makes
`TestSetRPCDeactivateRoutesNotMangled` fail on the leaked junk node.

## #2052 — load set as a real service-mode op

`mode == "set"` -> `store.LoadSet` on gRPC `Load` (`server_config.go`), REST
`configLoadHandler` (`pkg/api/config.go`), and remote CLI `handleLoad`
(`cmd/cli/main.go`, terminal + file). Applied-count is **log-only** (no
`LoadResponse` field). Proto comment fixed
(`proto/xpf/v1/xpf.proto` LoadRequest.mode: drop nonexistent `replace`, add
`set`) — comment-only, `xpf.pb.go` regenerated with a comment-only diff (no
wire change).

## Tests

All assert ACTUAL inactivation (display-set `deactivate <path>` line, a proxy
for `node.Inactive==true`), not merely a nil error:
- `pkg/configstore/activate_test.go` — wrappers mark/clear Inactive,
  idempotency, missing-path errors, not-in-config-mode.
- `pkg/grpcapi/server_config_activate_test.go` — Set RPC routes (not mangled);
  Load mode=set applies deactivate lines.
- `pkg/api/config_activate_test.go` — REST handlers; Load mode=set.
- `pkg/cli/cli_activate_test.go` — local dispatch + edit-path prefix.
- `pkg/cli/completion_activate_test.go` — cmdtree presence + schema-parity
  completion.

`go build ./...`, `go vet` (touched pkgs clean; two pre-existing findings in
untouched `cmd/cli/monitor.go` + `pkg/cli/cli.go`), and `go test` on
config/configstore/cli/grpcapi/api/cmd-cli/cmdtree all pass.

Docs: `docs/config-schema.md`, `pkg/config/README.md` (deferred increment now
shipped), `_Log.md`. Plan-doc edits on `research/review-015-triage` skipped
(code-focused per the directive); the two #2051 plan minors are folded in
(remote dispatch = `shared.go` `dispatchConfig`; schema-completion parity with
`delete`).

Closes #2051
Closes #2052

🤖 Generated with [Claude Code](https://claude.com/claude-code)