### PR TITLE
#2288: guard CLI completion suffix slices against over-typed input + implement monitor flow match filter

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9683,3 +9683,7 @@ top.
   pkg/grpcapi/server_nat.go,
   pkg/grpcapi/server_input_validation_test.go,
   pkg/grpcapi/README.md, _Log.md
+
+## 2026-06-21 — #2288 CLI completion panic guard + monitor match filter
+- **Action**: salvaged + committed the #2288 engineer worktree after a 529 death
+- **File(s)**: pkg/cli/completion.go, completion_panic_test.go, monitor.go, monitor_match_test.go

--- a/docs/next-features/monitor-command.md
+++ b/docs/next-features/monitor-command.md
@@ -59,6 +59,12 @@ Observed behavior:
 - `monitor security flow start` fails if file is not configured:
   - `error: Please specify the monitor flow trace file.`
 - The configured file resolves to `/var/log/<filename>` in status output.
+- `match <regex>` is a Go-RE2 regular expression evaluated against the
+  formatted trace line; only matching lines are written to the trace file.
+  The pattern is compiled at configure time — an invalid regex is rejected
+  immediately (`error: invalid match regex ...`) and never starts a trace
+  with a silently-broken filter (#2288). When set, the active pattern is
+  echoed in `show monitor security flow` output.
 
 #### Filter configuration
 ```text

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -31,6 +31,19 @@ type cliCompleter struct {
 	helpWritten bool // set by ? Listener to suppress duplicate help from Do()
 }
 
+// helpWriter returns the io.Writer that completion help is drawn to. It is the
+// readline-managed stdout when a readline instance is wired (the live CLI),
+// and io.Discard otherwise. The nil guard lets Do() run without a readline
+// instance — both for tests that drive the completer directly and as a
+// defensive measure against a completion firing before Run() wires c.rl
+// (#2288).
+func (cc *cliCompleter) helpWriter() io.Writer {
+	if cc.cli != nil && cc.cli.rl != nil {
+		return cc.cli.rl.Stdout()
+	}
+	return io.Discard
+}
+
 func (cc *cliCompleter) Do(line []rune, pos int) ([][]rune, int) {
 	// If the ? Listener already wrote help, suppress duplicate output.
 	if cc.helpWritten {
@@ -52,17 +65,20 @@ func (cc *cliCompleter) Do(line []rune, pos int) ([][]rune, int) {
 
 		sort.Slice(pipeCandidates, func(i, j int) bool { return pipeCandidates[i].name < pipeCandidates[j].name })
 		if len(pipeCandidates) == 1 {
-			suffix := pipeCandidates[0].name[len(partial):]
+			suffix, ok := completionSuffix(pipeCandidates[0].name, partial)
+			if !ok {
+				return nil, 0
+			}
 			return [][]rune{[]rune(suffix + " ")}, len(partial)
 		}
-		writeCompletionHelp(cc.cli.rl.Stdout(), pipeCandidates)
+		writeCompletionHelp(cc.helpWriter(), pipeCandidates)
 		names := make([]string, len(pipeCandidates))
 		for i, c := range pipeCandidates {
 			names[i] = c.name
 		}
 		cp := commonPrefix(names)
-		suffix := cp[len(partial):]
-		if suffix == "" {
+		suffix, ok := completionSuffix(cp, partial)
+		if !ok || suffix == "" {
 			return nil, 0
 		}
 		return [][]rune{[]rune(suffix)}, len(partial)
@@ -106,12 +122,15 @@ func (cc *cliCompleter) Do(line []rune, pos int) ([][]rune, int) {
 	sort.Slice(candidates, func(i, j int) bool { return candidates[i].name < candidates[j].name })
 
 	if len(candidates) == 1 {
-		suffix := candidates[0].name[len(partial):]
+		suffix, ok := completionSuffix(candidates[0].name, partial)
+		if !ok {
+			return nil, 0
+		}
 		return [][]rune{[]rune(suffix + " ")}, len(partial)
 	}
 
 	// Multiple matches: show descriptions above prompt.
-	writeCompletionHelp(cc.cli.rl.Stdout(), candidates)
+	writeCompletionHelp(cc.helpWriter(), candidates)
 
 	// Complete common prefix.
 	names := make([]string, len(candidates))
@@ -119,8 +138,8 @@ func (cc *cliCompleter) Do(line []rune, pos int) ([][]rune, int) {
 		names[i] = c.name
 	}
 	cp := commonPrefix(names)
-	suffix := cp[len(partial):]
-	if suffix == "" {
+	suffix, ok := completionSuffix(cp, partial)
+	if !ok || suffix == "" {
 		return nil, 0
 	}
 	return [][]rune{[]rune(suffix)}, len(partial)
@@ -317,6 +336,22 @@ func showConfigurationSubPath(words []string) ([]string, bool) {
 // commonPrefix returns the longest shared prefix among the given strings.
 func commonPrefix(items []string) string {
 	return cmdtree.CommonPrefix(items)
+}
+
+// completionSuffix returns the portion of name that follows the already-typed
+// partial, suitable for echoing back to readline. It guards the slice
+// expression name[len(partial):] against panics: candidate names can be
+// SHORTER than the typed partial (e.g. an over-typed token like "show f zzzzz"
+// where cmdtree returns the unfiltered "f" matches and commonPrefix("filter",
+// "flow") = "f" is shorter than "zzzzz"), and they need not even share a prefix
+// with partial. Returns (suffix, true) only when name is a genuine extension of
+// partial (name has partial as a prefix); otherwise (\"\", false) so callers
+// emit no completion instead of crashing (#2288).
+func completionSuffix(name, partial string) (string, bool) {
+	if len(partial) > len(name) || !strings.HasPrefix(name, partial) {
+		return "", false
+	}
+	return name[len(partial):], true
 }
 
 // pipeFilters defines the available pipe filter names and descriptions.

--- a/pkg/cli/completion_panic_test.go
+++ b/pkg/cli/completion_panic_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// #2288: tab-completion must not panic when the typed partial is longer than
+// (or unrelated to) any candidate name. cmdtree's CompleteFromTreeWithDesc has
+// an unfiltered fall-through (the "f"-matches branch) so commonPrefix(names)
+// can be SHORTER than the typed partial — the old completion.go computed
+// suffix := cp[len(partial):] unguarded and crashed the whole CLI with a
+// "slice bounds out of range" panic.
+//
+// This drives the REAL cliCompleter.Do() entry point (not a helper). The
+// completer's helpWriter() falls back to io.Discard when no readline instance
+// is wired, so the multi-candidate path (which would otherwise dereference
+// cc.cli.rl.Stdout()) is exercised end-to-end without a TTY. Removing
+// completionSuffix and restoring the bare slice expression makes this test
+// panic with the exact "slice bounds out of range" error from the issue.
+
+// newCompletionCLI builds a CLI in operational mode. No readline instance is
+// wired; cliCompleter.helpWriter() discards completion help in that case.
+func newCompletionCLI(t *testing.T) *cliCompleter {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	c := &CLI{store: store}
+	return &cliCompleter{cli: c}
+}
+
+func TestCliCompleterDo_OverTypedDoesNotPanic(t *testing.T) {
+	cases := []string{
+		"c zzzzz",        // single resolved verb (clear) + over-typed child
+		"clear s zzzzz",  // resolved clear, ambiguous "s", over-typed
+		"show f zzzzz",   // resolved show, ambiguous "f" (flow/filter/...), over-typed
+		"show zzzzzzzzz", // over-typed top-level token, no match
+		"zzzzzzzzz",      // over-typed top-level, single word
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Do(%q) panicked: %v", in, r)
+				}
+			}()
+			line := []rune(in)
+			suggestions, length := cc(t).Do(line, len(line))
+			// Sanity: a "no completion" result is acceptable (and expected
+			// for over-typed garbage). We only require no panic and a
+			// non-negative length offset.
+			if length < 0 {
+				t.Fatalf("Do(%q) returned negative length %d", in, length)
+			}
+			_ = suggestions
+		})
+	}
+}
+
+// helper so each sub-test gets a fresh completer (the readline instance and
+// store are cheap and isolation avoids cross-case state).
+func cc(t *testing.T) *cliCompleter {
+	t.Helper()
+	return newCompletionCLI(t)
+}
+
+// TestCliCompleterDo_PipeOverTypedDoesNotPanic exercises the pipe-filter
+// branch (completion.go:55/64) with an over-typed filter token after "|".
+func TestCliCompleterDo_PipeOverTypedDoesNotPanic(t *testing.T) {
+	cases := []string{
+		"show route | mzzzzz",  // "m" alone would resolve to "match"/"more-ish"; over-typed
+		"show route | gzzzzz",  // "g" -> grep, but over-typed
+		"show route | ezzzzz",  // "e" -> except, over-typed
+		"show route | zzzzzzz", // no filter prefix match at all
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Do(%q) panicked: %v", in, r)
+				}
+			}()
+			line := []rune(in)
+			_, length := newCompletionCLI(t).Do(line, len(line))
+			if length < 0 {
+				t.Fatalf("Do(%q) returned negative length %d", in, length)
+			}
+		})
+	}
+}
+
+// TestCompletionSuffix verifies the guard contract directly.
+func TestCompletionSuffix(t *testing.T) {
+	tests := []struct {
+		name, partial string
+		wantSuffix    string
+		wantOK        bool
+	}{
+		{"filter", "f", "ilter", true},   // normal extension
+		{"flow", "flow", "", true},       // exact match -> empty suffix, ok
+		{"f", "zzzzz", "", false},        // partial longer than name -> guarded
+		{"flow", "fz", "", false},        // same length region but not a prefix
+		{"filter", "show", "", false},    // unrelated, partial<name but no prefix
+		{"", "", "", true},               // both empty
+		{"abc", "", "abc", true},         // empty partial -> whole name
+	}
+	for _, tt := range tests {
+		gotSuffix, gotOK := completionSuffix(tt.name, tt.partial)
+		if gotSuffix != tt.wantSuffix || gotOK != tt.wantOK {
+			t.Errorf("completionSuffix(%q,%q) = (%q,%v), want (%q,%v)",
+				tt.name, tt.partial, gotSuffix, gotOK, tt.wantSuffix, tt.wantOK)
+		}
+	}
+}
+
+// TestCliCompleterDo_NormalCompletionStillWorks guards against the fix
+// over-suppressing legitimate completions: a normal in-prefix partial must
+// still produce a suffix.
+func TestCliCompleterDo_NormalCompletionStillWorks(t *testing.T) {
+	completer := newCompletionCLI(t)
+	line := []rune("sho")
+	suggestions, length := completer.Do(line, len(line))
+	if len(suggestions) == 0 {
+		t.Fatalf("Do(%q) returned no completion; expected the 'w' suffix for 'show'", "sho")
+	}
+	if length != 3 {
+		t.Fatalf("Do(%q) length = %d, want 3", "sho", length)
+	}
+	if string(suggestions[0]) != "w " && string(suggestions[0]) != "w" {
+		t.Fatalf("Do(%q) suffix = %q, want completion toward 'show'", "sho", string(suggestions[0]))
+	}
+}

--- a/pkg/cli/monitor.go
+++ b/pkg/cli/monitor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -67,10 +68,11 @@ func (f *monitorFlowFilter) matches(rec *logging.EventRecord) bool {
 // monitorFlowState holds the daemon-side state for "monitor security flow".
 type monitorFlowState struct {
 	mu       sync.Mutex
-	filename string // trace file name (base name, written to /var/log/)
-	fileSize int64  // max file size in bytes
-	files    int    // max number of trace files
-	match    string // regex for line filtering
+	filename string         // trace file name (base name, written to /var/log/)
+	fileSize int64          // max file size in bytes
+	files    int            // max number of trace files
+	match    string         // regex for line filtering (raw pattern, as typed)
+	matchRe  *regexp.Regexp // compiled form of match; nil when match is empty
 	filters  map[string]*monitorFlowFilter
 	active   bool
 	cancel   context.CancelFunc // cancel the active monitor goroutine
@@ -105,6 +107,13 @@ func extractPort(addrPort string) uint16 {
 		return 0
 	}
 	return uint16(p)
+}
+
+// traceLineMatches reports whether a formatted trace line should be written
+// given the optional compiled match regex (#2288). A nil regex (no `match`
+// configured) admits every line; otherwise the line must match the pattern.
+func traceLineMatches(line string, re *regexp.Regexp) bool {
+	return re == nil || re.MatchString(line)
 }
 
 // formatFlowEvent formats an EventRecord into Junos-style flow trace output.
@@ -232,7 +241,13 @@ func (c *CLI) handleMonitorSecurityFlowFile(args []string) error {
 		case "match":
 			if i+1 < len(args) {
 				i++
+				re, err := regexp.Compile(args[i])
+				if err != nil {
+					fmt.Printf("error: invalid match regex %q: %v\n", args[i], err)
+					return nil
+				}
 				c.monitorFlow.match = args[i]
+				c.monitorFlow.matchRe = re
 			}
 		}
 	}
@@ -365,6 +380,11 @@ func (c *CLI) handleMonitorSecurityFlowStart() error {
 		filters = append(filters, &fc)
 	}
 
+	// Snapshot the optional match regex (compiled at parse time). Applied
+	// as a post-format line filter so the advertised `file <name> match
+	// <regex>` filter actually drops non-matching trace lines (#2288).
+	matchRe := c.monitorFlow.matchRe
+
 	// Open trace file.
 	path := "/var/log/" + c.monitorFlow.filename
 	logFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
@@ -403,6 +423,9 @@ func (c *CLI) handleMonitorSecurityFlowStart() error {
 					continue
 				}
 				line := formatFlowEvent(rec)
+				if !traceLineMatches(line, matchRe) {
+					continue
+				}
 				fmt.Fprintln(logFile, line)
 			}
 		}
@@ -448,6 +471,9 @@ func (c *CLI) showMonitorSecurityFlow() error {
 		fmt.Printf("  Monitor security flow trace file: /var/log/%s\n", c.monitorFlow.filename)
 	} else {
 		fmt.Printf("  Monitor security flow trace file: (not configured)\n")
+	}
+	if c.monitorFlow.match != "" {
+		fmt.Printf("  Monitor security flow match: %s\n", c.monitorFlow.match)
 	}
 	fmt.Printf("  Monitor security flow filters: %d\n", len(c.monitorFlow.filters))
 

--- a/pkg/cli/monitor_match_test.go
+++ b/pkg/cli/monitor_match_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// #2288: the `monitor security flow file <name> match <regex>` filter was a
+// dead field — set but never read. These tests pin the now-implemented
+// behavior: a valid regex is compiled at configure time and applied as a
+// line filter; a malformed regex is rejected cleanly (no panic, state
+// unchanged).
+
+func TestHandleMonitorSecurityFlowFile_CompilesMatch(t *testing.T) {
+	c := &CLI{}
+	if err := c.handleMonitorSecurityFlowFile([]string{"trace", "match", "deny|drop"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.monitorFlow == nil {
+		t.Fatal("monitorFlow not initialized")
+	}
+	if c.monitorFlow.match != "deny|drop" {
+		t.Fatalf("match = %q, want %q", c.monitorFlow.match, "deny|drop")
+	}
+	if c.monitorFlow.matchRe == nil {
+		t.Fatal("matchRe is nil; match regex was not compiled")
+	}
+	if !c.monitorFlow.matchRe.MatchString("policy=deny") {
+		t.Fatal("compiled regex should match 'policy=deny'")
+	}
+	if c.monitorFlow.matchRe.MatchString("policy=permit") {
+		t.Fatal("compiled regex should not match 'policy=permit'")
+	}
+}
+
+func TestHandleMonitorSecurityFlowFile_RejectsBadRegex(t *testing.T) {
+	c := &CLI{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("bad regex caused panic: %v", r)
+		}
+	}()
+	// "[" is an unterminated character class — invalid RE2.
+	if err := c.handleMonitorSecurityFlowFile([]string{"trace", "match", "["}); err != nil {
+		t.Fatalf("unexpected error return (should print + return nil): %v", err)
+	}
+	if c.monitorFlow == nil {
+		t.Fatal("monitorFlow not initialized")
+	}
+	// The bad regex must NOT be stored, and matchRe must stay nil so a trace
+	// never starts with a silently-broken filter.
+	if c.monitorFlow.match != "" {
+		t.Fatalf("match = %q, want empty (bad regex rejected)", c.monitorFlow.match)
+	}
+	if c.monitorFlow.matchRe != nil {
+		t.Fatal("matchRe should remain nil after a rejected regex")
+	}
+	// The filename (first arg) is still accepted.
+	if c.monitorFlow.filename != "trace" {
+		t.Fatalf("filename = %q, want trace", c.monitorFlow.filename)
+	}
+}
+
+func TestTraceLineMatches(t *testing.T) {
+	tests := []struct {
+		line    string
+		pattern string // "" means nil regex
+		want    bool
+	}{
+		{"policy=deny-all", "deny", true},
+		{"policy=permit", "deny", false},
+		{"anything at all", "", true}, // nil regex admits everything
+		{"TCP 10.0.1.5->10.0.2.1", "^TCP", true},
+		{"10.0.1.5 TCP", "^TCP", false}, // anchored: TCP not at start
+		{"TCP 10.0.1.5->10.0.2.1", "UDP", false},
+	}
+	for _, tt := range tests {
+		var re *regexp.Regexp
+		if tt.pattern != "" {
+			re = regexp.MustCompile(tt.pattern)
+		}
+		if got := traceLineMatches(tt.line, re); got != tt.want {
+			t.Errorf("traceLineMatches(%q, %q) = %v, want %v", tt.line, tt.pattern, got, tt.want)
+		}
+	}
+}
+
+// TestTraceMatch_FiltersFormattedEvents wires the match filter to the actual
+// formatted flow-event output: only lines matching the regex survive, exactly
+// as the live trace loop applies it.
+func TestTraceMatch_FiltersFormattedEvents(t *testing.T) {
+	re := regexp.MustCompile(`policy=deny`)
+
+	denied := logging.EventRecord{
+		Time:        time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC),
+		SrcAddr:     "10.0.1.5:12345",
+		DstAddr:     "10.0.2.1:80",
+		Protocol:    "TCP",
+		Action:      "deny",
+		InZoneName:  "trust",
+		OutZoneName: "untrust",
+		PolicyName:  "deny",
+	}
+	permitted := logging.EventRecord{
+		Time:        time.Date(2026, 3, 1, 10, 0, 1, 0, time.UTC),
+		SrcAddr:     "10.0.1.6:23456",
+		DstAddr:     "10.0.2.2:443",
+		Protocol:    "TCP",
+		Action:      "permit",
+		InZoneName:  "trust",
+		OutZoneName: "untrust",
+		PolicyName:  "allow-web",
+	}
+
+	var written []string
+	for _, rec := range []logging.EventRecord{denied, permitted} {
+		line := formatFlowEvent(rec)
+		if traceLineMatches(line, re) {
+			written = append(written, line)
+		}
+	}
+
+	if len(written) != 1 {
+		t.Fatalf("expected exactly 1 matching line, got %d: %v", len(written), written)
+	}
+	if !regexp.MustCompile(`policy=deny`).MatchString(written[0]) {
+		t.Fatalf("surviving line should be the denied event: %q", written[0])
+	}
+}


### PR DESCRIPTION
Fixes #2288 (audit-3 finding). Salvaged + committed after the engineer agent died on an API 529; parent reviewed inline.

## 1. Tab-completion slice-bounds panic (MEDIUM, verified)
completion.go computed `suffix := cp[len(partial):]` (and the pipe-filter `name[len(partial):]`) without checking `len(partial) <= len(cp)`. Verified via real `cliCompleter.Do()`: `show f zzzzz`, `clear s zzzzz`, `c zzzzz` panicked. Guarded every such slice to fall back to an empty suffix. Test: completion_panic_test.go (over-typed + pipe-over-typed → no panic; normal completion regression). Fail-on-revert: removing the guard re-panics.

## 2. monitor flow match filter (LOW)
`monitor security flow file <name> match <regex>` parsed/stored `match` but never applied it (silent no-op). Now compiled at parse time (bad regex rejected cleanly) and applied as a trace-line filter. Test: monitor_match_test.go.

go build/vet/test ./pkg/cli/ green. No user-WIP files touched.