### PR TITLE
#2136: NetFlow per-flow-server export-version binding (no double-export)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,11 @@
 # Action Log
 
+## 2026-06-21 — #2136 NetFlow per-flow-server export-version binding (no double-export)
+
+- **Timestamp**: 2026-06-21
+- **Action**: Fixed #2136 (deferred #2129 follow-up). A flow-server under BOTH global `version9` and `version-ipfix` was double-exported (one v9 + one IPFIX datagram to the same collector socket, mismatched 1-in-N). Bound each flow-server to exactly one export version (Junos semantics): added `FlowServer.Version`/`VersionIPFIXTemplate` + parse the per-server `version-ipfix`/`version-ipfix-template` selectors; `BuildExportConfig`/`BuildIPFIXExportConfig` now take only the flow-servers resolved to their version via shared `resolveFlowServerVersion`/`collectVersionCollectors`. Semantics for an UNBOUND server with both globals set: IPFIX wins (documented precedence — IETF-standard superset of v9; one stream not two). CLI shows IPFIX template; README/config-schema docs updated. Tests FAIL on pre-fix collect-all (mutation-verified) at both the build-config and live-reconcile/callback layers.
+- **File(s)**: pkg/config/types_system.go, pkg/config/compiler_services.go, pkg/config/schema_routing.go, pkg/config/parser_security_test.go, pkg/flowexport/manager.go, pkg/flowexport/version_binding_test.go, pkg/daemon/daemon_flowexport_reconcile_test.go, pkg/cli/cli_show_flow.go, pkg/cli/cli_show_routing.go, pkg/flowexport/README.md, docs/config-schema.md
+
 ## 2026-06-20 — #2120 PR #2166 Copilot fold (doc nits + SELF-HEAL/HOLD expect hardening)
 
 - **Timestamp**: 2026-06-20

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -521,10 +521,16 @@ the value sits in a single typed slot:
     server whose port is `<1` or `>65535`). `flow-server` keeps `args:1` for
     the collector address and gains a children map (the typed `port` plus the
     other compiler-read children `version9-template`, `version9 { template }`,
-    `source-address`), which deliberately flips a BARE `flow-server <addr>`
-    from single-value REPLACE to named-container APPEND — benign: a bare
-    no-port server compiles `Port==0` and the snapshot builder skips it, and
-    real multi-collector configs already take the container path.
+    `version-ipfix-template`, `version-ipfix { template }`, `source-address`),
+    which deliberately flips a BARE `flow-server <addr>` from single-value
+    REPLACE to named-container APPEND — benign: a bare no-port server compiles
+    `Port==0` and the snapshot builder skips it, and real multi-collector
+    configs already take the container path. The `version9` / `version-ipfix`
+    per-server selectors bind the collector to exactly one export protocol
+    (Junos semantics, #2136); the live Go exporter routes each flow-server to a
+    single version's collector set so a collector configured under both global
+    version stanzas is never double-exported (an unbound server resolves to
+    IPFIX when both globals are set — see `pkg/flowexport/README.md`).
   - `forwarding-options allow-dataplane-sleep` (#2008 H13 Stage 1) — a
     presence-only flag (no value, `children: nil`). Previously accepted via the
     no-schema-match fall-through and silently dropped; now a typed leaf that

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -1148,7 +1148,9 @@ func (c *CLI) showFlowMonitoring() error {
 					}
 					tmplStr := ""
 					if fs.Version9Template != "" {
-						tmplStr = fmt.Sprintf(" (template: %s)", fs.Version9Template)
+						tmplStr = fmt.Sprintf(" (v9 template: %s)", fs.Version9Template)
+					} else if fs.VersionIPFIXTemplate != "" {
+						tmplStr = fmt.Sprintf(" (ipfix template: %s)", fs.VersionIPFIXTemplate)
 					}
 					fmt.Printf("    Collector: %s%s%s\n", fs.Address, portStr, tmplStr)
 				}

--- a/pkg/cli/cli_show_routing.go
+++ b/pkg/cli/cli_show_routing.go
@@ -1071,6 +1071,9 @@ func (c *CLI) showForwardingOptions() error {
 					if fs.Version9Template != "" {
 						fmt.Printf("      Version 9 template: %s\n", fs.Version9Template)
 					}
+					if fs.VersionIPFIXTemplate != "" {
+						fmt.Printf("      IPFIX template: %s\n", fs.VersionIPFIXTemplate)
+					}
 				}
 				if fam.SourceAddress != "" {
 					fmt.Printf("    Source address: %s\n", fam.SourceAddress)

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -1037,14 +1037,32 @@ func compileSamplingFamily(node *Node) *SamplingFamily {
 						}
 					case "version9-template":
 						fs.Version9Template = nodeVal(prop)
+						fs.Version = FlowServerVersion9
 					case "version9":
 						// Hierarchical: version9 { template { <name>; } }
+						fs.Version = FlowServerVersion9
 						if tmplNode := prop.FindChild("template"); tmplNode != nil {
 							// Template name is either nodeVal or first child's name
 							if v := nodeVal(tmplNode); v != "" {
 								fs.Version9Template = v
 							} else if len(tmplNode.Children) > 0 {
 								fs.Version9Template = tmplNode.Children[0].Name()
+							}
+						}
+					case "version-ipfix-template":
+						fs.VersionIPFIXTemplate = nodeVal(prop)
+						fs.Version = FlowServerVersionIPFIX
+					case "version-ipfix":
+						// Hierarchical: version-ipfix { template { <name>; } }
+						// Junos binds each flow-server to exactly one export
+						// version; the per-server version-ipfix selector routes
+						// THIS collector to the IPFIX exporter only (#2136).
+						fs.Version = FlowServerVersionIPFIX
+						if tmplNode := prop.FindChild("template"); tmplNode != nil {
+							if v := nodeVal(tmplNode); v != "" {
+								fs.VersionIPFIXTemplate = v
+							} else if len(tmplNode.Children) > 0 {
+								fs.VersionIPFIXTemplate = tmplNode.Children[0].Name()
 							}
 						}
 					case "source-address":

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -921,6 +921,10 @@ forwarding-options {
 	if fs.Version9Template != "v9-tmpl" {
 		t.Errorf("flow-server template: got %q", fs.Version9Template)
 	}
+	if fs.Version != FlowServerVersion9 {
+		t.Errorf("flow-server version binding: got %q, want %q (#2136)",
+			fs.Version, FlowServerVersion9)
+	}
 	if inst.FamilyInet6 == nil {
 		t.Fatal("expected FamilyInet6")
 	}
@@ -983,6 +987,68 @@ forwarding-options {
 	}
 	if fs2.Version9Template != "v9-set" {
 		t.Errorf("set syntax flow-server template: %q", fs2.Version9Template)
+	}
+	if fs2.Version != FlowServerVersion9 {
+		t.Errorf("set syntax flow-server version binding: got %q, want %q (#2136)",
+			fs2.Version, FlowServerVersion9)
+	}
+}
+
+// TestFlowServerVersionIPFIXBinding covers the #2136 per-flow-server
+// version-ipfix selector (both hierarchical `version-ipfix { template }`
+// and the flat `version-ipfix-template` form), which the compiler must
+// parse into FlowServer.Version = version-ipfix + VersionIPFIXTemplate.
+// Before #2136 the compiler discarded any per-server IPFIX selector and
+// only recognised version9, so an IPFIX-bound collector could not be
+// distinguished from a v9-bound one.
+func TestFlowServerVersionIPFIXBinding(t *testing.T) {
+	tree := &ConfigTree{}
+	cmds := []string{
+		"set services flow-monitoring version-ipfix template ix-tmpl flow-active-timeout 60",
+		"set forwarding-options sampling instance ix-inst input rate 100",
+		"set forwarding-options sampling instance ix-inst family inet output flow-server 10.0.0.9 port 4739",
+		"set forwarding-options sampling instance ix-inst family inet output flow-server 10.0.0.9 version-ipfix template ix-tmpl",
+		"set forwarding-options sampling instance ix-inst family inet6 output flow-server 2001:db8::9 port 4739",
+		"set forwarding-options sampling instance ix-inst family inet6 output flow-server 2001:db8::9 version-ipfix-template ix-tmpl",
+	}
+	for _, c := range cmds {
+		path, err := ParseSetCommand(c)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", c, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", c, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	inst := cfg.ForwardingOptions.Sampling.Instances["ix-inst"]
+	if inst == nil || inst.FamilyInet == nil || len(inst.FamilyInet.FlowServers) != 1 {
+		t.Fatalf("expected 1 inet flow-server, got %+v", inst)
+	}
+	// Hierarchical version-ipfix { template ix-tmpl }
+	fs := inst.FamilyInet.FlowServers[0]
+	if fs.Version != FlowServerVersionIPFIX {
+		t.Errorf("inet version binding: got %q, want %q", fs.Version, FlowServerVersionIPFIX)
+	}
+	if fs.VersionIPFIXTemplate != "ix-tmpl" {
+		t.Errorf("inet ipfix template: got %q, want ix-tmpl", fs.VersionIPFIXTemplate)
+	}
+	if fs.Version9Template != "" {
+		t.Errorf("inet must not carry a v9 template, got %q", fs.Version9Template)
+	}
+	// Flat version-ipfix-template
+	if inst.FamilyInet6 == nil || len(inst.FamilyInet6.FlowServers) != 1 {
+		t.Fatalf("expected 1 inet6 flow-server")
+	}
+	fs6 := inst.FamilyInet6.FlowServers[0]
+	if fs6.Version != FlowServerVersionIPFIX {
+		t.Errorf("inet6 version binding: got %q, want %q", fs6.Version, FlowServerVersionIPFIX)
+	}
+	if fs6.VersionIPFIXTemplate != "ix-tmpl" {
+		t.Errorf("inet6 ipfix template: got %q, want ix-tmpl", fs6.VersionIPFIXTemplate)
 	}
 }
 

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -17,9 +17,12 @@ package config
 // carry `port` (taking the container path already). The `port` value feeds
 // the Rust u16 CollectorPort wire field; Layer A skips a server whose port
 // is <1 or >65535, so the bound is [1, 65535]. version9-template /
-// version9 { template } / source-address are the other children the
-// sampling compiler reads (compiler_services.go compileSamplingFamily) —
-// declared so completion does not silently drop them.
+// version9 { template } / version-ipfix-template / version-ipfix
+// { template } / source-address are the other children the sampling
+// compiler reads (compiler_services.go compileSamplingFamily) — declared
+// so completion does not silently drop them. A per-server version9 /
+// version-ipfix selector binds THIS collector to exactly one export
+// protocol (Junos semantics, #2136).
 func samplingFlowServerNode() *schemaNode {
 	return &schemaNode{
 		desc: "Flow collector address", args: 1, placeholder: "<address>",
@@ -30,6 +33,10 @@ func samplingFlowServerNode() *schemaNode {
 			"version9-template": {desc: "NetFlow v9 template name for this collector", args: 1, placeholder: "<template-name>", children: nil},
 			"version9": {desc: "NetFlow v9 export options", children: map[string]*schemaNode{
 				"template": {desc: "NetFlow v9 template name", args: 1, placeholder: "<template-name>", children: nil},
+			}},
+			"version-ipfix-template": {desc: "IPFIX template name for this collector", args: 1, placeholder: "<template-name>", children: nil},
+			"version-ipfix": {desc: "IPFIX export options", children: map[string]*schemaNode{
+				"template": {desc: "IPFIX template name", args: 1, placeholder: "<template-name>", children: nil},
 			}},
 			"source-address": {desc: "Source address for exported flows", args: 1, placeholder: "<address>", children: nil},
 		},

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -735,11 +735,35 @@ type SamplingFamily struct {
 }
 
 // FlowServer defines a flow export collector destination.
+//
+// Version selects the export protocol for THIS collector (Junos binds
+// each flow-server to exactly one export version). It is set by the
+// compiler from whichever per-server selector nests under the
+// flow-server: "version9" (the `version9 { template }` /
+// `version9-template` selector) or "version-ipfix" (the
+// `version-ipfix { template }` selector). It is "" when the operator
+// configured no per-server selector — in that case the live exporter
+// resolves a deterministic version per the documented precedence (see
+// pkg/flowexport BuildExportConfig / BuildIPFIXExportConfig and #2136).
+//
+// Before #2136 the live Go exporter ignored the per-server selector
+// entirely and flattened all flow-servers into BOTH the v9 and the
+// IPFIX collector set, so a flow-server reachable under both global
+// version stanzas received every flow twice (one v9 + one IPFIX
+// datagram to the same socket).
 type FlowServer struct {
-	Address          string
-	Port             int
-	Version9Template string
+	Address              string
+	Port                 int
+	Version              string // "version9" | "version-ipfix" | "" (unbound)
+	Version9Template     string
+	VersionIPFIXTemplate string
 }
+
+// Flow-server per-collector export version selectors (FlowServer.Version).
+const (
+	FlowServerVersion9     = "version9"
+	FlowServerVersionIPFIX = "version-ipfix"
+)
 
 // FirewallConfig holds firewall filter definitions.
 type FirewallConfig struct {

--- a/pkg/daemon/daemon_flowexport_reconcile_test.go
+++ b/pkg/daemon/daemon_flowexport_reconcile_test.go
@@ -52,6 +52,14 @@ func flowSamplingConfig(collector string, rate int) *config.Config {
 // also becomes configured. The base config already sets Version9 (#2129),
 // so this config drives BOTH exporters — used by the no-callback-leak and
 // independence tests.
+//
+// #2136: each flow-server now binds to exactly one export version, so to
+// drive BOTH exporters this fixture pins the base v9 server explicitly to
+// version9 and adds a SECOND, IPFIX-bound flow-server. (An UNBOUND server
+// under both global versions resolves to IPFIX only — the documented
+// precedence — so leaving the single server unbound would start only the
+// IPFIX exporter. That behaviour is asserted directly by
+// TestReconcileBothVersionsUnboundServerNoDoubleExport.)
 func ipfixSamplingConfig(collector string, rate int) *config.Config {
 	cfg := flowSamplingConfig(collector, rate)
 	cfg.Services.FlowMonitoring.VersionIPFIX = &config.NetFlowIPFIXConfig{
@@ -59,6 +67,13 @@ func ipfixSamplingConfig(collector string, rate int) *config.Config {
 			"t": {Name: "t"},
 		},
 	}
+	fam := cfg.ForwardingOptions.Sampling.Instances["s"].FamilyInet
+	// Pin the existing server to v9 so the v9 exporter keeps its collector.
+	fam.FlowServers[0].Version = config.FlowServerVersion9
+	// Add a distinct IPFIX-bound collector so the IPFIX exporter also runs.
+	fam.FlowServers = append(fam.FlowServers, &config.FlowServer{
+		Address: collector, Port: 4739, Version: config.FlowServerVersionIPFIX,
+	})
 	return cfg
 }
 
@@ -329,6 +344,50 @@ func TestReconcileIPFIXOnlyDoesNotStartV9(t *testing.T) {
 	if n := d.eventReader.CallbackCount(); n != 1 {
 		t.Fatalf("#2129: IPFIX-only config must register exactly 1 callback "+
 			"(IPFIX), got %d", n)
+	}
+}
+
+// bothVersionsUnboundConfig returns sampling with a SINGLE flow-server
+// that carries NO per-server version selector, under BOTH global version
+// stanzas. Per #2136 the unbound server resolves to IPFIX (documented
+// precedence), so this drives ONLY the IPFIX exporter — not both.
+func bothVersionsUnboundConfig(collector string, rate int) *config.Config {
+	cfg := flowSamplingConfig(collector, rate) // sets Version9
+	cfg.Services.FlowMonitoring.VersionIPFIX = &config.NetFlowIPFIXConfig{
+		Templates: map[string]*config.NetFlowIPFIXTemplate{"t": {Name: "t"}},
+	}
+	// The single flow-server stays UNBOUND (no .Version).
+	return cfg
+}
+
+// TestReconcileBothVersionsUnboundServerNoDoubleExport is the #2136
+// regression at the live exporter-wiring layer: a single, unbound
+// flow-server configured under BOTH version9 and version-ipfix must
+// register exactly ONE session-close callback (IPFIX), not two. Before
+// #2136 both exporters started against the same collector and each
+// registered its own callback, so every flow was exported twice (one v9
+// + one IPFIX datagram). With per-server binding the unbound server
+// resolves to IPFIX only, so the v9 exporter never starts.
+func TestReconcileBothVersionsUnboundServerNoDoubleExport(t *testing.T) {
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+	t.Cleanup(d.stopIPFIXExporter)
+
+	if !d.reconcileFlowExporters(bothVersionsUnboundConfig("127.0.0.1", 100)) {
+		t.Fatal("both-versions config must reconcile (the IPFIX exporter starts)")
+	}
+	if b := d.ipfixBundlePtr.Load(); b == nil || b.exp == nil {
+		t.Fatal("#2136: unbound server under both versions must run the IPFIX exporter")
+	}
+	if b := d.flowBundle.Load(); b != nil && b.exp != nil {
+		t.Fatal("#2136: an UNBOUND collector under both versions must NOT also " +
+			"start the v9 exporter — that is the double-export bug")
+	}
+	// Exactly one callback (IPFIX), not two — the wire-level proof of no
+	// double-export to the single collector socket.
+	if n := d.eventReader.CallbackCount(); n != 1 {
+		t.Fatalf("#2136: both-versions unbound server must register exactly 1 "+
+			"callback (IPFIX), got %d — double-export", n)
 	}
 }
 

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -57,15 +57,51 @@ Shared:
   has a flow-server AND `services flow-monitoring version9` is configured
   (#2129). This mirrors the `BuildIPFIXExportConfig` `version-ipfix` gate.
   Before #2129 the v9 exporter started on sampling alone, emitting an
-  unrequested v9 stream to an IPFIX-only operator's collector. (Known
-  remaining gap: a flow-server configured with BOTH `version9` and
-  `version-ipfix` still double-exports to one collector — the
-  per-flow-server version-binding fix is a tracked follow-up.)
+  unrequested v9 stream to an IPFIX-only operator's collector. Its
+  collector set now contains ONLY the flow-servers bound to v9 (#2136 —
+  see "Per-flow-server export-version binding" below).
 - `BuildIPFIXExportConfig(...)` / `BuildSamplingZones(...)` — `manager.go`.
 - `SamplingDir` — `manager.go`. Direction enum.
 - `SessionCloseData` — `manager.go`. Wire shape built from
   `logging.EventReader` SESSION_CLOSE records (in
   `pkg/daemon/daemon_flow.go`).
+
+## Per-flow-server export-version binding (#2136)
+
+Junos binds each `flow-server` to exactly one export version + template.
+`BuildExportConfig` (v9) and `BuildIPFIXExportConfig` (IPFIX) therefore
+no longer flatten every flow-server into both collector sets — they each
+take only the flow-servers resolved to their own version, via the shared
+`collectVersionCollectors` / `resolveFlowServerVersion` helpers in
+`manager.go`. A given collector address:port appears in at most one of
+the two sets, so it never receives both a NetFlow v9 (version 9) AND an
+IPFIX (v10) datagram for the same flow.
+
+Before #2136 both builders returned every flow-server, and the daemon
+started both exporters against the same collector socket — each with its
+own SESSION_CLOSE callback and its own independent 1-in-N counter — so a
+flow-server reachable under both global version stanzas was exported
+twice with mismatched sampling.
+
+Resolution order for one flow-server (`resolveFlowServerVersion`):
+
+1. **Explicit per-server selector wins.** A flow-server configured with
+   `version9 { template … }` / `version9-template …` binds to v9; one
+   configured with `version-ipfix { template … }` /
+   `version-ipfix-template …` binds to IPFIX (parsed by
+   `compiler_services.go` into `FlowServer.Version`). It is then bound to
+   that version *only if* the matching global `services flow-monitoring`
+   stanza exists (the global stanza supplies template timeouts/fields); a
+   server bound to a version whose global stanza is absent exports
+   nothing and does NOT silently fall back to the other version.
+2. **Unbound server inherits the single configured global version.**
+3. **Unbound server with BOTH global versions configured → IPFIX**
+   (documented precedence). IPFIX (v10) is the IETF-standard superset of
+   NetFlow v9, so an operator who enabled both but did not pin the
+   collector gets the modern protocol — and, critically, exactly ONE
+   datagram stream rather than the pre-#2136 double-export. To send v9 to
+   such a collector, pin it explicitly with a per-server `version9`
+   selector.
 
 ## Callers
 

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -48,6 +48,107 @@ type CollectorConfig struct {
 	SourceAddress string // local bind address (empty = auto)
 }
 
+// resolveFlowServerVersion returns the export protocol a single
+// flow-server is bound to, given the per-server selector and which
+// global flow-monitoring version stanzas are configured. Junos binds
+// each flow-server to exactly one export version + template; xpf
+// honours that binding so a collector never receives both a NetFlow v9
+// and an IPFIX datagram for the same flow (#2136).
+//
+// Resolution:
+//   - An explicit per-server selector (`version9` / `version-ipfix`
+//     nested under the flow-server) wins outright — but only if the
+//     matching global `services flow-monitoring` stanza is configured
+//     (the global stanza supplies the template timeouts/fields). A
+//     server bound to a version whose global stanza is absent exports
+//     nothing (it has no template), matching the existing global gates.
+//   - With no per-server selector, the server inherits the single
+//     configured global version. When BOTH global versions are set the
+//     unbound server resolves to IPFIX (documented precedence): IPFIX
+//     (v10) is the IETF-standard superset of NetFlow v9, so an operator
+//     who turned on both and did not pin the collector gets the modern
+//     protocol — and, critically, exactly ONE datagram stream rather
+//     than the pre-#2136 double-export.
+//
+// Returns "" when the server resolves to no configured version (it is
+// then skipped by both collector builders).
+func resolveFlowServerVersion(fs *config.FlowServer, hasV9, hasIPFIX bool) string {
+	switch fs.Version {
+	case config.FlowServerVersion9:
+		if hasV9 {
+			return config.FlowServerVersion9
+		}
+		return ""
+	case config.FlowServerVersionIPFIX:
+		if hasIPFIX {
+			return config.FlowServerVersionIPFIX
+		}
+		return ""
+	}
+	// Unbound: inherit the single configured global version. IPFIX wins
+	// when both are configured (documented precedence — see above).
+	switch {
+	case hasIPFIX:
+		return config.FlowServerVersionIPFIX
+	case hasV9:
+		return config.FlowServerVersion9
+	default:
+		return ""
+	}
+}
+
+// collectVersionCollectors walks every sampling family's flow-servers
+// and returns the deduplicated collector set for the requested export
+// version, skipping flow-servers resolved to the other version. This is
+// the per-flow-server version binding that prevents double-export
+// (#2136): the v9 builder calls it with version=version9, the IPFIX
+// builder with version=version-ipfix, and a server appears in at most
+// one of the two sets.
+func collectVersionCollectors(fo *config.ForwardingOptionsConfig, version string, hasV9, hasIPFIX bool) []CollectorConfig {
+	var collectors []CollectorConfig
+	for _, inst := range fo.Sampling.Instances {
+		families := []*config.SamplingFamily{inst.FamilyInet, inst.FamilyInet6}
+		for _, fam := range families {
+			if fam == nil {
+				continue
+			}
+			for _, fs := range fam.FlowServers {
+				if resolveFlowServerVersion(fs, hasV9, hasIPFIX) != version {
+					continue
+				}
+				addr := fs.Address
+				if fs.Port > 0 {
+					addr = fmt.Sprintf("%s:%d", fs.Address, fs.Port)
+				}
+				srcAddr := fam.SourceAddress
+				if srcAddr == "" {
+					srcAddr = fam.InlineJflowSourceAddress
+				}
+				collectors = append(collectors, CollectorConfig{
+					Address:       addr,
+					SourceAddress: srcAddr,
+				})
+			}
+		}
+	}
+	return dedupeCollectors(collectors)
+}
+
+// dedupeCollectors removes duplicate collector destinations (same
+// address + source-address) in-place, preserving first-seen order.
+func dedupeCollectors(collectors []CollectorConfig) []CollectorConfig {
+	seen := make(map[string]bool)
+	deduped := collectors[:0]
+	for _, c := range collectors {
+		key := collectorKey(c)
+		if !seen[key] {
+			seen[key] = true
+			deduped = append(deduped, c)
+		}
+	}
+	return deduped
+}
+
 // BuildExportConfig resolves config types into an ExportConfig.
 // Returns nil if no flow export is configured.
 func BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig {
@@ -109,45 +210,19 @@ func BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsC
 		}
 	}
 
-	// Collect flow servers from all sampling instances
-	for _, inst := range fo.Sampling.Instances {
-		families := []*config.SamplingFamily{inst.FamilyInet, inst.FamilyInet6}
-		for _, fam := range families {
-			if fam == nil {
-				continue
-			}
-			for _, fs := range fam.FlowServers {
-				addr := fs.Address
-				if fs.Port > 0 {
-					addr = fmt.Sprintf("%s:%d", fs.Address, fs.Port)
-				}
-				srcAddr := fam.SourceAddress
-				if srcAddr == "" {
-					srcAddr = fam.InlineJflowSourceAddress
-				}
-				ec.Collectors = append(ec.Collectors, CollectorConfig{
-					Address:       addr,
-					SourceAddress: srcAddr,
-				})
-			}
-		}
-	}
+	// Collect only the flow-servers bound to NetFlow v9. A server is
+	// bound to v9 by an explicit per-server selector, or — when it has
+	// no per-server selector — by inheriting v9 only if IPFIX is not
+	// also configured (IPFIX wins the unbound precedence). This is the
+	// #2136 per-flow-server version binding: it skips servers resolved
+	// to IPFIX so a collector configured under both versions receives
+	// exactly one datagram stream, not two.
+	hasIPFIX := svc.FlowMonitoring.VersionIPFIX != nil
+	ec.Collectors = collectVersionCollectors(fo, config.FlowServerVersion9, true, hasIPFIX)
 
 	if len(ec.Collectors) == 0 {
 		return nil
 	}
-
-	// Deduplicate collectors by address
-	seen := make(map[string]bool)
-	deduped := ec.Collectors[:0]
-	for _, c := range ec.Collectors {
-		key := collectorKey(c)
-		if !seen[key] {
-			seen[key] = true
-			deduped = append(deduped, c)
-		}
-	}
-	ec.Collectors = deduped
 
 	return ec
 }
@@ -185,7 +260,7 @@ func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOpt
 		TemplateRefreshRate: refreshRate,
 	}
 
-	// Reuse same sampling rate + collectors as v9 (shared forwarding-options)
+	// Same sampling rate as v9 (shared forwarding-options sampling).
 	for _, inst := range fo.Sampling.Instances {
 		if inst.InputRate > 0 {
 			ec.SamplingRate = inst.InputRate
@@ -193,44 +268,17 @@ func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOpt
 		}
 	}
 
-	for _, inst := range fo.Sampling.Instances {
-		families := []*config.SamplingFamily{inst.FamilyInet, inst.FamilyInet6}
-		for _, fam := range families {
-			if fam == nil {
-				continue
-			}
-			for _, fs := range fam.FlowServers {
-				addr := fs.Address
-				if fs.Port > 0 {
-					addr = fmt.Sprintf("%s:%d", fs.Address, fs.Port)
-				}
-				srcAddr := fam.SourceAddress
-				if srcAddr == "" {
-					srcAddr = fam.InlineJflowSourceAddress
-				}
-				ec.Collectors = append(ec.Collectors, CollectorConfig{
-					Address:       addr,
-					SourceAddress: srcAddr,
-				})
-			}
-		}
-	}
+	// Collect only the flow-servers bound to IPFIX (#2136). A server is
+	// bound to IPFIX by an explicit per-server selector, or — when it
+	// has no per-server selector — by inheriting IPFIX (which wins the
+	// unbound precedence whenever IPFIX is configured). The v9 builder
+	// skips exactly these servers, so no collector is double-exported.
+	hasV9 := svc.FlowMonitoring.Version9 != nil
+	ec.Collectors = collectVersionCollectors(fo, config.FlowServerVersionIPFIX, hasV9, true)
 
 	if len(ec.Collectors) == 0 {
 		return nil
 	}
-
-	// Deduplicate collectors
-	seen := make(map[string]bool)
-	deduped := ec.Collectors[:0]
-	for _, c := range ec.Collectors {
-		key := collectorKey(c)
-		if !seen[key] {
-			seen[key] = true
-			deduped = append(deduped, c)
-		}
-	}
-	ec.Collectors = deduped
 
 	return ec
 }

--- a/pkg/flowexport/version_binding_test.go
+++ b/pkg/flowexport/version_binding_test.go
@@ -1,0 +1,192 @@
+package flowexport
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2136 — per-flow-server export-version binding.
+//
+// Before #2136 BuildExportConfig (v9) and BuildIPFIXExportConfig (ipfix)
+// each flattened ALL flow-servers into their own collector set, so a
+// flow-server reachable under both global version stanzas received every
+// flow twice — one NetFlow v9 datagram and one IPFIX datagram to the same
+// socket. These tests assert each flow-server now binds to exactly one
+// export version, so a given collector appears in at most one builder's
+// collector set. The "both versions" cases FAIL on the pre-#2136 code
+// (the v9 builder returned the collector that the IPFIX builder also
+// returned -> two streams to one collector).
+
+func bothSvc() *config.ServicesConfig {
+	return &config.ServicesConfig{
+		FlowMonitoring: &config.FlowMonitoringConfig{
+			Version9: &config.NetFlowV9Config{
+				Templates: map[string]*config.NetFlowV9Template{"t": {Name: "t"}},
+			},
+			VersionIPFIX: &config.NetFlowIPFIXConfig{
+				Templates: map[string]*config.NetFlowIPFIXTemplate{"t": {Name: "t"}},
+			},
+		},
+	}
+}
+
+func ipfixSvc() *config.ServicesConfig {
+	return &config.ServicesConfig{
+		FlowMonitoring: &config.FlowMonitoringConfig{
+			VersionIPFIX: &config.NetFlowIPFIXConfig{
+				Templates: map[string]*config.NetFlowIPFIXTemplate{"t": {Name: "t"}},
+			},
+		},
+	}
+}
+
+func samplingFO(servers ...*config.FlowServer) *config.ForwardingOptionsConfig {
+	return &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"s": {
+					Name:       "s",
+					InputRate:  100,
+					FamilyInet: &config.SamplingFamily{FlowServers: servers},
+				},
+			},
+		},
+	}
+}
+
+func collectorAddrs(ec *ExportConfig) []string {
+	if ec == nil {
+		return nil
+	}
+	out := make([]string, 0, len(ec.Collectors))
+	for _, c := range ec.Collectors {
+		out = append(out, c.Address)
+	}
+	return out
+}
+
+// TestBindingV9Only: a v9-only global stanza routes every flow-server to
+// the v9 exporter and starts no IPFIX exporter.
+func TestBindingV9Only(t *testing.T) {
+	fo := samplingFO(&config.FlowServer{Address: "10.0.0.1", Port: 2055})
+
+	v9 := BuildExportConfig(v9Svc(), fo)
+	if v9 == nil || len(v9.Collectors) != 1 {
+		t.Fatalf("v9-only: want exactly 1 v9 collector, got %v", collectorAddrs(v9))
+	}
+	if v9.Collectors[0].Address != "10.0.0.1:2055" {
+		t.Errorf("v9 collector = %q, want 10.0.0.1:2055", v9.Collectors[0].Address)
+	}
+
+	if ipfix := BuildIPFIXExportConfig(v9Svc(), fo); ipfix != nil {
+		t.Errorf("v9-only must start no IPFIX exporter, got %v", collectorAddrs(ipfix))
+	}
+}
+
+// TestBindingIPFIXOnly: an ipfix-only global stanza routes every
+// flow-server to the IPFIX exporter and starts no v9 exporter.
+func TestBindingIPFIXOnly(t *testing.T) {
+	fo := samplingFO(&config.FlowServer{Address: "10.0.0.1", Port: 2055})
+
+	ipfix := BuildIPFIXExportConfig(ipfixSvc(), fo)
+	if ipfix == nil || len(ipfix.Collectors) != 1 {
+		t.Fatalf("ipfix-only: want exactly 1 ipfix collector, got %v", collectorAddrs(ipfix))
+	}
+	if v9 := BuildExportConfig(ipfixSvc(), fo); v9 != nil {
+		t.Errorf("ipfix-only must start no v9 exporter, got %v", collectorAddrs(v9))
+	}
+}
+
+// TestBindingBothVersionsUnboundServerGoesToIPFIXOnly is the headline
+// #2136 regression: a SINGLE flow-server with NO per-server selector,
+// under BOTH global version stanzas, must export exactly ONCE — to IPFIX
+// (the documented precedence) — NOT twice. On the pre-#2136 code the v9
+// builder ALSO returned this collector, so it received both a v9 and an
+// IPFIX datagram (double-export). This test fails on that code.
+func TestBindingBothVersionsUnboundServerGoesToIPFIXOnly(t *testing.T) {
+	fo := samplingFO(&config.FlowServer{Address: "10.0.0.1", Port: 2055})
+
+	v9 := BuildExportConfig(bothSvc(), fo)
+	ipfix := BuildIPFIXExportConfig(bothSvc(), fo)
+
+	// Exactly one collector total across both exporters — no double-export.
+	if v9 != nil {
+		t.Errorf("#2136: an unbound server under both versions must NOT also "+
+			"export v9 (double-export); v9 collectors = %v", collectorAddrs(v9))
+	}
+	if ipfix == nil || len(ipfix.Collectors) != 1 {
+		t.Fatalf("#2136: unbound server under both versions must export once "+
+			"via IPFIX, got ipfix=%v", collectorAddrs(ipfix))
+	}
+	if ipfix.Collectors[0].Address != "10.0.0.1:2055" {
+		t.Errorf("ipfix collector = %q, want 10.0.0.1:2055", ipfix.Collectors[0].Address)
+	}
+}
+
+// TestBindingExplicitPerServerSplit: two flow-servers, one pinned to v9
+// and one pinned to IPFIX, each appear in exactly one builder's set even
+// though both global version stanzas are configured.
+func TestBindingExplicitPerServerSplit(t *testing.T) {
+	fo := samplingFO(
+		&config.FlowServer{Address: "10.0.0.1", Port: 2055, Version: config.FlowServerVersion9},
+		&config.FlowServer{Address: "10.0.0.2", Port: 4739, Version: config.FlowServerVersionIPFIX},
+	)
+
+	v9 := BuildExportConfig(bothSvc(), fo)
+	ipfix := BuildIPFIXExportConfig(bothSvc(), fo)
+
+	if v9 == nil || len(v9.Collectors) != 1 || v9.Collectors[0].Address != "10.0.0.1:2055" {
+		t.Fatalf("v9 must hold only the v9-bound server, got %v", collectorAddrs(v9))
+	}
+	if ipfix == nil || len(ipfix.Collectors) != 1 || ipfix.Collectors[0].Address != "10.0.0.2:4739" {
+		t.Fatalf("ipfix must hold only the ipfix-bound server, got %v", collectorAddrs(ipfix))
+	}
+}
+
+// TestBindingSameCollectorPinnedToOneVersion: the exact #2136 harm — ONE
+// collector address:port, configured under both global versions, pinned
+// to v9. It must receive v9 only, never IPFIX. (Pinning to IPFIX is the
+// symmetric case.)
+func TestBindingSameCollectorPinnedToOneVersion(t *testing.T) {
+	foV9 := samplingFO(&config.FlowServer{
+		Address: "10.0.0.1", Port: 2055, Version: config.FlowServerVersion9,
+	})
+	if v9 := BuildExportConfig(bothSvc(), foV9); v9 == nil || len(v9.Collectors) != 1 {
+		t.Fatalf("v9-pinned server must export v9, got %v", collectorAddrs(v9))
+	}
+	if ipfix := BuildIPFIXExportConfig(bothSvc(), foV9); ipfix != nil {
+		t.Errorf("#2136: a v9-pinned collector must NOT also receive IPFIX, got %v",
+			collectorAddrs(ipfix))
+	}
+
+	foIPFIX := samplingFO(&config.FlowServer{
+		Address: "10.0.0.1", Port: 2055, Version: config.FlowServerVersionIPFIX,
+	})
+	if ipfix := BuildIPFIXExportConfig(bothSvc(), foIPFIX); ipfix == nil || len(ipfix.Collectors) != 1 {
+		t.Fatalf("ipfix-pinned server must export ipfix, got %v", collectorAddrs(ipfix))
+	}
+	if v9 := BuildExportConfig(bothSvc(), foIPFIX); v9 != nil {
+		t.Errorf("#2136: an ipfix-pinned collector must NOT also receive v9, got %v",
+			collectorAddrs(v9))
+	}
+}
+
+// TestBindingPinnedToVersionWithoutGlobalStanza: a server pinned to a
+// version whose global flow-monitoring stanza is absent exports nothing
+// (it has no template) — and does NOT silently fall back to the other
+// version. Mirrors the existing global gates.
+func TestBindingPinnedToVersionWithoutGlobalStanza(t *testing.T) {
+	// Server pinned to IPFIX, but only the v9 global stanza exists.
+	fo := samplingFO(&config.FlowServer{
+		Address: "10.0.0.1", Port: 2055, Version: config.FlowServerVersionIPFIX,
+	})
+	if v9 := BuildExportConfig(v9Svc(), fo); v9 != nil {
+		t.Errorf("an ipfix-pinned server must NOT fall back to v9, got %v",
+			collectorAddrs(v9))
+	}
+	if ipfix := BuildIPFIXExportConfig(v9Svc(), fo); ipfix != nil {
+		t.Errorf("ipfix not globally configured: no ipfix exporter, got %v",
+			collectorAddrs(ipfix))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2136 — the deferred per-flow-server version-binding half of the
NetFlow gating work (the unrequested-v9-stream half shipped in #2129).

When a `services flow-monitoring` flow-server was reachable under BOTH
the global `version9` and `version-ipfix` stanzas, `BuildExportConfig`
(v9) and `BuildIPFIXExportConfig` (IPFIX) each flattened *every*
flow-server into their own collector set. The daemon then started both
exporters against the same collector `address:port`, each with its own
`SESSION_CLOSE` callback and its own independent 1-in-N sample counter,
so every sampled flow was exported **twice** to one socket: one NetFlow
v9 (version 9) datagram and one IPFIX (v10) datagram, with mismatched
selection.

Junos binds each flow-server to exactly one export version + template.
This PR makes xpf honour that binding so a given collector receives at
most one version's datagrams.

## What changed

- **Config model + parser** (`pkg/config`): `FlowServer` gains `Version`
  (`version9` | `version-ipfix` | `""` unbound) and
  `VersionIPFIXTemplate`. The compiler now parses the per-server
  `version-ipfix { template … }` / `version-ipfix-template …` selectors
  (it previously parsed only the v9 selectors and discarded any IPFIX
  one). Schema declares the new leaves so completion + the commit-walk
  don't drop them.
- **Exporter collector loops** (`pkg/flowexport/manager.go`): new shared
  `resolveFlowServerVersion` + `collectVersionCollectors` route each
  flow-server to a single version's set. The v9 builder skips
  IPFIX-bound servers and vice versa; the duplicated dedup loop is
  collapsed into `dedupeCollectors`.
- **CLI + docs**: `show` displays the per-server IPFIX template;
  `pkg/flowexport/README.md` + `docs/config-schema.md` document the
  binding and resolution order.

## Both-versions semantics (and why)

`resolveFlowServerVersion`:

1. An **explicit per-server selector wins** — but only if the matching
   global stanza is configured (it supplies the template
   timeouts/fields). A server pinned to a version whose global stanza is
   absent exports nothing and does **not** silently fall back.
2. An **unbound** server inherits the single configured global version.
3. An **unbound** server with **both** globals set resolves to **IPFIX**
   (documented precedence). IPFIX (v10) is the IETF-standard superset of
   NetFlow v9, so an operator who turned both on but did not pin the
   collector gets the modern protocol — and, critically, **exactly one
   datagram stream** rather than the pre-#2136 double-export. To send v9
   to such a collector, pin it with a per-server `version9` selector.

I chose a documented precedence over a commit-reject because the config
is not malformed (both stanzas are individually valid and the per-server
selector is the intended disambiguator); rejecting would break existing
both-versions configs that today merely over-export. IPFIX-wins gives a
single, predictable, standards-forward stream with an explicit override.

## Tests

New tests FAIL on the pre-#2136 collect-all behaviour (verified by
mutation — reverting either builder to "collect all" trips them):

- `pkg/flowexport/version_binding_test.go`: v9-only, ipfix-only,
  both-versions-unbound (→ IPFIX only, not both), explicit per-server
  split, the exact harm (one collector under both versions pinned to one
  version → that version only), and pinned-without-its-global-stanza (no
  fallback).
- `daemon TestReconcileBothVersionsUnboundServerNoDoubleExport`: at the
  live reconcile/callback layer a single unbound server under both
  versions registers exactly **one** `SESSION_CLOSE` callback (IPFIX),
  not two.
- `TestFlowServerVersionIPFIXBinding` covers the hierarchical + flat
  per-server IPFIX selector parse.

`go build ./...` clean; `go test ./pkg/flowexport/... ./pkg/config/...
./pkg/daemon/ ./pkg/cli/...` all pass. Control-plane-only correctness
fix — no cluster smoke required.

## Claude SMR self-review

- Composes with #2129's gates, doesn't fight them: the v9 builder still
  returns nil unless `Version9 != nil`, the IPFIX builder unless
  `VersionIPFIX != nil`; the per-server filter is applied *after* those
  gates. The #2129 regression guards (`TestReconcileIPFIXOnlyDoesNotStartV9`,
  `TestReconcileV9RequiresVersion9Stanza`) still pass unchanged.
- Updated the `ipfixSamplingConfig` fixture to explicitly bind one server
  to v9 + add a second IPFIX-bound server so the no-callback-leak /
  family-independence tests still drive BOTH exporters under the new
  semantics, preserving their original intent (a single unbound server
  would now legitimately drive only IPFIX).
- The pre-existing `go vet` "passes lock by value" warnings on
  `NewExporter`/`NewIPFIXExporter` (`ExportConfig` embeds an
  `atomic.Uint64`) are unchanged on `origin/master` and untouched here —
  out of scope.
- Hash-gate unaffected: `flowExportConfigHash` marshals the resolved
  `ExportConfig.Collectors`, which now legitimately differs when a
  server's binding changes, so a binding change correctly re-applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
