### PR TITLE
#2125 #2126: IPsec swanctl render — IKE PRF for AEAD GCM + PSK/identity quote escaping

### DIFF
--- a/docs/pr/2125-2126-ipsec-swanctl-render/plan.md
+++ b/docs/pr/2125-2126-ipsec-swanctl-render/plan.md
@@ -1,6 +1,8 @@
 # #2125 + #2126 — IPsec swanctl render correctness (GCM ICV suffix + PSK/identity quoting)
 
-Status: DRAFT v1 — pending adversarial plan review (Codex + Gemini + Claude SMR)
+Status: DRAFT v2 — diagnosis corrected after Codex round-1 PLAN-KILL
+(the GCM-parse premise was wrong; load-bearing fix re-anchored to the
+IKE PRF). Pending re-review.
 
 ## Issue framing
 
@@ -9,19 +11,36 @@ Two independent swanctl-render correctness bugs in `pkg/ipsec`
 into `crypto.go` / `ike.go` / `manager.go` / `policy.go`; the
 target code now lives in `ike.go` and `policy.go`):
 
-- **#2125 (HIGH):** Junos-native GCM encryption-algorithm names
-  (`aes-128-gcm`, `aes-192-gcm`, `aes-256-gcm`) are normalized only
-  by stripping `-cbc` then all `-`, producing the bare token
-  `aes256gcm`. strongSwan's proposal parser has **no bare
-  `aes<N>gcm` keyword** — GCM ciphers require an explicit ICV-length
-  suffix (`aes256gcm16`, `aes256gcm128`, `aes256gcm12`,
-  `aes256gcm8`). The rendered ESP/IKE proposal (e.g.
-  `aes256gcm-modp2048`) is unparseable, so the SA never establishes
-  while the commit succeeds — a silent dead tunnel. Secondary defect
-  in the same path: for IKE (Phase 1) AEAD proposals strongSwan also
-  requires an explicit PRF (e.g. `aes256gcm16-prfsha256-modp2048`);
-  the current IKE builders skip auth for GCM and never add a PRF, so
-  even a correct ICV suffix would leave the IKE proposal incomplete.
+- **#2125 (HIGH) — CORRECTED diagnosis.** The Junos-native GCM
+  encryption-algorithm names (`aes-128-gcm`, `aes-192-gcm`,
+  `aes-256-gcm`) are normalized only by stripping `-cbc` then all
+  `-`, producing the bare token `aes256gcm`. The issue (and plan v1)
+  claimed this is an unparseable swanctl token — that is **FALSE**:
+  the strongSwan proposal-keyword table
+  (`proposal_keywords_static.txt`, verified in master AND stable
+  5.9.14) contains bare `aes128gcm`/`aes192gcm`/`aes256gcm` entries,
+  each mapping to `ENCR_AES_GCM_ICV16` (16-octet ICV). So
+  `aes256gcm-modp2048` is a *valid* ESP proposal — the ESP path does
+  NOT silently fail at parse, and the ICV canonicalization alone is
+  not the bug.
+  - **The real, load-bearing #2125 bug is the IKE (Phase 1) PRF.**
+    IKEv2 AEAD proposals carry no integrity algorithm for strongSwan
+    to derive a PRF from, so the IKE proposal MUST name a PRF
+    explicitly (strongSwan docs: "If AEAD ciphers are proposed there
+    won't be any integrity algorithms from which to derive PRFs. Thus
+    PRF algorithms have to be configured explicitly."). The current
+    IKE builders (`buildIKEProposal`, `buildIKEProposalFromIKE`) emit
+    `aes256gcm-modp2048` with NO PRF, so a GCM IKE proposal is
+    incomplete and the IKE SA fails to negotiate — the silently-dead
+    tunnel is real, but the cause is the missing PRF, not the ICV
+    spelling.
+  - **The ICV canonicalization is kept as a harmless clarity fix.**
+    Mapping `aes-256-gcm` -> `aes256gcm16` produces the *same*
+    algorithm (`ENCR_AES_GCM_ICV16`) as the bare alias, makes the ICV
+    length explicit in the generated config (matching the operator's
+    Junos intent — Juniper docs: AES-256-GCM uses a 16-octet ICV),
+    and the already-suffixed pass-through preserves `aes256gcm128`
+    etc. unchanged. It is NOT claimed to fix a parse failure.
 
 - **#2126 (MEDIUM):** the PSK is emitted as `secret = "%s"` with the
   decoded value passed only through `sanitizeSwanctlValue` (which
@@ -215,10 +234,14 @@ exported signature changes. New helpers (`normalizeEncAlg`,
 - New `pkg/ipsec` unit tests, each NON-tautological (must fail on
   pre-fix code):
   - GCM ESP: `buildESPProposal(aes-128/192/256-gcm, dh14)` ->
-    `aes{128,192,256}gcm16-modp2048`; no-dh -> `aes{N}gcm16`.
-  - GCM IKE: `buildIKEProposal` / `buildIKEProposalFromIKE` with
-    `aes-256-gcm` -> contains `aes256gcm16` AND a `prfsha*` part AND
-    `modp2048`; PRF derives from AuthAlg when set.
+    `aes{128,192,256}gcm16-modp2048`; no-dh -> `aes{N}gcm16`. (These
+    assert the canonical ICV spelling, not a parse fix — both bare
+    and suffixed forms parse; the test pins the explicit-ICV output.)
+  - GCM IKE (the load-bearing #2125 assertion): `buildIKEProposal` /
+    `buildIKEProposalFromIKE` with `aes-256-gcm` -> contains
+    `aes256gcm16` AND a `prfsha*` part AND `modp2048`; PRF derives
+    from AuthAlg when set. This is the test that fails pre-fix for a
+    real-grammar reason (no PRF == invalid IKE AEAD proposal).
   - Legacy already-suffixed `aes256gcm128` unchanged.
   - PSK with embedded `"` -> rendered `secret = "...\"..."` (assert
     exact bytes); PSK with `\` -> `\\`; PSK with both.
@@ -239,25 +262,58 @@ exported signature changes. New helpers (`normalizeEncAlg`,
 - `0x`/`0s` hex/base64 secret encoding alternative — backslash
   escaping is simpler, lexer-correct, and keeps the secret
   human-diffable in generated config.
+- **swanctl section/key NAME hardening** (Codex r1 finding #6).
+  `renderConfig` interpolates operator-controlled section names
+  (`<vpn> {`, `ike-<vpn> {`, traffic-selector child names) through
+  only `sanitizeSwanctlValue` (control-char strip) — a name with a
+  space/brace/`#`/`=` is not a free-text value and could still
+  malform a section header. This is a real but separate exposure
+  from the confirmed PSK/identity-value defects in #2125/#2126;
+  config-object names are already constrained by the Junos parser
+  grammar (the names come from parsed identifiers, not arbitrary
+  free text), and `sanitizeChildName` already restricts child names
+  to `[A-Za-z0-9._-]`. Deferred to a follow-up issue rather than
+  silently claimed as covered. This plan does NOT assert all
+  operator-influenced swanctl strings are hardened.
 - Any non-IPsec swanctl value.
 
-## Open questions for adversarial review
+## Round-1 adversarial review record
 
-1. Is `aes256gcm16` the right spelling vs `aes256gcm128`? (Both are
-   the 16-octet ICV; `gcm16` is the canonical short form. Either
-   parses — is there a reason to prefer 128 for Junos parity?)
-2. PRF default: is `prfsha256` the right default for a GCM IKE
-   proposal with no AuthAlg, or should it derive from the DH/cipher
-   strength (e.g. prfsha384 for aes256)? Junos default behavior?
-3. Should `id`/`certs` quoting be in-scope, or kept minimal to the
-   confirmed PSK defect to shrink the diff? (Quoting is safe but
-   changes existing test expectations.)
-4. Backslash-first then quote escaping order — any swanctl lexer
-   corner the `\\.` analysis misses (e.g. `\n`/`\r`/`\t` named
-   escapes interacting with a literal backslash-n in a PSK)?
-5. Does any existing in-the-wild config rely on the (broken) bare
-   `aes256gcm` rendering such that changing it is itself a
-   regression? (It cannot establish today, so no — but call it out.)
-6. Is appending a PRF to the IKE proposal safe when the peer
-   negotiated without one before? (It could not have — bare
-   `aes256gcm` never established.)
+- **Codex r1: PLAN-KILL** (task-mqn9xb9o-aaue4r). Correct and
+  decisive: proved against `proposal_keywords_static.txt` (master +
+  5.9.14) that bare `aes256gcm` IS a valid strongSwan keyword
+  (-> `ENCR_AES_GCM_ICV16`), so plan-v1's "unparseable ESP token ->
+  dead tunnel" premise was false. Re-anchored the load-bearing
+  #2125 fix to the missing IKE PRF; demoted the ICV canonicalization
+  to a harmless clarity fix; scoped out section-name hardening
+  (finding #6) explicitly; confirmed the PSK/backslash escaping plan
+  and order are correct (finding #4); confirmed `id`/`certs` quoting
+  is safe but broader-than-the-PSK-defect (finding #5, kept in scope
+  with tests). Junos 16-octet-ICV claim (finding #3) now backed by a
+  primary Juniper-docs citation.
+- **Gemini r1: infra failure** ("ACP initialize timed out after 30s",
+  then a second attempt). Re-dispatched against the corrected v2 plan.
+
+## Resolved questions
+
+1. `aes256gcm16` vs `aes256gcm128` vs bare `aes256gcm`: all three map
+   to `ENCR_AES_GCM_ICV16`. We emit `aes256gcm16` (explicit ICV,
+   matches Junos 16-octet intent). RESOLVED.
+2. PRF default `prfsha256` for a no-AuthAlg GCM IKE proposal; mirrors
+   the proposal's auth algorithm when present (sha384 -> prfsha384,
+   etc.). A reasonable, interoperable default. RESOLVED.
+3. `id`/`certs` quoting kept in scope — swanctl strips config quotes
+   before identity parsing, so a quoted `@fqdn`/IP/DN all parse
+   identically AND a DN with spaces/commas now parses as one value.
+   Existing test expectations updated. RESOLVED.
+4. Escape order (backslash-first, then quote) verified against the
+   lexer `\\.` rule; literal backslash-n round-trips as `\\n` (not a
+   newline). RESOLVED.
+5. No in-the-wild config can rely on the bare-`aes256gcm` ESP render
+   being broken — it was actually valid, so the canonical respelling
+   is behavior-equivalent for ESP; the IKE PRF addition is the only
+   negotiation-affecting change. RESOLVED.
+6. The added IKE PRF cannot break a previously-working peer: a GCM
+   IKE proposal with no PRF could not have negotiated, so any peer
+   using GCM IKE today is already failing; adding the PRF is what
+   lets it work. RESOLVED.

--- a/docs/pr/2125-2126-ipsec-swanctl-render/plan.md
+++ b/docs/pr/2125-2126-ipsec-swanctl-render/plan.md
@@ -1,0 +1,263 @@
+# #2125 + #2126 — IPsec swanctl render correctness (GCM ICV suffix + PSK/identity quoting)
+
+Status: DRAFT v1 — pending adversarial plan review (Codex + Gemini + Claude SMR)
+
+## Issue framing
+
+Two independent swanctl-render correctness bugs in `pkg/ipsec`
+(the file the issues reference as `ipsec.go` was split on master
+into `crypto.go` / `ike.go` / `manager.go` / `policy.go`; the
+target code now lives in `ike.go` and `policy.go`):
+
+- **#2125 (HIGH):** Junos-native GCM encryption-algorithm names
+  (`aes-128-gcm`, `aes-192-gcm`, `aes-256-gcm`) are normalized only
+  by stripping `-cbc` then all `-`, producing the bare token
+  `aes256gcm`. strongSwan's proposal parser has **no bare
+  `aes<N>gcm` keyword** — GCM ciphers require an explicit ICV-length
+  suffix (`aes256gcm16`, `aes256gcm128`, `aes256gcm12`,
+  `aes256gcm8`). The rendered ESP/IKE proposal (e.g.
+  `aes256gcm-modp2048`) is unparseable, so the SA never establishes
+  while the commit succeeds — a silent dead tunnel. Secondary defect
+  in the same path: for IKE (Phase 1) AEAD proposals strongSwan also
+  requires an explicit PRF (e.g. `aes256gcm16-prfsha256-modp2048`);
+  the current IKE builders skip auth for GCM and never add a PRF, so
+  even a correct ICV suffix would leave the IKE proposal incomplete.
+
+- **#2126 (MEDIUM):** the PSK is emitted as `secret = "%s"` with the
+  decoded value passed only through `sanitizeSwanctlValue` (which
+  strips C0 controls + DEL but leaves `"` and `\` untouched). A PSK
+  containing a literal `"` (legal in a real PSK) renders
+  `secret = "ab"cd"`, which the swanctl lexer reads as the string
+  `ab` followed by stray tokens — a corrupted/empty key → silent IKE
+  auth failure. The same unquoted/unescaped exposure applies to the
+  `id = ...` identity lines and `certs = ...`: a DN identity with
+  spaces/commas (`id = CN=fw, O=acme`) is emitted unquoted and
+  mis-parsed.
+
+## Honest scope/value framing
+
+This is a pure control-plane correctness fix in the swanctl.conf
+generator. No dataplane/forwarding code is touched, so there is no
+throughput/CPU dimension — the win is "documented Junos config that
+silently produces a dead tunnel today now produces a swanctl-valid
+config." If reviewers conclude any sub-part is wrong-target or the
+risk outweighs the value, PLAN-KILL of that sub-part is an
+acceptable verdict.
+
+## Grammar verification (load-bearing — not guessed)
+
+strongSwan / swanctl grammar confirmed against official docs +
+the actual lexer source before drafting:
+
+1. **AES-GCM tokens** (docs.strongswan.org Algorithm Proposals):
+   `aes128gcm16`==`aes128gcm128`, `aes192gcm16`==`aes192gcm128`,
+   `aes256gcm16`==`aes256gcm128` (16-octet / 128-bit ICV); also the
+   8/12-octet variants. Junos AES-GCM uses a 16-octet ICV, so the
+   correct mapping is `aes-256-gcm -> aes256gcm16` (and 128/192).
+   We use the `...gcm16` spelling (the canonical strongSwan short
+   form for the full 16-octet ICV).
+2. **AEAD requires explicit PRF** (same doc): "If AEAD ciphers are
+   proposed there won't be any integrity algorithms from which to
+   derive PRFs. Thus PRF algorithms have to be configured
+   explicitly." Token form `prfsha256` / `prfsha384` / `prfsha512`.
+   Applies to IKE (Phase 1) only; ESP children take no PRF.
+3. **swanctl string escaping** (settings_lexer.l, `<str>` state):
+   inside a double-quoted string the lexer recognizes `\n`/`\r`/`\t`
+   as the named escapes and `\\.` (backslash + any char) as that
+   literal char; a bare `"` terminates the string. Therefore the
+   correct render-time escaping is: replace `\` -> `\\` FIRST, then
+   `"` -> `\"`. (Order matters; doing `"` first would then double the
+   backslash it just inserted.) This makes a literal backslash render
+   as `\\` (lexer `\\.` -> `\`) and a quote as `\"` (lexer `\\.` ->
+   `"`), and `\` followed by `n` renders as `\\n` (lexer: `\\.` -> `\`
+   then literal `n`), never the newline escape — round-trip exact.
+
+## Concrete design
+
+### Part A — GCM ICV suffix + IKE PRF (#2125), in `ike.go`
+
+Add one shared normalizer used by all three builders
+(`buildESPProposal`, `buildIKEProposal`, `buildIKEProposalFromIKE`):
+
+```go
+// gcmICVSuffix maps a Junos GCM encryption-algorithm name to its
+// strongSwan token with the 16-octet ICV suffix swanctl requires
+// (a bare "aes256gcm" is not a valid swanctl keyword). Returns
+// (token, true) only for the Junos GCM variants; ("", false)
+// otherwise so the caller falls through to the existing CBC/legacy
+// normalization (strip "-cbc", strip "-").
+func normalizeEncAlg(enc string) (token string, isGCM bool) {
+	switch enc {
+	case "aes-128-gcm", "aes128gcm":
+		return "aes128gcm16", true
+	case "aes-192-gcm", "aes192gcm":
+		return "aes192gcm16", true
+	case "aes-256-gcm", "aes256gcm":
+		return "aes256gcm16", true
+	}
+	// Already-suffixed forms pass through unchanged so existing
+	// configs / tests that feed aes256gcm128 etc. keep working.
+	if strings.Contains(enc, "gcm") {
+		return strings.ReplaceAll(strings.ReplaceAll(enc, "-cbc", ""), "-", ""), true
+	}
+	return "", false
+}
+```
+
+Each builder becomes:
+
+```go
+enc := prop.EncryptionAlg
+if enc == "" { enc = "aes256" }
+if tok, isGCM := normalizeEncAlg(enc); isGCM {
+	parts = append(parts, tok)
+	// ESP: no auth, no PRF.
+	// IKE: append a PRF (prfsha256, or derived from AuthAlg) — AEAD
+	// has no integrity alg to derive a PRF from.
+} else {
+	enc = strings.ReplaceAll(enc, "-cbc", "")
+	enc = strings.ReplaceAll(enc, "-", "")
+	parts = append(parts, enc)
+	// existing auth handling for non-GCM
+}
+```
+
+For the two IKE builders, when `isGCM` append a PRF part. PRF is
+derived from the proposal's AuthAlg when present (`hmac-sha-256` ->
+`prfsha256`, `sha384`->`prfsha384`, `sha512`->`prfsha512`),
+defaulting to `prfsha256` when AuthAlg is empty/unknown. ESP
+(`buildESPProposal`) appends NO PRF (ESP AEAD children take only the
+cipher + optional DH).
+
+The GCM `gcm`-contains checks that currently gate auth-skipping are
+preserved via `isGCM`. The `aes256gcm128` already-suffixed form
+(fed by current tests) routes through the `strings.Contains(enc,
+"gcm")` pass-through branch unchanged.
+
+Result tokens after the fix:
+- ESP `aes-256-gcm`, dh14: `aes256gcm16-modp2048`
+- ESP `aes-256-gcm`, no dh: `aes256gcm16`
+- IKE `aes-256-gcm`, dh14, no auth: `aes256gcm16-prfsha256-modp2048`
+- IKE `aes-256-gcm`, dh14, auth hmac-sha-384: `aes256gcm16-prfsha384-modp2048`
+- ESP `aes256gcm128` (legacy already-suffixed): `aes256gcm128-...` (unchanged)
+
+### Part B — swanctl double-quote escaping (#2126), in `policy.go`
+
+Add a dedicated quoter and apply it where a value is interpolated
+inside `"..."` or where swanctl needs a quoted free-text value:
+
+```go
+// escapeSwanctlQuoted escapes a string for inclusion inside a
+// swanctl double-quoted value. The swanctl settings lexer treats a
+// bare double-quote as the string terminator and processes
+// backslash escapes inside quotes (\" -> ", \\ -> \). Order
+// matters: backslashes are doubled first, then quotes escaped.
+func escapeSwanctlQuoted(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}
+```
+
+- **PSK secret (line ~204):**
+  `secret = "%s"` with `escapeSwanctlQuoted(sanitizeSwanctlValue(decoded))`.
+  Control-char sanitization stays (belt for #1798); quote/backslash
+  escaping is the new layer.
+- **`id = ...` (lines ~115, ~123):** emit quoted +
+  escaped — `id = "%s"`. swanctl accepts a quoted identity for every
+  id type (docs example `id = "C=CH, O=strongSwan, CN=*"`), and a
+  quoted `@fqdn` / quoted IP parse identically to the unquoted form,
+  so this is safe AND fixes the DN-with-spaces/commas mis-parse. The
+  two existing tests that assert unquoted `id = @vpn.example.com` /
+  `id = 203.0.113.1` are updated to the quoted form (correct
+  behavior, not a regression).
+- **`certs = ...` (line ~112):** quote + escape the same way for
+  consistency (a cert filename with a space would otherwise truncate).
+
+`escapeSwanctlQuoted` is applied AFTER `sanitizeSwanctlValue` so the
+control-char belt still runs first; the order is composition, not
+conflict.
+
+## Public API preservation
+
+All target functions are unexported package-internal helpers
+(`buildESPProposal`, `buildIKEProposal`, `buildIKEProposalFromIKE`,
+`sanitizeSwanctlValue`, `formatIdentity`, `normalizePSK`). No
+exported signature changes. New helpers (`normalizeEncAlg`,
+`gcmPRF`, `escapeSwanctlQuoted`) are unexported.
+
+## Hidden invariants the change must preserve
+
+- **#1798 control-char belt** stays first in the PSK/id pipeline
+  (sanitize then escape) — embedded newline still cannot inject a
+  swanctl section.
+- **Legacy already-suffixed GCM** (`aes256gcm128`, fed by current
+  tests + any in-the-wild config) renders unchanged.
+- **Non-GCM CBC path** (`aes-256-cbc` -> `aes256`, plus auth) is
+  byte-identical to today.
+- **ESP vs IKE PRF asymmetry**: PRF is appended ONLY for IKE GCM,
+  never ESP — adding a PRF to an ESP proposal would itself be invalid.
+- **DH/modp suffix ordering** preserved (cipher[-auth|-prf][-modp]).
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression (non-GCM / legacy GCM) | LOW | new code only diverges for Junos-native GCM names; legacy + CBC paths fall through unchanged, asserted by retained tests |
+| Correctness of new grammar | LOW | tokens + escaping verified against strongSwan docs + lexer source, not guessed |
+| id/certs quoting behavior change | LOW-MED | changes existing `id =` test expectations; quoted form is universally swanctl-valid, so functionally safe |
+| Architectural mismatch | NONE | localized render fix, no new abstraction layer |
+
+## Test plan (control-plane only — NO dataplane smoke per directive)
+
+- `go build ./...` clean.
+- `go test ./pkg/ipsec/... ./pkg/config/...` — full pass.
+- New `pkg/ipsec` unit tests, each NON-tautological (must fail on
+  pre-fix code):
+  - GCM ESP: `buildESPProposal(aes-128/192/256-gcm, dh14)` ->
+    `aes{128,192,256}gcm16-modp2048`; no-dh -> `aes{N}gcm16`.
+  - GCM IKE: `buildIKEProposal` / `buildIKEProposalFromIKE` with
+    `aes-256-gcm` -> contains `aes256gcm16` AND a `prfsha*` part AND
+    `modp2048`; PRF derives from AuthAlg when set.
+  - Legacy already-suffixed `aes256gcm128` unchanged.
+  - PSK with embedded `"` -> rendered `secret = "...\"..."` (assert
+    exact bytes); PSK with `\` -> `\\`; PSK with both.
+  - Full `GenerateConfig` render with a quote-bearing PSK parses to
+    one balanced quoted secret (assert the exact secret line).
+  - id with spaces/commas -> quoted+escaped `id = "..."`.
+- If swanctl is installed in the test env, additionally pipe the
+  rendered config through a swanctl syntax check; it is NOT available
+  locally (`swanctl: command not found`), so the primary gate is
+  exact-byte assertions against the verified grammar.
+
+## Out of scope (explicitly)
+
+- Commit-time schema validation of encryption-algorithm /
+  PSK values (#2125/#2126 mention it as optional) — render-side fix
+  is the load-bearing change; a schema validator is a separate
+  follow-up and would not by itself fix already-committed configs.
+- `0x`/`0s` hex/base64 secret encoding alternative — backslash
+  escaping is simpler, lexer-correct, and keeps the secret
+  human-diffable in generated config.
+- Any non-IPsec swanctl value.
+
+## Open questions for adversarial review
+
+1. Is `aes256gcm16` the right spelling vs `aes256gcm128`? (Both are
+   the 16-octet ICV; `gcm16` is the canonical short form. Either
+   parses — is there a reason to prefer 128 for Junos parity?)
+2. PRF default: is `prfsha256` the right default for a GCM IKE
+   proposal with no AuthAlg, or should it derive from the DH/cipher
+   strength (e.g. prfsha384 for aes256)? Junos default behavior?
+3. Should `id`/`certs` quoting be in-scope, or kept minimal to the
+   confirmed PSK defect to shrink the diff? (Quoting is safe but
+   changes existing test expectations.)
+4. Backslash-first then quote escaping order — any swanctl lexer
+   corner the `\\.` analysis misses (e.g. `\n`/`\r`/`\t` named
+   escapes interacting with a literal backslash-n in a PSK)?
+5. Does any existing in-the-wild config rely on the (broken) bare
+   `aes256gcm` rendering such that changing it is itself a
+   regression? (It cannot establish today, so no — but call it out.)
+6. Is appending a PRF to the IKE proposal safe when the peer
+   negotiated without one before? (It could not have — bare
+   `aes256gcm` never established.)

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -120,21 +120,26 @@ all files stay in `package ipsec`, so the public API is unchanged.
     gateway — `set security ike gateway <name> address <ip>` (or
     `dynamic hostname <fqdn>`). The shared accept predicate is
     `config.IsUsableIPsecEndpoint`.
-- **AES-GCM proposal ICV suffix + IKE PRF (#2125).** strongSwan has no
-  bare `aes<N>gcm` keyword — AEAD ciphers MUST carry an explicit ICV
-  length. `normalizeEncAlg` (`ike.go`) maps the Junos-native GCM names
-  (`aes-128-gcm`/`aes-192-gcm`/`aes-256-gcm`) to the 16-octet-ICV
-  swanctl tokens (`aes128gcm16`/`aes192gcm16`/`aes256gcm16` — Junos
-  AES-GCM uses a 16-octet ICV) before the generic dash-strip, so the
-  proposal builders no longer emit the unparseable `aes256gcm-modp2048`
-  that silently failed the SA at apply while the commit succeeded.
-  Already-suffixed forms (e.g. `aes256gcm128`) pass through unchanged.
-  For AEAD the integrity algorithm is dropped (GCM carries its own ICV)
-  and, for IKE (Phase 1) only, an explicit PRF is appended
-  (`aes256gcm16-prfsha256-modp2048`) because an AEAD proposal has no
-  integrity algorithm for strongSwan to derive a PRF from; the PRF
+- **AES-GCM IKE PRF + ICV-suffix canonicalization (#2125).** The
+  load-bearing fix: a strongSwan IKEv2 AEAD (AES-GCM) proposal MUST
+  name a PRF explicitly — an AEAD cipher carries no integrity algorithm
+  for strongSwan to derive a PRF from — so a GCM IKE (Phase 1) proposal
+  with no PRF is incomplete and the IKE SA fails to negotiate (a
+  silently-dead tunnel while the commit succeeds). The IKE builders now
+  append a PRF for GCM (`aes256gcm16-prfsha256-modp2048`); the PRF
   mirrors the proposal's auth algorithm when set, defaulting to
-  `prfsha256`. ESP children take no PRF.
+  `prfsha256`. ESP children take NO PRF (and no separate integrity alg —
+  GCM carries its own ICV). Separately, `normalizeEncAlg` (`ike.go`)
+  canonicalizes the Junos-native GCM names
+  (`aes-128-gcm`/`aes-192-gcm`/`aes-256-gcm`) to the explicit
+  16-octet-ICV swanctl tokens (`aes128gcm16`/`aes192gcm16`/`aes256gcm16`
+  — Junos AES-GCM uses a 16-octet ICV). This is a clarity/consistency
+  fix, NOT a parse fix: strongSwan also accepts the bare `aes<N>gcm`
+  alias (it maps to `ENCR_AES_GCM_ICV16` in
+  `proposal_keywords_static.txt`), so the previous `aes256gcm-modp2048`
+  ESP render was valid — the canonicalization just makes the ICV
+  explicit in the generated config. Already-suffixed forms (e.g.
+  `aes256gcm128`) pass through unchanged.
 - **swanctl double-quote / backslash escaping (#2126).** Free-text
   values interpolated inside a swanctl double-quoted string — the PSK
   `secret = "..."` and the `id = "..."` / `certs = "..."` lines — are

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -120,3 +120,31 @@ all files stay in `package ipsec`, so the public API is unchanged.
     gateway — `set security ike gateway <name> address <ip>` (or
     `dynamic hostname <fqdn>`). The shared accept predicate is
     `config.IsUsableIPsecEndpoint`.
+- **AES-GCM proposal ICV suffix + IKE PRF (#2125).** strongSwan has no
+  bare `aes<N>gcm` keyword — AEAD ciphers MUST carry an explicit ICV
+  length. `normalizeEncAlg` (`ike.go`) maps the Junos-native GCM names
+  (`aes-128-gcm`/`aes-192-gcm`/`aes-256-gcm`) to the 16-octet-ICV
+  swanctl tokens (`aes128gcm16`/`aes192gcm16`/`aes256gcm16` — Junos
+  AES-GCM uses a 16-octet ICV) before the generic dash-strip, so the
+  proposal builders no longer emit the unparseable `aes256gcm-modp2048`
+  that silently failed the SA at apply while the commit succeeded.
+  Already-suffixed forms (e.g. `aes256gcm128`) pass through unchanged.
+  For AEAD the integrity algorithm is dropped (GCM carries its own ICV)
+  and, for IKE (Phase 1) only, an explicit PRF is appended
+  (`aes256gcm16-prfsha256-modp2048`) because an AEAD proposal has no
+  integrity algorithm for strongSwan to derive a PRF from; the PRF
+  mirrors the proposal's auth algorithm when set, defaulting to
+  `prfsha256`. ESP children take no PRF.
+- **swanctl double-quote / backslash escaping (#2126).** Free-text
+  values interpolated inside a swanctl double-quoted string — the PSK
+  `secret = "..."` and the `id = "..."` / `certs = "..."` lines — are
+  run through `escapeSwanctlQuoted` (`policy.go`), which doubles
+  backslashes then escapes double-quotes (order matters). The swanctl
+  settings lexer treats a bare `"` as the string terminator and
+  processes `\\`/`\"` escapes inside quotes, so a PSK or distinguished-
+  name identity containing a literal `"` (e.g. `pa"ss`, `CN=fw, O=acme`)
+  no longer corrupts the secrets/identity block (a silent IKE auth
+  failure). This composes with — does not replace — the #1798
+  `sanitizeSwanctlValue` control-char belt (sanitize first, then
+  escape). Identity values are now always emitted quoted so a DN with
+  spaces/commas parses as a single value.

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -171,6 +171,66 @@ func hasIKEChain(cfg *config.IPsecConfig, ikePolicyName string) bool {
 	return ok
 }
 
+// normalizeEncAlg maps a Junos encryption-algorithm name to its swanctl
+// token. For AES-GCM it returns the ICV-suffixed token strongSwan
+// requires (a bare "aes256gcm" is NOT a valid swanctl keyword — GCM
+// ciphers must carry an explicit ICV length). Junos AES-GCM uses a
+// 16-octet (128-bit) ICV, so aes-256-gcm -> aes256gcm16. isGCM reports
+// whether the algorithm is AEAD (the caller skips the integrity
+// algorithm for AEAD and, for IKE, appends an explicit PRF instead).
+//
+// Already-suffixed forms (e.g. aes256gcm128 fed directly by config or
+// older tests) pass through the generic dash-strip unchanged so they
+// keep rendering as before. Non-GCM algorithms return ("", false) and
+// the caller applies the historical "-cbc"/"-" normalization.
+func normalizeEncAlg(enc string) (token string, isGCM bool) {
+	switch enc {
+	case "aes-128-gcm", "aes128gcm":
+		return "aes128gcm16", true
+	case "aes-192-gcm", "aes192gcm":
+		return "aes192gcm16", true
+	case "aes-256-gcm", "aes256gcm":
+		return "aes256gcm16", true
+	}
+	if strings.Contains(enc, "gcm") {
+		// Already carries an ICV suffix (or some other GCM spelling);
+		// strip Junos punctuation but otherwise leave it intact.
+		t := strings.ReplaceAll(enc, "-cbc", "")
+		t = strings.ReplaceAll(t, "-", "")
+		return t, true
+	}
+	return "", false
+}
+
+// gcmPRF derives the swanctl PRF token for an IKE (Phase 1) AEAD
+// proposal. AEAD ciphers carry no integrity algorithm for strongSwan to
+// derive a PRF from, so IKEv2 GCM proposals MUST name a PRF explicitly
+// (e.g. aes256gcm16-prfsha256-modp2048). When the proposal names an
+// auth/integrity algorithm we mirror it as the PRF; otherwise we default
+// to prfsha256.
+func gcmPRF(authAlg string) string {
+	switch {
+	case strings.Contains(authAlg, "512"):
+		return "prfsha512"
+	case strings.Contains(authAlg, "384"):
+		return "prfsha384"
+	case strings.Contains(authAlg, "256"):
+		return "prfsha256"
+	case strings.Contains(authAlg, "sha1"), strings.Contains(authAlg, "sha-1"):
+		return "prfsha1"
+	default:
+		return "prfsha256"
+	}
+}
+
+// normalizeAuthAlg maps a Junos authentication-algorithm name to its
+// swanctl integrity token (hmac-sha-256 -> sha256).
+func normalizeAuthAlg(authAlg string) string {
+	a := strings.ReplaceAll(authAlg, "hmac-", "")
+	a = strings.ReplaceAll(a, "-", "")
+	return a
+}
+
 // buildIKEProposalFromIKE builds a swanctl IKE proposal string from an IKE proposal.
 func buildIKEProposalFromIKE(prop *config.IKEProposal) string {
 	var parts []string
@@ -179,15 +239,17 @@ func buildIKEProposalFromIKE(prop *config.IKEProposal) string {
 	if enc == "" {
 		enc = "aes256"
 	}
-	enc = strings.ReplaceAll(enc, "-cbc", "")
-	enc = strings.ReplaceAll(enc, "-", "")
-	parts = append(parts, enc)
-
-	if prop.AuthAlg != "" && !strings.Contains(prop.EncryptionAlg, "gcm") {
-		auth := prop.AuthAlg
-		auth = strings.ReplaceAll(auth, "hmac-", "")
-		auth = strings.ReplaceAll(auth, "-", "")
-		parts = append(parts, auth)
+	if tok, isGCM := normalizeEncAlg(enc); isGCM {
+		parts = append(parts, tok)
+		// IKEv2 AEAD proposals require an explicit PRF.
+		parts = append(parts, gcmPRF(prop.AuthAlg))
+	} else {
+		enc = strings.ReplaceAll(enc, "-cbc", "")
+		enc = strings.ReplaceAll(enc, "-", "")
+		parts = append(parts, enc)
+		if prop.AuthAlg != "" {
+			parts = append(parts, normalizeAuthAlg(prop.AuthAlg))
+		}
 	}
 
 	if prop.DHGroup > 0 {
@@ -205,16 +267,18 @@ func buildIKEProposal(prop *config.IPsecProposal) string {
 	if enc == "" {
 		enc = "aes256"
 	}
-	enc = strings.ReplaceAll(enc, "-cbc", "")
-	enc = strings.ReplaceAll(enc, "-", "")
-	parts = append(parts, enc)
-
-	// IKE always includes integrity/PRF (even for GCM, swanctl adds PRFHMACSHA256 implicitly)
-	if prop.AuthAlg != "" && !strings.Contains(prop.EncryptionAlg, "gcm") {
-		auth := prop.AuthAlg
-		auth = strings.ReplaceAll(auth, "hmac-", "")
-		auth = strings.ReplaceAll(auth, "-", "")
-		parts = append(parts, auth)
+	if tok, isGCM := normalizeEncAlg(enc); isGCM {
+		parts = append(parts, tok)
+		// IKEv2 AEAD proposals require an explicit PRF — there is no
+		// integrity algorithm to derive one from.
+		parts = append(parts, gcmPRF(prop.AuthAlg))
+	} else {
+		enc = strings.ReplaceAll(enc, "-cbc", "")
+		enc = strings.ReplaceAll(enc, "-", "")
+		parts = append(parts, enc)
+		if prop.AuthAlg != "" {
+			parts = append(parts, normalizeAuthAlg(prop.AuthAlg))
+		}
 	}
 
 	if prop.DHGroup > 0 {
@@ -232,17 +296,18 @@ func buildESPProposal(prop *config.IPsecProposal, pfsGroup int) string {
 	if enc == "" {
 		enc = "aes256"
 	}
-	// Normalize Junos names to swanctl names
-	enc = strings.ReplaceAll(enc, "-cbc", "")
-	enc = strings.ReplaceAll(enc, "-", "")
-	parts = append(parts, enc)
-
-	// Authentication algorithm (skip for GCM modes)
-	if !strings.Contains(prop.EncryptionAlg, "gcm") && prop.AuthAlg != "" {
-		auth := prop.AuthAlg
-		auth = strings.ReplaceAll(auth, "hmac-", "")
-		auth = strings.ReplaceAll(auth, "-", "")
-		parts = append(parts, auth)
+	// Normalize Junos names to swanctl names. AEAD (GCM) ciphers carry
+	// an ICV suffix and take no separate integrity algorithm and no PRF.
+	if tok, isGCM := normalizeEncAlg(enc); isGCM {
+		parts = append(parts, tok)
+	} else {
+		enc = strings.ReplaceAll(enc, "-cbc", "")
+		enc = strings.ReplaceAll(enc, "-", "")
+		parts = append(parts, enc)
+		// Authentication algorithm (non-GCM only)
+		if prop.AuthAlg != "" {
+			parts = append(parts, normalizeAuthAlg(prop.AuthAlg))
+		}
 	}
 
 	// DH group

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -172,12 +172,17 @@ func hasIKEChain(cfg *config.IPsecConfig, ikePolicyName string) bool {
 }
 
 // normalizeEncAlg maps a Junos encryption-algorithm name to its swanctl
-// token. For AES-GCM it returns the ICV-suffixed token strongSwan
-// requires (a bare "aes256gcm" is NOT a valid swanctl keyword — GCM
-// ciphers must carry an explicit ICV length). Junos AES-GCM uses a
-// 16-octet (128-bit) ICV, so aes-256-gcm -> aes256gcm16. isGCM reports
-// whether the algorithm is AEAD (the caller skips the integrity
-// algorithm for AEAD and, for IKE, appends an explicit PRF instead).
+// token. For AES-GCM it returns the explicit 16-octet-ICV token
+// (aes-256-gcm -> aes256gcm16). This is a canonicalization for clarity,
+// not a parse fix: strongSwan also accepts the bare "aes256gcm" alias
+// (it maps to ENCR_AES_GCM_ICV16 in proposal_keywords_static.txt), so
+// the previous bare render parsed fine — the suffix just makes the ICV
+// length explicit in the generated config, matching the operator's
+// Junos intent (Junos AES-GCM uses a 16-octet ICV). The load-bearing
+// #2125 correctness fix is the explicit IKE PRF the callers add for
+// AEAD, not this spelling. isGCM reports whether the algorithm is AEAD
+// (the caller skips the integrity algorithm for AEAD and, for IKE,
+// appends an explicit PRF instead).
 //
 // Already-suffixed forms (e.g. aes256gcm128 fed directly by config or
 // older tests) pass through the generic dash-strip unchanged so they

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -532,8 +532,8 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 		{"no NAT-T", "encap = no"},
 		{"DPD", "dpd_delay = 10s"},
 		{"DPD timeout", "dpd_timeout = 50s"},
-		{"local identity", "id = @vpn.example.com"},
-		{"remote identity", "id = 203.0.113.1"},
+		{"local identity", `id = "@vpn.example.com"`},
+		{"remote identity", `id = "203.0.113.1"`},
 		{"IKE proposal", "proposals = aes256-sha256-modp2048"},
 		{"ESP proposal", "esp_proposals = aes256-sha256128-modp2048"},
 		{"copy DF", "copy_df = yes"},
@@ -937,7 +937,7 @@ func TestGenerateConfig_PubkeyAuth(t *testing.T) {
 	if !strings.Contains(got, "auth = pubkey") {
 		t.Fatalf("expected pubkey auth, got:\n%s", got)
 	}
-	if !strings.Contains(got, "certs = gw-cert.pem") {
+	if !strings.Contains(got, `certs = "gw-cert.pem"`) {
 		t.Fatalf("expected local certificate, got:\n%s", got)
 	}
 	if strings.Contains(got, "secret = ") {

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -109,10 +109,14 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 		b.WriteString("    local {\n")
 		fmt.Fprintf(&b, "      auth = %s\n", authMethod)
 		if gw != nil && gw.LocalCertificate != "" {
-			fmt.Fprintf(&b, "      certs = %s\n", sanitizeSwanctlValue(gw.LocalCertificate))
+			fmt.Fprintf(&b, "      certs = \"%s\"\n", escapeSwanctlQuoted(sanitizeSwanctlValue(gw.LocalCertificate)))
 		}
 		if gw != nil && gw.LocalIDValue != "" {
-			fmt.Fprintf(&b, "      id = %s\n", sanitizeSwanctlValue(formatIdentity(gw.LocalIDType, gw.LocalIDValue)))
+			// Quote + escape the identity: a distinguished-name id with
+			// spaces/commas (id = CN=fw, O=acme) is mis-parsed when
+			// emitted unquoted, and swanctl accepts a quoted value for
+			// every identity type (@fqdn, IP, DN) (#2126).
+			fmt.Fprintf(&b, "      id = \"%s\"\n", escapeSwanctlQuoted(sanitizeSwanctlValue(formatIdentity(gw.LocalIDType, gw.LocalIDValue))))
 		}
 		b.WriteString("    }\n")
 
@@ -120,7 +124,7 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 		b.WriteString("    remote {\n")
 		fmt.Fprintf(&b, "      auth = %s\n", authMethod)
 		if gw != nil && gw.RemoteIDValue != "" {
-			fmt.Fprintf(&b, "      id = %s\n", sanitizeSwanctlValue(formatIdentity(gw.RemoteIDType, gw.RemoteIDValue)))
+			fmt.Fprintf(&b, "      id = \"%s\"\n", escapeSwanctlQuoted(sanitizeSwanctlValue(formatIdentity(gw.RemoteIDType, gw.RemoteIDValue))))
 		}
 		b.WriteString("    }\n")
 
@@ -201,7 +205,11 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 				return "", fmt.Errorf("vpn %s: %w", name, err)
 			}
 			fmt.Fprintf(&b, "  ike-%s {\n", sanitizeSwanctlValue(name))
-			fmt.Fprintf(&b, "    secret = \"%s\"\n", sanitizeSwanctlValue(decoded))
+			// sanitizeSwanctlValue strips control chars (#1798); the
+			// quote/backslash escaper (#2126) makes a PSK containing a
+			// double-quote or backslash render as a balanced, swanctl-
+			// parseable quoted string instead of corrupting the block.
+			fmt.Fprintf(&b, "    secret = \"%s\"\n", escapeSwanctlQuoted(sanitizeSwanctlValue(decoded)))
 			fmt.Fprintf(&b, "  }\n")
 		}
 	}
@@ -340,6 +348,27 @@ func sanitizeSwanctlValue(s string) string {
 		}
 	}
 	return string(b)
+}
+
+// escapeSwanctlQuoted escapes a string for safe inclusion inside a
+// swanctl double-quoted value (secret = "...", id = "...",
+// certs = "..."). The swanctl settings lexer treats a bare double-quote
+// as the string terminator and processes backslash escapes inside
+// quotes (\\ -> a literal backslash, \" -> a literal double-quote).
+// Without escaping, a value containing a double-quote — legal in a real
+// pre-shared key or a distinguished-name identity — truncates or
+// corrupts the rendered config (#2126).
+//
+// Order matters: backslashes are doubled FIRST, then double-quotes are
+// escaped. Escaping quotes first would let the second pass double the
+// backslash it just inserted. A literal backslash renders as \\ (lexer
+// \\. -> \) and a literal " renders as \" (lexer \\. -> "), so a PSK
+// like `a\nb` renders as `a\\nb` and round-trips to the literal
+// backslash + n, never the \n newline escape.
+func escapeSwanctlQuoted(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
 }
 
 func sanitizeChildName(name string) string {

--- a/pkg/ipsec/swanctl_render_test.go
+++ b/pkg/ipsec/swanctl_render_test.go
@@ -1,0 +1,305 @@
+package ipsec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestBuildESPProposal_JunosGCMSuffix is the #2125 regression: a
+// Junos-native GCM encryption-algorithm name must render to a swanctl
+// token WITH the 16-octet ICV suffix (aes256gcm16). Pre-fix the
+// normalizer only stripped "-cbc"/"-" and produced the bare,
+// unparseable token "aes256gcm" — so these assertions FAIL on the old
+// code (non-tautological).
+func TestBuildESPProposal_JunosGCMSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		prop *config.IPsecProposal
+		want string
+	}{
+		{
+			"aes-256-gcm dh14",
+			&config.IPsecProposal{EncryptionAlg: "aes-256-gcm", DHGroup: 14},
+			"aes256gcm16-modp2048",
+		},
+		{
+			"aes-192-gcm dh14",
+			&config.IPsecProposal{EncryptionAlg: "aes-192-gcm", DHGroup: 14},
+			"aes192gcm16-modp2048",
+		},
+		{
+			"aes-128-gcm dh14",
+			&config.IPsecProposal{EncryptionAlg: "aes-128-gcm", DHGroup: 14},
+			"aes128gcm16-modp2048",
+		},
+		{
+			"aes-256-gcm no dh",
+			&config.IPsecProposal{EncryptionAlg: "aes-256-gcm"},
+			"aes256gcm16",
+		},
+		{
+			// GCM must never emit a separate integrity algorithm even
+			// when AuthAlg is set — AEAD carries its own ICV.
+			"aes-256-gcm ignores auth",
+			&config.IPsecProposal{EncryptionAlg: "aes-256-gcm", AuthAlg: "hmac-sha-256", DHGroup: 14},
+			"aes256gcm16-modp2048",
+		},
+		{
+			// Already-suffixed legacy form is preserved unchanged.
+			"legacy aes256gcm128 unchanged",
+			&config.IPsecProposal{EncryptionAlg: "aes256gcm128", DHGroup: 14},
+			"aes256gcm128-modp2048",
+		},
+		{
+			// Non-GCM CBC path stays byte-identical to the old behavior.
+			"non-gcm cbc unchanged",
+			&config.IPsecProposal{EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha256-128", DHGroup: 14},
+			"aes256-sha256128-modp2048",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildESPProposal(tt.prop, 0); got != tt.want {
+				t.Errorf("buildESPProposal(%q) = %q, want %q", tt.prop.EncryptionAlg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildIKEProposal_JunosGCMSuffixAndPRF is the #2125 regression for
+// IKE (Phase 1): a Junos GCM name must render to aes<N>gcm16 AND carry
+// an explicit PRF (IKEv2 AEAD has no integrity alg to derive a PRF
+// from). Pre-fix the IKE builders emitted bare "aes256gcm" with no PRF.
+func TestBuildIKEProposal_JunosGCMSuffixAndPRF(t *testing.T) {
+	tests := []struct {
+		name string
+		prop *config.IPsecProposal
+		want string
+	}{
+		{
+			"aes-256-gcm default prf",
+			&config.IPsecProposal{EncryptionAlg: "aes-256-gcm", DHGroup: 14},
+			"aes256gcm16-prfsha256-modp2048",
+		},
+		{
+			"aes-256-gcm prf from sha384 auth",
+			&config.IPsecProposal{EncryptionAlg: "aes-256-gcm", AuthAlg: "hmac-sha-384", DHGroup: 14},
+			"aes256gcm16-prfsha384-modp2048",
+		},
+		{
+			"aes-128-gcm prf from sha512 auth",
+			&config.IPsecProposal{EncryptionAlg: "aes-128-gcm", AuthAlg: "hmac-sha-512", DHGroup: 14},
+			"aes128gcm16-prfsha512-modp2048",
+		},
+		{
+			"non-gcm cbc unchanged",
+			&config.IPsecProposal{EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha256-128", DHGroup: 14},
+			"aes256-sha256128-modp2048",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildIKEProposal(tt.prop); got != tt.want {
+				t.Errorf("buildIKEProposal(%q) = %q, want %q", tt.prop.EncryptionAlg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildIKEProposalFromIKE_JunosGCMSuffixAndPRF mirrors the IKE GCM
+// regression for the IKE-proposal-object path (buildIKEProposalFromIKE).
+func TestBuildIKEProposalFromIKE_JunosGCMSuffixAndPRF(t *testing.T) {
+	tests := []struct {
+		name string
+		prop *config.IKEProposal
+		want string
+	}{
+		{
+			"aes-256-gcm default prf",
+			&config.IKEProposal{EncryptionAlg: "aes-256-gcm", DHGroup: 14},
+			"aes256gcm16-prfsha256-modp2048",
+		},
+		{
+			"aes-256-gcm prf from sha-512 auth",
+			&config.IKEProposal{EncryptionAlg: "aes-256-gcm", AuthAlg: "sha-512", DHGroup: 14},
+			"aes256gcm16-prfsha512-modp2048",
+		},
+		{
+			"non-gcm cbc unchanged",
+			&config.IKEProposal{EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
+			"aes256-sha256-modp2048",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildIKEProposalFromIKE(tt.prop); got != tt.want {
+				t.Errorf("buildIKEProposalFromIKE(%q) = %q, want %q", tt.prop.EncryptionAlg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGenerateConfig_JunosGCM is an end-to-end render check that a
+// Junos-native aes-256-gcm proposal produces a valid, ICV-suffixed
+// esp_proposals line through generateConfig (#2125).
+func TestGenerateConfig_JunosGCM(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {Gateway: "172.16.0.1", IPsecPolicy: "gcm"},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"gcm": {Name: "gcm", EncryptionAlg: "aes-256-gcm", DHGroup: 14},
+		},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, "esp_proposals = aes256gcm16-modp2048") {
+		t.Errorf("expected ICV-suffixed GCM esp_proposals, got:\n%s", got)
+	}
+	// The broken bare form must NOT appear.
+	if strings.Contains(got, "aes256gcm-modp2048") {
+		t.Errorf("rendered the invalid bare aes256gcm token:\n%s", got)
+	}
+}
+
+// TestEscapeSwanctlQuoted unit-tests the swanctl double-quoted-string
+// escaper directly (#2126). Order matters: backslash doubled first,
+// then quote escaped.
+func TestEscapeSwanctlQuoted(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no special chars", "supersecret", "supersecret"},
+		{"embedded quote", `pa"ss`, `pa\"ss`},
+		{"embedded backslash", `pa\ss`, `pa\\ss`},
+		{"backslash then n stays literal", `a\nb`, `a\\nb`},
+		{"both quote and backslash", `a"\b`, `a\"\\b`},
+		{"trailing quote", `secret"`, `secret\"`},
+		{"leading quote", `"secret`, `\"secret`},
+		{"quote then backslash order", `"\`, `\"\\`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeSwanctlQuoted(tt.in); got != tt.want {
+				t.Errorf("escapeSwanctlQuoted(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGenerateConfig_PSKWithQuote is the #2126 end-to-end regression: a
+// PSK containing a double-quote must render as a balanced, escaped
+// quoted secret (secret = "pa\"ss"), not the corrupted secret = "pa"ss"
+// the pre-fix code produced.
+func TestGenerateConfig_PSKWithQuote(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"site-a": {
+				LocalAddr:     "10.0.1.1",
+				Gateway:       "10.0.2.1",
+				PSK:           `pa"ss`,
+				BindInterface: "st0.0",
+			},
+		},
+		Proposals: map[string]*config.IPsecProposal{},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, `secret = "pa\"ss"`) {
+		t.Errorf("expected escaped quoted PSK, got:\n%s", got)
+	}
+	// The corrupting unescaped form must NOT appear.
+	if strings.Contains(got, `secret = "pa"ss"`) {
+		t.Errorf("rendered the corrupted unescaped PSK:\n%s", got)
+	}
+	assertBalancedSecretQuotes(t, got)
+}
+
+// TestGenerateConfig_PSKWithBackslash covers a PSK containing a literal
+// backslash (#2126) — it must be doubled so the swanctl lexer reads one
+// literal backslash back.
+func TestGenerateConfig_PSKWithBackslash(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"site-a": {
+				LocalAddr:     "10.0.1.1",
+				Gateway:       "10.0.2.1",
+				PSK:           `pa\ss`,
+				BindInterface: "st0.0",
+			},
+		},
+		Proposals: map[string]*config.IPsecProposal{},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, `secret = "pa\\ss"`) {
+		t.Errorf("expected doubled backslash in PSK, got:\n%s", got)
+	}
+}
+
+// TestGenerateConfig_IdentityWithCommaQuoted is the #2126 regression for
+// the identity lines: a distinguished-name identity with spaces/commas
+// must render quoted so swanctl parses it as a single value rather than
+// truncating at the first space/comma.
+func TestGenerateConfig_IdentityWithCommaQuoted(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun": {Gateway: "gw", PSK: "k"},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw": {
+				Name:          "gw",
+				Address:       "203.0.113.1",
+				LocalAddress:  "198.51.100.1",
+				LocalIDType:   "inet",
+				LocalIDValue:  "CN=fw, O=acme",
+				RemoteIDType:  "inet",
+				RemoteIDValue: `peer"name`,
+			},
+		},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, `id = "CN=fw, O=acme"`) {
+		t.Errorf("expected quoted DN identity, got:\n%s", got)
+	}
+	if !strings.Contains(got, `id = "peer\"name"`) {
+		t.Errorf("expected quoted+escaped remote identity, got:\n%s", got)
+	}
+}
+
+// assertBalancedSecretQuotes verifies every "secret = " line has exactly
+// the opening + closing quote with no unescaped interior double-quote —
+// i.e. the rendered secret block is parseable by the swanctl lexer.
+func assertBalancedSecretQuotes(t *testing.T, cfg string) {
+	t.Helper()
+	for _, line := range strings.Split(cfg, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "secret = ") {
+			continue
+		}
+		val := strings.TrimPrefix(trimmed, "secret = ")
+		if len(val) < 2 || val[0] != '"' || val[len(val)-1] != '"' {
+			t.Errorf("secret value not wrapped in quotes: %q", val)
+			continue
+		}
+		inner := val[1 : len(val)-1]
+		// Walk the inner string mimicking the swanctl lexer: a backslash
+		// escapes the next char; a bare double-quote would terminate the
+		// string early (i.e. unbalanced).
+		for i := 0; i < len(inner); i++ {
+			if inner[i] == '\\' {
+				i++ // skip the escaped char
+				continue
+			}
+			if inner[i] == '"' {
+				t.Errorf("unescaped interior double-quote in secret: %q", val)
+				break
+			}
+		}
+	}
+}

--- a/pkg/ipsec/swanctl_render_test.go
+++ b/pkg/ipsec/swanctl_render_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
-// TestBuildESPProposal_JunosGCMSuffix is the #2125 regression: a
-// Junos-native GCM encryption-algorithm name must render to a swanctl
-// token WITH the 16-octet ICV suffix (aes256gcm16). Pre-fix the
-// normalizer only stripped "-cbc"/"-" and produced the bare,
-// unparseable token "aes256gcm" — so these assertions FAIL on the old
-// code (non-tautological).
+// TestBuildESPProposal_JunosGCMSuffix is the #2125 ESP-render
+// regression: a Junos-native GCM encryption-algorithm name renders to
+// the canonical 16-octet-ICV swanctl token (aes256gcm16). Pre-fix the
+// normalizer only stripped "-cbc"/"-" and produced the bare alias
+// "aes256gcm", so these assertions FAIL on the old code
+// (non-tautological). Note: the bare alias is ALSO valid strongSwan
+// (it maps to ENCR_AES_GCM_ICV16), so this test pins the explicit-ICV
+// spelling for clarity/consistency — it is not guarding against a parse
+// failure. (The parse-affecting #2125 fix is the IKE PRF, covered by
+// TestBuildIKEProposal_JunosGCMSuffixAndPRF below.)
 func TestBuildESPProposal_JunosGCMSuffix(t *testing.T) {
 	tests := []struct {
 		name string
@@ -158,9 +162,10 @@ func TestGenerateConfig_JunosGCM(t *testing.T) {
 	if !strings.Contains(got, "esp_proposals = aes256gcm16-modp2048") {
 		t.Errorf("expected ICV-suffixed GCM esp_proposals, got:\n%s", got)
 	}
-	// The broken bare form must NOT appear.
+	// The bare alias (valid strongSwan, but not the canonical spelling
+	// we now emit) must no longer appear.
 	if strings.Contains(got, "aes256gcm-modp2048") {
-		t.Errorf("rendered the invalid bare aes256gcm token:\n%s", got)
+		t.Errorf("rendered the bare aes256gcm alias instead of the canonical aes256gcm16:\n%s", got)
 	}
 }
 
@@ -241,6 +246,30 @@ func TestGenerateConfig_PSKWithBackslash(t *testing.T) {
 	}
 }
 
+// TestGenerateConfig_PSKTrailingBackslash is the adversarial corner a PSK
+// ending in a single backslash: it must render as a doubled backslash
+// (secret = "pass\\") so the trailing backslash does NOT escape the
+// closing quote. assertBalancedSecretQuotes is the lexer-accurate gate.
+func TestGenerateConfig_PSKTrailingBackslash(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"site-a": {
+				LocalAddr:     "10.0.1.1",
+				Gateway:       "10.0.2.1",
+				PSK:           `pass\`,
+				BindInterface: "st0.0",
+			},
+		},
+		Proposals: map[string]*config.IPsecProposal{},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, `secret = "pass\\"`) {
+		t.Errorf("expected trailing backslash doubled, got:\n%s", got)
+	}
+	assertBalancedSecretQuotes(t, got)
+}
+
 // TestGenerateConfig_IdentityWithCommaQuoted is the #2126 regression for
 // the identity lines: a distinguished-name identity with spaces/commas
 // must render quoted so swanctl parses it as a single value rather than
@@ -283,23 +312,33 @@ func assertBalancedSecretQuotes(t *testing.T, cfg string) {
 			continue
 		}
 		val := strings.TrimPrefix(trimmed, "secret = ")
-		if len(val) < 2 || val[0] != '"' || val[len(val)-1] != '"' {
-			t.Errorf("secret value not wrapped in quotes: %q", val)
+		if len(val) < 2 || val[0] != '"' {
+			t.Errorf("secret value not opened with a quote: %q", val)
 			continue
 		}
-		inner := val[1 : len(val)-1]
-		// Walk the inner string mimicking the swanctl lexer: a backslash
-		// escapes the next char; a bare double-quote would terminate the
-		// string early (i.e. unbalanced).
-		for i := 0; i < len(inner); i++ {
-			if inner[i] == '\\' {
+		// Walk from after the opening quote exactly as the swanctl lexer
+		// would: a backslash escapes the next char (so it can never
+		// terminate the string), and the FIRST unescaped double-quote is
+		// the real terminator. The line is balanced only if that
+		// terminator is the last character — catching both an unescaped
+		// interior quote (terminates early) and an odd trailing backslash
+		// run that escapes the would-be closing quote (e.g. `"foo\"`).
+		term := -1
+		for i := 1; i < len(val); i++ {
+			if val[i] == '\\' {
 				i++ // skip the escaped char
 				continue
 			}
-			if inner[i] == '"' {
-				t.Errorf("unescaped interior double-quote in secret: %q", val)
+			if val[i] == '"' {
+				term = i
 				break
 			}
+		}
+		switch {
+		case term == -1:
+			t.Errorf("secret value never closes (escaped/unterminated quote): %q", val)
+		case term != len(val)-1:
+			t.Errorf("secret value terminates before end of line (unescaped interior quote): %q", val)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Two control-plane swanctl-render correctness fixes in `pkg/ipsec`
(the file the issues cite as `ipsec.go` was split on master into
`ike.go` / `policy.go`):

- **#2125 — IKE PRF for AEAD GCM proposals.** strongSwan IKEv2 AEAD
  (AES-GCM) proposals require an explicit PRF — an AEAD cipher carries
  no integrity algorithm for strongSwan to derive a PRF from — so a GCM
  IKE (Phase 1) proposal with no PRF is incomplete and the IKE SA fails
  to negotiate (a silently-dead tunnel while the commit succeeds). The
  IKE builders emitted `aes256gcm-modp2048` with no PRF; they now emit
  `aes256gcm16-prfsha256-modp2048` (PRF mirrors the proposal's auth
  alg, default `prfsha256`). The Junos GCM names are also canonicalized
  to the explicit 16-octet-ICV tokens (`aes-256-gcm` -> `aes256gcm16`;
  Junos AES-GCM uses a 16-octet ICV). Note: the original issue claimed
  the bare `aes256gcm` token was unparseable — that is false (it is a
  valid strongSwan keyword -> `ENCR_AES_GCM_ICV16`, verified in master
  + 5.9.14), so the ESP canonicalization is a clarity fix; the IKE PRF
  is the load-bearing correctness fix.

- **#2126 — swanctl double-quote / backslash escaping.** A PSK or IKE
  identity containing a literal `"` corrupted the generated secrets /
  identity block (`secret = "pa"ss"` mis-parses). New
  `escapeSwanctlQuoted` doubles backslashes then escapes double-quotes
  (the swanctl settings lexer treats a bare `"` as the string
  terminator and processes `\\`/`\"` inside quotes). Applied to the PSK
  secret and the now-quoted `id =` / `certs =` identity lines (a DN with
  spaces/commas now parses as one value). Composes with — does not
  replace — the #1798 control-char belt.

## Plan + adversarial review

Plan doc: `docs/pr/2125-2126-ipsec-swanctl-render/plan.md`

- Codex plan round-1: **PLAN-KILL** (task-mqn9xb9o-aaue4r) — correctly
  refuted the "bare `aes256gcm` is unparseable" premise. Plan rewritten
  to v2, load-bearing fix re-anchored to the IKE PRF, section-name
  hardening scoped out as a follow-up. Re-review in progress.
- Gemini plan round-1: infra failure (ACP timeout) — re-dispatched.

## Test plan (control-plane only — no dataplane smoke)

- [x] `go build ./...` clean
- [x] `go test ./pkg/ipsec/... ./pkg/config/... ./pkg/grpcapi/... ./pkg/daemon/...` — all pass
- [x] New regression tests (`swanctl_render_test.go`) verified
      **non-tautological** — each fails when the fix is reverted:
  - [x] GCM ESP/IKE render + mandatory IKE PRF + legacy/CBC unchanged
  - [x] `escapeSwanctlQuoted` table (quote / backslash / order)
  - [x] end-to-end PSK-with-quote, PSK-with-backslash, DN-identity
  - [x] `assertBalancedSecretQuotes` lexer-mimic check
- [x] New tests 5/5 flake-clean
- swanctl not installed locally — primary gate is exact-byte assertions
  against the verified strongSwan grammar (keyword table + lexer source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)