### PR TITLE
#2122/#2123 follow-up: reject non-host masks in NAT address parse (Codex + Copilot review)

### DIFF
--- a/userspace-dp/src/nat/static_nat.rs
+++ b/userspace-dp/src/nat/static_nat.rs
@@ -22,16 +22,35 @@ pub(crate) struct StaticNatTable {
     snat: FxHashMap<IpAddr, StaticNatEntry>,
 }
 
-/// Parse a NAT address that may carry a canonical host mask
+/// Parse a static-NAT address that may carry a canonical host mask
 /// (`x.x.x.x/32`, `addr/128`). Junos emits static-NAT match/then in
 /// canonical prefix form, and the Go compiler copies that mask verbatim
 /// into the snapshot; `IpAddr::from_str` REJECTS CIDR notation, so the mask
 /// must be stripped before the parse or the rule is silently dropped (#2122).
-/// Mirrors the SNAT-pool idiom in `nat/source.rs`. A genuinely-malformed
-/// address still returns `None` so callers preserve their skip-on-invalid
+///
+/// Static NAT is an exact `IpAddr -> IpAddr` 1:1 mapping, so the ONLY
+/// meaningful mask is the host mask. We accept a bare address or a host mask
+/// (`/32` for v4, `/128` for v6) and reject any other suffix — a non-host
+/// prefix (`/24`), a non-numeric mask, a trailing/empty/double slash etc.
+/// would silently translate the wrong scope, so it is a misconfiguration to
+/// surface (skip), not to coerce to a host route. A genuinely-malformed
+/// address likewise returns `None`, preserving the caller's skip-on-invalid
 /// behavior.
 fn parse_nat_addr(s: &str) -> Option<IpAddr> {
-    s.split('/').next().unwrap_or(s).parse().ok()
+    let mut parts = s.splitn(2, '/');
+    let addr: IpAddr = parts.next()?.parse().ok()?;
+    match parts.next() {
+        // Bare address — no mask.
+        None => Some(addr),
+        // Host mask only: /32 for v4, /128 for v6. Anything else is rejected.
+        Some(mask) => {
+            let host_len = match addr {
+                IpAddr::V4(_) => "32",
+                IpAddr::V6(_) => "128",
+            };
+            if mask == host_len { Some(addr) } else { None }
+        }
+    }
 }
 
 impl StaticNatTable {

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -452,6 +452,36 @@ fn static_nat_cidr_and_bare_coexist() {
     );
 }
 
+#[test]
+fn static_nat_non_host_mask_rejected() {
+    // A non-host mask (or garbage suffix) is NOT a canonical host form and
+    // must be rejected (skipped), not silently coerced to a host route — it
+    // would otherwise translate the wrong scope. Pre-#2122 ALL of these were
+    // rejected too (the bare parser errored on any mask), so this is not a
+    // regression; it keeps the hardened parse strict about misconfiguration.
+    for bad in [
+        "203.0.113.5/24",     // non-host v4 prefix
+        "203.0.113.5/notanum", // non-numeric mask
+        "203.0.113.5/",       // empty mask
+        "203.0.113.5//32",    // double slash
+        "203.0.113.5/128",    // v6 host length applied to a v4 address
+        "2001:db8::1/64",     // non-host v6 prefix
+        "2001:db8::1/32",     // v4 host length applied to a v6 address
+    ] {
+        let table = StaticNatTable::from_snapshots(&[StaticNATRuleSnapshot {
+            name: "bad-mask".to_string(),
+            from_zone: String::new(),
+            external_ip: bad.to_string(),
+            internal_ip: "10.0.0.5".to_string(),
+        }]);
+        assert_eq!(
+            table.external_ips().count(),
+            0,
+            "non-host/garbage mask {bad:?} must be rejected, not installed"
+        );
+    }
+}
+
 // --- DNAT table tests ---
 
 #[test]

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -45,6 +45,23 @@ pub(crate) struct Nat64ReverseInfo {
     pub(crate) orig_dst_v6: Ipv6Addr,
 }
 
+/// Parse a NAT64 source-pool IPv4 address that may carry a canonical host
+/// mask (`x.x.x.x/32`). Address-range expansion stamps `/32` on every pool
+/// IP and `Ipv4Addr::from_str` rejects CIDR, so the mask is stripped before
+/// parse (#2123). The pool holds exact host source addresses, so only a bare
+/// address or the host mask (`/32`) is accepted; a non-host mask (`/24`) or
+/// garbage suffix returns `None` and is filtered, surfacing a misconfigured
+/// entry rather than silently coercing it to a host address.
+fn parse_pool_v4(s: &str) -> Option<Ipv4Addr> {
+    let mut parts = s.splitn(2, '/');
+    let addr: Ipv4Addr = parts.next()?.parse().ok()?;
+    match parts.next() {
+        None => Some(addr),
+        Some("32") => Some(addr),
+        Some(_) => None,
+    }
+}
+
 impl Nat64State {
     /// Build from config snapshot NAT64 rules.
     pub(crate) fn from_snapshots(snaps: &[NAT64RuleSnapshot]) -> Self {
@@ -74,14 +91,17 @@ impl Nat64State {
             // Pool addresses may carry a canonical host mask: an
             // address-range source pool (`address A to B`) is expanded by
             // the Go compiler into per-IP `/32` entries (#2123), and
-            // `Ipv4Addr::from_str` rejects CIDR notation. Strip the mask
-            // before parse (mirroring the SNAT-pool idiom in nat/source.rs)
-            // so range-form pools are not silently dropped, leaving pool_v4
-            // empty and NAT64 forward translation non-functional.
+            // `Ipv4Addr::from_str` rejects CIDR notation. Strip the host mask
+            // before parse so range-form pools are not silently dropped,
+            // leaving pool_v4 empty and NAT64 forward translation
+            // non-functional. A non-host mask (`/24`) or garbage suffix is
+            // rejected rather than coerced to a host address, so a
+            // misconfigured pool entry is surfaced (dropped) not silently
+            // mistranslated.
             let pool_v4: Vec<Ipv4Addr> = snap
                 .pool_addresses
                 .iter()
-                .filter_map(|s| s.split('/').next().unwrap_or(s).parse().ok())
+                .filter_map(|s| parse_pool_v4(s))
                 .collect();
             prefixes.push(Nat64Prefix {
                 prefix_bytes,

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -132,6 +132,30 @@ fn nat64_pool_genuinely_invalid_still_dropped() {
 }
 
 #[test]
+fn nat64_pool_non_host_mask_rejected() {
+    // A non-host mask or garbage suffix on a pool address must be filtered,
+    // not coerced to a host address. Only bare and /32 forms install. A valid
+    // /32 alongside the bad entries proves the good one survives.
+    let state = Nat64State::from_snapshots(&[NAT64RuleSnapshot {
+        name: "nat64-bad-mask".to_string(),
+        prefix: "64:ff9b::/96".to_string(),
+        pool_addresses: vec![
+            "100.64.0.1/24".to_string(),      // non-host prefix -> rejected
+            "100.64.0.2/notanum".to_string(), // non-numeric mask -> rejected
+            "100.64.0.3/".to_string(),        // empty mask -> rejected
+            "100.64.0.4//32".to_string(),     // double slash -> rejected
+            "100.64.0.9/32".to_string(),      // canonical host -> kept
+        ],
+        no_v6_frag_header: false,
+    }]);
+    assert_eq!(
+        state.prefixes[0].pool_v4,
+        vec![Ipv4Addr::new(100, 64, 0, 9)],
+        "only the canonical /32 host entry must survive"
+    );
+}
+
+#[test]
 fn invalid_prefix_length_ignored() {
     let state = Nat64State::from_snapshots(&[NAT64RuleSnapshot {
         name: "bad".to_string(),


### PR DESCRIPTION
## Summary

Follow-up to PR #2132 (the #2122/#2123 NAT canonical /32-/128 mask fix,
merged at `66965bdff`). PR #2132 was **merged before this review-response
commit landed**, so the lenient-parse hardening that both Codex and Copilot
asked for is not yet on master. This PR carries just that hardening commit.

The merged fix resolved the actual bugs (static NAT and NAT64 install rules
written in canonical Junos /32-/128 form). However the initial strip
(`s.split('/').next()`) accepted ANY suffix before the first slash, so a
non-host mask or garbage — `203.0.113.5/24`, `100.64.0.7//32`,
`addr/not-a-mask`, `addr/` — silently parsed as a bare host address rather
than being dropped.

Both reviewers independently flagged this (Codex MERGE-NEEDS-MINOR; Copilot
two inline comments on `static_nat.rs` and `nat64.rs`). Static NAT and the
NAT64 pool are exact host-IP mappings, so a non-host mask carries no
representable meaning and would translate the wrong scope — surfacing the
misconfiguration (drop) is safer than coercing it to a host route.

## Change

Harden both helpers to accept only a bare address or the canonical host mask
(/32 for v4, /128 for v6) and reject anything else:
- `static_nat.rs` `parse_nat_addr`: `splitn(2,'/')`, validate the mask matches
  the parsed family's host length.
- `nat64.rs` `parse_pool_v4`: bare or `/32` only (pool is v4).

Not a behavior regression — pre-#2122/#2123 every masked form (including the
legitimate /32) was already rejected by the bare parser. Real-world inputs
from the Go compiler (bare + canonical /32-/128) are unaffected.

## Test plan

- [x] cargo build clean (release)
- [x] All NAT tests: 313 passed, 0 failed
- [x] New tests: `static_nat_non_host_mask_rejected` (v4 non-host prefix,
  non-numeric, empty, double-slash, cross-family host length, v6 non-host),
  `nat64_pool_non_host_mask_rejected` (bad entries filtered while a valid /32
  survives)
- [ ] Loss-cluster NAT smoke — pending parent-run (covered by /security-matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)