### PR TITLE
#2175: route firewall-filter protocol resolution through appid.ProtocolNumber (5th SSOT site)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -7854,3 +7854,24 @@ top.
   **File(s)**: userspace-dp/src/afxdp/frame/tcp.rs,
   userspace-dp/src/afxdp/frame/tcp_tests.rs,
   userspace-dp/src/afxdp/frame/README.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2175 — centralize the firewall-filter `from protocol <name>`
+  resolution table onto the `appid.ProtocolNumber` SSOT (#2124). It was the
+  fifth, independent protocol-name→IANA-number copy: a hard-coded
+  tcp/udp/icmp/icmpv6 switch with a silent numeric fallback in
+  `compiler_filter.go`, so a name added to the SSOT (sctp/esp/ah/vrrp/...)
+  was silently unavailable to firewall filters even though the identical
+  token resolved in a security policy, and a typo'd name degraded to
+  "match protocol 0". Chose SSOT delegation (Junos firewall filters
+  legitimately accept the broad named/IANA protocol set in `from protocol`,
+  not just L4) plus a `validateFilterProtocols` pass at the top of
+  `compileFirewallFilters` that rejects an unrepresentable token at commit
+  with a clear family/filter/term/token error. No import cycle: pkg/dataplane
+  already imports pkg/appid. L4 subset + numeric (incl. HOPOPT "0") unchanged.
+  5 new Go tests (sctp/esp/ah/vrrp/gre/ospf/igmp/pim resolve; unknown name
+  fails commit on the full compileFirewallFilters path; sctp end-to-end
+  programs protocol 132); SSOT assertions FAIL on pre-fix. build ./... +
+  go test pkg/dataplane/... pkg/appid/... pkg/config/... green.
+  **File(s)**: pkg/dataplane/compiler_filter.go,
+  pkg/dataplane/compiler_filter_protocol_test.go, docs/feature-gaps.md

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,53 @@
 # Action Log
 
+## 2026-06-21 — #2175 review fold: firewall-filter protocol refuses commit
+
+- **Timestamp**: 2026-06-21
+- **Action**: Folded a MINOR review fix into the #2175 SSOT PR. The
+  branch routed `from protocol <token>` through the centralized
+  `appid.ProtocolNumber` and added `validateFilterProtocols` in the
+  DATAPLANE compiler (`compileFirewallFilters`), but that error path is
+  not in `requiredProtocolGateSentinels`, so
+  `compileErrorMustAbortApply` is false at `daemon_apply.go` — the
+  daemon SWALLOWS it (journal WARN + /health LastError only) and commit
+  reports SUCCESS while the term silently programs no protocol match.
+  Inconsistent with siblings #2142 (`validateApplicationSpecsStrict`)
+  and #2173 (`validateNATHostMaskStrict`) which refuse at the
+  `pkg/config` commit-check layer. Added
+  `validateFilterProtocolsStrict` (pkg/config/compiler.go), wired into
+  `compileExpanded` after the application-specs gate behind a new
+  `lenientFilterProtocols` opt (true on the load / peer-sync paths,
+  false on commit / commit-check). An invalid token (not a known name,
+  junos-* alias, or 0..255 numeric) now FAILS commit with a
+  family/filter/term/token error; LOAD / peer-sync downgrade to a
+  warning so a persisted/synced config still boots (#1960 no-brick).
+  Because `pkg/appid` imports `pkg/config` (import cycle), the gate
+  INLINE-mirrors `appid.ProtocolNumber`'s acceptance set via
+  `filterProtocolResolvable` (tighter than `validateProtocol`, which
+  blanket-accepts any `junos-` prefix); a `pkg/appid` drift-guard test
+  (`TestFilterProtocolResolvableMatchesProtocolNumber`) pins it to the
+  SSOT via the exported `FilterProtocolResolvable` accessor (#2185
+  pattern). KEPT the dataplane `validateFilterProtocols` as
+  strictly-more-fail-closed defense-in-depth. Reworded
+  docs/feature-gaps.md to attribute the commit refusal to the
+  commit-check layer + dataplane backstop. Renamed the misleading
+  `TestCompileFirewallFiltersUnknownProtocolFailsCommit` (it exercised
+  the dataplane drop, not commit refusal) to
+  `...ReturnsDataplaneError`. Added commit-refusal + valid-commit +
+  lenient-load tests; verified the commit-refusal tests FAIL when the
+  strict gate is neutralized.
+- **File(s)**: pkg/config/compiler.go,
+  pkg/config/compiler_filter_protocol_test.go,
+  pkg/appid/protocol_number_2124_test.go,
+  pkg/dataplane/compiler_filter_protocol_test.go,
+  docs/feature-gaps.md, _Log.md
+- **Validation**: `go build ./...` clean; `go test ./pkg/config/...
+  ./pkg/dataplane/... ./pkg/appid/... ./pkg/daemon/...` all pass;
+  `go vet` clean; revert-proof confirmed (commit-refusal + lenient-warn
+  tests fail with the gate removed); valid protocols
+  (tcp/udp/icmp/icmpv6/sctp/esp/ah/gre/ospf/vrrp/igmp/pim/junos-*/0/47/
+  132/255) still commit.
+
 ## 2026-06-21 — #2144 validate routing export references at commit
 
 - **Timestamp**: 2026-06-21

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -342,6 +342,16 @@ xpf has a broad chassis cluster implementation with redundancy groups, RETH (VRR
 
 xpf has firewall filters with source/dest addresses, prefix-lists (with except), DSCP, protocol, dest/source ports, ICMP type/code, TCP flags, fragment match, actions (accept/reject/discard), routing-instance, log, count, forwarding-class, loss-priority, DSCP rewrite, and IPv6 traffic-class matching.
 
+`from protocol <name>` resolution is centralized (#2175) on the same
+`appid.ProtocolNumber` source of truth used by security-policy applications
+(#2124), so every protocol a policy accepts a firewall filter accepts too: the
+L4 subset (`tcp`/`udp`/`icmp`/`icmpv6`), the broader named set
+(`gre`/`ospf`/`esp`/`ah`/`sctp`/`vrrp`/`igmp`/`pim`/`egp`/`ipip`/...), Junos
+predefined aliases, and any numeric value `0`-`255` (including the deliberate
+`0` for HOPOPT). An unrepresentable protocol token is **rejected at commit with
+a clear error** naming the offending family/filter/term/token, rather than
+silently degrading to "match protocol 0".
+
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
 | **Policer (Rate Limiting)** | `firewall policer ... bandwidth-limit N burst-size-limit N` | Token-bucket rate limiter applied to filter terms or interfaces. Single-rate two-color, three-color policers. | High | Partial for #1373: legacy eBPF/~~DPDK~~ (DPDK retired #1525) token-bucket policer support existed; userspace supports the admitted filter path and the color-blind `then discard` three-color slice. #1375 is closed; unsupported color-aware/non-drop behavior and broader Junos parity remain production/future parity work, not active #1373 source-removal blockers. |

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -350,7 +350,15 @@ L4 subset (`tcp`/`udp`/`icmp`/`icmpv6`), the broader named set
 predefined aliases, and any numeric value `0`-`255` (including the deliberate
 `0` for HOPOPT). An unrepresentable protocol token is **rejected at commit with
 a clear error** naming the offending family/filter/term/token, rather than
-silently degrading to "match protocol 0".
+silently degrading to "match protocol 0". The operator-visible refusal is
+enforced at the config commit-check layer
+(`config.validateFilterProtocolsStrict`, lenient warn-only on the load /
+peer-sync path so a persisted/synced config still boots — #1960), with the
+dataplane compiler (`validateFilterProtocols`) keeping an identical check as a
+strictly-more-fail-closed backstop. Because `pkg/appid` imports `pkg/config`,
+the commit-check gate INLINE-mirrors the `appid.ProtocolNumber` acceptance set
+(it cannot import `appid` — an import cycle); a `pkg/appid` drift-guard test
+pins the two together so the duplicated table cannot diverge silently.
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|

--- a/pkg/appid/protocol_number_2124_test.go
+++ b/pkg/appid/protocol_number_2124_test.go
@@ -1,6 +1,10 @@
 package appid
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
 
 // #2124 — ProtocolNumber is the single source of truth for resolving a protocol
 // name/alias/numeric string to its IANA number. These tests pin the table the
@@ -63,6 +67,47 @@ func TestProtocolNumberParityWithCatalog(t *testing.T) {
 		want, _ := ProtocolNumber(name)
 		if got := catalogProtocolNumber(name); got != want {
 			t.Errorf("catalogProtocolNumber(%q) = %d, ProtocolNumber = %d (divergence)", name, got, want)
+		}
+	}
+}
+
+// TestFilterProtocolResolvableMatchesProtocolNumber is the #2175 drift guard
+// for the firewall-filter commit-check gate. The compiler's
+// validateFilterProtocolsStrict resolves `from protocol <token>` via
+// config.filterProtocolResolvable, which INLINE-duplicates the acceptance set
+// of ProtocolNumber's ok==true result because pkg/appid imports pkg/config (so
+// the compiler cannot call ProtocolNumber directly without an import cycle —
+// the same constraint behind ApplicationsToValidateStrict / #2185). This test
+// pins the two together: for every token, config.FilterProtocolResolvable must
+// equal the ok bool of ProtocolNumber. If a future change to ProtocolNumber's
+// table silently diverges from the compiler copy, this fails — turning a silent
+// commit-gate drift (commit accepts a token the dataplane SSOT then drops, or
+// rejects one it accepts) into a test failure. It is a cross-check TEST, not a
+// runtime coupling.
+func TestFilterProtocolResolvableMatchesProtocolNumber(t *testing.T) {
+	tokens := []string{
+		// L4 subset + broader named set.
+		"tcp", "udp", "icmp", "icmpv6", "icmp6", "gre", "ospf", "ipip",
+		"esp", "ah", "sctp", "vrrp", "igmp", "pim", "egp",
+		// Junos predefined aliases.
+		"junos-tcp-any", "junos-udp-any", "junos-icmp-all", "junos-ping",
+		"junos-icmp6-all", "junos-pingv6", "junos-gre", "junos-ospf",
+		"junos-ip-in-ip", "junos-ipip",
+		// Case-insensitivity + whitespace trim.
+		"ESP", "Sctp", " tcp ",
+		// Numeric, including the deliberate "0" (HOPOPT) and the 0..255 bounds.
+		"0", "1", "47", "132", "255",
+		// Unrepresentable: out of range, malformed, junk, empty, and a
+		// junos-* alias that ProtocolNumber does NOT resolve (validateProtocol
+		// blanket-accepts any junos-* prefix, but the filter gate must not).
+		"256", "-1", "0x50", "bogus", "definitely-not-a-proto", "",
+		"junos-foobar",
+	}
+	for _, tok := range tokens {
+		_, want := ProtocolNumber(tok)
+		if got := config.FilterProtocolResolvable(tok); got != want {
+			t.Errorf("FilterProtocolResolvable(%q) = %v, ProtocolNumber ok = %v (divergence)",
+				tok, got, want)
 		}
 	}
 }

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -256,6 +256,27 @@ type compileOpts struct {
 	// SchemaValidate (applications stay opaque there). Same doctrine as
 	// lenientPolicyMatchAddress / lenientNATHostMask.
 	lenientApplicationSpecs bool
+	// lenientFilterProtocols (#2175 review) downgrades the firewall-filter
+	// `from protocol <token>` gate (validateFilterProtocolsStrict) from a
+	// hard compile error to a cfg.Warnings entry. The strict commit /
+	// commit-check path hard-rejects a term whose protocol token is neither
+	// a known protocol name, a junos-* alias, nor a 0..255 number — the same
+	// acceptance set the centralized appid.ProtocolNumber SSOT admits (#2124
+	// / #2175). Before this gate such a token was caught only by the
+	// dataplane compiler (compileFirewallFilters → validateFilterProtocols),
+	// whose error the daemon SWALLOWS (it is not in
+	// requiredProtocolGateSentinels, so compileErrorMustAbortApply == false):
+	// commit returned SUCCESS, the config was promoted, and the term silently
+	// programmed NO protocol match (the pre-#2175 "match protocol 0"
+	// surprise). The dataplane gate stays as defense-in-depth; this commit-
+	// check gate makes the refusal operator-visible. The tolerant load /
+	// peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config carrying a bad token still BOOTS (#1960 no-brick) —
+	// the dataplane independently drops the protocol constraint, so a
+	// leniently-loaded bad term is inert (it matches without a protocol
+	// constraint, never silently "protocol 0"). Same doctrine as
+	// lenientApplicationSpecs.
+	lenientFilterProtocols bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -291,6 +312,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientUnsupportedInterfaceStanzas: true,
 		lenientRoutingExportRef:            true,
 		lenientApplicationSpecs:            true,
+		lenientFilterProtocols:             true,
 	})
 }
 
@@ -377,6 +399,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientUnsupportedInterfaceStanzas: true,
 		lenientRoutingExportRef:            true,
 		lenientApplicationSpecs:            true,
+		lenientFilterProtocols:             true,
 	})
 }
 
@@ -740,6 +763,32 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientApplicationSpecs {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("application spec (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2175 firewall-filter `from protocol <token>` fail-open gate. Strict on
+	// commit / commit-check (hard-reject a term whose protocol token is not
+	// resolvable by the centralized appid.ProtocolNumber SSOT — neither a
+	// known protocol name, a junos-* alias, nor a 0..255 number). Before this
+	// gate such a token was caught only by the dataplane compiler
+	// (compileFirewallFilters → validateFilterProtocols), whose error the
+	// daemon SWALLOWS (not in requiredProtocolGateSentinels, so
+	// compileErrorMustAbortApply == false): commit returned SUCCESS, the
+	// config was promoted, and the term silently programmed NO protocol match
+	// (the pre-#2175 "match protocol 0" surprise). The dataplane gate remains
+	// as defense-in-depth; this gate makes the refusal operator-visible at
+	// commit, consistent with validateApplicationSpecsStrict / the other
+	// fail-open gates. Lenient on load / peer-sync (warn so an already-
+	// persisted or peer-synced config carrying a bad token still boots — #1960
+	// no-brick; the dataplane drops the constraint independently so the term
+	// is inert, never silently "protocol 0"). Runs on the fully-compiled
+	// *Config (firewall filters compiled) so the typed term list is populated.
+	if err := validateFilterProtocolsStrict(cfg); err != nil {
+		if opts.lenientFilterProtocols {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("firewall filter protocol (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}
@@ -1541,6 +1590,114 @@ func applicationsToValidateStrict(cfg *Config) map[string]struct{} {
 // unexported validateApplicationSpecsStrict directly.
 func ApplicationsToValidateStrict(cfg *Config) map[string]struct{} {
 	return applicationsToValidateStrict(cfg)
+}
+
+// validateFilterProtocolsStrict hard-rejects any firewall-filter term whose
+// `from protocol <token>` is not resolvable by the centralized protocol SSOT
+// (#2175) — neither a known protocol name, a junos-* alias, nor a 0..255
+// number. It walks every inet and inet6 filter and reports the first offending
+// family / filter / term / token (sorted by filter name, then by the term's
+// position, so the first-reported error is deterministic across runs).
+//
+// Resolution goes through filterProtocolResolvable, which INLINE-mirrors the
+// acceptance set of appid.ProtocolNumber. The compiler cannot call
+// appid.ProtocolNumber directly because pkg/appid imports pkg/config (an import
+// cycle) — the same constraint that forces validateApplicationSpecsStrict to
+// duplicate appid.CatalogNames's policy-reference walk (#2142). A pkg/appid
+// drift-guard test (TestFilterProtocolResolvableMatchesProtocolNumber) asserts
+// the two acceptance sets agree via the exported FilterProtocolResolvable
+// accessor, so a future change to appid.ProtocolNumber cannot let this copy
+// drift silently.
+//
+// The dataplane compiler (compileFirewallFilters → validateFilterProtocols)
+// keeps an identical check as defense-in-depth, but its error is swallowed by
+// the daemon (compileErrorMustAbortApply == false): this commit-check gate is
+// what makes the refusal operator-visible. On the tolerant load / peer-sync
+// path the caller downgrades the returned error to a warning (#1960 no-brick).
+func validateFilterProtocolsStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	check := func(family string, filters map[string]*FirewallFilter) error {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil {
+				continue
+			}
+			for _, term := range filter.Terms {
+				if term == nil || term.Protocol == "" {
+					continue
+				}
+				if !filterProtocolResolvable(term.Protocol) {
+					return fmt.Errorf(
+						"firewall family %s filter %q term %q: unknown protocol %q "+
+							"(use a protocol name such as tcp/udp/icmp/icmpv6/gre/esp/ah/"+
+							"sctp/ospf or a numeric value 0-255)",
+						family, name, term.Name, term.Protocol)
+				}
+			}
+		}
+		return nil
+	}
+	if err := check("inet", cfg.Firewall.FiltersInet); err != nil {
+		return err
+	}
+	return check("inet6", cfg.Firewall.FiltersInet6)
+}
+
+// filterProtocolResolvable reports whether a `from protocol <token>` is
+// representable: it INLINE-mirrors the acceptance set of
+// appid.ProtocolNumber's ok==true result (the #2124/#2175 SSOT). pkg/config
+// cannot import pkg/appid (import cycle: pkg/appid imports pkg/config), so the
+// known-name set is duplicated here and pinned by the pkg/appid drift-guard
+// test TestFilterProtocolResolvableMatchesProtocolNumber via the exported
+// FilterProtocolResolvable accessor.
+//
+// The acceptance set is intentionally TIGHTER than validateProtocol (used by
+// validateApplicationSpecsStrict): validateProtocol blanket-accepts ANY
+// "junos-" prefix, but appid.ProtocolNumber only resolves the specific
+// junos-* aliases below, so an unknown "junos-foobar" must be rejected here to
+// stay consistent with the dataplane SSOT — otherwise commit would pass while
+// the swallowed dataplane gate dropped the constraint.
+func filterProtocolResolvable(token string) bool {
+	switch strings.ToLower(strings.TrimSpace(token)) {
+	case "tcp", "junos-tcp-any",
+		"udp", "junos-udp-any",
+		"icmp", "junos-icmp-all", "junos-ping",
+		"icmpv6", "icmp6", "junos-icmp6-all", "junos-pingv6",
+		"gre", "junos-gre",
+		"ospf", "junos-ospf",
+		"junos-ip-in-ip", "junos-ipip", "ipip",
+		"egp",
+		"igmp",
+		"pim",
+		"ah",
+		"esp",
+		"sctp",
+		"vrrp":
+		return true
+	default:
+		// Numeric protocol number, including the deliberate "0" (HOPOPT).
+		if n, err := strconv.Atoi(strings.TrimSpace(token)); err == nil && n >= 0 && n < 256 {
+			return true
+		}
+		return false
+	}
+}
+
+// FilterProtocolResolvable exposes filterProtocolResolvable for the pkg/appid
+// drift-guard test (TestFilterProtocolResolvableMatchesProtocolNumber), which
+// asserts this acceptance set agrees with appid.ProtocolNumber's ok==true
+// result so the INLINE-duplicated table cannot drift from the SSOT silently. It
+// is a TEST seam, not a runtime coupling — production code uses the unexported
+// filterProtocolResolvable directly.
+func FilterProtocolResolvable(token string) bool {
+	return filterProtocolResolvable(token)
 }
 
 func policyMatchAddressError(scope, polName, field, addr string) error {

--- a/pkg/config/compiler_filter_protocol_test.go
+++ b/pkg/config/compiler_filter_protocol_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2175 review fold: a firewall-filter `from protocol <token>` whose protocol is
+// not resolvable by the centralized appid.ProtocolNumber SSOT was caught ONLY by
+// the dataplane compiler (compileFirewallFilters → validateFilterProtocols),
+// whose error the daemon swallows (compileErrorMustAbortApply == false). Commit
+// reported SUCCESS, the config was promoted, and the term silently programmed no
+// protocol match (the pre-#2175 "match protocol 0" surprise). These tests drive
+// the real strict commit path (CompileConfig) and the tolerant load path
+// (CompileConfigLenient) through validateFilterProtocolsStrict so an invalid
+// token now REFUSES the operator commit while a persisted/synced config still
+// boots.
+//
+// All trees are built from flat `set` commands via flatTreeFromSets (defined in
+// compiler_interfaces_unsupported_test.go) — the only correct way to exercise
+// the flat-set AST shape.
+
+func filterWithProtocol(family, proto string) []string {
+	return []string{
+		"set firewall family " + family + " filter f1 term t1 from protocol " + proto,
+		"set firewall family " + family + " filter f1 term t1 then accept",
+	}
+}
+
+func TestFilterProtocol_UnknownName_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithProtocol("inet", "bogus-proto")...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to reject firewall filter f1 term t1 with protocol bogus-proto")
+	}
+	if !strings.Contains(err.Error(), "bogus-proto") ||
+		!strings.Contains(err.Error(), "f1") ||
+		!strings.Contains(err.Error(), "t1") {
+		t.Fatalf("error %q must name the family/filter/term and the offending protocol", err.Error())
+	}
+}
+
+// An unknown junos-* alias must be rejected too: validateProtocol blanket-accepts
+// any "junos-" prefix, but the filter gate mirrors appid.ProtocolNumber, which
+// resolves only the specific junos-* aliases. A token the dataplane SSOT cannot
+// resolve must not slip past commit only to be dropped (swallowed) at the
+// dataplane.
+func TestFilterProtocol_UnknownJunosAlias_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithProtocol("inet", "junos-foobar")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("expected commit to reject firewall filter with protocol junos-foobar")
+	}
+}
+
+func TestFilterProtocol_OutOfRangeNumeric_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithProtocol("inet", "256")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("expected commit to reject firewall filter with protocol 256 (out of 0-255)")
+	}
+}
+
+func TestFilterProtocol_Inet6UnknownName_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithProtocol("inet6", "nope")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("expected commit to reject inet6 firewall filter with protocol nope")
+	}
+}
+
+// Valid protocols across the full SSOT acceptance set must still commit: the L4
+// subset, a #2124-added name (sctp/esp), a junos-* alias, the deliberate
+// numeric 0 (HOPOPT), and a numeric bound.
+func TestFilterProtocol_ValidProtocols_Commit(t *testing.T) {
+	for _, proto := range []string{
+		"tcp", "udp", "icmp", "icmpv6", "icmp6",
+		"sctp", "esp", "ah", "gre", "ospf", "vrrp", "igmp", "pim",
+		"junos-tcp-any", "junos-icmp6-all",
+		"0", "47", "132", "255",
+	} {
+		t.Run(proto, func(t *testing.T) {
+			tree := flatTreeFromSets(t, filterWithProtocol("inet", proto)...)
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("valid filter protocol %q must commit, got %v", proto, err)
+			}
+		})
+	}
+}
+
+// No-brick (#1960 doctrine): a config persisted/synced with a firewall filter
+// carrying an unrepresentable protocol token must still LOAD on the tolerant
+// path (CompileConfigLenient) — downgraded to a warning — so an upgraded or
+// receiving node does not fail closed on boot. The dataplane drops the protocol
+// constraint independently, so the leniently-loaded term is inert (it matches
+// without a protocol constraint, never silently "protocol 0").
+func TestFilterProtocol_Unknown_LenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithProtocol("inet", "bogus-proto")...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load of a bad filter protocol must not fail: %v", err)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "firewall filter protocol") && strings.Contains(w, "bogus-proto") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected lenient path to record a firewall-filter-protocol downgrade warning, got %v", cfg.Warnings)
+	}
+}

--- a/pkg/dataplane/compiler_filter.go
+++ b/pkg/dataplane/compiler_filter.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
 )
 
@@ -16,6 +17,15 @@ import (
 func compileFirewallFilters(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 	// Track written keys for populate-before-clear.
 	writtenIfaceFilter := make(map[IfaceFilterKey]bool)
+
+	// Validate every term's `from protocol <name>` token up front so an
+	// unrepresentable protocol fails the commit with a clear error instead of
+	// silently degrading to "match protocol 0" (the pre-#2175 numeric-fallback
+	// surprise). Resolution runs through the centralized appid.ProtocolNumber
+	// SSOT, so any name a security policy accepts a firewall filter accepts too.
+	if err := validateFilterProtocols(cfg); err != nil {
+		return err
+	}
 
 	// Build routing instance name -> table ID map (skip forwarding instances)
 	riTableIDs := make(map[string]uint32)
@@ -359,6 +369,48 @@ func compileFirewallFilters(dp DataPlane, cfg *config.Config, result *CompileRes
 	return nil
 }
 
+// validateFilterProtocols rejects any firewall-filter term whose
+// `from protocol <name>` token cannot be resolved by the centralized
+// appid.ProtocolNumber SSOT (#2175). It walks every inet and inet6 filter so
+// the failure surfaces at commit time with a clear, actionable error rather
+// than degrading silently to "match protocol 0" deep in rule expansion.
+//
+// A bare numeric token (including the deliberate "0" for HOPOPT) resolves
+// through ProtocolNumber's numeric fallback, so explicit numeric protocols
+// keep working; only genuinely unrepresentable tokens are rejected.
+func validateFilterProtocols(cfg *config.Config) error {
+	check := func(family string, filters map[string]*config.FirewallFilter) error {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil {
+				continue
+			}
+			for _, term := range filter.Terms {
+				if term == nil || term.Protocol == "" {
+					continue
+				}
+				if _, ok := appid.ProtocolNumber(term.Protocol); !ok {
+					return fmt.Errorf(
+						"firewall family %s filter %s term %s: unknown protocol %q "+
+							"(use a protocol name such as tcp/udp/icmp/icmpv6/gre/esp/ah/"+
+							"sctp/ospf or a numeric value 0-255)",
+						family, name, term.Name, term.Protocol)
+				}
+			}
+		}
+		return nil
+	}
+	if err := check("inet", cfg.Firewall.FiltersInet); err != nil {
+		return err
+	}
+	return check("inet6", cfg.Firewall.FiltersInet6)
+}
+
 // expandFilterTerm expands a single filter term into one or more BPF filter rules.
 // Terms with multiple source/destination addresses generate the cross product of rules.
 func expandFilterTerm(term *config.FirewallFilterTerm, family uint8, riTableIDs map[string]uint32, prefixLists map[string]*config.PrefixList, policerIDs map[string]uint32) []FilterRule {
@@ -431,22 +483,18 @@ func expandFilterTerm(term *config.FirewallFilterTerm, family uint8, riTableIDs 
 		}
 	}
 
-	// Protocol match
+	// Protocol match — resolve through the centralized appid.ProtocolNumber
+	// SSOT (#2124/#2175) so every protocol representable in a security policy
+	// (tcp/udp/icmp/icmpv6 plus gre/ospf/esp/ah/sctp/vrrp/igmp/pim/... and any
+	// numeric 0..255) resolves identically in a firewall filter match.
+	// compileFirewallFilters validates the token up front, so an
+	// unrepresentable name never reaches here; ok==false is treated
+	// defensively as "no protocol constraint" rather than the old silent
+	// "match protocol 0" surprise.
 	if term.Protocol != "" {
-		base.MatchFlags |= FilterMatchProtocol
-		switch strings.ToLower(term.Protocol) {
-		case "tcp":
-			base.Protocol = 6
-		case "udp":
-			base.Protocol = 17
-		case "icmp":
-			base.Protocol = 1
-		case "icmpv6":
-			base.Protocol = 58
-		default:
-			if v, err := strconv.Atoi(term.Protocol); err == nil {
-				base.Protocol = uint8(v)
-			}
+		if n, ok := appid.ProtocolNumber(term.Protocol); ok {
+			base.MatchFlags |= FilterMatchProtocol
+			base.Protocol = n
 		}
 	}
 

--- a/pkg/dataplane/compiler_filter_protocol_test.go
+++ b/pkg/dataplane/compiler_filter_protocol_test.go
@@ -142,10 +142,18 @@ func TestValidateFilterProtocolsAcceptsRepresentable(t *testing.T) {
 	}
 }
 
-// TestCompileFirewallFiltersUnknownProtocolFailsCommit drives the full
-// compileFirewallFilters entry point to prove the unknown-protocol error
-// propagates to the caller (the commit path) rather than being swallowed.
-func TestCompileFirewallFiltersUnknownProtocolFailsCommit(t *testing.T) {
+// TestCompileFirewallFiltersUnknownProtocolReturnsDataplaneError drives the
+// full compileFirewallFilters entry point to prove the dataplane defense-in-
+// depth gate returns an error and programs NO rules for an unrepresentable
+// protocol. NOTE: in production the daemon SWALLOWS this dataplane-layer error
+// (compileErrorMustAbortApply == false — it is not in
+// requiredProtocolGateSentinels), so this does NOT by itself refuse the
+// operator commit. The operator-visible commit refusal is enforced one layer
+// up by config.validateFilterProtocolsStrict — see
+// pkg/config/compiler_filter_protocol_test.go
+// (TestFilterProtocol_*_RejectsAtCommit). This test pins the dataplane gate as
+// the strictly-more-fail-closed backstop.
+func TestCompileFirewallFiltersUnknownProtocolReturnsDataplaneError(t *testing.T) {
 	cfg := filterCfgWithProtocol("inet", "bogus-proto")
 	dp := &recordingFilterDP{}
 	result := &CompileResult{}

--- a/pkg/dataplane/compiler_filter_protocol_test.go
+++ b/pkg/dataplane/compiler_filter_protocol_test.go
@@ -1,0 +1,185 @@
+package dataplane
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2175 — the firewall-filter `from protocol <name>` resolution table was a
+// fifth, independent copy of the protocol-name→IANA-number mapping that
+// #2124 centralized onto appid.ProtocolNumber for the four policy-application
+// sites. It only knew tcp/udp/icmp/icmpv6 + a silent numeric fallback, so a
+// name added to the SSOT (e.g. sctp/esp/ah/vrrp) was silently unavailable to
+// firewall filters even though the identical token resolved in a security
+// policy. These tests pin the fold onto appid.ProtocolNumber: the broad named
+// set now resolves, the L4 subset is unchanged, numeric tokens still work, and
+// an unrepresentable name fails the commit with a clear error instead of the
+// old silent "match protocol 0" surprise.
+
+// recordingFilterDP is a no-op DataPlane that records the FilterRules a compile
+// would have programmed, so a full compileFirewallFilters run can be exercised
+// without a live dataplane.
+type recordingFilterDP struct {
+	DataPlane
+	rules []FilterRule
+}
+
+func (d *recordingFilterDP) SetFilterRule(idx uint32, rule FilterRule) error {
+	d.rules = append(d.rules, rule)
+	return nil
+}
+
+func (d *recordingFilterDP) SetFilterConfig(id uint32, cfg FilterConfig) error { return nil }
+func (d *recordingFilterDP) SetPolicerConfig(id uint32, cfg PolicerConfig) error {
+	return nil
+}
+func (d *recordingFilterDP) DeleteStaleIfaceFilter(written map[IfaceFilterKey]bool) {}
+func (d *recordingFilterDP) ZeroStaleFilterConfigs(startID uint32)                  {}
+
+func filterCfgWithProtocol(family, proto string) *config.Config {
+	cfg := &config.Config{}
+	term := &config.FirewallFilterTerm{
+		Name:     "t",
+		Protocol: proto,
+		Action:   "accept",
+		ICMPType: -1,
+		ICMPCode: -1,
+	}
+	filter := &config.FirewallFilter{Name: "f", Terms: []*config.FirewallFilterTerm{term}}
+	if family == "inet6" {
+		cfg.Firewall.FiltersInet6 = map[string]*config.FirewallFilter{"f": filter}
+	} else {
+		cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{"f": filter}
+	}
+	return cfg
+}
+
+// TestExpandFilterTermProtocolSSOT verifies that firewall-filter protocol
+// resolution now goes through appid.ProtocolNumber: the L4 subset is byte-for-
+// byte unchanged AND the broader named protocols (#2124-added sctp/esp/ah/vrrp
+// plus gre/ospf/igmp/pim) and numeric tokens all resolve. The sctp case is the
+// acceptance assertion from #2175 — it would have hit the silent numeric
+// fallback (protocol 0) before the fold.
+func TestExpandFilterTermProtocolSSOT(t *testing.T) {
+	cases := []struct {
+		proto string
+		want  uint8
+	}{
+		// L4 subset (must remain unchanged from the pre-fold table).
+		{"tcp", 6},
+		{"udp", 17},
+		{"icmp", 1},
+		{"icmpv6", 58},
+		// #2124-added names that the firewall filter could NOT resolve before.
+		{"sctp", 132},
+		{"esp", 50},
+		{"ah", 51},
+		{"vrrp", 112},
+		{"gre", 47},
+		{"ospf", 89},
+		{"igmp", 2},
+		{"pim", 103},
+		// Numeric tokens, including the deliberate HOPOPT "0".
+		{"47", 47},
+		{"0", 0},
+		// Case-insensitive.
+		{"SCTP", 132},
+	}
+	for _, tc := range cases {
+		term := &config.FirewallFilterTerm{
+			Name:     "proto-" + tc.proto,
+			Protocol: tc.proto,
+			Action:   "accept",
+			ICMPType: -1,
+			ICMPCode: -1,
+		}
+		rules := expandFilterTerm(term, AFInet, nil, nil, nil)
+		if len(rules) != 1 {
+			t.Fatalf("protocol %q: expected 1 rule, got %d", tc.proto, len(rules))
+		}
+		r := rules[0]
+		if r.MatchFlags&FilterMatchProtocol == 0 {
+			t.Errorf("protocol %q: FilterMatchProtocol not set", tc.proto)
+		}
+		if r.Protocol != tc.want {
+			t.Errorf("protocol %q: got %d, want %d", tc.proto, r.Protocol, tc.want)
+		}
+	}
+}
+
+// TestValidateFilterProtocolsRejectsUnknown verifies that an unrepresentable
+// protocol token fails the compile with a clear, actionable error naming the
+// family/filter/term/token — replacing the pre-#2175 silent degrade to
+// "match protocol 0".
+func TestValidateFilterProtocolsRejectsUnknown(t *testing.T) {
+	for _, family := range []string{"inet", "inet6"} {
+		cfg := filterCfgWithProtocol(family, "definitely-not-a-proto")
+		err := validateFilterProtocols(cfg)
+		if err == nil {
+			t.Fatalf("family %s: expected error for unknown protocol, got nil", family)
+		}
+		msg := err.Error()
+		for _, want := range []string{family, "filter f", "term t", "unknown protocol", "definitely-not-a-proto"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("family %s: error %q missing %q", family, msg, want)
+			}
+		}
+	}
+}
+
+// TestValidateFilterProtocolsAcceptsRepresentable verifies the validation pass
+// admits every protocol the SSOT can resolve (the L4 subset, #2124-added names,
+// and numeric tokens including "0"), plus an empty token (no protocol match).
+func TestValidateFilterProtocolsAcceptsRepresentable(t *testing.T) {
+	good := []string{"", "tcp", "udp", "icmp", "icmpv6", "sctp", "esp", "ah", "vrrp", "gre", "ospf", "47", "0"}
+	for _, proto := range good {
+		cfg := filterCfgWithProtocol("inet", proto)
+		if err := validateFilterProtocols(cfg); err != nil {
+			t.Errorf("protocol %q: unexpected error: %v", proto, err)
+		}
+	}
+}
+
+// TestCompileFirewallFiltersUnknownProtocolFailsCommit drives the full
+// compileFirewallFilters entry point to prove the unknown-protocol error
+// propagates to the caller (the commit path) rather than being swallowed.
+func TestCompileFirewallFiltersUnknownProtocolFailsCommit(t *testing.T) {
+	cfg := filterCfgWithProtocol("inet", "bogus-proto")
+	dp := &recordingFilterDP{}
+	result := &CompileResult{}
+	err := compileFirewallFilters(dp, cfg, result)
+	if err == nil {
+		t.Fatal("expected commit-time error for unknown firewall-filter protocol, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus-proto") {
+		t.Errorf("error %q does not name the offending protocol", err.Error())
+	}
+	if len(dp.rules) != 0 {
+		t.Errorf("expected no rules programmed on validation failure, got %d", len(dp.rules))
+	}
+}
+
+// TestCompileFirewallFiltersSCTPCompiles drives the full compileFirewallFilters
+// entry point with an sctp term and asserts the programmed rule carries
+// protocol 132 — the end-to-end #2175 acceptance: a #2124-added name now
+// compiles in a firewall filter.
+func TestCompileFirewallFiltersSCTPCompiles(t *testing.T) {
+	cfg := filterCfgWithProtocol("inet", "sctp")
+	dp := &recordingFilterDP{}
+	result := &CompileResult{}
+	if err := compileFirewallFilters(dp, cfg, result); err != nil {
+		t.Fatalf("compileFirewallFilters: unexpected error: %v", err)
+	}
+	if len(dp.rules) != 1 {
+		t.Fatalf("expected 1 programmed rule, got %d", len(dp.rules))
+	}
+	r := dp.rules[0]
+	if r.MatchFlags&FilterMatchProtocol == 0 {
+		t.Error("FilterMatchProtocol not set for sctp term")
+	}
+	if r.Protocol != 132 {
+		t.Errorf("sctp rule protocol = %d, want 132", r.Protocol)
+	}
+}


### PR DESCRIPTION
Closes #2175.

## Context

#2124 (PR #2169, merged) centralized the four policy-application
protocol-name→IANA-number tables onto a single source of truth,
`appid.ProtocolNumber(name) (uint8, bool)`. The independent review of that
PR found a **fifth** copy that was not folded in: `compiler_filter.go`
resolved a firewall-filter term's `from protocol <name>` with a hard-coded
`tcp/udp/icmp/icmpv6` switch plus a silent numeric fallback.

This is a LOW-severity consistency sweep (the table has a numeric fallback,
so it is **not** a #2124-class silent fail-open), but it is a latent drift:
the same `protocol <name>` token resolved in a security policy yet was
silently unavailable in a firewall filter, and a typo'd name silently
degraded the term to "match protocol 0" (HOPOPT).

## Decision: SSOT delegation (not documented-subset)

Junos firewall filters legitimately accept the broad named/IANA protocol
set in `from protocol` — `esp`, `ah`, `gre`, `ospf`, `sctp`, `vrrp`,
`igmp`, `pim`, … — not just the L4 subset. So `from protocol sctp` is a
real, valid Junos firewall filter match. The acceptance's preferred path
(SSOT delegation when firewall-filter legitimately supports the broader
set) applies; the documented-L4-subset path would have been incorrect for
Junos semantics.

## Changes

- `expandFilterTerm` resolves `from protocol` through
  `appid.ProtocolNumber`, so every protocol a security policy accepts a
  firewall filter accepts too. The L4 subset (`tcp/udp/icmp/icmpv6`) and
  numeric tokens (including the deliberate `0` for HOPOPT) are byte-for-byte
  unchanged.
- New `validateFilterProtocols` pass runs first in `compileFirewallFilters`
  and rejects an unrepresentable token **at commit** with a clear error
  naming the offending family/filter/term/token — replacing the silent
  numeric-fallback surprise. `compileFirewallFilters` is on the live
  userspace commit path (`CompileUserspaceShim` → `CompileConfig` →
  `compileFirewallFilters`), so the error surfaces at config commit before
  any new snapshot is published (fail-closed).

**No import cycle:** `pkg/dataplane` already imports `pkg/appid`
(`pkg/appid` is a leaf importing only `pkg/config`), so the SSOT stays in
`pkg/appid` exactly as #2124's note prescribes.

## Tests (`pkg/dataplane`)

- `TestExpandFilterTermProtocolSSOT` — broad named set resolves to the
  correct IANA number (sctp=132, esp=50, ah=51, vrrp=112, gre=47, ospf=89,
  igmp=2, pim=103), L4 subset + numeric (incl. "0") unchanged,
  case-insensitive. **Fails against the pre-fix table** (sctp/esp/... → 0).
- `TestValidateFilterProtocolsRejectsUnknown` / `...AcceptsRepresentable`
  — unknown token → clear error; representable set + empty token accepted.
- `TestCompileFirewallFiltersUnknownProtocolFailsCommit` — full
  `compileFirewallFilters` rejects an unknown protocol with no rules
  programmed.
- `TestCompileFirewallFiltersSCTPCompiles` — end-to-end: an `sctp` term
  programs protocol 132 (the #2175 acceptance).

## Docs

`docs/feature-gaps.md` §17 documents the unified protocol set and the
commit-time rejection for an out-of-set name.

## Validation

`GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` and
`go test ./pkg/dataplane/... ./pkg/appid/... ./pkg/config/...` all green;
`go vet` + `gofmt` clean. Unit-testable consistency sweep — no cluster
smoke required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)