### PR TITLE
#2074: stop IPsec gateway NAME leaking into swanctl remote_addrs

### DIFF
--- a/docs/pr/2074-remote-addrs-name-leak/plan.md
+++ b/docs/pr/2074-remote-addrs-name-leak/plan.md
@@ -1,6 +1,63 @@
 # #2074 — renderConfig leaks the gateway NAME into swanctl remote_addrs
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** DRAFT v2 — addresses round-1 hostile review (reviewer A
+PLAN-NEEDS-MINOR, reviewer B PLAN-NEEDS-MAJOR). Both converged on the
+whole-render-abort blast-radius defect; B escalated on altitude
+(warn-only does not make `commit` fail). v2 adopts a **two-layer fix**:
+a commit-time cross-reference validator (primary, loud at `commit`) plus
+a **skip-and-continue** render-side belt (never zeroes healthy tunnels).
+
+## Round-1 review resolution (what changed in v2)
+
+- **R1 (both reviewers, blocking): whole-render abort.** v1 returned an
+  error from inside the per-VPN loop, so one bad VPN aborted rendering
+  of ALL VPNs — and on cold boot / first apply (no last-good file) that
+  zeroes EVERY tunnel, strictly worse than the single-tunnel bug. v2
+  changes the render path to **skip the offending VPN's connection block
+  and continue**, rendering all healthy VPNs, then returns the rendered
+  config plus a joined (non-fatal-to-other-VPNs) error so `Apply` still
+  writes the good tunnels and still surfaces a warning.
+- **R2 (reviewer B, blocking): altitude / does it actually fix the
+  bug.** A post-commit `slog.Warn` leaves `commit` green on a dead
+  tunnel. v2 adds the PRIMARY fix at commit time: a cross-reference
+  validator in `pkg/config/compiler_ipsec.go` (the VPN loop already has
+  both `VPNs` and `Gateways` in scope) that FAILS the commit when a VPN
+  references a gateway that is neither a defined gateway object nor a
+  usable inline IP/hostname. The operator now gets a loud `commit`
+  error, directly answering the issue's "no diagnostic" complaint. The
+  render-side guard remains as the by-construction belt.
+- **R3 (reviewer B): Rule A false-positive on inline single-label
+  hostname.** With the commit validator as the hard gate, the render
+  guard's job is only "never emit a bare NAME" — and because the
+  commit validator already rejects an unusable reference, a legit
+  single-label inline hostname that resolves via the system resolver is
+  no longer at risk of a *fatal* render abort (render skips+warns at
+  most, and the commit validator uses the SAME predicate so the operator
+  is told at commit). The predicate keeps Rule A (require a dot for a
+  bare hostname) but the single-label limitation is now a *documented
+  commit-check behavior*, not a silent render regression. Added table
+  row 6.
+- **R4 (reviewer B): non-tautological test fixture.** v2 pins the
+  dangling-name fixture to benign PSK auth so `resolveIKESettings` /
+  `normalizePSK` cannot error first, and adds a multi-VPN test
+  (healthy + dangling) asserting the healthy VPN's `remote_addrs` IS
+  rendered AND an error is returned — the regression guard for R1.
+- **R5 (reviewer B): overstated invariant.** v1 Hidden-invariant #5
+  wrongly claimed remote_addrs is "by construction" always a real
+  IP/host — cases 1/2 pass `gw.Address`/`gw.DynamicHostname` through raw
+  without the predicate. v2 states this honestly: content of a defined
+  gateway's address/dynamic-hostname is trusted to the parser/schema
+  (unchanged, out of scope); the guarantee is narrower and exact: *a
+  bare gateway config-object NAME never reaches remote_addrs.*
+- **Reviewer A: README deliverable + missing table rows + case-5
+  comment.** All folded in (concrete deliverable below; rows 6-8 added;
+  responder-only note added).
+- **OQ4/OQ6 closed as not-applicable:** grep confirms NO `%any` /
+  responder / wildcard concept anywhere in `pkg/ipsec/` or
+  `compiler_ipsec.go`; `vpn.Gateway` is a single non-`multi` token
+  (`schema_security.go`), so list/range/subnet forms cannot arrive
+  inline. The case-5 error branch carries a comment that it forecloses a
+  future responder-only peer.
 
 ## Issue framing
 
@@ -56,86 +113,152 @@ must distinguish:
 | 4. dangling/typo name | not found | NO (not an IP, not a hostname) | `remote_addrs=<NAME>` (BUG) | error, no leak |
 | 5. gw exists, addressless | found, both empty | NO | `remote_addrs=<NAME>` (BUG) | error, no leak |
 
-Cases 4 and 5 are the bug. Cases 1-3 are preserved bit-for-bit.
+Cases 4 and 5 are the bug. Cases 1-3 are preserved bit-for-bit. Two
+more rows for completeness (reviewer A R-A8):
 
-## Why resolve-or-error (NOT fail-commit)
+| Case | Description | Today | Desired |
+|------|-------------|-------|---------|
+| 6. inline single-label hostname | not found, dotless, not IP | `remote_addrs=<host>` (works iff resolver finds it) | commit-check rejects (Rule A); render skips+warns. Migration: define a `gateway` with `address`/`dynamic hostname`. |
+| 7. defined gw, Address is itself an FQDN | found, Address="peer.ex.com" | `remote_addrs=peer.ex.com` | unchanged — Case-1 passthrough, content NOT re-validated |
+| 8. gw object NAMED like an IP, referenced | found (map key="10.0.2.1") | map lookup wins → uses object's Address | unchanged — map precedence over literal |
 
-`renderConfig` already returns `error`. Its only real consumer is
-`Manager.Apply` (`manager.go:67`), reached from:
+Case 6 is the only behavior change for a *currently-working* config
+(a bare single-label hostname resolvable via DNS search / `/etc/hosts`).
+That is rare for a VPN peer, is now a loud `commit` error with a clear
+migration, and is documented in the README. Rows 7/8 are unchanged
+passthroughs called out so the implementer does not "fix" them.
 
-- `pkg/daemon/daemon_apply.go:1054` — `slog.Warn("failed to apply IPsec
-  config", ...)` (post-commit runtime apply).
-- `pkg/cli/apply.go:161` — `fmt.Fprintf(os.Stderr, "warning: IPsec
-  apply failed: %v\n", ...)`.
+## Decision: two-layer fix (commit-validator PRIMARY + render belt)
 
-Both are POST-commit apply paths that only warn; neither aborts the
-commit. There is no IPsec rendering on the commit/compile path. So:
+Round-1 reviewer B correctly argued that a render-only warning leaves
+`commit` reporting success on a dead tunnel — relocating the diagnostic
+to the journal, not removing it. So the issue's "operator gets no
+diagnostic" complaint is answered at the COMMIT layer:
 
-- Returning an error from `renderConfig` for cases 4/5 turns the silent
-  dead tunnel into a **visible apply-time warning** with the offending
-  VPN + gateway named. That is a strict improvement and stays inside the
-  issue's `pkg/ipsec/policy.go` target.
-- True **fail-commit** would require a NEW cross-reference validator in
-  `pkg/config` (schema_walk / compiler_ipsec) — a different file, a
-  larger blast radius, and explicitly noted by the issue as absent
-  today. That is deferred (see Out of scope) and could be a follow-up
-  issue. The issue text permits "omit/skip with a clear error OR fail
-  commit" — we choose the in-scope, already-plumbed error path.
+**Layer 1 — commit-time validator (primary, hard gate).**
+`compileIPsec` (`compiler_ipsec.go:185-382`) parses both `ike { gateway
+}` (via `compileIKE`, run first per `compiler_security.go:39-44`) and
+`ipsec { gateway }` and the VPNs, all into `sec.IPsec.Gateways` /
+`sec.IPsec.VPNs`. At the END of `compileIPsec` (after the VPN loop,
+line 378 — both gateway sections are populated by then), add a
+cross-reference pass: for each VPN with a non-empty `Gateway`, if it is
+neither a key in `sec.IPsec.Gateways` NOR a usable inline IP/hostname,
+return an error → `compileSecurity` wraps it → `Compile` returns it →
+**`commit` fails** with a clear message naming the VPN and gateway.
+`commit check` catches it too (same compile path). This is the loud,
+correct-altitude fix.
 
-The key invariant the issue demands either way: **a gateway NAME must
-never be rendered into `remote_addrs`.** This plan guarantees that by
-construction — the only strings that can reach `remote_addrs` are a
-resolved gateway Address/DynamicHostname or a `vpn.Gateway` value that
-is itself a syntactically valid IP or hostname.
+Verified safe against existing tests: `parser_security_test.go` commits
+`vpn site-a gateway 10.1.0.1` (inline IP — passes), `vpn site-b gateway
+10.2.0.1` (inline IP — passes), and `vpn ... gateway remote-gw` with a
+defined `gateway remote-gw address 203.0.113.1` (defined object —
+passes). No existing committed config references a dangling/addressless
+gateway, so none breaks.
+
+**Layer 2 — render-side belt (defense-in-depth, skip-and-continue).**
+`renderConfig` is the last line. Even though Layer 1 makes the bad
+config un-committable, the render guard guarantees BY CONSTRUCTION that
+a bare gateway NAME can never reach `remote_addrs` — covering any future
+path that reaches render without the compile gate (HA config sync,
+direct `IPsecConfig` construction, tests). Crucially, per R1, the render
+guard does NOT abort the whole file: it **skips the offending VPN's
+connection block, continues rendering the healthy VPNs**, and returns
+the rendered config plus a joined error. So one bad VPN never zeroes
+healthy tunnels on cold boot.
+
+`renderConfig`'s error consumers are both POST-commit apply paths that
+only warn (`daemon_apply.go:1054` slog.Warn; `cli/apply.go:161`
+stderr) — so Layer 2's returned error is informational; the rendered
+(healthy-VPNs) config is still written by `Apply`.
+
+**The exact guarantee:** *a bare gateway config-object NAME never
+reaches `remote_addrs`* (Layer 2, by construction) AND *a config that
+would produce one is rejected at `commit`* (Layer 1). The CONTENT of a
+defined gateway's `address` / `dynamic hostname` is trusted to the
+existing parser/schema (unchanged, out of scope) — the guarantee is
+specifically about the gateway-NAME leak, which is exactly the bug.
 
 ## Concrete design
 
-Replace the resolution block (current lines 37-51) with an explicit
-resolver that yields either a usable remote address or an error.
+### Layer 2 — render (`pkg/ipsec/policy.go`), skip-and-continue
+
+A shared resolver returns either a usable remote address or an error.
+The per-VPN loop, on a resolver error, records the error, `continue`s
+(skips that connection block), and renders the rest. After the loop,
+`renderConfig` returns the rendered config and the joined error.
 
 ```go
-// Resolve the remote gateway endpoint. remote_addrs must be a real
-// IP / hostname that strongSwan can use — never a bare gateway
-// config-object name (#2074). A name that leaks here produces a
-// silently-dead tunnel (strongSwan DNS-resolves the object name and
-// the IKE SA never comes up).
-localAddr := vpn.LocalAddr
-var gw *config.IPsecGateway
-remoteAddr := ""
-if g, ok := ipsecCfg.Gateways[vpn.Gateway]; ok {
-    gw = g
-    switch {
-    case gw.Address != "":
-        remoteAddr = gw.Address
-    case gw.DynamicHostname != "":
-        remoteAddr = gw.DynamicHostname
-    default:
-        // Case 5: the gateway exists but has neither an address nor a
-        // dynamic hostname. We have nothing routable to hand
-        // strongSwan; do NOT fall back to the object name.
-        return "", fmt.Errorf(
-            "vpn %s: ike gateway %q has no address or dynamic-hostname; "+
-                "cannot render remote_addrs", name, vpn.Gateway)
+func resolveRemoteAddr(ipsecCfg *config.IPsecConfig, vpn *config.IPsecVPN,
+    name string) (remoteAddr, localAddr string, gw *config.IPsecGateway, err error) {
+
+    localAddr = vpn.LocalAddr
+    if g, ok := ipsecCfg.Gateways[vpn.Gateway]; ok {
+        gw = g
+        switch {
+        case gw.Address != "":
+            remoteAddr = gw.Address
+        case gw.DynamicHostname != "":
+            remoteAddr = gw.DynamicHostname
+        default:
+            // Case 5: gateway exists but has neither an address nor a
+            // dynamic hostname — nothing routable. Do NOT fall back to
+            // the object name. (Forecloses a future responder-only /
+            // %any peer that legitimately omits remote_addrs; revisit
+            // this branch if/when that is added — no such concept
+            // exists in the parser today.)
+            return "", localAddr, gw, fmt.Errorf(
+                "ike gateway %q has no address or dynamic-hostname",
+                vpn.Gateway)
+        }
+        if gw.LocalAddress != "" && localAddr == "" {
+            localAddr = gw.LocalAddress
+        }
+        return remoteAddr, localAddr, gw, nil
     }
-    if gw.LocalAddress != "" && localAddr == "" {
-        localAddr = gw.LocalAddress
+    if isUsableRemoteEndpoint(vpn.Gateway) {
+        // Case 3: legacy inline shape — peer endpoint named directly as
+        // a literal IP or (dotted) hostname, no Gateways entry.
+        return vpn.Gateway, localAddr, nil, nil
     }
-} else if isUsableRemoteEndpoint(vpn.Gateway) {
-    // Case 3: legacy inline shape — the VPN names the peer endpoint
-    // directly as a literal IP or hostname, with no Gateways entry.
-    remoteAddr = vpn.Gateway
-} else if vpn.Gateway != "" {
-    // Case 4: dangling reference — a non-empty gateway value that is
-    // neither a known gateway object nor a usable IP/hostname. Emitting
-    // it as remote_addrs would leak the name.
-    return "", fmt.Errorf(
-        "vpn %s: ike gateway %q is not defined and is not a valid "+
-            "address or hostname", name, vpn.Gateway)
+    if vpn.Gateway != "" {
+        // Case 4/6: dangling reference / dotless single-label name that
+        // is neither a known gateway nor a usable IP/hostname. Emitting
+        // it as remote_addrs would leak the name.
+        return "", localAddr, nil, fmt.Errorf(
+            "ike gateway %q is not defined and is not a valid address "+
+                "or hostname", vpn.Gateway)
+    }
+    // vpn.Gateway == "" with no map entry => remoteAddr "" => the
+    // existing `if remoteAddr != ""` emit guard skips the line.
+    return "", localAddr, nil, nil
 }
-// vpn.Gateway == "" with no map entry => remoteAddr stays "" and the
-// existing `if remoteAddr != ""` guard at the emit site skips the line
-// (unchanged behavior — some configs legitimately omit remote_addrs).
 ```
+
+Loop integration (replacing current lines 37-51), skip-and-continue:
+
+```go
+var renderErrs []error
+for _, name := range sortedVPNNames(ipsecCfg.VPNs) {
+    vpn := ipsecCfg.VPNs[name]
+    remoteAddr, localAddr, gw, rerr := resolveRemoteAddr(ipsecCfg, vpn, name)
+    if rerr != nil {
+        // Skip ONLY this VPN's connection block; keep rendering the
+        // rest so one typo never zeroes healthy tunnels (#2074 R1).
+        renderErrs = append(renderErrs, fmt.Errorf("vpn %s: %w", name, rerr))
+        continue
+    }
+    fmt.Fprintf(&b, "  %s {\n", sanitizeSwanctlValue(name))
+    ... // unchanged emit body, using remoteAddr/localAddr/gw
+}
+...
+// after building secrets:
+return b.String(), errors.Join(renderErrs...)
+```
+
+`errors.Join(nil...)` is `nil`, so the no-error path is unchanged.
+The secrets loop also skips a VPN whose render errored (it would be
+harmless to emit secrets for a skipped connection, but skipping keeps
+the output minimal and avoids a dangling `ike-<name>` secret).
 
 `isUsableRemoteEndpoint` — a small, local, allocation-light predicate:
 
@@ -181,129 +304,218 @@ alone. Two candidate rules (decide in review):
   catches names with illegal hostname chars (`/`, space, `_` if we
   forbid underscore, etc.).
 
-**Plan recommendation: Rule A.** It is the only rule that actually
-catches case (a) from the issue — a typo'd single-label gateway name —
-while still passing every realistic inline gateway (IP or FQDN). The
-existing tests all use literal IPs for the inline shape, so Rule A
-breaks none of them. We document the single-label-hostname limitation
-in the IPsec README and the error message guides the operator to the
-fix (`set security ike gateway <name> address <ip>`).
+**Decision: Rule A.** It is the only rule that catches case (a) from the
+issue — a typo'd single-label gateway name — while passing every
+realistic inline gateway (IP or FQDN). Every existing test uses a
+literal IP for the inline shape, so Rule A breaks none of them. With the
+commit validator (Layer 1) as the hard gate using the SAME predicate,
+the single-label-inline-hostname limitation is a *documented commit-check
+behavior* with a clear migration (`set security ike gateway <name>
+address <ip>`), not a silent render regression. `isPlausibleHostname` is
+a manual byte scan (no regexp): non-empty, contains a `.`, every label
+1-63 alnum + internal hyphen, total ≤253.
 
-This is an explicit OPEN QUESTION for reviewers — if both reviewers
-prefer Rule B (or a fail-commit redesign), the plan changes.
+### Layer 1 — commit validator (`pkg/config/compiler_ipsec.go`)
+
+At the end of `compileIPsec` (after the VPN loop, current line 378 —
+both `ike{gateway}` and `ipsec{gateway}` sections are populated by then;
+`compileIKE` runs first), add:
+
+```go
+// #2074: a VPN that references a gateway which is neither a defined
+// gateway object nor a usable inline IP/hostname would render
+// `remote_addrs = <gateway-name>` — a config-object name strongSwan
+// can't use, producing a silently-dead tunnel. Reject it at commit so
+// the operator gets a diagnostic instead of a dead tunnel.
+for _, vpn := range sec.IPsec.VPNs {
+    if vpn.Gateway == "" {
+        continue
+    }
+    if _, ok := sec.IPsec.Gateways[vpn.Gateway]; ok {
+        continue // resolves to a defined gateway object
+    }
+    if isUsableRemoteEndpoint(vpn.Gateway) {
+        continue // legacy inline literal IP / dotted hostname
+    }
+    return fmt.Errorf("vpn %s: ike gateway %q is not defined and is "+
+        "not a valid address or hostname", vpn.Name, vpn.Gateway)
+}
+```
+
+The predicate `isUsableRemoteEndpoint` lives in `pkg/ipsec` but the
+validator runs in `pkg/config`, and **`pkg/config` must not import
+`pkg/ipsec`** (ipsec already imports config — an import cycle). So the
+predicate is defined in `pkg/config` (e.g. `isUsableIPsecEndpoint` in
+`compiler_ipsec.go`) and `pkg/ipsec` either re-implements the identical
+two-line predicate locally or calls the exported `config` helper. Plan
+choice: define `config.IsUsableIPsecEndpoint` (exported) once in
+`pkg/config` and have `pkg/ipsec` call it — single source of truth, no
+cycle (ipsec→config is the existing, allowed direction). This is the one
+implementation detail to get right; flagged for review.
+
+Iteration order: the validator iterates a map, so error ORDER is
+non-deterministic across multiple bad VPNs. For a deterministic error
+(stable tests / operator experience), sort VPN names first
+(`sortedVPNNames`-style) and return the first failure. Plan: sort, then
+validate.
+
+Does the addressless-gateway case (case 5) belong in Layer 1 too? Yes:
+extend the validator to also reject a VPN whose referenced gateway
+object exists but has neither `Address` nor `DynamicHostname`. Same
+loop, after the `ok` check: `if gw.Address=="" && gw.DynamicHostname==""
+{ return err }`. This makes BOTH leak cases (4 and 5) un-committable.
 
 ## Public API preservation
 
 - `renderConfig(*config.IPsecConfig) (string, error)` — signature
-  unchanged.
+  unchanged. Semantics: now returns the rendered config for the HEALTHY
+  VPNs plus a joined error naming any skipped VPNs (was: a single fatal
+  error aborting the whole file — the R1 defect).
 - `generateConfig(*config.IPsecConfig) string` — signature unchanged.
-  It already discards the error (`cfg, _ := m.renderConfig(...)`).
-  IMPORTANT: on the new error paths `renderConfig` returns
-  `("", err)`, so `generateConfig` now returns `""` for cases 4/5
-  where it previously returned a (broken) config string. Callers of
-  `generateConfig` are TEST-ONLY (`ipsec_test.go`) — no production
-  caller. Verified by grep. Tests that exercise the legacy inline IP
-  shape are unaffected (case 3).
-- `Manager.Apply` behavior unchanged for valid configs; for cases 4/5
-  it now returns the new error (previously wrote a broken file and
-  reloaded). Both Apply call sites already handle a non-nil error
-  (warn). This means: on a dangling/addressless gateway, the apply now
-  leaves the PREVIOUS swanctl config in place (the atomic write is
-  skipped because `renderConfig` errored before the write) rather than
-  overwriting it with a config that names a dead peer. Strict
-  improvement.
+  It discards the error. With skip-and-continue it now returns the
+  healthy-VPN config (NOT `""`) even when one VPN is malformed — strictly
+  better than v1's `""`. Callers are TEST-ONLY (`ipsec_test.go`); no
+  production caller. Verified by grep.
+- `Manager.Apply` — for a fully-valid config: unchanged. For a config
+  with one bad VPN reaching render (only possible via a path that
+  bypasses the commit validator, e.g. HA sync / direct construction):
+  it writes the healthy-VPN config AND returns the joined error, which
+  both call sites warn. Healthy tunnels stay up; the bad one is omitted
+  with a logged reason. No cold-boot zero-tunnels regression.
+- New exported `config.IsUsableIPsecEndpoint(string) bool` — additive,
+  no existing symbol changed.
 
 ## Hidden invariants the change must preserve
 
 1. **`gw` is consumed downstream** (lines 52, 57, 60-64, 78-91,
-   103-116). For case 3 (inline literal) and case 4, `gw` stays `nil`
-   exactly as today. For cases 1/2/5 `gw` is set as today. The early
-   `return` on case 5 happens AFTER `gw` is set but that's fine — we
-   never reach the downstream uses.
-2. **`localAddr` fallback from `gw.LocalAddress`** (current line 48-50)
-   only happens in the resolved-gateway branch — preserved.
-3. **Empty-gateway VPNs** (`vpn.Gateway == ""`, no map entry) must
-   still render with NO `remote_addrs` line, not an error. Handled: the
-   final `else if vpn.Gateway != ""` guards the error so empty stays
-   `remoteAddr == ""` → existing emit guard skips the line.
-4. **No new allocations on the hot path** — render runs only on config
-   apply (cold path), so this is not perf-sensitive, but the predicate
-   is still allocation-light (no regexp; manual byte scan).
-5. **sanitizeSwanctlValue is NOT applied to remote_addrs today** and we
-   do not change that — an IP/hostname has no control chars; the
-   predicate already rejects anything pathological.
+   103-116). For case 3 (inline literal) `gw` stays `nil` as today.
+   For cases 1/2 `gw` is set as today and the connection is rendered.
+   For cases 4/5/6 the VPN is SKIPPED before any downstream use of `gw`
+   (the `continue`), so no downstream `gw` access happens for a skipped
+   VPN — correct.
+2. **`localAddr` fallback from `gw.LocalAddress`** only happens in the
+   resolved-gateway branch (cases 1/2) — preserved inside the resolver.
+3. **Empty-gateway VPNs** (`vpn.Gateway == ""`, no map entry) still
+   render with NO `remote_addrs` line and NO error — the resolver
+   returns `("","",nil,nil)`, the connection IS emitted, and the
+   existing `if remoteAddr != ""` emit guard skips only the line.
+4. **No new hot-path allocations** — render + compile run only on config
+   apply / commit (cold path). The predicate is allocation-light (no
+   regexp; manual byte scan). `errors.Join` allocates only when there
+   ARE errors.
+5. **Exact guarantee (corrected from v1's overstated claim):** a bare
+   gateway config-object NAME never reaches `remote_addrs`. The CONTENT
+   of a *defined* gateway's `Address` / `DynamicHostname` (cases 1/2) is
+   passed through raw and is NOT re-validated — that is unchanged,
+   trusted to the parser/schema, and explicitly out of scope.
+   `sanitizeSwanctlValue` is still not applied to `remote_addrs`
+   (unchanged); an IP/dotted-hostname has no control chars and the
+   predicate rejects anything that is neither.
 
 ## Risk assessment
 
 | Class | Level | Notes |
 |-------|-------|-------|
-| Behavioral regression | LOW | Cases 1-3 bit-identical; only 4/5 change, and they were already broken. Test-only `generateConfig` callers. |
-| Lifetime / borrow (N/A Go) | — | Go; no borrow checker. |
-| Performance regression | NONE | Cold config-apply path only. |
-| Architectural mismatch | LOW-MED | Risk is the hostname predicate rule (A vs B) and the resolve-vs-fail-commit axis. Surfaced as open questions; PLAN-KILL acceptable if reviewers want a commit-time validator instead. |
+| Behavioral regression | LOW | Cases 1-3,7,8 bit-identical; only the already-broken leak cases (4/5/6) change. generateConfig now returns MORE (healthy config) not less. |
+| Import cycle | LOW | Predicate lives in `pkg/config` (exported), called from `pkg/ipsec` (ipsec→config is the existing allowed direction). Explicitly verified at build. |
+| Cold-boot / first-apply | RESOLVED | Skip-and-continue means a bad VPN never zeroes healthy tunnels — the R1 defect is fixed. |
+| Performance regression | NONE | Cold config-apply / commit path only. |
+| Architectural mismatch | LOW | Commit-validator is the right altitude (loud at `commit`); render guard is defense-in-depth. |
 
 ## Test plan (control-plane — NO dataplane smoke)
 
-This is a swanctl-render change with no dataplane/forwarding impact, so
-the triple-review smoke matrix (iperf3 / CoS / failover) does NOT
-apply. Coverage is a focused, NON-TAUTOLOGICAL `pkg/ipsec` unit test
-that FAILS against pre-fix code:
+A swanctl-render + config-compile change with no dataplane/forwarding
+impact, so the iperf3 / CoS / failover smoke matrix does NOT apply.
+Coverage is focused, NON-TAUTOLOGICAL unit tests that FAIL pre-fix:
 
-1. `go build ./...` clean.
-2. New `TestRenderConfig_GatewayNameNeverLeaks`:
-   - Sub-case resolved gw with Address → `remote_addrs = <IP>`, and
-     assert the rendered output does NOT contain the gateway object
-     name on a `remote_addrs` line.
-   - Sub-case dangling/typo gateway name (no map entry, not an IP/host)
-     → `renderConfig` returns a non-nil error AND (defensively) the
-     returned string does not contain `remote_addrs = <name>`.
-   - Sub-case gateway exists but addressless → non-nil error, no leak.
-   - Sub-case legacy inline literal IP (case 3) → no error,
-     `remote_addrs = <IP>` (guards against over-rejection).
-   - Sub-case empty gateway → no error, no `remote_addrs` line.
-   - Pre-fix proof: the dangling-name sub-case asserts the error; on
-     unpatched code `renderConfig` returns nil error + a leaked name,
-     so the test fails pre-fix (non-tautological).
-3. Full `go test ./pkg/ipsec/...` green (existing 25+ render tests must
-   still pass — proves cases 1-3 preserved).
-4. `go test ./...` (or at least `./pkg/ipsec/... ./pkg/config/...`)
-   green.
+1. `go build ./...` clean (verifies no import cycle).
+2. `pkg/ipsec` render tests — new `TestRenderConfig_GatewayNameNeverLeaks`:
+   - resolved gw with Address → `remote_addrs = <IP>`, and assert the
+     output does NOT contain the gateway object name on a `remote_addrs`
+     line.
+   - dangling/typo name (no map entry, not IP/host) → `renderConfig`
+     returns non-nil error AND the returned string contains NO
+     `remote_addrs = <name>` line. Fixture uses benign PSK auth (no
+     bogus auth-method) so `resolveIKESettings`/`normalizePSK` cannot
+     error first — guarantees the assertion targets the leak path, not a
+     pre-existing error (R4).
+   - addressless gw (exists, no Address/DynamicHostname) → non-nil
+     error, no leak.
+   - dotless single-label name (case 6) → non-nil error, no leak.
+   - legacy inline literal IP (case 3) → no error, `remote_addrs = <IP>`
+     (over-rejection guard).
+   - dotted inline hostname (case 3 FQDN) → no error,
+     `remote_addrs = peer.example.com`.
+   - empty gateway → no error, no `remote_addrs` line, connection still
+     emitted.
+   - **multi-VPN skip-and-continue (R1 regression guard):** one healthy
+     VPN + one dangling VPN → assert the HEALTHY VPN's `remote_addrs`
+     IS present in the output AND a non-nil error is returned AND the
+     dangling name does NOT appear in `remote_addrs`. On unpatched code
+     v1-style would have aborted the whole file → this proves the
+     skip-and-continue behavior.
+   - Pre-fix proof: every error-asserting sub-case fails on unpatched
+     code (which returns nil error + leaked name).
+3. `pkg/config` compile tests — new `TestCompileIPsec_DanglingGatewayRejected`:
+   - VPN referencing an undefined gateway name → `Compile`/`compileIPsec`
+     returns a non-nil error (commit fails). Fails pre-fix.
+   - VPN referencing a gateway object with no address → error.
+   - VPN with inline literal IP gateway (no object) → NO error (case 3;
+     mirrors `parser_security_test.go` `vpn site-a gateway 10.1.0.1`).
+   - VPN referencing a defined gateway with an address → NO error.
+4. Full `go test ./pkg/ipsec/... ./pkg/config/...` green (existing 25+
+   render tests + all parser/compiler tests must still pass — proves
+   cases 1-3,7,8 preserved and no committed-config regression).
+5. `go test ./...` green (or the affected packages + their importers).
+
+## Documentation deliverable (project docs-contract)
+
+`pkg/ipsec/README.md` updated (concrete, not a passing mention):
+- The **never-leak invariant**: a gateway config-object NAME never
+  reaches `remote_addrs`.
+- The **commit-time rejection**: a VPN referencing an undefined or
+  addressless gateway now fails `commit`/`commit check`.
+- The **Rule-A single-label-inline-hostname limitation** + migration
+  (`set security ike gateway <name> address <ip>` or `dynamic hostname
+  <fqdn>`).
+- The **render-side keep-healthy/skip-bad** behavior for paths that
+  bypass commit (HA sync / direct construction).
 
 ## Out of scope (explicitly)
 
-- Commit-time / schema cross-reference validation of IPsec gateway
-  references (would belong in `pkg/config/schema_walk.go` /
-  `compiler_ipsec.go`). Tracked as a possible follow-up; the issue
-  notes this layer is absent and does not require adding it here.
-- Validating `gw.Address` / `gw.DynamicHostname` *content* (we trust
+- Validating `gw.Address` / `gw.DynamicHostname` *content* (trusted to
   the existing parser/schema for those leaves).
-- Any change to the inline-literal-IP gateway shape beyond the
-  guard.
+- Schema-layer (`schema_walk.go`) validation — the commit gate lives in
+  the compiler (`compileIPsec`), which is sufficient and is where the
+  cross-reference data is already assembled.
+- Any change to the inline-literal-IP gateway shape beyond the guard.
+- Responder-only / `%any` peer support (no such concept exists today;
+  the case-5 branch carries a comment to revisit if it is added).
 
-## Open questions for adversarial review
+## Open questions for adversarial review (v2)
 
-1. **Hostname predicate Rule A vs Rule B** — is requiring a `.` for an
-   inline hostname (Rule A) too aggressive? Does any real config use a
-   bare single-label inline hostname as a VPN peer? If so Rule A breaks
-   it. Defend or kill.
-2. **Resolve-vs-fail-commit** — is returning a render error (warned,
-   not commit-blocking) sufficient, or must this be a commit-time
-   validator? The issue allows either; is the chosen in-scope path the
-   right altitude?
-3. **`generateConfig` now returns `""`** for cases 4/5. Confirm there is
-   truly no non-test caller (I grepped; double-check) and that an empty
-   string from `generateConfig` can never reach a production write path.
-4. **Addressless-but-DPD/identity-only gateway (case 5)** — is there any
-   legitimate strongSwan config where a connection has NO `remote_addrs`
-   but the gateway object still carries IKE settings (e.g. responder-
-   only / `%any` peer)? If yes, erroring on case 5 is wrong and we
-   should instead emit no `remote_addrs` line (silent, but valid for a
-   responder). This is the highest-risk question.
-5. **Stale-config-on-error semantics** — on cases 4/5 the apply now
-   skips the atomic write and leaves the prior swanctl config. Is
-   "keep last good config + warn" the right failure mode, or should a
-   broken VPN tear down ALL VPNs? (I argue keep-last-good is correct —
-   one typo'd VPN shouldn't drop healthy tunnels.)
-6. **Does `vpn.Gateway` ever legitimately hold a `%any`-style wildcard**
-   that strongSwan accepts but `net.ParseIP`/hostname rejects? If so,
-   Rule A/B both wrongly error. Check the parser.
+1. **Predicate location / import cycle** — defining
+   `config.IsUsableIPsecEndpoint` and calling it from `pkg/ipsec` keeps
+   one SSOT and respects ipsec→config. Confirm no cycle and that this is
+   the cleanest placement (vs duplicating the 2-line predicate).
+2. **Commit-validator placement** — end of `compileIPsec` (after the VPN
+   loop). Confirm both `ike{gateway}` and `ipsec{gateway}` sections are
+   fully populated at that point (compileIKE runs before compileIPsec per
+   `compiler_security.go:39-44`; both write `sec.IPsec.Gateways`). Any
+   ordering hazard?
+3. **Does committing the validator break ANY existing test config?**
+   Reviewers should independently grep `parser_*_test.go` /
+   `compiler_*_test.go` for VPN gateway references and confirm all
+   resolve to a defined gateway or an inline IP (I found
+   `10.1.0.1`/`10.2.0.1`/`remote-gw` — all pass).
+4. **Skip-and-continue secrets** — when a VPN is skipped in the
+   connections loop, its `secrets{}` entry should also be skipped.
+   Confirm the secrets loop is gated by the same skip set (the plan skips
+   it). Any case where a secret is still needed for a skipped conn? (No
+   — no connection, no SA.)
+5. **`errors.Join` import + nil semantics** — `errors.Join()` with no
+   args / all-nil returns nil. Confirm the no-error path is byte-identical
+   (existing tests using `generateConfig`/`renderConfig` see nil error).
+6. **Is rejecting case 5 at commit ever wrong?** Confirmed no
+   responder-only/`%any` concept exists in the parser today; the branch
+   is commented to revisit. Reviewers: re-verify by grep.

--- a/docs/pr/2074-remote-addrs-name-leak/plan.md
+++ b/docs/pr/2074-remote-addrs-name-leak/plan.md
@@ -1,0 +1,309 @@
+# #2074 — renderConfig leaks the gateway NAME into swanctl remote_addrs
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+In `pkg/ipsec/policy.go` `renderConfig` (line 38), `remoteAddr` is
+seeded from `vpn.Gateway` — the gateway *reference*. It is only
+overwritten when the referenced gateway object exists in
+`ipsecCfg.Gateways` AND that object carries a non-empty `Address`
+(line 43) or `DynamicHostname` (line 45). When a VPN names a gateway
+that
+
+  (a) does not exist in `ipsecCfg.Gateways` (typo in
+      `vpn ... ike gateway <name>`), or
+  (b) exists but was committed with neither `address` nor
+      `dynamic hostname`,
+
+`remoteAddr` stays equal to the raw gateway-reference string and lines
+73-75 emit `remote_addrs = <gateway-name>`. strongSwan then tries to
+DNS-resolve a config-object name, the IKE SA never establishes, and the
+operator gets no diagnostic — there is no IPsec cross-reference check at
+commit time (`compiler_ipsec.go` returns no errors;
+`schema_validators.go` has no gateway-reference validator). The tunnel
+is silently dead.
+
+## Honest scope / value framing
+
+This is a correctness fix for a misconfiguration footgun, not a perf
+change. The win: an operator who fat-fingers a gateway name (or omits
+the gateway address) gets a loud apply-time error in the journal /
+CLI stderr instead of a tunnel that comes up "configured" but never
+passes traffic. Blast radius is one function (`renderConfig`) plus a
+focused unit test. If reviewers conclude the change is wrong-shaped
+(e.g. it should be a commit-time validator instead), PLAN-KILL /
+PLAN-NEEDS-MAJOR is an acceptable verdict.
+
+## Critical compatibility constraint (the legacy inline-gateway shape)
+
+The existing tests (`ipsec_test.go` TestGenerateConfig_Basic line 14,
+TestGenerateConfig_TrafficSelectors line 856, many others) set
+`Gateway: "10.0.2.1"` — a **literal IP used directly as the gateway
+field**, with NO entry in `ipsecCfg.Gateways`. Today that flows through
+line 38 unchanged and correctly emits `remote_addrs = 10.0.2.1`. This
+is a supported shape and MUST keep working. Likewise a literal hostname
+(`Gateway: "peer.example.com"`) used inline is legitimate.
+
+Therefore the fix must NOT blanket-reject "no Gateways-map entry". It
+must distinguish:
+
+| Case | `Gateways[vpn.Gateway]` | `vpn.Gateway` literal? | Today | Desired |
+|------|------------------------|------------------------|-------|---------|
+| 1. resolved gw, has Address | found, Address!="" | n/a | `remote_addrs=Address` | unchanged |
+| 2. resolved gw, has DynamicHostname | found, DynHost!="" | n/a | `remote_addrs=DynHost` | unchanged |
+| 3. inline literal IP/host | not found | yes (parses as IP or DNS-name) | `remote_addrs=<literal>` | unchanged |
+| 4. dangling/typo name | not found | NO (not an IP, not a hostname) | `remote_addrs=<NAME>` (BUG) | error, no leak |
+| 5. gw exists, addressless | found, both empty | NO | `remote_addrs=<NAME>` (BUG) | error, no leak |
+
+Cases 4 and 5 are the bug. Cases 1-3 are preserved bit-for-bit.
+
+## Why resolve-or-error (NOT fail-commit)
+
+`renderConfig` already returns `error`. Its only real consumer is
+`Manager.Apply` (`manager.go:67`), reached from:
+
+- `pkg/daemon/daemon_apply.go:1054` — `slog.Warn("failed to apply IPsec
+  config", ...)` (post-commit runtime apply).
+- `pkg/cli/apply.go:161` — `fmt.Fprintf(os.Stderr, "warning: IPsec
+  apply failed: %v\n", ...)`.
+
+Both are POST-commit apply paths that only warn; neither aborts the
+commit. There is no IPsec rendering on the commit/compile path. So:
+
+- Returning an error from `renderConfig` for cases 4/5 turns the silent
+  dead tunnel into a **visible apply-time warning** with the offending
+  VPN + gateway named. That is a strict improvement and stays inside the
+  issue's `pkg/ipsec/policy.go` target.
+- True **fail-commit** would require a NEW cross-reference validator in
+  `pkg/config` (schema_walk / compiler_ipsec) — a different file, a
+  larger blast radius, and explicitly noted by the issue as absent
+  today. That is deferred (see Out of scope) and could be a follow-up
+  issue. The issue text permits "omit/skip with a clear error OR fail
+  commit" — we choose the in-scope, already-plumbed error path.
+
+The key invariant the issue demands either way: **a gateway NAME must
+never be rendered into `remote_addrs`.** This plan guarantees that by
+construction — the only strings that can reach `remote_addrs` are a
+resolved gateway Address/DynamicHostname or a `vpn.Gateway` value that
+is itself a syntactically valid IP or hostname.
+
+## Concrete design
+
+Replace the resolution block (current lines 37-51) with an explicit
+resolver that yields either a usable remote address or an error.
+
+```go
+// Resolve the remote gateway endpoint. remote_addrs must be a real
+// IP / hostname that strongSwan can use — never a bare gateway
+// config-object name (#2074). A name that leaks here produces a
+// silently-dead tunnel (strongSwan DNS-resolves the object name and
+// the IKE SA never comes up).
+localAddr := vpn.LocalAddr
+var gw *config.IPsecGateway
+remoteAddr := ""
+if g, ok := ipsecCfg.Gateways[vpn.Gateway]; ok {
+    gw = g
+    switch {
+    case gw.Address != "":
+        remoteAddr = gw.Address
+    case gw.DynamicHostname != "":
+        remoteAddr = gw.DynamicHostname
+    default:
+        // Case 5: the gateway exists but has neither an address nor a
+        // dynamic hostname. We have nothing routable to hand
+        // strongSwan; do NOT fall back to the object name.
+        return "", fmt.Errorf(
+            "vpn %s: ike gateway %q has no address or dynamic-hostname; "+
+                "cannot render remote_addrs", name, vpn.Gateway)
+    }
+    if gw.LocalAddress != "" && localAddr == "" {
+        localAddr = gw.LocalAddress
+    }
+} else if isUsableRemoteEndpoint(vpn.Gateway) {
+    // Case 3: legacy inline shape — the VPN names the peer endpoint
+    // directly as a literal IP or hostname, with no Gateways entry.
+    remoteAddr = vpn.Gateway
+} else if vpn.Gateway != "" {
+    // Case 4: dangling reference — a non-empty gateway value that is
+    // neither a known gateway object nor a usable IP/hostname. Emitting
+    // it as remote_addrs would leak the name.
+    return "", fmt.Errorf(
+        "vpn %s: ike gateway %q is not defined and is not a valid "+
+            "address or hostname", name, vpn.Gateway)
+}
+// vpn.Gateway == "" with no map entry => remoteAddr stays "" and the
+// existing `if remoteAddr != ""` guard at the emit site skips the line
+// (unchanged behavior — some configs legitimately omit remote_addrs).
+```
+
+`isUsableRemoteEndpoint` — a small, local, allocation-light predicate:
+
+```go
+// isUsableRemoteEndpoint reports whether s is something strongSwan can
+// place in remote_addrs directly: a literal IP address, or a plausible
+// DNS hostname / FQDN. It deliberately REJECTS bare config-object
+// names that contain none of the structure of a hostname (so a typo'd
+// gateway reference is caught rather than DNS-probed forever). It is
+// intentionally conservative on the accept side for IPs and permissive
+// for hostnames, because a real hostname is operator-supplied and we
+// must not break legitimate inline FQDN gateways.
+func isUsableRemoteEndpoint(s string) bool {
+    if s == "" {
+        return false
+    }
+    if net.ParseIP(s) != nil {
+        return true
+    }
+    return isPlausibleHostname(s)
+}
+```
+
+The hostname predicate is the one design lever the reviewers should
+attack hardest. Junos gateway object names and Junos hostnames overlap
+in character set (both allow letters, digits, hyphens). A name like
+`gw-to-hq` is a *valid Junos object name* AND a *syntactically valid
+single-label hostname*. We cannot perfectly disambiguate by syntax
+alone. Two candidate rules (decide in review):
+
+- **Rule A (require a dot / FQDN-ish):** accept as a hostname only if
+  it contains a `.` (so `peer.example.com` passes, `gw-to-hq` is
+  rejected as a likely object-name typo). Pro: catches the common
+  single-label typo. Con: rejects a legitimate inline single-label
+  hostname (rare — operators almost always use an FQDN or IP for a VPN
+  peer, and the single-label case has a clean migration: define a
+  proper `gateway` with `address`/`dynamic hostname`).
+- **Rule B (RFC-952/1123 label validity):** accept any string that is a
+  syntactically valid hostname (each label 1-63 chars, alnum +
+  internal hyphen, total ≤253). This accepts `gw-to-hq` — which means a
+  typo'd object name that *happens* to be hostname-shaped still leaks
+  (as a hostname, not an object name, but still a dead tunnel). It only
+  catches names with illegal hostname chars (`/`, space, `_` if we
+  forbid underscore, etc.).
+
+**Plan recommendation: Rule A.** It is the only rule that actually
+catches case (a) from the issue — a typo'd single-label gateway name —
+while still passing every realistic inline gateway (IP or FQDN). The
+existing tests all use literal IPs for the inline shape, so Rule A
+breaks none of them. We document the single-label-hostname limitation
+in the IPsec README and the error message guides the operator to the
+fix (`set security ike gateway <name> address <ip>`).
+
+This is an explicit OPEN QUESTION for reviewers — if both reviewers
+prefer Rule B (or a fail-commit redesign), the plan changes.
+
+## Public API preservation
+
+- `renderConfig(*config.IPsecConfig) (string, error)` — signature
+  unchanged.
+- `generateConfig(*config.IPsecConfig) string` — signature unchanged.
+  It already discards the error (`cfg, _ := m.renderConfig(...)`).
+  IMPORTANT: on the new error paths `renderConfig` returns
+  `("", err)`, so `generateConfig` now returns `""` for cases 4/5
+  where it previously returned a (broken) config string. Callers of
+  `generateConfig` are TEST-ONLY (`ipsec_test.go`) — no production
+  caller. Verified by grep. Tests that exercise the legacy inline IP
+  shape are unaffected (case 3).
+- `Manager.Apply` behavior unchanged for valid configs; for cases 4/5
+  it now returns the new error (previously wrote a broken file and
+  reloaded). Both Apply call sites already handle a non-nil error
+  (warn). This means: on a dangling/addressless gateway, the apply now
+  leaves the PREVIOUS swanctl config in place (the atomic write is
+  skipped because `renderConfig` errored before the write) rather than
+  overwriting it with a config that names a dead peer. Strict
+  improvement.
+
+## Hidden invariants the change must preserve
+
+1. **`gw` is consumed downstream** (lines 52, 57, 60-64, 78-91,
+   103-116). For case 3 (inline literal) and case 4, `gw` stays `nil`
+   exactly as today. For cases 1/2/5 `gw` is set as today. The early
+   `return` on case 5 happens AFTER `gw` is set but that's fine — we
+   never reach the downstream uses.
+2. **`localAddr` fallback from `gw.LocalAddress`** (current line 48-50)
+   only happens in the resolved-gateway branch — preserved.
+3. **Empty-gateway VPNs** (`vpn.Gateway == ""`, no map entry) must
+   still render with NO `remote_addrs` line, not an error. Handled: the
+   final `else if vpn.Gateway != ""` guards the error so empty stays
+   `remoteAddr == ""` → existing emit guard skips the line.
+4. **No new allocations on the hot path** — render runs only on config
+   apply (cold path), so this is not perf-sensitive, but the predicate
+   is still allocation-light (no regexp; manual byte scan).
+5. **sanitizeSwanctlValue is NOT applied to remote_addrs today** and we
+   do not change that — an IP/hostname has no control chars; the
+   predicate already rejects anything pathological.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Cases 1-3 bit-identical; only 4/5 change, and they were already broken. Test-only `generateConfig` callers. |
+| Lifetime / borrow (N/A Go) | — | Go; no borrow checker. |
+| Performance regression | NONE | Cold config-apply path only. |
+| Architectural mismatch | LOW-MED | Risk is the hostname predicate rule (A vs B) and the resolve-vs-fail-commit axis. Surfaced as open questions; PLAN-KILL acceptable if reviewers want a commit-time validator instead. |
+
+## Test plan (control-plane — NO dataplane smoke)
+
+This is a swanctl-render change with no dataplane/forwarding impact, so
+the triple-review smoke matrix (iperf3 / CoS / failover) does NOT
+apply. Coverage is a focused, NON-TAUTOLOGICAL `pkg/ipsec` unit test
+that FAILS against pre-fix code:
+
+1. `go build ./...` clean.
+2. New `TestRenderConfig_GatewayNameNeverLeaks`:
+   - Sub-case resolved gw with Address → `remote_addrs = <IP>`, and
+     assert the rendered output does NOT contain the gateway object
+     name on a `remote_addrs` line.
+   - Sub-case dangling/typo gateway name (no map entry, not an IP/host)
+     → `renderConfig` returns a non-nil error AND (defensively) the
+     returned string does not contain `remote_addrs = <name>`.
+   - Sub-case gateway exists but addressless → non-nil error, no leak.
+   - Sub-case legacy inline literal IP (case 3) → no error,
+     `remote_addrs = <IP>` (guards against over-rejection).
+   - Sub-case empty gateway → no error, no `remote_addrs` line.
+   - Pre-fix proof: the dangling-name sub-case asserts the error; on
+     unpatched code `renderConfig` returns nil error + a leaked name,
+     so the test fails pre-fix (non-tautological).
+3. Full `go test ./pkg/ipsec/...` green (existing 25+ render tests must
+   still pass — proves cases 1-3 preserved).
+4. `go test ./...` (or at least `./pkg/ipsec/... ./pkg/config/...`)
+   green.
+
+## Out of scope (explicitly)
+
+- Commit-time / schema cross-reference validation of IPsec gateway
+  references (would belong in `pkg/config/schema_walk.go` /
+  `compiler_ipsec.go`). Tracked as a possible follow-up; the issue
+  notes this layer is absent and does not require adding it here.
+- Validating `gw.Address` / `gw.DynamicHostname` *content* (we trust
+  the existing parser/schema for those leaves).
+- Any change to the inline-literal-IP gateway shape beyond the
+  guard.
+
+## Open questions for adversarial review
+
+1. **Hostname predicate Rule A vs Rule B** — is requiring a `.` for an
+   inline hostname (Rule A) too aggressive? Does any real config use a
+   bare single-label inline hostname as a VPN peer? If so Rule A breaks
+   it. Defend or kill.
+2. **Resolve-vs-fail-commit** — is returning a render error (warned,
+   not commit-blocking) sufficient, or must this be a commit-time
+   validator? The issue allows either; is the chosen in-scope path the
+   right altitude?
+3. **`generateConfig` now returns `""`** for cases 4/5. Confirm there is
+   truly no non-test caller (I grepped; double-check) and that an empty
+   string from `generateConfig` can never reach a production write path.
+4. **Addressless-but-DPD/identity-only gateway (case 5)** — is there any
+   legitimate strongSwan config where a connection has NO `remote_addrs`
+   but the gateway object still carries IKE settings (e.g. responder-
+   only / `%any` peer)? If yes, erroring on case 5 is wrong and we
+   should instead emit no `remote_addrs` line (silent, but valid for a
+   responder). This is the highest-risk question.
+5. **Stale-config-on-error semantics** — on cases 4/5 the apply now
+   skips the atomic write and leaves the prior swanctl config. Is
+   "keep last good config + warn" the right failure mode, or should a
+   broken VPN tear down ALL VPNs? (I argue keep-last-good is correct —
+   one typo'd VPN shouldn't drop healthy tunnels.)
+6. **Does `vpn.Gateway` ever legitimately hold a `%any`-style wildcard**
+   that strongSwan accepts but `net.ParseIP`/hostname rejects? If so,
+   Rule A/B both wrongly error. Check the parser.

--- a/docs/pr/2074-remote-addrs-name-leak/plan.md
+++ b/docs/pr/2074-remote-addrs-name-leak/plan.md
@@ -1,11 +1,57 @@
 # #2074 — renderConfig leaks the gateway NAME into swanctl remote_addrs
 
-**Status:** DRAFT v2 — addresses round-1 hostile review (reviewer A
-PLAN-NEEDS-MINOR, reviewer B PLAN-NEEDS-MAJOR). Both converged on the
-whole-render-abort blast-radius defect; B escalated on altitude
-(warn-only does not make `commit` fail). v2 adopts a **two-layer fix**:
-a commit-time cross-reference validator (primary, loud at `commit`) plus
-a **skip-and-continue** render-side belt (never zeroes healthy tunnels).
+**Status:** DRAFT v3 — addresses round-2 hostile review (both reviewers
+PLAN-NEEDS-MAJOR). Round-2 found two source-confirmed blocking defects in
+v2: (1) `Manager.Apply` bails on a render error BEFORE the write, so v2's
+"return (healthyConfig, joinedErr)" discards the healthy config and the
+skip-and-continue belt is inert; (2) v2 placed the commit validator
+inside `compileIPsec` with a hard `return`, which (a) depends on
+`ike`-before-`ipsec` stanza order (false — `compileSecurity` iterates in
+document order) and (b) runs on the LENIENT load/peer-sync path too,
+breaking boot of a pre-fix/peer-synced dangling-gateway config
+(fail-closed-on-load, the #1960 regression class).
+
+v3's corrected two-layer design:
+- **Layer 1** is a strict-accumulator validator
+  `validateIPsecGatewayReferencesStrict(cfg)` operating on the
+  FULLY-COMPILED `*Config` (both `ike{}` and `ipsec{}` gateways
+  populated, stanza-order-independent), with a `lenientIPsecGatewayRefs`
+  downgrade — EXACTLY the `validateDeviceMapStrict` (#1956) /
+  `validatePolicyMatchAddressesStrict` (#2008) template. Strict on
+  commit/commit-check; warns on load/peer-sync.
+- **Layer 2** is the MINIMAL render belt (reviewer B point 5): on a leak
+  case `renderConfig` **skips that VPN's connection block, `slog.Warn`s,
+  and continues** — it does NOT add a new error return, so the unchanged
+  `Apply` writes the healthy config. No `Apply` rewrite, no `errors.Join`,
+  no skip-set-for-error needed. By construction a bare NAME never reaches
+  `remote_addrs`, and healthy tunnels are never zeroed.
+
+## Round-2 review resolution (what changed in v3)
+
+- **R2-1 (both, blocking): Apply discards healthy config on render
+  error.** `manager.go:67-70` does `if err != nil { return err }` before
+  `WriteFileAtomic`. v3 sidesteps this entirely: the render belt no
+  longer RETURNS an error for the gateway-leak cases — it skips the bad
+  VPN, `slog.Warn`s, and continues. `renderConfig`'s error return is
+  reserved for its existing reasons (auth method, PSK decode) only. So
+  `Apply` is UNCHANGED, always writes the healthy config, and never
+  zeroes healthy tunnels. (We considered "write-then-warn in Apply" but
+  the skip-and-log render belt is simpler and needs no signature/Apply
+  churn.)
+- **R2-2 (both, blocking): Layer-1 ordering + lenient-path break.** v3
+  moves the validator OUT of `compileIPsec` to a strict-accumulator-style
+  pass on the fully-compiled `*Config` (after `compileSecurity`
+  returns, where `cfg.Security.IPsec.Gateways` holds BOTH `ike{}` and
+  `ipsec{}` gateways regardless of authoring order), and gates it with
+  `opts.lenientIPsecGatewayRefs` so the lenient load/peer-sync paths
+  (`CompileConfigLenient`, `CompileConfigForNodeLenient`) WARN instead of
+  failing to boot. Mirrors `validateDeviceMapStrict` (#1956) exactly.
+- **R2-3: secrets-loop skip** — with the minimal belt, the connections
+  loop builds a `skipped map[string]bool`; the secrets loop consults it
+  so a skipped connection emits no orphan secret. Concrete, not prose.
+- **R2-4: errors import** — no longer needed (no `errors.Join` in the
+  minimal belt). Dropped.
+- **R2-5: Layer-2 complexity** — adopted reviewer B's minimal belt.
 
 ## Round-1 review resolution (what changed in v2)
 
@@ -180,19 +226,28 @@ specifically about the gateway-NAME leak, which is exactly the bug.
 
 ## Concrete design
 
-### Layer 2 — render (`pkg/ipsec/policy.go`), skip-and-continue
+### Layer 2 — render belt (`pkg/ipsec/policy.go`), minimal skip-and-log
 
-A shared resolver returns either a usable remote address or an error.
-The per-VPN loop, on a resolver error, records the error, `continue`s
-(skips that connection block), and renders the rest. After the loop,
-`renderConfig` returns the rendered config and the joined error.
+A resolver classifies the gateway. On a leak case (4/5/6) it returns
+`ok=false`; the connections loop SKIPS that VPN, records it in a
+`skipped` set, `slog.Warn`s, and continues. `renderConfig` returns NO
+new error (its existing error return — auth method, PSK decode — is
+untouched), so the unchanged `Apply` writes the healthy config.
 
 ```go
-func resolveRemoteAddr(ipsecCfg *config.IPsecConfig, vpn *config.IPsecVPN,
-    name string) (remoteAddr, localAddr string, gw *config.IPsecGateway, err error) {
+// resolveRemoteAddr returns the swanctl remote_addrs value (a real
+// IP / dotted hostname) for a VPN, plus the resolved local addr and
+// gateway. ok=false means there is nothing usable to render — the
+// caller MUST skip the connection so a bare gateway config-object NAME
+// never leaks into remote_addrs (#2074). The hard diagnostic is the
+// commit-time validator (Layer 1); this is the by-construction belt for
+// any path that reaches render without passing local commit (HA sync /
+// direct construction / a config committed before this fix).
+func resolveRemoteAddr(ipsecCfg *config.IPsecConfig, vpn *config.IPsecVPN) (
+    remoteAddr, localAddr string, gw *config.IPsecGateway, ok bool) {
 
     localAddr = vpn.LocalAddr
-    if g, ok := ipsecCfg.Gateways[vpn.Gateway]; ok {
+    if g, found := ipsecCfg.Gateways[vpn.Gateway]; found {
         gw = g
         switch {
         case gw.Address != "":
@@ -200,85 +255,84 @@ func resolveRemoteAddr(ipsecCfg *config.IPsecConfig, vpn *config.IPsecVPN,
         case gw.DynamicHostname != "":
             remoteAddr = gw.DynamicHostname
         default:
-            // Case 5: gateway exists but has neither an address nor a
-            // dynamic hostname — nothing routable. Do NOT fall back to
-            // the object name. (Forecloses a future responder-only /
-            // %any peer that legitimately omits remote_addrs; revisit
-            // this branch if/when that is added — no such concept
-            // exists in the parser today.)
-            return "", localAddr, gw, fmt.Errorf(
-                "ike gateway %q has no address or dynamic-hostname",
-                vpn.Gateway)
+            // Case 5: gateway exists but addressless. (Forecloses a
+            // future responder-only / %any peer that legitimately omits
+            // remote_addrs; no such concept in the parser today —
+            // revisit if added.)
+            return "", localAddr, gw, false
         }
         if gw.LocalAddress != "" && localAddr == "" {
             localAddr = gw.LocalAddress
         }
-        return remoteAddr, localAddr, gw, nil
+        return remoteAddr, localAddr, gw, true
     }
-    if isUsableRemoteEndpoint(vpn.Gateway) {
-        // Case 3: legacy inline shape — peer endpoint named directly as
-        // a literal IP or (dotted) hostname, no Gateways entry.
-        return vpn.Gateway, localAddr, nil, nil
+    if config.IsUsableIPsecEndpoint(vpn.Gateway) {
+        return vpn.Gateway, localAddr, nil, true // Case 3: inline IP/FQDN
     }
-    if vpn.Gateway != "" {
-        // Case 4/6: dangling reference / dotless single-label name that
-        // is neither a known gateway nor a usable IP/hostname. Emitting
-        // it as remote_addrs would leak the name.
-        return "", localAddr, nil, fmt.Errorf(
-            "ike gateway %q is not defined and is not a valid address "+
-                "or hostname", vpn.Gateway)
+    if vpn.Gateway == "" {
+        // Empty gateway: emit the connection with NO remote_addrs line
+        // (unchanged behavior — some configs legitimately omit it).
+        return "", localAddr, nil, true
     }
-    // vpn.Gateway == "" with no map entry => remoteAddr "" => the
-    // existing `if remoteAddr != ""` emit guard skips the line.
-    return "", localAddr, nil, nil
+    // Case 4/6: dangling / dotless name — not renderable.
+    return "", localAddr, nil, false
 }
 ```
 
-Loop integration (replacing current lines 37-51), skip-and-continue:
+Connections loop (replacing current lines 33-51 head):
 
 ```go
-var renderErrs []error
+skipped := make(map[string]bool)
 for _, name := range sortedVPNNames(ipsecCfg.VPNs) {
     vpn := ipsecCfg.VPNs[name]
-    remoteAddr, localAddr, gw, rerr := resolveRemoteAddr(ipsecCfg, vpn, name)
-    if rerr != nil {
-        // Skip ONLY this VPN's connection block; keep rendering the
-        // rest so one typo never zeroes healthy tunnels (#2074 R1).
-        renderErrs = append(renderErrs, fmt.Errorf("vpn %s: %w", name, rerr))
+    remoteAddr, localAddr, gw, ok := resolveRemoteAddr(ipsecCfg, vpn)
+    if !ok {
+        skipped[name] = true
+        slog.Warn("skipping IPsec VPN: gateway not renderable "+
+            "(undefined or addressless) — fix the ike gateway reference",
+            "vpn", name, "gateway", vpn.Gateway)
         continue
     }
     fmt.Fprintf(&b, "  %s {\n", sanitizeSwanctlValue(name))
     ... // unchanged emit body, using remoteAddr/localAddr/gw
 }
-...
-// after building secrets:
-return b.String(), errors.Join(renderErrs...)
 ```
 
-`errors.Join(nil...)` is `nil`, so the no-error path is unchanged.
-The secrets loop also skips a VPN whose render errored (it would be
-harmless to emit secrets for a skipped connection, but skipping keeps
-the output minimal and avoids a dangling `ike-<name>` secret).
-
-`isUsableRemoteEndpoint` — a small, local, allocation-light predicate:
+Secrets loop consults `skipped` (real code is a separate loop):
 
 ```go
-// isUsableRemoteEndpoint reports whether s is something strongSwan can
+for _, name := range sortedVPNNames(ipsecCfg.VPNs) {
+    if skipped[name] {
+        continue // no connection => no orphan ike-<name> secret
+    }
+    ... // unchanged secret emission
+}
+```
+
+`renderConfig`'s signature and existing error returns are UNCHANGED;
+no `errors.Join`, no new error path, no `Apply` change. The no-skip path
+is byte-identical to today (empty `skipped`, every `ok==true`).
+
+`IsUsableIPsecEndpoint` — exported from `pkg/config` (so the SAME
+predicate backs Layer 1 and Layer 2 with no import cycle), a small
+allocation-light predicate:
+
+```go
+// IsUsableIPsecEndpoint reports whether s is something strongSwan can
 // place in remote_addrs directly: a literal IP address, or a plausible
-// DNS hostname / FQDN. It deliberately REJECTS bare config-object
-// names that contain none of the structure of a hostname (so a typo'd
-// gateway reference is caught rather than DNS-probed forever). It is
-// intentionally conservative on the accept side for IPs and permissive
-// for hostnames, because a real hostname is operator-supplied and we
-// must not break legitimate inline FQDN gateways.
-func isUsableRemoteEndpoint(s string) bool {
+// dotted DNS hostname / FQDN. It deliberately REJECTS bare config-object
+// names with no hostname structure (so a typo'd gateway reference is
+// caught, not DNS-probed forever). Lives in pkg/config so both the
+// commit validator (pkg/config) and the render belt (pkg/ipsec, which
+// imports config) share one SSOT — no import cycle.
+func IsUsableIPsecEndpoint(s string) bool {
     if s == "" {
         return false
     }
     if net.ParseIP(s) != nil {
         return true
     }
-    return isPlausibleHostname(s)
+    return isPlausibleHostname(s) // Rule A: requires a dot
 }
 ```
 
@@ -311,116 +365,140 @@ literal IP for the inline shape, so Rule A breaks none of them. With the
 commit validator (Layer 1) as the hard gate using the SAME predicate,
 the single-label-inline-hostname limitation is a *documented commit-check
 behavior* with a clear migration (`set security ike gateway <name>
-address <ip>`), not a silent render regression. `isPlausibleHostname` is
-a manual byte scan (no regexp): non-empty, contains a `.`, every label
-1-63 alnum + internal hyphen, total ≤253.
+address <ip>`), not a silent render regression. `isPlausibleHostname`
+(unexported, in `pkg/config`) is a manual byte scan (no regexp):
+non-empty, contains a `.`, every label 1-63 alnum + internal hyphen,
+total ≤253.
 
-### Layer 1 — commit validator (`pkg/config/compiler_ipsec.go`)
+### Layer 1 — commit validator (strict-accumulator, `pkg/config`)
 
-At the end of `compileIPsec` (after the VPN loop, current line 378 —
-both `ike{gateway}` and `ipsec{gateway}` sections are populated by then;
-`compileIKE` runs first), add:
+Do NOT place the check inside `compileIPsec` (round-2 R2-2: stanza order
++ lenient-path break). Instead add a validator on the FULLY-COMPILED
+`*Config`, slotted into the existing strict-validator chain in
+`compileConfigWithOpts` / `compileConfigForNodeWithOpts`
+(`compiler.go`), right after `validatePolicyMatchAddressesStrict` /
+`ValidateEventAttributesMatch` — the exact `validateDeviceMapStrict`
+(#1956) / `#2008` template:
 
 ```go
-// #2074: a VPN that references a gateway which is neither a defined
-// gateway object nor a usable inline IP/hostname would render
+// #2074: an IPsec VPN that references a gateway which is neither a
+// defined gateway object nor a usable inline IP/hostname would render
 // `remote_addrs = <gateway-name>` — a config-object name strongSwan
-// can't use, producing a silently-dead tunnel. Reject it at commit so
-// the operator gets a diagnostic instead of a dead tunnel.
-for _, vpn := range sec.IPsec.VPNs {
-    if vpn.Gateway == "" {
-        continue
+// cannot use, a silently-dead tunnel. Strict on commit/commit-check;
+// lenient on load/peer-sync so a pre-fix or peer-synced config that
+// carries such a VPN still BOOTS (warn, don't fail-closed-on-load —
+// #1960 class). Runs on the fully-compiled *Config so both ike{} and
+// ipsec{} gateways are populated regardless of stanza order.
+if err := validateIPsecGatewayReferencesStrict(cfg); err != nil {
+    if opts.lenientIPsecGatewayRefs {
+        cfg.Warnings = append(cfg.Warnings,
+            fmt.Sprintf("ipsec gateway reference (downgraded to warning "+
+                "on tolerant path): %v", err))
+    } else {
+        return nil, err
     }
-    if _, ok := sec.IPsec.Gateways[vpn.Gateway]; ok {
-        continue // resolves to a defined gateway object
-    }
-    if isUsableRemoteEndpoint(vpn.Gateway) {
-        continue // legacy inline literal IP / dotted hostname
-    }
-    return fmt.Errorf("vpn %s: ike gateway %q is not defined and is "+
-        "not a valid address or hostname", vpn.Name, vpn.Gateway)
 }
 ```
 
-The predicate `isUsableRemoteEndpoint` lives in `pkg/ipsec` but the
-validator runs in `pkg/config`, and **`pkg/config` must not import
-`pkg/ipsec`** (ipsec already imports config — an import cycle). So the
-predicate is defined in `pkg/config` (e.g. `isUsableIPsecEndpoint` in
-`compiler_ipsec.go`) and `pkg/ipsec` either re-implements the identical
-two-line predicate locally or calls the exported `config` helper. Plan
-choice: define `config.IsUsableIPsecEndpoint` (exported) once in
-`pkg/config` and have `pkg/ipsec` call it — single source of truth, no
-cycle (ipsec→config is the existing, allowed direction). This is the one
-implementation detail to get right; flagged for review.
+```go
+func validateIPsecGatewayReferencesStrict(cfg *Config) error {
+    ipsec := &cfg.Security.IPsec
+    names := make([]string, 0, len(ipsec.VPNs)) // sort for deterministic error
+    for name := range ipsec.VPNs {
+        names = append(names, name)
+    }
+    sort.Strings(names)
+    for _, name := range names {
+        vpn := ipsec.VPNs[name]
+        if vpn.Gateway == "" {
+            continue // legitimately omitted remote endpoint
+        }
+        if gw, ok := ipsec.Gateways[vpn.Gateway]; ok {
+            if gw.Address == "" && gw.DynamicHostname == "" {
+                return fmt.Errorf("security ipsec vpn %s: ike gateway %q "+
+                    "has no address or dynamic hostname", name, vpn.Gateway)
+            }
+            continue // resolves to a defined, addressed gateway
+        }
+        if IsUsableIPsecEndpoint(vpn.Gateway) {
+            continue // legacy inline literal IP / dotted hostname
+        }
+        return fmt.Errorf("security ipsec vpn %s: ike gateway %q is not "+
+            "defined and is not a valid address or hostname",
+            name, vpn.Gateway)
+    }
+    return nil
+}
+```
 
-Iteration order: the validator iterates a map, so error ORDER is
-non-deterministic across multiple bad VPNs. For a deterministic error
-(stable tests / operator experience), sort VPN names first
-(`sortedVPNNames`-style) and return the first failure. Plan: sort, then
-validate.
-
-Does the addressless-gateway case (case 5) belong in Layer 1 too? Yes:
-extend the validator to also reject a VPN whose referenced gateway
-object exists but has neither `Address` nor `DynamicHostname`. Same
-loop, after the `ok` check: `if gw.Address=="" && gw.DynamicHostname==""
-{ return err }`. This makes BOTH leak cases (4 and 5) un-committable.
+`opts.lenientIPsecGatewayRefs` is added to `compileOpts` and set
+`true` in BOTH `CompileConfigLenient` and `CompileConfigForNodeLenient`
+(alongside `lenientDeviceMap` etc.). Commit / commit-check
+(`CompileConfig` / `CompileConfigForNode`) leave it `false` → hard
+reject. This rejects BOTH leak cases (4 dangling, 5 addressless) at
+commit, and boots a pre-fix/peer-synced config with a warning.
 
 ## Public API preservation
 
-- `renderConfig(*config.IPsecConfig) (string, error)` — signature
-  unchanged. Semantics: now returns the rendered config for the HEALTHY
-  VPNs plus a joined error naming any skipped VPNs (was: a single fatal
-  error aborting the whole file — the R1 defect).
-- `generateConfig(*config.IPsecConfig) string` — signature unchanged.
-  It discards the error. With skip-and-continue it now returns the
-  healthy-VPN config (NOT `""`) even when one VPN is malformed — strictly
-  better than v1's `""`. Callers are TEST-ONLY (`ipsec_test.go`); no
-  production caller. Verified by grep.
-- `Manager.Apply` — for a fully-valid config: unchanged. For a config
-  with one bad VPN reaching render (only possible via a path that
-  bypasses the commit validator, e.g. HA sync / direct construction):
-  it writes the healthy-VPN config AND returns the joined error, which
-  both call sites warn. Healthy tunnels stay up; the bad one is omitted
-  with a logged reason. No cold-boot zero-tunnels regression.
-- New exported `config.IsUsableIPsecEndpoint(string) bool` — additive,
-  no existing symbol changed.
+- `renderConfig(*config.IPsecConfig) (string, error)` — signature AND
+  error semantics UNCHANGED. It returns the rendered config for the
+  HEALTHY VPNs; a leak-case VPN is silently skipped (with a `slog.Warn`),
+  NOT turned into a returned error. The error return remains reserved for
+  its existing causes (auth method, PSK decode). This is the key R2-1
+  fix: because `renderConfig` does not error on the leak case, the
+  unchanged `Apply` writes the healthy config (it never reaches its
+  `if err != nil { return err }` guard for the leak case).
+- `generateConfig(*config.IPsecConfig) string` — unchanged; returns the
+  healthy-VPN config. Callers are TEST-ONLY (`ipsec_test.go`); verified.
+- `Manager.Apply` — UNCHANGED (no edit). Fully-valid config: identical.
+  A bad VPN reaching render (only via a path that bypassed local commit:
+  HA sync / direct construction / pre-fix config): the connection is
+  omitted, a warning is logged, the healthy config is written and
+  reloaded. No cold-boot zero-tunnels regression.
+- `compileOpts` — additive `lenientIPsecGatewayRefs bool` field; set in
+  the two lenient entry points. No existing field changed.
+- New exported `config.IsUsableIPsecEndpoint(string) bool` and new
+  unexported `validateIPsecGatewayReferencesStrict` / `isPlausibleHostname`
+  — additive.
 
 ## Hidden invariants the change must preserve
 
-1. **`gw` is consumed downstream** (lines 52, 57, 60-64, 78-91,
+1. **`gw` is consumed downstream** (policy.go 52, 57, 60-64, 78-91,
    103-116). For case 3 (inline literal) `gw` stays `nil` as today.
    For cases 1/2 `gw` is set as today and the connection is rendered.
-   For cases 4/5/6 the VPN is SKIPPED before any downstream use of `gw`
-   (the `continue`), so no downstream `gw` access happens for a skipped
-   VPN — correct.
-2. **`localAddr` fallback from `gw.LocalAddress`** only happens in the
+   For cases 4/5/6 the VPN is SKIPPED (the `continue`) before any
+   downstream use of `gw` — no downstream `gw` access for a skipped VPN.
+2. **`localAddr` fallback from `gw.LocalAddress`** only in the
    resolved-gateway branch (cases 1/2) — preserved inside the resolver.
 3. **Empty-gateway VPNs** (`vpn.Gateway == ""`, no map entry) still
-   render with NO `remote_addrs` line and NO error — the resolver
-   returns `("","",nil,nil)`, the connection IS emitted, and the
-   existing `if remoteAddr != ""` emit guard skips only the line.
+   render WITH the connection block and NO `remote_addrs` line and NO
+   error — the resolver returns `("",localAddr,nil,true)`, so the
+   connection IS emitted and the existing `if remoteAddr != ""` emit
+   guard skips only the line. (Verify: this exact shape exists in
+   `ipsec_test.go` — VPNs with no gateway, e.g. cert/TS-only configs.)
 4. **No new hot-path allocations** — render + compile run only on config
-   apply / commit (cold path). The predicate is allocation-light (no
-   regexp; manual byte scan). `errors.Join` allocates only when there
-   ARE errors.
+   apply / commit (cold path). Predicate is allocation-light (no regexp;
+   manual byte scan). `skipped` map allocates one small map per render.
 5. **Exact guarantee (corrected from v1's overstated claim):** a bare
    gateway config-object NAME never reaches `remote_addrs`. The CONTENT
    of a *defined* gateway's `Address` / `DynamicHostname` (cases 1/2) is
-   passed through raw and is NOT re-validated — that is unchanged,
-   trusted to the parser/schema, and explicitly out of scope.
-   `sanitizeSwanctlValue` is still not applied to `remote_addrs`
-   (unchanged); an IP/dotted-hostname has no control chars and the
-   predicate rejects anything that is neither.
+   passed through raw and is NOT re-validated — unchanged, trusted to the
+   parser/schema, out of scope. `sanitizeSwanctlValue` is still not
+   applied to `remote_addrs` (unchanged).
+6. **Lenient compile MUST still boot** a config carrying a leak-case VPN
+   (pre-fix persisted / peer-synced) — `lenientIPsecGatewayRefs` warns,
+   does not fail. This is the R2-2 fix (avoids #1960 fail-closed-on-load).
 
 ## Risk assessment
 
 | Class | Level | Notes |
 |-------|-------|-------|
-| Behavioral regression | LOW | Cases 1-3,7,8 bit-identical; only the already-broken leak cases (4/5/6) change. generateConfig now returns MORE (healthy config) not less. |
-| Import cycle | LOW | Predicate lives in `pkg/config` (exported), called from `pkg/ipsec` (ipsec→config is the existing allowed direction). Explicitly verified at build. |
-| Cold-boot / first-apply | RESOLVED | Skip-and-continue means a bad VPN never zeroes healthy tunnels — the R1 defect is fixed. |
+| Behavioral regression | LOW | Cases 1-3,7,8 bit-identical; only the already-broken leak cases (4/5/6) change. renderConfig error semantics unchanged. |
+| Import cycle | LOW | Predicate in `pkg/config` (exported), called from `pkg/ipsec` (ipsec→config is the existing allowed direction). Verified at build. |
+| Cold-boot / first-apply zero-tunnels | RESOLVED | renderConfig does NOT error on the leak case → Apply writes the healthy config. The R2-1 defect is fixed by construction. |
+| Lenient load fail-closed (#1960 class) | RESOLVED | `lenientIPsecGatewayRefs` downgrades to a warning on load/peer-sync. The R2-2 defect is fixed. |
+| Stanza-order false-reject | RESOLVED | Validator runs on the fully-compiled `*Config`, not inside `compileIPsec` — order-independent. |
 | Performance regression | NONE | Cold config-apply / commit path only. |
-| Architectural mismatch | LOW | Commit-validator is the right altitude (loud at `commit`); render guard is defense-in-depth. |
 
 ## Test plan (control-plane — NO dataplane smoke)
 
@@ -429,44 +507,51 @@ impact, so the iperf3 / CoS / failover smoke matrix does NOT apply.
 Coverage is focused, NON-TAUTOLOGICAL unit tests that FAIL pre-fix:
 
 1. `go build ./...` clean (verifies no import cycle).
-2. `pkg/ipsec` render tests — new `TestRenderConfig_GatewayNameNeverLeaks`:
-   - resolved gw with Address → `remote_addrs = <IP>`, and assert the
-     output does NOT contain the gateway object name on a `remote_addrs`
-     line.
-   - dangling/typo name (no map entry, not IP/host) → `renderConfig`
-     returns non-nil error AND the returned string contains NO
-     `remote_addrs = <name>` line. Fixture uses benign PSK auth (no
-     bogus auth-method) so `resolveIKESettings`/`normalizePSK` cannot
-     error first — guarantees the assertion targets the leak path, not a
-     pre-existing error (R4).
-   - addressless gw (exists, no Address/DynamicHostname) → non-nil
-     error, no leak.
-   - dotless single-label name (case 6) → non-nil error, no leak.
-   - legacy inline literal IP (case 3) → no error, `remote_addrs = <IP>`
+2. `pkg/ipsec` render tests — new `TestRenderConfig_GatewayNameNeverLeaks`
+   (render belt; renderConfig does NOT error on the leak case — it skips):
+   - resolved gw with Address → `remote_addrs = <IP>` present, and the
+     gateway object NAME does NOT appear on any `remote_addrs` line.
+   - dangling/typo name (no map entry, not IP/host) → the output
+     contains NO `remote_addrs = <name>` line AND no connection block
+     for that VPN (skipped). Fixture uses benign PSK auth so an
+     unrelated error path is not what's under test (R4). Pre-fix: this
+     fails because unpatched code emits `remote_addrs = <name>`.
+   - addressless gw (exists, no Address/DynamicHostname) → skipped, no
+     leak. Pre-fix: fails (emits `remote_addrs = <name>`).
+   - dotless single-label name (case 6) → skipped, no leak. Pre-fix
+     fails.
+   - legacy inline literal IP (case 3) → `remote_addrs = <IP>` present
      (over-rejection guard).
-   - dotted inline hostname (case 3 FQDN) → no error,
-     `remote_addrs = peer.example.com`.
-   - empty gateway → no error, no `remote_addrs` line, connection still
-     emitted.
-   - **multi-VPN skip-and-continue (R1 regression guard):** one healthy
-     VPN + one dangling VPN → assert the HEALTHY VPN's `remote_addrs`
-     IS present in the output AND a non-nil error is returned AND the
-     dangling name does NOT appear in `remote_addrs`. On unpatched code
-     v1-style would have aborted the whole file → this proves the
-     skip-and-continue behavior.
-   - Pre-fix proof: every error-asserting sub-case fails on unpatched
-     code (which returns nil error + leaked name).
-3. `pkg/config` compile tests — new `TestCompileIPsec_DanglingGatewayRejected`:
-   - VPN referencing an undefined gateway name → `Compile`/`compileIPsec`
-     returns a non-nil error (commit fails). Fails pre-fix.
-   - VPN referencing a gateway object with no address → error.
-   - VPN with inline literal IP gateway (no object) → NO error (case 3;
+   - dotted inline hostname (case 3 FQDN) → `remote_addrs =
+     peer.example.com` present.
+   - empty gateway → connection emitted, NO `remote_addrs` line.
+   - **multi-VPN skip-and-keep (R2-1 regression guard):** one healthy
+     VPN + one dangling VPN → the HEALTHY VPN's connection AND its
+     `remote_addrs` ARE present in the output; the dangling name does
+     NOT appear anywhere in `remote_addrs`; the dangling VPN has no
+     `ike-<name>` secret. This proves the healthy config is never zeroed.
+3. `pkg/config` compile tests — new
+   `TestValidateIPsecGatewayReferences`:
+   - **commit (strict) rejects:** `CompileConfig` of a tree with a VPN
+     referencing an undefined gateway → non-nil error. Fails pre-fix.
+   - strict rejects a VPN referencing an addressless gateway object.
+   - strict ACCEPTS a VPN with an inline literal IP gateway (case 3;
      mirrors `parser_security_test.go` `vpn site-a gateway 10.1.0.1`).
-   - VPN referencing a defined gateway with an address → NO error.
+   - strict ACCEPTS a VPN referencing a defined gateway with an address.
+   - **stanza-order independence (R2-2):** a tree where the `ipsec`
+     stanza is authored BEFORE the `ike` stanza, with the VPN's gateway
+     defined under `ike { gateway ... address ... }` → `CompileConfig`
+     returns NO error (proves the validator runs on the fully-compiled
+     config, not order-dependently). Fails the v2 design.
+   - **lenient load warns, does not fail (R2-2 / #1960):**
+     `CompileConfigLenient` of a tree with a dangling-gateway VPN →
+     NO error returned AND a warning recorded in `cfg.Warnings`. Proves
+     a pre-fix/peer-synced config still boots.
 4. Full `go test ./pkg/ipsec/... ./pkg/config/...` green (existing 25+
-   render tests + all parser/compiler tests must still pass — proves
-   cases 1-3,7,8 preserved and no committed-config regression).
-5. `go test ./...` green (or the affected packages + their importers).
+   render tests + all parser/compiler tests still pass — proves cases
+   1-3,7,8 preserved and no committed-config regression).
+5. `go test ./...` green (or the affected packages + their importers,
+   incl. `pkg/configstore` which uses the lenient compile entry points).
 
 ## Documentation deliverable (project docs-contract)
 
@@ -485,37 +570,43 @@ Coverage is focused, NON-TAUTOLOGICAL unit tests that FAIL pre-fix:
 
 - Validating `gw.Address` / `gw.DynamicHostname` *content* (trusted to
   the existing parser/schema for those leaves).
-- Schema-layer (`schema_walk.go`) validation — the commit gate lives in
-  the compiler (`compileIPsec`), which is sufficient and is where the
-  cross-reference data is already assembled.
+- Schema-layer (`schema_walk.go`) validation — the commit gate lives as
+  a strict-accumulator validator on the compiled `*Config`
+  (`validateIPsecGatewayReferencesStrict`), which is sufficient and is
+  where the cross-reference data is fully assembled (both `ike{}` and
+  `ipsec{}` gateways).
 - Any change to the inline-literal-IP gateway shape beyond the guard.
 - Responder-only / `%any` peer support (no such concept exists today;
-  the case-5 branch carries a comment to revisit if it is added).
+  the case-5 path carries a comment to revisit if it is added).
 
-## Open questions for adversarial review (v2)
+## Open questions for adversarial review (v3)
 
-1. **Predicate location / import cycle** — defining
-   `config.IsUsableIPsecEndpoint` and calling it from `pkg/ipsec` keeps
-   one SSOT and respects ipsec→config. Confirm no cycle and that this is
-   the cleanest placement (vs duplicating the 2-line predicate).
-2. **Commit-validator placement** — end of `compileIPsec` (after the VPN
-   loop). Confirm both `ike{gateway}` and `ipsec{gateway}` sections are
-   fully populated at that point (compileIKE runs before compileIPsec per
-   `compiler_security.go:39-44`; both write `sec.IPsec.Gateways`). Any
-   ordering hazard?
-3. **Does committing the validator break ANY existing test config?**
-   Reviewers should independently grep `parser_*_test.go` /
-   `compiler_*_test.go` for VPN gateway references and confirm all
-   resolve to a defined gateway or an inline IP (I found
-   `10.1.0.1`/`10.2.0.1`/`remote-gw` — all pass).
-4. **Skip-and-continue secrets** — when a VPN is skipped in the
-   connections loop, its `secrets{}` entry should also be skipped.
-   Confirm the secrets loop is gated by the same skip set (the plan skips
-   it). Any case where a secret is still needed for a skipped conn? (No
-   — no connection, no SA.)
-5. **`errors.Join` import + nil semantics** — `errors.Join()` with no
-   args / all-nil returns nil. Confirm the no-error path is byte-identical
-   (existing tests using `generateConfig`/`renderConfig` see nil error).
-6. **Is rejecting case 5 at commit ever wrong?** Confirmed no
-   responder-only/`%any` concept exists in the parser today; the branch
-   is commented to revisit. Reviewers: re-verify by grep.
+1. **Predicate location / import cycle** — `config.IsUsableIPsecEndpoint`
+   in `pkg/config`, called from `pkg/ipsec`. Confirm no cycle (config
+   must NOT import ipsec) and that one SSOT predicate for both layers is
+   the right call.
+2. **Validator placement** — strict-accumulator-style on the compiled
+   `*Config`, gated by `opts.lenientIPsecGatewayRefs`, mirroring
+   `validateDeviceMapStrict`. Confirm `cfg.Security.IPsec.Gateways` holds
+   BOTH `ike{}` and `ipsec{}` gateways at that point regardless of stanza
+   order, and that the lenient flag is set in BOTH `CompileConfigLenient`
+   and `CompileConfigForNodeLenient`.
+3. **Apply is genuinely unchanged AND writes healthy config** —
+   `renderConfig` does NOT return a new error for the leak case (it
+   skips+warns), so `Apply`'s `if err != nil { return err }` is never
+   tripped by the leak. Confirm this actually means the healthy config
+   reaches `WriteFileAtomic` + reload (the R2-1 fix), with no Apply edit.
+4. **Lenient load really boots** — confirm `CompileConfigLenient` /
+   `CompileConfigForNodeLenient` return nil error (warning only) for a
+   dangling-gateway VPN, so an upgraded/peer-synced node boots (#1960
+   class). Which callers use these? (`pkg/configstore`, HA `SyncApply`.)
+5. **Secrets-loop skip** — the connections loop builds `skipped
+   map[string]bool`; the secrets loop consults it. Confirm no orphan
+   `ike-<name>` secret for a skipped connection, and that no healthy VPN
+   is wrongly skipped.
+6. **Existing test configs** — independently grep `parser_*_test.go` /
+   `compiler_*_test.go` for VPN gateway references; confirm all resolve
+   to a defined+addressed gateway or an inline IP (so neither layer
+   regresses a committed config).
+7. **Is rejecting case 5 ever wrong?** No responder-only/`%any` concept
+   in the parser today; re-verify by grep.

--- a/docs/pr/2074-remote-addrs-name-leak/plan.md
+++ b/docs/pr/2074-remote-addrs-name-leak/plan.md
@@ -1,6 +1,10 @@
 # #2074 — renderConfig leaks the gateway NAME into swanctl remote_addrs
 
-**Status:** DRAFT v3 — addresses round-2 hostile review (both reviewers
+**Status:** PLAN-READY (v3) — round-3 hostile review returned PLAN-READY
+from both independent reviewers (the two round-2 PLAN-NEEDS-MAJOR
+blockers verified fixed against source; only minor prose/import-precision
+folded in: validator edits `compileExpanded`, add `log/slog` to
+policy.go). Addresses round-2 hostile review (both reviewers
 PLAN-NEEDS-MAJOR). Round-2 found two source-confirmed blocking defects in
 v2: (1) `Manager.Apply` bails on a render error BEFORE the write, so v2's
 "return (healthyConfig, joinedErr)" discards the healthy config and the
@@ -375,10 +379,14 @@ total ≤253.
 Do NOT place the check inside `compileIPsec` (round-2 R2-2: stanza order
 + lenient-path break). Instead add a validator on the FULLY-COMPILED
 `*Config`, slotted into the existing strict-validator chain in
-`compileConfigWithOpts` / `compileConfigForNodeWithOpts`
-(`compiler.go`), right after `validatePolicyMatchAddressesStrict` /
-`ValidateEventAttributesMatch` — the exact `validateDeviceMapStrict`
-(#1956) / `#2008` template:
+**`compileExpanded`** (`compiler.go:277`, NOT the outer
+`compileConfigWithOpts`/`compileConfigForNodeWithOpts` — both of those
+call `compileExpanded(tree, opts)` with the threaded opts, so editing
+`compileExpanded` makes the validator fire on standalone AND node-aware
+commits and honor the lenient flag on `SyncApply`), right after
+`validateDeviceMapStrict` (`compiler.go:549`) /
+`validatePolicyMatchAddressesStrict` / `ValidateEventAttributesMatch` —
+the exact `validateDeviceMapStrict` (#1956) / `#2008` template:
 
 ```go
 // #2074: an IPsec VPN that references a gateway which is neither a
@@ -460,6 +468,10 @@ commit, and boots a pre-fix/peer-synced config with a warning.
 - New exported `config.IsUsableIPsecEndpoint(string) bool` and new
   unexported `validateIPsecGatewayReferencesStrict` / `isPlausibleHostname`
   — additive.
+- `pkg/ipsec/policy.go` MUST add `"log/slog"` to its import block for the
+  belt's `slog.Warn` (currently imports only fmt/net/sort/strconv/strings
+  + config; `slog` is used elsewhere in the package but each file imports
+  its own). `go build` (test-plan item 1) catches an omission.
 
 ## Hidden invariants the change must preserve
 

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -133,6 +133,19 @@ type compileOpts struct {
 	// still boot through that already-committed config rather than fail to
 	// load. Commit stays strict (see the validator call site).
 	lenientEventAttributesMatch bool
+
+	// lenientIPsecGatewayRefs (#2074) downgrades the IPsec VPN -> IKE
+	// gateway cross-reference check from a hard error to a warning on the
+	// tolerant load / peer-sync paths (CompileConfigLenient /
+	// CompileConfigForNodeLenient). A config persisted by an older binary,
+	// or synced from a peer, may carry a VPN that references an undefined
+	// or addressless gateway; an upgrading / receiving node must still
+	// boot through it (warn) rather than fail-closed-on-load (#1960
+	// class). Commit / commit-check stay strict — a new operator edit that
+	// would render `remote_addrs = <gateway-name>` (a silently-dead
+	// tunnel) is rejected. Same doctrine as lenientDeviceMap /
+	// lenientPolicyMatchAddress.
+	lenientIPsecGatewayRefs bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -160,6 +173,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyMatchAddress:    true,
 		lenientTCPMSSRange:           true,
 		lenientEventAttributesMatch:  true,
+		lenientIPsecGatewayRefs:      true,
 	})
 }
 
@@ -238,6 +252,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyMatchAddress:    true,
 		lenientTCPMSSRange:           true,
 		lenientEventAttributesMatch:  true,
+		lenientIPsecGatewayRefs:      true,
 	})
 }
 
@@ -583,6 +598,25 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientEventAttributesMatch {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("event-options attributes-match (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2074 IPsec VPN -> IKE gateway cross-reference. A VPN that
+	// references a gateway which is neither a defined gateway object nor a
+	// usable inline IP/hostname would render `remote_addrs = <gateway-name>`
+	// — a config-object name strongSwan cannot use, a silently-dead tunnel.
+	// Strict on commit / commit-check (hard reject so the operator gets a
+	// diagnostic); lenient on load / peer-sync (warn so a pre-fix or
+	// peer-synced config still boots — #1960 fail-closed-on-load class).
+	// Runs on the fully-compiled *Config so both ike{} and ipsec{} gateway
+	// definitions are present regardless of stanza authoring order. Mirrors
+	// validateDeviceMapStrict / the policy match-address gate above.
+	if err := validateIPsecGatewayReferencesStrict(cfg); err != nil {
+		if opts.lenientIPsecGatewayRefs {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("ipsec gateway reference (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"net"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -379,4 +382,134 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 	}
 
 	return nil
+}
+
+// validateIPsecGatewayReferencesStrict (#2074) rejects an IPsec VPN that
+// references an IKE gateway which is neither a defined gateway object
+// (carrying an address or dynamic hostname) nor a usable inline
+// IP/hostname. Without this check, renderConfig would emit
+// `remote_addrs = <gateway-name>` — a config-object name strongSwan
+// cannot use — producing a silently-dead tunnel with no diagnostic.
+//
+// It runs on the fully-compiled *Config (the strict-validator chain in
+// compileExpanded), so both `ike { gateway }` and `ipsec { gateway }`
+// definitions are present in sec.IPsec.Gateways regardless of which
+// stanza was authored first. The caller downgrades this to a warning on
+// the tolerant load / peer-sync paths (lenientIPsecGatewayRefs) so a
+// config persisted by an older binary, or synced from a peer, still
+// boots; commit / commit-check stay strict.
+//
+// VPN names are sorted so a multi-VPN config reports a deterministic
+// first failure.
+func validateIPsecGatewayReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	ipsec := &cfg.Security.IPsec
+	if len(ipsec.VPNs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(ipsec.VPNs))
+	for name := range ipsec.VPNs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		vpn := ipsec.VPNs[name]
+		if vpn == nil || vpn.Gateway == "" {
+			// A VPN may legitimately omit the remote endpoint (the
+			// generated connection simply has no remote_addrs line).
+			continue
+		}
+		if gw, ok := ipsec.Gateways[vpn.Gateway]; ok {
+			if gw.Address == "" && gw.DynamicHostname == "" {
+				return fmt.Errorf("security ipsec vpn %s: ike gateway %q "+
+					"has no address or dynamic hostname; the tunnel would "+
+					"never establish", name, vpn.Gateway)
+			}
+			continue // resolves to a defined, addressed gateway
+		}
+		if IsUsableIPsecEndpoint(vpn.Gateway) {
+			continue // legacy inline literal IP / dotted hostname
+		}
+		return fmt.Errorf("security ipsec vpn %s: ike gateway %q is not "+
+			"defined and is not a valid address or hostname", name, vpn.Gateway)
+	}
+	return nil
+}
+
+// IsUsableIPsecEndpoint reports whether s is something strongSwan can
+// place in a swanctl `remote_addrs` directly: a literal IP address, or a
+// plausible dotted DNS hostname / FQDN. It deliberately REJECTS a bare
+// config-object name with no hostname structure (e.g. a typo'd gateway
+// reference such as `gw-to-hq`), so such a name is caught at commit
+// rather than DNS-probed forever at runtime (#2074).
+//
+// It lives in pkg/config so that both the commit-time validator
+// (validateIPsecGatewayReferencesStrict, pkg/config) and the swanctl
+// render belt (pkg/ipsec, which imports pkg/config) share one predicate
+// with no import cycle.
+func IsUsableIPsecEndpoint(s string) bool {
+	if s == "" {
+		return false
+	}
+	if net.ParseIP(s) != nil {
+		return true
+	}
+	return isPlausibleHostname(s)
+}
+
+// isPlausibleHostname reports whether s looks like a multi-label DNS
+// hostname / FQDN: it must contain at least one dot (Rule A — this is
+// what distinguishes an operator-supplied peer hostname from a typo'd
+// single-label gateway object name), and every dot-separated label must
+// be a syntactically valid host label (1-63 chars, alphanumeric with
+// internal hyphens, no leading/trailing hyphen). Total length is capped
+// at 253. No regexp — a manual byte scan keeps it allocation-free.
+//
+// The single-label-hostname limitation (a bare `vpnpeer` resolvable via
+// the system resolver is rejected) is intentional and documented: define
+// a proper `security ike gateway <name> { address <ip>; }` (or
+// `dynamic { hostname <fqdn>; }`) instead.
+func isPlausibleHostname(s string) bool {
+	if len(s) == 0 || len(s) > 253 {
+		return false
+	}
+	if !strings.Contains(s, ".") {
+		return false
+	}
+	labelLen := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '.':
+			if labelLen == 0 {
+				return false // empty label (leading dot or "..")
+			}
+			if s[i-1] == '-' {
+				return false // label ends with hyphen
+			}
+			labelLen = 0
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+			labelLen++
+		case c == '-':
+			if labelLen == 0 {
+				return false // label begins with hyphen
+			}
+			labelLen++
+		default:
+			return false // illegal character for a hostname
+		}
+		if labelLen > 63 {
+			return false
+		}
+	}
+	// Trailing label must be non-empty and not end with a hyphen.
+	if labelLen == 0 {
+		return false // trailing dot => empty last label
+	}
+	if s[len(s)-1] == '-' {
+		return false
+	}
+	return true
 }

--- a/pkg/config/compiler_ipsec_gateway_ref_test.go
+++ b/pkg/config/compiler_ipsec_gateway_ref_test.go
@@ -1,0 +1,194 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildTree2074 compiles a set-command list into a ConfigTree for the
+// #2074 gateway-reference tests.
+func buildTree2074(t *testing.T, setCommands []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range setCommands {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestValidateIPsecGatewayReferences covers #2074: a VPN that references
+// an IKE gateway which is neither defined+addressed nor a usable inline
+// IP/hostname must be rejected at commit (strict), while valid shapes
+// compile cleanly. These cases fail against pre-fix code, which compiled
+// such configs without error (and then rendered a dead remote_addrs).
+func TestValidateIPsecGatewayReferences(t *testing.T) {
+	t.Run("commit rejects undefined gateway", func(t *testing.T) {
+		tree := buildTree2074(t, []string{
+			"set security ipsec vpn tun gateway nope",
+			"set security ipsec vpn tun bind-interface st0.0",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatalf("CompileConfig should reject a VPN referencing undefined gateway %q", "nope")
+		}
+		if !strings.Contains(err.Error(), "nope") {
+			t.Fatalf("error should name the offending gateway, got: %v", err)
+		}
+	})
+
+	t.Run("commit rejects addressless gateway", func(t *testing.T) {
+		tree := buildTree2074(t, []string{
+			// Gateway object exists (it has an ike-policy) but no address
+			// and no dynamic hostname.
+			"set security ike gateway bare-gw ike-policy pol1",
+			"set security ipsec vpn tun gateway bare-gw",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatalf("CompileConfig should reject an addressless gateway reference")
+		}
+		if !strings.Contains(err.Error(), "bare-gw") {
+			t.Fatalf("error should name the offending gateway, got: %v", err)
+		}
+	})
+
+	t.Run("commit accepts inline literal IP gateway", func(t *testing.T) {
+		// Mirrors parser_security_test.go `vpn site-a gateway 10.1.0.1`.
+		tree := buildTree2074(t, []string{
+			"set security ipsec vpn site-a gateway 10.1.0.1",
+			"set security ipsec vpn site-a bind-interface st0.0",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("inline IP gateway should compile, got: %v", err)
+		}
+	})
+
+	t.Run("commit accepts defined gateway with address", func(t *testing.T) {
+		tree := buildTree2074(t, []string{
+			"set security ike gateway remote-gw address 203.0.113.1",
+			"set security ipsec vpn tun gateway remote-gw",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("defined+addressed gateway should compile, got: %v", err)
+		}
+	})
+
+	t.Run("commit accepts dynamic-hostname gateway", func(t *testing.T) {
+		tree := buildTree2074(t, []string{
+			"set security ike gateway dyn-gw dynamic hostname peer.example.com",
+			"set security ipsec vpn tun gateway dyn-gw",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("dynamic-hostname gateway should compile, got: %v", err)
+		}
+	})
+
+	// Stanza-order independence (round-2 R2-2): the VPN's gateway is
+	// defined under `ike { gateway ... }`. The validator must run on the
+	// fully-compiled config, not order-dependently — so the VPN compiles
+	// regardless of whether `ipsec` set-commands appear before `ike` ones.
+	t.Run("ipsec stanza before ike stanza still compiles", func(t *testing.T) {
+		tree := buildTree2074(t, []string{
+			// VPN (ipsec subtree) authored first ...
+			"set security ipsec vpn tun gateway hub-gw",
+			"set security ipsec vpn tun bind-interface st0.0",
+			// ... ike gateway authored after.
+			"set security ike gateway hub-gw address 198.51.100.1",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("ike-defined gateway authored after the VPN should still compile, got: %v", err)
+		}
+	})
+
+	// Lenient load/peer-sync (round-2 R2-2 / #1960): a config carrying a
+	// dangling-gateway VPN must still BOOT under the tolerant compile
+	// paths (warn, do not fail) so an upgraded / peer-synced node loads.
+	t.Run("lenient load warns but does not fail", func(t *testing.T) {
+		tree := buildTree2074(t, []string{
+			"set security ipsec vpn tun gateway nope",
+		})
+		// Strict rejects.
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatalf("strict compile should reject the dangling gateway")
+		}
+		// Lenient boots with a warning.
+		cfg, err := CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("lenient compile should boot a dangling-gateway config, got: %v", err)
+		}
+		found := false
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "ipsec gateway reference") && strings.Contains(w, "nope") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("lenient compile should record an ipsec gateway warning, got: %v", cfg.Warnings)
+		}
+	})
+
+	t.Run("lenient for-node load warns but does not fail", func(t *testing.T) {
+		tree := buildTree2074(t, []string{
+			"set security ipsec vpn tun gateway nope",
+		})
+		cfg, err := CompileConfigForNodeLenient(tree, 0)
+		if err != nil {
+			t.Fatalf("lenient for-node compile should boot a dangling-gateway config, got: %v", err)
+		}
+		found := false
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "ipsec gateway reference") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("lenient for-node compile should record an ipsec gateway warning, got: %v", cfg.Warnings)
+		}
+	})
+
+	t.Run("no gateway is not rejected", func(t *testing.T) {
+		// A VPN may legitimately omit the gateway (cert/TS-only shapes).
+		tree := buildTree2074(t, []string{
+			"set security ipsec vpn tun bind-interface st0.0",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("a gateway-less VPN should compile, got: %v", err)
+		}
+	})
+}
+
+// TestIsUsableIPsecEndpoint exercises the shared predicate directly.
+func TestIsUsableIPsecEndpoint(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"10.0.0.1", true},
+		{"2001:db8::1", true},
+		{"peer.example.com", true},
+		{"a.b", true},
+		{"vpnpeer", false},   // dotless single-label name (Rule A)
+		{"typo-gw", false},   // dotless object-name typo
+		{"gw_underscore", false},
+		{"-bad.example.com", false}, // leading hyphen label
+		{"bad-.example.com", false}, // trailing hyphen label
+		{".example.com", false},     // empty leading label
+		{"example.com.", false},     // trailing dot / empty last label
+		{"a..b", false},             // empty middle label
+		{"has space.com", false},
+	}
+	for _, c := range cases {
+		if got := IsUsableIPsecEndpoint(c.in); got != c.want {
+			t.Errorf("IsUsableIPsecEndpoint(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -71,3 +71,32 @@ all files stay in `package ipsec`, so the public API is unchanged.
   `xfrmiIfID()`. The same name → same numeric ID across reboots — don't
   rename a bind interface without expecting a reset of the SAs that ride
   it.
+- **Gateway reference resolution / `remote_addrs` (#2074).** A VPN's
+  `ike gateway <name>` either names a defined `security ike gateway`
+  object (whose `address` or `dynamic hostname` becomes `remote_addrs`)
+  or, in the legacy inline shape, IS the peer endpoint directly (a
+  literal IP or a dotted hostname/FQDN). The invariant is: **a bare
+  gateway config-object NAME never reaches swanctl `remote_addrs`** — a
+  config-object name strongSwan cannot use would DNS-resolve forever and
+  the IKE SA would never come up (a silently-dead tunnel).
+  - **Commit-time rejection** (`validateIPsecGatewayReferencesStrict`,
+    `pkg/config/compiler_ipsec.go`, run from the strict-validator chain
+    in `compileExpanded`): a VPN that references an undefined gateway, or
+    a gateway object committed with neither `address` nor `dynamic
+    hostname`, fails `commit` / `commit check`. On the tolerant load /
+    peer-sync paths the same check is downgraded to a warning
+    (`lenientIPsecGatewayRefs`) so a config persisted by an older binary
+    or synced from a peer still boots.
+  - **Render belt** (`resolveRemoteAddr`, `policy.go`): for any path that
+    reaches render without passing local commit (HA sync / direct
+    construction), an unrenderable VPN is SKIPPED (logged via
+    `slog.Warn`) — its connection and secret are omitted — rather than
+    leaking the name or aborting the whole file. Healthy VPNs always
+    render, so one bad reference never zeroes healthy tunnels.
+  - **Rule-A limitation:** an inline gateway hostname must be dotted
+    (FQDN-like). A bare single-label inline hostname (e.g. `vpnpeer`,
+    even if resolvable via the system resolver) is rejected so a typo'd
+    single-label gateway name is caught. Migration: define a proper
+    gateway — `set security ike gateway <name> address <ip>` (or
+    `dynamic hostname <fqdn>`). The shared accept predicate is
+    `config.IsUsableIPsecEndpoint`.

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -971,3 +971,201 @@ func TestGenerateConfig_NewlineSecretDoesNotInject(t *testing.T) {
 		t.Errorf("sanitized secret missing:\n%s", got)
 	}
 }
+
+// remoteAddrsValue returns the value rendered for `remote_addrs = ` in
+// the swanctl output, or "" if no such line is present. It lets the
+// #2074 tests assert specifically that a gateway config-object NAME
+// never appears as the remote_addrs value (a substring match on the
+// whole config would falsely flag the connection-name line).
+func remoteAddrsValues(cfg string) []string {
+	var out []string
+	for _, line := range strings.Split(cfg, "\n") {
+		t := strings.TrimSpace(line)
+		if v, ok := strings.CutPrefix(t, "remote_addrs = "); ok {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// TestRenderConfig_GatewayNameNeverLeaks exercises #2074: a bare gateway
+// config-object NAME must never reach swanctl `remote_addrs`. The render
+// belt skips an unrenderable VPN rather than leaking its name; valid
+// shapes (defined+addressed gateway, inline IP/FQDN, empty gateway) are
+// preserved. These sub-cases fail against pre-fix code, which emitted
+// `remote_addrs = <gateway-name>` for the dangling / addressless cases.
+func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+
+	t.Run("resolved gateway with address", func(t *testing.T) {
+		cfg := &config.IPsecConfig{
+			Gateways: map[string]*config.IPsecGateway{
+				"corp-gw": {Name: "corp-gw", Address: "203.0.113.7"},
+			},
+			VPNs: map[string]*config.IPsecVPN{
+				"tun": {Gateway: "corp-gw", PSK: "k"},
+			},
+		}
+		got, err := m.renderConfig(cfg)
+		if err != nil {
+			t.Fatalf("renderConfig() error = %v", err)
+		}
+		vals := remoteAddrsValues(got)
+		if len(vals) != 1 || vals[0] != "203.0.113.7" {
+			t.Fatalf("remote_addrs = %v, want [203.0.113.7]\n%s", vals, got)
+		}
+		for _, v := range vals {
+			if v == "corp-gw" {
+				t.Fatalf("gateway NAME leaked into remote_addrs:\n%s", got)
+			}
+		}
+	})
+
+	t.Run("dangling gateway name is skipped, no leak", func(t *testing.T) {
+		cfg := &config.IPsecConfig{
+			// "typo-gw" is referenced but never defined, and is not a
+			// usable IP / dotted hostname. Benign PSK auth so no other
+			// render error path fires (this isolates the leak path).
+			VPNs: map[string]*config.IPsecVPN{
+				"tun": {Gateway: "typo-gw", PSK: "k"},
+			},
+		}
+		got, err := m.renderConfig(cfg)
+		if err != nil {
+			t.Fatalf("renderConfig() error = %v (skip should not error)", err)
+		}
+		if strings.Contains(got, "typo-gw") {
+			t.Fatalf("dangling gateway NAME leaked into config:\n%s", got)
+		}
+		if vals := remoteAddrsValues(got); len(vals) != 0 {
+			t.Fatalf("expected no remote_addrs, got %v\n%s", vals, got)
+		}
+		if strings.Contains(got, "ike-tun {") {
+			t.Fatalf("skipped VPN should have no secret entry:\n%s", got)
+		}
+	})
+
+	t.Run("addressless gateway is skipped, no leak", func(t *testing.T) {
+		cfg := &config.IPsecConfig{
+			Gateways: map[string]*config.IPsecGateway{
+				// Exists but has neither Address nor DynamicHostname.
+				"bare-gw": {Name: "bare-gw"},
+			},
+			VPNs: map[string]*config.IPsecVPN{
+				"tun": {Gateway: "bare-gw", PSK: "k"},
+			},
+		}
+		got, err := m.renderConfig(cfg)
+		if err != nil {
+			t.Fatalf("renderConfig() error = %v", err)
+		}
+		if strings.Contains(got, "bare-gw") {
+			t.Fatalf("addressless gateway NAME leaked:\n%s", got)
+		}
+		if vals := remoteAddrsValues(got); len(vals) != 0 {
+			t.Fatalf("expected no remote_addrs, got %v\n%s", vals, got)
+		}
+	})
+
+	t.Run("dotless single-label name is skipped", func(t *testing.T) {
+		cfg := &config.IPsecConfig{
+			VPNs: map[string]*config.IPsecVPN{
+				"tun": {Gateway: "vpnpeer", PSK: "k"},
+			},
+		}
+		got, err := m.renderConfig(cfg)
+		if err != nil {
+			t.Fatalf("renderConfig() error = %v", err)
+		}
+		if vals := remoteAddrsValues(got); len(vals) != 0 {
+			t.Fatalf("dotless name should be skipped, got remote_addrs %v\n%s", vals, got)
+		}
+	})
+
+	t.Run("inline literal IP is preserved", func(t *testing.T) {
+		cfg := &config.IPsecConfig{
+			VPNs: map[string]*config.IPsecVPN{
+				"tun": {Gateway: "198.51.100.9", PSK: "k"},
+			},
+		}
+		got, err := m.renderConfig(cfg)
+		if err != nil {
+			t.Fatalf("renderConfig() error = %v", err)
+		}
+		if vals := remoteAddrsValues(got); len(vals) != 1 || vals[0] != "198.51.100.9" {
+			t.Fatalf("remote_addrs = %v, want [198.51.100.9]\n%s", vals, got)
+		}
+	})
+
+	t.Run("inline dotted hostname is preserved", func(t *testing.T) {
+		cfg := &config.IPsecConfig{
+			VPNs: map[string]*config.IPsecVPN{
+				"tun": {Gateway: "peer.example.com", PSK: "k"},
+			},
+		}
+		got, err := m.renderConfig(cfg)
+		if err != nil {
+			t.Fatalf("renderConfig() error = %v", err)
+		}
+		if vals := remoteAddrsValues(got); len(vals) != 1 || vals[0] != "peer.example.com" {
+			t.Fatalf("remote_addrs = %v, want [peer.example.com]\n%s", vals, got)
+		}
+	})
+
+	t.Run("empty gateway emits connection with no remote_addrs", func(t *testing.T) {
+		cfg := &config.IPsecConfig{
+			VPNs: map[string]*config.IPsecVPN{
+				"tun": {Gateway: "", PSK: "k", BindInterface: "st0.0"},
+			},
+		}
+		got, err := m.renderConfig(cfg)
+		if err != nil {
+			t.Fatalf("renderConfig() error = %v", err)
+		}
+		if !strings.Contains(got, "  tun {\n") {
+			t.Fatalf("empty-gateway VPN should still render a connection:\n%s", got)
+		}
+		if vals := remoteAddrsValues(got); len(vals) != 0 {
+			t.Fatalf("empty gateway should emit no remote_addrs, got %v\n%s", vals, got)
+		}
+	})
+
+	// Regression guard for the round-2 cold-boot defect: a healthy VPN
+	// must still render (and keep its remote_addrs) when a sibling VPN is
+	// skipped. Pre-fix / v1-style whole-render-abort would have dropped
+	// the healthy tunnel too.
+	t.Run("one bad VPN does not zero a healthy sibling", func(t *testing.T) {
+		cfg := &config.IPsecConfig{
+			Gateways: map[string]*config.IPsecGateway{
+				"good-gw": {Name: "good-gw", Address: "192.0.2.10"},
+			},
+			VPNs: map[string]*config.IPsecVPN{
+				"good": {Gateway: "good-gw", PSK: "k1"},
+				"bad":  {Gateway: "missing-gw", PSK: "k2"},
+			},
+		}
+		got, err := m.renderConfig(cfg)
+		if err != nil {
+			t.Fatalf("renderConfig() error = %v", err)
+		}
+		if !strings.Contains(got, "  good {\n") {
+			t.Fatalf("healthy VPN was dropped:\n%s", got)
+		}
+		vals := remoteAddrsValues(got)
+		if len(vals) != 1 || vals[0] != "192.0.2.10" {
+			t.Fatalf("healthy remote_addrs = %v, want [192.0.2.10]\n%s", vals, got)
+		}
+		if strings.Contains(got, "missing-gw") {
+			t.Fatalf("bad gateway NAME leaked:\n%s", got)
+		}
+		if strings.Contains(got, "  bad {\n") {
+			t.Fatalf("bad VPN should be skipped:\n%s", got)
+		}
+		if strings.Contains(got, "ike-bad {") {
+			t.Fatalf("skipped VPN should have no secret:\n%s", got)
+		}
+		if !strings.Contains(got, "ike-good {") {
+			t.Fatalf("healthy VPN secret missing:\n%s", got)
+		}
+	})
+}

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -972,11 +972,12 @@ func TestGenerateConfig_NewlineSecretDoesNotInject(t *testing.T) {
 	}
 }
 
-// remoteAddrsValue returns the value rendered for `remote_addrs = ` in
-// the swanctl output, or "" if no such line is present. It lets the
-// #2074 tests assert specifically that a gateway config-object NAME
-// never appears as the remote_addrs value (a substring match on the
-// whole config would falsely flag the connection-name line).
+// remoteAddrsValues returns every value rendered on a `remote_addrs = `
+// line in the swanctl output (one per emitted connection), or an empty
+// slice if there are none. It lets the #2074 tests assert specifically
+// that a gateway config-object NAME never appears as a remote_addrs
+// value (a substring match on the whole config would falsely flag the
+// connection-name line).
 func remoteAddrsValues(cfg string) []string {
 	var out []string
 	for _, line := range strings.Split(cfg, "\n") {

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -2,6 +2,7 @@ package ipsec
 
 import (
 	"fmt"
+	"log/slog"
 	"net"
 	"sort"
 	"strconv"
@@ -28,27 +29,34 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 
 	b.WriteString("# xpf managed config - do not edit\n\n")
 
+	// skipped records VPNs whose gateway reference is not renderable
+	// (#2074) so the secrets loop below emits no orphan ike-<name> secret
+	// for a connection that was never written.
+	skipped := make(map[string]bool)
+
 	// Connections
 	b.WriteString("connections {\n")
 	for _, name := range sortedVPNNames(ipsecCfg.VPNs) {
 		vpn := ipsecCfg.VPNs[name]
-		fmt.Fprintf(&b, "  %s {\n", sanitizeSwanctlValue(name))
 
-		// Resolve gateway reference
-		remoteAddr := vpn.Gateway
-		localAddr := vpn.LocalAddr
-		var gw *config.IPsecGateway
-		if g, ok := ipsecCfg.Gateways[vpn.Gateway]; ok {
-			gw = g
-			if gw.Address != "" {
-				remoteAddr = gw.Address
-			} else if gw.DynamicHostname != "" {
-				remoteAddr = gw.DynamicHostname
-			}
-			if gw.LocalAddress != "" && localAddr == "" {
-				localAddr = gw.LocalAddress
-			}
+		// Resolve the remote gateway endpoint. remote_addrs must be a
+		// real IP / hostname strongSwan can use — never a bare gateway
+		// config-object name (#2074). The hard diagnostic for a bad
+		// reference is the commit-time validator
+		// (validateIPsecGatewayReferencesStrict); this render belt is the
+		// by-construction backstop for any path that reaches render
+		// without passing local commit (HA peer-sync, direct
+		// IPsecConfig construction, a config persisted before the fix).
+		remoteAddr, localAddr, gw, ok := resolveRemoteAddr(ipsecCfg, vpn)
+		if !ok {
+			skipped[name] = true
+			slog.Warn("skipping IPsec VPN: ike gateway not renderable "+
+				"(undefined or addressless) — fix the gateway reference",
+				"vpn", name, "gateway", vpn.Gateway)
+			continue
 		}
+
+		fmt.Fprintf(&b, "  %s {\n", sanitizeSwanctlValue(name))
 		authMethod, ikeProposals, ikeLifetime, aggressive, err := resolveIKESettings(ipsecCfg, gw)
 		if err != nil {
 			return "", fmt.Errorf("vpn %s: %w", name, err)
@@ -172,6 +180,11 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 	// Secrets — resolve PSK from IKE policy chain
 	b.WriteString("secrets {\n")
 	for _, name := range sortedVPNNames(ipsecCfg.VPNs) {
+		if skipped[name] {
+			// No connection was written for this VPN (#2074) — emit no
+			// orphan ike-<name> secret.
+			continue
+		}
 		vpn := ipsecCfg.VPNs[name]
 		secret := vpn.PSK.Reveal()
 		// Resolve PSK from IKE policy chain: VPN -> gateway -> IKE policy -> PSK
@@ -195,6 +208,59 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 	b.WriteString("}\n")
 
 	return b.String(), nil
+}
+
+// resolveRemoteAddr resolves the swanctl remote_addrs value (a real IP /
+// dotted hostname) for a VPN, plus the effective local address and the
+// resolved gateway. ok=false means there is nothing usable to render —
+// the caller MUST skip the connection so a bare gateway config-object
+// NAME never leaks into remote_addrs (#2074):
+//
+//   - defined gateway with an address / dynamic hostname -> remote = that
+//   - defined gateway with neither (addressless)         -> ok=false
+//   - no gateway object, vpn.Gateway is a usable IP/host -> remote = it
+//   - no gateway object, vpn.Gateway empty               -> ok=true,
+//     remote="" (connection emitted with no remote_addrs line, as before)
+//   - no gateway object, vpn.Gateway a dangling/dotless name -> ok=false
+//
+// This mirrors the commit-time validator validateIPsecGatewayReferencesStrict
+// exactly, using the same config.IsUsableIPsecEndpoint predicate.
+func resolveRemoteAddr(ipsecCfg *config.IPsecConfig, vpn *config.IPsecVPN) (
+	remoteAddr, localAddr string, gw *config.IPsecGateway, ok bool) {
+
+	localAddr = vpn.LocalAddr
+	if g, found := ipsecCfg.Gateways[vpn.Gateway]; found {
+		gw = g
+		switch {
+		case gw.Address != "":
+			remoteAddr = gw.Address
+		case gw.DynamicHostname != "":
+			remoteAddr = gw.DynamicHostname
+		default:
+			// Gateway exists but has nothing routable. Do NOT fall back
+			// to the object name. (Forecloses a future responder-only /
+			// %any peer that legitimately omits remote_addrs — no such
+			// concept exists in the parser today; revisit if added.)
+			return "", localAddr, gw, false
+		}
+		if gw.LocalAddress != "" && localAddr == "" {
+			localAddr = gw.LocalAddress
+		}
+		return remoteAddr, localAddr, gw, true
+	}
+	if vpn.Gateway == "" {
+		// Legitimately omitted remote endpoint — emit the connection with
+		// no remote_addrs line (unchanged behavior).
+		return "", localAddr, nil, true
+	}
+	if config.IsUsableIPsecEndpoint(vpn.Gateway) {
+		// Legacy inline shape: the VPN names the peer endpoint directly
+		// as a literal IP or dotted hostname, with no Gateways entry.
+		return vpn.Gateway, localAddr, nil, true
+	}
+	// Dangling / dotless single-label name — not a known gateway and not
+	// a usable IP/hostname. Rendering it would leak the name.
+	return "", localAddr, nil, false
 }
 
 func sortedVPNNames(vpns map[string]*config.IPsecVPN) []string {


### PR DESCRIPTION
## Summary

Fixes #2074. An IPsec VPN whose `ike gateway <name>` references a gateway that is neither a defined-and-addressed gateway object nor a usable inline IP/hostname (a typo, or a gateway committed without `address`/`dynamic hostname`) made `renderConfig` emit `remote_addrs = <gateway-name>` — a config-object name strongSwan cannot use. strongSwan DNS-resolves the bogus name forever, the IKE SA never establishes, and the operator gets no diagnostic: a silently-dead tunnel.

Two-layer fix:

- **Layer 1 — commit-time validator** (`validateIPsecGatewayReferencesStrict`, `pkg/config`): rejects an undefined or addressless gateway reference at `commit` / `commit check`. Runs in the strict-validator chain in `compileExpanded`, on the fully-compiled `*Config`, so both `ike { gateway }` and `ipsec { gateway }` definitions are present regardless of stanza authoring order. Downgraded to a warning on the tolerant load / peer-sync paths via a new `compileOpts.lenientIPsecGatewayRefs` (set in `CompileConfigLenient` and `CompileConfigForNodeLenient`) so a config persisted by an older binary or synced from a peer still **boots** (mirrors the #1956 / #2008 doctrine; avoids the #1960 fail-closed-on-load class).
- **Layer 2 — render belt** (`resolveRemoteAddr`, `pkg/ipsec/policy.go`): for any path that reaches render without passing local commit (HA sync, direct construction), an unrenderable VPN is **skipped** (with a `slog.Warn`) — its connection and secret are omitted — rather than leaking the name **or** aborting the whole file. Healthy VPNs always render, so one bad reference never zeroes healthy tunnels on cold boot. `renderConfig` adds **no** new error return, so the unchanged `Manager.Apply` still writes the healthy config.

The shared predicate `config.IsUsableIPsecEndpoint` (Rule A: an inline hostname must be dotted/FQDN) is exported from `pkg/config` so both layers classify identically with no import cycle. The guarantee is narrow and exact: **a bare gateway config-object NAME never reaches `remote_addrs`**; a defined gateway's `address`/`dynamic hostname` content is passed through unchanged (trusted to the parser/schema). The legacy inline-literal-IP gateway shape and the gateway-less (cert/TS-only) VPN shape are preserved bit-for-bit.

This is a control-plane (swanctl render + config compile) change with no dataplane/forwarding impact, so no iperf3/CoS/failover smoke applies.

## Plan + adversarial review

Plan doc: `docs/pr/2074-remote-addrs-name-leak/plan.md` (PLAN-READY).

Substituted hostile Claude reviewers (Codex/Gemini companions infra-degraded), two independent read-only reviewers per round + author SMR:

- Round 1: A PLAN-NEEDS-MINOR, B PLAN-NEEDS-MAJOR — whole-render-abort blast radius; altitude (warn-only doesn't fail commit). Addressed in v2.
- Round 2: both PLAN-NEEDS-MAJOR — (1) `Apply` bails before write so v2's error-return discarded the healthy config; (2) validator inside `compileIPsec` depended on stanza order and broke the lenient load path. Addressed in v3.
- Round 3: both **PLAN-READY** (only minor prose/import precision folded: validator edits `compileExpanded`; add `log/slog` to `policy.go`).

## Test plan

- [x] `go build ./...` clean (no import cycle)
- [x] `go test ./...` — full suite green
- [x] `go test ./pkg/ipsec/... ./pkg/config/... ./pkg/configstore/...` green; `go vet` clean
- [x] New `pkg/ipsec` `TestRenderConfig_GatewayNameNeverLeaks` (8 sub-cases incl. multi-VPN skip-keeps-healthy-sibling) — **verified to FAIL against pre-fix `policy.go`** via `go test -overlay` (non-tautological)
- [x] New `pkg/config` `TestValidateIPsecGatewayReferences` (strict reject undefined/addressless, accept inline-IP/defined/dynamic-hostname, stanza-order independence, lenient-load-warns-not-fails) + `TestIsUsableIPsecEndpoint` — **verified to FAIL when the validator is wired out** (non-tautological)
- [x] Existing `pkg/ipsec` render tests + `pkg/config` parser/compiler tests pass unchanged (legacy shapes preserved)
- [x] Docs: `pkg/ipsec/README.md` updated with the gateway-reference / `remote_addrs` invariant

🤖 Generated with [Claude Code](https://claude.com/claude-code)