### PR TITLE
#2327: segregate GRE decap by tunnel kind; fail closed on unknown modes

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -10297,3 +10297,22 @@ top.
   userspace-dp/src/afxdp/icmp_ptb.rs,
   userspace-dp/src/afxdp/icmp_ptb_tests.rs,
   userspace-dp/src/afxdp/README.md, _Log.md
+
+- **Timestamp**: 2026-06-22
+  **Action**: #2327 — GRE decap kind-segregation + fail-closed egress
+  encap dispatch + O(N) decap-scan fix. `match_tunnel_endpoint`
+  (gre.rs) now resolves via a new kind-segregated, outer-tuple-keyed
+  `gre_decap_index` (GRE-mode rows only) instead of scanning all
+  tunnel_endpoints; a GRE frame can no longer decap against a WireGuard
+  or other non-GRE row. Egress dispatcher (frame/mod.rs) matches on a
+  typed `TunnelKind` and DROPS unknown/missing modes (was `_ => GRE`
+  fail-open). Added `TunnelKind` + `tunnel_mode_kind` in
+  forwarding_build/tunnels.rs; index populated in
+  populate_tunnel_endpoints. 4 fail-on-revert tests.
+  **File(s)**: userspace-dp/src/afxdp/gre.rs,
+  userspace-dp/src/afxdp/frame/mod.rs,
+  userspace-dp/src/afxdp/forwarding_build/tunnels.rs,
+  userspace-dp/src/afxdp/forwarding_build/mod.rs,
+  userspace-dp/src/afxdp/types/forwarding.rs,
+  userspace-dp/src/afxdp/tests.rs, docs/userspace-native-gre-plan.md,
+  _Log.md

--- a/docs/userspace-native-gre-plan.md
+++ b/docs/userspace-native-gre-plan.md
@@ -227,6 +227,35 @@ Required behavior:
 
 Without that, the same HA parity gap reappears in another form.
 
+### 6a. Tunnel-Kind Segregation & Fail-Closed Dispatch (#2327)
+
+`state.tunnel_endpoints` is a MIXED-KIND table: GRE/`ip6gre` and
+WireGuard rows coexist (and future kinds may be added). Two invariants
+keep that table from crossing security boundaries:
+
+- **GRE decap is kind-segregated.** `match_tunnel_endpoint`
+  (`afxdp/gre.rs`) resolves a received proto-47 outer tuple ONLY through
+  `state.gre_decap_index` — a per-build index that contains ONLY
+  `mode == "gre"`/`"ip6gre"` endpoints, keyed by the endpoint's own
+  `(outer_family, source, destination)` and queried with the frame's
+  mirrored `(addr_family, outer_dst, outer_src)`. A GRE frame whose
+  outer tuple/key happen to collide with a WireGuard (or any non-GRE)
+  row is NEVER decapsulated as GRE — it finds no GRE candidate and is
+  dropped / falls through. The candidate list per bucket disambiguates a
+  duplicate outer tuple by GRE key instead of a non-deterministic
+  first-match scan, and replaces the former per-packet O(N)
+  `tunnel_endpoints.values().find(...)` linear scan (agy #4). A
+  per-candidate `tunnel_mode_kind` re-check is kept as defense in depth.
+- **Egress encap fails closed on an unknown mode.** The egress
+  dispatcher (`afxdp/frame/mod.rs`) matches on the typed `TunnelKind`
+  (`afxdp/forwarding_build/tunnels.rs::tunnel_mode_kind`): `WireGuard` →
+  WG encap, `Gre` → native GRE encap, and `Unknown`/missing-row → DROP.
+  The pre-#2327 `_ => GRE` arm fail-OPEN-encapsulated any unrecognized
+  or future mode as GRE; that is now a drop, matching the appliance's
+  fail-closed parser doctrine. Add a new tunnel kind in exactly one
+  place — `tunnel_mode_kind` — and the dispatcher will keep failing
+  closed until the new arm is added deliberately.
+
 ## Policy-Based Routing Without A Tunnel Netdevice
 
 This is the most important control-plane question.

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -45,6 +45,10 @@ pub(in crate::afxdp) use interfaces::{pick_interface_v4, pick_interface_v6};
 // tombstone-respawn coherence check + defer-branch prune. (The
 // `WgRowIdentity` type itself is only named inside `tunnels`.)
 pub(in crate::afxdp) use tunnels::hydrate_wg_identity;
+// #2327: typed tunnel-kind classifier shared with the GRE decap path
+// (`gre.rs`) and the egress encap dispatcher (`frame/mod.rs`) so the
+// kind-segregation and fail-closed `_ =>` arm have one source of truth.
+pub(in crate::afxdp) use tunnels::{tunnel_mode_kind, TunnelKind};
 
 // Plain (private) `use` for orchestrator-local symbols. NOT a
 // `pub(super) use` of a `pub(super)` item — that triggers E0364

--- a/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tunnels.rs
@@ -94,9 +94,52 @@ pub(super) fn populate_tunnel_endpoints(
         state
             .tunnel_endpoint_by_ifindex
             .insert(endpoint.ifindex, endpoint.id);
+        // #2327: kind-segregated decap index — only GRE-mode endpoints
+        // are indexed for the GRE (proto-47) decap fast path. A
+        // WireGuard or any non-GRE row is intentionally NOT indexed, so
+        // a received GRE frame can never be decapped against it even if
+        // the outer tuple/key collide. Keyed by the endpoint's own
+        // (outer_family, source, destination); the decap lookup queries
+        // with the received frame's mirrored (addr_family, outer_dst,
+        // outer_src).
+        if tunnel_mode_kind(&endpoint.mode) == TunnelKind::Gre {
+            state
+                .gre_decap_index
+                .entry((outer_family, source, destination))
+                .or_default()
+                .push(endpoint.id);
+        }
         if is_wireguard {
             state.has_wg_tunnels = true;
         }
+    }
+}
+
+/// #2327: the typed kind of a tunnel-endpoint `mode` string. Centralizes
+/// the kind classification that the decap index, the egress encap
+/// dispatcher, and the GRE supervision paths all rely on, so a future
+/// tunnel kind is added in exactly one place and the egress dispatcher's
+/// fail-closed `_ =>` arm cannot silently treat it as GRE.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(in crate::afxdp) enum TunnelKind {
+    /// `gre` / `ip6gre` — native GRE encapsulation/decapsulation.
+    Gre,
+    /// `wireguard` — WireGuard engine encap/decap.
+    WireGuard,
+    /// Any unrecognized / future / malformed mode string. The egress
+    /// dispatcher MUST fail closed (drop) on this rather than default to
+    /// GRE encap (the pre-#2327 fail-open behavior).
+    Unknown,
+}
+
+/// Classify a tunnel-endpoint `mode` string into a `TunnelKind`. Mirrors
+/// the canonical GRE-kind test used across the supervision paths
+/// (`mode == "gre" || mode == "ip6gre"`).
+pub(in crate::afxdp) fn tunnel_mode_kind(mode: &str) -> TunnelKind {
+    match mode {
+        "gre" | "ip6gre" => TunnelKind::Gre,
+        "wireguard" => TunnelKind::WireGuard,
+        _ => TunnelKind::Unknown,
     }
 }
 

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -279,13 +279,25 @@ pub(super) fn build_forwarded_frame_from_frame(
         // The endpoint is already fetched for the GRE builder; the
         // `mode` match reads a &str already in hand — no new branch on
         // the plain-forward fast path (#1432 §4.4).
-        let mode = forwarding
+        //
+        // #2327: dispatch on the TYPED kind and FAIL CLOSED on an
+        // unknown/missing mode. The pre-#2327 `_ => GRE` arm silently
+        // GRE-encapsulated any unrecognized or future tunnel mode (a
+        // fail-OPEN default in a security appliance). An endpoint id
+        // that resolves to no row, or to a row whose mode is neither
+        // GRE nor WireGuard, is now DROPPED (`None`) rather than emitted
+        // as GRE.
+        let kind = forwarding
             .tunnel_endpoints
             .get(&decision.resolution.tunnel_endpoint_id)
-            .map(|e| e.mode.as_str());
-        return match mode {
-            Some("wireguard") => wg::wg_encap_frame(&out, meta, decision, forwarding),
-            _ => encapsulate_native_gre_frame(&out, meta, decision, forwarding),
+            .map(|e| tunnel_mode_kind(&e.mode));
+        return match kind {
+            Some(TunnelKind::WireGuard) => wg::wg_encap_frame(&out, meta, decision, forwarding),
+            Some(TunnelKind::Gre) => {
+                encapsulate_native_gre_frame(&out, meta, decision, forwarding)
+            }
+            // Unknown mode or missing endpoint row: fail closed.
+            Some(TunnelKind::Unknown) | None => None,
         };
     }
     Some(out)

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -374,6 +374,22 @@ fn gre_inner_family_and_proto(proto: u16) -> Option<(u8, u16)> {
     }
 }
 
+/// Match a received GRE (proto-47) outer tuple to a GRE-mode tunnel
+/// endpoint.
+///
+/// #2327 (kind-segregation + O(N) fix): the lookup goes through
+/// `gre_decap_index`, which only contains `mode == "gre"` / `"ip6gre"`
+/// endpoints — so a GRE frame is NEVER decapped against a WireGuard or
+/// any other non-GRE row even if the outer tuple/key happen to collide.
+/// The index is keyed by the endpoint's own
+/// `(outer_family, source, destination)`; a received frame mirrors it as
+/// `(addr_family, outer_dst, outer_src)`. Each bucket is a small
+/// candidate list so a duplicate outer tuple (a keyed and an unkeyed
+/// endpoint, or distinct logical ifindexes) is disambiguated by the GRE
+/// key here rather than resolved non-deterministically by a first-match
+/// scan over the entire table. Defense-in-depth: each candidate's
+/// `mode` is re-checked via `tunnel_mode_kind` so a future build-side
+/// indexing bug can never surface a non-GRE row on this path.
 fn match_tunnel_endpoint(
     forwarding: &ForwardingState,
     outer_family: i32,
@@ -382,16 +398,28 @@ fn match_tunnel_endpoint(
     key: u32,
     key_present: bool,
 ) -> Option<&TunnelEndpoint> {
-    forwarding.tunnel_endpoints.values().find(|endpoint| {
-        endpoint.outer_family == outer_family
-            && endpoint.source == outer_dst
-            && endpoint.destination == outer_src
-            && if endpoint.key == 0 {
-                !key_present || key == 0
-            } else {
-                key_present && endpoint.key == key
-            }
-    })
+    let candidates = forwarding
+        .gre_decap_index
+        .get(&(outer_family, outer_dst, outer_src))?;
+    for id in candidates {
+        let Some(endpoint) = forwarding.tunnel_endpoints.get(id) else {
+            continue;
+        };
+        // Kind re-check (defense in depth): only GRE-mode rows decap as
+        // GRE, regardless of what the index claims.
+        if tunnel_mode_kind(&endpoint.mode) != TunnelKind::Gre {
+            continue;
+        }
+        let key_ok = if endpoint.key == 0 {
+            !key_present || key == 0
+        } else {
+            key_present && endpoint.key == key
+        };
+        if key_ok {
+            return Some(endpoint);
+        }
+    }
+    None
 }
 
 fn parse_inner_protocol_and_offsets(packet: &[u8], addr_family: u8) -> Option<(u8, u16, u16)> {

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7415,6 +7415,105 @@ fn native_gre_decap_tagged_ingress_yields_self_consistent_frame_meta() {
     assert_eq!(decap.meta.addr_family, libc::AF_INET as u8);
 }
 
+/// #2327 fail-on-revert: a GRE (proto-47) frame whose outer tuple/key
+/// match ONLY a non-GRE (here: WireGuard) tunnel row must NOT be
+/// decapsulated as GRE. Pre-#2327 `match_tunnel_endpoint` scanned
+/// `tunnel_endpoints.values()` ignoring `mode`, so any row whose outer
+/// tuple lined up was decapped as GRE. We mutate the built state so the
+/// ONLY endpoint that carries the matching outer tuple is mode
+/// "wireguard" — the GRE decap must return `None` (no match / drop),
+/// never decap the WireGuard endpoint's traffic as GRE. If the
+/// kind-segregation in `match_tunnel_endpoint` / the build-side
+/// `gre_decap_index` is reverted, this row reappears and the assert
+/// fires.
+#[test]
+fn gre_decap_does_not_match_wireguard_row_with_same_outer_tuple() {
+    let mut forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    // Flip the single (GRE) endpoint to WireGuard while keeping the
+    // exact outer tuple/key the inbound frame matches, and drop it from
+    // the kind-segregated decap index (as the WG build path would).
+    let id = 824u16;
+    if let Some(ep) = forwarding.tunnel_endpoints.get_mut(&id) {
+        ep.mode = "wireguard".to_string();
+    }
+    forwarding.gre_decap_index.clear();
+
+    let inner = build_gre_inner_icmp_packet_v4();
+    let frame = build_gre_to_self_outer_frame_v4(80, &inner);
+    let meta = gre_to_self_outer_meta(80, frame.len());
+    assert!(
+        try_native_gre_decap_from_frame(&frame, meta, &forwarding).is_none(),
+        "a GRE frame matching only a WireGuard row must NOT decap as GRE"
+    );
+}
+
+/// #2327 fail-on-revert (defense-in-depth pin): even if the build-side
+/// index were wrong and surfaced a non-GRE endpoint id for the inbound
+/// tuple, the per-candidate `tunnel_mode_kind` re-check in
+/// `match_tunnel_endpoint` must reject it. Here the decap index DOES
+/// point at the endpoint, but the endpoint's mode is non-GRE — the
+/// match must still be `None`.
+#[test]
+fn gre_decap_rejects_non_gre_candidate_even_if_indexed() {
+    let mut forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let id = 824u16;
+    if let Some(ep) = forwarding.tunnel_endpoints.get_mut(&id) {
+        ep.mode = "wireguard".to_string();
+    }
+    // Index intentionally left pointing at the now-WireGuard endpoint to
+    // exercise the per-candidate kind re-check.
+    let inner = build_gre_inner_icmp_packet_v4();
+    let frame = build_gre_to_self_outer_frame_v4(80, &inner);
+    let meta = gre_to_self_outer_meta(80, frame.len());
+    assert!(
+        try_native_gre_decap_from_frame(&frame, meta, &forwarding).is_none(),
+        "the per-candidate kind re-check must reject a non-GRE endpoint \
+         even when the decap index lists it"
+    );
+}
+
+/// #2327 fail-on-revert: a genuine GRE frame matching a GRE-mode row
+/// still decaps (the kind-segregation must not break the happy path).
+/// Complements the existing
+/// `native_gre_decap_tagged_ingress_yields_self_consistent_frame_meta`.
+#[test]
+fn gre_decap_still_matches_genuine_gre_row() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let inner = build_gre_inner_icmp_packet_v4();
+    let frame = build_gre_to_self_outer_frame_v4(80, &inner);
+    let meta = gre_to_self_outer_meta(80, frame.len());
+    let decap = try_native_gre_decap_from_frame(&frame, meta, &forwarding)
+        .expect("a genuine GRE frame matching a GRE row must still decap");
+    assert_eq!(
+        &decap.frame[decap.meta.l3_offset as usize..],
+        &inner[..],
+        "decapped inner packet must be byte-identical"
+    );
+}
+
+/// #2327 fail-on-revert: the egress encap dispatcher must FAIL CLOSED on
+/// an unknown tunnel mode — a row whose mode is neither GRE nor
+/// WireGuard must NOT be silently GRE-encapsulated (the pre-#2327
+/// `_ => GRE` fail-open default). `tunnel_mode_kind` classifies it as
+/// `Unknown`; the dispatcher drops (`None`). Asserted at the kind layer
+/// (the dispatch's `match` arms) so the test pins the fail-closed
+/// contract without standing up a full forwarded-frame fixture.
+#[test]
+fn unknown_tunnel_mode_classifies_as_unknown_not_gre() {
+    use crate::afxdp::{tunnel_mode_kind, TunnelKind};
+    assert_eq!(tunnel_mode_kind("gre"), TunnelKind::Gre);
+    assert_eq!(tunnel_mode_kind("ip6gre"), TunnelKind::Gre);
+    assert_eq!(tunnel_mode_kind("wireguard"), TunnelKind::WireGuard);
+    // Any unrecognized / future / malformed mode must NOT map to GRE.
+    for bad in ["", "ipip", "vxlan", "GRE", "wireguard ", "gre6", "geneve"] {
+        assert_eq!(
+            tunnel_mode_kind(bad),
+            TunnelKind::Unknown,
+            "mode {bad:?} must classify Unknown (fail closed), never GRE"
+        );
+    }
+}
+
 /// #1902 fixture: inner TCP SYN L3 packet (no Ethernet header — it is
 /// the flagless-GRE proto-0x0800 payload) 10.255.0.2 -> `dst`. With
 /// `dst` on the reth1.0 connected subnet the decap-INBOUND forward

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -22,6 +22,20 @@ pub(in crate::afxdp) struct ForwardingState {
     pub(in crate::afxdp) routes_v6: FastMap<String, Vec<RouteEntryV6>>,
     pub(in crate::afxdp) tunnel_endpoints: FastMap<u16, TunnelEndpoint>,
     pub(in crate::afxdp) tunnel_endpoint_by_ifindex: FastMap<i32, u16>,
+    /// #2327: kind-segregated, outer-tuple-keyed index for the GRE
+    /// decap fast path. Keyed by the OUTER tuple as seen FROM THE
+    /// ENDPOINT's perspective — `(outer_family, endpoint.source,
+    /// endpoint.destination)` — so a received GRE frame is matched with
+    /// `(meta.addr_family, outer_dst, outer_src)`. Only `mode == "gre"`
+    /// / `"ip6gre"` endpoints are indexed (kind-segregation): a GRE
+    /// (proto-47) packet can NEVER be decapped against a WireGuard or
+    /// any non-GRE row even if its outer tuple/key collide. Each bucket
+    /// is a `Vec<u16>` of endpoint IDs so a duplicate outer tuple
+    /// (keyed vs unkeyed, or different logical ifindex) is disambiguated
+    /// by the GRE key at lookup rather than resolved non-deterministically
+    /// by a first-match scan. Replaces the per-packet O(N)
+    /// `tunnel_endpoints.values().find(...)` scan (agy #4).
+    pub(in crate::afxdp) gre_decap_index: FastMap<(i32, IpAddr, IpAddr), Vec<u16>>,
     /// WireGuard engines keyed by tunnel_endpoint_id (#1432 S2a). One
     /// per `mode == "wireguard"` endpoint. Shared (`Arc`) so workers
     /// hold the engine across a forwarding-state ArcSwap; engine


### PR DESCRIPTION
Closes #2327

The userspace-dp tunnel-endpoint table is mixed-kind (GRE/`ip6gre` and WireGuard rows coexist), but two hot paths selected an endpoint without inspecting `endpoint.mode`, crossing a security boundary.

## Bugs (verified live in triage, master 06e25dd3f)
1. **GRE decap matched non-GRE rows.** `match_tunnel_endpoint` (`gre.rs`) did `tunnel_endpoints.values().find(...)` on the outer tuple + key only, never checking `mode`. A received proto-47 frame whose outer tuple/key collided with a WireGuard row was decapsulated as GRE.
2. **Unknown modes failed OPEN as GRE.** Egress dispatcher (`frame/mod.rs`) had `_ => encapsulate_native_gre_frame` — any unrecognized/future mode silently GRE-encapsulated (fail-open in a security appliance).
3. **O(N) per-packet decap scan** (agy #4) — the decap lookup linearly scanned every tunnel row (the map is keyed by sequential `tunnel_endpoint_id`, not the outer tuple).

## Fix (all three)
- **Kind classifier.** New typed `TunnelKind` (Gre / WireGuard / Unknown) + `tunnel_mode_kind` in `forwarding_build/tunnels.rs` — one source of truth for the GRE-kind test (`mode == "gre" || "ip6gre"`).
- **Full re-index (not just a short-circuit).** New kind-segregated, outer-tuple-keyed `gre_decap_index` (`FastMap<(outer_family, source, destination), Vec<endpoint_id>>`) built in `populate_tunnel_endpoints`, containing **only GRE-mode rows**. `match_tunnel_endpoint` resolves through it with the mirrored lookup key `(addr_family, outer_dst, outer_src)`, disambiguates a duplicate outer tuple by GRE key within the small candidate bucket, and keeps a per-candidate `tunnel_mode_kind` re-check as defense in depth. GRE decap is no longer a linear scan over unrelated rows. A GRE frame matching only a non-GRE row finds no GRE candidate and is dropped.
- **Fail-closed egress dispatch.** Dispatcher matches on `TunnelKind`: WireGuard → WG encap, Gre → native GRE encap, `Unknown`/missing-row → **drop (`None`)**. Adding a future kind is a deliberate edit in `tunnel_mode_kind`; until then it fails closed.

## Mode-check + fail-closed sites
- Kind-segregation (decap): `userspace-dp/src/afxdp/gre.rs` `match_tunnel_endpoint`
- Index build: `userspace-dp/src/afxdp/forwarding_build/tunnels.rs` `populate_tunnel_endpoints` + `tunnel_mode_kind`/`TunnelKind`
- Fail-closed encap dispatch: `userspace-dp/src/afxdp/frame/mod.rs` `build_forwarded_frame_from_frame`

## Tests (fail-on-revert)
- `gre_decap_does_not_match_wireguard_row_with_same_outer_tuple`
- `gre_decap_rejects_non_gre_candidate_even_if_indexed`
- `gre_decap_still_matches_genuine_gre_row`
- `unknown_tunnel_mode_classifies_as_unknown_not_gre`

## Validation
`cargo build --release` clean; targeted tests green 5x; full suite 2376 passed (the one failure is the pre-existing flaky `worker_queue::concurrent_recovery_processes_each_command_exactly_once` concurrency test — unrelated, passes in isolation 5/5). No wire/protocol field changed. Doc `userspace-native-gre-plan.md` §6a records the invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi