### PR TITLE
#1387: Kea expired-leases-processing (stale-lease cleanup) config — Path S

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9477,3 +9477,34 @@ top.
   build+vet+test green, new test 5x no flake.
   **File(s)**: pkg/routing/rules.go, pkg/routing/rules_test.go,
   pkg/routing/README.md, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #1387 Path S — Kea expired-leases-processing (stale-lease
+  cleanup) config. Opt-in per-family reclamation subtree under
+  `dhcp-local-server` / `dhcpv6-local-server`. Config model
+  `DHCPExpiredLeasesConfig` on the per-family `DHCPLocalServerConfig`
+  (GLOBAL per Dhcp4/Dhcp6, never per-pool — trap 1). The two cap knobs
+  (max-leases/max-time) carry a `*Set` bool so `0` (= unlimited in Kea)
+  renders distinctly from unset (trap 2). Schema floor split: the three
+  timers use ValidateIntegerMin(1) (a 0 some Kea versions reject would
+  brick the fail-closed restart), the cap knobs + unwarned-cycles use
+  Min(0) (trap 3). Compile (`compileDHCPExpiredLeases`, dual-AST walker
+  mirroring compileDHCPDynamicDNS) lands inside the shared compileExpanded
+  core, so it is present on BOTH the strict commit and the tolerant
+  load/peer-sync compile sites (trap 4); the typed-leaf schema gate
+  hard-rejects on commit but warns on Load/SyncApply (boot/HA safety).
+  Render `keaExpiredLeasesMap` returns nil for nil/disabled (UNCONDITIONAL
+  omit -> byte-identical to pre-#1387, H1); enabled-no-knobs renders {}.
+  Tests: dhcpserver golden render (v4/v6 all-knobs, disabled/absent omit,
+  max-leases 0 vs unset, one-knob-omits-rest, enabled-no-knobs-{}, per-
+  family independence); config dual-AST compile equality + per-family +
+  absent-default + H2 set/unset + schema completion + commit-check floor
+  split + lenient compile; configstore stored/peer-sync tolerance. All
+  build+vet+test green; new tests 5x no flake. Kea binaries not present
+  locally so `kea-dhcp4 -t` config-test is deploy-deferred. DDNS half of
+  #1387 already shipped (#2043/#2066); kea-d2 backend PLAN-KILLed.
+  **File(s)**: pkg/config/types_system.go, pkg/config/schema_system.go,
+  pkg/config/compiler_services.go, pkg/dhcpserver/dhcpserver.go,
+  pkg/dhcpserver/README.md, pkg/config/dhcp_expired_leases_test.go,
+  pkg/dhcpserver/expired_leases_test.go,
+  pkg/configstore/typed_leaf_lenient_test.go, _Log.md

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -136,6 +136,16 @@ func compileDHCPLocalServer(node *Node, dhcp *DHCPServerConfig, isV6 bool) error
 		}
 	}
 
+	// #1387 (stale-lease-cleanup slice / Path S): the
+	// expired-leases-processing block is GLOBAL to the family (Kea renders
+	// it per Dhcp4/Dhcp6, never per-subnet), so it attaches to this
+	// family's DHCPLocalServerConfig (lsc), NOT to a pool. v4 and v6 are
+	// tuned independently. A truly empty/garbage block compiles to nil so
+	// it neither forces reclamation on nor renders anything.
+	if elpNode := node.FindChild("expired-leases-processing"); elpNode != nil {
+		lsc.ExpiredLeases = compileDHCPExpiredLeases(elpNode)
+	}
+
 	for _, groupInst := range namedInstances(node.FindChildren("group")) {
 		group := &DHCPServerGroup{Name: groupInst.name}
 
@@ -343,6 +353,99 @@ func compileDHCPDynamicDNS(node *Node) *DHCPDynamicDNSConfig {
 		return nil
 	}
 	return d
+}
+
+// dhcpExpiredLeasesIntProps are the integer-valued expired-leases-processing
+// leaves (everything except the valueless `enable` flag). Used by
+// compileDHCPExpiredLeases's subtree walker to recognize a "<leaf> <value>"
+// pair at any depth regardless of the AST shape.
+var dhcpExpiredLeasesIntProps = map[string]bool{
+	"reclaim-timer":   true,
+	"flush-timer":     true,
+	"hold-time":       true,
+	"max-leases":      true,
+	"max-time":        true,
+	"unwarned-cycles": true,
+}
+
+// compileDHCPExpiredLeases converts a parsed `expired-leases-processing`
+// subtree into a typed *DHCPExpiredLeasesConfig (#1387 stale-lease-cleanup
+// slice). Like compileDHCPDynamicDNS it handles BOTH the hierarchical
+// shape (`expired-leases-processing { enable; reclaim-timer 10; }`, each
+// leaf a separate child node) and the flat-set shape
+// (`set ... expired-leases-processing reclaim-timer 10`, where SetPath may
+// pack trailing property tokens into a single leaf node's Keys). First
+// value wins so a later malformed re-set cannot clobber a good one.
+//
+// Returns nil for a truly empty/garbage block so an empty stanza neither
+// forces reclamation on nor renders anything (closing the
+// empty-tree-compiles-non-nil trap). The set/unset distinction for the
+// cap knobs (max-leases / max-time) is preserved into the model: 0 is a
+// MEANINGFUL Kea value (unlimited) that must render distinctly from unset
+// (invariant H2), so a *Set bool latches when the operator supplies the
+// key.
+func compileDHCPExpiredLeases(node *Node) *DHCPExpiredLeasesConfig {
+	c := &DHCPExpiredLeasesConfig{}
+	props := map[string]string{}
+	enabled := false
+
+	var walk func(n *Node, isRoot bool)
+	walk = func(n *Node, isRoot bool) {
+		start := 0
+		if isRoot {
+			start = 1 // skip the "expired-leases-processing" identifier itself
+		}
+		for i := start; i < len(n.Keys); i++ {
+			k := n.Keys[i]
+			switch {
+			case k == "enable":
+				enabled = true
+			case dhcpExpiredLeasesIntProps[k] && i+1 < len(n.Keys):
+				if _, ok := props[k]; !ok {
+					props[k] = n.Keys[i+1]
+				}
+				i++
+			}
+		}
+		for _, ch := range n.Children {
+			walk(ch, false)
+		}
+	}
+	walk(node, true)
+
+	c.Enabled = enabled
+	// parseInt sets the field from a decimal prop value when present and
+	// well-formed, returning whether the key was present at all (so the
+	// caller can distinguish a configured 0 from an unset key for the cap
+	// knobs). A garbage value is treated as unset for that field.
+	parseInt := func(key string, dst *int) bool {
+		v, present := props[key]
+		if !present {
+			return false
+		}
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return false
+		}
+		*dst = n
+		return true
+	}
+	parseInt("reclaim-timer", &c.ReclaimTimerWait)
+	parseInt("flush-timer", &c.FlushReclaimedTimerWait)
+	parseInt("hold-time", &c.HoldReclaimedTime)
+	c.MaxReclaimLeasesSet = parseInt("max-leases", &c.MaxReclaimLeases)
+	c.MaxReclaimTimeSet = parseInt("max-time", &c.MaxReclaimTime)
+	parseInt("unwarned-cycles", &c.UnwarnedReclaimCycles)
+
+	// Empty block -> treat as absent (no reclamation block rendered). A
+	// block with only `enable` is meaningful (Kea reads {} as "defaults"),
+	// so check the union of enable + any configured field.
+	if !c.Enabled && c.ReclaimTimerWait == 0 && c.FlushReclaimedTimerWait == 0 &&
+		c.HoldReclaimedTime == 0 && !c.MaxReclaimLeasesSet && !c.MaxReclaimTimeSet &&
+		c.UnwarnedReclaimCycles == 0 {
+		return nil
+	}
+	return c
 }
 
 func compileDynamicAddress(node *Node, sec *SecurityConfig) error {

--- a/pkg/config/dhcp_expired_leases_test.go
+++ b/pkg/config/dhcp_expired_leases_test.go
@@ -1,0 +1,341 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1387 stale-lease-cleanup slice (Path S): expired-leases-processing
+// config-model tests. The dual-AST tests use the production
+// ParseSetCommand + SetPath path (buildTree) for flat-set, never NewParser
+// for flat-set (the merge gotcha in CLAUDE.md); the hierarchical case uses
+// NewParser on real block syntax. They prove dual-AST compile equality, the
+// per-family attachment, the empty-block-is-absent guard, the H2 set-vs-0
+// distinction, and the schema typed-leaf floors at commit check.
+
+func elpV4(t *testing.T, cfg *Config) *DHCPExpiredLeasesConfig {
+	t.Helper()
+	if cfg.System.DHCPServer.DHCPLocalServer == nil {
+		return nil
+	}
+	return cfg.System.DHCPServer.DHCPLocalServer.ExpiredLeases
+}
+
+func elpV6(t *testing.T, cfg *Config) *DHCPExpiredLeasesConfig {
+	t.Helper()
+	if cfg.System.DHCPServer.DHCPv6LocalServer == nil {
+		return nil
+	}
+	return cfg.System.DHCPServer.DHCPv6LocalServer.ExpiredLeases
+}
+
+// TestDHCPExpiredLeasesHierarchicalAndFlatSetCompileEqually is the dual-AST
+// equality proof (invariant H6): the hierarchical block and the flat-set
+// spelling must compile to the same typed DHCPExpiredLeasesConfig.
+func TestDHCPExpiredLeasesHierarchicalAndFlatSetCompileEqually(t *testing.T) {
+	flat := buildTree(t, []string{
+		"set system services dhcp-local-server expired-leases-processing enable",
+		"set system services dhcp-local-server expired-leases-processing reclaim-timer 10",
+		"set system services dhcp-local-server expired-leases-processing flush-timer 25",
+		"set system services dhcp-local-server expired-leases-processing hold-time 600",
+		"set system services dhcp-local-server expired-leases-processing max-leases 100",
+		"set system services dhcp-local-server expired-leases-processing max-time 250",
+		"set system services dhcp-local-server expired-leases-processing unwarned-cycles 5",
+	})
+	cflat, err := CompileConfig(flat)
+	if err != nil {
+		t.Fatalf("CompileConfig(flat): %v", err)
+	}
+	cf := elpV4(t, cflat)
+	if cf == nil {
+		t.Fatal("flat-set expired-leases-processing compiled to nil")
+	}
+
+	want := &DHCPExpiredLeasesConfig{
+		Enabled:                 true,
+		ReclaimTimerWait:        10,
+		FlushReclaimedTimerWait: 25,
+		HoldReclaimedTime:       600,
+		MaxReclaimLeases:        100,
+		MaxReclaimLeasesSet:     true,
+		MaxReclaimTime:          250,
+		MaxReclaimTimeSet:       true,
+		UnwarnedReclaimCycles:   5,
+	}
+	if *cf != *want {
+		t.Fatalf("flat-set mismatch:\n got %+v\nwant %+v", *cf, *want)
+	}
+
+	hierSrc := `system {
+  services {
+    dhcp-local-server {
+      expired-leases-processing {
+        enable;
+        reclaim-timer 10;
+        flush-timer 25;
+        hold-time 600;
+        max-leases 100;
+        max-time 250;
+        unwarned-cycles 5;
+      }
+    }
+  }
+}`
+	hp := NewParser(hierSrc)
+	htree, perrs := hp.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("hierarchical Parse: %v", perrs)
+	}
+	chier, err := CompileConfig(htree)
+	if err != nil {
+		t.Fatalf("CompileConfig(hier): %v", err)
+	}
+	ch := elpV4(t, chier)
+	if ch == nil {
+		t.Fatal("hierarchical expired-leases-processing compiled to nil")
+	}
+	if *ch != *cf {
+		t.Fatalf("hierarchical vs flat-set differ:\n hier %+v\n flat %+v", *ch, *cf)
+	}
+}
+
+// TestDHCPExpiredLeasesAbsentByDefault: no block => nil => zero behaviour
+// change (invariant H1 at the model layer).
+func TestDHCPExpiredLeasesAbsentByDefault(t *testing.T) {
+	cfg, err := CompileConfig(buildTree(t, []string{
+		"set system services dhcp-local-server group g0 interface ge-0/0/0",
+		"set system services dhcp-local-server group g0 pool p0 subnet 10.0.1.0/24",
+	}))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if elpV4(t, cfg) != nil {
+		t.Fatal("absent expired-leases-processing must compile to nil")
+	}
+}
+
+// TestDHCPExpiredLeasesPerFamilyIndependence: the block attaches to the
+// per-family DHCPLocalServerConfig, NOT a shared DHCPServerConfig field, so
+// a v4-only block leaves v6 nil and vice-versa (invariant H3).
+func TestDHCPExpiredLeasesPerFamilyIndependence(t *testing.T) {
+	cfg, err := CompileConfig(buildTree(t, []string{
+		"set system services dhcp-local-server expired-leases-processing enable",
+		"set system services dhcp-local-server expired-leases-processing reclaim-timer 11",
+		"set system services dhcpv6-local-server expired-leases-processing enable",
+		"set system services dhcpv6-local-server expired-leases-processing reclaim-timer 22",
+	}))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	v4 := elpV4(t, cfg)
+	v6 := elpV6(t, cfg)
+	if v4 == nil || v4.ReclaimTimerWait != 11 {
+		t.Fatalf("v4 block not compiled independently: %+v", v4)
+	}
+	if v6 == nil || v6.ReclaimTimerWait != 22 {
+		t.Fatalf("v6 block not compiled independently: %+v", v6)
+	}
+
+	// v4-only: v6 must stay nil.
+	cfg4, err := CompileConfig(buildTree(t, []string{
+		"set system services dhcp-local-server expired-leases-processing enable",
+		"set system services dhcpv6-local-server group g0 pool p0 subnet 2001:db8::/64",
+	}))
+	if err != nil {
+		t.Fatalf("CompileConfig(v4-only): %v", err)
+	}
+	if elpV4(t, cfg4) == nil {
+		t.Fatal("v4 block missing")
+	}
+	if elpV6(t, cfg4) != nil {
+		t.Fatalf("v6 must be nil when only v4 configures the block, got %+v", elpV6(t, cfg4))
+	}
+}
+
+// TestDHCPExpiredLeasesMaxKnobsSetVsUnset pins the H2 model distinction:
+// `max-leases 0` (and `max-time 0`) compile to value 0 WITH the *Set bool
+// true (unlimited), distinct from not configuring them (*Set false). A bare
+// `if x > 0` model would lose the unlimited intent.
+func TestDHCPExpiredLeasesMaxKnobsSetVsUnset(t *testing.T) {
+	t.Run("explicit 0 latches Set", func(t *testing.T) {
+		cfg, err := CompileConfig(buildTree(t, []string{
+			"set system services dhcp-local-server expired-leases-processing enable",
+			"set system services dhcp-local-server expired-leases-processing max-leases 0",
+			"set system services dhcp-local-server expired-leases-processing max-time 0",
+		}))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		c := elpV4(t, cfg)
+		if c == nil {
+			t.Fatal("compiled to nil")
+		}
+		if !c.MaxReclaimLeasesSet || c.MaxReclaimLeases != 0 {
+			t.Errorf("max-leases 0 must set MaxReclaimLeasesSet=true, value=0; got set=%v val=%d", c.MaxReclaimLeasesSet, c.MaxReclaimLeases)
+		}
+		if !c.MaxReclaimTimeSet || c.MaxReclaimTime != 0 {
+			t.Errorf("max-time 0 must set MaxReclaimTimeSet=true, value=0; got set=%v val=%d", c.MaxReclaimTimeSet, c.MaxReclaimTime)
+		}
+	})
+
+	t.Run("unset leaves Set false", func(t *testing.T) {
+		cfg, err := CompileConfig(buildTree(t, []string{
+			"set system services dhcp-local-server expired-leases-processing enable",
+			"set system services dhcp-local-server expired-leases-processing reclaim-timer 10",
+		}))
+		if err != nil {
+			t.Fatalf("CompileConfig: %v", err)
+		}
+		c := elpV4(t, cfg)
+		if c == nil {
+			t.Fatal("compiled to nil")
+		}
+		if c.MaxReclaimLeasesSet || c.MaxReclaimTimeSet {
+			t.Errorf("unset cap knobs must keep *Set false; got leasesSet=%v timeSet=%v", c.MaxReclaimLeasesSet, c.MaxReclaimTimeSet)
+		}
+	})
+}
+
+// TestDHCPExpiredLeasesEnableOnlyCompiles: a block with only `enable` is a
+// meaningful state (Kea defaults apply / render {}), so it compiles non-nil.
+func TestDHCPExpiredLeasesEnableOnlyCompiles(t *testing.T) {
+	cfg, err := CompileConfig(buildTree(t, []string{
+		"set system services dhcp-local-server expired-leases-processing enable",
+	}))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	c := elpV4(t, cfg)
+	if c == nil || !c.Enabled {
+		t.Fatalf("enable-only block must compile to a non-nil enabled config, got %+v", c)
+	}
+}
+
+// TestDHCPExpiredLeasesSchemaCompletes: the new subtree + its six leaves are
+// offered by structural completion under both families (setSchema is the
+// SSOT; completion and validation read the same node).
+func TestDHCPExpiredLeasesSchemaCompletes(t *testing.T) {
+	for _, parent := range []string{"dhcp-local-server", "dhcpv6-local-server"} {
+		results := CompleteSetPathWithValues(
+			[]string{"system", "services", parent}, nil)
+		if !containsCompletionName(results, "expired-leases-processing") {
+			t.Fatalf("expired-leases-processing not offered under %s: %v", parent, completionNames(results))
+		}
+		leaves := CompleteSetPathWithValues(
+			[]string{"system", "services", parent, "expired-leases-processing"}, nil)
+		for _, want := range []string{
+			"enable", "reclaim-timer", "flush-timer", "hold-time",
+			"max-leases", "max-time", "unwarned-cycles",
+		} {
+			if !containsCompletionName(leaves, want) {
+				t.Errorf("leaf %q not offered under %s expired-leases-processing: %v", want, parent, completionNames(leaves))
+			}
+		}
+	}
+}
+
+// TestDHCPExpiredLeasesSchemaValueCompletion: a typed leaf's value slot
+// surfaces the placeholder + example values at `?` completion.
+func TestDHCPExpiredLeasesSchemaValueCompletion(t *testing.T) {
+	results := CompleteSetPathWithValues(
+		[]string{"system", "services", "dhcp-local-server", "expired-leases-processing", "max-leases"}, nil)
+	// The example values from the schema (100, 0) should appear.
+	if !containsCompletionName(results, "0") || !containsCompletionName(results, "100") {
+		t.Fatalf("max-leases value-slot completion should offer examples 0/100, got %v", completionNames(results))
+	}
+}
+
+// TestDHCPExpiredLeasesSchemaRejectsTimerZero pins the SMR MAJOR-3 floor
+// split: the three TIMERS use ValidateIntegerMin(1), so a 0 (which some Kea
+// versions reject and would take DHCP down on the fail-closed restart) is a
+// hard commit-check error.
+func TestDHCPExpiredLeasesSchemaRejectsTimerZero(t *testing.T) {
+	for _, timer := range []string{"reclaim-timer", "flush-timer", "hold-time"} {
+		tree := &ConfigTree{}
+		cmd := "set system services dhcp-local-server expired-leases-processing " + timer + " 0"
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+		cfg, _ := CompileConfig(tree)
+		err = SchemaValidate(tree, cfg)
+		if err == nil || !strings.Contains(err.Error(), timer) {
+			t.Fatalf("%s 0 must be rejected (Min(1)), got %v", timer, err)
+		}
+	}
+}
+
+// TestDHCPExpiredLeasesSchemaAcceptsCapZero pins the other half of the floor
+// split: the CAP knobs (max-leases, max-time) use ValidateIntegerMin(0), so
+// 0 (= unlimited in Kea) is accepted at commit-check. unwarned-cycles is
+// also Min(0).
+func TestDHCPExpiredLeasesSchemaAcceptsCapZero(t *testing.T) {
+	tree := &ConfigTree{}
+	cmds := []string{
+		"set system services dhcp-local-server expired-leases-processing enable",
+		"set system services dhcp-local-server expired-leases-processing max-leases 0",
+		"set system services dhcp-local-server expired-leases-processing max-time 0",
+		"set system services dhcp-local-server expired-leases-processing unwarned-cycles 0",
+	}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, _ := CompileConfig(tree)
+	if err := SchemaValidate(tree, cfg); err != nil {
+		t.Fatalf("cap knobs at 0 (unlimited) must pass commit-check, got %v", err)
+	}
+}
+
+// TestDHCPExpiredLeasesSchemaRejectsNonInteger: a non-integer value for a
+// typed leaf is rejected at commit-check.
+func TestDHCPExpiredLeasesSchemaRejectsNonInteger(t *testing.T) {
+	tree := &ConfigTree{}
+	cmd := "set system services dhcp-local-server expired-leases-processing reclaim-timer notanumber"
+	path, err := ParseSetCommand(cmd)
+	if err != nil {
+		t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+	}
+	if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath(%q): %v", cmd, err)
+	}
+	cfg, _ := CompileConfig(tree)
+	err = SchemaValidate(tree, cfg)
+	if err == nil || !strings.Contains(err.Error(), "reclaim-timer") {
+		t.Fatalf("non-integer reclaim-timer must be rejected, got %v", err)
+	}
+}
+
+// TestDHCPExpiredLeasesLenientCompile: a config carrying the block (even a
+// timer value a later range-tightening would reject) must still COMPILE on
+// the lenient load / peer-sync path — the model build is the shared
+// compileExpanded core, so both the strict and lenient sites land it
+// (invariant R4 / H7). The schema gate is separate and runs leniently as a
+// warning on those paths (exercised in pkg/configstore).
+func TestDHCPExpiredLeasesLenientCompile(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set system services dhcp-local-server expired-leases-processing enable",
+		"set system services dhcp-local-server expired-leases-processing reclaim-timer 10",
+		"set system services dhcpv6-local-server expired-leases-processing enable",
+		"set system services dhcpv6-local-server expired-leases-processing max-leases 0",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must compile the block, got %v", err)
+	}
+	if elpV4(t, cfg) == nil || !elpV4(t, cfg).Enabled {
+		t.Fatal("lenient compile dropped the v4 block")
+	}
+	c6 := elpV6(t, cfg)
+	if c6 == nil || !c6.MaxReclaimLeasesSet {
+		t.Fatalf("lenient compile dropped the v6 block / max-leases set state: %+v", c6)
+	}
+}

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -332,7 +332,8 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 					"static-binding": dhcpStaticBindingSchema(),
 				}},
 			}},
-			"dynamic-dns": dhcpDynamicDNSSchema(),
+			"dynamic-dns":               dhcpDynamicDNSSchema(),
+			"expired-leases-processing": dhcpExpiredLeasesSchema(),
 		}},
 		"dhcpv6-local-server": {desc: "DHCPv6 local server", children: map[string]*schemaNode{
 			"group": {desc: "DHCPv6 group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
@@ -340,7 +341,8 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 					"static-binding": dhcpStaticBindingSchema(),
 				}},
 			}},
-			"dynamic-dns": dhcpDynamicDNSSchema(),
+			"dynamic-dns":               dhcpDynamicDNSSchema(),
+			"expired-leases-processing": dhcpExpiredLeasesSchema(),
 		}},
 	}},
 }}
@@ -621,6 +623,82 @@ func dhcpDynamicDNSSchema() *schemaNode {
 			args:        1,
 			placeholder: "<secret>",
 			children:    nil,
+		},
+	}}
+}
+
+// dhcpExpiredLeasesSchema returns the typed-leaf schema for the #1387
+// stale-lease-cleanup slice (Path S): the per-family
+// `expired-leases-processing` reclamation block, shared by
+// dhcp-local-server and dhcpv6-local-server. Returned fresh per call so
+// the two parents do not alias a mutable map (same pattern as
+// dhcpDynamicDNSSchema / dhcpStaticBindingSchema).
+//
+// Floor split (SMR MAJOR-3, fail-safe default): the three TIMERS
+// (reclaim/flush/hold) use ValidateIntegerMin(1) because a 0 some Kea
+// versions reject would take DHCP DOWN on the fail-closed restart; the
+// two CAP knobs (max-leases, max-time) use ValidateIntegerMin(0) because
+// Kea documents 0 = unlimited there (a value the model tracks distinctly
+// from unset — invariant H2), and unwarned-cycles uses Min(0). Kea has
+// no documented hard upper bound on these knobs, so min-only validation
+// is correct (no schema-only cap, per the docs/config-schema.md range
+// policy).
+func dhcpExpiredLeasesSchema() *schemaNode {
+	return &schemaNode{desc: "Kea expired-lease reclamation policy (#1387)", children: map[string]*schemaNode{
+		"enable": {desc: "Enable expired-lease reclamation tuning", children: nil},
+		"reclaim-timer": {
+			desc:          "Seconds between reclamation cycles (reclaim-timer-wait-time)",
+			args:          1,
+			valueType:     ValueInteger,
+			valueDesc:     "Seconds (>= 1)",
+			valueExamples: []string{"10"},
+			validator:     ValidateIntegerMin(1),
+			children:      nil,
+		},
+		"flush-timer": {
+			desc:          "Seconds between reclaimed-lease flush passes (flush-reclaimed-timer-wait-time)",
+			args:          1,
+			valueType:     ValueInteger,
+			valueDesc:     "Seconds (>= 1)",
+			valueExamples: []string{"25"},
+			validator:     ValidateIntegerMin(1),
+			children:      nil,
+		},
+		"hold-time": {
+			desc:          "Seconds a reclaimed lease is held before removal (hold-reclaimed-time)",
+			args:          1,
+			valueType:     ValueInteger,
+			valueDesc:     "Seconds (>= 1)",
+			valueExamples: []string{"600"},
+			validator:     ValidateIntegerMin(1),
+			children:      nil,
+		},
+		"max-leases": {
+			desc:          "Maximum leases reclaimed per cycle, 0 = unlimited (max-reclaim-leases)",
+			args:          1,
+			valueType:     ValueInteger,
+			valueDesc:     "Leases per cycle (>= 0; 0 = unlimited)",
+			valueExamples: []string{"100", "0"},
+			validator:     ValidateIntegerMin(0),
+			children:      nil,
+		},
+		"max-time": {
+			desc:          "Max milliseconds spent reclaiming per cycle, 0 = unlimited (max-reclaim-time)",
+			args:          1,
+			valueType:     ValueInteger,
+			valueDesc:     "Milliseconds (>= 0; 0 = unlimited)",
+			valueExamples: []string{"250", "0"},
+			validator:     ValidateIntegerMin(0),
+			children:      nil,
+		},
+		"unwarned-cycles": {
+			desc:          "Consecutive capped cycles before Kea warns (unwarned-reclaim-cycles)",
+			args:          1,
+			valueType:     ValueInteger,
+			valueDesc:     "Cycles (>= 0)",
+			valueExamples: []string{"5"},
+			validator:     ValidateIntegerMin(0),
+			children:      nil,
 		},
 	}}
 }

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -12,29 +12,29 @@ import (
 
 // SystemConfig holds system-level configuration.
 type SystemConfig struct {
-	HostName                 string
-	DomainName               string   // system domain-name (e.g. "example.com")
-	DomainSearch             []string // system domain-search (search domains)
-	TimeZone                 string
-	NameServers              []string // DNS server addresses
-	NTPServers               []string // NTP server addresses
-	NTPThreshold             int      // NTP threshold in seconds (0 = default)
-	NTPThresholdAction       string   // "accept" or "reject"
-	NoRedirects              bool     // disable ICMP redirects
-	BackupRouter             string   // backup default gateway IP
-	BackupRouterDst          string   // backup router destination prefix
-	Lo0FilterInputV4         string   // lo0 unit 0 family inet filter input (host-bound filtering)
-	Lo0FilterInputV6         string   // lo0 unit 0 family inet6 filter input (host-bound filtering)
-	DataplaneType            string   // empty defaults to "userspace"; explicit "ebpf" is legacy; "dpdk" is retired (#1525) and tolerated via rewriteRetiredDataplaneType (pkg/configstore/dataplane_retire.go) at both Store.Load and Store.SyncApply for stored-config rolling upgrade
-	UserspaceDataplane       *UserspaceConfig
-	InternetOptions          *InternetOptionsConfig
-	Services                 *SystemServicesConfig
-	Syslog                   *SystemSyslogConfig
-	DHCPServer               DHCPServerConfig
-	SNMP                     *SNMPConfig
-	Login                    *LoginConfig
-	RootAuthentication       *RootAuthConfig
-	Archival                 *ArchivalConfig
+	HostName           string
+	DomainName         string   // system domain-name (e.g. "example.com")
+	DomainSearch       []string // system domain-search (search domains)
+	TimeZone           string
+	NameServers        []string // DNS server addresses
+	NTPServers         []string // NTP server addresses
+	NTPThreshold       int      // NTP threshold in seconds (0 = default)
+	NTPThresholdAction string   // "accept" or "reject"
+	NoRedirects        bool     // disable ICMP redirects
+	BackupRouter       string   // backup default gateway IP
+	BackupRouterDst    string   // backup router destination prefix
+	Lo0FilterInputV4   string   // lo0 unit 0 family inet filter input (host-bound filtering)
+	Lo0FilterInputV6   string   // lo0 unit 0 family inet6 filter input (host-bound filtering)
+	DataplaneType      string   // empty defaults to "userspace"; explicit "ebpf" is legacy; "dpdk" is retired (#1525) and tolerated via rewriteRetiredDataplaneType (pkg/configstore/dataplane_retire.go) at both Store.Load and Store.SyncApply for stored-config rolling upgrade
+	UserspaceDataplane *UserspaceConfig
+	InternetOptions    *InternetOptionsConfig
+	Services           *SystemServicesConfig
+	Syslog             *SystemSyslogConfig
+	DHCPServer         DHCPServerConfig
+	SNMP               *SNMPConfig
+	Login              *LoginConfig
+	RootAuthentication *RootAuthConfig
+	Archival           *ArchivalConfig
 	// MasterPassword is a misnomer kept for the Junos token: it holds the
 	// `system master-password pseudorandom-function <fn>` value, i.e. the PRF
 	// ALGORITHM-SELECTOR NAME (e.g. hmac-sha256), NOT key material. The actual
@@ -413,9 +413,9 @@ const (
 // H6) is derived from it so the commit-time validator and the runtime RBAC
 // table can never drift apart.
 var LoginClassPermissions = map[string][]LoginClassPermission{
-	"super-user":    {PermAll},
-	"operator":      {PermView, PermClear, PermControl},
-	"read-only":     {PermView},
+	"super-user": {PermAll},
+	"operator":   {PermView, PermClear, PermControl},
+	"read-only":  {PermView},
 	// config-viewer can view (including config display, which routes through
 	// `show`) but cannot enter configure to modify, clear, or operate (#2008
 	// H6). Within the current coarse permission model that is PermView only.
@@ -937,6 +937,65 @@ func (d *DHCPDynamicDNSConfig) String() string {
 // DHCPLocalServerConfig holds per-group DHCP server settings.
 type DHCPLocalServerConfig struct {
 	Groups map[string]*DHCPServerGroup
+	// ExpiredLeases is the opt-in Kea expired-lease reclamation policy
+	// (#1387 stale-lease-cleanup slice / Path S). nil == today's
+	// behaviour byte-for-byte: no `expired-leases-processing` block is
+	// rendered and Kea uses its built-in reclamation defaults. The block
+	// is GLOBAL to the family — Kea has no per-subnet reclamation — so it
+	// sits here on DHCPLocalServerConfig (one per family: dhcp-local-server
+	// for v4, dhcpv6-local-server for v6), not on DHCPPool. v4 and v6 are
+	// tuned independently because Kea renders the block per Dhcp4 / Dhcp6.
+	ExpiredLeases *DHCPExpiredLeasesConfig
+}
+
+// DHCPExpiredLeasesConfig maps to Kea's per-family
+// `expired-leases-processing` block (#1387 stale-lease-cleanup slice).
+// It controls how aggressively Kea REMOVES leases that have ALREADY
+// expired/been released/declined from the memfile — it is ORTHOGONAL to
+// lease-time (DHCPPool.LeaseTime / the hardcoded valid-lifetime), which
+// sets how long a lease stays VALID (invariant H4). Field
+// units/semantics are Kea-native (the operator types Kea numbers); see
+// https://kea.readthedocs.io for the authoritative meaning.
+//
+// Rendering is opt-in: a nil block OR Enabled==false renders NOTHING, so
+// the generated Kea config is byte-identical to today (invariant H1).
+// Each numeric field is emitted only when set, so an operator can flip
+// `enable` on and tune one knob without pinning the rest to a value we
+// invented.
+type DHCPExpiredLeasesConfig struct {
+	// Enabled gates rendering of the whole block. A block that parses but
+	// never sets `enable` still renders nothing (explicit opt-in, mirrors
+	// DHCPDynamicDNSConfig.Enabled).
+	Enabled bool
+	// ReclaimTimerWait is seconds between reclamation cycles
+	// (reclaim-timer-wait-time). 0 == unset -> the key is omitted and Kea
+	// uses its default.
+	ReclaimTimerWait int
+	// FlushReclaimedTimerWait is seconds between flush passes that remove
+	// reclaimed leases past hold-time (flush-reclaimed-timer-wait-time).
+	// 0 == unset -> omitted.
+	FlushReclaimedTimerWait int
+	// HoldReclaimedTime is seconds a reclaimed lease is retained before
+	// physical removal (hold-reclaimed-time). 0 == unset -> omitted. (Kea
+	// keeps a reclaimed lease this long so a renewing client reclaims its
+	// own address.)
+	HoldReclaimedTime int
+	// MaxReclaimLeases caps leases reclaimed per cycle (max-reclaim-leases).
+	// In Kea, 0 means UNLIMITED — a DIFFERENT desired state from "omit the
+	// key and inherit Kea's default" — so the model MUST distinguish a
+	// value of 0 from unset (invariant H2). MaxReclaimLeasesSet is true
+	// exactly when the operator configured `max-leases`; a bare `if x > 0`
+	// render would make `max-leases 0` (unlimited) un-expressible.
+	MaxReclaimLeases    int
+	MaxReclaimLeasesSet bool
+	// MaxReclaimTime caps milliseconds spent reclaiming per cycle
+	// (max-reclaim-time). 0 means UNLIMITED in Kea, so it uses the same
+	// set/unset discipline as MaxReclaimLeases (invariant H2).
+	MaxReclaimTime    int
+	MaxReclaimTimeSet bool
+	// UnwarnedReclaimCycles is consecutive cycles hitting the cap before
+	// Kea warns (unwarned-reclaim-cycles). 0 == unset -> omitted.
+	UnwarnedReclaimCycles int
 }
 
 // DHCPServerGroup defines a DHCP server group.

--- a/pkg/configstore/typed_leaf_lenient_test.go
+++ b/pkg/configstore/typed_leaf_lenient_test.go
@@ -178,6 +178,69 @@ func TestLoad_ToleratesStoredUnknownPollMode(t *testing.T) {
 	}
 }
 
+// #1387 stale-lease-cleanup slice (Path S) — boot/HA safety (invariant
+// H7 / R4). A stored config that committed an expired-leases-processing
+// timer of 0 BEFORE the Min(1) floor existed (or a peer-synced config from
+// an un-upgraded primary) must still LOAD — the schema gate downgrades to a
+// warning on the tolerant Load / SyncApply path. The compiler (the shared
+// compileExpanded core) lands the block on both strict and lenient sites,
+// so the block is present in the loaded active config, and the next strict
+// operator commit rejects the bad value loudly.
+func TestLoad_ToleratesStoredExpiredLeasesTimerZero(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config")
+	writeStoredConfig(t, cfgPath,
+		"set system services dhcp-local-server expired-leases-processing enable",
+		"set system services dhcp-local-server expired-leases-processing reclaim-timer 0")
+
+	s := newTestStoreAt(t, cfgPath)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load() must tolerate a stored expired-leases timer 0, got: %v", err)
+	}
+	active := s.ActiveConfig()
+	if active == nil {
+		t.Fatal("ActiveConfig() is nil after tolerated Load")
+	}
+	// The block must be present (compiled on the lenient path too — R4).
+	ls := active.System.DHCPServer.DHCPLocalServer
+	if ls == nil || ls.ExpiredLeases == nil || !ls.ExpiredLeases.Enabled {
+		t.Fatalf("lenient Load dropped the expired-leases block: %+v", ls)
+	}
+
+	// The next STRICT operator commit must reject the bad timer.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	_, err := s.CommitCheck()
+	if err == nil {
+		t.Fatal("CommitCheck must reject the stored timer 0, got nil")
+	}
+	if !strings.Contains(err.Error(), "reclaim-timer") {
+		t.Fatalf("CommitCheck error should reference reclaim-timer: %v", err)
+	}
+}
+
+// HA config sync from a primary carrying a sub-floor timer must not
+// alarm-loop the standby: SyncApply uses the same lenient path as Load.
+func TestSyncApply_ToleratesExpiredLeasesTimerZero(t *testing.T) {
+	s := newTestStoreAt(t, filepath.Join(t.TempDir(), "config"))
+	cfg, err := s.SyncApply(`system {
+    services {
+        dhcp-local-server {
+            expired-leases-processing {
+                enable;
+                reclaim-timer 0;
+            }
+        }
+    }
+}`, nil)
+	if err != nil {
+		t.Fatalf("SyncApply must tolerate a sub-floor expired-leases timer, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("SyncApply returned nil config on tolerated violation")
+	}
+}
+
 // #1319 PR 3 — firewall forwarding-class cross-ref, end-to-end through
 // the PRODUCTION gate path (Store commit-check / Load / SyncApply, the
 // call sites that pass cfg=nil to SchemaValidate). These are the proving

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -113,6 +113,97 @@ subtree with an IPv6 `fixed-address`.)
   separate companion gap, #2239.) ISC Kea handles static reservations
   entirely in the config file, independent of its HA hook.
 
+## Expired-lease reclamation — #1387 (stale-lease-cleanup slice / Path S)
+
+The "stale lease cleanup" half of #1387. Kea keeps an expired / released /
+declined lease ROW in its memfile (`kea-leases4.csv` / `kea-leases6.csv`)
+as an appended record until its reclamation cycle removes it; the defaults
+are conservative. Without tuning, expired rows accumulate — they bloat the
+memfile, slow startup re-load, and delay Kea's internal reclamation/reuse
+of the expired address. (They do NOT make `show dhcp-server` lie: since
+#2085 the lease display already filters non-active / expired rows, so the
+display is truthful today. This slice makes the *source* truthful by
+actually removing the rows Kea would otherwise keep.) This is the
+DHCP-lease-database layer — entirely distinct from the DDNS stale-*record*
+cleanup below (the reconciler withdrawing A/AAAA/PTR when a lease leaves
+the active set).
+
+Opt-in, per family, Junos-shaped — the keys map to Kea's per-`Dhcp4` /
+per-`Dhcp6` `expired-leases-processing` block:
+
+```
+set system services dhcp-local-server expired-leases-processing enable
+set system services dhcp-local-server expired-leases-processing reclaim-timer 10
+set system services dhcp-local-server expired-leases-processing flush-timer 25
+set system services dhcp-local-server expired-leases-processing hold-time 600
+set system services dhcp-local-server expired-leases-processing max-leases 100
+set system services dhcp-local-server expired-leases-processing max-time 250
+set system services dhcp-local-server expired-leases-processing unwarned-cycles 5
+```
+
+(The `dhcpv6-local-server` hierarchy takes the same subtree; v4 and v6 are
+tuned independently because Kea renders the block once per family.)
+
+- **Reclamation is GLOBAL per family, NOT per pool.** Kea's
+  `expired-leases-processing` is a top-level `Dhcp4`/`Dhcp6` block — there
+  is no per-subnet reclamation. The config model therefore attaches to the
+  per-family `DHCPLocalServerConfig.ExpiredLeases`
+  (`pkg/config/types_system.go`), never to `DHCPPool` (invariant H3).
+- **Reclamation is ORTHOGONAL to lease-time (invariant H4).** `valid-lifetime`
+  / per-pool `lease-time` set how long a lease stays VALID;
+  `expired-leases-processing` sets how aggressively Kea REMOVES leases that
+  have ALREADY expired. This slice does NOT touch lease-time — do not
+  conflate the two.
+- **Config model:** `DHCPExpiredLeasesConfig` carries `Enabled` plus the six
+  Kea knobs. The two CAP knobs (`max-leases` → `max-reclaim-leases`,
+  `max-time` → `max-reclaim-time`) carry a companion `*Set bool` because in
+  Kea **0 means UNLIMITED** there — a value distinct from "omit the key and
+  inherit Kea's default" (invariant H2). The model tracks set-vs-unset so an
+  operator can express `max-leases 0` (unlimited) distinctly from not
+  configuring it; a naive `if x > 0` render would make 0 un-expressible. The
+  schema is `dhcpExpiredLeasesSchema()` (`pkg/config/schema_system.go`),
+  returned fresh per call so the two parents do not alias a mutable map.
+- **Schema floor split (fail-safe):** the three TIMERS (`reclaim-timer`,
+  `flush-timer`, `hold-time`) use `ValidateIntegerMin(1)` because a 0 some
+  Kea versions reject would take DHCP DOWN on the fail-closed restart; the
+  two CAP knobs use `ValidateIntegerMin(0)` (0 = unlimited is documented Kea
+  behaviour) and `unwarned-cycles` is `Min(0)`. No schema-only upper cap
+  (Kea documents no hard ceiling; min-only validation per the
+  `docs/config-schema.md` range policy).
+- **Compile:** `compileDHCPExpiredLeases` (`pkg/config/compiler_services.go`),
+  handling both the hierarchical and flat-set AST shapes (walk +
+  first-value-wins, mirroring `compileDHCPDynamicDNS`); a truly empty /
+  garbage block returns nil (no block forced on, nothing rendered —
+  closing the empty-tree-compiles-non-nil trap). It runs inside the shared
+  `compileExpanded` core, so it lands on BOTH the strict commit and the
+  tolerant load / peer-sync compile sites — a peer-synced or stored config
+  carrying the block compiles on both (invariant R4); the typed-leaf schema
+  gate hard-rejects on commit but downgrades to a warning on Load /
+  SyncApply (boot/HA safety, invariant H7).
+- **Kea render:** `keaExpiredLeasesMap` (`pkg/dhcpserver/dhcpserver.go`)
+  renders the per-family `expired-leases-processing` JSON, or nil when the
+  block is absent OR disabled (UNCONDITIONAL omit → byte-identical to
+  pre-#1387 output, the cardinal invariant H1). Each numeric field emits
+  only when set (an operator tunes one knob without pinning the rest); the
+  two cap knobs emit on their `*Set` bool so `max-reclaim-leases: 0`
+  (unlimited) is rendered distinctly. `Enabled` with no knobs renders a
+  present empty `{}` (Kea reads it as "reclaim with built-in defaults"; the
+  block surfaces that the feature is on).
+- **No service-lifecycle / HA change.** The block is read by Kea on the
+  existing (re)start / reconfigure path exactly like every other generated
+  key — no new `systemctl` call, no extra daemon. It is in the
+  MASTER-filtered config each node already renders, so it is HA-neutral by
+  construction.
+
+**Validation status:** fully unit-tested (golden render for v4/v6,
+disabled/absent omit, `max-leases 0` vs unset, per-family independence,
+dual-AST compile, schema completion + commit-check floor split, stored /
+peer-sync lenient tolerance). End-to-end reclamation against a live Kea
+(hand a lease, let it expire, confirm the row is removed within
+`reclaim-timer + flush-timer + hold-time`) is lab-deferred — the unit
+golden is the binding gate; a `kea-dhcp4 -t <generated.json>` acceptance
+check on deploy confirms Kea parses the rendered block.
+
 ## Dynamic DNS (DDNS) — #1387, increment 1
 
 Opt-in publishing of forward (`A`/`AAAA`) and reverse (`PTR`) DNS records

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -657,6 +657,50 @@ func canonicalMAC(mac string) (string, bool) {
 	return hw.String(), true
 }
 
+// keaExpiredLeasesMap renders the per-family `expired-leases-processing`
+// reclamation block (#1387 stale-lease-cleanup slice / Path S), or nil
+// when the block is absent OR disabled. Returning nil makes the caller
+// omit the key entirely, so the generated Kea config is BYTE-IDENTICAL to
+// the pre-#1387 output (invariant H1, the cardinal compatibility
+// invariant — the disabled/nil omit is UNCONDITIONAL).
+//
+// Each numeric field is emitted only when set, so an operator can tune one
+// knob without pinning the rest to a value we invented. The two CAP knobs
+// (max-reclaim-leases / max-reclaim-time) emit on the model's *Set bool,
+// NOT on `> 0`, because 0 means UNLIMITED in Kea — a value distinct from
+// "omit -> Kea default" (invariant H2).
+//
+// When Enabled is true but no knob is configured this returns a non-nil
+// empty map, so the caller emits `"expired-leases-processing": {}` — Kea
+// reads an empty block as "reclamation with built-in defaults," and
+// surfacing the empty block lets an operator see the feature is on in the
+// rendered config.
+func keaExpiredLeasesMap(c *config.DHCPExpiredLeasesConfig) map[string]any {
+	if c == nil || !c.Enabled {
+		return nil
+	}
+	m := map[string]any{}
+	if c.ReclaimTimerWait > 0 {
+		m["reclaim-timer-wait-time"] = c.ReclaimTimerWait
+	}
+	if c.FlushReclaimedTimerWait > 0 {
+		m["flush-reclaimed-timer-wait-time"] = c.FlushReclaimedTimerWait
+	}
+	if c.HoldReclaimedTime > 0 {
+		m["hold-reclaimed-time"] = c.HoldReclaimedTime
+	}
+	if c.MaxReclaimLeasesSet {
+		m["max-reclaim-leases"] = c.MaxReclaimLeases // 0 == unlimited, intentional (H2)
+	}
+	if c.MaxReclaimTimeSet {
+		m["max-reclaim-time"] = c.MaxReclaimTime // 0 == unlimited, intentional (H2)
+	}
+	if c.UnwarnedReclaimCycles > 0 {
+		m["unwarned-reclaim-cycles"] = c.UnwarnedReclaimCycles
+	}
+	return m
+}
+
 func (m *Manager) generateKea4Config(cfg *config.DHCPServerConfig) error {
 	type keaPool struct {
 		Pool string `json:"pool"`
@@ -757,6 +801,11 @@ func (m *Manager) generateKea4Config(cfg *config.DHCPServerConfig) error {
 		},
 		"valid-lifetime": 86400,
 		"subnet4":        subnets,
+	}
+	// #1387: opt-in expired-lease reclamation tuning. nil/disabled -> key
+	// omitted -> byte-identical to pre-#1387 (H1).
+	if elp := keaExpiredLeasesMap(cfg.DHCPLocalServer.ExpiredLeases); elp != nil {
+		dhcp4["expired-leases-processing"] = elp
 	}
 	m.addLeaseSyncStanza(dhcp4, 4)
 	keaCfg := map[string]any{"Dhcp4": dhcp4}
@@ -867,6 +916,11 @@ func (m *Manager) generateKea6Config(cfg *config.DHCPServerConfig) error {
 		},
 		"valid-lifetime": 86400,
 		"subnet6":        subnets,
+	}
+	// #1387: opt-in expired-lease reclamation tuning. nil/disabled -> key
+	// omitted -> byte-identical to pre-#1387 (H1).
+	if elp := keaExpiredLeasesMap(cfg.DHCPv6LocalServer.ExpiredLeases); elp != nil {
+		dhcp6["expired-leases-processing"] = elp
 	}
 	m.addLeaseSyncStanza(dhcp6, 6)
 	keaCfg := map[string]any{"Dhcp6": dhcp6}

--- a/pkg/dhcpserver/expired_leases_test.go
+++ b/pkg/dhcpserver/expired_leases_test.go
@@ -1,0 +1,307 @@
+package dhcpserver
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// keaELPView reads back the rendered `expired-leases-processing` block from
+// either a Dhcp4 or Dhcp6 generated config. Using json.RawMessage for the
+// block lets us distinguish an ABSENT key (nil) from a present-but-empty
+// block ({}) — the H1 vs enabled-no-knobs distinction.
+type keaELPDoc struct {
+	Dhcp4 struct {
+		ExpiredLeases json.RawMessage `json:"expired-leases-processing"`
+	} `json:"Dhcp4"`
+	Dhcp6 struct {
+		ExpiredLeases json.RawMessage `json:"expired-leases-processing"`
+	} `json:"Dhcp6"`
+}
+
+func readELPRaw(t *testing.T, path string, family int) json.RawMessage {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc keaELPDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal kea%d: %v", family, err)
+	}
+	if family == 6 {
+		return doc.Dhcp6.ExpiredLeases
+	}
+	return doc.Dhcp4.ExpiredLeases
+}
+
+func readELPMap(t *testing.T, path string, family int) map[string]any {
+	t.Helper()
+	raw := readELPRaw(t, path, family)
+	if raw == nil {
+		t.Fatalf("expired-leases-processing key absent in kea%d (%s)", family, path)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal expired-leases-processing kea%d: %v", family, err)
+	}
+	return m
+}
+
+func v6Config(ifaces ...string) *config.DHCPServerConfig {
+	return &config.DHCPServerConfig{
+		DHCPv6LocalServer: &config.DHCPLocalServerConfig{
+			Groups: map[string]*config.DHCPServerGroup{
+				"g0": {
+					Name:       "g0",
+					Interfaces: ifaces,
+					Pools: []*config.DHCPPool{{
+						Name:     "p0",
+						Subnet:   "2001:db8::/64",
+						RangeLow: "2001:db8::100", RangeHigh: "2001:db8::200",
+					}},
+				},
+			},
+		},
+	}
+}
+
+// wantInt asserts a JSON number field equals want (JSON numbers decode to
+// float64 into an `any` map).
+func wantInt(t *testing.T, m map[string]any, key string, want int) {
+	t.Helper()
+	v, ok := m[key]
+	if !ok {
+		t.Errorf("expired-leases-processing missing key %q (%+v)", key, m)
+		return
+	}
+	f, ok := v.(float64)
+	if !ok {
+		t.Errorf("key %q: want number, got %T (%v)", key, v, v)
+		return
+	}
+	if int(f) != want {
+		t.Errorf("key %q: got %d, want %d", key, int(f), want)
+	}
+}
+
+func wantAbsent(t *testing.T, m map[string]any, key string) {
+	t.Helper()
+	if _, ok := m[key]; ok {
+		t.Errorf("key %q should be omitted, got %v", key, m[key])
+	}
+}
+
+// TestKea4ExpiredLeasesOmittedWhenAbsent is the cardinal H1 test (v4): a
+// config WITHOUT an expired-leases-processing block must omit the key
+// entirely, byte-identical to pre-#1387 output.
+func TestKea4ExpiredLeasesOmittedWhenAbsent(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	if err := m.Apply(v4Config("ge-0-0-0")); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if raw := readELPRaw(t, m.confPath4, 4); raw != nil {
+		t.Errorf("config without expired-leases-processing must omit the key, got %s", raw)
+	}
+}
+
+// TestKea6ExpiredLeasesOmittedWhenAbsent is the cardinal H1 test (v6).
+func TestKea6ExpiredLeasesOmittedWhenAbsent(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	if err := m.Apply(v6Config("ge-0-0-0")); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if raw := readELPRaw(t, m.confPath6, 6); raw != nil {
+		t.Errorf("config without expired-leases-processing must omit the key, got %s", raw)
+	}
+}
+
+// TestKeaExpiredLeasesDisabledBlockOmitted is the H1 disabled-omit test: a
+// PRESENT but Enabled==false block (even with knobs set) must STILL omit
+// the key. The disabled omit is unconditional (SMR MAJOR-1).
+func TestKeaExpiredLeasesDisabledBlockOmitted(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	cfg := v4Config("ge-0-0-0")
+	cfg.DHCPLocalServer.ExpiredLeases = &config.DHCPExpiredLeasesConfig{
+		Enabled:           false,
+		ReclaimTimerWait:  10,
+		HoldReclaimedTime: 600,
+	}
+	if err := m.Apply(cfg); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if raw := readELPRaw(t, m.confPath4, 4); raw != nil {
+		t.Errorf("disabled block must omit the key, got %s", raw)
+	}
+}
+
+// TestKea4ExpiredLeasesRendersAllKnobs is the FAIL-ON-REVERT render proof
+// (v4): an enabled block with every knob set renders the exact Kea
+// expired-leases-processing JSON. Deleting the call site or the helper drops
+// the key and fails this test.
+func TestKea4ExpiredLeasesRendersAllKnobs(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	cfg := v4Config("ge-0-0-0")
+	cfg.DHCPLocalServer.ExpiredLeases = &config.DHCPExpiredLeasesConfig{
+		Enabled:                 true,
+		ReclaimTimerWait:        10,
+		FlushReclaimedTimerWait: 25,
+		HoldReclaimedTime:       600,
+		MaxReclaimLeases:        100,
+		MaxReclaimLeasesSet:     true,
+		MaxReclaimTime:          250,
+		MaxReclaimTimeSet:       true,
+		UnwarnedReclaimCycles:   5,
+	}
+	if err := m.Apply(cfg); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	elp := readELPMap(t, m.confPath4, 4)
+	wantInt(t, elp, "reclaim-timer-wait-time", 10)
+	wantInt(t, elp, "flush-reclaimed-timer-wait-time", 25)
+	wantInt(t, elp, "hold-reclaimed-time", 600)
+	wantInt(t, elp, "max-reclaim-leases", 100)
+	wantInt(t, elp, "max-reclaim-time", 250)
+	wantInt(t, elp, "unwarned-reclaim-cycles", 5)
+}
+
+// TestKea6ExpiredLeasesRendersAllKnobs is the v6 FAIL-ON-REVERT render proof.
+func TestKea6ExpiredLeasesRendersAllKnobs(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	cfg := v6Config("ge-0-0-0")
+	cfg.DHCPv6LocalServer.ExpiredLeases = &config.DHCPExpiredLeasesConfig{
+		Enabled:                 true,
+		ReclaimTimerWait:        7,
+		FlushReclaimedTimerWait: 14,
+		HoldReclaimedTime:       1800,
+		MaxReclaimLeases:        50,
+		MaxReclaimLeasesSet:     true,
+		MaxReclaimTime:          100,
+		MaxReclaimTimeSet:       true,
+		UnwarnedReclaimCycles:   3,
+	}
+	if err := m.Apply(cfg); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	elp := readELPMap(t, m.confPath6, 6)
+	wantInt(t, elp, "reclaim-timer-wait-time", 7)
+	wantInt(t, elp, "flush-reclaimed-timer-wait-time", 14)
+	wantInt(t, elp, "hold-reclaimed-time", 1800)
+	wantInt(t, elp, "max-reclaim-leases", 50)
+	wantInt(t, elp, "max-reclaim-time", 100)
+	wantInt(t, elp, "unwarned-reclaim-cycles", 3)
+}
+
+// TestKeaExpiredLeasesMaxLeasesZeroVsUnset pins invariant H2: max-leases 0
+// (unlimited) renders "max-reclaim-leases": 0 distinctly from not setting it
+// (key omitted). A naive `if x > 0` render would make 0 (unlimited)
+// un-expressible. Same discipline for max-time.
+func TestKeaExpiredLeasesMaxLeasesZeroVsUnset(t *testing.T) {
+	t.Run("max-leases 0 renders 0 (unlimited)", func(t *testing.T) {
+		m, _ := testManager(t, map[string]bool{}, "")
+		cfg := v4Config("ge-0-0-0")
+		cfg.DHCPLocalServer.ExpiredLeases = &config.DHCPExpiredLeasesConfig{
+			Enabled:             true,
+			MaxReclaimLeases:    0,
+			MaxReclaimLeasesSet: true,
+			MaxReclaimTime:      0,
+			MaxReclaimTimeSet:   true,
+		}
+		if err := m.Apply(cfg); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		elp := readELPMap(t, m.confPath4, 4)
+		wantInt(t, elp, "max-reclaim-leases", 0)
+		wantInt(t, elp, "max-reclaim-time", 0)
+	})
+
+	t.Run("max-leases unset omits the key", func(t *testing.T) {
+		m, _ := testManager(t, map[string]bool{}, "")
+		cfg := v4Config("ge-0-0-0")
+		cfg.DHCPLocalServer.ExpiredLeases = &config.DHCPExpiredLeasesConfig{
+			Enabled:          true,
+			ReclaimTimerWait: 10,
+			// MaxReclaimLeasesSet / MaxReclaimTimeSet stay false.
+		}
+		if err := m.Apply(cfg); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		elp := readELPMap(t, m.confPath4, 4)
+		wantInt(t, elp, "reclaim-timer-wait-time", 10)
+		wantAbsent(t, elp, "max-reclaim-leases")
+		wantAbsent(t, elp, "max-reclaim-time")
+	})
+}
+
+// TestKeaExpiredLeasesOneKnobOmitsRest proves each numeric field emits only
+// when set: enabling with a single timer renders just that key, leaving the
+// rest absent (an operator tunes one knob without pinning the others).
+func TestKeaExpiredLeasesOneKnobOmitsRest(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	cfg := v4Config("ge-0-0-0")
+	cfg.DHCPLocalServer.ExpiredLeases = &config.DHCPExpiredLeasesConfig{
+		Enabled:          true,
+		ReclaimTimerWait: 30,
+	}
+	if err := m.Apply(cfg); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	elp := readELPMap(t, m.confPath4, 4)
+	wantInt(t, elp, "reclaim-timer-wait-time", 30)
+	for _, k := range []string{
+		"flush-reclaimed-timer-wait-time", "hold-reclaimed-time",
+		"max-reclaim-leases", "max-reclaim-time", "unwarned-reclaim-cycles",
+	} {
+		wantAbsent(t, elp, k)
+	}
+}
+
+// TestKeaExpiredLeasesEnabledNoKnobsEmptyBlock pins Open Q1's resolution:
+// Enabled==true with no knobs renders a present empty block ({}), NOT an
+// absent key, so the operator sees the feature is on. (Distinct from the
+// disabled/nil unconditional omit of H1.)
+func TestKeaExpiredLeasesEnabledNoKnobsEmptyBlock(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	cfg := v4Config("ge-0-0-0")
+	cfg.DHCPLocalServer.ExpiredLeases = &config.DHCPExpiredLeasesConfig{Enabled: true}
+	if err := m.Apply(cfg); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	raw := readELPRaw(t, m.confPath4, 4)
+	if raw == nil {
+		t.Fatal("enabled-no-knobs must render a present empty block, got absent key")
+	}
+	elp := readELPMap(t, m.confPath4, 4)
+	if len(elp) != 0 {
+		t.Errorf("enabled-no-knobs must render {}, got %+v", elp)
+	}
+}
+
+// TestKeaExpiredLeasesPerFamilyIndependence pins that the v4 and v6 blocks
+// are tuned independently: a config carrying ONLY a v4 block must NOT render
+// the key under Dhcp6, and vice-versa.
+func TestKeaExpiredLeasesPerFamilyIndependence(t *testing.T) {
+	m, _ := testManager(t, map[string]bool{}, "")
+	cfg := &config.DHCPServerConfig{
+		DHCPLocalServer: &config.DHCPLocalServerConfig{
+			Groups: v4Config("ge-0-0-0").DHCPLocalServer.Groups,
+			ExpiredLeases: &config.DHCPExpiredLeasesConfig{
+				Enabled: true, ReclaimTimerWait: 11,
+			},
+		},
+		DHCPv6LocalServer: &config.DHCPLocalServerConfig{
+			Groups: v6Config("ge-0-0-0").DHCPv6LocalServer.Groups,
+			// no ExpiredLeases on v6
+		},
+	}
+	if err := m.Apply(cfg); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	elp4 := readELPMap(t, m.confPath4, 4)
+	wantInt(t, elp4, "reclaim-timer-wait-time", 11)
+	if raw := readELPRaw(t, m.confPath6, 6); raw != nil {
+		t.Errorf("v6 has no block configured; key must be absent under Dhcp6, got %s", raw)
+	}
+}


### PR DESCRIPTION
Implements **Path S** of #1387 — the *stale-lease-cleanup* half: an opt-in
`expired-leases-processing` config subtree under `dhcp-local-server` /
`dhcpv6-local-server` that renders Kea's per-family reclamation block, so
expired/released/declined lease ROWS are actually removed from the memfile
instead of accumulating until LFC compaction.

The converged plan is `docs/research/1387-dhcp-dns/plan.md` (r2) +
`docs/research/1387-dhcp-ddns/claude-smr-plan-r1.md` on branch
`research/1387-dhcp-ddns-residual`.

## Scope / context

- The **DDNS half** of #1387 already shipped (#2043 Inc-1 + #2066 Inc-2 —
  direct RFC 2136, not Kea D2). This PR does NOT touch DDNS.
- The **kea-d2 alternate DDNS backend is PLAN-KILLed** (duplicates the
  shipped rfc2136 path, not in the image); the reserved `backend kea-d2`
  enum + WARN stays as-is.
- **Live DNS / end-to-end reclamation validation is lab-deferred** — there
  is no DNS/Kea fixture in CI. The unit golden render is the binding gate;
  a `kea-dhcp4 -t <generated.json>` acceptance check on deploy confirms Kea
  parses the rendered block. Kea binaries are not present on the build host,
  so that config-test is **deploy-pending** (parent may run it).

## What it does

```
set system services dhcp-local-server expired-leases-processing enable
set system services dhcp-local-server expired-leases-processing reclaim-timer 10
set system services dhcp-local-server expired-leases-processing flush-timer 25
set system services dhcp-local-server expired-leases-processing hold-time 600
set system services dhcp-local-server expired-leases-processing max-leases 100
set system services dhcp-local-server expired-leases-processing max-time 250
set system services dhcp-local-server expired-leases-processing unwarned-cycles 5
```

renders, per family, into the generated Kea config:

```json
"expired-leases-processing": {
  "reclaim-timer-wait-time": 10,
  "flush-reclaimed-timer-wait-time": 25,
  "hold-reclaimed-time": 600,
  "max-reclaim-leases": 100,
  "max-reclaim-time": 250,
  "unwarned-reclaim-cycles": 5
}
```

`dhcpv6-local-server` takes the same subtree; v4 and v6 are tuned
independently (Kea renders the block once per `Dhcp4`/`Dhcp6`).

## Design traps honored (the SMR-caught ones)

1. **GLOBAL per family, not per-pool** — model lives on the per-family
   `DHCPLocalServerConfig.ExpiredLeases`, schema directly under
   `dhcp-local-server`/`dhcpv6-local-server`, render reads one block per
   `Dhcp4`/`Dhcp6`. Never per-`DHCPPool`.
2. **`max-reclaim-leases: 0` = UNLIMITED** — the two cap knobs carry a
   `*Set bool` so `max-leases 0` (unlimited) renders distinctly from unset
   (key omitted); the render emits on the `*Set` flag, not `> 0`. Same
   discipline applied to `max-time` (0 = unlimited there too).
3. **Timer floor split** — `reclaim-timer`/`flush-timer`/`hold-time` use
   `ValidateIntegerMin(1)` (a 0 some Kea versions reject would brick the
   fail-closed restart); `max-leases`/`max-time`/`unwarned-cycles` use
   `Min(0)`.
4. **Both compile sites** — `compileDHCPExpiredLeases` runs inside the
   shared `compileExpanded` core, so it lands on BOTH the strict commit and
   the tolerant load / peer-sync compile paths (no HA config-sync
   warn-reject hazard). The typed-leaf schema gate hard-rejects on commit
   but downgrades to a warning on `Store.Load`/`SyncApply` — proven by a
   stored / peer-synced sub-floor-timer tolerance test in `pkg/configstore`.

`keaExpiredLeasesMap` returns nil for nil/disabled → key omitted →
**byte-identical to pre-#1387 output** (cardinal invariant H1).

## Tests (all green; new tests 5x no flake)

- `pkg/dhcpserver` golden render: v4 + v6 all-knobs FAIL-ON-REVERT,
  disabled/absent omit (H1), `max-leases`/`max-time` 0-vs-unset (H2),
  one-knob-omits-rest, enabled-no-knobs `{}`, per-family independence.
- `pkg/config`: dual-AST compile equality (hierarchical + flat-set via
  `ParseSetCommand`/`SetPath`), per-family independence, absent-default,
  H2 set/unset, enable-only-compiles, schema completion (both parents + six
  leaves + value examples), commit-check floor split (timer-0 rejects,
  cap-0 accepts, non-integer rejects), lenient compile.
- `pkg/configstore`: stored / peer-synced config carrying a sub-floor timer
  still LOADS (warn, not brick) and the next strict commit rejects it.

`go build ./... && go vet && go test ./pkg/config/... ./pkg/dhcpserver/...
./pkg/configstore/...` all green. No iperf/cluster smoke — this is
config-gen, not dataplane forwarding; touches no HA/VRRP/session-sync code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)