### PR TITLE
#2071: render IPv6 prefix-list with the IPv6 match clause

### DIFF
--- a/docs/pr/2071-ipv6-prefix-list/plan.md
+++ b/docs/pr/2071-ipv6-prefix-list/plan.md
@@ -1,8 +1,10 @@
 # #2071 — IPv6 prefix-list rendered with the IPv4 `match ip address` matcher
 
-**Status:** DRAFT v3 — scoped to mirror the route-filter precedent exactly
-after round-2 review (two-sequence machinery collided with co-resident
-route-filters; reverted to a single family-chosen matcher)
+**Status:** PLAN-READY v3 — round-3 both reviewers agree the single
+family-chosen matcher is correct (A: NEEDS-MINOR ×3 honesty/coverage
+items, all folded; B: PLAN-READY). Mirrors the route-filter precedent
+exactly; two-sequence machinery (v2) abandoned after it collided with
+co-resident route-filters.
 
 ## Issue framing
 
@@ -142,13 +144,21 @@ strictly local to the single match line that #2071 reports.
   undefined list regardless of the keyword, so the default is cosmetic for
   the miss case; v4 preserves byte-identity for existing configs.)
 - **mixed list** (a genuinely rare config — `from prefix-list` of a list
-  holding both families): picks `ipv6` (any v6 entry wins). This is the
-  SAME homogeneous-family limitation the route-filter path already has, no
-  better and no worse, and it strictly improves the reported failure
-  (a v6 list referenced in a v6 context now matches). A fully correct
-  mixed-list render cannot be expressed in one route-map index (FRR AND)
-  and is out of scope — see Out of scope; the route-filter path shares
-  this limitation and is the cited precedent.
+  holding both families): picks `ipv6` (any v6 entry wins). This is a
+  **behavior change** vs master, and it is a TRADE, not a strict
+  improvement: master renders `match ip address` for a mixed list, so
+  today the v4 entries match (in a v4 context) and the v6 entries are the
+  reported no-op; v3 renders `match ipv6 address`, so the v6 entries now
+  match (in a v6 context) but the v4 entries STOP matching. A single FRR
+  route-map index cannot serve both families (the round-1 AND finding), so
+  one direction must be chosen; v3 chooses the family the #2071 report is
+  about (v6). The same dual-stack route-map is attached under BOTH
+  `address-family ipv4 unicast` and `address-family ipv6 unicast` for BGP
+  (`policy_render.go` ~342/361), so a mixed list referenced by a dual-stack
+  export will, after v3, filter v6 routes and no longer filter v4 routes
+  via that term. This is the SAME homogeneous-family limitation the
+  adjacent route-filter path already has (it keys on `RouteFilters[0]`),
+  and a fully correct mixed-list render is out of scope (see Out of scope).
 
 ### Why "any v6 entry → ipv6" rather than "first entry's family"
 
@@ -191,7 +201,13 @@ touched. No config schema, AST, or compiler change.
   exact line directly (the two existing tests `internal`/`trusted-nets`
   assert only the `redistribute route-map` line, NOT the match line, so
   they do not by themselves guarantee byte-identity — round-2 reviewer A's
-  MAJOR-2; the new test closes that gap).
+  MAJOR-2; the new test closes that gap). NOTE the byte-identity claim is
+  scoped to v4-only / unknown / empty lists ONLY: a **v6-only list**
+  changes output unconditionally (master `match ip address` → v3
+  `match ipv6 address`) — that IS the fix — including the (benign) case of
+  a v6-only list referenced from a v4-only-attached route-map, where the
+  v6 matcher was already matching nothing useful under the v4 keyword
+  (round-3 MINOR-2).
 - **Single match line only:** exactly one `match ... address prefix-list`
   line per `from prefix-list`, in the term's single sequence. No term-body
   duplication, no second route-map sequence, no seq renumbering — so NO
@@ -212,7 +228,7 @@ touched. No config schema, AST, or compiler change.
 
 | Class | Level | Notes |
 |---|---|---|
-| Behavioral regression | LOW | v4-only and unknown/empty lists render byte-identically; only v6 lists change (from broken→correct); mixed lists pick ipv6, same homogeneous-family limitation the route-filter precedent already has |
+| Behavioral regression | LOW | v4-only and unknown/empty lists render byte-identically; v6 lists change broken→correct. ONE regression vector: a **mixed** list (v4+v6 entries) referenced by `from prefix-list` flips master's v4 matcher to ipv6, so v4 routes that matched via that term stop matching (the v6 routes start). Rare config; same homogeneous-family limitation the route-filter precedent already has; documented in Out of scope |
 | Lifetime / borrow-checker | N/A | Go, no borrow checker; no allocation beyond one stack string |
 | Performance regression | NONE | Control-plane render at commit time; one map lookup + early-exit slice scan per term |
 | Architectural mismatch (#961 / #946-P2) | NONE | Mirrors the adjacent route-filter family branch exactly; no new abstraction, no helper extraction |
@@ -244,8 +260,12 @@ cluster deploy, no iperf3. Coverage is a Go unit test in `pkg/frr`.
      renders the route-filter's `match ip address ...-<term>` clause AND
      the prefix-list's `match ipv6 address prefix-list <name>` clause in
      the term's single sequence, with the route-filter inline definition
-     emitted exactly once. (This documents the accepted homogeneous-family
-     limitation and confirms no term-body duplication — round-2 F1.)
+     emitted exactly once. The test asserts exactly ONE
+     `route-map <name> permit <seq>` header for the term (count == 1, e.g.
+     `strings.Count`) — guarding against any regression to the rejected v2
+     two-sequence design — and that the route-filter `ip prefix-list
+     <name>-<term> seq ...` definition line appears exactly once
+     (round-2 F1 / round-3 MINOR-3, confirming no term-body duplication).
    - **unknown prefix-list name** (not in `po.PrefixLists`) → falls back
      to `match ip address`, one sequence (no panic, no regression).
    Non-tautology: the v6 and mixed cases FAIL against pre-fix code (which
@@ -325,6 +345,22 @@ by the new v4-only test that asserts the exact `match ip address` line.
 F2's e2e-test-package guidance is folded into the test plan. The mixed
 case is explicitly scoped to the route-filter-equivalent homogeneous-family
 limitation (Out of scope).
+
+**Round 3 (on the v3 single-matcher design) — BOTH AGREE:**
+- Reviewer A — PLAN-NEEDS-MINOR (×3, all honesty/coverage, no design
+  change): MINOR-1 drop the "strictly improves" overclaim and name the
+  mixed-list v4→ipv6 flip as the explicit regression vector; MINOR-2 scope
+  the byte-identity claim to exclude the v6-list-in-v4-context emit change;
+  MINOR-3 tighten the co-resident test to assert exactly one route-map
+  sequence for the term. ALL FOLDED above.
+- Reviewer B — PLAN-READY: verified the exact snippet compiles and is
+  correct for all six edge cases, byte-identity proven against the master
+  line, non-tautology proven, the e2e compile path verified live, and the
+  no-doc-change claim accurate.
+
+Both reviewers confirm v3 closes round-1 and round-2 by construction (one
+matcher only → no AND-in-index; no body duplication → no route-filter
+interaction). PROCEED TO IMPLEMENT.
 
 ## Open questions for adversarial review (round 3 — on the v3 single-matcher design)
 

--- a/docs/pr/2071-ipv6-prefix-list/plan.md
+++ b/docs/pr/2071-ipv6-prefix-list/plan.md
@@ -1,0 +1,217 @@
+# #2071 — IPv6 prefix-list rendered with the IPv4 `match ip address` matcher
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+`pkg/frr/policy_render.go` `generatePolicyOptions()` renders a policy
+term's `from prefix-list <name>` unconditionally as
+`match ip address prefix-list <name>` (the IPv4 matcher), with no
+address-family detection:
+
+```go
+if term.PrefixList != "" {
+    fmt.Fprintf(&b, " match ip address prefix-list %s\n", term.PrefixList)
+}
+```
+
+If the referenced prefix-list holds IPv6 prefixes (e.g. `2001:db8::/32`)
+and the policy is applied in an IPv6 context (OSPFv3 export, BGP `inet6`
+route-map), FRR's `match ip address` clause never matches IPv6 routes.
+The operator's export/import filter is a **silent no-op for IPv6** — it
+can leak routes that should be filtered, or fail to permit routes that
+should pass.
+
+The adjacent route-filter path (lines 619-633) already branches on
+`strings.Contains(prefix, ":")` to choose `match ipv6 address` vs
+`match ip address`. The explicit-prefix-list path was never given the
+same family check.
+
+## Honest scope/value framing
+
+This is a **single-site control-plane correctness bug** in FRR config
+rendering. There is no perf dimension — it is a missing address-family
+branch that makes a configured IPv6 routing-policy filter inert. The win
+is correctness: an IPv6 `from prefix-list` filter starts actually
+matching IPv6 routes instead of being silently dropped on the floor.
+
+If reviewers conclude the perf gain is too small to justify the churn,
+PLAN-KILL is an acceptable verdict. (There is no perf gain; the
+justification is pure correctness, and the change is ~10 lines.)
+
+## What's already shipped / partially batched
+
+- The prefix-list *definition* render (lines 535-540) already splits a
+  Junos prefix-list into FRR `ip prefix-list NAME` (v4 entries) and
+  `ipv6 prefix-list NAME` (v6 entries) by per-entry `strings.Contains(":"`
+  detection. FRR keeps `ip` and `ipv6` prefix-lists in independent
+  namespaces even under the same NAME.
+- The route-filter inline-prefix-list path (lines 619-633) already
+  branches the *matcher* on family (it inspects `RouteFilters[0].Prefix`).
+- The compiler (`pkg/config/compiler_routing.go`) already populates both
+  `PolicyOptionsConfig.PrefixLists[name].Prefixes` (line 362) and
+  `term.PrefixList` (lines 518 / 620) from flat-set and hierarchical
+  syntax.
+
+So everything needed to determine the family already exists in the typed
+config; the render just doesn't consult it.
+
+## Concrete design
+
+`generatePolicyOptions` already has `po *config.PolicyOptionsConfig` in
+scope, so `po.PrefixLists[term.PrefixList]` is available. Replace the
+unconditional emit with a family-aware emit.
+
+Determine the family by inspecting the referenced prefix-list's entries.
+A prefix-list may hold v4 entries, v6 entries, or both (mixed). FRR's
+`match ip address` consults only the v4-namespace list; `match ipv6
+address` consults only the v6-namespace list. A given route is either v4
+or v6, so the correct, safe behavior is to emit the v4 matcher when the
+list has any v4 entry, and the v6 matcher when it has any v6 entry —
+emitting **both** for a mixed list. Each clause is consulted only in the
+matching address-family context, so a mixed list does the right thing in
+both an inet and an inet6 route-map without ever ANDing two
+mutually-exclusive matchers (FRR ANDs different-type match clauses, but
+v4-vs-v6 are never simultaneously true for one route, so emitting both is
+strictly correct per-AF and strictly better than today's v4-only).
+
+```go
+if term.PrefixList != "" {
+    hasV4, hasV6 := false, false
+    if pl := po.PrefixLists[term.PrefixList]; pl != nil {
+        for _, p := range pl.Prefixes {
+            if strings.Contains(p, ":") {
+                hasV6 = true
+            } else {
+                hasV4 = true
+            }
+        }
+    }
+    // Unknown / empty prefix-list (not defined, or no entries): default
+    // to the IPv4 matcher to preserve today's behavior — this is the
+    // pre-fix rendering for the lookup-miss case, so no regression.
+    if !hasV4 && !hasV6 {
+        hasV4 = true
+    }
+    if hasV4 {
+        fmt.Fprintf(&b, " match ip address prefix-list %s\n", term.PrefixList)
+    }
+    if hasV6 {
+        fmt.Fprintf(&b, " match ipv6 address prefix-list %s\n", term.PrefixList)
+    }
+}
+```
+
+### Why look up the list instead of carrying family on the term
+
+`PolicyTerm.PrefixList` is just the name string; the family lives on the
+referenced `PrefixList.Prefixes`. The issue text itself calls out that
+the fix "would need to look up `po.PrefixLists[term.PrefixList]` to
+inspect the family." `po` is already the function parameter, so no
+signature change is needed.
+
+### Ordering
+
+The match clause(s) are emitted in the same position as the current
+single line (between the route-filter block and the `match
+source-protocol` lines). For a mixed list, `match ip address` is emitted
+before `match ipv6 address` (deterministic order). No other clause moves.
+
+## Public API preservation
+
+No signature changes. `generatePolicyOptions(po
+*config.PolicyOptionsConfig) string` is unchanged. No exported symbols
+touched. No config schema, AST, or compiler change.
+
+## Hidden invariants the change must preserve
+
+- **Output ordering:** the prefix-list match clause stays between the
+  route-filter block and the `match source-protocol` block. Verified by
+  reading the surrounding emits.
+- **Lookup-miss behavior:** if `term.PrefixList` names a list not present
+  in `po.PrefixLists` (or an empty list), the output is byte-identical to
+  today (`match ip address prefix-list NAME`). No new failure mode.
+- **Determinism:** `pl.Prefixes` is iterated only to compute two booleans;
+  iteration order does not affect output. The two emits are in fixed
+  order. FRR config generation is already sorted by name upstream.
+- **No nil deref:** `po` is non-nil at this site (the function
+  dereferences `po.PrefixLists`, `po.Communities`, etc. unconditionally
+  above). The map index returns nil for a missing key, guarded by the
+  `pl != nil` check.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|---|---|---|
+| Behavioral regression | LOW | v4-only lists render identically; lookup-miss renders identically; only v6/mixed lists change, and they were broken |
+| Lifetime / borrow-checker | N/A | Go, no borrow checker; no new allocations beyond two stack bools |
+| Performance regression | NONE | Control-plane render, runs at commit time; one extra map lookup + slice scan per term |
+| Architectural mismatch (#961 / #946-P2) | NONE | Mirrors the already-accepted route-filter family branch directly above; no new abstraction |
+
+## Test plan
+
+This is a control-plane (FRR render) change — **no dataplane smoke**, no
+cluster deploy, no iperf3. Coverage is a Go unit test in `pkg/frr`.
+
+1. `go build ./...` clean.
+2. New render unit tests (white-box `package frr`, matching the existing
+   `pkg/frr` test convention):
+   - **v4 prefix-list** referenced by `from prefix-list` → output
+     contains `match ip address prefix-list <name>` and does NOT contain
+     `match ipv6 address prefix-list <name>`.
+   - **v6 prefix-list** referenced by `from prefix-list` → output
+     contains `match ipv6 address prefix-list <name>` and does NOT
+     contain `match ip address prefix-list <name>`.
+   - **mixed prefix-list** → output contains BOTH matchers.
+   - **unknown prefix-list name** (not in `po.PrefixLists`) → falls back
+     to `match ip address` (no panic, no regression).
+   Each assertion is non-tautological: the v6 case FAILS against the
+   pre-fix code (which emits `match ip address`), and the v4 case FAILS
+   if the fix accidentally flips the default.
+3. An **end-to-end flat-set test** honoring the CLAUDE.md rule
+   (`ParseSetCommand` + `tree.SetPath` loop, NOT `NewParser`): feed
+   `set policy-options prefix-list v6nets 2001:db8::/32`,
+   `set policy-options policy-statement p term t1 from prefix-list v6nets`,
+   `... then accept`, compile with `CompileConfig`, render via
+   `generatePolicyOptions(cfg.PolicyOptions)`, assert `match ipv6
+   address`. This proves the family propagates compiler→render.
+4. `go test ./pkg/frr/... ./pkg/config/...` green.
+5. Named new test 5x for flake stability.
+6. Full `go test ./...` green (30 Go packages).
+
+## Out of scope (explicitly)
+
+- The route-filter path's homogeneous-family assumption (it inspects only
+  `RouteFilters[0].Prefix`). That is a pre-existing, separate behavior and
+  not what #2071 reports. Not touched.
+- Any change to how prefix-lists are *defined* in FRR (lines 535-540) —
+  already family-correct.
+- BGP address-family-aware route-map *attachment* (which `address-family`
+  block a route-map is referenced under). Out of scope; the bug is the
+  match clause, not the attachment.
+
+## Open questions for adversarial review
+
+1. **Mixed-list correctness:** is emitting BOTH `match ip address` and
+   `match ipv6 address` for a mixed prefix-list correct, or could FRR AND
+   them and break matching in a single-AF route-map? (Claim: a route is
+   exactly one family, so the off-family matcher is simply never
+   consulted; per-AF behavior is correct. Challenge this.)
+2. **Lookup-miss default:** is defaulting to `match ip address` on an
+   undefined/empty prefix-list the right no-regression choice, or should
+   it emit nothing / a warning? (Pre-fix behavior was v4; preserving it
+   avoids surprise, but is silent-v4 the right call?)
+3. **Is the family knowable at render time at all?** Could a referenced
+   prefix-list legitimately be absent from `po.PrefixLists` in production
+   (forward reference, cross-instance)? If so, is silent v4 a latent bug?
+4. **Ordering:** does emitting `match ip` before `match ipv6` for mixed
+   lists matter to FRR, or to config-diff stability? (Claim: independent
+   clauses, order-irrelevant to FRR; fixed order for diff stability.)
+5. **Should the fix instead refuse / warn at commit time** when a v6
+   prefix-list is referenced from an inet-only policy context, rather than
+   fixing the renderer? (Claim: the renderer is the right layer — the
+   policy term itself is AF-agnostic in Junos; the render must honor the
+   referenced list's family. Challenge.)
+6. **Test adequacy:** does the unit test prove non-tautology (fails
+   pre-fix) AND cover the mixed + lookup-miss cases? Is the end-to-end
+   flat-set test redundant or load-bearing?

--- a/docs/pr/2071-ipv6-prefix-list/plan.md
+++ b/docs/pr/2071-ipv6-prefix-list/plan.md
@@ -1,7 +1,8 @@
 # #2071 — IPv6 prefix-list rendered with the IPv4 `match ip address` matcher
 
-**Status:** DRAFT v2 — mixed-list design corrected after round-1 review
-(reviewer A PLAN-NEEDS-MAJOR: dual-emit-in-one-sequence is FRR-broken)
+**Status:** DRAFT v3 — scoped to mirror the route-filter precedent exactly
+after round-2 review (two-sequence machinery collided with co-resident
+route-filters; reverted to a single family-chosen matcher)
 
 ## Issue framing
 
@@ -66,10 +67,10 @@ unconditional emit with a family-aware emit.
 Determine the family by inspecting the referenced prefix-list's entries.
 A prefix-list may hold v4 entries, v6 entries, or both (mixed).
 
-### FRR route-map AND semantics (round-1 correction)
+### FRR route-map AND semantics (round-1 finding — why "both in one sequence" is wrong)
 
-Round-1 reviewer A correctly refuted v1's "emit both matchers in one
-sequence" design. Verified against FRR master source:
+Round-1 reviewer A refuted v1's "emit both matchers in one sequence"
+design. Verified against FRR master source:
 
 - `lib/routemap.c` `route_map_apply_match` combines match clauses within
   a single route-map index with **AND** semantics — the truth table is
@@ -80,69 +81,85 @@ sequence" design. Verified against FRR master source:
   `RMAP_NOMATCH` (never `RMAP_NOOP`) both when the named list is absent in
   that AFI namespace AND when the prefix fails a present list.
 
-The definition render (lines 535-540) splits a mixed Junos list into BOTH
-a populated `ip prefix-list X` and a populated `ipv6 prefix-list X`.
-Therefore, if v1 emitted `match ip address X` and `match ipv6 address X`
-in the SAME route-map sequence, a v4 route would MATCH the v4 clause but
-NOMATCH the (populated) v6 clause → index NOMATCH → the route is
-**silently denied**, and symmetrically for v6 routes. That is strictly
-worse than today (today, mixed-list v4 routes at least work). The
-dual-emit-in-one-sequence design is therefore rejected.
+So two `match ip|ipv6 address prefix-list` clauses must never coexist in
+one route-map index — one of them will always NOMATCH a given route and
+AND the index to a silent deny.
 
-### Corrected design
+### Round-2 finding — why the two-sequence machinery is also wrong here
 
-The two address families must never be AND-ed in one index. Render rule:
+v2 tried to express a mixed list as TWO consecutive route-map sequences
+(a v4 sequence and a v6 sequence) each carrying the full term body.
+Round-2 reviewers A and B both found this collides with a co-resident
+route-filter: a term may carry BOTH `from route-filter` and
+`from prefix-list` (independent Junos `from` clauses; the compiler
+populates `term.RouteFilters` and `term.PrefixList` independently —
+`compiler_routing.go`). The route-filter emits its OWN
+`match ip|ipv6 address prefix-list NAME-TERM` clause whose family is fixed
+from `RouteFilters[0].Prefix`. Duplicating the full term body into both
+split sequences puts a v4 route-filter `match` clause into the v6
+sequence → a v6 route AND-NOMATCHes → the round-1 silent-deny bug,
+relocated. The two-sequence design also re-emits the route-filter's inline
+prefix-list *definition* lines twice. Rejected.
 
-- **Single-family list** (all v4, or all v6 — the common case and the
-  exact #2071 report): emit the one family-correct matcher in the term's
-  single sequence. This is the uncontested, correct fix.
-- **Mixed list:** emit the term as **two consecutive route-map
-  sequences** — an IPv4 sequence carrying `match ip address` and an IPv6
-  sequence carrying `match ipv6 address` — each carrying the term's other
-  match clauses and `then` set-actions. FRR evaluates sequences in order
-  and falls through on NOMATCH, so a v4 route NOMATCHes the v6 sequence
-  and is caught by the v4 sequence (and vice versa). This is the FRR-idiomatic
-  way to express "match if the route is in the v4 list OR the v6 list"
-  for an AF-agnostic Junos term.
-- **Unknown / empty list** (name absent from `po.PrefixLists`, or no
-  entries): default to the IPv4 matcher in the single sequence — the
-  pre-fix rendering, so no regression. (Note: FRR itself NOMATCHes an
-  undefined list regardless of the v4/v6 keyword, so the default is
-  cosmetic for the miss case; v4 is chosen only to preserve byte-identical
-  output for existing v4-only configs that reference a list.)
+### v3 design — mirror the route-filter precedent exactly
 
-Implementation: factor the term body (the route-filter block, the
-prefix-list match line, `match source-protocol`, `match community`,
-`match as-path`, the `then` set-actions, and the trailing `exit`) into a
-helper `func renderPolicyTermBody(b, term, prefixListMatch string)` so
-the only thing that varies between the v4 and v6 sequences is the
-prefix-list match line. The route-map loop then becomes:
+The issue and the parent directive both say to "branch the PrefixList
+render path on address family **exactly like the adjacent route-filter
+path**." The route-filter path (lines 629-633) emits exactly ONE matcher,
+chosen by family, and makes a deliberate homogeneous-family assumption
+(it inspects only `RouteFilters[0].Prefix`). v3 mirrors that precisely:
+
+- Look up `po.PrefixLists[term.PrefixList]`. If ANY entry is IPv6
+  (`strings.Contains(p, ":")`), emit `match ipv6 address prefix-list X`;
+  otherwise emit `match ip address prefix-list X`. Exactly ONE matcher,
+  in the term's single sequence, in the same position as today.
 
 ```go
-v4, v6 := prefixListFamilies(po, term.PrefixList) // (hasV4, hasV6)
-switch {
-case term.PrefixList == "":
-    emit one sequence, prefixListMatch = ""
-case v4 && v6:
-    // mixed: two sequences
-    emit sequence @ seq   with "match ip address prefix-list X"
-    seq += 10
-    emit sequence @ seq   with "match ipv6 address prefix-list X"
-case v6 && !v4:
-    emit one sequence with "match ipv6 address prefix-list X"
-default: // v4-only, or unknown/empty (default v4)
-    emit one sequence with "match ip address prefix-list X"
+if term.PrefixList != "" {
+    matchKW := "ip"
+    if pl := po.PrefixLists[term.PrefixList]; pl != nil {
+        for _, p := range pl.Prefixes {
+            if strings.Contains(p, ":") {
+                matchKW = "ipv6"
+                break
+            }
+        }
+    }
+    fmt.Fprintf(&b, " match %s address prefix-list %s\n", matchKW, term.PrefixList)
 }
-seq += 10
 ```
 
-`prefixListFamilies` classifies each entry with the SAME
-`strings.Contains(p, ":")` test the definition render uses, guaranteeing
-the match clause and the prefix-list namespace can never disagree.
+This is ~8 lines, no helper extraction, no term-body duplication, no
+sequence renumbering, and therefore **no interaction with co-resident
+route-filters, set-actions, or other match clauses** — the change is
+strictly local to the single match line that #2071 reports.
 
-The mixed case is rare but real (Junos `from prefix-list` is
-AF-agnostic and a list may hold both families); handling it correctly
-rather than producing a silent-deny is worth the small helper extraction.
+- **v6 list** (the #2071 report): now correctly emits `match ipv6 address`.
+- **v4-only list:** byte-identical to master (`match ip address`).
+- **unknown / empty list** (name absent from `po.PrefixLists`, or no
+  entries): `pl` is nil or has no entries → loop sets nothing → default
+  `match ip address` — byte-identical to master. (FRR NOMATCHes an
+  undefined list regardless of the keyword, so the default is cosmetic for
+  the miss case; v4 preserves byte-identity for existing configs.)
+- **mixed list** (a genuinely rare config — `from prefix-list` of a list
+  holding both families): picks `ipv6` (any v6 entry wins). This is the
+  SAME homogeneous-family limitation the route-filter path already has, no
+  better and no worse, and it strictly improves the reported failure
+  (a v6 list referenced in a v6 context now matches). A fully correct
+  mixed-list render cannot be expressed in one route-map index (FRR AND)
+  and is out of scope — see Out of scope; the route-filter path shares
+  this limitation and is the cited precedent.
+
+### Why "any v6 entry → ipv6" rather than "first entry's family"
+
+The route-filter precedent keys on `RouteFilters[0].Prefix` (first entry).
+v3 keys on "any v6 entry" so that a list whose first entry happens to be
+v4 but which the operator intends as a v6 filter (e.g. listed v4 then v6)
+still gets the v6 matcher — directly serving the reported bug. For a
+homogeneous list (the overwhelming common case) the two rules are
+identical. The difference only shows for a mixed list, where neither rule
+is fully correct (FRR limitation) and "any v6 wins" is the choice that
+makes the reported v6 case work.
 
 ### Why look up the list instead of carrying family on the term
 
@@ -154,13 +171,10 @@ signature change is needed.
 
 ### Ordering
 
-For a single-family or unknown list the match clause is emitted in the
-same position as the current single line (between the route-filter block
-and the `match source-protocol` lines) — output is byte-identical to
-v1-of-master for v4-only configs. For a mixed list, the v4 sequence is
-emitted at the term's seq, the v6 sequence at seq+10 (deterministic),
-shifting later terms' seq numbers by one step — a cosmetic numbering
-change with no semantic effect (FRR seq numbers only order evaluation).
+The single match clause is emitted in exactly the same position as the
+current single line (between the route-filter block and the
+`match source-protocol` lines). No clause moves; no seq renumbering. For
+v4-only and unknown/empty lists the output is byte-identical to master.
 
 ## Public API preservation
 
@@ -170,24 +184,25 @@ touched. No config schema, AST, or compiler change.
 
 ## Hidden invariants the change must preserve
 
-- **Output ordering / byte-identity for v4-only configs:** a term that
+- **Byte-identity for v4-only and unknown/empty configs:** a term that
   references a v4-only (or unknown/empty) prefix-list renders byte-identically
-  to master — same single `match ip address` line in the same position,
-  same seq numbering. Verified against the two existing tests
-  (`internal`, `trusted-nets`, both v4-only) which must still pass
-  unchanged.
-- **Term body equivalence across split:** the extracted
-  `renderPolicyTermBody` must emit exactly the same clauses (route-filter
-  block, source-protocol/community/as-path matches, all `then`
-  set-actions, trailing `exit`) it does today — only the prefix-list match
-  line is parameterized. A mixed-list split therefore duplicates the full
-  term semantics into both sequences (AND-ed per sequence, OR-ed across
-  the two sequences) — correct for an AF-agnostic term.
+  to master — the same single `match ip address` line in the same
+  position, same seq numbering. The new v4-only render test asserts the
+  exact line directly (the two existing tests `internal`/`trusted-nets`
+  assert only the `redistribute route-map` line, NOT the match line, so
+  they do not by themselves guarantee byte-identity — round-2 reviewer A's
+  MAJOR-2; the new test closes that gap).
+- **Single match line only:** exactly one `match ... address prefix-list`
+  line per `from prefix-list`, in the term's single sequence. No term-body
+  duplication, no second route-map sequence, no seq renumbering — so NO
+  interaction with co-resident route-filters, set-actions, or other match
+  clauses (round-2 MAJOR-1 / F1 eliminated by construction).
 - **No AND of v4 and v6 prefix-list matchers in one index** — the round-1
-  defect. The two matchers only ever appear in separate sequences.
-- **Determinism:** `pl.Prefixes` is iterated only to compute two booleans;
-  iteration order does not affect output. FRR config generation is sorted
-  by policy-statement name upstream.
+  defect; v3 emits only one matcher, so it cannot occur.
+- **Determinism:** `pl.Prefixes` is scanned only to pick one keyword;
+  the `break` on the first v6 entry makes it order-independent for the
+  v4/v6 decision (any v6 entry → ipv6). FRR config generation is sorted by
+  policy-statement name upstream.
 - **No nil deref:** `po` is non-nil at this site (the function
   dereferences `po.PrefixLists`, `po.Communities`, etc. unconditionally
   above). The map index returns nil for a missing key (and indexing even a
@@ -197,10 +212,10 @@ touched. No config schema, AST, or compiler change.
 
 | Class | Level | Notes |
 |---|---|---|
-| Behavioral regression | LOW | v4-only and unknown/empty lists render byte-identically; only v6 (now correct) and mixed (now two-sequence, was broken) change |
-| Lifetime / borrow-checker | N/A | Go, no borrow checker; the helper extraction is pure code motion |
-| Performance regression | NONE | Control-plane render at commit time; one map lookup + slice scan per term |
-| Architectural mismatch (#961 / #946-P2) | NONE | Single-family path mirrors the route-filter family branch; mixed path is the FRR-idiomatic two-sequence OR |
+| Behavioral regression | LOW | v4-only and unknown/empty lists render byte-identically; only v6 lists change (from broken→correct); mixed lists pick ipv6, same homogeneous-family limitation the route-filter precedent already has |
+| Lifetime / borrow-checker | N/A | Go, no borrow checker; no allocation beyond one stack string |
+| Performance regression | NONE | Control-plane render at commit time; one map lookup + early-exit slice scan per term |
+| Architectural mismatch (#961 / #946-P2) | NONE | Mirrors the adjacent route-filter family branch exactly; no new abstraction, no helper extraction |
 
 ## Test plan
 
@@ -211,29 +226,43 @@ cluster deploy, no iperf3. Coverage is a Go unit test in `pkg/frr`.
 2. New render unit tests (white-box `package frr`, matching the existing
    `pkg/frr` test convention):
    - **v4 prefix-list** referenced by `from prefix-list` → output
-     contains `match ip address prefix-list <name>` and does NOT contain
-     `match ipv6 address prefix-list <name>`; ONE route-map sequence.
+     contains the exact line `match ip address prefix-list <name>` and does
+     NOT contain `match ipv6 address prefix-list <name>`. This directly
+     asserts the v4 byte-identity that the existing tests do not (round-2
+     MAJOR-2).
    - **v6 prefix-list** referenced by `from prefix-list` → output
      contains `match ipv6 address prefix-list <name>` and does NOT
-     contain `match ip address prefix-list <name>`; ONE sequence.
-   - **mixed prefix-list** → output contains `match ip address` in one
-     route-map sequence and `match ipv6 address` in a SEPARATE sequence
-     (assert TWO `route-map <name> ...` headers and that the two matchers
-     are NOT in the same sequence body). This asserts the SAFE shape, not
-     "both lines present somewhere" — guarding against the round-1 defect.
+     contain `match ip address prefix-list <name>`.
+   - **mixed prefix-list** → output picks `match ipv6 address` (any v6
+     entry wins) and emits exactly ONE such match line (assert it does NOT
+     contain `match ip address prefix-list <name>` and that there is a
+     single route-map sequence for the term — no second sequence). This
+     locks in the v3 single-matcher behavior and guards against any
+     regression to the rejected v1 dual-emit or v2 two-sequence designs.
+   - **prefix-list co-resident with a v4 route-filter, mixed list** → a
+     term with both a v4 `from route-filter` and a mixed `from prefix-list`
+     renders the route-filter's `match ip address ...-<term>` clause AND
+     the prefix-list's `match ipv6 address prefix-list <name>` clause in
+     the term's single sequence, with the route-filter inline definition
+     emitted exactly once. (This documents the accepted homogeneous-family
+     limitation and confirms no term-body duplication — round-2 F1.)
    - **unknown prefix-list name** (not in `po.PrefixLists`) → falls back
      to `match ip address`, one sequence (no panic, no regression).
-   Each assertion is non-tautological: the v6 case FAILS against pre-fix
-   code (which emits `match ip address`); the mixed case FAILS against
-   both pre-fix code AND the rejected v1 dual-emit-in-one-sequence design.
+   Non-tautology: the v6 and mixed cases FAIL against pre-fix code (which
+   emits `match ip address`).
 3. An **end-to-end flat-set test** honoring the CLAUDE.md rule
-   (`ParseSetCommand` + `tree.SetPath` loop, NOT `NewParser`): feed
+   (`ParseSetCommand` + `tree.SetPath` loop, NOT `NewParser`). The test
+   lives in `package frr` (it calls the unexported `generatePolicyOptions`)
+   and therefore inlines its own `ParseSetCommand`+`SetPath`+`CompileConfig`
+   loop using the exported `config` APIs — it CANNOT reuse the
+   `package config` `buildTree` helper (round-2 F2). Feed
    `set policy-options prefix-list v6nets 2001:db8::/32`,
    `set policy-options policy-statement p term t1 from prefix-list v6nets`,
-   `... then accept`, compile with `CompileConfig`, render via
-   `generatePolicyOptions(&cfg.PolicyOptions)` (note: `PolicyOptions` is a
-   value field, so pass its address), assert `match ipv6 address`. This
-   proves the family propagates compiler→render.
+   `set policy-options policy-statement p term t1 then accept`, compile with
+   `config.CompileConfig`, render via `m.generatePolicyOptions(&cfg.PolicyOptions)`
+   (note: `PolicyOptions` is a value field, so pass its address — round-2
+   B Minor-1), assert `match ipv6 address`. Proves the family propagates
+   compiler→render.
 4. `go test ./pkg/frr/... ./pkg/config/...` green.
 5. Named new test 5x for flake stability.
 6. Full `go test ./...` green (30 Go packages).
@@ -241,58 +270,83 @@ cluster deploy, no iperf3. Coverage is a Go unit test in `pkg/frr`.
 **Docs:** `pkg/frr/README.md` describes `generatePolicyOptions`'
 responsibilities at a high level but does not document per-clause
 match-family rendering, so it stays accurate and needs no change — noted
-here per the CLAUDE.md docs-contract rule.
+here per the CLAUDE.md docs-contract rule (round-2 both reviewers
+confirmed no doc under `docs/` documents render-family behavior either).
 
 ## Out of scope (explicitly)
 
-- The route-filter path's homogeneous-family assumption (it inspects only
-  `RouteFilters[0].Prefix`). That is a pre-existing, separate behavior and
-  not what #2071 reports. Not touched.
+- **Fully-correct mixed-family prefix-list rendering.** A prefix-list
+  holding BOTH v4 and v6 entries, referenced by an AF-agnostic
+  `from prefix-list`, cannot be expressed as a single FRR route-map index
+  (two `match ... address` clauses would AND to a silent deny), and the
+  two-sequence workaround collides with co-resident route-filters (round-2
+  MAJOR-1). v3 picks the v6 matcher for a mixed list (making the reported
+  v6 case work) and accepts the same homogeneous-family limitation the
+  adjacent route-filter path already has. A complete mixed-family fix
+  (e.g. commit-time validation/warning, or a route-map redesign) is a
+  separate, larger effort — file a follow-up if a real mixed-list config
+  appears.
+- The route-filter path's own homogeneous-family assumption (it inspects
+  only `RouteFilters[0].Prefix`). Pre-existing; not what #2071 reports.
+  Not touched.
 - Any change to how prefix-lists are *defined* in FRR (lines 535-540) —
   already family-correct.
 - BGP address-family-aware route-map *attachment* (which `address-family`
   block a route-map is referenced under). Out of scope; the bug is the
   match clause, not the attachment.
 
-## Round-1 review resolution
+## Review resolution log
 
-- **Reviewer A — PLAN-NEEDS-MAJOR (mixed-list dual-emit-in-one-sequence is
-  FRR-broken).** ACCEPTED. Verified against FRR master source
-  (`lib/routemap.c` AND truth-table + no AF pre-filter in the match loop;
-  `bgpd/bgp_routemap.c route_match_address_prefix_list` returns NOMATCH on
-  off-family). v2 replaces dual-emit with the single-family matcher for
-  homogeneous lists and a **two-sequence OR** for mixed lists, and the
-  mixed test now asserts the two matchers are in SEPARATE sequences.
-- **Reviewer B — PLAN-READY w/ 2 minors.** Minor-1 (`&cfg.PolicyOptions`
-  pointer in the end-to-end test) FOLDED into the test plan. Minor-2 (docs
-  note) FOLDED — `pkg/frr/README.md` needs no change, stated explicitly.
-  B's heuristic-consistency verification (the fix's `strings.Contains(":")`
-  is byte-identical to the definition render at line 536, so the match
-  clause and namespace can never disagree) is retained as a load-bearing
-  correctness argument.
+**Round 1:**
+- Reviewer A — PLAN-NEEDS-MAJOR: v1's "emit both matchers in one sequence"
+  is FRR-broken. ACCEPTED, verified against FRR master source.
+- Reviewer B — PLAN-READY w/ 2 minors (`&cfg.PolicyOptions` pointer; docs
+  note). Both folded.
 
-## Open questions for adversarial review (round 2)
+**Round 2 (on the v2 two-sequence design):**
+- Reviewer A — PLAN-NEEDS-MAJOR: (MAJOR-1) the two-sequence split puts a
+  v4 route-filter `match` clause into the v6 sequence for a term carrying
+  BOTH a route-filter and a mixed prefix-list → relocated silent-deny;
+  (MAJOR-2) the byte-identity claim leaned on existing tests that do not
+  assert the `term.PrefixList` match line.
+- Reviewer B — PLAN-NEEDS-MINOR: (F1) the route-filter inline *definition*
+  lines get emitted twice under the split; (F2) the e2e test must live in
+  `package frr` and inline its own ParseSetCommand loop (can't reuse
+  `config.buildTree`); (F5) promote the reject-term OR-correctness to
+  resolved text.
 
-1. **Two-sequence mixed-list emit:** is splitting a mixed-list term into a
-   v4 sequence and a v6 sequence (each carrying the full term body, OR-ed
-   by fall-through) semantically correct for both `permit` and `reject`
-   terms? For a `reject` term, does the off-family sequence falling
-   through (rather than denying) ever change the policy outcome vs. a
-   single AF-agnostic Junos term? Challenge the OR-of-two-sequences model.
-2. **Term-body duplication side-effects:** does emitting the `then`
-   set-actions (next-hop, local-pref, metric, community, origin) twice —
-   once per sequence — cause any double-apply hazard, or is it inert
-   because only one sequence ever matches a given route?
-3. **Lookup-miss default to v4:** still the right no-regression choice
+**v3 resolution — ACCEPTED ALL, by simplification:** rather than keep the
+two-sequence machinery and patch its route-filter interactions, v3 drops
+it entirely and mirrors the route-filter precedent exactly — ONE match
+clause, family chosen by the referenced list (any v6 entry → ipv6). This
+eliminates MAJOR-1, F1, and the F2 helper-extraction complexity by
+construction (no body duplication, no second sequence). MAJOR-2 is closed
+by the new v4-only test that asserts the exact `match ip address` line.
+F2's e2e-test-package guidance is folded into the test plan. The mixed
+case is explicitly scoped to the route-filter-equivalent homogeneous-family
+limitation (Out of scope).
+
+## Open questions for adversarial review (round 3 — on the v3 single-matcher design)
+
+1. **Single-matcher correctness:** for a homogeneous list, is one
+   family-chosen `match ... address prefix-list` the complete and correct
+   fix (it is what the route-filter precedent does)? Any case where one
+   matcher is insufficient for a homogeneous list?
+2. **"Any v6 entry → ipv6" vs route-filter's "first entry":** is keying on
+   any-v6 (rather than first-entry family, as the route-filter path does)
+   a defensible deviation, or should v3 match the precedent's first-entry
+   rule byte-for-byte? (They differ only for mixed lists.)
+3. **Mixed-list scoping:** is accepting the route-filter-equivalent
+   homogeneous-family limitation (mixed → ipv6, document as out-of-scope)
+   the right call, or must #2071 also solve mixed lists? (Claim: a single
+   FRR route-map index cannot express a mixed match without a silent-deny;
+   solving it is a separate larger effort.)
+4. **Lookup-miss default to v4:** still the right no-regression choice
    given FRR NOMATCHes an undefined list regardless of keyword?
-4. **Seq renumbering:** the mixed case shifts later terms' seq numbers by
-   +10. Any concern for config-diff churn or FRR reload behavior? (Claim:
-   seq numbers only order evaluation; cosmetic.)
-5. **Should mixed lists instead be rejected/warned at commit time** rather
-   than rendered as two sequences? (Claim: two-sequence render preserves
-   the operator's intent without a new failure mode; commit-time refusal
-   would break configs that work today for v4.)
-6. **Test adequacy:** does the mixed test assert the SAFE two-sequence
-   shape (not merely "both lines present")? Does it prove non-tautology
-   against BOTH pre-fix code and the rejected v1 design? Is the end-to-end
-   flat-set test redundant or load-bearing?
+5. **Byte-identity:** does the v4-only test assert the exact unchanged line
+   (closing round-2 MAJOR-2), and is the v3 render provably identical to
+   master for all v4-only / unknown / empty configs?
+6. **Test adequacy / non-tautology:** do the v6 and mixed tests FAIL
+   against pre-fix code? Does the co-resident-route-filter test confirm no
+   term-body duplication and a single match clause? Is the end-to-end
+   flat-set test correctly placed in `package frr`?

--- a/docs/pr/2071-ipv6-prefix-list/plan.md
+++ b/docs/pr/2071-ipv6-prefix-list/plan.md
@@ -1,6 +1,7 @@
 # #2071 — IPv6 prefix-list rendered with the IPv4 `match ip address` matcher
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** DRAFT v2 — mixed-list design corrected after round-1 review
+(reviewer A PLAN-NEEDS-MAJOR: dual-emit-in-one-sequence is FRR-broken)
 
 ## Issue framing
 
@@ -63,44 +64,85 @@ scope, so `po.PrefixLists[term.PrefixList]` is available. Replace the
 unconditional emit with a family-aware emit.
 
 Determine the family by inspecting the referenced prefix-list's entries.
-A prefix-list may hold v4 entries, v6 entries, or both (mixed). FRR's
-`match ip address` consults only the v4-namespace list; `match ipv6
-address` consults only the v6-namespace list. A given route is either v4
-or v6, so the correct, safe behavior is to emit the v4 matcher when the
-list has any v4 entry, and the v6 matcher when it has any v6 entry —
-emitting **both** for a mixed list. Each clause is consulted only in the
-matching address-family context, so a mixed list does the right thing in
-both an inet and an inet6 route-map without ever ANDing two
-mutually-exclusive matchers (FRR ANDs different-type match clauses, but
-v4-vs-v6 are never simultaneously true for one route, so emitting both is
-strictly correct per-AF and strictly better than today's v4-only).
+A prefix-list may hold v4 entries, v6 entries, or both (mixed).
+
+### FRR route-map AND semantics (round-1 correction)
+
+Round-1 reviewer A correctly refuted v1's "emit both matchers in one
+sequence" design. Verified against FRR master source:
+
+- `lib/routemap.c` `route_map_apply_match` combines match clauses within
+  a single route-map index with **AND** semantics — the truth table is
+  `MATCH + NOMATCH → NOMATCH`, and the iteration loop calls EVERY match
+  rule's `func_apply` with no address-family pre-filter (an IPv4 route is
+  still tested against a `match ipv6 address` rule).
+- `bgpd/bgp_routemap.c` `route_match_address_prefix_list` returns
+  `RMAP_NOMATCH` (never `RMAP_NOOP`) both when the named list is absent in
+  that AFI namespace AND when the prefix fails a present list.
+
+The definition render (lines 535-540) splits a mixed Junos list into BOTH
+a populated `ip prefix-list X` and a populated `ipv6 prefix-list X`.
+Therefore, if v1 emitted `match ip address X` and `match ipv6 address X`
+in the SAME route-map sequence, a v4 route would MATCH the v4 clause but
+NOMATCH the (populated) v6 clause → index NOMATCH → the route is
+**silently denied**, and symmetrically for v6 routes. That is strictly
+worse than today (today, mixed-list v4 routes at least work). The
+dual-emit-in-one-sequence design is therefore rejected.
+
+### Corrected design
+
+The two address families must never be AND-ed in one index. Render rule:
+
+- **Single-family list** (all v4, or all v6 — the common case and the
+  exact #2071 report): emit the one family-correct matcher in the term's
+  single sequence. This is the uncontested, correct fix.
+- **Mixed list:** emit the term as **two consecutive route-map
+  sequences** — an IPv4 sequence carrying `match ip address` and an IPv6
+  sequence carrying `match ipv6 address` — each carrying the term's other
+  match clauses and `then` set-actions. FRR evaluates sequences in order
+  and falls through on NOMATCH, so a v4 route NOMATCHes the v6 sequence
+  and is caught by the v4 sequence (and vice versa). This is the FRR-idiomatic
+  way to express "match if the route is in the v4 list OR the v6 list"
+  for an AF-agnostic Junos term.
+- **Unknown / empty list** (name absent from `po.PrefixLists`, or no
+  entries): default to the IPv4 matcher in the single sequence — the
+  pre-fix rendering, so no regression. (Note: FRR itself NOMATCHes an
+  undefined list regardless of the v4/v6 keyword, so the default is
+  cosmetic for the miss case; v4 is chosen only to preserve byte-identical
+  output for existing v4-only configs that reference a list.)
+
+Implementation: factor the term body (the route-filter block, the
+prefix-list match line, `match source-protocol`, `match community`,
+`match as-path`, the `then` set-actions, and the trailing `exit`) into a
+helper `func renderPolicyTermBody(b, term, prefixListMatch string)` so
+the only thing that varies between the v4 and v6 sequences is the
+prefix-list match line. The route-map loop then becomes:
 
 ```go
-if term.PrefixList != "" {
-    hasV4, hasV6 := false, false
-    if pl := po.PrefixLists[term.PrefixList]; pl != nil {
-        for _, p := range pl.Prefixes {
-            if strings.Contains(p, ":") {
-                hasV6 = true
-            } else {
-                hasV4 = true
-            }
-        }
-    }
-    // Unknown / empty prefix-list (not defined, or no entries): default
-    // to the IPv4 matcher to preserve today's behavior — this is the
-    // pre-fix rendering for the lookup-miss case, so no regression.
-    if !hasV4 && !hasV6 {
-        hasV4 = true
-    }
-    if hasV4 {
-        fmt.Fprintf(&b, " match ip address prefix-list %s\n", term.PrefixList)
-    }
-    if hasV6 {
-        fmt.Fprintf(&b, " match ipv6 address prefix-list %s\n", term.PrefixList)
-    }
+v4, v6 := prefixListFamilies(po, term.PrefixList) // (hasV4, hasV6)
+switch {
+case term.PrefixList == "":
+    emit one sequence, prefixListMatch = ""
+case v4 && v6:
+    // mixed: two sequences
+    emit sequence @ seq   with "match ip address prefix-list X"
+    seq += 10
+    emit sequence @ seq   with "match ipv6 address prefix-list X"
+case v6 && !v4:
+    emit one sequence with "match ipv6 address prefix-list X"
+default: // v4-only, or unknown/empty (default v4)
+    emit one sequence with "match ip address prefix-list X"
 }
+seq += 10
 ```
+
+`prefixListFamilies` classifies each entry with the SAME
+`strings.Contains(p, ":")` test the definition render uses, guaranteeing
+the match clause and the prefix-list namespace can never disagree.
+
+The mixed case is rare but real (Junos `from prefix-list` is
+AF-agnostic and a list may hold both families); handling it correctly
+rather than producing a silent-deny is worth the small helper extraction.
 
 ### Why look up the list instead of carrying family on the term
 
@@ -112,10 +154,13 @@ signature change is needed.
 
 ### Ordering
 
-The match clause(s) are emitted in the same position as the current
-single line (between the route-filter block and the `match
-source-protocol` lines). For a mixed list, `match ip address` is emitted
-before `match ipv6 address` (deterministic order). No other clause moves.
+For a single-family or unknown list the match clause is emitted in the
+same position as the current single line (between the route-filter block
+and the `match source-protocol` lines) — output is byte-identical to
+v1-of-master for v4-only configs. For a mixed list, the v4 sequence is
+emitted at the term's seq, the v6 sequence at seq+10 (deterministic),
+shifting later terms' seq numbers by one step — a cosmetic numbering
+change with no semantic effect (FRR seq numbers only order evaluation).
 
 ## Public API preservation
 
@@ -125,28 +170,37 @@ touched. No config schema, AST, or compiler change.
 
 ## Hidden invariants the change must preserve
 
-- **Output ordering:** the prefix-list match clause stays between the
-  route-filter block and the `match source-protocol` block. Verified by
-  reading the surrounding emits.
-- **Lookup-miss behavior:** if `term.PrefixList` names a list not present
-  in `po.PrefixLists` (or an empty list), the output is byte-identical to
-  today (`match ip address prefix-list NAME`). No new failure mode.
+- **Output ordering / byte-identity for v4-only configs:** a term that
+  references a v4-only (or unknown/empty) prefix-list renders byte-identically
+  to master — same single `match ip address` line in the same position,
+  same seq numbering. Verified against the two existing tests
+  (`internal`, `trusted-nets`, both v4-only) which must still pass
+  unchanged.
+- **Term body equivalence across split:** the extracted
+  `renderPolicyTermBody` must emit exactly the same clauses (route-filter
+  block, source-protocol/community/as-path matches, all `then`
+  set-actions, trailing `exit`) it does today — only the prefix-list match
+  line is parameterized. A mixed-list split therefore duplicates the full
+  term semantics into both sequences (AND-ed per sequence, OR-ed across
+  the two sequences) — correct for an AF-agnostic term.
+- **No AND of v4 and v6 prefix-list matchers in one index** — the round-1
+  defect. The two matchers only ever appear in separate sequences.
 - **Determinism:** `pl.Prefixes` is iterated only to compute two booleans;
-  iteration order does not affect output. The two emits are in fixed
-  order. FRR config generation is already sorted by name upstream.
+  iteration order does not affect output. FRR config generation is sorted
+  by policy-statement name upstream.
 - **No nil deref:** `po` is non-nil at this site (the function
   dereferences `po.PrefixLists`, `po.Communities`, etc. unconditionally
-  above). The map index returns nil for a missing key, guarded by the
-  `pl != nil` check.
+  above). The map index returns nil for a missing key (and indexing even a
+  nil map is panic-safe in Go), guarded by the `pl != nil` check.
 
 ## Risk assessment
 
 | Class | Level | Notes |
 |---|---|---|
-| Behavioral regression | LOW | v4-only lists render identically; lookup-miss renders identically; only v6/mixed lists change, and they were broken |
-| Lifetime / borrow-checker | N/A | Go, no borrow checker; no new allocations beyond two stack bools |
-| Performance regression | NONE | Control-plane render, runs at commit time; one extra map lookup + slice scan per term |
-| Architectural mismatch (#961 / #946-P2) | NONE | Mirrors the already-accepted route-filter family branch directly above; no new abstraction |
+| Behavioral regression | LOW | v4-only and unknown/empty lists render byte-identically; only v6 (now correct) and mixed (now two-sequence, was broken) change |
+| Lifetime / borrow-checker | N/A | Go, no borrow checker; the helper extraction is pure code motion |
+| Performance regression | NONE | Control-plane render at commit time; one map lookup + slice scan per term |
+| Architectural mismatch (#961 / #946-P2) | NONE | Single-family path mirrors the route-filter family branch; mixed path is the FRR-idiomatic two-sequence OR |
 
 ## Test plan
 
@@ -158,26 +212,36 @@ cluster deploy, no iperf3. Coverage is a Go unit test in `pkg/frr`.
    `pkg/frr` test convention):
    - **v4 prefix-list** referenced by `from prefix-list` → output
      contains `match ip address prefix-list <name>` and does NOT contain
-     `match ipv6 address prefix-list <name>`.
+     `match ipv6 address prefix-list <name>`; ONE route-map sequence.
    - **v6 prefix-list** referenced by `from prefix-list` → output
      contains `match ipv6 address prefix-list <name>` and does NOT
-     contain `match ip address prefix-list <name>`.
-   - **mixed prefix-list** → output contains BOTH matchers.
+     contain `match ip address prefix-list <name>`; ONE sequence.
+   - **mixed prefix-list** → output contains `match ip address` in one
+     route-map sequence and `match ipv6 address` in a SEPARATE sequence
+     (assert TWO `route-map <name> ...` headers and that the two matchers
+     are NOT in the same sequence body). This asserts the SAFE shape, not
+     "both lines present somewhere" — guarding against the round-1 defect.
    - **unknown prefix-list name** (not in `po.PrefixLists`) → falls back
-     to `match ip address` (no panic, no regression).
-   Each assertion is non-tautological: the v6 case FAILS against the
-   pre-fix code (which emits `match ip address`), and the v4 case FAILS
-   if the fix accidentally flips the default.
+     to `match ip address`, one sequence (no panic, no regression).
+   Each assertion is non-tautological: the v6 case FAILS against pre-fix
+   code (which emits `match ip address`); the mixed case FAILS against
+   both pre-fix code AND the rejected v1 dual-emit-in-one-sequence design.
 3. An **end-to-end flat-set test** honoring the CLAUDE.md rule
    (`ParseSetCommand` + `tree.SetPath` loop, NOT `NewParser`): feed
    `set policy-options prefix-list v6nets 2001:db8::/32`,
    `set policy-options policy-statement p term t1 from prefix-list v6nets`,
    `... then accept`, compile with `CompileConfig`, render via
-   `generatePolicyOptions(cfg.PolicyOptions)`, assert `match ipv6
-   address`. This proves the family propagates compiler→render.
+   `generatePolicyOptions(&cfg.PolicyOptions)` (note: `PolicyOptions` is a
+   value field, so pass its address), assert `match ipv6 address`. This
+   proves the family propagates compiler→render.
 4. `go test ./pkg/frr/... ./pkg/config/...` green.
 5. Named new test 5x for flake stability.
 6. Full `go test ./...` green (30 Go packages).
+
+**Docs:** `pkg/frr/README.md` describes `generatePolicyOptions`'
+responsibilities at a high level but does not document per-clause
+match-family rendering, so it stays accurate and needs no change — noted
+here per the CLAUDE.md docs-contract rule.
 
 ## Out of scope (explicitly)
 
@@ -190,28 +254,45 @@ cluster deploy, no iperf3. Coverage is a Go unit test in `pkg/frr`.
   block a route-map is referenced under). Out of scope; the bug is the
   match clause, not the attachment.
 
-## Open questions for adversarial review
+## Round-1 review resolution
 
-1. **Mixed-list correctness:** is emitting BOTH `match ip address` and
-   `match ipv6 address` for a mixed prefix-list correct, or could FRR AND
-   them and break matching in a single-AF route-map? (Claim: a route is
-   exactly one family, so the off-family matcher is simply never
-   consulted; per-AF behavior is correct. Challenge this.)
-2. **Lookup-miss default:** is defaulting to `match ip address` on an
-   undefined/empty prefix-list the right no-regression choice, or should
-   it emit nothing / a warning? (Pre-fix behavior was v4; preserving it
-   avoids surprise, but is silent-v4 the right call?)
-3. **Is the family knowable at render time at all?** Could a referenced
-   prefix-list legitimately be absent from `po.PrefixLists` in production
-   (forward reference, cross-instance)? If so, is silent v4 a latent bug?
-4. **Ordering:** does emitting `match ip` before `match ipv6` for mixed
-   lists matter to FRR, or to config-diff stability? (Claim: independent
-   clauses, order-irrelevant to FRR; fixed order for diff stability.)
-5. **Should the fix instead refuse / warn at commit time** when a v6
-   prefix-list is referenced from an inet-only policy context, rather than
-   fixing the renderer? (Claim: the renderer is the right layer — the
-   policy term itself is AF-agnostic in Junos; the render must honor the
-   referenced list's family. Challenge.)
-6. **Test adequacy:** does the unit test prove non-tautology (fails
-   pre-fix) AND cover the mixed + lookup-miss cases? Is the end-to-end
+- **Reviewer A — PLAN-NEEDS-MAJOR (mixed-list dual-emit-in-one-sequence is
+  FRR-broken).** ACCEPTED. Verified against FRR master source
+  (`lib/routemap.c` AND truth-table + no AF pre-filter in the match loop;
+  `bgpd/bgp_routemap.c route_match_address_prefix_list` returns NOMATCH on
+  off-family). v2 replaces dual-emit with the single-family matcher for
+  homogeneous lists and a **two-sequence OR** for mixed lists, and the
+  mixed test now asserts the two matchers are in SEPARATE sequences.
+- **Reviewer B — PLAN-READY w/ 2 minors.** Minor-1 (`&cfg.PolicyOptions`
+  pointer in the end-to-end test) FOLDED into the test plan. Minor-2 (docs
+  note) FOLDED — `pkg/frr/README.md` needs no change, stated explicitly.
+  B's heuristic-consistency verification (the fix's `strings.Contains(":")`
+  is byte-identical to the definition render at line 536, so the match
+  clause and namespace can never disagree) is retained as a load-bearing
+  correctness argument.
+
+## Open questions for adversarial review (round 2)
+
+1. **Two-sequence mixed-list emit:** is splitting a mixed-list term into a
+   v4 sequence and a v6 sequence (each carrying the full term body, OR-ed
+   by fall-through) semantically correct for both `permit` and `reject`
+   terms? For a `reject` term, does the off-family sequence falling
+   through (rather than denying) ever change the policy outcome vs. a
+   single AF-agnostic Junos term? Challenge the OR-of-two-sequences model.
+2. **Term-body duplication side-effects:** does emitting the `then`
+   set-actions (next-hop, local-pref, metric, community, origin) twice —
+   once per sequence — cause any double-apply hazard, or is it inert
+   because only one sequence ever matches a given route?
+3. **Lookup-miss default to v4:** still the right no-regression choice
+   given FRR NOMATCHes an undefined list regardless of keyword?
+4. **Seq renumbering:** the mixed case shifts later terms' seq numbers by
+   +10. Any concern for config-diff churn or FRR reload behavior? (Claim:
+   seq numbers only order evaluation; cosmetic.)
+5. **Should mixed lists instead be rejected/warned at commit time** rather
+   than rendered as two sequences? (Claim: two-sequence render preserves
+   the operator's intent without a new failure mode; commit-time refusal
+   would break configs that work today for v4.)
+6. **Test adequacy:** does the mixed test assert the SAFE two-sequence
+   shape (not merely "both lines present")? Does it prove non-tautology
+   against BOTH pre-fix code and the rejected v1 design? Is the end-to-end
    flat-set test redundant or load-bearing?

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -2662,3 +2662,162 @@ func TestGenerateProtocols_NewlineFreeTextDoesNotInject(t *testing.T) {
 		t.Errorf("sanitized password missing:\n%s", got)
 	}
 }
+
+// --- #2071: from prefix-list match clause must honor the prefix-list's
+// address family. generatePolicyOptions previously emitted "match ip
+// address prefix-list" unconditionally, so an IPv6 prefix-list referenced
+// by `from prefix-list` was a silent no-op in an IPv6 routing-policy
+// context (OSPFv3 export, BGP inet6). The render now mirrors the
+// route-filter path and emits exactly one family-correct matcher.
+
+func policyOptionsWithPrefixListTerm(plName string, prefixes []string, withRouteFilter bool) *config.PolicyOptionsConfig {
+	term := &config.PolicyTerm{
+		Name:       "t1",
+		PrefixList: plName,
+		Action:     "accept",
+	}
+	if withRouteFilter {
+		// v4 route-filter co-resident with the prefix-list in the SAME
+		// term — exercises the no-term-body-duplication invariant.
+		term.RouteFilters = []*config.RouteFilter{
+			{Prefix: "192.168.50.0/24", MatchType: "exact"},
+		}
+	}
+	po := &config.PolicyOptionsConfig{
+		PrefixLists: map[string]*config.PrefixList{},
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"p": {
+				Name:  "p",
+				Terms: []*config.PolicyTerm{term},
+			},
+		},
+	}
+	if prefixes != nil {
+		po.PrefixLists[plName] = &config.PrefixList{Name: plName, Prefixes: prefixes}
+	}
+	return po
+}
+
+func TestPrefixListMatch_IPv4(t *testing.T) {
+	m := New()
+	po := policyOptionsWithPrefixListTerm("v4list", []string{"10.0.0.0/8", "172.16.0.0/12"}, false)
+	got := m.generatePolicyOptions(po)
+	// Byte-identical to pre-fix render: the exact IPv4 match line.
+	if !strings.Contains(got, " match ip address prefix-list v4list\n") {
+		t.Errorf("v4 prefix-list: missing exact `match ip address prefix-list v4list` in:\n%s", got)
+	}
+	if strings.Contains(got, "match ipv6 address prefix-list v4list") {
+		t.Errorf("v4 prefix-list: must NOT emit the IPv6 matcher in:\n%s", got)
+	}
+}
+
+func TestPrefixListMatch_IPv6(t *testing.T) {
+	m := New()
+	po := policyOptionsWithPrefixListTerm("v6list", []string{"2001:db8::/32", "2001:559:8585::/48"}, false)
+	got := m.generatePolicyOptions(po)
+	// This assertion FAILS against pre-fix code (which emitted `match ip
+	// address`): non-tautological.
+	if !strings.Contains(got, " match ipv6 address prefix-list v6list\n") {
+		t.Errorf("v6 prefix-list: missing `match ipv6 address prefix-list v6list` in:\n%s", got)
+	}
+	if strings.Contains(got, "match ip address prefix-list v6list") {
+		t.Errorf("v6 prefix-list: must NOT emit the IPv4 matcher in:\n%s", got)
+	}
+}
+
+func TestPrefixListMatch_Mixed_PicksIPv6_SingleSequence(t *testing.T) {
+	m := New()
+	// Mixed list: a single FRR route-map index cannot match both families
+	// (FRR ANDs match clauses), so exactly one matcher is emitted and any
+	// IPv6 entry selects the IPv6 matcher.
+	po := policyOptionsWithPrefixListTerm("mixed", []string{"10.0.0.0/8", "2001:db8::/32"}, false)
+	got := m.generatePolicyOptions(po)
+	if !strings.Contains(got, " match ipv6 address prefix-list mixed\n") {
+		t.Errorf("mixed prefix-list: missing `match ipv6 address prefix-list mixed` in:\n%s", got)
+	}
+	if strings.Contains(got, "match ip address prefix-list mixed") {
+		t.Errorf("mixed prefix-list: must NOT also emit the IPv4 matcher (would AND to a silent deny) in:\n%s", got)
+	}
+	// Exactly one route-map sequence for the term — guards against the
+	// rejected two-sequence design.
+	if n := strings.Count(got, "route-map p permit 10"); n != 1 {
+		t.Errorf("mixed prefix-list: want exactly 1 `route-map p permit 10` sequence, got %d in:\n%s", n, got)
+	}
+	if strings.Contains(got, "route-map p permit 20") {
+		t.Errorf("mixed prefix-list: must NOT emit a second route-map sequence for the term in:\n%s", got)
+	}
+}
+
+func TestPrefixListMatch_CoResidentRouteFilter_NoDuplication(t *testing.T) {
+	m := New()
+	// Term with BOTH a v4 route-filter and a mixed prefix-list. The
+	// route-filter keeps its own (v4) matcher; the prefix-list adds exactly
+	// one IPv6 matcher; both live in the term's single sequence; the
+	// route-filter inline definition is emitted once and there is no
+	// second route-map sequence (no term-body duplication).
+	po := policyOptionsWithPrefixListTerm("mixed", []string{"10.0.0.0/8", "2001:db8::/32"}, true)
+	got := m.generatePolicyOptions(po)
+	if !strings.Contains(got, " match ip address prefix-list p-t1\n") {
+		t.Errorf("co-resident: route-filter v4 matcher missing in:\n%s", got)
+	}
+	if !strings.Contains(got, " match ipv6 address prefix-list mixed\n") {
+		t.Errorf("co-resident: prefix-list IPv6 matcher missing in:\n%s", got)
+	}
+	if n := strings.Count(got, "route-map p permit 10"); n != 1 {
+		t.Errorf("co-resident: want exactly 1 route-map sequence, got %d in:\n%s", n, got)
+	}
+	if n := strings.Count(got, "ip prefix-list p-t1 seq 5 permit 192.168.50.0/24"); n != 1 {
+		t.Errorf("co-resident: route-filter inline definition must appear exactly once, got %d in:\n%s", n, got)
+	}
+}
+
+func TestPrefixListMatch_UnknownName_DefaultsIPv4(t *testing.T) {
+	m := New()
+	// Term references a prefix-list that is not defined (nil prefixes).
+	// Falls back to the IPv4 matcher — byte-identical to pre-fix render,
+	// no panic.
+	po := policyOptionsWithPrefixListTerm("ghost", nil, false)
+	got := m.generatePolicyOptions(po)
+	if !strings.Contains(got, " match ip address prefix-list ghost\n") {
+		t.Errorf("unknown prefix-list: must default to `match ip address prefix-list ghost` in:\n%s", got)
+	}
+	if strings.Contains(got, "match ipv6 address prefix-list ghost") {
+		t.Errorf("unknown prefix-list: must NOT emit the IPv6 matcher in:\n%s", got)
+	}
+}
+
+// TestPrefixListMatch_EndToEnd_FlatSet drives the full flat-set ->
+// compile -> render path, honoring the CLAUDE.md rule to use
+// ParseSetCommand + tree.SetPath (NOT NewParser). It lives in package frr
+// (generatePolicyOptions is unexported) and inlines its own compile loop
+// (config.buildTree is a package-config test helper, unreachable here).
+func TestPrefixListMatch_EndToEnd_FlatSet(t *testing.T) {
+	cmds := []string{
+		"set policy-options prefix-list v6nets 2001:db8::/32",
+		"set policy-options policy-statement p term t1 from prefix-list v6nets",
+		"set policy-options policy-statement p term t1 then accept",
+	}
+	tree := &config.ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	m := New()
+	// PolicyOptions is a value field — pass its address.
+	got := m.generatePolicyOptions(&cfg.PolicyOptions)
+	if !strings.Contains(got, " match ipv6 address prefix-list v6nets\n") {
+		t.Errorf("end-to-end: v6 prefix-list compiled+rendered must emit the IPv6 matcher, got:\n%s", got)
+	}
+	if strings.Contains(got, "match ip address prefix-list v6nets") {
+		t.Errorf("end-to-end: must NOT emit the IPv4 matcher for a v6 list, got:\n%s", got)
+	}
+}

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -634,7 +634,32 @@ func (m *Manager) generatePolicyOptions(po *config.PolicyOptionsConfig) string {
 			}
 
 			if term.PrefixList != "" {
-				fmt.Fprintf(&b, " match ip address prefix-list %s\n", term.PrefixList)
+				// Choose the address-family matcher from the referenced
+				// prefix-list's entries, mirroring the route-filter path
+				// above (lines ~619-633). FRR keeps `ip` and `ipv6`
+				// prefix-lists in independent namespaces; emitting the
+				// IPv4 `match ip address` for an IPv6 list makes the
+				// filter a silent no-op in an IPv6 routing-policy context
+				// (OSPFv3 export, BGP inet6) — issue #2071. Two matchers
+				// must NOT both appear in one route-map index: FRR ANDs
+				// match clauses (MATCH + NOMATCH = NOMATCH), so an
+				// off-family clause against the populated sibling-namespace
+				// list would deny the route. Emit exactly one matcher;
+				// any IPv6 entry selects the IPv6 matcher. A mixed
+				// (v4+v6) list therefore renders the IPv6 matcher — the
+				// same homogeneous-family limitation the route-filter path
+				// already has. Unknown/empty lists default to IPv4,
+				// byte-identical to the pre-fix render.
+				matchKW := "ip"
+				if pl := po.PrefixLists[term.PrefixList]; pl != nil {
+					for _, p := range pl.Prefixes {
+						if strings.Contains(p, ":") {
+							matchKW = "ipv6"
+							break
+						}
+					}
+				}
+				fmt.Fprintf(&b, " match %s address prefix-list %s\n", matchKW, term.PrefixList)
 			}
 
 			// Junos "from protocol [ bgp ospf static ]" matches ANY listed

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -635,8 +635,8 @@ func (m *Manager) generatePolicyOptions(po *config.PolicyOptionsConfig) string {
 
 			if term.PrefixList != "" {
 				// Choose the address-family matcher from the referenced
-				// prefix-list's entries, mirroring the route-filter path
-				// above (lines ~619-633). FRR keeps `ip` and `ipv6`
+				// prefix-list's entries, mirroring the route-filter match
+				// branch above. FRR keeps `ip` and `ipv6`
 				// prefix-lists in independent namespaces; emitting the
 				// IPv4 `match ip address` for an IPv6 list makes the
 				// filter a silent no-op in an IPv6 routing-policy context


### PR DESCRIPTION
## Summary

`pkg/frr/policy_render.go` `generatePolicyOptions` rendered a policy
term's `from prefix-list <name>` unconditionally as the IPv4
`match ip address prefix-list <name>` matcher with no address-family
detection. When the referenced prefix-list holds IPv6 prefixes and the
policy is applied in an IPv6 context (OSPFv3 export, BGP inet6
route-map), FRR's `match ip address` clause never matches IPv6 routes —
the operator's export/import filter is a **silent no-op for IPv6** (can
leak routes that should be filtered, or fail to permit routes that should
pass). Issue #2071.

The fix mirrors the adjacent route-filter render path (which already
branches on `strings.Contains(prefix, ":")`): look up
`po.PrefixLists[term.PrefixList]` and emit `match ipv6 address` when any
entry is an IPv6 prefix, otherwise `match ip address`. **Exactly one**
matcher is emitted per `from prefix-list`, in the term's existing single
route-map sequence — because FRR ANDs match clauses within a route-map
index (MATCH + NOMATCH = NOMATCH) and the definition render already
populates both the `ip` and `ipv6` prefix-list namespaces for a mixed
list, so emitting both matchers in one index would deny the route for
both families. A mixed (v4+v6) list renders the IPv6 matcher — the same
homogeneous-family limitation the route-filter precedent already has.
Unknown/empty lists default to the IPv4 matcher, byte-identical to the
pre-fix render.

Control-plane FRR config render only — **no dataplane change, no
dataplane smoke**.

## Plan + adversarial review

Plan doc: `docs/pr/2071-ipv6-prefix-list/plan.md` (3 review rounds).

- **Round 1** — reviewer A PLAN-NEEDS-MAJOR: v1's "emit both matchers in
  one route-map index" is FRR-broken (verified against FRR master:
  `lib/routemap.c` AND truth-table + no AF pre-filter in the match loop;
  `bgpd/bgp_routemap.c route_match_address_prefix_list` returns NOMATCH
  against a populated off-family list). reviewer B PLAN-READY w/ 2 minors.
- **Round 2** (v2 two-sequence design) — both reviewers found it collides
  with a co-resident `from route-filter` (relocated silent-deny) and
  double-emits route-filter definition lines.
- **Round 3** (v3 single family-chosen matcher) — reviewer B PLAN-READY
  (verified the snippet is correct for all six edge cases, byte-identity
  proven, e2e path verified live); reviewer A PLAN-NEEDS-MINOR ×3
  (honesty/coverage), all folded. Both confirm v3 closes rounds 1 and 2
  by construction (one matcher → no AND-in-index; no body duplication →
  no route-filter interaction).

(Codex + Antigravity companions are infra-degraded this session; two
independent hostile Claude reviewers + a Claude SMR pass substituted.
Copilot review requested below for the standard third opinion.)

## Test plan

- [x] `go build ./...` clean; `gofmt` clean; `go vet ./pkg/frr/` clean
- [x] Six new `pkg/frr` render tests: v4 (exact byte-identity), v6
      (non-tautological), mixed→ipv6 single-sequence, mixed +
      co-resident v4 route-filter (no term-body duplication), unknown
      name→v4 default, and an end-to-end flat-set
      ParseSetCommand+SetPath+CompileConfig→render test (CLAUDE.md rule,
      not NewParser)
- [x] **Non-tautology proven**: against the pre-fix `policy_render.go`
      the v6 / mixed / co-resident / end-to-end tests FAIL; the v4 /
      unknown tests pass (byte-identity preserved)
- [x] 5/5 flake check on `TestPrefixListMatch*`
- [x] `go test ./...` — 48 packages pass
- [x] No dataplane smoke (control-plane FRR render only)
- [x] Docs: `pkg/frr/README.md` documents `generatePolicyOptions` only at
      a high level (no per-clause match-family detail) — stays accurate,
      no change needed (confirmed across review rounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)