### PR TITLE
#2268: round-trip IA_TA lease type symmetrically in DHCP pre-seed memfile writer

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9430,3 +9430,24 @@ top.
   hardcoding IA_NA breaks them). build+vet+test green, new tests 5x no flake.
   **File(s)**: pkg/dhcpserver/ddns_leases.go, pkg/dhcpserver/lease_sync.go,
   pkg/dhcpserver/lease_sync_test.go, pkg/dhcpserver/README.md, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2268 — round-trip IA_TA lease type symmetrically in the DHCP
+  HA lease-sync pre-seed writer. Follow-up to #2267 (#2262), which fixed the
+  READ path to distinguish all three Kea v6 lease kinds (keaLeaseTypeToString:
+  0=IA_NA/1=IA_TA/2=IA_PD) but left the WRITE/pre-seed path asymmetric:
+  writeMemfile6 only encoded IA_PD vs "everything-else as IA_NA", so a synced
+  IA_TA lease read as IA_TA but was written back as lease_type=0 (IA_NA) on
+  takeover — a silent type downgrade across failover for temporary-address
+  bindings. Added stringToKeaLeaseType as the exact total inverse of
+  keaLeaseTypeToString and routed BOTH v6 write callers (writeMemfile6 memfile
+  pre-seed AND syncLeaseToKea lease6-add) through it so the read↔write mapping
+  cannot drift. IA_TA is a full /128 address binding, so its prefix_len column
+  is 128 (only IA_PD carries a delegated prefix). Unknown kind → IA_NA + log.
+  Added TestPreSeedMemfile6_RoundTrip_PreservesIATA (sync→pre-seed→read-back
+  round trip + byte-level lease_type=1 assertion; IA_NA/IA_PD no-regression)
+  and TestKeaLeaseTypeInverseTotality. Fail-on-revert verified (restoring the
+  IA_PD-vs-IA_NA-only writer makes the IA_TA assertions fail). build+vet+test
+  (dhcpserver, cluster) green; new tests 5x no flake.
+  **File(s)**: pkg/dhcpserver/lease_sync.go, pkg/dhcpserver/lease_sync_test.go,
+  pkg/dhcpserver/README.md, _Log.md

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -394,6 +394,15 @@ This package owns the KEA side of #2239 cross-chassis DHCP-server lease sync
   bindings at boot and can never hand an in-use address to a different client
   even in the pre-`lease-add` window (the duplicate-allocation-window closer).
   Durable (`fsatomic.WriteFileDurable`).
+  The v6 WRITE side (memfile pre-seed AND `lease6-add`) encodes the lease kind
+  SYMMETRICALLY with the read side: `stringToKeaLeaseType` is the exact total
+  inverse of the read path's `keaLeaseTypeToString`, so IA_NA / IA_TA / IA_PD
+  all round-trip (read IA_TA → write `lease_type=1`, not a downgrade to IA_NA).
+  Both write callers go through this one inverse so the read↔write mapping
+  cannot drift to re-introduce the #2268 IA_TA downgrade. Only IA_PD carries a
+  delegated `prefix_len`; IA_NA and IA_TA are full `/128` address bindings, so
+  their `prefix_len` column is 128. An unknown lease-type string falls back to
+  IA_NA (logged), never silently mis-typed.
 - `WaitControlSocket{4,6}(ctx, within)` — bounded readiness wait before the
   post-start seed.
 

--- a/pkg/dhcpserver/lease_sync.go
+++ b/pkg/dhcpserver/lease_sync.go
@@ -77,11 +77,11 @@ type SyncLease struct {
 	HWAddress string // "aa:bb:cc:dd:ee:ff"
 	ClientID  string // RFC 2131 client identifier, Kea hex form ("01:..")
 
-	// v6 identity (DUID/IAID) + lease kind. Type is "IA_NA" or "IA_PD".
+	// v6 identity (DUID/IAID) + lease kind. Type is "IA_NA", "IA_TA", or "IA_PD".
 	DUID      string
 	IAID      uint32
-	LeaseType string // v6: "IA_NA" (address) or "IA_PD" (prefix delegation)
-	PrefixLen int    // v6 IA_PD: delegated prefix length (0 for IA_NA)
+	LeaseType string // v6: "IA_NA"/"IA_TA" (address) or "IA_PD" (prefix delegation)
+	PrefixLen int    // v6 IA_PD: delegated prefix length (0 for IA_NA / IA_TA)
 
 	Hostname  string
 	FQDNFwd   bool // client requested forward DNS update
@@ -353,6 +353,14 @@ func splitV4Identity(identity string) (hwaddr, clientID string) {
 // caller skips a row it cannot faithfully type rather than mis-seeding it
 // (#2262). IA_TA is passed through for parity with the socket path, which
 // reports whatever kind Kea returns.
+//
+// keaLeaseTypeToString and stringToKeaLeaseType are a single total inverse
+// pair: every value one accepts, the other round-trips back, and neither has a
+// branch the other lacks. The memfile WRITE path (writeMemfile6) and the
+// control-socket add path (syncLeaseToKea) both go through stringToKeaLeaseType
+// so the read↔write lease-type mapping cannot drift to re-introduce the #2268
+// IA_TA downgrade (a synced IA_TA lease read as IA_TA but written back as
+// IA_NA).
 func keaLeaseTypeToString(t int) (string, bool) {
 	switch t {
 	case keaLeaseTypeIANA:
@@ -363,6 +371,24 @@ func keaLeaseTypeToString(t int) (string, bool) {
 		return "IA_PD", true
 	}
 	return "", false
+}
+
+// stringToKeaLeaseType is the exact inverse of keaLeaseTypeToString: it maps the
+// SyncLease.LeaseType string back to the numeric Kea memfile lease_type column.
+// An empty string defaults to IA_NA (an address lease) — the historical
+// behavior for a lease whose kind the read side could not determine. ok is false
+// for any other non-empty value so the WRITE path never silently emits a
+// mis-typed row; the caller falls back to IA_NA and logs.
+func stringToKeaLeaseType(s string) (int, bool) {
+	switch s {
+	case "", "IA_NA":
+		return keaLeaseTypeIANA, true
+	case "IA_TA":
+		return keaLeaseTypeIATA, true
+	case "IA_PD":
+		return keaLeaseTypeIAPD, true
+	}
+	return keaLeaseTypeIANA, false
 }
 
 // splitV6Identity inverts identity6 ("duid:DUID/IAID") back into DUID + IAID.
@@ -491,11 +517,19 @@ func syncLeaseToKea(l SyncLease, now time.Time) keaLeaseJSON {
 	if l.Family == 6 {
 		kl.DUID = l.DUID
 		kl.IAID = l.IAID
-		kl.Type = l.LeaseType
-		if kl.Type == "" {
-			kl.Type = "IA_NA"
+		// Normalize the lease kind through the shared inverse so the socket-add
+		// path and the memfile pre-seed path agree on every type (#2268). An
+		// unknown string falls back to IA_NA, matching writeMemfile6.
+		lt, ok := stringToKeaLeaseType(l.LeaseType)
+		if !ok {
+			slog.Warn("dhcpserver: seed v6 lease with unknown lease_type, sending as IA_NA",
+				"address", l.Address, "lease_type", l.LeaseType)
 		}
-		if kl.Type == "IA_PD" {
+		s, _ := keaLeaseTypeToString(lt)
+		kl.Type = s
+		// Only IA_PD carries a delegated prefix length; IA_NA / IA_TA are address
+		// bindings (Kea infers /128), so prefix-len stays unset for them.
+		if lt == keaLeaseTypeIAPD {
 			kl.PrefixLen = l.PrefixLen
 		}
 	} else {
@@ -632,12 +666,19 @@ func writeMemfile6(path string, leases []SyncLease, now time.Time) error {
 			rem = 1
 		}
 		expire := now.Unix() + int64(rem)
-		leaseType := 0 // IA_NA
-		if l.LeaseType == "IA_PD" {
-			leaseType = 2 // IA_PD
+		// Encode the v6 lease kind symmetrically with the read path
+		// (keaLeaseTypeToString) via the shared inverse so IA_NA / IA_TA / IA_PD
+		// all round-trip (#2268). An unknown string falls back to IA_NA (an
+		// address lease) and is logged rather than silently mis-typed.
+		leaseType, ok := stringToKeaLeaseType(l.LeaseType)
+		if !ok {
+			slog.Warn("dhcpserver: pre-seed v6 lease with unknown lease_type, writing as IA_NA",
+				"address", l.Address, "lease_type", l.LeaseType)
 		}
+		// IA_PD carries a delegated prefix length; IA_NA and IA_TA are full /128
+		// address bindings (no prefix concept), so their prefix_len column is 128.
 		prefixLen := l.PrefixLen
-		if leaseType == 0 {
+		if leaseType != keaLeaseTypeIAPD {
 			prefixLen = 128
 		}
 		// address,duid,valid_lifetime,expire,subnet_id,pref_lifetime,

--- a/pkg/dhcpserver/lease_sync_test.go
+++ b/pkg/dhcpserver/lease_sync_test.go
@@ -490,3 +490,134 @@ func TestPreSeedMemfile4_RoundTrip(t *testing.T) {
 		t.Errorf("expire = %d, want %d (local re-anchor)", got[0].Expire, localNow.Unix()+900)
 	}
 }
+
+// Test (#2268): the v6 memfile pre-seed must round-trip the lease KIND
+// symmetrically with the read path — an IA_TA (temporary-address) lease read
+// and held as IA_TA must be written back as lease_type=1 (IA_TA), never silently
+// downgraded to lease_type=0 (IA_NA). Before the fix writeMemfile6 only encoded
+// IA_PD vs "everything-else as IA_NA", so an IA_TA lease lost its kind across a
+// failover. IA_NA and IA_PD rows in the same file prove no regression.
+//
+// Fail-on-revert: reverting writeMemfile6 to the IA_PD-vs-IA_NA-only writer
+// makes the IA_TA assertions fail (the row would read back as IA_NA with
+// prefix_len=128, never IA_TA).
+func TestPreSeedMemfile6_RoundTrip_PreservesIATA(t *testing.T) {
+	localNow := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile := filepath.Join(dir, "kea-leases6.csv")
+	m := New()
+	// Pre-seed writes to memfile6; the read-back fallback (no socket) reads it.
+	m.SetLeaseSyncSeamsForTesting(nil, "", filepath.Join(dir, "missing.sock"), "", memfile)
+
+	in := []SyncLease{
+		{Family: 6, Address: "2001:db8::1", DUID: "00:01:00:01", IAID: 10,
+			LeaseType: "IA_NA", SubnetID: 1, Remaining: 1200, State: keaStateDefault},
+		{Family: 6, Address: "2001:db8::ta", DUID: "00:01:00:02", IAID: 20,
+			LeaseType: "IA_TA", SubnetID: 1, Remaining: 1800, State: keaStateDefault},
+		{Family: 6, Address: "2001:db8:abcd::", DUID: "00:01:00:03", IAID: 30,
+			LeaseType: "IA_PD", PrefixLen: 56, SubnetID: 1, Remaining: 2400, State: keaStateDefault},
+	}
+	if err := m.PreSeedMemfile6(in, localNow); err != nil {
+		t.Fatalf("PreSeedMemfile6: %v", err)
+	}
+
+	// Direct byte-level assertion: the IA_TA row must carry lease_type=1. This is
+	// the tightest fail-on-revert guard — an IA_PD-vs-IA_NA-only writer would
+	// emit lease_type=0 for the IA_TA address. The Kea v6 memfile lease_type is
+	// the 7th column (index 6).
+	raw, err := os.ReadFile(memfile)
+	if err != nil {
+		t.Fatalf("read pre-seeded memfile: %v", err)
+	}
+	var sawTAColumn bool
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if !strings.HasPrefix(line, "2001:db8::ta,") {
+			continue
+		}
+		cols := strings.Split(line, ",")
+		if len(cols) < 9 {
+			t.Fatalf("IA_TA row has too few columns: %q", line)
+		}
+		if cols[6] != "1" {
+			t.Errorf("IA_TA row lease_type column = %q, want 1 (#2268 downgrade regression): %q", cols[6], line)
+		}
+		// IA_TA is a full /128 address binding, not a delegated prefix.
+		if cols[8] != "128" {
+			t.Errorf("IA_TA row prefix_len column = %q, want 128: %q", cols[8], line)
+		}
+		sawTAColumn = true
+	}
+	if !sawTAColumn {
+		t.Fatalf("IA_TA row not found in pre-seeded memfile:\n%s", raw)
+	}
+
+	// Full round trip: read the pre-seeded memfile back through the production
+	// read path (socket missing → memfile fallback) and assert each kind survives.
+	got, err := m.GetSyncLeases6(context.Background(), localNow)
+	if err != nil {
+		t.Fatalf("GetSyncLeases6 (read-back): %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("read back %d leases, want 3: %+v", len(got), got)
+	}
+	byAddr := map[string]SyncLease{}
+	for _, l := range got {
+		byAddr[l.Address] = l
+	}
+
+	ta, ok := byAddr["2001:db8::ta"]
+	if !ok {
+		t.Fatalf("IA_TA lease missing after round trip: %+v", got)
+	}
+	if ta.LeaseType != "IA_TA" {
+		t.Errorf("IA_TA lease round-tripped as %q, want IA_TA (#2268 downgrade)", ta.LeaseType)
+	}
+	if ta.PrefixLen != 0 {
+		t.Errorf("IA_TA lease PrefixLen = %d, want 0 (address, not prefix)", ta.PrefixLen)
+	}
+	if ta.DUID != "00:01:00:02" || ta.IAID != 20 {
+		t.Errorf("IA_TA identity wrong: DUID=%q IAID=%d", ta.DUID, ta.IAID)
+	}
+
+	// No regression: IA_NA and IA_PD still round-trip.
+	if na := byAddr["2001:db8::1"]; na.LeaseType != "IA_NA" || na.PrefixLen != 0 {
+		t.Errorf("IA_NA lease regressed: %+v", na)
+	}
+	if pd := byAddr["2001:db8:abcd::"]; pd.LeaseType != "IA_PD" || pd.PrefixLen != 56 {
+		t.Errorf("IA_PD lease regressed: %+v", pd)
+	}
+}
+
+// Test (#2268): the lease-type read↔write mapping is a single total inverse —
+// keaLeaseTypeToString and stringToKeaLeaseType must agree on every value so the
+// pair can never drift to re-introduce an asymmetric downgrade. Every numeric
+// type the reader produces must invert back to the same number, and every string
+// the writer accepts must come from the reader. The empty string (unknown kind)
+// defaults to IA_NA on the write side.
+func TestKeaLeaseTypeInverseTotality(t *testing.T) {
+	for _, n := range []int{keaLeaseTypeIANA, keaLeaseTypeIATA, keaLeaseTypeIAPD} {
+		s, ok := keaLeaseTypeToString(n)
+		if !ok {
+			t.Fatalf("keaLeaseTypeToString(%d) not ok", n)
+		}
+		back, ok := stringToKeaLeaseType(s)
+		if !ok {
+			t.Fatalf("stringToKeaLeaseType(%q) not ok", s)
+		}
+		if back != n {
+			t.Errorf("inverse drift: %d -> %q -> %d", n, s, back)
+		}
+	}
+	// Empty string is the write-side default (unknown kind) → IA_NA.
+	if v, ok := stringToKeaLeaseType(""); !ok || v != keaLeaseTypeIANA {
+		t.Errorf(`stringToKeaLeaseType("") = %d ok=%v, want %d true`, v, ok, keaLeaseTypeIANA)
+	}
+	// An unknown non-empty string is rejected (ok=false) and falls back to IA_NA.
+	if v, ok := stringToKeaLeaseType("IA_BOGUS"); ok || v != keaLeaseTypeIANA {
+		t.Errorf(`stringToKeaLeaseType("IA_BOGUS") = %d ok=%v, want %d false`, v, ok, keaLeaseTypeIANA)
+	}
+	// An unknown numeric type is rejected (mirrors the read side fail-closed).
+	if _, ok := keaLeaseTypeToString(99); ok {
+		t.Errorf("keaLeaseTypeToString(99) ok=true, want false")
+	}
+}


### PR DESCRIPTION
Fixes #2268. Direct follow-up to #2267 (issue #2262).

## Problem
After #2267 the HA DHCP-server lease-sync **read** path distinguishes all
three Kea v6 lease kinds (`keaLeaseTypeToString`: 0=IA_NA, 1=IA_TA, 2=IA_PD),
but the **write / pre-seed** side was asymmetric: `writeMemfile6` only encoded
**IA_PD vs "everything else as IA_NA"** — no IA_TA branch. A synced **IA_TA**
(DHCPv6 temporary address, RFC 8415) lease was read and held as IA_TA on the
standby but written back as `lease_type=0` (IA_NA) when pre-seeding the Kea
memfile on takeover → silent type downgrade across failover.

## Fix (option 1 — full parity)
- Added `stringToKeaLeaseType` as the **exact total inverse** of
  `keaLeaseTypeToString`; both v6 write callers (`writeMemfile6` memfile
  pre-seed AND `syncLeaseToKea` / `lease6-add`) go through it, so the
  read↔write mapping cannot drift to re-introduce the downgrade.
- IA_TA now writes `lease_type=1`.
- `prefix_len` handled correctly: IA_TA (like IA_NA) is a full `/128` address
  binding, so its `prefix_len` column is 128; only IA_PD carries `l.PrefixLen`.
- Unknown lease-type string → IA_NA fallback + log (never silent mis-type).
- Updated `pkg/dhcpserver/README.md` lease-type contract + `SyncLease.LeaseType` doc.

## Tests (fail-on-revert)
- `TestPreSeedMemfile6_RoundTrip_PreservesIATA` — full sync → pre-seed →
  read-back round trip for an IA_TA lease + byte-level `lease_type=1` column
  assertion; IA_NA and IA_PD rows prove no regression.
- `TestKeaLeaseTypeInverseTotality` — asserts the inverse pair agrees on every value.
- Verified: restoring the IA_PD-vs-IA_NA-only writer makes the IA_TA assertions fail.

## Validation
`go build ./...`, `go vet` + `go test` for `pkg/dhcpserver` and `pkg/cluster`
all green; new tests run 5x with no flake.

Severity LOW (IA_TA is rarely used and xpf's Kea config does not hand out
temporary addresses by default), but closes the residual third-type tail of the
#2267 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)