### PR TITLE
#2208: recycle ingress UMEM descriptor on every TX dispatch exit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,28 @@
 # Action Log
 
+## 2026-06-21 — #2208: TX dispatch recycle-on-every-path (UMEM descriptor leak)
+
+- **Timestamp**: 2026-06-21
+- **Action**: Fixed four bare `continue;` statements in
+  `enqueue_pending_forwards` that jumped past the loop finalizer, leaking
+  the ingress UMEM descriptor (never recycled to the fill ring) under TX
+  congestion / oversized-frame edges → per-packet pool drain → worker
+  stall. The two enqueue-failure sites (cp1/cp2) now fall through with
+  `build_failed=true; fallback_to_slow_path=true` so the finalizer both
+  recycles and runs `handle_forward_build_failure` (slow-path reinject);
+  the two oversized sites (cp1/cp2) fall through with `build_failed=true`
+  only (undeliverable — drop-and-recycle, no reinject). Added three
+  dispatch tests (enqueue-failure recycle+reinject, oversized
+  recycle+no-reinject, N-forward conservation) that FAIL against the
+  pre-fix `continue;` (recycle-count == 0 leak); two `#[cfg(test)]`-only
+  fault-injection thread-locals (`FORCE_ENQUEUE_ERR`, `FORCE_OVERSIZED`)
+  drive the otherwise hard-to-reach branches with zero release-build cost.
+  Documented the recycle-on-every-path invariant in `afxdp/README.md`.
+- **File(s)**: userspace-dp/src/afxdp/tx/dispatch/mod.rs,
+  userspace-dp/src/afxdp/tx/dispatch/cos.rs,
+  userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs,
+  userspace-dp/src/afxdp/README.md
+
 ## 2026-06-21 — #2150 PR-1: Ethernet/IPv6 parser correctness sub-fixes + drift canaries
 
 - **Timestamp**: 2026-06-21

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -42,6 +42,24 @@ sync.
   4 KB (`UMEM_FRAME_SIZE = 4096`); index is `addr >> 12`.
 - `tx/` — TX ring management, batched enqueue, TSO segmentation
   (`tx/tcp_segmentation.rs` after PR #1199), per-binding TX counters.
+  - `tx/dispatch/` — the per-tick forwarding dispatcher
+    (`enqueue_pending_forwards`). **Recycle-on-every-path invariant
+    (#2208):** the ingress descriptor is read directly from ingress
+    UMEM (the RX ring already released it), so `recycle_ingress_frame`
+    — pushing `source_offset` to `pending_fill_frames` → the fill ring
+    — is the SOLE path that returns the frame to circulation. Every
+    per-request exit MUST recycle exactly once: the loop finalizer does
+    this (`if !retained_source_frame`), and `retained_source_frame` is
+    true ONLY on the in-place-rewrite branch (where the descriptor IS
+    the TX frame and is recycled by `PreparedTxRecycle::fill_on_slot`
+    on completion). Exception/build-failure branches must FALL THROUGH
+    to the finalizer, never `continue` past it — a bare `continue`
+    leaks the descriptor (per-packet UMEM-pool drain → worker stall
+    under TX congestion). The two enqueue-failure sites also set
+    `build_failed=true; fallback_to_slow_path=true` so the finalizer's
+    `handle_forward_build_failure` reinjects the frame to the slow path;
+    the two oversized sites set `build_failed=true` only (the frame is
+    undeliverable — drop-and-recycle, no reinject).
 - `cos/` — Class-of-Service scheduler: token-bucket admission, MQFQ
   active-bucket selection, fair-share lease (#1229 Phase 6 v8). See
   `docs/per-5-tuple/state.md` for the architectural ceiling.

--- a/userspace-dp/src/afxdp/tx/dispatch/cos.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/cos.rs
@@ -76,11 +76,31 @@ pub(super) fn request_runs_under_shared_exact_policy(
         .is_some_and(|queue_fast| queue_fast.shared_exact)
 }
 
+// #2208: test-only fault injection for the enqueue-failure control flow.
+// The owner-path `enqueue_tx_owned` swallows overflow today (it records a
+// redirect-inbox drop but returns Ok), so the `is_err()` arms in the
+// dispatch copy paths are not reachable from pure production inputs. They
+// ARE on the hot path (the function returns `Result<(), TxRequest>` and
+// the Err arm is compiled), and a future backpressure change would make
+// them live. This thread-local lets the dispatch tests drive the Err arm
+// deterministically to prove it recycles the ingress descriptor and runs
+// the slow-path fallback. It is `#[cfg(test)]` only — the production build
+// never sees the branch, so the hot path is unchanged.
+#[cfg(test)]
+thread_local! {
+    pub(super) static FORCE_ENQUEUE_ERR: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
 #[inline]
 pub(super) fn enqueue_local_request_to_target_or_owner(
     target_binding: &mut BindingWorker,
     req: TxRequest,
 ) -> Result<(), TxRequest> {
+    #[cfg(test)]
+    if FORCE_ENQUEUE_ERR.with(|c| c.get()) {
+        return Err(req);
+    }
     // #1598 secondary fix: gate on the routing-level `shared_exact`
     // flag rather than on `shared_queue_lease.is_some()`. The lease is
     // an exact-queue-only marker — non-exact uncapped queues run under

--- a/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
@@ -666,6 +666,313 @@ fn enqueue_pending_forwards_counts_prebuilt_fabric_redirect_no_binding() {
     assert_eq!(reasons, vec!["fabric_redirect_no_binding"]);
 }
 
+// ---------------------------------------------------------------------------
+// #2208: the dispatch copy paths must recycle the ingress UMEM descriptor on
+// EVERY exit. Four bare `continue;` statements (cp1/cp2 oversized + cp1/cp2
+// enqueue-failure) jumped to the next loop iteration before the finalizer,
+// permanently leaking the ingress descriptor (it never reached the fill ring)
+// and — for the enqueue-failure sites — also skipping the slow-path reinject
+// the `build_failed=true; fallback_to_slow_path=true` flags requested.
+//
+// These tests drive `enqueue_pending_forwards` through the cp2 copy fallback
+// (target on a separate UMEM with an empty free_tx_frames pool forces the
+// NoFreeTxFrame → Vec-copy branch) and assert:
+//   (a) the ingress descriptor IS returned to circulation exactly once
+//       (fill-ring pending + pending_fill_frames == 1, never 0 or 2);
+//   (b) the enqueue-failure path runs handle_forward_build_failure
+//       (dbg.build_fail bumped) AND its slow-path reinject
+//       (slow_path_drops bumped, since the test passes slow_path=None so the
+//        reinject lands on `slow_path_unavailable`);
+//   (c) the oversized path recycles but does NOT reinject (the frame is
+//       undeliverable) — build_fail bumped, slow_path_drops untouched.
+//
+// Against the pre-fix bare `continue;` (a) is 0 (leak) and (b)/(c) never fire.
+
+/// Count ingress descriptors returned to circulation: those submitted to the
+/// fill ring plus any still queued in `pending_fill_frames`. Each forwarded
+/// request must contribute exactly one — 0 is a leak, 2 is a double-recycle.
+fn ingress_recycled_count(ingress: &BindingWorker) -> usize {
+    ingress.xsk.device.pending() as usize + ingress.tx_pipeline.pending_fill_frames.len()
+}
+
+/// RAII guard that resets the #2208 fault-injection thread-locals so a
+/// panicking assertion cannot leak state into the next test on the same
+/// thread.
+struct ForceFaultGuard;
+impl Drop for ForceFaultGuard {
+    fn drop(&mut self) {
+        super::cos::FORCE_ENQUEUE_ERR.with(|c| c.set(false));
+        super::FORCE_OVERSIZED.with(|c| c.set(false));
+    }
+}
+
+/// Build a two-binding harness (ingress slot 0 / ifindex 11, egress slot 1 /
+/// ifindex 22) with a valid IPv4 frame in the ingress UMEM at offset 0 and the
+/// egress binding's `free_tx_frames` drained so dispatch is forced down the
+/// cp2 Vec-copy fallback. Returns everything `enqueue_pending_forwards` needs.
+fn cp2_copy_fallback_harness() -> (Vec<BindingWorker>, Vec<u8>) {
+    let mut bindings = vec![
+        BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+        BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+    ];
+    let original_frame = build_ipv4_test_packet(0);
+    unsafe {
+        bindings[0]
+            .umem
+            .area()
+            .slice_mut_unchecked(0, original_frame.len())
+    }
+    .expect("ingress frame")
+    .copy_from_slice(&original_frame);
+    // Drain the egress free-TX pool: with no direct-TX frame available the
+    // dispatcher falls back to the Vec copy path (cp2), which is where the
+    // enqueue/oversized #2208 sites live.
+    bindings[1].tx_pipeline.free_tx_frames.clear();
+    (bindings, original_frame)
+}
+
+#[test]
+fn enqueue_failure_recycles_ingress_descriptor_and_reinjects_slow_path() {
+    let _guard = ForceFaultGuard;
+    let (mut bindings, original_frame) = cp2_copy_fallback_harness();
+    let forwarding = test_forwarding_with_egress_mtu(1500);
+    let lookup = WorkerBindingLookup::from_bindings(&bindings);
+    let mirror_targets = MirrorTargetMap::default();
+    let mut pending = vec![test_live_forward_request_for_frame(
+        original_frame.len(),
+        test_forwarding_decision_to_bound_ifindex(22),
+    )];
+    let mut post_recycles = Vec::new();
+    let ingress_ident = bindings[0].identity();
+    let ingress_live = &*bindings[0].live as *const BindingLiveState;
+    let local_tunnel_deliveries: Arc<ArcSwap<BTreeMap<i32, SyncSender<Vec<u8>>>>> =
+        Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let worker_commands_by_id: BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>> = BTreeMap::new();
+    let mut dbg = DebugPollCounters::default();
+
+    // Force the cp2 enqueue to fail (owner queue full / TX congestion).
+    super::cos::FORCE_ENQUEUE_ERR.with(|c| c.set(true));
+
+    let (left, rest) = bindings.split_at_mut(0);
+    let (ingress, right) = rest.split_first_mut().expect("ingress binding");
+    enqueue_pending_forwards(
+        left,
+        0,
+        ingress,
+        right,
+        &lookup,
+        &mirror_targets,
+        &mut pending,
+        &mut post_recycles,
+        1,
+        &forwarding,
+        &ingress_ident,
+        unsafe { &*ingress_live },
+        None, // slow_path: None → reinject lands on slow_path_unavailable
+        &local_tunnel_deliveries,
+        &recent_exceptions,
+        &mut dbg,
+        0,
+        &worker_commands_by_id,
+    );
+
+    // (a) ingress descriptor recycled exactly once — the pre-fix `continue;`
+    // leaked it (would be 0).
+    assert_eq!(
+        ingress_recycled_count(&bindings[0]),
+        1,
+        "ingress descriptor must be recycled exactly once on enqueue failure"
+    );
+    // (b) handle_forward_build_failure ran (build_fail) AND it reinjected to
+    // the slow path (slow_path_drops, since slow_path=None). The pre-fix
+    // `continue;` skipped both even though it set the build-failure flags.
+    assert_eq!(dbg.build_fail, 1, "build-failure handler must run");
+    assert_eq!(
+        bindings[0].live.slow_path_drops.load(Ordering::Relaxed),
+        1,
+        "fallback_to_slow_path must reach the slow-path reinject"
+    );
+    // No successful TX was counted.
+    assert_eq!(dbg.enqueue_ok, 0, "no TX enqueue succeeded");
+    let reasons: Vec<String> = recent_exceptions
+        .lock()
+        .expect("exceptions")
+        .iter()
+        .map(|e| e.reason.clone())
+        .collect();
+    assert!(
+        reasons.iter().any(|r| r == "forward_build_failed"),
+        "build-failure exception recorded: {reasons:?}"
+    );
+    assert!(
+        reasons.iter().any(|r| r == "slow_path_unavailable"),
+        "slow-path reinject attempted (unavailable here): {reasons:?}"
+    );
+}
+
+#[test]
+fn oversized_forward_frame_recycles_ingress_descriptor_without_reinject() {
+    let _guard = ForceFaultGuard;
+    let (mut bindings, original_frame) = cp2_copy_fallback_harness();
+    let forwarding = test_forwarding_with_egress_mtu(1500);
+    let lookup = WorkerBindingLookup::from_bindings(&bindings);
+    let mirror_targets = MirrorTargetMap::default();
+    let mut pending = vec![test_live_forward_request_for_frame(
+        original_frame.len(),
+        test_forwarding_decision_to_bound_ifindex(22),
+    )];
+    let mut post_recycles = Vec::new();
+    let ingress_ident = bindings[0].identity();
+    let ingress_live = &*bindings[0].live as *const BindingLiveState;
+    let local_tunnel_deliveries: Arc<ArcSwap<BTreeMap<i32, SyncSender<Vec<u8>>>>> =
+        Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let worker_commands_by_id: BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>> = BTreeMap::new();
+    let mut dbg = DebugPollCounters::default();
+
+    // Force the built cp2 frame to be treated as oversized (undeliverable).
+    super::FORCE_OVERSIZED.with(|c| c.set(true));
+
+    let (left, rest) = bindings.split_at_mut(0);
+    let (ingress, right) = rest.split_first_mut().expect("ingress binding");
+    enqueue_pending_forwards(
+        left,
+        0,
+        ingress,
+        right,
+        &lookup,
+        &mirror_targets,
+        &mut pending,
+        &mut post_recycles,
+        1,
+        &forwarding,
+        &ingress_ident,
+        unsafe { &*ingress_live },
+        None,
+        &local_tunnel_deliveries,
+        &recent_exceptions,
+        &mut dbg,
+        0,
+        &worker_commands_by_id,
+    );
+
+    // (a) recycled exactly once — the pre-fix `continue;` leaked it.
+    assert_eq!(
+        ingress_recycled_count(&bindings[0]),
+        1,
+        "ingress descriptor must be recycled exactly once on oversized frame"
+    );
+    // (c) build-failure handler ran but did NOT reinject — an oversized frame
+    // is undeliverable, so slow_path_drops stays 0.
+    assert_eq!(dbg.build_fail, 1, "build-failure handler must run");
+    assert_eq!(
+        bindings[0].live.slow_path_drops.load(Ordering::Relaxed),
+        0,
+        "oversized frame must NOT be reinjected to the slow path"
+    );
+    assert_eq!(dbg.enqueue_ok, 0, "no TX enqueue succeeded");
+    let reasons: Vec<String> = recent_exceptions
+        .lock()
+        .expect("exceptions")
+        .iter()
+        .map(|e| e.reason.clone())
+        .collect();
+    assert!(
+        reasons.iter().any(|r| r == "oversized_forward_frame"),
+        "oversized exception recorded: {reasons:?}"
+    );
+    assert!(
+        !reasons.iter().any(|r| r == "slow_path_unavailable"),
+        "no slow-path reinject for an oversized frame: {reasons:?}"
+    );
+}
+
+#[test]
+fn enqueue_failure_conserves_free_frames_across_many_forwards() {
+    // Descriptor-conservation check: under sustained enqueue failure (TX
+    // congestion) every ingress descriptor must return to circulation. The
+    // pre-fix `continue;` leaked one per failed forward → pool exhaustion.
+    let _guard = ForceFaultGuard;
+    let mut bindings = vec![
+        BindingWorker::new_for_mirror_test(0, 0, 11, 0),
+        BindingWorker::new_for_mirror_test(1, 0, 22, 0),
+    ];
+    let original_frame = build_ipv4_test_packet(0);
+    // Lay the same frame down at N distinct ingress UMEM offsets and drive N
+    // requests, each referencing its own descriptor.
+    const N: usize = 16;
+    let mut pending = Vec::with_capacity(N);
+    for i in 0..N {
+        let offset = (i as u64) << super::UMEM_FRAME_SHIFT;
+        unsafe {
+            bindings[0]
+                .umem
+                .area()
+                .slice_mut_unchecked(offset as usize, original_frame.len())
+        }
+        .expect("ingress frame")
+        .copy_from_slice(&original_frame);
+        let mut req = test_live_forward_request_for_frame(
+            original_frame.len(),
+            test_forwarding_decision_to_bound_ifindex(22),
+        );
+        req.desc.addr = offset;
+        pending.push(req);
+    }
+    bindings[1].tx_pipeline.free_tx_frames.clear();
+
+    let forwarding = test_forwarding_with_egress_mtu(1500);
+    let lookup = WorkerBindingLookup::from_bindings(&bindings);
+    let mirror_targets = MirrorTargetMap::default();
+    let mut post_recycles = Vec::new();
+    let ingress_ident = bindings[0].identity();
+    let ingress_live = &*bindings[0].live as *const BindingLiveState;
+    let local_tunnel_deliveries: Arc<ArcSwap<BTreeMap<i32, SyncSender<Vec<u8>>>>> =
+        Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let worker_commands_by_id: BTreeMap<u32, Arc<Mutex<VecDeque<WorkerCommand>>>> = BTreeMap::new();
+    let mut dbg = DebugPollCounters::default();
+
+    super::cos::FORCE_ENQUEUE_ERR.with(|c| c.set(true));
+
+    let (left, rest) = bindings.split_at_mut(0);
+    let (ingress, right) = rest.split_first_mut().expect("ingress binding");
+    enqueue_pending_forwards(
+        left,
+        0,
+        ingress,
+        right,
+        &lookup,
+        &mirror_targets,
+        &mut pending,
+        &mut post_recycles,
+        1,
+        &forwarding,
+        &ingress_ident,
+        unsafe { &*ingress_live },
+        None,
+        &local_tunnel_deliveries,
+        &recent_exceptions,
+        &mut dbg,
+        0,
+        &worker_commands_by_id,
+    );
+
+    assert_eq!(
+        ingress_recycled_count(&bindings[0]),
+        N,
+        "every ingress descriptor must be recycled exactly once — no leak, \
+         no double-recycle"
+    );
+    assert_eq!(dbg.build_fail as usize, N, "every forward hit build failure");
+    assert_eq!(
+        bindings[0].live.slow_path_drops.load(Ordering::Relaxed) as usize,
+        N,
+        "every failed forward reinjected to the slow path"
+    );
+}
+
 #[test]
 fn shared_exact_policy_uses_requested_queue_id() {
     let cos_fast_interfaces = test_cos_fast_interfaces(80, 5, &[(5, true)]);

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -60,6 +60,28 @@ pub(in crate::afxdp) use slow_path::{
 // pre-split sibling-tx/ visibility verbatim.
 pub(in crate::afxdp::tx) use slow_path::{extract_l3_packet, extract_l3_packet_from_frame};
 
+// #2208: test-only fault injection for the oversized-frame control flow.
+// A built copy-path frame larger than `tx_frame_capacity()` (4096) cannot
+// be produced from a single in-UMEM ingress frame in a unit test (the
+// frame itself is capped at one UMEM frame), so this thread-local lets the
+// dispatch tests force the oversized branch to prove it recycles the
+// ingress descriptor (the pre-fix bare `continue;` leaked it). It is
+// `#[cfg(test)]` only and DCEs out of release builds — the hot path keeps
+// the bare `cp_len > tx_frame_capacity()` comparison with zero added cost.
+#[cfg(test)]
+thread_local! {
+    static FORCE_OVERSIZED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[inline(always)]
+fn copy_frame_is_oversized(cp_len: usize) -> bool {
+    #[cfg(test)]
+    if FORCE_OVERSIZED.with(|c| c.get()) {
+        return true;
+    }
+    cp_len > tx_frame_capacity()
+}
+
 #[inline]
 fn recycle_ingress_frame(ingress_binding: &mut BindingWorker, source_offset: u64, now_ns: u64) {
     ingress_binding
@@ -571,7 +593,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                     }
                                 }
                                 let cp1_len = frame.len();
-                                if cp1_len > tx_frame_capacity() {
+                                if copy_frame_is_oversized(cp1_len) {
                                     record_exception(
                                         recent_exceptions,
                                         ingress_ident,
@@ -581,33 +603,56 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                         None,
                                         forwarding,
                                     );
-                                    continue;
-                                }
-                                let req = TxRequest {
-                                    bytes: frame,
-                                    expected_ports,
-                                    expected_addr_family: request.meta.addr_family,
-                                    expected_protocol: request.meta.protocol,
-                                    flow_key: flow_key.take(),
-                                    egress_ifindex: request.decision.resolution.egress_ifindex,
-                                    cos_queue_id: request.cos_queue_id,
-                                    dscp_rewrite: request.dscp_rewrite,
-                                    mirror_clone: false,
-                                    enqueue_ns: 0,
-                                };
-                                if enqueue_local_request_to_target_or_owner(target_binding, req)
-                                    .is_err()
-                                {
+                                    // #2208: an oversized built frame is
+                                    // undeliverable. Fall through to the
+                                    // finalizer so the ingress descriptor is
+                                    // recycled to the fill ring (the bare
+                                    // `continue;` here leaked it). Do NOT set
+                                    // fallback_to_slow_path — reinjecting an
+                                    // already-oversized frame to the kernel
+                                    // slow path is pointless; matching the
+                                    // direct-TX oversized branch above, we
+                                    // drop-and-recycle.
                                     build_failed = true;
-                                    fallback_to_slow_path = true;
-                                    continue;
-                                }
-                                dbg.enqueue_ok += 1;
-                                dbg.enqueue_copy += 1;
-                                target_binding.tx_counters.pending_copy_tx_packets += 1;
-                                dbg.tx_bytes_total += cp1_len as u64;
-                                if (cp1_len as u32) > dbg.tx_max_frame {
-                                    dbg.tx_max_frame = cp1_len as u32;
+                                } else {
+                                    let req = TxRequest {
+                                        bytes: frame,
+                                        expected_ports,
+                                        expected_addr_family: request.meta.addr_family,
+                                        expected_protocol: request.meta.protocol,
+                                        flow_key: flow_key.take(),
+                                        egress_ifindex: request.decision.resolution.egress_ifindex,
+                                        cos_queue_id: request.cos_queue_id,
+                                        dscp_rewrite: request.dscp_rewrite,
+                                        mirror_clone: false,
+                                        enqueue_ns: 0,
+                                    };
+                                    if enqueue_local_request_to_target_or_owner(target_binding, req)
+                                        .is_err()
+                                    {
+                                        // #2208: a full cross-binding CoS-owner
+                                        // queue (TX congestion) returns Err and
+                                        // drops the TxRequest. Set the
+                                        // build-failure flags and FALL THROUGH
+                                        // to the finalizer — the old bare
+                                        // `continue;` skipped both
+                                        // handle_forward_build_failure (no
+                                        // slow-path reinject, contradicting the
+                                        // flags) AND recycle_ingress_frame
+                                        // (leaking the ingress descriptor). The
+                                        // finalizer reinjects from source_frame,
+                                        // so the dropped req is irrelevant.
+                                        build_failed = true;
+                                        fallback_to_slow_path = true;
+                                    } else {
+                                        dbg.enqueue_ok += 1;
+                                        dbg.enqueue_copy += 1;
+                                        target_binding.tx_counters.pending_copy_tx_packets += 1;
+                                        dbg.tx_bytes_total += cp1_len as u64;
+                                        if (cp1_len as u32) > dbg.tx_max_frame {
+                                            dbg.tx_max_frame = cp1_len as u32;
+                                        }
+                                    }
                                 }
                             }
                             None => {
@@ -852,7 +897,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                     }
                                 }
                                 let cp2_len = frame.len();
-                                if cp2_len > tx_frame_capacity() {
+                                if copy_frame_is_oversized(cp2_len) {
                                     record_exception(
                                         recent_exceptions,
                                         ingress_ident,
@@ -862,33 +907,49 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                                         None,
                                         forwarding,
                                     );
-                                    continue;
-                                }
-                                let req = TxRequest {
-                                    bytes: frame,
-                                    expected_ports,
-                                    expected_addr_family: request.meta.addr_family,
-                                    expected_protocol: request.meta.protocol,
-                                    flow_key: flow_key.take(),
-                                    egress_ifindex: request.decision.resolution.egress_ifindex,
-                                    cos_queue_id: request.cos_queue_id,
-                                    dscp_rewrite: request.dscp_rewrite,
-                                    mirror_clone: false,
-                                    enqueue_ns: 0,
-                                };
-                                if enqueue_local_request_to_target_or_owner(target_binding, req)
-                                    .is_err()
-                                {
+                                    // #2208: oversized fallback-copy frame —
+                                    // undeliverable. Fall through to the
+                                    // finalizer (recycle the ingress
+                                    // descriptor); the bare `continue;` here
+                                    // leaked it. Drop-and-recycle, no slow-path
+                                    // reinject (the frame is already oversized).
                                     build_failed = true;
-                                    fallback_to_slow_path = true;
-                                    continue;
-                                }
-                                dbg.enqueue_ok += 1;
-                                dbg.enqueue_copy += 1;
-                                target_binding.tx_counters.pending_copy_tx_packets += 1;
-                                dbg.tx_bytes_total += cp2_len as u64;
-                                if (cp2_len as u32) > dbg.tx_max_frame {
-                                    dbg.tx_max_frame = cp2_len as u32;
+                                } else {
+                                    let req = TxRequest {
+                                        bytes: frame,
+                                        expected_ports,
+                                        expected_addr_family: request.meta.addr_family,
+                                        expected_protocol: request.meta.protocol,
+                                        flow_key: flow_key.take(),
+                                        egress_ifindex: request.decision.resolution.egress_ifindex,
+                                        cos_queue_id: request.cos_queue_id,
+                                        dscp_rewrite: request.dscp_rewrite,
+                                        mirror_clone: false,
+                                        enqueue_ns: 0,
+                                    };
+                                    if enqueue_local_request_to_target_or_owner(target_binding, req)
+                                        .is_err()
+                                    {
+                                        // #2208: cross-binding CoS-owner queue
+                                        // full (TX congestion). Set the
+                                        // build-failure flags and FALL THROUGH
+                                        // to the finalizer instead of the old
+                                        // bare `continue;`, which skipped both
+                                        // handle_forward_build_failure (the
+                                        // slow-path reinject the flags request)
+                                        // AND recycle_ingress_frame (leaking the
+                                        // ingress descriptor under congestion).
+                                        build_failed = true;
+                                        fallback_to_slow_path = true;
+                                    } else {
+                                        dbg.enqueue_ok += 1;
+                                        dbg.enqueue_copy += 1;
+                                        target_binding.tx_counters.pending_copy_tx_packets += 1;
+                                        dbg.tx_bytes_total += cp2_len as u64;
+                                        if (cp2_len as u32) > dbg.tx_max_frame {
+                                            dbg.tx_max_frame = cp2_len as u32;
+                                        }
+                                    }
                                 }
                             }
                             None => {


### PR DESCRIPTION
Fixes #2208.

## Problem

`enqueue_pending_forwards` (the per-tick forwarding dispatcher) had four
bare `continue;` statements in the copy paths that jumped to the next
loop iteration BEFORE the per-request finalizer:

- cp1 oversized (built frame > `tx_frame_capacity()`)
- cp1 cross-binding CoS-owner enqueue failed
- cp2 oversized
- cp2 enqueue failed

`recycle_ingress_frame` — run only by the finalizer — is the SOLE path
that returns the ingress descriptor to `pending_fill_frames` → the fill
ring. The RX worker already released the descriptor from the RX ring and
the frame is read directly out of ingress UMEM, so skipping recycle
**permanently leaks the descriptor**. The UMEM is a fixed pre-allocated
pool, so a sustained TX-congestion episode (a cross-binding CoS owner's
bounded queue filling) or a burst of oversized frames drains the pool one
descriptor per failed forward until RX can no longer acquire frames and
the worker wedges (CRITICAL — no recovery without restart).

The two enqueue-failure sites additionally set `build_failed = true;
fallback_to_slow_path = true;` then `continue`, so
`handle_forward_build_failure` (the slow-path reinject the flags were
asking for) was ALSO skipped — directly contradicting the flags.

Present since `73ad37083` (frame_tx split) and `e4ae9eebc` (exact-cos
path); not touched by the recent #2148/#2189/#2150/#2207 work.

## Fix (pure control flow — no per-packet allocation)

Make all four sites fall through to the finalizer instead of `continue`:

- **enqueue-failure (cp1/cp2):** restructured `if enqueue(...).is_err()`
  into an if/else — the Err arm sets the build-failure flags and reaches
  the finalizer (recycle + reinject from `source_frame`; the failed
  enqueue already consumed/dropped the `TxRequest`), the Ok arm keeps the
  success counters.
- **oversized (cp1/cp2):** set `build_failed = true` (no
  `fallback_to_slow_path` — an oversized frame is undeliverable and
  reinjecting it is pointless, matching the existing direct-TX oversized
  drop-and-recycle branch) and fall through so the finalizer recycles.

`retained_source_frame` is false on all four paths (true only on the
in-place-rewrite branch, where the descriptor IS the TX frame), so the
finalizer recycles each descriptor **exactly once** — no leak, no
double-recycle. The success path is unchanged.

## Tests

Three dispatch tests drive `enqueue_pending_forwards` through the cp2
copy fallback and assert:

- ingress descriptor recycled **exactly once** (fill-ring pending +
  `pending_fill_frames`), never 0 (leak) or 2 (double-recycle);
- enqueue-failure path runs `handle_forward_build_failure` + its
  slow-path reinject (`build_fail` + `slow_path_drops` bumped);
- oversized path recycles but does NOT reinject (`slow_path_drops` == 0);
- N-forward descriptor conservation under sustained enqueue failure.

All three **FAIL against the pre-fix `continue;`** (recycle count == 0)
and pass with the fix. Two `#[cfg(test)]`-only thread-locals
(`FORCE_ENQUEUE_ERR`, `FORCE_OVERSIZED`) drive the otherwise hard-to-reach
branches (`enqueue_tx_owned` swallows overflow today; an oversized built
frame cannot come from a single in-UMEM ingress frame) and DCE out of
release builds. 5x single-threaded flake clean; forwarding (159),
afxdp::tx (67), poll_descriptor (17) suites green; release build +
clippy clean.

## Docs

`afxdp/README.md` gains a `tx/dispatch/` subsection documenting the
recycle-on-every-path invariant.

## Validation status

- [x] Release build clean (warnings pre-existing)
- [x] New tests fail pre-fix / pass post-fix, 5x flake clean
- [x] forwarding / afxdp::tx / poll_descriptor suites green
- [x] clippy clean on new code
- [ ] **PENDING-PARENT:** loss-cluster dataplane smoke (line-rate + a
  TX-congestion/queue-fill repro confirming no UMEM-pool exhaustion over
  sustained load). This is HOT-PATH dataplane and must be run centrally
  by the parent.

## Claude SMR self-review

- **Recycle exactly once on every path:** audited all per-request exits.
  CoS-drop (114), prebuilt no-binding/enqueue-fail (168/199), prebuilt
  success (209), Live-slice-fail (224), no-egress-binding /
  fabric-redirect (288/309), and the two finalizer arms (942/947) each
  recycle once; the four fixed sites now fall through to 947. The only
  no-recycle exit is `retained_source_frame == true` (in-place rewrite),
  where `PreparedTxRecycle::fill_on_slot` recycles on TX completion.
- **No double-recycle:** the fixed branches never push to a TX pipeline
  that owns the source descriptor and never set `retained_source_frame`,
  so exactly the single finalizer recycle runs.
- **Dropped `TxRequest` on Err:** `enqueue_local_request_to_target_or_owner`
  returns `Err(req)` and the req is dropped; the finalizer reinjects from
  `source_frame` (in-UMEM), so the dropped req does not matter.
- **Hot-path purity:** the change is fall-through vs `continue`; no new
  allocation. `copy_frame_is_oversized` reduces to the original
  comparison in release (the `#[cfg(test)]` block is removed).
- **Reachability caveat (documented):** the enqueue-failure Err arm is
  latent today because `enqueue_tx_owned` swallows overflow; the oversized
  arm IS live. Both are on the compiled hot path and the fix is correct
  for the moment backpressure is surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
