### PR TITLE
#2229: warn on address-book entry with empty compiled prefix

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,23 @@
 # Action Log
 
+## 2026-06-21 — #2229 address-book empty-prefix entry warn-flag
+
+- **Timestamp**: 2026-06-21
+- **Action**: Follow-up to #2228. An address-book `address <name>` entry
+  that compiles with no usable prefix (no prefix at all, or only an
+  uncompiled sub-stanza like dns-name/range-address/wildcard-address)
+  yields Value=="". This is fail-closed/safe at resolution but the warn
+  validator only flagged a NON-empty unparseable Value, so a prefix-less
+  entry produced no commit-time warning — an operator authoring error went
+  silent. Extended the address-book warn loop to emit a non-blocking
+  warning (`address-book "X": no usable prefix configured; it will match
+  nothing`) for an empty compiled Value. WARNING, not a hard reject (never
+  worked + fail-closed; don't brick existing configs). Added
+  TestAddressBookEmptyValueWarns (dual-AST, fail-on-revert) and a
+  docs/bugs.md entry.
+- **File(s)**: pkg/config/compiler_validate_warn.go,
+  pkg/config/parser_security_test.go, docs/bugs.md, _Log.md
+
 ## 2026-06-21 — #2243 PR #2254 review fixes: Kea MAC canonicalization + lenient validator gate
 
 - **Timestamp**: 2026-06-21

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -190,6 +190,12 @@
 - **Fix (pkg/config/compiler_security.go):** Merge all `address` nodes by name; derive the prefix from `Keys[2]` ONLY when it parses as a CIDR/IP (`looksLikeIPOrCIDR`), otherwise from a bare-leaf child (hierarchical block prefix); route `description` into a new `Address.Description` field so a non-prefix sub-stanza can never clobber `Value`. Handles both AST shapes and either sub-stanza ordering.
 - **Tests:** `TestAddressBookDescriptionPrefix` (dual-AST × ordering table) + `TestAddressBookDescriptionResolvesInPolicy` in `parser_security_test.go`.
 
+### Address-book empty-prefix entry not warn-flagged (#2229, FIXED)
+- **Symptom:** After #2228 an address-book `address <name>` entry with no compilable prefix — either no prefix at all (description-only) or only an as-yet-uncompiled sub-stanza (`dns-name`/`range-address`/`wildcard-address`) — compiles to `Value==""`. This is fail-closed and safe at resolution (`net.ParseCIDR("")` errors → the address matches nothing → policies referencing it deny), so it is NOT a security bug. But `ValidateConfig` only flagged `invalid address` on a NON-empty unparseable `Value`, so a prefix-less entry produced no commit-time warning at all — an operator authoring error (forgetting the prefix) went silent.
+- **Root cause:** The address-book warn loop in `compiler_validate_warn.go` guarded the parse with `if entry.Value != ""`, so the empty case fell straight through with no warning.
+- **Fix (pkg/config/compiler_validate_warn.go):** Emit a non-blocking warning for an `address` entry whose compiled `Value` is empty — `address-book "X": no usable prefix configured; it will match nothing`. This is a WARNING, never a hard reject: an empty-prefix address never forwarded and rejecting it would brick existing configs. `dns-name`/`range-address`/`wildcard-address` remain uncompiled (separate pre-existing gap) and genuinely resolve to nothing today, so the warning is correct to flag them too.
+- **Tests:** `TestAddressBookEmptyValueWarns` (dual-AST: flat-set description-only, hierarchical description-only, flat-set `dns-name` sub-stanza all warn; flat-set + hierarchical valid prefix do NOT warn; commit succeeds in every case) in `parser_security_test.go`.
+
 ### iter.Next(&key, nil) crash
 - cilium/ebpf v0.20 panics when iterating non-empty maps with nil value pointer
 - **Fix:** Always use `var val []byte; iter.Next(&key, &val)`

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -199,12 +199,24 @@ func ValidateConfig(cfg *Config) []string {
 	// Validate address-book entries have valid CIDR or IP formats
 	if ab := cfg.Security.AddressBook; ab != nil {
 		for name, entry := range ab.Addresses {
-			if entry.Value != "" {
-				if _, _, err := net.ParseCIDR(entry.Value); err != nil {
-					if net.ParseIP(entry.Value) == nil {
-						warnings = append(warnings, fmt.Sprintf(
-							"address-book %q: invalid address %q", name, entry.Value))
-					}
+			if entry.Value == "" {
+				// An `address <name>` entry with no compiled prefix —
+				// either no prefix at all, or only an as-yet-uncompiled
+				// sub-stanza (dns-name/range-address/wildcard-address) —
+				// resolves to nothing: net.ParseCIDR("") errors at match
+				// time, so every policy referencing it denies (fail-closed,
+				// #2229). That is safe but silent, so surface the operator
+				// authoring error at commit. This is a WARNING, never a
+				// hard reject: an empty-prefix address never forwarded and
+				// rejecting it would brick existing configs.
+				warnings = append(warnings, fmt.Sprintf(
+					"address-book %q: no usable prefix configured; it will match nothing", name))
+				continue
+			}
+			if _, _, err := net.ParseCIDR(entry.Value); err != nil {
+				if net.ParseIP(entry.Value) == nil {
+					warnings = append(warnings, fmt.Sprintf(
+						"address-book %q: invalid address %q", name, entry.Value))
 				}
 			}
 		}

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -4897,3 +4897,169 @@ func TestAddressBookDescriptionResolvesInPolicy(t *testing.T) {
 		t.Fatalf("policy source-address h2 prefix not parseable: %v", perr)
 	}
 }
+
+// TestAddressBookEmptyValueWarns is the #2229 regression: after #2228 an
+// address-book `address <name>` entry that compiles with no usable prefix —
+// either no prefix at all (description-only) or only an as-yet-uncompiled
+// sub-stanza (dns-name/range-address/wildcard-address) — has Value=="". That
+// is fail-closed and safe at resolution (net.ParseCIDR("") errors → matches
+// nothing), but before this fix the warn validator skipped empty Values, so an
+// operator authoring error went silent. ValidateConfig must now emit a
+// non-blocking warning, while commit still succeeds (warning, not reject), and
+// an address WITH a valid prefix must produce NO warning (no false-positive).
+//
+// FAIL-ON-REVERT: revert compiler_validate_warn.go and the empty-Value subtests
+// lose their warning; the valid-prefix subtest still passes (proves the new
+// branch is the load-bearing change). Both AST shapes are exercised.
+func TestAddressBookEmptyValueWarns(t *testing.T) {
+	const wantMsg = `address-book "h2": no usable prefix configured; it will match nothing`
+
+	flatSet := func(t *testing.T, lines []string) *ConfigTree {
+		t.Helper()
+		tree := &ConfigTree{}
+		for _, cmd := range lines {
+			path, err := ParseSetCommand(cmd)
+			if err != nil {
+				t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+			}
+			if err := tree.SetPath(path); err != nil {
+				t.Fatalf("SetPath(%q): %v", cmd, err)
+			}
+		}
+		return tree
+	}
+	hier := func(t *testing.T, src string) *ConfigTree {
+		t.Helper()
+		p := NewParser(src)
+		tree, errs := p.Parse()
+		if len(errs) > 0 {
+			t.Fatalf("Parse hierarchical: %v", errs)
+		}
+		return tree
+	}
+
+	hasMsg := func(ws []string, msg string) bool {
+		for _, w := range ws {
+			if strings.Contains(w, msg) {
+				return true
+			}
+		}
+		return false
+	}
+	hasH2InvalidOrEmpty := func(ws []string) bool {
+		for _, w := range ws {
+			if strings.Contains(w, `address-book "h2": invalid address`) ||
+				strings.Contains(w, `address-book "h2": no usable prefix`) {
+				return true
+			}
+		}
+		return false
+	}
+
+	cases := []struct {
+		name      string
+		tree      func(t *testing.T) *ConfigTree
+		wantWarn  bool // expect the empty-prefix warning for h2
+		wantValue string
+	}{
+		{
+			name: "flat-set description-only (no prefix) warns",
+			tree: func(t *testing.T) *ConfigTree {
+				return flatSet(t, []string{
+					"set security address-book global address h2 description web-server",
+				})
+			},
+			wantWarn:  true,
+			wantValue: "",
+		},
+		{
+			name: "hierarchical description-only (no prefix) warns",
+			tree: func(t *testing.T) *ConfigTree {
+				return hier(t, `security {
+    address-book {
+        global {
+            address h2 {
+                description "web-server";
+            }
+        }
+    }
+}`)
+			},
+			wantWarn:  true,
+			wantValue: "",
+		},
+		{
+			name: "flat-set uncompiled sub-stanza (dns-name) warns",
+			tree: func(t *testing.T) *ConfigTree {
+				return flatSet(t, []string{
+					"set security address-book global address h2 dns-name example.com",
+				})
+			},
+			wantWarn:  true,
+			wantValue: "",
+		},
+		{
+			name: "flat-set valid prefix does NOT warn (no false-positive)",
+			tree: func(t *testing.T) *ConfigTree {
+				return flatSet(t, []string{
+					"set security address-book global address h2 192.168.2.0/24",
+				})
+			},
+			wantWarn:  false,
+			wantValue: "192.168.2.0/24",
+		},
+		{
+			name: "hierarchical valid prefix does NOT warn (no false-positive)",
+			tree: func(t *testing.T) *ConfigTree {
+				return hier(t, `security {
+    address-book {
+        global {
+            address h2 {
+                192.168.2.0/24;
+            }
+        }
+    }
+}`)
+			},
+			wantWarn:  false,
+			wantValue: "192.168.2.0/24",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := tc.tree(t)
+
+			// Commit succeeds (compiles without error) in BOTH cases — the
+			// empty-prefix entry is a warning, never a hard reject.
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("CompileConfig: %v (commit must succeed — warning, not reject)", err)
+			}
+			ab := cfg.Security.AddressBook
+			if ab == nil {
+				t.Fatal("AddressBook is nil")
+			}
+			addr := ab.Addresses["h2"]
+			if addr == nil {
+				t.Fatalf("address h2 dropped (got %d addresses)", len(ab.Addresses))
+			}
+			if addr.Value != tc.wantValue {
+				t.Errorf("address h2 Value = %q, want %q", addr.Value, tc.wantValue)
+			}
+
+			warnings := ValidateConfig(cfg)
+			if tc.wantWarn {
+				if !hasMsg(warnings, wantMsg) {
+					t.Errorf("expected empty-prefix warning %q, got warnings: %v", wantMsg, warnings)
+				}
+			} else {
+				// Valid prefix: no empty-prefix warning AND no invalid-address
+				// warning for h2 (no false-positive of either flavour).
+				if hasH2InvalidOrEmpty(warnings) {
+					t.Errorf("unexpected h2 address warning for a valid prefix: %v", warnings)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2229 (follow-up to #2228 / #2222).

## Problem

After #2228, an address-book `address <name>` entry that compiles with no
usable prefix — either no prefix at all (description-only) or only an
as-yet-uncompiled sub-stanza (`dns-name`/`range-address`/`wildcard-address`) —
has `Value == ""`. This is **fail-closed and safe** at resolution time
(`net.ParseCIDR("")` errors → the address matches nothing → every policy
referencing it denies), so it is NOT a security bug.

But the commit-time warn validator (`ValidateConfig` /
`compiler_validate_warn.go`) guarded the parse with `if entry.Value != ""`
and emitted `invalid address` only for a NON-empty unparseable `Value`. A
prefix-less entry therefore produced **no warning at all**, so an operator
authoring error (forgetting the prefix) went silent.

## Fix

Extend the address-book warn loop to emit a non-blocking warning for an
entry whose compiled `Value` is empty:

> `address-book "X": no usable prefix configured; it will match nothing`

This is a **WARNING, never a hard reject** — an empty-prefix address never
forwarded and rejecting it would brick existing committed configs (#1960
no-brick discipline). The non-empty branch is byte-identical to prior
behaviour, so there is no false-positive for valid prefixes.

`dns-name`/`range-address`/`wildcard-address` sub-stanzas remain uncompiled
(a separate pre-existing gap) and genuinely resolve to nothing today, so the
warning is correct to flag them too; the wording is generic ("no usable
prefix") rather than claiming a specifically-missing prefix.

## Tests

`TestAddressBookEmptyValueWarns` drives the real compile path for both AST
shapes (flat-set via `ParseSetCommand`+`SetPath`, hierarchical via
`NewParser`):

- flat-set description-only → warns
- hierarchical description-only → warns
- flat-set `dns-name` sub-stanza → warns
- flat-set valid prefix → does NOT warn (no false-positive)
- hierarchical valid prefix → does NOT warn (no false-positive)
- `CompileConfig` (commit) **succeeds** in every case (warning, not reject)

**Fail-on-revert proof:** reverting `compiler_validate_warn.go` drops the
warning for the three empty-Value subtests (FAIL) while the two valid-prefix
subtests still pass — proving the validator change is the load-bearing fix.

## Validation

- `go build ./...` — clean
- `go vet ./pkg/config/...` — clean
- `go test ./pkg/config/...` — ok
- docs/bugs.md updated under the #2222 entry; _Log.md line added

🤖 Generated with [Claude Code](https://claude.com/claude-code)