### PR TITLE
dhcprelay: raw-L2 unicast OFFER/ACK for broadcast-flag-clear clients (#2076)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -7483,3 +7483,34 @@ top.
   pkg/config/ipsec_proposal_ref_test.go, pkg/ipsec/ipsec_test.go,
   pkg/config/parser_security_test.go, pkg/ipsec/README.md,
   docs/pr/2073-ipsec-pfs/plan.md
+
+## 2026-06-20 — #2076 DHCP relay raw-L2 unicast for broadcast-flag=0 clients
+
+- **Timestamp**: 2026-06-20
+- **Action**: Implement Option (d) — RFC-2131 raw AF_PACKET L2 unicast of
+  OFFER/ACK to chaddr+yiaddr by default for broadcast-flag-clear clients,
+  opt-in `overrides always-broadcast`, automatic broadcast fallback.
+- **File(s)**:
+  - `pkg/dhcprelay/l2send_linux.go` (new) — AF_PACKET TX sender, per-byte
+    frame builder (IPv4 csum computed, UDP csum=0), MTU/htype guards,
+    per-send iface re-resolution, idempotent Close (sync.Once).
+  - `pkg/dhcprelay/relay.go` — reply-destination matrix (deliverReply),
+    per-reason counters, l2Replier seam + factory, fail-soft L2 open closed
+    after wg.Wait() (#1915-preserving).
+  - `pkg/dhcprelay/delivery_test.go`, `l2send_test.go`, `relay_test.go` —
+    matrix oracle, exhaustive per-byte frame tests, guards, fallback,
+    no-double-deliver, saved-giaddr source, lifecycle.
+  - `pkg/config/types_system.go` — DHCPRelayGroup.AlwaysBroadcast.
+  - `pkg/config/compiler_services.go` — `overrides` boundary keyword +
+    block/inline parse (Codex#2 swallow blocker).
+  - `pkg/config/schema_routing.go` — `overrides { always-broadcast }`.
+  - `pkg/config/compiler_dhcp_relay_overrides_test.go` (new),
+    `dual_ast_differential_test.go` — flat-set swallow regression +
+    round-trip.
+  - `pkg/cli/cli_show_services.go` — reply-delivery breakdown + override
+    display.
+  - `pkg/dhcprelay/README.md` — reply-delivery model, CAP_NET_RAW, counters,
+    IPv6/HA parity notes.
+- **Validation**: `go test ./pkg/dhcprelay/ -race` 25/25 pass; config + cli +
+  daemon green; `go build ./...` clean. Live flag0 wire-capture +
+  test-failover pending parent-run (lab-gated).

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -307,6 +307,9 @@ func (c *CLI) showDHCPRelay() error {
 			fmt.Printf("  %s:\n", name)
 			fmt.Printf("    Interfaces: %s\n", strings.Join(g.Interfaces, ", "))
 			fmt.Printf("    Active server group: %s\n", g.ActiveServerGroup)
+			if g.AlwaysBroadcast {
+				fmt.Printf("    Overrides: always-broadcast\n")
+			}
 		}
 	}
 
@@ -318,6 +321,19 @@ func (c *CLI) showDHCPRelay() error {
 			fmt.Printf("  %-16s %-20s %s\n", "Interface", "Requests relayed", "Replies forwarded")
 			for _, s := range stats {
 				fmt.Printf("  %-16s %-20d %d\n", s.Interface, s.RequestsRelayed, s.RepliesForwarded)
+			}
+			// Reply-delivery breakdown (#2076). L2-fallback is the one to
+			// alert on: it means the raw-L2 path failed (CAP_NET_RAW,
+			// driver, or MTU) and the relay degraded to broadcast.
+			fmt.Println("\nReply delivery (#2076):")
+			fmt.Printf("  %-16s %-10s %-10s %-10s %-10s %-10s %s\n",
+				"Interface", "L2-unicast", "ciaddr", "bcast-flag", "bcast-fwd",
+				"no-target", "L2-fallback")
+			for _, s := range stats {
+				fmt.Printf("  %-16s %-10d %-10d %-10d %-10d %-10d %d\n",
+					s.Interface, s.RepliesL2Unicast, s.RepliesUnicastCiaddr,
+					s.RepliesBroadcastFlag1, s.RepliesBroadcastForced,
+					s.RepliesBroadcastNoTarget, s.RepliesBroadcastL2Fallback)
 			}
 		}
 	}

--- a/pkg/config/compiler_dhcp_relay_overrides_test.go
+++ b/pkg/config/compiler_dhcp_relay_overrides_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"testing"
+)
+
+// #2076: `forwarding-options dhcp-relay group <g> overrides always-broadcast`
+// must compile to DHCPRelayGroup.AlwaysBroadcast in BOTH AST shapes and must
+// NOT be swallowed into the interface list by the inline flat-set consumer.
+// All tests use the production ParseSetCommand + SetPath path (buildTree),
+// never NewParser (the flat-set gotcha in CLAUDE.md).
+
+func relayGroup(t *testing.T, cfg *Config, name string) *DHCPRelayGroup {
+	t.Helper()
+	if cfg.ForwardingOptions.DHCPRelay == nil {
+		t.Fatalf("DHCPRelay config nil")
+	}
+	g := cfg.ForwardingOptions.DHCPRelay.Groups[name]
+	if g == nil {
+		t.Fatalf("relay group %q not found", name)
+	}
+	return g
+}
+
+// TestDHCPRelayOverrides_FlatSet_NotSwallowed is the BLOCKER regression
+// (Codex#2): the flat-set inline interface consumer must stop at `overrides`,
+// not eat it (and `always-broadcast`) into the interface list.
+func TestDHCPRelayOverrides_FlatSet_NotSwallowed(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set forwarding-options dhcp-relay server-group sg 10.1.1.1",
+		"set forwarding-options dhcp-relay group lan active-server-group sg",
+		"set forwarding-options dhcp-relay group lan interface ge-0/0/0.0",
+		"set forwarding-options dhcp-relay group lan overrides always-broadcast",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	g := relayGroup(t, cfg, "lan")
+
+	if !g.AlwaysBroadcast {
+		t.Errorf("AlwaysBroadcast = false, want true (flat-set overrides)")
+	}
+	// The interface list must be EXACTLY [ge-0/0/0.0] — no overrides/
+	// always-broadcast swallowed in.
+	if len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0/0/0.0" {
+		t.Errorf("Interfaces = %v, want [ge-0/0/0.0] (swallow regression)", g.Interfaces)
+	}
+	for _, name := range g.Interfaces {
+		if name == "overrides" || name == "always-broadcast" {
+			t.Errorf("override token %q swallowed into Interfaces: %v", name, g.Interfaces)
+		}
+	}
+}
+
+// TestDHCPRelayOverrides_FlatSet_OverridesBeforeInterface guards the reverse
+// token order: `overrides always-broadcast` appearing before `interface` must
+// still set the flag and the boundary must keep interface parsing correct.
+func TestDHCPRelayOverrides_FlatSet_OverridesBeforeInterface(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set forwarding-options dhcp-relay server-group sg 10.1.1.1",
+		"set forwarding-options dhcp-relay group lan overrides always-broadcast",
+		"set forwarding-options dhcp-relay group lan active-server-group sg",
+		"set forwarding-options dhcp-relay group lan interface ge-0/0/0.0",
+		"set forwarding-options dhcp-relay group lan interface ge-0/0/1.0",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	g := relayGroup(t, cfg, "lan")
+	if !g.AlwaysBroadcast {
+		t.Errorf("AlwaysBroadcast = false, want true")
+	}
+	if len(g.Interfaces) != 2 {
+		t.Errorf("Interfaces = %v, want 2 entries", g.Interfaces)
+	}
+	for _, name := range g.Interfaces {
+		if name == "overrides" || name == "always-broadcast" {
+			t.Errorf("override token %q swallowed into Interfaces: %v", name, g.Interfaces)
+		}
+	}
+}
+
+// TestDHCPRelayOverrides_Absent proves the flag defaults to false with no
+// overrides stanza (the additive default).
+func TestDHCPRelayOverrides_Absent(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set forwarding-options dhcp-relay server-group sg 10.1.1.1",
+		"set forwarding-options dhcp-relay group lan active-server-group sg",
+		"set forwarding-options dhcp-relay group lan interface ge-0/0/0.0",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	g := relayGroup(t, cfg, "lan")
+	if g.AlwaysBroadcast {
+		t.Errorf("AlwaysBroadcast = true, want false (absent override)")
+	}
+}
+
+// TestDHCPRelayOverrides_SchemaCompletion proves the structural completion
+// offers `always-broadcast` under `overrides`.
+func TestDHCPRelayOverrides_SchemaCompletion(t *testing.T) {
+	comps := CompleteSetPath([]string{
+		"forwarding-options", "dhcp-relay", "group", "lan", "overrides", "",
+	})
+	found := false
+	for _, c := range comps {
+		if c == "always-broadcast" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("overrides completion missing always-broadcast; got %v", comps)
+	}
+}

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -1109,9 +1109,14 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 				// Multi-value (#1813): consume every following token up
 				// to the next recognized property keyword —
 				// `group lan interface [ a b ];` packs all interfaces
-				// inline.
+				// inline. `overrides` MUST be a boundary keyword
+				// (#2076) so a flat-set
+				// `group g interface ge-0/0/0.0 overrides always-broadcast`
+				// does not swallow `overrides`/`always-broadcast` into
+				// the interface list.
 				for i+1 < len(keys) && keys[i+1] != "interface" &&
-					keys[i+1] != "active-server-group" {
+					keys[i+1] != "active-server-group" &&
+					keys[i+1] != "overrides" {
 					i++
 					g.Interfaces = append(g.Interfaces, keys[i])
 				}
@@ -1119,6 +1124,18 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 				if i+1 < len(keys) {
 					i++
 					g.ActiveServerGroup = keys[i]
+				}
+			case "overrides":
+				// Inline flat-set spelling (#2076):
+				// `group g overrides always-broadcast`. Consume the
+				// override sub-keywords until the next group property.
+				for i+1 < len(keys) && keys[i+1] != "interface" &&
+					keys[i+1] != "active-server-group" &&
+					keys[i+1] != "overrides" {
+					i++
+					if keys[i] == "always-broadcast" {
+						g.AlwaysBroadcast = true
+					}
 				}
 			}
 		}
@@ -1141,6 +1158,18 @@ func compileDHCPRelay(node *Node, fo *ForwardingOptionsConfig) error {
 				}
 			case "active-server-group":
 				g.ActiveServerGroup = nodeVal(prop)
+			case "overrides":
+				// Block form (#2076): `overrides { always-broadcast; }`.
+				// always-broadcast may also ride in Keys[1:] when the
+				// override block collapses to a single inline value.
+				if prop.FindChild("always-broadcast") != nil {
+					g.AlwaysBroadcast = true
+				}
+				for _, k := range prop.Keys[1:] {
+					if k == "always-broadcast" {
+						g.AlwaysBroadcast = true
+					}
+				}
 			}
 		}
 	}

--- a/pkg/config/dual_ast_differential_test.go
+++ b/pkg/config/dual_ast_differential_test.go
@@ -740,6 +740,31 @@ services {
 		expectedFail: false,
 	},
 	{
+		// #2076: `overrides always-broadcast` must survive BOTH AST shapes
+		// and must NOT be swallowed into the interface list by the inline
+		// flat-set consumer. compileDHCPRelay added `overrides` to the
+		// interface boundary set and parses the override from both Keys and
+		// Children.
+		name: "forwarding-options-dhcp-relay-overrides",
+		hier: `forwarding-options {
+    dhcp-relay {
+        server-group {
+            sg1 {
+                10.1.1.1;
+            }
+        }
+        group lan {
+            active-server-group sg1;
+            interface ge-0/0/0.0;
+            overrides {
+                always-broadcast;
+            }
+        }
+    }
+}`,
+		expectedFail: false,
+	},
+	{
 		name: "protocols-ospf-bgp",
 		hier: `protocols {
     ospf {

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -378,6 +378,9 @@ var schemaForwardingOptions = &schemaNode{desc: "Packet forwarding options", chi
 		"group": {desc: "DHCP relay group", args: 1, placeholder: "<name>", children: map[string]*schemaNode{
 			"active-server-group": {desc: "Active server group", args: 1, placeholder: "<server-group>", children: nil},
 			"interface":           {desc: "Interface to relay on", args: 1, multi: true, placeholder: "<interface>", children: nil},
+			"overrides": {desc: "Relay overrides", children: map[string]*schemaNode{
+				"always-broadcast": {desc: "Always broadcast replies to clients", children: nil},
+			}},
 		}},
 	}},
 }}

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -704,6 +704,13 @@ type DHCPRelayGroup struct {
 	Name              string
 	Interfaces        []string
 	ActiveServerGroup string // reference to server group name
+	// AlwaysBroadcast forces every server reply (OFFER/ACK) to be
+	// broadcast to 255.255.255.255:68 even when the client cleared the
+	// broadcast flag, mirroring Junos `dhcp-relay ... overrides
+	// always-broadcast`. When false (the default) the relay honors the
+	// client's broadcast flag and raw-L2-unicasts flag-clear replies to
+	// chaddr+yiaddr (#2076).
+	AlwaysBroadcast bool
 }
 
 // SamplingConfig holds sampling instance definitions.

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -19,7 +19,91 @@ to the interface name.
 
 ## Dependencies
 
-`pkg/config` only.
+`pkg/config`, `github.com/insomniacslk/dhcp`, and `golang.org/x/sys/unix`
+(the last for the AF_PACKET raw-L2 reply socket — see "Reply delivery
+model" below). No dependency on other `pkg/*` packages.
+
+## Reply delivery model (#2076)
+
+Server replies (OFFER/ACK) are delivered to clients honoring the RFC 2131
+§4.1 broadcast flag:
+
+| Condition | Delivery |
+|-----------|----------|
+| `overrides always-broadcast` set | broadcast `255.255.255.255:68` (operator override wins) |
+| broadcast flag **set** | broadcast `255.255.255.255:68` |
+| flag **clear**, real `yiaddr` | **raw-L2 unicast** to `chaddr` + `yiaddr` |
+| flag **clear**, `yiaddr==0`, real `ciaddr` | UDP-unicast to `ciaddr` (client already owns the IP) |
+| flag **clear**, no `yiaddr`/`ciaddr` | broadcast (nothing routable) |
+| raw-L2 path unavailable/fails | broadcast fallback (always works) |
+
+**Why raw L2 (`l2send_linux.go`).** A client in SELECTING/REQUESTING that
+clears the broadcast flag has **not yet configured** the offered address,
+so it will not answer ARP for `yiaddr`. A normal UDP `WriteTo(yiaddr)`
+forces the kernel to ARP-resolve `yiaddr`, the ARP goes unanswered, and the
+reply is silently dropped — the client never acquires a lease. The relay
+therefore builds a full Ethernet+IPv4+UDP frame addressed to the client's
+`chaddr` and sends it on an `AF_PACKET`/`SOCK_RAW` socket (the
+`pkg/cluster/garp.go` hand-roll pattern). The IPv4 source is the **saved
+giaddr** (the same address the server saw in the relayed request); the IPv4
+header checksum is computed and the UDP checksum is 0 (legal for IPv4 per
+RFC 768).
+
+- **`CAP_NET_RAW` dependency.** The AF_PACKET socket needs `CAP_NET_RAW`,
+  already held by the root daemon (same as `pkg/vrrp`, `pkg/lldp`,
+  `pkg/cluster/garp.go`). If the socket cannot be opened (e.g. a future
+  hardened unit without the cap), the relay logs once and falls back to
+  broadcast — it **never regresses to undeliverable**.
+- **Guards → broadcast fallback.** Non-Ethernet `htype`, a non-6-byte
+  `chaddr`, an over-MTU reply (`20 + 8 + len(payload) > iface.MTU` — the raw
+  path cannot fragment), or any `Sendto` error fall back to broadcast.
+- **Per-send interface re-resolution.** The ifindex + source MAC are
+  re-resolved from `net.InterfaceByName` on every send (`garp.go`
+  precedent), so a link flap / dynamic recreate / VRRP `programRethMAC` MAC
+  change does not leave a stale ifindex or source MAC. VLAN sub-interface
+  egress uses the same netdev index the listener is bound to (the kernel
+  applies the `.N` 802.1Q tag).
+- **Counters.** `Stats()` exposes a per-reason breakdown
+  (`RepliesL2Unicast`, `RepliesUnicastCiaddr`, `RepliesBroadcastFlag1`,
+  `RepliesBroadcastForced`, `RepliesBroadcastNoTarget`,
+  `RepliesBroadcastL2Fallback`). **`RepliesBroadcastL2Fallback` is the one
+  to alert on** — it means the raw-L2 path failed (CAP_NET_RAW, driver, or
+  MTU) and the relay degraded to broadcast. `show ... dhcp-relay` prints
+  this breakdown.
+
+### `overrides always-broadcast` config
+
+```
+set forwarding-options dhcp-relay group <g> overrides always-broadcast
+```
+
+Mirrors the Junos knob: forces every reply to broadcast even for
+flag-clear clients (the raw-L2 socket is not opened at all when set). This
+is the operator escape hatch for environments where the L2 path is
+undesirable. Both the block form (`overrides { always-broadcast; }`) and
+the flat-set form compile to `DHCPRelayGroup.AlwaysBroadcast`; the flat-set
+inline-interface consumer treats `overrides` as a property boundary so it
+is not swallowed into the interface list (#2076 / dual-AST harness case
+`forwarding-options-dhcp-relay-overrides`).
+
+### IPv6 / DHCPv6 parity
+
+There is **no DHCPv6 relay agent** in the codebase, and DHCPv6 (RFC 8415)
+does not have this bug class: it has no BOOTP broadcast flag — clients use a
+link-local source and the relay replies to that link-local unicast (or
+`ff02::1:2`), so there is no "reply to an unconfigured global address via
+ND" failure mode. This fix is strictly DHCPv4.
+
+### HA / VRRP-Backup duplicate delivery
+
+Before #2076, a relay running on a VRRP **Backup** node sent a duplicate
+flag-clear reply that was harmlessly lost on ARP failure. Now that the
+flag-clear path actually delivers (raw L2 to `chaddr`), a flag-clear client
+may receive duplicate OFFER/ACK from both nodes. DHCP clients dedupe on
+`xid` + `chaddr`, so this is tolerable; a single node never double-delivers
+(L2 success and broadcast are mutually exclusive per reply). Suppressing
+relay forwarding on a VRRP-Backup node remains a deferred follow-up (see
+below). Changes touching this path must pass `make test-failover`.
 
 ## Socket / lifecycle model (#1915)
 
@@ -75,4 +159,6 @@ to the interface name.
   would relay duplicate requests. DHCP tolerates this (servers dedupe on
   xid + chaddr; clients dedupe offers), so it is an acceptable interim;
   suppressing forwarding on Backup is a deferred follow-up gated on
-  `make test-failover`.
+  `make test-failover`. Note (#2076): the Backup's duplicate *reply* to a
+  flag-clear client now actually delivers (raw L2) instead of being lost on
+  ARP failure — see "HA / VRRP-Backup duplicate delivery" above.

--- a/pkg/dhcprelay/delivery_test.go
+++ b/pkg/dhcprelay/delivery_test.go
@@ -1,0 +1,409 @@
+package dhcprelay
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/iana"
+)
+
+// fakeL2 records sendReply calls and can be forced to fail to exercise the
+// broadcast fallback. It implements l2Replier.
+type fakeL2 struct {
+	mu         sync.Mutex
+	calls      []fakeL2Call
+	failWith   error
+	closeCount int
+}
+
+type fakeL2Call struct {
+	dstMAC       net.HardwareAddr
+	srcIP, dstIP net.IP
+	payload      []byte
+}
+
+func (f *fakeL2) sendReply(dstMAC net.HardwareAddr, srcIP, dstIP net.IP, payload []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := append([]byte(nil), payload...)
+	f.calls = append(f.calls, fakeL2Call{
+		dstMAC:  append(net.HardwareAddr(nil), dstMAC...),
+		srcIP:   append(net.IP(nil), srcIP...),
+		dstIP:   append(net.IP(nil), dstIP...),
+		payload: cp,
+	})
+	return f.failWith
+}
+
+func (f *fakeL2) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closeCount++
+	return nil
+}
+
+func (f *fakeL2) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// newReply builds a BOOTREPLY OFFER with the given flags/yiaddr/ciaddr/chaddr.
+func newReply(t *testing.T, broadcast bool, yiaddr, ciaddr net.IP, chaddr net.HardwareAddr) *dhcpv4.DHCPv4 {
+	t.Helper()
+	pkt, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	pkt.OpCode = dhcpv4.OpcodeBootReply
+	pkt.HWType = iana.HWTypeEthernet
+	pkt.ClientHWAddr = chaddr
+	pkt.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeOffer))
+	if broadcast {
+		pkt.SetBroadcast()
+	}
+	if yiaddr != nil {
+		pkt.YourIPAddr = yiaddr
+	} else {
+		pkt.YourIPAddr = net.IPv4zero
+	}
+	if ciaddr != nil {
+		pkt.ClientIPAddr = ciaddr
+	} else {
+		pkt.ClientIPAddr = net.IPv4zero
+	}
+	return pkt
+}
+
+var (
+	testGiaddr = net.IPv4(10, 0, 0, 254)
+	testYiaddr = net.IPv4(10, 0, 0, 50)
+	testCiaddr = net.IPv4(10, 0, 0, 60)
+	testChaddr = net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x99}
+)
+
+// TestDeliverReply_Matrix is the §7.1 decision-matrix oracle: every row of the
+// reply-destination table maps to exactly one delivery path and one counter.
+func TestDeliverReply_Matrix(t *testing.T) {
+	type want struct {
+		l2Calls     int          // raw-L2 unicast sends
+		clientWrite *net.UDPAddr // expected UDP WriteTo dst, nil if none
+		counter     func(*interfaceRelay) uint64
+		counterName string
+	}
+	cases := []struct {
+		name            string
+		alwaysBroadcast bool
+		l2Fails         bool
+		nilL2           bool
+		pkt             func(*testing.T) *dhcpv4.DHCPv4
+		want            want
+	}{
+		{
+			name: "flag1_broadcast",
+			pkt:  func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, true, testYiaddr, nil, testChaddr) },
+			want: want{
+				clientWrite: &net.UDPAddr{IP: net.IPv4bcast, Port: clientPort},
+				counter:     func(ir *interfaceRelay) uint64 { return ir.repliesBroadcastFlag1.Load() },
+				counterName: "repliesBroadcastFlag1",
+			},
+		},
+		{
+			name: "flag0_real_yiaddr_L2",
+			pkt:  func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, testYiaddr, nil, testChaddr) },
+			want: want{
+				l2Calls:     1,
+				counter:     func(ir *interfaceRelay) uint64 { return ir.repliesL2Unicast.Load() },
+				counterName: "repliesL2Unicast",
+			},
+		},
+		{
+			name:    "flag0_real_yiaddr_L2_fail_fallback",
+			l2Fails: true,
+			pkt:     func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, testYiaddr, nil, testChaddr) },
+			want: want{
+				l2Calls:     1,
+				clientWrite: &net.UDPAddr{IP: net.IPv4bcast, Port: clientPort},
+				counter:     func(ir *interfaceRelay) uint64 { return ir.repliesBroadcastL2Fallback.Load() },
+				counterName: "repliesBroadcastL2Fallback",
+			},
+		},
+		{
+			name:  "flag0_real_yiaddr_nil_l2_fallback",
+			nilL2: true,
+			pkt:   func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, testYiaddr, nil, testChaddr) },
+			want: want{
+				clientWrite: &net.UDPAddr{IP: net.IPv4bcast, Port: clientPort},
+				counter:     func(ir *interfaceRelay) uint64 { return ir.repliesBroadcastL2Fallback.Load() },
+				counterName: "repliesBroadcastL2Fallback",
+			},
+		},
+		{
+			name: "flag0_no_yiaddr_ciaddr_unicast",
+			pkt:  func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, nil, testCiaddr, testChaddr) },
+			want: want{
+				clientWrite: &net.UDPAddr{IP: testCiaddr, Port: clientPort},
+				counter:     func(ir *interfaceRelay) uint64 { return ir.repliesUnicastCiaddr.Load() },
+				counterName: "repliesUnicastCiaddr",
+			},
+		},
+		{
+			name: "flag0_no_yiaddr_no_ciaddr_broadcast",
+			pkt:  func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, nil, nil, testChaddr) },
+			want: want{
+				clientWrite: &net.UDPAddr{IP: net.IPv4bcast, Port: clientPort},
+				counter:     func(ir *interfaceRelay) uint64 { return ir.repliesBroadcastNoTarget.Load() },
+				counterName: "repliesBroadcastNoTarget",
+			},
+		},
+		{
+			name:            "overrides_always_broadcast_wins",
+			alwaysBroadcast: true,
+			pkt:             func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, testYiaddr, nil, testChaddr) },
+			want: want{
+				clientWrite: &net.UDPAddr{IP: net.IPv4bcast, Port: clientPort},
+				counter:     func(ir *interfaceRelay) uint64 { return ir.repliesBroadcastForced.Load() },
+				counterName: "repliesBroadcastForced",
+			},
+		},
+		{
+			name:            "overrides_beats_flag0_yiaddr_no_L2",
+			alwaysBroadcast: true,
+			pkt:             func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, testYiaddr, nil, testChaddr) },
+			want: want{
+				l2Calls:     0, // override must NOT touch the L2 path
+				clientWrite: &net.UDPAddr{IP: net.IPv4bcast, Port: clientPort},
+				counter:     func(ir *interfaceRelay) uint64 { return ir.repliesBroadcastForced.Load() },
+				counterName: "repliesBroadcastForced",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ir := &interfaceRelay{ifaceName: "ge-0-0-0", alwaysBroadcast: tc.alwaysBroadcast}
+			client := newFakeConn()
+			defer client.Close()
+			var l2 l2Replier
+			fl2 := &fakeL2{}
+			if tc.l2Fails {
+				fl2.failWith = errors.New("forced l2 failure")
+			}
+			if !tc.nilL2 {
+				l2 = fl2
+			}
+			pkt := tc.pkt(t)
+			payload := pkt.ToBytes()
+
+			ok := deliverReply(ir, client, l2, testGiaddr, pkt, payload)
+			if !ok {
+				t.Fatalf("deliverReply returned false (delivery failed)")
+			}
+
+			if got := fl2.callCount(); got != tc.want.l2Calls {
+				t.Errorf("L2 sendReply calls = %d, want %d", got, tc.want.l2Calls)
+			}
+
+			client.mu.Lock()
+			writes := append([]fakeWrite(nil), client.writes...)
+			client.mu.Unlock()
+			if tc.want.clientWrite == nil {
+				if len(writes) != 0 {
+					t.Errorf("expected NO client UDP write, got %d", len(writes))
+				}
+			} else {
+				if len(writes) != 1 {
+					t.Fatalf("expected 1 client UDP write, got %d", len(writes))
+				}
+				got := writes[0].addr.(*net.UDPAddr)
+				if !got.IP.Equal(tc.want.clientWrite.IP) || got.Port != tc.want.clientWrite.Port {
+					t.Errorf("client write dst = %v, want %v", got, tc.want.clientWrite)
+				}
+			}
+
+			if got := tc.want.counter(ir); got != 1 {
+				t.Errorf("counter %s = %d, want 1", tc.want.counterName, got)
+			}
+
+			// On the L2-success path, verify the L2 frame is addressed to
+			// chaddr + yiaddr with the SAVED giaddr source.
+			if tc.want.l2Calls == 1 && !tc.l2Fails {
+				fl2.mu.Lock()
+				c := fl2.calls[0]
+				fl2.mu.Unlock()
+				if !equalBytes(c.dstMAC, testChaddr) {
+					t.Errorf("L2 dstMAC = %x, want chaddr %x", c.dstMAC, testChaddr)
+				}
+				if !c.srcIP.Equal(testGiaddr) {
+					t.Errorf("L2 srcIP = %v, want saved giaddr %v", c.srcIP, testGiaddr)
+				}
+				if !c.dstIP.Equal(testYiaddr) {
+					t.Errorf("L2 dstIP = %v, want yiaddr %v", c.dstIP, testYiaddr)
+				}
+			}
+		})
+	}
+}
+
+// TestL2Eligible enforces the htype/chaddr guards: only 6-byte Ethernet
+// addresses are L2-eligible; everything else falls back to broadcast.
+func TestL2Eligible(t *testing.T) {
+	mk := func(ht iana.HWType, chaddr net.HardwareAddr) *dhcpv4.DHCPv4 {
+		return &dhcpv4.DHCPv4{HWType: ht, ClientHWAddr: chaddr}
+	}
+	mac6 := net.HardwareAddr{1, 2, 3, 4, 5, 6}
+	mac8 := net.HardwareAddr{1, 2, 3, 4, 5, 6, 7, 8}
+
+	if !l2Eligible(mk(iana.HWTypeEthernet, mac6)) {
+		t.Errorf("6-byte Ethernet must be L2-eligible")
+	}
+	if l2Eligible(mk(iana.HWTypeEthernet, mac8)) {
+		t.Errorf("8-byte chaddr must NOT be L2-eligible")
+	}
+	if l2Eligible(mk(iana.HWTypeIEEE802, mac6)) {
+		t.Errorf("non-Ethernet htype must NOT be L2-eligible")
+	}
+	if l2Eligible(mk(iana.HWTypeEthernet, net.HardwareAddr{1, 2, 3})) {
+		t.Errorf("3-byte chaddr must NOT be L2-eligible")
+	}
+}
+
+// TestDeliverReply_NonEthernet_FallsBackToBroadcast proves a non-Ethernet htype
+// with a real yiaddr does NOT take the L2 path (the frame would be malformed)
+// and broadcasts instead, counting it as an L2 fallback.
+func TestDeliverReply_NonEthernet_FallsBackToBroadcast(t *testing.T) {
+	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+	client := newFakeConn()
+	defer client.Close()
+	fl2 := &fakeL2{}
+
+	pkt := newReply(t, false, testYiaddr, nil, net.HardwareAddr{1, 2, 3, 4, 5, 6})
+	pkt.HWType = iana.HWTypeIEEE802 // not Ethernet
+
+	if !deliverReply(ir, client, fl2, testGiaddr, pkt, pkt.ToBytes()) {
+		t.Fatal("deliverReply returned false")
+	}
+	if fl2.callCount() != 0 {
+		t.Errorf("non-Ethernet must NOT call L2 sendReply, got %d", fl2.callCount())
+	}
+	if ir.repliesBroadcastL2Fallback.Load() != 1 {
+		t.Errorf("expected L2-fallback counter, got %d", ir.repliesBroadcastL2Fallback.Load())
+	}
+	client.mu.Lock()
+	n := len(client.writes)
+	dst := net.IP(nil)
+	if n == 1 {
+		dst = client.writes[0].addr.(*net.UDPAddr).IP
+	}
+	client.mu.Unlock()
+	if n != 1 || !dst.Equal(net.IPv4bcast) {
+		t.Errorf("expected 1 broadcast write, got %d to %v", n, dst)
+	}
+}
+
+// TestDeliverReply_ExactlyOneSend_NoDoubleDeliver proves a single relay
+// instance never double-delivers a reply: for every matrix row, the total
+// number of sends (L2 + UDP) is EXACTLY one. This is the per-node invariant
+// behind the #2076 §7.6 HA analysis — cross-node duplication (Backup also
+// relaying) is handled by client xid+chaddr dedupe, but a single node must
+// NOT itself emit both an L2 frame AND a broadcast for the same reply (which
+// WOULD be a new duplicate-delivery defect introduced by this change).
+func TestDeliverReply_ExactlyOneSend_NoDoubleDeliver(t *testing.T) {
+	type row struct {
+		name            string
+		alwaysBroadcast bool
+		l2Fails         bool
+		pkt             func(*testing.T) *dhcpv4.DHCPv4
+	}
+	rows := []row{
+		{"flag1", false, false, func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, true, testYiaddr, nil, testChaddr) }},
+		{"flag0_L2_ok", false, false, func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, testYiaddr, nil, testChaddr) }},
+		{"flag0_L2_fail", false, true, func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, testYiaddr, nil, testChaddr) }},
+		{"ciaddr", false, false, func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, nil, testCiaddr, testChaddr) }},
+		{"no_target", false, false, func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, nil, nil, testChaddr) }},
+		{"override", true, false, func(t *testing.T) *dhcpv4.DHCPv4 { return newReply(t, false, testYiaddr, nil, testChaddr) }},
+	}
+	for _, r := range rows {
+		t.Run(r.name, func(t *testing.T) {
+			ir := &interfaceRelay{ifaceName: "ge-0-0-0", alwaysBroadcast: r.alwaysBroadcast}
+			client := newFakeConn()
+			defer client.Close()
+			fl2 := &fakeL2{}
+			if r.l2Fails {
+				fl2.failWith = errors.New("forced")
+			}
+			pkt := r.pkt(t)
+			if !deliverReply(ir, client, fl2, testGiaddr, pkt, pkt.ToBytes()) {
+				t.Fatal("deliverReply returned false")
+			}
+			client.mu.Lock()
+			udpSends := len(client.writes)
+			client.mu.Unlock()
+			total := udpSends + fl2.callCount()
+			// On L2 failure, the L2 attempt counts as one call but the frame
+			// did NOT go on the wire — the broadcast fallback is the single
+			// delivered send. So the DELIVERED count is exactly one UDP send.
+			if r.l2Fails {
+				if udpSends != 1 {
+					t.Errorf("%s: expected exactly 1 delivered (broadcast) send, got udp=%d l2=%d",
+						r.name, udpSends, fl2.callCount())
+				}
+				return
+			}
+			if total != 1 {
+				t.Errorf("%s: expected exactly 1 send, got udp=%d + l2=%d = %d",
+					r.name, udpSends, fl2.callCount(), total)
+			}
+		})
+	}
+}
+
+// TestHandleServerResponses_L2SourceIsSavedGiaddr proves the end-to-end path:
+// handleServerResponses zeroes pkt.GatewayIPAddr before sending, yet the L2
+// frame's source IP is the SAVED giaddr passed by runRelay (#2076 §7.2 / SMR-F4)
+// — never the zeroed packet field.
+func TestHandleServerResponses_L2SourceIsSavedGiaddr(t *testing.T) {
+	// Build a flag-clear OFFER from a server and feed it through a server conn.
+	offer := newReply(t, false, testYiaddr, nil, testChaddr)
+	offer.GatewayIPAddr = testGiaddr // server echoes giaddr; we must zero it
+	serverConn := newFakeConn()
+	serverConn.mu.Lock()
+	serverConn.pending = [][]byte{offer.ToBytes()}
+	serverConn.mu.Unlock()
+	clientConn := newFakeConn()
+	defer clientConn.Close()
+	fl2 := &fakeL2{}
+	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr)
+		close(done)
+	}()
+
+	// Wait for the L2 send.
+	deadline := time.Now().Add(2 * time.Second)
+	for fl2.callCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if fl2.callCount() == 0 {
+		t.Fatal("no L2 send observed")
+	}
+	fl2.mu.Lock()
+	c := fl2.calls[0]
+	fl2.mu.Unlock()
+	if !c.srcIP.Equal(testGiaddr) {
+		t.Errorf("L2 srcIP = %v, want saved giaddr %v", c.srcIP, testGiaddr)
+	}
+
+	cancel()
+	serverConn.Close()
+	<-done
+}

--- a/pkg/dhcprelay/l2send_linux.go
+++ b/pkg/dhcprelay/l2send_linux.go
@@ -1,0 +1,224 @@
+package dhcprelay
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// Frame layout constants for the hand-rolled Ethernet+IPv4+UDP frame.
+const (
+	ethHeaderLen  = 14
+	ipv4HeaderLen = 20 // no options
+	udpHeaderLen  = 8
+
+	etherTypeIPv4 = 0x0800
+	ipProtoUDP    = 17
+	ipv4TTL       = 64
+)
+
+// l2Sender owns an AF_PACKET TX socket used to deliver DHCP server replies
+// directly to a client's hardware address when the client cleared the
+// broadcast flag (RFC 2131 §4.1). A normal UDP WriteTo(yiaddr) would force the
+// kernel to ARP-resolve the offered address, but a client in SELECTING/
+// REQUESTING has not yet configured that address and will not answer ARP, so
+// the reply would be undeliverable (#2076).
+//
+// The socket is TX-only — it never blocks on a read — so it is deliberately
+// NOT registered with the relay's close-on-cancel watcher (that watcher exists
+// only to unblock a stuck ReadFrom; see runRelay). It is closed by Close(),
+// which is idempotent (sync.Once) and invoked from a defer that runs only after
+// wg.Wait() returns, i.e. after every sendReply caller has joined. This mirrors
+// the pkg/lldp closeOnce lifecycle and preserves the #1915 socket invariants.
+type l2Sender struct {
+	fd        int
+	ifaceName string // re-resolved per send for index + MAC (link-flap safe)
+	// openMAC is the interface MAC captured at open time. It is the fallback
+	// source MAC when a per-send re-resolution returns no MAC (e.g. mid-flap).
+	openMAC   net.HardwareAddr
+	closeOnce sync.Once
+}
+
+// newL2Sender opens an AF_PACKET/SOCK_RAW TX socket bound to the relay
+// interface. Open is fail-soft for the caller: any error (including EPERM when
+// CAP_NET_RAW is absent) is returned so the caller records a nil sender and
+// every flag-clear reply takes the broadcast fallback instead of failing the
+// relay. The socket protocol is ETH_P_IP because we send fully-formed IPv4
+// frames; the bound interface scopes egress.
+func newL2Sender(ifaceName string) (*l2Sender, error) {
+	iface, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		return nil, fmt.Errorf("interface lookup: %w", err)
+	}
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htonsLocal(unix.ETH_P_IP)))
+	if err != nil {
+		return nil, fmt.Errorf("raw socket: %w", err)
+	}
+	// Bind to the interface so the kernel scopes the socket to this netdev.
+	// Binding is not strictly required for Sendto (which carries the ifindex),
+	// but it matches the lldp.go precedent and rejects an obviously wrong fd
+	// early.
+	ll := unix.SockaddrLinklayer{
+		Protocol: htonsLocal(unix.ETH_P_IP),
+		Ifindex:  iface.Index,
+	}
+	if err := unix.Bind(fd, &ll); err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("bind: %w", err)
+	}
+	return &l2Sender{
+		fd:        fd,
+		ifaceName: ifaceName,
+		openMAC:   append(net.HardwareAddr(nil), iface.HardwareAddr...),
+	}, nil
+}
+
+// Close closes the underlying fd. It is idempotent (safe to call from multiple
+// defers) and must be called only after every sendReply caller has joined.
+func (s *l2Sender) Close() error {
+	if s == nil {
+		return nil
+	}
+	var err error
+	s.closeOnce.Do(func() {
+		err = unix.Close(s.fd)
+	})
+	return err
+}
+
+// sendReply builds an Ethernet+IPv4+UDP frame carrying the BOOTP reply payload
+// and transmits it on the AF_PACKET socket to dstMAC. The interface index and
+// source MAC are re-resolved at send time (garp.go precedent) so a link flap,
+// dynamic recreate, or VRRP programMAC change does not leave a stale ifindex or
+// source MAC. The source IP is the saved giaddr the caller passes (never the
+// per-send address list) so the L2 frame's IPv4 source matches what the server
+// saw in the relayed request (#2076 §7.2).
+//
+// On any guard failure or syscall error it returns an error so the caller falls
+// back to broadcast (which always works) — the relay never regresses to
+// undeliverable.
+func (s *l2Sender) sendReply(dstMAC net.HardwareAddr,
+	srcIP, dstIP net.IP, payload []byte) error {
+	if len(dstMAC) != 6 {
+		return fmt.Errorf("dst MAC not 6 bytes: %v", dstMAC)
+	}
+	src4 := srcIP.To4()
+	dst4 := dstIP.To4()
+	if src4 == nil {
+		return fmt.Errorf("src IP not IPv4: %v", srcIP)
+	}
+	if dst4 == nil {
+		return fmt.Errorf("dst IP not IPv4: %v", dstIP)
+	}
+
+	// Re-resolve the interface for a current ifindex + source MAC.
+	iface, err := net.InterfaceByName(s.ifaceName)
+	if err != nil {
+		return fmt.Errorf("interface re-resolve: %w", err)
+	}
+	srcMAC := iface.HardwareAddr
+	if len(srcMAC) != 6 {
+		// Fall back to the MAC captured at open time if the live one is
+		// missing (e.g. mid-flap). Still require a 6-byte Ethernet MAC.
+		srcMAC = s.openMAC
+	}
+	if len(srcMAC) != 6 {
+		return fmt.Errorf("src MAC not 6 bytes: %v", srcMAC)
+	}
+
+	// MTU guard: the raw path cannot fragment. The L3 size (IPv4 + UDP +
+	// payload) must fit the interface MTU (which excludes the 14-byte
+	// Ethernet header). Over-MTU → error so the caller broadcasts/UDP-falls-
+	// back and lets the kernel fragment.
+	l3Size := ipv4HeaderLen + udpHeaderLen + len(payload)
+	if iface.MTU > 0 && l3Size > iface.MTU {
+		return fmt.Errorf("reply L3 size %d exceeds MTU %d on %s",
+			l3Size, iface.MTU, s.ifaceName)
+	}
+
+	frame := buildL2Reply(dstMAC, srcMAC, src4, dst4, payload)
+
+	addr := unix.SockaddrLinklayer{
+		Protocol: htonsLocal(unix.ETH_P_IP),
+		Ifindex:  iface.Index,
+		Halen:    6,
+	}
+	copy(addr.Addr[:], dstMAC)
+
+	if err := unix.Sendto(s.fd, frame, 0, &addr); err != nil {
+		return fmt.Errorf("sendto: %w", err)
+	}
+	return nil
+}
+
+// buildL2Reply hand-rolls an Ethernet(0x0800)+IPv4(proto 17, header checksum
+// computed)+UDP(67->68, checksum=0)+payload frame. UDP checksum 0 is legal for
+// IPv4 (RFC 768) and removes the hand-rolled pseudo-header checksum bug class
+// (#2076 §7.2 / Q2). The IPv4 header checksum is mandatory and is computed.
+//
+// Exposed (unexported) for exhaustive per-byte unit tests.
+func buildL2Reply(dstMAC, srcMAC net.HardwareAddr, srcIP, dstIP net.IP,
+	payload []byte) []byte {
+	udpLen := udpHeaderLen + len(payload)
+	totalLen := ipv4HeaderLen + udpLen
+	frame := make([]byte, ethHeaderLen+totalLen)
+
+	// --- Ethernet header (14 bytes) ---
+	copy(frame[0:6], dstMAC)
+	copy(frame[6:12], srcMAC)
+	binary.BigEndian.PutUint16(frame[12:14], etherTypeIPv4)
+
+	// --- IPv4 header (20 bytes), starts at offset 14 ---
+	ip := frame[ethHeaderLen : ethHeaderLen+ipv4HeaderLen]
+	ip[0] = 0x45 // Version 4, IHL 5 (20 bytes)
+	ip[1] = 0x00 // DSCP/ECN
+	binary.BigEndian.PutUint16(ip[2:4], uint16(totalLen))
+	binary.BigEndian.PutUint16(ip[4:6], 0)      // Identification
+	binary.BigEndian.PutUint16(ip[6:8], 0x4000) // Flags=DF, Fragment offset 0
+	ip[8] = ipv4TTL
+	ip[9] = ipProtoUDP
+	// ip[10:12] checksum filled below.
+	copy(ip[12:16], srcIP.To4())
+	copy(ip[16:20], dstIP.To4())
+	binary.BigEndian.PutUint16(ip[10:12], ipv4Checksum(ip))
+
+	// --- UDP header (8 bytes), starts at offset 14+20 = 34 ---
+	udp := frame[ethHeaderLen+ipv4HeaderLen : ethHeaderLen+ipv4HeaderLen+udpHeaderLen]
+	binary.BigEndian.PutUint16(udp[0:2], relayPort)  // src port 67
+	binary.BigEndian.PutUint16(udp[2:4], clientPort) // dst port 68
+	binary.BigEndian.PutUint16(udp[4:6], uint16(udpLen))
+	binary.BigEndian.PutUint16(udp[6:8], 0) // checksum 0 (legal for IPv4)
+
+	// --- Payload (BOOTP reply bytes) ---
+	copy(frame[ethHeaderLen+ipv4HeaderLen+udpHeaderLen:], payload)
+
+	return frame
+}
+
+// ipv4Checksum computes the standard IPv4 header checksum (RFC 791) over the
+// given 20-byte header. The checksum field (bytes 10:12) must be zero on input.
+func ipv4Checksum(hdr []byte) uint16 {
+	var sum uint32
+	for i := 0; i+1 < len(hdr); i += 2 {
+		sum += uint32(hdr[i])<<8 | uint32(hdr[i+1])
+	}
+	if len(hdr)%2 != 0 {
+		sum += uint32(hdr[len(hdr)-1]) << 8
+	}
+	for sum > 0xffff {
+		sum = (sum >> 16) + (sum & 0xffff)
+	}
+	return ^uint16(sum)
+}
+
+// htonsLocal converts a uint16 from host to network byte order. Co-located here
+// (rather than importing pkg/cluster) to keep pkg/dhcprelay dependency-free
+// (README "Dependencies: pkg/config only").
+func htonsLocal(v uint16) uint16 {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, v)
+	return binary.NativeEndian.Uint16(b)
+}

--- a/pkg/dhcprelay/l2send_test.go
+++ b/pkg/dhcprelay/l2send_test.go
@@ -1,0 +1,209 @@
+package dhcprelay
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+// TestBuildL2Reply_PerByte asserts EVERY byte of the Ethernet/IPv4/UDP headers
+// produced by buildL2Reply, plus payload placement. A malformed-but-Sendto-
+// successful frame is silently dropped by the client and the runtime broadcast
+// fallback does NOT fire (#2076 §9), so per-byte coverage is the only defense.
+func TestBuildL2Reply_PerByte(t *testing.T) {
+	dstMAC := net.HardwareAddr{0x02, 0x11, 0x22, 0x33, 0x44, 0x55}
+	srcMAC := net.HardwareAddr{0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee}
+	srcIP := net.IPv4(192, 168, 1, 1)   // giaddr
+	dstIP := net.IPv4(192, 168, 1, 100) // yiaddr
+	payload := []byte{0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03}
+
+	frame := buildL2Reply(dstMAC, srcMAC, srcIP, dstIP, payload)
+
+	udpLen := udpHeaderLen + len(payload)
+	totalLen := ipv4HeaderLen + udpLen
+	wantFrameLen := ethHeaderLen + totalLen
+	if len(frame) != wantFrameLen {
+		t.Fatalf("frame len = %d, want %d", len(frame), wantFrameLen)
+	}
+
+	// --- Ethernet header ---
+	if got := frame[0:6]; !equalBytes(got, dstMAC) {
+		t.Errorf("eth dst = %x, want %x", got, dstMAC)
+	}
+	if got := frame[6:12]; !equalBytes(got, srcMAC) {
+		t.Errorf("eth src = %x, want %x", got, srcMAC)
+	}
+	if et := binary.BigEndian.Uint16(frame[12:14]); et != etherTypeIPv4 {
+		t.Errorf("ethertype = 0x%04x, want 0x%04x", et, etherTypeIPv4)
+	}
+
+	// --- IPv4 header ---
+	ip := frame[14:34]
+	if ip[0] != 0x45 {
+		t.Errorf("ip version/IHL = 0x%02x, want 0x45", ip[0])
+	}
+	if ip[1] != 0x00 {
+		t.Errorf("ip DSCP/ECN = 0x%02x, want 0x00", ip[1])
+	}
+	if tl := binary.BigEndian.Uint16(ip[2:4]); int(tl) != totalLen {
+		t.Errorf("ip total length = %d, want %d", tl, totalLen)
+	}
+	if id := binary.BigEndian.Uint16(ip[4:6]); id != 0 {
+		t.Errorf("ip identification = %d, want 0", id)
+	}
+	if ff := binary.BigEndian.Uint16(ip[6:8]); ff != 0x4000 {
+		t.Errorf("ip flags/frag = 0x%04x, want 0x4000 (DF)", ff)
+	}
+	if ip[8] != ipv4TTL {
+		t.Errorf("ip TTL = %d, want %d", ip[8], ipv4TTL)
+	}
+	if ip[9] != ipProtoUDP {
+		t.Errorf("ip proto = %d, want %d (UDP)", ip[9], ipProtoUDP)
+	}
+	if got := ip[12:16]; !equalBytes(got, srcIP.To4()) {
+		t.Errorf("ip src = %v, want %v", net.IP(got), srcIP)
+	}
+	if got := ip[16:20]; !equalBytes(got, dstIP.To4()) {
+		t.Errorf("ip dst = %v, want %v", net.IP(got), dstIP)
+	}
+	// IPv4 header checksum must VALIDATE: recompute over the header with the
+	// checksum field present — the one's-complement sum must be 0xFFFF.
+	if !ipv4ChecksumValid(ip) {
+		t.Errorf("ip header checksum does not validate; field=0x%04x",
+			binary.BigEndian.Uint16(ip[10:12]))
+	}
+
+	// --- UDP header ---
+	udp := frame[34:42]
+	if sp := binary.BigEndian.Uint16(udp[0:2]); sp != relayPort {
+		t.Errorf("udp src port = %d, want %d", sp, relayPort)
+	}
+	if dp := binary.BigEndian.Uint16(udp[2:4]); dp != clientPort {
+		t.Errorf("udp dst port = %d, want %d", dp, clientPort)
+	}
+	if ul := binary.BigEndian.Uint16(udp[4:6]); int(ul) != udpLen {
+		t.Errorf("udp length = %d, want %d", ul, udpLen)
+	}
+	// UDP checksum MUST be 0 (legal for IPv4 per RFC 768; #2076 Q2).
+	if cs := binary.BigEndian.Uint16(udp[6:8]); cs != 0 {
+		t.Errorf("udp checksum = 0x%04x, want 0", cs)
+	}
+
+	// --- Payload ---
+	if got := frame[42:]; !equalBytes(got, payload) {
+		t.Errorf("payload = %x, want %x", got, payload)
+	}
+}
+
+// TestBuildL2Reply_ChecksumNonTrivial guards against a tautology: an all-zero
+// or constant checksum would still "validate" against itself in a buggy
+// implementation. Two frames that differ only in destination IP must produce
+// DIFFERENT IPv4 header checksums, and each must independently validate.
+func TestBuildL2Reply_ChecksumNonTrivial(t *testing.T) {
+	dstMAC := net.HardwareAddr{0x02, 0, 0, 0, 0, 1}
+	srcMAC := net.HardwareAddr{0x02, 0, 0, 0, 0, 2}
+	srcIP := net.IPv4(10, 0, 0, 1)
+	payload := []byte{0x00}
+
+	f1 := buildL2Reply(dstMAC, srcMAC, srcIP, net.IPv4(10, 0, 0, 50), payload)
+	f2 := buildL2Reply(dstMAC, srcMAC, srcIP, net.IPv4(10, 0, 0, 51), payload)
+
+	c1 := binary.BigEndian.Uint16(f1[24:26]) // ip checksum field (14+10)
+	c2 := binary.BigEndian.Uint16(f2[24:26])
+	if c1 == c2 {
+		t.Errorf("checksums identical for different dst IPs (0x%04x) — "+
+			"checksum likely not computed over the header", c1)
+	}
+	if c1 == 0 || c2 == 0 {
+		t.Errorf("checksum is zero (c1=0x%04x c2=0x%04x) — not computed", c1, c2)
+	}
+	if !ipv4ChecksumValid(f1[14:34]) || !ipv4ChecksumValid(f2[14:34]) {
+		t.Errorf("a frame failed checksum validation")
+	}
+}
+
+// TestIPv4Checksum_KnownVector validates ipv4Checksum against a hand-computed
+// reference header (a well-known RFC-791 worked example).
+func TestIPv4Checksum_KnownVector(t *testing.T) {
+	// Classic worked example: 45 00 00 73 00 00 40 00 40 11 00 00
+	// c0 a8 00 01 c0 a8 00 c7 → checksum 0xb861.
+	hdr := []byte{
+		0x45, 0x00, 0x00, 0x73, 0x00, 0x00, 0x40, 0x00,
+		0x40, 0x11, 0x00, 0x00,
+		0xc0, 0xa8, 0x00, 0x01,
+		0xc0, 0xa8, 0x00, 0xc7,
+	}
+	if got := ipv4Checksum(hdr); got != 0xb861 {
+		t.Errorf("ipv4Checksum = 0x%04x, want 0xb861", got)
+	}
+	// And the computed header must validate.
+	binary.BigEndian.PutUint16(hdr[10:12], ipv4Checksum(hdr))
+	if !ipv4ChecksumValid(hdr) {
+		t.Errorf("computed checksum does not validate")
+	}
+}
+
+// TestHtonsLocal confirms host->network conversion round-trips a known value.
+func TestHtonsLocal(t *testing.T) {
+	// 0x0800 in network order is bytes {0x08, 0x00}.
+	got := htonsLocal(0x0800)
+	b := make([]byte, 2)
+	binary.NativeEndian.PutUint16(b, got)
+	if b[0] != 0x08 || b[1] != 0x00 {
+		t.Errorf("htonsLocal(0x0800) native bytes = %x, want 0800", b)
+	}
+}
+
+// ipv4ChecksumValid recomputes the one's-complement sum over a full IPv4 header
+// (checksum field included). A valid header sums to 0xFFFF.
+func ipv4ChecksumValid(hdr []byte) bool {
+	var sum uint32
+	for i := 0; i+1 < len(hdr); i += 2 {
+		sum += uint32(hdr[i])<<8 | uint32(hdr[i+1])
+	}
+	for sum > 0xffff {
+		sum = (sum >> 16) + (sum & 0xffff)
+	}
+	return uint16(sum) == 0xffff
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestNewL2Sender_CapturesOpenMAC proves newL2Sender records the interface MAC
+// at open time (the per-send fallback source). It needs CAP_NET_RAW + an
+// Ethernet interface; skipped otherwise. This keeps the openMAC fallback from
+// being dead/untested code.
+func TestNewL2Sender_CapturesOpenMAC(t *testing.T) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Skipf("Interfaces: %v", err)
+	}
+	var target string
+	for _, ifi := range ifaces {
+		if len(ifi.HardwareAddr) == 6 && ifi.Flags&net.FlagLoopback == 0 {
+			target = ifi.Name
+			break
+		}
+	}
+	if target == "" {
+		t.Skip("no 6-byte-MAC non-loopback interface available")
+	}
+	s, err := newL2Sender(target)
+	if err != nil {
+		t.Skipf("newL2Sender(%s): %v (likely no CAP_NET_RAW)", target, err)
+	}
+	defer s.Close()
+	if len(s.openMAC) != 6 {
+		t.Errorf("openMAC not captured: %v", s.openMAC)
+	}
+}

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/iana"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -45,6 +46,26 @@ type RelayStats struct {
 	Interface        string
 	RequestsRelayed  uint64
 	RepliesForwarded uint64
+
+	// Reply-delivery breakdown (#2076). These distinguish WHY a reply was
+	// broadcast vs L2-unicast so an L2/CAP_NET_RAW/driver/MTU regression is
+	// observable in operations. RepliesBroadcastL2Fallback is the one to
+	// alert on: it means the raw-L2 path failed and the relay had to
+	// degrade to broadcast.
+	RepliesL2Unicast           uint64 // flag-clear reply delivered via raw L2
+	RepliesUnicastCiaddr       uint64 // flag-clear reply UDP-unicast to ciaddr
+	RepliesBroadcastFlag1      uint64 // client set the broadcast flag
+	RepliesBroadcastForced     uint64 // overrides always-broadcast
+	RepliesBroadcastNoTarget   uint64 // no routable target (yiaddr==0,ciaddr==0)
+	RepliesBroadcastL2Fallback uint64 // raw-L2 path failed → degraded
+}
+
+// l2Replier is the raw-L2 unicast seam. *l2Sender implements it in production;
+// tests inject a fake to exercise the dst-decision matrix and fallback without
+// CAP_NET_RAW or real NICs.
+type l2Replier interface {
+	sendReply(dstMAC net.HardwareAddr, srcIP, dstIP net.IP, payload []byte) error
+	Close() error
 }
 
 // interfaceRelay represents a relay goroutine bound to one interface.
@@ -54,6 +75,18 @@ type interfaceRelay struct {
 	done             chan struct{}
 	requestsRelayed  atomic.Uint64
 	repliesForwarded atomic.Uint64
+
+	// alwaysBroadcast forces every reply to broadcast (overrides
+	// always-broadcast). Set once at start; read-only thereafter.
+	alwaysBroadcast bool
+
+	// Reply-delivery counters (#2076).
+	repliesL2Unicast           atomic.Uint64
+	repliesUnicastCiaddr       atomic.Uint64
+	repliesBroadcastFlag1      atomic.Uint64
+	repliesBroadcastForced     atomic.Uint64
+	repliesBroadcastNoTarget   atomic.Uint64
+	repliesBroadcastL2Fallback atomic.Uint64
 }
 
 // packetConnFactory creates a UDP packet connection with the relay's required
@@ -87,7 +120,17 @@ type Manager struct {
 	newConn       packetConnFactory
 	resolveGIAddr ifaceResolver
 	retryInterval time.Duration
+	// newL2 opens the raw-L2 unicast sender for an interface (#2076). It is
+	// a seam so tests can inject a fake or force open failure. The default
+	// returns (nil, err) → fail-soft to the broadcast path; the production
+	// implementation is defaultL2SenderFactory.
+	newL2 l2SenderFactory
 }
+
+// l2SenderFactory opens a raw-L2 reply sender bound to ifaceName. On error the
+// caller records a nil sender and every flag-clear reply takes the broadcast
+// fallback — the relay stays up (fail-soft).
+type l2SenderFactory func(ifaceName string) (l2Replier, error)
 
 // NewManager creates a new DHCP relay Manager.
 func NewManager() *Manager {
@@ -96,7 +139,19 @@ func NewManager() *Manager {
 		newConn:       defaultPacketConnFactory,
 		resolveGIAddr: defaultIfaceResolver,
 		retryInterval: startupRetryInterval,
+		newL2:         defaultL2SenderFactory,
 	}
+}
+
+// defaultL2SenderFactory opens a real AF_PACKET sender. Returning a typed-nil
+// *l2Sender through the l2Replier interface would defeat the `== nil` guard, so
+// on error it returns a nil interface value explicitly.
+func defaultL2SenderFactory(ifaceName string) (l2Replier, error) {
+	s, err := newL2Sender(ifaceName)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // defaultPacketConnFactory builds a real UDP packet connection, setting
@@ -196,9 +251,10 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 
 			rctx, cancel := context.WithCancel(ctx)
 			ir := &interfaceRelay{
-				ifaceName: ifaceName,
-				cancel:    cancel,
-				done:      make(chan struct{}),
+				ifaceName:       ifaceName,
+				cancel:          cancel,
+				done:            make(chan struct{}),
+				alwaysBroadcast: group.AlwaysBroadcast,
 			}
 			m.relays[ifaceName] = ir
 
@@ -222,9 +278,15 @@ func (m *Manager) Stats() []RelayStats {
 	stats := make([]RelayStats, 0, len(m.relays))
 	for _, ir := range m.relays {
 		stats = append(stats, RelayStats{
-			Interface:        ir.ifaceName,
-			RequestsRelayed:  ir.requestsRelayed.Load(),
-			RepliesForwarded: ir.repliesForwarded.Load(),
+			Interface:                  ir.ifaceName,
+			RequestsRelayed:            ir.requestsRelayed.Load(),
+			RepliesForwarded:           ir.repliesForwarded.Load(),
+			RepliesL2Unicast:           ir.repliesL2Unicast.Load(),
+			RepliesUnicastCiaddr:       ir.repliesUnicastCiaddr.Load(),
+			RepliesBroadcastFlag1:      ir.repliesBroadcastFlag1.Load(),
+			RepliesBroadcastForced:     ir.repliesBroadcastForced.Load(),
+			RepliesBroadcastNoTarget:   ir.repliesBroadcastNoTarget.Load(),
+			RepliesBroadcastL2Fallback: ir.repliesBroadcastL2Fallback.Load(),
 		})
 	}
 	return stats
@@ -296,8 +358,35 @@ func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
 	}
 	defer serverConn.Close()
 
+	// Open the raw-L2 unicast sender (#2076), fail-soft: a nil sender means
+	// every flag-clear reply takes the broadcast fallback and the relay stays
+	// up (e.g. no CAP_NET_RAW). It is opened AFTER both UDP conns succeed and
+	// BEFORE the cancel watcher. It is TX-only — it is deliberately NOT closed
+	// by the watcher (it never blocks a read); it is closed by the idempotent
+	// l2.Close() in a defer that runs only after wg.Wait() below, so every
+	// sendReply caller has joined first (preserves the #1915 invariants).
+	var l2 l2Replier
+	if ir.alwaysBroadcast {
+		slog.Info("dhcp-relay: overrides always-broadcast set, raw-L2 disabled",
+			"interface", ifaceName)
+	} else {
+		l2, err = m.newL2(ifaceName)
+		if err != nil {
+			slog.Warn("dhcp-relay: raw-L2 sender unavailable, "+
+				"flag-clear replies will broadcast",
+				"interface", ifaceName, "err", err)
+			l2 = nil
+		}
+	}
+	defer func() {
+		if l2 != nil {
+			_ = l2.Close()
+		}
+	}()
+
 	slog.Info("dhcp-relay: listening",
-		"interface", ifaceName, "giaddr", giaddr)
+		"interface", ifaceName, "giaddr", giaddr,
+		"always_broadcast", ir.alwaysBroadcast, "raw_l2", l2 != nil)
 
 	// Both the cancel watcher and the server-response goroutine are tracked by
 	// the WaitGroup so the runner's wg.Wait() is a true join of every spawned
@@ -323,7 +412,7 @@ func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
 	go func() {
 		defer wg.Done()
 		defer cancel()
-		handleServerResponses(ctx, serverConn, conn, ir)
+		handleServerResponses(ctx, serverConn, conn, ir, l2, giaddr)
 	}()
 
 	// Main read loop in its OWN func scope so its `defer cancel()` fires on
@@ -432,7 +521,21 @@ func (m *Manager) resolveGIAddrWithRetry(ctx context.Context, ifaceName string) 
 
 // handleServerResponses reads DHCP replies from servers on the serverConn
 // and forwards them back to clients on the client-facing conn.
-func handleServerResponses(ctx context.Context, serverConn, clientConn net.PacketConn, ir *interfaceRelay) {
+//
+// Reply delivery honors the RFC 2131 §4.1 broadcast flag (#2076):
+//
+//	overrides always-broadcast        -> broadcast (operator override wins)
+//	broadcast flag set                -> broadcast (existing path)
+//	flag clear, yiaddr real           -> raw-L2 unicast to chaddr+yiaddr
+//	flag clear, yiaddr 0, ciaddr real -> UDP-unicast to ciaddr (client has IP)
+//	flag clear, yiaddr 0, ciaddr 0    -> broadcast (nothing routable)
+//	raw-L2 path fails                 -> broadcast fallback (+ counter)
+//
+// srcIP is the saved interface giaddr (the IPv4 source the server saw in the
+// relayed request); it MUST come from the caller, not from pkt.GatewayIPAddr,
+// which is zeroed below before sending.
+func handleServerResponses(ctx context.Context, serverConn, clientConn net.PacketConn,
+	ir *interfaceRelay, l2 l2Replier, srcIP net.IP) {
 	ifaceName := ir.ifaceName
 	buf := make([]byte, 1500)
 	for {
@@ -474,27 +577,90 @@ func handleServerResponses(ctx context.Context, serverConn, clientConn net.Packe
 		// Strip Option 82 before forwarding to the client.
 		stripOption82(pkt)
 
-		// Clear giaddr since we are the last relay hop.
+		// Clear giaddr since we are the last relay hop. The L2 source IP
+		// comes from the saved giaddr (srcIP), NOT this field.
 		pkt.GatewayIPAddr = net.IPv4zero
 
-		// Determine destination: if the broadcast flag is set, broadcast;
-		// otherwise unicast to the assigned address.
-		var dst *net.UDPAddr
-		if pkt.IsBroadcast() || pkt.YourIPAddr == nil || pkt.YourIPAddr.Equal(net.IPv4zero) {
-			dst = &net.UDPAddr{IP: net.IPv4bcast, Port: clientPort}
-		} else {
-			dst = &net.UDPAddr{IP: pkt.YourIPAddr, Port: clientPort}
-		}
-
 		replyData := pkt.ToBytes()
-		if _, err := clientConn.WriteTo(replyData, dst); err != nil {
-			slog.Warn("dhcp-relay: send to client failed",
-				"interface", ifaceName,
-				"dst", dst, "err", err)
-		} else {
+		if deliverReply(ir, clientConn, l2, srcIP, pkt, replyData) {
 			ir.repliesForwarded.Add(1)
 		}
 	}
+}
+
+// deliverReply applies the #2076 reply-destination matrix and sends the reply.
+// It returns true if the reply was delivered (any path that issued a successful
+// send), false on a hard send failure. It increments the per-reason counters.
+func deliverReply(ir *interfaceRelay, clientConn net.PacketConn, l2 l2Replier,
+	srcIP net.IP, pkt *dhcpv4.DHCPv4, replyData []byte) bool {
+	yiaddr := pkt.YourIPAddr.To4()
+	yiaddrReal := yiaddr != nil && !yiaddr.Equal(net.IPv4zero)
+	ciaddr := pkt.ClientIPAddr.To4()
+	ciaddrReal := ciaddr != nil && !ciaddr.Equal(net.IPv4zero)
+
+	switch {
+	case ir.alwaysBroadcast:
+		ir.repliesBroadcastForced.Add(1)
+		return broadcastReply(ir, clientConn, replyData)
+
+	case pkt.IsBroadcast():
+		ir.repliesBroadcastFlag1.Add(1)
+		return broadcastReply(ir, clientConn, replyData)
+
+	case yiaddrReal:
+		// Flag clear with a real offered address: RFC-correct raw-L2
+		// unicast to chaddr+yiaddr. Fall back to broadcast on any L2
+		// failure or when no raw-L2 sender is available.
+		if l2 != nil && l2Eligible(pkt) {
+			err := l2.sendReply(pkt.ClientHWAddr, srcIP, yiaddr, replyData)
+			if err == nil {
+				ir.repliesL2Unicast.Add(1)
+				return true
+			}
+			slog.Warn("dhcp-relay: raw-L2 unicast failed, broadcasting",
+				"interface", ir.ifaceName,
+				"client_mac", pkt.ClientHWAddr,
+				"yiaddr", yiaddr, "err", err)
+		}
+		ir.repliesBroadcastL2Fallback.Add(1)
+		return broadcastReply(ir, clientConn, replyData)
+
+	case ciaddrReal:
+		// Flag clear, no yiaddr, but the client already owns ciaddr
+		// (DHCPINFORM / REBINDING ACK) — it answers ARP, so a normal UDP
+		// unicast is deliverable.
+		dst := &net.UDPAddr{IP: ciaddr, Port: clientPort}
+		if _, err := clientConn.WriteTo(replyData, dst); err != nil {
+			slog.Warn("dhcp-relay: unicast to ciaddr failed",
+				"interface", ir.ifaceName, "dst", dst, "err", err)
+			return false
+		}
+		ir.repliesUnicastCiaddr.Add(1)
+		return true
+
+	default:
+		// Flag clear, no yiaddr, no ciaddr: nothing routable. Broadcast.
+		ir.repliesBroadcastNoTarget.Add(1)
+		return broadcastReply(ir, clientConn, replyData)
+	}
+}
+
+// broadcastReply sends the reply to 255.255.255.255:68 on the client conn.
+func broadcastReply(ir *interfaceRelay, clientConn net.PacketConn, replyData []byte) bool {
+	dst := &net.UDPAddr{IP: net.IPv4bcast, Port: clientPort}
+	if _, err := clientConn.WriteTo(replyData, dst); err != nil {
+		slog.Warn("dhcp-relay: broadcast to client failed",
+			"interface", ir.ifaceName, "dst", dst, "err", err)
+		return false
+	}
+	return true
+}
+
+// l2Eligible reports whether a reply can be sent via the raw-L2 path: the
+// client must use a 6-byte Ethernet hardware address. Non-Ethernet htype or a
+// non-6-byte chaddr falls back to broadcast (the L2 frame would be malformed).
+func l2Eligible(pkt *dhcpv4.DHCPv4) bool {
+	return pkt.HWType == iana.HWTypeEthernet && len(pkt.ClientHWAddr) == 6
 }
 
 // addOption82 inserts or replaces the Relay Agent Information option (82)

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
+	"golang.org/x/sys/unix"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -224,6 +225,11 @@ func testManager(factory packetConnFactory) *Manager {
 		return net.IPv4(10, 0, 0, 254), nil
 	}
 	m.retryInterval = time.Millisecond
+	// Default to a no-op fake L2 sender so lifecycle tests do not depend on
+	// CAP_NET_RAW or a real NIC (#2076). Individual tests override m.newL2.
+	m.newL2 = func(ifaceName string) (l2Replier, error) {
+		return &fakeL2{}, nil
+	}
 	return m
 }
 
@@ -530,4 +536,131 @@ func TestRunRelay_ClosedNoSpin(t *testing.T) {
 	}
 
 	m.Stop()
+}
+
+// --- #2076 lifecycle / fail-soft tests ---
+
+// countingL2Factory returns an l2SenderFactory that records open attempts and
+// returns the supplied sender (or error).
+func countingL2Factory(s l2Replier, err error) (l2SenderFactory, func() int) {
+	var mu sync.Mutex
+	var opens int
+	f := func(ifaceName string) (l2Replier, error) {
+		mu.Lock()
+		opens++
+		mu.Unlock()
+		if err != nil {
+			return nil, err
+		}
+		return s, nil
+	}
+	getter := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return opens
+	}
+	return f, getter
+}
+
+// TestRunRelay_L2OpenFailure_RelayStaysUp proves that an L2 open failure (e.g.
+// no CAP_NET_RAW) is fail-soft: the relay still creates its UDP sockets and
+// Stop returns. runRelay must NOT return early on L2 open error (#2076 §7.3).
+func TestRunRelay_L2OpenFailure_RelayStaysUp(t *testing.T) {
+	client := newFakeConn()
+	server := newFakeConn()
+	factory, getCalls := recordingFactory(client, server)
+	m := testManager(factory)
+	l2f, getOpens := countingL2Factory(nil, errors.New("EPERM: no CAP_NET_RAW"))
+	m.newL2 = l2f
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	calls := waitCalls(t, getCalls, 2, 2*time.Second)
+	if len(calls) < 2 {
+		t.Fatalf("relay died on L2 open failure: only %d UDP conns", len(calls))
+	}
+	if getOpens() == 0 {
+		t.Errorf("expected at least one L2 open attempt")
+	}
+
+	done := make(chan struct{})
+	go func() { m.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return after L2 open failure")
+	}
+}
+
+// TestRunRelay_AlwaysBroadcast_SkipsL2Open proves that when overrides
+// always-broadcast is set, the relay never opens the L2 socket (#2076 §7.1:
+// override wins before the L2 path is even considered).
+func TestRunRelay_AlwaysBroadcast_SkipsL2Open(t *testing.T) {
+	client := newFakeConn()
+	server := newFakeConn()
+	factory, getCalls := recordingFactory(client, server)
+	m := testManager(factory)
+	l2f, getOpens := countingL2Factory(&fakeL2{}, nil)
+	m.newL2 = l2f
+
+	cfg := singleInterfaceConfig()
+	cfg.Groups["g"].AlwaysBroadcast = true
+	m.Apply(context.Background(), cfg)
+	waitCalls(t, getCalls, 2, 2*time.Second)
+
+	// Give runRelay a beat to reach (and skip) the L2 open.
+	time.Sleep(50 * time.Millisecond)
+	if getOpens() != 0 {
+		t.Errorf("always-broadcast must NOT open the L2 socket, got %d opens", getOpens())
+	}
+	m.Stop()
+}
+
+// TestRunRelay_L2Closed_AfterStop proves the L2 sender is closed (exactly once)
+// when the relay stops — closure happens after wg.Wait() (#2076 §7.3).
+func TestRunRelay_L2Closed_AfterStop(t *testing.T) {
+	client := newFakeConn()
+	server := newFakeConn()
+	factory, getCalls := recordingFactory(client, server)
+	m := testManager(factory)
+	fl2 := &fakeL2{}
+	l2f, _ := countingL2Factory(fl2, nil)
+	m.newL2 = l2f
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitCalls(t, getCalls, 2, 2*time.Second)
+	m.Stop()
+
+	fl2.mu.Lock()
+	cc := fl2.closeCount
+	fl2.mu.Unlock()
+	if cc != 1 {
+		t.Errorf("L2 sender Close count = %d, want exactly 1", cc)
+	}
+}
+
+// TestL2Sender_CloseIdempotent proves the real *l2Sender Close is idempotent
+// (sync.Once). It uses a sentinel fd; the second Close must be a no-op even
+// though the fd was already closed.
+func TestL2Sender_CloseIdempotent(t *testing.T) {
+	// A nil *l2Sender Close must be safe.
+	var nilSender *l2Sender
+	if err := nilSender.Close(); err != nil {
+		t.Errorf("nil l2Sender.Close() = %v, want nil", err)
+	}
+
+	// Use a real, closeable fd (a pipe read end) to prove Close idempotency
+	// without a NIC. The first Close closes it; the second must be a no-op
+	// (sync.Once), NOT a double-close EBADF.
+	var p [2]int
+	if err := unix.Pipe(p[:]); err != nil {
+		t.Skipf("pipe unavailable: %v", err)
+	}
+	_ = unix.Close(p[1]) // close the unused write end
+	s := &l2Sender{fd: p[0], ifaceName: "test"}
+	if err := s.Close(); err != nil {
+		t.Errorf("first Close = %v, want nil", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Errorf("second Close = %v, want nil (idempotent)", err)
+	}
 }


### PR DESCRIPTION
Closes #2076.

## Problem

The relay forwarded server replies on an ordinary `udp4` socket and, for a
reply with the broadcast flag **clear** and a real `yiaddr`, unicast it to
`yiaddr`. A client in SELECTING/REQUESTING has not yet configured the offered
address, so the kernel's ARP for `yiaddr` goes unanswered and the OFFER/ACK is
silently dropped — flag-clear clients (some Linux/Windows/embedded stacks) could
never acquire a lease via the relay (RFC 2131 §4.1).

## Fix (converged plan Option d)

RFC-correct raw `AF_PACKET` L2 unicast by default + opt-in Junos `overrides
always-broadcast` + automatic broadcast fallback. The relay honors the client's
broadcast flag and **never regresses to undeliverable** (worst case is
broadcast, which always works).

Reply-destination matrix:

| Condition | Delivery |
|-----------|----------|
| `overrides always-broadcast` | broadcast (operator override wins) |
| broadcast flag **set** | broadcast (existing path) |
| flag **clear**, real `yiaddr` | raw-L2 unicast to `chaddr` + `yiaddr` |
| flag **clear**, `yiaddr==0`, real `ciaddr` | UDP-unicast to `ciaddr` (client owns the IP) |
| flag **clear**, no `yiaddr`/`ciaddr` | broadcast (nothing routable) |
| raw-L2 path fails/unavailable | broadcast fallback (+ alert counter) |

### Raw-L2 sender (`pkg/dhcprelay/l2send_linux.go`)
- Hand-rolled Ethernet(0x0800)+IPv4(proto 17, **header checksum computed**)+
  UDP(67→68, **checksum 0** — legal for IPv4 per RFC 768, removes the
  pseudo-header bug class). `garp.go` hand-roll pattern.
- IPv4 source = the **saved interface giaddr** (what the server saw in the
  relayed request), never the per-reply `GatewayIPAddr` field that `runRelay`
  zeroes before sending.
- **Per-send interface re-resolution** (ifindex + source MAC) — link flap /
  dynamic recreate / VRRP `programMAC` cannot leave a stale ifindex or MAC.
- Guards fall back to broadcast: non-Ethernet `htype`, non-6-byte `chaddr`,
  over-MTU reply (raw path can't fragment), invalid IPs, `Sendto` error.
- **Fail-soft open** (no `CAP_NET_RAW` → nil sender → broadcast, relay stays
  up). TX-only fd kept **out** of the #1915 cancel watcher and closed
  idempotently (`sync.Once`) only **after** `wg.Wait()`.

### Config (Phase 2)
`set forwarding-options dhcp-relay group <g> overrides always-broadcast` →
`DHCPRelayGroup.AlwaysBroadcast`. The flat-set inline-interface consumer now
treats `overrides` as a property boundary so it (and `always-broadcast`) are
**not swallowed** into the interface list (the dual-AST swallow blocker); both
block and flat-set shapes parse; schema offers the leaf for completion.

### Observability
Per-reason counters (`RepliesL2Unicast`, `RepliesUnicastCiaddr`,
`RepliesBroadcastFlag1/Forced/NoTarget`, `RepliesBroadcastL2Fallback`) in
`Stats()` and `show ... dhcp-relay`. `RepliesBroadcastL2Fallback` is the one to
alert on (CAP_NET_RAW/driver/MTU regression).

## Tests — `go test ./pkg/dhcprelay/ -race` 25/25 pass

- Exhaustive **per-byte** L2 frame construction (IPv4 checksum validates, UDP
  checksum 0) + non-tautology guard (different dst IPs → different valid
  checksums) + known IPv4-checksum vector.
- Full dst-decision matrix oracle; htype/chaddr/non-Ethernet guards.
- Broadcast fallback on L2 error AND nil sender.
- No-single-node-double-deliver; saved-giaddr source through the zeroing path.
- L2-open-failure-relay-stays-up; always-broadcast skips L2 open; Close
  idempotency.
- `pkg/config`: dual-AST differential + flat-set swallow regression + schema
  completion.

## Docs
`pkg/dhcprelay/README.md`: reply-delivery model, CAP_NET_RAW dependency,
counters, and IPv6/DHCPv6-relay-does-not-exist + HA VRRP-Backup
duplicate-delivery parity notes.

## Pending parent-run (lab-gated)
- **Live flag0-client wire-capture** (`tcpdump -e` must show the OFFER/ACK as a
  unicast L2 frame to the client MAC with a valid IPv4/UDP checksum).
- **`make test-failover`** (HA duplicate-delivery characterization; no failover
  regression).

These are intentionally **not** run here per the engineering protocol; the
parent runs live validation. The runtime broadcast fallback covers Sendto
failure, no-CAP_NET_RAW, non-Ethernet htype, and over-MTU; the per-byte tests
are the defense against a Sendto-success-but-malformed frame (which the runtime
fallback cannot catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
