### PR TITLE
#2144: validate routing export references at commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,34 @@
 # Action Log
 
+## 2026-06-21 — #2144 validate routing export references at commit
+
+- **Timestamp**: 2026-06-21
+- **Action**: Fixed #2144 — routing export references reached FRR render
+  with no commit-time validation. A dynamic-protocol `export`
+  (OSPF/OSPFv3/BGP/IS-IS), a RIP `redistribute`, a BGP group/neighbor
+  `export`, or a `routing-options forwarding-table export` naming a
+  typo'd / undefined policy-statement passed commit, then failed OPEN at
+  render: `resolveRedistribute`'s fallback emits `redistribute <typo>`
+  (FRR reload rejected or no-op), a BGP neighbor export renders a missing
+  `route-map <name> out` (FRR permit-all → advertise everything), and
+  `resolveECMP` returns 0 max-paths for a missing forwarding-table policy
+  (silently disables ECMP/consistent-hash). Added
+  `validateRoutingExportReferencesStrict` (pkg/config/compiler.go):
+  redistribute-backed exports accept a known protocol token
+  (connected/direct/static/kernel/ospf/bgp/rip/isis) OR a defined
+  policy-statement; BGP neighbor/group export and forwarding-table export
+  accept only a defined policy-statement. Covers top-level + per
+  routing-instance protocols. Strict on commit/commit-check; lenient
+  (warn) on load/HA-sync via `lenientRoutingExportRef` (#1960 doctrine,
+  mirrors validateLogProfileStreamReferencesStrict). 18 new commit-time
+  tests + 1 FRR render test; the rejection/lenient tests FAIL on pre-fix
+  code (verified). Two pre-existing parser tests carried dangling export
+  refs and now seed the referenced policy-statement. build + go test
+  ./pkg/config/... ./pkg/frr/... ./pkg/routing/... ./pkg/configstore/...
+  ./pkg/daemon/... ./pkg/cluster/... green.
+- **File(s)**: pkg/config/compiler.go, pkg/config/routing_export_ref_test.go,
+  pkg/config/parser_routing_test.go, pkg/frr/frr_test.go, pkg/frr/README.md
+
 ## 2026-06-21 — #2134 wire screen session-limit enforcement (closes #2128)
 
 - **Timestamp**: 2026-06-21

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -215,6 +215,24 @@ type compileOpts struct {
 	// instead of silently ignored. Same doctrine as
 	// lenientVRRPTrackDuplicates / lenientLogProfileStreamRef.
 	lenientUnsupportedInterfaceStanzas bool
+
+	// lenientRoutingExportRef (#2144) downgrades the routing-export
+	// cross-reference gate (validateRoutingExportReferencesStrict) from a
+	// hard compile error to a cfg.Warnings entry. Set ONLY on the tolerant
+	// load / peer-sync paths (CompileConfigLenient /
+	// CompileConfigForNodeLenient): a dynamic-protocol `export`, RIP
+	// `redistribute`, BGP group/neighbor `export`, or `routing-options
+	// forwarding-table export` naming an undefined policy-statement (or a
+	// non-protocol typo) passed commit on every binary up to this gate, so
+	// an already-persisted or peer-synced config may carry it; an upgrading
+	// / receiving node must still BOOT through it (warn) rather than fail
+	// closed (#1960). Commit / commit-check stay strict — a new operator
+	// edit whose export FRR would reject, silently no-op, fail open
+	// (route-map permit-all), or silently disable ECMP is rejected loudly.
+	// The render-path fallbacks keep a leniently-loaded config behaving
+	// exactly as it did before this gate. Same doctrine as
+	// lenientLogProfileStreamRef.
+	lenientRoutingExportRef bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -248,6 +266,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientNATPoolAlarmThreshold:       true,
 		lenientNATHostMask:                 true,
 		lenientUnsupportedInterfaceStanzas: true,
+		lenientRoutingExportRef:            true,
 	})
 }
 
@@ -332,6 +351,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientNATPoolAlarmThreshold:       true,
 		lenientNATHostMask:                 true,
 		lenientUnsupportedInterfaceStanzas: true,
+		lenientRoutingExportRef:            true,
 	})
 }
 
@@ -759,6 +779,27 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #2144 routing export cross-reference gate. A dynamic-protocol
+	// `export` (OSPF/OSPFv3/BGP/IS-IS), a RIP `redistribute`, a BGP
+	// group/neighbor `export`, or a `routing-options forwarding-table
+	// export` whose token is neither a known redistribution protocol nor a
+	// defined policy-statement passes commit unnoticed, then at FRR render
+	// time either fails the reload, silently no-ops, fails OPEN as a
+	// permit-all route-map, or silently disables ECMP. Strict on commit /
+	// commit-check (hard reject so the typo is operator-visible); lenient on
+	// load / peer-sync (warn so an already-persisted or peer-synced config
+	// still boots — #1960 fail-closed-on-load class). Runs on the fully-
+	// compiled *Config so the policy-statement map is populated regardless
+	// of authoring order. Mirrors validateLogProfileStreamReferencesStrict.
+	if err := validateRoutingExportReferencesStrict(cfg); err != nil {
+		if opts.lenientRoutingExportRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("routing export reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
 	if warnings := ValidateConfig(cfg); len(warnings) > 0 {
 		for _, w := range warnings {
 			cfg.Warnings = append(cfg.Warnings, w)
@@ -1047,6 +1088,176 @@ func validateLogProfileStreamReferencesStrict(cfg *Config) error {
 			"log stream %q (the profile would route to nowhere — define "+
 			"the stream or fix the stream-name)", p.Name, p.StreamName)
 	}
+	return nil
+}
+
+// routingRedistProtocolTokens is the set of bare protocol keywords that an
+// OSPF/OSPFv3/BGP/IS-IS `export` (or a RIP `redistribute`) accepts in lieu
+// of a named policy-statement. resolveRedistribute (pkg/frr/policy_render.go)
+// emits a bare `redistribute <token>` for these. It mirrors
+// knownRedistProtocols there, plus Junos's `direct` spelling for FRR's
+// `connected`. Keep the two in sync: a token accepted here but unknown to
+// the renderer would emit a line FRR rejects; a token the renderer accepts
+// but missing here would be wrongly rejected at commit.
+var routingRedistProtocolTokens = map[string]bool{
+	"connected": true, "direct": true, "static": true, "kernel": true,
+	"ospf": true, "bgp": true, "rip": true, "isis": true,
+}
+
+// validateRoutingExportReferencesStrict hard-rejects a dynamic-protocol
+// `export` (OSPF / OSPFv3 / BGP / IS-IS), a RIP `redistribute`, a BGP
+// group/neighbor `export`, or a `routing-options forwarding-table export`
+// whose token resolves to neither a known redistribution protocol nor a
+// defined policy-statement (#2144).
+//
+// Without this gate a typo passes commit and reaches FRR render-time, where
+// it fails OPEN in three distinct ways:
+//
+//   - resolveRedistribute's fallback (policy_render.go) emits
+//     `redistribute <typo>` for any unknown token. FRR either rejects the
+//     line — failing the whole frr-reload (a single vtysh -f add-batch
+//     exits non-zero on any CMD_WARNING_CONFIG_FAILED) — or silently
+//     no-ops, so the intended redistribution never happens.
+//   - a BGP group/neighbor `export` renders `neighbor <addr> route-map
+//     <typo> out`. FRR resolves a route-map name with no definition to
+//     NULL, which it treats as permit-all — the outbound filter the
+//     operator wrote silently advertises EVERYTHING.
+//   - `forwarding-table export <typo>` is read by resolveECMP
+//     (config_render.go), which returns 0 max-paths when the policy is
+//     missing — silently DISABLING the expected ECMP / consistent-hash
+//     load balancing instead of rejecting the config.
+//
+// Protocol-token acceptance differs by site. A redistribute-backed export
+// (OSPF/OSPFv3/BGP/IS-IS export, RIP redistribute) legitimately names a
+// bare protocol (`export static`) OR a policy-statement, matching
+// resolveRedistribute. A BGP group/neighbor export and a forwarding-table
+// export render directly as a route-map / ECMP policy name, so only a
+// defined policy-statement is valid there — a protocol token would be a
+// dangling route-map / missing-policy reference, not a redistribute verb.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientRoutingExportRef) so an already-persisted or
+// peer-synced config carrying the typo still boots (#1960
+// fail-closed-on-load class); the render-path fallbacks above keep it inert
+// or fail-open-on-an-already-committed-config exactly as before. Commit /
+// commit-check stay strict. Mirrors validateLogProfileStreamReferencesStrict.
+func validateRoutingExportReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	defined := func(name string) bool {
+		if cfg.PolicyOptions.PolicyStatements == nil {
+			return false
+		}
+		_, ok := cfg.PolicyOptions.PolicyStatements[name]
+		return ok
+	}
+
+	// checkRedist validates a redistribute-backed export list: each token
+	// must be a known protocol OR a defined policy-statement.
+	checkRedist := func(scope, proto string, exports []string) error {
+		for _, e := range exports {
+			if e == "" || routingRedistProtocolTokens[e] || defined(e) {
+				continue
+			}
+			return fmt.Errorf("%s%s export %q references neither a known "+
+				"redistribution protocol (connected/direct/static/kernel/"+
+				"ospf/bgp/rip/isis) nor a defined policy-statement — the "+
+				"FRR redistribute line would be rejected or silently no-op; "+
+				"define the policy-statement or fix the export name",
+				scope, proto, e)
+		}
+		return nil
+	}
+
+	// checkPolicyRef validates an export list that renders directly as a
+	// route-map / ECMP policy name: only a defined policy-statement is valid.
+	checkPolicyRef := func(detail, name string) error {
+		if name == "" || defined(name) {
+			return nil
+		}
+		return fmt.Errorf("%s references undefined policy-statement %q; %s",
+			detail, name, "define the policy-statement or fix the export name")
+	}
+
+	checkProtocols := func(scope string, ospf *OSPFConfig, ospfv3 *OSPFv3Config, bgp *BGPConfig, rip *RIPConfig, isis *ISISConfig) error {
+		if ospf != nil {
+			if err := checkRedist(scope, "protocols ospf", ospf.Export); err != nil {
+				return err
+			}
+		}
+		if ospfv3 != nil {
+			if err := checkRedist(scope, "protocols ospf3", ospfv3.Export); err != nil {
+				return err
+			}
+		}
+		if rip != nil {
+			if err := checkRedist(scope, "protocols rip", rip.Redistribute); err != nil {
+				return err
+			}
+		}
+		if isis != nil {
+			if err := checkRedist(scope, "protocols isis", isis.Export); err != nil {
+				return err
+			}
+		}
+		if bgp != nil {
+			if err := checkRedist(scope, "protocols bgp", bgp.Export); err != nil {
+				return err
+			}
+			// A BGP group/neighbor export renders `route-map <name> out`,
+			// so it must be a defined policy-statement (no protocol-token
+			// fallback). Sort neighbor addresses for a deterministic
+			// first-error message.
+			neighbors := append([]*BGPNeighbor(nil), bgp.Neighbors...)
+			sort.SliceStable(neighbors, func(i, j int) bool {
+				return neighbors[i].Address < neighbors[j].Address
+			})
+			for _, n := range neighbors {
+				if n == nil {
+					continue
+				}
+				for _, e := range n.Export {
+					detail := fmt.Sprintf("%sprotocols bgp neighbor %s export", scope, n.Address)
+					if n.GroupName != "" {
+						detail = fmt.Sprintf("%sprotocols bgp group %s neighbor %s export", scope, n.GroupName, n.Address)
+					}
+					if err := checkPolicyRef(detail, e); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	// Top-level protocols.
+	if err := checkProtocols("", cfg.Protocols.OSPF, cfg.Protocols.OSPFv3, cfg.Protocols.BGP, cfg.Protocols.RIP, cfg.Protocols.ISIS); err != nil {
+		return err
+	}
+
+	// Per routing-instance protocols.
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil {
+			continue
+		}
+		scope := fmt.Sprintf("routing-instance %s ", ri.Name)
+		if err := checkProtocols(scope, ri.OSPF, ri.OSPFv3, ri.BGP, ri.RIP, ri.ISIS); err != nil {
+			return err
+		}
+	}
+
+	// forwarding-table export → resolveECMP (config_render.go). Renders
+	// directly as an ECMP policy lookup, so it must be a defined
+	// policy-statement; a missing one silently disables ECMP/consistent-hash.
+	if err := checkPolicyRef(
+		"routing-options forwarding-table export",
+		cfg.RoutingOptions.ForwardingTableExport,
+	); err != nil {
+		return fmt.Errorf("%s (the expected ECMP / consistent-hash "+
+			"load-balancing would be silently disabled)", err)
+	}
+
 	return nil
 }
 

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -918,7 +918,11 @@ func TestISISExport(t *testing.T) {
 
 func TestBGPGroupExportFamily(t *testing.T) {
 	tree := &ConfigTree{}
-	for _, cmd := range []string{"set protocols bgp local-as 64701", "set protocols bgp group ebgp-peer family inet unicast", "set protocols bgp group ebgp-peer family inet6 unicast", "set protocols bgp group ebgp-peer export my-export-policy", "set protocols bgp group ebgp-peer peer-as 65002", "set protocols bgp group ebgp-peer neighbor 10.1.0.1", "set protocols bgp group ebgp-peer neighbor 10.2.0.1"} {
+	// my-export-policy must be a defined policy-statement: a BGP
+	// group/neighbor export renders `route-map <name> out`, which the
+	// #2144 commit gate requires to resolve (a dangling route-map name
+	// fails open to permit-all in FRR).
+	for _, cmd := range []string{"set protocols bgp local-as 64701", "set protocols bgp group ebgp-peer family inet unicast", "set protocols bgp group ebgp-peer family inet6 unicast", "set protocols bgp group ebgp-peer export my-export-policy", "set protocols bgp group ebgp-peer peer-as 65002", "set protocols bgp group ebgp-peer neighbor 10.1.0.1", "set protocols bgp group ebgp-peer neighbor 10.2.0.1", "set policy-options policy-statement my-export-policy term t1 then accept"} {
 		if err := tree.SetPath(strings.Fields(cmd)[1:]); err != nil {
 			t.Fatalf("SetPath(%q): %v", cmd, err)
 		}
@@ -953,7 +957,20 @@ func TestBGPGroupExportFamily(t *testing.T) {
 }
 
 func TestRoutingOptionsExtended(t *testing.T) {
-	input := `routing-options {
+	// load-balancing-policy must be a defined policy-statement: the #2144
+	// commit gate rejects a forwarding-table export naming a missing policy
+	// (resolveECMP silently returns 0 max-paths, disabling ECMP).
+	input := `policy-options {
+    policy-statement load-balancing-policy {
+        term t1 {
+            then {
+                load-balance per-packet;
+                accept;
+            }
+        }
+    }
+}
+routing-options {
     autonomous-system 64701;
     rib inet6.0 {
         static {

--- a/pkg/config/routing_export_ref_test.go
+++ b/pkg/config/routing_export_ref_test.go
@@ -1,0 +1,270 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2144: routing export references (protocols ospf/bgp/ospf3/isis export,
+// rip redistribute, bgp group/neighbor export, routing-options
+// forwarding-table export) must be validated at commit against the defined
+// policy-statement set and the known redistribution protocol tokens. A typo
+// otherwise passes commit and fails OPEN at FRR render time (rejected
+// reload, silent no-op, permit-all route-map, or silently-disabled ECMP).
+//
+// These tests drive the real CompileConfig (strict) / CompileConfigLenient
+// (tolerant) paths via buildTreeFromSet (the flat-set helper shared with
+// ipsec_proposal_ref_test.go).
+
+// --- redistribute-backed exports: OSPF / OSPFv3 / BGP / IS-IS export,
+// RIP redistribute. Accept a known protocol token OR a defined
+// policy-statement; reject anything else. ---
+
+func TestOSPFExportTypoRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols ospf area 0.0.0.0 interface ge-0-0-0",
+		"set protocols ospf export EXPORT-POLCIY", // typo
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted protocols ospf export with a dangling/typo reference; expected rejection")
+	}
+	for _, want := range []string{"ospf", "EXPORT-POLCIY", "policy-statement"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestOSPFExportKnownProtocolAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols ospf area 0.0.0.0 interface ge-0-0-0",
+		"set protocols ospf export static",
+		"set protocols ospf export connected",
+		"set protocols ospf export direct",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected bare protocol-token OSPF exports: %v", err)
+	}
+}
+
+func TestOSPFExportDefinedPolicyAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement EXPORT-DIRECT term t1 from protocol direct",
+		"set policy-options policy-statement EXPORT-DIRECT term t1 then accept",
+		"set protocols ospf area 0.0.0.0 interface ge-0-0-0",
+		"set protocols ospf export EXPORT-DIRECT",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a defined policy-statement OSPF export: %v", err)
+	}
+}
+
+func TestBGPExportTypoRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp export NO-SUCH-POLICY",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted protocols bgp export with a dangling reference; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "NO-SUCH-POLICY") {
+		t.Errorf("error %q missing dangling export name", err.Error())
+	}
+}
+
+func TestRIPRedistributeTypoRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols rip group g1 neighbor ge-0-0-0",
+		"set protocols rip group g1 export RIP-TYPO",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a RIP redistribute typo; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "RIP-TYPO") {
+		t.Errorf("error %q missing dangling RIP export name", err.Error())
+	}
+}
+
+func TestISISExportTypoRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols isis interface ge-0-0-0",
+		"set protocols isis export ISIS-TYPO",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted an IS-IS export typo; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "ISIS-TYPO") {
+		t.Errorf("error %q missing dangling IS-IS export name", err.Error())
+	}
+}
+
+func TestOSPFv3ExportTypoRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols ospf3 area 0.0.0.0 interface ge-0-0-0",
+		"set protocols ospf3 export V3-TYPO",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted an OSPFv3 export typo; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "V3-TYPO") {
+		t.Errorf("error %q missing dangling OSPFv3 export name", err.Error())
+	}
+}
+
+// --- BGP group/neighbor export: renders `route-map <name> out`. A protocol
+// token is NOT a valid route-map name here — only a defined policy-statement
+// is accepted (a dangling route-map name fails open to permit-all in FRR). ---
+
+func TestBGPNeighborExportTypoRejected(t *testing.T) {
+	// export precedes neighbor: the group-export value is collected as the
+	// group's children are walked in order, then stamped onto each neighbor
+	// created afterward (mirrors TestBGPGroupExportFamily).
+	tree := buildTreeFromSet(t, []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group ebgp peer-as 65002",
+		"set protocols bgp group ebgp export OUT-TYPO",
+		"set protocols bgp group ebgp neighbor 10.0.2.1",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a BGP group/neighbor export with a dangling route-map; expected rejection")
+	}
+	for _, want := range []string{"OUT-TYPO", "policy-statement", "10.0.2.1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestBGPNeighborExportProtocolTokenRejected(t *testing.T) {
+	// A bare protocol token ("static") is a legitimate redistribute-backed
+	// export at the BGP top level but NOT at a neighbor, where it renders as
+	// a route-map name. It must be rejected as an undefined policy-statement.
+	tree := buildTreeFromSet(t, []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group ebgp peer-as 65002",
+		"set protocols bgp group ebgp export static",
+		"set protocols bgp group ebgp neighbor 10.0.2.1",
+	})
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("CompileConfig accepted a protocol token as a BGP neighbor route-map name; expected rejection")
+	}
+}
+
+func TestBGPNeighborExportDefinedPolicyAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement OUT-POL term t1 then accept",
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group ebgp peer-as 65002",
+		"set protocols bgp group ebgp export OUT-POL",
+		"set protocols bgp group ebgp neighbor 10.0.2.1",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a defined BGP neighbor export policy: %v", err)
+	}
+}
+
+// --- forwarding-table export: read by resolveECMP. A missing policy
+// silently returns 0 max-paths (ECMP disabled). Only a defined
+// policy-statement is valid. ---
+
+func TestForwardingTableExportMissingRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set routing-options forwarding-table export MISSING-POLICY",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a forwarding-table export naming a missing policy; expected rejection")
+	}
+	for _, want := range []string{"MISSING-POLICY", "forwarding-table", "ECMP"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestForwardingTableExportDefinedPolicyAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement LB term t1 then load-balance per-packet",
+		"set policy-options policy-statement LB term t1 then accept",
+		"set routing-options forwarding-table export LB",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a defined forwarding-table export policy: %v", err)
+	}
+}
+
+// --- per routing-instance protocols are validated identically. ---
+
+func TestRoutingInstanceOSPFExportTypoRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set routing-instances VR1 instance-type virtual-router",
+		"set routing-instances VR1 protocols ospf area 0.0.0.0 interface ge-0-0-0",
+		"set routing-instances VR1 protocols ospf export VR-TYPO",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a per-instance OSPF export typo; expected rejection")
+	}
+	for _, want := range []string{"VR1", "VR-TYPO"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestRoutingInstanceOSPFExportDefinedPolicyAccepted(t *testing.T) {
+	// policy-options is global; a per-instance export resolves against it.
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement VR-POL term t1 then accept",
+		"set routing-instances VR1 instance-type virtual-router",
+		"set routing-instances VR1 protocols ospf area 0.0.0.0 interface ge-0-0-0",
+		"set routing-instances VR1 protocols ospf export VR-POL",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a per-instance OSPF export naming a global policy: %v", err)
+	}
+}
+
+// --- tolerant load / peer-sync: a typo must downgrade to a warning so an
+// already-persisted or peer-synced config still boots (#1960). ---
+
+func TestRoutingExportTypoLenientDowngrade(t *testing.T) {
+	cmds := []string{
+		"set protocols ospf area 0.0.0.0 interface ge-0-0-0",
+		"set protocols ospf export EXPORT-POLCIY", // typo
+	}
+	hasWarning := func(cfg *Config) bool {
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "routing export reference") {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("standalone", func(t *testing.T) {
+		cfg, err := CompileConfigLenient(buildTreeFromSet(t, cmds))
+		if err != nil {
+			t.Fatalf("CompileConfigLenient hard-failed a dangling export ref; must downgrade to warning: %v", err)
+		}
+		if !hasWarning(cfg) {
+			t.Errorf("expected a routing export reference warning, got %v", cfg.Warnings)
+		}
+	})
+
+	t.Run("node-aware", func(t *testing.T) {
+		cfg, err := CompileConfigForNodeLenient(buildTreeFromSet(t, cmds), 0)
+		if err != nil {
+			t.Fatalf("CompileConfigForNodeLenient hard-failed a dangling export ref; must downgrade to warning (HA peer-sync): %v", err)
+		}
+		if !hasWarning(cfg) {
+			t.Errorf("expected a routing export reference warning, got %v", cfg.Warnings)
+		}
+	})
+}

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -81,6 +81,29 @@ move or rename the markers — they're literal strings.
 - In cluster mode the package emits a blackhole default at admin distance
   250 so traffic to the active fabric peer survives a brief
   active/active overlap.
+- **Export references are validated at commit (#2144).** A dynamic-protocol
+  `export` (OSPF/OSPFv3/BGP/IS-IS), a RIP `redistribute`, a BGP
+  group/neighbor `export`, and a `routing-options forwarding-table export`
+  are checked against the defined policy-statement set (and, for the
+  redistribute-backed exports, the known protocol tokens
+  `connected`/`direct`/`static`/`kernel`/`ospf`/`bgp`/`rip`/`isis`) by
+  `validateRoutingExportReferencesStrict` in `pkg/config/compiler.go`.
+  Strict on commit/commit-check; lenient (warn) on load/HA-sync (#1960).
+  This closes the render-side fail-open paths that previously turned a typo
+  into broken or silent config: `resolveRedistribute`'s fallback emits
+  `redistribute <token>` for ANY unknown export (FRR rejects the line or
+  no-ops); a BGP group/neighbor export renders `route-map <name> out`, where
+  a missing route-map resolves to permit-all (silently advertises
+  everything); and `resolveECMP` returns 0 max-paths for a missing
+  forwarding-table policy (silently disables ECMP/consistent-hash). Those
+  render fallbacks remain as belt-and-suspenders for a config that reaches
+  the renderer via the lenient path (an older-binary persisted config or a
+  peer-synced one). The bare-protocol render path also normalizes the Junos
+  `direct` token to the FRR `redistribute connected` keyword (`export
+  direct` previously rendered the FRR-invalid `redistribute direct`,
+  failing the reload) — matching the policy-term `FromProtocols`
+  normalization and keeping the commit gate's acceptance of `direct`
+  honest.
 - `vtysh -c` is run synchronously in batch mode for state queries. There
   is no streaming; long output is buffered.
 - All `vtysh` and `frr-reload.py` shell-outs route through the

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -344,6 +344,65 @@ func TestGenerateProtocols_BGPExport(t *testing.T) {
 	}
 }
 
+// TestGenerateProtocols_OSPFExportPolicyStatement covers the #2144
+// render path: an OSPF `export` that names a defined policy-statement (not
+// a bare protocol token) is expanded by resolveRedistribute into one
+// `redistribute <proto> route-map <name>` line per `from protocol` the
+// policy matches. This is the well-formed reference whose dangling sibling
+// the new commit-time validator rejects.
+func TestGenerateProtocols_OSPFExportPolicyStatement(t *testing.T) {
+	m := New()
+	ospf := &config.OSPFConfig{
+		RouterID: "1.1.1.1",
+		Areas: []*config.OSPFArea{
+			{ID: "0.0.0.0", Interfaces: []*config.OSPFInterface{{Name: "ge-0-0-0"}}},
+		},
+		Export: []string{"EXPORT-DIRECT-STATIC"},
+	}
+	po := &config.PolicyOptionsConfig{
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"EXPORT-DIRECT-STATIC": {
+				Name: "EXPORT-DIRECT-STATIC",
+				Terms: []*config.PolicyTerm{
+					{Name: "t1", FromProtocols: []string{"direct", "static"}, Action: "accept"},
+				},
+			},
+		},
+	}
+	got := m.generateProtocols(ospf, nil, nil, nil, nil, "", 0, po)
+	// "direct" maps to FRR "connected"; both protocols carry the route-map.
+	if !strings.Contains(got, "redistribute connected route-map EXPORT-DIRECT-STATIC\n") {
+		t.Errorf("missing redistribute connected route-map line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "redistribute static route-map EXPORT-DIRECT-STATIC\n") {
+		t.Errorf("missing redistribute static route-map line, got:\n%s", got)
+	}
+}
+
+// TestGenerateProtocols_ExportDirectNormalized covers the #2144 render fix:
+// a bare `export direct` (Junos spelling for directly-connected routes)
+// must render the FRR keyword `redistribute connected`, NOT the invalid
+// `redistribute direct` (which fails the frr-reload). The commit-time
+// validator accepts "direct" as a known token, so render and validation
+// must agree.
+func TestGenerateProtocols_ExportDirectNormalized(t *testing.T) {
+	m := New()
+	ospf := &config.OSPFConfig{
+		RouterID: "1.1.1.1",
+		Areas: []*config.OSPFArea{
+			{ID: "0.0.0.0", Interfaces: []*config.OSPFInterface{{Name: "ge-0-0-0"}}},
+		},
+		Export: []string{"direct"},
+	}
+	got := m.generateProtocols(ospf, nil, nil, nil, nil, "", 0, nil)
+	if !strings.Contains(got, "redistribute connected\n") {
+		t.Errorf("bare `export direct` must render `redistribute connected`, got:\n%s", got)
+	}
+	if strings.Contains(got, "redistribute direct") {
+		t.Errorf("rendered the FRR-invalid `redistribute direct`, got:\n%s", got)
+	}
+}
+
 func TestGenerateProtocols_ISISExport(t *testing.T) {
 	m := New()
 	isis := &config.ISISConfig{

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -65,6 +65,17 @@ var knownRedistProtocols = map[string]bool{
 // If it matches a policy-statement, it extracts protocols from the terms and emits
 // "redistribute <proto> route-map <name>" for each.
 func (m *Manager) resolveRedistribute(export string, po *config.PolicyOptionsConfig) string {
+	// Junos spells directly-connected routes "direct"; FRR's redistribute
+	// keyword is "connected". A bare `export direct` must render
+	// `redistribute connected`, not the FRR-invalid `redistribute direct`
+	// (which fails the reload). This mirrors the policy-term FromProtocols
+	// normalization below and in generatePolicyOptions. The commit-time
+	// gate (validateRoutingExportReferencesStrict, pkg/config) accepts
+	// "direct" as a known token, so this keeps render and validation in
+	// agreement (#2144).
+	if export == "direct" {
+		export = "connected"
+	}
 	if knownRedistProtocols[export] {
 		return fmt.Sprintf(" redistribute %s\n", export)
 	}


### PR DESCRIPTION
Closes #2144.

## Root cause
Routing export references reached the FRR renderer with **no commit-time validation** (no check existed in `pkg/config/compiler*.go`). A typo'd or undefined export passed commit and failed OPEN at render time:

- `pkg/frr/policy_render.go:67-101` `resolveRedistribute` — fallback emits `redistribute <typo>` for ANY unknown export token (FRR rejects the line, failing the whole frr-reload, or silently no-ops). Backs OSPF/OSPFv3/BGP/IS-IS export and RIP redistribute.
- BGP group/neighbor export renders `neighbor <addr> route-map <typo> out` — FRR resolves a missing route-map to NULL = **permit-all**, silently advertising everything.
- `pkg/frr/config_render.go:318-326` `resolveECMP` — returns 0 max-paths for a missing `forwarding-table export` policy, **silently disabling ECMP / consistent-hash**.

## Fix
`validateRoutingExportReferencesStrict` (`pkg/config/compiler.go`), wired into the strict/lenient validator block:

- **Redistribute-backed exports** (OSPF/OSPFv3/BGP/IS-IS `export`, RIP `redistribute`): accept a known protocol token (`connected`/`direct`/`static`/`kernel`/`ospf`/`bgp`/`rip`/`isis`) OR a defined policy-statement, matching `resolveRedistribute`.
- **BGP group/neighbor export** and **forwarding-table export**: render directly as a route-map / ECMP policy name, so only a defined policy-statement is accepted (a protocol token is a dangling route-map / missing-policy reference there).
- Covers top-level **and** per-routing-instance protocols (policy-options is global).
- **Strict** on commit / commit-check; **lenient (warn)** on tolerant load / HA-sync via `lenientRoutingExportRef` — #1960 fail-closed-on-load doctrine, mirroring `validateLogProfileStreamReferencesStrict`.

Also fixes a render-side mismatch the gate exposed: the bare-protocol path did not normalize the Junos `direct` token to FRR `connected`, so `export direct` rendered the FRR-invalid `redistribute direct` (failing the reload). `resolveRedistribute` now maps `direct` → `connected` on the bare path too.

## Proving tests
`pkg/config/routing_export_ref_test.go` (18 tests) + 2 `pkg/frr/frr_test.go` render tests. The rejection and lenient-downgrade tests were confirmed to **FAIL against pre-fix code** (validator call-site temporarily neutered). Two pre-existing parser tests carried dangling export refs and now seed the referenced policy-statement.

`go build ./...` and `go test ./pkg/config/... ./pkg/frr/... ./pkg/routing/... ./pkg/configstore/... ./pkg/daemon/... ./pkg/cluster/...` all green. Control-plane correctness — no cluster smoke (unit-testable via generated FRR config), per the issue disposition.

## Claude SMR self-review
- Protocol-token acceptance is **site-dependent** and deliberate: redistribute-backed exports accept tokens (real Junos `export static`); neighbor/forwarding-table exports do not (they are route-map / policy names). Verified `TestBGPNeighborExportProtocolTokenRejected`.
- `routingRedistProtocolTokens` is kept in sync with the renderer's `knownRedistProtocols` (+ `direct`); the `direct`→`connected` render fix closes the one token the renderer lacked, so acceptance and render now agree.
- Lenient path verified on both `CompileConfigLenient` (standalone) and `CompileConfigForNodeLenient` (HA peer-sync) — an already-persisted / peer-synced typo warns and boots; the render-path fallbacks keep it behaving exactly as before the gate.
- Deterministic first-error: policy maps are not iterated; BGP neighbors sorted by address.
- Empty / unset export tokens are skipped (no false positive on a config with no exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)