### PR TITLE
#2008 Tier-2: event-policy attributes-match regex (M7) + allow-dataplane-sleep schema/warn (H13 Stage 1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -24,6 +24,23 @@
   pkg/config/event_options_match_test.go, pkg/config/compiler.go,
   docs/feature-gaps.md
 
+- **Timestamp**: 2026-06-20
+- **Action**: H13 Stage 1 — `forwarding-options allow-dataplane-sleep` schema
+  + field + commit warning. The leaf was previously accepted only via the
+  no-schema-match fall-through and silently dropped by
+  `compileForwardingOptions`. Added the typed presence-flag schema leaf
+  (mirroring `power-mode-disable`), the
+  `ForwardingOptionsConfig.AllowDataplaneSleep` field, compiler extraction,
+  and an accepted-but-unenforced commit warning in `ValidateConfig`
+  (mirroring the persist-groups-inheritance / dns-proxy warnings). The
+  idle-yield dataplane runtime (Stage 2) is lab-gated and NOT implemented
+  here. Tests: leaf parses + field set + warning emitted, absent-leaf no
+  warning, schema completion offers the leaf.
+- **File(s)**: pkg/config/schema_routing.go, pkg/config/types_system.go,
+  pkg/config/compiler_services.go, pkg/config/compiler.go,
+  pkg/config/allow_dataplane_sleep_test.go, docs/feature-gaps.md,
+  docs/config-schema.md
+
 ## 2026-06-20 — #2008 Increment-1 quick-wins batch 1
 
 - **Timestamp**: 2026-06-20

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,29 @@
 # Action Log
 
+## 2026-06-20 — #2008 Increment-2 (M7 + H13 Stage 1)
+
+- **Timestamp**: 2026-06-20
+- **Action**: M7 — event-options `attributes-match` literal → regex. The
+  matcher (`attributesMatch`) did literal string equality; Junos `matches`
+  is a regex. Switched to RE2 regex (unanchored = substring, like Junos),
+  compiled once at `Apply()` time and cached by pattern string so the event
+  hot path never recompiles. Added commit-time pattern validation
+  (`ValidateEventAttributesMatch` wired into `CompileConfig`) so an
+  uncompilable regex is rejected at commit instead of silently dropped at
+  runtime. Shared the parse seam (`ParseEventAttributesMatch`) between the
+  compiler validator and the engine so they cannot drift. Documented the
+  literal→regex behavior change (correct Junos behavior, not
+  behavior-preserving for stored metacharacter literals). Attribute field
+  set kept at `test-owner`/`test-name` (the only `rpm.Event` fields);
+  field-widening deferred. Tests: config (parse, valid compiles, invalid
+  rejected-at-commit, malformed-not-rejected, direct validator) + eventengine
+  (anchored exact, unanchored substring, metacharacters-as-regex, test-name
+  field, unknown-field-ignored, cached-at-Apply no-recompile, AND semantics).
+- **File(s)**: pkg/eventengine/engine.go, pkg/eventengine/engine_test.go,
+  pkg/eventengine/README.md, pkg/config/event_options_match.go,
+  pkg/config/event_options_match_test.go, pkg/config/compiler.go,
+  docs/feature-gaps.md
+
 ## 2026-06-20 — #2008 Increment-1 quick-wins batch 1
 
 - **Timestamp**: 2026-06-20

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -465,6 +465,13 @@ the value sits in a single typed slot:
     from single-value REPLACE to named-container APPEND — benign: a bare
     no-port server compiles `Port==0` and the snapshot builder skips it, and
     real multi-collector configs already take the container path.
+  - `forwarding-options allow-dataplane-sleep` (#2008 H13 Stage 1) — a
+    presence-only flag (no value, `children: nil`). Previously accepted via the
+    no-schema-match fall-through and silently dropped; now a typed leaf that
+    compiles into `ForwardingOptionsConfig.AllowDataplaneSleep` and emits an
+    accepted-but-unenforced commit warning (the userspace workers busy-poll;
+    the idle-yield runtime is Stage 2, lab-gated). Same shape as the
+    `security flow power-mode-disable` presence flag.
 
 - **Compiler AST pre-walk (Tier 3 — the `validateVRRPTrackInterfaceAST`
   precedent):** `security flow tcp-mss {ipsec-vpn|gre-in|gre-out|all-tcp}`

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -610,3 +610,16 @@ Tier-2 gaps from the `#2008` parity audit researched in
   `test-owner` / `test-name` (the only fields on `rpm.Event`); widening the
   field surface is deferred until more attributes are exposed. See
   `pkg/eventengine/README.md`.
+- **H13 Stage 1 `forwarding-options allow-dataplane-sleep`** — DONE
+  (schema + field + commit warning). The leaf was previously accepted as a
+  no-schema-match fall-through and silently dropped by
+  `compileForwardingOptions`. Stage 1 adds the typed presence-flag schema leaf
+  (`pkg/config/schema_routing.go`), the `ForwardingOptionsConfig.AllowDataplaneSleep`
+  field (`pkg/config/types_system.go`), compiler extraction
+  (`pkg/config/compiler_services.go`), and a commit warning that the knob is
+  accepted but the idle-yield runtime is not yet implemented (the userspace
+  workers busy-poll), mirroring the `persist-groups-inheritance` /
+  `dns-proxy` accepted-but-unenforced warnings. Stage 2 (actual worker
+  idle-yield) is lab-gated and deferred per the research doc — the busy-poll
+  cold-start latency sensitivity (#1782) is the reason it needs explicit
+  validation before enabling.

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -588,3 +588,25 @@ drift) closed in `fix/2008-quickwins-batch1`:
   `config-viewer` RBAC entry (PermView) so the schema enum and the runtime RBAC
   table cannot drift. Mirrors the SNMP `authorization` enum leaf. See
   `docs/system-login.md`.
+
+## #2008 vSRX config-parity closures (Increment 2)
+
+Tier-2 gaps from the `#2008` parity audit researched in
+`docs/research/2008-tier2/plan.md`:
+
+- **M7 `event-options policy attributes-match`** — DONE (literal → regex).
+  Junos `attributes-match "<event>.<attribute> matches <pattern>"` is a regex
+  match; xpf previously did literal string equality
+  (`pkg/eventengine/engine.go` `attributesMatch`). The matcher now treats the
+  pattern as an RE2 regex (unanchored = substring, like Junos), compiled once
+  at `Apply()` time and cached by pattern string so the event hot path never
+  recompiles. Commit-time validation rejects an uncompilable pattern
+  (`config.ValidateEventAttributesMatch` via `CompileConfig`,
+  `pkg/config/event_options_match.go`). The parse/validate seam
+  (`config.ParseEventAttributesMatch`) is shared between the compiler and the
+  engine so they cannot drift. **Behavior-change note:** this is NOT
+  behavior-preserving for a stored literal containing regex metacharacters —
+  but regex IS the correct Junos behavior. The supported attribute set stays
+  `test-owner` / `test-name` (the only fields on `rpm.Event`); widening the
+  field surface is deferred until more attributes are exposed. See
+  `pkg/eventengine/README.md`.

--- a/pkg/config/allow_dataplane_sleep_test.go
+++ b/pkg/config/allow_dataplane_sleep_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #2008 H13 Stage 1 — forwarding-options allow-dataplane-sleep.
+// Stage 1 is schema + typed field + an accepted-but-unenforced commit
+// warning; the idle-yield dataplane runtime is Stage 2 (deferred, lab-gated).
+
+// The leaf parses and compiles onto the typed field, and commit emits the
+// accepted-but-unenforced warning.
+func TestAllowDataplaneSleep_ParsesFieldSetAndWarns(t *testing.T) {
+	cfg := compileSetLines(t, []string{
+		`set forwarding-options allow-dataplane-sleep`,
+	})
+
+	if !cfg.ForwardingOptions.AllowDataplaneSleep {
+		t.Fatal("allow-dataplane-sleep did not set ForwardingOptions.AllowDataplaneSleep")
+	}
+
+	warnings := strings.Join(cfg.Warnings, "\n")
+	if !strings.Contains(warnings, "allow-dataplane-sleep") {
+		t.Fatalf("expected an allow-dataplane-sleep commit warning, got %v", cfg.Warnings)
+	}
+	if !strings.Contains(warnings, "not yet implemented") &&
+		!strings.Contains(warnings, "accepted-only") {
+		t.Fatalf("warning does not flag the knob as unenforced: %v", cfg.Warnings)
+	}
+}
+
+// Absent leaf: field stays false and no spurious warning is emitted.
+func TestAllowDataplaneSleep_AbsentNoWarn(t *testing.T) {
+	cfg := compileSetLines(t, []string{
+		`set forwarding-options family inet6 mode flow-based`,
+	})
+	if cfg.ForwardingOptions.AllowDataplaneSleep {
+		t.Fatal("AllowDataplaneSleep set without the leaf configured")
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "allow-dataplane-sleep") {
+			t.Fatalf("unexpected allow-dataplane-sleep warning when leaf absent: %q", w)
+		}
+	}
+}
+
+// The schema accepts the leaf via structural completion (it is a real typed
+// leaf now, not a no-schema-match fall-through).
+func TestAllowDataplaneSleep_SchemaCompletes(t *testing.T) {
+	results := CompleteSetPathWithValues([]string{"forwarding-options"}, nil)
+	if !containsCompletionName(results, "allow-dataplane-sleep") {
+		t.Fatalf("allow-dataplane-sleep not offered by schema completion under forwarding-options: %v",
+			completionNames(results))
+	}
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -125,6 +125,14 @@ type compileOpts struct {
 	// compile decision and deliberately does NOT live in SchemaValidate
 	// (which only warns on the tolerant paths since #1319 PR 2).
 	lenientPolicyMatchAddress bool
+	// lenientEventAttributesMatch downgrades an uncompilable
+	// event-options attributes-match regex from a hard error to a warning
+	// on the tolerant load path. A config persisted under pre-#2008 xpf
+	// (literal-equality matcher, any string accepted) may hold a pattern
+	// that is not valid RE2; a node upgrading to the regex matcher must
+	// still boot through that already-committed config rather than fail to
+	// load. Commit stays strict (see the validator call site).
+	lenientEventAttributesMatch bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -151,6 +159,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientDeviceMap:             true,
 		lenientPolicyMatchAddress:    true,
 		lenientTCPMSSRange:           true,
+		lenientEventAttributesMatch: true,
 	})
 }
 
@@ -228,6 +237,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientDeviceMap:             true,
 		lenientPolicyMatchAddress:    true,
 		lenientTCPMSSRange:           true,
+		lenientEventAttributesMatch: true,
 	})
 }
 
@@ -564,11 +574,18 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// #2008 M7: event-options attributes-match patterns are RE2 regexes
 	// (Junos `matches` semantics). Reject an uncompilable pattern at commit
 	// so the operator gets immediate feedback instead of the event engine
-	// silently dropping the constraint at runtime. Strict on every path: a
-	// pattern that does not compile can never have a useful runtime effect,
-	// so there is nothing to be lenient about.
+	// silently dropping the constraint at runtime. On the tolerant LOAD path
+	// (#2063 review), downgrade to a warning: a config persisted under the
+	// pre-#2008 literal-equality matcher could hold a non-RE2 pattern, and an
+	// upgrading node must still boot through it (mirrors every sibling
+	// validator above). Commit stays strict.
 	if err := ValidateEventAttributesMatch(cfg); err != nil {
-		return nil, err
+		if opts.lenientEventAttributesMatch {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("event-options attributes-match (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
 	}
 
 	if warnings := ValidateConfig(cfg); len(warnings) > 0 {

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -561,6 +561,16 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #2008 M7: event-options attributes-match patterns are RE2 regexes
+	// (Junos `matches` semantics). Reject an uncompilable pattern at commit
+	// so the operator gets immediate feedback instead of the event engine
+	// silently dropping the constraint at runtime. Strict on every path: a
+	// pattern that does not compile can never have a useful runtime effect,
+	// so there is nothing to be lenient about.
+	if err := ValidateEventAttributesMatch(cfg); err != nil {
+		return nil, err
+	}
+
 	if warnings := ValidateConfig(cfg); len(warnings) > 0 {
 		for _, w := range warnings {
 			cfg.Warnings = append(cfg.Warnings, w)

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1291,6 +1291,14 @@ func ValidateConfig(cfg *Config) []string {
 		warnings = append(warnings, "system commit persist-groups-inheritance configured but group inheritance persistence is not implemented")
 	}
 
+	// #2008 H13 Stage 1: the leaf is now typed (schema + field) instead of
+	// being silently dropped, but the idle-yield dataplane runtime is not
+	// implemented — the userspace AF_XDP workers busy-poll. Warn so the
+	// operator knows the knob is accepted but currently has no effect.
+	if cfg.ForwardingOptions.AllowDataplaneSleep {
+		warnings = append(warnings, "forwarding-options allow-dataplane-sleep configured but is accepted-only — the userspace dataplane workers busy-poll and idle-yield is not yet implemented")
+	}
+
 	// #654: warn on `system processes X disable` for a process that
 	// bpfrx does not actually manage. Silently accepting the knob (as
 	// used to happen with e.g. `utmd disable` on vSRX) means the

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -910,6 +910,11 @@ func compileForwardingOptions(node *Node, fo *ForwardingOptionsConfig) error {
 		}
 	}
 
+	// #2008 H13 Stage 1: presence flag (mirrors security power-mode-disable).
+	if node.FindChild("allow-dataplane-sleep") != nil {
+		fo.AllowDataplaneSleep = true
+	}
+
 	return nil
 }
 

--- a/pkg/config/event_options_match.go
+++ b/pkg/config/event_options_match.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// event-options policy `attributes-match` parsing and commit-time
+// validation (#2008 M7).
+//
+// A match line has the Junos form "<event>.<attribute> matches <pattern>"
+// where <pattern> is an RE2 regular expression (NOT a literal — that was the
+// parity defect this closes). The parsing here is the single source of truth
+// shared by the commit-time validator (ValidateEventAttributesMatch) and the
+// runtime matcher (pkg/eventengine), so the two cannot drift on what counts
+// as a well-formed match line or where the pattern starts.
+
+const eventAttributesMatchSep = " matches "
+
+// ParseEventAttributesMatch splits a raw attributes-match line of the form
+// "<event>.<field> matches <pattern>" into its field name and regex pattern.
+// It returns ok=false when the line is not a well-formed match expression
+// (no " matches " separator, or no "." in the field spec). The returned
+// field is the last dot-separated component of the left-hand side (the
+// attribute name), mirroring the event_name.attribute Junos spelling.
+func ParseEventAttributesMatch(attr string) (field, pattern string, ok bool) {
+	parts := strings.SplitN(attr, eventAttributesMatchSep, 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	fieldSpec := strings.TrimSpace(parts[0])
+	pattern = strings.TrimSpace(parts[1])
+
+	dotIdx := strings.LastIndex(fieldSpec, ".")
+	if dotIdx < 0 {
+		return "", "", false
+	}
+	field = fieldSpec[dotIdx+1:]
+	if field == "" || pattern == "" {
+		return "", "", false
+	}
+	return field, pattern, true
+}
+
+// EventAttributesMatchPattern returns the regex pattern of a well-formed
+// attributes-match line. It is a convenience wrapper over
+// ParseEventAttributesMatch for callers that only need the pattern (e.g.
+// building the engine's compiled-regex cache).
+func EventAttributesMatchPattern(attr string) (pattern string, ok bool) {
+	_, pattern, ok = ParseEventAttributesMatch(attr)
+	return pattern, ok
+}
+
+// ValidateEventAttributesMatch checks that every event-options policy
+// attributes-match line carries a compilable RE2 regex pattern. It returns
+// the first error encountered so commit fails fast with a precise message.
+// Malformed lines (missing " matches " or ".") are not validated here — they
+// are silently ignored at runtime exactly as before, and rejecting them would
+// be a separate, broader grammar change.
+func ValidateEventAttributesMatch(cfg *Config) error {
+	for _, pol := range cfg.EventOptions {
+		if pol == nil {
+			continue
+		}
+		for _, attr := range pol.AttributesMatch {
+			pattern, ok := EventAttributesMatchPattern(attr)
+			if !ok {
+				continue
+			}
+			if _, err := regexp.Compile(pattern); err != nil {
+				return fmt.Errorf(
+					"event-options policy %q attributes-match %q: invalid regex pattern %q: %w",
+					pol.Name, attr, pattern, err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/config/event_options_match_test.go
+++ b/pkg/config/event_options_match_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #2008 M7 — event-options attributes-match is a regex match
+// (Junos `matches` semantics), validated at commit time.
+
+func TestEventAttributesMatch_ParseLine(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantField string
+		wantPat   string
+		wantOK    bool
+	}{
+		{`ping_test_failed.test-owner matches ^Comcast$`, "test-owner", "^Comcast$", true},
+		{`ping_test_failed.test-name matches .*down`, "test-name", ".*down", true},
+		// no separator
+		{`ping_test_failed.test-owner Comcast`, "", "", false},
+		// no dot in field spec
+		{`testowner matches Comcast`, "", "", false},
+		// empty pattern
+		{`ping_test_failed.test-owner matches `, "", "", false},
+	}
+	for _, c := range cases {
+		field, pat, ok := ParseEventAttributesMatch(c.in)
+		if ok != c.wantOK || field != c.wantField || pat != c.wantPat {
+			t.Errorf("ParseEventAttributesMatch(%q) = (%q,%q,%v); want (%q,%q,%v)",
+				c.in, field, pat, ok, c.wantField, c.wantPat, c.wantOK)
+		}
+	}
+}
+
+// A valid regex pattern compiles cleanly at commit.
+func TestEventAttributesMatch_ValidPatternCompiles(t *testing.T) {
+	cfg := compileSetLines(t, []string{
+		`set event-options policy p1 events ping_test_failed`,
+		`set event-options policy p1 attributes-match "ping_test_failed.test-owner matches ^Comcast.*$"`,
+	})
+	if len(cfg.EventOptions) != 1 {
+		t.Fatalf("want 1 event policy, got %d", len(cfg.EventOptions))
+	}
+	if len(cfg.EventOptions[0].AttributesMatch) != 1 {
+		t.Fatalf("attributes-match not stored: %#v", cfg.EventOptions[0].AttributesMatch)
+	}
+}
+
+// CRITICAL (#2008 M7 / SMR flag): an invalid regex must be REJECTED at
+// commit time, not silently accepted and dropped at runtime. This is the
+// commit-time pattern validation that backs the literal->regex switch.
+func TestEventAttributesMatch_InvalidPatternRejectedAtCommit(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		`set event-options policy p1 events ping_test_failed`,
+		// Unbalanced "[" is not a valid RE2 pattern.
+		`set event-options policy p1 attributes-match "ping_test_failed.test-owner matches [unterminated"`,
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted an invalid attributes-match regex; want commit error")
+	}
+	if !strings.Contains(err.Error(), "invalid regex pattern") {
+		t.Fatalf("commit error %q does not mention the invalid regex", err)
+	}
+	if !strings.Contains(err.Error(), "p1") {
+		t.Fatalf("commit error %q does not identify the offending policy", err)
+	}
+}
+
+// A malformed (non-match) line is ignored, not rejected — only the regex
+// of a well-formed line is validated.
+func TestEventAttributesMatch_MalformedLineNotRejected(t *testing.T) {
+	cfg := compileSetLines(t, []string{
+		`set event-options policy p1 events ping_test_failed`,
+		// No " matches " separator: not a match expression, left as-is.
+		`set event-options policy p1 attributes-match "garbage with no separator"`,
+	})
+	if len(cfg.EventOptions) != 1 {
+		t.Fatalf("want 1 event policy, got %d", len(cfg.EventOptions))
+	}
+}
+
+// The validator helper rejects an uncompilable pattern and accepts valid
+// ones directly (unit-level, independent of the full compile pipeline).
+func TestValidateEventAttributesMatch_Direct(t *testing.T) {
+	good := &Config{EventOptions: []*EventPolicy{
+		{Name: "ok", AttributesMatch: []string{`ev.test-owner matches ^a+b*$`}},
+	}}
+	if err := ValidateEventAttributesMatch(good); err != nil {
+		t.Fatalf("valid pattern rejected: %v", err)
+	}
+
+	bad := &Config{EventOptions: []*EventPolicy{
+		{Name: "bad", AttributesMatch: []string{`ev.test-owner matches a(b`}},
+	}}
+	if err := ValidateEventAttributesMatch(bad); err == nil {
+		t.Fatal("invalid pattern accepted by ValidateEventAttributesMatch")
+	}
+}

--- a/pkg/config/event_options_match_test.go
+++ b/pkg/config/event_options_match_test.go
@@ -108,3 +108,43 @@ func TestValidateEventAttributesMatch_Direct(t *testing.T) {
 		t.Fatal("invalid pattern accepted by ValidateEventAttributesMatch")
 	}
 }
+
+// #2063 review: the strict commit-time rejection must DOWNGRADE to a warning
+// on the tolerant load path. A config persisted under the pre-#2008
+// literal-equality matcher can hold a non-RE2 attributes-match pattern; an
+// upgrading node must boot through it (CompileConfigLenient) rather than fail
+// to load, mirroring every sibling lenient validator.
+func TestEventAttributesMatch_InvalidPatternLenientDowngrade(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range []string{
+		`set event-options policy p1 events ping_test_failed`,
+		`set event-options policy p1 attributes-match "ping_test_failed.test-owner matches [unterminated"`,
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	// Strict commit still rejects (guards against the downgrade leaking to commit).
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("strict CompileConfig accepted an invalid pattern; commit must stay strict")
+	}
+	// Tolerant load boots through with a warning.
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient hard-errored on an invalid persisted pattern; want boot-through: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "attributes-match") && strings.Contains(w, "tolerant path") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient load did not emit the attributes-match downgrade warning; got %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -322,6 +322,12 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 }}
 
 var schemaForwardingOptions = &schemaNode{desc: "Packet forwarding options", children: map[string]*schemaNode{
+	// #2008 H13 Stage 1: typed presence-flag leaf. Previously this was
+	// accepted only via the no-schema-match fall-through and silently
+	// dropped. Stage 1 gives it a schema (completion + validation) and a
+	// compiler field; the idle-yield dataplane runtime (Stage 2) is
+	// lab-gated and emits an accepted-but-unenforced commit warning.
+	"allow-dataplane-sleep": {desc: "Allow the dataplane to idle (accepted; idle-yield not yet enforced)", children: nil},
 	"family": {desc: "Protocol family forwarding options", compoundKey: true, children: map[string]*schemaNode{
 		"inet6": {desc: "IPv6 forwarding options", children: map[string]*schemaNode{
 			"mode": {desc: "IPv6 forwarding mode (flow-based|packet-based)", args: 1, placeholder: "<mode>", children: nil},

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -667,6 +667,11 @@ type ForwardingOptionsConfig struct {
 	DHCPRelay       *DHCPRelayConfig
 	FamilyInet6Mode string // "flow-based" or "packet-based" (default "flow-based")
 	PortMirroring   *PortMirroringConfig
+	// AllowDataplaneSleep mirrors `forwarding-options allow-dataplane-sleep`
+	// (#2008 H13 Stage 1). Syntax accepted + typed; the idle-yield runtime
+	// (workers currently busy-poll) is Stage 2 / lab-gated, so this is an
+	// accepted-but-unenforced flag that emits a commit warning.
+	AllowDataplaneSleep bool
 }
 
 // PortMirroringConfig holds port mirroring (SPAN) configuration.

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -22,6 +22,29 @@ temporal `within` windows) and triggers commit-and-apply actions.
 
 `pkg/config`, `pkg/configstore`, `pkg/rpm`.
 
+## attributes-match (regex, #2008 M7)
+
+`attributes-match "<event>.<attribute> matches <pattern>"` filters policy
+triggering on a **regex** match of `<pattern>` against the event attribute,
+matching Junos `matches` semantics. `<pattern>` is an RE2 regular expression.
+
+- Unanchored patterns are substring matches (`Com` matches `Comcast`); anchor
+  with `^...$` for an exact match.
+- Supported attributes today are `test-owner` and `test-name` (the only
+  fields on `rpm.Event`). Other attributes are silently ignored.
+- The pattern is validated at **commit time** (`config.ValidateEventAttributesMatch`
+  via `CompileConfig`): an uncompilable regex is rejected with a precise error
+  rather than being silently dropped at runtime.
+- Compiled regexes are cached at `Apply()` time keyed by pattern string, so the
+  event hot path (`HandleEvent` → `attributesMatch`) never recompiles.
+
+> Behavior note: this was a literal-equality matcher before #2008 M7. The
+> switch to regex is the correct Junos behavior but is **not** behavior-
+> preserving for an existing stored literal containing regex metacharacters
+> (e.g. a literal `.` now matches any character). The parse/validate seam is
+> shared between the compiler and the engine (`config.ParseEventAttributesMatch`)
+> so they cannot drift.
+
 ## Gotchas
 
 - 30 s policy cooldown (`engine.go`). The same policy will not

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,13 @@ type Engine struct {
 
 	// Cooldown tracking: policy name → last trigger time
 	lastTrigger map[string]time.Time
+
+	// Compiled attributes-match regexes, keyed by the raw pattern string.
+	// Built once at Apply() time so the hot HandleEvent path never compiles
+	// a regex per event. Patterns are also validated at commit
+	// (config.ValidateConfig), so a bad pattern never reaches here; the
+	// fallback in attributesMatch is defensive only.
+	regexCache map[string]*regexp.Regexp
 }
 
 // Minimum time between successive triggers of the same policy.
@@ -48,16 +56,41 @@ func New(store *configstore.Store, commitFn CommitFn) *Engine {
 		commitFn:    commitFn,
 		windows:     make(map[string]map[string][]time.Time),
 		lastTrigger: make(map[string]time.Time),
+		regexCache:  make(map[string]*regexp.Regexp),
 	}
 }
 
-// Apply loads new event-options policies. Resets temporal state.
+// Apply loads new event-options policies. Resets temporal state and
+// rebuilds the compiled-regex cache for every attributes-match pattern so
+// the event hot path (HandleEvent) never compiles a regex per event.
 func (e *Engine) Apply(policies []*config.EventPolicy) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.policies = policies
 	e.windows = make(map[string]map[string][]time.Time)
 	e.lastTrigger = make(map[string]time.Time)
+	e.regexCache = make(map[string]*regexp.Regexp)
+	for _, pol := range policies {
+		for _, attr := range pol.AttributesMatch {
+			pattern, ok := config.EventAttributesMatchPattern(attr)
+			if !ok {
+				continue
+			}
+			if _, cached := e.regexCache[pattern]; cached {
+				continue
+			}
+			// Patterns are validated at commit; a compile failure here
+			// should not happen. Log and skip so a single bad pattern
+			// can never wedge the engine.
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				slog.Warn("event-options: skipping uncompilable attributes-match pattern",
+					"policy", pol.Name, "pattern", pattern, "err", err)
+				continue
+			}
+			e.regexCache[pattern] = re
+		}
+	}
 }
 
 // HandleEvent is the callback for RPM events.
@@ -124,24 +157,29 @@ func (e *Engine) eventMatches(pol *config.EventPolicy, ev rpm.Event) bool {
 }
 
 // attributesMatch checks if the event attributes match the policy's filters.
-// Format: "ping_test_failed.test-owner matches <pattern>"
+// Format: "ping_test_failed.test-owner matches <pattern>".
+//
+// Junos `attributes-match ... matches ...` semantics are a REGEX match, not
+// literal equality (this was a parity defect, #2008 M7). The operator's
+// pattern is treated as an RE2 regular expression compiled once at Apply()
+// time and cached here. An unanchored pattern is a substring match (Junos
+// behavior): `foo` matches `foobar`; anchor with `^foo$` for exact match.
+//
+// Note this is NOT a behavior-preserving change from the previous literal
+// equality: a stored pattern containing regex metacharacters (`.`, `*`,
+// `[`, ...) now matches as a regex. That is the correct Junos behavior;
+// commit-time validation (config.ValidateEventAttributesMatch) rejects an
+// invalid regex so the operator gets immediate feedback.
 func (e *Engine) attributesMatch(pol *config.EventPolicy, ev rpm.Event) bool {
 	for _, attr := range pol.AttributesMatch {
-		// Parse "event.field matches pattern"
-		parts := strings.SplitN(attr, " matches ", 2)
-		if len(parts) != 2 {
+		field, pattern, ok := config.ParseEventAttributesMatch(attr)
+		if !ok {
 			continue
 		}
-		fieldSpec := parts[0]
-		pattern := parts[1]
 
-		// Extract field name from "event_name.field_name"
-		dotIdx := strings.LastIndex(fieldSpec, ".")
-		if dotIdx < 0 {
-			continue
-		}
-		field := fieldSpec[dotIdx+1:]
-
+		// Only test-owner and test-name are currently exposed on the event
+		// (rpm.Event). Any other field reference is silently ignored, as it
+		// was before — there is nothing to match it against yet.
 		var value string
 		switch field {
 		case "test-owner":
@@ -152,7 +190,24 @@ func (e *Engine) attributesMatch(pol *config.EventPolicy, ev rpm.Event) bool {
 			continue
 		}
 
-		if value != pattern {
+		re := e.regexCache[pattern]
+		if re == nil {
+			// Defensive: pattern was not cached (commit validation should
+			// have rejected an uncompilable pattern, and Apply caches every
+			// valid one). Compile on demand rather than silently dropping
+			// the constraint; on failure fall back to literal equality so a
+			// pathological pattern fails closed (constraint stays in force).
+			compiled, err := regexp.Compile(pattern)
+			if err != nil {
+				if value != pattern {
+					return false
+				}
+				continue
+			}
+			re = compiled
+		}
+
+		if !re.MatchString(value) {
 			return false
 		}
 	}

--- a/pkg/eventengine/engine_test.go
+++ b/pkg/eventengine/engine_test.go
@@ -1,0 +1,152 @@
+package eventengine
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/rpm"
+)
+
+// Tests for #2008 M7 — attributes-match is a regex match (Junos `matches`
+// semantics), with the compiled regex cached at Apply() time so the event
+// hot path never recompiles.
+
+func newTestEngine(t *testing.T, policies []*config.EventPolicy) *Engine {
+	t.Helper()
+	e := New(nil, nil) // nil store/commitFn: matcher tests never commit
+	e.Apply(policies)
+	return e
+}
+
+func policyWithMatch(name, event, match string) *config.EventPolicy {
+	return &config.EventPolicy{
+		Name:            name,
+		Events:          []string{event},
+		AttributesMatch: []string{match},
+	}
+}
+
+// A pattern that is an anchored exact match behaves like the old literal
+// equality for the matching value, and rejects a non-matching value.
+func TestAttributesMatch_AnchoredExact(t *testing.T) {
+	pol := policyWithMatch("p", "ping_test_failed",
+		"ping_test_failed.test-owner matches ^Comcast$")
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestOwner: "Comcast"}) {
+		t.Error("anchored ^Comcast$ should match TestOwner=Comcast")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestOwner: "ComcastBusiness"}) {
+		t.Error("anchored ^Comcast$ should NOT match TestOwner=ComcastBusiness")
+	}
+}
+
+// The behavior change vs the old literal equality: an UNANCHORED pattern is
+// a regex substring match (Junos semantics). `Com` matches `Comcast` — the
+// old code required exact equality and would have returned false.
+func TestAttributesMatch_UnanchoredSubstring(t *testing.T) {
+	pol := policyWithMatch("p", "ping_test_failed",
+		"ping_test_failed.test-owner matches Com")
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestOwner: "Comcast"}) {
+		t.Error("unanchored Com should substring-match Comcast (regex behavior)")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestOwner: "ATT"}) {
+		t.Error("unanchored Com should NOT match ATT")
+	}
+}
+
+// A metacharacter pattern is honored as a regex, not as a literal string.
+// `.*down` matches `link-down` (the `.` and `*` are regex operators); the
+// old literal code would only have matched the exact string ".*down".
+func TestAttributesMatch_MetacharactersBehaveAsRegex(t *testing.T) {
+	pol := policyWithMatch("p", "ping_test_failed",
+		"ping_test_failed.test-name matches .*down")
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestName: "link-down"}) {
+		t.Error(".*down should regex-match link-down")
+	}
+	// The literal string ".*down" is NOT what TestName equals here, proving
+	// the match is regex, not literal equality on the pattern text.
+	if e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestName: "up"}) {
+		t.Error(".*down should NOT match up")
+	}
+}
+
+// test-name field is supported in addition to test-owner.
+func TestAttributesMatch_TestNameField(t *testing.T) {
+	pol := policyWithMatch("p", "ping_test_failed",
+		"ping_test_failed.test-name matches ^wan-probe$")
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestName: "wan-probe"}) {
+		t.Error("test-name field should match")
+	}
+}
+
+// An unknown field is ignored (the constraint does not block the match) —
+// preserves the prior default:continue behavior.
+func TestAttributesMatch_UnknownFieldIgnored(t *testing.T) {
+	pol := policyWithMatch("p", "ping_test_failed",
+		"ping_test_failed.nonexistent matches whatever")
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestOwner: "x"}) {
+		t.Error("unknown attribute field should be ignored, leaving the match true")
+	}
+}
+
+// Cached-compile: Apply() must populate the regex cache for every valid
+// pattern so the hot path reads a pre-compiled regex. This proves the
+// matcher does NOT compile per event (it reads e.regexCache[pattern]).
+func TestAttributesMatch_RegexCachedAtApply(t *testing.T) {
+	pol := policyWithMatch("p", "ping_test_failed",
+		"ping_test_failed.test-owner matches ^Comcast$")
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+
+	pattern := "^Comcast$"
+	re, ok := e.regexCache[pattern]
+	if !ok || re == nil {
+		t.Fatalf("Apply() did not cache the compiled regex for %q; cache=%v",
+			pattern, e.regexCache)
+	}
+
+	// The cached pointer must be stable across matches — the hot path reads
+	// the same compiled object, never recompiling. Capture it, run several
+	// matches, and confirm the cache entry is identical (same pointer).
+	before := e.regexCache[pattern]
+	for i := 0; i < 5; i++ {
+		e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestOwner: "Comcast"})
+	}
+	after := e.regexCache[pattern]
+	if before != after {
+		t.Error("regex cache entry changed across matches — hot path recompiled")
+	}
+
+	// Re-Apply rebuilds the cache (new map); the same pattern is present.
+	e.Apply([]*config.EventPolicy{pol})
+	if _, ok := e.regexCache[pattern]; !ok {
+		t.Error("Apply() rebuild dropped the cached pattern")
+	}
+}
+
+// Multiple attributes-match lines must ALL match (AND semantics) — one
+// failing constraint blocks the policy.
+func TestAttributesMatch_AllMustMatch(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:   "p",
+		Events: []string{"ping_test_failed"},
+		AttributesMatch: []string{
+			"ping_test_failed.test-owner matches ^Comcast$",
+			"ping_test_failed.test-name matches ^wan$",
+		},
+	}
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestOwner: "Comcast", TestName: "wan"}) {
+		t.Error("both constraints satisfied should match")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", TestOwner: "Comcast", TestName: "lan"}) {
+		t.Error("one failing constraint should block the match")
+	}
+}


### PR DESCRIPTION
Tier-2 parity closures from the #2008 vSRX config-parity audit, researched
in `docs/research/2008-tier2/plan.md`. Two self-contained, decision-free
control-plane gaps shipped as one PR (2 logical commits). Companion-free
(parent serializes review).

## M7 — event-options `attributes-match` literal → regex

Junos `attributes-match "<event>.<attr> matches <pattern>"` is a **regex**
match; xpf did literal string equality (`pkg/eventengine/engine.go`
`attributesMatch`), so an operator's Junos regex silently got
literal-equality semantics and the policy under-fired.

- Switch the matcher to RE2 regex (unanchored = substring, Junos semantics).
- Compile each pattern **once at `Apply()`** into a per-pattern cache
  (`regexCache`) so the event hot path never recompiles.
- **Commit-time pattern validation** (`config.ValidateEventAttributesMatch`
  wired into `CompileConfig`) rejects an uncompilable regex at commit instead
  of silently dropping it at runtime — addresses the SMR flag that
  literal→regex is not behavior-preserving.
- Shared parse seam (`config.ParseEventAttributesMatch`) between the compiler
  validator and the engine so they cannot drift.
- **Behavior-change note:** regex is the correct Junos behavior but is NOT
  behavior-preserving for a stored literal containing regex metacharacters.
  Documented in the commit, `pkg/eventengine/README.md`, and
  `docs/feature-gaps.md`.
- Attribute field set kept at `test-owner`/`test-name` (the only `rpm.Event`
  fields); field-widening deferred until more attributes are exposed.

## H13 Stage 1 — `forwarding-options allow-dataplane-sleep` schema + warn

The leaf was accepted only via the no-schema-match fall-through and silently
dropped by `compileForwardingOptions` (a silent-drop). Stage 1 makes it
truthful in commit; the dataplane idle-yield runtime (Stage 2) is lab-gated
and intentionally NOT implemented here.

- Typed presence-flag schema leaf (`schema_routing.go`), modeled on
  `security flow power-mode-disable`.
- `ForwardingOptionsConfig.AllowDataplaneSleep` field + compiler extraction.
- Accepted-but-unenforced commit warning in `ValidateConfig` (the userspace
  workers busy-poll), mirroring the `persist-groups-inheritance` /
  `dns-proxy` warnings.
- Stage 2 deferred per the research doc — busy-poll cold-start latency
  sensitivity (#1782) needs explicit lab validation before enabling.

## Tests

- config: attributes-match parse, valid pattern compiles, **invalid pattern
  rejected at commit**, malformed-not-rejected, direct validator;
  allow-dataplane-sleep parses+field-set+warns, absent-no-warn,
  schema-completion.
- eventengine: anchored exact, **unanchored substring (regex behavior vs old
  literal)**, metacharacters-as-regex, test-name field, unknown-field-ignored,
  **regex cached at Apply (no per-event recompile)**, AND semantics.

`go build ./...`, `go vet ./pkg/eventengine ./pkg/config`, and
`go test ./pkg/eventengine ./pkg/config -count=1` all pass.

Refs #2008 (M7 + H13 Stage 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)