### PR TITLE
#2325: gate PTB generation on the L2 broadcast/multicast destination

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -10274,3 +10274,26 @@ top.
   pkg/dataplane/userspace/format/status_test.go,
   pkg/api/metrics_userspace.go,
   userspace-dp/src/afxdp/event_emit.rs, _Log.md
+
+- **Timestamp**: 2026-06-22
+  **Action**: #2325 — add the L2 (link-layer) destination broadcast/multicast
+  suppression gate to the PTB / Frag-Needed generation path so it has the same
+  L2+L3 suppression the reject / Time-Exceeded path already had. RFC 1812
+  §4.3.2.7 / RFC 4443 §2.4(e): an ICMP error MUST NOT be generated for a
+  datagram delivered as a link-layer broadcast/multicast. Before, a frame with
+  a UNICAST L3 dst but a multicast/broadcast L2 dst MAC still triggered a PTB.
+  Extracted the inline L2 test from `can_generate_icmp_error_reply` (icmp.rs)
+  into a shared `l2_dst_is_group_or_broadcast(eth_dst: &[u8;6])` helper in
+  frame/inspect.rs (IEEE I/G group bit = low bit of first MAC octet; all-FF
+  broadcast is a group address) and call it from BOTH the reject/TE path and
+  `ptb_reply_suppressed` (icmp_ptb.rs). The PTB site already had the full
+  trigger ethernet frame (`source_frame`), so no plumbing was needed — the L2
+  dst is the first 6 frame bytes. Added fail-on-revert tests (PTB suppressed
+  for L2 multicast v4/v6 + L2 broadcast, still generated for unicast L2/L3,
+  plus a direct helper unit test). Build clean; targeted tests 5x green;
+  verified the suppression tests turn red when the gate is removed.
+  **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+  userspace-dp/src/afxdp/frame/mod.rs, userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/icmp_ptb.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs,
+  userspace-dp/src/afxdp/README.md, _Log.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -89,9 +89,15 @@ sync.
   (RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e)), sharing the
   `dest_is_multicast_or_broadcast` predicate (`frame/inspect.rs`) with
   `icmp.rs`'s `can_generate_icmp_error_reply` so the PTB, reject, and
-  Time Exceeded paths agree. No new counter: a suppressed PTB is folded
-  into the existing fail-closed silent-drop path (the oversized original
-  is still dropped via `mtu_signalled`).
+  Time Exceeded paths agree on the L3 destination test. #2325: the same
+  gate now also drops PTBs triggered by a datagram delivered as a
+  link-layer (L2) broadcast/multicast frame, giving the PTB path the same
+  L2+L3 suppression the reject / Time-Exceeded path already had — both
+  call the shared `l2_dst_is_group_or_broadcast` predicate
+  (`frame/inspect.rs`, the IEEE I/G group bit on the destination MAC's
+  first octet; all-FF broadcast is a group address). No new counter: a
+  suppressed PTB is folded into the existing fail-closed silent-drop path
+  (the oversized original is still dropped via `mtu_signalled`).
 - `cos/` — Class-of-Service scheduler: token-bucket admission, MQFQ
   active-bucket selection, fair-share lease (#1229 Phase 6 v8). See
   `docs/per-5-tuple/state.md` for the architectural ceiling.

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -356,6 +356,28 @@ pub(in crate::afxdp) fn dest_is_multicast_or_broadcast(addr_family: u8, packet: 
     }
 }
 
+/// #2325: RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a router MUST NOT
+/// originate an ICMP/ICMPv6 *error* in reply to a datagram that was
+/// delivered as a link-layer (L2) broadcast or multicast. The IEEE 802
+/// group (I/G) bit is the low bit of the first MAC octet; the all-ones
+/// MAC (broadcast) is a special case of group, so a single bit test on
+/// the first destination-MAC octet covers both. This is the L2 sibling
+/// of [`dest_is_multicast_or_broadcast`] (the L3 destination test) and
+/// is shared by the reject / Time-Exceeded path
+/// (`can_generate_icmp_error_reply`) and the PTB path
+/// (`ptb_reply_suppressed`) so both apply the same L2+L3 suppression.
+///
+/// Takes the trigger frame's 6-byte destination MAC. Returns `true` when
+/// the L2 destination is group/broadcast and the ICMP error MUST be
+/// suppressed.
+#[inline]
+pub(in crate::afxdp) fn l2_dst_is_group_or_broadcast(eth_dst: &[u8; 6]) -> bool {
+    // The low bit of the first MAC octet is the I/G (group) bit; the
+    // all-ones MAC is broadcast (a group address). A single bit test
+    // catches both.
+    (eth_dst[0] & 0x01) != 0
+}
+
 pub(in crate::afxdp) fn metadata_tuple_complete(meta: UserspaceDpMeta, flow: &SessionFlow) -> bool {
     if flow.src_ip.is_unspecified() || flow.dst_ip.is_unspecified() {
         return false;

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -55,7 +55,7 @@ pub(in crate::afxdp) use checksum::{
 pub(in crate::afxdp) use inspect::{
     authoritative_forward_ports, decode_frame_summary, dest_is_multicast_or_broadcast,
     forward_tuple_mismatch_reason, ipv4_is_non_first_fragment, ipv6_is_non_first_fragment,
-    is_non_first_fragment, parse_session_flow, try_parse_metadata,
+    is_non_first_fragment, l2_dst_is_group_or_broadcast, parse_session_flow, try_parse_metadata,
 };
 pub(super) use inspect::{
     MAX_IPV6_EXT_HEADERS, frame_l3_offset, frame_l4_offset, live_frame_ports, live_frame_ports_bytes,

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -41,11 +41,13 @@ pub(super) fn can_generate_icmp_error_reply(frame: &[u8], meta: UserspaceDpMeta)
     };
 
     // (c) L2 destination: never reply to a broadcast/multicast frame.
-    // The low bit of the first MAC octet is the I/G (group) bit; the
-    // all-ones MAC is broadcast (a special case of group). frame[0]
-    // exists because frame_l3_offset/the 14|18 match imply >= 14 bytes.
-    if let Some(&l2_dst0) = frame.first()
-        && (l2_dst0 & 0x01) != 0
+    // The destination MAC is the first 6 frame bytes (present because
+    // frame_l3_offset / the 14|18 match imply >= 14 bytes). Routes
+    // through the shared #2325 predicate so the PTB and reject/TE paths
+    // agree on the L2 group/broadcast test.
+    if let Some(eth_dst) = frame.get(0..6)
+        && let Ok(eth_dst) = <&[u8; 6]>::try_from(eth_dst)
+        && l2_dst_is_group_or_broadcast(eth_dst)
     {
         return false;
     }

--- a/userspace-dp/src/afxdp/icmp_ptb.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb.rs
@@ -118,17 +118,32 @@ fn ipv4_df_set(packet: &[u8]) -> bool {
 
 /// RFC error-suppression gate shared by the PTB path. Mirrors the reject
 /// path: never reply to a non-first fragment (no transport header to quote
-/// / key), to a trigger packet whose destination was multicast/broadcast
-/// (RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e), #2314 — a multicast flood must
-/// not be amplified into an ICMP-error backscatter storm), or to an
-/// inbound ICMP/ICMPv6 *error* message (avoid error loops and
-/// amplification). Returns true when a PTB MUST be suppressed.
+/// / key), to a trigger frame whose link-layer (L2) destination was
+/// group/broadcast (RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e), #2325 — a
+/// datagram delivered as an L2 broadcast/multicast must not generate an
+/// error), to a trigger packet whose IP (L3) destination was
+/// multicast/broadcast (#2314 — a multicast flood must not be amplified
+/// into an ICMP-error backscatter storm), or to an inbound ICMP/ICMPv6
+/// *error* message (avoid error loops and amplification). Returns true
+/// when a PTB MUST be suppressed.
 #[inline]
 pub(in crate::afxdp) fn ptb_reply_suppressed(
     frame: &[u8],
     meta: UserspaceDpMeta,
     l3_offset: usize,
 ) -> bool {
+    // #2325: never generate a PTB in reply to a datagram delivered as an
+    // L2 broadcast/multicast frame. This gives the PTB path the same L2
+    // suppression that the reject / Time-Exceeded path
+    // (`can_generate_icmp_error_reply`) has. `frame` is the full trigger
+    // ethernet frame (the same slice the PTB builders read the reflected
+    // destination MAC from), so the L2 dst is the first 6 bytes.
+    if let Some(eth_dst) = frame.get(0..6)
+        && let Ok(eth_dst) = <&[u8; 6]>::try_from(eth_dst)
+        && l2_dst_is_group_or_broadcast(eth_dst)
+    {
+        return true;
+    }
     let Some(packet) = frame.get(l3_offset..) else {
         return true;
     };

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -417,6 +417,98 @@ fn ptb_still_generated_for_v4_unicast_dst() {
     );
 }
 
+/// #2325: rewrite the link-layer (L2) destination MAC of a built frame so
+/// the trigger is delivered to a group/broadcast MAC. The PTB L2 gate
+/// reads the destination off the first 6 frame bytes.
+fn set_l2_dst(frame: &mut [u8], mac: [u8; 6]) {
+    frame[0..6].copy_from_slice(&mac);
+}
+
+/// #2325: a frame with a UNICAST L3 destination but a MULTICAST L2
+/// destination MAC (the group I/G bit set) must NOT generate a PTB
+/// (RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a datagram delivered as a
+/// link-layer multicast must not produce an ICMP error). Fails if the
+/// L2 gate is reverted (the L3 destination here is plain unicast, so the
+/// #2314 L3 gate alone would let this through).
+#[test]
+fn ptb_suppressed_for_l2_multicast_dst() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    // 01:00:5e:... is the IPv4-multicast MAC range; the low bit of the
+    // first octet (0x01) is the IEEE group bit.
+    set_l2_dst(&mut frame, [0x01, 0x00, 0x5e, 0x01, 0x02, 0x03]);
+    assert!(
+        ptb_reply_suppressed(&frame, meta, l3),
+        "L2 multicast (group bit) destination must suppress the PTB"
+    );
+}
+
+/// #2325: a frame delivered to the L2 broadcast MAC (all-FF) must NOT
+/// generate a PTB even though its L3 destination is unicast. Fails if the
+/// L2 gate is reverted.
+#[test]
+fn ptb_suppressed_for_l2_broadcast_dst() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    set_l2_dst(&mut frame, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+    assert!(
+        ptb_reply_suppressed(&frame, meta, l3),
+        "L2 broadcast destination must suppress the PTB"
+    );
+}
+
+/// #2325: the same gate on IPv6 — a unicast L3 destination delivered to a
+/// multicast L2 MAC (e.g. 33:33:... IPv6-multicast range) must suppress.
+#[test]
+fn ptb_suppressed_for_l2_multicast_dst_v6() {
+    let (mut frame, meta) = inbound_v6_udp(1300);
+    let l3 = meta.l3_offset as usize;
+    set_l2_dst(&mut frame, [0x33, 0x33, 0x00, 0x00, 0x00, 0x01]);
+    assert!(
+        ptb_reply_suppressed(&frame, meta, l3),
+        "L2 multicast (33:33:..) destination must suppress the IPv6 PTB"
+    );
+}
+
+/// #2325 fail-on-revert pair: a UNICAST L3 destination delivered to a
+/// UNICAST L2 MAC must STILL generate the PTB. Pairs with the L2
+/// suppression tests above so reverting the L2 gate turns those red while
+/// this one stays green (proving the suppression is the L2 gate, not the
+/// frame bytes).
+#[test]
+fn ptb_still_generated_for_l2_unicast_dst() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    // A plain unicast MAC: low bit of the first octet clear.
+    set_l2_dst(&mut frame, [0x02, 0xbf, 0x72, 0x00, 0x00, 0x09]);
+    assert!(
+        !ptb_reply_suppressed(&frame, meta, l3),
+        "unicast L2 + unicast L3 destination must NOT suppress the PTB"
+    );
+    let fwd = forwarding_with_egress(1400);
+    assert!(
+        build_frag_needed_v4(&frame, meta, PTB_IFINDEX, &fwd, 1400).is_some(),
+        "unicast L2/L3 PTB must build"
+    );
+}
+
+/// #2325: direct unit test of the shared `l2_dst_is_group_or_broadcast`
+/// helper — the IEEE group (I/G) bit is the low bit of the first octet;
+/// broadcast (all-FF) is a group address. Unicast MACs (even bit clear)
+/// are not group/broadcast. Fails if the helper's bit test is reverted.
+#[test]
+fn l2_dst_group_broadcast_helper() {
+    // Unicast: low bit of first octet clear.
+    assert!(!l2_dst_is_group_or_broadcast(&[0x02, 0xbf, 0x72, 0x00, 0x00, 0x01]));
+    assert!(!l2_dst_is_group_or_broadcast(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]));
+    // IPv4 multicast MAC range (01:00:5e:..): group bit set.
+    assert!(l2_dst_is_group_or_broadcast(&[0x01, 0x00, 0x5e, 0x01, 0x02, 0x03]));
+    // IPv6 multicast MAC range (33:33:..): group bit set (0x33 & 0x01).
+    assert!(l2_dst_is_group_or_broadcast(&[0x33, 0x33, 0x00, 0x00, 0x00, 0x01]));
+    // Broadcast (all-FF): a group address.
+    assert!(l2_dst_is_group_or_broadcast(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
+}
+
 #[test]
 fn no_primary_address_fails_closed() {
     // Egress has no primary v4 -> the builder returns None (caller silently


### PR DESCRIPTION
Closes #2325

## Problem

The PTB (Packet-Too-Big / Frag-Needed) ICMP-error generation gate
`ptb_reply_suppressed` (userspace-dp/src/afxdp/icmp_ptb.rs) suppressed on
a multicast/broadcast **IP (L3) destination** (added in #2314) but did
**not** check the **link-layer (L2) destination MAC**. The reject /
Time-Exceeded path `can_generate_icmp_error_reply` (icmp.rs:~47-51)
already suppresses when the L2 destination MAC is a group/broadcast
address. So the PTB path had an L2-parity gap: a frame with a **unicast
L3 dst** but a **multicast/broadcast L2 dst MAC** still triggered a PTB.

## RFC basis

RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e): an ICMP error MUST NOT be
generated in response to a datagram delivered as a link-layer broadcast
or multicast.

## Fix — L2-parity gate + shared helper

- **Extracted a shared helper** `l2_dst_is_group_or_broadcast(eth_dst:
  &[u8; 6]) -> bool` into `frame/inspect.rs` (re-exported at
  `pub(in crate::afxdp)` from `frame/mod.rs`). It is the IEEE 802 I/G
  group bit (the low bit of the destination MAC's first octet); the
  all-FF broadcast MAC is a group address, so a single bit test covers
  both. No allocation.
- The inline L2 test that previously lived in
  `can_generate_icmp_error_reply` (icmp.rs) now **calls the shared
  helper**, and `ptb_reply_suppressed` (icmp_ptb.rs) now calls it too —
  giving the PTB path the same L2 + L3 suppression parity the reject / TE
  path has.

### PTB generation site gated

`ptb_reply_suppressed` is the gate called from the PTB emit site in
`userspace-dp/src/afxdp/tx/dispatch/mod.rs:520`
(`if !ptb_reply_suppressed(source_frame, ptb_meta, l3)` → then
`build_frag_needed_v4` / `build_packet_too_big_v6`). The site already
passes the **full trigger ethernet frame** (`source_frame` — the same
slice the PTB builders read the reflected destination MAC from), so the
L2 destination is simply the first 6 frame bytes. **No plumbing was
needed.**

No new counter: a suppressed PTB folds into the existing fail-closed
silent-drop path (the oversized original is still dropped via
`mtu_signalled`).

## Tests (fail-on-revert)

In `icmp_ptb_tests.rs`:
- `ptb_suppressed_for_l2_multicast_dst` — unicast L3 dst + L2 multicast
  MAC (01:00:5e:.., group bit set) → suppressed
- `ptb_suppressed_for_l2_broadcast_dst` — unicast L3 dst + L2 broadcast
  MAC (all-FF) → suppressed
- `ptb_suppressed_for_l2_multicast_dst_v6` — IPv6 unicast L3 dst + L2
  multicast MAC (33:33:..) → suppressed
- `ptb_still_generated_for_l2_unicast_dst` — unicast L2 + unicast L3 →
  STILL generated (and builds)
- `l2_dst_group_broadcast_helper` — direct unit test of the extracted
  helper (unicast vs group/broadcast bit cases)

Verified the three L2-suppression tests turn **red** when the gate is
removed from `ptb_reply_suppressed`, while the unicast/helper tests stay
green.

## Validation

- `cargo build --release` clean (only pre-existing dead-code warnings).
- `cargo test --release -- ptb icmp l2 suppress multicast` green (109
  matching tests incl. the existing reject/TE path tests after the helper
  extraction).
- New tests run 5x with no flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)