### PR TITLE
Suppress ICMP/ICMPv6 errors for multicast/broadcast triggers (#2314)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,33 @@
 # Action Log
 
+## 2026-06-22 — #2314 suppress ICMP/ICMPv6 errors for multicast/broadcast triggers
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a locally generated
+  ICMP/ICMPv6 error MUST NOT be originated when the triggering packet's
+  IP destination was multicast or broadcast (a multicast flood otherwise
+  amplifies into an ICMP-error backscatter storm). Added a shared cheap
+  predicate `dest_is_multicast_or_broadcast(addr_family, packet)` in
+  `frame/inspect.rs` (IPv4 224.0.0.0/4 + 255.255.255.255 via
+  `Ipv4Addr::is_multicast`/`is_broadcast`; IPv6 ff00::/8 via the leading
+  0xff byte; too-short slice fails closed). Gated the #2310/#2301 PTB
+  generation site by adding the predicate to `ptb_reply_suppressed`
+  (`icmp_ptb.rs`) — this was the real gap. Routed the reject /
+  Time Exceeded path's destination test in
+  `can_generate_icmp_error_reply` (`icmp.rs`) through the same predicate
+  (it already inline-suppressed multicast/broadcast; now DRY). No new
+  counter: a suppressed reply folds into the existing fail-closed
+  silent-drop path (the oversized/rejected original is still dropped).
+  Tests: 8 fail-on-revert unit tests (PTB + reject/time-exceeded) for
+  IPv4 multicast, IPv4 limited-broadcast, IPv6 multicast suppression plus
+  unicast-still-generated; verified 6 go red when the guards are reverted,
+  5x flake-free, `cargo build --release` clean. No Go/wire change.
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+  userspace-dp/src/afxdp/frame/mod.rs, userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/icmp_ptb.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs,
+  userspace-dp/src/afxdp/README.md
+
 ## 2026-06-22 — #1434 review round 1 (NEEDS-MINOR fold)
 
 - **Timestamp**: 2026-06-22 PDT

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,24 @@
 # Action Log
 
+## 2026-06-22 — #2314 review fold: dest predicate fails closed on unknown family
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Copilot review of PR #2323 — `dest_is_multicast_or_broadcast`
+  documented "fails closed" but its default (unknown `addr_family`) arm
+  returned `false` (fail OPEN). Flipped the default arm to `true` so an
+  unclassifiable destination family suppresses the ICMP error (the safer
+  posture — never emit backscatter for a packet whose family we did not
+  parse) and updated the doc comment to spell out the unknown-family
+  fail-closed behaviour. In practice the error generators never call this
+  for a non-IP family (their own family dispatch rejects first), so this
+  is contract-hardening, not a behaviour change on the live paths. Added
+  `dest_predicate_fails_closed_on_unknown_family` (fails if reverted to
+  `false`): addr_family 0 and AF_UNIX suppress, while the same unicast
+  bytes under AF_INET do NOT. `cargo build --release` clean; icmp/ptb/
+  reject/multicast/suppress tests green 5x.
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs
+
 ## 2026-06-22 — #2314 suppress ICMP/ICMPv6 errors for multicast/broadcast triggers
 
 - **Timestamp**: 2026-06-22 PDT

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -82,8 +82,16 @@ sync.
   `icmp.rs`'s reflected-error shape (L2 reflect + ingress-sourced outer
   IP + quoted inbound packet) but sets the MTU field; reuses the shared
   header/checksum helpers and the RFC error-suppression gate
-  (`reject_icmp_reply_suppressed`, `is_non_first_fragment`). Kept
-  separate from `icmp.rs` so the diff stays additive.
+  (`reject_icmp_reply_suppressed`, `is_non_first_fragment`,
+  `dest_is_multicast_or_broadcast`). Kept separate from `icmp.rs` so the
+  diff stays additive. #2314: the PTB gate (`ptb_reply_suppressed`) now
+  also drops PTBs triggered by a multicast/broadcast-destined datagram
+  (RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e)), sharing the
+  `dest_is_multicast_or_broadcast` predicate (`frame/inspect.rs`) with
+  `icmp.rs`'s `can_generate_icmp_error_reply` so the PTB, reject, and
+  Time Exceeded paths agree. No new counter: a suppressed PTB is folded
+  into the existing fail-closed silent-drop path (the oversized original
+  is still dropped via `mtu_signalled`).
 - `cos/` — Class-of-Service scheduler: token-bucket admission, MQFQ
   active-bucket selection, fair-share lease (#1229 Phase 6 v8). See
   `docs/per-5-tuple/state.md` for the architectural ceiling.

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -310,6 +310,44 @@ pub(in crate::afxdp) fn is_non_first_fragment(packet: &[u8], addr_family: u8) ->
     }
 }
 
+/// #2314: RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a router MUST NOT
+/// originate an ICMP/ICMPv6 *error* in reply to a datagram whose IP
+/// destination was a broadcast or multicast address. Reading the
+/// destination straight off the L3-relative packet slice keeps this
+/// cheap on the (cold-ish) error-generation arms: a single octet test
+/// for the common cases.
+///
+///   - IPv4: multicast 224.0.0.0/4 (first octet 224..=239) OR the
+///     limited broadcast 255.255.255.255. Subnet/directed broadcasts
+///     require per-interface mask knowledge that is not available at the
+///     generation site, so they are not detectable here — the limited
+///     broadcast and the multicast block are the cases this gate covers.
+///   - IPv6: multicast ff00::/8 (first byte 0xff). IPv6 has no broadcast.
+///
+/// Returns `true` when an ICMP error MUST be suppressed for this trigger
+/// destination. Fails closed (`true`) on a too-short packet slice.
+#[inline]
+pub(in crate::afxdp) fn dest_is_multicast_or_broadcast(addr_family: u8, packet: &[u8]) -> bool {
+    match addr_family as i32 {
+        libc::AF_INET => {
+            let Some(dst) = packet.get(16..20) else {
+                return true;
+            };
+            let dst = Ipv4Addr::new(dst[0], dst[1], dst[2], dst[3]);
+            dst.is_multicast() || dst.is_broadcast()
+        }
+        libc::AF_INET6 => {
+            let Some(dst) = packet.get(24..40) else {
+                return true;
+            };
+            // ff00::/8 — the leading byte alone identifies all IPv6
+            // multicast (link-local-all-nodes, solicited-node, etc.).
+            dst[0] == 0xff
+        }
+        _ => false,
+    }
+}
+
 pub(in crate::afxdp) fn metadata_tuple_complete(meta: UserspaceDpMeta, flow: &SessionFlow) -> bool {
     if flow.src_ip.is_unspecified() || flow.dst_ip.is_unspecified() {
         return false;

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -325,7 +325,11 @@ pub(in crate::afxdp) fn is_non_first_fragment(packet: &[u8], addr_family: u8) ->
 ///   - IPv6: multicast ff00::/8 (first byte 0xff). IPv6 has no broadcast.
 ///
 /// Returns `true` when an ICMP error MUST be suppressed for this trigger
-/// destination. Fails closed (`true`) on a too-short packet slice.
+/// destination. Fails closed (`true`) on a too-short packet slice and on
+/// an unknown/unexpected `addr_family`: a destination we cannot classify
+/// must suppress the error rather than risk emitting backscatter for a
+/// packet whose family (and therefore whose group/broadcast bits) we did
+/// not parse.
 #[inline]
 pub(in crate::afxdp) fn dest_is_multicast_or_broadcast(addr_family: u8, packet: &[u8]) -> bool {
     match addr_family as i32 {
@@ -344,7 +348,11 @@ pub(in crate::afxdp) fn dest_is_multicast_or_broadcast(addr_family: u8, packet: 
             // multicast (link-local-all-nodes, solicited-node, etc.).
             dst[0] == 0xff
         }
-        _ => false,
+        // Unknown family — fail closed (suppress). The error generators
+        // never call this for a non-IP family in practice (their own
+        // family dispatch rejects first), but the predicate's contract is
+        // "suppress on anything we could not classify."
+        _ => true,
     }
 }
 

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -53,9 +53,9 @@ pub(in crate::afxdp) use checksum::{
 // cos/queue_service.rs, so they go out at `pub(in crate::afxdp)`. The
 // rest stay at `pub(super)` (afxdp-only callers in sibling files).
 pub(in crate::afxdp) use inspect::{
-    authoritative_forward_ports, decode_frame_summary, forward_tuple_mismatch_reason,
-    ipv4_is_non_first_fragment, ipv6_is_non_first_fragment, is_non_first_fragment,
-    parse_session_flow, try_parse_metadata,
+    authoritative_forward_ports, decode_frame_summary, dest_is_multicast_or_broadcast,
+    forward_tuple_mismatch_reason, ipv4_is_non_first_fragment, ipv6_is_non_first_fragment,
+    is_non_first_fragment, parse_session_flow, try_parse_metadata,
 };
 pub(super) use inspect::{
     MAX_IPV6_EXT_HEADERS, frame_l3_offset, frame_l4_offset, live_frame_ports, live_frame_ports_bytes,

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -61,14 +61,15 @@ pub(super) fn can_generate_icmp_error_reply(frame: &[u8], meta: UserspaceDpMeta)
                 return false;
             }
             let src = Ipv4Addr::new(packet[12], packet[13], packet[14], packet[15]);
-            let dst = Ipv4Addr::new(packet[16], packet[17], packet[18], packet[19]);
-            // (d) bad source / (c) group or broadcast destination.
+            // (d) bad source / (c) group or broadcast destination. The
+            // destination test routes through the shared #2314 predicate
+            // so the PTB, reject, and Time Exceeded paths agree on what a
+            // multicast/broadcast destination is.
             if src.is_unspecified()
                 || src.is_loopback()
                 || src.is_multicast()
                 || src.is_broadcast()
-                || dst.is_multicast()
-                || dst.is_broadcast()
+                || dest_is_multicast_or_broadcast(meta.addr_family, packet)
             {
                 return false;
             }
@@ -81,16 +82,13 @@ pub(super) fn can_generate_icmp_error_reply(frame: &[u8], meta: UserspaceDpMeta)
                 Ok(addr) => addr,
                 Err(_) => return false,
             });
-            let dst = Ipv6Addr::from(match <[u8; 16]>::try_from(&packet[24..40]) {
-                Ok(addr) => addr,
-                Err(_) => return false,
-            });
             // (d) bad source / (c) multicast destination. IPv6 has no
-            // broadcast; multicast covers the group case.
+            // broadcast; multicast (ff00::/8) covers the group case. The
+            // destination test routes through the shared #2314 predicate.
             if src.is_unspecified()
                 || src.is_loopback()
                 || src.is_multicast()
-                || dst.is_multicast()
+                || dest_is_multicast_or_broadcast(meta.addr_family, packet)
             {
                 return false;
             }
@@ -674,5 +672,118 @@ mod tests {
             build_local_icmp_error_v4(&frame, meta, ICMP_IFINDEX, &fwd, 11, 0).expect("v4 error");
         assert_eq!(&out[12..14], &[0x81, 0x00]);
         assert_eq!(&out[14..16], &50u16.to_be_bytes(), "egress VID 50 fallback");
+    }
+
+    /// #2314: rewrite the IPv4 destination of an `inbound_v4` frame
+    /// (offset depends on the L2 tag) and fix the IP-header checksum.
+    fn set_inbound_v4_dst(frame: &mut [u8], meta: UserspaceDpMeta, dst: Ipv4Addr) {
+        let l3 = meta.l3_offset as usize;
+        frame[l3 + 16..l3 + 20].copy_from_slice(&dst.octets());
+        frame[l3 + 10..l3 + 12].copy_from_slice(&[0, 0]);
+        let csum = checksum16(&frame[l3..l3 + 20]);
+        frame[l3 + 10..l3 + 12].copy_from_slice(&csum.to_be_bytes());
+    }
+
+    /// Build an inbound IPv6 UDP frame (untagged) destined to `dst`, with
+    /// `l4_offset` set so `can_generate_icmp_error_reply` can locate the
+    /// transport header.
+    fn inbound_v6_to(dst: Ipv6Addr) -> (Vec<u8>, UserspaceDpMeta) {
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]); // firewall NIC
+        frame.extend_from_slice(&[0x00, 0x25, 0x90, 0x12, 0x34, 0x56]); // sender
+        frame.extend_from_slice(&0x86ddu16.to_be_bytes());
+        let l3 = frame.len();
+        frame.push(0x60); // version 6
+        frame.extend_from_slice(&[0x00, 0x00, 0x00]); // TC/flow
+        frame.extend_from_slice(&8u16.to_be_bytes()); // payload = 8 (UDP hdr)
+        frame.push(17); // next header UDP
+        frame.push(64); // hop limit
+        frame.extend_from_slice(&"2001:559:8585:bf01::20".parse::<Ipv6Addr>().unwrap().octets());
+        frame.extend_from_slice(&dst.octets());
+        let l4 = frame.len();
+        frame.extend_from_slice(&49152u16.to_be_bytes());
+        frame.extend_from_slice(&5201u16.to_be_bytes());
+        frame.extend_from_slice(&8u16.to_be_bytes());
+        frame.extend_from_slice(&0u16.to_be_bytes());
+        let meta = UserspaceDpMeta {
+            ingress_ifindex: ICMP_IFINDEX as u32,
+            l3_offset: l3 as u16,
+            l4_offset: l4 as u16,
+            addr_family: libc::AF_INET6 as u8,
+            protocol: 17,
+            ..UserspaceDpMeta::default()
+        };
+        (frame, meta)
+    }
+
+    /// #2314 reject/time-exceeded path: a trigger packet whose IPv4
+    /// destination is multicast (224.0.0.0/4) must suppress the locally
+    /// generated ICMP error (`can_generate_icmp_error_reply` returns false,
+    /// so `build_reject_icmp_unreachable` returns None). RFC 1812 §4.3.2.7.
+    #[test]
+    fn reject_suppressed_for_v4_multicast_dst() {
+        let (mut frame, meta) = inbound_v4(InL2::Untagged);
+        set_inbound_v4_dst(&mut frame, meta, Ipv4Addr::new(239, 1, 2, 3));
+        assert!(
+            !can_generate_icmp_error_reply(&frame, meta),
+            "IPv4 multicast destination must suppress the reply"
+        );
+        let fwd = forwarding_with_egress(0);
+        assert!(
+            build_reject_icmp_unreachable(&frame, meta, ICMP_IFINDEX, &fwd).is_none(),
+            "reject unreachable must not build for a multicast destination"
+        );
+    }
+
+    /// #2314: an IPv4 trigger destined to the limited broadcast
+    /// 255.255.255.255 must suppress the reply.
+    #[test]
+    fn reject_suppressed_for_v4_limited_broadcast_dst() {
+        let (mut frame, meta) = inbound_v4(InL2::Untagged);
+        set_inbound_v4_dst(&mut frame, meta, Ipv4Addr::new(255, 255, 255, 255));
+        assert!(
+            !can_generate_icmp_error_reply(&frame, meta),
+            "IPv4 limited broadcast destination must suppress the reply"
+        );
+    }
+
+    /// #2314: an IPv6 trigger destined to ff00::/8 multicast must suppress
+    /// the reply (RFC 4443 §2.4(e)).
+    #[test]
+    fn reject_suppressed_for_v6_multicast_dst() {
+        let (frame, meta) = inbound_v6_to("ff02::1".parse().expect("v6 mcast"));
+        assert!(
+            !can_generate_icmp_error_reply(&frame, meta),
+            "IPv6 multicast destination must suppress the reply"
+        );
+        let fwd = forwarding_with_egress(0);
+        assert!(
+            build_reject_icmp_unreachable(&frame, meta, ICMP_IFINDEX, &fwd).is_none(),
+            "reject unreachable must not build for an IPv6 multicast destination"
+        );
+    }
+
+    /// #2314 fail-on-revert: a NORMAL unicast destination must STILL allow
+    /// the reply. Pairs with the suppression tests so reverting the gate
+    /// turns those red while this one stays green.
+    #[test]
+    fn reject_still_allowed_for_unicast_dst() {
+        // IPv4 default destination 172.16.80.200 is plain unicast.
+        let (frame4, meta4) = inbound_v4(InL2::Untagged);
+        assert!(
+            can_generate_icmp_error_reply(&frame4, meta4),
+            "a unicast IPv4 destination must allow the reply"
+        );
+        let fwd = forwarding_with_egress(0);
+        assert!(
+            build_reject_icmp_unreachable(&frame4, meta4, ICMP_IFINDEX, &fwd).is_some(),
+            "reject unreachable must build for a unicast destination"
+        );
+        // IPv6 global unicast destination.
+        let (frame6, meta6) = inbound_v6_to("2001:559:8585:80::200".parse().expect("v6 ucast"));
+        assert!(
+            can_generate_icmp_error_reply(&frame6, meta6),
+            "a unicast IPv6 destination must allow the reply"
+        );
     }
 }

--- a/userspace-dp/src/afxdp/icmp_ptb.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb.rs
@@ -118,8 +118,11 @@ fn ipv4_df_set(packet: &[u8]) -> bool {
 
 /// RFC error-suppression gate shared by the PTB path. Mirrors the reject
 /// path: never reply to a non-first fragment (no transport header to quote
-/// / key) or to an inbound ICMP/ICMPv6 *error* message (avoid error loops
-/// and amplification). Returns true when a PTB MUST be suppressed.
+/// / key), to a trigger packet whose destination was multicast/broadcast
+/// (RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e), #2314 — a multicast flood must
+/// not be amplified into an ICMP-error backscatter storm), or to an
+/// inbound ICMP/ICMPv6 *error* message (avoid error loops and
+/// amplification). Returns true when a PTB MUST be suppressed.
 #[inline]
 pub(in crate::afxdp) fn ptb_reply_suppressed(
     frame: &[u8],
@@ -130,6 +133,11 @@ pub(in crate::afxdp) fn ptb_reply_suppressed(
         return true;
     };
     if is_non_first_fragment(packet, meta.addr_family) {
+        return true;
+    }
+    // #2314: never generate a PTB in reply to a datagram whose IP
+    // destination was multicast or broadcast.
+    if dest_is_multicast_or_broadcast(meta.addr_family, packet) {
         return true;
     }
     if matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6) {

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -313,6 +313,82 @@ fn inbound_icmp_error_is_suppressed() {
     );
 }
 
+/// #2314: rewrite the IPv4 destination of a built inbound frame (and fix
+/// the IP header checksum) so it heads to `dst`. The egress-MTU decision
+/// and `ptb_reply_suppressed` both read the destination off the frame.
+fn set_v4_dst(frame: &mut [u8], l3: usize, dst: Ipv4Addr) {
+    frame[l3 + 16..l3 + 20].copy_from_slice(&dst.octets());
+    frame[l3 + 10..l3 + 12].copy_from_slice(&[0, 0]);
+    let csum = checksum16(&frame[l3..l3 + 20]);
+    frame[l3 + 10..l3 + 12].copy_from_slice(&csum.to_be_bytes());
+}
+
+/// #2314: rewrite the IPv6 destination of a built inbound frame.
+fn set_v6_dst(frame: &mut [u8], l3: usize, dst: Ipv6Addr) {
+    frame[l3 + 24..l3 + 40].copy_from_slice(&dst.octets());
+}
+
+/// #2314: an oversized DF IPv4 datagram destined to a 224.0.0.0/4
+/// multicast address must NOT generate a PTB (RFC 1812 §4.3.2.7) — a
+/// multicast flood must not be amplified into an ICMP backscatter storm.
+/// The original is still dropped by the caller (decision still fires).
+#[test]
+fn ptb_suppressed_for_v4_multicast_dst() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    set_v4_dst(&mut frame, l3, Ipv4Addr::new(239, 1, 2, 3));
+    assert!(
+        ptb_reply_suppressed(&frame, meta, l3),
+        "IPv4 multicast destination must suppress the PTB"
+    );
+}
+
+/// #2314: an oversized DF IPv4 datagram destined to the limited
+/// broadcast 255.255.255.255 must NOT generate a PTB.
+#[test]
+fn ptb_suppressed_for_v4_limited_broadcast_dst() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    set_v4_dst(&mut frame, l3, Ipv4Addr::new(255, 255, 255, 255));
+    assert!(
+        ptb_reply_suppressed(&frame, meta, l3),
+        "IPv4 limited broadcast destination must suppress the PTB"
+    );
+}
+
+/// #2314: an oversized IPv6 datagram destined to ff00::/8 multicast must
+/// NOT generate a Packet-Too-Big (RFC 4443 §2.4(e)).
+#[test]
+fn ptb_suppressed_for_v6_multicast_dst() {
+    let (mut frame, meta) = inbound_v6_udp(1300);
+    let l3 = meta.l3_offset as usize;
+    set_v6_dst(&mut frame, l3, "ff02::1".parse().expect("v6 mcast"));
+    assert!(
+        ptb_reply_suppressed(&frame, meta, l3),
+        "IPv6 multicast destination must suppress the PTB"
+    );
+}
+
+/// #2314 fail-on-revert: a NORMAL unicast destination must STILL generate
+/// the PTB. If the multicast/broadcast guard is reverted this test still
+/// passes; it pairs with the suppression tests above so that reverting the
+/// guard turns those three red.
+#[test]
+fn ptb_still_generated_for_v4_unicast_dst() {
+    let (frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    // The default destination 172.16.80.200 is plain unicast.
+    assert!(
+        !ptb_reply_suppressed(&frame, meta, l3),
+        "a unicast destination must NOT suppress the PTB"
+    );
+    let fwd = forwarding_with_egress(1400);
+    assert!(
+        build_frag_needed_v4(&frame, meta, PTB_IFINDEX, &fwd, 1400).is_some(),
+        "unicast PTB must build"
+    );
+}
+
 #[test]
 fn no_primary_address_fails_closed() {
     // Egress has no primary v4 -> the builder returns None (caller silently

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -369,6 +369,34 @@ fn ptb_suppressed_for_v6_multicast_dst() {
     );
 }
 
+/// #2314 fail-closed contract: an unknown / unexpected addr_family (e.g.
+/// 0, or a non-IP family) must be treated as "could not classify" and
+/// suppress the error — the documented fail-closed posture. Fails if the
+/// predicate's default arm is reverted to `false` (fail open).
+#[test]
+fn dest_predicate_fails_closed_on_unknown_family() {
+    // A plain IPv4 unicast packet body — only the addr_family argument is
+    // bogus, proving the suppression comes from the family arm, not the
+    // bytes (those bytes classify as unicast under AF_INET).
+    let (frame, meta) = inbound_v4_udp(64, true);
+    let l3 = meta.l3_offset as usize;
+    let packet = &frame[l3..];
+    assert!(
+        dest_is_multicast_or_broadcast(0, packet),
+        "addr_family 0 (unknown) must fail closed -> suppress"
+    );
+    assert!(
+        dest_is_multicast_or_broadcast(libc::AF_UNIX as u8, packet),
+        "a non-IP addr_family must fail closed -> suppress"
+    );
+    // Sanity: the same bytes under AF_INET are NOT suppressed (unicast),
+    // so the suppression above is the family arm, not the destination.
+    assert!(
+        !dest_is_multicast_or_broadcast(libc::AF_INET as u8, packet),
+        "the same unicast bytes under AF_INET must NOT be suppressed"
+    );
+}
+
 /// #2314 fail-on-revert: a NORMAL unicast destination must STILL generate
 /// the PTB. If the multicast/broadcast guard is reverted this test still
 /// passes; it pairs with the suppression tests above so that reverting the


### PR DESCRIPTION
Closes #2314

## RFC basis

Per RFC 1812 §4.3.2.7 and RFC 4443 §2.4(e), a router MUST NOT originate
an ICMP/ICMPv6 error message in response to a datagram destined to an IP
multicast or broadcast address. Without this check a multicast flood can
trigger an ICMP-error backscatter storm.

## The two gated generation sites

1. **PTB / Frag-Needed (#2310/#2301)** — `userspace-dp/src/afxdp/icmp_ptb.rs:140`,
   inside `ptb_reply_suppressed`. This was the real gap: it gated only on
   non-first-fragment and inbound-ICMP-error, so it would build a Packet-Too-Big
   for a multicast/broadcast-destined oversized DF datagram. The gate is
   consulted at the dispatch site `userspace-dp/src/afxdp/tx/dispatch/mod.rs:520`.
2. **Policy-`reject` ICMP-unreachable / Time Exceeded** —
   `userspace-dp/src/afxdp/icmp.rs:72` (v4) and `:91` (v6), inside
   `can_generate_icmp_error_reply` (the gate used by
   `build_reject_icmp_unreachable` and `build_local_time_exceeded_request`).
   This path already inline-suppressed a multicast/broadcast destination; it is
   now routed through the shared predicate so all three error paths agree.

## Implementation

- New shared predicate `dest_is_multicast_or_broadcast(addr_family, packet)`
  in `frame/inspect.rs` (alongside `is_non_first_fragment`), operating on the
  L3-relative slice:
  - IPv4: multicast `224.0.0.0/4` OR limited broadcast `255.255.255.255`
    (via `Ipv4Addr::is_multicast`/`is_broadcast`).
  - IPv6: multicast `ff00::/8` (leading `0xff` byte).
  - Too-short slice fails closed (suppress).
- The original triggering packet is still dropped per existing policy — a
  suppressed reply folds into the existing fail-closed silent-drop path (PTB
  site keeps `mtu_signalled` so the oversized original drops; reject site
  returns `None`, which the caller drops).
- **No new counter** and **no wire/Go change**. Adding a wire-visible counter
  would balloon into protocol/Go plumbing inconsistent with the existing
  PTB/reject counters; the suppression itself is the load-bearing behaviour and
  a suppressed reply is accounted for by the existing drop accounting. The
  decision is documented in the `icmp_ptb.rs` README section.

## Tests

8 fail-on-revert unit tests across both paths
(`userspace-dp/src/afxdp/icmp_ptb_tests.rs` + the `icmp.rs` test module):

- `ptb_suppressed_for_v4_multicast_dst`
- `ptb_suppressed_for_v4_limited_broadcast_dst`
- `ptb_suppressed_for_v6_multicast_dst`
- `ptb_still_generated_for_v4_unicast_dst`
- `reject_suppressed_for_v4_multicast_dst`
- `reject_suppressed_for_v4_limited_broadcast_dst`
- `reject_suppressed_for_v6_multicast_dst`
- `reject_still_allowed_for_unicast_dst`

## Validation

- `cargo build --release` clean (only pre-existing unused-import warnings).
- `cargo test --release -- icmp ptb reject multicast suppress` green; the 8
  new tests pass by exact name.
- Fail-on-revert proven: temporarily reverting both guards turns the 6
  suppression tests red while the 2 unicast tests stay green; restored.
- 5x flake-free on the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)