### PR TITLE
vrrp: restart instance on member ifindex drift under unchanged config (#2294)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,35 @@
 # Action Log
 
+## 2026-06-22 — #2294 VRRP ifindex-drift restart (rebind on stale socket)
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Fixed the HA-availability gap where a VRRP instance was never
+  restarted when its member interface's kernel ifindex changed under an
+  otherwise byte-identical config. The per-instance AF_PACKET / raw / IPv6
+  sockets are bound to the ifindex at `openSocket()` time; a netdev
+  delete+recreate or rename (carrier/VLAN flap that fully removes and re-adds
+  the link) gives a new ifindex, but the reconcile diff only compared
+  priority/preempt/track/VIPs, so the "No change" branch left the sockets
+  bound to the STALE ifindex → permanent VRRP silence (split-brain /
+  blackhole). Added a cheap, tolerant `name→ifindex` probe at the top of the
+  per-instance branch in `Manager.UpdateInstances`: when the live ifindex
+  differs from `existing.iface.Index`, force the existing
+  build-before-teardown (#2156) restart path so the instance rebinds to a
+  fresh socket on the new ifindex. A resolve failure is treated as "no drift"
+  so a transient netlink hiccup never blocks a time-critical priority/preempt
+  in-place update; the build block already owns resolve-failure-keeps-old
+  recovery. Idempotent (unchanged ifindex → no restart). The restart rebuilds
+  from the same desired `inst` (preserves priority/preempt/track) and
+  re-applies sync-hold suppression, so a rebind cannot spuriously preempt or
+  break the sync hold; RG role stays driven by the cluster heartbeat /
+  debounced priority. Composes with the config-change restart (no
+  double-restart — drift and VIP-change share the one build block).
+- **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/update_instances_test.go,
+  pkg/vrrp/README.md, _Log.md
+- **Validation**: `go build ./...` clean; `go test ./pkg/vrrp/...
+  ./pkg/daemon/... ./pkg/cluster/...` green; new tests `-count=5` green;
+  `go test -race ./pkg/vrrp/` clean.
+
 ## 2026-06-22 — #2334 WG recvmsg cmsg buffer alignment fix
 
 - **Timestamp**: 2026-06-22 PDT

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -30,6 +30,23 @@ This is the package that drives chassis-cluster failover.
   therefore leaves the old instance running and advertising its old VIPs
   rather than orphaning the RG out of election. Priority/preempt/track
   changes still update in-place (no restart, no master-down gap).
+  **Ifindex drift (#2294):** before the no-change / in-place branch, a
+  cheap tolerant `name→ifindex` probe compares the live kernel ifindex
+  against the one the instance's sockets are bound to. A member netdev
+  that is deleted+recreated or renamed (carrier/VLAN flap that fully
+  removes and re-adds the link) gets a NEW ifindex while the xpf config
+  stays byte-identical; without the probe the instance would keep its
+  sockets bound to the STALE ifindex and go permanently silent
+  (split-brain / blackhole). A drift forces the same
+  build-before-teardown restart path so the instance rebinds to the new
+  ifindex; a resolve failure is treated as "no drift" (a transient
+  netlink hiccup never blocks a time-critical priority update — the
+  build block already owns resolve-failure recovery). The probe runs
+  every ~2s reconcile tick and is idempotent (unchanged ifindex → no
+  restart, no churn). The restart preserves configured
+  priority/preempt/tracking and re-applies sync-hold suppression, so a
+  rebind cannot spuriously preempt or break the sync hold; RG role is
+  driven separately by the cluster heartbeat / debounced priority.
 - `ReleaseSyncHold()` — `manager.go`. No-arg; releases hold for all
   instances.
 - `ResignRG(rgID int)` — `manager.go`. Forces this node out of master

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -234,19 +234,52 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 	for key, inst := range desiredMap {
 		existing, ok := m.instances[key]
 		if ok {
-			// Check if config changed.
-			if existing.cfg.Priority == inst.Priority &&
+			// #2294: detect ifindex drift on an otherwise-unchanged
+			// instance. The per-instance AF_PACKET / raw / IPv6 sockets are
+			// bound to the member interface's kernel ifindex at openSocket()
+			// time. If the netdev is deleted+recreated or renamed
+			// (carrier/VLAN flap that fully removes and re-adds the link) its
+			// ifindex changes while the xpf config stays byte-identical, so
+			// the no-change and in-place (priority-only) branches below would
+			// leave the instance bound to the STALE ifindex — its sockets can
+			// no longer send/receive VRRP adverts and the RG goes permanently
+			// silent (split-brain / blackhole) until an operator re-commit or
+			// daemon restart. When the live ifindex differs from the bound
+			// one we force the build-before-teardown restart path below (a
+			// fresh socket is mandatory; a config-only in-place update cannot
+			// rebind).
+			//
+			// The probe is a cheap, TOLERANT name->ifindex resolve: a resolve
+			// FAILURE is treated as "no drift" so a transient netlink hiccup
+			// never blocks a time-critical priority/preempt in-place update
+			// (failover priority, sync-hold release) — those paths
+			// historically never touched netlink, and the build block below
+			// already owns the resolve-failure-keeps-old-instance recovery.
+			// Detection is idempotent: an unchanged ifindex returns false and
+			// the normal no-change / in-place path runs with no churn. This
+			// runs every ~2s reconcile tick (daemon reconcileVRRPInstances),
+			// so it neither allocates nor restarts on a steady config.
+			ifindexChanged := false
+			if probe, perr := m.resolveIface(inst.Interface); perr == nil && probe.Index != existing.iface.Index {
+				ifindexChanged = true
+			}
+
+			// Check if config changed (and the live ifindex is unchanged).
+			if !ifindexChanged &&
+				existing.cfg.Priority == inst.Priority &&
 				existing.cfg.Preempt == inst.Preempt &&
 				existing.cfg.TrackInterface == inst.TrackInterface &&
 				existing.cfg.TrackPriorityCost == inst.TrackPriorityCost &&
 				vipsEqual(existing.cfg.VirtualAddresses, inst.VirtualAddresses) {
 				continue // No change.
 			}
-			// If only priority/preempt/tracking changed, update in-place
-			// without stopping. Restarting would cause a 3s master-down
-			// gap where the node falsely becomes MASTER before hearing
-			// the peer.
-			if vipsEqual(existing.cfg.VirtualAddresses, inst.VirtualAddresses) {
+			// If only priority/preempt/tracking changed (and the ifindex is
+			// unchanged), update in-place without stopping. Restarting would
+			// cause a 3s master-down gap where the node falsely becomes
+			// MASTER before hearing the peer. An ifindex change is NOT
+			// in-place-updatable — it requires a fresh socket — so it skips
+			// this arm and falls through to the build-before-teardown path.
+			if !ifindexChanged && vipsEqual(existing.cfg.VirtualAddresses, inst.VirtualAddresses) {
 				slog.Info("vrrp: priority update", "key", existing.key(),
 					"old_pri", existing.cfg.Priority, "new_pri", inst.Priority)
 				trackIfaceChanged := existing.cfg.TrackInterface != inst.TrackInterface
@@ -263,28 +296,40 @@ func (m *Manager) UpdateInstances(desired []*Instance) error {
 				}
 				continue
 			}
-			// VIPs changed — the instance must be restarted (changing the
-			// VIP set requires re-opening sockets and re-running the state
-			// machine). BUILD THE REPLACEMENT BEFORE TEARING DOWN the old
-			// one (#2156): a transient member-link failure (carrier flap,
-			// mid-rename by networkd) used to delete the working instance
-			// and then `continue` on InterfaceByName/openSocket error,
-			// orphaning the RG out of VRRP election until an operator
-			// re-commit. Falls through to the shared build block below; the
-			// old instance is only stopped+replaced on a fully-built
-			// replacement.
-			slog.Info("vrrp: restarting instance", "key", existing.key(),
-				"old_pri", existing.cfg.Priority, "new_pri", inst.Priority)
+			// VIPs changed OR the ifindex drifted — the instance must be
+			// restarted (changing the VIP set or rebinding to a new ifindex
+			// requires re-opening sockets and re-running the state machine).
+			// BUILD THE REPLACEMENT BEFORE TEARING DOWN the old one (#2156):
+			// a transient member-link failure (carrier flap, mid-rename by
+			// networkd) used to delete the working instance and then
+			// `continue` on InterfaceByName/openSocket error, orphaning the
+			// RG out of VRRP election until an operator re-commit. Falls
+			// through to the shared build block below; the old instance is
+			// only stopped+replaced on a fully-built replacement. The restart
+			// preserves the configured priority/preempt/tracking (it rebuilds
+			// from the same desired `inst`) and re-applies sync-hold
+			// suppression below, so an ifindex rebind cannot spuriously
+			// preempt or break the sync hold. RG role in the cluster state
+			// machine is driven separately (heartbeat / debounced priority),
+			// not reset here.
+			if ifindexChanged {
+				slog.Info("vrrp: restarting instance (ifindex changed)",
+					"key", existing.key(), "old_ifindex", existing.iface.Index)
+			} else {
+				slog.Info("vrrp: restarting instance", "key", existing.key(),
+					"old_pri", existing.cfg.Priority, "new_pri", inst.Priority)
+			}
 		}
 
-		// Build the (possibly replacement) instance. On ANY build failure
-		// we leave m.instances untouched: an existing instance keeps
-		// advertising its old VIP set (strictly better than dropping out of
-		// election), and a brand-new key is simply not created yet. The 2s
-		// reconcile re-drive (daemon reconcileVRRPInstances) and the two
-		// existing UpdateInstances callers retry until the interface
-		// returns. No placeholder state is added, so RGVRRPReady and the
-		// other map readers stay truthful.
+		// Build the (possibly replacement) instance. On ANY build failure we
+		// leave m.instances untouched: an existing instance keeps advertising
+		// its old VIP set (strictly better than dropping out of election), and
+		// a brand-new key is simply not created yet. The 2s reconcile re-drive
+		// (daemon reconcileVRRPInstances) and the two existing UpdateInstances
+		// callers retry until the interface returns. No placeholder state is
+		// added, so RGVRRPReady and the other map readers stay truthful. This
+		// resolve is the authoritative one bound into the new instance; the
+		// #2294 drift probe above is only a cheap detector.
 		iface, err := m.resolveIface(inst.Interface)
 		if err != nil {
 			slog.Warn("vrrp: interface not found, keeping existing instance",

--- a/pkg/vrrp/update_instances_test.go
+++ b/pkg/vrrp/update_instances_test.go
@@ -305,3 +305,259 @@ func TestUpdateInstances_NewKeyFailureNoPhantom(t *testing.T) {
 		t.Fatal("RGVRRPReady(1) should be true after the retry created the instance")
 	}
 }
+
+// seedRunningInstance installs an already-"running" instance for the given key
+// bound to the supplied ifindex. The instance's stopped channel is left open
+// so the stub stopInstance (which only records) does not block; the real run()
+// goroutine is never started in these no-network tests.
+func seedRunningInstance(m *Manager, key instanceKey, cfg Instance, ifindex int) *vrrpInstance {
+	vi := newInstance(cfg, &net.Interface{Name: cfg.Interface, Index: ifindex}, m.eventCh, nil)
+	m.mu.Lock()
+	m.instances[key] = vi
+	m.mu.Unlock()
+	return vi
+}
+
+// TestUpdateInstances_IfindexChange_RestartsRebind asserts the #2294 fix: when
+// a running instance's member interface keeps the SAME xpf config but its
+// kernel ifindex changes (netdev delete+recreate / rename), the reconcile path
+// detects the drift and restarts the instance — stopping the stale-bound old
+// one and starting a fresh instance bound to the NEW ifindex. Without the fix
+// the byte-identical config hits the "No change" continue and the instance
+// keeps its socket bound to the dead ifindex → permanent VRRP silence. This
+// test FAILS if the ifindex-drift detection is reverted (no restart occurs).
+func TestUpdateInstances_IfindexChange_RestartsRebind(t *testing.T) {
+	m, rec := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	// resolveIface returns whatever ifindex the test currently advertises.
+	var liveIndex atomic.Int64
+	liveIndex.Store(7)
+	m.resolveIface = func(name string) (*net.Interface, error) {
+		return &net.Interface{Name: name, Index: int(liveIndex.Load())}, nil
+	}
+
+	key := instanceKey{iface: "reth0.50", groupID: 101}
+	cfg := Instance{
+		Interface:        "reth0.50",
+		GroupID:          101,
+		Priority:         200,
+		Preempt:          true,
+		VirtualAddresses: []string{"172.16.50.1/24"},
+	}
+	orig := seedRunningInstance(m, key, cfg, 7) // bound to ifindex 7
+
+	// The netdev was deleted+recreated under the same name → new ifindex 9,
+	// while the desired config is byte-identical.
+	liveIndex.Store(9)
+	desired := []*Instance{{
+		Interface:        "reth0.50",
+		GroupID:          101,
+		Priority:         200,
+		Preempt:          true,
+		VirtualAddresses: []string{"172.16.50.1/24"}, // UNCHANGED config
+	}}
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances: %v", err)
+	}
+
+	open, run, stop := rec.snapshot()
+	if open != 1 || run != 1 || stop != 1 {
+		t.Fatalf("ifindex drift must restart: open=%d run=%d stop=%d, want 1/1/1", open, run, stop)
+	}
+
+	m.mu.RLock()
+	got, ok := m.instances[key]
+	n := len(m.instances)
+	m.mu.RUnlock()
+	if !ok || n != 1 {
+		t.Fatalf("expected exactly 1 instance for the key, ok=%v n=%d", ok, n)
+	}
+	if got == orig {
+		t.Fatal("instance was not replaced — stale ifindex socket kept (bug)")
+	}
+	if got.iface.Index != 9 {
+		t.Fatalf("replacement bound to ifindex %d, want 9 (new live ifindex)", got.iface.Index)
+	}
+
+	rec.mu.Lock()
+	stoppedOld := len(rec.stopped) == 1 && rec.stopped[0] == orig
+	rec.mu.Unlock()
+	if !stoppedOld {
+		t.Fatal("the stopped instance was not the original (build-before-teardown ordering wrong)")
+	}
+
+	// Restart must preserve the configured priority/preempt/VIPs.
+	if got.cfg.Priority != 200 || !got.cfg.Preempt {
+		t.Fatalf("restart lost config: priority=%d preempt=%v, want 200/true", got.cfg.Priority, got.cfg.Preempt)
+	}
+	if !vipsEqual(got.cfg.VirtualAddresses, cfg.VirtualAddresses) {
+		t.Fatalf("restart lost VIPs: %v, want %v", got.cfg.VirtualAddresses, cfg.VirtualAddresses)
+	}
+}
+
+// TestUpdateInstances_IfindexUnchanged_NoRestart asserts the idempotence half
+// of #2294: a reconcile pass where the resolved ifindex matches the bound
+// ifindex and the config is unchanged must NOT restart the instance (no socket
+// churn, no spurious failover). This is the steady-state every-2s reconcile
+// case; a regression here would restart-storm every RG.
+func TestUpdateInstances_IfindexUnchanged_NoRestart(t *testing.T) {
+	m, rec := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	// Live ifindex stays equal to the bound one.
+	m.resolveIface = func(name string) (*net.Interface, error) {
+		return &net.Interface{Name: name, Index: 5}, nil
+	}
+
+	key := instanceKey{iface: "reth0.50", groupID: 101}
+	cfg := Instance{
+		Interface:        "reth0.50",
+		GroupID:          101,
+		Priority:         200,
+		Preempt:          true,
+		VirtualAddresses: []string{"172.16.50.1/24"},
+	}
+	orig := seedRunningInstance(m, key, cfg, 5)
+
+	desired := []*Instance{{
+		Interface:        "reth0.50",
+		GroupID:          101,
+		Priority:         200,
+		Preempt:          true,
+		VirtualAddresses: []string{"172.16.50.1/24"},
+	}}
+
+	// Drive the reconcile several times — must remain a no-op every time.
+	for i := 0; i < 3; i++ {
+		if err := m.UpdateInstances(desired); err != nil {
+			t.Fatalf("UpdateInstances pass %d: %v", i, err)
+		}
+	}
+
+	open, run, stop := rec.snapshot()
+	if open != 0 || run != 0 || stop != 0 {
+		t.Fatalf("unchanged ifindex must NOT restart: open=%d run=%d stop=%d, want 0/0/0", open, run, stop)
+	}
+	m.mu.RLock()
+	got := m.instances[key]
+	m.mu.RUnlock()
+	if got != orig {
+		t.Fatal("instance was replaced despite unchanged ifindex+config (idempotence broken)")
+	}
+}
+
+// TestUpdateInstances_IfindexUnchanged_PriorityOnlyStaysInPlace asserts that a
+// priority-only delta with an UNCHANGED ifindex still takes the cheap in-place
+// updateConfig path (no restart) — the #2294 ifindex check must not turn a
+// priority bump into a socket-churning restart. Guards against over-triggering.
+func TestUpdateInstances_IfindexUnchanged_PriorityOnlyStaysInPlace(t *testing.T) {
+	m, rec := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	m.resolveIface = func(name string) (*net.Interface, error) {
+		return &net.Interface{Name: name, Index: 5}, nil
+	}
+
+	key := instanceKey{iface: "reth0.50", groupID: 101}
+	orig := seedRunningInstance(m, key, Instance{
+		Interface:        "reth0.50",
+		GroupID:          101,
+		Priority:         200,
+		Preempt:          true,
+		VirtualAddresses: []string{"172.16.50.1/24"},
+	}, 5)
+
+	desired := []*Instance{{
+		Interface:        "reth0.50",
+		GroupID:          101,
+		Priority:         150, // priority changed, VIPs + ifindex unchanged
+		Preempt:          true,
+		VirtualAddresses: []string{"172.16.50.1/24"},
+	}}
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances: %v", err)
+	}
+
+	open, run, stop := rec.snapshot()
+	if open != 0 || run != 0 || stop != 0 {
+		t.Fatalf("priority-only delta must stay in-place: open=%d run=%d stop=%d, want 0/0/0", open, run, stop)
+	}
+	m.mu.RLock()
+	got := m.instances[key]
+	m.mu.RUnlock()
+	if got != orig {
+		t.Fatal("priority-only delta replaced the instance (should be in-place)")
+	}
+	if got.cfg.Priority != 150 {
+		t.Fatalf("in-place update did not apply priority: got %d, want 150", got.cfg.Priority)
+	}
+}
+
+// TestUpdateInstances_IfindexChange_TransientResolveFailKeepsOld asserts that a
+// resolve failure during the reconcile does NOT churn the instance: the old
+// (possibly stale-bound) instance is kept until the interface resolves again,
+// matching the build-before-teardown tolerance (#2156) and avoiding dropping
+// the RG out of election on a transient netlink hiccup.
+func TestUpdateInstances_IfindexChange_TransientResolveFailKeepsOld(t *testing.T) {
+	m, rec := newTestManagerNoNetwork()
+	defer stopManagerForTest(m)
+
+	resolveErr := atomic.Bool{}
+	resolveErr.Store(true)
+	m.resolveIface = func(name string) (*net.Interface, error) {
+		if resolveErr.Load() {
+			return nil, errSocketOpenFailed
+		}
+		return &net.Interface{Name: name, Index: 9}, nil
+	}
+
+	key := instanceKey{iface: "reth0.50", groupID: 101}
+	cfg := Instance{
+		Interface:        "reth0.50",
+		GroupID:          101,
+		Priority:         200,
+		Preempt:          true,
+		VirtualAddresses: []string{"172.16.50.1/24"},
+	}
+	orig := seedRunningInstance(m, key, cfg, 7)
+
+	desired := []*Instance{{
+		Interface:        "reth0.50",
+		GroupID:          101,
+		Priority:         200,
+		Preempt:          true,
+		VirtualAddresses: []string{"172.16.50.1/24"},
+	}}
+
+	// Pass 1: resolve fails — keep the old instance, no restart.
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances pass 1: %v", err)
+	}
+	open, run, stop := rec.snapshot()
+	if open != 0 || run != 0 || stop != 0 {
+		t.Fatalf("resolve failure must keep old instance: open=%d run=%d stop=%d, want 0/0/0", open, run, stop)
+	}
+	m.mu.RLock()
+	if m.instances[key] != orig {
+		m.mu.RUnlock()
+		t.Fatal("pass 1: old instance orphaned on transient resolve failure")
+	}
+	m.mu.RUnlock()
+
+	// Pass 2: resolve returns the NEW ifindex — the drift restart fires.
+	resolveErr.Store(false)
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances pass 2: %v", err)
+	}
+	open, run, stop = rec.snapshot()
+	if open != 1 || run != 1 || stop != 1 {
+		t.Fatalf("pass 2 ifindex drift must restart: open=%d run=%d stop=%d, want 1/1/1", open, run, stop)
+	}
+	m.mu.RLock()
+	got := m.instances[key]
+	m.mu.RUnlock()
+	if got == orig || got.iface.Index != 9 {
+		t.Fatalf("pass 2: not rebound to new ifindex (same=%v index=%d)", got == orig, got.iface.Index)
+	}
+}

--- a/pkg/vrrp/vrrp_test.go
+++ b/pkg/vrrp/vrrp_test.go
@@ -580,6 +580,17 @@ func TestSyncHold_AppliesToExistingInstances(t *testing.T) {
 func TestUpdateInstances_PreservesSyncHoldForExistingInstances(t *testing.T) {
 	m := NewManager()
 
+	// Pin resolveIface so the #2294 ifindex-drift probe is hermetic
+	// regardless of whether the build/CI host has a real eth0: return the
+	// same Index (0) the instance below binds, so no drift is detected and
+	// this test exercises the priority-only in-place update it targets.
+	// Without the injection, a host that HAS an eth0 would resolve a
+	// non-zero index, trip the drift restart, and break the in-place
+	// assertion.
+	m.resolveIface = func(name string) (*net.Interface, error) {
+		return &net.Interface{Name: name, Index: 0}, nil
+	}
+
 	vi := newInstance(Instance{
 		Interface: "eth0",
 		GroupID:   101,


### PR DESCRIPTION
Closes #2294

## Problem

A VRRP instance binds its per-instance AF_PACKET / raw IP / IPv6 sockets to the member interface's kernel ifindex at `openSocket()` time. If the netdev is deleted+recreated or renamed (a carrier/VLAN flap that fully removes and re-adds the link) it gets a NEW ifindex while the xpf config stays byte-identical. `Manager.UpdateInstances` only diffed priority/preempt/track/VIPs, so the "No change" branch left the instance bound to the STALE ifindex — its sockets can no longer send/receive VRRP adverts and a MASTER node goes permanently silent (split-brain / blackhole) until an operator re-commit or daemon restart. The receive loops swallow ENODEV/ENETDOWN at debug, so nothing escalates; the 2s daemon re-drive re-ran with the same config and hit the same skip.

## Fix — ifindex-change detection in the periodic reconcile

A cheap, tolerant `name→ifindex` probe at the top of the per-instance branch in `UpdateInstances`. When the live ifindex differs from `existing.iface.Index`, it forces the existing **build-before-teardown** (#2156) restart path so the instance rebinds to a fresh socket on the new ifindex.

Detection+restart site: `pkg/vrrp/manager.go:262-265` (probe) → `pkg/vrrp/manager.go:299-322` (drift routes into the shared build-before-teardown block at `:324-364`).

- **Tolerant:** a probe resolve FAILURE is treated as "no drift" so a transient netlink hiccup never blocks a time-critical priority/preempt in-place update (failover priority, sync-hold release). The build block already owns resolve-failure-keeps-old-instance recovery.
- **Idempotent:** unchanged ifindex → false → the normal no-change / in-place path, no socket churn. Runs every ~2s reconcile tick; no alloc/restart on a steady config.
- **Composes with config-change restart:** drift and VIP-change share the one build-before-teardown block — no double-restart.

## Sync-hold / GARP / role handling on the ifindex restart

The restart rebuilds from the same desired `inst`, so it preserves configured priority/preempt/tracking, and the shared build block re-applies sync-hold preempt suppression (`if m.syncHold { instCfg.Preempt = false }` + `desiredPreempt`). A rebind therefore cannot spuriously preempt or break the sync hold. GARP is emitted by the fresh instance's normal `becomeMaster()` path when/if it wins election — not forced on the rebind. **RG role in the cluster state machine is driven separately** (heartbeat / debounced priority); the restart does not touch it, so there is no failover storm. This matched the issue's recommended fix sketch (reuse the #2156 build-before-teardown path) — no design fork.

## Tests (fail-on-revert)

`pkg/vrrp/update_instances_test.go`, via the existing resolveIface / openInstanceSocket / runInstance / stopInstance seams (no real sockets/goroutines):

- `TestUpdateInstances_IfindexChange_RestartsRebind` — drift triggers stop+open+run; replacement binds the new ifindex; preserves priority/preempt/VIPs.
- `TestUpdateInstances_IfindexUnchanged_NoRestart` — 3 reconcile passes with matching ifindex+config are a no-op (idempotence).
- `TestUpdateInstances_IfindexUnchanged_PriorityOnlyStaysInPlace` — priority-only delta with unchanged ifindex stays in-place (no restart).
- `TestUpdateInstances_IfindexChange_TransientResolveFailKeepsOld` — probe resolve failure keeps the old instance; the next pass with a fresh ifindex restarts.

## Validation

- `go build ./...` clean
- `go test ./pkg/vrrp/... ./pkg/daemon/... ./pkg/cluster/...` green
- new tests `-count=5` green
- `go test -race ./pkg/vrrp/` clean

Parent runs loss-cluster `make test-failover` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi