### PR TITLE
#2173: reject non-host static-NAT/NAT64 mask at commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,11 @@
 # Action Log
 
+## 2026-06-21 — #2173 static-NAT / NAT64 host-mask commit-time validation
+
+- **Timestamp**: 2026-06-21
+- **Action**: Added `validateNATHostMaskStrict` (strict-vs-lenient gate, `lenientNATHostMask` flag) rejecting a non-host (non-/32//128) static-NAT match/prefix or NAT64 source-pool address at commit, mirroring the Rust PR #2167 host-mask gate (NPTv6 + `inet` rules exempt). New `compiler_nat_host_mask_test.go`; doc section in `docs/config-schema.md`; fixed `TestNAT64` fixture to a /32 pool address.
+- **File(s)**: pkg/config/compiler_nat.go, pkg/config/compiler.go, pkg/config/compiler_nat_host_mask_test.go, pkg/config/parser_security_test.go, docs/config-schema.md
+
 ## 2026-06-20 — #2120 PR #2166 Copilot fold (doc nits + SELF-HEAL/HOLD expect hardening)
 
 - **Timestamp**: 2026-06-20

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,9 @@
 # Action Log
 
+## 2026-06-21 — #2173 (PR #2182) fold: v4-mapped-v6 host-mask family divergence
+
+- **2026-06-21** — Folded MINOR review fixes into PR #2182: NAT host-mask family is now classified textually via `natAddrFamily` (colon => IPv6, matching Rust `IpAddr`/`Ipv4Addr`), NOT `net.ParseIP(...).To4()` — `::ffff:203.0.113.5/32` was wrongly accepted at commit but dropped by the dataplane; the NAT64-pool lenient warning now says only the offending pool address is dropped (not the whole rule); added commit-level mapped-v6 tests for both static-NAT and the NAT64 pool. Files: pkg/config/compiler_nat.go, pkg/config/compiler_nat_host_mask_test.go.
+
 ## 2026-06-21 — #2173 static-NAT / NAT64 host-mask commit-time validation
 
 - **Timestamp**: 2026-06-21

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -613,8 +613,12 @@ strict-vs-lenient gates) closes that gap. The host-route rule mirrors the Rust
 gate EXACTLY (shared predicate `isHostMaskAddress`):
 
 - **Scope:** static-NAT rules' `match destination-address` (→ snapshot
-  `ExternalIP`) and `then static-nat prefix` (→ `InternalIP`), plus a NAT64
-  `rule-set ... source-pool` pool's addresses (→ `parse_pool_v4`).
+  `ExternalIP`) and `then static-nat prefix` (→ `InternalIP`) are checked with
+  the family-aware `isHostMaskAddress` (matching `parse_nat_addr`). A NAT64
+  `rule-set ... source-pool` pool's addresses are checked with the **IPv4-only**
+  `isNAT64PoolHostAddress` (matching `parse_pool_v4`, which is `Ipv4Addr`-only):
+  the pool translates to IPv4 source addresses, so an IPv6 pool entry — even a
+  `/128` — is silently dropped by the dataplane and is rejected at commit too.
 - **Exempt:** `then static-nat nptv6-prefix` rules (genuine RFC 6296 prefix
   translation, never host-checked by the Rust parser) and `then static-nat
   inet` rules (a NAT64 translation whose `match` is the well-known prefix, e.g.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -619,6 +619,12 @@ gate EXACTLY (shared predicate `isHostMaskAddress`):
   `isNAT64PoolHostAddress` (matching `parse_pool_v4`, which is `Ipv4Addr`-only):
   the pool translates to IPv4 source addresses, so an IPv6 pool entry — even a
   `/128` — is silently dropped by the dataplane and is rejected at commit too.
+  Both predicates classify address family **textually** (`natAddrFamily`: a
+  colon means IPv6) to match the Rust `from_str` parsers exactly — Go's
+  `net.ParseIP(...).To4()` folds the IPv4-mapped `::ffff:1.2.3.4` form to v4,
+  but Rust `Ipv4Addr::from_str` rejects it and `IpAddr::from_str` classifies it
+  as V6, so the mapped form is treated as IPv6 here (never accepted as a v4 host
+  the dataplane would then silently drop).
 - **Exempt:** `then static-nat nptv6-prefix` rules (genuine RFC 6296 prefix
   translation, never host-checked by the Rust parser) and `then static-nat
   inet` rules (a NAT64 translation whose `match` is the well-known prefix, e.g.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -594,6 +594,51 @@ NOTE: `pool-utilization-alarm` is not yet a typed `setSchema` leaf (no
 config-mode value-slot completion); the validation is compiler-side only. Adding
 schema completion is a separate, optional UX follow-up.
 
+### #2173 — static-NAT / NAT64 host-mask validation
+
+Static NAT is strictly host-1:1 and NAT64 source-pool entries are discrete host
+source IPs, so the ONLY meaningful mask on a static-NAT match/prefix or a NAT64
+pool address is the canonical host mask (`/32` for IPv4, `/128` for IPv6; a bare
+address is a host too). #2122/#2123 (PR #2132) made the Rust dataplane TOLERATE
+the canonical host mask; PR #2167 then hardened the Rust parser
+(`parse_nat_addr` in `userspace-dp/src/nat/static_nat.rs`, `parse_pool_v4` in
+`userspace-dp/src/nat64.rs`) to REJECT a non-host mask (`/24`, `/64`, garbage
+suffix, ...). The net effect before #2173 was a SILENT dataplane drop: a
+misconfigured `/24` match/prefix was parsed-out and the rule was never installed,
+with no operator feedback.
+
+`validateNATHostMaskStrict` (`pkg/config/compiler_nat.go`, invoked from the
+typed-config phase of `compileExpanded` in `compiler.go`, alongside the other
+strict-vs-lenient gates) closes that gap. The host-route rule mirrors the Rust
+gate EXACTLY (shared predicate `isHostMaskAddress`):
+
+- **Scope:** static-NAT rules' `match destination-address` (→ snapshot
+  `ExternalIP`) and `then static-nat prefix` (→ `InternalIP`), plus a NAT64
+  `rule-set ... source-pool` pool's addresses (→ `parse_pool_v4`).
+- **Exempt:** `then static-nat nptv6-prefix` rules (genuine RFC 6296 prefix
+  translation, never host-checked by the Rust parser) and `then static-nat
+  inet` rules (a NAT64 translation whose `match` is the well-known prefix, e.g.
+  `64:ff9b::/96`, driven by the separate NAT64 snapshot, not the static_nat
+  table). A non-IP token (an address-book name) is left to the existing address
+  handling.
+- **Strict (`commit` / `commit check`):** a non-host mask is a HARD commit error
+  naming the rule-set, rule, slot, and offending prefix.
+- **Lenient (`Store.Load` / HA peer-sync — `CompileConfigLenient` /
+  `CompileConfigForNodeLenient`, flag `lenientNATHostMask`):** the violation
+  downgrades to a `cfg.Warnings` entry so a node that committed a non-host
+  static-NAT mask BEFORE this gate existed (or a peer-synced config) still BOOTS
+  after upgrade instead of failing closed (#1960
+  fail-closed-on-compile-failure). The dataplane drops the bad entry
+  independently, so a leniently-loaded config is already inert for that rule —
+  and the operator's next strict commit rejects it loudly.
+
+Regression coverage: `pkg/config/compiler_nat_host_mask_test.go` (bare/​/32/​/128
+accept; v4 + v6 non-host match/prefix reject with asserted message; NPTv6 and
+`inet` exemptions; NAT64 source-pool host vs non-host; strict-reject /
+lenient-warn / valid-no-warning; `isHostMaskAddress` table). Like
+`pool-utilization-alarm`, this is compiler-side only — not yet a typed
+`setSchema` leaf.
+
 ## The `inactive:` universal node modifier (#2008 H1)
 
 `inactive:` is the Junos deactivate-without-delete marker and is NOT a

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -187,6 +187,21 @@ type compileOpts struct {
 	// lenientIPsecPolicyProposalRef.
 	lenientLogProfileStreamRef bool
 
+	// lenientNATHostMask (#2173) downgrades the static-NAT / NAT64
+	// host-mask gate (validateNATHostMaskStrict) from a hard compile error
+	// to a cfg.Warnings entry. Set ONLY on the tolerant load / peer-sync
+	// paths (CompileConfigLenient / CompileConfigForNodeLenient): #2132 made
+	// the Rust dataplane tolerate the canonical host mask, PR #2167 then
+	// hardened it to REJECT a non-host mask, so a config persisted/synced
+	// with a non-host static-NAT match/prefix or NAT64 pool address (which
+	// an older binary parsed-out silently, or a peer authored) must still
+	// BOOT after upgrade (warn) instead of failing closed (#1960). Commit /
+	// commit-check stay strict — a new operator edit whose rule the
+	// dataplane will silently drop is rejected loudly. The dataplane drops
+	// the bad entry independently, so a leniently-loaded config is already
+	// inert for that rule. Same doctrine as lenientNATPoolAlarmThreshold.
+	lenientNATHostMask bool
+
 	// lenientUnsupportedInterfaceStanzas (#2008 H9/H10) downgrades the
 	// interface silent-drop gate (validateUnsupportedInterfaceStanzasAST:
 	// `interface [unit] mac` static-MAC override, `family inet|inet6
@@ -231,6 +246,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientIPsecGatewayRefs:            true,
 		lenientLogProfileStreamRef:         true,
 		lenientNATPoolAlarmThreshold:       true,
+		lenientNATHostMask:                 true,
 		lenientUnsupportedInterfaceStanzas: true,
 	})
 }
@@ -314,6 +330,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientIPsecGatewayRefs:            true,
 		lenientLogProfileStreamRef:         true,
 		lenientNATPoolAlarmThreshold:       true,
+		lenientNATHostMask:                 true,
 		lenientUnsupportedInterfaceStanzas: true,
 	})
 }
@@ -761,6 +778,23 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 	cfg.Warnings = append(cfg.Warnings, napWarnings...)
+
+	// #2173: static-NAT / NAT64 host-mask gate. #2132 made the Rust
+	// dataplane tolerate the canonical /32-/128 host mask and PR #2167 then
+	// hardened it to REJECT a non-host mask — so a misconfigured non-host
+	// static-NAT match/prefix or NAT64 pool address is now SILENTLY DROPPED
+	// at the dataplane (parsed-out, never installed) with no operator
+	// feedback. Strict (commit / commit-check): hard-reject a non-host mask
+	// (static NAT is strictly host-1:1, NAT64 pool entries are discrete host
+	// IPs). Lenient (load / peer-sync): warn so a config committed before
+	// this gate existed (or peer-synced) still boots (#1960
+	// fail-closed-on-compile-failure would otherwise brick restart); the
+	// dataplane drops the bad entry independently, so it is already inert.
+	hostMaskWarnings, err := validateNATHostMaskStrict(cfg, opts.lenientNATHostMask)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Warnings = append(cfg.Warnings, hostMaskWarnings...)
 
 	// #1892: retired DPDK-era `system dataplane` knobs (cores, memory,
 	// socket-mem, rx-mode, ports) parse for stored-config compatibility

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -170,12 +170,22 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 		return nil, nil
 	}
 	var warnings []string
-	emit := func(msg string) error {
+	// emitSuffix returns a violation as an error (strict) or appends it to the
+	// lenient warning list with a dataplane-effect suffix. The suffix differs
+	// by case: a static-NAT IP failure drops the WHOLE rule (parse_nat_addr
+	// returns None for the rule's match/then), whereas a NAT64 source-pool
+	// entry is dropped individually by filter_map(parse_pool_v4) — the rest of
+	// the pool/rule stays installed. Keep the load-path text precise so the
+	// operator does not over-read the impact.
+	emitSuffix := func(msg, suffix string) error {
 		if lenient {
-			warnings = append(warnings, msg+" (ignored: rule dropped by dataplane until corrected)")
+			warnings = append(warnings, msg+suffix)
 			return nil
 		}
 		return fmt.Errorf("%s", msg)
+	}
+	emit := func(msg string) error {
+		return emitSuffix(msg, " (ignored: rule dropped by dataplane until corrected)")
 	}
 
 	for _, rs := range cfg.Security.NAT.Static {
@@ -240,9 +250,10 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 				continue
 			}
 			if host, parsed := isNAT64PoolHostAddress(a); parsed && !host {
-				if err := emit(fmt.Sprintf(
+				if err := emitSuffix(fmt.Sprintf(
 					"security nat source pool %q address %q is referenced by nat64 rule-set %q source-pool and must be an IPv4 host route (a bare IPv4 address or /32); a non-host or IPv6 address is silently dropped by the dataplane",
-					pool.Name, a, rs.Name)); err != nil {
+					pool.Name, a, rs.Name),
+					" (ignored: only this pool address is dropped by the dataplane until corrected)"); err != nil {
 					return nil, err
 				}
 			}

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -41,37 +41,65 @@ func validatePoolUtilizationAlarm(cfg *Config, lenient bool) ([]string, error) {
 	return nil, fmt.Errorf("%s", msg)
 }
 
+// natAddrFamily classifies an IP-part string the way the Rust parsers do,
+// so the Go commit gate and the dataplane agree on every input.
+//
+//   - kind "v4": parses as IPv4 AND is textually a dotted-quad (no colon) —
+//     i.e. exactly what Rust `Ipv4Addr::from_str` / `IpAddr::V4` accept.
+//   - kind "v6": parses as IPv6 (textually colon-bearing) — what Rust
+//     `IpAddr::V6` represents.
+//   - kind "": does not parse as an IP at all (e.g. an address-book name);
+//     NOT this validator's concern.
+//
+// The colon test is load-bearing: Go's net.ParseIP("::ffff:1.2.3.4").To4()
+// is NON-nil (Go folds the IPv4-mapped form), but Rust `Ipv4Addr::from_str`
+// REJECTS it and `IpAddr::from_str` classifies it as V6. Keying the family
+// on text (no colon == v4) reproduces the Rust classification exactly, so a
+// mapped form is treated as IPv6 here too — never accepted as a v4 host that
+// the dataplane would then silently drop.
+func natAddrFamily(ipPart string) string {
+	if net.ParseIP(ipPart) == nil {
+		return ""
+	}
+	if strings.IndexByte(ipPart, ':') >= 0 {
+		return "v6"
+	}
+	return "v4"
+}
+
 // isHostMaskAddress reports whether addr is a host route the static-NAT
 // dataplane can install: a bare IP (no mask) or the canonical host mask
 // (/32 for IPv4, /128 for IPv6). It mirrors EXACTLY the Rust host-mask gate
 // added in PR #2167 for static NAT (parse_nat_addr in
 // userspace-dp/src/nat/static_nat.rs): static NAT is a strictly 1:1 host
-// mapping, so a non-host mask carries no representable meaning. The second
-// return value reports whether addr parsed as an IP at all; a non-IP token
-// (e.g. an address-book name) is NOT this validator's concern and is left
-// to the existing address handling.
+// mapping, so a non-host mask carries no representable meaning. The family
+// (hence the required mask) is keyed on natAddrFamily so an IPv4-mapped
+// IPv6 literal is classified the SAME as Rust (V6, host_len 128). The
+// second return value reports whether addr parsed as an IP at all; a non-IP
+// token (e.g. an address-book name) is NOT this validator's concern and is
+// left to the existing address handling.
 //
 // NOTE: NAT64 source-pool addresses use isNAT64PoolHostAddress, NOT this
 // predicate — the Rust parse_pool_v4 (nat64.rs) is IPv4-ONLY (the pool
 // translates to IPv4 source addresses), so an IPv6 pool entry that this
-// family-agnostic predicate would accept is silently dropped there.
+// predicate would accept (its /128 host form) is silently dropped there.
 func isHostMaskAddress(addr string) (host bool, parsed bool) {
 	slash := strings.IndexByte(addr, '/')
-	if slash < 0 {
-		// Bare address — host iff it parses as an IP.
-		if net.ParseIP(addr) == nil {
-			return false, false
-		}
-		return true, true
+	ipPart := addr
+	if slash >= 0 {
+		ipPart = addr[:slash]
 	}
-	ipPart := addr[:slash]
-	maskPart := addr[slash+1:]
-	ip := net.ParseIP(ipPart)
-	if ip == nil {
+	fam := natAddrFamily(ipPart)
+	if fam == "" {
 		return false, false
 	}
+	if slash < 0 {
+		// Bare address — a host in both families.
+		return true, true
+	}
+	maskPart := addr[slash+1:]
 	wantMask := "128"
-	if ip.To4() != nil {
+	if fam == "v4" {
 		wantMask = "32"
 	}
 	return maskPart == wantMask, true
@@ -81,31 +109,34 @@ func isHostMaskAddress(addr string) (host bool, parsed bool) {
 // NAT64 source pool can install. It mirrors EXACTLY the Rust parse_pool_v4
 // gate (userspace-dp/src/nat64.rs): the NAT64 pool holds IPv4 source
 // addresses, so it accepts ONLY a bare IPv4 address or an IPv4 /32 — an
-// IPv6 address (bare or any mask) and a non-host IPv4 mask are both
+// IPv6 address (bare or any mask, INCLUDING the IPv4-mapped ::ffff:x.x.x.x
+// form that Ipv4Addr::from_str rejects) and a non-host IPv4 mask are all
 // silently dropped by parse_pool_v4, so the commit gate must reject them
-// too or the gate and the dataplane disagree. The second return value
-// reports whether addr parsed as an IP at all (so a non-IP address-book
-// token is left to existing handling); a parseable IPv6 returns
-// (host=false, parsed=true) — it parsed, but is not an installable pool
-// address.
+// too or the gate and the dataplane disagree. Family is keyed on
+// natAddrFamily (textual, colon == v6) to match Ipv4Addr::from_str. The
+// second return value reports whether addr parsed as an IP at all (so a
+// non-IP address-book token is left to existing handling); a parseable
+// non-IPv4 address returns (host=false, parsed=true) — it parsed, but is
+// not an installable pool address.
 func isNAT64PoolHostAddress(addr string) (host bool, parsed bool) {
 	slash := strings.IndexByte(addr, '/')
-	if slash < 0 {
-		ip := net.ParseIP(addr)
-		if ip == nil {
-			return false, false
-		}
-		// Bare address — installable iff IPv4.
-		return ip.To4() != nil, true
+	ipPart := addr
+	if slash >= 0 {
+		ipPart = addr[:slash]
 	}
-	ipPart := addr[:slash]
-	maskPart := addr[slash+1:]
-	ip := net.ParseIP(ipPart)
-	if ip == nil {
+	fam := natAddrFamily(ipPart)
+	if fam == "" {
 		return false, false
 	}
+	if fam != "v4" {
+		// Parsed, but not an IPv4 pool address — reject (parse_pool_v4 drops).
+		return false, true
+	}
+	if slash < 0 {
+		return true, true
+	}
 	// Only an IPv4 /32 is an installable pool host address.
-	return ip.To4() != nil && maskPart == "32", true
+	return addr[slash+1:] == "32", true
 }
 
 // validateNATHostMaskStrict is the #2173 strict-vs-lenient gate that

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -41,17 +41,20 @@ func validatePoolUtilizationAlarm(cfg *Config, lenient bool) ([]string, error) {
 	return nil, fmt.Errorf("%s", msg)
 }
 
-// isHostMaskAddress reports whether addr is a host route the static-NAT /
-// NAT64 dataplane can install: a bare IP (no mask) or the canonical host
-// mask (/32 for IPv4, /128 for IPv6). It mirrors EXACTLY the Rust
-// host-mask gate added in PR #2167 (parse_nat_addr in
-// userspace-dp/src/nat/static_nat.rs, parse_pool_v4 in
-// userspace-dp/src/nat64.rs): static NAT is a strictly 1:1 host mapping
-// and NAT64 pool entries are discrete host source addresses, so a non-host
-// mask carries no representable meaning. The third return value reports
-// whether addr parsed as an IP at all; a non-IP token (e.g. an
-// address-book name) is NOT this validator's concern and is left to the
-// existing address handling.
+// isHostMaskAddress reports whether addr is a host route the static-NAT
+// dataplane can install: a bare IP (no mask) or the canonical host mask
+// (/32 for IPv4, /128 for IPv6). It mirrors EXACTLY the Rust host-mask gate
+// added in PR #2167 for static NAT (parse_nat_addr in
+// userspace-dp/src/nat/static_nat.rs): static NAT is a strictly 1:1 host
+// mapping, so a non-host mask carries no representable meaning. The second
+// return value reports whether addr parsed as an IP at all; a non-IP token
+// (e.g. an address-book name) is NOT this validator's concern and is left
+// to the existing address handling.
+//
+// NOTE: NAT64 source-pool addresses use isNAT64PoolHostAddress, NOT this
+// predicate — the Rust parse_pool_v4 (nat64.rs) is IPv4-ONLY (the pool
+// translates to IPv4 source addresses), so an IPv6 pool entry that this
+// family-agnostic predicate would accept is silently dropped there.
 func isHostMaskAddress(addr string) (host bool, parsed bool) {
 	slash := strings.IndexByte(addr, '/')
 	if slash < 0 {
@@ -72,6 +75,37 @@ func isHostMaskAddress(addr string) (host bool, parsed bool) {
 		wantMask = "32"
 	}
 	return maskPart == wantMask, true
+}
+
+// isNAT64PoolHostAddress reports whether addr is an IPv4 host route the
+// NAT64 source pool can install. It mirrors EXACTLY the Rust parse_pool_v4
+// gate (userspace-dp/src/nat64.rs): the NAT64 pool holds IPv4 source
+// addresses, so it accepts ONLY a bare IPv4 address or an IPv4 /32 — an
+// IPv6 address (bare or any mask) and a non-host IPv4 mask are both
+// silently dropped by parse_pool_v4, so the commit gate must reject them
+// too or the gate and the dataplane disagree. The second return value
+// reports whether addr parsed as an IP at all (so a non-IP address-book
+// token is left to existing handling); a parseable IPv6 returns
+// (host=false, parsed=true) — it parsed, but is not an installable pool
+// address.
+func isNAT64PoolHostAddress(addr string) (host bool, parsed bool) {
+	slash := strings.IndexByte(addr, '/')
+	if slash < 0 {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			return false, false
+		}
+		// Bare address — installable iff IPv4.
+		return ip.To4() != nil, true
+	}
+	ipPart := addr[:slash]
+	maskPart := addr[slash+1:]
+	ip := net.ParseIP(ipPart)
+	if ip == nil {
+		return false, false
+	}
+	// Only an IPv4 /32 is an installable pool host address.
+	return ip.To4() != nil && maskPart == "32", true
 }
 
 // validateNATHostMaskStrict is the #2173 strict-vs-lenient gate that
@@ -152,10 +186,12 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 		}
 	}
 
-	// NAT64 source-pool addresses are discrete host source IPs (parse_pool_v4
-	// host-mask gate). Range-expanded pool entries are always /32 by
-	// construction (expandAddressRange), so only an operator-authored single
-	// `pool address <X>/<non-host>` can trip this.
+	// NAT64 source-pool addresses are discrete IPv4 host source IPs: the Rust
+	// parse_pool_v4 (nat64.rs) accepts ONLY a bare IPv4 or an IPv4 /32 and
+	// silently drops everything else (an IPv6 address, a non-host IPv4 mask).
+	// Range-expanded pool entries are always /32 by construction
+	// (expandAddressRange), so only an operator-authored single
+	// `pool address <X>` can trip this.
 	for _, rs := range cfg.Security.NAT.NAT64 {
 		if rs == nil || rs.SourcePool == "" {
 			continue
@@ -172,9 +208,9 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 			if a == "" {
 				continue
 			}
-			if host, parsed := isHostMaskAddress(a); parsed && !host {
+			if host, parsed := isNAT64PoolHostAddress(a); parsed && !host {
 				if err := emit(fmt.Sprintf(
-					"security nat source pool %q address %q is referenced by nat64 rule-set %q source-pool and must be a host route (/32 for IPv4, /128 for IPv6); a non-host mask is silently dropped by the dataplane",
+					"security nat source pool %q address %q is referenced by nat64 rule-set %q source-pool and must be an IPv4 host route (a bare IPv4 address or /32); a non-host or IPv6 address is silently dropped by the dataplane",
 					pool.Name, a, rs.Name)); err != nil {
 					return nil, err
 				}

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -41,6 +41,150 @@ func validatePoolUtilizationAlarm(cfg *Config, lenient bool) ([]string, error) {
 	return nil, fmt.Errorf("%s", msg)
 }
 
+// isHostMaskAddress reports whether addr is a host route the static-NAT /
+// NAT64 dataplane can install: a bare IP (no mask) or the canonical host
+// mask (/32 for IPv4, /128 for IPv6). It mirrors EXACTLY the Rust
+// host-mask gate added in PR #2167 (parse_nat_addr in
+// userspace-dp/src/nat/static_nat.rs, parse_pool_v4 in
+// userspace-dp/src/nat64.rs): static NAT is a strictly 1:1 host mapping
+// and NAT64 pool entries are discrete host source addresses, so a non-host
+// mask carries no representable meaning. The third return value reports
+// whether addr parsed as an IP at all; a non-IP token (e.g. an
+// address-book name) is NOT this validator's concern and is left to the
+// existing address handling.
+func isHostMaskAddress(addr string) (host bool, parsed bool) {
+	slash := strings.IndexByte(addr, '/')
+	if slash < 0 {
+		// Bare address — host iff it parses as an IP.
+		if net.ParseIP(addr) == nil {
+			return false, false
+		}
+		return true, true
+	}
+	ipPart := addr[:slash]
+	maskPart := addr[slash+1:]
+	ip := net.ParseIP(ipPart)
+	if ip == nil {
+		return false, false
+	}
+	wantMask := "128"
+	if ip.To4() != nil {
+		wantMask = "32"
+	}
+	return maskPart == wantMask, true
+}
+
+// validateNATHostMaskStrict is the #2173 strict-vs-lenient gate that
+// rejects a static-NAT match/prefix or a NAT64 source-pool address whose
+// mask is not a host route (/32 for v4, /128 for v6; a bare address is a
+// host too). #2132 made the Rust dataplane TOLERATE the canonical host
+// mask, and PR #2167 then hardened the Rust parser to REJECT a non-host
+// mask — so today a misconfigured /24 static-NAT match or pool address is
+// SILENTLY DROPPED at the dataplane (the rule is parsed-out, never
+// installed) with no operator feedback. This commit-time check surfaces
+// the misconfiguration at `commit`/`commit check` instead.
+//
+// Scope mirrors what the Rust host-mask gate covers:
+//   - static-NAT rules' `match destination-address` (-> ExternalIP) and
+//     `then static-nat prefix` (-> InternalIP). NPTv6 (`nptv6-prefix`) and
+//     NAT64 (`static-nat inet`) rules are EXEMPT: NPTv6 is a genuine prefix
+//     translation (RFC 6296), and an `inet` rule's match is the NAT64
+//     well-known prefix (e.g. 64:ff9b::/96) with translation driven by the
+//     separate NAT64 snapshot, not the static_nat table.
+//   - NAT64 source-pool addresses (the IPv4 pool referenced by a
+//     `nat64 rule-set ... source-pool` — parse_pool_v4 host-mask gate).
+//
+// Strict (commit / commit-check): hard-reject. Lenient (load / peer-sync,
+// #1960 / #1979 doctrine): return the message as a warning so a config
+// committed before this gate existed still boots (fail-closed-on-compile-
+// failure would otherwise brick the daemon on restart); the dataplane
+// independently drops the bad entry, so a leniently-loaded config is
+// already inert for that rule, not mis-installed.
+func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	var warnings []string
+	emit := func(msg string) error {
+		if lenient {
+			warnings = append(warnings, msg+" (ignored: rule dropped by dataplane until corrected)")
+			return nil
+		}
+		return fmt.Errorf("%s", msg)
+	}
+
+	for _, rs := range cfg.Security.NAT.Static {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil || rule.IsNPTv6 {
+				continue
+			}
+			// `then static-nat inet` is a NAT64 translation, not host-1:1
+			// static NAT: its `match destination-address` is the NAT64
+			// well-known prefix (e.g. 64:ff9b::/96, a legitimate non-host
+			// prefix) and the actual translation is driven by the separate
+			// NAT64 snapshot (buildNAT64Snapshots), not the static_nat table
+			// (the inet rule's static_nat snapshot entry is expected to be a
+			// no-op the Rust parse drops). Exempt the whole rule.
+			if rule.Then == "inet" {
+				continue
+			}
+			if rule.Match != "" {
+				if host, parsed := isHostMaskAddress(rule.Match); parsed && !host {
+					if err := emit(fmt.Sprintf(
+						"security nat static rule-set %q rule %q match destination-address %q must be a host route (/32 for IPv4, /128 for IPv6); a non-host mask is silently dropped by the dataplane",
+						rs.Name, rule.Name, rule.Match)); err != nil {
+						return nil, err
+					}
+				}
+			}
+			if rule.Then != "" {
+				if host, parsed := isHostMaskAddress(rule.Then); parsed && !host {
+					if err := emit(fmt.Sprintf(
+						"security nat static rule-set %q rule %q then static-nat prefix %q must be a host route (/32 for IPv4, /128 for IPv6); a non-host mask is silently dropped by the dataplane",
+						rs.Name, rule.Name, rule.Then)); err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+	}
+
+	// NAT64 source-pool addresses are discrete host source IPs (parse_pool_v4
+	// host-mask gate). Range-expanded pool entries are always /32 by
+	// construction (expandAddressRange), so only an operator-authored single
+	// `pool address <X>/<non-host>` can trip this.
+	for _, rs := range cfg.Security.NAT.NAT64 {
+		if rs == nil || rs.SourcePool == "" {
+			continue
+		}
+		pool, ok := cfg.Security.NAT.SourcePools[rs.SourcePool]
+		if !ok || pool == nil {
+			continue
+		}
+		addrs := pool.Addresses
+		if pool.Address != "" {
+			addrs = append([]string{pool.Address}, addrs...)
+		}
+		for _, a := range addrs {
+			if a == "" {
+				continue
+			}
+			if host, parsed := isHostMaskAddress(a); parsed && !host {
+				if err := emit(fmt.Sprintf(
+					"security nat source pool %q address %q is referenced by nat64 rule-set %q source-pool and must be a host route (/32 for IPv4, /128 for IPv6); a non-host mask is silently dropped by the dataplane",
+					pool.Name, a, rs.Name)); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return warnings, nil
+}
+
 func compileNAT(node *Node, sec *SecurityConfig) error {
 	// Initialize SourcePools map
 	if sec.NAT.SourcePools == nil {

--- a/pkg/config/compiler_nat_host_mask_test.go
+++ b/pkg/config/compiler_nat_host_mask_test.go
@@ -249,6 +249,12 @@ func TestIsHostMaskAddress(t *testing.T) {
 		{"not-an-ip", false, false},      // not an IP -> not our concern
 		{"addr/", false, false},          // garbage suffix, bad IP part anyway
 		{"203.0.113.5/", false, true},    // empty mask -> non-host (mask "" != "32")
+		// IPv4-mapped IPv6: Rust IpAddr::from_str classifies as V6 (host_len
+		// 128), so the colon-keyed family must agree — /128 is the host form,
+		// /32 is NOT (Go's To4() would have wrongly chosen /32).
+		{"::ffff:1.2.3.4", true, true},     // bare mapped -> host (V6)
+		{"::ffff:1.2.3.4/128", true, true}, // mapped /128 -> host (V6 mask)
+		{"::ffff:1.2.3.4/32", false, true}, // mapped /32 -> NOT host (V6 wants /128)
 	}
 	for _, c := range cases {
 		host, parsed := isHostMaskAddress(c.in)
@@ -277,6 +283,11 @@ func TestIsNAT64PoolHostAddress(t *testing.T) {
 		{"100.64.0.7/128", false, true},  // cross-family mask on IPv4
 		{"not-an-ip", false, false},      // not an IP
 		{"100.64.0.7/", false, true},     // empty mask -> non-host
+		// IPv4-mapped IPv6: Ipv4Addr::from_str REJECTS this (Rust drops it),
+		// so the IPv4-only pool gate must reject it too — Go's To4() would
+		// have wrongly accepted it as a v4 host.
+		{"::ffff:1.2.3.4", false, true},    // mapped bare -> not IPv4 pool addr
+		{"::ffff:1.2.3.4/32", false, true}, // mapped /32 -> not IPv4 pool addr
 	}
 	for _, c := range cases {
 		host, parsed := isNAT64PoolHostAddress(c.in)

--- a/pkg/config/compiler_nat_host_mask_test.go
+++ b/pkg/config/compiler_nat_host_mask_test.go
@@ -1,0 +1,238 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2173: commit-time validation for the static-NAT / NAT64 host-mask rule.
+// Static NAT is strictly host-1:1 and NAT64 source-pool entries are discrete
+// host IPs, so a non-host mask (/24, /64, ...) is silently dropped by the
+// dataplane (PR #2167 hardened parse_nat_addr / parse_pool_v4 to reject it).
+// The commit gate surfaces the misconfiguration at commit instead.
+//
+// All tests use the production ParseSetCommand + SetPath path (buildTree),
+// never NewParser (the flat-set gotcha in CLAUDE.md).
+
+// staticNATSet builds a minimal valid static-NAT rule-set with the given
+// match destination-address and then-prefix, zone defined to avoid the H15
+// undefined-zone warning noise.
+func staticNATSet(match, prefix string) []string {
+	return []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address " + match,
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix " + prefix,
+	}
+}
+
+func TestStaticNATHostMaskBareAddressOK(t *testing.T) {
+	// Bare address (no mask) is a host form — must compile.
+	tree := buildTree(t, staticNATSet("203.0.113.5", "10.0.0.5"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("bare host addresses must compile, got: %v", err)
+	}
+}
+
+func TestStaticNATHostMaskSlash32OK(t *testing.T) {
+	// Canonical IPv4 host mask /32 — must compile (this is what Junos emits
+	// and what the Go compiler copies verbatim into the snapshot).
+	tree := buildTree(t, staticNATSet("203.0.113.5/32", "10.0.0.5/32"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("/32 host masks must compile, got: %v", err)
+	}
+}
+
+func TestStaticNATHostMaskSlash128OK(t *testing.T) {
+	// Canonical IPv6 host mask /128 — must compile.
+	tree := buildTree(t, staticNATSet("2001:db8::5/128", "2001:db8:1::5/128"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("/128 host masks must compile, got: %v", err)
+	}
+}
+
+func TestStaticNATHostMaskRejectsV4NonHostMatch(t *testing.T) {
+	// A /24 on the match destination-address is a non-host mask — reject at
+	// commit (dataplane would silently drop the rule).
+	tree := buildTree(t, staticNATSet("203.0.113.0/24", "10.0.0.5/32"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("static-NAT match /24 (non-host) must be rejected")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "match destination-address") ||
+		!strings.Contains(msg, "203.0.113.0/24") ||
+		!strings.Contains(msg, "host route") {
+		t.Fatalf("error must name the rule + offending prefix + host-route rule, got: %v", err)
+	}
+}
+
+func TestStaticNATHostMaskRejectsV4NonHostPrefix(t *testing.T) {
+	// A /24 on the then static-nat prefix — reject at commit.
+	tree := buildTree(t, staticNATSet("203.0.113.5/32", "10.0.0.0/24"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("static-NAT prefix /24 (non-host) must be rejected")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "then static-nat prefix") ||
+		!strings.Contains(msg, "10.0.0.0/24") {
+		t.Fatalf("error must name the prefix slot + offending value, got: %v", err)
+	}
+}
+
+func TestStaticNATHostMaskRejectsV6NonHost(t *testing.T) {
+	// A /64 on an IPv6 match — reject at commit.
+	tree := buildTree(t, staticNATSet("2001:db8::/64", "2001:db8:1::5/128"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("static-NAT IPv6 match /64 (non-host) must be rejected")
+	}
+	if !strings.Contains(err.Error(), "2001:db8::/64") {
+		t.Fatalf("error must name the offending /64, got: %v", err)
+	}
+}
+
+// NPTv6 rules (nptv6-prefix) ARE genuine prefix translations (RFC 6296) and
+// MUST NOT be rejected by the host-mask gate — they never flow through the
+// static_nat.rs parse_nat_addr host gate.
+func TestStaticNATHostMaskNPTv6PrefixNotRejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone trust",
+		"set security nat static rule-set rs1 from zone trust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 2001:db8:aaaa::/48",
+		"set security nat static rule-set rs1 rule r1 then static-nat nptv6-prefix 2001:db8:bbbb::/48",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("NPTv6 prefix rule must NOT be rejected by the host-mask gate, got: %v", err)
+	}
+}
+
+// The NAT64 `then static-nat inet` rule is a prefix translation, not host-1:1
+// static NAT: its match destination-address is the NAT64 well-known prefix
+// (64:ff9b::/96, a legitimate non-host prefix). The whole rule must be exempt
+// from the host-mask gate (Then == "inet").
+func TestStaticNATHostMaskInetActionNotRejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match source-address ::/0",
+		"set security nat static rule-set rs1 rule r1 match destination-address 64:ff9b::/96",
+		"set security nat static rule-set rs1 rule r1 then static-nat inet",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("static-nat inet (NAT64) rule with prefix match must compile, got: %v", err)
+	}
+}
+
+// NAT64 source-pool: a non-host single pool address referenced by a nat64
+// rule-set must be rejected at commit.
+func TestNAT64SourcePoolHostMaskRejectsV4NonHost(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security nat source pool p64 address 100.64.0.0/24",
+		"set security nat nat64 rule-set rs1 prefix 64:ff9b::/96",
+		"set security nat nat64 rule-set rs1 source-pool p64",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("nat64 source-pool address /24 (non-host) must be rejected")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "p64") ||
+		!strings.Contains(msg, "100.64.0.0/24") ||
+		!strings.Contains(msg, "nat64") {
+		t.Fatalf("error must name the pool, offending address, and nat64 ref, got: %v", err)
+	}
+}
+
+func TestNAT64SourcePoolHostMaskHostOK(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security nat source pool p64 address 100.64.0.7/32",
+		"set security nat nat64 rule-set rs1 prefix 64:ff9b::/96",
+		"set security nat nat64 rule-set rs1 source-pool p64",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("nat64 source-pool /32 host address must compile, got: %v", err)
+	}
+}
+
+// The strict commit gate must NOT brick a daemon restart: a config committed
+// before this gate existed (non-host static-NAT mask) must LOAD under the
+// lenient path (Store.Load) with the violation downgraded to a warning —
+// otherwise #1960 fail-closed-on-compile-failure bricks the daemon.
+func TestStaticNATHostMaskLenientLoadAccepts(t *testing.T) {
+	cases := [][]string{
+		staticNATSet("203.0.113.0/24", "10.0.0.5/32"),      // v4 non-host match
+		staticNATSet("203.0.113.5/32", "10.0.0.0/24"),      // v4 non-host prefix
+		staticNATSet("2001:db8::/64", "2001:db8:1::5/128"), // v6 non-host match
+		{
+			"set security nat source pool p64 address 100.64.0.0/24",
+			"set security nat nat64 rule-set rs1 prefix 64:ff9b::/96",
+			"set security nat nat64 rule-set rs1 source-pool p64",
+		}, // nat64 pool non-host
+	}
+	for i, lines := range cases {
+		// Strict rejects.
+		if _, err := CompileConfig(buildTree(t, lines)); err == nil {
+			t.Fatalf("case %d: strict CompileConfig must reject", i)
+		}
+		// Lenient accepts + warns.
+		cfg, err := CompileConfigLenient(buildTree(t, lines))
+		if err != nil {
+			t.Fatalf("case %d: CompileConfigLenient must NOT fail (brick-on-restart), got: %v", i, err)
+		}
+		found := false
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "host route") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("case %d: lenient load must emit a host-route warning, warnings=%v", i, cfg.Warnings)
+		}
+	}
+}
+
+// A valid (host-mask) config must NOT produce a host-mask warning under
+// lenient compile (no false positive).
+func TestStaticNATHostMaskLenientValidNoWarning(t *testing.T) {
+	cfg, err := CompileConfigLenient(buildTree(t, staticNATSet("203.0.113.5/32", "10.0.0.5/32")))
+	if err != nil {
+		t.Fatalf("valid config lenient compile: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "host route") {
+			t.Fatalf("valid config must not warn, got: %q", w)
+		}
+	}
+}
+
+// isHostMaskAddress unit coverage: the predicate is the load-bearing core of
+// the gate; a regression here silently changes which forms are rejected.
+func TestIsHostMaskAddress(t *testing.T) {
+	cases := []struct {
+		in         string
+		wantHost   bool
+		wantParsed bool
+	}{
+		{"203.0.113.5", true, true},      // bare v4
+		{"2001:db8::5", true, true},      // bare v6
+		{"203.0.113.5/32", true, true},   // v4 host mask
+		{"2001:db8::5/128", true, true},  // v6 host mask
+		{"203.0.113.0/24", false, true},  // v4 non-host
+		{"2001:db8::/64", false, true},   // v6 non-host
+		{"203.0.113.5/128", false, true}, // cross-family mask on v4 -> non-host
+		{"2001:db8::5/32", false, true},  // cross-family mask on v6 -> non-host
+		{"not-an-ip", false, false},      // not an IP -> not our concern
+		{"addr/", false, false},          // garbage suffix, bad IP part anyway
+		{"203.0.113.5/", false, true},    // empty mask -> non-host (mask "" != "32")
+	}
+	for _, c := range cases {
+		host, parsed := isHostMaskAddress(c.in)
+		if host != c.wantHost || parsed != c.wantParsed {
+			t.Errorf("isHostMaskAddress(%q) = (host=%v, parsed=%v), want (host=%v, parsed=%v)",
+				c.in, host, parsed, c.wantHost, c.wantParsed)
+		}
+	}
+}

--- a/pkg/config/compiler_nat_host_mask_test.go
+++ b/pkg/config/compiler_nat_host_mask_test.go
@@ -178,6 +178,55 @@ func TestNAT64SourcePoolHostMaskRejectsIPv6(t *testing.T) {
 	}
 }
 
+// #2182: the IPv4-mapped IPv6 literal (`::ffff:203.0.113.5`) is the
+// pathological case where Go's net.ParseIP(...).To4() and Rust's IpAddr
+// family decision DISAGREE — exercised end-to-end at COMMIT (not just the
+// predicate-unit table). To4() returns non-nil (Go would call it IPv4 and
+// accept a /32), but Rust's parse_nat_addr parses it as IpAddr::V6 and demands
+// /128, so a /32 is silently dropped by the dataplane, re-creating the exact
+// "commit passes, dataplane drops" gap #2173 closes. The /32 form must now be
+// REJECTED at commit; the /128 form must compile.
+func TestStaticNATHostMaskV4MappedV6RejectsSlash32(t *testing.T) {
+	tree := buildTree(t, staticNATSet("::ffff:203.0.113.5/32", "10.0.0.5/32"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("static-NAT v4-mapped-v6 match /32 must be rejected (Rust treats it as IPv6, requires /128)")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "::ffff:203.0.113.5/32") || !strings.Contains(msg, "host route") {
+		t.Fatalf("error must name the offending v4-mapped-v6 prefix + host-route rule, got: %v", err)
+	}
+}
+
+func TestStaticNATHostMaskV4MappedV6AcceptsSlash128(t *testing.T) {
+	// As an IPv6 literal the host mask is /128 — must compile.
+	tree := buildTree(t, staticNATSet("::ffff:203.0.113.5/128", "::ffff:10.0.0.5/128"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("static-NAT v4-mapped-v6 /128 host mask must compile, got: %v", err)
+	}
+}
+
+// NAT64 source pool: Rust's parse_pool_v4 (Ipv4Addr::from_str) rejects ANY
+// colon-bearing literal, so the v4-mapped-v6 form is dropped regardless of
+// mask. To4() would have wrongly accepted `::ffff:.../32` as an IPv4 pool
+// host; the commit gate must reject BOTH /32 and /128 to match the dataplane.
+func TestNAT64SourcePoolHostMaskRejectsV4MappedV6(t *testing.T) {
+	for _, a := range []string{"::ffff:203.0.113.5/32", "::ffff:203.0.113.5/128", "::ffff:203.0.113.5"} {
+		tree := buildTree(t, []string{
+			"set security nat source pool p64 address " + a,
+			"set security nat nat64 rule-set rs1 prefix 64:ff9b::/96",
+			"set security nat nat64 rule-set rs1 source-pool p64",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatalf("nat64 source-pool v4-mapped-v6 address %q must be rejected (parse_pool_v4 is IPv4-only, rejects colon)", a)
+		}
+		if !strings.Contains(err.Error(), "IPv4 host route") {
+			t.Fatalf("error must say IPv4 host route for %q, got: %v", a, err)
+		}
+	}
+}
+
 // The strict commit gate must NOT brick a daemon restart: a config committed
 // before this gate existed (non-host static-NAT mask) must LOAD under the
 // lenient path (Store.Load) with the violation downgraded to a warning —
@@ -213,6 +262,38 @@ func TestStaticNATHostMaskLenientLoadAccepts(t *testing.T) {
 		if !found {
 			t.Fatalf("case %d: lenient load must emit a host-route warning, warnings=%v", i, cfg.Warnings)
 		}
+	}
+}
+
+// #2182: the lenient warning text must be precise about dataplane impact. A
+// static-NAT IP failure makes parse_nat_addr return None for the rule's
+// match/then -> the WHOLE rule is dropped. A NAT64 source-pool entry is
+// dropped individually by filter_map(parse_pool_v4) -> only that pool address
+// is dropped, the rest of the pool/rule stays installed. The two warnings must
+// say different things so the operator does not over-read the impact.
+func TestNATHostMaskLenientWarningSuffixPrecision(t *testing.T) {
+	staticCfg, err := CompileConfigLenient(buildTree(t, staticNATSet("203.0.113.0/24", "10.0.0.5/32")))
+	if err != nil {
+		t.Fatalf("static-NAT lenient compile: %v", err)
+	}
+	if !hasWarningContaining(staticCfg.Warnings, "rule dropped by dataplane") {
+		t.Fatalf("static-NAT warning must say the rule is dropped, got: %v", staticCfg.Warnings)
+	}
+
+	poolCfg, err := CompileConfigLenient(buildTree(t, []string{
+		"set security nat source pool p64 address 100.64.0.0/24",
+		"set security nat nat64 rule-set rs1 prefix 64:ff9b::/96",
+		"set security nat nat64 rule-set rs1 source-pool p64",
+	}))
+	if err != nil {
+		t.Fatalf("nat64-pool lenient compile: %v", err)
+	}
+	if !hasWarningContaining(poolCfg.Warnings, "only this pool address is dropped") {
+		t.Fatalf("nat64-pool warning must say only the pool address is dropped, got: %v", poolCfg.Warnings)
+	}
+	// And it must NOT claim the whole rule is dropped.
+	if hasWarningContaining(poolCfg.Warnings, "rule dropped by dataplane") {
+		t.Fatalf("nat64-pool warning must NOT claim the whole rule is dropped, got: %v", poolCfg.Warnings)
 	}
 }
 

--- a/pkg/config/compiler_nat_host_mask_test.go
+++ b/pkg/config/compiler_nat_host_mask_test.go
@@ -156,6 +156,28 @@ func TestNAT64SourcePoolHostMaskHostOK(t *testing.T) {
 	}
 }
 
+// A NAT64 source pool translates to IPv4 source addresses (the Rust
+// parse_pool_v4 is IPv4-only). An IPv6 pool address — even a /128 "host" —
+// is silently dropped by the dataplane, so the commit gate must reject it
+// (Codex MAJOR: family-agnostic isHostMaskAddress would have wrongly accepted
+// the /128).
+func TestNAT64SourcePoolHostMaskRejectsIPv6(t *testing.T) {
+	for _, a := range []string{"2001:db8::5/128", "2001:db8::5"} {
+		tree := buildTree(t, []string{
+			"set security nat source pool p64 address " + a,
+			"set security nat nat64 rule-set rs1 prefix 64:ff9b::/96",
+			"set security nat nat64 rule-set rs1 source-pool p64",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatalf("nat64 source-pool IPv6 address %q must be rejected (parse_pool_v4 is IPv4-only)", a)
+		}
+		if !strings.Contains(err.Error(), "IPv4 host route") {
+			t.Fatalf("error must say IPv4 host route for %q, got: %v", a, err)
+		}
+	}
+}
+
 // The strict commit gate must NOT brick a daemon restart: a config committed
 // before this gate existed (non-host static-NAT mask) must LOAD under the
 // lenient path (Store.Load) with the violation downgraded to a warning —
@@ -232,6 +254,34 @@ func TestIsHostMaskAddress(t *testing.T) {
 		host, parsed := isHostMaskAddress(c.in)
 		if host != c.wantHost || parsed != c.wantParsed {
 			t.Errorf("isHostMaskAddress(%q) = (host=%v, parsed=%v), want (host=%v, parsed=%v)",
+				c.in, host, parsed, c.wantHost, c.wantParsed)
+		}
+	}
+}
+
+// isNAT64PoolHostAddress is IPv4-ONLY (mirrors Rust parse_pool_v4): bare IPv4
+// or IPv4 /32 are installable; an IPv6 address (bare or any mask) and a
+// non-host IPv4 mask are not.
+func TestIsNAT64PoolHostAddress(t *testing.T) {
+	cases := []struct {
+		in         string
+		wantHost   bool
+		wantParsed bool
+	}{
+		{"100.64.0.7", true, true},       // bare IPv4
+		{"100.64.0.7/32", true, true},    // IPv4 host mask
+		{"100.64.0.0/24", false, true},   // IPv4 non-host
+		{"2001:db8::5", false, true},     // bare IPv6 -> not installable (parsed)
+		{"2001:db8::5/128", false, true}, // IPv6 /128 -> not installable (parsed)
+		{"2001:db8::/64", false, true},   // IPv6 non-host
+		{"100.64.0.7/128", false, true},  // cross-family mask on IPv4
+		{"not-an-ip", false, false},      // not an IP
+		{"100.64.0.7/", false, true},     // empty mask -> non-host
+	}
+	for _, c := range cases {
+		host, parsed := isNAT64PoolHostAddress(c.in)
+		if host != c.wantHost || parsed != c.wantParsed {
+			t.Errorf("isNAT64PoolHostAddress(%q) = (host=%v, parsed=%v), want (host=%v, parsed=%v)",
 				c.in, host, parsed, c.wantHost, c.wantParsed)
 		}
 	}

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -7,7 +7,11 @@ import (
 
 func TestNAT64(t *testing.T) {
 	tree := &ConfigTree{}
-	setCommands := []string{"set security nat source pool nat64-pool address 203.0.113.0/24", "set security nat nat64 rule-set v6-to-v4 prefix 64:ff9b::/96", "set security nat nat64 rule-set v6-to-v4 source-pool nat64-pool"}
+	// #2173: a NAT64 source-pool address must be a host route (/32) — the
+	// pool holds discrete host source IPs (parse_pool_v4) and a non-host mask
+	// is rejected at commit. This fixture is about NAT64 rule-set parsing, so
+	// use a canonical /32 host address.
+	setCommands := []string{"set security nat source pool nat64-pool address 203.0.113.5/32", "set security nat nat64 rule-set v6-to-v4 prefix 64:ff9b::/96", "set security nat nat64 rule-set v6-to-v4 source-pool nat64-pool"}
 	for _, cmd := range setCommands {
 		path, err := ParseSetCommand(cmd)
 		if err != nil {


### PR DESCRIPTION
## Summary

Follow-up to #2122/#2123/#2132 + PR #2167. Static NAT is strictly host-1:1 and
NAT64 source-pool entries are discrete host source IPs, so the only meaningful
mask on a static-NAT match/prefix or a NAT64 pool address is the canonical host
mask (`/32` for IPv4, `/128` for IPv6; a bare address is a host too).

#2132 made the Rust dataplane TOLERATE the canonical host mask; PR #2167 then
hardened the Rust parser (`parse_nat_addr` in `userspace-dp/src/nat/static_nat.rs`,
`parse_pool_v4` in `userspace-dp/src/nat64.rs`) to REJECT a non-host mask
(`/24`, `/64`, garbage suffix). The net effect before this PR was a **silent
dataplane drop**: a misconfigured `/24` match/prefix or pool address was
parsed-out and the rule was never installed, with no operator feedback.

This PR adds the missing **commit-time** validation in the Go config compiler so
the operator learns at `commit` / `commit check`, not via a silent dataplane
drop.

## Change

`validateNATHostMaskStrict` (`pkg/config/compiler_nat.go`), invoked from the
typed-config phase of `compileExpanded` alongside the other strict-vs-lenient
gates. The host-route rule mirrors the Rust gate EXACTLY via a shared predicate
`isHostMaskAddress` (bare IP OK, `/32` v4 OK, `/128` v6 OK, anything else
rejected; a cross-family mask is non-host; a non-IP token is left to existing
address handling).

Scope and exemptions match the Rust gate:
- static-NAT `match destination-address` (→ `ExternalIP`) and `then static-nat
  prefix` (→ `InternalIP`) are host-checked.
- **NPTv6** (`nptv6-prefix`) rules are exempt — genuine RFC 6296 prefix
  translation, never run through `parse_nat_addr`.
- **NAT64** (`then static-nat inet`) rules are exempt as a whole — the `match` is
  the NAT64 well-known prefix (e.g. `64:ff9b::/96`) and translation is driven by
  the separate NAT64 snapshot, not the static_nat table.
- NAT64 source-pool addresses (`parse_pool_v4` host-mask gate) are host-checked.
  Range-expanded pool entries are always `/32` by construction, so only an
  operator-authored single non-host pool address can trip this.

Strict-vs-lenient split (same doctrine as `#2079` pool-utilization-alarm):
- **Strict (`commit` / `commit check`):** hard-reject, naming the rule-set,
  rule, slot, and offending prefix.
- **Lenient (`Store.Load` / HA peer-sync — `CompileConfigLenient` /
  `CompileConfigForNodeLenient`, flag `lenientNATHostMask`):** downgrade to a
  `cfg.Warnings` entry so a node that committed a non-host mask before this gate
  existed (or a peer-synced config) still BOOTS after upgrade instead of failing
  closed (#1960 fail-closed-on-compile-failure). The dataplane drops the bad
  entry independently, so a leniently-loaded config is already inert for that
  rule.

## Junos parity

Junos static NAT requires host routes (`static-nat prefix` is a 1:1 host
mapping); a bare address and an explicit `/32`/`/128` are both valid host forms,
and Junos itself emits the canonical mask. A true subnet mask is a
misconfiguration. NPTv6 (prefix translation) and the NAT64 `inet` action are the
two legitimate prefix-bearing static stanzas and are correctly exempt.

## Test plan

- [x] `GOCACHE=... go build ./...` clean
- [x] `go test ./pkg/config/...` green; full `go test ./...` green
- [x] New `pkg/config/compiler_nat_host_mask_test.go`: bare/`/32`/`/128` accept;
      v4+v6 non-host match/prefix reject (message asserted); NPTv6 + `inet`
      exemptions; NAT64 source-pool host vs non-host; strict-reject /
      lenient-warn / valid-no-warning; `isHostMaskAddress` table.
- [x] Reject tests verified to FAIL when the guard is removed (sensitivity).
- [x] Fixed `TestNAT64` fixture to a `/32` NAT64 source-pool address (the value
      was incidental to that test's NAT64-parsing purpose).
- [x] Doc: `docs/config-schema.md` #2173 section.
- Isolated commit-time validation — no cluster smoke (unit-testable per the
  issue).

Closes #2173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)