### PR TITLE
#2008 H7: compile + validate security log profile / default-profile

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -324,6 +324,29 @@ reserved for whole-dataplane selection where a rewrite shim
     fails at commit; `allow-duplicates` is an explicit presence-only flag.
   Pure schema hardening — no runtime behavior change. Regression coverage:
   `pkg/config/schema_validate_2008_test.go`.
+- **#2008 H7 (security log profile):** declared the `security log
+  profile <name>` stanza — `stream-name` (`ValueHintStreamName`
+  completion), `default-profile` (presence flag), and
+  `category session field-extra-name`. Before H7 the whole stanza parsed
+  but was silently dropped (no schema child, no compiler case), so a real
+  imported config such as `vsrx-ha.conf`'s `profile default-syslog {
+  stream-name syslog-container; default-profile; }` committed with no
+  validation and no effect. It now compiles to typed `LogConfig.Profiles`
+  (`LogProfile{Name, StreamName, DefaultProfile}`) and the compiler
+  cross-references `stream-name` against the configured streams
+  (`validateLogProfileStreamReferencesStrict`): a profile naming an
+  undefined stream is rejected at commit / commit-check (strict) and
+  downgraded to a warning on the tolerant load / peer-sync paths
+  (`lenientLogProfileStreamRef`, mirroring the IPsec proposal/gateway
+  cross-ref gates and the #1960 fail-closed-on-load doctrine). **No
+  runtime/dataplane change:** xpf per-stream routing is already a Junos
+  superset (every stream whose category/severity filter matches receives
+  the event), so a profile's `stream-name` designates the stream that
+  carries its events; the `default-profile` flag records the operator's
+  default designation and `category field-extra-name` is accepted for
+  parity but not yet used to alter the emitted structured-data field set.
+  Regression coverage: `pkg/config/log_profile_test.go` +
+  `pkg/config/log_profile_schema_test.go`.
 - **#1387 (DHCP dynamic-DNS, increment 1):** added an opt-in
   `dynamic-dns` subtree under BOTH `services dhcp-local-server` and
   `services dhcpv6-local-server` (a single shared `config.DHCPDynamicDNSConfig`

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -261,6 +261,7 @@ xpf has security logging with mode (stream/event), format, streams with host/por
 | **Per-Policy Logging** | `security policies ... then log session-init session-close` | xpf has this but may not fully support all log fields (app-name, nat-*, nested-app, etc.) | Medium | Done (all key fields: policy-name, app, ingress-iface, client/server split, close-reason, session-id) |
 | **Log Event Mode** | `security log mode event` | Route security logs through eventd (control plane) for on-box processing, slower but allows local processing | Low | Done (event mode writes to local file) |
 | **Session Aggregation Logs** | `security log ... report` | Aggregate session logs for top-N reporting (top talkers, top applications) | Low | Done (session aggregation reporting implemented) |
+| **Log Profile** | `security log profile <name> { stream-name; default-profile; category ... }` | Named log-routing profile targeting a stream, with a default-profile designation (#2008 H7) | Low | Done (compiled to `LogConfig.Profiles`; `stream-name` cross-referenced at commit. Per-stream routing is already a Junos superset, so no dispatch change; `category field-extra-name` accepted but not yet used to alter emitted SD) |
 
 ---
 

--- a/docs/pr/2008-h7-log-default-profile/plan.md
+++ b/docs/pr/2008-h7-log-default-profile/plan.md
@@ -1,0 +1,263 @@
+# #2008 H7 — `security log profile` / `default-profile` (vSRX parity)
+
+Status: DRAFT v1 — pending hostile Claude reviews (2 independent + SMR).
+
+## Issue framing (H7, #2008 umbrella)
+
+The #2008 parity audit lists **H7** as `security log profile`
+(stream-name / category / default-profile) — "whole stanza absent."
+The Tier-3 `/research` (branch `research/2008-tier3`,
+`docs/research/2008-tier3/plan.md`) corrected that: xpf's
+`security log stream <name>` machinery already implements the *substance*
+of Junos per-stream profile routing end-to-end (typed `SyslogStream`,
+full `compileLog`, per-stream `SyslogClient` build in
+`daemon_system.go`, per-client filtered RT_FLOW broadcast in
+`ringbuf.go`). What is genuinely **absent** is the literal
+`security log profile <name> { ... }` stanza and its `default-profile`
+flag: there is no schema child, no typed field, and no compiler case, so
+a config such as the one shipped in `vsrx-ha.conf` (lines 751-763):
+
+```
+security log {
+    profile default-syslog {
+        stream-name syslog-container;
+        category { session { field-extra-name hostname; ... } }
+        default-profile;
+    }
+}
+```
+
+**parses but is silently discarded** (`schema_walk.go` returns nil for an
+unknown leaf under a known parent; `compileLog` has no `profile` case).
+This is the audit's silent-drop failure class: commit succeeds, operator
+intent is lost, and commit-time validation + `?` completion are absent.
+
+## Scope (H7 ONLY)
+
+Implement `security log profile <name>` as a validated, compiled config
+object with `default-profile` semantics, restoring commit-time
+validation in place of the silent-drop. **No runtime/dataplane change** —
+xpf's per-stream routing is already a Junos superset (every matching
+stream receives the event), so a `profile`'s `stream-name` maps onto the
+existing per-stream routing. This is the Tier-3 research's recommended
+**FEASIBLE-INCREMENT (small)**, sharpened from "validated alias leaf" to
+the real grammar found in the imported config (`profile <name>` object
+with a `stream-name` routing target + `default-profile` flag).
+
+Strictly out of scope (deferred, documented below): any change to
+`ringbuf.go` dispatch semantics ("catch-all only when no stream
+matched"), per-category `field-extra-name` structured-data emission, and
+H12 (dns-proxy).
+
+## Honest scope/value framing
+
+The win is **truth-in-commit**: a silently-dropped stanza that real
+imported vSRX configs use (`vsrx-ha.conf`) becomes parsed, validated,
+and cross-referenced. A `profile` naming a non-existent stream is
+rejected at commit (strict) / warned on tolerant load (mirrors the
+sibling cross-ref gates). The runtime routing is unchanged because it is
+already a Junos superset. No perf dimension. If reviewers conclude the
+parity value is too small to justify the surface, PLAN-KILL is an
+acceptable verdict — but the silent-drop of a real imported stanza is
+the project's explicitly-flagged operationally-dangerous class.
+
+## What's already shipped / composes-with
+
+- H1 `inactive:` (#2042, merged): the `inactive: profile default-syslog`
+  marker in `vsrx-ha.conf` is stripped before compile by the centralized
+  inactive-subtree prune. The new `profile` schema/compiler must behave
+  correctly for an **active** `profile` (the inactive one never reaches
+  `compileLog`). Tests cover the active case.
+- H8 / M2 / M3 Tier-1.5 schema-hardening (merged): `stream`'s
+  `transport` child + IKE/IPsec proposal leaves + dest-NAT match are
+  already typed. The new `profile` child sits beside `stream` under the
+  same `log` node.
+- The cross-ref + lenient-downgrade pattern
+  (`validateIPsecPolicyProposalReferencesStrict`,
+  `validateIPsecGatewayReferencesStrict`,
+  `validatePolicyMatchAddressesStrict`) is the exact template for the
+  `profile.stream-name` cross-reference.
+
+## Concrete design
+
+### Types (`pkg/config/types_security.go`)
+
+```go
+// LogProfile is a Junos `security log profile <name>` object: a named
+// log routing profile that targets a configured stream and may be the
+// default profile. xpf's per-stream routing is a Junos superset (every
+// matching stream receives the event), so a profile's StreamName names
+// the stream that carries its events; no dispatch change is required.
+type LogProfile struct {
+    Name           string
+    StreamName     string // references LogConfig.Streams[StreamName]
+    DefaultProfile bool   // `default-profile;` — marks this the default
+}
+```
+
+Add to `LogConfig`:
+
+```go
+Profiles map[string]*LogProfile
+```
+
+### Schema (`pkg/config/schema_security.go`, under the `log` node)
+
+Add a `profile` child beside `stream`:
+
+```go
+"profile": {desc: "Security log profile (routing object)", args: 1,
+    placeholder: "<profile-name>", children: map[string]*schemaNode{
+    "stream-name":     {desc: "Stream this profile routes to", args: 1,
+        valueHint: ValueHintStreamName, placeholder: "<stream-name>", children: nil},
+    "default-profile": {desc: "Mark this profile as the default", children: nil},
+    "category": {desc: "Per-category field configuration", children: map[string]*schemaNode{
+        "session": {desc: "Session category fields", children: map[string]*schemaNode{
+            "field-extra-name": {desc: "Extra field to include", args: 1,
+                placeholder: "<field>", children: nil},
+        }},
+    }},
+}},
+```
+
+`category { session { field-extra-name ...; } }` is declared so it
+parses + completes; xpf already emits per-stream structured data, so the
+field list is accepted/validated but not (in this increment) used to
+alter the emitted structured-data set — noted in the docs.
+
+### Compiler (`pkg/config/compiler_security.go`, in `compileLog`)
+
+After the stream loop, extract profiles (mirror the stream loop's
+`namedInstances` + flag handling for `default-profile`):
+
+```go
+for _, inst := range namedInstances(node.FindChildren("profile")) {
+    p := &LogProfile{Name: inst.name}
+    for _, prop := range inst.node.Children {
+        switch prop.Name() {
+        case "stream-name":
+            p.StreamName = nodeVal(prop)
+        case "default-profile":
+            p.DefaultProfile = true
+        case "category":
+            // accepted for parity; per-category field emission is
+            // out of scope for this increment.
+        }
+    }
+    if sec.Log.Profiles == nil {
+        sec.Log.Profiles = make(map[string]*LogProfile)
+    }
+    sec.Log.Profiles[p.Name] = p
+}
+```
+
+### Cross-reference validator (`pkg/config/compiler.go`)
+
+New `validateLogProfileStreamReferencesStrict(cfg)` mirroring
+`validateIPsecPolicyProposalReferencesStrict`: a `profile` whose
+`stream-name` is set but does not resolve to a configured
+`LogConfig.Streams[name]` is rejected (sorted keys → deterministic
+first-error). A profile with no `stream-name` is accepted (Junos allows
+a profile that inherits global routing). Call site mirrors the ipsec
+gateway-ref block: strict on commit / commit-check, downgraded to a
+warning on the tolerant load + peer-sync paths via a new
+`lenientLogProfileStreamRef` opt (set true in the two lenient option
+constructors).
+
+Rationale for compiler-side cross-ref (not a schema validator): the
+`schema_walk` per-leaf validators cannot see sibling `stream` nodes;
+`compileLog` (and the post-compile `*Config`) has the full stream map in
+scope. Same reason the ipsec proposal/gateway refs live in the compiler.
+
+## Public API preservation
+
+Pure additive. `LogConfig` gains one field (`Profiles`); a new exported
+type `LogProfile`; one new unexported validator + opt. No existing
+signature changes. `applySecurityLogging` / `ringbuf.go` untouched
+(runtime already correct).
+
+## Hidden invariants preserved
+
+- **Silent-drop → validated**: `profile`/`default-profile` were dropped;
+  now compiled + cross-referenced. No previously-accepted *valid* config
+  becomes rejected — only a `profile` naming a non-existent stream (a
+  typo / dangling ref) is newly rejected, and only on the strict path.
+- **Tolerant-path boot**: an already-persisted config with a dangling
+  `profile.stream-name` still boots (warning), per the #1960
+  fail-closed-on-load doctrine and every sibling cross-ref gate.
+- **Inactive interaction (#2042)**: an `inactive: profile` is pruned
+  before `compileLog`, so it never reaches the new code — verified by a
+  test that an inactive profile naming a missing stream does NOT error.
+- **Dual-AST**: `compileLog` reads via `namedInstances` + `nodeVal`,
+  which already handle both hierarchical and flat-set shapes (same as the
+  stream loop).
+
+## Risk assessment
+
+| Class | Level | Note |
+|---|---|---|
+| Behavioral regression | LOW | Additive; no runtime path touched; only new commit-time reject for a dangling ref (strict only, warned on load) |
+| Lifetime / borrow | N/A | Go, no borrow concerns |
+| Performance | NONE | Compile-time only; no dataplane/hot-path change |
+| Architectural mismatch | LOW | Reuses the established cross-ref + lenient-downgrade pattern verbatim; does not introduce a parallel `profile` dispatch model (Option B, rejected by research as a regression risk to the working broadcast model) |
+
+## Test plan (control-plane — NO dataplane smoke)
+
+Per parent scope: cover with `pkg/config` compile/validate unit tests,
+dual-AST flat-set via `ParseSetCommand` + `SetPath` (NOT `NewParser`),
+non-tautological (each reject test FAILS pre-fix).
+
+1. Flat-set: `set security log profile P stream-name S` +
+   `set ... default-profile` → compiles to `Profiles["P"]` with
+   `StreamName=="S"`, `DefaultProfile==true` (FAILS today — silently
+   dropped, map empty).
+2. Hierarchical round-trip: the `vsrx-ha.conf` profile shape (active,
+   not inactive) compiles to the same typed struct.
+3. Cross-ref reject (strict): `profile P stream-name nope` with no
+   stream `nope` → `CompileConfig`/`SchemaValidate` errors referencing
+   the profile + missing stream (FAILS today — accepted).
+4. Cross-ref accept: `profile P stream-name S` with stream `S` defined →
+   no error.
+5. Tolerant path: dangling ref on the lenient compile path → warning,
+   not error (config still compiles).
+6. Inactive interaction (#2042): `inactive: profile P stream-name nope`
+   → no error (pruned before compile).
+7. Schema completion/validation: `default-profile` + `stream-name`
+   accepted under `profile`; a bad child rejected by `SchemaValidate`.
+
+Gates: `go build ./...`, `go vet ./pkg/config/`,
+`go test ./pkg/config/...` (full package), `go test ./...` (full Go
+suite). No Rust / no cluster smoke — H7 is control-plane only.
+
+## Out of scope (explicitly deferred)
+
+- `ringbuf.go` "default-profile catches only unmatched events" dispatch
+  semantics (research Option B — rejected; xpf's broadcast model is a
+  Junos superset and changing it risks regressing working routing).
+- Per-category `field-extra-name` structured-data field selection
+  (accepted/validated, not yet used to alter emitted SD).
+- H12 dns-proxy (separate Tier-3 row, research disposition = DEFER).
+
+## Open questions for hostile review
+
+1. Is `stream-name` the correct cross-ref target, or does Junos
+   `default-profile` ALSO need a global "which profile is default"
+   uniqueness check (reject two `default-profile` profiles)? Proposed:
+   accept multiple but the cross-ref is per-profile; is a
+   single-default invariant worth enforcing?
+2. Should a dangling `profile.stream-name` be a hard commit ERROR or
+   only a WARNING even on the strict path? (Sibling ipsec refs are hard
+   errors on commit; this plan matches them. Counter: a log misroute is
+   less dangerous than a dropped crypto proposal.)
+3. Is declaring the `category { session { field-extra-name } }` subtree
+   (parsed-but-unused) better than omitting it (so it silently drops
+   again)? Plan says declare-and-accept; argue the other way.
+4. Does adding `profile` as a `log` child collide with any existing
+   flat-set token grouping or completion path (e.g. the feeds `profile`
+   node elsewhere in the schema)?
+5. Is the lenient-downgrade opt necessary, or does a log-profile
+   cross-ref never appear on a peer-sync/load path that must boot
+   through it? (Plan adds it for symmetry with the #1960 doctrine.)
+6. Is there any consumer that would now read `LogConfig.Profiles` and
+   change behavior unexpectedly (HA config-equality, display-set
+   round-trip, `show configuration`)?

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -158,6 +158,19 @@ type compileOpts struct {
 	// tunnel) is rejected. Same doctrine as lenientDeviceMap /
 	// lenientPolicyMatchAddress.
 	lenientIPsecGatewayRefs bool
+
+	// lenientLogProfileStreamRef (#2008 H7) downgrades the
+	// `security log profile <name> stream-name <stream>` cross-reference
+	// from a hard error to a warning on the tolerant load / peer-sync
+	// paths. A config persisted by an older binary (which silently dropped
+	// the whole profile stanza), or synced from a peer, may carry a profile
+	// naming a stream that is not configured; an upgrading / receiving node
+	// must still boot through it (warn) rather than fail-closed-on-load
+	// (#1960 class). Commit / commit-check stay strict — a new operator
+	// edit that names a non-existent stream (a typo whose log routing would
+	// silently never fire) is rejected. Same doctrine as
+	// lenientIPsecPolicyProposalRef.
+	lenientLogProfileStreamRef bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -187,6 +200,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientEventAttributesMatch:   true,
 		lenientIPsecPolicyProposalRef: true,
 		lenientIPsecGatewayRefs:       true,
+		lenientLogProfileStreamRef:    true,
 	})
 }
 
@@ -267,6 +281,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientEventAttributesMatch:   true,
 		lenientIPsecPolicyProposalRef: true,
 		lenientIPsecGatewayRefs:       true,
+		lenientLogProfileStreamRef:    true,
 	})
 }
 
@@ -652,6 +667,27 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #2008 H7 security log profile -> stream cross-reference. A
+	// `security log profile <name> stream-name <stream>` that names a
+	// stream which is not configured would route to nowhere — the operator
+	// authored a log profile whose target silently never receives events.
+	// Before H7 the whole profile stanza was dropped silently; now it is
+	// compiled and the reference is checked. Strict on commit / commit-
+	// check (hard reject so the typo is operator-visible); lenient on load
+	// / peer-sync (warn so a config persisted by an older binary that
+	// dropped the stanza, or a peer-synced config, still boots — #1960
+	// fail-closed-on-load class). Runs on the fully-compiled *Config so the
+	// stream map is fully populated regardless of authoring order. Mirrors
+	// validateIPsecPolicyProposalReferencesStrict.
+	if err := validateLogProfileStreamReferencesStrict(cfg); err != nil {
+		if opts.lenientLogProfileStreamRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("security log profile stream reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
 	if warnings := ValidateConfig(cfg); len(warnings) > 0 {
 		for _, w := range warnings {
 			cfg.Warnings = append(cfg.Warnings, w)
@@ -852,6 +888,57 @@ func validateIPsecPolicyProposalReferencesStrict(cfg *Config) error {
 			"(no `proposals` reference and no proposal named %q); the configured "+
 			"perfect-forward-secrecy group would be silently dropped — define a "+
 			"proposal or reference one", pol.Name, pol.Name)
+	}
+	return nil
+}
+
+// validateLogProfileStreamReferencesStrict hard-rejects a
+// `security log profile <name>` whose `stream-name` reference does not
+// resolve to a configured `security log stream` (#2008 H7). xpf routes
+// log events per stream (a Junos superset — every matching stream
+// receives the event), so a profile's `stream-name` designates the
+// stream that carries its events. A profile naming a stream that is not
+// configured routes to nowhere: the operator authored a log profile
+// whose target silently never fires. Before H7 the whole profile stanza
+// was dropped before compile, so the typo was invisible; now the
+// reference is validated.
+//
+// A profile with no `stream-name` is accepted: Junos permits a profile
+// that relies on the global routing inheritance, and there is nothing to
+// dangle. Only a non-empty `stream-name` that misses the stream map is
+// rejected.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this
+// to a warning (opts.lenientLogProfileStreamRef) so an already-persisted
+// config (older binaries dropped the stanza entirely) or a peer-synced
+// config still boots. Mirrors validateIPsecPolicyProposalReferencesStrict.
+func validateLogProfileStreamReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	profiles := cfg.Security.Log.Profiles
+	if len(profiles) == 0 {
+		return nil
+	}
+	streams := cfg.Security.Log.Streams
+	// Profiles is a map (unordered); sort keys so the first-error
+	// commit-check message is deterministic across runs.
+	names := make([]string, 0, len(profiles))
+	for name := range profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		p := profiles[name]
+		if p == nil || p.StreamName == "" {
+			continue
+		}
+		if _, ok := streams[p.StreamName]; ok {
+			continue
+		}
+		return fmt.Errorf("security log profile %q references undefined "+
+			"log stream %q (the profile would route to nowhere — define "+
+			"the stream or fix the stream-name)", p.Name, p.StreamName)
 	}
 	return nil
 }

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -908,6 +908,12 @@ func validateIPsecPolicyProposalReferencesStrict(cfg *Config) error {
 // dangle. Only a non-empty `stream-name` that misses the stream map is
 // rejected.
 //
+// Note: compileLog only records a stream in Log.Streams when it has a
+// host (a host-less stream is not a real destination and is dropped by
+// the stream loop), so a profile referencing a host-less stream is
+// treated as a dangling reference — consistent with the stream's own
+// "must have a host to exist" semantics.
+//
 // On the tolerant load / peer-sync paths the call site downgrades this
 // to a warning (opts.lenientLogProfileStreamRef) so an already-persisted
 // config (older binaries dropped the stanza entirely) or a peer-synced

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -569,6 +569,36 @@ func compileLog(node *Node, sec *SecurityConfig) error {
 			sec.Log.Streams[stream.Name] = stream
 		}
 	}
+
+	// H7 (#2008): `security log profile <name>` log-routing objects. Each
+	// names a target stream (`stream-name`), may be marked the default
+	// (`default-profile`), and may carry per-category field config. Reads
+	// via namedInstances + nodeVal so both hierarchical and flat-set AST
+	// shapes work (same as the stream loop). The stream-name cross-
+	// reference is enforced after full compile in
+	// validateLogProfileStreamReferencesStrict — schema_walk per-leaf
+	// validators cannot see sibling stream nodes. `category` is accepted
+	// for parse/validation parity; per-category field-extra-name selection
+	// is not yet used to alter the emitted structured data (out of scope).
+	for _, inst := range namedInstances(node.FindChildren("profile")) {
+		p := &LogProfile{Name: inst.name}
+		for _, prop := range inst.node.Children {
+			switch prop.Name() {
+			case "stream-name":
+				p.StreamName = nodeVal(prop)
+			case "default-profile":
+				p.DefaultProfile = true
+			case "category":
+				// Accepted for parity; field-extra-name emission is out of
+				// scope for this increment (xpf already emits per-stream
+				// structured data).
+			}
+		}
+		if sec.Log.Profiles == nil {
+			sec.Log.Profiles = make(map[string]*LogProfile)
+		}
+		sec.Log.Profiles[p.Name] = p
+	}
 	return nil
 }
 

--- a/pkg/config/log_profile_schema_test.go
+++ b/pkg/config/log_profile_schema_test.go
@@ -1,0 +1,58 @@
+package config_test
+
+// Schema-validation tests for #2008 H7: the `security log profile <name>`
+// stanza must be accepted by the #1319 typed-leaf gate (SchemaValidate)
+// without a false reject, and the declared children (`stream-name`,
+// `default-profile`, `category session field-extra-name`) must validate
+// so the config-mode `?` completion can offer them. Uses the flat-set
+// path (ParseSetCommand + SetPath via flatSchemaCheck).
+//
+// Note on the gate's contract: SchemaValidate is opt-in per leaf — an
+// UNKNOWN keyword under a known parent is intentionally NOT rejected
+// (schema_walk.go resolveSchemaChild == nil returns nil; reporting is
+// left to the compiler). So the H7 schema win is recognition + completion
+// of the declared subtree, not rejection of arbitrary children; these
+// tests assert the declared forms validate cleanly.
+
+import (
+	"testing"
+)
+
+// TestSchema2008H7_LogProfile_FlatAccepts verifies the profile stanza and
+// its declared children pass schema validation from flat-set syntax.
+func TestSchema2008H7_LogProfile_FlatAccepts(t *testing.T) {
+	err := flatSchemaCheck(t,
+		"set security log stream s1 host 192.0.2.1",
+		"set security log profile p1 stream-name s1",
+		"set security log profile p1 default-profile",
+		"set security log profile p1 category session field-extra-name hostname",
+	)
+	if err != nil {
+		t.Fatalf("expected log profile stanza to pass schema validation, got: %v", err)
+	}
+}
+
+// TestSchema2008H7_LogProfile_HierarchicalAccepts verifies the
+// vsrx-ha.conf-shaped hierarchical profile block validates cleanly.
+func TestSchema2008H7_LogProfile_HierarchicalAccepts(t *testing.T) {
+	err := schemaCheck(t, `security {
+    log {
+        stream syslog-container {
+            host 192.0.2.1;
+            category all;
+        }
+        profile default-syslog {
+            stream-name syslog-container;
+            category {
+                session {
+                    field-extra-name hostname;
+                }
+            }
+            default-profile;
+        }
+    }
+}`)
+	if err != nil {
+		t.Fatalf("expected hierarchical log profile block to pass schema validation, got: %v", err)
+	}
+}

--- a/pkg/config/log_profile_test.go
+++ b/pkg/config/log_profile_test.go
@@ -1,0 +1,216 @@
+package config
+
+// Tests for #2008 H7: `security log profile <name>` compilation +
+// stream-name cross-reference. Before H7 the whole profile stanza parsed
+// but was silently discarded (no schema child, no compiler case), so a
+// config such as vsrx-ha.conf's `profile default-syslog { stream-name ...;
+// default-profile; }` committed with no validation and no effect.
+//
+// Each compile test drives the dual-AST flat-set path
+// (ParseSetCommand + SetPath, NOT NewParser, per CLAUDE.md) and the
+// reject tests are non-tautological: pre-fix the profile is dropped
+// entirely so the Profiles map is empty and the dangling reference never
+// errors, so the assertions below FAIL against the unfixed compiler.
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildTree assembles a ConfigTree from flat `set ...` commands using the
+// dual-AST flat-set path (ParseSetCommand + SetPath).
+func buildLogProfileTree(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestLogProfile_FlatSet_Compiles verifies the profile object compiles to
+// typed state from flat-set syntax, including the default-profile flag.
+// Pre-fix this FAILS: the stanza is dropped, Profiles is nil.
+func TestLogProfile_FlatSet_Compiles(t *testing.T) {
+	tree := buildLogProfileTree(t,
+		"set security log stream syslog-container host 192.168.99.3",
+		"set security log stream syslog-container category all",
+		"set security log profile default-syslog stream-name syslog-container",
+		"set security log profile default-syslog default-profile",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.Security.Log.Profiles == nil {
+		t.Fatal("expected Log.Profiles populated, got nil (profile silently dropped?)")
+	}
+	p, ok := cfg.Security.Log.Profiles["default-syslog"]
+	if !ok || p == nil {
+		t.Fatalf("expected profile default-syslog, got %#v", cfg.Security.Log.Profiles)
+	}
+	if p.StreamName != "syslog-container" {
+		t.Errorf("StreamName = %q, want syslog-container", p.StreamName)
+	}
+	if !p.DefaultProfile {
+		t.Error("DefaultProfile = false, want true")
+	}
+}
+
+// TestLogProfile_Hierarchical_Compiles verifies the same profile shape as
+// authored in vsrx-ha.conf (hierarchical) compiles identically. Uses
+// NewParser only because hierarchical AST is the input shape under test;
+// the compiler must handle BOTH shapes.
+func TestLogProfile_Hierarchical_Compiles(t *testing.T) {
+	input := `security {
+    log {
+        stream syslog-container {
+            host {
+                192.168.99.3;
+            }
+            category all;
+        }
+        profile default-syslog {
+            stream-name syslog-container;
+            category {
+                session {
+                    field-extra-name hostname;
+                }
+            }
+            default-profile;
+        }
+    }
+}`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	prof, ok := cfg.Security.Log.Profiles["default-syslog"]
+	if !ok || prof == nil {
+		t.Fatalf("expected profile default-syslog, got %#v", cfg.Security.Log.Profiles)
+	}
+	if prof.StreamName != "syslog-container" {
+		t.Errorf("StreamName = %q, want syslog-container", prof.StreamName)
+	}
+	if !prof.DefaultProfile {
+		t.Error("DefaultProfile = false, want true")
+	}
+}
+
+// TestLogProfile_DanglingStream_Rejected verifies a profile naming a
+// stream that is not configured is rejected at commit. Pre-fix this
+// FAILS: the profile is dropped so no error is raised.
+func TestLogProfile_DanglingStream_Rejected(t *testing.T) {
+	tree := buildLogProfileTree(t,
+		"set security log stream real-stream host 192.168.99.3",
+		"set security log profile p1 stream-name does-not-exist",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected error for profile referencing undefined stream, got nil")
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") || !strings.Contains(err.Error(), "p1") {
+		t.Fatalf("error should name the profile and the missing stream: %v", err)
+	}
+}
+
+// TestLogProfile_ValidStream_Accepted verifies a profile naming a defined
+// stream compiles without error.
+func TestLogProfile_ValidStream_Accepted(t *testing.T) {
+	tree := buildLogProfileTree(t,
+		"set security log stream real-stream host 192.168.99.3",
+		"set security log profile p1 stream-name real-stream",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if p := cfg.Security.Log.Profiles["p1"]; p == nil || p.StreamName != "real-stream" {
+		t.Fatalf("expected profile p1 -> real-stream, got %#v", cfg.Security.Log.Profiles["p1"])
+	}
+}
+
+// TestLogProfile_NoStreamName_Accepted verifies a profile with only the
+// default-profile flag (no stream-name) is accepted — there is nothing to
+// dangle, and Junos permits a profile relying on global routing.
+func TestLogProfile_NoStreamName_Accepted(t *testing.T) {
+	tree := buildLogProfileTree(t,
+		"set security log profile p1 default-profile",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	p := cfg.Security.Log.Profiles["p1"]
+	if p == nil || !p.DefaultProfile || p.StreamName != "" {
+		t.Fatalf("expected profile p1 default-profile no stream-name, got %#v", p)
+	}
+}
+
+// TestLogProfile_DanglingStream_LenientWarns verifies the tolerant load /
+// peer-sync path downgrades the dangling reference to a warning rather
+// than failing the compile (the #1960 fail-closed-on-load doctrine).
+func TestLogProfile_DanglingStream_LenientWarns(t *testing.T) {
+	tree := buildLogProfileTree(t,
+		"set security log stream real-stream host 192.168.99.3",
+		"set security log profile p1 stream-name does-not-exist",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient should not error on dangling ref: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "security log profile stream reference") &&
+			strings.Contains(w, "does-not-exist") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a downgraded warning for the dangling stream ref, got %v", cfg.Warnings)
+	}
+}
+
+// TestLogProfile_InactiveProfile_NotValidated verifies an inactive
+// profile (#2042 inactive: marker) is pruned before compile, so a
+// dangling stream-name inside it does NOT error — the profile never
+// reaches compileLog or the cross-ref validator.
+func TestLogProfile_InactiveProfile_NotValidated(t *testing.T) {
+	input := `security {
+    log {
+        stream real-stream {
+            host {
+                192.168.99.3;
+            }
+        }
+        inactive: profile p1 {
+            stream-name does-not-exist;
+            default-profile;
+        }
+    }
+}`
+	p := NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("inactive profile must not be validated/compiled: %v", err)
+	}
+	if _, ok := cfg.Security.Log.Profiles["p1"]; ok {
+		t.Errorf("inactive profile p1 should be pruned, but it compiled: %#v", cfg.Security.Log.Profiles)
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -212,6 +212,26 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				"tls-profile": {desc: "TLS profile name (for protocol tls)", args: 1, placeholder: "<tls-profile-name>", children: nil},
 			}},
 		}},
+		// H7 (#2008): `security log profile <name>` is a Junos log-routing
+		// object — it targets a configured `stream` (`stream-name`), may be
+		// the default profile (`default-profile`), and may carry per-category
+		// field configuration. The whole stanza previously parsed but was
+		// silently discarded (no schema child, no compiler case), so a real
+		// imported config such as vsrx-ha.conf's `profile default-syslog`
+		// committed with no validation and no effect. Declaring it restores
+		// commit-time validation + `?` completion; the compiler cross-
+		// references `stream-name` against the configured streams
+		// (validateLogProfileStreamReferencesStrict). xpf per-stream routing
+		// is already a Junos superset, so no runtime/dispatch change is made.
+		"profile": {desc: "Security log profile (stream-routing object)", args: 1, placeholder: "<profile-name>", children: map[string]*schemaNode{
+			"stream-name":     {desc: "Stream this profile routes to", args: 1, valueHint: ValueHintStreamName, placeholder: "<stream-name>", children: nil},
+			"default-profile": {desc: "Designate this profile as the default", children: nil},
+			"category": {desc: "Per-category field configuration", children: map[string]*schemaNode{
+				"session": {desc: "Session category field configuration", children: map[string]*schemaNode{
+					"field-extra-name": {desc: "Extra field to include in session records", args: 1, placeholder: "<field>", children: nil},
+				}},
+			}},
+		}},
 	}},
 	"flow": {desc: "Flow and session settings", children: map[string]*schemaNode{
 		"aging": {desc: "Aggressive session aging thresholds", children: nil},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -133,6 +133,29 @@ type LogConfig struct {
 	SourceInterface string // interface for source address
 	Streams         map[string]*SyslogStream
 	Report          bool // enable session aggregation reporting (security log report)
+	// Profiles holds Junos `security log profile <name>` objects (#2008
+	// H7). Before this was added the whole `profile` stanza parsed but was
+	// silently discarded (no schema child, no compiler case) — a config
+	// such as `vsrx-ha.conf`'s `profile default-syslog { stream-name ...;
+	// default-profile; }` committed with no effect and no validation. It
+	// is now compiled and cross-referenced against Streams at commit.
+	Profiles map[string]*LogProfile
+}
+
+// LogProfile is a Junos `security log profile <name>` object: a named log
+// routing profile that targets a configured stream and may be marked the
+// default profile (#2008 H7). xpf's per-stream routing is a Junos superset
+// — every stream whose category/severity filter matches receives the
+// event — so a profile's StreamName names the stream that carries its
+// events and DefaultProfile records the operator's default designation.
+// No dispatch change is required: the runtime already routes by stream.
+// The compiler cross-references StreamName against LogConfig.Streams so a
+// profile naming a non-existent stream is rejected at commit rather than
+// silently dropped (see validateLogProfileStreamReferencesStrict).
+type LogProfile struct {
+	Name           string
+	StreamName     string // references LogConfig.Streams[StreamName] when set
+	DefaultProfile bool   // `default-profile;` — operator's default designation
 }
 
 // SyslogTransport defines the transport protocol for a syslog stream.


### PR DESCRIPTION
## Summary

Closes the #2008 (vSRX parity) umbrella sub-gap **H7** — `security log
profile <name>` / `default-profile`. The stanza was a **silent-drop**: a
real imported config such as `vsrx-ha.conf`'s

```
security log {
    profile default-syslog {
        stream-name syslog-container;
        category { session { field-extra-name hostname; } }
        default-profile;
    }
}
```

parsed but was discarded before reaching typed structs (no `profile`
schema child, no `compileLog` case), so it committed with no validation
and no effect — the audit's operationally-dangerous silent-drop class.

This compiles the stanza into typed `LogConfig.Profiles`
(`LogProfile{Name, StreamName, DefaultProfile}`), declares the schema
subtree (restoring `?` completion + commit-time recognition), and
cross-references `stream-name` against the configured streams
(`validateLogProfileStreamReferencesStrict`): a profile naming an
undefined stream is rejected at commit / commit-check (strict) and
downgraded to a warning on the tolerant load / peer-sync paths
(`lenientLogProfileStreamRef`), mirroring the IPsec proposal/gateway
cross-ref gates and the #1960 fail-closed-on-load doctrine.

**No runtime/dataplane change.** xpf per-stream routing is already a
Junos superset (every stream whose category/severity filter matches
receives the event), so a profile's `stream-name` designates the stream
that carries its events; the `default-profile` flag records the
operator's default designation, and `category field-extra-name` is
accepted for parity but not yet used to alter the emitted structured
data. This does **not** close the #2008 umbrella (other Tier-2/3 gaps
remain).

## Plan basis

`docs/research/2008-tier3/plan.md` (H7 = FEASIBLE-INCREMENT small),
sharpened to the real grammar found in the imported `vsrx-ha.conf` (the
audit row's "whole stanza absent" was inaccurate — the per-stream routing
machinery already existed; the residual was the `profile` object + its
`stream-name`/`default-profile`). Plan doc:
`docs/pr/2008-h7-log-default-profile/plan.md`.

## Test plan (control-plane — no dataplane smoke)

- [x] `go build ./...` clean
- [x] `go vet ./pkg/config/` clean
- [x] `go test ./pkg/config/` — full package green
- [x] `go test ./...` — full Go suite green
- [x] New tests (`pkg/config/log_profile_test.go` +
      `pkg/config/log_profile_schema_test.go`), dual-AST flat-set via
      `ParseSetCommand` + `SetPath`:
  - [x] flat-set + hierarchical compile to `LogProfile{StreamName,
        DefaultProfile}`
  - [x] dangling `stream-name` rejected (strict) / warned (lenient)
  - [x] no-`stream-name` profile accepted
  - [x] inactive profile (#2042) pruned before compile — dangling ref
        does not error
  - [x] profile stanza + declared children pass `SchemaValidate`
- [x] **Non-tautology proven**: against the pre-fix compiler (profile
      loop + cross-ref neutered) the compile/reject/lenient-warn tests
      FAIL; they pass with the fix.
- [x] 5/5 flake check on `TestLogProfile*`

## Docs

- `docs/config-schema.md` — #2008 H7 schema/compile/cross-ref entry.
- `docs/feature-gaps.md` — Security Logging Enhancements: Log Profile →
  Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)