### PR TITLE
nat64: walk IPv6 ext-header chain + fail closed on empty source pool (#2290, #2291)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -37,6 +37,33 @@
   pkg/logging/syslog.go, pkg/logging/syslog_reentrancy_test.go,
   pkg/logging/syslog_resilience_test.go, pkg/logging/README.md
 
+## 2026-06-21 — #2290 + #2291 NAT64 ext-header walk + fail-closed empty-pool
+
+- **Timestamp**: 2026-06-21
+- **Action**: #2290 — walk the IPv6 extension-header chain in the NAT64
+  v6->v4 translator (`write_v6_to_v4_into`) and the embedded ICMP-error
+  path (`translate_embedded_v6_to_v4`) instead of assuming L4 at fixed
+  offset 40 / reading the raw next-header. Added local bounded walker
+  `ipv6_l4_offset_and_protocol` + `ipv6_is_non_first_fragment` to
+  nat64.rs (does not reach into crate::afxdp, which depends on nat64;
+  unification tracked #2292). Fail closed on non-first fragments.
+  #2291 — tri-state `Nat64Match` enum + `classify_ipv6_dest`: a matched
+  NAT64 prefix with no allocatable source pool now DROPS + bumps the new
+  `nat64_no_source_pool` counter instead of falling through to plain IPv6
+  route lookup on the synthetic destination (was fail-open). Counter wired
+  BatchCounters -> BindingLiveState -> snapshot -> BindingStatus JSON ->
+  Go protocol.go + format/status.go operator line.
+- **File(s)**: userspace-dp/src/nat64.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/mod.rs, userspace-dp/src/afxdp/umem/mod.rs,
+  userspace-dp/src/afxdp/umem/snapshot.rs,
+  userspace-dp/src/afxdp/worker/mod.rs,
+  userspace-dp/src/afxdp/coordinator/refresh_bindings.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/reset.rs,
+  userspace-dp/src/protocol/binding.rs,
+  pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/format/status.go
+
 ## 2026-06-21 — #2258 VRRP localIP/localIPv6 lazy-resolve race (run-loop write vs receiver reads)
 
 - **Timestamp**: 2026-06-21

--- a/pkg/dataplane/userspace/format/status.go
+++ b/pkg/dataplane/userspace/format/status.go
@@ -149,6 +149,7 @@ func FormatStatusSummary(status userspace.ProcessStatus) string {
 	var snatPackets uint64
 	var dnatPackets uint64
 	var nat64Translations uint64
+	var nat64NoSourcePool uint64
 	var txPackets uint64
 	var txBytes uint64
 	var txErrors uint64
@@ -241,6 +242,7 @@ func FormatStatusSummary(status userspace.ProcessStatus) string {
 		snatPackets += binding.SNATPackets
 		dnatPackets += binding.DNATPackets
 		nat64Translations += binding.Nat64Translations
+		nat64NoSourcePool += binding.Nat64NoSourcePool
 		txPackets += binding.TXPackets
 		txBytes += binding.TXBytes
 		txErrors += binding.TXErrors
@@ -438,6 +440,7 @@ func FormatStatusSummary(status userspace.ProcessStatus) string {
 	fmt.Fprintf(&b, "  SNAT packets:              %d\n", snatPackets)
 	fmt.Fprintf(&b, "  DNAT packets:              %d\n", dnatPackets)
 	fmt.Fprintf(&b, "  NAT64 translations:        %d\n", nat64Translations)
+	fmt.Fprintf(&b, "  NAT64 no-source-pool drops:%d\n", nat64NoSourcePool)
 	if len(status.SourceNATPools) > 0 {
 		rows := append([]userspace.SourceNATPoolStatus(nil), status.SourceNATPools...)
 		sort.Slice(rows, func(i, j int) bool {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1514,6 +1514,11 @@ type BindingStatus struct {
 	// the Rust serde `default` keep cross-version wire safety (#1961-class:
 	// an older helper omits the field, Go reads 0 rather than failing decode).
 	Nat64Translations              uint64 `json:"nat64_translations,omitempty"`
+	// #2291: fail-closed NAT64 drops — a prefix matched but no IPv4 source
+	// could be allocated (empty/exhausted pool), so the synthetic IPv6
+	// destination was dropped rather than route-looked-up as IPv6. omitempty +
+	// Rust serde `default` keep the same cross-version wire safety.
+	Nat64NoSourcePool              uint64 `json:"nat64_no_source_pool,omitempty"`
 	SlowPathPackets                uint64 `json:"slow_path_packets,omitempty"`
 	SlowPathBytes                  uint64 `json:"slow_path_bytes,omitempty"`
 	SlowPathLocalDeliveryPackets   uint64 `json:"slow_path_local_delivery_packets,omitempty"`

--- a/userspace-dp/src/afxdp/coordinator/reconcile/reset.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/reset.rs
@@ -47,6 +47,7 @@ pub(super) fn reset_binding_counters(bindings: &mut [BindingStatus]) {
         binding.snat_packets = 0;
         binding.dnat_packets = 0;
         binding.nat64_translations = 0;
+        binding.nat64_no_source_pool = 0;
         binding.slow_path_packets = 0;
         binding.slow_path_bytes = 0;
         binding.slow_path_local_delivery_packets = 0;

--- a/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
+++ b/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
@@ -119,6 +119,7 @@ fn copy_live_snapshot(binding: &mut BindingStatus, snap: BindingLiveSnapshot) {
     binding.snat_packets = snap.snat_packets;
     binding.dnat_packets = snap.dnat_packets;
     binding.nat64_translations = snap.nat64_translations;
+    binding.nat64_no_source_pool = snap.nat64_no_source_pool;
     binding.slow_path_packets = snap.slow_path_packets;
     binding.slow_path_bytes = snap.slow_path_bytes;
     binding.slow_path_local_delivery_packets = snap.slow_path_local_delivery_packets;
@@ -297,6 +298,7 @@ fn zero_unbound_slot(binding: &mut BindingStatus) {
     binding.snat_packets = 0;
     binding.dnat_packets = 0;
     binding.nat64_translations = 0;
+    binding.nat64_no_source_pool = 0;
     binding.slow_path_packets = 0;
     binding.slow_path_bytes = 0;
     binding.slow_path_local_delivery_packets = 0;

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -424,6 +424,12 @@ pub(in crate::afxdp) struct BatchCounters {
     // #2161: per-translation NAT64 (v6<->v4) tally, batched like snat/dnat
     // and flushed to BindingLiveState.nat64_translations.
     nat64_translations: u64,
+    // #2291: fail-closed drop counter — a NAT64 prefix matched but no IPv4
+    // source could be allocated (empty/exhausted pool), so the synthetic
+    // IPv6 destination was DROPPED rather than route-looked-up as ordinary
+    // IPv6 (the pre-fix fail-open). Flushed to
+    // BindingLiveState.nat64_no_source_pool.
+    nat64_no_source_pool: u64,
     // #1187: 8 disposition-path counters added to eliminate per-packet
     // MESI thrash on BindingLiveState atomics during DDoS / config-
     // reload windows. See docs/pr/1187-telemetry-double-buffer/plan.md
@@ -520,6 +526,11 @@ impl BatchCounters {
             live.nat64_translations
                 .fetch_add(self.nat64_translations, Ordering::Relaxed);
             self.nat64_translations = 0;
+        }
+        if self.nat64_no_source_pool != 0 {
+            live.nat64_no_source_pool
+                .fetch_add(self.nat64_no_source_pool, Ordering::Relaxed);
+            self.nat64_no_source_pool = 0;
         }
         // #1187 disposition-path counters
         if self.screen_drops != 0 {

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -700,17 +700,37 @@ pub(super) fn poll_binding_process_descriptor(
                         // If dst is IPv6 matching a NAT64 prefix, extract IPv4
                         // dest and allocate an IPv4 SNAT address. Route lookup
                         // must use the IPv4 destination.
-                        let nat64_match = if pre_routing_dnat.is_none() && nptv6_inbound.is_none() {
+                        //
+                        // #2291: tri-state lookup. The pre-fix code collapsed
+                        // "prefix matched but no source pool" into "no match"
+                        // (a bare Option whose None meant both), so a matched-
+                        // but-unallocatable destination fell through to IPv6
+                        // route lookup on the SYNTHETIC NAT64 address — a
+                        // fail-OPEN that could leak it upstream on a default
+                        // IPv6 route. Now MatchUnavailable fails CLOSED (drop +
+                        // counter); only NoPrefixMatch continues IPv6 routing.
+                        let nat64_match = if pre_routing_dnat.is_none()
+                            && nptv6_inbound.is_none()
+                        {
                             if let IpAddr::V6(dst_v6) = resolution_target {
-                                worker_ctx
-                                    .forwarding
-                                    .nat64
-                                    .match_ipv6_dest(dst_v6)
-                                    .and_then(|(idx, dst_v4)| {
-                                        let snat_v4 =
-                                            worker_ctx.forwarding.nat64.allocate_v4_source(idx)?;
-                                        Some((idx, dst_v4, snat_v4, dst_v6))
-                                    })
+                                match worker_ctx.forwarding.nat64.classify_ipv6_dest(dst_v6) {
+                                    crate::nat64::Nat64Match::NoPrefixMatch => None,
+                                    crate::nat64::Nat64Match::MatchReady {
+                                        prefix_idx,
+                                        dst_v4,
+                                        snat_v4,
+                                        dst_v6,
+                                    } => Some((prefix_idx, dst_v4, snat_v4, dst_v6)),
+                                    crate::nat64::Nat64Match::MatchUnavailable => {
+                                        // Fail closed: a NAT64 prefix matched
+                                        // but the source pool is empty/exhausted.
+                                        // Drop rather than route the synthetic
+                                        // IPv6 destination as ordinary IPv6.
+                                        telemetry.counters.nat64_no_source_pool += 1;
+                                        binding.scratch.scratch_recycle.push(desc.addr);
+                                        continue;
+                                    }
+                                }
                             } else {
                                 None
                             }

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -5998,6 +5998,28 @@ fn nat64_translations_flushes_to_live_and_snapshot() {
     );
 }
 
+// #2291: the fail-closed NAT64 drop counter (prefix matched, no source pool)
+// must flush BatchCounters -> BindingLiveState -> snapshot the same way as
+// nat64_translations, so an operator can see the drops and a dropped flush
+// line is caught at build/test time.
+#[test]
+fn nat64_no_source_pool_flushes_to_live_and_snapshot() {
+    let live = BindingLiveState::new();
+    let mut batch = BatchCounters::default();
+    batch.touched = true;
+    batch.nat64_no_source_pool = 5;
+    batch.flush(&live);
+    assert_eq!(
+        batch.nat64_no_source_pool, 0,
+        "flush must zero the batched no-source-pool drop count"
+    );
+    let snap = live.snapshot();
+    assert_eq!(
+        snap.nat64_no_source_pool, 5,
+        "the live atomic + snapshot must carry the flushed no-source-pool count"
+    );
+}
+
 // === #1873 R-C: blanket tunnel gate at the slow-path chokepoint ===
 
 fn tunnel_gate_test_fixture() -> (

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -380,6 +380,12 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// #2161: cumulative NAT64 (v6<->v4) translations on this binding,
     /// surfaced as the `NAT64 translations` operator counter.
     pub(super) nat64_translations: AtomicU64,
+    /// #2291: cumulative fail-closed NAT64 drops — a NAT64 prefix matched but
+    /// no IPv4 source could be allocated (empty/exhausted pool). Surfaced as
+    /// the `NAT64 no-source-pool drops` operator counter; a non-zero value
+    /// flags a misconfigured/exhausted source pool that would otherwise have
+    /// leaked the synthetic IPv6 destination upstream (the pre-fix fail-open).
+    pub(super) nat64_no_source_pool: AtomicU64,
     pub(super) slow_path_packets: AtomicU64,
     pub(super) slow_path_bytes: AtomicU64,
     pub(super) slow_path_local_delivery_packets: AtomicU64,
@@ -759,6 +765,7 @@ impl BindingLiveState {
             snat_packets: AtomicU64::new(0),
             dnat_packets: AtomicU64::new(0),
             nat64_translations: AtomicU64::new(0),
+            nat64_no_source_pool: AtomicU64::new(0),
             slow_path_packets: AtomicU64::new(0),
             slow_path_bytes: AtomicU64::new(0),
             slow_path_local_delivery_packets: AtomicU64::new(0),

--- a/userspace-dp/src/afxdp/umem/snapshot.rs
+++ b/userspace-dp/src/afxdp/umem/snapshot.rs
@@ -99,6 +99,7 @@ impl BindingLiveState {
             snat_packets: self.snat_packets.load(Ordering::Relaxed),
             dnat_packets: self.dnat_packets.load(Ordering::Relaxed),
             nat64_translations: self.nat64_translations.load(Ordering::Relaxed),
+            nat64_no_source_pool: self.nat64_no_source_pool.load(Ordering::Relaxed),
             slow_path_packets: self.slow_path_packets.load(Ordering::Relaxed),
             slow_path_bytes: self.slow_path_bytes.load(Ordering::Relaxed),
             slow_path_local_delivery_packets: self

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1274,6 +1274,9 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) dnat_packets: u64,
     /// #2161: cumulative NAT64 translations snapshotted from BindingLiveState.
     pub(crate) nat64_translations: u64,
+    /// #2291: cumulative fail-closed NAT64 drops (prefix matched, no source
+    /// pool available) snapshotted from BindingLiveState.
+    pub(crate) nat64_no_source_pool: u64,
     pub(crate) slow_path_packets: u64,
     pub(crate) slow_path_bytes: u64,
     pub(crate) slow_path_local_delivery_packets: u64,

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -95,6 +95,42 @@ pub(crate) struct Nat64ReverseInfo {
     pub(crate) orig_dst_v6: Ipv6Addr,
 }
 
+/// Tri-state result of a NAT64 destination lookup (#2291).
+///
+/// The pre-fix lookup collapsed "prefix matched but no source could be
+/// allocated" into "no NAT64 match" (a bare `Option<...>` whose `None`
+/// meant both), so a matched-but-unallocatable destination fell through to
+/// ordinary IPv6 route lookup on the SYNTHETIC NAT64 destination
+/// (`64:ff9b::a.b.c.d`). With a permissive default IPv6 route present, that
+/// silently leaked untranslated synthetic-destination traffic upstream — a
+/// fail-OPEN at the NAT64 boundary.
+///
+/// Splitting the result into three states lets the caller fail CLOSED on the
+/// unallocatable case (drop + counter) while still routing genuinely
+/// non-matching IPv6 normally. Consistent with the project's fail-closed
+/// family (#2124/#2142/#2173/#2175).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Nat64Match {
+    /// The destination does not match any configured NAT64 prefix — continue
+    /// ordinary IPv6 route lookup. This is the ONLY arm that routes as IPv6.
+    NoPrefixMatch,
+    /// A prefix matched AND a source IPv4 was allocated — translate.
+    MatchReady {
+        /// Index of the matched NAT64 prefix in `prefixes`.
+        prefix_idx: usize,
+        /// IPv4 destination extracted from the synthetic NAT64 address.
+        dst_v4: Ipv4Addr,
+        /// Allocated IPv4 SNAT source from the matched prefix's pool.
+        snat_v4: Ipv4Addr,
+        /// Original synthetic IPv6 destination (kept for the reverse path).
+        dst_v6: Ipv6Addr,
+    },
+    /// A prefix matched but NO IPv4 source could be allocated (empty /
+    /// exhausted pool — a legitimate wire state the Go side emits for a
+    /// no-source-pool rule). The packet MUST be dropped, not routed as IPv6.
+    MatchUnavailable,
+}
+
 /// Parse a NAT64 source-pool IPv4 address that may carry a canonical host
 /// mask (`x.x.x.x/32`). Address-range expansion stamps `/32` on every pool
 /// IP and `Ipv4Addr::from_str` rejects CIDR, so the mask is stripped before
@@ -240,6 +276,31 @@ impl Nat64State {
             }
         }
         None
+    }
+
+    /// Tri-state NAT64 destination lookup (#2291).
+    ///
+    /// Returns [`Nat64Match::NoPrefixMatch`] when `dst` matches no configured
+    /// prefix (the caller continues IPv6 routing), [`Nat64Match::MatchReady`]
+    /// when a prefix matched and a source IPv4 was allocated (translate), or
+    /// [`Nat64Match::MatchUnavailable`] when a prefix matched but the pool
+    /// could not yield a source (caller MUST drop, never route the synthetic
+    /// IPv6 destination upstream). This is the fail-closed replacement for the
+    /// `match_ipv6_dest(...).and_then(allocate_v4_source)` chain that
+    /// collapsed the unallocatable case into "no match".
+    pub(crate) fn classify_ipv6_dest(&self, dst: Ipv6Addr) -> Nat64Match {
+        match self.match_ipv6_dest(dst) {
+            None => Nat64Match::NoPrefixMatch,
+            Some((prefix_idx, dst_v4)) => match self.allocate_v4_source(prefix_idx) {
+                Some(snat_v4) => Nat64Match::MatchReady {
+                    prefix_idx,
+                    dst_v4,
+                    snat_v4,
+                    dst_v6: dst,
+                },
+                None => Nat64Match::MatchUnavailable,
+            },
+        }
     }
 
     /// Round-robin allocation of an IPv4 source address from the pool.
@@ -419,6 +480,129 @@ pub(crate) fn translate_v6_to_v4(
     Some(out)
 }
 
+/// Walk the IPv6 extension-header chain of an L3-relative IPv6 packet to find
+/// the terminal transport header (#2290).
+///
+/// Returns `(l4_offset, l4_protocol)` where `l4_offset` is the byte offset of
+/// the real transport header (TCP/UDP/ICMPv6/...) measured from the start of
+/// the IPv6 header, and `l4_protocol` is its protocol number. Walks
+/// Hop-by-Hop (0), Routing (43), Destination Options (60), AH (51), and
+/// Fragment (44) headers, bounded to 6 iterations (RFC 8200 §4.1 — a
+/// fixed-order chain rarely exceeds a handful). No-Next-Header (59) and a
+/// chain that runs off the end of the packet return `None`.
+///
+/// This is the NAT64 translator's own bounded walk; it deliberately does NOT
+/// reach into `crate::afxdp` (which itself depends on `crate::nat64`). It
+/// mirrors `afxdp::frame::inspect::packet_rel_l4_offset_and_protocol`; the
+/// unification onto a single shared walker is tracked separately (#2292) and
+/// is not a prerequisite for this fix.
+///
+/// The returned offset is only the START of the L4 header; the caller is
+/// responsible for the non-first-fragment check (a non-first fragment carries
+/// NO L4 header at this offset — its bytes are payload).
+fn ipv6_l4_offset_and_protocol(packet: &[u8]) -> Option<(usize, u8)> {
+    if packet.len() < 40 {
+        return None;
+    }
+    let mut protocol = packet[6];
+    let mut offset = 40usize;
+    for _ in 0..6 {
+        match protocol {
+            // Hop-by-Hop / Routing / Destination Options: length in 8-byte
+            // units, NOT counting the first 8 bytes (RFC 8200).
+            0 | 43 | 60 => {
+                let opt = packet.get(offset..offset + 2)?;
+                protocol = opt[0];
+                offset = offset.checked_add((usize::from(opt[1]) + 1) * 8)?;
+                if packet.len() < offset {
+                    return None;
+                }
+            }
+            // Authentication Header: length in 4-byte units, "minus 2"
+            // (RFC 4302 §2.2).
+            51 => {
+                let opt = packet.get(offset..offset + 2)?;
+                protocol = opt[0];
+                offset = offset.checked_add((usize::from(opt[1]) + 2) * 4)?;
+                if packet.len() < offset {
+                    return None;
+                }
+            }
+            // Fragment header: fixed 8 bytes.
+            44 => {
+                let frag = packet.get(offset..offset + 8)?;
+                protocol = frag[0];
+                offset = offset.checked_add(8)?;
+                if packet.len() < offset {
+                    return None;
+                }
+            }
+            // No Next Header — no transport to translate.
+            59 => return None,
+            // Terminal: a real upper-layer protocol.
+            _ => return Some((offset, protocol)),
+        }
+    }
+    Some((offset, protocol))
+}
+
+/// Is this L3-relative IPv6 packet a NON-first fragment (#2290)?
+///
+/// Walks the (bounded) extension-header chain looking for a Fragment header
+/// (44). Returns `true` iff a fragment header is present AND its fragment
+/// offset (upper 13 bits of bytes 2-3, mask `0xFFF8`, RFC 8200 §4.5) is
+/// non-zero. A non-first fragment carries no L4 header, so its payload bytes
+/// must NOT be read as L4 — the translators fail closed on it. First/atomic
+/// fragments (offset 0) and packets without a fragment header return `false`.
+/// Mirrors `afxdp::frame::inspect::ipv6_is_non_first_fragment`.
+fn ipv6_is_non_first_fragment(packet: &[u8]) -> bool {
+    if packet.len() < 40 {
+        return false;
+    }
+    let mut protocol = packet[6];
+    let mut offset = 40usize;
+    for _ in 0..6 {
+        match protocol {
+            0 | 43 | 60 => {
+                let Some(opt) = packet.get(offset..offset + 2) else {
+                    return false;
+                };
+                protocol = opt[0];
+                let Some(next) = offset.checked_add((usize::from(opt[1]) + 1) * 8) else {
+                    return false;
+                };
+                offset = next;
+                if packet.len() < offset {
+                    return false;
+                }
+            }
+            51 => {
+                let Some(opt) = packet.get(offset..offset + 2) else {
+                    return false;
+                };
+                protocol = opt[0];
+                let Some(next) = offset.checked_add((usize::from(opt[1]) + 2) * 4) else {
+                    return false;
+                };
+                offset = next;
+                if packet.len() < offset {
+                    return false;
+                }
+            }
+            44 => {
+                let Some(frag) = packet.get(offset..offset + 8) else {
+                    return false;
+                };
+                let frag_off = u16::from_be_bytes([frag[2], frag[3]]) & 0xFFF8;
+                return frag_off != 0;
+            }
+            59 => return false,
+            _ => return false,
+        }
+    }
+    false
+}
+
 /// Allocation-free IPv6→IPv4 translation: write the translated IPv4 L3 packet
 /// directly into `dst` and return the number of bytes written (#2211).
 ///
@@ -445,21 +629,43 @@ pub(crate) fn write_v6_to_v4_into(
     // stateless translation, not RFC 6040 tunnel encapsulation).
     let traffic_class = ((packet[0] & 0x0f) << 4) | (packet[1] >> 4);
     let payload_len = u16::from_be_bytes([packet[4], packet[5]]) as usize;
-    let next_header = packet[6];
     let hop_limit = packet[7];
 
     if hop_limit <= 1 {
         return None; // TTL expired
     }
 
-    // Map protocol.
-    let ipv4_protocol = match next_header {
+    // #2290: walk the IPv6 extension-header chain to learn the terminal L4
+    // offset and protocol instead of assuming L4 at byte 40 / reading the
+    // raw next-header. A packet carrying Hop-by-Hop / Routing / Dest-Opts /
+    // AH / Fragment before its transport header was previously dropped as
+    // "unsupported protocol" even though it is legal RFC 8200 input.
+    let (l4_offset, l4_protocol) = ipv6_l4_offset_and_protocol(packet)?;
+
+    // A non-first fragment has NO L4 header at `l4_offset` — its bytes are
+    // payload. Reading them as a transport header (and translating) would
+    // corrupt the datagram, so fail closed (drop).
+    if ipv6_is_non_first_fragment(packet) {
+        return None;
+    }
+
+    // Map protocol from the terminal L4, not the raw next-header.
+    let ipv4_protocol = match l4_protocol {
         PROTO_ICMPV6 => PROTO_ICMP,
-        PROTO_TCP | PROTO_UDP => next_header,
+        PROTO_TCP | PROTO_UDP => l4_protocol,
         _ => return None, // Unsupported protocol
     };
 
-    let l4_payload = packet.get(40..40 + payload_len)?;
+    // The L4 region starts at the walked offset and ends at the IPv6
+    // payload boundary (`40 + payload_len`). The ext-header bytes between
+    // byte 40 and `l4_offset` are stripped by NAT64: RFC 7915 §5.1 maps the
+    // IPv6 packet to an IPv4 packet carrying only the transport payload,
+    // dropping the (non-translatable) IPv6 extension headers.
+    let l4_end = 40usize.checked_add(payload_len)?;
+    if l4_offset > l4_end {
+        return None; // ext-header chain overran the advertised payload
+    }
+    let l4_payload = packet.get(l4_offset..l4_end)?;
     let new_ttl = hop_limit - 1;
 
     // The L4 length is normally unchanged, but an ICMP *error* message embeds
@@ -499,7 +705,7 @@ pub(crate) fn write_v6_to_v4_into(
     out[16..20].copy_from_slice(&dst_v4.octets());
 
     // Translate the L4 region into the output and learn its final length.
-    let l4_len = if next_header == PROTO_ICMPV6 {
+    let l4_len = if l4_protocol == PROTO_ICMPV6 {
         // The embedded (quoted) original packet is the RETURN-direction packet:
         // its addresses are the outer error's addresses swapped, so v6->v4 the
         // embedded src maps to `dst_v4` and the embedded dst maps to `snat_v4`.
@@ -1013,23 +1219,43 @@ fn translate_embedded_v6_to_v4(
     let quote_in = &embedded[..embedded.len().min(MAX_EMBEDDED_LEN)];
 
     let payload_len = u16::from_be_bytes([quote_in[4], quote_in[5]]) as usize;
-    let next_header = quote_in[6];
     let hop_limit = quote_in[7];
     let traffic_class = ((quote_in[0] & 0x0f) << 4) | (quote_in[1] >> 4);
 
-    // Map protocol (same set the outer translator supports). An embedded packet
-    // carrying an unsupported protocol can't be faithfully translated -> drop.
-    let ipv4_protocol = match next_header {
+    // #2290: walk the quoted IPv6 packet's extension-header chain to find the
+    // terminal L4 offset/protocol rather than assuming L4 at byte 40. The
+    // quote is frequently truncated (often to 8 bytes of L4), so the walk may
+    // run off the end of `quote_in`; in that case `ipv6_l4_offset_and_protocol`
+    // returns `None` and we fail closed — the same drop the outer translator
+    // takes — rather than misreading ext-header bytes as a transport header.
+    let (l4_offset, l4_protocol) = ipv6_l4_offset_and_protocol(quote_in)?;
+
+    // A non-first fragment carries no L4 header — its bytes are payload. Do
+    // not read them as L4 (drop), matching the outer translator (#2290).
+    if ipv6_is_non_first_fragment(quote_in) {
+        return None;
+    }
+
+    // Map protocol (same set the outer translator supports) from the terminal
+    // L4. An embedded packet carrying an unsupported protocol can't be
+    // faithfully translated -> drop.
+    let ipv4_protocol = match l4_protocol {
         PROTO_ICMPV6 => PROTO_ICMP,
-        PROTO_TCP | PROTO_UDP => next_header,
+        PROTO_TCP | PROTO_UDP => l4_protocol,
         _ => return None,
     };
 
-    // The quoted L4 is whatever bytes are present after the IPv6 header, capped
-    // by both the IPv6 payload_len field and the bytes actually quoted.
-    let avail_l4 = quote_in.len() - 40;
-    let l4_len = payload_len.min(avail_l4);
-    let l4 = quote_in.get(40..40 + l4_len)?;
+    // The quoted L4 starts at the walked offset and runs to the end of the
+    // advertised IPv6 payload (`40 + payload_len`), capped by the bytes
+    // actually quoted. The IPv6 extension headers between byte 40 and
+    // `l4_offset` are stripped, mirroring the outer translation.
+    let payload_end = 40usize.checked_add(payload_len)?;
+    let quoted_end = payload_end.min(quote_in.len());
+    if l4_offset > quoted_end {
+        return None; // ext-header chain overran the quoted bytes
+    }
+    let l4 = quote_in.get(l4_offset..quoted_end)?;
+    let l4_len = l4.len();
 
     let total = 20 + l4_len;
     let out = dst.get_mut(..total)?;
@@ -1049,7 +1275,7 @@ fn translate_embedded_v6_to_v4(
     // quoted v4 packet is internally consistent (the quoted L4 checksum is left
     // as-is — it is not validated by a receiver). Only the leading type/code are
     // touched; a fuller embedded-ICMP translation is unnecessary for the quote.
-    if next_header == PROTO_ICMPV6 && l4_len >= 2 {
+    if l4_protocol == PROTO_ICMPV6 && l4_len >= 2 {
         if let Some((t, c)) = embedded_icmpv6_type_to_icmpv4(out[20]) {
             out[20] = t;
             out[21] = c;

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -1838,3 +1838,328 @@ fn nat64_unsupported_icmpv6_type_still_dropped() {
         "unmappable ICMPv6 type must be dropped"
     );
 }
+
+// ===========================================================================
+// #2290: IPv6 extension-header walk in the v6->v4 translator.
+//
+// Pre-fix the translator read packet[6] as the L4 protocol and assumed L4 at
+// byte 40, so any packet carrying a Hop-by-Hop / Routing / Dest-Opts / AH /
+// Fragment header before its transport header was dropped as "unsupported
+// protocol". These tests are FAIL-ON-REVERT: each builds a valid v6 packet
+// with an extension header before TCP/UDP and asserts it TRANSLATES (not
+// dropped). Reverting the fix (fixed offset 40 + raw next-header) reads the
+// ext-header type as the L4 protocol -> `expect("translate")` panics.
+// ===========================================================================
+
+/// Build an IPv6 packet carrying ONE extension header (`ext_type`, given
+/// option bytes) before the terminal L4 (`l4_proto`, `l4` bytes). The ext
+/// header is `Type-Length-Optiondata` per RFC 8200: byte 0 = next-header
+/// (the L4 proto), byte 1 = Hdr Ext Len in 8-octet units NOT counting the
+/// first 8 octets. `ext_payload` is the option data AFTER the 2-byte
+/// type/len; its length must make the ext header a multiple of 8 octets.
+fn build_v6_with_ext_then_l4(
+    src: Ipv6Addr,
+    dst: Ipv6Addr,
+    ext_type: u8,
+    ext_payload: &[u8],
+    l4_proto: u8,
+    hl: u8,
+    l4: &[u8],
+) -> Vec<u8> {
+    // ext header = [next_header, hdr_ext_len, ext_payload...]
+    let ext_len_bytes = 2 + ext_payload.len();
+    assert_eq!(ext_len_bytes % 8, 0, "ext header must be a multiple of 8");
+    let hdr_ext_len = (ext_len_bytes / 8 - 1) as u8;
+    let mut p = vec![0u8; 40 + ext_len_bytes + l4.len()];
+    p[0] = 0x60;
+    // IPv6 payload_len covers ext header + L4.
+    p[4..6].copy_from_slice(&((ext_len_bytes + l4.len()) as u16).to_be_bytes());
+    p[6] = ext_type; // first next-header points at the ext header
+    p[7] = hl;
+    p[8..24].copy_from_slice(&src.octets());
+    p[24..40].copy_from_slice(&dst.octets());
+    // Extension header.
+    p[40] = l4_proto; // ext's next-header = terminal L4
+    p[41] = hdr_ext_len;
+    p[42..42 + ext_payload.len()].copy_from_slice(ext_payload);
+    // L4.
+    let l4_off = 40 + ext_len_bytes;
+    p[l4_off..l4_off + l4.len()].copy_from_slice(l4);
+    p
+}
+
+#[test]
+fn ipv6_l4_offset_walks_dest_opts_then_tcp() {
+    // Dest-Opts (60) 8 bytes, then TCP at offset 48.
+    let src: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst: Ipv6Addr = "64:ff9b::0808:0808".parse().unwrap();
+    let pkt = build_v6_with_ext_then_l4(src, dst, 60, &[0u8; 6], PROTO_TCP, 64, &[0u8; 20]);
+    let (off, proto) = ipv6_l4_offset_and_protocol(&pkt).expect("walk must find L4");
+    assert_eq!(off, 48, "TCP starts after the 8-byte Dest-Opts header");
+    assert_eq!(proto, PROTO_TCP);
+}
+
+#[test]
+fn ipv6_l4_offset_walks_hop_by_hop_then_udp() {
+    let src: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst: Ipv6Addr = "64:ff9b::0808:0808".parse().unwrap();
+    let pkt = build_v6_with_ext_then_l4(src, dst, 0, &[0u8; 6], PROTO_UDP, 64, &[0u8; 8]);
+    let (off, proto) = ipv6_l4_offset_and_protocol(&pkt).expect("walk must find L4");
+    assert_eq!(off, 48);
+    assert_eq!(proto, PROTO_UDP);
+}
+
+#[test]
+fn translate_v6_to_v4_tcp_behind_dest_opts() {
+    // FAIL-ON-REVERT: a Dest-Opts header before TCP. Pre-fix this read
+    // next_header=60 (Dest-Opts) as the protocol -> `_ => return None` drop.
+    let src_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let snat_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(198, 51, 100, 50);
+
+    // Minimal TCP header (20 bytes) + 5-byte payload, ports 12345 -> 80.
+    let mut tcp = vec![0u8; 25];
+    tcp[0..2].copy_from_slice(&12345u16.to_be_bytes());
+    tcp[2..4].copy_from_slice(&80u16.to_be_bytes());
+    tcp[12] = 0x50; // data offset 5
+    tcp[13] = 0x02; // SYN
+    tcp[20..25].copy_from_slice(b"hello");
+
+    let ipv6_pkt =
+        build_v6_with_ext_then_l4(src_v6, dst_v6, 60, &[0u8; 6], PROTO_TCP, 64, &tcp);
+    let v4 = translate_v6_to_v4(&ipv6_pkt, snat_v4, dst_v4, false)
+        .expect("TCP behind Dest-Opts must translate, not drop");
+
+    assert_eq!(v4[0], 0x45);
+    assert_eq!(v4[9], PROTO_TCP, "protocol must be the terminal L4, not 60");
+    assert_eq!(&v4[12..16], &snat_v4.octets());
+    assert_eq!(&v4[16..20], &dst_v4.octets());
+    // The ext header is stripped: IPv4 length = 20 + 25 (NOT 20 + 8 + 25).
+    assert_eq!(v4.len(), 20 + 25, "Dest-Opts header stripped from output");
+    // TCP ports preserved at the IPv4 L4 offset.
+    assert_eq!(u16::from_be_bytes([v4[20], v4[21]]), 12345);
+    assert_eq!(u16::from_be_bytes([v4[22], v4[23]]), 80);
+    assert_eq!(checksum16(&v4[..20]), 0, "IPv4 header checksum valid");
+}
+
+#[test]
+fn translate_v6_to_v4_udp_behind_hop_by_hop() {
+    // FAIL-ON-REVERT: UDP behind a Hop-by-Hop (0) header.
+    let src_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst_v6: Ipv6Addr = "64:ff9b::0808:0808".parse().unwrap();
+    let snat_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+
+    let mut udp = vec![0u8; 8 + 4];
+    udp[0..2].copy_from_slice(&5353u16.to_be_bytes());
+    udp[2..4].copy_from_slice(&53u16.to_be_bytes());
+    udp[4..6].copy_from_slice(&(12u16).to_be_bytes()); // UDP length
+    udp[8..12].copy_from_slice(b"data");
+
+    let ipv6_pkt = build_v6_with_ext_then_l4(src_v6, dst_v6, 0, &[0u8; 6], PROTO_UDP, 64, &udp);
+    let v4 = translate_v6_to_v4(&ipv6_pkt, snat_v4, dst_v4, false)
+        .expect("UDP behind Hop-by-Hop must translate, not drop");
+
+    assert_eq!(v4[9], PROTO_UDP, "protocol must be the terminal L4, not 0");
+    assert_eq!(v4.len(), 20 + 12, "Hop-by-Hop header stripped");
+    assert_eq!(u16::from_be_bytes([v4[20], v4[21]]), 5353);
+    assert_eq!(u16::from_be_bytes([v4[22], v4[23]]), 53);
+}
+
+#[test]
+fn translate_v6_to_v4_non_first_fragment_dropped() {
+    // A non-first fragment carries no L4 header. The walker must NOT read its
+    // payload bytes as a transport header — fail closed (drop).
+    let src_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst_v6: Ipv6Addr = "64:ff9b::0808:0808".parse().unwrap();
+    let snat_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+
+    // Fragment header (44), 8 bytes: next-header=TCP, frag-offset != 0.
+    // bytes: [nh, reserved, frag_off_hi, frag_off_lo|flags, id(4)].
+    // Set fragment offset to 0x0010 (>0) in the upper 13 bits.
+    let mut frag = vec![0u8; 8 + 16]; // frag header + 16 "payload" bytes
+    frag[0] = PROTO_TCP; // next-header
+    frag[2..4].copy_from_slice(&0x0010u16.to_be_bytes()); // frag offset != 0
+    let mut pkt = vec![0u8; 40 + frag.len()];
+    pkt[0] = 0x60;
+    pkt[4..6].copy_from_slice(&(frag.len() as u16).to_be_bytes());
+    pkt[6] = 44; // first next-header = Fragment
+    pkt[7] = 64;
+    pkt[8..24].copy_from_slice(&src_v6.octets());
+    pkt[24..40].copy_from_slice(&dst_v6.octets());
+    pkt[40..].copy_from_slice(&frag);
+
+    assert!(
+        ipv6_is_non_first_fragment(&pkt),
+        "predicate must flag the non-first fragment"
+    );
+    assert!(
+        translate_v6_to_v4(&pkt, snat_v4, dst_v4, false).is_none(),
+        "non-first fragment must be dropped, not translated from payload bytes"
+    );
+}
+
+#[test]
+fn translate_v6_to_v4_first_fragment_still_translates() {
+    // A FIRST fragment (offset 0) carries the real L4 header and must still
+    // translate — the non-first-fragment guard must not over-reject.
+    let src_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst_v6: Ipv6Addr = "64:ff9b::0808:0808".parse().unwrap();
+    let snat_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+
+    let mut udp = vec![0u8; 8];
+    udp[0..2].copy_from_slice(&1111u16.to_be_bytes());
+    udp[2..4].copy_from_slice(&2222u16.to_be_bytes());
+    udp[4..6].copy_from_slice(&8u16.to_be_bytes());
+
+    // Fragment header with offset 0 (first fragment), MF can be set.
+    let mut frag = vec![0u8; 8 + udp.len()];
+    frag[0] = PROTO_UDP;
+    frag[2..4].copy_from_slice(&0x0001u16.to_be_bytes()); // offset 0, MF=1
+    frag[8..].copy_from_slice(&udp);
+    let mut pkt = vec![0u8; 40 + frag.len()];
+    pkt[0] = 0x60;
+    pkt[4..6].copy_from_slice(&(frag.len() as u16).to_be_bytes());
+    pkt[6] = 44;
+    pkt[7] = 64;
+    pkt[8..24].copy_from_slice(&src_v6.octets());
+    pkt[24..40].copy_from_slice(&dst_v6.octets());
+    pkt[40..].copy_from_slice(&frag);
+
+    assert!(!ipv6_is_non_first_fragment(&pkt), "first fragment is not non-first");
+    let v4 = translate_v6_to_v4(&pkt, snat_v4, dst_v4, false)
+        .expect("first fragment must translate");
+    assert_eq!(v4[9], PROTO_UDP);
+    assert_eq!(u16::from_be_bytes([v4[20], v4[21]]), 1111);
+}
+
+#[test]
+fn nat64_v6_to_v4_time_exceeded_quoting_ext_headered_tcp_translates() {
+    // FAIL-ON-REVERT (#2290 embedded path): an ICMPv6 Time-Exceeded whose
+    // quoted original packet carries a Dest-Opts header before TCP. Pre-fix
+    // the embedded translator read quote[6]=60 as the protocol and dropped
+    // the whole error -> PMTUD/traceroute blackhole. Now it walks the quoted
+    // ext-header chain and translates the embedded packet.
+    let client_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst_v6: Ipv6Addr = "64:ff9b::0808:0808".parse().unwrap();
+    let snat_v4 = Ipv4Addr::new(198, 51, 100, 1);
+    let dst_v4 = Ipv4Addr::new(8, 8, 8, 8);
+
+    // Quoted original = v6 packet with Dest-Opts then 8 bytes of TCP.
+    let inner_l4 = [0x30u8, 0x39, 0x00, 0x50, 0x09, 0x08, 0x07, 0x06];
+    let embedded =
+        build_v6_with_ext_then_l4(client_v6, dst_v6, 60, &[0u8; 6], PROTO_TCP, 1, &inner_l4);
+    let icmp = build_icmpv6_error(3, 0, [0, 0, 0, 0], &embedded);
+    let hop_v6: Ipv6Addr = "2001:db8:ffff::1".parse().unwrap();
+    let mut v6_pkt = build_v6_with_l4(hop_v6, client_v6, PROTO_ICMPV6_C, 64, &icmp);
+    v6_pkt[42..44].copy_from_slice(&[0, 0]);
+    let s = checksum16_ipv6_pseudo(hop_v6, client_v6, PROTO_ICMPV6_C, &v6_pkt[40..]);
+    v6_pkt[42..44].copy_from_slice(&s.to_be_bytes());
+
+    let v4 = translate_v6_to_v4(&v6_pkt, snat_v4, dst_v4, false)
+        .expect("ICMPv6 error quoting ext-headered TCP must translate, not drop");
+    assert_eq!(v4[20], 11, "outer ICMPv4 Time Exceeded type");
+    assert_eq!(checksum16(&v4[..20]), 0);
+    // Embedded translated IPv4 header starts at v4[28] (20 outer IP + 8 ICMP).
+    let emb = &v4[28..];
+    assert_eq!(emb[9], PROTO_TCP, "embedded protocol = TCP, ext header stripped");
+    assert_eq!(&emb[12..16], &dst_v4.octets(), "embedded src mapped to dst_v4");
+    assert_eq!(&emb[16..20], &snat_v4.octets(), "embedded dst mapped to snat_v4");
+    assert_eq!(checksum16(&emb[..20]), 0, "embedded IPv4 header checksum valid");
+}
+
+#[test]
+fn nat64_v6_to_v4_ext_header_path_unaffects_plain_tcp() {
+    // Regression: a PLAIN TCP packet (no ext header) must still translate
+    // byte-identically after the walk was added — the walk returns offset 40
+    // for a packet whose first next-header is already the L4.
+    let src_v6: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    let dst_v6: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap();
+    let pkt = make_ipv6_tcp_packet(src_v6, dst_v6, 12345, 80, b"hello");
+    let (off, proto) = ipv6_l4_offset_and_protocol(&pkt).expect("plain walk");
+    assert_eq!(off, 40, "no ext header -> L4 at byte 40");
+    assert_eq!(proto, PROTO_TCP);
+    let v4 = translate_v6_to_v4(
+        &pkt,
+        Ipv4Addr::new(198, 51, 100, 1),
+        Ipv4Addr::new(198, 51, 100, 50),
+        false,
+    )
+    .expect("plain TCP translate");
+    assert_eq!(v4.len(), 45, "plain TCP length unchanged (20 + 25)");
+    assert_eq!(v4[9], PROTO_TCP);
+}
+
+// ===========================================================================
+// #2291: fail-closed tri-state NAT64 lookup. A matched prefix with no usable
+// source pool must drop, not fall through to IPv6 routing on the synthetic
+// destination.
+// ===========================================================================
+
+#[test]
+fn classify_no_prefix_match_continues_ipv6_routing() {
+    let state = Nat64State::from_snapshots(&[well_known_prefix()]);
+    let dst: Ipv6Addr = "2001:db8::1".parse().unwrap(); // not the NAT64 prefix
+    assert_eq!(state.classify_ipv6_dest(dst), Nat64Match::NoPrefixMatch);
+}
+
+#[test]
+fn classify_match_ready_when_pool_has_source() {
+    let state = Nat64State::from_snapshots(&[well_known_prefix()]);
+    let dst: Ipv6Addr = "64:ff9b::c633:6432".parse().unwrap(); // ::198.51.100.50
+    match state.classify_ipv6_dest(dst) {
+        Nat64Match::MatchReady {
+            prefix_idx,
+            dst_v4,
+            snat_v4,
+            dst_v6,
+        } => {
+            assert_eq!(prefix_idx, 0);
+            assert_eq!(dst_v4, Ipv4Addr::new(198, 51, 100, 50));
+            assert!(
+                snat_v4 == Ipv4Addr::new(198, 51, 100, 1)
+                    || snat_v4 == Ipv4Addr::new(198, 51, 100, 2),
+                "snat from configured pool"
+            );
+            assert_eq!(dst_v6, dst);
+        }
+        other => panic!("expected MatchReady, got {other:?}"),
+    }
+}
+
+#[test]
+fn classify_match_unavailable_on_empty_pool_fails_closed() {
+    // The exact #2291 wire state: a configured NAT64 prefix with an empty
+    // (no-source) pool. The lookup MUST report MatchUnavailable so the caller
+    // drops, NOT NoPrefixMatch (which would continue IPv6 routing on the
+    // synthetic destination — the pre-fix fail-open).
+    let state = Nat64State::from_snapshots(&[NAT64RuleSnapshot {
+        name: "no-pool".to_string(),
+        prefix: "64:ff9b::/96".to_string(),
+        pool_addresses: vec![],
+        no_v6_frag_header: false,
+    }]);
+    let dst: Ipv6Addr = "64:ff9b::0808:0808".parse().unwrap();
+
+    // Sanity: the prefix DOES match, and the source allocation DOES fail.
+    assert!(state.match_ipv6_dest(dst).is_some(), "prefix must match");
+    assert!(state.allocate_v4_source(0).is_none(), "empty pool yields no source");
+
+    let result = state.classify_ipv6_dest(dst);
+    assert_eq!(
+        result,
+        Nat64Match::MatchUnavailable,
+        "empty-pool match must fail closed (drop), not fall through to IPv6 routing"
+    );
+    // Counter-factual: the pre-fix chain collapsed this to None ==
+    // NoPrefixMatch, which the caller treats as "route as IPv6". Assert the
+    // new result is NOT that fail-open value.
+    assert_ne!(
+        result,
+        Nat64Match::NoPrefixMatch,
+        "must NOT be treated as no-match (would IPv6-route the synthetic dest)"
+    );
+}

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -442,6 +442,12 @@ pub(crate) struct BindingStatus {
     // omitempty/serde-default contract).
     #[serde(rename = "nat64_translations", default)]
     pub nat64_translations: u64,
+    // #2291: fail-closed NAT64 drops — a prefix matched but no IPv4 source
+    // could be allocated (empty/exhausted pool), so the synthetic IPv6
+    // destination was dropped rather than route-looked-up as IPv6. `default`
+    // keeps the same cross-version wire safety as nat64_translations above.
+    #[serde(rename = "nat64_no_source_pool", default)]
+    pub nat64_no_source_pool: u64,
     #[serde(rename = "slow_path_packets", default)]
     pub slow_path_packets: u64,
     #[serde(rename = "slow_path_bytes", default)]

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -106,6 +106,7 @@
     "mirror_drops_tx_frame_reserve": 0,
     "mirrored_bytes": 0,
     "mirrored_packets": 0,
+    "nat64_no_source_pool": 0,
     "nat64_translations": 0,
     "neighbor_miss_packets": 0,
     "next_table_packets": 0,


### PR DESCRIPTION
## Summary

Two NAT64 correctness/fail-open fixes in the Rust AF_XDP dataplane.

- **#2290** — the v6→v4 translator parsed IPv6 at a fixed offset 40 and read
  the raw next-header byte, so any packet carrying a Hop-by-Hop, Routing,
  Destination Options, AH, or Fragment extension header before its transport
  header was dropped as "unsupported protocol" even though it is legal RFC 8200
  input. Worse on the embedded ICMP-error path (`translate_embedded_v6_to_v4`,
  the #2219 PMTUD/traceroute path): a quoted original packet with an ext header
  re-opened the blackhole #2219 closed. **Fix:** a local bounded ext-header
  walker (`ipv6_l4_offset_and_protocol`) + non-first-fragment predicate
  (`ipv6_is_non_first_fragment`) in `nat64.rs`, used by both
  `write_v6_to_v4_into` and `translate_embedded_v6_to_v4` to learn the terminal
  L4 offset/protocol before translating. Ext-header bytes are stripped
  (RFC 7915 maps only the transport payload). Non-first fragments fail closed.
- **#2291** — when a NAT64 prefix matched but no IPv4 source could be allocated
  (empty/exhausted pool — a legitimate wire state the Go side emits for a
  no-source-pool rule), the code collapsed "matched but unallocatable" into "no
  match" and continued ordinary IPv6 route lookup on the synthetic NAT64
  destination (`64:ff9b::a.b.c.d`). With a permissive default IPv6 route that
  leaked the untranslated synthetic-destination traffic upstream — a fail-open
  at the NAT64 boundary. **Fix:** tri-state `Nat64Match` enum
  (`NoPrefixMatch` / `MatchReady` / `MatchUnavailable`) returned by
  `Nat64State::classify_ipv6_dest`. Only `NoPrefixMatch` continues IPv6
  routing; `MatchUnavailable` fails closed — drop + bump a new
  `nat64_no_source_pool` per-binding counter, consistent with the
  #2124/#2142/#2173/#2175 fail-closed family.
- The drop counter is wired `BatchCounters` → `BindingLiveState` → snapshot →
  `BindingStatus` JSON → Go `protocol.go` + a `format/status.go` operator line
  (`NAT64 no-source-pool drops`). The wire-format fixture
  (`protocol_wire_v1.json`) is regenerated for the additive field.

## Why a local ext-header walker (not `inspect.rs`)

`crate::afxdp` already depends on `crate::nat64`, so reusing
`afxdp::frame::inspect::packet_rel_l4_offset_and_protocol` would invert the
dependency. The issue explicitly permits a correct local walk and says not to
block on the unifier (#2292). The walk is bounded to 6 iterations and allocates
nothing.

## Hot-path shape

- Ext-header walk: ≤6 iterations, zero allocation, only on NAT64 v6→v4 frames.
- Tri-state classify: same prefix scan + pool-index fetch as before, just not
  collapsing the unallocatable case into "no match".

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 2269 passed, 0 failed (full suite)
- [x] `go build ./...` — clean
- [x] #2290: `ipv6_l4_offset_walks_dest_opts_then_tcp` / `_hop_by_hop_then_udp`;
      `translate_v6_to_v4_tcp_behind_dest_opts` / `_udp_behind_hop_by_hop`
      (fail-on-revert); `translate_v6_to_v4_non_first_fragment_dropped` /
      `_first_fragment_still_translates`;
      `nat64_v6_to_v4_time_exceeded_quoting_ext_headered_tcp_translates`
      (embedded path); `nat64_v6_to_v4_ext_header_path_unaffects_plain_tcp`
- [x] #2291: `classify_no_prefix_match_continues_ipv6_routing`;
      `classify_match_ready_when_pool_has_source`;
      `classify_match_unavailable_on_empty_pool_fails_closed` (counter-factual:
      asserts result != `NoPrefixMatch`, the pre-fix fail-open);
      `nat64_no_source_pool_flushes_to_live_and_snapshot`
- [ ] Cluster smoke — deferred to parent batch (not run here)

## Note on test flakiness

The pre-existing `afxdp::worker_queue::tests::concurrent_recovery_processes_each_command_exactly_once`
contention test is timing-sensitive and flakes independently of this change
(verified failing 1-of-3 runs on clean `origin/master`); it touches no NAT64
code.

## Refs

Closes #2290, closes #2291. Ext-walker unification tracked in #2292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)