### PR TITLE
#2122/#2123: strip canonical /32-/128 mask before parsing static NAT + NAT64 addresses

### DIFF
--- a/docs/pr/2122-2123-nat-cidr-parse/plan.md
+++ b/docs/pr/2122-2123-nat-cidr-parse/plan.md
@@ -1,0 +1,178 @@
+# #2122 + #2123: NAT static + NAT64 address parse rejects the /32 (/128) CIDR mask
+
+Status: READY — small two-site bug fix matching an established idiom.
+
+## Issue framing
+
+Two HIGH-severity NAT-correctness bugs with the **same root cause** in two
+modules:
+
+- **#2122** — static 1:1 NAT silently drops every rule written in canonical
+  Junos prefix form. `StaticNatTable::from_snapshots`
+  (`userspace-dp/src/nat/static_nat.rs:29-36`) parses
+  `snap.external_ip` / `snap.internal_ip` with `IpAddr::from_str`, which
+  REJECTS CIDR notation. The Go compiler emits the canonical mask intact
+  (`compileNATStatic` → `rule.Match = "203.0.113.5/32"`,
+  `rule.Then = "10.0.0.5/32"`), and `buildStaticNATSnapshots`
+  (`pkg/dataplane/userspace/nat.go:131-137`) copies it verbatim. Each rule
+  then hits the `Err(_) => continue` arm and is dropped, so (1) no 1:1
+  translation occurs and (2) the external IP is never registered as a local
+  address (`forwarding_build/mod.rs` iterates `static_nat.external_ips()`),
+  so inbound traffic to the external IP is not even recognized.
+
+- **#2123** — NAT64 range-form source pool drops every pool address.
+  `Nat64State::from_snapshots` (`userspace-dp/src/nat64.rs:74-78`) collects
+  the pool with `snap.pool_addresses.iter().filter_map(|s| s.parse().ok())`
+  into `Vec<Ipv4Addr>`. `Ipv4Addr::from_str` also rejects CIDR. When the
+  pool is configured as a range (`address 100.64.0.1 to 100.64.0.4`),
+  `expandAddressRange` (`compiler_nat.go:188`) appends `/32` to every
+  produced IP, so `PoolAddresses = [100.64.0.1/32, ...]`. `filter_map`
+  silently discards all of them, leaving `pool_v4` empty;
+  `allocate_v4_source` then returns `None` and NAT64 forward translation
+  cannot proceed for any flow using that rule.
+
+A bare-IP static NAT / discrete bare-IP pool happens to parse, which is why
+quick smoke tests never caught it. The /32 form is the *canonical* Junos
+syntax (it is literally the form used in the project's own #2008 H15 test,
+which only asserts the Go-side `.Match` field and never verifies the Rust
+install).
+
+## Decision: fix the Rust parse side (be tolerant of the canonical /32-/128 form)
+
+The codebase already has an established idiom for exactly this: the SNAT
+pool path at `userspace-dp/src/nat/source.rs:240-251` strips the mask before
+parse:
+
+```rust
+// Pool addresses may be bare IPs or /32 CIDRs — strip the mask.
+let ip_str = addr_str.split('/').next().unwrap_or(addr_str);
+if let Ok(ip) = ip_str.parse::<IpAddr>() { ... }
+```
+
+The fix mirrors that idiom in both buggy sites. Rationale for the Rust side
+over the Go side:
+
+1. It matches the existing, reviewed SNAT-pool idiom — one consistent way to
+   handle the canonical form across all NAT pool/address parse sites.
+2. Static NAT's `external_ip` feeds two consumers (the DNAT/SNAT maps AND
+   `external_ips()` local-address recognition). A tolerant parse fixes both
+   with a single change at the parse boundary.
+3. It is robust against any Go caller that supplies a masked form; the Go
+   side already strips for DNAT, but the parse-side tolerance is the
+   lower-blast-radius, canonical fix and needs no Go change.
+4. The masks emitted here are always host masks (/32 from `expandAddressRange`,
+   /32 or /128 from canonical prefix form). NAT static and the NAT64 pool
+   operate on exact host IPs, so discarding the mask is semantically correct
+   — there is no prefix-length information to lose.
+
+Note the NAT64 *prefix* (`64:ff9b::/96`) is intentionally NOT touched: it
+already splits on `/` and validates the /96 (`nat64.rs:60-67`). Only the
+`pool_addresses` collection is the bug.
+
+## Concrete design
+
+### static_nat.rs (#2122)
+
+Add a small private helper and route both parses through it:
+
+```rust
+/// Parse a NAT address that may carry a canonical host mask (`x.x.x.x/32`,
+/// `addr/128`). Junos emits static-NAT match/then in canonical prefix form;
+/// IpAddr::from_str rejects the mask, so strip it before parse. Mirrors the
+/// SNAT-pool idiom in nat/source.rs.
+fn parse_nat_addr(s: &str) -> Option<IpAddr> {
+    s.split('/').next().unwrap_or(s).parse().ok()
+}
+```
+
+`from_snapshots` then becomes:
+
+```rust
+let external_ip = match parse_nat_addr(&snap.external_ip) {
+    Some(ip) => ip,
+    None => continue,
+};
+let internal_ip = match parse_nat_addr(&snap.internal_ip) {
+    Some(ip) => ip,
+    None => continue,
+};
+```
+
+The existing skip-on-invalid behavior (`continue` on a genuinely malformed
+address) is preserved — `parse_nat_addr` still returns `None` for
+`"not-an-ip"`.
+
+### nat64.rs (#2123)
+
+```rust
+let pool_v4: Vec<Ipv4Addr> = snap
+    .pool_addresses
+    .iter()
+    .filter_map(|s| s.split('/').next().unwrap_or(s).parse().ok())
+    .collect();
+```
+
+## Public API preservation
+
+No signatures change. `StaticNatTable::from_snapshots`,
+`Nat64State::from_snapshots`, and all downstream methods keep their exact
+shapes. Only the internal parse becomes mask-tolerant.
+
+## Hidden invariants preserved
+
+- **Skip genuinely-invalid addresses.** `parse_nat_addr("not-an-ip")` →
+  `None` → `continue`, matching the existing `static_nat_invalid_ip_skipped`
+  test. The NAT64 `filter_map` likewise still discards genuinely-bad entries.
+- **Bare addresses still parse.** `split('/').next()` on a string with no
+  `/` returns the whole string, so existing bare-IP configs are unaffected.
+- **No allocation on the hot path.** This is config-apply (snapshot install)
+  time, not per-packet. `split('/').next()` returns a borrowed `&str`, no
+  allocation.
+- **external_ips() local-address recognition** is fixed as a side effect:
+  the DNAT map is now populated for /32 rules, so `external_ips()` yields the
+  external IP and inbound traffic is recognized.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Strictly widens accepted input; bare-IP and invalid-IP behavior unchanged. |
+| Lifetime / borrow | LOW | `split('/').next()` borrows from the snapshot string; no new owned data. |
+| Performance | NONE | Config-apply path, not per-packet. |
+| Architectural mismatch | NONE | Mirrors the existing reviewed source.rs idiom. |
+
+## Test plan (non-tautological — must FAIL pre-fix)
+
+cargo unit tests added in `nat/tests.rs` and `nat64_tests.rs`:
+
+- **#2122**:
+  - `static_nat_dnat_matches_external_ip_v4_with_cidr_mask` — external_ip
+    `203.0.113.5/32`, internal_ip `10.0.0.5/32`; assert `match_dnat` and
+    `match_snat` both succeed AND `external_ips()` contains the bare external
+    IP. (Fails pre-fix: both parses error → rule dropped → table empty.)
+  - `static_nat_dnat_matches_external_ip_v6_with_cidr_mask` — `.../128`.
+  - Keep the existing bare-IP and `static_nat_invalid_ip_skipped` tests
+    green (proves no regression of the skip path).
+- **#2123**:
+  - `nat64_pool_with_cidr_mask_yields_nonempty_pool` — pool addresses
+    `["100.64.0.1/32", "100.64.0.2/32"]`; assert `pool_v4.len() == 2` and
+    `allocate_v4_source` returns the expected round-robin addresses. (Fails
+    pre-fix: filter_map discards both → pool empty → allocate returns None.)
+  - `nat64_pool_mixed_bare_and_masked` — `["198.51.100.1", "198.51.100.5/32"]`
+    → both present (proves range-expanded + discrete-bare coexist).
+
+Gates: cargo build clean, full `cargo test` suite, 5x flake on the new named
+tests, full Go suite (no Go change, but run to confirm nothing breaks).
+
+## Smoke
+
+Loss-cluster NAT smoke is **pending parent-run** (the parent drives the NAT
+smoke via /security-matrix: trust→untrust SNAT). This PR does not run the
+loss-cluster smoke per the engineering directive.
+
+## Out of scope
+
+- Go-side mask stripping for static-NAT / NAT64 snapshots — deliberately not
+  done; the parse-side fix is canonical and sufficient. The DNAT Go-side
+  strip stays as-is (it strips before the snapshot; harmless either way).
+- NPTv6 prefix handling (`nptv6.rs` already splits on `/`).

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -437,6 +437,15 @@ ConfigSnapshot {
     source_nat_rules:[{from_zone, to_zone, src/dst, interface/pool metadata}]
     static_nat_rules:[{name, from_zone, external_ip, internal_ip}]
     flow:            {allow_dns_reply, allow_embedded_icmp}
+    # NAT address fields (static_nat external_ip/internal_ip and the NAT64
+    # source-pool addresses) may arrive in canonical Junos host form carrying
+    # a /32 (or /128) mask — the Go compiler keeps the prefix from
+    # `match destination-address X/32` / `then static-nat prefix Y/32` and
+    # address-range expansion stamps /32 on every produced pool IP. These are
+    # exact host IPs, so the Rust parse strips the mask before IpAddr parsing
+    # (mirroring the SNAT-pool idiom in nat/source.rs). Pre-#2122/#2123 the
+    # bare IpAddr::from_str rejected the mask and silently dropped the rule /
+    # pool entry (no translation, external IP not even recognized).
     map_pins:        {xsk_map, heartbeat_map, sessions_map}
     ha_groups:       [{rg_id, active, watchdog_ts}]
 }

--- a/userspace-dp/src/nat/static_nat.rs
+++ b/userspace-dp/src/nat/static_nat.rs
@@ -22,17 +22,29 @@ pub(crate) struct StaticNatTable {
     snat: FxHashMap<IpAddr, StaticNatEntry>,
 }
 
+/// Parse a NAT address that may carry a canonical host mask
+/// (`x.x.x.x/32`, `addr/128`). Junos emits static-NAT match/then in
+/// canonical prefix form, and the Go compiler copies that mask verbatim
+/// into the snapshot; `IpAddr::from_str` REJECTS CIDR notation, so the mask
+/// must be stripped before the parse or the rule is silently dropped (#2122).
+/// Mirrors the SNAT-pool idiom in `nat/source.rs`. A genuinely-malformed
+/// address still returns `None` so callers preserve their skip-on-invalid
+/// behavior.
+fn parse_nat_addr(s: &str) -> Option<IpAddr> {
+    s.split('/').next().unwrap_or(s).parse().ok()
+}
+
 impl StaticNatTable {
     pub(crate) fn from_snapshots(snaps: &[StaticNATRuleSnapshot]) -> Self {
         let mut table = StaticNatTable::default();
         for snap in snaps {
-            let external_ip: IpAddr = match snap.external_ip.parse() {
-                Ok(ip) => ip,
-                Err(_) => continue,
+            let external_ip: IpAddr = match parse_nat_addr(&snap.external_ip) {
+                Some(ip) => ip,
+                None => continue,
             };
-            let internal_ip: IpAddr = match snap.internal_ip.parse() {
-                Ok(ip) => ip,
-                Err(_) => continue,
+            let internal_ip: IpAddr = match parse_nat_addr(&snap.internal_ip) {
+                Some(ip) => ip,
+                None => continue,
             };
             let entry = StaticNatEntry {
                 external_ip,

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -344,6 +344,114 @@ fn static_nat_external_ips_iterator() {
     assert!(ips.contains(&"203.0.113.20".parse::<IpAddr>().unwrap()));
 }
 
+#[test]
+fn static_nat_canonical_cidr_mask_v4_installs_entry() {
+    // #2122: Junos emits static-NAT match/then in canonical prefix form
+    // ("203.0.113.5/32" / "10.0.0.5/32") and the Go compiler copies the mask
+    // verbatim into the snapshot. IpAddr::from_str rejects CIDR, so pre-fix
+    // every rule hit the Err/skip arm and was silently dropped — no
+    // translation occurred and the external IP was never registered as a
+    // local address. The parse must strip the /32 mask. This test FAILS on
+    // the unfixed code (table is empty, every assertion is None).
+    let table = StaticNatTable::from_snapshots(&[StaticNATRuleSnapshot {
+        name: "static-cidr".to_string(),
+        from_zone: "untrust".to_string(),
+        external_ip: "203.0.113.5/32".to_string(),
+        internal_ip: "10.0.0.5/32".to_string(),
+    }]);
+    // Inbound DNAT on the bare external IP -> bare internal IP.
+    assert_eq!(
+        table.match_dnat("203.0.113.5".parse().expect("ext"), "untrust"),
+        Some(NatDecision {
+            rewrite_src: None,
+            rewrite_dst: Some("10.0.0.5".parse().expect("int")),
+            ..NatDecision::default()
+        })
+    );
+    // Outbound SNAT on the bare internal IP -> bare external IP.
+    assert_eq!(
+        table.match_snat("10.0.0.5".parse().expect("int"), "trust"),
+        Some(NatDecision {
+            rewrite_src: Some("203.0.113.5".parse().expect("ext")),
+            rewrite_dst: None,
+            ..NatDecision::default()
+        })
+    );
+    // The external IP must be registered (bare, no mask) for local delivery
+    // recognition (forwarding_build iterates external_ips()).
+    let ips: Vec<IpAddr> = table.external_ips().copied().collect();
+    assert_eq!(ips, vec!["203.0.113.5".parse::<IpAddr>().unwrap()]);
+}
+
+#[test]
+fn static_nat_canonical_cidr_mask_v6_installs_entry() {
+    // IPv6 canonical host form carries /128; same root cause as the v4 case.
+    let table = StaticNatTable::from_snapshots(&[StaticNATRuleSnapshot {
+        name: "static-cidr-v6".to_string(),
+        from_zone: "untrust".to_string(),
+        external_ip: "2001:db8::1/128".to_string(),
+        internal_ip: "fd00::1/128".to_string(),
+    }]);
+    assert_eq!(
+        table.match_dnat("2001:db8::1".parse().expect("ext"), "untrust"),
+        Some(NatDecision {
+            rewrite_src: None,
+            rewrite_dst: Some("fd00::1".parse().expect("int")),
+            ..NatDecision::default()
+        })
+    );
+    assert_eq!(
+        table.match_snat("fd00::1".parse().expect("int"), "trust"),
+        Some(NatDecision {
+            rewrite_src: Some("2001:db8::1".parse().expect("ext")),
+            rewrite_dst: None,
+            ..NatDecision::default()
+        })
+    );
+    let ips: Vec<IpAddr> = table.external_ips().copied().collect();
+    assert_eq!(ips, vec!["2001:db8::1".parse::<IpAddr>().unwrap()]);
+}
+
+#[test]
+fn static_nat_cidr_and_bare_coexist() {
+    // A masked rule and a bare-IP rule must both install — stripping the mask
+    // on one must not regress the other.
+    let table = StaticNatTable::from_snapshots(&[
+        StaticNATRuleSnapshot {
+            name: "masked".to_string(),
+            from_zone: String::new(),
+            external_ip: "203.0.113.5/32".to_string(),
+            internal_ip: "10.0.0.5".to_string(),
+        },
+        StaticNATRuleSnapshot {
+            name: "bare".to_string(),
+            from_zone: String::new(),
+            external_ip: "203.0.113.6".to_string(),
+            internal_ip: "10.0.0.6/32".to_string(),
+        },
+    ]);
+    assert!(
+        table
+            .match_dnat("203.0.113.5".parse().expect("ext"), "any")
+            .is_some()
+    );
+    assert!(
+        table
+            .match_dnat("203.0.113.6".parse().expect("ext"), "any")
+            .is_some()
+    );
+    assert!(
+        table
+            .match_snat("10.0.0.5".parse().expect("int"), "any")
+            .is_some()
+    );
+    assert!(
+        table
+            .match_snat("10.0.0.6".parse().expect("int"), "any")
+            .is_some()
+    );
+}
+
 // --- DNAT table tests ---
 
 #[test]

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -71,10 +71,17 @@ impl Nat64State {
             let octets = addr.octets();
             let mut prefix_bytes = [0u8; 12];
             prefix_bytes.copy_from_slice(&octets[..12]);
+            // Pool addresses may carry a canonical host mask: an
+            // address-range source pool (`address A to B`) is expanded by
+            // the Go compiler into per-IP `/32` entries (#2123), and
+            // `Ipv4Addr::from_str` rejects CIDR notation. Strip the mask
+            // before parse (mirroring the SNAT-pool idiom in nat/source.rs)
+            // so range-form pools are not silently dropped, leaving pool_v4
+            // empty and NAT64 forward translation non-functional.
             let pool_v4: Vec<Ipv4Addr> = snap
                 .pool_addresses
                 .iter()
-                .filter_map(|s| s.parse().ok())
+                .filter_map(|s| s.split('/').next().unwrap_or(s).parse().ok())
                 .collect();
             prefixes.push(Nat64Prefix {
                 prefix_bytes,

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -66,6 +66,72 @@ fn empty_pool_returns_none() {
 }
 
 #[test]
+fn nat64_pool_with_cidr_mask_yields_nonempty_pool() {
+    // #2123: a range-form source pool (`address A to B`) is expanded by the
+    // Go compiler into per-IP /32 entries. Ipv4Addr::from_str rejects the
+    // mask, so pre-fix the filter_map discarded every entry, leaving pool_v4
+    // empty and allocate_v4_source returning None. The parse must strip the
+    // /32 mask. This test FAILS on the unfixed code.
+    let state = Nat64State::from_snapshots(&[NAT64RuleSnapshot {
+        name: "nat64-range".to_string(),
+        prefix: "64:ff9b::/96".to_string(),
+        pool_addresses: vec![
+            "100.64.0.1/32".to_string(),
+            "100.64.0.2/32".to_string(),
+        ],
+        no_v6_frag_header: false,
+    }]);
+    assert!(state.is_active());
+    assert_eq!(
+        state.prefixes[0].pool_v4.len(),
+        2,
+        "range-expanded /32 pool addresses must parse, not be dropped"
+    );
+    // Round-robin allocation must now succeed (was None pre-fix).
+    let a1 = state.allocate_v4_source(0).expect("alloc1");
+    let a2 = state.allocate_v4_source(0).expect("alloc2");
+    let a3 = state.allocate_v4_source(0).expect("alloc3 wraps");
+    assert_eq!(a1, Ipv4Addr::new(100, 64, 0, 1));
+    assert_eq!(a2, Ipv4Addr::new(100, 64, 0, 2));
+    assert_eq!(a3, Ipv4Addr::new(100, 64, 0, 1));
+}
+
+#[test]
+fn nat64_pool_mixed_bare_and_masked() {
+    // Discrete bare-IP `address` lines and range-expanded /32 entries must
+    // coexist: stripping the mask must not break the bare-IP parse.
+    let state = Nat64State::from_snapshots(&[NAT64RuleSnapshot {
+        name: "nat64-mixed".to_string(),
+        prefix: "64:ff9b::/96".to_string(),
+        pool_addresses: vec![
+            "198.51.100.1".to_string(),
+            "198.51.100.5/32".to_string(),
+        ],
+        no_v6_frag_header: false,
+    }]);
+    assert_eq!(state.prefixes[0].pool_v4.len(), 2);
+    assert!(state.prefixes[0].pool_v4.contains(&Ipv4Addr::new(198, 51, 100, 1)));
+    assert!(state.prefixes[0].pool_v4.contains(&Ipv4Addr::new(198, 51, 100, 5)));
+}
+
+#[test]
+fn nat64_pool_genuinely_invalid_still_dropped() {
+    // A genuinely-malformed pool address must still be discarded (the skip
+    // path is preserved), while a valid masked entry is kept.
+    let state = Nat64State::from_snapshots(&[NAT64RuleSnapshot {
+        name: "nat64-bad".to_string(),
+        prefix: "64:ff9b::/96".to_string(),
+        pool_addresses: vec![
+            "not-an-ip".to_string(),
+            "100.64.0.7/32".to_string(),
+        ],
+        no_v6_frag_header: false,
+    }]);
+    assert_eq!(state.prefixes[0].pool_v4.len(), 1);
+    assert!(state.prefixes[0].pool_v4.contains(&Ipv4Addr::new(100, 64, 0, 7)));
+}
+
+#[test]
 fn invalid_prefix_length_ignored() {
     let state = Nat64State::from_snapshots(&[NAT64RuleSnapshot {
         name: "bad".to_string(),


### PR DESCRIPTION
## Summary

Static 1:1 NAT (#2122) and NAT64 source pools (#2123) silently dropped
every rule/pool written in canonical Junos prefix form, because the Rust
dataplane parsed the address with the bare std parser, which rejects CIDR
notation. Same root cause, two modules — fixed together at the parse
boundary, mirroring the existing SNAT-pool idiom in `nat/source.rs`.

## Root cause (verified against source)

- **#2122** `StaticNatTable::from_snapshots` (`userspace-dp/src/nat/static_nat.rs`)
  parsed `external_ip`/`internal_ip` with `IpAddr::from_str`, which errors
  on `"203.0.113.5/32"`. The Go compiler keeps the canonical mask
  (`match destination-address X/32`, `then static-nat prefix Y/32`) and
  `buildStaticNATSnapshots` copies it verbatim, so every rule hit the skip
  arm: no 1:1 translation occurred AND the external IP was never registered
  as a local address (`forwarding_build` iterates `external_ips()`), so
  inbound traffic to it was not even recognized.
- **#2123** `Nat64State::from_snapshots` (`userspace-dp/src/nat64.rs`)
  collected the pool with `filter_map(|s| s.parse::<Ipv4Addr>())`. A
  range-form pool (`address A to B`) is expanded by the Go compiler into
  per-IP `/32` entries, so `filter_map` discarded all of them, leaving
  `pool_v4` empty → `allocate_v4_source` returns `None` → NAT64 forward
  translation non-functional.

## Fix

Strip the canonical host mask before the parse:
`s.split('/').next().unwrap_or(s).parse()` — the exact idiom already used
for SNAT pool addresses at `nat/source.rs:242`. Decided on the **parse
side** (not Go): it composes with any caller, fixes both the translation
maps and `external_ips()` local-address recognition in one place, and
matches the established codebase idiom. These are exact host IPs, so
stripping `/32` (`/128`) loses no prefix information. A genuinely
malformed address still returns `None`/is filtered (skip path preserved);
bare-IP configs are unaffected. Config-apply path only — no per-packet
cost, no allocation (the strip returns a borrowed `&str`). The NAT64
`/96` prefix parse is untouched (it already splits and validates).

## Test plan

- [x] cargo build clean (release)
- [x] cargo test --release: full suite green except a pre-existing,
  change-independent flake `afxdp::worker_queue::tests::concurrent_recovery_processes_each_command_exactly_once`
  (reproduced 1/12 on pristine `origin/master` with no NAT changes;
  branch does not touch `worker_queue`). All NAT tests deterministic.
- [x] 6 new regression tests, each verified **non-tautological** (FAIL
  pre-fix, pass post-fix): static v4/v6 `/32`-`/128`, static masked+bare
  coexist, NAT64 `/32` range pool yields non-empty pool + round-robin
  alloc, NAT64 mixed bare+masked, NAT64 malformed-still-dropped.
- [x] New NAT tests 5/5 flake check — deterministically green.
- [x] Go suite: `pkg/dataplane/userspace/...` + `pkg/config/...` pass
  (no Go change).
- [ ] **Loss-cluster NAT smoke (trust→untrust SNAT, /security-matrix) —
  PENDING PARENT-RUN.** Per directive this PR does not run the loss-cluster
  smoke; the parent drives the NAT smoke after independent review.

Plan doc: `docs/pr/2122-2123-nat-cidr-parse/plan.md`

Closes #2122
Closes #2123

🤖 Generated with [Claude Code](https://claude.com/claude-code)