### PR TITLE
dhcprelay: reconcile DHCP relay on day-2 commits (#2348)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -10567,3 +10567,31 @@ top.
     No NAT64 doc documents L4-checksum sentinel handling; inline comment is the
     contract.
   - **File(s)**: userspace-dp/src/nat64.rs, userspace-dp/src/nat64_tests.rs, _Log.md
+
+- **Timestamp**: 2026-06-22
+  - **Action**: #2348 DHCP relay day-2 reconcile. (1) Wired the relay into the
+    commit-apply pipeline: new `daemon.reconcileDHCPRelay` called from
+    `applyConfigLocked` (step 16c, after reconcileFlowExporters), forwarding
+    `cfg.ForwardingOptions.DHCPRelay` to the Manager on `d.daemonCtx`. The boot
+    site now always creates the Manager (was gated on a non-nil relay config) so
+    a relay added day-2 can start. (2) Made `Manager.Apply` a true per-interface
+    reconcile instead of stop-all/rebuild-all: `computeDesired` builds the
+    desired set keyed by interface (spec = resolved server list + always-
+    broadcast); Apply diffs vs the running `relays` map — start added, stop
+    removed (and nil cfg stops all), restart changed (spec inequality), leave
+    unchanged (idempotent, no churn). Stop/restart reuse the #2347 supervisor +
+    #1915 close-on-cancel teardown; old listener fully closes before the
+    replacement binds (no EADDRINUSE); teardown joins run outside m.mu (no
+    Stats()/Apply stall).
+  - **Validation**: go build ./... clean; go test ./pkg/dhcprelay/...
+    ./pkg/daemon/... green; -race ./pkg/dhcprelay green; new tests 5x stable.
+    New Manager tests: TestApply_Reapply_Idempotent (rewritten from the old
+    stop-all assertion), TestApply_AddInterface_DayTwo,
+    TestApply_RemoveInterface_StopsRelay, TestApply_NilConfig_StopsAll,
+    TestApply_ChangedServers_Restarts, TestApply_ChangedBroadcast_Restarts. New
+    daemon-seam tests: TestReconcileDHCPRelayNilManagerNoop,
+    TestReconcileDHCPRelayRemoveStopsAll, TestReconcileDHCPRelayAddStartsRelay.
+    Live day-2 relay reconcile is lab-bound (deferred).
+  - **File(s)**: pkg/dhcprelay/relay.go, pkg/dhcprelay/relay_test.go,
+    pkg/dhcprelay/README.md, pkg/daemon/daemon_apply.go, pkg/daemon/daemon_run.go,
+    pkg/daemon/daemon_dhcprelay_reconcile_test.go, _Log.md

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1190,6 +1190,15 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	// to the next clean commit.
 	d.reconcileFlowExporters(cfg)
 
+	// 16c. Reconcile the DHCP relay (#2348). Before this the relay was
+	// applied only at boot (daemon_run.go), so a day-2 commit that added,
+	// removed, or changed a `forwarding-options dhcp-relay` group was
+	// ignored until a daemon restart. Manager.Apply diffs desired-vs-running
+	// per interface (start added, stop removed, restart changed, leave
+	// unchanged) and a nil relay config stops all relays. Bound to
+	// d.daemonCtx so the relay goroutines outlive this apply call.
+	d.reconcileDHCPRelay(cfg)
+
 	// 17. Update event-options policies (RPM-driven failover)
 	if d.eventEngine != nil {
 		d.eventEngine.Apply(cfg.EventOptions)
@@ -1337,6 +1346,27 @@ func (d *Daemon) setDataplaneDeferWorkers(deferWorkers bool) {
 		return
 	}
 	d.dp.Link().SetDeferWorkers(deferWorkers)
+}
+
+// reconcileDHCPRelay re-applies the DHCP relay config on every commit (#2348).
+// The relay Manager is created at boot (daemon_run.go) regardless of whether a
+// relay was configured then, so a relay added on a day-2 commit starts here and
+// a relay removed here stops. Manager.Apply diffs desired-vs-running per
+// interface (start added / stop removed / restart changed / leave unchanged),
+// and a nil relay config stops all relays. The relay goroutines bind to
+// d.daemonCtx (the daemon lifetime) — NOT a request-scoped context — so they
+// survive past this apply call and are torn down only at daemon stop. Guarded
+// on d.dhcpRelay so a daemon constructed without a relay Manager (e.g. a test
+// harness or NoDataplane boot that skipped the boot wiring) is a safe no-op.
+func (d *Daemon) reconcileDHCPRelay(cfg *config.Config) {
+	if d.dhcpRelay == nil {
+		return
+	}
+	ctx := d.daemonCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	d.dhcpRelay.Apply(ctx, cfg.ForwardingOptions.DHCPRelay)
 }
 
 func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, activeState map[string]bool, applyResult *dataplane.ApplyResult) {

--- a/pkg/daemon/daemon_dhcprelay_reconcile_test.go
+++ b/pkg/daemon/daemon_dhcprelay_reconcile_test.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dhcprelay"
+)
+
+// relayCfg builds a *config.Config carrying a single dhcp-relay group bound to
+// one interface, matching the shape the daemon hands reconcileDHCPRelay.
+func relayCfg(iface string) *config.Config {
+	c := &config.Config{}
+	c.ForwardingOptions.DHCPRelay = &config.DHCPRelayConfig{
+		ServerGroups: map[string]*config.DHCPRelayServerGroup{
+			"sg": {Name: "sg", Servers: []string{"192.0.2.1"}},
+		},
+		Groups: map[string]*config.DHCPRelayGroup{
+			"g": {Name: "g", Interfaces: []string{iface}, ActiveServerGroup: "sg"},
+		},
+	}
+	return c
+}
+
+// TestReconcileDHCPRelayNilManagerNoop proves the apply-path call is a safe
+// no-op when the daemon was constructed without a relay Manager (#2348). A
+// regression that dereferenced d.dhcpRelay unconditionally would panic here.
+func TestReconcileDHCPRelayNilManagerNoop(t *testing.T) {
+	d := &Daemon{daemonCtx: context.Background()}
+	// Must not panic and must not create a Manager out of thin air.
+	d.reconcileDHCPRelay(relayCfg("ge-0-0-0"))
+	if d.dhcpRelay != nil {
+		t.Fatal("reconcileDHCPRelay must not create a Manager when none exists")
+	}
+}
+
+// TestReconcileDHCPRelayRemoveStopsAll is the headline #2348 wiring proof on the
+// daemon seam: a relay running after boot is STOPPED when a day-2 commit removes
+// the `forwarding-options dhcp-relay` block (a nil relay config). Before #2348
+// the apply pipeline had no relay step, so the boot-started relay survived a
+// delete forever. This path is socket-free (Apply(nil) only tears down), so it
+// runs without root. It fails-on-revert: if reconcileDHCPRelay is removed from
+// applyConfigLocked or stops forwarding the config, the relay would never stop.
+func TestReconcileDHCPRelayRemoveStopsAll(t *testing.T) {
+	d := &Daemon{
+		daemonCtx: context.Background(),
+		dhcpRelay: dhcprelay.NewManager(),
+	}
+	t.Cleanup(d.dhcpRelay.Stop)
+
+	// Seed a running relay directly through the Manager (the boot path), using
+	// a config whose interface never resolves an address so no client socket is
+	// opened on :67 (the resolver retries forever in the background) — Stats()
+	// still reports the relay as managed.
+	d.dhcpRelay.Apply(context.Background(), relayCfg("xpf-test-nonexistent0").ForwardingOptions.DHCPRelay)
+	if n := len(d.dhcpRelay.Stats()); n != 1 {
+		t.Fatalf("expected 1 managed relay after seed, got %d", n)
+	}
+
+	// Day-2 commit removes the relay block. reconcileDHCPRelay must forward the
+	// nil config to Apply, which stops every relay.
+	cfgNoRelay := &config.Config{}
+	d.reconcileDHCPRelay(cfgNoRelay)
+
+	if n := len(d.dhcpRelay.Stats()); n != 0 {
+		t.Fatalf("day-2 relay removal must stop all relays via the apply path, %d still managed", n)
+	}
+}
+
+// TestReconcileDHCPRelayAddStartsRelay proves a relay ADDED on a day-2 commit is
+// started through the apply seam (#2348). It uses a non-resolvable interface so
+// the relay is registered/managed (Stats()==1) without opening a real :67
+// socket — the resolver retry loop is ctx-cancelable and torn down by Stop().
+func TestReconcileDHCPRelayAddStartsRelay(t *testing.T) {
+	d := &Daemon{
+		daemonCtx: context.Background(),
+		dhcpRelay: dhcprelay.NewManager(),
+	}
+	t.Cleanup(d.dhcpRelay.Stop)
+
+	// Boot had no relay configured.
+	d.reconcileDHCPRelay(&config.Config{})
+	if n := len(d.dhcpRelay.Stats()); n != 0 {
+		t.Fatalf("expected no relays for empty config, got %d", n)
+	}
+
+	// Day-2 commit adds a relay group.
+	d.reconcileDHCPRelay(relayCfg("xpf-test-nonexistent1"))
+	if n := len(d.dhcpRelay.Stats()); n != 1 {
+		t.Fatalf("day-2 relay add must start the relay via the apply path, got %d", n)
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -960,8 +960,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 		slog.Info("event-options engine started", "policies", len(cfg.EventOptions))
 	}
 
-	// Start DHCP relay if configured.
-	if cfg := d.store.ActiveConfig(); cfg != nil && cfg.ForwardingOptions.DHCPRelay != nil {
+	// Start DHCP relay. The Manager is always created (not gated on a
+	// non-nil relay config) so the apply pipeline (reconcileDHCPRelay,
+	// #2348) can start a relay added on a day-2 commit and stop one
+	// removed — Apply diffs desired-vs-running and a nil config stops all
+	// relays. The relay goroutines bind to d.daemonCtx (== ctx here) so
+	// they outlive each apply call and are torn down only at daemon stop.
+	if cfg := d.store.ActiveConfig(); cfg != nil {
 		d.dhcpRelay = dhcprelay.NewManager()
 		d.dhcpRelay.Apply(ctx, cfg.ForwardingOptions.DHCPRelay)
 	}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -966,8 +966,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// removed — Apply diffs desired-vs-running and a nil config stops all
 	// relays. The relay goroutines bind to d.daemonCtx (== ctx here) so
 	// they outlive each apply call and are torn down only at daemon stop.
+	d.dhcpRelay = dhcprelay.NewManager()
 	if cfg := d.store.ActiveConfig(); cfg != nil {
-		d.dhcpRelay = dhcprelay.NewManager()
 		d.dhcpRelay.Apply(ctx, cfg.ForwardingOptions.DHCPRelay)
 	}
 

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -8,8 +8,10 @@ to the interface name.
 
 - `Manager` — `relay.go`.
 - `NewManager()` — `relay.go`.
-- `Apply(ctx context.Context, cfg *config.DHCPRelayConfig)` — `relay.go`. Starts/stops per-interface relay
-  goroutines.
+- `Apply(ctx context.Context, cfg *config.DHCPRelayConfig)` — `relay.go`.
+  Reconciles per-interface relay goroutines to the desired config (start
+  added, stop removed, restart changed, leave unchanged). Called at boot
+  AND on every day-2 commit (#2348). A nil `cfg` stops all relays.
 - `Stats()` — `relay.go`. Per-interface counters.
 - `RelayStats` — `relay.go`.
 
@@ -153,11 +155,33 @@ below). Changes touching this path must pass `make test-failover`.
   a true join with no packet-dependent wait and no goroutine leak across
   `Apply`/`Stop` cycles. Both loops cancel the shared context on exit so a
   one-sided error cannot wedge the join.
-- **Startup readiness retry.** `Apply` runs once at daemon boot. If an
-  interface is not yet ready (no IPv4 address, or a dynamic VLAN/tunnel not
-  yet created), the relay retries resolving the interface + giaddr on a
-  bounded, `ctx`-cancelable interval instead of dying permanently. The
-  interface is re-looked-up every attempt (no stale cached index).
+- **Day-2 reconcile (#2348).** `Apply` is invoked at boot (`daemon_run.go`)
+  AND on every commit through `daemon.reconcileDHCPRelay` in the
+  `applyConfigLocked` pipeline (`daemon_apply.go`, step 16c) — the relay
+  Manager is created at boot regardless of whether a relay was configured
+  then, so a relay added later starts and a relay removed later stops.
+  `Apply` diffs the desired set (`computeDesired`) against the running
+  `relays` map **per interface** and:
+  - starts an interface present in desired but not running;
+  - stops (bounded `cancel()`+`<-done`) an interface running but no longer
+    desired (or when the whole block is deleted: a nil `cfg` stops all);
+  - restarts an interface whose **spec changed** — a `relaySpec` is the
+    resolved server list (config order) plus the `always-broadcast` flag;
+    a change in either tears the old session down and binds a fresh one;
+  - leaves an unchanged interface's session running untouched (idempotent —
+    a no-op commit causes **no churn**, no socket reopen).
+  The stop/restart teardown reuses the same `Stop()` mechanism (the #2347
+  supervisor + #1915 close-on-cancel + `WaitGroup` join), and the old
+  listener is fully closed before any replacement binds, so a restart never
+  races `EADDRINUSE` and never hangs. The teardown joins run **outside**
+  `m.mu` so a blocked relay's `<-done` does not stall `Stats()` or a
+  concurrent `Apply`.
+- **Startup readiness retry.** When `Apply` starts a relay (boot or a day-2
+  add) and the interface is not yet ready (no IPv4 address, or a dynamic
+  VLAN/tunnel not yet created), the relay retries resolving the interface +
+  giaddr on a bounded, `ctx`-cancelable interval instead of dying
+  permanently. The interface is re-looked-up every attempt (no stale cached
+  index).
 - **ifindex-drift detection (#2347).** `SO_BINDTODEVICE` pins the client
   listener to the interface's kernel **ifindex** at `bind(2)`. If the
   interface is deleted+recreated or renamed at runtime under unchanged config

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -81,6 +81,34 @@ type l2Replier interface {
 	Close() error
 }
 
+// relaySpec is the immutable per-interface configuration that determines a
+// relay session's behavior. Apply (#2348) keys the desired set by interface
+// name and compares the running relay's spec against the desired spec to
+// decide start (added), stop (removed), or restart (changed). Two specs are
+// equal iff their server set (order-significant: the relay forwards to servers
+// in config order) and alwaysBroadcast flag match — a change in either is a
+// behavior change that requires a fresh session.
+type relaySpec struct {
+	servers         []string // server IPs in config order
+	alwaysBroadcast bool
+}
+
+// equal reports whether two specs would produce an identical relay session.
+func (s relaySpec) equal(o relaySpec) bool {
+	if s.alwaysBroadcast != o.alwaysBroadcast {
+		return false
+	}
+	if len(s.servers) != len(o.servers) {
+		return false
+	}
+	for i := range s.servers {
+		if s.servers[i] != o.servers[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // interfaceRelay represents a relay goroutine bound to one interface.
 type interfaceRelay struct {
 	ifaceName        string
@@ -88,6 +116,12 @@ type interfaceRelay struct {
 	done             chan struct{}
 	requestsRelayed  atomic.Uint64
 	repliesForwarded atomic.Uint64
+
+	// spec is the desired-config snapshot this relay was started with. Apply
+	// (#2348) compares it against the new desired spec to detect a changed
+	// group (servers / always-broadcast) that requires a restart. Set once at
+	// start; read-only thereafter (Apply holds m.mu while reading it).
+	spec relaySpec
 
 	// alwaysBroadcast forces every reply to broadcast (overrides
 	// always-broadcast). Set once at start; read-only thereafter.
@@ -243,18 +277,28 @@ func defaultIfindexResolver(ifaceName string) (int, error) {
 	return iface.Index, nil
 }
 
-// Apply starts relay goroutines according to the provided configuration.
-// It stops any previously running relays before starting new ones.
-func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
-	m.Stop()
+// desiredRelay is one entry in the desired relay set computed from config: the
+// interface to bind, the originating group (for logging), and the per-interface
+// spec (servers + always-broadcast). Server addresses are resolved at the
+// desired-set build so a relay started from this entry never re-parses config.
+type desiredRelay struct {
+	ifaceName string
+	groupName string
+	spec      relaySpec
+	servers   []*net.UDPAddr
+}
 
+// computeDesired builds the desired per-interface relay set from config. It
+// mirrors the validation the previous Apply did inline (skip unknown/empty
+// server groups, skip invalid server IPs, skip an interface that already has a
+// desired entry — first group wins, matching the pre-#2348 dedup) but produces
+// data instead of starting goroutines, so Apply can diff it against the running
+// set. The returned map is keyed by interface name.
+func computeDesired(cfg *config.DHCPRelayConfig) map[string]desiredRelay {
+	desired := make(map[string]desiredRelay)
 	if cfg == nil {
-		return
+		return desired
 	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	for _, group := range cfg.Groups {
 		sgName := group.ActiveServerGroup
 		sg, ok := cfg.ServerGroups[sgName]
@@ -269,7 +313,11 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 			continue
 		}
 
-		// Resolve server addresses once at apply time.
+		// Resolve server addresses once. Keep the validated string list in
+		// lockstep with serverAddrs so the spec's equality compares exactly the
+		// servers the relay will use (a server dropped for being invalid must
+		// not count as "changed" forever).
+		serverIPs := make([]string, 0, len(sg.Servers))
 		serverAddrs := make([]*net.UDPAddr, 0, len(sg.Servers))
 		for _, s := range sg.Servers {
 			ip := net.ParseIP(s)
@@ -278,6 +326,7 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 					"group", group.Name, "server", s)
 				continue
 			}
+			serverIPs = append(serverIPs, s)
 			serverAddrs = append(serverAddrs, &net.UDPAddr{IP: ip, Port: relayPort})
 		}
 		if len(serverAddrs) == 0 {
@@ -285,31 +334,125 @@ func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
 		}
 
 		for _, ifaceName := range group.Interfaces {
-			if _, exists := m.relays[ifaceName]; exists {
-				slog.Warn("dhcp-relay: interface already has relay, skipping",
+			if _, exists := desired[ifaceName]; exists {
+				slog.Warn("dhcp-relay: interface already mapped, skipping",
 					"interface", ifaceName, "group", group.Name)
 				continue
 			}
-
-			rctx, cancel := context.WithCancel(ctx)
-			ir := &interfaceRelay{
-				ifaceName:       ifaceName,
-				cancel:          cancel,
-				done:            make(chan struct{}),
-				alwaysBroadcast: group.AlwaysBroadcast,
+			desired[ifaceName] = desiredRelay{
+				ifaceName: ifaceName,
+				groupName: group.Name,
+				spec: relaySpec{
+					servers:         serverIPs,
+					alwaysBroadcast: group.AlwaysBroadcast,
+				},
+				servers: serverAddrs,
 			}
-			m.relays[ifaceName] = ir
-
-			go func(relay *interfaceRelay, servers []*net.UDPAddr) {
-				defer close(relay.done)
-				m.runRelay(rctx, cancel, relay, servers)
-			}(ir, serverAddrs)
-
-			slog.Info("dhcp-relay: started",
-				"interface", ifaceName,
-				"group", group.Name,
-				"servers", sg.Servers)
 		}
+	}
+	return desired
+}
+
+// Apply reconciles the running per-interface relays to match the provided
+// configuration (#2348). It is called at boot AND on every day-2 commit
+// (pkg/daemon/daemon_apply.go), so it must diff desired-vs-running rather than
+// tearing everything down:
+//
+//   - interface in desired but not running  -> start a new relay
+//   - interface running but not desired      -> stop it (bounded teardown)
+//   - interface in both, spec changed         -> stop then start (restart)
+//   - interface in both, spec unchanged       -> leave running (no churn)
+//
+// A nil cfg stops all relays (relay configuration removed). Stop-then-start of
+// a changed/removed interface reuses the same ir.cancel()+<-ir.done teardown as
+// Stop(): the per-interface supervisor (#2347 runRelay) and socket lifecycle
+// (#1915 close-on-cancel + WaitGroup join) fully close the old listener before
+// the replacement binds, so a restart never races EADDRINUSE and never hangs.
+func (m *Manager) Apply(ctx context.Context, cfg *config.DHCPRelayConfig) {
+	desired := computeDesired(cfg)
+
+	// Phase 1 (under lock): decide which running relays to stop and which
+	// desired relays to start, mutating m.relays to the post-reconcile set.
+	// We collect the relays to stop and start them OUTSIDE the lock so the
+	// bounded <-ir.done join does not hold m.mu (Stats()/concurrent Apply
+	// would otherwise block on a teardown).
+	m.mu.Lock()
+
+	var toStop []*interfaceRelay // removed or changed: tear down
+	// Remove relays that are no longer desired, or whose spec changed. A
+	// changed relay is removed here and re-added in the start loop below.
+	for name, ir := range m.relays {
+		d, want := desired[name]
+		if !want {
+			toStop = append(toStop, ir)
+			delete(m.relays, name)
+			slog.Info("dhcp-relay: stopping (interface removed from config)",
+				"interface", name)
+			continue
+		}
+		if !ir.spec.equal(d.spec) {
+			toStop = append(toStop, ir)
+			delete(m.relays, name)
+			slog.Info("dhcp-relay: restarting (config changed)",
+				"interface", name,
+				"old_servers", ir.spec.servers, "new_servers", d.spec.servers,
+				"old_always_broadcast", ir.spec.alwaysBroadcast,
+				"new_always_broadcast", d.spec.alwaysBroadcast)
+		}
+	}
+
+	// Start relays that are desired but not currently running (newly added,
+	// plus the ones just removed for a spec change). Record each ir in
+	// m.relays before releasing the lock so a concurrent Apply observes the
+	// new set; the goroutine is launched after the lock is dropped is fine —
+	// the supervisor only reads its own ir + the manager seams.
+	var toStart []struct {
+		ir      *interfaceRelay
+		rctx    context.Context
+		servers []*net.UDPAddr
+		group   string
+	}
+	for name, d := range desired {
+		if _, running := m.relays[name]; running {
+			continue
+		}
+		rctx, cancel := context.WithCancel(ctx)
+		ir := &interfaceRelay{
+			ifaceName:       d.ifaceName,
+			cancel:          cancel,
+			done:            make(chan struct{}),
+			spec:            d.spec,
+			alwaysBroadcast: d.spec.alwaysBroadcast,
+		}
+		m.relays[name] = ir
+		toStart = append(toStart, struct {
+			ir      *interfaceRelay
+			rctx    context.Context
+			servers []*net.UDPAddr
+			group   string
+		}{ir, rctx, d.servers, d.groupName})
+	}
+	m.mu.Unlock()
+
+	// Phase 2 (outside lock): tear down removed/changed relays. For a changed
+	// interface this completes BEFORE the replacement's listener binds below,
+	// so the old SO_BINDTODEVICE socket is fully closed (no EADDRINUSE).
+	for _, ir := range toStop {
+		ir.cancel()
+		<-ir.done
+	}
+
+	// Phase 3 (outside lock): launch the new/restarted relays.
+	for _, s := range toStart {
+		go func(relay *interfaceRelay, rctx context.Context, servers []*net.UDPAddr) {
+			defer close(relay.done)
+			m.runRelay(rctx, relay.cancel, relay, servers)
+		}(s.ir, s.rctx, s.servers)
+
+		slog.Info("dhcp-relay: started",
+			"interface", s.ir.ifaceName,
+			"group", s.group,
+			"servers", s.ir.spec.servers)
 	}
 }
 

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -299,7 +300,21 @@ func computeDesired(cfg *config.DHCPRelayConfig) map[string]desiredRelay {
 	if cfg == nil {
 		return desired
 	}
-	for _, group := range cfg.Groups {
+	// Iterate groups in a DETERMINISTIC (sorted-by-name) order. cfg.Groups is a
+	// map, and the "interface already mapped, skipping" dedup below is
+	// first-group-wins — so a random map-iteration order would make an
+	// interface that appears in multiple groups resolve to a nondeterministic
+	// group across Apply calls. That both picks a nondeterministic server set
+	// AND defeats the day-2 idempotency diff (a re-Apply of the SAME config
+	// could compute a different relaySpec and spuriously restart the relay).
+	// Sorting the group names makes first-wins stable and the diff idempotent.
+	groupNames := make([]string, 0, len(cfg.Groups))
+	for name := range cfg.Groups {
+		groupNames = append(groupNames, name)
+	}
+	sort.Strings(groupNames)
+	for _, gname := range groupNames {
+		group := cfg.Groups[gname]
 		sgName := group.ActiveServerGroup
 		sg, ok := cfg.ServerGroups[sgName]
 		if !ok {

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -430,6 +430,35 @@ func twoInterfaceConfig() *config.DHCPRelayConfig {
 	}
 }
 
+// relayConfig builds a single-group relay config from explicit interfaces,
+// server IPs, and the always-broadcast flag — the inputs the #2348 reconcile
+// keys on (interface set + spec). It lets the reconcile tests express
+// add/remove/change directly.
+func relayConfig(servers []string, alwaysBroadcast bool, ifaces ...string) *config.DHCPRelayConfig {
+	return &config.DHCPRelayConfig{
+		ServerGroups: map[string]*config.DHCPRelayServerGroup{
+			"sg": {Name: "sg", Servers: servers},
+		},
+		Groups: map[string]*config.DHCPRelayGroup{
+			"g": {
+				Name:              "g",
+				Interfaces:        ifaces,
+				ActiveServerGroup: "sg",
+				AlwaysBroadcast:   alwaysBroadcast,
+			},
+		},
+	}
+}
+
+// statsIfaces returns the set of interface names with a running relay.
+func statsIfaces(m *Manager) map[string]bool {
+	out := map[string]bool{}
+	for _, s := range m.Stats() {
+		out[s.Interface] = true
+	}
+	return out
+}
+
 // waitRelays blocks until the manager reports n relays or the deadline passes.
 func waitRelays(t *testing.T, m *Manager, n int, d time.Duration) {
 	t.Helper()
@@ -539,7 +568,13 @@ func TestStop_BoundedNoPackets(t *testing.T) {
 
 // TestApply_Reapply_DoesNotHang calls Apply twice; the second Stops gen-1 and
 // must return bounded with gen-1 conns closed.
-func TestApply_Reapply_DoesNotHang(t *testing.T) {
+// TestApply_Reapply_Idempotent proves that re-applying the SAME config does
+// NOT churn a healthy relay (#2348): Apply now diffs desired-vs-running per
+// interface, so an unchanged interface keeps its existing session — the gen-1
+// conns stay OPEN and the factory is not called a second time. (Pre-#2348 Apply
+// tore everything down and rebuilt on every call, dropping every relay even
+// when nothing changed.) The re-Apply must also return promptly (no hang).
+func TestApply_Reapply_Idempotent(t *testing.T) {
 	gen1Client := newFakeConn()
 	gen1Server := newFakeConn()
 	factory, getCalls := recordingFactory(gen1Client, gen1Server)
@@ -556,10 +591,185 @@ func TestApply_Reapply_DoesNotHang(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("second Apply() hung — Stop() inside Apply did not return")
+		t.Fatal("second Apply() hung")
+	}
+
+	// No churn: the unchanged relay keeps its gen-1 conns and the factory is
+	// not re-invoked. Give any (erroneous) restart a brief window to manifest.
+	time.Sleep(50 * time.Millisecond)
+	if gen1Client.isClosed() || gen1Server.isClosed() {
+		t.Error("idempotent re-apply must NOT close gen-1 conns (no churn)")
+	}
+	if got := len(getCalls()); got != 2 {
+		t.Errorf("idempotent re-apply must not reopen sockets: factory calls = %d, want 2", got)
+	}
+	if n := len(m.Stats()); n != 1 {
+		t.Errorf("relay count after idempotent re-apply = %d, want 1", n)
+	}
+}
+
+// TestApply_AddInterface_DayTwo proves a relay group added on a day-2 commit
+// starts its listener (#2348): a first Apply with one interface, then a second
+// Apply with two interfaces, must leave the original relay running AND start a
+// listener for the newly added interface. Fails (only one relay) if Apply does
+// not start the added interface.
+func TestApply_AddInterface_DayTwo(t *testing.T) {
+	factory, _ := recordingFactory()
+	m := testManager(factory)
+	defer m.Stop()
+
+	m.Apply(context.Background(), relayConfig([]string{"192.0.2.1"}, false, "ge-0-0-0"))
+	waitRelays(t, m, 1, 2*time.Second)
+
+	m.Apply(context.Background(), relayConfig([]string{"192.0.2.1"}, false, "ge-0-0-0", "ge-0-0-1"))
+	waitRelays(t, m, 2, 2*time.Second)
+
+	ifaces := statsIfaces(m)
+	if !ifaces["ge-0-0-0"] || !ifaces["ge-0-0-1"] {
+		t.Errorf("day-2 add must run both interfaces, got %v", ifaces)
+	}
+}
+
+// TestApply_RemoveInterface_StopsRelay proves a relay whose interface is no
+// longer in the config is stopped on the next Apply (#2348), and that the stop
+// is BOUNDED (reuses the ir.cancel()+<-ir.done teardown — Apply returns
+// promptly even though the removed relay's conns block in ReadFrom). The
+// remaining interface's relay stays up and its conns stay open (no collateral
+// churn).
+func TestApply_RemoveInterface_StopsRelay(t *testing.T) {
+	// Conns are handed out sequentially: iface order in the desired map is
+	// non-deterministic, so use blocking fakes for all four and assert via
+	// Stats() + total-closed accounting rather than a specific conn.
+	factory, _ := recordingFactory()
+	m := testManager(factory)
+	defer m.Stop()
+
+	m.Apply(context.Background(), relayConfig([]string{"192.0.2.1"}, false, "ge-0-0-0", "ge-0-0-1"))
+	waitRelays(t, m, 2, 2*time.Second)
+
+	done := make(chan struct{})
+	go func() {
+		m.Apply(context.Background(), relayConfig([]string{"192.0.2.1"}, false, "ge-0-0-0"))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Apply removing an interface hung — bounded Stop teardown not reused")
+	}
+
+	// Give the removed relay's teardown a beat, then assert exactly the kept
+	// interface remains.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(m.Stats()) == 1 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	ifaces := statsIfaces(m)
+	if len(ifaces) != 1 || !ifaces["ge-0-0-0"] {
+		t.Errorf("after removing ge-0-0-1, expected only ge-0-0-0, got %v", ifaces)
+	}
+}
+
+// TestApply_NilConfig_StopsAll proves that applying a nil relay config (the
+// `forwarding-options dhcp-relay` block deleted on a day-2 commit) stops every
+// running relay (#2348). Bounded (the blocking fake conns must not hang Apply).
+func TestApply_NilConfig_StopsAll(t *testing.T) {
+	factory, _ := recordingFactory()
+	m := testManager(factory)
+	defer m.Stop()
+
+	m.Apply(context.Background(), twoInterfaceConfig())
+	waitRelays(t, m, 2, 2*time.Second)
+
+	done := make(chan struct{})
+	go func() { m.Apply(context.Background(), nil); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Apply(nil) hung")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(m.Stats()) == 0 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if n := len(m.Stats()); n != 0 {
+		t.Errorf("Apply(nil) must stop all relays, %d still running", n)
+	}
+}
+
+// TestApply_ChangedServers_Restarts proves a group whose server set changed on
+// a day-2 commit is RESTARTED (#2348): the old session is torn down (its conns
+// closed) and a fresh listener is opened. The interface count is unchanged, but
+// the gen-1 conns must be closed (restart) — distinguishing a restart from the
+// idempotent no-churn path.
+func TestApply_ChangedServers_Restarts(t *testing.T) {
+	gen1Client := newFakeConn()
+	gen1Server := newFakeConn()
+	factory, getCalls := recordingFactory(gen1Client, gen1Server)
+	m := testManager(factory)
+	defer m.Stop()
+
+	m.Apply(context.Background(), relayConfig([]string{"192.0.2.1"}, false, "ge-0-0-0"))
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second)
+
+	// Change the server set: must restart the relay.
+	m.Apply(context.Background(), relayConfig([]string{"192.0.2.99"}, false, "ge-0-0-0"))
+
+	// The gen-1 conns must close (old session torn down).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if gen1Client.isClosed() && gen1Server.isClosed() {
+			break
+		}
+		time.Sleep(time.Millisecond)
 	}
 	if !gen1Client.isClosed() || !gen1Server.isClosed() {
-		t.Error("gen-1 conns must be closed after reapply")
+		t.Error("server-set change must tear down the old session (gen-1 conns closed)")
+	}
+	// A fresh listener (2 more factory calls) opens for the new spec, and the
+	// relay stays present.
+	waitCalls(t, getCalls, 4, 2*time.Second)
+	if n := len(m.Stats()); n != 1 {
+		t.Errorf("relay count after server change = %d, want 1", n)
+	}
+}
+
+// TestApply_ChangedBroadcast_Restarts proves a group whose always-broadcast
+// flag flipped is restarted (#2348) — the spec equality must include
+// alwaysBroadcast, not just the server set.
+func TestApply_ChangedBroadcast_Restarts(t *testing.T) {
+	gen1Client := newFakeConn()
+	gen1Server := newFakeConn()
+	factory, getCalls := recordingFactory(gen1Client, gen1Server)
+	m := testManager(factory)
+	defer m.Stop()
+
+	m.Apply(context.Background(), relayConfig([]string{"192.0.2.1"}, false, "ge-0-0-0"))
+	waitRelays(t, m, 1, 2*time.Second)
+	waitCalls(t, getCalls, 2, 2*time.Second)
+
+	m.Apply(context.Background(), relayConfig([]string{"192.0.2.1"}, true, "ge-0-0-0"))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if gen1Client.isClosed() && gen1Server.isClosed() {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !gen1Client.isClosed() || !gen1Server.isClosed() {
+		t.Error("always-broadcast flip must restart the relay (gen-1 conns closed)")
+	}
+	waitCalls(t, getCalls, 4, 2*time.Second)
+	if n := len(m.Stats()); n != 1 {
+		t.Errorf("relay count after broadcast flip = %d, want 1", n)
 	}
 }
 


### PR DESCRIPTION
Closes #2348

## Problem
`forwarding-options dhcp-relay` was applied **only at daemon boot**
(`pkg/daemon/daemon_run.go`). The commit-apply pipeline
(`applyConfigLocked` in `pkg/daemon/daemon_apply.go`) reconciles FRR,
networkd, VRRP, DHCP clients, the Kea DHCP server, DDNS, RA, flow
exporters, RPM, ip-monitoring, etc. — but had **no DHCP-relay step**. Any
day-2 commit that added, removed, or changed a relay group was silently
ignored until a daemon restart (HIGH: routine day-2 config not honored).

Two halves, per triage:

## 1. Wire the relay into the apply pipeline
- New `daemon.reconcileDHCPRelay(cfg)` called from `applyConfigLocked` as
  **step 16c** (right after `reconcileFlowExporters` — both are
  forwarding-options subsystems that were previously boot-only). It
  forwards `cfg.ForwardingOptions.DHCPRelay` to the relay Manager on
  `d.daemonCtx` (daemon lifetime, not a request-scoped context, so relay
  goroutines outlive the apply call). Guarded on a non-nil `d.dhcpRelay`.
- The boot site (`daemon_run.go`) now **always** creates the relay
  Manager (was gated on a non-nil relay config at boot) so a relay added
  on a later commit has a Manager to start it.

## 2. Make `Manager.Apply` a true reconcile (was stop-all/rebuild-all)
The previous `Apply` called `Stop()` then rebuilt every relay — so a
no-op commit briefly dropped **all** relays (churn). Reworked into a
desired-vs-running per-interface diff:
- **start** an interface present in desired but not running;
- **stop** (bounded `cancel()`+`<-done`) an interface running but no
  longer desired (a nil `cfg` stops all);
- **restart** an interface whose **spec changed** — `relaySpec` is the
  resolved server list (config order) + the always-broadcast flag;
- **leave** an unchanged interface's session running untouched
  (idempotent — no churn, no socket reopen).

## Composition with #2347 / #1915
The stop/restart teardown reuses the existing `Stop()` mechanism: the
#2347 per-interface supervisor (`runRelay` → `runRelaySession`) + the
#1915 close-on-cancel + `WaitGroup` join. For a changed interface the old
`SO_BINDTODEVICE` listener is fully closed **before** the replacement
binds, so a restart never races `EADDRINUSE` and never hangs. The bounded
teardown joins run **outside** `m.mu`, so a blocked relay's `<-done`
cannot stall `Stats()` or a concurrent `Apply`.

## Tests (fail-on-revert)
Manager-level (`pkg/dhcprelay`): rewrote `TestApply_Reapply_DoesNotHang`
→ `TestApply_Reapply_Idempotent` (unchanged config keeps gen-1 conns
open, factory not re-invoked). Added `TestApply_AddInterface_DayTwo`,
`TestApply_RemoveInterface_StopsRelay` (bounded stop, no collateral
churn), `TestApply_NilConfig_StopsAll`, `TestApply_ChangedServers_Restarts`,
`TestApply_ChangedBroadcast_Restarts`.

Daemon-seam (`pkg/daemon`, root-free — non-resolvable interface keeps the
relay managed via `Stats()` without opening a real `:67` socket):
`TestReconcileDHCPRelayRemoveStopsAll`, `TestReconcileDHCPRelayAddStartsRelay`,
`TestReconcileDHCPRelayNilManagerNoop`.

## Validation
`go build ./...` clean; `go test ./pkg/dhcprelay/... ./pkg/daemon/...`
green; `go test -race ./pkg/dhcprelay/` clean; new tests stable 5x. Live
day-2 relay reconcile verification is lab-bound (requires a relay segment
+ DHCP server) and is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi