### PR TITLE
logging: bound syslog stream writes + cooldown reconnect (#2283)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9615,3 +9615,28 @@ top.
   userspace-dp/src/afxdp/event_emit.rs,
   userspace-dp/src/afxdp/poll_descriptor/mod.rs,
   userspace-dp/src/session/README.md, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2283 — syslog stream-transport resilience on the shared
+  dataplane event hot-path. Two fixes in pkg/logging: (1) per-write deadline
+  (`SetWriteDeadline(now + writeTimeout)`, default 4s) on every TCP/TLS
+  `conn.Write` via a new `streamWrite` helper so a hung/congested syslog
+  server can no longer block the event reader indefinitely — a deadline
+  expiry drops the message (counted) and the reader continues; (2) reconnect
+  cooldown (default 1s) gating `reconnect()` — a write failure attempts one
+  reconnect, but if the previous dial failed inside the window the reconnect
+  is skipped and the send fails fast (drop), preventing a thundering herd of
+  5s-timeout dials against a down server. UDP is exempt (connectionless,
+  never blocks). Added `nowFn`/`dialFn` test seams + `droppedWrites`/
+  `droppedCooldown` atomic counters (DroppedWrites()/DroppedCooldown()
+  accessors) + rate-limited (≤1/s) drop warning. New tests in
+  syslog_resilience_test.go with deterministic fakes (deadline-honouring
+  conn, always-fail conn, controllable clock) and NO sleeps: hang test
+  fails-on-revert if the deadline is removed; cooldown test fails-on-revert
+  (50 dials vs 1) if the cooldown gate is removed; healthy-path test proves
+  every message is delivered with no deadline-induced drop and a single dial.
+  go build/vet green; pkg/logging -race 5x no flake (only the pre-existing,
+  unrelated TestRawEventContractMatchesDataplaneEvent screen-flag mismatch
+  fails on clean origin/master too). README documents the contract.
+  **File(s)**: pkg/logging/syslog.go, pkg/logging/syslog_resilience_test.go,
+  pkg/logging/README.md, _Log.md

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -35,6 +35,39 @@ reports.
 - Never put `slog.Info` inside per-session, per-packet, or per-poll-tick
   loops.
 
+## Syslog stream-transport resilience (#2283)
+
+`SyslogClient.Send` / `SendBinary` are reached on the SHARED dataplane
+event hot-path (EventStream reader → `EventReader.ProcessRawEvent` →
+`logEvent` → `SyslogClient.Send`). The event reader runs that path
+inline, so a syslog client must never block or thrash on a bad target.
+Two bounds enforce that for the stream transports (TCP/TLS); UDP is
+connectionless and exempt:
+
+- **Per-write deadline.** Every TCP/TLS `conn.Write` is preceded by
+  `SetWriteDeadline(now + writeTimeout)` (default
+  `defaultWriteTimeout`, 4s). A slow/hung/congested server surfaces as
+  `os.ErrDeadlineExceeded`; the message is dropped (counted, not
+  retried-in-place) and the reader continues. Without this a hung
+  server stalls the entire event reader indefinitely.
+- **Reconnect cooldown.** A write failure on a stream transport
+  attempts one reconnect, gated by `reconnectCooldown` (default
+  `defaultReconnectCooldown`, 1s). If the previous dial failed inside
+  the window, the reconnect is skipped and the send fails fast (drop) —
+  so a down server cannot drive a fresh 5s-timeout dial on every event
+  (thundering herd). `lastDialFailure` is cleared on a successful dial.
+
+Drops are observable via `DroppedWrites()` (write timeout/error) and
+`DroppedCooldown()` (reconnect suppressed by cooldown); the drop
+warning is rate-limited to ≤1/s so a flapping target cannot spam the
+log from the hot-path (CLAUDE.md logging rules).
+
+Tests (`syslog_resilience_test.go`) use deterministic fakes — a
+deadline-honouring conn, an always-fail conn, a controllable clock, and
+a dial seam (`dialFn`/`nowFn`) — with no sleeps. The hang test fails if
+the write deadline is removed; the cooldown test fails if the cooldown
+gate is removed.
+
 ## Gotchas
 
 - The binary RT_FLOW format used by Junos session logging is custom; it

--- a/pkg/logging/syslog.go
+++ b/pkg/logging/syslog.go
@@ -8,7 +8,26 @@ import (
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
+)
+
+// Resilience defaults for the stream (TCP/TLS) transports. These bound the
+// time the dataplane event hot-path can spend inside a single Send and rate-
+// limit reconnect attempts so a down server cannot drive a fresh 5s-timeout
+// dial on every event. UDP is connectionless and never blocks on Write, so
+// these do not apply to it.
+const (
+	// defaultWriteTimeout caps how long a single conn.Write may block before
+	// it is treated as a write failure (message dropped, reconnect armed).
+	// Generous enough that a healthy server is never affected; short enough
+	// that a hung server cannot stall the event reader.
+	defaultWriteTimeout = 4 * time.Second
+	// defaultReconnectCooldown is the minimum interval between dial attempts
+	// after a dial failure. Within the window, a stream Send that needs a
+	// reconnect fails fast (drops) instead of dialing — preventing a
+	// thundering herd of 5s dials against a down server.
+	defaultReconnectCooldown = 1 * time.Second
 )
 
 // Syslog severity levels (RFC 3164).
@@ -50,6 +69,37 @@ type SyslogClient struct {
 	MinSeverity int    // 0 = no filter, else SyslogError(3)/SyslogWarning(4)/SyslogInfo(6)
 	Format      string // "sd-syslog" for RFC 5424, "structured" for Junos RT_FLOW, "" for RFC 3164
 	Categories  uint8  // bitmask of allowed event categories (0 = all)
+
+	// Stream-transport resilience (TCP/TLS). All guarded by mu except the
+	// atomic counters, which are observability only.
+	writeTimeout      time.Duration // per-Write deadline; 0 disables (UDP)
+	reconnectCooldown time.Duration // min interval between dial attempts
+	lastDialFailure   time.Time     // when the last dial failed (mu-guarded)
+	lastDropLog       time.Time     // rate-limit for the drop warning (mu-guarded)
+
+	droppedWrites   atomic.Uint64 // messages dropped on a write timeout/error
+	droppedCooldown atomic.Uint64 // messages dropped because reconnect was in cooldown
+
+	// Seams for deterministic testing. nil → real implementations.
+	nowFn  func() time.Time          // clock source (default time.Now)
+	dialFn func() (net.Conn, error)  // dial override (default s.dial)
+}
+
+// now returns the client's clock (overridable in tests).
+func (s *SyslogClient) now() time.Time {
+	if s.nowFn != nil {
+		return s.nowFn()
+	}
+	return time.Now()
+}
+
+// dialConn dials a new connection via the test seam if set, else the real
+// protocol dialer.
+func (s *SyslogClient) dialConn() (net.Conn, error) {
+	if s.dialFn != nil {
+		return s.dialFn()
+	}
+	return s.dial()
 }
 
 // Category bitmask constants for event filtering.
@@ -86,12 +136,14 @@ func NewSyslogClientTransport(host string, port int, sourceAddr, protocol string
 	}
 
 	c := &SyslogClient{
-		hostname:   hostname,
-		remoteAddr: remoteAddr,
-		sourceAddr: sourceAddr,
-		protocol:   protocol,
-		tlsConfig:  tlsCfg,
-		Facility:   FacilityLocal0,
+		hostname:          hostname,
+		remoteAddr:        remoteAddr,
+		sourceAddr:        sourceAddr,
+		protocol:          protocol,
+		tlsConfig:         tlsCfg,
+		Facility:          FacilityLocal0,
+		writeTimeout:      defaultWriteTimeout,
+		reconnectCooldown: defaultReconnectCooldown,
 	}
 
 	conn, err := c.dial()
@@ -156,19 +208,65 @@ func (s *SyslogClient) dialTLS() (net.Conn, error) {
 	return dialer.DialContext(context.Background(), "tcp", s.remoteAddr)
 }
 
-// reconnect attempts to re-establish the connection. Called with mu held.
+// reconnect attempts to re-establish the connection, subject to a cooldown so
+// a down server cannot drive a fresh dial on every event. Called with mu held.
+//
+// Returns errReconnectCooldown without dialing if the previous dial failed
+// within reconnectCooldown; the caller drops the message and continues. The
+// event hot-path therefore never spends more than one dial's worth of time per
+// cooldown window on a dead target.
 func (s *SyslogClient) reconnect() error {
+	if s.reconnectCooldown > 0 && !s.lastDialFailure.IsZero() {
+		if s.now().Sub(s.lastDialFailure) < s.reconnectCooldown {
+			return errReconnectCooldown
+		}
+	}
 	if s.conn != nil {
 		s.conn.Close()
 		s.conn = nil
 	}
-	conn, err := s.dial()
+	conn, err := s.dialConn()
 	if err != nil {
+		s.lastDialFailure = s.now()
 		return err
 	}
+	s.lastDialFailure = time.Time{}
 	s.conn = conn
 	return nil
 }
+
+// errReconnectCooldown signals that a reconnect was suppressed by the cooldown
+// window; the message is dropped (fail-fast) rather than blocking on a dial.
+var errReconnectCooldown = fmt.Errorf("syslog reconnect in cooldown")
+
+// noteDrop bumps the appropriate drop counter and emits a rate-limited warning
+// so a flapping target cannot spam the log on the event hot-path. Called with
+// mu held.
+func (s *SyslogClient) noteDrop(cooldown bool, err error) {
+	if cooldown {
+		s.droppedCooldown.Add(1)
+	} else {
+		s.droppedWrites.Add(1)
+	}
+	now := s.now()
+	if s.lastDropLog.IsZero() || now.Sub(s.lastDropLog) >= time.Second {
+		s.lastDropLog = now
+		slog.Warn("syslog message dropped",
+			"addr", s.remoteAddr,
+			"cooldown", cooldown,
+			"dropped_writes", s.droppedWrites.Load(),
+			"dropped_cooldown", s.droppedCooldown.Load(),
+			"err", err)
+	}
+}
+
+// DroppedWrites reports the count of messages dropped on a write timeout or
+// write error (observability).
+func (s *SyslogClient) DroppedWrites() uint64 { return s.droppedWrites.Load() }
+
+// DroppedCooldown reports the count of messages dropped because a reconnect was
+// suppressed by the cooldown window (observability).
+func (s *SyslogClient) DroppedCooldown() uint64 { return s.droppedCooldown.Load() }
 
 // Send sends a syslog message with the given severity.
 // For TCP/TLS, uses RFC 6587 octet-counting framing.
@@ -190,13 +288,21 @@ func (s *SyslogClient) Send(severity int, msg string) error {
 	defer s.mu.Unlock()
 
 	if err := s.writeMsg(line); err != nil {
-		// For stream protocols, attempt one reconnect
+		// For stream protocols, attempt one cooldown-gated reconnect. UDP
+		// never blocks or needs reconnect, so it just returns the error.
 		if s.protocol != "udp" {
 			slog.Debug("syslog send failed, reconnecting", "addr", s.remoteAddr, "err", err)
 			if rerr := s.reconnect(); rerr != nil {
+				// Cooldown or dial failure: drop and continue. The event
+				// reader must make forward progress regardless.
+				s.noteDrop(rerr == errReconnectCooldown, err)
 				return fmt.Errorf("syslog reconnect %s: %w", s.remoteAddr, rerr)
 			}
-			return s.writeMsg(line)
+			if werr := s.writeMsg(line); werr != nil {
+				s.noteDrop(false, werr)
+				return werr
+			}
+			return nil
 		}
 		return err
 	}
@@ -214,7 +320,22 @@ func (s *SyslogClient) writeMsg(line string) error {
 	}
 	// TCP/TLS: RFC 6587 octet-counting: "<length> <message>"
 	framed := fmt.Sprintf("%d %s", len(line), line)
-	_, err := s.conn.Write([]byte(framed))
+	return s.streamWrite([]byte(framed))
+}
+
+// streamWrite writes to a TCP/TLS conn with a bounded write deadline so a
+// hung/congested server cannot block the dataplane event reader indefinitely.
+// A deadline expiry surfaces as a timeout error (os.ErrDeadlineExceeded);
+// callers treat it as a write failure and drop the message. Called with mu
+// held; conn is non-nil.
+func (s *SyslogClient) streamWrite(b []byte) error {
+	if s.writeTimeout > 0 {
+		// Best-effort: if SetWriteDeadline is unsupported by the conn it
+		// returns an error we ignore (the Write still proceeds, just
+		// without the bound). Real TCP/TLS conns always support it.
+		_ = s.conn.SetWriteDeadline(s.now().Add(s.writeTimeout))
+	}
+	_, err := s.conn.Write(b)
 	return err
 }
 
@@ -229,9 +350,14 @@ func (s *SyslogClient) SendBinary(data []byte) error {
 		if s.protocol != "udp" {
 			slog.Debug("syslog binary send failed, reconnecting", "addr", s.remoteAddr, "err", err)
 			if rerr := s.reconnect(); rerr != nil {
+				s.noteDrop(rerr == errReconnectCooldown, err)
 				return fmt.Errorf("syslog reconnect %s: %w", s.remoteAddr, rerr)
 			}
-			return s.writeBinaryMsg(data)
+			if werr := s.writeBinaryMsg(data); werr != nil {
+				s.noteDrop(false, werr)
+				return werr
+			}
+			return nil
 		}
 		return err
 	}
@@ -243,8 +369,11 @@ func (s *SyslogClient) writeBinaryMsg(data []byte) error {
 	if s.conn == nil {
 		return fmt.Errorf("syslog connection closed")
 	}
-	_, err := s.conn.Write(data)
-	return err
+	if s.protocol == "udp" {
+		_, err := s.conn.Write(data)
+		return err
+	}
+	return s.streamWrite(data)
 }
 
 // ShouldSend returns true if the event severity passes this client's filter.

--- a/pkg/logging/syslog_resilience_test.go
+++ b/pkg/logging/syslog_resilience_test.go
@@ -1,0 +1,291 @@
+package logging
+
+import (
+	"errors"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestStreamClient builds a TCP-protocol SyslogClient wired to the supplied
+// dial seam, bypassing the real network. The first connection is established
+// eagerly (mirroring NewSyslogClientTransport) via the seam.
+func newTestStreamClient(t *testing.T, dial func() (net.Conn, error)) *SyslogClient {
+	t.Helper()
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.1:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      defaultWriteTimeout,
+		reconnectCooldown: defaultReconnectCooldown,
+		dialFn:            dial,
+	}
+	conn, err := dial()
+	if err != nil {
+		t.Fatalf("initial dial: %v", err)
+	}
+	c.conn = conn
+	return c
+}
+
+// deadlineConn is a net.Conn fake that faithfully models stream write-deadline
+// semantics: Write blocks until either the caller releases it or the most
+// recently set (non-zero) write deadline elapses, in which case it returns a
+// timeout error. With NO write deadline set, Write blocks until released —
+// which never happens in the hang test, so a reverted (deadline-less) producer
+// blocks forever.
+type deadlineConn struct {
+	mu       sync.Mutex
+	deadline time.Time
+	release  chan struct{} // closed to unblock all pending writes (healthy path)
+	writes   int32         // count of completed writes
+}
+
+func newDeadlineConn() *deadlineConn {
+	return &deadlineConn{release: make(chan struct{})}
+}
+
+func (c *deadlineConn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	dl := c.deadline
+	c.mu.Unlock()
+
+	if dl.IsZero() {
+		// No deadline: block until explicitly released. Models a hung
+		// server with the (buggy) deadline-less producer.
+		<-c.release
+		atomic.AddInt32(&c.writes, 1)
+		return len(b), nil
+	}
+
+	d := time.Until(dl)
+	if d <= 0 {
+		return 0, os.ErrDeadlineExceeded
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-c.release:
+		atomic.AddInt32(&c.writes, 1)
+		return len(b), nil
+	case <-timer.C:
+		return 0, os.ErrDeadlineExceeded
+	}
+}
+
+func (c *deadlineConn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.deadline = t
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *deadlineConn) Read(_ []byte) (int, error)        { return 0, nil }
+func (c *deadlineConn) Close() error                      { return nil }
+func (c *deadlineConn) LocalAddr() net.Addr               { return dummyAddr{} }
+func (c *deadlineConn) RemoteAddr() net.Addr              { return dummyAddr{} }
+func (c *deadlineConn) SetDeadline(_ time.Time) error     { return nil }
+func (c *deadlineConn) SetReadDeadline(_ time.Time) error { return nil }
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "tcp" }
+func (dummyAddr) String() string  { return "203.0.113.1:514" }
+
+// TestStreamWriteDeadlineDoesNotHang asserts that a hung server (Write that
+// never completes on its own) cannot stall the caller: with the write deadline
+// armed, Send returns a timeout-driven error within roughly writeTimeout and
+// counts the drop. Removing the SetWriteDeadline call makes the fake conn's
+// Write block forever, so Send never returns and this test deadlocks/fails
+// (the fail-on-revert proof for fix #1).
+func TestStreamWriteDeadlineDoesNotHang(t *testing.T) {
+	conn := newDeadlineConn()
+	c := newTestStreamClient(t, func() (net.Conn, error) {
+		return conn, nil
+	})
+	// Short, deterministic deadline. The dial seam never succeeds again, so
+	// after the write timeout the reconnect path also fails fast.
+	c.writeTimeout = 30 * time.Millisecond
+	// Make reconnect dial fail (server still hung) so Send cannot block on a
+	// fresh dial either.
+	c.dialFn = func() (net.Conn, error) { return nil, errors.New("still down") }
+
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Send(SyslogInfo, "hung-server message")
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected Send to fail on a hung server, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send did not return — write deadline missing (event reader would stall)")
+	}
+
+	if got := c.DroppedWrites() + c.DroppedCooldown(); got == 0 {
+		t.Errorf("expected a drop to be counted, got writes=%d cooldown=%d",
+			c.DroppedWrites(), c.DroppedCooldown())
+	}
+}
+
+// TestReconnectCooldownRateLimitsDials asserts that with a down target (every
+// dial fails), rapid Sends do NOT each drive a fresh dial. The cooldown caps
+// dials to roughly one per cooldown window, and intervening Sends fail fast.
+// Removing the cooldown gate makes every Send dial → dialCount == sends, which
+// trips this test (the fail-on-revert proof for fix #2).
+func TestReconnectCooldownRateLimitsDials(t *testing.T) {
+	var dialCount int32
+	// Use a controllable fake clock so the test is sleep-free and
+	// deterministic. Time only advances when the test advances it.
+	var nowMu sync.Mutex
+	now := time.Unix(0, 0)
+	clock := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return now
+	}
+	advance := func(d time.Duration) {
+		nowMu.Lock()
+		now = now.Add(d)
+		nowMu.Unlock()
+	}
+
+	dial := func() (net.Conn, error) {
+		atomic.AddInt32(&dialCount, 1)
+		return nil, errors.New("connection refused")
+	}
+
+	// First dial (in the helper) counts as dial #1 and seeds lastDialFailure
+	// only on subsequent reconnects; construct the client with a broken conn
+	// so the first Send triggers the reconnect path.
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.1:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      defaultWriteTimeout,
+		reconnectCooldown: time.Second,
+		dialFn:            dial,
+		nowFn:             clock,
+		conn:              &alwaysFailConn{}, // first writeMsg fails → reconnect path
+	}
+
+	const sends = 50
+	for i := 0; i < sends; i++ {
+		_ = c.Send(SyslogInfo, "down-target message")
+	}
+
+	// All sends happened at t=0; only the FIRST should have dialed. The rest
+	// are inside the cooldown window → fail fast, no dial.
+	if d := atomic.LoadInt32(&dialCount); d != 1 {
+		t.Fatalf("expected 1 dial within the cooldown window across %d sends, got %d",
+			sends, d)
+	}
+	if c.DroppedCooldown() == 0 {
+		t.Errorf("expected cooldown drops to be counted, got %d", c.DroppedCooldown())
+	}
+
+	// Advance past the cooldown: exactly one more dial may occur.
+	advance(time.Second + time.Millisecond)
+	for i := 0; i < sends; i++ {
+		_ = c.Send(SyslogInfo, "down-target message round 2")
+	}
+	if d := atomic.LoadInt32(&dialCount); d != 2 {
+		t.Fatalf("expected 2 total dials after one cooldown window, got %d", d)
+	}
+
+	// Sanity: dials (2) are far fewer than total sends (2*sends).
+	if int(atomic.LoadInt32(&dialCount)) >= 2*sends {
+		t.Fatalf("reconnect thrash: dials %d not rate-limited vs %d sends",
+			dialCount, 2*sends)
+	}
+}
+
+// alwaysFailConn is a net.Conn whose Write always fails immediately, forcing
+// the reconnect path without blocking.
+type alwaysFailConn struct{}
+
+func (alwaysFailConn) Write(_ []byte) (int, error)        { return 0, errors.New("broken pipe") }
+func (alwaysFailConn) Read(_ []byte) (int, error)         { return 0, nil }
+func (alwaysFailConn) Close() error                       { return nil }
+func (alwaysFailConn) LocalAddr() net.Addr                { return dummyAddr{} }
+func (alwaysFailConn) RemoteAddr() net.Addr               { return dummyAddr{} }
+func (alwaysFailConn) SetDeadline(_ time.Time) error      { return nil }
+func (alwaysFailConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (alwaysFailConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// TestHealthyStreamNoDeadlineDrops asserts the normal path is unaffected: a
+// healthy conn delivers every message with no deadline-induced drop and no
+// reconnect. Each Write completes promptly (released immediately).
+func TestHealthyStreamNoDeadlineDrops(t *testing.T) {
+	conn := newHealthyConn()
+	var dialCount int32
+	c := newTestStreamClient(t, func() (net.Conn, error) {
+		atomic.AddInt32(&dialCount, 1)
+		return conn, nil
+	})
+
+	const sends = 20
+	for i := 0; i < sends; i++ {
+		if err := c.Send(SyslogInfo, "healthy message"); err != nil {
+			t.Fatalf("send %d failed on healthy conn: %v", i, err)
+		}
+	}
+
+	if got := atomic.LoadInt32(&conn.writes); int(got) != sends {
+		t.Errorf("expected %d writes delivered, got %d", sends, got)
+	}
+	if c.DroppedWrites() != 0 || c.DroppedCooldown() != 0 {
+		t.Errorf("healthy path should not drop: writes=%d cooldown=%d",
+			c.DroppedWrites(), c.DroppedCooldown())
+	}
+	// Only the initial dial; no reconnect on a healthy conn.
+	if d := atomic.LoadInt32(&dialCount); d != 1 {
+		t.Errorf("healthy path should dial once, got %d", d)
+	}
+	// A write deadline must have been set on the healthy conn (the fix
+	// applies to the success path too, just far enough out to never fire).
+	if !conn.sawDeadline() {
+		t.Error("expected a write deadline to be set on the healthy stream conn")
+	}
+}
+
+// healthyConn completes every Write immediately and records that a non-zero
+// write deadline was set.
+type healthyConn struct {
+	mu          sync.Mutex
+	hadDeadline bool
+	writes      int32
+}
+
+func newHealthyConn() *healthyConn { return &healthyConn{} }
+
+func (c *healthyConn) Write(b []byte) (int, error) {
+	atomic.AddInt32(&c.writes, 1)
+	return len(b), nil
+}
+func (c *healthyConn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	if !t.IsZero() {
+		c.hadDeadline = true
+	}
+	c.mu.Unlock()
+	return nil
+}
+func (c *healthyConn) sawDeadline() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hadDeadline
+}
+func (c *healthyConn) Read(_ []byte) (int, error)        { return 0, nil }
+func (c *healthyConn) Close() error                      { return nil }
+func (c *healthyConn) LocalAddr() net.Addr               { return dummyAddr{} }
+func (c *healthyConn) RemoteAddr() net.Addr              { return dummyAddr{} }
+func (c *healthyConn) SetDeadline(_ time.Time) error     { return nil }
+func (c *healthyConn) SetReadDeadline(_ time.Time) error { return nil }


### PR DESCRIPTION
## Summary

`SyslogClient.Send` / `SendBinary` are reached **inline** on the shared dataplane event hot-path (EventStream reader → `onRawDataplaneEvent` → `EventReader.ProcessRawEvent` → `logEvent` → `SyslogClient.Send` → `conn.Write`). Two TCP/TLS resilience defects let a bad syslog target stall or thrash that path. Both fixed here as one PR (scoped to `pkg/logging`).

- **Write deadline (fix #1, availability).** `streamWrite()` sets `SetWriteDeadline(now + writeTimeout)` (default 4s) before every TCP/TLS `Write`. A slow/hung/congested server now surfaces as `os.ErrDeadlineExceeded`; the message is dropped (counted), and the event reader continues — it can no longer be stalled indefinitely. Previously `conn.Write` had only a 5s *connect* timeout and could block forever.
- **Reconnect cooldown (fix #2, thrash).** `reconnect()` is gated by `reconnectCooldown` (default 1s). A write failure attempts at most one reconnect; if the previous dial failed inside the window, the reconnect is skipped and the send fails fast (drop) — no more thundering herd of 5s-timeout dials against a down server. `lastDialFailure` is cleared on a successful dial.
- **UDP exempt.** Connectionless, never blocks on `Write`, never reconnects — the deadline/cooldown logic applies only to the stream transports.
- **Observability + log hygiene.** Drops counted via `DroppedWrites()` / `DroppedCooldown()`; the drop warning is rate-limited to ≤1/s so a flapping target cannot spam the log from the hot-path (CLAUDE.md logging rules).
- **Test seams.** `nowFn` (clock) and `dialFn` (dial) seams added for deterministic, sleep-free tests. README documents the new contract.

## Invariants held

The event reader makes forward progress under every failure mode — hung server, down server, mid-reconnect, dial failure. `Send`/`SendBinary` callers already discard the return value (`_ = c.Send(...)`); the change ensures those calls also *return promptly*. Normal-path behaviour is preserved: a healthy syslog server still receives every message (the deadline is far enough out to never fire on a healthy write).

## Test plan

- [x] `go build ./...` green
- [x] `go vet ./pkg/logging/...` green
- [x] `go test -race ./pkg/logging/...` — new tests pass; `pkg/logging` 5× with `-race`, no flake (deterministic fakes + a controllable clock, **no sleeps**). The only failing test, `TestRawEventContractMatchesDataplaneEvent` (screen-flag count 17 vs 20), is **pre-existing on clean `origin/master`** and unrelated to syslog.
- [x] **Fail-on-revert proof #1:** removing `SetWriteDeadline` → `TestStreamWriteDeadlineDoesNotHang` hangs and fails ("Send did not return — write deadline missing").
- [x] **Fail-on-revert proof #2:** removing the cooldown gate → `TestReconnectCooldownRateLimitsDials` fails (50 dials vs expected 1).

New tests (`syslog_resilience_test.go`):
- `TestStreamWriteDeadlineDoesNotHang` — hung-server conn; Send returns within the deadline and counts a drop.
- `TestReconnectCooldownRateLimitsDials` — down target; 50 rapid Sends → exactly 1 dial, fast-fail drops; one more dial after the cooldown advances.
- `TestHealthyStreamNoDeadlineDrops` — healthy conn delivers every message, zero drops, single dial, deadline still set.

Validation lanes not run: this is a `pkg/logging`-only Go change with no dataplane/CoS/HA/forwarding surface, so the cluster smoke/failover lanes don't apply.

## Refs

Closes #2283