### PR TITLE
nat64: map computed 0x0000 UDP checksum to 0xFFFF on v6->v4 (#2333)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -10463,3 +10463,15 @@ top.
 - **Validation**: cargo build --release clean; 6 new fail-on-revert tests green
   (5x stable); revert-simulation (wall-clock body) confirmed to FAIL the
   forward-step + recent tests; full ha/heartbeat/coordinator suite (449) green.
+
+- **Timestamp**: 2026-06-22
+  - **Action**: #2333 NAT64 v6->v4 UDP checksum 0x0000->0xFFFF map (RFC 768/1624).
+    Mirrored the existing v4->v6 UDP arm: after folding the recomputed IPv4 UDP
+    checksum in recompute_l4_checksum_after_nat64_v6_to_v4 (PROTO_UDP), a
+    computed 0x0000 is now written as 0xFFFF so receivers still validate it
+    (0x0000 = "no checksum present" sentinel). TCP path untouched (TCP cksum 0
+    is valid). Added 3 fail-on-revert tests (zero->0xFFFF, non-zero unchanged,
+    TCP not remapped). No wire field -> no protocol_wire_v1.json / Go change.
+    No NAT64 doc documents L4-checksum sentinel handling; inline comment is the
+    contract.
+  - **File(s)**: userspace-dp/src/nat64.rs, userspace-dp/src/nat64_tests.rs, _Log.md

--- a/userspace-dp/src/nat64.rs
+++ b/userspace-dp/src/nat64.rs
@@ -1401,7 +1401,14 @@ fn recompute_l4_checksum_after_nat64_v6_to_v4(packet: &mut [u8], protocol: u8) -
             }
             l4[6..8].copy_from_slice(&[0, 0]);
             let sum = checksum16_ipv4_pseudo(src, dst, protocol, l4);
-            l4[6..8].copy_from_slice(&sum.to_be_bytes());
+            // RFC 768 / RFC 1624: in IPv4 UDP a checksum field of 0x0000 is the
+            // reserved "no checksum present" sentinel. A genuinely computed
+            // checksum of zero MUST be transmitted as 0xFFFF (all-ones) so the
+            // receiver still validates it. `checksum16_ipv4_pseudo` returns the
+            // final one's-complement value, so a 0x0000 here is a real computed
+            // checksum, not an internal sentinel. Mirrors the v4->v6 UDP arm.
+            let final_sum = if sum == 0 { 0xFFFF } else { sum };
+            l4[6..8].copy_from_slice(&final_sum.to_be_bytes());
         }
         PROTO_ICMP => {
             if l4.len() < 4 {

--- a/userspace-dp/src/nat64_tests.rs
+++ b/userspace-dp/src/nat64_tests.rs
@@ -2163,3 +2163,129 @@ fn classify_match_unavailable_on_empty_pool_fails_closed() {
         "must NOT be treated as no-match (would IPv6-route the synthetic dest)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #2333: NAT64 v6->v4 UDP checksum 0x0000 -> 0xFFFF mapping (RFC 768/1624).
+//
+// In IPv4 UDP, a checksum field of 0x0000 is the reserved "no checksum
+// present" sentinel; the receiver skips validation. A genuinely COMPUTED
+// checksum of zero MUST be transmitted as 0xFFFF (all-ones). The v6->v4
+// translation arm previously wrote the raw fold, so a datagram whose computed
+// checksum folds to 0 was emitted as 0x0000 -> silent integrity loss. These
+// tests fail if the 0->0xFFFF map is reverted.
+// ---------------------------------------------------------------------------
+
+/// Build a minimal IPv4 + UDP packet (no Ethernet) suitable for feeding to
+/// `recompute_l4_checksum_after_nat64_v6_to_v4`. The 20-byte IPv4 header
+/// carries only the fields the recompute path reads (src/dst at 12..20); the
+/// UDP body is `payload`. The UDP checksum field (l4[6..8]) is left zeroed.
+fn build_v4_udp_for_recompute(src: Ipv4Addr, dst: Ipv4Addr, payload: &[u8]) -> Vec<u8> {
+    let udp_len = 8 + payload.len();
+    let mut pkt = vec![0u8; 20 + udp_len];
+    pkt[0] = 0x45;
+    pkt[9] = PROTO_UDP;
+    pkt[12..16].copy_from_slice(&src.octets());
+    pkt[16..20].copy_from_slice(&dst.octets());
+    // UDP header: src port, dst port, length, checksum(=0).
+    pkt[20..22].copy_from_slice(&1234u16.to_be_bytes());
+    pkt[22..24].copy_from_slice(&53u16.to_be_bytes());
+    pkt[24..26].copy_from_slice(&(udp_len as u16).to_be_bytes());
+    pkt[28..28 + payload.len()].copy_from_slice(payload);
+    pkt
+}
+
+#[test]
+fn v6_to_v4_udp_computed_zero_checksum_written_as_0xffff() {
+    let src = Ipv4Addr::new(198, 51, 100, 1);
+    let dst = Ipv4Addr::new(8, 8, 8, 8);
+
+    // Search for a 2-byte payload whose recomputed IPv4 UDP checksum folds to
+    // exactly 0x0000. The translated datagram must NOT be written as 0x0000;
+    // it must become the all-ones sentinel 0xFFFF.
+    let mut found = None;
+    for b in 0u16..=0xffff {
+        let payload = b.to_be_bytes();
+        let mut pkt = build_v4_udp_for_recompute(src, dst, &payload);
+        let l4 = &pkt[20..];
+        let raw = checksum16_ipv4_pseudo(src, dst, PROTO_UDP, l4);
+        if raw == 0 {
+            // Now run the production recompute path and assert the wire value.
+            recompute_l4_checksum_after_nat64_v6_to_v4(&mut pkt, PROTO_UDP)
+                .expect("recompute");
+            let on_wire = u16::from_be_bytes([pkt[26], pkt[27]]);
+            assert_eq!(
+                on_wire, 0xFFFF,
+                "computed UDP checksum of 0x0000 must be transmitted as 0xFFFF \
+                 (RFC 768/1624), not 0x0000"
+            );
+            found = Some(b);
+            break;
+        }
+    }
+    assert!(
+        found.is_some(),
+        "expected to find a payload yielding a zero-folding UDP checksum"
+    );
+}
+
+#[test]
+fn v6_to_v4_udp_nonzero_checksum_written_unchanged() {
+    let src = Ipv4Addr::new(198, 51, 100, 1);
+    let dst = Ipv4Addr::new(8, 8, 8, 8);
+    let payload = b"\x01\x02\x03\x04";
+    let mut pkt = build_v4_udp_for_recompute(src, dst, payload);
+
+    let expected = checksum16_ipv4_pseudo(src, dst, PROTO_UDP, &pkt[20..]);
+    assert_ne!(expected, 0, "test payload must not fold to zero");
+
+    recompute_l4_checksum_after_nat64_v6_to_v4(&mut pkt, PROTO_UDP).expect("recompute");
+    let on_wire = u16::from_be_bytes([pkt[26], pkt[27]]);
+    assert_eq!(
+        on_wire, expected,
+        "a normal non-zero UDP checksum must be written verbatim (no remap)"
+    );
+}
+
+#[test]
+fn v6_to_v4_tcp_checksum_not_remapped() {
+    // TCP checksum 0 is a normal valid value and MUST NOT be remapped to
+    // 0xFFFF. Build an IPv4 + TCP packet and confirm the recompute path writes
+    // the raw fold even if it is 0x0000.
+    let src = Ipv4Addr::new(198, 51, 100, 1);
+    let dst = Ipv4Addr::new(8, 8, 8, 8);
+
+    // 20-byte minimal TCP header; search for a sequence number that folds the
+    // computed TCP checksum to 0x0000 so we exercise the "0 stays 0" path.
+    let mut found = None;
+    for seq in 0u32..=0x000f_ffff {
+        let mut tcp = vec![0u8; 20];
+        tcp[0..2].copy_from_slice(&1234u16.to_be_bytes());
+        tcp[2..4].copy_from_slice(&80u16.to_be_bytes());
+        tcp[4..8].copy_from_slice(&seq.to_be_bytes());
+        tcp[12] = 0x50; // data offset = 5 (20 bytes), no flags
+        let raw = checksum16_ipv4_pseudo(src, dst, PROTO_TCP, &tcp);
+        if raw == 0 {
+            let mut pkt = vec![0u8; 20 + tcp.len()];
+            pkt[0] = 0x45;
+            pkt[9] = PROTO_TCP;
+            pkt[12..16].copy_from_slice(&src.octets());
+            pkt[16..20].copy_from_slice(&dst.octets());
+            pkt[20..].copy_from_slice(&tcp);
+            recompute_l4_checksum_after_nat64_v6_to_v4(&mut pkt, PROTO_TCP)
+                .expect("recompute");
+            // TCP checksum field is at l4[16..18] -> pkt[36..38].
+            let on_wire = u16::from_be_bytes([pkt[36], pkt[37]]);
+            assert_eq!(
+                on_wire, 0x0000,
+                "TCP checksum of 0x0000 is valid and must be written as 0x0000, \
+                 not remapped to 0xFFFF (the UDP-only RFC 768 rule must not leak)"
+            );
+            found = Some(seq);
+            break;
+        }
+    }
+    assert!(
+        found.is_some(),
+        "expected to find a TCP header that folds the checksum to zero"
+    );
+}


### PR DESCRIPTION
Closes #2333

## Problem

In the NAT64 IPv6->IPv4 translation, the recomputed IPv4 UDP checksum was
written raw (`userspace-dp/src/nat64.rs`, `recompute_l4_checksum_after_nat64_v6_to_v4`
PROTO_UDP arm). RFC 768 reserves a UDP checksum field of `0x0000` as the
"no checksum present" sentinel; RFC 1624 requires that a genuinely **computed**
checksum of zero be transmitted as `0xFFFF` (all-ones) to distinguish it from
"no checksum". Without the `0->0xFFFF` map, a translated datagram whose computed
UDP checksum happened to fold to `0x0000` was emitted with checksum=0 — telling
the receiver to skip validation, so in-transit corruption is silently accepted
(a router data-integrity violation). The v4->v6 direction already had this map.

## Fix

Mirror the existing v4->v6 UDP arm:

```rust
let final_sum = if sum == 0 { 0xFFFF } else { sum };
l4[6..8].copy_from_slice(&final_sum.to_be_bytes());
```

`checksum16_ipv4_pseudo` returns the final one's-complement fold
(`checksum16_fold` => `!(sum)`), so a `0x0000` return is a real computed
checksum, not an internal sentinel — safe to remap.

## Scope — UDP only

The TCP arm is **untouched**: a TCP checksum of `0x0000` is a normal valid value
(no "checksum absent" semantics), so it must never be remapped. The inbound IPv6
UDP checksum is mandatory and never 0 on the wire, so there is no "checksum
absent" case to carry over — the only concern is the output IPv4 checksum being
0, which this fixes.

## Map sites

- Fixed (v6->v4 UDP): `userspace-dp/src/nat64.rs` `recompute_l4_checksum_after_nat64_v6_to_v4`, PROTO_UDP arm.
- Mirrored from (v4->v6 UDP, already correct): `userspace-dp/src/nat64.rs` `recompute_l4_checksum_after_nat64_v4_to_v6`, PROTO_UDP arm.

## Tests (fail-on-revert)

- `v6_to_v4_udp_computed_zero_checksum_written_as_0xffff` — brute-forces a
  payload whose recomputed checksum folds to `0x0000`, asserts `0xFFFF` on the
  wire. Reverting the map FAILS this test (verified).
- `v6_to_v4_udp_nonzero_checksum_written_unchanged` — a normal checksum is
  written verbatim.
- `v6_to_v4_tcp_checksum_not_remapped` — a TCP header that folds to `0x0000`
  stays `0x0000` (the UDP rule must not leak to TCP).

## Validation

- `cargo build --release` clean (only pre-existing warnings).
- New tests green 5x stable; revert-simulation confirmed to fail the zero-map test.
- No wire field changed — no `protocol_wire_v1.json` / Go change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi