### PR TITLE
dataplane: fix 8-byte OOB write — register conntrack maps at on-map ABI size (#2360)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,28 @@
 # Action Log
 
+## 2026-06-22 — #2360 Copilot fold: SSOT const for conntrack map size
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Folded a Copilot consistency finding on PR #2365. Four test
+  fixtures in pkg/dataplane/userspace/manager_test.go created the
+  `sessions`/`sessions_v6` maps with ValueSize =
+  sizeof(SessionValue)/SessionValueV6 (136/184) — the OLD over-sized
+  value. After the production fix, the Manager's lookup copies the
+  registered 136/184 into the 128/176 bpfSessionValue buffer → the exact
+  #2360 OOB, reintroduced in test setup (latent: only manifests on a
+  BPF-privileged host). Collapsed the size to one SSOT: exported
+  `dataplane.ConntrackSessionValueSize` / `ConntrackSessionValueSizeV6`
+  (= unsafe.Sizeof(bpfSessionValue{}) / V6, the on-map C/Rust ABI,
+  excludes sync-only Generation). Production registration
+  (loader_userspace_shim.go) and the 4 fixture sites now both derive from
+  these constants. Repo-wide grep confirmed no other map-creation site
+  uses sizeof(SessionValue). Added a parity assertion that the exported
+  consts == the literal 128/176.
+- **File(s)**: pkg/dataplane/bpf_session_value.go (exported consts),
+  pkg/dataplane/loader_userspace_shim.go (registration via consts),
+  pkg/dataplane/userspace/manager_test.go (4 fixture sites),
+  pkg/dataplane/bpf_session_value_test.go (const == literal assertion).
+
 ## 2026-06-22 — #2360 conntrack map registration ABI fix (sync-only Generation)
 
 - **Timestamp**: 2026-06-22 PDT

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,33 @@
 # Action Log
 
+## 2026-06-22 — #2360 conntrack map registration ABI fix (sync-only Generation)
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Fixed an 8-byte stack OOB write (#2360, HIGH). The shared
+  `sessions`/`sessions_v6` BPF HASH maps were registered with
+  `sizeOf[SessionValue]()`/`sizeOf[SessionValueV6]()` (136/184 bytes), but
+  `SessionValue` ends with `Generation uint64` — sync-only #2170 HA
+  metadata that is intentionally NOT in the BPF C conntrack struct. The
+  on-map C/Rust layout is 128/176 (Rust `BpfSessionValueV4/V6`, asserted in
+  bpf_map_tests.rs; C `struct session_value` in xpf_conntrack.h). The
+  over-sized registration made the kernel copy value_size (136/184) into the
+  Rust helper's 128/176-byte lookup buffer on every `bpf_map_lookup_elem` —
+  an 8-byte OOB write (latent: trailing bytes usually zero). Fix: dedicated
+  on-map ABI types `bpfSessionValue`/`bpfSessionValueV6` (no Generation),
+  register the maps at their size, and project all map I/O through
+  `toBPF()`/`sessionValue()` at the boundary. Generation stays in
+  `SessionValue` (in-memory + sync wire, pkg/cluster/sync_protocol.go's own
+  byte codec) — only the map registration size changed; HA sync unaffected.
+  Added parity guards (Go: registered size == 128/176 and != sizeOf[
+  SessionValue], ABI-type size asserts, round-trip drops Generation; Rust
+  asserts retained).
+- **File(s)**: pkg/dataplane/bpf_session_value.go (new ABI types +
+  converters), pkg/dataplane/bpf_session_value_test.go (new parity guards),
+  pkg/dataplane/loader_userspace_shim.go (registration size),
+  pkg/dataplane/maps_session.go (boundary conversion at all map I/O),
+  pkg/dataplane/types.go (Generation cross-reference comment),
+  docs/sync-protocol.md (#2360 ABI section).
+
 ## 2026-06-22 — #2345 review folds (comment accuracy + MissingNeighbor tests)
 
 - **Timestamp**: 2026-06-22 PDT

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -175,6 +175,33 @@ belt-and-suspenders for helper-originated deletes; the Go cluster apply layer is
 authoritative. A mixed-version cluster degrades to exact pre-#2170 behavior for
 any pair where either end lacks a generation.
 
+### Generation is sync-only — it MUST NOT inflate the BPF map (#2360)
+
+The install `Generation` lives in three places: the in-memory `SessionValue` /
+`SessionValueV6` (Go) and `SyncedSessionEntry` (Rust), and the sync wire (the
+length-gated trailing 8 bytes above). It is deliberately **absent** from the BPF
+C conntrack struct (`struct session_value` / `struct session_value_v6` in
+`bpf/headers/xpf_conntrack.h`), so the kernel-visible `sessions` / `sessions_v6`
+HASH maps are 128 / 176 bytes per value — the same layout the Rust helper
+mirrors as `BpfSessionValueV4` / `BpfSessionValueV6` (size-asserted at
+`userspace-dp/src/afxdp/bpf_map_tests.rs`).
+
+Because `SessionValue` carries the extra trailing `Generation uint64`, it is
+136 / 184 bytes — 8 bytes larger than the on-map layout. The Go map
+registration therefore must use the dedicated on-map ABI types
+`bpfSessionValue` / `bpfSessionValueV6` (`pkg/dataplane/bpf_session_value.go`),
+which mirror the C struct exactly without `Generation`, and all map I/O
+(`SetSessionV4/V6`, `GetSessionV4/V6`, iterate/batch in
+`pkg/dataplane/maps_session.go`) projects through `toBPF()` / `sessionValue()`
+at the boundary. Registering at `sizeOf[SessionValue]` instead would make the
+kernel `value_size` 8 bytes larger than the Rust helper's lookup buffer, so a
+`bpf_map_lookup_elem` would copy `value_size` bytes into the smaller buffer — an
+8-byte out-of-bounds write (latent because the trailing bytes are usually zero).
+The parity guards `TestSessionMapRegisteredAtConntrackABISize` /
+`TestBPFSessionValueMatchesConntrackABI` (Go) and the Rust size asserts pin the
+128 / 176 contract on both sides. **A new sync-only field must be added to the
+sync codec and the in-memory structs — never to the on-map ABI types.**
+
 ### Generation-map bounds and overflow (#2198 F1)
 
 Both the sender echo maps (`genSentV4/V6`) and the receiver stored-generation

--- a/pkg/dataplane/bpf_session_value.go
+++ b/pkg/dataplane/bpf_session_value.go
@@ -1,5 +1,24 @@
 package dataplane
 
+import "unsafe"
+
+// ConntrackSessionValueSize / ConntrackSessionValueSizeV6 are the on-map
+// conntrack ABI value sizes (bytes) for the shared `sessions` / `sessions_v6`
+// BPF HASH maps. They EXCLUDE the sync-only Generation field — they mirror the
+// C `struct session_value` / `session_value_v6` (bpf/headers/xpf_conntrack.h)
+// and the Rust `BpfSessionValueV4` / `BpfSessionValueV6` (size-asserted at
+// 128 / 176 in userspace-dp/src/afxdp/bpf_map_tests.rs).
+//
+// This is the SINGLE source of truth for the map value_size: the production
+// registration (loader_userspace_shim.go) and every test fixture that creates a
+// `sessions` map MUST use these constants, NOT sizeOf[SessionValue] (which is
+// 8 bytes larger and would over-size the map → OOB copy into the helper's
+// smaller lookup buffer, #2360).
+var (
+	ConntrackSessionValueSize   = uint32(unsafe.Sizeof(bpfSessionValue{}))
+	ConntrackSessionValueSizeV6 = uint32(unsafe.Sizeof(bpfSessionValueV6{}))
+)
+
 // On-map conntrack ABI types (#2360).
 //
 // The shared kernel-visible `sessions` / `sessions_v6` BPF HASH maps store the

--- a/pkg/dataplane/bpf_session_value.go
+++ b/pkg/dataplane/bpf_session_value.go
@@ -1,0 +1,262 @@
+package dataplane
+
+// On-map conntrack ABI types (#2360).
+//
+// The shared kernel-visible `sessions` / `sessions_v6` BPF HASH maps store the
+// C `struct session_value` / `struct session_value_v6` layout (bpf/headers/
+// xpf_conntrack.h), which the Rust helper mirrors as BpfSessionValueV4 (128
+// bytes) / BpfSessionValueV6 (176 bytes) — test-asserted at
+// userspace-dp/src/afxdp/bpf_map_tests.rs.
+//
+// SessionValue / SessionValueV6 (types.go) carry one EXTRA trailing field,
+// `Generation uint64` — the #2170 HA deferred-delete install-generation guard.
+// That field is userspace-sync-only metadata: it lives in the Go session table
+// and travels on the cluster session-sync wire (pkg/cluster/sync_protocol.go,
+// its own length-gated byte codec), and is deliberately NOT part of the BPF C
+// conntrack struct. So SessionValue is 8 bytes larger than the on-map layout
+// (136 vs 128 v4; 184 vs 176 v6).
+//
+// Registering the map at sizeof(SessionValue) (the previous behaviour) made the
+// kernel value_size 8 bytes larger than every reader/writer's struct. A
+// bpf_map_lookup_elem from the Rust side into its 128/176-byte buffer then has
+// the kernel copy value_size (136/184) bytes into the smaller buffer — an
+// 8-byte stack out-of-bounds write (latent because the trailing bytes are
+// usually zero). See issue #2360.
+//
+// bpfSessionValue / bpfSessionValueV6 are the dedicated on-map ABI types:
+// identical to SessionValue / SessionValueV6 minus the sync-only Generation.
+// They are the size used for map registration AND for every map I/O (Update /
+// Lookup / Iterate / Batch), so cilium/ebpf marshals exactly the C layout. The
+// Go-facing accessors convert at the boundary; Generation never touches the
+// BPF map (it is sourced from the Go session table / sync path).
+
+// bpfSessionValue mirrors C `struct session_value` exactly (128 bytes). It is
+// SessionValue without the sync-only Generation field. Keep field-for-field in
+// sync with both SessionValue (types.go) and the C struct (xpf_conntrack.h);
+// the parity test in maps_session_test.go fails if the size drifts from 128.
+type bpfSessionValue struct {
+	State      uint8
+	Flags      uint8
+	TCPState   uint8
+	IsReverse  uint8
+	AppTimeout uint32
+
+	SessionID uint64
+
+	Created  uint64
+	LastSeen uint64
+	Timeout  uint32
+	PolicyID uint32
+
+	IngressZone uint16
+	EgressZone  uint16
+
+	NATSrcIP   uint32
+	NATDstIP   uint32
+	NATSrcPort uint16
+	NATDstPort uint16
+
+	FwdPackets uint64
+	FwdBytes   uint64
+	RevPackets uint64
+	RevBytes   uint64
+
+	ReverseKey SessionKey
+
+	ALGType  uint8
+	LogFlags uint8
+	AppID    uint16
+
+	FibIfindex uint32
+	FibVlanID  uint16
+	FibDmac    [6]byte
+	FibSmac    [6]byte
+	FibGen     uint16
+}
+
+// bpfSessionValueV6 mirrors C `struct session_value_v6` exactly (176 bytes). It
+// is SessionValueV6 without the sync-only Generation field.
+type bpfSessionValueV6 struct {
+	State      uint8
+	Flags      uint8
+	TCPState   uint8
+	IsReverse  uint8
+	AppTimeout uint32
+
+	SessionID uint64
+
+	Created  uint64
+	LastSeen uint64
+	Timeout  uint32
+	PolicyID uint32
+
+	IngressZone uint16
+	EgressZone  uint16
+
+	NATSrcIP   [16]byte
+	NATDstIP   [16]byte
+	NATSrcPort uint16
+	NATDstPort uint16
+
+	FwdPackets uint64
+	FwdBytes   uint64
+	RevPackets uint64
+	RevBytes   uint64
+
+	ReverseKey SessionKeyV6
+
+	ALGType  uint8
+	LogFlags uint8
+	AppID    uint16
+
+	FibIfindex uint32
+	FibVlanID  uint16
+	FibDmac    [6]byte
+	FibSmac    [6]byte
+	FibGen     uint16
+}
+
+// toBPF projects a SessionValue onto the on-map ABI layout, dropping the
+// sync-only Generation. Used before any write to the BPF sessions map.
+func (v SessionValue) toBPF() bpfSessionValue {
+	return bpfSessionValue{
+		State:       v.State,
+		Flags:       v.Flags,
+		TCPState:    v.TCPState,
+		IsReverse:   v.IsReverse,
+		AppTimeout:  v.AppTimeout,
+		SessionID:   v.SessionID,
+		Created:     v.Created,
+		LastSeen:    v.LastSeen,
+		Timeout:     v.Timeout,
+		PolicyID:    v.PolicyID,
+		IngressZone: v.IngressZone,
+		EgressZone:  v.EgressZone,
+		NATSrcIP:    v.NATSrcIP,
+		NATDstIP:    v.NATDstIP,
+		NATSrcPort:  v.NATSrcPort,
+		NATDstPort:  v.NATDstPort,
+		FwdPackets:  v.FwdPackets,
+		FwdBytes:    v.FwdBytes,
+		RevPackets:  v.RevPackets,
+		RevBytes:    v.RevBytes,
+		ReverseKey:  v.ReverseKey,
+		ALGType:     v.ALGType,
+		LogFlags:    v.LogFlags,
+		AppID:       v.AppID,
+		FibIfindex:  v.FibIfindex,
+		FibVlanID:   v.FibVlanID,
+		FibDmac:     v.FibDmac,
+		FibSmac:     v.FibSmac,
+		FibGen:      v.FibGen,
+	}
+}
+
+// sessionValue lifts an on-map entry back to SessionValue. Generation is left
+// zero — the BPF map never stores it; the authoritative Generation lives in the
+// Go session table / cluster sync path.
+func (v bpfSessionValue) sessionValue() SessionValue {
+	return SessionValue{
+		State:       v.State,
+		Flags:       v.Flags,
+		TCPState:    v.TCPState,
+		IsReverse:   v.IsReverse,
+		AppTimeout:  v.AppTimeout,
+		SessionID:   v.SessionID,
+		Created:     v.Created,
+		LastSeen:    v.LastSeen,
+		Timeout:     v.Timeout,
+		PolicyID:    v.PolicyID,
+		IngressZone: v.IngressZone,
+		EgressZone:  v.EgressZone,
+		NATSrcIP:    v.NATSrcIP,
+		NATDstIP:    v.NATDstIP,
+		NATSrcPort:  v.NATSrcPort,
+		NATDstPort:  v.NATDstPort,
+		FwdPackets:  v.FwdPackets,
+		FwdBytes:    v.FwdBytes,
+		RevPackets:  v.RevPackets,
+		RevBytes:    v.RevBytes,
+		ReverseKey:  v.ReverseKey,
+		ALGType:     v.ALGType,
+		LogFlags:    v.LogFlags,
+		AppID:       v.AppID,
+		FibIfindex:  v.FibIfindex,
+		FibVlanID:   v.FibVlanID,
+		FibDmac:     v.FibDmac,
+		FibSmac:     v.FibSmac,
+		FibGen:      v.FibGen,
+	}
+}
+
+// toBPF projects a SessionValueV6 onto the on-map ABI layout, dropping the
+// sync-only Generation.
+func (v SessionValueV6) toBPF() bpfSessionValueV6 {
+	return bpfSessionValueV6{
+		State:       v.State,
+		Flags:       v.Flags,
+		TCPState:    v.TCPState,
+		IsReverse:   v.IsReverse,
+		AppTimeout:  v.AppTimeout,
+		SessionID:   v.SessionID,
+		Created:     v.Created,
+		LastSeen:    v.LastSeen,
+		Timeout:     v.Timeout,
+		PolicyID:    v.PolicyID,
+		IngressZone: v.IngressZone,
+		EgressZone:  v.EgressZone,
+		NATSrcIP:    v.NATSrcIP,
+		NATDstIP:    v.NATDstIP,
+		NATSrcPort:  v.NATSrcPort,
+		NATDstPort:  v.NATDstPort,
+		FwdPackets:  v.FwdPackets,
+		FwdBytes:    v.FwdBytes,
+		RevPackets:  v.RevPackets,
+		RevBytes:    v.RevBytes,
+		ReverseKey:  v.ReverseKey,
+		ALGType:     v.ALGType,
+		LogFlags:    v.LogFlags,
+		AppID:       v.AppID,
+		FibIfindex:  v.FibIfindex,
+		FibVlanID:   v.FibVlanID,
+		FibDmac:     v.FibDmac,
+		FibSmac:     v.FibSmac,
+		FibGen:      v.FibGen,
+	}
+}
+
+// sessionValue lifts an on-map v6 entry back to SessionValueV6. Generation is
+// left zero (not stored in the BPF map).
+func (v bpfSessionValueV6) sessionValue() SessionValueV6 {
+	return SessionValueV6{
+		State:       v.State,
+		Flags:       v.Flags,
+		TCPState:    v.TCPState,
+		IsReverse:   v.IsReverse,
+		AppTimeout:  v.AppTimeout,
+		SessionID:   v.SessionID,
+		Created:     v.Created,
+		LastSeen:    v.LastSeen,
+		Timeout:     v.Timeout,
+		PolicyID:    v.PolicyID,
+		IngressZone: v.IngressZone,
+		EgressZone:  v.EgressZone,
+		NATSrcIP:    v.NATSrcIP,
+		NATDstIP:    v.NATDstIP,
+		NATSrcPort:  v.NATSrcPort,
+		NATDstPort:  v.NATDstPort,
+		FwdPackets:  v.FwdPackets,
+		FwdBytes:    v.FwdBytes,
+		RevPackets:  v.RevPackets,
+		RevBytes:    v.RevBytes,
+		ReverseKey:  v.ReverseKey,
+		ALGType:     v.ALGType,
+		LogFlags:    v.LogFlags,
+		AppID:       v.AppID,
+		FibIfindex:  v.FibIfindex,
+		FibVlanID:   v.FibVlanID,
+		FibDmac:     v.FibDmac,
+		FibSmac:     v.FibSmac,
+		FibGen:      v.FibGen,
+	}
+}

--- a/pkg/dataplane/bpf_session_value_test.go
+++ b/pkg/dataplane/bpf_session_value_test.go
@@ -29,6 +29,14 @@ func TestBPFSessionValueMatchesConntrackABI(t *testing.T) {
 		t.Fatalf("sizeof(bpfSessionValueV6) = %d, want %d (C struct session_value_v6 / Rust BpfSessionValueV6)",
 			got, conntrackValueSizeV6)
 	}
+	// The exported SSOT constants (used by production registration AND test
+	// fixtures) must equal the literal C/Rust contract.
+	if ConntrackSessionValueSize != conntrackValueSizeV4 {
+		t.Fatalf("ConntrackSessionValueSize = %d, want %d", ConntrackSessionValueSize, conntrackValueSizeV4)
+	}
+	if ConntrackSessionValueSizeV6 != conntrackValueSizeV6 {
+		t.Fatalf("ConntrackSessionValueSizeV6 = %d, want %d", ConntrackSessionValueSizeV6, conntrackValueSizeV6)
+	}
 }
 
 // TestSessionValueCarriesSyncOnlyGeneration confirms SessionValue is exactly 8

--- a/pkg/dataplane/bpf_session_value_test.go
+++ b/pkg/dataplane/bpf_session_value_test.go
@@ -1,0 +1,181 @@
+package dataplane
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// Sizes of the on-map C `struct session_value` / `struct session_value_v6`
+// conntrack ABI (bpf/headers/xpf_conntrack.h), mirrored by the Rust helper's
+// BpfSessionValueV4 / BpfSessionValueV6 and asserted on the Rust side at
+// userspace-dp/src/afxdp/bpf_map_tests.rs (size_of == 128 / 176). These are
+// the authoritative on-map value sizes — the Go map registration MUST match
+// them, not sizeOf[SessionValue] (which is 8 bytes larger due to the sync-only
+// Generation field, #2360).
+const (
+	conntrackValueSizeV4 = 128
+	conntrackValueSizeV6 = 176
+)
+
+// TestBPFSessionValueMatchesConntrackABI pins the dedicated on-map ABI types to
+// the C/Rust conntrack struct sizes. Fails if a field drifts so the Go layout
+// no longer mirrors the kernel struct.
+func TestBPFSessionValueMatchesConntrackABI(t *testing.T) {
+	if got := unsafe.Sizeof(bpfSessionValue{}); got != conntrackValueSizeV4 {
+		t.Fatalf("sizeof(bpfSessionValue) = %d, want %d (C struct session_value / Rust BpfSessionValueV4)",
+			got, conntrackValueSizeV4)
+	}
+	if got := unsafe.Sizeof(bpfSessionValueV6{}); got != conntrackValueSizeV6 {
+		t.Fatalf("sizeof(bpfSessionValueV6) = %d, want %d (C struct session_value_v6 / Rust BpfSessionValueV6)",
+			got, conntrackValueSizeV6)
+	}
+}
+
+// TestSessionValueCarriesSyncOnlyGeneration confirms SessionValue is exactly 8
+// bytes (one uint64 Generation) larger than the on-map ABI type, and that the
+// extra bytes are the trailing Generation field — the #2170 sync-only guard
+// that must NOT be registered into the BPF map (#2360).
+func TestSessionValueCarriesSyncOnlyGeneration(t *testing.T) {
+	deltaV4 := unsafe.Sizeof(SessionValue{}) - unsafe.Sizeof(bpfSessionValue{})
+	if deltaV4 != unsafe.Sizeof(uint64(0)) {
+		t.Fatalf("SessionValue is %d bytes larger than bpfSessionValue, want exactly %d (one uint64 Generation)",
+			deltaV4, unsafe.Sizeof(uint64(0)))
+	}
+	deltaV6 := unsafe.Sizeof(SessionValueV6{}) - unsafe.Sizeof(bpfSessionValueV6{})
+	if deltaV6 != unsafe.Sizeof(uint64(0)) {
+		t.Fatalf("SessionValueV6 is %d bytes larger than bpfSessionValueV6, want exactly %d (one uint64 Generation)",
+			deltaV6, unsafe.Sizeof(uint64(0)))
+	}
+	// Generation must be the trailing field: its offset equals the on-map size.
+	if off := unsafe.Offsetof(SessionValue{}.Generation); off != conntrackValueSizeV4 {
+		t.Fatalf("SessionValue.Generation offset = %d, want %d (must sit immediately past the on-map layout)",
+			off, conntrackValueSizeV4)
+	}
+	if off := unsafe.Offsetof(SessionValueV6{}.Generation); off != conntrackValueSizeV6 {
+		t.Fatalf("SessionValueV6.Generation offset = %d, want %d (must sit immediately past the on-map layout)",
+			off, conntrackValueSizeV6)
+	}
+}
+
+// TestSessionMapRegisteredAtConntrackABISize is the regression guard for
+// #2360: the `sessions` / `sessions_v6` BPF maps MUST be registered with the
+// on-map conntrack ABI value_size (128 / 176), NOT sizeOf[SessionValue] /
+// sizeOf[SessionValueV6] (136 / 184). Registering at the larger SessionValue
+// size makes the kernel value_size exceed the Rust helper's 128/176-byte lookup
+// buffer, causing an 8-byte out-of-bounds copy. This test fails if anyone
+// reverts the registration to sizeOf[SessionValue].
+func TestSessionMapRegisteredAtConntrackABISize(t *testing.T) {
+	specs := userspaceShimSharedMapSpecs()
+	valueSize := make(map[string]uint32, len(specs))
+	for _, spec := range specs {
+		valueSize[spec.Name] = spec.ValueSize
+	}
+
+	if got := valueSize["sessions"]; got != conntrackValueSizeV4 {
+		t.Fatalf("sessions map value_size = %d, want %d (C/Rust conntrack ABI); "+
+			"must NOT be sizeOf[SessionValue]=%d which inflates the map by the sync-only Generation (#2360)",
+			got, conntrackValueSizeV4, unsafe.Sizeof(SessionValue{}))
+	}
+	if got := valueSize["sessions_v6"]; got != conntrackValueSizeV6 {
+		t.Fatalf("sessions_v6 map value_size = %d, want %d (C/Rust conntrack ABI); "+
+			"must NOT be sizeOf[SessionValueV6]=%d which inflates the map by the sync-only Generation (#2360)",
+			got, conntrackValueSizeV6, unsafe.Sizeof(SessionValueV6{}))
+	}
+
+	// And the registration must equal the dedicated ABI type's size — the
+	// single source of the on-map layout.
+	if got, want := valueSize["sessions"], uint32(unsafe.Sizeof(bpfSessionValue{})); got != want {
+		t.Fatalf("sessions map value_size = %d, want sizeOf[bpfSessionValue]=%d", got, want)
+	}
+	if got, want := valueSize["sessions_v6"], uint32(unsafe.Sizeof(bpfSessionValueV6{})); got != want {
+		t.Fatalf("sessions_v6 map value_size = %d, want sizeOf[bpfSessionValueV6]=%d", got, want)
+	}
+}
+
+// TestSessionValueBPFRoundTripDropsGeneration verifies the conversion contract:
+// every field except the sync-only Generation survives a SessionValue -> on-map
+// -> SessionValue round trip, and Generation is dropped (the BPF map never
+// stores it). The authoritative Generation lives in the Go session table / on
+// the cluster sync wire, so dropping it at the map boundary is correct.
+func TestSessionValueBPFRoundTripDropsGeneration(t *testing.T) {
+	orig := SessionValue{
+		State:       3,
+		Flags:       SessFlagSNAT,
+		TCPState:    4,
+		IsReverse:   0,
+		AppTimeout:  120,
+		SessionID:   0xdeadbeefcafef00d,
+		Created:     111,
+		LastSeen:    222,
+		Timeout:     300,
+		PolicyID:    7,
+		IngressZone: 1,
+		EgressZone:  2,
+		NATSrcIP:    0x0a000001,
+		NATDstIP:    0x0a000002,
+		NATSrcPort:  1234,
+		NATDstPort:  5678,
+		FwdPackets:  10,
+		FwdBytes:    1000,
+		RevPackets:  20,
+		RevBytes:    2000,
+		ReverseKey:  SessionKey{SrcPort: 5678, DstPort: 1234, Protocol: 6},
+		ALGType:     1,
+		LogFlags:    2,
+		AppID:       42,
+		FibIfindex:  9,
+		FibVlanID:   50,
+		FibDmac:     [6]byte{1, 2, 3, 4, 5, 6},
+		FibSmac:     [6]byte{6, 5, 4, 3, 2, 1},
+		FibGen:      99,
+		Generation:  0x1122334455667788, // sync-only — must NOT survive to the map
+	}
+
+	got := orig.toBPF().sessionValue()
+
+	want := orig
+	want.Generation = 0 // dropped at the map boundary
+	if got != want {
+		t.Fatalf("v4 round trip mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+
+	origV6 := SessionValueV6{
+		State:       3,
+		Flags:       SessFlagDNAT,
+		TCPState:    4,
+		IsReverse:   1,
+		AppTimeout:  60,
+		SessionID:   0x0102030405060708,
+		Created:     1,
+		LastSeen:    2,
+		Timeout:     30,
+		PolicyID:    8,
+		IngressZone: 2,
+		EgressZone:  1,
+		NATSrcIP:    [16]byte{0xfe, 0x80, 15: 1},
+		NATDstIP:    [16]byte{0x20, 0x01, 15: 2},
+		NATSrcPort:  4321,
+		NATDstPort:  8765,
+		FwdPackets:  5,
+		FwdBytes:    500,
+		RevPackets:  6,
+		RevBytes:    600,
+		ReverseKey:  SessionKeyV6{SrcPort: 8765, DstPort: 4321, Protocol: 17},
+		ALGType:     2,
+		LogFlags:    3,
+		AppID:       43,
+		FibIfindex:  10,
+		FibVlanID:   80,
+		FibDmac:     [6]byte{9, 8, 7, 6, 5, 4},
+		FibSmac:     [6]byte{4, 5, 6, 7, 8, 9},
+		FibGen:      77,
+		Generation:  0x8877665544332211,
+	}
+
+	gotV6 := origV6.toBPF().sessionValue()
+	wantV6 := origV6
+	wantV6.Generation = 0
+	if gotV6 != wantV6 {
+		t.Fatalf("v6 round trip mismatch:\n got=%+v\nwant=%+v", gotV6, wantV6)
+	}
+}

--- a/pkg/dataplane/loader_userspace_shim.go
+++ b/pkg/dataplane/loader_userspace_shim.go
@@ -274,8 +274,14 @@ func closeUniqueMaps(maps map[string]*ebpf.Map) {
 
 func userspaceShimSharedMapSpecs() []*ebpf.MapSpec {
 	return []*ebpf.MapSpec{
-		hashMapSpec("sessions", sizeOf[SessionKey](), sizeOf[SessionValue](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
-		hashMapSpec("sessions_v6", sizeOf[SessionKeyV6](), sizeOf[SessionValueV6](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
+		// Register the conntrack maps at the on-map C/Rust ABI size
+		// (bpfSessionValue/bpfSessionValueV6), NOT sizeOf[SessionValue].
+		// SessionValue carries the sync-only Generation field (#2170) which
+		// is intentionally absent from the BPF C struct; using its size would
+		// inflate value_size by 8 bytes and cause an OOB copy into the Rust
+		// helper's smaller lookup buffer (#2360).
+		hashMapSpec("sessions", sizeOf[SessionKey](), sizeOf[bpfSessionValue](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
+		hashMapSpec("sessions_v6", sizeOf[SessionKeyV6](), sizeOf[bpfSessionValueV6](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
 		hashMapSpec("dnat_table", sizeOf[DNATKey](), sizeOf[DNATValue](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
 		hashMapSpec("dnat_table_v6", sizeOf[DNATKeyV6](), sizeOf[DNATValueV6](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
 		arrayMapSpec("fib_gen_map", sizeOf[uint32](), 1),
@@ -364,4 +370,3 @@ func ensureUserspaceMapPinned(name string, m *ebpf.Map, path string) error {
 	}
 	return nil
 }
-

--- a/pkg/dataplane/loader_userspace_shim.go
+++ b/pkg/dataplane/loader_userspace_shim.go
@@ -275,13 +275,14 @@ func closeUniqueMaps(maps map[string]*ebpf.Map) {
 func userspaceShimSharedMapSpecs() []*ebpf.MapSpec {
 	return []*ebpf.MapSpec{
 		// Register the conntrack maps at the on-map C/Rust ABI size
-		// (bpfSessionValue/bpfSessionValueV6), NOT sizeOf[SessionValue].
+		// (ConntrackSessionValueSize{,V6}), NOT sizeOf[SessionValue].
 		// SessionValue carries the sync-only Generation field (#2170) which
 		// is intentionally absent from the BPF C struct; using its size would
 		// inflate value_size by 8 bytes and cause an OOB copy into the Rust
-		// helper's smaller lookup buffer (#2360).
-		hashMapSpec("sessions", sizeOf[SessionKey](), sizeOf[bpfSessionValue](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
-		hashMapSpec("sessions_v6", sizeOf[SessionKeyV6](), sizeOf[bpfSessionValueV6](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
+		// helper's smaller lookup buffer (#2360). These constants are the
+		// single source of truth shared with the test fixtures.
+		hashMapSpec("sessions", sizeOf[SessionKey](), ConntrackSessionValueSize, userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
+		hashMapSpec("sessions_v6", sizeOf[SessionKeyV6](), ConntrackSessionValueSizeV6, userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
 		hashMapSpec("dnat_table", sizeOf[DNATKey](), sizeOf[DNATValue](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
 		hashMapSpec("dnat_table_v6", sizeOf[DNATKeyV6](), sizeOf[DNATValueV6](), userspaceShimMaxSessions, unix.BPF_F_NO_PREALLOC),
 		arrayMapSpec("fib_gen_map", sizeOf[uint32](), 1),

--- a/pkg/dataplane/maps_session.go
+++ b/pkg/dataplane/maps_session.go
@@ -30,10 +30,10 @@ func (m *Manager) IterateSessions(fn func(SessionKey, SessionValue) bool) error 
 	}
 
 	var key SessionKey
-	var val SessionValue
+	var val bpfSessionValue
 	iter := sm.Iterate()
 	for iter.Next(&key, &val) {
-		if !fn(key, val) {
+		if !fn(key, val.sessionValue()) {
 			break
 		}
 	}
@@ -55,7 +55,7 @@ func (m *Manager) SetSessionV4(key SessionKey, val SessionValue) error {
 	if !ok {
 		return fmt.Errorf("sessions map not found")
 	}
-	return sm.Update(key, val, ebpf.UpdateAny)
+	return sm.Update(key, val.toBPF(), ebpf.UpdateAny)
 }
 
 // GetSessionV4 looks up a single v4 session entry by key.
@@ -64,11 +64,11 @@ func (m *Manager) GetSessionV4(key SessionKey) (SessionValue, error) {
 	if !ok {
 		return SessionValue{}, fmt.Errorf("sessions map not found")
 	}
-	var val SessionValue
+	var val bpfSessionValue
 	if err := sm.Lookup(key, &val); err != nil {
 		return SessionValue{}, err
 	}
-	return val, nil
+	return val.sessionValue(), nil
 }
 
 // GetSessionV6 looks up a single v6 session entry by key.
@@ -77,11 +77,11 @@ func (m *Manager) GetSessionV6(key SessionKeyV6) (SessionValueV6, error) {
 	if !ok {
 		return SessionValueV6{}, fmt.Errorf("sessions_v6 map not found")
 	}
-	var val SessionValueV6
+	var val bpfSessionValueV6
 	if err := sm.Lookup(key, &val); err != nil {
 		return SessionValueV6{}, err
 	}
-	return val, nil
+	return val.sessionValue(), nil
 }
 
 // IterateSessionsV6 iterates all IPv6 session entries, calling fn for each.
@@ -92,10 +92,10 @@ func (m *Manager) IterateSessionsV6(fn func(SessionKeyV6, SessionValueV6) bool) 
 	}
 
 	var key SessionKeyV6
-	var val SessionValueV6
+	var val bpfSessionValueV6
 	iter := sm.Iterate()
 	for iter.Next(&key, &val) {
-		if !fn(key, val) {
+		if !fn(key, val.sessionValue()) {
 			break
 		}
 	}
@@ -126,7 +126,7 @@ func (m *Manager) IterateSessionsFrom(cursorKey *SessionKey, fn func(SessionKey,
 	}
 
 	for {
-		var val SessionValue
+		var val bpfSessionValue
 		if err := sm.Lookup(nextKey, &val); err != nil {
 			// Entry may have been deleted between NextKey and Lookup; skip.
 			var next SessionKey
@@ -139,7 +139,7 @@ func (m *Manager) IterateSessionsFrom(cursorKey *SessionKey, fn func(SessionKey,
 			nextKey = next
 			continue
 		}
-		if !fn(nextKey, val) {
+		if !fn(nextKey, val.sessionValue()) {
 			return nil
 		}
 		var next SessionKey
@@ -176,7 +176,7 @@ func (m *Manager) IterateSessionsV6From(cursorKey *SessionKeyV6, fn func(Session
 	}
 
 	for {
-		var val SessionValueV6
+		var val bpfSessionValueV6
 		if err := sm.Lookup(nextKey, &val); err != nil {
 			var next SessionKeyV6
 			if err := sm.NextKey(nextKey, &next); err != nil {
@@ -188,7 +188,7 @@ func (m *Manager) IterateSessionsV6From(cursorKey *SessionKeyV6, fn func(Session
 			nextKey = next
 			continue
 		}
-		if !fn(nextKey, val) {
+		if !fn(nextKey, val.sessionValue()) {
 			return nil
 		}
 		var next SessionKeyV6
@@ -213,13 +213,13 @@ func (m *Manager) BatchIterateSessions(fn func(SessionKey, SessionValue) bool) e
 
 	const batchSize = 256
 	keys := make([]SessionKey, batchSize)
-	vals := make([]SessionValue, batchSize)
+	vals := make([]bpfSessionValue, batchSize)
 	var cursor ebpf.MapBatchCursor
 
 	for {
 		n, err := sm.BatchLookup(&cursor, keys, vals, nil)
 		for i := 0; i < n; i++ {
-			if !fn(keys[i], vals[i]) {
+			if !fn(keys[i], vals[i].sessionValue()) {
 				return nil
 			}
 		}
@@ -242,13 +242,13 @@ func (m *Manager) BatchIterateSessionsV6(fn func(SessionKeyV6, SessionValueV6) b
 
 	const batchSize = 256
 	keys := make([]SessionKeyV6, batchSize)
-	vals := make([]SessionValueV6, batchSize)
+	vals := make([]bpfSessionValueV6, batchSize)
 	var cursor ebpf.MapBatchCursor
 
 	for {
 		n, err := sm.BatchLookup(&cursor, keys, vals, nil)
 		for i := 0; i < n; i++ {
-			if !fn(keys[i], vals[i]) {
+			if !fn(keys[i], vals[i].sessionValue()) {
 				return nil
 			}
 		}
@@ -301,7 +301,7 @@ func (m *Manager) SetSessionV6(key SessionKeyV6, val SessionValueV6) error {
 	if !ok {
 		return fmt.Errorf("sessions_v6 map not found")
 	}
-	return sm.Update(key, val, ebpf.UpdateAny)
+	return sm.Update(key, val.toBPF(), ebpf.UpdateAny)
 }
 
 // SessionCount returns the number of active IPv4 and IPv6 sessions.
@@ -309,7 +309,7 @@ func (m *Manager) SetSessionV6(key SessionKeyV6, val SessionValueV6) error {
 func (m *Manager) SessionCount() (v4, v6 int) {
 	if sm, ok := m.maps["sessions"]; ok {
 		var key SessionKey
-		var val SessionValue
+		var val bpfSessionValue
 		iter := sm.Iterate()
 		for iter.Next(&key, &val) {
 			if val.IsReverse == 0 {
@@ -319,7 +319,7 @@ func (m *Manager) SessionCount() (v4, v6 int) {
 	}
 	if sm, ok := m.maps["sessions_v6"]; ok {
 		var key SessionKeyV6
-		var val SessionValueV6
+		var val bpfSessionValueV6
 		iter := sm.Iterate()
 		for iter.Next(&key, &val) {
 			if val.IsReverse == 0 {

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -63,6 +63,13 @@ type SessionValue struct {
 	// replacement that was re-synced with a newer generation. A value of 0
 	// means "unknown / legacy peer" and falls back to unconditional
 	// delete (rolling-upgrade safe).
+	//
+	// Because this field is sync-only, the BPF conntrack maps are NOT
+	// registered at sizeof(SessionValue): they use the dedicated on-map ABI
+	// type bpfSessionValue (bpf_session_value.go), which omits Generation and
+	// matches the C/Rust 128-byte layout. Registering at sizeof(SessionValue)
+	// would over-size value_size by 8 bytes and OOB-write the Rust helper's
+	// lookup buffer (#2360). Do NOT mirror Generation into the BPF map.
 	Generation uint64
 }
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -611,9 +611,13 @@ func injectShimMap(t *testing.T, bpfShim *dataplane.Manager, name string, m *ebp
 func injectSessionMaps(t *testing.T, m *Manager) {
 	t.Helper()
 	sessionsMap, err := ebpf.NewMap(&ebpf.MapSpec{
-		Type:       ebpf.Hash,
-		KeySize:    uint32(unsafe.Sizeof(dataplane.SessionKey{})),
-		ValueSize:  uint32(unsafe.Sizeof(dataplane.SessionValue{})),
+		Type:    ebpf.Hash,
+		KeySize: uint32(unsafe.Sizeof(dataplane.SessionKey{})),
+		// On-map conntrack ABI size (excludes sync-only Generation) — must
+		// match the production registration, else the Manager's lookup copies
+		// the registered value_size into the smaller bpfSessionValue buffer
+		// (the #2360 OOB). Derive from the shared SSOT constant.
+		ValueSize:  dataplane.ConntrackSessionValueSize,
 		MaxEntries: 1024,
 	})
 	if err != nil {
@@ -624,7 +628,7 @@ func injectSessionMaps(t *testing.T, m *Manager) {
 	sessionsMapV6, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Hash,
 		KeySize:    uint32(unsafe.Sizeof(dataplane.SessionKeyV6{})),
-		ValueSize:  uint32(unsafe.Sizeof(dataplane.SessionValueV6{})),
+		ValueSize:  dataplane.ConntrackSessionValueSizeV6,
 		MaxEntries: 1024,
 	})
 	if err != nil {
@@ -1165,9 +1169,13 @@ func TestSetClusterSyncedSessionV4SkipsReverseHelperMirror(t *testing.T) {
 	m.proc = &exec.Cmd{}
 	m.cfg.ControlSocket = controlSock
 	sessionsMap, err := ebpf.NewMap(&ebpf.MapSpec{
-		Type:       ebpf.Hash,
-		KeySize:    uint32(unsafe.Sizeof(dataplane.SessionKey{})),
-		ValueSize:  uint32(unsafe.Sizeof(dataplane.SessionValue{})),
+		Type:    ebpf.Hash,
+		KeySize: uint32(unsafe.Sizeof(dataplane.SessionKey{})),
+		// On-map conntrack ABI size (excludes sync-only Generation) — must
+		// match the production registration, else the Manager's lookup copies
+		// the registered value_size into the smaller bpfSessionValue buffer
+		// (the #2360 OOB). Derive from the shared SSOT constant.
+		ValueSize:  dataplane.ConntrackSessionValueSize,
 		MaxEntries: 1024,
 	})
 	if err != nil {
@@ -1178,7 +1186,7 @@ func TestSetClusterSyncedSessionV4SkipsReverseHelperMirror(t *testing.T) {
 	sessionsMapV6, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Hash,
 		KeySize:    uint32(unsafe.Sizeof(dataplane.SessionKeyV6{})),
-		ValueSize:  uint32(unsafe.Sizeof(dataplane.SessionValueV6{})),
+		ValueSize:  dataplane.ConntrackSessionValueSizeV6,
 		MaxEntries: 1024,
 	})
 	if err != nil {


### PR DESCRIPTION
Closes #2360

## Root cause (registration-size, sync-only `Generation`)

The shared `sessions` / `sessions_v6` BPF HASH maps were registered in
`pkg/dataplane/loader_userspace_shim.go` with `sizeOf[SessionValue]()` /
`sizeOf[SessionValueV6]()`.

`pkg/dataplane/types.go` `SessionValue` / `SessionValueV6` end with
`Generation uint64` — the #2170 HA deferred-delete install-generation guard.
Its own doc-comment states it is **userspace-sync-only** metadata that is
**NOT mirrored into the BPF C conntrack struct**.

Measured sizes (this PR verified end-to-end):

| Layout | v4 | v6 |
|---|---|---|
| Go `SessionValue` / `SessionValueV6` (with `Generation`) | **136** | **184** |
| C `struct session_value` / `session_value_v6` (`bpf/headers/xpf_conntrack.h`) | **128** | **176** |
| Rust `BpfSessionValueV4` / `V6` (`bpf_map/mod.rs`, asserted at `bpf_map_tests.rs`) | **128** | **176** |

`Generation` sits at offset 128 (v4) / 176 (v6) — exactly the C-struct tail
(`FibGen` ends the C layout), so the delta is exactly 8 bytes (one `uint64`,
no extra alignment padding).

So the Go **registration** was 8 bytes larger than the true on-map ABI. A
`bpf_map_lookup_elem` from the Rust side into its 128/176-byte
`BpfSessionValueV4/V6` buffer (the `refresh_bpf_conntrack_last_seen` path in
`bpf_map/mod.rs`) against a 136/184-registered map has the kernel copy the
registered `value_size` into the smaller caller buffer → **8-byte stack
out-of-bounds write** (latent because the trailing bytes are usually zero).
HIGH memory-safety.

## Fix (register at C-struct size + parity guard)

- New dedicated on-map ABI types `bpfSessionValue` / `bpfSessionValueV6`
  (`pkg/dataplane/bpf_session_value.go`) that mirror the C struct exactly —
  identical to `SessionValue` minus the sync-only `Generation`.
- Register `sessions` / `sessions_v6` at `sizeOf[bpfSessionValue]` /
  `sizeOf[bpfSessionValueV6]` (128 / 176).
- Route **all** map I/O (`SetSessionV4/V6`, `GetSessionV4/V6`, iterate,
  iterate-from, batch, count) in `pkg/dataplane/maps_session.go` through
  `toBPF()` / `sessionValue()` at the boundary, so cilium/ebpf marshals
  exactly the C layout (Go previously marshaled the full 136-byte struct).

## `Generation` stays in sync — proof

`Generation` is unchanged. It still lives in `SessionValue` in memory and
travels on the cluster session-sync wire via `pkg/cluster/sync_protocol.go`'s
own length-gated byte codec (`binary.LittleEndian.PutUint64(buf[off:],
val.Generation)` — independent of the map `value_size`). The BPF map never
stored it before this PR and does not now (`sessionValue()` leaves it zero;
the authoritative value is the Go session table / sync path). Only the **map
registration size** changed. `pkg/cluster/...` tests pass unchanged.

## Tests (fail-on-revert)

- `TestSessionMapRegisteredAtConntrackABISize` — registered value_size MUST
  be 128/176 and MUST NOT be `sizeOf[SessionValue]` (136/184). **Verified it
  fails red when the registration is reverted to `sizeOf[SessionValue]`.**
- `TestBPFSessionValueMatchesConntrackABI` — `sizeof(bpfSessionValue)==128`,
  `bpfSessionValueV6==176` (matches the Rust `size_of` asserts).
- `TestSessionValueCarriesSyncOnlyGeneration` — `SessionValue` is exactly 8
  bytes larger; `Generation` is the trailing field.
- `TestSessionValueBPFRoundTripDropsGeneration` — all fields except
  `Generation` survive the round trip; `Generation` is dropped at the map
  boundary.
- Rust `bpf_map_tests.rs` size asserts retained (128/176).

## Validation

- `go build ./...` clean; `go vet` clean.
- `go test ./pkg/dataplane/... ./pkg/cluster/...` green; new tests pass 5x.
- `cargo build --release` clean; Rust `bpf_map` (23) / `session` / `conntrack`
  tests green.

No forwarding behavior change — this is a registration-size correctness fix.
The on-wire HA sync format is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi