### PR TITLE
#2084: insert `--` end-of-options separator before ping/traceroute target

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,32 @@
 # Action Log
 
+## 2026-06-20 — #2084 ping/traceroute argv `--` end-of-options separator (option-confusion hardening)
+
+- **Timestamp**: 2026-06-20
+- **Action**: Fixed #2084 (LOW, hardening, loopback-API gated). The
+  ping/traceroute exec sites build an argv slice (no shell — NOT
+  injection) but omitted a `--` end-of-options separator before the
+  user-supplied target, so a `-`-prefixed target was interpreted as a
+  ping/traceroute flag (option-confusion). Extracted the inline argv
+  construction at the six target-append points into pure, unit-testable
+  `buildPingArgv`/`buildTracerouteArgv` helpers (one pair per package)
+  and inserted `"--"` immediately before the target. For the
+  `ip vrf exec vrf-<name>` wrapped variant the `--` lands in the inner
+  command's argv (after `ping`/`traceroute`), which is where it must be.
+  The remote CLI (`cmd/cli/main.go`) builds a protobuf request, not an
+  argv, so it inherits the server-side fix; `pkg/upgrade/kernel_linux.go`
+  pings a daemon-internal gateway (no untrusted input) — both out of
+  scope. Added 12 unit tests (4 per package) asserting `--` is present,
+  immediately precedes the target, is the last-but-one element, comes
+  after all options and after the `ping`/`traceroute` binary, and that a
+  `-`-prefixed target lands as the operand. Updated pkg/api/README.md and
+  pkg/grpcapi/README.md.
+- **File(s)**: pkg/grpcapi/server_diag.go, pkg/api/system.go,
+  pkg/cli/cli_request.go, pkg/grpcapi/server_diag_argv_test.go (new),
+  pkg/api/system_argv_test.go (new), pkg/cli/cli_request_argv_test.go
+  (new), pkg/api/README.md, pkg/grpcapi/README.md,
+  docs/pr/2084-ping-traceroute-separator/plan.md (new)
+
 ## 2026-06-20 — #2070 interface-monitor carrier-state read (HIGH, failover-class)
 
 - **Timestamp**: 2026-06-20
@@ -23,6 +50,7 @@
 - **File(s)**: pkg/routing/monitor.go, pkg/routing/monitor_test.go (new),
   pkg/cluster/monitor.go, pkg/cluster/monitor_test.go,
   pkg/cluster/README.md, pkg/routing/README.md, _Log.md
+
 ## 2026-06-20 — #2069 lo0 input filter never installs (invalid `flush ruleset <table>` nft syntax)
 
 - **Timestamp**: 2026-06-20

--- a/docs/pr/2084-ping-traceroute-separator/plan.md
+++ b/docs/pr/2084-ping-traceroute-separator/plan.md
@@ -1,0 +1,145 @@
+# #2084 — `--` end-of-options separator for ping/traceroute argv
+
+Status: IMPLEMENTED — control-plane hardening (no smoke). Pending
+hostile review (2× Claude + Claude SMR) + Copilot.
+
+## Issue framing
+
+The ping/traceroute exec sites build an `argv` slice and run it with
+`exec.CommandContext` (no shell), so there is **no shell/argument
+injection**. The real, lower-severity issue is **option-confusion**: a
+`-`-prefixed target string (e.g. `-oProxyCommand=...`-style or a bare
+`-foo`) is interpreted by `ping`/`traceroute` as a flag rather than a
+destination. The endpoints are loopback-API gated. This is a hardening
+fix, not a security-critical injection bug.
+
+The fix per the triage re-scope: insert a `--` end-of-options separator
+immediately before the user-supplied target at the affected exec sites.
+
+## Affected exec sites (the argv builders)
+
+Six target-append points across three builder families (all build the
+argv that `exec.CommandContext` runs):
+
+| File | Function | Current append |
+|------|----------|----------------|
+| `pkg/grpcapi/server_diag.go` | `Ping` | `args = append(args, req.Target)` |
+| `pkg/grpcapi/server_diag.go` | `Traceroute` | `args = append(args, req.Target)` |
+| `pkg/api/system.go` | `pingHandler` | `args = append(args, req.Target)` |
+| `pkg/api/system.go` | `tracerouteHandler` | `args = append(args, req.Target)` |
+| `pkg/cli/cli_request.go` | `handlePing` | `cmdArgs = append(cmdArgs, target)` |
+| `pkg/cli/cli_request.go` | `handleTraceroute` | `cmdArgs = append(cmdArgs, target)` |
+
+The remote CLI (`cmd/cli/main.go` `handlePing`/`handleTraceroute`)
+builds a protobuf request, NOT an argv — it routes to the server-side
+`grpcapi.Ping`/`Traceroute`, so it inherits the server fix. No change
+needed there.
+
+`pkg/upgrade/kernel_linux.go:445` runs `ping -c 3 -w N <target>` where
+`<target>` is a daemon-internal kernel-promote gateway address, not a
+user-supplied string — out of scope (no untrusted input).
+
+## `--` placement semantics
+
+The `--` must be consumed by `ping`/`traceroute`, not by the
+`ip vrf exec` wrapper. `ip vrf exec <vrf> <cmd> <cmd-args...>` treats
+everything after the vrf name as the command and its arguments, so a
+`--` appended right before the target lands in the inner command's argv:
+
+```
+ip vrf exec vrf-foo ping -c 5 -- <target>
+                    └─── inner cmd argv: ping -c 5 -- <target> ──┘
+```
+
+`--` after the last option but before the operand is the standard
+end-of-options marker honored by util-linux `ping`/`traceroute` and
+inetutils. It makes a `-`-prefixed `<target>` an operand.
+
+## Design: extract pure argv builders + unit-test them
+
+The argv-construction logic is currently inline inside handlers that do
+I/O (`exec`, HTTP, gRPC stream). To get a deterministic unit test that
+asserts `--` precedes the target WITHOUT spawning a process, extract the
+slice-building into small pure helpers that return `[]string`:
+
+- `pkg/grpcapi/server_diag.go`: `buildPingArgv(req)` / `buildTracerouteArgv(req)`
+- `pkg/api/system.go`: `buildPingArgv(req)` / `buildTracerouteArgv(req)`
+- `pkg/cli/cli_request.go`: `buildPingArgv(target, count, source, size, vrf)` /
+  `buildTracerouteArgv(target, source, vrf)`
+
+Each handler calls its builder, then execs the returned slice. The
+builders append `--` then the target last. Each is byte-for-byte
+identical to today's inline logic except for the inserted `--`.
+
+This is a minimal-surface refactor: the handler bodies shrink to
+`cmd := buildXArgv(...)`, the exec/stream/timeout logic is untouched.
+
+## Public API preservation
+
+No exported signatures change. `grpcapi.Server.Ping/Traceroute`,
+`api` handlers, and `cli.CLI.handlePing/handleTraceroute` keep their
+signatures. The new builders are unexported package-level helpers.
+
+## Hidden invariants preserved
+
+- **Arg ordering** unchanged except the inserted `--` immediately before
+  the target. `-c`, `-I`/`-s`, `-s` (size) all still precede `--`.
+- **VRF wrapping** (`ip vrf exec vrf-<name>`) prefix unchanged; `--`
+  goes to the inner command.
+- **Timeouts / WaitDelay / ctx** logic untouched (the exec scaffolding
+  stays in the handler).
+- **Empty-target rejection** still happens in the handler before the
+  builder is reached (`req.Target == ""` guards remain).
+
+## Risk assessment
+
+| Class | Level | Note |
+|-------|-------|------|
+| Behavioral regression | LOW | `--` is a no-op for normal targets; only changes interpretation of `-`-prefixed targets (the intended fix). |
+| Lifetime / borrow | N/A | Go, no borrow checker. |
+| Performance | NONE | One extra slice append on a human-driven diag path. |
+| Architectural mismatch | LOW | Pure local refactor; no cross-cutting state. |
+
+## Test plan
+
+- `GOCACHE=/dev/shm/cache go build ./...` clean.
+- New unit tests, one per builder family, asserting:
+  1. `--` is present in the argv.
+  2. `--` is immediately followed by the target (index of target ==
+     index of `--` + 1).
+  3. `--` appears after all options (no option after `--`).
+  4. A `-`-prefixed target (`-foo`) lands as the operand after `--`.
+  5. VRF variant still wraps with `ip vrf exec vrf-<name>` and the `--`
+     is in the inner command, after `ping`/`traceroute`.
+- `go test ./pkg/grpcapi/ ./pkg/api/ ./pkg/cli/` green.
+- Control-plane only — NO dataplane smoke (per #2084 re-scope).
+
+## Docs
+
+`pkg/api/README.md` and `pkg/grpcapi/README.md` describe the
+ping/traceroute exec scaffolding. Add a one-line note that the target is
+passed after a `--` end-of-options separator (option-confusion
+hardening, #2084).
+
+## Out of scope
+
+- `pkg/upgrade/kernel_linux.go` ping (daemon-internal target).
+- Any input validation/allow-listing of the target string (separate
+  concern; `--` is the minimal, standard fix).
+
+## Open questions for adversarial review
+
+1. Is appending `--` after the wrapper-prefixed `ip vrf exec` correct,
+   i.e. does the `--` reliably reach the inner `ping`/`traceroute`?
+2. Does util-linux `traceroute` (and the busybox/inetutils variants
+   that might be installed) honor `--`? If any installed variant does
+   NOT, does the change break normal targets? (`--` before an operand is
+   POSIX-standard; verify no regression for the common case.)
+3. Is extracting builders worth it vs. a literal one-line
+   `append(args, "--", target)` inline with no test? (Trade-off:
+   testability vs. churn. Plan favors testable builders.)
+4. Any site missed? (cmd/cli, kernel_linux, monitor traffic tcpdump —
+   tcpdump filter is not a target and not `-`-confusable the same way;
+   confirm scope.)
+5. Could `--` itself ever be a problem if the target is legitimately
+   empty? (Guarded: empty target rejected before builder.)

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -90,5 +90,9 @@ under the daemon's errgroup. Nothing else imports this package.
   budgets are request-sized (#1819) via `pingExecTimeout` (count × 1s +
   15s slack, 30s floor) and `diagTracerouteTimeout` (60s), capped at the
   150s `diagExecCeiling` and mirrored in `pkg/grpcapi/exec_timeout.go`.
+  The argv builders (`buildPingArgv`/`buildTracerouteArgv`) place the
+  user-supplied target after a `--` end-of-options separator so a
+  `-`-prefixed target is an operand, not a flag (option-confusion
+  hardening, #2084).
   Do not add raw `exec.Command` calls in handlers: a wedged binary pins
   the handler goroutine and its HTTP connection.

--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -109,25 +109,7 @@ func (s *Server) pingHandler(w http.ResponseWriter, r *http.Request) {
 		count = 100
 	}
 
-	args := []string{"-c", fmt.Sprintf("%d", count)}
-	if req.Source != "" {
-		args = append(args, "-I", req.Source)
-	}
-	if req.Size > 0 {
-		args = append(args, "-s", fmt.Sprintf("%d", req.Size))
-	}
-	args = append(args, req.Target)
-
-	var cmd []string
-	if req.RoutingInstance != "" {
-		vrfDev := req.RoutingInstance
-		if !strings.HasPrefix(vrfDev, "vrf-") {
-			vrfDev = "vrf-" + vrfDev
-		}
-		cmd = append(cmd, "ip", "vrf", "exec", vrfDev)
-	}
-	cmd = append(cmd, "ping")
-	cmd = append(cmd, args...)
+	cmd := buildPingArgv(req, count)
 
 	// Request-sized budget (#1819): count × 1s + slack, 30s floor,
 	// 150s ceiling — see pingExecTimeout in exec_timeout.go.
@@ -156,22 +138,7 @@ func (s *Server) tracerouteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	args := []string{}
-	if req.Source != "" {
-		args = append(args, "-s", req.Source)
-	}
-	args = append(args, req.Target)
-
-	var cmd []string
-	if req.RoutingInstance != "" {
-		vrfDev := req.RoutingInstance
-		if !strings.HasPrefix(vrfDev, "vrf-") {
-			vrfDev = "vrf-" + vrfDev
-		}
-		cmd = append(cmd, "ip", "vrf", "exec", vrfDev)
-	}
-	cmd = append(cmd, "traceroute")
-	cmd = append(cmd, args...)
+	cmd := buildTracerouteArgv(req)
 
 	// Shared diag budget (#1819): same 60s as the gRPC Traceroute path
 	// — see diagTracerouteTimeout in exec_timeout.go.
@@ -187,6 +154,59 @@ func (s *Server) tracerouteHandler(w http.ResponseWriter, r *http.Request) {
 		output += "\n" + err.Error()
 	}
 	writeOK(w, TextResponse{Output: output})
+}
+
+// buildPingArgv builds the argv for the REST ping handler. The
+// user-supplied target is placed after a "--" end-of-options separator
+// so a "-"-prefixed target is treated as the destination operand rather
+// than a ping flag (option-confusion hardening, #2084). count is the
+// already-clamped probe count.
+func buildPingArgv(req PingRequest, count int) []string {
+	args := []string{"-c", fmt.Sprintf("%d", count)}
+	if req.Source != "" {
+		args = append(args, "-I", req.Source)
+	}
+	if req.Size > 0 {
+		args = append(args, "-s", fmt.Sprintf("%d", req.Size))
+	}
+	args = append(args, "--", req.Target)
+
+	var cmd []string
+	if req.RoutingInstance != "" {
+		vrfDev := req.RoutingInstance
+		if !strings.HasPrefix(vrfDev, "vrf-") {
+			vrfDev = "vrf-" + vrfDev
+		}
+		cmd = append(cmd, "ip", "vrf", "exec", vrfDev)
+	}
+	cmd = append(cmd, "ping")
+	cmd = append(cmd, args...)
+	return cmd
+}
+
+// buildTracerouteArgv builds the argv for the REST traceroute handler.
+// The user-supplied target is placed after a "--" end-of-options
+// separator so a "-"-prefixed target is treated as the destination
+// operand rather than a traceroute flag (option-confusion hardening,
+// #2084).
+func buildTracerouteArgv(req TracerouteRequest) []string {
+	args := []string{}
+	if req.Source != "" {
+		args = append(args, "-s", req.Source)
+	}
+	args = append(args, "--", req.Target)
+
+	var cmd []string
+	if req.RoutingInstance != "" {
+		vrfDev := req.RoutingInstance
+		if !strings.HasPrefix(vrfDev, "vrf-") {
+			vrfDev = "vrf-" + vrfDev
+		}
+		cmd = append(cmd, "ip", "vrf", "exec", vrfDev)
+	}
+	cmd = append(cmd, "traceroute")
+	cmd = append(cmd, args...)
+	return cmd
 }
 
 func (s *Server) systemBuffersHandler(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/api/system_argv_test.go
+++ b/pkg/api/system_argv_test.go
@@ -1,0 +1,108 @@
+package api
+
+import "testing"
+
+// indexOf returns the index of want in argv, or -1 if absent.
+func indexOf(argv []string, want string) int {
+	for i, a := range argv {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// assertSeparatorBeforeTarget checks the option-confusion hardening
+// invariant (#2084): a "--" end-of-options separator must appear in the
+// argv and the user-supplied target must be the element immediately
+// after it, and the last element.
+func assertSeparatorBeforeTarget(t *testing.T, argv []string, target string) {
+	t.Helper()
+	sep := indexOf(argv, "--")
+	if sep < 0 {
+		t.Fatalf("argv %v: missing \"--\" end-of-options separator", argv)
+	}
+	if sep+1 >= len(argv) {
+		t.Fatalf("argv %v: \"--\" has no following operand", argv)
+	}
+	if argv[sep+1] != target {
+		t.Fatalf("argv %v: target %q is not immediately after \"--\" (got %q)", argv, target, argv[sep+1])
+	}
+	if sep+1 != len(argv)-1 {
+		t.Fatalf("argv %v: target is not the final argv element", argv)
+	}
+}
+
+func TestBuildPingArgvSeparator(t *testing.T) {
+	tests := []struct {
+		name string
+		req  PingRequest
+		want string
+	}{
+		{"plain target", PingRequest{Target: "192.0.2.1"}, "192.0.2.1"},
+		{"dash-prefixed target", PingRequest{Target: "-I"}, "-I"},
+		{"with source and size", PingRequest{Target: "-f", Source: "10.0.0.1", Size: 1400}, "-f"},
+		{"with routing instance", PingRequest{Target: "-c", RoutingInstance: "blue"}, "-c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argv := buildPingArgv(tt.req, 5)
+			assertSeparatorBeforeTarget(t, argv, tt.want)
+			ping := indexOf(argv, "ping")
+			if ping < 0 || ping > indexOf(argv, "--") {
+				t.Fatalf("argv %v: ping must be present and precede the separator", argv)
+			}
+		})
+	}
+}
+
+func TestBuildPingArgvVRFInnerSeparator(t *testing.T) {
+	argv := buildPingArgv(PingRequest{Target: "-bad", RoutingInstance: "red"}, 5)
+	if indexOf(argv, "ip") != 0 {
+		t.Fatalf("argv %v: VRF wrapper must lead the argv", argv)
+	}
+	if indexOf(argv, "vrf-red") < 0 {
+		t.Fatalf("argv %v: missing vrf-red device", argv)
+	}
+	ping := indexOf(argv, "ping")
+	sep := indexOf(argv, "--")
+	if ping < 0 || sep < 0 || sep < ping {
+		t.Fatalf("argv %v: separator must follow ping in the inner command", argv)
+	}
+	assertSeparatorBeforeTarget(t, argv, "-bad")
+}
+
+func TestBuildTracerouteArgvSeparator(t *testing.T) {
+	tests := []struct {
+		name string
+		req  TracerouteRequest
+		want string
+	}{
+		{"plain target", TracerouteRequest{Target: "2001:db8::1"}, "2001:db8::1"},
+		{"dash-prefixed target", TracerouteRequest{Target: "-s"}, "-s"},
+		{"with source", TracerouteRequest{Target: "-m", Source: "10.0.0.1"}, "-m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argv := buildTracerouteArgv(tt.req)
+			assertSeparatorBeforeTarget(t, argv, tt.want)
+			tr := indexOf(argv, "traceroute")
+			if tr < 0 || tr > indexOf(argv, "--") {
+				t.Fatalf("argv %v: traceroute must be present and precede the separator", argv)
+			}
+		})
+	}
+}
+
+func TestBuildTracerouteArgvVRFInnerSeparator(t *testing.T) {
+	argv := buildTracerouteArgv(TracerouteRequest{Target: "-bad", RoutingInstance: "green"})
+	if indexOf(argv, "ip") != 0 {
+		t.Fatalf("argv %v: VRF wrapper must lead the argv", argv)
+	}
+	tr := indexOf(argv, "traceroute")
+	sep := indexOf(argv, "--")
+	if tr < 0 || sep < 0 || sep < tr {
+		t.Fatalf("argv %v: separator must follow traceroute in the inner command", argv)
+	}
+	assertSeparatorBeforeTarget(t, argv, "-bad")
+}

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -46,21 +46,7 @@ func (c *CLI) handlePing(args []string) error {
 		}
 	}
 
-	var cmdArgs []string
-	if vrfName != "" {
-		cmdArgs = append(cmdArgs, "ip", "vrf", "exec", "vrf-"+vrfName, "ping")
-	} else {
-		cmdArgs = append(cmdArgs, "ping")
-	}
-
-	cmdArgs = append(cmdArgs, "-c", count)
-	if source != "" {
-		cmdArgs = append(cmdArgs, "-I", source)
-	}
-	if size != "" {
-		cmdArgs = append(cmdArgs, "-s", size)
-	}
-	cmdArgs = append(cmdArgs, target)
+	cmdArgs := buildPingArgv(target, count, source, size, vrfName)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
@@ -81,6 +67,29 @@ func (c *CLI) handlePing(args []string) error {
 		return nil // cancelled by Ctrl-C or timeout
 	}
 	return err
+}
+
+// buildPingArgv builds the argv for the local CLI ping command. The
+// user-supplied target is placed after a "--" end-of-options separator
+// so a "-"-prefixed target is treated as the destination operand rather
+// than a ping flag (option-confusion hardening, #2084).
+func buildPingArgv(target, count, source, size, vrfName string) []string {
+	var cmdArgs []string
+	if vrfName != "" {
+		cmdArgs = append(cmdArgs, "ip", "vrf", "exec", "vrf-"+vrfName, "ping")
+	} else {
+		cmdArgs = append(cmdArgs, "ping")
+	}
+
+	cmdArgs = append(cmdArgs, "-c", count)
+	if source != "" {
+		cmdArgs = append(cmdArgs, "-I", source)
+	}
+	if size != "" {
+		cmdArgs = append(cmdArgs, "-s", size)
+	}
+	cmdArgs = append(cmdArgs, "--", target)
+	return cmdArgs
 }
 
 func (c *CLI) handleTraceroute(args []string) error {
@@ -104,17 +113,7 @@ func (c *CLI) handleTraceroute(args []string) error {
 		}
 	}
 
-	var cmdArgs []string
-	if vrfName != "" {
-		cmdArgs = append(cmdArgs, "ip", "vrf", "exec", "vrf-"+vrfName, "traceroute")
-	} else {
-		cmdArgs = append(cmdArgs, "traceroute")
-	}
-
-	if source != "" {
-		cmdArgs = append(cmdArgs, "-s", source)
-	}
-	cmdArgs = append(cmdArgs, target)
+	cmdArgs := buildTracerouteArgv(target, source, vrfName)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
@@ -135,6 +134,26 @@ func (c *CLI) handleTraceroute(args []string) error {
 		return nil // cancelled by Ctrl-C or timeout
 	}
 	return err
+}
+
+// buildTracerouteArgv builds the argv for the local CLI traceroute
+// command. The user-supplied target is placed after a "--"
+// end-of-options separator so a "-"-prefixed target is treated as the
+// destination operand rather than a traceroute flag (option-confusion
+// hardening, #2084).
+func buildTracerouteArgv(target, source, vrfName string) []string {
+	var cmdArgs []string
+	if vrfName != "" {
+		cmdArgs = append(cmdArgs, "ip", "vrf", "exec", "vrf-"+vrfName, "traceroute")
+	} else {
+		cmdArgs = append(cmdArgs, "traceroute")
+	}
+
+	if source != "" {
+		cmdArgs = append(cmdArgs, "-s", source)
+	}
+	cmdArgs = append(cmdArgs, "--", target)
+	return cmdArgs
 }
 
 // handleTest dispatches test sub-commands (policy, routing, security-zone).

--- a/pkg/cli/cli_request_argv_test.go
+++ b/pkg/cli/cli_request_argv_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import "testing"
+
+// indexOf returns the index of want in argv, or -1 if absent.
+func indexOf(argv []string, want string) int {
+	for i, a := range argv {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// assertSeparatorBeforeTarget checks the option-confusion hardening
+// invariant (#2084): a "--" end-of-options separator must appear in the
+// argv and the user-supplied target must be the element immediately
+// after it, and the last element.
+func assertSeparatorBeforeTarget(t *testing.T, argv []string, target string) {
+	t.Helper()
+	sep := indexOf(argv, "--")
+	if sep < 0 {
+		t.Fatalf("argv %v: missing \"--\" end-of-options separator", argv)
+	}
+	if sep+1 >= len(argv) {
+		t.Fatalf("argv %v: \"--\" has no following operand", argv)
+	}
+	if argv[sep+1] != target {
+		t.Fatalf("argv %v: target %q is not immediately after \"--\" (got %q)", argv, target, argv[sep+1])
+	}
+	if sep+1 != len(argv)-1 {
+		t.Fatalf("argv %v: target is not the final argv element", argv)
+	}
+}
+
+func TestBuildPingArgvSeparator(t *testing.T) {
+	tests := []struct {
+		name              string
+		target            string
+		count, source, sz string
+		vrf               string
+	}{
+		{"plain target", "192.0.2.1", "5", "", "", ""},
+		{"dash-prefixed target", "-I", "5", "", "", ""},
+		{"with source and size", "-f", "5", "10.0.0.1", "1400", ""},
+		{"with routing instance", "-c", "5", "", "", "blue"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argv := buildPingArgv(tt.target, tt.count, tt.source, tt.sz, tt.vrf)
+			assertSeparatorBeforeTarget(t, argv, tt.target)
+			ping := indexOf(argv, "ping")
+			if ping < 0 || ping > indexOf(argv, "--") {
+				t.Fatalf("argv %v: ping must be present and precede the separator", argv)
+			}
+		})
+	}
+}
+
+func TestBuildPingArgvVRFInnerSeparator(t *testing.T) {
+	argv := buildPingArgv("-bad", "5", "", "", "red")
+	if indexOf(argv, "ip") != 0 {
+		t.Fatalf("argv %v: VRF wrapper must lead the argv", argv)
+	}
+	if indexOf(argv, "vrf-red") < 0 {
+		t.Fatalf("argv %v: missing vrf-red device", argv)
+	}
+	ping := indexOf(argv, "ping")
+	sep := indexOf(argv, "--")
+	if ping < 0 || sep < 0 || sep < ping {
+		t.Fatalf("argv %v: separator must follow ping in the inner command", argv)
+	}
+	assertSeparatorBeforeTarget(t, argv, "-bad")
+}
+
+func TestBuildTracerouteArgvSeparator(t *testing.T) {
+	tests := []struct {
+		name           string
+		target, source string
+		vrf            string
+	}{
+		{"plain target", "2001:db8::1", "", ""},
+		{"dash-prefixed target", "-s", "", ""},
+		{"with source", "-m", "10.0.0.1", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argv := buildTracerouteArgv(tt.target, tt.source, tt.vrf)
+			assertSeparatorBeforeTarget(t, argv, tt.target)
+			tr := indexOf(argv, "traceroute")
+			if tr < 0 || tr > indexOf(argv, "--") {
+				t.Fatalf("argv %v: traceroute must be present and precede the separator", argv)
+			}
+		})
+	}
+}
+
+func TestBuildTracerouteArgvVRFInnerSeparator(t *testing.T) {
+	argv := buildTracerouteArgv("-bad", "", "green")
+	if indexOf(argv, "ip") != 0 {
+		t.Fatalf("argv %v: VRF wrapper must lead the argv", argv)
+	}
+	tr := indexOf(argv, "traceroute")
+	sep := indexOf(argv, "--")
+	if tr < 0 || sep < 0 || sep < tr {
+		t.Fatalf("argv %v: separator must follow traceroute in the inner command", argv)
+	}
+	assertSeparatorBeforeTarget(t, argv, "-bad")
+}

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -88,3 +88,7 @@ contract.
   the HTTP path), both capped at the 150s `diagExecCeiling`; the same
   formulas live in `pkg/api/exec_timeout.go` for the REST siblings, and
   `streamDiagCmd` kills the child promptly when a stream send fails.
+  The argv builders (`buildPingArgv`/`buildTracerouteArgv`) place the
+  user-supplied target after a `--` end-of-options separator so a
+  `-`-prefixed target is an operand, not a flag (option-confusion
+  hardening, #2084).

--- a/pkg/grpcapi/server_diag.go
+++ b/pkg/grpcapi/server_diag.go
@@ -75,6 +75,19 @@ func (s *Server) Ping(req *pb.PingRequest, stream grpc.ServerStreamingServer[pb.
 	if count > 100 {
 		count = 100
 	}
+	cmd := buildPingArgv(req, count)
+
+	return streamDiagCmd(stream.Context(), pingExecTimeout(count), cmd, func(line string) error {
+		return stream.Send(&pb.PingResponse{Output: line})
+	})
+}
+
+// buildPingArgv builds the argv for the gRPC Ping diag. The
+// user-supplied target is placed after a "--" end-of-options separator
+// so a "-"-prefixed target is treated as the destination operand rather
+// than a ping flag (option-confusion hardening, #2084). count is the
+// already-clamped probe count.
+func buildPingArgv(req *pb.PingRequest, count int) []string {
 	args := []string{"-c", fmt.Sprintf("%d", count)}
 	if req.Source != "" {
 		args = append(args, "-I", req.Source)
@@ -82,7 +95,7 @@ func (s *Server) Ping(req *pb.PingRequest, stream grpc.ServerStreamingServer[pb.
 	if req.Size > 0 {
 		args = append(args, "-s", fmt.Sprintf("%d", req.Size))
 	}
-	args = append(args, req.Target)
+	args = append(args, "--", req.Target)
 
 	var cmd []string
 	if req.RoutingInstance != "" {
@@ -94,21 +107,30 @@ func (s *Server) Ping(req *pb.PingRequest, stream grpc.ServerStreamingServer[pb.
 	}
 	cmd = append(cmd, "ping")
 	cmd = append(cmd, args...)
-
-	return streamDiagCmd(stream.Context(), pingExecTimeout(count), cmd, func(line string) error {
-		return stream.Send(&pb.PingResponse{Output: line})
-	})
+	return cmd
 }
 
 func (s *Server) Traceroute(req *pb.TracerouteRequest, stream grpc.ServerStreamingServer[pb.TracerouteResponse]) error {
 	if req.Target == "" {
 		return status.Error(codes.InvalidArgument, "target required")
 	}
+	cmd := buildTracerouteArgv(req)
+
+	return streamDiagCmd(stream.Context(), diagTracerouteTimeout, cmd, func(line string) error {
+		return stream.Send(&pb.TracerouteResponse{Output: line})
+	})
+}
+
+// buildTracerouteArgv builds the argv for the gRPC Traceroute diag. The
+// user-supplied target is placed after a "--" end-of-options separator
+// so a "-"-prefixed target is treated as the destination operand rather
+// than a traceroute flag (option-confusion hardening, #2084).
+func buildTracerouteArgv(req *pb.TracerouteRequest) []string {
 	args := []string{}
 	if req.Source != "" {
 		args = append(args, "-s", req.Source)
 	}
-	args = append(args, req.Target)
+	args = append(args, "--", req.Target)
 
 	var cmd []string
 	if req.RoutingInstance != "" {
@@ -120,10 +142,7 @@ func (s *Server) Traceroute(req *pb.TracerouteRequest, stream grpc.ServerStreami
 	}
 	cmd = append(cmd, "traceroute")
 	cmd = append(cmd, args...)
-
-	return streamDiagCmd(stream.Context(), diagTracerouteTimeout, cmd, func(line string) error {
-		return stream.Send(&pb.TracerouteResponse{Output: line})
-	})
+	return cmd
 }
 
 // streamDiagCmd runs a command and streams each line of combined output

--- a/pkg/grpcapi/server_diag_argv_test.go
+++ b/pkg/grpcapi/server_diag_argv_test.go
@@ -1,0 +1,150 @@
+package grpcapi
+
+import (
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// indexOf returns the index of want in argv, or -1 if absent.
+func indexOf(argv []string, want string) int {
+	for i, a := range argv {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// assertSeparatorBeforeTarget checks the option-confusion hardening
+// invariant (#2084): a "--" end-of-options separator must appear in the
+// argv and the user-supplied target must be the element immediately
+// after it, with no option appearing after the separator.
+func assertSeparatorBeforeTarget(t *testing.T, argv []string, target string) {
+	t.Helper()
+	sep := indexOf(argv, "--")
+	if sep < 0 {
+		t.Fatalf("argv %v: missing \"--\" end-of-options separator", argv)
+	}
+	if sep+1 >= len(argv) {
+		t.Fatalf("argv %v: \"--\" has no following operand", argv)
+	}
+	if argv[sep+1] != target {
+		t.Fatalf("argv %v: target %q is not immediately after \"--\" (got %q)", argv, target, argv[sep+1])
+	}
+	// The target must be the last element: nothing is appended after it.
+	if sep+1 != len(argv)-1 {
+		t.Fatalf("argv %v: target is not the final argv element", argv)
+	}
+}
+
+func TestBuildPingArgvSeparator(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *pb.PingRequest
+		want string // expected target operand
+	}{
+		{
+			name: "plain target",
+			req:  &pb.PingRequest{Target: "192.0.2.1"},
+			want: "192.0.2.1",
+		},
+		{
+			name: "dash-prefixed target is treated as operand",
+			req:  &pb.PingRequest{Target: "-I"},
+			want: "-I",
+		},
+		{
+			name: "with source and size",
+			req:  &pb.PingRequest{Target: "-f", Source: "10.0.0.1", Size: 1400},
+			want: "-f",
+		},
+		{
+			name: "with routing instance",
+			req:  &pb.PingRequest{Target: "-c", RoutingInstance: "blue"},
+			want: "-c",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argv := buildPingArgv(tt.req, 5)
+			assertSeparatorBeforeTarget(t, argv, tt.want)
+			// ping binary must still be present before the separator.
+			ping := indexOf(argv, "ping")
+			if ping < 0 {
+				t.Fatalf("argv %v: missing ping binary", argv)
+			}
+			if ping > indexOf(argv, "--") {
+				t.Fatalf("argv %v: ping must precede the separator", argv)
+			}
+		})
+	}
+}
+
+func TestBuildPingArgvVRFInnerSeparator(t *testing.T) {
+	argv := buildPingArgv(&pb.PingRequest{Target: "-bad", RoutingInstance: "red"}, 5)
+	// "ip vrf exec vrf-red" wrapper must precede ping, and "--" must be
+	// in the inner command (after ping), so it reaches the inner binary.
+	if indexOf(argv, "ip") != 0 {
+		t.Fatalf("argv %v: VRF wrapper must lead the argv", argv)
+	}
+	if indexOf(argv, "vrf-red") < 0 {
+		t.Fatalf("argv %v: missing vrf-red device", argv)
+	}
+	ping := indexOf(argv, "ping")
+	sep := indexOf(argv, "--")
+	if ping < 0 || sep < 0 || sep < ping {
+		t.Fatalf("argv %v: separator must follow ping in the inner command", argv)
+	}
+	assertSeparatorBeforeTarget(t, argv, "-bad")
+}
+
+func TestBuildTracerouteArgvSeparator(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *pb.TracerouteRequest
+		want string
+	}{
+		{
+			name: "plain target",
+			req:  &pb.TracerouteRequest{Target: "2001:db8::1"},
+			want: "2001:db8::1",
+		},
+		{
+			name: "dash-prefixed target is treated as operand",
+			req:  &pb.TracerouteRequest{Target: "-s"},
+			want: "-s",
+		},
+		{
+			name: "with source",
+			req:  &pb.TracerouteRequest{Target: "-m", Source: "10.0.0.1"},
+			want: "-m",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argv := buildTracerouteArgv(tt.req)
+			assertSeparatorBeforeTarget(t, argv, tt.want)
+			tr := indexOf(argv, "traceroute")
+			if tr < 0 {
+				t.Fatalf("argv %v: missing traceroute binary", argv)
+			}
+			if tr > indexOf(argv, "--") {
+				t.Fatalf("argv %v: traceroute must precede the separator", argv)
+			}
+		})
+	}
+}
+
+func TestBuildTracerouteArgvVRFInnerSeparator(t *testing.T) {
+	argv := buildTracerouteArgv(&pb.TracerouteRequest{Target: "-bad", RoutingInstance: "green"})
+	if indexOf(argv, "ip") != 0 {
+		t.Fatalf("argv %v: VRF wrapper must lead the argv", argv)
+	}
+	tr := indexOf(argv, "traceroute")
+	sep := indexOf(argv, "--")
+	if tr < 0 || sep < 0 || sep < tr {
+		t.Fatalf("argv %v: separator must follow traceroute in the inner command", argv)
+	}
+	assertSeparatorBeforeTarget(t, argv, "-bad")
+}


### PR DESCRIPTION
## Summary

The gRPC, REST, and local-CLI ping/traceroute exec sites build an `argv`
slice and run it with `exec.CommandContext` (no shell). There is **no
shell/argument injection**, but the user-supplied target was appended
directly after the options, so a `-`-prefixed target was interpreted by
`ping`/`traceroute` as a flag rather than a destination
(**option-confusion**). The endpoints are loopback-API gated; this is a
hardening fix, not a security-critical bug (#2084, re-scoped from the
original "argument injection" framing).

The fix inserts a `--` end-of-options separator immediately before the
target at the six target-append points, extracted into pure,
unit-testable `buildPingArgv`/`buildTracerouteArgv` helpers (one pair in
each of `pkg/grpcapi`, `pkg/api`, `pkg/cli`).

## Sites fixed

| File | Function |
|------|----------|
| `pkg/grpcapi/server_diag.go` | `Ping`, `Traceroute` (via `buildPingArgv`/`buildTracerouteArgv`) |
| `pkg/api/system.go` | `pingHandler`, `tracerouteHandler` (via builders) |
| `pkg/cli/cli_request.go` | `handlePing`, `handleTraceroute` (via builders) |

For the `ip vrf exec vrf-<name>` wrapped variant the `--` lands in the
inner command's argv (after the `ping`/`traceroute` binary), where it
must be honored.

**Out of scope:** the remote CLI (`cmd/cli/main.go`) builds a protobuf
request, not an argv, and inherits the server-side fix;
`pkg/upgrade/kernel_linux.go` pings a daemon-internal kernel-promote
gateway with no untrusted input.

## Plan + review

Plan doc: `docs/pr/2084-ping-traceroute-separator/plan.md`

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/grpcapi/ ./pkg/api/ ./pkg/cli/` green
- [x] 12 new argv unit tests (4 per package) pass — assert `--` present,
      immediately precedes the target, is the final-but-one element,
      follows all options and the binary, and that a `-`-prefixed target
      lands as the operand; VRF variants assert the separator sits in the
      inner command after the wrapper
- [x] Control-plane only — NO dataplane smoke (per #2084 re-scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)