### PR TITLE
logging: gate goID on no-client path + arm syslog cooldown on accept-then-reset (#2295, #2302)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,42 @@
 # Action Log
 
+## 2026-06-21 — #2295 + #2302 pkg/logging syslog follow-ups
+
+- **Timestamp**: 2026-06-21
+- **Action**: Two pkg/logging follow-ups from the #2287/#2289 review.
+  - #2295: `SyslogSlogHandler.Handle` now snapshots the client set FIRST
+    and returns before the re-entrancy guard when `len(clients)==0`, so
+    `goID()` (`runtime.Stack` + `ParseUint`) never runs on the common
+    no-syslog-client path. Added a `goIDFn` package seam so a test can
+    assert the no-client path makes zero `goID` calls. Corrected the
+    `goid.go` doc comment (runs once per forwarded record when clients
+    are present) and renamed the stale `emitDropWarn` reference in
+    `syslog.go` to the actual method name `emit`. The #2287 guard
+    (base.Handle unconditional, guard wraps forwarding when clients
+    present) is unchanged.
+  - #2302: the reconnect cooldown was bypassed when the TCP/TLS dial
+    succeeds but the subsequent Write fails (accept-then-reset
+    collector / half-open server / TLS app-layer drop). `lastDialFailure`
+    was set only on a dial ERROR and cleared on dial SUCCESS → the
+    cooldown stayed permanently disengaged and every log message drove a
+    fresh connect+teardown (a dial storm). Renamed the field to
+    `lastReconnectFailure` and arm it from BOTH failure modes — a failed
+    dial (in `reconnect`) and a dial-success-then-retry-write-failure
+    (via `armReconnectCooldown` in the Send/SendBinary retry-write path).
+    Cleared only on a fully successful reconnect (dial AND retry-write),
+    so the legit single-broken-pipe recovery path and the #2287
+    timeout-drop behavior are preserved.
+  - Tests: `TestHandleNoClientsSkipsGoID` /
+    `TestHandleWithClientsStillCallsGoID` (#2295),
+    `TestAcceptThenResetRateLimitsDials` /
+    `TestAcceptThenRecoverClearsCooldown` (#2302). Deterministic fakes,
+    fake clock, no sleeps, `-race` clean, 5x no flake. Fail-on-revert
+    verified for both fixes (100 goID calls / 50-dial storm when
+    reverted).
+- **File(s)**: pkg/logging/slog_handler.go, pkg/logging/goid.go,
+  pkg/logging/syslog.go, pkg/logging/syslog_reentrancy_test.go,
+  pkg/logging/syslog_resilience_test.go, pkg/logging/README.md
+
 ## 2026-06-21 — #2258 VRRP localIP/localIPv6 lazy-resolve race (run-loop write vs receiver reads)
 
 - **Timestamp**: 2026-06-21

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -60,11 +60,20 @@ connectionless and exempt:
   path below.
 - **Reconnect cooldown.** A non-timeout write failure on a stream
   transport attempts one reconnect, gated by `reconnectCooldown`
-  (default `defaultReconnectCooldown`, 1s). If the previous dial failed
-  inside the window, the reconnect is skipped and the send fails fast
-  (drop) — so a down server cannot drive a fresh 5s-timeout dial on
-  every event (thundering herd). `lastDialFailure` is cleared on a
-  successful dial.
+  (default `defaultReconnectCooldown`, 1s). If the previous reconnect
+  cycle failed inside the window, the reconnect is skipped and the send
+  fails fast (drop) — so a down server cannot drive a fresh 5s-timeout
+  dial on every event (thundering herd). The cooldown clock
+  (`lastReconnectFailure`) is armed by BOTH failure modes (#2302): a
+  failed **dial**, AND a dial that succeeds but whose subsequent
+  retry-**write** fails (accept-then-reset collector, half-open server,
+  TLS app-layer drop). Gating only on a failed dial left an
+  accept-then-reset target permanently un-throttled — the dial succeeded
+  every time, so every log message drove a fresh TCP connect + teardown
+  (a dial storm: ephemeral port exhaustion + SYN pressure on the
+  collector). The clock is cleared only on a FULLY successful reconnect
+  (dial AND the retry-write both land), so the legitimate
+  single-broken-pipe recovery path is unaffected.
 - **Drop warning emitted AFTER the lock is released (#2287).**
   `SyslogClient.Send`/`SendBinary` hold `s.mu` for the whole write +
   reconnect sequence. The rate-limited drop warning (`slog.Warn`) must
@@ -86,6 +95,11 @@ connectionless and exempt:
   concurrent `Handle` calls on different goroutines are never falsely
   skipped. Forwarding to the base handler (stderr) stays unconditional,
   even on a re-entrant call, so records are never lost from local logs.
+  `Handle` snapshots the client set FIRST and returns before the guard
+  when there are no clients (the default until syslog config applies), so
+  the guard's `goID()` (`runtime.Stack` + `ParseUint`) never runs on the
+  common no-client path (#2295) — only when a record is actually being
+  forwarded to at least one client.
 
 Drops are observable via `DroppedWrites()` (write timeout or write
 error), `DroppedDials()` (post-write-failure reconnect dial failed),
@@ -97,11 +111,15 @@ attribute is one of `write` / `dial` / `cooldown`.
 Tests (`syslog_resilience_test.go`, `syslog_reentrancy_test.go`) use
 deterministic fakes — a deadline-honouring conn, an always-fail conn, a
 timeout conn, a recording conn, a controllable clock, and a dial seam
-(`dialFn`/`nowFn`) — with no sleeps. The hang test fails if the write
-deadline is removed; the cooldown test fails if the cooldown gate is
-removed; the re-entrancy test deadlocks (and times out) if the drop
-warning is moved back under `s.mu` or the handler guard is removed; the
-timeout-drop test fails (sees a dial) if a write timeout reconnects.
+(`dialFn`/`nowFn`) — plus a `goIDFn` seam — with no sleeps. The hang
+test fails if the write deadline is removed; the cooldown test fails if
+the cooldown gate is removed; the accept-then-reset test (#2302) fails
+(sees a 50-dial storm) if the cooldown is not armed on a
+dial-success-then-write-failure; the re-entrancy test deadlocks (and
+times out) if the drop warning is moved back under `s.mu` or the handler
+guard is removed; the timeout-drop test fails (sees a dial) if a write
+timeout reconnects; the no-client test (#2295) fails (sees `goID` calls)
+if `Handle` runs the re-entrancy guard before the client check.
 
 ## Gotchas
 

--- a/pkg/logging/goid.go
+++ b/pkg/logging/goid.go
@@ -13,10 +13,11 @@ import (
 // skipped). A per-handler atomic flag cannot make that distinction and would
 // silently drop legitimate forwarding under concurrent logging.
 //
-// This runs only on the slog path (warnings / state transitions, plus the
-// ≤1/s rate-limited drop warning), never per-packet or per-session, so the
-// runtime.Stack cost is acceptable. The buffer is small because only the
-// header line is needed.
+// This runs on the slog path (Handle) once per forwarded record, but ONLY when
+// at least one syslog client is configured: SyslogSlogHandler.Handle returns
+// before calling goID on the common no-client path (#2295). It never runs
+// per-packet or per-session, so the runtime.Stack cost is acceptable. The
+// buffer is small because only the header line is needed.
 func goID() uint64 {
 	var buf [64]byte
 	n := runtime.Stack(buf[:], false)

--- a/pkg/logging/slog_handler.go
+++ b/pkg/logging/slog_handler.go
@@ -61,19 +61,37 @@ func (h *SyslogSlogHandler) Enabled(ctx context.Context, level slog.Level) bool 
 	return h.base.Enabled(ctx, level)
 }
 
+// goIDFn resolves the current goroutine ID. It is a package var so tests can
+// install a counting seam to assert the no-client fast path never pays the
+// runtime.Stack cost (#2295). Production always uses goID.
+var goIDFn = goID
+
 // Handle implements slog.Handler.
 func (h *SyslogSlogHandler) Handle(ctx context.Context, r slog.Record) error {
 	// Always forward to the base handler (stderr) — unconditionally, even on a
 	// re-entrant call, so the record is never lost from local logs.
 	err := h.base.Handle(ctx, r)
 
+	// Snapshot the client set first. With no syslog clients configured (the
+	// default until syslog config applies) there is nothing to forward, so
+	// return before paying for the re-entrancy guard's goID() — runtime.Stack +
+	// ParseUint per record is wasted work on the common no-client path (#2295).
+	h.mu.RLock()
+	clients := h.clients
+	h.mu.RUnlock()
+
+	if len(clients) == 0 {
+		return err
+	}
+
 	// Re-entrancy guard (#2287): if this goroutine is already inside the
 	// syslog-forwarding section (a client Send emitted an slog record that
 	// routed back here), skip re-forwarding to syslog. Defense-in-depth so no
 	// under-lock or transitive slog call from the send path can wedge the
-	// daemon by recursing into a client's Send.
+	// daemon by recursing into a client's Send. Only reached when clients are
+	// present, so goID() runs only when there is something to forward (#2295).
 	if h.forwarding != nil {
-		gid := goID()
+		gid := goIDFn()
 		if _, busy := h.forwarding.Load(gid); busy {
 			return err
 		}
@@ -81,18 +99,12 @@ func (h *SyslogSlogHandler) Handle(ctx context.Context, r slog.Record) error {
 		defer h.forwarding.Delete(gid)
 	}
 
-	// Forward to syslog clients
-	h.mu.RLock()
-	clients := h.clients
-	h.mu.RUnlock()
-
-	if len(clients) > 0 {
-		severity := slogLevelToSyslog(r.Level)
-		msg := formatRecord(r, h.attrs, h.groups)
-		for _, c := range clients {
-			if c.ShouldSend(severity) {
-				c.Send(severity, msg)
-			}
+	// Forward to syslog clients.
+	severity := slogLevelToSyslog(r.Level)
+	msg := formatRecord(r, h.attrs, h.groups)
+	for _, c := range clients {
+		if c.ShouldSend(severity) {
+			c.Send(severity, msg)
 		}
 	}
 

--- a/pkg/logging/syslog.go
+++ b/pkg/logging/syslog.go
@@ -74,9 +74,14 @@ type SyslogClient struct {
 	// Stream-transport resilience (TCP/TLS). All guarded by mu except the
 	// atomic counters, which are observability only.
 	writeTimeout      time.Duration // per-Write deadline; 0 disables (UDP)
-	reconnectCooldown time.Duration // min interval between dial attempts
-	lastDialFailure   time.Time     // when the last dial failed (mu-guarded)
-	lastDropLog       time.Time     // rate-limit for the drop warning (mu-guarded)
+	reconnectCooldown time.Duration // min interval between reconnect attempts
+	// lastReconnectFailure is when the last reconnect CYCLE failed: either the
+	// dial errored, OR the dial succeeded but the retry-write that followed it
+	// failed (accept-then-reset). Armed by both modes so an accept-then-reset
+	// target cannot bypass the cooldown (#2302); cleared only on a fully
+	// successful reconnect (dial + retry-write). mu-guarded.
+	lastReconnectFailure time.Time
+	lastDropLog          time.Time // rate-limit for the drop warning (mu-guarded)
 
 	// droppedWrites counts messages dropped because the write itself failed:
 	// a write timeout (SetWriteDeadline expiry) or a write error
@@ -222,13 +227,27 @@ func (s *SyslogClient) dialTLS() (net.Conn, error) {
 // reconnect attempts to re-establish the connection, subject to a cooldown so
 // a down server cannot drive a fresh dial on every event. Called with mu held.
 //
-// Returns errReconnectCooldown without dialing if the previous dial failed
-// within reconnectCooldown; the caller drops the message and continues. The
-// event hot-path therefore never spends more than one dial's worth of time per
-// cooldown window on a dead target.
+// Returns errReconnectCooldown without dialing if the previous reconnect cycle
+// failed within reconnectCooldown; the caller drops the message and continues.
+// The event hot-path therefore never spends more than one dial's worth of time
+// per cooldown window on a dead target.
+//
+// The cooldown clock (lastReconnectFailure) is armed by BOTH failure modes:
+//   - a failed dial (set here), and
+//   - a dial that SUCCEEDS but whose subsequent retry-write fails (set by the
+//     caller via armReconnectCooldown).
+//
+// Arming on dial-success-then-write-failure closes #2302: an accept-then-reset
+// target (overloaded collector, half-open server, TLS app-layer drop) lets the
+// dial succeed every time, so gating only on a failed dial left the cooldown
+// permanently disengaged and every log message drove a fresh TCP connect +
+// teardown — a dial storm. The clock is cleared only on a FULLY successful
+// reconnect (dial AND the retry-write that follows it land), so the legitimate
+// recovery path (a single broken-pipe error that the reconnect repairs) is
+// unaffected.
 func (s *SyslogClient) reconnect() error {
-	if s.reconnectCooldown > 0 && !s.lastDialFailure.IsZero() {
-		if s.now().Sub(s.lastDialFailure) < s.reconnectCooldown {
+	if s.reconnectCooldown > 0 && !s.lastReconnectFailure.IsZero() {
+		if s.now().Sub(s.lastReconnectFailure) < s.reconnectCooldown {
 			return errReconnectCooldown
 		}
 	}
@@ -238,12 +257,30 @@ func (s *SyslogClient) reconnect() error {
 	}
 	conn, err := s.dialConn()
 	if err != nil {
-		s.lastDialFailure = s.now()
+		s.lastReconnectFailure = s.now()
 		return err
 	}
-	s.lastDialFailure = time.Time{}
+	// Dial succeeded. Do NOT clear the cooldown clock yet — the retry-write may
+	// still fail (accept-then-reset). The caller clears it on a successful
+	// retry-write and arms it (armReconnectCooldown) if the retry-write fails.
 	s.conn = conn
 	return nil
+}
+
+// armReconnectCooldown records a reconnect-cycle failure on the cooldown clock
+// so the NEXT reconnect within the window fails fast. Called with mu held from
+// the post-reconnect retry-write-failure path (dial succeeded, write failed):
+// without this, an accept-then-reset target bypasses the cooldown forever
+// because the dial never errors (#2302).
+func (s *SyslogClient) armReconnectCooldown() {
+	s.lastReconnectFailure = s.now()
+}
+
+// clearReconnectCooldown marks the reconnect cycle as fully recovered (dial AND
+// the retry-write both succeeded), re-enabling immediate reconnect on the next
+// failure. Called with mu held.
+func (s *SyslogClient) clearReconnectCooldown() {
+	s.lastReconnectFailure = time.Time{}
 }
 
 // errReconnectCooldown signals that a reconnect was suppressed by the cooldown
@@ -302,10 +339,10 @@ func (s *SyslogClient) noteDrop(reason dropReason, err error) *pendingDropWarn {
 	}
 }
 
-// emitDropWarn emits the rate-limited drop warning. It MUST be called with s.mu
-// NOT held (typically via a defer ordered to run after the Unlock) so the
-// slog.Warn cannot re-enter SyslogClient.Send under the lock (#2287). A nil
-// receiver (rate-limited) is a no-op.
+// emit emits the rate-limited drop warning. It MUST be called with s.mu NOT
+// held (typically via a defer ordered to run after the Unlock) so the slog.Warn
+// cannot re-enter SyslogClient.Send under the lock (#2287). A nil receiver
+// (rate-limited) is a no-op.
 func (w *pendingDropWarn) emit(remoteAddr string) {
 	if w == nil {
 		return
@@ -395,9 +432,16 @@ func (s *SyslogClient) Send(severity int, msg string) error {
 				return fmt.Errorf("syslog reconnect %s: %w", s.remoteAddr, rerr)
 			}
 			if werr := s.writeMsg(line); werr != nil {
+				// Dial succeeded but the retry-write failed (accept-then-reset).
+				// Arm the cooldown so the NEXT message's reconnect is throttled
+				// instead of dialing afresh every time (#2302).
+				s.armReconnectCooldown()
 				pendingWarn = s.noteDrop(dropWrite, werr)
 				return werr
 			}
+			// Full recovery: dial AND retry-write both succeeded. Clear the
+			// cooldown clock so a future failure can reconnect immediately.
+			s.clearReconnectCooldown()
 			return nil
 		}
 		return err
@@ -473,9 +517,14 @@ func (s *SyslogClient) SendBinary(data []byte) error {
 				return fmt.Errorf("syslog reconnect %s: %w", s.remoteAddr, rerr)
 			}
 			if werr := s.writeBinaryMsg(data); werr != nil {
+				// Dial succeeded but the retry-write failed (accept-then-reset):
+				// arm the cooldown so the next reconnect is throttled (#2302).
+				s.armReconnectCooldown()
 				pendingWarn = s.noteDrop(dropWrite, werr)
 				return werr
 			}
+			// Full recovery: clear the cooldown clock.
+			s.clearReconnectCooldown()
 			return nil
 		}
 		return err

--- a/pkg/logging/syslog_reentrancy_test.go
+++ b/pkg/logging/syslog_reentrancy_test.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -297,6 +298,74 @@ func TestDialFailureCountsAsDialDrop(t *testing.T) {
 	if c.DroppedWrites() != 0 {
 		t.Fatalf("a dial failure must not be counted as a write drop, got %d",
 			c.DroppedWrites())
+	}
+}
+
+// TestHandleNoClientsSkipsGoID is the #2295 fix-on-revert proof: with NO syslog
+// clients configured (the default until syslog config applies), Handle must
+// return before paying the goID() runtime.Stack + ParseUint cost. A counting
+// seam over goIDFn records calls; the no-client path must record zero. Reverting
+// the reorder (calling the guard before the client check) makes goID fire on
+// every record and trips this test.
+func TestHandleNoClientsSkipsGoID(t *testing.T) {
+	var goIDCalls int32
+	prev := goIDFn
+	goIDFn = func() uint64 {
+		atomic.AddInt32(&goIDCalls, 1)
+		return goID()
+	}
+	t.Cleanup(func() { goIDFn = prev })
+
+	h := NewSyslogSlogHandler(slog.NewTextHandler(io.Discard, nil))
+	// No SetClients: the zero-client default.
+
+	for i := 0; i < 100; i++ {
+		if err := h.Handle(context.Background(), slog.Record{}); err != nil {
+			t.Fatalf("Handle returned an error on the no-client path: %v", err)
+		}
+	}
+
+	if got := atomic.LoadInt32(&goIDCalls); got != 0 {
+		t.Fatalf("expected goID NOT to be called on the no-client path, got %d calls "+
+			"(runtime.Stack regression #2295)", got)
+	}
+}
+
+// TestHandleWithClientsStillCallsGoID asserts the reorder did NOT disable the
+// re-entrancy guard: when at least one client is present, goID still runs (the
+// guard remains armed). Combined with TestHandleReentrancyGuardSkipsNestedForward
+// (the guard still suppresses the nested forward), this proves the #2287 fix is
+// intact after the #2295 fast-path reorder.
+func TestHandleWithClientsStillCallsGoID(t *testing.T) {
+	var goIDCalls int32
+	prev := goIDFn
+	goIDFn = func() uint64 {
+		atomic.AddInt32(&goIDCalls, 1)
+		return goID()
+	}
+	t.Cleanup(func() { goIDFn = prev })
+
+	rec := &recordingConn{}
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.14:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      defaultWriteTimeout,
+		reconnectCooldown: defaultReconnectCooldown,
+		conn:              rec,
+	}
+	h := NewSyslogSlogHandler(slog.NewTextHandler(io.Discard, nil))
+	h.SetClients([]*SyslogClient{c})
+
+	if err := h.Handle(context.Background(), slog.Record{}); err != nil {
+		t.Fatalf("Handle returned an error with a client present: %v", err)
+	}
+	if got := atomic.LoadInt32(&goIDCalls); got != 1 {
+		t.Fatalf("expected goID to run once when a client is present (guard armed), got %d", got)
+	}
+	if n := atomic.LoadInt32(&rec.writes); n != 1 {
+		t.Fatalf("expected the record to be forwarded to the client, got %d writes", n)
 	}
 }
 

--- a/pkg/logging/syslog_resilience_test.go
+++ b/pkg/logging/syslog_resilience_test.go
@@ -161,9 +161,9 @@ func TestReconnectCooldownRateLimitsDials(t *testing.T) {
 		return nil, errors.New("connection refused")
 	}
 
-	// First dial (in the helper) counts as dial #1 and seeds lastDialFailure
-	// only on subsequent reconnects; construct the client with a broken conn
-	// so the first Send triggers the reconnect path.
+	// First dial (in the helper) counts as dial #1 and seeds
+	// lastReconnectFailure only on subsequent reconnects; construct the client
+	// with a broken conn so the first Send triggers the reconnect path.
 	c := &SyslogClient{
 		hostname:          "test",
 		remoteAddr:        "203.0.113.1:514",
@@ -204,6 +204,120 @@ func TestReconnectCooldownRateLimitsDials(t *testing.T) {
 	if int(atomic.LoadInt32(&dialCount)) >= 2*sends {
 		t.Fatalf("reconnect thrash: dials %d not rate-limited vs %d sends",
 			dialCount, 2*sends)
+	}
+}
+
+// TestAcceptThenResetRateLimitsDials is the #2302 fix-on-revert proof: an
+// accept-then-reset target lets every DIAL succeed but every WRITE fail
+// (overloaded collector, half-open server, TLS app-layer drop). Before the fix
+// lastDialFailure was set only on a dial ERROR and cleared on dial SUCCESS, so
+// the cooldown never engaged and every log message drove a fresh connect +
+// teardown — a dial storm. With the fix a dial-success-then-write-failure arms
+// the cooldown, so dials are capped to roughly one per cooldown window.
+//
+// Reverting the fix (gating only on a failed dial / clearing the clock on dial
+// success) makes dialCount == sends, which trips this test.
+func TestAcceptThenResetRateLimitsDials(t *testing.T) {
+	var dialCount int32
+	var nowMu sync.Mutex
+	now := time.Unix(0, 0)
+	clock := func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return now
+	}
+	advance := func(d time.Duration) {
+		nowMu.Lock()
+		now = now.Add(d)
+		nowMu.Unlock()
+	}
+
+	// Every dial SUCCEEDS (handshake completes) but hands back a conn whose
+	// Write always fails immediately — the accept-then-reset signature.
+	dial := func() (net.Conn, error) {
+		atomic.AddInt32(&dialCount, 1)
+		return &alwaysFailConn{}, nil
+	}
+
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.20:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      defaultWriteTimeout,
+		reconnectCooldown: time.Second,
+		dialFn:            dial,
+		nowFn:             clock,
+		conn:              &alwaysFailConn{}, // first writeMsg fails → reconnect
+	}
+
+	const sends = 50
+	for i := 0; i < sends; i++ {
+		_ = c.Send(SyslogInfo, "accept-then-reset target")
+	}
+
+	// All sends at t=0: only the FIRST should have dialed (the retry-write
+	// failed, arming the cooldown); the rest fail fast inside the window.
+	if d := atomic.LoadInt32(&dialCount); d != 1 {
+		t.Fatalf("accept-then-reset dial storm not throttled: expected 1 dial "+
+			"within the cooldown window across %d sends, got %d (#2302)", sends, d)
+	}
+	if c.DroppedCooldown() == 0 {
+		t.Errorf("expected cooldown drops to be counted, got %d", c.DroppedCooldown())
+	}
+
+	// Advance past the cooldown: exactly one more dial may occur.
+	advance(time.Second + time.Millisecond)
+	for i := 0; i < sends; i++ {
+		_ = c.Send(SyslogInfo, "accept-then-reset target round 2")
+	}
+	if d := atomic.LoadInt32(&dialCount); d != 2 {
+		t.Fatalf("expected 2 total dials after one cooldown window, got %d", d)
+	}
+
+	// Sanity: dials (2) are far fewer than the total sends (2*sends).
+	if int(atomic.LoadInt32(&dialCount)) >= 2*sends {
+		t.Fatalf("dial storm: dials %d not rate-limited vs %d sends", dialCount, 2*sends)
+	}
+}
+
+// TestAcceptThenRecoverClearsCooldown asserts the fix preserves the legitimate
+// recovery path: a single broken-pipe error whose reconnect lands a HEALTHY conn
+// must succeed AND leave the cooldown clear, so an immediately-following failure
+// can reconnect at once (not blocked by a stale cooldown). This is the
+// counter-factual to the dial-storm test — a recovered conn must not be
+// penalized by the #2302 cooldown arming.
+func TestAcceptThenRecoverClearsCooldown(t *testing.T) {
+	var dialCount int32
+	healthy := &recordingConn{}
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.21:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      defaultWriteTimeout,
+		reconnectCooldown: time.Second,
+		conn:              &alwaysFailConn{}, // first write fails → reconnect
+		dialFn: func() (net.Conn, error) {
+			atomic.AddInt32(&dialCount, 1)
+			return healthy, nil // dial lands a healthy conn → retry-write succeeds
+		},
+	}
+
+	if err := c.Send(SyslogInfo, "broken pipe then recover"); err != nil {
+		t.Fatalf("expected reconnect+retry to succeed, got %v", err)
+	}
+	if d := atomic.LoadInt32(&dialCount); d != 1 {
+		t.Fatalf("expected exactly 1 reconnect dial, got %d", d)
+	}
+	// Full recovery must clear the cooldown clock.
+	if !c.lastReconnectFailure.IsZero() {
+		t.Fatalf("a fully recovered reconnect (dial + retry-write) must clear the " +
+			"cooldown clock, but lastReconnectFailure is set")
+	}
+	if c.DroppedWrites() != 0 || c.DroppedDials() != 0 || c.DroppedCooldown() != 0 {
+		t.Fatalf("successful recovery must not count a drop: w=%d d=%d c=%d",
+			c.DroppedWrites(), c.DroppedDials(), c.DroppedCooldown())
 	}
 }
 


### PR DESCRIPTION
Two `pkg/logging` syslog follow-ups carried over from the #2287/#2289 review.

## Summary

- **#2295 (LOW):** `SyslogSlogHandler.Handle` ran `goID()` (`runtime.Stack` + `ParseUint`) for every forwarded record whenever the re-entrancy guard was active, including the common **no-syslog-client** path (the default until syslog config applies). `Handle` now snapshots the client set FIRST and returns before the guard when `len(clients)==0`, so `goID()` runs only when there is something to forward. Also corrects the `goid.go` doc comment and renames the stale `emitDropWarn` reference in `syslog.go` to the actual method name `emit`. The #2287 guard (base.Handle unconditional, guard wraps forwarding when clients present) is **unchanged**.
- **#2302 (MEDIUM):** the reconnect cooldown was bypassed when the TCP/TLS **dial succeeds but the subsequent Write fails** (accept-then-reset collector, half-open server, TLS app-layer drop). `lastDialFailure` was set only on a dial ERROR and cleared on dial SUCCESS → the cooldown stayed permanently disengaged and every log message drove a fresh TCP connect + teardown (a dial storm: ephemeral port exhaustion + SYN pressure on the collector). The field is renamed `lastReconnectFailure` and armed from BOTH failure modes — a failed dial (in `reconnect`) and a dial-success-then-retry-write-failure (via `armReconnectCooldown` in the Send/SendBinary retry-write path). The clock is cleared only on a **fully** successful reconnect (dial AND retry-write both land), so the legit single-broken-pipe recovery path and the #2287 timeout-drop-without-retry behavior are preserved.

## Hot-path shape

- #2295 removes `runtime.Stack` + `ParseUint` from the common no-client slog path (zero added cost; pure removal). On the with-client path, behavior is identical.
- #2302 adds one `s.now()` store on the retry-write-failure path and one `time.Time{}` store on full recovery — both already inside the held `s.mu` critical section, no new lock, no new allocation.

## Test plan

- [x] `TestHandleNoClientsSkipsGoID` (#2295) — `goIDFn` counting seam; no-client path makes ZERO `goID` calls. Fail-on-revert: reordering the guard before the client check → 100 calls.
- [x] `TestHandleWithClientsStillCallsGoID` (#2295) — reorder did NOT disable the #2287 guard: with a client present `goID` runs once and the record forwards.
- [x] `TestAcceptThenResetRateLimitsDials` (#2302) — fake clock + dial seam that always succeeds but hands back an always-fail-write conn; 50 sends at t=0 → exactly 1 dial; +1 after the window advances. Fail-on-revert: removing `armReconnectCooldown` → 50-dial storm.
- [x] `TestAcceptThenRecoverClearsCooldown` (#2302) — counter-factual: a single broken-pipe error whose reconnect lands a healthy conn succeeds AND leaves `lastReconnectFailure` zero (legit recovery not penalized).
- [x] Existing #2287 resilience + re-entrancy tests still green.
- [x] `go build ./...` + `go vet ./pkg/logging/...` clean; `go test -race ./pkg/logging/...` green; new tests 5x no flake.

Deterministic fakes (fake clock, dial seam, `goIDFn` seam), channels not sleeps. No cluster needed — pure `pkg/logging` Go change off the dataplane forwarding path (it touches the slog/syslog event path only).

## Refs

Closes #2295, closes #2302. Follow-up to #2287 (PR #2289).

🤖 Generated with [Claude Code](https://claude.com/claude-code)