### PR TITLE
#2345: evaluate inbound DNAT/NPTv6 security policy on the translated destination tuple

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,41 @@
 # Action Log
 
+## 2026-06-22 — #2345 review folds (comment accuracy + MissingNeighbor tests)
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Folded three review items on PR #2353. (1) Corrected the
+  MissingNeighbor policy-tuple comment in poll_descriptor/mod.rs: it
+  claimed "DNAT/static-DNAT/NPTv6/NAT64 all set rewrite_dst" — false for
+  NAT64, which populates NEITHER nptv6_nat NOR pre_routing_dnat at that
+  site, so decision.nat.rewrite_dst is None and policy_dst_ip correctly
+  falls back to flow.dst_ip (synthetic IPv6), the intended NAT64
+  exclusion. (2) Corrected the tests.rs #2345 block header that listed
+  NAT64 among the translated-dst-matching types; it now states the NAT64
+  synthetic-IPv6 exclusion. (3) Added 5 MissingNeighbor (neighbor-ABSENT)
+  cold-path tests — the prior tests all installed the next-hop neighbor
+  and exercised only the ForwardCandidate site, leaving the separate
+  MissingNeighbor policy gate uncovered. NO behavior change (the
+  coordinator-confirmed Copilot "NAT64 default-deny at MissingNeighbor"
+  HIGH is a FALSE POSITIVE; verified the fallback is correct).
+- **Validation**: cargo build --release clean. New + existing #2345 tests
+  green (12 policy_inbound_* + reverse-key); 5x stable. Fail-on-revert
+  verified: reverting the MissingNeighbor decision.nat.rewrite_dst
+  fallback to unconditional flow.dst_ip/flow.forward_key.dst_port fails
+  all 4 DNAT/NPTv6 MissingNeighbor tests (the NAT64 MissingNeighbor test
+  correctly stays green under that mutation — it already expects the
+  synthetic-V6 fallback; its guard is the opposite mutation, feeding
+  extracted V4, which would default-deny). Full bin suite: 2433 passed, 1
+  pre-existing unrelated concurrency flake (worker_queue
+  concurrent_recovery_processes_each_command_exactly_once — passes 5/5 in
+  isolation). New tests:
+  policy_inbound_dnat_missing_neighbor_permits_on_translated_dst,
+  policy_inbound_dnat_missing_neighbor_denies_when_only_original_dst_permitted,
+  policy_inbound_nptv6_missing_neighbor_permits_on_translated_dst,
+  policy_inbound_nptv6_missing_neighbor_denies_when_only_external_prefix_permitted,
+  policy_inbound_nat64_missing_neighbor_permits_on_synthetic_v6_not_default_deny.
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/tests.rs, _Log.md
+
 ## 2026-06-22 — #2345 inbound destination-translation policy tuple
 
 - **Timestamp**: 2026-06-22 PDT

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,45 @@
 # Action Log
 
+## 2026-06-22 — #2345 inbound destination-translation policy tuple
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Fixed the HIGH/MED security-policy-correctness gap where the
+  inbound security-policy lookup was evaluated against the ORIGINAL
+  (pre-translation) destination tuple for DNAT / static-DNAT / inbound
+  NPTv6, instead of the POST-translation (real/internal) destination —
+  contradicting Junos/SRX semantics (inbound destination translation
+  precedes the policy lookup) and the documented twice-NAT contract.
+  Diagnosis confirmed against current code: the destination ZONE was
+  already correct (derived from `resolution.egress_ifindex`, which is
+  computed from `effective_resolution_target`), so only the address/port
+  half of the policy-match tuple was wrong. Fix: compute `policy_dst_ip`
+  (= `effective_resolution_target`) and `policy_dst_port` (= the DNAT
+  `rewrite_dst_port`, else the original port) once on the session-miss
+  path and feed them to `evaluate_policy_result_with_len` at BOTH the
+  `ForwardCandidate` and `MissingNeighbor` policy-eval sites (the
+  MissingNeighbor site reconstructs the same tuple from the merged
+  `decision.nat`, since the miss-block locals are out of scope there).
+  NAT64 is DELIBERATELY EXCLUDED (design fork resolved in-scope): it is a
+  cross-family translation (V6 src, V4 dst) and the policy matcher
+  requires same-family src+dst, so the extracted IPv4 dst would match no
+  rule and break ALL NAT64 connectivity — NAT64 keeps matching on the
+  synthetic IPv6 dst. Session reversal is preserved (the change touches
+  only the policy lookup, not session keys).
+- **Validation**: `cargo build --release` clean; targeted suites green
+  (nat 379, dnat 40, npt 24, nat64 81, policy 97, poll_descriptor 19, 0
+  failures); 8 new tests 5x stable. New tests (afxdp/tests.rs):
+  policy_inbound_dnat_matches_translated_destination_permit,
+  policy_inbound_dnat_denies_when_only_original_dst_permitted,
+  policy_inbound_dnat_matches_translated_destination_port,
+  policy_inbound_nptv6_matches_translated_destination_permit,
+  policy_inbound_nptv6_denies_when_only_external_prefix_permitted,
+  policy_inbound_nat64_matches_synthetic_v6_destination_permit,
+  policy_inbound_nat64_denies_on_synthetic_v6_deny_rule,
+  inbound_dnat_reverse_session_key_uses_public_facing_tuple.
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/tests.rs, docs/next-features/twice-nat.md,
+  _Log.md
+
 ## 2026-06-22 — #2344 non-first-fragment SessionFlow gate
 
 - **Timestamp**: 2026-06-22 PDT

--- a/docs/next-features/twice-nat.md
+++ b/docs/next-features/twice-nat.md
@@ -38,6 +38,49 @@ Document and validate one supported order for combined NAT:
 
 This should be the documented behavior for all dataplanes that claim Twice NAT support.
 
+#### Implemented (#2345): inbound destination-translation policy tuple
+
+As of #2345 the userspace AF_XDP dataplane evaluates the inbound
+security policy against the POST-translation destination tuple for the
+SAME-FAMILY inbound destination translations that happen before the
+route/zone lookup:
+
+- **DNAT / static-DNAT** — policy matches on the translated internal
+  destination address, and on the translated destination **port** for
+  port-based DNAT (e.g. public `VIP:443` DNAT'd to internal `B:8443` is
+  matched as `B:8443`, not `VIP:443`).
+- **inbound NPTv6** — policy matches on the translated internal IPv6
+  prefix destination, not the external/public prefix.
+
+The destination **zone** was already correct before #2345: it is derived
+from the translated destination (the resolution's `egress_ifindex`), so
+only the address/port half of the tuple needed correcting. This matches
+Junos/SRX semantics, where inbound destination translation precedes the
+security-policy lookup and the policy is matched on the real internal
+destination in the destination zone. Implementation: `policy_dst_ip` /
+`policy_dst_port` in `userspace-dp/src/afxdp/poll_descriptor/mod.rs`,
+used in both the `ForwardCandidate` and `MissingNeighbor` policy-eval
+sites. Session reversal is unaffected — the policy-tuple change touches
+only the policy lookup, not the installed session keys, so the reverse
+session is still keyed off the public-facing wire tuple (DNAT reverse
+source = the internal host with the translated port; reverse dst = the
+original external client).
+
+**NAT64 is excluded from this post-translation matching, by design.**
+NAT64 is a cross-family translation: the translated destination is IPv4
+while the flow source remains IPv6. xpf's policy matcher
+(`policy.rs::evaluate_policy`) requires the source and destination of the
+match to be the SAME address family — a mixed `(V6 src, V4 dst)` tuple
+matches no rule and falls to default-deny. Feeding the extracted IPv4
+destination into the policy match would therefore break ALL NAT64
+connectivity rather than fix it. NAT64 keeps its historical behavior:
+the policy is matched on the synthetic IPv6 destination (the only
+same-family tuple available at the policy-eval site), so NAT64 security
+policy must be written against the synthetic IPv6 destination prefix.
+Making NAT64 policy match the real IPv4 server is a larger, separate
+design change (cross-family policy matching) and is intentionally NOT
+part of #2345.
+
 ### 2. Add end-to-end coverage
 Add explicit tests for:
 

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2636,14 +2636,28 @@ pub(super) fn poll_binding_process_descriptor(
                                 // (or permitted) verdict is identical whether or
                                 // not the next-hop neighbor is already resolved.
                                 // The session-miss block's `effective_resolution_target`
-                                // is out of scope here, but the merged
-                                // `decision.nat` carries the same inbound
-                                // destination translation (DNAT/static-DNAT/
-                                // NPTv6/NAT64 all set `rewrite_dst`; only
-                                // port-based DNAT sets `rewrite_dst_port`), so
-                                // reconstruct the post-translation dst tuple from
-                                // it. Falls back to the original dst when no
-                                // inbound destination translation applies.
+                                // is out of scope here, so reconstruct the
+                                // post-translation dst tuple from the merged
+                                // `decision.nat`:
+                                //   - DNAT / static-DNAT / inbound NPTv6 each
+                                //     populate `decision.nat.rewrite_dst` (set at
+                                //     the decision build as `nptv6_nat.or(
+                                //     pre_routing_dnat)`), so the translated
+                                //     internal dst is used; only port-based DNAT
+                                //     also sets `rewrite_dst_port`.
+                                //   - NAT64 populates NEITHER `nptv6_nat` NOR
+                                //     `pre_routing_dnat`, so `decision.nat
+                                //     .rewrite_dst` is None here and the tuple
+                                //     falls back to `flow.dst_ip` (the synthetic
+                                //     IPv6 dst). That is the INTENDED NAT64
+                                //     exclusion — cross-family policy matching is
+                                //     not supported (see the long comment at the
+                                //     ForwardCandidate policy-tuple binding), and
+                                //     this fallback keeps the MissingNeighbor
+                                //     verdict identical to the ForwardCandidate
+                                //     path for NAT64.
+                                // Both halves fall back to the original dst/port
+                                // when no inbound destination translation applies.
                                 let policy_dst_ip =
                                     decision.nat.rewrite_dst.unwrap_or(flow.dst_ip);
                                 let policy_dst_port = decision

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -752,6 +752,46 @@ pub(super) fn poll_binding_process_descriptor(
                                     None => resolution_target,
                                 }
                             };
+                        // #2345: Junos evaluates the inbound security policy
+                        // against the POST-translation destination tuple. For
+                        // the SAME-FAMILY destination translations that happen
+                        // BEFORE the route/zone lookup — DNAT, static-DNAT, and
+                        // inbound NPTv6 — the policy must match on the translated
+                        // (real/internal) destination address + port, in the
+                        // zone derived from that translated destination, NOT the
+                        // original public/virtual destination. The egress zone
+                        // (`to_zone_id`) is already derived from
+                        // `effective_resolution_target`, so the zone is correct;
+                        // these bindings carry the translated address + port into
+                        // the policy-match call so the address/port match also
+                        // runs on the post-translation tuple. Only port-based
+                        // DNAT carries a destination-port rewrite; static-DNAT
+                        // and NPTv6 preserve the L4 port, so the original port
+                        // flows through for those.
+                        //
+                        // NAT64 is DELIBERATELY EXCLUDED here. NAT64 is a
+                        // cross-family translation: the translated destination is
+                        // IPv4 while the flow source stays IPv6. xpf's policy
+                        // matcher (`policy.rs` `evaluate_policy`) requires the
+                        // source and destination to be the SAME family — a mixed
+                        // (V6 src, V4 dst) tuple matches no rule and falls to
+                        // default-deny. Feeding the extracted IPv4 destination
+                        // here would therefore break ALL NAT64 connectivity, not
+                        // fix it. NAT64 keeps its historical behavior (policy
+                        // matched on the synthetic IPv6 destination, the only
+                        // same-family tuple available at this site). Making NAT64
+                        // policy match the real IPv4 server is a larger,
+                        // separate design change (cross-family policy matching);
+                        // see `docs/next-features/twice-nat.md` and #2345.
+                        let policy_dst_ip = if nat64_match.is_some() {
+                            flow.dst_ip
+                        } else {
+                            effective_resolution_target
+                        };
+                        let policy_dst_port = pre_routing_dnat
+                            .as_ref()
+                            .and_then(|d| d.rewrite_dst_port)
+                            .unwrap_or(flow.forward_key.dst_port);
                         let input_filter_eval = evaluate_non_pbr_input_filter(
                             worker_ctx.forwarding,
                             Some(flow),
@@ -1315,15 +1355,20 @@ pub(super) fn poll_binding_process_descriptor(
                                 };
                                 (tag, t)
                             };
+                            // #2345: match on the POST-translation destination
+                            // tuple (translated dst addr + port) in the
+                            // translated-dst zone. `policy_dst_ip` /
+                            // `policy_dst_port` collapse to the original dst when
+                            // no inbound destination translation applies.
                             let policy_result = evaluate_policy_result_with_len(
                                 &worker_ctx.forwarding.policy,
                                 from_zone_id,
                                 to_zone_id,
                                 flow.src_ip,
-                                flow.dst_ip,
+                                policy_dst_ip,
                                 flow.forward_key.protocol,
                                 flow.forward_key.src_port,
-                                flow.forward_key.dst_port,
+                                policy_dst_port,
                                 desc.len as u64,
                             );
                             // #1620: cold-path latency histogram post-eval record.
@@ -2585,15 +2630,35 @@ pub(super) fn poll_binding_process_descriptor(
                                     };
                                     (tag, t)
                                 };
+                                // #2345: MissingNeighbor cold path must match
+                                // the SAME post-translation destination tuple as
+                                // the ForwardCandidate path above so a denied
+                                // (or permitted) verdict is identical whether or
+                                // not the next-hop neighbor is already resolved.
+                                // The session-miss block's `effective_resolution_target`
+                                // is out of scope here, but the merged
+                                // `decision.nat` carries the same inbound
+                                // destination translation (DNAT/static-DNAT/
+                                // NPTv6/NAT64 all set `rewrite_dst`; only
+                                // port-based DNAT sets `rewrite_dst_port`), so
+                                // reconstruct the post-translation dst tuple from
+                                // it. Falls back to the original dst when no
+                                // inbound destination translation applies.
+                                let policy_dst_ip =
+                                    decision.nat.rewrite_dst.unwrap_or(flow.dst_ip);
+                                let policy_dst_port = decision
+                                    .nat
+                                    .rewrite_dst_port
+                                    .unwrap_or(flow.forward_key.dst_port);
                                 let policy_result = evaluate_policy_result_with_len(
                                     &worker_ctx.forwarding.policy,
                                     from_zone_id,
                                     to_zone_id,
                                     flow.src_ip,
-                                    flow.dst_ip,
+                                    policy_dst_ip,
                                     flow.forward_key.protocol,
                                     flow.forward_key.src_port,
-                                    flow.forward_key.dst_port,
+                                    policy_dst_port,
                                     desc.len as u64,
                                 );
                                 if cp_sample_tag {

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7981,16 +7981,23 @@ fn publish_dnat_table_entry_failure_increments_counter() {
 // #2345: inbound destination-translation policy is evaluated on the
 // POST-translation destination tuple (Junos parity).
 //
-// For every inbound destination translation that happens BEFORE the
-// route/zone lookup — DNAT, static-DNAT, inbound NPTv6, and NAT64 — the
-// security policy must match on the TRANSLATED (real/internal)
-// destination address + port, in the zone derived from that translated
-// destination. These tests are fail-on-revert: each builds a config
-// where the ORIGINAL (public/virtual) destination and the TRANSLATED
-// (internal) destination would draw DIFFERENT policy verdicts, so the
-// observed forward/deny outcome can only be produced if the match ran on
-// the translated tuple. If the policy lookup reverts to the pre-
-// translation tuple/zone these tests flip and fail.
+// For the SAME-FAMILY inbound destination translations that happen BEFORE
+// the route/zone lookup — DNAT, static-DNAT, and inbound NPTv6 — the
+// security policy must match on the TRANSLATED (real/internal) destination
+// address + port, in the zone derived from that translated destination.
+// These tests are fail-on-revert: each builds a config where the ORIGINAL
+// (public/virtual) destination and the TRANSLATED (internal) destination
+// would draw DIFFERENT policy verdicts, so the observed forward/deny
+// outcome can only be produced if the match ran on the translated tuple.
+// If the policy lookup reverts to the pre-translation tuple/zone these
+// tests flip and fail.
+//
+// NAT64 is DELIBERATELY EXCLUDED from post-translation matching. It is a
+// cross-family translation (IPv6 source, IPv4 destination) and the policy
+// matcher requires same-family src+dst, so NAT64 policy is matched on the
+// SYNTHETIC IPv6 destination (the only same-family tuple available at the
+// policy-eval site), NOT the extracted IPv4 destination. The NAT64 tests
+// below pin that synthetic-IPv6 behavior.
 // =====================================================================
 
 /// v6 ingress meta for the txn harness (TCP, ingress on `ifindex`).
@@ -8472,4 +8479,252 @@ fn inbound_dnat_reverse_session_key_uses_public_facing_tuple() {
         "reverse dst = original external client"
     );
     assert_eq!(reverse.dst_port, 54321, "reverse dst port = original src port");
+}
+
+// =====================================================================
+// #2345 MissingNeighbor (neighbor-ABSENT) cold-path coverage.
+//
+// All the tests above install the next-hop neighbor, so they exercise
+// ONLY the ForwardCandidate policy-eval site. These tests drop the
+// next-hop neighbor so the resolution returns MissingNeighbor and the
+// SEPARATE policy gate at the MissingNeighbor site runs instead. That
+// site reconstructs the post-translation tuple from the merged
+// `decision.nat` (the miss-block `effective_resolution_target` is out of
+// scope there), so a revert there would not be caught by the
+// ForwardCandidate tests.
+//
+// MissingNeighbor verdict signals used below:
+//   - PERMIT: the cold path seeds a MissingNeighborSeed session (forward
+//     + reverse), so `sessions.len() >= 1` and `policy_deny == 0`. The
+//     trigger packet is NOT forwarded yet (it buffers / probes), so
+//     `dbg.tx == 0` on this path even on permit.
+//   - DENY: the deny gate recycles the frame, installs no session, and
+//     bumps `policy_deny` (>= 1). `sessions.len() == 0`.
+// `missing_neigh >= 1` confirms the MissingNeighbor arm was actually the
+// path taken (rather than the flow silently resolving to ForwardCandidate
+// because a neighbor leaked in).
+// =====================================================================
+
+/// Drop a neighbor entry (by IP) from a snapshot so its next hop stays
+/// unresolved → MissingNeighbor.
+fn drop_neighbor(snapshot: &mut ConfigSnapshot, ip: &str) {
+    snapshot.neighbors.retain(|n| n.ip != ip);
+}
+
+/// DNAT MissingNeighbor: a policy permitting ONLY the translated internal
+/// destination must PERMIT (seed a session) the inbound DNAT'd flow when
+/// the internal host's neighbor is unresolved. Proves the MissingNeighbor
+/// site matches on the post-DNAT internal dst. Fails if the MissingNeighbor
+/// eval reverts to flow.dst_ip (the public VIP, uncovered → deny).
+#[test]
+fn policy_inbound_dnat_missing_neighbor_permits_on_translated_dst() {
+    let mut snapshot =
+        inbound_dnat_snapshot(wan_to_lan_permit("10.0.61.102/32", "permit-internal"));
+    drop_neighbor(&mut snapshot, "10.0.61.102");
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 12, 0);
+    binding.interface = Arc::<str>::from("reth0.80");
+    let mut sessions = SessionTable::new();
+
+    let frame = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(198, 51, 100, 10),
+        Ipv4Addr::new(172, 16, 80, 8),
+        54331,
+        443,
+        TCP_FLAG_SYN,
+    );
+    let meta = txn_meta_v4(12, TCP_FLAG_SYN, (frame.len() - 14) as u16);
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert!(
+        dbg.missing_neigh >= 1,
+        "the unresolved internal host must drive the MissingNeighbor arm"
+    );
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "MissingNeighbor policy on the translated internal dst must NOT deny"
+    );
+    assert!(
+        sessions.len() >= 1,
+        "a permitted MissingNeighbor DNAT flow seeds a session"
+    );
+}
+
+/// DNAT MissingNeighbor fail-on-revert: a policy permitting ONLY the
+/// original public VIP must DENY the inbound DNAT'd flow at the
+/// MissingNeighbor site (the match runs on the post-DNAT internal dst,
+/// which the policy does not cover). Fails if the MissingNeighbor eval
+/// reverts to the pre-DNAT tuple (which would wrongly permit + seed).
+#[test]
+fn policy_inbound_dnat_missing_neighbor_denies_when_only_original_dst_permitted() {
+    let mut snapshot =
+        inbound_dnat_snapshot(wan_to_lan_permit("172.16.80.8/32", "permit-public-vip"));
+    drop_neighbor(&mut snapshot, "10.0.61.102");
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 12, 0);
+    binding.interface = Arc::<str>::from("reth0.80");
+    let mut sessions = SessionTable::new();
+
+    let frame = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(198, 51, 100, 10),
+        Ipv4Addr::new(172, 16, 80, 8),
+        54332,
+        443,
+        TCP_FLAG_SYN,
+    );
+    let meta = txn_meta_v4(12, TCP_FLAG_SYN, (frame.len() - 14) as u16);
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert!(
+        dbg.policy_deny >= 1,
+        "MissingNeighbor match on the post-DNAT internal dst (uncovered) must deny"
+    );
+    assert_eq!(
+        sessions.len(),
+        0,
+        "a denied MissingNeighbor flow seeds no session"
+    );
+    assert_eq!(dbg.tx, 0, "denied flow does not forward");
+}
+
+/// NPTv6 MissingNeighbor: a policy permitting ONLY the internal prefix
+/// must PERMIT (seed) the inbound external-prefix flow when the internal
+/// host's neighbor is unresolved — proving the MissingNeighbor site uses
+/// the post-NPTv6 internal dst.
+#[test]
+fn policy_inbound_nptv6_missing_neighbor_permits_on_translated_dst() {
+    let mut snapshot = inbound_nptv6_snapshot(wan_to_lan_permit(
+        "fd35:1940:27::/48",
+        "permit-internal-prefix",
+    ));
+    drop_neighbor(&mut snapshot, "fd35:1940:27:100::102");
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 12, 0);
+    binding.interface = Arc::<str>::from("reth0.80");
+    let mut sessions = SessionTable::new();
+
+    let src: Ipv6Addr = "2001:559:8585:80::200".parse().expect("ext client");
+    let dst: Ipv6Addr = "2602:fd41:70:100::102".parse().expect("ext dst");
+    let frame = build_txn_tcp_syn_frame_v6(src, dst, 54331, 443);
+    let meta = txn_meta_v6(12, frame.len());
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert!(
+        dbg.missing_neigh >= 1,
+        "the unresolved internal host must drive the MissingNeighbor arm"
+    );
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "MissingNeighbor policy on the translated internal prefix must NOT deny"
+    );
+    assert!(
+        sessions.len() >= 1,
+        "a permitted MissingNeighbor NPTv6 flow seeds a session"
+    );
+}
+
+/// NPTv6 MissingNeighbor fail-on-revert: a policy permitting ONLY the
+/// external prefix must DENY at the MissingNeighbor site.
+#[test]
+fn policy_inbound_nptv6_missing_neighbor_denies_when_only_external_prefix_permitted() {
+    let mut snapshot = inbound_nptv6_snapshot(wan_to_lan_permit(
+        "2602:fd41:70::/48",
+        "permit-external-prefix",
+    ));
+    drop_neighbor(&mut snapshot, "fd35:1940:27:100::102");
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 12, 0);
+    binding.interface = Arc::<str>::from("reth0.80");
+    let mut sessions = SessionTable::new();
+
+    let src: Ipv6Addr = "2001:559:8585:80::200".parse().expect("ext client");
+    let dst: Ipv6Addr = "2602:fd41:70:100::102".parse().expect("ext dst");
+    let frame = build_txn_tcp_syn_frame_v6(src, dst, 54332, 443);
+    let meta = txn_meta_v6(12, frame.len());
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert!(
+        dbg.policy_deny >= 1,
+        "MissingNeighbor match on the post-NPTv6 internal dst (uncovered) must deny"
+    );
+    assert_eq!(sessions.len(), 0);
+}
+
+/// NAT64 MissingNeighbor: directly pins that Copilot's feared "NAT64
+/// default-deny at MissingNeighbor" does NOT happen. With the IPv4 server's
+/// next-hop neighbor (172.16.80.1) unresolved, the NAT64 flow takes the
+/// MissingNeighbor arm; the policy on the SYNTHETIC IPv6 prefix permits it
+/// (NOT default-denied). This holds because at the MissingNeighbor site
+/// NAT64 populates neither nptv6_nat nor pre_routing_dnat, so
+/// `decision.nat.rewrite_dst` is None and `policy_dst_ip` falls back to
+/// `flow.dst_ip` (the synthetic IPv6 dst) — exactly the ForwardCandidate
+/// NAT64 exclusion. If the fallback were reverted to unconditionally feed
+/// the extracted IPv4 dst, the synthetic-V6 policy would no longer match
+/// (cross-family) and this flow would default-deny — failing this test.
+#[test]
+fn policy_inbound_nat64_missing_neighbor_permits_on_synthetic_v6_not_default_deny() {
+    let mut snapshot =
+        nat64_snapshot(lan_to_wan_permit("64:ff9b::/96", "permit-synthetic-v6"));
+    // Unresolve the IPv4 server's next hop so the NAT64 flow hits
+    // MissingNeighbor instead of ForwardCandidate.
+    drop_neighbor(&mut snapshot, "172.16.80.1");
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+
+    let src: Ipv6Addr = "2001:559:8585:ef00::102".parse().expect("v6 client");
+    let dst: Ipv6Addr = "64:ff9b::808:808".parse().expect("nat64 dst");
+    let frame = build_txn_tcp_syn_frame_v6(src, dst, 12345, 443);
+    let meta = txn_meta_v6(24, frame.len());
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert!(
+        dbg.missing_neigh >= 1,
+        "the unresolved IPv4 next hop must drive the NAT64 flow to MissingNeighbor"
+    );
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "NAT64 MissingNeighbor must match the synthetic IPv6 policy, NOT default-deny"
+    );
 }

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7976,3 +7976,500 @@ fn publish_dnat_table_entry_failure_increments_counter() {
     }
     assert_eq!(live.dnat_publish_errors.load(Ordering::Relaxed), 2);
 }
+
+// =====================================================================
+// #2345: inbound destination-translation policy is evaluated on the
+// POST-translation destination tuple (Junos parity).
+//
+// For every inbound destination translation that happens BEFORE the
+// route/zone lookup — DNAT, static-DNAT, inbound NPTv6, and NAT64 — the
+// security policy must match on the TRANSLATED (real/internal)
+// destination address + port, in the zone derived from that translated
+// destination. These tests are fail-on-revert: each builds a config
+// where the ORIGINAL (public/virtual) destination and the TRANSLATED
+// (internal) destination would draw DIFFERENT policy verdicts, so the
+// observed forward/deny outcome can only be produced if the match ran on
+// the translated tuple. If the policy lookup reverts to the pre-
+// translation tuple/zone these tests flip and fail.
+// =====================================================================
+
+/// v6 ingress meta for the txn harness (TCP, ingress on `ifindex`).
+fn txn_meta_v6(ingress_ifindex: u32, frame_len: usize) -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        ingress_ifindex,
+        l3_offset: 14,
+        l4_offset: 54,
+        payload_offset: 74,
+        pkt_len: (frame_len - 14) as u16,
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+        config_generation: 7,
+        fib_generation: 9,
+        ..UserspaceDpMeta::default()
+    }
+}
+
+/// Build a wan->lan inbound DNAT snapshot: public VIP 172.16.80.8:443 is
+/// port-DNAT'd to the internal LAN host 10.0.61.102:8443. The internal
+/// host is directly connected on reth1.0 (10.0.61.0/24) and given a
+/// neighbor so the translated destination resolves to a ForwardCandidate.
+/// The caller supplies the single from=wan/to=lan policy.
+fn inbound_dnat_snapshot(policy: PolicyRuleSnapshot) -> ConfigSnapshot {
+    let mut snapshot = nat_snapshot();
+    snapshot.destination_nat_rules = vec![DestinationNATRuleSnapshot {
+        counter_id: 0,
+        name: "web-dnat".to_string(),
+        from_zone: "wan".to_string(),
+        destination_address: "172.16.80.8".to_string(),
+        destination_port: 443,
+        protocol: "tcp".to_string(),
+        pool_address: "10.0.61.102".to_string(),
+        pool_port: 8443,
+    }];
+    snapshot.neighbors.push(NeighborSnapshot {
+        interface: "reth1.0".to_string(),
+        ifindex: 24,
+        family: "inet".to_string(),
+        ip: "10.0.61.102".to_string(),
+        mac: "02:aa:bb:cc:dd:01".to_string(),
+        state: "reachable".to_string(),
+        router: false,
+        link_local: false,
+    });
+    // Replace the default lan->wan permit with the caller's wan->lan rule
+    // so the only policy that can match the inbound flow is the one under
+    // test (default-policy stays deny).
+    snapshot.policies = vec![policy];
+    snapshot
+}
+
+fn wan_to_lan_permit(dst: &str, name: &str) -> PolicyRuleSnapshot {
+    PolicyRuleSnapshot {
+        name: name.to_string(),
+        from_zone: "wan".to_string(),
+        to_zone: "lan".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec![dst.to_string()],
+        applications: vec!["any".to_string()],
+        application_terms: Vec::new(),
+        action: "permit".to_string(),
+        ..Default::default()
+    }
+}
+
+/// DNAT: a policy that permits ONLY the translated internal destination
+/// (10.0.61.102) MUST permit + forward the inbound packet whose original
+/// destination is the public VIP (172.16.80.8). Proves the policy match
+/// ran on the post-DNAT address.
+#[test]
+fn policy_inbound_dnat_matches_translated_destination_permit() {
+    let snapshot = inbound_dnat_snapshot(wan_to_lan_permit("10.0.61.102/32", "permit-internal"));
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 12, 0);
+    binding.interface = Arc::<str>::from("reth0.80");
+    let mut sessions = SessionTable::new();
+
+    // Inbound: external client -> public VIP:443 on the wan interface.
+    let frame = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(198, 51, 100, 10),
+        Ipv4Addr::new(172, 16, 80, 8),
+        54321,
+        443,
+        TCP_FLAG_SYN,
+    );
+    let meta = txn_meta_v4(12, TCP_FLAG_SYN, (frame.len() - 14) as u16);
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "policy on the translated internal dst must NOT deny the DNAT'd flow"
+    );
+    assert_eq!(
+        dbg.tx, 1,
+        "DNAT'd flow permitted by a policy on the translated dst must forward"
+    );
+    // forward + reverse install: session reversal is preserved.
+    assert_eq!(
+        sessions.len(),
+        2,
+        "forward + reverse session install (return-path reversal preserved)"
+    );
+}
+
+/// DNAT fail-on-revert: a policy that permits ONLY the original public VIP
+/// (172.16.80.8) — and does NOT cover the internal host — MUST deny the
+/// inbound packet, because the match runs on the post-DNAT internal dst.
+/// If the lookup reverted to the pre-DNAT tuple this would wrongly permit.
+#[test]
+fn policy_inbound_dnat_denies_when_only_original_dst_permitted() {
+    let snapshot = inbound_dnat_snapshot(wan_to_lan_permit("172.16.80.8/32", "permit-public-vip"));
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 12, 0);
+    binding.interface = Arc::<str>::from("reth0.80");
+    let mut sessions = SessionTable::new();
+
+    let frame = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(198, 51, 100, 10),
+        Ipv4Addr::new(172, 16, 80, 8),
+        54322,
+        443,
+        TCP_FLAG_SYN,
+    );
+    let meta = txn_meta_v4(12, TCP_FLAG_SYN, (frame.len() - 14) as u16);
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert_eq!(
+        dbg.tx, 0,
+        "a policy covering only the public VIP must NOT forward the DNAT'd flow"
+    );
+    assert!(
+        dbg.policy_deny >= 1,
+        "match on the post-DNAT internal dst (uncovered) must deny"
+    );
+    assert_eq!(sessions.len(), 0, "denied flow installs no session");
+}
+
+/// DNAT port: a policy that permits the translated dst at the translated
+/// PORT (8443) but with the wrong port (443) for the same address would
+/// not match. Permitting tcp/8443 to 10.0.61.102 forwards; this pins the
+/// translated dst PORT (not just the address) into the policy match.
+#[test]
+fn policy_inbound_dnat_matches_translated_destination_port() {
+    let mut permit = wan_to_lan_permit("10.0.61.102/32", "permit-internal-8443");
+    // Restrict the application to tcp/8443 (the translated port). The
+    // original packet is tcp/443; only a match on the post-DNAT port 8443
+    // can permit it.
+    permit.applications = vec!["app-8443".to_string()];
+    permit.application_terms = vec![crate::protocol::PolicyApplicationSnapshot {
+        name: "app-8443".to_string(),
+        protocol: "tcp".to_string(),
+        source_port: String::new(),
+        destination_port: "8443".to_string(),
+    }];
+    let snapshot = inbound_dnat_snapshot(permit);
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 12, 0);
+    binding.interface = Arc::<str>::from("reth0.80");
+    let mut sessions = SessionTable::new();
+
+    let frame = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(198, 51, 100, 10),
+        Ipv4Addr::new(172, 16, 80, 8),
+        54323,
+        443,
+        TCP_FLAG_SYN,
+    );
+    let meta = txn_meta_v4(12, TCP_FLAG_SYN, (frame.len() - 14) as u16);
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "policy on tcp/8443 (translated port) must permit the DNAT'd flow"
+    );
+    assert_eq!(dbg.tx, 1, "match on the translated dst port must forward");
+}
+
+/// Build a wan-ingress inbound NPTv6 snapshot. The external prefix
+/// 2602:fd41:70::/48 is translated to the internal prefix
+/// fd35:1940:27::/48; a route + neighbor for the internal prefix make the
+/// translated destination a ForwardCandidate out reth1.0 (lan). The
+/// caller supplies the single wan->lan policy under test.
+fn inbound_nptv6_snapshot(policy: PolicyRuleSnapshot) -> ConfigSnapshot {
+    let mut snapshot = nat_snapshot();
+    snapshot.nptv6_rules = vec![crate::protocol::Nptv6RuleSnapshot {
+        name: "nptv6".to_string(),
+        from_zone: "wan".to_string(),
+        internal_prefix: "fd35:1940:27::/48".to_string(),
+        external_prefix: "2602:fd41:70::/48".to_string(),
+    }];
+    // Route the internal /48 toward the LAN host (reth1.0) so the
+    // translated destination resolves on the inside.
+    snapshot.routes.push(RouteSnapshot {
+        table: "inet6.0".to_string(),
+        family: "inet6".to_string(),
+        destination: "fd35:1940:27::/48".to_string(),
+        next_hops: vec!["fd35:1940:27:100::102@reth1.0".to_string()],
+        discard: false,
+        next_table: String::new(),
+    });
+    snapshot.neighbors.push(NeighborSnapshot {
+        interface: "reth1.0".to_string(),
+        ifindex: 24,
+        family: "inet6".to_string(),
+        ip: "fd35:1940:27:100::102".to_string(),
+        mac: "02:aa:bb:cc:dd:02".to_string(),
+        state: "reachable".to_string(),
+        router: false,
+        link_local: false,
+    });
+    snapshot.policies = vec![policy];
+    snapshot
+}
+
+/// NPTv6: a policy permitting ONLY the INTERNAL prefix must permit + forward
+/// an inbound packet addressed to the EXTERNAL prefix. Proves the match
+/// runs on the post-NPTv6 (internal) destination.
+#[test]
+fn policy_inbound_nptv6_matches_translated_destination_permit() {
+    let snapshot = inbound_nptv6_snapshot(wan_to_lan_permit(
+        "fd35:1940:27::/48",
+        "permit-internal-prefix",
+    ));
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 12, 0);
+    binding.interface = Arc::<str>::from("reth0.80");
+    let mut sessions = SessionTable::new();
+
+    let src: Ipv6Addr = "2001:559:8585:80::200".parse().expect("ext client");
+    // External-prefix destination; NPTv6 maps it to fd35:1940:27:100::102.
+    let dst: Ipv6Addr = "2602:fd41:70:100::102".parse().expect("ext dst");
+    let frame = build_txn_tcp_syn_frame_v6(src, dst, 54321, 443);
+    let meta = txn_meta_v6(12, frame.len());
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "policy on the internal prefix must NOT deny the NPTv6-translated flow"
+    );
+    assert_eq!(
+        dbg.tx, 1,
+        "NPTv6 flow permitted by a policy on the internal prefix must forward"
+    );
+    assert_eq!(sessions.len(), 2, "forward + reverse install");
+}
+
+/// NPTv6 fail-on-revert: a policy permitting ONLY the EXTERNAL prefix (and
+/// NOT the internal one) must DENY the inbound packet, because the match
+/// runs on the post-NPTv6 internal destination.
+#[test]
+fn policy_inbound_nptv6_denies_when_only_external_prefix_permitted() {
+    let snapshot = inbound_nptv6_snapshot(wan_to_lan_permit(
+        "2602:fd41:70::/48",
+        "permit-external-prefix",
+    ));
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 12, 0);
+    binding.interface = Arc::<str>::from("reth0.80");
+    let mut sessions = SessionTable::new();
+
+    let src: Ipv6Addr = "2001:559:8585:80::200".parse().expect("ext client");
+    let dst: Ipv6Addr = "2602:fd41:70:100::102".parse().expect("ext dst");
+    let frame = build_txn_tcp_syn_frame_v6(src, dst, 54322, 443);
+    let meta = txn_meta_v6(12, frame.len());
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert_eq!(
+        dbg.tx, 0,
+        "a policy covering only the external prefix must NOT forward the NPTv6 flow"
+    );
+    assert!(
+        dbg.policy_deny >= 1,
+        "match on the post-NPTv6 internal dst (uncovered) must deny"
+    );
+    assert_eq!(sessions.len(), 0);
+}
+
+/// Build a NAT64 snapshot: the synthetic IPv6 destination 64:ff9b::808:808
+/// extracts the IPv4 server 8.8.8.8 (routed out wan via the default route).
+/// Ingress is on reth1.0 (lan, ifindex 24); egress zone is wan. The caller
+/// supplies the lan->wan policy under test.
+fn nat64_snapshot(policy: PolicyRuleSnapshot) -> ConfigSnapshot {
+    let mut snapshot = nat_snapshot();
+    snapshot.nat64_rules = vec![crate::protocol::NAT64RuleSnapshot {
+        name: "nat64".to_string(),
+        prefix: "64:ff9b::/96".to_string(),
+        pool_addresses: vec!["172.16.80.50".to_string()],
+        no_v6_frag_header: false,
+    }];
+    snapshot.policies = vec![policy];
+    snapshot
+}
+
+fn lan_to_wan_permit(dst: &str, name: &str) -> PolicyRuleSnapshot {
+    PolicyRuleSnapshot {
+        name: name.to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec![dst.to_string()],
+        applications: vec!["any".to_string()],
+        application_terms: Vec::new(),
+        action: "permit".to_string(),
+        ..Default::default()
+    }
+}
+
+/// NAT64: a policy permitting ONLY the EXTRACTED IPv4 server (8.8.8.8/32)
+/// NAT64 (DELIBERATELY EXCLUDED from the #2345 post-translation tuple, see
+/// the long comment at the policy-tuple binding in poll_descriptor): NAT64
+/// is cross-family (V6 src, V4 dst) and xpf's policy matcher requires
+/// same-family src+dst, so feeding the extracted IPv4 destination would
+/// match no rule and break ALL NAT64 connectivity. NAT64 therefore keeps
+/// its historical behavior: policy matches on the SYNTHETIC IPv6 dst (the
+/// only same-family tuple available). This test pins that a policy on the
+/// synthetic IPv6 prefix permits + forwards the NAT64 flow.
+#[test]
+fn policy_inbound_nat64_matches_synthetic_v6_destination_permit() {
+    let snapshot = nat64_snapshot(lan_to_wan_permit("64:ff9b::/96", "permit-synthetic-v6"));
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+
+    let src: Ipv6Addr = "2001:559:8585:ef00::102".parse().expect("v6 client");
+    let dst: Ipv6Addr = "64:ff9b::808:808".parse().expect("nat64 dst");
+    let frame = build_txn_tcp_syn_frame_v6(src, dst, 12345, 443);
+    let meta = txn_meta_v6(24, frame.len());
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "policy on the synthetic IPv6 prefix must NOT deny the NAT64 flow"
+    );
+    assert_eq!(
+        dbg.tx, 1,
+        "NAT64 flow permitted by a policy on the synthetic IPv6 dst must forward"
+    );
+    assert_eq!(sessions.len(), 2, "NAT64 forward + reverse install");
+}
+
+/// NAT64 fail-on-revert: an explicit DENY on the synthetic IPv6 NAT64
+/// destination prefix must DROP the flow. This proves the NAT64 policy
+/// match runs on the synthetic IPv6 destination (the documented #2345
+/// NAT64 behavior): if NAT64 were folded onto the extracted IPv4 tuple,
+/// the V6 deny rule would no longer match (cross-family) and the flow would
+/// fall to the default policy, changing the verdict.
+#[test]
+fn policy_inbound_nat64_denies_on_synthetic_v6_deny_rule() {
+    let mut deny = lan_to_wan_permit("64:ff9b::/96", "deny-synthetic-v6");
+    deny.action = "deny".to_string();
+    let mut snapshot = nat64_snapshot(deny);
+    // A trailing permit-any so the ONLY thing that can drop this flow is the
+    // synthetic-V6 deny rule matching first — not the default policy.
+    snapshot
+        .policies
+        .push(lan_to_wan_permit("any", "permit-rest"));
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+
+    let src: Ipv6Addr = "2001:559:8585:ef00::102".parse().expect("v6 client");
+    let dst: Ipv6Addr = "64:ff9b::808:808".parse().expect("nat64 dst");
+    let frame = build_txn_tcp_syn_frame_v6(src, dst, 12346, 443);
+    let meta = txn_meta_v6(24, frame.len());
+    let (_batch, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert_eq!(
+        dbg.tx, 0,
+        "an explicit deny on the synthetic IPv6 dst must drop the NAT64 flow"
+    );
+    assert!(
+        dbg.policy_deny >= 1,
+        "the synthetic-V6 deny rule must match the NAT64 flow"
+    );
+    assert_eq!(sessions.len(), 0);
+}
+
+/// Session reversal is preserved by the #2345 policy-tuple change. The
+/// policy-match tuple change touches ONLY the policy lookup, NOT the
+/// installed session keys: a DNAT forward still keys the reverse session
+/// off the PUBLIC-facing wire tuple (the public VIP as the reply source),
+/// so return traffic from the internal host (rewritten back to the VIP on
+/// egress) reverses correctly. This pins that the reverse key is built
+/// from the public dst, independent of the policy-match address.
+#[test]
+fn inbound_dnat_reverse_session_key_uses_public_facing_tuple() {
+    // Forward: external client 198.51.100.10:54321 -> public VIP
+    // 172.16.80.8:443, DNAT'd to internal 10.0.61.102:8443.
+    let forward_key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8)),
+        src_port: 54321,
+        dst_port: 443,
+    };
+    let dnat = NatDecision {
+        rewrite_dst: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
+        rewrite_dst_port: Some(8443),
+        ..NatDecision::default()
+    };
+    let reverse = reverse_session_key(&forward_key, dnat);
+    // The reply from the internal host arrives as 10.0.61.102:8443 ->
+    // 198.51.100.10:54321; the reverse session key must match exactly that
+    // wire 5-tuple so the return packet reverses (dst rewritten back to the
+    // public VIP on egress). This is unchanged by the policy-tuple fix.
+    assert_eq!(
+        reverse.src_ip,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+        "reverse src = internal host (post-DNAT dst), reply wire source"
+    );
+    assert_eq!(reverse.src_port, 8443, "reverse src port = translated dst port");
+    assert_eq!(
+        reverse.dst_ip,
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10)),
+        "reverse dst = original external client"
+    );
+    assert_eq!(reverse.dst_port, 54321, "reverse dst port = original src port");
+}


### PR DESCRIPTION
Closes #2345

## Problem
For inbound destination translations that happen BEFORE the route/zone
lookup, Junos/SRX evaluates the security policy against the
POST-translation (real/internal) destination, in the destination zone
derived from the translated destination. The userspace AF_XDP dataplane
was evaluating the policy lookup against the ORIGINAL (pre-translation)
destination tuple for DNAT, static-DNAT, and inbound NPTv6. Effect: a
policy written for the real inside server never matched (connectivity
break), and a policy written for the public VIP/prefix could be matched
on traffic that should be governed by the internal address (security
concern).

## Per-translation-type verdict
- **DNAT** — was WRONG (matched on the original public VIP and port).
  Fixed: matches the translated internal address + the translated port
  for port-based DNAT.
- **static-DNAT** — was WRONG (matched on the original public address).
  Fixed: matches the translated internal address (port preserved).
- **inbound NPTv6** — was WRONG (matched on the external/public IPv6
  prefix). Fixed: matches the translated internal prefix.
- **destination ZONE** — was ALREADY CORRECT for all of the above: it is
  derived from `resolution.egress_ifindex`, which is computed from
  `effective_resolution_target` (the translated destination). Only the
  address/port half of the policy-match tuple needed correcting.
- **NAT64** — DELIBERATELY EXCLUDED (design fork, resolved in scope, see
  below). Keeps matching on the synthetic IPv6 destination.

## Junos-order reasoning
Junos order for inbound translation: dst-translation -> route/zone lookup
on translated dst -> policy match on the translated tuple in the
translated dst zone -> src-translation (SNAT) on egress. This change
makes the policy-match address/port follow that order; the zone already
did.

## Fix
`policy_dst_ip` (= `effective_resolution_target`) and `policy_dst_port`
(= the DNAT `rewrite_dst_port`, else the original port) are computed once
on the session-miss path and used at BOTH policy-eval sites in
`userspace-dp/src/afxdp/poll_descriptor/mod.rs`:
- ForwardCandidate: `evaluate_policy_result_with_len(...)` (was
  `flow.dst_ip` / `flow.forward_key.dst_port`).
- MissingNeighbor: reconstructs the same tuple from the merged
  `decision.nat` (the miss-block locals are out of scope there), so a
  denied unresolved-neighbor cold-path packet gets the same verdict as
  the resolved path.

### NAT64 design fork (resolved in scope)
NAT64 is cross-family: the translated destination is IPv4 while the flow
source stays IPv6. `policy.rs::evaluate_policy` requires the source and
destination of the match to be the same address family — a mixed
`(V6 src, V4 dst)` tuple matches no rule and falls to default-deny.
Feeding the extracted IPv4 destination into the policy match would break
ALL NAT64 connectivity rather than fix it, so NAT64 is left on its
historical behavior (policy matched on the synthetic IPv6 destination,
the only same-family tuple available at the policy-eval site). Making
NAT64 policy match the real IPv4 server is a larger, separate change
(cross-family policy matching) and is documented as out of scope in
`docs/next-features/twice-nat.md`.

## Session-reversal preservation
The change touches ONLY the policy lookup, not the installed session
keys. The reverse session is still keyed off the public-facing wire
tuple: for a port-DNAT forward, the reverse key's source is the internal
host with the translated port and the reverse destination is the
original external client, so return traffic reverses correctly. Pinned
by `inbound_dnat_reverse_session_key_uses_public_facing_tuple`.

## Tests (fail-on-revert)
8 new tests in `userspace-dp/src/afxdp/tests.rs`, all driven through the
full `poll_binding_process_descriptor` harness except the reverse-key
unit test:
- `policy_inbound_dnat_matches_translated_destination_permit`
- `policy_inbound_dnat_denies_when_only_original_dst_permitted`
- `policy_inbound_dnat_matches_translated_destination_port`
- `policy_inbound_nptv6_matches_translated_destination_permit`
- `policy_inbound_nptv6_denies_when_only_external_prefix_permitted`
- `policy_inbound_nat64_matches_synthetic_v6_destination_permit`
- `policy_inbound_nat64_denies_on_synthetic_v6_deny_rule`
- `inbound_dnat_reverse_session_key_uses_public_facing_tuple`

## Validation
`cargo build --release` clean. Targeted suites green: nat 379, dnat 40,
npt 24, nat64 81, policy 97, poll_descriptor 19, 0 failures. New tests
5x stable. No wire/contract or Go changes (Rust-internal + docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi