### PR TITLE
wg: RFC 6040 §4.2 decap-side ECN combine (outer→inner) via recvmsg (#2317)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,54 @@
 # Action Log
 
+## 2026-06-22 — #2317 WG decap RFC 6040 §4.2 ECN combine
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Implemented the WireGuard DECAP-side RFC 6040 §4.2 ECN
+  combine (outer ECN → inner ECN), completing the half #2315 deferred for
+  the WG path. The WG control thread reads transport records from a kernel
+  `UdpSocket`, which strips the outer IP header (and its ECN) before
+  userspace — so the recv loop now uses `recvmsg` (libc, no new crate)
+  with `IP_RECVTOS` (v4 / v4-mapped) and `IPV6_RECVTCLASS` (v6) enabled at
+  bind. The outer DS byte arrives as an `IP_TOS`/`IPV6_TCLASS` cmsg;
+  `parse_outer_ecn_from_cmsg` walks the control chain (libc CMSG_* macros)
+  and extracts ECN = ds & 0x03. The captured `Option<u8>` outer ECN is
+  threaded `wg_recvmsg → dispatch_inbound → WG_TYPE_DATA arm`, where after
+  `engine.try_decap` produces the inner IP packet it is folded in via the
+  SHARED `gre::apply_decap_ecn_combine` (refactored to take the per-family
+  drop counter by `&AtomicU64`) BEFORE `tun.write_all`. Illegal outer-CE /
+  inner-Not-ECT drops bump a new WG sibling counter
+  `WG_DECAP_ECN_ILLEGAL_DROPS`, wired end-to-end (status.rs → control.rs
+  ProcessStatus → helpers.rs → Go protocol.go → Prometheus
+  `xpf_userspace_wg_decap_ecn_illegal_drops_total`). recvmsg cmsg is
+  best-effort: no cmsg ⇒ combine skipped (pre-#2317 behavior), never fatal.
+  Live ECN-propagation verification is lab-deferred to #1703-class interop.
+- **File(s)**: userspace-dp/src/afxdp/gre.rs (counter + shared
+  apply signature), userspace-dp/src/afxdp/coordinator/wg_control.rs
+  (set_recv_tos_options, wg_recvmsg, parse_outer_ecn_from_cmsg,
+  sockaddr_storage_to_socketaddr, dispatch_inbound combine, tests),
+  userspace-dp/src/afxdp/coordinator/status.rs,
+  userspace-dp/src/protocol/control.rs,
+  userspace-dp/src/protocol/tests.rs,
+  userspace-dp/src/server/{helpers.rs,lifecycle.rs},
+  userspace-dp/src/afxdp/tunnel_tests.rs (counter-arg + flake-harden),
+  userspace-dp/src/afxdp/wg/dscp.rs (doc),
+  userspace-dp/tests/fixtures/protocol_wire_v1.json (regen, +1 key),
+  pkg/dataplane/userspace/protocol.go, pkg/api/{metrics.go,
+  metrics_descriptors.go,metrics_userspace.go,metrics_test.go,
+  metrics_descriptor_coverage_test.go}, docs/wireguard-interop.md.
+- **Validation**: `cargo build --release` clean; targeted
+  `cargo test --release -- wg ecn decap recvmsg tclass` 229/0; new tests
+  (cmsg_parse_v4_ip_tos_extracts_ecn, cmsg_parse_v6_tclass_extracts_ecn,
+  cmsg_parse_ignores_unrelated_cmsg, cmsg_parse_empty_control_yields_none,
+  wg_apply_combine_sets_ipv4_ce_and_recomputes_checksum,
+  wg_apply_combine_drops_illegal_combo_and_counts,
+  process_status_wg_decap_ecn_illegal_drops_roundtrip) 5x green after
+  flake-hardening the shared-global counter asserts onto test-local
+  atomics. `go build ./...` + `go test ./pkg/api/...
+  ./pkg/dataplane/userspace/...` green. Pre-existing unrelated flake:
+  worker_queue concurrent_recovery (no ECN/WG refs, fails 1/3 in
+  isolation, on master too). Live loss-cluster smoke deferred to parent.
+
 ## 2026-06-22 — #1434 review round 1 (NEEDS-MINOR fold)
 
 - **Timestamp**: 2026-06-22 PDT

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -18,7 +18,7 @@ therefore staged by capability, not by vendor.
 | #1434 | Multi-PEER per WG interface (N peers on one listen port) | **DONE (#1434 B1a+B1b)** — Go config `TunnelConfig.WgPeers []WgPeerConfig` (named-instance `peer <pubkey>` schema + dual-AST compiler + commit gate), wire slice `wg_peers`, Rust engine fed N peers (RX/decap already multi-peer), egress generalized: encap LPM-selects the peer by inner-dst AllowedIPs (`frame/wg.rs` + `engine.peer_for_dest`), the WG control thread keeps per-peer effective-endpoint + per-peer handshake attempt + per-peer keepalive/rekey timers (`timer_pass_for_peer`), and per-peer status rows. The LIVE multi-peer handshake / Ubiquiti interop validation is #1703. KNOWN LIMITATION: the worker-driven NoSession/rekey REQUEST edges are still engine-wide (single edge), not per-peer — the per-peer T6/T7/T8 timers ARE per-peer; per-peer request edges ride #1703. |
 | S5 | Persistent-keepalive + REKEY/REJECT-AFTER timers + endpoint roaming + empty-record (keepalive/key-confirm) handling + TAI64N disk persistence | **timers + keepalives DONE (#1888/#1889)** — full whitepaper §6.1 timer machine (REKEY_AFTER_TIME 120s initiator-only, 165s receive horizon, REJECT_AFTER_TIME 180s per-use + expiry teardown, 5s/90s retry discipline, 10s passive + configured persistent keepalives, post-msg2 key-confirmation keepalive) on a blocking-poll(2) control loop; design of record `docs/research/1888-wg-timers/plan.md`. Authenticated-datagram endpoint LEARNING shipped in S2a/#1888 (keepalives now count); engine-level roam API + TAI64N disk persistence remain pending |
 | S6 | Junos config surface (grammar + compiler + snapshot population, base64↔hex keys) | pending |
-| S7 | Type-3 CookieReply + MAC2 generation/verification + IPv6 outer encap + DSCP/ECN | **DSCP/ECN encap DONE (#2303)** — inner DSCP+ECN copied onto the outer header (uniform DSCP + RFC 6040 ECN ingress copy). GRE decap-side RFC 6040 §4.2 ECN *combine* shipped in #2315; **WG decap-side combine still pending (#2317)** — blocked on `IP_RECVTOS`/`recvmsg` recv-loop changes. CookieReply/MAC2 still pending |
+| S7 | Type-3 CookieReply + MAC2 generation/verification + IPv6 outer encap + DSCP/ECN | **DSCP/ECN encap DONE (#2303)** — inner DSCP+ECN copied onto the outer header (uniform DSCP + RFC 6040 ECN ingress copy). RFC 6040 §4.2 decap-side ECN *combine* shipped for GRE (#2315) AND WG (#2317) — WG captures the outer ECN via `recvmsg` + `IP_RECVTOS`/`IPV6_RECVTCLASS` cmsg and folds it into the decrypted inner via the shared `apply_decap_ecn_combine` (live ECN-propagation verification lab-deferred to #1703-class interop). CookieReply/MAC2 still pending |
 | S8 | HA RG WG-session migration | pending |
 
 ## Tunnel MTU + MSS + DSCP/ECN model (#2299 / #2300 / #2303)
@@ -70,25 +70,37 @@ plus the RFC 6040 normal-mode ECN ingress COPY (inner ECN → outer ECN).
 `wg::dscp::tos_from_dscp` (which clears ECN) is retained for the
 DSCP-only case but is NOT the encap reader.
 
-**Decap (#2315).** The RFC 6040 §4.2 decap-side ECN *combine* (outer ECN
-→ inner ECN) — the half that actually reflects a CE mark applied by a
-congested router on the outer path back to the inner endpoints — is
-implemented for the **GRE decap path only**
-(`gre::apply_decap_ecn_combine`, wired into
-`try_native_gre_decap_from_frame`): an outer CE upgrades an ECN-capable
-inner to CE; the illegal outer-CE / inner-Not-ECT combination is dropped
-(`xpf_userspace_gre_decap_ecn_illegal_drops_total`); the inner DSCP is
-authoritative at decap and is never copied from the outer. DSCP is not
-copied back at decap.
+**Decap (#2315 GRE / #2317 WG).** The RFC 6040 §4.2 decap-side ECN
+*combine* (outer ECN → inner ECN) — the half that actually reflects a CE
+mark applied by a congested router on the outer path back to the inner
+endpoints — is implemented for **both tunnel paths** via the shared
+`gre::apply_decap_ecn_combine`: an outer CE upgrades an ECN-capable inner
+to CE; the illegal outer-CE / inner-Not-ECT combination is dropped; the
+inner DSCP is authoritative at decap and is never copied from the outer.
+DSCP is not copied back at decap.
 
-> **WireGuard decap is NOT yet combined (#2317).** The WG control thread
-> reads transport records from a plain `UdpSocket::recv_from`, so the
-> kernel has already stripped the outer IP header before the datagram
-> reaches userspace — the outer ECN is gone at that layer. Recovering it
-> needs `IP_RECVTOS` / `IPV6_RECVTCLASS` + a `recvmsg` control-message
-> recv loop, then combining into the inner before the `tun.write_all`.
-> Tracked as a follow-up; do NOT read the encap-copy as "ECN is
-> reflected at WG decap".
+- **GRE (#2315)** reads the outer ECN from the still-present outer IP
+  header in the frame (`outer_ecn_bits`, wired into
+  `try_native_gre_decap_from_frame`). Illegal-combination drops surface as
+  `xpf_userspace_gre_decap_ecn_illegal_drops_total`.
+
+- **WireGuard (#2317)** captures the outer ECN out-of-band. The WG control
+  thread reads transport records from a kernel `UdpSocket`, which strips
+  the outer IP header (and its ECN) before the datagram reaches
+  userspace, so the recv loop uses `recvmsg` with the `IP_RECVTOS` (v4 /
+  v4-mapped) and `IPV6_RECVTCLASS` (v6) socket options enabled at bind;
+  the outer DS byte arrives as ancillary data (`IP_TOS` / `IPV6_TCLASS`
+  cmsg), and its low 2 bits are folded into the freshly-decrypted inner IP
+  packet — before `tun.write_all` — through the same combine. Illegal-
+  combination drops surface as
+  `xpf_userspace_wg_decap_ecn_illegal_drops_total` (a sibling counter, so
+  the two families are independently observable). The combine is skipped
+  best-effort when no TOS cmsg arrives (a kernel that did not honor the
+  sockopt) — never fatal to the tunnel. Live end-to-end verification (a
+  real WG peer CE-marking the outer → CE on the inner) is lab-bound,
+  deferred to the #1703-class interop validation; the code path and unit
+  tests (cmsg parse for v4/v6, the §4.2 combine reuse, CE upgrade + IPv4
+  checksum, illegal-combo drop+count) are in tree.
 
 ## What S1 delivers
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -250,7 +250,11 @@ type xpfCollector struct {
 	// that ECT-marked the outer for un-ECN inner traffic on a congested
 	// path.
 	userspaceGreDecapEcnIllegalDrops *prometheus.Desc
-	userspaceFlowCacheActiveFlows    *prometheus.Desc
+	// #2317: WG-decap RFC 6040 §4.2 illegal-combination drops (outer CE,
+	// captured via recvmsg IP_RECVTOS/IPV6_RECVTCLASS, over a Not-ECT
+	// inner) — the WG sibling of the GRE counter above.
+	userspaceWgDecapEcnIllegalDrops *prometheus.Desc
+	userspaceFlowCacheActiveFlows   *prometheus.Desc
 	userspaceFlowCacheCapacity                  *prometheus.Desc
 	// #1379: daemon-side userspace event-stream transport counters.
 	userspaceEventStreamFramesTotal          *prometheus.Desc
@@ -537,6 +541,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.userspaceNatReverseKeySharedDisplacements
 	ch <- c.userspaceWorkerCommandQueuePoisonRecoveries
 	ch <- c.userspaceGreDecapEcnIllegalDrops
+	ch <- c.userspaceWgDecapEcnIllegalDrops
 	ch <- c.userspaceFlowCacheActiveFlows
 	ch <- c.userspaceFlowCacheCapacity
 	ch <- c.userspaceEventStreamFramesTotal

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -516,6 +516,7 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_userspace_session_nat_reverse_key_shared_displacements_total", // #1760 W3' shared displacements
 		"xpf_userspace_worker_command_queue_poison_recoveries_total",       // #1807 poison recoveries
 		"xpf_userspace_gre_decap_ecn_illegal_drops_total",                  // #2315 RFC 6040 4.2 decap illegal-combo drops
+		"xpf_userspace_wg_decap_ecn_illegal_drops_total",                   // #2317 WG RFC 6040 4.2 decap illegal-combo drops
 		// #1771 §2.6 resolver backoff + §2.5 ENOBUFS/re-dump + key gauges
 		"xpf_userspace_neighbor_resolver_get_backoff_attempts_total",
 		"xpf_userspace_neighbor_netlink_enobufs_total",

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -831,6 +831,23 @@ func newCollector(srv *Server) *xpfCollector {
 				"traffic on a congested path (#2315).",
 			nil, nil,
 		),
+		userspaceWgDecapEcnIllegalDrops: prometheus.NewDesc(
+			"xpf_userspace_wg_decap_ecn_illegal_drops_total",
+			"WireGuard-decap inner packets dropped by the RFC 6040 4.2 "+
+				"decap-side ECN combine because the (recvmsg-captured) "+
+				"outer header carried a CE (congestion experienced) mark "+
+				"over an inner packet that was Not-ECT (the illegal "+
+				"combination: a congested router CE-marked a packet whose "+
+				"endpoints never negotiated ECN). The WG decap path reads "+
+				"the outer ECN out-of-band via IP_RECVTOS/IPV6_RECVTCLASS "+
+				"(the kernel UDP socket strips the outer IP header before "+
+				"userspace) and applies the same combine. RFC 6040 mandates "+
+				"dropping this rather than silently clearing the bogus CE. "+
+				"A nonzero value flags a misbehaving WG ingress that "+
+				"ECT-marked the outer for un-ECN inner traffic on a "+
+				"congested path (#2317).",
+			nil, nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"Aggregate active userspace flow-cache entries across bindings.",

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -830,6 +830,12 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 			nil,
 			nil,
 		),
+		userspaceWgDecapEcnIllegalDrops: prometheus.NewDesc(
+			"xpf_userspace_wg_decap_ecn_illegal_drops_total",
+			"wg decap rfc6040 illegal-combo drops",
+			nil,
+			nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"flow-cache active flows",
@@ -864,6 +870,9 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 		// #2315: GRE-decap RFC 6040 §4.2 illegal-combo drop counter
 		// emitted unconditionally.
 		GreDecapEcnIllegalDropsTotal: 3,
+		// #2317: WG-decap RFC 6040 §4.2 illegal-combo drop counter
+		// emitted unconditionally.
+		WgDecapEcnIllegalDropsTotal: 5,
 		// #1861: install-refusal trio emitted unconditionally.
 		SessionCreateDrops:             9,
 		SessionInstallAdmissionRefused: 8,
@@ -899,9 +908,10 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	}
 	// 10 pre-#1861 metrics + the #1861 install-refusal trio + the #2244
 	// dnat_table reverse-NAT publish-error counter (= 14) + the #2315
-	// gre_decap_ecn_illegal_drops_total counter = 15.
-	if len(got) != 15 {
-		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 15 metrics, got %d", len(got))
+	// gre_decap_ecn_illegal_drops_total counter (= 15) + the #2317
+	// wg_decap_ecn_illegal_drops_total counter = 16.
+	if len(got) != 16 {
+		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 16 metrics, got %d", len(got))
 	}
 
 	assertGaugeClose(t, got, c.userspaceSessionTableEntries, nil, 77)
@@ -921,6 +931,9 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	// #2315: GRE-decap RFC 6040 §4.2 illegal-combo drop counter emitted
 	// unconditionally.
 	assertCounterClose(t, got, c.userspaceGreDecapEcnIllegalDrops, nil, 3)
+	// #2317: WG-decap RFC 6040 §4.2 illegal-combo drop counter emitted
+	// unconditionally.
+	assertCounterClose(t, got, c.userspaceWgDecapEcnIllegalDrops, nil, 5)
 	// #1861: install-refusal trio emitted unconditionally.
 	assertCounterClose(t, got, c.userspaceSessionCreateDrops, nil, 9)
 	assertCounterClose(t, got, c.userspaceSessionInstallAdmissionRefused, nil, 8)

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -534,6 +534,16 @@ func (c *xpfCollector) emitUserspaceDynamicBufferMetrics(ch chan<- prometheus.Me
 		float64(status.GreDecapEcnIllegalDropsTotal),
 	)
 
+	// #2317: WG-decap RFC 6040 4.2 illegal-combination drops (outer CE,
+	// recvmsg-captured, over a Not-ECT inner). Emitted unconditionally so
+	// a 0 is a real "no illegal combinations seen" signal rather than an
+	// absent series.
+	ch <- prometheus.MustNewConstMetric(
+		c.userspaceWgDecapEcnIllegalDrops,
+		prometheus.CounterValue,
+		float64(status.WgDecapEcnIllegalDropsTotal),
+	)
+
 	var activeFlows, flowCapacity uint64
 	for _, b := range status.Bindings {
 		activeFlows += uint64(b.ActiveFlowCount)

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -809,6 +809,14 @@ type ProcessStatus struct {
 	// xpf_userspace_gre_decap_ecn_illegal_drops_total. Omitempty for wire
 	// compat with older helpers (defaults to 0).
 	GreDecapEcnIllegalDropsTotal uint64 `json:"gre_decap_ecn_illegal_drops_total,omitempty"`
+	// #2317: WireGuard-decap inner packets dropped by the SAME RFC 6040
+	// §4.2 decap-side ECN combine, for the WG path. The WG decap site
+	// captures the outer ECN out-of-band via recvmsg + IP_RECVTOS /
+	// IPV6_RECVTCLASS (the kernel UDP socket strips the outer IP header
+	// before userspace) and feeds it into the same combine. Surfaced as
+	// xpf_userspace_wg_decap_ecn_illegal_drops_total. Omitempty for wire
+	// compat with older helpers (defaults to 0).
+	WgDecapEcnIllegalDropsTotal uint64 `json:"wg_decap_ecn_illegal_drops_total,omitempty"`
 	// #1769: on-demand neighbor-resolver telemetry. The resolver fires
 	// when a MissingNeighbor negative-cache fast-fail nudges a wedged dst
 	// (single-key RTM_GETNEIGH + epoch-guarded cache or probe-on-stale).

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -193,6 +193,17 @@ impl super::Coordinator {
         crate::afxdp::gre::GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed)
     }
 
+    /// #2317: WireGuard-decap inner packets dropped by the RFC 6040 §4.2
+    /// decap-side ECN combine because the (recvmsg-captured) outer ECN
+    /// was CE over a Not-ECT inner — the illegal combination. RFC 6040
+    /// mandates a drop here. Surfaced as
+    /// `xpf_userspace_wg_decap_ecn_illegal_drops_total`; a nonzero value
+    /// flags a misbehaving WG ingress / congested path that CE-marked the
+    /// outer of un-ECN inner traffic.
+    pub fn wg_decap_ecn_illegal_drops_total(&self) -> u64 {
+        crate::afxdp::gre::WG_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed)
+    }
+
     /// #1782: debug dump of every key currently present in the userspace
     /// `dynamic_neighbors` mirror, as `(ifindex, ip)` pairs. The
     /// cold-start capture harness reads this at the pre-connect t0'

--- a/userspace-dp/src/afxdp/coordinator/wg_control.rs
+++ b/userspace-dp/src/afxdp/coordinator/wg_control.rs
@@ -156,6 +156,15 @@ pub(super) fn wg_control_loop(
         );
         return;
     }
+    // #2317: request the outer IP TOS / Traffic Class as ancillary data so
+    // the RFC 6040 §4.2 decap ECN combine has the outer ECN to fold into
+    // the decrypted inner packet. The kernel UDP socket strips the outer
+    // IP header before the WG record reaches userspace, so `IP_RECVTOS`
+    // (v4 / v4-mapped) and `IPV6_RECVTCLASS` (v6) are the only way to see
+    // it. Best-effort: a kernel that rejects the option just leaves the
+    // outer ECN unseen and the combine is skipped (the pre-#2317
+    // behavior) — never fatal to the tunnel.
+    set_recv_tos_options(socket.as_raw_fd(), socket_is_v6);
 
     // Attach to the persistent wgN TUN (Go pre-created it; open_tun
     // attaches to the existing device by name). Non-blocking.
@@ -391,8 +400,18 @@ fn run_wg_control_loop(
 
         // --- Inbound: kernel socket → engine → TUN ---
         for _ in 0..WG_RX_BURST {
-            match socket.recv_from(&mut sock_buf) {
-                Ok((len, from)) if len > 0 => {
+            // #2317: recvmsg (not recv_from) so the outer IP TOS /
+            // Traffic Class arrives as ancillary data — the only way to
+            // see the outer ECN the kernel UDP stack stripped with the
+            // outer IP header. `outer_ecn` is None when no TOS cmsg
+            // arrived (kernel ignored the sockopt); the decap combine is
+            // then skipped.
+            match wg_recvmsg(socket, &mut sock_buf) {
+                Ok(WgRecv {
+                    len,
+                    from,
+                    outer_ecn,
+                }) if len > 0 => {
                     did_work = true;
                     // Learn / refresh the peer endpoint from `from` ONLY
                     // after the datagram cryptographically authenticates
@@ -406,6 +425,7 @@ fn run_wg_control_loop(
                         &mut tun,
                         &sock_buf[..len],
                         from,
+                        outer_ecn,
                         &mut decap_buf,
                         &mut encap_buf,
                         tunnel_name,
@@ -979,6 +999,168 @@ fn wg_send_to(
     socket.send_to(buf, wire_target)
 }
 
+/// #2317: enable receiving the outer IP TOS / Traffic Class as ancillary
+/// data on the WG listen socket so the RFC 6040 §4.2 decap ECN combine
+/// can fold the outer ECN into the decrypted inner packet (the kernel
+/// UDP socket strips the outer IP header before the WG record reaches
+/// userspace). Sets `IP_RECVTOS` on every socket (it governs both native
+/// v4 and the v4-mapped datagrams the dual-stack v6 socket delivers) and
+/// additionally `IPV6_RECVTCLASS` on the dual-stack v6 socket for native
+/// v6 peers. Best-effort: a failure is logged via the return value being
+/// ignored by the caller — the combine is simply skipped when no cmsg
+/// arrives, which is the pre-#2317 behavior, so this is never fatal.
+fn set_recv_tos_options(fd: i32, socket_is_v6: bool) {
+    let on: libc::c_int = 1;
+    // IP_RECVTOS — outer IPv4 TOS (also delivered for v4-mapped peers on
+    // the dual-stack socket).
+    unsafe {
+        libc::setsockopt(
+            fd,
+            libc::IPPROTO_IP,
+            libc::IP_RECVTOS,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        );
+    }
+    if socket_is_v6 {
+        // IPV6_RECVTCLASS — outer IPv6 Traffic Class for native v6 peers.
+        unsafe {
+            libc::setsockopt(
+                fd,
+                libc::IPPROTO_IPV6,
+                libc::IPV6_RECVTCLASS,
+                &on as *const _ as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            );
+        }
+    }
+}
+
+/// #2317: outcome of a single `recvmsg` on the WG socket — the datagram
+/// length plus the 2-bit outer ECN parsed from the `IP_RECVTOS` /
+/// `IPV6_RECVTCLASS` ancillary data (None when no TOS cmsg arrived, e.g.
+/// the kernel did not honor the sockopt, in which case the decap combine
+/// is skipped).
+struct WgRecv {
+    len: usize,
+    from: SocketAddr,
+    outer_ecn: Option<u8>,
+}
+
+/// #2317: receive one WG datagram via `recvmsg`, capturing the outer IP
+/// TOS / Traffic Class from the ancillary `IP_RECVTOS` /
+/// `IPV6_RECVTCLASS` control message. Replaces `recv_from` so the outer
+/// ECN — stripped by the kernel UDP stack with the outer IP header —
+/// reaches the RFC 6040 §4.2 decap combine.
+///
+/// The cmsg buffer is a fixed 256-byte stack array (a single TOS cmsg is
+/// ~16-20 bytes; 256 covers both the v4 and v6 TOS cmsgs with margin and
+/// never allocates on the hot path). `MSG_TRUNC`/`MSG_CTRUNC` are not
+/// requested — the data buffer is the loop's 64 KiB scratch (max IP
+/// datagram) so transport records never truncate, and a truncated cmsg
+/// only loses the (best-effort) ECN, not the datagram.
+fn wg_recvmsg(socket: &UdpSocket, buf: &mut [u8]) -> io::Result<WgRecv> {
+    let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+    let mut cmsg_space = [0u8; 256];
+    let mut iov = libc::iovec {
+        iov_base: buf.as_mut_ptr() as *mut libc::c_void,
+        iov_len: buf.len(),
+    };
+    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+    msg.msg_name = &mut storage as *mut _ as *mut libc::c_void;
+    msg.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+    msg.msg_iov = &mut iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_space.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cmsg_space.len() as _;
+
+    let n = unsafe { libc::recvmsg(socket.as_raw_fd(), &mut msg, 0) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let len = n as usize;
+    let from = sockaddr_storage_to_socketaddr(&storage, msg.msg_namelen)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "recvmsg bad sockaddr"))?;
+    let outer_ecn = parse_outer_ecn_from_cmsg(&msg);
+    Ok(WgRecv {
+        len,
+        from,
+        outer_ecn,
+    })
+}
+
+/// #2317: walk the control-message chain of a populated `msghdr` and
+/// return the 2-bit ECN (low 2 bits of the DS byte) from the first
+/// `IP_RECVTOS` / `IPV6_TCLASS` cmsg found. `IP_RECVTOS` delivers the
+/// IPv4 TOS as a single byte (some kernels pad it into an `int`-sized
+/// payload); `IPV6_TCLASS` delivers the Traffic Class as an `int`. We
+/// read the FIRST payload byte in both cases — the DS byte is the
+/// low-order byte on the little-endian hosts xpf targets and, more
+/// robustly, IP_RECVTOS's documented payload is a `u8`. Returns `None`
+/// when no TOS cmsg is present (kernel ignored the sockopt, or a
+/// truncated cmsg).
+fn parse_outer_ecn_from_cmsg(msg: &libc::msghdr) -> Option<u8> {
+    // SAFETY: `msg` is a fully-initialized msghdr returned by recvmsg
+    // (msg_control / msg_controllen describe a valid buffer). CMSG_*
+    // macros walk it; we only read aligned payload bytes within
+    // `cmsg_len`.
+    unsafe {
+        let mut cmsg = libc::CMSG_FIRSTHDR(msg);
+        while !cmsg.is_null() {
+            let level = (*cmsg).cmsg_level;
+            let ctype = (*cmsg).cmsg_type;
+            let is_v4_tos = level == libc::IPPROTO_IP && ctype == libc::IP_TOS;
+            let is_v6_tclass = level == libc::IPPROTO_IPV6 && ctype == libc::IPV6_TCLASS;
+            if is_v4_tos || is_v6_tclass {
+                let data = libc::CMSG_DATA(cmsg);
+                // cmsg_len includes the header; payload length is the
+                // remainder. Require at least one byte of payload.
+                let payload_len =
+                    (*cmsg).cmsg_len as usize - (libc::CMSG_DATA(cmsg) as usize - cmsg as usize);
+                if payload_len >= 1 {
+                    let ds = *data;
+                    return Some(ds & 0x03);
+                }
+            }
+            cmsg = libc::CMSG_NXTHDR(msg, cmsg);
+        }
+    }
+    None
+}
+
+/// #2317: convert a `recvmsg`-populated `sockaddr_storage` to a Rust
+/// `SocketAddr`. The dual-stack v6 socket reports v4 peers as v4-mapped
+/// IPv6 (caller `canonicalize_endpoint`s the result, as the prior
+/// `recv_from` path did). Returns `None` for an unrecognized family.
+fn sockaddr_storage_to_socketaddr(
+    storage: &libc::sockaddr_storage,
+    len: libc::socklen_t,
+) -> Option<SocketAddr> {
+    match storage.ss_family as libc::c_int {
+        libc::AF_INET => {
+            if (len as usize) < std::mem::size_of::<libc::sockaddr_in>() {
+                return None;
+            }
+            // SAFETY: family is AF_INET and len covers a sockaddr_in.
+            let sin = unsafe { &*(storage as *const _ as *const libc::sockaddr_in) };
+            let ip = std::net::Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr));
+            let port = u16::from_be(sin.sin_port);
+            Some(SocketAddr::new(std::net::IpAddr::V4(ip), port))
+        }
+        libc::AF_INET6 => {
+            if (len as usize) < std::mem::size_of::<libc::sockaddr_in6>() {
+                return None;
+            }
+            // SAFETY: family is AF_INET6 and len covers a sockaddr_in6.
+            let sin6 = unsafe { &*(storage as *const _ as *const libc::sockaddr_in6) };
+            let ip = std::net::Ipv6Addr::from(sin6.sin6_addr.s6_addr);
+            let port = u16::from_be(sin6.sin6_port);
+            Some(SocketAddr::new(std::net::IpAddr::V6(ip), port))
+        }
+        _ => None,
+    }
+}
+
 /// Build + send a fresh initiation toward the peer endpoint. A send
 /// error is surfaced as an exception (the next tick retries); a missing
 /// session keeps the timer armed.
@@ -1033,6 +1215,7 @@ fn dispatch_inbound(
     tun: &mut std::fs::File,
     datagram: &[u8],
     from: SocketAddr,
+    outer_ecn: Option<u8>,
     decap_buf: &mut [u8],
     response_buf: &mut [u8],
     tunnel_name: &str,
@@ -1089,6 +1272,42 @@ fn dispatch_inbound(
         crate::afxdp::wg::WG_TYPE_DATA => {
             match engine.try_decap(datagram, decap_buf) {
                 Ok(outcome) => {
+                    // #2317: RFC 6040 §4.2 decap-side ECN combine. The
+                    // outer ECN was captured out-of-band via recvmsg's
+                    // IP_RECVTOS / IPV6_RECVTCLASS cmsg (the kernel UDP
+                    // stack stripped the outer IP header before this WG
+                    // record reached userspace). Fold it into the
+                    // freshly-decrypted inner IP packet: an outer CE
+                    // upgrades an ECN-capable inner to CE (recomputing the
+                    // inner IPv4 header checksum), and the illegal
+                    // outer-CE / inner-Not-ECT combination is dropped
+                    // (counter bumped in apply_decap_ecn_combine). Reuses
+                    // the GRE decap combine body, with the WG-specific
+                    // illegal-drop counter. Skipped when no TOS cmsg
+                    // arrived (`outer_ecn` is None) or the inner family is
+                    // unrecognizable — never mutate on a malformed inner.
+                    if let Some(outer_ecn) = outer_ecn {
+                        let inner = &mut decap_buf[..outcome.len];
+                        let inner_family = match inner.first().map(|b| b >> 4) {
+                            Some(4) => Some(libc::AF_INET as u8),
+                            Some(6) => Some(libc::AF_INET6 as u8),
+                            _ => None,
+                        };
+                        if let Some(fam) = inner_family
+                            && !crate::afxdp::gre::apply_decap_ecn_combine(
+                                inner,
+                                fam,
+                                outer_ecn,
+                                &crate::afxdp::gre::WG_DECAP_ECN_ILLEGAL_DROPS,
+                            )
+                        {
+                            // Illegal RFC 6040 §4.2 combination — drop the
+                            // inner without writing it to the TUN. The
+                            // datagram still authenticated (the peer holds
+                            // the keys), so endpoint-learning proceeds.
+                            return InboundOutcome::Authenticated(outcome.peer_pubkey);
+                        }
+                    }
                     // Write the plaintext inner IP to the wgN TUN; the
                     // kernel routes/firewalls it (NOT the AF_XDP policy
                     // engine — the AllowedIPs gate inside try_decap is
@@ -1508,5 +1727,171 @@ mod tests {
         // the old constant would have capped this at 1500.
         assert!(wg_inner_fits_outer_mtu(5000, false, 9000));
         assert!(!wg_inner_fits_outer_mtu(5000, false, 1500));
+    }
+
+    // =======================================================================
+    // #2317: recvmsg / cmsg outer-ECN capture + RFC 6040 §4.2 WG decap
+    // combine. The cmsg-parse tests build a synthetic control buffer with
+    // the real libc CMSG_* macros and feed it to the same
+    // `parse_outer_ecn_from_cmsg` the recv path uses, so the alignment +
+    // walk logic is exercised exactly as in production.
+    // =======================================================================
+
+    /// Build a `msghdr` whose msg_control holds a single cmsg of
+    /// `(level, ctype)` carrying the one-byte DS payload `ds`, and return
+    /// the parsed outer ECN. The cmsg buffer is leaked into a Vec the
+    /// caller keeps alive for the duration of the parse (the msghdr
+    /// borrows it).
+    fn parse_ecn_with_cmsg(level: libc::c_int, ctype: libc::c_int, ds: u8) -> Option<u8> {
+        unsafe {
+            // CMSG_SPACE(1) bytes hold a header + 1 padded payload byte.
+            let space = libc::CMSG_SPACE(1) as usize;
+            let mut buf = vec![0u8; space];
+            let mut msg: libc::msghdr = std::mem::zeroed();
+            msg.msg_control = buf.as_mut_ptr() as *mut libc::c_void;
+            msg.msg_controllen = space as _;
+            let cmsg = libc::CMSG_FIRSTHDR(&msg);
+            assert!(!cmsg.is_null(), "CMSG_FIRSTHDR null");
+            (*cmsg).cmsg_level = level;
+            (*cmsg).cmsg_type = ctype;
+            (*cmsg).cmsg_len = libc::CMSG_LEN(1) as _;
+            *libc::CMSG_DATA(cmsg) = ds;
+            // msg_controllen must reflect the actual bytes written for the
+            // walk to terminate correctly.
+            msg.msg_controllen = libc::CMSG_SPACE(1) as _;
+            parse_outer_ecn_from_cmsg(&msg)
+        }
+    }
+
+    #[test]
+    fn cmsg_parse_v4_ip_tos_extracts_ecn() {
+        // IPv4 IP_TOS cmsg: DS byte 0xB8 = EF (DSCP 46) + Not-ECT(00).
+        assert_eq!(
+            parse_ecn_with_cmsg(libc::IPPROTO_IP, libc::IP_TOS, 0xB8),
+            Some(0b00)
+        );
+        // DS byte with ECT(0) low bits: DSCP 0 + ECT(0)=0b10.
+        assert_eq!(
+            parse_ecn_with_cmsg(libc::IPPROTO_IP, libc::IP_TOS, 0b10),
+            Some(0b10)
+        );
+        // DS byte with CE low bits: AF41 (DSCP 34 << 2 = 0x88) | CE(0b11).
+        assert_eq!(
+            parse_ecn_with_cmsg(libc::IPPROTO_IP, libc::IP_TOS, 0x88 | 0b11),
+            Some(0b11)
+        );
+    }
+
+    #[test]
+    fn cmsg_parse_v6_tclass_extracts_ecn() {
+        // IPv6 IPV6_TCLASS cmsg: Traffic Class byte with ECT(1) low bits.
+        assert_eq!(
+            parse_ecn_with_cmsg(libc::IPPROTO_IPV6, libc::IPV6_TCLASS, 0b01),
+            Some(0b01)
+        );
+        // CE in the low 2 bits.
+        assert_eq!(
+            parse_ecn_with_cmsg(libc::IPPROTO_IPV6, libc::IPV6_TCLASS, 0xFF),
+            Some(0b11)
+        );
+    }
+
+    #[test]
+    fn cmsg_parse_ignores_unrelated_cmsg() {
+        // A non-TOS cmsg (e.g. SOL_SOCKET / SO_TIMESTAMP-shaped) yields no
+        // ECN — only IP_TOS / IPV6_TCLASS are honored.
+        assert_eq!(
+            parse_ecn_with_cmsg(libc::SOL_SOCKET, libc::SCM_RIGHTS, 0xFF),
+            None
+        );
+    }
+
+    #[test]
+    fn cmsg_parse_empty_control_yields_none() {
+        // No control buffer at all (kernel ignored the sockopt) → None,
+        // and the decap combine is skipped.
+        unsafe {
+            let mut msg: libc::msghdr = std::mem::zeroed();
+            msg.msg_control = std::ptr::null_mut();
+            msg.msg_controllen = 0;
+            assert_eq!(parse_outer_ecn_from_cmsg(&msg), None);
+        }
+    }
+
+    /// The WG decap site reuses the shared `apply_decap_ecn_combine`: an
+    /// outer CE over an ECN-capable IPv4 inner upgrades the inner to CE
+    /// and recomputes the IPv4 header checksum, and a LEGAL upgrade does
+    /// NOT touch the (per-tunnel) illegal-drop counter. A test-local
+    /// `AtomicU64` stands in for the counter so the strict delta is
+    /// deterministic regardless of concurrent tests touching the
+    /// process-global GRE/WG statics.
+    #[test]
+    fn wg_apply_combine_sets_ipv4_ce_and_recomputes_checksum() {
+        use crate::afxdp::gre::apply_decap_ecn_combine;
+        // Minimal 20-byte IPv4 header, DSCP 0 + ECT(0), valid checksum.
+        let mut inner = vec![0u8; 20];
+        inner[0] = 0x45; // version 4, IHL 5
+        inner[1] = 0b10; // DSCP 0, ECT(0)
+        inner[9] = PROTO_TCP;
+        let cs = crate::afxdp::frame::checksum16(&inner[..20]);
+        inner[10..12].copy_from_slice(&cs.to_be_bytes());
+        assert_eq!(crate::afxdp::frame::checksum16(&inner[..20]), 0);
+
+        let counter = AtomicU64::new(0);
+        let forward = apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, 0b11, &counter);
+        assert!(forward, "ECT inner + outer CE forwards after CE upgrade");
+        assert_eq!(inner[1] & 0x03, 0b11, "inner ECN upgraded to CE");
+        assert_eq!(inner[1] >> 2, 0, "inner DSCP untouched");
+        assert_eq!(
+            crate::afxdp::frame::checksum16(&inner[..20]),
+            0,
+            "IPv4 header checksum recomputed after the TOS change"
+        );
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "a legal CE upgrade must not bump the illegal-drop counter"
+        );
+    }
+
+    /// The illegal §4.2 combo (outer CE over a Not-ECT inner) DROPS and
+    /// bumps the passed counter exactly once. The WG production wiring
+    /// passes `WG_DECAP_ECN_ILLEGAL_DROPS` (asserted separately below with
+    /// a concurrency-tolerant `>=` check); the strict +1 is verified on a
+    /// test-local atomic so it is deterministic under parallel tests.
+    #[test]
+    fn wg_apply_combine_drops_illegal_combo_and_counts() {
+        use crate::afxdp::gre::{apply_decap_ecn_combine, WG_DECAP_ECN_ILLEGAL_DROPS};
+        let mut inner = vec![0u8; 20];
+        inner[0] = 0x45;
+        inner[1] = 0x88; // AF41 (DSCP 34), ECN Not-ECT(00)
+
+        // Strict +1 on an isolated counter — deterministic.
+        let counter = AtomicU64::new(0);
+        let forward = apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, 0b11, &counter);
+        assert!(!forward, "outer CE over a Not-ECT inner must DROP (§4.2)");
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            1,
+            "the illegal combo must bump the passed counter exactly once"
+        );
+
+        // Production wiring: the WG global advances (>= because other
+        // parallel tests may also bump it). Proves the WG path routes to
+        // the WG counter, not just an arbitrary one.
+        let wg_before = WG_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed);
+        let mut inner2 = vec![0u8; 20];
+        inner2[0] = 0x45;
+        inner2[1] = 0x88;
+        assert!(!apply_decap_ecn_combine(
+            &mut inner2,
+            libc::AF_INET as u8,
+            0b11,
+            &WG_DECAP_ECN_ILLEGAL_DROPS,
+        ));
+        assert!(
+            WG_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed) >= wg_before + 1,
+            "the WG global illegal-drop counter must advance on the WG path"
+        );
     }
 }

--- a/userspace-dp/src/afxdp/coordinator/wg_control.rs
+++ b/userspace-dp/src/afxdp/coordinator/wg_control.rs
@@ -1009,28 +1009,48 @@ fn wg_send_to(
 /// v6 peers. Best-effort: a failure is logged via the return value being
 /// ignored by the caller — the combine is simply skipped when no cmsg
 /// arrives, which is the pre-#2317 behavior, so this is never fatal.
+/// #2317: enable outer-TOS ancillary delivery (`IP_RECVTOS` /
+/// `IPV6_RECVTCLASS`) on a WG UDP socket so the decap ECN combine can see
+/// the outer DS byte the kernel UDP stack otherwise strips. Best-effort:
+/// a kernel that rejects the sockopt (very old, or a restricted sandbox)
+/// simply delivers no TOS cmsg and the combine is skipped (outer_ecn =
+/// None). A failure is logged once here — this runs only at socket
+/// creation, never on the packet path — so an operator can see why ECN
+/// propagation is inactive.
 fn set_recv_tos_options(fd: i32, socket_is_v6: bool) {
     let on: libc::c_int = 1;
     // IP_RECVTOS — outer IPv4 TOS (also delivered for v4-mapped peers on
     // the dual-stack socket).
-    unsafe {
+    let rc = unsafe {
         libc::setsockopt(
             fd,
             libc::IPPROTO_IP,
             libc::IP_RECVTOS,
             &on as *const _ as *const libc::c_void,
             std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if rc != 0 {
+        eprintln!(
+            "xpf-wg: IP_RECVTOS not enabled (fd {fd}): {} — decap ECN combine inactive for v4",
+            io::Error::last_os_error()
         );
     }
     if socket_is_v6 {
         // IPV6_RECVTCLASS — outer IPv6 Traffic Class for native v6 peers.
-        unsafe {
+        let rc6 = unsafe {
             libc::setsockopt(
                 fd,
                 libc::IPPROTO_IPV6,
                 libc::IPV6_RECVTCLASS,
                 &on as *const _ as *const libc::c_void,
                 std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+        if rc6 != 0 {
+            eprintln!(
+                "xpf-wg: IPV6_RECVTCLASS not enabled (fd {fd}): {} — decap ECN combine inactive for v6",
+                io::Error::last_os_error()
             );
         }
     }
@@ -1081,7 +1101,16 @@ fn wg_recvmsg(socket: &UdpSocket, buf: &mut [u8]) -> io::Result<WgRecv> {
     let len = n as usize;
     let from = sockaddr_storage_to_socketaddr(&storage, msg.msg_namelen)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "recvmsg bad sockaddr"))?;
-    let outer_ecn = parse_outer_ecn_from_cmsg(&msg);
+    // If the kernel truncated the ancillary data (MSG_CTRUNC), the cmsg
+    // chain may be incomplete — don't trust it for the best-effort ECN.
+    // The 256-byte control buffer is sized so this never triggers for a
+    // single ~20-byte TOS cmsg, but skip defensively rather than walk a
+    // partial chain (worst case: the decap combine is skipped this once).
+    let outer_ecn = if msg.msg_flags & libc::MSG_CTRUNC != 0 {
+        None
+    } else {
+        parse_outer_ecn_from_cmsg(&msg)
+    };
     Ok(WgRecv {
         len,
         from,
@@ -1113,11 +1142,14 @@ fn parse_outer_ecn_from_cmsg(msg: &libc::msghdr) -> Option<u8> {
             let is_v6_tclass = level == libc::IPPROTO_IPV6 && ctype == libc::IPV6_TCLASS;
             if is_v4_tos || is_v6_tclass {
                 let data = libc::CMSG_DATA(cmsg);
-                // cmsg_len includes the header; payload length is the
-                // remainder. Require at least one byte of payload.
-                let payload_len =
-                    (*cmsg).cmsg_len as usize - (libc::CMSG_DATA(cmsg) as usize - cmsg as usize);
-                if payload_len >= 1 {
+                // cmsg_len includes the header; the payload starts at
+                // CMSG_DATA. Guard with `>=` against a malformed/truncated
+                // cmsg_len shorter than the header offset (a raw
+                // subtraction would underflow the unsigned length): require
+                // cmsg_len to cover the header plus at least one payload
+                // byte before reading the DS byte.
+                let data_off = data as usize - cmsg as usize;
+                if (*cmsg).cmsg_len as usize >= data_off + 1 {
                     let ds = *data;
                     return Some(ds & 0x03);
                 }

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -94,6 +94,19 @@ pub(in crate::afxdp) fn packet_trimmed_len(packet: &[u8], addr_family: u8) -> Op
 /// the bogus CE — would silently hide the protocol violation).
 pub(in crate::afxdp) static GRE_DECAP_ECN_ILLEGAL_DROPS: AtomicU64 = AtomicU64::new(0);
 
+/// #2317: count of WireGuard-decap inner packets DROPPED by the same
+/// RFC 6040 §4.2 combine, for the WG path. Separate from the GRE
+/// counter so the two tunnel families are independently observable.
+/// Surfaced via `coordinator/status.rs` as
+/// `xpf_userspace_wg_decap_ecn_illegal_drops_total`. The WG decap path
+/// captures the outer ECN out-of-band (the kernel UDP socket strips the
+/// outer IP header before userspace, so the bits arrive as `IP_RECVTOS`
+/// / `IPV6_RECVTCLASS` ancillary data on `recvmsg` — see
+/// `coordinator/wg_control.rs`) and feeds it into the SAME
+/// `apply_decap_ecn_combine` below. A nonzero value means a misbehaving
+/// WG ingress / congested path CE-marked the outer of a Not-ECT inner.
+pub(in crate::afxdp) static WG_DECAP_ECN_ILLEGAL_DROPS: AtomicU64 = AtomicU64::new(0);
+
 /// Read the inner IP packet's DSCP+ECN byte for outer-header
 /// propagation on tunnel encap (#2303). Returns the full 8-bit
 /// TOS / Traffic-Class value (DSCP in the high 6 bits, ECN in the
@@ -275,11 +288,16 @@ pub(in crate::afxdp) fn decap_ecn_combine(inner_ecn: u8, outer_ecn: u8) -> Decap
 /// header checksum but NOT by the L4 checksum). IPv6 inners have no IP
 /// header checksum, and the IPv6 Traffic Class is not covered by the L4
 /// pseudo-header, so no checksum work is needed.
+///
+/// `illegal_drops` is the per-tunnel-family drop counter bumped on the
+/// illegal §4.2 combination (GRE and WG keep independent counters,
+/// #2315 / #2317), so this one body is shared by both decap paths.
 #[inline]
 pub(in crate::afxdp) fn apply_decap_ecn_combine(
     inner_packet: &mut [u8],
     inner_family: u8,
     outer_ecn: u8,
+    illegal_drops: &AtomicU64,
 ) -> bool {
     match inner_family as i32 {
         libc::AF_INET => {
@@ -292,7 +310,7 @@ pub(in crate::afxdp) fn apply_decap_ecn_combine(
             match decap_ecn_combine(ecn_of_tos(tos), outer_ecn) {
                 DecapEcn::Keep => true,
                 DecapEcn::Drop => {
-                    GRE_DECAP_ECN_ILLEGAL_DROPS.fetch_add(1, Ordering::Relaxed);
+                    illegal_drops.fetch_add(1, Ordering::Relaxed);
                     false
                 }
                 DecapEcn::SetCe => {
@@ -313,7 +331,7 @@ pub(in crate::afxdp) fn apply_decap_ecn_combine(
             match decap_ecn_combine(inner_ecn, outer_ecn) {
                 DecapEcn::Keep => true,
                 DecapEcn::Drop => {
-                    GRE_DECAP_ECN_ILLEGAL_DROPS.fetch_add(1, Ordering::Relaxed);
+                    illegal_drops.fetch_add(1, Ordering::Relaxed);
                     false
                 }
                 DecapEcn::SetCe => {
@@ -524,7 +542,12 @@ pub(super) fn try_native_gre_decap_from_frame(
     // recomputes the inner IPv4 header checksum when CE is set. Skipped
     // when the outer header is truncated (`outer_ecn_bits` → None).
     if let Some(outer_ecn) = outer_ecn_bits(frame, meta)
-        && !apply_decap_ecn_combine(&mut synthetic[14..], inner_family, outer_ecn)
+        && !apply_decap_ecn_combine(
+            &mut synthetic[14..],
+            inner_family,
+            outer_ecn,
+            &GRE_DECAP_ECN_ILLEGAL_DROPS,
+        )
     {
         // Illegal RFC 6040 §4.2 combination — drop (counter bumped in
         // apply_decap_ecn_combine).

--- a/userspace-dp/src/afxdp/tunnel_tests.rs
+++ b/userspace-dp/src/afxdp/tunnel_tests.rs
@@ -466,7 +466,9 @@ fn apply_decap_combine_sets_ipv4_ce_and_recomputes_checksum() {
     // Inner IPv4, ECT(0), valid checksum. Outer CE → inner must become
     // CE and the IPv4 header checksum must stay valid after the TOS
     // byte changed.
-    let before = GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed);
+    // Test-local counter so the "must not bump" assertion is
+    // deterministic regardless of parallel tests touching the global.
+    let counter = AtomicU64::new(0);
     let mut inner = inner_ipv4_with_tos((0u8 << 2) | ECT_0); // DSCP 0, ECT(0)
     // Seed a correct checksum for the starting header.
     inner[10] = 0;
@@ -475,7 +477,7 @@ fn apply_decap_combine_sets_ipv4_ce_and_recomputes_checksum() {
     inner[10..12].copy_from_slice(&cs.to_be_bytes());
     assert!(ipv4_header_checksum_ok(&inner), "fixture must start valid");
 
-    let forward = apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, CE);
+    let forward = apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, CE, &counter);
     assert!(forward, "ECT inner + outer CE forwards (after CE upgrade)");
     assert_eq!(inner[1] & 0x03, CE, "inner ECN must be upgraded to CE");
     assert_eq!(inner[1] >> 2, 0, "inner DSCP must be untouched (was 0)");
@@ -484,8 +486,8 @@ fn apply_decap_combine_sets_ipv4_ce_and_recomputes_checksum() {
         "IPv4 header checksum must be recomputed after the TOS change"
     );
     assert_eq!(
-        GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed),
-        before,
+        counter.load(Ordering::Relaxed),
+        0,
         "a legal upgrade must not bump the illegal-drop counter"
     );
 }
@@ -499,7 +501,12 @@ fn apply_decap_combine_preserves_dscp_on_ce_upgrade() {
     let cs = crate::afxdp::frame::checksum16(&inner[..20]);
     inner[10..12].copy_from_slice(&cs.to_be_bytes());
 
-    assert!(apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, CE));
+    assert!(apply_decap_ecn_combine(
+        &mut inner,
+        libc::AF_INET as u8,
+        CE,
+        &GRE_DECAP_ECN_ILLEGAL_DROPS,
+    ));
     assert_eq!(inner[1] >> 2, 46, "DSCP (EF) must survive the CE upgrade");
     assert_eq!(inner[1] & 0x03, CE);
     assert!(ipv4_header_checksum_ok(&inner));
@@ -510,12 +517,19 @@ fn apply_decap_combine_drops_illegal_ipv4_combo_and_counts() {
     // Inner Not-ECT + outer CE → drop + counter bump.
     let before = GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed);
     let mut inner = inner_ipv4_with_tos((34u8 << 2) | NOT_ECT); // AF41, Not-ECT
-    let forward = apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, CE);
+    let forward = apply_decap_ecn_combine(
+        &mut inner,
+        libc::AF_INET as u8,
+        CE,
+        &GRE_DECAP_ECN_ILLEGAL_DROPS,
+    );
     assert!(!forward, "outer CE over a Not-ECT inner must DROP (§4.2)");
-    assert_eq!(
-        GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed),
-        before + 1,
-        "the illegal-combo drop must bump the counter"
+    // `>=` not `== before + 1`: GRE_DECAP_ECN_ILLEGAL_DROPS is a
+    // process-global static and other parallel tests (the IPv6 drop test,
+    // the WG-wiring test) may bump it between the snapshots.
+    assert!(
+        GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed) >= before + 1,
+        "the illegal-combo drop must advance the counter"
     );
 }
 
@@ -530,7 +544,12 @@ fn apply_decap_combine_keeps_inner_when_outer_not_congested() {
     inner[10..12].copy_from_slice(&cs.to_be_bytes());
     let snapshot = inner.clone();
 
-    assert!(apply_decap_ecn_combine(&mut inner, libc::AF_INET as u8, NOT_ECT));
+    assert!(apply_decap_ecn_combine(
+        &mut inner,
+        libc::AF_INET as u8,
+        NOT_ECT,
+        &GRE_DECAP_ECN_ILLEGAL_DROPS,
+    ));
     assert_eq!(
         inner, snapshot,
         "outer Not-ECT must leave the inner byte-for-byte unchanged"
@@ -549,7 +568,12 @@ fn apply_decap_combine_sets_ipv6_ce_without_checksum() {
     v6[1] = ECT_0 << 4; // ECN = ECT(0) in the high nibble of octet 1
     let snapshot_octet0 = v6[0];
 
-    assert!(apply_decap_ecn_combine(&mut v6, libc::AF_INET6 as u8, CE));
+    assert!(apply_decap_ecn_combine(
+        &mut v6,
+        libc::AF_INET6 as u8,
+        CE,
+        &GRE_DECAP_ECN_ILLEGAL_DROPS,
+    ));
     // ECN = (octet1 >> 4) & 0x03 must be CE.
     assert_eq!((v6[1] >> 4) & 0x03, CE, "inner IPv6 ECN must become CE");
     assert_eq!(
@@ -564,20 +588,29 @@ fn apply_decap_combine_drops_illegal_ipv6_combo_and_counts() {
     let mut v6 = vec![0u8; 40];
     v6[0] = 0x60;
     v6[1] = (NOT_ECT) << 4; // inner Not-ECT
-    assert!(!apply_decap_ecn_combine(&mut v6, libc::AF_INET6 as u8, CE));
-    assert_eq!(
-        GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed),
-        before + 1
-    );
+    assert!(!apply_decap_ecn_combine(
+        &mut v6,
+        libc::AF_INET6 as u8,
+        CE,
+        &GRE_DECAP_ECN_ILLEGAL_DROPS,
+    ));
+    // `>=`: process-global static; parallel tests may also bump it.
+    assert!(GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed) >= before + 1);
 }
 
 #[test]
 fn apply_decap_combine_short_packet_forwards_unchanged() {
     // Too short to hold the TOS byte: forward, never panic, no counter.
-    let before = GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed);
+    // Test-local counter so the "no bump" assertion is deterministic.
+    let counter = AtomicU64::new(0);
     let mut tiny = vec![0x45u8]; // 1 byte
-    assert!(apply_decap_ecn_combine(&mut tiny, libc::AF_INET as u8, CE));
-    assert_eq!(GRE_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed), before);
+    assert!(apply_decap_ecn_combine(
+        &mut tiny,
+        libc::AF_INET as u8,
+        CE,
+        &counter,
+    ));
+    assert_eq!(counter.load(Ordering::Relaxed), 0);
 }
 
 // --- #2299 WG SYN MSS clamp uses the WG-overhead formula --------------

--- a/userspace-dp/src/afxdp/wg/dscp.rs
+++ b/userspace-dp/src/afxdp/wg/dscp.rs
@@ -15,14 +15,20 @@
 //! helper remains for the DSCP-only case (a config-set DSCP value with
 //! no inner-packet ECN to carry).
 //!
-//! NOTE (#2315): the complementary DECAP-side RFC 6040 §4.2 ECN
+//! NOTE (#2315/#2317): the complementary DECAP-side RFC 6040 §4.2 ECN
 //! *combine* (outer ECN → inner ECN — the half that reflects a CE mark
-//! back to the inner endpoints) is implemented for the GRE decap path
-//! only (`crate::afxdp::gre::apply_decap_ecn_combine`). The WG decap
-//! path reads transport records from a plain `UdpSocket::recv_from`, so
-//! the kernel strips the outer IP header (and its ECN) before userspace
-//! sees the datagram; the WG decap combine is a tracked follow-up
-//! (#2317) gated on `IP_RECVTOS`/`IPV6_RECVTCLASS` + `recvmsg`.
+//! back to the inner endpoints) is implemented for BOTH tunnel paths via
+//! the shared `crate::afxdp::gre::apply_decap_ecn_combine`. The GRE path
+//! reads the outer ECN from the still-present outer IP header in the
+//! frame (#2315). The WG control thread reads transport records from a
+//! kernel `UdpSocket`, which strips the outer IP header (and its ECN)
+//! before userspace sees the datagram; #2317 captures the outer ECN
+//! out-of-band via `recvmsg` + `IP_RECVTOS` (v4 / v4-mapped) /
+//! `IPV6_RECVTCLASS` (v6) ancillary data and feeds it into the same
+//! combine after WG-decrypt, before the inner packet is written to the
+//! wgN TUN (see `crate::afxdp::coordinator::wg_control`). The two
+//! tunnel families keep independent illegal-combination drop counters
+//! (`GRE_DECAP_ECN_ILLEGAL_DROPS` / `WG_DECAP_ECN_ILLEGAL_DROPS`).
 
 /// Build the outer IPv4 TOS / IPv6 Traffic Class byte from a
 /// 6-bit DSCP value. ECN bits are cleared (use

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -244,6 +244,17 @@ pub(crate) struct ProcessStatus {
     /// Additive / defaulted for backward compatibility.
     #[serde(rename = "gre_decap_ecn_illegal_drops_total", default)]
     pub gre_decap_ecn_illegal_drops_total: u64,
+    /// #2317: WireGuard-decap inner packets dropped by the SAME RFC 6040
+    /// §4.2 decap-side ECN combine, for the WG path. The WG decap site
+    /// captures the outer ECN out-of-band via `recvmsg` +
+    /// `IP_RECVTOS`/`IPV6_RECVTCLASS` (the kernel UDP socket strips the
+    /// outer IP header before userspace) and feeds it into the same
+    /// combine. Surfaced as the Prometheus counter
+    /// `xpf_userspace_wg_decap_ecn_illegal_drops_total`; nonzero flags a
+    /// misbehaving WG ingress on a congested path. Additive / defaulted
+    /// for backward compatibility.
+    #[serde(rename = "wg_decap_ecn_illegal_drops_total", default)]
+    pub wg_decap_ecn_illegal_drops_total: u64,
     /// #1782 cold-start capture instrumentation. Debug dump of every key
     /// present in the userspace `dynamic_neighbors` mirror, rendered as
     /// `"ifindex ip"` strings. The capture harness greps this at the

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -191,6 +191,35 @@ fn process_status_gre_decap_ecn_illegal_drops_roundtrip() {
     assert_eq!(legacy.gre_decap_ecn_illegal_drops_total, 0);
 }
 
+// #2317: round-trip + backward-compat pin for the WG-decap RFC 6040
+// §4.2 illegal-combination drop counter. The wire key feeds
+// pkg/dataplane/userspace/protocol.go and the Prometheus counter
+// `xpf_userspace_wg_decap_ecn_illegal_drops_total`.
+#[test]
+fn process_status_wg_decap_ecn_illegal_drops_roundtrip() {
+    let status = ProcessStatus {
+        wg_decap_ecn_illegal_drops_total: 7,
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize ProcessStatus to Value");
+    assert_eq!(value["wg_decap_ecn_illegal_drops_total"], 7);
+    let back: ProcessStatus = serde_json::from_value(value).expect("deserialize ProcessStatus");
+    assert_eq!(back.wg_decap_ecn_illegal_drops_total, 7);
+
+    // Pre-#2317 payload (key absent) must decode with a zero default.
+    let mut legacy_value =
+        serde_json::to_value(ProcessStatus::default()).expect("serialize default ProcessStatus");
+    legacy_value
+        .as_object_mut()
+        .expect("ProcessStatus serializes to an object")
+        .remove("wg_decap_ecn_illegal_drops_total")
+        .expect("new key present before strip");
+    let legacy: ProcessStatus =
+        serde_json::from_value(legacy_value).expect("pre-#2317 payload decodes");
+    assert_eq!(legacy.wg_decap_ecn_illegal_drops_total, 0);
+}
+
 // #1760 W3': round-trip + backward-compat pin for the shared-map NAT
 // reverse-key displacement counter. The wire key feeds
 // pkg/dataplane/userspace/protocol.go and the Prometheus counter

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -87,6 +87,12 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     // ECT-marked the outer for un-ECN inner traffic on a congested path.
     state.status.gre_decap_ecn_illegal_drops_total =
         state.afxdp.gre_decap_ecn_illegal_drops_total();
+    // #2317: WG-decap RFC 6040 §4.2 illegal-combination drops (outer CE,
+    // captured via recvmsg IP_RECVTOS/IPV6_RECVTCLASS, over a Not-ECT
+    // inner). Nonzero = a misbehaving WG ingress CE-marked the outer for
+    // un-ECN inner traffic on a congested path.
+    state.status.wg_decap_ecn_illegal_drops_total =
+        state.afxdp.wg_decap_ecn_illegal_drops_total();
     // The per-key dynamic_neighbors dump is a high-cardinality
     // (ifindex,ip)-labelled debug surface used only by the #1782 cold-start
     // capture. Gate it behind XPF_DEBUG_NEIGHBOR_KEYS so it is OFF by default:

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -116,6 +116,7 @@ pub(crate) fn run() -> Result<(), String> {
             nat_reverse_key_shared_displacements_total: 0,
             worker_command_queue_poison_recoveries: 0,
             gre_decap_ecn_illegal_drops_total: 0,
+            wg_decap_ecn_illegal_drops_total: 0,
             dynamic_neighbor_keys: Vec::new(),
             neighbor_resolver_queue_depth: 0,
             neighbor_resolver_enqueue_drops_total: 0,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -831,6 +831,7 @@
     "started_at": "1970-01-01T00:00:00Z",
     "state_file": "",
     "three_color_policer_counters": [],
+    "wg_decap_ecn_illegal_drops_total": 0,
     "worker_command_queue_poison_recoveries": 0,
     "worker_heartbeats": [],
     "worker_runtime": [],


### PR DESCRIPTION
Closes #2317

## Summary

Implements the WireGuard DECAP-side RFC 6040 §4.2 ECN combine
(outer ECN → inner ECN), completing the half #2315 deferred for the WG
path. #2315 shipped the §4.2 combine for GRE and deferred WG because the
WG control thread reads encrypted transport records from a kernel
`std::net::UdpSocket`, so the kernel strips the outer IP header (and its
ECN/TOS) before the bytes reach userspace — userspace never saw the outer
ECN to combine into the decrypted inner packet.

## What changed

**Capture the outer ECN via recvmsg + cmsg.** The WG recv loop
(`coordinator/wg_control.rs`, the burst at the former
`socket.recv_from(&mut sock_buf)` call site) switches to `recvmsg` using
**libc** directly — `socket2`/`nix` are not dependencies, only `libc =
"0.2"` is, so no new crate. The listen socket enables `IP_RECVTOS` (v4 /
v4-mapped) and `IPV6_RECVTCLASS` (native v6 on the dual-stack socket) at
bind. The outer DS byte then arrives as an `IP_TOS` / `IPV6_TCLASS`
ancillary control message; `parse_outer_ecn_from_cmsg` walks the cmsg
chain with the libc `CMSG_*` macros and extracts `ECN = ds & 0x03`.
Capture is **best-effort**: no cmsg (kernel ignored the sockopt) ⇒ the
combine is skipped (pre-#2317 behavior), never fatal to the tunnel.

**Apply the §4.2 combine, reusing gre.rs.** The captured `Option<u8>`
outer ECN threads `wg_recvmsg → dispatch_inbound → WG_TYPE_DATA arm`,
where after `engine.try_decap` produces the inner IP packet and before
`tun.write_all` it is folded in via the **shared**
`gre::apply_decap_ecn_combine`. That function is refactored to take the
per-tunnel-family illegal-drop counter by `&AtomicU64`, so the §4.2 table
+ IPv4 inner-header-checksum recompute stay single-sourced across GRE and
WG (no duplication). Outer CE upgrades an ECN-capable inner to CE
(recomputing the IPv4 header checksum); the illegal outer-CE /
inner-Not-ECT combo is dropped without writing the inner to the TUN (the
datagram still authenticated, so endpoint-learning proceeds); everything
else keeps the inner verbatim.

**New counter.** `WG_DECAP_ECN_ILLEGAL_DROPS` — a sibling of
`GRE_DECAP_ECN_ILLEGAL_DROPS` so the two families are independently
observable — wired end-to-end mirroring the GRE metric: atomic →
`coordinator/status.rs` accessor → protocol `ProcessStatus`
(`wg_decap_ecn_illegal_drops_total`, serde-`default` for wire compat) →
server helpers/lifecycle → Go `pkg/dataplane/userspace/protocol.go` →
Prometheus **`xpf_userspace_wg_decap_ecn_illegal_drops_total`**. The wire
fixture `protocol_wire_v1.json` is regenerated (one new key).

## Tests

- `cmsg_parse_v4_ip_tos_extracts_ecn`, `cmsg_parse_v6_tclass_extracts_ecn`,
  `cmsg_parse_ignores_unrelated_cmsg`, `cmsg_parse_empty_control_yields_none`
  — synthetic cmsg buffers built with the real `CMSG_*` macros for v4/v6
  and the negative cases.
- `wg_apply_combine_sets_ipv4_ce_and_recomputes_checksum`,
  `wg_apply_combine_drops_illegal_combo_and_counts` — CE upgrade + IPv4
  checksum validity + illegal-combo drop+count on the WG path.
- `process_status_wg_decap_ecn_illegal_drops_roundtrip` — wire round-trip
  + backward-compat (key-absent decodes to 0).
- Go `pkg/api` — descriptor coverage list + the emit/`assertCounterClose`
  assertion for the new Prometheus series.
- The existing §4.2 combine **table** tests (`rfc6040_combine_*`,
  `apply_decap_combine_*`) already cover the shared `decap_ecn_combine` /
  `apply_decap_ecn_combine` and were updated for the new counter arg;
  their shared-global counter asserts (and the new WG ones) were hardened
  onto test-local atomics so they are deterministic under parallel runs.

`cargo build --release` clean; `cargo test --release -- wg ecn decap
recvmsg tclass` 229/0 and the new tests 5× green; `go build ./...` +
`go test ./pkg/api/... ./pkg/dataplane/userspace/...` green.

## Lab-deferred

Live end-to-end ECN verification (a real WG peer marking CE on the outer
→ CE propagating to the decrypted inner) is **lab-bound and deferred to
#1703-class interop**. The code path and the unit tests above are the
deliverable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)