### PR TITLE
#2070: interface-monitor reads carrier (operstate), not admin IFF_UP

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,29 @@
 # Action Log
 
+## 2026-06-20 — #2070 interface-monitor carrier-state read (HIGH, failover-class)
+
+- **Timestamp**: 2026-06-20
+- **Action**: #2070 — the interface-monitor reported a carrier-down
+  (cable-pulled / peer-down) link as UP, suppressing HA failover. The
+  link-health read was `OperState == OperUp || Flags&IFF_UP != 0`; since
+  xpfd admin-ups every managed interface, the `IFF_UP` term is always
+  true, so the OR collapsed to "administratively up" regardless of
+  carrier — a redundancy group with a dead uplink was never demoted.
+  Fixed by reading the kernel operational state via a new package-local
+  `linkAttrsUp` helper (mirrors `pkg/vrrp.linkAttrsUp`): `OperUp` → up,
+  `OperUnknown` → admin-flag fallback (virtual devices with no carrier
+  state), `OperDown`/`OperLowerLayerDown`/other → down. Replaced all
+  three identical buggy sites: `pkg/routing/monitor.go` (display signal)
+  and `pkg/cluster/monitor.go` (the live 1s poll loop feeding
+  `SetMonitorWeight`, and the readiness check). Added regression tests in
+  both packages that fail pre-fix (carrier-down reported UP / weight not
+  demoted) and pass post-fix, plus admin-down and OperUnknown guard cases.
+  FAILOVER-class: `make test-failover` (cable-pull / link-down failover)
+  is the mandatory merge gate, run by the parent.
+- **File(s)**: pkg/routing/monitor.go, pkg/routing/monitor_test.go (new),
+  pkg/cluster/monitor.go, pkg/cluster/monitor_test.go,
+  pkg/cluster/README.md, pkg/routing/README.md, _Log.md
+
 ## 2026-06-20 — #1387 Increment-2 (DDNS live RFC 2136 backend + loop + HA gate)
 
 - **Timestamp**: 2026-06-20

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -84,6 +84,26 @@ The primary consumer of the `Manager.Events()` channel is
 publish, etc.). `pkg/cluster/reth.go::HandleStateChange` is a
 state-handler method, not the event-channel consumer.
 
+## Interface-monitor link-state detection
+
+`Monitor` (`monitor.go`) is the live carrier-detection loop: a 1-second
+ticker polls each configured `interface-monitor`, dampens transitions,
+and calls `SetMonitorWeight` so a redundancy group is demoted when a
+monitored uplink goes down. The whole point of interface-monitoring is to
+catch carrier loss (cable pulled / peer link down) and fail over.
+
+Link health is therefore decided from the kernel **operational** state
+(`IFLA_OPERSTATE`) via `linkAttrsUp`, **not** the administrative `IFF_UP`
+flag. xpfd admin-ups every managed interface, so `IFF_UP` is the normal
+steady state and stays set even after carrier loss — using it (or OR-ing
+it in) would report a cable-pulled link as UP and suppress failover
+(#2070). The rule is: `OperUp` → up; `OperUnknown` → fall back to the
+admin flag (virtual devices that report no carrier state); `OperDown` /
+`OperLowerLayerDown` / anything else → down. This mirrors
+`pkg/vrrp.linkAttrsUp`, the canonical link-state read used by VRRP
+track-interface detection. `pkg/routing/monitor.go` (the display-side
+`InterfaceMonitorStatus` path) uses the identical helper.
+
 ## Callers
 
 `pkg/daemon`, `pkg/cli`, `pkg/grpcapi`, `pkg/vrrp`.

--- a/pkg/cluster/monitor.go
+++ b/pkg/cluster/monitor.go
@@ -25,8 +25,8 @@ type monitorState struct {
 
 // Dampening defaults.
 const (
-	DefaultMonitorFailThreshold = 3              // consecutive failures before marking down
-	DefaultMonitorPassThreshold = 3              // consecutive successes before marking up
+	DefaultMonitorFailThreshold = 3               // consecutive failures before marking down
+	DefaultMonitorPassThreshold = 3               // consecutive successes before marking up
 	DefaultMonitorHoldDown      = 5 * time.Second // hold-down after state change
 )
 
@@ -264,8 +264,7 @@ func (mon *Monitor) pollInterfaceMonitors(rg *config.RedundancyGroup, statuses [
 			continue
 		}
 
-		up := link.Attrs().OperState == netlink.OperUp ||
-			link.Attrs().Flags&net.FlagUp != 0
+		up := linkAttrsUp(link.Attrs())
 
 		// Track local interface status for heartbeat propagation.
 		statuses = append(statuses, InterfaceMonitorInfo{
@@ -450,8 +449,7 @@ func (mon *Monitor) RGInterfaceReady(rgID int) (bool, []string) {
 				reasons = append(reasons, fmt.Sprintf("interface %s missing", im.Interface))
 				continue
 			}
-			up := link.Attrs().OperState == netlink.OperUp ||
-				link.Attrs().Flags&net.FlagUp != 0
+			up := linkAttrsUp(link.Attrs())
 			if !up {
 				reasons = append(reasons, fmt.Sprintf("interface %s down", im.Interface))
 			}
@@ -482,6 +480,33 @@ func (mon *Monitor) getNlHandle() nlLinkGetter {
 	}
 	mon.cachedNlHandle = h
 	return h
+}
+
+// linkAttrsUp reports whether a monitored interface is operationally up.
+//
+// Interface-monitoring exists to detect carrier loss (cable pulled / peer
+// link down) and demote the redundancy group so HA failover fires. The
+// administrative IFF_UP flag (net.FlagUp) stays set whenever the interface
+// is admin-up — and xpfd admin-ups ALL managed interfaces — so it must NOT
+// be used to decide carrier health: a carrier-down link keeps IFF_UP set
+// while OperState transitions to OperDown/OperLowerLayerDown. Decide from
+// the operational state (IFLA_OPERSTATE):
+//   - OperUp                 -> up.
+//   - OperUnknown            -> fall back to the admin flag (common on
+//     virtual devices that report no carrier state).
+//   - OperDown / lower-layer-down / anything else -> down.
+//
+// This mirrors pkg/vrrp.linkAttrsUp, the canonical link-state read used by
+// VRRP track-interface detection (#2070).
+func linkAttrsUp(attrs *netlink.LinkAttrs) bool {
+	switch attrs.OperState {
+	case netlink.OperUp:
+		return true
+	case netlink.OperUnknown:
+		return attrs.Flags&net.FlagUp != 0
+	default:
+		return false
+	}
 }
 
 type noopNlHandle struct{}

--- a/pkg/cluster/monitor_test.go
+++ b/pkg/cluster/monitor_test.go
@@ -44,6 +44,20 @@ func (h *mockNlHandle) setLink(name string, up bool) {
 	}
 }
 
+// setLinkCarrierDown models a cable-pulled / peer-down interface: it is
+// administratively up (IFF_UP set) but has lost carrier, so OperState is
+// OperDown. This is the #2070 case — the monitor must report it DOWN and
+// demote the redundancy group. Pre-fix the OR with net.FlagUp reported UP.
+func (h *mockNlHandle) setLinkCarrierDown(name string) {
+	h.links[name] = &mockLink{
+		attrs: netlink.LinkAttrs{
+			Name:      name,
+			OperState: netlink.OperDown,
+			Flags:     net.FlagUp,
+		},
+	}
+}
+
 // setNoDampening configures the monitor for immediate state changes (no dampening).
 func setNoDampening(mon *Monitor) {
 	mon.FailThreshold = 1
@@ -681,6 +695,52 @@ func TestMonitor_LocalStatusesConcurrent(t *testing.T) {
 	}()
 
 	<-done
+}
+
+// TestMonitor_CarrierDownDemotesRG is the #2070 regression for the live
+// cluster carrier-detection loop. An admin-up interface that loses carrier
+// (cable pulled / peer down) must be reported DOWN so the redundancy group
+// is demoted and HA failover fires. Pre-fix, poll() OR'd in net.FlagUp
+// (IFF_UP, the admin flag, which stays set on carrier loss), so the link
+// was reported UP, the weight was never subtracted, and failover was
+// suppressed — the bug this test would catch.
+func TestMonitor_CarrierDownDemotesRG(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(0, false, map[int]int{0: 200},
+			&config.InterfaceMonitor{Interface: "trust0", Weight: 100},
+		),
+	)
+	m.UpdateConfig(cfg)
+	drainEvents(m, 1)
+
+	nlh := newMockNlHandle()
+	nlh.setLink("trust0", true)
+
+	mon := NewMonitor(m, cfg.RedundancyGroups)
+	mon.nlHandle = nlh
+	setNoDampening(mon)
+
+	// Initial poll: carrier up, full weight.
+	mon.poll()
+	if w := m.GroupStates()[0].Weight; w != 255 {
+		t.Fatalf("initial weight = %d, want 255", w)
+	}
+
+	// Pull the cable: admin-up but carrier-down. This MUST demote the RG.
+	nlh.setLinkCarrierDown("trust0")
+	mon.poll()
+	if w := m.GroupStates()[0].Weight; w != 155 {
+		t.Errorf("weight after carrier-down = %d, want 155 "+
+			"(carrier-down link reported UP — #2070)", w)
+	}
+
+	// Restore carrier: RG recovers.
+	nlh.setLink("trust0", true)
+	mon.poll()
+	if w := m.GroupStates()[0].Weight; w != 255 {
+		t.Errorf("weight after carrier recovery = %d, want 255", w)
+	}
 }
 
 // drainEvents is defined in election_test.go

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -31,7 +31,7 @@ which makes each domain unit-testable with a fake (see `rules_test.go`'s
 | `probe_pin.go` | `probePinManager` | RPM probe next-hop pin reconciler (#1827): fwmark rules in band 50-99 + pinned host routes in reserved tables 7000-7049 (`probePinOps`, stateless). `Apply` returns per-test install failures (keyed by TestKey) and rolls back the fwmark rule when the pinned route fails (best-effort — a failed rollback is swept by the next band clear; the pin reports failed either way); callers thread the failed map into `pkg/rpm` so affected tests hold state instead of probing unpinned (#1895) |
 | `bond.go` | `bondManager` | bond device lifecycle; own `mu` |
 | `reth.go` | `rethManager` | stale `reth*` bond cleanup |
-| `monitor.go` | `monitorManager` | interface-monitor HA signal; own `mu` |
+| `monitor.go` | `monitorManager` | interface-monitor HA signal; own `mu`. Link health via `linkAttrsUp` reads kernel **operstate** (`OperUp` → up; `OperUnknown` → admin-flag fallback; `OperDown`/lower-layer-down → down), **not** `IFF_UP` — admin-up-but-carrier-down (cable pulled) must report DOWN so HA fails over (#2070). Mirrors `pkg/vrrp.linkAttrsUp` and `pkg/cluster/monitor.go` |
 
 The tunnel domain depends on the VRF domain (`tunnelManager.vrfBinder`)
 to bind tunnel interfaces to a routing-instance VRF;

--- a/pkg/routing/monitor.go
+++ b/pkg/routing/monitor.go
@@ -45,8 +45,7 @@ func (mm *monitorManager) Apply(groups []*config.RedundancyGroup) {
 				// Interface doesn't exist — belongs to peer node. Skip.
 				continue
 			}
-			up := link.Attrs().OperState == netlink.OperUp ||
-				link.Attrs().Flags&net.FlagUp != 0
+			up := linkAttrsUp(link.Attrs())
 			statuses = append(statuses, InterfaceMonitorStatus{
 				Interface: mon.Interface,
 				Weight:    mon.Weight,
@@ -62,6 +61,33 @@ func (mm *monitorManager) Apply(groups []*config.RedundancyGroup) {
 		if len(statuses) > 0 {
 			mm.monitorStatus[rg.ID] = statuses
 		}
+	}
+}
+
+// linkAttrsUp reports whether a monitored interface is operationally up.
+//
+// Interface-monitoring exists to detect carrier loss (cable pulled / peer
+// link down) and demote the redundancy group so HA failover fires. The
+// administrative IFF_UP flag (net.FlagUp) stays set whenever the interface
+// is admin-up — and xpfd admin-ups ALL managed interfaces — so it must NOT
+// be used to decide carrier health: a carrier-down link keeps IFF_UP set
+// while OperState transitions to OperDown/OperLowerLayerDown. Decide from
+// the operational state (IFLA_OPERSTATE):
+//   - OperUp                 -> up.
+//   - OperUnknown            -> fall back to the admin flag (common on
+//     virtual devices that report no carrier state).
+//   - OperDown / lower-layer-down / anything else -> down.
+//
+// This mirrors pkg/vrrp.linkAttrsUp, the canonical link-state read used by
+// VRRP track-interface detection (#2070).
+func linkAttrsUp(attrs *netlink.LinkAttrs) bool {
+	switch attrs.OperState {
+	case netlink.OperUp:
+		return true
+	case netlink.OperUnknown:
+		return attrs.Flags&net.FlagUp != 0
+	default:
+		return false
 	}
 }
 

--- a/pkg/routing/monitor_test.go
+++ b/pkg/routing/monitor_test.go
@@ -1,0 +1,138 @@
+package routing
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// monitorFakeLink is a minimal netlink.Link carrying caller-chosen attrs.
+type monitorFakeLink struct {
+	attrs netlink.LinkAttrs
+}
+
+func (l *monitorFakeLink) Attrs() *netlink.LinkAttrs { return &l.attrs }
+func (l *monitorFakeLink) Type() string              { return "monitor-fake" }
+
+// monitorFakeOps satisfies linkOps but only LinkByName is meaningful; the
+// interface-monitor path touches nothing else. Unused methods return nil so
+// the type still implements the full surface.
+type monitorFakeOps struct {
+	links map[string]netlink.Link
+}
+
+func (o *monitorFakeOps) LinkByName(name string) (netlink.Link, error) {
+	if l, ok := o.links[name]; ok {
+		return l, nil
+	}
+	return nil, net.UnknownNetworkError("not found: " + name)
+}
+
+func (o *monitorFakeOps) LinkAdd(netlink.Link) error                     { return nil }
+func (o *monitorFakeOps) LinkDel(netlink.Link) error                     { return nil }
+func (o *monitorFakeOps) LinkSetUp(netlink.Link) error                   { return nil }
+func (o *monitorFakeOps) LinkSetDown(netlink.Link) error                 { return nil }
+func (o *monitorFakeOps) LinkSetMaster(netlink.Link, netlink.Link) error { return nil }
+func (o *monitorFakeOps) LinkSetNoMaster(netlink.Link) error             { return nil }
+func (o *monitorFakeOps) LinkSetMTU(netlink.Link, int) error             { return nil }
+func (o *monitorFakeOps) LinkList() ([]netlink.Link, error)              { return nil, nil }
+func (o *monitorFakeOps) AddrAdd(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *monitorFakeOps) AddrDel(netlink.Link, *netlink.Addr) error      { return nil }
+func (o *monitorFakeOps) AddrList(netlink.Link, int) ([]netlink.Addr, error) {
+	return nil, nil
+}
+
+// TestInterfaceMonitor_CarrierState is the #2070 regression: a monitored
+// interface that is administratively up but has lost carrier (cable pulled /
+// peer link down) MUST report DOWN so the redundancy-group weight is demoted
+// and HA failover fires. The pre-fix code OR'd in net.FlagUp (IFF_UP, the
+// admin flag), which stays set on carrier loss, so a carrier-down link was
+// reported UP and failover was suppressed.
+func TestInterfaceMonitor_CarrierState(t *testing.T) {
+	const ifName = "ge-0/0/0"
+	linuxName := config.LinuxIfName(ifName)
+
+	tests := []struct {
+		name      string
+		operState netlink.LinkOperState
+		flags     net.Flags
+		wantUp    bool
+	}{
+		{
+			// Cable pulled: admin-up but no carrier. The bug reported UP here.
+			name:      "admin-up carrier-down reports down",
+			operState: netlink.OperDown,
+			flags:     net.FlagUp,
+			wantUp:    false,
+		},
+		{
+			// Peer link down: kernel reports lower-layer-down, IFF_UP still set.
+			name:      "admin-up lower-layer-down reports down",
+			operState: netlink.OperLowerLayerDown,
+			flags:     net.FlagUp,
+			wantUp:    false,
+		},
+		{
+			name:      "admin-up carrier-up reports up",
+			operState: netlink.OperUp,
+			flags:     net.FlagUp,
+			wantUp:    true,
+		},
+		{
+			// Admin-down: IFF_UP clear, must report down.
+			name:      "admin-down reports down",
+			operState: netlink.OperDown,
+			flags:     0,
+			wantUp:    false,
+		},
+		{
+			// Virtual device with no carrier reporting: OperUnknown falls back
+			// to the admin flag (matches pkg/vrrp.linkAttrsUp).
+			name:      "operunknown admin-up reports up",
+			operState: netlink.OperUnknown,
+			flags:     net.FlagUp,
+			wantUp:    true,
+		},
+		{
+			name:      "operunknown admin-down reports down",
+			operState: netlink.OperUnknown,
+			flags:     0,
+			wantUp:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ops := &monitorFakeOps{links: map[string]netlink.Link{
+				linuxName: &monitorFakeLink{attrs: netlink.LinkAttrs{
+					Name:      linuxName,
+					OperState: tc.operState,
+					Flags:     tc.flags,
+				}},
+			}}
+			mm := &monitorManager{
+				ops:           ops,
+				monitorStatus: make(map[int][]InterfaceMonitorStatus),
+			}
+
+			groups := []*config.RedundancyGroup{{
+				ID: 1,
+				InterfaceMonitors: []*config.InterfaceMonitor{
+					{Interface: ifName, Weight: 100},
+				},
+			}}
+			mm.Apply(groups)
+
+			statuses := mm.monitorStatus[1]
+			if len(statuses) != 1 {
+				t.Fatalf("expected 1 monitor status, got %d", len(statuses))
+			}
+			if statuses[0].Up != tc.wantUp {
+				t.Errorf("Up = %v, want %v (operstate=%v flags=%v)",
+					statuses[0].Up, tc.wantUp, tc.operState, tc.flags)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2070 (HIGH, audit-found). The chassis-cluster interface-monitor
reported a **carrier-down** (cable-pulled / peer-link-down) interface as
**UP**, suppressing HA failover — the cluster stayed on a node with a dead
uplink.

## Root cause

Link health was `OperState == netlink.OperUp || Flags&net.FlagUp != 0`.
`net.FlagUp` is the **administrative** IFF_UP flag. xpfd admin-ups ALL
managed interfaces, so that term is essentially always true and the OR
collapsed to "administratively up" regardless of carrier. On carrier loss
the kernel keeps IFF_UP set while `OperState` transitions to
`OperDown`/`OperLowerLayerDown`, so `up` stayed `true`. Downstream,
`SetMonitorWeight(..., down=false, ...)` removed the iface from
`MonitorFails` and deleted its weight, so the redundancy group was never
demoted and the configured failover never fired.

## Fix

Decide link health from the kernel **operational state** (IFLA_OPERSTATE)
via a package-local `linkAttrsUp` helper that mirrors
`pkg/vrrp.linkAttrsUp` — the canonical link-state read already used by VRRP
track-interface detection:

- `OperUp` → up
- `OperUnknown` → fall back to admin IFF_UP (virtual devices with no
  carrier state)
- `OperDown` / `OperLowerLayerDown` / anything else → down

The identical buggy expression lived at **three** sites; all now route
through the helper:

- `pkg/routing/monitor.go` — display-side `InterfaceMonitorStatus` signal
  (the location cited in the issue, ~48-49)
- `pkg/cluster/monitor.go` — the **live** 1-second `poll()` loop feeding
  `SetMonitorWeight` (the dominant continuous carrier-detection path the
  issue flags as broader impact), and the `RGInterfaceReady` readiness
  check

Admin-down still reports down.

## Tests (non-tautological)

Added regression tests in both packages, verified to **FAIL on the pre-fix
code** (carrier-down reported UP; RG weight stayed 255 instead of demoting
to 155) and **PASS after the fix**:

- `pkg/routing/monitor_test.go::TestInterfaceMonitor_CarrierState` —
  table: admin-up+carrier-down → down, admin-up+lower-layer-down → down,
  admin-up+carrier-up → up, admin-down → down, OperUnknown+admin-up → up,
  OperUnknown+admin-down → down.
- `pkg/cluster/monitor_test.go::TestMonitor_CarrierDownDemotesRG` — drives
  the full `poll()` → `SetMonitorWeight` → `GroupStates` weight-demotion
  path with an admin-up+carrier-down link.

## Validation

`go build ./...`, `go vet ./pkg/routing/`, and
`go test ./pkg/routing/ ./pkg/vrrp/ ./pkg/cluster/` all pass.

## ⚠️ Failover-class — mandatory merge gate

This change touches the chassis-cluster failover signal. Per project
policy, **`make test-failover` (cable-pull / link-down failover) is the
mandatory merge gate** and must pass before merge — to be run by the
parent / reviewer.

## Docs

- `pkg/cluster/README.md` — new "Interface-monitor link-state detection"
  section.
- `pkg/routing/README.md` — updated `monitor.go` row.
- `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)