### PR TITLE
userspace-dp: gate non-first IP fragments out of payload-derived TX-CoS / fabric-queue / output-filter (#2357)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -10756,3 +10756,38 @@ top.
     still uses SHA-256).
   - **File(s)**: userspace-dp/src/nat/tests.rs, docs/userspace-dataplane-architecture.md,
     docs/feature-coverage.md, docs/pr/1373-retire-ebpf-dataplane/plan-1377-snat-pools.md, _Log.md
+
+- **Timestamp**: 2026-06-22T01:30Z
+  - **Action**: #2357 — gate forwarded non-first IP fragments out of the
+    payload-derived TX-CoS / fabric-queue / output-filter path (Option 1,
+    the issue's minimal fix). A non-first fragment has no L4 header; #2344
+    already makes it flowless, but the TX-side selection re-derived a ported
+    tuple from metadata independently. Exposed `frame_is_non_first_fragment`
+    as `pub(in crate::afxdp)`. In
+    `build_live_forward_request_from_frame`, computed
+    `non_first_fragment = flow.is_none() && frame_is_non_first_fragment(...)`
+    ONCE and: forced `expected_ports = None`, set `tx_selection_flow = None`
+    (→ default queue, no output-filter port eval), and passed
+    `non_first_fragment` to `fabric_queue_hash`. Added a `non_first_fragment`
+    param to `fabric_queue_hash` — when set it hashes a fragment-stable
+    3-tuple (proto + meta L3 src/dst, no ports). Updated the flow-cache-hit
+    call site (always `false` — a cache hit is a real session). Gated the
+    poll_descriptor pending-neigh buffer-admission so a buffered fragment
+    stores `flow_key = None`. Left `coordinator/inject.rs:220` unchanged
+    (emit-on-wire control-plane packets carry a validated tuple; not reached
+    by a payload-ported fragment). Caution honored: the gate is the
+    fragment predicate, NOT "every None flow" — legit flowless TCP/UDP keeps
+    its meta ports. Added 5 fail-on-revert tests (v4 + v6 not-dropped,
+    legit-flowless still-dropped, fabric-hash port-independence, pending-neigh
+    no-flow-key). Also added the #2358 NAT64 cross-family policy-matching
+    note to docs/feature-gaps.md (doc accuracy only; #2358 stays open) and a
+    TX-CoS fragment section to docs/cos-validation-notes.md. cargo build +
+    cos/frag/fabric/tx_selection/inject tests green; new tests 5x.
+  - **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+    userspace-dp/src/afxdp/frame/mod.rs,
+    userspace-dp/src/afxdp/forward_request.rs,
+    userspace-dp/src/afxdp/worker/mod.rs,
+    userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs,
+    userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+    userspace-dp/src/afxdp/tests.rs, docs/feature-gaps.md,
+    docs/cos-validation-notes.md, _Log.md

--- a/docs/cos-validation-notes.md
+++ b/docs/cos-validation-notes.md
@@ -909,3 +909,52 @@ landing silently.
 - #728 — VLAN-aware L3 offset + threshold tune (resolved the dormant-marker symptom)
 - #754 — rate-aware per-flow ECN threshold (this section)
 - #712 — CPU pinning + IRQ isolation (Option A measured no-op on this lab; see "CPU pinning layout for the loss lab")
+
+## TX-CoS / fabric-queue selection on non-first IP fragments (#2357)
+
+A non-first IP fragment (IPv4 fragment-offset != 0; IPv6 Fragment Header
+type 44 with offset != 0) carries **no L4 header** — the bytes at the
+post-IP-header offset are payload, not TCP/UDP ports. #2344 already makes
+such a fragment *flowless* on the policy/session path
+(`parse_session_flow_from_bytes` returns `None`), so it forwards
+route-based with no policy/NAT/session.
+
+The TX-side CoS queue / fabric-queue / output-filter selection re-derives
+a tuple from metadata independently of that gate. Before #2357 a forwarded
+non-first fragment therefore got its egress queue, DSCP rewrite, fabric
+target binding, and output-filter verdict computed from payload bytes
+interpreted as ports — different fragments of one datagram could land on
+different queues (reordering / reassembly stress), and a port-matching
+terminal output-filter term could spuriously `discard` a fragment.
+
+#2357 gates the meta fallback at the TX-CoS sites:
+
+- `forward_request.rs::build_live_forward_request_from_frame` — when the
+  gated `flow` is `None` AND `frame_is_non_first_fragment(frame, meta)`
+  (the #2344 family-aware predicate), the TX path passes `flow_key = None`
+  to `resolve_cos_tx_selection_at` (→ interface `default_queue`, no
+  output-filter / port evaluation) and `expected_ports = None`, and
+  `fabric_queue_hash` is called with `non_first_fragment = true` so it
+  hashes a fragment-stable **3-tuple** (protocol + L3 src/dst from
+  metadata, which the XDP shim copies from the IP header present on every
+  fragment) with **no ports** — every fragment of one datagram selects the
+  same fabric target binding.
+- `poll_descriptor/mod.rs` pending-neigh buffering — a buffered fragment
+  stores `flow_key = None` so the later `retry_pending_neigh` flush also
+  selects the default queue with no port-filter eval.
+
+The gate fires **only** for an actual non-first fragment. A legitimate
+flowless TCP/UDP packet (real L4 header, no session yet) still gets its
+meta/frame-derived ports and full CoS/filter selection — the gate is the
+`frame_is_non_first_fragment` predicate, not a blanket "every `None` flow
+→ default queue". `coordinator/inject.rs` (emit-on-wire control-plane
+packets) is unaffected: it stamps a validated real tuple and is never
+reached by a forwarded payload-ported fragment.
+
+Regression tests live in `userspace-dp/src/afxdp/tests.rs`
+(`non_first_fragment_v4_not_dropped_by_port_matching_output_filter`,
+`non_first_fragment_v6_not_dropped_by_port_matching_output_filter`,
+`flowless_non_fragmented_tcp_still_hits_port_matching_output_filter`,
+`fabric_queue_hash_non_first_fragment_is_port_independent_3tuple`,
+`pending_neigh_fragment_buffers_no_flow_key`) and fail if the gate is
+reverted.

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -168,6 +168,24 @@ User-based policy enforcement integrating with directory services. Not implement
 
 xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT (with pools, hit counters, source-address-name match, protocol-only match, port rewriting, multi-port matching), static 1:1, NAT64, and exemption rules. These are additional NAT features from the vSRX.
 
+> **NAT64 inbound policy matches the SYNTHETIC IPv6 destination, not the
+> real internal IPv4 host (#2358).** For inbound NAT64 flows the security
+> policy is evaluated against the synthetic IPv6 destination the v6 client
+> sent to (the NAT64-prefixed address), NOT the real internal IPv4 server
+> the traffic is translated to. This is because `policy.rs::evaluate_policy`
+> requires the source and destination to be the same address family — a
+> `(V6 src, V4 dst)` tuple matches no rule and would default-deny, which
+> would break all NAT64. Same-family DNAT/static-DNAT/NPTv6 *do* match the
+> translated destination tuple (#2345), but NAT64 is excluded by that
+> same-family constraint. **Operator impact:** write NAT64 inbound security
+> policy against the synthetic IPv6 destination *prefix*, not the real IPv4
+> host address/zone. This diverges from Junos/SRX, where inbound
+> destination translation precedes the policy lookup so the policy matches
+> the real internal destination. Cross-family policy matching (match the
+> v6 source zone against the extracted IPv4 host + its zone) is the
+> separate design change tracked in **#2358**; this is a documented
+> behavior, not a deny regression.
+
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
 | **Proxy ARP for NAT** | `security nat proxy-arp interface ... address ...` | Auto-reply ARP for NAT pool addresses on same subnet as ingress interface. Required when SNAT pool, DNAT, or static-NAT external addresses are on same L2 segment. | High | **Done** -- Proxy ARP neighbor entries (NTF_PROXY) for NAT addresses with GARP on addition, AND the per-interface `net.ipv4.conf.<if>.proxy_arp` sysctl is enabled so the kernel actually answers the ARP (#2160). The kernel has two ARP-proxy paths: the pneigh (NTF_PROXY) reply branch, which answers only when the target routes out a *different* interface and does not consult the sysctl; and the `arp_fwd_proxy` path, gated by the per-interface `proxy_arp` sysctl. Whether the sysctl is load-bearing is therefore route-topology dependent (a same-L2-subnet external address is answered by neither path until the sysctl is on -- the #2160 case); enabling it guarantees a reply. Note: with the default `medium_id=0`, `proxy_arp=1` makes the kernel answer ARP on that interface for ANY target routed out a different interface -- broader than Junos `proxy-arp` (which proxies only listed addresses); per-address (v4-only) narrowing is **deferred** in #2197 item 3 (PLAN-DEFER, lab characterization pending -- dropping the sysctl would re-break the same-L2 #2160 case). IPv6 addresses get a real proxy-NDP pneigh install (#2197 item 1, see Proxy NDP row). The reconcile is also re-asserted by an always-on 30s ticker so a non-commit kernel link cycle (HA RETH flap, `programRethMAC`) self-heals without an operator re-commit (#2197 item 2). Config: `set security nat proxy-arp interface <iface> address <addr>` with range support. |

--- a/userspace-dp/src/afxdp/forward_request.rs
+++ b/userspace-dp/src/afxdp/forward_request.rs
@@ -81,17 +81,33 @@ pub(super) fn build_live_forward_request_from_frame(
     } else {
         resolve_tx_binding_ifindex(forwarding, decision.resolution.egress_ifindex)
     };
+    // #2357: a forwarded non-first IP fragment carries no L4 header — its
+    // post-IP-header bytes are payload, not ports. #2344 already made it
+    // flowless on the policy/session path (`flow` is `None` here), but the
+    // TX-CoS / fabric-queue selection below re-derives a ported tuple from
+    // metadata/frame independently of that gate. Compute the non-first-
+    // fragment predicate ONCE and suppress port synthesis for it so all
+    // fragments of one datagram land on the interface default queue / a
+    // fragment-stable (port-less) fabric hash and never hit a port-matching
+    // output-filter term. The gate fires ONLY for an actual non-first
+    // fragment with no real flow — a legitimate flowless TCP/UDP packet
+    // (real L4 header, `flow` None) keeps its meta/frame-derived ports.
+    let non_first_fragment = flow.is_none() && frame_is_non_first_fragment(frame, meta);
     // Prefer session flow ports (set by conntrack, immune to DMA races),
     // then live frame ports (lazy — only parsed if session ports unavailable),
     // then metadata as last resort.
-    let expected_ports = hints
-        .expected_ports
-        .or_else(|| authoritative_forward_ports(frame, meta, flow));
+    let expected_ports = if non_first_fragment {
+        None
+    } else {
+        hints
+            .expected_ports
+            .or_else(|| authoritative_forward_ports(frame, meta, flow))
+    };
     let target_binding_index = hints.target_binding_index.or_else(|| {
         if decision.resolution.disposition == ForwardingDisposition::FabricRedirect {
             binding_lookup.fabric_target_index(
                 target_ifindex,
-                fabric_queue_hash(flow, expected_ports, meta),
+                fabric_queue_hash(flow, expected_ports, meta, non_first_fragment),
             )
         } else {
             binding_lookup.target_index(
@@ -114,6 +130,14 @@ pub(super) fn build_live_forward_request_from_frame(
     let fallback_flow;
     let tx_selection_flow = if flow.is_some() {
         flow
+    } else if non_first_fragment {
+        // #2357: do NOT synthesize a ported tuple from metadata for a
+        // non-first fragment. A `None` flow_key drives
+        // `resolve_cos_tx_selection_at` to the interface default queue with
+        // NO output-filter (port) evaluation (tx/cos_classify.rs early
+        // `None` arm) — so a fragment is never misclassified by, or
+        // spuriously dropped by, a port-matching terminal filter term.
+        None
     } else {
         fallback_flow = parse_session_flow_from_meta(meta);
         fallback_flow.as_ref()

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -504,7 +504,7 @@ pub(in crate::afxdp) fn forward_tuple_mismatch_reason(
 /// predicate over it. Returns `true` only when the packet is positively
 /// identified as a non-first fragment; an unresolvable/too-short frame
 /// returns `false` (the downstream parser length guards reject it).
-fn frame_is_non_first_fragment(frame: &[u8], meta: UserspaceDpMeta) -> bool {
+pub(in crate::afxdp) fn frame_is_non_first_fragment(frame: &[u8], meta: UserspaceDpMeta) -> bool {
     let expected_version = match meta.addr_family as i32 {
         libc::AF_INET => 4u8,
         libc::AF_INET6 => 6u8,

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -58,8 +58,9 @@ pub(in crate::afxdp) use inspect::{
     is_non_first_fragment, l2_dst_is_group_or_broadcast, parse_session_flow, try_parse_metadata,
 };
 pub(super) use inspect::{
-    MAX_IPV6_EXT_HEADERS, frame_l3_offset, frame_l4_offset, live_frame_ports, live_frame_ports_bytes,
-    live_frame_ports_from_meta_bytes, metadata_tuple_complete, packet_rel_l4_offset,
+    MAX_IPV6_EXT_HEADERS, frame_is_non_first_fragment, frame_l3_offset, frame_l4_offset,
+    live_frame_ports, live_frame_ports_bytes, live_frame_ports_from_meta_bytes,
+    metadata_tuple_complete, packet_rel_l4_offset,
     packet_rel_l4_offset_and_protocol, parse_flow_ports, parse_ipv4_session_flow_from_frame,
     parse_packet_destination_from_frame, parse_session_flow_from_bytes,
     parse_session_flow_from_frame, parse_session_flow_from_meta,

--- a/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
@@ -209,7 +209,10 @@ pub(super) fn stage_flow_cache_hit(
                 if cached_decision.resolution.disposition == ForwardingDisposition::FabricRedirect {
                     worker_ctx.binding_lookup.fabric_target_index(
                         target_ifindex,
-                        fabric_queue_hash(Some(flow), expected_ports, meta),
+                        // #2357: a flow-cache hit is a real established
+                        // session (never a flowless fragment), so the
+                        // non-first-fragment gate is `false` here.
+                        fabric_queue_hash(Some(flow), expected_ports, meta, false),
                     )
                 } else {
                     worker_ctx.binding_lookup.target_index(

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -3332,12 +3332,36 @@ pub(super) fn poll_binding_process_descriptor(
                                             .fetch_add(1, Ordering::Relaxed);
                                     }
                                     PendingNeighAdmission::Buffer => {
+                                        // #2357: when this buffered packet is
+                                        // later flushed by retry_pending_neigh,
+                                        // its stored flow_key drives
+                                        // resolve_cos_tx_selection_at (egress
+                                        // queue / DSCP / output-filter). A
+                                        // non-first IP fragment carries no L4
+                                        // header, so refuse to synthesize a
+                                        // ported tuple from metadata for it —
+                                        // store `None` so the flush selects the
+                                        // interface default queue with no
+                                        // port-filter eval. `flow` is already
+                                        // `None` for a fragment (#2344); the
+                                        // gate only suppresses the meta
+                                        // fallback, leaving legitimate flowless
+                                        // TCP/UDP packets (real L4 header) their
+                                        // meta-derived ports. `raw_frame` is the
+                                        // UMEM slice for `desc`; this branch is
+                                        // only reached when
+                                        // `owned_packet_frame.is_none()`, so it
+                                        // describes the packet `meta` refers to.
                                         let pending_flow_key = flow
                                             .as_ref()
                                             .map(|flow| flow.forward_key.clone())
                                             .or_else(|| {
-                                                parse_session_flow_from_meta(meta)
-                                                    .map(|flow| flow.forward_key)
+                                                if frame_is_non_first_fragment(raw_frame, meta) {
+                                                    None
+                                                } else {
+                                                    parse_session_flow_from_meta(meta)
+                                                        .map(|flow| flow.forward_key)
+                                                }
                                             });
                                         binding.pending_neigh.insert(
                                             pending_key,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -8728,3 +8728,414 @@ fn policy_inbound_nat64_missing_neighbor_permits_on_synthetic_v6_not_default_den
         "NAT64 MissingNeighbor must match the synthetic IPv6 policy, NOT default-deny"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #2357 — forwarded non-first IP fragments must not select a CoS/fabric queue
+// (or hit an output-filter term) from payload bytes interpreted as L4 ports.
+// The TX-CoS / fabric-hash paths re-derive a flow tuple from metadata when
+// the gated `flow` is `None` (the #2344 fragment case). These tests pin the
+// gate: a non-first fragment routes to the default-queue / port-less paths,
+// while a legitimate flowless TCP packet (real L4 header) keeps its ports.
+// ---------------------------------------------------------------------------
+
+/// Ethernet (14B) + IPv4 header with the given `frag_off` (raw flags+offset
+/// field) + `payload`. A non-first fragment carries payload where an L4
+/// header would be; we plant TCP-port-shaped bytes there to prove they are
+/// NOT parsed as ports.
+fn eth_ipv4_frag_frame(frag_off: u16, payload: &[u8]) -> Vec<u8> {
+    let mut f = vec![
+        // dst mac, src mac
+        0x02, 0xbf, 0x72, 0x00, 0x80, 0x08, 0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5,
+        // ethertype IPv4
+        0x08, 0x00,
+    ];
+    let mut ip = vec![0u8; 20];
+    ip[0] = 0x45;
+    let total = (20 + payload.len()) as u16;
+    ip[2..4].copy_from_slice(&total.to_be_bytes());
+    ip[4..6].copy_from_slice(&0x1234u16.to_be_bytes()); // id
+    ip[6..8].copy_from_slice(&frag_off.to_be_bytes());
+    ip[8] = 64; // ttl
+    ip[9] = PROTO_TCP;
+    ip[12..16].copy_from_slice(&[10, 0, 61, 100]); // src
+    ip[16..20].copy_from_slice(&[172, 16, 80, 200]); // dst
+    f.extend_from_slice(&ip);
+    f.extend_from_slice(payload);
+    f
+}
+
+/// The egress output-filter that DISCARDs TCP traffic to dst port 443.
+/// Re-used from `build_live_forward_request_from_frame_drops_logged_output_filter_discard`.
+fn wan_drop_443_forwarding() -> ForwardingState {
+    build_forwarding_state(&ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 12,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-drop".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-drop".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "discard".into(),
+                log: true,
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    })
+}
+
+fn frag_test_ingress_ident() -> BindingIdentity {
+    BindingIdentity {
+        slot: 7,
+        queue_id: 3,
+        worker_id: 0,
+        interface: Arc::<str>::from("ge-0-0-1"),
+        ifindex: 10,
+    }
+}
+
+fn frag_test_decision() -> SessionDecision {
+    SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 11,
+            tunnel_endpoint_id: 0,
+            next_hop: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
+            neighbor_mac: Some([0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]),
+            src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]),
+            tx_vlan_id: 80,
+        },
+        nat: NatDecision::default(),
+    }
+}
+
+/// Meta describing a flowless TCP packet whose stamped flow_* fields claim
+/// dst port 443 (what the shim would write from the bytes at the post-IP
+/// offset of a non-first fragment). flow_*_addr are non-zero so
+/// `parse_session_flow_from_meta` returns Some (the meta fallback the gate
+/// must suppress for a fragment).
+fn frag_test_meta(l3_offset: u16) -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        ingress_ifindex: 10,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        pkt_len: 60,
+        l3_offset,
+        flow_src_port: 33333,
+        flow_dst_port: 443,
+        flow_src_addr: [10, 0, 61, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        flow_dst_addr: [172, 16, 80, 200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ..UserspaceDpMeta::default()
+    }
+}
+
+#[test]
+fn non_first_fragment_v4_not_dropped_by_port_matching_output_filter() {
+    // payload at the post-IP offset spells src=33333 dst=443 — exactly what
+    // the buggy meta fallback would parse as the discarded web port.
+    let payload = [0x82, 0x35, 0x01, 0xbb, 0, 0, 0, 0];
+    let frame = eth_ipv4_frag_frame(0x0001, &payload); // non-first (offset != 0)
+    let forwarding = wan_drop_443_forwarding();
+    let ingress_ident = frag_test_ingress_ident();
+    let decision = frag_test_decision();
+    let meta = frag_test_meta(14);
+    let (event_handle, _event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+
+    let req = build_live_forward_request_from_frame(
+        &WorkerBindingLookup::default(),
+        2,
+        &ingress_ident,
+        XdpDesc {
+            addr: 0,
+            len: frame.len() as u32,
+            options: 0,
+        },
+        &frame,
+        meta,
+        &decision,
+        &forwarding,
+        None, // flowless — the #2344 fragment case
+        None,
+        false,
+        123,
+        Some(&event_handle),
+        None,
+        None,
+    );
+
+    let req = req.expect(
+        "a non-first fragment must NOT be dropped by a port-matching output filter \
+         (gate routes it to the None flow_key default-queue path)",
+    );
+    assert_eq!(
+        req.flow_key, None,
+        "fragment TX selection must use no flow_key (no payload-derived ports)"
+    );
+    assert_eq!(
+        req.expected_ports, None,
+        "fragment must not carry payload-derived expected ports"
+    );
+}
+
+#[test]
+fn flowless_non_fragmented_tcp_still_hits_port_matching_output_filter() {
+    // Same meta (dst port 443) but a FIRST/atomic fragment (offset 0) — a
+    // real L4 header, so the gate must NOT fire and the meta fallback's
+    // ports must drive the discard. Proves we did not over-gate every None
+    // flow to the default queue.
+    let payload = [0x82, 0x35, 0x01, 0xbb, 0, 0, 0, 0];
+    let frame = eth_ipv4_frag_frame(0x0000, &payload); // atomic (offset 0)
+    let forwarding = wan_drop_443_forwarding();
+    let ingress_ident = frag_test_ingress_ident();
+    let decision = frag_test_decision();
+    let meta = frag_test_meta(14);
+    let (event_handle, _event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+
+    let req = build_live_forward_request_from_frame(
+        &WorkerBindingLookup::default(),
+        2,
+        &ingress_ident,
+        XdpDesc {
+            addr: 0,
+            len: frame.len() as u32,
+            options: 0,
+        },
+        &frame,
+        meta,
+        &decision,
+        &forwarding,
+        None, // flowless, but a real L4 header (not a fragment)
+        None,
+        false,
+        123,
+        Some(&event_handle),
+        None,
+        None,
+    );
+
+    assert!(
+        req.is_none(),
+        "a flowless NON-fragmented TCP packet to dst 443 must still be dropped \
+         by the port-matching terminal output filter (gate must not over-suppress)"
+    );
+}
+
+#[test]
+fn fabric_queue_hash_non_first_fragment_is_port_independent_3tuple() {
+    // Two non-first fragments of one datagram differ only in payload bytes
+    // (the fictitious "ports"); the fabric hash must be identical so they
+    // bind the same fabric target (no cross-chassis reordering).
+    let mut meta_a = frag_test_meta(14);
+    meta_a.flow_src_port = 1111;
+    meta_a.flow_dst_port = 2222;
+    let mut meta_b = meta_a;
+    meta_b.flow_src_port = 40000; // different payload bytes
+    meta_b.flow_dst_port = 50000;
+
+    let h_a = fabric_queue_hash(None, Some((1111, 2222)), meta_a, true);
+    let h_b = fabric_queue_hash(None, Some((40000, 50000)), meta_b, true);
+    assert_eq!(
+        h_a, h_b,
+        "fragment fabric hash must be port-independent (3-tuple: src/dst/proto)"
+    );
+
+    // The 3-tuple still distinguishes different src/dst/proto.
+    let mut meta_c = meta_a;
+    meta_c.flow_dst_addr[3] = 201; // different dst IP
+    let h_c = fabric_queue_hash(None, Some((1111, 2222)), meta_c, true);
+    assert_ne!(h_a, h_c, "fragment fabric hash must depend on dst address");
+
+    let mut meta_d = meta_a;
+    meta_d.protocol = PROTO_UDP;
+    let h_d = fabric_queue_hash(None, Some((1111, 2222)), meta_d, true);
+    assert_ne!(h_a, h_d, "fragment fabric hash must depend on protocol");
+
+    // And the non-fragment (ported) path is still port-sensitive — proves
+    // the gate flag, not a blanket change, drives the new behavior.
+    let h_ported_a = fabric_queue_hash(None, Some((1111, 2222)), meta_a, false);
+    let h_ported_b = fabric_queue_hash(None, Some((40000, 50000)), meta_b, false);
+    assert_ne!(
+        h_ported_a, h_ported_b,
+        "non-fragment fabric hash must remain port-sensitive"
+    );
+}
+
+/// Ethernet (14B) + IPv6 header + fragment header (44) + `payload`. A
+/// non-first fragment has fragment-offset bits set.
+fn eth_ipv6_frag_frame(frag_off: u16, payload: &[u8]) -> Vec<u8> {
+    let mut f = vec![
+        0x02, 0xbf, 0x72, 0x00, 0x80, 0x08, 0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5, 0x86, 0xdd,
+    ];
+    let mut ip = vec![0u8; 40];
+    ip[0] = 0x60;
+    ip[6] = 44; // next header = fragment
+    ip[7] = 64; // hop limit
+    // src 2001:559:8585:80::100, dst 2001:559:8585:80::200
+    ip[8..24].copy_from_slice(&[
+        0x20, 0x01, 0x05, 0x59, 0x85, 0x85, 0x00, 0x80, 0, 0, 0, 0, 0, 0, 0x01, 0x00,
+    ]);
+    ip[24..40].copy_from_slice(&[
+        0x20, 0x01, 0x05, 0x59, 0x85, 0x85, 0x00, 0x80, 0, 0, 0, 0, 0, 0, 0x02, 0x00,
+    ]);
+    let mut frag = [0u8; 8];
+    frag[0] = PROTO_TCP; // next header after fragment
+    frag[2..4].copy_from_slice(&frag_off.to_be_bytes());
+    frag[4..8].copy_from_slice(&0xdead_beefu32.to_be_bytes());
+    let plen = (8 + payload.len()) as u16;
+    ip[4..6].copy_from_slice(&plen.to_be_bytes());
+    f.extend_from_slice(&ip);
+    f.extend_from_slice(&frag);
+    f.extend_from_slice(payload);
+    f
+}
+
+#[test]
+fn non_first_fragment_v6_not_dropped_by_port_matching_output_filter() {
+    let payload = [0x82, 0x35, 0x01, 0xbb, 0, 0, 0, 0];
+    let frame = eth_ipv6_frag_frame(0x0008, &payload); // non-first (offset != 0)
+    let forwarding = build_forwarding_state(&ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 12,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v6: "wan-drop6".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-drop6".into(),
+            family: "inet6".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-web".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "discard".into(),
+                log: true,
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    });
+    let ingress_ident = frag_test_ingress_ident();
+    let decision = frag_test_decision();
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        ingress_ifindex: 10,
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        pkt_len: 80,
+        l3_offset: 14,
+        flow_src_port: 33333,
+        flow_dst_port: 443,
+        flow_src_addr: [
+            0x20, 0x01, 0x05, 0x59, 0x85, 0x85, 0x00, 0x80, 0, 0, 0, 0, 0, 0, 0x01, 0x00,
+        ],
+        flow_dst_addr: [
+            0x20, 0x01, 0x05, 0x59, 0x85, 0x85, 0x00, 0x80, 0, 0, 0, 0, 0, 0, 0x02, 0x00,
+        ],
+        ..UserspaceDpMeta::default()
+    };
+    let (event_handle, _event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+
+    let req = build_live_forward_request_from_frame(
+        &WorkerBindingLookup::default(),
+        2,
+        &ingress_ident,
+        XdpDesc {
+            addr: 0,
+            len: frame.len() as u32,
+            options: 0,
+        },
+        &frame,
+        meta,
+        &decision,
+        &forwarding,
+        None,
+        None,
+        false,
+        123,
+        Some(&event_handle),
+        None,
+        None,
+    );
+
+    let req = req.expect("a non-first IPv6 fragment must NOT be dropped by a port filter");
+    assert_eq!(req.flow_key, None, "v6 fragment TX selection must use no flow_key");
+    assert_eq!(req.expected_ports, None, "v6 fragment must not carry payload ports");
+}
+
+#[test]
+fn pending_neigh_fragment_buffers_no_flow_key() {
+    // Mirrors the poll_descriptor pending-neigh buffer-admission expression
+    // (#2357): a buffered packet's stored flow_key later drives
+    // resolve_cos_tx_selection_at on flush, so a non-first fragment must
+    // store `None` rather than a payload-derived ported tuple. A legitimate
+    // flowless TCP packet (real L4 header) keeps its meta-derived flow_key.
+    let flow: Option<&SessionFlow> = None;
+
+    // Non-first fragment frame; meta claims a ported tuple (the shim stamps
+    // payload bytes). The gate must suppress the meta fallback.
+    let frag_frame = eth_ipv4_frag_frame(0x0001, &[0x82, 0x35, 0x01, 0xbb, 0, 0, 0, 0]);
+    let frag_meta = frag_test_meta(14);
+    let frag_key = flow
+        .as_ref()
+        .map(|flow| flow.forward_key.clone())
+        .or_else(|| {
+            if frame_is_non_first_fragment(&frag_frame, frag_meta) {
+                None
+            } else {
+                parse_session_flow_from_meta(frag_meta).map(|flow| flow.forward_key)
+            }
+        });
+    assert_eq!(
+        frag_key, None,
+        "a buffered non-first fragment must store no flow_key"
+    );
+
+    // First/atomic fragment (real L4 header) — same meta — keeps its ports.
+    let ok_frame = eth_ipv4_frag_frame(0x0000, &[0x82, 0x35, 0x01, 0xbb, 0, 0, 0, 0]);
+    let ok_meta = frag_test_meta(14);
+    let ok_key = flow
+        .as_ref()
+        .map(|flow| flow.forward_key.clone())
+        .or_else(|| {
+            if frame_is_non_first_fragment(&ok_frame, ok_meta) {
+                None
+            } else {
+                parse_session_flow_from_meta(ok_meta).map(|flow| flow.forward_key)
+            }
+        });
+    let ok_key = ok_key.expect("a flowless non-fragmented TCP packet keeps its meta flow_key");
+    assert_eq!(ok_key.dst_port, 443, "legit flowless packet keeps its dst port");
+}

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -240,6 +240,7 @@ pub(crate) fn fabric_queue_hash(
     flow: Option<&SessionFlow>,
     expected_ports: Option<(u16, u16)>,
     meta: UserspaceDpMeta,
+    non_first_fragment: bool,
 ) -> u64 {
     fn mix(seed: &mut u64, value: u64) {
         *seed ^= value
@@ -249,6 +250,47 @@ pub(crate) fn fabric_queue_hash(
     }
 
     let mut seed = meta.protocol as u64;
+    // #2357: a non-first IP fragment has no L4 header — `meta.flow_*_port`
+    // and `expected_ports` describe payload bytes, not real ports. Hash a
+    // fragment-stable 3-tuple (protocol + L3 src/dst from metadata, which the
+    // XDP shim copies from the IP header that IS present on every fragment)
+    // and OMIT the ports, so every fragment of one datagram selects the same
+    // fabric target binding (no cross-chassis reordering). `flow` is `None`
+    // for a fragment (#2344), so the ported `flow`/`expected_ports` branches
+    // below never run for it.
+    if non_first_fragment {
+        match meta.addr_family as i32 {
+            libc::AF_INET => {
+                mix(
+                    &mut seed,
+                    u32::from_be_bytes([
+                        meta.flow_src_addr[0],
+                        meta.flow_src_addr[1],
+                        meta.flow_src_addr[2],
+                        meta.flow_src_addr[3],
+                    ]) as u64,
+                );
+                mix(
+                    &mut seed,
+                    u32::from_be_bytes([
+                        meta.flow_dst_addr[0],
+                        meta.flow_dst_addr[1],
+                        meta.flow_dst_addr[2],
+                        meta.flow_dst_addr[3],
+                    ]) as u64,
+                );
+            }
+            _ => {
+                for chunk in meta.flow_src_addr.chunks_exact(8) {
+                    mix(&mut seed, u64::from_be_bytes(chunk.try_into().unwrap()));
+                }
+                for chunk in meta.flow_dst_addr.chunks_exact(8) {
+                    mix(&mut seed, u64::from_be_bytes(chunk.try_into().unwrap()));
+                }
+            }
+        }
+        return seed;
+    }
     if let Some(flow) = flow {
         match flow.src_ip {
             IpAddr::V4(ip) => mix(&mut seed, u32::from(ip) as u64),


### PR DESCRIPTION
Closes #2357
Refs #2358 (adds the NAT64 feature-gaps note; cross-family policy build stays tracked there)

## Problem

A non-first IP fragment (IPv4 fragment-offset != 0; IPv6 Fragment Header
type 44, offset != 0) carries **no L4 header** — the bytes at the
post-IP-header offset are payload, not TCP/UDP ports. #2344 already makes
such a fragment flowless on the policy/session path
(`parse_session_flow_from_bytes` → `None`), so it forwards route-based
with no policy/NAT/session.

The TX-side CoS queue / fabric-queue / output-filter selection re-derived
a flow tuple from metadata **independently** of that gate. A forwarded
non-first fragment therefore got its egress queue, DSCP rewrite, fabric
target binding, and output-filter verdict computed from payload bytes
interpreted as ports: different fragments of one datagram could land on
different queues (cross-chassis reordering / reassembly stress), and a
port-matching terminal output-filter term could spuriously `discard` a
fragment. LOW, pre-existing (predates #2344).

## Fix — Option 1 (the issue's minimal fix)

Exposed `frame_is_non_first_fragment` as `pub(in crate::afxdp)` and gated
the TX-CoS sites where the gated `flow` is `None`:

- **`forward_request.rs::build_live_forward_request_from_frame`** — compute
  `non_first_fragment = flow.is_none() && frame_is_non_first_fragment(frame, meta)`
  once, then force `expected_ports = None`, set `tx_selection_flow = None`
  (→ `resolve_cos_tx_selection_at` takes its early `None` arm: interface
  `default_queue`, no output-filter / port eval), and pass the flag to
  `fabric_queue_hash`.
- **`worker/mod.rs::fabric_queue_hash`** — new `non_first_fragment` param;
  when set it hashes a fragment-stable **3-tuple** (protocol + L3 src/dst
  from metadata, which the XDP shim copies from the IP header present on
  every fragment) with **no ports**, so all fragments of one datagram
  select the same fabric binding. Flow-cache-hit call site passes `false`
  (a cache hit is always a real session).
- **`poll_descriptor/mod.rs` pending-neigh buffering** — a buffered
  fragment stores `flow_key = None`, so the later `retry_pending_neigh`
  flush (which feeds the stored `flow_key` to `resolve_cos_tx_selection_at`)
  also selects the default queue with no port-filter eval.

### Over-gating caution honored
The gate is the **non-first-fragment predicate**, NOT "every `None` flow".
A legitimate flowless TCP/UDP packet (real L4 header, no session yet)
keeps its meta/frame-derived ports and full CoS/filter selection. A test
asserts this explicitly.

### Site that was deliberately NOT changed
`coordinator/inject.rs:220` (emit-on-wire control-plane packets) stamps a
**validated real tuple** (`validate_injected_packet_tuple` →
`stamp_injected_packet_tuple`) and is never reached by a forwarded
payload-ported fragment — changing it would risk breaking control-plane
packets that have a legit stamped tuple. Verified not reachable.

## Tests (fail-on-revert)

`userspace-dp/src/afxdp/tests.rs`:
- `non_first_fragment_v4_not_dropped_by_port_matching_output_filter`
- `non_first_fragment_v6_not_dropped_by_port_matching_output_filter`
- `flowless_non_fragmented_tcp_still_hits_port_matching_output_filter` (anti-over-gate)
- `fabric_queue_hash_non_first_fragment_is_port_independent_3tuple`
- `pending_neigh_fragment_buffers_no_flow_key`

Verified: neutralizing the `forward_request` gate makes the v4 not-dropped
test FAIL. `cargo build --release` clean; cos/fragment/frag/fabric/
tx_selection/inject selectors green; new tests 5x.

## Docs
- `docs/cos-validation-notes.md` — new TX-CoS fragment section.
- `docs/feature-gaps.md` — NAT64 inbound-policy-matches-synthetic-IPv6 note (#2358 doc half; does not close #2358).

No wire field change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
