### PR TITLE
ra: clamp prefix preferred lifetime + atomic WithdrawOnce check-and-claim (#2271 #2272)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9430,3 +9430,34 @@ top.
   hardcoding IA_NA breaks them). build+vet+test green, new tests 5x no flake.
   **File(s)**: pkg/dhcpserver/ddns_leases.go, pkg/dhcpserver/lease_sync.go,
   pkg/dhcpserver/lease_sync_test.go, pkg/dhcpserver/README.md, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2271 + #2272 — pkg/ra RA lifetime clamp + WithdrawOnce
+  check-and-act atomicity (ONE PR closing both). #2271 (LOW, real bug):
+  buildRA (sender.go) constructed PrefixInformation without enforcing RFC
+  4861 §4.6.2 (preferred-lifetime <= valid-lifetime); a misconfigured or
+  0-defaulted pair could advertise pref > valid, which conforming hosts
+  (RFC 4862 §5.5.3) ignore — silently dropping SLAAC on every host. Fix:
+  clamp prefLife DOWN to validLife after the existing default-fill
+  (`if prefLife > validLife { prefLife = validLife }`), never the reverse.
+  Matrix unit test (ordered/inverted/equal/both-zero/default-mixes/infinite
+  endpoints) asserts the advertised values AND the §4.6.2 invariant;
+  fail-on-revert verified (removing the clamp fails 4 cases). #2272 (MEDIUM):
+  the check-and-act race the issue describes was already structurally closed
+  by #2033's claim-and-hold tombstone (WithdrawOnce holds m.mu across the
+  interfaceBusy check AND the tombstone install). Extracted that atomic
+  step into claimWithdrawOnceLocked with a hard contract comment so it
+  cannot drift back to the pre-#2033 split-lock shape, and added the missing
+  -race regression: TestWithdrawOnceVsApplySingleOwner (concurrent Apply/
+  WithdrawOnce/Withdraw on one iface, peak live-conn <=1 + no normal RA after
+  a goodbye per conn) and TestWithdrawOnceHoldsTombstoneDuringGoodbye
+  (deterministic: a concurrent Apply defers for the whole goodbye window).
+  REVERT-PROOF: temporarily reverting WithdrawOnce to the pre-#2033
+  check-then-act shape (drop lock between check and act, start a REAL
+  sender) made BOTH -race tests fail (peak=2 conns; normal RA lifetime=30m
+  after a goodbye; Apply started a live sender during the goodbye) across 3
+  runs; restored. go build ./... + go vet ./pkg/ra/... + go test ./pkg/ra/
+  + go test -race ./pkg/ra/ all green; -race -count=5 no flake. Did NOT
+  merge — parent runs test-failover (RA withdraw fires on failover).
+  **File(s)**: pkg/ra/sender.go, pkg/ra/ra.go, pkg/ra/ra_test.go,
+  pkg/ra/serialize_test.go, pkg/ra/README.md, _Log.md

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -148,7 +148,15 @@ best-effort).
 - `WithdrawInterfaces(names []string)` — `ra.go`. Graceful goodbye + stop
   by interface name.
 - `WithdrawOnce(configs []*config.RAInterfaceConfig)` — `ra.go`.
-  Goodbye-only (no burst, no link toggle); skips busy interfaces.
+  Goodbye-only (no burst, no link toggle); skips busy interfaces. The
+  busy-check and the claim-and-hold tombstone install are performed
+  ATOMICALLY under `m.mu` by `claimWithdrawOnceLocked` (#2272): holding the
+  lock across BOTH closes the check-and-act window in which a concurrent
+  `Apply`/`WithdrawOnce` could otherwise start a competing sender between
+  the check and the claim (two owners on one link, or a sender racing the
+  goodbye — the #2033 blackhole class). The tombstone is then HELD across
+  the goodbye emit, so the busy state — and thus the mutual exclusion —
+  extends over the whole operation, not just the install instant.
 - `Clear() error` — `ra.go`. Hard stop (no goodbye) of every sender.
 - `Status()` — `ra.go`. Per-interface `SenderInfo`. A running sender has
   `State == "active"`; an interface whose sender is tearing down /

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -174,6 +174,15 @@ best-effort).
   or shutting down. It is emitted by the per-interface owner goroutine as
   its last write (see the shutdown contract above) so a normal RA can
   never follow it on the wire.
+- Prefix lifetimes are clamped to satisfy RFC 4861 §4.6.2 (#2271):
+  `buildRA` (`sender.go`) clamps each PrefixInformation's preferred
+  lifetime DOWN to its valid lifetime (`if prefLife > validLife`). A pair
+  where preferred > valid is malformed and a conforming host (RFC 4862
+  §5.5.3) ignores the prefix, so an operator that types
+  `preferred-lifetime` larger than `valid-lifetime` (or a 0-defaulted
+  valid life paired with a large explicit preferred life) would otherwise
+  silently lose SLAAC on every host. The clamp is never the reverse —
+  extending validity would advertise a longer-lived prefix than configured.
 - IPv6 NODAD is set on the per-instance NDP socket so it doesn't fight
   the kernel's own duplicate-address detection on the link-local
   address.

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -565,7 +565,46 @@ func (m *Manager) ResendBurst() {
 // sender (VRRP MASTER already won) or an existing tombstone are skipped — a
 // goodbye must not clobber a live primary.
 func (m *Manager) WithdrawOnce(configs []*config.RAInterfaceConfig) {
+	// The busy-check and the tombstone install MUST be atomic under m.mu —
+	// claimWithdrawOnceLocked does both while holding the lock. Splitting them
+	// (check, drop the lock, then install) reopens the #2272 check-and-act race:
+	// between the check and the install, an Apply() or a concurrent WithdrawOnce
+	// could start a real sender on the same interface, producing two owners on
+	// one link or a sender that races the goodbye (the #2033 blackhole class).
+	toGoodbye := m.claimWithdrawOnceLocked(configs)
+
+	// The tombstone for each claimed interface is HELD across sendOneGoodbye
+	// (which runs without m.mu so the emit's blocking writes do not stall other
+	// callers). While it is held, interfaceBusy reports the interface as busy, so
+	// a concurrent Apply defers instead of opening a second NDP conn (#2033 I4),
+	// and a concurrent WithdrawOnce skips it. sendOneGoodbye never launches a
+	// run() loop, so it emits only the lifetime-0 goodbye and never a normal RA
+	// after it — preserving the single-owner-emit invariant. The tombstone is
+	// removed only AFTER the goodbye fully completes.
+	for _, cfg := range toGoodbye {
+		m.sendOneGoodbye(cfg)
+		m.mu.Lock()
+		delete(m.draining, cfg.Interface)
+		m.mu.Unlock()
+	}
+}
+
+// claimWithdrawOnceLocked performs the WithdrawOnce check-and-claim for each
+// config ATOMICALLY under a single m.mu hold (#2272). For every interface that
+// is not already busy (no live sender, no draining tombstone) it installs a
+// claim-and-hold tombstone and returns it for the caller to emit a goodbye on.
+// Holding m.mu across BOTH the interfaceBusy check AND the tombstone install is
+// the whole point: it closes the window in which an Apply()/WithdrawOnce could
+// otherwise start a competing sender between the check and the claim. The
+// returned slice is the set this call OWNS the goodbye + tombstone-release for.
+//
+// The tombstone pre-marks goodbyeClaimed=true: WithdrawOnce emits exactly one
+// goodbye itself, so a racing graceful Withdraw that flips goodbyeWanted on this
+// entry must NOT also emit a standalone (claim-once, #2033). sender is nil — a
+// WithdrawOnce claim has no run() loop to join.
+func (m *Manager) claimWithdrawOnceLocked(configs []*config.RAInterfaceConfig) []*config.RAInterfaceConfig {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.bumpEpoch()
 	var toGoodbye []*config.RAInterfaceConfig
 	for _, cfg := range configs {
@@ -574,21 +613,10 @@ func (m *Manager) WithdrawOnce(configs []*config.RAInterfaceConfig) {
 				"interface", cfg.Interface)
 			continue
 		}
-		// Claim the interface (sender:nil — no run() loop) and pre-mark the
-		// goodbye as CLAIMED: WithdrawOnce emits exactly one goodbye below, so a
-		// racing graceful Withdraw that flips goodbyeWanted must NOT also emit.
-		// The entry is HELD across the emit so a concurrent Apply defers.
 		m.draining[cfg.Interface] = &drainEntry{cfg: cfg, goodbyeClaimed: true}
 		toGoodbye = append(toGoodbye, cfg)
 	}
-	m.mu.Unlock()
-
-	for _, cfg := range toGoodbye {
-		m.sendOneGoodbye(cfg)
-		m.mu.Lock()
-		delete(m.draining, cfg.Interface)
-		m.mu.Unlock()
-	}
+	return toGoodbye
 }
 
 // sendOneGoodbye opens a temporary sender for cfg, emits the standalone goodbye

--- a/pkg/ra/ra_test.go
+++ b/pkg/ra/ra_test.go
@@ -269,6 +269,100 @@ func TestBuildRA_LifetimeAndMTU(t *testing.T) {
 	}
 }
 
+// TestBuildRA_PrefLifeClampedToValidLife is the #2271 regression. RFC 4861
+// §4.6.2 requires PreferredLifetime <= ValidLifetime; buildRA must clamp the
+// preferred lifetime down to the valid lifetime so a misconfigured (or
+// 0-defaulted) pair never advertises a malformed PrefixInformation that
+// conforming hosts (RFC 4862 §5.5.3) ignore.
+//
+// The matrix exercises: ordered pairs (no-op), the inverted pair that triggers
+// the clamp, 0-config (defaults), a mix of an explicit valid life with an
+// over-large preferred life, equal lifetimes, and the "infinite" (max-int)
+// endpoints in both positions.
+func TestBuildRA_PrefLifeClampedToValidLife(t *testing.T) {
+	const infinite = 4294967295 // 0xffffffff: largest lifetime an operator can express
+	cases := []struct {
+		name      string
+		valid     int // pfx.ValidLifetime config
+		preferred int // pfx.PreferredLife config
+		wantValid int // expected advertised valid lifetime (seconds)
+		wantPref  int // expected advertised preferred lifetime (seconds)
+	}{
+		{"ordered_no_clamp", 86400, 14400, 86400, 14400},
+		{"inverted_clamps_pref_down", 100, 200, 100, 100},
+		{"equal_no_clamp", 3600, 3600, 3600, 3600},
+		{"both_zero_uses_defaults", 0, 0, defaultValidLifetime, defaultPreferredLifetime},
+		// valid=0 -> default valid (2592000), explicit pref below the default
+		// valid: no clamp. defaultPreferredLifetime (604800) <= 2592000.
+		{"valid_default_pref_explicit_ok", 0, 1000, defaultValidLifetime, 1000},
+		// valid=0 -> default valid (2592000), explicit pref ABOVE the default
+		// valid would be malformed -> clamp down to the default valid life.
+		{"valid_default_pref_over_clamps", 0, defaultValidLifetime + 1, defaultValidLifetime, defaultValidLifetime},
+		// pref=0 -> default preferred (604800); valid explicitly smaller ->
+		// the defaulted preferred life must be clamped down to the valid life.
+		{"pref_default_over_valid_clamps", 100, 0, 100, 100},
+		// Infinite valid life: any preferred life (even infinite) is <= it.
+		{"infinite_valid_finite_pref", infinite, 14400, infinite, 14400},
+		{"infinite_both_equal", infinite, infinite, infinite, infinite},
+		// Infinite preferred life but finite valid life: clamp the preferred
+		// life all the way down to the finite valid life.
+		{"infinite_pref_finite_valid_clamps", 86400, infinite, 86400, 86400},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &sender{
+				cfg: &config.RAInterfaceConfig{
+					Interface: "trust0",
+					Prefixes: []*config.RAPrefix{
+						{
+							Prefix:        "2001:db8::/64",
+							OnLink:        true,
+							Autonomous:    true,
+							ValidLifetime: tc.valid,
+							PreferredLife: tc.preferred,
+						},
+					},
+				},
+				iface: &net.Interface{
+					Name:         "trust0",
+					HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+				},
+			}
+
+			ra := s.buildRA()
+
+			var pi *ndp.PrefixInformation
+			for _, opt := range ra.Options {
+				if p, ok := opt.(*ndp.PrefixInformation); ok {
+					pi = p
+					break
+				}
+			}
+			if pi == nil {
+				t.Fatal("missing prefix information option")
+			}
+
+			wantValid := time.Duration(tc.wantValid) * time.Second
+			wantPref := time.Duration(tc.wantPref) * time.Second
+			if pi.ValidLifetime != wantValid {
+				t.Errorf("ValidLifetime = %v, want %v", pi.ValidLifetime, wantValid)
+			}
+			if pi.PreferredLifetime != wantPref {
+				t.Errorf("PreferredLifetime = %v, want %v", pi.PreferredLifetime, wantPref)
+			}
+
+			// The RFC 4861 §4.6.2 invariant itself: preferred MUST NOT exceed
+			// valid. This is the fail-on-revert pin — if the clamp is removed,
+			// inverted/over-large cases advertise pref > valid and fail here.
+			if pi.PreferredLifetime > pi.ValidLifetime {
+				t.Errorf("RFC 4861 §4.6.2 violated: PreferredLifetime (%v) > ValidLifetime (%v)",
+					pi.PreferredLifetime, pi.ValidLifetime)
+			}
+		})
+	}
+}
+
 func TestBuildRA_MultipleInterfaces(t *testing.T) {
 	m := New()
 	// Verify manager starts empty.

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -544,6 +544,25 @@ func (s *sender) buildRA() *ndp.RouterAdvertisement {
 			prefLife = defaultPreferredLifetime
 		}
 
+		// RFC 4861 §4.6.2: the Preferred Lifetime MUST NOT exceed the Valid
+		// Lifetime. A PrefixInformation that violates this is malformed; per
+		// RFC 4862 §5.5.3 a conforming host treats prefLife>validLife as an
+		// error and ignores the prefix, so a misconfigured pair (operator types
+		// preferred-lifetime larger than valid-lifetime, or a 0-defaulted valid
+		// life paired with a large explicit preferred life) could silently drop
+		// the prefix on every host. Clamp prefLife DOWN to validLife — never the
+		// reverse, since extending the valid lifetime would advertise a
+		// longer-lived prefix than the operator configured. Both values are plain
+		// non-negative seconds (the schema gate rejects negatives, and a 0 has
+		// already been replaced by its SLAAC default above), so the comparison is
+		// a straight integer ordering check. "Infinite" is simply the largest
+		// value the operator can express; the same clamp keeps it ordered (a
+		// finite valid life still pulls an over-large preferred life down to it,
+		// and an infinite valid life leaves any preferred life unchanged).
+		if prefLife > validLife {
+			prefLife = validLife
+		}
+
 		ra.Options = append(ra.Options, &ndp.PrefixInformation{
 			PrefixLength:                   uint8(prefix.Bits()),
 			OnLink:                         pfx.OnLink,

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -1910,6 +1910,196 @@ func TestRound5_WithdrawDuringRestartDecisionNoReplacementGoodbyeEmitted(t *test
 //
 // NON-TAUTOLOGY: against the cached-boolean code the restart starts the
 // replacement (RA re-armed after a newer Clear) → FAILS.
+// TestWithdrawOnceVsApplySingleOwner is the #2272 regression: WithdrawOnce must
+// hold m.mu across its busy-check AND its tombstone install, so a concurrent
+// Apply() / WithdrawOnce cannot start a competing sender between the two. We
+// hammer Apply, WithdrawOnce, and Withdraw concurrently on ONE interface under
+// -race and assert two invariants that the split-lock bug would break:
+//
+//  1. Single owner: the live NDP-conn count for the interface never exceeds 1.
+//     Two senders (or a sender started during a WithdrawOnce goodbye) trips it.
+//  2. No normal RA after a goodbye on any single conn: a sender that raced the
+//     withdraw would emit a lifetime>0 RA after a lifetime-0 goodbye on the same
+//     conn — the exact #2033 blackhole class the issue calls out.
+//
+// REVERT-PROOF: reverting WithdrawOnce to the pre-#2033 check-then-act shape
+// (lock, check m.senders, UNLOCK, then start a sender + send the goodbye —
+// dropping the lock between the check and the act) lets Apply start a live
+// sender in the gap, so the peak live-conn count reaches 2 and/or a normal RA
+// follows a goodbye on a conn, failing this test. Verified during development.
+func TestWithdrawOnceVsApplySingleOwner(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+	cfg := []*config.RAInterfaceConfig{testCfg("lo")}
+
+	stop := make(chan struct{})
+	var peak int32
+	var peakMu sync.Mutex
+	recordPeak := func() {
+		lc := fl.liveCount()
+		peakMu.Lock()
+		if lc > peak {
+			peak = lc
+		}
+		peakMu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	worker := func(fn func()) {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			fn()
+			recordPeak()
+		}
+	}
+	wg.Add(3)
+	go worker(func() { _ = m.Apply(cfg) })
+	go worker(func() { m.WithdrawOnce(cfg) })
+	go worker(func() { _ = m.Withdraw() })
+
+	time.Sleep(400 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	// Drain to a known state.
+	_ = m.Clear()
+
+	peakMu.Lock()
+	p := peak
+	peakMu.Unlock()
+	if p > 1 {
+		t.Fatalf("peak live conns = %d, want <=1 — WithdrawOnce raced a competing "+
+			"sender onto the same interface (#2272 check-and-act race)", p)
+	}
+	if lc := fl.liveCount(); lc != 0 {
+		t.Fatalf("leaked %d live conns after Clear", lc)
+	}
+
+	// Per-conn ordering: no normal RA may follow a goodbye on the SAME conn.
+	// (A WithdrawOnce conn that somehow ran a sender, or a sender started during
+	// the goodbye window, would show a lifetime>0 write after the lifetime-0 one.)
+	fl.mu.Lock()
+	conns := append([]*fakeConn(nil), fl.allConns["lo"]...)
+	fl.mu.Unlock()
+	for ci, c := range conns {
+		writes := c.snapshot()
+		firstGoodbye := -1
+		for _, w := range writes {
+			if w.lifetime == 0 {
+				firstGoodbye = w.seq
+				break
+			}
+		}
+		if firstGoodbye < 0 {
+			continue
+		}
+		for _, w := range writes {
+			if w.lifetime > 0 && w.seq > firstGoodbye {
+				t.Fatalf("conn %d: normal RA (lifetime=%v, seq=%d) emitted AFTER the "+
+					"first goodbye (seq=%d) — single-owner-emit invariant broken (#2272/#2033)",
+					ci, w.lifetime, w.seq, firstGoodbye)
+			}
+		}
+	}
+}
+
+// TestWithdrawOnceHoldsTombstoneDuringGoodbye is the deterministic companion to
+// the stress test above. It drives the PUBLIC WithdrawOnce path and proves that
+// the claim-and-hold tombstone is held across the goodbye emit: while a
+// WithdrawOnce goodbye is mid-write (gated), a concurrent Apply for the same
+// interface must DEFER — it must not start a live sender and the live-conn count
+// must stay <=1 for the whole emit window. After the goodbye completes the
+// deferred Apply proceeds and starts the sender.
+//
+// This is the structural #2272 proof: even though the goodbye runs WITHOUT m.mu,
+// the interface stays "busy" (tombstone present) so the check-and-act atomicity
+// extends across the whole WithdrawOnce operation, not just the install instant.
+func TestWithdrawOnceHoldsTombstoneDuringGoodbye(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+	m := New()
+
+	// Gate the WithdrawOnce goodbye conn's first (lifetime-0) write so we can
+	// hold the emit open. WithdrawOnce opens its conn via sendOneGoodbye and
+	// writes only lifetime-0 RAs, so gate on lifetime==0.
+	gateReached := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	fl.preHook("lo", func(lifetime time.Duration) {
+		if lifetime == 0 {
+			once.Do(func() { close(gateReached); <-release })
+		}
+	})
+
+	woDone := make(chan struct{})
+	go func() {
+		m.WithdrawOnce([]*config.RAInterfaceConfig{testCfg("lo")})
+		close(woDone)
+	}()
+
+	select {
+	case <-gateReached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WithdrawOnce goodbye never reached its write gate")
+	}
+
+	// A concurrent Apply for "lo" must DEFER (the held tombstone makes the
+	// interface busy) — no live sender, <=1 live conn — for the whole emit.
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}) }()
+	for i := 0; i < 40; i++ {
+		m.mu.Lock()
+		_, live := m.senders["lo"]
+		m.mu.Unlock()
+		if live {
+			t.Fatal("Apply started a live sender DURING the WithdrawOnce goodbye " +
+				"(tombstone did not block it) — #2272 check-and-act race")
+		}
+		if lc := fl.liveCount(); lc > 1 {
+			t.Fatalf(">1 live conn during the WithdrawOnce goodbye (%d) — #2272", lc)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Release the goodbye; WithdrawOnce finishes (removes the tombstone); the
+	// deferred Apply then proceeds and starts a live sender.
+	close(release)
+	select {
+	case <-woDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WithdrawOnce did not complete after the goodbye released")
+	}
+	select {
+	case <-applyDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("deferred Apply did not complete after the emit released")
+	}
+
+	m.mu.Lock()
+	_, live := m.senders["lo"]
+	m.mu.Unlock()
+	if !live {
+		t.Fatal("deferred Apply did not start a live sender after the goodbye")
+	}
+	// Exactly one goodbye event (one conn carried the lifetime-0 writes).
+	total, gconns := fl.goodbyeStats("lo")
+	if gconns != 1 || total != goodbyeCount {
+		t.Fatalf("expected exactly one goodbye (1 conn, %d writes); got %d/%d",
+			goodbyeCount, gconns, total)
+	}
+	_ = m.Clear()
+}
+
 func TestRound5_ClearDuringRestartDecisionNoReplacement(t *testing.T) {
 	if _, err := net.InterfaceByName("lo"); err != nil {
 		t.Skip("lo interface unavailable")


### PR DESCRIPTION
## Summary

Two `pkg/ra` (embedded RA sender) fixes, one PR per the issues sharing the package:

- **#2271 (LOW, real bug):** `buildRA` built each `PrefixInformation` without enforcing RFC 4861 §4.6.2 (`preferred-lifetime <= valid-lifetime`). A misconfigured pair (operator types preferred > valid, or valid=0 defaults to the 30-day SLAAC valid life while preferred is a large explicit value) advertised a malformed option that conforming hosts (RFC 4862 §5.5.3) ignore — silently dropping SLAAC on every host. Fix: clamp the preferred lifetime **down** to the valid lifetime after the existing zero-to-default normalization (never the reverse — extending validity would advertise a longer-lived prefix than configured).
- **#2272 (MEDIUM):** `WithdrawOnce`'s busy-check and tombstone install must be atomic under `m.mu` so a concurrent `Apply()`/`WithdrawOnce` cannot start a competing sender between the check and the claim (two owners on one link, or a sender racing the lifetime-0 goodbye — the #2033 blackhole class). The #2033 claim-and-hold tombstone work **already** holds the lock across both steps, so the described race is structurally closed today; this PR locks that in by extracting the atomic step into `claimWithdrawOnceLocked` (with a contract comment naming the race) so it cannot silently regress to the pre-#2033 check-then-act shape, and adds the missing `-race` regression. The tombstone stays HELD across the lockless goodbye emit, so `interfaceBusy` reports the interface busy for the whole operation and the single-owner-emit invariant (no normal RA after the goodbye) is preserved.

## Single-owner-emit invariant (#2033)

Both changes preserve it. The #2271 clamp only touches `buildRA` field values. The #2272 change keeps `WithdrawOnce` goodbye-only via `sendOneGoodbye` (no `run()` loop, so no normal RA ever follows the goodbye) and keeps the tombstone held across the emit.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/ra/...`
- [x] `go test ./pkg/ra/`
- [x] `go test -race ./pkg/ra/`
- [x] `go test -race -count=5 ./pkg/ra/` — no flake
- [x] **#2271** `TestBuildRA_PrefLifeClampedToValidLife` — lifetime matrix (ordered / inverted / equal / both-zero / default-mixes / infinite endpoints); asserts advertised values **and** the §4.6.2 ordering invariant. Fail-on-revert verified (removing the clamp fails 4 cases).
- [x] **#2272** `TestWithdrawOnceVsApplySingleOwner` — concurrent Apply/WithdrawOnce/Withdraw on one interface under `-race`; peak live-conn count <= 1 + no normal RA after a goodbye per conn.
- [x] **#2272** `TestWithdrawOnceHoldsTombstoneDuringGoodbye` — deterministic: a concurrent Apply defers (no live sender, <= 1 conn) for the whole goodbye window, then proceeds.

### Revert-proof (#2272)
Temporarily restoring `WithdrawOnce` to the pre-#2033 check-then-act shape (lock → check → **unlock** → start a REAL sender → send goodbye) made **both** `-race` tests fail across 3 runs:
```
peak live conns = 2, want <=1 — WithdrawOnce raced a competing sender (#2272)
conn 3: normal RA (lifetime=30m0s, seq=2) emitted AFTER the first goodbye (seq=1) — single-owner-emit invariant broken
Apply started a live sender DURING the WithdrawOnce goodbye (tombstone did not block it) — #2272
```

## Note on validation lanes

RA withdraw fires on HA failover, so the cluster lane is `make test-failover`. Per the task brief, **the PARENT will run `test-failover` before merge** — it was not run here. This PR is **not merged**.

## Refs

Closes #2271, closes #2272. Single-owner-emit context: #2033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)