### PR TITLE
vrrp: fix data race on lastDropWarn (#2225)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,30 @@
 # Action Log
 
+## 2026-06-21 — #2225 VRRP data race on lastDropWarn (AF_PACKET fallback dual receivers)
+
+- **Timestamp**: 2026-06-21
+- **Action**: Fixed a Go data race on `vrrpInstance.lastDropWarn`. On the
+  AF_PACKET-fallback path `run()` starts two concurrent receiver goroutines
+  (`receiver()` IPv4 raw + `receiverIPv6()`); both call `warnRXDrop()` on a
+  full `rxCh`, which did an unsynchronized read-modify-write of the
+  `lastDropWarn time.Time` rate-limiter field (`go test -race` flag).
+  Converted `lastDropWarn` to `atomic.Int64` of Unix nanos updated with
+  `CompareAndSwap` (mirrors the existing `lastGARPTime` dampener); the CAS
+  preserves the once-per-10s dampener under contention (only the swapping
+  goroutine logs). Audited the two receiver paths for sibling races: no
+  other field is shared+mutated between them (`rxReceived`/`rxDrops` already
+  atomic; `localIPv6`/`key()`/`cfg` read-only on those paths). Added
+  `instance_rxdrop_race_test.go` (concurrent hammer + dampener-once +
+  interval-reset); fail-on-revert proven — `-race` flags the DATA RACE on
+  `lastDropWarn` (`warnRXDrop` instance.go) when reverted to `time.Time`,
+  clean with the atomic fix. Documented the dual-receiver concurrency model
+  in `pkg/vrrp/README.md`.
+- **File(s)**: pkg/vrrp/instance.go, pkg/vrrp/instance_rxdrop_race_test.go,
+  pkg/vrrp/README.md, _Log.md
+- **Validation**: `go build ./...` OK; `go vet ./pkg/vrrp/...` OK;
+  `go test ./pkg/vrrp/...` ok; `go test -race ./pkg/vrrp/...` ok.
+  make test-failover no-regression run PENDING-PARENT (VRRP/HA change).
+
 ## 2026-06-21 — #2243 PR #2254 review fixes: Kea MAC canonicalization + lenient validator gate
 
 - **Timestamp**: 2026-06-21

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -144,6 +144,24 @@ load/peer-sync compile paths.
   multicast on VLANs).
 - IPv6: separate raw socket; hop limit set to 255 per RFC.
 
+### Receiver goroutine model
+
+When AF_PACKET opens (`afPacketFD >= 0`), a single `receiverAfPacket()`
+goroutine handles both IPv4 and IPv6 (it captures full link-layer frames
+and dispatches by EtherType). When AF_PACKET is unavailable, `run()`
+falls back to the raw-socket path and starts **two concurrent receiver
+goroutines** — `receiver()` (IPv4 raw, proto 112) and, if an IPv6 socket
+exists, `receiverIPv6()` (`ip6:112`). Both feed the same per-instance
+`rxCh` and, on a full channel, both call `warnRXDrop()`. Every field
+they share on that drop path is therefore concurrency-safe: `rxReceived`
+and `rxDrops` are `atomic.Uint64`, and `lastDropWarn` (the once-per-10s
+warning rate-limiter) is an `atomic.Int64` of Unix nanos updated with
+`CompareAndSwap` — only the goroutine that swaps the stale timestamp logs
+the warning, so a concurrent drop burst yields one log line per interval
+(#2225, mirrors the `lastGARPTime` dampener). A plain `time.Time` here
+was an unsynchronized read-modify-write across the two goroutines (a
+`go test -race` data race).
+
 ### AF_PACKET cBPF filter + IPv6 extension headers (#2155)
 
 The AF_PACKET receiver attaches a cBPF prefilter

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -98,9 +98,14 @@ type vrrpInstance struct {
 	stopped chan struct{}
 
 	// RX backpressure counters (atomic).
-	rxDrops      atomic.Uint64 // packets dropped due to full rxCh
-	rxReceived   atomic.Uint64 // total packets delivered to rxCh
-	lastDropWarn time.Time     // last time we logged a drop warning (rate-limited)
+	rxDrops    atomic.Uint64 // packets dropped due to full rxCh
+	rxReceived atomic.Uint64 // total packets delivered to rxCh
+	// lastDropWarn is the Unix-nanos timestamp of the last drop warning we
+	// logged (rate-limited). It is an atomic.Int64 because warnRXDrop is
+	// called concurrently from both receiver() and receiverIPv6() on the
+	// AF_PACKET-fallback path (#2225); a plain time.Time would be a data
+	// race. Mirrors the lastGARPTime atomic pattern below.
+	lastDropWarn atomic.Int64
 
 	// GARP suppression for strict-vip-ownership mode.
 	suppressGARP  atomic.Bool   // when true, becomeMaster() skips GARP/NA
@@ -1434,14 +1439,27 @@ func (vi *vrrpInstance) resolveIPv6LinkLocal(vipSet map[string]bool) net.IP {
 }
 
 // warnRXDrop increments the drop counter and logs a rate-limited warning.
+//
+// warnRXDrop may run concurrently from both receiver() and receiverIPv6() on
+// the AF_PACKET-fallback path (#2225), so lastDropWarn is an atomic.Int64 of
+// Unix nanos and the read-modify-write is done with CompareAndSwap. The CAS
+// ensures the once-per-interval dampener holds even under contention: only the
+// goroutine that successfully swaps the stale timestamp emits the warning, so a
+// burst of concurrent drops produces a single log line per interval rather than
+// one per racing goroutine.
 func (vi *vrrpInstance) warnRXDrop() {
 	drops := vi.rxDrops.Add(1)
-	now := time.Now()
-	if now.Sub(vi.lastDropWarn) >= 10*time.Second {
-		vi.lastDropWarn = now
-		slog.Warn("vrrp: rx channel full, dropping advertisements",
-			"key", vi.key(), "total_drops", drops)
+	now := time.Now().UnixNano()
+	last := vi.lastDropWarn.Load()
+	if now-last < int64(10*time.Second) {
+		return
 	}
+	if !vi.lastDropWarn.CompareAndSwap(last, now) {
+		// Another goroutine just emitted the warning for this interval.
+		return
+	}
+	slog.Warn("vrrp: rx channel full, dropping advertisements",
+		"key", vi.key(), "total_drops", drops)
 }
 
 // stop signals the instance goroutine to stop and waits for it to finish.

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -1451,7 +1451,12 @@ func (vi *vrrpInstance) warnRXDrop() {
 	drops := vi.rxDrops.Add(1)
 	now := time.Now().UnixNano()
 	last := vi.lastDropWarn.Load()
-	if now-last < int64(10*time.Second) {
+	// Clamp negative elapsed: lastDropWarn is wall-clock UnixNano (not a
+	// monotonic time.Time), so a backward wall-clock step makes now-last
+	// negative — without the >= 0 guard that would read as "< 10s" and
+	// suppress drop warnings until the clock re-advances. Mirrors
+	// garpDampened's elapsed>=0 clamp (#1792).
+	if elapsed := now - last; elapsed >= 0 && elapsed < int64(10*time.Second) {
 		return
 	}
 	if !vi.lastDropWarn.CompareAndSwap(last, now) {

--- a/pkg/vrrp/instance_rxdrop_race_test.go
+++ b/pkg/vrrp/instance_rxdrop_race_test.go
@@ -1,0 +1,164 @@
+package vrrp
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #2225: warnRXDrop is invoked concurrently from receiver() and
+// receiverIPv6() on the AF_PACKET-fallback path (run() starts both goroutines
+// when afPacketFD < 0 and an IPv6 socket exists). Both touch the shared
+// lastDropWarn rate-limiter field. With lastDropWarn as a plain time.Time the
+// read-modify-write was an unsynchronized data race; `go test -race` flags it.
+// The fix makes lastDropWarn an atomic.Int64 of Unix nanos updated via
+// CompareAndSwap.
+//
+// These tests are the fail-on-revert gate: under -race they are CLEAN with the
+// atomic fix and DETECT the race if lastDropWarn is reverted to time.Time.
+
+// countingHandler counts emitted log records so the dampener semantics can be
+// asserted (warn at most once per interval).
+type countingHandler struct {
+	n *atomic.Int64
+}
+
+func (h countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h countingHandler) Handle(context.Context, slog.Record) error {
+	h.n.Add(1)
+	return nil
+}
+func (h countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h countingHandler) WithGroup(string) slog.Handler      { return h }
+
+// installCountingLogger swaps the default slog logger for one that counts
+// records, returning the counter and a restore function.
+func installCountingLogger(t *testing.T) (*atomic.Int64, func()) {
+	t.Helper()
+	var n atomic.Int64
+	prev := slog.Default()
+	slog.SetDefault(slog.New(countingHandler{n: &n}))
+	return &n, func() { slog.SetDefault(prev) }
+}
+
+// TestWarnRXDropConcurrent drives warnRXDrop from many goroutines at once,
+// mirroring the concurrent receiver()/receiverIPv6() call sites. To force the
+// read-modify-WRITE branch repeatedly (so the detector observes concurrent
+// writes, not just the single first write per 10s window), a companion goroutine
+// continually rewinds lastDropWarn past the dampening window. Under -race this
+// FAILS (race detected on lastDropWarn) if the field is reverted to an
+// unsynchronized time.Time, and is CLEAN with the atomic.Int64 fix.
+func TestWarnRXDropConcurrent(t *testing.T) {
+	_, restore := installCountingLogger(t)
+	defer restore()
+
+	vi := &vrrpInstance{cfg: Instance{Interface: "ge-0-0-2", GroupID: 1}}
+
+	const goroutines = 16
+	const perGoroutine = 4000
+
+	stale := time.Now().Add(-1 * time.Hour).UnixNano()
+	stopRewind := make(chan struct{})
+	var rewindWG sync.WaitGroup
+	rewindWG.Add(1)
+	go func() {
+		defer rewindWG.Done()
+		for {
+			select {
+			case <-stopRewind:
+				return
+			default:
+				// Keep the timestamp stale so concurrent warnRXDrop callers
+				// repeatedly take the write branch — this is what surfaces the
+				// write/write and write/read hazard under -race.
+				vi.lastDropWarn.Store(stale)
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				vi.warnRXDrop()
+			}
+		}()
+	}
+	wg.Wait()
+	close(stopRewind)
+	rewindWG.Wait()
+
+	// All drops must be counted regardless of synchronization.
+	if got := vi.rxDrops.Load(); got != goroutines*perGoroutine {
+		t.Fatalf("rxDrops = %d, want %d", got, goroutines*perGoroutine)
+	}
+}
+
+// TestWarnRXDropDampenerOnce verifies the rate-limiter still warns at most once
+// per interval even under heavy concurrency. The CompareAndSwap in warnRXDrop
+// ensures only the goroutine that swaps the stale timestamp emits the warning,
+// so a burst of concurrent drops yields exactly one log line per interval.
+func TestWarnRXDropDampenerOnce(t *testing.T) {
+	n, restore := installCountingLogger(t)
+	defer restore()
+
+	vi := &vrrpInstance{cfg: Instance{Interface: "ge-0-0-2", GroupID: 1}}
+
+	// First call seeds lastDropWarn from its zero value: now - 0 >> 10s, so it
+	// warns once. A concurrent burst that follows immediately is within the
+	// 10s window and must NOT add further warnings.
+	const goroutines = 32
+	const perGoroutine = 500
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				vi.warnRXDrop()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Every call is within a single 10s interval (the test runs in well under
+	// a second), so exactly one warning must have been emitted.
+	if got := n.Load(); got != 1 {
+		t.Fatalf("dampener emitted %d warnings within one interval, want exactly 1", got)
+	}
+}
+
+// TestWarnRXDropDampenerResetsAfterInterval confirms the dampener is a delay,
+// not a permanent gate: once the interval has elapsed, the next drop warns
+// again. lastDropWarn is rewound past the 10s window to simulate elapsed time
+// without sleeping.
+func TestWarnRXDropDampenerResetsAfterInterval(t *testing.T) {
+	n, restore := installCountingLogger(t)
+	defer restore()
+
+	vi := &vrrpInstance{cfg: Instance{Interface: "ge-0-0-2", GroupID: 1}}
+
+	vi.warnRXDrop() // warns once (seeds from zero)
+	if got := n.Load(); got != 1 {
+		t.Fatalf("first warn count = %d, want 1", got)
+	}
+
+	// A second drop immediately after is dampened.
+	vi.warnRXDrop()
+	if got := n.Load(); got != 1 {
+		t.Fatalf("warn count after dampened drop = %d, want 1", got)
+	}
+
+	// Rewind the last-warn timestamp past the 10s window; the next drop warns.
+	vi.lastDropWarn.Store(time.Now().Add(-11 * time.Second).UnixNano())
+	vi.warnRXDrop()
+	if got := n.Load(); got != 2 {
+		t.Fatalf("warn count after interval elapsed = %d, want 2", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2225 — a Go data race on `vrrpInstance.lastDropWarn`.

On the AF_PACKET-fallback path, `run()` starts two concurrent receiver
goroutines: `receiver()` (IPv4 raw, proto 112) and, when an IPv6 socket
is present, `receiverIPv6()` (`ip6:112`). Both feed the same per-instance
`rxCh` and, on a full channel, both call `warnRXDrop()`, which did an
unsynchronized read-modify-write of the `lastDropWarn time.Time`
rate-limiter field — a torn multi-word read and a lost-update on the
timestamp, flagged by `go test -race`.

## Fix

- `lastDropWarn` is now an `atomic.Int64` of Unix nanos, updated with
  `CompareAndSwap` — mirrors the existing `lastGARPTime` dampener in the
  same struct.
- The CAS preserves the once-per-10s dampener under contention: only the
  goroutine that swaps the stale timestamp logs, so a concurrent drop
  burst yields one log line per interval (not one per racing goroutine).
- `rxReceived`/`rxDrops` were already `atomic.Uint64`.

## Sibling-race audit

Audited both receiver paths: no other field is shared and mutated
between the two goroutines. `localIPv6`, `cfg`, and `key()` are read-only
on those paths; the counters are atomic. No other races found.

## Tests

`pkg/vrrp/instance_rxdrop_race_test.go`:
- `TestWarnRXDropConcurrent` — concurrent hammer; **fails under `-race`
  when reverted to `time.Time`, clean with the atomic fix** (fail-on-revert
  gate).
- `TestWarnRXDropDampenerOnce` — exactly one warning per interval under
  heavy concurrency.
- `TestWarnRXDropDampenerResetsAfterInterval` — dampener is a delay, not a
  permanent gate.

## Validation

- `go build ./...` — OK
- `go vet ./pkg/vrrp/...` — OK
- `go test ./pkg/vrrp/...` — ok
- `go test -race ./pkg/vrrp/...` — ok
- **Fail-on-revert proof**: with `lastDropWarn` reverted to `time.Time`,
  `-race` reports `WARNING: DATA RACE` / `Write at … warnRXDrop()
  instance.go`. Clean with the atomic fix.
- `make test-failover` no-regression run — **PENDING** (VRRP/HA change;
  the `-race` unit test is the primary correctness gate for this fix).

Docs: dual-receiver concurrency model documented in `pkg/vrrp/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
