### PR TITLE
#2214: empty NAT64 pool / zero-term filter serialize as JSON null -> whole-snapshot decode abort -> no transit

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -8602,3 +8602,27 @@ top.
   userspace-dp/src/afxdp/types/shared_cos_lease/lease.rs,
   userspace-dp/src/afxdp/types/shared_cos_lease/shared_cos_lease_tests.rs,
   docs/refactoring-audit-current.txt
+
+- **Timestamp**: 2026-06-21
+- **Action**: #2214 — fix Go<->Rust empty-collection null-decode no-transit
+  bug (#1961-class). A NAT64 rule with no resolvable source-pool emitted
+  `pool_addresses:null` and a firewall filter with zero terms emitted
+  `terms:null`; the Rust helper's `Vec<T>` decoder rejects an explicit null
+  ("invalid type: null, expected a sequence"), aborting the WHOLE
+  apply_snapshot decode -> helper EOF -> enabled:false -> NO TRANSIT.
+  BOTH-sided fix: Go builders now initialize the two slices non-nil so they
+  marshal as `[]` (buildNAT64Snapshots, buildFilterTermSnapshots — no
+  `,omitempty`, the empty states are meaningful, WireUint8List convention);
+  Rust adds a generic `null_tolerant_vec` deserializer (protocol/mod.rs)
+  applied to NAT64RuleSnapshot.pool_addresses + FirewallFilterSnapshot.terms
+  for mixed-version safety. Audited protocol.go: ONLY these two slice fields
+  lacked omitempty (no other hazard). Fail-on-revert proven on both sides
+  (Go: 4 tests fail with `"pool_addresses":null`; Rust: 3 tests panic with
+  the exact serde "expected a sequence" error). Go tests + go vet clean;
+  cargo release build clean (145 pre-existing warnings, none on changed
+  files); 68 Rust protocol tests pass.
+- **File(s)**: pkg/dataplane/userspace/nat.go,
+  pkg/dataplane/userspace/filters.go,
+  pkg/dataplane/userspace/protocol_null_collections_2214_test.go,
+  userspace-dp/src/protocol/mod.rs, userspace-dp/src/protocol/nat.rs,
+  userspace-dp/src/protocol/security.rs, userspace-dp/src/protocol/tests.rs

--- a/pkg/dataplane/userspace/filters.go
+++ b/pkg/dataplane/userspace/filters.go
@@ -54,8 +54,14 @@ func buildFirewallFilterSnapshots(cfg *config.Config) []FirewallFilterSnapshot {
 }
 
 func buildFilterTermSnapshots(filter *config.FirewallFilter, cfg *config.Config) []FirewallTermSnapshot {
+	// #2214: return a non-nil empty slice (never nil) so the enclosing
+	// FirewallFilterSnapshot.Terms marshals as `[]`, never JSON `null`. The
+	// Terms field has no `,omitempty` (the compiler can store a filter with
+	// zero terms — see compileFirewall) and the Rust `Vec<FirewallTermSnapshot>`
+	// rejects an explicit null, which aborts the whole snapshot decode and
+	// kills ALL transit (#1961 no-transit signature).
 	if filter == nil || len(filter.Terms) == 0 {
-		return nil
+		return []FirewallTermSnapshot{}
 	}
 	terms := make([]FirewallTermSnapshot, 0, len(filter.Terms))
 	for _, term := range filter.Terms {

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -292,7 +292,13 @@ func buildNAT64Snapshots(cfg *config.Config) []NAT64RuleSnapshot {
 		if rs == nil || rs.Prefix == "" {
 			continue
 		}
-		var poolAddresses []string
+		// #2214: initialize non-nil so a rule with no resolvable source pool
+		// marshals `pool_addresses` as `[]`, never JSON `null`. The field has
+		// no `,omitempty` (an empty pool is still a meaningful "no source-pool
+		// resolved" state the dataplane must see), and the Rust `Vec<String>`
+		// rejects an explicit null — which aborts the whole snapshot decode and
+		// kills ALL transit (#1961 no-transit signature).
+		poolAddresses := []string{}
 		if rs.SourcePool != "" {
 			if pool, ok := cfg.Security.NAT.SourcePools[rs.SourcePool]; ok && pool != nil {
 				if pool.Address != "" {

--- a/pkg/dataplane/userspace/protocol_null_collections_2214_test.go
+++ b/pkg/dataplane/userspace/protocol_null_collections_2214_test.go
@@ -1,0 +1,163 @@
+package userspace
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2214 (HIGH, #1961-class): a nil Go slice on a snapshot field declared
+// WITHOUT `,omitempty` marshals as JSON `null`. The Rust helper decodes
+// NAT64RuleSnapshot.pool_addresses and FirewallFilterSnapshot.terms as
+// `Vec<T>`, which rejects an explicit `null` ("invalid type: null, expected a
+// sequence") and aborts the ENTIRE apply_snapshot decode -> helper EOF ->
+// enabled:false -> NO TRANSIT for the whole config.
+//
+// Two reachable triggers verified in the issue:
+//   A: a NAT64 rule with a prefix but no resolvable source-pool -> the Go
+//      builder leaves pool_addresses nil.
+//   B: a firewall filter declared with zero terms -> the Go builder returns
+//      nil terms.
+//
+// The fix initializes both slices non-nil at the build site so they marshal as
+// `[]`. These tests FAIL on the pre-fix code (the marshaled wire carries `null`
+// for those keys) and pass after — they are the no-transit-prevention proof on
+// the Go side. The Rust side independently tolerates `null` (see
+// userspace-dp/src/protocol/{nat,security}.rs + the config_snapshot_*_null
+// tests) for cross-version safety.
+
+// nat64NoPoolCfg builds a config with a single NAT64 rule whose source-pool is
+// absent, so buildNAT64Snapshots resolves zero pool addresses.
+func nat64NoPoolCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.NAT.NAT64 = []*config.NAT64RuleSet{
+		{Name: "rs1", Prefix: "64:ff9b::/96"}, // no SourcePool
+	}
+	return cfg
+}
+
+// emptyFilterCfg builds a config with a single inet filter declared with zero
+// terms (the compiler stores the filter regardless of term count).
+func emptyFilterCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"EMPTY": {Name: "EMPTY"}, // Terms == nil
+	}
+	return cfg
+}
+
+// fieldRawMessage marshals v, decodes it as a generic object, and returns the
+// raw JSON bytes for the named top-level key (or the empty string if absent).
+func fieldRawMessage(t *testing.T, v any, key string) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(b, &obj); err != nil {
+		t.Fatalf("unmarshal to object: %v", err)
+	}
+	raw, ok := obj[key]
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func TestNAT64EmptyPoolMarshalsEmptyArrayNotNull(t *testing.T) {
+	rules := buildNAT64Snapshots(nat64NoPoolCfg())
+	if len(rules) != 1 {
+		t.Fatalf("buildNAT64Snapshots = %d rules, want 1 (rule must NOT be dropped)", len(rules))
+	}
+	if rules[0].PoolAddresses == nil {
+		t.Fatal("PoolAddresses is nil; the Go builder must initialize it non-nil so it marshals as [] not null (#2214)")
+	}
+	raw := fieldRawMessage(t, rules[0], "pool_addresses")
+	if raw == "null" || raw == "" {
+		t.Fatalf("pool_addresses marshaled as %q, want \"[]\" — a null aborts the Rust snapshot decode (#2214 no-transit)", raw)
+	}
+	if raw != "[]" {
+		t.Fatalf("pool_addresses = %q, want \"[]\"", raw)
+	}
+}
+
+func TestEmptyFilterTermsMarshalsEmptyArrayNotNull(t *testing.T) {
+	filters := buildFirewallFilterSnapshots(emptyFilterCfg())
+	if len(filters) != 1 {
+		t.Fatalf("buildFirewallFilterSnapshots = %d filters, want 1", len(filters))
+	}
+	if filters[0].Terms == nil {
+		t.Fatal("Terms is nil; the Go builder must return a non-nil empty slice so it marshals as [] not null (#2214)")
+	}
+	raw := fieldRawMessage(t, filters[0], "terms")
+	if raw == "null" || raw == "" {
+		t.Fatalf("terms marshaled as %q, want \"[]\" — a null aborts the Rust snapshot decode (#2214 no-transit)", raw)
+	}
+	if raw != "[]" {
+		t.Fatalf("terms = %q, want \"[]\"", raw)
+	}
+}
+
+// buildFilterTermSnapshots returns a non-nil empty slice for a filter with no
+// terms (covers nil filter and the all-nil-terms case too).
+func TestBuildFilterTermSnapshotsNeverNil(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		filter *config.FirewallFilter
+	}{
+		{"nil filter", nil},
+		{"zero terms", &config.FirewallFilter{Name: "F"}},
+		{"all-nil terms", &config.FirewallFilter{Name: "F", Terms: []*config.FirewallFilterTerm{nil, nil}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildFilterTermSnapshots(tc.filter, &config.Config{})
+			if got == nil {
+				t.Fatalf("buildFilterTermSnapshots(%s) = nil, want non-nil empty slice (#2214)", tc.name)
+			}
+			if len(got) != 0 {
+				t.Fatalf("buildFilterTermSnapshots(%s) len = %d, want 0", tc.name, len(got))
+			}
+		})
+	}
+}
+
+// End-to-end: the full ConfigSnapshot wire emitted for a config that hits BOTH
+// triggers must contain `[]` (never null) for both keys. This is the wire-shape
+// guarantee the Rust decoder relies on; a regression here reintroduces the
+// whole-snapshot decode abort.
+func TestSnapshotWireNoNullCollections2214(t *testing.T) {
+	cfg := nat64NoPoolCfg()
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"EMPTY": {Name: "EMPTY"},
+	}
+	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+
+	if len(snap.NAT64) != 1 {
+		t.Fatalf("snap.NAT64 = %d, want 1", len(snap.NAT64))
+	}
+	if len(snap.Filters) != 1 {
+		t.Fatalf("snap.Filters = %d, want 1", len(snap.Filters))
+	}
+
+	b, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	wire := string(b)
+	if strings.Contains(wire, `"pool_addresses":null`) {
+		t.Fatal(`snapshot wire contains "pool_addresses":null — Rust Vec<String> rejects null and aborts the whole decode (#2214)`)
+	}
+	if strings.Contains(wire, `"terms":null`) {
+		t.Fatal(`snapshot wire contains "terms":null — Rust Vec<FirewallTermSnapshot> rejects null and aborts the whole decode (#2214)`)
+	}
+	// Positive: the empty collections are present as [].
+	if !strings.Contains(wire, `"pool_addresses":[]`) {
+		t.Fatal(`snapshot wire missing "pool_addresses":[] for the empty-pool NAT64 rule (#2214)`)
+	}
+	if !strings.Contains(wire, `"terms":[]`) {
+		t.Fatal(`snapshot wire missing "terms":[] for the zero-term filter (#2214)`)
+	}
+}

--- a/userspace-dp/src/protocol/mod.rs
+++ b/userspace-dp/src/protocol/mod.rs
@@ -46,3 +46,30 @@ pub(crate) use nat::*;
 pub(crate) use resolution::*;
 pub(crate) use security::*;
 pub(crate) use snapshot::*;
+
+/// Deserialize a `Vec<T>` that tolerates an explicit JSON `null` as an empty
+/// vector (#2214).
+///
+/// `#[serde(default)]` alone only supplies a value when the KEY IS ABSENT; an
+/// explicit `null` is still handed to the field's `Deserialize` impl, and
+/// `Vec<T>::deserialize` rejects `null` with `invalid type: null, expected a
+/// sequence`. For a field on `ConfigSnapshot` (or any nested snapshot type)
+/// that rejection aborts the ENTIRE `apply_snapshot` decode — the helper
+/// returns an error before responding, closes the control socket, the Go side
+/// sees a bare EOF, the helper stays in bootstrap (`enabled:false`), and the
+/// dataplane forwards NOTHING. This is the #1961 no-transit signature.
+///
+/// A nil Go slice declared WITHOUT `,omitempty` marshals as JSON `null`, so any
+/// such field is one un-resolvable config away from this crash (e.g. a NAT64
+/// rule with an empty source-pool -> `pool_addresses:null`, or a firewall
+/// filter with zero terms -> `terms:null`). Pair this null-tolerant decoder
+/// with `,omitempty` (or an empty-not-nil slice) on the Go side so the wire is
+/// robust across mixed-version Go/Rust pairs in BOTH directions.
+pub(crate) fn null_tolerant_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    use serde::Deserialize as _;
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
+}

--- a/userspace-dp/src/protocol/nat.rs
+++ b/userspace-dp/src/protocol/nat.rs
@@ -74,7 +74,15 @@ pub(crate) struct NAT64RuleSnapshot {
     pub name: String,
     #[serde(default)]
     pub prefix: String,
-    #[serde(rename = "pool_addresses", default)]
+    // #2214: null-tolerant. A NAT64 rule with no resolvable source pool
+    // makes the Go builder emit `pool_addresses:null` (nil slice, no
+    // `,omitempty`); plain `default` would only cover an ABSENT key, so an
+    // explicit null would abort the whole snapshot decode (#1961 no-transit).
+    #[serde(
+        rename = "pool_addresses",
+        default,
+        deserialize_with = "crate::protocol::null_tolerant_vec"
+    )]
     pub pool_addresses: Vec<String>,
     /// Mirrors `security nat natv6v4 no-v6-frag-header`. This is an
     /// option-gated LOCAL DF policy (not the size-driven RFC 7915 5.1

--- a/userspace-dp/src/protocol/security.rs
+++ b/userspace-dp/src/protocol/security.rs
@@ -53,7 +53,11 @@ pub(crate) struct FirewallFilterSnapshot {
     pub name: String,
     #[serde(default)]
     pub family: String,
-    #[serde(default)]
+    // #2214: null-tolerant. A filter declared with zero terms makes the Go
+    // builder emit `terms:null` (nil slice, no `,omitempty`); plain `default`
+    // only covers an ABSENT key, so an explicit null would abort the whole
+    // snapshot decode (#1961 no-transit).
+    #[serde(default, deserialize_with = "crate::protocol::null_tolerant_vec")]
     pub terms: Vec<FirewallTermSnapshot>,
 }
 

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1100,6 +1100,94 @@ fn config_snapshot_decodes_without_app_catalog() {
         "snapshot without app_catalog must decode to an empty catalog (HA/upgrade compat)");
 }
 
+// #2214 (HIGH, #1961-class): a NAT64 rule with no resolvable source pool makes
+// the Go builder emit `pool_addresses:null` (nil slice, no `,omitempty`). Plain
+// `#[serde(default)]` only fills an ABSENT key; an explicit null is still handed
+// to `Vec<String>::deserialize`, which rejects it ("invalid type: null,
+// expected a sequence") and aborts the ENTIRE ConfigSnapshot decode -> helper
+// EOF -> enabled:false -> NO TRANSIT. These tests pin the null-tolerant decoder
+// so a mixed-version Go binary that still emits null decodes cleanly.
+//
+// FAIL-ON-REVERT: drop the `deserialize_with = "crate::protocol::null_tolerant_vec"`
+// attribute on NAT64RuleSnapshot.pool_addresses / FirewallFilterSnapshot.terms
+// and the two `*_null` snapshot tests below fail with the serde "expected a
+// sequence" error — i.e. the whole snapshot decode aborts, exactly the
+// no-transit signature.
+#[test]
+fn nat64_rule_snapshot_tolerates_null_pool_addresses() {
+    // An explicit null (not absent) must decode to an empty Vec, not error.
+    let json = r#"{"name":"rs1","prefix":"64:ff9b::/96","pool_addresses":null}"#;
+    let rule: NAT64RuleSnapshot =
+        serde_json::from_str(json).expect("NAT64 rule with pool_addresses:null must decode (#2214)");
+    assert_eq!(rule.name, "rs1");
+    assert_eq!(rule.prefix, "64:ff9b::/96");
+    assert!(
+        rule.pool_addresses.is_empty(),
+        "pool_addresses:null must decode to an empty Vec"
+    );
+    // Absent key (omitempty path) still works.
+    let absent: NAT64RuleSnapshot =
+        serde_json::from_str(r#"{"name":"rs1","prefix":"64:ff9b::/96"}"#)
+            .expect("NAT64 rule with absent pool_addresses must decode");
+    assert!(absent.pool_addresses.is_empty());
+    // A populated array still round-trips.
+    let full: NAT64RuleSnapshot = serde_json::from_str(
+        r#"{"name":"rs1","prefix":"64:ff9b::/96","pool_addresses":["192.0.2.1","192.0.2.2"]}"#,
+    )
+    .expect("populated pool_addresses must decode");
+    assert_eq!(full.pool_addresses, vec!["192.0.2.1", "192.0.2.2"]);
+}
+
+#[test]
+fn firewall_filter_snapshot_tolerates_null_terms() {
+    let json = r#"{"name":"EMPTY","family":"inet","terms":null}"#;
+    let filter: FirewallFilterSnapshot =
+        serde_json::from_str(json).expect("filter with terms:null must decode (#2214)");
+    assert_eq!(filter.name, "EMPTY");
+    assert_eq!(filter.family, "inet");
+    assert!(filter.terms.is_empty(), "terms:null must decode to an empty Vec");
+    // Absent key still works.
+    let absent: FirewallFilterSnapshot =
+        serde_json::from_str(r#"{"name":"EMPTY","family":"inet"}"#)
+            .expect("filter with absent terms must decode");
+    assert!(absent.terms.is_empty());
+    // Populated terms still round-trip.
+    let full: FirewallFilterSnapshot = serde_json::from_str(
+        r#"{"name":"F","family":"inet","terms":[{"name":"t1","action":"accept"}]}"#,
+    )
+    .expect("populated terms must decode");
+    assert_eq!(full.terms.len(), 1);
+    assert_eq!(full.terms[0].name, "t1");
+    assert_eq!(full.terms[0].action, "accept");
+}
+
+// The whole-snapshot guarantee: a ConfigSnapshot whose nat64_rules[].pool_addresses
+// AND filters[].terms are both explicit null must STILL decode in full (no abort).
+// This is the no-transit-prevention test — pre-fix this returned a serde error,
+// which is exactly the failure the Go side sees as helper EOF / enabled:false.
+#[test]
+fn config_snapshot_decodes_with_null_collections_2214() {
+    let json = r#"{
+        "version": 3,
+        "generation": 1,
+        "generated_at": "2024-01-01T00:00:00Z",
+        "summary": {"host_name":"h","dataplane_type":"userspace","interface_count":0,
+                    "zone_count":0,"policy_count":0,"scheduler_count":0,"ha_enabled":false},
+        "nat64_rules": [
+            {"name":"rs1","prefix":"64:ff9b::/96","pool_addresses":null}
+        ],
+        "filters": [
+            {"name":"EMPTY","family":"inet","terms":null}
+        ]
+    }"#;
+    let snap: ConfigSnapshot = serde_json::from_str(json)
+        .expect("snapshot with null pool_addresses + null terms must decode in full (#2214 no-transit)");
+    assert_eq!(snap.nat64_rules.len(), 1);
+    assert!(snap.nat64_rules[0].pool_addresses.is_empty());
+    assert_eq!(snap.filters.len(), 1);
+    assert!(snap.filters[0].terms.is_empty());
+}
+
 #[test]
 fn app_catalog_entry_roundtrip() {
     let e = AppCatalogEntry {


### PR DESCRIPTION
Fixes #2214 (HIGH, #1961-class).

## The bug
A nil Go slice on a `ConfigSnapshot` field declared WITHOUT `,omitempty`
marshals as JSON `null`. Two ordinary one-line configs hit this:

- **NAT64 rule with no resolvable source-pool** — `buildNAT64Snapshots`
  still emits the rule but leaves `NAT64RuleSnapshot.PoolAddresses` nil
  (`pkg/dataplane/userspace/nat.go`), so the wire carries
  `"pool_addresses":null`.
- **Firewall filter declared with zero terms** — the compiler stores the
  filter regardless of term count, and `buildFilterTermSnapshots` returns
  nil terms (`pkg/dataplane/userspace/filters.go`), so the wire carries
  `"terms":null`.

The Rust helper decodes both fields as `Vec<T>`. With only
`#[serde(default)]`, an explicit `null` is still handed to
`Vec<T>::deserialize`, which rejects it (`invalid type: null, expected a
sequence`) and aborts the ENTIRE `apply_snapshot` decode -> helper returns
an error before responding -> control socket closes -> Go side sees a bare
EOF -> helper stays in bootstrap (`enabled:false`) -> the dataplane forwards
NOTHING. This is the exact #1961 no-transit signature, reachable from a
single ordinary stanza, and it kills ALL transit, not just the affected
feature.

## The fix (BOTH-sided, #1961/#1976/#1977 pattern)
- **Go producer** — initialize both slices non-nil at the build site so
  they marshal as `[]`, never `null`. `,omitempty` is deliberately NOT
  used: an empty pool ("no source-pool resolved") and a zero-term filter
  are meaningful states the dataplane must still see; emitting `[]` keeps
  the field present, matching the `WireUint8List` (#1961) convention.
- **Rust consumer** — add a generic `null_tolerant_vec` deserializer
  (`protocol/mod.rs`, absolute-path attribute convention mirroring
  `u64_is_zero`) that decodes `null` -> empty Vec while leaving the
  absent-key (`default`) and populated-sequence paths unchanged. Applied
  to `NAT64RuleSnapshot.pool_addresses` and `FirewallFilterSnapshot.terms`.
  Deserialize-only; the serialize path is unchanged. This keeps
  mixed-version Go/Rust pairs safe in both directions.

## Audit
Swept all of `protocol.go` for slice fields lacking `,omitempty`: ONLY
these two were hazardous. (`WireUint8List` fields already render nil as
`[]` via their custom `MarshalJSON`.)

## Tests (fail-on-revert proven both sides)
- **Go** (`protocol_null_collections_2214_test.go`): the empty-pool NAT64
  rule and zero-term filter must marshal `[]` not `null`, plus a
  full-snapshot wire assertion. All FAIL on the pre-fix nil-emitting code
  with the exact `"pool_addresses":null` whole-snapshot wire.
- **Rust** (`protocol/tests.rs`): `null` / absent / populated decode for
  both fields, plus a whole-`ConfigSnapshot`-with-null-collections decode
  test. All FAIL on the pre-fix plain `#[serde(default)]` with the exact
  `Error("invalid type: null, expected a sequence")` — i.e. the
  whole-snapshot decode abort that is the no-transit signature.

## Validation
- `go build ./...`, `go vet ./pkg/dataplane/userspace/...` clean.
- `go test ./pkg/dataplane/userspace/... ./pkg/config/...` green.
- `cargo build --release` clean (145 pre-existing warnings, none on the
  changed files); 68 `protocol` tests pass.

No markdown doc change: the wire null-tolerance contract is documented
inline at all five source sites (matching the #1961 `WireUint8List`
convention — there is no standalone wire-contract module doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
