### PR TITLE
#2008 M7: correct regexCache validation comment (Copilot #2063 follow-up)

### DIFF
--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -37,9 +37,13 @@ type Engine struct {
 
 	// Compiled attributes-match regexes, keyed by the raw pattern string.
 	// Built once at Apply() time so the hot HandleEvent path never compiles
-	// a regex per event. Patterns are also validated at commit
-	// (config.ValidateConfig), so a bad pattern never reaches here; the
-	// fallback in attributesMatch is defensive only.
+	// a regex per event. Patterns are validated at COMMIT by
+	// config.ValidateEventAttributesMatch (called from CompileConfig), so a
+	// bad pattern normally never reaches here. The one exception is the
+	// tolerant LOAD path (CompileConfigLenient), which downgrades an invalid
+	// persisted pattern to a warning so an upgraded node boots through — so
+	// the skip-on-compile-failure fallback in Apply/attributesMatch is a real
+	// handler for that case, not purely defensive.
 	regexCache map[string]*regexp.Regexp
 }
 


### PR DESCRIPTION
Trivial comment-accuracy follow-up to PR #2063 (merged), addressing the one Copilot inline finding I should have folded before merge.

The `regexCache` comment in `pkg/eventengine/engine.go` said patterns are validated at commit via `config.ValidateConfig` and a bad pattern never reaches the engine. Corrected: (1) the validator is `config.ValidateEventAttributesMatch` (from `CompileConfig`), not `ValidateConfig`; (2) after the #2063 lenient-path fix, an invalid persisted pattern is downgraded to a warning on `CompileConfigLenient` so an upgrading node boots through — so a bad pattern *can* reach the engine on the tolerant load path, making the skip-on-compile-failure fallback a real handler, not purely defensive.

Comment-only, no logic change. `go build ./pkg/eventengine/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)