### PR TITLE
#2330: post-transform PMTUD — inner-source PTB for NAT64/GRE/WireGuard

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -10369,3 +10369,45 @@ top.
   userspace-dp/src/afxdp/README.md,
   pkg/dataplane/userspace/protocol.go,
   pkg/dataplane/userspace/format/status.go, docs/feature-coverage.md
+
+## 2026-06-22 — #2330 post-transform PMTUD (NAT64/GRE/WireGuard inner-source PTB)
+
+- **Timestamp**: 2026-06-22
+- **Action**: Added a POST-TRANSFORM PMTUD path so size-changing forwards
+  (NAT64, native GRE, WireGuard) generate an inner-source ICMP Frag-Needed /
+  Packet-Too-Big derived from the INNER MTU, closing the silent-blackhole gap
+  #2301 left (it gated PTB on `!is_nat64 && !uses_native_tunnel`) and the
+  PTB signal #2331 explicitly deferred here. New `post_transform_inner_mtu`
+  (icmp_ptb.rs) derives the inner MTU from the existing SSOT: GRE via
+  `native_gre_inner_mtu`, WireGuard via the new pad-aware `wg::mss::wg_inner_mtu`
+  (inverse of `frame::wg::wg_encapped_size`), NAT64 via the egress MTU ± 20
+  v6<->v4 header delta (RFC 7915). The dispatcher (tx/dispatch/mod.rs) now
+  runs the existing `forwarded_egress_mtu_decision` + `build_frag_needed_v4` /
+  `build_packet_too_big_v6` against the inner `source_frame` (which IS the
+  pre-encap/pre-translate inner packet; `meta.addr_family` is the inner
+  family) with the inner MTU as the comparison, and the generated PTB routes
+  through `classify_generated_reply` (#2328) at the shared finalizer. Pre-build
+  `mtu_signalled` skips the encap/translate build entirely, so the #2331
+  `GRE_ENCAP_DF_OVERSIZE_DROPS` and WG `encap_mtu_drops` guards are NOT bumped
+  for the PTB case (no double-drop / double-count); they remain the backstop
+  only for the residual non-DF-IPv4-inner `Forward` case. Fail-open when no
+  MTU resolvable / unknown tunnel kind (decision returns Forward). No wire
+  counter added — reuses existing `mtu_signalled` / `egress_mtu_exceeded`
+  exception / `ptb_output_filter_drops` accounting, so no protocol_wire_v1.json
+  / Go rebuild needed. Tests: 10 in icmp_ptb_tests.rs (inner-MTU per type,
+  GRE key-word, WG pad-aware, NAT64 both directions, unknown-kind fail-open,
+  end-to-end oversize -> inner PTB for GRE-v4-DF / WG-v6 / NAT64-v6,
+  in-MTU-no-PTB), 2 in cos_classify_tests.rs (post-transform PTB through
+  classify_generated_reply: terminal-discard drop + filterless admit), 4 in
+  wg/mss.rs (wg_inner_mtu). cargo build --release clean; full suite green;
+  new tests 5x stable.
+- **File(s)**: userspace-dp/src/afxdp/icmp_ptb.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs,
+  userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/afxdp/tx/dispatch/mod.rs,
+  userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+  userspace-dp/src/afxdp/wg/mss.rs,
+  userspace-dp/src/afxdp/gre.rs,
+  userspace-dp/src/afxdp/frame/wg.rs,
+  userspace-dp/src/afxdp/README.md,
+  docs/userspace-native-gre-plan.md

--- a/docs/userspace-native-gre-plan.md
+++ b/docs/userspace-native-gre-plan.md
@@ -195,14 +195,41 @@ signal back to the inner source). The drop bumps
 A nonzero counter flags inner flows whose encapped size exceeds the
 tunnel path MTU — typically a missing/too-high inner MSS clamp
 (`native_gre_tcp_mss`), or a non-TCP inner (UDP/ICMP/ESP) with no
-segmentation lever. PMTUD (ICMP Frag-Needed / Packet-Too-Big) signalling
-back to the inner source is **deferred to #2330** (the post-transform
-PMTUD plumbing; inner TCP-segment sizing is #2329). This site scopes to
-drop+count only, mirroring the deliberate `!uses_native_tunnel`
-exclusion in the plain-forward PTB path (tx/dispatch/mod.rs, #2301):
-the source-frame-vs-egress-MTU check there would produce a false PTB for
-tunnel encap because the correct inner-source PTB must be derived from
-the inner MTU after subtracting tunnel overhead.
+segmentation lever.
+
+#### Post-transform PMTUD (#2330, closes the #2331-deferred signal)
+
+The inner-source PTB that #2331 deferred is now generated in the TX
+dispatcher (`tx/dispatch/mod.rs`). #2301's plain-forward PTB compared the
+SOURCE frame against the egress MTU — correct only for a size-preserving
+forward — and deliberately excluded `!uses_native_tunnel` / `!is_nat64`
+because the source-vs-egress check produces a FALSE PTB for a transformed
+path (the frame grows on encap / changes header size on NAT64). #2330
+replaces that exclusion with a PRE-build `post_transform_inner_mtu`
+decision: it derives the INNER MTU (the largest inner IP packet whose
+TRANSFORMED frame fits the egress/transport MTU) from the same SSOT this
+guard uses —
+
+- **GRE**: `native_gre_inner_mtu` (== `tunnel_outer_mtu − outer_ip − gre`,
+  the exact inverse of this guard's comparison),
+- **WireGuard**: `wg::mss::wg_inner_mtu` (pad-aware, the inverse of
+  `frame::wg::wg_encapped_size`),
+- **NAT64**: the egress MTU ± 20 for the v6↔v4 header delta (RFC 7915),
+
+— and runs the existing `forwarded_egress_mtu_decision` + ICMP builders
+(`build_frag_needed_v4` / `build_packet_too_big_v6`) against the inner
+`source_frame` (the pre-encap / pre-translate inner packet, `meta`'s
+family = the inner family). The PTB carries the inner MTU and routes
+through `classify_generated_reply` (#2328) at the finalizer, identically
+to the plain path.
+
+Coordination with this drop guard: when a PTB is owed (inner IPv4 DF or
+IPv6) the decision sets `mtu_signalled` and SKIPS the encap build, so
+`GRE_ENCAP_DF_OVERSIZE_DROPS` is NOT bumped — no double-drop / double-
+count. The guard's drop+count now fires only for the residual case where
+no PTB is owed (a non-DF IPv4 inner, kept `Forward` to preserve
+fragmentable behaviour) whose encapped outer still exceeds the DF-set
+transport MTU. Inner TCP-segment sizing remains #2329.
 
 ### 4. Session Model
 

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -71,11 +71,31 @@ sync.
     and drops the oversized original (`mtu_signalled` keeps
     `retained_source_frame` false → the finalizer recycles the ingress
     descriptor; a suppressed/unbuildable reply is the fail-closed silent
-    drop). NAT64 / native-tunnel encap are skipped (their on-wire L3 size
-    differs from the source frame; the descriptor-capacity oversized
-    backstop still applies). The reply is built inside the
-    `target_binding` borrow and enqueued onto `ingress_binding` once that
-    borrow ends.
+    drop). The reply is built inside the `target_binding` borrow and
+    enqueued onto `ingress_binding` once that borrow ends.
+    **Post-transform PMTUD (#2330):** the #2301 decision above compares the
+    SOURCE frame against the egress MTU, which is correct ONLY for a
+    size-preserving plain forward. For the size-CHANGING paths (NAT64,
+    native GRE, WireGuard) the on-wire frame grows (encap) or its header
+    shrinks/grows (NAT64), so a source-vs-egress comparison is wrong and
+    #2301 skipped them entirely — leaving the inner source with NO PMTUD
+    signal (a silent blackhole). #2330 derives the INNER-source MTU (the
+    largest inner IP packet whose TRANSFORMED frame fits the
+    egress/transport MTU) from the #2300/#2331 SSOT helpers
+    (`post_transform_inner_mtu` → `native_gre_inner_mtu` for GRE,
+    `wg::mss::wg_inner_mtu` for WireGuard, the v6↔v4 ±20 header delta for
+    NAT64) and runs the SAME `forwarded_egress_mtu_decision` + builders
+    against the inner `source_frame` (which IS the pre-encap / pre-translate
+    inner packet, with `meta.addr_family` the inner family). The generated
+    PTB carries the INNER MTU and routes through `classify_generated_reply`
+    (#2328) at the finalizer, identically to the plain path. This CLOSES the
+    PTB signal #2331 deferred: an oversized GRE/WG inner now yields a
+    Frag-Needed/PTB instead of a silent `GRE_ENCAP_DF_OVERSIZE_DROPS` /
+    `encap_mtu_drops` — and because `mtu_signalled` skips the build entirely,
+    there is no double-drop/double-count with those encap guards (a non-DF
+    IPv4 inner stays fragmentable → `Forward` → the #2331 drop guard remains
+    the backstop). `mtu == 0` (no MTU resolvable / unknown tunnel kind)
+    fails open to `Forward`.
 - `icmp_ptb.rs` — #2301 PMTUD error generators for the generic
   forwarder: the egress-MTU decision plus the ICMPv4 Frag-Needed /
   ICMPv6 Packet-Too-Big builders (MTU in the body). Mirrors

--- a/userspace-dp/src/afxdp/frame/wg.rs
+++ b/userspace-dp/src/afxdp/frame/wg.rs
@@ -110,6 +110,16 @@ pub(super) fn wg_encap_frame(
         // #1865: the promised "follow-up" counter store — same
         // `encap_mtu_drops` counter as the control thread's symmetric
         // guard (the plan's both-guards requirement).
+        //
+        // #2330: when a PTB is OWED (inner IPv4 DF or IPv6), the TX
+        // dispatcher's pre-build `post_transform_inner_mtu` decision fires
+        // BEFORE this builder is called (advertising the WG inner MTU =
+        // `wg::mss::wg_inner_mtu`, the inverse of `wg_encapped_size`),
+        // `mtu_signalled` skips the encap build, and this site is never
+        // reached for that case — so the PTB and this drop counter never
+        // both fire. This guard remains the backstop for a non-DF IPv4
+        // inner (kept `Forward` to preserve fragmentable behaviour) whose
+        // encapped outer still exceeds the MTU.
         crate::afxdp::wg::counters::WgCounters::bump(&engine.counters().encap_mtu_drops);
         return None;
     }

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -123,11 +123,18 @@ pub(in crate::afxdp) static WG_DECAP_ECN_ILLEGAL_DROPS: AtomicU64 = AtomicU64::n
 /// or a non-TCP inner (UDP/ICMP/ESP) with no segmentation lever.
 ///
 /// PMTUD (ICMP Frag-Needed / PTB) signalling back to the inner source is
-/// intentionally NOT generated here: the post-transform PMTUD plumbing
-/// is owned by #2330 (and inner TCP-segment sizing by #2329). This site
-/// scopes to stop EMITTING the oversized DF outer (drop + count); the
-/// PTB signal is deferred to #2330 so the two changes do not duplicate
-/// the same plumbing.
+/// NOT generated at THIS site — it lives in the TX dispatcher
+/// (`tx/dispatch/mod.rs`, #2330). For the case where a PTB is owed (the
+/// inner is IPv4 DF or IPv6), the dispatcher's PRE-build
+/// `post_transform_inner_mtu` decision fires first, builds the inner-source
+/// PTB advertising the GRE inner MTU (the SAME `native_gre_inner_mtu` value
+/// this guard's `tunnel_outer_mtu - outer_ip - gre` math reduces to), sets
+/// `mtu_signalled`, and SKIPS the encap build — so this counter is NOT
+/// bumped in that case (no double-drop / double-count). This drop+bump now
+/// fires only for the residual case where no PTB is owed but the outer is
+/// still oversized: a non-DF IPv4 inner (downstream-fragmentable, so #2301/
+/// #2330 keep `Forward` to preserve pre-#2301 behaviour) whose encapped
+/// outer nonetheless exceeds the DF-set transport MTU.
 pub(in crate::afxdp) static GRE_ENCAP_DF_OVERSIZE_DROPS: AtomicU64 = AtomicU64::new(0);
 
 /// Read the inner IP packet's DSCP+ECN byte for outer-header

--- a/userspace-dp/src/afxdp/icmp_ptb.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb.rs
@@ -137,8 +137,12 @@ pub(in crate::afxdp) fn forwarded_egress_mtu_decision(
 ///     bytes SMALLER. The advertised value is floored at the per-family
 ///     minimum by `forwarded_egress_mtu_decision`.
 ///
-/// Returns 0 (fail-open — never invent a too-small MTU) when no MTU is
-/// resolvable, the endpoint row is missing, or the tunnel kind is unknown.
+/// Returns 0 (fail-open — never invent a too-small MTU) when the endpoint
+/// row is missing, the tunnel kind is unknown, or the computed inner MTU is
+/// below the usable minimum (the per-kind inner-MTU helper returns 0). Note:
+/// the outer/transport MTU itself always resolves — `tunnel_outer_mtu` falls
+/// back to 1500 — so a 0 return reflects a missing/unknown endpoint or an
+/// unusably-small inner budget, never an unresolved outer MTU.
 /// `egress_mtu` is the already-resolved physical egress-interface MTU
 /// (`forwarded_egress_mtu`); used only for the NAT64 arm (the tunnel arms
 /// re-resolve the transport MTU via the SSOT helpers).

--- a/userspace-dp/src/afxdp/icmp_ptb.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb.rs
@@ -106,6 +106,88 @@ pub(in crate::afxdp) fn forwarded_egress_mtu_decision(
     }
 }
 
+/// #2330: the inner-source post-transform MTU for a size-changing forward
+/// path (NAT64 / native GRE / WireGuard).
+///
+/// #2301's `forwarded_egress_mtu_decision` compares the SOURCE frame against
+/// the egress MTU, which is correct ONLY for a plain forward where the
+/// on-wire size does not change. For a transformed path the on-wire frame
+/// GROWS (GRE/WG encap) or its header SHRINKS/GROWS (NAT64 v6<->v4), so a
+/// source-frame-vs-egress-MTU comparison is wrong and #2301 deliberately
+/// SKIPS these paths (`if !is_nat64 && !uses_native_tunnel`). The result was
+/// a silent blackhole: an inner source whose packet will not fit
+/// post-transform got NO PMTUD signal.
+///
+/// This returns the largest INNER IP packet length (the L3 size of the
+/// pre-transform `source_frame` the dispatcher already holds) whose
+/// transformed frame is guaranteed to fit the egress/transport MTU. Feeding
+/// it to `forwarded_egress_mtu_decision` as the `mtu` argument turns the
+/// existing per-family DF/IPv6 decision + the existing PTB builders into the
+/// correct INNER-source signal:
+///   - GRE: the #2300 SSOT `native_gre_inner_mtu` (transport MTU minus the
+///     outer IP + GRE[+key] header) — the SAME value the #2331 encap drop
+///     guard enforces, so this site and that drop site agree.
+///   - WireGuard: the pad-aware `wg::mss::wg_inner_mtu` derived from
+///     `tunnel_outer_mtu` (the #2300 transport-MTU SSOT) minus the WG outer
+///     overhead and worst-case §5.4.6 padding — the inverse of the
+///     `frame::wg::wg_encapped_size` drop guard.
+///   - NAT64: the egress MTU adjusted by the v6<->v4 header-size delta
+///     (RFC 7915): a v6 inner translated to a v4 egress may be 20 bytes
+///     LARGER on the inner side; a v4 inner translated to a v6 egress 20
+///     bytes SMALLER. The advertised value is floored at the per-family
+///     minimum by `forwarded_egress_mtu_decision`.
+///
+/// Returns 0 (fail-open — never invent a too-small MTU) when no MTU is
+/// resolvable, the endpoint row is missing, or the tunnel kind is unknown.
+/// `egress_mtu` is the already-resolved physical egress-interface MTU
+/// (`forwarded_egress_mtu`); used only for the NAT64 arm (the tunnel arms
+/// re-resolve the transport MTU via the SSOT helpers).
+pub(in crate::afxdp) fn post_transform_inner_mtu(
+    decision: &SessionDecision,
+    forwarding: &ForwardingState,
+    is_nat64: bool,
+    inner_addr_family: u8,
+    egress_mtu: usize,
+) -> usize {
+    if is_nat64 {
+        if egress_mtu == 0 {
+            return 0;
+        }
+        // RFC 7915 §4 / §5: the translator changes the IP header size by 20
+        // bytes (IPv6 40 vs IPv4 20). The inner source advertises a PTB in
+        // ITS family, so the inner MTU is the egress MTU adjusted by the
+        // header delta in the direction that keeps the TRANSLATED frame at
+        // or under the egress MTU.
+        return match inner_addr_family as i32 {
+            // Inner v6 -> egress v4: translated v4 is 20 bytes SMALLER, so a
+            // v6 inner up to egress_mtu + 20 still fits the v4 egress. Floor
+            // at the IPv6 minimum is applied by the decision helper.
+            libc::AF_INET6 => egress_mtu.saturating_add(20),
+            // Inner v4 -> egress v6: translated v6 is 20 bytes LARGER, so the
+            // v4 inner must be 20 bytes SMALLER than the v6 egress MTU.
+            libc::AF_INET => egress_mtu.saturating_sub(20),
+            _ => 0,
+        };
+    }
+    if decision.resolution.tunnel_endpoint_id == 0 {
+        return 0;
+    }
+    let Some(endpoint) = forwarding
+        .tunnel_endpoints
+        .get(&decision.resolution.tunnel_endpoint_id)
+    else {
+        return 0;
+    };
+    match tunnel_mode_kind(&endpoint.mode) {
+        TunnelKind::Gre => native_gre_inner_mtu(forwarding, decision),
+        TunnelKind::WireGuard => {
+            let outer_mtu = tunnel_outer_mtu(forwarding, decision, endpoint);
+            crate::afxdp::wg::mss::wg_inner_mtu(endpoint.outer_family, outer_mtu)
+        }
+        TunnelKind::Unknown => 0,
+    }
+}
+
 /// Read the IPv4 Don't-Fragment bit from an L3 (IP-header-first) slice.
 #[inline]
 fn ipv4_df_set(packet: &[u8]) -> bool {

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -522,3 +522,271 @@ fn no_primary_address_fails_closed() {
         "no ingress primary v4 -> fail-closed None"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #2330: post-transform (NAT64 / GRE / WireGuard) inner-source PMTUD.
+//
+// The on-wire size of a transformed forward differs from the SOURCE frame
+// (encap grows, NAT64 header shrinks/grows), so #2301's source-vs-egress
+// comparison is wrong and was deliberately skipped for these paths. #2330
+// derives the INNER-source MTU from the #2300/#2331 SSOT helpers and compares
+// the inner `source_frame` against THAT — feeding the existing decision +
+// builders so the inner sender gets a PTB carrying the INNER MTU instead of a
+// silent encap/translate drop.
+// ---------------------------------------------------------------------------
+
+const TUN_ID: u16 = 7;
+const TRANSPORT_IFINDEX: i32 = PTB_IFINDEX; // egress carries the transport MTU
+
+/// A ForwardingResolution wired for a native tunnel on `TRANSPORT_IFINDEX`.
+fn tunnel_resolution() -> ForwardingResolution {
+    ForwardingResolution {
+        disposition: ForwardingDisposition::ForwardCandidate,
+        local_ifindex: 0,
+        egress_ifindex: TRANSPORT_IFINDEX,
+        tx_ifindex: TRANSPORT_IFINDEX,
+        tunnel_endpoint_id: TUN_ID,
+        next_hop: None,
+        neighbor_mac: Some([0x02, 0x00, 0x00, 0x00, 0x00, 0x09]),
+        src_mac: Some(EGRESS_SRC_MAC),
+        tx_vlan_id: 0,
+    }
+}
+
+fn tunnel_decision() -> SessionDecision {
+    SessionDecision {
+        resolution: tunnel_resolution(),
+        nat: NatDecision::default(),
+    }
+}
+
+fn nat64_decision(nat64: bool) -> SessionDecision {
+    SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: TRANSPORT_IFINDEX,
+            tx_ifindex: TRANSPORT_IFINDEX,
+            tunnel_endpoint_id: 0,
+            next_hop: None,
+            neighbor_mac: Some([0x02, 0x00, 0x00, 0x00, 0x00, 0x09]),
+            src_mac: Some(EGRESS_SRC_MAC),
+            tx_vlan_id: 0,
+        },
+        nat: NatDecision {
+            nat64,
+            ..NatDecision::default()
+        },
+    }
+}
+
+/// Insert a minimal tunnel endpoint of the given `mode` / outer family /
+/// `key` so the SSOT inner-MTU helpers resolve.
+fn insert_tunnel_endpoint(fwd: &mut ForwardingState, mode: &str, outer_family: i32, key: u32) {
+    fwd.tunnel_endpoints.insert(
+        TUN_ID,
+        TunnelEndpoint {
+            id: TUN_ID,
+            logical_ifindex: TRANSPORT_IFINDEX,
+            interface_label: "tun0".into(),
+            interface: "tun0.0".into(),
+            redundancy_group: 0,
+            mode: mode.into(),
+            outer_family,
+            source: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+            destination: IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)),
+            key,
+            ttl: 64,
+            transport_table: String::new(),
+            wg_listen_port: 51820,
+            wg_local_privkey: zeroize::Zeroizing::new([0u8; 32]),
+            wg_peers: Vec::new(),
+        },
+    );
+}
+
+#[test]
+fn post_transform_inner_mtu_gre_subtracts_outer_and_gre_header() {
+    // transport MTU 1400, IPv4 outer (20) + GRE base (4), no key:
+    // inner MTU = 1400 - 24 = 1376. SAME value the #2331 encap drop guard
+    // enforces (native_gre_inner_mtu).
+    let mut fwd = forwarding_with_egress(1400);
+    insert_tunnel_endpoint(&mut fwd, "gre", libc::AF_INET, 0);
+    let decision = tunnel_decision();
+    let inner = post_transform_inner_mtu(&decision, &fwd, false, libc::AF_INET as u8, 1400);
+    assert_eq!(inner, 1376, "GRE inner MTU = transport - outer_ip(20) - gre(4)");
+    assert_eq!(
+        inner,
+        native_gre_inner_mtu(&fwd, &decision),
+        "post-transform GRE inner MTU MUST equal the #2331 encap-guard SSOT"
+    );
+}
+
+#[test]
+fn post_transform_inner_mtu_gre_counts_key_word() {
+    // A key-present endpoint adds 4 bytes of GRE header: 1400 - 28 = 1372.
+    let mut fwd = forwarding_with_egress(1400);
+    insert_tunnel_endpoint(&mut fwd, "gre", libc::AF_INET, 0xdead_beef);
+    let inner =
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, libc::AF_INET as u8, 1400);
+    assert_eq!(inner, 1372, "key-present GRE counts the extra 4-byte key word");
+}
+
+#[test]
+fn post_transform_inner_mtu_wireguard_is_pad_aware() {
+    // WG over an IPv4 outer: inner MTU = outer_mtu - WG_OVERHEAD_V4 - 15
+    // (worst-case §5.4.6 padding). WG_OVERHEAD_V4 = 20 + 8 + 16 + 16 = 60.
+    // 1400 - 60 - 15 = 1325. The inverse of frame::wg::wg_encapped_size.
+    let mut fwd = forwarding_with_egress(1400);
+    insert_tunnel_endpoint(&mut fwd, "wireguard", libc::AF_INET, 0);
+    let inner =
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, libc::AF_INET as u8, 1400);
+    assert_eq!(inner, 1325, "WG inner MTU = outer_mtu - WG_OVERHEAD_V4 - max_pad");
+    assert_eq!(
+        inner,
+        crate::afxdp::wg::mss::wg_inner_mtu(libc::AF_INET, 1400),
+        "post-transform WG inner MTU MUST equal the wg_inner_mtu SSOT"
+    );
+}
+
+#[test]
+fn post_transform_inner_mtu_unknown_tunnel_kind_fails_open() {
+    // An unknown/missing mode yields 0 (fail-open: the decision then returns
+    // Forward and the frame falls through to its normal fail-closed build).
+    let mut fwd = forwarding_with_egress(1400);
+    insert_tunnel_endpoint(&mut fwd, "l2tp", libc::AF_INET, 0);
+    assert_eq!(
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, libc::AF_INET as u8, 1400),
+        0,
+        "unknown tunnel mode -> 0 (fail-open)"
+    );
+}
+
+#[test]
+fn post_transform_inner_mtu_nat64_v6_to_v4_adds_header_delta() {
+    // Inner v6 translated to a v4 egress: the v4 frame is 20 bytes SMALLER,
+    // so a v6 inner up to egress_mtu + 20 still fits. egress 1400 -> 1420.
+    let fwd = forwarding_with_egress(1400);
+    let inner =
+        post_transform_inner_mtu(&nat64_decision(true), &fwd, true, libc::AF_INET6 as u8, 1400);
+    assert_eq!(inner, 1420, "NAT64 v6->v4 inner MTU = egress + 20");
+}
+
+#[test]
+fn post_transform_inner_mtu_nat64_v4_to_v6_subtracts_header_delta() {
+    // Inner v4 translated to a v6 egress: the v6 frame is 20 bytes LARGER,
+    // so the v4 inner must be 20 bytes SMALLER. egress 1400 -> 1380.
+    let fwd = forwarding_with_egress(1400);
+    let inner =
+        post_transform_inner_mtu(&nat64_decision(true), &fwd, true, libc::AF_INET as u8, 1400);
+    assert_eq!(inner, 1380, "NAT64 v4->v6 inner MTU = egress - 20");
+}
+
+#[test]
+fn post_transform_gre_oversized_v4_df_emits_inner_ptb() {
+    // End-to-end: a 1500-byte inner v4 DF datagram over a GRE tunnel whose
+    // inner MTU is 1376 must emit a Frag-Needed advertising 1376 (NOT the
+    // 1400 transport MTU, NOT a silent #2331 drop). This is the #2331-loop
+    // closure: the oversize that #2331 drops now yields a PTB.
+    let (frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    let mut fwd = forwarding_with_egress(1400);
+    insert_tunnel_endpoint(&mut fwd, "gre", libc::AF_INET, 0);
+    let decision = tunnel_decision();
+    let inner_mtu =
+        post_transform_inner_mtu(&decision, &fwd, false, meta.addr_family, 1400);
+    assert_eq!(inner_mtu, 1376);
+
+    // Source-vs-egress (the WRONG pre-#2330 comparison) would advertise 1400;
+    // the inner-MTU decision advertises 1376.
+    let next_hop_mtu = match forwarded_egress_mtu_decision(&frame, l3, meta.addr_family, inner_mtu)
+    {
+        EgressMtuDecision::EmitPacketTooBig { next_hop_mtu } => next_hop_mtu,
+        other => panic!("expected EmitPacketTooBig, got {other:?}"),
+    };
+    assert_eq!(next_hop_mtu, 1376, "advertised MTU = GRE inner MTU, not transport MTU");
+    assert!(!ptb_reply_suppressed(&frame, meta, l3));
+    let out = build_frag_needed_v4(&frame, meta, PTB_IFINDEX, &fwd, next_hop_mtu)
+        .expect("inner-source frag-needed must build");
+    let icmp = 14 + 20;
+    assert_eq!(out[icmp], 3);
+    assert_eq!(out[icmp + 1], 4);
+    assert_eq!(
+        u16::from_be_bytes([out[icmp + 6], out[icmp + 7]]),
+        1376,
+        "PTB carries the inner MTU"
+    );
+    assert_eq!(&out[30..34], &Ipv4Addr::new(198, 51, 100, 20).octets(), "dst = inner source");
+}
+
+#[test]
+fn post_transform_wireguard_oversized_v6_emits_inner_ptb() {
+    // A 1300-payload inner v6 over a WG tunnel whose inner MTU is 1325
+    // (1400 - 60 - 15) — the inner L3 is 40 + 8 + 1300 = 1348 > 1325 — must
+    // emit a Packet-Too-Big advertising the WG inner MTU.
+    let (frame, meta) = inbound_v6_udp(1300);
+    let l3 = meta.l3_offset as usize;
+    let mut fwd = forwarding_with_egress(1400);
+    insert_tunnel_endpoint(&mut fwd, "wireguard", libc::AF_INET, 0);
+    let inner_mtu =
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, meta.addr_family, 1400);
+    assert_eq!(inner_mtu, 1325);
+    let next_hop_mtu = match forwarded_egress_mtu_decision(&frame, l3, meta.addr_family, inner_mtu)
+    {
+        EgressMtuDecision::EmitPacketTooBig { next_hop_mtu } => next_hop_mtu,
+        other => panic!("expected EmitPacketTooBig, got {other:?}"),
+    };
+    assert_eq!(next_hop_mtu, 1325, "advertised MTU = WG pad-aware inner MTU");
+    let out = build_packet_too_big_v6(&frame, meta, PTB_IFINDEX, &fwd, next_hop_mtu as u32)
+        .expect("inner-source PTB must build");
+    let icmp = 14 + 40;
+    assert_eq!(out[icmp], 2, "ICMPv6 Packet Too Big");
+    assert_eq!(
+        u32::from_be_bytes([out[icmp + 4], out[icmp + 5], out[icmp + 6], out[icmp + 7]]),
+        1325,
+    );
+}
+
+#[test]
+fn post_transform_nat64_v6_oversized_emits_inner_ptb() {
+    // NAT64 v6->v4: a 1400-payload inner v6 (L3 = 40 + 8 + 1400 = 1448)
+    // translated to a v4 egress of MTU 1400. Inner MTU = 1400 + 20 = 1420;
+    // 1448 > 1420 -> Packet-Too-Big advertising 1420 to the v6 inner source.
+    let (frame, meta) = inbound_v6_udp(1400);
+    let l3 = meta.l3_offset as usize;
+    let fwd = forwarding_with_egress(1400);
+    let inner_mtu =
+        post_transform_inner_mtu(&nat64_decision(true), &fwd, true, meta.addr_family, 1400);
+    assert_eq!(inner_mtu, 1420, "NAT64 v6->v4 inner MTU = egress + 20");
+    let next_hop_mtu = match forwarded_egress_mtu_decision(&frame, l3, meta.addr_family, inner_mtu)
+    {
+        EgressMtuDecision::EmitPacketTooBig { next_hop_mtu } => next_hop_mtu,
+        other => panic!("expected EmitPacketTooBig, got {other:?}"),
+    };
+    assert_eq!(next_hop_mtu, 1420);
+    let out = build_packet_too_big_v6(&frame, meta, PTB_IFINDEX, &fwd, next_hop_mtu as u32)
+        .expect("NAT64 inner v6 PTB must build");
+    let icmp = 14 + 40;
+    assert_eq!(out[icmp], 2);
+    assert_eq!(
+        u32::from_be_bytes([out[icmp + 4], out[icmp + 5], out[icmp + 6], out[icmp + 7]]),
+        1420,
+    );
+}
+
+#[test]
+fn post_transform_in_mtu_forwards_no_ptb() {
+    // An inner packet that fits the GRE inner MTU must NOT emit a PTB
+    // (no false signal on a correctly-sized transformed flow).
+    let (frame, meta) = inbound_v4_udp(1000, true); // L3 = 1028 <= 1376
+    let l3 = meta.l3_offset as usize;
+    let mut fwd = forwarding_with_egress(1400);
+    insert_tunnel_endpoint(&mut fwd, "gre", libc::AF_INET, 0);
+    let inner_mtu =
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, meta.addr_family, 1400);
+    assert_eq!(
+        forwarded_egress_mtu_decision(&frame, l3, meta.addr_family, inner_mtu),
+        EgressMtuDecision::Forward,
+        "in-inner-MTU transformed frame must forward, no PTB"
+    );
+}

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -155,7 +155,7 @@ use self::gre::{encapsulate_native_gre_frame, try_native_gre_decap_from_frame};
 use self::icmp::{FABRIC_INGRESS_FLAG, build_local_time_exceeded_request, is_icmp_error};
 use self::icmp_ptb::{
     EgressMtuDecision, build_frag_needed_v4, build_packet_too_big_v6,
-    forwarded_egress_mtu_decision, ptb_reply_suppressed,
+    forwarded_egress_mtu_decision, post_transform_inner_mtu, ptb_reply_suppressed,
 };
 #[cfg(test)]
 use self::icmp::{

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -2710,3 +2710,112 @@ fn classify_generated_reply_counterfactual_trigger_keying_would_misverdict() {
         "trigger-keyed classification would WRONGLY admit the reply (the #2238 bug)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #2330: the POST-TRANSFORM inner-source PTB (NAT64/GRE/WG) must route
+// through the SAME classify_generated_reply contract as the #2301/#2328
+// egress-MTU PTB — i.e. an output `then discard protocol icmp` drops it, and
+// a malformed PTB fails closed. This proves the inner-MTU PTB built by
+// build_frag_needed_v4 / build_packet_too_big_v6 from the #2330 site is a
+// well-formed, classifiable reply (the finalizer enqueue is shared verbatim
+// with #2301, so classification behavior is identical).
+// ---------------------------------------------------------------------------
+
+/// Build a real inner-source Frag-Needed PTB (carrying an INNER MTU, the
+/// #2330 GRE/WG/NAT64 case) on egress ifindex 202's address pair, using the
+/// production builder. The trigger is a 1500-byte inner v4 DF UDP datagram.
+fn post_transform_inner_frag_needed_ptb(inner_mtu: u16) -> Vec<u8> {
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&[0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]); // fw mac (becomes PTB src side)
+    frame.extend_from_slice(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x02]); // sender mac (becomes PTB dst)
+    frame.extend_from_slice(&0x0800u16.to_be_bytes());
+    let l3 = frame.len();
+    let total_len = (20 + 8 + 1500) as u16;
+    frame.push(0x45);
+    frame.push(0x00);
+    frame.extend_from_slice(&total_len.to_be_bytes());
+    frame.extend_from_slice(&[0x00, 0x01, 0x40, 0x00, 64, 17, 0x00, 0x00]); // DF set, UDP
+    frame.extend_from_slice(&Ipv4Addr::new(198, 51, 100, 20).octets()); // inner src
+    frame.extend_from_slice(&Ipv4Addr::new(172, 16, 80, 200).octets()); // inner dst
+    let ip_csum = crate::afxdp::checksum16(&frame[l3..l3 + 20]);
+    frame[l3 + 10..l3 + 12].copy_from_slice(&ip_csum.to_be_bytes());
+    frame.extend_from_slice(&49152u16.to_be_bytes());
+    frame.extend_from_slice(&5201u16.to_be_bytes());
+    frame.extend_from_slice(&((8 + 1500) as u16).to_be_bytes());
+    frame.extend_from_slice(&0u16.to_be_bytes());
+    frame.extend(std::iter::repeat(0xABu8).take(1500));
+
+    let meta = UserspaceDpMeta {
+        ingress_ifindex: 202,
+        l3_offset: l3 as u16,
+        l4_offset: (l3 + 20) as u16,
+        addr_family: libc::AF_INET as u8,
+        protocol: 17,
+        ..Default::default()
+    };
+
+    let mut fwd = ForwardingState::default();
+    fwd.egress.insert(
+        202,
+        EgressInterface {
+            bind_ifindex: 0,
+            vlan_id: 0,
+            mtu: 1400,
+            src_mac: [0x02, 0xbf, 0x72, 0x00, 0x80, 0x08],
+            zone_id: 0,
+            redundancy_group: 0,
+            primary_v4: Some(Ipv4Addr::new(172, 16, 80, 8)),
+            primary_v6: None,
+        },
+    );
+    crate::afxdp::build_frag_needed_v4(&frame, meta, 202, &fwd, inner_mtu)
+        .expect("inner-source frag-needed must build")
+}
+
+#[test]
+fn classify_post_transform_inner_ptb_drops_on_terminal_discard() {
+    // The #2330 inner-source PTB (advertising a GRE/WG/NAT64 inner MTU)
+    // routes through classify_generated_reply exactly like #2328's PTB: an
+    // output `then discard protocol icmp` drops it.
+    let forwarding = forwarding_with_v4_output_filter(
+        "drop-icmp",
+        FirewallTermSnapshot {
+            name: "drop-icmp".into(),
+            action: "discard".into(),
+            protocols: vec!["icmp".into()],
+            ..Default::default()
+        },
+    );
+    let ptb = post_transform_inner_frag_needed_ptb(1376); // GRE inner MTU
+    // Sanity: the built PTB carries the INNER MTU, not the transport MTU.
+    let icmp = 14 + 20;
+    assert_eq!(ptb[icmp], 3, "ICMP Frag-Needed");
+    assert_eq!(
+        u16::from_be_bytes([ptb[icmp + 6], ptb[icmp + 7]]),
+        1376,
+        "PTB advertises the inner MTU"
+    );
+    let verdict = classify_generated_reply(&forwarding, 202, &ptb, 0);
+    assert!(verdict.drop, "post-transform PTB must honor the output discard filter");
+    assert!(!verdict.parse_error, "a well-formed PTB must NOT fail as a parse error");
+}
+
+#[test]
+fn classify_post_transform_inner_ptb_admitted_without_filter() {
+    // No matching output filter -> the inner PTB is admitted (drop=false),
+    // proving classification is keyed on the PTB's own ICMP tuple and the
+    // built bytes parse cleanly (so the only drop is an intentional filter).
+    let forwarding = forwarding_with_v4_output_filter(
+        "drop-tcp",
+        FirewallTermSnapshot {
+            name: "drop-tcp".into(),
+            action: "discard".into(),
+            protocols: vec!["tcp".into()],
+            ..Default::default()
+        },
+    );
+    let ptb = post_transform_inner_frag_needed_ptb(1325); // WG inner MTU
+    let verdict = classify_generated_reply(&forwarding, 202, &ptb, 0);
+    assert!(!verdict.drop, "a TCP-only discard must not drop the ICMP PTB");
+    assert!(!verdict.parse_error);
+}

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -486,20 +486,50 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                 let is_nat64 = request.decision.nat.nat64;
                 let uses_native_tunnel = request.decision.resolution.tunnel_endpoint_id != 0;
 
-                // #2301: egress-MTU decision for forwarded frames the TCP
-                // segmentation path did not handle (non-TCP, TCP seg-miss,
-                // non-segmentable TCP). For NAT64 and native-tunnel encap
-                // the on-wire L3 size differs from `source_frame` (header
-                // grow/shrink), and the built frame still hits the
-                // `copy_frame_is_oversized` descriptor-capacity backstop —
-                // skip the source-frame MTU check for them to avoid a false
-                // PTB. When the L3 payload exceeds the egress MTU and the
-                // sender forbade fragmentation (IPv4 DF) or it is IPv6,
-                // generate a Frag-Needed / Packet-Too-Big back to the
-                // sender so PMTUD converges, and drop the original instead
-                // of forwarding it into a silent MTU drop.
-                if !is_nat64 && !uses_native_tunnel {
-                    let mtu = forwarded_egress_mtu(&request.decision, forwarding);
+                // #2301 + #2330: the PMTUD decision for forwarded frames the
+                // TCP segmentation path did not handle (non-TCP, TCP
+                // seg-miss, non-segmentable TCP).
+                //
+                // #2301 handled ONLY plain forwards (size-preserving), where
+                // the egress MTU compared against the SOURCE frame is exact.
+                // #2330 closes the gap for the size-CHANGING paths (NAT64,
+                // native GRE, WireGuard): there the on-wire frame grows
+                // (encap) or its header shrinks/grows (NAT64), so a
+                // source-frame-vs-egress comparison is wrong. Instead we
+                // derive the INNER-source MTU (the largest inner IP packet
+                // whose TRANSFORMED frame fits the egress/transport MTU) from
+                // the #2300/#2331 SSOT helpers (`native_gre_inner_mtu` /
+                // `wg::mss::wg_inner_mtu` / the NAT64 v6<->v4 header delta)
+                // and compare the SAME inner `source_frame` against THAT.
+                //
+                // In all three transformed cases `source_frame` IS the
+                // pre-encap / pre-translation inner packet and
+                // `request.meta.addr_family` is the inner family, so the
+                // existing `build_frag_needed_v4` / `build_packet_too_big_v6`
+                // builders already target the correct inner source — they
+                // just carry the inner MTU instead of the egress MTU. The
+                // generated PTB then routes through `classify_generated_reply`
+                // (#2328) at the finalizer below, exactly like the plain
+                // path. When `mtu` is 0 (no MTU resolvable / unknown tunnel
+                // kind) `forwarded_egress_mtu_decision` returns `Forward`
+                // (fail-open) and the transformed frame falls through to its
+                // normal build (and, for GRE/WG oversize, the #2331 encap
+                // drop guard). This CLOSES the signal #2331 deferred here: an
+                // oversized GRE/WG inner now yields a PTB instead of a silent
+                // `GRE_ENCAP_DF_OVERSIZE_DROPS` / `encap_mtu_drops`.
+                {
+                    let egress_mtu = forwarded_egress_mtu(&request.decision, forwarding);
+                    let mtu = if is_nat64 || uses_native_tunnel {
+                        post_transform_inner_mtu(
+                            &request.decision,
+                            forwarding,
+                            is_nat64,
+                            request.meta.addr_family,
+                            egress_mtu,
+                        )
+                    } else {
+                        egress_mtu
+                    };
                     let ptb_meta: UserspaceDpMeta = request.meta.into();
                     let l3 = frame_l3_offset(source_frame).or_else(|| {
                         match request.meta.l3_offset {

--- a/userspace-dp/src/afxdp/wg/mss.rs
+++ b/userspace-dp/src/afxdp/wg/mss.rs
@@ -94,6 +94,37 @@ pub(crate) fn wg_tcp_mss(outer_family: i32, inner_family: i32, mtu: usize) -> u1
         .unwrap_or(0)
 }
 
+/// #2330: the pad-aware WireGuard INNER-IP MTU for the given outer-link MTU
+/// and outer IP family — the largest inner IP packet length whose encapped
+/// outer frame is guaranteed to fit `outer_mtu`, accounting for the
+/// worst-case 15 bytes of WG §5.4.6 transport-padding the encap side may
+/// add. This is the inverse of the encap MTU guard
+/// (`frame::wg::wg_encapped_size`): `wg_encapped_size(inner, outer_v6) <=
+/// outer_mtu` iff `inner <= wg_inner_mtu(outer_family, outer_mtu)` for a
+/// 16-aligned inner (the conservative `WG_MAX_PADDING` subtraction makes the
+/// bound hold for ANY inner length).
+///
+/// The advertised value is what a post-transform Packet-Too-Big / Frag-
+/// Needed back to the INNER source must carry so the inner sender shrinks
+/// its packets below the WG encap drop threshold (`encap_mtu_drops`).
+/// Returns 0 when `outer_mtu` is too small to carry any inner payload
+/// (fail-open: never advertise a nonsensical inner MTU).
+///
+/// `outer_family` is the family of the WG transport (the peer endpoint
+/// address), one of `libc::AF_INET` / `libc::AF_INET6`. The inner family is
+/// irrelevant to the encap overhead (the WG record wraps the raw inner IP
+/// packet whole), so unlike `wg_tcp_mss` no inner-family argument is needed.
+pub(crate) fn wg_inner_mtu(outer_family: i32, outer_mtu: usize) -> usize {
+    let outer_overhead = match outer_family {
+        x if x == libc::AF_INET => WG_OVERHEAD_V4,
+        x if x == libc::AF_INET6 => WG_OVERHEAD_V6,
+        _ => return 0,
+    };
+    outer_mtu
+        .checked_sub(outer_overhead + WG_MAX_PADDING)
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 mod mss_tests {
     use super::*;
@@ -180,5 +211,29 @@ mod mss_tests {
         // constants used by the framing code.
         assert_eq!(WG_OVERHEAD_V4, 60);
         assert_eq!(WG_OVERHEAD_V6, 80);
+    }
+
+    #[test]
+    fn wg_inner_mtu_v4_outer_pad_aware() {
+        // #2330: inner MTU = outer_mtu - WG_OVERHEAD_V4(60) - max_pad(15).
+        assert_eq!(wg_inner_mtu(libc::AF_INET, 1500), 1425);
+        assert_eq!(wg_inner_mtu(libc::AF_INET, 1400), 1325);
+    }
+
+    #[test]
+    fn wg_inner_mtu_v6_outer_pad_aware() {
+        // WG_OVERHEAD_V6 = 80. 1500 - 80 - 15 = 1405.
+        assert_eq!(wg_inner_mtu(libc::AF_INET6, 1500), 1405);
+    }
+
+    #[test]
+    fn wg_inner_mtu_under_minimum_returns_zero() {
+        // Too small to carry any inner payload -> 0 (fail-open).
+        assert_eq!(wg_inner_mtu(libc::AF_INET, 50), 0);
+    }
+
+    #[test]
+    fn wg_inner_mtu_unknown_family_returns_zero() {
+        assert_eq!(wg_inner_mtu(99, 1500), 0);
     }
 }


### PR DESCRIPTION
Closes #2330

## Problem

#2301 generates an egress-MTU PTB only for PLAIN forwards. It compares the
SOURCE frame against the egress MTU — correct only when the on-wire size
does not change — and deliberately gates the decision behind
`!is_nat64 && !uses_native_tunnel` (tx/dispatch/mod.rs). For the
size-CHANGING paths the on-wire frame **grows** on encap (GRE/WireGuard) or
its header **shrinks/grows** on NAT64, so a source-vs-egress comparison is
wrong and was skipped. The result: an inner source whose packet will not fit
post-transform got **no PMTUD signal** — a silent blackhole.

#2331 added a GRE-encap-DF oversize **drop + count** but, by design,
**deferred** the inner-source PTB to this issue.

## Fix

A pre-build post-transform PMTUD decision in the dispatcher. New
`post_transform_inner_mtu` (icmp_ptb.rs) derives the **inner** MTU — the
largest inner IP packet whose transformed frame fits the egress/transport
MTU — from the existing SSOT (no hand-rolled overhead):

| Transform | Inner-MTU source | file:line |
|---|---|---|
| GRE | `native_gre_inner_mtu` (== the #2331 encap-guard math) | `forwarding/mod.rs:740` |
| WireGuard | new pad-aware `wg::mss::wg_inner_mtu` (inverse of `wg_encapped_size`) | `wg/mss.rs` |
| NAT64 | egress MTU ± 20 v6↔v4 header delta (RFC 7915) | `icmp_ptb.rs` (`post_transform_inner_mtu`) |

The dispatcher feeds that inner MTU to the **existing**
`forwarded_egress_mtu_decision` + `build_frag_needed_v4` /
`build_packet_too_big_v6`, run against the inner `source_frame` (which IS
the pre-encap / pre-translate inner packet; `meta.addr_family` = inner
family). So the PTB already targets the **inner source** and carries the
**inner MTU** (RFC 1191 v4 next-hop MTU / RFC 4443 §3.2 v6 PTB MTU). The PTB
routes through `classify_generated_reply` (#2328) at the shared finalizer
→ output-filter / CoS / DSCP + `ptb_output_filter_drops` accounting, fail-
closed on a malformed reply.

## #2331-loop closure / coordination

The decision is **pre-build** and sets `mtu_signalled`, which skips the
encap/translate build entirely. So for the PTB-owed case (inner IPv4 DF or
IPv6) the #2331 `GRE_ENCAP_DF_OVERSIZE_DROPS` and the WG `encap_mtu_drops`
guards are **not** reached — no double-drop / double-count. Those guards
remain the backstop only for the residual **non-DF IPv4 inner** case (kept
`Forward` to preserve fragmentable behaviour) whose encapped outer still
exceeds the DF-set transport MTU. `mtu == 0` (no MTU resolvable / unknown
tunnel kind) fails open to `Forward`.

No new wire counter (reuses `mtu_signalled` / `egress_mtu_exceeded` /
`ptb_output_filter_drops`), so no protocol_wire_v1.json / Go change.

## Coverage

**Covered:** GRE, WireGuard, **and** NAT64 (both v6→v4 and v4→v6). Nothing
deferred — the NAT64 ±20 header delta was tractable and is tested.

## Tests (fail-on-revert)

- `icmp_ptb_tests.rs` (10): inner-MTU per type (each cross-checked against
  its SSOT: GRE == `native_gre_inner_mtu`, WG == `wg_inner_mtu`), GRE
  key-word, WG pad-aware, NAT64 +20 / −20, unknown-kind fail-open, and
  end-to-end oversize → inner PTB advertising the **inner** MTU (GRE v4 DF
  asserts 1376 not the 1400 transport MTU — the #2331-loop case), WG v6,
  NAT64 v6, plus in-MTU → no PTB.
- `cos_classify_tests.rs` (2): a real `build_frag_needed_v4` inner PTB
  routed through `classify_generated_reply` is dropped by `then discard
  protocol icmp` and admitted without a matching filter.
- `wg/mss.rs` (4): `wg_inner_mtu` v4/v6 pad-aware + fail-open.

`cargo build --release` clean; `cargo test --release -- pmtud ptb mtu
tunnel nat64 dispatch wg_inner post_transform` green (228 in main bin);
full suite green; new tests 5× stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
