### PR TITLE
dhcprelay: rebind listener on interface ifindex drift (#2347)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,36 @@
 # Action Log
 
+## 2026-06-22 — #2347 DHCP-relay ifindex-drift listener rebind
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Fixed the HIGH availability gap (sibling of #2294, for the relay
+  listener) where the DHCP relay's per-interface client listener stays bound to
+  a STALE kernel ifindex after the interface is deleted+recreated/renamed under
+  unchanged config. `SO_BINDTODEVICE` pins the listener to the ifindex at
+  `bind(2)`; on drift the kernel stops delivering DHCP requests and the relay
+  goes permanently DEAF until daemon restart. The relay had no periodic
+  reconcile (only `Apply`-on-config at boot), so rather than wire the HA-only
+  daemon loop I made each per-interface relay a self-contained SUPERVISOR:
+  `runRelay` now runs one `runRelaySession` under a child context and rebuilds
+  it on drift. `runRelaySession` captures the live ifindex at listener open and
+  runs a periodic (5s, `ifindexCheckInterval`) tolerant `name→ifindex` watcher;
+  on a real differing index it records drift and cancels the SESSION context,
+  reusing the existing #1915 close-on-cancel + WaitGroup teardown (no new
+  teardown path, no EADDRINUSE, no Stop()-hang). Tolerant (resolve failure =
+  no drift), idempotent (unchanged index = no rebind), degraded-baseline-safe
+  (failed capture adopts the first real reading), per-interface (a rebind never
+  drops other segments). Added `resolveIfindex` (ifindexResolver) +
+  `ifindexCheck` seams + `defaultIfindexResolver`. Mirrors the #2294 VRRP fix.
+- **File(s)**: pkg/dhcprelay/relay.go, pkg/dhcprelay/relay_test.go,
+  pkg/dhcprelay/README.md, _Log.md
+- **Validation**: `go build ./...` clean; `go test ./pkg/dhcprelay/...
+  ./pkg/daemon/...` green; 5 new fail-on-revert tests
+  (TestRunRelay_IfindexDrift_RebindsListener / _IfindexStable_NoRebind /
+  _IfindexResolveFailure_KeepsListener / _IfindexDrift_StopStillBounded /
+  TestRunRelay_DegradedBaseline_AdoptsFirstRealIfindex) green 5x under -race;
+  `go test -race ./pkg/dhcprelay/` clean. Live relay-ifindex-change
+  verification is lab-bound (deferred — code + unit tests are the deliverable).
+
 ## 2026-06-22 — #2294 VRRP ifindex-drift restart (rebind on stale socket)
 
 - **Timestamp**: 2026-06-22 PDT

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -158,6 +158,29 @@ below). Changes touching this path must pass `make test-failover`.
   yet created), the relay retries resolving the interface + giaddr on a
   bounded, `ctx`-cancelable interval instead of dying permanently. The
   interface is re-looked-up every attempt (no stale cached index).
+- **ifindex-drift detection (#2347).** `SO_BINDTODEVICE` pins the client
+  listener to the interface's kernel **ifindex** at `bind(2)`. If the
+  interface is deleted+recreated or renamed at runtime under unchanged config
+  (VLAN delete/recreate, tunnel rebuild, device reset) it gets a NEW ifindex
+  and the kernel stops delivering DHCP client requests to the stale-bound
+  socket — the relay goes permanently **deaf** on that segment until a daemon
+  restart. (Note: the raw-L2 reply path is unaffected — it re-resolves the
+  ifindex per send; only the listener is at risk.) Each per-interface relay is
+  now a **supervisor**: `runRelay` runs one `runRelaySession` under a child
+  context and rebuilds it when the session tears down due to drift.
+  `runRelaySession` captures the live ifindex when it opens the listener and
+  runs a periodic (`ifindexCheckInterval`, 5s) watcher that re-resolves the
+  name to the live ifindex; on a real, differing index it records drift and
+  cancels the **session** context, reusing the existing #1915 close-on-cancel
+  + `WaitGroup` teardown (no new teardown path, no `EADDRINUSE` — the stale
+  socket is fully closed before the rebind, no `Stop()`-hang risk). The probe
+  is **tolerant**: a resolve failure is treated as "no drift" so a transient
+  netlink hiccup or mid-rename window never tears down a working listener, and
+  it is **idempotent** (unchanged ifindex => no rebind). A failed baseline
+  capture (`boundIfindex==0`) adopts the first real reading as the baseline
+  rather than triggering a spurious rebind. Drift detection is per-interface,
+  so a rebind on one segment never drops relays on the others. This mirrors
+  the #2294 VRRP instance-restart-on-ifindex-drift fix for the relay listener.
 
 ## Gotchas
 

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -377,9 +377,8 @@ func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
 		// runRelaySession returns drift=true ONLY when it tore down because the
 		// live ifindex moved; in that case rebuild immediately (rebind to the
 		// new ifindex). Any other return (Stop/one-sided exit/listen failure)
-		// is terminal for this supervisor unless the manager ctx is still live
-		// AND the cause was not drift — in which case we fall through to the
-		// ctx.Err() guard at the top and exit.
+		// is drift=false and terminal for this supervisor — we return right
+		// here, ending the per-interface goroutine.
 		drift := m.runRelaySession(ctx, ir, servers)
 		if !drift {
 			return
@@ -440,11 +439,19 @@ func (m *Manager) runRelaySession(ctx context.Context,
 	// real ifindex) so the FIRST successful watcher resolve that returns a real
 	// index is NOT mistaken for drift; the watcher only fires when it can read a
 	// real index that differs from a real captured baseline.
-	boundIfindex, ierr := m.resolveIfindex(ifaceName)
-	if ierr != nil {
-		slog.Warn("dhcp-relay: could not capture bound ifindex (drift detection degraded)",
-			"interface", ifaceName, "err", ierr)
-		boundIfindex = 0
+	// Guard the resolver the same way the drift watcher does (`m.resolveIfindex
+	// != nil`): a Manager constructed without a resolver disables drift
+	// detection entirely, so the baseline capture must not call a nil resolver
+	// (it would panic at session startup). nil resolver → degraded baseline 0.
+	var boundIfindex int
+	if m.resolveIfindex != nil {
+		idx, ierr := m.resolveIfindex(ifaceName)
+		if ierr != nil {
+			slog.Warn("dhcp-relay: could not capture bound ifindex (drift detection degraded)",
+				"interface", ifaceName, "err", ierr)
+		} else {
+			boundIfindex = idx
+		}
 	}
 
 	// Client-facing listener: 0.0.0.0:67, REUSEPORT (coexist with other

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -35,6 +35,19 @@ const clientPort = 68
 // retry loop is ctx-cancelable so Stop() unwinds it promptly.
 const startupRetryInterval = 5 * time.Second
 
+// ifindexCheckInterval is how often a running relay re-resolves its interface
+// name to the live kernel ifindex and compares it against the ifindex its
+// client listener was SO_BINDTODEVICE-bound to at socket creation (#2347). The
+// listener socket pins to the interface's ifindex at bind(2); if the interface
+// is deleted+recreated or renamed under unchanged config it gets a NEW ifindex
+// and the kernel stops delivering DHCP client requests to the stale-bound
+// listener (the relay goes deaf on that segment). On drift the relay tears down
+// the current session and rebinds to the new ifindex. This mirrors the #2294
+// VRRP reconcile probe. 5s matches the VRRP/daemon reconcile cadence closely
+// enough to bound the deaf window without a tight netlink loop; the resolve is
+// a cheap name->ifindex lookup and idempotent (unchanged ifindex => no action).
+const ifindexCheckInterval = 5 * time.Second
+
 // option82 is the DHCP Relay Agent Information option (RFC 3046).
 const option82 = dhcpv4.OptionRelayAgentInformation
 
@@ -111,6 +124,15 @@ type packetConnFactory func(ctx context.Context, ifaceName string,
 // not-yet-addressed one. It is a seam so the retry behavior is testable.
 type ifaceResolver func(ifaceName string) (net.IP, error)
 
+// ifindexResolver resolves an interface name to its current kernel ifindex
+// (#2347). It is a separate seam from ifaceResolver so the drift detector can
+// observe ifindex churn independently of giaddr addressing, and so lifecycle
+// tests can drive an ifindex change without root/netlink. A non-nil error means
+// "unresolvable right now" — the caller MUST treat that as "no drift" and keep
+// the existing listener (a transient netlink hiccup or a mid-rename window must
+// NOT tear down a working relay), mirroring the tolerant #2294 VRRP probe.
+type ifindexResolver func(ifaceName string) (int, error)
+
 // Manager manages per-interface DHCP relay goroutines.
 type Manager struct {
 	mu     sync.Mutex
@@ -120,6 +142,12 @@ type Manager struct {
 	newConn       packetConnFactory
 	resolveGIAddr ifaceResolver
 	retryInterval time.Duration
+
+	// resolveIfindex resolves the interface name to its live kernel ifindex for
+	// the #2347 drift detector; ifindexCheck is how often runRelay re-checks.
+	// Both are seams so lifecycle tests drive a deterministic ifindex change.
+	resolveIfindex ifindexResolver
+	ifindexCheck   time.Duration
 	// newL2 opens the raw-L2 unicast sender for an interface (#2076). It is
 	// a seam so tests can inject a fake or force open failure. The default
 	// returns (nil, err) → fail-soft to the broadcast path; the production
@@ -135,11 +163,13 @@ type l2SenderFactory func(ifaceName string) (l2Replier, error)
 // NewManager creates a new DHCP relay Manager.
 func NewManager() *Manager {
 	return &Manager{
-		relays:        make(map[string]*interfaceRelay),
-		newConn:       defaultPacketConnFactory,
-		resolveGIAddr: defaultIfaceResolver,
-		retryInterval: startupRetryInterval,
-		newL2:         defaultL2SenderFactory,
+		relays:         make(map[string]*interfaceRelay),
+		newConn:        defaultPacketConnFactory,
+		resolveGIAddr:  defaultIfaceResolver,
+		retryInterval:  startupRetryInterval,
+		resolveIfindex: defaultIfindexResolver,
+		ifindexCheck:   ifindexCheckInterval,
+		newL2:          defaultL2SenderFactory,
 	}
 }
 
@@ -199,6 +229,18 @@ func defaultIfaceResolver(ifaceName string) (net.IP, error) {
 		return nil, fmt.Errorf("interface lookup: %w", err)
 	}
 	return interfaceIPv4(iface)
+}
+
+// defaultIfindexResolver resolves an interface name to its live kernel ifindex
+// (#2347). It deliberately does NOT require an address (unlike
+// defaultIfaceResolver): ifindex drift must be observable even during a window
+// where the recreated interface has not yet been re-addressed.
+func defaultIfindexResolver(ifaceName string) (int, error) {
+	iface, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		return 0, fmt.Errorf("interface lookup: %w", err)
+	}
+	return iface.Index, nil
 }
 
 // Apply starts relay goroutines according to the provided configuration.
@@ -308,13 +350,55 @@ func (m *Manager) Stop() {
 	}
 }
 
-// runRelay is the main loop for a single interface relay. It resolves the
-// interface giaddr (with bounded ctx-cancelable retry for boot races), opens a
-// client-facing listener on 0.0.0.0:67 bound to the interface and a server
-// conn bound to giaddr, then relays client requests to the configured servers
-// and forwards server responses back to clients.
+// runRelay is the per-interface supervisor. It runs one relay SESSION (resolve
+// giaddr, open listener + server conn + raw-L2 sender, relay packets) under a
+// child context, and rebuilds the session when it exits because the interface's
+// kernel ifindex drifted away from the ifindex the client listener was bound to
+// (#2347). It returns only when the manager context is cancelled (Stop()), at
+// which point ir.done closes and Stop()'s join completes.
 //
-// Lifecycle invariants (see docs/research/1915-relay-socket-lifecycle/plan.md):
+// Why a supervisor loop: the client listener binds SO_BINDTODEVICE once at
+// bind(2), pinning it to the interface's then-current ifindex. If the interface
+// is deleted+recreated/renamed under unchanged config the kernel stops
+// delivering to the stale-bound socket and the relay goes permanently deaf
+// until daemon restart. Detecting drift and rebinding restores delivery without
+// dropping relays on other interfaces (each interface has its own supervisor).
+// This mirrors the #2294 VRRP instance-restart-on-ifindex-drift fix.
+func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
+	ir *interfaceRelay, servers []*net.UDPAddr) {
+	// cancel is the manager-level cancel for this interface (invoked by Stop()).
+	// We do not need it here beyond observing ctx.Done(); keep the signature
+	// stable for Apply's call site.
+	_ = cancel
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		// runRelaySession returns drift=true ONLY when it tore down because the
+		// live ifindex moved; in that case rebuild immediately (rebind to the
+		// new ifindex). Any other return (Stop/one-sided exit/listen failure)
+		// is terminal for this supervisor unless the manager ctx is still live
+		// AND the cause was not drift — in which case we fall through to the
+		// ctx.Err() guard at the top and exit.
+		drift := m.runRelaySession(ctx, ir, servers)
+		if !drift {
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		slog.Info("dhcp-relay: interface ifindex changed, rebinding listener",
+			"interface", ir.ifaceName)
+	}
+}
+
+// runRelaySession runs a single relay session and returns drift=true iff it tore
+// down because the interface's live ifindex differs from the ifindex the client
+// listener was bound to (#2347). On any other exit (Stop, one-sided socket
+// close, fatal listen failure) it returns drift=false and the supervisor exits.
+//
+// Lifecycle invariants (see docs/research/1915-relay-socket-lifecycle/plan.md),
+// preserved intact under a per-session child context:
 //   - Both conns are net.PacketConn (ReadFrom/WriteTo) — no *net.UDPConn
 //     assertion — which keeps the factory mockable.
 //   - A close-on-cancel watcher is started LAST (after both conns exist) and
@@ -322,39 +406,67 @@ func (m *Manager) Stop() {
 //   - Both loops cancel the shared ctx on exit BEFORE the runner joins, so a
 //     one-sided exit cannot hang wg.Wait(). The main loop runs in an inner
 //     func whose `defer cancel()` fires before the outer wg.Wait().
-func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
-	ir *interfaceRelay, servers []*net.UDPAddr) {
+//   - The #2347 drift watcher cancels this SAME session ctx, so a drift teardown
+//     reuses the existing close-on-cancel + WaitGroup join — no new teardown
+//     path, no EADDRINUSE (the old socket is fully closed before rebind), no
+//     Stop()-hang risk.
+func (m *Manager) runRelaySession(ctx context.Context,
+	ir *interfaceRelay, servers []*net.UDPAddr) (drift bool) {
 	ifaceName := ir.ifaceName
+
+	// Per-session context. Either the manager ctx (Stop), a loop's exit
+	// (cross-cancel), or the drift watcher cancels it.
+	sctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// driftDetected is set by the watcher under no lock other than its own
+	// happens-before with wg.Wait(): the watcher writes it then the session
+	// returns after wg.Wait() joins the watcher, so the read below is safe.
+	var driftDetected atomic.Bool
 
 	// Axis C1: resolve giaddr with bounded, ctx-cancelable retry. Re-resolve
 	// the interface every attempt so a dynamic interface recreated under the
 	// same name (new Index) is picked up, and so a not-yet-created interface
 	// does not permanently kill the relay.
-	giaddr, ok := m.resolveGIAddrWithRetry(ctx, ifaceName)
+	giaddr, ok := m.resolveGIAddrWithRetry(sctx, ifaceName)
 	if !ok {
-		return // ctx cancelled during retry; nothing created yet.
+		return false // ctx cancelled during retry; nothing created yet.
+	}
+
+	// #2347: capture the interface's live ifindex at the moment we open the
+	// client listener. SO_BINDTODEVICE inside the factory binds the socket to
+	// this ifindex; the drift watcher compares against this baseline. A resolve
+	// failure here is non-fatal — we proceed with boundIfindex=0 (an impossible
+	// real ifindex) so the FIRST successful watcher resolve that returns a real
+	// index is NOT mistaken for drift; the watcher only fires when it can read a
+	// real index that differs from a real captured baseline.
+	boundIfindex, ierr := m.resolveIfindex(ifaceName)
+	if ierr != nil {
+		slog.Warn("dhcp-relay: could not capture bound ifindex (drift detection degraded)",
+			"interface", ifaceName, "err", ierr)
+		boundIfindex = 0
 	}
 
 	// Client-facing listener: 0.0.0.0:67, REUSEPORT (coexist with other
 	// interfaces), SO_BINDTODEVICE (per-interface isolation under REUSEPORT),
 	// SO_BROADCAST (deliver broadcast OFFER/ACK to 255.255.255.255:68).
-	conn, err := m.newConn(ctx, ifaceName, true, true,
+	conn, err := m.newConn(sctx, ifaceName, true, true,
 		&net.UDPAddr{IP: net.IPv4zero, Port: relayPort})
 	if err != nil {
 		slog.Error("dhcp-relay: listen failed",
 			"interface", ifaceName, "err", err)
-		return
+		return false
 	}
 	defer conn.Close()
 
 	// Server conn: bound to giaddr ephemeral port. No REUSEPORT, no
 	// BINDTODEVICE (unique port), no broadcast.
-	serverConn, err := m.newConn(ctx, "", false, false,
+	serverConn, err := m.newConn(sctx, "", false, false,
 		&net.UDPAddr{IP: giaddr, Port: 0})
 	if err != nil {
 		slog.Error("dhcp-relay: server conn failed",
 			"interface", ifaceName, "err", err)
-		return
+		return false
 	}
 	defer serverConn.Close()
 
@@ -385,13 +497,13 @@ func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
 	}()
 
 	slog.Info("dhcp-relay: listening",
-		"interface", ifaceName, "giaddr", giaddr,
+		"interface", ifaceName, "giaddr", giaddr, "ifindex", boundIfindex,
 		"always_broadcast", ir.alwaysBroadcast, "raw_l2", l2 != nil)
 
 	// Both the cancel watcher and the server-response goroutine are tracked by
 	// the WaitGroup so the runner's wg.Wait() is a true join of every spawned
-	// goroutine — runRelay does not return (and ir.done does not close) until
-	// the watcher's two Close() calls have completed.
+	// goroutine — runRelaySession does not return until the watcher's two
+	// Close() calls have completed.
 	var wg sync.WaitGroup
 
 	// Cancel watcher — started LAST, after BOTH conns exist. Closing both is
@@ -400,10 +512,57 @@ func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		<-ctx.Done()
+		<-sctx.Done()
 		_ = conn.Close()
 		_ = serverConn.Close()
 	}()
+
+	// #2347 ifindex-drift watcher. Periodically re-resolve the interface name
+	// to its live ifindex and compare against the baseline captured at bind. On
+	// a real, differing index it records drift and cancels THIS session ctx,
+	// which trips the close-on-cancel watcher above (clean teardown) and makes
+	// runRelay rebuild bound to the new ifindex. A resolve FAILURE is treated
+	// as "no drift" (tolerant) so a transient netlink hiccup / mid-rename window
+	// never tears down a working listener. Disabled when ifindexCheck<=0 or no
+	// resolver, and a degraded baseline (boundIfindex==0) means we only treat a
+	// later real index as drift if the baseline was real — see the guard below.
+	if m.ifindexCheck > 0 && m.resolveIfindex != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ticker := time.NewTicker(m.ifindexCheck)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-sctx.Done():
+					return
+				case <-ticker.C:
+					live, lerr := m.resolveIfindex(ifaceName)
+					if lerr != nil {
+						// Tolerant: keep the listener; this is not drift.
+						slog.Debug("dhcp-relay: ifindex re-resolve failed, keeping listener",
+							"interface", ifaceName, "err", lerr)
+						continue
+					}
+					// Only a real baseline can be compared. boundIfindex==0
+					// (degraded capture) adopts the first real reading as the
+					// baseline rather than treating it as drift.
+					if boundIfindex == 0 {
+						boundIfindex = live
+						continue
+					}
+					if live != boundIfindex {
+						slog.Info("dhcp-relay: detected ifindex drift",
+							"interface", ifaceName,
+							"old_ifindex", boundIfindex, "new_ifindex", live)
+						driftDetected.Store(true)
+						cancel()
+						return
+					}
+				}
+			}
+		}()
+	}
 
 	// Track the server-response goroutine so the runner joins it. Its exit
 	// cancels the shared ctx (cross-cancellation) so the watcher closes both
@@ -412,7 +571,7 @@ func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
 	go func() {
 		defer wg.Done()
 		defer cancel()
-		handleServerResponses(ctx, serverConn, conn, ir, l2, giaddr)
+		handleServerResponses(sctx, serverConn, conn, ir, l2, giaddr)
 	}()
 
 	// Main read loop in its OWN func scope so its `defer cancel()` fires on
@@ -427,8 +586,8 @@ func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
 				// Exit ONLY on cancel or socket-close; a transient read error
 				// is logged and the loop continues (a single bad datagram must
 				// not kill the relay). Returning on ErrClosed too prevents a
-				// hot-spin if the socket is closed while ctx.Err() is still nil.
-				if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				// hot-spin if the socket is closed while sctx.Err() is still nil.
+				if sctx.Err() != nil || errors.Is(err, net.ErrClosed) {
 					return
 				}
 				slog.Warn("dhcp-relay: read error",
@@ -493,6 +652,10 @@ func (m *Manager) runRelay(ctx context.Context, cancel context.CancelFunc,
 	// Safe now: the inner func's defer cancel() has fired, so the watcher has
 	// closed both conns and the response goroutine's ReadFrom is unblocked.
 	wg.Wait()
+
+	// The drift watcher (joined above) is the only writer of driftDetected; its
+	// store happens-before this read through wg.Wait().
+	return driftDetected.Load()
 }
 
 // resolveGIAddrWithRetry resolves the interface giaddr, retrying on a bounded

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -391,6 +391,11 @@ func testManager(factory packetConnFactory) *Manager {
 		return net.IPv4(10, 0, 0, 254), nil
 	}
 	m.retryInterval = time.Millisecond
+	// Default to a stable ifindex with the #2347 drift watcher effectively off
+	// (a long interval) so pre-existing lifecycle tests see no extra churn.
+	// Drift tests override resolveIfindex + ifindexCheck.
+	m.resolveIfindex = func(ifaceName string) (int, error) { return 100, nil }
+	m.ifindexCheck = time.Hour
 	// Default to a no-op fake L2 sender so lifecycle tests do not depend on
 	// CAP_NET_RAW or a real NIC (#2076). Individual tests override m.newL2.
 	m.newL2 = func(ifaceName string) (l2Replier, error) {
@@ -828,5 +833,197 @@ func TestL2Sender_CloseIdempotent(t *testing.T) {
 	}
 	if err := s.Close(); err != nil {
 		t.Errorf("second Close = %v, want nil (idempotent)", err)
+	}
+}
+
+// --- #2347 ifindex-drift detection ---
+
+// driftResolver returns an ifindexResolver backed by an atomic value (so a test
+// can flip the live ifindex mid-flight) plus an atomic error toggle (so a test
+// can simulate a transient resolve failure). It also counts calls.
+func driftResolver(initial int) (ifindexResolver, *atomic.Int64, *atomic.Bool, *atomic.Int64) {
+	idx := &atomic.Int64{}
+	idx.Store(int64(initial))
+	failing := &atomic.Bool{}
+	calls := &atomic.Int64{}
+	r := func(ifaceName string) (int, error) {
+		calls.Add(1)
+		if failing.Load() {
+			return 0, errors.New("transient resolve failure")
+		}
+		return int(idx.Load()), nil
+	}
+	return r, idx, failing, calls
+}
+
+// TestRunRelay_IfindexDrift_RebindsListener proves the #2347 fix: when the
+// interface's live ifindex changes under unchanged config, the relay tears down
+// the stale-bound session and rebinds a fresh client listener to the new
+// ifindex. Asserted by construction via the factory call count: the first
+// session opens 2 conns (client+server); after drift the supervisor rebuilds,
+// opening 2 more — 4 total — and the rebuilt client listener still carries the
+// SO_BINDTODEVICE ifaceName invariant.
+func TestRunRelay_IfindexDrift_RebindsListener(t *testing.T) {
+	factory, getCalls := recordingFactory()
+	m := testManager(factory)
+	defer m.Stop()
+
+	resolve, liveIdx, _, _ := driftResolver(100)
+	m.resolveIfindex = resolve
+	m.ifindexCheck = 5 * time.Millisecond
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second) // gen-1 client + server
+
+	// Interface deleted+recreated -> new kernel ifindex.
+	liveIdx.Store(200)
+
+	// The drift watcher must cancel the session and the supervisor must rebuild,
+	// producing 2 more factory calls (gen-2 client + server).
+	calls := waitCalls(t, getCalls, 4, 2*time.Second)
+
+	// The rebound client listener (a :67 call after the first two) must keep the
+	// per-interface SO_BINDTODEVICE ifaceName.
+	clientListeners := 0
+	for _, c := range calls {
+		if c.bindAddr.Port == relayPort {
+			clientListeners++
+			if c.ifaceName != "ge-0-0-0" {
+				t.Errorf("rebound client listener lost BINDTODEVICE ifaceName: %+v", c)
+			}
+		}
+	}
+	if clientListeners < 2 {
+		t.Errorf("expected >=2 client listeners (original + rebind), got %d", clientListeners)
+	}
+}
+
+// TestRunRelay_IfindexStable_NoRebind proves idempotency: with the live ifindex
+// never changing, the drift watcher fires repeatedly but never restarts the
+// session. The factory is called exactly twice (one session) for the lifetime.
+func TestRunRelay_IfindexStable_NoRebind(t *testing.T) {
+	factory, getCalls := recordingFactory()
+	m := testManager(factory)
+	defer m.Stop()
+
+	resolve, _, _, calls := driftResolver(100)
+	m.resolveIfindex = resolve
+	m.ifindexCheck = 2 * time.Millisecond
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second)
+
+	// Let the watcher tick many times against a stable ifindex.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) && calls.Load() < 10 {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if calls.Load() < 5 {
+		t.Fatalf("drift watcher did not run enough to be meaningful (%d resolves)", calls.Load())
+	}
+
+	// No rebind: still exactly the original 2 factory calls.
+	if got := len(getCalls()); got != 2 {
+		t.Errorf("stable ifindex must NOT rebind: got %d factory calls, want 2", got)
+	}
+}
+
+// TestRunRelay_IfindexResolveFailure_KeepsListener proves the tolerant-resolve
+// invariant: a transient ifindex resolve failure must NOT tear down a working
+// listener (no rebind, no socket close), mirroring #2294's tolerant probe.
+func TestRunRelay_IfindexResolveFailure_KeepsListener(t *testing.T) {
+	client := newFakeConn()
+	server := newFakeConn()
+	factory, getCalls := recordingFactory(client, server)
+	m := testManager(factory)
+	defer m.Stop()
+
+	resolve, _, failing, calls := driftResolver(100)
+	m.resolveIfindex = resolve
+	m.ifindexCheck = 2 * time.Millisecond
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second)
+
+	// Resolver now fails on every tick.
+	failing.Store(true)
+
+	// Let it fail many times.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	base := calls.Load()
+	for time.Now().Before(deadline) && calls.Load() < base+10 {
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// The working session must be intact: no rebind (still 2 factory calls) and
+	// the gen-1 conns must NOT be closed.
+	if got := len(getCalls()); got != 2 {
+		t.Errorf("resolve failure must NOT rebind: got %d factory calls, want 2", got)
+	}
+	if client.isClosed() || server.isClosed() {
+		t.Error("resolve failure must NOT tear down the working listener")
+	}
+}
+
+// TestRunRelay_IfindexDrift_StopStillBounded proves a #1915 non-regression: even
+// after a drift rebind, Stop() returns under a bounded timeout (the supervisor
+// observes ctx cancellation and the close-on-cancel + WaitGroup join still
+// unblock the rebuilt session's blocking ReadFrom).
+func TestRunRelay_IfindexDrift_StopStillBounded(t *testing.T) {
+	factory, getCalls := recordingFactory()
+	m := testManager(factory)
+
+	resolve, liveIdx, _, _ := driftResolver(100)
+	m.resolveIfindex = resolve
+	m.ifindexCheck = 5 * time.Millisecond
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second)
+
+	liveIdx.Store(200) // force a rebind
+	waitCalls(t, getCalls, 4, 2*time.Second)
+
+	done := make(chan struct{})
+	go func() { m.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() after ifindex-drift rebind did not return within 2s (#1915 regression)")
+	}
+}
+
+// TestRunRelay_DegradedBaseline_AdoptsFirstRealIfindex proves that a failed
+// baseline capture at bind (boundIfindex==0) does NOT cause a spurious rebind:
+// the first real resolve is adopted as the baseline, and only a subsequent
+// change triggers a rebind.
+func TestRunRelay_DegradedBaseline_AdoptsFirstRealIfindex(t *testing.T) {
+	factory, getCalls := recordingFactory()
+	m := testManager(factory)
+	defer m.Stop()
+
+	// First resolve (the bind-time baseline capture) fails; later resolves
+	// return a stable real index.
+	var first atomic.Bool
+	first.Store(true)
+	m.resolveIfindex = func(ifaceName string) (int, error) {
+		if first.Swap(false) {
+			return 0, errors.New("baseline capture failed")
+		}
+		return 300, nil
+	}
+	m.ifindexCheck = 2 * time.Millisecond
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second)
+
+	// Watcher adopts 300 as baseline then sees 300 forever -> no rebind.
+	time.Sleep(150 * time.Millisecond)
+	if got := len(getCalls()); got != 2 {
+		t.Errorf("degraded baseline must adopt first real ifindex, not rebind: got %d calls, want 2", got)
 	}
 }

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -975,6 +975,12 @@ func TestRunRelay_IfindexResolveFailure_KeepsListener(t *testing.T) {
 func TestRunRelay_IfindexDrift_StopStillBounded(t *testing.T) {
 	factory, getCalls := recordingFactory()
 	m := testManager(factory)
+	// Clean up on an early t.Fatal (waitRelays/waitCalls timeout) before the
+	// explicit timed Stop below. Stop() is idempotent (it empties m.relays
+	// under lock), so the later explicit Stop is unaffected and this defer is
+	// a no-op on the happy path — it just prevents leaked relay goroutines
+	// from interfering with subsequent tests on an early failure.
+	defer m.Stop()
 
 	resolve, liveIdx, _, _ := driftResolver(100)
 	m.resolveIfindex = resolve


### PR DESCRIPTION
Closes #2347

## Problem
The DHCP relay's per-interface client listener sets `SO_BINDTODEVICE` once at `bind(2)`, pinning the socket to the interface's then-current kernel **ifindex**. If the interface is deleted+recreated or renamed at runtime under unchanged config (VLAN delete/recreate, tunnel rebuild, device reset), it gets a NEW ifindex, the kernel stops delivering DHCP client requests to the stale-bound socket, and nothing restarts the goroutine — the relay goes permanently **deaf** on that segment until daemon restart. This is the DHCP-relay sibling of #2294 (which fixed the same bug class for VRRP only).

The triage corrected agy-review-025: the raw-L2 reply path re-resolves the ifindex per send and is drift-safe, so the genuine defect is the **deaf listener**, not outgoing writes.

## ifindex-drift detection + listener restart
The relay has no periodic reconcile loop (only `Apply`-on-config at boot) and its daemon driver is HA-only, so rather than introduce a standalone-vs-HA daemon-loop fork the detection is self-contained in `pkg/dhcprelay` as a **per-interface supervisor**:

- `runRelay` now runs one `runRelaySession` under a child context and rebuilds it when the session tears down due to drift.
- `runRelaySession` captures the live ifindex when it opens the client listener (`resolveIfindex` seam) and runs a periodic (5s, `ifindexCheckInterval`) watcher that re-resolves the interface name. On a real, differing index it records drift and cancels the **session** context. The supervisor then rebuilds, rebinding to the new ifindex.
- Detection site: `pkg/dhcprelay/relay.go` — the drift watcher inside `runRelaySession` (the `if m.ifindexCheck > 0 && m.resolveIfindex != nil` block).

## Tolerant resolve + #1915 lifecycle preservation
- **Tolerant** (mirrors #2294): a resolve failure is treated as "no drift" so a transient netlink hiccup / mid-rename window never tears down a working listener.
- **Idempotent**: an unchanged ifindex => no rebind, no churn (the watcher runs periodically).
- **Degraded-baseline-safe**: a failed capture at bind (`boundIfindex==0`) adopts the first real reading as the baseline rather than triggering a spurious rebind.
- **Per-interface**: a rebind on one segment never drops relays on the others.
- **#1915 preserved**: the drift watcher cancels the **same session context**, so teardown reuses the existing close-on-cancel watcher + `WaitGroup` join. The stale socket is fully closed before the rebind (no `EADDRINUSE`) and `Stop()` stays bounded (no #1915 hang). No new teardown path.

## Tests (fail-on-revert, conn-factory + ifindex-resolver seams)
- `TestRunRelay_IfindexDrift_RebindsListener` — drift rebinds; rebound listener keeps the `BINDTODEVICE` ifaceName invariant.
- `TestRunRelay_IfindexStable_NoRebind` — stable ifindex never rebinds (idempotent).
- `TestRunRelay_IfindexResolveFailure_KeepsListener` — transient resolve failure keeps the listener up (no teardown).
- `TestRunRelay_IfindexDrift_StopStillBounded` — `Stop()` bounded after a drift rebind (#1915 non-regression).
- `TestRunRelay_DegradedBaseline_AdoptsFirstRealIfindex` — failed baseline capture adopts the first real reading.

Revert-simulation confirms `TestRunRelay_IfindexDrift_RebindsListener` fails when the detection is neutralized.

## Validation
- `go build ./...` clean
- `go test ./pkg/dhcprelay/... ./pkg/daemon/...` green
- new tests pass 5x under `-race`; `go test -race ./pkg/dhcprelay/` clean
- Live relay-ifindex-change verification is **lab-bound and deferred** — code + unit tests are the deliverable.

Mirror of #2294 (VRRP instance-restart-on-ifindex-drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi