### PR TITLE
#2221: converge same-generation install/delete reorder on the standby (#2170 residual)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9333,3 +9333,22 @@ top.
   standby mem-hold + takeover pre-seed/lease-add seed. test-failover + live
   lease-survives-failover smoke PENDING-PARENT before merge.
   **File(s)**: _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2221 (MEDIUM, residual of #2170) — same-generation install/delete
+  REORDER no longer leaves a stale session on the standby. Sender: a delete now
+  draws a FRESH generation strictly greater than the install it cancels
+  (takeDeleteGenV4/V6 -> nextInstallGen) instead of echoing it, so a delete
+  out-ranks its install on the wire. Receiver: an applied non-zero delete records
+  the delete generation as a TOMBSTONE in recvGenV4/V6 (no eviction) so a
+  reordered older install of the cancelled session is refused by the install
+  guard; gen-0 (legacy) delete still evicts. Last-writer-wins per key: standby
+  converges to the master's final state regardless of install/delete arrival
+  order. Composes with the #2170 gen-guard, the #2198 F1 overflow bound, the F2
+  bulk-barrier resetRecvGen, and the bulk reconcile. New regression tests drive
+  the real sender enqueue + receiver apply in wire order (both reorder
+  directions) and prove fail-on-revert. build/vet/test/-race green on
+  pkg/cluster. test-failover REQUIRED before merge (PENDING-PARENT).
+  **File(s)**: pkg/cluster/sync_conn.go, pkg/cluster/sync.go,
+  pkg/cluster/sync_gen_guard_test.go, docs/sync-protocol.md,
+  pkg/cluster/README.md, _Log.md

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -139,11 +139,15 @@ trailing `Generation uint64` (LE):
 
 **Semantics (sender, `pkg/cluster`):** a single process-wide strictly-monotonic
 counter (seeded from `CLOCK_MONOTONIC` nanos) stamps every install send
-(`QueueSession*`, sweep, bulk) and is recorded per wire key. A delete echoes the
-exact generation last stamped for that key and evicts the record, so the
-delete's generation is always same-domain as the entry the receiver stored.
-Generations are only ever compared per-`(sender,key)` — never across keys — so a
-single sender-local counter suffices.
+(`QueueSession*`, sweep, bulk) and is recorded per wire key. A delete draws a
+**fresh, strictly-greater** generation from the same counter (`takeDeleteGenV4/V6`
+→ `nextInstallGen`) rather than echoing the install's stamp, and evicts the
+sender record. A delete therefore always out-ranks the install it cancels — the
+property that lets the receiver order a reordered delete/install pair (see #2221
+below). A key never installed in this boot (no stamp recorded) yields `gen == 0`
+(legacy unconditional delete). Generations are only ever compared
+per-`(sender,key)` — never across keys — so a single sender-local counter
+suffices.
 
 **Semantics (receiver, `pkg/cluster`):** `SessionSync` keeps the authoritative
 per-key stored generation in its own map (the BPF C conntrack struct stays
@@ -154,11 +158,15 @@ generation-free). The apply layer:
   with both non-zero → refuse (`DeletesStaleIgnored++`), short-circuiting BOTH
   the BPF map delete and the helper. Equality applies (the delete of the very
   session installed); `gen == 0` on either side falls back to today's
-  unconditional delete (rolling-upgrade safe).
+  unconditional delete (rolling-upgrade safe). On an applied **non-zero** delete
+  the stored generation is **upgraded to the delete generation as a TOMBSTONE**
+  (not evicted), so a reordered older install of the cancelled session is refused
+  by the install guard (#2221). A `gen == 0` delete evicts (no tombstone).
 - **Install guard** (`installClusterSynced*`): refuse to overwrite a stored
-  entry with a strictly-older-generation install (`InstallsStaleIgnored++`) so
-  the per-key stored generation never regresses (closes the delayed-stale-install
-  variant).
+  entry (live OR a delete tombstone) with a strictly-older-generation install
+  (`incoming < stored` → `InstallsStaleIgnored++`) so the per-key stored
+  generation never regresses (closes the delayed-stale-install variant AND the
+  reordered-install-after-delete residual).
 
 The userspace helper mirrors the same field on its in-memory
 `SyncedSessionEntry` (via `SessionSyncRequest.generation`) and enforces the
@@ -171,9 +179,12 @@ any pair where either end lacks a generation.
 
 Both the sender echo maps (`genSentV4/V6`) and the receiver stored-generation
 maps (`recvGenV4/V6`) are bounded by `genGuardMapCap` (200000) so a churning
-workload cannot grow them without limit. Entries are normally evicted on the
-matching delete; the cap is the safety valve for keys whose delete never
-arrives (e.g. a dropped close delta).
+workload cannot grow them without limit. Sender entries are evicted on the
+matching delete. Receiver entries are evicted on a `gen == 0` (legacy) delete
+but a non-zero delete **records a tombstone in place** (#2221, see below); the
+cap (via `putGenBounded`) plus the bulk-barrier `resetRecvGen` keep the
+receiver map bounded under steady churn, and the cap is also the safety valve
+for keys whose delete never arrives (e.g. a dropped close delta).
 
 On overflow the map is **never cleared**. A map at cap updates an EXISTING key
 in place (its stored generation is never dropped) and **skip-records** a NEW
@@ -218,6 +229,47 @@ key are ever applied concurrently, so the per-key stored generation cannot be
 interleaved between the guard read and the record write. Holding `recvGenMu`
 across the dataplane `Put` would serialize unrelated keys under dataplane I/O
 for no benefit the single-active-fabric invariant doesn't already provide.
+
+### Same-generation install/delete reorder (#2221, residual of #2170)
+
+The #2170 guard assumes per-key generations are strictly monotonic so a stale
+(older-generation) delete is refused. The **residual** hazard is WITHIN a single
+generation domain: the gen-stamp and the `sendCh` enqueue are not atomic, and two
+producer goroutines mutate the same key — the 1s sweep re-stamps a LIVE session
+to generation `N` and queues an install carrying `N`, while the userspace
+delta-drain takes the close and (pre-fix) echoed that same `N` on the delete. The
+delete can then win the `sendCh` enqueue race and be sent BEFORE the install. The
+receiver applies `delete(N)` then `install(N)`. Because the guards refuse only a
+*strictly-older* operation, an equal-`N` install after an equal-`N` delete was
+re-applied — the standby resurrected a session the master had already closed
+(the stale-RETAIN inverse of #2170, this time triggered by reorder rather than a
+journaled replay).
+
+The fix makes convergence **order-independent (last-writer-wins per key)** with
+two composed changes:
+
+1. **Sender** — a delete draws a FRESH generation strictly greater than the
+   install it cancels (`takeDeleteGenV4/V6` → `nextInstallGen`, see above)
+   instead of echoing it. A delete therefore always out-ranks its install.
+2. **Receiver** — an applied non-zero delete records the delete generation as a
+   **tombstone** in `recvGenV4/V6` (it does not evict). A reordered install of
+   the cancelled session carries the OLDER install generation, so the install
+   guard (`incoming < stored`) refuses it (`InstallsStaleIgnored++`) and the
+   standby stays GONE — matching the master. A genuinely newer incarnation,
+   re-established and re-stamped by a later sweep, carries a strictly-greater
+   generation than the tombstone and still installs.
+
+Both reorder directions, and the in-order close, converge to the master's final
+state: GONE when the master deleted last, PRESENT when a strictly-newer install
+arrived last. The tombstone is bounded by `genGuardMapCap` and cleared by the
+bulk barrier (`resetRecvGen`), which also handles the cross-boot generation
+regression (#2198 F2) so a tombstone never blocks a legitimate cold-start
+re-prime. Regression coverage: `TestSameGenReorderDeleteThenInstallConverges{V4,
+V6}` (drives the real sender enqueue + receiver apply in wire order),
+`TestReorderedInstallRefusedByTombstoneV4`,
+`TestReestablishAfterDeleteAppliesV4`, and
+`TestDeleteGenerationStrictlyGreaterThanInstall{V4,V6}` in
+`pkg/cluster/sync_gen_guard_test.go`.
 
 ## Config Payload (Variable)
 

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -208,12 +208,15 @@ outside the monitor loop:
   `(key,value)` snapshot. Reverse-session, DNAT/DNATv6, and persistent-NAT
   side effects are backend-owned; do not add local map cleanup in
   `pkg/cluster`.
-- **Install-generation delete guard (#2170)**: every session install and every
-  delete carries a per-`(sender,key)` monotonic install generation as a
+- **Install-generation delete guard (#2170, #2221)**: every session install and
+  every delete carries a per-`(sender,key)` monotonic install generation as a
   length-gated trailing `uint64` (see `docs/sync-protocol.md`). The sender
   (`sync_conn.go`/`sync_bulk.go`) stamps installs from a single boot-seeded
-  counter and the matching delete **echoes** the install generation it cancels
-  (so the comparison is always same-domain, even across an ownership change).
+  counter. A delete draws a **fresh, strictly-greater** generation
+  (`takeDeleteGenV4/V6` → `nextInstallGen`) rather than echoing the install's
+  stamp, so a delete always out-ranks the install it cancels — this is what makes
+  a reordered delete/install pair orderable (#2221). The comparison is always
+  same-`(sender,key)`-domain, even across an ownership change.
   The receiver keeps the authoritative per-key stored generation in
   `SessionSync.recvGenV4/V6` (the BPF C struct stays generation-free) and the
   apply layer refuses a delete whose generation is **strictly older** than the
@@ -225,16 +228,25 @@ outside the monitor loop:
   replacement that was re-synced with a newer generation. Do NOT reuse the
   synthesized `SessionID` for this — it is non-monotonic
   (`now_seconds<<16|slot`) and collides on same-second/same-slot reuse.
-  The generation maps are bounded by `genGuardMapCap` (200000); on overflow
-  the map is NEVER cleared (#2198 F1) — an existing key updates in place, a new
-  key skip-records (degrades to safe gen-0) and bumps `GenMapOverflow`. The
-  receiver also RESETS `recvGenV4/V6` when the peer begins a bulk transfer
-  (`resetRecvGen` from the `syncMsgBulkStart` handler, #2198 F2) so a rebooted
-  peer — whose monotonic-seeded counter legitimately restarts lower — has its
-  cold-start bulk re-prime accepted instead of refused as stale (the
-  stale-RETAIN inverse of #2170). The check→Put→record apply sequence is not
-  held under one `recvGenMu` acquisition; it is safe because the per-peer
-  receive path is single-threaded over the single active fabric (#2198 F3).
+  **#2221 (same-generation reorder residual):** an applied non-zero delete now
+  records the delete generation as a **TOMBSTONE** in `recvGenV4/V6` (it does not
+  evict). A reordered install of the very session that delete cancelled carries
+  the OLDER install generation and is refused by the install guard, so the
+  standby converges to the master's state (session GONE) regardless of
+  install/delete arrival order; a genuinely newer incarnation (re-stamped by a
+  later sweep) carries a higher generation and still installs (last-writer-wins).
+  A `gen == 0` (legacy) delete still evicts. The generation maps are bounded by
+  `genGuardMapCap` (200000); on overflow the map is NEVER cleared (#2198 F1) — an
+  existing key updates in place, a new key skip-records (degrades to safe gen-0)
+  and bumps `GenMapOverflow`. The receiver also RESETS `recvGenV4/V6` when the
+  peer begins a bulk transfer (`resetRecvGen` from the `syncMsgBulkStart`
+  handler, #2198 F2) so a rebooted peer — whose monotonic-seeded counter
+  legitimately restarts lower — has its cold-start bulk re-prime accepted instead
+  of refused as stale (the stale-RETAIN inverse of #2170), and so a delete
+  tombstone never permanently blocks a legitimate cold re-prime. The
+  check→Put→record apply sequence is not held under one `recvGenMu` acquisition;
+  it is safe because the per-peer receive path is single-threaded over the single
+  active fabric (#2198 F3).
 - Dual-active overlap is intentional: primary sets `rg_active=true`
   immediately on becoming master; secondary defers `rg_active=false` until
   it sees the VRRP BACKUP event. Brief overlap, never both inactive.

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -326,17 +326,21 @@ type SessionSync struct {
 	// so it never regresses below a value a peer may already hold across
 	// this node's restarts within a boot. Every session install (Queue*,
 	// sweep, bulk) draws genCounter.Add(1) and records it in genSentV4/V6
-	// keyed by the wire key. A delete echoes the recorded generation (the
-	// exact g of the install it cancels) and evicts the map entry, so the
-	// delete's generation is always same-domain as the entry the receiver
-	// stored. Generations are only ever compared per-(sender,key), never
-	// across keys, so a single sender-local counter is sufficient and no
-	// cross-node agreement on absolute values is required.
+	// keyed by the wire key. A delete draws a FRESH generation strictly
+	// greater than the install it cancels (takeDeleteGen*, #2221) and evicts
+	// the sender map entry, so the delete always out-ranks its install — the
+	// property that lets the receiver order a reordered delete/install pair.
+	// Generations are only ever compared per-(sender,key), never across keys,
+	// so a single sender-local counter is sufficient and no cross-node
+	// agreement on absolute values is required.
 	//
 	// Receiver side: recvGenV4/V6 is the authoritative per-key stored
-	// generation (the BPF C struct stays generation-free, SMR fix #3). It
-	// is set on install-apply and consulted by both the install guard and
-	// the delete guard, then evicted on delete-apply.
+	// generation (the BPF C struct stays generation-free, SMR fix #3). It is
+	// set on install-apply and consulted by both the install guard and the
+	// delete guard. An applied non-zero delete upgrades the entry to the
+	// delete generation as a TOMBSTONE (#2221) rather than evicting, so a
+	// reordered older install of the cancelled session is refused; a gen-0
+	// (legacy) delete evicts.
 	genCounter atomic.Uint64
 	genSentMu  sync.Mutex
 	genSentV4  map[dataplane.SessionKey]uint64

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -100,24 +100,47 @@ func (s *SessionSync) stampInstallGenV6(key dataplane.SessionKeyV6, val *datapla
 	s.genSentMu.Unlock()
 }
 
-// takeDeleteGenV4 returns the generation last stamped for this wire key and
-// evicts the entry, so a delete carries the exact generation of the install it
-// cancels. A key never installed in this boot returns 0 (legacy fallback →
-// unconditional delete in the apply guard), which is the safe behavior.
+// takeDeleteGenV4 returns the generation a delete for this wire key should
+// carry and evicts the sender-side stamp.
+//
+// #2221: the delete draws a FRESH, strictly-greater generation
+// (nextInstallGen) rather than echoing the install's stamp. The stamp and the
+// sendCh enqueue are not atomic and two producer goroutines (the sweep
+// stamping a live re-send, the delta-drain taking the close) mutate the same
+// key, so a delete can be enqueued onto sendCh BEFORE the install it cancels.
+// On the wire the receiver then applies delete then install with IDENTICAL
+// generations; the receiver guards only refuse a STRICTLY-older operation, so
+// the late install resurrects the closed session (the #2170 residual:
+// stale-RETAIN rather than stale-delete). Drawing a fresh generation that is
+// strictly greater than every prior install of this key makes a delete always
+// out-rank the install it cancels: the receiver's install guard refuses a
+// reordered older install (incoming < the delete tombstone), while a genuinely
+// newer incarnation (re-established + re-stamped by a later sweep) carries an
+// even higher generation and still applies. This composes with #2170: the
+// per-key generation only ever climbs, so a journaled stale delete from before
+// a re-sync is still strictly older than the live entry and refused.
+//
+// A key never installed in this boot (no stamp recorded) returns 0 (legacy
+// fallback → unconditional delete in the apply guard), which is the safe
+// behavior and preserves rolling-upgrade compatibility.
 func (s *SessionSync) takeDeleteGenV4(key dataplane.SessionKey) uint64 {
 	s.genSentMu.Lock()
 	defer s.genSentMu.Unlock()
-	g := s.genSentV4[key]
+	if _, ok := s.genSentV4[key]; !ok {
+		return 0
+	}
 	delete(s.genSentV4, key)
-	return g
+	return s.nextInstallGen()
 }
 
 func (s *SessionSync) takeDeleteGenV6(key dataplane.SessionKeyV6) uint64 {
 	s.genSentMu.Lock()
 	defer s.genSentMu.Unlock()
-	g := s.genSentV6[key]
+	if _, ok := s.genSentV6[key]; !ok {
+		return 0
+	}
 	delete(s.genSentV6, key)
-	return g
+	return s.nextInstallGen()
 }
 
 // installGenGuardV4 implements the receiver-side install-side guard (#2170 SMR
@@ -188,9 +211,21 @@ func (s *SessionSync) recordInstalledGenV6(key dataplane.SessionKeyV6, gen uint6
 // is refused only when both the stored and delete generations are non-zero and
 // the delete generation is STRICTLY older than the stored entry's. Equality
 // applies (it is the delete of the very session installed); gen==0 on either
-// side falls back to today's unconditional delete (rolling-upgrade safe). On
-// an applied delete the stored generation is evicted. The bool reports whether
-// the delete should proceed.
+// side falls back to today's unconditional delete (rolling-upgrade safe). The
+// bool reports whether the delete should proceed.
+//
+// #2221: on an applied delete the stored generation is NOT evicted — it is
+// upgraded to the (strictly-greater, see takeDeleteGenV4) delete generation as
+// a TOMBSTONE. A subsequent reordered install that carries the OLDER generation
+// of the very session this delete cancelled is then refused by installGenGuard*
+// (incoming < the tombstone), so the standby converges to the master's state
+// (session GONE) regardless of install/delete arrival order. A genuinely newer
+// incarnation re-established and re-stamped by a later sweep carries a higher
+// generation and still applies (incoming > tombstone). A gen-0 (legacy) delete
+// evicts (no tombstone to record) — the legacy unconditional path is unchanged.
+// Tombstones are bounded by genGuardMapCap (putGenBounded) and cleared by the
+// bulk barrier (resetRecvGen), so a churning workload cannot grow the map
+// without limit and a cross-boot generation regression is handled at BulkStart.
 func (s *SessionSync) deleteGenGuardV4(key dataplane.SessionKey, deleteGen uint64) bool {
 	s.recvGenMu.Lock()
 	defer s.recvGenMu.Unlock()
@@ -198,7 +233,18 @@ func (s *SessionSync) deleteGenGuardV4(key dataplane.SessionKey, deleteGen uint6
 	if stored != 0 && deleteGen != 0 && deleteGen < stored {
 		return false
 	}
-	delete(s.recvGenV4, key)
+	if deleteGen != 0 {
+		// Record the delete generation as a tombstone so a reordered older
+		// install of the cancelled session is refused. Bounded; never clears.
+		if s.recvGenV4 == nil {
+			s.recvGenV4 = make(map[dataplane.SessionKey]uint64)
+		}
+		if !putGenBounded(s.recvGenV4, key, deleteGen) {
+			s.stats.GenMapOverflow.Add(1)
+		}
+	} else {
+		delete(s.recvGenV4, key)
+	}
 	return true
 }
 
@@ -209,7 +255,16 @@ func (s *SessionSync) deleteGenGuardV6(key dataplane.SessionKeyV6, deleteGen uin
 	if stored != 0 && deleteGen != 0 && deleteGen < stored {
 		return false
 	}
-	delete(s.recvGenV6, key)
+	if deleteGen != 0 {
+		if s.recvGenV6 == nil {
+			s.recvGenV6 = make(map[dataplane.SessionKeyV6]uint64)
+		}
+		if !putGenBounded(s.recvGenV6, key, deleteGen) {
+			s.stats.GenMapOverflow.Add(1)
+		}
+	} else {
+		delete(s.recvGenV6, key)
+	}
 	return true
 }
 
@@ -772,9 +827,12 @@ func (s *SessionSync) QueueSessionV6(key dataplane.SessionKeyV6, val dataplane.S
 
 // QueueDeleteV4 queues a v4 session deletion for synchronization. If the peer
 // is disconnected, the delete is journaled for replay on reconnect. The delete
-// echoes the install generation last stamped for this key (#2170) so a
-// journaled delete that replays after a same-key replacement was re-synced is
-// refused by the peer (its generation is strictly older than the live entry).
+// draws a fresh generation strictly greater than the install it cancels
+// (takeDeleteGenV4, #2170 + #2221) so (a) a journaled delete that replays after
+// a same-key replacement was re-synced is refused by the peer (its generation
+// is strictly older than the live entry) and (b) a delete reordered ahead of
+// its own install out-ranks it, letting the peer's tombstone refuse the late
+// install of the cancelled session.
 func (s *SessionSync) QueueDeleteV4(key dataplane.SessionKey) {
 	gen := s.takeDeleteGenV4(key)
 	msg := encodeDeleteV4(key, gen)

--- a/pkg/cluster/sync_gen_guard_test.go
+++ b/pkg/cluster/sync_gen_guard_test.go
@@ -179,11 +179,14 @@ func TestStaleInstallDoesNotRegressStoredGen(t *testing.T) {
 	}
 }
 
-// TestSenderEchoesInstallGenerationV4 verifies the sender stamps a fresh,
-// strictly-increasing generation on every install send and echoes the exact
-// install generation on the matching delete (SMR fix #1). This is the property
-// that makes a journaled delete strictly older than a re-synced replacement.
-func TestSenderEchoesInstallGenerationV4(t *testing.T) {
+// TestDeleteGenerationStrictlyGreaterThanInstallV4 (#2221) verifies the sender
+// stamps a fresh, strictly-increasing generation on every install send and that
+// the matching delete draws a FRESH generation STRICTLY GREATER than the last
+// install of the key (rather than echoing it). A delete out-ranking its install
+// is what lets the receiver order a reordered delete-then-install pair (the
+// delete tombstone refuses the late, lower-generation install of the cancelled
+// session). A key never installed still returns 0 (legacy unconditional path).
+func TestDeleteGenerationStrictlyGreaterThanInstallV4(t *testing.T) {
 	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
 	ss.stats.Connected.Store(true)
 	key := gen2170KeyV4()
@@ -202,14 +205,37 @@ func TestSenderEchoesInstallGenerationV4(t *testing.T) {
 		t.Fatalf("second install generation %d must be strictly greater than first %d", g2, g1)
 	}
 
-	// The delete echoes the LAST stamped generation for the key.
-	if echoed := ss.takeDeleteGenV4(key); echoed != g2 {
-		t.Fatalf("delete echoed generation %d, want last-installed %d", echoed, g2)
+	// The delete draws a fresh generation strictly greater than the last
+	// install, so it out-ranks the install it cancels.
+	del := ss.takeDeleteGenV4(key)
+	if del <= g2 {
+		t.Fatalf("delete generation %d must be strictly greater than last install %d (#2221)", del, g2)
 	}
-	// After the echo the entry is evicted; a second delete returns 0 (legacy
-	// fallback) rather than a stale value.
-	if echoed := ss.takeDeleteGenV4(key); echoed != 0 {
-		t.Fatalf("delete after eviction echoed %d, want 0", echoed)
+	// After the take the entry is evicted; a second delete returns 0 (legacy
+	// fallback) rather than a stale or fresh value.
+	if again := ss.takeDeleteGenV4(key); again != 0 {
+		t.Fatalf("delete after eviction returned %d, want 0", again)
+	}
+}
+
+// TestDeleteGenerationStrictlyGreaterThanInstallV6 mirrors the V4 #2221 contract.
+func TestDeleteGenerationStrictlyGreaterThanInstallV6(t *testing.T) {
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	ss.stats.Connected.Store(true)
+	key := gen2170KeyV6()
+
+	val := dataplane.SessionValueV6{}
+	ss.stampInstallGenV6(key, &val)
+	g1 := val.Generation
+	if g1 == 0 {
+		t.Fatal("first install generation must be non-zero")
+	}
+	del := ss.takeDeleteGenV6(key)
+	if del <= g1 {
+		t.Fatalf("delete generation %d must be strictly greater than install %d (#2221)", del, g1)
+	}
+	if again := ss.takeDeleteGenV6(key); again != 0 {
+		t.Fatalf("delete after eviction returned %d, want 0", again)
 	}
 }
 
@@ -598,14 +624,21 @@ func TestGenGuardConcurrentMaps(t *testing.T) {
 				if apply {
 					ss.recordInstalledGenV4(key, rec)
 				}
-				_ = ss.deleteGenGuardV4(key, val.Generation)
+				// #2221: a non-zero delete generation records a tombstone in
+				// recvGenV4 rather than evicting, so the receiver map retains a
+				// per-key entry. Use a fresh, strictly-greater delete generation
+				// (as the real sender does via takeDeleteGenV4) so the delete
+				// out-ranks its install.
+				_ = ss.deleteGenGuardV4(key, ss.nextInstallGen())
 			}
 		}(w)
 	}
 	wg.Wait()
 
-	// Every key was install-then-delete-guarded at equal generation, so both
-	// maps must be fully drained.
+	// Every key was install-then-delete-guarded. The sender map evicts on
+	// delete, so genSentV4 must be fully drained. The receiver map records the
+	// delete generation as a tombstone (#2221) rather than evicting, so it
+	// retains exactly one entry per distinct key (bounded by genGuardMapCap).
 	ss.genSentMu.Lock()
 	sentRemaining := len(ss.genSentV4)
 	ss.genSentMu.Unlock()
@@ -615,7 +648,177 @@ func TestGenGuardConcurrentMaps(t *testing.T) {
 	if sentRemaining != 0 {
 		t.Fatalf("genSentV4 not drained: %d entries remain", sentRemaining)
 	}
-	if recvRemaining != 0 {
-		t.Fatalf("recvGenV4 not drained: %d entries remain", recvRemaining)
+	if recvRemaining == 0 || recvRemaining > genGuardMapCap {
+		t.Fatalf("recvGenV4 tombstone count = %d, want (0, %d]", recvRemaining, genGuardMapCap)
+	}
+}
+
+// --- #2221: same-generation install/delete reorder convergence -------------
+
+// applySendChInOrder drains the sender's sendCh and applies each framed message
+// to the SAME SessionSync's receiver apply path in the exact order it was
+// enqueued. This models a single ACTIVE fabric: the receiver applies messages
+// in the order the sender placed them on the wire, so whichever of the
+// install/delete pair won the enqueue race is applied first. Returns the count
+// drained.
+func applySendChInOrder(t *testing.T, ss *SessionSync) int {
+	t.Helper()
+	n := 0
+	for {
+		select {
+		case msg := <-ss.sendCh:
+			if len(msg) < syncHeaderSize {
+				t.Fatalf("framed message too short: %d", len(msg))
+			}
+			ss.handleMessage(nil, msg[4], msg[syncHeaderSize:])
+			n++
+		default:
+			return n
+		}
+	}
+}
+
+// TestSameGenReorderDeleteThenInstallConvergesV4 is the #2170 RESIDUAL (#2221):
+// within the SAME generation domain, a session's install and its cancelling
+// delete are reordered on sendCh so the receiver applies DELETE then INSTALL.
+// The master closed the session, so the standby MUST end with the session GONE.
+//
+// It drives the REAL sender enqueue path: the sweep stamps a live key (model:
+// stampInstallGenV4 + queue the install), then the delta-drain takes the close
+// (QueueDeleteV4), then the install is enqueued AFTER the delete — exactly the
+// "delete wins the sendCh enqueue race" ordering the issue documents. Both
+// messages then apply through handleMessage in enqueue order.
+//
+// Pre-fix (delete echoes the install's IDENTICAL generation, delete evicts the
+// stored generation): delete(N) applies + evicts; install(N) sees stored==0 →
+// applies → the closed session is RESURRECTED on the standby. This FAILS.
+// Post-fix (delete draws a strictly-greater generation + records a tombstone):
+// delete(N+1) applies + tombstones N+1; install(N) is N < N+1 → REFUSED. GONE.
+func TestSameGenReorderDeleteThenInstallConvergesV4(t *testing.T) {
+	key := gen2170KeyV4()
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	ss.stats.Connected.Store(true)
+
+	// The sweep re-stamps the LIVE session and builds the install message.
+	val := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 1, EgressZone: 2}
+	ss.stampInstallGenV4(key, &val)
+	installMsg := encodeSessionV4(key, val)
+
+	// The delta-drain closes the session and enqueues the delete FIRST (it won
+	// the enqueue race against the still-queued install).
+	ss.QueueDeleteV4(key)
+	// The install is enqueued AFTER the delete.
+	if !ss.queueMessage(installMsg, &ss.stats.SessionsSent, "test_install_v4") {
+		t.Fatal("install enqueue failed")
+	}
+
+	// Apply in wire (enqueue) order: delete then install.
+	if got := applySendChInOrder(t, ss); got != 2 {
+		t.Fatalf("expected to drain 2 messages, drained %d", got)
+	}
+
+	if _, ok := dp.v4sessions[key]; ok {
+		t.Fatal("#2221: reordered delete-then-install resurrected the closed session on the standby (master deleted it last)")
+	}
+}
+
+func TestSameGenReorderDeleteThenInstallConvergesV6(t *testing.T) {
+	key := gen2170KeyV6()
+	dp := &mockSweepDP{v6sessions: map[dataplane.SessionKeyV6]dataplane.SessionValueV6{}}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	ss.stats.Connected.Store(true)
+
+	val := dataplane.SessionValueV6{State: dataplane.SessStateEstablished, IngressZone: 1, EgressZone: 2}
+	ss.stampInstallGenV6(key, &val)
+	installMsg := encodeSessionV6(key, val)
+
+	ss.QueueDeleteV6(key)
+	if !ss.queueMessage(installMsg, &ss.stats.SessionsSent, "test_install_v6") {
+		t.Fatal("install enqueue failed")
+	}
+
+	if got := applySendChInOrder(t, ss); got != 2 {
+		t.Fatalf("expected to drain 2 messages, drained %d", got)
+	}
+	if _, ok := dp.v6sessions[key]; ok {
+		t.Fatal("#2221: reordered v6 delete-then-install resurrected the closed session on the standby")
+	}
+}
+
+// TestSameGenInstallThenDeleteConvergesV4 is the in-order half of #2221: the
+// install is enqueued before its cancelling delete (the common case). The
+// standby must still end with the session GONE. This guards against a fix that
+// only handled the reorder direction and broke the normal path.
+func TestSameGenInstallThenDeleteConvergesV4(t *testing.T) {
+	key := gen2170KeyV4()
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	ss.stats.Connected.Store(true)
+
+	val := dataplane.SessionValue{State: dataplane.SessStateEstablished, IngressZone: 1, EgressZone: 2}
+	ss.stampInstallGenV4(key, &val)
+	installMsg := encodeSessionV4(key, val)
+
+	// Install first, then the delete.
+	if !ss.queueMessage(installMsg, &ss.stats.SessionsSent, "test_install_v4") {
+		t.Fatal("install enqueue failed")
+	}
+	ss.QueueDeleteV4(key)
+
+	if got := applySendChInOrder(t, ss); got != 2 {
+		t.Fatalf("expected to drain 2 messages, drained %d", got)
+	}
+	if _, ok := dp.v4sessions[key]; ok {
+		t.Fatal("#2221: in-order install-then-delete left a stale session (the normal close path regressed)")
+	}
+}
+
+// TestReestablishAfterDeleteAppliesV4 (#2221): after a session is closed (its
+// delete recorded a tombstone), a GENUINELY NEW incarnation of the same key —
+// re-established and re-stamped by a later sweep with a strictly-greater
+// generation — MUST install. The tombstone must not block a legitimately newer
+// session. This is the "install last, present" half of last-writer-wins.
+func TestReestablishAfterDeleteAppliesV4(t *testing.T) {
+	key := gen2170KeyV4()
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+
+	// Install gen=5, delete at a strictly-greater gen=6 (as the fixed sender
+	// produces). The delete applies and tombstones gen=6.
+	installWithGenV4(ss, key, 5)
+	ss.deleteClusterSyncedV4(key, 6)
+	if _, ok := dp.v4sessions[key]; ok {
+		t.Fatal("delete did not remove the session")
+	}
+
+	// A new incarnation re-established later carries a higher generation (the
+	// sweep re-stamps from a strictly-monotonic counter) and MUST install.
+	installWithGenV4(ss, key, 7)
+	if _, ok := dp.v4sessions[key]; !ok {
+		t.Fatal("#2221: a genuinely newer incarnation (gen>tombstone) was wrongly blocked by the delete tombstone")
+	}
+	if got := ss.stats.InstallsStaleIgnored.Load(); got != 0 {
+		t.Fatalf("InstallsStaleIgnored = %d, want 0 for a newer-generation re-establishment", got)
+	}
+}
+
+// TestReorderedInstallRefusedByTombstoneV4 (#2221, apply-layer unit): a delete
+// applies at gen=6 (tombstone), then the OLDER install (gen=5) of the very
+// session that delete cancelled arrives late and MUST be refused — the standby
+// stays GONE. This is the direct receiver-side property the wire test exercises
+// end-to-end.
+func TestReorderedInstallRefusedByTombstoneV4(t *testing.T) {
+	key := gen2170KeyV4()
+	dp := &mockSweepDP{v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{}}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+
+	ss.deleteClusterSyncedV4(key, 6) // tombstone gen=6 (no prior stored entry)
+	installWithGenV4(ss, key, 5)     // reordered older install — must be refused
+	if _, ok := dp.v4sessions[key]; ok {
+		t.Fatal("#2221: a reordered older install (gen<tombstone) resurrected the closed session")
+	}
+	if got := ss.stats.InstallsStaleIgnored.Load(); got != 1 {
+		t.Fatalf("InstallsStaleIgnored = %d, want 1 (the reordered install must be refused by the tombstone)", got)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #2221 — the **same-generation install/delete REORDER** residual of #2170.

The #2170 install-generation guard refuses a strictly-older delete so a stale
(older-generation) delete cannot kill a same-5-tuple session re-established in a
newer generation. The **residual** is WITHIN a single generation domain: the
gen-stamp and the `sendCh` enqueue are not atomic, and two producer goroutines
mutate the same key — the 1s sweep re-stamps a LIVE session to generation `N` and
queues an install carrying `N`, while the userspace delta-drain takes the close
and (pre-fix) echoed that same `N` on the delete. The delete can win the `sendCh`
enqueue race and be sent BEFORE the install. The receiver applies `delete(N)`
then `install(N)`; because the guards refuse only a *strictly-older* operation,
the equal-`N` install after the equal-`N` delete was re-applied — the standby
**resurrected a session the master had already closed** (the stale-RETAIN inverse
of #2170, triggered by reorder rather than a journaled replay).

## Fix (last-writer-wins per key, order-independent)

Two composed changes (`pkg/cluster/sync_conn.go`):

1. **Sender** — a delete draws a **fresh generation strictly greater** than the
   install it cancels (`takeDeleteGenV4/V6` → `nextInstallGen`) instead of echoing
   it, so a delete always out-ranks its install on the wire. A key never installed
   in this boot still yields `gen == 0` (legacy unconditional delete), preserving
   rolling-upgrade compatibility.
2. **Receiver** — an applied non-zero delete records the delete generation as a
   **TOMBSTONE** in `recvGenV4/V6` (it does not evict). A reordered install of the
   cancelled session carries the OLDER install generation and is refused by the
   install guard (`incoming < stored`), so the standby stays GONE — matching the
   master. A genuinely newer incarnation (re-stamped by a later sweep) carries a
   strictly-greater generation and still installs. A `gen == 0` (legacy) delete
   still evicts.

The standby's final state equals the master's after every same-gen install+delete
interleaving: GONE when the master deleted last, PRESENT when a strictly-newer
install arrived last.

### Composition (no regression)
- **#2170 gen-guard**: deletes/installs are still compared per-`(sender,key)` and
  the per-key generation only climbs — a journaled stale delete is still refused.
- **#2198 F1 overflow bound**: tombstones go through `putGenBounded`; the map is
  never cleared and is bounded by `genGuardMapCap`.
- **#2198 F2 bulk-barrier `resetRecvGen`**: a tombstone never blocks a legitimate
  cold-start re-prime (including the cross-boot `genCounter`-restart case).
- **Bulk reconcile** at `BulkEnd` is unchanged.
- **Wire format unchanged** — only the generation values a delete carries change.
- **Userspace helper** (`delete_synced_session_gen`) already refuses only
  strictly-older deletes and sees the Go layer's serial, already-ordered
  decisions (Go is authoritative) — no Rust change required.

## Tests (fail-on-revert proven)

New regression tests in `pkg/cluster/sync_gen_guard_test.go` drive the **real
sender enqueue + receiver apply in wire order** for both reorder directions:
- `TestSameGenReorderDeleteThenInstallConverges{V4,V6}` — delete-then-install
  (the bug) → session GONE
- `TestSameGenInstallThenDeleteConvergesV4` — in-order close → GONE
- `TestReestablishAfterDeleteAppliesV4` — newer install after delete → PRESENT
- `TestReorderedInstallRefusedByTombstoneV4` — apply-layer tombstone refusal
- `TestDeleteGenerationStrictlyGreaterThanInstall{V4,V6}` — sender contract

Against pre-fix `origin/master` the reorder tests FAIL (the closed session is
resurrected on the standby, both V4 and V6); post-fix they pass. Existing
#2170/#2198 guard tests are updated for the new sender (delete gen > install gen)
and receiver (tombstone, not eviction) contracts and still pass.

```
go build ./...                       # clean
go vet ./pkg/cluster/...             # clean
go test ./pkg/cluster/...            # ok
go test -race ./pkg/cluster/...      # ok
go test ./pkg/dataplane/...          # ok (mirror-guard consumers)
```

## HA validation

This is an HA / session-sync change. **`make test-failover` is REQUIRED before
merge** (PENDING-PARENT — run by the maintainer driving the merge).

## Docs
- `docs/sync-protocol.md` — sender fresh-gen + receiver tombstone + new
  "Same-generation install/delete reorder (#2221)" subsection.
- `pkg/cluster/README.md` — install-generation delete guard bullet updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
