### PR TITLE
#2118: unify per-policy hit-count display gate across CLI/gRPC/Prometheus

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,35 @@
 # Action Log
 
+## 2026-06-20 — #2118 policy hit-count display-gate consistency
+
+- **Timestamp**: 2026-06-20
+- **Action**: Diagnosed #2118 ("show security policies hit-count reads 0").
+  The increment→snapshot→wire→read→display chain is intact end-to-end and
+  Go-unit-tested (verified by static reading + an independent second-pass
+  agent). The observed all-0 was (a) deny rows correctly 0 — the loss
+  cluster has only explicit permit rules + default-policy deny-all, so
+  blocked traffic rode the implicit default-deny (aggregate counter, not
+  per-rule); (b) the smoke ran with `policy-stats` OFF; and (c) the genuine
+  bug: #2008 M4 gated ONLY the Prometheus collector on
+  `cfg.Security.PolicyStatsEnabled`, leaving the gRPC text/CLI/structured
+  display surfaces reading counters unconditionally — so the four surfaces
+  disagreed. Fix: gate all four surfaces on the same knob (display-only;
+  Rust increment stays always-on, no wire change). Added Go gate tests
+  (gRPC text hit-count + detail, structured GetPolicies, local CLI),
+  a `policies-hit-count` golden topic, and a Rust test proving explicit
+  permit AND explicit deny rules attribute per-rule hits while the implicit
+  default-deny does not. Flagged (not changed) the Junos divergence: xpf
+  preserves per-policy counts across recompile (Junos resets on commit).
+- **File(s)**: pkg/grpcapi/server_show_policies_text.go,
+  pkg/cli/cli_show_security.go, pkg/grpcapi/server_show_zones.go,
+  pkg/grpcapi/server_show_zones_test.go,
+  pkg/grpcapi/server_show_policies_hitcount_gate_test.go,
+  pkg/cli/cli_show_policies_hitcount_gate_test.go,
+  pkg/grpcapi/server_show_golden_test.go,
+  pkg/grpcapi/testdata/server_show_golden.json,
+  userspace-dp/src/policy_tests.rs, docs/feature-gaps.md,
+  docs/pr/2118-policy-hit-count/plan.md
+
 ## 2026-06-20 — #2079 nat pool-utilization-alarm lenient-disable runtime parity
 
 - **Timestamp**: 2026-06-20

--- a/_Log.md
+++ b/_Log.md
@@ -12,8 +12,10 @@
   per-rule); (b) the smoke ran with `policy-stats` OFF; and (c) the genuine
   bug: #2008 M4 gated ONLY the Prometheus collector on
   `cfg.Security.PolicyStatsEnabled`, leaving the gRPC text/CLI/structured
-  display surfaces reading counters unconditionally — so the four surfaces
-  disagreed. Fix: gate all four surfaces on the same knob (display-only;
+  display surfaces reading counters unconditionally — so the surfaces
+  disagreed. Fix: gate all SIX display surfaces (Prometheus, gRPC text
+  hit-count + detail, structured gRPC GetPolicies, REST policies endpoint,
+  local CLI hit-count + brief) on the same knob (display-only;
   Rust increment stays always-on, no wire change). Added Go gate tests
   (gRPC text hit-count + detail, structured GetPolicies, local CLI),
   a `policies-hit-count` golden topic, and a Rust test proving explicit
@@ -21,10 +23,12 @@
   default-deny does not. Flagged (not changed) the Junos divergence: xpf
   preserves per-policy counts across recompile (Junos resets on commit).
 - **File(s)**: pkg/grpcapi/server_show_policies_text.go,
-  pkg/cli/cli_show_security.go, pkg/grpcapi/server_show_zones.go,
+  pkg/cli/cli_show_security.go, pkg/cli/cli_show_security_dispatch.go,
+  pkg/grpcapi/server_show_zones.go, pkg/api/security.go,
   pkg/grpcapi/server_show_zones_test.go,
   pkg/grpcapi/server_show_policies_hitcount_gate_test.go,
   pkg/cli/cli_show_policies_hitcount_gate_test.go,
+  pkg/api/policy_counters_test.go,
   pkg/grpcapi/server_show_golden_test.go,
   pkg/grpcapi/testdata/server_show_golden.json,
   userspace-dp/src/policy_tests.rs, docs/feature-gaps.md,

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -568,14 +568,19 @@ drift) closed in `fix/2008-quickwins-batch1`:
   compiled into typed state but counters were always collected; Junos only
   maintains per-policy stats when the knob is enabled (default off).
   **#2118 follow-on (DONE):** M4 gated only the Prometheus collector; the
-  text/structured display surfaces (`show security policies hit-count` and
-  `... detail` in `pkg/grpcapi/server_show_policies_text.go` +
-  `pkg/cli/cli_show_security.go`, and the structured `GetPolicies` block in
-  `pkg/grpcapi/server_show_zones.go`) read the per-rule counters
-  unconditionally, so the four surfaces disagreed. They are now gated on the
-  same knob: when `policy-stats system-wide enable` is absent (the default),
-  all four surfaces report 0 per-rule counts; when set, they all report the
-  same live counts. The Rust increment (`policy.rs` `try_match_rule`) stays
+  text/structured display surfaces read the per-rule counters
+  unconditionally, so the surfaces disagreed. All SIX display surfaces are
+  now gated on the same knob: Prometheus (`metrics_counters.go`), gRPC text
+  `show security policies hit-count` and `... detail`
+  (`pkg/grpcapi/server_show_policies_text.go`), the structured gRPC
+  `GetPolicies` block (`pkg/grpcapi/server_show_zones.go`), the REST
+  `GET /api/v1/security/policies` endpoint (`pkg/api/security.go`), and the
+  local CLI `show security policies hit-count` + `... brief` views
+  (`pkg/cli/cli_show_security.go`, `pkg/cli/cli_show_security_dispatch.go`).
+  When `policy-stats system-wide enable` is absent (the default), all six
+  report 0 per-rule counts; when set, they all report the same live counts.
+  The raw read primitive (`Manager.ReadPolicyCounters`) and
+  `clear security policies hit-count` stay ungated by design. The Rust increment (`policy.rs` `try_match_rule`) stays
   always-on (a single relaxed atomic) — the gate is display-only, so enabling
   the knob surfaces counts that accrued while it was off, and no wire-format
   change was needed. NOTE: the per-rule hit-count chain itself (increment →

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -567,6 +567,34 @@ drift) closed in `fix/2008-quickwins-batch1`:
   is now gated on `cfg.Security.PolicyStatsEnabled`. Previously the flag
   compiled into typed state but counters were always collected; Junos only
   maintains per-policy stats when the knob is enabled (default off).
+  **#2118 follow-on (DONE):** M4 gated only the Prometheus collector; the
+  text/structured display surfaces (`show security policies hit-count` and
+  `... detail` in `pkg/grpcapi/server_show_policies_text.go` +
+  `pkg/cli/cli_show_security.go`, and the structured `GetPolicies` block in
+  `pkg/grpcapi/server_show_zones.go`) read the per-rule counters
+  unconditionally, so the four surfaces disagreed. They are now gated on the
+  same knob: when `policy-stats system-wide enable` is absent (the default),
+  all four surfaces report 0 per-rule counts; when set, they all report the
+  same live counts. The Rust increment (`policy.rs` `try_match_rule`) stays
+  always-on (a single relaxed atomic) — the gate is display-only, so enabling
+  the knob surfaces counts that accrued while it was off, and no wire-format
+  change was needed. NOTE: the per-rule hit-count chain itself (increment →
+  coordinator snapshot → `policy_rule_counters` wire array → Go
+  `ReadPolicyCounters`) was already intact and Go-unit-tested; #2118's "reads
+  0" was the display-gate inconsistency above plus the smoke running with the
+  knob off (and explicit-deny rows correctly reading 0 because the loss
+  cluster config has only explicit permit rules + `default-policy deny-all`,
+  so blocked traffic rides the implicit default-deny — which bumps the
+  aggregate `policy_deny` counter, not any per-rule counter).
+- **Per-policy hit-count reset semantics — INTENTIONAL Junos divergence
+  (FLAGGED, behavior unchanged).** Junos resets per-policy hit counters on a
+  commit that changes the policy. xpf PRESERVES counts across recompile as
+  long as the stable `from-zone->to-zone/name` rule identity is unchanged
+  (`PolicyCounterStore::reconcile_rules` retains the `Arc<PolicyRuleCounter>`
+  by `rule_id`; a renamed/deleted rule loses its count). This is deliberately
+  more useful for long-running rules and is left as-is; it is documented here
+  rather than changed. Per-policy hit counts are also per-node (node-local),
+  not cluster-aggregated, matching Junos per-node behavior.
 - **H14 `security flow power-mode-disable`** — DONE (threaded). The parsed
   `cfg.Security.Flow.PowerModeDisable` now reaches the dataplane via
   `FlowSnapshot.PowerModeDisable` (`pkg/dataplane/userspace/protocol.go` +

--- a/docs/pr/2118-policy-hit-count/plan.md
+++ b/docs/pr/2118-policy-hit-count/plan.md
@@ -55,7 +55,13 @@ paths were NOT gated:
 | gRPC text `show ... hit-count` | `pkg/grpcapi/server_show_policies_text.go:26` | NO |
 | gRPC text `show ... detail` | `pkg/grpcapi/server_show_policies_text.go:88` | NO |
 | Local CLI `show ... hit-count` | `pkg/cli/cli_show_security.go:21` | NO |
+| Local CLI `show ... brief` (Hits col) | `pkg/cli/cli_show_security_dispatch.go:176` | NO |
 | Structured gRPC `GetPolicies` | `pkg/grpcapi/server_show_zones.go:95` | NO |
+| REST `GET /api/v1/security/policies` | `pkg/api/security.go:103` | NO |
+
+(The CLI `brief` and REST surfaces were found by Codex's hostile review
+after the first three were gated — the gate is now uniform across all
+six display surfaces.)
 
 This is divergent behavior: the same traffic+config can read nonzero on
 CLI/gRPC but zero on Prometheus. That is the consistency defect #2118

--- a/docs/pr/2118-policy-hit-count/plan.md
+++ b/docs/pr/2118-policy-hit-count/plan.md
@@ -1,0 +1,118 @@
+# #2118 — `show security policies hit-count` reads 0: diagnosis + display-gate unification
+
+- **Status:** IMPLEMENT — diagnosis complete, fix is small + localized.
+- **Base:** origin/master `325d106838` (research base was `5fa964c13`).
+- **Research:** converged PLAN-READY (Option A) on branch
+  `research/2118-policy-hit-count`, r3 after hostile A+B + SMR.
+
+## 1. Diagnosis (code-read, no live break found)
+
+The per-rule hit-count chain is **intact end-to-end** and Go-unit-tested.
+Verified by static reading + an independent second-pass agent:
+
+- **Rust increment** (`policy.rs:1068`, `try_match_rule`): unconditional
+  `rule.hit_counter.add(packet_len)` on `src_ok && dst_ok`, for permit
+  AND deny actions. No `count`/policy-stats gate. Reached at BOTH call
+  sites: `poll_descriptor/mod.rs:1110` (ForwardCandidate) and `:2342`
+  (MissingNeighbor cold path), both passing the real `desc.len`.
+- **Arc identity:** worker increment and coordinator `counter_snapshots()`
+  (`policy.rs:502`) hit the SAME `Arc<PolicyRuleCounter>`
+  (`PolicyCounterStore.rule_hit_counter` reuses Arcs by `rule_id`;
+  `PolicyRule::clone` is a shallow Arc clone; the worker ArcSwap carries
+  `Arc::new(self.forwarding.clone())`).
+- **Wire:** `policy_rule_counters` is serde-default (Rust) / omitempty
+  (Go), numeric — #1961-safe. No field-name mismatch.
+- **Go read** (`policycounters.go:53`): `ReadPolicyCounters` maps
+  `policyID → rule_id → m.lastStatus.PolicyRuleCounters`; `m.lastStatus`
+  is populated by the 1Hz status loop. Unit-tested.
+
+So the live "all 0" is NOT a broken chain. It is explained by:
+
+1. **DENY rows = 0 is CORRECT** (confirmed). The loss cluster config
+   (`docs/ha-cluster-userspace.conf:34`) has `default-policy deny-all`
+   and ONLY explicit `permit` rules — no explicit deny rules. Blocked
+   traffic rode the implicit default-deny → aggregate `policy_deny`
+   increments, no per-rule counter. Not a bug. Do NOT "fix".
+2. **The smoke ran with `policy-stats` OFF** (confirmed). The config has
+   no `policy-stats system-wide enable`. Under Junos parity (#2008 M4),
+   0 is the intended read.
+3. **The PERMIT-row 0** is most plausibly the single-flow "0 is really 1"
+   artifact (one new flow bumps a permit rule by exactly packets=1),
+   amplified by the real bug below: the CLI/gRPC text + structured paths
+   are UNGATED, so they would show the raw (ungated) count regardless of
+   the knob. The display-gate inconsistency is the genuine, fixable bug.
+
+## 2. The genuine bug: display-gate inconsistency (#2008 M4 follow-on)
+
+#2008 M4 gated ONLY the Prometheus collector
+(`pkg/api/metrics_counters.go:131`, early return when
+`!cfg.Security.PolicyStatsEnabled`). The three text/structured display
+paths were NOT gated:
+
+| Surface | File | Gated on `PolicyStatsEnabled`? |
+|---------|------|--------------------------------|
+| Prometheus `policy_hits_total` | `pkg/api/metrics_counters.go:131` | YES (M4) |
+| gRPC text `show ... hit-count` | `pkg/grpcapi/server_show_policies_text.go:26` | NO |
+| gRPC text `show ... detail` | `pkg/grpcapi/server_show_policies_text.go:88` | NO |
+| Local CLI `show ... hit-count` | `pkg/cli/cli_show_security.go:21` | NO |
+| Structured gRPC `GetPolicies` | `pkg/grpcapi/server_show_zones.go:95` | NO |
+
+This is divergent behavior: the same traffic+config can read nonzero on
+CLI/gRPC but zero on Prometheus. That is the consistency defect #2118
+points at.
+
+## 3. Fix (Option A, Step 3 — display-gate unification)
+
+Gate the three ungated text/structured surfaces on
+`cfg.Security.PolicyStatsEnabled`, matching M4's Prometheus behavior, so
+all FOUR surfaces agree: when the knob is off, the per-rule counter
+columns read 0 (skip `ReadPolicyCounters`); when on, they show live
+counts.
+
+- Display-only gate. Keep the Rust increment always-on (single relaxed
+  atomic; §7 of research). No wire change, no `policy_stats_enabled`
+  flag, no protocol bump. Smallest diff, #1961-safe.
+- The table/struct SHAPE is unchanged (rows/fields still present); only
+  the count value is forced to 0 when the knob is off — consistent with
+  M4, which suppresses metric emission entirely (a metric reading 0 ==
+  not emitted, for a counter).
+
+No Rust change required: the increment chain is correct; the second
+increment site / MissingNeighbor over-count is a pre-existing transient
+that #2118 does not need to alter (no behavior change to packet path).
+
+## 4. Tests
+
+- **Go (manager):** `ReadPolicyCounters` is the read primitive and is
+  intentionally NOT gated (the gate belongs at the display layer so
+  Prometheus/CLI/gRPC can each decide). Existing tests stay green.
+- **Go (gRPC text):** new test — `showPoliciesHitCount` shows 0 for a
+  populated dataplane when `PolicyStatsEnabled` is false, nonzero when
+  true. Mirror for `GetPolicies` (structured) in
+  `server_show_zones_test.go`.
+- **Go (CLI):** new test for `cli_show_security.go showPoliciesHitCount`
+  gate parity (capture stdout).
+- **Go (golden):** add `policies-hit-count` to `goldenShowTopics` so a
+  future all-0/gate regression in the rendered table fails the golden.
+- **Rust:** assert `try_match_rule` bumps the snapshotted counter for a
+  permit AND a deny match, and that `counter_snapshots` reflects it
+  (fills the gap that let the "is the chain alive?" question stand).
+
+## 5. Junos divergence — FLAG for the user (do NOT change unilaterally)
+
+xpf PRESERVES per-policy hit counts across a recompile as long as the
+stable `from→to/name` identity is unchanged (`reconcile_rules` retains
+the Arc). Junos RESETS per-policy hit counters on a commit that changes
+the policy. The research recommends KEEPING the preserve-on-recompile
+behavior (more useful for long-running rules) and documenting the
+divergence. This plan does NOT change it; it is surfaced for a decision.
+
+## 6. Out of scope
+
+- No wire-protocol change.
+- No change to aggregate flow counters (they work).
+- No change to the Rust increment or the two-site invariant (no live
+  break; #2118 is a display-consistency bug).
+- The CLI `showPoliciesDetail` does not render counters at all
+  (`_ = ruleID`) while gRPC's does — a separate display gap, not the
+  hit-count surface #2118 names. Noted, not fixed here.

--- a/pkg/api/policy_counters_test.go
+++ b/pkg/api/policy_counters_test.go
@@ -88,8 +88,30 @@ func scheduledCounterPolicyID(t *testing.T, store *configstore.Store) uint32 {
 	return 0
 }
 
+// enablePolicyStatsAPI commits `security policy-stats system-wide
+// enable` onto an existing store so the per-policy display gate (#2118)
+// admits the live counters. Kept separate from newSchedulerCounterAPI
+// Store so the M4 gate-off test (TestCollectPolicyCountersGatedOnPolicy
+// Stats) can keep using the knob-disabled store.
+func enablePolicyStatsAPI(t *testing.T, store *configstore.Store) {
+	t.Helper()
+	// newSchedulerCounterAPIStore leaves the store in configure mode
+	// (EnterConfigure was called and Commit does not exit it), so set the
+	// knob directly without re-entering configure.
+	if err := store.SetFromInput("security policy-stats system-wide enable"); err != nil {
+		t.Fatalf("SetFromInput(policy-stats) error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if cfg := store.ActiveConfig(); cfg == nil || !cfg.Security.PolicyStatsEnabled {
+		t.Fatal("policy-stats enable did not take effect")
+	}
+}
+
 func TestPoliciesHandlerExposesScheduledRuleCounters(t *testing.T) {
 	store := newSchedulerCounterAPIStore(t)
+	enablePolicyStatsAPI(t, store)
 	policyID := scheduledCounterPolicyID(t, store)
 	s := &Server{
 		store: store,
@@ -139,4 +161,98 @@ func TestPoliciesHandlerExposesScheduledRuleCounters(t *testing.T) {
 		}
 	}
 	t.Fatal("scheduled-allow rule not found in API response")
+}
+
+// newPolicyCounterAPIStoreNoStats builds the same fixture as
+// newSchedulerCounterAPIStore but WITHOUT `policy-stats system-wide
+// enable`, so the #2118 display gate must suppress the REST counters.
+func newPolicyCounterAPIStoreNoStats(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+schedulers {
+    scheduler workhours {
+        daily;
+    }
+}
+security {
+    zones {
+        security-zone dmz;
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone dmz {
+            policy plain-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        from-zone trust to-zone untrust {
+            policy scheduled-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+                scheduler-name workhours;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if cfg := store.ActiveConfig(); cfg == nil || cfg.Security.PolicyStatsEnabled {
+		t.Fatal("test precondition: policy-stats must be disabled in this store")
+	}
+	return store
+}
+
+// TestPoliciesHandlerGatesCountersOnPolicyStats verifies the #2118
+// display gate on the REST `GET /api/v1/security/policies` endpoint:
+// with a fully populated dataplane but `policy-stats` OFF, every rule's
+// hit_packets/hit_bytes are 0, matching the Prometheus collector and the
+// CLI/gRPC surfaces. Without the gate the same fixture (verified nonzero
+// by TestPoliciesHandlerExposesScheduledRuleCounters) would leak counts.
+func TestPoliciesHandlerGatesCountersOnPolicyStats(t *testing.T) {
+	store := newPolicyCounterAPIStoreNoStats(t)
+	policyID := scheduledCounterPolicyID(t, store)
+	s := &Server{
+		store: store,
+		dp: &schedulerCounterAPIDP{
+			Manager: dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{
+				1:        {Packets: 99, Bytes: 9900},
+				policyID: {Packets: 17, Bytes: 1700},
+			},
+		},
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []PolicyInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	for _, policy := range resp.Data {
+		for _, rule := range policy.Rules {
+			if rule.HitPackets != 0 || rule.HitBytes != 0 {
+				t.Fatalf("policy %s->%s rule %q: counters = %d/%d, want 0/0 (policy-stats off)",
+					policy.FromZone, policy.ToZone, rule.Name, rule.HitPackets, rule.HitBytes)
+			}
+		}
+	}
 }

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -73,6 +73,12 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
+	// Honor `set security policy-stats system-wide enable` (#2008 M4 /
+	// #2118): per-policy hit counters are populated only when policy-stats
+	// is enabled system-wide (default off), matching the Prometheus
+	// collector and the CLI/gRPC display surfaces. When the knob is off,
+	// hit_packets/hit_bytes stay 0 (we skip the dataplane read).
+	statsEnabled := cfg.Security.PolicyStatsEnabled
 	var policySetID uint32
 	var result []PolicyInfo
 	for _, zpp := range cfg.Security.Policies {
@@ -100,7 +106,7 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				pr.Applications = []string{}
 			}
 
-			if s.dp != nil && s.dp.IsLoaded() {
+			if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
 				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(len(pi.Rules))
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets

--- a/pkg/cli/cli_show_policies_hitcount_gate_test.go
+++ b/pkg/cli/cli_show_policies_hitcount_gate_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #2118: the local-CLI `show security policies hit-count` table must
+// honor `security policy-stats system-wide enable` exactly like the
+// Prometheus collector (#2008 M4) and the gRPC surfaces, so all surfaces
+// agree. These tests assert the "Policy count" column reflects live
+// counts when the knob is on and reads 0 when off, for the SAME
+// populated dataplane.
+
+type policyCounterCLIDP struct {
+	*dataplane.Manager
+	counters map[uint32]dataplane.CounterValue
+}
+
+func (d *policyCounterCLIDP) IsLoaded() bool { return true }
+
+func (d *policyCounterCLIDP) ReadPolicyCounters(policyID uint32) (dataplane.CounterValue, error) {
+	return d.counters[policyID], nil
+}
+
+func newPolicyHitCountCLIStore(t *testing.T, statsEnabled bool) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	cmds := []string{
+		"security zones security-zone trust",
+		"security zones security-zone untrust",
+		"security policies from-zone trust to-zone untrust policy allow-web match source-address any",
+		"security policies from-zone trust to-zone untrust policy allow-web match destination-address any",
+		"security policies from-zone trust to-zone untrust policy allow-web match application any",
+		"security policies from-zone trust to-zone untrust policy allow-web then permit",
+	}
+	if statsEnabled {
+		cmds = append(cmds, "security policy-stats system-wide enable")
+	}
+	for _, cmd := range cmds {
+		if err := store.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q) error = %v", cmd, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil || cfg.Security.PolicyStatsEnabled != statsEnabled {
+		t.Fatalf("PolicyStatsEnabled precondition not met (want %v)", statsEnabled)
+	}
+	return store
+}
+
+func TestCLIShowPoliciesHitCountHonorsPolicyStats(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		statsOn bool
+	}{
+		{name: "enabled", statsOn: true},
+		{name: "disabled", statsOn: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newPolicyHitCountCLIStore(t, tc.statsOn)
+			cfg := store.ActiveConfig()
+			// trust->untrust is the only policy set -> set 0, rule 0.
+			ruleID := uint32(0)
+			c := &CLI{
+				store: store,
+				dp: &policyCounterCLIDP{
+					Manager:  dataplane.New(),
+					counters: map[uint32]dataplane.CounterValue{ruleID: {Packets: 42, Bytes: 4242}},
+				},
+			}
+
+			var callErr error
+			out := captureStdout(t, func() {
+				callErr = c.showPoliciesHitCount(cfg, "", "")
+			})
+			if callErr != nil {
+				t.Fatalf("showPoliciesHitCount() error = %v", callErr)
+			}
+
+			var row string
+			for _, line := range strings.Split(out, "\n") {
+				if strings.Contains(line, "allow-web") {
+					row = line
+					break
+				}
+			}
+			if row == "" {
+				t.Fatalf("allow-web row not found in output:\n%s", out)
+			}
+			if tc.statsOn {
+				if !strings.Contains(row, "42") {
+					t.Fatalf("policy-stats ON: allow-web row missing live count 42:\n%s", row)
+				}
+			} else {
+				if strings.Contains(row, "42") {
+					t.Fatalf("policy-stats OFF: allow-web row leaked live count 42 (must be 0):\n%s", row)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cli/cli_show_policies_hitcount_gate_test.go
+++ b/pkg/cli/cli_show_policies_hitcount_gate_test.go
@@ -111,3 +111,55 @@ func TestCLIShowPoliciesHitCountHonorsPolicyStats(t *testing.T) {
 		})
 	}
 }
+
+// TestCLIShowPoliciesBriefHonorsPolicyStats covers the `show security
+// policies brief` "Hits" column gate (#2118 — the brief view is a
+// separate display surface from the hit-count table).
+func TestCLIShowPoliciesBriefHonorsPolicyStats(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		statsOn bool
+	}{
+		{name: "enabled", statsOn: true},
+		{name: "disabled", statsOn: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newPolicyHitCountCLIStore(t, tc.statsOn)
+			c := &CLI{
+				store: store,
+				dp: &policyCounterCLIDP{
+					Manager:  dataplane.New(),
+					counters: map[uint32]dataplane.CounterValue{0: {Packets: 42, Bytes: 4242}},
+				},
+			}
+
+			var callErr error
+			out := captureStdout(t, func() {
+				callErr = c.handleShowSecurity([]string{"policies", "brief"})
+			})
+			if callErr != nil {
+				t.Fatalf("handleShowSecurity(policies brief) error = %v", callErr)
+			}
+
+			var row string
+			for _, line := range strings.Split(out, "\n") {
+				if strings.Contains(line, "allow-web") {
+					row = line
+					break
+				}
+			}
+			if row == "" {
+				t.Fatalf("allow-web row not found in brief output:\n%s", out)
+			}
+			if tc.statsOn {
+				if !strings.Contains(row, "42") {
+					t.Fatalf("policy-stats ON: brief allow-web row missing live hits 42:\n%s", row)
+				}
+			} else {
+				if strings.Contains(row, "42") {
+					t.Fatalf("policy-stats OFF: brief allow-web row leaked live hits 42:\n%s", row)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -24,6 +24,16 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 		return nil
 	}
 
+	// Honor `set security policy-stats system-wide enable` (#2008 M4 /
+	// #2118): per-policy hit counters are maintained and displayed only
+	// when policy-stats is enabled system-wide (default off). The
+	// Prometheus collector already gates on this knob; gate the CLI
+	// hit-count table identically so the CLI, gRPC text, structured
+	// gRPC, and Prometheus surfaces all report the SAME values. When the
+	// knob is off the "Policy count" column reads 0 (we skip the
+	// dataplane read).
+	statsEnabled := cfg.Security.PolicyStatsEnabled
+
 	fmt.Println("Logical system: root-logical-system")
 	fmt.Printf("%-8s%-17s%-18s%-24s%-14s%s\n",
 		"Index", "From zone", "To zone", "Name", "Policy count", "Action")
@@ -49,8 +59,10 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 			}
 			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 			var count uint64
-			if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
-				count = counters.Packets
+			if statsEnabled {
+				if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
+					count = counters.Packets
+				}
 			}
 			fmt.Printf("%-8d%-17s%-18s%-24s%-14d%s\n",
 				index, zpp.FromZone, zpp.ToZone, pol.Name, count, action)
@@ -70,8 +82,10 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 			}
 			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 			var count uint64
-			if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
-				count = counters.Packets
+			if statsEnabled {
+				if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
+					count = counters.Packets
+				}
 			}
 			fmt.Printf("%-8d%-17s%-18s%-24s%-14d%s\n",
 				index, "junos-global", "junos-global", pol.Name, count, action)

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -179,13 +179,15 @@ func (c *CLI) handleShowSecurity(args []string) error {
 						action = "reject"
 					}
 					ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
-					hits := "-"
+					// Default to "0" (consistent with the hit-count table
+					// and the gRPC/REST surfaces, which render 0 whenever
+					// the counter is unavailable or the knob is off);
+					// overwrite only on a successful gated read.
+					hits := "0"
 					if statsEnabled && c.dp != nil && c.dp.IsLoaded() {
 						if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
 							hits = fmt.Sprintf("%d", counters.Packets)
 						}
-					} else if !statsEnabled {
-						hits = "0"
 					}
 					fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
 						zpp.FromZone, zpp.ToZone, pol.Name, action, hits)
@@ -203,13 +205,13 @@ func (c *CLI) handleShowSecurity(args []string) error {
 						action = "reject"
 					}
 					ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
-					hits := "-"
+					// Default to "0" for the same cross-surface
+					// consistency reason as the zone-pair branch above.
+					hits := "0"
 					if statsEnabled && c.dp != nil && c.dp.IsLoaded() {
 						if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
 							hits = fmt.Sprintf("%d", counters.Packets)
 						}
-					} else if !statsEnabled {
-						hits = "0"
 					}
 					fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
 						"*", "*", pol.Name, action, hits)

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -150,6 +150,13 @@ func (c *CLI) handleShowSecurity(args []string) error {
 		}
 		brief := len(args) >= 2 && args[1] == "brief"
 		if brief {
+			// Honor `set security policy-stats system-wide enable`
+			// (#2008 M4 / #2118): the brief view's "Hits" column is
+			// per-policy hit-count display, so it must obey the same
+			// knob as the hit-count table, the gRPC/REST surfaces, and
+			// the Prometheus collector. When the knob is off the column
+			// reads 0 (we skip the dataplane read).
+			statsEnabled := cfg.Security.PolicyStatsEnabled
 			// Brief tabular summary
 			fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
 				"From", "To", "Name", "Action", "Hits")
@@ -173,10 +180,12 @@ func (c *CLI) handleShowSecurity(args []string) error {
 					}
 					ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 					hits := "-"
-					if c.dp != nil && c.dp.IsLoaded() {
+					if statsEnabled && c.dp != nil && c.dp.IsLoaded() {
 						if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
 							hits = fmt.Sprintf("%d", counters.Packets)
 						}
+					} else if !statsEnabled {
+						hits = "0"
 					}
 					fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
 						zpp.FromZone, zpp.ToZone, pol.Name, action, hits)
@@ -195,10 +204,12 @@ func (c *CLI) handleShowSecurity(args []string) error {
 					}
 					ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 					hits := "-"
-					if c.dp != nil && c.dp.IsLoaded() {
+					if statsEnabled && c.dp != nil && c.dp.IsLoaded() {
 						if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
 							hits = fmt.Sprintf("%d", counters.Packets)
 						}
+					} else if !statsEnabled {
+						hits = "0"
 					}
 					fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
 						"*", "*", pol.Name, action, hits)

--- a/pkg/grpcapi/server_show_golden_test.go
+++ b/pkg/grpcapi/server_show_golden_test.go
@@ -83,6 +83,11 @@ var goldenShowTopics = []string{
 	"test-policy:from=trust,to=untrust,src=10.0.1.1,dst=10.0.2.1,port=80,proto=tcp",
 	"test-routing:dest=10.0.2.1",
 	"test-zone:interface=ge-0-0-0.0",
+	// #2118: lock the per-policy hit-count table so a future all-0 /
+	// gate regression in the rendered table fails the golden. The golden
+	// config has `policy-stats system-wide enable` set (showGolden-
+	// ConfigCommands) so the table renders the policy-stats-gated path.
+	"policies-hit-count",
 	"firewall-filter:bandwidth-output",
 	"firewall-filter:bandwidth-output:inet",
 	// switch cases (cfg-rendered)
@@ -174,6 +179,9 @@ var showGoldenConfigCommands = []string{
 	"security policies from-zone trust to-zone untrust policy p1 match destination-address any",
 	"security policies from-zone trust to-zone untrust policy p1 match application any",
 	"security policies from-zone trust to-zone untrust policy p1 then permit",
+	// #2118: enable policy-stats so the policies-hit-count golden topic
+	// renders the gated display path (counters read from the dataplane).
+	"security policy-stats system-wide enable",
 	"security alg sip disable",
 	"security dynamic-address feed-server office url http://example.com/feed feed-name blocklist",
 	"security address-book global address host1 10.0.1.1/32",

--- a/pkg/grpcapi/server_show_golden_test.go
+++ b/pkg/grpcapi/server_show_golden_test.go
@@ -83,10 +83,15 @@ var goldenShowTopics = []string{
 	"test-policy:from=trust,to=untrust,src=10.0.1.1,dst=10.0.2.1,port=80,proto=tcp",
 	"test-routing:dest=10.0.2.1",
 	"test-zone:interface=ge-0-0-0.0",
-	// #2118: lock the per-policy hit-count table so a future all-0 /
-	// gate regression in the rendered table fails the golden. The golden
-	// config has `policy-stats system-wide enable` set (showGolden-
-	// ConfigCommands) so the table renders the policy-stats-gated path.
+	// #2118: lock the per-policy hit-count table SHAPE (headers, columns,
+	// the gated render path) so a future regression in the rendered table
+	// fails the golden. The golden config has `policy-stats system-wide
+	// enable` set (showGoldenConfigCommands) so the table takes the
+	// stats-enabled branch; the golden server's dataplane is unloaded
+	// (dataplane.New(), IsLoaded()==false), so the counter columns read
+	// 0/0 — the regression value is the table layout and the fact that
+	// the gated path renders, not non-zero counts (those are covered by
+	// the dedicated gate tests with a fake loaded dataplane).
 	"policies-hit-count",
 	"firewall-filter:bandwidth-output",
 	"firewall-filter:bandwidth-output:inet",
@@ -180,7 +185,9 @@ var showGoldenConfigCommands = []string{
 	"security policies from-zone trust to-zone untrust policy p1 match application any",
 	"security policies from-zone trust to-zone untrust policy p1 then permit",
 	// #2118: enable policy-stats so the policies-hit-count golden topic
-	// renders the gated display path (counters read from the dataplane).
+	// takes the stats-enabled display branch. (The golden server's
+	// dataplane is unloaded, so the counter columns still render 0/0;
+	// non-zero counter behavior is covered by the dedicated gate tests.)
 	"security policy-stats system-wide enable",
 	"security alg sip disable",
 	"security dynamic-address feed-server office url http://example.com/feed feed-name blocklist",

--- a/pkg/grpcapi/server_show_policies_hitcount_gate_test.go
+++ b/pkg/grpcapi/server_show_policies_hitcount_gate_test.go
@@ -1,0 +1,179 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #2118: `show security policies hit-count` (and the structured /
+// Prometheus surfaces) must honor `security policy-stats system-wide
+// enable`. #2008 M4 gated only the Prometheus collector; the gRPC text +
+// CLI + structured paths read counters unconditionally, so the four
+// surfaces disagreed. These tests assert the gRPC text `hit-count` and
+// `detail` tables show live counts when the knob is on and 0 when off,
+// for the SAME populated dataplane.
+
+// newHitCountGateStore builds a single permit policy with a known
+// per-rule counter slot. `statsEnabled` toggles the policy-stats knob.
+func newHitCountGateStore(t *testing.T, statsEnabled bool) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	cmds := []string{
+		"security zones security-zone trust",
+		"security zones security-zone untrust",
+		"security policies from-zone trust to-zone untrust policy allow-web match source-address any",
+		"security policies from-zone trust to-zone untrust policy allow-web match destination-address any",
+		"security policies from-zone trust to-zone untrust policy allow-web match application any",
+		"security policies from-zone trust to-zone untrust policy allow-web then permit",
+	}
+	if statsEnabled {
+		cmds = append(cmds, "security policy-stats system-wide enable")
+	}
+	for _, cmd := range cmds {
+		if err := store.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q) error = %v", cmd, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	if cfg.Security.PolicyStatsEnabled != statsEnabled {
+		t.Fatalf("PolicyStatsEnabled = %v, want %v", cfg.Security.PolicyStatsEnabled, statsEnabled)
+	}
+	return store
+}
+
+// allowWebPolicyID resolves the dataplane counter slot for the single
+// trust->untrust allow-web rule so the fake dataplane can serve it.
+func allowWebPolicyID(t *testing.T, store *configstore.Store) uint32 {
+	t.Helper()
+	cfg := store.ActiveConfig()
+	for setID, zpp := range cfg.Security.Policies {
+		for ruleIndex, pol := range zpp.Policies {
+			if pol.Name == "allow-web" {
+				return uint32(setID)*dataplane.MaxRulesPerPolicy + uint32(ruleIndex)
+			}
+		}
+	}
+	t.Fatal("allow-web policy not found")
+	return 0
+}
+
+func TestShowPoliciesHitCountHonorsPolicyStats(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		statsOn     bool
+		wantPackets string // substring that must / must-not appear
+	}{
+		{name: "enabled", statsOn: true, wantPackets: "42"},
+		{name: "disabled", statsOn: false, wantPackets: "0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newHitCountGateStore(t, tc.statsOn)
+			ruleID := allowWebPolicyID(t, store)
+			s := &Server{
+				store: store,
+				dp: &schedulerCounterGRPCDP{
+					Manager: dataplane.New(),
+					counters: map[uint32]dataplane.CounterValue{
+						ruleID: {Packets: 42, Bytes: 4242},
+					},
+				},
+			}
+
+			resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "policies-hit-count"})
+			if err != nil {
+				t.Fatalf("ShowText(policies-hit-count) error = %v", err)
+			}
+			out := resp.GetOutput()
+
+			// Locate the allow-web data row.
+			var row string
+			for _, line := range strings.Split(out, "\n") {
+				if strings.Contains(line, "allow-web") {
+					row = line
+					break
+				}
+			}
+			if row == "" {
+				t.Fatalf("allow-web row not found in output:\n%s", out)
+			}
+			if tc.statsOn {
+				if !strings.Contains(row, "42") || !strings.Contains(row, "4242") {
+					t.Fatalf("policy-stats ON: allow-web row missing live counts (want 42/4242):\n%s", row)
+				}
+			} else {
+				if strings.Contains(row, "42") || strings.Contains(row, "4242") {
+					t.Fatalf("policy-stats OFF: allow-web row leaked live counts (must be 0):\n%s", row)
+				}
+				// The Packets/Bytes columns must read 0.
+				fields := strings.Fields(row)
+				if len(fields) < 2 {
+					t.Fatalf("malformed row: %q", row)
+				}
+				if fields[len(fields)-1] != "0" || fields[len(fields)-2] != "0" {
+					t.Fatalf("policy-stats OFF: trailing Packets/Bytes columns must be 0/0:\n%s", row)
+				}
+			}
+		})
+	}
+}
+
+func TestShowPoliciesDetailHonorsPolicyStats(t *testing.T) {
+	// policy-stats OFF: the "Session statistics" block (per-policy hit
+	// count) must be suppressed even though the dataplane has counts.
+	store := newHitCountGateStore(t, false)
+	ruleID := allowWebPolicyID(t, store)
+	s := &Server{
+		store: store,
+		dp: &schedulerCounterGRPCDP{
+			Manager: dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{
+				ruleID: {Packets: 42, Bytes: 4242},
+			},
+		},
+	}
+
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "policies-detail"})
+	if err != nil {
+		t.Fatalf("ShowText(policies-detail) error = %v", err)
+	}
+	if strings.Contains(resp.GetOutput(), "Session statistics") {
+		t.Fatalf("policy-stats OFF: detail leaked Session statistics block:\n%s", resp.GetOutput())
+	}
+
+	// policy-stats ON: the block appears with the live counts.
+	store = newHitCountGateStore(t, true)
+	ruleID = allowWebPolicyID(t, store)
+	s = &Server{
+		store: store,
+		dp: &schedulerCounterGRPCDP{
+			Manager: dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{
+				ruleID: {Packets: 42, Bytes: 4242},
+			},
+		},
+	}
+	resp, err = s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "policies-detail"})
+	if err != nil {
+		t.Fatalf("ShowText(policies-detail) error = %v", err)
+	}
+	if !strings.Contains(resp.GetOutput(), "Session statistics") ||
+		!strings.Contains(resp.GetOutput(), "42 packets, 4242 bytes") {
+		t.Fatalf("policy-stats ON: detail missing Session statistics with live counts:\n%s", resp.GetOutput())
+	}
+}

--- a/pkg/grpcapi/server_show_policies_hitcount_gate_test.go
+++ b/pkg/grpcapi/server_show_policies_hitcount_gate_test.go
@@ -75,12 +75,11 @@ func allowWebPolicyID(t *testing.T, store *configstore.Store) uint32 {
 
 func TestShowPoliciesHitCountHonorsPolicyStats(t *testing.T) {
 	for _, tc := range []struct {
-		name        string
-		statsOn     bool
-		wantPackets string // substring that must / must-not appear
+		name    string
+		statsOn bool
 	}{
-		{name: "enabled", statsOn: true, wantPackets: "42"},
-		{name: "disabled", statsOn: false, wantPackets: "0"},
+		{name: "enabled", statsOn: true},
+		{name: "disabled", statsOn: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := newHitCountGateStore(t, tc.statsOn)

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -44,6 +44,17 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 			}
 		}
 	}
+	// Honor `set security policy-stats system-wide enable` (#2008 M4 /
+	// #2118): Junos maintains and displays per-policy hit counters only
+	// when policy-stats is enabled system-wide (default off). The
+	// Prometheus collector (metrics_counters.go) already gates on this
+	// knob; gate the text/structured display surfaces identically so all
+	// four surfaces (Prometheus, gRPC text hit-count, gRPC text detail,
+	// structured gRPC GetPolicies, local CLI) report the SAME values.
+	// When the knob is off, the per-rule counter columns read 0 (we skip
+	// the dataplane read) rather than surfacing live counts the operator
+	// did not enable.
+	statsEnabled := cfg.Security.PolicyStatsEnabled
 	fmt.Fprintf(buf, "%-12s %-12s %-24s %-8s %12s %16s\n",
 		"From zone", "To zone", "Policy", "Action", "Packets", "Bytes")
 	fmt.Fprintln(buf, strings.Repeat("-", 88))
@@ -65,7 +76,7 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 			}
 			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 			var pkts, bytes uint64
-			if s.dp != nil && s.dp.IsLoaded() {
+			if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
 				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
 					pkts = counters.Packets
 					bytes = counters.Bytes
@@ -105,6 +116,10 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 			}
 		}
 	}
+	// Same policy-stats gate as showPoliciesHitCount (#2008 M4 / #2118):
+	// the "Session statistics" block is per-policy hit-count display, so
+	// it must honor the knob for cross-surface consistency.
+	statsEnabled := cfg.Security.PolicyStatsEnabled
 	policySetID := uint32(0)
 	for _, zpp := range cfg.Security.Policies {
 		if (filterFrom != "" && zpp.FromZone != filterFrom) ||
@@ -152,7 +167,7 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 			if pol.Count {
 				fmt.Fprintf(buf, "      count\n")
 			}
-			if s.dp != nil && s.dp.IsLoaded() {
+			if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
 				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
 					fmt.Fprintf(buf, "    Session statistics:\n")
 					fmt.Fprintf(buf, "      %d packets, %d bytes\n", counters.Packets, counters.Bytes)
@@ -202,7 +217,7 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 			if pol.Count {
 				fmt.Fprintf(buf, "      count\n")
 			}
-			if s.dp != nil && s.dp.IsLoaded() {
+			if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
 				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
 					fmt.Fprintf(buf, "    Session statistics:\n")
 					fmt.Fprintf(buf, "      %d packets, %d bytes\n", counters.Packets, counters.Bytes)

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -65,6 +65,12 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 		return &pb.GetPoliciesResponse{}, nil
 	}
 
+	// Honor `set security policy-stats system-wide enable` (#2008 M4 /
+	// #2118): per-policy hit counters are populated only when policy-stats
+	// is enabled system-wide (default off), matching the Prometheus
+	// collector and the CLI/gRPC text surfaces. When the knob is off,
+	// HitPackets/HitBytes stay 0 (we skip the dataplane read).
+	statsEnabled := cfg.Security.PolicyStatsEnabled
 	resp := &pb.GetPoliciesResponse{}
 	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
@@ -92,7 +98,7 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 			if pr.Applications == nil {
 				pr.Applications = []string{}
 			}
-			if s.dp != nil && s.dp.IsLoaded() {
+			if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
 				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
@@ -134,7 +140,7 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 			if pr.Applications == nil {
 				pr.Applications = []string{}
 			}
-			if s.dp != nil && s.dp.IsLoaded() {
+			if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
 				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets

--- a/pkg/grpcapi/server_show_zones_test.go
+++ b/pkg/grpcapi/server_show_zones_test.go
@@ -37,6 +37,9 @@ schedulers {
     }
 }
 security {
+    policy-stats {
+        system-wide enable;
+    }
     zones {
         security-zone dmz;
         security-zone trust;
@@ -133,6 +136,99 @@ func TestGetPoliciesExposesScheduledRuleCounters(t *testing.T) {
 		}
 	}
 	t.Fatal("scheduled-allow rule not found in gRPC response")
+}
+
+// newPolicyCounterGRPCStoreNoStats builds the same policy fixture as
+// newSchedulerCounterGRPCStore but WITHOUT `policy-stats system-wide
+// enable`, so the #2118 display gate must suppress the counters.
+func newPolicyCounterGRPCStoreNoStats(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+schedulers {
+    scheduler workhours {
+        daily;
+    }
+}
+security {
+    zones {
+        security-zone dmz;
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone dmz {
+            policy plain-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        from-zone trust to-zone untrust {
+            policy scheduled-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+                scheduler-name workhours;
+            }
+        }
+        global {
+            policy global-scheduled {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+                scheduler-name workhours;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if cfg := store.ActiveConfig(); cfg == nil || cfg.Security.PolicyStatsEnabled {
+		t.Fatal("test precondition: policy-stats must be disabled in this store")
+	}
+	return store
+}
+
+// TestGetPoliciesGatesCountersOnPolicyStats verifies the #2118 display
+// gate: with a fully populated dataplane but `policy-stats` OFF, the
+// structured GetPolicies response reports zero HitPackets/HitBytes —
+// matching the Prometheus collector (#2008 M4) and the CLI/gRPC text
+// surfaces. Without the gate the same fixture (verified nonzero by
+// TestGetPoliciesExposesScheduledRuleCounters) would leak live counts.
+func TestGetPoliciesGatesCountersOnPolicyStats(t *testing.T) {
+	store := newPolicyCounterGRPCStoreNoStats(t)
+	policyID := scheduledCounterGRPCPolicyID(t, store)
+	s := &Server{
+		store: store,
+		dp: &schedulerCounterGRPCDP{
+			Manager: dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{
+				1:                               {Packets: 99, Bytes: 9900},
+				policyID:                        {Packets: 23, Bytes: 2300},
+				dataplane.MaxRulesPerPolicy * 2: {Packets: 31, Bytes: 3100},
+			},
+		},
+	}
+
+	resp, err := s.GetPolicies(context.Background(), &pb.GetPoliciesRequest{})
+	if err != nil {
+		t.Fatalf("GetPolicies() error = %v", err)
+	}
+	for _, policy := range resp.GetPolicies() {
+		for _, rule := range policy.GetRules() {
+			if rule.GetHitPackets() != 0 || rule.GetHitBytes() != 0 {
+				t.Fatalf("policy %s->%s rule %q: counters = %d/%d, want 0/0 (policy-stats off)",
+					policy.GetFromZone(), policy.GetToZone(), rule.GetName(),
+					rule.GetHitPackets(), rule.GetHitBytes())
+			}
+		}
+	}
 }
 
 func TestGetPoliciesExposesGlobalScheduledRuleCounters(t *testing.T) {

--- a/pkg/grpcapi/testdata/server_show_golden.json
+++ b/pkg/grpcapi/testdata/server_show_golden.json
@@ -18,6 +18,7 @@
   "ipv6-router-advertisement": "Router Advertisements: not available\n",
   "login": "User             UID    Class          SSH Keys\nadmin            -      super-user     0\n",
   "monitor-security-flow": "  Monitor security flow session status: Inactive\n  Monitor security flow trace file: (not configured)\n  Monitor security flow filters: 0\n\n  Note: Flow monitor state is per-CLI-session.\n  Use the local CLI on the firewall for flow tracing.\n",
+  "policies-hit-count": "From zone    To zone      Policy                   Action        Packets            Bytes\n----------------------------------------------------------------------------------------\ntrust        untrust      p1                       permit              0                0\n----------------------------------------------------------------------------------------\nTotal                                                                0                0\n",
   "root-authentication": "No root authentication configured\n",
   "route-instance": "Usage: show route instance \u003cname\u003e\n",
   "route-map": "FRR not available\n",

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -124,6 +124,120 @@ fn default_deny_applies_without_match() {
     );
 }
 
+// #2118: explicit permit AND explicit deny rules both attribute their
+// hit to the matched rule's per-rule counter (visible in
+// counter_snapshots), while a flow that matches NO explicit rule and
+// rides the implicit default-deny increments NO per-rule counter. The
+// last assertion is the load-bearing one for #2118: it proves that the
+// "deny rows read 0" observed in the loss-cluster smoke is CORRECT when
+// the config has only explicit permit rules plus default-policy
+// deny-all — the blocked traffic rode the default-deny, which bumps the
+// aggregate counter but no per-rule counter, so there is no bug to fix
+// on the deny rows.
+#[test]
+fn hit_counter_attributes_permit_and_deny_but_not_default_deny() {
+    let permit_id = "security-policy:lan:wan:permit-web".to_string();
+    let deny_id = "security-policy:lan:wan:deny-ssh".to_string();
+    let state = parse_policy_state(
+        "deny",
+        &[
+            PolicyRuleSnapshot {
+                rule_id: permit_id.clone(),
+                name: "permit-web".to_string(),
+                from_zone: "lan".to_string(),
+                to_zone: "wan".to_string(),
+                source_addresses: vec!["any".to_string()],
+                destination_addresses: vec!["10.0.0.0/8".to_string()],
+                applications: vec!["any".to_string()],
+                action: "permit".to_string(),
+                ..Default::default()
+            },
+            PolicyRuleSnapshot {
+                rule_id: deny_id.clone(),
+                name: "deny-ssh".to_string(),
+                from_zone: "lan".to_string(),
+                to_zone: "wan".to_string(),
+                source_addresses: vec!["any".to_string()],
+                destination_addresses: vec!["192.168.0.0/16".to_string()],
+                applications: vec!["any".to_string()],
+                action: "deny".to_string(),
+                ..Default::default()
+            },
+        ],
+        &test_zone_name_to_id(),
+    );
+
+    // Flow matching the explicit PERMIT rule (dst in 10.0.0.0/8).
+    assert_eq!(
+        evaluate_policy_with_len(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "10.0.61.100".parse().expect("src"),
+            "10.0.2.5".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            80,
+            100,
+        ),
+        PolicyAction::Permit
+    );
+    // Flow matching the explicit DENY rule (dst in 192.168.0.0/16).
+    assert_eq!(
+        evaluate_policy_with_len(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "10.0.61.100".parse().expect("src"),
+            "192.168.1.7".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            22,
+            200,
+        ),
+        PolicyAction::Deny
+    );
+    // Flow matching NEITHER explicit rule (dst 172.16.x) -> implicit
+    // default-deny.
+    assert_eq!(
+        evaluate_policy_with_len(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "10.0.61.100".parse().expect("src"),
+            "172.16.80.200".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            443,
+            300,
+        ),
+        PolicyAction::Deny
+    );
+
+    let permit_counter = policy_counter(&state, &permit_id);
+    assert_eq!(permit_counter.packets, 1, "permit rule must record 1 hit");
+    assert_eq!(permit_counter.bytes, 100);
+
+    let deny_counter = policy_counter(&state, &deny_id);
+    assert_eq!(deny_counter.packets, 1, "explicit deny rule must record 1 hit");
+    assert_eq!(deny_counter.bytes, 200);
+
+    // The default-deny flow must NOT have inflated either per-rule
+    // counter — there is no rule_id for the default action, so no
+    // per-rule counter exists for it (the aggregate policy_deny counter,
+    // owned by the forwarding path, accounts for it instead).
+    let total_per_rule_packets: u64 = state
+        .counter_snapshots()
+        .into_iter()
+        .map(|c| c.packets)
+        .sum();
+    assert_eq!(
+        total_per_rule_packets, 2,
+        "default-deny must not increment any per-rule counter (only the \
+         permit + explicit-deny hits should be attributed)"
+    );
+}
+
 #[test]
 fn evaluate_policy_skips_inactive_rules() {
     let state = parse_policy_state(


### PR DESCRIPTION
## Summary

Fixes #2118. `show security policies hit-count` (and `... detail`, the
structured gRPC `GetPolicies` block, and the local-CLI table) read the
per-rule hit counters **unconditionally**, while #2008 M4 had gated only
the Prometheus collector on `cfg.Security.PolicyStatsEnabled`. The four
display surfaces therefore disagreed. This PR gates all four on the same
knob (display-only), so per-policy hit counts are shown only when
`set security policy-stats system-wide enable` is configured (Junos
default off) and read 0 uniformly otherwise.

## Diagnosis (the issue is NOT a missing feature)

The increment -> coordinator snapshot -> `policy_rule_counters` wire
array -> Go `ReadPolicyCounters` chain is **intact end-to-end** and was
already Go-unit-tested (verified by static reading + an independent
second-pass agent). The observed "all 0" in the 2026-06-20 smoke was:

1. **DENY rows = 0 is CORRECT.** The loss-cluster config has
   `default-policy deny-all` and ONLY explicit permit rules. Blocked
   traffic rode the implicit default-deny, which bumps the aggregate
   `policy_deny` counter, not any per-rule counter. Not a bug.
2. **The smoke ran with `policy-stats` OFF**, so 0 is the intended
   Prometheus read per M4.
3. **The genuine bug:** the display-gate inconsistency above (CLI/gRPC
   text/structured surfaces ignored the knob while Prometheus honored
   it). The permit-row 0 is also consistent with the single-flow
   "0 is really 1" artifact (one new flow bumps a permit rule by exactly
   packets=1).

Fix = unify the gate (display-only; the Rust increment stays always-on,
a single relaxed atomic). No wire-format change — the existing
`policy_rule_counters` array (numeric, serde-default / omitempty) is
reused, so old<->new compatibility is unaffected.

## Flagged for decision (behavior left UNCHANGED)

xpf **preserves** per-policy hit counts across a recompile as long as the
stable `from-zone->to-zone/name` rule identity is unchanged; Junos
**resets** per-policy counts on a commit that changes the policy. This PR
keeps the preserve-on-recompile behavior (more useful for long-running
rules) and documents the divergence in `docs/feature-gaps.md`. Change it
only on an explicit decision.

## Test plan

- [x] `go build ./...` clean
- [x] Go tests: pkg/grpcapi, pkg/cli, pkg/api, pkg/dataplane/userspace,
      pkg/config — all pass (incl. the new gate tests + the M4 collector
      test still green)
- [x] New Go gate tests: gRPC text hit-count + detail, structured
      GetPolicies, local CLI — all assert live counts with the knob on,
      0 with the knob off (non-tautological)
- [x] `policies-hit-count` added to the show golden regression spine
- [x] Rust: `cargo test --release` — 2082 pass (1 pre-existing flaky
      concurrency test `afxdp::worker_queue::concurrent_recovery...`,
      4/5 pass in isolation, OUTSIDE this diff which touches no afxdp
      code)
- [x] New Rust test: explicit permit AND explicit deny attribute
      per-rule hits; implicit default-deny attributes none

This is a control-plane display-only change — no dataplane forwarding
behavior is modified, so no heavy smoke / failover run is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)