### PR TITLE
#2331: guard native GRE encap against DF-set oversized outer frames

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -10316,3 +10316,31 @@ top.
   userspace-dp/src/afxdp/types/forwarding.rs,
   userspace-dp/src/afxdp/tests.rs, docs/userspace-native-gre-plan.md,
   _Log.md
+
+- **Timestamp**: 2026-06-22
+  **Action**: #2331 — native GRE encap outer-MTU / DF-set oversize guard.
+  `encapsulate_native_gre_frame` (gre.rs) now sizes the full outer
+  datagram (outer IP + GRE[+key] + inner via the new
+  `gre_encapped_outer_len` helper, L2 excluded) and compares it against
+  the resolved transport MTU (`tunnel_outer_mtu`, #2300 SSOT) BEFORE
+  allocating/emitting. An outer larger than the MTU is NOT emitted (the
+  IPv4 outer is DF=1 / IPv6 cannot be in-path fragmented → downstream
+  blackhole, no PMTUD); it is dropped and bumps the new
+  `GRE_ENCAP_DF_OVERSIZE_DROPS` static, wired through status.rs →
+  server/helpers.rs+lifecycle.rs → ProcessStatus
+  (gre_encap_df_oversize_drops_total) → Go protocol.go + metrics
+  (xpf_userspace_gre_encap_df_oversize_drops_total). PMTUD/PTB
+  signalling DEFERRED to #2330 (matches the deliberate
+  !uses_native_tunnel exclusion in the #2301 dispatch PTB path). 5
+  fail-on-revert Rust tests + Go metric assertions; protocol_wire_v1.json
+  regenerated (1 new key).
+  **File(s)**: userspace-dp/src/afxdp/gre.rs,
+  userspace-dp/src/afxdp/coordinator/status.rs,
+  userspace-dp/src/server/helpers.rs, userspace-dp/src/server/lifecycle.rs,
+  userspace-dp/src/protocol/control.rs, userspace-dp/src/protocol/tests.rs,
+  userspace-dp/src/afxdp/tunnel_tests.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  pkg/dataplane/userspace/protocol.go, pkg/api/metrics.go,
+  pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go,
+  pkg/api/metrics_test.go, pkg/api/metrics_descriptor_coverage_test.go,
+  docs/userspace-native-gre-plan.md, _Log.md

--- a/docs/userspace-native-gre-plan.md
+++ b/docs/userspace-native-gre-plan.md
@@ -169,10 +169,40 @@ When the forwarding resolution selects a tunnel endpoint:
 2. compute outer route using the configured outer transport routing-instance
 3. resolve outer next-hop MAC on the physical egress interface
 4. prepend outer IPv4/IPv6 + GRE header in Rust
+4a. enforce the outer MTU before emitting (see "Outer MTU / DF guard")
 5. transmit the final encapsulated packet through the physical NIC AF_XDP TX path
 
 This replaces the current “mark as `MissingNeighbor` and hand to kernel
 slow-path because tunnel AF_XDP TX does not exist”.
+
+#### Outer MTU / DF guard (#2331)
+
+`encapsulate_native_gre_frame` (userspace-dp/src/afxdp/gre.rs) writes
+the IPv4 outer with `DF=1` (#1440), and the IPv6 outer cannot be
+fragmented in-path either. So once the full outer datagram is sized —
+`outer IP + GRE header (incl. the optional 4-byte key) + inner packet`
+(the `gre_encapped_outer_len` helper; the L2 eth/VLAN header is NOT part
+of the MTU budget) — the builder compares it against the resolved
+transport/egress MTU via `tunnel_outer_mtu` (forwarding/mod.rs, the
+#2300 SSOT used by the inner MSS clamp and `native_gre_inner_mtu`: real
+transport ifindex → stored-resolution egress → endpoint logical ifindex,
+`unwrap_or(1500)`). If the outer exceeds that MTU the frame is **not
+emitted**: it would be a downstream blackhole (NIC/router drop, no PMTUD
+signal back to the inner source). The drop bumps
+`GRE_ENCAP_DF_OVERSIZE_DROPS`, surfaced as the Prometheus counter
+`xpf_userspace_gre_encap_df_oversize_drops_total`.
+
+A nonzero counter flags inner flows whose encapped size exceeds the
+tunnel path MTU — typically a missing/too-high inner MSS clamp
+(`native_gre_tcp_mss`), or a non-TCP inner (UDP/ICMP/ESP) with no
+segmentation lever. PMTUD (ICMP Frag-Needed / Packet-Too-Big) signalling
+back to the inner source is **deferred to #2330** (the post-transform
+PMTUD plumbing; inner TCP-segment sizing is #2329). This site scopes to
+drop+count only, mirroring the deliberate `!uses_native_tunnel`
+exclusion in the plain-forward PTB path (tx/dispatch/mod.rs, #2301):
+the source-frame-vs-egress-MTU check there would produce a false PTB for
+tunnel encap because the correct inner-source PTB must be derived from
+the inner MTU after subtracting tunnel overhead.
 
 ### 4. Session Model
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -254,7 +254,13 @@ type xpfCollector struct {
 	// captured via recvmsg IP_RECVTOS/IPV6_RECVTCLASS, over a Not-ECT
 	// inner) — the WG sibling of the GRE counter above.
 	userspaceWgDecapEcnIllegalDrops *prometheus.Desc
-	userspaceFlowCacheActiveFlows   *prometheus.Desc
+	// #2331: native-GRE encap frames dropped because the fully built outer
+	// datagram exceeded the resolved transport/egress MTU while the IPv4
+	// outer carries DF=1 (the only outer the native builder emits). A
+	// DF-set oversized outer cannot be fragmented downstream and would
+	// silently blackhole every inner flow with no PMTUD signal.
+	userspaceGreEncapDfOversizeDrops *prometheus.Desc
+	userspaceFlowCacheActiveFlows    *prometheus.Desc
 	userspaceFlowCacheCapacity      *prometheus.Desc
 	// #1379: daemon-side userspace event-stream transport counters.
 	userspaceEventStreamFramesTotal          *prometheus.Desc
@@ -542,6 +548,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.userspaceWorkerCommandQueuePoisonRecoveries
 	ch <- c.userspaceGreDecapEcnIllegalDrops
 	ch <- c.userspaceWgDecapEcnIllegalDrops
+	ch <- c.userspaceGreEncapDfOversizeDrops
 	ch <- c.userspaceFlowCacheActiveFlows
 	ch <- c.userspaceFlowCacheCapacity
 	ch <- c.userspaceEventStreamFramesTotal

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -517,6 +517,7 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_userspace_worker_command_queue_poison_recoveries_total",       // #1807 poison recoveries
 		"xpf_userspace_gre_decap_ecn_illegal_drops_total",                  // #2315 RFC 6040 4.2 decap illegal-combo drops
 		"xpf_userspace_wg_decap_ecn_illegal_drops_total",                   // #2317 WG RFC 6040 4.2 decap illegal-combo drops
+		"xpf_userspace_gre_encap_df_oversize_drops_total",                  // #2331 GRE encap DF-set oversized-outer drops
 		// #1771 §2.6 resolver backoff + §2.5 ENOBUFS/re-dump + key gauges
 		"xpf_userspace_neighbor_resolver_get_backoff_attempts_total",
 		"xpf_userspace_neighbor_netlink_enobufs_total",

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -848,6 +848,25 @@ func newCollector(srv *Server) *xpfCollector {
 				"congested path (#2317).",
 			nil, nil,
 		),
+		userspaceGreEncapDfOversizeDrops: prometheus.NewDesc(
+			"xpf_userspace_gre_encap_df_oversize_drops_total",
+			"Native-GRE encap frames dropped because the fully built "+
+				"outer datagram (outer IP + GRE header, including the "+
+				"optional 4-byte key, + inner packet) exceeded the "+
+				"resolved transport/egress MTU while the IPv4 outer "+
+				"carries DF=1 (the only outer the native encap builder "+
+				"emits; the IPv6 outer cannot be fragmented in-path "+
+				"either). A DF-set oversized outer cannot be fragmented "+
+				"downstream and would silently blackhole every inner flow "+
+				"over the tunnel with no PMTUD signal back to the inner "+
+				"source, so the builder refuses to emit it. A nonzero "+
+				"value flags inner flows whose encapped size exceeds the "+
+				"tunnel path MTU (typically a missing or too-high inner "+
+				"MSS clamp, or a non-TCP inner with no segmentation "+
+				"lever). PMTUD/PTB signalling is deferred to #2330 "+
+				"(#2331).",
+			nil, nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"Aggregate active userspace flow-cache entries across bindings.",

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -836,6 +836,12 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 			nil,
 			nil,
 		),
+		userspaceGreEncapDfOversizeDrops: prometheus.NewDesc(
+			"xpf_userspace_gre_encap_df_oversize_drops_total",
+			"gre encap df-set oversized-outer drops",
+			nil,
+			nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"flow-cache active flows",
@@ -873,6 +879,9 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 		// #2317: WG-decap RFC 6040 §4.2 illegal-combo drop counter
 		// emitted unconditionally.
 		WgDecapEcnIllegalDropsTotal: 5,
+		// #2331: GRE-encap DF-set oversized-outer drop counter emitted
+		// unconditionally.
+		GreEncapDfOversizeDropsTotal: 6,
 		// #1861: install-refusal trio emitted unconditionally.
 		SessionCreateDrops:             9,
 		SessionInstallAdmissionRefused: 8,
@@ -909,9 +918,10 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	// 10 pre-#1861 metrics + the #1861 install-refusal trio + the #2244
 	// dnat_table reverse-NAT publish-error counter (= 14) + the #2315
 	// gre_decap_ecn_illegal_drops_total counter (= 15) + the #2317
-	// wg_decap_ecn_illegal_drops_total counter = 16.
-	if len(got) != 16 {
-		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 16 metrics, got %d", len(got))
+	// wg_decap_ecn_illegal_drops_total counter (= 16) + the #2331
+	// gre_encap_df_oversize_drops_total counter = 17.
+	if len(got) != 17 {
+		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 17 metrics, got %d", len(got))
 	}
 
 	assertGaugeClose(t, got, c.userspaceSessionTableEntries, nil, 77)
@@ -934,6 +944,9 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	// #2317: WG-decap RFC 6040 §4.2 illegal-combo drop counter emitted
 	// unconditionally.
 	assertCounterClose(t, got, c.userspaceWgDecapEcnIllegalDrops, nil, 5)
+	// #2331: GRE-encap DF-set oversized-outer drop counter emitted
+	// unconditionally.
+	assertCounterClose(t, got, c.userspaceGreEncapDfOversizeDrops, nil, 6)
 	// #1861: install-refusal trio emitted unconditionally.
 	assertCounterClose(t, got, c.userspaceSessionCreateDrops, nil, 9)
 	assertCounterClose(t, got, c.userspaceSessionInstallAdmissionRefused, nil, 8)

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -544,6 +544,16 @@ func (c *xpfCollector) emitUserspaceDynamicBufferMetrics(ch chan<- prometheus.Me
 		float64(status.WgDecapEcnIllegalDropsTotal),
 	)
 
+	// #2331: native-GRE encap DF-set oversized-outer drops. Emitted
+	// unconditionally so a 0 is a real "no oversized DF outers refused"
+	// signal rather than an absent series. Nonzero flags inner flows whose
+	// encapped size exceeds the tunnel path MTU.
+	ch <- prometheus.MustNewConstMetric(
+		c.userspaceGreEncapDfOversizeDrops,
+		prometheus.CounterValue,
+		float64(status.GreEncapDfOversizeDropsTotal),
+	)
+
 	var activeFlows, flowCapacity uint64
 	for _, b := range status.Bindings {
 		activeFlows += uint64(b.ActiveFlowCount)

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -817,6 +817,16 @@ type ProcessStatus struct {
 	// xpf_userspace_wg_decap_ecn_illegal_drops_total. Omitempty for wire
 	// compat with older helpers (defaults to 0).
 	WgDecapEcnIllegalDropsTotal uint64 `json:"wg_decap_ecn_illegal_drops_total,omitempty"`
+	// #2331: native-GRE encap frames dropped because the fully built outer
+	// datagram (outer IP + GRE[+key] + inner) exceeded the resolved
+	// transport/egress MTU while the IPv4 outer carries DF=1 (the only
+	// outer the native encap builder emits). A DF-set oversized outer
+	// cannot be fragmented downstream and would silently blackhole every
+	// inner flow with no PMTUD signal — so the builder refuses to emit it.
+	// Surfaced as xpf_userspace_gre_encap_df_oversize_drops_total. PMTUD /
+	// PTB signalling is deferred to #2330. Omitempty for wire compat with
+	// older helpers (defaults to 0).
+	GreEncapDfOversizeDropsTotal uint64 `json:"gre_encap_df_oversize_drops_total,omitempty"`
 	// #1769: on-demand neighbor-resolver telemetry. The resolver fires
 	// when a MissingNeighbor negative-cache fast-fail nudges a wedged dst
 	// (single-key RTM_GETNEIGH + epoch-guarded cache or probe-on-stale).

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -204,6 +204,21 @@ impl super::Coordinator {
         crate::afxdp::gre::WG_DECAP_ECN_ILLEGAL_DROPS.load(Ordering::Relaxed)
     }
 
+    /// #2331: native-GRE encap frames dropped because the fully built
+    /// outer datagram exceeded the resolved transport/egress MTU while
+    /// the IPv4 outer carries DF=1 (the only outer the native builder
+    /// emits). A DF-set oversized outer cannot be fragmented downstream
+    /// and would silently blackhole every inner flow over the tunnel
+    /// with no PMTUD signal — so the builder refuses to emit it. Surfaced
+    /// as `xpf_userspace_gre_encap_df_oversize_drops_total`; a nonzero
+    /// value flags inner flows whose encapped size exceeds the tunnel
+    /// path MTU (a missing/too-high inner MSS clamp, or a non-TCP inner
+    /// with no segmentation lever). PMTUD/PTB signalling is deferred to
+    /// #2330.
+    pub fn gre_encap_df_oversize_drops_total(&self) -> u64 {
+        crate::afxdp::gre::GRE_ENCAP_DF_OVERSIZE_DROPS.load(Ordering::Relaxed)
+    }
+
     /// #1782: debug dump of every key currently present in the userspace
     /// `dynamic_neighbors` mirror, as `(ifindex, ip)` pairs. The
     /// cold-start capture harness reads this at the pre-connect t0'

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -107,6 +107,29 @@ pub(in crate::afxdp) static GRE_DECAP_ECN_ILLEGAL_DROPS: AtomicU64 = AtomicU64::
 /// WG ingress / congested path CE-marked the outer of a Not-ECT inner.
 pub(in crate::afxdp) static WG_DECAP_ECN_ILLEGAL_DROPS: AtomicU64 = AtomicU64::new(0);
 
+/// #2331: count of native-GRE encap frames DROPPED because the fully
+/// built outer datagram (outer IP + GRE header[+key] + inner packet)
+/// exceeded the resolved transport/egress MTU while the IPv4 outer
+/// carries DF=1 (the only outer the native encap builder emits — see
+/// `encapsulate_native_gre_frame`). A DF-set outer larger than the path
+/// MTU cannot be fragmented downstream and would be silently dropped by
+/// the egress NIC or an intermediate router with no PMTUD signal back to
+/// the inner source — a blackhole for every inner flow whose encapped
+/// size exceeds the path MTU. We refuse to EMIT that frame (drop +
+/// bump). Surfaced via `coordinator/status.rs` as
+/// `xpf_userspace_gre_encap_df_oversize_drops_total`. A nonzero value
+/// flags inner flows whose encapped size exceeds the tunnel path MTU —
+/// most often a missing/too-high inner MSS clamp (`native_gre_tcp_mss`)
+/// or a non-TCP inner (UDP/ICMP/ESP) with no segmentation lever.
+///
+/// PMTUD (ICMP Frag-Needed / PTB) signalling back to the inner source is
+/// intentionally NOT generated here: the post-transform PMTUD plumbing
+/// is owned by #2330 (and inner TCP-segment sizing by #2329). This site
+/// scopes to stop EMITTING the oversized DF outer (drop + count); the
+/// PTB signal is deferred to #2330 so the two changes do not duplicate
+/// the same plumbing.
+pub(in crate::afxdp) static GRE_ENCAP_DF_OVERSIZE_DROPS: AtomicU64 = AtomicU64::new(0);
+
 /// Read the inner IP packet's DSCP+ECN byte for outer-header
 /// propagation on tunnel encap (#2303). Returns the full 8-bit
 /// TOS / Traffic-Class value (DSCP in the high 6 bits, ECN in the
@@ -646,6 +669,24 @@ pub(super) fn try_native_gre_decap_from_frame(
     })
 }
 
+/// #2331: the built native-GRE OUTER L3 datagram length for an
+/// `inner_len`-byte inner packet — outer IP header + GRE header (incl.
+/// the optional 4-byte key, already folded into `gre_len`) + inner. The
+/// L2 Ethernet/VLAN header is deliberately EXCLUDED: the MTU budget is
+/// the L3 payload limit, and this matches `native_gre_inner_mtu`
+/// (forwarding/mod.rs), which subtracts exactly `outer_ip + gre` from
+/// the transport MTU to derive the inner allowance. Pulled out so the
+/// MTU arithmetic is unit-testable in isolation (mirrors wg.rs's
+/// `wg_encapped_size`).
+#[inline]
+pub(in crate::afxdp) fn gre_encapped_outer_len(
+    outer_ip_len: usize,
+    gre_len: usize,
+    inner_len: usize,
+) -> usize {
+    outer_ip_len + gre_len + inner_len
+}
+
 pub(super) fn encapsulate_native_gre_frame(
     inner_frame: &[u8],
     inner_meta: impl Into<ForwardPacketMeta>,
@@ -688,6 +729,28 @@ pub(super) fn encapsulate_native_gre_frame(
         libc::AF_INET6 => 40,
         _ => return None,
     };
+
+    // #2331: refuse to EMIT an oversized DF-set outer. The IPv4 outer
+    // this builder writes always carries DF=1 (#1440), and the IPv6
+    // outer cannot be fragmented in-path either — so an outer L3
+    // datagram larger than the transport/egress MTU is a downstream
+    // blackhole (NIC/router drop, no PMTUD back to the inner source).
+    // Compare the built outer L3 length (outer IP + GRE[+key] + inner;
+    // the L2 eth/VLAN header is NOT part of the MTU budget) against the
+    // SAME resolved outer MTU the rest of the tunnel path uses
+    // (`tunnel_outer_mtu`, #2300 SSOT — the real transport ifindex, not
+    // the logical tunnel ifindex). The 4-byte GRE key, when present, is
+    // already folded into `gre_len`, so a key-present endpoint's extra
+    // 4 bytes are counted. Drop + bump rather than emit; PMTUD/PTB
+    // signalling from this site is deferred to #2330 (see the
+    // GRE_ENCAP_DF_OVERSIZE_DROPS doc comment).
+    let outer_l3_len = gre_encapped_outer_len(outer_ip_len, gre_len, inner_packet.len());
+    let outer_mtu = tunnel_outer_mtu(forwarding, decision, endpoint);
+    if outer_l3_len > outer_mtu {
+        GRE_ENCAP_DF_OVERSIZE_DROPS.fetch_add(1, Ordering::Relaxed);
+        return None;
+    }
+
     let frame_len = outer_eth_len + outer_ip_len + gre_len + inner_packet.len();
     let mut out = vec![0u8; frame_len];
     write_eth_header_slice(

--- a/userspace-dp/src/afxdp/tunnel_tests.rs
+++ b/userspace-dp/src/afxdp/tunnel_tests.rs
@@ -351,6 +351,168 @@ fn gre_encap_copies_inner_dscp_ecn_to_outer_ipv6_traffic_class() {
     assert_ne!(outer_tc, 0, "stripped DSCP/ECN regression");
 }
 
+/// Build a valid IPv4 inner packet of exactly `total` bytes (>= 20),
+/// with the IPv4 total-length field set to `total` so
+/// `packet_trimmed_len` keeps the whole buffer (no trim).
+fn inner_ipv4_of_len(total: usize) -> Vec<u8> {
+    assert!(total >= 20 && total <= u16::MAX as usize);
+    let mut pkt = vec![0u8; total];
+    pkt[0] = 0x45; // version 4, IHL 5
+    pkt[1] = 0; // TOS
+    pkt[2..4].copy_from_slice(&(total as u16).to_be_bytes()); // total length
+    pkt[8] = 64; // TTL
+    pkt[9] = PROTO_TCP;
+    pkt[12..16].copy_from_slice(&[10, 0, 0, 1]); // src
+    pkt[16..20].copy_from_slice(&[10, 0, 0, 2]); // dst
+    pkt
+}
+
+// --- #2331 native-GRE encap DF-set oversized-outer MTU guard -----------
+
+use super::super::gre::{gre_encapped_outer_len, GRE_ENCAP_DF_OVERSIZE_DROPS};
+
+/// The pure outer-L3 arithmetic must fold in the GRE key bytes (already
+/// part of `gre_len`) and EXCLUDE the L2 header. Fail-on-revert: if the
+/// helper ever starts counting eth/VLAN, or drops the key term, the
+/// expected sums below diverge.
+#[test]
+fn gre_encapped_outer_len_is_outer_l3_only() {
+    // IPv6 outer (40) + GRE no-key (4) + 1000 inner = 1044.
+    assert_eq!(gre_encapped_outer_len(40, 4, 1000), 1044);
+    // IPv4 outer (20) + GRE with key (8) + 1000 inner = 1028; the 4-byte
+    // key adds exactly 4 vs the no-key (20 + 4 + 1000 = 1024) case.
+    assert_eq!(gre_encapped_outer_len(20, 8, 1000), 1028);
+    assert_eq!(gre_encapped_outer_len(20, 4, 1000), 1024);
+}
+
+#[test]
+fn gre_encap_drops_oversized_df_outer_and_bumps_counter() {
+    // The gre1881 fixture is IPv6-outer (40-byte outer IP), no key
+    // (gre_len 4), 1500-byte transport MTU. Discover the resolved outer
+    // MTU, then size the inner so the built outer L3 (40 + 4 + inner)
+    // exceeds it by one byte — the DF-set / un-fragmentable oversized
+    // case the builder must refuse.
+    let state = gre1881_state();
+    let decision = SessionDecision {
+        resolution: gre_encap_resolution(),
+        nat: NatDecision::default(),
+    };
+    let endpoint = state.tunnel_endpoints.get(&1).expect("fixture endpoint");
+    let outer_mtu = tunnel_outer_mtu(&state, &decision, endpoint);
+    assert!(outer_mtu > 64, "fixture outer MTU should be ~1500");
+
+    // outer L3 = 40 (IPv6) + 4 (GRE no-key) + inner_len; pick inner_len so
+    // the outer is exactly outer_mtu + 1.
+    let inner_len = outer_mtu + 1 - (40 + 4);
+    let inner = inner_ipv4_of_len(inner_len);
+    let inner_frame = wrap_raw_ip_packet_for_tunnel(&inner, libc::AF_INET as u8);
+    let mut meta = ForwardPacketMeta::default();
+    meta.addr_family = libc::AF_INET as u8;
+    meta.protocol = PROTO_TCP;
+    meta.l3_offset = 14;
+
+    let before = GRE_ENCAP_DF_OVERSIZE_DROPS.load(Ordering::Relaxed);
+    let out = encapsulate_native_gre_frame(&inner_frame, meta, &decision, &state);
+
+    assert!(
+        out.is_none(),
+        "an outer datagram larger than the transport MTU must NOT be \
+         emitted (DF-set / un-fragmentable blackhole) — pre-#2331 it was"
+    );
+    // `>=` not `== before + 1`: GRE_ENCAP_DF_OVERSIZE_DROPS is a
+    // process-global static and the other oversize tests (key-present)
+    // may bump it between the snapshots when tests run in parallel.
+    assert!(
+        GRE_ENCAP_DF_OVERSIZE_DROPS.load(Ordering::Relaxed) >= before + 1,
+        "the oversized-DF-outer drop must advance the counter"
+    );
+}
+
+#[test]
+fn gre_encap_emits_when_outer_within_mtu() {
+    // Same fixture, but size the inner so the outer L3 is exactly at the
+    // MTU — the legitimate in-MTU case must still build a frame.
+    let state = gre1881_state();
+    let decision = SessionDecision {
+        resolution: gre_encap_resolution(),
+        nat: NatDecision::default(),
+    };
+    let endpoint = state.tunnel_endpoints.get(&1).expect("fixture endpoint");
+    let outer_mtu = tunnel_outer_mtu(&state, &decision, endpoint);
+
+    let inner_len = outer_mtu - (40 + 4); // outer L3 == outer_mtu exactly
+    let inner = inner_ipv4_of_len(inner_len);
+    let inner_frame = wrap_raw_ip_packet_for_tunnel(&inner, libc::AF_INET as u8);
+    let mut meta = ForwardPacketMeta::default();
+    meta.addr_family = libc::AF_INET as u8;
+    meta.protocol = PROTO_TCP;
+    meta.l3_offset = 14;
+
+    let out = encapsulate_native_gre_frame(&inner_frame, meta, &decision, &state);
+
+    // The Some(_) return is the fail-on-revert signal here: an outer
+    // exactly AT the MTU must still build a frame (the guard is strictly
+    // `>`, not `>=`). We do NOT assert the global drop counter is
+    // unchanged — it is a process-global static shared with the parallel
+    // oversize tests, which would race a `== before` check.
+    assert!(
+        out.is_some(),
+        "an outer exactly AT the transport MTU must still be emitted"
+    );
+}
+
+#[test]
+fn gre_encap_mtu_accounts_for_4byte_key() {
+    // Boundary test: pick an inner_len so the NO-key outer (gre_len 4) is
+    // exactly at the MTU, then flip the endpoint to key-present (gre_len
+    // 8). The extra 4 key bytes push the same inner one over the MTU —
+    // proving the key is folded into the MTU math (#2331 / issue's
+    // key-present requirement). No-key: emits. Key-present: drops.
+    let mut state = gre1881_state();
+    let decision = SessionDecision {
+        resolution: gre_encap_resolution(),
+        nat: NatDecision::default(),
+    };
+    let endpoint = state.tunnel_endpoints.get(&1).expect("fixture endpoint");
+    let outer_mtu = tunnel_outer_mtu(&state, &decision, endpoint);
+
+    // outer L3 (no key) = 40 + 4 + inner_len == outer_mtu exactly.
+    let inner_len = outer_mtu - (40 + 4);
+    let inner = inner_ipv4_of_len(inner_len);
+    let inner_frame = wrap_raw_ip_packet_for_tunnel(&inner, libc::AF_INET as u8);
+    let mut meta = ForwardPacketMeta::default();
+    meta.addr_family = libc::AF_INET as u8;
+    meta.protocol = PROTO_TCP;
+    meta.l3_offset = 14;
+
+    // No key: at the MTU, must emit.
+    assert!(
+        encapsulate_native_gre_frame(&inner_frame, meta, &decision, &state).is_some(),
+        "no-key outer exactly at MTU must emit"
+    );
+
+    // Flip the endpoint to key-present: the +4 key bytes tip it oversize.
+    state
+        .tunnel_endpoints
+        .get_mut(&1)
+        .expect("fixture endpoint")
+        .key = 0x1234_5678;
+
+    let before = GRE_ENCAP_DF_OVERSIZE_DROPS.load(Ordering::Relaxed);
+    let out = encapsulate_native_gre_frame(&inner_frame, meta, &decision, &state);
+    assert!(
+        out.is_none(),
+        "with a 4-byte GRE key the same inner exceeds the MTU and must \
+         be dropped — the key bytes MUST be counted in the MTU math"
+    );
+    // `>=`: process-global static, parallel-test-safe (see the sibling
+    // oversize test's note).
+    assert!(
+        GRE_ENCAP_DF_OVERSIZE_DROPS.load(Ordering::Relaxed) >= before + 1,
+        "key-present oversize must advance the counter"
+    );
+}
+
 #[test]
 fn inner_tos_byte_reads_ipv4_and_ipv6() {
     // IPv4: TOS is octet 1.

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -255,6 +255,19 @@ pub(crate) struct ProcessStatus {
     /// for backward compatibility.
     #[serde(rename = "wg_decap_ecn_illegal_drops_total", default)]
     pub wg_decap_ecn_illegal_drops_total: u64,
+    /// #2331: native-GRE encap frames DROPPED because the fully built
+    /// outer datagram (outer IP + GRE[+key] + inner) exceeded the
+    /// resolved transport/egress MTU while the IPv4 outer carries DF=1
+    /// (the only outer the native encap builder emits). A DF-set
+    /// oversized outer cannot be fragmented downstream and would
+    /// silently blackhole every inner flow with no PMTUD signal — so the
+    /// builder refuses to emit it. Surfaced as the Prometheus counter
+    /// `xpf_userspace_gre_encap_df_oversize_drops_total`; nonzero flags
+    /// inner flows whose encapped size exceeds the tunnel path MTU.
+    /// PMTUD/PTB signalling is deferred to #2330. Additive / defaulted
+    /// for backward compatibility.
+    #[serde(rename = "gre_encap_df_oversize_drops_total", default)]
+    pub gre_encap_df_oversize_drops_total: u64,
     /// #1782 cold-start capture instrumentation. Debug dump of every key
     /// present in the userspace `dynamic_neighbors` mirror, rendered as
     /// `"ifindex ip"` strings. The capture harness greps this at the

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -220,6 +220,35 @@ fn process_status_wg_decap_ecn_illegal_drops_roundtrip() {
     assert_eq!(legacy.wg_decap_ecn_illegal_drops_total, 0);
 }
 
+// #2331: round-trip + backward-compat pin for the native-GRE encap
+// DF-set oversized-outer drop counter. The wire key feeds
+// pkg/dataplane/userspace/protocol.go and the Prometheus counter
+// `xpf_userspace_gre_encap_df_oversize_drops_total`.
+#[test]
+fn process_status_gre_encap_df_oversize_drops_roundtrip() {
+    let status = ProcessStatus {
+        gre_encap_df_oversize_drops_total: 9,
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize ProcessStatus to Value");
+    assert_eq!(value["gre_encap_df_oversize_drops_total"], 9);
+    let back: ProcessStatus = serde_json::from_value(value).expect("deserialize ProcessStatus");
+    assert_eq!(back.gre_encap_df_oversize_drops_total, 9);
+
+    // Pre-#2331 payload (key absent) must decode with a zero default.
+    let mut legacy_value =
+        serde_json::to_value(ProcessStatus::default()).expect("serialize default ProcessStatus");
+    legacy_value
+        .as_object_mut()
+        .expect("ProcessStatus serializes to an object")
+        .remove("gre_encap_df_oversize_drops_total")
+        .expect("new key present before strip");
+    let legacy: ProcessStatus =
+        serde_json::from_value(legacy_value).expect("pre-#2331 payload decodes");
+    assert_eq!(legacy.gre_encap_df_oversize_drops_total, 0);
+}
+
 // #1760 W3': round-trip + backward-compat pin for the shared-map NAT
 // reverse-key displacement counter. The wire key feeds
 // pkg/dataplane/userspace/protocol.go and the Prometheus counter

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -93,6 +93,12 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     // un-ECN inner traffic on a congested path.
     state.status.wg_decap_ecn_illegal_drops_total =
         state.afxdp.wg_decap_ecn_illegal_drops_total();
+    // #2331: native-GRE encap DF-set oversized-outer drops. Nonzero =
+    // inner flows whose encapped size exceeds the tunnel path MTU; the
+    // builder refused to emit the un-fragmentable DF outer (blackhole)
+    // rather than silently dropping it downstream.
+    state.status.gre_encap_df_oversize_drops_total =
+        state.afxdp.gre_encap_df_oversize_drops_total();
     // The per-key dynamic_neighbors dump is a high-cardinality
     // (ifindex,ip)-labelled debug surface used only by the #1782 cold-start
     // capture. Gate it behind XPF_DEBUG_NEIGHBOR_KEYS so it is OFF by default:

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -117,6 +117,7 @@ pub(crate) fn run() -> Result<(), String> {
             worker_command_queue_poison_recoveries: 0,
             gre_decap_ecn_illegal_drops_total: 0,
             wg_decap_ecn_illegal_drops_total: 0,
+            gre_encap_df_oversize_drops_total: 0,
             dynamic_neighbor_keys: Vec::new(),
             neighbor_resolver_queue_depth: 0,
             neighbor_resolver_enqueue_drops_total: 0,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -756,6 +756,7 @@
     "flow_worker_map_truncated": false,
     "forwarding_armed": false,
     "gre_decap_ecn_illegal_drops_total": 0,
+    "gre_encap_df_oversize_drops_total": 0,
     "ha_groups": [],
     "helper_mode": "",
     "inject_packet_tuple_protocol_version": 0,


### PR DESCRIPTION
Closes #2331

## Problem

`encapsulate_native_gre_frame` (userspace-dp/src/afxdp/gre.rs) built and
returned the outer GRE frame with **no comparison of the outer datagram
length against the transport/egress MTU**. The IPv4 outer is built with
`DF=1` (#1440), and the IPv6 outer cannot be fragmented in-path either.
So an outer larger than the path MTU egressed un-fragmentable: it was
dropped by the egress NIC or an intermediate router with **no PMTUD
signal back to the inner source** — a silent blackhole for every inner
flow whose encapped size exceeded the path MTU. (Not TCP-only: GRE
carries UDP/ICMP/ESP with no segmentation lever.)

The only existing backstop was the dispatch `copy_frame_is_oversized`
descriptor-capacity check, which is **not** an MTU check; the #2301
source-frame PTB path deliberately excludes native tunnels because a
source-frame-vs-egress-MTU PTB would be wrong for encap.

## Fix

The size-check site is **userspace-dp/src/afxdp/gre.rs** (in
`encapsulate_native_gre_frame`, immediately before the `vec![0u8; frame_len]`
allocation). Before building the frame:

- Size the outer **L3** datagram — `outer IP + GRE header (incl. the
  optional 4-byte key) + inner` — via the new unit-testable
  `gre_encapped_outer_len` helper. The L2 eth/VLAN header is excluded
  (it is not part of the MTU budget), matching `native_gre_inner_mtu`.
- Resolve the outer MTU with `tunnel_outer_mtu` (forwarding/mod.rs, the
  #2300 SSOT used by the inner MSS clamp: real transport ifindex →
  stored-resolution egress → endpoint logical ifindex, `unwrap_or(1500)`).
- If the outer exceeds the MTU, **drop** (return `None`) and bump the new
  `GRE_ENCAP_DF_OVERSIZE_DROPS` counter.

### Counter

Added `GRE_ENCAP_DF_OVERSIZE_DROPS`, wired through `status.rs` →
`server/helpers.rs`+`lifecycle.rs` → `ProcessStatus.gre_encap_df_oversize_drops_total`
→ Go `protocol.go` → Prometheus
`xpf_userspace_gre_encap_df_oversize_drops_total` (mirrors the #2315 /
#2317 decap-drop counters). `protocol_wire_v1.json` regenerated (1 new
key, additive/defaulted — backward compatible).

### PMTUD deferred to #2330

PMTUD/PTB (ICMP Frag-Needed / Packet-Too-Big) signalling back to the
inner source is **deferred to #2330** (post-transform PMTUD plumbing;
inner TCP-segment sizing is #2329). The correct inner-source PTB must be
derived from the inner MTU after subtracting tunnel overhead — exactly
the work #2330 owns, and exactly why the #2301 plain-forward PTB path
already excludes `uses_native_tunnel`. This PR scopes to **drop + count**
so the two changes do not duplicate the plumbing. No PTB is generated
from the encap site.

DF-clear: not applicable — the native builder only emits IPv4 DF=1 and
IPv6 (no in-path fragmentation for either), so the drop applies uniformly.

## Tests (fail-on-revert)

Rust (userspace-dp/src/afxdp/tunnel_tests.rs +
userspace-dp/src/protocol/tests.rs):
- `gre_encap_drops_oversized_df_outer_and_bumps_counter` — outer one byte
  over MTU is not emitted + counter advances.
- `gre_encap_emits_when_outer_within_mtu` — outer exactly at MTU still
  emits (guard is strict `>`).
- `gre_encap_mtu_accounts_for_4byte_key` — same inner emits no-key (at
  MTU) but drops key-present (the +4 key bytes tip it over) — proves the
  key is in the MTU math.
- `gre_encapped_outer_len_is_outer_l3_only` — pure arithmetic: folds the
  key, excludes L2.
- `process_status_gre_encap_df_oversize_drops_roundtrip` — wire roundtrip
  + pre-#2331 backward-compat.

Go (pkg/api/metrics_test.go): collector emits the counter
unconditionally; coverage-list + count assertions updated.

## Validation

- `cargo build --release` clean.
- `cargo test --release -- gre encap df mtu oversize` green; new tests
  pass 8x with no flake.
- `go build ./...` clean; `go test ./pkg/api/ ./pkg/dataplane/userspace/`
  green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi