### PR TITLE
config: vSRX parity batch 2 — traceoptions packet-filter protocol (M8) + ssh key-exchange (H5) (#2008)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,35 @@
 # Action Log
 
+## 2026-06-20 — #2008 Increment-1 quick-wins BATCH 2 (M8 traceoptions packet-filter protocol, H5 ssh key-exchange)
+
+- **Timestamp**: 2026-06-20
+- **Action**: Close two vSRX config-parity gaps from #2008 on the
+  render/match paths. **M8** — traceoptions `packet-filter protocol`:
+  added the `protocol` child to the packet-filter schema, extract into
+  `TracePacketFilter.Protocol`, and an ANDed compare in
+  `matchFilters()` (`pkg/logging/trace.go`) via a `normalizeTraceProto`
+  helper that canonicalizes both Junos protocol names (tcp/udp/icmp/icmp6)
+  and numbers (6/17/1/58) to the same string `protoName` renders, so a
+  config filter value matches the EventRecord protocol regardless of name
+  vs number spelling. **H5** — `system services ssh key-exchange`: added a
+  repeatable (`multi: true`) typed leaf, extract into
+  `SSHServiceConfig.KeyExchange []string`, and render to the sshd
+  `KexAlgorithms` drop-in line. Extracted the render body-building into a
+  pure `buildSSHDConfig` helper so it is unit-testable and so key-exchange
+  renders independently of root-login (the old `applySSHConfig`
+  early-returned when root-login was unset).
+- **File(s)**: pkg/config/types_security.go, pkg/config/schema_security.go,
+  pkg/config/compiler_security.go, pkg/config/types_system.go,
+  pkg/config/schema_system.go, pkg/config/compiler_system.go,
+  pkg/logging/trace.go, pkg/logging/trace_test.go,
+  pkg/config/parser_ast_test.go, pkg/config/parser_system_test.go,
+  pkg/daemon/daemon_system.go, pkg/daemon/daemon_ssh_test.go,
+  docs/feature-gaps.md, docs/config-schema.md, _Log.md
+- **Validation**: `go build ./...` clean; `go vet ./pkg/config
+  ./pkg/logging ./pkg/daemon` clean except two PRE-EXISTING
+  daemon_flow.go:152,216 lock-copy warnings present on origin/master;
+  `go test ./pkg/config ./pkg/logging ./pkg/daemon -count=1` all pass.
+
 ## 2026-06-20 — #2049 enforce dynamic-address feed prefixes in the userspace dataplane
 
 - **Timestamp**: 2026-06-20

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -230,7 +230,10 @@ reserved for whole-dataplane selection where a rewrite shim
   commit; same-commit definition + reference passes; `best-effort` is
   always resolvable; the other Junos default classes are deliberately NOT
   implicit — xpf's runtime does not define them); (c) **system/services**:
-  22 typed slots (name-server, ssh root-login enum, the dataplane
+  22 typed slots (name-server, ssh root-login enum, ssh key-exchange
+  multi-value list (H5/#2008; renders to sshd `KexAlgorithms` —
+  `pkg/daemon/daemon_system.go` `buildSSHDConfig`; left untyped/no enum
+  because sshd validates the algorithm spellings at reload), the dataplane
   workers/ring-entries/poll-mode/rss-indirection/claim-host-tunables/
   netdev-budget/coalescence knobs, the rpm probe knobs, ip-monitoring
   hold-down / preferred-metric) plus the `validateMultiValueLeaf`

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -200,7 +200,7 @@ xpf implements 11 screen checks (land, syn-flood, ping-death, teardrop, rate-lim
 
 ## 10. Security Flow Enhancements
 
-xpf has TCP session timeouts (established, initial, closing, time-wait), UDP/ICMP timeouts, TCP MSS clamping (IPsec, GRE in/out), allow-dns-reply, allow-embedded-icmp, GRE performance acceleration, and flow traceoptions.
+xpf has TCP session timeouts (established, initial, closing, time-wait), UDP/ICMP timeouts, TCP MSS clamping (IPsec, GRE in/out), allow-dns-reply, allow-embedded-icmp, GRE performance acceleration, and flow traceoptions (packet-filter source-prefix / destination-prefix / `protocol` — M8/#2008).
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
@@ -424,10 +424,11 @@ xpf manages all interfaces with .link/.network files, supports VLANs, tunnel int
 
 ## 22. System Enhancements
 
-xpf has hostname, domain-name, domain-search, timezone, name-servers, NTP, services (SSH, web-management, DNS), syslog, SNMP, login users/classes (including per-user `authentication encrypted-password` for console login — #1944, see [docs/system-login.md](system-login.md)), root-authentication, archival, internet-options, backup-router, DHCP server (Kea), and ~~DPDK~~ config (DPDK retired #1525, removed in #1527/#1528).
+xpf has hostname, domain-name, domain-search, timezone, name-servers, NTP, services (SSH with root-login and key-exchange/`KexAlgorithms`, web-management, DNS), syslog, SNMP, login users/classes (including per-user `authentication encrypted-password` for console login — #1944, see [docs/system-login.md](system-login.md)), root-authentication, archival, internet-options, backup-router, DHCP server (Kea), and ~~DPDK~~ config (DPDK retired #1525, removed in #1527/#1528).
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
+| **SSH Key Exchange** | `system services ssh key-exchange ...` | Restrict the SSH key-exchange (KEX) algorithms the firewall offers | Medium | Done (H5/#2008 — repeatable leaf rendered to the sshd `KexAlgorithms` drop-in, `pkg/daemon/daemon_system.go`) |
 | **RADIUS Server Config** | `system radius-server ... port ... secret ...` | RADIUS server definitions for AAA (authentication, authorization, accounting) | Medium | Missing |
 | **TACACS+ Server Config** | `system tacplus-server ... port ... secret ...` | TACACS+ server definitions for per-command authorization | Medium | Missing |
 | **Authentication Order** | `system authentication-order [radius tacplus password]` | Control order of authentication methods for management access | Medium | Missing |

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -841,6 +841,9 @@ func compileFlow(node *Node, sec *SecurityConfig) error {
 			if dpNode := pfInst.node.FindChild("destination-prefix"); dpNode != nil {
 				pf.DestinationPrefix = nodeVal(dpNode)
 			}
+			if protoNode := pfInst.node.FindChild("protocol"); protoNode != nil {
+				pf.Protocol = nodeVal(protoNode)
+			}
 			to.PacketFilters = append(to.PacketFilters, pf)
 		}
 		sec.Flow.Traceoptions = to

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -322,6 +322,11 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 			if rl := sshNode.FindChild("root-login"); rl != nil && len(rl.Keys) >= 2 {
 				sys.Services.SSH.RootLogin = rl.Keys[1]
 			}
+			for _, kx := range sshNode.FindChildren("key-exchange") {
+				if v := nodeVal(kx); v != "" {
+					sys.Services.SSH.KeyExchange = append(sys.Services.SSH.KeyExchange, v)
+				}
+			}
 		}
 		// DNS service
 		if dnsNode := svcNode.FindChild("dns"); dnsNode != nil {

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -2484,6 +2484,45 @@ func TestFlowTraceoptions(t *testing.T) {
 	}
 }
 
+// TestFlowTraceoptionsPacketFilterProtocol verifies the M8 (#2008)
+// traceoptions packet-filter `protocol` child compiles into the typed
+// TracePacketFilter.Protocol field via the flat-set path (ParseSetCommand +
+// SetPath, per the project testing rule).
+func TestFlowTraceoptionsPacketFilterProtocol(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set security flow traceoptions file flowtrace.log",
+		"set security flow traceoptions packet-filter f0 source-prefix 10.0.1.0/24",
+		"set security flow traceoptions packet-filter f0 protocol tcp",
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	to := cfg.Security.Flow.Traceoptions
+	if to == nil || len(to.PacketFilters) != 1 {
+		t.Fatalf("PacketFilters = %v, want 1", to)
+	}
+	pf := to.PacketFilters[0]
+	if pf.Name != "f0" {
+		t.Errorf("Name = %q, want f0", pf.Name)
+	}
+	if pf.SourcePrefix != "10.0.1.0/24" {
+		t.Errorf("SourcePrefix = %q, want 10.0.1.0/24", pf.SourcePrefix)
+	}
+	if pf.Protocol != "tcp" {
+		t.Errorf("Protocol = %q, want tcp", pf.Protocol)
+	}
+}
+
 func TestFormatJSON(t *testing.T) {
 	input := `system {
     host-name fw1;

--- a/pkg/config/parser_system_test.go
+++ b/pkg/config/parser_system_test.go
@@ -1567,3 +1567,44 @@ system {
 		}
 	})
 }
+
+// TestSSHKeyExchangeCompile verifies the H5 (#2008) ssh key-exchange leaf
+// parses + compiles into SSHServiceConfig.KeyExchange, preserving order and
+// supporting multiple repeated values, via the flat-set path (ParseSetCommand
+// + SetPath, per the project testing rule).
+func TestSSHKeyExchangeCompile(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set system services ssh root-login deny",
+		"set system services ssh key-exchange ecdh-sha2-nistp256",
+		"set system services ssh key-exchange curve25519-sha256",
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.System.Services == nil || cfg.System.Services.SSH == nil {
+		t.Fatal("SSH service config is nil")
+	}
+	ssh := cfg.System.Services.SSH
+	if ssh.RootLogin != "deny" {
+		t.Errorf("RootLogin = %q, want deny", ssh.RootLogin)
+	}
+	want := []string{"ecdh-sha2-nistp256", "curve25519-sha256"}
+	if len(ssh.KeyExchange) != len(want) {
+		t.Fatalf("KeyExchange = %v, want %v", ssh.KeyExchange, want)
+	}
+	for i := range want {
+		if ssh.KeyExchange[i] != want[i] {
+			t.Errorf("KeyExchange[%d] = %q, want %q", i, ssh.KeyExchange[i], want[i])
+		}
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -271,7 +271,7 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			"packet-filter": {desc: "Trace packet filter name", args: 1, placeholder: "<filter-name>", children: map[string]*schemaNode{
 				"source-prefix":      {desc: "Source prefix to trace", args: 1, placeholder: "<prefix>", children: nil},
 				"destination-prefix": {desc: "Destination prefix to trace", args: 1, placeholder: "<prefix>", children: nil},
-				"protocol":           {desc: "Protocol to trace (name or number)", args: 1, placeholder: "<tcp|udp|icmp|number>", children: nil},
+				"protocol":           {desc: "Protocol to trace (name or number)", args: 1, placeholder: "<tcp|udp|icmp|icmp6|number>", children: nil},
 			}},
 		}},
 	}},

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -271,6 +271,7 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			"packet-filter": {desc: "Trace packet filter name", args: 1, placeholder: "<filter-name>", children: map[string]*schemaNode{
 				"source-prefix":      {desc: "Source prefix to trace", args: 1, placeholder: "<prefix>", children: nil},
 				"destination-prefix": {desc: "Destination prefix to trace", args: 1, placeholder: "<prefix>", children: nil},
+				"protocol":           {desc: "Protocol to trace (name or number)", args: 1, placeholder: "<tcp|udp|icmp|number>", children: nil},
 			}},
 		}},
 	}},

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -287,6 +287,17 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 				validator:     ValidateEnum([]string{"allow", "deny", "deny-password"}),
 				children:      nil,
 			},
+			// H5 (#2008): repeatable key-exchange method → sshd
+			// KexAlgorithms (pkg/daemon/daemon_system.go applySSHConfig).
+			// Junos takes a free-form algorithm-name list; sshd validates
+			// the spellings at reload, so no enum here.
+			"key-exchange": {
+				desc:        "SSH key-exchange method (KexAlgorithms)",
+				args:        1,
+				multi:       true,
+				placeholder: "<key-exchange-method>",
+				children:    nil,
+			},
 		}},
 		"netconf": {desc: "NETCONF service", children: map[string]*schemaNode{
 			"ssh": {desc: "NETCONF over SSH", children: nil},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -95,6 +95,7 @@ type TracePacketFilter struct {
 	Name              string
 	SourcePrefix      string
 	DestinationPrefix string
+	Protocol          string // protocol name (tcp|udp|icmp|...) or number
 }
 
 // ALGConfig holds ALG (Application Layer Gateway) disable flags.

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -196,7 +196,8 @@ type SystemServicesConfig struct {
 
 // SSHServiceConfig holds SSH service settings.
 type SSHServiceConfig struct {
-	RootLogin string // "allow", "deny", "deny-password"
+	RootLogin   string   // "allow", "deny", "deny-password"
+	KeyExchange []string // sshd KexAlgorithms (key-exchange methods)
 }
 
 // WebManagementConfig holds web management settings.

--- a/pkg/daemon/daemon_ssh_test.go
+++ b/pkg/daemon/daemon_ssh_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestBuildSSHDConfigKeyExchange verifies the H5 (#2008) ssh key-exchange
+// leaf renders to an sshd KexAlgorithms line, that multiple methods are
+// comma-joined, and that key-exchange renders independently of root-login.
+func TestBuildSSHDConfigKeyExchange(t *testing.T) {
+	tests := []struct {
+		name string
+		ssh  *config.SSHServiceConfig
+		want []string // substrings that must be present
+		not  []string // substrings that must be absent
+		// empty=true means buildSSHDConfig must return ""
+		empty bool
+	}{
+		{
+			name:  "nil",
+			ssh:   nil,
+			empty: true,
+		},
+		{
+			name:  "no-settings",
+			ssh:   &config.SSHServiceConfig{},
+			empty: true,
+		},
+		{
+			name: "key-exchange-only",
+			ssh:  &config.SSHServiceConfig{KeyExchange: []string{"ecdh-sha2-nistp256"}},
+			want: []string{"KexAlgorithms ecdh-sha2-nistp256"},
+			not:  []string{"PermitRootLogin"},
+		},
+		{
+			name: "multiple-key-exchange-comma-joined",
+			ssh: &config.SSHServiceConfig{KeyExchange: []string{
+				"ecdh-sha2-nistp256", "curve25519-sha256",
+			}},
+			want: []string{"KexAlgorithms ecdh-sha2-nistp256,curve25519-sha256"},
+		},
+		{
+			name: "root-login-and-key-exchange",
+			ssh: &config.SSHServiceConfig{
+				RootLogin:   "deny",
+				KeyExchange: []string{"curve25519-sha256"},
+			},
+			want: []string{"PermitRootLogin no", "KexAlgorithms curve25519-sha256"},
+		},
+		{
+			name: "root-login-only",
+			ssh:  &config.SSHServiceConfig{RootLogin: "allow"},
+			want: []string{"PermitRootLogin yes"},
+			not:  []string{"KexAlgorithms"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSSHDConfig(tt.ssh)
+			if tt.empty {
+				if got != "" {
+					t.Fatalf("buildSSHDConfig = %q, want empty", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("buildSSHDConfig = empty, want content")
+			}
+			for _, w := range tt.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("output missing %q\ngot:\n%s", w, got)
+				}
+			}
+			for _, n := range tt.not {
+				if strings.Contains(got, n) {
+					t.Errorf("output unexpectedly contains %q\ngot:\n%s", n, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -886,25 +886,13 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 	}
 
 	ssh := cfg.System.Services.SSH
-	if ssh.RootLogin == "" {
-		return
-	}
 
-	// Map Junos values to sshd_config PermitRootLogin values
-	var permitRoot string
-	switch ssh.RootLogin {
-	case "allow":
-		permitRoot = "yes"
-	case "deny":
-		permitRoot = "no"
-	case "deny-password":
-		permitRoot = "prohibit-password"
-	default:
-		return
+	content := buildSSHDConfig(ssh)
+	if content == "" {
+		return // nothing to manage
 	}
 
 	confPath := "/etc/ssh/sshd_config.d/xpf.conf"
-	content := fmt.Sprintf("# Managed by xpf — do not edit\nPermitRootLogin %s\n", permitRoot)
 
 	current, _ := os.ReadFile(confPath)
 	if string(current) == content {
@@ -927,7 +915,42 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 			"err", err, "output", strings.TrimSpace(string(out)))
 		return
 	}
-	slog.Info("SSH config applied", "permit_root_login", permitRoot)
+	slog.Info("SSH config applied",
+		"root_login", ssh.RootLogin,
+		"key_exchange", strings.Join(ssh.KeyExchange, ","))
+}
+
+// buildSSHDConfig renders the xpf-managed sshd drop-in body from the SSH
+// service config, or "" when there is nothing to manage. Each setting is an
+// independent line: root-login → PermitRootLogin, key-exchange → KexAlgorithms
+// (H5, #2008). sshd validates algorithm spellings at reload, so xpf does not
+// enum-check the key-exchange list.
+func buildSSHDConfig(ssh *config.SSHServiceConfig) string {
+	if ssh == nil {
+		return ""
+	}
+	var lines []string
+	if ssh.RootLogin != "" {
+		var permitRoot string
+		switch ssh.RootLogin {
+		case "allow":
+			permitRoot = "yes"
+		case "deny":
+			permitRoot = "no"
+		case "deny-password":
+			permitRoot = "prohibit-password"
+		}
+		if permitRoot != "" {
+			lines = append(lines, "PermitRootLogin "+permitRoot)
+		}
+	}
+	if len(ssh.KeyExchange) > 0 {
+		lines = append(lines, "KexAlgorithms "+strings.Join(ssh.KeyExchange, ","))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return "# Managed by xpf — do not edit\n" + strings.Join(lines, "\n") + "\n"
 }
 
 // applyRootAuth applies root-authentication config: encrypted-password and SSH keys.

--- a/pkg/logging/trace.go
+++ b/pkg/logging/trace.go
@@ -28,6 +28,7 @@ type traceFilter struct {
 	name   string
 	srcNet netip.Prefix
 	dstNet netip.Prefix
+	proto  string // normalized protocol name (e.g. "TCP"); "" = any
 }
 
 // NewTraceWriter creates a trace writer from flow traceoptions config.
@@ -87,6 +88,9 @@ func NewTraceWriter(opts *config.FlowTraceoptions) (*TraceWriter, error) {
 				continue
 			}
 			f.dstNet = prefix
+		}
+		if pf.Protocol != "" {
+			f.proto = normalizeTraceProto(pf.Protocol)
 		}
 		tw.filters = append(tw.filters, f)
 	}
@@ -171,14 +175,38 @@ func (tw *TraceWriter) matchFilters(rec EventRecord) bool {
 	srcAddr := extractAddr(rec.SrcAddr)
 	dstAddr := extractAddr(rec.DstAddr)
 
+	recProto := normalizeTraceProto(rec.Protocol)
+
 	for _, f := range tw.filters {
 		srcMatch := !f.srcNet.IsValid() || (srcAddr.IsValid() && f.srcNet.Contains(srcAddr))
 		dstMatch := !f.dstNet.IsValid() || (dstAddr.IsValid() && f.dstNet.Contains(dstAddr))
-		if srcMatch && dstMatch {
+		protoMatch := f.proto == "" || f.proto == recProto
+		if srcMatch && dstMatch && protoMatch {
 			return true
 		}
 	}
 	return false
+}
+
+// normalizeTraceProto canonicalizes a protocol identifier so a config filter
+// value (a Junos name like "tcp" or a numeric value like "6") compares equal
+// to the EventRecord.Protocol string (which protoName renders as "TCP",
+// "UDP", "ICMP", "ICMPv6", or a decimal string). Names are upper-cased and
+// known numbers are mapped to their canonical name.
+func normalizeTraceProto(p string) string {
+	up := strings.ToUpper(strings.TrimSpace(p))
+	switch up {
+	case "1", "ICMP":
+		return "ICMP"
+	case "6", "TCP":
+		return "TCP"
+	case "17", "UDP":
+		return "UDP"
+	case "58", "ICMPV6", "ICMP6":
+		return "ICMPv6"
+	default:
+		return up
+	}
 }
 
 // extractAddr parses an IP address from "IP:port" or "[IPv6]:port" format.

--- a/pkg/logging/trace_test.go
+++ b/pkg/logging/trace_test.go
@@ -1,0 +1,81 @@
+package logging
+
+import (
+	"net/netip"
+	"testing"
+)
+
+// TestMatchFiltersProtocol verifies the M8 (#2008) traceoptions packet-filter
+// `protocol` match: a filter with protocol set matches only records of that
+// protocol, accepts both Junos protocol names and numbers, and an unset
+// protocol matches any protocol.
+func TestMatchFiltersProtocol(t *testing.T) {
+	tests := []struct {
+		name        string
+		filterProto string // config value (name or number); "" = no protocol filter
+		recProto    string // EventRecord.Protocol (as rendered by protoName)
+		want        bool
+	}{
+		{"name-tcp-matches-tcp", "tcp", "TCP", true},
+		{"name-tcp-rejects-udp", "tcp", "UDP", false},
+		{"name-udp-matches-udp", "udp", "UDP", true},
+		{"name-icmp-matches-icmp", "icmp", "ICMP", true},
+		{"name-icmp6-matches-icmpv6", "icmp6", "ICMPv6", true},
+		{"number-6-matches-tcp", "6", "TCP", true},
+		{"number-17-matches-udp", "17", "UDP", true},
+		{"number-1-matches-icmp", "1", "ICMP", true},
+		{"number-58-matches-icmpv6", "58", "ICMPv6", true},
+		{"number-6-rejects-udp", "6", "UDP", false},
+		{"unconfigured-matches-tcp", "", "TCP", true},
+		{"unconfigured-matches-udp", "", "UDP", true},
+		{"uppercase-config-matches", "TCP", "TCP", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := traceFilter{name: "f"}
+			if tt.filterProto != "" {
+				f.proto = normalizeTraceProto(tt.filterProto)
+			}
+			tw := &TraceWriter{filters: []traceFilter{f}}
+			rec := EventRecord{
+				SrcAddr:  "10.0.1.5:1000",
+				DstAddr:  "10.0.2.5:80",
+				Protocol: tt.recProto,
+			}
+			if got := tw.matchFilters(rec); got != tt.want {
+				t.Errorf("matchFilters(proto-filter=%q, rec=%q) = %v, want %v",
+					tt.filterProto, tt.recProto, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMatchFiltersProtocolWithPrefix verifies protocol is ANDed with the
+// existing source/destination prefix match: a record matches only when it
+// satisfies prefix AND protocol.
+func TestMatchFiltersProtocolWithPrefix(t *testing.T) {
+	tw := &TraceWriter{
+		filters: []traceFilter{{
+			name:   "f",
+			srcNet: netip.MustParsePrefix("10.0.1.0/24"),
+			proto:  normalizeTraceProto("tcp"),
+		}},
+	}
+
+	cases := []struct {
+		src   string
+		proto string
+		want  bool
+	}{
+		{"10.0.1.5:1000", "TCP", true},  // prefix + proto both match
+		{"10.0.1.5:1000", "UDP", false}, // prefix matches, proto does not
+		{"10.0.9.5:1000", "TCP", false}, // proto matches, prefix does not
+	}
+	for _, c := range cases {
+		rec := EventRecord{SrcAddr: c.src, DstAddr: "10.0.2.5:80", Protocol: c.proto}
+		if got := tw.matchFilters(rec); got != c.want {
+			t.Errorf("matchFilters(src=%s proto=%s) = %v, want %v", c.src, c.proto, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Increment-1 quick-wins **batch 2** for #2008 — two vSRX config-parity gaps
on the render / match paths, each verified still un-shipped on current
master before implementing. One PR, two logical commits.

### M8 — traceoptions packet-filter `protocol`
`security flow traceoptions packet-filter <name> protocol <p>` was silently
dropped (the packet-filter schema had only `source-prefix` /
`destination-prefix` children, no extract, no match), so a trace scoped to
one protocol still captured every protocol.

- Schema `protocol` child + extract into `TracePacketFilter.Protocol`.
- ANDed compare in `TraceWriter.matchFilters` (`pkg/logging/trace.go`) via a
  `normalizeTraceProto` helper that canonicalizes both Junos protocol names
  (tcp/udp/icmp/icmp6) and numbers (6/17/1/58) to the string `protoName`
  already renders into `EventRecord.Protocol`, so the filter matches
  regardless of name-vs-number spelling. Unset protocol = match any
  (unchanged).
- Tests: flat-set compile test (`ParseSetCommand` + `SetPath`) + trace-side
  table tests (name/number/unset, protocol ANDed with source-prefix).

### H5 — ssh `key-exchange`
`system services ssh key-exchange <method>` (restrict the offered SSH KEX
algorithms) had no schema leaf, typed field, or render path — it was
ignored and the sshd KEX set stayed at the base-image default.

- Repeatable typed leaf (`multi: true`) → `SSHServiceConfig.KeyExchange`
  → comma-joined sshd `KexAlgorithms` drop-in line. No enum: sshd validates
  spellings at reload, so an enum would false-reject newer/site methods.
- Render body-building extracted into a pure `buildSSHDConfig` helper so it
  is unit-testable and so key-exchange renders independently of root-login
  (the old `applySSHConfig` early-returned when root-login was unset).
  `PermitRootLogin` behavior unchanged.
- Tests: flat-set compile test (multiple values accumulate in order) +
  daemon-side `buildSSHDConfig` table test.

## Validation (in worktree)
- `go build ./...` clean.
- `go vet ./pkg/config ./pkg/logging ./pkg/daemon` clean except two
  **pre-existing** `daemon_flow.go:152,216` lock-copy warnings present on
  origin/master (unrelated to this change).
- `go test ./pkg/config ./pkg/logging ./pkg/daemon -count=1` all pass.

## Docs
- `docs/feature-gaps.md`: §10 flow line (traceoptions protocol filter), §22
  System Enhancements (SSH key-exchange row + services summary).
- `docs/config-schema.md`: system/services typed-leaf note for ssh
  key-exchange.
- `_Log.md`: batch-2 entry.

(The #2008 gap-tracking triage doc lives on the `research/2008-parity-triage`
branch, not master, so it is not edited here.)

Companion-free per the dispatch; parent serializes review. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)