### PR TITLE
routing: surface per-family RuleList errors from clear() (#2273)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9451,3 +9451,29 @@ top.
   (dhcpserver, cluster) green; new tests 5x no flake.
   **File(s)**: pkg/dhcpserver/lease_sync.go, pkg/dhcpserver/lease_sync_test.go,
   pkg/dhcpserver/README.md, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2273 — surface per-family RuleList errors from routing clear()
+  instead of swallowing them. All three policy-routing reconcilers
+  (nextTableManager, ribGroupManager, pbrManager in pkg/routing/rules.go)
+  looped [AF_INET, AF_INET6], called RuleList(family), `continue`d on error,
+  and returned nil unconditionally. A transient AF_INET dump failure left the
+  IPv4 rules in the manager's priority window orphaned for that pass while
+  IPv6 was cleaned, and the caller (daemon_apply.go 3b-3d) never learned — a
+  brief, unobservable self-healing window (re-cleared on next commit). Fix:
+  each clear() now aggregates per-family RuleList failures (errors.Join,
+  wrapped with the family) and returns them, while still best-effort deleting
+  every family whose dump succeeded. Each Apply captures the clear error,
+  logs it at WARN, still re-adds the desired rules (forward progress preserved,
+  including the empty-config early returns), then returns the clear error so
+  the daemon observes it. Decision: Apply logs-and-continues — it does NOT
+  abort on a clear() error — so the common (no-error) path is unchanged; the
+  daemon still logs+continues, the failure is now just visible/retryable.
+  Extended fakeRuleOps with a per-family listErr injector + failList helper;
+  added TestRulesClearListErrorSurfaced (table-driven over all three managers)
+  asserting Apply returns an error wrapping the injected failure AND still
+  deletes the successful family's window rule. Fail-on-revert verified
+  (reverting next-table to continue+return-nil fails the next-table subtest).
+  build+vet+test green, new test 5x no flake.
+  **File(s)**: pkg/routing/rules.go, pkg/routing/rules_test.go,
+  pkg/routing/README.md, _Log.md

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -98,6 +98,34 @@ delegate to the owning domain. Exported types:
   (lower priority value = higher priority). PBR sits before main as
   well; rib-group sits after.
 
+### clear()/Apply error contract (#2273)
+
+Each reconciler's `Apply` is clear-then-re-add: `clear()` removes every
+rule in the manager's own priority window, then `Apply` re-installs the
+desired set. `clear()` walks `[AF_INET, AF_INET6]`, calling `RuleList`
+(a per-family netlink dump) on each. The error handling is:
+
+- **Per-family `RuleList` failures are best-effort but observable.** A
+  family whose dump fails is skipped (its in-window rules are left in
+  place that pass), but the failure is **aggregated and returned**
+  (`errors.Join`, wrapped with the family) rather than swallowed. Every
+  family whose dump succeeds is still cleaned. Before #2273 a transient
+  `AF_INET` dump failure orphaned the IPv4 rules in the window for that
+  pass and `clear()` returned `nil`, so the caller never learned — a
+  brief, unobservable self-healing window (the rules are re-cleared on
+  the next commit once the transient clears).
+- **`Apply` logs-and-continues; it does NOT abort on a `clear()` error.**
+  The clear error is captured, logged at WARN, and the desired rules are
+  still re-added (forward progress on the common path is preserved,
+  including the empty-config early returns). `Apply` then **returns the
+  clear error** so `pkg/daemon` (`daemon_apply.go` steps 3b–3d) observes
+  it. The daemon currently logs Apply errors at WARN and continues; the
+  change makes the failure visible (and lets a future caller retry)
+  without changing the daemon's apply sequencing. `RuleDel` failures on
+  individual rules remain debug-logged and do not fail `Apply` — a stale
+  rule that survives one delete is swept by the next pass and re-add uses
+  `NLM_F_CREATE|NLM_F_EXCL`, so a still-desired rule stays correct.
+
 ## Tunnel reconcile-in-place (#1884)
 
 `tunnelManager.Apply` reconciles instead of clear-all +

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -1,6 +1,8 @@
 package routing
 
 import (
+	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"strconv"
@@ -54,9 +56,15 @@ func (n *nextTableManager) Apply(routes []*config.StaticRoute, instances []*conf
 		tableIDs[inst.Name] = inst.TableID
 	}
 
-	// Clean up old next-table rules (priority range 100-199)
-	if err := n.clear(); err != nil {
-		slog.Warn("failed to clear old next-table rules", "err", err)
+	// Clean up old next-table rules (priority range 100-199). A failed
+	// per-family list does NOT abort the apply — we still re-add every
+	// desired rule below so forward progress is preserved on the common
+	// path. The clear error is captured and returned at the end so the
+	// caller can observe (and a future caller retry) instead of leaving
+	// orphaned rules in an unobservable window (#2273).
+	clearErr := n.clear()
+	if clearErr != nil {
+		slog.Warn("failed to clear old next-table rules", "err", clearErr)
 	}
 
 	prio := nextTableRulePriority
@@ -111,14 +119,27 @@ func (n *nextTableManager) Apply(routes []*config.StaticRoute, instances []*conf
 			"destination", sr.Destination, "instance", sr.NextTable, "table", tableID)
 		prio++
 	}
-	return nil
+	// Desired rules are re-added; surface any clear() list failure so the
+	// orphaned-rule window is observable rather than silently nil.
+	return clearErr
 }
 
 // clear removes all ip rules in the next-table priority range.
+//
+// A per-family RuleList dump that fails transiently must NOT be silently
+// swallowed: continuing past it means the rules in that family's window
+// are left in place (orphaned) for this pass while the other family is
+// cleaned, and the caller never learns it happened. We still best-effort
+// delete every family whose dump DID succeed, but we aggregate the dump
+// failures and return them so Apply (and ultimately the daemon apply
+// loop) can observe — and a future caller could retry — instead of the
+// brief, unobservable self-healing-orphan window described in #2273.
 func (n *nextTableManager) clear() error {
+	var errs []error
 	for _, family := range []int{unix.AF_INET, unix.AF_INET6} {
 		rules, err := n.ops.RuleList(family)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("list next-table rules family %d: %w", family, err))
 			continue
 		}
 		for _, r := range rules {
@@ -130,7 +151,7 @@ func (n *nextTableManager) clear() error {
 			}
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // ribGroupManager reconciles rib-group route-leak ip rules. Stateless
@@ -154,13 +175,17 @@ type ribGroupManager struct {
 //
 //	ip rule add from all lookup 101 pref 33000
 func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instances []*config.RoutingInstanceConfig) error {
-	// Clean up old rib-group rules
-	if err := rg.clear(); err != nil {
-		slog.Warn("failed to clear old rib-group rules", "err", err)
+	// Clean up old rib-group rules. As with next-table, a failed per-family
+	// list does not abort the apply; the clear error is captured and
+	// returned at the end (or at the early-return below) so the caller can
+	// observe it (#2273).
+	clearErr := rg.clear()
+	if clearErr != nil {
+		slog.Warn("failed to clear old rib-group rules", "err", clearErr)
 	}
 
 	if len(ribGroups) == 0 || len(instances) == 0 {
-		return nil
+		return clearErr
 	}
 
 	// Build instance name → table ID map
@@ -269,15 +294,21 @@ func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instance
 		}
 		prio++
 	}
-	return nil
+	// Desired rules are re-added; surface any clear() list failure.
+	return clearErr
 }
 
 // clear removes all ip rules in the rib-group priority range. Also
 // cleans up legacy rules from the old 200-299 range.
+//
+// Per-family RuleList dump failures are aggregated and returned rather
+// than swallowed; see the rationale on nextTableManager.clear (#2273).
 func (rg *ribGroupManager) clear() error {
+	var errs []error
 	for _, family := range []int{unix.AF_INET, unix.AF_INET6} {
 		rules, err := rg.ops.RuleList(family)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("list rib-group rules family %d: %w", family, err))
 			continue
 		}
 		for _, r := range rules {
@@ -291,7 +322,7 @@ func (rg *ribGroupManager) clear() error {
 			}
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // PBRRule describes a single policy-based routing rule derived from a
@@ -316,13 +347,17 @@ type pbrManager struct {
 // policy-based routing: traffic matching DSCP/source/destination
 // criteria is routed via the specified VRF's routing table.
 func (p *pbrManager) Apply(rules []PBRRule) error {
-	// Clean up old PBR rules first
-	if err := p.clear(); err != nil {
-		slog.Warn("failed to clear old PBR rules", "err", err)
+	// Clean up old PBR rules first. As with next-table, a failed per-family
+	// list does not abort the apply; the clear error is captured and
+	// returned at the end (or at the early-return below) so the caller can
+	// observe it (#2273).
+	clearErr := p.clear()
+	if clearErr != nil {
+		slog.Warn("failed to clear old PBR rules", "err", clearErr)
 	}
 
 	if len(rules) == 0 {
-		return nil
+		return clearErr
 	}
 
 	prio := pbrRulePriority
@@ -368,14 +403,20 @@ func (p *pbrManager) Apply(rules []PBRRule) error {
 			break
 		}
 	}
-	return nil
+	// Desired rules are re-added; surface any clear() list failure.
+	return clearErr
 }
 
 // clear removes all ip rules in the PBR priority range.
+//
+// Per-family RuleList dump failures are aggregated and returned rather
+// than swallowed; see the rationale on nextTableManager.clear (#2273).
 func (p *pbrManager) clear() error {
+	var errs []error
 	for _, family := range []int{unix.AF_INET, unix.AF_INET6} {
 		rules, err := p.ops.RuleList(family)
 		if err != nil {
+			errs = append(errs, fmt.Errorf("list PBR rules family %d: %w", family, err))
 			continue
 		}
 		for _, r := range rules {
@@ -387,7 +428,7 @@ func (p *pbrManager) clear() error {
 			}
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // BuildPBRRules extracts policy-based routing rules from firewall filter

--- a/pkg/routing/rules_test.go
+++ b/pkg/routing/rules_test.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -20,6 +21,12 @@ type fakeRuleOps struct {
 	// rules holds the current rule set keyed by family, mirroring the
 	// kernel's per-family rule list that RuleList returns.
 	rules map[int][]netlink.Rule
+
+	// listErr injects a per-family RuleList dump failure, simulating a
+	// transient netlink error on one address family while the other
+	// succeeds — the failure mode #2273 fixes. RuleList(family) returns
+	// listErr[family] (and a nil slice) when present.
+	listErr map[int]error
 
 	adds int
 	dels int
@@ -53,7 +60,21 @@ func (f *fakeRuleOps) RuleDel(r *netlink.Rule) error {
 }
 
 func (f *fakeRuleOps) RuleList(family int) ([]netlink.Rule, error) {
+	if f.listErr != nil {
+		if err := f.listErr[family]; err != nil {
+			return nil, err
+		}
+	}
 	return f.rules[family], nil
+}
+
+// failList arms RuleList(family) to return err. Used to recreate the
+// transient per-family netlink dump failure from #2273.
+func (f *fakeRuleOps) failList(family int, err error) {
+	if f.listErr == nil {
+		f.listErr = map[int]error{}
+	}
+	f.listErr[family] = err
 }
 
 // count returns the number of rules currently present for a family.
@@ -442,5 +463,112 @@ func TestPBRRulesApply_Fake(t *testing.T) {
 	if ops.count(unix.AF_INET) != 0 || ops.count(unix.AF_INET6) != 0 {
 		t.Errorf("expected all PBR rules cleared, v4=%d v6=%d",
 			ops.count(unix.AF_INET), ops.count(unix.AF_INET6))
+	}
+}
+
+// seedRule inserts a rule at the given family/priority/table directly into
+// the fake's backing store (bypassing RuleAdd accounting) so a clear() can
+// be exercised against pre-existing kernel rules.
+func seedRule(ops *fakeRuleOps, family, prio, table int) {
+	ops.rules[family] = append(ops.rules[family], netlink.Rule{
+		Family:   family,
+		Priority: prio,
+		Table:    table,
+	})
+}
+
+// TestRulesClearListErrorSurfaced is the #2273 fail-on-revert guard. When
+// RuleList(AF_INET) fails transiently while RuleList(AF_INET6) succeeds,
+// clear() (via Apply) must:
+//
+//  1. return a non-nil error naming the failing family (so the daemon
+//     apply loop observes it instead of a silent self-healing-orphan
+//     window), and
+//  2. still best-effort delete the rules it COULD list — the AF_INET6
+//     rule in the managed window is removed.
+//
+// The AF_INET rule in the window is left in place because its family's
+// dump failed (the orphan this PR makes observable). Reverting clear() to
+// `continue` + `return nil` makes assertion (1) fail for all three
+// managers, and reverting the Apply wiring (returning bare nil) also fails
+// (1) — this is the regression pin.
+func TestRulesClearListErrorSurfaced(t *testing.T) {
+	injErr := errors.New("netlink: transient EBUSY on AF_INET dump")
+
+	type tc struct {
+		name string
+		// run pre-seeds rules, arms the AF_INET list failure, runs Apply
+		// with a desired config that produces ZERO new rules (so the only
+		// activity is the clear), and returns the Apply error.
+		run func(ops *fakeRuleOps) error
+		// inetPrio / inet6Prio are managed-window priorities for each
+		// domain so the seeded rules fall inside clear()'s scan range.
+		inetPrio  int
+		inet6Prio int
+	}
+
+	cases := []tc{
+		{
+			name:      "next-table",
+			inetPrio:  nextTableRulePriority + 1,
+			inet6Prio: nextTableRulePriority + 2,
+			run: func(ops *fakeRuleOps) error {
+				nt := &nextTableManager{ops: ops}
+				// No routes carry a next-table directive → no re-adds; the
+				// only work clear() does is delete-in-window.
+				return nt.Apply(nil, nil)
+			},
+		},
+		{
+			name:      "rib-group",
+			inetPrio:  ribGroupRulePriority + 1,
+			inet6Prio: ribGroupRulePriority + 2,
+			run: func(ops *fakeRuleOps) error {
+				rg := &ribGroupManager{ops: ops}
+				// Empty rib-groups → early return after clear; no re-adds.
+				return rg.Apply(nil, nil)
+			},
+		},
+		{
+			name:      "pbr",
+			inetPrio:  pbrRulePriority + 1,
+			inet6Prio: pbrRulePriority + 2,
+			run: func(ops *fakeRuleOps) error {
+				p := &pbrManager{ops: ops}
+				// Empty PBR set → early return after clear; no re-adds.
+				return p.Apply(nil)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ops := newFakeRuleOps()
+			// One managed-window rule per family.
+			seedRule(ops, unix.AF_INET, c.inetPrio, 100)
+			seedRule(ops, unix.AF_INET6, c.inet6Prio, 101)
+			// AF_INET dump fails transiently; AF_INET6 succeeds.
+			ops.failList(unix.AF_INET, injErr)
+
+			err := c.run(ops)
+			if err == nil {
+				t.Fatalf("%s: Apply must return an error when RuleList(AF_INET) fails (#2273) — got nil", c.name)
+			}
+			if !errors.Is(err, injErr) {
+				t.Errorf("%s: returned error must wrap the injected list failure, got %v", c.name, err)
+			}
+
+			// Best-effort delete preserved: the family that DID list is
+			// cleaned. The AF_INET6 window rule must be gone.
+			if got := ops.count(unix.AF_INET6); got != 0 {
+				t.Errorf("%s: AF_INET6 window rule must still be deleted despite the AF_INET list failure, count=%d rules=%v",
+					c.name, got, ops.rules[unix.AF_INET6])
+			}
+			// The AF_INET window rule could not be listed, so it survives
+			// (the orphan this PR makes observable, not silent).
+			if got := ops.count(unix.AF_INET); got != 1 {
+				t.Errorf("%s: AF_INET window rule should remain (its dump failed), count=%d", c.name, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- All three policy-routing ip-rule reconcilers (`nextTableManager`, `ribGroupManager`, `pbrManager` in `pkg/routing/rules.go`) cleaned their priority window by looping `[AF_INET, AF_INET6]`, calling `RuleList(family)`, `continue`-ing on a dump error, and returning `nil` unconditionally.
- A transient `AF_INET` netlink dump failure (while `AF_INET6` succeeds) left the IPv4 rules in the managed window **orphaned for that pass** while IPv6 was cleaned. The caller (`daemon_apply.go` steps 3b–3d) only logs the Apply result, so the failure was invisible. Self-heals on the next commit, but the window — though brief and bounded to the manager's own priority range (100–199 / 33000–33099 / 31000–31999) — was entirely unobservable (#2273, LOW).
- Each `clear()` now **aggregates** per-family `RuleList` failures (`errors.Join`, wrapped with the family) and returns them, while still **best-effort deleting** every family whose dump succeeded.
- Each `Apply` captures the clear error, logs it at WARN, and **still re-adds the full desired rule set** (forward progress preserved, including the empty-config early returns), then returns the clear error so the daemon apply loop observes it.

## Decision: Apply abort-vs-continue

**Apply logs-and-continues — it does NOT abort on a `clear()` error.** The clear error is captured, logged at WARN, the desired rules are re-added, and the error is then returned for observability. The no-error path is bit-identical to before; the daemon (`daemon_apply.go`) still logs Apply errors and continues, so sequencing is unchanged — the failure is now just visible and retryable. Per-rule `RuleDel` failures stay debug-logged and non-fatal (a stale rule is swept next pass; re-add uses `NLM_F_CREATE|NLM_F_EXCL`, so a still-desired rule stays correct).

## Test plan

- [x] Extended `fakeRuleOps` with a per-family `RuleList` error injector (`listErr` map + `failList` helper) — it previously never returned a `RuleList` error.
- [x] New table-driven `TestRulesClearListErrorSurfaced` runs all three managers with `RuleList(AF_INET)` armed to fail: each `Apply` must return an error wrapping the injected failure AND must still delete the successful `AF_INET6` window rule (best-effort delete preserved); the `AF_INET` window rule survives (the orphan, now observable).
- [x] **Fail-on-revert** verified: reverting a manager to `continue` + `return nil` fails its subtest (confirmed against next-table; rib-group/PBR subtests still pass in the same run).
- [x] `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` green.
- [x] `go vet ./pkg/routing/...` green.
- [x] `go test ./pkg/routing/...` green; new test 5x no flake.

## Docs

- `pkg/routing/README.md` gains a "clear()/Apply error contract (#2273)" subsection documenting the best-effort-but-observable per-family list behavior and the log-and-continue Apply decision.

## Scope

`pkg/routing` only (rules.go, rules_test.go, README.md) + `_Log.md`. No dataplane / VRRP / HA / daemon code changed.

Refs #2273

🤖 Generated with [Claude Code](https://claude.com/claude-code)