### PR TITLE
config+routing: reject and never-leak an undefined rib-group import-rib (#2226)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,45 @@
 # Action Log
 
+## 2026-06-21 — #2226: rib-group import-rib undefined-reference validation
+
+- **Timestamp**: 2026-06-21
+- **Action**: Closed the rib-group `import-rib` table-0 mis-leak. An
+  import-rib naming a rib that resolves to no real table (typo,
+  non-existent instance, garbage) previously mapped to a bare table 0 in
+  `resolveRibTable`; because an instance's source table is always
+  `>= 100`, `targetTable(0) != sourceTable` set `needsLeak` and the
+  applier installed a phantom `ip rule from all lookup <sourceTable>
+  pref 33000` — a silent mis-leak with no diagnostic. Two layers:
+  - **Commit-time (preferred)**: new
+    `validateRibGroupImportRibReferencesStrict` in
+    `compiler_validate_strict.go`, wired into `compileExpanded` next to
+    the #2217/#2240/#2144 strict gates. A valid import-rib names
+    `inet.0` / `inet6.0` or `<defined-instance>.inet[6].0`; anything else
+    is a HARD commit error. Lenient (load / HA peer-sync,
+    `lenientRibGroupRefs`) downgrades to a warning so an
+    already-persisted / peer-synced config still BOOTS (#1960).
+  - **Runtime backstop**: `resolveRibTable` now returns
+    `(tableID int, ok bool)`; the `Apply` needsLeak loop skips
+    `ok == false` ribs with a warn and never installs a rule into table 0
+    from an unresolved name.
+- **File(s)**: `pkg/config/compiler_validate_strict.go`,
+  `pkg/config/compiler.go`,
+  `pkg/config/compiler_ribgroup_ref_2226_test.go` (new),
+  `pkg/config/parser_ast_test.go`, `pkg/config/parser_routing_test.go`
+  (three pre-existing parse tests gained the routing-instance
+  definitions their import-ribs name — genuine catches),
+  `pkg/routing/rules.go`, `pkg/routing/rules_test.go` (new
+  fail-on-revert + no-false-reject tests), `pkg/routing/routing_test.go`
+  (call-site updates), `docs/config-schema.md`, `pkg/routing/README.md`.
+- **Validation**: `go build ./...`; `go vet ./pkg/routing/...
+  ./pkg/config/...`; `go test ./pkg/routing/... ./pkg/config/...` green.
+  Fail-on-revert proven both layers: neutering the `Apply` ok-guard
+  reinstalls the phantom `table 101` rule (runtime test fails); neutering
+  the strict validator call makes the four reject/lenient config tests
+  fail. Defined-rib tests pass unchanged (no false reject). Three
+  pre-existing `pkg/dataplane` / `pkg/fsatomic` canary failures are
+  unrelated to this change (fail identically on origin/master).
+
 ## 2026-06-21 — #2244: dnat_table reverse-NAT publish failure now counted + surfaced
 
 - **Timestamp**: 2026-06-21

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -714,6 +714,56 @@ lenient-warns; plus three-color-policer + `junos-*` predefined + nested-set +
 implicit-multi-term-not-false-rejected cases). Like the gates above, these are
 compiler-side only — not yet typed `setSchema` leaves.
 
+### #2226 — rib-group `import-rib` undefined-reference validation
+
+`routing-options rib-groups <group> import-rib <rib>` was unvalidated: an
+import-rib naming a rib that resolves to no real routing table (a typo, a
+non-existent routing-instance, or unparseable garbage) compiled cleanly. At apply
+time `resolveRibTable` (`pkg/routing/rules.go`) mapped any unresolvable name to a
+bare table **0**. Because a routing-instance's source table is always `>= 100`,
+the unresolvable name yielded `targetTable(0) != sourceTable`, which set
+`needsLeak` and installed an `ip rule from all lookup <sourceTable> pref 33000`
+for a rib that does not exist — a silent mis-leak of the source table into the
+main lookup, with no diagnostic. (`ValidateConfig` only ever emitted an
+over-limit *warning* for rib-groups; it never checked that an import-rib names a
+real rib.)
+
+Two layers close the gap:
+
+- **Commit-time gate (preferred) — `validateRibGroupImportRibReferencesStrict`**
+  in `pkg/config/compiler_validate_strict.go`, invoked from `compileExpanded`
+  (`compiler.go`) alongside the other strict gates. A valid import-rib names
+  `inet.0` / `inet6.0` (the main table) or `"<instance>.inet.0"` /
+  `"<instance>.inet6.0"` for a defined routing-instance. Any other name is a HARD
+  commit error naming the rib-group and the offending rib. Every defined
+  rib-group is validated (not only ones referenced by an instance's
+  interface-routes rib-group), mirroring Junos, which rejects an undefined rib
+  regardless of whether the group is in use. Rib-groups are iterated in sorted
+  order for a deterministic first-error.
+- **Runtime backstop — `resolveRibTable` now returns `(tableID int, ok bool)`.**
+  The `Apply` `needsLeak` loop treats `ok == false` as "unknown rib": it skips
+  the entry (with a `slog.Warn`) and never sets `needsLeak` from it, so no rule
+  is installed for a phantom rib and nothing is ever installed into table 0 from
+  an unresolved name. This guards any reference that still reaches apply via the
+  tolerant load / peer-sync path.
+
+**Strict (`commit` / `commit check`):** a dangling import-rib is a hard commit
+error. **Lenient (`Store.Load` / HA peer-sync — `CompileConfigLenient` /
+`CompileConfigForNodeLenient`, flag `lenientRibGroupRefs`):** downgraded to a
+`cfg.Warnings` entry so a node that committed a dangling import-rib BEFORE this
+gate existed (or a peer-synced config) still BOOTS (#1960
+fail-closed-on-compile-failure). The runtime backstop keeps a leniently-loaded
+reference inert (the phantom rib is skipped, no rule installed), matching the
+post-fix behaviour, and the operator's next strict commit rejects it loudly.
+
+Regression coverage: `pkg/config/compiler_ribgroup_ref_2226_test.go`
+(undefined-reject in both AST shapes, garbage-token reject, defined-ribs +
+inet6-ribs commit cleanly, lenient-warns) and `pkg/routing/rules_test.go`
+(`TestRibGroupRulesApply_UnknownRibNoLeak` — an all-unknown rib-group installs
+ZERO rules; `TestRibGroupRulesApply_DefinedRibStillLeaks` — a defined rib still
+leaks correctly). Like the gates above, this is compiler-side only — not yet a
+typed `setSchema` leaf.
+
 ## The `inactive:` universal node modifier (#2008 H1)
 
 `inactive:` is the Junos deactivate-without-delete marker and is NOT a

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -320,6 +320,21 @@ type compileOpts struct {
 	// independently, so it is already inert. Same doctrine as
 	// lenientApplicationSpecs.
 	lenientApplicationSetMembers bool
+	// lenientRibGroupRefs (#2226) downgrades the rib-group import-rib
+	// cross-reference gate (validateRibGroupImportRibReferencesStrict) from a
+	// hard compile error to a cfg.Warnings entry. An `import-rib` naming a rib
+	// that resolves to no real routing table (a typo, a non-existent instance,
+	// or unparseable garbage) was previously unvalidated: the applier mapped
+	// the unresolvable name to a bare table 0, which differs from any
+	// instance's (>= 100) source table, so it spuriously installed an `ip rule
+	// from all lookup <sourceTable>` — a silent mis-leak of the source table
+	// into the main lookup. The strict commit / commit-check path hard-rejects
+	// so the typo is operator-visible; the tolerant load / peer-sync paths warn
+	// so an already-persisted or peer-synced config carrying a dangling
+	// import-rib still BOOTS (#1960) — the applier's resolveRibTable ok=false
+	// guard skips the phantom rib and installs no rule, so a leniently-loaded
+	// config is already inert. Same doctrine as lenientRoutingExportRef.
+	lenientRibGroupRefs bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -359,6 +374,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientNPTv6:                       true,
 		lenientFirewallRefs:                true,
 		lenientApplicationSetMembers:       true,
+		lenientRibGroupRefs:                true,
 	})
 }
 
@@ -449,6 +465,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientNPTv6:                       true,
 		lenientFirewallRefs:                true,
 		lenientApplicationSetMembers:       true,
+		lenientRibGroupRefs:                true,
 	})
 }
 
@@ -992,6 +1009,25 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientApplicationSetMembers {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("application-set member (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2226: rib-group `import-rib <rib>` cross-reference. An import-rib naming
+	// a rib that resolves to no real routing table (a typo, a non-existent
+	// instance, or unparseable garbage) compiled cleanly; the applier mapped
+	// the unresolvable name to table 0, which differs from the (>= 100) source
+	// table, and spuriously installed an `ip rule from all lookup <sourceTable>`
+	// — a silent mis-leak of the source table into the main lookup. Strict on
+	// commit / commit-check (hard reject so the typo is operator-visible);
+	// lenient on load / peer-sync (warn — #1960; the applier's resolveRibTable
+	// ok=false guard skips the phantom rib so it is already inert). Mirrors
+	// validateRoutingExportReferencesStrict.
+	if err := validateRibGroupImportRibReferencesStrict(cfg); err != nil {
+		if opts.lenientRibGroupRefs {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("rib-group import-rib reference (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_ribgroup_ref_2226_test.go
+++ b/pkg/config/compiler_ribgroup_ref_2226_test.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2226: commit-time strict validation of a rib-group `import-rib <rib>`
+// cross-reference. An import-rib naming a rib that resolves to no real
+// routing table (a typo, a non-existent routing-instance, or unparseable
+// garbage) compiled cleanly and then, at apply time, mapped to a bare
+// table 0 — which differs from any routing-instance's (>= 100) source
+// table — so the applier installed an `ip rule from all lookup
+// <sourceTable> pref 33000` for a rib that does not exist: a silent
+// mis-leak of the source table into the main lookup with no diagnostic.
+//
+// validateRibGroupImportRibReferencesStrict now hard-rejects the dangling
+// reference at commit; the applier's resolveRibTable ok=false guard is the
+// runtime backstop (tested in pkg/routing/rules_test.go).
+//
+// Each case is exercised in BOTH AST shapes (flat-set via ParseSetCommand
+// + SetPath, hierarchical via NewParser), in both directions: an
+// UNDEFINED import-rib is hard-rejected at commit (the fail-on-revert
+// assertion — neuter the validator and the reject disappears), and a
+// DEFINED import-rib commits cleanly with no false reject.
+
+func TestRibGroupImportRibUndefinedRejectedFlatSet(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set routing-instances dmz-vr instance-type virtual-router",
+		"set routing-instances dmz-vr interface-routes rib-group inet dmz-leak",
+		"set routing-options rib-groups dmz-leak import-rib does-not-exist.inet.0",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit rejection for import-rib does-not-exist.inet.0, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined rib") ||
+		!strings.Contains(err.Error(), "does-not-exist.inet.0") {
+		t.Fatalf("error = %v, want it to name the undefined rib", err)
+	}
+}
+
+// A bare garbage token (no ".inet" suffix at all) is also undefined.
+func TestRibGroupImportRibGarbageRejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set routing-instances dmz-vr instance-type virtual-router",
+		"set routing-instances dmz-vr interface-routes rib-group inet dmz-leak",
+		"set routing-options rib-groups dmz-leak import-rib garbage",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit rejection for import-rib garbage, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined rib") ||
+		!strings.Contains(err.Error(), "garbage") {
+		t.Fatalf("error = %v, want it to name the undefined rib", err)
+	}
+}
+
+func TestRibGroupImportRibUndefinedRejectedHierarchical(t *testing.T) {
+	input := `routing-instances {
+    dmz-vr {
+        instance-type virtual-router;
+        interface-routes {
+            rib-group inet dmz-leak;
+        }
+    }
+}
+routing-options {
+    rib-groups {
+        dmz-leak {
+            import-rib does-not-exist.inet.0;
+        }
+    }
+}
+`
+	parser := NewParser(input)
+	tree, errs := parser.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit rejection for import-rib does-not-exist.inet.0, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined rib") {
+		t.Fatalf("error = %v, want undefined-rib rejection", err)
+	}
+}
+
+// A defined rib-group importing a defined instance's rib + the main table
+// commits cleanly (no false reject).
+func TestRibGroupImportRibDefinedCommitsFlatSet(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set routing-instances tunnel-vr instance-type virtual-router",
+		"set routing-instances dmz-vr instance-type virtual-router",
+		"set routing-instances dmz-vr interface-routes rib-group inet dmz-leak",
+		"set routing-options rib-groups dmz-leak import-rib dmz-vr.inet.0",
+		"set routing-options rib-groups dmz-leak import-rib tunnel-vr.inet.0",
+		"set routing-options rib-groups dmz-leak import-rib inet.0",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("defined import-ribs must commit cleanly, got: %v", err)
+	}
+	rg := cfg.RoutingOptions.RibGroups["dmz-leak"]
+	if rg == nil {
+		t.Fatal("rib-group dmz-leak missing from compiled config")
+	}
+	if len(rg.ImportRibs) != 3 {
+		t.Fatalf("import-rib list = %v, want 3 entries", rg.ImportRibs)
+	}
+}
+
+// inet6.0 and "<instance>.inet6.0" are valid main-table / VRF rib names.
+func TestRibGroupImportRibInet6Commits(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set routing-instances vpn-vr instance-type virtual-router",
+		"set routing-instances vpn-vr interface-routes rib-group inet6 v6-leak",
+		"set routing-options rib-groups v6-leak import-rib vpn-vr.inet6.0",
+		"set routing-options rib-groups v6-leak import-rib inet6.0",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("inet6 import-ribs must commit cleanly, got: %v", err)
+	}
+}
+
+// The strict reject is downgraded to a warning on the tolerant load /
+// peer-sync path so an already-persisted config carrying the typo still
+// boots (#1960 fail-closed-on-load class).
+func TestRibGroupImportRibUndefinedLenientWarns(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set routing-instances dmz-vr instance-type virtual-router",
+		"set routing-instances dmz-vr interface-routes rib-group inet dmz-leak",
+		"set routing-options rib-groups dmz-leak import-rib does-not-exist.inet.0",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient path must boot through undefined import-rib, got: %v", err)
+	}
+	if !warningsContain(cfg.Warnings, "rib-group import-rib reference") {
+		t.Fatalf("expected a downgraded import-rib-reference warning, got: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -1163,3 +1163,92 @@ func isKnownProcessName(name string) bool {
 	_, ok := knownManagedProcessNames[name]
 	return ok
 }
+
+// validateRibGroupImportRibReferencesStrict hard-rejects a
+// `routing-options rib-groups <group> import-rib <rib>` entry whose rib
+// name resolves to no real routing table (#2226).
+//
+// A valid import-rib names one of:
+//   - inet.0 / inet6.0 (the main table), OR
+//   - "<instance>.inet.0" / "<instance>.inet6.0" where <instance> is a
+//     defined routing-instance.
+//
+// Any other name — a typo, a non-existent instance, or unparseable
+// garbage — is undefined. ValidateConfig only ever emitted an over-limit
+// WARNING for rib-groups; it never validated that an import-rib names a
+// real rib. The applier's resolveRibTable previously mapped any
+// unresolvable name to a bare table 0 (see pkg/routing/rules.go). Because
+// a routing-instance's source table is always >= 100, an unresolvable
+// import-rib yielded targetTable(0) != sourceTable, which set needsLeak
+// and installed an `ip rule from all lookup <sourceTable> pref 33000` for
+// a rib that does not exist — a silent mis-leak of the source table into
+// the main lookup, with no diagnostic. This gate makes the dangling
+// reference an operator-visible commit error; resolveRibTable's ok=false
+// path is the defense-in-depth backstop for any reference that still
+// reaches apply via the tolerant load / peer-sync path.
+//
+// Rib-group names are iterated in sorted order, and each group's
+// import-rib list is walked in declaration order, so the first-reported
+// error is deterministic (Go map order is randomized). Every defined
+// rib-group is validated (not only ones referenced by an instance's
+// interface-routes rib-group), mirroring Junos, which rejects an
+// undefined rib regardless of whether the group is in use.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to
+// a warning (opts.lenientRibGroupRefs) so an already-persisted or peer-
+// synced config carrying a dangling import-rib still BOOTS (#1960
+// fail-closed-on-load class); the applier's ok=false guard keeps it inert
+// (the phantom rib is skipped, no rule is installed), exactly matching the
+// post-fix runtime behaviour. Commit / commit-check stay strict. Mirrors
+// validateRoutingExportReferencesStrict.
+func validateRibGroupImportRibReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	ribGroups := cfg.RoutingOptions.RibGroups
+	if len(ribGroups) == 0 {
+		return nil
+	}
+	definedInstance := make(map[string]bool, len(cfg.RoutingInstances))
+	for _, ri := range cfg.RoutingInstances {
+		if ri != nil && ri.Name != "" {
+			definedInstance[ri.Name] = true
+		}
+	}
+	// resolvable mirrors pkg/routing.resolveRibTable's definedness view:
+	// inet.0 / inet6.0, or "<defined-instance>.inet[6].0".
+	resolvable := func(ribName string) bool {
+		if ribName == "inet.0" || ribName == "inet6.0" {
+			return true
+		}
+		if idx := strings.Index(ribName, ".inet"); idx > 0 {
+			return definedInstance[ribName[:idx]]
+		}
+		return false
+	}
+	names := make([]string, 0, len(ribGroups))
+	for name := range ribGroups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		rg := ribGroups[name]
+		if rg == nil {
+			continue
+		}
+		for _, ribName := range rg.ImportRibs {
+			if ribName == "" || resolvable(ribName) {
+				continue
+			}
+			return fmt.Errorf(
+				"routing-options rib-groups %q import-rib %q references an "+
+					"undefined rib (name a defined routing-instance as "+
+					"\"<instance>.inet.0\" / \"<instance>.inet6.0\", or use "+
+					"inet.0 / inet6.0 for the main table — an undefined rib "+
+					"would otherwise silently leak this table's routes into "+
+					"the main lookup)",
+				name, ribName)
+		}
+	}
+	return nil
+}

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -2229,7 +2229,14 @@ func TestInlineJflowSourceAddress(t *testing.T) {
 }
 
 func TestRibGroups(t *testing.T) {
-	input := `routing-options {
+	// ATT is defined so the import-rib reference resolves (#2226 strict
+	// gate); the test's purpose is the rib-groups parse/compile shape.
+	input := `routing-instances {
+    ATT {
+        instance-type virtual-router;
+    }
+}
+routing-options {
     rib-groups {
         Other-ISPS {
             import-rib [ ATT.inet.0 inet.0 ];

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -2414,7 +2414,15 @@ func TestPointToPointFlag(t *testing.T) {
 }
 
 func TestGlobalInterfaceRoutesRibGroup(t *testing.T) {
-	input := `routing-options {
+	// The ISP instances are defined so the import-rib references resolve
+	// (#2226 strict gate); the test's purpose is the rib-group parse shape.
+	input := `routing-instances {
+    Comcast-BCI { instance-type virtual-router; }
+    ATT { instance-type virtual-router; }
+    Atherton-Fiber { instance-type virtual-router; }
+    sfmix { instance-type virtual-router; }
+}
+routing-options {
     interface-routes {
         rib-group {
             inet Other-ISPS;
@@ -2462,7 +2470,17 @@ func TestGlobalInterfaceRoutesRibGroup(t *testing.T) {
 }
 
 func TestGlobalInterfaceRoutesRibGroupSetSyntax(t *testing.T) {
-	lines := []string{"set routing-options interface-routes rib-group inet Other-ISPS", "set routing-options interface-routes rib-group inet6 Other-ISP6", "set routing-options rib-groups Other-ISPS import-rib Comcast-BCI.inet.0", "set routing-options rib-groups Other-ISPS import-rib inet.0", "set routing-options rib-groups Other-ISPS import-rib Other-GigabitPro.inet.0", "set routing-options rib-groups Other-ISPS import-rib bv-firehouse-vpn.inet.0", "set routing-options rib-groups Other-ISPS import-rib Comcast-GigabitPro.inet.0", "set routing-options rib-groups Other-ISPS import-rib ATT.inet.0", "set routing-options rib-groups Other-ISPS import-rib Atherton-Fiber.inet.0", "set routing-options rib-groups Other-ISPS import-rib sfmix.inet.0", "set routing-options rib-groups Other-ISP6 import-rib Comcast-BCI.inet6.0", "set routing-options rib-groups Other-ISP6 import-rib inet6.0", "set routing-options rib-groups Other-ISP6 import-rib Comcast-GigabitPro.inet6.0", "set routing-options rib-groups Other-ISP6 import-rib ATT.inet6.0", "set routing-options rib-groups Other-ISP6 import-rib Atherton-Fiber.inet6.0"}
+	lines := []string{
+		// Define the ISP instances so the import-rib references resolve
+		// (#2226 strict gate); the test's purpose is the parse shape.
+		"set routing-instances Comcast-BCI instance-type virtual-router",
+		"set routing-instances Other-GigabitPro instance-type virtual-router",
+		"set routing-instances bv-firehouse-vpn instance-type virtual-router",
+		"set routing-instances Comcast-GigabitPro instance-type virtual-router",
+		"set routing-instances ATT instance-type virtual-router",
+		"set routing-instances Atherton-Fiber instance-type virtual-router",
+		"set routing-instances sfmix instance-type virtual-router",
+		"set routing-options interface-routes rib-group inet Other-ISPS", "set routing-options interface-routes rib-group inet6 Other-ISP6", "set routing-options rib-groups Other-ISPS import-rib Comcast-BCI.inet.0", "set routing-options rib-groups Other-ISPS import-rib inet.0", "set routing-options rib-groups Other-ISPS import-rib Other-GigabitPro.inet.0", "set routing-options rib-groups Other-ISPS import-rib bv-firehouse-vpn.inet.0", "set routing-options rib-groups Other-ISPS import-rib Comcast-GigabitPro.inet.0", "set routing-options rib-groups Other-ISPS import-rib ATT.inet.0", "set routing-options rib-groups Other-ISPS import-rib Atherton-Fiber.inet.0", "set routing-options rib-groups Other-ISPS import-rib sfmix.inet.0", "set routing-options rib-groups Other-ISP6 import-rib Comcast-BCI.inet6.0", "set routing-options rib-groups Other-ISP6 import-rib inet6.0", "set routing-options rib-groups Other-ISP6 import-rib Comcast-GigabitPro.inet6.0", "set routing-options rib-groups Other-ISP6 import-rib ATT.inet6.0", "set routing-options rib-groups Other-ISP6 import-rib Atherton-Fiber.inet6.0"}
 	tree := &ConfigTree{}
 	for _, line := range lines {
 		cmd, err := ParseSetCommand(line)

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -72,7 +72,18 @@ delegate to the owning domain. Exported types:
 - `31000–31999`: PBR (firewall-filter `routing-instance` action).
   `pbrRulePriority` in `rules.go`.
 - `33000–33099`: rib-group inter-VRF leaking (`from all lookup
-  <table>`).
+  <table>`). `ribGroupManager.Apply` only installs a leak rule when an
+  instance's `interface-routes` rib-group imports a rib that resolves to
+  a real table *different* from the instance's own source table.
+  `resolveRibTable` returns `(tableID, ok)`; an **unknown / undefined**
+  import-rib (typo, non-existent instance, garbage — `ok == false`) is
+  skipped with a warning and never sets `needsLeak`, so it cannot install
+  a phantom `from all lookup <sourceTable>` rule — and nothing is ever
+  installed into table 0 from an unresolved name (#2226). The matching
+  commit-time gate `validateRibGroupImportRibReferencesStrict`
+  (`pkg/config`) hard-rejects the dangling import-rib before apply; this
+  runtime guard is the defense-in-depth backstop for the tolerant load /
+  peer-sync path.
 - main table at `32766`. The next-table range sits **before** main
   (lower priority value = higher priority). PBR sits before main as
   well; rib-group sits after.

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -535,20 +535,24 @@ func TestResolveRibTable(t *testing.T) {
 	tests := []struct {
 		ribName string
 		want    int
+		wantOK  bool
 	}{
-		{"inet.0", 254},
-		{"inet6.0", 254},
-		{"dmz-vr.inet.0", 101},
-		{"dmz-vr.inet6.0", 101},
-		{"tunnel-vr.inet.0", 100},
-		{"unknown-vr.inet.0", 0},
-		{"garbage", 0},
+		{"inet.0", 254, true},
+		{"inet6.0", 254, true},
+		{"dmz-vr.inet.0", 101, true},
+		{"dmz-vr.inet6.0", 101, true},
+		{"tunnel-vr.inet.0", 100, true},
+		// #2226: unresolvable rib names report ok=false (NOT a bare
+		// table 0 the needsLeak loop would read as a real target table
+		// and spuriously leak the source table into the main lookup).
+		{"unknown-vr.inet.0", 0, false},
+		{"garbage", 0, false},
 	}
 
 	for _, tt := range tests {
-		got := resolveRibTable(tt.ribName, tableIDs)
-		if got != tt.want {
-			t.Errorf("resolveRibTable(%q) = %d, want %d", tt.ribName, got, tt.want)
+		got, ok := resolveRibTable(tt.ribName, tableIDs)
+		if got != tt.want || ok != tt.wantOK {
+			t.Errorf("resolveRibTable(%q) = (%d, %v), want (%d, %v)", tt.ribName, got, ok, tt.want, tt.wantOK)
 		}
 	}
 }
@@ -584,7 +588,7 @@ func TestRibGroupNeedsLeak(t *testing.T) {
 	inst := instances[1] // dmz-vr
 	needsLeak := false
 	for _, ribName := range rg.ImportRibs {
-		if resolveRibTable(ribName, tableIDs) != inst.TableID {
+		if t, ok := resolveRibTable(ribName, tableIDs); ok && t != inst.TableID {
 			needsLeak = true
 			break
 		}
@@ -598,7 +602,7 @@ func TestRibGroupNeedsLeak(t *testing.T) {
 	inst = instances[0] // tunnel-vr
 	needsLeak = false
 	for _, ribName := range rg.ImportRibs {
-		if resolveRibTable(ribName, tableIDs) != inst.TableID {
+		if t, ok := resolveRibTable(ribName, tableIDs); ok && t != inst.TableID {
 			needsLeak = true
 			break
 		}
@@ -1075,7 +1079,7 @@ func TestMultiVRFRibGroupLeaking(t *testing.T) {
 		rg := ribGroups[inst.InterfaceRoutesRibGroup]
 		needsLeak := false
 		for _, ribName := range rg.ImportRibs {
-			if resolveRibTable(ribName, tableIDs) != inst.TableID {
+			if t, ok := resolveRibTable(ribName, tableIDs); ok && t != inst.TableID {
 				needsLeak = true
 				break
 			}
@@ -1107,7 +1111,7 @@ func TestIPv6OnlyRibGroupLeaking(t *testing.T) {
 	rg := ribGroups[rgName]
 	needsLeak := false
 	for _, ribName := range rg.ImportRibs {
-		if resolveRibTable(ribName, tableIDs) != inst.TableID {
+		if t, ok := resolveRibTable(ribName, tableIDs); ok && t != inst.TableID {
 			needsLeak = true
 			break
 		}

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -191,7 +191,21 @@ func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instance
 				continue
 			}
 			for _, ribName := range rgDef.ImportRibs {
-				targetTable := resolveRibTable(ribName, tableIDs)
+				targetTable, ok := resolveRibTable(ribName, tableIDs)
+				if !ok {
+					// Unknown / undefined rib name: do NOT treat it as
+					// a (non-source) target table — that would set
+					// needsLeak and install an `ip rule from all lookup
+					// <sourceTable>` for a rib that does not exist,
+					// silently leaking the source table into the main
+					// lookup (#2226). Skip it; warn for visibility. The
+					// strict commit-time gate normally rejects this
+					// before apply, but a tolerantly-loaded / peer-synced
+					// config can still reach here.
+					slog.Warn("rib-group import-rib references unknown rib; skipping (not leaking)",
+						"instance", inst.Name, "rib-group", rgName, "import-rib", ribName)
+					continue
+				}
 				if targetTable != sourceTable {
 					needsLeak = true
 					break
@@ -485,16 +499,29 @@ func dscpToTOS(dscp string) uint8 {
 
 // resolveRibTable maps a Junos rib name to its kernel routing table ID.
 // "<instance>.inet.0" or "<instance>.inet6.0" maps to the instance's table.
-func resolveRibTable(ribName string, tableIDs map[string]int) int {
+//
+// The boolean return distinguishes "resolved to a real table" (ok=true)
+// from "unresolvable rib name" (ok=false) — a name that is neither
+// inet.0/inet6.0 nor "<known-instance>.inet[6].0". Callers MUST treat
+// ok=false as "unknown rib": never fall back to table 0 (#2226). Before
+// this split the unresolvable case returned a bare 0, which the Apply
+// needsLeak loop read as a real (non-source) table and spuriously
+// installed an `ip rule from all lookup <sourceTable>` for a typo'd /
+// non-existent import-rib — a silent mis-leak of the source table into
+// the main lookup. Commit-time validation
+// (validateRibGroupImportRibReferencesStrict) now also rejects the
+// dangling reference; this guard is defense in depth for any reference
+// that reaches apply via the tolerant load / peer-sync path.
+func resolveRibTable(ribName string, tableIDs map[string]int) (int, bool) {
 	if ribName == "inet.0" || ribName == "inet6.0" {
-		return 254 // main table
+		return 254, true // main table
 	}
 	// Parse "instance-name.inet.0" or "instance-name.inet6.0"
 	if idx := strings.Index(ribName, ".inet"); idx > 0 {
 		instanceName := ribName[:idx]
 		if tableID, ok := tableIDs[instanceName]; ok {
-			return tableID
+			return tableID, true
 		}
 	}
-	return 0
+	return 0, false
 }

--- a/pkg/routing/rules_test.go
+++ b/pkg/routing/rules_test.go
@@ -129,6 +129,88 @@ func TestRibGroupRulesApply_Fake(t *testing.T) {
 	}
 }
 
+// TestRibGroupRulesApply_UnknownRibNoLeak is the #2226 fail-on-revert
+// guard. A rib-group whose ONLY import-rib names a rib that resolves to
+// no real routing table (a typo / non-existent instance) must NOT install
+// any leak rule for the source table. Before the fix, resolveRibTable
+// returned a bare 0 for the unknown name; 0 != sourceTable(101) set
+// needsLeak, and the applier installed `ip rule from all lookup 101` —
+// a silent mis-leak of the source table into the main lookup. With the
+// fix the unknown rib is skipped (ok=false) and no rule is programmed.
+//
+// Reverting either the resolveRibTable (int,bool) split or the
+// needsLeak-loop ok guard makes this test fail (a phantom rule for
+// table 101 appears).
+func TestRibGroupRulesApply_UnknownRibNoLeak(t *testing.T) {
+	ops := newFakeRuleOps()
+	rg := &ribGroupManager{ops: ops}
+
+	ribGroups := map[string]*config.RibGroup{
+		"typo-leak": {
+			Name: "typo-leak",
+			// Both names are undefined: a non-existent instance and pure
+			// garbage. Neither resolves to a real table.
+			ImportRibs: []string{"does-not-exist.inet.0", "garbage"},
+		},
+	}
+	instances := []*config.RoutingInstanceConfig{
+		{Name: "dmz-vr", TableID: 101, InterfaceRoutesRibGroup: "typo-leak"},
+	}
+
+	if err := rg.Apply(ribGroups, instances); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if ops.hasTable(unix.AF_INET, 101) {
+		t.Errorf("unknown import-rib must NOT install an IPv4 leak rule for table 101 (#2226), rules=%v", ops.rules[unix.AF_INET])
+	}
+	if ops.hasTable(unix.AF_INET6, 101) {
+		t.Errorf("unknown import-rib must NOT install an IPv6 leak rule for table 101 (#2226), rules=%v", ops.rules[unix.AF_INET6])
+	}
+	// And specifically never a rule into table 0 (the old fallback target).
+	if ops.hasTable(unix.AF_INET, 0) || ops.hasTable(unix.AF_INET6, 0) {
+		t.Errorf("must never install a rule into table 0 from an unresolved rib (#2226)")
+	}
+	if got := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6); got != 0 {
+		t.Errorf("expected zero rules for an all-unknown rib-group, got %d (%v / %v)",
+			got, ops.rules[unix.AF_INET], ops.rules[unix.AF_INET6])
+	}
+}
+
+// TestRibGroupRulesApply_DefinedRibStillLeaks is the companion no-false-
+// reject guard for #2226: a rib-group importing a DEFINED rib (another
+// real instance's table, plus the main table) still leaks the source
+// table correctly. This pins that the (int,bool) split did not break the
+// happy path — only the unresolvable case changed.
+func TestRibGroupRulesApply_DefinedRibStillLeaks(t *testing.T) {
+	ops := newFakeRuleOps()
+	rg := &ribGroupManager{ops: ops}
+
+	ribGroups := map[string]*config.RibGroup{
+		"dmz-leak": {
+			Name: "dmz-leak",
+			// dmz-vr.inet.0 (self, table 101), tunnel-vr.inet.0 (defined,
+			// table 100), inet.0 (main, 254). The defined non-self ribs
+			// must drive the leak.
+			ImportRibs: []string{"dmz-vr.inet.0", "tunnel-vr.inet.0", "inet.0"},
+		},
+	}
+	instances := []*config.RoutingInstanceConfig{
+		{Name: "tunnel-vr", TableID: 100},
+		{Name: "dmz-vr", TableID: 101, InterfaceRoutesRibGroup: "dmz-leak"},
+	}
+
+	if err := rg.Apply(ribGroups, instances); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !ops.hasTable(unix.AF_INET, 101) {
+		t.Errorf("defined import-rib must still leak table 101 (IPv4), rules=%v", ops.rules[unix.AF_INET])
+	}
+	if !ops.hasTable(unix.AF_INET6, 101) {
+		t.Errorf("defined import-rib must still leak table 101 (IPv6), rules=%v", ops.rules[unix.AF_INET6])
+	}
+}
+
 // TestNextTableRulesApply_Fake exercises nextTableManager over a fake,
 // asserting a next-table directive becomes an ip rule pointing at the
 // target instance's table.


### PR DESCRIPTION
Fixes #2226.

## The bug

`routing-options rib-groups <group> import-rib <rib>` was unvalidated.
`pkg/routing/rules.go:resolveRibTable` returned a bare `0` for any rib
name it could not resolve — a typo, a non-existent routing-instance, or
unparseable garbage. Because a routing-instance's source table is always
`>= 100`, the unresolvable name yielded `targetTable(0) != sourceTable`
in `ribGroupManager.Apply`'s `needsLeak` loop, so it set `needsLeak` and
installed an `ip rule from all lookup <sourceTable> pref 33000` for a rib
that does not exist — a silent mis-leak of the source table's routes into
the main lookup, with no diagnostic. `ValidateConfig` only ever emitted
an over-limit *warning* for rib-groups; nothing checked that an
import-rib names a real rib.

## The fix (two layers)

**Commit-time gate (preferred) — `validateRibGroupImportRibReferencesStrict`**
in `pkg/config/compiler_validate_strict.go`, wired into `compileExpanded`
alongside the existing strict cross-reference gates (mirrors the #2144
routing-export, #2240 NPTv6, and #2217 firewall-reference families). A
valid import-rib names `inet.0` / `inet6.0` or
`"<defined-instance>.inet.0"` / `"<defined-instance>.inet6.0"`; any other
name is a HARD commit error naming the rib-group and the offending rib.
Every defined rib-group is validated, mirroring Junos. Strict on commit /
commit-check; lenient (`Store.Load` / HA peer-sync via
`CompileConfigLenient` / `CompileConfigForNodeLenient`, flag
`lenientRibGroupRefs`) downgrades to a `cfg.Warnings` entry so an
already-persisted / peer-synced config carrying a dangling import-rib
still BOOTS (#1960 fail-closed-on-compile-failure).

**Runtime backstop — `resolveRibTable` now returns `(tableID int, ok bool)`.**
The `Apply` `needsLeak` loop treats `ok == false` as "unknown rib": it
skips the entry with a `slog.Warn` and never sets `needsLeak` from it, so
no rule is installed for a phantom rib and nothing is ever installed into
table 0 from an unresolved name. This guards any reference that still
reaches apply via the tolerant load / peer-sync path.

## Tests / fail-on-revert proof

- `pkg/routing/rules_test.go` (over the existing `fakeRuleOps` seam):
  - `TestRibGroupRulesApply_UnknownRibNoLeak` — an all-unknown rib-group
    installs ZERO rules. **Fail-on-revert proven**: neutering the `Apply`
    `ok` guard reinstalls the phantom `from all ... table 101` rule and
    the test fails.
  - `TestRibGroupRulesApply_DefinedRibStillLeaks` — a defined import-rib
    still leaks table 101 correctly (no false reject).
- `pkg/config/compiler_ribgroup_ref_2226_test.go` — undefined reject in
  both AST shapes (flat-set + hierarchical), bare garbage token reject,
  defined ribs + inet6 ribs commit cleanly, lenient-warns. **Fail-on-revert
  proven**: neutering the strict validator call makes the four
  reject/lenient tests fail.
- Three pre-existing rib-group parse tests gained the routing-instance
  definitions their import-ribs name (genuine catches by the new gate;
  their purpose is the rib-group parse/compile shape).

## Validation

`go build ./...`; `go vet ./pkg/routing/... ./pkg/config/...`;
`go test ./pkg/routing/... ./pkg/config/...` — all green. Three
pre-existing `pkg/dataplane` / `pkg/fsatomic` canary failures are
unrelated to this change (fail identically on `origin/master`).

Docs: `docs/config-schema.md` (new #2226 section) and
`pkg/routing/README.md` (ip-rule priorities: the unknown-rib guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
