### PR TITLE
grpcapi: harden Complete pos + ShowNAT port-pool against int32 abuse (#2282)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9615,3 +9615,19 @@ top.
   userspace-dp/src/afxdp/event_emit.rs,
   userspace-dp/src/afxdp/poll_descriptor/mod.rs,
   userspace-dp/src/session/README.md, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2282 grpcapi input-validation hardening — Complete RPC
+  negative-Pos slice-panic guard + ShowNAT int32 port-pool overflow clamp.
+  Complete now rejects req.Pos < 0 with codes.InvalidArgument before
+  slicing line[:pos] (int(-1)<len passed → line[:-1] panic). GetNATPoolStats
+  computes (portHigh-portLow+1)*len(addresses) in int64 and saturates to
+  int32 via new clampInt32 helper before the int32 proto fields (bare cast
+  wrapped negative for ~40k-address pools). Table tests cover Pos
+  {MinInt32,-1,0,mid,len,len+1,MaxInt32} and an int32-overflowing pool;
+  both are fail-on-revert (reverting the guard panics the test; reverting
+  the clamp makes TotalPorts go negative). 5x no flake; go vet clean.
+  **File(s)**: pkg/grpcapi/server_cluster.go,
+  pkg/grpcapi/server_nat.go,
+  pkg/grpcapi/server_input_validation_test.go,
+  pkg/grpcapi/README.md, _Log.md

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -92,3 +92,14 @@ contract.
   user-supplied target after a `--` end-of-options separator so a
   `-`-prefixed target is an operand, not a flag (option-confusion
   hardening, #2084).
+- Request-supplied numeric fields are signed on the wire and must be
+  range-checked before they index/slice/size anything (#2282). `Complete`
+  rejects a negative `pos` with `InvalidArgument` before slicing
+  `line[:pos]` — without the guard `int(-1) < len(line)` passed and
+  `line[:-1]` panicked the handler goroutine (`pos > len` is already safe
+  because the slice is then skipped). `GetNATPoolStats` computes the
+  port-pool size `(portHigh-portLow+1) * len(addresses)` in int64 and
+  saturates to int32 via `clampInt32` before assigning the int32 proto
+  fields — a bare cast wrapped negative for a large pool (~40k addresses
+  over the default 64512-port window) and corrupted the
+  `avail = total - used` display.

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -419,6 +419,14 @@ func grpcResolveAddress(cfg *config.Config, name string) string {
 }
 
 func (s *Server) Complete(_ context.Context, req *pb.CompleteRequest) (*pb.CompleteResponse, error) {
+	// req.Pos is the caller-supplied cursor offset into req.Line. It is an
+	// int32 on the wire, so a crafted negative value would make the
+	// upper-bound guard below pass (int(-1) < len(text)) and slice
+	// text[:-1], panicking the handler goroutine. Reject negatives outright;
+	// Pos > len is already safe because the slice is then skipped.
+	if req.Pos < 0 {
+		return nil, status.Error(codes.InvalidArgument, "invalid position")
+	}
 	text := req.Line
 	if int(req.Pos) < len(text) {
 		text = text[:req.Pos]

--- a/pkg/grpcapi/server_input_validation_test.go
+++ b/pkg/grpcapi/server_input_validation_test.go
@@ -1,0 +1,226 @@
+package grpcapi
+
+import (
+	"context"
+	"math"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestCompleteRejectsNegativePos guards the #2282 negative-Pos slice panic.
+// CompleteRequest.pos is an int32 on the wire; before the fix a crafted
+// negative value made the upper-bound guard pass (int(-1) < len(text)) and
+// slice text[:-1], panicking the handler goroutine. The handler must reject
+// any negative position with InvalidArgument and must not panic for any
+// position (negative, zero, len, len+1, MinInt32).
+//
+// Fail-on-revert: removing the `if req.Pos < 0` guard makes the MinInt32 and
+// Pos=-1 cases panic (slice bounds out of range), failing this test rather
+// than crashing silently in production.
+func TestCompleteRejectsNegativePos(t *testing.T) {
+	s := &Server{}
+	const line = "show security"
+
+	cases := []struct {
+		name      string
+		pos       int32
+		wantError bool
+	}{
+		{name: "min-int32", pos: math.MinInt32, wantError: true},
+		{name: "negative-one", pos: -1, wantError: true},
+		{name: "zero", pos: 0, wantError: false},
+		{name: "mid", pos: 4, wantError: false},
+		{name: "len", pos: int32(len(line)), wantError: false},
+		{name: "len-plus-one", pos: int32(len(line)) + 1, wantError: false},
+		{name: "far-beyond-len", pos: math.MaxInt32, wantError: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A panic here (e.g. if the guard is reverted) fails the test.
+			resp, err := s.Complete(context.Background(), &pb.CompleteRequest{
+				Line: line,
+				Pos:  tc.pos,
+			})
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("Complete(pos=%d) error = nil, want InvalidArgument", tc.pos)
+				}
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("Complete(pos=%d) code = %v, want InvalidArgument", tc.pos, status.Code(err))
+				}
+				if resp != nil {
+					t.Fatalf("Complete(pos=%d) resp = %v, want nil on error", tc.pos, resp)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Complete(pos=%d) unexpected error = %v", tc.pos, err)
+			}
+			if resp == nil {
+				t.Fatalf("Complete(pos=%d) resp = nil, want non-nil", tc.pos)
+			}
+		})
+	}
+}
+
+// TestCompleteValidPosCompletes confirms a valid position still produces the
+// expected completions after the negative-Pos guard was added — the guard must
+// reject only negatives, not perturb normal completion. With Pos truncating
+// "show sec" the operational completer should offer "security".
+func TestCompleteValidPosCompletes(t *testing.T) {
+	s := &Server{}
+	const line = "show secdropme"
+	// Pos=8 truncates to "show sec" so "security" is the expected candidate.
+	resp, err := s.Complete(context.Background(), &pb.CompleteRequest{
+		Line: line,
+		Pos:  8,
+	})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	found := false
+	for _, c := range resp.Candidates {
+		if c == "security" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Complete(pos=8) candidates = %v, want to contain %q", resp.Candidates, "security")
+	}
+}
+
+// newNATPoolStatsStore commits a single named source NAT pool so the active
+// config exposes one entry in Security.NAT.SourcePools that the test can then
+// grow to provoke the #2282 int32 overflow without pushing tens of thousands
+// of addresses through the address-range-capped compiler.
+func newNATPoolStatsStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(`set security nat source pool bigpool address 10.0.0.0/24
+set security nat source rule-set rs from zone trust
+set security nat source rule-set rs to zone untrust
+set security nat source rule-set rs rule r1 match source-address 10.0.0.0/8
+set security nat source rule-set rs rule r1 then source-nat pool bigpool`); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestGetNATPoolStatsClampsInt32Overflow guards the #2282 int32 port-pool
+// overflow. The port-pool size (portHigh-portLow+1)*len(Addresses) is
+// computed in int64 and clamped to int32 max for the int32 proto fields; a
+// bare int32() cast would wrap negative for a large pool and corrupt the
+// avail=total-used display.
+//
+// Fail-on-revert: reverting the int64 computation + clampInt32 back to the
+// bare int32() cast makes TotalPorts wrap negative, failing the
+// non-negative + clamped-to-max assertions below.
+func TestGetNATPoolStatsClampsInt32Overflow(t *testing.T) {
+	store := newNATPoolStatsStore(t)
+
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	pool := cfg.Security.NAT.SourcePools["bigpool"]
+	if pool == nil {
+		t.Fatalf("SourcePools[bigpool] missing; pools = %v", cfg.Security.NAT.SourcePools)
+	}
+
+	// Force a large pool: default port window is 1024..65535 (64512 ports).
+	// 64512 * 40000 ≈ 2.58e9 > math.MaxInt32 (~2.147e9), so the int64
+	// product overflows int32 and must be clamped to MaxInt32.
+	pool.PortLow = 0
+	pool.PortHigh = 0 // handler defaults these to 1024/65535
+	pool.Addresses = make([]string, 40000)
+	for i := range pool.Addresses {
+		pool.Addresses[i] = "10.0.0.0/32"
+	}
+	const portWindow = 65535 - 1024 + 1
+	wantTotal64 := int64(portWindow) * int64(len(pool.Addresses))
+	if wantTotal64 <= math.MaxInt32 {
+		t.Fatalf("test precondition: pool size %d does not overflow int32", wantTotal64)
+	}
+
+	s := &Server{store: store}
+	resp, err := s.GetNATPoolStats(context.Background(), &pb.GetNATPoolStatsRequest{})
+	if err != nil {
+		t.Fatalf("GetNATPoolStats() error = %v", err)
+	}
+
+	var got *pb.NATPoolStats
+	for _, p := range resp.Pools {
+		if p.Name == "bigpool" {
+			got = p
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("bigpool not in response pools = %v", resp.Pools)
+	}
+	if got.TotalPorts < 0 {
+		t.Fatalf("TotalPorts = %d, want non-negative (int32 overflow not clamped)", got.TotalPorts)
+	}
+	if got.TotalPorts != math.MaxInt32 {
+		t.Fatalf("TotalPorts = %d, want clamped to MaxInt32 (%d)", got.TotalPorts, int32(math.MaxInt32))
+	}
+	if got.AvailablePorts < 0 {
+		t.Fatalf("AvailablePorts = %d, want non-negative", got.AvailablePorts)
+	}
+	// avail = total - used, used is 0 here (no dataplane apply result), so
+	// avail must equal the clamped total.
+	if got.AvailablePorts != got.TotalPorts {
+		t.Fatalf("AvailablePorts = %d, want = TotalPorts %d (used=0)", got.AvailablePorts, got.TotalPorts)
+	}
+}
+
+// TestGetNATPoolStatsSmallPoolExact confirms the int64+clamp path leaves a
+// normal pool size exactly correct (no clamping for in-range values).
+func TestGetNATPoolStatsSmallPoolExact(t *testing.T) {
+	store := newNATPoolStatsStore(t)
+	cfg := store.ActiveConfig()
+	pool := cfg.Security.NAT.SourcePools["bigpool"]
+	if pool == nil {
+		t.Fatalf("SourcePools[bigpool] missing")
+	}
+	pool.PortLow = 1024
+	pool.PortHigh = 2023 // 1000-port window
+	pool.Addresses = []string{"10.0.0.1/32", "10.0.0.2/32", "10.0.0.3/32"}
+	wantTotal := int32((2023 - 1024 + 1) * 3) // 3000
+
+	s := &Server{store: store}
+	resp, err := s.GetNATPoolStats(context.Background(), &pb.GetNATPoolStatsRequest{})
+	if err != nil {
+		t.Fatalf("GetNATPoolStats() error = %v", err)
+	}
+	var got *pb.NATPoolStats
+	for _, p := range resp.Pools {
+		if p.Name == "bigpool" {
+			got = p
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("bigpool not in response")
+	}
+	if got.TotalPorts != wantTotal {
+		t.Fatalf("TotalPorts = %d, want %d", got.TotalPorts, wantTotal)
+	}
+	if got.AvailablePorts != wantTotal {
+		t.Fatalf("AvailablePorts = %d, want %d (used=0)", got.AvailablePorts, wantTotal)
+	}
+}

--- a/pkg/grpcapi/server_nat.go
+++ b/pkg/grpcapi/server_nat.go
@@ -3,12 +3,26 @@ package grpcapi
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/psaab/xpf/pkg/dataplane"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/psaab/xpf/pkg/vrrp"
 )
+
+// clampInt32 saturates a non-negative int64 to the int32 range so a large
+// NAT port-pool size (which is computed in int64) does not wrap negative
+// when stored in an int32 protobuf field (#2282).
+func clampInt32(v int64) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
+}
 
 func (s *Server) GetNATSource(_ context.Context, _ *pb.GetNATSourceRequest) (*pb.GetNATSourceResponse, error) {
 	cfg := s.store.ActiveConfig()
@@ -106,33 +120,38 @@ func (s *Server) GetNATPoolStats(_ context.Context, _ *pb.GetNATPoolStatsRequest
 		if portHigh == 0 {
 			portHigh = 65535
 		}
-		totalPorts := int32((portHigh - portLow + 1) * len(pool.Addresses))
-		used := int32(0)
-
+		// Compute the port-pool size in int64: (portHigh-portLow+1) *
+		// len(Addresses) can exceed int32 for a large pool (e.g. a /16
+		// address range over the default 64512-port window is ~4.2e9),
+		// and a bare int32() cast would wrap negative and corrupt the
+		// avail=total-used display. Saturate to int32 max when assigning
+		// the int32 proto fields (#2282).
+		totalPorts64 := int64(portHigh-portLow+1) * int64(len(pool.Addresses))
+		var used64 int64
 		if cr != nil {
 			if id, ok := cr.PoolIDs[name]; ok {
 				cnt, err := telemetry.NATPortCounter(uint32(id))
 				if err == nil {
-					used = int32(cnt)
+					used64 = int64(cnt)
 				}
 			}
 		}
 
-		avail := totalPorts - used
-		if avail < 0 {
-			avail = 0
+		avail64 := totalPorts64 - used64
+		if avail64 < 0 {
+			avail64 = 0
 		}
 		util := "0.0%"
-		if totalPorts > 0 {
-			util = fmt.Sprintf("%.1f%%", float64(used)/float64(totalPorts)*100)
+		if totalPorts64 > 0 {
+			util = fmt.Sprintf("%.1f%%", float64(used64)/float64(totalPorts64)*100)
 		}
 
 		resp.Pools = append(resp.Pools, &pb.NATPoolStats{
 			Name:           name,
 			Address:        strings.Join(pool.Addresses, ","),
-			TotalPorts:     totalPorts,
-			UsedPorts:      used,
-			AvailablePorts: avail,
+			TotalPorts:     clampInt32(totalPorts64),
+			UsedPorts:      clampInt32(used64),
+			AvailablePorts: clampInt32(avail64),
 			Utilization:    util,
 		})
 	}


### PR DESCRIPTION
Closes #2282.

Two gRPC input-robustness gaps in `pkg/grpcapi`, both flagged by the
adversarial audit-2 sweep (2/2 skeptics).

## 1. `Complete` RPC — negative `pos` slice panic (MEDIUM, local DoS)
`CompleteRequest.pos` is `int32` on the wire. The handler only bounded the
upper end (`if int(req.Pos) < len(text) { text = text[:req.Pos] }`), so a
crafted `pos = -1` with a non-empty `line` made `int(-1) < len(text)` pass
and sliced `text[:-1]`, panicking the handler goroutine. A single local
gRPC call could crash the handler.

**Fix:** reject any negative `pos` with `codes.InvalidArgument` before the
slice (matching the `InvalidArgument` convention of the address validators
in this file). `pos > len` was already safe (the slice is skipped) and is
unchanged.

## 2. `GetNATPoolStats` — int32 port-pool overflow (LOW, display corruption)
`(portHigh-portLow+1) * len(Addresses)` was computed in `int` then cast
straight to the `int32` `NATPoolStats.TotalPorts` field. For a large pool
(~40k addresses over the default 64512-port window → ~2.6e9) the cast wraps
negative and corrupts the `avail = total - used` display.

**Fix:** compute `total`/`used`/`avail` in `int64` and saturate to int32
max via a new `clampInt32` helper before assigning the int32 proto fields;
`avail` stays coherent (clamped total − clamped used, floored at 0). Proto
field type unchanged.

## Tests
`server_input_validation_test.go`:
- Table test for `Complete` over `pos` {MinInt32, -1, 0, mid, len, len+1,
  MaxInt32} — negatives → `InvalidArgument` with no panic; valid → correct
  completion.
- A NAT pool grown to overflow int32 → `TotalPorts` clamped to `MaxInt32`,
  non-negative, `avail == total`; plus a small-pool exactness case.

Both are **fail-on-revert**: removing the `pos` guard makes the negative
cases panic (`slice bounds out of range`); reverting the int64+clamp makes
`TotalPorts` wrap negative (verified -1714487296).

## Validation
- `go build ./...` — green
- `go vet ./pkg/grpcapi/...` — clean
- `go test ./pkg/grpcapi/...` — green
- New tests 5x — no flake

`pkg/grpcapi/README.md` handler-discipline section documents the
signed-wire-field range-check rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)