### PR TITLE
#2121: re-journal un-sent deletes on a full send queue (no silent drop)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -7514,3 +7514,28 @@ top.
 - **Validation**: `go test ./pkg/dhcprelay/ -race` 25/25 pass; config + cli +
   daemon green; `go build ./...` clean. Live flag0 wire-capture +
   test-failover pending parent-run (lab-gated).
+
+## 2026-06-20 — #2121 flushDeleteJournal: re-journal un-sent deletes (no silent drop)
+- **Timestamp**: 2026-06-20
+- **Action**: Fix flushDeleteJournal silently dropping journaled deletes on a
+  full send queue. Replay now goes through the ordered send channel; on a
+  queueMessage failure (full sendCh or disconnect) the un-sent tail is
+  re-journaled (FIFO-prepended, oldest-evicted on overflow) instead of dropped,
+  matching the QueueDeleteV4/V6 journal-on-failure contract. Non-blocking — no
+  timeout/force-disconnect (5 prior plan rounds; v1/v2 KILLED, v3/v4 NEEDS-MAJOR
+  for ordering/liveness; v5.1 PLAN-READY by Claude-SMR + AGY, Codex framing-only
+  NEEDS-MAJOR re-scoped honestly). Also fixed a pre-existing data race in
+  TestBulkEpochMismatchIgnored (test-local `called` bool) surfaced by -race.
+- **File(s)**:
+  - `pkg/cluster/sync_conn.go` — flushDeleteJournal re-journal-on-failure +
+    new rejournalTail (FIFO-prepend, cap-bounded, DeletesDropped accounting).
+  - `pkg/cluster/sync_test.go` — TestDeleteJournalFlushRetainsTailOnFullQueue
+    (non-tautological regression), …FlushPartialThenRetains,
+    TestRejournalTailFIFOPrependAndOverflow (3 branches), …FlushAllFit,
+    …FlushOrderingWithQueuedSession; TestBulkEpochMismatchIgnored race fix.
+  - `docs/session-sync-architecture.md` — Delete Journal replay/retention +
+    key-only-delete residual exposure note.
+  - `docs/pr/2121-flushdeletejournal-requeue/plan.md` — plan v1→v5.1.
+- **Validation**: `go test -race ./pkg/cluster/` green; new tests 5/5 flake;
+  regression tests verified FAIL against pre-fix (silent drop); `go build ./...`
+  clean; full `go test ./...` green. Control-plane HA fix — no dataplane smoke.

--- a/_Log.md
+++ b/_Log.md
@@ -7536,6 +7536,6 @@ top.
   - `docs/session-sync-architecture.md` — Delete Journal replay/retention +
     key-only-delete residual exposure note.
   - `docs/pr/2121-flushdeletejournal-requeue/plan.md` — plan v1→v5.1.
-- **Validation**: `go test -race ./pkg/cluster/` green; new tests 5/5 flake;
+- **Validation**: `go test -race ./pkg/cluster/` green; new tests 5/5 pass (flake-free);
   regression tests verified FAIL against pre-fix (silent drop); `go build ./...`
   clean; full `go test ./...` green. Control-plane HA fix — no dataplane smoke.

--- a/docs/pr/2121-flushdeletejournal-requeue/plan.md
+++ b/docs/pr/2121-flushdeletejournal-requeue/plan.md
@@ -1,8 +1,11 @@
 # #2121 — flushDeleteJournal must not silently drop journaled deletes on a full send queue
 
-Status: DRAFT v5 — radical simplification after THREE NEEDS-MAJOR on v4
-(Codex + Claude-SMR + AGY converged: the timeout/force-disconnect/deferral
-machinery is the problem). Pending re-review.
+Status: PLAN-READY v5.1 — v5 design approved by Claude-SMR (READY) + AGY
+(READY); Codex (NEEDS-MAJOR) required the safety claim be re-scoped
+honestly (it is, below) — all three agree on the FACTS and the design;
+the disagreement was purely whether the "never worse than drop" wording
+was accurate. v5.1 corrects that over-claim and the full-queue-only
+wording. Design unchanged from v5.
 
 ## Design history (why every "active drain" variant failed)
 
@@ -108,13 +111,18 @@ func (s *SessionSync) flushDeleteJournal() {
 			flushed++
 			continue
 		}
-		// First failure: queue is full. Re-journal this message and the rest
+		// First failure: queueMessage returned false — either the send queue
+		// is full OR the peer disconnected (queueMessage checks Connected
+		// first). Either way, re-journal this message and the rest
 		// (FIFO-prepended ahead of any deletes concurrently journaled during
-		// the flush) and stop — further attempts on a full queue would also
-		// fail, and stopping preserves order.
+		// the flush) and stop: on a full queue the rest would also fail, and
+		// on a disconnect there is nothing to send to. Stopping preserves
+		// order. They replay on the next reconnect flush (the QueueDeleteV4
+		// contract).
 		s.rejournalTail(journal[i:])
-		slog.Warn("cluster sync: delete journal flush hit full send queue, re-journaled un-sent tail for next reconnect",
+		slog.Warn("cluster sync: delete journal flush could not enqueue (queue full or disconnected), re-journaled un-sent tail for next reconnect",
 			"total", len(journal), "flushed", flushed, "rejournaled", len(journal)-i,
+			"connected", s.stats.Connected.Load(),
 			"queue_len", len(s.sendCh), "queue_cap", cap(s.sendCh))
 		return
 	}
@@ -162,41 +170,66 @@ is full the rest will fail too, and stopping keeps the un-sent suffix
 contiguous and ordered. This matches `QueueDeleteV4`, which makes a single
 attempt per delete.)
 
-### Why this is correct AND never worse than today
+### What this fixes, and the honest trade-off (Codex re-scoping)
 
 - **Fixes the filed bug:** un-sent journaled deletes are RETAINED, not
-  dropped. They replay on the next reconnect flush.
-- **No new hazard:** the only behavior change on failure is "re-journal"
-  vs "drop". Re-journal is exactly what `QueueDeleteV4` already does on a
-  full queue (sync_conn.go:517), so the deferred-delete-vs-replacement
-  exposure is identical to existing, accepted behavior — NOT introduced or
-  widened by #2121.
-- **Never worse than the silent drop:** for any `D(K)` that today is
-  silently dropped, v5 retains it for later delivery. The only outcome
-  difference is "D(K) eventually delivered" vs "D(K) lost". Delivering the
-  delete is the issue's goal (the lost delete is the bug). The
-  replacement-resurrection concern is the pre-existing journal property,
-  not a regression here.
+  silently lost. They replay on the next reconnect flush, so a session
+  deleted on the primary is no longer leaked indefinitely on the peer.
+- **Behaviorally identical to the shipped `QueueDeleteV4` contract:** the
+  only change on a `queueMessage` failure is "re-journal" instead of
+  "drop". `QueueDeleteV4`/`V6` already re-journal on a `queueMessage`
+  failure (sync_conn.go:517-529), including a full `sendCh` while
+  connected. So the flush path now uses the same journal, the same replay
+  timing (reconnect flush, before bulk), and the same deferral semantics
+  as the runtime delete path. Consistency, not a new mechanism.
 - **No liveness risk:** non-blocking throughout (queueMessage's
   `default`). No timeout, no force-disconnect, no reconnect storm, no
   accept-loop hang, no dual-fabric teardown — all the v3/v4 hazard surface
   is gone.
-- **Ordering for the delivered deletes:** the deletes that DO enqueue go
+- **Ordering for the delivered deletes:** deletes that DO enqueue go
   through `sendCh` in journal order behind already-queued sessions (the v2
   reorder cannot occur — same single ordered path). The re-journaled tail
   is FIFO-prepended so a later flush replays it before concurrently-
   journaled newer deletes.
 
-### Residual exposure (pre-existing, scoped out)
+**Honest safety statement (corrects the v5 over-claim Codex flagged):**
+v5.1 is NOT unconditionally "never worse than the silent drop." There is a
+specific sequence where retain is worse than drop:
+
+1. `D(K)` journaled while disconnected.
+2. Reconnect; `sendCh` full; flush re-journals `D(K)` (today: drops it).
+3. Link stays healthy; a replacement `S'(K)` is created and successfully
+   synced; the peer installs it; a later sweep advances `lastSweepTime`
+   past `S'(K)` (so it is not re-swept).
+4. A later reconnect flushes the retained `D(K)` before peer callbacks /
+   bulk (handleNewConnection:198); the receiver applies a key-only delete
+   (sync_conn.go:832) and removes the live `S'(K)`.
+
+Silent drop would have spared `S'(K)`; retain can delete it. So #2121
+**widens** the pre-existing key-only-delete-kills-replacement hazard from
+the `QueueDeleteV4` full-queue/disconnect paths TO the flush path. This is
+accepted as a **deliberate trade-off**: it converts an *unrecoverable
+silent loss of a delete* (the filed bug — a session leaked on the peer
+forever) into a *bounded retention with the same already-shipped
+deferred-delete exposure that `QueueDeleteV4` carries today*. The class is
+not new; the surface is widened by one path. Two of three reviewers judged
+this acceptable for a LOW-severity fix; Codex agrees the fix is meaningful
+and required only that the plan say this plainly rather than claim
+"never worse." Done.
+
+### Residual exposure & the real fix
 
 The "a journaled delete can kill a same-key replacement re-synced before
-it replays" class is intrinsic to key-only deletes + a reconnect-surviving
-journal. It already exists for `QueueDeleteV4`'s full-queue and disconnect
-journaling. #2121 does not widen it (v5 only changes drop→retain on the
-flush path, matching `QueueDeleteV4`). Fully eliminating it needs a wire-
-protocol generation/session-identity guard on deletes — a larger,
-backward-incompatible change. **Recommend a follow-up issue.** #2121
-deliberately does the narrow, safe fix.
+it replays" class is intrinsic to **key-only deletes + a reconnect-
+surviving journal**. It already exists for `QueueDeleteV4`'s full-queue and
+disconnect journaling; v5.1 extends it to the flush path (above). Fully
+eliminating it requires a wire-protocol **generation / session-identity
+guard** on deletes so the receiver can refuse a stale delete whose
+generation predates the installed session — a larger, backward-
+incompatible change. **A follow-up issue MUST be filed for the generation
+guard**, and the PR references it. #2121 deliberately ships the narrow,
+LOW-severity fix (stop silently losing deletes) and explicitly defers the
+generation guard.
 
 ## Public API preservation
 
@@ -223,6 +256,11 @@ dependence in tests).
 8. Concurrency: a `QueueDeleteV4` racing the flush appends to the new
    (nil'd→empty) journal; `rejournalTail` FIFO-prepends the older tail
    ahead of it under one lock. No race, no lost delete (validated -race).
+   Benign nil-window (SMR note): between the flush nil-ing `s.deleteJournal`
+   and `rejournalTail` repopulating it, a concurrent `QueueDeleteV4` either
+   enqueues to `sendCh` (succeeds — not journaled) or journals into the
+   empty journal (retained). No delete is ever both un-journaled AND
+   un-sent in that window.
 
 ## Risk assessment
 
@@ -238,24 +276,35 @@ dependence in tests).
 
 New `pkg/cluster` tests, `go test -race ./pkg/cluster/`:
 
+   Test-mechanism note (SMR): `NewSessionSync` hardcodes `sendCh` cap 4096
+   with no knob; in-package tests reassign `s.sendCh = make(chan []byte, N)`
+   post-construction (or push 4096 dummies). Tests #1/#2 use the small-cap
+   reassignment.
+
 1. **TestDeleteJournalFlushRetainsTailOnFullQueue** (non-tautological
-   regression): Connected=true, NO drainer; pre-fill `sendCh` to cap so
-   `queueMessage` fails immediately; journal N deletes; `flushDeleteJournal`.
-   Assert: `s.deleteJournal` now holds all N (re-journaled, FIFO order),
-   `DeletesSent == 0`, `DeletesDropped == 0` (N ≤ cap). Pre-fix: journal
-   nil'd + all dropped → `len(s.deleteJournal)==0` → test fails pre-fix.
-   Deterministic (no goroutine/timing — sendCh full ⇒ queueMessage's
-   `default` fires synchronously).
-2. **TestDeleteJournalFlushPartialThenRetains**: cap-3 `sendCh`, drain
-   nothing; Connected=true; journal 5 deletes; flush. Assert `DeletesSent
-   == 3` (first 3 enqueue), the un-sent 2 are re-journaled at the FRONT,
-   journal len == 2.
+   regression): Connected=true, NO drainer; reassign `s.sendCh` small and
+   pre-fill to cap so `queueMessage` fails immediately; journal N deletes;
+   `flushDeleteJournal`. Assert: `s.deleteJournal` now holds all N
+   (re-journaled, FIFO order), `DeletesSent == 0`, `DeletesDropped == 0`
+   (N ≤ cap). Pre-fix: journal nil'd + all dropped →
+   `len(s.deleteJournal)==0` → test fails pre-fix. Deterministic (no
+   goroutine/timing — sendCh full ⇒ queueMessage's `default` fires
+   synchronously).
+2. **TestDeleteJournalFlushPartialThenRetains**: reassign `s.sendCh` to
+   cap-3, drain nothing; Connected=true; journal 5 deletes; flush. Assert
+   `DeletesSent == 3` (first 3 enqueue), the un-sent 2 are re-journaled at
+   the FRONT, journal len == 2.
 3. **TestRejournalTailFIFOPrependAndOverflow** (unit-test rejournalTail
-   directly): seed `s.deleteJournal` with concurrent `[N1,N2]`; call
-   `rejournalTail([T3,T4,T5])`; assert order `[T3,T4,T5,N1,N2]`. Then with a
-   small cap assert overflow drops oldest tail first
-   (`[T4,T5,N1,N2]`/`[N2,N3]`-style per the dry-runs) and `DeletesDropped`
-   counts exactly the dropped.
+   directly). Cover ALL THREE branches with correctly-derived vectors
+   (SMR: the illustrative `[N2,N3]` label in the design dry-run is a
+   comment artifact — write the actual expected slices from the branch):
+   - no overflow: seed journal `[N1,N2]`; `rejournalTail([T3,T4,T5])`;
+     assert `[T3,T4,T5,N1,N2]`, `DeletesDropped==0`.
+   - overflow within tail (`dropped < len(tail)`): cap 4, journal `[N1,N2]`,
+     tail `[T3,T4,T5]` → assert `[T4,T5,N1,N2]`, `DeletesDropped+=1`.
+   - tail fully dropped (`dropped >= len(tail)`): cap 2, journal
+     `[N1,N2,N3]`, tail `[T3,T4,T5]` → assert `[N2,N3]`,
+     `DeletesDropped+=4`.
 4. **TestDeleteJournalFlushAllFit**: room in `sendCh` + a drainer; journal
    N; flush; assert `DeletesSent == N`, journal empty.
 5. **TestDeleteJournalFlushOrderingWithQueuedSession**: enqueue a session

--- a/docs/pr/2121-flushdeletejournal-requeue/plan.md
+++ b/docs/pr/2121-flushdeletejournal-requeue/plan.md
@@ -1,95 +1,93 @@
 # #2121 — flushDeleteJournal must not silently drop journaled deletes on a full send queue
 
-Status: DRAFT v3 — revised after Codex PLAN-KILL of v1 AND v2; pending re-review
+Status: DRAFT v4 — incorporates Claude-SMR (NEEDS-MINOR) + AGY (NEEDS-MAJOR)
+findings on v3; pending re-review.
 
-## Design history (why v1 and v2 were killed)
+## Design history
 
-- **v1 (re-journal for next-reconnect retry): KILLED.** Deferring a
-  journaled delete across a healthy connected interval can replay it on a
-  later reconnect after a replacement session with the same key was
-  re-synced, wrongly deleting the live replacement (deletes are key-only
-  on the peer — `deleteClusterSynced*` → `DeleteWithCompanions*`, no
-  generation guard). Codex also refuted v1's FIFO "suffix" claim.
-- **v2 (direct-write under writeMu, bypass sendCh): KILLED.** Bypassing
-  `sendCh` re-orders the delete ahead of session frames already queued in
-  `sendCh`. Concrete resurrection: (1) `S(K)` queued to `sendCh` while
-  connected, not yet written; (2) connection drops — **`handleDisconnect`
-  does NOT drain `sendCh`** (verified, sync_conn.go); (3) `D(K)` journaled
-  while disconnected; (4) reconnect flush direct-writes `D(K)`; (5)
-  `sendLoop` later writes the stale queued `S(K)`, resurrecting the
-  deleted session. Codex noted the codebase already solves this class:
-  **barriers deliberately go through `sendCh`** (`writeBarrierMessage`,
-  sync_bulk.go:308) "to preserve ordering with already-queued session
+- **v1 (re-journal failed deletes for retry on the NEXT reconnect):
+  KILLED (Codex).** Deletes are key-only on the peer
+  (`deleteClusterSynced*` → `DeleteWithCompanions*`, no generation guard).
+  Deferring a delete across a healthy connected interval can replay it on
+  a later reconnect after a replacement session with the same key was
+  re-synced, wrongly deleting the live replacement.
+- **v2 (direct-write each frame under writeMu, bypass sendCh): KILLED
+  (Codex).** `handleDisconnect` does NOT drain `sendCh`, so a session
+  frame `S(K)` queued before a disconnect survives; on reconnect the flush
+  direct-writes `D(K)` while the stale `S(K)` is still in `sendCh` and
+  `sendLoop` writes it AFTER `D(K)`, resurrecting the deleted session. The
+  codebase already solves this class: `writeBarrierMessage` (sync_bulk.go)
+  goes through `sendCh` "to preserve ordering with already-queued session
   messages."
-
-## v3 design (the correct ordering discipline)
-
-Replay journaled deletes **through `sendCh`, with a bounded blocking
-send** — exactly the pattern `writeBarrierMessage` uses for ordering-
-sensitive stream messages. This reconciles the two kill findings:
-
-- Through `sendCh` ⇒ the delete is enqueued **behind** any session frames
-  already queued in `sendCh`, then drained by `sendLoop` in FIFO order →
-  no S(K)/D(K) reordering (fixes v2 kill).
-- Blocking (bounded) send instead of `queueMessage`'s non-blocking
-  `select/default` ⇒ a full `sendCh` no longer drops; the flush waits for
-  `sendLoop` to make room (fixes the original bug).
-- Re-journal ONLY on send timeout or no-connection ⇒ deferral happens
-  only when the stream is genuinely stalled (peer wedged), the one case
-  where the next-reconnect flush is the correct place to retry. No
-  deferral while the link is healthy (so the v1 stale-replacement hazard
-  does not arise in the common case).
+- **v3 (replay through sendCh, per-message blocking send): NEEDS-MAJOR.**
+  Correct channel-ordered approach, but three implementation defects, all
+  fixed in v4 below:
+  - **Liveness hang (SMR finding #1 + AGY §3, CRITICAL):** the per-message
+    `syncWriteDeadline` reset means a slow-but-not-stalled peer
+    (~1.5s/frame) blocks the synchronous accept/dial loop for
+    `N × syncWriteDeadline` — up to `deleteJournalCap × 2s` (~hours for a
+    10k journal). Worse than the silent drop. → **Fix A: single global
+    flush timeout.**
+  - **Re-journal FIFO inversion + overflow bias (AGY §4, CRITICAL):**
+    `rejournalAll` appended the un-sent tail to the END of the journal,
+    placing it AFTER deletes concurrently journaled during the flush
+    (`QueueDeleteV4` on a full `sendCh` while connected), inverting replay
+    order; and on overflow `journalDelete`'s front-eviction drops the
+    NEWER concurrent deletes. → **Fix B: FIFO-prepend merge under a single
+    lock, evict oldest from the merged front.**
+  - **Active-deferral stale-replacement (AGY §4 + SMR Q4, MAJOR):** on a
+    timeout where the link does NOT immediately drop, the re-journaled
+    deletes wait for the next reconnect while a replacement `S'(K)` is
+    synced on the healthy link → on reconnect `D(K)` kills the live
+    `S'(K)` (the v1 hazard, reintroduced via the timeout path). → **Fix C:
+    on timeout, force-close the connection so the deferral is to a genuine
+    disconnect, not a healthy interval.**
 
 ## Issue framing
 
 `pkg/cluster/sync_conn.go`. `flushDeleteJournal` — invoked from
 `handleNewConnection` on the first post-disconnect connection — drains the
 bounded delete journal under lock (`s.deleteJournal = nil`), then replays
-each delete via `queueMessage`, whose `sendCh` send is **non-blocking**
-(`select { case s.sendCh <- msg: ... default: return false }`). If
-`sendCh` (cap 4096) is full at replay time the un-sent deletes are
-**silently dropped** (the journal was already nil'd). The dropped delete
-leaves a stale session on the peer until it independently ages out,
-defeating the journal's purpose. `queueMessage`'s overflow sets
-`syncBackfillNeeded`, which re-sweeps SESSIONS (not deletes), so the drop
-is not recovered.
+each delete via `queueMessage`, whose `sendCh` send is **non-blocking**.
+If `sendCh` (cap 4096) is full at replay time the un-sent deletes are
+**silently dropped** (journal already nil'd), leaving stale sessions on
+the peer until they age out. `queueMessage`'s overflow re-sweeps SESSIONS
+(`syncBackfillNeeded`), not deletes, so the drop is unrecovered.
 
-Severity: LOW — narrow window (queue full immediately after a fresh
-connect, before the send loop drains it), consequence is a stale standby
-session, not a forwarding error.
+Severity: LOW — narrow window, consequence is a stale standby session.
 
 ## Relevant existing behavior (verified against master 325d10683)
 
-- Journaled messages are **full framed frames**: `encodeDeleteV4`/`V6`
-  return `syncHeaderSize+payload` bytes; `sendLoop` writes them verbatim
-  via `writeFull(conn, msg)` (sync_conn.go:694). So a journaled delete is
-  a valid `sendCh` element exactly as produced (`QueueDeleteV4` already
-  puts the same frame on `sendCh` via `queueMessage`).
-- `sendLoop` (sync_conn.go:681) pulls each `sendCh` message and writes it
-  under `writeMu`, retrying on disconnect; it drains continuously on a
-  healthy connection.
-- **Ordering precedent:** `writeBarrierMessage` (sync_bulk.go:308) sends
-  through `sendCh` with a timed blocking send
-  (`select { case s.sendCh <- msg: case <-timer.C: return err }`)
-  expressly "to preserve ordering with already-queued session messages."
-  v3 adopts this for delete replay.
+- Journaled messages are full framed frames (`encodeDeleteV4`/`V6`);
+  `sendLoop` writes them verbatim via `writeFull`.
+- `sendCh` is the SINGLE ordered FIFO path; `sendLoop` (sync_conn.go:681)
+  the SINGLE writer (under `writeMu`). The only `sendCh <-` sites are
+  `queueMessage` (489), `writeBarrierMessage` (320), and the proposed
+  flush. (Confirmed by both reviewers.)
+- `writeBarrierMessage` (sync_bulk.go:308) sends through `sendCh` with a
+  timed blocking send "to preserve ordering with already-queued session
+  messages" — the precedent v4 follows.
 - `flushDeleteJournal` runs synchronously in `handleNewConnection`
-  (sync_conn.go:200) BEFORE `OnPeerConnected` and bulk, on the accept
-  goroutine. `Connected` is set true earlier (sync_conn.go:186), so
-  `sendLoop` and producers run concurrently with the flush — which is
-  fine: through-`sendCh` FIFO is exactly the ordering we want.
-- `handleDisconnect` does NOT drain `sendCh` (verified) — the reason v2's
-  bypass was unsafe and why v3 must use the same channel.
-- `journalDelete` (sync_conn.go:534): bounded ring append, evicts oldest +
-  increments `DeletesDropped` at cap (default 10000). Takes
-  `deleteJournalMu`.
-- `DeletesSent` incremented only on a real `sendCh` enqueue (inside
-  `queueMessage` today; v3 increments on the blocking enqueue). Surfaced
-  via `SyncStatsSnapshot`.
-- `syncWriteDeadline = 2s` (sync.go:73) — the per-frame wire write bound
-  used as the per-message enqueue timeout below.
+  (sync_conn.go:200) BEFORE `OnPeerConnected` and `doBulkSync` (207), on
+  the accept/dial-loop goroutine. `Connected` set true earlier (186).
+- **`handleNewConnection` is single-flush per reconnect:** `wasDisconnected`
+  is computed under `s.mu` (158-159) before the conn pointer is set, so
+  only the first fabric to flip `conn0/conn1` from nil sees
+  `wasDisconnected==true` and flushes. Two simultaneous fresh connections
+  cannot both flush the (nil'd) journal. (SMR finding.)
+- `handleDisconnect` does NOT drain `sendCh` (verified) — already-queued
+  frames survive a disconnect.
+- `journalDelete` (534): bounded ring append, FIFO front-eviction +
+  `DeletesDropped++` at cap (`deleteJournalCap`, default 10000).
+- `BulkSync` (sync_bulk.go:79) writes session frames DIRECTLY under
+  `writeMu` (not via `sendCh`).
+- `syncWriteDeadline = 2s` (sync.go:73). `sendCh` cap 4096 (sync.go:381).
 
-## Concrete design
+## Concrete design (v4)
+
+Replay journaled deletes through `sendCh` with a **single global-timeout**
+blocking send; on timeout or disconnect, **FIFO-prepend** the un-sent tail
+back into the journal and, on timeout, **force-close** the connection.
 
 ```go
 func (s *SessionSync) flushDeleteJournal() {
@@ -100,206 +98,245 @@ func (s *SessionSync) flushDeleteJournal() {
 	if len(journal) == 0 {
 		return
 	}
+	// Fix A: ONE global timeout for the whole flush bounds how long the
+	// accept/dial loop can block to a constant, independent of journal size
+	// or drain rate (per-message reset allowed O(N*deadline) hangs).
+	timer := time.NewTimer(syncWriteDeadline)
+	defer timer.Stop()
+
 	var sent int
-	timer := time.NewTimer(0)
-	if !timer.Stop() {
-		<-timer.C
-	}
-	// Replay journaled deletes THROUGH sendCh (not a direct write) so they
-	// stay ordered behind any session frames already queued in sendCh, then
-	// drain via sendLoop in FIFO order. Use a bounded blocking send (mirror
-	// writeBarrierMessage) so a full sendCh does not drop the delete — we
-	// wait for sendLoop to make room. On a genuine stall (timeout) or a
-	// dropped connection, re-journal the un-sent tail for the next reconnect
-	// flush (the original journal-on-disconnect contract — still ordered
-	// ahead of normal sync because flush runs before it).
 	for i, msg := range journal {
 		if !s.stats.Connected.Load() {
-			s.rejournalAll(journal[i:])
+			// Disconnected mid-flush: defer the tail to the next reconnect
+			// flush (runs before normal sync — the original contract).
+			s.rejournalTail(journal[i:])
 			slog.Warn("cluster sync: delete journal flush aborted (disconnected), re-journaled tail",
 				"total", len(journal), "sent", sent, "rejournaled", len(journal)-i)
 			return
 		}
-		timer.Reset(syncWriteDeadline)
 		select {
 		case s.sendCh <- msg:
 			s.stats.DeletesSent.Add(1)
 			sent++
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
 		case <-timer.C:
-			// sendCh stayed full past the deadline: stream stalled. Defer
-			// the rest to the next reconnect flush rather than spin.
-			s.rejournalAll(journal[i:])
+			// Fix A: global budget exhausted (sendCh stayed full → stream
+			// stalled). Defer the tail AND (Fix C) force-disconnect so the
+			// deferral is to a genuine reconnect, not a healthy interval —
+			// otherwise a replacement S'(K) synced on the still-up link
+			// would be killed by the deferred D(K) on the next reconnect.
+			s.rejournalTail(journal[i:])
 			s.stats.Errors.Add(1)
-			slog.Warn("cluster sync: delete journal flush stalled on full send queue, re-journaled un-sent tail",
+			slog.Warn("cluster sync: delete journal flush timed out on full send queue, re-journaled tail and forcing reconnect",
 				"total", len(journal), "sent", sent, "rejournaled", len(journal)-i,
 				"queue_len", len(s.sendCh), "queue_cap", cap(s.sendCh))
+			if conn := s.getActiveConn(); conn != nil {
+				s.handleDisconnect(conn)
+			}
 			return
 		}
 	}
 	slog.Info("cluster sync: flushed delete journal", "total", len(journal), "sent", sent)
 }
 
-// rejournalAll re-appends un-sent delete frames to the journal under lock,
-// honoring the bounded cap (journalDelete counts genuine loss via
-// DeletesDropped). Used only when the stream is stalled or the connection
-// is gone — the next reconnect flush replays them before normal sync.
-func (s *SessionSync) rejournalAll(msgs [][]byte) {
-	for _, msg := range msgs {
-		s.journalDelete(msg)
+// rejournalTail re-inserts the un-sent delete tail at the FRONT of the
+// journal so it replays BEFORE any deletes concurrently journaled during
+// the flush (Fix B — preserve FIFO; appending to the end inverted order).
+// On overflow it drops the OLDEST entries from the front of the merged
+// list (the tail), counting them in DeletesDropped — never the newer
+// concurrently-journaled deletes. One lock acquisition.
+func (s *SessionSync) rejournalTail(tail [][]byte) {
+	if len(tail) == 0 {
+		return
 	}
+	s.deleteJournalMu.Lock()
+	defer s.deleteJournalMu.Unlock()
+	cap := s.deleteJournalCap
+	if cap <= 0 {
+		cap = deleteJournalDefaultCap
+	}
+	total := len(tail) + len(s.deleteJournal)
+	if total <= cap {
+		merged := make([][]byte, 0, total)
+		merged = append(merged, tail...)            // older un-sent first
+		merged = append(merged, s.deleteJournal...) // then concurrent new
+		s.deleteJournal = merged
+		return
+	}
+	dropped := total - cap
+	s.stats.DeletesDropped.Add(uint64(dropped))
+	merged := make([][]byte, 0, cap)
+	if dropped < len(tail) {
+		merged = append(merged, tail[dropped:]...)  // drop oldest tail prefix
+		merged = append(merged, s.deleteJournal...)
+	} else {
+		newDropped := dropped - len(tail)           // tail fully dropped
+		merged = append(merged, s.deleteJournal[newDropped:]...)
+	}
+	s.deleteJournal = merged
 }
 ```
 
-(The single reusable `timer` with the standard drain-on-Reset dance avoids
-allocating a timer per message in a possibly-large journal.)
+### Notes on the fixes
 
-### Why through-sendCh blocking send (vs bypass / vs non-blocking)
+- **Fix A bound:** total flush block ≤ `syncWriteDeadline` (2s) regardless
+  of journal length. The risk table's old "one write deadline" claim is now
+  TRUE because the timer is global, not per-message.
+- **Fix B FIFO:** concurrent `QueueDeleteV4`/`V6` during the flush append
+  `D(new)` to `s.deleteJournal` (the now-empty journal). Prepending the
+  un-sent older `tail` keeps replay order `tail` (older) → `D(new)`
+  (newer). Overflow drops the oldest (front of `tail`), never `D(new)`.
+- **Fix C deferral safety:** force-`handleDisconnect` on timeout means the
+  link goes down; a replacement session cannot be synced on a healthy link
+  in the deferral window, so the deferred delete cannot kill a live
+  replacement. The deferral is now to a genuine reconnect — identical to
+  the existing journal-on-disconnect contract. `getActiveConn` +
+  `handleDisconnect` reuse the project's standard teardown (matches
+  `BulkSync`/`sendLoop`).
 
-- **Ordering:** the delete shares the single `sendCh → sendLoop → writeFull`
-  path with queued sessions, so FIFO is preserved — the v2 reordering /
-  resurrection cannot occur.
-- **No silent drop:** the bounded blocking send waits for room; it never
-  takes the `default` drop branch.
-- **Bounded liveness:** `sendLoop` drains continuously on a healthy
-  connection, so the send rarely blocks; on a wedged peer the per-message
-  `syncWriteDeadline` timeout caps the stall and re-journals the rest —
-  the same bound `writeBarrierMessage`/`writeFull` rely on. The flush
-  cannot hang `handleNewConnection` longer than one write deadline beyond
-  the time `sendLoop` needs to drain.
-- **No new ordering hazard on the deferral path:** re-journal happens only
-  on a stall/disconnect — i.e. when nothing is making it onto the wire
-  anyway — so re-journaled deletes still replay on the next reconnect
-  before normal sync. This is the SAME exposure the existing
-  journal-on-disconnect path already has; v3 does not widen it.
+### Residual ordering exposure (scoped, not introduced here)
+
+`QueueDeleteV4`/`V6` (sync_conn.go:515-529) STILL re-journal on a full
+`sendCh` while the link is healthy and connected (`queueMessage` returns
+false → `journalDelete`). That is the v1 hazard (a delete journaled during
+a healthy interval can later kill a same-key replacement). It is
+**pre-existing and untouched by #2121**; fully closing it needs a
+generation/session-identity guard on the delete wire (a separate change).
+#2121 **narrows** the loss (flush no longer drops, and the flush-deferral
+path is now disconnect-gated) but does NOT eliminate this class. Out of
+scope; recommend a follow-up issue for the generation guard.
+
+Cold-start bulk interleaving (AGY §1): `doBulkSync` direct-writes current
+LIVE sessions under `writeMu` after the flush has enqueued all deletes to
+`sendCh`. A live `S(K)` landing after a stale `D(K)` on the wire is the
+SAFE direction (the peer ends with the live session). Pre-existing
+property of direct-write bulk; not introduced by #2121.
 
 ## Public API preservation
 
-No exported API changes. `flushDeleteJournal`, `journalDelete`,
-`queueMessage`, `rejournalAll` unexported. `SyncStats` fields/semantics
+No exported API changes. `flushDeleteJournal`, `rejournalTail`,
+`journalDelete`, `queueMessage` unexported. `SyncStats` fields/semantics
 unchanged. No new field.
 
 ## Hidden invariants the change must preserve
 
-1. **No lock held across the blocking send.** `deleteJournalMu` is
-   released before the loop; the `sendCh` send holds NO lock (matches
-   `writeBarrierMessage`). `rejournalAll`/`journalDelete` re-take
-   `deleteJournalMu` from outside any held lock.
-2. **No deadlock with sendLoop.** `sendLoop` only blocks on `writeFull`
-   (deadline-bounded) or waiting for a conn; it consumes `sendCh`
-   independently of any lock the flush holds (none). Blocking send + active
-   consumer = progress.
-3. **FIFO / ordering:** deletes interleave with queued sessions in `sendCh`
-   in submission order; `sendLoop` is the single writer. Same stream-order
-   guarantee barriers rely on.
-4. **Accounting:** `DeletesSent` incremented once per successful enqueue;
-   re-journaled (stall/disconnect) messages are not counted as sent.
-5. **Bounded re-journal:** `rejournalAll`→`journalDelete` honors the cap;
-   genuine loss surfaced via `DeletesDropped`.
-6. **Termination:** loop bounded by captured `journal`; re-journaled
-   messages go to `s.deleteJournal`, not the loop slice. No livelock.
-7. **Ordering contract preserved:** flush still completes (all enqueued, or
-   tail re-journaled) synchronously before `OnPeerConnected`/bulk.
-8. **Timer hygiene:** one reused `time.Timer`, drained correctly on Reset
-   to avoid a stale fire (the standard Go idiom).
+1. No lock held across the blocking `sendCh` send (matches
+   `writeBarrierMessage`). `rejournalTail` takes `deleteJournalMu` once,
+   from outside any held lock.
+2. No deadlock with `sendLoop`: it consumes `sendCh` independently;
+   `writeFull` is `syncWriteDeadline`-bounded; the flush holds no lock
+   during the send. Termination guaranteed by the global timer + the
+   `Connected` check.
+3. FIFO on the wire: deletes share the single `sendCh → sendLoop` path
+   with queued sessions (fixes v2 reorder). Re-journal prepend keeps FIFO
+   across a deferral (Fix B).
+4. `DeletesSent` incremented once per enqueue; re-journaled messages not
+   counted as sent (matches `queueMessage` semantics).
+5. Bounded journal: `rejournalTail` enforces cap; `tail` ≤ original journal
+   ≤ cap, and `total = len(tail)+len(concurrent)` can exceed cap only via
+   concurrent journaling — handled by the overflow branch (drops oldest,
+   counts `DeletesDropped`).
+6. Termination: loop bounded by captured `journal`; re-journaled messages
+   go to `s.deleteJournal`, not the loop slice. No livelock.
+7. Single-flush per reconnect (mutex-gated `wasDisconnected`), so no two
+   flushes race the nil'd journal.
+8. Force-disconnect on timeout uses the standard `handleDisconnect`
+   teardown; idempotent on a stale conn (handleDisconnect ignores
+   non-active conns).
 
 ## Risk assessment
 
 | Risk class | Level | Notes |
 |---|---|---|
-| Behavioral regression | LOW | Still enqueues to sendCh (same wire path as today's queueMessage); only the full-queue branch changes from drop→bounded-block. |
-| Concurrency / deadlock | LOW | Mirrors writeBarrierMessage (no lock across send); sendLoop drains independently. Covered by -race. |
-| Performance | NONE | Reconnect-only, bounded by journal len; blocking only when sendCh is full (the failure the issue describes). |
-| Architectural mismatch | LOW | Adopts the established ordered-through-sendCh pattern; abandons both broken alternatives. |
+| Behavioral regression | LOW | Same wire path as today's queueMessage; only the full-queue branch changes drop→bounded-block→deferred-with-disconnect. |
+| Concurrency / deadlock | LOW | No lock across send; global timer bounds block; rejournalTail single-lock. -race covered. |
+| Liveness | LOW | Global 2s flush cap (Fix A); force-disconnect prevents inconsistent-state lingering (Fix C). |
+| Ordering | LOW | Single ordered sendCh path; FIFO-prepend on deferral (Fix B). Residual healthy-interval QueueDelete hazard explicitly scoped out. |
+| Performance | LOW | Reconnect-only; blocks only when sendCh full, capped at 2s. |
 
 ## Test plan
 
-New `pkg/cluster` unit tests, `go test -race ./pkg/cluster/`:
+New `pkg/cluster` tests, `go test -race ./pkg/cluster/`:
 
 1. **TestDeleteJournalFlushBlocksThenDeliversOnFullQueue** (non-tautological
-   regression): Connected=true, an active `net.Pipe` conn + a `sendLoop`
-   (or a manual drainer reading `sendCh` and writing the conn). Pre-fill
-   `sendCh` to cap, journal N deletes, start `flushDeleteJournal` in a
-   goroutine, then start draining `sendCh` slowly. Assert: all N delete
-   frames eventually arrive on the wire IN ORDER (after the pre-filled
-   frames), `DeletesSent == N`, journal empty, NO `DeletesDropped`. Against
-   PRE-FIX (`queueMessage` non-blocking) the full sendCh drops all N → 0
-   frames, journal empty → test fails pre-fix.
-2. **TestDeleteJournalFlushStallTimeoutRejournals**: fill `sendCh` to cap
-   with NO drainer (stream stalled), set Connected=true, journal N deletes,
-   flush. With the per-message `syncWriteDeadline`, the first send times out
-   → assert the full tail is re-journaled (`s.deleteJournal` len == N or ==
-   cap with `DeletesDropped`), `DeletesSent == 0`, and an `Errors` bump.
-   (Use a test-injected short deadline if `syncWriteDeadline` is too long
-   for the suite — see Q5.)
-3. **TestDeleteJournalFlushDisconnectedRejournals**: Connected=false,
-   journal N deletes, flush; assert all re-journaled, `DeletesSent == 0`.
-4. **TestDeleteJournalFlushOrderingWithQueuedSession**: enqueue a session
-   frame to `sendCh`, then flush a delete for the SAME key; drain and assert
-   the session frame is read BEFORE the delete (proving through-sendCh FIFO
-   — the property v2 violated).
-5. Existing tests still green; update `TestDeleteJournalBasic` /
-   `TestDeleteJournalReconnectConvergence` wiring as needed (they still
-   assert deletes delivered + journal emptied + `DeletesSent==N`, which
-   v3 preserves).
+   regression): Connected=true, active `net.Pipe`, pre-fill `sendCh` to cap
+   FIRST, journal N deletes, launch `flushDeleteJournal` in a goroutine,
+   THEN start a drainer that reads `sendCh` + writes the conn (strict
+   ordering — drainer starts after the flush goroutine to keep it
+   non-tautological per SMR). Assert: all N delete frames arrive on the
+   wire IN ORDER after the pre-filled frames, `DeletesSent == N`, journal
+   empty, `DeletesDropped == 0`. Pre-fix (non-blocking queueMessage) drops
+   all N → 0 frames → fails. (Verify by reverting the fix.)
+2. **TestDeleteJournalFlushTimeoutRejournalsAndDisconnects**: fill `sendCh`
+   to cap with NO drainer, Connected=true, active conn, journal N deletes,
+   flush with a TEST-INJECTED short flush timeout (see Q-test). Assert: the
+   full tail is re-journaled (`s.deleteJournal` len == N), `DeletesSent ==
+   0`, `Errors >= 1` (>=, not ==, per SMR — sendLoop/handleDisconnect may
+   also bump), and the connection was torn down (Connected false / conn
+   closed).
+3. **TestDeleteJournalFlushRejournalFIFOPrepend** (Fix B): simulate a
+   concurrent journal: pre-seed `s.deleteJournal` is empty, but during the
+   timeout path inject a `D(new)` into the journal before `rejournalTail`
+   runs (or unit-test `rejournalTail` directly): assert the older tail is
+   at the FRONT and `D(new)` after it, and that an overflowing merge drops
+   the oldest tail entries (counted in `DeletesDropped`), never `D(new)`.
+4. **TestDeleteJournalFlushDisconnectedRejournals**: Connected=false,
+   journal N, flush; assert all re-journaled, `DeletesSent == 0`.
+5. **TestDeleteJournalFlushOrderingWithQueuedSession**: enqueue a session
+   frame to `sendCh`, then flush a delete for the SAME key; drain; assert
+   the session is read BEFORE the delete (through-sendCh FIFO — the
+   property v2 violated).
+6. Existing `TestDeleteJournal*` updated for the new active-conn wiring
+   where needed; asserted behavior (deletes delivered, journal emptied,
+   `DeletesSent==N`) preserved.
 
 Gates: `go test -race ./pkg/cluster/`, `go build ./...`, full
 `go test ./...`.
 
-No loss-cluster iperf smoke: control-plane HA delete-journal replay, not a
-dataplane forwarding change.
+No loss-cluster iperf smoke: control-plane HA delete-journal replay logic,
+not a dataplane forwarding change.
 
 ## Docs
 
-`docs/session-sync-architecture.md` §"Delete Journal" (244) and §"Delete
-Journal Overflow" (425): note flush now replays journaled deletes through
-the ordered send stream with a bounded blocking enqueue (so a full send
-queue blocks until drained rather than dropping), and re-journals only on
-a genuine stall/disconnect.
+`docs/session-sync-architecture.md` §"Delete Journal" (244) + §"Delete
+Journal Overflow" (425): flush now replays journaled deletes through the
+ordered send stream with a bounded (global-timeout) blocking enqueue (full
+queue blocks until drained rather than dropping); on stall it re-journals
+the un-sent tail FIFO-first and forces a reconnect; genuine loss at cap is
+counted in `DeletesDropped`.
 
 ## Out of scope (explicitly)
 
-- `sendCh` capacity (4096) — orthogonal.
-- Generation/session-identity guard on deletes — larger wire+receive
-  change; not required once deletes are ordered through `sendCh`. Possible
-  separate hardening issue.
-- A distinct `DeletesRequeued` metric — re-journal now only on
-  stall/disconnect (the normal journaled path); Warn log + `DeletesDropped`
-  cover observability.
-- #2120 (`syncSweep`) — different function, sibling agent. Untouched.
+- `sendCh` capacity (4096).
+- Generation/session-identity guard on deletes (closes the residual
+  healthy-interval `QueueDelete` re-journal hazard) — separate wire+receive
+  change; recommend a follow-up issue.
+- Cold-start bulk direct-write interleaving — pre-existing; safe direction
+  for live sessions.
+- A distinct `DeletesRequeued` metric — Warn log + `DeletesDropped` cover
+  observability.
+- #2120 (`syncSweep`) — different function, sibling agent.
 
-## Open questions for adversarial review
+## Open questions for adversarial re-review
 
-Q1. Does through-`sendCh` blocking send fully resolve the v2 reordering
-    (S(K) queued / D(K) flushed / S(K) resurrects)? Confirm `sendCh` is
-    the single ordered path and `sendLoop` the single writer.
-Q2. Liveness: per-message `syncWriteDeadline` blocking send on the accept
-    goroutine. Can `flushDeleteJournal` ever hang `handleNewConnection`
-    longer than acceptable? Is the timeout→re-journal-tail abort the right
-    escape, or should it keep blocking (matching barriers, which also bound
-    with a timeout)?
-Q3. Deadlock: any scenario where `sendLoop` is blocked AND the flush's
-    blocking send waits on it (with no timeout escape)? The deadline should
-    prevent indefinite block — verify against `sendLoop`'s
-    conn-wait/writeFull-deadline behavior.
-Q4. Stall/disconnect deferral: on timeout/disconnect we re-journal the
-    tail. A stale `S(K)` may still sit in `sendCh` and be written on
-    reconnect after the re-journaled `D(K)` replays — the SAME exposure the
-    existing journal-on-disconnect path has. Is that acceptable (pre-
-    existing, not widened by v3), or must v3 also address it (out of
-    scope)?
-Q5. Test hygiene: `syncWriteDeadline = 2s` makes the stall test slow.
-    Acceptable to add a test-only injectable enqueue deadline field
-    (defaulting to `syncWriteDeadline`)? Or restructure the stall test to
-    avoid the wait?
-Q6. Is incrementing `DeletesSent` on the blocking enqueue (same as
-    `queueMessage` does on its enqueue) correct, vs only on actual wire
-    write? (Existing `DeletesSent` semantics = "handed to the send stream",
-    not "acked".)
-Q7. Timer reuse + drain idiom — is the Reset/Stop/drain dance correct to
-    avoid a stale fire across iterations?
+Q1. Fix A: is a single global `syncWriteDeadline` (2s) the right budget for
+    the whole flush, or should the flush get its own (larger?) constant so a
+    near-full but draining queue still completes? Trade-off: longer budget =
+    more deletes delivered on this connection vs. longer accept-loop block.
+Q2. Fix C: force-`handleDisconnect` on timeout drops the connection (and any
+    deletes already enqueued to `sendCh` this flush ride out the disconnect
+    in `sendCh`, replayed on reconnect). Is dropping a freshly-established
+    connection on a transient full-queue acceptable, given it guarantees the
+    deferral is disconnect-gated? Any reconnect storm risk if the queue is
+    chronically full?
+Q3. Fix B: is FIFO-prepend correct given deletes are idempotent by key? Does
+    order among deletes actually matter, or is the prepend belt-and-braces?
+    (Idempotent-by-key suggests order among pure deletes is not load-
+    bearing, but the inversion-vs-new-delete and overflow-drop-bias are real
+    correctness issues regardless — confirm the prepend resolves both.)
+Q4. Is the residual healthy-interval `QueueDeleteV4` re-journal hazard
+    correctly scoped OUT of #2121, or must it be fixed here for the fix to
+    be meaningful? (It needs a wire-protocol generation guard.)
+Q5. Test injection: tests #1/#2 need a controllable flush timeout. Add an
+    unexported `flushSendTimeout time.Duration` field defaulting to
+    `syncWriteDeadline`, set small in tests? Acceptable seam?
+Q6. Any remaining sequence where v4 is WORSE than the silent drop?

--- a/docs/pr/2121-flushdeletejournal-requeue/plan.md
+++ b/docs/pr/2121-flushdeletejournal-requeue/plan.md
@@ -1,89 +1,95 @@
 # #2121 — flushDeleteJournal must not silently drop journaled deletes on a full send queue
 
-Status: DRAFT v2 — revised after Codex PLAN-KILL of v1; pending re-review
+Status: DRAFT v3 — revised after Codex PLAN-KILL of v1 AND v2; pending re-review
 
-## v1 → v2 change (why the design changed)
+## Design history (why v1 and v2 were killed)
 
-v1 proposed re-journaling un-sent deletes for retry on the NEXT
-reconnect. Codex PLAN-KILLed it for a real ordering regression: deletes
-are key-only on the peer (`deleteClusterSynced*` → `DeleteWithCompanions*`
-deletes whatever currently owns the key, no generation guard). Deferring
-a delete across a healthy connected interval means a stale delete can
-replay on a later reconnect AFTER a replacement session with the same key
-has been re-synced — wrongly removing the live replacement. That is worse
-than the stale standby session the journal exists to prevent. Codex also
-correctly refuted v1's "failed messages are a suffix" FIFO claim
-(`queueMessage` is retried per-entry; `sendLoop` can drain between
-iterations so a later entry can succeed after an earlier one fails) and
-noted that re-journal-only does not restore current-connection
-convergence.
+- **v1 (re-journal for next-reconnect retry): KILLED.** Deferring a
+  journaled delete across a healthy connected interval can replay it on a
+  later reconnect after a replacement session with the same key was
+  re-synced, wrongly deleting the live replacement (deletes are key-only
+  on the peer — `deleteClusterSynced*` → `DeleteWithCompanions*`, no
+  generation guard). Codex also refuted v1's FIFO "suffix" claim.
+- **v2 (direct-write under writeMu, bypass sendCh): KILLED.** Bypassing
+  `sendCh` re-orders the delete ahead of session frames already queued in
+  `sendCh`. Concrete resurrection: (1) `S(K)` queued to `sendCh` while
+  connected, not yet written; (2) connection drops — **`handleDisconnect`
+  does NOT drain `sendCh`** (verified, sync_conn.go); (3) `D(K)` journaled
+  while disconnected; (4) reconnect flush direct-writes `D(K)`; (5)
+  `sendLoop` later writes the stale queued `S(K)`, resurrecting the
+  deleted session. Codex noted the codebase already solves this class:
+  **barriers deliberately go through `sendCh`** (`writeBarrierMessage`,
+  sync_bulk.go:308) "to preserve ordering with already-queued session
+  messages."
 
-v2 fixes the bug WITHOUT changing the journal's ordering contract:
-**drain the un-sent deletes on the CURRENT connection, before normal sync
-resumes**, by writing them directly under `writeMu` — the exact
-direct-write path `BulkSync`/`QueueConfig` already use to bypass the
-bounded `sendCh`. No deferral, no cross-reconnect re-journal of a delete
-while the link is up, no stale-replacement hazard.
+## v3 design (the correct ordering discipline)
+
+Replay journaled deletes **through `sendCh`, with a bounded blocking
+send** — exactly the pattern `writeBarrierMessage` uses for ordering-
+sensitive stream messages. This reconciles the two kill findings:
+
+- Through `sendCh` ⇒ the delete is enqueued **behind** any session frames
+  already queued in `sendCh`, then drained by `sendLoop` in FIFO order →
+  no S(K)/D(K) reordering (fixes v2 kill).
+- Blocking (bounded) send instead of `queueMessage`'s non-blocking
+  `select/default` ⇒ a full `sendCh` no longer drops; the flush waits for
+  `sendLoop` to make room (fixes the original bug).
+- Re-journal ONLY on send timeout or no-connection ⇒ deferral happens
+  only when the stream is genuinely stalled (peer wedged), the one case
+  where the next-reconnect flush is the correct place to retry. No
+  deferral while the link is healthy (so the v1 stale-replacement hazard
+  does not arise in the common case).
 
 ## Issue framing
 
-`pkg/cluster/sync_conn.go`. `QueueDeleteV4`/`QueueDeleteV6` follow a
-journal-on-failure contract: when `queueMessage` returns false (peer
-disconnected or `sendCh` full), the delete is re-journaled via
-`journalDelete` so it is not lost. `flushDeleteJournal` — invoked from
-`handleNewConnection` on the first post-disconnect connection — drains
-the whole journal under lock (`s.deleteJournal = nil`), then replays each
-message via `queueMessage`. It does **not** handle a `queueMessage`
-failure: a delete that hits a full `sendCh` (cap 4096) during replay is
-silently dropped (the journal was already nil'd). The dropped delete
-leaves a stale session on the peer until it independently ages out.
+`pkg/cluster/sync_conn.go`. `flushDeleteJournal` — invoked from
+`handleNewConnection` on the first post-disconnect connection — drains the
+bounded delete journal under lock (`s.deleteJournal = nil`), then replays
+each delete via `queueMessage`, whose `sendCh` send is **non-blocking**
+(`select { case s.sendCh <- msg: ... default: return false }`). If
+`sendCh` (cap 4096) is full at replay time the un-sent deletes are
+**silently dropped** (the journal was already nil'd). The dropped delete
+leaves a stale session on the peer until it independently ages out,
+defeating the journal's purpose. `queueMessage`'s overflow sets
+`syncBackfillNeeded`, which re-sweeps SESSIONS (not deletes), so the drop
+is not recovered.
 
 Severity: LOW — narrow window (queue full immediately after a fresh
 connect, before the send loop drains it), consequence is a stale standby
 session, not a forwarding error.
 
-## Honest scope / value framing
-
-Small, focused HA-correctness fix in the control-plane session-sync
-reconnect path. Not a perf change, not a dataplane (hot-path) change. The
-win: every journaled delete is delivered on the reconnect, in journal
-order, before normal sync resumes — no silent loss, no ordering
-regression. If reviewers conclude the change is unnecessary or the
-direct-write approach introduces a worse failure mode, PLAN-KILL is
-acceptable.
-
 ## Relevant existing behavior (verified against master 325d10683)
 
 - Journaled messages are **full framed frames**: `encodeDeleteV4`/`V6`
-  return `syncHeaderSize+payload` bytes (magic, type, length, body). They
-  are written verbatim by `sendLoop` via `writeFull(conn, msg)` — NOT
-  re-framed with `writeMsg`.
+  return `syncHeaderSize+payload` bytes; `sendLoop` writes them verbatim
+  via `writeFull(conn, msg)` (sync_conn.go:694). So a journaled delete is
+  a valid `sendCh` element exactly as produced (`QueueDeleteV4` already
+  puts the same frame on `sendCh` via `queueMessage`).
 - `sendLoop` (sync_conn.go:681) pulls each `sendCh` message and writes it
-  under `writeMu` via `writeFull`, retrying on disconnect.
-- The established **direct-write, bypass-sendCh** pattern: `BulkSync`
-  (sync_bulk.go:79) and `QueueConfig` (sync_conn.go:566) take `writeMu`,
-  call `writeMsg(conn, ...)`, and on error call `s.handleDisconnect(conn)`
-  and stop. `BulkSync` writes potentially thousands of messages this way.
-- `flushDeleteJournal` is called only from `handleNewConnection` when
-  `wasDisconnected` is true (sync_conn.go:200), synchronously, BEFORE
-  `OnPeerConnected` and before bulk sync, on the connection-accept
-  goroutine. While disconnected `syncSweep` does not advance, so the flush
-  replays the outage's deletes before any newer session state can become
-  durable on the peer — the ordering contract v2 must preserve.
-- `journalDelete` (sync_conn.go:534) is the bounded ring append: evicts
-  oldest + increments `DeletesDropped` at cap (`deleteJournalCap`,
-  default 10000). Takes `deleteJournalMu`.
-- `DeletesSent` is incremented only on a real send. `DeletesDropped` is
-  surfaced in `SyncStatsSnapshot` (sync.go:477).
+  under `writeMu`, retrying on disconnect; it drains continuously on a
+  healthy connection.
+- **Ordering precedent:** `writeBarrierMessage` (sync_bulk.go:308) sends
+  through `sendCh` with a timed blocking send
+  (`select { case s.sendCh <- msg: case <-timer.C: return err }`)
+  expressly "to preserve ordering with already-queued session messages."
+  v3 adopts this for delete replay.
+- `flushDeleteJournal` runs synchronously in `handleNewConnection`
+  (sync_conn.go:200) BEFORE `OnPeerConnected` and bulk, on the accept
+  goroutine. `Connected` is set true earlier (sync_conn.go:186), so
+  `sendLoop` and producers run concurrently with the flush — which is
+  fine: through-`sendCh` FIFO is exactly the ordering we want.
+- `handleDisconnect` does NOT drain `sendCh` (verified) — the reason v2's
+  bypass was unsafe and why v3 must use the same channel.
+- `journalDelete` (sync_conn.go:534): bounded ring append, evicts oldest +
+  increments `DeletesDropped` at cap (default 10000). Takes
+  `deleteJournalMu`.
+- `DeletesSent` incremented only on a real `sendCh` enqueue (inside
+  `queueMessage` today; v3 increments on the blocking enqueue). Surfaced
+  via `SyncStatsSnapshot`.
+- `syncWriteDeadline = 2s` (sync.go:73) — the per-frame wire write bound
+  used as the per-message enqueue timeout below.
 
 ## Concrete design
-
-Rewrite the `flushDeleteJournal` replay loop to **write each journaled
-delete directly to the active connection under `writeMu`** (mirror
-`BulkSync`), instead of enqueueing to the bounded `sendCh`. This delivers
-every journaled delete on the current connection, in journal order,
-before normal sync resumes — eliminating the `sendCh`-full drop and
-preserving the ordering contract.
 
 ```go
 func (s *SessionSync) flushDeleteJournal() {
@@ -94,49 +100,55 @@ func (s *SessionSync) flushDeleteJournal() {
 	if len(journal) == 0 {
 		return
 	}
-	conn := s.getActiveConn()
-	if conn == nil {
-		// No active connection: re-journal everything for the next
-		// reconnect flush (the original journal-on-disconnect contract —
-		// safe because the next flush again runs before normal sync).
-		s.rejournalAll(journal)
-		return
-	}
 	var sent int
-	// Replay journaled delete frames directly under writeMu (bypassing the
-	// bounded sendCh, like BulkSync) so they are delivered IN ORDER on the
-	// current connection before normal sync resumes. Journaled messages are
-	// already fully framed (encodeDeleteV4/V6), so write them verbatim.
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	// Replay journaled deletes THROUGH sendCh (not a direct write) so they
+	// stay ordered behind any session frames already queued in sendCh, then
+	// drain via sendLoop in FIFO order. Use a bounded blocking send (mirror
+	// writeBarrierMessage) so a full sendCh does not drop the delete — we
+	// wait for sendLoop to make room. On a genuine stall (timeout) or a
+	// dropped connection, re-journal the un-sent tail for the next reconnect
+	// flush (the original journal-on-disconnect contract — still ordered
+	// ahead of normal sync because flush runs before it).
 	for i, msg := range journal {
-		s.writeMu.Lock()
-		err := writeFull(conn, msg)
-		s.writeMu.Unlock()
-		if err != nil {
-			// Genuine disconnect mid-flush: re-journal the un-sent tail
-			// (including this one) for the next reconnect flush, and tear
-			// down the connection like the other senders.
+		if !s.stats.Connected.Load() {
 			s.rejournalAll(journal[i:])
-			s.stats.Errors.Add(1)
-			s.handleDisconnect(conn)
-			slog.Warn("cluster sync: delete journal flush write error, re-journaled un-sent tail",
-				"err", err, "total", len(journal), "sent", sent, "rejournaled", len(journal)-i)
+			slog.Warn("cluster sync: delete journal flush aborted (disconnected), re-journaled tail",
+				"total", len(journal), "sent", sent, "rejournaled", len(journal)-i)
 			return
 		}
-		s.stats.DeletesSent.Add(1)
-		sent++
-		// Yield periodically so barrier/ack writers can acquire writeMu
-		// (Go mutex is not fair) — mirror BulkSync's runtime.Gosched().
-		if sent%64 == 0 {
-			runtime.Gosched()
+		timer.Reset(syncWriteDeadline)
+		select {
+		case s.sendCh <- msg:
+			s.stats.DeletesSent.Add(1)
+			sent++
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		case <-timer.C:
+			// sendCh stayed full past the deadline: stream stalled. Defer
+			// the rest to the next reconnect flush rather than spin.
+			s.rejournalAll(journal[i:])
+			s.stats.Errors.Add(1)
+			slog.Warn("cluster sync: delete journal flush stalled on full send queue, re-journaled un-sent tail",
+				"total", len(journal), "sent", sent, "rejournaled", len(journal)-i,
+				"queue_len", len(s.sendCh), "queue_cap", cap(s.sendCh))
+			return
 		}
 	}
 	slog.Info("cluster sync: flushed delete journal", "total", len(journal), "sent", sent)
 }
 
 // rejournalAll re-appends un-sent delete frames to the journal under lock,
-// honoring the bounded cap (journalDelete increments DeletesDropped on
-// eviction). Used only when the connection is gone — the next reconnect
-// flush will replay them before normal sync resumes.
+// honoring the bounded cap (journalDelete counts genuine loss via
+// DeletesDropped). Used only when the stream is stalled or the connection
+// is gone — the next reconnect flush replays them before normal sync.
 func (s *SessionSync) rejournalAll(msgs [][]byte) {
 	for _, msg := range msgs {
 		s.journalDelete(msg)
@@ -144,154 +156,150 @@ func (s *SessionSync) rejournalAll(msgs [][]byte) {
 }
 ```
 
-### Why direct-write on the current connection (vs sendCh / vs block)
+(The single reusable `timer` with the standard drain-on-Reset dance avoids
+allocating a timer per message in a possibly-large journal.)
 
-- **Preserves the ordering contract.** Sequential `writeFull` under one
-  `writeMu` delivers the journaled deletes in strict journal order, on the
-  current connection, before `handleNewConnection` proceeds to
-  `OnPeerConnected`/bulk. No delete is deferred across a healthy interval,
-  so the v1 stale-replacement-delete hazard cannot occur.
-- **No silent drop.** There is no bounded queue to overflow on the flush
-  path. `writeFull` blocks on TCP backpressure (with `syncWriteDeadline`),
-  it does not drop.
-- **Does not stall indefinitely.** `writeFull` has a write deadline
-  (`syncWriteDeadline`); a wedged peer trips the deadline → error →
-  `handleDisconnect` + re-journal-tail (correct: genuinely failing peer,
-  defer to next reconnect). This is the same bound `BulkSync`/`sendLoop`
-  rely on.
-- **Consistent with the codebase.** `BulkSync` already direct-writes far
-  more messages on this exact goroutine sequence under `writeMu`.
+### Why through-sendCh blocking send (vs bypass / vs non-blocking)
 
-### Re-journal only on genuine disconnect
-
-Re-journaling now happens ONLY when there is no active connection (or a
-write fails → disconnect). In that case deferring to the next reconnect
-flush is correct and matches the original journal-on-disconnect contract:
-the next flush again runs before normal sync resumes, so the deletes still
-replay ahead of newer session state. The v1 "re-journal while connected
-and retry next reconnect" path — the source of the ordering regression —
-is gone.
+- **Ordering:** the delete shares the single `sendCh → sendLoop → writeFull`
+  path with queued sessions, so FIFO is preserved — the v2 reordering /
+  resurrection cannot occur.
+- **No silent drop:** the bounded blocking send waits for room; it never
+  takes the `default` drop branch.
+- **Bounded liveness:** `sendLoop` drains continuously on a healthy
+  connection, so the send rarely blocks; on a wedged peer the per-message
+  `syncWriteDeadline` timeout caps the stall and re-journals the rest —
+  the same bound `writeBarrierMessage`/`writeFull` rely on. The flush
+  cannot hang `handleNewConnection` longer than one write deadline beyond
+  the time `sendLoop` needs to drain.
+- **No new ordering hazard on the deferral path:** re-journal happens only
+  on a stall/disconnect — i.e. when nothing is making it onto the wire
+  anyway — so re-journaled deletes still replay on the next reconnect
+  before normal sync. This is the SAME exposure the existing
+  journal-on-disconnect path already has; v3 does not widen it.
 
 ## Public API preservation
 
 No exported API changes. `flushDeleteJournal`, `journalDelete`,
-`queueMessage`, `rejournalAll` are unexported. `SyncStats` fields and
-semantics unchanged (`DeletesSent` still per-send; `DeletesDropped` still
-cap-eviction). No new field.
+`queueMessage`, `rejournalAll` unexported. `SyncStats` fields/semantics
+unchanged. No new field.
 
 ## Hidden invariants the change must preserve
 
-1. **Lock ordering**: `flushDeleteJournal` releases `deleteJournalMu`
-   before writing; `rejournalAll`/`journalDelete` re-take it from outside
-   any held lock. `writeMu` is taken/released per message (never held
-   across `deleteJournalMu`). No new lock nesting vs `BulkSync`.
-2. **writeMu serialization**: direct writes serialize with `sendLoop`,
-   heartbeat, bulk, config writers on `writeMu` — same as every other
-   sender. Frame integrity preserved (whole frame written under the lock).
-3. **No double-send / accounting**: `DeletesSent` incremented once per
-   successful `writeFull`. Re-journaled (disconnect) messages are not
-   counted as sent.
-4. **Bounded re-journal**: `rejournalAll` → `journalDelete` honors the cap
-   and counts genuine loss via `DeletesDropped`.
-5. **Termination**: loop bounded by captured `journal`; re-journaled
+1. **No lock held across the blocking send.** `deleteJournalMu` is
+   released before the loop; the `sendCh` send holds NO lock (matches
+   `writeBarrierMessage`). `rejournalAll`/`journalDelete` re-take
+   `deleteJournalMu` from outside any held lock.
+2. **No deadlock with sendLoop.** `sendLoop` only blocks on `writeFull`
+   (deadline-bounded) or waiting for a conn; it consumes `sendCh`
+   independently of any lock the flush holds (none). Blocking send + active
+   consumer = progress.
+3. **FIFO / ordering:** deletes interleave with queued sessions in `sendCh`
+   in submission order; `sendLoop` is the single writer. Same stream-order
+   guarantee barriers rely on.
+4. **Accounting:** `DeletesSent` incremented once per successful enqueue;
+   re-journaled (stall/disconnect) messages are not counted as sent.
+5. **Bounded re-journal:** `rejournalAll`→`journalDelete` honors the cap;
+   genuine loss surfaced via `DeletesDropped`.
+6. **Termination:** loop bounded by captured `journal`; re-journaled
    messages go to `s.deleteJournal`, not the loop slice. No livelock.
-6. **handleDisconnect on write error**: mirrors `BulkSync`/`sendLoop`
-   exactly — required so the dead connection is torn down and reconnect
-   re-armed.
-7. **Ordering contract**: flush completes (all deletes written, or tail
-   re-journaled on disconnect) synchronously before `handleNewConnection`
-   calls `OnPeerConnected`/bulk — unchanged call sequence.
+7. **Ordering contract preserved:** flush still completes (all enqueued, or
+   tail re-journaled) synchronously before `OnPeerConnected`/bulk.
+8. **Timer hygiene:** one reused `time.Timer`, drained correctly on Reset
+   to avoid a stale fire (the standard Go idiom).
 
 ## Risk assessment
 
 | Risk class | Level | Notes |
 |---|---|---|
-| Behavioral regression | LOW | Happy path now direct-writes (like BulkSync) instead of via sendCh; same wire output, same writeMu serialization, runs at most once per reconnect. |
-| Concurrency / deadlock | LOW | Reuses BulkSync's writeMu+handleDisconnect pattern; deleteJournalMu released before writes. Covered by -race. |
-| Performance | NONE | Reconnect-only, bounded by journal len; BulkSync writes far more this way. |
-| Architectural mismatch | LOW | Adopts the established direct-write-bypass-sendCh pattern; removes the broken deferred-retry idea. |
+| Behavioral regression | LOW | Still enqueues to sendCh (same wire path as today's queueMessage); only the full-queue branch changes from drop→bounded-block. |
+| Concurrency / deadlock | LOW | Mirrors writeBarrierMessage (no lock across send); sendLoop drains independently. Covered by -race. |
+| Performance | NONE | Reconnect-only, bounded by journal len; blocking only when sendCh is full (the failure the issue describes). |
+| Architectural mismatch | LOW | Adopts the established ordered-through-sendCh pattern; abandons both broken alternatives. |
 
 ## Test plan
 
 New `pkg/cluster` unit tests, `go test -race ./pkg/cluster/`:
 
-1. **TestDeleteJournalFlushDeliversAllOnFullQueue** (non-tautological
-   regression): saturate `sendCh` (fill to cap so any `queueMessage` would
-   fail), wire an active `net.Pipe` conn, journal N deletes, run
-   `flushDeleteJournal` with a reader draining the conn. Assert: ALL N
-   frames are read off the wire (in order) and `DeletesSent == N`, and the
-   journal is empty. Against the PRE-FIX code (which used `queueMessage`
-   into the full `sendCh`) this delivers 0 and drops N — so the test fails
-   pre-fix. (Verify by reverting the fix locally.)
-2. **TestDeleteJournalFlushRejournalsTailOnDisconnect**: journal N
-   deletes, set an active conn, then close the peer side so `writeFull`
-   errors after some prefix; assert the un-sent tail is re-journaled (back
-   in `s.deleteJournal`) and `handleDisconnect` ran (Connected false), so a
-   later reconnect flush re-delivers them.
-3. **TestDeleteJournalFlushNoConnRejournals**: journal N deletes with NO
-   active conn; flush; assert all N are re-journaled (journal len == N, or
-   == cap with `DeletesDropped` for the overflow) and `DeletesSent == 0`.
-4. Existing tests still green — note `TestDeleteJournalReconnectConvergence`
-   and `TestDeleteJournalBasic` may need the active-conn / reader wiring
-   updated since flush now writes directly instead of to `sendCh`; the
-   ASSERTED behavior (deletes delivered, journal emptied, DeletesSent==N)
-   is preserved.
+1. **TestDeleteJournalFlushBlocksThenDeliversOnFullQueue** (non-tautological
+   regression): Connected=true, an active `net.Pipe` conn + a `sendLoop`
+   (or a manual drainer reading `sendCh` and writing the conn). Pre-fill
+   `sendCh` to cap, journal N deletes, start `flushDeleteJournal` in a
+   goroutine, then start draining `sendCh` slowly. Assert: all N delete
+   frames eventually arrive on the wire IN ORDER (after the pre-filled
+   frames), `DeletesSent == N`, journal empty, NO `DeletesDropped`. Against
+   PRE-FIX (`queueMessage` non-blocking) the full sendCh drops all N → 0
+   frames, journal empty → test fails pre-fix.
+2. **TestDeleteJournalFlushStallTimeoutRejournals**: fill `sendCh` to cap
+   with NO drainer (stream stalled), set Connected=true, journal N deletes,
+   flush. With the per-message `syncWriteDeadline`, the first send times out
+   → assert the full tail is re-journaled (`s.deleteJournal` len == N or ==
+   cap with `DeletesDropped`), `DeletesSent == 0`, and an `Errors` bump.
+   (Use a test-injected short deadline if `syncWriteDeadline` is too long
+   for the suite — see Q5.)
+3. **TestDeleteJournalFlushDisconnectedRejournals**: Connected=false,
+   journal N deletes, flush; assert all re-journaled, `DeletesSent == 0`.
+4. **TestDeleteJournalFlushOrderingWithQueuedSession**: enqueue a session
+   frame to `sendCh`, then flush a delete for the SAME key; drain and assert
+   the session frame is read BEFORE the delete (proving through-sendCh FIFO
+   — the property v2 violated).
+5. Existing tests still green; update `TestDeleteJournalBasic` /
+   `TestDeleteJournalReconnectConvergence` wiring as needed (they still
+   assert deletes delivered + journal emptied + `DeletesSent==N`, which
+   v3 preserves).
 
 Gates: `go test -race ./pkg/cluster/`, `go build ./...`, full
-`go test ./...` (cluster + dependents).
+`go test ./...`.
 
 No loss-cluster iperf smoke: control-plane HA delete-journal replay, not a
 dataplane forwarding change.
 
 ## Docs
 
-`docs/session-sync-architecture.md` §"Delete Journal" (line 244) and
-§"Delete Journal Overflow" (line 425): note that flush now delivers
-journaled deletes directly on the reconnect (in order, before normal sync
-resumes) and re-journals only on a genuine disconnect, so a full send
-queue no longer drops them.
+`docs/session-sync-architecture.md` §"Delete Journal" (244) and §"Delete
+Journal Overflow" (425): note flush now replays journaled deletes through
+the ordered send stream with a bounded blocking enqueue (so a full send
+queue blocks until drained rather than dropping), and re-journals only on
+a genuine stall/disconnect.
 
 ## Out of scope (explicitly)
 
 - `sendCh` capacity (4096) — orthogonal.
-- Generation/session-identity guard on deletes (Codex's deeper
-  alternative) — larger change touching the wire protocol + receive path;
-  not needed once deletes are delivered in-order on the current
-  connection. Could be a separate hardening issue.
-- A distinct `DeletesRequeued` metric — re-journal now happens only on
-  genuine disconnect (already the normal journaled path); the Warn log +
-  `DeletesDropped` cover the observable cases.
-- #2120 (standby session-expiry / `syncSweep`) — different function, owned
-  by a sibling research agent. Untouched.
+- Generation/session-identity guard on deletes — larger wire+receive
+  change; not required once deletes are ordered through `sendCh`. Possible
+  separate hardening issue.
+- A distinct `DeletesRequeued` metric — re-journal now only on
+  stall/disconnect (the normal journaled path); Warn log + `DeletesDropped`
+  cover observability.
+- #2120 (`syncSweep`) — different function, sibling agent. Untouched.
 
 ## Open questions for adversarial review
 
-Q1. Is direct-write-under-`writeMu` on the accept goroutine the right
-    drain mechanism, given `BulkSync` already does exactly this on the same
-    sequence? Any reason the delete flush must NOT block on TCP
-    backpressure the way bulk does?
-Q2. `writeFull` uses `syncWriteDeadline`. Is that deadline an acceptable
-    upper bound on how long `flushDeleteJournal` can hold up
-    `OnPeerConnected`/bulk on a slow peer? (BulkSync accepts the same.)
-Q3. Concurrency: while flush direct-writes under `writeMu`, `sendLoop` may
-    also be draining `sendCh` and writing under `writeMu`. Both serialize on
-    `writeMu` so frames don't interleave, but a normal session/delete
-    enqueued to `sendCh` just before reconnect could be written BETWEEN two
-    journaled deletes. Deletes are idempotent by key; is any
-    delete-vs-session interleave hazardous here, or is "all journaled
-    deletes delivered before OnPeerConnected/bulk" the only contract that
-    matters?
-Q4. On write error mid-flush we re-journal `journal[i:]` and call
-    `handleDisconnect`. Is re-journaling the CURRENT failed message (index
-    i) correct, or could it have been partially written (torn frame) — does
-    `writeFull` guarantee all-or-nothing per frame? (It loops on short
-    writes but a mid-frame error leaves a partial frame on the wire; the
-    peer then resyncs on disconnect — confirm that's the existing behavior
-    for BulkSync too.)
-Q5. Test #1 non-tautological: does saturating `sendCh` + asserting frames
-    arrive on the wire actually fail against the pre-fix `queueMessage`
-    path? (Pre-fix: full sendCh → queueMessage false → silent drop → 0
-    frames on the wire.)
-Q6. Should `rejournalAll` preserve order strictly (it appends in slice
-    order to an empty/!empty journal)? Any case where re-journal order
-    matters given the next flush re-delivers in order anyway?
+Q1. Does through-`sendCh` blocking send fully resolve the v2 reordering
+    (S(K) queued / D(K) flushed / S(K) resurrects)? Confirm `sendCh` is
+    the single ordered path and `sendLoop` the single writer.
+Q2. Liveness: per-message `syncWriteDeadline` blocking send on the accept
+    goroutine. Can `flushDeleteJournal` ever hang `handleNewConnection`
+    longer than acceptable? Is the timeout→re-journal-tail abort the right
+    escape, or should it keep blocking (matching barriers, which also bound
+    with a timeout)?
+Q3. Deadlock: any scenario where `sendLoop` is blocked AND the flush's
+    blocking send waits on it (with no timeout escape)? The deadline should
+    prevent indefinite block — verify against `sendLoop`'s
+    conn-wait/writeFull-deadline behavior.
+Q4. Stall/disconnect deferral: on timeout/disconnect we re-journal the
+    tail. A stale `S(K)` may still sit in `sendCh` and be written on
+    reconnect after the re-journaled `D(K)` replays — the SAME exposure the
+    existing journal-on-disconnect path has. Is that acceptable (pre-
+    existing, not widened by v3), or must v3 also address it (out of
+    scope)?
+Q5. Test hygiene: `syncWriteDeadline = 2s` makes the stall test slow.
+    Acceptable to add a test-only injectable enqueue deadline field
+    (defaulting to `syncWriteDeadline`)? Or restructure the stall test to
+    avoid the wait?
+Q6. Is incrementing `DeletesSent` on the blocking enqueue (same as
+    `queueMessage` does on its enqueue) correct, vs only on actual wire
+    write? (Existing `DeletesSent` semantics = "handed to the send stream",
+    not "acked".)
+Q7. Timer reuse + drain idiom — is the Reset/Stop/drain dance correct to
+    avoid a stale fire across iterations?

--- a/docs/pr/2121-flushdeletejournal-requeue/plan.md
+++ b/docs/pr/2121-flushdeletejournal-requeue/plan.md
@@ -1,93 +1,90 @@
 # #2121 — flushDeleteJournal must not silently drop journaled deletes on a full send queue
 
-Status: DRAFT v4 — incorporates Claude-SMR (NEEDS-MINOR) + AGY (NEEDS-MAJOR)
-findings on v3; pending re-review.
+Status: DRAFT v5 — radical simplification after THREE NEEDS-MAJOR on v4
+(Codex + Claude-SMR + AGY converged: the timeout/force-disconnect/deferral
+machinery is the problem). Pending re-review.
 
-## Design history
+## Design history (why every "active drain" variant failed)
 
-- **v1 (re-journal failed deletes for retry on the NEXT reconnect):
-  KILLED (Codex).** Deletes are key-only on the peer
-  (`deleteClusterSynced*` → `DeleteWithCompanions*`, no generation guard).
-  Deferring a delete across a healthy connected interval can replay it on
-  a later reconnect after a replacement session with the same key was
-  re-synced, wrongly deleting the live replacement.
-- **v2 (direct-write each frame under writeMu, bypass sendCh): KILLED
-  (Codex).** `handleDisconnect` does NOT drain `sendCh`, so a session
-  frame `S(K)` queued before a disconnect survives; on reconnect the flush
-  direct-writes `D(K)` while the stale `S(K)` is still in `sendCh` and
-  `sendLoop` writes it AFTER `D(K)`, resurrecting the deleted session. The
-  codebase already solves this class: `writeBarrierMessage` (sync_bulk.go)
-  goes through `sendCh` "to preserve ordering with already-queued session
-  messages."
-- **v3 (replay through sendCh, per-message blocking send): NEEDS-MAJOR.**
-  Correct channel-ordered approach, but three implementation defects, all
-  fixed in v4 below:
-  - **Liveness hang (SMR finding #1 + AGY §3, CRITICAL):** the per-message
-    `syncWriteDeadline` reset means a slow-but-not-stalled peer
-    (~1.5s/frame) blocks the synchronous accept/dial loop for
-    `N × syncWriteDeadline` — up to `deleteJournalCap × 2s` (~hours for a
-    10k journal). Worse than the silent drop. → **Fix A: single global
-    flush timeout.**
-  - **Re-journal FIFO inversion + overflow bias (AGY §4, CRITICAL):**
-    `rejournalAll` appended the un-sent tail to the END of the journal,
-    placing it AFTER deletes concurrently journaled during the flush
-    (`QueueDeleteV4` on a full `sendCh` while connected), inverting replay
-    order; and on overflow `journalDelete`'s front-eviction drops the
-    NEWER concurrent deletes. → **Fix B: FIFO-prepend merge under a single
-    lock, evict oldest from the merged front.**
-  - **Active-deferral stale-replacement (AGY §4 + SMR Q4, MAJOR):** on a
-    timeout where the link does NOT immediately drop, the re-journaled
-    deletes wait for the next reconnect while a replacement `S'(K)` is
-    synced on the healthy link → on reconnect `D(K)` kills the live
-    `S'(K)` (the v1 hazard, reintroduced via the timeout path). → **Fix C:
-    on timeout, force-close the connection so the deferral is to a genuine
-    disconnect, not a healthy interval.**
+- **v1 (non-blocking send; re-journal failures for next-reconnect retry):
+  KILLED (Codex)** for an ordering regression vs the existing flush — but
+  see the v5 reframing below: re-journal is identical in exposure to the
+  already-accepted `QueueDeleteV4` full-queue path, and strictly better
+  than the silent drop.
+- **v2 (direct-write, bypass sendCh): KILLED (Codex).** Reorders the
+  delete ahead of sessions already queued in `sendCh` (not drained on
+  disconnect) → resurrection.
+- **v3 (through-sendCh, per-message blocking timeout): NEEDS-MAJOR.**
+  Per-message reset → O(N·deadline) accept-loop hang on a slow peer.
+- **v4 (single global timeout + FIFO-prepend re-journal + force-
+  disconnect): THREE NEEDS-MAJOR, converging:**
+  - **AGY:** the single global 2s budget → on a slow link the budget
+    exhausts mid-flush → force-disconnect → reconnect re-blocks on the
+    un-drained `sendCh` → **reconnect storm, 0% sync, worse than the
+    silent drop.** Its proposed "progress-resetting timer" reintroduces
+    v3's O(N·deadline) hang — so no timeout policy on a synchronous
+    blocking flush is correct.
+  - **Claude-SMR:** Fix C does NOT close the resurrection hole — a
+    replacement `S'(K)` enqueued to `sendCh` before the timeout survives
+    the force-disconnect (sendCh not drained) and on reconnect is written
+    by `sendLoop`, then the re-journaled `D(K)` (re-enqueued by the next
+    flush) lands after it and kills the live `S'(K)`. **Pre-fix this is
+    SAFE (drop ⇒ D(K) never sent), so v4 is strictly worse on this path.**
+  - **Codex:** dual-fabric — `handleDisconnect(getActiveConn())` closes
+    only one fabric (getActiveConn prefers conn0; the other fabric can
+    connect during the unlocked flush); flush returns and
+    `handleNewConnection` still runs `OnPeerConnected`/`doBulkSync` on the
+    remaining fabric, where `BulkSync` direct-writes the live `S'(K)`,
+    which the deferred `D(K)` later kills. Worse than the silent drop.
+
+**Unifying conclusion:** the timeout / force-disconnect / active-deferral
+machinery is the source of every defect. The original bug is ONLY the
+*silent drop*. The minimal fix is to make `flushDeleteJournal`'s full-queue
+handling **identical to the already-shipped `QueueDeleteV4` contract**:
+non-blocking enqueue, and on a full queue **re-journal (retain) the
+un-sent deletes** instead of dropping them — with NO blocking, NO timeout,
+NO force-disconnect. This fixes the drop, matches the issue's stated goal
+("Match how the session-UPSERT/delete sync path handles queue-full"), and
+introduces **no hazard beyond what `QueueDeleteV4` already has**.
 
 ## Issue framing
 
-`pkg/cluster/sync_conn.go`. `flushDeleteJournal` — invoked from
-`handleNewConnection` on the first post-disconnect connection — drains the
-bounded delete journal under lock (`s.deleteJournal = nil`), then replays
-each delete via `queueMessage`, whose `sendCh` send is **non-blocking**.
-If `sendCh` (cap 4096) is full at replay time the un-sent deletes are
-**silently dropped** (journal already nil'd), leaving stale sessions on
-the peer until they age out. `queueMessage`'s overflow re-sweeps SESSIONS
-(`syncBackfillNeeded`), not deletes, so the drop is unrecovered.
+`pkg/cluster/sync_conn.go`. `flushDeleteJournal` drains the bounded delete
+journal under lock (`s.deleteJournal = nil`), then replays each delete via
+`queueMessage`, whose `sendCh` send is **non-blocking**. On a full `sendCh`
+(cap 4096) the un-sent deletes are **silently dropped** (journal already
+nil'd), leaving stale sessions on the peer. By contrast `QueueDeleteV4`/`V6`
+already RE-JOURNAL on a `queueMessage` failure (sync_conn.go:515-529) — the
+flush path is the lone inconsistency. The issue asks for exactly this:
+"re-journal ... any message for which queueMessage returns false, instead
+of dropping it ... Mirror the QueueDeleteV4 contract."
 
-Severity: LOW — narrow window, consequence is a stale standby session.
+Severity: LOW.
 
-## Relevant existing behavior (verified against master 325d10683)
+## Relevant existing behavior (verified, master 325d10683)
 
-- Journaled messages are full framed frames (`encodeDeleteV4`/`V6`);
-  `sendLoop` writes them verbatim via `writeFull`.
-- `sendCh` is the SINGLE ordered FIFO path; `sendLoop` (sync_conn.go:681)
-  the SINGLE writer (under `writeMu`). The only `sendCh <-` sites are
-  `queueMessage` (489), `writeBarrierMessage` (320), and the proposed
-  flush. (Confirmed by both reviewers.)
-- `writeBarrierMessage` (sync_bulk.go:308) sends through `sendCh` with a
-  timed blocking send "to preserve ordering with already-queued session
-  messages" — the precedent v4 follows.
-- `flushDeleteJournal` runs synchronously in `handleNewConnection`
-  (sync_conn.go:200) BEFORE `OnPeerConnected` and `doBulkSync` (207), on
-  the accept/dial-loop goroutine. `Connected` set true earlier (186).
-- **`handleNewConnection` is single-flush per reconnect:** `wasDisconnected`
-  is computed under `s.mu` (158-159) before the conn pointer is set, so
-  only the first fabric to flip `conn0/conn1` from nil sees
-  `wasDisconnected==true` and flushes. Two simultaneous fresh connections
-  cannot both flush the (nil'd) journal. (SMR finding.)
-- `handleDisconnect` does NOT drain `sendCh` (verified) — already-queued
-  frames survive a disconnect.
-- `journalDelete` (534): bounded ring append, FIFO front-eviction +
-  `DeletesDropped++` at cap (`deleteJournalCap`, default 10000).
-- `BulkSync` (sync_bulk.go:79) writes session frames DIRECTLY under
-  `writeMu` (not via `sendCh`).
-- `syncWriteDeadline = 2s` (sync.go:73). `sendCh` cap 4096 (sync.go:381).
+- `queueMessage` (sync_conn.go:484): non-blocking `select { case s.sendCh
+  <- msg: sent++; return true; default: Errors++; set syncBackfillNeeded;
+  return false }`. The single source of `sendCh` enqueues for sessions and
+  deletes; ordering with queued sessions is preserved for messages that DO
+  enqueue.
+- `QueueDeleteV4`/`V6` (515-529): `if !queueMessage(...) { journalDelete }`.
+  This ALREADY journals deletes that hit a full `sendCh` **while connected**
+  (queueMessage returns false on a full queue regardless of Connected).
+  That delete then replays on the next reconnect flush — i.e. the
+  "healthy-interval deferral" exposure already exists and is accepted.
+- `journalDelete` (534): bounded ring, FIFO front-eviction +
+  `DeletesDropped++` at cap (default 10000).
+- `flushDeleteJournal` runs in `handleNewConnection` (200) before
+  `OnPeerConnected`/`doBulkSync`. `handleDisconnect` does NOT drain
+  `sendCh`.
+- `DeletesSent` is incremented inside `queueMessage` on a successful
+  enqueue (so the flush does not separately count).
 
-## Concrete design (v4)
+## Concrete design (v5)
 
-Replay journaled deletes through `sendCh` with a **single global-timeout**
-blocking send; on timeout or disconnect, **FIFO-prepend** the un-sent tail
-back into the journal and, on timeout, **force-close** the connection.
+Replace the flush's drop-on-failure with re-journal-on-failure, FIFO-
+correct. No blocking, no timeout, no disconnect.
 
 ```go
 func (s *SessionSync) flushDeleteJournal() {
@@ -98,245 +95,223 @@ func (s *SessionSync) flushDeleteJournal() {
 	if len(journal) == 0 {
 		return
 	}
-	// Fix A: ONE global timeout for the whole flush bounds how long the
-	// accept/dial loop can block to a constant, independent of journal size
-	// or drain rate (per-message reset allowed O(N*deadline) hangs).
-	timer := time.NewTimer(syncWriteDeadline)
-	defer timer.Stop()
-
-	var sent int
+	var flushed int
+	// Replay journaled deletes through the ordered send stream. queueMessage
+	// is non-blocking and increments DeletesSent on success; on a full
+	// sendCh it returns false. Mirror the QueueDeleteV4 contract: re-journal
+	// (retain) the un-sent tail instead of dropping it, so it replays on the
+	// next reconnect flush. The journal was nil'd, so re-journaling here is
+	// the SAME deferral the QueueDeleteV4 full-queue path already performs —
+	// no new hazard, and strictly better than the previous silent drop.
 	for i, msg := range journal {
-		if !s.stats.Connected.Load() {
-			// Disconnected mid-flush: defer the tail to the next reconnect
-			// flush (runs before normal sync — the original contract).
-			s.rejournalTail(journal[i:])
-			slog.Warn("cluster sync: delete journal flush aborted (disconnected), re-journaled tail",
-				"total", len(journal), "sent", sent, "rejournaled", len(journal)-i)
-			return
+		if s.queueMessage(msg, &s.stats.DeletesSent, "journal_flush") {
+			flushed++
+			continue
 		}
-		select {
-		case s.sendCh <- msg:
-			s.stats.DeletesSent.Add(1)
-			sent++
-		case <-timer.C:
-			// Fix A: global budget exhausted (sendCh stayed full → stream
-			// stalled). Defer the tail AND (Fix C) force-disconnect so the
-			// deferral is to a genuine reconnect, not a healthy interval —
-			// otherwise a replacement S'(K) synced on the still-up link
-			// would be killed by the deferred D(K) on the next reconnect.
-			s.rejournalTail(journal[i:])
-			s.stats.Errors.Add(1)
-			slog.Warn("cluster sync: delete journal flush timed out on full send queue, re-journaled tail and forcing reconnect",
-				"total", len(journal), "sent", sent, "rejournaled", len(journal)-i,
-				"queue_len", len(s.sendCh), "queue_cap", cap(s.sendCh))
-			if conn := s.getActiveConn(); conn != nil {
-				s.handleDisconnect(conn)
-			}
-			return
-		}
+		// First failure: queue is full. Re-journal this message and the rest
+		// (FIFO-prepended ahead of any deletes concurrently journaled during
+		// the flush) and stop — further attempts on a full queue would also
+		// fail, and stopping preserves order.
+		s.rejournalTail(journal[i:])
+		slog.Warn("cluster sync: delete journal flush hit full send queue, re-journaled un-sent tail for next reconnect",
+			"total", len(journal), "flushed", flushed, "rejournaled", len(journal)-i,
+			"queue_len", len(s.sendCh), "queue_cap", cap(s.sendCh))
+		return
 	}
-	slog.Info("cluster sync: flushed delete journal", "total", len(journal), "sent", sent)
+	slog.Info("cluster sync: flushed delete journal", "total", len(journal), "flushed", flushed)
 }
 
 // rejournalTail re-inserts the un-sent delete tail at the FRONT of the
 // journal so it replays BEFORE any deletes concurrently journaled during
-// the flush (Fix B — preserve FIFO; appending to the end inverted order).
-// On overflow it drops the OLDEST entries from the front of the merged
-// list (the tail), counting them in DeletesDropped — never the newer
-// concurrently-journaled deletes. One lock acquisition.
+// the flush (preserve FIFO). On overflow it drops the OLDEST entries from
+// the front of the merged list, counted in DeletesDropped — never the
+// newer concurrently-journaled deletes. Single lock acquisition.
 func (s *SessionSync) rejournalTail(tail [][]byte) {
 	if len(tail) == 0 {
 		return
 	}
 	s.deleteJournalMu.Lock()
 	defer s.deleteJournalMu.Unlock()
-	cap := s.deleteJournalCap
-	if cap <= 0 {
-		cap = deleteJournalDefaultCap
+	capN := s.deleteJournalCap
+	if capN <= 0 {
+		capN = deleteJournalDefaultCap
 	}
 	total := len(tail) + len(s.deleteJournal)
-	if total <= cap {
+	if total <= capN {
 		merged := make([][]byte, 0, total)
-		merged = append(merged, tail...)            // older un-sent first
-		merged = append(merged, s.deleteJournal...) // then concurrent new
+		merged = append(merged, tail...)
+		merged = append(merged, s.deleteJournal...)
 		s.deleteJournal = merged
 		return
 	}
-	dropped := total - cap
+	dropped := total - capN
 	s.stats.DeletesDropped.Add(uint64(dropped))
-	merged := make([][]byte, 0, cap)
+	merged := make([][]byte, 0, capN)
 	if dropped < len(tail) {
-		merged = append(merged, tail[dropped:]...)  // drop oldest tail prefix
+		merged = append(merged, tail[dropped:]...)
 		merged = append(merged, s.deleteJournal...)
 	} else {
-		newDropped := dropped - len(tail)           // tail fully dropped
-		merged = append(merged, s.deleteJournal[newDropped:]...)
+		merged = append(merged, s.deleteJournal[dropped-len(tail):]...)
 	}
 	s.deleteJournal = merged
 }
 ```
 
-### Notes on the fixes
+(Stop at the first failure rather than re-trying each message: once `sendCh`
+is full the rest will fail too, and stopping keeps the un-sent suffix
+contiguous and ordered. This matches `QueueDeleteV4`, which makes a single
+attempt per delete.)
 
-- **Fix A bound:** total flush block ≤ `syncWriteDeadline` (2s) regardless
-  of journal length. The risk table's old "one write deadline" claim is now
-  TRUE because the timer is global, not per-message.
-- **Fix B FIFO:** concurrent `QueueDeleteV4`/`V6` during the flush append
-  `D(new)` to `s.deleteJournal` (the now-empty journal). Prepending the
-  un-sent older `tail` keeps replay order `tail` (older) → `D(new)`
-  (newer). Overflow drops the oldest (front of `tail`), never `D(new)`.
-- **Fix C deferral safety:** force-`handleDisconnect` on timeout means the
-  link goes down; a replacement session cannot be synced on a healthy link
-  in the deferral window, so the deferred delete cannot kill a live
-  replacement. The deferral is now to a genuine reconnect — identical to
-  the existing journal-on-disconnect contract. `getActiveConn` +
-  `handleDisconnect` reuse the project's standard teardown (matches
-  `BulkSync`/`sendLoop`).
+### Why this is correct AND never worse than today
 
-### Residual ordering exposure (scoped, not introduced here)
+- **Fixes the filed bug:** un-sent journaled deletes are RETAINED, not
+  dropped. They replay on the next reconnect flush.
+- **No new hazard:** the only behavior change on failure is "re-journal"
+  vs "drop". Re-journal is exactly what `QueueDeleteV4` already does on a
+  full queue (sync_conn.go:517), so the deferred-delete-vs-replacement
+  exposure is identical to existing, accepted behavior — NOT introduced or
+  widened by #2121.
+- **Never worse than the silent drop:** for any `D(K)` that today is
+  silently dropped, v5 retains it for later delivery. The only outcome
+  difference is "D(K) eventually delivered" vs "D(K) lost". Delivering the
+  delete is the issue's goal (the lost delete is the bug). The
+  replacement-resurrection concern is the pre-existing journal property,
+  not a regression here.
+- **No liveness risk:** non-blocking throughout (queueMessage's
+  `default`). No timeout, no force-disconnect, no reconnect storm, no
+  accept-loop hang, no dual-fabric teardown — all the v3/v4 hazard surface
+  is gone.
+- **Ordering for the delivered deletes:** the deletes that DO enqueue go
+  through `sendCh` in journal order behind already-queued sessions (the v2
+  reorder cannot occur — same single ordered path). The re-journaled tail
+  is FIFO-prepended so a later flush replays it before concurrently-
+  journaled newer deletes.
 
-`QueueDeleteV4`/`V6` (sync_conn.go:515-529) STILL re-journal on a full
-`sendCh` while the link is healthy and connected (`queueMessage` returns
-false → `journalDelete`). That is the v1 hazard (a delete journaled during
-a healthy interval can later kill a same-key replacement). It is
-**pre-existing and untouched by #2121**; fully closing it needs a
-generation/session-identity guard on the delete wire (a separate change).
-#2121 **narrows** the loss (flush no longer drops, and the flush-deferral
-path is now disconnect-gated) but does NOT eliminate this class. Out of
-scope; recommend a follow-up issue for the generation guard.
+### Residual exposure (pre-existing, scoped out)
 
-Cold-start bulk interleaving (AGY §1): `doBulkSync` direct-writes current
-LIVE sessions under `writeMu` after the flush has enqueued all deletes to
-`sendCh`. A live `S(K)` landing after a stale `D(K)` on the wire is the
-SAFE direction (the peer ends with the live session). Pre-existing
-property of direct-write bulk; not introduced by #2121.
+The "a journaled delete can kill a same-key replacement re-synced before
+it replays" class is intrinsic to key-only deletes + a reconnect-surviving
+journal. It already exists for `QueueDeleteV4`'s full-queue and disconnect
+journaling. #2121 does not widen it (v5 only changes drop→retain on the
+flush path, matching `QueueDeleteV4`). Fully eliminating it needs a wire-
+protocol generation/session-identity guard on deletes — a larger,
+backward-incompatible change. **Recommend a follow-up issue.** #2121
+deliberately does the narrow, safe fix.
 
 ## Public API preservation
 
-No exported API changes. `flushDeleteJournal`, `rejournalTail`,
+No exported changes. `flushDeleteJournal`, `rejournalTail`,
 `journalDelete`, `queueMessage` unexported. `SyncStats` fields/semantics
-unchanged. No new field.
+unchanged. No new field, no test seam needed (non-blocking ⇒ no timing
+dependence in tests).
 
-## Hidden invariants the change must preserve
+## Hidden invariants preserved
 
-1. No lock held across the blocking `sendCh` send (matches
-   `writeBarrierMessage`). `rejournalTail` takes `deleteJournalMu` once,
-   from outside any held lock.
-2. No deadlock with `sendLoop`: it consumes `sendCh` independently;
-   `writeFull` is `syncWriteDeadline`-bounded; the flush holds no lock
-   during the send. Termination guaranteed by the global timer + the
-   `Connected` check.
-3. FIFO on the wire: deletes share the single `sendCh → sendLoop` path
-   with queued sessions (fixes v2 reorder). Re-journal prepend keeps FIFO
-   across a deferral (Fix B).
-4. `DeletesSent` incremented once per enqueue; re-journaled messages not
-   counted as sent (matches `queueMessage` semantics).
-5. Bounded journal: `rejournalTail` enforces cap; `tail` ≤ original journal
-   ≤ cap, and `total = len(tail)+len(concurrent)` can exceed cap only via
-   concurrent journaling — handled by the overflow branch (drops oldest,
-   counts `DeletesDropped`).
-6. Termination: loop bounded by captured `journal`; re-journaled messages
-   go to `s.deleteJournal`, not the loop slice. No livelock.
-7. Single-flush per reconnect (mutex-gated `wasDisconnected`), so no two
-   flushes race the nil'd journal.
-8. Force-disconnect on timeout uses the standard `handleDisconnect`
-   teardown; idempotent on a stale conn (handleDisconnect ignores
-   non-active conns).
+1. `deleteJournalMu` released before the loop; `rejournalTail` re-takes it
+   once from outside any held lock. No new lock nesting.
+2. No lock held across `queueMessage` (it takes none of these locks).
+3. FIFO: delivered deletes share the single `sendCh → sendLoop` path with
+   queued sessions; the re-journaled tail is FIFO-prepended.
+4. `DeletesSent` incremented once per enqueue inside `queueMessage`;
+   re-journaled messages are not counted as sent (no double-count — the v4
+   double-count came from the force-disconnect path, which is gone).
+5. Bounded journal: `rejournalTail` enforces cap; overflow drops oldest,
+   counts `DeletesDropped`.
+6. Termination: loop bounded by captured `journal`; stops at first failure;
+   re-journaled messages go to `s.deleteJournal`, not the loop slice.
+7. Single-flush per reconnect (mutex-gated `wasDisconnected`).
+8. Concurrency: a `QueueDeleteV4` racing the flush appends to the new
+   (nil'd→empty) journal; `rejournalTail` FIFO-prepends the older tail
+   ahead of it under one lock. No race, no lost delete (validated -race).
 
 ## Risk assessment
 
 | Risk class | Level | Notes |
 |---|---|---|
-| Behavioral regression | LOW | Same wire path as today's queueMessage; only the full-queue branch changes drop→bounded-block→deferred-with-disconnect. |
-| Concurrency / deadlock | LOW | No lock across send; global timer bounds block; rejournalTail single-lock. -race covered. |
-| Liveness | LOW | Global 2s flush cap (Fix A); force-disconnect prevents inconsistent-state lingering (Fix C). |
-| Ordering | LOW | Single ordered sendCh path; FIFO-prepend on deferral (Fix B). Residual healthy-interval QueueDelete hazard explicitly scoped out. |
-| Performance | LOW | Reconnect-only; blocks only when sendCh full, capped at 2s. |
+| Behavioral regression | LOW | Only change: full-queue branch drop→retain, matching QueueDeleteV4. |
+| Concurrency / deadlock | LOW | Non-blocking; single-lock rejournalTail. -race covered. |
+| Liveness | NONE | No blocking/timeout/disconnect. |
+| Ordering | LOW | Single ordered sendCh path; FIFO-prepend tail. Residual key-only-delete class pre-existing, scoped out. |
+| Performance | NONE | Reconnect-only, non-blocking. |
 
 ## Test plan
 
 New `pkg/cluster` tests, `go test -race ./pkg/cluster/`:
 
-1. **TestDeleteJournalFlushBlocksThenDeliversOnFullQueue** (non-tautological
-   regression): Connected=true, active `net.Pipe`, pre-fill `sendCh` to cap
-   FIRST, journal N deletes, launch `flushDeleteJournal` in a goroutine,
-   THEN start a drainer that reads `sendCh` + writes the conn (strict
-   ordering — drainer starts after the flush goroutine to keep it
-   non-tautological per SMR). Assert: all N delete frames arrive on the
-   wire IN ORDER after the pre-filled frames, `DeletesSent == N`, journal
-   empty, `DeletesDropped == 0`. Pre-fix (non-blocking queueMessage) drops
-   all N → 0 frames → fails. (Verify by reverting the fix.)
-2. **TestDeleteJournalFlushTimeoutRejournalsAndDisconnects**: fill `sendCh`
-   to cap with NO drainer, Connected=true, active conn, journal N deletes,
-   flush with a TEST-INJECTED short flush timeout (see Q-test). Assert: the
-   full tail is re-journaled (`s.deleteJournal` len == N), `DeletesSent ==
-   0`, `Errors >= 1` (>=, not ==, per SMR — sendLoop/handleDisconnect may
-   also bump), and the connection was torn down (Connected false / conn
-   closed).
-3. **TestDeleteJournalFlushRejournalFIFOPrepend** (Fix B): simulate a
-   concurrent journal: pre-seed `s.deleteJournal` is empty, but during the
-   timeout path inject a `D(new)` into the journal before `rejournalTail`
-   runs (or unit-test `rejournalTail` directly): assert the older tail is
-   at the FRONT and `D(new)` after it, and that an overflowing merge drops
-   the oldest tail entries (counted in `DeletesDropped`), never `D(new)`.
-4. **TestDeleteJournalFlushDisconnectedRejournals**: Connected=false,
-   journal N, flush; assert all re-journaled, `DeletesSent == 0`.
+1. **TestDeleteJournalFlushRetainsTailOnFullQueue** (non-tautological
+   regression): Connected=true, NO drainer; pre-fill `sendCh` to cap so
+   `queueMessage` fails immediately; journal N deletes; `flushDeleteJournal`.
+   Assert: `s.deleteJournal` now holds all N (re-journaled, FIFO order),
+   `DeletesSent == 0`, `DeletesDropped == 0` (N ≤ cap). Pre-fix: journal
+   nil'd + all dropped → `len(s.deleteJournal)==0` → test fails pre-fix.
+   Deterministic (no goroutine/timing — sendCh full ⇒ queueMessage's
+   `default` fires synchronously).
+2. **TestDeleteJournalFlushPartialThenRetains**: cap-3 `sendCh`, drain
+   nothing; Connected=true; journal 5 deletes; flush. Assert `DeletesSent
+   == 3` (first 3 enqueue), the un-sent 2 are re-journaled at the FRONT,
+   journal len == 2.
+3. **TestRejournalTailFIFOPrependAndOverflow** (unit-test rejournalTail
+   directly): seed `s.deleteJournal` with concurrent `[N1,N2]`; call
+   `rejournalTail([T3,T4,T5])`; assert order `[T3,T4,T5,N1,N2]`. Then with a
+   small cap assert overflow drops oldest tail first
+   (`[T4,T5,N1,N2]`/`[N2,N3]`-style per the dry-runs) and `DeletesDropped`
+   counts exactly the dropped.
+4. **TestDeleteJournalFlushAllFit**: room in `sendCh` + a drainer; journal
+   N; flush; assert `DeletesSent == N`, journal empty.
 5. **TestDeleteJournalFlushOrderingWithQueuedSession**: enqueue a session
-   frame to `sendCh`, then flush a delete for the SAME key; drain; assert
-   the session is read BEFORE the delete (through-sendCh FIFO — the
-   property v2 violated).
-6. Existing `TestDeleteJournal*` updated for the new active-conn wiring
-   where needed; asserted behavior (deletes delivered, journal emptied,
-   `DeletesSent==N`) preserved.
+   frame to `sendCh`, then flush a same-key delete (with room); drain;
+   assert session read BEFORE delete (through-sendCh FIFO).
+6. Existing `TestDeleteJournalBasic` / `…Overflow` / `…FlushNoEntries` /
+   `…ReconnectConvergence` / `TestSessionQueueDoesNotJournal` still green
+   (v5 preserves their asserted outcomes: deletes delivered when room,
+   journal emptied, `DeletesSent==N`).
 
 Gates: `go test -race ./pkg/cluster/`, `go build ./...`, full
 `go test ./...`.
 
-No loss-cluster iperf smoke: control-plane HA delete-journal replay logic,
-not a dataplane forwarding change.
+No loss-cluster iperf smoke: control-plane HA delete-journal replay logic.
 
 ## Docs
 
 `docs/session-sync-architecture.md` §"Delete Journal" (244) + §"Delete
-Journal Overflow" (425): flush now replays journaled deletes through the
-ordered send stream with a bounded (global-timeout) blocking enqueue (full
-queue blocks until drained rather than dropping); on stall it re-journals
-the un-sent tail FIFO-first and forces a reconnect; genuine loss at cap is
-counted in `DeletesDropped`.
+Journal Overflow" (425): flush now re-journals (retains) un-sent deletes
+on a full send queue — matching `QueueDeleteV4` — instead of dropping
+them; they replay on the next reconnect; genuine loss only at the journal
+cap (`DeletesDropped`).
 
 ## Out of scope (explicitly)
 
-- `sendCh` capacity (4096).
 - Generation/session-identity guard on deletes (closes the residual
-  healthy-interval `QueueDelete` re-journal hazard) — separate wire+receive
-  change; recommend a follow-up issue.
-- Cold-start bulk direct-write interleaving — pre-existing; safe direction
-  for live sessions.
-- A distinct `DeletesRequeued` metric — Warn log + `DeletesDropped` cover
-  observability.
+  key-only-delete-kills-replacement class) — separate wire change; FILE A
+  FOLLOW-UP ISSUE.
+- Delivering ALL journaled deletes on the CURRENT connection regardless of
+  queue depth (the v3/v4 goal) — every mechanism for it (blocking,
+  timeout, force-disconnect) was shown worse than the narrow fix. The
+  deletes that don't fit replay on the next reconnect, exactly as
+  `QueueDeleteV4`'s full-queue deletes already do.
+- `sendCh` capacity (4096).
 - #2120 (`syncSweep`) — different function, sibling agent.
 
 ## Open questions for adversarial re-review
 
-Q1. Fix A: is a single global `syncWriteDeadline` (2s) the right budget for
-    the whole flush, or should the flush get its own (larger?) constant so a
-    near-full but draining queue still completes? Trade-off: longer budget =
-    more deletes delivered on this connection vs. longer accept-loop block.
-Q2. Fix C: force-`handleDisconnect` on timeout drops the connection (and any
-    deletes already enqueued to `sendCh` this flush ride out the disconnect
-    in `sendCh`, replayed on reconnect). Is dropping a freshly-established
-    connection on a transient full-queue acceptable, given it guarantees the
-    deferral is disconnect-gated? Any reconnect storm risk if the queue is
-    chronically full?
-Q3. Fix B: is FIFO-prepend correct given deletes are idempotent by key? Does
-    order among deletes actually matter, or is the prepend belt-and-braces?
-    (Idempotent-by-key suggests order among pure deletes is not load-
-    bearing, but the inversion-vs-new-delete and overflow-drop-bias are real
-    correctness issues regardless — confirm the prepend resolves both.)
-Q4. Is the residual healthy-interval `QueueDeleteV4` re-journal hazard
-    correctly scoped OUT of #2121, or must it be fixed here for the fix to
-    be meaningful? (It needs a wire-protocol generation guard.)
-Q5. Test injection: tests #1/#2 need a controllable flush timeout. Add an
-    unexported `flushSendTimeout time.Duration` field defaulting to
-    `syncWriteDeadline`, set small in tests? Acceptable seam?
-Q6. Any remaining sequence where v4 is WORSE than the silent drop?
+Q1. Is v5 genuinely never-worse-than-the-silent-drop? Construct any
+    sequence where retaining (re-journaling) the un-sent delete produces a
+    worse outcome than dropping it. (Claim: no — drop loses the delete;
+    retain delivers it later, which is the bug's intent; the
+    replacement-resurrection class is pre-existing in QueueDeleteV4.)
+Q2. Is stopping at the first failure (vs attempting every message) correct
+    given `sendCh` is full at that point and order must be preserved?
+Q3. Is the FIFO-prepend in `rejournalTail` necessary, or would a plain
+    append suffice (deletes idempotent by key)? (Prepend still correct for
+    overflow-eviction bias even if intra-delete order is not load-bearing.)
+Q4. Does v5 leave the issue meaningfully fixed (silent drop eliminated),
+    or does the "deletes that don't fit wait for next reconnect" deferral
+    make it a no-op? Note `QueueDeleteV4` already behaves this way; the
+    delta is purely drop→retain on the flush path.
+Q5. Any concurrency hazard between the flush's nil-ing of `s.deleteJournal`
+    and a concurrent `QueueDeleteV4`→`journalDelete` (race / lost delete /
+    eviction bias) that `rejournalTail`'s single-lock prepend does not
+    cover?
+Q6. Is reusing `DeletesDropped` (cap eviction only) + the Warn log
+    sufficient observability for "flush hit a full queue and deferred",
+    or is a distinct counter warranted?

--- a/docs/pr/2121-flushdeletejournal-requeue/plan.md
+++ b/docs/pr/2121-flushdeletejournal-requeue/plan.md
@@ -1,0 +1,266 @@
+# #2121 — flushDeleteJournal must not silently drop journaled deletes on a full send queue
+
+Status: DRAFT v1 — pending adversarial plan review
+
+## Issue framing
+
+`pkg/cluster/sync_conn.go`. `QueueDeleteV4`/`QueueDeleteV6` follow a
+journal-on-failure contract: when `queueMessage` returns false (peer
+disconnected or `sendCh` full), the delete is re-journaled via
+`journalDelete` so it is not lost. `flushDeleteJournal` — invoked from
+`handleNewConnection` on the first post-disconnect connection — drains
+the whole journal under lock (`s.deleteJournal = nil`), then replays each
+message via `queueMessage` directly. It does **not** re-journal a message
+for which `queueMessage` returns false.
+
+Consequence: if `sendCh` (cap 4096) is full at replay time — a large
+delete journal coinciding with bulk/session traffic on the same channel
+immediately after connect — the deletes that hit the full channel are
+silently dropped. The journal was already nil'd, so they are neither
+sent nor retained. A dropped delete leaves a stale session on the peer
+until it independently ages out, defeating the journal's purpose
+(preventing indefinite stale-session leak across a disconnect).
+`queueMessage` sets `syncBackfillNeeded` on overflow, but that triggers
+a SESSION re-sweep (re-sending sessions), not a delete replay — so a
+dropped delete is not recovered.
+
+Severity: LOW. The window (queue full immediately after a fresh connect,
+before the send loop drains it) is narrow and the consequence is a stale
+standby session, not a forwarding error.
+
+## Honest scope / value framing
+
+This is a small, focused HA-correctness fix in the control-plane session-
+sync path. It is not a perf change and not a dataplane (hot-path) change.
+The win is: no journaled delete is silently lost on the flush path; the
+flush path becomes consistent with the `QueueDeleteV4` contract; and any
+genuinely-unavoidable bounded loss (journal cap reached) is surfaced via
+the existing `DeletesDropped` counter + a log line rather than vanishing.
+
+If reviewers conclude the change is unnecessary (e.g. the drop is already
+recovered by some path I missed) or wrong (re-journaling introduces a
+worse failure mode), PLAN-KILL is an acceptable verdict.
+
+## What's already shipped / relevant existing behavior
+
+- `journalDelete(msg)` (sync_conn.go:534) is the bounded ring-buffer
+  append. It evicts the oldest entry and increments `DeletesDropped`
+  when the journal is at cap (`deleteJournalCap`, default
+  `deleteJournalDefaultCap = 10000`). It takes `deleteJournalMu`.
+- `QueueDeleteV4`/`V6` (sync_conn.go:517/526) call
+  `journalDelete(msg)` when `queueMessage` returns false. This is the
+  contract to mirror.
+- `queueMessage` (sync_conn.go:484) returns false when not connected or
+  when `sendCh` is full; on a full-channel failure it sets
+  `syncBackfillNeeded` (session re-sweep) and increments `Errors`.
+- `flushDeleteJournal` is called only from `handleNewConnection` when
+  `wasDisconnected` is true (sync_conn.go:200), before `OnPeerConnected`
+  and before bulk sync. It runs on the connection-accept goroutine, not
+  under `s.mu`.
+- `DeletesDropped` is surfaced in `SyncStatsSnapshot` (sync.go:477) and
+  thus to status/metrics consumers.
+
+## Concrete design
+
+In `flushDeleteJournal`, when `queueMessage` returns false during the
+replay loop, re-journal that message via `journalDelete(msg)` instead of
+dropping it. This mirrors the `QueueDeleteV4` contract exactly.
+
+```go
+func (s *SessionSync) flushDeleteJournal() {
+	s.deleteJournalMu.Lock()
+	journal := s.deleteJournal
+	s.deleteJournal = nil
+	s.deleteJournalMu.Unlock()
+	if len(journal) == 0 {
+		return
+	}
+	var flushed, requeued int
+	// Replay journaled delete messages before normal sync resumes. If the
+	// send queue is full mid-replay, re-journal the un-sent delete (mirror
+	// the QueueDeleteV4 journal-on-failure contract) so it is retried on
+	// the next flush instead of being silently lost. journalDelete itself
+	// enforces the bounded cap and increments DeletesDropped if the ring
+	// is genuinely full, so unavoidable loss stays observable.
+	for _, msg := range journal {
+		if s.queueMessage(msg, &s.stats.DeletesSent, "journal_flush") {
+			flushed++
+			continue
+		}
+		s.journalDelete(msg)
+		requeued++
+	}
+	if requeued > 0 {
+		slog.Warn("cluster sync: delete journal flush hit full send queue, re-journaled un-sent deletes for retry",
+			"total", len(journal), "sent", flushed, "requeued", requeued,
+			"journal_len_after", s.deleteJournalLen())
+	} else {
+		slog.Info("cluster sync: flushed delete journal", "total", len(journal), "sent", flushed)
+	}
+}
+```
+
+`deleteJournalLen()` is a tiny lock-guarded accessor (`len(s.deleteJournal)`
+under `deleteJournalMu`) added for the log line; if reviewers prefer, the
+log can omit it to avoid a re-lock — open question Q5.
+
+### Why re-journal (not block / not stop-and-restore-tail)
+
+The issue lists three options: block/retry until drained, re-queue failed
+deletes, or stop and restore the un-flushed tail. Re-journaling per-failed-
+message is chosen because:
+
+1. It is the **exact contract `QueueDeleteV4` already uses** — consistency
+   was an explicit goal in the issue. One code path, one behavior.
+2. It does **not block** the connection-accept goroutine. Blocking until
+   `sendCh` drains would stall `handleNewConnection` (and therefore
+   `OnPeerConnected`/bulk sync) behind the send loop, on the very goroutine
+   that accepted the connection — a worse failure mode than a deferred
+   retry. `queueMessage` is deliberately non-blocking everywhere else.
+3. Re-journaled deletes are retried on the next `flushDeleteJournal`, which
+   fires on the next first-post-disconnect connection. In the meantime they
+   sit in the bounded ring exactly as a delete journaled while disconnected
+   would — no new invariant.
+4. `journalDelete` already enforces the cap and increments `DeletesDropped`,
+   so if the ring is genuinely full the loss is surfaced (counter + the new
+   Warn log), satisfying the "if bounded loss is unavoidable, surface it"
+   fallback in the issue.
+
+### Ordering note (re-journal preserves FIFO-enough semantics)
+
+The journal is a ring (oldest-first). When we re-journal failed messages
+during a flush, they append to the tail of the now-empty journal. Because
+`sendCh` fills up only after some prefix succeeded, the failed messages are
+a suffix of the original order, so re-appending them preserves their
+relative order. Deletes are idempotent on the peer (delete-by-key), so
+absolute global ordering vs. other message types is not required — a delete
+that arrives "late" still removes the stale entry.
+
+## Public API preservation
+
+No exported API changes. `flushDeleteJournal`, `journalDelete`,
+`queueMessage` are all unexported. `SyncStats.DeletesDropped` semantics are
+unchanged (still: a journaled delete the bounded ring could not retain).
+No new exported field. (`deleteJournalLen()` is an unexported helper.)
+
+## Hidden invariants the change must preserve
+
+1. **Lock ordering / no deadlock**: `flushDeleteJournal` releases
+   `deleteJournalMu` before the replay loop (current behavior). `journalDelete`
+   re-acquires `deleteJournalMu` per failed message — called from OUTSIDE
+   the lock, so no re-entrant deadlock. `queueMessage` does not take
+   `deleteJournalMu`. Confirm no path holds `deleteJournalMu` across
+   `journalDelete`.
+2. **Concurrent `QueueDeleteV4` during flush**: while a flush runs,
+   `QueueDeleteV4` on another goroutine may call `journalDelete`
+   concurrently. Both serialize on `deleteJournalMu`; the slice append is
+   safe. The re-journaled flush messages and concurrently-journaled new
+   deletes interleave in the ring — both are valid deletes, order among
+   them is not load-bearing (idempotent by key). No data race (validated
+   under `-race`).
+3. **No unbounded growth**: re-journaling is bounded by `deleteJournalCap`
+   via `journalDelete`'s eviction. A persistently-full `sendCh` cannot grow
+   the journal past cap.
+4. **`DeletesSent` accounting**: only incremented on a real channel enqueue
+   (inside `queueMessage`). Re-journaled messages do not double-count.
+5. **`syncBackfillNeeded` still set**: `queueMessage`'s overflow path still
+   fires (session re-sweep), unchanged.
+6. **Termination**: the flush loop is bounded by the captured `journal`
+   slice length; re-journaled messages go to `s.deleteJournal`, NOT back
+   into the loop's `journal` — so the loop cannot livelock.
+
+## Risk assessment
+
+| Risk class | Level | Notes |
+|---|---|---|
+| Behavioral regression | LOW | Pure additive on the false-branch; success path (flushed++) unchanged. Empty-journal early return unchanged. |
+| Lifetime / concurrency | LOW | journalDelete called outside the lock it takes; -race covers the concurrent-journal interleave. |
+| Performance | NONE | Control-plane reconnect path, runs at most once per reconnect; bounded by journal len. Not a hot path. |
+| Architectural mismatch | LOW | Reuses the established journal-on-failure contract; no new mechanism. |
+
+## Test plan
+
+New `pkg/cluster` unit tests, run with `go test -race ./pkg/cluster/`:
+
+1. **TestDeleteJournalFlushRequeuesOnFullQueue** (the non-tautological
+   regression test): construct a `SessionSync` with a TINY `sendCh` (e.g.
+   replace with a cap-2 channel) and Connected=true. Journal N>2 deletes.
+   Pre-fill / saturate `sendCh` so only the first 2 enqueue succeed. Call
+   `flushDeleteJournal`. Assert: `DeletesSent == 2`, and the journal now
+   contains the remaining N-2 messages (re-journaled), NOT empty. Pre-fix
+   this FAILS (journal is empty — deletes dropped). Confirm it fails
+   against base by reverting the fix locally.
+2. **TestDeleteJournalFlushRequeueRetriedOnNextFlush**: after #1, drain
+   `sendCh` and call `flushDeleteJournal` again; assert the remaining
+   deletes now flush (DeletesSent reaches N) and the journal empties —
+   proving the re-journaled deletes are actually retried, not just parked.
+3. **TestDeleteJournalFlushRequeueRespectsCapAndCounts**: set a small
+   `deleteJournalCap`; saturate `sendCh`; journal more than cap; flush;
+   assert journal len == cap and `DeletesDropped` increments for the
+   genuinely-evicted ones (surfaced bounded loss). This proves the
+   fallback path in the issue.
+4. Existing tests unchanged and still green: `TestDeleteJournalBasic`,
+   `TestDeleteJournalOverflow`, `TestDeleteJournalFlushNoEntries`,
+   `TestDeleteJournalReconnectConvergence`, `TestSessionQueueDoesNotJournal`.
+
+Gates:
+- `go test -race ./pkg/cluster/` green.
+- `go build ./...` clean.
+- Full `go test ./...` for the cluster package + dependents.
+
+No loss-cluster iperf smoke: this is control-plane HA delete-journal
+replay logic, not a dataplane forwarding change. The standing
+"smoke v4+v6, per-class CoS" matrix in the triple-review skill is for
+dataplane/CoS refactors and does not apply.
+
+## Docs
+
+`docs/session-sync-architecture.md` §"Delete Journal" (line 244) and
+§"Delete Journal Overflow" (line 425) describe the journal + replay. The
+Delete Journal section will be updated to note that flush re-journals
+un-sent deletes on a full send queue (retry on next reconnect) rather than
+dropping them, and that genuinely-unavoidable loss at the journal cap is
+counted in `DeletesDropped`. No other doc references the flush path.
+
+## Out of scope (explicitly)
+
+- Changing `sendCh` capacity (4096) — orthogonal sizing question.
+- Blocking/backpressure redesign of `queueMessage` — rejected above
+  (would stall the accept goroutine).
+- A dedicated `DeletesRequeued` Prometheus counter — the Warn log surfaces
+  the requeue, and `DeletesDropped` surfaces genuine loss. Could be a
+  trivial follow-up if operators want a metric for "requeue happened" vs
+  "drop happened"; not needed for correctness. Open question Q4.
+- #2120 (standby session-expiry / `syncSweep`) — a DIFFERENT function in
+  the same file, owned by a sibling research agent. Untouched here.
+
+## Open questions for adversarial review
+
+Q1. Is re-journal (vs block-until-drained vs stop-and-restore-tail) the
+    right choice given `flushDeleteJournal` runs on the connection-accept
+    goroutine before `OnPeerConnected`/bulk sync? Argue for blocking if you
+    think the deferred-retry window is unacceptable.
+Q2. Re-journaled deletes are only retried on the NEXT first-post-disconnect
+    flush. If the link stays up, they sit in the journal until the next
+    disconnect/reconnect. Is that acceptable, or must they be drained on
+    the current connection (e.g. by a deferred re-flush once `sendCh`
+    drains)? Note: the session re-sweep (`syncBackfillNeeded`) re-sends
+    SESSIONS but not deletes, so a still-open standby session for a deleted
+    flow is the failure being fixed — does the deferred-retry fully close
+    it, or only on next reconnect?
+Q3. Concurrency: a `QueueDeleteV4` racing the flush both call
+    `journalDelete`. Any ordering or correctness hazard beyond "interleaved
+    but all valid"? Any case where a re-journaled delete could be evicted by
+    a concurrent journal append before it is ever retried (silent loss under
+    the cap path)? Is the `DeletesDropped` accounting still meaningful?
+Q4. Counter design: is reusing `DeletesDropped` (only on genuine cap
+    eviction) + a Warn log sufficient, or does the issue's "surface via a
+    counter" intent require a distinct `DeletesRequeued` metric?
+Q5. Is the `deleteJournalLen()` re-lock for the log line worth it, or should
+    the log omit journal_len_after to avoid re-taking `deleteJournalMu`?
+Q6. Is the FIFO/ordering reasoning (failed messages are a suffix; deletes
+    idempotent by key) sound? Any scenario where late delete arrival is
+    incorrect (e.g. key reuse — a NEW session installed with the same key
+    before the stale delete arrives, and the delete then removes the new
+    session)? How does the existing journal already handle that, and does
+    re-journal change the exposure?

--- a/docs/pr/2121-flushdeletejournal-requeue/plan.md
+++ b/docs/pr/2121-flushdeletejournal-requeue/plan.md
@@ -1,6 +1,29 @@
 # #2121 — flushDeleteJournal must not silently drop journaled deletes on a full send queue
 
-Status: DRAFT v1 — pending adversarial plan review
+Status: DRAFT v2 — revised after Codex PLAN-KILL of v1; pending re-review
+
+## v1 → v2 change (why the design changed)
+
+v1 proposed re-journaling un-sent deletes for retry on the NEXT
+reconnect. Codex PLAN-KILLed it for a real ordering regression: deletes
+are key-only on the peer (`deleteClusterSynced*` → `DeleteWithCompanions*`
+deletes whatever currently owns the key, no generation guard). Deferring
+a delete across a healthy connected interval means a stale delete can
+replay on a later reconnect AFTER a replacement session with the same key
+has been re-synced — wrongly removing the live replacement. That is worse
+than the stale standby session the journal exists to prevent. Codex also
+correctly refuted v1's "failed messages are a suffix" FIFO claim
+(`queueMessage` is retried per-entry; `sendLoop` can drain between
+iterations so a later entry can succeed after an earlier one fails) and
+noted that re-journal-only does not restore current-connection
+convergence.
+
+v2 fixes the bug WITHOUT changing the journal's ordering contract:
+**drain the un-sent deletes on the CURRENT connection, before normal sync
+resumes**, by writing them directly under `writeMu` — the exact
+direct-write path `BulkSync`/`QueueConfig` already use to bypass the
+bounded `sendCh`. No deferral, no cross-reconnect re-journal of a delete
+while the link is up, no stale-replacement hazard.
 
 ## Issue framing
 
@@ -10,61 +33,57 @@ disconnected or `sendCh` full), the delete is re-journaled via
 `journalDelete` so it is not lost. `flushDeleteJournal` — invoked from
 `handleNewConnection` on the first post-disconnect connection — drains
 the whole journal under lock (`s.deleteJournal = nil`), then replays each
-message via `queueMessage` directly. It does **not** re-journal a message
-for which `queueMessage` returns false.
+message via `queueMessage`. It does **not** handle a `queueMessage`
+failure: a delete that hits a full `sendCh` (cap 4096) during replay is
+silently dropped (the journal was already nil'd). The dropped delete
+leaves a stale session on the peer until it independently ages out.
 
-Consequence: if `sendCh` (cap 4096) is full at replay time — a large
-delete journal coinciding with bulk/session traffic on the same channel
-immediately after connect — the deletes that hit the full channel are
-silently dropped. The journal was already nil'd, so they are neither
-sent nor retained. A dropped delete leaves a stale session on the peer
-until it independently ages out, defeating the journal's purpose
-(preventing indefinite stale-session leak across a disconnect).
-`queueMessage` sets `syncBackfillNeeded` on overflow, but that triggers
-a SESSION re-sweep (re-sending sessions), not a delete replay — so a
-dropped delete is not recovered.
-
-Severity: LOW. The window (queue full immediately after a fresh connect,
-before the send loop drains it) is narrow and the consequence is a stale
-standby session, not a forwarding error.
+Severity: LOW — narrow window (queue full immediately after a fresh
+connect, before the send loop drains it), consequence is a stale standby
+session, not a forwarding error.
 
 ## Honest scope / value framing
 
-This is a small, focused HA-correctness fix in the control-plane session-
-sync path. It is not a perf change and not a dataplane (hot-path) change.
-The win is: no journaled delete is silently lost on the flush path; the
-flush path becomes consistent with the `QueueDeleteV4` contract; and any
-genuinely-unavoidable bounded loss (journal cap reached) is surfaced via
-the existing `DeletesDropped` counter + a log line rather than vanishing.
+Small, focused HA-correctness fix in the control-plane session-sync
+reconnect path. Not a perf change, not a dataplane (hot-path) change. The
+win: every journaled delete is delivered on the reconnect, in journal
+order, before normal sync resumes — no silent loss, no ordering
+regression. If reviewers conclude the change is unnecessary or the
+direct-write approach introduces a worse failure mode, PLAN-KILL is
+acceptable.
 
-If reviewers conclude the change is unnecessary (e.g. the drop is already
-recovered by some path I missed) or wrong (re-journaling introduces a
-worse failure mode), PLAN-KILL is an acceptable verdict.
+## Relevant existing behavior (verified against master 325d10683)
 
-## What's already shipped / relevant existing behavior
-
-- `journalDelete(msg)` (sync_conn.go:534) is the bounded ring-buffer
-  append. It evicts the oldest entry and increments `DeletesDropped`
-  when the journal is at cap (`deleteJournalCap`, default
-  `deleteJournalDefaultCap = 10000`). It takes `deleteJournalMu`.
-- `QueueDeleteV4`/`V6` (sync_conn.go:517/526) call
-  `journalDelete(msg)` when `queueMessage` returns false. This is the
-  contract to mirror.
-- `queueMessage` (sync_conn.go:484) returns false when not connected or
-  when `sendCh` is full; on a full-channel failure it sets
-  `syncBackfillNeeded` (session re-sweep) and increments `Errors`.
+- Journaled messages are **full framed frames**: `encodeDeleteV4`/`V6`
+  return `syncHeaderSize+payload` bytes (magic, type, length, body). They
+  are written verbatim by `sendLoop` via `writeFull(conn, msg)` — NOT
+  re-framed with `writeMsg`.
+- `sendLoop` (sync_conn.go:681) pulls each `sendCh` message and writes it
+  under `writeMu` via `writeFull`, retrying on disconnect.
+- The established **direct-write, bypass-sendCh** pattern: `BulkSync`
+  (sync_bulk.go:79) and `QueueConfig` (sync_conn.go:566) take `writeMu`,
+  call `writeMsg(conn, ...)`, and on error call `s.handleDisconnect(conn)`
+  and stop. `BulkSync` writes potentially thousands of messages this way.
 - `flushDeleteJournal` is called only from `handleNewConnection` when
-  `wasDisconnected` is true (sync_conn.go:200), before `OnPeerConnected`
-  and before bulk sync. It runs on the connection-accept goroutine, not
-  under `s.mu`.
-- `DeletesDropped` is surfaced in `SyncStatsSnapshot` (sync.go:477) and
-  thus to status/metrics consumers.
+  `wasDisconnected` is true (sync_conn.go:200), synchronously, BEFORE
+  `OnPeerConnected` and before bulk sync, on the connection-accept
+  goroutine. While disconnected `syncSweep` does not advance, so the flush
+  replays the outage's deletes before any newer session state can become
+  durable on the peer — the ordering contract v2 must preserve.
+- `journalDelete` (sync_conn.go:534) is the bounded ring append: evicts
+  oldest + increments `DeletesDropped` at cap (`deleteJournalCap`,
+  default 10000). Takes `deleteJournalMu`.
+- `DeletesSent` is incremented only on a real send. `DeletesDropped` is
+  surfaced in `SyncStatsSnapshot` (sync.go:477).
 
 ## Concrete design
 
-In `flushDeleteJournal`, when `queueMessage` returns false during the
-replay loop, re-journal that message via `journalDelete(msg)` instead of
-dropping it. This mirrors the `QueueDeleteV4` contract exactly.
+Rewrite the `flushDeleteJournal` replay loop to **write each journaled
+delete directly to the active connection under `writeMu`** (mirror
+`BulkSync`), instead of enqueueing to the bounded `sendCh`. This delivers
+every journaled delete on the current connection, in journal order,
+before normal sync resumes — eliminating the `sendCh`-full drop and
+preserving the ordering contract.
 
 ```go
 func (s *SessionSync) flushDeleteJournal() {
@@ -75,192 +94,204 @@ func (s *SessionSync) flushDeleteJournal() {
 	if len(journal) == 0 {
 		return
 	}
-	var flushed, requeued int
-	// Replay journaled delete messages before normal sync resumes. If the
-	// send queue is full mid-replay, re-journal the un-sent delete (mirror
-	// the QueueDeleteV4 journal-on-failure contract) so it is retried on
-	// the next flush instead of being silently lost. journalDelete itself
-	// enforces the bounded cap and increments DeletesDropped if the ring
-	// is genuinely full, so unavoidable loss stays observable.
-	for _, msg := range journal {
-		if s.queueMessage(msg, &s.stats.DeletesSent, "journal_flush") {
-			flushed++
-			continue
-		}
-		s.journalDelete(msg)
-		requeued++
+	conn := s.getActiveConn()
+	if conn == nil {
+		// No active connection: re-journal everything for the next
+		// reconnect flush (the original journal-on-disconnect contract —
+		// safe because the next flush again runs before normal sync).
+		s.rejournalAll(journal)
+		return
 	}
-	if requeued > 0 {
-		slog.Warn("cluster sync: delete journal flush hit full send queue, re-journaled un-sent deletes for retry",
-			"total", len(journal), "sent", flushed, "requeued", requeued,
-			"journal_len_after", s.deleteJournalLen())
-	} else {
-		slog.Info("cluster sync: flushed delete journal", "total", len(journal), "sent", flushed)
+	var sent int
+	// Replay journaled delete frames directly under writeMu (bypassing the
+	// bounded sendCh, like BulkSync) so they are delivered IN ORDER on the
+	// current connection before normal sync resumes. Journaled messages are
+	// already fully framed (encodeDeleteV4/V6), so write them verbatim.
+	for i, msg := range journal {
+		s.writeMu.Lock()
+		err := writeFull(conn, msg)
+		s.writeMu.Unlock()
+		if err != nil {
+			// Genuine disconnect mid-flush: re-journal the un-sent tail
+			// (including this one) for the next reconnect flush, and tear
+			// down the connection like the other senders.
+			s.rejournalAll(journal[i:])
+			s.stats.Errors.Add(1)
+			s.handleDisconnect(conn)
+			slog.Warn("cluster sync: delete journal flush write error, re-journaled un-sent tail",
+				"err", err, "total", len(journal), "sent", sent, "rejournaled", len(journal)-i)
+			return
+		}
+		s.stats.DeletesSent.Add(1)
+		sent++
+		// Yield periodically so barrier/ack writers can acquire writeMu
+		// (Go mutex is not fair) — mirror BulkSync's runtime.Gosched().
+		if sent%64 == 0 {
+			runtime.Gosched()
+		}
+	}
+	slog.Info("cluster sync: flushed delete journal", "total", len(journal), "sent", sent)
+}
+
+// rejournalAll re-appends un-sent delete frames to the journal under lock,
+// honoring the bounded cap (journalDelete increments DeletesDropped on
+// eviction). Used only when the connection is gone — the next reconnect
+// flush will replay them before normal sync resumes.
+func (s *SessionSync) rejournalAll(msgs [][]byte) {
+	for _, msg := range msgs {
+		s.journalDelete(msg)
 	}
 }
 ```
 
-`deleteJournalLen()` is a tiny lock-guarded accessor (`len(s.deleteJournal)`
-under `deleteJournalMu`) added for the log line; if reviewers prefer, the
-log can omit it to avoid a re-lock — open question Q5.
+### Why direct-write on the current connection (vs sendCh / vs block)
 
-### Why re-journal (not block / not stop-and-restore-tail)
+- **Preserves the ordering contract.** Sequential `writeFull` under one
+  `writeMu` delivers the journaled deletes in strict journal order, on the
+  current connection, before `handleNewConnection` proceeds to
+  `OnPeerConnected`/bulk. No delete is deferred across a healthy interval,
+  so the v1 stale-replacement-delete hazard cannot occur.
+- **No silent drop.** There is no bounded queue to overflow on the flush
+  path. `writeFull` blocks on TCP backpressure (with `syncWriteDeadline`),
+  it does not drop.
+- **Does not stall indefinitely.** `writeFull` has a write deadline
+  (`syncWriteDeadline`); a wedged peer trips the deadline → error →
+  `handleDisconnect` + re-journal-tail (correct: genuinely failing peer,
+  defer to next reconnect). This is the same bound `BulkSync`/`sendLoop`
+  rely on.
+- **Consistent with the codebase.** `BulkSync` already direct-writes far
+  more messages on this exact goroutine sequence under `writeMu`.
 
-The issue lists three options: block/retry until drained, re-queue failed
-deletes, or stop and restore the un-flushed tail. Re-journaling per-failed-
-message is chosen because:
+### Re-journal only on genuine disconnect
 
-1. It is the **exact contract `QueueDeleteV4` already uses** — consistency
-   was an explicit goal in the issue. One code path, one behavior.
-2. It does **not block** the connection-accept goroutine. Blocking until
-   `sendCh` drains would stall `handleNewConnection` (and therefore
-   `OnPeerConnected`/bulk sync) behind the send loop, on the very goroutine
-   that accepted the connection — a worse failure mode than a deferred
-   retry. `queueMessage` is deliberately non-blocking everywhere else.
-3. Re-journaled deletes are retried on the next `flushDeleteJournal`, which
-   fires on the next first-post-disconnect connection. In the meantime they
-   sit in the bounded ring exactly as a delete journaled while disconnected
-   would — no new invariant.
-4. `journalDelete` already enforces the cap and increments `DeletesDropped`,
-   so if the ring is genuinely full the loss is surfaced (counter + the new
-   Warn log), satisfying the "if bounded loss is unavoidable, surface it"
-   fallback in the issue.
-
-### Ordering note (re-journal preserves FIFO-enough semantics)
-
-The journal is a ring (oldest-first). When we re-journal failed messages
-during a flush, they append to the tail of the now-empty journal. Because
-`sendCh` fills up only after some prefix succeeded, the failed messages are
-a suffix of the original order, so re-appending them preserves their
-relative order. Deletes are idempotent on the peer (delete-by-key), so
-absolute global ordering vs. other message types is not required — a delete
-that arrives "late" still removes the stale entry.
+Re-journaling now happens ONLY when there is no active connection (or a
+write fails → disconnect). In that case deferring to the next reconnect
+flush is correct and matches the original journal-on-disconnect contract:
+the next flush again runs before normal sync resumes, so the deletes still
+replay ahead of newer session state. The v1 "re-journal while connected
+and retry next reconnect" path — the source of the ordering regression —
+is gone.
 
 ## Public API preservation
 
 No exported API changes. `flushDeleteJournal`, `journalDelete`,
-`queueMessage` are all unexported. `SyncStats.DeletesDropped` semantics are
-unchanged (still: a journaled delete the bounded ring could not retain).
-No new exported field. (`deleteJournalLen()` is an unexported helper.)
+`queueMessage`, `rejournalAll` are unexported. `SyncStats` fields and
+semantics unchanged (`DeletesSent` still per-send; `DeletesDropped` still
+cap-eviction). No new field.
 
 ## Hidden invariants the change must preserve
 
-1. **Lock ordering / no deadlock**: `flushDeleteJournal` releases
-   `deleteJournalMu` before the replay loop (current behavior). `journalDelete`
-   re-acquires `deleteJournalMu` per failed message — called from OUTSIDE
-   the lock, so no re-entrant deadlock. `queueMessage` does not take
-   `deleteJournalMu`. Confirm no path holds `deleteJournalMu` across
-   `journalDelete`.
-2. **Concurrent `QueueDeleteV4` during flush**: while a flush runs,
-   `QueueDeleteV4` on another goroutine may call `journalDelete`
-   concurrently. Both serialize on `deleteJournalMu`; the slice append is
-   safe. The re-journaled flush messages and concurrently-journaled new
-   deletes interleave in the ring — both are valid deletes, order among
-   them is not load-bearing (idempotent by key). No data race (validated
-   under `-race`).
-3. **No unbounded growth**: re-journaling is bounded by `deleteJournalCap`
-   via `journalDelete`'s eviction. A persistently-full `sendCh` cannot grow
-   the journal past cap.
-4. **`DeletesSent` accounting**: only incremented on a real channel enqueue
-   (inside `queueMessage`). Re-journaled messages do not double-count.
-5. **`syncBackfillNeeded` still set**: `queueMessage`'s overflow path still
-   fires (session re-sweep), unchanged.
-6. **Termination**: the flush loop is bounded by the captured `journal`
-   slice length; re-journaled messages go to `s.deleteJournal`, NOT back
-   into the loop's `journal` — so the loop cannot livelock.
+1. **Lock ordering**: `flushDeleteJournal` releases `deleteJournalMu`
+   before writing; `rejournalAll`/`journalDelete` re-take it from outside
+   any held lock. `writeMu` is taken/released per message (never held
+   across `deleteJournalMu`). No new lock nesting vs `BulkSync`.
+2. **writeMu serialization**: direct writes serialize with `sendLoop`,
+   heartbeat, bulk, config writers on `writeMu` — same as every other
+   sender. Frame integrity preserved (whole frame written under the lock).
+3. **No double-send / accounting**: `DeletesSent` incremented once per
+   successful `writeFull`. Re-journaled (disconnect) messages are not
+   counted as sent.
+4. **Bounded re-journal**: `rejournalAll` → `journalDelete` honors the cap
+   and counts genuine loss via `DeletesDropped`.
+5. **Termination**: loop bounded by captured `journal`; re-journaled
+   messages go to `s.deleteJournal`, not the loop slice. No livelock.
+6. **handleDisconnect on write error**: mirrors `BulkSync`/`sendLoop`
+   exactly — required so the dead connection is torn down and reconnect
+   re-armed.
+7. **Ordering contract**: flush completes (all deletes written, or tail
+   re-journaled on disconnect) synchronously before `handleNewConnection`
+   calls `OnPeerConnected`/bulk — unchanged call sequence.
 
 ## Risk assessment
 
 | Risk class | Level | Notes |
 |---|---|---|
-| Behavioral regression | LOW | Pure additive on the false-branch; success path (flushed++) unchanged. Empty-journal early return unchanged. |
-| Lifetime / concurrency | LOW | journalDelete called outside the lock it takes; -race covers the concurrent-journal interleave. |
-| Performance | NONE | Control-plane reconnect path, runs at most once per reconnect; bounded by journal len. Not a hot path. |
-| Architectural mismatch | LOW | Reuses the established journal-on-failure contract; no new mechanism. |
+| Behavioral regression | LOW | Happy path now direct-writes (like BulkSync) instead of via sendCh; same wire output, same writeMu serialization, runs at most once per reconnect. |
+| Concurrency / deadlock | LOW | Reuses BulkSync's writeMu+handleDisconnect pattern; deleteJournalMu released before writes. Covered by -race. |
+| Performance | NONE | Reconnect-only, bounded by journal len; BulkSync writes far more this way. |
+| Architectural mismatch | LOW | Adopts the established direct-write-bypass-sendCh pattern; removes the broken deferred-retry idea. |
 
 ## Test plan
 
-New `pkg/cluster` unit tests, run with `go test -race ./pkg/cluster/`:
+New `pkg/cluster` unit tests, `go test -race ./pkg/cluster/`:
 
-1. **TestDeleteJournalFlushRequeuesOnFullQueue** (the non-tautological
-   regression test): construct a `SessionSync` with a TINY `sendCh` (e.g.
-   replace with a cap-2 channel) and Connected=true. Journal N>2 deletes.
-   Pre-fill / saturate `sendCh` so only the first 2 enqueue succeed. Call
-   `flushDeleteJournal`. Assert: `DeletesSent == 2`, and the journal now
-   contains the remaining N-2 messages (re-journaled), NOT empty. Pre-fix
-   this FAILS (journal is empty — deletes dropped). Confirm it fails
-   against base by reverting the fix locally.
-2. **TestDeleteJournalFlushRequeueRetriedOnNextFlush**: after #1, drain
-   `sendCh` and call `flushDeleteJournal` again; assert the remaining
-   deletes now flush (DeletesSent reaches N) and the journal empties —
-   proving the re-journaled deletes are actually retried, not just parked.
-3. **TestDeleteJournalFlushRequeueRespectsCapAndCounts**: set a small
-   `deleteJournalCap`; saturate `sendCh`; journal more than cap; flush;
-   assert journal len == cap and `DeletesDropped` increments for the
-   genuinely-evicted ones (surfaced bounded loss). This proves the
-   fallback path in the issue.
-4. Existing tests unchanged and still green: `TestDeleteJournalBasic`,
-   `TestDeleteJournalOverflow`, `TestDeleteJournalFlushNoEntries`,
-   `TestDeleteJournalReconnectConvergence`, `TestSessionQueueDoesNotJournal`.
+1. **TestDeleteJournalFlushDeliversAllOnFullQueue** (non-tautological
+   regression): saturate `sendCh` (fill to cap so any `queueMessage` would
+   fail), wire an active `net.Pipe` conn, journal N deletes, run
+   `flushDeleteJournal` with a reader draining the conn. Assert: ALL N
+   frames are read off the wire (in order) and `DeletesSent == N`, and the
+   journal is empty. Against the PRE-FIX code (which used `queueMessage`
+   into the full `sendCh`) this delivers 0 and drops N — so the test fails
+   pre-fix. (Verify by reverting the fix locally.)
+2. **TestDeleteJournalFlushRejournalsTailOnDisconnect**: journal N
+   deletes, set an active conn, then close the peer side so `writeFull`
+   errors after some prefix; assert the un-sent tail is re-journaled (back
+   in `s.deleteJournal`) and `handleDisconnect` ran (Connected false), so a
+   later reconnect flush re-delivers them.
+3. **TestDeleteJournalFlushNoConnRejournals**: journal N deletes with NO
+   active conn; flush; assert all N are re-journaled (journal len == N, or
+   == cap with `DeletesDropped` for the overflow) and `DeletesSent == 0`.
+4. Existing tests still green — note `TestDeleteJournalReconnectConvergence`
+   and `TestDeleteJournalBasic` may need the active-conn / reader wiring
+   updated since flush now writes directly instead of to `sendCh`; the
+   ASSERTED behavior (deletes delivered, journal emptied, DeletesSent==N)
+   is preserved.
 
-Gates:
-- `go test -race ./pkg/cluster/` green.
-- `go build ./...` clean.
-- Full `go test ./...` for the cluster package + dependents.
+Gates: `go test -race ./pkg/cluster/`, `go build ./...`, full
+`go test ./...` (cluster + dependents).
 
-No loss-cluster iperf smoke: this is control-plane HA delete-journal
-replay logic, not a dataplane forwarding change. The standing
-"smoke v4+v6, per-class CoS" matrix in the triple-review skill is for
-dataplane/CoS refactors and does not apply.
+No loss-cluster iperf smoke: control-plane HA delete-journal replay, not a
+dataplane forwarding change.
 
 ## Docs
 
 `docs/session-sync-architecture.md` §"Delete Journal" (line 244) and
-§"Delete Journal Overflow" (line 425) describe the journal + replay. The
-Delete Journal section will be updated to note that flush re-journals
-un-sent deletes on a full send queue (retry on next reconnect) rather than
-dropping them, and that genuinely-unavoidable loss at the journal cap is
-counted in `DeletesDropped`. No other doc references the flush path.
+§"Delete Journal Overflow" (line 425): note that flush now delivers
+journaled deletes directly on the reconnect (in order, before normal sync
+resumes) and re-journals only on a genuine disconnect, so a full send
+queue no longer drops them.
 
 ## Out of scope (explicitly)
 
-- Changing `sendCh` capacity (4096) — orthogonal sizing question.
-- Blocking/backpressure redesign of `queueMessage` — rejected above
-  (would stall the accept goroutine).
-- A dedicated `DeletesRequeued` Prometheus counter — the Warn log surfaces
-  the requeue, and `DeletesDropped` surfaces genuine loss. Could be a
-  trivial follow-up if operators want a metric for "requeue happened" vs
-  "drop happened"; not needed for correctness. Open question Q4.
-- #2120 (standby session-expiry / `syncSweep`) — a DIFFERENT function in
-  the same file, owned by a sibling research agent. Untouched here.
+- `sendCh` capacity (4096) — orthogonal.
+- Generation/session-identity guard on deletes (Codex's deeper
+  alternative) — larger change touching the wire protocol + receive path;
+  not needed once deletes are delivered in-order on the current
+  connection. Could be a separate hardening issue.
+- A distinct `DeletesRequeued` metric — re-journal now happens only on
+  genuine disconnect (already the normal journaled path); the Warn log +
+  `DeletesDropped` cover the observable cases.
+- #2120 (standby session-expiry / `syncSweep`) — different function, owned
+  by a sibling research agent. Untouched.
 
 ## Open questions for adversarial review
 
-Q1. Is re-journal (vs block-until-drained vs stop-and-restore-tail) the
-    right choice given `flushDeleteJournal` runs on the connection-accept
-    goroutine before `OnPeerConnected`/bulk sync? Argue for blocking if you
-    think the deferred-retry window is unacceptable.
-Q2. Re-journaled deletes are only retried on the NEXT first-post-disconnect
-    flush. If the link stays up, they sit in the journal until the next
-    disconnect/reconnect. Is that acceptable, or must they be drained on
-    the current connection (e.g. by a deferred re-flush once `sendCh`
-    drains)? Note: the session re-sweep (`syncBackfillNeeded`) re-sends
-    SESSIONS but not deletes, so a still-open standby session for a deleted
-    flow is the failure being fixed — does the deferred-retry fully close
-    it, or only on next reconnect?
-Q3. Concurrency: a `QueueDeleteV4` racing the flush both call
-    `journalDelete`. Any ordering or correctness hazard beyond "interleaved
-    but all valid"? Any case where a re-journaled delete could be evicted by
-    a concurrent journal append before it is ever retried (silent loss under
-    the cap path)? Is the `DeletesDropped` accounting still meaningful?
-Q4. Counter design: is reusing `DeletesDropped` (only on genuine cap
-    eviction) + a Warn log sufficient, or does the issue's "surface via a
-    counter" intent require a distinct `DeletesRequeued` metric?
-Q5. Is the `deleteJournalLen()` re-lock for the log line worth it, or should
-    the log omit journal_len_after to avoid re-taking `deleteJournalMu`?
-Q6. Is the FIFO/ordering reasoning (failed messages are a suffix; deletes
-    idempotent by key) sound? Any scenario where late delete arrival is
-    incorrect (e.g. key reuse — a NEW session installed with the same key
-    before the stale delete arrives, and the delete then removes the new
-    session)? How does the existing journal already handle that, and does
-    re-journal change the exposure?
+Q1. Is direct-write-under-`writeMu` on the accept goroutine the right
+    drain mechanism, given `BulkSync` already does exactly this on the same
+    sequence? Any reason the delete flush must NOT block on TCP
+    backpressure the way bulk does?
+Q2. `writeFull` uses `syncWriteDeadline`. Is that deadline an acceptable
+    upper bound on how long `flushDeleteJournal` can hold up
+    `OnPeerConnected`/bulk on a slow peer? (BulkSync accepts the same.)
+Q3. Concurrency: while flush direct-writes under `writeMu`, `sendLoop` may
+    also be draining `sendCh` and writing under `writeMu`. Both serialize on
+    `writeMu` so frames don't interleave, but a normal session/delete
+    enqueued to `sendCh` just before reconnect could be written BETWEEN two
+    journaled deletes. Deletes are idempotent by key; is any
+    delete-vs-session interleave hazardous here, or is "all journaled
+    deletes delivered before OnPeerConnected/bulk" the only contract that
+    matters?
+Q4. On write error mid-flush we re-journal `journal[i:]` and call
+    `handleDisconnect`. Is re-journaling the CURRENT failed message (index
+    i) correct, or could it have been partially written (torn frame) — does
+    `writeFull` guarantee all-or-nothing per frame? (It loops on short
+    writes but a mid-frame error leaves a partial frame on the wire; the
+    peer then resyncs on disconnect — confirm that's the existing behavior
+    for BulkSync too.)
+Q5. Test #1 non-tautological: does saturating `sendCh` + asserting frames
+    arrive on the wire actually fail against the pre-fix `queueMessage`
+    path? (Pre-fix: full sendCh → queueMessage false → silent drop → 0
+    frames on the wire.)
+Q6. Should `rejournalAll` preserve order strictly (it appends in slice
+    order to an empty/!empty journal)? Any case where re-journal order
+    matters given the next flush re-delivers in order anyway?

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -250,8 +250,12 @@ The journal is replayed when the next first-post-disconnect connection comes up,
 before `OnPeerConnected` and before the fresh bulk starts.
 
 Replay goes through the ordered send channel (`queueMessage`), so a delete that
-is delivered stays ordered behind any session frames already queued for the
-peer. If the send queue is full (or the peer disconnects) mid-replay,
+is delivered stays ordered behind any session frames already queued in `sendCh`
+for the peer. (Note: cold-start bulk sync direct-writes session frames under
+`writeMu` rather than via `sendCh`, so flush-vs-bulk wire order is not strictly
+guaranteed; flush still completes — enqueueing all deletes — before bulk
+starts, and a live session landing after a stale delete is the safe direction.)
+If the send queue is full (or the peer disconnects) mid-replay,
 `flushDeleteJournal` does **not** drop the un-sent deletes: it re-journals the
 un-sent tail at the front of the ring (FIFO-preserving, evicting the oldest on
 overflow) so they replay on the next reconnect flush — the same

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -249,6 +249,25 @@ is disconnected, deletes are journaled in a bounded ring.
 The journal is replayed when the next first-post-disconnect connection comes up,
 before `OnPeerConnected` and before the fresh bulk starts.
 
+Replay goes through the ordered send channel (`queueMessage`), so a delete that
+is delivered stays ordered behind any session frames already queued for the
+peer. If the send queue is full (or the peer disconnects) mid-replay,
+`flushDeleteJournal` does **not** drop the un-sent deletes: it re-journals the
+un-sent tail at the front of the ring (FIFO-preserving, evicting the oldest on
+overflow) so they replay on the next reconnect flush — the same
+journal-on-failure contract `QueueDeleteV4`/`V6` use for runtime deletes (#2121
+fixed an earlier silent drop here). Genuine loss only occurs at the journal cap
+and is counted in `DeletesDropped`.
+
+Because deletes are key-only on the peer (no generation/session-identity guard
+yet), a re-journaled delete that replays after a same-key replacement session
+has been synced can remove the live replacement. This is a pre-existing
+property of the journal (it also applies to `QueueDeleteV4`'s full-queue and
+disconnect journaling); #2121 widens it to the flush path as a deliberate
+trade-off (bounded retention instead of unrecoverable silent loss). Fully
+closing it requires a wire-protocol generation guard on deletes — a tracked
+follow-up.
+
 ## Userspace Session Integration
 
 ### Event Stream (Primary Path)

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -554,13 +554,74 @@ func (s *SessionSync) flushDeleteJournal() {
 		return
 	}
 	var flushed int
-	// Replay journaled delete messages before normal sync resumes.
-	for _, msg := range journal {
+	// Replay journaled deletes through the ordered send stream. queueMessage
+	// is non-blocking and increments DeletesSent on success; on a full sendCh
+	// (or a peer disconnect) it returns false. Mirror the QueueDeleteV4
+	// contract: re-journal (retain) the un-sent tail instead of dropping it,
+	// so it replays on the next reconnect flush. Previously a full sendCh
+	// here silently dropped the un-sent deletes (the journal was already
+	// nil'd), leaving stale sessions on the peer (#2121).
+	for i, msg := range journal {
 		if s.queueMessage(msg, &s.stats.DeletesSent, "journal_flush") {
 			flushed++
+			continue
 		}
+		// queueMessage returned false — the send queue is full or the peer
+		// disconnected (queueMessage checks Connected first). Either way the
+		// remaining messages would also fail, so re-journal this message and
+		// the rest (FIFO-prepended ahead of any deletes concurrently journaled
+		// during the flush) and stop. Stopping keeps the un-sent suffix
+		// contiguous and ordered; they replay on the next reconnect flush.
+		s.rejournalTail(journal[i:])
+		slog.Warn("cluster sync: delete journal flush could not enqueue (queue full or disconnected), re-journaled un-sent tail for next reconnect",
+			"total", len(journal), "flushed", flushed, "rejournaled", len(journal)-i,
+			"connected", s.stats.Connected.Load(),
+			"queue_len", len(s.sendCh), "queue_cap", cap(s.sendCh))
+		return
 	}
-	slog.Info("cluster sync: flushed delete journal", "total", len(journal), "sent", flushed)
+	slog.Info("cluster sync: flushed delete journal", "total", len(journal), "flushed", flushed)
+}
+
+// rejournalTail re-inserts the un-sent delete tail at the FRONT of the
+// delete journal so it replays before any deletes that were concurrently
+// journaled (by QueueDeleteV4/V6) while the flush ran, preserving FIFO
+// order. On overflow it drops the OLDEST entries from the front of the
+// merged list — never the newer concurrently-journaled deletes — and
+// counts the dropped entries in DeletesDropped. Acquires deleteJournalMu
+// exactly once. Used by flushDeleteJournal when the send stream is full or
+// disconnected; the retained deletes replay on the next reconnect flush.
+func (s *SessionSync) rejournalTail(tail [][]byte) {
+	if len(tail) == 0 {
+		return
+	}
+	s.deleteJournalMu.Lock()
+	defer s.deleteJournalMu.Unlock()
+	capN := s.deleteJournalCap
+	if capN <= 0 {
+		capN = deleteJournalDefaultCap
+	}
+	total := len(tail) + len(s.deleteJournal)
+	if total <= capN {
+		merged := make([][]byte, 0, total)
+		merged = append(merged, tail...)
+		merged = append(merged, s.deleteJournal...)
+		s.deleteJournal = merged
+		return
+	}
+	dropped := total - capN
+	s.stats.DeletesDropped.Add(uint64(dropped))
+	merged := make([][]byte, 0, capN)
+	if dropped < len(tail) {
+		// Drop the oldest prefix of the tail; keep the rest plus all of the
+		// newer concurrently-journaled deletes.
+		merged = append(merged, tail[dropped:]...)
+		merged = append(merged, s.deleteJournal...)
+	} else {
+		// The entire tail is evicted; also drop the oldest prefix of the
+		// concurrently-journaled deletes to fit the cap.
+		merged = append(merged, s.deleteJournal[dropped-len(tail):]...)
+	}
+	s.deleteJournal = merged
 }
 
 // QueueConfig sends the full config text to the peer for configuration synchronization.

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -573,8 +573,13 @@ func (s *SessionSync) flushDeleteJournal() {
 		// during the flush) and stop. Stopping keeps the un-sent suffix
 		// contiguous and ordered; they replay on the next reconnect flush.
 		s.rejournalTail(journal[i:])
+		// "unsent_tail" is the count handed to rejournalTail; some of those
+		// may still be evicted there if the journal is over cap — that loss is
+		// counted in DeletesDropped (logged here as the running total), so
+		// this field is the tail size, not a guarantee that all were retained.
 		slog.Warn("cluster sync: delete journal flush could not enqueue (queue full or disconnected), re-journaled un-sent tail for next reconnect",
-			"total", len(journal), "flushed", flushed, "rejournaled", len(journal)-i,
+			"total", len(journal), "flushed", flushed, "unsent_tail", len(journal)-i,
+			"deletes_dropped_total", s.stats.DeletesDropped.Load(),
 			"connected", s.stats.Connected.Load(),
 			"queue_len", len(s.sendCh), "queue_cap", cap(s.sendCh))
 		return
@@ -586,10 +591,13 @@ func (s *SessionSync) flushDeleteJournal() {
 // delete journal so it replays before any deletes that were concurrently
 // journaled (by QueueDeleteV4/V6) while the flush ran, preserving FIFO
 // order. On overflow it drops the OLDEST entries from the front of the
-// merged list — never the newer concurrently-journaled deletes — and
-// counts the dropped entries in DeletesDropped. Acquires deleteJournalMu
-// exactly once. Used by flushDeleteJournal when the send stream is full or
-// disconnected; the retained deletes replay on the next reconnect flush.
+// merged list (the tail is older than the concurrently-journaled deletes,
+// so the tail is evicted first; only if the entire tail is dropped does it
+// also evict the oldest of the concurrent deletes, e.g. when the journal
+// was already at cap), counting the dropped entries in DeletesDropped.
+// Acquires deleteJournalMu exactly once. Used by flushDeleteJournal when
+// the send stream is full or disconnected; the retained deletes replay on
+// the next reconnect flush.
 func (s *SessionSync) rejournalTail(tail [][]byte) {
 	if len(tail) == 0 {
 		return

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -1406,8 +1406,20 @@ func TestBulkEpochMismatchIgnored(t *testing.T) {
 	ss.IsPrimaryForRGFn = func(rgID int) bool { return false }
 	ss.SetZoneRGMap(map[uint16]int{2: 2})
 
+	// OnBulkSyncReceived fires on a goroutine spawned by handleMessage, so
+	// guard the flag against the test's reads (data race under -race).
+	var calledMu sync.Mutex
 	called := false
-	ss.OnBulkSyncReceived = func() { called = true }
+	wasCalled := func() bool {
+		calledMu.Lock()
+		defer calledMu.Unlock()
+		return called
+	}
+	ss.OnBulkSyncReceived = func() {
+		calledMu.Lock()
+		called = true
+		calledMu.Unlock()
+	}
 
 	// BulkStart with epoch 5
 	var startBuf [8]byte
@@ -1421,7 +1433,7 @@ func TestBulkEpochMismatchIgnored(t *testing.T) {
 
 	// Callback should NOT have been invoked
 	time.Sleep(50 * time.Millisecond)
-	if called {
+	if wasCalled() {
 		t.Fatal("OnBulkSyncReceived should not be called on epoch mismatch")
 	}
 
@@ -1436,7 +1448,7 @@ func TestBulkEpochMismatchIgnored(t *testing.T) {
 	ss.handleMessage(nil, syncMsgBulkEnd, matchBuf[:])
 
 	time.Sleep(50 * time.Millisecond)
-	if !called {
+	if !wasCalled() {
 		t.Fatal("OnBulkSyncReceived should be called on matching epoch")
 	}
 }
@@ -2265,6 +2277,205 @@ func TestSessionQueueDoesNotJournal(t *testing.T) {
 		t.Fatal("session updates should not be journaled")
 	}
 	ss.deleteJournalMu.Unlock()
+}
+
+// deleteKeyN builds a distinct v4 delete key for index n.
+func deleteKeyN(n int) dataplane.SessionKey {
+	return dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 1, byte(n)},
+		Protocol: 6,
+		SrcPort:  uint16(1000 + n),
+		DstPort:  80,
+	}
+}
+
+// TestDeleteJournalFlushRetainsTailOnFullQueue is the #2121 regression: a
+// flush that hits a full send queue must RE-JOURNAL the un-sent deletes
+// instead of silently dropping them. Pre-fix the journal was nil'd and the
+// deletes dropped (len(deleteJournal)==0 here), so this test fails pre-fix.
+func TestDeleteJournalFlushRetainsTailOnFullQueue(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	// Reassign a tiny send channel and saturate it so queueMessage's
+	// non-blocking send fails immediately (NewSessionSync hardcodes cap 4096).
+	ss.sendCh = make(chan []byte, 2)
+	ss.sendCh <- []byte{0}
+	ss.sendCh <- []byte{0}
+	ss.stats.Connected.Store(true)
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		ss.deleteJournalMu.Lock()
+		ss.deleteJournal = append(ss.deleteJournal, encodeDeleteV4(deleteKeyN(i)))
+		ss.deleteJournalMu.Unlock()
+	}
+
+	ss.flushDeleteJournal()
+
+	if got := ss.stats.DeletesSent.Load(); got != 0 {
+		t.Fatalf("expected 0 deletes sent on a full queue, got %d", got)
+	}
+	if got := ss.stats.DeletesDropped.Load(); got != 0 {
+		t.Fatalf("expected 0 deletes dropped (n <= cap), got %d", got)
+	}
+	ss.deleteJournalMu.Lock()
+	defer ss.deleteJournalMu.Unlock()
+	if len(ss.deleteJournal) != n {
+		t.Fatalf("expected all %d un-sent deletes re-journaled, got %d", n, len(ss.deleteJournal))
+	}
+	// FIFO order preserved.
+	for i := 0; i < n; i++ {
+		want := encodeDeleteV4(deleteKeyN(i))
+		if string(ss.deleteJournal[i]) != string(want) {
+			t.Fatalf("re-journaled delete %d out of order", i)
+		}
+	}
+}
+
+// TestDeleteJournalFlushPartialThenRetains: when only some deletes fit in
+// the send queue, the rest are re-journaled at the FRONT (FIFO).
+func TestDeleteJournalFlushPartialThenRetains(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	ss.sendCh = make(chan []byte, 3) // 3 slots free, all empty
+	ss.stats.Connected.Store(true)
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		ss.deleteJournalMu.Lock()
+		ss.deleteJournal = append(ss.deleteJournal, encodeDeleteV4(deleteKeyN(i)))
+		ss.deleteJournalMu.Unlock()
+	}
+
+	ss.flushDeleteJournal()
+
+	if got := ss.stats.DeletesSent.Load(); got != 3 {
+		t.Fatalf("expected 3 deletes enqueued, got %d", got)
+	}
+	ss.deleteJournalMu.Lock()
+	defer ss.deleteJournalMu.Unlock()
+	if len(ss.deleteJournal) != 2 {
+		t.Fatalf("expected 2 un-sent deletes re-journaled, got %d", len(ss.deleteJournal))
+	}
+	// The two re-journaled deletes are the last two (indices 3,4) in order.
+	for j, i := range []int{3, 4} {
+		want := encodeDeleteV4(deleteKeyN(i))
+		if string(ss.deleteJournal[j]) != string(want) {
+			t.Fatalf("re-journaled delete %d (orig idx %d) out of order", j, i)
+		}
+	}
+}
+
+// TestRejournalTailFIFOPrependAndOverflow unit-tests rejournalTail across
+// all three branches: no overflow, overflow within the tail, and tail
+// fully dropped (overflow into the concurrently-journaled deletes).
+func TestRejournalTailFIFOPrependAndOverflow(t *testing.T) {
+	mk := func(n int) []byte { return encodeDeleteV4(deleteKeyN(n)) }
+	eq := func(t *testing.T, got [][]byte, wantIdx []int) {
+		t.Helper()
+		if len(got) != len(wantIdx) {
+			t.Fatalf("len = %d, want %d", len(got), len(wantIdx))
+		}
+		for i, idx := range wantIdx {
+			if string(got[i]) != string(mk(idx)) {
+				t.Fatalf("entry %d mismatch (want idx %d)", i, idx)
+			}
+		}
+	}
+
+	// Branch 1: no overflow. journal=[1,2] (newer), tail=[3,4,5] (older).
+	// Result: tail prepended -> [3,4,5,1,2].
+	t.Run("no_overflow", func(t *testing.T) {
+		ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+		ss.deleteJournalCap = 10
+		ss.deleteJournal = [][]byte{mk(1), mk(2)}
+		ss.rejournalTail([][]byte{mk(3), mk(4), mk(5)})
+		eq(t, ss.deleteJournal, []int{3, 4, 5, 1, 2})
+		if d := ss.stats.DeletesDropped.Load(); d != 0 {
+			t.Fatalf("dropped = %d, want 0", d)
+		}
+	})
+
+	// Branch 2: overflow within tail. cap=4, journal=[1,2], tail=[3,4,5].
+	// total=5, dropped=1 (< len(tail)=3) -> drop oldest tail entry (3),
+	// keep [4,5] + [1,2] = [4,5,1,2].
+	t.Run("overflow_within_tail", func(t *testing.T) {
+		ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+		ss.deleteJournalCap = 4
+		ss.deleteJournal = [][]byte{mk(1), mk(2)}
+		ss.rejournalTail([][]byte{mk(3), mk(4), mk(5)})
+		eq(t, ss.deleteJournal, []int{4, 5, 1, 2})
+		if d := ss.stats.DeletesDropped.Load(); d != 1 {
+			t.Fatalf("dropped = %d, want 1", d)
+		}
+	})
+
+	// Branch 3: tail fully dropped. cap=2, journal=[1,2,3], tail=[4,5,6].
+	// total=6, dropped=4 (>= len(tail)=3) -> drop all tail + oldest 1 of
+	// journal -> keep journal[1:] = [2,3].
+	t.Run("tail_fully_dropped", func(t *testing.T) {
+		ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+		ss.deleteJournalCap = 2
+		ss.deleteJournal = [][]byte{mk(1), mk(2), mk(3)}
+		ss.rejournalTail([][]byte{mk(4), mk(5), mk(6)})
+		eq(t, ss.deleteJournal, []int{2, 3})
+		if d := ss.stats.DeletesDropped.Load(); d != 4 {
+			t.Fatalf("dropped = %d, want 4", d)
+		}
+	})
+}
+
+// TestDeleteJournalFlushAllFit: with room in the send queue, every
+// journaled delete is enqueued and the journal empties.
+func TestDeleteJournalFlushAllFit(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	ss.sendCh = make(chan []byte, 16)
+	ss.stats.Connected.Store(true)
+
+	const n = 4
+	for i := 0; i < n; i++ {
+		ss.deleteJournalMu.Lock()
+		ss.deleteJournal = append(ss.deleteJournal, encodeDeleteV4(deleteKeyN(i)))
+		ss.deleteJournalMu.Unlock()
+	}
+	ss.flushDeleteJournal()
+
+	if got := ss.stats.DeletesSent.Load(); got != n {
+		t.Fatalf("expected %d deletes sent, got %d", n, got)
+	}
+	ss.deleteJournalMu.Lock()
+	defer ss.deleteJournalMu.Unlock()
+	if len(ss.deleteJournal) != 0 {
+		t.Fatalf("journal should be empty after a fully-flushed journal, got %d", len(ss.deleteJournal))
+	}
+}
+
+// TestDeleteJournalFlushOrderingWithQueuedSession proves the flush keeps a
+// delete ordered BEHIND a session frame already queued in sendCh (the
+// single ordered path), so a same-key delete cannot jump ahead of a
+// queued session on the wire.
+func TestDeleteJournalFlushOrderingWithQueuedSession(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	ss.sendCh = make(chan []byte, 16)
+	ss.stats.Connected.Store(true)
+
+	key := deleteKeyN(7)
+	val := dataplane.SessionValue{State: 1}
+	// Session frame queued first.
+	ss.sendCh <- encodeSessionV4(key, val)
+	// Then flush a same-key delete.
+	ss.deleteJournalMu.Lock()
+	ss.deleteJournal = append(ss.deleteJournal, encodeDeleteV4(key))
+	ss.deleteJournalMu.Unlock()
+	ss.flushDeleteJournal()
+
+	// Drain in order: session must come out before the delete.
+	first := <-ss.sendCh
+	second := <-ss.sendCh
+	if first[4] != syncMsgSessionV4 {
+		t.Fatalf("expected session frame first, got type %d", first[4])
+	}
+	if second[4] != syncMsgDeleteV4 {
+		t.Fatalf("expected delete frame second, got type %d", second[4])
+	}
 }
 
 func TestWaitForPeerBarrierRequiresConnection(t *testing.T) {


### PR DESCRIPTION
## Summary

`flushDeleteJournal` (pkg/cluster/sync_conn.go) drained the bounded delete
journal under lock (setting it nil) then replayed each delete via the
non-blocking `queueMessage`. On a full `sendCh` (cap 4096) the un-sent deletes
were **silently dropped** — the journal was already nil'd — leaving stale
sessions on the HA peer until they aged out, defeating the journal's purpose
(#2121, LOW severity).

This makes the flush path mirror the already-shipped `QueueDeleteV4`/`V6`
journal-on-failure contract: when `queueMessage` returns false (full queue or
peer disconnect), re-journal the un-sent tail via the new `rejournalTail` and
stop. `rejournalTail` FIFO-prepends the tail ahead of any deletes concurrently
journaled during the flush and, on overflow, drops the oldest from the merged
front (never the newer concurrent deletes), counting dropped entries in
`DeletesDropped`. Non-blocking throughout — no timeout, no force-disconnect; the
un-sent deletes replay on the next reconnect flush, exactly as `QueueDeleteV4`'s
full-queue deletes already do.

### Honest trade-off
This converts an unrecoverable silent loss of a delete into bounded retention.
It deliberately **widens** the pre-existing key-only-delete-kills-replacement
exposure (a re-journaled delete replayed after a same-key replacement was synced
can remove the replacement) from the `QueueDeleteV4` paths to the flush path.
Fully closing that class requires a wire-protocol generation guard on deletes —
**a follow-up issue will be filed.** Accepted across five adversarial plan-review
rounds (v1/v2 plan-killed for ordering; v3/v4 needs-major for liveness/ordering;
v5.1 plan-ready).

## Plan + adversarial review

Plan doc: `docs/pr/2121-flushdeletejournal-requeue/plan.md` (v1 → v5.1)

- Claude-SMR (v5): PLAN-READY
- Antigravity (v5): PLAN-READY
- Codex (v5): NEEDS-MAJOR on the "never worse than drop" wording only (same
  facts) → re-scoped honestly in v5.1

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./pkg/cluster/` green
- [x] New tests (`pkg/cluster/sync_test.go`):
  - [x] `TestDeleteJournalFlushRetainsTailOnFullQueue` — non-tautological
        regression (verified to **fail** against the pre-fix silent drop)
  - [x] `TestDeleteJournalFlushPartialThenRetains`
  - [x] `TestRejournalTailFIFOPrependAndOverflow` — all three merge branches
  - [x] `TestDeleteJournalFlushAllFit`
  - [x] `TestDeleteJournalFlushOrderingWithQueuedSession`
  - [x] new tests 5/5 flake-free under -race
- [x] Fixed a **pre-existing** data race in `TestBulkEpochMismatchIgnored`
      (test-local `called` bool on the callback goroutine) surfaced by -race
- [x] full `go test ./...` green
- Control-plane HA delete-journal replay logic — no loss-cluster dataplane
  smoke needed.

## Docs

- `docs/session-sync-architecture.md` — Delete Journal replay/retention + the
  residual key-only-delete exposure note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)