### PR TITLE
#2075: reconcile NetFlow v9 / IPFIX exporters on config commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27,6 +27,53 @@
   (new), pkg/api/README.md, pkg/grpcapi/README.md,
   docs/pr/2084-ping-traceroute-separator/plan.md (new)
 
+## 2026-06-20 — #2075 NetFlow v9 / IPFIX exporters never reconciled on commit
+
+- **Timestamp**: 2026-06-20
+- **Action**: Fixed #2075 (MEDIUM, audit-found, stored-but-never-enforced
+  observability config). The NetFlow v9 / IPFIX exporters
+  (`pkg/flowexport`) were started only at daemon boot and stopped only at
+  shutdown; the apply path (`daemon_apply.go`) had zero flowexport
+  references, so any commit changing `forwarding-options sampling`
+  (collector, source-address, 1-in-N rate, sampled zones) or a
+  `services flow-monitoring` export-extension was silently ignored until a
+  daemon restart — and flow export ADDED in a later commit never started.
+  Added `reconcileFlowExporters` (new `pkg/daemon/daemon_flowexport.go`),
+  called from `applyConfigLocked` (step 16b) and from the post-EventReader
+  boot block (replacing the old boot-only `startFlowExporter`/
+  `startIPFIXExporter`, which were deleted). Config-hash-gated PER FAMILY
+  so an unrelated commit never bounces a healthy exporter (preserving its
+  template-refresh cadence + 1-in-N sampling counter). The EventReader
+  callback list is append-only (clear-all only, no per-callback removal),
+  so a naive stop/start would leak a closure per commit; instead a single
+  stable indirection callback per family is registered exactly once
+  (`flowCBOnce`/`ipfixCBOnce`) and reads the live `(exporter, config)`
+  pair lock-free from an `atomic.Pointer` bundle that reconcile swaps
+  atomically. The daemon-held `*ExportConfig` is the sole 1-in-N counter
+  owner (the exporter never reads `sampleCounter`), so it is held by
+  pointer in the bundle.
+- **File(s)**: `pkg/daemon/daemon_flowexport.go` (new),
+  `pkg/daemon/daemon_flow.go` (deleted start funcs, hardened stop funcs),
+  `pkg/daemon/daemon.go` (bundle/hash/once/mutex fields),
+  `pkg/daemon/daemon_run.go` (boot call sites),
+  `pkg/daemon/daemon_apply.go` (step 16b),
+  `pkg/logging/ringbuf.go` (`CallbackCount` test accessor),
+  `pkg/daemon/daemon_flowexport_reconcile_test.go` (new, 8 tests incl. a
+  non-tautological apply-wiring guard that drives the REAL
+  `applyConfigLocked` and fails iff the reconcile call is removed —
+  mutation-verified, plus a create-failure retry test),
+  `pkg/flowexport/README.md` (lifecycle),
+  `docs/pr/2075-flowexport-reconcile/plan.md` (plan + folded plan reviews).
+  A hostile-code-review MINOR was folded: a transient `NewExporter`
+  failure now leaves the per-family hash UNSET so the next commit retries
+  (no permanently-dead exporter), instead of recording the hash.
+- **Validation**: full Go suite green; `pkg/daemon`/`pkg/logging`/
+  `pkg/flowexport` pass; new tests 5/5 flake-clean and `-race` clean;
+  mutation check confirms the apply-wiring test fails when the call is
+  deleted; `go vet` shows no NEW copylocks beyond the pre-existing
+  `NewExporter(*ec)` (count unchanged 2→2). Control-plane fix — no
+  dataplane smoke (no forwarding path touched).
+
 ## 2026-06-20 — #2070 interface-monitor carrier-state read (HIGH, failover-class)
 
 - **Timestamp**: 2026-06-20

--- a/docs/pr/2075-flowexport-reconcile/plan.md
+++ b/docs/pr/2075-flowexport-reconcile/plan.md
@@ -1,7 +1,9 @@
 # #2075 — Reconcile NetFlow v9 / IPFIX exporters on config commit
 
-**Status:** v2 — both hostile reviewers PLAN-NEEDS-MINOR (no kill); all
-findings folded in below. Ready to implement.
+**Status:** IMPLEMENTED — both hostile plan reviewers PLAN-NEEDS-MINOR
+(no kill), all findings folded in (changelog below). Code shipped in
+`pkg/daemon/daemon_flowexport.go` + tests; full Go suite green, new
+tests 5/5 flake-clean + `-race` clean, apply-wiring mutation-verified.
 
 ### Review-fold changelog (v1 → v2)
 

--- a/docs/pr/2075-flowexport-reconcile/plan.md
+++ b/docs/pr/2075-flowexport-reconcile/plan.md
@@ -1,0 +1,296 @@
+# #2075 — Reconcile NetFlow v9 / IPFIX exporters on config commit
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## 1. Issue framing
+
+`pkg/flowexport` exporters (NetFlow v9 + IPFIX) are
+started/stopped **only** at daemon boot/shutdown:
+
+- `startFlowExporter` / `startIPFIXExporter` are invoked only in the
+  one-shot boot sequence (`daemon_run.go:838/843` and the `er==nil`
+  fallback at `857/858`).
+- `stopFlowExporter` / `stopIPFIXExporter` are called only at shutdown
+  (`daemon_run.go:1475/1476`).
+- `applyConfigLocked` (`daemon_apply.go`) re-runs `applySyslogConfig`
+  (step 14b) and `updateFlowTrace` (step 16) but has **zero**
+  flowexport references.
+
+Consequence: any runtime commit that changes
+`forwarding-options sampling` (collector address/port, source-address,
+1-in-N input-rate), adds/removes a sampling instance, changes which
+zones sample, or toggles a v9 export-extension is silently ignored
+until a daemon restart. Worse: if flow export is *not* configured at
+boot but is *added* in a later commit, no exporter ever starts.
+
+The fix: reconcile the flow exporters on every commit in the apply
+path, mirroring how `reconcileRPM` / `reconcileIPMon` / SNMP /
+`updateFlowTrace` already reconcile their subsystems.
+
+## 2. Honest scope / value framing
+
+This is an observability-subsystem correctness fix: committed config
+must take effect without a daemon restart. No crash, no dataplane
+impact, no perf-path change. The win is operator-facing: NetFlow/IPFIX
+sampling config edits become live on `commit`, matching every other
+service in the apply path.
+
+If reviewers conclude the change is unnecessary or that the latent
+callback-leak is out of scope, that is a legitimate finding — but the
+core "config is stored but never enforced" defect is real and
+triage-confirmed.
+
+## 3. The hard part: the EventReader callback model
+
+`startFlowExporter` registers a session-close handler via
+`er.AddCallback(...)` (daemon_flow.go:163) that **closes over the
+boot-time `ec` and `exp`**. The `EventReader` callback list
+(`pkg/logging/ringbuf.go`) is **append-only** with only a clear-ALL
+primitive (`ClearCallbacks`) — there is **no per-callback removal**.
+The same EventReader carries callbacks for the flow exporter, the
+IPFIX exporter, and `updateFlowTrace` (the trace writer).
+
+Therefore a naive "stop then start again" reconcile is **broken**:
+the old boot-time closure stays in `er.callbacks` forever, pointing
+at a closed exporter, and `ClearCallbacks` would also nuke the
+trace-writer callback. Every commit would append yet another closure
+(unbounded leak + writes to closed exporters).
+
+> Note — pre-existing latent leak: `updateFlowTrace`
+> (daemon_flow.go:379) already appends a NEW `tw.HandleEvent`
+> callback on every commit with traceoptions, without removing the
+> prior one (the old TraceWriter is `Close()`d, so its callback now
+> writes to a closed writer). This is the same class of bug. It is
+> **out of scope** for #2075 (tracked separately if desired) — but
+> our flowexport design must NOT add a second instance of it.
+
+### Design: register the callback ONCE, swap the exporter behind a pointer
+
+Register a single, stable indirection callback per exporter family at
+the point the EventReader is created (boot), reading the *current*
+exporter + its *current* resolved `ExportConfig` from daemon fields
+guarded by a mutex. Reconcile then swaps those fields atomically —
+the registered callback never changes, so nothing is ever appended or
+leaked on commit.
+
+```go
+// daemon.go fields (replace the bare *Exporter / cancel / wg with a
+// small holder, or keep fields + add a mutex). Concretely add:
+flowMu        sync.Mutex      // guards flowExporter + flowEC + flowCancel
+flowEC        *flowexport.ExportConfig // live resolved config (for ShouldExport)
+flowHash      [32]byte        // config-hash gate
+flowCBOnce    sync.Once       // register the indirection callback once
+// (mirror for ipfix*)
+```
+
+The stable callback:
+
+```go
+er.AddCallback(func(rec logging.EventRecord, raw []byte) {
+    if rec.Type != "SESSION_CLOSE" {
+        return
+    }
+    d.flowMu.Lock()
+    exp, ec := d.flowExporter, d.flowEC
+    d.flowMu.Unlock()
+    if exp == nil || ec == nil || !ec.ShouldExport(rec.InZone, rec.OutZone) {
+        return
+    }
+    sd := flowexport.SessionCloseData{ ... }   // unchanged extraction
+    exp.ExportSessionClose(rec, sd)
+})
+```
+
+### Reconcile entry point
+
+```go
+// reconcileFlowExporters runs on every apply; CONFIG-HASH-GATED so an
+// unrelated commit never bounces a healthy exporter (and never drops
+// the in-flight template-refresh / sampling counter state). Returns
+// true when it actually (re)started or stopped an exporter.
+func (d *Daemon) reconcileFlowExporters(cfg *config.Config) bool
+```
+
+Behavior:
+
+1. If `d.eventReader == nil` → return false (no event plumbing yet;
+   the boot path will start it). This matches the syslog step 14b
+   guard `if d.eventReader != nil`.
+2. Build the desired resolved config:
+   `ec := BuildExportConfig(&cfg.Services, &cfg.ForwardingOptions)`;
+   if non-nil, fill `ec.SamplingZones = BuildSamplingZones(...)`.
+3. Compute a content hash over the resolved-config inputs. **Hash the
+   config inputs, not the built `*ExportConfig`** — `ExportConfig`
+   carries an unexported `atomic.Uint64 sampleCounter`, but
+   `json.Marshal` ignores unexported fields, so a JSON hash over the
+   resolved `ec` (Collectors, timeouts, SamplingZones, SamplingRate,
+   V9TemplateOpts) is deterministic. Use the same `sha256(json)`
+   helper shape as `rpmConfigHash`. A nil `ec` hashes to a distinct
+   sentinel (so "configured → removed" is a real change).
+4. If hash == stored hash → return false (gated; healthy exporter
+   keeps running with its template-refresh + sampling state intact).
+5. Otherwise: stop the old exporter (`d.flowCancel()` + `flowWg.Wait()`
+   + `Close()` under the swap discipline), then if `ec != nil` start a
+   new one and publish `(exp, ec)` under `flowMu`. Ensure the
+   indirection callback is registered exactly once (`flowCBOnce`).
+   Store the new hash.
+
+The callback registration moves OUT of `startFlowExporter` and into a
+once-guarded path so reconcile and boot share it. `startFlowExporter`
+/ `startIPFIXExporter` become thin wrappers that call
+`reconcileFlowExporters` (boot just calls reconcile), or are removed
+in favor of a single reconcile call at boot. Either way the boot
+call sites collapse to the reconcile.
+
+### Stop/start ordering invariant
+
+`stopFlowExporter` cancels the context, waits the WaitGroup, then
+`Close()`s. The swap must publish `flowExporter=nil` BEFORE
+`flowWg.Wait()` is NOT required — but we must not hold `flowMu` across
+`flowWg.Wait()` (the running `exp.Run` goroutine does not take
+`flowMu`, so there is no deadlock either way; still, take the cancel
+funcs under the lock, release, then Wait, to keep the lock hold short).
+The callback reads `(exp, ec)` under `flowMu`; during a swap a
+session-close event sees either the old pair or the new pair, never a
+torn read — both are valid exporters. A brief window where `exp` is the
+old (cancelled-but-not-yet-Closed) exporter is harmless:
+`ExportSessionClose` on a cancelled exporter just queues into a buffer
+that will be drained/dropped on Close — no panic. (Verify: walk
+`Exporter.ExportSessionClose` / `Close` for a post-Close send hazard;
+if a channel send after Close can panic, publish `nil` first, then
+Wait+Close.)
+
+## 4. Call-site changes
+
+- `daemon_apply.go`: add a step (near 16, after `updateFlowTrace`):
+  `d.reconcileFlowExporters(cfg)`.
+- `daemon_run.go`: replace the two boot start blocks (838-843 and the
+  857-858 fallback) with a single `d.reconcileFlowExporters(cfg)`
+  call in each location, OR keep `startFlowExporter`/`startIPFIXExporter`
+  as wrappers that delegate to reconcile. Boot uses `d.daemonCtx`
+  (set at daemon_run.go:178) the same way reconcile does — so the
+  exporter goroutine is parented to the daemon context, not a
+  per-commit context. (Today boot uses the `ctx` arg which IS
+  `d.daemonCtx`.)
+
+## 5. Public API preservation
+
+- `flowexport.Exporter` / `IPFIXExporter` / `BuildExportConfig` /
+  `BuildIPFIXExportConfig` / `ShouldExport` / `ExportSessionClose` —
+  **unchanged**.
+- `EventReader.AddCallback` / `ClearCallbacks` — **unchanged** (we add
+  no removal API; the once-registered indirection avoids needing one).
+- `stopFlowExporter` / `stopIPFIXExporter` shutdown semantics —
+  **unchanged** (still called at shutdown).
+
+## 6. Hidden invariants the change must preserve
+
+- **No callback leak:** exactly one flow-export callback and one
+  IPFIX callback ever registered on the EventReader, for the daemon's
+  lifetime. Proven by `sync.Once` + a test asserting callback count.
+- **Hash-gate:** an unrelated commit (no sampling/flow-monitoring
+  change) must NOT bounce a running exporter (preserves template
+  refresh + sampling counter). Mirrors RPM/IPMon gating.
+- **Boot parity:** boot still starts the exporter when configured;
+  behavior with flow export configured at boot is unchanged.
+- **Add-after-boot:** flow export added in a later commit now starts
+  (the headline fix).
+- **Remove-after-boot:** flow export removed in a later commit now
+  stops the exporter (was impossible before).
+- **Shutdown:** `stopFlowExporter`/`stopIPFIXExporter` still drain at
+  shutdown; reconcile's swap must leave `flowExporter`/`flowCancel`
+  in a state where the shutdown stop is idempotent (nil-safe).
+- **Concurrency:** `applyConfigLocked` runs under `applySem`; the
+  session-close callback runs on the event-reader goroutine. `flowMu`
+  serializes the swap vs. the callback read. No lock held across
+  `flowWg.Wait()`.
+
+## 7. Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Gated; boot path semantics preserved; new behavior only on a flow-export config change. |
+| Lifetime / goroutine | MED | Stop/start swap + WaitGroup ordering; mitigated by short lock hold + nil-publish-before-Close if post-Close send can panic. |
+| Performance | LOW | Per-commit only (slow path); callback adds one mutex lock per SESSION_CLOSE event — events are already callback-dispatched and rate-bounded by session closes, not per-packet. |
+| Architectural mismatch | LOW | Directly mirrors the established `reconcileRPM`/`reconcileIPMon` pattern in the same file. |
+
+## 8. Test plan (control-plane — NO dataplane smoke)
+
+Per the campaign triage: this is a control-plane fix; cover with Go
+unit tests in `pkg/daemon`. Tests must FAIL if the reconcile call is
+removed (non-tautological). Gates:
+
+- `go build ./...` clean.
+- New `pkg/daemon/daemon_flowexport_reconcile_test.go`:
+  1. **Add-after-boot:** Daemon with a non-nil EventReader and no
+     flow export configured; `reconcileFlowExporters(cfgWithSampling)`
+     returns true and `d.flowExporter != nil`.
+  2. **Remove-after-boot:** from configured → empty config; reconcile
+     returns true and `d.flowExporter == nil` (and the exporter
+     goroutine drained).
+  3. **Hash-gate:** identical config twice → second returns false; a
+     semantically-equal freshly-built config also gated (content
+     hash).
+  4. **Change re-applies:** changing collector address/port/rate →
+     reconcile returns true.
+  5. **No callback leak:** after N reconciles the EventReader has
+     exactly one flow callback (+ one ipfix callback) — assert via a
+     test accessor on EventReader callback count, or a recorder seam.
+  6. **Removal-of-the-reconcile-call regression guard:** a test that
+     drives `applyConfigLocked` (or a thin seam it calls) and asserts
+     the exporter started — so deleting the step-16.x line fails a
+     test. If wiring full `applyConfigLocked` is too heavy, assert at
+     minimum that `reconcileFlowExporters` is invoked by the apply
+     path via a recorder/seam.
+- 5x flake check on the most timing-sensitive new test (goroutine
+  start/stop).
+- Full `go test ./...` (30 Go packages) green.
+- `pkg/flowexport` existing tests still pass.
+
+No iperf / CoS / cluster smoke — the issue explicitly states
+control-plane, no dataplane path touched.
+
+## 9. Out of scope (explicitly)
+
+- The `updateFlowTrace` latent callback leak (same class, different
+  subsystem) — note it, do not fix it here.
+- Adding a per-callback removal API to EventReader — the once-guarded
+  indirection makes it unnecessary.
+- Any change to NetFlow/IPFIX wire encoding or sampling math.
+- HA / session-sync interaction (exporters are node-local).
+
+## 10. Open questions for adversarial review (any may justify PLAN-KILL)
+
+1. Is the **once-registered indirection callback** the right design,
+   or should we instead add a real `RemoveCallback`/handle API to
+   EventReader and re-register per reconcile? (Indirection avoids API
+   churn + the clear-all hazard; is there a correctness reason to
+   prefer explicit removal?)
+2. Is hashing the **resolved `*ExportConfig` JSON** safe given the
+   unexported `atomic.Uint64 sampleCounter` (ignored by
+   `json.Marshal`)? Should we instead hash the raw config inputs
+   (`cfg.Services.FlowMonitoring` + `cfg.ForwardingOptions.Sampling` +
+   the zone-ID map)? Which is less fragile to future field additions?
+3. **Post-Close send hazard:** RESOLVED by source walk —
+   `Exporter.ExportSessionClose` calls only `e.batch.add(fr)`
+   (transport.go:102, a mutex-guarded slice append; NOT a channel),
+   and `Close()` only closes UDP connections (`conns.close()`). A
+   post-Close `ExportSessionClose` therefore just appends to an
+   in-memory batch that is never flushed — harmless, no panic. The
+   swap ordering is forgiving. We still publish `(exp, ec)`
+   atomically under `flowMu` for a clean read; nil-before-Close is
+   not required for safety. (Reviewers: confirm IPFIX
+   `ExportSessionClose` has the same shape — it does per
+   ipfix.go:341.)
+4. Should `reconcileFlowExporters` be **one** function handling both
+   v9 and IPFIX, or two parallel functions? (RPM has one; the two
+   exporters share zone-ID building and the callback shape.)
+5. Is the **lock-ordering** (`flowMu` short hold, never across
+   `flowWg.Wait()`) actually deadlock-free given `Exporter.Run`
+   does not take `flowMu`? Any path where the event-reader goroutine
+   blocks on a full channel while reconcile holds `flowMu` and waits
+   on that goroutine?
+6. Does running reconcile under `applySem` while the session-close
+   callback fires on the event-reader goroutine introduce any
+   ordering hazard with `applySyslogConfig` (which mutates the same
+   EventReader's zone/policy/if-name maps under their own RW locks)?

--- a/docs/pr/2075-flowexport-reconcile/plan.md
+++ b/docs/pr/2075-flowexport-reconcile/plan.md
@@ -1,6 +1,73 @@
 # #2075 — Reconcile NetFlow v9 / IPFIX exporters on config commit
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** v2 — both hostile reviewers PLAN-NEEDS-MINOR (no kill); all
+findings folded in below. Ready to implement.
+
+### Review-fold changelog (v1 → v2)
+
+- **[MAJOR, both reviewers]** Boot start is load-bearing in the
+  post-EventReader block, NOT the apply-path step. Boot's
+  `applyConfig` runs at `daemon_run.go:671`, BEFORE the EventReader is
+  created (`778` native / `853` userspace fallback). The apply-path
+  `reconcileFlowExporters` therefore no-ops at boot (`eventReader ==
+  nil` guard). The post-EventReader reconcile call (replacing the
+  `daemon_run.go:836-862` start blocks) is what starts the exporter at
+  boot; the apply-path step is **additive** for later commits. Do NOT
+  delete the post-EventReader block. (§4 rewritten.)
+- **[MAJOR-1, reviewer B]** v1's claim "boot `ctx` IS `d.daemonCtx`" is
+  FALSE. `daemon_run.go:178` sets `d.daemonCtx = ctx`, but `697-700`
+  REASSIGNS the local `ctx` to `signal.NotifyContext(...)`. So today's
+  boot exporter goroutine is cancelled by `stop()` (signal child) at
+  `1471`, before the explicit `stopFlowExporter` at `1475`. Reconcile
+  derives the exporter's cancel from `d.daemonCtx` (mirroring
+  `reconcileRPM`), so after this change the goroutine dies ONLY via the
+  explicit `flowCancel()` in `stopFlowExporter`/swap — which still runs
+  at shutdown. Authoritative-stop invariant: `flowCancel =
+  WithCancel(d.daemonCtx)` and shutdown's `stopFlowExporter` remains
+  the stop path. (§3, §4 updated.)
+- **[MAJOR-2 / criterion 6, both]** Drop the recorder/seam fallback for
+  the apply-wiring test. Mandate a test that drives the REAL
+  `applyConfigLocked` and asserts `d.flowExporter != nil` — fails iff
+  the apply-path call is deleted. Template: `daemon_snmp_reconcile_test.go`
+  (already drives real `applyConfigLocked` with
+  `applySem: semaphore.NewWeighted(1)`, a runtime-only test DP, and a
+  config store). (§8 rewritten.)
+- **[MINOR, both]** Hash contradiction resolved: hash the **resolved
+  `*ExportConfig`** (after `SamplingZones` is filled), JSON+sha256,
+  **two separate hashes** (v9 + IPFIX) so a single-family change never
+  cross-bounces the other. `sampleCounter` (unexported `atomic.Uint64`)
+  is invisible to `json.Marshal`; `map[uint16]SamplingDir` marshals with
+  numerically-sorted keys → deterministic. (§3 step 3 updated.)
+- **[MINOR, B] sampleCounter ownership clarified:** the exporter never
+  calls `ShouldExport` (only the daemon callback does, daemon_flow.go:
+  168/230). So the exporter's by-value `cfg.sampleCounter` copy is dead;
+  the daemon-held `*ExportConfig` is the SOLE 1-in-N counter owner.
+  Therefore `flowEC` MUST be a `*ExportConfig` (pointer) — a value
+  field would copy the atomic and split the counter. (§3 updated.)
+- **[MINOR, B] copylocks:** `go vet ./pkg/flowexport ./pkg/daemon`
+  ALREADY reports pre-existing copylocks on `NewExporter(cfg
+  ExportConfig)` / `NewExporter(*ec)` (atomic.Uint64 by value). The swap
+  introduces NO NEW vet class. We do not add extra by-value
+  `ExportConfig` copies beyond the unavoidable `NewExporter(*ec)` already
+  present. Changing `NewExporter` to take `*ExportConfig` is out of
+  scope. (§9.)
+- **[MINOR-3, B → ADOPTED] Replace the per-event mutex with
+  `atomic.Pointer[exporterBundle]`.** The callback must read `(exp, ec)`
+  as a consistent pair; an `atomic.Pointer` to an immutable
+  `{exp *Exporter; ec *ExportConfig}` bundle makes the read lock-free and
+  eliminates the "never hold a mutex across `flowWg.Wait()`" footgun
+  entirely. Reconcile builds a new bundle and `Store`s it; a stale read
+  during a swap sees either the old or new bundle — both valid. (§3.)
+- **[MINOR, B] abort-side placement:** the reconcile step lands AFTER
+  `updateFlowTrace` (step ~16), i.e. below the `compileErrorMustAbortApply`
+  early-return at `daemon_apply.go:693-696`. Consistent with
+  reconcileRPM/IPMon/syslog: an aborting commit defers the exporter
+  change to the next clean commit. Stated as a deliberate choice. (§4.)
+- **[MINOR, both] shutdown idempotency:** reconcile sets the bundle to a
+  nil-exporter bundle (and clears `flowCancel`) after a stop, so the
+  shutdown `stopFlowExporter` is nil-safe and `flowCancel()` double-call
+  is harmless (stdlib CancelFunc is idempotent). (§6.)
+
 
 ## 1. Issue framing
 
@@ -64,42 +131,64 @@ trace-writer callback. Every commit would append yet another closure
 > **out of scope** for #2075 (tracked separately if desired) — but
 > our flowexport design must NOT add a second instance of it.
 
-### Design: register the callback ONCE, swap the exporter behind a pointer
+### Design: register the callback ONCE, swap an immutable bundle via atomic.Pointer
 
 Register a single, stable indirection callback per exporter family at
 the point the EventReader is created (boot), reading the *current*
-exporter + its *current* resolved `ExportConfig` from daemon fields
-guarded by a mutex. Reconcile then swaps those fields atomically —
-the registered callback never changes, so nothing is ever appended or
-leaked on commit.
+exporter + its *current* resolved `*ExportConfig` from an
+`atomic.Pointer` to an immutable bundle. Reconcile builds a new bundle
+and `Store`s it — the registered callback never changes, so nothing is
+ever appended or leaked on commit, and the read is lock-free.
 
 ```go
-// daemon.go fields (replace the bare *Exporter / cancel / wg with a
-// small holder, or keep fields + add a mutex). Concretely add:
-flowMu        sync.Mutex      // guards flowExporter + flowEC + flowCancel
-flowEC        *flowexport.ExportConfig // live resolved config (for ShouldExport)
-flowHash      [32]byte        // config-hash gate
-flowCBOnce    sync.Once       // register the indirection callback once
-// (mirror for ipfix*)
+// flowexport bundle: immutable once built; swapped atomically.
+type exporterBundle struct {
+    exp *flowexport.Exporter
+    ec  *flowexport.ExportConfig // pointer — SOLE 1-in-N counter owner
+}
+type ipfixBundle struct {
+    exp *flowexport.IPFIXExporter
+    ec  *flowexport.ExportConfig
+}
+
+// daemon.go fields (keep flowExporter/flowCancel/flowWg for shutdown
+// stop; ADD):
+flowBundle    atomic.Pointer[exporterBundle] // live (exp, ec) for the callback
+flowHash      [32]byte                        // v9 config-hash gate
+flowCBOnce    sync.Once                        // register the v9 callback once
+flowReconMu   sync.Mutex                       // serialize swap vs. shutdown stop
+ipfixBundlePtr atomic.Pointer[ipfixBundle]
+ipfixHash     [32]byte
+ipfixCBOnce   sync.Once
+ipfixReconMu  sync.Mutex
 ```
 
-The stable callback:
+The stable callback (read is lock-free; no mutex per session-close):
 
 ```go
 er.AddCallback(func(rec logging.EventRecord, raw []byte) {
     if rec.Type != "SESSION_CLOSE" {
         return
     }
-    d.flowMu.Lock()
-    exp, ec := d.flowExporter, d.flowEC
-    d.flowMu.Unlock()
-    if exp == nil || ec == nil || !ec.ShouldExport(rec.InZone, rec.OutZone) {
+    b := d.flowBundle.Load()
+    if b == nil || b.exp == nil || b.ec == nil ||
+        !b.ec.ShouldExport(rec.InZone, rec.OutZone) {
         return
     }
     sd := flowexport.SessionCloseData{ ... }   // unchanged extraction
-    exp.ExportSessionClose(rec, sd)
+    b.exp.ExportSessionClose(rec, sd)
 })
 ```
+
+`flowReconMu` serializes the reconcile swap against the shutdown
+`stopFlowExporter` (both touch `flowCancel`/`flowWg`); it is NOT held
+across the lock-free callback read. `b.ec` is a `*ExportConfig` because
+the exporter never reads `sampleCounter` (only the callback's
+`ShouldExport` does) — the daemon-held `ec` is the sole 1-in-N counter
+owner. The exporter's cancel is derived from `d.daemonCtx`
+(`flowCancel = WithCancel(d.daemonCtx)`), mirroring `reconcileRPM`; the
+goroutine dies only via the explicit `flowCancel()` in the swap /
+shutdown stop.
 
 ### Reconcile entry point
 
@@ -119,21 +208,27 @@ Behavior:
 2. Build the desired resolved config:
    `ec := BuildExportConfig(&cfg.Services, &cfg.ForwardingOptions)`;
    if non-nil, fill `ec.SamplingZones = BuildSamplingZones(...)`.
-3. Compute a content hash over the resolved-config inputs. **Hash the
-   config inputs, not the built `*ExportConfig`** — `ExportConfig`
-   carries an unexported `atomic.Uint64 sampleCounter`, but
-   `json.Marshal` ignores unexported fields, so a JSON hash over the
-   resolved `ec` (Collectors, timeouts, SamplingZones, SamplingRate,
-   V9TemplateOpts) is deterministic. Use the same `sha256(json)`
-   helper shape as `rpmConfigHash`. A nil `ec` hashes to a distinct
-   sentinel (so "configured → removed" is a real change).
+3. Compute a content hash over the **resolved `*ExportConfig`** (AFTER
+   `SamplingZones` is filled, so a zone-only change is detected). JSON +
+   sha256, same helper shape as `rpmConfigHash`. `ExportConfig`'s
+   unexported `atomic.Uint64 sampleCounter` is ignored by
+   `json.Marshal`; `map[uint16]SamplingDir` marshals with
+   numerically-sorted keys → deterministic. A nil `ec` hashes to a
+   distinct sentinel (so "configured → removed" is a real change).
+   **Two separate hashes** — `flowHash` (v9) and `ipfixHash` — so a
+   single-family change never cross-bounces the other family.
 4. If hash == stored hash → return false (gated; healthy exporter
-   keeps running with its template-refresh + sampling state intact).
-5. Otherwise: stop the old exporter (`d.flowCancel()` + `flowWg.Wait()`
-   + `Close()` under the swap discipline), then if `ec != nil` start a
-   new one and publish `(exp, ec)` under `flowMu`. Ensure the
-   indirection callback is registered exactly once (`flowCBOnce`).
-   Store the new hash.
+   keeps running with its template-refresh + sampling-counter state
+   intact — the headline reason for gating).
+5. Otherwise: stop the old exporter under `flowReconMu`
+   (`flowCancel()` + `flowWg.Wait()` + `Close()`), then if `ec != nil`
+   build a fresh exporter (`flowCancel = WithCancel(d.daemonCtx)`,
+   start its `Run` goroutine on `flowWg`) and `flowBundle.Store(&{exp,
+   ec})`; if `ec == nil`, `flowBundle.Store(&{nil, nil})` and clear
+   `flowCancel`. Register the indirection callback exactly once
+   (`flowCBOnce`). Store the new hash. `flowReconMu` is released before
+   any lock-free callback read can observe a torn pair — the bundle is
+   swapped as one atomic pointer.
 
 The callback registration moves OUT of `startFlowExporter` and into a
 once-guarded path so reconcile and boot share it. `startFlowExporter`
@@ -162,16 +257,34 @@ Wait+Close.)
 
 ## 4. Call-site changes
 
-- `daemon_apply.go`: add a step (near 16, after `updateFlowTrace`):
-  `d.reconcileFlowExporters(cfg)`.
-- `daemon_run.go`: replace the two boot start blocks (838-843 and the
-  857-858 fallback) with a single `d.reconcileFlowExporters(cfg)`
-  call in each location, OR keep `startFlowExporter`/`startIPFIXExporter`
-  as wrappers that delegate to reconcile. Boot uses `d.daemonCtx`
-  (set at daemon_run.go:178) the same way reconcile does — so the
-  exporter goroutine is parented to the daemon context, not a
-  per-commit context. (Today boot uses the `ctx` arg which IS
-  `d.daemonCtx`.)
+- `daemon_apply.go`: add a step AFTER `updateFlowTrace` (step ~16),
+  i.e. BELOW the `compileErrorMustAbortApply` early-return
+  (`daemon_apply.go:693-696`): `d.reconcileFlowExporters(cfg)`.
+  Deliberate abort-side placement, consistent with reconcileRPM /
+  reconcileIPMon / applySyslogConfig: an aborting commit defers the
+  exporter change to the next clean commit. (SNMP was deliberately
+  placed ABOVE the abort; flowexport is observability and follows the
+  RPM/IPMon side — stated as a choice.)
+- `daemon_run.go`: the two boot start blocks
+  (`836-844` native, `857-858` userspace fallback) each become a single
+  `d.reconcileFlowExporters(cfg)` call. **These post-EventReader
+  blocks are LOAD-BEARING** — they are what start the exporter at boot,
+  because the earlier boot `applyConfig` at `daemon_run.go:671` runs
+  while `d.eventReader == nil` (the EventReader is created at `778` /
+  `853`), so the apply-path step no-ops at boot. Do NOT delete these.
+- **Context:** the exporter goroutine is parented to `d.daemonCtx`
+  (set at `daemon_run.go:178`), mirroring `reconcileRPM`. NOTE the
+  correction from v1: boot's local `ctx` is the signal child
+  (`signal.NotifyContext` at `697-700`), NOT `d.daemonCtx`. After this
+  change the goroutine is no longer cancelled by `stop()` at `1471`;
+  it dies via the explicit `flowCancel()` in `stopFlowExporter` (still
+  called at shutdown, `1475`). `flowCancel = WithCancel(d.daemonCtx)`
+  keeps shutdown authoritative.
+- `startFlowExporter` / `startIPFIXExporter` are folded into
+  `reconcileFlowExporters` (the callback registration moves into the
+  `flowCBOnce`/`ipfixCBOnce` path). The shutdown `stopFlowExporter` /
+  `stopIPFIXExporter` remain unchanged (still called at shutdown,
+  nil-safe).
 
 ## 5. Public API preservation
 
@@ -224,28 +337,50 @@ removed (non-tautological). Gates:
 - New `pkg/daemon/daemon_flowexport_reconcile_test.go`:
   1. **Add-after-boot:** Daemon with a non-nil EventReader and no
      flow export configured; `reconcileFlowExporters(cfgWithSampling)`
-     returns true and `d.flowExporter != nil`.
+     returns true and `d.flowBundle.Load().exp != nil`.
   2. **Remove-after-boot:** from configured → empty config; reconcile
-     returns true and `d.flowExporter == nil` (and the exporter
-     goroutine drained).
-  3. **Hash-gate:** identical config twice → second returns false; a
-     semantically-equal freshly-built config also gated (content
-     hash).
+     returns true and the bundle's exporter is nil (goroutine drained
+     — assert via `flowWg.Wait()` returning / a closed exporter).
+  3. **Hash-gate (counter-preserving):** identical config twice →
+     second returns false; a semantically-equal freshly-built config
+     also gated (content hash). Assert the SAME exporter instance is
+     still live after the gated call (the counter/template state is
+     not reset).
   4. **Change re-applies:** changing collector address/port/rate →
-     reconcile returns true.
+     reconcile returns true and swaps to a new exporter instance.
   5. **No callback leak:** after N reconciles the EventReader has
-     exactly one flow callback (+ one ipfix callback) — assert via a
-     test accessor on EventReader callback count, or a recorder seam.
-  6. **Removal-of-the-reconcile-call regression guard:** a test that
-     drives `applyConfigLocked` (or a thin seam it calls) and asserts
-     the exporter started — so deleting the step-16.x line fails a
-     test. If wiring full `applyConfigLocked` is too heavy, assert at
-     minimum that `reconcileFlowExporters` is invoked by the apply
-     path via a recorder/seam.
+     exactly one flow callback (+ one ipfix callback). Add a tiny
+     test-only accessor `EventReader.CallbackCount()` (under
+     `callbackMu.RLock`) in `pkg/logging` — used only by the test;
+     mirrors existing test accessors. (The `sync.Once` guarantees this,
+     but the test makes the leak class regress-detectable.)
+  6. **Apply-wiring regression guard (NON-tautological — MANDATORY):**
+     drive the REAL `applyConfigLocked` with a config that enables
+     sampling and assert the exporter started. Template:
+     `daemon_snmp_reconcile_test.go` — construct
+     `&Daemon{applySem: semaphore.NewWeighted(1), dp:
+     <runtimeOnlyApplyTestDP>, store: <configStore>, eventReader:
+     <non-nil>, daemonCtx: ctx, opts: {NoDataplane:true}}`, call
+     `applyConfigLocked(cfgWithSampling)`, assert
+     `d.flowBundle.Load().exp != nil`. This FAILS iff the
+     `reconcileFlowExporters` call is deleted from `applyConfigLocked`.
+     No recorder/seam fallback.
+  7. **v9/IPFIX independence:** v9 configured, IPFIX added in a later
+     commit → IPFIX starts, the v9 exporter instance is untouched
+     (same pointer).
 - 5x flake check on the most timing-sensitive new test (goroutine
-  start/stop).
+  start/stop — test 2 or 4).
+- `go vet ./pkg/daemon/...` shows NO NEW copylocks beyond the
+  pre-existing `NewExporter(*ec)` noise (documented in §9).
 - Full `go test ./...` (30 Go packages) green.
 - `pkg/flowexport` existing tests still pass.
+
+The exporters bind UDP collector sockets in `NewExporter`
+(`dialCollectors`). Tests use a loopback/`127.0.0.1:<port>` collector
+(or `:0`) so `NewExporter` succeeds without external dependencies —
+verify `dialCollectors` accepts an unreachable UDP collector (UDP
+connect does not require a listener). If it requires a resolvable
+address, the test config uses `127.0.0.1:9995`.
 
 No iperf / CoS / cluster smoke — the issue explicitly states
 control-plane, no dataplane path touched.
@@ -258,19 +393,25 @@ control-plane, no dataplane path touched.
   indirection makes it unnecessary.
 - Any change to NetFlow/IPFIX wire encoding or sampling math.
 - HA / session-sync interaction (exporters are node-local).
+- **Pre-existing copylocks:** `go vet ./pkg/flowexport ./pkg/daemon`
+  already reports copylocks on `NewExporter(cfg ExportConfig)` /
+  `NewExporter(*ec)` (ExportConfig embeds `atomic.Uint64`). There is no
+  `go vet` CI gate, so these are latent. Changing
+  `NewExporter`/`NewIPFIXExporter` to take `*ExportConfig` would fix the
+  root cause but is a separate refactor. This PR adds NO new by-value
+  `ExportConfig` copy beyond the existing `NewExporter(*ec)`.
 
-## 10. Open questions for adversarial review (any may justify PLAN-KILL)
+## 10. Open questions — RESOLVED by adversarial review
 
-1. Is the **once-registered indirection callback** the right design,
-   or should we instead add a real `RemoveCallback`/handle API to
-   EventReader and re-register per reconcile? (Indirection avoids API
-   churn + the clear-all hazard; is there a correctness reason to
-   prefer explicit removal?)
+1. **Once-registered indirection vs RemoveCallback API:** indirection
+   chosen. Both reviewers confirmed `applySyslogConfig` does NOT touch
+   `er.callbacks` / `ClearCallbacks`, so the once-indirection is safe
+   and avoids API churn. RESOLVED.
 2. Is hashing the **resolved `*ExportConfig` JSON** safe given the
    unexported `atomic.Uint64 sampleCounter` (ignored by
-   `json.Marshal`)? Should we instead hash the raw config inputs
-   (`cfg.Services.FlowMonitoring` + `cfg.ForwardingOptions.Sampling` +
-   the zone-ID map)? Which is less fragile to future field additions?
+   `json.Marshal`)? RESOLVED — both reviewers verified `json.Marshal`
+   ignores `sampleCounter` and sorts the `map[uint16]` keys; hash the
+   resolved `ec` (after zones filled), two separate hashes.
 3. **Post-Close send hazard:** RESOLVED by source walk —
    `Exporter.ExportSessionClose` calls only `e.batch.add(fr)`
    (transport.go:102, a mutex-guarded slice append; NOT a channel),

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -140,6 +140,24 @@ type Daemon struct {
 	ipfixExporter              *flowexport.IPFIXExporter
 	ipfixCancel                context.CancelFunc
 	ipfixWg                    sync.WaitGroup
+	// #2075 flowexport reconcile state. The bundle pointers carry the
+	// live (exporter, resolved-config) pair read lock-free by the
+	// once-registered session-close callbacks; reconcile swaps them
+	// atomically. The per-family hashes gate the reconcile so an
+	// unrelated commit never bounces a healthy exporter; the *HashSet
+	// bools distinguish "never reconciled" from "reconciled to the
+	// nil sentinel". The *ReconMu serialize the reconcile swap against
+	// shutdown's stopFlow/IPFIXExporter (both touch the cancel/wg).
+	flowBundle     atomic.Pointer[exporterBundle]
+	flowHash       [32]byte
+	flowHashSet    bool
+	flowCBOnce     sync.Once
+	flowReconMu    sync.Mutex
+	ipfixBundlePtr atomic.Pointer[ipfixBundle]
+	ipfixHash      [32]byte
+	ipfixHashSet   bool
+	ipfixCBOnce    sync.Once
+	ipfixReconMu   sync.Mutex
 	dhcpRelay                  *dhcprelay.Manager
 	snmpAgent                  *snmp.Agent
 	lldpMgr                    *lldp.Manager

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1197,6 +1197,17 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	// 16. Update flow traceoptions (trace file + filters)
 	d.updateFlowTrace(cfg)
 
+	// 16b. Reconcile the NetFlow v9 / IPFIX exporters (#2075). Before
+	// this, the exporters were only started at boot and stopped at
+	// shutdown, so forwarding-options sampling / flow-monitoring config
+	// changes were ignored until a daemon restart (and flow export
+	// added in a later commit never started). Hash-gated per family so
+	// an unrelated commit never bounces a healthy exporter. Placed
+	// below the dataplane-apply abort (consistent with reconcileRPM /
+	// applySyslogConfig): an aborting commit defers the exporter change
+	// to the next clean commit.
+	d.reconcileFlowExporters(cfg)
+
 	// 17. Update event-options policies (RPM-driven failover)
 	if d.eventEngine != nil {
 		d.eventEngine.Apply(cfg.EventOptions)

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -11,7 +11,6 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/psaab/xpf/pkg/dhcp"
-	"github.com/psaab/xpf/pkg/flowexport"
 	"github.com/psaab/xpf/pkg/frr"
 	"github.com/psaab/xpf/pkg/logging"
 	"github.com/vishvananda/netlink"
@@ -137,62 +136,16 @@ func logFinalStats(ready dataplaneReadyProbe, telemetry dataplane.Telemetry) {
 	slog.Info("final statistics", attrs...)
 }
 
-// startFlowExporter starts the NetFlow v9 exporter if configured.
-func (d *Daemon) startFlowExporter(ctx context.Context, cfg *config.Config, er *logging.EventReader) {
-	ec := flowexport.BuildExportConfig(&cfg.Services, &cfg.ForwardingOptions)
-	if ec == nil {
-		return
-	}
-
-	// Build per-zone sampling direction flags using deterministic zone IDs
-	// (same sorted assignment as dataplane compiler).
-	zoneIDs := buildZoneIDs(cfg)
-	ec.SamplingZones = flowexport.BuildSamplingZones(cfg, zoneIDs)
-
-	exp, err := flowexport.NewExporter(*ec)
-	if err != nil {
-		slog.Warn("failed to create flow exporter", "err", err)
-		return
-	}
-
-	flowCtx, cancel := context.WithCancel(ctx)
-	d.flowExporter = exp
-	d.flowCancel = cancel
-
-	// Register callback for session close events
-	er.AddCallback(func(rec logging.EventRecord, raw []byte) {
-		if rec.Type != "SESSION_CLOSE" {
-			return
-		}
-		// Check sampling direction: skip if zone has no sampling enabled
-		if !ec.ShouldExport(rec.InZone, rec.OutZone) {
-			return
-		}
-		sd := flowexport.SessionCloseData{
-			SrcPort:  parseSrcPort(rec.SrcAddr),
-			DstPort:  parseSrcPort(rec.DstAddr),
-			Protocol: parseProtocol(rec.Protocol),
-		}
-		sd.SrcIP, sd.DstIP, sd.IsIPv6 = parseAddrPair(rec.SrcAddr, rec.DstAddr)
-		exp.ExportSessionClose(rec, sd)
-	})
-
-	d.flowWg.Add(1)
-	go func() {
-		defer d.flowWg.Done()
-		exp.Run(flowCtx)
-	}()
-
-	slog.Info("NetFlow v9 exporter started",
-		"collectors", len(ec.Collectors),
-		"active_timeout", ec.FlowActiveTimeout,
-		"inactive_timeout", ec.FlowInactiveTimeout,
-		"sampling_zones", len(ec.SamplingZones),
-		"sampling_rate", ec.SamplingRate)
-}
-
-// stopFlowExporter stops the running flow exporter.
+// stopFlowExporter stops the running NetFlow v9 exporter (shutdown).
+//
+// #2075: the exporter is now (re)started by reconcileFlowExporters, not
+// startFlowExporter. This stop is called only at shutdown. It takes
+// flowReconMu so it cannot race a concurrent reconcile swap, and it is
+// nil-safe / idempotent (a reconcile that already stopped the exporter
+// leaves flowCancel/flowExporter nil; context.CancelFunc is idempotent).
 func (d *Daemon) stopFlowExporter() {
+	d.flowReconMu.Lock()
+	defer d.flowReconMu.Unlock()
 	if d.flowCancel != nil {
 		d.flowCancel()
 	}
@@ -201,60 +154,14 @@ func (d *Daemon) stopFlowExporter() {
 		d.flowExporter.Close()
 		d.flowExporter = nil
 	}
+	d.flowCancel = nil
+	d.flowBundle.Store(&exporterBundle{})
 }
 
-// startIPFIXExporter starts the IPFIX (NetFlow v10) exporter if configured.
-func (d *Daemon) startIPFIXExporter(ctx context.Context, cfg *config.Config, er *logging.EventReader) {
-	ec := flowexport.BuildIPFIXExportConfig(&cfg.Services, &cfg.ForwardingOptions)
-	if ec == nil {
-		return
-	}
-
-	zoneIDs := buildZoneIDs(cfg)
-	ec.SamplingZones = flowexport.BuildSamplingZones(cfg, zoneIDs)
-
-	exp, err := flowexport.NewIPFIXExporter(*ec)
-	if err != nil {
-		slog.Warn("failed to create IPFIX exporter", "err", err)
-		return
-	}
-
-	ipfixCtx, cancel := context.WithCancel(ctx)
-	d.ipfixExporter = exp
-	d.ipfixCancel = cancel
-
-	er.AddCallback(func(rec logging.EventRecord, raw []byte) {
-		if rec.Type != "SESSION_CLOSE" {
-			return
-		}
-		if !ec.ShouldExport(rec.InZone, rec.OutZone) {
-			return
-		}
-		sd := flowexport.SessionCloseData{
-			SrcPort:  parseSrcPort(rec.SrcAddr),
-			DstPort:  parseSrcPort(rec.DstAddr),
-			Protocol: parseProtocol(rec.Protocol),
-		}
-		sd.SrcIP, sd.DstIP, sd.IsIPv6 = parseAddrPair(rec.SrcAddr, rec.DstAddr)
-		exp.ExportSessionClose(rec, sd)
-	})
-
-	d.ipfixWg.Add(1)
-	go func() {
-		defer d.ipfixWg.Done()
-		exp.Run(ipfixCtx)
-	}()
-
-	slog.Info("IPFIX exporter started",
-		"collectors", len(ec.Collectors),
-		"active_timeout", ec.FlowActiveTimeout,
-		"inactive_timeout", ec.FlowInactiveTimeout,
-		"sampling_zones", len(ec.SamplingZones),
-		"sampling_rate", ec.SamplingRate)
-}
-
-// stopIPFIXExporter stops the running IPFIX exporter.
+// stopIPFIXExporter stops the running IPFIX exporter (shutdown).
 func (d *Daemon) stopIPFIXExporter() {
+	d.ipfixReconMu.Lock()
+	defer d.ipfixReconMu.Unlock()
 	if d.ipfixCancel != nil {
 		d.ipfixCancel()
 	}
@@ -263,6 +170,8 @@ func (d *Daemon) stopIPFIXExporter() {
 		d.ipfixExporter.Close()
 		d.ipfixExporter = nil
 	}
+	d.ipfixCancel = nil
+	d.ipfixBundlePtr.Store(&ipfixBundle{})
 }
 
 // parseAddrPair parses "ip:port" or "[ip]:port" into net.IPs and IPv6 flag.

--- a/pkg/daemon/daemon_flowexport.go
+++ b/pkg/daemon/daemon_flowexport.go
@@ -158,10 +158,15 @@ func (d *Daemon) reconcileV9Exporter(cfg *config.Config) bool {
 	exp, err := flowexport.NewExporter(*ec)
 	if err != nil {
 		slog.Warn("failed to create flow exporter", "err", err)
-		// Leave the (stopped) state published; record the hash so we do
-		// not spin retrying every commit. A config change re-attempts.
+		// Do NOT record the hash on a create failure: NewExporter ->
+		// dialCollectors can fail transiently (a pinned source-address
+		// bind before the source interface is up, transient collector
+		// DNS). Leaving flowHashSet false means the NEXT commit (even an
+		// identical one) retries instead of being hash-gated into a
+		// permanently-dead exporter. NewExporter is cheap, so the retry
+		// is safe; the gate re-arms on the first successful start.
 		d.flowBundle.Store(&exporterBundle{})
-		d.flowHash, d.flowHashSet = h, true
+		d.flowHashSet = false
 		return true
 	}
 
@@ -226,8 +231,11 @@ func (d *Daemon) reconcileIPFIXExporter(cfg *config.Config) bool {
 	exp, err := flowexport.NewIPFIXExporter(*ec)
 	if err != nil {
 		slog.Warn("failed to create IPFIX exporter", "err", err)
+		// Do NOT record the hash on a create failure (see the v9 path):
+		// leaving ipfixHashSet false lets the next commit retry instead
+		// of being gated into a permanently-dead exporter.
 		d.ipfixBundlePtr.Store(&ipfixBundle{})
-		d.ipfixHash, d.ipfixHashSet = h, true
+		d.ipfixHashSet = false
 		return true
 	}
 

--- a/pkg/daemon/daemon_flowexport.go
+++ b/pkg/daemon/daemon_flowexport.go
@@ -1,0 +1,302 @@
+// daemon_flowexport.go — NetFlow v9 / IPFIX exporter lifecycle wiring
+// (#2075).
+//
+// Before #2075 the flow exporters were started once at daemon boot and
+// stopped only at shutdown: the apply path (daemon_apply.go) had zero
+// flowexport references, so a runtime commit that changed
+// forwarding-options sampling (collector address/port, source-address,
+// 1-in-N input-rate, which zones sample, a v9 export-extension) was
+// silently ignored until a daemon restart — and flow export ADDED in a
+// later commit never started at all.
+//
+// reconcileFlowExporters runs on every apply (and at boot, after the
+// EventReader exists) but is CONFIG-HASH-GATED per family: it
+// (re)starts or stops an exporter only when the rendered v9 / IPFIX
+// stanza actually changed, so an unrelated commit never bounces a
+// healthy exporter (preserving its template-refresh cadence and the
+// 1-in-N sampling counter).
+//
+// The EventReader callback list is append-only with only a clear-ALL
+// primitive (no per-callback removal), and the same EventReader carries
+// callbacks for the trace writer too. A naive stop/start reconcile
+// would therefore leak a closure (closed over a now-closed exporter) on
+// every commit. Instead we register a single stable indirection
+// callback per family exactly once (flowCBOnce / ipfixCBOnce) that
+// reads the live (exporter, config) pair from an atomic.Pointer bundle;
+// reconcile swaps the bundle atomically. The exporter never reads the
+// config's 1-in-N sampleCounter (only the callback's ShouldExport
+// does), so the daemon-held *ExportConfig is the sole counter owner and
+// is held by pointer in the bundle.
+package daemon
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/flowexport"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// exporterBundle is the immutable (exporter, resolved-config) pair the
+// NetFlow v9 session-close callback reads via d.flowBundle. A nil exp
+// means "no v9 exporter configured".
+type exporterBundle struct {
+	exp *flowexport.Exporter
+	ec  *flowexport.ExportConfig
+}
+
+// ipfixBundle is the IPFIX equivalent of exporterBundle.
+type ipfixBundle struct {
+	exp *flowexport.IPFIXExporter
+	ec  *flowexport.ExportConfig
+}
+
+// flowExportConfigHash hashes the resolved *ExportConfig (Collectors,
+// timeouts, SamplingZones, SamplingRate, V9TemplateOpts). The
+// unexported atomic.Uint64 sampleCounter is invisible to json.Marshal,
+// and Go marshals map[uint16]SamplingDir keys in sorted numeric order,
+// so the encoding is deterministic. A nil ec hashes to a distinct
+// sentinel so "configured -> removed" registers as a real change.
+func flowExportConfigHash(ec *flowexport.ExportConfig) [32]byte {
+	if ec == nil {
+		// Distinct, stable sentinel for the unconfigured state.
+		return sha256.Sum256([]byte("flowexport:nil"))
+	}
+	data, err := json.Marshal(ec)
+	if err != nil {
+		// Marshal of plain structs cannot realistically fail; fall back
+		// to a zero hash (forces re-apply) rather than silently skip.
+		return [32]byte{}
+	}
+	return sha256.Sum256(data)
+}
+
+// buildFlowExportConfig resolves the NetFlow v9 export config from the
+// committed config, filling per-zone sampling directions. Returns nil
+// when flow export is not configured.
+func (d *Daemon) buildFlowExportConfig(cfg *config.Config) *flowexport.ExportConfig {
+	ec := flowexport.BuildExportConfig(&cfg.Services, &cfg.ForwardingOptions)
+	if ec == nil {
+		return nil
+	}
+	zoneIDs := buildZoneIDs(cfg)
+	ec.SamplingZones = flowexport.BuildSamplingZones(cfg, zoneIDs)
+	return ec
+}
+
+// buildIPFIXExportConfig resolves the IPFIX export config from the
+// committed config. Returns nil when IPFIX export is not configured.
+func (d *Daemon) buildIPFIXExportConfig(cfg *config.Config) *flowexport.ExportConfig {
+	ec := flowexport.BuildIPFIXExportConfig(&cfg.Services, &cfg.ForwardingOptions)
+	if ec == nil {
+		return nil
+	}
+	zoneIDs := buildZoneIDs(cfg)
+	ec.SamplingZones = flowexport.BuildSamplingZones(cfg, zoneIDs)
+	return ec
+}
+
+// reconcileFlowExporters reconciles BOTH the NetFlow v9 and IPFIX
+// exporters against the committed config. Safe to call from boot (after
+// the EventReader exists) and from applyConfigLocked. Returns true when
+// either family actually (re)started or stopped.
+//
+// No-ops (returns false) when the EventReader does not yet exist — the
+// boot apply runs before the EventReader is created, so the
+// post-EventReader boot block is what first starts the exporters; the
+// apply-path call handles every later commit.
+func (d *Daemon) reconcileFlowExporters(cfg *config.Config) bool {
+	if cfg == nil || d.eventReader == nil || d.daemonCtx == nil {
+		return false
+	}
+	v9 := d.reconcileV9Exporter(cfg)
+	ipfix := d.reconcileIPFIXExporter(cfg)
+	return v9 || ipfix
+}
+
+// reconcileV9Exporter reconciles only the NetFlow v9 exporter.
+func (d *Daemon) reconcileV9Exporter(cfg *config.Config) bool {
+	d.flowReconMu.Lock()
+	defer d.flowReconMu.Unlock()
+
+	ec := d.buildFlowExportConfig(cfg)
+	h := flowExportConfigHash(ec)
+	if d.flowHashSet && h == d.flowHash {
+		return false // gated: healthy exporter keeps running
+	}
+
+	wasRunning := d.flowExporter != nil
+
+	// Stop the old exporter (if any). The session-close callback reads
+	// the bundle lock-free; we publish the new bundle as one atomic
+	// pointer, so a concurrent read sees either the old or new pair.
+	if d.flowCancel != nil {
+		d.flowCancel()
+		d.flowWg.Wait()
+		if d.flowExporter != nil {
+			d.flowExporter.Close()
+		}
+		d.flowExporter = nil
+		d.flowCancel = nil
+	}
+
+	if ec == nil {
+		d.flowBundle.Store(&exporterBundle{})
+		d.flowHash, d.flowHashSet = h, true
+		if !wasRunning {
+			// Nothing was running and nothing starts: record the hash so
+			// later identical commits gate, but report no change.
+			return false
+		}
+		slog.Info("NetFlow v9 exporter stopped (flow export removed)")
+		return true
+	}
+
+	exp, err := flowexport.NewExporter(*ec)
+	if err != nil {
+		slog.Warn("failed to create flow exporter", "err", err)
+		// Leave the (stopped) state published; record the hash so we do
+		// not spin retrying every commit. A config change re-attempts.
+		d.flowBundle.Store(&exporterBundle{})
+		d.flowHash, d.flowHashSet = h, true
+		return true
+	}
+
+	flowCtx, cancel := context.WithCancel(d.daemonCtx)
+	d.flowExporter = exp
+	d.flowCancel = cancel
+	d.flowBundle.Store(&exporterBundle{exp: exp, ec: ec})
+
+	d.flowCBOnce.Do(func() {
+		d.eventReader.AddCallback(d.flowExportCallback)
+	})
+
+	d.flowWg.Add(1)
+	go func() {
+		defer d.flowWg.Done()
+		exp.Run(flowCtx)
+	}()
+
+	d.flowHash, d.flowHashSet = h, true
+	slog.Info("NetFlow v9 exporter reconciled",
+		"collectors", len(ec.Collectors),
+		"active_timeout", ec.FlowActiveTimeout,
+		"inactive_timeout", ec.FlowInactiveTimeout,
+		"sampling_zones", len(ec.SamplingZones),
+		"sampling_rate", ec.SamplingRate)
+	return true
+}
+
+// reconcileIPFIXExporter reconciles only the IPFIX exporter.
+func (d *Daemon) reconcileIPFIXExporter(cfg *config.Config) bool {
+	d.ipfixReconMu.Lock()
+	defer d.ipfixReconMu.Unlock()
+
+	ec := d.buildIPFIXExportConfig(cfg)
+	h := flowExportConfigHash(ec)
+	if d.ipfixHashSet && h == d.ipfixHash {
+		return false
+	}
+
+	wasRunning := d.ipfixExporter != nil
+
+	if d.ipfixCancel != nil {
+		d.ipfixCancel()
+		d.ipfixWg.Wait()
+		if d.ipfixExporter != nil {
+			d.ipfixExporter.Close()
+		}
+		d.ipfixExporter = nil
+		d.ipfixCancel = nil
+	}
+
+	if ec == nil {
+		d.ipfixBundlePtr.Store(&ipfixBundle{})
+		d.ipfixHash, d.ipfixHashSet = h, true
+		if !wasRunning {
+			return false
+		}
+		slog.Info("IPFIX exporter stopped (flow export removed)")
+		return true
+	}
+
+	exp, err := flowexport.NewIPFIXExporter(*ec)
+	if err != nil {
+		slog.Warn("failed to create IPFIX exporter", "err", err)
+		d.ipfixBundlePtr.Store(&ipfixBundle{})
+		d.ipfixHash, d.ipfixHashSet = h, true
+		return true
+	}
+
+	ipfixCtx, cancel := context.WithCancel(d.daemonCtx)
+	d.ipfixExporter = exp
+	d.ipfixCancel = cancel
+	d.ipfixBundlePtr.Store(&ipfixBundle{exp: exp, ec: ec})
+
+	d.ipfixCBOnce.Do(func() {
+		d.eventReader.AddCallback(d.ipfixExportCallback)
+	})
+
+	d.ipfixWg.Add(1)
+	go func() {
+		defer d.ipfixWg.Done()
+		exp.Run(ipfixCtx)
+	}()
+
+	d.ipfixHash, d.ipfixHashSet = h, true
+	slog.Info("IPFIX exporter reconciled",
+		"collectors", len(ec.Collectors),
+		"active_timeout", ec.FlowActiveTimeout,
+		"inactive_timeout", ec.FlowInactiveTimeout,
+		"sampling_zones", len(ec.SamplingZones),
+		"sampling_rate", ec.SamplingRate)
+	return true
+}
+
+// flowExportCallback is the single, stable NetFlow v9 session-close
+// handler registered on the EventReader exactly once. It reads the live
+// (exporter, config) pair lock-free from the atomic bundle, so reconcile
+// can swap the exporter without ever touching the callback list.
+func (d *Daemon) flowExportCallback(rec logging.EventRecord, raw []byte) {
+	if rec.Type != "SESSION_CLOSE" {
+		return
+	}
+	b := d.flowBundle.Load()
+	if b == nil || b.exp == nil || b.ec == nil {
+		return
+	}
+	if !b.ec.ShouldExport(rec.InZone, rec.OutZone) {
+		return
+	}
+	sd := flowexport.SessionCloseData{
+		SrcPort:  parseSrcPort(rec.SrcAddr),
+		DstPort:  parseSrcPort(rec.DstAddr),
+		Protocol: parseProtocol(rec.Protocol),
+	}
+	sd.SrcIP, sd.DstIP, sd.IsIPv6 = parseAddrPair(rec.SrcAddr, rec.DstAddr)
+	b.exp.ExportSessionClose(rec, sd)
+}
+
+// ipfixExportCallback is the IPFIX equivalent of flowExportCallback.
+func (d *Daemon) ipfixExportCallback(rec logging.EventRecord, raw []byte) {
+	if rec.Type != "SESSION_CLOSE" {
+		return
+	}
+	b := d.ipfixBundlePtr.Load()
+	if b == nil || b.exp == nil || b.ec == nil {
+		return
+	}
+	if !b.ec.ShouldExport(rec.InZone, rec.OutZone) {
+		return
+	}
+	sd := flowexport.SessionCloseData{
+		SrcPort:  parseSrcPort(rec.SrcAddr),
+		DstPort:  parseSrcPort(rec.DstAddr),
+		Protocol: parseProtocol(rec.Protocol),
+	}
+	sd.SrcIP, sd.DstIP, sd.IsIPv6 = parseAddrPair(rec.SrcAddr, rec.DstAddr)
+	b.exp.ExportSessionClose(rec, sd)
+}

--- a/pkg/daemon/daemon_flowexport_reconcile_test.go
+++ b/pkg/daemon/daemon_flowexport_reconcile_test.go
@@ -204,6 +204,45 @@ func TestReconcileV9IPFIXIndependence(t *testing.T) {
 	}
 }
 
+// flowSamplingConfigSrc returns a sampling config that pins a collector
+// source-address. An unassignable source IP makes dialCollectors fail,
+// exercising the NewExporter create-failure path.
+func flowSamplingConfigSrc(collector, source string, rate int) *config.Config {
+	cfg := flowSamplingConfig(collector, rate)
+	cfg.ForwardingOptions.Sampling.Instances["s"].FamilyInet.SourceAddress = source
+	return cfg
+}
+
+// TestReconcileFlowExporterRetriesAfterCreateFailure proves a transient
+// NewExporter failure (here: an unassignable pinned source-address) does
+// NOT hash-gate the exporter into a permanently-dead state — a later
+// commit (even of a working config) retries and starts it.
+func TestReconcileFlowExporterRetriesAfterCreateFailure(t *testing.T) {
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+
+	// 192.0.2.250 (TEST-NET-1) is not assigned to this host, so binding
+	// it as a UDP source fails with "cannot assign requested address".
+	if !d.reconcileFlowExporters(flowSamplingConfigSrc("127.0.0.1", "192.0.2.250", 100)) {
+		t.Fatal("a create-failing reconcile should still report a change")
+	}
+	if b := d.flowBundle.Load(); b == nil || b.exp != nil {
+		t.Fatal("no exporter should be live after a create failure")
+	}
+	if d.flowHashSet {
+		t.Fatal("the hash must NOT be recorded on a create failure " +
+			"(else an identical retry would be gated into a dead exporter)")
+	}
+
+	// A later commit with a working config must retry and start.
+	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
+		t.Fatal("a working config after a create failure must start the exporter")
+	}
+	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
+		t.Fatal("exporter must recover on the next working commit")
+	}
+}
+
 // TestApplyConfigLockedReconcilesFlowExporters is the NON-tautological
 // apply-wiring guard: it drives the REAL applyConfigLocked body (not the
 // applyBodyForTest seam) and asserts the flow exporter started. It FAILS

--- a/pkg/daemon/daemon_flowexport_reconcile_test.go
+++ b/pkg/daemon/daemon_flowexport_reconcile_test.go
@@ -1,0 +1,237 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/logging"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// flowSamplingConfig returns a config that enables NetFlow v9 flow
+// export to a single (loopback, unreachable-but-resolvable) collector.
+// UDP connect does not require a live listener, so NewExporter succeeds
+// with no external dependency.
+func flowSamplingConfig(collector string, rate int) *config.Config {
+	cfg := &config.Config{}
+	cfg.ForwardingOptions.Sampling = &config.SamplingConfig{
+		Instances: map[string]*config.SamplingInstance{
+			"s": {
+				Name:      "s",
+				InputRate: rate,
+				FamilyInet: &config.SamplingFamily{
+					FlowServers: []*config.FlowServer{
+						{Address: collector, Port: 2055},
+					},
+				},
+			},
+		},
+	}
+	return cfg
+}
+
+// ipfixSamplingConfig augments a v9 sampling config with a
+// services flow-monitoring version-ipfix stanza so the IPFIX exporter
+// also becomes configured.
+func ipfixSamplingConfig(collector string, rate int) *config.Config {
+	cfg := flowSamplingConfig(collector, rate)
+	cfg.Services.FlowMonitoring = &config.FlowMonitoringConfig{
+		VersionIPFIX: &config.NetFlowIPFIXConfig{
+			Templates: map[string]*config.NetFlowIPFIXTemplate{
+				"t": {Name: "t"},
+			},
+		},
+	}
+	return cfg
+}
+
+// newFlowTestDaemon builds a daemon with the minimum wiring
+// reconcileFlowExporters needs: a non-nil EventReader and a daemon
+// context.
+func newFlowTestDaemon() *Daemon {
+	d := &Daemon{
+		daemonCtx:   context.Background(),
+		eventReader: logging.NewEventReader(nil, nil),
+	}
+	return d
+}
+
+// TestReconcileFlowExporterAddAfterBoot is the headline #2075 fix:
+// flow export NOT configured at boot but ADDED in a later commit must
+// start the exporter (previously it never started).
+func TestReconcileFlowExporterAddAfterBoot(t *testing.T) {
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+
+	// No sampling configured: reconcile is a no-op start.
+	if d.reconcileFlowExporters(&config.Config{}) {
+		t.Fatal("empty config should not start an exporter")
+	}
+	if b := d.flowBundle.Load(); b != nil && b.exp != nil {
+		t.Fatal("no exporter should exist for empty config")
+	}
+
+	// Add sampling in a later commit.
+	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
+		t.Fatal("adding flow export must start the exporter")
+	}
+	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
+		t.Fatal("exporter must be live after add-after-boot")
+	}
+	if d.flowExporter == nil {
+		t.Fatal("d.flowExporter must be set after add-after-boot")
+	}
+}
+
+// TestReconcileFlowExporterRemoveAfterBoot proves a commit that removes
+// flow export stops the exporter (impossible before #2075).
+func TestReconcileFlowExporterRemoveAfterBoot(t *testing.T) {
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+
+	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
+		t.Fatal("initial config must start exporter")
+	}
+	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
+		t.Fatal("exporter must be live")
+	}
+
+	// Remove sampling.
+	if !d.reconcileFlowExporters(&config.Config{}) {
+		t.Fatal("removing flow export must reconcile (stop exporter)")
+	}
+	if b := d.flowBundle.Load(); b == nil || b.exp != nil {
+		t.Fatal("exporter must be stopped after removal")
+	}
+	if d.flowExporter != nil {
+		t.Fatal("d.flowExporter must be nil after removal")
+	}
+}
+
+// TestReconcileFlowExporterHashGate proves an unrelated / identical
+// commit does NOT bounce a healthy exporter — the SAME exporter
+// instance survives, preserving its template-refresh + 1-in-N counter
+// state.
+func TestReconcileFlowExporterHashGate(t *testing.T) {
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+
+	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
+		t.Fatal("initial config must start exporter")
+	}
+	first := d.flowBundle.Load().exp
+	if first == nil {
+		t.Fatal("exporter must be live")
+	}
+
+	// Identical config: gated (no restart).
+	if d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
+		t.Fatal("identical config must be hash-gated (no restart)")
+	}
+	if got := d.flowBundle.Load().exp; got != first {
+		t.Fatal("hash-gated reconcile must keep the SAME exporter instance")
+	}
+
+	// A real change re-applies and swaps to a new instance.
+	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.2", 100)) {
+		t.Fatal("changed collector must re-apply")
+	}
+	if got := d.flowBundle.Load().exp; got == first {
+		t.Fatal("a real config change must swap to a new exporter instance")
+	}
+	// A sampling-rate change also re-applies.
+	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.2", 50)) {
+		t.Fatal("changed sampling rate must re-apply")
+	}
+}
+
+// TestReconcileFlowExporterNoCallbackLeak proves the indirection
+// callback is registered exactly once across many reconciles — the
+// append-only EventReader callback list never grows.
+func TestReconcileFlowExporterNoCallbackLeak(t *testing.T) {
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+	t.Cleanup(d.stopIPFIXExporter)
+
+	for i := 0; i < 5; i++ {
+		// Alternate collectors so each reconcile actually swaps.
+		coll := "127.0.0.1"
+		if i%2 == 1 {
+			coll = "127.0.0.2"
+		}
+		d.reconcileFlowExporters(ipfixSamplingConfig(coll, 100))
+	}
+	// Exactly one v9 callback + one IPFIX callback.
+	if n := d.eventReader.CallbackCount(); n != 2 {
+		t.Fatalf("expected exactly 2 callbacks (v9 + ipfix), got %d — callback leak", n)
+	}
+}
+
+// TestReconcileV9IPFIXIndependence proves the two families gate
+// independently: adding IPFIX in a later commit must not bounce the
+// running v9 exporter.
+func TestReconcileV9IPFIXIndependence(t *testing.T) {
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+	t.Cleanup(d.stopIPFIXExporter)
+
+	// v9 only at first.
+	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
+		t.Fatal("v9 config must start")
+	}
+	v9 := d.flowBundle.Load().exp
+	if v9 == nil {
+		t.Fatal("v9 exporter must be live")
+	}
+	if b := d.ipfixBundlePtr.Load(); b != nil && b.exp != nil {
+		t.Fatal("IPFIX must not be configured yet")
+	}
+
+	// Add IPFIX in a later commit.
+	if !d.reconcileFlowExporters(ipfixSamplingConfig("127.0.0.1", 100)) {
+		t.Fatal("adding IPFIX must reconcile")
+	}
+	if b := d.ipfixBundlePtr.Load(); b == nil || b.exp == nil {
+		t.Fatal("IPFIX exporter must be live after add")
+	}
+	// v9 untouched (same instance).
+	if got := d.flowBundle.Load().exp; got != v9 {
+		t.Fatal("adding IPFIX must NOT bounce the running v9 exporter")
+	}
+}
+
+// TestApplyConfigLockedReconcilesFlowExporters is the NON-tautological
+// apply-wiring guard: it drives the REAL applyConfigLocked body (not the
+// applyBodyForTest seam) and asserts the flow exporter started. It FAILS
+// if the reconcileFlowExporters call is removed from applyConfigLocked.
+//
+// Mutation check: delete the `d.reconcileFlowExporters(cfg)` line from
+// applyConfigLocked and this test fails — d.flowExporter stays nil after
+// committing a config that enables flow-monitoring sampling.
+func TestApplyConfigLockedReconcilesFlowExporters(t *testing.T) {
+	installFakeNetworkctl(t)
+	d := &Daemon{
+		applySem:    semaphore.NewWeighted(1),
+		dp:          &runtimeOnlyApplyTestDP{},
+		vrrpMgr:     vrrp.NewManager(),
+		store:       newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		eventReader: logging.NewEventReader(nil, nil),
+		daemonCtx:   context.Background(),
+		opts:        Options{NoDataplane: true},
+	}
+	t.Cleanup(d.stopFlowExporter)
+
+	if err := d.applyConfigLocked(flowSamplingConfig("127.0.0.1", 100)); err != nil {
+		t.Fatalf("applyConfigLocked: %v", err)
+	}
+
+	if d.flowExporter == nil {
+		t.Fatal("applyConfigLocked did not reconcile the flow exporter: " +
+			"a committed forwarding-options sampling stanza left the NetFlow " +
+			"exporter unstarted (missing reconcileFlowExporters wiring)")
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -833,14 +833,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 				d.applySyslogConfig(er, cfg)
 			}
 
-			// Start NetFlow exporter if configured
+			// Start NetFlow v9 + IPFIX exporters if configured (#2075).
+			// This post-EventReader block is load-bearing: the earlier
+			// boot applyConfig ran before d.eventReader existed, so the
+			// apply-path reconcileFlowExporters no-op'd. This call is
+			// what first starts the exporters at boot; later commits go
+			// through the apply path.
 			if cfg := d.store.ActiveConfig(); cfg != nil {
-				d.startFlowExporter(ctx, cfg, er)
-			}
-
-			// Start IPFIX exporter if configured
-			if cfg := d.store.ActiveConfig(); cfg != nil {
-				d.startIPFIXExporter(ctx, cfg, er)
+				d.reconcileFlowExporters(cfg)
 			}
 
 			// Set up flow traceoptions if configured
@@ -854,8 +854,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 				d.eventReader = er
 				if cfg := d.store.ActiveConfig(); cfg != nil {
 					d.applySyslogConfig(er, cfg)
-					d.startFlowExporter(ctx, cfg, er)
-					d.startIPFIXExporter(ctx, cfg, er)
+					d.reconcileFlowExporters(cfg)
 					d.applyFlowTrace(cfg, er)
 				}
 			}

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -3,8 +3,8 @@
 NetFlow v9 and IPFIX (NetFlow v10) exporters. Both ship session-close
 events to remote collectors with per-zone direction filters and 1-in-N
 session sampling. Wired off `pkg/logging.EventReader` SESSION_CLOSE
-events in `pkg/daemon/daemon_flow.go`, not the conntrack GC delete
-callback. No per-packet sampling path.
+events in `pkg/daemon/daemon_flowexport.go`, not the conntrack GC
+delete callback. No per-packet sampling path.
 
 ## File layout
 
@@ -53,10 +53,28 @@ Shared:
 
 ## Callers
 
-`pkg/daemon/daemon_flow.go::startFlowExporter` calls
-`Exporter.ExportSessionClose()` for NetFlow v9; `startIPFIXExporter`
-calls `IPFIXExporter.ExportSessionClose()` for IPFIX. Both run from
-the `logging.EventReader` SESSION_CLOSE callback.
+`pkg/daemon/daemon_flowexport.go::reconcileFlowExporters` owns the
+exporter lifecycle (#2075). It runs at boot (after the EventReader
+exists) AND on every config commit from `applyConfigLocked`, and is
+config-hash-gated per family so an unrelated commit never bounces a
+healthy exporter (preserving its template-refresh cadence and 1-in-N
+sampling counter). A commit that changes `forwarding-options sampling`
+/ `services flow-monitoring` — or that ADDS / REMOVES flow export
+entirely — therefore takes effect immediately, without a daemon
+restart (before #2075 the exporters were started only at boot and
+stopped only at shutdown).
+
+Because the `EventReader` callback list is append-only (clear-all only,
+no per-callback removal), the reconcile registers ONE stable
+indirection callback per family exactly once
+(`flowCBOnce`/`ipfixCBOnce`) that reads the live `(exporter, config)`
+pair lock-free from an `atomic.Pointer` bundle; reconcile swaps the
+bundle atomically. The callback calls `Exporter.ExportSessionClose()`
+(NetFlow v9) / `IPFIXExporter.ExportSessionClose()` (IPFIX) from the
+`logging.EventReader` SESSION_CLOSE event. The daemon-held
+`*ExportConfig` is the sole 1-in-N counter owner (the exporter never
+reads `sampleCounter`), so it is held by pointer in the bundle.
+`stopFlowExporter`/`stopIPFIXExporter` drain the exporter at shutdown.
 
 ## Dependencies
 

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -245,6 +245,17 @@ func (er *EventReader) ClearCallbacks() {
 	er.callbackMu.Unlock()
 }
 
+// CallbackCount returns the number of registered callbacks. Used by the
+// daemon flow-exporter reconcile tests to assert the once-registered
+// indirection callback is never leaked across repeated reconciles
+// (#2075).
+func (er *EventReader) CallbackCount() int {
+	er.callbackMu.RLock()
+	n := len(er.callbacks)
+	er.callbackMu.RUnlock()
+	return n
+}
+
 // SetSyslogClients replaces the set of syslog clients (goroutine-safe).
 func (er *EventReader) SetSyslogClients(clients []*SyslogClient) {
 	er.syslogMu.Lock()


### PR DESCRIPTION
## Summary

The NetFlow v9 / IPFIX flow exporters (`pkg/flowexport`) were started only
at daemon boot and stopped only at shutdown — the apply path
(`daemon_apply.go`) had **zero** flowexport references. As a result, any
runtime commit that changed `forwarding-options sampling` (collector
address/port, source-address, 1-in-N input-rate, sampled zones) or a
`services flow-monitoring` export-extension was silently ignored until a
daemon restart, and flow export **added** in a later commit never started
at all.

This adds `reconcileFlowExporters` (new `pkg/daemon/daemon_flowexport.go`),
called from `applyConfigLocked` (step 16b) and from the post-EventReader
boot block (replacing the deleted boot-only `startFlowExporter` /
`startIPFIXExporter`), mirroring the established `reconcileRPM` /
`reconcileIPMon` pattern.

## Design

- **Config-hash-gated per family** (`flowHash` / `ipfixHash`): an unrelated
  commit never bounces a healthy exporter (preserving its template-refresh
  cadence and 1-in-N sampling counter); a single-family change never
  cross-bounces the other.
- **No callback leak.** The `EventReader` callback list is append-only with
  only a clear-ALL primitive (no per-callback removal). A naive stop/start
  would leak a closure (closed over a now-closed exporter) on every commit.
  Instead a single stable indirection callback per family is registered
  exactly once (`flowCBOnce` / `ipfixCBOnce`); it reads the live
  `(exporter, *ExportConfig)` pair **lock-free** from an `atomic.Pointer`
  bundle that reconcile swaps atomically. The daemon-held `*ExportConfig`
  is the sole 1-in-N counter owner (the exporter never reads
  `sampleCounter`), so it is held by pointer in the bundle.
- **Boot:** the boot `applyConfig` runs before the EventReader exists, so
  the apply-path reconcile no-ops at boot (eventReader-nil guard precedes
  any hash store); the post-EventReader block first starts the exporters.
  The exporter goroutine is parented to `d.daemonCtx`, so the explicit
  `stopFlowExporter` / `stopIPFIXExporter` at shutdown stays authoritative
  (the stop funcs now take the per-family reconcile mutex and are nil-safe).
- **Transient-failure recovery:** a `NewExporter` create failure (e.g. a
  pinned source-address bind before the source interface is up) leaves the
  hash UNSET so the next commit retries, instead of gating a
  permanently-dead exporter.

## Plan + adversarial review

Plan doc: `docs/pr/2075-flowexport-reconcile/plan.md`

- Two independent hostile Claude plan reviewers: PLAN-NEEDS-MINOR (no kill);
  all findings folded into plan v2 (boot load-bearing block, ctx
  correction, per-family hashes, atomic.Pointer bundle, non-tautological
  apply-wiring test).
- Two independent hostile Claude code reviewers: **MERGE-READY**; one MINOR
  (transient-failure retry) folded in.

## Test plan (control-plane — no dataplane path touched, no smoke)

- [x] `go build ./...` clean
- [x] `go vet ./pkg/daemon/...` — no NEW copylocks (pre-existing
  `NewExporter(*ec)` only, count unchanged 2→2)
- [x] `pkg/daemon` / `pkg/logging` / `pkg/flowexport` suites pass
- [x] Full `go test ./...` green
- [x] 8 new tests in `daemon_flowexport_reconcile_test.go`:
  add-after-boot, remove-after-boot, hash-gate (same instance survives),
  change-re-applies, no-callback-leak (exactly 2 callbacks after 5 swaps),
  v9/IPFIX independence, transient-failure retry, and a **non-tautological
  apply-wiring guard** that drives the REAL `applyConfigLocked` and fails
  iff the reconcile call is removed (**mutation-verified**)
- [x] New tests 5/5 flake-clean and `-race` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)