### PR TITLE
#2085: filter expired/non-active + dedup Kea display lease parser

### DIFF
--- a/docs/pr/2085-kea-lease-parser/plan.md
+++ b/docs/pr/2085-kea-lease-parser/plan.md
@@ -1,6 +1,13 @@
 # #2085 — Display lease parser returns stale/expired and duplicate Kea memfile rows
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** v2 — folds in adversarial plan-review round 1 (two hostile
+Claude reviewers: PLAN-NEEDS-MAJOR + PLAN-NEEDS-MINOR). Changes from v1:
+(1) state-column filtering pulled IN scope — expire-only is incomplete
+because released (state=2) and declined (state=1) Kea leases carry
+FUTURE expire epochs and would still display as live; (2) test-fixture
+`now` contradiction fixed (legacy call sites use a `now` BEFORE the
+2024-02 fixture expiries); (3) call-site count corrected to FOUR;
+(4) README update added.
 
 ## Issue framing
 
@@ -88,31 +95,57 @@ buried in the parser.
 ### Body (replaces the `for _, fields := range records[1:]` accumulate)
 
 Keep the existing header-map build and per-field extraction. Replace
-the final `if l.Address != "" { leases = append(...) }` block with:
+the final `if l.Address != "" { leases = append(...) }` block with, per
+row, in this order:
 
 1. Skip rows with empty `address` (unchanged — empty address is not a
-   displayable lease).
-2. **Expire filter (lenient):** parse the `expire` field as a Unix
+   displayable lease). Otherwise note the address into the
+   first-appearance `order` slice (tombstone or not) so a later live
+   append can reclaim it.
+2. **State filter (lenient) — FOLDED IN per review:** read the `state`
+   column. If it parses to a non-default value (`state != 0` — Kea
+   `state=1` declined, `state=2` expired-reclaimed), the lease is NOT
+   active — record a TOMBSTONE for the address and do not emit. A
+   released or declined Kea lease is written with a non-default state
+   but often a FUTURE `expire` epoch, so the expire filter alone would
+   leave it visible — exactly the "stale row shown" symptom the issue
+   is about. An absent/unparseable state is treated as active (Kea's
+   default; lenient — matches the DDNS parser ddns_leases.go:264-273).
+3. **Expire filter (lenient):** parse the `expire` field as a Unix
    epoch (`strconv.ParseInt(.., 10, 64)`). If it parses AND
    `expire > 0` AND `now.Unix() >= expire`, the row is expired — record
    it as a TOMBSTONE for that address (so a later append for the same
    address can supersede it) and do not emit. If `expire` is absent or
    unparseable, treat the row as live (lenient — display path must not
    hide a lease just because Kea wrote an exotic/blank expire).
-3. **Dedup (last-write-wins):** keep a `map[string]Lease` keyed by
+4. **Dedup (last-write-wins):** keep a `map[string]Lease` keyed by
    address, overwriting on each row so the LAST row for an address wins
-   (append-only memfile ⇒ chronological ⇒ newest last), plus a
+   (append-only memfile ⇒ chronological ⇒ newest last), plus the
    first-appearance `order []string` slice so display order is stable
-   and deterministic. An expired row writes a zero `Lease{}` tombstone;
-   a live row writes the populated `Lease`.
-4. **Emit:** walk `order`, skip tombstones (`l.Address == ""`), append
+   and deterministic. A non-active or expired row writes a zero
+   `Lease{}` tombstone; a live row writes the populated `Lease`.
+5. **Emit:** walk `order`, skip tombstones (`l.Address == ""`), append
    the rest. This is the exact emit pattern `parseActiveLeases`
    already uses — proven over six #1387 review rounds.
 
-Crucially the tombstone-and-reclaim shape (an expired row tombstones
-the address; a later live append for the same address re-populates it)
-matches the DDNS parser so a re-allocated address that Kea appended a
-fresh live row for is shown live, not hidden by an earlier expired row.
+Crucially the tombstone-and-reclaim shape (a non-active/expired row
+tombstones the address; a later live append for the same address
+re-populates it) matches the DDNS parser so a re-allocated address that
+Kea appended a fresh live row for is shown live, not hidden by an
+earlier expired/reclaimed row. State is filtered BEFORE expire so a
+declined lease with a future expire is correctly tombstoned.
+
+### Why state filtering is lenient, not the DDNS hard-fail
+
+The DDNS parser hard-errors on a mangled header because its empty
+result authorizes a destructive DNS-record delete. The display path
+copies ONLY the per-row lenient state/expire tombstone logic
+(ddns_leases.go:255-287) — NOT the required-column header validation,
+the duplicate-column rejection, or the ragged-row error. An absent
+`state` column (older Kea, exotic header) therefore degrades to
+"treat all rows as active" (today's behaviour), never blanks the
+`show`. This keeps display leniency intact while closing the
+state-stale gap.
 
 ### now boundary semantics
 
@@ -154,7 +187,7 @@ display-only and immaterial.
 
 | Class | Level | Notes |
 |-------|-------|-------|
-| Behavioral regression | LOW | Only the display set shrinks (expired + duplicate rows removed). Live, unique rows are unchanged. Two test-only call sites updated for the new param. |
+| Behavioral regression | LOW | Only the display set shrinks (expired + non-active state + duplicate rows removed). Live, unique, state=0 rows are unchanged. Four test-only call sites updated for the new param. Absent state/expire columns ⇒ today's behaviour (lenient). |
 | Lifetime / borrow (Go: aliasing) | LOW | Pure value copies into a `map[string]Lease`; `Lease` has no pointers/slices. No aliasing hazard. |
 | Performance regression | LOW | Display path, ~1/s operator-driven, never hot. O(rows) map+slice replaces O(rows) slice append. |
 | Architectural mismatch | LOW | Reuses the proven `parseActiveLeases` tombstone/order/emit shape in-place; does NOT merge the two parsers (which would be the mismatch). |
@@ -163,69 +196,112 @@ display-only and immaterial.
 
 Control-plane display bug — **NO smoke** (no dataplane change; the
 loss-cluster CoS matrix is irrelevant here). Coverage is a focused
-`pkg/dhcpserver` unit test, non-tautological (fails against pre-fix code):
+`pkg/dhcpserver` unit test, non-tautological (fails against pre-fix code).
+
+**Existing call sites (FOUR, corrected from v1):** `dhcpserver_test.go`
+lines 265 (`TestParseLeaseCSV`), 292 (`TestParseLeaseCSV_NoFile`), 308
+(`TestParseLeaseCSV_Empty`), 329 (`TestParseLeaseCSV_QuotedHostname`).
+The existing fixtures (`TestParseLeaseCSV`, `TestParseLeaseCSV_QuotedHostname`)
+use expire epochs `1707868800` / `1707955200` (2024-02) with `state=0`,
+so the legacy call sites MUST pass a `now` BEFORE `1707868800` (use a
+named constant, e.g. `time.Unix(1707800000, 0)`) so those rows stay live
+and the pre-existing assertions still hold. `NoFile` and `Empty` take any
+`now`. This is the F1/F2 fix: a `now` past the fixtures would silently
+drop them and neuter the existing assertions.
 
 1. New `TestParseLeaseCSV_ExpiredAndDuplicate`: synthetic append-only
-   CSV with (a) the SAME address appearing twice with different
-   `expire`/hostname (newer row last) and (b) a separate expired
-   address (`expire` well in the past). Assert:
-   - the duplicate address appears EXACTLY once, carrying the NEWEST
-     row's fields;
-   - the expired address is ABSENT;
-   - a normal live address is present unchanged;
-   - injects a fixed `now` (e.g. `time.Unix(1707900000, 0)`) so the
-     test is deterministic and the boundary is explicit. Fails pre-fix
-     (pre-fix returns 4 rows incl. the dup + expired).
-2. Edge: absent/blank/garbage `expire` ⇒ row kept (lenient).
-3. Edge: expired row for an address SUPERSEDED by a later live append
-   ⇒ address shown live (tombstone-reclaim).
-4. Update the three existing `parseLeaseCSV` call sites in
-   `dhcpserver_test.go` to pass a `now` (use a fixed time past the
-   1707955200 expiries in the existing fixtures so those rows stay live
-   — preserves the existing assertions). The existing fixture expires
-   (1707868800 / 1707955200 = 2024-02) need a `now` BEFORE them, or the
-   existing 2-lease test would now correctly drop them; pick a `now`
-   that keeps the existing fixtures live so those tests still assert the
-   pre-existing behaviour.
-5. Gates: `go build ./...`, `go vet ./pkg/dhcpserver/...`,
-   `go test ./pkg/dhcpserver/...` (named test 5x for flake), full
+   CSV (its OWN `now`, e.g. `time.Unix(1707900000, 0)`, with fixtures
+   built relative to it) covering:
+   - the SAME address appearing twice (state=0) with different
+     `expire`/hostname (newer row last, future expire) ⇒ appears
+     EXACTLY once, carrying the NEWEST row's fields;
+   - a separate address whose only row has a PAST `expire` ⇒ ABSENT;
+   - a normal live address (state=0, future expire) ⇒ present unchanged.
+   - Assert `len(leases)` is the post-fix count and that against pre-fix
+     code it would have returned MORE rows (comment the pre-fix vs
+     post-fix expectation so the non-tautology is explicit).
+2. New `TestParseLeaseCSV_StateFiltered`: a declined (`state=1`) and an
+   expired-reclaimed (`state=2`) row, BOTH with a FUTURE `expire` (the
+   gap expire-only misses), ⇒ both ABSENT; plus a state=2 row for an
+   address SUPERSEDED by a later state=0 live append ⇒ shown live
+   (state tombstone-reclaim). Fails an expire-only fix.
+3. Edge: absent/blank/garbage `expire` with state=0 ⇒ row kept
+   (lenient); absent/garbage `state` ⇒ row kept (lenient, default
+   active). Optionally a header with NO `state` column ⇒ all rows kept
+   (proves the lenient degrade-to-today path).
+4. Edge: expired row for an address SUPERSEDED by a later live append
+   ⇒ address shown live (expire tombstone-reclaim).
+5. Update the FOUR existing call sites per the note above.
+6. Gates: `go build ./...`, `go vet ./pkg/dhcpserver/...`,
+   `go test ./pkg/dhcpserver/...` (named tests 5x for flake), full
    `go test ./...`.
+
+## Docs
+
+`pkg/dhcpserver/README.md` must be updated (CLAUDE.md mandates module
+docs in the same work item):
+
+- Lines 78-92 currently contrast the state-aware DDNS parser against
+  "the display-only `parseLeaseCSV`" and assert reusing the display
+  parser "would publish/retain stale records." Post-fix the display
+  parser ALSO filters expired + non-active + dedups, so the rationale
+  for keeping them separate shifts from "display has no filtering" to
+  "display is lenient/non-destructive (never blanks the `show` on a bad
+  row) vs DDNS is hard-fail/destructive (must error on a mangled
+  header)." Update that paragraph.
+- The lease-queries paragraph (lines 318-322) should note that the
+  display now returns only active, non-expired leases, deduplicated
+  per-address to the newest memfile row.
 
 ## Out of scope (explicitly)
 
-- The Kea `state` column (declined/expired-reclaimed) — the display
-  path stays lenient and address+expire-based. Adding state filtering
-  to the display is a separate enhancement; DDNS already handles state
-  for the destructive path. (Open question 4 invites a reviewer to
-  argue this should be in scope.)
 - Merging the display and DDNS parsers — explicitly rejected above.
+  The per-row lenient state/expire/dedup logic is COPIED, not shared,
+  so the destructive DDNS header-validation invariants are untouched.
 - Any change to how `expire`/`valid_lifetime` are RENDERED (epoch vs
   human time) — out of scope; only the row SET changes.
+- DDNS-grade header/duplicate-column/ragged-row validation — the
+  display path stays lenient by design (a bad row degrades, never
+  aborts the `show`).
 
-## Open questions for adversarial review
+## Plan-review round 1 — resolutions
 
-1. **Time seam vs. param:** is adding `now time.Time` to a
-   package-private function the right seam, or should the clock be a
-   `Manager` field? (The function is package-private with two trivial
-   callers and the sibling `parseActiveLeases` already uses the param
-   form — but argue if a `Manager` clock field is cleaner.)
-2. **Lenient expire:** is "unparseable/absent expire ⇒ keep" correct
-   for a display, or should an unparseable expire DROP the row
-   (fail-safe)? DDNS keeps such a row too (line 275-280: expire stays
-   0, no drop). Argue if display should differ.
-3. **Boundary `>=` vs `>`:** `now.Unix() >= expire` treats expiring-now
-   as expired (matches DDNS). Is `>` (still valid at the instant of
-   expiry) more correct for a display? PLAN-KILL-adjacent if the
-   boundary matters operationally.
-4. **State column:** should the display ALSO drop declined /
-   expired-reclaimed (state != 0) rows, not just past-`expire` rows? A
-   reclaimed lease can have a future `expire` but a non-default state.
-   Is expire-only filtering an incomplete fix?
-5. **Dedup key:** is `address` the right dedup key for v6 (where the
-   same address is effectively unique per lease) and v4? Could two
-   genuinely-distinct live leases ever share an address in a healthy
-   memfile such that last-write-wins hides a real lease?
-6. **Should this fix instead just call `parseActiveLeases`?** Argue the
-   merge case if you believe the two-parser split is wrong — the plan
-   rejects it (destructive vs lenient semantics) but invites the
-   counter-argument.
+Two hostile Claude reviewers (PLAN-NEEDS-MAJOR + PLAN-NEEDS-MINOR):
+
+1. **Time seam vs. param** — RESOLVED: param. Both reviewers confirmed
+   `now time.Time` mirrors the sibling `parseActiveLeases` and a
+   `Manager` field would be inconsistent over-engineering for a
+   package-private two-caller function.
+2. **Lenient expire** — RESOLVED: keep (unparseable/absent ⇒ live),
+   matches DDNS. Display must not hide a lease over an exotic expire.
+3. **Boundary `>=` vs `>`** — RESOLVED: keep `>=`, matches DDNS
+   (ddns_leases.go:284); immaterial for a 1/s display, consistency
+   between the two parsers is the tie-breaker.
+4. **State column** — RESOLVED **IN SCOPE** (both reviewers, MAJOR/MINOR):
+   released (state=2) and declined (state=1) Kea leases carry FUTURE
+   `expire`, so expire-only leaves them visible — the issue's own
+   symptom. State filter folded in (lenient, copied from
+   ddns_leases.go:265-273).
+5. **Dedup key** — RESOLVED: `address` is sound for v4 and v6 (IA_NA
+   address is the row identity; IA_PD delegated prefix is unique per
+   row). Kea never double-allocates one address concurrently in a
+   healthy memfile, so last-write-wins only collapses genuine
+   duplicates. v4/v6 are separate files/calls, no cross-family
+   collision.
+6. **Merge with `parseActiveLeases`** — RESOLVED: NO. Both reviewers
+   confirmed the destructive-vs-lenient split is correct; merging would
+   either re-open the #1387 mass-delete or blank the display on one bad
+   row. Copy the lenient per-row logic, not the header-validation.
+
+Also fixed: F1 test-fixture `now` contradiction, F2 call-site count
+(FOUR), F5 README update.
+
+## Open questions for round 2
+
+- Is the lenient state filter correctly placed BEFORE the expire filter
+  (so a declined lease with future expire is tombstoned by state, not
+  missed)? Verify the order in the implementation.
+- Does the new `TestParseLeaseCSV_StateFiltered` genuinely fail an
+  expire-only fix (non-tautological against the half-fix)?
+- Any remaining inaccuracy in the README rewrite of the two-parser
+  rationale?

--- a/docs/pr/2085-kea-lease-parser/plan.md
+++ b/docs/pr/2085-kea-lease-parser/plan.md
@@ -1,0 +1,231 @@
+# #2085 — Display lease parser returns stale/expired and duplicate Kea memfile rows
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+`parseLeaseCSV` (`pkg/dhcpserver/dhcpserver.go:377-430`) — the
+display-only Kea memfile lease parser consumed by `GetLeases4`/`GetLeases6`
+(`:368`/`:374`) and rendered by `show dhcp server leases` (CLI
+`pkg/cli/cli_show_services.go`, gRPC
+`pkg/grpcapi/server_show_dhcp_lldp_snmp.go`) — returns EVERY data row
+whose `address` field is non-empty. It applies:
+
+- **no expire-vs-now filter** — a row whose `expire` epoch is in the
+  past is still shown; and
+- **no per-address dedup** — Kea's memfile is **append-only**, so a
+  lease that has been renewed, re-allocated, or had a state change
+  appears as MULTIPLE rows, all of which are returned.
+
+Result: `show dhcp server leases` lists stale/expired leases and
+duplicate rows for the same address. This is purely a control-plane
+**display** bug — it does not affect forwarding, Kea's own lease
+authority, or DDNS (which has its own parser, see below).
+
+## Honest scope / value framing
+
+The win is correctness of an operator display command, not
+throughput. At absolute scale the cost is a per-call O(rows) map +
+slice build (display path, called at most ~1/s by an operator typing
+`show dhcp server leases` — never on the packet path, never on the
+config-apply path). The blast radius is one function plus its two
+test-only consumers. If reviewers conclude the fix is wrong-shaped or
+the existing behaviour is somehow load-bearing, PLAN-KILL is an
+acceptable verdict.
+
+## What's already shipped / partially batched
+
+`pkg/dhcpserver/ddns_leases.go` already implements a **state-aware**
+parser — `parseActiveLeases(path, family, now)` — for the #1387 DDNS
+reconciler. It ALREADY does expire-filter + per-address
+last-write-wins dedup + state-column filtering + DUID/IAID identity +
+fail-safe header validation, with `now time.Time` injected for tests.
+
+That parser is deliberately SEPARATE from the display parser and the
+plan keeps it that way: DDNS is a **destructive** consumer (an empty
+or wrongly-keyed result deletes owned DNS records), so it must
+hard-error on a mangled header and must read the `state`/identity
+columns. The display path is **non-destructive** and **lenient** — a
+mangled or short row should degrade to showing what it can, never
+abort the whole `show`. Merging the two parsers would force the
+display path to adopt DDNS's hard-fail semantics (a single corrupt row
+would blank the entire lease display) or force DDNS to adopt the
+display path's lenient semantics (re-opening the mass-delete bug
+#1387 spent six review rounds closing). They stay separate; this plan
+brings ONLY the two missing behaviours (expire filter + dedup) to the
+display parser, in the display parser's own lenient style.
+
+## Concrete design
+
+Change `parseLeaseCSV` to take an injected clock and apply expire
+filtering + last-write-wins dedup. Keep it lenient.
+
+### Signature
+
+```go
+// before
+func parseLeaseCSV(path string) ([]Lease, error)
+
+// after
+func parseLeaseCSV(path string, now time.Time) ([]Lease, error)
+```
+
+`GetLeases4`/`GetLeases6` pass `time.Now()`:
+
+```go
+func (m *Manager) GetLeases4() ([]Lease, error) {
+	return parseLeaseCSV("/var/lib/kea/kea-leases4.csv", time.Now())
+}
+func (m *Manager) GetLeases6() ([]Lease, error) {
+	return parseLeaseCSV("/var/lib/kea/kea-leases6.csv", time.Now())
+}
+```
+
+This mirrors the `now time.Time` injection already used by
+`parseActiveLeases` — a real seam, not an untestable `time.Now()`
+buried in the parser.
+
+### Body (replaces the `for _, fields := range records[1:]` accumulate)
+
+Keep the existing header-map build and per-field extraction. Replace
+the final `if l.Address != "" { leases = append(...) }` block with:
+
+1. Skip rows with empty `address` (unchanged — empty address is not a
+   displayable lease).
+2. **Expire filter (lenient):** parse the `expire` field as a Unix
+   epoch (`strconv.ParseInt(.., 10, 64)`). If it parses AND
+   `expire > 0` AND `now.Unix() >= expire`, the row is expired — record
+   it as a TOMBSTONE for that address (so a later append for the same
+   address can supersede it) and do not emit. If `expire` is absent or
+   unparseable, treat the row as live (lenient — display path must not
+   hide a lease just because Kea wrote an exotic/blank expire).
+3. **Dedup (last-write-wins):** keep a `map[string]Lease` keyed by
+   address, overwriting on each row so the LAST row for an address wins
+   (append-only memfile ⇒ chronological ⇒ newest last), plus a
+   first-appearance `order []string` slice so display order is stable
+   and deterministic. An expired row writes a zero `Lease{}` tombstone;
+   a live row writes the populated `Lease`.
+4. **Emit:** walk `order`, skip tombstones (`l.Address == ""`), append
+   the rest. This is the exact emit pattern `parseActiveLeases`
+   already uses — proven over six #1387 review rounds.
+
+Crucially the tombstone-and-reclaim shape (an expired row tombstones
+the address; a later live append for the same address re-populates it)
+matches the DDNS parser so a re-allocated address that Kea appended a
+fresh live row for is shown live, not hidden by an earlier expired row.
+
+### now boundary semantics
+
+`now.Unix() >= expire` ⇒ a lease expiring exactly at `now` is treated
+expired (matches `parseActiveLeases` line 284: `now.Unix() >= expire`).
+Consistent with the DDNS parser; the one-second boundary is
+display-only and immaterial.
+
+## Public API preservation
+
+- `GetLeases4() ([]Lease, error)` — unchanged signature.
+- `GetLeases6() ([]Lease, error)` — unchanged signature.
+- `Lease` struct — unchanged (all six fields preserved).
+- `parseLeaseCSV` is **package-private**; its only callers are
+  `GetLeases4`/`GetLeases6` and the package's own tests. Adding the
+  `now time.Time` param touches exactly those call sites. Confirmed by
+  `grep -rn parseLeaseCSV` — no consumer outside the package.
+
+## Hidden invariants the change must preserve
+
+- **Lenient display semantics:** a corrupt/short/exotic row must
+  degrade to showing what it can, NEVER abort the whole `show`. The
+  display parser must NOT inherit DDNS's hard-error-on-mangled-header
+  behaviour. (A blanked lease display on one bad row is a regression.)
+- **Missing file ⇒ `(nil, nil)`** — unchanged (`os.IsNotExist`).
+- **Header-only / <2 record file ⇒ `(nil, nil)`** — unchanged.
+- **Quoted-field column integrity (#1778)** — unchanged (still
+  `encoding/csv`, `FieldsPerRecord=-1`, `Comment='#'`). The dedup map
+  keys on the already-parsed `address` value, so quoting is irrelevant
+  to dedup.
+- **DDNS parser untouched** — `parseActiveLeases` and its consumers are
+  not modified; the destructive-path invariants from #1387 are
+  unaffected.
+- **No new error paths from the lenient filter** — an unparseable
+  `expire` does not error; it falls through to "live". The function's
+  error contract (only file-open and csv-read errors) is unchanged.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Only the display set shrinks (expired + duplicate rows removed). Live, unique rows are unchanged. Two test-only call sites updated for the new param. |
+| Lifetime / borrow (Go: aliasing) | LOW | Pure value copies into a `map[string]Lease`; `Lease` has no pointers/slices. No aliasing hazard. |
+| Performance regression | LOW | Display path, ~1/s operator-driven, never hot. O(rows) map+slice replaces O(rows) slice append. |
+| Architectural mismatch | LOW | Reuses the proven `parseActiveLeases` tombstone/order/emit shape in-place; does NOT merge the two parsers (which would be the mismatch). |
+
+## Test plan
+
+Control-plane display bug — **NO smoke** (no dataplane change; the
+loss-cluster CoS matrix is irrelevant here). Coverage is a focused
+`pkg/dhcpserver` unit test, non-tautological (fails against pre-fix code):
+
+1. New `TestParseLeaseCSV_ExpiredAndDuplicate`: synthetic append-only
+   CSV with (a) the SAME address appearing twice with different
+   `expire`/hostname (newer row last) and (b) a separate expired
+   address (`expire` well in the past). Assert:
+   - the duplicate address appears EXACTLY once, carrying the NEWEST
+     row's fields;
+   - the expired address is ABSENT;
+   - a normal live address is present unchanged;
+   - injects a fixed `now` (e.g. `time.Unix(1707900000, 0)`) so the
+     test is deterministic and the boundary is explicit. Fails pre-fix
+     (pre-fix returns 4 rows incl. the dup + expired).
+2. Edge: absent/blank/garbage `expire` ⇒ row kept (lenient).
+3. Edge: expired row for an address SUPERSEDED by a later live append
+   ⇒ address shown live (tombstone-reclaim).
+4. Update the three existing `parseLeaseCSV` call sites in
+   `dhcpserver_test.go` to pass a `now` (use a fixed time past the
+   1707955200 expiries in the existing fixtures so those rows stay live
+   — preserves the existing assertions). The existing fixture expires
+   (1707868800 / 1707955200 = 2024-02) need a `now` BEFORE them, or the
+   existing 2-lease test would now correctly drop them; pick a `now`
+   that keeps the existing fixtures live so those tests still assert the
+   pre-existing behaviour.
+5. Gates: `go build ./...`, `go vet ./pkg/dhcpserver/...`,
+   `go test ./pkg/dhcpserver/...` (named test 5x for flake), full
+   `go test ./...`.
+
+## Out of scope (explicitly)
+
+- The Kea `state` column (declined/expired-reclaimed) — the display
+  path stays lenient and address+expire-based. Adding state filtering
+  to the display is a separate enhancement; DDNS already handles state
+  for the destructive path. (Open question 4 invites a reviewer to
+  argue this should be in scope.)
+- Merging the display and DDNS parsers — explicitly rejected above.
+- Any change to how `expire`/`valid_lifetime` are RENDERED (epoch vs
+  human time) — out of scope; only the row SET changes.
+
+## Open questions for adversarial review
+
+1. **Time seam vs. param:** is adding `now time.Time` to a
+   package-private function the right seam, or should the clock be a
+   `Manager` field? (The function is package-private with two trivial
+   callers and the sibling `parseActiveLeases` already uses the param
+   form — but argue if a `Manager` clock field is cleaner.)
+2. **Lenient expire:** is "unparseable/absent expire ⇒ keep" correct
+   for a display, or should an unparseable expire DROP the row
+   (fail-safe)? DDNS keeps such a row too (line 275-280: expire stays
+   0, no drop). Argue if display should differ.
+3. **Boundary `>=` vs `>`:** `now.Unix() >= expire` treats expiring-now
+   as expired (matches DDNS). Is `>` (still valid at the instant of
+   expiry) more correct for a display? PLAN-KILL-adjacent if the
+   boundary matters operationally.
+4. **State column:** should the display ALSO drop declined /
+   expired-reclaimed (state != 0) rows, not just past-`expire` rows? A
+   reclaimed lease can have a future `expire` but a non-default state.
+   Is expire-only filtering an incomplete fix?
+5. **Dedup key:** is `address` the right dedup key for v6 (where the
+   same address is effectively unique per lease) and v4? Could two
+   genuinely-distinct live leases ever share an address in a healthy
+   memfile such that last-write-wins hides a real lease?
+6. **Should this fix instead just call `parseActiveLeases`?** Argue the
+   merge case if you believe the two-parser split is wrong — the plan
+   rejects it (destructive vs lenient semantics) but invites the
+   counter-argument.

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -79,8 +79,16 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   honors Kea's `state` column (default/declined/expired-reclaimed), the
   `expire` epoch, and the `fqdn_fwd` split between host-name and
   client-supplied FQDN, and extracts the v6 DUID/IAID identity. SEPARATE
-  from the display-only `parseLeaseCSV` (reusing that would publish/retain
-  stale records — the exact bug this feature fixes). Header columns are
+  from the display-only `parseLeaseCSV` — NOT because the display parser
+  is unfiltered (since #2085 it also filters non-active state + expired
+  rows and dedups per address), but because the two have opposite
+  failure postures: the DDNS parser is **destructive** (its empty result
+  authorizes deleting owned DNS records), so it must hard-error on a
+  mangled / duplicate-column / ragged header; the display parser is
+  **non-destructive and lenient** — an exotic or short row must degrade
+  to showing what it can, never blank the whole `show`. Merging them
+  would force one posture onto the other (re-opening the #1387
+  mass-delete, or blanking the display on one bad row). Header columns are
   matched CASE-INSENSITIVELY (both the header keys AND the lookup name are
   lower-cased in `leaseColumnValue`; field values are data and stay
   verbatim). A header maps to columns UNAMBIGUOUSLY: a DUPLICATE column name
@@ -319,7 +327,18 @@ adds `github.com/miekg/dns` (DNS UPDATE construction + TSIG signing).
   `/var/lib/kea/kea-leases4.csv` and `kea-leases6.csv`. No control
   channel / socket call. Missing files yield an empty list, not an
   error. Parsing uses `encoding/csv` (#1778) so quoted fields with
-  embedded commas don't shift columns.
+  embedded commas don't shift columns. Kea's memfile is **append-only**
+  between lease-file-cleanup (LFC) compactions — every renewal,
+  re-allocation, release, decline, and expiry-reclaim is a new row — so
+  `parseLeaseCSV` (#2085) collapses the append log to one row per
+  address (the last/newest row wins), drops non-active rows
+  (`state != 0` — declined / expired-reclaimed, which can still carry a
+  future `expire`, so state is filtered before expire) and lapsed rows
+  (`expire <= now`), and emits in first-appearance order. The clock is
+  injected (`parseLeaseCSV(path, now)`) for deterministic tests. The
+  filter is lenient: an absent or unparseable `state` / `expire` column
+  degrades to "treat the row as active", preserving the pre-#2085
+  behaviour for older Kea or exotic headers.
 - Per-subnet interface binding (#1778): Kea allows at most ONE
   interface per subnet. Single-interface groups bind explicitly;
   multi-interface groups omit the binding so Kea uses address-based

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -10,11 +10,17 @@ import (
 )
 
 // ddns_leases.go: a STATE-AWARE Kea memfile lease parser for the #1387
-// DDNS reconciler (plan §5 invariant 3). The existing parseLeaseCSV is
-// display-only — it has no active/expired filtering, no Kea `state`
-// column, and no v6 DUID/IAID identity. Reusing it for DDNS would publish
-// or retain stale records, the exact bug this feature is about. This
-// parser is separate and intentionally does NOT replace the display one.
+// DDNS reconciler (plan §5 invariant 3). It stays SEPARATE from the
+// display-only parseLeaseCSV not because that parser is unfiltered —
+// since #2085 it also filters non-active state + expired rows and dedups
+// per address — but because the two have opposite failure postures: this
+// DDNS parser is DESTRUCTIVE (its empty result authorizes deleting owned
+// DNS records), so it hard-errors on a mangled / duplicate-column /
+// ragged header, validates the required columns, and carries the v6
+// DUID/IAID identity the reconciler keys ownership on; the display parser
+// is NON-DESTRUCTIVE and LENIENT (a bad row degrades, never blanks the
+// `show`). Merging them would force one posture onto the other, so this
+// parser intentionally does NOT replace the display one.
 
 // Kea lease state column values (memfile CSV `state`).
 const (

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -366,15 +367,39 @@ type Lease struct {
 
 // GetLeases4 reads Kea DHCPv4 lease file and returns active leases.
 func (m *Manager) GetLeases4() ([]Lease, error) {
-	return parseLeaseCSV("/var/lib/kea/kea-leases4.csv")
+	return parseLeaseCSV("/var/lib/kea/kea-leases4.csv", time.Now())
 }
 
 // GetLeases6 reads Kea DHCPv6 lease file and returns active leases.
 func (m *Manager) GetLeases6() ([]Lease, error) {
-	return parseLeaseCSV("/var/lib/kea/kea-leases6.csv")
+	return parseLeaseCSV("/var/lib/kea/kea-leases6.csv", time.Now())
 }
 
-func parseLeaseCSV(path string) ([]Lease, error) {
+// parseLeaseCSV parses Kea's append-only memfile CSV and returns the
+// CURRENT, ACTIVE leases for display (`show dhcp server leases`).
+//
+// Kea never rewrites the memfile in place between lease-file-cleanup
+// (LFC) compactions: every renewal, re-allocation, release, decline,
+// and expiry-reclaim is APPENDED as a new row, so the same address
+// appears multiple times and superseded/stale rows linger until the
+// next LFC. A naive "emit every row with a non-empty address" therefore
+// shows duplicate and stale leases (#2085). This parser collapses the
+// append log to one row per address (the LAST, i.e. newest, row wins —
+// rows are chronological) and drops rows that are not currently active:
+//
+//   - state != 0 (declined / expired-reclaimed): Kea writes a
+//     non-default state but often a FUTURE expire epoch on
+//     release/decline, so an expire-only filter would still show it.
+//   - expire <= now: a genuinely lapsed lease.
+//
+// It is LENIENT by design (this is a non-destructive display path,
+// unlike the destructive DDNS reconciler's parseActiveLeases, which
+// hard-errors on a mangled header): an absent or unparseable state /
+// expire column degrades to "treat the row as active", preserving the
+// pre-#2085 behaviour for older Kea or exotic headers rather than
+// blanking the whole `show` on one odd row. now is injected so the
+// expiry comparison is deterministic in tests.
+func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -400,31 +425,76 @@ func parseLeaseCSV(path string) ([]Lease, error) {
 	for i, h := range records[0] {
 		cols[h] = i
 	}
+	field := func(fields []string, name string) string {
+		if idx, ok := cols[name]; ok && idx >= 0 && idx < len(fields) {
+			return fields[idx]
+		}
+		return ""
+	}
 
-	var leases []Lease
+	// latest holds the final disposition per address; a zero Lease
+	// (empty Address) is a TOMBSTONE meaning the last row for that
+	// address was inactive/expired. order keeps first-appearance order
+	// so the display is stable and deterministic. Re-recording the
+	// disposition on every row lets a later active append RECLAIM an
+	// address an earlier row tombstoned (release-then-reallocate).
+	latest := make(map[string]Lease, len(records)-1)
+	order := make([]string, 0, len(records)-1)
+	seen := make(map[string]struct{}, len(records)-1)
+	nowUnix := now.Unix()
+
 	for _, fields := range records[1:] {
-		l := Lease{}
-		if idx, ok := cols["address"]; ok && idx < len(fields) {
-			l.Address = fields[idx]
+		addr := field(fields, "address")
+		if addr == "" {
+			continue
 		}
-		if idx, ok := cols["hwaddr"]; ok && idx < len(fields) {
-			l.HWAddress = fields[idx]
+		if _, ok := seen[addr]; !ok {
+			seen[addr] = struct{}{}
+			order = append(order, addr)
 		}
-		if idx, ok := cols["hostname"]; ok && idx < len(fields) {
-			l.Hostname = fields[idx]
+
+		// State filter (lenient): only Kea's default state (0 = active)
+		// is displayable. A declined (1) or expired-reclaimed (2) lease
+		// can still carry a FUTURE expire epoch, so this must precede the
+		// expire check. An absent/unparseable state ⇒ active (Kea
+		// default). A non-active row tombstones the address; a later
+		// active append can still reclaim it.
+		if s := field(fields, "state"); s != "" {
+			if st, e := strconv.Atoi(s); e == nil && st != 0 {
+				latest[addr] = Lease{}
+				continue
+			}
 		}
-		if idx, ok := cols["valid_lifetime"]; ok && idx < len(fields) {
-			l.ValidLife = fields[idx]
+
+		// Expire filter (lenient): drop a lease whose expire epoch has
+		// lapsed. Absent/unparseable/zero expire ⇒ keep (don't hide a
+		// lease over an exotic value on a display).
+		expireStr := field(fields, "expire")
+		if expireStr != "" {
+			if exp, e := strconv.ParseInt(expireStr, 10, 64); e == nil && exp > 0 && nowUnix >= exp {
+				latest[addr] = Lease{}
+				continue
+			}
 		}
-		if idx, ok := cols["expire"]; ok && idx < len(fields) {
-			l.ExpireTime = fields[idx]
+
+		latest[addr] = Lease{
+			Address:    addr,
+			HWAddress:  field(fields, "hwaddr"),
+			Hostname:   field(fields, "hostname"),
+			ValidLife:  field(fields, "valid_lifetime"),
+			ExpireTime: expireStr,
+			SubnetID:   field(fields, "subnet_id"),
 		}
-		if idx, ok := cols["subnet_id"]; ok && idx < len(fields) {
-			l.SubnetID = fields[idx]
-		}
-		if l.Address != "" {
+	}
+
+	leases := make([]Lease, 0, len(order))
+	for _, addr := range order {
+		if l := latest[addr]; l.Address != "" {
 			leases = append(leases, l)
 		}
+	}
+	if len(leases) == 0 {
+		return nil, nil
 	}
 	return leases, nil
 }

--- a/pkg/dhcpserver/dhcpserver_test.go
+++ b/pkg/dhcpserver/dhcpserver_test.go
@@ -251,6 +251,12 @@ func TestApplyGenerateFailureFailsApply(t *testing.T) {
 	}
 }
 
+// leaseTestNow is a fixed reference time BEFORE the 2024-02 expire
+// epochs used by the legacy fixtures (1707868800 / 1707955200), so the
+// expire filter added in #2085 keeps those (state=0) rows live and the
+// pre-existing assertions still hold. New #2085 tests use their own now.
+var leaseTestNow = time.Unix(1707800000, 0) // 2024-02-13 03:33:20 UTC
+
 func TestParseLeaseCSV(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kea-leases4.csv")
@@ -262,7 +268,7 @@ func TestParseLeaseCSV(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	leases, err := parseLeaseCSV(path)
+	leases, err := parseLeaseCSV(path, leaseTestNow)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +295,7 @@ func TestParseLeaseCSV(t *testing.T) {
 }
 
 func TestParseLeaseCSV_NoFile(t *testing.T) {
-	leases, err := parseLeaseCSV("/nonexistent/path")
+	leases, err := parseLeaseCSV("/nonexistent/path", leaseTestNow)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +311,7 @@ func TestParseLeaseCSV_Empty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	leases, err := parseLeaseCSV(path)
+	leases, err := parseLeaseCSV(path, leaseTestNow)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,7 +332,7 @@ func TestParseLeaseCSV_QuotedHostname(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	leases, err := parseLeaseCSV(path)
+	leases, err := parseLeaseCSV(path, leaseTestNow)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,6 +344,168 @@ func TestParseLeaseCSV_QuotedHostname(t *testing.T) {
 	}
 	if leases[0].SubnetID != "1" {
 		t.Errorf("subnet_id shifted: got %q", leases[0].SubnetID)
+	}
+}
+
+// indexLeasesByAddr collapses a lease slice to address→Lease and also
+// returns the count, so the #2085 tests can assert both presence and
+// that an address appears exactly once.
+func indexLeasesByAddr(leases []Lease) map[string]Lease {
+	m := make(map[string]Lease, len(leases))
+	for _, l := range leases {
+		m[l.Address] = l
+	}
+	return m
+}
+
+// TestParseLeaseCSV_ExpiredAndDuplicate pins the core of #2085: Kea's
+// memfile is append-only, so the SAME address appears multiple times
+// (renewals) and lapsed leases linger until LFC. The display parser
+// must collapse to one row per address (newest wins) and drop expired
+// rows. Non-tautological: against the pre-#2085 parser this fixture
+// returns FOUR rows (the duplicate twice + the expired one + the live
+// one); the fix returns TWO (deduped live + the other live).
+func TestParseLeaseCSV_ExpiredAndDuplicate(t *testing.T) {
+	now := time.Unix(1707900000, 0) // 2024-02-14 06:40:00 UTC
+	past := now.Unix() - 3600       // expired an hour ago
+	future := now.Unix() + 3600     // valid for another hour
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kea-leases4.csv")
+	// Append order is chronological: the second 10.0.1.50 row (client1b,
+	// newer expire) supersedes the first. 10.0.1.99 is expired. 10.0.1.60
+	// is a normal single live lease.
+	csv := fmt.Sprintf(`address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id
+10.0.1.50,aa:bb:cc:dd:ee:01,,86400,%d,1,0,0,client1a,0,,0
+10.0.1.99,aa:bb:cc:dd:ee:99,,86400,%d,1,0,0,stale,0,,0
+10.0.1.50,aa:bb:cc:dd:ee:01,,86400,%d,1,0,0,client1b,0,,0
+10.0.1.60,aa:bb:cc:dd:ee:60,,86400,%d,1,0,0,client2,0,,0
+`, future, past, future, future)
+	if err := os.WriteFile(path, []byte(csv), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	leases, err := parseLeaseCSV(path, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases) != 2 {
+		t.Fatalf("got %d leases, want 2 (deduped + non-expired); pre-#2085 returned 4", len(leases))
+	}
+	byAddr := indexLeasesByAddr(leases)
+	dup, ok := byAddr["10.0.1.50"]
+	if !ok {
+		t.Fatalf("deduped address 10.0.1.50 missing; got %+v", leases)
+	}
+	if dup.Hostname != "client1b" {
+		t.Errorf("dedup must keep the NEWEST row: hostname got %q, want client1b", dup.Hostname)
+	}
+	if _, ok := byAddr["10.0.1.99"]; ok {
+		t.Errorf("expired lease 10.0.1.99 must be dropped; got %+v", leases)
+	}
+	if _, ok := byAddr["10.0.1.60"]; !ok {
+		t.Errorf("live lease 10.0.1.60 must be present; got %+v", leases)
+	}
+	// Order is stable (first-appearance): 10.0.1.50 before 10.0.1.60.
+	if leases[0].Address != "10.0.1.50" || leases[1].Address != "10.0.1.60" {
+		t.Errorf("display order not stable first-appearance: %q, %q", leases[0].Address, leases[1].Address)
+	}
+}
+
+// TestParseLeaseCSV_StateFiltered pins the second half of #2085: a
+// released (state=2 expired-reclaimed) or declined (state=1) Kea lease
+// is written with a non-default state but often a FUTURE expire epoch,
+// so an expire-only filter would still show it as live. The display
+// must drop non-default-state rows too, BEFORE the expire check. A
+// later active (state=0) append must still reclaim the address.
+// Non-tautological against an expire-only half-fix (which would emit the
+// declined and reclaimed rows because their expire is in the future).
+func TestParseLeaseCSV_StateFiltered(t *testing.T) {
+	now := time.Unix(1707900000, 0)
+	future := now.Unix() + 3600
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kea-leases4.csv")
+	// 10.0.1.10 declined (state=1, future expire) — must be hidden.
+	// 10.0.1.11 expired-reclaimed (state=2, future expire) — must be hidden.
+	// 10.0.1.12 reclaimed (state=2) then re-allocated live (state=0) —
+	//   the later live append must reclaim the address.
+	// 10.0.1.13 plain active — present.
+	csv := fmt.Sprintf(`address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id
+10.0.1.10,aa:bb:cc:dd:ee:10,,86400,%d,1,0,0,declined,1,,0
+10.0.1.11,aa:bb:cc:dd:ee:11,,86400,%d,1,0,0,reclaimed,2,,0
+10.0.1.12,aa:bb:cc:dd:ee:12,,86400,%d,1,0,0,old,2,,0
+10.0.1.12,aa:bb:cc:dd:ee:12,,86400,%d,1,0,0,reallocated,0,,0
+10.0.1.13,aa:bb:cc:dd:ee:13,,86400,%d,1,0,0,active,0,,0
+`, future, future, future, future, future)
+	if err := os.WriteFile(path, []byte(csv), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	leases, err := parseLeaseCSV(path, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byAddr := indexLeasesByAddr(leases)
+	if _, ok := byAddr["10.0.1.10"]; ok {
+		t.Errorf("declined lease (state=1, future expire) must be dropped; got %+v", leases)
+	}
+	if _, ok := byAddr["10.0.1.11"]; ok {
+		t.Errorf("expired-reclaimed lease (state=2, future expire) must be dropped; got %+v", leases)
+	}
+	reclaimed, ok := byAddr["10.0.1.12"]
+	if !ok {
+		t.Errorf("re-allocated address 10.0.1.12 must be shown live; got %+v", leases)
+	} else if reclaimed.Hostname != "reallocated" {
+		t.Errorf("reclaim must keep the live row: hostname got %q, want reallocated", reclaimed.Hostname)
+	}
+	if _, ok := byAddr["10.0.1.13"]; !ok {
+		t.Errorf("plain active lease 10.0.1.13 must be present; got %+v", leases)
+	}
+	if len(leases) != 2 {
+		t.Fatalf("got %d leases, want 2 (reallocated + active); pre-fix/expire-only returns more", len(leases))
+	}
+}
+
+// TestParseLeaseCSV_Lenient pins the display path's leniency: absent or
+// unparseable state/expire columns must NOT hide a lease, and a header
+// missing the state column entirely must degrade to today's behaviour
+// (all addressed rows shown), never abort the show. This is what keeps
+// the fix safe for older Kea / exotic headers.
+func TestParseLeaseCSV_Lenient(t *testing.T) {
+	now := time.Unix(1707900000, 0)
+	dir := t.TempDir()
+
+	// Garbage state + blank/garbage expire ⇒ rows kept.
+	path := filepath.Join(dir, "garbage.csv")
+	csv := `address,hwaddr,expire,state,hostname
+10.0.2.10,aa:bb:cc:dd:ee:10,notanumber,xyz,a
+10.0.2.11,aa:bb:cc:dd:ee:11,,,b
+`
+	if err := os.WriteFile(path, []byte(csv), 0644); err != nil {
+		t.Fatal(err)
+	}
+	leases, err := parseLeaseCSV(path, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases) != 2 {
+		t.Errorf("lenient: garbage/blank state+expire must keep rows; got %d, want 2 (%+v)", len(leases), leases)
+	}
+
+	// Header with NO state and NO expire column ⇒ all addressed rows shown.
+	path2 := filepath.Join(dir, "nostate.csv")
+	csv2 := `address,hwaddr,hostname
+10.0.3.10,aa:bb:cc:dd:ee:10,a
+10.0.3.11,aa:bb:cc:dd:ee:11,b
+`
+	if err := os.WriteFile(path2, []byte(csv2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	leases2, err := parseLeaseCSV(path2, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leases2) != 2 {
+		t.Errorf("lenient: missing state/expire columns must keep rows; got %d, want 2 (%+v)", len(leases2), leases2)
 	}
 }
 

--- a/pkg/dhcpserver/dhcpserver_test.go
+++ b/pkg/dhcpserver/dhcpserver_test.go
@@ -347,9 +347,9 @@ func TestParseLeaseCSV_QuotedHostname(t *testing.T) {
 	}
 }
 
-// indexLeasesByAddr collapses a lease slice to address→Lease and also
-// returns the count, so the #2085 tests can assert both presence and
-// that an address appears exactly once.
+// indexLeasesByAddr collapses a lease slice to an address→Lease map so
+// the #2085 tests can assert per-address presence and field values; the
+// expected lease count is asserted separately via len(leases).
 func indexLeasesByAddr(leases []Lease) map[string]Lease {
 	m := make(map[string]Lease, len(leases))
 	for _, l := range leases {


### PR DESCRIPTION
## Summary

`parseLeaseCSV` (the display-only Kea memfile lease parser behind `show dhcp server leases`, via `GetLeases4`/`GetLeases6`) returned every data row with a non-empty address — no expire filter, no state filter, no per-address dedup. Kea's memfile is **append-only** between lease-file-cleanup (LFC) compactions, so every renewal, re-allocation, release, decline, and expiry-reclaim is appended as a new row. The display therefore showed **duplicate rows** for the same address and **stale** (expired / released / declined) leases (#2085).

The fix collapses the append log to one active row per address (newest wins) and drops non-active and expired rows, in the parser's existing **lenient, non-destructive** style:

- **Dedup, last-write-wins** — chronological rows ⇒ last row per address is authoritative; first-appearance order preserved for a stable display.
- **State filter BEFORE expire** — drop `state != 0` (declined / expired-reclaimed). These often carry a **future** `expire`, so expire-only would still show them — the issue's own "stale row" symptom. A later active append reclaims a tombstoned address.
- **Expire filter** — drop rows where `now >= expire`.
- **Lenient** — absent/unparseable `state`/`expire` ⇒ treat as active (pre-#2085 behaviour for older Kea / exotic headers); a bad row never blanks the whole `show`. Clock injected (`now time.Time`) for deterministic tests, mirroring the sibling `parseActiveLeases` seam.

Only the per-row tombstone/order/emit logic is copied from the state-aware DDNS parser (`ddns_leases.go`); the destructive header-validation hard-fail is deliberately NOT adopted (it would blank the display on one mangled row, and re-merging the two would re-open the #1387 mass-delete).

## Plan + adversarial review

Plan doc: `docs/pr/2085-kea-lease-parser/plan.md`

Round-1 plan review (two hostile Claude reviewers): **PLAN-NEEDS-MAJOR + PLAN-NEEDS-MINOR**, converged on one substantive gap — expire-only is incomplete; state-column filtering must be in scope (released/declined leases carry future expire) — plus a test-fixture `now` contradiction and the README update. All folded into plan v2 and the implementation. The reviewers agreed the `now` param seam, `>=` boundary, `address` dedup key, and keeping the two parsers separate are all correct.

## Test plan

Control-plane **display** bug — NO smoke (no dataplane change). Coverage is `pkg/dhcpserver` unit tests, non-tautological:

- [x] `go build ./...` clean
- [x] `go vet ./pkg/dhcpserver/...` clean
- [x] `TestParseLeaseCSV_ExpiredAndDuplicate` — dedup keeps newest, expired dropped, stable order (pre-fix returns 4, asserts 2)
- [x] `TestParseLeaseCSV_StateFiltered` — declined (state=1) / expired-reclaimed (state=2) with **future** expire dropped; state tombstone-reclaim; fails an expire-only half-fix (pre-fix returns 5, asserts 2)
- [x] `TestParseLeaseCSV_Lenient` — garbage/absent state+expire and a header with no state/expire column keep rows (degrade-to-today, never blank the show)
- [x] Four existing `parseLeaseCSV` call sites updated to pass a fixed `now` before the 2024-02 fixture expiries so their (state=0) rows stay live — pre-existing assertions preserved
- [x] `pkg/dhcpserver` tests 5/5 (flake check)
- [x] Full `go test ./...` — all packages pass
- [x] Non-tautology proven: pre-fix logic returns 4 and 5 rows where the new tests assert 2

## Docs

- [x] `pkg/dhcpserver/README.md` updated — shifted two-parser rationale (destructive-vs-lenient) and the new active/dedup display semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)