### PR TITLE
#2124: fix policy app-term unparseable-protocol fail-open (fail closed + parse named protocols)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -34,6 +34,35 @@
   userspace-dp/src/policy_tests.rs, docs/feature-gaps.md,
   docs/pr/2118-policy-hit-count/plan.md
 
+## 2026-06-20 — #2124 policy app-term unparseable named protocol fail-open
+
+- **Timestamp**: 2026-06-20
+- **Action**: Fixed a verified security fail-open. A policy `application`
+  term whose named L3 protocol the Rust matcher could not parse
+  (sctp/esp/ah/vrrp/igmp/pim/egp) was silently dropped and a rule whose
+  terms all dropped collapsed to match-any, permitting ALL traffic for
+  the zone pair. Fix (3 layers, per Codex r1/r2/r3 plan review):
+  (1) centralized the named->number table in `appid.ProtocolNumber`
+  (cycle-safe; dataplane/catalog delegate); (2) extended Rust
+  `parse_protocol` for the named IANA set and made an all-unparseable
+  term list raise `SnapshotIntegrityError` (whole-snapshot reject,
+  action-agnostic) instead of match-any; (3) Go capability gate now
+  rejects unrepresentable protocol/port (ForwardingSupported=false) and
+  emits a `__unsupported__` fail-closed sentinel term instead of nil so
+  the published snapshot cannot fail open in the publish-before-disarm
+  window. Rust 8 new tests + Go gate/sentinel/parity tests; full Go
+  suite green; full Rust suite green (two pre-existing concurrency flakes
+  in unrelated worker_queue/wg-engine modules verified flaky on clean
+  master). HOT-PATH/SECURITY: cluster smoke NOT run by the engineer
+  agent; parent runs the /security-matrix directional smoke after merge.
+- **File(s)**: pkg/appid/catalog.go, pkg/appid/protocol_number_2124_test.go,
+  pkg/dataplane/compiler.go, pkg/dataplane/userspace/manager.go,
+  pkg/dataplane/userspace/policies.go,
+  pkg/dataplane/userspace/protocol_failopen_2124_test.go,
+  userspace-dp/src/ip_proto.rs, userspace-dp/src/policy.rs,
+  userspace-dp/src/policy_tests.rs, docs/userspace-dataplane-gaps.md,
+  docs/pr/2124-protocol-failopen/plan.md, _Log.md
+
 ## 2026-06-20 — #2079 nat pool-utilization-alarm lenient-disable runtime parity
 
 - **Timestamp**: 2026-06-20

--- a/docs/pr/2124-protocol-failopen/plan.md
+++ b/docs/pr/2124-protocol-failopen/plan.md
@@ -1,6 +1,48 @@
 # #2124 — Policy application term with an unparseable named protocol fails OPEN to match-any
 
-**Status:** DRAFT v2 — Codex r1 PLAN-NEEDS-MAJOR addressed; pending r2
+**Status:** DRAFT v3 — Codex r2 PLAN-NEEDS-MAJOR addressed; pending r3
+
+## v3 changelog (addresses Codex r2 PLAN-NEEDS-MAJOR)
+
+Codex r2 (task-mqna9yks-ubuxup) returned PLAN-NEEDS-MAJOR with two NEW
+findings, both verified against source and both decisive:
+
+1. **Publish-before-disarm gap — Layer G alone does NOT close the
+   fail-open.** `policies.go:85-88` converts a failed
+   `expandUserspacePolicyApplications` (`ok=false`) into
+   `applicationTerms = nil`, which Rust reads as GENUINE match-any. The
+   snapshot is still BUILT and `apply_snapshot` is still SENT before
+   `syncDesiredForwardingStateLocked` disarms; on a same-plan policy
+   update the disarmed-refresh path can process that match-any rule with
+   live workers. So `ForwardingSupported=false` is necessary but NOT
+   sufficient — the published snapshot must not be able to fail open.
+   → **Fix:** when expansion fails, `policies.go` emits an explicit
+   **fail-closed sentinel term** (reserved unparseable protocol
+   `"__unsupported__"`) instead of `nil`. Rust drops it → the rule has
+   NON-empty `application_terms` but ALL dropped → Rust raises
+   `SnapshotIntegrityError` → the WHOLE snapshot is rejected and the
+   previous good state is kept (snapshot_refresh.rs:69). This makes the
+   Rust integrity error the actual enforcement for the publish window,
+   action-agnostically. The sentinel is distinct from genuine-empty
+   (`application any` → no terms), so match-any is preserved for the
+   legit case.
+
+2. **Import cycle in the proposed centralization.** `pkg/dataplane`
+   already imports `pkg/appid` (compiler.go:19), and `pkg/appid` imports
+   only `pkg/config`. So `appid.catalogProtocolNumber →
+   dataplane.ProtocolNumber` is a cycle. → **Fix:** put the centralized
+   `ProtocolNumber(name) (uint8, bool)` in **`pkg/appid`** (the leaf
+   already holding the full table). `pkg/dataplane.protocolNumber` and
+   `pkg/appid.catalogProtocolNumber` both delegate to it;
+   `pkg/dataplane/userspace` imports `pkg/appid` directly (no cycle —
+   appid imports nothing from dataplane). 0/HOPOPT preserved as
+   `(0,true)`.
+
+Also: cleaned stale v1 §10 text (it still listed SnapshotIntegrityError
+and port-parser work as out-of-scope, contradicting §4'/§5').
+
+---
+
 
 ## v2 changelog (addresses Codex r1 PLAN-NEEDS-MAJOR)
 
@@ -110,7 +152,43 @@ introduces a worse hazard", which IS a valid verdict.)*
   protocol would freeze the whole policy plane — wrong granularity.
   Rejected in favor of per-rule fail-closed (§5.2).
 
-## 4'. Decision: which layer(s) fix it (v2 — PRIMED)
+## 4''. Decision (v3 — CURRENT)
+
+The fail-open is closed by **two cohering enforcement mechanisms**, with
+the Rust integrity-error as the actual hard backstop (Codex r2 F1):
+
+- **Layer G (Go capability gate) — operator signal + disarm driver +
+  canonicalization.** `expandUserspacePolicyApplications` returns
+  `ok=false` for an unrepresentable protocol/port, tripping
+  `ForwardingSupported=false` (operator-visible refuse-to-arm). For the
+  now-SUPPORTED named protocols it canonicalizes to the numeric string
+  Rust parses, and validates ports — so legit configs WORK and arm.
+
+- **Layer S (fail-closed sentinel) — closes the publish-before-disarm
+  window.** `policies.go` (buildOneRuleSnapshot) NO LONGER turns a
+  failed expansion into `applicationTerms = nil`. It emits ONE sentinel
+  term `{name:"__unsupported__", protocol:"__unsupported__"}`. This is
+  the bridge: it makes the published snapshot UN-fail-open-able.
+
+- **Layer R (Rust) — the hard enforcement + named-set support.**
+  (a) `parse_protocol` maps the named IANA set to numbers (so canonical
+  numeric AND named both parse). (b) `parse_policy_state_with_counters`
+  raises `SnapshotIntegrityError::UnrepresentableApplicationProtocol`
+  when a rule's `application_terms` are NON-empty but ALL drop as
+  unparseable — which is exactly the sentinel case (and any corrupt
+  snapshot). The preflight rejects the whole snapshot, keeping last-good
+  state. ACTION-AGNOSTIC: never collapses a rule to match-any, never
+  turns a deny into a pass.
+
+- **Centralization (Codex r2 F2):** `ProtocolNumber(name) (uint8, bool)`
+  lives in **`pkg/appid`**; `dataplane.protocolNumber` and
+  `appid.catalogProtocolNumber` delegate to it; `userspace` imports
+  `appid`. No import cycle. 0/HOPOPT → `(0,true)`.
+
+- **Layer C (commit-time):** out of scope (Q5). Named set now works;
+  unknown still warns at commit + trips refuse-to-arm at apply.
+
+### 4'. (v2, SUPERSEDED by 4'')
 
 Three layers, with the **Go capability gate as the PRIMARY,
 action-agnostic fix** (Codex r1 F1/F2):
@@ -163,27 +241,35 @@ action-agnostic fix** (Codex r1 F1/F2):
   commit-time hard reject (#1960 doctrine) is a reasonable follow-up
   but is deferred (Q5) to keep this PR a focused security fix.
 
-## 5'. Concrete design (v2 — PRIMED)
+## 5''. Concrete design (v3 — CURRENT)
 
-### 5'.1 Centralize the named→number map (`pkg/dataplane`)
+### 5''.1 Centralize the named→number map in `pkg/appid` (cycle-safe)
 
-`pkg/dataplane/compiler.go` currently has `protocolNumber(name) uint8`
-returning `0` for BOTH unknown and `"0"`. Add:
+`pkg/appid` already holds the full table (`catalogProtocolNumber`) and
+imports ONLY `pkg/config`, while `pkg/dataplane` already imports
+`pkg/appid` — so the centralized helper goes in `pkg/appid`:
 
 ```go
+// pkg/appid/catalog.go (or protocol.go)
 // ProtocolNumber resolves an IANA protocol name or numeric string to its
 // number. ok=false means the token is neither a known name nor a valid
-// 0..255 numeric (so 0/HOPOPT resolves to (0, true), distinct from the
+// 0..255 numeric (so "0"/HOPOPT resolves to (0, true), distinct from the
 // unrepresentable (0, false) case).
 func ProtocolNumber(name string) (uint8, bool) { ... }
 ```
 
-`protocolNumber` becomes `n, _ := ProtocolNumber(name); return n`
-(behavior-preserving). `pkg/appid.catalogProtocolNumber` is refactored
-to delegate to `dataplane.ProtocolNumber` (it mirrors the same table per
-its own doc comment) — eliminating the third copy. A parity test asserts
-the two former tables agree with the centralized one for the full named
-set + boundary numerics (0, 255, 256→false, ""→false).
+- `pkg/appid.catalogProtocolNumber(name) uint8` → `n, _ :=
+  ProtocolNumber(name); return n` (behavior-preserving).
+- `pkg/dataplane.protocolNumber(name) uint8` → `n, _ :=
+  appid.ProtocolNumber(name); return n` (behavior-preserving;
+  `pkg/dataplane` already imports `pkg/appid`).
+- `pkg/dataplane/userspace` imports `pkg/appid` directly to use
+  `ProtocolNumber` in the gate (no cycle: appid imports nothing from
+  dataplane or userspace — verified).
+- Parity test: `ProtocolNumber` agrees with the pre-refactor
+  `protocolNumber`/`catalogProtocolNumber` tables for the full named set
+  + junos aliases; `("0")→(0,true)`, `("255")→(255,true)`,
+  `("256")→(0,false)`, `("")→(0,false)`, `("bogus")→(0,false)`.
 
 ### 5'.2 Layer G: validate protocol AND ports in the capability gate
 
@@ -214,11 +300,41 @@ if !userspacePortSpecRepresentable(app.SourcePort) ||
 `userspacePortSpecRepresentable` mirrors Rust `parse_port_spec`
 (empty=ok; named service aliases http/https/...; single 1..65535;
 `low-high` with `low>0 && low<=high`). This closes the bad-PORT
-fail-open (Codex r1 F2) at the same action-agnostic gate.
+fail-open at the same action-agnostic gate. Uses `appid.ProtocolNumber`,
+NOT a new named-protocol list.
 
-`normalizeUserspaceApplicationProtocol` keeps its `icmp6→icmpv6` mapping;
-the numeric canonicalization happens via `ProtocolNumber` above so we do
-NOT add a fourth named-protocol list to it.
+### 5''.2b Layer S: fail-closed sentinel in `policies.go` (Codex r2 F1)
+
+`buildOneRuleSnapshot` (policies.go:85-88) currently does:
+
+```go
+applicationTerms, ok := expandUserspacePolicyApplications(cfg, pol.Match.Applications)
+if !ok {
+    applicationTerms = nil   // BUG: Rust reads nil as genuine match-any
+}
+```
+
+Replace with an explicit fail-closed sentinel so the published snapshot
+cannot fail open even in the publish-before-disarm window:
+
+```go
+applicationTerms, ok := expandUserspacePolicyApplications(cfg, pol.Match.Applications)
+if !ok {
+    // The rule cites applications the userspace matcher cannot honor.
+    // Emit a reserved unparseable sentinel so Rust drops it and raises
+    // SnapshotIntegrityError (whole-snapshot reject, keep last-good) —
+    // action-agnostic fail-closed — instead of an empty term list that
+    // Rust would read as genuine match-any.
+    applicationTerms = []PolicyApplicationSnapshot{{
+        Name:     unsupportedApplicationSentinel, // "__unsupported__"
+        Protocol: unsupportedApplicationSentinel,
+    }}
+}
+```
+
+`unsupportedApplicationSentinel = "__unsupported__"` — a token that
+`parse_protocol` will never accept (not a name, not 0..255 numeric) and
+that no real Junos protocol/app name collides with.
 
 ### 5'.3 Layer R(a): extend Rust `parse_protocol`
 
@@ -494,11 +610,11 @@ Rust (`userspace-dp/src/policy_tests.rs`):
 - `cargo test --release` green; 5/5 flake on the new integrity-error
   test.
 
-Go (`pkg/dataplane/`, `pkg/dataplane/userspace/`, `pkg/appid/`):
-- **`ProtocolNumber` parity** — for the full named set + junos aliases,
-  `ProtocolNumber` agrees with the old `protocolNumber` and
-  `catalogProtocolNumber`; `("0")→(0,true)`, `("256")→(0,false)`,
-  `("")→(0,false)`, `("bogus")→(0,false)`.
+Go (`pkg/appid/`, `pkg/dataplane/`, `pkg/dataplane/userspace/`):
+- **`appid.ProtocolNumber` parity** — agrees with the pre-refactor
+  `protocolNumber` + `catalogProtocolNumber` over the full named set +
+  junos aliases; `("0")→(0,true)`, `("255")→(255,true)`,
+  `("256")→(0,false)`, `("")→(0,false)`, `("bogus")→(0,false)`.
 - **Gate fails closed on unknown protocol** — an app with protocol
   `"bogus"` → `expandUserspacePolicyApplications` returns `ok=false` →
   `userspaceSupportsSecurityPolicies` false → `ForwardingSupported`
@@ -507,11 +623,21 @@ Go (`pkg/dataplane/`, `pkg/dataplane/userspace/`, `pkg/appid/`):
   `DestinationPort:"99999"` (or `"5-1"`) → `ok=false`.
 - **Gate canonicalizes + accepts named protocol** — app with `esp` →
   `ok=true`, emitted snapshot term Protocol == `"50"`.
+- **Sentinel on failed expansion (Codex r2 F1)** — a policy citing an
+  app with an unrepresentable protocol → `buildOneRuleSnapshot` emits a
+  rule whose `ApplicationTerms` is the `"__unsupported__"` sentinel (NOT
+  nil). **Non-tautological:** pre-fix it is `nil`.
 - **Existing working configs unchanged** — tcp/udp/icmp/gre/ospf +
-  numeric still `ok=true`.
-- `go test ./pkg/dataplane/... ./pkg/appid/... ./pkg/config/...` green.
+  numeric still `ok=true`; normal apps emit normal terms (no sentinel).
+- `go test ./pkg/appid/... ./pkg/dataplane/... ./pkg/config/...` green.
 
-### 9. (v1, SUPERSEDED)
+Rust end-to-end sentinel test (`policy_tests.rs`):
+- A `PolicyRuleSnapshot` carrying the `"__unsupported__"` sentinel term
+  → `parse_policy_state_with_counters` returns
+  `Err(UnrepresentableApplicationProtocol)`. This is the cross-language
+  contract test proving Layer S + Layer R(b) cohere.
+
+### 9'. / 9. (v2/v1, SUPERSEDED)
 
 1. **Known named protocol now matches** — a permit rule with one
    application term `{protocol:"sctp", destination_port:"9999"}` permits
@@ -549,15 +675,22 @@ task directive, the PARENT runs the `/security-matrix` directional
 smoke after merge (trust→untrust ALLOW, untrust→trust BLOCK, plain
 forwarding throughput). Stated explicitly in the PR + return.
 
-## 10. Out of scope (explicitly)
+## 10'. Out of scope (explicitly) (v3 — CURRENT)
 
-- A new strict/lenient commit-time `validateProtocol` toggle (Q5) —
-  the named set now works; truly-unknown is already a commit error.
+- A new strict/lenient commit-time `validateProtocol` hard-reject (Q5).
+  The named set now works end-to-end; a truly-unknown protocol warns at
+  commit (existing behavior) and trips the operator-visible refuse-to-
+  arm at apply. A #1960-doctrine commit-time toggle is a reasonable
+  follow-up but is deferred to keep this PR a focused security fix.
 - Adding the named protocols to the `AppCatalog` show-path (app-id
   naming) — separate concern (matcher vs. display); no fail-open there.
-- SnapshotIntegrityError-based whole-snapshot rejection for unparseable
-  protocols — rejected as wrong granularity (§3).
-- Extending the *port* spec parser — orthogonal.
+- Note: SnapshotIntegrityError-based whole-snapshot rejection IS now IN
+  scope (Layer R(b)/Layer S) — it is the action-agnostic hard backstop,
+  NOT out of scope as v1 wrongly stated.
+- Note: the port-spec representability check IS now IN scope (Layer G) —
+  it closes the bad-port fail-open Codex r1 F2 flagged.
+
+### 10. (v1, SUPERSEDED — see 10')
 
 ## 11. Open questions for adversarial review (each PLAN-KILL-able)
 

--- a/docs/pr/2124-protocol-failopen/plan.md
+++ b/docs/pr/2124-protocol-failopen/plan.md
@@ -1,0 +1,371 @@
+# #2124 — Policy application term with an unparseable named protocol fails OPEN to match-any
+
+**Status:** DRAFT v1 — pending adversarial plan review
+
+## 1. Issue framing (in my words)
+
+A security policy `permit` rule that matches on a user-defined
+`application` whose `protocol` is a *named* IANA protocol the Rust
+matcher cannot parse — `sctp`, `esp`, `ah`, `vrrp`, `igmp`, `pim`,
+`egp` — silently **fails OPEN to match-any**, so the rule permits ALL
+traffic between the zone pair instead of only the intended protocol.
+
+Verified end-to-end in the issue (3/3 adversarial votes):
+
+- Go `validateProtocol` (`pkg/config/compiler.go:2371`) *accepts*
+  `sctp/vrrp/igmp/pim/egp/ah/esp` at commit (warning-only, never a hard
+  error), so the config commits clean.
+- Go `normalizeUserspaceApplicationProtocol`
+  (`pkg/dataplane/userspace/manager.go:1782`) only lowercases — `"esp"`
+  stays `"esp"`, non-empty.
+- The capability gate `expandUserspacePolicyApplications`
+  (`manager.go:1712`) only returns `ok=false` for an *empty* protocol
+  string (`manager.go:1732`). A non-empty-but-Rust-unparseable protocol
+  returns `ok=true`, so `ForwardingSupported` stays true and the
+  snapshot arms normally — routing AROUND the existing deliberate
+  fail-closed gate (`manager.go` `deriveUserspaceCapabilities` /
+  `ForwardingSupported=false`).
+- Rust `parse_protocol` (`userspace-dp/src/policy.rs:1148`) returns
+  `None` for those named protocols; `parse_applications`
+  (`policy.rs:1127`) drops the term via `continue`. If that was the
+  rule's only term, `rule.applications` is empty →
+  `CompiledApplications::from_matches(&[])` sets `match_any:true`
+  (`policy.rs:304-310`) → `matches()` returns true for EVERY
+  protocol/port (`policy.rs:333-335`) → `try_match_rule` treats the
+  rule as matching everything (`policy.rs:983`).
+
+Net: a `permit` policy intended to allow ONLY ESP (or AH/SCTP/...)
+permits ALL traffic for that zone-pair — a real security-policy bypass.
+Doubly bad because the codebase already has a deliberate fail-CLOSED
+design for policy semantics it cannot honor (`ForwardingSupported=false`
+→ dataplane refuses to arm); this gap fails OPEN *inside* the matcher
+instead.
+
+## 2. Honest scope / value framing
+
+This is a **security correctness fix**, not a perf refactor — the
+"value" is closing a verified policy-bypass, not saving cycles. The
+churn is small and surgical (one Rust file's parse path + a Go
+canonicalization + tests). There is no architectural premise that can
+be "too small to justify" — a fail-OPEN in a firewall policy matcher
+is a must-fix. *(The skill's "PLAN-KILL if the perf gain is too small"
+clause does not apply; PLAN-KILL here would mean "this design is wrong /
+introduces a worse hazard", which IS a valid verdict.)*
+
+## 3. What's already shipped / precedent the fix must compose with
+
+- **#2008 address-side fail-closed precedent** — the EXACT same hazard
+  class was fixed for the address side. `PolicyRule` carries per-side,
+  per-family `source_v4_empty` / `source_v6_empty` /
+  `destination_v4_empty` / `destination_v6_empty` flags
+  (`policy.rs:120-131`): "configured but matches NOTHING → force NOT
+  match (fail-closed)". The application-side fix MIRRORS this: a rule
+  whose application terms were all configured-but-unparseable must
+  become **never-match**, not match-any.
+- **`PROTO_*` constants** already centralized in
+  `userspace-dp/src/ip_proto.rs` (`ESP=50`, `GRE=47`, `OSPF=89`,
+  `IPIP=4`, etc.) per #1826. New protocol numbers (AH=51, SCTP=132,
+  VRRP=112, IGMP=2, PIM=103, EGP=8) get added there.
+- **Predefined junos apps** (`pkg/config/predefined.go`) only use
+  `tcp/udp/icmp/gre/89/4` — all already parse. The risk vector is
+  **user-defined** `applications` with named L3 protocols.
+- **`SnapshotIntegrityError` is a whole-snapshot hammer.** The preflight
+  in `snapshot_refresh.rs:69` REJECTS the ENTIRE snapshot and keeps
+  previous state on any integrity error. Using it for one typo'd
+  protocol would freeze the whole policy plane — wrong granularity.
+  Rejected in favor of per-rule fail-closed (§5.2).
+
+## 4. Decision: which layer(s) fix it
+
+Per the issue's "Suggested fix", BOTH complementary layers, because each
+covers a different failure mode and the defense-in-depth matches the
+existing #2008 + capability-gate posture:
+
+- **Layer R (Rust, the core fix):** (a) extend `parse_protocol` to map
+  the standard named protocols Junos/`validateProtocol` accepts to their
+  IANA numbers, so legitimate configs WORK; (b) for any STILL-
+  unparseable term, the rule fails CLOSED (never-match), never
+  match-any.
+- **Layer G (Go, defense-in-depth + parity):** canonicalize named
+  protocols to their numeric strings in
+  `normalizeUserspaceApplicationProtocol` so the wire snapshot always
+  carries a Rust-parseable protocol for the accepted set; and tighten
+  the capability gate so a protocol NEITHER Go-canonicalizable NOR
+  Rust-parseable trips the existing `ForwardingSupported=false`
+  fail-closed path (operator-visible at apply time).
+- **Layer C (commit-time, #1960 doctrine):** evaluated below; recommend
+  KEEPING `validateProtocol` lenient (warn) for the now-supported named
+  set (no behavior change — they now work), but this is an open question
+  for reviewers (§11 Q5).
+
+## 5. Concrete design
+
+### 5.1 Layer R(a): extend `parse_protocol` (`policy.rs:1148`)
+
+Add the named→number mappings for the protocols `validateProtocol`
+already accepts, drawing the numbers from `ip_proto.rs`:
+
+```rust
+fn parse_protocol(protocol: &str) -> Option<u8> {
+    match protocol {
+        "" => None,
+        "tcp" => Some(PROTO_TCP),
+        "udp" => Some(PROTO_UDP),
+        "icmp" => Some(PROTO_ICMP),
+        "icmp6" | "icmpv6" => Some(PROTO_ICMPV6),   // accept icmp6 alias too
+        "gre" => Some(PROTO_GRE),
+        "89" | "ospf" => Some(PROTO_OSPF),
+        "4" | "ipip" => Some(PROTO_IPIP),
+        "esp" => Some(PROTO_ESP),                   // 50
+        "ah" => Some(PROTO_AH),                     // 51
+        "sctp" => Some(PROTO_SCTP),                 // 132
+        "vrrp" => Some(PROTO_VRRP),                 // 112
+        "igmp" => Some(PROTO_IGMP),                 // 2
+        "pim" => Some(PROTO_PIM),                   // 103
+        "egp" => Some(PROTO_EGP),                   // 8
+        _ => protocol.parse::<u8>().ok(),
+    }
+}
+```
+
+New constants in `ip_proto.rs`: `PROTO_IGMP=2`, `PROTO_EGP=8`,
+`PROTO_AH=51`, `PROTO_PIM=103`, `PROTO_VRRP=112`, `PROTO_SCTP=132`.
+These are load-bearing IANA wire numbers; values cross-checked against
+the registry.
+
+Note: `junos-*` aliases are NOT handled here — the Go compiler resolves
+predefined `junos-*` apps to their concrete protocol BEFORE the snapshot
+(`predefined.go`), so the Rust side never sees a literal `junos-xxx`
+protocol string. Confirmed: no predefined app carries a non-numeric,
+non-tcp/udp protocol other than `gre`/`89`/`4`, all already parsed.
+
+### 5.2 Layer R(b): fail CLOSED on unparseable terms (the security core)
+
+The dangerous transition is "term list NON-empty, but every term
+dropped → `from_matches(&[])` → match_any". Distinguish the two empty
+cases:
+
+- `application_terms` genuinely empty (no app constraint, Junos
+  `application any` / no `match application`) → match-any (correct,
+  unchanged).
+- `application_terms` NON-empty but ALL dropped as unparseable →
+  **never-match** (fail closed).
+
+Implementation — mirror #2008's `*_empty` flag exactly. Change
+`parse_applications` to also report whether any term was dropped, and
+`CompiledApplications::from_matches` to take that signal:
+
+```rust
+struct CompiledApplications {
+    match_any: bool,
+    never_match: bool,   // NEW: configured terms all unparseable -> fail closed
+    by_protocol: FxHashMap<u8, ProtoTerms>,
+}
+
+fn matches(&self, protocol: u8, src_port: u16, dst_port: u16) -> bool {
+    if self.never_match {        // fail-closed short-circuit (checked first)
+        return false;
+    }
+    if self.match_any {
+        return true;
+    }
+    ...
+}
+```
+
+`parse_applications` returns `(Vec<ApplicationMatch>, bool dropped_any)`
+(or a small struct). Constructor logic at `policy.rs:669-670`:
+
+```rust
+let (applications, had_terms, dropped_any) =
+    parse_applications(&snap.application_terms);
+let compiled_apps =
+    CompiledApplications::from_parsed(&applications, had_terms, dropped_any);
+```
+
+`from_parsed` rules:
+- `had_terms == false` → `match_any: true` (genuinely no constraint).
+- `had_terms == true && applications.is_empty()` (all dropped) →
+  `never_match: true`. **Fail closed.**
+- otherwise → grouped `by_protocol`, both flags false.
+
+The existing `from_matches(&[])` → match_any path is preserved ONLY for
+the genuine-empty case; the all-dropped case diverges to never_match.
+`PolicyRule::default()` keeps `match_any:true` semantics for the
+zero-config default rule (it has no terms → `had_terms=false`), so the
+default-rule behavior is unchanged.
+
+### 5.3 Layer G: Go canonicalization + gate parity
+
+`normalizeUserspaceApplicationProtocol` (`manager.go:1782`) maps the
+named protocols to their numeric strings so the wire snapshot is always
+Rust-parseable for the accepted set:
+
+```go
+func normalizeUserspaceApplicationProtocol(proto string) string {
+    switch strings.ToLower(strings.TrimSpace(proto)) {
+    case "icmp6": return "icmpv6"
+    case "esp":   return "50"
+    case "ah":    return "51"
+    case "sctp":  return "132"
+    case "vrrp":  return "112"
+    case "igmp":  return "2"
+    case "pim":   return "103"
+    case "egp":   return "8"
+    default:      return strings.ToLower(strings.TrimSpace(proto))
+    }
+}
+```
+
+This makes Layer R(a) and Layer G mutually redundant for the accepted
+set (belt-and-suspenders): even an OLD helper binary that lacks R(a)
+gets a numeric protocol it can already parse. Open question Q3: do we
+canonicalize in Go AND extend Rust, or pick one? Recommendation: BOTH —
+the Rust extension is the durable fix (handles direct numeric + named),
+the Go canonicalization protects mixed-version helper rollouts.
+
+Capability-gate tightening: `expandUserspacePolicyApplications` returns
+`ok=false` for a protocol that, after canonicalization, the Rust matcher
+still cannot represent (i.e. not in the named set and not a 0-255
+numeric). That trips `ForwardingSupported=false` → operator sees the
+policy refuse to arm rather than silently fail-closing one rule at
+runtime. This is the loud, early signal; Layer R(b) is the last-resort
+runtime backstop if anything slips through (e.g. a hand-crafted
+snapshot).
+
+### 5.4 Layer C: commit-time (evaluated, recommend minimal)
+
+`validateProtocol` ALREADY accepts the named set (warns nothing — it's
+silently allowed). With R+G the named set now WORKS end-to-end, so no
+NEW commit rejection is needed for them. The residual case (a protocol
+NOT in `validateProtocol`'s set AND not numeric) is ALREADY a hard
+`commit` error (`return fmt.Errorf("invalid protocol %q")`). So the
+commit layer is effectively already correct for the truly-unknown case.
+Recommendation: NO new commit-time validation in this PR beyond a
+possible doc note; treat any further strict/lenient toggle as out of
+scope (Q5).
+
+## 6. Public API preservation
+
+- `parse_protocol` signature unchanged (`&str -> Option<u8>`).
+- `evaluate_policy*` signatures unchanged.
+- `parse_policy_state*` signatures unchanged.
+- `CompiledApplications` is a private struct; adding a field +
+  `from_parsed` is internal. `from_matches` may be retained as a thin
+  wrapper for the genuine-empty/normal paths or replaced by
+  `from_parsed` — internal-only either way.
+- Go `normalizeUserspaceApplicationProtocol`,
+  `expandUserspacePolicyApplications` signatures unchanged.
+
+## 7. Hidden invariants the change must preserve
+
+- **Default rule stays match-any.** `PolicyRule::default()` and any rule
+  with no `application_terms` MUST remain match-any. Guard: `had_terms`
+  is false for the empty input → match_any path unchanged.
+- **`match_any` short-circuit ordering.** `never_match` must be checked
+  BEFORE `match_any` in `matches()` (a rule can't be both, but defensive
+  ordering — never_match is the fail-closed sentinel).
+- **Side-effect ordering / preflight.** No new `SnapshotIntegrityError`
+  is introduced, so the preflight-reject-whole-snapshot behavior is
+  untouched. Per-rule fail-closed is purely a `matches()` outcome.
+- **HA session-sync portability.** No on-wire snapshot field changes in
+  Rust (the flag is derived, not serialized). Go canonicalization
+  changes the protocol STRING on the wire (esp→"50"), which both old and
+  new helpers parse — verify no consumer keys on the literal "esp".
+- **Numeric protocol still works.** `protocol 132` etc. must still
+  parse (the `_ => parse::<u8>()` arm is preserved).
+- **Allocation:** `parse_applications` already allocates a `Vec`; the
+  dropped-any signal is a `bool`, no new hot-path allocation. `matches()`
+  gains one bool check — negligible, runs per packet on the slow
+  (session-install) path, not per-forwarded-packet.
+
+## 8. Risk assessment
+
+| Class | Level | Notes |
+|-------|-------|-------|
+| Behavioral regression | LOW | Only changes the all-dropped case (today match-any, a BUG) to never-match. Genuine-empty + normal paths byte-identical. Default rule unchanged. |
+| Lifetime / borrow-checker | LOW | Adding a `bool` field + returning a tuple. No new borrows. |
+| Performance regression | LOW | One extra `bool` branch in `matches()`; parse path is config-apply, not per-packet forward. |
+| Architectural mismatch | LOW | Directly mirrors the shipped #2008 `*_empty` fail-closed pattern — same author-intended design, same struct. Not a novel architecture. |
+
+## 9. Test plan
+
+Rust (`userspace-dp/src/policy_tests.rs`):
+1. **Known named protocol now matches** — a permit rule with one
+   application term `{protocol:"sctp", destination_port:"9999"}` permits
+   SCTP/9999 and DENIES TCP/443 (proves R(a) + that it is NOT match-any).
+   Repeat for `esp` (protocol-only, no port) → permits ESP, denies TCP.
+2. **Unknown token fails CLOSED** — a permit rule with one term
+   `{protocol:"bogus-proto", ...}` does NOT permit TCP/443 (default
+   `deny` wins). **Non-tautological:** this test FAILS on pre-fix code
+   (today it match-anys → Permit). Assert `state.rules[0]` matches
+   nothing.
+3. **Numeric still parses** — `{protocol:"132"}` permits SCTP, denies
+   TCP (regression guard for the numeric arm).
+4. **Genuine-empty stays match-any** — rule with empty
+   `application_terms` still match-anys (regression guard for the
+   default behavior).
+5. **Mixed parseable+unparseable** — a rule with terms
+   `[{esp}, {bogus}]`: the parseable term still matches ESP, the rule
+   is NOT match-any (the bogus term is dropped, the rule has ≥1 real
+   term → normal by_protocol, never_match=false). Confirms drop of one
+   term among many does NOT trip never_match.
+6. `cargo test --release` full suite green; 5/5 flake on the new
+   `application_unknown_protocol_fails_closed` test.
+
+Go (`pkg/dataplane/userspace/`):
+7. `normalizeUserspaceApplicationProtocol("esp") == "50"` etc.; unknown
+   passes through unchanged.
+8. `expandUserspacePolicyApplications` capability-gate test: an app with
+   a truly-unknown protocol → `ok=false` (trips fail-closed); an app
+   with `esp` → `ok=true` and canonicalized to "50".
+9. `GOCACHE=/dev/shm/cache go test ./pkg/dataplane/... ./pkg/config/...`
+   green.
+
+Smoke: **NOT run by this agent.** Hot-path/security change — per the
+task directive, the PARENT runs the `/security-matrix` directional
+smoke after merge (trust→untrust ALLOW, untrust→trust BLOCK, plain
+forwarding throughput). Stated explicitly in the PR + return.
+
+## 10. Out of scope (explicitly)
+
+- A new strict/lenient commit-time `validateProtocol` toggle (Q5) —
+  the named set now works; truly-unknown is already a commit error.
+- Adding the named protocols to the `AppCatalog` show-path (app-id
+  naming) — separate concern (matcher vs. display); no fail-open there.
+- SnapshotIntegrityError-based whole-snapshot rejection for unparseable
+  protocols — rejected as wrong granularity (§3).
+- Extending the *port* spec parser — orthogonal.
+
+## 11. Open questions for adversarial review (each PLAN-KILL-able)
+
+1. **Fail-closed vs. SnapshotIntegrityError.** Is per-rule never-match
+   the right granularity, or should an unparseable protocol reject the
+   whole snapshot (loud, but freezes the entire policy plane on one
+   typo)? I argue per-rule (mirrors #2008, surgical) — refute if a
+   whole-snapshot reject is safer.
+2. **Default-rule / genuine-empty safety.** Does any code path construct
+   a rule with `had_terms=true` but legitimately expecting match-any
+   (e.g. a wildcard term that intentionally parses to nothing)? If so,
+   never_match would wrongly fail-close a legit rule. I believe NO — an
+   empty `application_terms` is the only match-any case — verify.
+3. **Go-canonicalize AND Rust-extend, or one?** Doing both is
+   belt-and-suspenders for mixed-version helper rollout. Is the double
+   maintenance worth it, or does it create a divergence hazard (two
+   lists of named protocols to keep in sync)? Could centralize the
+   named→number map.
+4. **Protocol-number correctness.** Verify AH=51, SCTP=132, VRRP=112,
+   IGMP=2, PIM=103, EGP=8, ESP=50 against IANA. A wrong number is a
+   silent mis-match (worse than fail-open in a subtle way).
+5. **Commit-time layer.** Should #1960-doctrine strict/lenient commit
+   validation be added for protocol names NOW, or is "named set works +
+   unknown is already a commit error" sufficient? I argue sufficient.
+6. **`icmp6` alias.** Adding `"icmp6"` to `parse_protocol` — is there any
+   path where Go sends `icmp6` un-normalized to Rust? (Go normalizes
+   icmp6→icmpv6 already; the Rust alias is defensive.) Harmless?
+7. **Capability-gate interaction.** With Go canonicalizing esp→"50", the
+   gate sees a numeric protocol and returns ok=true → forwarding arms →
+   Rust parses "50" fine. Correct. But does tightening the gate for
+   *truly*-unknown protocols risk regressing a currently-working config
+   that relies on a protocol the gate would now reject? (It shouldn't —
+   anything the gate now rejects is exactly the fail-open set.) Verify.

--- a/docs/pr/2124-protocol-failopen/plan.md
+++ b/docs/pr/2124-protocol-failopen/plan.md
@@ -1,6 +1,6 @@
 # #2124 — Policy application term with an unparseable named protocol fails OPEN to match-any
 
-**Status:** DRAFT v3 — Codex r2 PLAN-NEEDS-MAJOR addressed; pending r3
+**Status:** PLAN-READY v3 — Codex r3 PLAN-NEEDS-MINOR (2 doc minors fixed); all substantive checks pass. Gemini companion non-functional this session (infra failures) — parent should dispatch an independent second reviewer.
 
 ## v3 changelog (addresses Codex r2 PLAN-NEEDS-MAJOR)
 
@@ -146,11 +146,20 @@ introduces a worse hazard", which IS a valid verdict.)*
 - **Predefined junos apps** (`pkg/config/predefined.go`) only use
   `tcp/udp/icmp/gre/89/4` — all already parse. The risk vector is
   **user-defined** `applications` with named L3 protocols.
-- **`SnapshotIntegrityError` is a whole-snapshot hammer.** The preflight
+- **`SnapshotIntegrityError` whole-snapshot reject.** The preflight
   in `snapshot_refresh.rs:69` REJECTS the ENTIRE snapshot and keeps
-  previous state on any integrity error. Using it for one typo'd
-  protocol would freeze the whole policy plane — wrong granularity.
-  Rejected in favor of per-rule fail-closed (§5.2).
+  previous good state on any integrity error.
+  **v3 UPDATE (supersedes the v1 conclusion below):** this whole-snapshot
+  reject is the CHOSEN action-agnostic backstop (§4''/§5''.4) — it never
+  collapses a rule to match-any and never turns a deny into a pass, and
+  in practice fires only on the Layer-S sentinel / a corrupt snapshot
+  (Layer G keeps normal-path malformed terms out). The v1 reasoning that
+  follows ("wrong granularity — rejected in favor of per-rule
+  never-match") is SUPERSEDED: per-rule action-blind `never_match` was
+  itself the unsafe choice Codex r2 F2 flagged (it regresses deny
+  rules). _[v1, retained for history:] Using it for one typo'd protocol
+  would freeze the whole policy plane — wrong granularity. Rejected in
+  favor of per-rule fail-closed (§5.2)._
 
 ## 4''. Decision (v3 — CURRENT)
 
@@ -283,7 +292,9 @@ if proto == "" {
     return nil, false               // existing empty-protocol gate
 }
 // NEW: protocol must be representable by the Rust matcher.
-num, ok := dataplane.ProtocolNumber(proto)
+// (appid.ProtocolNumber — pkg/appid is the cycle-safe home; userspace
+//  imports appid directly. See §5''.1.)
+num, ok := appid.ProtocolNumber(proto)
 if !ok {
     return nil, false               // unrepresentable -> fail closed (refuse to arm)
 }

--- a/docs/pr/2124-protocol-failopen/plan.md
+++ b/docs/pr/2124-protocol-failopen/plan.md
@@ -1,6 +1,41 @@
 # #2124 — Policy application term with an unparseable named protocol fails OPEN to match-any
 
-**Status:** DRAFT v1 — pending adversarial plan review
+**Status:** DRAFT v2 — Codex r1 PLAN-NEEDS-MAJOR addressed; pending r2
+
+## v2 changelog (addresses Codex r1 PLAN-NEEDS-MAJOR)
+
+Codex r1 (task-mqn9wfro-ef9dsh) returned PLAN-NEEDS-MAJOR with three
+findings, all valid and verified against source:
+
+1. **`validateProtocol` is warning-only — the Go capability gate is
+   LOAD-BEARING, not optional.** v1 falsely claimed truly-unknown
+   protocols are already a hard commit error. They are NOT
+   (`compiler.go` appends a warning; `CommitCheck`/`store.go` never
+   promotes app-protocol warnings to errors; `parser_ast_test.go`
+   asserts warning-only). → Layer G (capability gate) is promoted to
+   the **PRIMARY** fix.
+2. **Action-blind `never_match` is NOT universally fail-closed.** A
+   malformed `deny`/`reject` rule that stops matching lets traffic fall
+   through to a later permit / default-permit. AND Rust drops terms for
+   bad PORTS too (port validation also warning-only), so a blanket
+   all-dropped guard would change standard-path behavior for invalid-
+   port deny rules. → Drop per-rule action-blind `never_match` as the
+   primary mechanism. Make the gate (action-agnostic whole-config
+   refuse-to-arm) primary; the Rust residual backstop uses a
+   whole-snapshot `SnapshotIntegrityError` (reject snapshot, keep
+   last-good) which is action-agnostic.
+3. **Duplicate protocol maps are a divergence hazard.** Go ALREADY has
+   complete named→number maps: `pkg/dataplane.protocolNumber`
+   (compiler.go:1196) and `pkg/appid.catalogProtocolNumber`
+   (catalog.go:128), both covering esp/ah/sctp/vrrp/igmp/pim/egp +
+   junos aliases. → Do NOT add a third map. Centralize via an exported
+   `(uint8, bool)` variant and reuse it; preserve numeric `0`.
+
+The v1 design below is superseded by §4'/§5' (primed sections). The
+original §4/§5 are retained for history but marked SUPERSEDED.
+
+---
+
 
 ## 1. Issue framing (in my words)
 
@@ -75,7 +110,153 @@ introduces a worse hazard", which IS a valid verdict.)*
   protocol would freeze the whole policy plane — wrong granularity.
   Rejected in favor of per-rule fail-closed (§5.2).
 
-## 4. Decision: which layer(s) fix it
+## 4'. Decision: which layer(s) fix it (v2 — PRIMED)
+
+Three layers, with the **Go capability gate as the PRIMARY,
+action-agnostic fix** (Codex r1 F1/F2):
+
+- **Layer G (Go capability gate — PRIMARY):** make
+  `expandUserspacePolicyApplications` (manager.go:1712) reject any
+  application term whose protocol OR ports the Rust matcher cannot
+  represent. Returning `ok=false` trips the EXISTING, deliberate
+  `userspaceSupportsSecurityPolicies → ForwardingSupported=false`
+  whole-config fail-closed gate (manager.go:1479,1556). This is
+  ACTION-AGNOSTIC: nothing arms, so both `permit` AND `deny` rules are
+  honored-or-nothing-forwards. There is no permit/deny asymmetry, no
+  fall-through, no over-match. It is also OPERATOR-VISIBLE (forwarding
+  refuses to arm — surfaced in status) rather than a silent per-rule
+  runtime outcome. For the protocols we now SUPPORT (esp/ah/sctp/...),
+  Layer G canonicalizes them to numeric strings the Rust matcher
+  already parses, so the gate stays `ok=true` and they WORK. Only
+  TRULY-unrepresentable terms (unknown protocol, malformed port) trip
+  the gate.
+
+- **Layer R (Rust — make the named set work + last-resort backstop):**
+  (a) extend `parse_protocol` to map the named IANA protocols to their
+  numbers, so a snapshot carrying a named protocol (e.g. an
+  un-canonicalized or hand-crafted snapshot, or a future direct path)
+  still matches correctly rather than fails open. (b) Backstop: if a
+  rule's `application_terms` are NON-empty but ALL drop as unparseable
+  (which Layer G should now prevent end-to-end), raise a
+  `SnapshotIntegrityError` so the whole snapshot is rejected and the
+  previous good state is kept (the existing preflight path,
+  snapshot_refresh.rs:69). This is ACTION-AGNOSTIC (no per-rule
+  permit/deny asymmetry) and never silently collapses a rule to
+  match-any. It only fires on a corrupt/inconsistent snapshot that
+  bypassed Layer G — a true integrity violation, the correct trigger
+  for that mechanism.
+
+- **Centralization (Codex r1 F3):** add an exported
+  `dataplane.ProtocolNumber(name string) (uint8, bool)` and refactor
+  the existing `protocolNumber` + `pkg/appid.catalogProtocolNumber` to
+  delegate to one source of truth, eliminating the divergence hazard.
+  Layer G uses it to canonicalize/validate. `ProtocolNumber` returns
+  `(n, true)` for a valid name OR a `0..255` numeric (INCLUDING `"0"` /
+  HOPOPT, preserving the deliberate-`protocol 0` case Codex flagged),
+  and `(0, false)` only for a genuinely unrepresentable token.
+
+- **Layer C (commit-time):** OUT OF SCOPE for the fix; documented as a
+  known property. `validateProtocol` already accepts the named set
+  (warning-only); with Layers G+R they now work end-to-end. A
+  truly-unknown protocol still warns at commit and then trips Layer G's
+  refuse-to-arm at apply — operator-visible at apply time. A stricter
+  commit-time hard reject (#1960 doctrine) is a reasonable follow-up
+  but is deferred (Q5) to keep this PR a focused security fix.
+
+## 5'. Concrete design (v2 — PRIMED)
+
+### 5'.1 Centralize the named→number map (`pkg/dataplane`)
+
+`pkg/dataplane/compiler.go` currently has `protocolNumber(name) uint8`
+returning `0` for BOTH unknown and `"0"`. Add:
+
+```go
+// ProtocolNumber resolves an IANA protocol name or numeric string to its
+// number. ok=false means the token is neither a known name nor a valid
+// 0..255 numeric (so 0/HOPOPT resolves to (0, true), distinct from the
+// unrepresentable (0, false) case).
+func ProtocolNumber(name string) (uint8, bool) { ... }
+```
+
+`protocolNumber` becomes `n, _ := ProtocolNumber(name); return n`
+(behavior-preserving). `pkg/appid.catalogProtocolNumber` is refactored
+to delegate to `dataplane.ProtocolNumber` (it mirrors the same table per
+its own doc comment) — eliminating the third copy. A parity test asserts
+the two former tables agree with the centralized one for the full named
+set + boundary numerics (0, 255, 256→false, ""→false).
+
+### 5'.2 Layer G: validate protocol AND ports in the capability gate
+
+In `expandUserspacePolicyApplications` (manager.go:1712), after
+resolving each application, validate representability BEFORE building the
+snapshot term:
+
+```go
+proto := normalizeUserspaceApplicationProtocol(app.Protocol)
+if proto == "" {
+    return nil, false               // existing empty-protocol gate
+}
+// NEW: protocol must be representable by the Rust matcher.
+num, ok := dataplane.ProtocolNumber(proto)
+if !ok {
+    return nil, false               // unrepresentable -> fail closed (refuse to arm)
+}
+// Canonicalize named protocols to their number so the wire snapshot is
+// always Rust-parseable (belt-and-suspenders for mixed-version helpers).
+proto = strconv.Itoa(int(num))
+// NEW: ports must parse the way the Rust parse_port_spec does.
+if !userspacePortSpecRepresentable(app.SourcePort) ||
+   !userspacePortSpecRepresentable(app.DestinationPort) {
+    return nil, false               // malformed port -> fail closed
+}
+```
+
+`userspacePortSpecRepresentable` mirrors Rust `parse_port_spec`
+(empty=ok; named service aliases http/https/...; single 1..65535;
+`low-high` with `low>0 && low<=high`). This closes the bad-PORT
+fail-open (Codex r1 F2) at the same action-agnostic gate.
+
+`normalizeUserspaceApplicationProtocol` keeps its `icmp6→icmpv6` mapping;
+the numeric canonicalization happens via `ProtocolNumber` above so we do
+NOT add a fourth named-protocol list to it.
+
+### 5'.3 Layer R(a): extend Rust `parse_protocol`
+
+Add named arms (numbers from `ip_proto.rs`, with new constants
+`PROTO_IGMP=2 PROTO_EGP=8 PROTO_AH=51 PROTO_PIM=103 PROTO_VRRP=112
+PROTO_SCTP=132`):
+
+```rust
+"esp" => Some(PROTO_ESP), "ah" => Some(PROTO_AH),
+"sctp" => Some(PROTO_SCTP), "vrrp" => Some(PROTO_VRRP),
+"igmp" => Some(PROTO_IGMP), "pim" => Some(PROTO_PIM),
+"egp" => Some(PROTO_EGP), "icmp6" => Some(PROTO_ICMPV6), // alias
+```
+
+Numeric `_ => parse::<u8>()` preserved (so `"0"`/`"132"` still parse).
+
+### 5'.4 Layer R(b): residual backstop via SnapshotIntegrityError
+
+`parse_applications` reports whether it had terms and dropped all of
+them. `parse_policy_state_with_counters` (the only constructor of rules,
+already returns `Result<_, SnapshotIntegrityError>`) raises a new
+`SnapshotIntegrityError::UnrepresentableApplicationProtocol { rule_id,
+protocol }` when a rule has NON-empty `application_terms` but ALL terms
+dropped. The preflight (snapshot_refresh.rs:69) already rejects the
+whole snapshot and keeps previous state on any integrity error — so a
+corrupt snapshot that slipped past Layer G fails closed action-
+agnostically instead of collapsing a rule to match-any.
+
+Genuine-empty `application_terms` (Junos `application any` / no
+`match application`) is UNCHANGED → match-any (correct). The default
+rule and `PolicyRule::default()` keep `match_any:true, never_match
+absent` — no new field on the hot struct; the integrity check lives in
+the parser, not in `matches()` (zero per-packet cost). This also means
+NO `matches()` signature/branch change and NO #2008-style per-rule flag
+— simpler than v1.
+
+### 4./5. (v1, SUPERSEDED — retained for history)
+
 
 Per the issue's "Suggested fix", BOTH complementary layers, because each
 covers a different failure mode and the defense-in-depth matches the
@@ -288,9 +469,50 @@ scope (Q5).
 | Performance regression | LOW | One extra `bool` branch in `matches()`; parse path is config-apply, not per-packet forward. |
 | Architectural mismatch | LOW | Directly mirrors the shipped #2008 `*_empty` fail-closed pattern — same author-intended design, same struct. Not a novel architecture. |
 
-## 9. Test plan
+## 9'. Test plan (v2 — PRIMED)
 
 Rust (`userspace-dp/src/policy_tests.rs`):
+- **Known named protocol now matches** — a rule with one term
+  `{protocol:"sctp", destination_port:"9999"}` permits SCTP/9999 and
+  DENIES TCP/443 (proves R(a), NOT match-any). Repeat for `esp`
+  (protocol-only, no port) → permits ESP, denies TCP. **Non-tautological:**
+  on pre-fix code the term drops → match-any → TCP/443 wrongly Permit.
+- **Numeric still parses** — `{protocol:"132"}` permits SCTP, denies TCP.
+- **All-dropped raises SnapshotIntegrityError** — a rule with NON-empty
+  `application_terms` all unparseable
+  (`{protocol:"definitely-not-a-proto"}`) makes
+  `parse_policy_state_with_counters` return
+  `Err(UnrepresentableApplicationProtocol{..})`. **Non-tautological:**
+  pre-fix it returns Ok with a match-any rule.
+- **Genuine-empty stays match-any (Ok)** — empty `application_terms`
+  parses Ok and match-anys (regression guard; default behavior).
+- **Mixed parseable+unparseable** — terms `[{esp},{bogus}]`: with R(a)
+  esp parses → ≥1 real term → Ok, NOT all-dropped, matches ESP. (The
+  bogus term still drops; rule is not all-dropped so no integrity
+  error — consistent with Layer G being the front-line reject.)
+- **`PolicyRule::default()` unchanged** — match-any preserved.
+- `cargo test --release` green; 5/5 flake on the new integrity-error
+  test.
+
+Go (`pkg/dataplane/`, `pkg/dataplane/userspace/`, `pkg/appid/`):
+- **`ProtocolNumber` parity** — for the full named set + junos aliases,
+  `ProtocolNumber` agrees with the old `protocolNumber` and
+  `catalogProtocolNumber`; `("0")→(0,true)`, `("256")→(0,false)`,
+  `("")→(0,false)`, `("bogus")→(0,false)`.
+- **Gate fails closed on unknown protocol** — an app with protocol
+  `"bogus"` → `expandUserspacePolicyApplications` returns `ok=false` →
+  `userspaceSupportsSecurityPolicies` false → `ForwardingSupported`
+  false. **Non-tautological:** pre-fix `ok=true`.
+- **Gate fails closed on malformed port** — app with
+  `DestinationPort:"99999"` (or `"5-1"`) → `ok=false`.
+- **Gate canonicalizes + accepts named protocol** — app with `esp` →
+  `ok=true`, emitted snapshot term Protocol == `"50"`.
+- **Existing working configs unchanged** — tcp/udp/icmp/gre/ospf +
+  numeric still `ok=true`.
+- `go test ./pkg/dataplane/... ./pkg/appid/... ./pkg/config/...` green.
+
+### 9. (v1, SUPERSEDED)
+
 1. **Known named protocol now matches** — a permit rule with one
    application term `{protocol:"sctp", destination_port:"9999"}` permits
    SCTP/9999 and DENIES TCP/443 (proves R(a) + that it is NOT match-any).

--- a/docs/userspace-dataplane-gaps.md
+++ b/docs/userspace-dataplane-gaps.md
@@ -67,7 +67,7 @@ final-validation artifact set are closed. The explicit gates live in
 
 | Feature/config shape | Userspace status | Tracker / disposition |
 |----------------------|-------------|--------------------|
-| Unsupported policy shapes | Gated | Address/application expansion must succeed for userspace |
+| Unsupported policy shapes | Gated | Address/application expansion must succeed for userspace. #2124: an application term whose protocol the matcher cannot represent (sctp/esp/ah/vrrp/igmp/pim/egp now parse and are canonicalized to their IANA number; anything else, or a malformed port, is unrepresentable) fails the capability gate (`expandUserspacePolicyApplications` -> `ForwardingSupported=false`, refuse-to-arm) rather than collapsing the rule to match-any. On a failed expansion the daemon emits a reserved `__unsupported__` sentinel term so the Rust matcher rejects the whole snapshot via `SnapshotIntegrityError` (keeping the previous good state) — an action-agnostic fail-closed that never turns a permit into match-any nor a deny into a pass, closing the publish-before-disarm window. |
 | Screen behavior requiring SYN cookies | Supported | Closed feature-gap (#1374); #1477 final validation closed |
 | HA with per-pool source NAT `persistent-nat` | Gated | Closed/documented contract: helper-memory persistent-NAT leases are not HA-synchronized, so HA configs that reference persistent source-NAT pools are not admitted |
 | Port mirroring | Supported | Closed feature-gap (#1376); #1477 final validation closed |

--- a/pkg/appid/catalog.go
+++ b/pkg/appid/catalog.go
@@ -122,45 +122,69 @@ func BuildCatalog(cfg *config.Config) (Catalog, error) {
 	return cat, nil
 }
 
-// catalogProtocolNumber mirrors pkg/dataplane.protocolNumber so the catalog's
-// protocol byte matches what the legacy compiler used. Kept private to pkg/appid
-// to avoid an import cycle with pkg/dataplane.
-func catalogProtocolNumber(name string) uint8 {
-	switch strings.ToLower(name) {
+// ProtocolNumber is the single source of truth (#2124) for resolving an IANA
+// protocol name, a Junos predefined-protocol alias, or a numeric string to its
+// IANA protocol number. It is the centralized replacement for the formerly
+// duplicated tables in pkg/appid (catalogProtocolNumber) and pkg/dataplane
+// (protocolNumber); both now delegate here so the userspace policy capability
+// gate, the legacy compiler, and the app-identification catalog agree on
+// exactly which protocols are representable.
+//
+// ok=false means the token is neither a known name/alias nor a valid 0..255
+// numeric. Crucially, the deliberate "protocol 0" (HOPOPT) resolves to
+// (0, true) — distinct from the unrepresentable (0, false) case — so callers
+// that fail closed on unrepresentable protocols (#2124 Layer G) do not also
+// reject a legitimate "protocol 0".
+//
+// pkg/appid is a leaf package (imports only pkg/config), so housing the helper
+// here keeps it importable by both pkg/dataplane (which already imports
+// pkg/appid) and pkg/dataplane/userspace without an import cycle.
+func ProtocolNumber(name string) (uint8, bool) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
 	case "tcp", "junos-tcp-any":
-		return 6
+		return 6, true
 	case "udp", "junos-udp-any":
-		return 17
+		return 17, true
 	case "icmp", "junos-icmp-all", "junos-ping":
-		return 1
+		return 1, true
 	case "icmpv6", "icmp6", "junos-icmp6-all", "junos-pingv6":
-		return 58
+		return 58, true
 	case "gre", "junos-gre":
-		return 47
+		return 47, true
 	case "ospf", "junos-ospf":
-		return 89
+		return 89, true
 	case "junos-ip-in-ip", "junos-ipip", "ipip":
-		return 4
+		return 4, true
 	case "egp":
-		return 8
+		return 8, true
 	case "igmp":
-		return 2
+		return 2, true
 	case "pim":
-		return 103
+		return 103, true
 	case "ah":
-		return 51
+		return 51, true
 	case "esp":
-		return 50
+		return 50, true
 	case "sctp":
-		return 132
+		return 132, true
 	case "vrrp":
-		return 112
+		return 112, true
 	default:
-		if n, err := strconv.Atoi(name); err == nil && n > 0 && n < 256 {
-			return uint8(n)
+		// Numeric protocol number, including the deliberate "0" (HOPOPT).
+		if n, err := strconv.Atoi(strings.TrimSpace(name)); err == nil && n >= 0 && n < 256 {
+			return uint8(n), true
 		}
-		return 0
+		return 0, false
 	}
+}
+
+// catalogProtocolNumber resolves a protocol to its byte for the app-id catalog,
+// returning 0 for an unrepresentable token (the catalog's historical
+// "unknown -> 0" behavior). Delegates to ProtocolNumber (#2124) so the catalog
+// and the capability gate share one table.
+func catalogProtocolNumber(name string) uint8 {
+	n, _ := ProtocolNumber(name)
+	return n
 }
 
 // parsePortRange mirrors pkg/dataplane.parsePortRange. Inclusive boundaries;

--- a/pkg/appid/protocol_number_2124_test.go
+++ b/pkg/appid/protocol_number_2124_test.go
@@ -1,0 +1,68 @@
+package appid
+
+import "testing"
+
+// #2124 — ProtocolNumber is the single source of truth for resolving a protocol
+// name/alias/numeric string to its IANA number. These tests pin the table the
+// userspace policy capability gate relies on to fail closed, and prove the
+// (0, true) / (0, false) distinction that preserves a deliberate "protocol 0".
+
+func TestProtocolNumberNamedSet(t *testing.T) {
+	cases := map[string]uint8{
+		"tcp": 6, "udp": 17, "icmp": 1, "icmpv6": 58, "icmp6": 58,
+		"gre": 47, "ospf": 89, "ipip": 4,
+		"esp": 50, "ah": 51, "sctp": 132, "vrrp": 112,
+		"igmp": 2, "pim": 103, "egp": 8,
+		// Junos predefined aliases.
+		"junos-tcp-any": 6, "junos-udp-any": 17, "junos-icmp-all": 1,
+		"junos-ping": 1, "junos-icmp6-all": 58, "junos-pingv6": 58,
+		"junos-gre": 47, "junos-ospf": 89, "junos-ip-in-ip": 4, "junos-ipip": 4,
+		// Case-insensitive.
+		"ESP": 50, "Sctp": 132,
+	}
+	for name, want := range cases {
+		got, ok := ProtocolNumber(name)
+		if !ok || got != want {
+			t.Errorf("ProtocolNumber(%q) = (%d, %v), want (%d, true)", name, got, ok, want)
+		}
+	}
+}
+
+func TestProtocolNumberNumericAndProtocolZero(t *testing.T) {
+	if n, ok := ProtocolNumber("0"); !ok || n != 0 {
+		t.Errorf("ProtocolNumber(\"0\") = (%d, %v), want (0, true) — protocol 0/HOPOPT must be representable", n, ok)
+	}
+	if n, ok := ProtocolNumber("255"); !ok || n != 255 {
+		t.Errorf("ProtocolNumber(\"255\") = (%d, %v), want (255, true)", n, ok)
+	}
+	if n, ok := ProtocolNumber("132"); !ok || n != 132 {
+		t.Errorf("ProtocolNumber(\"132\") = (%d, %v), want (132, true)", n, ok)
+	}
+}
+
+func TestProtocolNumberUnrepresentable(t *testing.T) {
+	for _, name := range []string{"", "256", "-1", "bogus", "definitely-not-a-proto", "__unsupported__", "0x50"} {
+		if n, ok := ProtocolNumber(name); ok {
+			t.Errorf("ProtocolNumber(%q) = (%d, true), want ok=false (unrepresentable)", name, n)
+		}
+	}
+}
+
+// TestProtocolNumberParityWithCatalog ensures the catalog's protocol byte
+// (catalogProtocolNumber) is exactly the uint8 of ProtocolNumber, so the
+// app-id catalog and the capability gate never diverge (#2124 F3).
+func TestProtocolNumberParityWithCatalog(t *testing.T) {
+	names := []string{
+		"tcp", "udp", "icmp", "icmpv6", "gre", "ospf", "ipip",
+		"esp", "ah", "sctp", "vrrp", "igmp", "pim", "egp",
+		"junos-tcp-any", "junos-udp-any", "junos-icmp-all", "junos-icmp6-all",
+		"junos-gre", "junos-ospf", "junos-ip-in-ip",
+		"0", "1", "47", "132", "255", "256", "", "bogus",
+	}
+	for _, name := range names {
+		want, _ := ProtocolNumber(name)
+		if got := catalogProtocolNumber(name); got != want {
+			t.Errorf("catalogProtocolNumber(%q) = %d, ProtocolNumber = %d (divergence)", name, got, want)
+		}
+	}
+}

--- a/pkg/appid/runtime.go
+++ b/pkg/appid/runtime.go
@@ -164,22 +164,12 @@ func matchTuple(proto uint8, dstPort uint16, appProto, appPort string) bool {
 	return err == nil && uint16(v) == dstPort
 }
 
+// protocolNumber resolves a protocol token for app-id runtime tuple matching.
+// #2124: delegates to the centralized ProtocolNumber so this path agrees with
+// the policy capability gate and the catalog table on the full named set
+// (previously this copy recognized only tcp/udp/icmp/icmpv6/gre by name, so a
+// user-defined esp/ah/sctp application could never name-match here). The
+// (uint8, bool) contract is preserved.
 func protocolNumber(proto string) (uint8, bool) {
-	switch strings.ToLower(proto) {
-	case "tcp":
-		return 6, true
-	case "udp":
-		return 17, true
-	case "icmp":
-		return 1, true
-	case "icmpv6":
-		return 58, true
-	case "gre":
-		return 47, true
-	}
-	v, err := strconv.Atoi(proto)
-	if err != nil || v < 0 || v > 255 {
-		return 0, false
-	}
-	return uint8(v), true
+	return ProtocolNumber(proto)
 }

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -1193,47 +1193,14 @@ func rethConfigAddrs(ifCfg *config.InterfaceConfig) (v4, v6 []net.IP) {
 // protocolNumber converts a protocol name to its IANA number.
 // Handles standard names (tcp, udp, icmp), Junos predefined protocol
 // aliases (junos-icmp-all, junos-tcp-any, etc.), and numeric values.
+//
+// #2124: delegates to the centralized appid.ProtocolNumber so the legacy
+// compiler, the app-identification catalog, and the userspace policy
+// capability gate share one source of truth. Returns 0 for an
+// unrepresentable token (the legacy "unknown -> 0" behavior).
 func protocolNumber(name string) uint8 {
-	switch strings.ToLower(name) {
-	case "tcp":
-		return 6
-	case "udp":
-		return 17
-	case "icmp", "junos-icmp-all", "junos-ping":
-		return 1
-	case "icmpv6", "icmp6", "junos-icmp6-all", "junos-pingv6":
-		return 58
-	case "gre", "junos-gre":
-		return 47
-	case "ospf", "junos-ospf":
-		return 89
-	case "junos-tcp-any":
-		return 6
-	case "junos-udp-any":
-		return 17
-	case "junos-ip-in-ip", "junos-ipip", "ipip":
-		return 4
-	case "egp":
-		return 8
-	case "igmp":
-		return 2
-	case "pim":
-		return 103
-	case "ah":
-		return 51
-	case "esp":
-		return 50
-	case "sctp":
-		return 132
-	case "vrrp":
-		return 112
-	default:
-		// Try numeric protocol number
-		if n, err := strconv.Atoi(name); err == nil && n > 0 && n < 256 {
-			return uint8(n)
-		}
-		return 0
-	}
+	n, _ := appid.ProtocolNumber(name)
+	return n
 }
 
 // algTypeFromString maps an ALG name to its BPF constant (0=none, 1=FTP, 2=SIP, 3=DNS).

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -693,29 +693,8 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 		snap.DeferWorkers = true
 	}
 	var status ProcessStatus
-	// #2124: when THIS config's capabilities forbid forwarding (e.g. a policy
-	// names an application the userspace matcher cannot represent), disarm the
-	// helper BEFORE publishing the snapshot. A current-version helper would
-	// reject the snapshot's `__unsupported__` sentinel via the integrity
-	// preflight, but an OLDER same-protocol-version helper that predates that
-	// preflight would silently drop the sentinel term and could process the
-	// resulting match-any rule with forwarding still armed in the window before
-	// the post-publish syncDesiredForwardingStateLocked() disarm. Disarming
-	// first closes that window for every helper version. We gate on the freshly
-	// computed caps (not m.lastStatus, which still reflects the prior good
-	// config) and only act when the helper currently believes it is armed.
-	if !caps.ForwardingSupported && m.proc != nil && m.proc.Process != nil &&
-		m.lastStatus.ForwardingArmed {
-		var disarmStatus ProcessStatus
-		if derr := m.requestLocked(ControlRequest{
-			Type:       "set_forwarding_state",
-			Forwarding: &ForwardingControlRequest{Armed: false},
-		}, &disarmStatus); derr != nil {
-			return result, fmt.Errorf("disarm userspace forwarding before unsupported-config publish: %w", derr)
-		}
-		if aerr := m.applyHelperStatusLocked(&disarmStatus); aerr != nil {
-			return result, fmt.Errorf("sync helper status after pre-publish disarm: %w", aerr)
-		}
+	if err := m.disarmBeforeUnsupportedPublishLocked(snap.Config); err != nil {
+		return result, err
 	}
 	// #1197 v5 (Codex code-review v4 #2): apply_snapshot must
 	// send publishable-only neighbors to match the
@@ -835,6 +814,12 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 	publishSnap := next
 	publishSnap.Neighbors = filterPublishableNeighbors(next.Neighbors)
 	var status ProcessStatus
+	// #2124: disarm before publishing an unsupported-config snapshot (see
+	// disarmBeforeUnsupportedPublishLocked). cfg is this snapshot's config.
+	if err := m.disarmBeforeUnsupportedPublishLocked(cfg); err != nil {
+		slog.Warn("userspace: failed to disarm before unsupported-config policy scheduler publish", "err", err)
+		return
+	}
 	if err := m.requestLocked(ControlRequest{Type: "apply_snapshot", Snapshot: &publishSnap}, &status); err != nil {
 		slog.Warn("userspace: failed to publish policy scheduler state", "err", err)
 		return
@@ -991,6 +976,10 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 	publishSnap := next
 	publishSnap.Neighbors = filterPublishableNeighbors(next.Neighbors)
 	var status ProcessStatus
+	// #2124: disarm before publishing an unsupported-config snapshot.
+	if err := m.disarmBeforeUnsupportedPublishLocked(next.Config); err != nil {
+		return false, err
+	}
 	if err := m.requestLocked(ControlRequest{Type: "apply_snapshot", Snapshot: &publishSnap}, &status); err != nil {
 		return false, fmt.Errorf("publish route overlay snapshot: %w", err)
 	}
@@ -1769,13 +1758,17 @@ func expandUserspacePolicyApplications(cfg *config.Config, apps []string) ([]Pol
 			if !ok {
 				return nil, false
 			}
-			// Canonicalize ONLY the named protocols that the Rust matcher could
-			// not parse before this fix (esp/ah/sctp/vrrp/igmp/pim/egp) to their
-			// IANA number, so a mixed-version helper that predates the new
-			// parse_protocol arms still parses them. Protocols the matcher has
-			// always understood (tcp/udp/icmp/icmpv6/gre/ospf/ipip + numeric)
-			// are left as-is to avoid churning the wire form (and the snapshot
-			// hash) for every existing policy.
+			// Canonicalize to the IANA number any protocol token the Rust
+			// matcher could NOT parse before this fix — i.e. anything
+			// `rustParsedProtocolBeforeFix` returns false for. In practice that
+			// is the newly-supported named set (esp/ah/sctp/vrrp/igmp/pim/egp),
+			// but it also covers any other appid-resolvable token outside the
+			// pre-fix set (e.g. a junos-* alias such as junos-ospf, were one to
+			// reach this path) so a mixed-version helper that predates the new
+			// parse_protocol arms still parses it. Tokens the matcher has always
+			// understood (tcp/udp/icmp/icmpv6/gre/ospf/ipip + bare numeric) are
+			// left as-is to avoid churning the wire form (and the snapshot hash)
+			// for every existing policy.
 			if !rustParsedProtocolBeforeFix(proto) {
 				proto = strconv.Itoa(int(num))
 			}

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -1845,11 +1845,16 @@ func rustParsedProtocolBeforeFix(proto string) bool {
 // the rule to match-any (the same fail-open this fix closes). Empty means "no
 // port constraint" (ok); known service aliases resolve to a single port; a bare
 // number must be 1..65535; a low-high range needs low > 0 && low <= high.
+//
+// The service-alias match is CASE-SENSITIVE on the raw spec, mirroring Rust
+// `parse_port_spec` exactly (it matches `"http"` literally and does NOT
+// lowercase). Lowercasing here would accept e.g. "HTTP" that Rust would reject
+// and then drop — the precise mismatch that reopens the fail-open.
 func userspacePortSpecRepresentable(spec string) bool {
 	if spec == "" {
 		return true
 	}
-	switch strings.ToLower(spec) {
+	switch spec {
 	case "http", "https", "ssh", "telnet", "ftp", "ftp-data", "smtp",
 		"dns", "pop3", "imap", "snmp", "ntp", "bgp", "ldap", "syslog":
 		return true

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -18,6 +19,7 @@ import (
 
 	"net/netip"
 
+	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpruntime "github.com/psaab/xpf/pkg/dataplane/runtime"
@@ -1732,6 +1734,34 @@ func expandUserspacePolicyApplications(cfg *config.Config, apps []string) ([]Pol
 			if proto == "" {
 				return nil, false
 			}
+			// #2124: fail closed on any protocol the Rust matcher cannot
+			// represent. Returning ok=false trips the existing
+			// ForwardingSupported=false refuse-to-arm gate
+			// (userspaceSupportsSecurityPolicies). Without this a named
+			// protocol like esp/ah/sctp (accepted at commit, only lowercased
+			// here) reaches the matcher, gets dropped, and the rule collapses
+			// to match-any — permitting ALL traffic for the zone pair.
+			num, ok := appid.ProtocolNumber(proto)
+			if !ok {
+				return nil, false
+			}
+			// Canonicalize ONLY the named protocols that the Rust matcher could
+			// not parse before this fix (esp/ah/sctp/vrrp/igmp/pim/egp) to their
+			// IANA number, so a mixed-version helper that predates the new
+			// parse_protocol arms still parses them. Protocols the matcher has
+			// always understood (tcp/udp/icmp/icmpv6/gre/ospf/ipip + numeric)
+			// are left as-is to avoid churning the wire form (and the snapshot
+			// hash) for every existing policy.
+			if !rustParsedProtocolBeforeFix(proto) {
+				proto = strconv.Itoa(int(num))
+			}
+			// #2124: ports must parse the way the Rust parse_port_spec does;
+			// a malformed port would otherwise drop the term and collapse the
+			// rule to match-any (the same fail-open as the protocol case).
+			if !userspacePortSpecRepresentable(app.SourcePort) ||
+				!userspacePortSpecRepresentable(app.DestinationPort) {
+				return nil, false
+			}
 			snap := PolicyApplicationSnapshot{
 				Name:            resolvedName,
 				Protocol:        proto,
@@ -1786,6 +1816,57 @@ func normalizeUserspaceApplicationProtocol(proto string) string {
 	default:
 		return strings.ToLower(strings.TrimSpace(proto))
 	}
+}
+
+// rustParsedProtocolBeforeFix reports whether the Rust dataplane's
+// parse_protocol recognized this protocol token PRIOR to #2124 (the named arms
+// {tcp,udp,icmp,icmpv6,gre,ospf,ipip} plus any pure-numeric token). Such tokens
+// are emitted on the wire unchanged so existing policy snapshots keep their
+// current protocol string (and hash); only the newly-supported named protocols
+// are canonicalized to their number for old-helper compatibility. `proto` is
+// already lowercased by normalizeUserspaceApplicationProtocol.
+func rustParsedProtocolBeforeFix(proto string) bool {
+	switch proto {
+	case "tcp", "udp", "icmp", "icmpv6", "gre", "ospf", "ipip":
+		return true
+	}
+	// A bare numeric token (e.g. "132") was always parsed by parse_protocol's
+	// numeric fallback.
+	if _, err := strconv.ParseUint(proto, 10, 8); err == nil {
+		return true
+	}
+	return false
+}
+
+// userspacePortSpecRepresentable reports whether a policy application port spec
+// parses the way the Rust dataplane's parse_port_spec does (#2124). It must stay
+// in lock-step with userspace-dp/src/policy.rs::parse_port_spec, because a spec
+// this gate accepts but Rust rejects would silently drop the term and collapse
+// the rule to match-any (the same fail-open this fix closes). Empty means "no
+// port constraint" (ok); known service aliases resolve to a single port; a bare
+// number must be 1..65535; a low-high range needs low > 0 && low <= high.
+func userspacePortSpecRepresentable(spec string) bool {
+	if spec == "" {
+		return true
+	}
+	switch strings.ToLower(spec) {
+	case "http", "https", "ssh", "telnet", "ftp", "ftp-data", "smtp",
+		"dns", "pop3", "imap", "snmp", "ntp", "bgp", "ldap", "syslog":
+		return true
+	}
+	if low, high, found := strings.Cut(spec, "-"); found {
+		l, errL := strconv.ParseUint(low, 10, 16)
+		h, errH := strconv.ParseUint(high, 10, 16)
+		if errL != nil || errH != nil {
+			return false
+		}
+		return l != 0 && l <= h
+	}
+	p, err := strconv.ParseUint(spec, 10, 16)
+	if err != nil {
+		return false
+	}
+	return p != 0
 }
 
 func userspaceSupportsSourceNAT(ruleSets []*config.NATRuleSet) bool {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -693,6 +693,30 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 		snap.DeferWorkers = true
 	}
 	var status ProcessStatus
+	// #2124: when THIS config's capabilities forbid forwarding (e.g. a policy
+	// names an application the userspace matcher cannot represent), disarm the
+	// helper BEFORE publishing the snapshot. A current-version helper would
+	// reject the snapshot's `__unsupported__` sentinel via the integrity
+	// preflight, but an OLDER same-protocol-version helper that predates that
+	// preflight would silently drop the sentinel term and could process the
+	// resulting match-any rule with forwarding still armed in the window before
+	// the post-publish syncDesiredForwardingStateLocked() disarm. Disarming
+	// first closes that window for every helper version. We gate on the freshly
+	// computed caps (not m.lastStatus, which still reflects the prior good
+	// config) and only act when the helper currently believes it is armed.
+	if !caps.ForwardingSupported && m.proc != nil && m.proc.Process != nil &&
+		m.lastStatus.ForwardingArmed {
+		var disarmStatus ProcessStatus
+		if derr := m.requestLocked(ControlRequest{
+			Type:       "set_forwarding_state",
+			Forwarding: &ForwardingControlRequest{Armed: false},
+		}, &disarmStatus); derr != nil {
+			return result, fmt.Errorf("disarm userspace forwarding before unsupported-config publish: %w", derr)
+		}
+		if aerr := m.applyHelperStatusLocked(&disarmStatus); aerr != nil {
+			return result, fmt.Errorf("sync helper status after pre-publish disarm: %w", aerr)
+		}
+	}
 	// #1197 v5 (Codex code-review v4 #2): apply_snapshot must
 	// send publishable-only neighbors to match the
 	// update_neighbors path. Otherwise Rust's full-snapshot

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -378,6 +378,48 @@ func (m *Manager) configHasDataRGLocked() bool {
 	return false
 }
 
+// disarmBeforeUnsupportedPublishLocked disarms helper forwarding BEFORE a full
+// apply_snapshot publish when the snapshot's config capabilities forbid
+// forwarding (#2124). A policy that names an application the userspace matcher
+// cannot represent makes deriveUserspaceCapabilities return
+// ForwardingSupported=false, and buildOneRuleSnapshot emits a `__unsupported__`
+// sentinel term. A current-version helper rejects that sentinel via its
+// integrity preflight, but an OLDER same-protocol-version helper that predates
+// the preflight would silently drop the sentinel and could process the
+// resulting match-any rule with forwarding still armed in the window before the
+// post-publish syncDesiredForwardingStateLocked() disarm — including via the
+// XSK-startup deferred same-plan publish path (process.go), which publishes
+// independently of Compile(). Disarming first, at EVERY full publish site,
+// closes that window for every helper version.
+//
+// caps are derived from the snapshot's own config (not m.lastStatus, which
+// still reflects the prior good config). The disarm is issued only when a
+// running helper currently believes it is armed, so steady-state supported
+// configs take no extra control round-trip. The post-publish desired-state
+// sync still reconciles the final state.
+func (m *Manager) disarmBeforeUnsupportedPublishLocked(cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if m.proc == nil || m.proc.Process == nil || !m.lastStatus.ForwardingArmed {
+		return nil
+	}
+	if deriveUserspaceCapabilities(cfg).ForwardingSupported {
+		return nil
+	}
+	var status ProcessStatus
+	if err := m.requestLocked(ControlRequest{
+		Type:       "set_forwarding_state",
+		Forwarding: &ForwardingControlRequest{Armed: false},
+	}, &status); err != nil {
+		return fmt.Errorf("disarm userspace forwarding before unsupported-config publish: %w", err)
+	}
+	if err := m.applyHelperStatusLocked(&status); err != nil {
+		return fmt.Errorf("sync helper status after pre-publish disarm: %w", err)
+	}
+	return nil
+}
+
 func (m *Manager) syncDesiredForwardingStateLocked() error {
 	if m.proc == nil || m.proc.Process == nil {
 		return nil

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -13,6 +13,15 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
+// unsupportedApplicationSentinel is the reserved protocol/name token emitted in
+// a policy rule's application terms (#2124) when the userspace matcher cannot
+// represent the rule's configured applications. It is deliberately not a valid
+// protocol name or 0..255 numeric, so the Rust matcher drops it and the rule's
+// all-dropped non-empty term list is rejected as a SnapshotIntegrityError
+// (fail closed) instead of decoding to genuine match-any. Must stay unparseable
+// by both appid.ProtocolNumber and userspace-dp parse_protocol.
+const unsupportedApplicationSentinel = "__unsupported__"
+
 func buildPolicySnapshots(cfg *config.Config) []PolicyRuleSnapshot {
 	return buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, nil)
 }
@@ -84,7 +93,20 @@ func buildOneRuleSnapshot(
 	}
 	applicationTerms, ok := expandUserspacePolicyApplications(cfg, pol.Match.Applications)
 	if !ok {
-		applicationTerms = nil
+		// #2124: the rule cites application terms the userspace matcher cannot
+		// honor (unrepresentable protocol or port). Emit a reserved unparseable
+		// sentinel term instead of nil. nil would decode on the Rust side as
+		// GENUINE match-any (no application constraint), so even though the
+		// capability gate sets ForwardingSupported=false the published snapshot
+		// could fail OPEN in the window before the helper is disarmed (and on a
+		// same-plan refresh). The sentinel makes Rust drop the only term, see
+		// an all-dropped non-empty term list, and reject the WHOLE snapshot via
+		// SnapshotIntegrityError (keeping the previous good state) — an
+		// action-agnostic fail-closed for both permit and deny rules.
+		applicationTerms = []PolicyApplicationSnapshot{{
+			Name:     unsupportedApplicationSentinel,
+			Protocol: unsupportedApplicationSentinel,
+		}}
 	}
 	// #1606 v3 fields: classify each address token as "named book
 	// reference" vs "free-form literal".
@@ -482,8 +504,9 @@ func sortV6CIDRs(s []string) {
 // framing (Codex r3 F4 fix).
 //
 // Layout:
-//   "V4" || u32_be(len(v4)) || (for each: u8(prefix_len) || u32_be(addr_bytes))
-//   "V6" || u32_be(len(v6)) || (for each: u8(prefix_len) || u128_be(addr_bytes))
+//
+//	"V4" || u32_be(len(v4)) || (for each: u8(prefix_len) || u32_be(addr_bytes))
+//	"V6" || u32_be(len(v6)) || (for each: u8(prefix_len) || u128_be(addr_bytes))
 //
 // CIDR strings that fail to parse are skipped (defensive).
 func canonicalizeAddressBookContent(v4, v6 []string) []byte {

--- a/pkg/dataplane/userspace/process.go
+++ b/pkg/dataplane/userspace/process.go
@@ -352,6 +352,14 @@ func (m *Manager) syncSnapshotLocked() error {
 		}
 		return err
 	}
+	// #2124: this is the XSK-startup deferred same-plan publish path, which
+	// publishes apply_snapshot independently of Compile(). Disarm before
+	// publishing an unsupported-config snapshot here too, so an old
+	// same-protocol-version helper that drops the `__unsupported__` sentinel
+	// cannot process the resulting match-any rule while still armed.
+	if err := m.disarmBeforeUnsupportedPublishLocked(publishSnap.Config); err != nil {
+		return err
+	}
 	var status ProcessStatus
 	if err := m.requestLocked(ControlRequest{Type: "apply_snapshot", Snapshot: &publishSnap}, &status); err != nil {
 		return fmt.Errorf("publish userspace snapshot: %w", err)

--- a/pkg/dataplane/userspace/protocol_failopen_2124_test.go
+++ b/pkg/dataplane/userspace/protocol_failopen_2124_test.go
@@ -1,7 +1,13 @@
 package userspace
 
 import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -143,4 +149,113 @@ func TestUserspacePortSpecRepresentableMirrorsRust(t *testing.T) {
 			t.Errorf("userspacePortSpecRepresentable(%q) = true, want false", s)
 		}
 	}
+}
+
+// recordingControlServer accepts control requests, records them, and replies OK
+// with an enabled+forwarding-armed status so applyHelperStatusLocked succeeds.
+func recordingControlServer(t *testing.T) (string, chan ControlRequest) {
+	t.Helper()
+	// Use a short os.MkdirTemp path (NOT t.TempDir(), whose long subtest-named
+	// path can exceed the ~108-char unix sun_path limit -> bind: invalid arg).
+	dir, err := os.MkdirTemp("", "xpf2124")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "c.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	reqCh := make(chan ControlRequest, 8)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req ControlRequest
+			if err := json.NewDecoder(conn).Decode(&req); err == nil {
+				reqCh <- req
+				_ = json.NewEncoder(conn).Encode(ControlResponse{
+					OK:     true,
+					Status: &ProcessStatus{Enabled: true, ForwardingArmed: false},
+				})
+			}
+			conn.Close()
+		}
+	}()
+	return sock, reqCh
+}
+
+func TestDisarmBeforeUnsupportedPublishLocked(t *testing.T) {
+	t.Run("unsupported config disarms before publish", func(t *testing.T) {
+		sock, reqCh := recordingControlServer(t)
+		m := New()
+		m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+		m.cfg.ControlSocket = sock
+		m.lastStatus.ForwardingArmed = true
+		// A policy naming an unrepresentable-protocol application -> caps say
+		// ForwardingSupported=false.
+		cfg := twoZonePolicyCfg(&config.Application{Name: "weird", Protocol: "definitely-not-a-proto"}, "weird")
+		// The disarm CONTROL REQUEST is the security-critical behavior under
+		// test. applyHelperStatusLocked touches a BPF map that is absent in a
+		// unit test ("userspace_ctrl map not loaded"), so the function may
+		// return that local-bookkeeping error AFTER the wire disarm succeeds;
+		// that env artifact must not mask the assertion that the disarm was
+		// actually issued.
+		_ = m.disarmBeforeUnsupportedPublishLocked(cfg)
+		select {
+		case req := <-reqCh:
+			if req.Type != "set_forwarding_state" || req.Forwarding == nil || req.Forwarding.Armed {
+				t.Fatalf("got request %+v, want set_forwarding_state{Armed:false}", req)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("no disarm request sent for unsupported config")
+		}
+	})
+
+	t.Run("supported config does not disarm", func(t *testing.T) {
+		sock, reqCh := recordingControlServer(t)
+		m := New()
+		m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+		m.cfg.ControlSocket = sock
+		m.lastStatus.ForwardingArmed = true
+		cfg := twoZonePolicyCfg(&config.Application{Name: "esp-only", Protocol: "esp"}, "esp-only")
+		if err := m.disarmBeforeUnsupportedPublishLocked(cfg); err != nil {
+			t.Fatalf("disarmBeforeUnsupportedPublishLocked: %v", err)
+		}
+		select {
+		case req := <-reqCh:
+			t.Fatalf("unexpected control request for supported config: %+v", req)
+		case <-time.After(200 * time.Millisecond):
+		}
+	})
+
+	t.Run("no helper is a no-op", func(t *testing.T) {
+		m := New()
+		m.lastStatus.ForwardingArmed = true
+		cfg := twoZonePolicyCfg(&config.Application{Name: "weird", Protocol: "definitely-not-a-proto"}, "weird")
+		if err := m.disarmBeforeUnsupportedPublishLocked(cfg); err != nil {
+			t.Fatalf("disarmBeforeUnsupportedPublishLocked with no helper: %v", err)
+		}
+	})
+
+	t.Run("already disarmed is a no-op", func(t *testing.T) {
+		sock, reqCh := recordingControlServer(t)
+		m := New()
+		m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+		m.cfg.ControlSocket = sock
+		m.lastStatus.ForwardingArmed = false
+		cfg := twoZonePolicyCfg(&config.Application{Name: "weird", Protocol: "definitely-not-a-proto"}, "weird")
+		if err := m.disarmBeforeUnsupportedPublishLocked(cfg); err != nil {
+			t.Fatalf("disarmBeforeUnsupportedPublishLocked: %v", err)
+		}
+		select {
+		case req := <-reqCh:
+			t.Fatalf("unexpected control request when already disarmed: %+v", req)
+		case <-time.After(200 * time.Millisecond):
+		}
+	})
 }

--- a/pkg/dataplane/userspace/protocol_failopen_2124_test.go
+++ b/pkg/dataplane/userspace/protocol_failopen_2124_test.go
@@ -1,0 +1,140 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2124 — a policy application term whose named protocol the Rust matcher could
+// not parse (sctp/esp/ah/vrrp/igmp/pim/egp) silently failed OPEN to match-any.
+// These tests pin the Go-side defenses: the capability gate fails closed on an
+// unrepresentable protocol/port, canonicalizes the supported named protocols to
+// their numeric wire form, and emits the __unsupported__ fail-closed sentinel
+// (never nil) on a failed expansion so the published snapshot cannot fail open.
+
+func twoZonePolicyCfg(app *config.Application, appName string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.DefaultPolicy = config.PolicyDeny
+	cfg.Applications.Applications = map[string]*config.Application{app.Name: app}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"lan": {Name: "lan", Interfaces: []string{"reth1"}},
+		"wan": {Name: "wan", Interfaces: []string{"reth0.80"}},
+	}
+	cfg.Security.Policies = []*config.ZonePairPolicies{{
+		FromZone: "lan",
+		ToZone:   "wan",
+		Policies: []*config.Policy{{
+			Name: "p",
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{appName},
+			},
+			Action: config.PolicyPermit,
+		}},
+	}}
+	return cfg
+}
+
+func TestUserspaceGateAcceptsAndCanonicalizesNamedProtocol(t *testing.T) {
+	// esp must be supported (so a legit esp-only policy works) AND canonicalized
+	// to its numeric wire form so an older helper that lacks the named-protocol
+	// arms still parses it.
+	cfg := twoZonePolicyCfg(&config.Application{Name: "esp-only", Protocol: "esp"}, "esp-only")
+	terms, ok := expandUserspacePolicyApplications(cfg, []string{"esp-only"})
+	if !ok {
+		t.Fatal("expandUserspacePolicyApplications = ok=false, want true for esp")
+	}
+	if len(terms) != 1 {
+		t.Fatalf("len(terms) = %d, want 1", len(terms))
+	}
+	if terms[0].Protocol != "50" {
+		t.Fatalf("esp canonicalized Protocol = %q, want \"50\"", terms[0].Protocol)
+	}
+	if !userspaceSupportsSecurityPolicies(cfg) {
+		t.Fatal("userspaceSupportsSecurityPolicies = false, want true for esp policy")
+	}
+}
+
+func TestUserspaceGateFailsClosedOnUnknownProtocol(t *testing.T) {
+	// A user-defined application with a protocol neither the Rust matcher nor
+	// the centralized appid table can represent must fail the capability gate so
+	// the dataplane refuses to arm (ForwardingSupported=false). Pre-fix this
+	// returned ok=true (the fail-open).
+	cfg := twoZonePolicyCfg(&config.Application{Name: "weird", Protocol: "definitely-not-a-proto"}, "weird")
+	if _, ok := expandUserspacePolicyApplications(cfg, []string{"weird"}); ok {
+		t.Fatal("expandUserspacePolicyApplications = ok=true, want false for unknown protocol")
+	}
+	if userspaceSupportsSecurityPolicies(cfg) {
+		t.Fatal("userspaceSupportsSecurityPolicies = true, want false (refuse to arm) for unknown protocol")
+	}
+}
+
+func TestUserspaceGateFailsClosedOnMalformedPort(t *testing.T) {
+	for _, port := range []string{"99999", "5-1", "0", "abc"} {
+		cfg := twoZonePolicyCfg(
+			&config.Application{Name: "badport", Protocol: "tcp", DestinationPort: port},
+			"badport",
+		)
+		if _, ok := expandUserspacePolicyApplications(cfg, []string{"badport"}); ok {
+			t.Fatalf("expandUserspacePolicyApplications = ok=true for malformed port %q, want false", port)
+		}
+	}
+}
+
+func TestUserspaceGateAcceptsValidPortsAndAliases(t *testing.T) {
+	for _, port := range []string{"", "443", "8080-8090", "https", "dns"} {
+		cfg := twoZonePolicyCfg(
+			&config.Application{Name: "okport", Protocol: "tcp", DestinationPort: port},
+			"okport",
+		)
+		if _, ok := expandUserspacePolicyApplications(cfg, []string{"okport"}); !ok {
+			t.Fatalf("expandUserspacePolicyApplications = ok=false for valid port %q, want true", port)
+		}
+	}
+}
+
+func TestBuildOneRuleSnapshotEmitsUnsupportedSentinel(t *testing.T) {
+	// When expansion fails, the published rule must carry the __unsupported__
+	// sentinel term (so Rust fails the whole snapshot closed), NEVER nil (which
+	// Rust would read as genuine match-any — the publish-window fail-open).
+	cfg := twoZonePolicyCfg(&config.Application{Name: "weird", Protocol: "definitely-not-a-proto"}, "weird")
+	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	if len(snap.Policies) != 1 {
+		t.Fatalf("len(Policies) = %d, want 1", len(snap.Policies))
+	}
+	terms := snap.Policies[0].ApplicationTerms
+	if len(terms) != 1 {
+		t.Fatalf("ApplicationTerms = %+v, want exactly the sentinel term", terms)
+	}
+	if terms[0].Protocol != unsupportedApplicationSentinel {
+		t.Fatalf("sentinel Protocol = %q, want %q", terms[0].Protocol, unsupportedApplicationSentinel)
+	}
+}
+
+func TestBuildOneRuleSnapshotNoSentinelForSupportedApp(t *testing.T) {
+	// A supported named protocol must NOT trigger the sentinel; the rule carries
+	// a normal canonicalized term.
+	cfg := twoZonePolicyCfg(&config.Application{Name: "esp-only", Protocol: "esp"}, "esp-only")
+	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	terms := snap.Policies[0].ApplicationTerms
+	if len(terms) != 1 || terms[0].Protocol != "50" {
+		t.Fatalf("ApplicationTerms = %+v, want one esp term canonicalized to \"50\"", terms)
+	}
+}
+
+func TestUserspacePortSpecRepresentableMirrorsRust(t *testing.T) {
+	ok := []string{"", "1", "443", "65535", "80-90", "https", "ftp-data", "syslog"}
+	for _, s := range ok {
+		if !userspacePortSpecRepresentable(s) {
+			t.Errorf("userspacePortSpecRepresentable(%q) = false, want true", s)
+		}
+	}
+	bad := []string{"0", "65536", "99999", "5-1", "0-10", "abc", "80-", "-80", "80-abc"}
+	for _, s := range bad {
+		if userspacePortSpecRepresentable(s) {
+			t.Errorf("userspacePortSpecRepresentable(%q) = true, want false", s)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/protocol_failopen_2124_test.go
+++ b/pkg/dataplane/userspace/protocol_failopen_2124_test.go
@@ -131,7 +131,13 @@ func TestUserspacePortSpecRepresentableMirrorsRust(t *testing.T) {
 			t.Errorf("userspacePortSpecRepresentable(%q) = false, want true", s)
 		}
 	}
-	bad := []string{"0", "65536", "99999", "5-1", "0-10", "abc", "80-", "-80", "80-abc"}
+	// Aliases are CASE-SENSITIVE to mirror Rust parse_port_spec exactly: the
+	// uppercase forms are NOT recognized by Rust (it would drop the term), so
+	// the gate must reject them here too rather than accept-then-mismatch.
+	bad := []string{
+		"0", "65536", "99999", "5-1", "0-10", "abc", "80-", "-80", "80-abc",
+		"HTTP", "Https", "DNS",
+	}
 	for _, s := range bad {
 		if userspacePortSpecRepresentable(s) {
 			t.Errorf("userspacePortSpecRepresentable(%q) = true, want false", s)

--- a/userspace-dp/src/ip_proto.rs
+++ b/userspace-dp/src/ip_proto.rs
@@ -8,10 +8,16 @@
 //! matching, and screen checks.
 
 pub(crate) const PROTO_ICMP: u8 = 1;
+pub(crate) const PROTO_IGMP: u8 = 2;
 pub(crate) const PROTO_IPIP: u8 = 4;
 pub(crate) const PROTO_TCP: u8 = 6;
+pub(crate) const PROTO_EGP: u8 = 8;
 pub(crate) const PROTO_UDP: u8 = 17;
 pub(crate) const PROTO_GRE: u8 = 47;
 pub(crate) const PROTO_ESP: u8 = 50;
+pub(crate) const PROTO_AH: u8 = 51;
 pub(crate) const PROTO_ICMPV6: u8 = 58;
 pub(crate) const PROTO_OSPF: u8 = 89;
+pub(crate) const PROTO_PIM: u8 = 103;
+pub(crate) const PROTO_VRRP: u8 = 112;
+pub(crate) const PROTO_SCTP: u8 = 132;

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -16,15 +16,16 @@ pub(crate) enum SnapshotIntegrityError {
     AddressBookIdZero,
     DuplicateAddressBookId(u32),
     UnknownAddressBookId { rule_id: String, book_id: u32 },
-    /// #2124: a policy rule's `application_terms` are NON-empty but EVERY term
-    /// failed to parse (unrepresentable protocol or malformed port). Collapsing
-    /// such a rule to match-any is a security fail-open (a permit meant for one
-    /// protocol would permit ALL traffic). The Go capability gate emits a
-    /// reserved `__unsupported__` sentinel term for exactly this case, and any
-    /// corrupt snapshot that produces an all-dropped term list lands here too.
-    /// Rejecting the whole snapshot (the preflight keeps the previous good
-    /// state) is action-agnostic: it never turns a deny into a pass nor a
-    /// permit into match-any.
+    /// #2124: a policy rule has at least one `application_terms` entry that
+    /// failed to parse (unrepresentable protocol or malformed port). Dropping a
+    /// term silently is a security fail-open: an all-dropped rule collapses to
+    /// match-any (a permit over-matching), and a partially-dropped rule narrows
+    /// the match (for a deny rule, narrowing lets blocked traffic fall through).
+    /// The Go capability gate emits a reserved `__unsupported__` sentinel term
+    /// for the failed-expansion case, and any corrupt snapshot with an
+    /// unparseable term lands here too. Rejecting the whole snapshot (the
+    /// preflight keeps the previous good state) is action-agnostic: it never
+    /// turns a deny into a pass nor a permit into match-any.
     UnrepresentableApplicationProtocol { rule_id: String },
 }
 
@@ -42,7 +43,7 @@ impl std::fmt::Display for SnapshotIntegrityError {
             ),
             Self::UnrepresentableApplicationProtocol { rule_id } => write!(
                 f,
-                "rule {:?} has application terms but none are representable (unparseable protocol or port) — refusing to fail open to match-any",
+                "rule {:?} has an unrepresentable application term (unparseable protocol or port) — refusing to fail open by dropping it",
                 rule_id
             ),
         }

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -683,20 +683,25 @@ pub(crate) fn parse_policy_state_with_counters(
         // the constructor is updated, eliminating the silent-zero-
         // default hazard (originally raised by AGY r2 D on #1632).
         // #2124: parse the application terms and FAIL CLOSED if a rule cites
-        // application terms but NONE are representable (unparseable protocol or
-        // port). Such a rule must not collapse to match-any — that is the
-        // security fail-open this fixes. The Go capability gate emits a
-        // `__unsupported__` sentinel term for the unsupported-protocol case, so
-        // this fires for that sentinel and for any otherwise-corrupt snapshot.
-        // Genuinely-empty terms (`application any`) keep `had_terms == false`
-        // and remain match-any.
+        // application terms and ANY of them is unrepresentable (unparseable
+        // protocol or port). Dropping a term silently is the security fail-open
+        // this fixes: an all-dropped rule would collapse to match-any (a permit
+        // over-matching), and a PARTIALLY-dropped rule would NARROW the match —
+        // for a deny rule that narrowing lets traffic the deny meant to block
+        // fall through to a later permit / default-permit. Rejecting on
+        // `dropped_any` (not just all-dropped) is action-agnostic for permit
+        // and deny alike. The Go capability gate rejects any unrepresentable
+        // term before publish (and emits a `__unsupported__` sentinel for the
+        // failed-expansion case), so a normal Go snapshot never trips this; it
+        // is the backstop for that sentinel and for any corrupt/non-Go
+        // snapshot. Genuinely-empty terms (`application any`) keep
+        // `had_terms == false`, `dropped_any == false`, and stay match-any.
         let parsed = parse_applications(&snap.application_terms);
-        if parsed.had_terms && parsed.matches.is_empty() {
+        if parsed.dropped_any {
             return Err(SnapshotIntegrityError::UnrepresentableApplicationProtocol {
                 rule_id: rule_id.clone(),
             });
         }
-        let _ = parsed.dropped_any; // retained for diagnostics/future counters
         let applications = parsed.matches;
         let compiled_apps = CompiledApplications::from_matches(&applications);
 
@@ -1156,15 +1161,14 @@ fn parse_address(prefix: &str, out_v4: &mut Vec<PrefixV4>, out_v6: &mut Vec<Pref
 }
 
 /// #2124: outcome of parsing a rule's application terms. `dropped_any` records
-/// whether at least one term failed to parse (unparseable protocol or port).
-/// The caller uses `(matches.is_empty() && had_terms)` — i.e. terms were
-/// configured but ALL dropped — to fail the rule closed via
-/// `SnapshotIntegrityError`, rather than letting an empty `matches` collapse to
-/// match-any. A genuinely-empty input (`application any` / no match application)
-/// has `had_terms == false` and stays match-any.
+/// whether at least one configured term failed to parse (unparseable protocol
+/// or port). The caller fails the rule closed via `SnapshotIntegrityError`
+/// whenever `dropped_any` is set, rather than letting a dropped term collapse
+/// the rule to match-any (all-dropped) or silently narrow it (partial-drop).
+/// A genuinely-empty input (`application any` / no match application) drops
+/// nothing, so `dropped_any == false` and the rule stays match-any.
 struct ParsedApplications {
     matches: Vec<ApplicationMatch>,
-    had_terms: bool,
     dropped_any: bool,
 }
 
@@ -1192,7 +1196,6 @@ fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> ParsedApplications
     }
     ParsedApplications {
         matches: out,
-        had_terms: !terms.is_empty(),
         dropped_any,
     }
 }

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -695,8 +695,8 @@ pub(crate) fn parse_policy_state_with_counters(
         // term before publish (and emits a `__unsupported__` sentinel for the
         // failed-expansion case), so a normal Go snapshot never trips this; it
         // is the backstop for that sentinel and for any corrupt/non-Go
-        // snapshot. Genuinely-empty terms (`application any`) keep
-        // `had_terms == false`, `dropped_any == false`, and stay match-any.
+        // snapshot. Genuinely-empty terms (`application any`) drop nothing, so
+        // `dropped_any == false` and the rule stays match-any.
         let parsed = parse_applications(&snap.application_terms);
         if parsed.dropped_any {
             return Err(SnapshotIntegrityError::UnrepresentableApplicationProtocol {

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -16,6 +16,16 @@ pub(crate) enum SnapshotIntegrityError {
     AddressBookIdZero,
     DuplicateAddressBookId(u32),
     UnknownAddressBookId { rule_id: String, book_id: u32 },
+    /// #2124: a policy rule's `application_terms` are NON-empty but EVERY term
+    /// failed to parse (unrepresentable protocol or malformed port). Collapsing
+    /// such a rule to match-any is a security fail-open (a permit meant for one
+    /// protocol would permit ALL traffic). The Go capability gate emits a
+    /// reserved `__unsupported__` sentinel term for exactly this case, and any
+    /// corrupt snapshot that produces an all-dropped term list lands here too.
+    /// Rejecting the whole snapshot (the preflight keeps the previous good
+    /// state) is action-agnostic: it never turns a deny into a pass nor a
+    /// permit into match-any.
+    UnrepresentableApplicationProtocol { rule_id: String },
 }
 
 impl std::fmt::Display for SnapshotIntegrityError {
@@ -29,6 +39,11 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "rule {:?} references unknown address book id={}",
                 rule_id, book_id
+            ),
+            Self::UnrepresentableApplicationProtocol { rule_id } => write!(
+                f,
+                "rule {:?} has application terms but none are representable (unparseable protocol or port) — refusing to fail open to match-any",
+                rule_id
             ),
         }
     }
@@ -60,7 +75,8 @@ pub(crate) const JUNOS_GLOBAL_ZONE_ID: u16 = u16::MAX;
 pub(crate) const ZONE_ID_RESERVED_MIN: u16 = u16::MAX - 1;
 
 use crate::ip_proto::{
-    PROTO_GRE, PROTO_ICMP, PROTO_ICMPV6, PROTO_IPIP, PROTO_OSPF, PROTO_TCP, PROTO_UDP,
+    PROTO_AH, PROTO_EGP, PROTO_ESP, PROTO_GRE, PROTO_ICMP, PROTO_ICMPV6, PROTO_IGMP, PROTO_IPIP,
+    PROTO_OSPF, PROTO_PIM, PROTO_SCTP, PROTO_TCP, PROTO_UDP, PROTO_VRRP,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -666,7 +682,22 @@ pub(crate) fn parse_policy_state_with_counters(
         // forces a compile error on any future field addition until
         // the constructor is updated, eliminating the silent-zero-
         // default hazard (originally raised by AGY r2 D on #1632).
-        let applications = parse_applications(&snap.application_terms);
+        // #2124: parse the application terms and FAIL CLOSED if a rule cites
+        // application terms but NONE are representable (unparseable protocol or
+        // port). Such a rule must not collapse to match-any — that is the
+        // security fail-open this fixes. The Go capability gate emits a
+        // `__unsupported__` sentinel term for the unsupported-protocol case, so
+        // this fires for that sentinel and for any otherwise-corrupt snapshot.
+        // Genuinely-empty terms (`application any`) keep `had_terms == false`
+        // and remain match-any.
+        let parsed = parse_applications(&snap.application_terms);
+        if parsed.had_terms && parsed.matches.is_empty() {
+            return Err(SnapshotIntegrityError::UnrepresentableApplicationProtocol {
+                rule_id: rule_id.clone(),
+            });
+        }
+        let _ = parsed.dropped_any; // retained for diagnostics/future counters
+        let applications = parsed.matches;
         let compiled_apps = CompiledApplications::from_matches(&applications);
 
         let rule = PolicyRule {
@@ -1124,16 +1155,33 @@ fn parse_address(prefix: &str, out_v4: &mut Vec<PrefixV4>, out_v6: &mut Vec<Pref
     }
 }
 
-fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> Vec<ApplicationMatch> {
+/// #2124: outcome of parsing a rule's application terms. `dropped_any` records
+/// whether at least one term failed to parse (unparseable protocol or port).
+/// The caller uses `(matches.is_empty() && had_terms)` — i.e. terms were
+/// configured but ALL dropped — to fail the rule closed via
+/// `SnapshotIntegrityError`, rather than letting an empty `matches` collapse to
+/// match-any. A genuinely-empty input (`application any` / no match application)
+/// has `had_terms == false` and stays match-any.
+struct ParsedApplications {
+    matches: Vec<ApplicationMatch>,
+    had_terms: bool,
+    dropped_any: bool,
+}
+
+fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> ParsedApplications {
     let mut out = Vec::with_capacity(terms.len());
+    let mut dropped_any = false;
     for term in terms {
         let Some(protocol) = parse_protocol(&term.protocol) else {
+            dropped_any = true;
             continue;
         };
         let Some(source_ports) = parse_port_spec(&term.source_port) else {
+            dropped_any = true;
             continue;
         };
         let Some(destination_ports) = parse_port_spec(&term.destination_port) else {
+            dropped_any = true;
             continue;
         };
         out.push(ApplicationMatch {
@@ -1142,19 +1190,44 @@ fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> Vec<ApplicationMat
             destination_ports,
         });
     }
-    out
+    ParsedApplications {
+        matches: out,
+        had_terms: !terms.is_empty(),
+        dropped_any,
+    }
 }
 
+/// Resolve a policy application term's protocol token to its IANA number.
+///
+/// #2124: extended to map the named IANA protocols Junos / the Go
+/// `validateProtocol` accept (`sctp`/`esp`/`ah`/`vrrp`/`igmp`/`pim`/`egp`) to
+/// their numbers, so a policy that matches only those protocols is honored
+/// instead of silently failing OPEN to match-any. Returning `None` for an
+/// unparseable token causes `parse_applications` to drop the term; a rule whose
+/// terms ALL drop is then rejected as a `SnapshotIntegrityError` (fail closed)
+/// rather than collapsing to match-any — see `parse_applications` /
+/// `parse_policy_state_with_counters`.
+///
+/// The numeric `_ => parse::<u8>()` arm is preserved, so a config that names a
+/// protocol numerically (e.g. `protocol 132`) still parses. Numbers MUST match
+/// `crate::ip_proto` / the centralized Go `appid.ProtocolNumber` table.
 fn parse_protocol(protocol: &str) -> Option<u8> {
     match protocol {
         "" => None,
         "tcp" => Some(PROTO_TCP),
         "udp" => Some(PROTO_UDP),
         "icmp" => Some(PROTO_ICMP),
-        "icmpv6" => Some(PROTO_ICMPV6),
+        "icmp6" | "icmpv6" => Some(PROTO_ICMPV6),
         "gre" => Some(PROTO_GRE),
         "89" | "ospf" => Some(PROTO_OSPF),
         "4" | "ipip" => Some(PROTO_IPIP),
+        "esp" => Some(PROTO_ESP),
+        "ah" => Some(PROTO_AH),
+        "sctp" => Some(PROTO_SCTP),
+        "vrrp" => Some(PROTO_VRRP),
+        "igmp" => Some(PROTO_IGMP),
+        "pim" => Some(PROTO_PIM),
+        "egp" => Some(PROTO_EGP),
         _ => protocol.parse::<u8>().ok(),
     }
 }

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -1207,10 +1207,10 @@ fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> ParsedApplications
 /// `validateProtocol` accept (`sctp`/`esp`/`ah`/`vrrp`/`igmp`/`pim`/`egp`) to
 /// their numbers, so a policy that matches only those protocols is honored
 /// instead of silently failing OPEN to match-any. Returning `None` for an
-/// unparseable token causes `parse_applications` to drop the term; a rule whose
-/// terms ALL drop is then rejected as a `SnapshotIntegrityError` (fail closed)
-/// rather than collapsing to match-any — see `parse_applications` /
-/// `parse_policy_state_with_counters`.
+/// unparseable token records a dropped term in `parse_applications`; a rule with
+/// ANY dropped term is then rejected as a `SnapshotIntegrityError` (fail closed)
+/// rather than collapsing to match-any (all-dropped) or silently narrowing
+/// (partial-drop) — see `parse_applications` / `parse_policy_state_with_counters`.
 ///
 /// The numeric `_ => parse::<u8>()` arm is preserved, so a config that names a
 /// protocol numerically (e.g. `protocol 132`) still parses. Numbers MUST match

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -766,12 +766,17 @@ fn empty_application_terms_stay_match_any() {
 }
 
 #[test]
-fn mixed_parseable_and_unparseable_keeps_parseable_term() {
-    // A rule with one parseable (esp) and one unparseable term is NOT
-    // all-dropped, so it parses Ok and matches ESP via the surviving term. The
-    // bogus term is silently dropped (the gate is the front-line reject); the
-    // rule does NOT fail closed because it still has a real constraint.
-    let state = parse_policy_state(
+fn mixed_parseable_and_unparseable_fails_closed() {
+    // A rule with one parseable (esp) and one unparseable term has dropped_any
+    // set, so it fails CLOSED (whole-snapshot integrity error) rather than
+    // silently NARROWING the match by dropping the bad term. Narrowing matters
+    // for a deny rule: a dropped term would let traffic the deny meant to block
+    // fall through to a later permit / default. Normal Go snapshots never reach
+    // this (the capability gate rejects any unrepresentable term before
+    // publish); this is the corrupt/non-Go-snapshot backstop (Codex code-review
+    // finding 2). Pre-fix this returned Ok with the bad term silently dropped.
+    let store = PolicyCounterStore::default();
+    let result = parse_policy_state_with_counters(
         "deny",
         &[PolicyRuleSnapshot {
             rule_id: "esp-plus-bogus".to_string(),
@@ -799,6 +804,50 @@ fn mixed_parseable_and_unparseable_keeps_parseable_term() {
             ..Default::default()
         }],
         &test_zone_name_to_id(),
+        &[],
+        &store,
+    );
+    assert!(
+        matches!(
+            result,
+            Err(SnapshotIntegrityError::UnrepresentableApplicationProtocol { .. })
+        ),
+        "a partially-unparseable term list must fail closed, got {result:?}"
+    );
+}
+
+#[test]
+fn all_parseable_terms_match_each_protocol() {
+    // Sanity: a rule with two fully-parseable terms (esp + tcp/443) parses Ok
+    // and matches BOTH, without tripping the dropped_any backstop.
+    let state = parse_policy_state(
+        "deny",
+        &[PolicyRuleSnapshot {
+            rule_id: "esp-and-https".to_string(),
+            name: "esp-and-https".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["any".to_string()],
+            destination_addresses: vec!["any".to_string()],
+            applications: vec!["esp-and-https".to_string()],
+            application_terms: vec![
+                PolicyApplicationSnapshot {
+                    name: "esp".to_string(),
+                    protocol: "esp".to_string(),
+                    source_port: String::new(),
+                    destination_port: String::new(),
+                },
+                PolicyApplicationSnapshot {
+                    name: "https".to_string(),
+                    protocol: "tcp".to_string(),
+                    source_port: String::new(),
+                    destination_port: "443".to_string(),
+                },
+            ],
+            action: "permit".to_string(),
+            ..Default::default()
+        }],
+        &test_zone_name_to_id(),
     );
     let src = "10.0.61.100".parse().expect("src");
     let dst = "172.16.80.200".parse().expect("dst");
@@ -807,14 +856,21 @@ fn mixed_parseable_and_unparseable_keeps_parseable_term() {
             &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_ESP, 0, 0,
         ),
         PolicyAction::Permit,
-        "the surviving esp term must still match"
+        "esp term must match"
     );
     assert_eq!(
         evaluate_policy(
             &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_TCP, 40000, 443,
         ),
+        PolicyAction::Permit,
+        "tcp/443 term must match"
+    );
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_TCP, 40000, 80,
+        ),
         PolicyAction::Deny,
-        "TCP must NOT match (rule is not match-any despite the dropped term)"
+        "tcp/80 must NOT match (not match-any)"
     );
 }
 

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -557,6 +557,267 @@ fn named_application_matches_protocol_and_port() {
     );
 }
 
+// #2124 — a policy application term whose named protocol the Rust matcher
+// previously could not parse (sctp/esp/ah/vrrp/igmp/pim/egp) silently failed
+// OPEN to match-any: parse_protocol returned None, the term was dropped, and a
+// rule whose only term dropped collapsed to match_any, permitting ALL traffic.
+// These tests assert the named set now matches correctly AND that an
+// all-unparseable term list fails CLOSED (whole-snapshot integrity error)
+// rather than match-any.
+
+fn proto_only_app_rule(rule_id: &str, protocol: &str) -> PolicyRuleSnapshot {
+    PolicyRuleSnapshot {
+        rule_id: rule_id.to_string(),
+        name: rule_id.to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec![rule_id.to_string()],
+        application_terms: vec![PolicyApplicationSnapshot {
+            name: rule_id.to_string(),
+            protocol: protocol.to_string(),
+            source_port: String::new(),
+            destination_port: String::new(),
+        }],
+        action: "permit".to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn named_protocol_sctp_matches_only_sctp_not_tcp() {
+    // PROVES #2124(R-a): a permit rule for an sctp-only application permits
+    // SCTP and DENIES TCP. Pre-fix the sctp term dropped -> match_any ->
+    // TCP would be (wrongly) Permit, so this is non-tautological.
+    let state = parse_policy_state(
+        "deny",
+        &[proto_only_app_rule("esp-or-sctp", "sctp")],
+        &test_zone_name_to_id(),
+    );
+    let src = "10.0.61.100".parse().expect("src");
+    let dst = "172.16.80.200".parse().expect("dst");
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_SCTP, 0, 0,
+        ),
+        PolicyAction::Permit,
+        "sctp must match an sctp-only rule"
+    );
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_TCP, 40000, 443,
+        ),
+        PolicyAction::Deny,
+        "TCP must NOT match an sctp-only rule (no fail-open to match-any)"
+    );
+}
+
+#[test]
+fn named_protocol_esp_matches_only_esp_not_tcp() {
+    let state = parse_policy_state(
+        "deny",
+        &[proto_only_app_rule("esp-only", "esp")],
+        &test_zone_name_to_id(),
+    );
+    let src = "10.0.61.100".parse().expect("src");
+    let dst = "172.16.80.200".parse().expect("dst");
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_ESP, 0, 0,
+        ),
+        PolicyAction::Permit
+    );
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_TCP, 40000, 443,
+        ),
+        PolicyAction::Deny
+    );
+}
+
+#[test]
+fn named_protocol_parse_covers_full_iana_set() {
+    // Every named protocol the Go validateProtocol/capability gate accepts must
+    // resolve to its IANA number here, or the gate-and-matcher contract breaks.
+    assert_eq!(parse_protocol("sctp"), Some(PROTO_SCTP));
+    assert_eq!(parse_protocol("esp"), Some(PROTO_ESP));
+    assert_eq!(parse_protocol("ah"), Some(PROTO_AH));
+    assert_eq!(parse_protocol("vrrp"), Some(PROTO_VRRP));
+    assert_eq!(parse_protocol("igmp"), Some(PROTO_IGMP));
+    assert_eq!(parse_protocol("pim"), Some(PROTO_PIM));
+    assert_eq!(parse_protocol("egp"), Some(PROTO_EGP));
+    assert_eq!(parse_protocol("icmp6"), Some(PROTO_ICMPV6));
+    // Numeric forms (including the canonicalized wire form the Go gate emits).
+    assert_eq!(parse_protocol("132"), Some(PROTO_SCTP));
+    assert_eq!(parse_protocol("50"), Some(PROTO_ESP));
+    assert_eq!(parse_protocol("0"), Some(0));
+    // Unparseable tokens stay None (so parse_applications drops + fails closed).
+    assert_eq!(parse_protocol(""), None);
+    assert_eq!(parse_protocol("definitely-not-a-proto"), None);
+    assert_eq!(parse_protocol("__unsupported__"), None);
+    assert_eq!(parse_protocol("256"), None);
+}
+
+#[test]
+fn numeric_protocol_still_matches() {
+    // Regression guard for the numeric parse arm.
+    let state = parse_policy_state(
+        "deny",
+        &[proto_only_app_rule("num-132", "132")],
+        &test_zone_name_to_id(),
+    );
+    let src = "10.0.61.100".parse().expect("src");
+    let dst = "172.16.80.200".parse().expect("dst");
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_SCTP, 0, 0,
+        ),
+        PolicyAction::Permit
+    );
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_TCP, 40000, 443,
+        ),
+        PolicyAction::Deny
+    );
+}
+
+#[test]
+fn all_unparseable_terms_fail_closed_with_integrity_error() {
+    // PROVES #2124(R-b/Layer S): a rule whose application_terms are NON-empty
+    // but ALL unparseable raises SnapshotIntegrityError instead of collapsing
+    // to match-any. Pre-fix this returned Ok with a match_any rule (the
+    // fail-open), so this is non-tautological.
+    let store = PolicyCounterStore::default();
+    let result = parse_policy_state_with_counters(
+        "deny",
+        &[proto_only_app_rule("bogus", "definitely-not-a-proto")],
+        &test_zone_name_to_id(),
+        &[],
+        &store,
+    );
+    match result {
+        Err(SnapshotIntegrityError::UnrepresentableApplicationProtocol { rule_id }) => {
+            assert_eq!(rule_id, "bogus");
+        }
+        other => panic!("expected UnrepresentableApplicationProtocol, got {other:?}"),
+    }
+}
+
+#[test]
+fn go_unsupported_sentinel_fails_closed() {
+    // Cross-language contract: the Go capability gate emits a "__unsupported__"
+    // sentinel term for an unrepresentable application; Rust must drop it and
+    // reject the whole snapshot (fail closed), NOT decode it as match-any.
+    let store = PolicyCounterStore::default();
+    let result = parse_policy_state_with_counters(
+        "deny",
+        &[proto_only_app_rule("sentinel-rule", "__unsupported__")],
+        &test_zone_name_to_id(),
+        &[],
+        &store,
+    );
+    assert!(
+        matches!(
+            result,
+            Err(SnapshotIntegrityError::UnrepresentableApplicationProtocol { .. })
+        ),
+        "the Go __unsupported__ sentinel must fail closed, got {result:?}"
+    );
+}
+
+#[test]
+fn empty_application_terms_stay_match_any() {
+    // Regression guard: genuinely-empty application_terms (Junos
+    // `application any` / no match application) must remain match-any and parse
+    // Ok — the new integrity check must NOT fire here.
+    let state = parse_policy_state(
+        "deny",
+        &[PolicyRuleSnapshot {
+            rule_id: "allow-any-app".to_string(),
+            name: "allow-any-app".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["any".to_string()],
+            destination_addresses: vec!["any".to_string()],
+            applications: vec!["any".to_string()],
+            application_terms: Vec::new(),
+            action: "permit".to_string(),
+            ..Default::default()
+        }],
+        &test_zone_name_to_id(),
+    );
+    let src = "10.0.61.100".parse().expect("src");
+    let dst = "172.16.80.200".parse().expect("dst");
+    // Both an arbitrary TCP flow and an SCTP flow must be permitted (match-any).
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_TCP, 40000, 443,
+        ),
+        PolicyAction::Permit
+    );
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_SCTP, 0, 0,
+        ),
+        PolicyAction::Permit
+    );
+}
+
+#[test]
+fn mixed_parseable_and_unparseable_keeps_parseable_term() {
+    // A rule with one parseable (esp) and one unparseable term is NOT
+    // all-dropped, so it parses Ok and matches ESP via the surviving term. The
+    // bogus term is silently dropped (the gate is the front-line reject); the
+    // rule does NOT fail closed because it still has a real constraint.
+    let state = parse_policy_state(
+        "deny",
+        &[PolicyRuleSnapshot {
+            rule_id: "esp-plus-bogus".to_string(),
+            name: "esp-plus-bogus".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["any".to_string()],
+            destination_addresses: vec!["any".to_string()],
+            applications: vec!["esp-plus-bogus".to_string()],
+            application_terms: vec![
+                PolicyApplicationSnapshot {
+                    name: "esp".to_string(),
+                    protocol: "esp".to_string(),
+                    source_port: String::new(),
+                    destination_port: String::new(),
+                },
+                PolicyApplicationSnapshot {
+                    name: "bogus".to_string(),
+                    protocol: "definitely-not-a-proto".to_string(),
+                    source_port: String::new(),
+                    destination_port: String::new(),
+                },
+            ],
+            action: "permit".to_string(),
+            ..Default::default()
+        }],
+        &test_zone_name_to_id(),
+    );
+    let src = "10.0.61.100".parse().expect("src");
+    let dst = "172.16.80.200".parse().expect("dst");
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_ESP, 0, 0,
+        ),
+        PolicyAction::Permit,
+        "the surviving esp term must still match"
+    );
+    assert_eq!(
+        evaluate_policy(
+            &state, TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, src, dst, PROTO_TCP, 40000, 443,
+        ),
+        PolicyAction::Deny,
+        "TCP must NOT match (rule is not match-any despite the dropped term)"
+    );
+}
+
 #[test]
 fn application_set_matches_any_expanded_term() {
     let state = parse_policy_state(


### PR DESCRIPTION
## Summary

Closes a verified **security fail-open** (#2124, 3/3 adversarial votes). A policy `permit` rule matching a user-defined `application` whose named L3 protocol the Rust matcher could not parse (`sctp`/`esp`/`ah`/`vrrp`/`igmp`/`pim`/`egp`) silently **failed OPEN to match-any** — the rule permitted ALL traffic for the zone pair instead of only the intended protocol. `parse_protocol` returned `None`, `parse_applications` dropped the term, and a rule whose terms all dropped collapsed to `CompiledApplications { match_any: true }`.

Fix is three cohering layers (design driven through 3 Codex plan-review rounds, r1/r2 PLAN-NEEDS-MAJOR → r3 PLAN-READY):

1. **Centralize** the named→number table in `appid.ProtocolNumber(name) (uint8, bool)` (cycle-safe leaf package). `pkg/dataplane.protocolNumber`, `pkg/appid.catalogProtocolNumber`, and the app-id runtime `protocolNumber` all delegate — eliminating the (formerly four) divergent copies. `(0, true)` preserves a deliberate `protocol 0`; `(0, false)` is the unrepresentable sentinel.
2. **Rust matcher**: `parse_protocol` now maps the named IANA set to their numbers (esp=50, ah=51, sctp=132, vrrp=112, igmp=2, pim=103, egp=8 + `icmp6` alias) so those policies are honored. A rule whose `application_terms` are NON-empty but ALL drop now raises `SnapshotIntegrityError::UnrepresentableApplicationProtocol` → the preflight rejects the whole snapshot and keeps the previous good state. **Action-agnostic**: never turns a permit into match-any nor a deny into a pass. Genuinely-empty terms (`application any`) stay match-any, unchanged.
3. **Go control plane**: `expandUserspacePolicyApplications` rejects any unrepresentable protocol OR port (`ForwardingSupported=false`, operator-visible refuse-to-arm) and canonicalizes the newly-supported names to their number on the wire (only those — tcp/udp/icmp/... keep their string so the snapshot hash is unchanged for existing policies). On a failed expansion `buildOneRuleSnapshot` emits a reserved `__unsupported__` **fail-closed sentinel** term instead of `nil` (nil reads as genuine match-any on the Rust side), closing the publish-before-disarm window Codex r2 identified.

## Plan + adversarial review

Plan doc: `docs/pr/2124-protocol-failopen/plan.md`

- Codex round-1: PLAN-NEEDS-MAJOR (validateProtocol warning-only → gate load-bearing; action-blind never_match unsafe; duplicate maps) — addressed in v2
- Codex round-2: PLAN-NEEDS-MAJOR (publish-before-disarm `nil`→match-any; import cycle) — addressed in v3
- Codex round-3: PLAN-NEEDS-MINOR (2 doc consistency fixes) — all substantive checks pass; minors folded

Self-review (SMR) additionally caught and fixed: port-alias case sensitivity must mirror Rust `parse_port_spec` exactly (was lowercasing), and a fourth divergent protocol table in `pkg/appid/runtime.go` (folded into `ProtocolNumber`).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` full suite green (2 pre-existing concurrency flakes in unrelated `worker_queue` / `wg-engine` modules — proven flaky on clean `origin/master`, do not touch this code)
- [x] 8 new Rust policy tests, 5/5 flake check; `policy::` module 57/57 deterministic (3x)
- [x] Go suite: 49 packages pass; new gate/sentinel/parity tests + 5/5 flake
- [ ] **Cluster smoke: NOT run here.** Hot-path/security change — the parent runs the `/security-matrix` directional smoke (trust→untrust ALLOW, untrust→trust BLOCK, plain forwarding throughput) after merge. **Smoke pending parent-run.**

Non-tautological tests: a named sctp/esp policy permits its protocol and DENIES TCP (pre-fix TCP was wrongly permitted); an all-unparseable term list and the `__unsupported__` sentinel both raise the integrity error (pre-fix returned Ok with a match-any rule); the Go gate fails closed on unknown protocol / malformed port (pre-fix `ok=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)