### PR TITLE
state_writer: fsync fallback file and parent dir on both paths (#2147)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,23 @@
 # Action Log
 
+## 2026-06-21 — #2147 state_writer fallback path crash-safety
+
+- **Timestamp**: 2026-06-21
+- **Action**: Fixed #2147 — the userspace state_writer's sync fallback
+  (`persist_sync`) wrote the temp file via `fs::write` then renamed with
+  NO file fsync, and neither transport fsync'd the parent directory, so a
+  state snapshot could be lost or torn on power loss. Extracted one shared
+  `finalize_durably` (file fsync → atomic rename → parent-dir fsync) used
+  by BOTH the io_uring transport and the fallback, so neither can drift
+  from the durability contract. Added a `sync_all` test seam (function-
+  pointer hook) and four unit tests, mutation-verified to FAIL if either
+  fsync is deleted from the finalizer.
+- **File(s)**: userspace-dp/src/state_writer.rs,
+  userspace-dp/src/FEATURES.md
+- **Validation**: full userspace-dp test suite green (2094+46+8+16+1, 0
+  failed); new tests 5/5 flake-clean; both fsync-removal mutations fail
+  the tests.
+
 ## 2026-06-20 — #2120 PR #2166 Copilot fold (doc nits + SELF-HEAL/HOLD expect hardening)
 
 - **Timestamp**: 2026-06-20

--- a/userspace-dp/src/FEATURES.md
+++ b/userspace-dp/src/FEATURES.md
@@ -45,7 +45,7 @@ ordering.
 | File | What it does |
 |------|--------------|
 | `protocol.rs` | Control request / response and snapshot schema types shared between the control socket server (`server/`) and the AF_XDP coordinator. The JSON tags ARE the wire contract — changing them without updating the Go side (`pkg/dataplane/userspace/protocol.go`) breaks the helper. |
-| `state_writer.rs` | `io_uring`-backed atomic writer for the daemon's state snapshot file. |
+| `state_writer.rs` | Crash-safe writer for the daemon's state snapshot file. Both the `io_uring` transport and the sync fallback route through one durable finalizer (`finalize_durably`): fsync temp file → atomic rename → fsync parent dir (#2147). |
 | `xsk_ffi.rs` | Drop-in replacement for `xdpilone` using libxdp's XSK helpers via a C bridge. Provides the same type names (`Umem`, `UmemConfig`, `UmemChunk`, `IfInfo`, `Socket`, `DeviceQueue`, `RingRx`, `RingTx`, `ReadRx`, `WriteTx`, `WriteFill`, `ReadComplete`, `XdpDesc`) so the rest of the crate compiles unchanged. |
 | `test_zone_ids.rs` | Test-only zone-id constants used across `_tests.rs` files. |
 | `main.rs` / `main_tests.rs` | Crate `main()` — argv handling and dispatch into `server::lifecycle::run()`. Tests live next door. |

--- a/userspace-dp/src/state_writer.rs
+++ b/userspace-dp/src/state_writer.rs
@@ -1,12 +1,39 @@
 use io_uring::{IoUring, opcode, types};
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::os::fd::AsRawFd;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
+
+/// Durability seam: fsync a [`File`]. Indirected through a function pointer so
+/// crash-safety unit tests can record calls (and so a test FAILS if the fsync
+/// is removed from the durable finalizer). Production always uses
+/// [`real_sync_all`].
+#[cfg(test)]
+type SyncAllFn = fn(&File) -> io::Result<()>;
+
+fn real_sync_all(f: &File) -> io::Result<()> {
+    f.sync_all()
+}
+
+#[cfg(test)]
+thread_local! {
+    static SYNC_ALL_HOOK: std::cell::Cell<SyncAllFn> = const { std::cell::Cell::new(real_sync_all) };
+}
+
+#[cfg(test)]
+fn sync_all(f: &File) -> io::Result<()> {
+    SYNC_ALL_HOOK.with(|h| (h.get())(f))
+}
+
+#[cfg(not(test))]
+#[inline]
+fn sync_all(f: &File) -> io::Result<()> {
+    real_sync_all(f)
+}
 
 enum WriteMode {
     IoUring(IoUring),
@@ -130,16 +157,54 @@ fn persist_with_io_uring(ring: &mut IoUring, path: &str, data: &[u8]) -> Result<
         .open(&tmp)
         .map_err(|e| format!("open temp state file {}: {e}", tmp.display()))?;
     write_all_with_ring(ring, file.as_raw_fd(), data)?;
-    file.sync_all()
-        .map_err(|e| format!("sync temp state file {}: {e}", tmp.display()))?;
-    fs::rename(&tmp, path).map_err(|e| format!("rename {} -> {}: {e}", tmp.display(), path))?;
-    Ok(())
+    finalize_durably(&file, &tmp, path)
 }
 
 fn persist_sync(path: &str, data: &[u8]) -> Result<(), String> {
     let tmp = temporary_path(path);
-    fs::write(&tmp, data).map_err(|e| format!("write temp state file {}: {e}", tmp.display()))?;
-    fs::rename(&tmp, path).map_err(|e| format!("rename {} -> {}: {e}", tmp.display(), path))?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&tmp)
+        .map_err(|e| format!("open temp state file {}: {e}", tmp.display()))?;
+    {
+        use io::Write;
+        file.write_all(data)
+            .map_err(|e| format!("write temp state file {}: {e}", tmp.display()))?;
+    }
+    finalize_durably(&file, &tmp, path)
+}
+
+/// Shared crash-safe finalizer for both write transports (io_uring and the
+/// sync fallback). The temp file's data must already be fully written. Applies
+/// the same durability contract regardless of how the bytes got there:
+///   1. fsync the temp file so its data + metadata reach stable storage,
+///   2. atomically rename it onto the destination,
+///   3. fsync the parent directory so the rename itself survives power loss.
+///
+/// Without (1) the file can be empty/torn after a crash; without (3) the rename
+/// (the dirent change) can be lost even though the file data is durable. Both
+/// modes go through here so neither can drift from this contract.
+fn finalize_durably(file: &File, tmp: &Path, dest: &str) -> Result<(), String> {
+    sync_all(file).map_err(|e| format!("sync temp state file {}: {e}", tmp.display()))?;
+    fs::rename(tmp, dest).map_err(|e| format!("rename {} -> {dest}: {e}", tmp.display()))?;
+    sync_parent_dir(dest)?;
+    Ok(())
+}
+
+/// fsync the directory that contains `dest` so the rename's dirent update is
+/// durable. A missing parent (path has no directory component) is treated as
+/// the current directory.
+fn sync_parent_dir(dest: &str) -> Result<(), String> {
+    let parent = Path::new(dest).parent().filter(|p| !p.as_os_str().is_empty());
+    let dir = match parent {
+        Some(p) => p,
+        None => Path::new("."),
+    };
+    let dir_file =
+        File::open(dir).map_err(|e| format!("open parent dir {} for fsync: {e}", dir.display()))?;
+    sync_all(&dir_file).map_err(|e| format!("fsync parent dir {}: {e}", dir.display()))?;
     Ok(())
 }
 
@@ -189,4 +254,176 @@ fn temporary_path(path: &str) -> PathBuf {
         .unwrap_or_else(|| "tmp".to_string());
     tmp.set_extension(ext);
     tmp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    thread_local! {
+        static SYNC_CALLS: AtomicUsize = const { AtomicUsize::new(0) };
+        // 1-based index of the fsync call to fail; 0 = never fail.
+        static SYNC_FAIL_AT: AtomicUsize = const { AtomicUsize::new(0) };
+        // Records, per sync_all call, whether the synced fd was a directory.
+        static SYNC_WAS_DIR: RefCell<Vec<bool>> = const { RefCell::new(Vec::new()) };
+    }
+
+    fn fd_is_dir(f: &File) -> bool {
+        f.metadata().map(|m| m.is_dir()).unwrap_or(false)
+    }
+
+    /// Test hook: counts every fsync, records whether each was a directory fd,
+    /// and optionally fails one specific call (1-based) for fault injection.
+    fn recording_sync(f: &File) -> io::Result<()> {
+        let this_call = SYNC_CALLS.with(|c| c.fetch_add(1, AtomicOrdering::Relaxed) + 1);
+        SYNC_WAS_DIR.with(|v| v.borrow_mut().push(fd_is_dir(f)));
+        let fail_at = SYNC_FAIL_AT.with(|r| r.load(AtomicOrdering::Relaxed));
+        if fail_at != 0 && this_call == fail_at {
+            return Err(io::Error::new(io::ErrorKind::Other, "injected fsync failure"));
+        }
+        real_sync_all(f)
+    }
+
+    struct SyncGuard;
+    impl SyncGuard {
+        fn install() -> Self {
+            SYNC_CALLS.with(|c| c.store(0, AtomicOrdering::Relaxed));
+            SYNC_FAIL_AT.with(|r| r.store(0, AtomicOrdering::Relaxed));
+            SYNC_WAS_DIR.with(|v| v.borrow_mut().clear());
+            SYNC_ALL_HOOK.with(|h| h.set(recording_sync));
+            SyncGuard
+        }
+        fn calls(&self) -> usize {
+            SYNC_CALLS.with(|c| c.load(AtomicOrdering::Relaxed))
+        }
+        fn dir_syncs(&self) -> usize {
+            SYNC_WAS_DIR.with(|v| v.borrow().iter().filter(|&&d| d).count())
+        }
+        /// Make the `n`th fsync (1-based) fail.
+        fn fail_at(&self, n: usize) {
+            SYNC_FAIL_AT.with(|r| r.store(n, AtomicOrdering::Relaxed));
+        }
+    }
+    impl Drop for SyncGuard {
+        fn drop(&mut self) {
+            SYNC_ALL_HOOK.with(|h| h.set(real_sync_all));
+        }
+    }
+
+    fn tmpdir() -> PathBuf {
+        let base = std::env::var_os("TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        let unique = format!(
+            "xpf-state-writer-test-{}-{:?}",
+            std::process::id(),
+            thread::current().id()
+        );
+        let dir = base.join(unique);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create test dir");
+        dir
+    }
+
+    // The durability contract that both modes must honor: exactly the file
+    // fsync + the parent-directory fsync. If either fsync is deleted from
+    // finalize_durably, these counts drop and the test fails (#2147 / #1968:
+    // a durability test must fail if the durable effect is removed).
+    const EXPECTED_FSYNCS_PER_PERSIST: usize = 2; // temp file + parent dir
+    const EXPECTED_DIR_FSYNCS_PER_PERSIST: usize = 1; // parent dir
+
+    #[test]
+    fn fallback_persist_fsyncs_file_and_parent_dir() {
+        let dir = tmpdir();
+        let path = dir.join("state.json");
+        let path_str = path.to_str().unwrap();
+        let guard = SyncGuard::install();
+
+        persist_sync(path_str, b"hello durable fallback").expect("fallback persist");
+
+        assert_eq!(
+            guard.calls(),
+            EXPECTED_FSYNCS_PER_PERSIST,
+            "fallback path must fsync the temp file AND the parent dir"
+        );
+        assert_eq!(
+            guard.dir_syncs(),
+            EXPECTED_DIR_FSYNCS_PER_PERSIST,
+            "fallback path must fsync the parent directory after rename"
+        );
+        assert_eq!(fs::read(&path).unwrap(), b"hello durable fallback");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn finalize_durably_fsyncs_file_and_parent_dir() {
+        // Drive the shared finalizer directly so the test pins the contract
+        // both transports route through, independent of write mechanism.
+        let dir = tmpdir();
+        let dest = dir.join("snap.json");
+        let dest_str = dest.to_str().unwrap();
+        let tmp = temporary_path(dest_str);
+        let guard = SyncGuard::install();
+
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp)
+            .unwrap();
+        {
+            use io::Write;
+            (&file).write_all(b"payload").unwrap();
+        }
+        finalize_durably(&file, &tmp, dest_str).expect("finalize");
+
+        assert_eq!(guard.calls(), EXPECTED_FSYNCS_PER_PERSIST);
+        assert_eq!(guard.dir_syncs(), EXPECTED_DIR_FSYNCS_PER_PERSIST);
+        assert!(!tmp.exists(), "temp file must be renamed away");
+        assert_eq!(fs::read(&dest).unwrap(), b"payload");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn file_fsync_failure_is_propagated_and_does_not_rename() {
+        // First fsync is the temp file. If it fails, the rename must NOT run —
+        // the destination must keep its prior contents.
+        let dir = tmpdir();
+        let dest = dir.join("state.json");
+        let dest_str = dest.to_str().unwrap();
+        fs::write(&dest, b"previous-good").unwrap();
+
+        let guard = SyncGuard::install();
+        guard.fail_at(1); // 1st fsync = temp file
+
+        let err = persist_sync(dest_str, b"new-data").expect_err("file fsync should fail");
+        assert!(err.contains("sync temp state file"), "unexpected error: {err}");
+        assert_eq!(
+            fs::read(&dest).unwrap(),
+            b"previous-good",
+            "destination must be untouched when the temp-file fsync fails"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn parent_dir_fsync_failure_is_propagated() {
+        // Let the file fsync succeed but fail the directory fsync (the 2nd
+        // call). The error must surface so a caller never believes a snapshot
+        // is durable when the rename may be lost on power loss.
+        let dir = tmpdir();
+        let dest = dir.join("state.json");
+        let dest_str = dest.to_str().unwrap();
+
+        let guard = SyncGuard::install();
+        guard.fail_at(2); // 2nd fsync = parent dir
+
+        let err = persist_sync(dest_str, b"data").expect_err("parent dir fsync should fail");
+        assert!(err.contains("fsync parent dir"), "unexpected error: {err}");
+        // Both fsyncs were attempted (file succeeded, dir failed) -> 2 calls.
+        assert_eq!(guard.calls(), 2);
+        let _ = fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #2147. The userspace `state_writer`'s sync fallback (`persist_sync`,
used when io_uring is unavailable — e.g. a container that blocks it) wrote the
temp file via `fs::write` and renamed it with **no file fsync at all**. The
io_uring path fsync'd the temp file but **neither path fsync'd the parent
directory** after the rename. On power loss the fallback could leave the
snapshot empty or torn, and either path could lose the rename (the dirent
change) itself. This is the Rust-side equivalent of the Go configstore
crash-safety contract.

## Fix

Extract one shared durable finalizer, `finalize_durably`, that both write
transports route through:

1. fsync the temp file (data + metadata to stable storage),
2. atomically `rename` it onto the destination,
3. fsync the parent directory so the rename survives power loss.

io_uring is now only the write *transport*, not a separate durability
protocol. The fallback opens the temp file with `OpenOptions` and writes
through the same `File` handle so it can fsync it before the rename. Any
step's error propagates, so a caller never believes a snapshot is durable
when an fsync failed and the rename may be lost.

## Tests

Added a `sync_all` test seam (a function-pointer hook; production always uses
`real_sync_all`) and four unit tests:

- `fallback_persist_fsyncs_file_and_parent_dir` — the fallback fsyncs exactly
  the temp file + the parent dir.
- `finalize_durably_fsyncs_file_and_parent_dir` — pins the shared contract
  directly.
- `file_fsync_failure_is_propagated_and_does_not_rename` — a temp-file fsync
  failure aborts before the rename; the destination keeps its prior bytes.
- `parent_dir_fsync_failure_is_propagated` — a parent-dir fsync failure
  surfaces.

Per the #1968 durability-test discipline, the tests are **mutation-verified**:
deleting either fsync from `finalize_durably` makes them fail (confirmed
locally — removing the parent-dir fsync fails 3/4, removing the file fsync
fails 4/4).

## Validation

- Full `userspace-dp` test suite green: 2094 + 46 + 8 + 16 + 1 passed, 0 failed.
- The four new tests pass 5/5 flake runs.
- Release build clean (no new warnings; the previously-unused alias warning is gone).
- Isolated durability-correctness bug — unit-testable, no cluster smoke needed.

## Self-review (Claude SMR)

- fsync ordering (file → rename → dir) is the standard atomic-durable-write recipe.
- Directory fsync uses the portable POSIX idiom (`File::open(dir)` read-only + `fsync`).
- Relative-filename edge case handled: empty parent falls back to `.`.
- The io_uring path now also routes its fsync through the shared finalizer, so
  the seam covers both modes and they cannot drift.
- The test seam is `thread_local` and only exists under `#[cfg(test)]`; tests
  drive the persist functions on the test thread, so the hook is observed with
  no cross-thread effect on the production writer thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
