### PR TITLE
afxdp/frame: bound live L4 port read by IP-declared length (#2361)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,30 @@
 # Action Log
 
+## 2026-06-22 — #2361 Copilot fold: clamp-panic guard in ipv4_declared_l3_end
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Folded a Copilot finding on PR #2366 — a real panic/DoS in
+  the #2361 helper. `ipv4_declared_l3_end` guarded only `frame.len() >=
+  l3+20` and `ihl >= 20`, then did `clamp(l3+ihl, frame.len())`. IPv4 IHL
+  can be 21..=60 (options), and the meta-driven callers
+  (`live_frame_ports_from_meta_bytes` / meta-offset fallback) do NOT
+  validate ihl against the slice. A crafted frame with IHL nibble = 15
+  (60-byte header) in a buffer truncated to l3+20 yields `clamp(min=l3+60,
+  max=l3+20)` → min > max → `Ord::clamp` panics → attacker-reachable
+  parser DoS. Fix: add `frame.len() < l3 + ihl` to the guard before the
+  clamp so `min <= max` is guaranteed (fail closed when the buffer does
+  not hold the declared IHL header). Behavior otherwise identical.
+  Verified the IPv6 helper is already safe (its clamp floor l3+40 ==
+  its guard `frame.len() >= l3+40`, so min <= max). Verified the sibling
+  `generated.rs::parse_generated_v4` is ALSO already safe — line 74
+  `if ihl < 20 || packet.len() < ihl` precedes its
+  `total_len.clamp(ihl, packet.len())`, and v6's floor 40 is guarded — so
+  generated.rs needed NO change. Added 2 fail-on-revert tests (direct
+  helper + meta-fast-path caller) that PANIC when the guard is removed;
+  both confirmed to fail (clamp panic) on revert, pass with the guard.
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs (guard),
+  userspace-dp/src/afxdp/frame/inspect_tests.rs (2 tests).
+
 ## 2026-06-22 — #2361 live frame parser: bound L4 ports by IP-declared length
 
 - **Timestamp**: 2026-06-22 PDT

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,35 @@
 # Action Log
 
+## 2026-06-22 — #2361 live frame parser: bound L4 ports by IP-declared length
+
+- **Timestamp**: 2026-06-22 PDT
+- **Action**: Fixed a HIGH input-validation gap (#2361). The live AF_XDP
+  frame parser read L4 ports bounded only by the backing slice (and the
+  fragment gate), never by the IPv4 `total_len` / IPv6 `payload_len`. A
+  frame declaring a short datagram but carrying trailing slack (NIC
+  zero-pad or attacker bytes) could have its ports read from out-of-packet
+  bytes → bogus tuple drives policy / firewall-filter / CoS / session
+  install. Added `ipv4_declared_l3_end` / `ipv6_declared_l3_end` /
+  `declared_l3_end` helpers (clamp `l3+total_len` / `l3+40+payload_len` to
+  the slice) and a `declared_end` parameter on `parse_flow_ports`: TCP/UDP
+  (4 bytes) and ICMP ident (2 bytes at +4) must lie within `declared_end`,
+  else `None` (flowless / route-based forward, consistent with #2344).
+  Updated all live callers — the v4/v6 frame-led parsers, the meta-offset
+  fallback in `parse_session_flow_from_bytes`, and the meta fast-path
+  readers `live_frame_ports_from_meta_bytes` / `live_frame_ports_bytes`
+  (re-derive `declared_end` from the frame's L3 header; the XDP shim does
+  NOT enforce the bound). Mirrors the sibling generated-reply parser's
+  fail-closed `generated_l4_ports` bound (#2238/#2321) so both paths treat
+  an out-of-IP-bound L4 identically. Added 11 fail-on-revert unit tests
+  (v4/v6, frame-led + meta fallback + meta fast path + helper clamp truth +
+  anti-over-gate well-formed cases); 7 fail when the bound is reverted to
+  slice-only. cargo build --release clean; full suite green (one unrelated
+  pre-existing worker_queue concurrency flake, passes 3/3 in isolation).
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs (helpers + bound +
+  all callers + test module decl), userspace-dp/src/afxdp/frame/inspect_tests.rs
+  (new), userspace-dp/src/afxdp/frame/prop_tests/inspect.rs (arity),
+  userspace-dp/src/afxdp/frame/README.md (invariant).
+
 ## 2026-06-22 — #2360 Copilot fold: SSOT const for conntrack map size
 
 - **Timestamp**: 2026-06-22 PDT

--- a/userspace-dp/src/afxdp/frame/README.md
+++ b/userspace-dp/src/afxdp/frame/README.md
@@ -106,6 +106,32 @@ inspect or rewrite a packet sitting in a UMEM frame.
   it stamps `(0, 0)` ports instead of synthesizing them. Composes with
   the #2293-era screen fragment classification (`extract_screen_info`),
   which independently sees and screens non-first fragments.
+- **L4 ports are bounded by the IP-DECLARED packet length (#2361)**: the
+  live ingress parsers (`parse_ipv4_session_flow_from_frame`, the IPv6 arm
+  of `parse_session_flow_from_frame`, the meta-offset fallback in
+  `parse_session_flow_from_bytes`, and the meta fast-path readers
+  `live_frame_ports_from_meta_bytes` / `live_frame_ports_bytes`) read the
+  L4 ports via `parse_flow_ports(frame, l4, proto, declared_end)`, where
+  `declared_end` is `ipv4_declared_l3_end` (`l3 + total_len`) /
+  `ipv6_declared_l3_end` (`l3 + 40 + payload_len`), each CLAMPED to the
+  backing slice. The 4 port bytes (2 ident bytes for ICMP) MUST lie inside
+  `declared_end` — a frame whose `total_len` / `payload_len` declares a
+  short datagram but carries trailing slack (NIC zero-pad on a sub-60-byte
+  frame, or attacker-supplied bytes) returns `None` rather than reading the
+  out-of-datagram bytes as ports. Before #2361 the read was bounded only by
+  the slice (and the fragment gate), so out-of-packet padding could spell a
+  TCP/UDP port pair that then drove port-based policy, firewall-filter
+  matching, CoS queue selection, and session installation. A `None` result
+  is flowless (the same route-based, session-less forward path #2344 uses).
+  This MIRRORS the sibling generated-reply parser, which already enforced
+  the identical bound as a fail-closed security invariant
+  (`generated.rs::generated_l4_ports`, clamping to
+  `total_len` / `40+payload_len` before extracting ports, #2238/#2321) — so
+  the live ingress path and the generated path now treat an out-of-IP-bound
+  L4 identically. The meta fast path is gated too: the XDP shim stamps
+  `meta.l4_offset` but does NOT enforce the IP-declared bound, so the meta
+  readers re-derive `declared_end` from the L3 header in the frame before
+  reading ports (mirroring #2357's meta-fast-path chokepoint concern).
 - **TCP inspection helpers are ext-header-aware (#2148)**: the read-only
   diagnostic/telemetry helpers `frame_has_tcp_rst`,
   `extract_tcp_flags_and_window`, and `extract_tcp_window` (`tcp.rs`) all

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -410,7 +410,14 @@ pub(in crate::afxdp) fn ipv4_declared_l3_end(frame: &[u8], l3: usize) -> Option<
         return None;
     }
     let ihl = usize::from(frame[l3] & 0x0f) * 4;
-    if ihl < 20 {
+    // Fail closed when the buffer does not even hold the declared IHL
+    // header (ihl can be 21..=60 with IPv4 options, but the meta-driven
+    // callers do NOT validate ihl against the slice). This guard is also a
+    // PANIC SAFETY invariant: the `clamp` below requires `min <= max`, i.e.
+    // `l3 + ihl <= frame.len()`. Without this guard a crafted frame with
+    // IHL nibble = 15 (60 bytes) in a buffer truncated to l3+20 would give
+    // `clamp(min = l3+60, max = l3+20)` -> `min > max` -> panic (DoS).
+    if ihl < 20 || frame.len() < l3 + ihl {
         return None;
     }
     let total_len = u16::from_be_bytes([frame[l3 + 2], frame[l3 + 3]]) as usize;

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -388,21 +388,105 @@ pub(in crate::afxdp) fn metadata_tuple_complete(meta: UserspaceDpMeta, flow: &Se
     }
 }
 
+/// The frame-relative byte offset at which the IPv4 datagram ENDS, as
+/// declared by the IP header `total_len` (bytes [l3+2..l3+4]), clamped to
+/// `[l3 + ihl, frame.len()]`.
+///
+/// #2361 fail-CLOSED: the L4 port read MUST be bounded by the IP-DECLARED
+/// packet end, not merely the backing slice. A frame whose `total_len`
+/// declares a short datagram but carries trailing slack (NIC zero-pad on a
+/// sub-60-byte frame, or attacker-supplied bytes) would otherwise have its
+/// "ports" read from out-of-datagram bytes. We clamp to the slice so a
+/// truncated capture (slice shorter than `total_len`) also fails closed
+/// (the read still cannot exceed what is present). Mirrors the
+/// `total_len.clamp(ihl, packet.len())` bound the sibling generated-reply
+/// parser enforces (`generated.rs::parse_generated_v4`).
+///
+/// Returns `None` when the IPv4 header itself is truncated/malformed
+/// (caller already validated `frame.len() >= l3 + 20` and `ihl >= 20`, so
+/// this is belt-and-suspenders for stray callers).
+pub(in crate::afxdp) fn ipv4_declared_l3_end(frame: &[u8], l3: usize) -> Option<usize> {
+    if frame.len() < l3 + 20 {
+        return None;
+    }
+    let ihl = usize::from(frame[l3] & 0x0f) * 4;
+    if ihl < 20 {
+        return None;
+    }
+    let total_len = u16::from_be_bytes([frame[l3 + 2], frame[l3 + 3]]) as usize;
+    Some(l3.saturating_add(total_len).clamp(l3 + ihl, frame.len()))
+}
+
+/// The frame-relative byte offset at which the IPv6 datagram ENDS, as
+/// declared by the fixed-header `payload_len` (bytes [l3+4..l3+6]), clamped
+/// to `[l3 + 40, frame.len()]`.
+///
+/// #2361 fail-CLOSED counterpart of [`ipv4_declared_l3_end`]: the IPv6
+/// packet end is `l3 + 40 + payload_len`. Mirrors the
+/// `(40 + payload_len).clamp(40, packet.len())` bound in
+/// `generated.rs::parse_generated_v6`.
+pub(in crate::afxdp) fn ipv6_declared_l3_end(frame: &[u8], l3: usize) -> Option<usize> {
+    if frame.len() < l3 + 40 {
+        return None;
+    }
+    let payload_len = u16::from_be_bytes([frame[l3 + 4], frame[l3 + 5]]) as usize;
+    Some(
+        l3.saturating_add(40)
+            .saturating_add(payload_len)
+            .clamp(l3 + 40, frame.len()),
+    )
+}
+
+/// IP-declared datagram end for either family, given the L3 offset and the
+/// address family. `None` for an unknown family or a truncated L3 header.
+pub(in crate::afxdp) fn declared_l3_end(frame: &[u8], l3: usize, addr_family: u8) -> Option<usize> {
+    match addr_family as i32 {
+        libc::AF_INET => ipv4_declared_l3_end(frame, l3),
+        libc::AF_INET6 => ipv6_declared_l3_end(frame, l3),
+        _ => None,
+    }
+}
+
+/// Read the L4 ports at `l4`, bounded by BOTH the backing slice AND the
+/// IP-DECLARED packet end (`declared_end`, the slice-clamped
+/// `ipv4_declared_l3_end` / `ipv6_declared_l3_end`).
+///
+/// #2361 fail-CLOSED: TCP/UDP need 4 port bytes at `[l4, l4+4)`; ICMP/ICMPv6
+/// read the 2 identifier bytes at `[l4+4, l4+6)`. The read MUST lie entirely
+/// within `declared_end`. When the IP header declares a datagram that ends
+/// BEFORE the L4 ports — even though the backing buffer still holds trailing
+/// slack/padding bytes — this returns `None` rather than synthesizing ports
+/// from out-of-datagram bytes. The caller treats `None` as flowless (the
+/// packet follows the route-based, session-less forward path, consistent with
+/// the #2344 non-first-fragment handling), so out-of-packet bytes never drive
+/// policy / firewall-filter / CoS / session installation. This is the same
+/// invariant the sibling generated-reply parser enforces via
+/// `generated.rs::generated_l4_ports`.
 pub(in crate::afxdp) fn parse_flow_ports(
     frame: &[u8],
     l4: usize,
     protocol: u8,
+    declared_end: usize,
 ) -> Option<(u16, u16)> {
     match protocol {
         PROTO_TCP | PROTO_UDP => {
-            let bytes = frame.get(l4..l4 + 4)?;
+            let end = l4.checked_add(4)?;
+            if end > declared_end {
+                return None;
+            }
+            let bytes = frame.get(l4..end)?;
             Some((
                 u16::from_be_bytes([bytes[0], bytes[1]]),
                 u16::from_be_bytes([bytes[2], bytes[3]]),
             ))
         }
         PROTO_ICMP | PROTO_ICMPV6 => {
-            let bytes = frame.get(l4 + 4..l4 + 6)?;
+            let ident_start = l4.checked_add(4)?;
+            let ident_end = l4.checked_add(6)?;
+            if ident_end > declared_end {
+                return None;
+            }
+            let bytes = frame.get(ident_start..ident_end)?;
             let ident = u16::from_be_bytes([bytes[0], bytes[1]]);
             Some((ident, 0))
         }
@@ -460,8 +544,18 @@ pub(in crate::afxdp) fn live_frame_ports_from_meta_bytes(
         return None;
     }
     let l4 = meta.l4_offset as usize;
+    // #2361: bound the meta-stamped L4 read by the IP-declared packet end,
+    // not just the slice. The XDP shim stamps `meta.l4_offset` but does NOT
+    // enforce that the L4 header lies inside the IP-declared datagram, so a
+    // frame with a short total_len/payload_len + trailing slack could have
+    // its ports read past the datagram. We re-derive the declared end from
+    // the L3 header in the frame (using `meta.l3_offset`). If the meta
+    // offsets are unusable, fall through to the byte-led parser, which
+    // re-derives both L3 and the declared end from the frame.
     if l4 != 0
-        && let Some(ports) = parse_flow_ports(frame, l4, meta.protocol)
+        && let Some(declared_end) =
+            declared_l3_end(frame, meta.l3_offset as usize, meta.addr_family)
+        && let Some(ports) = parse_flow_ports(frame, l4, meta.protocol, declared_end)
     {
         return Some(ports);
     }
@@ -476,8 +570,12 @@ pub(in crate::afxdp) fn live_frame_ports_bytes(
     if !matches!(protocol, PROTO_TCP | PROTO_UDP) {
         return None;
     }
+    let l3 = frame_l3_offset(frame)?;
     let l4 = frame_l4_offset(frame, addr_family)?;
-    parse_flow_ports(frame, l4, protocol)
+    // #2361: bound by the IP-declared packet end (re-derived from the frame),
+    // not just the backing slice.
+    let declared_end = declared_l3_end(frame, l3, addr_family)?;
+    parse_flow_ports(frame, l4, protocol, declared_end)
 }
 
 pub(in crate::afxdp) fn forward_tuple_mismatch_reason(
@@ -612,7 +710,9 @@ pub(in crate::afxdp) fn parse_session_flow_from_bytes(
                 frame[l3 + 18],
                 frame[l3 + 19],
             ));
-            let (src_port, dst_port) = parse_flow_ports(frame, l4, meta.protocol)?;
+            // #2361: bound by the IP-declared packet end, not just the slice.
+            let declared_end = ipv4_declared_l3_end(frame, l3)?;
+            let (src_port, dst_port) = parse_flow_ports(frame, l4, meta.protocol, declared_end)?;
             Some(SessionFlow {
                 src_ip,
                 dst_ip,
@@ -640,7 +740,9 @@ pub(in crate::afxdp) fn parse_session_flow_from_bytes(
             let dst_ip = IpAddr::V6(Ipv6Addr::from(
                 <[u8; 16]>::try_from(&frame[l3 + 24..l3 + 40]).ok()?,
             ));
-            let (src_port, dst_port) = parse_flow_ports(frame, l4, meta.protocol)?;
+            // #2361: bound by the IP-declared packet end, not just the slice.
+            let declared_end = ipv6_declared_l3_end(frame, l3)?;
+            let (src_port, dst_port) = parse_flow_ports(frame, l4, meta.protocol, declared_end)?;
             Some(SessionFlow {
                 src_ip,
                 dst_ip,
@@ -790,7 +892,10 @@ pub(in crate::afxdp) fn parse_session_flow_from_frame(
             let dst_ip = IpAddr::V6(Ipv6Addr::from(
                 <[u8; 16]>::try_from(&frame[l3 + 24..l3 + 40]).ok()?,
             ));
-            let (src_port, dst_port) = parse_flow_ports(frame, l4, meta.protocol)?;
+            // #2361: bound the L4 port read by the IP-declared packet end
+            // (l3 + 40 + payload_len, slice-clamped), not just the slice.
+            let declared_end = ipv6_declared_l3_end(frame, l3)?;
+            let (src_port, dst_port) = parse_flow_ports(frame, l4, meta.protocol, declared_end)?;
             Some(SessionFlow {
                 src_ip,
                 dst_ip,
@@ -895,7 +1000,12 @@ pub(in crate::afxdp) fn parse_ipv4_session_flow_from_frame(
         frame[l3 + 18],
         frame[l3 + 19],
     ));
-    let (src_port, dst_port) = parse_flow_ports(frame, l4, protocol)?;
+    // #2361: bound the L4 port read by the IP-declared packet end
+    // (l3 + total_len, slice-clamped), not just the slice. A short total_len
+    // with trailing slack/padding must NOT yield ports from out-of-datagram
+    // bytes.
+    let declared_end = ipv4_declared_l3_end(frame, l3)?;
+    let (src_port, dst_port) = parse_flow_ports(frame, l4, protocol, declared_end)?;
     Some(SessionFlow {
         src_ip,
         dst_ip,
@@ -1004,3 +1114,7 @@ pub(in crate::afxdp) fn try_parse_metadata(area: &MmapArea, desc: XdpDesc) -> Op
     }
     Some(meta)
 }
+
+#[cfg(test)]
+#[path = "inspect_tests.rs"]
+mod inspect_iplen_tests;

--- a/userspace-dp/src/afxdp/frame/inspect_tests.rs
+++ b/userspace-dp/src/afxdp/frame/inspect_tests.rs
@@ -249,3 +249,43 @@ fn declared_end_helpers_clamp_to_slice_and_floor() {
     let frame3 = v6_frame(PROTO_TCP, 1000, &FAKE_PORTS);
     assert_eq!(ipv6_declared_l3_end(&frame3, 14), Some(frame3.len()));
 }
+
+// ---- clamp-panic safety (Copilot fold): ihl declares more than the slice ----
+
+#[test]
+fn ipv4_declared_end_oversized_ihl_truncated_buffer_returns_none_no_panic() {
+    // IHL nibble = 15 => declared IPv4 header = 60 bytes, but the buffer
+    // holds only l3 + 20 (eth + minimal IPv4 header, no options present).
+    // Without the `frame.len() < l3 + ihl` guard, `clamp(min = l3+60,
+    // max = l3+20)` has min > max and PANICS. Must fail closed (None).
+    let mut frame = v4_frame(PROTO_TCP, 20, &[]); // eth(14) + IPv4(20), no L4
+    assert_eq!(frame.len(), 14 + 20);
+    frame[14] = 0x4f; // version 4, IHL = 15 (60-byte header claimed)
+    // A panic here (clamp min > max) is a test FAILURE.
+    assert_eq!(
+        ipv4_declared_l3_end(&frame, 14),
+        None,
+        "oversized IHL on a truncated buffer must fail closed, not panic"
+    );
+}
+
+#[test]
+fn meta_fast_path_oversized_ihl_truncated_buffer_no_panic() {
+    // Reachable from the meta-driven caller, which does NOT validate ihl
+    // against the slice. Same crafted frame; must not panic and must yield
+    // no ports (None).
+    let mut frame = v4_frame(PROTO_TCP, 20, &[]);
+    frame[14] = 0x4f; // IHL = 15
+    let meta = ForwardPacketMeta {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        l3_offset: 14,
+        l4_offset: 14 + 20,
+        ..ForwardPacketMeta::default()
+    };
+    assert_eq!(
+        live_frame_ports_from_meta_bytes(&frame, meta),
+        None,
+        "meta fast path must not panic on an oversized IHL truncated frame"
+    );
+}

--- a/userspace-dp/src/afxdp/frame/inspect_tests.rs
+++ b/userspace-dp/src/afxdp/frame/inspect_tests.rs
@@ -1,0 +1,251 @@
+// Tests for afxdp/frame/inspect.rs (#2361) — the live ingress frame parser
+// must bound the L4 port read by the IP-DECLARED packet length
+// (IPv4 total_len / IPv6 40+payload_len), not merely the backing slice.
+//
+// These pin the fail-closed invariant that out-of-datagram trailing slack
+// (NIC zero-pad on a sub-60-byte frame, or attacker-supplied bytes) can NOT
+// be read as L4 ports — mirroring the sibling generated-reply parser's
+// `generated_l4_ports` bound (`generated.rs`, #2321/#2238). Loaded as a
+// sibling submodule via `#[path = "inspect_tests.rs"]`.
+
+use super::*;
+
+const ETH_DST: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+const ETH_SRC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x02];
+
+/// Build an untagged IPv4 frame: eth(14) + IPv4 header(20) + `l4` bytes.
+/// `declared_total_len` is written into the IPv4 total_len field (bytes
+/// [2..4]) INDEPENDENTLY of how many L4 bytes are actually appended, so a
+/// caller can declare a short datagram but still carry trailing slack.
+fn v4_frame(protocol: u8, declared_total_len: u16, l4: &[u8]) -> Vec<u8> {
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&ETH_DST);
+    frame.extend_from_slice(&ETH_SRC);
+    frame.extend_from_slice(&0x0800u16.to_be_bytes());
+    // IPv4 header (IHL=5 => 20 bytes).
+    frame.push(0x45);
+    frame.push(0x00); // ToS
+    frame.extend_from_slice(&declared_total_len.to_be_bytes());
+    frame.extend_from_slice(&[0x00, 0x00]); // id
+    frame.extend_from_slice(&[0x40, 0x00]); // flags/frag-off (DF, offset 0)
+    frame.extend_from_slice(&[64, protocol]); // ttl, proto
+    frame.extend_from_slice(&[0x00, 0x00]); // checksum (unused by parser)
+    frame.extend_from_slice(&Ipv4Addr::new(192, 0, 2, 1).octets());
+    frame.extend_from_slice(&Ipv4Addr::new(192, 0, 2, 2).octets());
+    frame.extend_from_slice(l4);
+    frame
+}
+
+/// Build an untagged IPv6 frame: eth(14) + IPv6 header(40) + `l4` bytes.
+/// `declared_payload_len` is written into the payload_len field (bytes
+/// [4..6]) INDEPENDENTLY of the appended L4, so a short datagram can carry
+/// trailing slack.
+fn v6_frame(next_header: u8, declared_payload_len: u16, l4: &[u8]) -> Vec<u8> {
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&ETH_DST);
+    frame.extend_from_slice(&ETH_SRC);
+    frame.extend_from_slice(&0x86ddu16.to_be_bytes());
+    frame.push(0x60); // version 6
+    frame.extend_from_slice(&[0x00, 0x00, 0x00]); // tc + flow label
+    frame.extend_from_slice(&declared_payload_len.to_be_bytes());
+    frame.push(next_header);
+    frame.push(64); // hop limit
+    frame.extend_from_slice(&[0x20; 16]); // src
+    frame.extend_from_slice(&[0x30; 16]); // dst
+    frame.extend_from_slice(l4);
+    frame
+}
+
+/// 4 TCP/UDP port bytes (src=0x1122, dst=0x3344) the parser must NOT read
+/// when they fall outside the IP-declared packet end.
+const FAKE_PORTS: [u8; 4] = [0x11, 0x22, 0x33, 0x44];
+
+fn v4_meta(protocol: u8) -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        addr_family: libc::AF_INET as u8,
+        protocol,
+        ..UserspaceDpMeta::default()
+    }
+}
+
+fn v6_meta(protocol: u8) -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        addr_family: libc::AF_INET6 as u8,
+        protocol,
+        ..UserspaceDpMeta::default()
+    }
+}
+
+// ---- IPv4 frame-led parser: out-of-declared-length ports -> None ----
+
+#[test]
+fn v4_total_len_ihl_only_with_fake_tcp_ports_returns_none() {
+    // total_len = 20 (IHL only, no L4 in the IP-declared datagram) but the
+    // buffer carries 4 trailing slack bytes that spell tcp/ports. The port
+    // read at l4=l3+20 would land entirely OUTSIDE the IP-declared end
+    // (l3+20) -> must fail closed (None / flowless).
+    let frame = v4_frame(PROTO_TCP, 20, &FAKE_PORTS);
+    assert_eq!(
+        parse_ipv4_session_flow_from_frame(&frame, v4_meta(PROTO_TCP)),
+        None,
+        "ports past the IPv4 total_len must NOT be read as L4"
+    );
+    // The bytes ARE present in the slice — proving the old slice-only bound
+    // would have returned them.
+    assert_eq!(&frame[14 + 20..14 + 24], &FAKE_PORTS);
+}
+
+#[test]
+fn v4_total_len_ihl_plus_two_with_fake_udp_ports_returns_none() {
+    // total_len = 22 => declared end at l3+22, but the 4 UDP port bytes end
+    // at l3+24 > l3+22 -> straddles the IP-declared boundary -> None.
+    let frame = v4_frame(PROTO_UDP, 22, &FAKE_PORTS);
+    assert_eq!(
+        parse_ipv4_session_flow_from_frame(&frame, v4_meta(PROTO_UDP)),
+        None,
+        "ports straddling the IPv4 total_len boundary must fail closed"
+    );
+}
+
+#[test]
+fn v4_well_formed_tcp_parses_ports_normally() {
+    // total_len == actual (20 + 4) so the ports lie INSIDE the declared
+    // datagram. Anti-over-gate: a legitimate packet still classifies.
+    let frame = v4_frame(PROTO_TCP, 24, &[0xab, 0xcd, 0x12, 0x34]);
+    let flow = parse_ipv4_session_flow_from_frame(&frame, v4_meta(PROTO_TCP))
+        .expect("well-formed v4 TCP must parse");
+    assert_eq!(flow.forward_key.src_port, 0xabcd);
+    assert_eq!(flow.forward_key.dst_port, 0x1234);
+}
+
+// ---- IPv6 frame-led parser ----
+
+#[test]
+fn v6_payload_len_zero_with_fake_tcp_ports_returns_none() {
+    // payload_len = 0 => declared end at l3+40, but the slice carries 4
+    // trailing fake port bytes at l3+40. Must fail closed.
+    let frame = v6_frame(PROTO_TCP, 0, &FAKE_PORTS);
+    assert_eq!(
+        parse_session_flow_from_frame(&frame, v6_meta(PROTO_TCP)),
+        None,
+        "ports past the IPv6 payload_len must NOT be read as L4"
+    );
+    assert_eq!(&frame[14 + 40..14 + 44], &FAKE_PORTS);
+}
+
+#[test]
+fn v6_well_formed_udp_parses_ports_normally() {
+    // payload_len == 4 (the 4 UDP port bytes are inside the datagram).
+    let frame = v6_frame(PROTO_UDP, 4, &[0x55, 0x66, 0x77, 0x88]);
+    let flow = parse_session_flow_from_frame(&frame, v6_meta(PROTO_UDP))
+        .expect("well-formed v6 UDP must parse");
+    assert_eq!(flow.forward_key.src_port, 0x5566);
+    assert_eq!(flow.forward_key.dst_port, 0x7788);
+}
+
+// ---- meta-offset fallback (parse_session_flow_from_bytes) ----
+
+#[test]
+fn meta_fallback_v4_short_total_len_returns_none() {
+    // Drive the meta-offset fallback arm: stamp matching IPs (so the meta
+    // fast path's metadata_tuple_complete is satisfied by addresses) but a
+    // protocol that needs ports, with l4 pointing past the declared end.
+    // total_len = 20 (no L4 declared) + trailing fake ports.
+    let frame = v4_frame(PROTO_TCP, 20, &FAKE_PORTS);
+    let meta = UserspaceDpMeta {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        l3_offset: 14,
+        l4_offset: 14 + 20,
+        ..UserspaceDpMeta::default()
+    };
+    assert_eq!(
+        parse_session_flow_from_bytes(&frame, meta),
+        None,
+        "meta-offset fallback must also honor the IPv4 total_len bound"
+    );
+}
+
+#[test]
+fn meta_fallback_v6_short_payload_len_returns_none() {
+    let frame = v6_frame(PROTO_TCP, 0, &FAKE_PORTS);
+    let meta = UserspaceDpMeta {
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        l3_offset: 14,
+        l4_offset: 14 + 40,
+        ..UserspaceDpMeta::default()
+    };
+    assert_eq!(
+        parse_session_flow_from_bytes(&frame, meta),
+        None,
+        "meta-offset fallback must also honor the IPv6 payload_len bound"
+    );
+}
+
+// ---- meta fast path (live_frame_ports_from_meta_bytes / _bytes) ----
+
+#[test]
+fn meta_fast_path_v4_out_of_declared_ports_returns_none() {
+    // #2357-style chokepoint: a meta-stamped l4_offset that points past the
+    // IP-declared end must not yield ports. total_len = 20, fake trailing
+    // ports, l4_offset = l3+20.
+    let frame = v4_frame(PROTO_TCP, 20, &FAKE_PORTS);
+    let meta = ForwardPacketMeta {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        l3_offset: 14,
+        l4_offset: 14 + 20,
+        ..ForwardPacketMeta::default()
+    };
+    assert_eq!(
+        live_frame_ports_from_meta_bytes(&frame, meta),
+        None,
+        "meta fast path must bound the port read by the IPv4 total_len"
+    );
+}
+
+#[test]
+fn meta_fast_path_v4_well_formed_returns_ports() {
+    // Anti-over-gate for the meta fast path.
+    let frame = v4_frame(PROTO_TCP, 24, &[0xab, 0xcd, 0x12, 0x34]);
+    let meta = ForwardPacketMeta {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        l3_offset: 14,
+        l4_offset: 14 + 20,
+        ..ForwardPacketMeta::default()
+    };
+    assert_eq!(
+        live_frame_ports_from_meta_bytes(&frame, meta),
+        Some((0xabcd, 0x1234)),
+        "well-formed meta fast path still returns ports"
+    );
+}
+
+#[test]
+fn live_frame_ports_bytes_v6_out_of_declared_returns_none() {
+    // Byte-led variant (no usable meta l4): re-derives l3 + declared end
+    // from the frame and must still fail closed.
+    let frame = v6_frame(PROTO_TCP, 0, &FAKE_PORTS);
+    assert_eq!(
+        live_frame_ports_bytes(&frame, libc::AF_INET6 as u8, PROTO_TCP),
+        None,
+        "byte-led meta path must bound by the IPv6 payload_len"
+    );
+}
+
+// ---- declared-end helper unit truth ----
+
+#[test]
+fn declared_end_helpers_clamp_to_slice_and_floor() {
+    // v4: total_len declares MORE than the slice -> clamp to slice len.
+    let frame = v4_frame(PROTO_TCP, 1500, &FAKE_PORTS); // slice = 14+20+4=38
+    assert_eq!(ipv4_declared_l3_end(&frame, 14), Some(frame.len()));
+    // v4: total_len below ihl floors at l3+ihl (l3+20).
+    let frame2 = v4_frame(PROTO_TCP, 10, &FAKE_PORTS);
+    assert_eq!(ipv4_declared_l3_end(&frame2, 14), Some(14 + 20));
+    // v6: payload_len declares more than the slice -> clamp to slice.
+    let frame3 = v6_frame(PROTO_TCP, 1000, &FAKE_PORTS);
+    assert_eq!(ipv6_declared_l3_end(&frame3, 14), Some(frame3.len()));
+}

--- a/userspace-dp/src/afxdp/frame/prop_tests/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/inspect.rs
@@ -18,7 +18,7 @@ fn call_all_parsers(frame: &[u8], meta: UserspaceDpMeta, l4_probe: usize) {
     let _ = frame_l4_offset(frame, meta.addr_family);
     let _ = packet_rel_l4_offset(frame, meta.addr_family);
     let _ = packet_rel_l4_offset_and_protocol(frame, meta.addr_family);
-    let _ = parse_flow_ports(frame, l4_probe, meta.protocol);
+    let _ = parse_flow_ports(frame, l4_probe, meta.protocol, frame.len());
     let _ = parse_session_flow_from_bytes(frame, meta);
     let _ = parse_session_flow_from_frame(frame, meta);
     let _ = parse_ipv4_session_flow_from_frame(frame, meta);


### PR DESCRIPTION
Closes #2361

## Problem

The live AF_XDP frame parser (`userspace-dp/src/afxdp/frame/inspect.rs`) read
L4 ports bounded **only** by the backing slice length and the non-first-fragment
gate (#2344) — **never** by the IPv4 `total_len` / IPv6 `payload_len`. A frame
whose IP header declares a short datagram but carries trailing slack (NIC
zero-pad on a sub-60-byte minimum frame, or attacker-supplied bytes) had its
TCP/UDP "ports" read from out-of-datagram bytes. Those phantom ports then drove
port-based security policy, firewall-filter matching, CoS queue selection, and
session installation — both falsely matching a permissive port term and evading
a port-scoped deny. HIGH severity (codex review-026 finding 1).

## Bound: before vs after

**Before** — `parse_flow_ports` read `frame[l4..l4+4]` bounded only by the slice:
```rust
let bytes = frame.get(l4..l4 + 4)?;   // slice-only
```

**After** — the read must lie within the IP-declared packet end:
```rust
let end = l4.checked_add(4)?;
if end > declared_end { return None; }   // declared_end = min(l3+ip_len, frame.len())
let bytes = frame.get(l4..end)?;
```
where `declared_end` comes from new helpers:
- `ipv4_declared_l3_end` = `(l3 + total_len).clamp(l3+ihl, frame.len())`
- `ipv6_declared_l3_end` = `(l3 + 40 + payload_len).clamp(l3+40, frame.len())`

A violation returns `None` → flowless, route-based session-less forward (the
same behavior #2344 uses for non-first fragments). The slice clamp also fails
closed on a truncated capture (slice shorter than declared length).

## Consistency with the generated path (#2321/#2238)

The sibling generated-reply parser already enforced this exact invariant as a
fail-closed security boundary in `generated.rs::generated_l4_ports`, clamping to
`total_len` / `40+payload_len` (`pkt_len`) before extracting ports and returning
`None` when the 4 port bytes fall outside the IP-declared end "even when the
backing buffer still has trailing slack bytes." This PR mirrors that idiom so
the **live ingress path and the generated path now treat an out-of-IP-bound L4
identically**.

## Meta path

Gated too. The XDP shim stamps `meta.l4_offset` but does NOT enforce the
IP-declared bound, so `live_frame_ports_from_meta_bytes` / `live_frame_ports_bytes`
re-derive `declared_end` from the L3 header in the frame before reading ports
(mirroring #2357's meta-fast-path chokepoint concern). All live callers updated:
v4/v6 frame-led parsers, the meta-offset fallback in
`parse_session_flow_from_bytes`, and both meta fast-path readers.

## Tests (fail-on-revert)

`inspect_tests.rs`, 11 new tests:
- `v4_total_len_ihl_only_with_fake_tcp_ports_returns_none`
- `v4_total_len_ihl_plus_two_with_fake_udp_ports_returns_none`
- `v6_payload_len_zero_with_fake_tcp_ports_returns_none`
- `meta_fallback_v4_short_total_len_returns_none` / `meta_fallback_v6_short_payload_len_returns_none`
- `meta_fast_path_v4_out_of_declared_ports_returns_none`
- `live_frame_ports_bytes_v6_out_of_declared_returns_none`
- `declared_end_helpers_clamp_to_slice_and_floor`
- anti-over-gate: `v4_well_formed_tcp_parses_ports_normally`, `v6_well_formed_udp_parses_ports_normally`, `meta_fast_path_v4_well_formed_returns_ports`

**7 of the 11 fail when the bound is reverted to slice-only** (verified). New
tests 5x green; `cargo build --release` clean; full suite green (one unrelated
pre-existing `worker_queue` concurrency flake, passes 3/3 in isolation).

No wire field changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi