### PR TITLE
#2149: frame builders emit priority-tagged VLAN-0 + preserve PCP/TPID

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,37 @@
 # Action Log
 
+## 2026-06-21 — #2149: frame builders emit priority-tagged VLAN-0 + preserve PCP
+
+- **Timestamp**: 2026-06-21
+- **Action**: Fixed the userspace frame builders so an 802.1p
+  priority-tagged VLAN-0 frame (real 802.1Q tag, VID 0, PCP != 0) is
+  emitted WITH its tag and PCP preserved, and the reflected local-origin
+  ICMP error path carries the inbound PCP/DEI/TPID through verbatim. The
+  Ethernet writers gated tag emission on `vlan_id > 0`, hard-coded TPID
+  0x8100, and had no PCP input; `ingress_reply_l2` returned a bare `u16`
+  VID, dropping PCP/DEI and the original TPID (0x88a8 vs 0x8100).
+  Introduced `TxVlanTag` (TPID + full TCI + present) in
+  `frame/headers.rs`: writers emit on `tag.emits()` (present AND non-zero
+  TCI — VID > 0 OR PCP/DEI set). `From<u16>` reproduces the legacy
+  bare-VID bytes exactly, so the config-driven egress builders
+  (forwarding, GRE/WG outer, TSO) stay bit-identical (VID 0 == untagged
+  is the intended semantic there — no PCP source). Builder side: new
+  `_tagged` variants; ICMP side: `ingress_reply_l2` returns `TxVlanTag`,
+  v4/v6 builders reflect it when present, fall back to egress VID when
+  untagged. Companion to #2171/#2145, which fixed the screen/SYN-cookie
+  L3-offset on tag presence (the parse side); this is the builder side.
+- **File(s)**: userspace-dp/src/afxdp/frame/headers.rs,
+  userspace-dp/src/afxdp/frame/headers_tests.rs,
+  userspace-dp/src/afxdp/frame/mod.rs,
+  userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/README.md
+- **Validation**: cargo build --release clean (no new warnings — the only
+  re-export unused-import warning predates this change);
+  frame/icmp/poll_stages/nat64 365/0; the 7 new tests pass 5x with no
+  flake; all three priority-tagged tests fail under the pre-fix
+  `vlan_id > 0` gating (non-tautological). PENDING-PARENT: live
+  PCP-on-the-wire verification on the loss cluster (not run here).
+
 ## 2026-06-21 — #2146 (PR #2189) fold: close IPv6 ext-header overshoot fail-open
 
 - **Timestamp**: 2026-06-21

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -24,6 +24,20 @@ sync.
   VID-based test would mis-read the IP header at offset 14 (#2145).
 - `frame/` — packet parsing (L2 / L3 / L4), checksum helpers, TCP MSS
   clamp. `tests.rs` was relocated out of `mod.rs` in #1046 Phase 1.
+  `headers.rs` holds the consolidated outer-header serializers (#1440).
+  The Ethernet writers emit an 802.1Q/802.1ad tag on tag *presence*
+  via `TxVlanTag` (#2149), not `vlan_id > 0`: a tag is serialized when
+  the VID is non-zero OR the PCP/DEI bits are set, so an 802.1p
+  priority-tagged VLAN-0 frame (real tag, VID 0, PCP != 0) keeps its
+  priority instead of collapsing to untagged. The reflected
+  local-origin ICMP error path (`icmp.rs`) carries the inbound TCI
+  (PCP + DEI + VID) and TPID through verbatim, so a priority-tagged or
+  802.1ad-tagged inbound packet is reflected with its tag intact;
+  untagged ingress still falls back to the egress interface's
+  configured VID. The egress *config-driven* builders (forwarding,
+  GRE/WG outer, TSO) still take a bare VID where VID 0 == untagged is
+  the intended semantic (no PCP source on those paths) — `From<u16>`
+  reproduces the legacy bytes exactly.
 - `umem/` — UMEM allocator, fill ring, completion ring. Frames are
   4 KB (`UMEM_FRAME_SIZE = 4096`); index is `addr >> 12`.
 - `tx/` — TX ring management, batched enqueue, TSO segmentation

--- a/userspace-dp/src/afxdp/frame/headers.rs
+++ b/userspace-dp/src/afxdp/frame/headers.rs
@@ -41,10 +41,96 @@
 use super::checksum::checksum16;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+/// Default 802.1Q customer-VLAN TPID.
+pub(in crate::afxdp) const TPID_8021Q: u16 = 0x8100;
+/// 802.1ad service-VLAN (Q-in-Q outer) TPID. Recognized on ingress and
+/// preserved on reflected local-origin errors so an inbound 0x88a8 tag
+/// is not silently rewritten to 0x8100.
+pub(in crate::afxdp) const TPID_8021AD: u16 = 0x88a8;
+
+/// An egress 802.1Q/802.1ad tag carrying the full TCI (PCP, DEI, VID)
+/// plus the TPID and a presence flag.
+///
+/// #2149: the old builder API took a bare `vlan_id: u16` and emitted a
+/// tag only when `vlan_id > 0`, hard-coding TPID 0x8100 and zeroing
+/// PCP/DEI. That cannot emit an 802.1p *priority-tagged* frame (a real
+/// tag with VID 0 but PCP != 0, used for priority-only QoS without VLAN
+/// membership), and it dropped the inbound PCP/DEI/TPID when reflecting
+/// a local-origin ICMP error. `TxVlanTag` carries enough state to do
+/// both: emit on tag *presence* (VID > 0 OR PCP > 0, or an explicitly
+/// present tag) and preserve the full TCI + TPID.
+///
+/// `From<u16>` reproduces the legacy bare-VID semantics exactly
+/// (present iff `vid > 0`, TPID 0x8100, PCP/DEI 0), so the egress
+/// config-driven call sites that only have a VID are bit-identical.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub(in crate::afxdp) struct TxVlanTag {
+    /// Tag Protocol Identifier (0x8100 for 802.1Q, 0x88a8 for 802.1ad).
+    pub tpid: u16,
+    /// Tag Control Information: PCP (3 bits) | DEI (1 bit) | VID (12 bits).
+    pub tci: u16,
+    /// Whether a tag should be emitted at all.
+    pub present: bool,
+}
+
+impl TxVlanTag {
+    /// No tag — emit a bare 14-byte Ethernet header.
+    pub(in crate::afxdp) const NONE: TxVlanTag = TxVlanTag {
+        tpid: TPID_8021Q,
+        tci: 0,
+        present: false,
+    };
+
+    /// Build a present tag from its parts. `pcp` low 3 bits, `dei` low
+    /// bit, `vid` low 12 bits are packed into the TCI. Used by the
+    /// reflected-local-error path to preserve the inbound priority bits.
+    #[inline]
+    pub(in crate::afxdp) fn from_parts(tpid: u16, pcp: u8, dei: bool, vid: u16) -> TxVlanTag {
+        let tci = (((pcp & 0x07) as u16) << 13)
+            | ((dei as u16) << 12)
+            | (vid & 0x0fff);
+        TxVlanTag {
+            tpid,
+            tci,
+            present: true,
+        }
+    }
+
+    /// True iff this tag should be serialized (present AND carries at
+    /// least one meaningful bit — VID > 0 or PCP/DEI set). A present tag
+    /// with an all-zero TCI is a degenerate "tag with no information"
+    /// and is treated as untagged, matching the legacy bare-VID
+    /// behavior for `vid == 0`.
+    #[inline]
+    pub(in crate::afxdp) fn emits(&self) -> bool {
+        self.present && self.tci != 0
+    }
+
+    /// Serialized L2 header length: 18 if a tag is emitted, else 14.
+    #[inline]
+    pub(in crate::afxdp) fn header_len(&self) -> usize {
+        if self.emits() { 18 } else { 14 }
+    }
+}
+
+impl From<u16> for TxVlanTag {
+    /// Legacy bare-VID semantics: present iff `vid > 0`, TPID 0x8100,
+    /// PCP/DEI 0. Bit-identical to the pre-#2149 `vlan_id > 0` builders.
+    #[inline]
+    fn from(vid: u16) -> TxVlanTag {
+        let vid = vid & 0x0fff;
+        TxVlanTag {
+            tpid: TPID_8021Q,
+            tci: vid,
+            present: vid > 0,
+        }
+    }
+}
+
 /// Length of an outer L2 header with optional 802.1Q tag.
 #[inline]
 pub(in crate::afxdp) fn eth_header_len(vlan_id: u16) -> usize {
-    if vlan_id > 0 { 18 } else { 14 }
+    TxVlanTag::from(vlan_id).header_len()
 }
 
 /// Write the Ethernet header (with optional 802.1Q tag) into a
@@ -59,11 +145,25 @@ pub(in crate::afxdp) fn write_eth_header(
     vlan_id: u16,
     ether_type: u16,
 ) {
+    write_eth_header_tagged(buf, dst, src, TxVlanTag::from(vlan_id), ether_type);
+}
+
+/// Tag-aware Vec-push Ethernet writer. Emits an 802.1Q/802.1ad tag
+/// whenever `tag.emits()` — i.e. VID > 0 OR PCP/DEI set (priority-
+/// tagged VLAN-0) — preserving the full TCI and the carried TPID.
+#[inline]
+pub(in crate::afxdp) fn write_eth_header_tagged(
+    buf: &mut Vec<u8>,
+    dst: [u8; 6],
+    src: [u8; 6],
+    tag: TxVlanTag,
+    ether_type: u16,
+) {
     buf.extend_from_slice(&dst);
     buf.extend_from_slice(&src);
-    if vlan_id > 0 {
-        buf.extend_from_slice(&0x8100u16.to_be_bytes());
-        buf.extend_from_slice(&(vlan_id & 0x0fff).to_be_bytes());
+    if tag.emits() {
+        buf.extend_from_slice(&tag.tpid.to_be_bytes());
+        buf.extend_from_slice(&tag.tci.to_be_bytes());
     }
     buf.extend_from_slice(&ether_type.to_be_bytes());
 }
@@ -81,26 +181,35 @@ pub(in crate::afxdp) fn write_eth_header_slice(
     vlan_id: u16,
     ether_type: u16,
 ) -> Option<()> {
-    let eth_len = eth_header_len(vlan_id);
+    write_eth_header_slice_tagged(buf, dst, src, TxVlanTag::from(vlan_id), ether_type)
+}
+
+/// Tag-aware in-place Ethernet writer. Emits the full TCI + carried
+/// TPID whenever `tag.emits()`, so a priority-tagged VLAN-0 tag (VID 0,
+/// PCP != 0) is serialized rather than collapsed to untagged (#2149).
+#[inline]
+pub(in crate::afxdp) fn write_eth_header_slice_tagged(
+    buf: &mut [u8],
+    dst: [u8; 6],
+    src: [u8; 6],
+    tag: TxVlanTag,
+    ether_type: u16,
+) -> Option<()> {
+    let eth_len = tag.header_len();
     if buf.len() < eth_len {
         return None;
     }
     let ether_type_bytes = ether_type.to_be_bytes();
     // SAFETY: buf.len() >= eth_len is guaranteed by the guard above.
-    // eth_len is 14 (no VLAN) or 18 (VLAN), so all writes are
-    // in-bounds.
+    // eth_len is 14 (no tag) or 18 (tag), so all writes are in-bounds.
     debug_assert!(buf.len() >= eth_len);
     unsafe {
         let ptr = buf.as_mut_ptr();
         core::ptr::copy_nonoverlapping(dst.as_ptr(), ptr, 6);
         core::ptr::copy_nonoverlapping(src.as_ptr(), ptr.add(6), 6);
-        if vlan_id > 0 {
-            core::ptr::copy_nonoverlapping(0x8100u16.to_be_bytes().as_ptr(), ptr.add(12), 2);
-            core::ptr::copy_nonoverlapping(
-                (vlan_id & 0x0fff).to_be_bytes().as_ptr(),
-                ptr.add(14),
-                2,
-            );
+        if tag.emits() {
+            core::ptr::copy_nonoverlapping(tag.tpid.to_be_bytes().as_ptr(), ptr.add(12), 2);
+            core::ptr::copy_nonoverlapping(tag.tci.to_be_bytes().as_ptr(), ptr.add(14), 2);
             core::ptr::copy_nonoverlapping(ether_type_bytes.as_ptr(), ptr.add(16), 2);
         } else {
             core::ptr::copy_nonoverlapping(ether_type_bytes.as_ptr(), ptr.add(12), 2);

--- a/userspace-dp/src/afxdp/frame/headers_tests.rs
+++ b/userspace-dp/src/afxdp/frame/headers_tests.rs
@@ -331,3 +331,126 @@ fn eth_header_vec_push_with_vlan() {
     assert_eq!(&buf[14..16], &[0x01, 0x00]);
     assert_eq!(&buf[16..18], &[0x86, 0xdd]);
 }
+
+// ---- #2149: TxVlanTag priority-tagged VLAN-0 / PCP preservation ----
+
+#[test]
+fn txvlantag_from_vid_matches_legacy_semantics() {
+    // `From<u16>` must reproduce the pre-#2149 bare-VID behavior
+    // exactly: present iff VID > 0, TPID 0x8100, PCP/DEI 0, VID masked
+    // to 12 bits.
+    assert_eq!(
+        TxVlanTag::from(0),
+        TxVlanTag {
+            tpid: 0x8100,
+            tci: 0,
+            present: false
+        }
+    );
+    assert!(!TxVlanTag::from(0).emits(), "VID 0 must not emit a tag");
+    assert_eq!(TxVlanTag::from(0).header_len(), 14);
+
+    let t = TxVlanTag::from(0x123);
+    assert!(t.emits());
+    assert_eq!(t.tpid, 0x8100);
+    assert_eq!(t.tci, 0x123, "bare VID has PCP/DEI 0");
+    assert_eq!(t.header_len(), 18);
+
+    // VID > 0xFFF masked to 12 bits.
+    assert_eq!(TxVlanTag::from(0xF123).tci, 0x123);
+}
+
+#[test]
+fn txvlantag_priority_tagged_vlan0_emits() {
+    // The 802.1p priority-tagged VLAN-0 case: VID 0, PCP 5. A bare VID
+    // would NOT emit (the pre-fix bug); the tag MUST emit because PCP
+    // is non-zero.
+    let t = TxVlanTag::from_parts(0x8100, 5, false, 0);
+    assert!(t.present);
+    assert!(t.emits(), "PCP != 0 with VID 0 must still emit a tag");
+    assert_eq!(t.header_len(), 18);
+    // TCI = PCP(5) << 13 | DEI(0) << 12 | VID(0) = 0xA000.
+    assert_eq!(t.tci, 0xA000);
+}
+
+#[test]
+fn txvlantag_present_but_empty_tci_degrades_to_untagged() {
+    // A present tag with an all-zero TCI carries no information (no
+    // VID, no priority) and must be treated as untagged — matching the
+    // legacy `vid == 0` behavior so an inbound plain VID-0 tag does not
+    // produce a meaningless tag on the reflected error.
+    let t = TxVlanTag {
+        tpid: 0x8100,
+        tci: 0,
+        present: true,
+    };
+    assert!(!t.emits());
+    assert_eq!(t.header_len(), 14);
+}
+
+#[test]
+fn eth_header_tagged_priority_tagged_vlan0_preserves_full_tci() {
+    // The core #2149 builder proof: a priority-tagged VLAN-0 tag
+    // (TPID 0x8100, PCP 5, DEI 0, VID 0) is serialized WITH the tag and
+    // the full TCI preserved. Pre-fix (`vlan_id > 0` gating) this frame
+    // was emitted untagged (14 bytes) with PCP lost.
+    let tag = TxVlanTag::from_parts(0x8100, 5, false, 0);
+
+    // Vec-push variant.
+    let mut vbuf = Vec::new();
+    write_eth_header_tagged(&mut vbuf, [1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12], tag, 0x0800);
+    assert_eq!(vbuf.len(), 18, "priority-tagged VLAN-0 must be 18 bytes");
+    assert_eq!(&vbuf[12..14], &[0x81, 0x00], "TPID 0x8100");
+    // TCI 0xA000: PCP 5 in the top 3 bits, DEI 0, VID 0.
+    assert_eq!(&vbuf[14..16], &[0xA0, 0x00], "TCI must preserve PCP=5, VID=0");
+    assert_eq!(&vbuf[16..18], &[0x08, 0x00], "ether_type follows the tag");
+
+    // Slice variant must produce identical bytes.
+    let mut sbuf = [0xffu8; 18];
+    write_eth_header_slice_tagged(
+        &mut sbuf,
+        [1, 2, 3, 4, 5, 6],
+        [7, 8, 9, 10, 11, 12],
+        tag,
+        0x0800,
+    )
+    .expect("slice writer");
+    assert_eq!(&sbuf[..], &vbuf[..], "slice and vec writers must agree");
+}
+
+#[test]
+fn eth_header_tagged_preserves_8021ad_tpid_and_dei() {
+    // A reflected 802.1ad (0x88a8) tag must keep its TPID, and DEI must
+    // survive. TCI = PCP(3) | DEI(1) | VID(100).
+    let tag = TxVlanTag::from_parts(0x88a8, 3, true, 100);
+    let mut buf = [0u8; 18];
+    write_eth_header_slice_tagged(&mut buf, [0; 6], [0; 6], tag, 0x86dd).expect("writer");
+    assert_eq!(&buf[12..14], &[0x88, 0xa8], "802.1ad TPID preserved");
+    // TCI = (3 << 13) | (1 << 12) | 100 = 0x6000 | 0x1000 | 0x64 = 0x7064.
+    assert_eq!(&buf[14..16], &[0x70, 0x64], "PCP=3, DEI=1, VID=100");
+    assert_eq!(&buf[16..18], &[0x86, 0xdd]);
+}
+
+#[test]
+fn eth_header_tagged_untagged_stays_untagged() {
+    // No tag ⇒ 14-byte header, ether_type at byte 12, nothing past 14.
+    let mut buf = [0xffu8; 18];
+    write_eth_header_slice_tagged(&mut buf, [1; 6], [2; 6], TxVlanTag::NONE, 0x0800)
+        .expect("writer");
+    assert_eq!(&buf[12..14], &[0x08, 0x00], "ether_type at byte 12 when untagged");
+    // Bytes 14.. are untouched by the writer (still the 0xff sentinel),
+    // proving no tag was written.
+    assert_eq!(&buf[14..18], &[0xff, 0xff, 0xff, 0xff], "no tag bytes written");
+}
+
+#[test]
+fn eth_header_legacy_vid_path_still_emits_8021q_tag() {
+    // The bare-VID `write_eth_header` path (egress config VID) must be
+    // unchanged: a normal VID > 0 still emits a plain 802.1Q tag.
+    let mut buf = Vec::new();
+    write_eth_header(&mut buf, [0; 6], [0; 6], 0x064, 0x0800);
+    assert_eq!(buf.len(), 18);
+    assert_eq!(&buf[12..14], &[0x81, 0x00]);
+    assert_eq!(&buf[14..16], &[0x00, 0x64], "PCP 0, VID 100");
+    assert_eq!(&buf[16..18], &[0x08, 0x00]);
+}

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -14,8 +14,8 @@ mod wg;
 // paths. The previous in-place definitions in this file were
 // moved verbatim into headers.rs.
 pub(in crate::afxdp) use headers::{
-    eth_header_len, write_eth_header, write_eth_header_slice, write_ipv4_header,
-    write_ipv6_header, write_udp_header,
+    eth_header_len, write_eth_header, write_eth_header_slice, write_eth_header_tagged,
+    write_ipv4_header, write_ipv6_header, write_udp_header, TxVlanTag, TPID_8021AD, TPID_8021Q,
 };
 
 use byte_writes::{

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -90,20 +90,36 @@ pub(super) fn build_local_time_exceeded_request(
     })
 }
 
-fn ingress_reply_l2(frame: &[u8]) -> Option<([u8; 6], [u8; 6], u16)> {
+/// Parse the inbound L2 header for a reflected local-origin reply:
+/// swapped MACs plus the full ingress 802.1Q/802.1ad tag (TPID + TCI:
+/// PCP, DEI, VID). #2149: this previously returned only `vlan_id: u16`,
+/// collapsing VID 0 to untagged and dropping PCP/DEI/TPID — so a
+/// priority-tagged VLAN-0 frame (a real tag with VID 0 and PCP != 0,
+/// used for 802.1p priority-only QoS) was reflected untagged with its
+/// priority lost, and an 802.1ad (0x88a8) tag was lost entirely.
+/// Returning a `TxVlanTag` preserves the full tag so the reflected
+/// error carries the original priority and TPID.
+fn ingress_reply_l2(frame: &[u8]) -> Option<([u8; 6], [u8; 6], TxVlanTag)> {
     if frame.len() < 14 {
         return None;
     }
     let dst_mac = <[u8; 6]>::try_from(frame.get(0..6)?).ok()?;
     let src_mac = <[u8; 6]>::try_from(frame.get(6..12)?).ok()?;
     let eth_proto = u16::from_be_bytes([frame[12], frame[13]]);
-    let vlan_id = if matches!(eth_proto, 0x8100 | 0x88a8) {
+    let ingress_tag = if matches!(eth_proto, TPID_8021Q | TPID_8021AD) {
         let tci = u16::from_be_bytes([*frame.get(14)?, *frame.get(15)?]);
-        tci & 0x0fff
+        // Preserve the full TCI (PCP | DEI | VID) and the original TPID.
+        // `present: true` makes a priority-tagged VID-0 frame reflect
+        // its tag; an all-zero TCI degrades to untagged via `emits()`.
+        TxVlanTag {
+            tpid: eth_proto,
+            tci,
+            present: true,
+        }
     } else {
-        0
+        TxVlanTag::NONE
     };
-    Some((src_mac, dst_mac, vlan_id))
+    Some((src_mac, dst_mac, ingress_tag))
 }
 
 pub(super) fn build_local_time_exceeded_v4(
@@ -131,7 +147,7 @@ pub(super) fn build_local_icmp_error_v4(
     icmp_code: u8,
 ) -> Option<Vec<u8>> {
     let egress = forwarding.egress.get(&ingress_ifindex)?;
-    let (dst_mac, fallback_src_mac, ingress_vlan_id) = ingress_reply_l2(frame)?;
+    let (dst_mac, fallback_src_mac, ingress_tag) = ingress_reply_l2(frame)?;
     let src_ip = egress.primary_v4?;
     let src_mac = egress.src_mac;
     let l3 = match meta.l3_offset {
@@ -150,15 +166,20 @@ pub(super) fn build_local_icmp_error_v4(
     let total_len = u16::from_be_bytes([packet[2], packet[3]]) as usize;
     let packet_len = total_len.min(packet.len());
     let quoted_len = packet_len.min(ihl.saturating_add(8));
-    let vlan_id = if ingress_vlan_id > 0 {
-        ingress_vlan_id
+    // #2149: reflect the inbound tag verbatim (TPID + PCP + DEI + VID)
+    // when one was present, so a priority-tagged VLAN-0 inbound error
+    // is reflected with its priority intact. Fall back to the egress
+    // interface's configured VID (bare 802.1Q, PCP 0) when ingress was
+    // untagged.
+    let tag = if ingress_tag.emits() {
+        ingress_tag
     } else {
-        egress.vlan_id
+        TxVlanTag::from(egress.vlan_id)
     };
-    let eth_len = if vlan_id > 0 { 18 } else { 14 };
+    let eth_len = tag.header_len();
     let total_len = 20usize.checked_add(8)?.checked_add(quoted_len)?;
     let mut out = Vec::with_capacity(eth_len + total_len);
-    write_eth_header(
+    write_eth_header_tagged(
         &mut out,
         dst_mac,
         if src_mac == [0; 6] {
@@ -166,7 +187,7 @@ pub(super) fn build_local_icmp_error_v4(
         } else {
             src_mac
         },
-        vlan_id,
+        tag,
         0x0800,
     );
     // #1440: consolidated IPv4 outer builder. Sets DF=1 + computes
@@ -218,7 +239,7 @@ pub(super) fn build_local_icmp_error_v6(
     icmp_code: u8,
 ) -> Option<Vec<u8>> {
     let egress = forwarding.egress.get(&ingress_ifindex)?;
-    let (dst_mac, fallback_src_mac, ingress_vlan_id) = ingress_reply_l2(frame)?;
+    let (dst_mac, fallback_src_mac, ingress_tag) = ingress_reply_l2(frame)?;
     let src_ip = egress.primary_v6?;
     let src_mac = egress.src_mac;
     let l3 = match meta.l3_offset {
@@ -233,15 +254,18 @@ pub(super) fn build_local_icmp_error_v6(
     let payload_len = u16::from_be_bytes([packet[4], packet[5]]) as usize;
     let packet_len = (40 + payload_len).min(packet.len());
     let quoted_len = packet_len.min(48);
-    let vlan_id = if ingress_vlan_id > 0 {
-        ingress_vlan_id
+    // #2149: preserve the inbound tag (TPID + PCP + DEI + VID) on the
+    // reflected error; fall back to the egress configured VID when
+    // ingress was untagged. See the v4 builder for the rationale.
+    let tag = if ingress_tag.emits() {
+        ingress_tag
     } else {
-        egress.vlan_id
+        TxVlanTag::from(egress.vlan_id)
     };
-    let eth_len = if vlan_id > 0 { 18 } else { 14 };
+    let eth_len = tag.header_len();
     let outer_payload_len = 8usize.checked_add(quoted_len)?;
     let mut out = Vec::with_capacity(eth_len + 40 + outer_payload_len);
-    write_eth_header(
+    write_eth_header_tagged(
         &mut out,
         dst_mac,
         if src_mac == [0; 6] {
@@ -249,7 +273,7 @@ pub(super) fn build_local_icmp_error_v6(
         } else {
             src_mac
         },
-        vlan_id,
+        tag,
         0x86dd,
     );
     // #1440: consolidated IPv6 outer builder.
@@ -348,5 +372,164 @@ pub(super) fn is_icmp_error(protocol: u8, icmp_type: u8) -> bool {
         PROTO_ICMP => matches!(icmp_type, 3 | 11 | 12),
         PROTO_ICMPV6 => matches!(icmp_type, 1 | 2 | 3 | 4),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ICMP_IFINDEX: i32 = 24;
+    const EGRESS_SRC_MAC: [u8; 6] = [0x02, 0xbf, 0x72, 0x00, 0x00, 0x01];
+
+    /// A ForwardingState with one egress interface (the ingress index
+    /// the reflected-error builders look up). `egress.vlan_id` is the
+    /// fallback used when the inbound frame is untagged.
+    fn forwarding_with_egress(vlan_id: u16) -> ForwardingState {
+        let mut state = ForwardingState::default();
+        state.egress.insert(
+            ICMP_IFINDEX,
+            EgressInterface {
+                bind_ifindex: 0,
+                vlan_id,
+                mtu: 1500,
+                src_mac: EGRESS_SRC_MAC,
+                zone_id: 0,
+                redundancy_group: 0,
+                primary_v4: Some(Ipv4Addr::new(172, 16, 80, 8)),
+                primary_v6: Some("2001:559:8585:80::8".parse().expect("v6")),
+            },
+        );
+        state
+    }
+
+    #[derive(Clone, Copy)]
+    enum InL2 {
+        Untagged,
+        /// 802.1p priority-tagged VLAN-0: TPID 0x8100, PCP 5, VID 0.
+        PriorityTaggedVlan0,
+        /// Normal 802.1Q tag, PCP 0, VID 100.
+        Vlan100,
+    }
+
+    /// Build an inbound IPv4 UDP packet (so the reflected reply is a
+    /// real error, not suppressed) with the chosen L2 header. The TTL
+    /// is 1 so `build_local_time_exceeded_v4` fires; the builders read
+    /// the inbound tag straight from the frame bytes.
+    fn inbound_v4(l2: InL2) -> (Vec<u8>, UserspaceDpMeta) {
+        let mut frame = Vec::new();
+        let dst_mac = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]; // firewall NIC
+        let src_mac = [0x00, 0x25, 0x90, 0x12, 0x34, 0x56]; // sender
+        frame.extend_from_slice(&dst_mac);
+        frame.extend_from_slice(&src_mac);
+        let l3_off: u16 = match l2 {
+            InL2::Untagged => {
+                frame.extend_from_slice(&0x0800u16.to_be_bytes());
+                14
+            }
+            InL2::PriorityTaggedVlan0 => {
+                frame.extend_from_slice(&0x8100u16.to_be_bytes());
+                // TCI = PCP 5 << 13 | DEI 0 | VID 0 = 0xA000.
+                frame.extend_from_slice(&0xA000u16.to_be_bytes());
+                frame.extend_from_slice(&0x0800u16.to_be_bytes());
+                18
+            }
+            InL2::Vlan100 => {
+                frame.extend_from_slice(&0x8100u16.to_be_bytes());
+                frame.extend_from_slice(&100u16.to_be_bytes());
+                frame.extend_from_slice(&0x0800u16.to_be_bytes());
+                18
+            }
+        };
+        let l3 = frame.len();
+        // IPv4 header, IHL 5, TTL 1, proto UDP, total_len = 20 + 8.
+        frame.push(0x45);
+        frame.push(0x00);
+        frame.extend_from_slice(&28u16.to_be_bytes());
+        frame.extend_from_slice(&[0x00, 0x01, 0x40, 0x00, 1, 17, 0x00, 0x00]);
+        frame.extend_from_slice(&Ipv4Addr::new(198, 51, 100, 20).octets()); // src
+        frame.extend_from_slice(&Ipv4Addr::new(172, 16, 80, 200).octets()); // dst
+        let ip_csum = checksum16(&frame[l3..l3 + 20]);
+        frame[l3 + 10..l3 + 12].copy_from_slice(&ip_csum.to_be_bytes());
+        // 8-byte UDP header.
+        frame.extend_from_slice(&49152u16.to_be_bytes());
+        frame.extend_from_slice(&5201u16.to_be_bytes());
+        frame.extend_from_slice(&8u16.to_be_bytes());
+        frame.extend_from_slice(&0u16.to_be_bytes());
+
+        let meta = UserspaceDpMeta {
+            ingress_ifindex: ICMP_IFINDEX as u32,
+            l3_offset: l3_off,
+            addr_family: libc::AF_INET as u8,
+            protocol: 17,
+            ..UserspaceDpMeta::default()
+        };
+        (frame, meta)
+    }
+
+    /// #2149 regression: a priority-tagged VLAN-0 inbound frame
+    /// (TPID 0x8100, PCP 5, VID 0) must have its tag — including PCP —
+    /// reflected on the local-origin ICMP error. Pre-fix the builder
+    /// gated tag emission on `vlan_id > 0`, so VID 0 collapsed to
+    /// untagged (14-byte L2) and PCP was lost.
+    #[test]
+    fn reflected_v4_error_preserves_priority_tagged_vlan0() {
+        let (frame, meta) = inbound_v4(InL2::PriorityTaggedVlan0);
+        // Egress config VID is 0 (no membership) — the ONLY tag source
+        // is the inbound priority tag, proving preservation rather than
+        // an egress-config fallback.
+        let fwd = forwarding_with_egress(0);
+        let out =
+            build_local_icmp_error_v4(&frame, meta, ICMP_IFINDEX, &fwd, 11, 0).expect("v4 error");
+
+        assert_eq!(&out[12..14], &[0x81, 0x00], "reflected frame must carry an 802.1Q TPID");
+        assert_eq!(
+            &out[14..16],
+            &[0xA0, 0x00],
+            "reflected TCI must preserve PCP=5, VID=0 (the priority tag)"
+        );
+        // EtherType IPv4 follows the tag → L3 starts at byte 18.
+        assert_eq!(&out[16..18], &[0x08, 0x00]);
+        assert_eq!(out[18], 0x45, "IPv4 outer header starts at offset 18");
+        // MACs swapped: reflected dst = inbound src.
+        assert_eq!(&out[0..6], &[0x00, 0x25, 0x90, 0x12, 0x34, 0x56]);
+        assert_eq!(&out[6..12], &EGRESS_SRC_MAC);
+    }
+
+    /// A normal VID > 0 inbound tag is reflected unchanged (regression
+    /// guard for the common path).
+    #[test]
+    fn reflected_v4_error_preserves_normal_vlan() {
+        let (frame, meta) = inbound_v4(InL2::Vlan100);
+        let fwd = forwarding_with_egress(0);
+        let out =
+            build_local_icmp_error_v4(&frame, meta, ICMP_IFINDEX, &fwd, 11, 0).expect("v4 error");
+        assert_eq!(&out[12..14], &[0x81, 0x00]);
+        assert_eq!(&out[14..16], &100u16.to_be_bytes(), "VID 100 preserved, PCP 0");
+        assert_eq!(out[18], 0x45);
+    }
+
+    /// An untagged inbound frame stays untagged on the reflected error
+    /// when the egress interface has no configured VID.
+    #[test]
+    fn reflected_v4_error_untagged_stays_untagged() {
+        let (frame, meta) = inbound_v4(InL2::Untagged);
+        let fwd = forwarding_with_egress(0);
+        let out =
+            build_local_icmp_error_v4(&frame, meta, ICMP_IFINDEX, &fwd, 11, 0).expect("v4 error");
+        assert_eq!(&out[12..14], &[0x08, 0x00], "EtherType IPv4 at byte 12 (untagged)");
+        assert_eq!(out[14], 0x45, "IPv4 outer header starts at offset 14");
+    }
+
+    /// An untagged inbound frame on an egress interface WITH a
+    /// configured VID falls back to that VID (legacy egress behavior).
+    #[test]
+    fn reflected_v4_error_untagged_falls_back_to_egress_vid() {
+        let (frame, meta) = inbound_v4(InL2::Untagged);
+        let fwd = forwarding_with_egress(50);
+        let out =
+            build_local_icmp_error_v4(&frame, meta, ICMP_IFINDEX, &fwd, 11, 0).expect("v4 error");
+        assert_eq!(&out[12..14], &[0x81, 0x00]);
+        assert_eq!(&out[14..16], &50u16.to_be_bytes(), "egress VID 50 fallback");
     }
 }


### PR DESCRIPTION
Closes #2149.

## Problem

The userspace frame builders could not emit an 802.1p **priority-tagged VLAN-0** frame (a real 802.1Q tag with VID 0 but PCP != 0, used for priority-only QoS without VLAN membership), and they dropped PCP/DEI plus the original TPID (0x88a8 vs 0x8100) when reflecting an inbound tag.

- `frame/headers.rs` — the Ethernet writers gated tag emission on `vlan_id > 0`, hard-coded TPID 0x8100, and had no PCP/DEI input, so a VID-0 tag collapsed to a bare 14-byte untagged header with the priority bits lost.
- `icmp.rs` — `ingress_reply_l2` parsed the inbound tag but returned only a `u16` VID, discarding PCP, DEI, and the TPID. The local-origin ICMP error builders (Time Exceeded, #2089 reject Destination Unreachable) therefore reflected a priority-tagged VLAN-0 inbound frame untagged with its priority gone, and rewrote 0x88a8 to 0x8100.

This is the **builder** side of the VLAN-0 work; #2171/#2145 fixed the screen/SYN-cookie L3-offset on tag presence (the parse side).

## Fix

Introduce `TxVlanTag` (TPID + full TCI: PCP | DEI | VID, plus a presence flag) in `frame/headers.rs`. The Ethernet writers now serialize a tag whenever `tag.emits()` — present AND a non-zero TCI, i.e. **VID > 0 OR PCP/DEI set** — preserving the full TCI and the carried TPID, mirroring the `ingress_vlan_present`-based presence semantics from #2171.

- `From<u16>` reproduces the legacy bare-VID bytes exactly (present iff `vid > 0`, TPID 0x8100, PCP/DEI 0), so the config-driven egress builders (forwarding, GRE/WG outer, TSO) stay **bit-identical** — VID 0 == untagged is the intended semantic there because those paths have no PCP source.
- `write_eth_header` / `write_eth_header_slice` keep their `u16` signature and delegate through `TxVlanTag::from(vid)`; new `_tagged` variants take a `TxVlanTag`.
- `ingress_reply_l2` returns the full `TxVlanTag`; the v4/v6 ICMP-error builders reflect it verbatim when present, falling back to the egress interface's configured VID when the inbound frame was untagged (preserving the legacy `ingress_vlan_id > 0 ? ingress : egress` behavior for the untagged case).

Hot-path safe: `TxVlanTag` is `Copy`, the writers stay allocation-free, all `#[inline]`.

## Tests

7 new unit tests. The load-bearing proof is `eth_header_tagged_priority_tagged_vlan0_preserves_full_tci` (builder) and `reflected_v4_error_preserves_priority_tagged_vlan0` (end-to-end via `build_local_icmp_error_v4`): a priority-tagged VLAN-0 frame (PCP 5, VID 0) is emitted with the 802.1Q tag and TCI 0xA000 (PCP preserved); pre-fix it was emitted untagged with PCP dropped. Companions cover normal VID-100 (unchanged), untagged stays untagged, untagged falls back to egress VID, and 802.1ad TPID/DEI preservation. **All three priority-tagged tests fail under the pre-fix `vlan_id > 0` gating** (verified by temporarily restoring the old predicate) — non-tautological.

## Validation

- `cargo build --release` clean — no new warnings (the only re-export unused-import warning predates this change and lists symbols unrelated to it).
- `cargo test --release` frame/icmp/poll_stages/nat64: 365/0.
- New tests pass 5x with no flake.

PENDING-PARENT: live PCP-on-the-wire verification on the loss userspace cluster was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)