### PR TITLE
daemon: ssh sshd_config.d drop-in lifecycle — remove on config-empty + revert on reload failure

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,25 @@
 # Action Log
 
+## 2026-06-20 — #2062 ssh sshd_config.d drop-in lifecycle
+
+- **Timestamp**: 2026-06-20
+- **Action**: #2062 — hardened the xpf-managed sshd drop-in lifecycle in
+  `Daemon.applySSHConfig`. Two pre-existing gaps fixed: (1) removing/emptying
+  the ssh stanza now REMOVES `/etc/ssh/sshd_config.d/xpf.conf` and reloads
+  sshd so it reverts to base-image defaults (was: early-return on nil/empty
+  left the stale drop-in enforcing old PermitRootLogin/KexAlgorithms); (2) a
+  `systemctl reload sshd` failure AFTER a successful write now reverts the
+  drop-in to its prior content (or removes it if there was none) and re-reloads
+  best-effort, so a bad config (e.g. invalid free-form key-exchange) never
+  persists to break the next sshd restart. Introduced an injectable FS+reload
+  seam (package vars `sshdConfPath`/`sshdReadFile`/`sshdWriteFile`/
+  `sshdRemoveFile`/`sshdMkdirAll`/`sshdReloadCmd`, mirroring the pkg/ra
+  `listenFn` seam) so the remove/revert side effects are unit-testable. Added 7
+  recorder-backed tests; the 4 covering the new behavior were verified to FAIL
+  against the pre-fix logic (seam kept, old body) — non-tautological.
+- **File(s)**: pkg/daemon/daemon_system.go, pkg/daemon/daemon_ssh_test.go,
+  docs/feature-gaps.md, _Log.md
+
 ## 2026-06-20 — #1387 Increment-2 (DDNS live RFC 2136 backend + loop + HA gate)
 
 - **Timestamp**: 2026-06-20

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -428,7 +428,7 @@ xpf has hostname, domain-name, domain-search, timezone, name-servers, NTP, servi
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
-| **SSH Key Exchange** | `system services ssh key-exchange ...` | Restrict the SSH key-exchange (KEX) algorithms the firewall offers | Medium | Done (H5/#2008 — repeatable leaf rendered to the sshd `KexAlgorithms` drop-in, `pkg/daemon/daemon_system.go`) |
+| **SSH Key Exchange** | `system services ssh key-exchange ...` | Restrict the SSH key-exchange (KEX) algorithms the firewall offers | Medium | Done (H5/#2008 — repeatable leaf rendered to the sshd `KexAlgorithms` drop-in, `pkg/daemon/daemon_system.go`; drop-in lifecycle hardened in #2062 — removing/emptying the ssh stanza removes the `/etc/ssh/sshd_config.d/xpf.conf` drop-in and reloads so sshd reverts to base-image defaults, and a reload failure after a write reverts the drop-in to its prior content/removes it so a bad config never breaks the next sshd restart) |
 | **RADIUS Server Config** | `system radius-server ... port ... secret ...` | RADIUS server definitions for AAA (authentication, authorization, accounting) | Medium | Missing |
 | **TACACS+ Server Config** | `system tacplus-server ... port ... secret ...` | TACACS+ server definitions for per-command authorization | Medium | Missing |
 | **Authentication Order** | `system authentication-order [radius tacplus password]` | Control order of authentication methods for management access | Medium | Missing |

--- a/pkg/daemon/daemon_ssh_test.go
+++ b/pkg/daemon/daemon_ssh_test.go
@@ -98,16 +98,28 @@ type sshdSeamRecorder struct {
 	writes  [][]byte // each WriteFileAtomic payload, in order
 	removed int      // number of successful Remove calls
 	reloads int      // number of reload attempts
+	writeN  int      // number of write attempts (including failed ones)
+
+	// readErr, when set, makes sshdReadFile return (nil, readErr) even though
+	// present is non-nil — models an existing-but-unreadable drop-in
+	// (permission/IO error). Distinct from present==nil (truly absent).
+	readErr error
 
 	// reloadErr, when set, makes the NEXT reload fail; reloads after the
 	// nth (failNthReload) succeed. failNthReload<=0 means every reload
 	// returns reloadErr.
 	reloadErr     error
 	failNthReload int
+
+	// writeErr, when set, makes the nth write (failNthWrite) fail; other
+	// writes succeed. failNthWrite<=0 means every write returns writeErr.
+	writeErr     error
+	failNthWrite int
 }
 
-// install swaps the package-level seam vars to route through the recorder and
-// returns a restore func (registered via t.Cleanup).
+// installSSHDSeam swaps the package-level seam vars to route through the
+// recorder and registers a t.Cleanup that restores the originals when the test
+// ends.
 func installSSHDSeam(t *testing.T, r *sshdSeamRecorder) {
 	t.Helper()
 	origPath := sshdConfPath
@@ -122,10 +134,19 @@ func installSSHDSeam(t *testing.T, r *sshdSeamRecorder) {
 		if r.present == nil {
 			return nil, os.ErrNotExist
 		}
+		// Existing file that cannot be read (permission/IO): present stays
+		// non-nil but the read surfaces a non-NotExist error.
+		if r.readErr != nil {
+			return nil, r.readErr
+		}
 		// Return a copy so callers cannot mutate the backing store.
 		return append([]byte(nil), r.present...), nil
 	}
 	sshdWriteFile = func(_ string, data []byte, _ os.FileMode, _ ...fsatomic.Option) error {
+		r.writeN++
+		if r.writeErr != nil && (r.failNthWrite <= 0 || r.writeN == r.failNthWrite) {
+			return r.writeErr
+		}
 		cp := append([]byte(nil), data...)
 		r.writes = append(r.writes, cp)
 		r.present = cp
@@ -316,6 +337,62 @@ func TestApplySSHConfig_NormalWrite(t *testing.T) {
 	}
 	if r.removed != 0 {
 		t.Errorf("unexpected Remove: %d", r.removed)
+	}
+}
+
+// TestApplySSHConfig_RemoveOnConfigRemovedUnreadablePrior verifies that an
+// existing-but-UNREADABLE drop-in is treated as present and removed when the
+// config is cleared (#2067 fold 1). Fails pre-fix: hadDropIn := priorErr == nil
+// treated the read error as "absent", so the content=="" path returned early
+// and left the stale drop-in enforcing old settings.
+func TestApplySSHConfig_RemoveOnConfigRemovedUnreadablePrior(t *testing.T) {
+	r := &sshdSeamRecorder{
+		present: []byte("# Managed by xpf\nPermitRootLogin no\n"),
+		readErr: os.ErrPermission, // exists, but cannot be read
+	}
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(nil)) // ssh stanza gone
+
+	if r.present != nil {
+		t.Fatalf("unreadable-but-present drop-in not removed on config removal: %q", r.present)
+	}
+	if r.removed != 1 {
+		t.Errorf("Remove called %d times, want 1", r.removed)
+	}
+	if r.reloads != 1 {
+		t.Errorf("reload called %d times, want 1", r.reloads)
+	}
+}
+
+// TestApplySSHConfig_RevertWriteFailureRemovesBadContent verifies the
+// fail-safe in fold 3: when the post-write reload fails AND restoring the prior
+// content also fails (the restore write errors), the bad just-written drop-in
+// is REMOVED rather than left on disk to break the next sshd restart. Fails
+// pre-fix: the restore failure was only logged, leaving the bad content.
+func TestApplySSHConfig_RevertWriteFailureRemovesBadContent(t *testing.T) {
+	priorContent := buildSSHDConfig(&config.SSHServiceConfig{RootLogin: "deny"})
+	r := &sshdSeamRecorder{
+		present:       []byte(priorContent),
+		reloadErr:     errors.New("sshd: bad configuration"),
+		failNthReload: 1, // post-write reload fails
+		writeErr:      errors.New("write failed"),
+		failNthWrite:  2, // first (new content) write OK; revert write (2nd) fails
+	}
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(&config.SSHServiceConfig{
+		RootLogin:   "deny",
+		KeyExchange: []string{"bogus-kex-algorithm"},
+	}))
+
+	if r.present != nil {
+		t.Fatalf("bad content left on disk after failed restore; want drop-in removed: %q", r.present)
+	}
+	if r.removed != 1 {
+		t.Errorf("Remove called %d times after failed restore, want 1", r.removed)
 	}
 }
 

--- a/pkg/daemon/daemon_ssh_test.go
+++ b/pkg/daemon/daemon_ssh_test.go
@@ -1,10 +1,13 @@
 package daemon
 
 import (
+	"errors"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/fsatomic"
 )
 
 // TestBuildSSHDConfigKeyExchange verifies the H5 (#2008) ssh key-exchange
@@ -81,5 +84,255 @@ func TestBuildSSHDConfigKeyExchange(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// sshdSeamRecorder records the FS + reload effects driven through the
+// applySSHConfig seam (#2062) and lets a test stub the in-memory drop-in
+// contents and the reload result. The recorder backs the package-level
+// sshd* function vars during a test and is restored on cleanup.
+type sshdSeamRecorder struct {
+	// present models the on-disk drop-in: nil == file absent.
+	present []byte
+
+	writes  [][]byte // each WriteFileAtomic payload, in order
+	removed int      // number of successful Remove calls
+	reloads int      // number of reload attempts
+
+	// reloadErr, when set, makes the NEXT reload fail; reloads after the
+	// nth (failNthReload) succeed. failNthReload<=0 means every reload
+	// returns reloadErr.
+	reloadErr     error
+	failNthReload int
+}
+
+// install swaps the package-level seam vars to route through the recorder and
+// returns a restore func (registered via t.Cleanup).
+func installSSHDSeam(t *testing.T, r *sshdSeamRecorder) {
+	t.Helper()
+	origPath := sshdConfPath
+	origRead := sshdReadFile
+	origWrite := sshdWriteFile
+	origRemove := sshdRemoveFile
+	origMkdir := sshdMkdirAll
+	origReload := sshdReloadCmd
+
+	sshdConfPath = "/test/sshd_config.d/xpf.conf"
+	sshdReadFile = func(string) ([]byte, error) {
+		if r.present == nil {
+			return nil, os.ErrNotExist
+		}
+		// Return a copy so callers cannot mutate the backing store.
+		return append([]byte(nil), r.present...), nil
+	}
+	sshdWriteFile = func(_ string, data []byte, _ os.FileMode, _ ...fsatomic.Option) error {
+		cp := append([]byte(nil), data...)
+		r.writes = append(r.writes, cp)
+		r.present = cp
+		return nil
+	}
+	sshdRemoveFile = func(string) error {
+		if r.present == nil {
+			return os.ErrNotExist
+		}
+		r.present = nil
+		r.removed++
+		return nil
+	}
+	sshdMkdirAll = func(string, os.FileMode) error { return nil }
+	sshdReloadCmd = func() ([]byte, error) {
+		r.reloads++
+		if r.reloadErr != nil && (r.failNthReload <= 0 || r.reloads == r.failNthReload) {
+			return []byte("bad config"), r.reloadErr
+		}
+		return nil, nil
+	}
+
+	t.Cleanup(func() {
+		sshdConfPath = origPath
+		sshdReadFile = origRead
+		sshdWriteFile = origWrite
+		sshdRemoveFile = origRemove
+		sshdMkdirAll = origMkdir
+		sshdReloadCmd = origReload
+	})
+}
+
+func sshConfig(ssh *config.SSHServiceConfig) *config.Config {
+	cfg := &config.Config{}
+	if ssh != nil {
+		cfg.System.Services = &config.SystemServicesConfig{SSH: ssh}
+	}
+	return cfg
+}
+
+// TestApplySSHConfig_RemoveOnConfigRemoved verifies that deleting the whole ssh
+// stanza removes a previously-written drop-in and reloads sshd so it reverts to
+// base-image defaults (#2062 gap 1). Fails pre-fix: the old applySSHConfig
+// returned early on a nil ssh stanza, leaving the drop-in in place.
+func TestApplySSHConfig_RemoveOnConfigRemoved(t *testing.T) {
+	r := &sshdSeamRecorder{present: []byte("# Managed by xpf\nPermitRootLogin no\n")}
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(nil)) // ssh stanza gone
+
+	if r.present != nil {
+		t.Fatalf("drop-in still present after config removed: %q", r.present)
+	}
+	if r.removed != 1 {
+		t.Errorf("Remove called %d times, want 1", r.removed)
+	}
+	if r.reloads != 1 {
+		t.Errorf("reload called %d times, want 1", r.reloads)
+	}
+	if len(r.writes) != 0 {
+		t.Errorf("unexpected writes on removal: %v", r.writes)
+	}
+}
+
+// TestApplySSHConfig_RemoveOnConfigEmptied verifies that an ssh stanza with no
+// recognised leaves (buildSSHDConfig == "") removes the existing drop-in and
+// reloads (#2062 gap 1). Fails pre-fix: the old code returned early when
+// content=="" without touching the drop-in.
+func TestApplySSHConfig_RemoveOnConfigEmptied(t *testing.T) {
+	r := &sshdSeamRecorder{present: []byte("# Managed by xpf\nKexAlgorithms curve25519-sha256\n")}
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(&config.SSHServiceConfig{})) // no leaves
+
+	if r.present != nil {
+		t.Fatalf("drop-in still present after config emptied: %q", r.present)
+	}
+	if r.removed != 1 {
+		t.Errorf("Remove called %d times, want 1", r.removed)
+	}
+	if r.reloads != 1 {
+		t.Errorf("reload called %d times, want 1", r.reloads)
+	}
+}
+
+// TestApplySSHConfig_NoOpWhenEmptyAndAbsent verifies that an empty config with
+// no existing drop-in does nothing: no remove, no reload (#2062). Fails if the
+// remove/reload path runs unconditionally when content=="".
+func TestApplySSHConfig_NoOpWhenEmptyAndAbsent(t *testing.T) {
+	r := &sshdSeamRecorder{present: nil} // no drop-in on disk
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(nil))
+
+	if r.removed != 0 {
+		t.Errorf("spurious Remove: %d", r.removed)
+	}
+	if r.reloads != 0 {
+		t.Errorf("spurious reload: %d", r.reloads)
+	}
+	if len(r.writes) != 0 {
+		t.Errorf("spurious writes: %v", r.writes)
+	}
+}
+
+// TestApplySSHConfig_RevertOnReloadFailureWithPrior verifies that when the
+// write succeeds but the reload fails, the drop-in is reverted to its PRIOR
+// content rather than left as the bad new content (#2062 gap 2). Fails pre-fix:
+// the old code logged the reload error and returned, leaving the bad new
+// content on disk.
+func TestApplySSHConfig_RevertOnReloadFailureWithPrior(t *testing.T) {
+	priorContent := buildSSHDConfig(&config.SSHServiceConfig{RootLogin: "deny"})
+	r := &sshdSeamRecorder{
+		present:       []byte(priorContent),
+		reloadErr:     errors.New("sshd: bad configuration"),
+		failNthReload: 1, // first reload (post-write) fails; revert reload succeeds
+	}
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	// New config has a bad free-form key-exchange — write succeeds, reload fails.
+	d.applySSHConfig(sshConfig(&config.SSHServiceConfig{
+		RootLogin:   "deny",
+		KeyExchange: []string{"bogus-kex-algorithm"},
+	}))
+
+	if r.present == nil {
+		t.Fatalf("drop-in removed on reload failure but a prior existed; want prior restored")
+	}
+	if string(r.present) != priorContent {
+		t.Fatalf("drop-in not reverted to prior content\n got: %q\nwant: %q", r.present, priorContent)
+	}
+	if strings.Contains(string(r.present), "bogus-kex-algorithm") {
+		t.Errorf("bad new content left on disk: %q", r.present)
+	}
+}
+
+// TestApplySSHConfig_RemoveOnReloadFailureNoPrior verifies that when the write
+// succeeds, the reload fails, and there was NO prior drop-in, the bad new
+// drop-in is removed (#2062 gap 2). Fails pre-fix: old code left the bad
+// content on disk to break the next restart.
+func TestApplySSHConfig_RemoveOnReloadFailureNoPrior(t *testing.T) {
+	r := &sshdSeamRecorder{
+		present:       nil, // no prior drop-in
+		reloadErr:     errors.New("sshd: bad configuration"),
+		failNthReload: 1,
+	}
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(&config.SSHServiceConfig{
+		KeyExchange: []string{"bogus-kex-algorithm"},
+	}))
+
+	if r.present != nil {
+		t.Fatalf("bad drop-in left on disk after reload failure with no prior: %q", r.present)
+	}
+	if r.removed != 1 {
+		t.Errorf("Remove called %d times after reload failure, want 1", r.removed)
+	}
+}
+
+// TestApplySSHConfig_NormalWrite verifies the unchanged happy path: a managed
+// config writes the drop-in and reloads once, with no revert.
+func TestApplySSHConfig_NormalWrite(t *testing.T) {
+	r := &sshdSeamRecorder{present: nil}
+	installSSHDSeam(t, r)
+
+	want := buildSSHDConfig(&config.SSHServiceConfig{RootLogin: "deny", KeyExchange: []string{"curve25519-sha256"}})
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(&config.SSHServiceConfig{
+		RootLogin:   "deny",
+		KeyExchange: []string{"curve25519-sha256"},
+	}))
+
+	if r.present == nil || string(r.present) != want {
+		t.Fatalf("drop-in content = %q, want %q", r.present, want)
+	}
+	if len(r.writes) != 1 {
+		t.Errorf("Write called %d times, want 1", len(r.writes))
+	}
+	if r.reloads != 1 {
+		t.Errorf("reload called %d times, want 1", r.reloads)
+	}
+	if r.removed != 0 {
+		t.Errorf("unexpected Remove: %d", r.removed)
+	}
+}
+
+// TestApplySSHConfig_NoChange verifies that re-applying identical content does
+// not rewrite or reload (idempotence preserved by #2062).
+func TestApplySSHConfig_NoChange(t *testing.T) {
+	want := buildSSHDConfig(&config.SSHServiceConfig{RootLogin: "deny"})
+	r := &sshdSeamRecorder{present: []byte(want)}
+	installSSHDSeam(t, r)
+
+	d := &Daemon{}
+	d.applySSHConfig(sshConfig(&config.SSHServiceConfig{RootLogin: "deny"}))
+
+	if len(r.writes) != 0 {
+		t.Errorf("unexpected write on no-change: %v", r.writes)
+	}
+	if r.reloads != 0 {
+		t.Errorf("unexpected reload on no-change: %d", r.reloads)
 	}
 }

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -878,41 +878,110 @@ func (d *Daemon) reconcileUserPassword(user *config.LoginUser) {
 	}
 }
 
+// sshdConfPath is the xpf-managed sshd drop-in. Overridable in tests so the
+// remove/revert side effects can be exercised against a temp dir.
+var sshdConfPath = "/etc/ssh/sshd_config.d/xpf.conf"
+
+// FS + reload seam (#2062). applySSHConfig owns three real-world side effects
+// — write the drop-in, remove the drop-in, reload sshd — and the
+// config-removal and reload-failure recovery paths can only be tested if those
+// effects are injectable. These package-level vars default to the production
+// implementations and are overridden by a recorder in daemon_ssh_test.go.
+// Mirrors the listenFn/ensureLinkLocalFn seam in pkg/ra.
+var (
+	sshdReadFile   = os.ReadFile
+	sshdWriteFile  = fsatomic.WriteFileAtomic
+	sshdRemoveFile = os.Remove
+	sshdMkdirAll   = os.MkdirAll
+	sshdReloadCmd  = func() ([]byte, error) {
+		return runCommandTimeout("systemctl", "reload", "sshd")
+	}
+)
+
 // applySSHConfig configures sshd from system { services { ssh { ... } } }.
 // Uses a drop-in config file to avoid modifying the main sshd_config.
+//
+// Drop-in lifecycle (#2062): the drop-in is created/updated when there are
+// xpf-managed ssh settings, and REMOVED when there are none — including when
+// the whole ssh stanza is deleted (cfg.System.Services / .SSH == nil) — so
+// clearing the config reverts sshd to the base-image defaults instead of
+// leaving stale PermitRootLogin/KexAlgorithms enforced. If the reload fails
+// after a write, the drop-in is reverted to its prior content (or removed if
+// there was none) so a bad config never persists to break the next sshd
+// restart.
 func (d *Daemon) applySSHConfig(cfg *config.Config) {
-	if cfg.System.Services == nil || cfg.System.Services.SSH == nil {
+	var ssh *config.SSHServiceConfig
+	if cfg.System.Services != nil {
+		ssh = cfg.System.Services.SSH
+	}
+
+	// buildSSHDConfig is nil-safe and returns "" when there is nothing to
+	// manage, so an absent ssh stanza and an ssh stanza with no recognised
+	// leaves collapse to the same "no managed settings" case.
+	content := buildSSHDConfig(ssh)
+
+	// Read the prior content once: needed both to skip no-op writes and to
+	// restore the file if a reload fails after we change it.
+	prior, priorErr := sshdReadFile(sshdConfPath)
+	hadDropIn := priorErr == nil
+
+	if content == "" {
+		// No xpf-managed ssh settings. Remove any existing drop-in and reload
+		// so sshd reverts to base-image defaults. No-op when absent.
+		if !hadDropIn {
+			return
+		}
+		if err := sshdRemoveFile(sshdConfPath); err != nil && !os.IsNotExist(err) {
+			slog.Warn("failed to remove sshd config drop-in", "err", err)
+			return
+		}
+		if out, err := sshdReloadCmd(); err != nil {
+			slog.Error("failed to reload sshd after removing drop-in",
+				"err", err, "output", strings.TrimSpace(string(out)))
+			return
+		}
+		slog.Info("SSH config drop-in removed (reverted to defaults)")
 		return
 	}
 
-	ssh := cfg.System.Services.SSH
-
-	content := buildSSHDConfig(ssh)
-	if content == "" {
-		return // nothing to manage
-	}
-
-	confPath := "/etc/ssh/sshd_config.d/xpf.conf"
-
-	current, _ := os.ReadFile(confPath)
-	if string(current) == content {
+	if hadDropIn && string(prior) == content {
 		return // no change
 	}
 
-	os.MkdirAll("/etc/ssh/sshd_config.d", 0755)
+	sshdMkdirAll("/etc/ssh/sshd_config.d", 0755)
 	// AtomicGeneratedConfig (D2): regenerated each apply and reloaded
 	// immediately. A power-cut loss reverts PermitRootLogin to the base
 	// image default (prohibit-password) until the next boot apply — that
 	// FAILS SAFE (more restrictive, never more permissive), so no fsync.
-	if err := fsatomic.WriteFileAtomic(confPath, []byte(content), 0644); err != nil {
+	if err := sshdWriteFile(sshdConfPath, []byte(content), 0644); err != nil {
 		slog.Warn("failed to write sshd config", "err", err)
 		return
 	}
 
-	// Reload sshd to pick up changes
-	if out, err := runCommandTimeout("systemctl", "reload", "sshd"); err != nil {
+	// Reload sshd to pick up changes. On failure the drop-in we just wrote is
+	// syntactically/semantically bad (e.g. an invalid key-exchange algorithm)
+	// and would break the next sshd RESTART, so revert it to the prior state:
+	// restore the previous content, or remove the file if there was none.
+	if out, err := sshdReloadCmd(); err != nil {
 		slog.Error("failed to reload sshd",
 			"err", err, "output", strings.TrimSpace(string(out)))
+		if hadDropIn {
+			if rerr := sshdWriteFile(sshdConfPath, prior, 0644); rerr != nil {
+				slog.Warn("failed to restore prior sshd config after reload failure", "err", rerr)
+			}
+		} else {
+			if rerr := sshdRemoveFile(sshdConfPath); rerr != nil && !os.IsNotExist(rerr) {
+				slog.Warn("failed to remove bad sshd config after reload failure", "err", rerr)
+			}
+		}
+		// Best-effort reload of the restored content so the running sshd is
+		// not left referencing a drop-in we just rewrote/removed underneath
+		// it. The original reload already failed; a second failure here is
+		// only logged.
+		if out2, err2 := sshdReloadCmd(); err2 != nil {
+			slog.Warn("failed to reload sshd after reverting drop-in",
+				"err", err2, "output", strings.TrimSpace(string(out2)))
+		}
 		return
 	}
 	slog.Info("SSH config applied",

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -905,10 +905,12 @@ var (
 // xpf-managed ssh settings, and REMOVED when there are none — including when
 // the whole ssh stanza is deleted (cfg.System.Services / .SSH == nil) — so
 // clearing the config reverts sshd to the base-image defaults instead of
-// leaving stale PermitRootLogin/KexAlgorithms enforced. If the reload fails
-// after a write, the drop-in is reverted to its prior content (or removed if
-// there was none) so a bad config never persists to break the next sshd
-// restart.
+// leaving stale PermitRootLogin/KexAlgorithms enforced — an existing drop-in
+// that cannot be read (permission/IO error) is still treated as present so it
+// gets removed. If the reload fails after a write, the drop-in is reverted to
+// its prior content (or removed if there was none, the prior was unreadable,
+// or the restore write itself fails) so a bad config never persists to break
+// the next sshd restart.
 func (d *Daemon) applySSHConfig(cfg *config.Config) {
 	var ssh *config.SSHServiceConfig
 	if cfg.System.Services != nil {
@@ -922,8 +924,17 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 
 	// Read the prior content once: needed both to skip no-op writes and to
 	// restore the file if a reload fails after we change it.
+	//
+	// Distinguish "absent" from "exists but unreadable": a permission/IO error
+	// reading an existing drop-in is NOT the same as no drop-in. Treating an
+	// unreadable-but-present file as absent would skip removal and leave a
+	// stale drop-in enforcing PermitRootLogin/KexAlgorithms after the config
+	// was cleared. hadDropIn = the file exists (read OK, or failed with
+	// something other than not-exist); priorReadable = we actually have its
+	// content (only then can we restore it on a reload failure).
 	prior, priorErr := sshdReadFile(sshdConfPath)
-	hadDropIn := priorErr == nil
+	priorReadable := priorErr == nil
+	hadDropIn := priorReadable || !os.IsNotExist(priorErr)
 
 	if content == "" {
 		// No xpf-managed ssh settings. Remove any existing drop-in and reload
@@ -944,11 +955,17 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 		return
 	}
 
-	if hadDropIn && string(prior) == content {
+	if priorReadable && string(prior) == content {
 		return // no change
 	}
 
-	sshdMkdirAll("/etc/ssh/sshd_config.d", 0755)
+	// Best-effort create the drop-in directory before writing. If this fails
+	// the write below will also fail, but the mkdir error is the real cause
+	// (e.g. a read-only /etc) so surface it rather than only the opaque write
+	// error.
+	if err := sshdMkdirAll("/etc/ssh/sshd_config.d", 0755); err != nil {
+		slog.Warn("failed to create sshd config drop-in directory", "err", err)
+	}
 	// AtomicGeneratedConfig (D2): regenerated each apply and reloaded
 	// immediately. A power-cut loss reverts PermitRootLogin to the base
 	// image default (prohibit-password) until the next boot apply — that
@@ -965,9 +982,18 @@ func (d *Daemon) applySSHConfig(cfg *config.Config) {
 	if out, err := sshdReloadCmd(); err != nil {
 		slog.Error("failed to reload sshd",
 			"err", err, "output", strings.TrimSpace(string(out)))
-		if hadDropIn {
+		// Revert. Only restore the prior content when we actually read it
+		// (priorReadable); an unreadable-but-present prior is unknown, so
+		// fail safe by removing the drop-in instead of restoring garbage.
+		if priorReadable {
 			if rerr := sshdWriteFile(sshdConfPath, prior, 0644); rerr != nil {
-				slog.Warn("failed to restore prior sshd config after reload failure", "err", rerr)
+				// Restoring the prior content failed too. No drop-in is safer
+				// than the known-bad content we just wrote (which would break
+				// the next sshd restart), so fall back to removing the file.
+				slog.Warn("failed to restore prior sshd config after reload failure; removing drop-in", "err", rerr)
+				if rmErr := sshdRemoveFile(sshdConfPath); rmErr != nil && !os.IsNotExist(rmErr) {
+					slog.Warn("failed to remove bad sshd config after failed restore", "err", rmErr)
+				}
 			}
 		} else {
 			if rerr := sshdRemoveFile(sshdConfPath); rerr != nil && !os.IsNotExist(rerr) {


### PR DESCRIPTION
Fixes two pre-existing gaps in `Daemon.applySSHConfig` (pkg/daemon/daemon_system.go) for the xpf-managed sshd drop-in `/etc/ssh/sshd_config.d/xpf.conf`. Spun out of #2008 / PR #2060 (Copilot review), surfaced by the H5 key-exchange work. Closes #2062.

## Gaps

1. **Stale drop-in on config removal.** `applySSHConfig` returned early when the ssh stanza was absent (`Services`/`SSH == nil`) and when `buildSSHDConfig` rendered `""` (no recognised leaves), leaving any existing drop-in in place. Deleting/emptying the xpf-managed ssh config therefore did NOT revert sshd to base-image defaults — stale `PermitRootLogin`/`KexAlgorithms` stayed enforced until the next boot or a manual cleanup.
2. **Bad drop-in left on reload failure.** When the atomic write succeeded but `systemctl reload sshd` failed (e.g. an invalid free-form `key-exchange` algorithm), the bad drop-in was left on disk; the running sshd kept its old in-memory config, but a future sshd RESTART would then fail to start with the bad drop-in.

## Fixes

- No xpf-managed ssh settings (`content == ""`, covering both the absent-stanza and empty-stanza cases via the nil-safe `buildSSHDConfig`) → remove the drop-in if present and reload so sshd reverts to base-image defaults. No-op when the drop-in is already absent (no spurious remove/reload).
- Reload failure after a write → revert the drop-in to its prior content (or remove it if there was none) and reload again best-effort, so a bad config never persists to break the next sshd restart.

## Testability seam

The write/remove/reload effects were hard-wired to `os`/`fsatomic`/`systemctl` with no seam, so the remove/revert paths were untestable (only the pure `buildSSHDConfig` was tested). Added package-level function vars (`sshdConfPath`, `sshdReadFile`, `sshdWriteFile`, `sshdRemoveFile`, `sshdMkdirAll`, `sshdReloadCmd`) defaulting to the production impls, overridden by a recorder in tests — mirroring the `listenFn`/`ensureLinkLocalFn` seam in `pkg/ra`.

## Tests

Recorder-backed, side-effect-asserting: config-removed and config-emptied each remove the drop-in + reload once; empty-and-absent is a no-op; reload-failure-after-write reverts to the prior content; reload-failure-with-no-prior removes the bad drop-in; normal write and no-change keep existing behavior. The four new-behavior tests were verified to FAIL against the pre-fix logic (seam kept, old function body) — non-tautological.

## Validation

`go build ./...`, `go vet ./pkg/daemon/` (only the pre-existing `flowexport` copy-lock warnings remain), `go test ./pkg/daemon/ -count=1` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)