### PR TITLE
#2145: screen/SYN-cookie L3 offset on tag presence, not VID>0 (priority-tagged VLAN-0)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -7623,3 +7623,34 @@ top.
   against FRR source; Codex code review + AGY adversarial both
   MERGE-READY; Copilot reviewed 3/3 files, no comments. Control-plane
   display only — no dataplane smoke. PR #2135 MERGEABLE.
+
+## #2145 — screen/SYN-cookie L3-offset on tag-presence, not VID>0
+- **Timestamp**: 2026-06-20
+- **Action**: Fix priority-tagged VLAN-0 misclassification. The screen
+  and SYN-cookie-ACK stages computed the L3 offset as
+  `if meta.ingress_vlan_id > 0 { 18 } else { 14 }`, so an 802.1p
+  priority-tagged frame (real 802.1Q tag, VID 0, PCP>0,
+  ingress_vlan_present=1) was read at offset 14 — parsing the tag's
+  TPID/TCI bytes as the IP header (LAND/syn-frag/flood misclassification,
+  SYN-cookie skipped or computed from garbage). Switched both sites to
+  `meta.ingress_vlan_present != 0` (tag presence), matching
+  tx/cos_classify.rs. Extended the property strategy: PacketSpec gains
+  `vlan_present`/`pcp`; build_valid_frame emits the tag on presence (not
+  VID); new arb_vlan_tag() generates present=true,vid=0,pcp>0 (egress
+  arb_vlan() kept u16, VID-0=untagged is correct there). Added a
+  non-tautological poll_stages unit test (priority-tagged VID-0 SYN
+  parsed at offset 18 via ip-source-route signal + cookie-ACK validates
+  only when tcp_ack read at 18; untagged control still uses 14) and a
+  frame-level pin (frame_l3_offset->18 for the priority-tagged shape).
+- **File(s)**: userspace-dp/src/afxdp/poll_stages.rs,
+  userspace-dp/src/afxdp/frame/prop_tests/strategies.rs,
+  userspace-dp/src/afxdp/frame/prop_tests/inspect.rs,
+  userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs,
+  userspace-dp/src/afxdp/frame/prop_tests/segment.rs,
+  userspace-dp/src/afxdp/README.md
+- **Validation**: cargo build + cargo test --no-run clean; new tests
+  pass and FAIL with the fix reverted (proven non-tautological); 33/33
+  frame prop_tests green; affected suites green. Pre-existing flaky
+  concurrency test (worker_queue_tests concurrent_recovery, untouched)
+  4/5 in isolation — unrelated. Broader L2-centralization deferred to
+  #2150. Smoke deferred to parent (hot-path/security).

--- a/docs/pr/2145-vlan-present-l3-offset/plan.md
+++ b/docs/pr/2145-vlan-present-l3-offset/plan.md
@@ -1,0 +1,68 @@
+# #2145 — screen/SYN-cookie L3 offset on tag-presence, not VID>0
+
+Status: IMPLEMENTED — narrow correctness fix (point fix per issue
+disposition ENGINEER-NOW; broader L2-centralization is #2150).
+
+## Issue framing
+
+The userspace screen stage and the SYN-cookie-ACK stage compute the
+L3 offset with `if meta.ingress_vlan_id > 0 { 18 } else { 14 }`
+(`userspace-dp/src/afxdp/poll_stages.rs:276` and `:377`). 802.1p
+priority-tagged frames carry a *real* 802.1Q tag (TPID 0x8100, PCP
+bits) but with VID 0. For such a frame the shim sets
+`ingress_vlan_present = 1` and `ingress_vlan_id = 0`, so the VID-based
+test picks offset 14 (untagged) and `extract_screen_info` reads the
+IP header from the tag's TPID/TCI bytes instead of the real header.
+Consequences: LAND / SYN-frag / flood misclassification, and the
+SYN-cookie challenge skipped or computed from corrupted bytes.
+
+The codebase already has the correct signal: `ingress_vlan_present`,
+which the CoS path uses (`tx/cos_classify.rs:152/401` —
+`vlan_present != 0`), and the production frame parser
+`frame_l3_offset` already keys on the TPID (0x8100/0x88a8), returning
+18 regardless of VID.
+
+## Fix (narrow correctness)
+
+1. Replace `meta.ingress_vlan_id > 0` with
+   `meta.ingress_vlan_present != 0` at both offset-decision sites in
+   `poll_stages.rs` (screen + SYN-cookie). These are the only two
+   `vlan_id > 0` L3-offset decisions on the ingress screen path. The
+   many other `vlan_id > 0` sites are egress frame builders
+   (`egress.vlan_id`, `write_eth_header`, etc.) where VID 0 ==
+   untagged is the correct, intended semantic — out of scope.
+
+2. Property-strategy extension (issue's "if feasible"): decouple tag
+   presence from VID in the frame builders so the
+   `present=true, vid=0, pcp>0` shape is generatable:
+   - `PacketSpec` gains `vlan_present: bool` and `pcp: u8`.
+   - `build_valid_frame` emits the 802.1Q tag on `vlan_present` (not
+     `vlan_id != 0`) and sets `ingress_vlan_present`/`ingress_pcp`.
+   - new `arb_vlan_tag()` generates untagged, normal-tagged, and
+     priority-tagged-VID-0 cases. The egress `arb_vlan()` keeps its
+     `u16` return (egress VID-0 == untagged is correct there).
+
+## Tests
+
+- `poll_stages::tests::priority_tagged_vlan0_screen_stage_parses_l3_at_offset_18`
+  — drives `stage_screen_check` (ip-source-route fires only if the
+  IHL byte is read at offset 18) and
+  `stage_screen_syn_cookie_ack_on_session_miss` (cookie ACK validates
+  only if `tcp_ack` is read at offset 18), with an untagged control.
+  Proven to FAIL with the fix reverted.
+- `frame::prop_tests::inspect::pin_priority_tagged_vlan0_frame_parses_l3_at_offset_18`
+  — frame-level pin: priority-tagged VID-0 frame → `frame_l3_offset`
+  == 18, `ingress_vlan_present` == 1, flow parses through the tag.
+- The existing `parse_valid_round_trip` property now also exercises
+  priority-tagged VID-0 frames via `arb_vlan_tag()`.
+
+## Out of scope
+
+- The `afxdp/l2` model / `L2Tag` / `l3_offset_from_meta` centralization
+  refactor — tracked as #2150.
+- Egress / frame-build `vlan_id > 0` sites (correct as-is).
+
+## Validation
+
+cargo build + cargo test clean; full release suite; new tests
+fail-pre-fix. Smoke (hot-path/security) deferred to the parent.

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -17,7 +17,11 @@ sync.
   the per-worker handle table.
 - `worker/` — the per-worker poll loop (`mod.rs` runs the dispatch).
 - `poll_stages.rs` — sibling of `worker/`, not inside it. Holds the
-  per-packet pipeline stages extracted in #946 Phase 1.
+  per-packet pipeline stages extracted in #946 Phase 1. The screen and
+  SYN-cookie stages decide the L3 offset (14 vs 18) on tag PRESENCE
+  (`meta.ingress_vlan_present != 0`), not `vlan_id > 0` — 802.1p
+  priority-tagged frames carry a real 802.1Q tag with VID 0, so a
+  VID-based test would mis-read the IP header at offset 14 (#2145).
 - `frame/` — packet parsing (L2 / L3 / L4), checksum helpers, TCP MSS
   clamp. `tests.rs` was relocated out of `mod.rs` in #1046 Phase 1.
 - `umem/` — UMEM allocator, fill ring, completion ring. Frames are

--- a/userspace-dp/src/afxdp/frame/prop_tests/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/inspect.rs
@@ -197,6 +197,8 @@ fn v6_frame_with_n_hbh(n: usize) -> Vec<u8> {
         src_port: 1000,
         dst_port: 2000,
         vlan_id: 0,
+        vlan_present: false,
+        pcp: 0,
         ttl: 64,
         ihl: 20,
         ext: vec![ExtHdr::HopByHop(0); n],
@@ -264,6 +266,8 @@ fn pin_ext_walk_mixed_chain_exact_offset() {
         src_port: 53,
         dst_port: 5353,
         vlan_id: 80,
+        vlan_present: true,
+        pcp: 0,
         ttl: 64,
         ihl: 20,
         ext,
@@ -300,6 +304,54 @@ fn pin_ext_walk_no_next_header_is_none() {
     assert_eq!(frame_l4_offset(&frame, AF6), None);
 }
 
+/// #2145 pin: an 802.1p priority-tagged VLAN-0 frame
+/// (`vlan_present = true, vlan_id = 0, pcp > 0`) carries a real 802.1Q
+/// tag, so L3 starts at offset 18 and `ingress_vlan_present` is 1
+/// while `ingress_vlan_id` is 0. The strategy builder must be able to
+/// produce this shape (the old `present = vlan_id != 0` derivation
+/// could not), and the production `frame_l3_offset` parser must resolve
+/// it to 18 from the TPID, not 14.
+#[test]
+fn pin_priority_tagged_vlan0_frame_parses_l3_at_offset_18() {
+    use super::strategies::{build_valid_frame, PacketSpec};
+    let spec = PacketSpec {
+        v6: false,
+        src4: 0x0a00_3d66,
+        dst4: 0xac10_50c8,
+        src6: [0; 16],
+        dst6: [0; 16],
+        protocol: PROTO_TCP,
+        src_port: 49152,
+        dst_port: 443,
+        vlan_id: 0,
+        vlan_present: true,
+        pcp: 5,
+        ttl: 64,
+        ihl: 20,
+        ext: Vec::new(),
+        payload_len: 0,
+        payload_seed: 1,
+        udp_zero_csum: false,
+        tcp_flags: 0x02,
+        tcp_opt_len: 0,
+        seq: 1,
+    };
+    let pkt = build_valid_frame(&spec);
+    assert_eq!(pkt.l3, 18, "priority-tagged VLAN-0 frame keeps the tag → L3 at 18");
+    assert_eq!(
+        pkt.meta.ingress_vlan_present, 1,
+        "tag is present even though VID is 0"
+    );
+    assert_eq!(pkt.meta.ingress_vlan_id, 0, "priority tag carries VID 0");
+    assert_eq!(pkt.meta.ingress_pcp, 5);
+    // The on-wire TPID is 802.1Q so the production parser resolves 18.
+    assert_eq!(u16::from_be_bytes([pkt.frame[12], pkt.frame[13]]), 0x8100);
+    assert_eq!(frame_l3_offset(&pkt.frame), Some(18));
+    // The flow still parses correctly through the tagged header.
+    let flow = parse_session_flow_from_bytes(&pkt.frame, pkt.meta).expect("flow");
+    assert_eq!(flow, pkt.session_flow());
+}
+
 /// P-I5 divergence pin (inspect.rs:329-356 arbitration): when
 /// `meta.protocol` disagrees with the frame's protocol byte, the
 /// meta-led fast path wins for TCP/UDP-complete metadata and the
@@ -320,6 +372,8 @@ fn pin_meta_frame_protocol_arbitration_divergence() {
         src_port: 1234,
         dst_port: 80,
         vlan_id: 0,
+        vlan_present: false,
+        pcp: 0,
         ttl: 64,
         ihl: 20,
         ext: Vec::new(),

--- a/userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs
@@ -299,6 +299,8 @@ fn pin_packet(v6: bool, protocol: u8, ttl: u8, ext: Vec<ExtHdr>) -> ValidPacket 
         src_port: 0x1111,
         dst_port: 0x2222,
         vlan_id: 0,
+        vlan_present: false,
+        pcp: 0,
         ttl,
         ihl: 20,
         ext,

--- a/userspace-dp/src/afxdp/frame/prop_tests/segment.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/segment.rs
@@ -295,6 +295,8 @@ fn pin_segmentation_v6_ext_chain_segments_valid() {
         src_port: 0x1111,
         dst_port: 0x2222,
         vlan_id: 0,
+        vlan_present: false,
+        pcp: 0,
         ttl: 64,
         ihl: 20,
         ext: vec![ExtHdr::HopByHop(0), ExtHdr::DestOpts(0)],

--- a/userspace-dp/src/afxdp/frame/prop_tests/strategies.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/strategies.rs
@@ -130,6 +130,14 @@ pub(super) struct PacketSpec {
     pub(super) src_port: u16,
     pub(super) dst_port: u16,
     pub(super) vlan_id: u16,
+    /// Whether an 802.1Q tag is present on the wire. Decoupled from
+    /// `vlan_id` so the generators can produce 802.1p priority-tagged
+    /// VLAN-0 frames (`vlan_present = true, vlan_id = 0, pcp > 0`) — the
+    /// #2145 shape that a `vlan_id != 0` test could not reach.
+    pub(super) vlan_present: bool,
+    /// 802.1p priority code point (0..=7), only meaningful when
+    /// `vlan_present` is set.
+    pub(super) pcp: u8,
     pub(super) ttl: u8,
     /// v4 only — header length in bytes (20..=60, multiple of 4).
     pub(super) ihl: usize,
@@ -164,7 +172,20 @@ fn fill_payload(out: &mut Vec<u8>, len: usize, seed: u64) {
 pub(super) fn build_valid_frame(spec: &PacketSpec) -> ValidPacket {
     let mut frame = Vec::new();
     let ether_type: u16 = if spec.v6 { 0x86dd } else { 0x0800 };
-    write_eth_header(&mut frame, DST_MAC, SRC_MAC, spec.vlan_id, ether_type);
+    // Emit the L2 header by tag PRESENCE, not by `vlan_id != 0`, so a
+    // priority-tagged VLAN-0 frame still carries the 4-byte 802.1Q tag
+    // and lands L3 at offset 18. `write_eth_header` (production egress
+    // helper) keys on `vlan_id > 0`, so the priority-tagged-VID-0 case
+    // is built explicitly here (#2145).
+    frame.extend_from_slice(&DST_MAC);
+    frame.extend_from_slice(&SRC_MAC);
+    if spec.vlan_present {
+        // TCI = PCP(3) | DEI(1=0) | VID(12).
+        let tci = ((spec.pcp as u16 & 0x7) << 13) | (spec.vlan_id & 0x0fff);
+        frame.extend_from_slice(&0x8100u16.to_be_bytes());
+        frame.extend_from_slice(&tci.to_be_bytes());
+    }
+    frame.extend_from_slice(&ether_type.to_be_bytes());
     let l3 = frame.len();
 
     let l4_header_len = match spec.protocol {
@@ -322,7 +343,8 @@ pub(super) fn build_valid_frame(spec: &PacketSpec) -> ValidPacket {
             0
         },
         ingress_vlan_id: spec.vlan_id,
-        ingress_vlan_present: u8::from(spec.vlan_id != 0),
+        ingress_pcp: spec.pcp,
+        ingress_vlan_present: u8::from(spec.vlan_present),
         flow_src_port: src_port,
         flow_dst_port: dst_port,
         flow_src_addr: if spec.v6 {
@@ -456,10 +478,39 @@ pub(super) fn arb_meta() -> impl Strategy<Value = UserspaceDpMeta> {
 // Valid-packet strategies
 // ---------------------------------------------------------------------------
 
+/// Egress VLAN ID for the TX/rewrite/segment differential strategies,
+/// where VID 0 == untagged is the correct semantic (`write_eth_header`
+/// keys on `vid > 0`). The ingress frame builders use [`arb_vlan_tag`]
+/// instead so they can also generate priority-tagged VLAN-0 frames.
 pub(super) fn arb_vlan() -> impl Strategy<Value = u16> {
     prop_oneof![
         2 => Just(0u16),
         1 => 1u16..4095,
+    ]
+}
+
+/// A generated 802.1Q tag decision for an INGRESS frame: whether a tag
+/// is present, the VID, and the PCP. Untagged frames carry
+/// `present = false`; tagged frames carry `present = true` with an
+/// arbitrary VID (which may be 0 — the 802.1p priority-tagged shape)
+/// and PCP (#2145).
+#[derive(Clone, Copy, Debug)]
+pub(super) struct VlanTag {
+    pub(super) present: bool,
+    pub(super) vid: u16,
+    pub(super) pcp: u8,
+}
+
+pub(super) fn arb_vlan_tag() -> impl Strategy<Value = VlanTag> {
+    prop_oneof![
+        // Untagged.
+        2 => Just(VlanTag { present: false, vid: 0, pcp: 0 }),
+        // Tagged with a non-zero VID (the common 802.1Q case).
+        2 => (1u16..4095, 0u8..=7)
+            .prop_map(|(vid, pcp)| VlanTag { present: true, vid, pcp }),
+        // Priority-tagged VLAN 0 (PCP > 0, VID 0) — the #2145 shape the
+        // old `present = (vid != 0)` derivation could never produce.
+        1 => (1u8..=7).prop_map(|pcp| VlanTag { present: true, vid: 0, pcp }),
     ]
 }
 
@@ -485,8 +536,8 @@ pub(super) fn arb_ext_chain(max: usize) -> impl Strategy<Value = Vec<ExtHdr>> {
 type TupleParts = (
     (u32, u32, [u8; 16], [u8; 16]),
     (u16, u16),
-    u16, // vlan
-    u8,  // ttl 2..=255
+    VlanTag, // 802.1Q tag decision (present / vid / pcp)
+    u8,      // ttl 2..=255
     (usize, u64), // payload (len, seed)
 );
 
@@ -499,7 +550,7 @@ fn arb_tuple_parts(max_payload: usize) -> impl Strategy<Value = TupleParts> {
             any::<[u8; 16]>(),
         ),
         (any::<u16>(), any::<u16>()),
-        arb_vlan(),
+        arb_vlan_tag(),
         2u8..=255,
         (0usize..=max_payload, any::<u64>()),
     )
@@ -516,7 +567,7 @@ fn spec_from_parts(
     tcp_opt_len: usize,
     seq: u32,
 ) -> PacketSpec {
-    let ((src4, dst4, src6, dst6), (src_port, dst_port), vlan_id, ttl, (payload_len, payload_seed)) =
+    let ((src4, dst4, src6, dst6), (src_port, dst_port), vlan, ttl, (payload_len, payload_seed)) =
         parts;
     PacketSpec {
         v6,
@@ -527,7 +578,9 @@ fn spec_from_parts(
         protocol,
         src_port,
         dst_port,
-        vlan_id,
+        vlan_id: vlan.vid,
+        vlan_present: vlan.present,
+        pcp: vlan.pcp,
         ttl,
         ihl,
         ext,
@@ -705,7 +758,7 @@ pub(super) fn arb_seg_packet() -> impl Strategy<Value = (ValidPacket, usize)> {
             any::<[u8; 16]>(),
         ),
         (any::<u16>(), any::<u16>()),
-        arb_vlan(),
+        arb_vlan_tag(),
         2u8..=255,
         any::<bool>(),
         arb_ihl(),
@@ -727,7 +780,7 @@ pub(super) fn arb_seg_packet() -> impl Strategy<Value = (ValidPacket, usize)> {
             |(
                 ips,
                 ports,
-                vlan_id,
+                vlan,
                 ttl,
                 v6,
                 ihl,
@@ -752,7 +805,9 @@ pub(super) fn arb_seg_packet() -> impl Strategy<Value = (ValidPacket, usize)> {
                     protocol: PROTO_TCP,
                     src_port,
                     dst_port,
-                    vlan_id,
+                    vlan_id: vlan.vid,
+                    vlan_present: vlan.present,
+                    pcp: vlan.pcp,
                     ttl,
                     ihl,
                     ext: if v6 { ext } else { Vec::new() },

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -273,7 +273,15 @@ pub(super) fn stage_screen_check(
     else {
         return StageOutcome::Continue(ScreenCheckOutcome::Pass);
     };
-    let l3_off = if meta.ingress_vlan_id > 0 { 18 } else { 14 };
+    // L3 starts after the 802.1Q tag whenever a tag is PRESENT, not
+    // only when the VID is non-zero. 802.1p priority-tagged frames
+    // carry a real tag (TPID 0x8100 + PCP bits) with VID 0, so a
+    // `vlan_id > 0` test would read the IP header at offset 14 and
+    // parse the tag's TPID/TCI bytes as the IPv4/IPv6 header — the
+    // #2145 misclassification. `ingress_vlan_present` is the
+    // tag-presence signal the shim already sets (mirrors the CoS path
+    // in tx/cos_classify.rs).
+    let l3_off = if meta.ingress_vlan_present != 0 { 18 } else { 14 };
     let screen_pkt = extract_screen_info(
         packet_frame,
         meta.addr_family,
@@ -374,7 +382,10 @@ pub(super) fn stage_screen_syn_cookie_ack_on_session_miss(
     else {
         return StageOutcome::Continue(SynCookieAckOutcome::Pass);
     };
-    let l3_off = if meta.ingress_vlan_id > 0 { 18 } else { 14 };
+    // See `stage_screen_check`: decide L3 offset on tag PRESENCE, not
+    // VID > 0, so a priority-tagged VID-0 cookie ACK is parsed at the
+    // correct offset (18) instead of mis-reading the tag bytes (#2145).
+    let l3_off = if meta.ingress_vlan_present != 0 { 18 } else { 14 };
     let screen_pkt = extract_screen_info(
         packet_frame,
         meta.addr_family,
@@ -522,6 +533,106 @@ mod tests {
             tcp_flags: flags,
             ..UserspaceDpMeta::default()
         }
+    }
+
+    /// Build an IPv4 TCP SYN with the L2 header chosen by `vlan`:
+    /// `Vlan::None` → 14-byte untagged header; `Vlan::PriorityTagged`
+    /// → an 802.1p priority tag (TPID 0x8100, PCP 5, **VID 0**), so the
+    /// L3 header starts at offset 18 while `ingress_vlan_id` is 0. The
+    /// IPv4 header is built with `ihl` 32-bit words (5 = no options;
+    /// 6 = one option word, which trips the `ip-source-route` screen).
+    fn tcp_v4_syn_frame_with_l2(vlan: Vlan, ihl: u8) -> Vec<u8> {
+        let mut frame = Vec::new();
+        let dst_mac = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let src_mac = [0x00, 0x25, 0x90, 0x12, 0x34, 0x56];
+        frame.extend_from_slice(&dst_mac);
+        frame.extend_from_slice(&src_mac);
+        if let Vlan::PriorityTagged = vlan {
+            // 802.1Q TPID + TCI. TCI = PCP(3) | DEI(1) | VID(12); here
+            // PCP=5, DEI=0, VID=0 — the priority-tagged-VLAN-0 shape
+            // that #2145 mis-parsed.
+            frame.extend_from_slice(&0x8100u16.to_be_bytes());
+            frame.extend_from_slice(&(0x5u16 << 13).to_be_bytes());
+        }
+        frame.extend_from_slice(&0x0800u16.to_be_bytes());
+        let l3 = frame.len();
+        let ihl_bytes = ihl as usize * 4;
+        // IPv4 header: version/IHL, then the fixed 20-byte base header,
+        // then `ihl_bytes - 20` NOP option bytes.
+        frame.push(0x40 | ihl);
+        frame.push(0x00);
+        let total_len = (ihl_bytes + 20) as u16; // IP header + 20-byte TCP
+        frame.extend_from_slice(&total_len.to_be_bytes());
+        frame.extend_from_slice(&[0x00, 0x01, 0x40, 0x00, 64, PROTO_TCP, 0x00, 0x00]);
+        frame.extend_from_slice(&Ipv4Addr::new(192, 0, 2, 10).octets());
+        frame.extend_from_slice(&Ipv4Addr::new(198, 51, 100, 20).octets());
+        // IPv4 options as NOP (0x01) to reach `ihl_bytes`.
+        frame.resize(l3 + ihl_bytes, 0x01);
+        let ip_csum = checksum16(&frame[l3..l3 + ihl_bytes]);
+        frame[l3 + 10..l3 + 12].copy_from_slice(&ip_csum.to_be_bytes());
+        // TCP SYN.
+        let l4 = frame.len();
+        frame.extend_from_slice(&49152u16.to_be_bytes());
+        frame.extend_from_slice(&443u16.to_be_bytes());
+        frame.extend_from_slice(&1u32.to_be_bytes()); // seq
+        frame.extend_from_slice(&0u32.to_be_bytes()); // ack
+        frame.extend_from_slice(&[0x50, TCP_FLAG_SYN, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        recompute_l4_checksum_ipv4(&mut frame[l3..], ihl_bytes, PROTO_TCP, false)
+            .expect("tcp checksum");
+        let _ = l4;
+        frame
+    }
+
+    #[derive(Clone, Copy)]
+    enum Vlan {
+        None,
+        PriorityTagged,
+    }
+
+    /// Metadata mirroring the shim contract for the frame built above:
+    /// tagged frames carry `ingress_vlan_present = 1` with
+    /// `ingress_vlan_id = 0` (priority tag) and `l3_offset = 18`;
+    /// untagged frames carry `present = 0`, `l3_offset = 14`.
+    fn tcp_v4_syn_meta_with_l2(frame: &[u8], vlan: Vlan) -> UserspaceDpMeta {
+        let (l3, present): (u16, u8) = match vlan {
+            Vlan::None => (14, 0),
+            Vlan::PriorityTagged => (18, 1),
+        };
+        UserspaceDpMeta {
+            magic: USERSPACE_META_MAGIC,
+            version: USERSPACE_META_VERSION,
+            length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+            ingress_ifindex: 24,
+            ingress_vlan_id: 0,
+            ingress_pcp: if present != 0 { 5 } else { 0 },
+            ingress_vlan_present: present,
+            l3_offset: l3,
+            l4_offset: l3 + 20,
+            payload_offset: l3 + 40,
+            pkt_len: frame.len() as u16 - l3,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            tcp_flags: TCP_FLAG_SYN,
+            ..UserspaceDpMeta::default()
+        }
+    }
+
+    /// Screen state with only the IP source-route check armed. The
+    /// check fires purely on `ip_ihl > 5` read from the frame at the
+    /// computed L3 offset, so the verdict is a direct probe of whether
+    /// the screen stage parsed the IP header at the right offset.
+    fn source_route_screen() -> ScreenState {
+        let mut profiles = FxHashMap::default();
+        profiles.insert(
+            "lan".to_string(),
+            ScreenProfile {
+                source_route: true,
+                ..ScreenProfile::default()
+            },
+        );
+        let mut screen = ScreenState::new();
+        screen.update_profiles(profiles);
+        screen
     }
 
     fn syn_cookie_screen() -> ScreenState {
@@ -732,6 +843,202 @@ mod tests {
                 ScreenVerdict::SynCookieChallenge(_)
             ),
             "validated SYN-cookie bypass must be single-use"
+        );
+    }
+
+    /// #2145 regression: a priority-tagged VLAN-0 SYN
+    /// (`ingress_vlan_present = 1`, `ingress_vlan_id = 0`) must have its
+    /// IP header parsed at offset 18 by the screen + SYN-cookie stages,
+    /// not at the untagged offset 14. The screen carries an IPv4 header
+    /// with IHL = 6, so the `ip-source-route` check fires *iff* the
+    /// stage reads `ip_ihl` from the real header at offset 18. Pre-fix
+    /// (`ingress_vlan_id > 0`) the stage used offset 14, read the
+    /// 802.1Q TPID byte (0x81) as the IP header → `ip_ihl = 1`,
+    /// source-route did NOT fire, and the SYN passed. An untagged
+    /// control frame (with the same IHL-6 header at offset 14) keeps
+    /// dropping, proving the assertion is not tautological.
+    #[test]
+    fn priority_tagged_vlan0_screen_stage_parses_l3_at_offset_18() {
+        let forwarding = build_forwarding_state(&super::super::test_fixtures::nat_snapshot());
+        let ident = BindingIdentity {
+            slot: 0,
+            queue_id: 0,
+            worker_id: 0,
+            interface: Arc::<str>::from("reth1.0"),
+            ifindex: 24,
+        };
+        let binding_lookup = WorkerBindingLookup::default();
+        let mirror_targets = MirrorTargetMap::default();
+        let ha_state = BTreeMap::new();
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+        let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+        let last_resolution = Arc::new(Mutex::new(None));
+        let peer_worker_commands = Vec::new();
+        let dnat_fds = DnatTableFds::default();
+        let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+        let (event_handle, _event_rx) = crate::event_stream::test_worker_handle(
+            8,
+            DataplaneEventRateLimitConfig {
+                events_per_second: 0,
+                burst: 0,
+            },
+        );
+        let worker_ctx = WorkerContext {
+            ident: &ident,
+            binding_lookup: &binding_lookup,
+            mirror_targets: &mirror_targets,
+            forwarding: &forwarding,
+            ha_state: &ha_state,
+            dynamic_neighbors: &dynamic_neighbors,
+            neighbor_resolver: None,
+            shared_sessions: &shared_sessions,
+            shared_nat_sessions: &shared_nat_sessions,
+            shared_forward_wire_sessions: &shared_forward_wire_sessions,
+            shared_owner_rg_indexes: &shared_owner_rg_indexes,
+            slow_path: None,
+            event_stream: Some(&event_handle),
+            local_tunnel_deliveries: &local_tunnel_deliveries,
+            recent_exceptions: &recent_exceptions,
+            last_resolution: &last_resolution,
+            peer_worker_commands: &peer_worker_commands,
+            dnat_fds: &dnat_fds,
+            rg_epochs: &rg_epochs,
+            cold_path_sample_mask: 0xff,
+        };
+
+        // Run one SYN through stage_screen_check and return the verdict
+        // (true = dropped) plus the screen_drops delta.
+        let run_screen = |vlan: Vlan| -> bool {
+            let mut screen = source_route_screen();
+            let frame = tcp_v4_syn_frame_with_l2(vlan, 6);
+            let meta = tcp_v4_syn_meta_with_l2(&frame, vlan);
+            let flow =
+                parse_session_flow_from_bytes(&frame, meta).expect("session flow from tagged SYN");
+            let mut counters = BatchCounters::default();
+            let outcome = stage_screen_check(
+                Some(&flow),
+                &frame,
+                meta,
+                None,
+                TEST_NOW_SECS,
+                &mut screen,
+                &mut counters,
+                &worker_ctx,
+            );
+            matches!(outcome, StageOutcome::RecycleAndContinue)
+        };
+
+        // Priority-tagged VID-0 frame: real IP header (IHL 6) sits at
+        // offset 18. Post-fix the stage reads it and source-route fires.
+        assert!(
+            run_screen(Vlan::PriorityTagged),
+            "priority-tagged VLAN-0 SYN with IHL=6 must be parsed at \
+             offset 18 and dropped by ip-source-route (#2145)"
+        );
+        // Untagged control: same IHL-6 header at offset 14, still dropped.
+        assert!(
+            run_screen(Vlan::None),
+            "untagged SYN with IHL=6 must still be parsed at offset 14 \
+             and dropped by ip-source-route"
+        );
+
+        // The same offset bug lives in the SYN-cookie ACK stage. The
+        // returning cookie ACK's TCP acknowledgement number is read
+        // from the frame at l3_off + ihl*4 + 8; if l3_off is wrong, the
+        // cookie ack is read from the wrong bytes and validation fails.
+        // Drive a real challenge/validate cycle with priority-tagged
+        // VID-0 frames (IHL 5, so the TCP ack sits at offset 18+20+8 =
+        // 46). Post-fix the stage reads the correct cookie+1 and
+        // returns Validated; pre-fix it read offset 14, parsed garbage,
+        // and returned Invalid → RecycleAndContinue.
+        let mut cookie_screen = syn_cookie_screen();
+        let syn_frame = tcp_v4_syn_frame_with_l2(Vlan::PriorityTagged, 5);
+        let syn_meta = tcp_v4_syn_meta_with_l2(&syn_frame, Vlan::PriorityTagged);
+        let syn_flow = parse_session_flow_from_bytes(&syn_frame, syn_meta)
+            .expect("session flow from tagged SYN");
+        let syn_info = extract_screen_info(
+            &syn_frame,
+            syn_meta.addr_family,
+            syn_meta.protocol,
+            syn_meta.tcp_flags,
+            syn_meta.pkt_len,
+            syn_flow.src_ip,
+            syn_flow.dst_ip,
+            syn_flow.forward_key.src_port,
+            syn_flow.forward_key.dst_port,
+            syn_meta.l3_offset as usize,
+        );
+        // First SYN passes; second crosses the flood threshold and
+        // mints the cookie challenge (mirrors the SYN-cookie test).
+        assert_eq!(
+            cookie_screen.check_packet_with_zone_id(
+                "lan",
+                TEST_LAN_ZONE_ID,
+                &syn_info,
+                TEST_NOW_SECS
+            ),
+            ScreenVerdict::Pass
+        );
+        let challenge = match cookie_screen.check_packet_with_zone_id(
+            "lan",
+            TEST_LAN_ZONE_ID,
+            &syn_info,
+            TEST_NOW_SECS,
+        ) {
+            ScreenVerdict::SynCookieChallenge(challenge) => challenge,
+            other => panic!("expected SYN-cookie challenge, got {other:?}"),
+        };
+
+        // Returning ACK: priority-tagged VID-0, ack = cookie + 1, with
+        // the TCP ack field written at the correct offset-18 layout.
+        let ack_frame = {
+            let mut f = tcp_v4_syn_frame_with_l2(Vlan::PriorityTagged, 5);
+            // l3=18, ihl=20 → TCP at 38, flags byte at 38+13=51, ack
+            // field at 38+8=46.
+            f[51] = TCP_FLAG_ACK;
+            f[46..50].copy_from_slice(&challenge.cookie_isn.wrapping_add(1).to_be_bytes());
+            recompute_l4_checksum_ipv4(&mut f[18..], 20, PROTO_TCP, false)
+                .expect("tcp checksum");
+            f
+        };
+        let ack_meta = tcp_v4_syn_meta_with_l2(&ack_frame, Vlan::PriorityTagged);
+        // The shim contract reports the real protocol/flags; flip the
+        // meta's TCP flag to ACK so the stage routes this as a returning
+        // ACK (the meta tcp_flags field is set by the parser, not read
+        // from the frame's l3 offset).
+        let ack_meta = UserspaceDpMeta {
+            tcp_flags: TCP_FLAG_ACK,
+            ..ack_meta
+        };
+        let ack_flow = parse_session_flow_from_bytes(&ack_frame, ack_meta)
+            .expect("session flow from tagged ACK");
+        let mut counters = BatchCounters::default();
+        assert!(
+            matches!(
+                stage_screen_syn_cookie_ack_on_session_miss(
+                    Some(&ack_flow),
+                    &ack_frame,
+                    ack_meta,
+                    None,
+                    TEST_NOW_SECS,
+                    &mut cookie_screen,
+                    &mut counters,
+                    &worker_ctx,
+                ),
+                StageOutcome::Continue(SynCookieAckOutcome::Validated)
+            ),
+            "priority-tagged VLAN-0 cookie ACK must be parsed at offset \
+             18 by the SYN-cookie stage so its TCP ack matches cookie+1 \
+             (#2145); pre-fix it read offset 14 and rejected the cookie"
+        );
+        assert_eq!(
+            counters.syn_cookie_ack_valid, 1,
+            "the tagged cookie ACK must validate exactly once"
         );
     }
 }


### PR DESCRIPTION
## Summary

The userspace screen stage and the SYN-cookie-ACK stage computed the L3
offset with `if meta.ingress_vlan_id > 0 { 18 } else { 14 }`
(`poll_stages.rs:276/377`). 802.1p **priority-tagged** frames carry a
real 802.1Q tag (TPID 0x8100, PCP bits) but with **VID 0**; the shim
sets `ingress_vlan_present=1`, `ingress_vlan_id=0` for them. The
VID-based test therefore picked offset 14 (untagged) and
`extract_screen_info` read the IP header from the tag's TPID/TCI bytes
— **LAND / SYN-frag / flood misclassification**, and the SYN-cookie
challenge **skipped or computed from corrupted bytes** (HIGH, security).

This switches both offset decisions to `meta.ingress_vlan_present != 0`
(tag presence), matching `tx/cos_classify.rs` and the production frame
parser `frame_l3_offset` (which already keys on the TPID, returning 18
regardless of VID).

Narrow correctness fix only. The broader `afxdp/l2` `L2Tag` /
`l3_offset_from_meta` centralization is deferred to **#2150**. Egress
frame builders (`egress.vlan_id`, `write_eth_header`) keep `vlan_id > 0`
— there VID 0 == untagged is the correct, intended semantic.

## Sites switched to `ingress_vlan_present`

- `userspace-dp/src/afxdp/poll_stages.rs:276` — `stage_screen_check`
- `userspace-dp/src/afxdp/poll_stages.rs:377` — `stage_screen_syn_cookie_ack_on_session_miss`

These are the only two `vlan_id > 0` L3-offset decisions on the ingress
screen path (all other `vlan_id > 0` sites are egress builders — left
unchanged).

## Property-strategy extension

Decoupled tag presence from VID so `present=true, vid=0, pcp>0` frames
are generatable (the old `present = (vid != 0)` derivation masked this):

- `PacketSpec` gains `vlan_present: bool` + `pcp: u8`.
- `build_valid_frame` emits the 802.1Q tag on `vlan_present` (not VID)
  and sets `ingress_vlan_present` / `ingress_pcp`.
- new `arb_vlan_tag()` generates untagged / normal-tagged /
  priority-tagged-VID-0; egress `arb_vlan()` kept as `u16`.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --no-run` clean (all test binaries)
- [x] New `poll_stages` regression test
  `priority_tagged_vlan0_screen_stage_parses_l3_at_offset_18`:
  - tagged VID-0 SYN → `stage_screen_check` trips `ip-source-route`
    only if `ip_ihl` is read at offset 18; untagged control still uses 14
  - tagged VID-0 cookie ACK → `stage_screen_syn_cookie_ack_on_session_miss`
    validates only if `tcp_ack` is read at offset 18
  - **proven non-tautological**: FAILS with the fix reverted
- [x] New frame-level pin
  `pin_priority_tagged_vlan0_frame_parses_l3_at_offset_18`
- [x] Frame `prop_tests`: 33/33 (was 32; +1 pin; round-trip property now
  exercises the priority-tagged-VID-0 shape)
- [x] New test 5/5 flake check (release)
- [x] Full release suite: 2090/2091 — the one failure is a pre-existing
  flaky concurrency test (`worker_queue_tests::concurrent_recovery_processes_each_command_exactly_once`,
  untouched code) — 4/5 in isolation, unrelated to this change
- [ ] Targeted smoke (hot-path/security) — deferred to the maintainer

No wire-contract change (`UserspaceDpMeta` untouched) → Go side
unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)