### PR TITLE
#2279: tighten IKE proposals-line test + clearer ike-policy validator diagnostics

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9514,3 +9514,27 @@ top.
   pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
   pkg/config/ike_policy_chain_ref_test.go, pkg/config/parser_security_test.go,
   _Log.md
+
+- **Timestamp**: 2026-06-21 (#2279)
+  **Action**: IKE-chain validator diagnostics + test-robustness polish (3
+  Copilot follow-up items from merged #2277). (1) Tightened the healthy-tunnel
+  assertion in TestRenderConfig_BrokenChainSkipsVPN_HealthyTunnelSurvives:
+  `proposals = aes256` → `\n    proposals = aes256` (anchored to the 4-space
+  Phase-1 line) so it cannot FALSE-PASS off the child 8-space
+  `esp_proposals = aes256...` line, mirroring the negative guard in
+  TestRenderConfig_NoPolicyGatewayRendersWithoutProposalsLine. Fail-on-revert
+  proven: removing the Phase-1 `proposals =` emission now breaks the test
+  (old bare substring would have false-passed — demonstrated structurally).
+  (2) compiler_validate_strict.go: an ike-policy defined with NO proposals
+  leaf (pol.Proposals == "") now reports "ike-policy <name> ... has no
+  proposals configured" instead of the misleading `undefined ike-proposal ""`.
+  (3) The dangling-ike-policy message no longer asserts a single
+  `security ike gateway` prefix — gateways are authored under either
+  `security ike` or `security ipsec` (both compileIKE/compileIPsec populate
+  the same Gateways map), so the message is stanza-agnostic
+  ("gateway <name> (under `security ike` or `security ipsec`)"). Diagnostics/
+  test-quality only; no security-logic change. build+vet green; pkg/ipsec +
+  pkg/config tests pass; affected tests 5x no flake.
+  **File(s)**: pkg/ipsec/ike_chain_failclosed_test.go,
+  pkg/config/compiler_validate_strict.go,
+  pkg/config/ike_policy_chain_ref_test.go, _Log.md

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -287,14 +287,32 @@ func validateIKEPolicyChainReferencesStrict(cfg *Config) error {
 		if chainResolves(gw.IKEPolicy) {
 			continue
 		}
+		// A gateway may be authored under either `security ike gateway` or
+		// `security ipsec gateway` (both compileIKE and compileIPsec populate
+		// the same Gateways map; #2279). The typed gateway does not record
+		// which stanza it came from, so the message names both candidates
+		// rather than asserting a single (possibly wrong) prefix.
 		if _, polDefined := ikePolicies[gw.IKEPolicy]; !polDefined {
-			return fmt.Errorf("security ike gateway %q (used by ipsec vpn %q) "+
-				"references undefined ike-policy %q; phase-1 would silently "+
-				"negotiate with the strongSwan default proposal set instead "+
-				"of the configured crypto",
+			return fmt.Errorf("gateway %q (under `security ike` or "+
+				"`security ipsec`, used by ipsec vpn %q) references undefined "+
+				"ike-policy %q; phase-1 would silently negotiate with the "+
+				"strongSwan default proposal set instead of the configured "+
+				"crypto",
 				gw.Name, vpnName, gw.IKEPolicy)
 		}
 		pol := ikePolicies[gw.IKEPolicy]
+		if pol.Proposals == "" {
+			// The ike-policy exists but has no `proposals` leaf at all, so
+			// pol.Proposals is the empty string. Reporting an "undefined
+			// ike-proposal \"\"" misleads the operator into hunting for a
+			// proposal named "" — say plainly that the policy is missing its
+			// proposals configuration.
+			return fmt.Errorf("ike-policy %q (via gateway %q, ipsec vpn %q) "+
+				"has no proposals configured; phase-1 would silently negotiate "+
+				"with the strongSwan default proposal set instead of the "+
+				"configured crypto",
+				gw.IKEPolicy, gw.Name, vpnName)
+		}
 		return fmt.Errorf("ike-policy %q (via gateway %q, ipsec vpn %q) "+
 			"references undefined ike-proposal %q; phase-1 would silently "+
 			"negotiate with the strongSwan default proposal set instead of "+

--- a/pkg/config/ike_policy_chain_ref_test.go
+++ b/pkg/config/ike_policy_chain_ref_test.go
@@ -53,6 +53,57 @@ func TestIKEPolicyDanglingProposalRejected(t *testing.T) {
 	}
 }
 
+// (b2) an ike-policy that is DEFINED but has no `proposals` leaf at all
+// (pol.Proposals == "") must be hard-rejected with a clear "no proposals
+// configured" message — not the pre-#2279 "undefined ike-proposal \"\""
+// which sent the operator hunting for a proposal literally named "".
+func TestIKEPolicyMissingProposalsLeafRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security ike gateway gw1 address 192.0.2.1",
+		"set security ike gateway gw1 ike-policy ike-pol",
+		// ike-pol is defined (mode set) but carries no `proposals` leaf.
+		"set security ike policy ike-pol mode main",
+		"set security ipsec vpn tun1 ike gateway gw1",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted an ike-policy with no proposals leaf; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "has no proposals configured") {
+		t.Errorf("error %q must say the ike-policy has no proposals configured", err.Error())
+	}
+	// The confusing pre-#2279 phrasing must be gone.
+	if strings.Contains(err.Error(), `undefined ike-proposal ""`) {
+		t.Errorf("error %q still reports the misleading empty-proposal name", err.Error())
+	}
+	if !strings.Contains(err.Error(), "ike-pol") {
+		t.Errorf("error %q must name the offending ike-policy", err.Error())
+	}
+}
+
+// (b3) the dangling-ike-policy message must NOT assert a single authoring
+// stanza: a gateway can be authored under `security ike` OR `security ipsec`
+// (#2279). The stanza-agnostic phrasing names both so the operator can find
+// the offending gateway regardless of where it was written.
+func TestIKEGatewayDanglingPolicyMessageStanzaAgnostic(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set security ike gateway gw1 address 192.0.2.1",
+		"set security ike gateway gw1 ike-policy does-not-exist",
+		"set security ipsec vpn tun1 ike gateway gw1",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a gateway with an undefined ike-policy; expected rejection")
+	}
+	msg := err.Error()
+	// Both candidate stanzas are named so the message is not misleading.
+	for _, want := range []string{"security ike", "security ipsec", "gw1", "does-not-exist"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("stanza-agnostic message %q missing %q", msg, want)
+		}
+	}
+}
+
 // (c) a fully resolvable chain compiles cleanly and the IKE proposal object
 // is present so the renderer emits a non-empty `proposals =` line.
 func TestIKEPolicyResolvableChainAccepted(t *testing.T) {

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -142,8 +142,14 @@ all files stay in `package ipsec`, so the public API is unchanged.
   - **Commit-time rejection** (`validateIKEPolicyChainReferencesStrict`,
     `pkg/config/compiler_validate_strict.go`, run from the strict-validator
     chain in `compileExpanded`): a VPN whose gateway names an undefined
-    `ike-policy`, or an `ike-policy` whose `proposals` reference dangles,
-    fails `commit` / `commit check`. Only gateways actually referenced by a
+    `ike-policy`, an `ike-policy` whose `proposals` reference dangles, or an
+    `ike-policy` defined with no `proposals` leaf at all, fails `commit` /
+    `commit check`. The diagnostics name the offending object precisely
+    (#2279): the gateway message is stanza-agnostic ("under `security ike`
+    or `security ipsec`", since both stanzas populate the same gateway map),
+    and the missing-`proposals`-leaf case reports "has no proposals
+    configured" rather than a misleading `undefined ike-proposal ""`.
+    Only gateways actually referenced by a
     VPN are validated (an orphan never reaches render, matching Junos). On
     the tolerant load / peer-sync paths the same check is downgraded to a
     warning (`lenientIKEPolicyChainRef`) so a config persisted by an older

--- a/pkg/ipsec/ike_chain_failclosed_test.go
+++ b/pkg/ipsec/ike_chain_failclosed_test.go
@@ -121,13 +121,18 @@ func TestRenderConfig_BrokenChainSkipsVPN_HealthyTunnelSurvives(t *testing.T) {
 	m := New()
 	out := m.generateConfig(cfg)
 
-	// Healthy tunnel: connection block present, with a non-empty proposals
-	// line carrying the configured crypto.
+	// Healthy tunnel: connection block present, with a non-empty Phase-1
+	// proposals line carrying the configured crypto. Match the four-space-
+	// indented connection-level "\n    proposals = aes256" specifically:
+	// a bare substring "proposals = aes256" would FALSE-PASS off the child
+	// "        esp_proposals = aes256..." line even if the Phase-1
+	// "    proposals = " line were missing (mirror of the negative guard in
+	// TestRenderConfig_NoPolicyGatewayRendersWithoutProposalsLine).
 	if !strings.Contains(out, "tun-good {") {
 		t.Errorf("healthy tunnel tun-good missing from render:\n%s", out)
 	}
-	if !strings.Contains(out, "proposals = aes256") {
-		t.Errorf("healthy tunnel missing a non-empty proposals line:\n%s", out)
+	if !strings.Contains(out, "proposals = aes256") { // SCRATCH OLD WEAK CHECK
+		t.Errorf("healthy tunnel missing a non-empty Phase-1 proposals line:\n%s", out)
 	}
 
 	// Broken tunnel: connection block must NOT be emitted (no proposal-less

--- a/pkg/ipsec/ike_chain_failclosed_test.go
+++ b/pkg/ipsec/ike_chain_failclosed_test.go
@@ -131,7 +131,7 @@ func TestRenderConfig_BrokenChainSkipsVPN_HealthyTunnelSurvives(t *testing.T) {
 	if !strings.Contains(out, "tun-good {") {
 		t.Errorf("healthy tunnel tun-good missing from render:\n%s", out)
 	}
-	if !strings.Contains(out, "proposals = aes256") { // SCRATCH OLD WEAK CHECK
+	if !strings.Contains(out, "\n    proposals = aes256") {
 		t.Errorf("healthy tunnel missing a non-empty Phase-1 proposals line:\n%s", out)
 	}
 


### PR DESCRIPTION
Closes #2279. Three LOW (diagnostic / test-quality) polish items Copilot
flagged on merged PR #2277 (#2270 IKE Phase-1 fail-closed). No
security-logic change — the validator hard-rejects exactly the same
configs and the renderer skips exactly the same broken chains; only
operator-facing diagnostics and one test assertion improve.

## Item 1 — tighten the weak Phase-1 proposals-line assertion
`pkg/ipsec/ike_chain_failclosed_test.go`:
`TestRenderConfig_BrokenChainSkipsVPN_HealthyTunnelSurvives` asserted the
healthy tunnel renders a non-empty Phase-1 proposals line via the bare
substring `proposals = aes256`. That substring is also contained in the
child 8-space `        esp_proposals = aes256...` line, so the assertion
would FALSE-PASS even if the 4-space Phase-1 `    proposals = ` line were
missing. Tightened to `\n    proposals = aes256`, anchoring to the
Phase-1 line, mirroring the negative guard in
`TestRenderConfig_NoPolicyGatewayRendersWithoutProposalsLine`.

**Fail-on-revert proof:** dropping the Phase-1 `proposals =` emission in
`policy.go` now breaks the tightened assertion; the old bare substring
matched an `esp_proposals = aes256...` line and would have passed
(demonstrated structurally — `strings.Contains` of a Phase-1-less render).

## Item 2 — clearer error for a missing proposals leaf
`pkg/config/compiler_validate_strict.go`: an ike-policy defined with no
`proposals` leaf left `pol.Proposals == ""` and the error read
`undefined ike-proposal ""`, sending the operator hunting for a proposal
literally named `""`. A dedicated branch now reports
`ike-policy <name> ... has no proposals configured`.

## Item 3 — stanza-agnostic gateway phrasing
The dangling-ike-policy error prefixed the object as `security ike
gateway`, but gateways can be authored under either `security ike` or
`security ipsec` (both `compileIKE` and `compileIPsec` populate the same
`Gateways` map; the typed struct does not record the stanza). The message
now names both candidates so the operator can find the gateway regardless
of where it was written.

## Tests
New: `TestIKEPolicyMissingProposalsLeafRejected`,
`TestIKEGatewayDanglingPolicyMessageStanzaAgnostic`. Existing chain-ref
tests unchanged-and-passing (they assert object-name substrings, not the
reworded prefixes). `pkg/ipsec/README.md` #2270 bullet updated to document
the new diagnostics.

## Validation
- `go build ./...`, `go vet ./pkg/ipsec/... ./pkg/config/...`,
  `go test ./pkg/ipsec/... ./pkg/config/...` all green.
- Affected tests run 5x with no flake.
- Item-1 fail-on-revert proven (Phase-1 line removed -> tightened test
  fails; old bare substring would have false-passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)