### PR TITLE
#2127: fix rtProtoName mislabeling of FRR route protocols

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -7514,3 +7514,22 @@ top.
 - **Validation**: `go test ./pkg/dhcprelay/ -race` 25/25 pass; config + cli +
   daemon green; `go build ./...` clean. Live flag0 wire-capture +
   test-failover pending parent-run (lab-gated).
+
+## #2127 — rtProtoName FRR route-protocol mislabel fix (PR #2135)
+- **Timestamp**: 2026-06-21
+- **Action**: Fix rtProtoName() rtnetlink protocol→name mapping. Add
+  RTPROT_ISIS(187)->isis (was unmapped, displayed literal "187"); keep
+  196->static as FRR private RTPROT_ZSTATIC (local rtprotZStatic const;
+  verified ZEBRA_ROUTE_STATIC->RTPROT_ZSTATIC(196) in FRR zebra2proto);
+  drop RTPROT_ZEBRA(11) (FRR TABLE/NHG, not static — falls through) and
+  RTPROT_BIRD(12) (not emitted by FRR). Express all arms via named
+  unix.RTPROT_* constants. New rtproto_test.go (non-tautological table
+  test + end-to-end protoTag/junosProtoName IS-IS check).
+- **File(s)**: pkg/routing/routes.go, pkg/routing/rtproto_test.go,
+  docs/pr/2127-rtproto-name-mapping/plan.md
+- **Validation**: go build/vet clean; go test ./pkg/routing/ green;
+  5/5 flake on new tests; full go test ./... green. Codex round-1
+  PLAN-NEEDS-MAJOR (caught the 196=RTPROT_ZSTATIC semantics) resolved
+  against FRR source; Codex code review + AGY adversarial both
+  MERGE-READY; Copilot reviewed 3/3 files, no comments. Control-plane
+  display only — no dataplane smoke. PR #2135 MERGEABLE.

--- a/docs/pr/2127-rtproto-name-mapping/plan.md
+++ b/docs/pr/2127-rtproto-name-mapping/plan.md
@@ -1,0 +1,227 @@
+# #2127 — rtProtoName mislabels FRR route protocols
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+`rtProtoName()` in `pkg/routing/routes.go` (lines 204-233) converts the
+kernel rtnetlink route-protocol byte (`netlink.RouteProtocol`, i.e. the
+`rtm_protocol` field on a route) into the xpf protocol name that drives
+`show route`. That name is consumed downstream by `protoTag()` (single-
+letter Junos marker, `pkg/routing/routeformat.go:11`) and
+`junosProtoName()` (long Junos name, `routeformat.go:259`).
+
+The numeric switch arms are wrong against the real kernel constants:
+
+- There is **no `case 187`**, so IS-IS routes (zebra tags them
+  `RTPROT_ISIS = 187`) fall through to `default: strconv.Itoa(pi)` and
+  display as the literal string `"187"`. `protoTag("187")` returns `"?"`
+  in `show route terse`; `junosProtoName("187")` returns `"187"` in the
+  detail/summary views — instead of `I` / `IS-IS`. This is a real
+  regression for any deployment using IS-IS (`set protocols isis`,
+  rendered as `router isis xpf` in `policy_render.go`; IS-IS is listed as
+  supported in CLAUDE.md).
+- `case 11` (`RTPROT_ZEBRA = 11`) is mislabeled `"ospf"`.
+- `case 12` (`RTPROT_BIRD = 12`) is mislabeled `"isis"`.
+- `case 196` is labeled `// RTPROT_ZEBRA — FRR staticd-installed routes`,
+  but `196` is **not** a kernel rtproto constant and ZEBRA is actually
+  `11`. The comment is wrong and the arm is effectively dead.
+
+Display-only; no forwarding impact. Severity LOW.
+
+## Ground-truth verification (done before drafting)
+
+Confirmed the constant values two ways:
+
+1. `go run` against `golang.org/x/sys/unix` inside this module:
+   `RTPROT_REDIRECT=1 KERNEL=2 BOOT=3 STATIC=4 RA=9 ZEBRA=11 BIRD=12
+   DHCP=16 BABEL=42 BGP=186 ISIS=187 OSPF=188 RIP=189`.
+2. `/usr/include/linux/rtnetlink.h`: `RTPROT_ZEBRA 11 /* Zebra */`,
+   `RTPROT_BIRD 12 /* BIRD */`, `RTPROT_DHCP 16`, `RTPROT_BABEL 42`,
+   `RTPROT_BGP 186`, `RTPROT_ISIS 187`, `RTPROT_OSPF 188`,
+   `RTPROT_RIP 189`.
+
+So the current code's `186->bgp`, `188->ospf`, `189->rip` are CORRECT;
+`11->ospf`, `12->isis`, missing-187, and `196->static` are the bugs.
+
+### What FRR's daemons actually install
+
+FRR's zebra programs the kernel FIB and stamps each route's
+`rtm_protocol` with the originating client protocol's value, using the
+upstream-assigned `RTPROT_*` numbers above:
+
+- bgpd → `RTPROT_BGP` (186)
+- ospfd/ospf6d → `RTPROT_OSPF` (188)
+- isisd → `RTPROT_ISIS` (187)
+- ripd/ripngd → `RTPROT_RIP` (189)
+- staticd → routes carry the route's own configured protocol; FRR's
+  default for zebra/staticd-originated entries that have no dedicated
+  rtproto is `RTPROT_ZEBRA` (11) unless `zebra` is built to use a
+  distinct value. In practice xpf installs static routes through FRR's
+  managed config; those that zebra stamps as ZEBRA appear as 11.
+- connected/kernel → the kernel itself uses `RTPROT_KERNEL` (2) for
+  link routes and `RTPROT_BOOT`/`RTPROT_STATIC` for boot/manual; these
+  are already handled correctly by the existing arms.
+
+Conclusion: 11 (`RTPROT_ZEBRA`) should map to a sensible xpf name. The
+issue accepts `11 -> "static"` "to match FRR staticd" provided the
+comment is corrected (196 is not ZEBRA). We adopt `11 -> "static"` with
+a correct comment. We DROP the `12` (BIRD — not used by FRR/xpf) and
+`196` (bogus) arms so they fall through to `default` (numeric string),
+which is the honest behavior for a protocol byte xpf does not recognize.
+
+## Concrete design
+
+Rewrite `rtProtoName` to use the named `unix.RTPROT_*` constants
+throughout (no magic numbers), add the IS-IS arm, fix ZEBRA, drop BIRD
+and the bogus 196:
+
+```go
+// rtProtoName maps a netlink route protocol to its xpf protocol name.
+//
+// The protocol byte is the kernel rtnetlink rtm_protocol value. FRR's
+// zebra stamps FIB routes with the originating daemon's RTPROT_*
+// value (bgpd->BGP, ospfd->OSPF, isisd->ISIS, ripd->RIP); zebra/staticd
+// routes appear as RTPROT_ZEBRA. Values xpf does not recognize fall
+// through to their numeric string.
+func rtProtoName(p netlink.RouteProtocol) string {
+	switch int(p) {
+	case unix.RTPROT_REDIRECT:
+		return "redirect"
+	case unix.RTPROT_KERNEL:
+		return "connected"
+	case unix.RTPROT_BOOT:
+		return "dhcp"
+	case unix.RTPROT_STATIC:
+		return "static"
+	case unix.RTPROT_DHCP: // 16
+		return "dhcp"
+	case unix.RTPROT_ZEBRA: // 11 — FRR zebra/staticd-installed routes
+		return "static"
+	case unix.RTPROT_BGP: // 186
+		return "bgp"
+	case unix.RTPROT_ISIS: // 187
+		return "isis"
+	case unix.RTPROT_OSPF: // 188
+		return "ospf"
+	case unix.RTPROT_RIP: // 189
+		return "rip"
+	default:
+		return strconv.Itoa(int(p))
+	}
+}
+```
+
+Notes:
+- All arms keyed on named constants; comments give the numeric value for
+  the reader.
+- `RTPROT_ZEBRA` (11) -> "static" replaces the wrong `11 -> "ospf"`.
+- IS-IS (187) added.
+- BIRD (12) and the bogus 196 arms removed -> they now hit `default`.
+- `unix.RTPROT_STATIC` (4) and `unix.RTPROT_ZEBRA` (11) both return
+  "static" — intentional: both are operator/FRR-originated static-style
+  routes and Junos shows them as `S`/`Static`.
+
+## Public API preservation
+
+`rtProtoName` is an unexported helper. Its only caller is
+`routes.go:171` (`Protocol: rtProtoName(r.Protocol)`). Signature
+unchanged: `func rtProtoName(p netlink.RouteProtocol) string`. No
+exported API touched. `protoTag` / `junosProtoName` unchanged — the
+existing names ("isis", "static", etc.) already map correctly there
+(`protoTag("isis")="I"`, `junosProtoName("isis")="IS-IS"`), so fixing
+the producer is sufficient.
+
+## Out of scope (explicitly)
+
+- `pkg/frr/status_parse.go` `Protocol` field — that comes from FRR's
+  vtysh JSON `protocol` string (already a name like "isis"), a separate
+  path from the netlink rtproto byte. Not touched.
+- Any change to `protoTag`/`junosProtoName` (they already handle the
+  five corrected names).
+- Adding RA (9) / Babel (42) arms — xpf does not surface those today;
+  leaving them to `default` is acceptable and keeps the change minimal.
+
+## Hidden invariants the change must preserve
+
+- The five correct arms (REDIRECT, KERNEL->connected, BOOT->dhcp,
+  STATIC->static, BGP/OSPF/RIP) keep their current outputs.
+- `default` still returns the numeric string for unknown protos (so the
+  output is never empty / never panics).
+- DHCP (16) still -> "dhcp" (now via `unix.RTPROT_DHCP`).
+
+## Risk assessment
+
+| Class | Level | Note |
+|-------|-------|------|
+| Behavioral regression | LOW | Only changes outputs for 11/12/187/196 inputs; 11 and 187 were already wrong/unmapped, 12/196 are not produced by FRR. Correct arms untouched. |
+| Lifetime / borrow | N/A | Go, no borrow checker; pure value switch. |
+| Performance | NONE | Same O(1) switch; display-only path. |
+| Architectural mismatch | NONE | Direct correction of a lookup table; no new abstraction. |
+
+## Test plan
+
+New table-driven unit test in a new file
+`pkg/routing/rtproto_test.go` (package `routing`, so it can call the
+unexported `rtProtoName`). Assert, using the `unix.RTPROT_*` constants
+as inputs (not magic numbers), that each maps to the expected name:
+
+- `unix.RTPROT_ISIS` (187) -> "isis"  ← the regression the issue is about
+- `unix.RTPROT_BGP` (186) -> "bgp"
+- `unix.RTPROT_OSPF` (188) -> "ospf"
+- `unix.RTPROT_RIP` (189) -> "rip"
+- `unix.RTPROT_ZEBRA` (11) -> "static" (was "ospf" — fails pre-fix)
+- `unix.RTPROT_KERNEL` (2) -> "connected"
+- `unix.RTPROT_STATIC` (4) -> "static"
+- `unix.RTPROT_BOOT` (3) -> "dhcp"
+- `unix.RTPROT_DHCP` (16) -> "dhcp"
+- `unix.RTPROT_REDIRECT` (1) -> "redirect"
+- `unix.RTPROT_BIRD` (12) -> "12" (now falls through — was wrongly "isis")
+- 196 -> "196" (now falls through — was wrongly "static")
+- an arbitrary unknown (e.g. 250) -> "250"
+
+Non-tautological: the test fails against pre-fix master for
+`RTPROT_ISIS` (would be "187"), `RTPROT_ZEBRA` (would be "ospf"),
+`RTPROT_BIRD` (would be "isis"), and 196 (would be "static").
+
+Additionally a thin assertion that the produced name feeds the
+formatters correctly: `protoTag(rtProtoName(unix.RTPROT_ISIS)) == "I"`
+and `junosProtoName(rtProtoName(unix.RTPROT_ISIS)) == "IS-IS"` — proving
+the end-to-end `show route` fix, not just the producer.
+
+Gates:
+- `go build ./...`
+- `go test ./pkg/routing/...` (and full `go test ./...`)
+- `go vet ./pkg/routing/...`
+
+This is a CONTROL-PLANE (route-display) change with NO dataplane /
+forwarding impact, so per the task's standing constraints there is NO
+cluster smoke (no iperf3, no CoS matrix). The unit test is the
+validation.
+
+## Docs
+
+No operator-facing doc claims the wrong mapping; `show route` output is
+behavior, not documented as a table. The code comment is corrected
+in-place. No separate doc update needed (stated here per the
+documentation-contract rule).
+
+## Open questions for adversarial review
+
+1. Is `RTPROT_ZEBRA` (11) -> "static" the right name, or should it be a
+   distinct "zebra"/"frr" name? (Junos has no "zebra" protocol; `S`/
+   Static is the closest faithful mapping. PLAN-KILL the 11 arm if you
+   think dropping it to `default` ("11") is more honest.)
+2. Should BIRD (12) and 196 be DROPPED (fall through to numeric) as
+   planned, or remapped? Is there any xpf/FRR path that installs 12 or
+   196 today? (I found none.)
+3. Should RA (9) and Babel (42) be added now, or is leaving them to
+   `default` acceptable for this focused fix?
+4. `unix.RTPROT_STATIC` (4) and `unix.RTPROT_ZEBRA` (11) both -> "static".
+   Any reason these must be distinguished in `show route`?
+5. Is a new file `rtproto_test.go` the right home, or should the test go
+   into an existing `routing_test.go`? (New file keeps the focused fix
+   self-contained.)
+6. Any concern that switching from magic numbers to `unix.RTPROT_*`
+   constants could change behavior on a non-Linux build? (pkg/routing is
+   Linux-only; netlink is Linux-only — no cross-platform risk.)

--- a/docs/pr/2127-rtproto-name-mapping/plan.md
+++ b/docs/pr/2127-rtproto-name-mapping/plan.md
@@ -1,6 +1,47 @@
 # #2127 — rtProtoName mislabels FRR route protocols
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** v2 — Codex round-1 PLAN-NEEDS-MAJOR resolved (see "Plan
+review resolution" below). Implemented.
+
+## Plan review resolution (round 1)
+
+Codex (task-mqnaft7k-62iwbm) returned **PLAN-NEEDS-MAJOR** with one
+load-bearing finding that the v1 plan got wrong, verified against FRR
+upstream source (`zebra/rt_netlink.h` + `zebra/rt_netlink.c`
+`zebra2proto`/`proto2zebra`):
+
+- **`196` is FRR's private `RTPROT_ZSTATIC`** (not a bogus value).
+  `zebra2proto()` maps `ZEBRA_ROUTE_STATIC -> RTPROT_ZSTATIC(196)`, and
+  `proto2zebra()` reads BOTH `RTPROT_STATIC`(4) and `RTPROT_ZSTATIC`(196)
+  back as `ZEBRA_ROUTE_STATIC`. So FRR staticd routes ARE stamped 196 and
+  the original `196 -> static` arm was CORRECT. **Resolution:** keep
+  `196 -> static`, define a local `rtprotZStatic = 196` const (no
+  `unix` counterpart exists) with a correct comment citing FRR.
+- **`RTPROT_ZEBRA(11)` is NOT static.** `zebra2proto()` maps
+  `ZEBRA_ROUTE_TABLE` / `ZEBRA_ROUTE_NHG -> RTPROT_ZEBRA(11)`. Mapping 11
+  to "static" (v1 plan) would mislabel table/NHG routes; `11 -> ospf`
+  (pre-fix) is also wrong. **Resolution:** drop the 11 arm entirely so it
+  falls through to the numeric string (xpf has no Junos name for
+  table/NHG routes). Verified against FRR source, the `unix.RTPROT_*`
+  values (BGP 186, ISIS 187, OSPF 188, RIP 189, ZEBRA 11, BIRD 12,
+  DHCP 16) are correct.
+- **`RouteEntry.Protocol` also feeds the `show route protocol <x>`
+  filter** (`pkg/cli/cli_show_routing.go:170`, `strings.ToLower(
+  e.Protocol) == proto`) and gRPC route text — confirmed. This makes the
+  fix MORE valuable: pre-fix, `show route protocol isis` returned nothing
+  because IS-IS routes carried `Protocol="187"`. The corrected names
+  ("isis"/"static"/etc.) are exactly the filter tokens, so the fix is
+  downstream-consistent. No change to consumers needed.
+
+Gemini companion is **unavailable** (the abiswas97-gemini runtime
+returned "This client is no longer supported for Gemini Code Assist for
+individuals" — the Code Assist personal tier is deprecated). The
+independent second plan review is delegated to AGY (Antigravity) / the
+parent's reviewer set instead.
+
+---
+
+## v1 (superseded by the resolution above)
 
 ## Issue framing
 

--- a/pkg/routing/routes.go
+++ b/pkg/routing/routes.go
@@ -202,32 +202,37 @@ func (rr *routeReader) routeToEntry(r netlink.Route, family int) RouteEntry {
 }
 
 // rtProtoName maps a netlink route protocol to its xpf protocol name.
+//
+// The argument is the kernel rtnetlink rtm_protocol byte. FRR's zebra
+// stamps each FIB route with the originating daemon's RTPROT_* value
+// (bgpd->BGP, ospfd/ospf6d->OSPF, isisd->ISIS, ripd/ripngd->RIP);
+// zebra/staticd-originated routes appear as RTPROT_ZEBRA. The numeric
+// comments record the constant values for the reader. Protocol bytes
+// xpf does not recognize fall through to their numeric string. The
+// returned name feeds protoTag()/junosProtoName() in routeformat.go.
 func rtProtoName(p netlink.RouteProtocol) string {
-	pi := int(p)
-	switch pi {
-	case unix.RTPROT_REDIRECT:
+	switch int(p) {
+	case unix.RTPROT_REDIRECT: // 1
 		return "redirect"
-	case unix.RTPROT_KERNEL:
+	case unix.RTPROT_KERNEL: // 2
 		return "connected"
-	case unix.RTPROT_BOOT:
+	case unix.RTPROT_BOOT: // 3
 		return "dhcp"
-	case unix.RTPROT_STATIC:
+	case unix.RTPROT_STATIC: // 4
 		return "static"
-	case 16: // RTPROT_DHCP
+	case unix.RTPROT_ZEBRA: // 11 — FRR zebra/staticd-installed routes
+		return "static"
+	case unix.RTPROT_DHCP: // 16
 		return "dhcp"
-	case 11:
-		return "ospf"
-	case 12:
-		return "isis"
-	case 186:
+	case unix.RTPROT_BGP: // 186
 		return "bgp"
-	case 188:
+	case unix.RTPROT_ISIS: // 187
+		return "isis"
+	case unix.RTPROT_OSPF: // 188
 		return "ospf"
-	case 189:
+	case unix.RTPROT_RIP: // 189
 		return "rip"
-	case 196:
-		return "static" // RTPROT_ZEBRA — FRR staticd-installed routes
 	default:
-		return strconv.Itoa(pi)
+		return strconv.Itoa(int(p))
 	}
 }

--- a/pkg/routing/routes.go
+++ b/pkg/routing/routes.go
@@ -201,26 +201,36 @@ func (rr *routeReader) routeToEntry(r netlink.Route, family int) RouteEntry {
 	return entry
 }
 
+// rtprotZStatic is FRR's private rtnetlink protocol value for staticd-
+// installed routes (RTPROT_ZSTATIC). It is NOT a Linux UAPI constant, so
+// it has no golang.org/x/sys/unix counterpart; FRR's zebra2proto() maps
+// ZEBRA_ROUTE_STATIC -> RTPROT_ZSTATIC (zebra/rt_netlink.h, value 196)
+// and proto2zebra() reads both RTPROT_STATIC and RTPROT_ZSTATIC back as
+// ZEBRA_ROUTE_STATIC.
+const rtprotZStatic = 196
+
 // rtProtoName maps a netlink route protocol to its xpf protocol name.
 //
 // The argument is the kernel rtnetlink rtm_protocol byte. FRR's zebra
-// stamps each FIB route with the originating daemon's RTPROT_* value
-// (bgpd->BGP, ospfd/ospf6d->OSPF, isisd->ISIS, ripd/ripngd->RIP);
-// zebra/staticd-originated routes appear as RTPROT_ZEBRA. The numeric
-// comments record the constant values for the reader. Protocol bytes
-// xpf does not recognize fall through to their numeric string. The
-// returned name feeds protoTag()/junosProtoName() in routeformat.go.
+// stamps each FIB route with the originating daemon's RTPROT_* value via
+// zebra2proto(): bgpd->RTPROT_BGP, ospfd/ospf6d->RTPROT_OSPF,
+// isisd->RTPROT_ISIS, ripd->RTPROT_RIP, staticd->RTPROT_ZSTATIC(196),
+// connected/local/kernel->RTPROT_KERNEL. RTPROT_ZEBRA(11) is reserved by
+// FRR for ZEBRA_ROUTE_TABLE/NHG routes, which xpf does not surface as a
+// named protocol, so it falls through to its numeric string like any
+// other unrecognized value. The numeric comments record the constant
+// values for the reader. The returned name feeds protoTag() and
+// junosProtoName() in routeformat.go and the `show route protocol <x>`
+// filter in pkg/cli/cli_show_routing.go.
 func rtProtoName(p netlink.RouteProtocol) string {
 	switch int(p) {
 	case unix.RTPROT_REDIRECT: // 1
 		return "redirect"
-	case unix.RTPROT_KERNEL: // 2
+	case unix.RTPROT_KERNEL: // 2 — also FRR connected/local/kernel
 		return "connected"
 	case unix.RTPROT_BOOT: // 3
 		return "dhcp"
-	case unix.RTPROT_STATIC: // 4
-		return "static"
-	case unix.RTPROT_ZEBRA: // 11 — FRR zebra/staticd-installed routes
+	case unix.RTPROT_STATIC: // 4 — manual `ip route` static
 		return "static"
 	case unix.RTPROT_DHCP: // 16
 		return "dhcp"
@@ -232,6 +242,8 @@ func rtProtoName(p netlink.RouteProtocol) string {
 		return "ospf"
 	case unix.RTPROT_RIP: // 189
 		return "rip"
+	case rtprotZStatic: // 196 — FRR staticd (RTPROT_ZSTATIC)
+		return "static"
 	default:
 		return strconv.Itoa(int(p))
 	}

--- a/pkg/routing/rtproto_test.go
+++ b/pkg/routing/rtproto_test.go
@@ -7,12 +7,17 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// frrZStatic is FRR's private RTPROT_ZSTATIC value (zebra/rt_netlink.h)
+// for staticd-installed routes; it has no golang.org/x/sys/unix
+// constant. Mirrors the package-internal rtprotZStatic.
+const frrZStatic = 196
+
 // TestRtProtoName asserts that each kernel rtnetlink rtm_protocol value
 // maps to the xpf protocol name shown by "show route" (#2127). The
 // inputs use the named unix.RTPROT_* constants so the test stays correct
 // if the constant numbers ever change. The cases are non-tautological:
-// against pre-#2127 code, RTPROT_ISIS yielded "187", RTPROT_ZEBRA
-// yielded "ospf", RTPROT_BIRD yielded "isis", and 196 yielded "static".
+// against pre-#2127 code, RTPROT_ISIS yielded the literal "187",
+// RTPROT_ZEBRA yielded "ospf", and RTPROT_BIRD yielded "isis".
 func TestRtProtoName(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -29,13 +34,22 @@ func TestRtProtoName(t *testing.T) {
 		{"ospf", unix.RTPROT_OSPF, "ospf"},
 		{"rip", unix.RTPROT_RIP, "rip"},
 
-		// The #2127 fixes.
-		{"isis-187", unix.RTPROT_ISIS, "isis"},    // was "187" (unmapped)
-		{"zebra-11", unix.RTPROT_ZEBRA, "static"}, // was "ospf"
+		// FRR staticd installs routes as RTPROT_ZSTATIC=196, mapped to
+		// "static". This arm pre-dates #2127 and must be preserved (the
+		// kernel UAPI RTPROT_STATIC=4 above is a different value).
+		{"frr-zstatic-196", frrZStatic, "static"},
 
-		// Dropped/bogus arms now fall through to the numeric string.
-		{"bird-12-falls-through", unix.RTPROT_BIRD, "12"}, // was "isis"
-		{"bogus-196-falls-through", 196, "196"},           // was "static"
+		// The #2127 fixes.
+		{"isis-187", unix.RTPROT_ISIS, "isis"}, // was the literal "187"
+
+		// RTPROT_ZEBRA(11) is FRR's ZEBRA_ROUTE_TABLE/NHG marker, not a
+		// named xpf protocol, so it falls through to the numeric string.
+		// Pre-#2127 it was wrongly mapped to "ospf".
+		{"zebra-11-falls-through", unix.RTPROT_ZEBRA, "11"},
+
+		// BIRD(12) is not emitted by FRR; fall through to numeric.
+		// Pre-#2127 it was wrongly mapped to "isis".
+		{"bird-12-falls-through", unix.RTPROT_BIRD, "12"},
 
 		// Genuinely unknown protocol byte.
 		{"unknown-250", 250, "250"},

--- a/pkg/routing/rtproto_test.go
+++ b/pkg/routing/rtproto_test.go
@@ -7,11 +7,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// frrZStatic is FRR's private RTPROT_ZSTATIC value (zebra/rt_netlink.h)
-// for staticd-installed routes; it has no golang.org/x/sys/unix
-// constant. Mirrors the package-internal rtprotZStatic.
-const frrZStatic = 196
-
 // TestRtProtoName asserts that each kernel rtnetlink rtm_protocol value
 // maps to the xpf protocol name shown by "show route" (#2127). The
 // inputs use the named unix.RTPROT_* constants so the test stays correct
@@ -37,7 +32,7 @@ func TestRtProtoName(t *testing.T) {
 		// FRR staticd installs routes as RTPROT_ZSTATIC=196, mapped to
 		// "static". This arm pre-dates #2127 and must be preserved (the
 		// kernel UAPI RTPROT_STATIC=4 above is a different value).
-		{"frr-zstatic-196", frrZStatic, "static"},
+		{"frr-zstatic-196", rtprotZStatic, "static"},
 
 		// The #2127 fixes.
 		{"isis-187", unix.RTPROT_ISIS, "isis"}, // was the literal "187"

--- a/pkg/routing/rtproto_test.go
+++ b/pkg/routing/rtproto_test.go
@@ -1,0 +1,66 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// TestRtProtoName asserts that each kernel rtnetlink rtm_protocol value
+// maps to the xpf protocol name shown by "show route" (#2127). The
+// inputs use the named unix.RTPROT_* constants so the test stays correct
+// if the constant numbers ever change. The cases are non-tautological:
+// against pre-#2127 code, RTPROT_ISIS yielded "187", RTPROT_ZEBRA
+// yielded "ospf", RTPROT_BIRD yielded "isis", and 196 yielded "static".
+func TestRtProtoName(t *testing.T) {
+	tests := []struct {
+		name  string
+		proto int
+		want  string
+	}{
+		// Correct mappings (must not regress).
+		{"redirect", unix.RTPROT_REDIRECT, "redirect"},
+		{"kernel->connected", unix.RTPROT_KERNEL, "connected"},
+		{"boot->dhcp", unix.RTPROT_BOOT, "dhcp"},
+		{"static", unix.RTPROT_STATIC, "static"},
+		{"dhcp", unix.RTPROT_DHCP, "dhcp"},
+		{"bgp", unix.RTPROT_BGP, "bgp"},
+		{"ospf", unix.RTPROT_OSPF, "ospf"},
+		{"rip", unix.RTPROT_RIP, "rip"},
+
+		// The #2127 fixes.
+		{"isis-187", unix.RTPROT_ISIS, "isis"},    // was "187" (unmapped)
+		{"zebra-11", unix.RTPROT_ZEBRA, "static"}, // was "ospf"
+
+		// Dropped/bogus arms now fall through to the numeric string.
+		{"bird-12-falls-through", unix.RTPROT_BIRD, "12"}, // was "isis"
+		{"bogus-196-falls-through", 196, "196"},           // was "static"
+
+		// Genuinely unknown protocol byte.
+		{"unknown-250", 250, "250"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rtProtoName(netlink.RouteProtocol(tc.proto))
+			if got != tc.want {
+				t.Errorf("rtProtoName(%d) = %q, want %q", tc.proto, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRtProtoNameFeedsFormatters proves the end-to-end #2127 fix: the
+// name rtProtoName produces for IS-IS routes drives the Junos display
+// helpers to "I" (terse) and "IS-IS" (detail/summary), instead of the
+// pre-fix "?" / "187".
+func TestRtProtoNameFeedsFormatters(t *testing.T) {
+	name := rtProtoName(netlink.RouteProtocol(unix.RTPROT_ISIS))
+	if got := protoTag(name); got != "I" {
+		t.Errorf("protoTag(rtProtoName(RTPROT_ISIS)) = %q, want %q", got, "I")
+	}
+	if got := junosProtoName(name); got != "IS-IS" {
+		t.Errorf("junosProtoName(rtProtoName(RTPROT_ISIS)) = %q, want %q", got, "IS-IS")
+	}
+}


### PR DESCRIPTION
## Summary

`rtProtoName()` in `pkg/routing/routes.go` converts the kernel rtnetlink
`rtm_protocol` byte into the xpf protocol name shown by `show route` (it
feeds `protoTag()`/`junosProtoName()` in `pkg/routing/routeformat.go` and
the `show route protocol <x>` filter in `pkg/cli/cli_show_routing.go`).
Several switch arms were wrong against the real kernel/FRR constants:

- **IS-IS (`RTPROT_ISIS=187`) had no case**, so isisd-installed routes fell
  through to `default: strconv.Itoa(pi)` and displayed as the literal
  `"187"` (`protoTag` -> `"?"`, `junosProtoName` -> `"187"`, and
  `show route protocol isis` matched nothing) instead of `I` / `IS-IS`.
- `case 11` (`RTPROT_ZEBRA`) was mislabeled `"ospf"`.
- `case 12` (`RTPROT_BIRD`) was mislabeled `"isis"`.

## Corrected mapping

- Add `RTPROT_ISIS(187) -> "isis"`.
- Keep `196 -> "static"`: `196` is FRR's private `RTPROT_ZSTATIC`
  (`zebra/rt_netlink.h`); `zebra2proto()` maps
  `ZEBRA_ROUTE_STATIC -> RTPROT_ZSTATIC(196)` and `proto2zebra()` reads
  both `RTPROT_STATIC(4)` and `RTPROT_ZSTATIC(196)` back as
  `ZEBRA_ROUTE_STATIC`. Expressed via a local `rtprotZStatic = 196`
  const (no `golang.org/x/sys/unix` counterpart — it is FRR-private, not
  a Linux UAPI constant). The old comment calling 196 "RTPROT_ZEBRA" was
  wrong; corrected.
- Drop `RTPROT_ZEBRA(11)` so it falls through to the numeric string — FRR
  uses 11 for `ZEBRA_ROUTE_TABLE`/`ZEBRA_ROUTE_NHG`, not static, and xpf
  has no Junos name for those. (Both the pre-fix `11 -> ospf` and the
  first-cut `11 -> static` were wrong.)
- Drop `RTPROT_BIRD(12)` (not emitted by FRR) so it falls through.
- Express all arms via the named `unix.RTPROT_*` constants (numeric value
  in a comment); previously-correct BGP/OSPF/RIP/KERNEL/BOOT/STATIC/DHCP
  preserved.

Constant values verified against `golang.org/x/sys/unix`,
`/usr/include/linux/rtnetlink.h`, and FRR upstream
`zebra/rt_netlink.{h,c}`. Display-only; no forwarding impact (LOW
severity).

## Plan + review

Plan doc: `docs/pr/2127-rtproto-name-mapping/plan.md`. Codex round-1
returned **PLAN-NEEDS-MAJOR** and correctly caught that `196` is FRR's
`RTPROT_ZSTATIC` (so the original `196 -> static` arm was right and the
first cut wrongly dropped it) and that `RTPROT_ZEBRA(11)` is not static.
Both findings were verified against FRR source and folded in. The Gemini
companion is unavailable (deprecated Code Assist personal tier); the
independent second review is via AGY adversarial review.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/routing/...` clean
- [x] New `pkg/routing/rtproto_test.go`: table test asserting each
  rtproto value maps to the correct name, plus end-to-end
  `protoTag(rtProtoName(RTPROT_ISIS)) == "I"` and
  `junosProtoName(...) == "IS-IS"`. **Non-tautological** — proven to fail
  against pre-fix code for `ISIS->"187"`, `ZEBRA-11->"ospf"`,
  `BIRD-12->"isis"`.
- [x] `go test ./pkg/routing/` green; 5/5 flake check on the new tests
- [x] Full `go test ./...` green

This is a control-plane (route-display) change with **no dataplane /
forwarding impact**, so there is no cluster smoke / iperf3 / CoS matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)