### PR TITLE
#2262: preserve IA_PD lease type in DHCP memfile-fallback read (no IA_NA mis-seed)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9397,3 +9397,20 @@ top.
   **File(s)**: pkg/cluster/sync_conn.go, pkg/cluster/sync.go,
   pkg/cluster/sync_gen_guard_test.go, docs/sync-protocol.md,
   pkg/cluster/README.md, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2262 — preserve IA_PD lease type in DHCP memfile-fallback read
+  (no IA_NA mis-seed). Follow-up to #2239 (PR #2260). The v6 memfile-fallback
+  path (readSyncLeasesViaMemfile, taken only when the Kea control socket is
+  down) hardcoded LeaseType="IA_NA" and dropped the prefix length, mis-seeding
+  an IA_PD prefix-delegation lease as an address lease on the peer. Added
+  LeaseType/LeaseTypeOK/PrefixLen to ddnsLease, parse the OPTIONAL v6 memfile
+  lease_type (0=IA_NA/1=IA_TA/2=IA_PD) + prefix_len columns non-destructively
+  in parseActiveLeases (DDNS posture unchanged — fields inert there), and map
+  them to SyncLease in the fallback exactly as the socket path does. Present-
+  but-unparseable lease_type is fail-closed (skip+log), absent/empty stays
+  IA_NA-equivalent. Two new tests (PreservesType + SkipMalformedType) feed a
+  v6 memfile with both IA_NA and IA_PD rows; fail-on-revert verified (re-
+  hardcoding IA_NA breaks them). build+vet+test green, new tests 5x no flake.
+  **File(s)**: pkg/dhcpserver/ddns_leases.go, pkg/dhcpserver/lease_sync.go,
+  pkg/dhcpserver/lease_sync_test.go, pkg/dhcpserver/README.md, _Log.md

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -377,7 +377,14 @@ This package owns the KEA side of #2239 cross-chassis DHCP-server lease sync
   destructive-safe memfile parser (`parseActiveLeases`) when the socket is not
   up. Each `SyncLease` carries REMAINING LIFETIME (`expire - now` on the
   reader's clock), never an absolute epoch — the clock-skew-immunity invariant.
-  Expired / non-active leases are dropped at read time.
+  Expired / non-active leases are dropped at read time. The v6 fallback
+  PRESERVES the lease kind: it reads the memfile `lease_type` (0=IA_NA,
+  1=IA_TA, 2=IA_PD) and `prefix_len` columns and maps them to
+  `SyncLease.LeaseType` / `PrefixLen` exactly as the socket path does, so an
+  IA_PD prefix-delegation lease read during the socket-down window is no longer
+  mis-seeded as an IA_NA address lease (#2262). A present-but-unparseable
+  `lease_type` is fail-closed: the row is skipped (logged), never defaulted to
+  IA_NA. An absent/empty column (old memfile, v4) stays IA_NA-equivalent.
 - `SeedSyncLeases{4,6}(ctx, leases, now)` — write held peer leases into a
   just-started Kea via `lease{4,6}-add` (→ `lease{4,6}-update` on collision,
   idempotent), re-anchoring `expire = now + remaining` on the LOCAL clock.

--- a/pkg/dhcpserver/ddns_leases.go
+++ b/pkg/dhcpserver/ddns_leases.go
@@ -87,7 +87,28 @@ type ddnsLease struct {
 	HostName   string // host-name option
 	ClientFQDN string // client-supplied FQDN option (fqdn_fwd implied)
 	Expire     int64  // unix epoch
+
+	// v6 lease kind, recovered from the memfile so the #2239 lease-sync
+	// fallback (readSyncLeasesViaMemfile) preserves IA_PD vs IA_NA instead of
+	// mis-seeding a prefix-delegation lease as an address lease (#2262). These
+	// are NOT used by the DDNS reconciler (it keys on identity+address) — the
+	// fields are inert for v4 and for the DDNS path. lease_type / prefix_len are
+	// OPTIONAL memfile columns (not in requiredLeaseColumns): an old memfile or
+	// a v4 file leaves LeaseType == keaLeaseTypeIANA and LeaseTypeOK == true,
+	// preserving the prior (hardcoded IA_NA) behavior. A PRESENT but
+	// unparseable lease_type sets LeaseTypeOK == false so the sync path can
+	// skip the row rather than silently mis-type it.
+	LeaseType   int  // Kea numeric lease_type: 0=IA_NA, 1=IA_TA, 2=IA_PD
+	LeaseTypeOK bool // false ⇒ lease_type column present but unparseable
+	PrefixLen   int  // v6 IA_PD delegated prefix length (0 when absent)
 }
+
+// Kea memfile lease_type column values (v6 only).
+const (
+	keaLeaseTypeIANA = 0
+	keaLeaseTypeIATA = 1
+	keaLeaseTypeIAPD = 2
+)
 
 // parseActiveLeases4 reads the Kea v4 memfile and returns only active
 // leases (state default, not yet expired). now is the reference time for
@@ -294,15 +315,35 @@ func parseActiveLeases(path string, family int, now time.Time) ([]ddnsLease, err
 
 		hostName, clientFQDN := splitLeaseNames(get(fields, "hostname"), get(fields, "fqdn_fwd"))
 		l := ddnsLease{
-			Family:     family,
-			Address:    addr,
-			SubnetID:   get(fields, "subnet_id"),
-			HostName:   hostName,
-			ClientFQDN: clientFQDN,
-			Expire:     expire,
+			Family:      family,
+			Address:     addr,
+			SubnetID:    get(fields, "subnet_id"),
+			HostName:    hostName,
+			ClientFQDN:  clientFQDN,
+			Expire:      expire,
+			LeaseType:   keaLeaseTypeIANA, // address lease by default (v4, or v6 sans column)
+			LeaseTypeOK: true,
 		}
 		if family == 6 {
 			l.Identity = identity6(get(fields, "duid"), get(fields, "iaid"))
+			// Recover the v6 lease kind so the lease-sync memfile fallback can
+			// preserve IA_PD vs IA_NA (#2262). lease_type / prefix_len are
+			// OPTIONAL columns: an absent or empty lease_type leaves the IA_NA
+			// default (matching the prior hardcoded behavior); a PRESENT but
+			// unparseable value flips LeaseTypeOK so the sync path skips the row
+			// instead of mis-typing it. The DDNS reconciler ignores both fields.
+			if lt := get(fields, "lease_type"); lt != "" {
+				if v, e := strconv.Atoi(strings.TrimSpace(lt)); e == nil {
+					l.LeaseType = v
+				} else {
+					l.LeaseTypeOK = false
+				}
+			}
+			if pl := get(fields, "prefix_len"); pl != "" {
+				if v, e := strconv.Atoi(strings.TrimSpace(pl)); e == nil {
+					l.PrefixLen = v
+				}
+			}
 		} else {
 			l.Identity = identity4(get(fields, "client_id"), get(fields, "hwaddr"))
 		}

--- a/pkg/dhcpserver/lease_sync.go
+++ b/pkg/dhcpserver/lease_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -292,7 +293,27 @@ func readSyncLeasesViaMemfile(path string, family int, now time.Time) ([]SyncLea
 			duid, iaid := splitV6Identity(a.Identity)
 			l.DUID = duid
 			l.IAID = iaid
-			l.LeaseType = "IA_NA"
+			// #2262: preserve the v6 lease kind from the memfile instead of
+			// hardcoding IA_NA, which mis-seeded an IA_PD (prefix-delegation)
+			// lease as an address lease on the peer. A PRESENT but unparseable
+			// lease_type column flips LeaseTypeOK=false: skip (logged) rather
+			// than mis-type — fail-closed, mirroring the socket path which
+			// reports the kind faithfully.
+			if !a.LeaseTypeOK {
+				slog.Warn("dhcpserver: skipping v6 memfile lease with unparseable lease_type",
+					"address", a.Address, "duid", duid, "iaid", iaid)
+				continue
+			}
+			lt, ok := keaLeaseTypeToString(a.LeaseType)
+			if !ok {
+				slog.Warn("dhcpserver: skipping v6 memfile lease with unknown lease_type",
+					"address", a.Address, "lease_type", a.LeaseType)
+				continue
+			}
+			l.LeaseType = lt
+			if a.LeaseType == keaLeaseTypeIAPD {
+				l.PrefixLen = a.PrefixLen
+			}
 		} else {
 			hw, cid := splitV4Identity(a.Identity)
 			l.HWAddress = hw
@@ -324,6 +345,24 @@ func splitV4Identity(identity string) (hwaddr, clientID string) {
 		return strings.TrimPrefix(identity, "mac:"), ""
 	}
 	return "", ""
+}
+
+// keaLeaseTypeToString maps the numeric Kea memfile lease_type column to the
+// string form the control-socket path reports (and SeedSyncLeases6 consumes):
+// 0 → IA_NA, 1 → IA_TA, 2 → IA_PD. ok is false for any other value so the
+// caller skips a row it cannot faithfully type rather than mis-seeding it
+// (#2262). IA_TA is passed through for parity with the socket path, which
+// reports whatever kind Kea returns.
+func keaLeaseTypeToString(t int) (string, bool) {
+	switch t {
+	case keaLeaseTypeIANA:
+		return "IA_NA", true
+	case keaLeaseTypeIATA:
+		return "IA_TA", true
+	case keaLeaseTypeIAPD:
+		return "IA_PD", true
+	}
+	return "", false
 }
 
 // splitV6Identity inverts identity6 ("duid:DUID/IAID") back into DUID + IAID.

--- a/pkg/dhcpserver/lease_sync_test.go
+++ b/pkg/dhcpserver/lease_sync_test.go
@@ -181,6 +181,114 @@ func TestGetSyncLeases4_MemfileFallback(t *testing.T) {
 	}
 }
 
+// Test (a) v6 fallback (#2262): the memfile-fallback read path must PRESERVE
+// the v6 lease kind (IA_NA vs IA_PD) and the PD prefix length from the Kea v6
+// memfile, not hardcode IA_NA. A memfile holding BOTH an IA_NA and an IA_PD row
+// must round-trip each lease's type (and the PD prefix-len) — mirroring the
+// faithful control-socket path (TestSeedSyncLeases6_IdentityAndPD). Fail-on-
+// revert: re-hardcoding LeaseType="IA_NA" makes the IA_PD assertions fail.
+func TestGetSyncLeases6_MemfileFallback_PreservesType(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "kea-leases6.csv")
+	expire := strconv.FormatInt(now.Unix()+1800, 10)
+	// Canonical Kea v6 memfile header + one IA_NA (lease_type 0, prefix_len 128)
+	// and one IA_PD (lease_type 2, prefix_len 56) row.
+	//   address,duid,valid_lifetime,expire,subnet_id,pref_lifetime,
+	//   lease_type,iaid,prefix_len,fqdn_fwd,fqdn_rev,hostname,hwaddr,
+	//   state,user_context,hwtype,hwaddr_source,pool_id
+	csv := keaMemfileHeader6 + "\n" +
+		"2001:db8::100,00:01:00:01,3600," + expire + ",1,3600,0,42,128,0,0,host-na,,0,,,,0\n" +
+		"2001:db8:abcd::,00:01:00:02,3600," + expire + ",1,3600,2,7,56,0,0,host-pd,,0,,,,0\n"
+	if err := os.WriteFile(memfile, []byte(csv), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New()
+	// Missing socket → memfile fallback; leaseFile6 = our fixture.
+	m.SetLeaseSyncSeamsForTesting(nil, "", filepath.Join(dir, "missing.sock"), "", memfile)
+
+	leases, err := m.GetSyncLeases6(context.Background(), now)
+	if err != nil {
+		t.Fatalf("GetSyncLeases6 (fallback): %v", err)
+	}
+	if len(leases) != 2 {
+		t.Fatalf("expected 2 leases from v6 memfile, got %d: %+v", len(leases), leases)
+	}
+
+	byAddr := map[string]SyncLease{}
+	for _, l := range leases {
+		byAddr[l.Address] = l
+	}
+
+	na, ok := byAddr["2001:db8::100"]
+	if !ok {
+		t.Fatalf("IA_NA lease missing from fallback result: %+v", leases)
+	}
+	if na.LeaseType != "IA_NA" {
+		t.Errorf("IA_NA lease type = %q, want IA_NA", na.LeaseType)
+	}
+	if na.PrefixLen != 0 {
+		t.Errorf("IA_NA lease PrefixLen = %d, want 0", na.PrefixLen)
+	}
+	if na.DUID != "00:01:00:01" || na.IAID != 42 {
+		t.Errorf("IA_NA identity wrong: DUID=%q IAID=%d", na.DUID, na.IAID)
+	}
+
+	pd, ok := byAddr["2001:db8:abcd::"]
+	if !ok {
+		t.Fatalf("IA_PD lease missing from fallback result: %+v", leases)
+	}
+	// This is the #2262 regression guard: pre-fix the fallback hardcoded
+	// LeaseType="IA_NA" and dropped the prefix length, so a PD lease arrived as
+	// an address lease on the peer.
+	if pd.LeaseType != "IA_PD" {
+		t.Errorf("IA_PD lease mis-typed as %q (want IA_PD) — #2262 regression", pd.LeaseType)
+	}
+	if pd.PrefixLen != 56 {
+		t.Errorf("IA_PD lease PrefixLen = %d, want 56 — #2262 regression", pd.PrefixLen)
+	}
+	if pd.DUID != "00:01:00:02" || pd.IAID != 7 {
+		t.Errorf("IA_PD identity wrong: DUID=%q IAID=%d", pd.DUID, pd.IAID)
+	}
+}
+
+// Test (a) v6 fallback skip-malformed (#2262): a PRESENT-but-unparseable
+// lease_type column must cause the row to be SKIPPED (fail-closed), not
+// defaulted to IA_NA, so a corrupt row can never silently mis-seed an address
+// lease on the peer. A well-formed IA_PD row in the same file still parses.
+func TestGetSyncLeases6_MemfileFallback_SkipMalformedType(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "kea-leases6.csv")
+	expire := strconv.FormatInt(now.Unix()+1800, 10)
+	// First row: lease_type column is garbage ("PD") → unparseable → skipped.
+	// Second row: a valid IA_PD lease that must still survive.
+	csv := keaMemfileHeader6 + "\n" +
+		"2001:db8::bad,00:01:00:09,3600," + expire + ",1,3600,PD,9,64,0,0,host-bad,,0,,,,0\n" +
+		"2001:db8:cafe::,00:01:00:0a,3600," + expire + ",1,3600,2,10,60,0,0,host-good,,0,,,,0\n"
+	if err := os.WriteFile(memfile, []byte(csv), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(nil, "", filepath.Join(dir, "missing.sock"), "", memfile)
+
+	leases, err := m.GetSyncLeases6(context.Background(), now)
+	if err != nil {
+		t.Fatalf("GetSyncLeases6 (fallback): %v", err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("expected 1 lease (malformed-type row skipped), got %d: %+v", len(leases), leases)
+	}
+	if leases[0].Address != "2001:db8:cafe::" {
+		t.Errorf("surviving lease = %q, want the valid IA_PD row", leases[0].Address)
+	}
+	if leases[0].LeaseType != "IA_PD" || leases[0].PrefixLen != 60 {
+		t.Errorf("surviving IA_PD lease wrong: %+v", leases[0])
+	}
+}
+
 // Test (b): seed re-anchors Remaining to the LOCAL clock — a skewed peer "now"
 // must NOT influence the seeded expiry (clock-skew immunity).
 func TestSeedSyncLeases4_ClockSkewImmune(t *testing.T) {


### PR DESCRIPTION
## Summary

- Follow-up to #2239 (PR #2260). The v6 lease-sync **memfile-fallback** read path (`readSyncLeasesViaMemfile`, taken only when the Kea control socket is not yet up) hardcoded `LeaseType="IA_NA"` and could not recover the prefix length, so an IA_PD (prefix-delegation) lease read during the socket-down window was mis-seeded on the peer as an IA_NA address lease.
- Recover the lease kind from the memfile: parse the canonical Kea v6 `lease_type` (0=IA_NA, 1=IA_TA, 2=IA_PD) and `prefix_len` columns onto `ddnsLease`, and map them into `SyncLease` in the fallback exactly as the socket path (`keaLeaseToSync`) does — IA_PD carries its prefix length, IA_NA carries 0.
- The parse is **non-destructive and confined**: `lease_type`/`prefix_len` are OPTIONAL columns (NOT added to `requiredLeaseColumns`), so the DDNS reconciler's destructive posture is unchanged and the fields are inert on the v4 / DDNS paths.
- **Fail-closed on corruption:** an absent/empty `lease_type` (old memfile, v4 file) stays IA_NA-equivalent (prior behavior preserved); a PRESENT-but-unparseable `lease_type` is skipped (logged) rather than defaulted to IA_NA, so a corrupt row can never silently mis-seed an address lease.
- README contract updated on `GetSyncLeases`.

## Test plan

- [x] `TestGetSyncLeases6_MemfileFallback_PreservesType` — v6 memfile with BOTH an IA_NA (lease_type 0) and an IA_PD (lease_type 2, prefix_len 56) row; asserts each lease's type and the PD prefix length survive.
- [x] `TestGetSyncLeases6_MemfileFallback_SkipMalformedType` — a present-but-unparseable `lease_type` row is skipped while a valid IA_PD row in the same file still parses.
- [x] **Fail-on-revert verified**: temporarily re-hardcoding `LeaseType="IA_NA"` fails both IA_PD assertions and the skip-count assertion.
- [x] `go build ./...`, `go vet ./pkg/dhcpserver/... ./pkg/cluster/...`, `go test ./pkg/dhcpserver/... ./pkg/cluster/...` all green; new tests pass 5x with no flake.

This is a Go-only control-plane change with no dataplane/forwarding impact; no cluster smoke run required.

## Refs

Closes #2262. Follow-up to #2239 / PR #2260.