### PR TITLE
vrrp: gate sync-hold preempt shortcut on peer priority (#2082)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ in git history; `git log -- bpf/xdp/ bpf/tc/` walks the deleted source.
 - **Fabric forwarding**: the userspace dataplane redirects packets for peer-owned synced sessions over the fabric link — `resolve_fabric_redirect()` / `ingress_is_fabric()` in `userspace-dp/src/afxdp/forwarding/mod.rs` (see `docs/fabric-cross-chassis-fwd.md`) — prevents TCP death on VRRP failback. The pre-#1476 eBPF mechanism (`try_fabric_redirect()` in xdp_zone) is historical
 - **RETH virtual MAC**: per-node `02:bf:72:CC:RR:NN`; `programRethMAC()` does link DOWN→set MAC→link UP
 - **VIP reconciliation**: `ReconcileVIPs()` re-adds VRRP VIPs after `programRethMAC` link DOWN/UP (which removes all kernel addresses)
-- **Sync hold**: VRRP starts with `preempt=false`; released after bulk session sync (or 10s timeout); `preemptNowCh` triggers instant preemption
+- **Sync hold**: VRRP starts with `preempt=false`; released after bulk session sync (or 10s timeout); `preemptNowCh` triggers instant preemption. Sync-hold release preempt is now peer-priority gated (#2082): the non-force `preemptNowCh` shortcut becomes MASTER only on a STRICTLY higher effective priority than the last-observed master (RFC 5798 §6.4.2); `ForceRGMaster` (force=true) and priority-0 takeover (ungated `masterDownTimer` path) bypass the gate — no ~60ms failover regression
 - **Heartbeat**: 200ms interval, threshold 5 (1s detection); bind retry loop for simultaneous boot
 - **Session sync connect**: immediate first attempt, 1s retry (was 5s)
 - **Event debounce**: 500ms for cluster state → VRRP priority updates

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -63,6 +63,25 @@ This is the package that drives chassis-cluster failover.
 - Sync hold: VRRP starts with `preempt=false`; released after bulk
   session sync (or 10 s timeout). `preemptNowCh` triggers instant
   preemption when sync completes early.
+- Sync-hold preempt gate (#2082): the non-force `preemptNowCh` shortcut
+  is peer-priority gated. `becomeMaster()` runs on the kick only when the
+  node's **effective** priority is **strictly greater** than the last
+  observed master's (RFC 5798 §6.4.2 — equal priority does NOT preempt;
+  no IP tie-break, that resolves a MASTER-MASTER collision in
+  `handleMasterRx`, not preemption). A lower-priority preempt-enabled node
+  (e.g. a rejoining cluster Secondary at priority 100) therefore no longer
+  transiently becomes a second MASTER on sync-hold release while a
+  higher-priority peer is legitimately MASTER. `handleBackupRx` /
+  `handleMasterRx` record each non-zero peer advert
+  (`lastMasterPriority`/`lastMasterSeen`); priority-0 resignation adverts
+  are not recorded (post-resign takeover flows through the ungated
+  `masterDownTimer` path). Staleness — no master seen, or last seen older
+  than `masterDownInterval` — is treated as "no live master", allowing
+  cold-start / silent-master-death takeover. `ForceRGMaster` (force=true,
+  cluster-authoritative Secondary→Primary promotion) bypasses the gate
+  unchanged, so the ~60 ms failover path is untouched. The gate only
+  governs the shortcut: a denied gate never stops `masterDownTimer`, so the
+  normal RFC election still promotes the node when the real master dies.
 
 ## Interface tracking (#1814)
 

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -56,11 +56,24 @@ type vrrpInstance struct {
 	desiredPreempt   bool // configured preempt value (may differ from cfg.Preempt during sync hold)
 	forcePreemptOnce bool // one-shot preempt override from ForceRGMaster (auto-cleared after use)
 	trackDown        bool // tracked interface (cfg.TrackInterface) is down (#1814); guarded by mu
-	state            VRRPState
-	iface            *net.Interface
-	eventCh          chan<- VRRPEvent
-	localIP          net.IP // our IPv4 address on this interface (for filtering self-sent)
-	localIPv6        net.IP // our link-local IPv6 address (source for IPv6 VRRP adverts)
+
+	// Last-seen master advertisement (#2082). Recorded by handleBackupRx /
+	// handleMasterRx for every non-zero-priority advert from a peer, and read
+	// by shouldPreemptObservedMaster to gate the non-force sync-hold preempt
+	// shortcut on a strictly-higher effective priority (RFC 5798 §6.4.2). Both
+	// writers and the gate reader run in the run-loop goroutine, so they are
+	// already serialized with respect to each other; mu makes the writes/reads
+	// race-clean for any future cross-goroutine reader. Priority-0
+	// (resignation) adverts are NOT recorded — post-resign takeover flows
+	// through the ungated masterDownTimer path. Guarded by mu.
+	lastMasterPriority int       // last non-zero peer advert priority
+	lastMasterSeen     time.Time // when lastMasterPriority was recorded
+
+	state     VRRPState
+	iface     *net.Interface
+	eventCh   chan<- VRRPEvent
+	localIP   net.IP // our IPv4 address on this interface (for filtering self-sent)
+	localIPv6 net.IP // our link-local IPv6 address (source for IPv6 VRRP adverts)
 
 	// Per-instance raw socket and receiver.
 	conn    net.PacketConn
@@ -255,6 +268,82 @@ func (vi *vrrpInstance) getPreempt() bool {
 	return vi.cfg.Preempt
 }
 
+// shouldPreemptObservedMaster decides whether the non-force sync-hold preempt
+// shortcut (the preemptNowCh case in run) may transition this BACKUP instance
+// to MASTER (#2082). It encodes RFC 5798 §6.4.2 preemption: a BACKUP preempts
+// only on a STRICTLY higher priority than the currently-observed master. It
+// returns true iff:
+//
+//   - preempt is configured (a non-preempting node never preempts on the
+//     shortcut), AND
+//   - either no live master has been observed recently (lastMasterSeen is zero
+//     or older than masterDownInterval — the cold-start / peer-down /
+//     silent-master-death rescue, where becoming MASTER is correct), OR a
+//     recent master was observed AND our effective priority is strictly greater
+//     than its last advertised priority.
+//
+// Equal priority returns false (RFC 5798 §6.4.2 — an equal-priority BACKUP does
+// not preempt; the address tie-break in handleMasterRx resolves a MASTER-MASTER
+// collision, a different state than preemption). The ForceRGMaster path
+// (force=true) is gated OUTSIDE this helper (the run-loop short-circuits it),
+// so cluster-authoritative promotion is unaffected.
+//
+// Lock discipline (BINDING — Go's sync.RWMutex is non-reentrant): this helper
+// snapshots everything it needs under ONE vi.mu.RLock(), releases, then
+// computes the effective priority and the staleness horizon from the locals.
+// It MUST NOT call getPriority()/getPreempt()/masterDownInterval() (each of
+// which RLocks vi.mu) while holding the lock. RLock (not Lock) is used so it
+// never blocks concurrent external readers such as Status().
+func (vi *vrrpInstance) shouldPreemptObservedMaster() bool {
+	vi.mu.RLock()
+	preempt := vi.cfg.Preempt
+	priority := vi.cfg.Priority
+	trackDown := vi.trackDown
+	trackIface := vi.cfg.TrackInterface
+	trackCost := vi.cfg.TrackPriorityCost
+	advertMS := vi.cfg.AdvertiseInterval
+	lastMasterPriority := vi.lastMasterPriority
+	lastMasterSeen := vi.lastMasterSeen
+	vi.mu.RUnlock()
+
+	if !preempt {
+		return false
+	}
+
+	// Effective advertised priority — replicates getPriority() (track.go)
+	// from the snapshot: priority 0/255 pass through unchanged; otherwise
+	// while the tracked link is down, TrackPriorityCost is subtracted and
+	// clamped to [1, 254].
+	effective := priority
+	if priority != 0 && priority != 255 && trackDown && trackIface != "" {
+		effective -= trackCost
+		if effective < 1 {
+			effective = 1
+		} else if effective > 254 {
+			effective = 254
+		}
+	}
+
+	// masterDownInterval staleness horizon — replicates masterDownInterval()
+	// (3*advert + skew) from the snapshot using the effective priority.
+	advert := time.Duration(advertMS) * time.Millisecond
+	if advertMS <= 0 {
+		advert = 1000 * time.Millisecond
+	}
+	skew := time.Duration(256-effective) * advert / 256
+	masterDown := 3*advert + skew
+
+	// No live master observed (cold-start) or the last advert is older than
+	// the master-down horizon (silent death / peer-down) → no master to
+	// respect, becoming MASTER is correct.
+	if lastMasterSeen.IsZero() || time.Since(lastMasterSeen) > masterDown {
+		return true
+	}
+
+	// A live master was observed — preempt only on STRICTLY higher priority.
+	return effective > lastMasterPriority
+}
+
 func (vi *vrrpInstance) getState() VRRPState {
 	vi.mu.RLock()
 	defer vi.mu.RUnlock()
@@ -284,6 +373,46 @@ func (vi *vrrpInstance) masterDownInterval() time.Duration {
 	advert := vi.advertInterval()
 	skew := time.Duration(256-vi.getPriority()) * advert / 256
 	return 3*advert + skew
+}
+
+// stepBackup runs one iteration of the StateBackup select. It is called by the
+// run loop AND directly by unit tests (the run() preamble unconditionally
+// spawns a receiver goroutine that nil-derefs vi.conn on a test instance, so
+// tests must not call run() — they drive this seam instead). It returns true
+// when the instance has been told to stop (the caller's run loop should
+// return).
+func (vi *vrrpInstance) stepBackup(masterDownTimer, advertTimer *time.Timer) (stop bool) {
+	select {
+	case <-vi.stopCh:
+		return true
+	case pkt := <-vi.rxCh:
+		vi.handleBackupRx(pkt, masterDownTimer)
+	case <-masterDownTimer.C:
+		// Master timed out — become Master.
+		vi.becomeMaster()
+		advertTimer.Reset(vi.advertInterval())
+	case <-vi.preemptNowCh:
+		// Coordinated preemption from ReleaseSyncHold or forced transition
+		// from ForceRGMaster. The forcePreemptOnce flag allows a one-shot
+		// preemption even when preempt=false, without leaking into the
+		// configured preempt value.
+		//
+		// force=true (ForceRGMaster) is cluster-authoritative and bypasses
+		// the peer-priority gate unconditionally. The non-force sync-hold
+		// path is gated on shouldPreemptObservedMaster (#2082): a
+		// lower-priority preempt-enabled node no longer transiently becomes
+		// a second MASTER while a higher-priority peer is legitimately MASTER.
+		vi.mu.Lock()
+		force := vi.forcePreemptOnce
+		vi.forcePreemptOnce = false
+		vi.mu.Unlock()
+		if force || vi.shouldPreemptObservedMaster() {
+			vi.becomeMaster()
+			advertTimer.Reset(vi.advertInterval())
+			masterDownTimer.Stop()
+		}
+	}
+	return false
 }
 
 // run is the main state machine loop. Must be called as a goroutine.
@@ -348,29 +477,8 @@ func (vi *vrrpInstance) run() {
 
 		switch state {
 		case StateBackup:
-			select {
-			case <-vi.stopCh:
+			if vi.stepBackup(masterDownTimer, advertTimer) {
 				return
-			case pkt := <-vi.rxCh:
-				vi.handleBackupRx(pkt, masterDownTimer)
-			case <-masterDownTimer.C:
-				// Master timed out — become Master.
-				vi.becomeMaster()
-				advertTimer.Reset(vi.advertInterval())
-			case <-vi.preemptNowCh:
-				// Coordinated preemption from ReleaseSyncHold or forced
-				// transition from ForceRGMaster. The forcePreemptOnce flag
-				// allows a one-shot preemption even when preempt=false,
-				// without leaking into the configured preempt value.
-				vi.mu.Lock()
-				force := vi.forcePreemptOnce
-				vi.forcePreemptOnce = false
-				vi.mu.Unlock()
-				if vi.getPreempt() || force {
-					vi.becomeMaster()
-					advertTimer.Reset(vi.advertInterval())
-					masterDownTimer.Stop()
-				}
 			}
 
 		case StateMaster:
@@ -714,8 +822,25 @@ func (vi *vrrpInstance) parseAfPacketIPv6(buf []byte, n, ethHeaderLen int) {
 	}
 }
 
+// recordMasterAdvert records a peer's last advertised priority for the
+// sync-hold preempt gate (#2082). Priority-0 (resignation) adverts are NOT
+// recorded — leaving a stale lastMasterPriority is safe because post-resign
+// takeover flows through the ungated masterDownTimer path, not the gated
+// preemptNowCh shortcut. Called from handleBackupRx/handleMasterRx, which run
+// in the run-loop goroutine; mu only guards external readers.
+func (vi *vrrpInstance) recordMasterAdvert(pkt *VRRPPacket) {
+	if pkt.Priority == 0 {
+		return
+	}
+	vi.mu.Lock()
+	vi.lastMasterPriority = int(pkt.Priority)
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+}
+
 // handleBackupRx processes a received advertisement while in Backup state.
 func (vi *vrrpInstance) handleBackupRx(pkt *VRRPPacket, masterDownTimer *time.Timer) {
+	vi.recordMasterAdvert(pkt)
 	pri := vi.getPriority()
 	if pkt.Priority == 0 {
 		// Master is explicitly resigning — become Master immediately.
@@ -739,6 +864,7 @@ func (vi *vrrpInstance) handleBackupRx(pkt *VRRPPacket, masterDownTimer *time.Ti
 // Per RFC 5798 §6.4.3: if priority is higher, step down. If equal,
 // the node with the higher source IP stays Master (tie-breaking).
 func (vi *vrrpInstance) handleMasterRx(pkt *VRRPPacket, masterDownTimer, advertTimer *time.Timer) {
+	vi.recordMasterAdvert(pkt)
 	pri := vi.getPriority()
 	if pkt.Priority == 0 {
 		// Peer resigning — send immediate advert and stay Master.

--- a/pkg/vrrp/instance_preempt_gate_test.go
+++ b/pkg/vrrp/instance_preempt_gate_test.go
@@ -1,0 +1,419 @@
+package vrrp
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// Tests for the sync-hold preempt peer-priority gate (#2082). The
+// preemptNowCh consumer must only transition a BACKUP to MASTER on the
+// non-force shortcut when its effective priority strictly exceeds the
+// observed master's (RFC 5798 §6.4.2), so a lower-priority preempt-enabled
+// node no longer transiently becomes a second MASTER on sync-hold release
+// while a higher-priority peer is legitimately MASTER.
+//
+// The wiring tests drive stepBackup() directly (NOT run()): run()'s preamble
+// unconditionally spawns a receiver goroutine that nil-derefs vi.conn on a
+// test instance. becomeMaster() is fail-soft on a fake interface (addVIPs
+// Warn+returns on netlink failure, sendAdvert/sendPacket no-op on nil
+// rawConn), and suppressGARP avoids the async GARP goroutine.
+
+// newGateTestInstance builds a BACKUP instance suitable for driving stepBackup
+// in a unit test: GARP suppressed (no stray goroutine), state BACKUP, a
+// local IP set so the handlers behave normally.
+func newGateTestInstance(t *testing.T, priority int, preempt bool) *vrrpInstance {
+	t.Helper()
+	eventCh := make(chan VRRPEvent, 16)
+	vi := newInstance(Instance{
+		Interface: "eth0",
+		GroupID:   101,
+		Priority:  priority,
+		Preempt:   preempt,
+	}, &net.Interface{Name: "eth0"}, eventCh, nil)
+	vi.localIP = net.IPv4(10, 0, 0, 1)
+	vi.suppressGARP.Store(true)
+	vi.setState(StateBackup)
+	return vi
+}
+
+// longTimers returns a masterDown/advert timer pair armed far in the future so
+// that, in a stepBackup select, only a pre-loaded preemptNowCh (or rxCh) case
+// is ready — making the select deterministic. Do NOT use already-expired
+// timers in these wiring tests (that makes the select nondeterministic).
+func longTimers(t *testing.T) (masterDown, advert *time.Timer) {
+	t.Helper()
+	masterDown = time.NewTimer(time.Hour)
+	t.Cleanup(func() { masterDown.Stop() })
+	advert = time.NewTimer(time.Hour)
+	t.Cleanup(func() { advert.Stop() })
+	return masterDown, advert
+}
+
+// TestPreemptNow_LowerPriorityStaysBackup is the PRIMARY regression guard. A
+// priority-100 preempt-enabled node that has just heard a live priority-200
+// master must NOT become MASTER on the non-force sync-hold preempt kick.
+//
+// This MUST FAIL on the pre-fix code (`if vi.getPreempt() || force` →
+// unconditional becomeMaster) — it tests the run-loop wiring, not the helper
+// in isolation.
+func TestPreemptNow_LowerPriorityStaysBackup(t *testing.T) {
+	vi := newGateTestInstance(t, 100, true)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 200
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	masterDown, advert := longTimers(t)
+	vi.triggerPreemptNow()
+	if stop := vi.stepBackup(masterDown, advert); stop {
+		t.Fatal("stepBackup returned stop=true unexpectedly")
+	}
+
+	if vi.getState() != StateBackup {
+		t.Errorf("state = %s, want BACKUP (lower-priority non-force preempt must be blocked)", vi.getState())
+	}
+}
+
+// TestPreemptNow_HigherPriorityBecomesMaster: a priority-200 node observing a
+// priority-100 master passes the gate and becomes MASTER immediately (the
+// legitimate fast preempt is preserved — no failover-timing regression).
+func TestPreemptNow_HigherPriorityBecomesMaster(t *testing.T) {
+	vi := newGateTestInstance(t, 200, true)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	masterDown, advert := longTimers(t)
+	vi.triggerPreemptNow()
+	vi.stepBackup(masterDown, advert)
+
+	if vi.getState() != StateMaster {
+		t.Errorf("state = %s, want MASTER (higher priority must preempt)", vi.getState())
+	}
+}
+
+// TestPreemptNow_EqualPriorityStaysBackup: equal priority does not preempt
+// (RFC 5798 §6.4.2; no IP tie-break in the preempt gate). Wiring-level.
+func TestPreemptNow_EqualPriorityStaysBackup(t *testing.T) {
+	vi := newGateTestInstance(t, 150, true)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 150
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	masterDown, advert := longTimers(t)
+	vi.triggerPreemptNow()
+	vi.stepBackup(masterDown, advert)
+
+	if vi.getState() != StateBackup {
+		t.Errorf("state = %s, want BACKUP (equal priority must not preempt)", vi.getState())
+	}
+}
+
+// TestPreemptNow_ForceBypassesGate: ForceRGMaster (force=true) is
+// cluster-authoritative and bypasses the gate — a priority-100 node observing
+// a priority-200 master still becomes MASTER when forced.
+func TestPreemptNow_ForceBypassesGate(t *testing.T) {
+	vi := newGateTestInstance(t, 100, true)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 200
+	vi.lastMasterSeen = time.Now()
+	vi.forcePreemptOnce = true
+	vi.mu.Unlock()
+
+	masterDown, advert := longTimers(t)
+	vi.triggerPreemptNow()
+	vi.stepBackup(masterDown, advert)
+
+	if vi.getState() != StateMaster {
+		t.Errorf("state = %s, want MASTER (force must bypass the priority gate)", vi.getState())
+	}
+}
+
+// TestPreemptNow_ForceBypassesGate_EvenWithoutPreempt: force=true must promote
+// even when preempt is NOT configured (the ForceRGMaster one-shot semantics).
+func TestPreemptNow_ForceBypassesGate_EvenWithoutPreempt(t *testing.T) {
+	vi := newGateTestInstance(t, 100, false)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 200
+	vi.lastMasterSeen = time.Now()
+	vi.forcePreemptOnce = true
+	vi.mu.Unlock()
+
+	masterDown, advert := longTimers(t)
+	vi.triggerPreemptNow()
+	vi.stepBackup(masterDown, advert)
+
+	if vi.getState() != StateMaster {
+		t.Errorf("state = %s, want MASTER (force must promote even with preempt=false)", vi.getState())
+	}
+}
+
+// TestPreemptNow_NoPreemptStaysBackup: a non-force kick on a node with
+// preempt=false never promotes (helper returns false on !preempt). Guards
+// against a future change that drops the preempt check.
+func TestPreemptNow_NoPreemptStaysBackup(t *testing.T) {
+	vi := newGateTestInstance(t, 200, false)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	masterDown, advert := longTimers(t)
+	vi.triggerPreemptNow()
+	vi.stepBackup(masterDown, advert)
+
+	if vi.getState() != StateBackup {
+		t.Errorf("state = %s, want BACKUP (preempt=false must never preempt on the shortcut)", vi.getState())
+	}
+}
+
+// TestPreemptNow_NoObservedMasterBecomesMaster: cold-start — never heard a
+// master — the gate treats it as "no live master to respect" and the
+// preempt-enabled node becomes MASTER on the kick (wiring-level).
+func TestPreemptNow_NoObservedMasterBecomesMaster(t *testing.T) {
+	vi := newGateTestInstance(t, 100, true)
+	// lastMasterSeen left zero.
+
+	masterDown, advert := longTimers(t)
+	vi.triggerPreemptNow()
+	vi.stepBackup(masterDown, advert)
+
+	if vi.getState() != StateMaster {
+		t.Errorf("state = %s, want MASTER (cold-start, no observed master)", vi.getState())
+	}
+}
+
+// TestPreemptNow_DeniedGateLeavesMasterDownTimerArmed verifies invariant (a):
+// a denied gate never stops the masterDownTimer, so the ungated RFC election
+// remains armed and can still promote the node when the real master dies. A
+// denied stepBackup is followed by a second stepBackup whose masterDownTimer
+// has expired — that must promote to MASTER.
+func TestPreemptNow_DeniedGateLeavesMasterDownTimerArmed(t *testing.T) {
+	vi := newGateTestInstance(t, 100, true)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 200
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+
+	// First: denied non-force preempt kick. Use a long masterDown timer so
+	// the select deterministically picks preemptNowCh.
+	masterDownLong := time.NewTimer(time.Hour)
+	defer masterDownLong.Stop()
+	advert := time.NewTimer(time.Hour)
+	defer advert.Stop()
+	vi.triggerPreemptNow()
+	vi.stepBackup(masterDownLong, advert)
+	if vi.getState() != StateBackup {
+		t.Fatalf("state = %s after denied gate, want BACKUP", vi.getState())
+	}
+
+	// Now simulate the masterDownTimer firing (real master died): a fresh,
+	// already-expired masterDown timer drives the second iteration. The gate
+	// never stopped the timer, so the RFC election promotes us.
+	masterDownExpired := time.NewTimer(0)
+	defer masterDownExpired.Stop()
+	vi.stepBackup(masterDownExpired, advert)
+	if vi.getState() != StateMaster {
+		t.Errorf("state = %s, want MASTER (masterDown election must still promote after a denied gate)", vi.getState())
+	}
+}
+
+// --- shouldPreemptObservedMaster helper unit tests ---
+
+func TestShouldPreempt_NoObservedMaster(t *testing.T) {
+	vi := newGateTestInstance(t, 100, true)
+	// lastMasterSeen zero → no live master → true (cold-start).
+	if !vi.shouldPreemptObservedMaster() {
+		t.Error("want true (no observed master / cold-start)")
+	}
+}
+
+func TestShouldPreempt_StaleMaster(t *testing.T) {
+	// Default RETH-ish interval; with a short advert, masterDownInterval is
+	// tens of ms. Set lastMasterSeen well in the past so it is stale.
+	vi := newInstance(Instance{
+		Interface:         "eth0",
+		GroupID:           101,
+		Priority:          100,
+		Preempt:           true,
+		AdvertiseInterval: 30,
+	}, &net.Interface{Name: "eth0"}, make(chan VRRPEvent, 1), nil)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 200
+	vi.lastMasterSeen = time.Now().Add(-1 * time.Hour)
+	vi.mu.Unlock()
+	if !vi.shouldPreemptObservedMaster() {
+		t.Error("want true (stale master beyond masterDownInterval → silent-death rescue)")
+	}
+}
+
+func TestShouldPreempt_LiveHigherMasterDenies(t *testing.T) {
+	vi := newGateTestInstance(t, 100, true)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 200
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	if vi.shouldPreemptObservedMaster() {
+		t.Error("want false (live higher-priority master → must not preempt)")
+	}
+}
+
+func TestShouldPreempt_LiveLowerMasterAllows(t *testing.T) {
+	vi := newGateTestInstance(t, 200, true)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	if !vi.shouldPreemptObservedMaster() {
+		t.Error("want true (strictly higher than the observed master → preempt)")
+	}
+}
+
+func TestShouldPreempt_EqualPriorityNoPreempt(t *testing.T) {
+	vi := newGateTestInstance(t, 150, true)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 150
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	if vi.shouldPreemptObservedMaster() {
+		t.Error("want false (equal priority does not preempt, RFC 5798 §6.4.2; no IP tie-break)")
+	}
+}
+
+func TestShouldPreempt_NoPreemptConfigured(t *testing.T) {
+	vi := newGateTestInstance(t, 200, false)
+	vi.mu.Lock()
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	if vi.shouldPreemptObservedMaster() {
+		t.Error("want false (preempt not configured)")
+	}
+}
+
+// TestShouldPreempt_OwnerExemptFromTrackDemotion: priority 255 (address owner)
+// is exempt from track-down demotion, so the owner's effective priority stays
+// 255 and beats any observed master.
+func TestShouldPreempt_OwnerExemptFromTrackDemotion(t *testing.T) {
+	vi := newInstance(Instance{
+		Interface:         "eth0",
+		GroupID:           101,
+		Priority:          255,
+		Preempt:           true,
+		TrackInterface:    "ge-0-0-9",
+		TrackPriorityCost: 100,
+		AdvertiseInterval: 30,
+	}, &net.Interface{Name: "eth0"}, make(chan VRRPEvent, 1), nil)
+	vi.mu.Lock()
+	vi.trackDown = true // would normally demote, but 255 is exempt
+	vi.lastMasterPriority = 200
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	if !vi.shouldPreemptObservedMaster() {
+		t.Error("want true (owner-255 is track-exempt; effective 255 > 200)")
+	}
+}
+
+// TestShouldPreempt_TrackDemotedNodeDenied: a track-demoted node whose
+// effective priority falls at/below the observed master must not preempt.
+func TestShouldPreempt_TrackDemotedNodeDenied(t *testing.T) {
+	// Priority 200, cost 150 while track down → effective 50, clamped not
+	// needed (50 ≥ 1). Observed master at 100 → 50 > 100 false → denied.
+	vi := newInstance(Instance{
+		Interface:         "eth0",
+		GroupID:           101,
+		Priority:          200,
+		Preempt:           true,
+		TrackInterface:    "ge-0-0-9",
+		TrackPriorityCost: 150,
+		AdvertiseInterval: 30,
+	}, &net.Interface{Name: "eth0"}, make(chan VRRPEvent, 1), nil)
+	vi.mu.Lock()
+	vi.trackDown = true
+	vi.lastMasterPriority = 100
+	vi.lastMasterSeen = time.Now()
+	vi.mu.Unlock()
+	if vi.shouldPreemptObservedMaster() {
+		t.Error("want false (track-demoted effective 50 ≤ observed master 100)")
+	}
+	// Sanity: the effective priority matches getPriority().
+	if got := vi.getPriority(); got != 50 {
+		t.Errorf("getPriority() = %d, want 50 (track demotion); gate must use the same effective value", got)
+	}
+}
+
+// --- recordMasterAdvert tests ---
+
+func TestRecordMasterAdvert_RecordsNonZero(t *testing.T) {
+	vi := newGateTestInstance(t, 100, true)
+	masterDown := time.NewTimer(time.Hour)
+	defer masterDown.Stop()
+
+	before := time.Now()
+	vi.handleBackupRx(&VRRPPacket{Priority: 200, SrcIP: net.IPv4(10, 0, 0, 2)}, masterDown)
+
+	vi.mu.RLock()
+	gotPri := vi.lastMasterPriority
+	gotSeen := vi.lastMasterSeen
+	vi.mu.RUnlock()
+	if gotPri != 200 {
+		t.Errorf("lastMasterPriority = %d, want 200", gotPri)
+	}
+	if gotSeen.Before(before) {
+		t.Errorf("lastMasterSeen = %v, want ≥ %v", gotSeen, before)
+	}
+}
+
+// TestRecordMasterAdvert_IgnoresPriorityZero: a priority-0 (resignation)
+// advert must NOT update lastMaster* — post-resign takeover flows through the
+// ungated masterDownTimer path, so recording a stale-high value is irrelevant
+// and recording 0 would wrongly mark "no live master".
+func TestRecordMasterAdvert_IgnoresPriorityZero(t *testing.T) {
+	vi := newGateTestInstance(t, 100, true)
+	masterDown := time.NewTimer(time.Hour)
+	defer masterDown.Stop()
+
+	// Seed a recorded master.
+	vi.mu.Lock()
+	vi.lastMasterPriority = 200
+	seeded := time.Now().Add(-time.Minute)
+	vi.lastMasterSeen = seeded
+	vi.mu.Unlock()
+
+	// Feed a priority-0 advert (resignation).
+	vi.handleBackupRx(&VRRPPacket{Priority: 0, SrcIP: net.IPv4(10, 0, 0, 2)}, masterDown)
+
+	vi.mu.RLock()
+	gotPri := vi.lastMasterPriority
+	gotSeen := vi.lastMasterSeen
+	vi.mu.RUnlock()
+	if gotPri != 200 {
+		t.Errorf("lastMasterPriority = %d, want 200 unchanged (priority-0 not recorded)", gotPri)
+	}
+	if !gotSeen.Equal(seeded) {
+		t.Errorf("lastMasterSeen = %v, want unchanged %v (priority-0 not recorded)", gotSeen, seeded)
+	}
+}
+
+// TestRecordMasterAdvert_MasterRxAlsoRecords: handleMasterRx records too, so a
+// node that observes a peer while it is itself MASTER tracks the peer priority.
+func TestRecordMasterAdvert_MasterRxAlsoRecords(t *testing.T) {
+	vi := newGateTestInstance(t, 200, true)
+	vi.setState(StateMaster)
+	masterDown := time.NewTimer(time.Hour)
+	defer masterDown.Stop()
+	advert := time.NewTimer(time.Hour)
+	defer advert.Stop()
+
+	vi.handleMasterRx(&VRRPPacket{Priority: 100, SrcIP: net.IPv4(10, 0, 0, 2)}, masterDown, advert)
+
+	vi.mu.RLock()
+	gotPri := vi.lastMasterPriority
+	vi.mu.RUnlock()
+	if gotPri != 100 {
+		t.Errorf("lastMasterPriority = %d, want 100 (handleMasterRx must record)", gotPri)
+	}
+}


### PR DESCRIPTION
Fixes #2082.

## Problem

The VRRP `preemptNowCh` consumer in the `StateBackup` machine called
`becomeMaster()` whenever `getPreempt() || force` was true, with **no**
comparison against the priority of the master it was about to displace. On
sync-hold release, `Manager.ReleaseSyncHold` restores the configured preempt and
fires `triggerPreemptNow()` on every instance. A rejoining cluster Secondary
(RETH VRRP priority 100, `preempt=true`) therefore transiently became a **second
MASTER** while the priority-200 peer was still legitimately MASTER — adding the
RETH VIP on the wrong node, emitting a spurious MASTER `VRRPEvent` (which flips
`rg_active` and removes blackholes), and possibly firing a GARP burst that moves
the L2 path. The transient self-heals within one advert interval, but the side
effects are real.

## Fix (Path A — converged plan, RFC 5798 §6.4.2)

Record the last-seen master's advertised priority and gate the **non-force**
preempt shortcut on a **strictly higher** effective priority.

- `lastMasterPriority`/`lastMasterSeen` added to `vrrpInstance`, recorded by
  `handleBackupRx`/`handleMasterRx` via `recordMasterAdvert` for every non-zero
  peer advert. Priority-0 (resignation) adverts are **not** recorded —
  post-resign takeover flows through the ungated `masterDownTimer` path, so a
  stale-high recorded priority cannot block it.
- `shouldPreemptObservedMaster()` returns true iff preempt is configured **AND**
  (no live master observed — `lastMasterSeen` zero or older than
  `masterDownInterval`, the cold-start / silent-death rescue — **OR** our
  effective priority is strictly greater than the observed master's). Equal
  priority does **not** preempt (the IP tie-break is `handleMasterRx`'s
  MASTER-MASTER collision resolver, not a preemption rule; it is left untouched).
  The helper snapshots all state under **one** `vi.mu.RLock()` then computes the
  effective priority and the staleness horizon from locals — it never calls
  `getPriority()`/`getPreempt()`/`masterDownInterval()` under the lock (Go
  RWMutex is non-reentrant).
- The `StateBackup` select is extracted into `stepBackup()` and the shortcut
  rewired to `if force || shouldPreemptObservedMaster()`. **`force=true`**
  (`ForceRGMaster`, cluster-authoritative Secondary→Primary promotion)
  short-circuits the gate unchanged, so the **~60 ms failover path and priority-0
  takeover are untouched**. The `stepBackup` seam lets unit tests drive the
  run-loop decision without calling `run()`, whose preamble spawns a receiver
  goroutine that nil-derefs `vi.conn` on a test instance.

## Tests

`pkg/vrrp/instance_preempt_gate_test.go`:
- **Wiring guards via the `stepBackup` seam** — lower-priority and equal-priority
  non-force preempt are **BLOCKED**; both (and the denied-gate invariant test)
  **FAIL on the pre-fix `getPreempt() || force`** (non-tautological, verified by
  a temporary overlay of the old condition); higher-priority, force (incl.
  `preempt=false`), and cold-start still promote.
- **Invariant (a)** — a denied gate leaves `masterDownTimer` armed, so the RFC
  election still promotes on real master death.
- **Helper unit tests** — no/stale/live-higher/live-lower/equal master, owner-255
  track-exempt, track-demoted denial (cross-checked against `getPriority()`).
- **recordMasterAdvert** — records non-zero, ignores priority-0, `handleMasterRx`
  also records.

`go test ./pkg/vrrp/ -race -count=1` green; `go build ./...` green;
`go vet ./pkg/vrrp/` clean; `gofmt -l` clean.

## Reviews

Driven through the triple-review gate: two hostile Claude reviewers (both
**APPROVE**, no blocking findings) + Claude SMR (**MERGE-READY** after the single
gofmt struct-alignment fix it caught, now resolved). Copilot review pending.

## test-failover

**Pending a central parent run.** `make test-failover` (loss userspace cluster)
is a **no-regression gate only** for this change — the smoke cluster runs
`preempt=false`, so the bug path is not exercised there; the unit wiring guard is
the authoritative validation. The parent runs `test-failover` centrally to avoid
multi-agent cluster collisions.

## Docs

`pkg/vrrp/README.md` sync-hold section + `CLAUDE.md` Chassis-Cluster sync-hold
bullet document the gate.

## Rollback

Pure-Go, self-contained in `pkg/vrrp`. Revert is a single `git revert`; no
migration, no on-disk state, no wire-format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)