### PR TITLE
flowexport: hold ExportConfig by pointer to stop atomic-copy (#2224)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,13 @@ install: build build-ctl
 	install -m 0755 cli $(PREFIX)/bin/cli
 
 test:
+	# go vet gate scoped to pkg/flowexport (#2224): catches the
+	# atomic.Uint64-copy regression class (ExportConfig embeds the live
+	# 1-in-N sampleCounter and must never be copied by value). NOT
+	# tree-wide yet — two pre-existing vet diagnostics live outside this
+	# package (cmd/cli protobuf MessageState copy, pkg/cli unreachable
+	# code); widen to ./... once those are resolved.
+	$(GO) vet ./pkg/flowexport/...
 	$(GO) test ./...
 
 # Drift guard for the committed refactoring heatmap (#1661 item 8).

--- a/_Log.md
+++ b/_Log.md
@@ -8710,3 +8710,24 @@ top.
   multi-match event in-order, so it does not reliably trip that one test).
 - **File(s)**: pkg/eventengine/engine_window_test.go (new),
   pkg/eventengine/README.md
+
+- **Timestamp**: 2026-06-21
+- **Action**: #2224 — fix flowexport ExportConfig atomic-copy (go vet
+  "copies lock value" + latent double-sampling). ExportConfig embeds the
+  live 1-in-N sampleCounter (atomic.Uint64); NewExporter/NewIPFIXExporter
+  took it by VALUE and the daemon called NewExporter(*ec) — six go-vet
+  "copies lock value" / "passes lock by value" diagnostics, and a forked
+  counter that re-seeds the sampling cadence if any caller ever sampled
+  off the exporter's copy. Fix: both exporters now hold *ExportConfig and
+  the constructors take *ExportConfig; daemon passes the bundle's ec
+  pointer directly, so exporter + bundle + ShouldExport share ONE counter.
+  Added fail-on-revert test TestExporterSharesSingleSampleCounter (pointer
+  identity + 1-in-N cadence across 100 packets on the shared counter;
+  reverting to value-type breaks compilation AND go vet). Scoped a
+  `go vet ./pkg/flowexport/...` gate into the Makefile test target (NOT
+  tree-wide: two pre-existing vet diagnostics live in cmd/cli + pkg/cli).
+  Build + vet (flowexport+daemon) clean; flowexport -race green; daemon
+  tests green.
+- **File(s)**: pkg/flowexport/netflow.go, pkg/flowexport/ipfix.go,
+  pkg/flowexport/exporter_test.go (new test),
+  pkg/daemon/daemon_flowexport.go, pkg/flowexport/README.md, Makefile

--- a/pkg/daemon/daemon_flowexport.go
+++ b/pkg/daemon/daemon_flowexport.go
@@ -23,10 +23,14 @@
 // every commit. Instead we register a single stable indirection
 // callback per family exactly once (flowCBOnce / ipfixCBOnce) that
 // reads the live (exporter, config) pair from an atomic.Pointer bundle;
-// reconcile swaps the bundle atomically. The exporter never reads the
-// config's 1-in-N sampleCounter (only the callback's ShouldExport
-// does), so the daemon-held *ExportConfig is the sole counter owner and
-// is held by pointer in the bundle.
+// reconcile swaps the bundle atomically. The resolved *ExportConfig is
+// held by pointer everywhere — in the bundle, by the session-close
+// callback's ShouldExport, AND inside the exporter (#2224) — so there is
+// exactly ONE live 1-in-N sampleCounter per family. ExportConfig embeds
+// that counter as an atomic.Uint64; passing it by value would copy the
+// atomic (a go-vet "copies lock value" failure) and fork the counter,
+// silently re-seeding the modulo cadence the moment any caller sampled
+// off the copy.
 package daemon
 
 import (
@@ -155,7 +159,7 @@ func (d *Daemon) reconcileV9Exporter(cfg *config.Config) bool {
 		return true
 	}
 
-	exp, err := flowexport.NewExporter(*ec)
+	exp, err := flowexport.NewExporter(ec)
 	if err != nil {
 		slog.Warn("failed to create flow exporter", "err", err)
 		// Do NOT record the hash on a create failure: NewExporter ->
@@ -228,7 +232,7 @@ func (d *Daemon) reconcileIPFIXExporter(cfg *config.Config) bool {
 		return true
 	}
 
-	exp, err := flowexport.NewIPFIXExporter(*ec)
+	exp, err := flowexport.NewIPFIXExporter(ec)
 	if err != nil {
 		slog.Warn("failed to create IPFIX exporter", "err", err)
 		// Do NOT record the hash on a create failure (see the v9 path):

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -40,13 +40,18 @@ The package is split by responsibility (#1988):
 
 NetFlow v9:
 - `Exporter` — `netflow.go`.
-- `NewExporter(cfg ExportConfig) (*Exporter, error)` — `netflow.go`.
+- `NewExporter(cfg *ExportConfig) (*Exporter, error)` — `netflow.go`.
+  Takes `*ExportConfig` (never a value copy): `ExportConfig` embeds the
+  live 1-in-N `sampleCounter` (`atomic.Uint64`), and copying it would
+  fork the counter (a go-vet "copies lock value" failure) — see #2224.
 - `Run(ctx context.Context)` — `netflow.go`. Main export loop.
 - `Exporter.ExportSessionClose(rec, evt)` — emit one record.
 
 IPFIX:
 - `IPFIXExporter` — `ipfix.go`.
-- `NewIPFIXExporter(cfg ExportConfig) (*IPFIXExporter, error)` — `ipfix.go`.
+- `NewIPFIXExporter(cfg *ExportConfig) (*IPFIXExporter, error)` — `ipfix.go`.
+  Also takes `*ExportConfig` (never a value copy) for the same #2224
+  reason as `NewExporter`.
 - `IPFIXExporter.Run(ctx context.Context)` — `ipfix.go`.
 - `IPFIXExporter.ExportSessionClose(rec, evt)` — emit one record.
 
@@ -123,9 +128,13 @@ indirection callback per family exactly once
 pair lock-free from an `atomic.Pointer` bundle; reconcile swaps the
 bundle atomically. The callback calls `Exporter.ExportSessionClose()`
 (NetFlow v9) / `IPFIXExporter.ExportSessionClose()` (IPFIX) from the
-`logging.EventReader` SESSION_CLOSE event. The daemon-held
-`*ExportConfig` is the sole 1-in-N counter owner (the exporter never
-reads `sampleCounter`), so it is held by pointer in the bundle.
+`logging.EventReader` SESSION_CLOSE event. The resolved `*ExportConfig`
+is shared by pointer everywhere — in the bundle, by the callback's
+`ShouldExport`, AND inside the exporter — so there is exactly ONE live
+1-in-N `sampleCounter` (`atomic.Uint64`) per family. `ExportConfig` is
+never copied by value: doing so would fork the atomic counter (a go-vet
+"copies lock value" failure) and silently re-seed the modulo cadence the
+moment any caller sampled off the copy (#2224).
 `stopFlowExporter`/`stopIPFIXExporter` drain the exporter at shutdown.
 
 ## Dependencies

--- a/pkg/flowexport/exporter_test.go
+++ b/pkg/flowexport/exporter_test.go
@@ -140,6 +140,80 @@ func TestShouldExport(t *testing.T) {
 	}
 }
 
+// TestExporterSharesSingleSampleCounter is the #2224 fail-on-revert
+// guard: ExportConfig embeds the live 1-in-N sampleCounter
+// (atomic.Uint64), so it MUST be held by pointer everywhere. NewExporter
+// / NewIPFIXExporter take *ExportConfig and store that same pointer, so
+// the exporter's internal cfg, the daemon-held *ExportConfig, and the
+// session-close callback's ShouldExport all increment ONE counter.
+//
+// Revert the fix (cfg ExportConfig by value + NewExporter(*ec)) and this
+// test fails two ways: (1) the exporter's cfg is a distinct copy with a
+// freshly-zeroed counter, so sampling through it re-seeds the modulo
+// cadence; (2) go vet flags the "copies lock value" diagnostic that this
+// test's contract exists to prevent.
+func TestExporterSharesSingleSampleCounter(t *testing.T) {
+	const rate = 5
+	// Empty Collectors -> dialCollectors opens no sockets and returns no
+	// error, so the exporters construct without touching the network.
+	ec := &ExportConfig{SamplingRate: rate}
+
+	v9, err := NewExporter(ec)
+	if err != nil {
+		t.Fatalf("NewExporter: %v", err)
+	}
+	if v9.cfg != ec {
+		t.Fatalf("v9 exporter cfg is a value copy (%p) not the shared *ExportConfig (%p): "+
+			"copying forks the sampleCounter and re-seeds the 1-in-N cadence (#2224)", v9.cfg, ec)
+	}
+
+	ipfix, err := NewIPFIXExporter(ec)
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter: %v", err)
+	}
+	if ipfix.cfg != ec {
+		t.Fatalf("ipfix exporter cfg is a value copy (%p) not the shared *ExportConfig (%p) (#2224)",
+			ipfix.cfg, ec)
+	}
+
+	// Drive the 1-in-N sampler across N packets through the SHARED config
+	// (no SamplingZones -> every packet is eligible). The counter
+	// increments per call (n := counter.Add(1)); ShouldExport returns true
+	// exactly when n % rate == 0. So packet k (1-indexed) samples iff
+	// k % rate == 0 -> exactly floor(N/rate) samples, evenly spaced.
+	const packets = 100
+	got := 0
+	for k := 1; k <= packets; k++ {
+		sampled := ec.ShouldExport(0, 0)
+		wantSampled := k%rate == 0
+		if sampled != wantSampled {
+			t.Fatalf("packet %d: ShouldExport=%v, want %v (cadence broke -> "+
+				"counter was forked, not shared)", k, sampled, wantSampled)
+		}
+		if sampled {
+			got++
+		}
+	}
+	want := packets / rate
+	if got != want {
+		t.Fatalf("sampled %d of %d packets at 1-in-%d, want %d", got, packets, rate, want)
+	}
+
+	// The shared counter has advanced to exactly `packets` — proving the
+	// exporters did not fork their own zeroed copies. If cfg were copied
+	// by value, v9.cfg/ipfix.cfg would each hold an independent counter
+	// still at 0 while only `ec`'s advanced.
+	if n := ec.sampleCounter.Load(); n != packets {
+		t.Fatalf("shared sampleCounter = %d, want %d", n, packets)
+	}
+	if n := v9.cfg.sampleCounter.Load(); n != packets {
+		t.Fatalf("v9 exporter sees sampleCounter = %d, want %d (counter forked)", n, packets)
+	}
+	if n := ipfix.cfg.sampleCounter.Load(); n != packets {
+		t.Fatalf("ipfix exporter sees sampleCounter = %d, want %d (counter forked)", n, packets)
+	}
+}
+
 func TestParseIfaceRef(t *testing.T) {
 	tests := []struct {
 		ref      string

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -283,7 +283,7 @@ func encodeIPFIXRecordV6(b []byte, off int, r FlowRecord) int {
 
 // IPFIXExporter sends IPFIX (NetFlow v10) messages to configured collectors.
 type IPFIXExporter struct {
-	cfg         ExportConfig
+	cfg         *ExportConfig
 	sourceID    uint32
 	templateSet []byte
 
@@ -297,8 +297,11 @@ type IPFIXExporter struct {
 	exportedPkts  atomic.Uint64
 }
 
-// NewIPFIXExporter creates a new IPFIX exporter.
-func NewIPFIXExporter(cfg ExportConfig) (*IPFIXExporter, error) {
+// NewIPFIXExporter creates a new IPFIX exporter. cfg is held by pointer
+// (never copied) for the same reason as NewExporter: ExportConfig
+// embeds the live 1-in-N sampleCounter (atomic.Uint64) and copying it
+// would fork the counter, re-seeding the sampling cadence (#2224).
+func NewIPFIXExporter(cfg *ExportConfig) (*IPFIXExporter, error) {
 	e := &IPFIXExporter{
 		cfg:         cfg,
 		sourceID:    1,

--- a/pkg/flowexport/netflow.go
+++ b/pkg/flowexport/netflow.go
@@ -397,7 +397,7 @@ func uptimeMs(boot, t time.Time) uint32 {
 
 // Exporter sends NetFlow v9 packets to configured collectors.
 type Exporter struct {
-	cfg             ExportConfig
+	cfg             *ExportConfig
 	bootTime        time.Time
 	sourceID        uint32
 	fieldsV4        []templateField
@@ -418,8 +418,13 @@ type Exporter struct {
 	exportedPkts  atomic.Uint64
 }
 
-// NewExporter creates a new NetFlow v9 exporter.
-func NewExporter(cfg ExportConfig) (*Exporter, error) {
+// NewExporter creates a new NetFlow v9 exporter. cfg is held by pointer
+// (never copied) because ExportConfig embeds the live 1-in-N
+// sampleCounter (atomic.Uint64); copying it would fork the counter and
+// silently re-seed the sampling cadence (#2224). The caller (the daemon
+// reconcile path) shares the same *ExportConfig with the session-close
+// callback so there is exactly one counter per exporter.
+func NewExporter(cfg *ExportConfig) (*Exporter, error) {
 	e := &Exporter{
 		cfg:      cfg,
 		bootTime: time.Now(),


### PR DESCRIPTION
Fixes #2224.

## Problem

`ExportConfig` embeds the live 1-in-N `sampleCounter` (an `atomic.Uint64`,
which carries a `noCopy` marker). `NewExporter` / `NewIPFIXExporter` took
the config by VALUE and the daemon called `NewExporter(*ec)` /
`NewIPFIXExporter(*ec)`, so every construction copied the atomic. `go vet
./pkg/flowexport/ ./pkg/daemon/` flagged six `copies lock value` /
`passes lock by value` diagnostics.

The copy was latent (not yet live) only because `ShouldExport` is always
invoked on the daemon-held `*ExportConfig` in the bundle, never on the
exporter's internal copy. Any future caller that sampled off the
exporter's copy would read a freshly-zeroed counter, restarting the
modulo cycle and double-sampling / mis-pacing 1-in-N NetFlow export.
There is no CI `go vet` gate, so the failure was silent.

## Fix

Both `Exporter` and `IPFIXExporter` now hold `*ExportConfig`, and their
constructors take `*ExportConfig`. The daemon reconcile path passes the
bundle's `ec` pointer directly, so the exporter, the `atomic.Pointer`
bundle, and the session-close callback's `ShouldExport` all share
exactly ONE counter per family. Smallest correct change — it strengthens
the single-counter-owner contract the `daemon_flowexport.go` header
already documented.

Also scoped a `go vet ./pkg/flowexport/...` gate into the Makefile `test`
target so this atomic-copy regression class is caught. Deliberately NOT
tree-wide: two unrelated vet diagnostics pre-exist on master (cmd/cli
protobuf `MessageState` copy, pkg/cli unreachable code); widen to `./...`
once those are resolved.

## Fail-on-revert proof

`TestExporterSharesSingleSampleCounter` asserts pointer identity
(`exp.cfg == ec`) and drives the 1-in-N sampler across 100 packets on the
shared config, requiring exactly `floor(N/rate)` samples on the
documented `n%rate==0` cadence and the shared counter advancing to N.
Reverting `cfg` to a value type breaks the test's compilation (mismatched
pointer/value types) AND re-triggers the `go vet` diagnostics — verified
both: reverting yields 2 `copies lock value` diagnostics in the package
and a build-failed test.

## Validation

- `go build ./...` — clean
- `go vet ./pkg/flowexport/ ./pkg/daemon/` — clean (was 6 diagnostics)
- `go test ./pkg/flowexport/... ./pkg/daemon/...` — pass
- `go test -race ./pkg/flowexport/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
