### PR TITLE
io_uring_write: strengthen stale-CQE test + reconcile drain/ceiling docs (#2312)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,29 @@
 # Action Log
 
+## 2026-06-21 — #2312 io_uring_write follow-ups (test-quality + docs)
+
+- **Timestamp**: 2026-06-21 23:00 PDT
+- **Action**: #2312 — strengthened `stale_cqe_is_not_misattributed` so it
+  genuinely fails on revert of the #2297 user_data CQE-match. Switched it
+  to a two-chunk 8-byte write (real results 4+4) and added two stale-CQE
+  sources: a pre-seeded one (exercises `drain_stale`) and one injected
+  ahead of the real CQE during the wait (`with_stale_on_wait` — exercises
+  the reap-loop user_data match). FakeRing now records `accepted_bytes`
+  (sum of res for matched completions) so the test asserts the exact
+  applied total (8), not just the unit `WriteOutcome::Done`. Fail-on-revert
+  verified: reverting `reap_matching` to reap the head CQE unconditionally
+  makes the test fail (push_calls left:1 right:2); restored after proof.
+  Also reconciled docs: dropped the unused `keep` param from `drain_stale`
+  and rewrote its docstring to describe the unconditional full drain (and
+  why it is safe), and softened the module + `write_all` "never returns
+  while an SQE is in flight" claims to acknowledge the `MAX_WAIT_RETRIES`
+  ceiling. No behaviour change to the write loop; the #2297 EINTR-retry /
+  user_data match / buffer-lifetime guarantees are intact.
+- **Validation**: cargo build --release clean; io_uring_write (8),
+  state_writer (4), slowpath (2) green; strengthened test 5x green;
+  go build ./... clean.
+- **File(s)**: userspace-dp/src/io_uring_write.rs, _Log.md
+
 ## 2026-06-21 — #2237/#2242 ICMP error-generation RFC suppression + v6 quote length
 
 - **Timestamp**: 2026-06-21

--- a/userspace-dp/src/io_uring_write.rs
+++ b/userspace-dp/src/io_uring_write.rs
@@ -20,7 +20,13 @@
 //!       memory.
 //!
 //! The fix here keeps the SQE-in-flight invariant the callers always assumed:
-//! the function does not return until every SQE it submitted has been reaped.
+//! under normal operation the function does not return until every SQE it
+//! submitted has been reaped. The sole escape hatch is a hard retry ceiling
+//! (`MAX_WAIT_RETRIES`) that converts a pathological never-ending EINTR storm
+//! into an `Err` so a worker cannot wedge forever; reaching it requires
+//! thousands of consecutive interrupted/failed waits with the CQE still
+//! unreaped, which is astronomically improbable. See the per-`Err` notes on
+//! [`reap_matching`] for what each ceiling return implies for the buffer.
 //!
 //!   * `EINTR` (and any wait error) RETRIES the wait instead of returning. The
 //!     `io-uring` crate's `submit_and_wait` derives `to_submit` from the
@@ -140,11 +146,18 @@ pub(crate) fn write_all_to_fd(
 /// file-offset write (state writer) vs. a stream write (TUN slow path).
 ///
 /// Invariants this upholds (the #2297 fix):
-///   * never returns while an SQE we submitted is still in flight — on any
-///     submit/wait error we keep waiting until the in-flight count drains;
+///   * does not return while an SQE we submitted is still in flight — on any
+///     submit/wait error we keep waiting until the matching CQE is reaped. The
+///     one exception is the `MAX_WAIT_RETRIES` ceiling in [`reap_matching`],
+///     which returns `Err` after thousands of consecutive interrupted/failed
+///     waits to avoid wedging a worker forever; in that (astronomically rare)
+///     case the SQE may still be outstanding when the buffer is dropped — the
+///     same residual UAF window the pre-#2297 code always had, now bounded to a
+///     storm that should never occur in practice rather than every EINTR;
 ///   * advances `offset` only by a CQE whose `user_data` matches the current
 ///     submission, so a stale leftover CQE cannot corrupt the offset;
-///   * the caller's `data` buffer therefore outlives every kernel reference.
+///   * the caller's `data` buffer therefore outlives every kernel reference
+///     except in the bounded ceiling case above.
 pub(crate) fn write_all(
     port: &mut dyn RingPort,
     data: &[u8],
@@ -192,8 +205,11 @@ pub(crate) fn write_all(
 /// interrupted call) are drained and discarded rather than mis-attributed.
 fn reap_matching(port: &mut dyn RingPort, want: u64, label: &str) -> Result<i32, String> {
     // First, drain any already-ready stale completions so a leftover CQE from a
-    // previously interrupted submission can never be returned as ours.
-    drain_stale(port, want);
+    // previously interrupted submission can never be returned as ours. At this
+    // point the SQE for `want` has been pushed but NOT yet submitted/waited on,
+    // so nothing in the completion queue can carry `want` — everything ready is
+    // necessarily a leftover and safe to discard.
+    drain_stale(port);
 
     // Bound the wait retries so a pathological always-EINTR storm cannot wedge
     // the worker forever. EINTR under normal signal pressure resolves in one or
@@ -245,16 +261,14 @@ fn reap_matching(port: &mut dyn RingPort, want: u64, label: &str) -> Result<i32,
     }
 }
 
-/// Discard any completions currently ready whose `user_data != keep`. Used
-/// before a fresh submission to evict leftovers from a prior interrupted call.
-fn drain_stale(port: &mut dyn RingPort, keep: u64) {
-    // Peek-and-discard. We cannot peek without consuming with this API, so we
-    // only drain when there is no risk of dropping our own (not-yet-submitted)
-    // completion: at this point nothing for `keep` has been submitted in this
-    // iteration, so anything ready is necessarily stale. Anything matching
-    // `keep` here would be a wrap-around collision; keep it conservatively
-    // un-drained by re-checking inside the reap loop.
-    let _ = keep;
+/// Discard every completion currently ready. Called by [`reap_matching`] only
+/// at the point right after the current SQE is pushed but BEFORE it is submitted
+/// or waited on, so no completion for the current tag can exist yet — everything
+/// ready is necessarily a leftover from a prior interrupted call and is dropped
+/// unconditionally. This is a full drain, not a keep-one-matching drain: there
+/// is nothing to keep, and [`reap_matching`] re-checks `user_data` on the real
+/// reap anyway, so a wrap-around tag collision is still caught there.
+fn drain_stale(port: &mut dyn RingPort) {
     while let Some(_cqe) = port.next_completion() {
         // Drop stale completion.
     }
@@ -280,8 +294,26 @@ mod tests {
         in_flight: VecDeque<u64>,
         /// Completions ready to be reaped.
         ready: VecDeque<Completion>,
-        /// Pre-seeded stale completions (e.g. left by a prior interrupted call).
+        /// Number of `push_write` calls — i.e. SQEs submitted.
         push_calls: usize,
+        /// `user_data` tags this fake itself materialised from `in_flight`
+        /// (i.e. completions for SQEs we really submitted). A pre-seeded stale
+        /// completion's tag is NOT in here, so we can tell, at reap time,
+        /// whether a popped completion is a real one of ours.
+        real_tags: std::collections::HashSet<u64>,
+        /// Running total of `res` for REAL completions that the consumer popped
+        /// and consumed. `reap_matching` discards non-matching (stale) CQEs and
+        /// only ever advances `offset` by a CQE whose `user_data` matches its
+        /// current tag — which is always one of `real_tags`. So this sum equals
+        /// the byte total `write_all` actually applied to its offset.
+        accepted_bytes: i64,
+        /// Stale completions to inject AHEAD of the real one on the i-th
+        /// SUCCESSFUL wait. Unlike `with_stale` (which pre-seeds the ready queue
+        /// so `drain_stale` evicts it before the reap loop runs), these surface
+        /// during the wait, so the leftover sits in the completion queue
+        /// alongside the real CQE and the REAP-LOOP user_data match is what must
+        /// skip it. `None` for a given wait injects nothing.
+        stale_on_wait: VecDeque<Option<Completion>>,
     }
 
     impl FakeRing {
@@ -292,12 +324,50 @@ mod tests {
                 in_flight: VecDeque::new(),
                 ready: VecDeque::new(),
                 push_calls: 0,
+                real_tags: std::collections::HashSet::new(),
+                accepted_bytes: 0,
+                stale_on_wait: VecDeque::new(),
             }
         }
 
         fn with_stale(mut self, stale: Vec<Completion>) -> Self {
             self.ready.extend(stale);
             self
+        }
+
+        /// Inject a stale completion ahead of the real one on each successful
+        /// wait. Entry `i` (a `Some(_)`) is pushed to the FRONT of the ready
+        /// queue just before the i-th successful wait materialises its real CQE,
+        /// so the reap loop encounters `[stale, real]` and must match on
+        /// `user_data` to skip the stale. `None` injects nothing for that wait.
+        fn with_stale_on_wait(mut self, stale: Vec<Option<Completion>>) -> Self {
+            self.stale_on_wait = stale.into_iter().collect();
+            self
+        }
+
+        /// Byte total of REAL (matched) completions the consumer accepted. A
+        /// stale-CQE misattribution would show here as a wrong sum (e.g. the
+        /// stale 9999) because only matched CQEs are supposed to advance offset.
+        fn accepted_bytes(&self) -> i64 {
+            self.accepted_bytes
+        }
+
+        /// On a successful wait: inject this wait's scripted stale CQE (if any)
+        /// at the FRONT of the ready queue, then materialise one in-flight SQE's
+        /// real completion at the BACK. The result is `[stale, real]` so the
+        /// reap loop must skip the stale by `user_data` to find the real one.
+        fn materialise_on_successful_wait(&mut self) {
+            if let Some(Some(stale)) = self.stale_on_wait.pop_front() {
+                self.ready.push_front(stale);
+            }
+            if let Some(ud) = self.in_flight.pop_front() {
+                let res = self.results.pop_front().unwrap_or(0);
+                self.real_tags.insert(ud);
+                self.ready.push_back(Completion {
+                    user_data: ud,
+                    result: res,
+                });
+            }
         }
     }
 
@@ -316,34 +386,33 @@ mod tests {
         fn submit_and_wait_one(&mut self) -> io::Result<()> {
             match self.wait_script.pop_front() {
                 Some(Ok(())) => {
-                    // Materialise one in-flight SQE's completion.
-                    if let Some(ud) = self.in_flight.pop_front() {
-                        let res = self.results.pop_front().unwrap_or(0);
-                        self.ready.push_back(Completion {
-                            user_data: ud,
-                            result: res,
-                        });
-                    }
+                    self.materialise_on_successful_wait();
                     Ok(())
                 }
                 Some(Err(e)) => Err(e),
                 None => {
                     // No more script: behave as a successful wait that
                     // materialises an in-flight completion if any, else Ok.
-                    if let Some(ud) = self.in_flight.pop_front() {
-                        let res = self.results.pop_front().unwrap_or(0);
-                        self.ready.push_back(Completion {
-                            user_data: ud,
-                            result: res,
-                        });
-                    }
+                    self.materialise_on_successful_wait();
                     Ok(())
                 }
             }
         }
 
         fn next_completion(&mut self) -> Option<Completion> {
-            self.ready.pop_front()
+            let cqe = self.ready.pop_front();
+            // Account a REAL (matched) completion as accepted. `reap_matching`
+            // only ever advances `offset` by a CQE whose `user_data` matches its
+            // tag, and a matching tag is always one we materialised, so summing
+            // popped real completions equals the byte total applied to `offset`.
+            // Stale (pre-seeded) completions are not in `real_tags` and so do
+            // not contribute — exactly the misattribution this test guards.
+            if let Some(c) = cqe {
+                if self.real_tags.contains(&c.user_data) {
+                    self.accepted_bytes += i64::from(c.result);
+                }
+            }
+            cqe
         }
     }
 
@@ -383,25 +452,62 @@ mod tests {
         assert_eq!(ring.push_calls, 1, "EINTR retry must not re-submit the SQE");
     }
 
-    /// Counter-factual: prove the pre-fix behaviour WOULD corrupt the offset. A
-    /// stale CQE (res = 9999, from a prior interrupted submission) is sitting in
-    /// the completion queue. The naive code reaps it as this write's result and
-    /// adds 9999 to offset. The fix must skip it (user_data mismatch) and apply
-    /// only the real res.
+    /// Counter-factual: prove the pre-fix behaviour WOULD corrupt the offset and
+    /// that BOTH stale defences in the fix — the `drain_stale` pre-drain AND the
+    /// `user_data` match inside the reap loop — genuinely matter. The buffer is
+    /// two chunks (8 bytes, real results 4 then 4), so a CORRECT run pushes a
+    /// SECOND SQE and applies exactly 8 bytes; a stale-CQE misattribution
+    /// finishes in one push with an overshot offset.
+    ///
+    /// Two stale CQEs (`user_data = 999`, `res = 9999`) are placed to exercise
+    /// each defence:
+    ///   * one PRE-SEEDED in the ready queue (`with_stale`) — defended by the
+    ///     `drain_stale` call at the top of `reap_matching`;
+    ///   * one INJECTED ahead of the first real CQE DURING the wait
+    ///     (`with_stale_on_wait`) — surfaces after `drain_stale` has run, so the
+    ///     reap loop sees `[stale, real]` and ONLY the `user_data == want` match
+    ///     stops it from returning the stale 9999.
+    ///
+    /// Fail-on-revert (verified): reverting `reap_matching` to reap the head CQE
+    /// unconditionally (dropping the `user_data` match) makes the reap loop
+    /// return the injected stale's `res = 9999`; `offset` jumps past the buffer,
+    /// the loop ends after a SINGLE push, the second chunk is never written, and
+    /// the real completion is abandoned. So buggy code yields `push_calls == 1`
+    /// (assert wants 2) and an accepted-byte total that is not 8 — both fail.
+    ///
+    /// The fake also sums the `res` of every ACCEPTED (matched) completion so the
+    /// test asserts the exact applied byte total, not just the push count: a
+    /// misattribution shows up as a wrong running total even if the push count
+    /// happened to coincide.
     #[test]
     fn stale_cqe_is_not_misattributed() {
-        let stale = Completion {
-            user_data: 999, // not a tag this call will ever use for byte 0
+        let stale = || Completion {
+            user_data: 999, // not a tag this call will ever use
             result: 9999,
         };
-        let mut ring = FakeRing::new(vec![Ok(())], vec![5]).with_stale(vec![stale]);
-        // 5-byte buffer: the only correct outcome reaps res=5 for OUR tag and
-        // finishes in one positioned write. If the stale 9999 were applied,
-        // offset would overshoot and the loop would terminate having "written"
-        // far past the buffer — or the byte count would be wrong.
-        let out = write_all(&mut ring, &[0u8; 5], false, "test").unwrap();
+        // Two-chunk write: real results 4 then 4. Both staged stale CQEs must be
+        // skipped for the second push to ever happen.
+        let mut ring = FakeRing::new(vec![Ok(()), Ok(())], vec![4, 4])
+            // Defended by drain_stale (already ready before the first wait).
+            .with_stale(vec![stale()])
+            // Defended by the reap-loop user_data match (surfaces during the
+            // first wait, ahead of the real CQE).
+            .with_stale_on_wait(vec![Some(stale()), None]);
+        let out = write_all(&mut ring, &[0u8; 8], false, "test").unwrap();
         assert_eq!(out, WriteOutcome::Done);
-        assert_eq!(ring.push_calls, 1);
+        // A misattributed stale CQE (res=9999) would overshoot offset and finish
+        // in ONE push; the correct path needs TWO.
+        assert_eq!(
+            ring.push_calls, 2,
+            "stale CQE must be skipped; second chunk must still be written"
+        );
+        // The accepted completions must sum to exactly the buffer length — never
+        // the stale 9999 — proving only our own CQEs advanced the offset.
+        assert_eq!(
+            ring.accepted_bytes(),
+            8,
+            "only matched CQEs (4 + 4) may advance the offset; stale 9999 excluded"
+        );
     }
 
     /// A write error (negative res) surfaces as Err, not a silent advance.


### PR DESCRIPTION
## Summary

Three non-blocking follow-ups from the #2308 (#2297) review — all
test-quality and documentation. **No behaviour change** to the io_uring
write loop; the #2297 EINTR-retry, `user_data` CQE-matching, and
buffer-lifetime guarantees are unchanged.

- **Strengthen `stale_cqe_is_not_misattributed` into a real
  fail-on-revert guard.** The prior test used a single-chunk 5-byte
  buffer with a pre-seeded stale CQE (`res=9999`) that `drain_stale`
  evicts before the reap loop runs, and `WriteOutcome` carries no byte
  count — so it passed on both fixed and buggy code (an overshoot to
  9999 still exits the `while` loop with the same unit `Done`). It now
  writes a two-chunk 8-byte buffer (real results 4 then 4) so a correct
  run must push a SECOND SQE (`push_calls == 2`), and stages the stale
  CQE against BOTH defences: one pre-seeded (`drain_stale`) and one
  injected ahead of the real CQE *during the wait* (`with_stale_on_wait`)
  so it surfaces after `drain_stale` and only the reap-loop `user_data`
  match can skip it. The `FakeRing` records `accepted_bytes` so the test
  asserts the exact applied total is 8, never the stale 9999.
- **Reconcile the `drain_stale` doc with its body.** The docstring
  claimed a `keep`-matching CQE was preserved, but the body did
  `let _ = keep; while next_completion() {}` (full drain). Dropped the
  unused `keep` param and rewrote the doc to describe the unconditional
  drain and why it's safe (nothing ready can carry the current tag yet
  at the call site).
- **Soften the retry-ceiling docs.** The module + `write_all` docstrings
  said the loop "never returns while an SQE we submitted is still in
  flight", but `reap_matching` returns `Err` at `MAX_WAIT_RETRIES`. The
  docs now acknowledge the ceiling as a bounded escape hatch for a
  pathological EINTR storm.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test io_uring_write` — 8 pass
- [x] `cargo test state_writer` — 4 pass; `cargo test slowpath` — 2 pass
- [x] strengthened test run 5x — 5/5 green (no flake)
- [x] `go build ./...` clean
- [x] **Fail-on-revert verified:** reverting `reap_matching` to reap the
      head CQE unconditionally (dropping the `user_data` match) makes
      `stale_cqe_is_not_misattributed` FAIL — `push_calls left:1 right:2`
      — while every other io_uring_write test still passes. Restored
      after the proof.

## Refs

- Closes #2312
- Follows up #2308 / #2297

🤖 Generated with [Claude Code](https://claude.com/claude-code)