### PR TITLE
logging: mirror screen reason flags 17-19 into screenFlagNames (#2278 follow-up, fixes master-red contract test)

### DIFF
--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -108,26 +108,37 @@ const (
 	screenSynCookie       = 1 << 14
 	screenSessionLimitSrc = 1 << 15
 	screenSessionLimitDst = 1 << 16
+	// Bits 17-19 mirror the userspace-dp screen reason flags added after the
+	// original eBPF parity set (kept in lockstep with dataplane.ScreenFlagNames;
+	// the cross-package count is asserted by TestRawEventContractMatchesDataplaneEvent):
+	// ICMP fragment, IP malformed (#2146 fail-closed parse), and scan-table
+	// pressure (#2234 bounded-eviction operator alarm — not a packet drop).
+	screenICMPFragment      = 1 << 17
+	screenIPMalformed       = 1 << 18
+	screenScanTablePressure = 1 << 19
 )
 
 var screenFlagNames = map[uint32]string{
-	screenSynFlood:        "SYN flood",
-	screenICMPFlood:       "ICMP flood",
-	screenUDPFlood:        "UDP flood",
-	screenPortScan:        "port scan",
-	screenIPSweep:         "IP sweep",
-	screenLandAttack:      "LAND attack",
-	screenPingOfDeath:     "ping of death",
-	screenTearDrop:        "tear drop",
-	screenTCPSynFin:       "TCP SYN+FIN",
-	screenTCPNoFlag:       "TCP no-flag",
-	screenTCPFinNoAck:     "TCP FIN-no-ACK",
-	screenWinNuke:         "WinNuke",
-	screenIPSourceRoute:   "IP source-route",
-	screenSynFrag:         "SYN fragment",
-	screenSynCookie:       "SYN cookie",
-	screenSessionLimitSrc: "session limit (source)",
-	screenSessionLimitDst: "session limit (destination)",
+	screenSynFlood:          "SYN flood",
+	screenICMPFlood:         "ICMP flood",
+	screenUDPFlood:          "UDP flood",
+	screenPortScan:          "port scan",
+	screenIPSweep:           "IP sweep",
+	screenLandAttack:        "LAND attack",
+	screenPingOfDeath:       "ping of death",
+	screenTearDrop:          "tear drop",
+	screenTCPSynFin:         "TCP SYN+FIN",
+	screenTCPNoFlag:         "TCP no-flag",
+	screenTCPFinNoAck:       "TCP FIN-no-ACK",
+	screenWinNuke:           "WinNuke",
+	screenIPSourceRoute:     "IP source-route",
+	screenSynFrag:           "SYN fragment",
+	screenSynCookie:         "SYN cookie",
+	screenSessionLimitSrc:   "session limit (source)",
+	screenSessionLimitDst:   "session limit (destination)",
+	screenICMPFragment:      "ICMP fragment",
+	screenIPMalformed:       "IP malformed",
+	screenScanTablePressure: "scan-table pressure",
 }
 
 // EventReader reads events from an EventSource.


### PR DESCRIPTION
**Fixes a failing test on master.** PR #2278 (#2234) added 3 screen reason bits to `dataplane.ScreenFlagNames` (ScreenICMPFragment 1<<17, ScreenIPMalformed 1<<18, ScreenScanTablePressure 1<<19, now 20 entries) and bumped `TestRawEventContractMatchesDataplaneEvent` to expect 20, but the logging-side mirror `screenFlagNames` in `pkg/logging/ringbuf.go` (used to format screen reasons for syslog without importing pkg/dataplane) was left at 17 entries. The cross-package contract test consequently fails on master: `screen flag count = 17, want 20`.

This adds the 3 missing constants + map entries so the logging mirror matches `dataplane.ScreenFlagNames` exactly. The contract test checks both the count AND each flag's name string, so the names match verbatim ("ICMP fragment", "IP malformed", "scan-table pressure") — the test passing is the authoritative verification.

Validation: `go test ./pkg/logging/...` green (contract test now passes), `go build ./...` clean, gofmt clean. No behavior change beyond syslog rendering human-readable names for these 3 reasons instead of a numeric fallback.

Root cause: #2278's engineer + review ran cargo + `go vet ./pkg/dataplane` but not `go test ./pkg/logging/`, so the logging-mirror drift slipped through.