### PR TITLE
#2128: stop screen session-limit tracker from leaking phantom zero entries (memory-DoS)

### DIFF
--- a/docs/pr/2128-session-limit-leak/plan.md
+++ b/docs/pr/2128-session-limit-leak/plan.md
@@ -1,0 +1,233 @@
+# #2128 — Screen session-limit tracker phantom zero-entry leak (memory-exhaustion DoS)
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+`SessionLimitTracker::check_src` / `check_dst`
+(`userspace-dp/src/screen/session_limit.rs:19-36`) read the current
+per-IP session count via `self.src_counts.entry(ip).or_insert(0)` /
+`self.dst_counts.entry(ip).or_insert(0)`. `entry().or_insert(0)` has a
+**write side effect**: it inserts a zero-valued entry for any IP that is
+not already present. The check runs on the ingress hot path for every
+transit packet whenever `profile.session_limit_src > 0` /
+`session_limit_dst > 0` (`screen/mod.rs:342-358`,
+`poll_descriptor/mod.rs:199`).
+
+Consequence: every distinct source IP (and every distinct destination
+IP) that ever reaches the screen stage permanently allocates a HashMap
+entry, even when the packet never creates a session — e.g. it is later
+dropped by zone policy, is a spoofed-source flood packet, or is a
+stateless UDP/ICMP packet. These phantom zero entries are never
+reclaimed: `session_expired` only removes an entry that was first
+incremented by `session_created` and then decremented to 0. An IP whose
+count was created at 0 and never incremented is never removed. The
+periodic cleanup in `screen/mod.rs:361-365` sweeps only `port_scan` and
+`ip_sweep`; `update_profiles` (mod.rs:118-139) never clears
+`session_limits`. So the leak survives config reloads, and the map grows
+without bound — one entry per unique source/destination IP.
+
+This is the precise inversion of the protection the operator enabled:
+turning on `limit-session source-ip-based <n>` makes the dataplane MORE
+vulnerable to a source-IP-spray memory DoS. Each worker owns its own
+`ScreenState`, so growth is per-worker and unbounded.
+
+**Severity: HIGH (security, memory-exhaustion DoS).** Filed from the
+2026-06-20 campaign-2 adversarial audit, 3/3 adversarial-skeptic votes.
+
+## Honest scope / value framing
+
+This is a correctness + security bug fix, not a perf refactor. The win
+is bounding an unbounded attacker-controlled allocation. Absolute scale:
+each `FxHashMap<IpAddr, u32>` bucket entry is ~24-32 bytes amortized
+(IpAddr enum is 17 bytes + alignment, u32 value, hashbrown control
+byte + load-factor slack); at, say, 10M distinct spoofed source IPs per
+worker that is on the order of hundreds of MB per worker, across N
+workers. The fix removes the write side effect from the read path,
+which is also a tiny per-packet win (no hash insert / no rehash growth
+on the hot path for never-session IPs). There is no churn beyond the two
+read sites and tests.
+
+If reviewers conclude the perf gain is too small to justify the churn,
+PLAN-KILL is an acceptable verdict. (It should not be killed on perf
+grounds — the justification is security/DoS, not throughput — but the
+bar is stated for completeness.)
+
+## What's already shipped / partially batched
+
+- `session_created` / `session_expired` already maintain the count
+  correctly via `entry().or_insert(0) += 1` and saturating decrement +
+  `remove` on reaching 0. Those are the ONLY legitimate writers of the
+  count map and they already prune to empty. The fix must leave them
+  untouched so the prune-to-empty invariant holds.
+- The orchestrator calls `check_src`/`check_dst` BEFORE session
+  creation (mod.rs:342-358) so the `(limit+1)`-th attempt is dropped.
+  This pre-check ordering is preserved.
+
+## Concrete design
+
+Make the two read methods read-only:
+
+```rust
+pub(super) fn check_src(&self, ip: IpAddr, limit: u32) -> bool {
+    if limit == 0 {
+        return false;
+    }
+    self.src_counts.get(&ip).copied().unwrap_or(0) >= limit
+}
+
+pub(super) fn check_dst(&self, ip: IpAddr, limit: u32) -> bool {
+    if limit == 0 {
+        return false;
+    }
+    self.dst_counts.get(&ip).copied().unwrap_or(0) >= limit
+}
+```
+
+Two changes per method:
+
+1. `entry(ip).or_insert(0)` → `get(&ip).copied().unwrap_or(0)` — removes
+   the insert side effect. An absent IP reads as 0, which is `< limit`
+   for any `limit >= 1` (and `limit == 0` already early-returns), so the
+   first session attempt for a never-seen IP still passes, exactly as
+   before.
+2. `&mut self` → `&self` — the methods no longer mutate, so taking a
+   shared borrow makes the read-only contract **compiler-enforced**.
+   This is a stronger regression guard than a comment: any future edit
+   that reintroduces a write side effect on this path fails to compile.
+
+The callers in `mod.rs` invoke these from inside `&mut self` methods
+(`check_packet_with_zone_id`), so a `&self` callee is fine (a `&mut`
+receiver can call `&self` methods on its fields). No caller signature
+changes.
+
+### Test accessors (cfg(test) only)
+
+Add `#[cfg(test)]` len accessors so tests can assert the map size
+returns to 0 after distinct-IP churn:
+
+```rust
+#[cfg(test)]
+pub(super) fn src_len(&self) -> usize { self.src_counts.len() }
+#[cfg(test)]
+pub(super) fn dst_len(&self) -> usize { self.dst_counts.len() }
+```
+
+Expose them through `ScreenState` (also `#[cfg(test)]`) so the existing
+`screen/tests.rs` suite (which drives `ScreenState`, not the tracker
+directly) can read them:
+
+```rust
+#[cfg(test)]
+fn session_limit_src_len(&self) -> usize { self.session_limits.src_len() }
+#[cfg(test)]
+fn session_limit_dst_len(&self) -> usize { self.session_limits.dst_len() }
+```
+
+### Tests (in `screen/tests.rs`, the existing session-limit section)
+
+1. **`session_limit_no_leak_on_distinct_ip_churn`** (the key guard):
+   configure `session_limit_src = 5`, drive N (e.g. 1000) DISTINCT
+   source IPs through `check_packet` WITHOUT calling `session_created`
+   (the spoofed-flood / dropped-by-policy / stateless case). Assert
+   `session_limit_src_len() == 0` afterwards. **This test FAILS pre-fix**
+   (`entry().or_insert(0)` leaves 1000 entries) and passes post-fix —
+   non-tautological.
+2. **`session_limit_entry_removed_on_last_expire`**: create a session
+   for one IP (`src_len() == 1`), expire it, assert `src_len() == 0` —
+   the entry is removed when count returns to 0. (Confirms
+   `session_expired`'s prune is the only thing populating/draining the
+   map now.)
+3. **`session_limit_count_tracks_up_and_down`**: open 3 sessions for one
+   src IP (`src_len() == 1`, count 3), expire 2 (still present), expire
+   the 3rd, assert `src_len() == 0`.
+4. Reuse / keep the existing `session_limit_src_enforced`,
+   `session_limit_dst_enforced`, `session_limit_decrements_on_expire`
+   tests — they prove the limit is still enforced at the threshold and
+   that decrement re-admits.
+
+## Public API preservation
+
+- `check_src(&self, IpAddr, u32) -> bool` — receiver changes `&mut` →
+  `&` (private to `super`, only callers are in `screen/mod.rs`); return
+  type and semantics unchanged.
+- `check_dst(&self, IpAddr, u32) -> bool` — same.
+- `session_created`, `session_expired` — UNCHANGED.
+- `ScreenState::check_packet*`, `session_created`, `session_expired`
+  public API — UNCHANGED.
+
+## Hidden invariants the change must preserve
+
+1. **Pre-check ordering**: check runs before `session_created`; the
+   `(limit+1)`-th attempt is dropped. Preserved — only the read
+   mechanism changes.
+2. **First-session-for-new-IP admits**: absent IP must read as 0 and
+   pass. `get().unwrap_or(0)` returns 0 for absent → `0 >= limit` is
+   false for `limit >= 1`. Preserved.
+3. **Count map populated only by `session_created`, drained to empty by
+   `session_expired`**: after the fix this becomes strictly true (it was
+   the intended contract; the bug was the read path also populating it).
+4. **No new per-packet allocation**: `get` does not allocate or grow the
+   table; strictly fewer writes than before. No regression.
+5. **`limit == 0` early return** unchanged (session-limit disabled path).
+6. **Borrow shape**: `&self` callee from `&mut self` caller compiles;
+   `session_limits` field access stays a disjoint borrow.
+
+## Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Read semantics identical for present IPs; absent IP read-as-0 matches the old freshly-inserted-0 behavior. Limit enforcement byte-for-byte equivalent. |
+| Lifetime / borrow-checker | LOW | `&mut self` → `&self` is a relaxation; callers hold `&mut self` and can call `&self` methods. No new borrows. |
+| Performance regression | LOW (net win) | Removes a hash insert + potential rehash from the hot path. `get` is cheaper than `entry`. |
+| Architectural mismatch | LOW | Targets the exact reported defect; matches the issue's own suggested fix. No new abstraction. |
+
+## Test plan
+
+- `cargo build` clean (TMPDIR=/dev/shm, CARGO_TARGET_DIR=/dev/shm).
+- `cargo test --release` full userspace-dp suite — all pass.
+- New `session_limit_no_leak_on_distinct_ip_churn` 5/5 flake check.
+- Confirm the leak test FAILS on the pre-fix code (run once against the
+  unmodified `check_src` to prove non-tautological), then fix.
+- Go suite (`go test ./...`) — unaffected (Rust-only change) but run to
+  confirm no breakage.
+- **Cluster smoke: DEFERRED TO PARENT.** Per the driving directive this
+  is a SECURITY / hot-path change; the parent runs targeted smoke if
+  needed. Smoke is marked pending parent-run.
+
+## Out of scope (explicitly)
+
+- Capping / LRU-bounding the count map beyond evict-on-zero. With the
+  read side effect removed, the map is already bounded by the number of
+  IPs with live sessions, which is itself bounded by the configured
+  per-IP limit times the number of distinct peers with live sessions —
+  no separate cap needed. A hard cap is a possible future hardening but
+  is not required to close this DoS.
+- Extending periodic cleanup to sweep `session_limits` — unnecessary
+  once the map only holds live-session IPs and prunes to empty.
+- Any change to `port_scan` / `ip_sweep` trackers.
+
+## Open questions for adversarial review
+
+1. Is `get(&ip).copied().unwrap_or(0) >= limit` semantically identical
+   to the old `*entry(ip).or_insert(0) >= limit` for ALL inputs,
+   including the first-session-for-a-new-IP admit case? (Claim: yes —
+   absent reads as 0.)
+2. After the fix, is the count map provably bounded by live sessions
+   only? Is there ANY remaining path that inserts a key without a
+   matching `session_expired` decrement-to-zero removal?
+3. Does changing `&mut self` → `&self` create any borrow conflict at the
+   `mod.rs` call sites, or interact badly with any other `&mut`
+   field access in `check_packet_with_zone_id`?
+4. Is the leak-churn test genuinely non-tautological — does it FAIL
+   against the unmodified code and PASS only after the fix? Is asserting
+   `src_len() == 0` the right invariant (vs `<= some bound`)?
+5. Could removing the phantom zero entry mask a real session ever being
+   under-counted (e.g. a `session_created` that races a `check` and the
+   entry is briefly absent)? Single-threaded per-worker `ScreenState`
+   means no concurrency — confirm that assumption holds (each worker
+   owns its `ScreenState`; no shared access).
+6. Is evict-on-zero (already present in `session_expired`) the cleanest
+   fix vs never-insert-until-positive vs an LRU cap? (Claim:
+   read-only-check is strictly the simplest and closes the DoS; the
+   write path already evicts-on-zero.)

--- a/docs/pr/2128-session-limit-leak/plan.md
+++ b/docs/pr/2128-session-limit-leak/plan.md
@@ -3,6 +3,11 @@
 **Status:** v2 — Codex round-1 PLAN-KILL addressed (false "already
 maintained" premise removed; enforcement gap split to a follow-up issue;
 leak fix retained as the correct + complete fix for the filed DoS).
+Codex round-2 PLAN-NEEDS-MINOR addressed: the out-of-scope cap note now
+states the correct key-cardinality bound (distinct live-session IPs /
+session-table capacity, NOT the per-IP limit). Codex round-2 confirmed
+the kill is resolved, the leak fix is correct with no residual read-side
+insert, and the leak test is non-tautological.
 
 ## Round-1 adversarial review outcome
 
@@ -265,9 +270,13 @@ fn session_limit_dst_len(&self) -> usize { self.session_limits.dst_len() }
   surface and HA implications — deliberately NOT bundled with this
   security leak fix.
 - Capping / LRU-bounding the count map beyond evict-on-zero. With the
-  read side effect removed, the map is bounded by the number of IPs with
-  live sessions (which, once enforcement is wired, is itself bounded by
-  the configured limit). No separate cap is needed to close THIS DoS.
+  read side effect removed, the map's key cardinality is bounded by the
+  number of DISTINCT IPs that currently have at least one live session —
+  i.e. by global live-session cardinality / the session-table capacity,
+  NOT by the configured per-IP `limit` (the per-IP limit bounds the COUNT
+  stored per key, not how many distinct keys exist). The attacker can no
+  longer add a key without a live session, which is what closes the DoS;
+  no separate cap is needed.
 - Extending periodic cleanup to sweep `session_limits` — unnecessary
   once the read path no longer inserts.
 - Any change to `port_scan` / `ip_sweep` trackers.

--- a/docs/pr/2128-session-limit-leak/plan.md
+++ b/docs/pr/2128-session-limit-leak/plan.md
@@ -1,6 +1,54 @@
 # #2128 — Screen session-limit tracker phantom zero-entry leak (memory-exhaustion DoS)
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** v2 — Codex round-1 PLAN-KILL addressed (false "already
+maintained" premise removed; enforcement gap split to a follow-up issue;
+leak fix retained as the correct + complete fix for the filed DoS).
+
+## Round-1 adversarial review outcome
+
+**Codex round-1: PLAN-KILL** (task `task-mqn9ue7w-e3kuyd`). The verdict
+was correct and is taken seriously. Codex found that the v1 plan's claim
+"the count map is already maintained by `session_created` /
+`session_expired`, leave it untouched" is **false**: production never
+calls `ScreenState::session_created` or `ScreenState::session_expired`.
+Verified independently against source —
+`grep -rn '\.session_created(\|\.session_expired(' userspace-dp/src`
+finds callers ONLY in `screen/tests.rs`; the production session-create
+hook (`poll_descriptor/mod.rs:321`, `resolved.created`) and the expiry
+loop (`worker/loop_body/mod.rs:573`) never notify `screen`. `git log -S`
+confirms `screen_state.session_created` was NEVER wired in `afxdp/`.
+The methods carry `#[cfg_attr(not(test), allow(dead_code))]`, which is
+the smoking gun.
+
+**Consequence (two distinct defects):**
+
+1. **The filed leak (#2128)** — REAL. `check_src`/`check_dst` use
+   `entry(ip).or_insert(0)` to read, inserting a phantom zero entry per
+   distinct IP on the hot path; never reclaimed; unbounded growth ->
+   memory-exhaustion DoS. **This plan's fix fully closes it.**
+2. **Latent enforcement gap** — surfaced by Codex, NOT the filed issue.
+   Because the lifecycle is unwired, the production count map only ever
+   held phantom ZEROS, so `*count >= limit` was `0 >= limit` — always
+   false. **Session-limit screen enforcement has been a no-op in the
+   userspace dataplane since inception.** The read-only fix does not
+   change that (the map stays empty), it just stops the leak. Wiring
+   enforcement correctly requires covering ALL session deletion paths
+   (stale expiry, conntrack GC, HA delete-sync, session clear) plus HA
+   considerations — a separate feature-bug with its own design and test
+   surface. Bolting it onto a security leak fix would be exactly the
+   scope-creep / partial-delete-path leak risk Codex warned about.
+
+**Resolution:** scope this PR to the filed leak (defect 1). Remove the
+false v1 premise. File the enforcement gap (defect 2) as a dedicated
+follow-up issue (#2134) and link it. The leak fix is correct and complete for
+the filed bug regardless of whether enforcement is ever wired: with the
+read path made read-only, the map is populated ONLY by
+`session_created` (currently nothing in production, tests in the suite)
+and pruned to empty by `session_expired` — bounded by definition.
+
+---
+
+DRAFT v1 superseded.
 
 ## Issue framing
 
@@ -53,16 +101,23 @@ PLAN-KILL is an acceptable verdict. (It should not be killed on perf
 grounds — the justification is security/DoS, not throughput — but the
 bar is stated for completeness.)
 
-## What's already shipped / partially batched
+## What's already in the code (corrected after Codex round-1)
 
-- `session_created` / `session_expired` already maintain the count
-  correctly via `entry().or_insert(0) += 1` and saturating decrement +
-  `remove` on reaching 0. Those are the ONLY legitimate writers of the
-  count map and they already prune to empty. The fix must leave them
-  untouched so the prune-to-empty invariant holds.
-- The orchestrator calls `check_src`/`check_dst` BEFORE session
-  creation (mod.rs:342-358) so the `(limit+1)`-th attempt is dropped.
-  This pre-check ordering is preserved.
+- `SessionLimitTracker::session_created` / `session_expired` are the only
+  legitimate WRITERS of the count map: `session_created` does
+  `entry().or_insert(0) += 1`; `session_expired` saturating-decrements
+  and `remove`s on reaching 0 (evict-on-zero is already correct on the
+  write path). They are pruned-to-empty by construction.
+- **They are NOT called from production.** The only callers of the
+  `ScreenState` wrappers are `screen/tests.rs`. The methods are
+  `#[cfg_attr(not(test), allow(dead_code))]`. So in production the count
+  map is, today, populated ONLY as a side effect of the buggy read path
+  (`entry().or_insert(0)` in `check_src`/`check_dst`), and only ever with
+  zeros. This is the v1 plan's error; see the round-1 outcome above.
+- The orchestrator calls `check_src`/`check_dst` BEFORE session creation
+  (`mod.rs:342-358`) so a real `(limit+1)`-th attempt WOULD be dropped —
+  if the count were ever non-zero. The pre-check ordering is preserved
+  by this change; making enforcement actually fire is the follow-up.
 
 ## Concrete design
 
@@ -165,8 +220,10 @@ fn session_limit_dst_len(&self) -> usize { self.session_limits.dst_len() }
    pass. `get().unwrap_or(0)` returns 0 for absent → `0 >= limit` is
    false for `limit >= 1`. Preserved.
 3. **Count map populated only by `session_created`, drained to empty by
-   `session_expired`**: after the fix this becomes strictly true (it was
-   the intended contract; the bug was the read path also populating it).
+   `session_expired`**: after the fix this becomes strictly true — the
+   read path no longer writes. (In production today nothing calls
+   `session_created`, so the map stays empty; that is the separate
+   enforcement gap, not a leak.)
 4. **No new per-packet allocation**: `get` does not allocate or grow the
    table; strictly fewer writes than before. No regression.
 5. **`limit == 0` early return** unchanged (session-limit disabled path).
@@ -197,14 +254,22 @@ fn session_limit_dst_len(&self) -> usize { self.session_limits.dst_len() }
 
 ## Out of scope (explicitly)
 
+- **Wiring session-limit enforcement into the production lifecycle**
+  (defect 2 above) — filed as #2134. It needs a
+  design that notifies `screen.session_created` on `resolved.created`
+  (poll_descriptor) and `screen.session_expired` on EVERY session
+  delete path (stale expiry in loop_body, conntrack GC, HA delete-sync,
+  `clear security flow session`), or it will leak in the opposite
+  direction (counts that never decrement eventually block legitimate
+  traffic). That is a feature-correctness change with its own test
+  surface and HA implications — deliberately NOT bundled with this
+  security leak fix.
 - Capping / LRU-bounding the count map beyond evict-on-zero. With the
-  read side effect removed, the map is already bounded by the number of
-  IPs with live sessions, which is itself bounded by the configured
-  per-IP limit times the number of distinct peers with live sessions —
-  no separate cap needed. A hard cap is a possible future hardening but
-  is not required to close this DoS.
+  read side effect removed, the map is bounded by the number of IPs with
+  live sessions (which, once enforcement is wired, is itself bounded by
+  the configured limit). No separate cap is needed to close THIS DoS.
 - Extending periodic cleanup to sweep `session_limits` — unnecessary
-  once the map only holds live-session IPs and prunes to empty.
+  once the read path no longer inserts.
 - Any change to `port_scan` / `ip_sweep` trackers.
 
 ## Open questions for adversarial review

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -453,6 +453,20 @@ impl ScreenState {
             .unwrap_or(0)
     }
 
+    /// Live source-IP session-limit entry count. Lets tests assert the
+    /// tracker map does not leak phantom zero-count entries under
+    /// distinct-IP churn (#2128).
+    #[cfg(test)]
+    fn session_limit_src_len(&self) -> usize {
+        self.session_limits.src_len()
+    }
+
+    /// Live destination-IP session-limit entry count (#2128).
+    #[cfg(test)]
+    fn session_limit_dst_len(&self) -> usize {
+        self.session_limits.dst_len()
+    }
+
     /// Notify the screen state that a new session was created. This increments
     /// per-IP session counters for session limiting.
     #[cfg_attr(not(test), allow(dead_code))]

--- a/userspace-dp/src/screen/session_limit.rs
+++ b/userspace-dp/src/screen/session_limit.rs
@@ -12,27 +12,37 @@ pub(super) struct SessionLimitTracker {
 
 impl SessionLimitTracker {
     /// Look up the current session count for a source IP and return true
-    /// if it already meets or exceeds `limit`. This does NOT increment —
-    /// the count is moved by [`session_created`] / [`session_expired`].
+    /// if it already meets or exceeds `limit`. This is strictly read-only —
+    /// the count is moved only by [`session_created`] / [`session_expired`].
     /// The orchestrator runs this BEFORE session creation so the
     /// (limit+1)-th attempt is dropped.
-    pub(super) fn check_src(&mut self, ip: IpAddr, limit: u32) -> bool {
+    ///
+    /// The receiver is `&self` deliberately: an earlier implementation used
+    /// `entry(ip).or_insert(0)` to read the count, which inserted a phantom
+    /// zero-count entry as a side effect for every distinct source IP that
+    /// reached the screen stage. Those entries were never reclaimed
+    /// (`session_expired` only removes entries first incremented by
+    /// `session_created`), so a flood from many distinct/spoofed source IPs
+    /// grew this per-worker map without bound — a memory-exhaustion DoS
+    /// (issue #2128). An absent IP reads as 0, so the first session attempt
+    /// for a never-seen IP still passes, identical to the old freshly-
+    /// inserted-zero behaviour. Keeping this `&self` makes the read-only
+    /// contract compiler-enforced so the leak cannot regress.
+    pub(super) fn check_src(&self, ip: IpAddr, limit: u32) -> bool {
         if limit == 0 {
             return false;
         }
-        let count = self.src_counts.entry(ip).or_insert(0);
-        *count >= limit
+        self.src_counts.get(&ip).copied().unwrap_or(0) >= limit
     }
 
     /// Look up the current session count for a destination IP and return
     /// true if it already meets or exceeds `limit`. Mirror of
-    /// [`check_src`]; does NOT increment the count.
-    pub(super) fn check_dst(&mut self, ip: IpAddr, limit: u32) -> bool {
+    /// [`check_src`]; strictly read-only (see #2128).
+    pub(super) fn check_dst(&self, ip: IpAddr, limit: u32) -> bool {
         if limit == 0 {
             return false;
         }
-        let count = self.dst_counts.entry(ip).or_insert(0);
-        *count >= limit
+        self.dst_counts.get(&ip).copied().unwrap_or(0) >= limit
     }
 
     /// Called when a new session is created (after the check passes).
@@ -57,5 +67,18 @@ impl SessionLimitTracker {
                 self.dst_counts.remove(&dst_ip);
             }
         }
+    }
+
+    /// Number of live source-IP entries. Used by tests to assert the map
+    /// stays bounded (does not leak phantom zero-count entries, #2128).
+    #[cfg(test)]
+    pub(super) fn src_len(&self) -> usize {
+        self.src_counts.len()
+    }
+
+    /// Number of live destination-IP entries. Mirror of [`src_len`].
+    #[cfg(test)]
+    pub(super) fn dst_len(&self) -> usize {
+        self.dst_counts.len()
     }
 }

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -1911,6 +1911,119 @@ fn session_limit_decrements_on_expire() {
     assert_eq!(state.check_packet("trust", &pkt2, 1), ScreenVerdict::Pass);
 }
 
+/// Regression guard for #2128: the session-limit tracker must NOT leak a
+/// phantom zero-count entry per distinct source IP. Driving many distinct
+/// source IPs through the screen check WITHOUT ever creating a session
+/// (the spoofed-flood / dropped-by-policy / stateless-packet case) must
+/// leave the tracker map empty. Pre-fix `check_src` used
+/// `entry(ip).or_insert(0)`, which inserted a permanent entry per IP and
+/// would leave the map at size N here — an unbounded memory-exhaustion
+/// DoS. This test FAILS against that implementation and passes only with
+/// the read-only check, so it is non-tautological.
+#[test]
+fn session_limit_no_leak_on_distinct_ip_churn() {
+    let mut profile = ScreenProfile::default();
+    profile.session_limit_src = 5;
+    profile.session_limit_dst = 5;
+    let mut state = make_state("untrust", profile);
+
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    // Spray 1000 distinct source IPs (and 1000 distinct dst IPs) through
+    // the screen check. None of them ever calls session_created, mirroring
+    // a spoofed-source flood whose packets pass stateless screen but never
+    // establish a session.
+    for i in 0..1000u32 {
+        let octets = i.to_be_bytes();
+        let src = IpAddr::V4(Ipv4Addr::new(10, 1, octets[2], octets[3]));
+        let dst_spray = IpAddr::V4(Ipv4Addr::new(10, 2, octets[2], octets[3]));
+        let pkt = tcp_pkt(src, dst, 1234, 80, TCP_SYN);
+        assert_eq!(state.check_packet("untrust", &pkt, 1), ScreenVerdict::Pass);
+        let pkt2 = tcp_pkt(IpAddr::V4(Ipv4Addr::new(10, 3, 0, 1)), dst_spray, 1235, 80, TCP_SYN);
+        assert_eq!(
+            state.check_packet("untrust", &pkt2, 1),
+            ScreenVerdict::Pass
+        );
+    }
+
+    // The read-only check must not have populated the tracker maps: no
+    // session was ever created, so the maps stay empty regardless of how
+    // many distinct IPs were checked.
+    assert_eq!(
+        state.session_limit_src_len(),
+        0,
+        "src_counts leaked entries under distinct-IP churn (#2128)"
+    );
+    assert_eq!(
+        state.session_limit_dst_len(),
+        0,
+        "dst_counts leaked entries under distinct-IP churn (#2128)"
+    );
+}
+
+/// The tracker map must grow only with live sessions and return to empty
+/// when the last session for an IP closes (#2128 evict-on-zero invariant).
+#[test]
+fn session_limit_entry_removed_on_last_expire() {
+    let mut profile = ScreenProfile::default();
+    profile.session_limit_src = 4;
+    profile.session_limit_dst = 4;
+    let mut state = make_state("trust", profile);
+
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+
+    // No sessions yet -> empty.
+    assert_eq!(state.session_limit_src_len(), 0);
+    assert_eq!(state.session_limit_dst_len(), 0);
+
+    // One live session -> one entry on each side.
+    state.session_created(src, dst);
+    assert_eq!(state.session_limit_src_len(), 1);
+    assert_eq!(state.session_limit_dst_len(), 1);
+
+    // A read-only check for the same (and a different) IP must not change
+    // the entry count.
+    let other = IpAddr::V4(Ipv4Addr::new(10, 9, 9, 9));
+    let pkt = tcp_pkt(src, dst, 1111, 80, TCP_SYN);
+    assert_eq!(state.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
+    let pkt_other = tcp_pkt(other, other, 2222, 80, TCP_SYN);
+    assert_eq!(state.check_packet("trust", &pkt_other, 1), ScreenVerdict::Pass);
+    assert_eq!(state.session_limit_src_len(), 1);
+    assert_eq!(state.session_limit_dst_len(), 1);
+
+    // Expiring the last session prunes the entry back to empty.
+    state.session_expired(src, dst);
+    assert_eq!(state.session_limit_src_len(), 0);
+    assert_eq!(state.session_limit_dst_len(), 0);
+}
+
+/// Count tracks up and down across multiple sessions for one IP, and the
+/// entry survives until the final expire (#2128).
+#[test]
+fn session_limit_count_tracks_up_and_down() {
+    let mut profile = ScreenProfile::default();
+    profile.session_limit_src = 10;
+    let mut state = make_state("trust", profile);
+
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let dst1 = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let dst2 = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 2));
+    let dst3 = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 3));
+
+    state.session_created(src, dst1);
+    state.session_created(src, dst2);
+    state.session_created(src, dst3);
+    // Three sessions for one src IP collapse to a single map entry (count 3).
+    assert_eq!(state.session_limit_src_len(), 1);
+
+    state.session_expired(src, dst1);
+    assert_eq!(state.session_limit_src_len(), 1, "entry must survive while count > 0");
+    state.session_expired(src, dst2);
+    assert_eq!(state.session_limit_src_len(), 1, "entry must survive while count > 0");
+    state.session_expired(src, dst3);
+    assert_eq!(state.session_limit_src_len(), 0, "entry removed when count hits 0");
+}
+
 // ================================================================
 // Port scan detection
 // ================================================================


### PR DESCRIPTION
## Summary

The screen session-limit tracker (`limit-session source-ip-based` /
`destination-ip-based`) leaked an unbounded zero-count HashMap entry per
distinct source/destination IP. `SessionLimitTracker::check_src` /
`check_dst` read the per-IP count with `self.src_counts.entry(ip).or_insert(0)`,
whose insert side effect permanently allocates an entry for every IP that
reaches the screen stage on the ingress hot path — even when the packet
never creates a session (spoofed-source flood, dropped-by-policy,
stateless UDP/ICMP). These phantom entries are never reclaimed
(`session_expired` only removes entries first incremented by
`session_created`), so a many-distinct/spoofed-source flood grows the
per-worker map without bound — a memory-exhaustion DoS, the precise
inversion of the protection `limit-session` is meant to provide (issue
#2128).

**Fix (evict-on-zero / read-only check):** make `check_src`/`check_dst`
strictly read-only — `get(&ip).copied().unwrap_or(0) >= limit`. An absent
IP reads as 0 so the first attempt for a never-seen IP still passes,
identical to the old freshly-inserted-zero behaviour; limit enforcement
at the threshold is byte-for-byte equivalent. The count map is then
populated only by `session_created` and pruned to empty by
`session_expired` (which already evicts on count 0), bounding it to IPs
with live sessions. The receiver is tightened `&mut self` -> `&self` so
the read-only contract is **compiler-enforced** and the leak cannot
silently regress.

## Plan + adversarial review

Plan doc: `docs/pr/2128-session-limit-leak/plan.md`

- **Codex round-1: PLAN-KILL** (task `task-mqn9ue7w-e3kuyd`) — correct
  and addressed. Codex found the v1 plan's premise ("count map already
  maintained by create/expire") was false: production never calls
  `ScreenState::session_created`/`session_expired` (only tests do; the
  methods are `#[cfg_attr(not(test), allow(dead_code))]`). This surfaced
  an **orthogonal latent defect** — session-limit enforcement is a no-op
  in the dataplane because the lifecycle is unwired (the count is always
  0). That is filed as **#2134** and is deliberately OUT OF SCOPE for
  this security leak fix. The plan was revised to v2 to drop the false
  premise and separate the two defects.
- **Codex round-2:** re-review of the v2 plan + committed leak fix — in
  progress.
- **Independent second review (AGY):** to be dispatched by the parent
  (the AGY MCP tool operates on the MCP workspace, not safely scoped to
  this worktree from a sub-agent — flagged rather than risk a checkout
  hijack).

## Scope note

This PR fixes ONLY the memory-leak DoS (issue #2128). The separate
enforcement-wiring gap is tracked in #2134.

## Test plan

- [x] `cargo build` clean (TMPDIR=/dev/shm, CARGO_TARGET_DIR=/dev/shm)
- [x] `cargo test --release`: **2091 passed**, rebased on current master.
  The only failure is the pre-existing flaky
  `afxdp::worker_queue::concurrent_recovery_processes_each_command_exactly_once`
  timing test — byte-identical to origin/master, touches no
  screen/session_limit code, fails 2/5 in isolation on unmodified code
  (independently confirmed flaky by the parallel #2118 work).
- [x] **Non-tautological leak guard**: `session_limit_no_leak_on_distinct_ip_churn`
  sprays 1000 distinct src+dst IPs through the screen check WITHOUT
  creating sessions and asserts both tracker maps return to size 0.
  Verified it **FAILS against the pre-fix `entry().or_insert(0)` code**
  (panics: "src_counts leaked entries under distinct-IP churn") and
  passes only with the read-only fix.
- [x] `session_limit_no_leak_on_distinct_ip_churn` 5/5 flake check.
- [x] `session_limit_entry_removed_on_last_expire`,
  `session_limit_count_tracks_up_and_down` (new) +
  `session_limit_src_enforced` / `dst_enforced` /
  `decrements_on_expire` (existing) all pass — entry tracks sessions
  up/down, removed at count 0, limit still enforced at threshold.
- [ ] **Cluster smoke: PENDING PARENT-RUN.** SECURITY / hot-path change;
  per the driving directive the sub-agent does NOT run cluster smoke —
  the parent runs targeted smoke if needed.

## Docs

No module-contract doc references the tracker's internal map behaviour
(`grep` of `userspace-dp/README.md` and `docs/` for session-limit found
only feature/plan docs). The external contract (per-IP limit
enforcement) is unchanged; the plan doc records the change. No doc update
needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)