### PR TITLE
#2154: parseLeaseCSV must skip malformed lines, not abort whole file

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -7567,3 +7567,18 @@ top.
   against FRR source; Codex code review + AGY adversarial both
   MERGE-READY; Copilot reviewed 3/3 files, no comments. Control-plane
   display only — no dataplane smoke. PR #2135 MERGEABLE.
+
+- **Timestamp**: 2026-06-20
+  **Action**: #2154 — parseLeaseCSV reads Kea memfile record-by-record
+  (`csv.Reader.Read` loop) instead of `ReadAll`, so one torn/concurrent
+  Kea append no longer blanks the whole `show dhcp server leases`. Header
+  is the first successful record; a malformed row is logged at debug and
+  SKIPPED (csv.Read recovers after a *csv.ParseError; FieldsPerRecord=-1
+  makes a short line a non-event). #2085's per-record dedup/expire/state
+  loop body is preserved verbatim — robust READ layered ON TOP of #2085's
+  lenient SEMANTICS. New non-tautological TestParseLeaseCSV_SkipsMalformedLine
+  (fails against pre-fix ReadAll with "bare \" in non-quoted-field").
+  Full pkg/dhcpserver suite green, 5/5 flake. Control-plane display path —
+  no dataplane smoke.
+  **File(s)**: pkg/dhcpserver/dhcpserver.go, pkg/dhcpserver/dhcpserver_test.go,
+  pkg/dhcpserver/README.md, docs/pr/2154-parseleasecsv/plan.md

--- a/docs/pr/2154-parseleasecsv/plan.md
+++ b/docs/pr/2154-parseleasecsv/plan.md
@@ -1,0 +1,199 @@
+# #2154 — parseLeaseCSV must skip malformed lines, not abort whole file
+
+**Status:** IMPLEMENTED — pending adversarial code review
+
+## Issue framing
+
+`pkg/dhcpserver/dhcpserver.go::parseLeaseCSV` backs `show dhcp server
+leases` and the REST/gRPC lease endpoints. It reads Kea's append-only
+memfile with a single `csv.Reader.ReadAll()`. Kea appends a new row on
+every renewal / re-allocation / release / decline / expiry-reclaim,
+concurrently with xpf reading. If xpf reads while Kea is mid-append, the
+file ends on a partial/torn line. `ReadAll()` aborts on the FIRST
+malformed record and returns `(nil, err)`, so a single torn last line
+fails the ENTIRE `GetLeases4`/`GetLeases6` call and `show ... leases`
+shows nothing even though most rows are valid — exactly when the network
+is busiest.
+
+#2085 already made the *semantics* lenient (per-record dedup/expire/state
+filtering rather than blanking on one odd row) but left the *I/O* layer
+all-or-nothing. This change makes the read robust ON TOP of #2085's
+dedup/expire logic without regressing it.
+
+## What's already shipped (#2085) that this must compose with
+
+Inside the per-record loop (current lines 446-488):
+- **Dedup**: one row per address, newest (last chronological) wins.
+- **Tombstone**: a non-active row records an empty `Lease{}` for the
+  address; a later active append can RECLAIM it.
+- **State filter**: `state != 0` (declined/expired-reclaimed) tombstones.
+- **Expire filter**: `expire <= now` tombstones.
+- **Leniency**: absent/unparseable state/expire ⇒ treat row as active.
+- **Stable order**: first-appearance order preserved via `order`/`seen`.
+- Header column-index map built from the FIRST record.
+
+This change touches ONLY the I/O layer (how records are obtained). The
+dedup/expire/state/tombstone/order/leniency loop body is copied verbatim.
+
+## Empirical csv.Reader.Read() semantics (verified, not assumed)
+
+A standalone probe (5 torn-line shapes) against the project Go toolchain
+confirmed:
+
+1. After a `*csv.ParseError`, the next `Read()` recovers — it returns the
+   next valid record or `io.EOF`. **It does NOT loop forever.** So a
+   "log + skip + continue" loop terminates naturally.
+2. A torn quoted field that spans to EOF (append in progress on a
+   `"`-quoted column) consumes the remainder of the file as field content
+   — but this is identical to `ReadAll()`'s behavior and the realistic
+   Kea case is a torn LAST line, which after the error yields `io.EOF`.
+3. Short lines (fewer fields) with `FieldsPerRecord = -1` produce NO
+   error at all — already tolerated; the issue's "field-count mismatch"
+   concern is a non-event with `-1`.
+4. `io.EOF` terminates cleanly and MUST break the loop.
+5. `csv.ErrFieldCount` cannot fire while `FieldsPerRecord = -1`, but the
+   skip branch handles it generically anyway.
+
+## Concrete design
+
+Replace the `ReadAll()` block (lines 412-421) and the `records[0]`/
+`records[1:]` indexing with a single streaming loop:
+
+```go
+r := csv.NewReader(f)
+r.FieldsPerRecord = -1 // memfile rows vary across Kea versions / torn appends
+r.Comment = '#'
+r.ReuseRecord = false  // we keep header `cols` indices across iterations;
+                       // ReuseRecord aliasing would not corrupt cols (we
+                       // copy nothing by reference), but leave default false
+                       // to avoid any shared-slice surprise.
+
+var (
+    cols   map[string]int // header column indices; nil until header read
+    latest = make(map[string]Lease)
+    order  = make([]string, 0)
+    seen   = make(map[string]struct{})
+)
+nowUnix := now.Unix()
+field := func(fields []string, name string) string {
+    if idx, ok := cols[name]; ok && idx >= 0 && idx < len(fields) {
+        return fields[idx]
+    }
+    return ""
+}
+
+for {
+    fields, err := r.Read()
+    if errors.Is(err, io.EOF) {
+        break
+    }
+    if err != nil {
+        // Torn/concurrent Kea append or exotic row: skip this record,
+        // keep the rest. #2154 — one bad line must not blank the show.
+        slog.Debug("dhcpserver: skipping malformed lease row",
+            "path", path, "err", err)
+        continue
+    }
+    if cols == nil { // first successful record is the header
+        cols = make(map[string]int, len(fields))
+        for i, h := range fields {
+            cols[h] = i
+        }
+        continue
+    }
+    // ---- #2085 loop body, verbatim ----
+    addr := field(fields, "address")
+    ...dedup / state / expire / tombstone / order ...
+}
+
+if cols == nil { // no header at all (empty/comment-only file)
+    return nil, nil
+}
+// ---- #2085 emit phase, verbatim ----
+```
+
+### Behavioral equivalences to preserve
+
+| Old (`ReadAll`)                       | New (`Read` loop)                         |
+|---------------------------------------|-------------------------------------------|
+| `len(records) < 2` ⇒ `nil,nil`        | `cols==nil` (no header) ⇒ `nil,nil`; header-only ⇒ empty `order` ⇒ `nil,nil` |
+| header = `records[0]`                 | header = first successful `Read()` record |
+| data = `records[1:]`                  | every successful `Read()` after header    |
+| any parse error ⇒ `(nil, err)`        | per-record parse error ⇒ skip+debug, continue |
+| `os.IsNotExist` ⇒ `nil,nil`           | unchanged (open path untouched)           |
+| other `os.Open` error ⇒ `err`         | unchanged                                 |
+
+The function still returns a non-nil `error` ONLY for an `os.Open`
+failure that is not `IsNotExist` — the same contract as before, minus the
+now-removed `ReadAll` parse-error path (which was the bug).
+
+## Hidden invariants preserved
+
+- **Side-effect ordering**: state-filter precedes expire-filter precedes
+  emit — copied verbatim, unchanged.
+- **Tombstone/reclaim ordering**: chronological append order is preserved
+  because `Read()` yields records in file order, identical to `ReadAll`.
+- **Stable display order**: `order`/`seen` first-appearance logic
+  unchanged.
+- **Leniency**: absent/garbage state/expire still keeps the row.
+- **No new allocations on the hot path** — this is a slow display path
+  (1/`show`), allocation rules N/A, but the map/slice pre-sizing hint
+  `len(records)-1` is simply dropped (we no longer have the count up
+  front); maps grow as needed. Negligible.
+
+## Risk assessment
+
+| Class                          | Level | Rationale |
+|--------------------------------|-------|-----------|
+| Behavioral regression          | LOW   | Loop body byte-identical to #2085; only record acquisition changes. Equivalence table above. |
+| Lifetime / aliasing            | LOW   | `ReuseRecord=false` (default); `field()` reads strings by value into `Lease`. No retained slice aliases the reader buffer. |
+| Performance                    | NONE  | Slow path; loses one pre-size hint, gains nothing-loses-nothing. |
+| Architectural mismatch         | NONE  | Localized to one function; no new abstraction. |
+| Infinite loop on parse error   | NONE  | Empirically verified `Read()` recovers/EOFs after `ParseError`. |
+
+## Test plan
+
+`go test ./pkg/dhcpserver/` — all existing tests must pass unchanged
+(they prove #2085 dedup/expire/state/leniency is not regressed), PLUS a
+new non-tautological test:
+
+- **`TestParseLeaseCSV_SkipsMalformedLine`**: a fixture with valid rows
+  surrounding/followed by a torn line (short line, then a bad-quote line
+  at EOF) must return the VALID leases, not `(nil, err)`. Asserts the
+  count and that a specific valid address survives. This FAILS against
+  the pre-fix `ReadAll` code (which returns `(nil, err)` on the torn
+  quote), so it is non-tautological.
+- Also assert the torn line at the very END (the canonical Kea
+  mid-append case) still returns the leading valid rows.
+
+No HA/cluster smoke: control-plane display path only (per issue
+disposition: "Smoke-class: standard (display path), no HA smoke
+required").
+
+## Out of scope
+
+- Changing what columns are displayed or the dedup/expire policy (#2085
+  owns that).
+- The destructive DDNS reconciler `parseActiveLeases` (intentionally
+  hard-errors on a mangled header — different contract, not touched).
+- Atomic-snapshot reads of the memfile (Kea owns the file; we only read).
+
+## Open questions for adversarial review
+
+1. Is the header-detection change (`cols == nil` ⇒ first successful
+   record is header) equivalent to `records[0]` in ALL cases, including a
+   file whose FIRST line is malformed? (Then the header would be the
+   first *valid* line — is that a regression vs. ReadAll, which would
+   have errored out entirely? Arguably better: ReadAll returned nothing.)
+2. Could a torn quote on a NON-last line silently swallow trailing valid
+   rows (verified case `bad-mid-then-good`)? Is that acceptable given it
+   matches `ReadAll` behavior and the realistic case is a torn last line?
+3. Is `slog.Debug` the right level (vs. Warn)? The issue says debug;
+   per CLAUDE.md logging rules a 1/`show` event is not high-frequency,
+   but Debug matches the issue's explicit instruction and avoids log
+   spam if a persistently-corrupt file is polled.
+4. Does dropping the `len(records)-1` pre-size hint matter? (No — slow
+   path, maps grow.)
+5. Should the function ever return an error for a partially-corrupt file
+   (telemetry), or is silent-skip+nil-error correct for a display path?
+   The issue mandates skip+continue → silent success is correct.

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -86,7 +86,18 @@ What increment 1 ships (the fully unit-testable, lab-free slice):
   authorizes deleting owned DNS records), so it must hard-error on a
   mangled / duplicate-column / ragged header; the display parser is
   **non-destructive and lenient** — an exotic or short row must degrade
-  to showing what it can, never blank the whole `show`. Merging them
+  to showing what it can, never blank the whole `show`. That leniency is
+  enforced at BOTH layers: #2085 made the per-record SEMANTICS lenient
+  (dedup/expire/state), and #2154 made the READ itself robust — the
+  display parser reads the memfile record-by-record (`csv.Reader.Read`)
+  and logs+SKIPS a malformed row (torn/concurrent Kea append, e.g. an
+  unterminated quote on the in-progress last line) instead of `ReadAll`'s
+  all-or-nothing abort, which used to blank `show dhcp server leases`
+  exactly when lease churn was highest. (`FieldsPerRecord = -1` makes a
+  short concurrent line a non-event, and `csv.Read` recovers after a
+  `*csv.ParseError`, so the skip loop terminates naturally.) The DDNS
+  parser keeps the opposite posture by design: there a torn/short row is
+  delete-UNSAFE, so it is rejected, not skipped. Merging the two parsers
   would force one posture onto the other (re-opening the #1387
   mass-delete, or blanking the display on one bad row). Header columns are
   matched CASE-INSENSITIVELY (both the header keys AND the lookup name are

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/netip"
 	"os"
@@ -409,22 +410,28 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 	}
 	defer f.Close()
 
+	// Read the memfile RECORD-BY-RECORD rather than with ReadAll so a
+	// single torn/concurrent Kea append (Kea appends a row on every
+	// renewal/release/decline/reclaim while we read) does not blank the
+	// entire `show dhcp server leases` (#2154). ReadAll aborts on the
+	// FIRST malformed record and returns (nil, err); the per-record loop
+	// logs and SKIPS the bad row, keeping every valid lease around it.
+	// This is the I/O-layer companion to #2085's per-record semantic
+	// leniency (dedup/expire/state) — #2085 made the SEMANTICS lenient
+	// but left the READ all-or-nothing.
+	//
+	// FieldsPerRecord = -1 means a short concurrent line is not even an
+	// error; csv.Read() also RECOVERS after a *csv.ParseError (the next
+	// Read returns the following valid record or io.EOF), so the skip
+	// loop terminates naturally rather than spinning.
 	r := csv.NewReader(f)
-	r.FieldsPerRecord = -1 // memfile rows can vary across Kea versions
+	r.FieldsPerRecord = -1 // memfile rows can vary across Kea versions / torn appends
 	r.Comment = '#'
-	records, err := r.ReadAll()
-	if err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
-	}
-	if len(records) < 2 {
-		return nil, nil
-	}
 
-	// Parse CSV header to find column indices
-	cols := make(map[string]int)
-	for i, h := range records[0] {
-		cols[h] = i
-	}
+	// cols maps header name -> column index; it stays nil until the
+	// first successful record (the header) is read. field() reads a named
+	// column out of a data row.
+	var cols map[string]int
 	field := func(fields []string, name string) string {
 		if idx, ok := cols[name]; ok && idx >= 0 && idx < len(fields) {
 			return fields[idx]
@@ -438,12 +445,37 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 	// so the display is stable and deterministic. Re-recording the
 	// disposition on every row lets a later active append RECLAIM an
 	// address an earlier row tombstoned (release-then-reallocate).
-	latest := make(map[string]Lease, len(records)-1)
-	order := make([]string, 0, len(records)-1)
-	seen := make(map[string]struct{}, len(records)-1)
+	latest := make(map[string]Lease)
+	order := make([]string, 0)
+	seen := make(map[string]struct{})
 	nowUnix := now.Unix()
 
-	for _, fields := range records[1:] {
+	for {
+		fields, err := r.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			// Torn/concurrent Kea append or an exotic malformed row.
+			// Skip just this record and keep reading the rest (#2154);
+			// csv.Read recovers on the next call. Debug, not Warn: a
+			// persistently corrupt file is polled once per `show`, and
+			// the issue mandates debug-level so a busy network does not
+			// spam the log.
+			slog.Debug("dhcpserver: skipping malformed lease row",
+				"path", path, "err", err)
+			continue
+		}
+		if cols == nil {
+			// First successful record is the header; build the column
+			// index map and move on (mirrors the old records[0]).
+			cols = make(map[string]int, len(fields))
+			for i, h := range fields {
+				cols[h] = i
+			}
+			continue
+		}
+
 		addr := field(fields, "address")
 		if addr == "" {
 			continue
@@ -485,6 +517,14 @@ func parseLeaseCSV(path string, now time.Time) ([]Lease, error) {
 			ExpireTime: expireStr,
 			SubnetID:   field(fields, "subnet_id"),
 		}
+	}
+
+	if cols == nil {
+		// No header row was ever read (empty file, comment-only file, or
+		// a file whose only line was malformed). Mirrors the old
+		// len(records) < 2 ⇒ nil,nil guard. A header-only file falls
+		// through with an empty order and returns nil,nil below.
+		return nil, nil
 	}
 
 	leases := make([]Lease, 0, len(order))

--- a/pkg/dhcpserver/dhcpserver_test.go
+++ b/pkg/dhcpserver/dhcpserver_test.go
@@ -509,6 +509,127 @@ func TestParseLeaseCSV_Lenient(t *testing.T) {
 	}
 }
 
+// TestParseLeaseCSV_SkipsMalformedLine pins #2154: the READ layer must be
+// row-robust, not all-or-nothing. Kea appends to its memfile concurrently
+// with our read, so the file can end on a torn line (a partially-written
+// row, e.g. an unterminated quoted field). The pre-#2154 ReadAll() aborted
+// the WHOLE parse on the first such record and returned (nil, err), so
+// `show dhcp server leases` blanked even though most rows were valid —
+// worst exactly when the network is busy. The fix reads record-by-record,
+// logs+skips a malformed row, and keeps every valid lease around it.
+//
+// Non-tautological: against the ReadAll() code this fixture returns
+// (nil, err) and the valid leases are LOST. It also exercises the #2085
+// dedup/expire/state body on the surviving rows to prove that logic is
+// preserved on top of the robust read.
+func TestParseLeaseCSV_SkipsMalformedLine(t *testing.T) {
+	now := time.Unix(1707900000, 0)
+	future := now.Unix() + 3600
+	past := now.Unix() - 3600
+	dir := t.TempDir()
+
+	// A self-contained malformed row in the MIDDLE — a bare quote in a
+	// non-quoted field — produces a *csv.ParseError that csv.Read RECOVERS
+	// from on the next call (verified: the following record reads cleanly),
+	// so the valid rows AFTER it survive too. (An UNTERMINATED quote is a
+	// different shape: it opens a field that spans to EOF and is covered by
+	// the torn-tail case below — that matches ReadAll and is unavoidable.)
+	// Surrounding rows include a #2085 duplicate (newest wins), an expired
+	// row (dropped), and a declined row (state=1, dropped) so the read fix
+	// is proven to compose with #2085's per-record semantics.
+	path := filepath.Join(dir, "kea-leases4.csv")
+	csvData := fmt.Sprintf(`address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id
+10.0.4.10,aa:bb:cc:dd:ee:10,,86400,%d,1,0,0,first,0,,0
+10.0.4.20,aa:bb:cc:dd:ee:20,,86400,%d,1,0,0,ba"req,0,,0
+10.0.4.30,aa:bb:cc:dd:ee:30,,86400,%d,1,0,0,dupA,0,,0
+10.0.4.30,aa:bb:cc:dd:ee:30,,86400,%d,1,0,0,dupB,0,,0
+10.0.4.40,aa:bb:cc:dd:ee:40,,86400,%d,1,0,0,expired,0,,0
+10.0.4.50,aa:bb:cc:dd:ee:50,,86400,%d,1,0,0,declined,1,,0
+10.0.4.60,aa:bb:cc:dd:ee:60,,86400,%d,1,0,0,last,0,,0
+`, future, future, future, future, past, future, future)
+	if err := os.WriteFile(path, []byte(csvData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	leases, err := parseLeaseCSV(path, now)
+	if err != nil {
+		t.Fatalf("malformed line must not abort the whole read; got err %v", err)
+	}
+	byAddr := indexLeasesByAddr(leases)
+
+	// The valid rows surrounding the malformed line survive. The bad row
+	// (10.0.4.20) is skipped; what matters is that the read did not abort
+	// and every row it could parse is returned.
+	if _, ok := byAddr["10.0.4.10"]; !ok {
+		t.Errorf("valid row before malformed line lost; got %+v", leases)
+	}
+	if _, ok := byAddr["10.0.4.20"]; ok {
+		t.Errorf("malformed row 10.0.4.20 must be skipped; got %+v", leases)
+	}
+	if _, ok := byAddr["10.0.4.60"]; !ok {
+		t.Errorf("valid row after malformed line lost; got %+v", leases)
+	}
+	// #2085 logic preserved on the surviving rows:
+	if dup, ok := byAddr["10.0.4.30"]; !ok {
+		t.Errorf("deduped row 10.0.4.30 missing; got %+v", leases)
+	} else if dup.Hostname != "dupB" {
+		t.Errorf("dedup must keep newest row: hostname got %q, want dupB", dup.Hostname)
+	}
+	if _, ok := byAddr["10.0.4.40"]; ok {
+		t.Errorf("expired row 10.0.4.40 must be dropped; got %+v", leases)
+	}
+	if _, ok := byAddr["10.0.4.50"]; ok {
+		t.Errorf("declined row 10.0.4.50 (state=1) must be dropped; got %+v", leases)
+	}
+
+	// Canonical Kea case: the torn line is the VERY LAST line (an append in
+	// progress). The leading valid rows must still render. Against ReadAll
+	// this returns (nil, err) and shows nothing.
+	path2 := filepath.Join(dir, "torn-tail.csv")
+	csv2 := fmt.Sprintf(`address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id
+10.0.5.10,aa:bb:cc:dd:ee:10,,86400,%d,1,0,0,good1,0,,0
+10.0.5.11,aa:bb:cc:dd:ee:11,,86400,%d,1,0,0,good2,0,,0
+10.0.5.12,aa:bb:cc:dd:ee:12,,86400,%d,1,0,0,"torn-mid-append`, future, future, future)
+	if err := os.WriteFile(path2, []byte(csv2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	leases2, err := parseLeaseCSV(path2, now)
+	if err != nil {
+		t.Fatalf("torn last line must not abort the read; got err %v", err)
+	}
+	by2 := indexLeasesByAddr(leases2)
+	if _, ok := by2["10.0.5.10"]; !ok {
+		t.Errorf("leading valid row lost to torn tail; got %+v", leases2)
+	}
+	if _, ok := by2["10.0.5.11"]; !ok {
+		t.Errorf("leading valid row lost to torn tail; got %+v", leases2)
+	}
+
+	// A short concurrent line (fewer fields) must also be tolerated, not
+	// fatal. With FieldsPerRecord = -1 it is not even an error; the field()
+	// helper bounds-checks the column index.
+	path3 := filepath.Join(dir, "short.csv")
+	csv3 := fmt.Sprintf(`address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id
+10.0.6.10,aa:bb:cc:dd:ee:10,,86400,%d,1,0,0,full,0,,0
+10.0.6.11,aa:bb:cc:dd:ee:11
+10.0.6.12,aa:bb:cc:dd:ee:12,,86400,%d,1,0,0,after,0,,0
+`, future, future)
+	if err := os.WriteFile(path3, []byte(csv3), 0644); err != nil {
+		t.Fatal(err)
+	}
+	leases3, err := parseLeaseCSV(path3, now)
+	if err != nil {
+		t.Fatalf("short line must not abort the read; got err %v", err)
+	}
+	by3 := indexLeasesByAddr(leases3)
+	if _, ok := by3["10.0.6.10"]; !ok {
+		t.Errorf("row before short line lost; got %+v", leases3)
+	}
+	if _, ok := by3["10.0.6.12"]; !ok {
+		t.Errorf("row after short line lost; got %+v", leases3)
+	}
+}
+
 // TestApplyStopsDeactivatingUnit pins the Codex finding on PR #1835:
 // a unit reported "deactivating" can have a queued start behind it, so
 // the reconcile must treat it as active-for-stop (unitIsActive returns


### PR DESCRIPTION
## Summary

`parseLeaseCSV` (backing `show dhcp server leases` + REST/gRPC lease
endpoints) read Kea's append-only memfile with a single
`csv.Reader.ReadAll()`. Kea appends a row on every renewal / release /
decline / expiry-reclaim concurrently with xpf reading, so the file can
end on a torn last line. `ReadAll()` aborts on the FIRST malformed
record and returns `(nil, err)`, blanking the entire lease display over
one torn line — worst exactly when lease churn is highest.

This replaces `ReadAll()` with a record-by-record `csv.Reader.Read()`
loop: the first successful record is the header, a malformed row is
logged at debug and SKIPPED, and `io.EOF` terminates normally.
`FieldsPerRecord = -1` makes a short concurrent line a non-event, and
`csv.Read()` recovers after a `*csv.ParseError` (verified empirically),
so the skip loop terminates naturally rather than spinning.

This is the **I/O-layer** companion to #2085, which made the per-record
**semantics** lenient (dedup/expire/state) but left the **read**
all-or-nothing. The #2085 dedup/tombstone/expire/state/order loop body
is preserved verbatim — only record acquisition changes.

## Plan + design

Plan doc: `docs/pr/2154-parseleasecsv/plan.md` (empirical `csv.Read`
semantics, behavioral-equivalence table vs `ReadAll`, risk assessment).

## Test plan

- [x] `go build ./...` clean (whole repo)
- [x] `go test ./pkg/dhcpserver/` green (all #2085 dedup/expire/state/
      leniency tests pass unchanged — fix does not regress them)
- [x] `go test -race ./pkg/dhcpserver/ -run ParseLeaseCSV` clean
- [x] New **non-tautological** `TestParseLeaseCSV_SkipsMalformedLine`:
      malformed row in the middle (bare quote, csv recovers), torn quoted
      field on the last line (canonical Kea append-in-progress), and a
      short line. **Verified it FAILS against the pre-fix `ReadAll` code**
      (`parse ...: bare " in non-quoted-field`) and PASSES with the fix.
- [x] 5/5 flake check on the new test
- [x] `go vet ./pkg/dhcpserver/` clean

**No HA/cluster smoke** — control-plane lease-display path only (per
issue disposition: "Smoke-class: standard (display path), no HA smoke
required").

## Docs

`pkg/dhcpserver/README.md` updated: the display parser's leniency is now
enforced at BOTH the semantic (#2085) and read (#2154) layers; contrasts
with the DDNS parser's delete-safe reject-on-torn posture.

Closes #2154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)