### PR TITLE
#2114: fix NAT pool-alarm monitor data race on bootstrap-exit d.dp

### DIFF
--- a/docs/pr/2114-natpoolalarm-bootstrap-race/plan.md
+++ b/docs/pr/2114-natpoolalarm-bootstrap-race/plan.md
@@ -1,7 +1,12 @@
 # #2114 — NAT pool-alarm monitor races `d.dp = nil` in bootstrap-exit
 
-**Status:** DRAFT v2 — Codex r1 PLAN-NEEDS-MAJOR addressed (rollback→re-arm
-race; monitor not restartable after Stop). Adds Edit 3 + revised test plan.
+**Status:** DRAFT v3 — Codex r2 PLAN-NEEDS-MAJOR addressed. v2's
+runtime-mutated `d.natPoolAlarm` pointer is itself read unsynchronized by
+`natPoolAlarms()` on the gRPC/CLI `show security alarms` render path,
+racing the new start/discard writes. v3 makes the pointer
+`atomic.Pointer[natpoolalarm.Monitor]` and routes ALL access through
+helpers (`maybeStartNATPoolAlarm`, `stopAndDiscardNATPoolAlarm`,
+`natPoolAlarms`, shutdown). Now FOUR edits.
 
 ## Issue framing
 
@@ -88,32 +93,116 @@ launching a continuous reader during bootstrap, where the
 bootstrap-exit write still happens. Option A restores the invariant
 and exactly mirrors the dataplane-`Start()` gate already at line 642.
 
-### Edit 1 — `daemon_run.go` ~880: gate the boot-time start
+**Second field made shared (v3 — Codex r2):** moving the monitor start
+out of the single-threaded boot window means `d.natPoolAlarm` is now
+WRITTEN at runtime (started at bootstrap exit, stopped+discarded at
+rollback) while gRPC/CLI are already serving. The reader
+`natPoolAlarms()` (`daemon_natpoolalarm.go:71`) is wired into the
+`show security alarms` render path on both gRPC (`daemon_run.go:1282`,
+`NATPoolAlarmsFn`) and CLI (`daemon_run.go:1402`,
+`SetNATPoolAlarmsFn`) — request goroutines that race the new
+start/discard writes. On origin/master this field is written once at
+boot before serving begins, so it is safe today; the fix must NOT
+introduce a new pointer race. v3 therefore changes the field to
+`atomic.Pointer[natpoolalarm.Monitor]` and routes EVERY access
+(start, stop+discard, read, shutdown) through helpers. `sync/atomic`
+is already imported in `daemon.go`; the daemon already uses
+`atomic.Bool` for `bootstrapMode`, so this matches the local style and
+is lock-free.
 
-Wrap the monitor `New/Start` in `if !d.inBootstrap()`:
+### Edit 0 — `daemon.go:136`: make the field atomic + add helpers
 
 ```go
-// #2114: do NOT start the NAT pool-alarm monitor while in bootstrap
-// mode. In bootstrap the dataplane object is constructed (d.dp != nil)
-// but not armed, and the bootstrap-exit path may write d.dp = nil on
-// an arm failure. The monitor's sampler reads d.dp unsynchronized, so
-// launching it here would race that write. It is started instead at
-// the end of runBootstrapExitStartup once the dataplane is armed
-// (mirroring the dataplane Start() gate above). On a normal
-// (non-bootstrap) boot this branch runs as before.
-if !d.inBootstrap() {
-    d.natPoolAlarm = natpoolalarm.New(d.natPoolAlarmSampler(), d.natPoolAlarmEmitter())
-    d.natPoolAlarm.Start()
+// natPoolAlarm holds the #2079 monitor. Made atomic in #2114 because the
+// monitor is now started/stopped at runtime (bootstrap exit / rollback)
+// concurrently with the show-security-alarms render reader.
+natPoolAlarm atomic.Pointer[natpoolalarm.Monitor]
+```
+
+Helpers (in `daemon_natpoolalarm.go`):
+
+```go
+// maybeStartNATPoolAlarm constructs and starts the monitor exactly once,
+// gated on a non-bootstrap, dataplane-armed daemon. Idempotent: a
+// non-nil stored monitor short-circuits. Called from the normal-boot
+// background-services block and from runBootstrapExitStartup's success
+// branch.
+func (d *Daemon) maybeStartNATPoolAlarm() {
+    if d.opts.NoDataplane || d.inBootstrap() {
+        return
+    }
+    if d.natPoolAlarm.Load() != nil {
+        return // already started
+    }
+    m := natpoolalarm.New(d.natPoolAlarmSampler(), d.natPoolAlarmEmitter())
+    d.natPoolAlarm.Store(m)
+    m.Start()
 }
+
+// stopAndDiscardNATPoolAlarm stops the monitor (joins its goroutine) and
+// clears the pointer so a later re-arm builds a fresh one (Monitor is not
+// restartable after Stop). Safe when no monitor is running. Called from
+// rollback (enterBootstrapMode) and shutdown.
+func (d *Daemon) stopAndDiscardNATPoolAlarm() {
+    if m := d.natPoolAlarm.Swap(nil); m != nil {
+        m.Stop()
+    }
+}
+```
+
+and the reader becomes:
+
+```go
+func (d *Daemon) natPoolAlarms() []natpoolalarm.ActiveAlarm {
+    if d == nil {
+        return nil
+    }
+    m := d.natPoolAlarm.Load()
+    if m == nil {
+        return nil
+    }
+    return m.ActiveAlarms()
+}
+```
+
+Note: `maybeStartNATPoolAlarm` itself is only ever called under
+`applySem` (boot path runs before serving; bootstrap-exit runs under the
+apply caller's `applySem`), so two concurrent starts cannot interleave;
+the `Load()!=nil` short-circuit + atomic `Store` are belt-and-suspenders.
+`stopAndDiscardNATPoolAlarm`'s `Swap(nil)` is the single point that
+both reads-and-clears, so a concurrent reader either sees the old
+monitor (valid; `ActiveAlarms()` is itself mutex-guarded inside the
+Monitor) or nil — never a torn pointer.
+
+### Edit 1 — `daemon_run.go` ~880: gate the boot-time start via the helper
+
+Replace the unconditional `New(...).Start()` with the gated helper.
+Because `maybeStartNATPoolAlarm` already checks `!inBootstrap()` and
+`!NoDataplane`, the call is simply:
+
+```go
+// #2114: start the NAT pool-alarm monitor only when NOT in bootstrap
+// mode. maybeStartNATPoolAlarm() gates on !inBootstrap() && !NoDataplane
+// and is idempotent. In bootstrap the dataplane object is constructed
+// (d.dp != nil) but not armed, and the bootstrap-exit path may write
+// d.dp = nil on an arm failure; the monitor's sampler reads d.dp, so
+// launching it here would race that write. It is started instead at the
+// end of runBootstrapExitStartup once the dataplane is armed (mirroring
+// the dataplane Start() gate above). On a normal boot the gate passes
+// and the monitor starts here exactly as before.
+d.maybeStartNATPoolAlarm()
 ```
 
 ### Edit 2 — `runBootstrapExitStartup` (~1701): start on successful arm
 
 In the existing arm block, start the monitor in the success branch
 (after `d.dp.Start()` succeeds, so `d.dp` is confirmed non-nil; this is
-*after* the `d.dp = nil` failure write, so the start is never reached
-on the failure path). This runs under `applySem`, so the monitor's
-first sampler read cannot overlap a concurrent `d.dp` write:
+*after* the `d.dp = nil` failure write, so the start is never reached on
+the failure path). This runs under `applySem`, so the monitor's first
+sampler read cannot overlap a concurrent `d.dp` write. By this point
+`exitBootstrapMode` has already flipped `bootstrapMode=false` (in
+`applyConfigLocked` just before calling `runBootstrapExitStartup`), so
+the helper's `!inBootstrap()` gate passes:
 
 ```go
 if d.dp != nil {
@@ -125,70 +214,68 @@ if d.dp != nil {
             seeder.SeedNATPortCounters()
             seeder.SeedSessionIDCounter(nodeID)
         }
-        // #2114: start the NAT pool-alarm monitor now that the
-        // dataplane is armed and d.dp is stable. Suppressed at boot in
-        // bootstrap mode (see daemon_run.go monitor-start gate). Guard
-        // against an unexpected double-start (idempotent: Start() is a
-        // no-op once started, but we also only construct once).
-        if d.natPoolAlarm == nil {
-            d.natPoolAlarm = natpoolalarm.New(d.natPoolAlarmSampler(), d.natPoolAlarmEmitter())
-            d.natPoolAlarm.Start()
-        }
+        // #2114: start the NAT pool-alarm monitor now that the dataplane
+        // is armed and d.dp is stable. Suppressed at boot in bootstrap
+        // mode; bootstrap is already exited here (exitBootstrapMode ran in
+        // applyConfigLocked), so the helper's gate passes. Idempotent.
+        d.maybeStartNATPoolAlarm()
     }
 }
 ```
 
-### Edit 3 — `enterBootstrapMode` (~bootstrap.go:363): stop + discard the monitor
+### Edit 3 — `enterBootstrapMode` (~bootstrap.go): stop + discard the monitor
 
-**(Added in v2 — Codex r1 PLAN-NEEDS-MAJOR.)** The rollback-to-bootstrap
-path (`enterBootstrapMode`, reached from a first-commit-confirmed
-timeout at `daemon_apply.go:308`) is reached AFTER a successful
-bootstrap-exit arm — so the monitor started by Edit 2 is alive. The
-rollback `Teardown()`s the dataplane but keeps `d.dp` NON-nil and does
-NOT stop the monitor. A subsequent corrected confirmed commit re-enters
+**(Codex r1.)** The rollback-to-bootstrap path (`enterBootstrapMode`,
+reached from a first-commit-confirmed timeout at
+`daemon_apply.go:308`) is reached AFTER a successful bootstrap-exit arm
+— so the monitor started by Edit 2 is alive. The rollback `Teardown()`s
+the dataplane but keeps `d.dp` NON-nil and (before this fix) did NOT
+stop the monitor. A subsequent corrected confirmed commit re-enters
 `runBootstrapExitStartup`; if THAT arm fails it writes `d.dp = nil`
-while the still-running monitor goroutine samples `d.dp` — **the same
-race survives**. Edit 2's `if d.natPoolAlarm == nil` guard does NOT
-help: the field is still non-nil (the old monitor), so no fresh monitor
-is built but the OLD goroutine keeps sampling.
+while the still-running monitor samples `d.dp` — **the same race
+survives**. Also `enterBootstrapMode` re-sets `bootstrapMode=true`, so
+without an explicit discard the stale monitor keeps running against a
+torn-down dp during the bootstrap window.
 
-Fix: in `enterBootstrapMode`, stop AND discard the monitor so it no
-longer samples `d.dp`, and so a later re-arm constructs a FRESH one
-(the existing `Monitor` is NOT restartable after `Stop()`: `started`
-stays true and the `stop` channel is closed, so calling `Start()` again
-is a no-op). Place it in the cleanup sequence (runs under the caller's
-`applySem`, serialized with the `d.dp = nil` writes):
+Fix: stop AND discard via the helper (the existing `Monitor` is NOT
+restartable after `Stop()` — `started` stays true and the `stop`
+channel is closed — so the next successful re-arm must build a FRESH
+one). `enterBootstrapMode` runs under the caller's `applySem`, and the
+helper's `Swap(nil)` atomically clears the pointer so a concurrent
+`show security alarms` reader never sees a torn value. Place it AFTER
+`d.bootstrapMode.Store(true)` but BEFORE the `applyBodyForTest`
+early-return so the existing `bootstrap_rollback_test.go` seam tests
+also exercise the discard (it is a no-op when no monitor is running):
 
 ```go
-// #2114: stop and DISCARD the NAT pool-alarm monitor. It was started
-// on the successful bootstrap-exit arm; rolling back to bootstrap means
-// a later corrected commit may re-enter runBootstrapExitStartup and, on
-// an arm failure, write d.dp = nil — which would race the monitor's
-// sampler if it kept running. Discard (not just Stop) because Monitor is
-// not restartable after Stop(); the next successful re-arm builds a
-// fresh one (Edit 2's nil-guard then fires).
-if d.natPoolAlarm != nil {
-    d.natPoolAlarm.Stop()
-    d.natPoolAlarm = nil
-}
+func (d *Daemon) enterBootstrapMode() {
+    d.bootstrapMode.Store(true)
+
+    // #2114: stop and discard the NAT pool-alarm monitor. It may have
+    // been started on a prior successful bootstrap-exit arm; rolling
+    // back to bootstrap means a later corrected commit can re-enter
+    // runBootstrapExitStartup and, on an arm failure, write d.dp = nil
+    // — which would race the monitor's sampler if it kept running.
+    // Discard (not just Stop) because Monitor is not restartable after
+    // Stop(); the next successful re-arm builds a fresh one.
+    d.stopAndDiscardNATPoolAlarm()
+
+    // Test seam: ...
+    if d.applyBodyForTest != nil {
+        return
+    }
+    ...
 ```
 
-This must run BEFORE the `d.dp.Teardown()` step is not strictly
-required (Teardown does not nil `d.dp`), but placing the Stop early in
-the sequence is cleanest. The `applyBodyForTest` early-return in
-`enterBootstrapMode` means this Stop must be placed AFTER that seam
-return only if we want unit tests with a stubbed body to skip it —
-but stopping a monitor is cheap and side-effect-free, so it can go
-either before or after the seam. Decided in Step 5: place it BEFORE the
-`applyBodyForTest` early-return so the lifecycle is exercised by the
-existing `bootstrap_rollback_test.go` seam tests too (Stop on a
-nil/un-started monitor is a no-op, so it is safe there).
+### Edit 4 — shutdown stop (`daemon_run.go:1512`): route through the helper
 
-Note: `Monitor.Start()` is already idempotent (`started` guard) and
-`Stop()` is safe whether or not `Start` ran, so shutdown
-(`daemon_run.go:1512` `if d.natPoolAlarm != nil { d.natPoolAlarm.Stop() }`)
-remains correct in all cases (never started, started at boot, started
-at bootstrap exit, stopped+discarded at rollback then re-built).
+The shutdown stop becomes the helper too (it both stops and clears,
+which is harmless at shutdown and keeps a single code path):
+
+```go
+// #2079/#2114: stop the NAT pool-utilization-alarm monitor.
+d.stopAndDiscardNATPoolAlarm()
+```
 
 ## Behavior matrix (must hold after the fix)
 
@@ -255,6 +342,7 @@ at bootstrap exit, stopped+discarded at rollback then re-built).
 | Architectural mismatch | LOW | Mirrors the existing dataplane-Start() bootstrap gate exactly; no new abstraction. |
 | Missed start path | LOW (was MED) | RESOLVED: single bootstrap-exit site (daemon_apply.go:378-380); cluster SyncApply shares it. |
 | Rollback→re-arm race | LOW (was the v1 miss) | Edit 3 stops+discards the monitor in enterBootstrapMode; Monitor rebuilt fresh on next arm. Covered by the new -race rollback test. |
+| Monitor-pointer race | LOW (was the v2 miss, Codex r2) | Edit 0 makes d.natPoolAlarm atomic.Pointer + routes all access (start/discard/read/shutdown) through helpers; the show-security-alarms reader can no longer race the runtime start/discard. Covered by the -race pointer-hammer test. |
 
 ## Test plan (this is a DATA RACE — `-race` is the gate)
 
@@ -280,13 +368,21 @@ at bootstrap exit, stopped+discarded at rollback then re-built).
      `d.natPoolAlarm == nil`, then concurrently write `d.dp = nil`
      (the re-arm-failure write) — no sampler survives, so no race.
    - **(c) re-arm builds fresh:** after the discard, `maybeStartNATPoolAlarm`
-     constructs a new monitor (nil-guard) and starts it.
+     constructs a new monitor (Swap/Load-guard) and starts it.
+   - **(d) pointer-publication race (Codex r2):** concurrently hammer
+     `natPoolAlarms()` (the `show security alarms` reader) from N
+     goroutines while another goroutine repeatedly
+     `maybeStartNATPoolAlarm()` → `stopAndDiscardNATPoolAlarm()`. With
+     `d.natPoolAlarm` as `atomic.Pointer`, reads/writes of the pointer
+     are race-free; pre-fix (plain pointer field mutated at runtime)
+     this trips `-race`. This proves Edit 0 (atomic field + helpers).
    - **fail-pre / pass-post guarantee:** part (a) fails under `-race` if
      Edit 1's `!inBootstrap()` gate is reverted (sampler races
-     `d.dp = nil`); part (b) fails under `-race` if Edit 3's
-     Stop+discard is reverted (stale sampler races the re-arm write).
-     Both target the real production gating, so the test is a true
-     regression guard, not a tautology.
+     `d.dp = nil`); part (b) fails if Edit 3's Stop+discard is reverted
+     (stale sampler races the re-arm write); part (d) fails if Edit 0's
+     atomic pointer is reverted to a plain field (reader races
+     start/discard). All target real production gating — true regression
+     guards, not tautologies.
    - To force the race window deterministically: the monitor's
      `tick` field is unexported and the daemon test is in a different
      package, so add a small exported test-support hook on

--- a/docs/pr/2114-natpoolalarm-bootstrap-race/plan.md
+++ b/docs/pr/2114-natpoolalarm-bootstrap-race/plan.md
@@ -1,6 +1,7 @@
 # #2114 — NAT pool-alarm monitor races `d.dp = nil` in bootstrap-exit
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** DRAFT v2 — Codex r1 PLAN-NEEDS-MAJOR addressed (rollback→re-arm
+race; monitor not restartable after Stop). Adds Edit 3 + revised test plan.
 
 ## Issue framing
 
@@ -137,11 +138,57 @@ if d.dp != nil {
 }
 ```
 
+### Edit 3 — `enterBootstrapMode` (~bootstrap.go:363): stop + discard the monitor
+
+**(Added in v2 — Codex r1 PLAN-NEEDS-MAJOR.)** The rollback-to-bootstrap
+path (`enterBootstrapMode`, reached from a first-commit-confirmed
+timeout at `daemon_apply.go:308`) is reached AFTER a successful
+bootstrap-exit arm — so the monitor started by Edit 2 is alive. The
+rollback `Teardown()`s the dataplane but keeps `d.dp` NON-nil and does
+NOT stop the monitor. A subsequent corrected confirmed commit re-enters
+`runBootstrapExitStartup`; if THAT arm fails it writes `d.dp = nil`
+while the still-running monitor goroutine samples `d.dp` — **the same
+race survives**. Edit 2's `if d.natPoolAlarm == nil` guard does NOT
+help: the field is still non-nil (the old monitor), so no fresh monitor
+is built but the OLD goroutine keeps sampling.
+
+Fix: in `enterBootstrapMode`, stop AND discard the monitor so it no
+longer samples `d.dp`, and so a later re-arm constructs a FRESH one
+(the existing `Monitor` is NOT restartable after `Stop()`: `started`
+stays true and the `stop` channel is closed, so calling `Start()` again
+is a no-op). Place it in the cleanup sequence (runs under the caller's
+`applySem`, serialized with the `d.dp = nil` writes):
+
+```go
+// #2114: stop and DISCARD the NAT pool-alarm monitor. It was started
+// on the successful bootstrap-exit arm; rolling back to bootstrap means
+// a later corrected commit may re-enter runBootstrapExitStartup and, on
+// an arm failure, write d.dp = nil — which would race the monitor's
+// sampler if it kept running. Discard (not just Stop) because Monitor is
+// not restartable after Stop(); the next successful re-arm builds a
+// fresh one (Edit 2's nil-guard then fires).
+if d.natPoolAlarm != nil {
+    d.natPoolAlarm.Stop()
+    d.natPoolAlarm = nil
+}
+```
+
+This must run BEFORE the `d.dp.Teardown()` step is not strictly
+required (Teardown does not nil `d.dp`), but placing the Stop early in
+the sequence is cleanest. The `applyBodyForTest` early-return in
+`enterBootstrapMode` means this Stop must be placed AFTER that seam
+return only if we want unit tests with a stubbed body to skip it —
+but stopping a monitor is cheap and side-effect-free, so it can go
+either before or after the seam. Decided in Step 5: place it BEFORE the
+`applyBodyForTest` early-return so the lifecycle is exercised by the
+existing `bootstrap_rollback_test.go` seam tests too (Stop on a
+nil/un-started monitor is a no-op, so it is safe there).
+
 Note: `Monitor.Start()` is already idempotent (`started` guard) and
 `Stop()` is safe whether or not `Start` ran, so shutdown
 (`daemon_run.go:1512` `if d.natPoolAlarm != nil { d.natPoolAlarm.Stop() }`)
-remains correct in all three cases (never started, started at boot,
-started at bootstrap exit).
+remains correct in all cases (never started, started at boot, started
+at bootstrap exit, stopped+discarded at rollback then re-built).
 
 ## Behavior matrix (must hold after the fix)
 
@@ -150,6 +197,9 @@ started at bootstrap exit).
 | Normal boot (not bootstrap, d.dp armed) | start at line 880 | n/a | yes, from boot | no (d.dp not written after boot single-thread) |
 | Bootstrap boot → first commit arms OK | suppressed | start in runBootstrapExitStartup success branch | yes, from exit | no (started under applySem after Start succeeds) |
 | Bootstrap boot → first commit arm FAILS (d.dp=nil) | suppressed | NOT started (failure branch) | no | no (no monitor goroutine exists) |
+| Bootstrap exit OK → confirm times out → rollback (enterBootstrapMode) | suppressed | started then **stopped+discarded** (Edit 3) | no (after rollback) | no (Edit 3 stops sampler before any future d.dp=nil) |
+| ...then corrected commit re-arms OK | n/a | fresh monitor built (Edit 2 nil-guard fires) | yes | no |
+| ...then corrected commit re-arm FAILS (d.dp=nil) | n/a | NOT started (failure branch); no stale sampler (Edit 3) | no | no |
 | NoDataplane | not reached (`if d.dp != nil` false) | runBootstrapExitStartup returns early | no | n/a |
 
 ## Hidden invariants preserved
@@ -179,19 +229,21 @@ started at bootstrap exit).
   bootstrap mode and runs ... runBootstrapExitStartup". There is NO
   second bootstrap-exit path. So Edit 2 covers every bootstrap-exit
   case. Option A is complete.
-- **Rollback-to-bootstrap (RESOLVED — OQ#3):** `enterBootstrapMode`
-  (`bootstrap.go:313`, the `prevCfg==nil` first-commit-timeout
-  rollback at `daemon_apply.go:308`) is reached only AFTER
-  `runBootstrapExitStartup` already ran (it is the rollback of a failed
-  first commit). It does NOT write `d.dp = nil` — it calls
-  `d.dp.Teardown()` and KEEPS the object non-nil. So there is no
-  `d.dp` nil-write race on this path. If the monitor was started at
-  the earlier successful arm, it keeps running and samples the
-  torn-down-but-non-nil `d.dp`; the sampler tolerates this
-  (AppliedNATView → Available:false → monitor HOLDs). A later
-  corrected `runBootstrapExitStartup` re-arm hits the
-  `d.natPoolAlarm == nil` guard (non-nil) and does NOT double-start.
-  Correct and race-free across rollback→re-arm.
+- **Rollback-to-bootstrap → re-arm (CORRECTED in v2 — Codex r1):**
+  `enterBootstrapMode` (`bootstrap.go:313`, the `prevCfg==nil`
+  first-commit-timeout rollback at `daemon_apply.go:308`) is reached
+  AFTER a SUCCESSFUL bootstrap-exit arm, so the Edit-2 monitor IS
+  alive. `enterBootstrapMode` does NOT nil `d.dp` (Teardown + keep) and
+  (before v2) did NOT stop the monitor. A later corrected confirmed
+  commit re-enters `runBootstrapExitStartup`; on an arm FAILURE it
+  writes `d.dp = nil` while the still-running monitor samples `d.dp`
+  → THE SAME RACE survives Option A's Edits 1+2. Edit 2's nil-guard
+  does not help (the field is still the old non-nil monitor). **Edit 3
+  closes this**: `enterBootstrapMode` now `Stop()`s AND discards
+  (`= nil`) the monitor under `applySem`, so no sampler goroutine
+  survives the rollback, and the next successful re-arm builds a fresh
+  monitor. (Stop+discard is required because `Monitor` is not
+  restartable after `Stop()`.)
 
 ## Risk assessment
 
@@ -201,43 +253,60 @@ started at bootstrap exit).
 | Lifetime / nil-deref | LOW | Monitor Start/Stop already nil-safe + idempotent; guard added. |
 | Concurrency correctness | LOW | Removes the race; introduces no new shared state. Start-at-exit runs under applySem. |
 | Architectural mismatch | LOW | Mirrors the existing dataplane-Start() bootstrap gate exactly; no new abstraction. |
-| Missed start path | **MED** | If a bootstrap-exit code path other than `runBootstrapExitStartup` exists (e.g. cluster SyncApply), the monitor could fail to start there. MUST verify in review. |
+| Missed start path | LOW (was MED) | RESOLVED: single bootstrap-exit site (daemon_apply.go:378-380); cluster SyncApply shares it. |
+| Rollback→re-arm race | LOW (was the v1 miss) | Edit 3 stops+discards the monitor in enterBootstrapMode; Monitor rebuilt fresh on next arm. Covered by the new -race rollback test. |
 
 ## Test plan (this is a DATA RACE — `-race` is the gate)
 
 1. `go build ./...` clean (worktree).
-2. **New `-race` regression test** in `pkg/daemon` (preferred — it
-   exercises the real daemon fields) OR a focused seam test:
-   - Construct a `*Daemon` with a fake `RuntimeDataPlane` set in `d.dp`
-     and `bootstrapMode=true`.
-   - Start the NAT-alarm monitor via the **real** start path used at
-     bootstrap exit (or via a small test seam that calls the same
-     sampler against `d.dp`), with a very short tick so the sampler
-     fires immediately and repeatedly.
-   - Concurrently, from another goroutine, flip `d.dp = nil` (mirroring
-     the bootstrap-exit failure write) while the sampler is reading.
-   - Run under `go test -race`. **PRE-FIX:** the unsynchronized read
-     vs write trips the detector (FAIL). **POST-FIX:** the monitor is
-     not started in bootstrap mode (Edit 1) / is started only under the
-     serialized exit path, so the test asserts the monitor goroutine is
-     NOT racing the bootstrap-mode `d.dp` write → clean under `-race`.
-   - NOTE: To get a clean PRE-FIX failure that POST-FIX passes, the test
-     must target the *daemon's start gating*, not the raw field (a raw
-     unsynchronized read+write will always race regardless of the daemon
-     fix). The test will therefore exercise: "with bootstrapMode=true,
-     starting the monitor via the boot path does NOT launch a sampler
-     goroutine that reads d.dp" — i.e. assert no goroutine is sampling
-     d.dp while bootstrap-exit nils it. Final test shape decided in
-     Step 5 to guarantee fail-pre / pass-post; if a deterministic
-     daemon-level seam is awkward, fall back to a `natpoolalarm`-level
-     test that drives `Start()`/sampler vs a concurrent
-     dp-transition seam under `-race`.
+2. **New `-race` regression test** in `pkg/daemon` that targets the
+   **daemon's monitor-lifecycle decisions** (NOT a raw always-racy
+   field — that would fail pre AND post, proving nothing). To make the
+   start/stop gating testable, extract the production start logic into a
+   tiny method, e.g. `maybeStartNATPoolAlarm()` (called from both
+   `daemon_run.go` boot path and `runBootstrapExitStartup`), so the
+   test drives the REAL gate. Reuse the existing `runtimeOnlyApplyTestDP`
+   fake (`policy_scheduler_apply_test.go`) as a non-nil `d.dp`.
+   The test asserts, under `go test -race`:
+   - **(a) boot-start gating:** with `bootstrapMode=true`, the boot-path
+     start is a no-op — no sampler goroutine is launched — so a
+     concurrent `d.dp = nil` (mirroring the bootstrap-exit failure
+     write) does NOT race. With `bootstrapMode=false`, the monitor IS
+     started.
+   - **(b) rollback stop+discard:** start the monitor (simulating a
+     successful bootstrap-exit arm), call `enterBootstrapMode` (the
+     real method, via the `applyBodyForTest` seam so it skips
+     fs/FRR/dataplane teardown but still runs the Stop+discard), assert
+     `d.natPoolAlarm == nil`, then concurrently write `d.dp = nil`
+     (the re-arm-failure write) — no sampler survives, so no race.
+   - **(c) re-arm builds fresh:** after the discard, `maybeStartNATPoolAlarm`
+     constructs a new monitor (nil-guard) and starts it.
+   - **fail-pre / pass-post guarantee:** part (a) fails under `-race` if
+     Edit 1's `!inBootstrap()` gate is reverted (sampler races
+     `d.dp = nil`); part (b) fails under `-race` if Edit 3's
+     Stop+discard is reverted (stale sampler races the re-arm write).
+     Both target the real production gating, so the test is a true
+     regression guard, not a tautology.
+   - To force the race window deterministically: the monitor's
+     `tick` field is unexported and the daemon test is in a different
+     package, so add a small exported test-support hook on
+     `natpoolalarm.Monitor` — `SetTickForTest(d time.Duration)` (guarded
+     to be called only before `Start`) — OR have the daemon test loop
+     Start→Stop→discard→rebuild N times so the immediate `m.evaluate()`
+     sampler read at the top of `run()` repeatedly overlaps a concurrent
+     `d.dp` write. Preferred: the loop approach needs no new API; the
+     immediate-evaluate read on each Start gives a deterministic
+     overlap with a tight write loop, and `-race` catches a single
+     overlapping access. If the loop proves flaky-detecting, add
+     `SetTickForTest`. Decided in Step 5; either keeps the test
+     sleep-free.
 3. `go test -race ./pkg/daemon/... ./pkg/natpoolalarm/...` clean.
 4. `go test ./...` (or at least affected packages) green.
-5. **No cluster smoke** — this is control-plane only and changes no
-   forwarding path (per task scoping). It DOES touch the bootstrap/HA
-   startup sequence, so review must confirm the normal-boot and
-   bootstrap-exit monitor-start paths both still fire.
+5. **No cluster smoke** — control-plane only; no forwarding path change
+   (per task scoping). It DOES touch the bootstrap/HA startup sequence,
+   so review must confirm normal-boot, bootstrap-exit, rollback, and
+   re-arm monitor-lifecycle paths all behave (covered by the test
+   above).
 
 ## Out of scope (explicitly)
 
@@ -260,12 +329,12 @@ started at bootstrap exit).
    go away pre-fix?** i.e. is the boot-time start the ONLY place the
    monitor goroutine is launched during the bootstrap window? (It is,
    per source — but confirm.)
-3. **[RESOLVED] Rollback-to-bootstrap edge case.** `enterBootstrapMode`
-   does NOT nil `d.dp` (it Teardown()s and keeps the object), so no
-   nil-write race there. The monitor (if started at the prior successful
-   arm) keeps running and HOLDs while the dataplane is unavailable; a
-   re-arm does not double-start (guard). See "Rollback-to-bootstrap"
-   under invariants. Acceptable.
+3. **[CORRECTED v2 — Codex r1] Rollback-to-bootstrap → re-arm race.**
+   `enterBootstrapMode` does NOT nil `d.dp` but ALSO did not stop the
+   monitor, leaving the sampler alive to race a subsequent re-arm's
+   `d.dp = nil`. Plus `Monitor` is not restartable after `Stop()`.
+   FIXED by Edit 3 (Stop + discard in `enterBootstrapMode`). Test plan
+   now covers this path.
 4. **Is the `-race` test genuinely fail-pre / pass-post**, or does it
    merely test an always-racy raw field (which would fail both pre and
    post and prove nothing)? The test must target the daemon's

--- a/docs/pr/2114-natpoolalarm-bootstrap-race/plan.md
+++ b/docs/pr/2114-natpoolalarm-bootstrap-race/plan.md
@@ -1,0 +1,278 @@
+# #2114 — NAT pool-alarm monitor races `d.dp = nil` in bootstrap-exit
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+The #2079 NAT pool-utilization-alarm monitor (PR #2109) starts a
+long-running background goroutine (`Monitor.run()` → `evaluate()` →
+`sample()`) on a 10s timer. Its sampler closure (`natPoolAlarmSampler`,
+`pkg/daemon/daemon_natpoolalarm.go`) reads the daemon's `d.dp`
+(`dataplane.RuntimeDataPlane`) interface field with **no
+synchronization**.
+
+In **bootstrap mode** the dataplane backend object is *constructed*
+(`d.dp != nil`) but not *armed*. The monitor start block in
+`pkg/daemon/daemon_run.go` (~line 880, inside the `if d.dp != nil {`
+background-services block) is gated only on `d.dp != nil` — NOT on
+`!d.inBootstrap()`. So in bootstrap mode the monitor goroutine is
+launched and its sampler runs every 10s.
+
+On the **first confirmed (non-empty) commit**, the apply path
+(`daemon_apply.go`) calls `exitBootstrapMode()` then
+`runBootstrapExitStartup(cfg)` (`daemon_run.go:1657`), which on a
+dataplane arm **failure** writes `d.dp = nil`
+(`daemon_run.go:1701`) — under `d.applySem`, on the apply goroutine.
+
+The monitor's sampler goroutine and the apply goroutine both touch
+`d.dp` (a non-atomic interface value) without a common lock. A 10s
+sampler tick that lands in the bootstrap-exit window = concurrent
+read + write of the same non-atomic interface field = a data race per
+the Go memory model. `go test -race` / a production race detector
+flags it; a torn interface read can panic or mis-resolve a type
+assertion.
+
+## Honest scope / value framing
+
+This is a correctness/safety fix for a freshly merged regression, not
+a perf change. The win is: **eliminate a Go-memory-model data race on
+the unhappy bootstrap path** (fresh foreign-host install whose first
+confirmed commit fails to arm the dataplane — the exact #1922/#2079
+target scenario). Severity is Medium per the issue: it requires
+bootstrap mode + an arm failure, but a torn interface read is UB and
+the race detector blocks `-race` builds/CI.
+
+If reviewers conclude the fix is wrong-shaped or the race is not real,
+PLAN-KILL is an acceptable verdict. (It is not: the issue's analysis is
+confirmed against current origin/master — see "Confirmed against
+source" below.)
+
+## Confirmed against source (origin/master @ b30a78e8)
+
+- `pkg/daemon/daemon.go:70` — `dp dataplane.RuntimeDataPlane` is a
+  plain field; no mutex, no `atomic.Pointer`.
+- `pkg/daemon/daemon_run.go:880-881` — monitor `New(...).Start()`
+  inside `if d.dp != nil {`, NOT gated on `!d.inBootstrap()`.
+- `pkg/daemon/daemon_run.go:642` — the dataplane `Start()` IS gated:
+  `if d.inBootstrap() { ...suppressed... } else { if d.dp != nil { d.dp.Start(ctx) ... } }`. The monitor start should mirror this.
+- `pkg/daemon/daemon_run.go:1657` `runBootstrapExitStartup` — arms the
+  dataplane on bootstrap exit; on failure `d.dp = nil`
+  (`daemon_run.go:1701`), under `applySem` (apply caller holds it).
+- `pkg/daemon/daemon_natpoolalarm.go:18-22` — sampler reads
+  `d.dp` then type-asserts `d.dp.(interface{ Manager() *Manager })`.
+- `pkg/natpoolalarm/natpoolalarm.go` — `Start()` spawns `go m.run()`;
+  `run()` calls `m.evaluate()` immediately (so the first racy read
+  happens on the new goroutine right after `Start()`), then ticks
+  every `tick` (default 10s).
+- `pkg/daemon/bootstrap.go:280` — `inBootstrap()` reads
+  `d.bootstrapMode atomic.Bool` (race-free gate).
+- `pkg/daemon/daemon_run.go:1512` — monitor `Stop()` at shutdown only.
+
+## Chosen design — Option A (gate the start; start on bootstrap exit)
+
+**Why A, not B (synchronize all `d.dp` access):** there is NO existing
+mutex/accessor for `d.dp` anywhere in the daemon. Every reader
+(`daemon_forwarding_status.go` `IsLoaded`/`IsUserspaceDataplane`,
+`daemon_ha_sync.go`, `daemon_ha_fabric.go`, `daemon_neighbor_listener.go`,
+`daemon_apply.go`, ~40 sites) reads `d.dp` unsynchronized. Introducing a
+mutex/`atomic.Pointer` accessor would touch all of them and is a much
+larger, riskier change that the issue itself labels the "durable"
+(option 2) fix for the *whole* field — out of scope for a targeted
+regression fix. The codebase's actual invariant is: **`d.dp` is written
+only on the boot/apply goroutine under `applySem` (or during the
+single-threaded boot sequence before background goroutines start);
+continuously-running readers must not be launched while a write can
+still occur.** The bug is that #2109 violated that invariant by
+launching a continuous reader during bootstrap, where the
+bootstrap-exit write still happens. Option A restores the invariant
+and exactly mirrors the dataplane-`Start()` gate already at line 642.
+
+### Edit 1 — `daemon_run.go` ~880: gate the boot-time start
+
+Wrap the monitor `New/Start` in `if !d.inBootstrap()`:
+
+```go
+// #2114: do NOT start the NAT pool-alarm monitor while in bootstrap
+// mode. In bootstrap the dataplane object is constructed (d.dp != nil)
+// but not armed, and the bootstrap-exit path may write d.dp = nil on
+// an arm failure. The monitor's sampler reads d.dp unsynchronized, so
+// launching it here would race that write. It is started instead at
+// the end of runBootstrapExitStartup once the dataplane is armed
+// (mirroring the dataplane Start() gate above). On a normal
+// (non-bootstrap) boot this branch runs as before.
+if !d.inBootstrap() {
+    d.natPoolAlarm = natpoolalarm.New(d.natPoolAlarmSampler(), d.natPoolAlarmEmitter())
+    d.natPoolAlarm.Start()
+}
+```
+
+### Edit 2 — `runBootstrapExitStartup` (~1701): start on successful arm
+
+In the existing arm block, start the monitor in the success branch
+(after `d.dp.Start()` succeeds, so `d.dp` is confirmed non-nil; this is
+*after* the `d.dp = nil` failure write, so the start is never reached
+on the failure path). This runs under `applySem`, so the monitor's
+first sampler read cannot overlap a concurrent `d.dp` write:
+
+```go
+if d.dp != nil {
+    if err := d.dp.Start(d.daemonCtx); err != nil {
+        slog.Warn("bootstrap exit: failed to start dataplane, running in config-only mode", "err", err)
+        d.dp = nil
+    } else {
+        if seeder, ok := d.dp.(natSeeder); ok {
+            seeder.SeedNATPortCounters()
+            seeder.SeedSessionIDCounter(nodeID)
+        }
+        // #2114: start the NAT pool-alarm monitor now that the
+        // dataplane is armed and d.dp is stable. Suppressed at boot in
+        // bootstrap mode (see daemon_run.go monitor-start gate). Guard
+        // against an unexpected double-start (idempotent: Start() is a
+        // no-op once started, but we also only construct once).
+        if d.natPoolAlarm == nil {
+            d.natPoolAlarm = natpoolalarm.New(d.natPoolAlarmSampler(), d.natPoolAlarmEmitter())
+            d.natPoolAlarm.Start()
+        }
+    }
+}
+```
+
+Note: `Monitor.Start()` is already idempotent (`started` guard) and
+`Stop()` is safe whether or not `Start` ran, so shutdown
+(`daemon_run.go:1512` `if d.natPoolAlarm != nil { d.natPoolAlarm.Stop() }`)
+remains correct in all three cases (never started, started at boot,
+started at bootstrap exit).
+
+## Behavior matrix (must hold after the fix)
+
+| Path | Boot | Bootstrap exit | Monitor running? | Races d.dp write? |
+|------|------|----------------|------------------|-------------------|
+| Normal boot (not bootstrap, d.dp armed) | start at line 880 | n/a | yes, from boot | no (d.dp not written after boot single-thread) |
+| Bootstrap boot → first commit arms OK | suppressed | start in runBootstrapExitStartup success branch | yes, from exit | no (started under applySem after Start succeeds) |
+| Bootstrap boot → first commit arm FAILS (d.dp=nil) | suppressed | NOT started (failure branch) | no | no (no monitor goroutine exists) |
+| NoDataplane | not reached (`if d.dp != nil` false) | runBootstrapExitStartup returns early | no | n/a |
+
+## Hidden invariants preserved
+
+- **Monitor lifecycle:** still constructed at most once; `Stop()` at
+  shutdown still safe (idempotent + safe-on-unstarted). The `d.natPoolAlarm == nil`
+  guard in Edit 2 prevents any double-construct if both paths somehow
+  ran (they cannot — boot-start is gated on `!inBootstrap()`, exit-start
+  only runs from bootstrap exit — but the guard is cheap insurance).
+- **Sampler correctness in normal case:** unchanged; the sampler reads
+  the same cached `AppliedNATView`. The monitor still surfaces an
+  over-threshold pool within the first tick after it starts.
+- **Bootstrap-exit ordering:** the monitor start is the LAST step in
+  `runBootstrapExitStartup`'s arm block, after NAT seeding, so it never
+  changes the takeover sequence (rename → forwarding → arm → seed →
+  monitor).
+- **applySem discipline:** the bootstrap-exit start runs under the
+  caller's `applySem` hold (same as the `d.dp = nil` write site), so
+  the construct+launch is serialized w.r.t. any other `d.dp` mutation.
+- **HA / cluster (RESOLVED — OQ#1):** the bootstrap-exit transition
+  (`exitBootstrapMode` + `runBootstrapExitStartup`) lives at
+  `daemon_apply.go:379-380`, inside `applyConfigLocked` — the SINGLE
+  reconcile pipeline that BOTH a local confirmed commit AND a cluster
+  `SyncApply` route through. The in-source comment is explicit:
+  "the FIRST apply of a non-empty config (an interface-claiming
+  confirmed commit, or a cluster SyncApply from the primary) leaves
+  bootstrap mode and runs ... runBootstrapExitStartup". There is NO
+  second bootstrap-exit path. So Edit 2 covers every bootstrap-exit
+  case. Option A is complete.
+- **Rollback-to-bootstrap (RESOLVED — OQ#3):** `enterBootstrapMode`
+  (`bootstrap.go:313`, the `prevCfg==nil` first-commit-timeout
+  rollback at `daemon_apply.go:308`) is reached only AFTER
+  `runBootstrapExitStartup` already ran (it is the rollback of a failed
+  first commit). It does NOT write `d.dp = nil` — it calls
+  `d.dp.Teardown()` and KEEPS the object non-nil. So there is no
+  `d.dp` nil-write race on this path. If the monitor was started at
+  the earlier successful arm, it keeps running and samples the
+  torn-down-but-non-nil `d.dp`; the sampler tolerates this
+  (AppliedNATView → Available:false → monitor HOLDs). A later
+  corrected `runBootstrapExitStartup` re-arm hits the
+  `d.natPoolAlarm == nil` guard (non-nil) and does NOT double-start.
+  Correct and race-free across rollback→re-arm.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Pure start-gating; normal-boot path byte-identical. Only new behavior: monitor start deferred to bootstrap exit on the bootstrap path. |
+| Lifetime / nil-deref | LOW | Monitor Start/Stop already nil-safe + idempotent; guard added. |
+| Concurrency correctness | LOW | Removes the race; introduces no new shared state. Start-at-exit runs under applySem. |
+| Architectural mismatch | LOW | Mirrors the existing dataplane-Start() bootstrap gate exactly; no new abstraction. |
+| Missed start path | **MED** | If a bootstrap-exit code path other than `runBootstrapExitStartup` exists (e.g. cluster SyncApply), the monitor could fail to start there. MUST verify in review. |
+
+## Test plan (this is a DATA RACE — `-race` is the gate)
+
+1. `go build ./...` clean (worktree).
+2. **New `-race` regression test** in `pkg/daemon` (preferred — it
+   exercises the real daemon fields) OR a focused seam test:
+   - Construct a `*Daemon` with a fake `RuntimeDataPlane` set in `d.dp`
+     and `bootstrapMode=true`.
+   - Start the NAT-alarm monitor via the **real** start path used at
+     bootstrap exit (or via a small test seam that calls the same
+     sampler against `d.dp`), with a very short tick so the sampler
+     fires immediately and repeatedly.
+   - Concurrently, from another goroutine, flip `d.dp = nil` (mirroring
+     the bootstrap-exit failure write) while the sampler is reading.
+   - Run under `go test -race`. **PRE-FIX:** the unsynchronized read
+     vs write trips the detector (FAIL). **POST-FIX:** the monitor is
+     not started in bootstrap mode (Edit 1) / is started only under the
+     serialized exit path, so the test asserts the monitor goroutine is
+     NOT racing the bootstrap-mode `d.dp` write → clean under `-race`.
+   - NOTE: To get a clean PRE-FIX failure that POST-FIX passes, the test
+     must target the *daemon's start gating*, not the raw field (a raw
+     unsynchronized read+write will always race regardless of the daemon
+     fix). The test will therefore exercise: "with bootstrapMode=true,
+     starting the monitor via the boot path does NOT launch a sampler
+     goroutine that reads d.dp" — i.e. assert no goroutine is sampling
+     d.dp while bootstrap-exit nils it. Final test shape decided in
+     Step 5 to guarantee fail-pre / pass-post; if a deterministic
+     daemon-level seam is awkward, fall back to a `natpoolalarm`-level
+     test that drives `Start()`/sampler vs a concurrent
+     dp-transition seam under `-race`.
+3. `go test -race ./pkg/daemon/... ./pkg/natpoolalarm/...` clean.
+4. `go test ./...` (or at least affected packages) green.
+5. **No cluster smoke** — this is control-plane only and changes no
+   forwarding path (per task scoping). It DOES touch the bootstrap/HA
+   startup sequence, so review must confirm the normal-boot and
+   bootstrap-exit monitor-start paths both still fire.
+
+## Out of scope (explicitly)
+
+- Option B (uniform `d.dp` accessor / mutex / `atomic.Pointer`) — the
+  durable whole-field fix. Deferred; the pre-existing unsynchronized
+  request-driven readers (`IsLoaded`, `IsUserspaceDataplane`) predate
+  #2109 and are not this regression. File a follow-up if desired.
+- Any change to the alarm evaluation / hysteresis / emit logic.
+- Rust / wire / forwarding changes (none).
+
+## Open questions for adversarial review (invite PLAN-KILL)
+
+1. **[RESOLVED] Does every bootstrap-exit path route through
+   `runBootstrapExitStartup`?** YES — `exitBootstrapMode` +
+   `runBootstrapExitStartup` are called from exactly one site
+   (`daemon_apply.go:379-380`, inside `applyConfigLocked`), which is
+   the common pipeline for both local confirmed commit and cluster
+   SyncApply. No second exit path. Edit 2 is complete.
+2. **Is Edit 1's `!d.inBootstrap()` gate sufficient to make the race
+   go away pre-fix?** i.e. is the boot-time start the ONLY place the
+   monitor goroutine is launched during the bootstrap window? (It is,
+   per source — but confirm.)
+3. **[RESOLVED] Rollback-to-bootstrap edge case.** `enterBootstrapMode`
+   does NOT nil `d.dp` (it Teardown()s and keeps the object), so no
+   nil-write race there. The monitor (if started at the prior successful
+   arm) keeps running and HOLDs while the dataplane is unavailable; a
+   re-arm does not double-start (guard). See "Rollback-to-bootstrap"
+   under invariants. Acceptable.
+4. **Is the `-race` test genuinely fail-pre / pass-post**, or does it
+   merely test an always-racy raw field (which would fail both pre and
+   post and prove nothing)? The test must target the daemon's
+   start-gating decision, not a hand-rolled unsynchronized read+write.
+5. **Should Edit 2 start the monitor even on a cluster (HA) bootstrap
+   exit**, or is the monitor cluster-gated elsewhere? (Per #2079 the
+   monitor is not cluster-gated; both nodes can raise local alarms.)
+6. **Is option A preferable to B given the issue explicitly frames B as
+   the "durable" fix?** Argue why the minimal targeted fix is correct
+   for a regression and B is a separate, larger refactor.

--- a/docs/pr/2114-natpoolalarm-bootstrap-race/plan.md
+++ b/docs/pr/2114-natpoolalarm-bootstrap-race/plan.md
@@ -1,12 +1,14 @@
 # #2114 — NAT pool-alarm monitor races `d.dp = nil` in bootstrap-exit
 
-**Status:** DRAFT v3 — Codex r2 PLAN-NEEDS-MAJOR addressed. v2's
-runtime-mutated `d.natPoolAlarm` pointer is itself read unsynchronized by
-`natPoolAlarms()` on the gRPC/CLI `show security alarms` render path,
-racing the new start/discard writes. v3 makes the pointer
-`atomic.Pointer[natpoolalarm.Monitor]` and routes ALL access through
-helpers (`maybeStartNATPoolAlarm`, `stopAndDiscardNATPoolAlarm`,
-`natPoolAlarms`, shutdown). Now FOUR edits.
+**Status:** PLAN-READY (v4) — Codex converged: r1 NEEDS-MAJOR
+(rollback→re-arm race) → r2 NEEDS-MAJOR (natPoolAlarm pointer race) →
+r3 NEEDS-MINOR (all minor folded in v4: `d.dp==nil` in the helper
+guard; test assertions use `.Load()`; part-(c) clears bootstrap before
+re-arm). Independent second reviewer (Gemini) is UNAVAILABLE (client
+deprecated); parent should dispatch an independent review. v4 makes the
+pointer `atomic.Pointer[natpoolalarm.Monitor]` and routes ALL access
+through helpers (`maybeStartNATPoolAlarm`, `stopAndDiscardNATPoolAlarm`,
+`natPoolAlarms`, shutdown). FIVE edits (0-4).
 
 ## Issue framing
 
@@ -128,7 +130,13 @@ Helpers (in `daemon_natpoolalarm.go`):
 // background-services block and from runBootstrapExitStartup's success
 // branch.
 func (d *Daemon) maybeStartNATPoolAlarm() {
-    if d.opts.NoDataplane || d.inBootstrap() {
+    // Gate: no dataplane backend, in bootstrap (unarmed dp / pending
+    // d.dp=nil write), or no constructed dp object → do not start. The
+    // d.dp==nil check is added per Codex r3: the plan says
+    // "dataplane-armed", and even though every current caller already
+    // enforces it, making the helper self-contained prevents a future
+    // caller from launching a sampler with no dp.
+    if d.opts.NoDataplane || d.inBootstrap() || d.dp == nil {
         return
     }
     if d.natPoolAlarm.Load() != nil {
@@ -365,10 +373,18 @@ d.stopAndDiscardNATPoolAlarm()
      successful bootstrap-exit arm), call `enterBootstrapMode` (the
      real method, via the `applyBodyForTest` seam so it skips
      fs/FRR/dataplane teardown but still runs the Stop+discard), assert
-     `d.natPoolAlarm == nil`, then concurrently write `d.dp = nil`
-     (the re-arm-failure write) — no sampler survives, so no race.
-   - **(c) re-arm builds fresh:** after the discard, `maybeStartNATPoolAlarm`
-     constructs a new monitor (Swap/Load-guard) and starts it.
+     `d.natPoolAlarm.Load() == nil` (atomic field — NOT `== nil`), then
+     concurrently write `d.dp = nil` (the re-arm-failure write) — no
+     sampler survives, so no race. Note `enterBootstrapMode` also sets
+     `bootstrapMode=true`, so the helper is gated off afterward.
+   - **(c) re-arm builds fresh:** mimic production re-arm ordering —
+     clear bootstrap mode (`d.bootstrapMode.Store(false)`, as
+     `exitBootstrapMode` does before `runBootstrapExitStartup`) BEFORE
+     calling `maybeStartNATPoolAlarm`, then assert
+     `d.natPoolAlarm.Load() != nil` (a FRESH monitor was built). Also
+     assert that calling `maybeStartNATPoolAlarm` while still in
+     bootstrap (after the part-(b) `enterBootstrapMode`) is a no-op
+     (`Load() == nil`).
    - **(d) pointer-publication race (Codex r2):** concurrently hammer
      `natPoolAlarms()` (the `show security alarms` reader) from N
      goroutines while another goroutine repeatedly

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -177,12 +177,16 @@ never lock an operator out of a remote box it manages.
       window further but is a separable follow-up, not required for the Go fix.
 - **Bootstrap mode** (`d.bootstrapMode` atomic): runs gRPC/REST/CLI normally
   but SUPPRESSES interface takeover ACTIONS — the full rename loop, host
-  tunables, `enableForwarding`, dataplane arm (`dp.Start`), and boot-time
-  `applyConfig`. Managers are still constructed (so the exit reconcile wires
-  every subsystem). A plain first `commit` is REFUSED — the operator must
-  `commit confirmed`. Exit is one-way, on the first non-empty config apply
-  (confirmed commit OR cluster `SyncApply`); `runBootstrapExitStartup` then
-  runs the deferred startup takeover before the reconcile.
+  tunables, `enableForwarding`, dataplane arm (`dp.Start`), the boot-time
+  `applyConfig`, and the #2079 NAT pool-alarm monitor start (#2114: the
+  monitor samples `d.dp`, which is still nil-able on a bootstrap-exit arm
+  failure, so it must not run during the bootstrap window). Managers are
+  still constructed (so the exit reconcile wires every subsystem). A plain
+  first `commit` is REFUSED — the operator must `commit confirmed`. Exit is
+  one-way, on the first non-empty config apply (confirmed commit OR cluster
+  `SyncApply`); `runBootstrapExitStartup` then runs the deferred startup
+  takeover (including starting the NAT pool-alarm monitor on a successful
+  arm) before the reconcile.
 - **PCI-keyed lifeline** (`setupBootstrapLifeline`): in bootstrap mode the
   daemon detects the default-route mgmt NIC (v4 then v6, else refuse +
   console), records its PCI+MAC to `/etc/xpf/lifeline-interface` (keyed by
@@ -195,10 +199,14 @@ never lock an operator out of a remote box it manages.
   always-down / address-stripped, even on an empty/absent/rolled-back config.
   An explicit non-fxp0 leaf narrows fxp0 off the auto-protection.
 - **First-commit rollback** (`enterBootstrapMode`): a timed-out first
-  `commit confirmed` removes the takeover `.network` files (keeping the
-  lifeline + `.link` files), clears the FRR managed section, and detaches the
-  dataplane — instead of applying an empty config — and the store persists
-  the never-committed marker so a restart re-enters bootstrap.
+  `commit confirmed` stops+discards the NAT pool-alarm monitor (#2114 — so
+  no sampler survives to race a later re-arm's `d.dp = nil` write; the
+  monitor is rebuilt fresh on a corrected re-arm because it is not
+  restartable after `Stop`), removes the takeover `.network` files (keeping
+  the lifeline + `.link` files), clears the FRR managed section, and
+  detaches the dataplane — instead of applying an empty config — and the
+  store persists the never-committed marker so a restart re-enters
+  bootstrap.
 
 ## Notable gotchas
 

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -313,6 +313,18 @@ func (d *Daemon) exitBootstrapMode(reason string) {
 func (d *Daemon) enterBootstrapMode() {
 	d.bootstrapMode.Store(true)
 
+	// #2114: stop and DISCARD the NAT pool-alarm monitor. It may have been
+	// started on a prior successful bootstrap-exit arm; rolling back to
+	// bootstrap means a later corrected commit can re-enter
+	// runBootstrapExitStartup and, on an arm failure, write d.dp = nil —
+	// which would race the still-running monitor's sampler. Discard (not
+	// just Stop) because natpoolalarm.Monitor is not restartable after
+	// Stop(); the next successful re-arm builds a fresh one via
+	// maybeStartNATPoolAlarm. Placed BEFORE the applyBodyForTest seam return
+	// so the lifecycle is exercised by the rollback unit tests too (it is a
+	// no-op when no monitor is running). Runs under the caller's d.applySem.
+	d.stopAndDiscardNATPoolAlarm()
+
 	// Test seam: when the apply body is stubbed (unit tests), skip the
 	// real filesystem / networkctl / FRR / dataplane teardown — those touch
 	// /etc/systemd/network and run external commands. The flag flip above is

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -141,6 +141,10 @@ type Daemon struct {
 	// through maybeStartNATPoolAlarm / stopAndDiscardNATPoolAlarm /
 	// natPoolAlarms so the pointer is never read or written unsynchronized.
 	natPoolAlarm atomic.Pointer[natpoolalarm.Monitor]
+	// natPoolAlarmTestTick overrides the monitor's sampler cadence at
+	// construction time (#2114 race tests only). Zero in production (default
+	// 10s). Read once in maybeStartNATPoolAlarm before Start.
+	natPoolAlarmTestTick time.Duration
 	// pendingFIBBump records an UNCONFIRMED FIB-generation bump after a
 	// successful route-overlay publish (#1844, Codex plan r2-1): the
 	// bump_fib_generation control message failed, so the next actuation

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -133,20 +133,27 @@ type Daemon struct {
 	// that raises/clears `show security alarms` entries with hysteresis and
 	// emits one structured RT_NAT syslog line per transition. Nil in
 	// NoDataplane mode (no helper to sample).
-	natPoolAlarm *natpoolalarm.Monitor
+	//
+	// #2114: atomic.Pointer because the monitor is now started/stopped at
+	// RUNTIME (bootstrap exit arms it; bootstrap rollback stops+discards
+	// it) concurrently with the `show security alarms` render reader
+	// (natPoolAlarms, wired into the gRPC/CLI callbacks). All access goes
+	// through maybeStartNATPoolAlarm / stopAndDiscardNATPoolAlarm /
+	// natPoolAlarms so the pointer is never read or written unsynchronized.
+	natPoolAlarm atomic.Pointer[natpoolalarm.Monitor]
 	// pendingFIBBump records an UNCONFIRMED FIB-generation bump after a
 	// successful route-overlay publish (#1844, Codex plan r2-1): the
 	// bump_fib_generation control message failed, so the next actuation
 	// must retry the bump even when its publish is a duplicate-skip —
 	// otherwise cached flow routes stay pinned to pre-failover paths.
 	// Mutated only in actuateRouteOverlayLocked under applySem.
-	pendingFIBBump             bool
-	flowExporter               *flowexport.Exporter
-	flowCancel                 context.CancelFunc
-	flowWg                     sync.WaitGroup
-	ipfixExporter              *flowexport.IPFIXExporter
-	ipfixCancel                context.CancelFunc
-	ipfixWg                    sync.WaitGroup
+	pendingFIBBump bool
+	flowExporter   *flowexport.Exporter
+	flowCancel     context.CancelFunc
+	flowWg         sync.WaitGroup
+	ipfixExporter  *flowexport.IPFIXExporter
+	ipfixCancel    context.CancelFunc
+	ipfixWg        sync.WaitGroup
 	// #2075 flowexport reconcile state. The bundle pointers carry the
 	// live (exporter, resolved-config) pair read lock-free by the
 	// once-registered session-close callbacks; reconcile swaps them
@@ -155,16 +162,16 @@ type Daemon struct {
 	// bools distinguish "never reconciled" from "reconciled to the
 	// nil sentinel". The *ReconMu serialize the reconcile swap against
 	// shutdown's stopFlow/IPFIXExporter (both touch the cancel/wg).
-	flowBundle     atomic.Pointer[exporterBundle]
-	flowHash       [32]byte
-	flowHashSet    bool
-	flowCBOnce     sync.Once
-	flowReconMu    sync.Mutex
-	ipfixBundlePtr atomic.Pointer[ipfixBundle]
-	ipfixHash      [32]byte
-	ipfixHashSet   bool
-	ipfixCBOnce    sync.Once
-	ipfixReconMu   sync.Mutex
+	flowBundle                 atomic.Pointer[exporterBundle]
+	flowHash                   [32]byte
+	flowHashSet                bool
+	flowCBOnce                 sync.Once
+	flowReconMu                sync.Mutex
+	ipfixBundlePtr             atomic.Pointer[ipfixBundle]
+	ipfixHash                  [32]byte
+	ipfixHashSet               bool
+	ipfixCBOnce                sync.Once
+	ipfixReconMu               sync.Mutex
 	dhcpRelay                  *dhcprelay.Manager
 	snmpAgent                  *snmp.Agent
 	lldpMgr                    *lldp.Manager

--- a/pkg/daemon/daemon_natpoolalarm.go
+++ b/pkg/daemon/daemon_natpoolalarm.go
@@ -67,10 +67,57 @@ func (d *Daemon) natPoolAlarmEmitter() natpoolalarm.Emitter {
 
 // natPoolAlarms returns the active NAT pool-utilization alarms for the
 // `show security alarms` render sites (#2079). Returns nil when the monitor
-// is not running (NoDataplane).
+// is not running (NoDataplane, bootstrap mode, or a torn-down dataplane).
+//
+// #2114: reads the monitor pointer atomically. This runs on gRPC/CLI
+// request goroutines concurrently with the runtime start (bootstrap exit)
+// and stop+discard (bootstrap rollback / shutdown) of the monitor. The
+// atomic Load yields either a valid *Monitor (ActiveAlarms() is itself
+// mutex-guarded inside the monitor) or nil — never a torn pointer.
 func (d *Daemon) natPoolAlarms() []natpoolalarm.ActiveAlarm {
-	if d == nil || d.natPoolAlarm == nil {
+	if d == nil {
 		return nil
 	}
-	return d.natPoolAlarm.ActiveAlarms()
+	m := d.natPoolAlarm.Load()
+	if m == nil {
+		return nil
+	}
+	return m.ActiveAlarms()
+}
+
+// maybeStartNATPoolAlarm constructs and starts the NAT pool-alarm monitor
+// exactly once, gated on a non-NoDataplane, non-bootstrap, dataplane-armed
+// daemon (#2114). It is idempotent: a non-nil stored monitor short-circuits.
+//
+// Called from the normal-boot background-services block (daemon_run.go) and
+// from runBootstrapExitStartup's successful-arm branch. Both call sites run
+// before the control plane serves requests (boot) or under d.applySem
+// (bootstrap exit), so two concurrent constructions cannot interleave; the
+// Load()!=nil short-circuit plus the atomic Store are belt-and-suspenders.
+//
+// The d.dp==nil guard keeps the helper self-contained: bootstrap suppresses
+// the start, and a torn-down/never-armed dataplane has nothing to sample.
+func (d *Daemon) maybeStartNATPoolAlarm() {
+	if d.opts.NoDataplane || d.inBootstrap() || d.dp == nil {
+		return
+	}
+	if d.natPoolAlarm.Load() != nil {
+		return // already started
+	}
+	m := natpoolalarm.New(d.natPoolAlarmSampler(), d.natPoolAlarmEmitter())
+	d.natPoolAlarm.Store(m)
+	m.Start()
+}
+
+// stopAndDiscardNATPoolAlarm stops the monitor (Stop joins its goroutine)
+// and CLEARS the pointer so a later re-arm builds a fresh monitor — the
+// natpoolalarm.Monitor is not restartable after Stop() (#2114). Safe when no
+// monitor is running (Swap returns nil). Called from bootstrap rollback
+// (enterBootstrapMode) and shutdown. The atomic Swap(nil) is the single
+// read-and-clear point, so a concurrent natPoolAlarms() reader sees either
+// the old monitor or nil, never a torn pointer.
+func (d *Daemon) stopAndDiscardNATPoolAlarm() {
+	if m := d.natPoolAlarm.Swap(nil); m != nil {
+		m.Stop()
+	}
 }

--- a/pkg/daemon/daemon_natpoolalarm.go
+++ b/pkg/daemon/daemon_natpoolalarm.go
@@ -105,6 +105,12 @@ func (d *Daemon) maybeStartNATPoolAlarm() {
 		return // already started
 	}
 	m := natpoolalarm.New(d.natPoolAlarmSampler(), d.natPoolAlarmEmitter())
+	// Test seam: drive the sampler at a fast tick so the #2114 race tests can
+	// exercise the sampler-vs-d.dp overlap deterministically. Zero in
+	// production (default 10s cadence). Must be applied before Start().
+	if d.natPoolAlarmTestTick > 0 {
+		m.SetTickForTest(d.natPoolAlarmTestTick)
+	}
 	d.natPoolAlarm.Store(m)
 	m.Start()
 }

--- a/pkg/daemon/daemon_natpoolalarm_race_test.go
+++ b/pkg/daemon/daemon_natpoolalarm_race_test.go
@@ -1,0 +1,193 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2114 regression tests for the NAT pool-alarm monitor's lifecycle vs the
+// daemon's d.dp / bootstrap-exit transitions. These MUST be run under
+// `go test -race`; the bug they guard is a data race on the unsynchronized
+// d.dp interface field (sampler read vs bootstrap-exit d.dp=nil write) and a
+// second race on the d.natPoolAlarm pointer itself (now atomic.Pointer) that
+// the runtime start/discard introduced and the show-security-alarms reader
+// raced.
+//
+// The tests target the REAL production gating helpers (maybeStartNATPoolAlarm,
+// stopAndDiscardNATPoolAlarm, natPoolAlarms) rather than a hand-rolled racy
+// field, so they are genuine fail-pre / pass-post regression guards:
+//   - TestNATPoolAlarm_BootGate fails if the boot-time start drops its
+//     !inBootstrap() gate (Edit 1): a sampler goroutine then reads d.dp while
+//     the test writes d.dp = nil.
+//   - TestNATPoolAlarm_RollbackDiscard fails if enterBootstrapMode drops the
+//     stop+discard (Edit 3): a stale sampler survives the rollback and races
+//     a later d.dp = nil re-arm-failure write.
+//   - TestNATPoolAlarm_PointerPublication fails if d.natPoolAlarm reverts to a
+//     plain pointer (Edit 0): the show-security-alarms reader races the
+//     runtime start/discard writes.
+
+// newNATPoolAlarmTestDaemon builds a minimal *Daemon with a non-nil runtime
+// dataplane fake (so d.dp != nil) and an injected apply-body seam (so
+// enterBootstrapMode skips the real fs/FRR/dataplane teardown but still runs
+// the #2114 stop+discard placed before that seam return).
+func newNATPoolAlarmTestDaemon() *Daemon {
+	d := &Daemon{}
+	d.dp = &runtimeOnlyApplyTestDP{}
+	d.applyBodyForTest = func(_ *config.Config) {}
+	// Fast sampler cadence so any monitor that DOES start actively reads
+	// d.dp during the concurrent d.dp-write loops below — making the
+	// sampler-vs-d.dp race detectable under -race if a gate/discard is
+	// removed (not merely caught by the start/discard assertions).
+	d.natPoolAlarmTestTick = time.Millisecond
+	return d
+}
+
+// writeDPFor mirrors the bootstrap-exit/re-arm-failure write of the daemon's
+// d.dp field in a tight loop for the given duration, then joins. It is the
+// concurrent writer the monitor's sampler would race if a start gate or the
+// rollback discard were removed.
+func writeDPFor(dur time.Duration, d *Daemon) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deadline := time.Now().Add(dur)
+		for time.Now().Before(deadline) {
+			d.dp = nil
+			d.dp = &runtimeOnlyApplyTestDP{}
+		}
+	}()
+	wg.Wait()
+}
+
+// TestNATPoolAlarm_BootGate verifies that the production start helper does NOT
+// launch a sampler goroutine while in bootstrap mode, so the bootstrap-exit
+// d.dp = nil write cannot race a sampler read. With the gate removed, a
+// sampler goroutine started here reads d.dp on its fast tick while the writer
+// nils d.dp → -race trips.
+func TestNATPoolAlarm_BootGate(t *testing.T) {
+	d := newNATPoolAlarmTestDaemon()
+	d.bootstrapMode.Store(true)
+
+	// In bootstrap mode the start is gated off: no monitor, no sampler.
+	d.maybeStartNATPoolAlarm()
+	if d.natPoolAlarm.Load() != nil {
+		t.Fatal("monitor must NOT start in bootstrap mode (Edit 1 gate)")
+	}
+
+	// Mirror the bootstrap-exit failure write of d.dp, run long enough to
+	// overlap several 1ms sampler ticks. Because the gate suppressed the
+	// start, no sampler goroutine exists, so this cannot race. If the gate
+	// were removed, a sampler on the 1ms tick would be reading d.dp here and
+	// -race would trip.
+	writeDPFor(50*time.Millisecond, d)
+	d.stopAndDiscardNATPoolAlarm()
+
+	// Out of bootstrap, the gate passes and the monitor starts.
+	d.bootstrapMode.Store(false)
+	d.maybeStartNATPoolAlarm()
+	if d.natPoolAlarm.Load() == nil {
+		t.Fatal("monitor MUST start once out of bootstrap with d.dp armed")
+	}
+	d.stopAndDiscardNATPoolAlarm()
+	if d.natPoolAlarm.Load() != nil {
+		t.Fatal("stopAndDiscard must clear the pointer")
+	}
+}
+
+// TestNATPoolAlarm_RollbackDiscard verifies the rollback path stops AND
+// discards the monitor so a later re-arm-failure d.dp = nil write cannot race
+// a stale sampler goroutine, and a corrected re-arm builds a FRESH monitor
+// (the Monitor is not restartable after Stop).
+func TestNATPoolAlarm_RollbackDiscard(t *testing.T) {
+	d := newNATPoolAlarmTestDaemon()
+
+	// Simulate a successful bootstrap-exit arm: out of bootstrap, monitor
+	// running on the fast (1ms) test tick so it actively samples d.dp.
+	d.bootstrapMode.Store(false)
+	d.maybeStartNATPoolAlarm()
+	first := d.natPoolAlarm.Load()
+	if first == nil {
+		t.Fatal("monitor must start on a successful arm")
+	}
+
+	// Roll back to bootstrap. enterBootstrapMode must Stop()+discard the
+	// monitor (Stop joins the sampler goroutine) before returning at the
+	// applyBodyForTest seam.
+	d.enterBootstrapMode()
+	if d.natPoolAlarm.Load() != nil {
+		t.Fatal("enterBootstrapMode must stop+discard the monitor (Edit 3)")
+	}
+	if !d.inBootstrap() {
+		t.Fatal("enterBootstrapMode must re-enter bootstrap mode")
+	}
+
+	// A re-arm attempt while STILL in bootstrap must stay gated off.
+	d.maybeStartNATPoolAlarm()
+	if d.natPoolAlarm.Load() != nil {
+		t.Fatal("monitor must remain gated off while in bootstrap after rollback")
+	}
+
+	// The re-arm-failure write of d.dp, run long enough to overlap several
+	// 1ms sampler ticks: no sampler survives the rollback, so this cannot
+	// race. If the discard were missing, the first monitor's sampler would
+	// be reading d.dp here and -race would trip (in addition to the discard
+	// assertion above).
+	writeDPFor(50*time.Millisecond, d)
+
+	// A corrected commit re-arms: clear bootstrap (as exitBootstrapMode does
+	// before runBootstrapExitStartup), then start — a FRESH monitor.
+	d.bootstrapMode.Store(false)
+	d.maybeStartNATPoolAlarm()
+	second := d.natPoolAlarm.Load()
+	if second == nil {
+		t.Fatal("a corrected re-arm must build a fresh monitor")
+	}
+	if second == first {
+		t.Fatal("re-arm must build a NEW monitor (Monitor is not restartable)")
+	}
+	d.stopAndDiscardNATPoolAlarm()
+}
+
+// TestNATPoolAlarm_PointerPublication hammers natPoolAlarms() (the
+// show-security-alarms reader) concurrently with the runtime start/discard of
+// the monitor pointer. With d.natPoolAlarm as atomic.Pointer the reads/writes
+// of the pointer are race-free; as a plain field they are not. This is the
+// deterministic guard for Edit 0.
+func TestNATPoolAlarm_PointerPublication(t *testing.T) {
+	d := newNATPoolAlarmTestDaemon()
+	d.bootstrapMode.Store(false)
+
+	var readers sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Readers: the gRPC/CLI render path, looping until the writer is done.
+	for r := 0; r < 4; r++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = d.natPoolAlarms()
+				}
+			}
+		}()
+	}
+
+	// Writer: runtime start/discard cycles (bootstrap exit / rollback),
+	// inline so the readers are guaranteed to overlap a full run before stop.
+	for i := 0; i < 2000; i++ {
+		d.maybeStartNATPoolAlarm()
+		d.stopAndDiscardNATPoolAlarm()
+	}
+
+	close(stop)
+	readers.Wait()
+	d.stopAndDiscardNATPoolAlarm()
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -37,7 +37,6 @@ import (
 	"github.com/psaab/xpf/pkg/ipsec"
 	"github.com/psaab/xpf/pkg/lldp"
 	"github.com/psaab/xpf/pkg/logging"
-	"github.com/psaab/xpf/pkg/natpoolalarm"
 	"github.com/psaab/xpf/pkg/networkd"
 	"github.com/psaab/xpf/pkg/ra"
 	"github.com/psaab/xpf/pkg/routing"
@@ -877,8 +876,16 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// `show security alarms` entries with hysteresis and emits one
 		// structured RT_NAT syslog line per transition. (The whole block is
 		// gated on a non-NoDataplane dataplane being present.)
-		d.natPoolAlarm = natpoolalarm.New(d.natPoolAlarmSampler(), d.natPoolAlarmEmitter())
-		d.natPoolAlarm.Start()
+		//
+		// #2114: route through maybeStartNATPoolAlarm, which gates on
+		// !inBootstrap() in addition to a constructed dataplane. In bootstrap
+		// mode the dataplane object exists (d.dp != nil) but is not armed, and
+		// the bootstrap-exit path may write d.dp = nil on an arm failure;
+		// launching the sampler here would race that write. The monitor is
+		// instead started in runBootstrapExitStartup once the dataplane is
+		// armed. On a normal (non-bootstrap) boot the gate passes and the
+		// monitor starts here exactly as before.
+		d.maybeStartNATPoolAlarm()
 	}
 
 	// Start cluster heartbeat + sync after event fanout is initialized.
@@ -1507,10 +1514,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.ipmon.Stop()
 	}
 
-	// #2079: stop the NAT pool-utilization-alarm monitor.
-	if d.natPoolAlarm != nil {
-		d.natPoolAlarm.Stop()
-	}
+	// #2079/#2114: stop the NAT pool-utilization-alarm monitor. Routed
+	// through the helper so the atomic pointer is read/cleared the same way
+	// as the runtime start/discard paths.
+	d.stopAndDiscardNATPoolAlarm()
 
 	// Stop the FRR manager (after ipmon, whose actuator is an FRR
 	// writer): cancels the degraded-retry goroutine and kills any
@@ -1699,9 +1706,19 @@ func (d *Daemon) runBootstrapExitStartup(cfg *config.Config) {
 			slog.Warn("bootstrap exit: failed to start dataplane, running in config-only mode",
 				"err", err)
 			d.dp = nil
-		} else if seeder, ok := d.dp.(natSeeder); ok {
-			seeder.SeedNATPortCounters()
-			seeder.SeedSessionIDCounter(nodeID)
+		} else {
+			if seeder, ok := d.dp.(natSeeder); ok {
+				seeder.SeedNATPortCounters()
+				seeder.SeedSessionIDCounter(nodeID)
+			}
+			// #2114: start the NAT pool-alarm monitor now that the dataplane
+			// is armed and d.dp is stable. It was suppressed at boot in
+			// bootstrap mode; exitBootstrapMode already flipped
+			// bootstrapMode=false in applyConfigLocked before calling this,
+			// so maybeStartNATPoolAlarm's !inBootstrap() gate passes. Runs
+			// under the apply caller's d.applySem, so the monitor's first
+			// sampler read cannot overlap a concurrent d.dp write. Idempotent.
+			d.maybeStartNATPoolAlarm()
 		}
 	}
 	slog.Info("bootstrap exit: startup takeover complete; applying first config")

--- a/pkg/natpoolalarm/natpoolalarm.go
+++ b/pkg/natpoolalarm/natpoolalarm.go
@@ -133,6 +133,22 @@ func New(sample Sampler, emit Emitter) *Monitor {
 	}
 }
 
+// SetTickForTest overrides the evaluation cadence. It MUST be called before
+// Start (the running loop captures m.tick once). Intended only for tests that
+// need the sampler to fire rapidly — e.g. the #2114 daemon race regression
+// test, which drives the monitor's d.dp sampler against a concurrent
+// bootstrap-exit d.dp transition under the race detector.
+func (m *Monitor) SetTickForTest(d time.Duration) {
+	if m == nil || d <= 0 {
+		return
+	}
+	m.mu.Lock()
+	if !m.started {
+		m.tick = d
+	}
+	m.mu.Unlock()
+}
+
 // Start launches the evaluation loop. It is a no-op if the monitor is nil or
 // the sampler is nil, and is safe to call at most once.
 func (m *Monitor) Start() {


### PR DESCRIPTION
## Summary

The #2079 NAT pool-utilization-alarm monitor (PR #2109) launched a 10s
background sampler goroutine whose closure reads the daemon's `d.dp`
(`dataplane.RuntimeDataPlane`) interface field **without synchronization**.
The monitor was started even in bootstrap mode (gated only on `d.dp != nil`,
NOT on `!inBootstrap()`), where the bootstrap-exit path
(`runBootstrapExitStartup`) writes `d.dp = nil` on a dataplane arm failure
under `d.applySem` on the apply goroutine. Sampler read vs apply-goroutine
write of the same non-atomic interface value is a data race per the Go memory
model — the race detector flags it, and a torn interface read can panic or
mis-resolve the sampler's type assertion. It requires bootstrap mode plus an
arm failure on the first confirmed commit (the unhappy path of a fresh
foreign-host install, #1922/#2079).

## Fix (Option A — match how the daemon already guards `d.dp`)

The codebase's invariant is: `d.dp` is written only on the boot/apply
goroutine (under `applySem`), and a continuously-running reader must not be
launched while a write can still occur. #2109 violated that by launching a
continuous reader during the bootstrap window. This mirrors the existing
dataplane `dp.Start()` bootstrap gate. Option B (a uniform `d.dp`
mutex/accessor across ~40 readers) is the larger durable refactor the issue
frames as separate, and is left out of scope.

- **Edit 1 (boot start gate):** start the monitor only when `!inBootstrap()`
  (via `maybeStartNATPoolAlarm`, which also checks `!NoDataplane` and
  `d.dp != nil`).
- **Edit 2 (bootstrap-exit start):** start the monitor at the tail of
  `runBootstrapExitStartup`'s successful-arm branch — the single
  bootstrap-exit pipeline shared by a local confirmed commit and a cluster
  `SyncApply` (`applyConfigLocked`). `exitBootstrapMode` flips
  `bootstrapMode=false` before this runs, so the gate passes.
- **Edit 3 (rollback discard):** `enterBootstrapMode` (first-commit-timeout
  rollback) now **stops AND discards** the monitor. The rollback Teardown()s
  the dataplane but keeps `d.dp` non-nil and is reached after a successful
  arm, so without this a stale sampler survives to race a later corrected
  commit's re-arm-failure `d.dp = nil` write. Discard (not just Stop) because
  `natpoolalarm.Monitor` is not restartable after `Stop()`; the next
  successful re-arm builds a fresh one.
- **Edit 0 (atomic pointer):** moving the start out of the single-threaded
  boot window made `d.natPoolAlarm` runtime-mutated while the
  `show security alarms` render reader (`natPoolAlarms`, wired into the
  gRPC/CLI callbacks) reads it on request goroutines — a second race the fix
  must not introduce. `d.natPoolAlarm` is now
  `atomic.Pointer[natpoolalarm.Monitor]` and all access (start, stop+discard,
  read, shutdown) is routed through helpers. `ActiveAlarms()` is itself
  mutex-guarded inside the monitor.

## Plan + adversarial review

Plan doc: `docs/pr/2114-natpoolalarm-bootstrap-race/plan.md`

Codex plan review converged across three rounds (each a real hostile catch):
- r1 PLAN-NEEDS-MAJOR — the rollback→re-arm `d.dp` race (added Edit 3).
- r2 PLAN-NEEDS-MAJOR — the `d.natPoolAlarm` pointer-publication race (added
  Edit 0, atomic pointer + helpers).
- r3 PLAN-NEEDS-MINOR — minors folded (`d.dp==nil` in helper guard, atomic
  `.Load()` in test assertions, part-(c) clears bootstrap before re-arm).

Gemini was unavailable (Code Assist client deprecated); an independent
second code review should be dispatched.

## Test plan (control-plane; data race → `-race` is the gate)

- [x] `go build ./...` clean
- [x] **New `-race` regression tests** in `pkg/daemon`, each verified
  **fail-pre / pass-post** by reverting the corresponding edit:
  - `TestNATPoolAlarm_BootGate` (Edit 1)
  - `TestNATPoolAlarm_RollbackDiscard` (Edit 3 — fails via both the discard
    assertion and, with that removed, via `-race` from the surviving fast
    sampler)
  - `TestNATPoolAlarm_PointerPublication` (Edit 0 — deterministic `-race`
    trip as a plain field)
- [x] `go test -race ./pkg/daemon/... ./pkg/natpoolalarm/...` clean
- [x] 5/5 flake check on the new tests under `-race`
- [x] `go test ./...` green
- [x] `pkg/daemon/README.md` updated (monitor lifecycle in the bootstrap
  suppression / exit / rollback contract)
- No cluster smoke — control-plane only, no forwarding-path change (it does
  touch the bootstrap/HA startup sequence; covered by the lifecycle tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)