### PR TITLE
#2344: gate session-flow parser on non-first IP fragments

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,39 @@
 # Action Log
 
+## 2026-06-22 — #2344 non-first-fragment SessionFlow gate
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Fixed the HIGH parsing/correctness gap where non-first IP
+  fragments were admitted to the SessionFlow parsers. A non-first fragment
+  carries no L4 header — its post-IP-header bytes are payload — but
+  `parse_ipv4_session_flow_from_frame`, the IPv6 branch of
+  `parse_session_flow_from_frame`, and the meta-offset fallback in
+  `parse_session_flow_from_bytes` all called `parse_flow_ports` with no
+  fragment-offset guard, reading payload bytes as TCP/UDP ports. That fake
+  tuple drove policy eval, the flow cache, and the session/reverse indexes.
+  #1852 had gated only the NAT rewrite leaves and explicitly deferred this
+  forwarding/session-path question. Fix: each session-flow parser now reuses
+  the existing `ipv4_is_non_first_fragment` / `ipv6_is_non_first_fragment`
+  predicates and returns `None` for a non-first fragment.
+  `parse_session_flow_from_bytes` runs a single top-of-function chokepoint
+  (`frame_is_non_first_fragment`) so the meta fast path cannot admit a
+  fragment either (the XDP shim does NOT gate fragments, so `meta.flow_*_port`
+  can carry payload bytes). The chokepoint requires the byte at the resolved
+  L3 offset to be a real IP header of the metadata family before reading the
+  fragment-offset bits, so a non-IP frame whose tuple lives only in metadata
+  is not spuriously suppressed. Fragment model: xpf does NOT reassemble; a
+  flowless (`None`) packet follows the existing route-based, session-less
+  forward path (the pre-#1913 "no flow tuple" branch in `poll_descriptor`),
+  so fragments forward statelessly per route without policy-on-fake-ports.
+  GRE decap inherits this (flow `None` → `(0,0)` ports, no synthesis).
+  Composes with #2293-era screen fragment classification.
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+  userspace-dp/src/afxdp/frame/prop_tests/inspect.rs,
+  userspace-dp/src/afxdp/frame/README.md, _Log.md
+- **Validation**: cargo build --release clean; new fragment pins pass 5x;
+  full userspace-dp test suite green (one unrelated pre-existing worker_queue
+  concurrency flake, passes 3/3 in isolation).
+
 ## 2026-06-22 — #2347 DHCP-relay ifindex-drift listener rebind
 
 - **Timestamp**: 2026-06-22 PDT

--- a/userspace-dp/src/afxdp/frame/README.md
+++ b/userspace-dp/src/afxdp/frame/README.md
@@ -85,6 +85,27 @@ inspect or rewrite a packet sitting in a UMEM frame.
   `packet_rel_l4_offset_and_protocol` so MSS clamping reaches
   ext-headered v6 SYNs (the shared helper is left unchanged — GRE decap
   and tunnel local-origin read it to forward fragmented inner packets).
+- **Non-first fragments build NO ported SessionFlow (#2344)**: #1852
+  gated only the NAT rewrite leaves; the generic session-flow parsers
+  (`parse_session_flow_from_bytes` / `parse_session_flow_from_frame` /
+  `parse_ipv4_session_flow_from_frame`) still called `parse_flow_ports`
+  on a non-first fragment, reading payload bytes as TCP/UDP ports and
+  feeding that fake tuple to policy eval, the flow cache, and the
+  session/reverse indexes. The parsers now reuse the same
+  `is_non_first_fragment` / `ipv4_is_non_first_fragment` /
+  `ipv6_is_non_first_fragment` predicates and return `None` for a
+  non-first fragment. `parse_session_flow_from_bytes` runs the check
+  ONCE at the top (`frame_is_non_first_fragment`) as the single
+  chokepoint, so the meta fast path cannot admit a fragment either — the
+  XDP shim does NOT gate fragments, so `meta.flow_*_port` may carry
+  payload bytes stamped at the post-IP offset. A flowless (`None`)
+  packet follows the existing route-based, session-less forward path
+  (the pre-#1913 "no flow tuple" behavior in `poll_descriptor`), so xpf
+  forwards fragments statelessly per route without policy-on-fake-ports.
+  GRE decap (`gre.rs`) inherits this automatically: with `flow == None`
+  it stamps `(0, 0)` ports instead of synthesizing them. Composes with
+  the #2293-era screen fragment classification (`extract_screen_info`),
+  which independently sees and screens non-first fragments.
 - **TCP inspection helpers are ext-header-aware (#2148)**: the read-only
   diagnostic/telemetry helpers `frame_has_tcp_rst`,
   `extract_tcp_flags_and_window`, and `extract_tcp_window` (`tcp.rs`) all

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -497,10 +497,64 @@ pub(in crate::afxdp) fn forward_tuple_mismatch_reason(
     ))
 }
 
+/// #2344: resolve the L3-relative slice the way the SessionFlow frame
+/// parsers do (prefer `meta.l3_offset` when it points at a frame byte
+/// whose IP-version nibble matches `addr_family`, else fall back to
+/// `frame_l3_offset`) and run the family-aware non-first-fragment
+/// predicate over it. Returns `true` only when the packet is positively
+/// identified as a non-first fragment; an unresolvable/too-short frame
+/// returns `false` (the downstream parser length guards reject it).
+fn frame_is_non_first_fragment(frame: &[u8], meta: UserspaceDpMeta) -> bool {
+    let expected_version = match meta.addr_family as i32 {
+        libc::AF_INET => 4u8,
+        libc::AF_INET6 => 6u8,
+        _ => return false,
+    };
+    let l3 = match meta.l3_offset {
+        14 | 18
+            if frame
+                .get(meta.l3_offset as usize)
+                .is_some_and(|byte| (byte >> 4) == expected_version) =>
+        {
+            meta.l3_offset as usize
+        }
+        _ => match frame_l3_offset(frame) {
+            Some(off) => off,
+            None => return false,
+        },
+    };
+    // Only flag a fragment when the byte at the resolved L3 offset is a
+    // real IP header whose version matches the metadata family. Without
+    // this the predicate would read the fragment-offset bytes out of a
+    // garbage/non-IP frame whose flow tuple is carried entirely in
+    // metadata (e.g. the meta-led ICMP fixtures), spuriously suppressing
+    // a legitimate flow. The downstream parsers already re-derive L3,
+    // so this only guards the early-exit decision.
+    if frame.get(l3).is_none_or(|byte| (byte >> 4) != expected_version) {
+        return false;
+    }
+    match frame.get(l3..) {
+        Some(slice) => is_non_first_fragment(slice, meta.addr_family),
+        None => false,
+    }
+}
+
 pub(in crate::afxdp) fn parse_session_flow_from_bytes(
     frame: &[u8],
     meta: UserspaceDpMeta,
 ) -> Option<SessionFlow> {
+    // #2344: a non-first IP fragment carries no L4 header. Refuse to build
+    // any ported SessionFlow for it — this is the single chokepoint that
+    // also defeats the meta fast path below (the XDP shim does NOT gate
+    // non-first fragments, so `meta.flow_*_port` may hold payload bytes
+    // read at the post-IP-header offset). Returning `None` makes the
+    // fragment flowless: it follows the route-based, session-less forward
+    // path instead of polluting policy / flow-cache / session indexes.
+    // Composes with #1852 (NAT leaves gated on the same predicate) and
+    // #2293-era screen fragment classification.
+    if frame_is_non_first_fragment(frame, meta) {
+        return None;
+    }
     let meta_flow = parse_session_flow_from_meta(meta);
     // Fast path: for TCP/UDP with complete metadata tuple, use meta directly
     // without parsing the frame. This avoids extra L3/L4 parsing for the
@@ -541,6 +595,11 @@ pub(in crate::afxdp) fn parse_session_flow_from_bytes(
             if frame.len() < l3 + 20 || frame.len() < l4 {
                 return None;
             }
+            // #2344: same non-first-fragment gate as the frame parsers —
+            // this meta-offset fallback must not fabricate ports either.
+            if ipv4_is_non_first_fragment(&frame[l3..]) {
+                return None;
+            }
             let src_ip = IpAddr::V4(Ipv4Addr::new(
                 frame[l3 + 12],
                 frame[l3 + 13],
@@ -569,6 +628,10 @@ pub(in crate::afxdp) fn parse_session_flow_from_bytes(
         }
         libc::AF_INET6 => {
             if frame.len() < l3 + 40 || frame.len() < l4 {
+                return None;
+            }
+            // #2344: same non-first-fragment gate as the frame parsers.
+            if ipv6_is_non_first_fragment(&frame[l3..]) {
                 return None;
             }
             let src_ip = IpAddr::V6(Ipv6Addr::from(
@@ -712,6 +775,15 @@ pub(in crate::afxdp) fn parse_session_flow_from_frame(
             if frame.len() < l3 + 40 || frame.len() < l4 {
                 return None;
             }
+            // #2344: a non-first IPv6 fragment (Fragment Header type 44
+            // with a non-zero offset) carries NO L4 header. Refuse to
+            // synthesize a ported SessionFlow for it; return `None` so the
+            // fragment is flowless and follows the route-based forward
+            // path. Same predicate #1852 uses for the NAT leaves, walked
+            // over the L3-relative slice.
+            if ipv6_is_non_first_fragment(&frame[l3..]) {
+                return None;
+            }
             let src_ip = IpAddr::V6(Ipv6Addr::from(
                 <[u8; 16]>::try_from(&frame[l3 + 8..l3 + 24]).ok()?,
             ));
@@ -791,6 +863,17 @@ pub(in crate::afxdp) fn parse_ipv4_session_flow_from_frame(
         return None;
     }
     let protocol = frame[l3 + 9];
+    // #2344: a non-first IPv4 fragment carries NO L4 header — its
+    // post-IP-header bytes are payload, not TCP/UDP ports. Refuse to
+    // synthesize a ported SessionFlow for it. Returning `None` makes the
+    // fragment flowless: it follows the route-based, session-less forward
+    // path (the existing pre-#1913 "no flow tuple" behavior) instead of
+    // polluting policy / flow-cache / session indexes with fake ports.
+    // Mirrors #1852, which gates the NAT rewrite leaves on the same
+    // `ipv4_is_non_first_fragment` predicate over the L3-relative slice.
+    if ipv4_is_non_first_fragment(&frame[l3..]) {
+        return None;
+    }
     let parsed_l4 = l3 + ihl;
     let l4 = if meta.l4_offset > meta.l3_offset && meta.l4_offset as usize == parsed_l4 {
         meta.l4_offset as usize

--- a/userspace-dp/src/afxdp/frame/prop_tests/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/inspect.rs
@@ -513,7 +513,9 @@ fn pin_ipv4_non_first_fragment_no_session_flow_frame_led() {
     assert_eq!(control, pkt.session_flow());
 
     // Set IPv4 fragment offset = 1 (8-byte units) in bytes l3+6..l3+8.
-    // High 13 bits are the offset; low 3 are flags. 0x0001 -> offset 1.
+    // IPv4 frag_off layout: HIGH 3 bits are flags (Reserved/DF/MF), LOW
+    // 13 bits are the fragment offset (`& 0x1FFF`, per
+    // ipv4_is_non_first_fragment). 0x0001 -> offset 1, no flags.
     let mut frag = pkt.frame.clone();
     let off = u16::from_be_bytes([frag[pkt.l3 + 6], frag[pkt.l3 + 7]]) | 0x0001;
     frag[pkt.l3 + 6..pkt.l3 + 8].copy_from_slice(&off.to_be_bytes());
@@ -566,7 +568,8 @@ fn pin_ipv4_non_first_fragment_no_session_flow_meta_fast_path() {
 fn pin_ipv4_first_fragment_offset_zero_still_parses() {
     let pkt = build_valid_frame(&ipv4_tcp_spec());
     let mut frag = pkt.frame.clone();
-    // Set MF (bit 0x2000) but keep offset 0 -> this is a FIRST fragment.
+    // Set MF (one of the HIGH 3 flag bits, 0x2000) but keep the LOW 13
+    // offset bits 0 -> this is a FIRST fragment.
     let off = u16::from_be_bytes([frag[pkt.l3 + 6], frag[pkt.l3 + 7]]) | 0x2000;
     frag[pkt.l3 + 6..pkt.l3 + 8].copy_from_slice(&off.to_be_bytes());
     assert!(

--- a/userspace-dp/src/afxdp/frame/prop_tests/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/inspect.rs
@@ -446,3 +446,199 @@ fn pin_af_constants() {
     assert_eq!(AF4 as i32, libc::AF_INET);
     assert_eq!(AF6 as i32, libc::AF_INET6);
 }
+
+// === #2344: non-first-fragment SessionFlow gate ===
+//
+// A non-first IP fragment carries NO L4 header — its post-IP-header
+// bytes are payload, not TCP/UDP ports. The SessionFlow parsers MUST
+// NOT fabricate a ported flow from such a packet; they return `None`
+// so the fragment is flowless and follows the route-based, session-less
+// forward path (composing with #1852's NAT-leaf gate and the #2293-era
+// screen fragment classification). These pins fail if the gate is
+// reverted, because the parser would then synthesize a flow carrying
+// payload bytes as ports.
+
+use super::strategies::{ExtHdr, PacketSpec, build_valid_frame};
+
+/// A baseline TCP/IPv4 spec with a distinct port pair. The fragment
+/// tests mutate the built frame's fragment-offset field and assert the
+/// parsers refuse to produce a flow.
+fn ipv4_tcp_spec() -> PacketSpec {
+    PacketSpec {
+        v6: false,
+        src4: 0x0a00_0001,
+        dst4: 0x0a00_0002,
+        src6: [0; 16],
+        dst6: [0; 16],
+        protocol: PROTO_TCP,
+        src_port: 0x1234,
+        dst_port: 0x5678,
+        vlan_id: 0,
+        vlan_present: false,
+        pcp: 0,
+        ttl: 64,
+        ihl: 20,
+        ext: Vec::new(),
+        payload_len: 16,
+        payload_seed: 0xABCD,
+        udp_zero_csum: false,
+        tcp_flags: 0x10,
+        tcp_opt_len: 0,
+        seq: 1,
+    }
+}
+
+/// Zero the tuple/offset fields so `parse_session_flow_from_bytes` is
+/// forced down the frame-led path (the meta fast path requires a
+/// complete TCP/UDP tuple). This isolates the per-parser gate.
+fn frame_led_meta(meta: UserspaceDpMeta) -> UserspaceDpMeta {
+    let mut m = meta;
+    m.flow_src_addr = [0; 16];
+    m.flow_dst_addr = [0; 16];
+    m.flow_src_port = 0;
+    m.flow_dst_port = 0;
+    m.l3_offset = 0;
+    m.l4_offset = 0;
+    m
+}
+
+/// IPv4 non-first fragment (frag-offset != 0) must NOT parse into a
+/// ported SessionFlow on the frame-led path.
+#[test]
+fn pin_ipv4_non_first_fragment_no_session_flow_frame_led() {
+    let pkt = build_valid_frame(&ipv4_tcp_spec());
+    // Control: the unmodified frame parses to the expected ported flow.
+    let blank = frame_led_meta(pkt.meta);
+    let control = parse_session_flow_from_bytes(&pkt.frame, blank).expect("control flow");
+    assert_eq!(control, pkt.session_flow());
+
+    // Set IPv4 fragment offset = 1 (8-byte units) in bytes l3+6..l3+8.
+    // High 13 bits are the offset; low 3 are flags. 0x0001 -> offset 1.
+    let mut frag = pkt.frame.clone();
+    let off = u16::from_be_bytes([frag[pkt.l3 + 6], frag[pkt.l3 + 7]]) | 0x0001;
+    frag[pkt.l3 + 6..pkt.l3 + 8].copy_from_slice(&off.to_be_bytes());
+    assert!(
+        ipv4_is_non_first_fragment(&frag[pkt.l3..]),
+        "fragment offset must be non-zero for this pin"
+    );
+
+    assert_eq!(
+        parse_session_flow_from_bytes(&frag, frame_led_meta(pkt.meta)),
+        None,
+        "non-first IPv4 fragment must not fabricate a ported flow"
+    );
+    // Direct frame parser (GRE decap calls this) is gated too.
+    assert_eq!(
+        parse_ipv4_session_flow_from_frame(&frag, frame_led_meta(pkt.meta)),
+        None,
+        "parse_ipv4_session_flow_from_frame must gate the non-first fragment"
+    );
+    assert_eq!(
+        parse_session_flow_from_frame(&frag, frame_led_meta(pkt.meta)),
+        None,
+        "parse_session_flow_from_frame must gate the non-first fragment"
+    );
+}
+
+/// The meta fast path must NOT bypass the gate. The XDP shim does not
+/// gate non-first fragments, so meta can arrive with payload bytes in
+/// `flow_*_port`. The chokepoint in `parse_session_flow_from_bytes`
+/// must reject the fragment before consulting that meta tuple.
+#[test]
+fn pin_ipv4_non_first_fragment_no_session_flow_meta_fast_path() {
+    let pkt = build_valid_frame(&ipv4_tcp_spec());
+    // pkt.meta carries a complete TCP tuple -> meta fast path would fire.
+    let mut frag = pkt.frame.clone();
+    let off = u16::from_be_bytes([frag[pkt.l3 + 6], frag[pkt.l3 + 7]]) | 0x0001;
+    frag[pkt.l3 + 6..pkt.l3 + 8].copy_from_slice(&off.to_be_bytes());
+
+    assert_eq!(
+        parse_session_flow_from_bytes(&frag, pkt.meta),
+        None,
+        "meta fast path must not admit a non-first IPv4 fragment"
+    );
+}
+
+/// First / atomic fragment (offset 0, MF possibly set) still carries
+/// the real L4 header -> parses normally. Guards against an over-broad
+/// gate that drops legitimate first fragments.
+#[test]
+fn pin_ipv4_first_fragment_offset_zero_still_parses() {
+    let pkt = build_valid_frame(&ipv4_tcp_spec());
+    let mut frag = pkt.frame.clone();
+    // Set MF (bit 0x2000) but keep offset 0 -> this is a FIRST fragment.
+    let off = u16::from_be_bytes([frag[pkt.l3 + 6], frag[pkt.l3 + 7]]) | 0x2000;
+    frag[pkt.l3 + 6..pkt.l3 + 8].copy_from_slice(&off.to_be_bytes());
+    assert!(
+        !ipv4_is_non_first_fragment(&frag[pkt.l3..]),
+        "MF-set, offset-0 is a FIRST fragment"
+    );
+    let flow = parse_session_flow_from_bytes(&frag, frame_led_meta(pkt.meta))
+        .expect("first fragment still parses");
+    assert_eq!(flow, pkt.session_flow());
+}
+
+/// IPv6 non-first fragment (Fragment Header type 44, offset != 0) must
+/// NOT parse into a ported SessionFlow.
+#[test]
+fn pin_ipv6_non_first_fragment_no_session_flow() {
+    let mut spec = ipv4_tcp_spec();
+    spec.v6 = true;
+    spec.src6 = [0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+    spec.dst6 = [0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2];
+    spec.ext = vec![ExtHdr::Fragment];
+    let pkt = build_valid_frame(&spec);
+
+    // Control: with offset 0 the fragment header is a first fragment and
+    // the flow parses normally.
+    let blank = frame_led_meta(pkt.meta);
+    let control = parse_session_flow_from_bytes(&pkt.frame, blank).expect("v6 control flow");
+    assert_eq!(control, pkt.session_flow());
+
+    // Fragment header sits at l3+40; its offset field is bytes 2..4 of
+    // the header. Mask 0xFFF8 (upper 13 bits) is the offset; set offset
+    // = 1 (8-octet units) -> byte 3 = 0x08.
+    let mut frag = pkt.frame.clone();
+    let fh = pkt.l3 + 40;
+    let foff = u16::from_be_bytes([frag[fh + 2], frag[fh + 3]]) | 0x0008;
+    frag[fh + 2..fh + 4].copy_from_slice(&foff.to_be_bytes());
+    assert!(
+        ipv6_is_non_first_fragment(&frag[pkt.l3..]),
+        "v6 fragment offset must be non-zero for this pin"
+    );
+
+    assert_eq!(
+        parse_session_flow_from_bytes(&frag, frame_led_meta(pkt.meta)),
+        None,
+        "non-first IPv6 fragment must not fabricate a ported flow"
+    );
+    assert_eq!(
+        parse_session_flow_from_frame(&frag, frame_led_meta(pkt.meta)),
+        None,
+        "parse_session_flow_from_frame must gate the non-first IPv6 fragment"
+    );
+}
+
+/// IPv6 first fragment (Fragment Header present, offset 0) still parses
+/// — the L4 header is in this fragment.
+#[test]
+fn pin_ipv6_first_fragment_offset_zero_still_parses() {
+    let mut spec = ipv4_tcp_spec();
+    spec.v6 = true;
+    spec.src6 = [0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+    spec.dst6 = [0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2];
+    spec.ext = vec![ExtHdr::Fragment];
+    let pkt = build_valid_frame(&spec);
+    // Set MF (low bit 0x0001) but keep offset bits 0 -> FIRST fragment.
+    let mut frag = pkt.frame.clone();
+    let fh = pkt.l3 + 40;
+    let foff = u16::from_be_bytes([frag[fh + 2], frag[fh + 3]]) | 0x0001;
+    frag[fh + 2..fh + 4].copy_from_slice(&foff.to_be_bytes());
+    assert!(
+        !ipv6_is_non_first_fragment(&frag[pkt.l3..]),
+        "MF-set, offset-0 IPv6 fragment is a FIRST fragment"
+    );
+    let flow = parse_session_flow_from_bytes(&frag, frame_led_meta(pkt.meta))
+        .expect("v6 first fragment still parses");
+    assert_eq!(flow, pkt.session_flow());
+}


### PR DESCRIPTION
Closes #2344

## Problem
A non-first IP fragment carries **no L4 header** — its post-IP-header bytes are payload, not TCP/UDP ports. The generic SessionFlow parsers in `userspace-dp/src/afxdp/frame/inspect.rs` called `parse_flow_ports` with **no fragment-offset guard**:

- `parse_ipv4_session_flow_from_frame`
- the IPv6 branch of `parse_session_flow_from_frame`
- the meta-offset fallback in `parse_session_flow_from_bytes`

So payload bytes were read as ports and a **fake TCP/UDP tuple** was promoted to a full `SessionFlow`. That tuple then drove **policy evaluation** (`poll_descriptor` reads `flow.forward_key.src_port/dst_port`), the **flow cache**, and the **session/reverse indexes**.

`is_non_first_fragment` already existed (from #1852) but gated **only the NAT path**, not the session-flow/policy/flow-cache parse. #1852 explicitly deferred the forwarding/session-path question; this PR closes that gap.

## Fix — the non-first-fragment session/policy gate
Each session-flow parser now reuses the existing `ipv4_is_non_first_fragment` / `ipv6_is_non_first_fragment` predicates over the L3-relative slice and returns `None` for a non-first fragment.

`parse_session_flow_from_bytes` runs a single chokepoint (`frame_is_non_first_fragment`) at the top so the **meta fast path cannot admit a fragment either** — the XDP shim does NOT gate non-first fragments (`parse_ipv4`/`parse_ipv6` in `userspace-xdp` read `flow_*_port` at `l3+ihl` with no offset check), so `meta.flow_*_port` can carry payload bytes. The chokepoint requires the byte at the resolved L3 offset to be a real IP header of the metadata family before reading the fragment-offset bits, so a non-IP frame whose tuple lives only in metadata (the meta-led ICMP fixtures) is not spuriously suppressed.

## Fragment-model reasoning
**xpf does NOT reassemble** — it forwards fragments statelessly per route. A flowless (`None`) packet follows the **existing route-based, session-less forward path** (the pre-#1913 "no flow tuple" branch in `poll_descriptor`'s `MissingNeighbor` arm). So the chosen behavior is **forward-per-3-tuple-route, no fabricated ports** — not drop, not match-existing-session (xpf has no first-fragment session tracking to match against). This is the same outcome #1852 chose for NAT (skip L4 ops, keep the IP-level forward).

### How it composes
- **#1852 (NAT):** gates the NAT rewrite leaves on the same `is_non_first_fragment` predicate; the descriptor fast path already returns `None` for non-first fragments. This PR makes the session/policy parser consistent — same predicate, same L3-relative slice.
- **#2293-era (screen):** `extract_screen_info` independently sees and screens non-first fragments (ping-of-death, teardrop, syn-frag). Unchanged — screen still runs.
- **GRE decap (`gre.rs`):** inherits the fix automatically — with `flow == None` it stamps `(0, 0)` ports instead of synthesizing them.

## Gate site
`userspace-dp/src/afxdp/frame/inspect.rs` — chokepoint at `parse_session_flow_from_bytes` (top of fn) + per-parser gates in `parse_ipv4_session_flow_from_frame`, the IPv6 branch of `parse_session_flow_from_frame`, and the meta-offset fallback arms.

## Tests (fail-on-revert, `prop_tests/inspect.rs`)
- `pin_ipv4_non_first_fragment_no_session_flow_frame_led` — frag-offset IPv4 TCP fragment → `None` from all three parse entry points (control: unmodified frame parses to the expected ported flow).
- `pin_ipv4_non_first_fragment_no_session_flow_meta_fast_path` — complete meta tuple (fast-path eligible) still → `None`.
- `pin_ipv4_first_fragment_offset_zero_still_parses` — MF-set/offset-0 first fragment still parses (guards against an over-broad gate).
- `pin_ipv6_non_first_fragment_no_session_flow` / `pin_ipv6_first_fragment_offset_zero_still_parses` — IPv6 Fragment Header: offset != 0 → `None`; offset 0 parses.

## Validation
`cargo build --release` clean; new pins pass 5x; full `userspace-dp` suite green (one unrelated pre-existing `worker_queue::concurrent_recovery` concurrency flake, passes 3/3 in isolation, no frame/flow involvement). No wire field. Doc: `frame/README.md` notable-invariants bullet + `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi