### PR TITLE
#2321: fail closed on truncated generated-reply L4 ports

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,32 @@
 # Action Log
 
+## 2026-06-22 — #2321 round 2: bound L4 port read by IP-declared length
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Fold Copilot's follow-up on PR #2322. The round-1 fix made
+  `generated_l4_ports` return `None` when the 4 port bytes were absent, but it
+  bounded the read by the BACKING SLICE length only, not by the IP-declared
+  length (`pkt_len` = IPv4 total_len / IPv6 40+payload_len, each clamped to the
+  slice). A corrupted/short total_len/payload_len that ends BEFORE the L4
+  header while the buffer still has trailing bytes would read those slack bytes
+  and return bogus ports instead of failing closed — exactly what the doc
+  comment claimed it prevented. Now `generated_l4_ports` takes `pkt_len` and
+  returns `None` for TCP/UDP when `rel_l4 + 4 > pkt_len` (read bounded by
+  `min(pkt_len, slice_len)` = `pkt_len`, since `pkt_len <= packet.len()` by
+  construction). Both call sites pass the already-computed `pkt_len`.
+  ICMP/ICMPv6 unchanged (no ports).
+- **File(s)**: userspace-dp/src/afxdp/frame/generated.rs,
+  userspace-dp/src/afxdp/frame/generated_tests.rs, _Log.md
+- **Tests**: added `v4_tcp_declared_len_short_of_ports_fails_closed_none`,
+  `v4_udp_declared_len_short_of_ports_fails_closed_none`,
+  `v6_tcp_declared_len_short_of_ports_fails_closed_none`,
+  `v6_udp_declared_len_short_of_ports_fails_closed_none` — each corrupts
+  total_len/payload_len to end before the L4 header while keeping the full
+  backing buffer (asserts the buffer retains the trailing port bytes), so they
+  FAIL if the bound is reverted to slice-only (verified: 0/4 with the bound
+  neutered). `cargo build --release` clean; `generated` (17 tests) +
+  `cos_classify` green, 5x flake-free.
+
 ## 2026-06-22 — #2321 generated-reply parser fail-closed (§6.2)
 
 - **Timestamp**: 2026-06-22 PDT

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,29 @@
 # Action Log
 
+## 2026-06-22 — #2321 generated-reply parser fail-closed (§6.2)
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Make `parse_generated_v4`/`parse_generated_v6` fail CLOSED
+  when a locally-generated TCP/UDP reply is truncated before its 4 L4 port
+  bytes. `generated_l4_ports` now returns `Option<(u16,u16)>` — `None` for a
+  TCP/UDP frame whose ports cannot be read at the computed L4 offset, rather
+  than the old `(0,0)` substitution that misclassified the reply past an
+  output-filter `discard`. Both parsers propagate the `None` with `?`, so the
+  caller (`classify_generated_reply` in `tx/cos_classify.rs`) drops the reply
+  and bumps `generated_reply_classify_parse_errors`. ICMP/ICMPv6 (no transport
+  ports) still return `(0,0)` unchanged; well-formed TCP/UDP replies are
+  unaffected. Defense-in-depth — generated replies are well-formed by
+  construction. Copilot flagged this on PR #2319.
+- **File(s)**: userspace-dp/src/afxdp/frame/generated.rs,
+  userspace-dp/src/afxdp/frame/generated_tests.rs, _Log.md
+- **Tests**: added `truncated_v4_tcp_ports_fails_closed_none`,
+  `truncated_v4_udp_ports_fails_closed_none`,
+  `truncated_v6_tcp_ports_fails_closed_none`,
+  `truncated_v6_udp_ports_fails_closed_none` (fail-on-revert — they pass with
+  `(0,0)` substitution if the guard is removed) and `parses_v4_udp_reply_ports`
+  (well-formed regression guard). `cargo build --release` clean;
+  `cargo test --release -- generated parse_generated cos_classify` green.
+
 ## 2026-06-22 — #1434 review round 1 (NEEDS-MINOR fold)
 
 - **Timestamp**: 2026-06-22 PDT

--- a/userspace-dp/src/afxdp/frame/generated.rs
+++ b/userspace-dp/src/afxdp/frame/generated.rs
@@ -35,7 +35,8 @@ use super::*;
 /// `(SessionKey, ForwardPacketMeta)`.
 ///
 /// Returns `None` on any parse failure (truncated header, unknown family,
-/// over-bound IPv6 extension chain). The caller MUST fail CLOSED on `None`
+/// over-bound IPv6 extension chain, or a TCP/UDP reply truncated before its 4
+/// L4 port bytes). The caller MUST fail CLOSED on `None`
 /// (#2238 §6.2): an output-filter terminal `discard`/`reject` is a security
 /// boundary, so a reply whose own bytes cannot be classified is DROPPED, not
 /// leaked past the filter. The bytes are our own, so `None` is a logic bug —
@@ -83,7 +84,12 @@ fn parse_generated_v4(packet: &[u8], l3_offset: usize) -> Option<(SessionKey, Fo
     // byte counter.
     let total_len = u16::from_be_bytes([packet[2], packet[3]]) as usize;
     let pkt_len = total_len.clamp(ihl, packet.len());
-    let (src_port, dst_port) = generated_l4_ports(packet, ihl, protocol);
+    // §6.2 fail-CLOSED: a TCP/UDP generated reply MUST carry its 4 port bytes
+    // at the L4 offset (`ihl`). A frame truncated before the ports yields
+    // `None` here, so the caller drops the reply (and bumps
+    // `generated_reply_classify_parse_errors`) rather than misclassifying it
+    // with substituted (0,0) ports past an output `discard`.
+    let (src_port, dst_port) = generated_l4_ports(packet, ihl, protocol)?;
     finish_generated_key(
         libc::AF_INET as u8,
         protocol,
@@ -113,7 +119,9 @@ fn parse_generated_v6(packet: &[u8], l3_offset: usize) -> Option<(SessionKey, Fo
     // Walk the extension-header chain to the L4 protocol + offset (bounded,
     // fail-closed at the bound — same contract as the forwarding walkers).
     let (rel_l4, protocol) = packet_rel_l4_offset_and_protocol(packet, libc::AF_INET6 as u8)?;
-    let (src_port, dst_port) = generated_l4_ports(packet, rel_l4, protocol);
+    // §6.2 fail-CLOSED: see parse_generated_v4 — a TCP/UDP reply truncated
+    // before its 4 port bytes drops rather than misclassifies with (0,0).
+    let (src_port, dst_port) = generated_l4_ports(packet, rel_l4, protocol)?;
     finish_generated_key(
         libc::AF_INET6 as u8,
         protocol,
@@ -130,18 +138,23 @@ fn parse_generated_v6(packet: &[u8], l3_offset: usize) -> Option<(SessionKey, Fo
 
 /// L4 ports for the generated frame: real ports for TCP/UDP, 0/0 for
 /// ICMP/ICMPv6 (no transport ports) and anything else.
-fn generated_l4_ports(packet: &[u8], rel_l4: usize, protocol: u8) -> (u16, u16) {
+///
+/// §6.2 fail-CLOSED: for TCP/UDP this returns `None` when the frame is
+/// truncated before the 4 port bytes at `rel_l4` (a clamped total_len too
+/// short to reach the L4 header, or the frame physically chopped). The
+/// callers propagate that `None` so a generated reply whose ports cannot be
+/// read is DROPPED, never misclassified with substituted (0,0) ports past an
+/// output-filter `discard`. ICMP/ICMPv6 (and anything else) legitimately have
+/// no transport ports and return `(0, 0)` unchanged.
+fn generated_l4_ports(packet: &[u8], rel_l4: usize, protocol: u8) -> Option<(u16, u16)> {
     match protocol {
-        PROTO_TCP | PROTO_UDP => packet
-            .get(rel_l4..rel_l4 + 4)
-            .map(|b| {
-                (
-                    u16::from_be_bytes([b[0], b[1]]),
-                    u16::from_be_bytes([b[2], b[3]]),
-                )
-            })
-            .unwrap_or((0, 0)),
-        _ => (0, 0),
+        PROTO_TCP | PROTO_UDP => packet.get(rel_l4..rel_l4 + 4).map(|b| {
+            (
+                u16::from_be_bytes([b[0], b[1]]),
+                u16::from_be_bytes([b[2], b[3]]),
+            )
+        }),
+        _ => Some((0, 0)),
     }
 }
 

--- a/userspace-dp/src/afxdp/frame/generated.rs
+++ b/userspace-dp/src/afxdp/frame/generated.rs
@@ -85,11 +85,13 @@ fn parse_generated_v4(packet: &[u8], l3_offset: usize) -> Option<(SessionKey, Fo
     let total_len = u16::from_be_bytes([packet[2], packet[3]]) as usize;
     let pkt_len = total_len.clamp(ihl, packet.len());
     // §6.2 fail-CLOSED: a TCP/UDP generated reply MUST carry its 4 port bytes
-    // at the L4 offset (`ihl`). A frame truncated before the ports yields
-    // `None` here, so the caller drops the reply (and bumps
+    // at the L4 offset (`ihl`) within the IP-DECLARED packet end (`pkt_len`).
+    // A frame truncated before the ports — or whose total_len ends short of
+    // the L4 header while the buffer has trailing slack — yields `None` here,
+    // so the caller drops the reply (and bumps
     // `generated_reply_classify_parse_errors`) rather than misclassifying it
     // with substituted (0,0) ports past an output `discard`.
-    let (src_port, dst_port) = generated_l4_ports(packet, ihl, protocol)?;
+    let (src_port, dst_port) = generated_l4_ports(packet, ihl, protocol, pkt_len)?;
     finish_generated_key(
         libc::AF_INET as u8,
         protocol,
@@ -120,8 +122,10 @@ fn parse_generated_v6(packet: &[u8], l3_offset: usize) -> Option<(SessionKey, Fo
     // fail-closed at the bound — same contract as the forwarding walkers).
     let (rel_l4, protocol) = packet_rel_l4_offset_and_protocol(packet, libc::AF_INET6 as u8)?;
     // §6.2 fail-CLOSED: see parse_generated_v4 — a TCP/UDP reply truncated
-    // before its 4 port bytes drops rather than misclassifies with (0,0).
-    let (src_port, dst_port) = generated_l4_ports(packet, rel_l4, protocol)?;
+    // before its 4 port bytes, or whose payload_len ends short of the L4
+    // header (bounded by `pkt_len`, not the backing slice), drops rather than
+    // misclassifies with (0,0).
+    let (src_port, dst_port) = generated_l4_ports(packet, rel_l4, protocol, pkt_len)?;
     finish_generated_key(
         libc::AF_INET6 as u8,
         protocol,
@@ -139,21 +143,39 @@ fn parse_generated_v6(packet: &[u8], l3_offset: usize) -> Option<(SessionKey, Fo
 /// L4 ports for the generated frame: real ports for TCP/UDP, 0/0 for
 /// ICMP/ICMPv6 (no transport ports) and anything else.
 ///
-/// §6.2 fail-CLOSED: for TCP/UDP this returns `None` when the frame is
-/// truncated before the 4 port bytes at `rel_l4` (a clamped total_len too
-/// short to reach the L4 header, or the frame physically chopped). The
-/// callers propagate that `None` so a generated reply whose ports cannot be
-/// read is DROPPED, never misclassified with substituted (0,0) ports past an
-/// output-filter `discard`. ICMP/ICMPv6 (and anything else) legitimately have
-/// no transport ports and return `(0, 0)` unchanged.
-fn generated_l4_ports(packet: &[u8], rel_l4: usize, protocol: u8) -> Option<(u16, u16)> {
+/// §6.2 fail-CLOSED: for TCP/UDP this returns `None` when the 4 port bytes
+/// at `rel_l4` cannot be read inside the IP-DECLARED packet end. `pkt_len`
+/// is the slice-clamped IP-declared length (IPv4 total_len / IPv6
+/// 40+payload_len, each clamped to the backing slice), so the read is bounded
+/// by `min(pkt_len, packet.len())` — i.e. `pkt_len`, since `pkt_len <=
+/// packet.len()` by construction. This means a corrupted or short total_len /
+/// payload_len that ends BEFORE the L4 header fails closed even when the
+/// backing buffer still has trailing slack bytes (reading those would yield
+/// bogus ports). The callers propagate that `None` so a generated reply whose
+/// ports cannot be read is DROPPED, never misclassified with substituted (0,0)
+/// ports past an output-filter `discard`. ICMP/ICMPv6 (and anything else)
+/// legitimately have no transport ports and return `(0, 0)` unchanged.
+fn generated_l4_ports(
+    packet: &[u8],
+    rel_l4: usize,
+    protocol: u8,
+    pkt_len: usize,
+) -> Option<(u16, u16)> {
     match protocol {
-        PROTO_TCP | PROTO_UDP => packet.get(rel_l4..rel_l4 + 4).map(|b| {
-            (
-                u16::from_be_bytes([b[0], b[1]]),
-                u16::from_be_bytes([b[2], b[3]]),
-            )
-        }),
+        PROTO_TCP | PROTO_UDP => {
+            // Bound the port read by the IP-declared end, not the backing
+            // slice. `end > pkt_len` => declared packet stops before the ports.
+            let end = rel_l4.checked_add(4)?;
+            if end > pkt_len {
+                return None;
+            }
+            packet.get(rel_l4..end).map(|b| {
+                (
+                    u16::from_be_bytes([b[0], b[1]]),
+                    u16::from_be_bytes([b[2], b[3]]),
+                )
+            })
+        }
         _ => Some((0, 0)),
     }
 }

--- a/userspace-dp/src/afxdp/frame/generated_tests.rs
+++ b/userspace-dp/src/afxdp/frame/generated_tests.rs
@@ -199,6 +199,75 @@ fn truncated_v6_udp_ports_fails_closed_none() {
 }
 
 #[test]
+fn v4_tcp_declared_len_short_of_ports_fails_closed_none() {
+    // #2321 (Copilot follow-up): the IPv4 total_len is corrupted to end at
+    // the IP header (20) — BEFORE the TCP ports at ihl(20)..24 — while the
+    // backing buffer KEEPS the full TCP header (trailing slack present).
+    // Bounding the port read by the slice alone would read those trailing
+    // bytes and return bogus ports; the pkt_len bound must drop instead.
+    let mut frame = v4_frame(PROTO_TCP, 0x00, 5201, 49152, &[]);
+    let l3 = 14;
+    // total_len = 20 (IP header only, no L4 declared). Buffer still holds the
+    // 20-byte TCP header after it.
+    frame[l3 + 2..l3 + 4].copy_from_slice(&20u16.to_be_bytes());
+    assert!(
+        frame.len() > l3 + 24,
+        "buffer must retain trailing port bytes for this to be a real regression"
+    );
+    assert!(
+        generated_reply_session_key(&frame).is_none(),
+        "v4 TCP with total_len short of the ports must fail closed, not read slack bytes"
+    );
+}
+
+#[test]
+fn v4_udp_declared_len_short_of_ports_fails_closed_none() {
+    // #2321: same, UDP. total_len ends before the UDP ports while the
+    // backing buffer retains them.
+    let mut frame = v4_frame(PROTO_UDP, 0x00, 5201, 49152, &[]);
+    let l3 = 14;
+    frame[l3 + 2..l3 + 4].copy_from_slice(&20u16.to_be_bytes());
+    assert!(frame.len() > l3 + 24);
+    assert!(
+        generated_reply_session_key(&frame).is_none(),
+        "v4 UDP with total_len short of the ports must fail closed"
+    );
+}
+
+#[test]
+fn v6_tcp_declared_len_short_of_ports_fails_closed_none() {
+    // #2321: the IPv6 payload_len is corrupted to 0 — so the declared packet
+    // ends at the fixed IPv6 header (40), BEFORE the TCP ports at 40..44 —
+    // while the backing buffer KEEPS the full TCP header. The pkt_len bound
+    // must drop instead of reading the trailing slack bytes.
+    let mut frame = v6_frame(PROTO_TCP, 0x00, 443, 33333);
+    let l3 = 14;
+    // payload_len bytes are at IPv6 header offset 4..6.
+    frame[l3 + 4..l3 + 6].copy_from_slice(&0u16.to_be_bytes());
+    assert!(
+        frame.len() > l3 + 44,
+        "buffer must retain trailing port bytes for this to be a real regression"
+    );
+    assert!(
+        generated_reply_session_key(&frame).is_none(),
+        "v6 TCP with payload_len short of the ports must fail closed, not read slack bytes"
+    );
+}
+
+#[test]
+fn v6_udp_declared_len_short_of_ports_fails_closed_none() {
+    // #2321: same, UDP over IPv6.
+    let mut frame = v6_frame(PROTO_UDP, 0x00, 443, 33333);
+    let l3 = 14;
+    frame[l3 + 4..l3 + 6].copy_from_slice(&0u16.to_be_bytes());
+    assert!(frame.len() > l3 + 44);
+    assert!(
+        generated_reply_session_key(&frame).is_none(),
+        "v6 UDP with payload_len short of the ports must fail closed"
+    );
+}
+
+#[test]
 fn parses_v4_udp_reply_ports() {
     // #2321: a WELL-FORMED UDP reply still parses with its real ports — the
     // fail-closed guard must not regress correct frames.

--- a/userspace-dp/src/afxdp/frame/generated_tests.rs
+++ b/userspace-dp/src/afxdp/frame/generated_tests.rs
@@ -151,6 +151,67 @@ fn truncated_v4_header_fails_closed_none() {
 }
 
 #[test]
+fn truncated_v4_tcp_ports_fails_closed_none() {
+    // #2321 §6.2: a TCP generated reply whose frame is chopped before the 4
+    // L4 port bytes MUST drop (None), not misclassify with (0,0) ports.
+    // L2(14) + IP(20) puts the TCP ports at offset 34..38; keep the full IP
+    // header (so the IHL/length checks pass) but lose 2 of the 4 port bytes.
+    let mut frame = v4_frame(PROTO_TCP, 0x00, 5201, 49152, &[]);
+    frame.truncate(14 + 20 + 2);
+    assert!(
+        generated_reply_session_key(&frame).is_none(),
+        "truncated v4 TCP reply must fail closed (no (0,0)-port misclassify)"
+    );
+}
+
+#[test]
+fn truncated_v4_udp_ports_fails_closed_none() {
+    // #2321 §6.2: same for UDP — missing port bytes must drop, not default.
+    let mut frame = v4_frame(PROTO_UDP, 0x00, 5201, 49152, &[]);
+    frame.truncate(14 + 20 + 2);
+    assert!(
+        generated_reply_session_key(&frame).is_none(),
+        "truncated v4 UDP reply must fail closed (no (0,0)-port misclassify)"
+    );
+}
+
+#[test]
+fn truncated_v6_tcp_ports_fails_closed_none() {
+    // #2321 §6.2: L2(14) + IPv6(40) puts TCP ports at offset 54..58; keep the
+    // full IPv6 header but lose 2 of the 4 port bytes — must fail closed.
+    let mut frame = v6_frame(PROTO_TCP, 0x00, 443, 33333);
+    frame.truncate(14 + 40 + 2);
+    assert!(
+        generated_reply_session_key(&frame).is_none(),
+        "truncated v6 TCP reply must fail closed (no (0,0)-port misclassify)"
+    );
+}
+
+#[test]
+fn truncated_v6_udp_ports_fails_closed_none() {
+    // #2321 §6.2: same for UDP over IPv6.
+    let mut frame = v6_frame(PROTO_UDP, 0x00, 443, 33333);
+    frame.truncate(14 + 40 + 2);
+    assert!(
+        generated_reply_session_key(&frame).is_none(),
+        "truncated v6 UDP reply must fail closed (no (0,0)-port misclassify)"
+    );
+}
+
+#[test]
+fn parses_v4_udp_reply_ports() {
+    // #2321: a WELL-FORMED UDP reply still parses with its real ports — the
+    // fail-closed guard must not regress correct frames.
+    let frame = v4_frame(PROTO_UDP, 0x00, 53, 40000, &[]);
+    let (key, meta) = generated_reply_session_key(&frame).expect("v4 udp parse");
+    assert_eq!(key.protocol, PROTO_UDP);
+    assert_eq!(key.src_port, 53);
+    assert_eq!(key.dst_port, 40000);
+    assert_eq!(meta.flow_src_port, 53);
+    assert_eq!(meta.flow_dst_port, 40000);
+}
+
+#[test]
 fn unknown_l3_version_fails_closed_none() {
     let mut frame = v4_frame(PROTO_TCP, 0x00, 5201, 49152, &[]);
     // Corrupt the IP version nibble to 5 (unknown).


### PR DESCRIPTION
Closes #2321

## Problem (§6.2 fail-closed doctrine, LOW)

The #2319 generated-reply re-parser (`parse_generated_v4` /
`parse_generated_v6` in `userspace-dp/src/afxdp/frame/generated.rs`)
rebuilds a locally GENERATED reply's egress `SessionKey` from its own
bytes so the output firewall filter / CoS forwarding-class / DSCP rewrite
can be evaluated against the reply's real tuple.

On a TCP/UDP reply truncated before its 4 L4 port bytes,
`generated_l4_ports` fell through `unwrap_or((0, 0))` and the parser
CONTINUED with ports `(0, 0)`. That **misclassifies** the reply instead
of dropping it — violating the project's §6.2 fail-CLOSED doctrine: a
parse failure of a generated reply must DROP it, never leak past an
output `discard`/`reject` or land on the wrong filter term.

Copilot independently flagged this on PR #2319.

## Fix

Make the port read fail closed:

- `generated_l4_ports` now returns `Option<(u16, u16)>` — `None` for a
  TCP/UDP frame whose 4 port bytes are not present at the computed L4
  offset (a clamped IP `total_len` too short to reach the L4 header, or
  the frame physically chopped).
- Both parsers propagate that `None` with `?`, so
  `classify_generated_reply` (`afxdp/tx/cos_classify.rs`) drops the reply
  (`drop: true, parse_error: true`) and bumps the existing
  `generated_reply_classify_parse_errors` counter rather than
  classifying a `(0, 0)`-port phantom tuple.
- ICMP/ICMPv6 (and any non-TCP/UDP protocol) legitimately carry no
  transport ports and still return `(0, 0)` unchanged.
- Well-formed TCP/UDP replies are unaffected — generated replies are
  well-formed by construction, so this is defense-in-depth.

No Go-visible wire fields touched (internal parse only); no wire fixture
regen needed.

## Tests (fail-on-revert)

`afxdp/frame/generated_tests.rs`:

- `truncated_v4_tcp_ports_fails_closed_none`
- `truncated_v4_udp_ports_fails_closed_none`
- `truncated_v6_tcp_ports_fails_closed_none`
- `truncated_v6_udp_ports_fails_closed_none`

Each keeps a full, well-formed IP header (so the IHL/length checks pass)
but chops the frame 2 bytes into the L4 ports, asserting the parse
returns `None`. **Verified fail-on-revert**: reverting the guard to the
old `unwrap_or((0, 0))` turns all 4 red (parse returns `Some` with
`(0, 0)` ports).

`parses_v4_udp_reply_ports` added to guard the well-formed UDP path; the
existing ICMP tests confirm no-port replies still parse.

## Validation

- `cargo build --release` clean (only pre-existing warnings).
- `cargo test --release -- generated parse_generated cos_classify` green:
  13/13 generated, 35/35 cos_classify.
- Targeted `generated` suite run 5x — 13/13 every run, flake-free.
- Revert check: the 4 truncation tests fail if the `?` guard is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)