### PR TITLE
config: merged-Keys overrides regression test for DHCP relay (#2115 item 2)

### DIFF
--- a/pkg/config/compiler_dhcp_relay_overrides_test.go
+++ b/pkg/config/compiler_dhcp_relay_overrides_test.go
@@ -100,6 +100,131 @@ func TestDHCPRelayOverrides_Absent(t *testing.T) {
 	}
 }
 
+// TestDHCPRelayOverrides_MergedKeys_NotSwallowed is the #2115-item-2
+// non-tautological guard for the #2076 boundary fix. The committed
+// flat-set test above passes even with the boundary fix reverted,
+// because ParseSetCommand+SetPath split the four `set` lines into
+// per-property sub-nodes (so the inline-Keys[2:] consumer in
+// compileDHCPRelay never sees `interface` and `overrides` packed in one
+// node). The shape that actually triggers the swallow is the
+// MERGED-Keys group node the parser produces when it flattens a
+// single statement into one node:
+//
+//	Keys = [group <g> interface <if> overrides always-broadcast]
+//
+// Compiled by the inline Keys[2:] loop (compiler_services.go ~1106),
+// the `interface` case (~1108) must STOP at the `overrides` boundary
+// (~1117-1119) — otherwise it consumes `overrides` and
+// `always-broadcast` into g.Interfaces and AlwaysBroadcast stays
+// false. We build the merged-Keys node directly and drive
+// compileDHCPRelay so the boundary keyword cannot silently regress.
+//
+// Non-tautology proof: with the `keys[i+1] != "overrides"` boundary
+// removed from compiler_services.go (the #2076 fix), this test FAILS —
+// AlwaysBroadcast is false and Interfaces becomes
+// [ge-0/0/0.0 overrides always-broadcast]. Verified by reverting that
+// boundary locally.
+func TestDHCPRelayOverrides_MergedKeys_NotSwallowed(t *testing.T) {
+	// Construct the `forwarding-options dhcp-relay` node directly with a
+	// single merged-Keys `group` child. This is the packed shape the
+	// parser emits when a whole statement collapses into one node; it is
+	// NOT reproducible via ParseSetCommand+SetPath (which splits into
+	// sub-nodes), which is exactly why the flat-set test above is
+	// tautological for the boundary fix.
+	relayNode := &Node{
+		Keys: []string{"dhcp-relay"},
+		Children: []*Node{
+			{
+				Keys:   []string{"server-group", "sg", "10.1.1.1"},
+				IsLeaf: true,
+			},
+			{
+				// The merged-Keys group node: interface value followed
+				// immediately by the overrides boundary keyword and its
+				// always-broadcast sub-keyword, all packed into Keys.
+				Keys: []string{
+					"group", "lan",
+					"interface", "ge-0/0/0.0",
+					"overrides", "always-broadcast",
+				},
+				IsLeaf: true,
+			},
+		},
+	}
+
+	fo := &ForwardingOptionsConfig{}
+	if err := compileDHCPRelay(relayNode, fo); err != nil {
+		t.Fatalf("compileDHCPRelay: %v", err)
+	}
+	if fo.DHCPRelay == nil {
+		t.Fatalf("DHCPRelay config nil")
+	}
+	g := fo.DHCPRelay.Groups["lan"]
+	if g == nil {
+		t.Fatalf("relay group %q not found", "lan")
+	}
+
+	if !g.AlwaysBroadcast {
+		t.Errorf("AlwaysBroadcast = false, want true (merged-Keys overrides swallowed)")
+	}
+	// The interface list must be EXACTLY [ge-0/0/0.0]. If the boundary
+	// fix is reverted, the interface consumer eats overrides and
+	// always-broadcast into this list.
+	if len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0/0/0.0" {
+		t.Errorf("Interfaces = %v, want [ge-0/0/0.0] (merged-Keys swallow regression)", g.Interfaces)
+	}
+	for _, name := range g.Interfaces {
+		if name == "overrides" || name == "always-broadcast" {
+			t.Errorf("override token %q swallowed into Interfaces: %v", name, g.Interfaces)
+		}
+	}
+}
+
+// TestDHCPRelayOverrides_MergedKeys_OverridesBeforeInterface guards the
+// reverse merged-Keys token order: `overrides always-broadcast` packed
+// before `interface` in one group node. The `overrides` case (~1128)
+// must consume only its own sub-keyword and stop at the `interface`
+// boundary, leaving a clean single-entry interface list.
+func TestDHCPRelayOverrides_MergedKeys_OverridesBeforeInterface(t *testing.T) {
+	relayNode := &Node{
+		Keys: []string{"dhcp-relay"},
+		Children: []*Node{
+			{
+				Keys:   []string{"server-group", "sg", "10.1.1.1"},
+				IsLeaf: true,
+			},
+			{
+				Keys: []string{
+					"group", "lan",
+					"overrides", "always-broadcast",
+					"interface", "ge-0/0/0.0",
+				},
+				IsLeaf: true,
+			},
+		},
+	}
+
+	fo := &ForwardingOptionsConfig{}
+	if err := compileDHCPRelay(relayNode, fo); err != nil {
+		t.Fatalf("compileDHCPRelay: %v", err)
+	}
+	g := fo.DHCPRelay.Groups["lan"]
+	if g == nil {
+		t.Fatalf("relay group %q not found", "lan")
+	}
+	if !g.AlwaysBroadcast {
+		t.Errorf("AlwaysBroadcast = false, want true (merged-Keys overrides-first)")
+	}
+	if len(g.Interfaces) != 1 || g.Interfaces[0] != "ge-0/0/0.0" {
+		t.Errorf("Interfaces = %v, want [ge-0/0/0.0]", g.Interfaces)
+	}
+	for _, name := range g.Interfaces {
+		if name == "overrides" || name == "always-broadcast" {
+			t.Errorf("override token %q swallowed into Interfaces: %v", name, g.Interfaces)
+		}
+	}
+}
+
 // TestDHCPRelayOverrides_SchemaCompletion proves the structural completion
 // offers `always-broadcast` under `overrides`.
 func TestDHCPRelayOverrides_SchemaCompletion(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a **non-tautological** regression test for the #2076 DHCP-relay
`overrides always-broadcast` boundary fix. The committed flat-set
BLOCKER test (`TestDHCPRelayOverrides_FlatSet_NotSwallowed`) passes even
with the #2076 fix reverted — because `ParseSetCommand`+`SetPath` split
the four `set` lines into per-property sub-nodes, so the inline-`Keys[2:]`
consumer in `compileDHCPRelay` never sees `interface` and `overrides`
packed into one group node, which is the only shape that triggers the
swallow. The flat-set test therefore does not actually guard the code
path #2076 repaired.

This PR adds `TestDHCPRelayOverrides_MergedKeys_NotSwallowed`, which
builds the `forwarding-options dhcp-relay` node directly with a single
**merged-Keys** group child —
`Keys = [group lan interface ge-0/0/0.0 overrides always-broadcast]` —
the packed shape the parser emits when a whole statement flattens into
one node (the input `compiler_services.go:~1106` was written to handle).
It drives `compileDHCPRelay` directly and asserts `AlwaysBroadcast=true`
and `Interfaces==[ge-0/0/0.0]`.

A second test (`_OverridesBeforeInterface`) pins the reverse packed
token order as a complementary contract guard.

**Pure test addition — no behavior change.** `compiler_services.go` is
byte-identical to master (`git diff origin/master -- pkg/config/compiler_services.go`
is empty).

This is **item 2** of #2115. Item 1 (live flag0 wire-capture) remains
lab-gated; this PR does not close the issue.

## Non-tautology / mutation proof

With the `keys[i+1] != "overrides"` boundary removed from the interface
case (i.e. the #2076 fix reverted):

- `TestDHCPRelayOverrides_MergedKeys_NotSwallowed` **FAILS** —
  `AlwaysBroadcast=false`, `Interfaces=[ge-0/0/0.0 overrides always-broadcast]`.
- `TestDHCPRelayOverrides_FlatSet_NotSwallowed` (the committed test)
  still **PASSES** — confirming the tautology this PR fixes.

## Test plan

- [x] `go test ./pkg/config/` — full package passes
- [x] new tests 5/5 flake-clean
- [x] `go vet ./pkg/config/` clean
- [x] mutation proof: reverting the #2076 boundary fails
      `_MergedKeys_NotSwallowed` while `_FlatSet_NotSwallowed` keeps passing
- [x] `compiler_services.go` confirmed byte-identical to master

Note: test-only change in `pkg/config`; no dataplane/forwarding code is
touched, so the Rust cargo suite and the loss-cluster smoke matrix are
not implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)