### PR TITLE
#2234: bounded stalest-eviction for screen scan/sweep source table (restore detection under saturation)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9543,3 +9543,31 @@ top.
   pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
   pkg/config/ike_policy_chain_ref_test.go, pkg/config/parser_security_test.go,
   _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2234 — bounded stalest-eviction for the screen scan/sweep
+  per-zone source table (restore detection under saturation). Replaced the
+  hard skip-on-full cliff (`MAX_SOURCES_PER_ZONE = 4096`) with O(K) eviction
+  (K = `EVICT_SCAN_LIMIT` = 64): a brand-new `(zone, src_ip)` at a full zone
+  reclaims any expired window in a fixed sample, else evicts the stalest
+  sampled entry — so a fresh real scanner is always trackable (closes the
+  detection-DoS where a spoofed flood pinned the table and suppressed a real
+  scanner). Per-zone source count maintained incrementally (`per_zone_count`)
+  so the cap test is O(1) — replaces the pre-#2234 O(sources) `sources_in_zone`
+  scan that on the new-source-at-cap path was itself an O(n)-per-packet
+  amplifier. Both trackers unified on a shared `ScanCore<T>` (one source of
+  truth for bound/eviction/clamp/pressure). Added `evicted_pressure` counter +
+  a rare LOGARITHMIC `scan-table-pressure` screen event (powers of two in the
+  eviction count) emitted from the cold session-miss hook — never per-flow.
+  New reason bit `SCREEN_SCAN_TABLE_PRESSURE = 1<<19` (Rust + Go
+  `ScreenFlagNames`, also backfilled the stale 1<<17/1<<18 names). Tests:
+  fail-on-revert (fresh scanner detected after saturation, both scan.rs and
+  ScreenState levels), eviction-prefers-stalest, eviction-prefers-expired,
+  bounded-cost + count-exact under sustained churn, logarithmic pressure-event
+  rate. cargo build/test green (full suite 2255/0 main bin + all targets;
+  new tests 5x no flake); go build/vet clean. SMOKE on loss cluster PENDING.
+  **File(s)**: userspace-dp/src/screen/scan.rs,
+  userspace-dp/src/screen/mod.rs, userspace-dp/src/screen/tests.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/event_emit.rs, pkg/dataplane/types.go,
+  userspace-dp/src/session/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -9571,3 +9571,24 @@ top.
   userspace-dp/src/afxdp/poll_descriptor/mod.rs,
   userspace-dp/src/afxdp/event_emit.rs, pkg/dataplane/types.go,
   userspace-dp/src/session/README.md, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2234 — applied Copilot-review fixes + loss-cluster smoke.
+  Fixes: (1) take_pressure_event uses checked_next_power_of_two().unwrap_or
+  (u64::MAX) — next_power_of_two() panics/wraps past 2^63; (2/3) tightened
+  scan.rs + README wording (eviction scans a FIXED PREFIX of the whole
+  source table, not "the zone's entries", with the documented same-zone
+  fallback); (4) added emit_screen_alarm_event (RT_FLOW action PERMIT) so the
+  scan-table-pressure alarm is NOT counted as a drop/deny downstream — was
+  riding emit_screen_drop_event (action DENY). New fail-on-revert test
+  screen_alarm_event_is_permit_not_deny. SMOKE on loss userspace cluster
+  (deploy verify-dataplane gate PASSED both nodes; fw1 was RG0 primary;
+  scan-protect screen profile with ip-sweep+port-scan threshold attached to
+  lan+wan; CoS re-applied): iperf3 -P12 -t20 uncapped port 5211 —
+  v4-push 22.9 / v4-rev 22.7 / v6-push 22.5 / v6-rev 22.2 Gbit/s. Screen
+  drops: 0 total, Packets dropped: 0 — legit multi-flow traffic NOT spuriously
+  flagged by scan/sweep. cargo screen 123/0.
+  **File(s)**: userspace-dp/src/screen/scan.rs,
+  userspace-dp/src/afxdp/event_emit.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/session/README.md, _Log.md

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -653,27 +653,37 @@ const (
 	ScreenSynCookie       = 1 << 14
 	ScreenSessionLimitSrc = 1 << 15
 	ScreenSessionLimitDst = 1 << 16
+	// Bits 17-19 mirror the userspace-dp screen reason flags added after the
+	// original eBPF parity set: ICMP fragment (#2146 sibling), IP malformed
+	// (#2146 fail-closed parse error), and scan-table pressure (#2234, the
+	// bounded stalest-eviction operator alarm — NOT a packet drop).
+	ScreenICMPFragment      = 1 << 17
+	ScreenIPMalformed       = 1 << 18
+	ScreenScanTablePressure = 1 << 19
 )
 
 // ScreenFlagNames maps screen flag values to human-readable names.
 var ScreenFlagNames = map[uint32]string{
-	ScreenSynFlood:        "SYN flood",
-	ScreenICMPFlood:       "ICMP flood",
-	ScreenUDPFlood:        "UDP flood",
-	ScreenPortScan:        "port scan",
-	ScreenIPSweep:         "IP sweep",
-	ScreenLandAttack:      "LAND attack",
-	ScreenPingOfDeath:     "ping of death",
-	ScreenTearDrop:        "tear drop",
-	ScreenTCPSynFin:       "TCP SYN+FIN",
-	ScreenTCPNoFlag:       "TCP no-flag",
-	ScreenTCPFinNoAck:     "TCP FIN-no-ACK",
-	ScreenWinNuke:         "WinNuke",
-	ScreenIPSourceRoute:   "IP source-route",
-	ScreenSynFrag:         "SYN fragment",
-	ScreenSynCookie:       "SYN cookie",
-	ScreenSessionLimitSrc: "session limit (source)",
-	ScreenSessionLimitDst: "session limit (destination)",
+	ScreenSynFlood:          "SYN flood",
+	ScreenICMPFlood:         "ICMP flood",
+	ScreenUDPFlood:          "UDP flood",
+	ScreenPortScan:          "port scan",
+	ScreenIPSweep:           "IP sweep",
+	ScreenLandAttack:        "LAND attack",
+	ScreenPingOfDeath:       "ping of death",
+	ScreenTearDrop:          "tear drop",
+	ScreenTCPSynFin:         "TCP SYN+FIN",
+	ScreenTCPNoFlag:         "TCP no-flag",
+	ScreenTCPFinNoAck:       "TCP FIN-no-ACK",
+	ScreenWinNuke:           "WinNuke",
+	ScreenIPSourceRoute:     "IP source-route",
+	ScreenSynFrag:           "SYN fragment",
+	ScreenSynCookie:         "SYN cookie",
+	ScreenSessionLimitSrc:   "session limit (source)",
+	ScreenSessionLimitDst:   "session limit (destination)",
+	ScreenICMPFragment:      "ICMP fragment",
+	ScreenIPMalformed:       "IP malformed",
+	ScreenScanTablePressure: "scan-table pressure",
 }
 
 // SessionCountKey mirrors the C struct session_count_key.

--- a/userspace-dp/src/afxdp/event_emit.rs
+++ b/userspace-dp/src/afxdp/event_emit.rs
@@ -33,6 +33,13 @@ const SCREEN_ICMP_FRAGMENT: u32 = 1 << 17;
 /// evaluate the fragment/TCP screens (e.g. a truncated IPv6
 /// extension-header chain) is dropped FAIL-CLOSED under this reason.
 const SCREEN_IP_MALFORMED: u32 = 1 << 18;
+/// #2234: NOT a packet drop — a rare (logarithmic) operator ALARM that the
+/// per-zone scan/sweep source table is saturated and the detector is
+/// displacing stale sources (bounded stalest-eviction) to keep tracking a
+/// fresh real scanner under a high-cardinality spoofed flood. Rides the
+/// screen event path so it surfaces alongside other screen activity; the
+/// triggering 5-tuple is the new source that forced an eviction.
+const SCREEN_SCAN_TABLE_PRESSURE: u32 = 1 << 19;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum FilterLogSource {
@@ -281,6 +288,7 @@ fn screen_reason_id(reason: &'static str) -> u32 {
         "session-limit-dst" => SCREEN_SESSION_LIMIT_DST,
         "icmp-fragment" => SCREEN_ICMP_FRAGMENT,
         "ip-malformed" => SCREEN_IP_MALFORMED,
+        "scan-table-pressure" => SCREEN_SCAN_TABLE_PRESSURE,
         _ => 0,
     }
 }
@@ -480,6 +488,21 @@ mod tests {
         // malformed-frame drop apart from the syn-frag screen.
         assert_eq!(screen_reason_id("ip-malformed"), SCREEN_IP_MALFORMED);
         assert_ne!(SCREEN_IP_MALFORMED, SCREEN_SYN_FRAG);
+    }
+
+    #[test]
+    fn screen_reason_id_maps_scan_table_pressure() {
+        // #2234: the bounded stalest-eviction operator ALARM must map to a
+        // dedicated screen_id bit, distinct from the port-scan / ip-sweep
+        // DROP reasons (it is a saturation signal, not a packet drop), so an
+        // operator can tell "detector is saturated" apart from a real scan
+        // detection.
+        assert_eq!(
+            screen_reason_id("scan-table-pressure"),
+            SCREEN_SCAN_TABLE_PRESSURE
+        );
+        assert_ne!(SCREEN_SCAN_TABLE_PRESSURE, SCREEN_PORT_SCAN);
+        assert_ne!(SCREEN_SCAN_TABLE_PRESSURE, SCREEN_IP_SWEEP);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/event_emit.rs
+++ b/userspace-dp/src/afxdp/event_emit.rs
@@ -153,6 +153,55 @@ pub(super) fn emit_screen_drop_event(
     let _ = event_stream.try_emit_dataplane_event_at(event, now_ns);
 }
 
+/// Emit a screen ALARM event — a `ScreenDrop`-kind event that did NOT drop
+/// the packet (#2234 scan-table-pressure). It shares the screen event frame
+/// so it surfaces alongside other screen activity, but the RT_FLOW action is
+/// PERMIT (the flow forwards), so downstream stats / syslog / dashboards do
+/// NOT count it as a deny/drop. The `reason` maps to a dedicated `screen_id`
+/// bit; the 5-tuple is the source that forced an eviction.
+#[inline]
+pub(super) fn emit_screen_alarm_event(
+    event_stream: Option<&EventStreamWorkerHandle>,
+    pkt: &ScreenPacketInfo,
+    meta: UserspaceDpMeta,
+    ingress_zone_id: u16,
+    reason: &'static str,
+    now_ns: u64,
+) {
+    let Some(event_stream) = event_stream else {
+        return;
+    };
+    let event = DataplaneEventPayload {
+        kind: DataplaneEventKind::ScreenDrop,
+        addr_family: pkt.addr_family,
+        protocol: pkt.protocol,
+        // PERMIT — this is a saturation alarm, not a drop. The packet still
+        // forwards; reporting DENY here would inflate drop/deny counters.
+        action: RT_FLOW_ACTION_PERMIT,
+        src_ip: pkt.src_ip,
+        dst_ip: pkt.dst_ip,
+        src_port: pkt.src_port,
+        dst_port: pkt.dst_port,
+        nat_src_ip: None,
+        nat_dst_ip: None,
+        nat_src_port: 0,
+        nat_dst_port: 0,
+        ingress_zone_id,
+        egress_zone_id: 0,
+        ingress_ifindex: ingress_ifindex_to_wire(meta.ingress_ifindex),
+        policy_id: 0,
+        rule_id: 0,
+        term_id: 0,
+        reason: 0,
+        owner_rg_id: 0,
+        application_id: 0,
+        filter_id: 0,
+        screen_id: screen_reason_id(reason),
+        timestamp_ns: 0,
+    };
+    let _ = event_stream.try_emit_dataplane_event_at(event, now_ns);
+}
+
 /// Build a minimal `ScreenPacketInfo` describing an L3 header that the
 /// screen extractor could NOT parse (#2146 fail-closed path). The
 /// packet bytes are untrustworthy past L3, so only the fields the
@@ -446,6 +495,49 @@ mod tests {
         assert_eq!(event.src_ip, pkt.src_ip);
         assert_eq!(event.dst_ip, pkt.dst_ip);
         assert_eq!(handle.dataplane_event_stats().screen_drop.sent, 1);
+    }
+
+    #[test]
+    fn screen_alarm_event_is_permit_not_deny() {
+        // #2234 fail-on-revert: the scan-table-pressure ALARM must carry the
+        // PERMIT action so downstream stats / syslog / dashboards do NOT count
+        // it as a drop/deny (the packet still forwards). Reverting the alarm
+        // emitter back to emit_screen_drop_event (action=DENY) breaks this.
+        let (handle, rx) = unlimited_handle();
+        let pkt = ScreenPacketInfo {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            tcp_flags: TCP_FLAG_SYN,
+            src_ip: IpAddr::V4(Ipv4Addr::new(203, 0, 113, 77)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 5)),
+            src_port: 40000,
+            dst_port: 443,
+            tcp_seq: 1,
+            tcp_ack: 0,
+            tcp_mss: 1460,
+            pkt_len: 60,
+            is_fragment: false,
+            is_first_fragment: false,
+            ip_ihl: 5,
+            ip_frag_off: 0,
+            ip_total_len: 60,
+        };
+
+        emit_screen_alarm_event(Some(&handle), &pkt, test_meta(), 2, "scan-table-pressure", 789);
+
+        let event = rx
+            .try_recv()
+            .expect("screen alarm frame")
+            .decode_dataplane_event()
+            .expect("screen alarm payload");
+        assert_eq!(event.kind, DataplaneEventKind::ScreenDrop);
+        assert_eq!(
+            event.action, RT_FLOW_ACTION_PERMIT,
+            "a pressure ALARM must not report a drop/deny action"
+        );
+        assert_eq!(event.screen_id, SCREEN_SCAN_TABLE_PRESSURE);
+        assert_eq!(event.src_ip, pkt.src_ip);
+        assert_eq!(event.dst_ip, pkt.dst_ip);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -907,16 +907,17 @@ pub(super) fn poll_binding_process_descriptor(
                         // when the scan/sweep source table is saturated and
                         // the detector is displacing stale sources to stay
                         // able to track a fresh real scanner. This is NOT a
-                        // drop — the packet still forwards; it rides the
-                        // existing screen event-emit path with a dedicated
-                        // `scan-table-pressure` reason, and fires at most a
-                        // handful of times under a sustained flood (never
-                        // per-flow). Checked here, on the cold session-miss
-                        // path only (the same path that performs the
-                        // eviction), so the hot established-flow path pays
-                        // nothing.
+                        // drop — the packet still forwards — so it uses the
+                        // ALARM emitter (RT_FLOW action PERMIT), which rides
+                        // the screen event frame with a dedicated
+                        // `scan-table-pressure` reason WITHOUT inflating the
+                        // drop/deny counters. It fires at most a handful of
+                        // times under a sustained flood (never per-flow), and
+                        // is checked here on the cold session-miss path only
+                        // (the same path that performs the eviction), so the
+                        // hot established-flow path pays nothing.
                         if screen.take_scan_table_pressure_event() {
-                            emit_screen_drop_event(
+                            emit_screen_alarm_event(
                                 worker_ctx.event_stream,
                                 &screen_pkt,
                                 meta,

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -903,6 +903,28 @@ pub(super) fn poll_binding_process_descriptor(
                                     flow.dst_ip,
                                 )
                             });
+                        // #2234: surface a rare (logarithmic) operator alarm
+                        // when the scan/sweep source table is saturated and
+                        // the detector is displacing stale sources to stay
+                        // able to track a fresh real scanner. This is NOT a
+                        // drop — the packet still forwards; it rides the
+                        // existing screen event-emit path with a dedicated
+                        // `scan-table-pressure` reason, and fires at most a
+                        // handful of times under a sustained flood (never
+                        // per-flow). Checked here, on the cold session-miss
+                        // path only (the same path that performs the
+                        // eviction), so the hot established-flow path pays
+                        // nothing.
+                        if screen.take_scan_table_pressure_event() {
+                            emit_screen_drop_event(
+                                worker_ctx.event_stream,
+                                &screen_pkt,
+                                meta,
+                                from_zone_id,
+                                "scan-table-pressure",
+                                event_now_ns_from_secs(now_secs),
+                            );
+                        }
                         if let Some(reason) = new_flow_screen_reason {
                             // The screen verdict is already decided; reuse
                             // the single parse above for the drop event's

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -471,6 +471,30 @@ impl ScreenState {
         self.port_scan.threshold_clamped() + self.ip_sweep.threshold_clamped()
     }
 
+    /// #2234: total stalest-evictions on the scan/sweep source-saturation
+    /// path. A non-zero value means the per-zone source table hit its cap and
+    /// the detector displaced stale sources to keep a fresh real scanner
+    /// trackable (it no longer silently drops new sources on a full table).
+    /// Pure observability; never affects a verdict.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn scan_sweep_evicted_pressure(&self) -> u64 {
+        self.port_scan.evicted_pressure() + self.ip_sweep.evicted_pressure()
+    }
+
+    /// #2234: returns `true` on a rare (logarithmic) eviction-rate threshold
+    /// crossing, signalling the caller to emit a `scan-table-pressure` screen
+    /// event so the operator is told the scan/sweep detector is saturated.
+    /// Fires at most a handful of times under a sustained flood (powers of
+    /// two in the cumulative eviction count) — NEVER per flow, honouring the
+    /// no-per-packet-logging rule. The crossing is consumed on read.
+    pub fn take_scan_table_pressure_event(&mut self) -> bool {
+        // Evaluate BOTH so each tracker's epoch advances independently; the
+        // `|` (not `||`) avoids short-circuiting the second take.
+        let port = self.port_scan.take_pressure_event();
+        let sweep = self.ip_sweep.take_pressure_event();
+        port | sweep
+    }
+
     /// Validate a returning SYN-cookie ACK only after the caller has already
     /// established that no normal session matched. This preserves established
     /// ACK traffic and prevents random ACKs from installing sessions while a

--- a/userspace-dp/src/screen/scan.rs
+++ b/userspace-dp/src/screen/scan.rs
@@ -32,19 +32,25 @@
 //!   subsequently-arriving REAL scanner is never tracked — and so never
 //!   detected — until `WINDOW_SECS` expiry, which the attacker can defer
 //!   indefinitely by keeping its 4096 sources fresh. The new-source path now
-//!   makes BOUNDED room instead of skipping: it first reclaims any expired
-//!   window found within a FIXED-SIZE sample of the zone's entries, and if
-//!   none is expired it evicts the stalest (oldest `window_start`) entry in
-//!   the sample. A fresh real scanner is therefore ALWAYS admissible. The
-//!   per-new-flow worst case is O(`EVICT_SCAN_LIMIT`) — a fixed sample, NOT
-//!   an O(sources) min-scan over the whole table (a full scan on every
-//!   new flow under a saturation flood would itself be an O(n)-per-packet
-//!   amplifier). The per-zone source count is tracked in `per_zone_count`
-//!   so the cap test is O(1); the only walk is the bounded eviction sample.
-//!   Each eviction bumps `evicted_pressure`, and a rare logarithmic
-//!   threshold crossing surfaces a `scan-table-pressure` screen event (see
-//!   `take_pressure_event`) so the operator is told the detector is
-//!   saturated — never a per-flow log.
+//!   makes BOUNDED room instead of skipping: it scans a FIXED PREFIX of the
+//!   source table (`iter().take(EVICT_SCAN_LIMIT)` — the budget counts EVERY
+//!   iterated entry, same-zone or not), reclaims the first expired same-zone
+//!   window it finds, and if none is expired evicts the stalest (oldest
+//!   `window_start`) same-zone entry within that prefix. Because this branch
+//!   only runs when the TARGET zone alone holds `>= MAX_SOURCES_PER_ZONE`
+//!   keys, same-zone entries are dense in the table and the prefix reliably
+//!   contains a victim, so a fresh real scanner is admissible. The
+//!   per-new-flow worst case is O(`EVICT_SCAN_LIMIT`), NOT an O(sources)
+//!   min-scan over the whole table (a full scan on every new flow under a
+//!   saturation flood would itself be an O(n)-per-packet amplifier). In the
+//!   pathological many-zones-sparsely-interleaved case where the prefix holds
+//!   no same-zone entry, the path degrades back to skip-on-full
+//!   (`skipped_pressure`) — still bounded, never fail-open. The per-zone
+//!   source count is tracked in `per_zone_count` so the cap test is O(1); the
+//!   only walk is the bounded prefix. Each eviction bumps `evicted_pressure`,
+//!   and a rare logarithmic threshold crossing surfaces a
+//!   `scan-table-pressure` screen event (see `take_pressure_event`) so the
+//!   operator is told the detector is saturated — never a per-flow log.
 //!
 //! - **Budgeted cleanup.** The periodic sweep walks the source table
 //!   (`HashMap::retain`, O(sources)) but removes at most `CLEANUP_BUDGET`
@@ -374,10 +380,17 @@ impl<T: std::hash::Hash + Eq> ScanCore<T> {
     #[inline]
     fn take_pressure_event(&mut self) -> bool {
         if self.evicted_pressure >= self.pressure_event_at {
-            // Advance to the next power-of-two boundary at or above the
-            // current count so repeated calls within the same epoch do not
-            // re-fire. saturating_mul keeps it monotone at u64::MAX.
-            self.pressure_event_at = self.evicted_pressure.saturating_add(1).next_power_of_two();
+            // Advance to the next power-of-two boundary above the current
+            // count so repeated calls within the same epoch do not re-fire.
+            // `checked_next_power_of_two` returns None when no power of two
+            // fits in u64 (count > 2^63); saturate to u64::MAX there so the
+            // gate never panics/wraps and simply stops firing (the alarm has
+            // long since been raised). Cannot regress below the current bar.
+            self.pressure_event_at = self
+                .evicted_pressure
+                .saturating_add(1)
+                .checked_next_power_of_two()
+                .unwrap_or(u64::MAX);
             true
         } else {
             false

--- a/userspace-dp/src/screen/scan.rs
+++ b/userspace-dp/src/screen/scan.rs
@@ -15,16 +15,36 @@
 //!   (a spoofed-source flood multiplies the source keys; a fan-out flood
 //!   multiplies the inner unique entries). Both axes are capped:
 //!   `MAX_SOURCES_PER_ZONE` distinct source keys per zone and
-//!   `MAX_UNIQUE_PER_SOURCE` unique entries per source. On a SOURCE-axis
-//!   overflow the tracker SKIPS the new source and bumps `skipped_pressure`
-//!   — it degrades to *not counting* that source (a verdict can only become
-//!   LESS likely). On the UNIQUE-entry axis the set is capped, but the
-//!   detection threshold is CLAMPED to `MAX_UNIQUE_PER_SOURCE - 1` so a
-//!   source that fills the set ALWAYS crosses it: a threshold larger than
-//!   the cap detects AT THE CAP rather than never (fail-CLOSED, #2227
-//!   MAJOR-1). The maps never grow without bound. This mirrors the
-//!   #2134/#2177 session-limit per-IP bound discipline (skip-on-full, never
-//!   a phantom growth) plus a fail-closed clamp on the inner axis.
+//!   `MAX_UNIQUE_PER_SOURCE` unique entries per source. On the UNIQUE-entry
+//!   axis the set is capped, but the detection threshold is CLAMPED to
+//!   `MAX_UNIQUE_PER_SOURCE - 1` so a source that fills the set ALWAYS
+//!   crosses it: a threshold larger than the cap detects AT THE CAP rather
+//!   than never (fail-CLOSED, #2227 MAJOR-1). The maps never grow without
+//!   bound. This mirrors the #2134/#2177 session-limit per-IP bound
+//!   discipline (skip-on-full, never a phantom growth) plus a fail-closed
+//!   clamp on the inner axis.
+//!
+//! - **Bounded stalest-eviction on source-axis saturation (#2234).** The
+//!   per-zone source cap was originally a HARD cliff: once a zone held
+//!   `MAX_SOURCES_PER_ZONE` keys a brand-new `(zone, src_ip)` was SKIPPED
+//!   (bumping `skipped_pressure`). That is fail-safe for forwarding but a
+//!   DETECTION-DoS: a high-cardinality spoofed flood fills the table and a
+//!   subsequently-arriving REAL scanner is never tracked — and so never
+//!   detected — until `WINDOW_SECS` expiry, which the attacker can defer
+//!   indefinitely by keeping its 4096 sources fresh. The new-source path now
+//!   makes BOUNDED room instead of skipping: it first reclaims any expired
+//!   window found within a FIXED-SIZE sample of the zone's entries, and if
+//!   none is expired it evicts the stalest (oldest `window_start`) entry in
+//!   the sample. A fresh real scanner is therefore ALWAYS admissible. The
+//!   per-new-flow worst case is O(`EVICT_SCAN_LIMIT`) — a fixed sample, NOT
+//!   an O(sources) min-scan over the whole table (a full scan on every
+//!   new flow under a saturation flood would itself be an O(n)-per-packet
+//!   amplifier). The per-zone source count is tracked in `per_zone_count`
+//!   so the cap test is O(1); the only walk is the bounded eviction sample.
+//!   Each eviction bumps `evicted_pressure`, and a rare logarithmic
+//!   threshold crossing surfaces a `scan-table-pressure` screen event (see
+//!   `take_pressure_event`) so the operator is told the detector is
+//!   saturated — never a per-flow log.
 //!
 //! - **Budgeted cleanup.** The periodic sweep walks the source table
 //!   (`HashMap::retain`, O(sources)) but removes at most `CLEANUP_BUDGET`
@@ -69,8 +89,27 @@ const MAX_UNIQUE_PER_SOURCE: usize = 1024;
 /// a single poll tick.
 const CLEANUP_BUDGET: usize = 256;
 
+/// Hard upper bound on the number of `per_src` entries examined while
+/// looking for an eviction victim on the source-saturation path (#2234).
+/// The new-flow worst case is O(`EVICT_SCAN_LIMIT`), NOT O(sources): a full
+/// min-scan over all `MAX_SOURCES_PER_ZONE` entries on every new flow under
+/// a saturation flood would itself be an O(n)-per-packet DoS amplifier. We
+/// instead sample a fixed prefix of the table and evict the stalest
+/// same-zone entry found within it. Under the realistic single-zone flood
+/// the entire table is the target zone, so the first sampled entries are
+/// always same-zone victims; the limit only matters in the pathological
+/// many-zones-sparsely-interleaved case, where eviction degrades gracefully
+/// back to skip-on-full (still bounded, never fail-open).
+const EVICT_SCAN_LIMIT: usize = 64;
+
 /// 10-second detection window shared by both trackers.
 const WINDOW_SECS: u64 = 10;
+
+/// Compile-time guard: the eviction sample must be smaller than the per-zone
+/// source cap, otherwise the "sample a prefix" bound would be meaningless
+/// (it would scan the whole table). It must also be non-empty so the
+/// new-source path can always find a victim under a single-zone flood.
+const _: () = assert!(EVICT_SCAN_LIMIT > 0 && EVICT_SCAN_LIMIT < MAX_SOURCES_PER_ZONE);
 
 /// Test-only accessor for the per-zone source cap, used by the
 /// `ScreenState`-level bounded-state test in `screen/tests.rs`.
@@ -87,31 +126,275 @@ pub(super) fn max_unique_per_source_for_test() -> usize {
     MAX_UNIQUE_PER_SOURCE
 }
 
+/// Test-only accessor for the bounded eviction sample limit (#2234), used by
+/// the bounded-cost eviction test in `screen/tests.rs`.
+#[cfg(test)]
+pub(super) fn evict_scan_limit_for_test() -> usize {
+    EVICT_SCAN_LIMIT
+}
+
 /// Per-zone scan/sweep tracker key: `(zone_id, src_ip)`.
 type ScanKey = (u16, IpAddr);
 
-/// Tracks unique destination ports per `(zone_id, source IP)` within a
-/// time window (port-scan detection).
-#[derive(Debug, Clone, Default)]
-pub(super) struct PortScanTracker {
-    per_src: FxHashMap<ScanKey, (u64, FxHashSet<u16>)>, // (window_start_secs, unique_ports)
-    /// Count of records skipped because a per-zone / per-source cap was
-    /// hit. Pure observability — exposed for the bounded-state tests and
-    /// the screen status surface. Never affects a verdict.
+/// Shared bounded windowed-unique tracker core (#2209/#2227/#2234). Both
+/// the port-scan (`T = u16`) and IP-sweep (`T = IpAddr`) trackers are thin
+/// `T`-specialised wrappers over this single implementation so the bound /
+/// eviction / pressure logic exists in exactly ONE place (engineering-style
+/// "one source of truth" — the pre-#2234 free functions duplicated the
+/// formula across the two trackers).
+#[derive(Debug, Clone)]
+struct ScanCore<T: std::hash::Hash + Eq> {
+    per_src: FxHashMap<ScanKey, (u64, FxHashSet<T>)>, // (window_start_secs, unique entries)
+    /// Live count of distinct source keys per zone. Maintained on every
+    /// insert / removal so the per-zone cap test is O(1) (#2234) — the
+    /// pre-#2234 code walked every key to count one zone (`sources_in_zone`,
+    /// O(sources)), which on the new-source-at-cap path under a saturation
+    /// flood is O(n) per packet.
+    per_zone_count: FxHashMap<u16, u32>,
+    /// Count of records skipped because a per-source unique-entry cap was
+    /// hit, or because eviction could not free a same-zone slot within the
+    /// bounded sample (rare). Pure observability — exposed for the
+    /// bounded-state tests and the screen status surface. Never affects a
+    /// verdict.
     skipped_pressure: u64,
+    /// Count of stalest-eviction events on the source-saturation path
+    /// (#2234): a brand-new source displaced an expired-or-stalest existing
+    /// source so a fresh real scanner stays trackable. Pure observability.
+    evicted_pressure: u64,
     /// Count of checks whose operator threshold exceeded the supported
     /// maximum (`MAX_UNIQUE_PER_SOURCE - 1`) and was clamped to it
     /// (fail-closed clamp, #2227 MAJOR-1). Pure observability — surfaces an
     /// operator misconfiguration (threshold the bounded set can never reach
     /// un-clamped) without changing the (clamped) verdict.
     threshold_clamped: u64,
+    /// Next `evicted_pressure` value at which a `scan-table-pressure` screen
+    /// event should be surfaced. Grows geometrically (see
+    /// [`ScanCore::take_pressure_event`]) so the operator alarm fires at a
+    /// LOGARITHMIC rate — never per-flow — even under a sustained flood.
+    pressure_event_at: u64,
+}
+
+impl<T: std::hash::Hash + Eq> Default for ScanCore<T> {
+    fn default() -> Self {
+        Self {
+            per_src: FxHashMap::default(),
+            per_zone_count: FxHashMap::default(),
+            skipped_pressure: 0,
+            evicted_pressure: 0,
+            threshold_clamped: 0,
+            // First eviction surfaces an event; thereafter the bar doubles.
+            pressure_event_at: 1,
+        }
+    }
+}
+
+impl<T: std::hash::Hash + Eq> ScanCore<T> {
+    /// Bounded windowed-unique check. `entry_val` is the per-(zone_id,
+    /// src_ip) unique entry (dst port or dst IP).
+    ///
+    /// Bounds (fail-safe, never fail-OPEN):
+    /// - a brand-new source key for a zone already holding
+    ///   `MAX_SOURCES_PER_ZONE` keys triggers a BOUNDED stalest-eviction
+    ///   (#2234): the stalest (or any expired) entry within an
+    ///   `EVICT_SCAN_LIMIT`-sized sample of the zone is removed to admit the
+    ///   fresh source, so a real scanner is always trackable. Only if the
+    ///   bounded sample finds no same-zone victim (pathological many-zone
+    ///   interleave) does it fall back to skip-on-full (bumps
+    ///   `skipped_pressure`, returns `false`) — still bounded, never
+    ///   fail-open;
+    /// - a new unique entry for a source whose set already holds
+    ///   `MAX_UNIQUE_PER_SOURCE` entries is SKIPPED, but the threshold is
+    ///   still evaluated against the current (capped) set size;
+    /// - the EFFECTIVE comparison threshold is CLAMPED to
+    ///   `MAX_UNIQUE_PER_SOURCE - 1` (#2227 MAJOR-1). The set can hold at
+    ///   most `MAX_UNIQUE_PER_SOURCE` entries, so an operator threshold
+    ///   `>= MAX_UNIQUE_PER_SOURCE` could otherwise NEVER be crossed by
+    ///   `len() > threshold` — a silent fail-OPEN where the scanner is never
+    ///   dropped. Clamping guarantees a source that fills the bounded set
+    ///   ALWAYS crosses the effective threshold: detection fires AT THE CAP
+    ///   rather than never. The clamp is counted in `threshold_clamped` and
+    ///   the Go control plane warns at commit time when a threshold exceeds
+    ///   the supported maximum.
+    #[inline]
+    fn check(
+        &mut self,
+        zone_id: u16,
+        src_ip: IpAddr,
+        entry_val: T,
+        now_secs: u64,
+        threshold: u32,
+    ) -> bool {
+        if threshold == 0 {
+            return false;
+        }
+        // Fail-closed clamp: the bounded set tops out at
+        // MAX_UNIQUE_PER_SOURCE, so the comparison `len() > effective` can
+        // only ever fire if `effective <= MAX_UNIQUE_PER_SOURCE - 1`. A
+        // larger operator threshold is clamped here (and counted) so
+        // detection fires at the cap instead of never. MAX_UNIQUE_PER_SOURCE
+        // fits a u32, so the cast and subtraction are safe.
+        let max_effective = (MAX_UNIQUE_PER_SOURCE - 1) as u32;
+        let effective_threshold = if threshold > max_effective {
+            self.threshold_clamped += 1;
+            max_effective
+        } else {
+            threshold
+        };
+        let key: ScanKey = (zone_id, src_ip);
+        let exists = self.per_src.contains_key(&key);
+        // Per-zone source-count bound. A brand-new source for a zone at the
+        // cap makes BOUNDED room by eviction (#2234) instead of the old
+        // hard skip-on-full cliff. An existing key is always allowed through
+        // (it is bounded on the inner axis below).
+        if !exists && self.zone_count(zone_id) >= MAX_SOURCES_PER_ZONE {
+            if !self.evict_stalest_in_zone(zone_id, now_secs) {
+                // No same-zone victim within the bounded sample (pathological
+                // many-zone interleave). Preserve the fail-safe: skip, never
+                // fail-open. Cost is still O(EVICT_SCAN_LIMIT).
+                self.skipped_pressure += 1;
+                return false;
+            }
+        }
+        let newly_inserted = !exists;
+        let entry = self
+            .per_src
+            .entry(key)
+            .or_insert_with(|| (now_secs, FxHashSet::default()));
+        if newly_inserted {
+            *self.per_zone_count.entry(zone_id).or_insert(0) += 1;
+        }
+        // Reset window if expired.
+        if now_secs.saturating_sub(entry.0) >= WINDOW_SECS {
+            entry.0 = now_secs;
+            entry.1.clear();
+        }
+        // Per-source unique-entry bound: once the set is full, skip new
+        // entries (counting pressure) but still evaluate the threshold.
+        if entry.1.len() >= MAX_UNIQUE_PER_SOURCE {
+            if !entry.1.contains(&entry_val) {
+                self.skipped_pressure += 1;
+            }
+        } else {
+            entry.1.insert(entry_val);
+        }
+        entry.1.len() as u32 > effective_threshold
+    }
+
+    /// O(1) per-zone source count (maintained incrementally).
+    #[inline]
+    fn zone_count(&self, zone_id: u16) -> usize {
+        self.per_zone_count.get(&zone_id).copied().unwrap_or(0) as usize
+    }
+
+    /// Evict one same-zone source so a fresh source can be admitted under
+    /// source-axis saturation (#2234). Examines at most `EVICT_SCAN_LIMIT`
+    /// `per_src` entries TOTAL (a FIXED prefix of the iterator, NOT the whole
+    /// table) and removes the FIRST expired same-zone entry it finds, or —
+    /// failing that — the STALEST (oldest `window_start`) same-zone entry
+    /// within the sample.
+    ///
+    /// Cost: O(`EVICT_SCAN_LIMIT`), independent of the table size, because the
+    /// budget counts EVERY iterated entry (same-zone or not) — so even a
+    /// pathological many-zones-interleaved table cannot turn this into an
+    /// O(n)-per-packet amplifier. This branch only runs when the TARGET zone
+    /// alone holds `>= MAX_SOURCES_PER_ZONE` keys, so same-zone entries are
+    /// dense in the table and the fixed prefix reliably contains a victim;
+    /// in the rare event the sample holds no same-zone entry, the caller
+    /// falls back to skip-on-full (still bounded, never fail-open).
+    /// Returns `true` if a victim was evicted (count decremented,
+    /// `evicted_pressure` bumped), `false` otherwise.
+    #[inline]
+    fn evict_stalest_in_zone(&mut self, zone_id: u16, now_secs: u64) -> bool {
+        let mut stalest_key: Option<ScanKey> = None;
+        let mut stalest_start = u64::MAX;
+        let mut expired_victim: Option<ScanKey> = None;
+        // Hard total-iteration bound: take a fixed prefix of the iterator.
+        for (k, (start, set)) in self.per_src.iter().take(EVICT_SCAN_LIMIT) {
+            if k.0 != zone_id {
+                continue; // not a candidate, but still counts against the bound
+            }
+            // An expired-or-empty window is dead weight — evict it first.
+            if now_secs.saturating_sub(*start) >= WINDOW_SECS || set.is_empty() {
+                expired_victim = Some(*k);
+                break;
+            }
+            if *start < stalest_start {
+                stalest_start = *start;
+                stalest_key = Some(*k);
+            }
+        }
+        let victim = expired_victim.or(stalest_key);
+        if let Some(victim) = victim {
+            if self.per_src.remove(&victim).is_some() {
+                if let Some(c) = self.per_zone_count.get_mut(&zone_id) {
+                    *c = c.saturating_sub(1);
+                }
+                self.evicted_pressure += 1;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Remove up to `CLEANUP_BUDGET` expired or empty entries.
+    /// `HashMap::retain` still WALKS every entry (O(sources)), but the number
+    /// REMOVED per call is budgeted — so the per-tick mutation/rehash cost is
+    /// bounded, and stale entries that survive a tick are reclaimed on
+    /// subsequent ticks. The walk itself is bounded only by the
+    /// `MAX_SOURCES_PER_ZONE` cap on the table. The per-zone count is
+    /// decremented for each removed key so the eviction cap test stays exact.
+    #[inline]
+    fn cleanup(&mut self, now_secs: u64) {
+        let mut removed = 0usize;
+        let per_zone_count = &mut self.per_zone_count;
+        self.per_src.retain(|key, (start, set)| {
+            if removed >= CLEANUP_BUDGET {
+                return true; // budget exhausted — keep the rest for next tick
+            }
+            let expired = now_secs.saturating_sub(*start) >= WINDOW_SECS || set.is_empty();
+            if expired {
+                removed += 1;
+                if let Some(c) = per_zone_count.get_mut(&key.0) {
+                    *c = c.saturating_sub(1);
+                }
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    /// Returns `true` once each time the cumulative eviction count crosses a
+    /// geometric threshold (1, 2, 4, 8, ...). Surfacing a `scan-table-
+    /// pressure` screen event on this rare transition (#2234) tells the
+    /// operator the detector is saturated — at a LOGARITHMIC rate, never
+    /// per-flow, so a sustained flood produces a handful of alarms rather
+    /// than a per-packet log storm (CLAUDE.md logging rules). Consumes the
+    /// crossing (idempotent until the next boundary).
+    #[inline]
+    fn take_pressure_event(&mut self) -> bool {
+        if self.evicted_pressure >= self.pressure_event_at {
+            // Advance to the next power-of-two boundary at or above the
+            // current count so repeated calls within the same epoch do not
+            // re-fire. saturating_mul keeps it monotone at u64::MAX.
+            self.pressure_event_at = self.evicted_pressure.saturating_add(1).next_power_of_two();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Tracks unique destination ports per `(zone_id, source IP)` within a
+/// time window (port-scan detection). Thin wrapper over [`ScanCore`].
+#[derive(Debug, Clone, Default)]
+pub(super) struct PortScanTracker {
+    core: ScanCore<u16>,
 }
 
 impl PortScanTracker {
     /// Check if `(zone_id, src_ip)` has exceeded the port scan threshold.
-    /// Returns true if exceeded. New ports for a source whose set is full,
-    /// or new sources for a zone at the source cap, are skipped (not
-    /// recorded) and counted in `skipped_pressure` — never fail-open.
+    /// Returns true if exceeded. Bounded + fail-safe (see [`ScanCore::check`]).
     pub(super) fn check(
         &mut self,
         zone_id: u16,
@@ -120,58 +403,54 @@ impl PortScanTracker {
         now_secs: u64,
         threshold: u32,
     ) -> bool {
-        if threshold == 0 {
-            return false;
-        }
-        check_unique(
-            &mut self.per_src,
-            &mut self.skipped_pressure,
-            &mut self.threshold_clamped,
-            zone_id,
-            src_ip,
-            dst_port,
-            now_secs,
-            threshold,
-        )
+        self.core.check(zone_id, src_ip, dst_port, now_secs, threshold)
     }
 
     /// Remove expired entries (budgeted periodic cleanup).
     pub(super) fn cleanup(&mut self, now_secs: u64) {
-        cleanup_expired(&mut self.per_src, now_secs);
+        self.core.cleanup(now_secs);
     }
 
-    /// Records skipped due to a per-zone / per-source cap (fail-safe
-    /// overflow pressure). Pure observability.
+    /// Records skipped due to a per-source unique-entry cap or a failed
+    /// bounded eviction (fail-safe overflow pressure). Pure observability.
     pub(super) fn skipped_pressure(&self) -> u64 {
-        self.skipped_pressure
+        self.core.skipped_pressure
+    }
+
+    /// Stalest-evictions on the source-saturation path (#2234). Pure
+    /// observability.
+    pub(super) fn evicted_pressure(&self) -> u64 {
+        self.core.evicted_pressure
     }
 
     /// Checks whose operator threshold was clamped to the supported maximum
     /// (`MAX_UNIQUE_PER_SOURCE - 1`). Pure observability (#2227 MAJOR-1).
     pub(super) fn threshold_clamped(&self) -> u64 {
-        self.threshold_clamped
+        self.core.threshold_clamped
+    }
+
+    /// Rare (logarithmic) pressure-event transition for the operator alarm
+    /// (#2234). See [`ScanCore::take_pressure_event`].
+    pub(super) fn take_pressure_event(&mut self) -> bool {
+        self.core.take_pressure_event()
     }
 
     #[cfg(test)]
     pub(super) fn tracked_sources(&self) -> usize {
-        self.per_src.len()
+        self.core.per_src.len()
     }
 }
 
 /// Tracks unique destination IPs per `(zone_id, source IP)` within a time
-/// window (IP-sweep detection).
+/// window (IP-sweep detection). Thin wrapper over [`ScanCore`].
 #[derive(Debug, Clone, Default)]
 pub(super) struct IpSweepTracker {
-    per_src: FxHashMap<ScanKey, (u64, FxHashSet<IpAddr>)>, // (window_start_secs, unique_dst_ips)
-    skipped_pressure: u64,
-    /// See [`PortScanTracker::threshold_clamped`].
-    threshold_clamped: u64,
+    core: ScanCore<IpAddr>,
 }
 
 impl IpSweepTracker {
     /// Check if `(zone_id, src_ip)` has exceeded the IP sweep threshold.
-    /// Returns true if exceeded. Bounded + fail-safe like
-    /// [`PortScanTracker::check`].
+    /// Returns true if exceeded. Bounded + fail-safe (see [`ScanCore::check`]).
     pub(super) fn check(
         &mut self,
         zone_id: u16,
@@ -180,146 +459,42 @@ impl IpSweepTracker {
         now_secs: u64,
         threshold: u32,
     ) -> bool {
-        if threshold == 0 {
-            return false;
-        }
-        check_unique(
-            &mut self.per_src,
-            &mut self.skipped_pressure,
-            &mut self.threshold_clamped,
-            zone_id,
-            src_ip,
-            dst_ip,
-            now_secs,
-            threshold,
-        )
+        self.core.check(zone_id, src_ip, dst_ip, now_secs, threshold)
     }
 
     /// Remove expired entries (budgeted periodic cleanup).
     pub(super) fn cleanup(&mut self, now_secs: u64) {
-        cleanup_expired(&mut self.per_src, now_secs);
+        self.core.cleanup(now_secs);
     }
 
-    /// Records skipped due to a per-zone / per-source cap (fail-safe
-    /// overflow pressure). Pure observability.
+    /// Records skipped due to a per-source unique-entry cap or a failed
+    /// bounded eviction (fail-safe overflow pressure). Pure observability.
     pub(super) fn skipped_pressure(&self) -> u64 {
-        self.skipped_pressure
+        self.core.skipped_pressure
+    }
+
+    /// Stalest-evictions on the source-saturation path (#2234). Pure
+    /// observability.
+    pub(super) fn evicted_pressure(&self) -> u64 {
+        self.core.evicted_pressure
     }
 
     /// Checks whose operator threshold was clamped to the supported maximum
     /// (`MAX_UNIQUE_PER_SOURCE - 1`). Pure observability (#2227 MAJOR-1).
     pub(super) fn threshold_clamped(&self) -> u64 {
-        self.threshold_clamped
+        self.core.threshold_clamped
+    }
+
+    /// Rare (logarithmic) pressure-event transition for the operator alarm
+    /// (#2234). See [`ScanCore::take_pressure_event`].
+    pub(super) fn take_pressure_event(&mut self) -> bool {
+        self.core.take_pressure_event()
     }
 
     #[cfg(test)]
     pub(super) fn tracked_sources(&self) -> usize {
-        self.per_src.len()
+        self.core.per_src.len()
     }
-}
-
-/// Shared bounded windowed-unique check used by both trackers. `entry`
-/// is the per-(zone_id, src_ip) unique set of `T` (dst port or dst IP).
-///
-/// Bounds (fail-safe, never fail-OPEN):
-/// - a brand-new source key for a zone already holding
-///   `MAX_SOURCES_PER_ZONE` keys is SKIPPED (returns `false`, bumps
-///   pressure) — the screen drop is the more-restrictive verdict, so
-///   declining to track can only relax it;
-/// - a new unique entry for a source whose set already holds
-///   `MAX_UNIQUE_PER_SOURCE` entries is SKIPPED, but the threshold is
-///   still evaluated against the current (capped) set size;
-/// - the EFFECTIVE comparison threshold is CLAMPED to
-///   `MAX_UNIQUE_PER_SOURCE - 1` (#2227 MAJOR-1). The set can hold at most
-///   `MAX_UNIQUE_PER_SOURCE` entries, so an operator threshold `>=
-///   MAX_UNIQUE_PER_SOURCE` could otherwise NEVER be crossed by
-///   `len() > threshold` — a silent fail-OPEN where the scanner is never
-///   dropped. Clamping guarantees a source that fills the bounded set
-///   ALWAYS crosses the effective threshold: detection fires AT THE CAP
-///   rather than never. The clamp is counted in `threshold_clamped` (pure
-///   observability) and the Go control plane warns at commit time when an
-///   operator threshold exceeds the supported maximum.
-#[inline]
-fn check_unique<T: std::hash::Hash + Eq>(
-    per_src: &mut FxHashMap<ScanKey, (u64, FxHashSet<T>)>,
-    skipped_pressure: &mut u64,
-    threshold_clamped: &mut u64,
-    zone_id: u16,
-    src_ip: IpAddr,
-    entry_val: T,
-    now_secs: u64,
-    threshold: u32,
-) -> bool {
-    // Fail-closed clamp: the bounded set tops out at MAX_UNIQUE_PER_SOURCE,
-    // so the comparison `len() > effective_threshold` can only ever fire if
-    // `effective_threshold <= MAX_UNIQUE_PER_SOURCE - 1`. A larger operator
-    // threshold is clamped here (and counted) so detection fires at the cap
-    // instead of never. `MAX_UNIQUE_PER_SOURCE` fits a u32, so the cast and
-    // subtraction are safe.
-    let max_effective = (MAX_UNIQUE_PER_SOURCE - 1) as u32;
-    let effective_threshold = if threshold > max_effective {
-        *threshold_clamped += 1;
-        max_effective
-    } else {
-        threshold
-    };
-    let key: ScanKey = (zone_id, src_ip);
-    // Per-zone source-count bound: refuse to register a brand-new source
-    // for a zone that is already at the cap. An existing key is always
-    // allowed through (it is bounded on the inner axis below).
-    let exists = per_src.contains_key(&key);
-    if !exists && sources_in_zone(per_src, zone_id) >= MAX_SOURCES_PER_ZONE {
-        *skipped_pressure += 1;
-        return false;
-    }
-    let entry = per_src
-        .entry(key)
-        .or_insert_with(|| (now_secs, FxHashSet::default()));
-    // Reset window if expired.
-    if now_secs.saturating_sub(entry.0) >= WINDOW_SECS {
-        entry.0 = now_secs;
-        entry.1.clear();
-    }
-    // Per-source unique-entry bound: once the set is full, skip new
-    // entries (counting pressure) but still evaluate the threshold.
-    if entry.1.len() >= MAX_UNIQUE_PER_SOURCE {
-        if !entry.1.contains(&entry_val) {
-            *skipped_pressure += 1;
-        }
-    } else {
-        entry.1.insert(entry_val);
-    }
-    entry.1.len() as u32 > effective_threshold
-}
-
-/// Count of source keys currently tracked for `zone_id`. Linear in the
-/// table size; only walked when admitting a brand-new source (cold path),
-/// and the table is itself capped, so this stays bounded.
-#[inline]
-fn sources_in_zone<T>(per_src: &FxHashMap<ScanKey, (u64, FxHashSet<T>)>, zone_id: u16) -> usize {
-    per_src.keys().filter(|(z, _)| *z == zone_id).count()
-}
-
-/// Remove up to `CLEANUP_BUDGET` expired or empty entries. `HashMap::retain`
-/// still WALKS every entry (O(sources)), but the number REMOVED per call is
-/// budgeted — so the per-tick mutation/rehash cost is bounded, and stale
-/// entries that survive a tick are reclaimed on subsequent ticks. The walk
-/// itself is bounded only by the `MAX_SOURCES_PER_ZONE` cap on the table.
-#[inline]
-fn cleanup_expired<T>(per_src: &mut FxHashMap<ScanKey, (u64, FxHashSet<T>)>, now_secs: u64) {
-    let mut removed = 0usize;
-    per_src.retain(|_, (start, set)| {
-        if removed >= CLEANUP_BUDGET {
-            return true; // budget exhausted — keep the rest for next tick
-        }
-        let expired = now_secs.saturating_sub(*start) >= WINDOW_SECS || set.is_empty();
-        if expired {
-            removed += 1;
-            false
-        } else {
-            true
-        }
-    });
 }
 
 #[cfg(test)]
@@ -374,19 +549,23 @@ mod scan_tests {
         }
         assert_eq!(t.tracked_sources(), MAX_SOURCES_PER_ZONE);
         assert_eq!(t.skipped_pressure(), 0);
-        // One more brand-new source must be SKIPPED, not grow the table,
-        // and must NOT fail-open (returns false = no drop).
+        assert_eq!(t.evicted_pressure(), 0);
+        // #2234: one more brand-new source must NOW be admitted by BOUNDED
+        // stalest-eviction (not skipped), so a fresh real scanner is always
+        // trackable — and must NOT fail-open (returns false = no drop). The
+        // table must STAY bounded at the cap (eviction made room, the table
+        // never grows).
         let overflow_src = IpAddr::V4(Ipv4Addr::from(0x0b00_0000u32));
         assert!(!t.check(0, overflow_src, v4(1), 100, 0));
         assert!(!t.check(0, overflow_src, v4(2), 100, 1));
         assert_eq!(
             t.tracked_sources(),
             MAX_SOURCES_PER_ZONE,
-            "over-cap source must not grow the table"
+            "eviction must keep the table bounded at the cap, not grow it"
         );
         assert!(
-            t.skipped_pressure() >= 1,
-            "over-cap source records pressure"
+            t.evicted_pressure() >= 1,
+            "admitting an over-cap source records eviction pressure"
         );
     }
 
@@ -502,5 +681,197 @@ mod scan_tests {
         // up to the budget.
         t.cleanup(1_000);
         assert_eq!(t.tracked_sources(), seed - CLEANUP_BUDGET);
+    }
+
+    /// #2234 fail-on-revert: a brand-new REAL scanner that arrives AFTER the
+    /// per-zone source table is saturated must still be tracked AND detected.
+    /// Pre-#2234 the new source was SKIPPED on a full table (returns false,
+    /// only bumps `skipped_pressure`), so a high-cardinality spoofed flood
+    /// could suppress detection of a subsequently-arriving genuine scanner
+    /// indefinitely — a detection-DoS. Reverting `evict_stalest_in_zone` to
+    /// the skip-on-full cliff breaks this test (the scanner never fires).
+    #[test]
+    fn fresh_scanner_tracked_and_detected_after_saturation() {
+        let mut t = IpSweepTracker::default();
+        // Fill zone 0 to the cap with spoofed sources at an OLD window so the
+        // stalest-eviction has clear victims. High threshold so none of them
+        // trips (the flood is high-cardinality, low-per-source fan-out).
+        let flood_t = 0u64;
+        for i in 0..MAX_SOURCES_PER_ZONE {
+            let src = IpAddr::V4(Ipv4Addr::from(0x0a00_0000u32 + i as u32));
+            assert!(!t.check(0, src, v4(1), flood_t, 1_000_000));
+        }
+        assert_eq!(t.tracked_sources(), MAX_SOURCES_PER_ZONE);
+        // A real scanner arrives later, sweeping many destinations with a low
+        // threshold. Even though the table is full, it must be admitted by
+        // eviction and cross its threshold.
+        let scanner = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
+        let threshold = 5u32;
+        let now = flood_t + 1; // still inside the flood's window
+        let mut fired = false;
+        for d in 0..(threshold + 3) {
+            let dst = IpAddr::V4(Ipv4Addr::new(198, 51, 100, d as u8));
+            if t.check(0, scanner, dst, now, threshold) {
+                fired = true;
+                break;
+            }
+        }
+        assert!(
+            fired,
+            "a fresh real scanner arriving after saturation MUST be tracked \
+             and detected (pre-#2234 it was skipped on a full table → never \
+             detected)"
+        );
+        // The table must remain bounded (eviction made room, not growth).
+        assert_eq!(
+            t.tracked_sources(),
+            MAX_SOURCES_PER_ZONE,
+            "eviction keeps the table at the cap"
+        );
+        assert!(t.evicted_pressure() >= 1, "admission recorded an eviction");
+    }
+
+    /// #2234: eviction must prefer the STALEST (oldest `window_start`) entry
+    /// over fresher ones when no entry is expired. We fill a small synthetic
+    /// zone to the cap is too expensive here, so exercise the victim-choice
+    /// logic on `ScanCore` directly via the public `check` path with a cap
+    /// reduced by construction is not possible (the cap is a const) — instead
+    /// assert the property on the eviction helper through a saturated table:
+    /// the source whose window is oldest is the one removed.
+    #[test]
+    fn eviction_prefers_stalest_window() {
+        let mut core: ScanCore<u16> = ScanCore::default();
+        // Seed a handful of zone-9 entries with DISTINCT, increasing window
+        // starts so exactly one is the stalest. (Direct ScanCore access keeps
+        // this O(few) instead of filling 4096 cap entries.) Each set is
+        // NON-EMPTY and the window is FRESH so the expired-or-empty branch
+        // never fires — the victim choice is decided purely by window_start.
+        let mut nonempty = |p: u16| {
+            let mut s = FxHashSet::default();
+            s.insert(p);
+            s
+        };
+        let stale_src = IpAddr::V4(Ipv4Addr::new(10, 9, 0, 1));
+        core.per_src.insert((9, stale_src), (100, nonempty(1)));
+        for i in 2..=8u32 {
+            let s = IpAddr::V4(Ipv4Addr::from(0x0a09_0000u32 + i));
+            core.per_src
+                .insert((9, s), (200 + i as u64, nonempty(i as u16)));
+        }
+        *core.per_zone_count.entry(9).or_insert(0) = core.per_src.len() as u32;
+        let before = core.per_src.len();
+        // `now` close to the stalest start so NOTHING is expired (force the
+        // stalest-not-expired branch).
+        let now = 105u64;
+        assert!(
+            core.evict_stalest_in_zone(9, now),
+            "a same-zone victim must be found"
+        );
+        assert_eq!(core.per_src.len(), before - 1, "exactly one evicted");
+        assert!(
+            !core.per_src.contains_key(&(9, stale_src)),
+            "the STALEST (window_start=100) entry must be the one evicted, \
+             not a fresher one"
+        );
+        assert_eq!(core.evicted_pressure, 1);
+    }
+
+    /// #2234: eviction prefers an EXPIRED window even if it is not the
+    /// numerically-oldest in iteration order — dead weight is reclaimed first.
+    #[test]
+    fn eviction_prefers_expired_window() {
+        let mut core: ScanCore<u16> = ScanCore::default();
+        let expired_src = IpAddr::V4(Ipv4Addr::new(10, 9, 0, 50));
+        // One expired entry plus several fresh ones.
+        core.per_src
+            .insert((9, expired_src), (0, FxHashSet::default()));
+        for i in 1..=5u32 {
+            let s = IpAddr::V4(Ipv4Addr::from(0x0a09_1000u32 + i));
+            let mut set = FxHashSet::default();
+            set.insert(i as u16);
+            core.per_src.insert((9, s), (1_000, set));
+        }
+        *core.per_zone_count.entry(9).or_insert(0) = core.per_src.len() as u32;
+        // now far past the expired window but inside the fresh entries'.
+        let now = 1_000 + WINDOW_SECS - 1;
+        assert!(core.evict_stalest_in_zone(9, now));
+        assert!(
+            !core.per_src.contains_key(&(9, expired_src)),
+            "the EXPIRED entry must be reclaimed first"
+        );
+    }
+
+    /// #2234 bounded-cost guard: the eviction sample is FIXED
+    /// (`EVICT_SCAN_LIMIT`), never an O(sources) scan. With many more
+    /// same-zone entries than the limit, one eviction must examine at most
+    /// the limit and still succeed — and the per-zone count is maintained
+    /// exactly across repeated admit-with-eviction so the cap test stays O(1).
+    #[test]
+    fn eviction_is_bounded_and_count_exact() {
+        assert!(
+            evict_scan_limit_for_test() < MAX_SOURCES_PER_ZONE,
+            "the sample must be a fixed PREFIX, not the whole table"
+        );
+        let mut t = PortScanTracker::default();
+        // Saturate zone 4.
+        for i in 0..MAX_SOURCES_PER_ZONE {
+            let src = IpAddr::V4(Ipv4Addr::from(0x0a04_0000u32 + i as u32));
+            assert!(!t.check(4, src, 80, 0, 1_000_000));
+        }
+        assert_eq!(t.tracked_sources(), MAX_SOURCES_PER_ZONE);
+        // Admit many fresh sources; each must evict one (bounded) and the
+        // table size must never exceed the cap.
+        for i in 0..1024u32 {
+            let fresh = IpAddr::V4(Ipv4Addr::from(0x0b04_0000u32 + i));
+            t.check(4, fresh, 80, 1, 1_000_000);
+            assert!(
+                t.tracked_sources() <= MAX_SOURCES_PER_ZONE,
+                "the table must never exceed the cap under sustained churn"
+            );
+        }
+        assert_eq!(
+            t.tracked_sources(),
+            MAX_SOURCES_PER_ZONE,
+            "sustained admit-with-eviction keeps the table exactly at the cap"
+        );
+        assert!(t.evicted_pressure() >= 1024);
+        assert_eq!(t.skipped_pressure(), 0, "single-zone flood never skips");
+    }
+
+    /// #2234: the per-zone count is decremented on budgeted cleanup so the
+    /// O(1) cap test stays exact after entries age out.
+    #[test]
+    fn per_zone_count_tracks_cleanup() {
+        let mut core: ScanCore<u16> = ScanCore::default();
+        for i in 0..10u32 {
+            let s = IpAddr::V4(Ipv4Addr::from(0x0a05_0000u32 + i));
+            core.check(5, s, 80, 0, 1_000_000);
+        }
+        assert_eq!(core.zone_count(5), 10);
+        // Age everything out; cleanup removes them and the count follows.
+        core.cleanup(1_000);
+        assert_eq!(core.zone_count(5), 0, "count decremented on cleanup");
+        assert_eq!(core.per_src.len(), 0);
+    }
+
+    /// #2234: the pressure-event transition fires at a LOGARITHMIC rate
+    /// (powers of two), never per eviction — so a sustained flood yields a
+    /// handful of operator alarms, not a per-flow log storm.
+    #[test]
+    fn pressure_event_is_logarithmic() {
+        let mut core: ScanCore<u16> = ScanCore::default();
+        let mut events = 0u32;
+        // Simulate 1000 evictions, asking for a pressure event after each.
+        for _ in 0..1000u64 {
+            core.evicted_pressure += 1;
+            if core.take_pressure_event() {
+                events += 1;
+            }
+        }
+        // 1000 evictions cross boundaries 1,2,4,...,512 → 10 events.
+        assert_eq!(
+            events, 10,
+            "pressure events must be logarithmic in eviction count, got {events}"
+        );
     }
 }

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -2576,8 +2576,10 @@ fn scan_sweep_state_bounded_and_records_pressure() {
     let mut state = make_state("trust", profile);
 
     assert_eq!(state.scan_sweep_skipped_pressure(), 0);
+    assert_eq!(state.scan_sweep_evicted_pressure(), 0);
+    let cap = super::scan::max_sources_per_zone_for_test();
     // Far more distinct sources than the per-zone cap.
-    for i in 0..(super::scan::max_sources_per_zone_for_test() + 200) {
+    for i in 0..(cap + 200) {
         let src = IpAddr::V4(Ipv4Addr::from(0x0a00_0000u32 + i as u32));
         let dst = IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1));
         let pkt = tcp_pkt(src, dst, 1234, 80, TCP_SYN);
@@ -2587,11 +2589,103 @@ fn scan_sweep_state_bounded_and_records_pressure() {
             None
         );
     }
+    // #2234: over-cap sources are now ADMITTED by bounded stalest-eviction
+    // (the table stays bounded but a fresh source is no longer silently
+    // dropped on a full table), recorded as eviction pressure — NOT skip
+    // pressure. The single-zone flood never falls back to skip.
     assert!(
-        state.scan_sweep_skipped_pressure() >= 200,
-        "over-cap sources must record pressure, got {}",
-        state.scan_sweep_skipped_pressure()
+        state.scan_sweep_evicted_pressure() >= 200,
+        "over-cap sources must record eviction pressure, got {}",
+        state.scan_sweep_evicted_pressure()
     );
+    assert_eq!(
+        state.scan_sweep_skipped_pressure(),
+        0,
+        "a single-zone source flood must evict, never skip"
+    );
+}
+
+/// #2234 fail-on-revert at the production `ScreenState` new-flow hook: a
+/// genuine port-scanner arriving AFTER a high-cardinality spoofed flood has
+/// saturated the per-zone source table must STILL be tracked and dropped.
+/// Pre-#2234 the new source was skipped on a full table (returns None
+/// forever), so the spoofed flood suppressed detection of the real scanner —
+/// a detection-DoS. Reverting the bounded stalest-eviction breaks this test.
+#[test]
+fn fresh_scanner_detected_after_source_flood_at_screen_state() {
+    let mut profile = ScreenProfile::default();
+    profile.port_scan_threshold = 5; // low: a real scan trips quickly
+    let mut state = make_state("trust", profile);
+    let cap = super::scan::max_sources_per_zone_for_test();
+
+    // Saturate the trust zone with a spoofed-source flood (one SYN each, so
+    // none individually trips the port-scan threshold).
+    let flood_now = 1_000u64;
+    let dst = IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1));
+    for i in 0..cap {
+        let src = IpAddr::V4(Ipv4Addr::from(0x0a00_0000u32 + i as u32));
+        let pkt = tcp_pkt(src, dst, 1234, 80, TCP_SYN);
+        assert_eq!(
+            state.scan_sweep_drop_on_new_flow("trust", ZID, &pkt, flood_now),
+            None
+        );
+    }
+
+    // A real scanner shows up afterward, hitting many ports on one target.
+    let scanner = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9));
+    let target = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10));
+    let mut fired = false;
+    for port in 1000u16..1010 {
+        let pkt = tcp_pkt(scanner, target, 1234, port, TCP_SYN);
+        if state.scan_sweep_drop_on_new_flow("trust", ZID, &pkt, flood_now + 1) == Some("port-scan")
+        {
+            fired = true;
+            break;
+        }
+    }
+    assert!(
+        fired,
+        "a real port-scanner arriving after a saturating flood MUST be \
+         detected (pre-#2234 it was skipped on the full table → never \
+         detected)"
+    );
+    assert!(
+        state.scan_sweep_evicted_pressure() >= 1,
+        "tracking the scanner required at least one eviction"
+    );
+}
+
+/// #2234: the `scan-table-pressure` operator alarm transition fires at a
+/// rare logarithmic rate under a sustained source flood — never per flow.
+#[test]
+fn scan_table_pressure_event_fires_rarely_under_flood() {
+    let mut profile = ScreenProfile::default();
+    profile.ip_sweep_threshold = 1_000_000; // never trips by detection
+    let mut state = make_state("trust", profile);
+    let cap = super::scan::max_sources_per_zone_for_test();
+
+    // No evictions yet → no pressure-event transition.
+    assert!(!state.take_scan_table_pressure_event());
+
+    // Saturate, then churn many fresh sources to force sustained eviction.
+    let dst = IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1));
+    let mut events = 0u32;
+    for i in 0..(cap + 2_000) {
+        let src = IpAddr::V4(Ipv4Addr::from(0x0a00_0000u32 + i as u32));
+        let pkt = tcp_pkt(src, dst, 1234, 80, TCP_SYN);
+        let _ = state.scan_sweep_drop_on_new_flow("trust", ZID, &pkt, 100);
+        if state.take_scan_table_pressure_event() {
+            events += 1;
+        }
+    }
+    // ~2000 evictions → log2(2000) ≈ 11 events, far fewer than the flood
+    // size: the alarm is logarithmic, not per-flow.
+    assert!(
+        events >= 1 && events <= 20,
+        "pressure-event must be rare/logarithmic, got {events} over {} flows",
+        cap + 2_000
+    );
+    assert!(state.scan_sweep_evicted_pressure() >= 2_000);
 }
 
 /// #2227 MAJOR-1 fail-on-revert (at the production `ScreenState` hook): an

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -410,24 +410,39 @@ Per-worker scoping applies identically to scan/sweep (each worker owns its
 `ScreenState`), so the effective unique-entry count is multiplied by the
 worker count, exactly as documented for the session limit above.
 
-**Known limitation (#2227 MINOR-2 — detection-DoS via source-table
-saturation).** The per-zone source table is a hard cap
-(`MAX_SOURCES_PER_ZONE = 4096`). Once a zone holds 4096 tracked sources, a
-brand-new source key is SKIPPED (not recorded) — so a spoofed-source flood
-that fills the table can prevent a *subsequently-arriving* genuine scanner
-from being tracked, and therefore from being detected, until table entries
-expire. Worse, each existing source's window is refreshed whenever that
-source sends another new flow, so an attacker controlling 4096 sources can
-keep the table pinned full indefinitely (the entries never expire while the
-attacker keeps touching them; cleanup only reclaims windows older than
-`WINDOW_SECS`). This is a fail-SAFE-but-detection-degrading bound: it never
-fail-opens the *forwarding* path (no traffic is admitted that policy would
-deny) and never grows memory without bound, but it can suppress scan/sweep
-*detection* under a high-cardinality spoofed flood. `skipped_pressure`
-surfaces the saturation so an operator/alarm can see it. A follow-up
-(oldest/LRU eviction so a fresh real source can displace a stale tracked one,
-or a pressure-driven alarm) is tracked in #2234. Mitigations today:
-anti-spoofing / uRPF upstream and the `skipped_pressure` signal.
+**Source-table saturation — bounded stalest-eviction (#2234, was MINOR-2).**
+The per-zone source table is still capped at `MAX_SOURCES_PER_ZONE = 4096`
+(memory never grows without bound), but the cap is no longer a HARD cliff. The
+pre-#2234 behaviour SKIPPED a brand-new source once the zone was full, so a
+high-cardinality spoofed-source flood that filled the table could prevent a
+*subsequently-arriving* genuine scanner from being tracked — and therefore
+from being detected — until entries expired (which the attacker could defer
+indefinitely by keeping its 4096 sources fresh). That was a detection-DoS: it
+never fail-opened the *forwarding* path, but it suppressed scan/sweep
+*detection*.
+
+The new-source path now makes BOUNDED room instead of skipping. When a brand-
+new `(zone, src_ip)` arrives at a full zone, the tracker reclaims any expired
+window found within a FIXED-SIZE sample (`EVICT_SCAN_LIMIT = 64` entries) of
+the zone, and if none is expired it evicts the STALEST (oldest `window_start`)
+sampled entry. A fresh real scanner is therefore ALWAYS admissible, so the
+detection-suppression cliff is gone. The per-new-flow worst case is
+O(`EVICT_SCAN_LIMIT`) — a fixed prefix of the table, NOT an O(sources)
+min-scan, which under a saturation flood would itself be an O(n)-per-packet
+amplifier. The per-zone source count is maintained incrementally
+(`per_zone_count`) so the cap test is O(1); the only walk is the bounded
+eviction sample. In the pathological many-zones-sparsely-interleaved case
+where the fixed sample finds no same-zone victim, the path degrades back to
+skip-on-full (`skipped_pressure`) — still bounded, still never fail-open.
+
+Each eviction bumps `evicted_pressure` (surfaced via
+`ScreenState::scan_sweep_evicted_pressure`), and a rare LOGARITHMIC threshold
+crossing (powers of two in the cumulative eviction count) emits a
+`scan-table-pressure` screen event so the operator is told the detector is
+saturated — at a handful of alarms under a sustained flood, never per-flow
+(honouring the no-per-packet-logging rule). Defence-in-depth mitigations still
+apply: anti-spoofing / uRPF upstream reduces the spoofed-source axis, and the
+`skipped_pressure` / `evicted_pressure` signals surface the pressure.
 
 ## Why a slab + integer handles
 

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -422,18 +422,22 @@ never fail-opened the *forwarding* path, but it suppressed scan/sweep
 *detection*.
 
 The new-source path now makes BOUNDED room instead of skipping. When a brand-
-new `(zone, src_ip)` arrives at a full zone, the tracker reclaims any expired
-window found within a FIXED-SIZE sample (`EVICT_SCAN_LIMIT = 64` entries) of
-the zone, and if none is expired it evicts the STALEST (oldest `window_start`)
-sampled entry. A fresh real scanner is therefore ALWAYS admissible, so the
+new `(zone, src_ip)` arrives at a full zone, the tracker scans a FIXED PREFIX
+of the source table (`iter().take(EVICT_SCAN_LIMIT)`, `EVICT_SCAN_LIMIT = 64`
+— the budget counts EVERY iterated entry, same-zone or not), reclaims the
+first expired same-zone window it finds, and if none is expired evicts the
+STALEST (oldest `window_start`) same-zone entry within that prefix. This
+branch only runs when the TARGET zone alone holds `>= MAX_SOURCES_PER_ZONE`
+keys, so same-zone entries are dense in the table and the prefix reliably
+contains a victim — a fresh real scanner is therefore admissible and the
 detection-suppression cliff is gone. The per-new-flow worst case is
-O(`EVICT_SCAN_LIMIT`) — a fixed prefix of the table, NOT an O(sources)
-min-scan, which under a saturation flood would itself be an O(n)-per-packet
-amplifier. The per-zone source count is maintained incrementally
-(`per_zone_count`) so the cap test is O(1); the only walk is the bounded
-eviction sample. In the pathological many-zones-sparsely-interleaved case
-where the fixed sample finds no same-zone victim, the path degrades back to
-skip-on-full (`skipped_pressure`) — still bounded, still never fail-open.
+O(`EVICT_SCAN_LIMIT`), NOT an O(sources) min-scan over 4096 entries, which
+under a saturation flood would itself be an O(n)-per-packet amplifier. The
+per-zone source count is maintained incrementally (`per_zone_count`) so the
+cap test is O(1); the only walk is the bounded prefix. In the pathological
+many-zones-sparsely-interleaved case where the prefix holds no same-zone
+victim, the path degrades back to skip-on-full (`skipped_pressure`) — still
+bounded, still never fail-open.
 
 Each eviction bumps `evicted_pressure` (surfaced via
 `ScreenState::scan_sweep_evicted_pressure`), and a rare LOGARITHMIC threshold


### PR DESCRIPTION
Fixes #2234 (MINOR-2 from PR #2227).

## Problem
The per-zone scan/sweep source table was a HARD cap
(`MAX_SOURCES_PER_ZONE = 4096`). Once a zone held 4096 tracked
`(zone, src_ip)` keys, a brand-new source was SKIPPED (only bumped
`skipped_pressure`). Fail-safe for forwarding, but a **detection-DoS**: a
high-cardinality spoofed-source flood fills the table and a
subsequently-arriving REAL scanner is never tracked, so never detected,
until `WINDOW_SECS` expiry — which an attacker keeping its 4096 sources
fresh can defer indefinitely.

## Fix
- **Bounded stalest-eviction.** A new source at a full zone reclaims any
  expired window in a FIXED sample (`EVICT_SCAN_LIMIT = 64`) of the zone,
  else evicts the stalest (oldest `window_start`) sampled entry. A fresh
  real scanner is therefore always trackable — the detection cliff is gone.
- **O(K) bounded, K=64.** The sample budget counts every iterated entry (a
  fixed prefix), so the per-new-flow worst case is **O(EVICT_SCAN_LIMIT)**,
  never an O(sources) min-scan (which under a flood would itself be an
  O(n)-per-packet amplifier). Per-zone source count is tracked
  incrementally (`per_zone_count`) so the cap test is O(1), replacing the
  pre-#2234 O(sources) `sources_in_zone` walk on the new-source path. If the
  sample finds no same-zone victim, it degrades to skip-on-full — still
  bounded, never fail-open.
- **One source of truth.** Both trackers unified on a shared `ScanCore<T>`
  (the pre-#2234 free functions duplicated the windowed-unique formula).
- **Operator alarm.** `evicted_pressure` counter + a rare LOGARITHMIC
  `scan-table-pressure` screen event (powers of two in the eviction count),
  emitted from the cold session-miss hook — NOT a drop, never per-flow.
  New reason bit `SCREEN_SCAN_TABLE_PRESSURE = 1<<19` (Rust + Go
  `ScreenFlagNames`, also backfilled the stale 1<<17/1<<18 names).

## Hot-path shape
The pressure-event check (`take_scan_table_pressure_event`) is two integer
comparisons on the **cold session-miss path only**; eviction is
O(64) and runs only when a zone is at its 4096 cap. The hot established-flow
path is untouched. No per-packet allocation.

## Eviction cost bound
**O(K), K = EVICT_SCAN_LIMIT = 64.** A `const _: () = assert!` pins
`EVICT_SCAN_LIMIT < MAX_SOURCES_PER_ZONE`.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo test --release` full suite green (2255/0 main bin + all targets)
- [x] New fail-on-revert tests, run 5x no flake:
  - fresh real scanner detected after table saturation (scan.rs + ScreenState)
  - eviction prefers the stalest window
  - eviction prefers an expired window
  - bounded-cost + count-exact under sustained admit-with-eviction churn
  - pressure-event rate is logarithmic
  - per-zone count follows cleanup
- [x] Existing screen tests preserved (121/0)
- [x] `go build ./...` + `go vet ./pkg/dataplane` clean
- [ ] Loss-cluster smoke (screen-safety + line-rate forwarding) — running

## Docs
`userspace-dp/src/session/README.md` "Known limitation" note rewritten:
the saturation cliff is now mitigated (bounded eviction), with the cost
bound, fail-safe fallback, and `evicted_pressure` / `scan-table-pressure`
observability documented.

## Refs
- PR #2227 (MAJOR-1 clamp + this MINOR-2 documentation)
- `userspace-dp/src/screen/scan.rs`, `userspace-dp/src/session/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)