### PR TITLE
gre: implement decap-side RFC 6040 §4.2 ECN combine; scope WG to encap-copy (#2315)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,45 @@
 # Action Log
 
+## 2026-06-21 — #2315 GRE decap-side RFC 6040 §4.2 ECN combine (+ WG doc-scope)
+
+- **Timestamp**: 2026-06-21 23:30 PDT
+- **Action**: #2315 — implemented the DECAP-side RFC 6040 §4.2 ECN
+  combine for the GRE decap path (the encap-side #2303 only COPIED inner
+  ECN to the outer; the doc over-claimed it was "reflected at decap"
+  with no decap combine present). Added `outer_ecn_bits`,
+  `decap_ecn_combine` (pure §4.2 table → `DecapEcn::{Keep,SetCe,Drop}`),
+  and `apply_decap_ecn_combine` (in-place inner ECN mutate + IPv4
+  inner-header-checksum recompute; IPv6 needs none) in `gre.rs`, wired
+  into `try_native_gre_decap_from_frame`: an outer CE upgrades an
+  ECN-capable inner to CE; the illegal outer-CE/inner-Not-ECT combo is
+  DROPPED (`GRE_DECAP_ECN_ILLEGAL_DROPS` atomic → status →
+  `xpf_userspace_gre_decap_ecn_illegal_drops_total` Prometheus counter).
+  WG decap combine DEFERRED to follow-up #2317 (the control thread reads
+  WG records from a plain `UdpSocket::recv_from`, so the kernel strips
+  the outer IP/ECN before userspace — needs IP_RECVTOS/recvmsg). Scoped
+  the #2303 doc/comment over-claim to encap-copy-only. Tests: full RFC
+  6040 §4.2 table, apply-combine (CE upgrade + checksum validity, DSCP
+  preservation, illegal-combo drop+count, IPv6, short-packet, no-op when
+  outer not congested) + end-to-end GRE-decap CE-propagation/drop/no-op,
+  fail-on-revert, protocol round-trip + wire-fixture regen, Go metric
+  emit/assert. cargo build+test green; `go build ./...` + Go api/dp
+  tests green.
+- **File(s)**: userspace-dp/src/afxdp/gre.rs,
+  userspace-dp/src/afxdp/coordinator/status.rs,
+  userspace-dp/src/afxdp/wg/dscp.rs,
+  userspace-dp/src/protocol/control.rs,
+  userspace-dp/src/protocol/tests.rs,
+  userspace-dp/src/server/lifecycle.rs,
+  userspace-dp/src/server/helpers.rs,
+  userspace-dp/src/afxdp/tunnel_tests.rs,
+  userspace-dp/src/afxdp/frame/tests.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  pkg/dataplane/userspace/protocol.go, pkg/api/metrics.go,
+  pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go,
+  pkg/api/metrics_test.go, pkg/api/metrics_descriptor_coverage_test.go,
+  docs/wireguard-interop.md, docs/pr/2315-wg-gre-decap-ecn/plan.md,
+  _Log.md
+
 ## 2026-06-21 — #2312 io_uring_write follow-ups (test-quality + docs)
 
 - **Timestamp**: 2026-06-21 23:00 PDT

--- a/docs/pr/2315-wg-gre-decap-ecn/plan.md
+++ b/docs/pr/2315-wg-gre-decap-ecn/plan.md
@@ -1,0 +1,100 @@
+# #2315 — WG/GRE outer→inner ECN handling at DECAP (RFC 6040 §4.2)
+
+## Problem
+
+PR #2307 (#2303) added the encap-side inner→outer DSCP+ECN COPY (RFC
+2983 uniform DSCP + RFC 6040 normal-mode *ingress*). The `gre.rs`
+`inner_tos_byte` rustdoc over-claims that "a CE mark applied by a
+congested router on the OUTER path can be reflected back to the inner
+endpoints at decap" — but there is **no decap-side RFC 6040 ECN combine**
+implemented. Issue #2315 asks to either implement the decap-side combine
+or correct the doc.
+
+## RFC 6040 §4.2 decapsulation combine table
+
+Resulting *inner* ECN as a function of (arriving inner, arriving outer):
+
+| Inner ↓ \ Outer → | Not-ECT(00) | ECT(0)(10) | ECT(1)(01) | CE(11) |
+|---|---|---|---|---|
+| Not-ECT(00)       | Not-ECT     | Not-ECT    | Not-ECT    | **drop** |
+| ECT(0)(10)        | ECT(0)      | ECT(0)     | ECT(1)     | CE     |
+| ECT(1)(01)        | ECT(1)      | ECT(1)     | ECT(1)     | CE     |
+| CE(11)            | CE          | CE         | CE         | CE     |
+
+- The only mutation that ever happens: outer CE upgrades a non-CE,
+  ECN-capable inner to CE (loss-free congestion signalling). Outer
+  ECT(1) over inner ECT(0) → ECT(1) (the §4.2 "MAY" left as the upgrade
+  variant; matches Linux). Everything else leaves the inner unchanged.
+- The illegal combination outer=CE + inner=Not-ECT is **dropped**
+  (a congested router CE-marked a packet whose endpoints never
+  negotiated ECN — never legitimate; §4.2). We bump a counter and drop.
+
+## Scope decision
+
+**Hybrid.** Two decap surfaces:
+
+1. **GRE decap** — `try_native_gre_decap_from_frame` in `gre.rs`
+   operates on the FULL AF_XDP frame: the outer IP header (with outer
+   ECN) is present at `meta.l3_offset`, and we build a synthetic inner
+   frame we fully own. The combine is a few bit-ops on the inner TOS
+   byte plus an IPv4 inner-header-checksum recompute. **Implement.**
+
+2. **WireGuard decap** — `coordinator/wg_control.rs` `dispatch_inbound`
+   reads the WG record from a plain `UdpSocket::recv_from`. The kernel
+   has ALREADY stripped the outer IP header before the datagram reaches
+   userspace, so the outer ECN is GONE at this layer. Recovering it
+   needs `IP_RECVTOS` / `IPV6_RECVTCLASS` socket options + a switch from
+   `recv_from` to `recvmsg` control-message parsing in the recv loop,
+   then plumbing the outer TOS through `dispatch_inbound` → combine
+   before the `tun.write_all`. That is a meaningfully larger/riskier
+   recv-loop subsystem change. **Defer to a follow-up issue; correct the
+   doc to scope the WG claim to encap-copy only.**
+
+## Why GRE checksum handling is narrow
+
+- IPv4 inner: changing the TOS byte changes the IPv4 **header**
+  checksum → recompute the 20-byte (IHL-based) header checksum. The L4
+  (TCP/UDP) checksum does NOT cover the IPv4 TOS byte, so it is
+  untouched.
+- IPv6 inner: there is NO IP header checksum, and the L4 pseudo-header
+  covers src/dst/length/next-header only — NOT the Traffic Class field.
+  So setting the inner CE bit needs no checksum work at all.
+
+## Files touched
+
+- `userspace-dp/src/afxdp/gre.rs`
+  - `outer_ecn_bits(frame, meta)` — read the 2-bit outer ECN from the
+    outer IP header (v4 octet 1 low 2 bits; v6 (b0<<6)&... → TC low 2).
+  - `rfc6040_combine_inner_ecn(inner_ecn, outer_ecn) -> Decap6040`
+    enum {Keep, SetCe, Drop} — pure table, unit-tested over all 16.
+  - `apply_decap_ecn_combine(inner_packet: &mut [u8], inner_family,
+    outer_ecn) -> bool` — mutate inner ECN in place + recompute IPv4
+    header checksum; return false = DROP (illegal combo).
+  - Wire into `try_native_gre_decap_from_frame`: compute outer ECN,
+    apply to the synthetic inner before flow parse; on Drop, bump
+    `gre_decap_ecn_illegal_drops` counter and return None.
+  - Correct the `inner_tos_byte` rustdoc (encap is a copy; decap combine
+    now exists for GRE).
+- `userspace-dp/src/afxdp/wg/dscp.rs` — doc note: WG decap combine is a
+  follow-up (#NNNN), socket-option blocked.
+- Counter: add `gre_decap_ecn_illegal_drops` to the forwarding /
+  dataplane counter surface used by gre decap.
+- `userspace-dp/src/afxdp/tunnel_tests.rs` — RFC 6040 table tests +
+  end-to-end GRE decap CE-propagation + illegal-drop + IPv4 checksum
+  validity + fail-on-revert.
+- `docs/wireguard-interop.md` — scope the ECN claim; note GRE decap
+  combine landed, WG decap deferred.
+
+## Test strategy
+
+- `rfc6040_combine_inner_ecn` over all 16 (inner×outer) → exact table.
+- `apply_decap_ecn_combine`:
+  - outer CE + inner ECT(0) → inner CE, IPv4 checksum valid.
+  - outer CE + inner Not-ECT → returns false (drop).
+  - outer Not-ECT + inner ECT(0) → inner unchanged, checksum unchanged.
+  - IPv6 inner CE set, no checksum field touched.
+- End-to-end through `try_native_gre_decap_from_frame`: an outer-CE GRE
+  frame with an ECT inner emerges with inner CE set and a valid inner
+  IPv4 header checksum; an outer-CE + Not-ECT inner is dropped (None).
+- Fail-on-revert: assert the inner CE bit is SET (the exact behavior the
+  pre-fix copy-only path could never produce).

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -17,7 +17,7 @@ therefore staged by capability, not by vendor.
 | S4 | Non-zero pre-shared key (PSK) plumbing | pending |
 | S5 | Persistent-keepalive + REKEY/REJECT-AFTER timers + endpoint roaming + empty-record (keepalive/key-confirm) handling + TAI64N disk persistence | **timers + keepalives DONE (#1888/#1889)** — full whitepaper §6.1 timer machine (REKEY_AFTER_TIME 120s initiator-only, 165s receive horizon, REJECT_AFTER_TIME 180s per-use + expiry teardown, 5s/90s retry discipline, 10s passive + configured persistent keepalives, post-msg2 key-confirmation keepalive) on a blocking-poll(2) control loop; design of record `docs/research/1888-wg-timers/plan.md`. Authenticated-datagram endpoint LEARNING shipped in S2a/#1888 (keepalives now count); engine-level roam API + TAI64N disk persistence remain pending |
 | S6 | Junos config surface (grammar + compiler + snapshot population, base64↔hex keys) | pending |
-| S7 | Type-3 CookieReply + MAC2 generation/verification + IPv6 outer encap + DSCP/ECN | **DSCP/ECN DONE (#2303)** — inner DSCP+ECN copied onto the outer header (uniform DSCP + RFC 6040 ECN ingress); CookieReply/MAC2 still pending |
+| S7 | Type-3 CookieReply + MAC2 generation/verification + IPv6 outer encap + DSCP/ECN | **DSCP/ECN encap DONE (#2303)** — inner DSCP+ECN copied onto the outer header (uniform DSCP + RFC 6040 ECN ingress copy). GRE decap-side RFC 6040 §4.2 ECN *combine* shipped in #2315; **WG decap-side combine still pending (#2317)** — blocked on `IP_RECVTOS`/`recvmsg` recv-loop changes. CookieReply/MAC2 still pending |
 | S8 | HA RG WG-session migration | pending |
 
 ## Tunnel MTU + MSS + DSCP/ECN model (#2299 / #2300 / #2303)
@@ -59,15 +59,35 @@ the route at the tunnel-manager layer, so a non-1500 underlay relies on
 either the operator `mtu` statement or the Rust egress guard as the
 authoritative backstop.
 
-### DSCP/ECN propagation (#2303)
-GRE and WG encap copy the inner packet's full TOS / IPv6 Traffic-Class
-byte (DSCP 6 bits + ECN 2 bits) onto the outer header via
-`gre::inner_tos_byte`, instead of hardcoding 0. This is the uniform DSCP
-model (RFC 2983) — per-hop QoS classification survives the tunnel — plus
-RFC 6040 normal-mode ECN ingress (inner ECN copied to outer), so a CE
-mark applied by a congested router on the outer path is reflected to the
-inner endpoints at decap. `wg::dscp::tos_from_dscp` (which clears ECN)
-is retained for the DSCP-only case but is NOT the encap reader.
+### DSCP/ECN propagation (#2303 encap, #2315 GRE decap)
+
+**Encap (#2303).** GRE and WG encap copy the inner packet's full TOS /
+IPv6 Traffic-Class byte (DSCP 6 bits + ECN 2 bits) onto the outer header
+via `gre::inner_tos_byte`, instead of hardcoding 0. This is the uniform
+DSCP model (RFC 2983) — per-hop QoS classification survives the tunnel —
+plus the RFC 6040 normal-mode ECN ingress COPY (inner ECN → outer ECN).
+`wg::dscp::tos_from_dscp` (which clears ECN) is retained for the
+DSCP-only case but is NOT the encap reader.
+
+**Decap (#2315).** The RFC 6040 §4.2 decap-side ECN *combine* (outer ECN
+→ inner ECN) — the half that actually reflects a CE mark applied by a
+congested router on the outer path back to the inner endpoints — is
+implemented for the **GRE decap path only**
+(`gre::apply_decap_ecn_combine`, wired into
+`try_native_gre_decap_from_frame`): an outer CE upgrades an ECN-capable
+inner to CE; the illegal outer-CE / inner-Not-ECT combination is dropped
+(`xpf_userspace_gre_decap_ecn_illegal_drops_total`); the inner DSCP is
+authoritative at decap and is never copied from the outer. DSCP is not
+copied back at decap.
+
+> **WireGuard decap is NOT yet combined (#2317).** The WG control thread
+> reads transport records from a plain `UdpSocket::recv_from`, so the
+> kernel has already stripped the outer IP header before the datagram
+> reaches userspace — the outer ECN is gone at that layer. Recovering it
+> needs `IP_RECVTOS` / `IPV6_RECVTCLASS` + a `recvmsg` control-message
+> recv loop, then combining into the inner before the `tun.write_all`.
+> Tracked as a follow-up; do NOT read the encap-copy as "ECN is
+> reflected at WG decap".
 
 ## What S1 delivers
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -245,7 +245,12 @@ type xpfCollector struct {
 	// helper worker panic poisoned a command queue and it was recovered
 	// (committed-prefix + clear_poison policy) instead of going deaf.
 	userspaceWorkerCommandQueuePoisonRecoveries *prometheus.Desc
-	userspaceFlowCacheActiveFlows               *prometheus.Desc
+	// #2315: GRE-decap RFC 6040 §4.2 illegal-combination drops (outer CE
+	// over a Not-ECT inner) — nonzero flags a misbehaving tunnel ingress
+	// that ECT-marked the outer for un-ECN inner traffic on a congested
+	// path.
+	userspaceGreDecapEcnIllegalDrops *prometheus.Desc
+	userspaceFlowCacheActiveFlows    *prometheus.Desc
 	userspaceFlowCacheCapacity                  *prometheus.Desc
 	// #1379: daemon-side userspace event-stream transport counters.
 	userspaceEventStreamFramesTotal          *prometheus.Desc
@@ -531,6 +536,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.userspaceDnatPublishErrors
 	ch <- c.userspaceNatReverseKeySharedDisplacements
 	ch <- c.userspaceWorkerCommandQueuePoisonRecoveries
+	ch <- c.userspaceGreDecapEcnIllegalDrops
 	ch <- c.userspaceFlowCacheActiveFlows
 	ch <- c.userspaceFlowCacheCapacity
 	ch <- c.userspaceEventStreamFramesTotal

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -513,6 +513,7 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_userspace_dnat_publish_errors_total",                          // #2244 dnat_table reverse-NAT publish failures
 		"xpf_userspace_session_nat_reverse_key_shared_displacements_total", // #1760 W3' shared displacements
 		"xpf_userspace_worker_command_queue_poison_recoveries_total",       // #1807 poison recoveries
+		"xpf_userspace_gre_decap_ecn_illegal_drops_total",                  // #2315 RFC 6040 4.2 decap illegal-combo drops
 		// #1771 §2.6 resolver backoff + §2.5 ENOBUFS/re-dump + key gauges
 		"xpf_userspace_neighbor_resolver_get_backoff_attempts_total",
 		"xpf_userspace_neighbor_netlink_enobufs_total",

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -818,6 +818,19 @@ func newCollector(srv *Server) *xpfCollector {
 				"occurred (#1807, extends #1790).",
 			nil, nil,
 		),
+		userspaceGreDecapEcnIllegalDrops: prometheus.NewDesc(
+			"xpf_userspace_gre_decap_ecn_illegal_drops_total",
+			"GRE-decap frames dropped by the RFC 6040 4.2 decap-side ECN "+
+				"combine because the outer header carried a CE (congestion "+
+				"experienced) mark over an inner packet that was Not-ECT "+
+				"(the illegal combination: a congested router CE-marked a "+
+				"packet whose endpoints never negotiated ECN). RFC 6040 "+
+				"mandates dropping this rather than silently clearing the "+
+				"bogus CE. A nonzero value flags a misbehaving tunnel "+
+				"ingress that ECT-marked the outer for un-ECN inner "+
+				"traffic on a congested path (#2315).",
+			nil, nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"Aggregate active userspace flow-cache entries across bindings.",

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -824,6 +824,12 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 			nil,
 			nil,
 		),
+		userspaceGreDecapEcnIllegalDrops: prometheus.NewDesc(
+			"xpf_userspace_gre_decap_ecn_illegal_drops_total",
+			"gre decap rfc6040 illegal-combo drops",
+			nil,
+			nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"flow-cache active flows",
@@ -855,6 +861,9 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 		NatReverseKeySharedDisplacementsTotal: 4,
 		// #1807: poison-recovery counter emitted unconditionally.
 		WorkerCommandQueuePoisonRecoveries: 2,
+		// #2315: GRE-decap RFC 6040 §4.2 illegal-combo drop counter
+		// emitted unconditionally.
+		GreDecapEcnIllegalDropsTotal: 3,
 		// #1861: install-refusal trio emitted unconditionally.
 		SessionCreateDrops:             9,
 		SessionInstallAdmissionRefused: 8,
@@ -889,9 +898,10 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 		got = append(got, m)
 	}
 	// 10 pre-#1861 metrics + the #1861 install-refusal trio + the #2244
-	// dnat_table reverse-NAT publish-error counter = 14.
-	if len(got) != 14 {
-		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 14 metrics, got %d", len(got))
+	// dnat_table reverse-NAT publish-error counter (= 14) + the #2315
+	// gre_decap_ecn_illegal_drops_total counter = 15.
+	if len(got) != 15 {
+		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 15 metrics, got %d", len(got))
 	}
 
 	assertGaugeClose(t, got, c.userspaceSessionTableEntries, nil, 77)
@@ -908,6 +918,9 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	assertCounterClose(t, got, c.userspaceNatReverseKeySharedDisplacements, nil, 4)
 	// #1807: poison-recovery counter emitted unconditionally.
 	assertCounterClose(t, got, c.userspaceWorkerCommandQueuePoisonRecoveries, nil, 2)
+	// #2315: GRE-decap RFC 6040 §4.2 illegal-combo drop counter emitted
+	// unconditionally.
+	assertCounterClose(t, got, c.userspaceGreDecapEcnIllegalDrops, nil, 3)
 	// #1861: install-refusal trio emitted unconditionally.
 	assertCounterClose(t, got, c.userspaceSessionCreateDrops, nil, 9)
 	assertCounterClose(t, got, c.userspaceSessionInstallAdmissionRefused, nil, 8)

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -521,6 +521,15 @@ func (c *xpfCollector) emitUserspaceDynamicBufferMetrics(ch chan<- prometheus.Me
 		float64(status.WorkerCommandQueuePoisonRecoveries),
 	)
 
+	// #2315: GRE-decap RFC 6040 4.2 illegal-combination drops (outer CE
+	// over a Not-ECT inner). Emitted unconditionally so a 0 is a real
+	// "no illegal combinations seen" signal rather than an absent series.
+	ch <- prometheus.MustNewConstMetric(
+		c.userspaceGreDecapEcnIllegalDrops,
+		prometheus.CounterValue,
+		float64(status.GreDecapEcnIllegalDropsTotal),
+	)
+
 	var activeFlows, flowCapacity uint64
 	for _, b := range status.Bindings {
 		activeFlows += uint64(b.ActiveFlowCount)

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -783,6 +783,15 @@ type ProcessStatus struct {
 	// Omitempty-free on the Rust side (always serialized); plain decode
 	// here defaults to 0 for older helpers.
 	WorkerCommandQueuePoisonRecoveries uint64 `json:"worker_command_queue_poison_recoveries,omitempty"`
+	// #2315: GRE-decap frames dropped by the RFC 6040 §4.2 decap-side ECN
+	// combine because the outer header carried a CE mark over an inner
+	// packet that was Not-ECT (the illegal combination — a congested
+	// router CE-marked a packet whose endpoints never negotiated ECN).
+	// RFC 6040 mandates a drop here rather than silently clearing the
+	// bogus CE. Surfaced as
+	// xpf_userspace_gre_decap_ecn_illegal_drops_total. Omitempty for wire
+	// compat with older helpers (defaults to 0).
+	GreDecapEcnIllegalDropsTotal uint64 `json:"gre_decap_ecn_illegal_drops_total,omitempty"`
 	// #1769: on-demand neighbor-resolver telemetry. The resolver fires
 	// when a MissingNeighbor negative-cache fast-fail nudges a wedged dst
 	// (single-key RTM_GETNEIGH + epoch-guarded cache or probe-on-stale).

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -181,6 +181,18 @@ impl super::Coordinator {
         crate::afxdp::worker_queue::WORKER_COMMAND_QUEUE_POISON_RECOVERIES.load(Ordering::Relaxed)
     }
 
+    /// #2315: GRE-decap frames dropped by the RFC 6040 §4.2 decap-side
+    /// ECN combine because the outer header carried a CE mark over an
+    /// inner packet that was Not-ECT (the illegal combination — a
+    /// congested router CE-marked a packet whose endpoints never
+    /// negotiated ECN). RFC 6040 mandates a drop here. Surfaced as
+    /// `xpf_userspace_gre_decap_ecn_illegal_drops_total`; a nonzero
+    /// value flags a misbehaving tunnel ingress (it copied ECT onto the
+    /// outer for un-ECN-marked inner traffic) on a congested path.
+    pub fn gre_decap_ecn_illegal_drops_total(&self) -> u64 {
+        crate::afxdp::gre::GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed)
+    }
+
     /// #1782: debug dump of every key currently present in the userspace
     /// `dynamic_neighbors` mirror, as `(ifindex, ip)` pairs. The
     /// cold-start capture harness reads this at the pre-connect t0'

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -565,6 +565,123 @@ fn native_gre_decap_maps_inner_packet_to_logical_tunnel_ingress() {
     assert_eq!(&packet.frame[30..34], &[10, 255, 192, 42]);
 }
 
+/// #2315: build an inner IPv4 ICMP frame, set its TOS byte, and
+/// recompute the inner IPv4 header checksum so it stays valid. The IPv4
+/// header is at inner[14..34]; the TOS byte is inner[15]; the checksum
+/// is inner[24..26].
+fn inner_v4_frame_with_tos(src: Ipv4Addr, dst: Ipv4Addr, ttl: u8, tos: u8) -> Vec<u8> {
+    let mut inner = build_icmp_echo_frame_v4(src, dst, ttl);
+    inner[15] = tos;
+    inner[24] = 0;
+    inner[25] = 0;
+    let cs = checksum16(&inner[14..34]);
+    inner[24..26].copy_from_slice(&cs.to_be_bytes());
+    inner
+}
+
+/// #2315: overwrite the outer IPv6 ECN field (low 2 bits of the Traffic
+/// Class) on a built GRE frame. The IPv6 header starts at frame[14];
+/// TC = (octet0<<4)|(octet1>>4); ECN is bits 4-5 of octet 1.
+fn set_outer_ipv6_ecn(frame: &mut [u8], ecn: u8) {
+    frame[15] = (frame[15] & 0xCF) | ((ecn & 0x03) << 4);
+}
+
+#[test]
+fn native_gre_decap_combines_outer_ce_into_inner_ecn() {
+    // #2315 RFC 6040 §4.2: an outer CE over an ECN-capable inner must
+    // upgrade the inner ECN to CE at decap, and the inner IPv4 header
+    // checksum must remain valid after the TOS change.
+    let state = build_forwarding_state(&native_gre_snapshot(true));
+    // Inner DSCP EF (46) + ECT(0) (0b10).
+    let inner_tos = (46u8 << 2) | 0b10;
+    let inner = inner_v4_frame_with_tos(
+        Ipv4Addr::new(10, 255, 192, 41),
+        Ipv4Addr::new(10, 255, 192, 42),
+        63,
+        inner_tos,
+    );
+    let mut outer = build_ipv6_gre_frame(
+        &inner[14..],
+        "2602:ffd3:0:2::7".parse().unwrap(),
+        "2001:559:8585:80::8".parse().unwrap(),
+        None,
+    );
+    set_outer_ipv6_ecn(&mut outer, 0b11); // outer CE
+
+    let packet = try_native_gre_decap_from_frame(&outer, native_gre_outer_meta(), &state)
+        .expect("decap must forward (legal CE upgrade)");
+    // Inner emerges in the synthetic frame at offset 14 (eth) + 1 (TOS).
+    let inner_tos_out = packet.frame[15];
+    assert_eq!(inner_tos_out & 0x03, 0b11, "inner ECN must be upgraded to CE");
+    assert_eq!(inner_tos_out >> 2, 46, "inner DSCP (EF) must be preserved");
+    // Fail-on-revert: the CE bit MUST be set — the pre-#2315 copy-only
+    // path could never produce this (it never touched the inner ECN).
+    assert_ne!(inner_tos_out & 0x03, 0b10, "ECN must change from ECT(0)");
+    // Inner IPv4 header checksum (synthetic frame[14..34]) must be valid.
+    assert_eq!(
+        checksum16(&packet.frame[14..34]),
+        0,
+        "inner IPv4 header checksum must be recomputed after the CE upgrade"
+    );
+}
+
+#[test]
+fn native_gre_decap_drops_illegal_outer_ce_over_not_ect_inner() {
+    // #2315 RFC 6040 §4.2: outer CE over a Not-ECT inner is the illegal
+    // combination — decap must DROP (return None).
+    let state = build_forwarding_state(&native_gre_snapshot(true));
+    let inner = inner_v4_frame_with_tos(
+        Ipv4Addr::new(10, 255, 192, 41),
+        Ipv4Addr::new(10, 255, 192, 42),
+        63,
+        (46u8 << 2) | 0b00, // Not-ECT
+    );
+    let mut outer = build_ipv6_gre_frame(
+        &inner[14..],
+        "2602:ffd3:0:2::7".parse().unwrap(),
+        "2001:559:8585:80::8".parse().unwrap(),
+        None,
+    );
+    set_outer_ipv6_ecn(&mut outer, 0b11); // outer CE
+
+    assert!(
+        try_native_gre_decap_from_frame(&outer, native_gre_outer_meta(), &state).is_none(),
+        "outer CE over a Not-ECT inner must be dropped (§4.2)"
+    );
+}
+
+#[test]
+fn native_gre_decap_leaves_inner_unchanged_when_outer_not_congested() {
+    // Outer Not-ECT must leave the inner ECN/DSCP and checksum exactly
+    // as they arrived (no spurious mutation on the common case).
+    let state = build_forwarding_state(&native_gre_snapshot(true));
+    let inner_tos = (10u8 << 2) | 0b01; // DSCP 10 + ECT(1)
+    let inner = inner_v4_frame_with_tos(
+        Ipv4Addr::new(10, 255, 192, 41),
+        Ipv4Addr::new(10, 255, 192, 42),
+        63,
+        inner_tos,
+    );
+    let outer = build_ipv6_gre_frame(
+        &inner[14..],
+        "2602:ffd3:0:2::7".parse().unwrap(),
+        "2001:559:8585:80::8".parse().unwrap(),
+        None,
+    );
+    // build_ipv6_gre_frame writes outer TC = 0 (Not-ECT) — no mutation.
+    let packet = try_native_gre_decap_from_frame(&outer, native_gre_outer_meta(), &state)
+        .expect("decap forwards");
+    assert_eq!(
+        packet.frame[15], inner_tos,
+        "outer Not-ECT must leave the inner TOS byte verbatim"
+    );
+    assert_eq!(
+        checksum16(&packet.frame[14..34]),
+        0,
+        "inner checksum unchanged and valid"
+    );
+}
+
 #[test]
 fn build_forwarded_frame_from_frame_encapsulates_native_gre() {
     let state = build_forwarding_state(&native_gre_snapshot(true));

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -82,6 +82,18 @@ pub(in crate::afxdp) fn packet_trimmed_len(packet: &[u8], addr_family: u8) -> Op
     }
 }
 
+/// #2315: count of GRE-decap frames DROPPED because the outer header
+/// carried a CE mark over an inner packet that was Not-ECT — the
+/// "illegal" RFC 6040 §4.2 combination (a congested router CE-marked a
+/// packet whose endpoints never negotiated ECN). Surfaced via
+/// `coordinator/status.rs` as
+/// `xpf_userspace_gre_decap_ecn_illegal_drops_total`. A nonzero value
+/// means a misbehaving/misconfigured tunnel ingress copied ECT onto the
+/// outer for traffic the inner endpoints did not mark, then the path
+/// congested. RFC 6040 mandates a drop here (the alternative — clearing
+/// the bogus CE — would silently hide the protocol violation).
+pub(in crate::afxdp) static GRE_DECAP_ECN_ILLEGAL_DROPS: AtomicU64 = AtomicU64::new(0);
+
 /// Read the inner IP packet's DSCP+ECN byte for outer-header
 /// propagation on tunnel encap (#2303). Returns the full 8-bit
 /// TOS / Traffic-Class value (DSCP in the high 6 bits, ECN in the
@@ -91,11 +103,14 @@ pub(in crate::afxdp) fn packet_trimmed_len(packet: &[u8], addr_family: u8) -> Op
 ///   - DSCP: uniform model (RFC 2983 §3) — the inner DSCP is mirrored
 ///     onto the outer so per-hop QoS classification survives the
 ///     tunnel.
-///   - ECN: RFC 6040 normal-mode ingress — the inner ECN is copied to
-///     the outer ECN field, so a CE mark applied by a congested router
-///     on the OUTER path can be reflected back to the inner endpoints
-///     at decap (loss-free congestion signalling instead of a fallback
-///     to loss-based control).
+///   - ECN: RFC 6040 normal-mode ingress — the inner ECN is COPIED to
+///     the outer ECN field at ENCAP, so a CE mark applied by a
+///     congested router on the OUTER path can later be combined back
+///     into the inner ECN at DECAP (loss-free congestion signalling
+///     instead of a fallback to loss-based control). The complementary
+///     DECAP-side combine (outer ECN → inner ECN) is `decap_ecn_combine`
+///     below, wired into `try_native_gre_decap_from_frame` (#2315). This
+///     function is ENCAP-only — it just reads the byte to copy.
 ///
 /// Reading the WHOLE byte (rather than masking to DSCP and re-shifting,
 /// the `wg::dscp::tos_from_dscp` shape that clears ECN) is what makes
@@ -123,6 +138,187 @@ pub(in crate::afxdp) fn inner_tos_byte(packet: &[u8], addr_family: u8) -> u8 {
         }
         _ => 0,
     }
+}
+
+/// Extract the 2-bit ECN field from an IP TOS / Traffic-Class byte.
+/// ECN occupies the low 2 bits of the DiffServ octet:
+///   00 = Not-ECT, 10 = ECT(0), 01 = ECT(1), 11 = CE.
+#[inline]
+fn ecn_of_tos(tos: u8) -> u8 {
+    tos & 0x03
+}
+
+/// Read the OUTER IP header's 2-bit ECN field for the RFC 6040 §4.2
+/// decap combine. `frame` is the full received frame; `meta.l3_offset`
+/// is the outer IP header start; `meta.addr_family` is the OUTER family.
+/// Returns `None` when the outer header is truncated (caller then skips
+/// the combine — a malformed outer never mutates the inner).
+#[inline]
+fn outer_ecn_bits(frame: &[u8], meta: UserspaceDpMeta) -> Option<u8> {
+    let l3 = meta.l3_offset as usize;
+    match meta.addr_family as i32 {
+        // IPv4: TOS/DiffServ is octet 1 of the outer header.
+        libc::AF_INET => Some(ecn_of_tos(*frame.get(l3 + 1)?)),
+        // IPv6: Traffic Class spans the low nibble of octet 0 and the
+        // high nibble of octet 1; ECN is its low 2 bits — i.e. bits 2-3
+        // of octet 1. TC = (b0 << 4) | (b1 >> 4); ECN = TC & 0x03 =
+        // (b1 >> 4) & 0x03.
+        libc::AF_INET6 => Some((*frame.get(l3 + 1)? >> 4) & 0x03),
+        _ => None,
+    }
+}
+
+/// RFC 6040 §4.2 decapsulation outcome for a single (inner, outer) ECN
+/// pair.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) enum DecapEcn {
+    /// Leave the inner ECN field unchanged.
+    Keep,
+    /// Upgrade the inner ECN to CE (congestion experienced).
+    SetCe,
+    /// Illegal combination (outer CE over a Not-ECT inner) — drop the
+    /// packet per RFC 6040 §4.2.
+    Drop,
+}
+
+/// RFC 6040 §4.2 ECN combine. Given the ARRIVING inner ECN and the
+/// ARRIVING outer ECN, decide how the inner ECN must change at decap.
+///
+/// Table (rows = inner, columns = outer):
+///
+/// | inner \ outer | Not-ECT(00) | ECT0(10) | ECT1(01) | CE(11) |
+/// |---------------|-------------|----------|----------|--------|
+/// | Not-ECT(00)   | Keep        | Keep     | Keep     | Drop   |
+/// | ECT(0)(10)    | Keep        | Keep     | SetCe*   | SetCe  |
+/// | ECT(1)(01)    | Keep        | Keep     | Keep     | SetCe  |
+/// | CE(11)        | Keep        | Keep     | Keep     | Keep   |
+///
+/// The only state changes are: outer CE upgrades any ECN-capable,
+/// non-CE inner to CE (the loss-free congestion signal this whole
+/// feature exists for); and the §4.2 "MAY" case outer=ECT(1) over
+/// inner=ECT(0) is taken as the upgrade-to-ECT(1) variant (* — matches
+/// Linux's `__INET_ECN_decapsulate`). The illegal outer=CE / inner=
+/// Not-ECT cell is a Drop. Every other cell keeps the inner verbatim
+/// (so a Not-ECT or already-CE inner is never touched, and the inner
+/// DSCP — which is authoritative at decap — is never copied from the
+/// outer).
+///
+/// `inner_ecn` and `outer_ecn` are the 2-bit ECN values (low 2 bits).
+#[inline]
+pub(in crate::afxdp) fn decap_ecn_combine(inner_ecn: u8, outer_ecn: u8) -> DecapEcn {
+    const NOT_ECT: u8 = 0b00;
+    const ECT_1: u8 = 0b01;
+    const ECT_0: u8 = 0b10;
+    const CE: u8 = 0b11;
+    match (inner_ecn & 0x03, outer_ecn & 0x03) {
+        // Not-ECT inner: never carries a congestion mark. Outer CE is
+        // the illegal combination — drop. Any other outer is ignored
+        // (a Not-ECT endpoint cannot consume an ECN signal).
+        (NOT_ECT, CE) => DecapEcn::Drop,
+        (NOT_ECT, _) => DecapEcn::Keep,
+        // CE inner already carries the strongest signal — nothing to do.
+        (CE, _) => DecapEcn::Keep,
+        // ECN-capable, non-CE inner: outer CE upgrades it to CE.
+        (_, CE) => DecapEcn::SetCe,
+        // §4.2 MAY: outer ECT(1) over inner ECT(0) → ECT(1) (upgrade
+        // variant). Implemented as SetCe? No — ECT(1) is not CE; this is
+        // an ECT-codepoint change, NOT a congestion mark. Handled by the
+        // dedicated SetEct1 path below would over-complicate the type;
+        // since ECT(1)→ECT(0) carries no congestion semantics and RFC
+        // 6040 leaves it a MAY, take the simpler compliant choice: Keep
+        // the inner ECT(0). (Linux upgrades; both are conformant.)
+        (ECT_0, ECT_1) => DecapEcn::Keep,
+        // All remaining non-CE outer values leave an ECN-capable inner
+        // unchanged.
+        _ => DecapEcn::Keep,
+    }
+}
+
+/// Apply the RFC 6040 §4.2 decap ECN combine IN PLACE to the inner IP
+/// packet. `inner_packet` is the inner IP datagram (L2 already
+/// stripped); `inner_family` is the inner family; `outer_ecn` is the
+/// 2-bit outer ECN read from the (now-stripped) outer header.
+///
+/// Returns `true` to FORWARD (possibly after setting the inner CE bit)
+/// and `false` to DROP (the illegal outer-CE / inner-Not-ECT combo, per
+/// §4.2; the drop counter is bumped here).
+///
+/// When the inner ECN is upgraded to CE on an IPv4 inner, the IPv4
+/// header checksum is recomputed (the TOS byte is covered by the IPv4
+/// header checksum but NOT by the L4 checksum). IPv6 inners have no IP
+/// header checksum, and the IPv6 Traffic Class is not covered by the L4
+/// pseudo-header, so no checksum work is needed.
+#[inline]
+pub(in crate::afxdp) fn apply_decap_ecn_combine(
+    inner_packet: &mut [u8],
+    inner_family: u8,
+    outer_ecn: u8,
+) -> bool {
+    match inner_family as i32 {
+        libc::AF_INET => {
+            // IPv4 TOS is octet 1; ECN is its low 2 bits.
+            let Some(&tos) = inner_packet.get(1) else {
+                // Too short to hold the byte — forward unchanged
+                // (consistent with the encap-side short-packet fallback).
+                return true;
+            };
+            match decap_ecn_combine(ecn_of_tos(tos), outer_ecn) {
+                DecapEcn::Keep => true,
+                DecapEcn::Drop => {
+                    GRE_DECAP_ECN_ILLEGAL_DROPS.fetch_add(1, Ordering::Relaxed);
+                    false
+                }
+                DecapEcn::SetCe => {
+                    // Set ECN = CE (low 2 bits) without disturbing DSCP.
+                    inner_packet[1] = (tos & 0xFC) | 0x03;
+                    recompute_ipv4_header_checksum(inner_packet);
+                    true
+                }
+            }
+        }
+        libc::AF_INET6 => {
+            // IPv6 ECN is bits 2-3 of octet 1 (low 2 bits of the
+            // Traffic Class). Need octets 0 and 1 to read/write it.
+            let Some(&b1) = inner_packet.get(1) else {
+                return true;
+            };
+            let inner_ecn = (b1 >> 4) & 0x03;
+            match decap_ecn_combine(inner_ecn, outer_ecn) {
+                DecapEcn::Keep => true,
+                DecapEcn::Drop => {
+                    GRE_DECAP_ECN_ILLEGAL_DROPS.fetch_add(1, Ordering::Relaxed);
+                    false
+                }
+                DecapEcn::SetCe => {
+                    // CE = 0b11 in the ECN slot = bits 2-3 of octet 1.
+                    // Clear the existing ECN nibble-bits then set CE.
+                    inner_packet[1] = (b1 & 0xCF) | (0x03 << 4);
+                    // IPv6: no header checksum; TC not in the L4
+                    // pseudo-header — nothing else to recompute.
+                    true
+                }
+            }
+        }
+        _ => true,
+    }
+}
+
+/// Recompute the IPv4 header checksum in place. `packet` starts at the
+/// IPv4 header. The header length is taken from IHL (octet 0 low nibble,
+/// in 32-bit words). A short or malformed header leaves the packet
+/// unchanged. Used after the decap ECN combine mutates the TOS byte.
+#[inline]
+fn recompute_ipv4_header_checksum(packet: &mut [u8]) {
+    let Some(&b0) = packet.first() else { return };
+    let ihl = usize::from(b0 & 0x0f) * 4;
+    if ihl < 20 || packet.len() < ihl {
+        return;
+    }
+    // Zero the checksum field (octets 10-11) before recomputing.
+    packet[10] = 0;
+    packet[11] = 0;
+    let cs = checksum16(&packet[..ihl]);
+    packet[10..12].copy_from_slice(&cs.to_be_bytes());
 }
 
 fn gre_inner_family_and_proto(proto: u16) -> Option<(u8, u16)> {
@@ -290,6 +486,23 @@ pub(super) fn try_native_gre_decap_from_frame(
     let mut synthetic = vec![0u8; 14 + inner_packet.len()];
     synthetic[12..14].copy_from_slice(&inner_eth_proto.to_be_bytes());
     synthetic[14..].copy_from_slice(inner_packet);
+
+    // #2315: RFC 6040 §4.2 decap-side ECN combine. The outer ECN (read
+    // from the still-present outer IP header in `frame` at
+    // `meta.l3_offset`) is combined into the inner ECN: an outer CE
+    // upgrades an ECN-capable inner to CE so a congestion mark applied
+    // on the OUTER path is reflected to the inner endpoints; the illegal
+    // outer-CE / inner-Not-ECT combination is dropped. Mutates the
+    // synthetic inner in place (octet `14 + 1` for the inner TOS) and
+    // recomputes the inner IPv4 header checksum when CE is set. Skipped
+    // when the outer header is truncated (`outer_ecn_bits` → None).
+    if let Some(outer_ecn) = outer_ecn_bits(frame, meta)
+        && !apply_decap_ecn_combine(&mut synthetic[14..], inner_family, outer_ecn)
+    {
+        // Illegal RFC 6040 §4.2 combination — drop (counter bumped in
+        // apply_decap_ecn_combine).
+        return None;
+    }
 
     let flow = parse_session_flow_from_frame(
         &synthetic,

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -189,19 +189,23 @@ pub(in crate::afxdp) enum DecapEcn {
 /// | inner \ outer | Not-ECT(00) | ECT0(10) | ECT1(01) | CE(11) |
 /// |---------------|-------------|----------|----------|--------|
 /// | Not-ECT(00)   | Keep        | Keep     | Keep     | Drop   |
-/// | ECT(0)(10)    | Keep        | Keep     | SetCe*   | SetCe  |
+/// | ECT(0)(10)    | Keep        | Keep     | Keep*    | SetCe  |
 /// | ECT(1)(01)    | Keep        | Keep     | Keep     | SetCe  |
 /// | CE(11)        | Keep        | Keep     | Keep     | Keep   |
 ///
-/// The only state changes are: outer CE upgrades any ECN-capable,
-/// non-CE inner to CE (the loss-free congestion signal this whole
-/// feature exists for); and the §4.2 "MAY" case outer=ECT(1) over
-/// inner=ECT(0) is taken as the upgrade-to-ECT(1) variant (* — matches
-/// Linux's `__INET_ECN_decapsulate`). The illegal outer=CE / inner=
-/// Not-ECT cell is a Drop. Every other cell keeps the inner verbatim
-/// (so a Not-ECT or already-CE inner is never touched, and the inner
-/// DSCP — which is authoritative at decap — is never copied from the
-/// outer).
+/// The only state change is: outer CE upgrades any ECN-capable, non-CE
+/// inner to CE (the loss-free congestion signal this whole feature
+/// exists for). The illegal outer=CE / inner=Not-ECT cell is a Drop.
+/// Every other cell keeps the inner verbatim (so a Not-ECT or already-CE
+/// inner is never touched, and the inner DSCP — which is authoritative
+/// at decap — is never copied from the outer).
+///
+/// (* the §4.2 "MAY" cell — outer=ECT(1) over inner=ECT(0) — leaves the
+/// receiver free to either keep the inner ECT(0) or upgrade it to
+/// ECT(1); neither carries a congestion mark. We take the simpler
+/// conformant choice and Keep the inner ECT(0). Linux's
+/// `__INET_ECN_decapsulate` upgrades to ECT(1) instead; both are RFC
+/// 6040 conformant.)
 ///
 /// `inner_ecn` and `outer_ecn` are the 2-bit ECN values (low 2 bits).
 #[inline]
@@ -220,13 +224,14 @@ pub(in crate::afxdp) fn decap_ecn_combine(inner_ecn: u8, outer_ecn: u8) -> Decap
         (CE, _) => DecapEcn::Keep,
         // ECN-capable, non-CE inner: outer CE upgrades it to CE.
         (_, CE) => DecapEcn::SetCe,
-        // §4.2 MAY: outer ECT(1) over inner ECT(0) → ECT(1) (upgrade
-        // variant). Implemented as SetCe? No — ECT(1) is not CE; this is
-        // an ECT-codepoint change, NOT a congestion mark. Handled by the
-        // dedicated SetEct1 path below would over-complicate the type;
-        // since ECT(1)→ECT(0) carries no congestion semantics and RFC
-        // 6040 leaves it a MAY, take the simpler compliant choice: Keep
-        // the inner ECT(0). (Linux upgrades; both are conformant.)
+        // §4.2 MAY: outer=ECT(1) over inner=ECT(0). RFC 6040 leaves this
+        // cell a MAY — the receiver may keep the inner ECT(0) or upgrade
+        // it to ECT(1); neither is a congestion mark. We take the simpler
+        // conformant choice and Keep the inner ECT(0). (Linux's
+        // `__INET_ECN_decapsulate` upgrades to ECT(1); both are
+        // conformant. A codepoint upgrade would need a distinct SetEct1
+        // outcome variant, which carries no congestion semantics and is
+        // not worth the type complexity.)
         (ECT_0, ECT_1) => DecapEcn::Keep,
         // All remaining non-CE outer values leave an ECN-capable inner
         // unchanged.

--- a/userspace-dp/src/afxdp/tunnel_tests.rs
+++ b/userspace-dp/src/afxdp/tunnel_tests.rs
@@ -452,8 +452,10 @@ fn rfc6040_combine_masks_high_bits() {
     );
 }
 
-/// Validate an IPv4 header checksum: the one's-complement sum over the
-/// 20-byte header (including the checksum field) must be 0xFFFF.
+/// Validate an IPv4 header checksum. The folded one's-complement sum
+/// over the full header (including the checksum field) is 0xFFFF for a
+/// valid header; `checksum16` returns the one's-complement of that
+/// folded sum, so a valid header verifies as 0.
 fn ipv4_header_checksum_ok(packet: &[u8]) -> bool {
     let ihl = usize::from(packet[0] & 0x0f) * 4;
     crate::afxdp::frame::checksum16(&packet[..ihl]) == 0

--- a/userspace-dp/src/afxdp/tunnel_tests.rs
+++ b/userspace-dp/src/afxdp/tunnel_tests.rs
@@ -379,6 +379,205 @@ fn inner_tos_byte_reads_ipv4_and_ipv6() {
     );
 }
 
+// --- #2315 RFC 6040 §4.2 decap-side ECN combine -----------------------
+
+use super::super::gre::{
+    apply_decap_ecn_combine, decap_ecn_combine, DecapEcn, GRE_DECAP_ECN_ILLEGAL_DROPS,
+};
+
+// 2-bit ECN codepoints (low 2 bits of the DiffServ octet).
+const NOT_ECT: u8 = 0b00;
+const ECT_1: u8 = 0b01;
+const ECT_0: u8 = 0b10;
+const CE: u8 = 0b11;
+
+#[test]
+fn rfc6040_combine_table_is_exact() {
+    // The full 4×4 RFC 6040 §4.2 decapsulation table. Rows = arriving
+    // inner ECN; columns = arriving outer ECN. Every cell is asserted
+    // so a future edit that flips one entry fails here.
+    use DecapEcn::*;
+    let table: [[(u8, DecapEcn); 4]; 4] = [
+        // inner Not-ECT: outer CE is the illegal combo (Drop); else Keep.
+        [
+            (NOT_ECT, Keep),
+            (ECT_0, Keep),
+            (ECT_1, Keep),
+            (CE, Drop),
+        ],
+        // inner ECT(0): outer CE → SetCe; outer ECT(1) → Keep (MAY,
+        // compliant); else Keep.
+        [
+            (NOT_ECT, Keep),
+            (ECT_0, Keep),
+            (ECT_1, Keep),
+            (CE, SetCe),
+        ],
+        // inner ECT(1): outer CE → SetCe; else Keep.
+        [
+            (NOT_ECT, Keep),
+            (ECT_0, Keep),
+            (ECT_1, Keep),
+            (CE, SetCe),
+        ],
+        // inner CE: already the strongest signal — always Keep.
+        [(NOT_ECT, Keep), (ECT_0, Keep), (ECT_1, Keep), (CE, Keep)],
+    ];
+    let inner_codes = [NOT_ECT, ECT_0, ECT_1, CE];
+    for (row, inner) in inner_codes.iter().enumerate() {
+        for (outer, expect) in table[row].iter() {
+            assert_eq!(
+                decap_ecn_combine(*inner, *outer),
+                *expect,
+                "RFC 6040 §4.2 cell inner={inner:#04b} outer={outer:#04b} \
+                 must be {expect:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn rfc6040_combine_masks_high_bits() {
+    // High DSCP bits in the byte must not leak into the ECN decision —
+    // only the low 2 bits matter.
+    assert_eq!(
+        decap_ecn_combine(0xFC | ECT_0, 0xFC | CE),
+        DecapEcn::SetCe,
+        "DSCP bits must be masked off before the combine"
+    );
+    assert_eq!(
+        decap_ecn_combine(0xFC | NOT_ECT, 0xFC | CE),
+        DecapEcn::Drop,
+        "DSCP bits must not turn the illegal combo into a keep"
+    );
+}
+
+/// Validate an IPv4 header checksum: the one's-complement sum over the
+/// 20-byte header (including the checksum field) must be 0xFFFF.
+fn ipv4_header_checksum_ok(packet: &[u8]) -> bool {
+    let ihl = usize::from(packet[0] & 0x0f) * 4;
+    crate::afxdp::frame::checksum16(&packet[..ihl]) == 0
+}
+
+#[test]
+fn apply_decap_combine_sets_ipv4_ce_and_recomputes_checksum() {
+    // Inner IPv4, ECT(0), valid checksum. Outer CE → inner must become
+    // CE and the IPv4 header checksum must stay valid after the TOS
+    // byte changed.
+    let before = GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed);
+    let mut inner = inner_ipv4_with_tos((0u8 << 2) | ECT_0); // DSCP 0, ECT(0)
+    // Seed a correct checksum for the starting header.
+    inner[10] = 0;
+    inner[11] = 0;
+    let cs = crate::afxdp::frame::checksum16(&inner[..20]);
+    inner[10..12].copy_from_slice(&cs.to_be_bytes());
+    assert!(ipv4_header_checksum_ok(&inner), "fixture must start valid");
+
+    let forward = apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, CE);
+    assert!(forward, "ECT inner + outer CE forwards (after CE upgrade)");
+    assert_eq!(inner[1] & 0x03, CE, "inner ECN must be upgraded to CE");
+    assert_eq!(inner[1] >> 2, 0, "inner DSCP must be untouched (was 0)");
+    assert!(
+        ipv4_header_checksum_ok(&inner),
+        "IPv4 header checksum must be recomputed after the TOS change"
+    );
+    assert_eq!(
+        GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed),
+        before,
+        "a legal upgrade must not bump the illegal-drop counter"
+    );
+}
+
+#[test]
+fn apply_decap_combine_preserves_dscp_on_ce_upgrade() {
+    // EF (DSCP 46) + ECT(1), outer CE → DSCP stays 46, ECN becomes CE.
+    let mut inner = inner_ipv4_with_tos((46u8 << 2) | ECT_1);
+    inner[10] = 0;
+    inner[11] = 0;
+    let cs = crate::afxdp::frame::checksum16(&inner[..20]);
+    inner[10..12].copy_from_slice(&cs.to_be_bytes());
+
+    assert!(apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, CE));
+    assert_eq!(inner[1] >> 2, 46, "DSCP (EF) must survive the CE upgrade");
+    assert_eq!(inner[1] & 0x03, CE);
+    assert!(ipv4_header_checksum_ok(&inner));
+}
+
+#[test]
+fn apply_decap_combine_drops_illegal_ipv4_combo_and_counts() {
+    // Inner Not-ECT + outer CE → drop + counter bump.
+    let before = GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed);
+    let mut inner = inner_ipv4_with_tos((34u8 << 2) | NOT_ECT); // AF41, Not-ECT
+    let forward = apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, CE);
+    assert!(!forward, "outer CE over a Not-ECT inner must DROP (§4.2)");
+    assert_eq!(
+        GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed),
+        before + 1,
+        "the illegal-combo drop must bump the counter"
+    );
+}
+
+#[test]
+fn apply_decap_combine_keeps_inner_when_outer_not_congested() {
+    // Outer Not-ECT must never touch the inner (no checksum change, no
+    // ECN change), even for an ECN-capable inner.
+    let mut inner = inner_ipv4_with_tos((10u8 << 2) | ECT_0);
+    inner[10] = 0;
+    inner[11] = 0;
+    let cs = crate::afxdp::frame::checksum16(&inner[..20]);
+    inner[10..12].copy_from_slice(&cs.to_be_bytes());
+    let snapshot = inner.clone();
+
+    assert!(apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, NOT_ECT));
+    assert_eq!(
+        inner, snapshot,
+        "outer Not-ECT must leave the inner byte-for-byte unchanged"
+    );
+}
+
+#[test]
+fn apply_decap_combine_sets_ipv6_ce_without_checksum() {
+    // Inner IPv6 with DSCP 0 + ECT(0). The Traffic Class spans the low
+    // nibble of octet 0 and the high nibble of octet 1; ECN is the low 2
+    // bits of TC = bits 4-5 of octet 1. Start: version 6 + TC high
+    // nibble 0 (octet0 = 0x60); ECN(ECT0) in octet1 high nibble
+    // (octet1 = ECT_0 << 4 = 0x20).
+    let mut v6 = vec![0u8; 40];
+    v6[0] = 0x60; // version 6, TC high nibble = 0 (DSCP top bits 0)
+    v6[1] = ECT_0 << 4; // ECN = ECT(0) in the high nibble of octet 1
+    let snapshot_octet0 = v6[0];
+
+    assert!(apply_decap_ecn_combine(&mut v6, libc::AF_INET6 as u8, CE));
+    // ECN = (octet1 >> 4) & 0x03 must be CE.
+    assert_eq!((v6[1] >> 4) & 0x03, CE, "inner IPv6 ECN must become CE");
+    assert_eq!(
+        v6[0], snapshot_octet0,
+        "octet 0 (version + DSCP high bits) untouched"
+    );
+}
+
+#[test]
+fn apply_decap_combine_drops_illegal_ipv6_combo_and_counts() {
+    let before = GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed);
+    let mut v6 = vec![0u8; 40];
+    v6[0] = 0x60;
+    v6[1] = (NOT_ECT) << 4; // inner Not-ECT
+    assert!(!apply_decap_ecn_combine(&mut v6, libc::AF_INET6 as u8, CE));
+    assert_eq!(
+        GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed),
+        before + 1
+    );
+}
+
+#[test]
+fn apply_decap_combine_short_packet_forwards_unchanged() {
+    // Too short to hold the TOS byte: forward, never panic, no counter.
+    let before = GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed);
+    let mut tiny = vec![0x45u8]; // 1 byte
+    assert!(apply_decap_ecn_combine(&mut tiny, libc::AF_INET as u8, CE));
+    assert_eq!(GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed), before);
+}
+
 // --- #2299 WG SYN MSS clamp uses the WG-overhead formula --------------
 
 #[test]

--- a/userspace-dp/src/afxdp/wg/dscp.rs
+++ b/userspace-dp/src/afxdp/wg/dscp.rs
@@ -10,10 +10,19 @@
 //!
 //! NOTE (#2303): the production WG/GRE encap path does NOT use this
 //! helper for outer-header DSCP/ECN. It copies the FULL inner TOS byte
-//! (DSCP + ECN) via `crate::afxdp::gre::inner_tos_byte`, so ECN
-//! propagates per RFC 6040 normal-mode ingress. This helper remains for
-//! the DSCP-only case (a config-set DSCP value with no inner-packet ECN
-//! to carry).
+//! (DSCP + ECN) via `crate::afxdp::gre::inner_tos_byte`, so the inner
+//! ECN is COPIED to the outer per RFC 6040 normal-mode ingress. This
+//! helper remains for the DSCP-only case (a config-set DSCP value with
+//! no inner-packet ECN to carry).
+//!
+//! NOTE (#2315): the complementary DECAP-side RFC 6040 §4.2 ECN
+//! *combine* (outer ECN → inner ECN — the half that reflects a CE mark
+//! back to the inner endpoints) is implemented for the GRE decap path
+//! only (`crate::afxdp::gre::apply_decap_ecn_combine`). The WG decap
+//! path reads transport records from a plain `UdpSocket::recv_from`, so
+//! the kernel strips the outer IP header (and its ECN) before userspace
+//! sees the datagram; the WG decap combine is a tracked follow-up
+//! (#2317) gated on `IP_RECVTOS`/`IPV6_RECVTCLASS` + `recvmsg`.
 
 /// Build the outer IPv4 TOS / IPv6 Traffic Class byte from a
 /// 6-bit DSCP value. ECN bits are cleared (use

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -233,6 +233,17 @@ pub(crate) struct ProcessStatus {
     /// Additive / defaulted for backward compatibility.
     #[serde(rename = "worker_command_queue_poison_recoveries", default)]
     pub worker_command_queue_poison_recoveries: u64,
+    /// #2315: GRE-decap frames dropped by the RFC 6040 §4.2 decap-side
+    /// ECN combine because the outer header carried a CE mark over an
+    /// inner packet that was Not-ECT (the illegal combination — a
+    /// congested router CE-marked a packet whose endpoints never
+    /// negotiated ECN). RFC 6040 mandates a drop here rather than
+    /// silently clearing the bogus CE. Surfaced as the Prometheus
+    /// counter `xpf_userspace_gre_decap_ecn_illegal_drops_total`;
+    /// nonzero flags a misbehaving tunnel ingress on a congested path.
+    /// Additive / defaulted for backward compatibility.
+    #[serde(rename = "gre_decap_ecn_illegal_drops_total", default)]
+    pub gre_decap_ecn_illegal_drops_total: u64,
     /// #1782 cold-start capture instrumentation. Debug dump of every key
     /// present in the userspace `dynamic_neighbors` mirror, rendered as
     /// `"ifindex ip"` strings. The capture harness greps this at the

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -162,6 +162,35 @@ fn process_status_worker_command_queue_poison_recoveries_roundtrip() {
     assert_eq!(legacy.worker_command_queue_poison_recoveries, 0);
 }
 
+// #2315: round-trip + backward-compat pin for the GRE-decap RFC 6040
+// §4.2 illegal-combination drop counter. The wire key feeds
+// pkg/dataplane/userspace/protocol.go and the Prometheus counter
+// `xpf_userspace_gre_decap_ecn_illegal_drops_total`.
+#[test]
+fn process_status_gre_decap_ecn_illegal_drops_roundtrip() {
+    let status = ProcessStatus {
+        gre_decap_ecn_illegal_drops_total: 5,
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize ProcessStatus to Value");
+    assert_eq!(value["gre_decap_ecn_illegal_drops_total"], 5);
+    let back: ProcessStatus = serde_json::from_value(value).expect("deserialize ProcessStatus");
+    assert_eq!(back.gre_decap_ecn_illegal_drops_total, 5);
+
+    // Pre-#2315 payload (key absent) must decode with a zero default.
+    let mut legacy_value =
+        serde_json::to_value(ProcessStatus::default()).expect("serialize default ProcessStatus");
+    legacy_value
+        .as_object_mut()
+        .expect("ProcessStatus serializes to an object")
+        .remove("gre_decap_ecn_illegal_drops_total")
+        .expect("new key present before strip");
+    let legacy: ProcessStatus =
+        serde_json::from_value(legacy_value).expect("pre-#2315 payload decodes");
+    assert_eq!(legacy.gre_decap_ecn_illegal_drops_total, 0);
+}
+
 // #1760 W3': round-trip + backward-compat pin for the shared-map NAT
 // reverse-key displacement counter. The wire key feeds
 // pkg/dataplane/userspace/protocol.go and the Prometheus counter

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -82,6 +82,11 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     // panic poisoned a command queue and it was recovered.
     state.status.worker_command_queue_poison_recoveries =
         state.afxdp.worker_command_queue_poison_recoveries_total();
+    // #2315: GRE-decap RFC 6040 §4.2 illegal-combination drops (outer CE
+    // over a Not-ECT inner). Nonzero = a misbehaving tunnel ingress
+    // ECT-marked the outer for un-ECN inner traffic on a congested path.
+    state.status.gre_decap_ecn_illegal_drops_total =
+        state.afxdp.gre_decap_ecn_illegal_drops_total();
     // The per-key dynamic_neighbors dump is a high-cardinality
     // (ifindex,ip)-labelled debug surface used only by the #1782 cold-start
     // capture. Gate it behind XPF_DEBUG_NEIGHBOR_KEYS so it is OFF by default:

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -115,6 +115,7 @@ pub(crate) fn run() -> Result<(), String> {
             dnat_publish_errors_total: 0,
             nat_reverse_key_shared_displacements_total: 0,
             worker_command_queue_poison_recoveries: 0,
+            gre_decap_ecn_illegal_drops_total: 0,
             dynamic_neighbor_keys: Vec::new(),
             neighbor_resolver_queue_depth: 0,
             neighbor_resolver_enqueue_drops_total: 0,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -751,6 +751,7 @@
     "flow_worker_map": [],
     "flow_worker_map_truncated": false,
     "forwarding_armed": false,
+    "gre_decap_ecn_illegal_drops_total": 0,
     "ha_groups": [],
     "helper_mode": "",
     "inject_packet_tuple_protocol_version": 0,


### PR DESCRIPTION
Fixes #2315. Follow-up filed as #2317 (WG decap combine).

## Summary

- **#2303 over-claim corrected.** PR #2307 (#2303) added the ENCAP-side
  inner→outer DSCP/ECN COPY (RFC 2983 + RFC 6040 normal-mode ingress),
  but the doc/comment claimed the inner ECN was "reflected at decap"
  while no DECAP-side RFC 6040 ECN combine existed.
- **GRE decap combine implemented (path chosen: implement).** GRE decap
  (`try_native_gre_decap_from_frame`) operates on the full received
  frame, so the outer IP header — and its ECN — is present at
  `meta.l3_offset`. New `gre.rs` helpers: `outer_ecn_bits` (read the
  2-bit outer ECN), `decap_ecn_combine` (the pure RFC 6040 §4.2 table →
  `Keep`/`SetCe`/`Drop`), `apply_decap_ecn_combine` (in-place inner ECN
  mutate + IPv4 inner-header-checksum recompute). Wired into the decap
  path: an outer CE upgrades an ECN-capable inner to CE; the illegal
  outer-CE / inner-Not-ECT combo is **dropped** per §4.2.
- **WG decap deferred (path: doc-correct + follow-up #2317).** The WG
  control thread reads transport records from a plain
  `UdpSocket::recv_from`, so the kernel strips the outer IP/ECN before
  userspace. Recovering it needs `IP_RECVTOS`/`IPV6_RECVTCLASS` +
  `recvmsg` — a recv-loop subsystem change, tracked as #2317. The doc
  and `wg/dscp.rs` comment are scoped to encap-copy-only.
- **Observability.** Illegal-combo drops bump
  `GRE_DECAP_ECN_ILLEGAL_DROPS`, surfaced as the Prometheus counter
  `xpf_userspace_gre_decap_ecn_illegal_drops_total`.

## RFC 6040 §4.2 combine

The only state changes: outer CE upgrades a non-CE ECN-capable inner to
CE; the illegal outer-CE / inner-Not-ECT cell drops. Every other cell
keeps the inner verbatim — the inner DSCP is authoritative at decap and
is never copied from the outer.

## Hot-path shape

A couple of bit ops on the inner TOS byte plus (only on a CE upgrade of
an IPv4 inner) one header-checksum recompute; no per-packet allocation.
The outer-ECN read is one branch on the already-decapsulating GRE path —
not on the plain-forward fast path. IPv6 inners need no checksum work
(no IP header checksum; the TC is outside the L4 pseudo-header).

## Test plan

- [x] RFC 6040 §4.2 full 4x4 table (`rfc6040_combine_table_is_exact`,
      high-bit masking).
- [x] `apply_decap_ecn_combine`: CE upgrade + IPv4 checksum validity,
      DSCP preservation, illegal-combo drop+count (v4 and v6), IPv6
      no-checksum, short-packet fallback, no-op when outer not congested.
- [x] End-to-end through `try_native_gre_decap_from_frame`:
      CE-propagation (inner CE set + valid inner checksum), illegal-drop
      (None), and no-op when outer Not-ECT; **fail-on-revert** asserts
      the inner CE bit is set (the pre-#2315 copy-only path could never
      produce this).
- [x] `ProcessStatus` wire round-trip + backward-compat default +
      `protocol_wire_v1.json` regen (single additive field).
- [x] Go: metric emit + value assertion + descriptor-coverage list.
- [x] `cargo build --release` clean; `cargo test` green (one pre-existing
      `worker_queue` concurrency flake, unrelated — my diff does not touch
      that subsystem); `go build ./...` + `go test ./pkg/api/... ./pkg/dataplane/...` green.

## Deferred

- **#2317** — WireGuard decap-side RFC 6040 §4.2 ECN combine, blocked on
  `IP_RECVTOS`/`recvmsg` recv-loop changes.

## Refs

- #2315 (this), #2303 / PR #2307 (encap copy), #2317 (WG follow-up),
  RFC 6040 §4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)