### PR TITLE
userspace-dp: RFC error-suppression guards + RFC 4443 §3 quote length on locally-generated ICMP errors (#2237 #2242)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -9827,3 +9827,22 @@ top.
   **File(s)**: userspace-dp/src/afxdp/icmp.rs,
   userspace-dp/src/afxdp/mod.rs, userspace-dp/src/afxdp/tests.rs,
   userspace-dp/src/afxdp/README.md, _Log.md
+- **Timestamp**: 2026-06-21
+  **Action**: #2242 (LOW) — RFC 4443 §3 quote length on the
+  locally-generated ICMPv6 error builder. `build_local_icmp_error_v6`
+  quoted a fixed 48 bytes (40-byte IPv6 base header + only 8), which
+  omitted the transport header whenever IPv6 extension headers pushed it
+  past byte 48 — so the receiver could not demux the error back to a
+  socket (broken PMTUD/traceroute diagnostics). Now quotes up to the
+  RFC 4443 §3 minimum-MTU cap: `1280 - 40 - 8 = 1232` bytes, bounded by
+  the actual invoking packet length. The IPv4 builder keeps the RFC 792
+  minimum (IHL + 8) — correct for v4. The UMEM frame is 4096 B so the
+  larger quote never overruns the TX buffer. Tests (2 new,
+  fail-on-revert): an ICMPv6 error for a packet with a 56-byte
+  Destination-Options ext header asserts the quote includes the transport
+  marker behind the ext headers (and the whole ICMPv6 packet stays under
+  1280); an oversized invoking packet asserts the quote clamps to exactly
+  the 1280 cap. Reverting to the fixed-48 quote fails both.
+  **File(s)**: userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/tests.rs, userspace-dp/src/afxdp/README.md,
+  _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -9802,3 +9802,28 @@ top.
   pkg/dataplane/userspace/format/status_test.go,
   pkg/api/metrics_userspace.go,
   userspace-dp/src/afxdp/event_emit.rs, _Log.md
+
+- **Timestamp**: 2026-06-21
+  **Action**: #2237 (HIGH) — RFC error-suppression guards on the
+  locally-generated ICMP Time Exceeded path. The Time Exceeded generator
+  only checked TTL — it lacked the RFC 1812 §4.3.2.7 / RFC 4443 §2.4
+  guards the reject path already had. Added a single shared gate
+  `can_generate_icmp_error_reply(frame, meta)` in `icmp.rs` that
+  suppresses an ICMP error when the trigger is itself an ICMP/ICMPv6
+  error (storm/amplification), a non-first IP fragment, sent to an L3
+  multicast/broadcast or an L2 group MAC, or sourced from a non-unique
+  address (unspecified/loopback/multicast/broadcast). Both
+  `build_local_time_exceeded_request` and `build_reject_icmp_unreachable`
+  now route through this one predicate (one source of truth — the reject
+  path previously guarded only the fragment + ICMP-error subset). Hot
+  path: cheap branchless field reads, no per-packet allocation; normal
+  TTL>1 forwarding untouched. Tests (13 new, all fail-on-revert): TTL=1
+  ICMP-error trigger (v4+v6), non-first fragment (v4+v6),
+  multicast/broadcast dest (v4+v6), L2 group MAC with unicast L3 dest,
+  unspecified/loopback/multicast source produce NO Time Exceeded; normal
+  unicast UDP/TCP DOES (echo-query counterfactuals). Fail-on-revert
+  proven: removing the guard fails all 13 suppression tests; the 2
+  positive tests stay green.
+  **File(s)**: userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/mod.rs, userspace-dp/src/afxdp/tests.rs,
+  userspace-dp/src/afxdp/README.md, _Log.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -73,9 +73,13 @@ sync.
   ICMP/ICMPv6 error (storm/amplification), a non-first IP fragment
   (no transport context), a multicast/broadcast destination (L3 or L2),
   or a non-unique source (unspecified/loopback/multicast/broadcast) —
-  one source of truth so the two generators cannot drift. The reflected
-  error carries the inbound VLAN TCI verbatim (see the `frame/` note
-  above).
+  one source of truth so the two generators cannot drift. The ICMPv6
+  builder quotes as much of the invoking packet as fits under the
+  RFC 4443 §3 minimum-MTU cap (1280 = 40 IPv6 + 8 ICMPv6 + 1232 quote)
+  so the transport header is included even behind extension headers
+  (#2242, was a fixed 48 bytes). The IPv4 builder quotes the RFC 792
+  minimum (IHL + 8). The reflected error carries the inbound VLAN TCI
+  verbatim (see the `frame/` note above).
 - `event_emit.rs` — fixed-size, non-blocking RT_FLOW event producers
   for userspace policy-deny, screen-drop, logged PBR filter hits, and
   non-PBR input/output/lo0 filter logs. Output filter-log identity is

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -64,6 +64,18 @@ sync.
   active-bucket selection, fair-share lease (#1229 Phase 6 v8). See
   `docs/per-5-tuple/state.md` for the architectural ceiling.
 - `forwarding/` — FIB lookup, next-hop selection, VLAN/GRE encap.
+- `icmp.rs` — locally-generated ICMP/ICMPv6 error builders: TTL/hop-limit
+  expiry Time Exceeded (`build_local_time_exceeded_request`) and the
+  #2089 policy-`reject` Destination Unreachable
+  (`build_reject_icmp_unreachable`). Both originate a *new* ICMP error and
+  share one RFC 1812 §4.3.2.7 / RFC 4443 §2.4 suppression gate,
+  `can_generate_icmp_error_reply` (#2237): never reply to an inbound
+  ICMP/ICMPv6 error (storm/amplification), a non-first IP fragment
+  (no transport context), a multicast/broadcast destination (L3 or L2),
+  or a non-unique source (unspecified/loopback/multicast/broadcast) —
+  one source of truth so the two generators cannot drift. The reflected
+  error carries the inbound VLAN TCI verbatim (see the `frame/` note
+  above).
 - `event_emit.rs` — fixed-size, non-blocking RT_FLOW event producers
   for userspace policy-deny, screen-drop, logged PBR filter hits, and
   non-PBR input/output/lo0 filter logs. Output filter-log identity is

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -17,6 +17,115 @@ pub(super) fn packet_ttl_would_expire(frame: &[u8], meta: UserspaceDpMeta) -> Op
     }
 }
 
+/// RFC 1812 §4.3.2.7 / RFC 792 / RFC 4443 §2.4 ICMP-error generation
+/// suppression gate. An ICMP/ICMPv6 error message MUST NOT be generated
+/// in response to a triggering datagram that is any of the following.
+/// All callers that originate a *new* ICMP error (Time Exceeded, reject
+/// Destination Unreachable) route through this single predicate so the
+/// two generators enforce one contract (engineering-style §3, one source
+/// of truth) — the #2237 fix found the Time Exceeded path missing the
+/// guards the reject path already had.
+///
+/// Suppressed when the triggering packet is:
+///   (a) itself an ICMP/ICMPv6 *error* message — prevents error storms
+///       and amplification loops (RFC 1812 §4.3.2.7(c), RFC 4443 §2.4(e));
+///   (b) a non-first IP fragment (fragment offset != 0) — only the first
+///       fragment carries transport context that an error can quote
+///       (RFC 1812 §4.3.2.7(d), RFC 4443 §2.4(f));
+///   (c) destined to an L3 multicast/broadcast address (v4 multicast,
+///       directed/limited broadcast 255.255.255.255; v6 ff00::/8) OR sent
+///       to an L2 broadcast/multicast (low bit of the destination MAC)
+///       (RFC 1812 §4.3.2.7(a)/(b), RFC 4443 §2.4(e.3));
+///   (d) sourced from a non-unique address (0.0.0.0/unspecified,
+///       loopback, or a multicast/broadcast source) — there is no unique
+///       host to reply to (RFC 1812 §4.3.2.7(e), RFC 4443 §2.4(e.6)).
+///
+/// An unparseable frame (no L3 offset, short header, missing L4 type for
+/// an ICMP trigger) fails closed — the generator returns `None`.
+///
+/// This is a small set of branchless field reads on the hot TTL-expiry
+/// path; no allocation.
+pub(super) fn can_generate_icmp_error_reply(frame: &[u8], meta: UserspaceDpMeta) -> bool {
+    let l3 = match meta.l3_offset {
+        14 | 18 => meta.l3_offset as usize,
+        _ => match frame_l3_offset(frame) {
+            Some(off) => off,
+            None => return false,
+        },
+    };
+    let Some(packet) = frame.get(l3..) else {
+        return false;
+    };
+
+    // (b) Non-first fragments carry no transport header to quote/key.
+    if is_non_first_fragment(packet, meta.addr_family) {
+        return false;
+    }
+
+    // (a) Never reply to an inbound ICMP/ICMPv6 error message. Reuse the
+    //     reject path's (broader) ICMP-error classification.
+    if matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6) {
+        let Some(&icmp_type) = frame.get(meta.l4_offset as usize) else {
+            return false; // unparseable ICMP trigger: fail closed.
+        };
+        if reject_icmp_reply_suppressed(meta.protocol, icmp_type) {
+            return false;
+        }
+    }
+
+    // (c)/(d) L3 source/destination uniqueness + scope. The trigger's
+    // src/dst sit at fixed offsets in the (already non-fragmented) IP
+    // header.
+    match meta.addr_family as i32 {
+        libc::AF_INET => {
+            if packet.len() < 20 {
+                return false;
+            }
+            let src = Ipv4Addr::new(packet[12], packet[13], packet[14], packet[15]);
+            let dst = Ipv4Addr::new(packet[16], packet[17], packet[18], packet[19]);
+            // (c) multicast / broadcast / limited-broadcast destination.
+            if dst.is_multicast() || dst.is_broadcast() {
+                return false;
+            }
+            // (d) unspecified / loopback / multicast / broadcast source.
+            if src.is_unspecified()
+                || src.is_loopback()
+                || src.is_multicast()
+                || src.is_broadcast()
+            {
+                return false;
+            }
+        }
+        libc::AF_INET6 => {
+            if packet.len() < 40 {
+                return false;
+            }
+            let src = Ipv6Addr::from(<[u8; 16]>::try_from(&packet[8..24]).expect("16 bytes"));
+            let dst = Ipv6Addr::from(<[u8; 16]>::try_from(&packet[24..40]).expect("16 bytes"));
+            // (c) multicast destination (ff00::/8).
+            if dst.is_multicast() {
+                return false;
+            }
+            // (d) unspecified / loopback / multicast source.
+            if src.is_unspecified() || src.is_loopback() || src.is_multicast() {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+
+    // (c) L2 broadcast/multicast destination (low bit of the destination
+    //     MAC, IEEE 802 group bit). A unicast L3 destination delivered to
+    //     a group MAC still must not elicit an error.
+    if let Some(&dst_mac0) = frame.first()
+        && (dst_mac0 & 0x01) != 0
+    {
+        return false;
+    }
+
+    true
+}
+
 pub(super) fn build_local_time_exceeded_request(
     frame: &[u8],
     desc: XdpDesc,
@@ -29,6 +138,15 @@ pub(super) fn build_local_time_exceeded_request(
     _now_secs: u64,
 ) -> Option<PendingForwardRequest> {
     if !matches!(packet_ttl_would_expire(frame, meta), Some(true)) {
+        return None;
+    }
+
+    // #2237: RFC 1812 §4.3.2.7 / RFC 4443 §2.4 — suppress Time Exceeded
+    // for ICMP-error triggers (error storms), non-first fragments,
+    // multicast/broadcast destinations, and non-unique sources. The
+    // reject Destination Unreachable path already honored a subset of
+    // these via build_reject_icmp_unreachable; this shares the guard.
+    if !can_generate_icmp_error_reply(frame, meta) {
         return None;
     }
 
@@ -322,33 +440,22 @@ pub(super) fn reject_icmp_reply_suppressed(protocol: u8, icmp_type: u8) -> bool 
 /// ICMPv4 type 3 code 13, or ICMPv6 type 1 code 1 — the codes the
 /// retired eBPF reject path used ("matching Junos reject behavior").
 ///
-/// Returns `None` (caller fail-closes to a silent drop) when:
-///   - the inbound is an ICMP/ICMPv6 *error* message
-///     ([`reject_icmp_reply_suppressed`]),
-///   - the inbound is a non-first fragment (no transport header to key),
-///   - the ingress interface has no primary address of the inbound
-///     family, or the frame is otherwise unparseable.
+/// Returns `None` (caller fail-closes to a silent drop) when the shared
+/// [`can_generate_icmp_error_reply`] gate (RFC 1812 §4.3.2.7 /
+/// RFC 4443 §2.4) refuses — inbound ICMP/ICMPv6 error, non-first
+/// fragment, multicast/broadcast destination (L3 or L2), or non-unique
+/// source — or when the ingress interface has no primary address of the
+/// inbound family / the frame is otherwise unparseable. #2237 unified
+/// this gate with the Time Exceeded path; previously the reject path
+/// guarded only the fragment + ICMP-error subset.
 pub(super) fn build_reject_icmp_unreachable(
     frame: &[u8],
     meta: UserspaceDpMeta,
     ingress_ifindex: i32,
     forwarding: &ForwardingState,
 ) -> Option<Vec<u8>> {
-    let l3 = match meta.l3_offset {
-        14 | 18 => meta.l3_offset as usize,
-        _ => frame_l3_offset(frame)?,
-    };
-    let packet = frame.get(l3..)?;
-    // Never reply to a non-first fragment (no L4 header to quote/key).
-    if is_non_first_fragment(packet, meta.addr_family) {
+    if !can_generate_icmp_error_reply(frame, meta) {
         return None;
-    }
-    // Suppress replies to inbound ICMP/ICMPv6 error messages.
-    if matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6) {
-        let icmp_type = *frame.get(meta.l4_offset as usize)?;
-        if reject_icmp_reply_suppressed(meta.protocol, icmp_type) {
-            return None;
-        }
     }
     match meta.addr_family as i32 {
         // ICMPv4 Destination Unreachable, code 13 (communication

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -342,12 +342,12 @@ pub(super) fn build_local_time_exceeded_v6(
 
 /// Build a local-origin ICMPv6 error message of the given type/code,
 /// reflecting L2 (MAC swap + ingress VLAN), sourcing the outer IP from
-/// the ingress interface primary v6, and quoting the inbound packet up
-/// to 48 bytes (well under the RFC 4443 minimum-MTU cap). The ICMPv6
-/// checksum (`checksum16_ipv6`) is computed over the pseudo-header and
-/// is type-agnostic, so this is shared by the Time Exceeded builder
-/// (type 3) and the #2089 reject Destination Unreachable builder
-/// (type 1, code 1).
+/// the ingress interface primary v6, and quoting as much of the inbound
+/// packet as fits under the RFC 4443 §3 minimum-MTU cap (1280 bytes; see
+/// #2242). The ICMPv6 checksum (`checksum16_ipv6`) is computed over the
+/// pseudo-header and is type-agnostic, so this is shared by the Time
+/// Exceeded builder (type 3) and the #2089 reject Destination
+/// Unreachable builder (type 1, code 1).
 pub(super) fn build_local_icmp_error_v6(
     frame: &[u8],
     meta: UserspaceDpMeta,
@@ -371,7 +371,18 @@ pub(super) fn build_local_icmp_error_v6(
     let dst_ip = Ipv6Addr::from(<[u8; 16]>::try_from(packet.get(8..24)?).ok()?);
     let payload_len = u16::from_be_bytes([packet[4], packet[5]]) as usize;
     let packet_len = (40 + payload_len).min(packet.len());
-    let quoted_len = packet_len.min(48);
+    // #2242: RFC 4443 §3 — include as much of the invoking packet as
+    // possible without the ICMPv6 error message exceeding the IPv6
+    // minimum MTU (1280). The ICMPv6 packet is the outer IPv6 header (40)
+    // + ICMPv6 header (8) + quoted bytes, so the quote is capped at
+    // 1280 - 40 - 8 = 1232 and bounded by the actual invoking packet
+    // length. The previous fixed 48-byte quote (40-byte IPv6 base header
+    // + only 8 bytes) omitted the transport header whenever IPv6
+    // extension headers pushed it past byte 48, so the receiver could not
+    // demux the error back to a socket. The UMEM frame is 4096 bytes, so
+    // the 1232-byte cap never overruns the TX buffer.
+    const ICMPV6_QUOTE_MAX: usize = 1280 - 40 - 8;
+    let quoted_len = packet_len.min(ICMPV6_QUOTE_MAX);
     // #2149: preserve the inbound tag (TPID + PCP + DEI + VID) on the
     // reflected error; fall back to the egress configured VID when
     // ingress was untagged. See the v4 builder for the rationale.

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -155,7 +155,7 @@ use self::icmp::{FABRIC_INGRESS_FLAG, build_local_time_exceeded_request, is_icmp
 #[cfg(test)]
 use self::icmp::{
     build_local_time_exceeded_v4, build_local_time_exceeded_v6, build_reject_icmp_unreachable,
-    packet_ttl_would_expire, reject_icmp_reply_suppressed,
+    can_generate_icmp_error_reply, packet_ttl_would_expire, reject_icmp_reply_suppressed,
 };
 #[cfg(test)]
 use self::icmp_embed::{

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7550,3 +7550,117 @@ fn te_suppressed_for_multicast_source_v6() {
         "a hop-limit=1 packet from a multicast source MUST NOT elicit a Time Exceeded"
     );
 }
+
+// ---- #2242: ICMPv6 error quote length includes transport header behind
+//      extension headers, bounded by the 1280 IPv6 minimum MTU. ----
+
+#[test]
+fn icmpv6_error_quotes_transport_header_behind_ext_headers() {
+    let src: Ipv6Addr = "2001:559:8585:61::102".parse().unwrap();
+    let dst: Ipv6Addr = "2606:4700:4700::1111".parse().unwrap();
+    // Build an inbound IPv6 packet: base header (next-header = 60,
+    // Destination Options) + a 56-byte (7*8) dest-options ext header
+    // (pushing the transport header well past byte 48) + an 8-byte TCP-ish
+    // header carrying a recognizable marker.
+    let ext_len_units: usize = 6; // hdr-ext-len = 6 -> (6+1)*8 = 56 bytes
+    let ext_bytes = (ext_len_units + 1) * 8;
+    let marker = [0xDEu8, 0xAD, 0xBE, 0xEF, 0x00, 0x50, 0x01, 0xBB];
+    let payload_len = ext_bytes + marker.len();
+
+    let mut frame = Vec::new();
+    write_eth_header(&mut frame, FW_MAC, [0x02, 0x11, 0x22, 0x33, 0x44, 0x55], 0, 0x86dd);
+    let l3 = frame.len();
+    frame.extend_from_slice(&[0x60, 0, 0, 0]);
+    frame.extend_from_slice(&(payload_len as u16).to_be_bytes());
+    frame.push(60); // next-header = Destination Options
+    frame.push(1); // hop-limit 1 -> expires
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    // Destination Options ext header: next-header = TCP, hdr-ext-len.
+    frame.push(PROTO_TCP);
+    frame.push(ext_len_units as u8);
+    frame.resize(frame.len() + (ext_bytes - 2), 0); // pad-1/pad-N filler
+    let transport_off = frame.len();
+    frame.extend_from_slice(&marker);
+
+    // L4 offset (post-ext-header) is past byte 48 of the L3 payload.
+    assert!(
+        transport_off - l3 > 48,
+        "test setup: transport header must start past byte 48"
+    );
+    let meta = icmp_guard_meta_v6(PROTO_TCP, transport_off as u16);
+    let flow = icmp_guard_flow_v6(src, dst, PROTO_TCP);
+
+    let req = run_local_te(&frame, meta, &flow, &icmp_guard_forwarding())
+        .expect("ext-header IPv6 TTL=1 packet must elicit a Time Exceeded");
+    let PendingForwardFrame::Prebuilt(out) = &req.frame else {
+        panic!("expected a prebuilt Time Exceeded frame");
+    };
+
+    // Locate the start of the quoted invoking packet in the generated
+    // error: Eth (14, untagged) + outer IPv6 (40) + ICMPv6 header (8).
+    let quote_start = 14 + 40 + 8;
+    let quoted = &out[quote_start..];
+    // The whole invoking packet (40 base + ext + marker) is < 1232, so
+    // it must be quoted in full — including the transport marker.
+    let inbound_l3 = &frame[l3..];
+    assert!(
+        quoted.len() >= inbound_l3.len(),
+        "quote ({} B) must include the full invoking packet ({} B) — \
+         the fixed-48 quote omitted everything past byte 48",
+        quoted.len(),
+        inbound_l3.len()
+    );
+    // The transport marker (the 8 bytes at transport_off) must appear in
+    // the quote at the expected offset.
+    let marker_in_quote = &quoted[(transport_off - l3)..(transport_off - l3) + marker.len()];
+    assert_eq!(
+        marker_in_quote, &marker,
+        "the quoted invoking packet must include the transport header behind the ext headers"
+    );
+    // RFC 4443 §3: the ICMPv6 packet (outer IPv6 onward) must not exceed
+    // the 1280 minimum MTU.
+    let icmpv6_packet_len = out.len() - 14; // strip Ethernet
+    assert!(
+        icmpv6_packet_len <= 1280,
+        "ICMPv6 error packet ({icmpv6_packet_len} B) must not exceed the 1280 minimum MTU"
+    );
+}
+
+#[test]
+fn icmpv6_error_quote_capped_at_min_mtu() {
+    let src: Ipv6Addr = "2001:559:8585:61::102".parse().unwrap();
+    let dst: Ipv6Addr = "2606:4700:4700::1111".parse().unwrap();
+    // Build an oversized inbound IPv6 packet (> 1280 after L3) so the
+    // quote must be clamped to the minimum-MTU cap, not the packet length.
+    let big_payload = vec![0x41u8; 1600];
+    let payload_len = big_payload.len();
+    let mut frame = Vec::new();
+    write_eth_header(&mut frame, FW_MAC, [0x02, 0x11, 0x22, 0x33, 0x44, 0x55], 0, 0x86dd);
+    frame.extend_from_slice(&[0x60, 0, 0, 0]);
+    frame.extend_from_slice(&(payload_len as u16).to_be_bytes());
+    frame.push(PROTO_UDP);
+    frame.push(1);
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    frame.extend_from_slice(&big_payload);
+
+    let meta = icmp_guard_meta_v6(PROTO_UDP, 54);
+    let flow = icmp_guard_flow_v6(src, dst, PROTO_UDP);
+    let req = run_local_te(&frame, meta, &flow, &icmp_guard_forwarding())
+        .expect("oversized IPv6 TTL=1 packet must elicit a Time Exceeded");
+    let PendingForwardFrame::Prebuilt(out) = &req.frame else {
+        panic!("expected a prebuilt Time Exceeded frame");
+    };
+    let icmpv6_packet_len = out.len() - 14;
+    assert!(
+        icmpv6_packet_len <= 1280,
+        "ICMPv6 error packet ({icmpv6_packet_len} B) must be clamped to the 1280 minimum MTU"
+    );
+    // And it must be close to the cap (the quote is the dominant term):
+    // outer IPv6 (40) + ICMPv6 (8) + 1232 = 1280.
+    assert_eq!(
+        icmpv6_packet_len, 1280,
+        "the quote must fill up to exactly the 1280 cap for an oversized invoking packet"
+    );
+}

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7188,3 +7188,365 @@ fn publish_dnat_table_entry_failure_increments_counter() {
     }
     assert_eq!(live.dnat_publish_errors.load(Ordering::Relaxed), 2);
 }
+
+// ============================================================================
+// #2237: RFC 1812 §4.3.2.7 / RFC 4443 §2.4 ICMP-error suppression guards on
+// the locally-generated Time Exceeded path.
+// #2242: RFC 4443 §3 ICMPv6 error quote length (include transport header
+// behind extension headers, bounded by the 1280 IPv6 minimum MTU).
+// ============================================================================
+
+/// Egress used by the #2237/#2242 Time Exceeded suppression tests:
+/// ifindex 5 with a v4 and v6 primary so both families build.
+fn icmp_guard_forwarding() -> ForwardingState {
+    reject_egress_forwarding(
+        Some(Ipv4Addr::new(10, 0, 61, 1)),
+        Some("2001:559:8585:61::1".parse().unwrap()),
+    )
+}
+
+fn icmp_guard_ident() -> BindingIdentity {
+    BindingIdentity {
+        slot: 0,
+        queue_id: 7,
+        worker_id: 0,
+        interface: Arc::<str>::from("ge-0-0-1"),
+        ifindex: 5,
+    }
+}
+
+fn icmp_guard_flow_v4(src: Ipv4Addr, dst: Ipv4Addr, proto: u8) -> SessionFlow {
+    SessionFlow {
+        src_ip: IpAddr::V4(src),
+        dst_ip: IpAddr::V4(dst),
+        forward_key: SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: proto,
+            src_ip: IpAddr::V4(src),
+            dst_ip: IpAddr::V4(dst),
+            src_port: 0x1234,
+            dst_port: 0x0035,
+        },
+    }
+}
+
+fn icmp_guard_flow_v6(src: Ipv6Addr, dst: Ipv6Addr, proto: u8) -> SessionFlow {
+    SessionFlow {
+        src_ip: IpAddr::V6(src),
+        dst_ip: IpAddr::V6(dst),
+        forward_key: SessionKey {
+            addr_family: libc::AF_INET6 as u8,
+            protocol: proto,
+            src_ip: IpAddr::V6(src),
+            dst_ip: IpAddr::V6(dst),
+            src_port: 0x1234,
+            dst_port: 0x0035,
+        },
+    }
+}
+
+fn run_local_te(
+    frame: &[u8],
+    meta: UserspaceDpMeta,
+    flow: &SessionFlow,
+    forwarding: &ForwardingState,
+) -> Option<PendingForwardRequest> {
+    let desc = XdpDesc {
+        addr: 4096,
+        len: frame.len() as u32,
+        options: 0,
+    };
+    build_local_time_exceeded_request(
+        frame,
+        desc,
+        meta,
+        &icmp_guard_ident(),
+        flow,
+        forwarding,
+        &Arc::new(ShardedNeighborMap::new()),
+        &BTreeMap::new(),
+        0,
+    )
+}
+
+/// Build an IPv4 frame [Eth][IP ttl=1 proto][8 L4 bytes] with explicit
+/// dst MAC, src/dst IP, protocol, and IPv4 frag_off (bytes 6-7).
+fn icmp_guard_v4_frame(
+    dst_mac: [u8; 6],
+    src: Ipv4Addr,
+    dst: Ipv4Addr,
+    proto: u8,
+    frag_off: u16,
+    l4: &[u8],
+) -> Vec<u8> {
+    let mut frame = Vec::new();
+    write_eth_header(&mut frame, dst_mac, [0x02, 0x11, 0x22, 0x33, 0x44, 0x55], 0, 0x0800);
+    let l3 = frame.len();
+    let total = 20 + l4.len();
+    frame.push(0x45);
+    frame.push(0x00);
+    frame.extend_from_slice(&(total as u16).to_be_bytes());
+    frame.extend_from_slice(&[0x00, 0x01]); // ident
+    frame.extend_from_slice(&frag_off.to_be_bytes());
+    frame.push(1); // ttl = 1 -> would expire
+    frame.push(proto);
+    frame.extend_from_slice(&[0x00, 0x00]); // csum placeholder
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    let csum = checksum16(&frame[l3..l3 + 20]);
+    frame[l3 + 10..l3 + 12].copy_from_slice(&csum.to_be_bytes());
+    frame.extend_from_slice(l4);
+    frame
+}
+
+/// 8 generic L4 bytes (acts as a UDP/TCP-ish header for quoting).
+const L4_8: [u8; 8] = [0xc0, 0x00, 0x00, 0x35, 0x00, 0x08, 0x00, 0x00];
+
+/// Standard unicast firewall NIC dst MAC (low bit clear).
+const FW_MAC: [u8; 6] = [0x00, 0x25, 0x90, 0x12, 0x34, 0x56];
+
+fn icmp_guard_meta_v4(proto: u8) -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 34,
+        ingress_ifindex: 5,
+        addr_family: libc::AF_INET as u8,
+        protocol: proto,
+        ..UserspaceDpMeta::default()
+    }
+}
+
+fn icmp_guard_meta_v6(proto: u8, l4_offset: u16) -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset,
+        ingress_ifindex: 5,
+        addr_family: libc::AF_INET6 as u8,
+        protocol: proto,
+        ..UserspaceDpMeta::default()
+    }
+}
+
+// ---- #2237 positive cases (no over-suppression) ----
+
+#[test]
+fn te_emitted_for_normal_unicast_udp_v4() {
+    let src = Ipv4Addr::new(198, 51, 100, 20);
+    let dst = Ipv4Addr::new(203, 0, 113, 7);
+    let frame = icmp_guard_v4_frame(FW_MAC, src, dst, PROTO_UDP, 0x0000, &L4_8);
+    let meta = icmp_guard_meta_v4(PROTO_UDP);
+    let flow = icmp_guard_flow_v4(src, dst, PROTO_UDP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_some(),
+        "a normal unicast UDP TTL=1 packet MUST elicit a Time Exceeded"
+    );
+    assert!(can_generate_icmp_error_reply(&frame, meta));
+}
+
+#[test]
+fn te_emitted_for_normal_unicast_tcp_v4() {
+    let src = Ipv4Addr::new(198, 51, 100, 20);
+    let dst = Ipv4Addr::new(203, 0, 113, 7);
+    let frame = icmp_guard_v4_frame(FW_MAC, src, dst, PROTO_TCP, 0x0000, &L4_8);
+    let meta = icmp_guard_meta_v4(PROTO_TCP);
+    let flow = icmp_guard_flow_v4(src, dst, PROTO_TCP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_some(),
+        "a normal unicast TCP TTL=1 packet MUST elicit a Time Exceeded"
+    );
+}
+
+// ---- #2237 (a): ICMP-error trigger suppressed ----
+
+#[test]
+fn te_suppressed_for_inbound_icmp_error_v4() {
+    let src = Ipv4Addr::new(198, 51, 100, 20);
+    let dst = Ipv4Addr::new(203, 0, 113, 7);
+    // ICMPv4 type 11 (Time Exceeded) trigger — an ICMP error.
+    let icmp = [11u8, 0, 0, 0, 0, 0, 0, 0];
+    let frame = icmp_guard_v4_frame(FW_MAC, src, dst, PROTO_ICMP, 0x0000, &icmp);
+    let meta = icmp_guard_meta_v4(PROTO_ICMP);
+    let flow = icmp_guard_flow_v4(src, dst, PROTO_ICMP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a TTL=1 inbound ICMP error MUST NOT elicit a Time Exceeded (error loop)"
+    );
+    // Counterfactual: an ICMP echo request (query, not error) is NOT
+    // suppressed — proves the gate keys on the ICMP type, not the proto.
+    let echo = [8u8, 0, 0, 0, 0, 0, 0, 0];
+    let echo_frame = icmp_guard_v4_frame(FW_MAC, src, dst, PROTO_ICMP, 0x0000, &echo);
+    assert!(
+        run_local_te(&echo_frame, meta, &flow, &icmp_guard_forwarding()).is_some(),
+        "a TTL=1 ICMP echo (query) MUST still elicit a Time Exceeded"
+    );
+}
+
+#[test]
+fn te_suppressed_for_inbound_icmpv6_error() {
+    let src: Ipv6Addr = "2001:559:8585:61::102".parse().unwrap();
+    let dst: Ipv6Addr = "2606:4700:4700::1111".parse().unwrap();
+    // ICMPv6 type 3 (Time Exceeded) trigger — an ICMPv6 error (type < 128).
+    let frame = build_icmp_echo_frame_v6_hl_typed(src, dst, 1, 3);
+    let meta = icmp_guard_meta_v6(PROTO_ICMPV6, 54);
+    let flow = icmp_guard_flow_v6(src, dst, PROTO_ICMPV6);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a hop-limit=1 inbound ICMPv6 error MUST NOT elicit a Time Exceeded"
+    );
+    // Echo request (type 128, a query) is not suppressed.
+    let echo = build_icmp_echo_frame_v6_hl_typed(src, dst, 1, 128);
+    assert!(
+        run_local_te(&echo, meta, &flow, &icmp_guard_forwarding()).is_some(),
+        "a hop-limit=1 ICMPv6 echo (query) MUST still elicit a Time Exceeded"
+    );
+}
+
+/// Build an ICMPv6 frame with hop-limit `hl` and ICMPv6 type `ty`
+/// (no extension headers; L4 at offset 54).
+fn build_icmp_echo_frame_v6_hl_typed(src: Ipv6Addr, dst: Ipv6Addr, hl: u8, ty: u8) -> Vec<u8> {
+    let mut frame = Vec::new();
+    write_eth_header(&mut frame, FW_MAC, [0x02, 0x11, 0x22, 0x33, 0x44, 0x55], 0, 0x86dd);
+    frame.extend_from_slice(&[0x60, 0, 0, 0, 0, 0x08, PROTO_ICMPV6, hl]);
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    let icmp_start = frame.len();
+    frame.extend_from_slice(&[ty, 0, 0, 0, 0, 0, 0, 0]);
+    let csum = checksum16_ipv6(src, dst, PROTO_ICMPV6, &frame[icmp_start..]);
+    frame[icmp_start + 2..icmp_start + 4].copy_from_slice(&csum.to_be_bytes());
+    frame
+}
+
+// ---- #2237 (b): non-first fragment suppressed ----
+
+#[test]
+fn te_suppressed_for_non_first_fragment_v4() {
+    let src = Ipv4Addr::new(198, 51, 100, 20);
+    let dst = Ipv4Addr::new(203, 0, 113, 7);
+    // frag_off = 0x0001 -> fragment offset 1 (non-first), MF=0.
+    let frame = icmp_guard_v4_frame(FW_MAC, src, dst, PROTO_UDP, 0x0001, &L4_8);
+    let meta = icmp_guard_meta_v4(PROTO_UDP);
+    let flow = icmp_guard_flow_v4(src, dst, PROTO_UDP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a TTL=1 non-first IPv4 fragment MUST NOT elicit a Time Exceeded"
+    );
+}
+
+#[test]
+fn te_suppressed_for_non_first_fragment_v6() {
+    let src: Ipv6Addr = "2001:559:8585:61::102".parse().unwrap();
+    let dst: Ipv6Addr = "2606:4700:4700::1111".parse().unwrap();
+    let mut frame = Vec::new();
+    write_eth_header(&mut frame, FW_MAC, [0x02, 0x11, 0x22, 0x33, 0x44, 0x55], 0, 0x86dd);
+    // IPv6 base: next-header = 44 (fragment), hop-limit 1, payload_len 16.
+    frame.extend_from_slice(&[0x60, 0, 0, 0, 0, 16, 44, 1]);
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    // Fragment header (8 bytes): next-header UDP, frag-offset != 0
+    // (bytes 2-3 = 0x0008 -> offset bits non-zero), then 8 payload bytes.
+    frame.extend_from_slice(&[PROTO_UDP, 0, 0x00, 0x08, 0, 0, 0, 1]);
+    frame.extend_from_slice(&L4_8);
+    let meta = icmp_guard_meta_v6(PROTO_UDP, 62);
+    let flow = icmp_guard_flow_v6(src, dst, PROTO_UDP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a hop-limit=1 non-first IPv6 fragment MUST NOT elicit a Time Exceeded"
+    );
+}
+
+// ---- #2237 (c): multicast / broadcast destination suppressed ----
+
+#[test]
+fn te_suppressed_for_multicast_dest_v4() {
+    let src = Ipv4Addr::new(198, 51, 100, 20);
+    let dst = Ipv4Addr::new(224, 0, 0, 251); // mDNS multicast
+    // L2 dst is the matching multicast MAC, but the L3 guard fires first.
+    let frame = icmp_guard_v4_frame([0x01, 0x00, 0x5e, 0x00, 0x00, 0xfb], src, dst, PROTO_UDP, 0, &L4_8);
+    let meta = icmp_guard_meta_v4(PROTO_UDP);
+    let flow = icmp_guard_flow_v4(src, dst, PROTO_UDP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a TTL=1 multicast-dest packet MUST NOT elicit a Time Exceeded"
+    );
+}
+
+#[test]
+fn te_suppressed_for_broadcast_dest_v4() {
+    let src = Ipv4Addr::new(198, 51, 100, 20);
+    let dst = Ipv4Addr::new(255, 255, 255, 255); // limited broadcast
+    let frame = icmp_guard_v4_frame([0xff; 6], src, dst, PROTO_UDP, 0, &L4_8);
+    let meta = icmp_guard_meta_v4(PROTO_UDP);
+    let flow = icmp_guard_flow_v4(src, dst, PROTO_UDP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a TTL=1 broadcast-dest packet MUST NOT elicit a Time Exceeded"
+    );
+}
+
+#[test]
+fn te_suppressed_for_l2_multicast_with_unicast_l3_dest_v4() {
+    let src = Ipv4Addr::new(198, 51, 100, 20);
+    let dst = Ipv4Addr::new(203, 0, 113, 7); // unicast L3
+    // Group MAC (low bit set) on a unicast L3 dest still suppresses.
+    let frame = icmp_guard_v4_frame([0x01, 0x00, 0x5e, 0x12, 0x34, 0x56], src, dst, PROTO_UDP, 0, &L4_8);
+    let meta = icmp_guard_meta_v4(PROTO_UDP);
+    let flow = icmp_guard_flow_v4(src, dst, PROTO_UDP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a TTL=1 packet to an L2 group MAC MUST NOT elicit a Time Exceeded"
+    );
+}
+
+#[test]
+fn te_suppressed_for_multicast_dest_v6() {
+    let src: Ipv6Addr = "2001:559:8585:61::102".parse().unwrap();
+    let dst: Ipv6Addr = "ff02::1".parse().unwrap(); // all-nodes multicast
+    let frame = build_icmp_echo_frame_v6_hl_typed(src, dst, 1, 128);
+    let meta = icmp_guard_meta_v6(PROTO_ICMPV6, 54);
+    let flow = icmp_guard_flow_v6(src, dst, PROTO_ICMPV6);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a hop-limit=1 multicast-dest IPv6 packet MUST NOT elicit a Time Exceeded"
+    );
+}
+
+// ---- #2237 (d): non-unique source suppressed ----
+
+#[test]
+fn te_suppressed_for_unspecified_source_v4() {
+    let src = Ipv4Addr::new(0, 0, 0, 0);
+    let dst = Ipv4Addr::new(203, 0, 113, 7);
+    let frame = icmp_guard_v4_frame(FW_MAC, src, dst, PROTO_UDP, 0, &L4_8);
+    let meta = icmp_guard_meta_v4(PROTO_UDP);
+    let flow = icmp_guard_flow_v4(src, dst, PROTO_UDP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a TTL=1 packet from 0.0.0.0 MUST NOT elicit a Time Exceeded"
+    );
+}
+
+#[test]
+fn te_suppressed_for_loopback_source_v4() {
+    let src = Ipv4Addr::new(127, 0, 0, 1);
+    let dst = Ipv4Addr::new(203, 0, 113, 7);
+    let frame = icmp_guard_v4_frame(FW_MAC, src, dst, PROTO_UDP, 0, &L4_8);
+    let meta = icmp_guard_meta_v4(PROTO_UDP);
+    let flow = icmp_guard_flow_v4(src, dst, PROTO_UDP);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a TTL=1 packet from a loopback source MUST NOT elicit a Time Exceeded"
+    );
+}
+
+#[test]
+fn te_suppressed_for_multicast_source_v6() {
+    let src: Ipv6Addr = "ff02::1".parse().unwrap();
+    let dst: Ipv6Addr = "2606:4700:4700::1111".parse().unwrap();
+    let frame = build_icmp_echo_frame_v6_hl_typed(src, dst, 1, 128);
+    let meta = icmp_guard_meta_v6(PROTO_ICMPV6, 54);
+    let flow = icmp_guard_flow_v6(src, dst, PROTO_ICMPV6);
+    assert!(
+        run_local_te(&frame, meta, &flow, &icmp_guard_forwarding()).is_none(),
+        "a hop-limit=1 packet from a multicast source MUST NOT elicit a Time Exceeded"
+    );
+}


### PR DESCRIPTION
## Summary

Two fixes to the locally-generated ICMP error path (`userspace-dp/src/afxdp/icmp.rs`), the hot TTL/hop-limit-expiry forwarding path.

- **#2237 (HIGH):** the locally-generated ICMP/ICMPv6 Time Exceeded path (`build_local_time_exceeded_request`) fired after only a TTL check — it lacked the RFC 1812 §4.3.2.7 / RFC 4443 §2.4 error-suppression guards that the sibling `reject` Destination Unreachable path (`build_reject_icmp_unreachable`, #2089) already had. An inbound ICMP error with TTL=1 elicited a fresh Time Exceeded (error loop / amplification), and a non-first fragment with TTL=1 generated an error for a datagram with no transport context.
- Added one shared gate, `icmp::can_generate_icmp_error_reply(frame, meta)`, and routed **both** generators through it (one source of truth so the two paths cannot drift). It refuses to originate an ICMP error when the triggering packet is: (a) itself an ICMP/ICMPv6 error message; (b) a non-first IP fragment; (c) destined to an L3 multicast/broadcast or an L2 group MAC; (d) sourced from a non-unique address (unspecified/loopback/multicast/broadcast). Unparseable frames fail closed. RFC clauses are cited inline.
- The reject path previously guarded only the fragment + ICMP-error subset; it now also honors the multicast/broadcast and non-unique-source cases (the correct contract for that path too).
- **#2242 (LOW):** `build_local_icmp_error_v6` quoted a fixed 48 bytes of the invoking packet, omitting the transport header whenever IPv6 extension headers pushed it past byte 48 (breaking receiver-side error↔socket demux). Now quotes up to the RFC 4443 §3 minimum-MTU cap: `1280 - 40 - 8 = 1232` bytes, bounded by the actual packet length. The IPv4 builder is unchanged (already RFC 792 minimum, IHL + 8).

## Hot-path shape

The guard is a small set of branchless field reads on the TTL-expiry path, no per-packet heap allocation (no scratch buffer needed — it only reads). The normal TTL>1 forwarding fast path is untouched. The larger ICMPv6 quote stays well within the 4096-byte UMEM frame.

## Test plan

- [x] **#2237** — 13 new tests, each **fail-on-revert**: TTL=1 ICMP-error trigger (v4+v6), non-first fragment (v4+v6), multicast/broadcast dest (v4+v6), L2 group MAC over a unicast L3 dest, and unspecified/loopback/multicast source each produce **no** Time Exceeded; a normal unicast UDP/TCP TTL=1 packet **does** (with ICMP/ICMPv6 echo-query counterfactuals proving the gate keys on the ICMP type, not the protocol). Reverting the gate fails all 13; the 2 positive tests stay green.
- [x] **#2242** — 2 new tests, each fail-on-revert: an ICMPv6 error for a packet with a 56-byte Destination-Options ext header asserts the quote includes the transport marker (and the ICMPv6 packet stays ≤ 1280); an oversized invoking packet asserts the quote clamps to exactly 1280. Reverting to fixed-48 fails both.
- [x] `cargo build --release` clean; full `cargo test --release` green (the only failures are the pre-existing, load-sensitive `wg::...reconcile_peers_snapshot` and `worker_queue::...concurrent_recovery` concurrency flakes — both fail identically on clean `origin/master` and neither touches the ICMP path).
- [x] New tests run 5x with no flake.
- [x] `go build ./...` clean.
- [ ] **Cluster iperf smoke is pending** — this is a forwarding-path change; the parent reviews and runs the loss-userspace-cluster smoke.

## Refs

Closes #2237, closes #2242.