### PR TITLE
#2334: over-align WG recvmsg cmsg buffer to cmsghdr alignment

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,36 @@
 # Action Log
 
+## 2026-06-22 — #2334 WG recvmsg cmsg buffer alignment fix
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Fixed the latent UB in the #2317 WG decap-ECN recv path: the
+  `recvmsg` control buffer was a bare `[u8; 256]` (alignment 1), but the
+  `CMSG_FIRSTHDR`/`CMSG_NXTHDR` macros and `parse_outer_ecn_from_cmsg`
+  dereference a `*const cmsghdr` (alignment 8 on LP64) pointing into it to
+  read the multi-byte `cmsg_len`/`cmsg_level`/`cmsg_type` header fields —
+  an unaligned access (UB in Rust; SIGBUS / alignment-trap risk on
+  strict-alignment targets such as ARMv8, which xpf also targets per
+  #2332/#1958). Introduced a `#[repr(C, align(8))] struct CmsgBuf([u8;
+  256])` newtype (matching the codebase's existing `#[repr(align(N))]`
+  idiom) and point `msg_control` at `cmsg_space.0.as_mut_ptr()` /
+  `msg_controllen = cmsg_space.0.len()`. Added a fail-on-revert
+  compile-time sentinel `const _: () = assert!(align_of::<CmsgBuf>() >=
+  align_of::<libc::cmsghdr>())` that breaks the build if the alignment is
+  ever dropped (verified: removing `align(8)` produces the #2334 panic).
+  Routed the #2317 `parse_ecn_with_cmsg` test helper through the same
+  `CmsgBuf` so the synthetic cmsg is align-8 like production. Updated the
+  inaccurate SAFETY comment that claimed only payload bytes were read. The
+  #2317 cmsg_len underflow guard and the `MSG_CTRUNC` skip are untouched —
+  this PR changes ONLY the buffer's alignment, not the parse logic. No wire
+  field changed.
+- **File(s)**: userspace-dp/src/afxdp/coordinator/wg_control.rs (CmsgBuf
+  newtype + static assertion, wg_recvmsg buffer, parse SAFETY comment,
+  parse_ecn_with_cmsg test helper).
+- **Validation**: `cargo build --release` clean (static-assert compiles);
+  `cargo test --release --bin xpf-userspace-dp -- cmsg wg_recv outer_ecn
+  wg_control` 17/0, stable 5x; sentinel verified to fail compilation when
+  `align(8)` is removed.
+
 ## 2026-06-22 — #2317 WG decap RFC 6040 §4.2 ECN combine
 
 - **Timestamp**: 2026-06-22 PDT

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -145,7 +145,14 @@ DSCP is not copied back at decap.
   real WG peer CE-marking the outer → CE on the inner) is lab-bound,
   deferred to the #1703-class interop validation; the code path and unit
   tests (cmsg parse for v4/v6, the §4.2 combine reuse, CE upgrade + IPv4
-  checksum, illegal-combo drop+count) are in tree.
+  checksum, illegal-combo drop+count) are in tree. The `recvmsg` control
+  buffer is the 8-byte-aligned `CmsgBuf([u8; 256])` newtype (#2334) so the
+  `cmsghdr` header-field reads the `CMSG_*` macros perform are naturally
+  aligned (a bare `[u8; N]` is align-1; reading `cmsg_len`/`cmsg_level`/
+  `cmsg_type` through an under-aligned `*const cmsghdr` is UB and a SIGBUS
+  risk on strict-alignment targets such as ARMv8). A compile-time
+  `align_of::<CmsgBuf>() >= align_of::<cmsghdr>()` assertion is the
+  fail-on-revert sentinel.
 
 ## What S1 delivers
 

--- a/userspace-dp/src/afxdp/coordinator/wg_control.rs
+++ b/userspace-dp/src/afxdp/coordinator/wg_control.rs
@@ -1067,6 +1067,31 @@ struct WgRecv {
     outer_ecn: Option<u8>,
 }
 
+/// #2334: 256-byte recvmsg control buffer, over-aligned to 8 bytes so the
+/// `cmsghdr` header-field reads the `CMSG_*` macros perform through a
+/// `*const cmsghdr` pointing into this storage are naturally aligned.
+///
+/// A bare `[u8; N]` has alignment 1; `cmsghdr` (containing a `size_t`
+/// `cmsg_len` plus two `c_int`s on LP64) has alignment 8. `CMSG_FIRSTHDR`
+/// returns the buffer base and `parse_outer_ecn_from_cmsg` then reads the
+/// multi-byte `cmsg_len` / `cmsg_level` / `cmsg_type` fields through that
+/// pointer — an unaligned dereference (UB in Rust, a SIGBUS / alignment-
+/// trap risk on strict-alignment targets such as ARMv8) unless the base
+/// is `cmsghdr`-aligned. `align(8)` covers `align_of::<cmsghdr>()`; the
+/// static assertion below fails to compile if that ever regresses.
+#[repr(C, align(8))]
+struct CmsgBuf([u8; 256]);
+
+// Fail-on-revert sentinel: the control buffer MUST be at least as aligned
+// as `cmsghdr`, or the header-field reads in `parse_outer_ecn_from_cmsg`
+// become unaligned dereferences (#2334). A future change that drops the
+// `#[repr(align(8))]` (or replaces the wrapper with a bare `[u8; N]`)
+// breaks compilation here rather than reintroducing latent UB.
+const _: () = assert!(
+    std::mem::align_of::<CmsgBuf>() >= std::mem::align_of::<libc::cmsghdr>(),
+    "CmsgBuf must be at least cmsghdr-aligned (see #2334)"
+);
+
 /// #2317: receive one WG datagram via `recvmsg`, capturing the outer IP
 /// TOS / Traffic Class from the ancillary `IP_RECVTOS` /
 /// `IPV6_RECVTCLASS` control message. Replaces `recv_from` so the outer
@@ -1075,13 +1100,15 @@ struct WgRecv {
 ///
 /// The cmsg buffer is a fixed 256-byte stack array (a single TOS cmsg is
 /// ~16-20 bytes; 256 covers both the v4 and v6 TOS cmsgs with margin and
-/// never allocates on the hot path). `MSG_TRUNC`/`MSG_CTRUNC` are not
-/// requested — the data buffer is the loop's 64 KiB scratch (max IP
-/// datagram) so transport records never truncate, and a truncated cmsg
-/// only loses the (best-effort) ECN, not the datagram.
+/// never allocates on the hot path). It is wrapped in the 8-byte-aligned
+/// `CmsgBuf` so the `cmsghdr` header-field reads are aligned (#2334).
+/// `MSG_TRUNC`/`MSG_CTRUNC` are not requested — the data buffer is the
+/// loop's 64 KiB scratch (max IP datagram) so transport records never
+/// truncate, and a truncated cmsg only loses the (best-effort) ECN, not
+/// the datagram.
 fn wg_recvmsg(socket: &UdpSocket, buf: &mut [u8]) -> io::Result<WgRecv> {
     let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-    let mut cmsg_space = [0u8; 256];
+    let mut cmsg_space = CmsgBuf([0u8; 256]);
     let mut iov = libc::iovec {
         iov_base: buf.as_mut_ptr() as *mut libc::c_void,
         iov_len: buf.len(),
@@ -1091,8 +1118,8 @@ fn wg_recvmsg(socket: &UdpSocket, buf: &mut [u8]) -> io::Result<WgRecv> {
     msg.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
     msg.msg_iov = &mut iov;
     msg.msg_iovlen = 1;
-    msg.msg_control = cmsg_space.as_mut_ptr() as *mut libc::c_void;
-    msg.msg_controllen = cmsg_space.len() as _;
+    msg.msg_control = cmsg_space.0.as_mut_ptr() as *mut libc::c_void;
+    msg.msg_controllen = cmsg_space.0.len() as _;
 
     let n = unsafe { libc::recvmsg(socket.as_raw_fd(), &mut msg, 0) };
     if n < 0 {
@@ -1130,9 +1157,13 @@ fn wg_recvmsg(socket: &UdpSocket, buf: &mut [u8]) -> io::Result<WgRecv> {
 /// truncated cmsg).
 fn parse_outer_ecn_from_cmsg(msg: &libc::msghdr) -> Option<u8> {
     // SAFETY: `msg` is a fully-initialized msghdr returned by recvmsg
-    // (msg_control / msg_controllen describe a valid buffer). CMSG_*
-    // macros walk it; we only read aligned payload bytes within
-    // `cmsg_len`.
+    // (msg_control / msg_controllen describe a valid buffer). The control
+    // buffer is the 8-byte-aligned `CmsgBuf` (#2334), so the `cmsghdr`
+    // base CMSG_FIRSTHDR/CMSG_NXTHDR return — and therefore the multi-byte
+    // `cmsg_len` / `cmsg_level` / `cmsg_type` header-field reads below —
+    // are naturally aligned (cmsghdr has alignment 8 on LP64). The single
+    // payload byte at CMSG_DATA is read only after the `cmsg_len` guard
+    // confirms it lies within the cmsg.
     unsafe {
         let mut cmsg = libc::CMSG_FIRSTHDR(msg);
         while !cmsg.is_null() {
@@ -1777,10 +1808,15 @@ mod tests {
     fn parse_ecn_with_cmsg(level: libc::c_int, ctype: libc::c_int, ds: u8) -> Option<u8> {
         unsafe {
             // CMSG_SPACE(1) bytes hold a header + 1 padded payload byte.
+            // Back the control buffer with the same 8-byte-aligned `CmsgBuf`
+            // the production recv path uses (#2334) so the synthetic cmsg
+            // header-field writes/reads here are aligned exactly as in
+            // `wg_recvmsg` — a bare `vec![0u8; _]` would be align-1.
             let space = libc::CMSG_SPACE(1) as usize;
-            let mut buf = vec![0u8; space];
+            assert!(space <= 256, "CMSG_SPACE(1) exceeds CmsgBuf storage");
+            let mut buf = CmsgBuf([0u8; 256]);
             let mut msg: libc::msghdr = std::mem::zeroed();
-            msg.msg_control = buf.as_mut_ptr() as *mut libc::c_void;
+            msg.msg_control = buf.0.as_mut_ptr() as *mut libc::c_void;
             msg.msg_controllen = space as _;
             let cmsg = libc::CMSG_FIRSTHDR(&msg);
             assert!(!cmsg.is_null(), "CMSG_FIRSTHDR null");

--- a/userspace-dp/src/afxdp/coordinator/wg_control.rs
+++ b/userspace-dp/src/afxdp/coordinator/wg_control.rs
@@ -1802,9 +1802,9 @@ mod tests {
 
     /// Build a `msghdr` whose msg_control holds a single cmsg of
     /// `(level, ctype)` carrying the one-byte DS payload `ds`, and return
-    /// the parsed outer ECN. The cmsg buffer is leaked into a Vec the
-    /// caller keeps alive for the duration of the parse (the msghdr
-    /// borrows it).
+    /// the parsed outer ECN. The cmsg buffer is a stack `CmsgBuf`
+    /// (8-byte-aligned, #2334) that the msghdr borrows for the duration
+    /// of the parse.
     fn parse_ecn_with_cmsg(level: libc::c_int, ctype: libc::c_int, ds: u8) -> Option<u8> {
         unsafe {
             // CMSG_SPACE(1) bytes hold a header + 1 padded payload byte.


### PR DESCRIPTION
Closes #2334

## Problem

The #2317 WG decap-ECN recv path (`userspace-dp/src/afxdp/coordinator/wg_control.rs`) used a bare `[u8; 256]` (alignment 1) as the `recvmsg` control buffer. `CMSG_FIRSTHDR`/`CMSG_NXTHDR` and `parse_outer_ecn_from_cmsg` dereference a `*const cmsghdr` pointing into that storage to read the multi-byte `cmsg_len` / `cmsg_level` / `cmsg_type` header fields. `cmsghdr` has alignment 8 on LP64, so those reads were unaligned pointer dereferences — UB under Rust's pointer rules and a SIGBUS / alignment-trap risk on strict-alignment targets such as ARMv8 (which xpf also targets, per the #2332/#1958 cross-arch notes). Tolerated on x86_64, so latent rather than observed.

The #2317 Copilot fold added the `cmsg_len` underflow guard but not alignment; this PR closes that remaining hole. The single-byte `*data` payload read was already alignment-safe — only the cmsghdr header-field reads were the risk.

## Fix

- New `#[repr(C, align(8))] struct CmsgBuf([u8; 256])` newtype (matches the codebase's existing `#[repr(align(N))]` idiom). `msg_control` points at `cmsg_space.0.as_mut_ptr()`, `msg_controllen = cmsg_space.0.len()`. Buffer stays 256 bytes. `align(8)` covers `align_of::<cmsghdr>()`, so the cmsghdr base — and every header-field read — is naturally aligned.
- **Fail-on-revert sentinel:** `const _: () = assert!(align_of::<CmsgBuf>() >= align_of::<libc::cmsghdr>(), ...)` — breaks the build if the alignment is ever dropped (verified: removing `align(8)` produces the #2334 panic at compile time).
- The #2317 `parse_ecn_with_cmsg` test helper now backs its buffer with the same `CmsgBuf` so the synthetic cmsg is align-8 like production.
- Corrected the SAFETY comment that incorrectly claimed only payload bytes were read.

## Preserved

This PR changes ONLY the buffer's alignment. The #2317 `cmsg_len` underflow guard (`cmsg_len >= data_off + 1`) and the `MSG_CTRUNC` skip are untouched. No wire field changed.

## Validation

- `cargo build --release` clean (the static assert compiles).
- `cargo test --release --bin xpf-userspace-dp -- cmsg wg_recv outer_ecn wg_control` → 17/0, stable across 5 runs.
- Sentinel confirmed to fail compilation (`error[E0080]: ... CmsgBuf must be at least cmsghdr-aligned (see #2334)`) when `align(8)` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi