### PR TITLE
ipsec: fail closed on a broken ike-policy chain (#2270)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9477,3 +9477,40 @@ top.
   build+vet+test green, new test 5x no flake.
   **File(s)**: pkg/routing/rules.go, pkg/routing/rules_test.go,
   pkg/routing/README.md, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2270 — fail closed when an IKE (Phase 1) policy chain cannot
+  resolve, instead of silently emitting a proposal-less swanctl connection
+  that strongSwan negotiates with its compiled-in default crypto set (a
+  silent downgrade). resolveIKESettings (pkg/ipsec/ike.go) now distinguishes
+  the intentional no-policy case (gateway with no ike-policy → empty
+  proposal, nil error) from a broken chain (gateway names an ike-policy that
+  is undefined, or whose `proposals` ref dangles, and the legacy direct-
+  proposal fallback also misses) → returns the errIKEChainUnresolved
+  sentinel. renderConfig (policy.go) resolves IKE settings BEFORE writing
+  the connection block and SKIPS the VPN on that sentinel (mirroring the
+  #2074 render belt — one bad reference never zeroes a healthy tunnel; the
+  secrets block already excludes skipped VPNs). Added the commit-time strict
+  validator validateIKEPolicyChainReferencesStrict (compiler_validate_strict
+  .go), wired into compileExpanded right after the #2074 gateway gate;
+  strict on commit/commit-check, lenient (warn, no-brick) on the tolerant
+  load / peer-sync paths via lenientIKEPolicyChainRef (set in
+  CompileConfigLenient + CompileConfigForNodeLenient). Only gateways
+  referenced by a VPN are validated (orphans never render; matches Junos).
+  Tests: config-side reject (dangling policy / dangling proposal), accept
+  (resolvable chain / no-policy / legacy direct-proposal / orphan gateway),
+  lenient downgrade (standalone + node-aware), and a load-bearing fail-on-
+  revert (unwiring the validator makes the dangling tests fail — verified by
+  neutering the call site). ipsec-side: resolveIKESettings sentinel/no-policy
+  behavior + renderConfig skips broken chain while healthy tunnel + no-policy
+  tunnel survive. Mirrors the #2073 ESP fail-closed family. Three pre-
+  existing tests (TestIPsecGatewaySetSyntax, TestGenerateConfig_AggressiveMode
+  /_NotSet, TestGenerateConfig_DynamicHostname) carried latent dangling IKE
+  chains and were made self-consistent (define the referenced ike-policy +
+  proposal) — they assert flags orthogonal to the chain. build+vet green,
+  new tests 5x no flake.
+  **File(s)**: pkg/ipsec/ike.go, pkg/ipsec/policy.go, pkg/ipsec/README.md,
+  pkg/ipsec/ike_chain_failclosed_test.go, pkg/ipsec/ipsec_test.go,
+  pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
+  pkg/config/ike_policy_chain_ref_test.go, pkg/config/parser_security_test.go,
+  _Log.md

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -171,6 +171,22 @@ type compileOpts struct {
 	// lenientPolicyMatchAddress.
 	lenientIPsecGatewayRefs bool
 
+	// lenientIKEPolicyChainRef (#2270) downgrades the IKE (Phase 1)
+	// gateway -> ike-policy -> ike-proposal cross-reference check from a
+	// hard error to a warning on the tolerant load / peer-sync paths
+	// (CompileConfigLenient / CompileConfigForNodeLenient). A dangling
+	// ike-policy reference (the policy is undefined, or its `proposals`
+	// reference dangles) made resolveIKESettings return an empty proposal,
+	// which renderConfig omitted entirely — strongSwan then negotiated
+	// phase-1 with its compiled-in default set (a silent crypto downgrade).
+	// Commit / commit-check hard-reject it so a new operator edit fails
+	// loudly, but an already-persisted or peer-synced config carrying this
+	// latent misconfiguration must still boot (the render-path safety net in
+	// pkg/ipsec resolveIKESettings -> renderConfig skips the unrenderable VPN
+	// rather than negotiating with defaults). Same doctrine as
+	// lenientIPsecPolicyProposalRef.
+	lenientIKEPolicyChainRef bool
+
 	// lenientLogProfileStreamRef (#2008 H7) downgrades the
 	// `security log profile <name> stream-name <stream>` cross-reference
 	// from a hard error to a warning on the tolerant load / peer-sync
@@ -377,6 +393,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientEventAttributesMatch:        true,
 		lenientIPsecPolicyProposalRef:      true,
 		lenientIPsecGatewayRefs:            true,
+		lenientIKEPolicyChainRef:           true,
 		lenientLogProfileStreamRef:         true,
 		lenientNATPoolAlarmThreshold:       true,
 		lenientNATHostMask:                 true,
@@ -469,6 +486,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientEventAttributesMatch:        true,
 		lenientIPsecPolicyProposalRef:      true,
 		lenientIPsecGatewayRefs:            true,
+		lenientIKEPolicyChainRef:           true,
 		lenientLogProfileStreamRef:         true,
 		lenientNATPoolAlarmThreshold:       true,
 		lenientNATHostMask:                 true,
@@ -949,6 +967,29 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientIPsecGatewayRefs {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("ipsec gateway reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2270 IKE (Phase 1) gateway -> ike-policy -> ike-proposal cross-
+	// reference. A gateway that names an ike-policy whose chain does not
+	// resolve (the policy is undefined, or its `proposals` reference
+	// dangles) made resolveIKESettings return an empty proposal, which
+	// renderConfig omitted — strongSwan then negotiated phase-1 with its
+	// compiled-in default set instead of the configured crypto (a silent
+	// downgrade). Strict on commit / commit-check (hard reject so the
+	// operator gets a diagnostic); lenient on load / peer-sync (warn so a
+	// pre-fix or peer-synced config still boots — #1960 fail-closed-on-load
+	// class; the render belt in pkg/ipsec skips the unrenderable VPN rather
+	// than negotiating with defaults). Runs on the fully-compiled *Config so
+	// both ike{} and ipsec{} gateway/policy/proposal definitions are present
+	// regardless of stanza authoring order. Mirrors
+	// validateIPsecPolicyProposalReferencesStrict (its Phase-2 sibling).
+	if err := validateIKEPolicyChainReferencesStrict(cfg); err != nil {
+		if opts.lenientIKEPolicyChainRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("ike-policy chain reference (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -182,6 +182,128 @@ func validateIPsecPolicyProposalReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// validateIKEPolicyChainReferencesStrict hard-rejects an IKE (Phase 1)
+// reference chain that cannot resolve to a real proposal (#2270). A
+// gateway names an `ike-policy`; that policy names a `proposals` (an
+// `ike-proposal`). resolveIKESettings (pkg/ipsec/ike.go) walks
+// gateway -> ike-policy -> ike-proposal. When that chain breaks — the
+// ike-policy is undefined, or the policy's `proposals` reference dangles —
+// resolveIKESettings used to return an empty proposal string with a nil
+// error, and renderConfig (which guards the line with `if ikeProposals !=
+// ""`) emitted the connection block with NO `proposals =` line. strongSwan
+// then negotiates phase-1 with its compiled-in default proposal set instead
+// of the configured/required crypto — a silent security-posture downgrade,
+// the same class validateIPsecPolicyProposalReferencesStrict closes for the
+// Phase-2 (ESP) chain.
+//
+// What is accepted (mirror resolveIKESettings exactly so commit and render
+// agree on what resolves):
+//   - a gateway with no `ike-policy` at all: the intentional no-policy
+//     case — strongSwan's default set is the operator's explicit choice,
+//     nothing dangles.
+//   - gateway -> defined ike-policy -> defined ike-proposal.
+//   - the legacy direct-proposal fallback: a gateway whose `ike-policy`
+//     value is itself the NAME of a defined IPsec (Phase 2) proposal, which
+//     resolveIKESettings renders via buildIKEProposal when the ike-policy
+//     chain is absent. Accepted so a config that genuinely renders a
+//     non-empty proposal is never rejected.
+//
+// Rejected:
+//   - a gateway whose `ike-policy` names no defined ike-policy AND is not a
+//     defined IPsec-proposal name (a typo / dangling reference).
+//   - a gateway whose `ike-policy` resolves to a defined ike-policy but
+//     that policy's `proposals` reference names no defined ike-proposal,
+//     and the ike-policy value is not also a defined IPsec-proposal name.
+//
+// Only gateways actually referenced by a VPN are validated: an orphan
+// gateway never reaches render, so an unreferenced dangling chain is inert
+// (and Junos likewise only faults a gateway in use). Gateways are iterated
+// via the sorted VPN list so the first-reported error is deterministic.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientIKEPolicyChainRef) so an already-persisted or
+// peer-synced config carrying a dangling reference still BOOTS (#1960
+// fail-closed-on-load class); the render-path safety net in pkg/ipsec
+// (resolveIKESettings -> errIKEChainUnresolved -> renderConfig skips the
+// VPN) keeps the bad tunnel out of the generated config rather than letting
+// it negotiate with defaults. Commit / commit-check stay strict. Mirrors
+// validateIPsecPolicyProposalReferencesStrict.
+func validateIKEPolicyChainReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	ipsec := &cfg.Security.IPsec
+	if len(ipsec.VPNs) == 0 {
+		return nil
+	}
+	gateways := ipsec.Gateways
+	ikePolicies := ipsec.IKEPolicies
+	ikeProposals := ipsec.IKEProposals
+	espProposals := ipsec.Proposals
+
+	// chainResolves mirrors resolveIKESettings' acceptance: the
+	// ike-policy -> ike-proposal chain, OR the legacy direct-proposal
+	// fallback (the ike-policy value is itself a defined Phase-2 proposal
+	// name).
+	chainResolves := func(ikePolicyName string) bool {
+		if pol, ok := ikePolicies[ikePolicyName]; ok && pol != nil {
+			if _, ok := ikeProposals[pol.Proposals]; ok {
+				return true
+			}
+		}
+		// Legacy fallback: a gateway's ike-policy value naming an IPsec
+		// proposal directly. resolveIKESettings only consults this when the
+		// ike-policy chain is absent, so checking it unconditionally here is
+		// a superset that never wrongly rejects a renderable config.
+		if _, ok := espProposals[ikePolicyName]; ok {
+			return true
+		}
+		return false
+	}
+
+	// VPNs is a map (unordered); sort keys so the first-error commit-check
+	// message is deterministic across runs.
+	vpnNames := make([]string, 0, len(ipsec.VPNs))
+	for name := range ipsec.VPNs {
+		vpnNames = append(vpnNames, name)
+	}
+	sort.Strings(vpnNames)
+	for _, vpnName := range vpnNames {
+		vpn := ipsec.VPNs[vpnName]
+		if vpn == nil || vpn.Gateway == "" {
+			continue
+		}
+		gw, ok := gateways[vpn.Gateway]
+		if !ok || gw == nil {
+			// An undefined / inline gateway is the domain of
+			// validateIPsecGatewayReferencesStrict (#2074); there is no
+			// ike-policy chain to validate here.
+			continue
+		}
+		if gw.IKEPolicy == "" {
+			// Intentional no-policy case (strongSwan defaults chosen).
+			continue
+		}
+		if chainResolves(gw.IKEPolicy) {
+			continue
+		}
+		if _, polDefined := ikePolicies[gw.IKEPolicy]; !polDefined {
+			return fmt.Errorf("security ike gateway %q (used by ipsec vpn %q) "+
+				"references undefined ike-policy %q; phase-1 would silently "+
+				"negotiate with the strongSwan default proposal set instead "+
+				"of the configured crypto",
+				gw.Name, vpnName, gw.IKEPolicy)
+		}
+		pol := ikePolicies[gw.IKEPolicy]
+		return fmt.Errorf("ike-policy %q (via gateway %q, ipsec vpn %q) "+
+			"references undefined ike-proposal %q; phase-1 would silently "+
+			"negotiate with the strongSwan default proposal set instead of "+
+			"the configured crypto",
+			gw.IKEPolicy, gw.Name, vpnName, pol.Proposals)
+	}
+	return nil
+}
+
 // validateLogProfileStreamReferencesStrict hard-rejects a
 // `security log profile <name>` whose `stream-name` reference does not
 // resolve to a configured `security log stream` (#2008 H7). xpf routes

--- a/pkg/config/ike_policy_chain_ref_test.go
+++ b/pkg/config/ike_policy_chain_ref_test.go
@@ -1,0 +1,205 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2270: a gateway naming an ike-policy whose chain cannot resolve made
+// resolveIKESettings return an empty proposal, which renderConfig omitted —
+// strongSwan then negotiated phase-1 with its compiled-in default set
+// instead of the configured crypto (a silent downgrade). The commit-time
+// validator validateIKEPolicyChainReferencesStrict hard-rejects the
+// dangling reference; the tolerant load / peer-sync paths downgrade it to a
+// warning so a previously-committed config still boots.
+
+// (a) commit with a gateway referencing an undefined ike-policy must be
+// hard-rejected.
+func TestIKEGatewayDanglingPolicyRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security ike gateway gw1 address 192.0.2.1",
+		"set security ike gateway gw1 ike-policy does-not-exist",
+		"set security ipsec vpn tun1 ike gateway gw1",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a gateway with an undefined ike-policy; expected rejection")
+	}
+	for _, want := range []string{"gw1", "does-not-exist", "default"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// (b) an ike-policy whose `proposals` reference names no defined
+// ike-proposal must be hard-rejected.
+func TestIKEPolicyDanglingProposalRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security ike gateway gw1 address 192.0.2.1",
+		"set security ike gateway gw1 ike-policy ike-pol",
+		"set security ike policy ike-pol mode main",
+		"set security ike policy ike-pol proposals no-such-proposal",
+		"set security ipsec vpn tun1 ike gateway gw1",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted an ike-policy with a dangling proposal reference; expected rejection")
+	}
+	for _, want := range []string{"ike-pol", "no-such-proposal"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// (c) a fully resolvable chain compiles cleanly and the IKE proposal object
+// is present so the renderer emits a non-empty `proposals =` line.
+func TestIKEPolicyResolvableChainAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security ike proposal ike-aes256 authentication-method pre-shared-keys",
+		"set security ike proposal ike-aes256 encryption-algorithm aes-256-cbc",
+		"set security ike proposal ike-aes256 authentication-algorithm sha-256",
+		"set security ike proposal ike-aes256 dh-group group14",
+		"set security ike policy ike-pol mode main",
+		"set security ike policy ike-pol proposals ike-aes256",
+		"set security ike gateway gw1 address 192.0.2.1",
+		"set security ike gateway gw1 ike-policy ike-pol",
+		"set security ipsec vpn tun1 ike gateway gw1",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig rejected a fully resolvable IKE chain: %v", err)
+	}
+	pol := cfg.Security.IPsec.IKEPolicies["ike-pol"]
+	if pol == nil || pol.Proposals != "ike-aes256" {
+		t.Fatalf("ike-policy ike-pol not compiled with proposals=ike-aes256: %+v", pol)
+	}
+	if _, ok := cfg.Security.IPsec.IKEProposals["ike-aes256"]; !ok {
+		t.Fatal("ike-proposal ike-aes256 not compiled")
+	}
+}
+
+// (d) a gateway with no ike-policy at all is the intentional no-policy case
+// (strongSwan defaults are the operator's choice) — it must compile cleanly.
+func TestIKEGatewayNoPolicyAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security ike gateway gw1 address 192.0.2.1",
+		"set security ipsec vpn tun1 ike gateway gw1",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a gateway with no ike-policy: %v", err)
+	}
+}
+
+// The legacy direct-proposal fallback: a gateway whose ike-policy value is
+// itself the NAME of a defined IPsec (Phase 2) proposal renders a non-empty
+// proposal via buildIKEProposal, so it must NOT be rejected.
+func TestIKEGatewayLegacyDirectProposalAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security ipsec proposal direct-prop protocol esp",
+		"set security ipsec proposal direct-prop encryption-algorithm aes-256-cbc",
+		"set security ipsec proposal direct-prop authentication-algorithm hmac-sha-256-128",
+		"set security ike gateway gw1 address 192.0.2.1",
+		"set security ike gateway gw1 ike-policy direct-prop",
+		"set security ipsec vpn tun1 ike gateway gw1",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected the legacy direct-proposal ike-policy fallback: %v", err)
+	}
+}
+
+// An orphan gateway (defined but not referenced by any VPN) with a dangling
+// ike-policy never reaches render, so it must not fault — Junos only faults
+// a gateway in use.
+func TestIKEOrphanGatewayDanglingPolicyAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		// Healthy referenced tunnel.
+		"set security ike proposal ike-aes256 authentication-method pre-shared-keys",
+		"set security ike proposal ike-aes256 encryption-algorithm aes-256-cbc",
+		"set security ike policy ike-pol proposals ike-aes256",
+		"set security ike gateway gw-good address 192.0.2.1",
+		"set security ike gateway gw-good ike-policy ike-pol",
+		"set security ipsec vpn tun1 ike gateway gw-good",
+		// Orphan gateway with a dangling policy, referenced by nothing.
+		"set security ike gateway gw-orphan address 192.0.2.2",
+		"set security ike gateway gw-orphan ike-policy nonexistent",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig faulted an unreferenced orphan gateway with a dangling ike-policy: %v", err)
+	}
+}
+
+// Fail-on-revert: a counter-factual that reconstructs the PRE-fix acceptance
+// (validator absent) and proves the dangling-ike-policy config WOULD have
+// compiled clean. If validateIKEPolicyChainReferencesStrict is ever removed
+// from the strict chain, TestIKEGatewayDanglingPolicyRejected starts passing
+// without an error — this test documents that the validator is the only thing
+// standing between a dangling reference and a silent crypto downgrade.
+func TestIKEPolicyChainValidatorIsLoadBearing(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security ike gateway gw1 address 192.0.2.1",
+		"set security ike gateway gw1 ike-policy does-not-exist",
+		"set security ipsec vpn tun1 ike gateway gw1",
+	})
+	// The compiled config (skipping the strict gate) carries the dangling
+	// reference. Confirm the gate is what rejects it: without the validator,
+	// the gateway resolves but its ike-policy chain does not — the exact
+	// fall-through resolveIKESettings used to render as an empty proposal.
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must accept the dangling ref (warn): %v", err)
+	}
+	gw := cfg.Security.IPsec.Gateways["gw1"]
+	if gw == nil || gw.IKEPolicy != "does-not-exist" {
+		t.Fatalf("expected gateway gw1 carrying the dangling ike-policy reference, got %+v", gw)
+	}
+	if _, ok := cfg.Security.IPsec.IKEPolicies["does-not-exist"]; ok {
+		t.Fatal("test premise broken: ike-policy does-not-exist must NOT be defined")
+	}
+	// And the strict path MUST reject the same tree.
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("strict CompileConfig accepted the dangling ike-policy; the validator is not wired")
+	}
+}
+
+// The tolerant load / peer-sync paths (CompileConfigLenient and
+// CompileConfigForNodeLenient) downgrade the dangling-reference error to a
+// warning so an already-persisted or peer-synced config still boots (#1960
+// no-brick).
+func TestIKEPolicyChainDanglingLenientDowngrade(t *testing.T) {
+	cmds := []string{
+		"set security ike gateway gw1 address 192.0.2.1",
+		"set security ike gateway gw1 ike-policy does-not-exist",
+		"set security ipsec vpn tun1 ike gateway gw1",
+	}
+
+	hasIKEWarning := func(cfg *Config) bool {
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "ike-policy chain reference") {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("standalone", func(t *testing.T) {
+		cfg, err := CompileConfigLenient(buildTreeFromSet(t, cmds))
+		if err != nil {
+			t.Fatalf("CompileConfigLenient hard-failed a dangling ike-policy ref; must downgrade to warning: %v", err)
+		}
+		if !hasIKEWarning(cfg) {
+			t.Errorf("expected an ike-policy chain reference warning, got %v", cfg.Warnings)
+		}
+	})
+
+	t.Run("node-aware", func(t *testing.T) {
+		cfg, err := CompileConfigForNodeLenient(buildTreeFromSet(t, cmds), 0)
+		if err != nil {
+			t.Fatalf("CompileConfigForNodeLenient hard-failed a dangling ike-policy ref; must downgrade to warning (HA peer-sync): %v", err)
+		}
+		if !hasIKEWarning(cfg) {
+			t.Errorf("expected an ike-policy chain reference warning, got %v", cfg.Warnings)
+		}
+	})
+}

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1636,7 +1636,10 @@ func TestIPsecGateway(t *testing.T) {
 }
 
 func TestIPsecGatewaySetSyntax(t *testing.T) {
-	setCommands := []string{`set security ipsec gateway remote-gw address 203.0.113.1`, `set security ipsec gateway remote-gw local-address 198.51.100.1`, `set security ipsec gateway remote-gw ike-policy ike-strong`, `set security ipsec gateway remote-gw external-interface untrust0`, `set security ipsec vpn site-a gateway remote-gw`, `set security ipsec vpn site-a bind-interface st0.0`}
+	// Define the referenced ike-policy + proposal so the gateway's
+	// ike-policy chain resolves (#2270 commit-time gate); the assertions
+	// below only exercise the parser's gateway-field storage.
+	setCommands := []string{`set security ike proposal ike-prop authentication-method pre-shared-keys`, `set security ike proposal ike-prop encryption-algorithm aes-256-cbc`, `set security ike policy ike-strong proposals ike-prop`, `set security ipsec gateway remote-gw address 203.0.113.1`, `set security ipsec gateway remote-gw local-address 198.51.100.1`, `set security ipsec gateway remote-gw ike-policy ike-strong`, `set security ipsec gateway remote-gw external-interface untrust0`, `set security ipsec vpn site-a gateway remote-gw`, `set security ipsec vpn site-a bind-interface st0.0`}
 	tree := &ConfigTree{}
 	for _, cmd := range setCommands {
 		path, err := ParseSetCommand(cmd)

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -120,6 +120,43 @@ all files stay in `package ipsec`, so the public API is unchanged.
     gateway — `set security ike gateway <name> address <ip>` (or
     `dynamic hostname <fqdn>`). The shared accept predicate is
     `config.IsUsableIPsecEndpoint`.
+- **IKE policy chain → proposal cross-reference (#2270).** A gateway's
+  `ike-policy` reference walks gateway → `ike-policy` → `ike-proposal`
+  (`resolveIKESettings`, `ike.go`). When that chain breaks — the
+  `ike-policy` is undefined, or its `proposals` reference dangles —
+  `resolveIKESettings` previously returned an EMPTY proposal string with a
+  nil error, and `renderConfig` (which guards the line with
+  `if ikeProposals != ""`) emitted the connection block with NO
+  `proposals =` line. strongSwan then negotiated phase-1 with its
+  compiled-in default proposal set instead of the configured/required
+  crypto — a silent security-posture downgrade, the Phase-1 analogue of the
+  #2073 ESP gap.
+  - **Fail-closed resolution** (`resolveIKESettings`): the intentional
+    no-policy case (gateway with no `ike-policy`) still returns an empty
+    proposal with a nil error (strongSwan's default set is the operator's
+    explicit choice). A gateway that DOES name an `ike-policy` whose chain
+    cannot resolve now returns the `errIKEChainUnresolved` sentinel instead
+    of an empty proposal. The legacy direct-proposal fallback (an
+    `ike-policy` value that is itself the name of a defined Phase-2
+    proposal, rendered via `buildIKEProposal`) is still accepted.
+  - **Commit-time rejection** (`validateIKEPolicyChainReferencesStrict`,
+    `pkg/config/compiler_validate_strict.go`, run from the strict-validator
+    chain in `compileExpanded`): a VPN whose gateway names an undefined
+    `ike-policy`, or an `ike-policy` whose `proposals` reference dangles,
+    fails `commit` / `commit check`. Only gateways actually referenced by a
+    VPN are validated (an orphan never reaches render, matching Junos). On
+    the tolerant load / peer-sync paths the same check is downgraded to a
+    warning (`lenientIKEPolicyChainRef`) so a config persisted by an older
+    binary or synced from a peer still boots (#1960 no-brick).
+  - **Render belt** (`renderConfig`, `policy.go`): for any path that
+    reaches render without passing local commit (HA sync / direct
+    construction / pre-fix persisted config), a VPN whose IKE chain does
+    not resolve is SKIPPED (logged via `slog.Warn`) — its connection and
+    secret are omitted — rather than emitting a proposal-less connection.
+    Healthy VPNs always render, so one bad reference never zeroes a healthy
+    tunnel. A non-chain resolve error (e.g. an unknown auth-method token
+    from `authMethodToSwan`) is a different class and still aborts the
+    whole render.
 - **AES-GCM IKE PRF + ICV-suffix canonicalization (#2125).** The
   load-bearing fix: a strongSwan IKEv2 AEAD (AES-GCM) proposal MUST
   name a PRF explicitly — an AEAD cipher carries no integrity algorithm

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -3,6 +3,7 @@ package ipsec
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -20,9 +21,31 @@ type dpdSettings struct {
 	Action  string
 }
 
+// errIKEChainUnresolved signals that a gateway names an IKE policy whose
+// reference chain cannot be resolved (the policy is undefined, or the
+// policy's `proposals` reference dangles, AND the legacy direct-proposal
+// fallback also misses). Returning this instead of an empty proposal with
+// a nil error is the fail-closed core of #2270: an empty proposal makes
+// renderConfig omit the `proposals =` line, which silently hands phase-1
+// negotiation to strongSwan's compiled-in default set (a crypto downgrade).
+// renderConfig recognises this sentinel and SKIPS the offending VPN (one
+// bad reference never zeroes a healthy tunnel); the commit-time validator
+// validateIKEPolicyChainReferencesStrict (pkg/config) hard-rejects the
+// dangling reference up front so a new operator edit fails loudly.
+var errIKEChainUnresolved = errors.New(
+	"ike gateway names an ike-policy whose proposal chain does not resolve")
+
 // resolveIKESettings resolves the IKE (Phase 1) auth method, proposal
 // string, lifetime, and aggressive-mode flag from the gateway's IKE policy
 // chain.
+//
+// It distinguishes two superficially similar empty-proposal cases:
+//   - gw is nil or names no ike-policy: the intentional no-policy case —
+//     return an empty proposal with a nil error (strongSwan's default set
+//     is the operator's choice).
+//   - gw names an ike-policy but the chain cannot resolve: return
+//     errIKEChainUnresolved so the caller never silently emits a
+//     proposal-less connection (#2270).
 func resolveIKESettings(cfg *config.IPsecConfig, gw *config.IPsecGateway) (authMethod, proposals string, lifetime int, aggressive bool, err error) {
 	authMethod = "psk"
 	if gw == nil || gw.IKEPolicy == "" {
@@ -46,7 +69,10 @@ func resolveIKESettings(cfg *config.IPsecConfig, gw *config.IPsecGateway) (authM
 		}
 	}
 
-	return authMethod, "", 0, aggressive, nil
+	// gw.IKEPolicy is set but neither the ike-policy -> ike-proposal chain
+	// nor the legacy direct-proposal fallback resolves. Fail closed: do NOT
+	// return an empty proposal with a nil error (#2270).
+	return "", "", 0, aggressive, fmt.Errorf("%w: ike-policy %q", errIKEChainUnresolved, gw.IKEPolicy)
 }
 
 // resolveESPSettings resolves the ESP (Phase 2) proposal string and lifetime

--- a/pkg/ipsec/ike_chain_failclosed_test.go
+++ b/pkg/ipsec/ike_chain_failclosed_test.go
@@ -1,0 +1,166 @@
+package ipsec
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2270 render-side fail-closed coverage. resolveIKESettings must
+// distinguish the intentional no-policy case (empty proposal, nil error)
+// from a broken ike-policy chain (errIKEChainUnresolved), so renderConfig
+// never silently emits a proposal-less connection that strongSwan would
+// negotiate with its compiled-in defaults.
+
+// resolveIKESettings returns a nil error and an empty proposal for the
+// intentional no-policy case.
+func TestResolveIKESettings_NoPolicyOK(t *testing.T) {
+	cfg := &config.IPsecConfig{}
+	gw := &config.IPsecGateway{Name: "gw1", Address: "192.0.2.1"}
+	_, prop, _, _, err := resolveIKESettings(cfg, gw)
+	if err != nil {
+		t.Fatalf("no-policy gateway must not error: %v", err)
+	}
+	if prop != "" {
+		t.Errorf("no-policy gateway proposal = %q, want empty (strongSwan default chosen)", prop)
+	}
+}
+
+// resolveIKESettings returns errIKEChainUnresolved when the gateway names
+// an undefined ike-policy.
+func TestResolveIKESettings_DanglingPolicyFailsClosed(t *testing.T) {
+	cfg := &config.IPsecConfig{}
+	gw := &config.IPsecGateway{Name: "gw1", Address: "192.0.2.1", IKEPolicy: "does-not-exist"}
+	_, prop, _, _, err := resolveIKESettings(cfg, gw)
+	if err == nil {
+		t.Fatal("dangling ike-policy must fail closed, got nil error")
+	}
+	if !errors.Is(err, errIKEChainUnresolved) {
+		t.Errorf("error = %v, want errIKEChainUnresolved", err)
+	}
+	if prop != "" {
+		t.Errorf("broken chain proposal = %q, want empty", prop)
+	}
+}
+
+// resolveIKESettings returns errIKEChainUnresolved when the ike-policy
+// resolves but its `proposals` reference dangles.
+func TestResolveIKESettings_DanglingProposalFailsClosed(t *testing.T) {
+	cfg := &config.IPsecConfig{
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"ike-pol": {Name: "ike-pol", Proposals: "no-such-proposal"},
+		},
+	}
+	gw := &config.IPsecGateway{Name: "gw1", Address: "192.0.2.1", IKEPolicy: "ike-pol"}
+	_, _, _, _, err := resolveIKESettings(cfg, gw)
+	if !errors.Is(err, errIKEChainUnresolved) {
+		t.Fatalf("dangling proposal must fail closed with errIKEChainUnresolved, got: %v", err)
+	}
+}
+
+// A fully resolvable chain returns the built proposal with no error.
+func TestResolveIKESettings_ResolvableChain(t *testing.T) {
+	cfg := &config.IPsecConfig{
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"ike-pol": {Name: "ike-pol", Proposals: "ike-prop"},
+		},
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-prop": {
+				Name:          "ike-prop",
+				AuthMethod:    "pre-shared-keys",
+				EncryptionAlg: "aes-256-cbc",
+				AuthAlg:       "sha-256",
+				DHGroup:       14,
+			},
+		},
+	}
+	gw := &config.IPsecGateway{Name: "gw1", Address: "192.0.2.1", IKEPolicy: "ike-pol"}
+	_, prop, _, _, err := resolveIKESettings(cfg, gw)
+	if err != nil {
+		t.Fatalf("resolvable chain errored: %v", err)
+	}
+	if prop == "" {
+		t.Fatal("resolvable chain produced an empty proposal")
+	}
+	if !strings.Contains(prop, "aes256") {
+		t.Errorf("proposal %q missing encryption token", prop)
+	}
+}
+
+// renderConfig SKIPS a VPN whose ike-policy chain is broken (so its
+// connection and secret are omitted) while a healthy tunnel in the same
+// config renders normally with a `proposals =` line. One bad reference
+// never zeroes a healthy tunnel, and a proposal-less connection is never
+// written for the broken one.
+func TestRenderConfig_BrokenChainSkipsVPN_HealthyTunnelSurvives(t *testing.T) {
+	cfg := &config.IPsecConfig{
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"good-pol": {Name: "good-pol", Proposals: "good-prop", PSK: "secret-good"},
+		},
+		IKEProposals: map[string]*config.IKEProposal{
+			"good-prop": {
+				Name:          "good-prop",
+				AuthMethod:    "pre-shared-keys",
+				EncryptionAlg: "aes-256-cbc",
+				AuthAlg:       "sha-256",
+				DHGroup:       14,
+			},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw-good": {Name: "gw-good", Address: "192.0.2.1", IKEPolicy: "good-pol"},
+			"gw-bad":  {Name: "gw-bad", Address: "192.0.2.2", IKEPolicy: "missing-pol"},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun-good": {Name: "tun-good", Gateway: "gw-good"},
+			"tun-bad":  {Name: "tun-bad", Gateway: "gw-bad"},
+		},
+	}
+
+	m := New()
+	out := m.generateConfig(cfg)
+
+	// Healthy tunnel: connection block present, with a non-empty proposals
+	// line carrying the configured crypto.
+	if !strings.Contains(out, "tun-good {") {
+		t.Errorf("healthy tunnel tun-good missing from render:\n%s", out)
+	}
+	if !strings.Contains(out, "proposals = aes256") {
+		t.Errorf("healthy tunnel missing a non-empty proposals line:\n%s", out)
+	}
+
+	// Broken tunnel: connection block must NOT be emitted (no proposal-less
+	// connection that would negotiate with strongSwan defaults).
+	if strings.Contains(out, "tun-bad {") {
+		t.Errorf("broken-chain tunnel tun-bad was rendered; it must be skipped:\n%s", out)
+	}
+	// And its secret must not be orphaned in the secrets block.
+	if strings.Contains(out, "ike-tun-bad {") {
+		t.Errorf("broken-chain tunnel tun-bad secret was emitted; must be skipped:\n%s", out)
+	}
+}
+
+// A no-policy gateway renders a normal connection WITHOUT a proposals line
+// (the intentional default case) and is NOT skipped.
+func TestRenderConfig_NoPolicyGatewayRendersWithoutProposalsLine(t *testing.T) {
+	cfg := &config.IPsecConfig{
+		Gateways: map[string]*config.IPsecGateway{
+			"gw1": {Name: "gw1", Address: "192.0.2.1"},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {Name: "tun1", Gateway: "gw1"},
+		},
+	}
+	m := New()
+	out := m.generateConfig(cfg)
+	if !strings.Contains(out, "tun1 {") {
+		t.Errorf("no-policy tunnel tun1 missing from render:\n%s", out)
+	}
+	// The IKE-level (Phase 1) proposals line is intentionally absent. Guard
+	// against the connection-level "    proposals = " (four-space indent),
+	// distinct from the child "        esp_proposals = " line.
+	if strings.Contains(out, "\n    proposals = ") {
+		t.Errorf("no-policy tunnel must not emit an IKE proposals line:\n%s", out)
+	}
+}

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -552,6 +552,14 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 func TestGenerateConfig_DynamicHostname(t *testing.T) {
 	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
 	cfg := &config.IPsecConfig{
+		// The ike-policy -> ike-proposal chain must resolve, else
+		// renderConfig fail-closed-skips the VPN (#2270).
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"pol1": {Name: "pol1", Proposals: "ike-p1"},
+		},
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-p1": {Name: "ike-p1", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
+		},
 		Gateways: map[string]*config.IPsecGateway{
 			"dyn-gw": {
 				Name:            "dyn-gw",
@@ -707,6 +715,11 @@ func TestGenerateConfig_AggressiveMode(t *testing.T) {
 				PSK:       "secret",
 			},
 		},
+		// The ike-policy -> ike-proposal chain must resolve, else
+		// renderConfig fail-closed-skips the VPN (#2270).
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-p1": {Name: "ike-p1", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
+		},
 		Gateways: map[string]*config.IPsecGateway{
 			"gw": {
 				Name:      "gw",
@@ -734,10 +747,16 @@ func TestGenerateConfig_AggressiveMode_NotSet(t *testing.T) {
 	cfg := &config.IPsecConfig{
 		IKEPolicies: map[string]*config.IKEPolicy{
 			"main-pol": {
-				Name: "main-pol",
-				Mode: "main",
-				PSK:  "secret",
+				Name:      "main-pol",
+				Mode:      "main",
+				Proposals: "ike-p1",
+				PSK:       "secret",
 			},
+		},
+		// The ike-policy -> ike-proposal chain must resolve, else
+		// renderConfig fail-closed-skips the VPN (#2270).
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-p1": {Name: "ike-p1", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
 		},
 		Gateways: map[string]*config.IPsecGateway{
 			"gw": {

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -1,6 +1,7 @@
 package ipsec
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -56,11 +57,34 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 			continue
 		}
 
-		fmt.Fprintf(&b, "  %s {\n", sanitizeSwanctlValue(name))
+		// Resolve the IKE settings BEFORE writing the connection block so a
+		// gateway whose ike-policy chain does not resolve SKIPS this VPN
+		// instead of emitting a proposal-less connection (#2270). An empty
+		// `proposals =` line lets strongSwan fall back to its compiled-in
+		// default phase-1 set — a silent crypto downgrade. The hard
+		// diagnostic for a dangling reference is the commit-time validator
+		// (validateIKEPolicyChainReferencesStrict); this render belt is the
+		// by-construction backstop for any path that reaches render without
+		// passing local commit (HA peer-sync, direct IPsecConfig
+		// construction, a config persisted before the fix). One bad
+		// reference never zeroes a healthy tunnel. A non-chain resolve error
+		// (e.g. an unknown auth-method token from authMethodToSwan) is a
+		// different class and still aborts the whole render.
 		authMethod, ikeProposals, ikeLifetime, aggressive, err := resolveIKESettings(ipsecCfg, gw)
 		if err != nil {
+			if errors.Is(err, errIKEChainUnresolved) {
+				skipped[name] = true
+				slog.Warn("skipping IPsec VPN: ike-policy chain does not "+
+					"resolve — fix the ike-policy / ike-proposal reference "+
+					"(emitting no proposal would silently downgrade phase-1 "+
+					"to strongSwan defaults)",
+					"vpn", name, "ike_policy", gw.IKEPolicy)
+				continue
+			}
 			return "", fmt.Errorf("vpn %s: %w", name, err)
 		}
+
+		fmt.Fprintf(&b, "  %s {\n", sanitizeSwanctlValue(name))
 		espProposals, espLifetime := resolveESPSettings(ipsecCfg, vpn)
 		dpd := deriveDPD(gw, vpn)
 


### PR DESCRIPTION
## Summary

- A gateway that names an `ike-policy` whose chain cannot resolve (policy undefined, or its `proposals` reference dangles) made `resolveIKESettings` return an **empty proposal string with a nil error**. `renderConfig` guards the line with `if ikeProposals != ""`, so it emitted the connection block with **no `proposals =` line** → strongSwan negotiates phase-1 with its compiled-in default proposal set instead of the configured crypto (a silent security-posture downgrade — the Phase-1 analogue of the #2073 ESP gap). Nothing validated the chain at commit.
- **Fail closed on resolution:** `resolveIKESettings` (`pkg/ipsec/ike.go`) now distinguishes the intentional no-policy case (gateway with no `ike-policy` → empty proposal, nil error) from a broken chain → returns the new `errIKEChainUnresolved` sentinel. The legacy direct-proposal fallback stays accepted.
- **Render belt:** `renderConfig` (`policy.go`) resolves IKE settings *before* writing the connection block and **skips** the VPN on the sentinel (its connection + secret omitted, reusing the #2074 `skipped` set) — one bad reference never zeroes a healthy tunnel. A non-chain error (bad auth-method token) still aborts the whole render.
- **Commit-time gate:** `validateIKEPolicyChainReferencesStrict` (`compiler_validate_strict.go`), wired into `compileExpanded` after the #2074 gateway gate. Hard-rejects a VPN whose gateway names an undefined `ike-policy`, or an `ike-policy` whose `proposals` reference dangles. Only gateways referenced by a VPN are validated (orphans never render; matches Junos). Strict on commit/commit-check; **lenient (warn, #1960 no-brick)** on the tolerant load / peer-sync paths via `lenientIKEPolicyChainRef`.
- Mirrors the #2073 / #2074 IPsec fail-closed family exactly (lenient/strict split, render belt, README contract entry).

## Test plan

- [x] `pkg/config`: reject dangling-policy (a) and dangling-proposal (b) at commit; accept a resolvable chain (c), a no-policy gateway (d), the legacy direct-proposal fallback, and an unreferenced orphan gateway; lenient downgrade-to-warning (standalone + node-aware).
- [x] **Fail-on-revert** (`TestIKEPolicyChainValidatorIsLoadBearing` + manual): neutering the validator call site makes the dangling-reject tests fail; restoring makes them pass.
- [x] `pkg/ipsec`: `resolveIKESettings` returns the sentinel for a broken chain and a nil error for the no-policy case; `renderConfig` skips a broken-chain VPN while a healthy tunnel renders with a non-empty `proposals` line and a no-policy tunnel renders without an IKE proposals line.
- [x] `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go build ./...` + `go vet ./pkg/ipsec/... ./pkg/config/...` clean.
- [x] `go test ./pkg/ipsec/... ./pkg/config/...` green; new + affected tests **5x no flake**.
- [x] Downstream `grpcapi` / `api` / `configstore` / `daemon` / `cluster` suites green.
- Live IPsec validation not run in this env (config-compile + render change only; no dataplane/HA path touched).

## Notes

Three pre-existing tests (`TestIPsecGatewaySetSyntax`, `TestGenerateConfig_AggressiveMode`/`_NotSet`, `TestGenerateConfig_DynamicHostname`) carried **latent dangling IKE chains** (they asserted flags orthogonal to the proposal chain). Made self-consistent by defining the referenced `ike-policy` + proposal — they were exercising the exact silent-downgrade this PR closes.

Refs #2270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)