### PR TITLE
#2187: validate source/destination-NAT match-application app refs at commit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,27 @@
 # Action Log
 
+## 2026-06-21 — #2187 validate NAT-rule app references at commit
+
+- **Timestamp**: 2026-06-21
+- **Action**: Fixed #2187 (follow-up to #2142/#2185) — the strict
+  commit-time application-spec validation walk
+  (`applicationsToValidateStrict`) was policy-only, so a malformed user
+  app referenced ONLY by a source/destination-NAT rule's `match
+  application` escaped both the #2142 commit gate and the #2124 runtime
+  gate (`appPortsFromSpec` returns nil → NAT term silently never/over-
+  matches). Extended the walk to collect NAT-rule references via the
+  existing `addRef` closure (single app + application-set, inheriting the
+  #2185 F1 dangling-member fallback); strict-commit / lenient-load wiring
+  is unchanged (single call site). Static NAT not walked (no `match
+  application` on `StaticNATRule`). Added compiler-package tests
+  (source + destination reject / valid / via-set / unreferenced-warn /
+  lenient-warn) that FAIL on the pre-fix tree; updated the appid
+  drift-guard comment. go test ./pkg/config/... ./pkg/appid/... +
+  ./pkg/dataplane/userspace/... green; go vet clean.
+- **File(s)**: pkg/config/compiler.go,
+  pkg/config/compiler_nat_application_specs_test.go,
+  pkg/appid/runtime_test.go, docs/services-application-identification.md
+
 ## 2026-06-21 — #2186 docs: screen session-limit cap is per-worker (× num_workers)
 
 - **Timestamp**: 2026-06-21

--- a/docs/services-application-identification.md
+++ b/docs/services-application-identification.md
@@ -105,14 +105,23 @@ runtime effect is the L3/L4 catalog classification above
     range) or whose `protocol` is not a known name, a `junos-*`
     alias, or a `0..255` number is **rejected at commit** —
     *but only when the application is referenced by a security
-    policy, or when `services application-identification` is
+    policy or a source/destination-NAT rule's `match application`
+    (#2187), or when `services application-identification` is
     enabled* (every user application then compiles into the
     catalog). Such a spec was previously only WARNED: commit
     succeeded, the app-id compiler recorded the AppID name and
     then skipped the unparsable port (a never-match AppID), and a
     policy referencing it failed CLOSED on a `permit` rule or fell
     through OPEN on a `deny` rule (`validateApplicationSpecsStrict`,
-    `pkg/config/compiler.go`). An **unreferenced** application with
+    `pkg/config/compiler.go`). A source/destination-NAT rule's
+    `match application` consumes the same port/proto
+    (`appPortsFromSpec`, `pkg/dataplane/userspace/nat.go`), so a
+    malformed app referenced only by a NAT rule used to escape both
+    this commit gate and the #2124 runtime gate, silently
+    never-matching (or over-matching) the NAT term; #2187 closes that
+    by collecting NAT-rule references into the same strict walk
+    (static NAT carries no `match application`, so only source and
+    destination NAT rule-sets are walked). An **unreferenced** application with
     app-id disabled is not matchable by anything, so its malformed
     spec stays a *warning* (the operator can iterate on a
     not-yet-wired application library). This is the

--- a/pkg/appid/runtime_test.go
+++ b/pkg/appid/runtime_test.go
@@ -50,6 +50,12 @@ func TestCatalogNamesReferencedOnly(t *testing.T) {
 // If a future change to CatalogNames's resolution silently diverges from the
 // compiler copy, this fails — turning a silent commit-gate drift into a test
 // failure. It is a cross-check TEST, not a runtime coupling.
+//
+// Scope note (#2187): the strict walk also collects source/destination-NAT
+// `match application` references, which CatalogNames does not. This fixture
+// carries NO NAT rules, so the two walks still coincide here. Adding a NAT
+// reference to this fixture would (correctly) break the equality — the
+// NAT-reference path is exercised by the compiler-package tests instead.
 func TestStrictValidationSetMatchesCatalogNames(t *testing.T) {
 	cfg := &config.Config{
 		Applications: config.ApplicationsConfig{

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1440,7 +1440,8 @@ func validatePolicyMatchAddressesStrict(cfg *Config) error {
 // service name, out of 1..65535, or an inverted low>high range) or whose
 // protocol token is not a known name, a junos-*
 // alias, or a 0..255 number (#2142) — but ONLY for applications that are
-// actually REFERENCED by a security policy, or for ALL applications when
+// actually REFERENCED by a security policy or a source/destination-NAT rule's
+// `match application` (#2187), or for ALL applications when
 // `services application-identification` is enabled (every app then compiles
 // into the app-id catalog). Such a spec is accepted by ValidateConfig as a
 // WARNING only; commit succeeds, the dataplane app-id compiler records the
@@ -1503,13 +1504,17 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 // names whose port/protocol spec is validated as a hard COMMIT error rather
 // than a warning. That is every user application referenced (directly, or as a
 // member of a referenced application-set) by a zone-pair or global security
-// policy, plus — when `services application-identification` is enabled — every
-// user application (app-id compiles them all into the catalog). It mirrors the
-// policy-reference walk in appid.CatalogNames; the logic is duplicated here
-// because pkg/appid imports pkg/config (so the compiler cannot call back into
-// appid without an import cycle). Predefined junos-* applications are never
-// returned — they are not in cfg.Applications.Applications and their specs are
-// owned by the predefined table, not the operator.
+// policy, OR by a source/destination-NAT rule's `match application` (#2187 — a
+// NAT term consumes the app's port/proto the same way a policy does, so a
+// malformed app referenced only by a NAT rule must reject too), plus — when
+// `services application-identification` is enabled — every user application
+// (app-id compiles them all into the catalog). It mirrors the policy-reference
+// walk in appid.CatalogNames; the logic is duplicated here because pkg/appid
+// imports pkg/config (so the compiler cannot call back into appid without an
+// import cycle). Predefined junos-* applications are never returned — they are
+// not in cfg.Applications.Applications and their specs are owned by the
+// predefined table, not the operator. Static NAT carries no application match,
+// so only source and destination NAT rule-sets are walked.
 func applicationsToValidateStrict(cfg *Config) map[string]struct{} {
 	out := make(map[string]struct{})
 	if cfg == nil {
@@ -1576,6 +1581,38 @@ func applicationsToValidateStrict(cfg *Config) map[string]struct{} {
 		walk(zpp.Policies)
 	}
 	walk(cfg.Security.GlobalPolicies)
+
+	// #2187: a source/destination-NAT rule with `match application <name>` also
+	// consumes the referenced app's port/proto (pkg/dataplane/userspace/nat.go
+	// appPortsFromSpec). A malformed spec there returns nil ports, so the NAT
+	// term silently never-matches (or over-matches on a degenerate proto) with
+	// no commit error — and a bad app referenced ONLY by a NAT rule (not by any
+	// policy) escaped both this commit gate (policy-only) and the #2124 runtime
+	// gate (policy-only). Collect NAT-rule app references the same way as policy
+	// references (single app or application-set) so they are hard-rejected at
+	// commit, lenient on load — identical wiring to the policy path. Static NAT
+	// is intentionally not walked: StaticNATRule has no application match
+	// (compileNATStatic parses only source/destination-address), so there is no
+	// app reference to validate there.
+	walkNATRules := func(rs *NATRuleSet) {
+		if rs == nil {
+			return
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			addRef(rule.Match.Application)
+		}
+	}
+	for _, rs := range cfg.Security.NAT.Source {
+		walkNATRules(rs)
+	}
+	if cfg.Security.NAT.Destination != nil {
+		for _, rs := range cfg.Security.NAT.Destination.RuleSets {
+			walkNATRules(rs)
+		}
+	}
 	return out
 }
 

--- a/pkg/config/compiler_nat_application_specs_test.go
+++ b/pkg/config/compiler_nat_application_specs_test.go
@@ -1,0 +1,192 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2187: a source/destination-NAT rule with `match application <name>` consumes
+// the referenced app's port/proto (pkg/dataplane/userspace/nat.go
+// appPortsFromSpec). #2142 (PR #2185) added strict commit-time validation of
+// application specs, but scoped the reference walk to security POLICIES only —
+// mirroring #2124's policy-only runtime gate. So a malformed user app referenced
+// ONLY by a NAT rule (not by any policy) escaped both the commit gate and the
+// runtime gate: appPortsFromSpec returns nil on the malformed spec → the NAT
+// term silently never-matches (or over-matches), with no commit-time error.
+//
+// These tests drive the real strict commit path (CompileConfig) and the
+// tolerant load path (CompileConfigLenient) through validateApplicationSpecsStrict
+// for NAT-rule references. They FAIL on the pre-fix tree (the NAT walk was not
+// part of applicationsToValidateStrict).
+//
+// All trees are built from flat `set` commands via flatTreeFromSets (defined in
+// compiler_interfaces_unsupported_test.go) — the only correct way to exercise
+// the flat-set AST shape.
+
+// natRefBadApp_source wires a source-NAT rule whose `match application` names a
+// malformed app (caller controls the bad destination-port). No security policy
+// references BAD, so only the NAT walk can make this reject.
+func natRefBadApp_source(destPort string) []string {
+	return []string{
+		"set applications application BAD protocol tcp",
+		"set applications application BAD destination-port " + destPort,
+		"set security nat source rule-set rs1 from zone trust",
+		"set security nat source rule-set rs1 to zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address 10.0.0.0/8",
+		"set security nat source rule-set rs1 rule r1 match application BAD",
+		"set security nat source rule-set rs1 rule r1 then source-nat interface",
+	}
+}
+
+// natRefBadApp_dest wires a destination-NAT rule whose `match application` names
+// a malformed app. No security policy references BAD.
+func natRefBadApp_dest(destPort string) []string {
+	return []string{
+		"set applications application BAD protocol tcp",
+		"set applications application BAD destination-port " + destPort,
+		"set security nat destination pool web1 address 10.0.30.100",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address 50.0.0.1/32",
+		"set security nat destination rule-set rs1 rule r1 match application BAD",
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool web1",
+	}
+}
+
+func TestNATAppRef_SourceBadDestPort_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, natRefBadApp_source("nope")...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to reject source-nat rule referencing malformed application BAD")
+	}
+	if !strings.Contains(err.Error(), "BAD") ||
+		!strings.Contains(err.Error(), "destination-port") {
+		t.Fatalf("error %q must name application BAD and destination-port", err.Error())
+	}
+}
+
+func TestNATAppRef_SourceOutOfRangeDestPort_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, natRefBadApp_source("99999")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("expected commit to reject source-nat rule referencing application BAD with destination-port 99999")
+	}
+}
+
+func TestNATAppRef_DestBadDestPort_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, natRefBadApp_dest("nope")...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to reject destination-nat rule referencing malformed application BAD")
+	}
+	if !strings.Contains(err.Error(), "BAD") ||
+		!strings.Contains(err.Error(), "destination-port") {
+		t.Fatalf("error %q must name application BAD and destination-port", err.Error())
+	}
+}
+
+func TestNATAppRef_DestUnknownProtocol_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application BAD protocol bogus",
+		"set applications application BAD destination-port 80",
+		"set security nat destination pool web1 address 10.0.30.100",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address 50.0.0.1/32",
+		"set security nat destination rule-set rs1 rule r1 match application BAD",
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool web1",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to reject destination-nat rule referencing application BAD with protocol bogus")
+	}
+	if !strings.Contains(err.Error(), "BAD") ||
+		!strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("error %q must name application BAD and the bad protocol", err.Error())
+	}
+}
+
+// Non-tautological companion: the SAME source-nat structure with a VALID
+// destination-port must commit cleanly, proving the reject above is caused by
+// the malformed spec and not the surrounding NAT rule.
+func TestNATAppRef_SourceValid_AcceptsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, natRefBadApp_source("8080-8090")...)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("expected commit to accept source-nat rule referencing valid application BAD: %v", err)
+	}
+}
+
+func TestNATAppRef_DestValid_AcceptsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, natRefBadApp_dest("443")...)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("expected commit to accept destination-nat rule referencing valid application BAD: %v", err)
+	}
+}
+
+// A malformed application referenced by a NAT rule via an application-SET (the
+// NAT rule names the set, not the app directly) must also reject at commit — the
+// addRef closure expands sets identically for policy and NAT references.
+func TestNATAppRef_DestViaSet_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application BAD protocol tcp",
+		"set applications application BAD destination-port nope",
+		"set applications application-set SET application BAD",
+		"set security nat destination pool web1 address 10.0.30.100",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address 50.0.0.1/32",
+		"set security nat destination rule-set rs1 rule r1 match application SET",
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool web1",
+	)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("expected commit to reject NAT rule referencing application-set SET carrying malformed BAD")
+	}
+}
+
+// Control: an UNREFERENCED malformed app with app-id disabled and NO NAT/policy
+// reference stays a warning — the #2142 referenced-vs-unreferenced distinction is
+// preserved (the NAT walk only ADDS references, it does not change the
+// unreferenced behaviour). This test would also pass pre-fix; it pins that the
+// fix did not over-reach into unreferenced apps.
+func TestNATAppRef_Unreferenced_WarnsNotRejected(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application BAD protocol bogus",
+		"set applications application BAD destination-port nope",
+		// A source-nat rule exists but does NOT reference BAD.
+		"set security nat source rule-set rs1 from zone trust",
+		"set security nat source rule-set rs1 to zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address 10.0.0.0/8",
+		"set security nat source rule-set rs1 rule r1 then source-nat interface",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("unreferenced bad app must not reject at commit: %v", err)
+	}
+	var warned bool
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "BAD") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatal("expected ValidateConfig to warn about unreferenced bad application BAD")
+	}
+}
+
+// No-brick (#1960 / #2008 doctrine): a config persisted/synced with a NAT-rule
+// reference to a malformed application must still LOAD on the tolerant path
+// (CompileConfigLenient) — downgraded to a warning — so an upgraded node does
+// not fail closed on boot. Same lenient wiring as the policy path; the runtime
+// just gets nil ports for the NAT term (never-match), inert rather than a crash.
+func TestNATAppRef_SourceBad_LenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t, natRefBadApp_source("nope")...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load of a NAT-referenced bad app must not fail: %v", err)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "application spec") && strings.Contains(w, "BAD") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected lenient path to record an application-spec downgrade warning, got %v", cfg.Warnings)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2187 (correctness follow-up to #2142 / PR #2185).

The #2142 strict commit-time validation of application port/proto specs
(`validateApplicationSpecsStrict`) scoped its reference walk to security
**policies** only, mirroring #2124's policy-only runtime gate. A
source/destination-NAT rule's `match application <name>` also consumes the
referenced app's port/proto (`pkg/dataplane/userspace/nat.go`
`appPortsFromSpec` returns `nil` on a malformed spec → the NAT term silently
never-matches, or over-matches on a degenerate proto). So a malformed user app
referenced **only** by a NAT rule (not by any policy) escaped both the #2142
commit gate and the #2124 runtime gate.

## Fix

Extend `applicationsToValidateStrict` (`pkg/config/compiler.go`) to also collect
app references from **source-nat** and **destination-nat** rule-sets'
`match application`, reusing the existing `addRef` closure so single-app and
application-set references — including the dangling-member fallback from #2185
F1 — resolve identically to the policy path. The strict-commit / lenient-load
wiring and warning text live at the single `validateApplicationSpecsStrict` call
site, so NAT references inherit them unchanged: hard-rejected at commit /
commit-check, downgraded to a warning on the tolerant load and peer-sync paths
(#1960 no-brick doctrine).

**Static NAT is intentionally not walked**: `StaticNATRule` has no application
match (`compileNATStatic` parses only source/destination-address), so there is
no app reference to validate there. Verified against the type + compiler.

## Tests (`pkg/config/compiler_nat_application_specs_test.go`)

Drive the real `CompileConfig` / `CompileConfigLenient` path:

- source-nat / destination-nat rule referencing a malformed app (bad
  destination-port, out-of-range port, unknown protocol) is **rejected** at
  commit, error naming the app + bad field;
- the same NAT rule referencing a **valid** app commits cleanly
  (non-tautological control);
- malformed app referenced via an application-set named by a NAT rule also
  rejects;
- an **unreferenced** malformed app with a NAT rule that does not reference it
  stays a **warning** (the #2142 referenced-vs-unreferenced distinction is
  preserved — the NAT walk only adds references);
- a NAT-referenced malformed app **loads** on the lenient path with an
  application-spec downgrade warning.

The reject + lenient tests **FAIL on the pre-fix tree** (verified by neutralizing
the NAT walk: the reject/lenient cases fail, the valid + unreferenced controls
still pass). Updated the appid drift-guard comment
(`TestStrictValidationSetMatchesCatalogNames`): the strict walk now also collects
NAT references that `CatalogNames` does not, so the two walks coincide only
because that fixture carries no NAT rules.

## Validation

```
go build ./...                                  # clean
go test ./pkg/config/... ./pkg/appid/...        # ok
go test ./pkg/dataplane/userspace/...           # ok
go vet ./pkg/config/...                          # clean
```

Unit-testable — no cluster smoke required.

Docs: `docs/services-application-identification.md` updated to state the strict
gate now engages for NAT-rule `match application` references and that static NAT
is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
