### PR TITLE
vrrp: fix data race on localIP/localIPv6 lazy resolve (#2258)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,36 @@
 # Action Log
 
+## 2026-06-21 — #2258 VRRP localIP/localIPv6 lazy-resolve race (run-loop write vs receiver reads)
+
+- **Timestamp**: 2026-06-21
+- **Action**: Fixed a Go data race on `vrrpInstance.localIP`/`localIPv6`
+  (found during the #2257/#2225 review; pre-existing, distinct from the
+  `lastDropWarn` race). `localIP`/`localIPv6` are resolved once in
+  `openSocket()` before any goroutine starts, but that resolution can come
+  back empty (no IPv4 address yet, or IPv6 DAD still running). In that case
+  `sendPacket()`/`sendPacketIPv6()` perform a one-shot LAZY-RESOLVE WRITE
+  from the run-loop goroutine, while the receiver goroutines
+  (`receiver`/`receiverIPv6`/`parseAfPacketIPv4`/`parseAfPacketIPv6`) read
+  the fields to filter self-sent adverts — an unsynchronized write/read
+  (`go test -race` flags it; fires at most once, only when unresolved at
+  socket-open). Option (a) early-resolve was infeasible because the address
+  genuinely may be unresolvable at socket-open (DAD/no-addr); chose option
+  (b): both fields are now `atomic.Pointer[net.IP]` accessed only via
+  `getLocalIP`/`setLocalIP` and `getLocalIPv6`/`setLocalIPv6` (nil pointer =
+  unresolved). Lazy-resolve semantics preserved (the address still becomes
+  available once resolvable); packet hot path stays lock-free, mirroring
+  the `lastDropWarn` atomic pattern (#2225). Sibling audit: the run-loop
+  tie-break reader in `handleMasterRx` and the `run()` IPv6-receiver gate
+  also route through the accessors (same-goroutine, but consistent). New
+  fail-on-revert `-race` tests drive the lazy-resolve write concurrently
+  with the real `parseAfPacketIPv4`/`parseAfPacketIPv6` reader (CLEAN with
+  the atomic fix, DETECTS the race when reverted to a plain net.IP).
+  make test-failover (HA/VRRP no-regression) PENDING-PARENT — the -race
+  unit test is the primary gate.
+- **File(s)**: pkg/vrrp/instance.go,
+  pkg/vrrp/instance_localip_race_test.go (new), pkg/vrrp/vrrp_test.go,
+  pkg/vrrp/instance_preempt_gate_test.go, pkg/vrrp/README.md
+
 ## 2026-06-21 — #2255 NAT translation-hit counter_id stability
 
 - **Timestamp**: 2026-06-21

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -162,6 +162,22 @@ the warning, so a concurrent drop burst yields one log line per interval
 was an unsynchronized read-modify-write across the two goroutines (a
 `go test -race` data race).
 
+The self-sent-advert filter is a second cross-goroutine hazard.
+`localIP` / `localIPv6` are resolved once in `openSocket()` — **before**
+any goroutine starts — but that resolution can come back empty (no IPv4
+address assigned yet, or IPv6 DAD still running). In that case
+`sendPacket()` / `sendPacketIPv6()` perform a one-shot **lazy-resolve
+write** from the run-loop goroutine, while every receiver
+(`receiver` / `receiverIPv6` / `parseAfPacketIPv4` / `parseAfPacketIPv6`)
+reads the fields to drop self-sent adverts. With the fields as plain
+`net.IP` this write/read was an unsynchronized data race (#2258, fires
+at most once — only when the address was unresolved at socket-open).
+They are now `atomic.Pointer[net.IP]` accessed solely via
+`getLocalIP`/`setLocalIP` and `getLocalIPv6`/`setLocalIPv6` (a `nil`
+pointer means unresolved). The lazy-resolve semantics are preserved —
+the address still becomes available once it is resolvable — and the
+packet hot path stays lock-free, mirroring the `lastDropWarn` atomic.
+
 ### AF_PACKET cBPF filter + IPv6 extension headers (#2155)
 
 The AF_PACKET receiver attaches a cBPF prefilter

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -69,11 +69,26 @@ type vrrpInstance struct {
 	lastMasterPriority int       // last non-zero peer advert priority
 	lastMasterSeen     time.Time // when lastMasterPriority was recorded
 
-	state     VRRPState
-	iface     *net.Interface
-	eventCh   chan<- VRRPEvent
-	localIP   net.IP // our IPv4 address on this interface (for filtering self-sent)
-	localIPv6 net.IP // our link-local IPv6 address (source for IPv6 VRRP adverts)
+	state   VRRPState
+	iface   *net.Interface
+	eventCh chan<- VRRPEvent
+
+	// localIP / localIPv6 are our IPv4 address (for filtering self-sent
+	// adverts) and our link-local IPv6 address (source for IPv6 VRRP
+	// adverts). They are resolved once at openSocket() time, BEFORE any
+	// goroutine is started — but that resolution can come back empty (no
+	// IPv4 address assigned yet, or IPv6 DAD still running). In that case
+	// sendPacket()/sendPacketIPv6() perform a one-shot lazy resolve from
+	// the run-loop goroutine. Meanwhile the receiver goroutines
+	// (receiver/receiverIPv6/parseAfPacketIPv4/parseAfPacketIPv6) read
+	// these fields to filter self-sent packets. The lazy-resolve write
+	// thus races the receiver reads (#2258), so the fields are
+	// atomic.Pointer[net.IP] accessed only via getLocalIP/setLocalIP and
+	// getLocalIPv6/setLocalIPv6. A nil pointer means unresolved; the
+	// resolve semantics are preserved (the address still becomes available
+	// once resolvable). Mirrors the lastDropWarn atomic pattern (#2225).
+	localIP   atomic.Pointer[net.IP] // our IPv4 address on this interface
+	localIPv6 atomic.Pointer[net.IP] // our link-local IPv6 address
 
 	// Per-instance raw socket and receiver.
 	conn    net.PacketConn
@@ -136,6 +151,44 @@ func newInstance(cfg Instance, iface *net.Interface, eventCh chan<- VRRPEvent, o
 	}
 }
 
+// getLocalIP returns the resolved local IPv4 address, or nil if unresolved.
+// Safe to call from any goroutine — the field is written via setLocalIP from
+// openSocket() (pre-goroutine) and from the sendPacket() lazy-resolve path
+// (run-loop goroutine), while the receiver goroutines read it (#2258).
+func (vi *vrrpInstance) getLocalIP() net.IP {
+	if p := vi.localIP.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// setLocalIP atomically stores the resolved local IPv4 address.
+func (vi *vrrpInstance) setLocalIP(ip net.IP) {
+	if ip == nil {
+		vi.localIP.Store(nil)
+		return
+	}
+	vi.localIP.Store(&ip)
+}
+
+// getLocalIPv6 returns the resolved local link-local IPv6 address, or nil if
+// unresolved. Safe to call from any goroutine — see getLocalIP (#2258).
+func (vi *vrrpInstance) getLocalIPv6() net.IP {
+	if p := vi.localIPv6.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// setLocalIPv6 atomically stores the resolved local link-local IPv6 address.
+func (vi *vrrpInstance) setLocalIPv6(ip net.IP) {
+	if ip == nil {
+		vi.localIPv6.Store(nil)
+		return
+	}
+	vi.localIPv6.Store(&ip)
+}
+
 // openSocket creates the per-instance raw socket bound to the interface.
 func (vi *vrrpInstance) openSocket() error {
 	isVLAN := strings.Contains(vi.cfg.Interface, ".")
@@ -186,13 +239,13 @@ func (vi *vrrpInstance) openSocket() error {
 		}
 		ip4 := ipNet.IP.To4()
 		if ip4 != nil && !vipSet[ip4.String()] {
-			vi.localIP = ip4
+			vi.setLocalIP(ip4)
 		}
 	}
 	// Deterministic IPv6 link-local selection: sort candidates and
 	// pick the lowest address. This ensures the same source address
 	// is used even when the interface has multiple link-locals.
-	vi.localIPv6 = vi.resolveIPv6LinkLocal(vipSet)
+	vi.setLocalIPv6(vi.resolveIPv6LinkLocal(vipSet))
 
 	// Open IPv6 raw socket if any VIPs are IPv6.
 	if hasIPv6VIPs {
@@ -444,7 +497,7 @@ func (vi *vrrpInstance) run() {
 			slog.Warn("vrrp: af_packet unavailable, using separate IPv6 raw socket fallback",
 				"key", vi.key())
 			go vi.receiverIPv6()
-		} else if vi.localIPv6 != nil {
+		} else if vi.getLocalIPv6() != nil {
 			slog.Warn("vrrp: af_packet unavailable and no IPv6 socket — IPv6 VRRP reception disabled",
 				"key", vi.key())
 		}
@@ -576,7 +629,7 @@ func (vi *vrrpInstance) receiver() {
 		}
 
 		// Filter self-sent packets (RFC 5798 §6.4.2/6.4.3).
-		if vi.localIP != nil && hdr.Src.Equal(vi.localIP) {
+		if lip := vi.getLocalIP(); lip != nil && hdr.Src.Equal(lip) {
 			continue
 		}
 
@@ -650,7 +703,7 @@ func (vi *vrrpInstance) receiverIPv6() {
 		}
 
 		// Filter self-sent packets.
-		if vi.localIPv6 != nil && srcIP != nil && srcIP.Equal(vi.localIPv6) {
+		if lip6 := vi.getLocalIPv6(); lip6 != nil && srcIP != nil && srcIP.Equal(lip6) {
 			continue
 		}
 
@@ -749,7 +802,7 @@ func (vi *vrrpInstance) parseAfPacketIPv4(buf []byte, n, ethHeaderLen int) {
 	copy(srcIP, ip[12:16])
 
 	// Filter self-sent packets.
-	if vi.localIP != nil && srcIP.Equal(vi.localIP) {
+	if lip := vi.getLocalIP(); lip != nil && srcIP.Equal(lip) {
 		return
 	}
 
@@ -800,7 +853,7 @@ func (vi *vrrpInstance) parseAfPacketIPv6(buf []byte, n, ethHeaderLen int) {
 	copy(srcIP, ip6[8:24])
 
 	// Filter self-sent packets.
-	if vi.localIPv6 != nil && srcIP.Equal(vi.localIPv6) {
+	if lip6 := vi.getLocalIPv6(); lip6 != nil && srcIP.Equal(lip6) {
 		return
 	}
 
@@ -972,15 +1025,17 @@ func (vi *vrrpInstance) handleMasterRx(pkt *VRRPPacket, masterDownTimer, advertT
 	} else if pktPri == pri && pkt.SrcIP != nil {
 		// Equal priority — RFC 5798 §6.4.3 tie-break: higher IP wins.
 		// Handle both IPv4 and IPv6 address families.
+		localIP := vi.getLocalIP()
+		localIPv6 := vi.getLocalIPv6()
 		var peerHigher bool
-		if pkt.SrcIP.To4() != nil && vi.localIP != nil {
-			peerHigher = bytes.Compare(pkt.SrcIP.To4(), vi.localIP.To4()) > 0
-		} else if pkt.SrcIP.To4() == nil && vi.localIPv6 != nil {
-			peerHigher = bytes.Compare(pkt.SrcIP.To16(), vi.localIPv6.To16()) > 0
+		if pkt.SrcIP.To4() != nil && localIP != nil {
+			peerHigher = bytes.Compare(pkt.SrcIP.To4(), localIP.To4()) > 0
+		} else if pkt.SrcIP.To4() == nil && localIPv6 != nil {
+			peerHigher = bytes.Compare(pkt.SrcIP.To16(), localIPv6.To16()) > 0
 		}
 		if peerHigher {
 			slog.Info("vrrp: equal priority tie-break, peer IP is higher — stepping down",
-				"key", vi.key(), "our_ip", vi.localIP, "our_ipv6", vi.localIPv6,
+				"key", vi.key(), "our_ip", localIP, "our_ipv6", localIPv6,
 				"peer_ip", pkt.SrcIP, "priority", pri)
 			vi.becomeBackup(masterDownTimer, advertTimer)
 		}
@@ -1108,10 +1163,12 @@ func (vi *vrrpInstance) sendPacket(pkt *VRRPPacket, isIPv6 bool) error {
 		return nil
 	}
 
-	srcIP := vi.localIP
+	srcIP := vi.getLocalIP()
 	if srcIP == nil {
 		// Lazy resolve: interface may not have had an address at socket open time.
-		// Skip VIPs — must send from primary/base address.
+		// Skip VIPs — must send from primary/base address. The atomic
+		// setLocalIP makes this run-loop write race-clean against the
+		// receiver-goroutine reads (#2258).
 		vipSet := make(map[string]bool, len(vi.cfg.VirtualAddresses))
 		for _, vip := range vi.cfg.VirtualAddresses {
 			addr := vip
@@ -1124,8 +1181,8 @@ func (vi *vrrpInstance) sendPacket(pkt *VRRPPacket, isIPv6 bool) error {
 			for _, a := range addrs {
 				if ipNet, ok := a.(*net.IPNet); ok && ipNet.IP.To4() != nil {
 					if !vipSet[ipNet.IP.To4().String()] {
-						vi.localIP = ipNet.IP.To4()
-						srcIP = vi.localIP
+						srcIP = ipNet.IP.To4()
+						vi.setLocalIP(srcIP)
 						break
 					}
 				}
@@ -1175,11 +1232,13 @@ func (vi *vrrpInstance) sendPacketIPv6(pkt *VRRPPacket) error {
 		return nil
 	}
 
-	srcIP := vi.localIPv6
+	srcIP := vi.getLocalIPv6()
 	if srcIP == nil {
 		// Lazy resolve: deterministically select the lowest link-local
 		// address. This happens when the interface didn't have a
-		// link-local at openSocket() time (e.g. DAD still running).
+		// link-local at openSocket() time (e.g. DAD still running). The
+		// atomic setLocalIPv6 makes this run-loop write race-clean against
+		// the receiver-goroutine reads (#2258).
 		vipSet := make(map[string]bool, len(vi.cfg.VirtualAddresses))
 		for _, vip := range vi.cfg.VirtualAddresses {
 			addr := vip
@@ -1190,7 +1249,7 @@ func (vi *vrrpInstance) sendPacketIPv6(pkt *VRRPPacket) error {
 		}
 		resolved := vi.resolveIPv6LinkLocal(vipSet)
 		if resolved != nil {
-			vi.localIPv6 = resolved
+			vi.setLocalIPv6(resolved)
 			srcIP = resolved
 			slog.Info("vrrp: late-resolved IPv6 link-local address",
 				"key", vi.key(), "addr", srcIP)

--- a/pkg/vrrp/instance_localip_race_test.go
+++ b/pkg/vrrp/instance_localip_race_test.go
@@ -1,0 +1,152 @@
+package vrrp
+
+import (
+	"net"
+	"sync"
+	"testing"
+)
+
+// #2258: sendPacket()/sendPacketIPv6() perform a one-shot LAZY-RESOLVE WRITE of
+// localIP/localIPv6 from the run-loop goroutine (when the address was
+// unresolved at openSocket() time), while the receiver goroutines
+// (receiver/receiverIPv6/parseAfPacketIPv4/parseAfPacketIPv6) READ those fields
+// to filter self-sent adverts. With localIP/localIPv6 as plain net.IP the
+// write/read was an unsynchronized data race; `go test -race` flags it. The fix
+// makes both fields atomic.Pointer[net.IP] accessed only via
+// getLocalIP/setLocalIP and getLocalIPv6/setLocalIPv6.
+//
+// These tests are the fail-on-revert gate: under -race they are CLEAN with the
+// atomic fix and DETECT the race if either field is reverted to a plain net.IP
+// touched directly by both the lazy-resolve write and the receiver reads. The
+// race detector reports on the FIRST unsynchronized concurrent access, so a few
+// thousand tightly-interleaved iterations suffice (and keep the test fast even
+// under -race on a loaded machine).
+
+// installNopLogger silences slog for the duration of a test so the rx-drop
+// warnings emitted while localIP is transiently nil (the advert is not filtered
+// and lands on a full rxCh) don't spam output. It reuses the counting logger
+// from instance_rxdrop_race_test.go and discards the count.
+func installNopLogger(t *testing.T) func() {
+	t.Helper()
+	_, restore := installCountingLogger(t)
+	return restore
+}
+
+// TestLocalIPLazyResolveConcurrentWithReceiver drives the lazy-resolve WRITE
+// path (mirroring sendPacket's setLocalIP from the run-loop goroutine) and the
+// receiver READ path (the real parseAfPacketIPv4, which reads getLocalIP)
+// concurrently. The writer alternates the field between nil and the resolved
+// address so the resolve transition keeps happening (the production lazy-resolve
+// fires once); the reader observes it via the self-sent filter. Under -race this
+// FAILS if localIP is reverted to a plain net.IP, and is CLEAN with the
+// atomic.Pointer fix.
+func TestLocalIPLazyResolveConcurrentWithReceiver(t *testing.T) {
+	defer installNopLogger(t)()
+
+	vi := newInstance(Instance{
+		Interface: "ge-0-0-2",
+		GroupID:   7,
+		Priority:  100,
+	}, &net.Interface{Name: "ge-0-0-2", Index: 1}, make(chan VRRPEvent, 256), nil)
+
+	resolved := net.IPv4(10, 0, 0, 1).To4()
+
+	// A self-sent IPv4 advert: source == the address the lazy-resolve will
+	// install, so the reader exercises the getLocalIP()/srcIP.Equal() filter
+	// branch — exactly the field read that races the run-loop write.
+	frame := buildEthFrame(t, 0, net.IPv4(10, 0, 0, 1), net.IPv4(224, 0, 0, 18), &VRRPPacket{
+		VRID:         7,
+		Priority:     100,
+		MaxAdvertInt: 100,
+		IPAddresses:  []net.IP{net.IPv4(10, 0, 0, 100)},
+	})
+
+	const iters = 4000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: the lazy-resolve WRITE the run-loop goroutine does in
+	// sendPacket() — flipping nil/resolved keeps the resolve branch live.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if i%2 == 0 {
+				vi.setLocalIP(nil)
+			} else {
+				vi.setLocalIP(resolved)
+			}
+		}
+	}()
+
+	// Reader: the real receiver-goroutine read path. parseAfPacketIPv4 reads
+	// getLocalIP() to filter self-sent adverts.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			vi.parseAfPacketIPv4(frame, len(frame), 14)
+		}
+	}()
+
+	wg.Wait()
+
+	// Resolve semantics preserved: once set, the address is readable.
+	vi.setLocalIP(resolved)
+	if got := vi.getLocalIP(); !got.Equal(resolved) {
+		t.Fatalf("getLocalIP() = %v, want %v", got, resolved)
+	}
+}
+
+// TestLocalIPv6LazyResolveConcurrentWithReceiver is the IPv6 sibling: it drives
+// the sendPacketIPv6 lazy-resolve WRITE (setLocalIPv6 from the run-loop
+// goroutine) concurrently with the real parseAfPacketIPv6 READ path
+// (getLocalIPv6). Under -race this FAILS if localIPv6 is reverted to a plain
+// net.IP, and is CLEAN with the atomic.Pointer fix.
+func TestLocalIPv6LazyResolveConcurrentWithReceiver(t *testing.T) {
+	defer installNopLogger(t)()
+
+	vi := newInstance(Instance{
+		Interface:        "ge-0-0-2",
+		GroupID:          7,
+		Priority:         100,
+		VirtualAddresses: []string{"2001:db8::1/64"},
+	}, &net.Interface{Name: "ge-0-0-2", Index: 1}, make(chan VRRPEvent, 256), nil)
+
+	resolved := net.ParseIP("fe80::1")
+
+	// Self-sent IPv6 advert sourced from the address the lazy-resolve installs.
+	frame := buildEthIPv6Frame(t, 0, net.ParseIP("fe80::1"), net.ParseIP("ff02::12"), &VRRPPacket{
+		VRID:         7,
+		Priority:     100,
+		MaxAdvertInt: 100,
+		IPAddresses:  []net.IP{net.ParseIP("2001:db8::1")},
+	})
+
+	const iters = 4000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if i%2 == 0 {
+				vi.setLocalIPv6(nil)
+			} else {
+				vi.setLocalIPv6(resolved)
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			vi.parseAfPacketIPv6(frame, len(frame), 14)
+		}
+	}()
+
+	wg.Wait()
+
+	vi.setLocalIPv6(resolved)
+	if got := vi.getLocalIPv6(); !got.Equal(resolved) {
+		t.Fatalf("getLocalIPv6() = %v, want %v", got, resolved)
+	}
+}

--- a/pkg/vrrp/instance_preempt_gate_test.go
+++ b/pkg/vrrp/instance_preempt_gate_test.go
@@ -31,7 +31,7 @@ func newGateTestInstance(t *testing.T, priority int, preempt bool) *vrrpInstance
 		Priority:  priority,
 		Preempt:   preempt,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIP = net.IPv4(10, 0, 0, 1)
+	vi.setLocalIP(net.IPv4(10, 0, 0, 1))
 	vi.suppressGARP.Store(true)
 	vi.setState(StateBackup)
 	return vi

--- a/pkg/vrrp/vrrp_test.go
+++ b/pkg/vrrp/vrrp_test.go
@@ -1036,7 +1036,7 @@ func TestHandleMasterRx_HigherPriority_StepsDown(t *testing.T) {
 		GroupID:   101,
 		Priority:  100,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIP = net.IPv4(10, 0, 0, 1)
+	vi.setLocalIP(net.IPv4(10, 0, 0, 1))
 	vi.setState(StateMaster)
 
 	masterDownTimer := time.NewTimer(time.Hour)
@@ -1062,7 +1062,7 @@ func TestHandleMasterRx_LowerPriority_StaysMaster(t *testing.T) {
 		GroupID:   101,
 		Priority:  200,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIP = net.IPv4(10, 0, 0, 1)
+	vi.setLocalIP(net.IPv4(10, 0, 0, 1))
 	vi.setState(StateMaster)
 
 	masterDownTimer := time.NewTimer(time.Hour)
@@ -1088,7 +1088,7 @@ func TestHandleMasterRx_EqualPriority_HigherPeerIP_StepsDown(t *testing.T) {
 		GroupID:   101,
 		Priority:  200,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIP = net.IPv4(10, 0, 0, 1) // lower IP
+	vi.setLocalIP(net.IPv4(10, 0, 0, 1)) // lower IP
 	vi.setState(StateMaster)
 
 	masterDownTimer := time.NewTimer(time.Hour)
@@ -1114,7 +1114,7 @@ func TestHandleMasterRx_EqualPriority_LowerPeerIP_StaysMaster(t *testing.T) {
 		GroupID:   101,
 		Priority:  200,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIP = net.IPv4(10, 0, 0, 2) // higher IP
+	vi.setLocalIP(net.IPv4(10, 0, 0, 2)) // higher IP
 	vi.setState(StateMaster)
 
 	masterDownTimer := time.NewTimer(time.Hour)
@@ -1140,7 +1140,7 @@ func TestHandleMasterRx_EqualPriority_NilSrcIP_StaysMaster(t *testing.T) {
 		GroupID:   101,
 		Priority:  200,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIP = net.IPv4(10, 0, 0, 1)
+	vi.setLocalIP(net.IPv4(10, 0, 0, 1))
 	vi.setState(StateMaster)
 
 	masterDownTimer := time.NewTimer(time.Hour)
@@ -1167,7 +1167,7 @@ func TestHandleMasterRx_Priority0_StaysMaster(t *testing.T) {
 		GroupID:   101,
 		Priority:  200,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIP = net.IPv4(10, 0, 0, 1)
+	vi.setLocalIP(net.IPv4(10, 0, 0, 1))
 	vi.setState(StateMaster)
 
 	masterDownTimer := time.NewTimer(time.Hour)
@@ -1193,7 +1193,7 @@ func TestHandleMasterRx_EqualPriority_HigherPeerIPv6_StepsDown(t *testing.T) {
 		GroupID:   101,
 		Priority:  200,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIPv6 = net.ParseIP("fe80::1") // lower IPv6
+	vi.setLocalIPv6(net.ParseIP("fe80::1")) // lower IPv6
 	vi.setState(StateMaster)
 
 	masterDownTimer := time.NewTimer(time.Hour)
@@ -1219,7 +1219,7 @@ func TestHandleMasterRx_EqualPriority_LowerPeerIPv6_StaysMaster(t *testing.T) {
 		GroupID:   101,
 		Priority:  200,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIPv6 = net.ParseIP("fe80::2") // higher IPv6
+	vi.setLocalIPv6(net.ParseIP("fe80::2")) // higher IPv6
 	vi.setState(StateMaster)
 
 	masterDownTimer := time.NewTimer(time.Hour)
@@ -1975,7 +1975,7 @@ func TestReceiverIPv6_DeliversPacket(t *testing.T) {
 		GroupID:   42,
 		Priority:  100,
 	}, &net.Interface{Name: "eth0"}, eventCh, nil)
-	vi.localIPv6 = net.ParseIP("fe80::1")
+	vi.setLocalIPv6(net.ParseIP("fe80::1"))
 
 	// Build a valid VRRPv3 packet.
 	srcIP := net.ParseIP("fe80::2")
@@ -2074,7 +2074,7 @@ func TestSendPacketIPv6_NilLocalIPv6_ReturnsError(t *testing.T) {
 		VirtualAddresses: []string{"2001:db8::1/128"},
 	}, &net.Interface{Name: "lo", Index: 1}, eventCh, nil)
 	// localIPv6 is nil and interface has no link-local → should error.
-	vi.localIPv6 = nil
+	vi.setLocalIPv6(nil)
 
 	// Create a mock conn so ipv6Conn is non-nil (we test the srcIP path).
 	vi.ipv6Conn = &mockPacketConn{
@@ -2104,7 +2104,7 @@ func TestSendPacketIPv6_WithLocalIPv6_SendsPacket(t *testing.T) {
 		Priority:  200,
 		VirtualAddresses: []string{"2001:db8::1/128"},
 	}, &net.Interface{Name: "lo", Index: 1}, eventCh, nil)
-	vi.localIPv6 = net.ParseIP("fe80::1")
+	vi.setLocalIPv6(net.ParseIP("fe80::1"))
 
 	var sentData []byte
 	var sentAddr net.Addr


### PR DESCRIPTION
Fixes #2258.

## The bug
`sendPacket()` / `sendPacketIPv6()` perform a one-shot **lazy-resolve WRITE** of
`localIP` / `localIPv6` from the run-loop goroutine when the local address was
unresolved at `openSocket()` time (no IPv4 address assigned yet, or IPv6 DAD
still running). Meanwhile the receiver goroutines — `receiver()`,
`receiverIPv6()`, `parseAfPacketIPv4()`, `parseAfPacketIPv6()` — **READ** those
fields to filter self-sent advertisements. With the fields as plain `net.IP`
the write/read was an unsynchronized Go data race (`go test -race` flags it).
It fires at most once (only on the unresolved-at-socket-open path), is
pre-existing, and is distinct from the `lastDropWarn` race fixed in #2225
(this was found during that review).

## The fix (option b — atomic)
Early resolution alone (option a) is **infeasible**: the local address genuinely
may not be resolvable at socket-open, which is the entire reason the lazy resolve
exists. So `localIP` / `localIPv6` are now `atomic.Pointer[net.IP]`, accessed
solely via `getLocalIP`/`setLocalIP` and `getLocalIPv6`/`setLocalIPv6` (a nil
pointer means unresolved). This keeps the packet hot path lock-free, mirrors the
`lastDropWarn` atomic pattern, and **preserves the lazy-resolve semantics** —
the address still becomes available once it is resolvable.

All call sites route through the accessors: the `openSocket` resolve, the
`sendPacket`/`sendPacketIPv6` lazy write, the four receiver self-sent filters,
the `run()` IPv6-receiver gate, and the `handleMasterRx` equal-priority
tie-break (run-loop reader; same goroutine but made consistent).

## Sibling audit
The other readers of these fields (`run()` gate, `handleMasterRx` tie-break) run
in the run-loop goroutine — the same goroutine as the lazy-resolve write, so
they are already serialized — but they were routed through the accessors anyway
for consistency. No other field has the same run-loop-write-vs-receiver-read
hazard (the `lastMasterPriority`/`lastMasterSeen` fields are already mu-guarded;
`lastDropWarn` was fixed in #2225).

## Validation
- `go vet ./pkg/vrrp/...` — clean
- `go build ./...` — clean
- `go test ./pkg/vrrp/...` — ok
- **`go test -race ./pkg/vrrp/...` — ok (the primary gate, full suite clean)**

**Fail-on-revert proof:** new `pkg/vrrp/instance_localip_race_test.go` drives the
lazy-resolve write concurrently with the **real** `parseAfPacketIPv4` /
`parseAfPacketIPv6` reader. Under `-race` the tests are CLEAN with the atomic
fix; reverting the fields to a plain `net.IP` makes `-race` report
`WARNING: DATA RACE` (`setLocalIP` write vs `getLocalIP`→`parseAfPacketIPv4`
read, and the IPv6 sibling) and both tests FAIL — confirming the test detects
exactly the issue's race.

The pkg/vrrp README receiver-goroutine concurrency section now documents the new
hazard alongside #2225.

`make test-failover` (HA/VRRP no-regression) is **pending** — the `-race` unit
test is the primary gate for this concurrency-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)