### PR TITLE
cluster: re-check heartbeat staleness after peer-timeout guard (#2080)

### DIFF
--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -154,3 +154,16 @@ outside the monitor loop:
 - Dual-active overlap is intentional: primary sets `rg_active=true`
   immediately on becoming master; secondary defers `rg_active=false` until
   it sees the VRRP BACKUP event. Brief overlap, never both inactive.
+- `handlePeerTimeout` runs its peer-timeout guard (`peerTimeoutGuardFn`) with
+  `m.mu` released, so the receiver read path can run `handlePeerHeartbeat`
+  during the call for ANY guard duration (a configured slow guard only widens
+  the window). After the guard it re-checks heartbeat STALENESS via
+  `peerHeartbeatFreshLocked`, not just `peerAlive` (#2080): a heartbeat that
+  lands during the guard window keeps `peerAlive` true but is a fresh
+  heartbeat, so the only correct post-guard question is "is the heartbeat
+  fresh again?". `peerHeartbeatFreshLocked`
+  re-reads the receiver's `lastSeen` against the live monotonic clock (test
+  seam: `peerHeartbeatFreshFn`); a fresh heartbeat aborts the peer-lost
+  transition and prevents spurious failover churn. A nil receiver / unset seam
+  reports not-fresh, so the no-receiver call paths behave exactly as before the
+  re-check existed.

--- a/pkg/cluster/heartbeat.go
+++ b/pkg/cluster/heartbeat.go
@@ -495,6 +495,25 @@ func heartbeatStale(lastSeenMono, nowMono int64, timeout time.Duration) bool {
 	return time.Duration(nowMono-lastSeenMono) > timeout
 }
 
+// peerHeartbeatFresh reports whether a peer heartbeat has been received and is
+// currently within the timeout window — i.e. NOT stale. It re-reads lastSeen
+// against the live monotonic clock, so a heartbeat that landed since the
+// timeout was first declared is observed. A receiver that has never seen a
+// heartbeat (lastSeen == 0) is not "fresh".
+//
+// This is the truth source for handlePeerTimeout's post-guard re-check: after a
+// slow guard window, the only correct question is "is the heartbeat fresh
+// again?", not "is peerAlive still set?" (peerAlive is essentially always true
+// at that point — a fresh heartbeat only keeps it true).
+func (r *heartbeatReceiver) peerHeartbeatFresh() bool {
+	lastNano := r.lastSeen.Load()
+	if lastNano == 0 {
+		return false
+	}
+	timeout := time.Duration(r.threshold) * r.interval
+	return !heartbeatStale(lastNano, MonotonicNanos(), timeout)
+}
+
 func (r *heartbeatReceiver) stop() {
 	close(r.stopCh)
 	r.conn.Close()

--- a/pkg/cluster/heartbeat_guard_recheck_test.go
+++ b/pkg/cluster/heartbeat_guard_recheck_test.go
@@ -1,0 +1,188 @@
+package cluster
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestHandlePeerTimeout_FreshHeartbeatDuringGuardWindow exercises the #2080
+// bug directly: a slow guard window during which a fresh peer heartbeat
+// arrives. The post-guard re-check must consult heartbeat STALENESS, not just
+// peerAlive — a fresh heartbeat that landed during the guard must abort the
+// peer-lost transition.
+//
+// This test FAILS against the pre-fix code (which only re-checked peerAlive,
+// essentially always true) and PASSES with the staleness re-check.
+func TestHandlePeerTimeout_FreshHeartbeatDuringGuardWindow(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(0, false, map[int]int{0: 200, 1: 100}),
+	)
+	m.UpdateConfig(cfg)
+
+	m.mu.Lock()
+	m.peerAlive = true
+	m.peerEverSeen = true
+	m.peerNodeID = 1
+	m.peerGroups = map[int]PeerGroupState{
+		0: {GroupID: 0, Priority: 100, Weight: 255, State: StatePrimary},
+	}
+	// Model the receiver's freshness via the seam. heartbeatArrived flips to
+	// true while the guard runs, simulating a heartbeat landing on the read
+	// path during the (slow) guard window.
+	var heartbeatArrived atomic.Bool
+	m.peerHeartbeatFreshFn = func() bool { return heartbeatArrived.Load() }
+	m.mu.Unlock()
+
+	guardCalled := false
+	// The guard does NOT itself suppress (returns false); it only consumes
+	// wall time, during which a fresh heartbeat arrives. This isolates the
+	// post-guard staleness re-check as the only thing that can save the peer.
+	m.SetPeerTimeoutGuard(func() (bool, string) {
+		guardCalled = true
+		heartbeatArrived.Store(true) // peer heartbeat lands during the guard
+		return false, ""
+	})
+
+	m.handlePeerTimeout()
+
+	if !guardCalled {
+		t.Fatal("guard was not invoked")
+	}
+	if !m.PeerAlive() {
+		t.Fatal("peer marked lost despite a fresh heartbeat arriving during the guard window (#2080)")
+	}
+	if got := len(m.PeerGroupStates()); got != 1 {
+		t.Fatalf("peer groups = %d, want 1 — peer state must be preserved when the heartbeat is fresh", got)
+	}
+}
+
+// TestHandlePeerTimeout_StaleAfterGuardStillMarksLost is the negative control:
+// when NO fresh heartbeat arrives during the guard window (the heartbeat is
+// genuinely stale), the peer must still be marked lost. This guards against an
+// over-eager abort that would break real failover.
+func TestHandlePeerTimeout_StaleAfterGuardStillMarksLost(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(0, false, map[int]int{0: 200, 1: 100}),
+	)
+	m.UpdateConfig(cfg)
+
+	m.mu.Lock()
+	m.peerAlive = true
+	m.peerEverSeen = true
+	m.peerNodeID = 1
+	m.peerGroups = map[int]PeerGroupState{
+		0: {GroupID: 0, Priority: 100, Weight: 255, State: StatePrimary},
+	}
+	// Heartbeat stays stale throughout — no heartbeat arrives during the guard.
+	m.peerHeartbeatFreshFn = func() bool { return false }
+	m.mu.Unlock()
+
+	guardCalled := false
+	m.SetPeerTimeoutGuard(func() (bool, string) {
+		guardCalled = true
+		return false, "" // do not suppress
+	})
+
+	m.handlePeerTimeout()
+
+	if !guardCalled {
+		t.Fatal("guard was not invoked")
+	}
+	if m.PeerAlive() {
+		t.Fatal("peer should be marked lost when the heartbeat is genuinely stale after the guard")
+	}
+	if got := len(m.PeerGroupStates()); got != 0 {
+		t.Fatalf("peer groups = %d, want 0 — peer state must be cleared on a real peer loss", got)
+	}
+}
+
+// TestHandlePeerTimeout_NoReceiverNoSeamStillMarksLost pins the default
+// behavior: with no receiver wired and no seam set, peerHeartbeatFreshLocked
+// reports not-fresh, so the peer-lost transition proceeds exactly as it did
+// before the re-check existed. This protects the many existing callers that
+// drive handlePeerTimeout without a real heartbeat receiver.
+func TestHandlePeerTimeout_NoReceiverNoSeamStillMarksLost(t *testing.T) {
+	m := NewManager(0, 1)
+	cfg := makeConfig(
+		makeRG(0, false, map[int]int{0: 200, 1: 100}),
+	)
+	m.UpdateConfig(cfg)
+
+	m.mu.Lock()
+	m.peerAlive = true
+	m.peerEverSeen = true
+	m.peerGroups = map[int]PeerGroupState{
+		0: {GroupID: 0, Priority: 100, Weight: 255, State: StatePrimary},
+	}
+	m.mu.Unlock()
+
+	// No guard, no seam, no receiver.
+	m.handlePeerTimeout()
+
+	if m.PeerAlive() {
+		t.Fatal("peer should be marked lost with no receiver/seam (default fall-through)")
+	}
+}
+
+// TestPeerHeartbeatFresh_ReceiverBacked exercises the real receiver-backed
+// freshness check (the production path that peerHeartbeatFreshLocked defers to
+// when no seam is set), so the test seam used above is not the only thing
+// validated.
+func TestPeerHeartbeatFresh_ReceiverBacked(t *testing.T) {
+	r := &heartbeatReceiver{
+		threshold: DefaultHeartbeatThreshold,
+		interval:  DefaultHeartbeatInterval,
+	}
+
+	// Never seen → not fresh.
+	if r.peerHeartbeatFresh() {
+		t.Fatal("receiver with lastSeen==0 must report not-fresh")
+	}
+
+	// A heartbeat that just landed → fresh.
+	r.lastSeen.Store(MonotonicNanos())
+	if !r.peerHeartbeatFresh() {
+		t.Fatal("receiver with a just-stored lastSeen must report fresh")
+	}
+
+	// A heartbeat older than the timeout window → stale.
+	timeout := time.Duration(r.threshold) * r.interval
+	r.lastSeen.Store(MonotonicNanos() - (2 * timeout).Nanoseconds())
+	if r.peerHeartbeatFresh() {
+		t.Fatal("receiver with a lastSeen older than the timeout must report stale")
+	}
+}
+
+// TestPeerHeartbeatFreshLocked_ReceiverWiring confirms peerHeartbeatFreshLocked
+// defers to the live receiver when no seam is set — closing the seam-vs-real
+// gap end to end (handlePeerTimeout → Manager helper → receiver).
+func TestPeerHeartbeatFreshLocked_ReceiverWiring(t *testing.T) {
+	m := NewManager(0, 1)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// No receiver, no seam → not fresh.
+	if m.peerHeartbeatFreshLocked() {
+		t.Fatal("no receiver and no seam must report not-fresh")
+	}
+
+	// Wire a receiver with a fresh heartbeat.
+	m.hbReceiver = &heartbeatReceiver{
+		threshold: DefaultHeartbeatThreshold,
+		interval:  DefaultHeartbeatInterval,
+	}
+	m.hbReceiver.lastSeen.Store(MonotonicNanos())
+	if !m.peerHeartbeatFreshLocked() {
+		t.Fatal("receiver with a fresh heartbeat must report fresh through peerHeartbeatFreshLocked")
+	}
+
+	// Seam takes precedence over the receiver.
+	m.peerHeartbeatFreshFn = func() bool { return false }
+	if m.peerHeartbeatFreshLocked() {
+		t.Fatal("seam must take precedence over the receiver")
+	}
+}

--- a/pkg/cluster/heartbeat_manager.go
+++ b/pkg/cluster/heartbeat_manager.go
@@ -329,6 +329,20 @@ func (m *Manager) handlePeerTimeout() {
 	if !m.peerAlive {
 		return // already marked lost while guard ran
 	}
+	// Re-check heartbeat STALENESS, not just peerAlive. m.mu is released
+	// across the guard call above, so the receiver read path can run
+	// handlePeerHeartbeat — setting peerAlive and advancing lastSeen — for
+	// ANY guard duration, not only a slow guard fn (a configured slow guard
+	// merely widens the window). peerAlive is essentially always true here
+	// (it was true on entry and a fresh heartbeat only keeps it true), so
+	// checking it cannot detect that a heartbeat landed during the window —
+	// re-reading lastSeen against the live clock can. If the heartbeat is
+	// fresh again, the peer is not lost: abort to avoid a spurious peer-loss
+	// and the unnecessary failover churn that follows (#2080).
+	if m.peerHeartbeatFreshLocked() {
+		slog.Debug("cluster: aborting peer heartbeat timeout, fresh heartbeat arrived during guard window")
+		return
+	}
 	if suppress, reason := m.suppressPeerTimeoutForTransferCommitLocked(time.Now()); suppress {
 		slog.Debug("cluster: suppressing peer heartbeat timeout", "reason", reason)
 		return

--- a/pkg/cluster/manager.go
+++ b/pkg/cluster/manager.go
@@ -185,6 +185,14 @@ type Manager struct {
 	// session-sync traffic on the control link).
 	peerTimeoutGuardFn func() (suppress bool, reason string)
 
+	// peerHeartbeatFreshFn reports whether a peer heartbeat is currently
+	// within the timeout window (i.e. NOT stale). handlePeerTimeout consults
+	// it AFTER the (possibly slow) guard window so a heartbeat that arrived
+	// during the guard aborts the spurious peer-lost transition. Defaults to
+	// the live receiver-backed check via peerHeartbeatFresh; overridable in
+	// tests to inject a fresh/stale heartbeat without a real socket.
+	peerHeartbeatFreshFn func() bool
+
 	// hbRestartNotifyFn is invoked around RestartHeartbeat's socket
 	// teardown/rebind window (once before teardown, once after each failed
 	// bind retry). The daemon wires it to SessionSync.SendLivenessKeepalive

--- a/pkg/cluster/peer_state.go
+++ b/pkg/cluster/peer_state.go
@@ -7,6 +7,25 @@ func (m *Manager) PeerAlive() bool {
 	return m.peerAlive
 }
 
+// peerHeartbeatFreshLocked reports whether a peer heartbeat is currently within
+// the timeout window (NOT stale). It is the truth source for
+// handlePeerTimeout's post-guard re-check. Must be called with m.mu held (it
+// reads m.peerHeartbeatFreshFn and m.hbReceiver).
+//
+// The test seam (m.peerHeartbeatFreshFn) takes precedence so tests can inject a
+// fresh/stale heartbeat without a real socket. Otherwise it defers to the live
+// receiver. A nil receiver (no heartbeat path wired) reports "not fresh" so the
+// peer-lost transition proceeds exactly as before this re-check existed.
+func (m *Manager) peerHeartbeatFreshLocked() bool {
+	if m.peerHeartbeatFreshFn != nil {
+		return m.peerHeartbeatFreshFn()
+	}
+	if m.hbReceiver != nil {
+		return m.hbReceiver.peerHeartbeatFresh()
+	}
+	return false
+}
+
 // PeerNodeID returns the peer's node ID (valid only when PeerAlive is true).
 func (m *Manager) PeerNodeID() int {
 	m.mu.RLock()


### PR DESCRIPTION
## Summary

Fixes #2080. In `pkg/cluster`, `handlePeerTimeout` runs its peer-timeout
guard (`peerTimeoutGuardFn`) with `m.mu` released, then post-guard it
re-checked only `m.peerAlive` — which is essentially always true at that
point — instead of re-checking heartbeat **staleness**. A peer heartbeat
that lands during the guard window advances the receiver's `lastSeen` and
sets `peerAlive = true`, yet the peer was still marked lost, producing a
spurious peer-loss and unnecessary failover churn.

The fix adds a post-guard staleness re-check: a new
`(*heartbeatReceiver).peerHeartbeatFresh()` re-reads `lastSeen` against
the live monotonic clock (reusing `heartbeatStale` + the receiver's own
`threshold*interval` timeout), and `handlePeerTimeout` aborts the
peer-lost transition if a fresh heartbeat arrived during the guard. The
abort returns **before** any state mutation, election, or fencing, so a
live peer is never fenced or left half-cleared.

**Failover-safe by construction:** `peerHeartbeatFresh` uses the *same*
timeout that `timeoutLoop` used to declare staleness, and `MonotonicNanos`
is forward-only — so once `timeoutLoop` fired, a re-check can only confirm
stale unless a *real* heartbeat advanced `lastSeen`. A dead peer can never
wrongly abort failover. A nil receiver / unset seam reports not-fresh, so
every existing no-receiver call path behaves exactly as before.

## Review (companions infra-degraded — independent hostile Claude reviewers)

- Hostile Claude reviewer 1 (correctness/locking/TOCTOU/test-tautology): **MERGE-READY** — neutered the fix line and confirmed the key test FAILS pre-fix, then reverted clean. One cosmetic NIT.
- Hostile Claude reviewer 2 (HA-semantics/failover-safety): **MERGE-READY** — independently derived that a dead peer cannot abort failover (monotonic-forward + identical receiver timeout source). Two NITs.
- Maintainer SMR (contrarian final pass): **MERGE-READY** — re-derived failover safety from scratch; raised one MINOR (comment/commit over-emphasized "slow guard" when the window exists for any guard duration due to the lock release) which has been **folded in**. Other items NITs.

## Test plan

- [x] `go build ./pkg/cluster/` clean
- [x] `go vet ./pkg/cluster/` clean
- [x] `go test ./pkg/cluster/` passes
- [x] Heartbeat/timeout path passes under `-race` with `-count=3`
- [x] Full `pkg/cluster` suite passes under `-race` **except** the pre-existing `TestBulkEpochMismatchIgnored` test-side data race (bulk-epoch sync path; reproduces on clean origin/master; unrelated to this change)
- [x] New tests are non-tautological: `TestHandlePeerTimeout_FreshHeartbeatDuringGuardWindow` FAILS against pre-fix code (verified by removing the re-check line); negative control + no-receiver default still mark the peer lost; receiver-backed `peerHeartbeatFresh` + `peerHeartbeatFreshLocked` wiring exercised directly
- [x] `pkg/cluster/README.md` updated with the post-guard staleness re-check gotcha
- [ ] **HA cluster `make test-failover` — PENDING the parent harness run** (this PR was driven without running cluster smoke / test-failover per the campaign division of labor; the parent runs the central test-failover before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)