### PR TITLE
deploy: target VM by name + reconcile stale upgrade residue + verify deployed binary (#2162, #2176)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,13 @@ make test            # Run Go tests
 ```bash
 make test-env-init   # One-time: install incus, create networks + profiles
 make test-vm         # Create Ubuntu 26.04 VM with FRR, strongSwan
-make test-deploy     # Build -> push binary + config + unit -> systemctl enable --now
+make test-deploy     # Build -> push xpfd+cli+helper (each sha256-verified ==
+                     #   local build) + config + unit -> systemctl enable --now,
+                     #   then assert the RUNNING xpfd == pushed build + base-unit
+                     #   ExecStart (reconciles stale #1917 version pins / dangling
+                     #   sbin symlinks, #2162/#2176). Override target instance with
+                     #   XPF_INSTANCE=<name> (default xpf-fw).
+make test-deploy-lib # Self-test the deploy reconcile/sha-verify helpers (no VM)
 make test-ssh        # Shell into VM
 make test-status     # Instance + service + network info
 make test-logs       # journalctl -u xpfd -n 50

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,10 @@ clean:
 	rm -rf userspace-dp/target
 
 # Legacy standalone test environment management (single Incus VM/container).
-.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
+# The standalone instance name defaults to xpf-fw; override it for an
+# ad-hoc/renamed VM with `XPF_INSTANCE=<name> make test-deploy` (#2162). The
+# env var flows through to setup.sh (INSTANCE_NAME=${XPF_INSTANCE:-xpf-fw}).
+.PHONY: test-env-init test-vm standalone-test-vm test-ct test-deploy test-deploy-lib test-ssh test-destroy test-status test-start test-stop test-restart test-logs test-journal
 
 test-env-init:
 	./test/incus/setup.sh init
@@ -179,6 +182,11 @@ test-ct:
 
 test-deploy: build build-ctl
 	./test/incus/setup.sh deploy
+
+# Self-test the raw-deploy reconciliation + sha-verify helpers (#2162/#2176)
+# against a mocked fake VM. No incus, no cluster, no network — pure bash logic.
+test-deploy-lib:
+	bash ./test/incus/deploy-lib-selftest.sh
 
 test-ssh:
 	./test/incus/setup.sh ssh

--- a/_Log.md
+++ b/_Log.md
@@ -8098,3 +8098,31 @@ top.
   go test pkg/dataplane/... pkg/appid/... pkg/config/... green.
   **File(s)**: pkg/dataplane/compiler_filter.go,
   pkg/dataplane/compiler_filter_protocol_test.go, docs/feature-gaps.md
+
+## 2026-06-21 — #2162/#2176 deploy robustness (stale-binary hazards)
+- **Timestamp**: 2026-06-21
+- **Action**: #2162 — make the standalone deploy target env-overridable
+  (`INSTANCE_NAME=${XPF_INSTANCE:-xpf-fw}`) so `make test-deploy` can hit the
+  actual VM (e.g. ad-hoc `xpf-fwd`) instead of the hardcoded `xpf-fw`. The
+  helper push + sha-verify was already added by #1962/#1980; #2162's remaining
+  gap was the instance targeting + extending sha-verify to xpfd/cli.
+- **Action**: #2176 — new shared `test/incus/deploy-lib.sh` (sourced by both
+  `setup.sh` and `cluster-setup.sh` raw-deploy paths): (1) detect+remove a stale
+  #1917 `10-xpf-version.conf` ExecStart pin (revert to base-unit ExecStart),
+  HARD-FAIL on any OTHER operator-authored ExecStart override; (2) detect+remove
+  dangling `/usr/local/sbin/{xpfd,cli,xpf-userspace-dp}` symlinks into a removed
+  versions/ dir (which break `incus file push`); (3) sha256-verify EACH pushed
+  binary == local build; (4) after restart, assert the LIVE xpfd process image
+  sha == pushed build AND the effective systemd ExecStart is the base-unit path.
+  All four are HARD failures — a deploy now rc!=0 instead of silently running
+  stale code. The #1917 deb-dogfood path (`deploy_vm_deb`) is untouched (it
+  legitimately keeps the version pin).
+- **Validation**: `test/incus/deploy-lib-selftest.sh` (`make test-deploy-lib`)
+  mocks `incus` against a fake VM rootfs — 12/12, including the five hard-fail
+  cases (sha mismatch, absent binary, foreign ExecStart override, surviving
+  version pin, stale running binary). shellcheck -x -S warning clean on all
+  four scripts; bash -n clean. Not run on a live cluster (shared + no lock; the
+  logic is tooling and fully covered by the mocked self-test).
+- **File(s)**: test/incus/deploy-lib.sh, test/incus/deploy-lib-selftest.sh,
+  test/incus/setup.sh, test/incus/cluster-setup.sh, Makefile, docs/test_env.md,
+  CLAUDE.md

--- a/docs/test_env.md
+++ b/docs/test_env.md
@@ -589,7 +589,10 @@ sg incus-admin -c 'incus exec xpf-fw0 -- grep -l OriginalName /etc/systemd/netwo
 make test-env-init   # Install incus, create networks + profiles
 make test-vm         # Create Ubuntu 26.04 VM with FRR, strongSwan
 make test-deploy     # Build -> push xpfd + cli + xpf-userspace-dp helper
-                     #   (sha256-verified) + config + unit -> systemctl enable --now
+                     #   (each sha256-verified == local build) + config + unit
+                     #   -> systemctl enable --now -> assert the RUNNING xpfd
+                     #   matches the pushed build + base-unit ExecStart (#2176)
+make test-deploy-lib # Self-test the deploy reconcile/sha-verify helpers (no VM)
 make test-ssh        # Shell into VM
 make test-status     # Instance + service + network info
 make test-logs       # journalctl -u xpfd -n 50
@@ -597,3 +600,44 @@ make test-journal    # journalctl -u xpfd -f (follow)
 make test-start/stop/restart  # Service lifecycle
 make test-destroy    # Tear down
 ```
+
+### Target the standalone VM by name (#2162)
+
+`setup.sh` defaults `INSTANCE_NAME` to `xpf-fw`. If the standalone VM was
+created under a different name (e.g. an ad-hoc `xpf-fwd`), point the deploy at
+it with `XPF_INSTANCE`, otherwise the deploy hits the wrong instance (or a
+non-existent `xpf-fw`):
+
+```
+XPF_INSTANCE=xpf-fwd make test-deploy
+XPF_INSTANCE=xpf-fwd ./test/incus/setup.sh ssh
+```
+
+### Raw-deploy stale-state reconciliation (#2162 / #2176)
+
+Both raw deploy paths (`setup.sh deploy` and `cluster-setup.sh deploy`) now
+reconcile prior #1917 in-place-upgrade residue and HARD-verify the swap, so a
+deploy can no longer silently run OLD code:
+
+- **Stale ExecStart pin.** A leftover `xpfd.service.d/10-xpf-version.conf` (from
+  a `.deb` dogfood) pins systemd to a concrete versioned binary; a raw
+  `incus file push` replaces `/usr/local/sbin/xpfd` but systemd keeps launching
+  the pinned path. The deploy detects and removes the xpf-managed pin (reverting
+  to base-unit `ExecStart=/usr/local/sbin/xpfd`); any OTHER, operator-authored
+  `ExecStart` override under `xpfd.service.d` is a HARD FAILURE (never silently
+  deleted).
+- **Dangling sbin symlinks.** After a `versions/` dir is removed,
+  `/usr/local/sbin/{xpfd,cli,xpf-userspace-dp}` can be left as dangling symlinks
+  that break `incus file push`. The deploy removes them so the push lands a
+  fresh regular file.
+- **Pushed-sha verify.** Each of xpfd, cli, and xpf-userspace-dp is sha256-read
+  back from the VM and compared to the local build; mismatch or empty readback
+  fails the deploy (extends the #1962/#1980 helper-only check to all three).
+- **Running-binary backstop.** After restart, the deploy asserts the live xpfd
+  process image sha == the pushed build AND the effective systemd ExecStart is
+  the base-unit path. If a pin survived or systemd is launching stale code, the
+  deploy exits non-zero.
+
+The reconcile/verify logic lives in `test/incus/deploy-lib.sh` (sourced by both
+scripts) and is covered by `test/incus/deploy-lib-selftest.sh`
+(`make test-deploy-lib`), which mocks `incus` against a fake VM rootfs.

--- a/test/incus/cluster-setup.sh
+++ b/test/incus/cluster-setup.sh
@@ -138,6 +138,11 @@ info()  { echo "==> $*"; }
 warn()  { echo "WARNING: $*" >&2; }
 die()   { echo "ERROR: $*" >&2; exit 1; }
 
+# Shared raw-deploy reconciliation + sha-verify helpers (#2162/#2176). Sourced
+# after info/warn/die so the lib can use them.
+# shellcheck source=deploy-lib.sh
+source "${SCRIPT_DIR}/deploy-lib.sh"
+
 # ── Helpers ───────────────────────────────────────────────────────────
 
 run_on_host() {
@@ -867,6 +872,15 @@ deploy_vm() {
 	incus exec "$rinst" -- rm -f /usr/local/sbin/bpfrx-userspace-dp 2>/dev/null || true
 	incus exec "$rinst" -- bash -c 'if [ -d /etc/bpfrx ] && [ ! -d /etc/xpf ]; then mv /etc/bpfrx /etc/xpf; elif [ -d /etc/bpfrx ] && [ -d /etc/xpf ]; then shopt -s dotglob nullglob; for f in /etc/bpfrx/*; do base=$(basename "$f"); if [ ! -e "/etc/xpf/$base" ]; then cp -a "$f" "/etc/xpf/$base"; fi; done; shopt -u dotglob nullglob; rm -rf /etc/bpfrx; fi; if [ -f /etc/xpf/bpfrx.conf ] && [ ! -f /etc/xpf/xpf.conf ]; then mv /etc/xpf/bpfrx.conf /etc/xpf/xpf.conf; fi' 2>/dev/null || true
 
+	# Reconcile prior #1917 in-place-upgrade residue BEFORE pushing binaries
+	# (#2176). A stale 10-xpf-version.conf ExecStart pin (left by a deb dogfood)
+	# would make systemd keep launching an OLD versioned binary after this raw
+	# push, and dangling sbin symlinks into a removed versions/ dir would break
+	# `incus file push`. This was hit live during the #2166 smoke and worked
+	# around by hand — both silently produce a "successful" deploy of stale code.
+	deploy_reconcile_stale_pin "$rinst"
+	deploy_reconcile_dangling_sbin "$rinst"
+
 	# Stop service gracefully, then clean BPF state for binary upgrade.
 	# Order matters: systemctl stop sends SIGTERM (graceful socket close),
 	# then xpfd cleanup removes pinned BPF maps/links.  The final
@@ -880,15 +894,21 @@ deploy_vm() {
 	incus exec "$rinst" -- pkill -9 cli 2>/dev/null || true
 	sleep 1
 
+	# Push each binary, then HARD-verify its on-VM sha256 == the local build
+	# (#2162/#2176). An `incus file push` can silently no-op and a local build
+	# can be stale — either runs old code, the #1 false-result hazard.
 	info "Pushing xpfd to $vm..."
 	incus file push "$PROJECT_ROOT/xpfd" "${rinst}/usr/local/sbin/xpfd" --mode 0755
+	deploy_verify_pushed_sha "$rinst" "$PROJECT_ROOT/xpfd" /usr/local/sbin/xpfd xpfd
 
 	info "Pushing cli to $vm..."
 	incus file push "$PROJECT_ROOT/cli" "${rinst}/usr/local/sbin/cli" --mode 0755
+	deploy_verify_pushed_sha "$rinst" "$PROJECT_ROOT/cli" /usr/local/sbin/cli cli
 
 	if [[ -f "$PROJECT_ROOT/xpf-userspace-dp" ]]; then
 		info "Pushing xpf-userspace-dp to $vm..."
 		incus file push "$PROJECT_ROOT/xpf-userspace-dp" "${rinst}/usr/local/sbin/xpf-userspace-dp" --mode 0755
+		deploy_verify_pushed_sha "$rinst" "$PROJECT_ROOT/xpf-userspace-dp" /usr/local/sbin/xpf-userspace-dp xpf-userspace-dp
 	else
 		warn "xpf-userspace-dp not found locally; helper not pushed to $vm"
 	fi
@@ -917,6 +937,11 @@ deploy_vm() {
 	incus file push "${SCRIPT_DIR}/xpfd.service" "${rinst}/etc/systemd/system/xpfd.service"
 	incus exec "$rinst" -- systemctl daemon-reload
 	incus exec "$rinst" -- systemctl enable --now xpfd
+
+	# Backstop (#2176): assert the LIVE xpfd is the binary we just pushed and the
+	# effective ExecStart is the base-unit path — a HARD failure if a version pin
+	# survived or systemd is launching stale code.
+	deploy_verify_running_xpfd "$rinst" "$PROJECT_ROOT/xpfd"
 
 	info "Deploy complete for $vm."
 }

--- a/test/incus/deploy-lib-selftest.sh
+++ b/test/incus/deploy-lib-selftest.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# Self-test for test/incus/deploy-lib.sh (#2162/#2176). Runs WITHOUT incus or a
+# live VM by mocking `incus exec` / `incus file push` against a local fake-VM
+# rootfs ($FAKE_VM), so the reconciliation + sha-verify logic is exercised
+# end-to-end. No cluster, no lock, no network.
+#
+# Usage: ./test/incus/deploy-lib-selftest.sh   (rc 0 = all pass)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Minimal info/warn/die the lib depends on. die exits non-zero (the whole point
+# of the HARD-fail behavior), so tests that EXPECT a die run the call in a
+# subshell and assert on the exit code.
+info() { echo "  info: $*"; }
+warn() { echo "  warn: $*" >&2; }
+die()  { echo "  die: $*" >&2; exit 1; }
+
+# shellcheck source=deploy-lib.sh
+source "${SCRIPT_DIR}/deploy-lib.sh"
+
+PASS=0
+FAIL=0
+ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ── Fake VM + incus mock ──────────────────────────────────────────────
+# FAKE_VM is a directory that stands in for the VM rootfs. The mock maps
+# absolute remote paths under it. A small state file controls dynamic answers
+# (MainPID, ExecStart path) the filesystem alone cannot express.
+FAKE_VM=""
+FAKE_MAINPID="0"
+FAKE_EXECSTART="/usr/local/sbin/xpfd"
+
+setup_fake_vm() {
+	FAKE_VM=$(mktemp -d)
+	FAKE_MAINPID="0"
+	FAKE_EXECSTART="/usr/local/sbin/xpfd"
+	mkdir -p "$FAKE_VM/usr/local/sbin" "$FAKE_VM/etc/systemd/system"
+}
+
+teardown_fake_vm() {
+	[[ -n "$FAKE_VM" && -d "$FAKE_VM" ]] && rm -rf "$FAKE_VM"
+	FAKE_VM=""
+}
+
+# incus mock: supports `incus exec <inst> -- <cmd...>` and
+# `incus file push <local> <inst>/<path> [--mode m]`. <inst> is ignored
+# (single fake VM). All paths resolve under $FAKE_VM.
+incus() {
+	local verb="$1"; shift
+	case "$verb" in
+	exec)
+		shift          # instance name
+		[[ "$1" == "--" ]] && shift
+		_fake_exec "$@"
+		;;
+	file)
+		local sub="$1"; shift
+		case "$sub" in
+		push)
+			local src="$1" dst="$2"
+			# dst is "<inst>/usr/local/sbin/xpfd" — strip the inst prefix.
+			local rel="${dst#*/}"          # drop up to first slash => path after inst
+			local target="$FAKE_VM/$rel"
+			mkdir -p "$(dirname "$target")"
+			# Mirror `incus file push` over a dangling symlink: it fails.
+			if [[ -L "$target" && ! -e "$target" ]]; then
+				echo "Error: push through dangling symlink $target" >&2
+				return 1
+			fi
+			cp -f "$src" "$target"
+			;;
+		*) echo "unsupported incus file $sub" >&2; return 2 ;;
+		esac
+		;;
+	*) echo "unsupported incus verb $verb" >&2; return 2 ;;
+	esac
+}
+
+# _fake_exec runs a remote command against the fake VM. It special-cases the
+# few commands the lib issues; bash -c bodies are rewritten to operate under
+# $FAKE_VM, and systemctl/sha256sum/test/rm/readlink are intercepted.
+_fake_exec() {
+	# Reconstruct argv. The lib calls:
+	#   test -f <path>
+	#   rm -f <path>
+	#   bash -c '<script>'
+	#   systemctl daemon-reload
+	#   systemctl show -p ExecStart --value xpfd  (via bash -c "... sed ...")
+	#   sha256sum <path>
+	case "$1" in
+	test)
+		shift
+		# test -f <path>  /  used by deploy_reconcile_stale_pin
+		if [[ "$1" == "-f" ]]; then
+			[[ -f "$FAKE_VM/${2#/}" ]]
+			return $?
+		fi
+		return 2
+		;;
+	rm)
+		shift
+		[[ "$1" == "-f" ]] && shift
+		rm -f "$FAKE_VM/${1#/}"
+		return 0
+		;;
+	systemctl)
+		shift
+		case "$1" in
+		daemon-reload) return 0 ;;
+		show)
+			# systemctl show -p ExecStart --value xpfd  => emit a
+			# "{ path=... ; ... }" line; -p MainPID --value => the pid.
+			if [[ "$*" == *ExecStart* ]]; then
+				echo "{ path=$FAKE_EXECSTART ; argv[]=$FAKE_EXECSTART ; ... }"
+			elif [[ "$*" == *MainPID* ]]; then
+				echo "$FAKE_MAINPID"
+			fi
+			return 0
+			;;
+		esac
+		return 0
+		;;
+	sha256sum)
+		shift
+		sha256sum "$FAKE_VM/${1#/}" 2>/dev/null | awk -v p="$1" '{print $1"  "p}'
+		return ${PIPESTATUS[0]}
+		;;
+	bash)
+		# bash -c '<script>' — run the script with a tiny shim layer that
+		# redirects absolute paths into $FAKE_VM and emulates systemctl/sha256sum
+		# for the running-verify body.
+		shift
+		[[ "$1" == "-c" ]] && shift
+		local body="$1"
+		_fake_remote_bash "$body"
+		return $?
+		;;
+	esac
+	return 0
+}
+
+# _fake_remote_bash interprets the specific bash -c bodies the lib sends.
+_fake_remote_bash() {
+	local body="$1"
+	# deploy_verify_running_xpfd: effective ExecStart query (systemctl show
+	# ExecStart | sed path=). Emit the modeled ExecStart through the same sed
+	# the lib applies, so the extraction path is exercised end-to-end.
+	if [[ "$body" == *"systemctl show -p ExecStart"* ]]; then
+		echo "{ path=$FAKE_EXECSTART ; argv[]=$FAKE_EXECSTART ; ... }" \
+			| sed -n 's/.*path=\([^ ;]*\).*/\1/p' | head -n1
+		return 0
+	fi
+	# deploy_reconcile_stale_pin: rmdir-empty-dir guard
+	if [[ "$body" == *"xpfd.service.d"* && "$body" == *rmdir* ]]; then
+		local d="$FAKE_VM/etc/systemd/system/xpfd.service.d"
+		[ -d "$d" ] && [ -z "$(ls -A "$d" 2>/dev/null)" ] && rmdir "$d"
+		return 0
+	fi
+	# deploy_reconcile_stale_pin: other-ExecStart-override scan
+	if [[ "$body" == *"grep -lE"* && "$body" == *ExecStart* ]]; then
+		local d="$FAKE_VM/etc/systemd/system/xpfd.service.d"
+		[ -d "$d" ] || return 0
+		grep -lE "^[[:space:]]*ExecStart[[:space:]]*=" "$d"/*.conf 2>/dev/null || true
+		return 0
+	fi
+	# deploy_reconcile_dangling_sbin: [ -L p ] && [ ! -e p ]
+	if [[ "$body" == *"-L"* && "$body" == *"-e"* ]]; then
+		# Extract the quoted path: ...'<path>'...
+		local p
+		p=$(sed -E "s/.*-L '([^']+)'.*/\1/" <<<"$body")
+		local fp="$FAKE_VM/${p#/}"
+		[ -L "$fp" ] && [ ! -e "$fp" ]
+		return $?
+	fi
+	# deploy_verify_running_xpfd: MainPID + sha256sum /proc/PID/exe
+	if [[ "$body" == *MainPID* && "$body" == *"/proc/"* ]]; then
+		[[ "$FAKE_MAINPID" != "0" ]] || return 1
+		# The "running exe" is the file the fake pid points at: we model it as
+		# whatever currently lives at /usr/local/sbin/xpfd in the fake VM.
+		sha256sum "$FAKE_VM/usr/local/sbin/xpfd" 2>/dev/null || return 1
+		return 0
+	fi
+	return 0
+}
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+make_local_bin() { printf '%s' "$2" > "$1"; }   # path, content
+
+# ── Tests ─────────────────────────────────────────────────────────────
+
+test_verify_pushed_sha_match() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "BINARY-A"
+	cp "$lb" "$FAKE_VM/usr/local/sbin/xpfd"
+	if ( deploy_verify_pushed_sha vm "$lb" /usr/local/sbin/xpfd xpfd ) >/dev/null 2>&1; then
+		ok "verify_pushed_sha: matching sha passes"
+	else
+		bad "verify_pushed_sha: matching sha should pass"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_verify_pushed_sha_mismatch_hardfails() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "BINARY-NEW"
+	make_local_bin "$FAKE_VM/usr/local/sbin/xpfd" "BINARY-OLD"
+	if ( deploy_verify_pushed_sha vm "$lb" /usr/local/sbin/xpfd xpfd ) >/dev/null 2>&1; then
+		bad "verify_pushed_sha: mismatch MUST hard-fail (stale binary)"
+	else
+		ok "verify_pushed_sha: mismatch hard-fails (rc!=0)"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_verify_pushed_sha_absent_hardfails() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "BINARY-A"
+	# no file on VM
+	if ( deploy_verify_pushed_sha vm "$lb" /usr/local/sbin/xpfd xpfd ) >/dev/null 2>&1; then
+		bad "verify_pushed_sha: absent binary MUST hard-fail"
+	else
+		ok "verify_pushed_sha: absent binary hard-fails (empty readback)"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_reconcile_stale_pin_removes_managed() {
+	setup_fake_vm
+	mkdir -p "$FAKE_VM/etc/systemd/system/xpfd.service.d"
+	printf '[Service]\nExecStart=\nExecStart=/usr/local/share/xpf/versions/v1/xpfd\n' \
+		> "$FAKE_VM$DEPLOY_VERSION_DROPIN"
+	if ( deploy_reconcile_stale_pin vm ) >/dev/null 2>&1; then :; else
+		bad "reconcile_stale_pin: should succeed removing the managed pin"; teardown_fake_vm; return
+	fi
+	if [[ -f "$FAKE_VM$DEPLOY_VERSION_DROPIN" ]]; then
+		bad "reconcile_stale_pin: managed pin still present after reconcile"
+	elif [[ -d "$FAKE_VM/etc/systemd/system/xpfd.service.d" ]]; then
+		bad "reconcile_stale_pin: empty drop-in dir not removed"
+	else
+		ok "reconcile_stale_pin: managed pin + empty dir removed"
+	fi
+	teardown_fake_vm
+}
+
+test_reconcile_stale_pin_no_pin_noop() {
+	setup_fake_vm
+	if ( deploy_reconcile_stale_pin vm ) >/dev/null 2>&1; then
+		ok "reconcile_stale_pin: clean VM is a no-op (passes)"
+	else
+		bad "reconcile_stale_pin: clean VM should pass"
+	fi
+	teardown_fake_vm
+}
+
+test_reconcile_stale_pin_foreign_override_hardfails() {
+	setup_fake_vm
+	mkdir -p "$FAKE_VM/etc/systemd/system/xpfd.service.d"
+	# A NON-managed ExecStart override (operator-authored) must HARD FAIL.
+	printf '[Service]\nExecStart=\nExecStart=/opt/custom/xpfd\n' \
+		> "$FAKE_VM/etc/systemd/system/xpfd.service.d/50-operator.conf"
+	if ( deploy_reconcile_stale_pin vm ) >/dev/null 2>&1; then
+		bad "reconcile_stale_pin: foreign ExecStart override MUST hard-fail"
+	else
+		ok "reconcile_stale_pin: foreign ExecStart override hard-fails"
+	fi
+	teardown_fake_vm
+}
+
+test_reconcile_dangling_sbin_removes() {
+	setup_fake_vm
+	# Dangling symlink into a removed versions dir.
+	ln -s /usr/local/share/xpf/versions/current/xpfd "$FAKE_VM/usr/local/sbin/xpfd"
+	if ( deploy_reconcile_dangling_sbin vm ) >/dev/null 2>&1; then :; else
+		bad "reconcile_dangling_sbin: should succeed"; teardown_fake_vm; return
+	fi
+	if [[ -L "$FAKE_VM/usr/local/sbin/xpfd" ]]; then
+		bad "reconcile_dangling_sbin: dangling symlink not removed"
+	else
+		ok "reconcile_dangling_sbin: dangling symlink removed (push can land a file)"
+	fi
+	# A subsequent push must now succeed (mock fails on dangling symlink).
+	local lb; lb=$(mktemp); make_local_bin "$lb" "FRESH"
+	if incus file push "$lb" "vm/usr/local/sbin/xpfd" --mode 0755 2>/dev/null; then
+		ok "reconcile_dangling_sbin: push lands a regular file afterward"
+	else
+		bad "reconcile_dangling_sbin: push still fails after reconcile"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_reconcile_dangling_sbin_keeps_valid() {
+	setup_fake_vm
+	# A VALID symlink (target exists) is NOT removed.
+	make_local_bin "$FAKE_VM/usr/local/sbin/.xpfd-real" "REAL"
+	ln -s .xpfd-real "$FAKE_VM/usr/local/sbin/xpfd"
+	( deploy_reconcile_dangling_sbin vm ) >/dev/null 2>&1
+	if [[ -L "$FAKE_VM/usr/local/sbin/xpfd" ]]; then
+		ok "reconcile_dangling_sbin: valid symlink preserved"
+	else
+		bad "reconcile_dangling_sbin: wrongly removed a VALID symlink"
+	fi
+	teardown_fake_vm
+}
+
+test_verify_running_match() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "RUNNING-OK"
+	cp "$lb" "$FAKE_VM/usr/local/sbin/xpfd"
+	FAKE_MAINPID="4242"
+	FAKE_EXECSTART="/usr/local/sbin/xpfd"
+	if ( deploy_verify_running_xpfd vm "$lb" ) >/dev/null 2>&1; then
+		ok "verify_running: running sha == pushed + base ExecStart passes"
+	else
+		bad "verify_running: matching run should pass"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_verify_running_stale_pin_hardfails() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "RUNNING-OK"
+	cp "$lb" "$FAKE_VM/usr/local/sbin/xpfd"
+	FAKE_MAINPID="4242"
+	# ExecStart points at a versioned path => a pin survived => MUST hard-fail.
+	FAKE_EXECSTART="/usr/local/share/xpf/versions/v1/xpfd"
+	if ( deploy_verify_running_xpfd vm "$lb" ) >/dev/null 2>&1; then
+		bad "verify_running: surviving version pin MUST hard-fail"
+	else
+		ok "verify_running: surviving version pin hard-fails (ExecStart != base)"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+test_verify_running_stale_binary_hardfails() {
+	setup_fake_vm
+	local lb; lb=$(mktemp); make_local_bin "$lb" "NEW-BUILD"
+	# VM is running the OLD binary (different content) at the base path.
+	make_local_bin "$FAKE_VM/usr/local/sbin/xpfd" "OLD-BUILD"
+	FAKE_MAINPID="4242"
+	FAKE_EXECSTART="/usr/local/sbin/xpfd"
+	if ( deploy_verify_running_xpfd vm "$lb" ) >/dev/null 2>&1; then
+		bad "verify_running: stale running binary MUST hard-fail"
+	else
+		ok "verify_running: stale running binary hard-fails (run sha != pushed)"
+	fi
+	rm -f "$lb"; teardown_fake_vm
+}
+
+# ── Run ───────────────────────────────────────────────────────────────
+test_verify_pushed_sha_match
+test_verify_pushed_sha_mismatch_hardfails
+test_verify_pushed_sha_absent_hardfails
+test_reconcile_stale_pin_removes_managed
+test_reconcile_stale_pin_no_pin_noop
+test_reconcile_stale_pin_foreign_override_hardfails
+test_reconcile_dangling_sbin_removes
+test_reconcile_dangling_sbin_keeps_valid
+test_verify_running_match
+test_verify_running_stale_pin_hardfails
+test_verify_running_stale_binary_hardfails
+
+echo "----------------------------------------"
+echo "deploy-lib selftest: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/test/incus/deploy-lib.sh
+++ b/test/incus/deploy-lib.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Shared raw-deploy reconciliation + verification helpers for the xpf test
+# Incus deploy paths (setup.sh and cluster-setup.sh).
+#
+# Both scripts push xpfd/cli/xpf-userspace-dp to a VM with `incus file push`
+# and then (re)start the systemd unit. Two classes of stale-state on the
+# target VM silently defeat that swap and make a deploy report success while
+# the node keeps running OLD code — the #1 false-result hazard:
+#
+#   #2176 (a): a leftover #1917 in-place-upgrade drop-in
+#     /etc/systemd/system/xpfd.service.d/10-xpf-version.conf pins ExecStart to
+#     a CONCRETE versioned binary (versions/<ver>/xpfd). A raw `incus file push`
+#     replaces /usr/local/sbin/xpfd, but systemd still launches the pinned
+#     versioned path, so the freshly-pushed binary never runs.
+#
+#   #2176 (b): after that drop-in's versions/ dir is removed,
+#     /usr/local/sbin/{xpfd,cli,xpf-userspace-dp} are left as DANGLING symlinks
+#     into versions/current/<bin>. `incus file push` onto a dangling symlink
+#     fails (no target to write through), breaking the deploy.
+#
+# These helpers run BEFORE the binary push to reconcile both, and AFTER the
+# restart to ASSERT the running binary sha == the pushed sha (#2176 (c)) and
+# that the effective ExecStart is the base-unit path (no surviving pin).
+#
+# #2162: deploy_verify_pushed_sha generalizes the helper-only sha readback
+# (#1962/#1980) so xpfd and cli get the same HARD post-push verification.
+#
+# All functions take a FULLY-RESOLVED instance name (e.g. "loss:xpf-userspace-fw0"
+# or "xpf-fw") because the two callers compute that differently (cluster-setup.sh
+# r() remote prefix vs setup.sh INSTANCE_NAME). They depend on info()/warn()/die()
+# being defined by the sourcing script (both define them identically).
+
+# deploy_managed_bins is the set of binaries the deploy paths push into
+# /usr/local/sbin and that the #1917 upgrade machinery links/pins. Keep in
+# sync with pkg/upgrade manifest.Names() (xpfd, cli, xpf-userspace-dp).
+deploy_managed_bins=(xpfd cli xpf-userspace-dp)
+
+# The #1917 in-place-upgrade ExecStart pin drop-in (pkg/upgrade/flip.go
+# unitDropinName). Removing it reverts the unit to the package/base-unit
+# ExecStart=/usr/local/sbin/xpfd.
+DEPLOY_VERSION_DROPIN="/etc/systemd/system/xpfd.service.d/10-xpf-version.conf"
+
+# deploy_reconcile_stale_pin <rinst>
+#
+# Detect a stale xpfd ExecStart override drop-in on the target and remove it,
+# reverting to the base-unit ExecStart=/usr/local/sbin/xpfd, then daemon-reload
+# so the change is in effect before the unit is (re)started. Without this a raw
+# deploy pushes a new /usr/local/sbin/xpfd that systemd never launches (#2176a).
+#
+# Only the xpf-managed pin file (10-xpf-version.conf) is removed automatically;
+# any OTHER, operator-authored ExecStart override under xpfd.service.d is a HARD
+# FAILURE (we will not silently delete a drop-in we did not write).
+deploy_reconcile_stale_pin() {
+	local rinst="$1"
+
+	# Is the managed #1917 pin present?
+	if incus exec "$rinst" -- test -f "$DEPLOY_VERSION_DROPIN" 2>/dev/null; then
+		warn "Removing stale #1917 ExecStart pin ($DEPLOY_VERSION_DROPIN) on $rinst — it would pin systemd to an OLD versioned xpfd and silently defeat this deploy (#2176)."
+		incus exec "$rinst" -- rm -f "$DEPLOY_VERSION_DROPIN" 2>/dev/null \
+			|| die "failed to remove stale ExecStart pin $DEPLOY_VERSION_DROPIN on $rinst"
+		# Drop an empty xpfd.service.d if nothing else remains, so the unit
+		# is purely the base file again.
+		incus exec "$rinst" -- bash -c 'd=/etc/systemd/system/xpfd.service.d; [ -d "$d" ] && [ -z "$(ls -A "$d" 2>/dev/null)" ] && rmdir "$d"; true' 2>/dev/null || true
+		incus exec "$rinst" -- systemctl daemon-reload 2>/dev/null || true
+	fi
+
+	# Refuse to proceed if SOME OTHER ExecStart override survives in the
+	# drop-in dir — a raw deploy must never leave an unknown pin in force.
+	local other
+	other=$(incus exec "$rinst" -- bash -c '
+		d=/etc/systemd/system/xpfd.service.d
+		[ -d "$d" ] || exit 0
+		grep -lE "^[[:space:]]*ExecStart[[:space:]]*=" "$d"/*.conf 2>/dev/null || true
+	' 2>/dev/null || true)
+	if [[ -n "$other" ]]; then
+		die "unexpected ExecStart override(s) under xpfd.service.d on $rinst — a raw deploy will not run the pushed binary while these pin a different path. Remove them or fix the drop-in, then re-deploy:
+$other"
+	fi
+}
+
+# deploy_reconcile_dangling_sbin <rinst>
+#
+# Detect dangling /usr/local/sbin/{xpfd,cli,xpf-userspace-dp} symlinks (left
+# pointing into a removed versions/current/ after a #1917 dogfood was torn
+# down) and remove them, so the subsequent `incus file push` lands a fresh
+# REGULAR file instead of failing to write through a broken symlink (#2176b).
+deploy_reconcile_dangling_sbin() {
+	local rinst="$1"
+	local b
+	for b in "${deploy_managed_bins[@]}"; do
+		local p="/usr/local/sbin/$b"
+		# -L: is a symlink; -e: resolves to an existing target. A symlink
+		# that is NOT -e is dangling.
+		if incus exec "$rinst" -- bash -c "[ -L '$p' ] && [ ! -e '$p' ]" 2>/dev/null; then
+			warn "Replacing dangling symlink $p on $rinst (points into a removed versions/ dir) with the freshly-pushed binary (#2176)."
+			incus exec "$rinst" -- rm -f "$p" 2>/dev/null \
+				|| die "failed to remove dangling symlink $p on $rinst"
+		fi
+	done
+}
+
+# deploy_verify_pushed_sha <rinst> <local_path> <remote_path> <label>
+#
+# Assert the on-VM sha256 of a just-pushed binary matches the local build.
+# An `incus file push` can silently no-op and the local build can be stale;
+# either leaves the VM running an old/absent binary. HARD FAIL on mismatch or
+# empty readback (#2162 generalizes the #1962/#1980 helper-only check).
+deploy_verify_pushed_sha() {
+	local rinst="$1" local_path="$2" remote_path="$3" label="$4"
+	local local_sum vm_sum
+	local_sum=$(sha256sum "$local_path" | awk '{print $1}')
+	# Readback may fail (binary absent) — || true so the explicit empty-check
+	# below produces the clear diagnostic instead of set -e aborting here.
+	vm_sum=$(incus exec "$rinst" -- sha256sum "$remote_path" 2>/dev/null | awk '{print $1}' || true)
+	if [[ -z "$vm_sum" ]]; then
+		die "$label not present on $rinst after push (sha256 readback empty: $remote_path)"
+	fi
+	if [[ "$local_sum" != "$vm_sum" ]]; then
+		die "$label sha256 mismatch after push to $rinst (local=$local_sum vm=$vm_sum) — push silently no-op'd or the build is stale"
+	fi
+	info "Verified $label sha256 on $rinst ($local_sum)."
+}
+
+# deploy_verify_running_xpfd <rinst> <local_xpfd_path>
+#
+# After (re)start, assert the LIVE xpfd process is the binary we just pushed
+# (running-exe sha == local build) AND that the effective systemd ExecStart is
+# the base-unit /usr/local/sbin/xpfd path — i.e. no version pin survived. This
+# is the backstop that turns a silent stale-binary deploy into a HARD failure
+# (#2176c). The whole point: a deploy MUST rc!=0 if the running binary != the
+# pushed binary.
+deploy_verify_running_xpfd() {
+	local rinst="$1" local_xpfd="$2"
+	local local_sum want_exec="/usr/local/sbin/xpfd"
+	local_sum=$(sha256sum "$local_xpfd" | awk '{print $1}')
+
+	# Effective ExecStart must resolve to the base-unit path. `systemctl show`
+	# emits ExecStart={ path=/usr/local/sbin/xpfd ; ... }; extract the path=.
+	local exec_path
+	exec_path=$(incus exec "$rinst" -- bash -c "systemctl show -p ExecStart --value xpfd 2>/dev/null | sed -n 's/.*path=\([^ ;]*\).*/\1/p' | head -n1" 2>/dev/null || true)
+	if [[ -z "$exec_path" ]]; then
+		die "could not read effective xpfd ExecStart on $rinst — cannot confirm the deploy is in effect"
+	fi
+	if [[ "$exec_path" != "$want_exec" ]]; then
+		die "xpfd ExecStart on $rinst is '$exec_path', not the base-unit '$want_exec' — a version pin survived this deploy (#2176); systemd is launching a different binary than was pushed"
+	fi
+
+	# Running-process exe sha must equal the local build. Wait briefly for the
+	# unit to come up (enable --now / restart returns before the main PID is
+	# necessarily settled).
+	local tries=0 run_raw="" run_sum=""
+	while [[ $tries -lt 15 ]]; do
+		# The remote emits the raw `sha256sum /proc/PID/exe` line; the first
+		# field is split off locally to avoid nested single-quote awk fragility.
+		# sha256sum on /proc/PID/exe reads the LIVE process image even if the
+		# on-disk file was replaced after exec ("(deleted)").
+		run_raw=$(incus exec "$rinst" -- bash -c '
+			p=$(systemctl show -p MainPID --value xpfd 2>/dev/null)
+			[ -n "$p" ] && [ "$p" != "0" ] || exit 1
+			sha256sum "/proc/$p/exe" 2>/dev/null || exit 1
+		' 2>/dev/null || true)
+		run_sum=${run_raw%% *}
+		[[ -n "$run_sum" ]] && break
+		tries=$((tries + 1))
+		sleep 1
+	done
+	if [[ -z "$run_sum" ]]; then
+		die "xpfd is not running on $rinst after deploy (no live MainPID) — cannot verify the running binary"
+	fi
+	if [[ "$run_sum" != "$local_sum" ]]; then
+		die "running xpfd on $rinst (sha256=$run_sum) does not match the pushed build (sha256=$local_sum) — the deploy did NOT take effect (#2176); the node is running STALE code"
+	fi
+	info "Verified running xpfd on $rinst matches the pushed build ($local_sum, ExecStart=$exec_path)."
+}

--- a/test/incus/setup.sh
+++ b/test/incus/setup.sh
@@ -38,7 +38,13 @@ if ! incus list &>/dev/null 2>&1; then
 	fi
 fi
 
-INSTANCE_NAME="xpf-fw"
+# INSTANCE_NAME is env-overridable (XPF_INSTANCE) so a deploy can target the
+# actual standalone VM when it was created under a non-default name (e.g. an
+# ad-hoc xpf-fwd). Defaulting silently to xpf-fw was the #2162 footgun: a deploy
+# either errored mid-flow against a non-existent xpf-fw or, worse, wiped the
+# config of an unrelated xpf-fw instance. cmd_deploy/cmd_ssh/etc already guard on
+# instance existence, so an overridden name that does not exist fails clearly.
+INSTANCE_NAME="${XPF_INSTANCE:-xpf-fw}"
 VM_PROFILE="xpf-vm"
 CT_PROFILE="xpf-container"
 # Ubuntu 26.04 to match the production appliance base (scripts/image/bake.py).
@@ -728,6 +734,10 @@ usage() {
 	echo "  journal     Follow xpfd logs (live)"
 	echo ""
 	echo "Env:"
+	echo "  XPF_INSTANCE=<name>         Target instance name (default: xpf-fw). Set this"
+	echo "                              when the VM was created under a different name"
+	echo "                              (e.g. an ad-hoc xpf-fwd) so deploy/ssh/etc do not"
+	echo "                              hit the wrong instance (#2162)"
 	echo "  XPF_FORCE_TEARDOWN_PEERS=1  On create-vm/create-ct/deploy, remove any"
 	echo "                              OTHER firewall holding the dataplane gateway"
 	echo "                              IPs instead of aborting (DUT isolation, #1992)"

--- a/test/incus/setup.sh
+++ b/test/incus/setup.sh
@@ -100,6 +100,11 @@ info()  { echo "==> $*"; }
 warn()  { echo "WARNING: $*" >&2; }
 die()   { echo "ERROR: $*" >&2; exit 1; }
 
+# Shared raw-deploy reconciliation + sha-verify helpers (#2162/#2176). Sourced
+# after info/warn/die so the lib can use them.
+# shellcheck source=deploy-lib.sh
+source "${SCRIPT_DIR}/deploy-lib.sh"
+
 # ── DUT isolation guard (#1992) ───────────────────────────────────────
 
 # List instance names attached to an incus network bridge. Parses the
@@ -589,6 +594,14 @@ cmd_deploy() {
 	incus exec "$INSTANCE_NAME" -- rm -f /usr/local/sbin/bpfrx-userspace-dp 2>/dev/null || true
 	incus exec "$INSTANCE_NAME" -- bash -c 'if [ -d /etc/bpfrx ] && [ ! -d /etc/xpf ]; then mv /etc/bpfrx /etc/xpf; elif [ -d /etc/bpfrx ] && [ -d /etc/xpf ]; then shopt -s dotglob nullglob; for f in /etc/bpfrx/*; do base=$(basename "$f"); if [ ! -e "/etc/xpf/$base" ]; then cp -a "$f" "/etc/xpf/$base"; fi; done; shopt -u dotglob nullglob; rm -rf /etc/bpfrx; fi; if [ -f /etc/xpf/bpfrx.conf ] && [ ! -f /etc/xpf/xpf.conf ]; then mv /etc/xpf/bpfrx.conf /etc/xpf/xpf.conf; fi' 2>/dev/null || true
 
+	# Reconcile prior #1917 in-place-upgrade residue BEFORE pushing binaries
+	# (#2176). A stale 10-xpf-version.conf ExecStart pin would make systemd keep
+	# launching an OLD versioned binary after the raw push, and dangling sbin
+	# symlinks into a removed versions/ dir would break `incus file push`. Both
+	# silently produce a "successful" deploy that runs stale code.
+	deploy_reconcile_stale_pin "$INSTANCE_NAME"
+	deploy_reconcile_dangling_sbin "$INSTANCE_NAME"
+
 	# Stop service gracefully, then clean BPF state for binary upgrade.
 	# Order matters: systemctl stop sends SIGTERM (graceful socket close),
 	# then xpfd cleanup removes pinned BPF maps/links.  The final
@@ -601,30 +614,25 @@ cmd_deploy() {
 	incus exec "$INSTANCE_NAME" -- pkill -9 cli 2>/dev/null || true
 	sleep 1
 
+	# Push each binary, then HARD-verify its on-VM sha256 == the local build
+	# (#2162 extends the #1962/#1980 helper-only readback to xpfd and cli). An
+	# `incus file push` can silently no-op and a local build can be stale —
+	# either runs old code, the #1 false-result hazard.
 	info "Pushing xpfd to $INSTANCE_NAME..."
 	incus file push "$PROJECT_ROOT/xpfd" "$INSTANCE_NAME/usr/local/sbin/xpfd" --mode 0755
+	deploy_verify_pushed_sha "$INSTANCE_NAME" "$PROJECT_ROOT/xpfd" /usr/local/sbin/xpfd xpfd
 
 	info "Pushing cli to $INSTANCE_NAME..."
 	incus file push "$PROJECT_ROOT/cli" "$INSTANCE_NAME/usr/local/sbin/cli" --mode 0755
+	deploy_verify_pushed_sha "$INSTANCE_NAME" "$PROJECT_ROOT/cli" /usr/local/sbin/cli cli
 
 	# Push the Rust AF_XDP helper next to xpfd (see the findBinary search path
-	# above), then verify the on-VM sha256 matches the local binary. A push can
-	# silently no-op and the build can be stale, either of which leaves xpfd
-	# without a working dataplane — fail the deploy loudly if they differ (#1962).
+	# above), then verify the on-VM sha256 matches the local binary. Without it
+	# the standalone VM comes up with no dataplane (#1962).
 	if [[ -f "$PROJECT_ROOT/xpf-userspace-dp" ]]; then
 		info "Pushing xpf-userspace-dp to $INSTANCE_NAME..."
 		incus file push "$PROJECT_ROOT/xpf-userspace-dp" "$INSTANCE_NAME/usr/local/sbin/xpf-userspace-dp" --mode 0755
-
-		local local_sum vm_sum
-		local_sum=$(sha256sum "$PROJECT_ROOT/xpf-userspace-dp" | awk '{print $1}')
-		vm_sum=$(incus exec "$INSTANCE_NAME" -- sha256sum /usr/local/sbin/xpf-userspace-dp 2>/dev/null | awk '{print $1}' || true)
-		if [[ -z "$vm_sum" ]]; then
-			die "xpf-userspace-dp not present on $INSTANCE_NAME after push (sha256 readback empty)"
-		fi
-		if [[ "$local_sum" != "$vm_sum" ]]; then
-			die "xpf-userspace-dp sha256 mismatch after push to $INSTANCE_NAME (local=$local_sum vm=$vm_sum) — push silently no-op'd or the build is stale"
-		fi
-		info "Verified xpf-userspace-dp sha256 on $INSTANCE_NAME ($local_sum)."
+		deploy_verify_pushed_sha "$INSTANCE_NAME" "$PROJECT_ROOT/xpf-userspace-dp" /usr/local/sbin/xpf-userspace-dp xpf-userspace-dp
 	else
 		warn "xpf-userspace-dp not found locally ($PROJECT_ROOT/xpf-userspace-dp); helper not pushed — xpfd will have no dataplane"
 	fi
@@ -643,6 +651,11 @@ cmd_deploy() {
 	incus file push "${SCRIPT_DIR}/xpfd.service" "$INSTANCE_NAME/etc/systemd/system/xpfd.service"
 	incus exec "$INSTANCE_NAME" -- systemctl daemon-reload
 	incus exec "$INSTANCE_NAME" -- systemctl enable --now xpfd
+
+	# Backstop (#2176): assert the LIVE xpfd is the binary we just pushed and the
+	# effective ExecStart is the base-unit path — a HARD failure if a version pin
+	# survived or systemd is launching stale code.
+	deploy_verify_running_xpfd "$INSTANCE_NAME" "$PROJECT_ROOT/xpfd"
 
 	# Suppress management interface default route so FRR-managed routes take effect.
 	# The permanent fix is UseRoutes=false in networkd, but on existing VMs the


### PR DESCRIPTION
Fixes #2162 and #2176 — two deploy-tooling robustness bugs that both cause
SILENT STALE-BINARY deploys (the #1 false-result hazard).

## #2162 — standalone deploy targeted the wrong instance

`test/incus/setup.sh` hardcoded `INSTANCE_NAME=xpf-fw`, so `make test-deploy`
always hit `xpf-fw`. When the standalone VM was created under another name
(e.g. the ad-hoc `xpf-fwd` used in the #2132 NAT smoke) the deploy errored
mid-flow against a non-existent `xpf-fw` or, worse, would have wiped the config
of an unrelated `xpf-fw`. Now env-overridable: `INSTANCE_NAME=${XPF_INSTANCE:-xpf-fw}`,
default unchanged. `XPF_INSTANCE=xpf-fwd make test-deploy`.

The helper push + sha-verify that #2162 also mentions was already added by
#1962/#1980 (standalone `setup.sh` builds/pushes/sha-verifies the Rust helper).
This PR extends that sha-verify to **xpfd and cli** too (the remaining #2162
"sha-verify it == local build" gap), via the shared lib below.

## #2176 — raw deploy silently runs OLD code over #1917 residue

A raw `incus file push` + restart could report success while systemd kept
launching stale code, because of two residues from a prior #1917 in-place-upgrade
`.deb` dogfood (both hit live in the #2166 smoke, worked around by hand):

- a leftover `xpfd.service.d/10-xpf-version.conf` drop-in pinning `ExecStart`
  to an OLD versioned binary; and
- dangling `/usr/local/sbin/{xpfd,cli,xpf-userspace-dp}` symlinks into a
  removed `versions/` dir, which break `incus file push`.

New shared `test/incus/deploy-lib.sh` (sourced by both `setup.sh` and
`cluster-setup.sh` raw-deploy paths) makes the deploy **rc!=0** instead of
silently running stale code:

1. **`deploy_reconcile_stale_pin`** — remove the xpf-managed `10-xpf-version.conf`
   (revert to base-unit `ExecStart=/usr/local/sbin/xpfd`) + daemon-reload. Any
   OTHER, operator-authored `ExecStart` override under `xpfd.service.d` is a
   HARD FAILURE — never silently deleted.
2. **`deploy_reconcile_dangling_sbin`** — remove dangling sbin symlinks so the
   push lands a fresh regular file.
3. **`deploy_verify_pushed_sha`** — sha256 readback of EACH pushed binary
   (xpfd, cli, helper) == local build; mismatch/empty fails the deploy.
4. **`deploy_verify_running_xpfd`** — after restart, assert the LIVE xpfd
   process image sha == the pushed build AND the effective systemd ExecStart is
   the base-unit path.

Both raw paths call (1)+(2) before the push and (4) after `enable --now`. The
#1917 deb-dogfood path (`deploy_vm_deb` / `xpfd upgrade --rolling`) is
untouched — it legitimately keeps the version pin; only the raw dev/test push
reconciles against a prior dogfood's residue.

## Validation

- `make test-deploy-lib` (`test/incus/deploy-lib-selftest.sh`) mocks `incus`
  against a fake VM rootfs and exercises the helpers end-to-end: **12/12**,
  including the five hard-fail cases (sha mismatch, absent binary, foreign
  ExecStart override, surviving version pin, stale running binary) — each
  asserted to exit non-zero.
- `shellcheck -x -S warning` CLEAN on deploy-lib.sh, deploy-lib-selftest.sh,
  setup.sh, cluster-setup.sh; `bash -n` clean.
- Not run on a live cluster (shared resource, no lock); the change is tooling
  and fully covered by the mocked self-test. ExecStart `path=` extraction
  verified against real `systemctl show -p ExecStart --value`.

## Claude SMR self-review

- The HARD-fail contract is the whole point: every verify path `die`s (rc!=0)
  on mismatch — covered by 5 negative self-tests that assert non-zero exit.
- Foreign-override scan runs whether or not the managed pin existed, and
  fires AFTER removing the managed pin (so a managed+foreign mix still
  hard-fails on the foreign one).
- deb-dogfood path deliberately excluded from reconcile/running-verify (it
  owns the version pin) — verified `deploy_vm_deb` shares no code with the
  reconciled `deploy_vm`.
- Default behavior preserved: `XPF_INSTANCE` defaults to `xpf-fw`; reconcile
  is a no-op on a clean VM (tested).
- All new remote `bash -c` bodies use the project's established single-quote
  expand-on-VM convention (matches existing SC2016 info-level patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
