### PR TITLE
#2362: wire dropped firewall-filter match terms (tcp-flags/is-fragment/icmp-type/icmp-code) end-to-end

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -10952,3 +10952,55 @@ top.
     userspace-dp/src/afxdp/worker/loop_body/mod.rs,
     userspace-dp/tests/fixtures/protocol_wire_v1.json,
     userspace-dp/src/filter/README.md, docs/feature-gaps.md, _Log.md
+
+- **Timestamp**: 2026-06-22 (review folds)
+  - **Action**: #2362 PR #2373 review folds A + B (hostile reviewer + Copilot).
+    FOLD A (security, #2344 class): term_match_extra_from_frame read tcp_flags /
+    icmp_type / icmp_code from meta/l4_offset for ANY packet — but a NON-FIRST
+    fragment has no L4 header there (payload bytes), so a crafted fragment whose
+    payload byte == a filter icmp-type (or payload-derived meta.tcp_flags)
+    spuriously matched, contradicting the matching.rs doc contract. Fix: gate the
+    L4-derived inputs on the EXISTING is_non_first_fragment predicate (reused, not
+    re-written) — force tcp_flags=icmp_type=icmp_code=0 for a non-first fragment
+    while KEEPING is_fragment=is_any_fragment (a non-first fragment IS a fragment;
+    is-fragment reads only the L3 header). FOLD B (CoS/TX-selection leg): the
+    tx_selection.rs v4/v6 evaluators hardcoded TermMatchExtra::default(), so
+    `from { tcp-flags syn } then forwarding-class X` reached the CoS path and
+    never matched the per-packet condition (silent under-match — the same bug on
+    the CoS leg). Fix: thread real TermMatchExtra through
+    resolve_cos_tx_selection/_at/_internal -> the tx_selection evaluators, built
+    from the live frame at forward_request.rs (transit), classify_generated_reply
+    (own bytes), neighbor_dispatch (buffered transit frame), inject (control
+    frame); meta-only extra at the no-frame paths (resolve_cos_queue_id, tunnel
+    local-origin, generated ICMP-PTB). Added PendingForwardRequest.filter_match_extra
+    so the DEFERRED dispatch recompute consumes the build-time snapshot (UMEM frame
+    may be recycled). The flow-cache decline (FOLD already shipped) keeps the
+    precomputed TX descriptor from being built for per-packet-L4 filters, so the
+    cached tx_selection path (cache_sensitive.rs Default) is unreachable for them.
+    Added two ForwardPacketMeta builders (term_match_extra_from_frame_fwd,
+    term_match_extra_from_meta) in inspect.rs. Tests: FOLD A — non-first ICMP/TCP
+    fragment suppresses icmp-type/tcp-flags but keeps is-fragment; first fragment
+    keeps L4 fields (frame/tests.rs). FOLD B — `tcp-flags syn then
+    forwarding-class ef` selects EF queue only for SYN, not pure-ACK
+    (cos_classify_tests.rs). cargo build --release clean; filter/tcp_flags/
+    fragment/icmp/tx_selection/cos suites green; new tests 5x; protocol_wire_v1.json
+    UNCHANGED (filter_match_extra is internal, not serialized). Two pre-existing
+    full-suite concurrency flakes (umem tx_latency_hist, worker_queue
+    concurrent_recovery) pass in isolation — untouched code.
+  - **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+    userspace-dp/src/afxdp/frame/mod.rs,
+    userspace-dp/src/afxdp/frame/tests.rs,
+    userspace-dp/src/filter/engine/tx_selection.rs,
+    userspace-dp/src/afxdp/tx/cos_classify.rs,
+    userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+    userspace-dp/src/afxdp/tx/dispatch/cos.rs,
+    userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs,
+    userspace-dp/src/afxdp/types/tx.rs,
+    userspace-dp/src/afxdp/forward_request.rs,
+    userspace-dp/src/afxdp/neighbor_dispatch.rs,
+    userspace-dp/src/afxdp/tunnel.rs, userspace-dp/src/afxdp/icmp.rs,
+    userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+    userspace-dp/src/afxdp/coordinator/inject.rs,
+    userspace-dp/src/afxdp/forwarding_build/tests.rs,
+    userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md,
+    docs/feature-gaps.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -11004,3 +11004,39 @@ top.
     userspace-dp/src/afxdp/forwarding_build/tests.rs,
     userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md,
     docs/feature-gaps.md, _Log.md
+
+- **Timestamp**: 2026-06-22 (fold A correction)
+  - **Action**: #2362 PR #2373 — Copilot caught that FOLD A's "force the L4
+    byte to 0 for a non-first fragment" guard was insufficient: 0 is a VALID
+    icmp-type (echo-reply) and a VALID icmp-code, so a non-first fragment with
+    forced icmp_type=0 STILL spuriously matched `from { icmp-type 0 }` /
+    `from { icmp-code 0 }` — the matching.rs contract was still violated.
+    (tcp-flags was fine: a real term has a non-zero mask and (0 & mask)==mask is
+    false.) Fix: replace the value-sentinel with an explicit l4_present:bool on
+    TermMatchExtra — true normally, FALSE for a non-first fragment (set in both
+    term_match_extra_from_frame and term_match_extra_from_frame_fwd via
+    is_non_first_fragment) and the meta-only builder sets it TRUE (synthetic
+    packets have an L4 header, never fragments). per_packet_l4_matches now
+    requires extra.l4_present for the tcp-flags AND icmp-type AND icmp-code
+    constraints (return false if !l4_present); is_fragment stays UNGATED
+    (L3-derived). Default(l4_present=false) fails closed — safe for the
+    cached/tx-rebuild Default paths (unreachable for L4 filters anyway). Kept the
+    byte-zeroing as defense-in-depth. Updated existing test extras that represent
+    real packets to set l4_present:true (extra_tcp helper + icmp literals + the
+    FOLD B SYN/ACK). New fail-on-revert tests: a non-first fragment (l4_present
+    false, byte 0, is_fragment true) does NOT match `icmp-type 0` NOR
+    `icmp-code 0` but STILL matches `is-fragment`; a real echo-reply (type 0,
+    l4_present true) DOES match `icmp-type 0` (anti-over-gate). Builder tests now
+    assert l4_present false (non-first) / true (first). cargo build --release
+    clean; filter/icmp/fragment/tcp_flags/matching/tx_selection/cos suites green;
+    full suite green (no failures this run); new tests 5x; protocol_wire_v1.json
+    UNCHANGED (l4_present is internal). matching.rs doc + feature-gaps.md +
+    filter/README.md updated to describe the l4_present gate (not the byte
+    sentinel).
+  - **File(s)**: userspace-dp/src/filter/mod.rs,
+    userspace-dp/src/filter/engine/matching.rs,
+    userspace-dp/src/afxdp/frame/inspect.rs,
+    userspace-dp/src/afxdp/frame/tests.rs,
+    userspace-dp/src/filter/tests.rs,
+    userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+    userspace-dp/src/filter/README.md, docs/feature-gaps.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -10897,3 +10897,58 @@ top.
     userspace-dp/src/afxdp/poll_descriptor/mod.rs,
     userspace-dp/src/afxdp/tests.rs, docs/feature-gaps.md,
     docs/cos-validation-notes.md, _Log.md
+
+- **Timestamp**: 2026-06-22
+  - **Action**: #2362 — wire the 4 dropped firewall-filter per-packet L4 match
+    terms (tcp-flags / is-fragment / icmp-type / icmp-code) end-to-end to the
+    userspace dataplane. ALL FOUR were parsed by the Go compiler into
+    config.FirewallFilterTerm and claimed in feature-gaps.md, but DROPPED on the
+    Go->Rust snapshot wire and absent from the Rust matcher, so a term like
+    `from { tcp-flags syn; } then discard` silently matched ALL TCP (broader than
+    authored — security-relevant). Fix: added explicit wire fields
+    (tcp_flags:Option<u8> required-bits mask, is_fragment:bool, icmp_type/code:
+    Option<u8>) to FirewallTermSnapshot on BOTH sides with matching serde tags;
+    Go filters.go folds the parsed flag-name list to a mask (tcpFlagsMask) and
+    serializes the rest; Rust runtime FilterTerm carries the 4 fields, evaluated
+    per packet in engine::matching::per_packet_l4_matches (non-TCP never matches
+    tcp-flags; non-ICMP never matches icmp-type/code; is-fragment uses the new
+    is_any_fragment predicate = IPv4 MF|offset, IPv6 frag header). Threaded a
+    Copy TermMatchExtra (built once per packet at the cold filter-eval call sites
+    from frame+meta) through eval.rs/matching.rs; cached/tx-selection paths pass
+    Default (unreachable for these filters due to the cache decline). Cache-
+    sensitivity (path b, #1431): new has_per_packet_l4_match_terms aggregate +
+    iface_filter_v{4,6}_has_per_packet_l4_match sets + flow-cache decline gate
+    (flow_cache.rs) + on-session re-eval gate + config-rotation purge (folded
+    into the existing dscp purge). Regenerated protocol_wire_v1.json. Tests:
+    Go snapshot+mask-helper (filters_per_packet_match_2362_test.go); Rust match-
+    eval per term (v4+v6, match/no-match/wrong-proto), count side-effect, cache-
+    sensitive flag, wire round-trip, flow-cache decline (input+output), and
+    is_any_fragment truth tables. go build+test green; cargo build --release +
+    full test suite (2468) green; new tests 5x stable. Docs: filter/README.md
+    (future->implemented rows), feature-gaps.md (#2362 wiring + grammar limits).
+    Limitation noted: parser yields a flat flag list, so the richer
+    `(syn & !ack)` expression grammar and named icmp-type aliases are out of
+    scope (parser limitation, not dataplane).
+  - **File(s)**: pkg/dataplane/userspace/protocol.go,
+    pkg/dataplane/userspace/filters.go,
+    pkg/dataplane/userspace/filters_per_packet_match_2362_test.go,
+    userspace-dp/src/protocol/security.rs, userspace-dp/src/filter/mod.rs,
+    userspace-dp/src/filter/compiler.rs,
+    userspace-dp/src/filter/engine/mod.rs,
+    userspace-dp/src/filter/engine/matching.rs,
+    userspace-dp/src/filter/engine/eval.rs,
+    userspace-dp/src/filter/engine/cache_sensitive.rs,
+    userspace-dp/src/filter/engine/tx_selection.rs,
+    userspace-dp/src/filter/tests.rs,
+    userspace-dp/src/afxdp/frame/inspect.rs,
+    userspace-dp/src/afxdp/frame/mod.rs,
+    userspace-dp/src/afxdp/frame/tests.rs,
+    userspace-dp/src/afxdp/flow_cache.rs,
+    userspace-dp/src/afxdp/flow_cache_tests.rs,
+    userspace-dp/src/afxdp/poll_descriptor/filter.rs,
+    userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+    userspace-dp/src/afxdp/forwarding/mod.rs,
+    userspace-dp/src/afxdp/session_glue/tests.rs,
+    userspace-dp/src/afxdp/worker/loop_body/mod.rs,
+    userspace-dp/tests/fixtures/protocol_wire_v1.json,
+    userspace-dp/src/filter/README.md, docs/feature-gaps.md, _Log.md

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -379,6 +379,29 @@ the commit-check gate INLINE-mirrors the `appid.ProtocolNumber` acceptance set
 (it cannot import `appid` — an import cycle); a `pkg/appid` drift-guard test
 pins the two together so the duplicated table cannot diverge silently.
 
+The per-packet L4 match conditions — `tcp-flags`, `is-fragment`, `icmp-type`,
+`icmp-code` — are wired end-to-end to the userspace dataplane (#2362). Earlier
+they were parsed into `config.FirewallFilterTerm` and counted in this list but
+silently DROPPED on the snapshot wire, so a term like `from { tcp-flags syn; }
+then discard` matched broader than authored (discard-all-TCP). They are now
+serialized as explicit `FirewallTermSnapshot` wire fields
+(`tcp_flags`/`is_fragment`/`icmp_type`/`icmp_code`, mirrored in
+`userspace-dp/src/protocol/security.rs`) and evaluated per packet by the Rust
+matcher (`filter::engine::matching::per_packet_l4_matches`). Because none of
+these are part of the 5-tuple `SessionKey`, a filter carrying any of them is
+cache-sensitive (path (b) of the #1431 runbook): the flow-cache declines, the
+on-session decision is re-evaluated per packet, and a config rotation purges the
+affected sessions. Semantics: `tcp-flags <list>` requires ALL listed flags set
+(a non-TCP packet never matches); `is-fragment` matches any IP fragment (IPv4 MF
+set OR non-zero offset; IPv6 fragment header present); `icmp-type`/`icmp-code`
+match the ICMP/ICMPv6 type/code bytes (a non-ICMP packet never matches).
+Limitation: the parser produces a flat flag-name list, so the richer Junos
+`tcp-flags "(syn & !ack)"` expression grammar (negation/disjunction/aliases like
+`tcp-established`) is not representable — only a conjunction of named flags is
+supported; an unrecognized token yields no constraint rather than a match-all.
+Named `icmp-type`/`icmp-code` aliases (e.g. `echo-request`) are likewise not
+parsed — numeric values only.
+
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
 | **Policer (Rate Limiting)** | `firewall policer ... bandwidth-limit N burst-size-limit N` | Token-bucket rate limiter applied to filter terms or interfaces. Single-rate two-color, three-color policers. | High | Partial for #1373: legacy eBPF/~~DPDK~~ (DPDK retired #1525) token-bucket policer support existed; userspace supports the admitted filter path and the color-blind `then discard` three-color slice. #1375 is closed; unsupported color-aware/non-drop behavior and broader Junos parity remain production/future parity work, not active #1373 source-removal blockers. |

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -391,7 +391,18 @@ matcher (`filter::engine::matching::per_packet_l4_matches`). Because none of
 these are part of the 5-tuple `SessionKey`, a filter carrying any of them is
 cache-sensitive (path (b) of the #1431 runbook): the flow-cache declines, the
 on-session decision is re-evaluated per packet, and a config rotation purges the
-affected sessions. Semantics: `tcp-flags <list>` requires ALL listed flags set
+affected sessions. This holds on BOTH the input/output forwarding-filter leg and
+the CoS / TX-selection leg (`from { tcp-flags syn; } then forwarding-class X`):
+the TX-selection evaluators thread the same per-packet inputs, so a CoS action
+gated on a per-packet condition selects the class only on the matching packets
+of a flow, not all of them (the flow-cache decline keeps the precomputed
+TX-selection descriptor from being built for such filters). Fragment safety: the
+match inputs are built fragment-safe — a NON-FIRST fragment carries no L4 header
+at the post-IP offset (its bytes are payload), so the tcp-flags / icmp-type /
+icmp-code inputs are forced to 0 for it (those terms fail closed) while the
+L3-derived `is-fragment` bit stays true; this prevents a crafted fragment whose
+payload byte equals a filter's `icmp-type` from spuriously matching (the #2344
+non-first-fragment class). Semantics: `tcp-flags <list>` requires ALL listed flags set
 (a non-TCP packet never matches); `is-fragment` matches any IP fragment (IPv4 MF
 set OR non-zero offset; IPv6 fragment header present); `icmp-type`/`icmp-code`
 match the ICMP/ICMPv6 type/code bytes (a non-ICMP packet never matches).

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -398,11 +398,16 @@ gated on a per-packet condition selects the class only on the matching packets
 of a flow, not all of them (the flow-cache decline keeps the precomputed
 TX-selection descriptor from being built for such filters). Fragment safety: the
 match inputs are built fragment-safe — a NON-FIRST fragment carries no L4 header
-at the post-IP offset (its bytes are payload), so the tcp-flags / icmp-type /
-icmp-code inputs are forced to 0 for it (those terms fail closed) while the
-L3-derived `is-fragment` bit stays true; this prevents a crafted fragment whose
-payload byte equals a filter's `icmp-type` from spuriously matching (the #2344
-non-first-fragment class). Semantics: `tcp-flags <list>` requires ALL listed flags set
+at the post-IP offset (its bytes are payload), so the per-packet match inputs
+carry an explicit `l4_present = false` flag for it and the matcher gates the
+tcp-flags / icmp-type / icmp-code constraints on that flag (NOT on the byte
+value). Keying off the value alone is insufficient: 0 is a VALID icmp-type
+(echo-reply) and a VALID icmp-code, so a zeroed byte would still spuriously match
+`from { icmp-type 0 }` / `from { icmp-code 0 }`. The L3-derived `is-fragment` bit
+is NOT gated by `l4_present` and stays true (a non-first fragment IS a fragment).
+This prevents a crafted fragment whose payload byte equals a filter's
+`icmp-type`/`icmp-code` from spuriously matching (the #2344 non-first-fragment
+class). Semantics: `tcp-flags <list>` requires ALL listed flags set
 (a non-TCP packet never matches); `is-fragment` matches any IP fragment (IPv4 MF
 set OR non-zero offset; IPv6 fragment header present); `icmp-type`/`icmp-code`
 match the ICMP/ICMPv6 type/code bytes (a non-ICMP packet never matches).

--- a/pkg/dataplane/userspace/filters.go
+++ b/pkg/dataplane/userspace/filters.go
@@ -107,9 +107,62 @@ func buildFilterTermSnapshots(filter *config.FirewallFilter, cfg *config.Config)
 				snap.DSCPRewrite = &rewrite
 			}
 		}
+		// Per-packet L4 match conditions (#2362). Previously parsed but
+		// dropped on the wire — wire them through so the dataplane matches
+		// exactly what the operator authored.
+		if mask, ok := tcpFlagsMask(term.TCPFlags); ok {
+			m := mask
+			snap.TCPFlags = &m
+		}
+		snap.IsFragment = term.IsFragment
+		// The typed config uses -1 for "not set"; only serialize a valid
+		// in-range byte. Junos icmp-type/icmp-code are 0..255.
+		if term.ICMPType >= 0 && term.ICMPType <= 255 {
+			t := uint8(term.ICMPType)
+			snap.ICMPType = &t
+		}
+		if term.ICMPCode >= 0 && term.ICMPCode <= 255 {
+			c := uint8(term.ICMPCode)
+			snap.ICMPCode = &c
+		}
 		terms = append(terms, snap)
 	}
 	return terms
+}
+
+// tcpFlagsBits maps Junos TCP-flag names to their bit value in the TCP flags
+// byte. Junos also accepts aliases (e.g. `syn`, `ack`); only the literal flag
+// names the firewall-filter compiler emits as a flat list are supported here —
+// the parser does not produce the richer `(syn & !ack)` expression grammar, so
+// no negation/disjunction is representable (a parser limitation, tracked
+// separately). Bit order matches userspace-dp/src/tcp_flags.rs.
+var tcpFlagsBits = map[string]uint8{
+	"fin": 0x01,
+	"syn": 0x02,
+	"rst": 0x04,
+	"psh": 0x08,
+	"ack": 0x10,
+	"urg": 0x20,
+}
+
+// tcpFlagsMask folds a parsed flag-name list into a required-bits mask. A TCP
+// packet matches the term when (flags & mask) == mask (all listed flags set).
+// Returns ok=false when the list is empty or contains no recognized flag name,
+// so the wire field stays nil (no tcp-flags constraint) rather than a 0 mask
+// that would match every packet.
+func tcpFlagsMask(flags []string) (uint8, bool) {
+	var mask uint8
+	matched := false
+	for _, f := range flags {
+		if bit, ok := tcpFlagsBits[strings.ToLower(strings.TrimSpace(f))]; ok {
+			mask |= bit
+			matched = true
+		}
+	}
+	if !matched {
+		return 0, false
+	}
+	return mask, true
 }
 
 func buildPolicerSnapshots(cfg *config.Config) []PolicerSnapshot {

--- a/pkg/dataplane/userspace/filters_per_packet_match_2362_test.go
+++ b/pkg/dataplane/userspace/filters_per_packet_match_2362_test.go
@@ -1,0 +1,160 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2362: the firewall-filter compiler parses tcp-flags / is-fragment /
+// icmp-type / icmp-code into config.FirewallFilterTerm, but the userspace
+// snapshot builder previously dropped all four — so a term like
+// `from { tcp-flags syn; }` silently matched broader than authored
+// (discard-all-TCP instead of discard-SYN). These tests fail on the pre-fix
+// builder (the fields never reach FirewallTermSnapshot) and pass after the
+// wire-through fix.
+
+// perPacketMatchCfg builds a config with one inet filter whose single term
+// carries all four per-packet L4 match conditions.
+func perPacketMatchCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"edge": {
+			Name: "edge",
+			Terms: []*config.FirewallFilterTerm{
+				{
+					Name:       "syn-only",
+					Protocol:   "tcp",
+					TCPFlags:   []string{"syn"},
+					IsFragment: false,
+					ICMPType:   -1,
+					ICMPCode:   -1,
+					Action:     "discard",
+				},
+			},
+		},
+	}
+	return cfg
+}
+
+func TestFilterSnapshotTCPFlagsSerialized(t *testing.T) {
+	snaps := buildFirewallFilterSnapshots(perPacketMatchCfg())
+	if len(snaps) != 1 || len(snaps[0].Terms) != 1 {
+		t.Fatalf("expected 1 filter with 1 term, got %#v", snaps)
+	}
+	term := snaps[0].Terms[0]
+	if term.TCPFlags == nil {
+		t.Fatal("tcp-flags syn was dropped from the snapshot (#2362)")
+	}
+	// SYN == 0x02; the mask must require exactly the SYN bit.
+	if *term.TCPFlags != 0x02 {
+		t.Errorf("tcp_flags mask = 0x%02x, want 0x02 (SYN)", *term.TCPFlags)
+	}
+}
+
+func TestFilterSnapshotTCPFlagsMultipleAreAnded(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"f": {Name: "f", Terms: []*config.FirewallFilterTerm{{
+			Name: "t", Protocol: "tcp", TCPFlags: []string{"syn", "ack"},
+			ICMPType: -1, ICMPCode: -1, Action: "discard",
+		}}},
+	}
+	snaps := buildFirewallFilterSnapshots(cfg)
+	term := snaps[0].Terms[0]
+	if term.TCPFlags == nil {
+		t.Fatal("tcp-flags dropped")
+	}
+	// SYN(0x02) | ACK(0x10) == 0x12.
+	if *term.TCPFlags != 0x12 {
+		t.Errorf("tcp_flags mask = 0x%02x, want 0x12 (SYN|ACK)", *term.TCPFlags)
+	}
+}
+
+func TestFilterSnapshotTCPFlagsUnknownYieldsNil(t *testing.T) {
+	// The parser can store the unsupported expression form (e.g. the literal
+	// "(syn & !ack)") as a single token. It is not a recognized flag name, so
+	// the mask must stay nil (no constraint) rather than 0 (matches all).
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"f": {Name: "f", Terms: []*config.FirewallFilterTerm{{
+			Name: "t", Protocol: "tcp", TCPFlags: []string{"(syn & !ack)"},
+			ICMPType: -1, ICMPCode: -1, Action: "discard",
+		}}},
+	}
+	snaps := buildFirewallFilterSnapshots(cfg)
+	if got := snaps[0].Terms[0].TCPFlags; got != nil {
+		t.Errorf("unrecognized tcp-flags expression should yield nil mask, got 0x%02x", *got)
+	}
+}
+
+func TestFilterSnapshotIsFragmentSerialized(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"f": {Name: "f", Terms: []*config.FirewallFilterTerm{{
+			Name: "t", IsFragment: true, ICMPType: -1, ICMPCode: -1, Action: "discard",
+		}}},
+	}
+	snaps := buildFirewallFilterSnapshots(cfg)
+	if !snaps[0].Terms[0].IsFragment {
+		t.Error("is-fragment was dropped from the snapshot (#2362)")
+	}
+}
+
+func TestFilterSnapshotICMPTypeCodeSerialized(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"f": {Name: "f", Terms: []*config.FirewallFilterTerm{{
+			Name: "t", Protocol: "icmp", ICMPType: 8, ICMPCode: 0, Action: "discard",
+		}}},
+	}
+	snaps := buildFirewallFilterSnapshots(cfg)
+	term := snaps[0].Terms[0]
+	if term.ICMPType == nil || *term.ICMPType != 8 {
+		t.Errorf("icmp-type = %v, want 8 (echo-request) (#2362)", term.ICMPType)
+	}
+	if term.ICMPCode == nil || *term.ICMPCode != 0 {
+		t.Errorf("icmp-code = %v, want 0 (#2362)", term.ICMPCode)
+	}
+}
+
+func TestFilterSnapshotICMPUnsetStaysNil(t *testing.T) {
+	// The compiler uses -1 for "not set"; an unset icmp-type/code must not
+	// serialize a bogus 0 constraint.
+	cfg := &config.Config{}
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"f": {Name: "f", Terms: []*config.FirewallFilterTerm{{
+			Name: "t", Protocol: "tcp", ICMPType: -1, ICMPCode: -1, Action: "accept",
+		}}},
+	}
+	snaps := buildFirewallFilterSnapshots(cfg)
+	term := snaps[0].Terms[0]
+	if term.ICMPType != nil {
+		t.Errorf("unset icmp-type should be nil, got %d", *term.ICMPType)
+	}
+	if term.ICMPCode != nil {
+		t.Errorf("unset icmp-code should be nil, got %d", *term.ICMPCode)
+	}
+}
+
+func TestTCPFlagsMaskHelper(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want uint8
+		ok   bool
+	}{
+		{nil, 0, false},
+		{[]string{}, 0, false},
+		{[]string{"syn"}, 0x02, true},
+		{[]string{"SYN"}, 0x02, true},
+		{[]string{"fin", "syn", "rst", "psh", "ack", "urg"}, 0x3f, true},
+		{[]string{"bogus"}, 0, false},
+		{[]string{"syn", "bogus"}, 0x02, true},
+	}
+	for _, c := range cases {
+		got, ok := tcpFlagsMask(c.in)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("tcpFlagsMask(%v) = (0x%02x, %v), want (0x%02x, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -490,6 +490,25 @@ type FirewallTermSnapshot struct {
 	RoutingInstance string        `json:"routing_instance,omitempty"`
 	ForwardingClass string        `json:"forwarding_class,omitempty"`
 	DSCPRewrite     *uint8        `json:"dscp_rewrite,omitempty"`
+	// Per-packet L4 match conditions (#2362). These are parsed by the Junos
+	// firewall-filter compiler but were previously dropped on the wire, so a
+	// term like `from { tcp-flags syn; }` silently matched broader than
+	// authored. They are NOT part of the 5-tuple SessionKey, so a filter
+	// carrying any of them is cache-sensitive (flow-cache must decline — see
+	// the #1431 invariant in userspace-dp/src/filter/mod.rs).
+	//
+	// TCPFlags is a required-bits mask over the TCP flags byte (FIN=0x01,
+	// SYN=0x02, RST=0x04, PSH=0x08, ACK=0x10, URG=0x20): a TCP packet matches
+	// when (flags & mask) == mask. Nil = no tcp-flags constraint. A non-TCP
+	// packet never matches a term that sets this.
+	TCPFlags *uint8 `json:"tcp_flags,omitempty"`
+	// IsFragment matches any IP fragment (IPv4 MF set OR non-zero offset; IPv6
+	// fragment extension header present). False = no fragment constraint.
+	IsFragment bool `json:"is_fragment,omitempty"`
+	// ICMPType / ICMPCode match the ICMP/ICMPv6 type and code bytes. Nil = no
+	// constraint. A non-ICMP(v6) packet never matches a term that sets these.
+	ICMPType *uint8 `json:"icmp_type,omitempty"`
+	ICMPCode *uint8 `json:"icmp_code,omitempty"`
 }
 
 type PolicerSnapshot struct {

--- a/userspace-dp/src/afxdp/coordinator/inject.rs
+++ b/userspace-dp/src/afxdp/coordinator/inject.rs
@@ -218,11 +218,17 @@ impl super::Coordinator {
                         stamp_injected_packet_tuple(&mut tx_meta, frame.len(), tuple, egress)?;
                         let now_ns = monotonic_nanos();
                         let cos_flow = parse_session_flow_from_meta(tx_meta);
+                        // #2362 fold B: classify the injected control packet on
+                        // its own stamped tuple — the frame + stamped meta give
+                        // the fragment-safe per-packet match inputs.
+                        let cos_extra =
+                            crate::afxdp::frame::term_match_extra_from_frame(&frame, tx_meta);
                         let cos = resolve_cos_tx_selection_at(
                             &self.forwarding,
                             resolution.egress_ifindex,
                             tx_meta,
                             cos_flow.as_ref().map(|flow| &flow.forward_key),
+                            cos_extra,
                             now_ns,
                         );
                         if cos.drop {

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -316,6 +316,26 @@ impl FlowCacheEntry {
         ) {
             return None;
         }
+        // #2362: same coherency hazard for per-packet L4 match terms
+        // (tcp-flags / is-fragment / icmp-type / icmp-code). They are not in
+        // the 5-tuple flow-cache key and vary per packet within a flow, so a
+        // cached first-packet decision must not be replayed. Decline the cache
+        // whenever the ingress input filter or the resolved egress output
+        // filter carries such a term.
+        if crate::filter::interface_input_filter_has_per_packet_l4_match(
+            &forwarding.filter_state,
+            ingress_ifindex,
+            is_v6,
+        ) {
+            return None;
+        }
+        if crate::filter::interface_output_filter_has_per_packet_l4_match(
+            &forwarding.filter_state,
+            decision.resolution.egress_ifindex,
+            is_v6,
+        ) {
+            return None;
+        }
         // Keep cache invalidation tied to the flow owner RG, not the current
         // fabric parent ifindex. During split-RG operation a live flow can
         // temporarily resolve to FabricRedirect, but failback must still evict

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -156,12 +156,16 @@ fn cache_hit_accumulates_observed_bytes() {
         config_generation: 5,
         fib_generation: 3,
     };
-    assert!(cache
-        .lookup_counted(&key, lookup, 0, &rg_epochs, 1500)
-        .is_some());
-    assert!(cache
-        .lookup_counted(&key, lookup, 0, &rg_epochs, 900)
-        .is_some());
+    assert!(
+        cache
+            .lookup_counted(&key, lookup, 0, &rg_epochs, 1500)
+            .is_some()
+    );
+    assert!(
+        cache
+            .lookup_counted(&key, lookup, 0, &rg_epochs, 900)
+            .is_some()
+    );
 
     let (_active_count, rows, _cos_counts, _truncated) = cache.active_flow_debug_entries(8);
     assert_eq!(rows.len(), 1);
@@ -743,6 +747,106 @@ fn from_forward_decision_skips_cache_for_dscp_matched_input_filter() {
     );
 }
 
+// #2362: a per-packet L4 (tcp-flags / is-fragment / icmp-type / icmp-code)
+// input filter must decline the flow-cache for the same reason DSCP does —
+// the condition varies per packet within a 5-tuple flow.
+#[test]
+fn from_forward_decision_skips_cache_for_per_packet_l4_input_filter() {
+    let rg_epochs = default_rg_epochs();
+    let (flow, meta, validation, decision, mut forwarding, ha_state) = make_v4_round_trip_inputs();
+    forwarding.filter_state = crate::filter::parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "lan-drop-syn".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-syn".into(),
+                protocols: vec!["tcp".into()],
+                action: "discard".into(),
+                tcp_flags: Some(0x02),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[InterfaceSnapshot {
+            name: "reth1.0".into(),
+            ifindex: meta.ingress_ifindex as i32,
+            filter_input_v4: "lan-drop-syn".into(),
+            ..Default::default()
+        }],
+        "",
+        "",
+    );
+
+    let entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(TEST_TRUST_ZONE_ID),
+        Some(7),
+        None,
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+    );
+
+    assert!(
+        entry.is_none(),
+        "tcp-flags-matched input filters depend on per-packet state outside \
+         the flow-cache key (#2362)",
+    );
+}
+
+#[test]
+fn from_forward_decision_skips_cache_for_per_packet_l4_output_filter() {
+    let rg_epochs = default_rg_epochs();
+    let (flow, meta, validation, decision, mut forwarding, ha_state) = make_v4_round_trip_inputs();
+    forwarding.filter_state = crate::filter::parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "wan-drop-frag".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-frag".into(),
+                action: "discard".into(),
+                is_fragment: true,
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: decision.resolution.egress_ifindex,
+            filter_output_v4: "wan-drop-frag".into(),
+            ..Default::default()
+        }],
+        "",
+        "",
+    );
+
+    let entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(TEST_TRUST_ZONE_ID),
+        Some(7),
+        None,
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+    );
+
+    assert!(
+        entry.is_none(),
+        "is-fragment-matched output filters depend on per-packet state outside \
+         the flow-cache key (#2362)",
+    );
+}
+
 // ============================================================
 // #1431 cache-invariant runbook reference tests
 //
@@ -1024,16 +1128,17 @@ fn from_forward_decision_matching_family_returns_some() {
     // entry. Companion to the negative tests below so a future
     // refactor that breaks the constructor is obviously the cause and
     // not an unrelated input change.
-    let (flow, meta, validation, decision, forwarding, ha_state) =
-        make_v4_round_trip_inputs();
+    let (flow, meta, validation, decision, forwarding, ha_state) = make_v4_round_trip_inputs();
     let entry = try_build_entry(&flow, meta, validation, decision, &forwarding, &ha_state);
-    assert!(entry.is_some(), "matching-family v4 NAT should be cacheable");
+    assert!(
+        entry.is_some(),
+        "matching-family v4 NAT should be cacheable"
+    );
 }
 
 #[test]
 fn from_forward_decision_preserves_input_filter_log_for_cached_hits() {
-    let (flow, meta, validation, decision, forwarding, ha_state) =
-        make_v4_round_trip_inputs();
+    let (flow, meta, validation, decision, forwarding, ha_state) = make_v4_round_trip_inputs();
     let rg_epochs = default_rg_epochs();
     let input_log = CachedInputFilterLog {
         log_match: crate::filter::FilterLogMatch {
@@ -1084,8 +1189,7 @@ fn from_forward_decision_preserves_input_filter_log_for_cached_hits() {
 #[test]
 #[should_panic(expected = "RewriteDescriptor af-mismatch")]
 fn from_forward_decision_rejects_v6_rewrite_src_on_v4_meta_debug() {
-    let (flow, meta, validation, mut decision, forwarding, ha_state) =
-        make_v4_round_trip_inputs();
+    let (flow, meta, validation, mut decision, forwarding, ha_state) = make_v4_round_trip_inputs();
     decision.nat.rewrite_src = Some(IpAddr::V6(std::net::Ipv6Addr::new(
         0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
     )));
@@ -1096,8 +1200,7 @@ fn from_forward_decision_rejects_v6_rewrite_src_on_v4_meta_debug() {
 #[cfg(not(debug_assertions))]
 #[test]
 fn from_forward_decision_rejects_v6_rewrite_src_on_v4_meta_release() {
-    let (flow, meta, validation, mut decision, forwarding, ha_state) =
-        make_v4_round_trip_inputs();
+    let (flow, meta, validation, mut decision, forwarding, ha_state) = make_v4_round_trip_inputs();
     decision.nat.rewrite_src = Some(IpAddr::V6(std::net::Ipv6Addr::new(
         0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
     )));
@@ -1112,8 +1215,7 @@ fn from_forward_decision_rejects_v6_rewrite_src_on_v4_meta_release() {
 #[test]
 #[should_panic(expected = "RewriteDescriptor af-mismatch")]
 fn from_forward_decision_rejects_v4_rewrite_dst_on_v6_meta_debug() {
-    let (flow, meta, validation, mut decision, forwarding, ha_state) =
-        make_v6_round_trip_inputs();
+    let (flow, meta, validation, mut decision, forwarding, ha_state) = make_v6_round_trip_inputs();
     decision.nat.rewrite_dst = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)));
     let _ = try_build_entry(&flow, meta, validation, decision, &forwarding, &ha_state);
 }
@@ -1121,8 +1223,7 @@ fn from_forward_decision_rejects_v4_rewrite_dst_on_v6_meta_debug() {
 #[cfg(not(debug_assertions))]
 #[test]
 fn from_forward_decision_rejects_v4_rewrite_dst_on_v6_meta_release() {
-    let (flow, meta, validation, mut decision, forwarding, ha_state) =
-        make_v6_round_trip_inputs();
+    let (flow, meta, validation, mut decision, forwarding, ha_state) = make_v6_round_trip_inputs();
     decision.nat.rewrite_dst = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 7)));
     let entry = try_build_entry(&flow, meta, validation, decision, &forwarding, &ha_state);
     assert!(
@@ -1142,8 +1243,7 @@ fn from_forward_decision_rejects_v4_rewrite_dst_on_v6_meta_release() {
 #[test]
 #[should_panic(expected = "RewriteDescriptor af-mismatch")]
 fn from_forward_decision_rejects_v6_rewrite_dst_on_v4_meta_debug() {
-    let (flow, meta, validation, mut decision, forwarding, ha_state) =
-        make_v4_round_trip_inputs();
+    let (flow, meta, validation, mut decision, forwarding, ha_state) = make_v4_round_trip_inputs();
     decision.nat.rewrite_dst = Some(IpAddr::V6(std::net::Ipv6Addr::new(
         0x2001, 0xdb8, 0, 0, 0, 0, 0, 4,
     )));
@@ -1153,8 +1253,7 @@ fn from_forward_decision_rejects_v6_rewrite_dst_on_v4_meta_debug() {
 #[cfg(not(debug_assertions))]
 #[test]
 fn from_forward_decision_rejects_v6_rewrite_dst_on_v4_meta_release() {
-    let (flow, meta, validation, mut decision, forwarding, ha_state) =
-        make_v4_round_trip_inputs();
+    let (flow, meta, validation, mut decision, forwarding, ha_state) = make_v4_round_trip_inputs();
     decision.nat.rewrite_dst = Some(IpAddr::V6(std::net::Ipv6Addr::new(
         0x2001, 0xdb8, 0, 0, 0, 0, 0, 4,
     )));
@@ -1169,8 +1268,7 @@ fn from_forward_decision_rejects_v6_rewrite_dst_on_v4_meta_release() {
 #[test]
 #[should_panic(expected = "RewriteDescriptor af-mismatch")]
 fn from_forward_decision_rejects_v4_rewrite_src_on_v6_meta_debug() {
-    let (flow, meta, validation, mut decision, forwarding, ha_state) =
-        make_v6_round_trip_inputs();
+    let (flow, meta, validation, mut decision, forwarding, ha_state) = make_v6_round_trip_inputs();
     decision.nat.rewrite_src = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 8)));
     let _ = try_build_entry(&flow, meta, validation, decision, &forwarding, &ha_state);
 }
@@ -1178,8 +1276,7 @@ fn from_forward_decision_rejects_v4_rewrite_src_on_v6_meta_debug() {
 #[cfg(not(debug_assertions))]
 #[test]
 fn from_forward_decision_rejects_v4_rewrite_src_on_v6_meta_release() {
-    let (flow, meta, validation, mut decision, forwarding, ha_state) =
-        make_v6_round_trip_inputs();
+    let (flow, meta, validation, mut decision, forwarding, ha_state) = make_v6_round_trip_inputs();
     decision.nat.rewrite_src = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 8)));
     let entry = try_build_entry(&flow, meta, validation, decision, &forwarding, &ha_state);
     assert!(
@@ -1852,7 +1949,7 @@ fn count_active_flows_handles_epoch_wraparound() {
     // tick_advance_epoch skips 0 (sentinel), so the sequence near the
     // top is: MAX-1 → MAX → 1 → 2 (not 0).
     cache.current_epoch = u16::MAX - 1;
-    cache.tick_advance_epoch();  // u16::MAX
+    cache.tick_advance_epoch(); // u16::MAX
     let lookup = FlowCacheLookup {
         ingress_ifindex: 7,
         config_generation: 1,
@@ -1860,8 +1957,8 @@ fn count_active_flows_handles_epoch_wraparound() {
     };
     assert!(cache.lookup(&key, lookup, 0, &rg_epochs).is_some());
     // Now wrap: u16::MAX → wrapping_add(1) = 0, skipped → 1 → 2.
-    cache.tick_advance_epoch();  // skips 0, becomes 1
-    cache.tick_advance_epoch();  // 2
+    cache.tick_advance_epoch(); // skips 0, becomes 1
+    cache.tick_advance_epoch(); // 2
     // last_used_epoch was u16::MAX; current is 2; wrapping_sub
     // gives 2 - u16::MAX wrapping = 3. Within 10-epoch window → active.
     assert_eq!(cache.count_active_flows(), 1);
@@ -1874,7 +1971,10 @@ fn tick_advance_epoch_skips_zero_sentinel() {
     let mut cache = FlowCache::new();
     cache.current_epoch = u16::MAX;
     cache.tick_advance_epoch(); // would be 0 without the skip
-    assert_ne!(cache.current_epoch, 0, "epoch 0 is reserved sentinel and must never be produced by tick_advance_epoch");
+    assert_ne!(
+        cache.current_epoch, 0,
+        "epoch 0 is reserved sentinel and must never be produced by tick_advance_epoch"
+    );
     assert_eq!(cache.current_epoch, 1);
 }
 
@@ -1904,7 +2004,11 @@ fn count_active_flows_entry_at_epoch_max_not_confused_with_sentinel() {
     assert!(cache.lookup(&key, lookup, 0, &rg_epochs).is_some());
     // stamp is u16::MAX, not 0 → survives the sentinel check
     cache.tick_advance_epoch(); // skips 0 → 1
-    assert_eq!(cache.count_active_flows(), 1, "entry at epoch MAX must be active after 1-tick advance");
+    assert_eq!(
+        cache.count_active_flows(),
+        1,
+        "entry at epoch MAX must be active after 1-tick advance"
+    );
 }
 
 // ----------------------------------------------------------------
@@ -2043,7 +2147,10 @@ fn issue_1741_window_boundary_counts_age_9_clamps_age_10() {
         .map(|entry| entry.last_used_epoch)
         .next()
         .expect("entry still cached (clamp must not evict)");
-    assert_eq!(stamp_after_expiry, 0, "expired stamp must be sentinel-cleared");
+    assert_eq!(
+        stamp_after_expiry, 0,
+        "expired stamp must be sentinel-cleared"
+    );
 }
 
 /// A clamped entry is not evicted: a later fast-path hit re-stamps it,
@@ -2054,9 +2161,11 @@ fn issue_1741_clamped_entry_recoverable_by_hit() {
     let rg_epochs = default_rg_epochs();
     let (mut cache, key, lookup) = issue_1741_stamp_and_lookup();
     cache.insert(make_entry(key.clone(), issue_1741_stamp(), 1));
-    assert!(cache
-        .lookup_counted(&key, lookup, 0, &rg_epochs, 1500)
-        .is_some());
+    assert!(
+        cache
+            .lookup_counted(&key, lookup, 0, &rg_epochs, 1500)
+            .is_some()
+    );
     // Age out + clamp.
     for _ in 0..(ACTIVE_WINDOW_EPOCHS + 2) {
         cache.tick_advance_epoch();
@@ -2068,7 +2177,10 @@ fn issue_1741_clamped_entry_recoverable_by_hit() {
     let hit = cache
         .lookup_counted(&key, lookup, 0, &rg_epochs, 900)
         .expect("clamped entry must still be a cache hit");
-    assert_eq!(hit.observed_bytes, 2400, "observed_bytes preserved across clamp");
+    assert_eq!(
+        hit.observed_bytes, 2400,
+        "observed_bytes preserved across clamp"
+    );
     let (active, rows, _, _) = cache.active_flow_debug_entries(8);
     assert_eq!(active, 1, "re-hit entry counts as active again");
     assert_eq!(rows.len(), 1);

--- a/userspace-dp/src/afxdp/forward_request.rs
+++ b/userspace-dp/src/afxdp/forward_request.rs
@@ -155,6 +155,12 @@ pub(super) fn build_live_forward_request_from_frame(
                 decision.resolution.egress_ifindex,
                 meta,
                 tx_selection_flow.map(|flow| &flow.forward_key),
+                // #2362 fold B: build the fragment-safe per-packet match inputs
+                // from the live frame so a `from { tcp-flags ... } then
+                // forwarding-class X` (or is-fragment / icmp-type) output filter
+                // selects the class on exactly the authored packets on the
+                // TX-selection / CoS leg, not every packet of the flow.
+                crate::afxdp::frame::term_match_extra_from_frame(frame, meta),
                 now_ns,
             )
         });
@@ -204,5 +210,9 @@ pub(super) fn build_live_forward_request_from_frame(
         cos_queue_id: cos.queue_id,
         dscp_rewrite: cos.dscp_rewrite,
         cos_tx_selection_resolved: true,
+        // #2362 fold B: snapshot the fragment-safe per-packet match inputs so a
+        // later deferred TX-selection recompute keeps the same verdict even
+        // after the UMEM frame is recycled.
+        filter_match_extra: crate::afxdp::frame::term_match_extra_from_frame(frame, meta),
     })
 }

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1013,6 +1013,7 @@ pub(super) fn lookup_forwarding_resolution_inner(
 
 pub(super) fn ingress_route_table_override(
     forwarding: &ForwardingState,
+    frame: &[u8],
     meta: UserspaceDpMeta,
     flow: &SessionFlow,
     ingress_zone_override: Option<u16>,
@@ -1033,6 +1034,11 @@ pub(super) fn ingress_route_table_override(
     ) {
         return None;
     }
+    // #2362: PBR terms may carry per-packet L4 match conditions (tcp-flags /
+    // is-fragment / icmp-type / icmp-code); build the extra inputs so a
+    // `from { tcp-flags ...; } then routing-instance ...` term matches exactly
+    // the authored packets.
+    let extra = crate::afxdp::frame::term_match_extra_from_frame(frame, meta);
     let routing_result = crate::filter::evaluate_interface_filter_routing_instance_event_counted(
         &forwarding.filter_state,
         ingress_ifindex,
@@ -1043,6 +1049,7 @@ pub(super) fn ingress_route_table_override(
         flow.forward_key.src_port,
         flow.forward_key.dst_port,
         meta.dscp,
+        extra,
         meta.pkt_len as u64,
     )?;
     if routing_result.log {

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -5,6 +5,7 @@
 // tests;` in forwarding_build/mod.rs (no `#[path]` attribute).
 
 use super::*;
+use crate::filter::TermMatchExtra;
 use crate::filter::evaluate_filter_ref_tx_selection_runtime_counted;
 use crate::{
     ClassOfServiceSnapshot, CoSDSCPClassifierEntrySnapshot, CoSDSCPClassifierSnapshot,
@@ -94,6 +95,7 @@ fn forwarding_state_refresh_preserves_three_color_runtime_state() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         100,
         0,
     );
@@ -108,6 +110,7 @@ fn forwarding_state_refresh_preserves_three_color_runtime_state() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         51,
         0,
     );

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -310,6 +310,113 @@ pub(in crate::afxdp) fn is_non_first_fragment(packet: &[u8], addr_family: u8) ->
     }
 }
 
+/// #2362: is this L3-relative IPv4 packet ANY fragment? Junos `is-fragment`
+/// matches a datagram that is part of a fragmented packet — the FIRST fragment
+/// (MF=1, offset=0), a MIDDLE/LAST fragment (offset != 0), but NOT an
+/// unfragmented datagram (MF=0, offset=0). The MF bit is 0x2000 and the
+/// fragment-offset field is the low 13 bits, so the combined test on the
+/// `frag_off` field (IPv4 header bytes 6-7) is `(value & 0x3FFF) != 0`. The DF
+/// bit (0x4000) and the reserved bit (0x8000) are intentionally excluded. A
+/// too-short slice returns `false`.
+#[inline]
+pub(in crate::afxdp) fn ipv4_is_any_fragment(packet: &[u8]) -> bool {
+    packet.len() >= 8 && (u16::from_be_bytes([packet[6], packet[7]]) & 0x3FFF) != 0
+}
+
+/// #2362: is this L3-relative IPv6 packet ANY fragment? IPv6 carries
+/// fragmentation in a Fragment extension header (next-header 44). Junos
+/// `is-fragment` matches any datagram that carries a fragment header, including
+/// the first fragment (offset 0, M=1). Walks the extension-header chain
+/// (bounded by `MAX_IPV6_EXT_HEADERS`) and returns `true` as soon as a fragment
+/// header is found. Packets with no fragment header return `false`.
+#[inline]
+pub(in crate::afxdp) fn ipv6_is_any_fragment(packet: &[u8]) -> bool {
+    if packet.len() < 40 {
+        return false;
+    }
+    let mut protocol = packet[6];
+    let mut offset = 40usize;
+    for _ in 0..MAX_IPV6_EXT_HEADERS {
+        match protocol {
+            0 | 43 | 60 => {
+                let Some(opt) = packet.get(offset..offset + 2) else {
+                    return false;
+                };
+                protocol = opt[0];
+                let Some(next) = offset.checked_add((usize::from(opt[1]) + 1) * 8) else {
+                    return false;
+                };
+                offset = next;
+                if packet.len() < offset {
+                    return false;
+                }
+            }
+            51 => {
+                let Some(opt) = packet.get(offset..offset + 2) else {
+                    return false;
+                };
+                protocol = opt[0];
+                let Some(next) = offset.checked_add((usize::from(opt[1]) + 2) * 4) else {
+                    return false;
+                };
+                offset = next;
+                if packet.len() < offset {
+                    return false;
+                }
+            }
+            44 => return true,
+            _ => return false,
+        }
+    }
+    false
+}
+
+/// #2362: family-dispatched ANY-fragment predicate over the L3-relative packet
+/// slice. Used by the firewall-filter `is-fragment` match condition.
+#[inline]
+pub(in crate::afxdp) fn is_any_fragment(packet: &[u8], addr_family: u8) -> bool {
+    match addr_family as i32 {
+        libc::AF_INET => ipv4_is_any_fragment(packet),
+        libc::AF_INET6 => ipv6_is_any_fragment(packet),
+        _ => false,
+    }
+}
+
+/// #2362: build the per-packet L4 match inputs (tcp-flags / is-fragment /
+/// icmp-type / icmp-code) consumed by the firewall-filter term predicate, from
+/// the live frame + metadata. `tcp_flags` comes straight from `meta`; the
+/// fragment bit is read from the L3-relative packet slice (`meta.l3_offset`),
+/// and the ICMP/ICMPv6 type/code bytes from `meta.l4_offset`. Only the cold
+/// filter-evaluation path calls this, and only when an interface carries a
+/// per-packet-L4 (or DSCP) match filter, so the parse cost stays off the hot
+/// path. A non-ICMP protocol yields (0, 0) for type/code — the matcher already
+/// guards those against the protocol, so the values are never consulted.
+#[inline]
+pub(in crate::afxdp) fn term_match_extra_from_frame(
+    frame: &[u8],
+    meta: UserspaceDpMeta,
+) -> crate::filter::TermMatchExtra {
+    use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6};
+    let is_fragment = frame
+        .get(meta.l3_offset as usize..)
+        .is_some_and(|packet| is_any_fragment(packet, meta.addr_family));
+    let (icmp_type, icmp_code) = if matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6) {
+        let l4 = meta.l4_offset as usize;
+        (
+            frame.get(l4).copied().unwrap_or(0),
+            frame.get(l4.wrapping_add(1)).copied().unwrap_or(0),
+        )
+    } else {
+        (0, 0)
+    };
+    crate::filter::TermMatchExtra {
+        tcp_flags: meta.tcp_flags,
+        is_fragment,
+        icmp_type,
+        icmp_code,
+    }
+}
+
 /// #2314: RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a router MUST NOT
 /// originate an ICMP/ICMPv6 *error* in reply to a datagram whose IP
 /// destination was a broadcast or multicast address. Reading the
@@ -635,7 +742,10 @@ pub(in crate::afxdp) fn frame_is_non_first_fragment(frame: &[u8], meta: Userspac
     // metadata (e.g. the meta-led ICMP fixtures), spuriously suppressing
     // a legitimate flow. The downstream parsers already re-derive L3,
     // so this only guards the early-exit decision.
-    if frame.get(l3).is_none_or(|byte| (byte >> 4) != expected_version) {
+    if frame
+        .get(l3)
+        .is_none_or(|byte| (byte >> 4) != expected_version)
+    {
         return false;
     }
     match frame.get(l3..) {
@@ -1101,7 +1211,10 @@ pub(in crate::afxdp) fn parse_packet_destination_from_frame(
     }
 }
 
-pub(in crate::afxdp) fn try_parse_metadata(area: &MmapArea, desc: XdpDesc) -> Option<UserspaceDpMeta> {
+pub(in crate::afxdp) fn try_parse_metadata(
+    area: &MmapArea,
+    desc: XdpDesc,
+) -> Option<UserspaceDpMeta> {
     let meta_len = std::mem::size_of::<UserspaceDpMeta>();
     if (desc.addr as usize) < meta_len {
         return None;

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -433,6 +433,10 @@ pub(in crate::afxdp) fn term_match_extra_from_frame(
         is_fragment,
         icmp_type,
         icmp_code,
+        // The L4 header is absent only on a non-first fragment. The matcher
+        // gates tcp-flags / icmp-type / icmp-code on this (a zeroed icmp byte
+        // is otherwise a valid icmp-type 0 / icmp-code 0 match).
+        l4_present: !non_first_fragment,
     }
 }
 
@@ -471,6 +475,7 @@ pub(in crate::afxdp) fn term_match_extra_from_frame_fwd(
         is_fragment,
         icmp_type,
         icmp_code,
+        l4_present: !non_first_fragment,
     }
 }
 
@@ -492,6 +497,11 @@ pub(in crate::afxdp) fn term_match_extra_from_meta(
         is_fragment: false,
         icmp_type: 0,
         icmp_code: 0,
+        // TRUE: these synthetic / locally-stamped packets carry a real L4
+        // header and are never IP fragments, so a legit tcp-flags match keeps
+        // working. The 0 icmp bytes are an under-match (frame unavailable), NOT
+        // an absent-L4 signal.
+        l4_present: true,
     }
 }
 

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -384,36 +384,114 @@ pub(in crate::afxdp) fn is_any_fragment(packet: &[u8], addr_family: u8) -> bool 
 
 /// #2362: build the per-packet L4 match inputs (tcp-flags / is-fragment /
 /// icmp-type / icmp-code) consumed by the firewall-filter term predicate, from
-/// the live frame + metadata. `tcp_flags` comes straight from `meta`; the
-/// fragment bit is read from the L3-relative packet slice (`meta.l3_offset`),
-/// and the ICMP/ICMPv6 type/code bytes from `meta.l4_offset`. Only the cold
+/// the live frame + metadata. The fragment bit is read from the L3-relative
+/// packet slice (`meta.l3_offset`); `tcp_flags` comes from `meta`, and the
+/// ICMP/ICMPv6 type/code bytes from `meta.l4_offset`. Only the cold
 /// filter-evaluation path calls this, and only when an interface carries a
 /// per-packet-L4 (or DSCP) match filter, so the parse cost stays off the hot
 /// path. A non-ICMP protocol yields (0, 0) for type/code — the matcher already
 /// guards those against the protocol, so the values are never consulted.
+///
+/// #2362 fold A (the #2344 non-first-fragment class): a NON-FIRST fragment
+/// carries NO L4 header at `l4_offset` — those bytes are payload, and
+/// `meta.protocol` / `meta.tcp_flags` are derived from the IP header / shim
+/// stamping, not a real L4 header. Reading them would let a crafted fragment
+/// whose payload byte equals a filter's `icmp-type` (or whose payload-derived
+/// `tcp_flags` carries the masked bits) spuriously match. So when the packet is
+/// a non-first fragment, force `tcp_flags = icmp_type = icmp_code = 0` — those
+/// L4 terms must NOT match (matching the `per_packet_l4_matches` doc contract).
+/// `is_fragment` is KEPT true (a non-first fragment IS a fragment; the
+/// `is-fragment` term reads only the L3 header, which is present on every
+/// fragment). Reuses the existing `is_non_first_fragment` predicate (#2344).
 #[inline]
 pub(in crate::afxdp) fn term_match_extra_from_frame(
     frame: &[u8],
     meta: UserspaceDpMeta,
 ) -> crate::filter::TermMatchExtra {
     use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6};
-    let is_fragment = frame
-        .get(meta.l3_offset as usize..)
-        .is_some_and(|packet| is_any_fragment(packet, meta.addr_family));
-    let (icmp_type, icmp_code) = if matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6) {
+    let l3_packet = frame.get(meta.l3_offset as usize..);
+    let is_fragment = l3_packet.is_some_and(|packet| is_any_fragment(packet, meta.addr_family));
+    // A non-first fragment has no L4 header at `l4_offset` (its bytes are
+    // payload) — suppress every L4-derived match input so those terms fail
+    // closed. The is-fragment bit above stays as-is (L3-only).
+    let non_first_fragment =
+        l3_packet.is_some_and(|packet| is_non_first_fragment(packet, meta.addr_family));
+    let (tcp_flags, icmp_type, icmp_code) = if non_first_fragment {
+        (0, 0, 0)
+    } else if matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6) {
         let l4 = meta.l4_offset as usize;
         (
+            meta.tcp_flags,
             frame.get(l4).copied().unwrap_or(0),
             frame.get(l4.wrapping_add(1)).copied().unwrap_or(0),
         )
     } else {
-        (0, 0)
+        (meta.tcp_flags, 0, 0)
     };
     crate::filter::TermMatchExtra {
-        tcp_flags: meta.tcp_flags,
+        tcp_flags,
         is_fragment,
         icmp_type,
         icmp_code,
+    }
+}
+
+/// #2362 fold B: the `ForwardPacketMeta` flavor of `term_match_extra_from_frame`,
+/// for the TX-selection / CoS classification path (`tx/cos_classify.rs`), which
+/// carries a `ForwardPacketMeta` rather than the full `UserspaceDpMeta`. Same
+/// fragment-safe contract: a non-first fragment forces the L4-derived fields to
+/// 0 (its bytes are payload) while keeping the L3-only `is_fragment` bit. The
+/// CoS path already routes a non-first fragment to the default queue with no
+/// flow_key (#2357), so in practice this builder is invoked on first/atomic
+/// packets — the gate is defense-in-depth and keeps the two builders identical.
+#[inline]
+pub(in crate::afxdp) fn term_match_extra_from_frame_fwd(
+    frame: &[u8],
+    meta: ForwardPacketMeta,
+) -> crate::filter::TermMatchExtra {
+    use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6};
+    let l3_packet = frame.get(meta.l3_offset as usize..);
+    let is_fragment = l3_packet.is_some_and(|packet| is_any_fragment(packet, meta.addr_family));
+    let non_first_fragment =
+        l3_packet.is_some_and(|packet| is_non_first_fragment(packet, meta.addr_family));
+    let (tcp_flags, icmp_type, icmp_code) = if non_first_fragment {
+        (0, 0, 0)
+    } else if matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6) {
+        let l4 = meta.l4_offset as usize;
+        (
+            meta.tcp_flags,
+            frame.get(l4).copied().unwrap_or(0),
+            frame.get(l4.wrapping_add(1)).copied().unwrap_or(0),
+        )
+    } else {
+        (meta.tcp_flags, 0, 0)
+    };
+    crate::filter::TermMatchExtra {
+        tcp_flags,
+        is_fragment,
+        icmp_type,
+        icmp_code,
+    }
+}
+
+/// #2362 fold B: build the per-packet match inputs from metadata ALONE, for the
+/// rare TX-selection callers that have no contiguous ingress frame slice
+/// (locally-generated replies whose tuple is re-derived, ARP/NDP-deferred
+/// forwards, control-plane injects). `tcp_flags` is taken from the
+/// shim-stamped `meta` (authoritative on the forwarding path); `is_fragment`
+/// and `icmp_type`/`icmp_code` cannot be read without the frame, so they are
+/// 0/false — a CoS-action filter term keyed on is-fragment or icmp-type on one
+/// of these non-transit paths under-matches rather than mis-matches. The common
+/// `tcp-flags` CoS term is fully covered.
+#[inline]
+pub(in crate::afxdp) fn term_match_extra_from_meta(
+    meta: ForwardPacketMeta,
+) -> crate::filter::TermMatchExtra {
+    crate::filter::TermMatchExtra {
+        tcp_flags: meta.tcp_flags,
+        is_fragment: false,
+        icmp_type: 0,
+        icmp_code: 0,
     }
 }
 

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -20,8 +20,8 @@ pub(in crate::afxdp) use generated::generated_reply_session_key;
 // paths. The previous in-place definitions in this file were
 // moved verbatim into headers.rs.
 pub(in crate::afxdp) use headers::{
-    eth_header_len, write_eth_header, write_eth_header_slice, write_eth_header_tagged,
-    write_ipv4_header, write_ipv6_header, write_udp_header, TxVlanTag, TPID_8021AD, TPID_8021Q,
+    TPID_8021AD, TPID_8021Q, TxVlanTag, eth_header_len, write_eth_header, write_eth_header_slice,
+    write_eth_header_tagged, write_ipv4_header, write_ipv6_header, write_udp_header,
 };
 
 use byte_writes::{
@@ -35,8 +35,8 @@ use byte_writes::{
 // pulled in via a non-pub `use` to avoid a glob re-export at a
 // wider visibility than its own.
 use checksum::{
-    adjust_l4_checksum_ipv6_addr_bytes, adjust_zero_checksum_illegal, checksum_family_of,
-    l4_udp_checksum_optional, ChecksumFamily,
+    ChecksumFamily, adjust_l4_checksum_ipv6_addr_bytes, adjust_zero_checksum_illegal,
+    checksum_family_of, l4_udp_checksum_optional,
 };
 pub(in crate::afxdp) use checksum::{
     adjust_ipv4_header_checksum, adjust_l4_checksum_ipv4, adjust_l4_checksum_ipv4_dst,
@@ -52,19 +52,20 @@ pub(in crate::afxdp) use checksum::{
 // reached for from afxdp.rs / tx/transmit.rs / tx/dispatch.rs /
 // cos/queue_service.rs, so they go out at `pub(in crate::afxdp)`. The
 // rest stay at `pub(super)` (afxdp-only callers in sibling files).
-pub(in crate::afxdp) use inspect::{
-    authoritative_forward_ports, decode_frame_summary, dest_is_multicast_or_broadcast,
-    forward_tuple_mismatch_reason, ipv4_is_non_first_fragment, ipv6_is_non_first_fragment,
-    is_non_first_fragment, l2_dst_is_group_or_broadcast, parse_session_flow, try_parse_metadata,
-};
 pub(super) use inspect::{
     MAX_IPV6_EXT_HEADERS, frame_is_non_first_fragment, frame_l3_offset, frame_l4_offset,
     live_frame_ports, live_frame_ports_bytes, live_frame_ports_from_meta_bytes,
-    metadata_tuple_complete, packet_rel_l4_offset,
-    packet_rel_l4_offset_and_protocol, parse_flow_ports, parse_ipv4_session_flow_from_frame,
-    parse_packet_destination_from_frame, parse_session_flow_from_bytes,
-    parse_session_flow_from_frame, parse_session_flow_from_meta,
+    metadata_tuple_complete, packet_rel_l4_offset, packet_rel_l4_offset_and_protocol,
+    parse_flow_ports, parse_ipv4_session_flow_from_frame, parse_packet_destination_from_frame,
+    parse_session_flow_from_bytes, parse_session_flow_from_frame, parse_session_flow_from_meta,
     parse_zone_encoded_fabric_ingress, parse_zone_encoded_fabric_ingress_from_frame,
+};
+pub(in crate::afxdp) use inspect::{
+    authoritative_forward_ports, decode_frame_summary, dest_is_multicast_or_broadcast,
+    forward_tuple_mismatch_reason, ipv4_is_any_fragment, ipv4_is_non_first_fragment,
+    ipv6_is_any_fragment, ipv6_is_non_first_fragment, is_any_fragment, is_non_first_fragment,
+    l2_dst_is_group_or_broadcast, parse_session_flow, term_match_extra_from_frame,
+    try_parse_metadata,
 };
 
 // #989: TCP-specific inspection + mutation kernels relocated from
@@ -131,10 +132,6 @@ pub(in crate::afxdp) fn v6_rel_l4_offset(
     }
 }
 
-
-
-
-
 pub(in crate::afxdp) fn apply_dscp_rewrite_to_frame(frame: &mut [u8], dscp: u8) -> Option<()> {
     let dscp = dscp & 0x3f;
     let l3 = frame_l3_offset(frame)?;
@@ -173,13 +170,6 @@ pub(in crate::afxdp) fn apply_dscp_rewrite_to_frame(frame: &mut [u8], dscp: u8) 
         _ => None,
     }
 }
-
-
-
-
-
-
-
 
 pub(super) fn build_injected_packet(
     req: &InjectPacketRequest,
@@ -294,17 +284,13 @@ pub(super) fn build_forwarded_frame_from_frame(
             .map(|e| tunnel_mode_kind(&e.mode));
         return match kind {
             Some(TunnelKind::WireGuard) => wg::wg_encap_frame(&out, meta, decision, forwarding),
-            Some(TunnelKind::Gre) => {
-                encapsulate_native_gre_frame(&out, meta, decision, forwarding)
-            }
+            Some(TunnelKind::Gre) => encapsulate_native_gre_frame(&out, meta, decision, forwarding),
             // Unknown mode or missing endpoint row: fail closed.
             Some(TunnelKind::Unknown) | None => None,
         };
     }
     Some(out)
 }
-
-
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn build_forwarded_frame(
@@ -318,7 +304,6 @@ pub(super) fn build_forwarded_frame(
     let frame = area.slice(desc.addr as usize, desc.len as usize)?;
     build_forwarded_frame_from_frame(frame, meta, decision, forwarding, false, expected_ports)
 }
-
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn build_forwarded_frame_into(
@@ -438,8 +423,7 @@ fn rewrite_prepare_eth_from_parts(
     };
     let eth_len = if params.vlan_id > 0 { 18usize } else { 14usize };
     let frame_len = eth_len.checked_add(payload_len)?;
-    let (tx_offset, l2_rewrite) =
-        classify_in_place_l2_rewrite(desc.addr, l3, eth_len, frame_len)?;
+    let (tx_offset, l2_rewrite) = classify_in_place_l2_rewrite(desc.addr, l3, eth_len, frame_len)?;
 
     if matches!(
         l2_rewrite,
@@ -776,7 +760,6 @@ fn trim_l3_payload<'a>(raw_payload: &'a [u8], meta: impl Into<ForwardPacketMeta>
         _ => raw_payload,
     }
 }
-
 
 /// `non_first_fragment` (#1852): when true, the L4-offset bytes are
 /// PAYLOAD (a non-first fragment has no L4 header). The IP-address

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -65,7 +65,7 @@ pub(in crate::afxdp) use inspect::{
     forward_tuple_mismatch_reason, ipv4_is_any_fragment, ipv4_is_non_first_fragment,
     ipv6_is_any_fragment, ipv6_is_non_first_fragment, is_any_fragment, is_non_first_fragment,
     l2_dst_is_group_or_broadcast, parse_session_flow, term_match_extra_from_frame,
-    try_parse_metadata,
+    term_match_extra_from_frame_fwd, term_match_extra_from_meta, try_parse_metadata,
 };
 
 // #989: TCP-specific inspection + mutation kernels relocated from

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -5852,6 +5852,81 @@ fn ipv6_any_fragment_predicate_truth_table() {
     )));
 }
 
+// #2362 fold A (the #2344 non-first-fragment class): term_match_extra_from_frame
+// must NOT read L4-derived match inputs from a non-first fragment — its bytes
+// at l4_offset are payload, not a real L4 header. is_fragment (L3-only) MUST
+// still be set. These fail if the non-first-fragment gate is removed.
+#[test]
+fn term_extra_non_first_icmp_fragment_suppresses_icmp_type_keeps_is_fragment() {
+    // Non-first ICMP fragment (offset != 0) whose payload byte at l4_offset == 8
+    // (would spuriously match `icmp-type 8` without the gate).
+    let frag = frag_v4_packet(PROTO_ICMP, 0x0001, &[8, 0, 0, 0, 0, 0, 0, 0]);
+    let mut frame = vec![0u8; 14];
+    frame.extend_from_slice(&frag);
+    let meta = UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 34,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_ICMP,
+        ..UserspaceDpMeta::default()
+    };
+    let extra = term_match_extra_from_frame(&frame, meta);
+    assert_eq!(
+        extra.icmp_type, 0,
+        "non-first fragment payload byte must NOT leak as icmp_type"
+    );
+    assert_eq!(extra.icmp_code, 0);
+    assert_eq!(extra.tcp_flags, 0);
+    assert!(
+        extra.is_fragment,
+        "a non-first fragment IS a fragment (is-fragment must match)"
+    );
+}
+
+#[test]
+fn term_extra_non_first_tcp_fragment_suppresses_tcp_flags() {
+    // Non-first TCP fragment with meta.tcp_flags carrying SYN (payload-derived).
+    let frag = frag_v4_packet(PROTO_TCP, 0x0001, &[0; 8]);
+    let mut frame = vec![0u8; 14];
+    frame.extend_from_slice(&frag);
+    let meta = UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 34,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x02, // SYN — would spuriously match `tcp-flags syn`
+        ..UserspaceDpMeta::default()
+    };
+    let extra = term_match_extra_from_frame(&frame, meta);
+    assert_eq!(
+        extra.tcp_flags, 0,
+        "non-first fragment must NOT expose payload-derived tcp_flags"
+    );
+    assert!(extra.is_fragment);
+}
+
+#[test]
+fn term_extra_first_fragment_keeps_l4_fields() {
+    // A FIRST fragment (offset 0, MF=1) carries the real L4 header — keep the
+    // L4 fields AND mark is_fragment.
+    let frag = frag_v4_packet(PROTO_ICMP, 0x2000, &[8, 0, 0, 0, 0, 0, 0, 0]);
+    let mut frame = vec![0u8; 14];
+    frame.extend_from_slice(&frag);
+    let meta = UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 34,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_ICMP,
+        ..UserspaceDpMeta::default()
+    };
+    let extra = term_match_extra_from_frame(&frame, meta);
+    assert_eq!(
+        extra.icmp_type, 8,
+        "first fragment carries the real ICMP type"
+    );
+    assert!(extra.is_fragment, "first fragment IS a fragment");
+}
+
 #[test]
 fn apply_nat_ipv4_non_first_fragment_rewrites_ip_only() {
     // Payload bytes occupy the post-IP offset where the buggy code would

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -6,8 +6,8 @@ use super::super::test_fixtures::*;
 use super::*;
 use crate::event_stream::DataplaneEventRateLimitConfig;
 use crate::event_stream::codec::DataplaneEventKind;
-use crate::{FirewallFilterSnapshot, FirewallTermSnapshot, ThreeColorPolicerSnapshot};
 use crate::test_zone_ids::*;
+use crate::{FirewallFilterSnapshot, FirewallTermSnapshot, ThreeColorPolicerSnapshot};
 
 fn active_ha_runtime(now_secs: u64) -> HAGroupRuntime {
     HAGroupRuntime {
@@ -48,12 +48,7 @@ fn build_icmp_echo_frame_v4(src: Ipv4Addr, dst: Ipv4Addr, ttl: u8) -> Vec<u8> {
     frame
 }
 
-fn build_icmp_echo_frame_v4_vlan(
-    src: Ipv4Addr,
-    dst: Ipv4Addr,
-    ttl: u8,
-    vlan_id: u16,
-) -> Vec<u8> {
+fn build_icmp_echo_frame_v4_vlan(src: Ipv4Addr, dst: Ipv4Addr, ttl: u8, vlan_id: u16) -> Vec<u8> {
     let mut frame = Vec::new();
     write_eth_header(
         &mut frame,
@@ -134,8 +129,7 @@ fn trim_l3_payload_uses_frame_length_metadata_relative_to_l3_offset_without_pars
 }
 
 #[test]
-fn trim_l3_payload_uses_vlan_frame_length_metadata_relative_to_l3_offset_without_parsing_header()
- {
+fn trim_l3_payload_uses_vlan_frame_length_metadata_relative_to_l3_offset_without_parsing_header() {
     let mut frame = build_icmp_echo_frame_v4_vlan(
         Ipv4Addr::new(10, 0, 0, 1),
         Ipv4Addr::new(10, 0, 0, 2),
@@ -492,7 +486,7 @@ fn ingress_filter_routing_instance_steers_flow_into_native_gre_table() {
         },
     );
     let override_table =
-        ingress_route_table_override(&state, meta, &flow, None, Some(&event_handle), 99);
+        ingress_route_table_override(&state, &[], meta, &flow, None, Some(&event_handle), 99);
     assert_eq!(override_table.as_deref(), Some("sfmix.inet.0"));
     let filter_event = event_rx
         .try_recv()
@@ -612,7 +606,11 @@ fn native_gre_decap_combines_outer_ce_into_inner_ecn() {
         .expect("decap must forward (legal CE upgrade)");
     // Inner emerges in the synthetic frame at offset 14 (eth) + 1 (TOS).
     let inner_tos_out = packet.frame[15];
-    assert_eq!(inner_tos_out & 0x03, 0b11, "inner ECN must be upgraded to CE");
+    assert_eq!(
+        inner_tos_out & 0x03,
+        0b11,
+        "inner ECN must be upgraded to CE"
+    );
     assert_eq!(inner_tos_out >> 2, 46, "inner DSCP (EF) must be preserved");
     // Fail-on-revert: the CE bit MUST be set — the pre-#2315 copy-only
     // path could never produce this (it never touched the inner ECN).
@@ -747,10 +745,7 @@ fn local_origin_tunnel_tx_request_encapsulates_raw_ip_for_active_owner() {
     let state = build_forwarding_state(&native_gre_snapshot(true));
     // #1881: the loop now loads HA state once per iteration and
     // passes the map down — the builder takes &BTreeMap directly.
-    let ha_state = BTreeMap::from([(
-        1,
-        active_ha_runtime(monotonic_nanos() / 1_000_000_000),
-    )]);
+    let ha_state = BTreeMap::from([(1, active_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
     let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
     let packet = build_icmp_echo_frame_v4(
         Ipv4Addr::new(10, 255, 192, 42),
@@ -778,10 +773,7 @@ fn local_origin_tunnel_tx_request_encapsulates_raw_ip_for_active_owner() {
 #[test]
 fn local_origin_tunnel_tx_request_rejects_inactive_owner() {
     let state = build_forwarding_state(&native_gre_snapshot(true));
-    let ha_state = BTreeMap::from([(
-        1,
-        inactive_ha_runtime(monotonic_nanos() / 1_000_000_000),
-    )]);
+    let ha_state = BTreeMap::from([(1, inactive_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
     let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
     let packet = build_icmp_echo_frame_v4(
         Ipv4Addr::new(10, 255, 192, 42),
@@ -922,14 +914,7 @@ fn build_forwarded_frame_from_frame_recomputes_tcp_checksum_for_native_gre_snat(
         ..UserspaceDpMeta::default()
     };
     let decision = SessionDecision {
-        resolution: lookup_forwarding_resolution_v4(
-            &state,
-            None,
-            dst_ip,
-            "sfmix.inet.0",
-            0,
-            true,
-        ),
+        resolution: lookup_forwarding_resolution_v4(&state, None, dst_ip, "sfmix.inet.0", 0, true),
         nat: NatDecision {
             rewrite_src: Some(IpAddr::V4(snat_ip)),
             ..NatDecision::default()
@@ -1026,14 +1011,7 @@ fn build_forwarded_frame_from_frame_clamps_tcp_mss_for_native_gre() {
         ..UserspaceDpMeta::default()
     };
     let decision = SessionDecision {
-        resolution: lookup_forwarding_resolution_v4(
-            &state,
-            None,
-            dst_ip,
-            "sfmix.inet.0",
-            0,
-            true,
-        ),
+        resolution: lookup_forwarding_resolution_v4(&state, None, dst_ip, "sfmix.inet.0", 0, true),
         nat: NatDecision::default(),
     };
     let built = build_forwarded_frame_from_frame(
@@ -1121,20 +1099,11 @@ fn syn_cookie_syn_ack_builder_swaps_tuple_and_preserves_vlan() {
     frame.extend_from_slice(&443u16.to_be_bytes());
     frame.extend_from_slice(&0x0102_0304u32.to_be_bytes());
     frame.extend_from_slice(&0u32.to_be_bytes());
-    frame.extend_from_slice(&[
-        0x50,
-        TCP_FLAG_SYN,
-        0x20,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-    ]);
+    frame.extend_from_slice(&[0x50, TCP_FLAG_SYN, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00]);
     recompute_l4_checksum_ipv4(&mut frame[18..], 20, PROTO_TCP, false).expect("tcp sum");
 
-    let out = build_syn_cookie_syn_ack_frame(&frame, 0xaabb_ccdd, 1460)
-        .expect("syn-cookie syn-ack");
+    let out =
+        build_syn_cookie_syn_ack_frame(&frame, 0xaabb_ccdd, 1460).expect("syn-cookie syn-ack");
 
     assert_eq!(&out[0..6], &[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
     assert_eq!(&out[6..12], &[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
@@ -1163,18 +1132,10 @@ fn syn_cookie_syn_ack_builder_swaps_tuple_and_preserves_vlan() {
 fn syn_cookie_ipv4_syn_ack_builder_pads_to_ethernet_minimum() {
     let client = Ipv4Addr::new(192, 0, 2, 10);
     let server = Ipv4Addr::new(198, 51, 100, 20);
-    let frame = build_ipv4_tcp_frame(
-        client,
-        server,
-        49152,
-        443,
-        0x0102_0304,
-        0,
-        TCP_FLAG_SYN,
-    );
+    let frame = build_ipv4_tcp_frame(client, server, 49152, 443, 0x0102_0304, 0, TCP_FLAG_SYN);
 
-    let out = build_syn_cookie_syn_ack_frame(&frame, 0xaabb_ccdd, 1460)
-        .expect("syn-cookie syn-ack");
+    let out =
+        build_syn_cookie_syn_ack_frame(&frame, 0xaabb_ccdd, 1460).expect("syn-cookie syn-ack");
 
     assert_eq!(out.len(), 60);
     assert_eq!(u16::from_be_bytes([out[16], out[17]]), 44);
@@ -1188,15 +1149,7 @@ fn syn_cookie_ipv4_syn_ack_builder_pads_to_ethernet_minimum() {
 fn syn_cookie_ipv4_rst_builder_pads_to_ethernet_minimum() {
     let client = Ipv4Addr::new(192, 0, 2, 10);
     let server = Ipv4Addr::new(198, 51, 100, 20);
-    let frame = build_ipv4_tcp_frame(
-        client,
-        server,
-        49152,
-        443,
-        0x1111_2222,
-        0x3333_4444,
-        0x10,
-    );
+    let frame = build_ipv4_tcp_frame(client, server, 49152, 443, 0x1111_2222, 0x3333_4444, 0x10);
 
     let out = build_syn_cookie_ack_rst_frame(&frame).expect("syn-cookie rst");
 
@@ -1230,8 +1183,7 @@ fn syn_cookie_vlan_ipv4_rst_builder_pads_to_ethernet_minimum() {
         0x0800,
     );
     frame.extend_from_slice(&[
-        0x45, 0x00, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00,
-        64, PROTO_TCP, 0x00, 0x00,
+        0x45, 0x00, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00,
     ]);
     frame.extend_from_slice(&client.octets());
     frame.extend_from_slice(&server.octets());
@@ -1241,11 +1193,8 @@ fn syn_cookie_vlan_ipv4_rst_builder_pads_to_ethernet_minimum() {
     frame.extend_from_slice(&443u16.to_be_bytes());
     frame.extend_from_slice(&0x1111_2222u32.to_be_bytes());
     frame.extend_from_slice(&0x3333_4444u32.to_be_bytes());
-    frame.extend_from_slice(&[
-        0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00,
-    ]);
-    recompute_l4_checksum_ipv4(&mut frame[18..], 20, PROTO_TCP, false)
-        .expect("tcp sum");
+    frame.extend_from_slice(&[0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    recompute_l4_checksum_ipv4(&mut frame[18..], 20, PROTO_TCP, false).expect("tcp sum");
 
     let out = build_syn_cookie_ack_rst_frame(&frame).expect("syn-cookie rst");
 
@@ -1323,10 +1272,10 @@ fn icmpv6_checksum_ok(packet: &[u8]) -> bool {
 #[test]
 fn apply_nat_ipv4_recomputes_tcp_checksum() {
     let mut packet = vec![
-        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
-        102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x00, 0x01, 0x50, 0x18, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
-        b'a', b't', b'a',
+        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61, 102,
+        172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x50, 0x18, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't',
+        b'a',
     ];
     let ip_sum = checksum16(&packet[..20]);
     packet[10] = (ip_sum >> 8) as u8;
@@ -1363,8 +1312,8 @@ fn extract_l3_packet_with_nat_rewrites_reverse_snat_reply_v4() {
     frame.extend_from_slice(&[
         0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 63, PROTO_TCP, 0x00, 0x00, 172, 16, 80,
         200, 172, 16, 80, 8, 0x14, 0x51, 0x9c, 0x40, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-        0x01, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
-        b'a', b't', b'a',
+        0x01, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a',
+        b't', b'a',
     ]);
     let ip_sum = checksum16(&frame[18..38]);
     frame[28] = (ip_sum >> 8) as u8;
@@ -1411,9 +1360,9 @@ fn extract_l3_packet_with_nat_rewrites_reverse_snat_reply_v6() {
     frame.extend_from_slice(&src_ip.octets());
     frame.extend_from_slice(&dst_ip.octets());
     frame.extend_from_slice(&[
-        0x14, 0x51, 0x95, 0x2c, 0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x10,
-        0x00, 0x40, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
-        b't', b'e', b's', b't',
+        0x14, 0x51, 0x95, 0x2c, 0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x10, 0x00,
+        0x40, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e',
+        b's', b't',
     ]);
     recompute_l4_checksum_ipv6(&mut frame[18..], 40, PROTO_TCP).expect("tcp sum");
 
@@ -1459,10 +1408,10 @@ fn build_forwarded_frame_keeps_tcp_checksum_valid_after_snat() {
         0x0800,
     );
     frame.extend_from_slice(&[
-        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
-        102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x00, 0x01, 0x50, 0x18, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
-        b'a', b't', b'a',
+        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61, 102,
+        172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x50, 0x18, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't',
+        b'a',
     ]);
     let ip_sum = checksum16(&frame[14..34]);
     frame[24] = (ip_sum >> 8) as u8;
@@ -1582,7 +1531,9 @@ fn rewrite_forwarded_frame_in_place_keeps_icmpv6_checksum_valid_after_snat() {
         None,
     )
     .expect("in-place v6 forward");
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("rewritten frame");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("rewritten frame");
     assert_eq!(&out[0..6], &[0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]);
     assert_eq!(&out[6..12], &[0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]);
     assert_eq!(out[25], 63);
@@ -1864,7 +1815,9 @@ fn rewrite_forwarded_frame_in_place_keeps_icmpv6_echo_identifier_and_sequence() 
         None,
     )
     .expect("in-place v6 echo forward");
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("rewritten frame");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("rewritten frame");
 
     let packet = &out[18..];
     assert_eq!(packet[40], 128);
@@ -1904,8 +1857,8 @@ fn enforce_expected_ports_repairs_ipv6_tcp_ports_and_checksum() {
     frame.extend_from_slice(&dst_ip.octets());
     frame.extend_from_slice(&[
         0x04, 0x01, 0x14, 0x51, // wrong src port 1025 -> 5201
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
     ]);
     recompute_l4_checksum_ipv6(&mut frame[18..], 40, PROTO_TCP).expect("initial checksum");
     assert!(tcp_checksum_ok_ipv6(&frame[18..]));
@@ -1942,14 +1895,13 @@ fn enforce_expected_ports_repairs_ipv4_tcp_ports_and_checksum() {
     frame.extend_from_slice(&dst_ip.octets());
     frame.extend_from_slice(&[
         0x04, 0x01, 0x14, 0x51, // wrong src port 1025 -> 54688
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
     ]);
     let ip_sum = checksum16(&frame[18..38]);
     frame[28] = (ip_sum >> 8) as u8;
     frame[29] = ip_sum as u8;
-    recompute_l4_checksum_ipv4(&mut frame[18..], 20, PROTO_TCP, true)
-        .expect("initial checksum");
+    recompute_l4_checksum_ipv4(&mut frame[18..], 20, PROTO_TCP, true).expect("initial checksum");
     assert!(tcp_checksum_ok_ipv4(&frame[18..]));
 
     let repaired = enforce_expected_ports(
@@ -2037,7 +1989,9 @@ fn rewrite_forwarded_frame_in_place_keeps_ipv6_tcp_ports_after_vlan_snat() {
         Some((54688, 5201)),
     )
     .expect("rewrite in place");
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("rewritten frame");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("rewritten frame");
     assert_eq!(u16::from_be_bytes([out[12], out[13]]), 0x8100);
     assert_eq!(u16::from_be_bytes([out[14], out[15]]) & 0x0fff, 80);
     assert_eq!(u16::from_be_bytes([out[16], out[17]]), 0x86dd);
@@ -2237,8 +2191,8 @@ fn build_live_forward_request_prefers_session_flow_ports_over_frame() {
     frame.extend_from_slice(&frame_src_port.to_be_bytes());
     frame.extend_from_slice(&frame_dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
     ]);
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
 
@@ -2354,8 +2308,8 @@ fn build_live_forward_request_uses_live_frame_ports_when_no_session_flow() {
     frame.extend_from_slice(&real_src_port.to_be_bytes());
     frame.extend_from_slice(&real_dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
     ]);
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
 
@@ -2513,9 +2467,9 @@ fn build_live_forward_request_meters_non_l4_metadata_flow() {
             ieee8021_queue_by_pcp: [u8::MAX; 8],
             queue_by_forwarding_class: FastMap::default(),
             queues: Vec::new(),
-        oversubscription_policy: CoSOversubscriptionPolicy::Proportional,
-        oversubscription_guarantee_fraction: 0.0,
-        priority_low_min_share_bytes: 0,
+            oversubscription_policy: CoSOversubscriptionPolicy::Proportional,
+            oversubscription_guarantee_fraction: 0.0,
+            priority_low_min_share_bytes: 0,
         },
     );
     let decision = SessionDecision {
@@ -2559,7 +2513,10 @@ fn build_live_forward_request_meters_non_l4_metadata_flow() {
         0,
     );
 
-    assert!(req.is_none(), "red-drop policer should reject non-L4 metadata flow");
+    assert!(
+        req.is_none(),
+        "red-drop policer should reject non-L4 metadata flow"
+    );
     let status = forwarding.filter_state.three_color_policer_statuses();
     assert_eq!(status[0].red_packets, 1);
     assert_eq!(status[0].drop_packets, 1);
@@ -3123,8 +3080,8 @@ fn build_forwarded_frame_into_keeps_ipv6_ports_when_frame_and_metadata_disagree(
     frame.extend_from_slice(&real_src_port.to_be_bytes());
     frame.extend_from_slice(&real_dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
     ]);
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
 
@@ -3201,8 +3158,8 @@ fn build_forwarded_frame_into_prefers_expected_ipv6_ports_over_wrong_live_ports(
     frame.extend_from_slice(&real_src_port.to_be_bytes());
     frame.extend_from_slice(&real_dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
     ]);
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
 
@@ -3280,8 +3237,8 @@ fn build_forwarded_frame_into_repairs_wrong_ipv6_frame_ports_from_expected_tuple
     frame.extend_from_slice(&wrong_src_port.to_be_bytes());
     frame.extend_from_slice(&dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
     ]);
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
 
@@ -3362,8 +3319,8 @@ fn build_forwarded_frame_into_ignores_wrong_ipv4_offsets() {
     frame.extend_from_slice(&real_src_port.to_be_bytes());
     frame.extend_from_slice(&real_dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
     ]);
     let ip_sum = checksum16(&frame[14..34]);
     frame[24] = (ip_sum >> 8) as u8;
@@ -3580,8 +3537,8 @@ fn segment_forwarded_tcp_frames_repairs_ipv6_tcp_ports_when_metadata_disagrees()
     frame.extend_from_slice(&src_port.to_be_bytes());
     frame.extend_from_slice(&dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00,
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00,
     ]);
     frame.extend((0..tcp_payload_len).map(|i| (i & 0xff) as u8));
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
@@ -3684,8 +3641,8 @@ fn segment_forwarded_tcp_frames_prefers_expected_ipv6_ports_over_wrong_live_port
     frame.extend_from_slice(&src_port.to_be_bytes());
     frame.extend_from_slice(&dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00,
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00,
     ]);
     frame.extend((0..tcp_payload_len).map(|i| (i & 0xff) as u8));
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
@@ -3789,8 +3746,8 @@ fn segment_forwarded_tcp_frames_repairs_wrong_ipv6_frame_ports_from_expected_tup
     frame.extend_from_slice(&wrong_src_port.to_be_bytes());
     frame.extend_from_slice(&dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00,
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00,
     ]);
     frame.extend((0..tcp_payload_len).map(|i| (i & 0xff) as u8));
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
@@ -3885,8 +3842,8 @@ fn authoritative_forward_ports_prefers_flow_tuple_when_frame_ports_mismatch() {
     frame.extend_from_slice(&wrong_src_port.to_be_bytes());
     frame.extend_from_slice(&dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
     ]);
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
 
@@ -3946,8 +3903,8 @@ fn authoritative_forward_ports_prefers_frame_tuple_over_metadata_when_flow_missi
     frame.extend_from_slice(&frame_src_port.to_be_bytes());
     frame.extend_from_slice(&dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
     ]);
     let ip_csum = checksum16(&frame[14..34]);
     frame[24..26].copy_from_slice(&ip_csum.to_be_bytes());
@@ -4040,8 +3997,8 @@ fn parse_session_flow_prefers_metadata_tuple_when_frame_ports_mismatch() {
     frame.extend_from_slice(&wrong_src_port.to_be_bytes());
     frame.extend_from_slice(&dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
+        0x31, 0x96, 0xc8, 0x32, 0x08, 0xf0, 0x5a, 0xc6, 0x50, 0x18, 0x00, 0x40, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a', b't', b'e', b's', b't',
     ]);
     recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("tcp sum");
 
@@ -4249,8 +4206,8 @@ fn segment_forwarded_tcp_frames_keeps_ipv4_snat_inside_native_gre() {
     frame.extend_from_slice(&src_port.to_be_bytes());
     frame.extend_from_slice(&dst_port.to_be_bytes());
     frame.extend_from_slice(&[
-        0x52, 0x04, 0xc1, 0xa3, 0x73, 0x7f, 0x63, 0x1c, 0x80, 0x10, 0x00, 0x3f, 0x00, 0x00,
-        0x00, 0x00, 0x01, 0x01, 0x08, 0x0a, 0x91, 0x9b, 0x0d, 0x5f, 0xd3, 0x53, 0x0f, 0x7f,
+        0x52, 0x04, 0xc1, 0xa3, 0x73, 0x7f, 0x63, 0x1c, 0x80, 0x10, 0x00, 0x3f, 0x00, 0x00, 0x00,
+        0x00, 0x01, 0x01, 0x08, 0x0a, 0x91, 0x9b, 0x0d, 0x5f, 0xd3, 0x53, 0x0f, 0x7f,
     ]);
     frame.extend((0..tcp_payload_len).map(|i| (i & 0xff) as u8));
     let ip_sum = checksum16(&frame[14..34]);
@@ -4276,14 +4233,7 @@ fn segment_forwarded_tcp_frames_keeps_ipv4_snat_inside_native_gre() {
     };
     let state = build_forwarding_state(&native_gre_snapshot(true));
     let decision = SessionDecision {
-        resolution: lookup_forwarding_resolution_v4(
-            &state,
-            None,
-            dst_ip,
-            "sfmix.inet.0",
-            0,
-            true,
-        ),
+        resolution: lookup_forwarding_resolution_v4(&state, None, dst_ip, "sfmix.inet.0", 0, true),
         nat: NatDecision {
             rewrite_src: Some(IpAddr::V4(snat_ip)),
             ..NatDecision::default()
@@ -4425,10 +4375,18 @@ fn build_oversized_tcp_frame_for_ttl_gate(
                 PROTO_TCP,
                 ttl, // hop-limit field at IP-header offset 7
             ]);
-            frame
-                .extend_from_slice(&"2001:559:8585:ef00::102".parse::<Ipv6Addr>().unwrap().octets());
-            frame
-                .extend_from_slice(&"2001:559:8585:80::200".parse::<Ipv6Addr>().unwrap().octets());
+            frame.extend_from_slice(
+                &"2001:559:8585:ef00::102"
+                    .parse::<Ipv6Addr>()
+                    .unwrap()
+                    .octets(),
+            );
+            frame.extend_from_slice(
+                &"2001:559:8585:80::200"
+                    .parse::<Ipv6Addr>()
+                    .unwrap()
+                    .octets(),
+            );
             (54usize, 40usize)
         }
         _ => unreachable!(),
@@ -4507,8 +4465,7 @@ fn segment_forwarded_tcp_frames_keeps_fabric_ingress_low_ttl_both_families() {
         ("v4", libc::AF_INET, 8usize),
         ("v6", libc::AF_INET6, 7usize),
     ] {
-        let (frame, mut meta, decision, forwarding) =
-            build_oversized_tcp_frame_for_ttl_gate(af, 1);
+        let (frame, mut meta, decision, forwarding) = build_oversized_tcp_frame_for_ttl_gate(af, 1);
         meta.meta_flags = 0x80; // FABRIC_INGRESS_FLAG — peer already decremented
 
         let segments = segment_forwarded_tcp_frames_from_frame(
@@ -4552,10 +4509,14 @@ fn segment_forwarded_tcp_frames_keeps_fabric_ingress_low_ttl_both_families() {
 #[test]
 fn segment_forwarded_tcp_frames_drops_non_fabric_low_ttl_both_families() {
     for (label, af) in [("v4", libc::AF_INET), ("v6", libc::AF_INET6)] {
-        let (frame, meta, decision, forwarding) =
-            build_oversized_tcp_frame_for_ttl_gate(af, 1);
+        let (frame, meta, decision, forwarding) = build_oversized_tcp_frame_for_ttl_gate(af, 1);
         // meta_flags defaults to 0 (NOT fabric-ingress).
-        assert_eq!(meta.meta_flags & 0x80, 0, "[{}] expected non-fabric meta", label);
+        assert_eq!(
+            meta.meta_flags & 0x80,
+            0,
+            "[{}] expected non-fabric meta",
+            label
+        );
 
         let result = segment_forwarded_tcp_frames_from_frame(
             &frame,
@@ -4584,8 +4545,7 @@ fn segment_forwarded_tcp_frames_decrements_non_fabric_healthy_ttl_both_families(
         ("v4", libc::AF_INET, 8usize),
         ("v6", libc::AF_INET6, 7usize),
     ] {
-        let (frame, meta, decision, forwarding) =
-            build_oversized_tcp_frame_for_ttl_gate(af, 64);
+        let (frame, meta, decision, forwarding) = build_oversized_tcp_frame_for_ttl_gate(af, 64);
 
         let segments = segment_forwarded_tcp_frames_from_frame(
             &frame,
@@ -4620,10 +4580,10 @@ fn rewrite_forwarded_frame_in_place_keeps_tcp_checksum_valid_after_vlan_snat() {
         0x0800,
     );
     frame.extend_from_slice(&[
-        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
-        102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x00, 0x00, 0x50, 0x02, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd',
-        b'a', b't', b'a',
+        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61, 102,
+        172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x50, 0x02, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't',
+        b'a',
     ]);
     let ip_sum = checksum16(&frame[14..34]);
     frame[24] = (ip_sum >> 8) as u8;
@@ -4675,7 +4635,9 @@ fn rewrite_forwarded_frame_in_place_keeps_tcp_checksum_valid_after_vlan_snat() {
     )
     .expect("rewrite in place");
 
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("rewritten frame");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("rewritten frame");
     assert_eq!(u16::from_be_bytes([out[12], out[13]]), 0x8100);
     assert_eq!(u16::from_be_bytes([out[14], out[15]]) & 0x0fff, 80);
     assert_eq!(u16::from_be_bytes([out[16], out[17]]), 0x0800);
@@ -4750,7 +4712,9 @@ fn rewrite_forwarded_frame_in_place_keeps_tcp_checksum_valid_after_vlan_dnat() {
     )
     .expect("rewrite in place");
 
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("rewritten frame");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("rewritten frame");
     assert_eq!(u16::from_be_bytes([out[12], out[13]]), 0x0800);
     assert_eq!(&out[30..34], &[10, 0, 61, 102]);
     assert_eq!(out[22], 63);
@@ -4762,10 +4726,10 @@ fn rewrite_forwarded_frame_in_place_applies_nat_for_fabric_redirect_when_enabled
     let mut frame = Vec::new();
     write_eth_header(&mut frame, [0xaa; 6], [0xbb; 6], 0, 0x0800);
     frame.extend_from_slice(&[
-        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
-        102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x00, 0x00, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't',
-        b'd', b'a', b't', b'a',
+        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61, 102,
+        172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't',
+        b'a',
     ]);
     let ip_sum = checksum16(&frame[14..34]);
     frame[24] = (ip_sum >> 8) as u8;
@@ -4816,7 +4780,9 @@ fn rewrite_forwarded_frame_in_place_applies_nat_for_fabric_redirect_when_enabled
     )
     .expect("rewrite in place");
 
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("rewritten frame");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("rewritten frame");
     assert_eq!(&out[0..6], &[0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]);
     assert_eq!(&out[6..12], &[0x02, 0xbf, 0x72, 0xff, 0x00, 0x01]);
     assert_eq!(&out[26..30], &[172, 16, 80, 8]);
@@ -4837,10 +4803,10 @@ fn rewrite_forwarded_frame_in_place_skips_nat_for_fabric_redirect_when_disabled(
     let mut frame = Vec::new();
     write_eth_header(&mut frame, [0xaa; 6], [0xbb; 6], 0, 0x0800);
     frame.extend_from_slice(&[
-        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
-        102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x00, 0x00, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't',
-        b'd', b'a', b't', b'a',
+        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61, 102,
+        172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't',
+        b'a',
     ]);
     let ip_sum = checksum16(&frame[14..34]);
     frame[24] = (ip_sum >> 8) as u8;
@@ -4890,7 +4856,9 @@ fn rewrite_forwarded_frame_in_place_skips_nat_for_fabric_redirect_when_disabled(
     )
     .expect("rewrite in place");
 
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("rewritten frame");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("rewritten frame");
     // Source IP MUST be the original 10.0.61.102, not the SNAT'd
     // 198.51.100.99. This validates that apply_nat=false is
     // correctly threaded through the dispatch into rewrite_apply_v4.
@@ -4921,12 +4889,12 @@ fn rewrite_forwarded_frame_in_place_skips_ttl_when_fabric_ingress_flag_set() {
     // the IP header total_len matches the actual constructed
     // frame (Codex impl review round-1 caught a 0x0030 mismatch).
     let v4_header: Vec<u8> = vec![
-        0x45, 0x00, 0x00, 0x2c, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
-        102, 172, 16, 80, 200,
+        0x45, 0x00, 0x00, 0x2c, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61, 102,
+        172, 16, 80, 200,
     ];
     let v4_payload: Vec<u8> = vec![
-        0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x50, 0x10,
-        0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't',
+        0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x50, 0x10, 0x20,
+        0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't',
     ];
     let v6_header: Vec<u8> = vec![
         0x60, 0x00, 0x00, 0x00, 0x00, 0x14, PROTO_TCP, 64, // src 2001:db8::1
@@ -4935,8 +4903,8 @@ fn rewrite_forwarded_frame_in_place_skips_ttl_when_fabric_ingress_flag_set() {
         0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02, 0x00,
     ];
     let v6_payload: Vec<u8> = vec![
-        0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x50, 0x10,
-        0x20, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x50, 0x10, 0x20,
+        0x00, 0x00, 0x00, 0x00, 0x00,
     ];
     for (label, addr_family, ether_type, ip_header, ip_payload, ttl_rel_offset, src_ip) in [
         (
@@ -4966,8 +4934,7 @@ fn rewrite_forwarded_frame_in_place_skips_ttl_when_fabric_ingress_flag_set() {
             let ip_sum = checksum16(&frame[14..14 + ip_header.len()]);
             frame[24] = (ip_sum >> 8) as u8;
             frame[25] = ip_sum as u8;
-            recompute_l4_checksum_ipv4(&mut frame[14..], 20, PROTO_TCP, false)
-                .expect("v4 tcp sum");
+            recompute_l4_checksum_ipv4(&mut frame[14..], 20, PROTO_TCP, false).expect("v4 tcp sum");
         } else {
             recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("v6 tcp sum");
         }
@@ -5014,7 +4981,9 @@ fn rewrite_forwarded_frame_in_place_skips_ttl_when_fabric_ingress_flag_set() {
         )
         .unwrap_or_else(|| panic!("[{}] rewrite_in_place returned None", label));
 
-        let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("rewritten frame");
+        let out = area
+            .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+            .expect("rewritten frame");
         let post_ttl = out[14 + ttl_rel_offset];
         assert_eq!(
             pre_ttl, post_ttl,
@@ -5037,8 +5006,7 @@ fn test_descriptor(
     RewriteDescriptor {
         dst_mac: decision.resolution.neighbor_mac.unwrap_or([0; 6]),
         src_mac: decision.resolution.src_mac.unwrap_or([0; 6]),
-        fabric_redirect: decision.resolution.disposition
-            == ForwardingDisposition::FabricRedirect,
+        fabric_redirect: decision.resolution.disposition == ForwardingDisposition::FabricRedirect,
         tx_vlan_id: vlan_id,
         ether_type,
         rewrite_src_ip: decision.nat.rewrite_src,
@@ -5137,7 +5105,9 @@ fn apply_descriptor_ipv4_no_nat_ttl_and_checksum() {
     )
     .expect("descriptor rewrite");
 
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("out");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("out");
     // Ethernet header
     assert_eq!(&out[0..6], &[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
     assert_eq!(&out[6..12], &[0x02, 0xbf, 0x72, 0x00, 0x50, 0x08]);
@@ -5161,8 +5131,8 @@ fn apply_descriptor_ipv4_snat_with_vlan() {
         102, // src = 10.0.61.102
         172, 16, 80, 200, // dst = 172.16.80.200
         0x9c, 0x40, 0x14, 0x51, // src_port=40000 dst_port=5201
-        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
     ]);
     let ip_sum = checksum16(&frame[14..34]);
     frame[24] = (ip_sum >> 8) as u8;
@@ -5229,8 +5199,13 @@ fn apply_descriptor_ipv4_snat_with_vlan() {
     .expect("descriptor snat rewrite");
 
     assert_eq!(rewrite_result.offset, rx_addr - 4);
-    assert_eq!(rewrite_result.l2_rewrite, InPlaceL2Rewrite::VlanPushDescriptor);
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("out");
+    assert_eq!(
+        rewrite_result.l2_rewrite,
+        InPlaceL2Rewrite::VlanPushDescriptor
+    );
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("out");
     // VLAN tag added
     assert_eq!(u16::from_be_bytes([out[12], out[13]]), 0x8100);
     assert_eq!(u16::from_be_bytes([out[14], out[15]]) & 0x0fff, 80);
@@ -5251,10 +5226,10 @@ fn apply_descriptor_fabric_redirect_skips_nat_when_flag_is_false() {
     let mut frame = Vec::new();
     write_eth_header(&mut frame, [0xaa; 6], [0xbb; 6], 0, 0x0800);
     frame.extend_from_slice(&[
-        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61,
-        102, 172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-        0x00, 0x00, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't',
-        b'd', b'a', b't', b'a',
+        0x45, 0x00, 0x00, 0x30, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 61, 102,
+        172, 16, 80, 200, 0x9c, 0x40, 0x14, 0x51, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't',
+        b'a',
     ]);
     let ip_sum = checksum16(&frame[14..34]);
     frame[24] = (ip_sum >> 8) as u8;
@@ -5320,7 +5295,9 @@ fn apply_descriptor_fabric_redirect_skips_nat_when_flag_is_false() {
     )
     .expect("descriptor fabric rewrite");
 
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("out");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("out");
     assert_eq!(&out[0..6], &[0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]);
     assert_eq!(&out[6..12], &[0x02, 0xbf, 0x72, 0xff, 0x00, 0x01]);
     assert_eq!(&out[26..30], &[10, 0, 61, 102]);
@@ -5340,8 +5317,8 @@ fn apply_descriptor_ipv4_dnat_removes_vlan() {
         200, // src
         172, 16, 80, 8, // dst (pre-DNAT)
         0x14, 0x51, 0x9c, 0x40, // src_port=5201 dst_port=40000
-        0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00,
-        0x00, 0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
+        0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00,
+        0x00, b't', b'e', b's', b't', b'd', b'a', b't', b'a',
     ]);
     let ip_sum = checksum16(&frame[18..38]);
     frame[28] = (ip_sum >> 8) as u8;
@@ -5406,8 +5383,13 @@ fn apply_descriptor_ipv4_dnat_removes_vlan() {
     .expect("descriptor dnat rewrite");
 
     assert_eq!(rewrite_result.offset, 4);
-    assert_eq!(rewrite_result.l2_rewrite, InPlaceL2Rewrite::VlanPopDescriptor);
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("out");
+    assert_eq!(
+        rewrite_result.l2_rewrite,
+        InPlaceL2Rewrite::VlanPopDescriptor
+    );
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("out");
     // No VLAN
     assert_eq!(u16::from_be_bytes([out[12], out[13]]), 0x0800);
     // DNAT applied
@@ -5499,7 +5481,9 @@ fn apply_descriptor_ipv6_no_nat_hop_limit() {
     )
     .expect("descriptor ipv6 rewrite");
 
-    let out = area.slice(rewrite_result.offset as usize, rewrite_result.len as usize).expect("out");
+    let out = area
+        .slice(rewrite_result.offset as usize, rewrite_result.len as usize)
+        .expect("out");
     assert_eq!(&out[0..6], &[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
     assert_eq!(u16::from_be_bytes([out[12], out[13]]), 0x86dd);
     // Hop limit decremented
@@ -5521,8 +5505,8 @@ fn apply_descriptor_returns_none_on_port_mismatch() {
     let mut frame = Vec::new();
     write_eth_header(&mut frame, [0xaa; 6], [0xbb; 6], 0, 0x0800);
     frame.extend_from_slice(&[
-        0x45, 0x00, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 1,
-        102, 172, 16, 80, 200, 0x9c, 0x40, 0x01, 0xbb, // src=40000 dst=443
+        0x45, 0x00, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00, 64, PROTO_TCP, 0x00, 0x00, 10, 0, 1, 102,
+        172, 16, 80, 200, 0x9c, 0x40, 0x01, 0xbb, // src=40000 dst=443
         0, 0, 0, 1, 0, 0, 0, 0, 0x50, 0x10, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00,
     ]);
     let ip_sum = checksum16(&frame[14..34]);
@@ -5652,9 +5636,7 @@ fn apply_dscp_rewrite_to_ipv6_frame_updates_traffic_class() {
         58, 64, // next header + hop limit
     ]);
     frame.extend_from_slice(&Ipv6Addr::LOCALHOST.octets());
-    frame.extend_from_slice(
-        &Ipv6Addr::new(0x2001, 0x559, 0x8585, 0x80, 0, 0, 0, 0x200).octets(),
-    );
+    frame.extend_from_slice(&Ipv6Addr::new(0x2001, 0x559, 0x8585, 0x80, 0, 0, 0, 0x200).octets());
     frame.extend_from_slice(&[128, 0, 0, 0, 0, 1, 0, 1]);
 
     let l3 = frame_l3_offset(&frame).expect("l3");
@@ -5710,7 +5692,10 @@ fn adjust_l4_checksum_port_v4_skip_v6_no_skip() {
         adjust_l4_checksum_port(&mut p6, 0, PROTO_UDP, ChecksumFamily::V6, 0x1234, 0x4321),
         Some(())
     );
-    assert_eq!(p4, p6, "non-zero stored checksum: families behave identically");
+    assert_eq!(
+        p4, p6,
+        "non-zero stored checksum: families behave identically"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -5765,11 +5750,19 @@ fn frag_v6_packet(protocol: u8, frag_off: Option<u16>, payload: &[u8]) -> Vec<u8
 #[test]
 fn ipv4_non_first_fragment_predicate_truth_table() {
     // offset 0, MF=0 (atomic) and MF=1 (first) -> first/atomic, false.
-    assert!(!ipv4_is_non_first_fragment(&frag_v4_packet(PROTO_TCP, 0x0000, &[0; 8])));
-    assert!(!ipv4_is_non_first_fragment(&frag_v4_packet(PROTO_TCP, 0x2000, &[0; 8])));
+    assert!(!ipv4_is_non_first_fragment(&frag_v4_packet(
+        PROTO_TCP, 0x0000, &[0; 8]
+    )));
+    assert!(!ipv4_is_non_first_fragment(&frag_v4_packet(
+        PROTO_TCP, 0x2000, &[0; 8]
+    )));
     // offset != 0 -> non-first (with and without MF).
-    assert!(ipv4_is_non_first_fragment(&frag_v4_packet(PROTO_TCP, 0x0001, &[0; 8])));
-    assert!(ipv4_is_non_first_fragment(&frag_v4_packet(PROTO_TCP, 0x2001, &[0; 8])));
+    assert!(ipv4_is_non_first_fragment(&frag_v4_packet(
+        PROTO_TCP, 0x0001, &[0; 8]
+    )));
+    assert!(ipv4_is_non_first_fragment(&frag_v4_packet(
+        PROTO_TCP, 0x2001, &[0; 8]
+    )));
     // too-short slice -> false (length guards reject separately).
     assert!(!ipv4_is_non_first_fragment(&[0x45, 0x00, 0x00]));
 }
@@ -5777,13 +5770,86 @@ fn ipv4_non_first_fragment_predicate_truth_table() {
 #[test]
 fn ipv6_non_first_fragment_predicate_truth_table() {
     // No fragment header -> false.
-    assert!(!ipv6_is_non_first_fragment(&frag_v6_packet(PROTO_TCP, None, &[0; 8])));
+    assert!(!ipv6_is_non_first_fragment(&frag_v6_packet(
+        PROTO_TCP, None, &[0; 8]
+    )));
     // Fragment header, offset 0 (first/atomic) with MF=0 and MF=1 -> false.
-    assert!(!ipv6_is_non_first_fragment(&frag_v6_packet(PROTO_TCP, Some(0x0000), &[0; 8])));
-    assert!(!ipv6_is_non_first_fragment(&frag_v6_packet(PROTO_TCP, Some(0x0001), &[0; 8])));
+    assert!(!ipv6_is_non_first_fragment(&frag_v6_packet(
+        PROTO_TCP,
+        Some(0x0000),
+        &[0; 8]
+    )));
+    assert!(!ipv6_is_non_first_fragment(&frag_v6_packet(
+        PROTO_TCP,
+        Some(0x0001),
+        &[0; 8]
+    )));
     // Fragment header, offset bits set -> non-first.
-    assert!(ipv6_is_non_first_fragment(&frag_v6_packet(PROTO_TCP, Some(0x0008), &[0; 8])));
-    assert!(ipv6_is_non_first_fragment(&frag_v6_packet(PROTO_TCP, Some(0xABC8), &[0; 8])));
+    assert!(ipv6_is_non_first_fragment(&frag_v6_packet(
+        PROTO_TCP,
+        Some(0x0008),
+        &[0; 8]
+    )));
+    assert!(ipv6_is_non_first_fragment(&frag_v6_packet(
+        PROTO_TCP,
+        Some(0xABC8),
+        &[0; 8]
+    )));
+}
+
+// #2362: Junos `is-fragment` matches ANY fragment (first OR non-first), unlike
+// the non-first predicate above. The MF bit (0x2000) alone (offset 0) means a
+// FIRST fragment, which must match.
+#[test]
+fn ipv4_any_fragment_predicate_truth_table() {
+    // Unfragmented datagram (MF=0, offset=0) -> not a fragment.
+    assert!(!ipv4_is_any_fragment(&frag_v4_packet(
+        PROTO_TCP, 0x0000, &[0; 8]
+    )));
+    // DF set only (0x4000) -> still not a fragment.
+    assert!(!ipv4_is_any_fragment(&frag_v4_packet(
+        PROTO_TCP, 0x4000, &[0; 8]
+    )));
+    // First fragment (MF=1, offset=0) -> IS a fragment.
+    assert!(ipv4_is_any_fragment(&frag_v4_packet(
+        PROTO_TCP, 0x2000, &[0; 8]
+    )));
+    // Middle/last fragment (offset != 0) -> IS a fragment, MF set or not.
+    assert!(ipv4_is_any_fragment(&frag_v4_packet(
+        PROTO_TCP, 0x0001, &[0; 8]
+    )));
+    assert!(ipv4_is_any_fragment(&frag_v4_packet(
+        PROTO_TCP, 0x2001, &[0; 8]
+    )));
+    // Too-short slice -> false.
+    assert!(!ipv4_is_any_fragment(&[0x45, 0x00, 0x00]));
+}
+
+#[test]
+fn ipv6_any_fragment_predicate_truth_table() {
+    // No fragment header -> not a fragment.
+    assert!(!ipv6_is_any_fragment(&frag_v6_packet(
+        PROTO_TCP, None, &[0; 8]
+    )));
+    // Fragment header present, first fragment (offset 0, M=1) -> IS a fragment.
+    assert!(ipv6_is_any_fragment(&frag_v6_packet(
+        PROTO_TCP,
+        Some(0x0001),
+        &[0; 8]
+    )));
+    // Fragment header present, offset 0, M=0 (atomic-ish) -> still a fragment
+    // header is present, so Junos is-fragment matches.
+    assert!(ipv6_is_any_fragment(&frag_v6_packet(
+        PROTO_TCP,
+        Some(0x0000),
+        &[0; 8]
+    )));
+    // Middle/last fragment -> IS a fragment.
+    assert!(ipv6_is_any_fragment(&frag_v6_packet(
+        PROTO_TCP,
+        Some(0x0008),
+        &[0; 8]
+    )));
 }
 
 #[test]
@@ -5815,7 +5881,10 @@ fn apply_nat_ipv6_non_first_fragment_rewrites_ip_only() {
         ..NatDecision::default()
     };
     // rel_l4 = 48 (40 base + 8 fragment header).
-    assert_eq!(apply_nat_ipv6(&mut frag, 48, PROTO_TCP, nat, true), Some(()));
+    assert_eq!(
+        apply_nat_ipv6(&mut frag, 48, PROTO_TCP, nat, true),
+        Some(())
+    );
     assert_eq!(&frag[24..40], &new_dst.octets());
     assert_eq!(&frag[48..], &payload);
 }
@@ -5835,7 +5904,10 @@ fn enforce_expected_ports_skips_non_first_fragment() {
     )
     .expect("enforce");
     assert!(!repaired);
-    assert_eq!(frame, before, "non-first fragment payload must be untouched");
+    assert_eq!(
+        frame, before,
+        "non-first fragment payload must be untouched"
+    );
 }
 
 #[test]
@@ -5862,7 +5934,10 @@ fn clamp_tcp_mss_clamps_ext_headered_v6_syn() {
     let plen = (p.len() - 40) as u16;
     p[4..6].copy_from_slice(&plen.to_be_bytes());
 
-    assert!(super::tcp::clamp_tcp_mss(&mut p, 1400), "ext-headered v6 SYN must clamp");
+    assert!(
+        super::tcp::clamp_tcp_mss(&mut p, 1400),
+        "ext-headered v6 SYN must clamp"
+    );
     let mss = u16::from_be_bytes([p[48 + 22], p[48 + 23]]);
     assert_eq!(mss, 1400);
 }
@@ -5972,10 +6047,7 @@ fn local_origin_tunnel_tx_request_follows_supplied_state_destination() {
     let mut snapshot_new = native_gre_snapshot(true);
     snapshot_new.tunnel_endpoints[0].destination = "2602:ffd3:0:2::9".to_string();
     let state_new = build_forwarding_state(&snapshot_new);
-    let ha_state = BTreeMap::from([(
-        1,
-        active_ha_runtime(monotonic_nanos() / 1_000_000_000),
-    )]);
+    let ha_state = BTreeMap::from([(1, active_ha_runtime(monotonic_nanos() / 1_000_000_000))]);
     let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
     let packet = build_icmp_echo_frame_v4(
         Ipv4Addr::new(10, 255, 192, 42),
@@ -5983,13 +6055,23 @@ fn local_origin_tunnel_tx_request_follows_supplied_state_destination() {
         64,
     );
     // Outer IPv6 destination: eth(14) + vlan(4) + 24 = offset 42..58.
-    let plan_old =
-        build_local_origin_tunnel_tx_request(&packet[14..], 1, &state_old, &ha_state, &dynamic_neighbors)
-            .expect("old-state plan");
+    let plan_old = build_local_origin_tunnel_tx_request(
+        &packet[14..],
+        1,
+        &state_old,
+        &ha_state,
+        &dynamic_neighbors,
+    )
+    .expect("old-state plan");
     assert_eq!(plan_old.tx_request.bytes[57], 0x07, "old outer destination");
-    let plan_new =
-        build_local_origin_tunnel_tx_request(&packet[14..], 1, &state_new, &ha_state, &dynamic_neighbors)
-            .expect("new-state plan");
+    let plan_new = build_local_origin_tunnel_tx_request(
+        &packet[14..],
+        1,
+        &state_new,
+        &ha_state,
+        &dynamic_neighbors,
+    )
+    .expect("new-state plan");
     assert_eq!(
         plan_new.tx_request.bytes[57], 0x09,
         "destination edit reaches the encap as soon as the thread \

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -5878,6 +5878,10 @@ fn term_extra_non_first_icmp_fragment_suppresses_icmp_type_keeps_is_fragment() {
     assert_eq!(extra.icmp_code, 0);
     assert_eq!(extra.tcp_flags, 0);
     assert!(
+        !extra.l4_present,
+        "non-first fragment has no L4 header → l4_present must be false (the matcher gates on this, not the byte value)"
+    );
+    assert!(
         extra.is_fragment,
         "a non-first fragment IS a fragment (is-fragment must match)"
     );
@@ -5902,6 +5906,7 @@ fn term_extra_non_first_tcp_fragment_suppresses_tcp_flags() {
         extra.tcp_flags, 0,
         "non-first fragment must NOT expose payload-derived tcp_flags"
     );
+    assert!(!extra.l4_present, "non-first fragment → l4_present false");
     assert!(extra.is_fragment);
 }
 
@@ -5923,6 +5928,10 @@ fn term_extra_first_fragment_keeps_l4_fields() {
     assert_eq!(
         extra.icmp_type, 8,
         "first fragment carries the real ICMP type"
+    );
+    assert!(
+        extra.l4_present,
+        "first fragment carries the real L4 header → l4_present true"
     );
     assert!(extra.is_fragment, "first fragment IS a fragment");
 }

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -220,6 +220,12 @@ pub(super) fn build_local_time_exceeded_request(
         cos_queue_id: verdict.cos_queue_id,
         dscp_rewrite: verdict.dscp_rewrite,
         cos_tx_selection_resolved: true,
+        // #2362 fold B: TX-selection already resolved above via
+        // classify_generated_reply (which read the prebuilt frame), so the
+        // deferred recompute path is never taken for this request — Default is
+        // unused. The prebuilt frame was moved into `frame`, so it cannot be
+        // re-read here regardless.
+        filter_match_extra: crate::filter::TermMatchExtra::default(),
     })
 }
 
@@ -496,14 +502,10 @@ pub(super) fn build_reject_icmp_unreachable(
     match meta.addr_family as i32 {
         // ICMPv4 Destination Unreachable, code 13 (communication
         // administratively prohibited).
-        libc::AF_INET => {
-            build_local_icmp_error_v4(frame, meta, ingress_ifindex, forwarding, 3, 13)
-        }
+        libc::AF_INET => build_local_icmp_error_v4(frame, meta, ingress_ifindex, forwarding, 3, 13),
         // ICMPv6 Destination Unreachable, code 1 (communication with
         // destination administratively prohibited).
-        libc::AF_INET6 => {
-            build_local_icmp_error_v6(frame, meta, ingress_ifindex, forwarding, 1, 1)
-        }
+        libc::AF_INET6 => build_local_icmp_error_v6(frame, meta, ingress_ifindex, forwarding, 1, 1),
         _ => None,
     }
 }
@@ -625,7 +627,11 @@ mod tests {
         let out =
             build_local_icmp_error_v4(&frame, meta, ICMP_IFINDEX, &fwd, 11, 0).expect("v4 error");
 
-        assert_eq!(&out[12..14], &[0x81, 0x00], "reflected frame must carry an 802.1Q TPID");
+        assert_eq!(
+            &out[12..14],
+            &[0x81, 0x00],
+            "reflected frame must carry an 802.1Q TPID"
+        );
         assert_eq!(
             &out[14..16],
             &[0xA0, 0x00],
@@ -648,7 +654,11 @@ mod tests {
         let out =
             build_local_icmp_error_v4(&frame, meta, ICMP_IFINDEX, &fwd, 11, 0).expect("v4 error");
         assert_eq!(&out[12..14], &[0x81, 0x00]);
-        assert_eq!(&out[14..16], &100u16.to_be_bytes(), "VID 100 preserved, PCP 0");
+        assert_eq!(
+            &out[14..16],
+            &100u16.to_be_bytes(),
+            "VID 100 preserved, PCP 0"
+        );
         assert_eq!(out[18], 0x45);
     }
 
@@ -660,7 +670,11 @@ mod tests {
         let fwd = forwarding_with_egress(0);
         let out =
             build_local_icmp_error_v4(&frame, meta, ICMP_IFINDEX, &fwd, 11, 0).expect("v4 error");
-        assert_eq!(&out[12..14], &[0x08, 0x00], "EtherType IPv4 at byte 12 (untagged)");
+        assert_eq!(
+            &out[12..14],
+            &[0x08, 0x00],
+            "EtherType IPv4 at byte 12 (untagged)"
+        );
         assert_eq!(out[14], 0x45, "IPv4 outer header starts at offset 14");
     }
 
@@ -700,7 +714,12 @@ mod tests {
         frame.extend_from_slice(&8u16.to_be_bytes()); // payload = 8 (UDP hdr)
         frame.push(17); // next header UDP
         frame.push(64); // hop limit
-        frame.extend_from_slice(&"2001:559:8585:bf01::20".parse::<Ipv6Addr>().unwrap().octets());
+        frame.extend_from_slice(
+            &"2001:559:8585:bf01::20"
+                .parse::<Ipv6Addr>()
+                .unwrap()
+                .octets(),
+        );
         frame.extend_from_slice(&dst.octets());
         let l4 = frame.len();
         frame.extend_from_slice(&49152u16.to_be_bytes());

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -224,11 +224,17 @@ pub(super) fn retry_pending_neigh(
             binding.tx_pipeline.pending_fill_frames.push_back(pkt.addr);
             continue;
         };
+        // #2362 fold B: this is the ARP/NDP-resolved retransmit of a real
+        // buffered transit frame — build the fragment-safe per-packet match
+        // inputs from that frame so an output filter's tcp-flags / is-fragment /
+        // icmp-type term matches the same packet it would on the immediate path.
+        let cos_extra = crate::afxdp::frame::term_match_extra_from_frame(source_frame, pkt.meta);
         let cos = resolve_cos_tx_selection_at(
             forwarding,
             decision.resolution.egress_ifindex,
             pkt.meta,
             pkt.flow_key.as_ref(),
+            cos_extra,
             now_ns,
         );
         if cos.drop {
@@ -542,19 +548,22 @@ mod mirror_tests {
 
         let next_hop = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
         let meta = pending_neighbor_meta(original_frame.len());
-        push_pending(&mut bindings[0], PendingNeighPacket {
-            addr: 0,
-            desc: XdpDesc {
+        push_pending(
+            &mut bindings[0],
+            PendingNeighPacket {
                 addr: 0,
-                len: original_frame.len() as u32,
-                options: 0,
+                desc: XdpDesc {
+                    addr: 0,
+                    len: original_frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                decision: resolved_neighbor_decision(next_hop),
+                flow_key: Some(test_session_key(12345, 443)),
+                queued_ns: 0,
+                probe_attempts: 0,
             },
-            meta,
-            decision: resolved_neighbor_decision(next_hop),
-            flow_key: Some(test_session_key(12345, 443)),
-            queued_ns: 0,
-            probe_attempts: 0,
-        });
+        );
 
         let mut forwarding = ForwardingState::default();
         forwarding.neighbors.insert(
@@ -661,20 +670,23 @@ mod mirror_tests {
 
         let next_hop = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 137));
         let meta = pending_neighbor_meta(original_frame.len());
-        push_pending(&mut bindings[0], PendingNeighPacket {
-            addr: 0,
-            desc: XdpDesc {
+        push_pending(
+            &mut bindings[0],
+            PendingNeighPacket {
                 addr: 0,
-                len: original_frame.len() as u32,
-                options: 0,
+                desc: XdpDesc {
+                    addr: 0,
+                    len: original_frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                decision: resolved_neighbor_decision(next_hop),
+                flow_key: Some(test_session_key(12345, 443)),
+                queued_ns: 0,
+                // All probes already fired; the dst never resolved.
+                probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
             },
-            meta,
-            decision: resolved_neighbor_decision(next_hop),
-            flow_key: Some(test_session_key(12345, 443)),
-            queued_ns: 0,
-            // All probes already fired; the dst never resolved.
-            probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
-        });
+        );
 
         // No neighbor for `next_hop` anywhere → unresolved. Use the
         // compile-time fallback timeout (default ForwardingState leaves
@@ -789,19 +801,22 @@ mod mirror_tests {
         // the real dispatch path with the correct sum + bucket.
         let queued_ns = 1_000_000u64;
         let dwell_ns = 500_000_000u64; // 500 ms
-        push_pending(&mut bindings[0], PendingNeighPacket {
-            addr: 0,
-            desc: XdpDesc {
+        push_pending(
+            &mut bindings[0],
+            PendingNeighPacket {
                 addr: 0,
-                len: original_frame.len() as u32,
-                options: 0,
+                desc: XdpDesc {
+                    addr: 0,
+                    len: original_frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                decision: resolved_neighbor_decision(next_hop),
+                flow_key: Some(test_session_key(12345, 443)),
+                queued_ns,
+                probe_attempts: 0,
             },
-            meta,
-            decision: resolved_neighbor_decision(next_hop),
-            flow_key: Some(test_session_key(12345, 443)),
-            queued_ns,
-            probe_attempts: 0,
-        });
+        );
 
         let mut forwarding = ForwardingState::default();
         // Neighbor IS resolved now → the retry sweep dispatches it and
@@ -883,19 +898,22 @@ mod mirror_tests {
 
         let next_hop = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 138));
         let meta = pending_neighbor_meta(original_frame.len());
-        push_pending(&mut bindings[0], PendingNeighPacket {
-            addr: 0,
-            desc: XdpDesc {
+        push_pending(
+            &mut bindings[0],
+            PendingNeighPacket {
                 addr: 0,
-                len: original_frame.len() as u32,
-                options: 0,
+                desc: XdpDesc {
+                    addr: 0,
+                    len: original_frame.len() as u32,
+                    options: 0,
+                },
+                meta,
+                decision: resolved_neighbor_decision(next_hop),
+                flow_key: Some(test_session_key(12345, 443)),
+                queued_ns: 0,
+                probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
             },
-            meta,
-            decision: resolved_neighbor_decision(next_hop),
-            flow_key: Some(test_session_key(12345, 443)),
-            queued_ns: 0,
-            probe_attempts: PROBE_SCHEDULE_NS.len() as u8,
-        });
+        );
 
         // No neighbor anywhere → never resolves → timeout drop.
         let forwarding = ForwardingState::default();
@@ -1097,7 +1115,10 @@ mod pending_admission_tests {
     /// how much room remains.
     #[test]
     fn first_packet_buffers_siblings_duplicate_drop() {
-        assert_eq!(pending_neigh_admission(false, 0), PendingNeighAdmission::Buffer);
+        assert_eq!(
+            pending_neigh_admission(false, 0),
+            PendingNeighAdmission::Buffer
+        );
         assert_eq!(
             pending_neigh_admission(true, 1),
             PendingNeighAdmission::DuplicateDrop

--- a/userspace-dp/src/afxdp/poll_descriptor/filter.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/filter.rs
@@ -39,6 +39,8 @@
 // side-effect ordering, counter increments, or allocation sites change.
 
 use super::*;
+use crate::afxdp::frame::term_match_extra_from_frame;
+use crate::filter::TermMatchExtra;
 
 #[inline]
 pub(super) fn filter_log_ingress_zone_id(
@@ -83,6 +85,7 @@ pub(super) struct NonPbrInputFilterEval {
 #[inline(never)]
 pub(super) fn evaluate_non_pbr_input_filter(
     forwarding: &ForwardingState,
+    extra: TermMatchExtra,
     flow: Option<&SessionFlow>,
     meta: UserspaceDpMeta,
     ingress_zone_override: Option<u16>,
@@ -110,6 +113,7 @@ pub(super) fn evaluate_non_pbr_input_filter(
         flow.forward_key.src_port,
         flow.forward_key.dst_port,
         meta.dscp,
+        extra,
         meta.pkt_len as u64,
     );
     let ingress_zone_id =
@@ -127,6 +131,7 @@ pub(super) fn evaluate_non_pbr_input_filter(
 #[inline(never)]
 pub(super) fn evaluate_non_pbr_input_filter_log_only(
     forwarding: &ForwardingState,
+    extra: TermMatchExtra,
     flow: Option<&SessionFlow>,
     meta: UserspaceDpMeta,
     ingress_zone_override: Option<u16>,
@@ -151,6 +156,7 @@ pub(super) fn evaluate_non_pbr_input_filter_log_only(
         flow.forward_key.src_port,
         flow.forward_key.dst_port,
         meta.dscp,
+        extra,
         true,
     )?;
     Some(CachedInputFilterLog {
@@ -167,6 +173,7 @@ pub(super) fn evaluate_non_pbr_input_filter_log_only(
 #[inline]
 pub(super) fn evaluate_dscp_sensitive_input_filter_on_session_hit(
     forwarding: &ForwardingState,
+    frame: &[u8],
     flow: Option<&SessionFlow>,
     meta: UserspaceDpMeta,
     ingress_zone_override: Option<u16>,
@@ -179,15 +186,28 @@ pub(super) fn evaluate_dscp_sensitive_input_filter_on_session_hit(
     )
     .unwrap_or(meta.ingress_ifindex as i32);
     let is_v6 = matches!(flow.dst_ip, IpAddr::V6(_));
+    // #2362: re-evaluate on a session hit whenever the interface input filter
+    // carries EITHER a DSCP match term OR a per-packet L4 match term
+    // (tcp-flags / is-fragment / icmp-type / icmp-code). Both classes vary per
+    // packet within a flow, so the first-packet decision must not be replayed.
+    // The extra-build stays AFTER this gate so the common no-such-filter case
+    // pays only two FxHashSet lookups (this function is #[inline] on the hot
+    // session-hit path).
     if !crate::filter::interface_input_filter_has_dscp_match(
+        &forwarding.filter_state,
+        ingress_ifindex,
+        is_v6,
+    ) && !crate::filter::interface_input_filter_has_per_packet_l4_match(
         &forwarding.filter_state,
         ingress_ifindex,
         is_v6,
     ) {
         return None;
     }
+    let extra = term_match_extra_from_frame(frame, meta);
     Some(evaluate_non_pbr_input_filter(
         forwarding,
+        extra,
         Some(flow),
         meta,
         ingress_zone_override,
@@ -288,6 +308,7 @@ fn emit_cached_output_filter_log_tail(
 #[inline(never)]
 pub(super) fn apply_lo0_filter_action(
     forwarding: &ForwardingState,
+    extra: TermMatchExtra,
     event_stream: Option<&crate::event_stream::EventStreamWorkerHandle>,
     flow: Option<&SessionFlow>,
     meta: UserspaceDpMeta,
@@ -307,6 +328,7 @@ pub(super) fn apply_lo0_filter_action(
         flow.forward_key.src_port,
         flow.forward_key.dst_port,
         meta.dscp,
+        extra,
         meta.pkt_len as u64,
     );
     if let Some(log_match) = result.log_match {

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -426,6 +426,7 @@ pub(super) fn poll_binding_process_descriptor(
                         if let Some(input_filter_eval) =
                             evaluate_dscp_sensitive_input_filter_on_session_hit(
                                 worker_ctx.forwarding,
+                                packet_frame,
                                 Some(flow),
                                 meta,
                                 Some(resolved.metadata.ingress_zone),
@@ -449,6 +450,10 @@ pub(super) fn poll_binding_process_descriptor(
                             == ForwardingDisposition::LocalDelivery
                             && apply_lo0_filter_action(
                                 worker_ctx.forwarding,
+                                crate::afxdp::frame::term_match_extra_from_frame(
+                                    packet_frame,
+                                    meta,
+                                ),
                                 worker_ctx.event_stream,
                                 Some(flow),
                                 meta,
@@ -712,9 +717,7 @@ pub(super) fn poll_binding_process_descriptor(
                         // fail-OPEN that could leak it upstream on a default
                         // IPv6 route. Now MatchUnavailable fails CLOSED (drop +
                         // counter); only NoPrefixMatch continues IPv6 routing.
-                        let nat64_match = if pre_routing_dnat.is_none()
-                            && nptv6_inbound.is_none()
-                        {
+                        let nat64_match = if pre_routing_dnat.is_none() && nptv6_inbound.is_none() {
                             if let IpAddr::V6(dst_v6) = resolution_target {
                                 match worker_ctx.forwarding.nat64.classify_ipv6_dest(dst_v6) {
                                     crate::nat64::Nat64Match::NoPrefixMatch => None,
@@ -794,6 +797,7 @@ pub(super) fn poll_binding_process_descriptor(
                             .unwrap_or(flow.forward_key.dst_port);
                         let input_filter_eval = evaluate_non_pbr_input_filter(
                             worker_ctx.forwarding,
+                            crate::afxdp::frame::term_match_extra_from_frame(packet_frame, meta),
                             Some(flow),
                             meta,
                             ingress_zone_override,
@@ -813,6 +817,7 @@ pub(super) fn poll_binding_process_descriptor(
                         }
                         let route_table_override = ingress_route_table_override(
                             worker_ctx.forwarding,
+                            packet_frame,
                             meta,
                             flow,
                             ingress_zone_override,
@@ -924,7 +929,11 @@ pub(super) fn poll_binding_process_descriptor(
                         // (#2146 Err), fall back to a meta+flow info so the
                         // scan/sweep tuple and any drop event still carry
                         // the offending 5-tuple.
-                        let l3_off = if meta.ingress_vlan_present != 0 { 18 } else { 14 };
+                        let l3_off = if meta.ingress_vlan_present != 0 {
+                            18
+                        } else {
+                            14
+                        };
                         let screen_pkt = extract_screen_info(
                             packet_frame,
                             meta.addr_family,
@@ -1098,6 +1107,10 @@ pub(super) fn poll_binding_process_descriptor(
                         if resolution.disposition == ForwardingDisposition::LocalDelivery
                             && apply_lo0_filter_action(
                                 worker_ctx.forwarding,
+                                crate::afxdp::frame::term_match_extra_from_frame(
+                                    packet_frame,
+                                    meta,
+                                ),
                                 worker_ctx.event_stream,
                                 Some(flow),
                                 meta,
@@ -2407,6 +2420,14 @@ pub(super) fn poll_binding_process_descriptor(
                         None,
                         None,
                     ) {
+                        // #2362: capture the per-packet L4 match inputs from the
+                        // frame BEFORE `owned_packet_frame.take()` below moves the
+                        // backing buffer out — the flow-cache log-only evaluation
+                        // further down would otherwise borrow `packet_frame`
+                        // after the take. TermMatchExtra is a small Copy value
+                        // holding no borrow.
+                        let filter_match_extra =
+                            crate::afxdp::frame::term_match_extra_from_frame(packet_frame, meta);
                         request.frame = owned_packet_frame
                             .take()
                             .map(PendingForwardFrame::Owned)
@@ -2486,6 +2507,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 request_target_binding_index,
                                 evaluate_non_pbr_input_filter_log_only(
                                     worker_ctx.forwarding,
+                                    filter_match_extra,
                                     Some(flow),
                                     meta,
                                     ingress_zone_override,
@@ -2658,8 +2680,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 //     path for NAT64.
                                 // Both halves fall back to the original dst/port
                                 // when no inbound destination translation applies.
-                                let policy_dst_ip =
-                                    decision.nat.rewrite_dst.unwrap_or(flow.dst_ip);
+                                let policy_dst_ip = decision.nat.rewrite_dst.unwrap_or(flow.dst_ip);
                                 let policy_dst_port = decision
                                     .nat
                                     .rewrite_dst_port

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1260,6 +1260,13 @@ pub(super) fn poll_binding_process_descriptor(
                                             icmp_decision.resolution.egress_ifindex,
                                             meta,
                                             Some(&flow.forward_key),
+                                            // #2362 fold B: generated ICMP error
+                                            // reply — meta-only extra (tcp_flags
+                                            // authoritative; no per-packet frame
+                                            // re-read for this synthesized frame).
+                                            crate::afxdp::frame::term_match_extra_from_meta(
+                                                meta.into(),
+                                            ),
                                             now_ns,
                                         );
                                         if !cos.drop {
@@ -1288,6 +1295,11 @@ pub(super) fn poll_binding_process_descriptor(
                                                     cos_queue_id: cos.queue_id,
                                                     dscp_rewrite: cos.dscp_rewrite,
                                                     cos_tx_selection_resolved: true,
+                                                    // #2362 fold B: resolved
+                                                    // above; deferred recompute
+                                                    // not taken.
+                                                    filter_match_extra:
+                                                        crate::filter::TermMatchExtra::default(),
                                                 },
                                             );
                                             recycle_now = false;

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -73,6 +73,7 @@ fn empty_filter(name: &str, family: &str) -> Arc<Filter> {
         has_log_terms: false,
         has_terminal_action_terms: false,
         has_dscp_match_terms: false,
+        has_per_packet_l4_match_terms: false,
         has_three_color_policer_terms: false,
     })
 }
@@ -901,9 +902,8 @@ fn lookup_forward_nat_across_scopes_returns_shared_canonical_reverse_entry() {
         .expect("shared nat lock")
         .insert(canonical_reply.clone(), entry.clone());
 
-    let hit =
-        lookup_forward_nat_across_scopes(&sessions, &shared_nat_sessions, &canonical_reply)
-            .expect("shared canonical reverse hit");
+    let hit = lookup_forward_nat_across_scopes(&sessions, &shared_nat_sessions, &canonical_reply)
+        .expect("shared canonical reverse hit");
     assert_eq!(hit.key, entry.key);
     assert_eq!(hit.decision, entry.decision);
     assert_eq!(hit.metadata, entry.metadata);
@@ -956,8 +956,7 @@ fn publish_and_remove_shared_session_tracks_forward_wire_alias() {
         &entry.key,
     );
     assert!(
-        lookup_shared_forward_wire_match(&shared_forward_wire_sessions, &translated_key)
-            .is_none()
+        lookup_shared_forward_wire_match(&shared_forward_wire_sessions, &translated_key).is_none()
     );
 }
 
@@ -1064,9 +1063,7 @@ fn publish_and_remove_shared_session_tracks_owner_rg_indexes() {
     assert!(
         nat_index
             .get(&entry.metadata.owner_rg_id)
-            .is_some_and(
-                |keys| keys.contains(&reverse_wire) && keys.contains(&reverse_canonical)
-            )
+            .is_some_and(|keys| keys.contains(&reverse_wire) && keys.contains(&reverse_canonical))
     );
     drop(nat_index);
 
@@ -1388,8 +1385,7 @@ fn resolve_flow_session_decision_promotes_translated_shared_hit_on_active_fabric
 }
 
 #[test]
-fn resolve_flow_session_decision_promotes_local_synced_translated_hit_on_active_fabric_ingress()
-{
+fn resolve_flow_session_decision_promotes_local_synced_translated_hit_on_active_fabric_ingress() {
     let mut sessions = SessionTable::new();
     let key = test_key();
     let decision = SessionDecision {
@@ -1473,7 +1469,7 @@ fn resolve_flow_session_decision_promotes_local_synced_translated_hit_on_active_
 
 #[test]
 fn resolve_flow_session_decision_keeps_translated_shared_hit_transient_on_inactive_fabric_ingress()
- {
+{
     let mut sessions = SessionTable::new();
     let key = test_key();
     let decision = SessionDecision {
@@ -3146,7 +3142,14 @@ fn synthesized_synced_reverse_entry_uses_fabric_redirect_when_client_rg_inactive
     assert_eq!(reverse.decision.resolution.egress_ifindex, 21);
     assert_eq!(
         reverse.decision.resolution.src_mac,
-        Some([0x02, 0xbf, 0x72, FABRIC_ZONE_MAC_MAGIC, 0x00, TEST_WAN_ZONE_ID as u8])
+        Some([
+            0x02,
+            0xbf,
+            0x72,
+            FABRIC_ZONE_MAC_MAGIC,
+            0x00,
+            TEST_WAN_ZONE_ID as u8
+        ])
     );
     assert_eq!(reverse.metadata.owner_rg_id, 2);
     assert!(reverse.metadata.is_reverse);
@@ -3179,7 +3182,14 @@ fn session_hit_ha_inactive_uses_zone_encoded_fabric_redirect() {
     assert_eq!(redirected.tx_ifindex, 21);
     assert_eq!(
         redirected.src_mac,
-        Some([0x02, 0xbf, 0x72, FABRIC_ZONE_MAC_MAGIC, 0x00, TEST_SFMIX_ZONE_ID as u8])
+        Some([
+            0x02,
+            0xbf,
+            0x72,
+            FABRIC_ZONE_MAC_MAGIC,
+            0x00,
+            TEST_SFMIX_ZONE_ID as u8
+        ])
     );
 }
 
@@ -3568,8 +3578,7 @@ fn reverse_prewarm_index_tracks_split_reverse_owner_rg_candidate() {
 }
 
 #[test]
-fn reverse_session_from_split_owner_fabric_redirect_uses_fabric_return_when_client_rg_inactive()
-{
+fn reverse_session_from_split_owner_fabric_redirect_uses_fabric_return_when_client_rg_inactive() {
     let forwarding = test_forwarding_state_split_rgs();
     let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
     let ha_state = BTreeMap::from([(2, inactive_ha_runtime(1))]);
@@ -3894,9 +3903,7 @@ fn apply_worker_commands_dispatch_order_pin_with_demote_dedup() {
 
     {
         let mut pending = commands.lock().expect("commands lock");
-        pending.push_back(WorkerCommand::DemoteOwnerRGS {
-            owner_rgs: vec![5],
-        });
+        pending.push_back(WorkerCommand::DemoteOwnerRGS { owner_rgs: vec![5] });
         pending.push_back(WorkerCommand::UpsertSynced(synced_entry.clone()));
         pending.push_back(WorkerCommand::DemoteOwnerRGS {
             owner_rgs: vec![5, 5], // duplicate within the same command
@@ -3905,13 +3912,9 @@ fn apply_worker_commands_dispatch_order_pin_with_demote_dedup() {
             sequence: 7,
             owner_rgs: vec![5],
         });
-        pending.push_back(WorkerCommand::DemoteOwnerRGS {
-            owner_rgs: vec![7],
-        });
+        pending.push_back(WorkerCommand::DemoteOwnerRGS { owner_rgs: vec![7] });
         pending.push_back(WorkerCommand::EnqueueShapedLocal(shaped_req));
-        pending.push_back(WorkerCommand::RefreshOwnerRGS {
-            owner_rgs: vec![5],
-        });
+        pending.push_back(WorkerCommand::RefreshOwnerRGS { owner_rgs: vec![5] });
         pending.push_back(WorkerCommand::VacateAllSharedExactSlots);
     }
 
@@ -3972,8 +3975,14 @@ fn apply_worker_commands_dispatch_order_pin_with_demote_dedup() {
         .iter()
         .filter(|k| **k == key_rg7)
         .count();
-    assert_eq!(rg5_count, 1, "key_rg5 must appear exactly once in cancelled_keys");
-    assert_eq!(rg7_count, 1, "key_rg7 must appear exactly once in cancelled_keys");
+    assert_eq!(
+        rg5_count, 1,
+        "key_rg5 must appear exactly once in cancelled_keys"
+    );
+    assert_eq!(
+        rg7_count, 1,
+        "key_rg7 must appear exactly once in cancelled_keys"
+    );
     // Nothing else got cancelled.
     assert_eq!(results.cancelled_keys.len(), 2);
 
@@ -4080,10 +4089,10 @@ fn replicate_session_upsert_delivers_to_poisoned_queue() {
     for (worker_id, queue) in queues.iter().enumerate() {
         let pending = queue.lock().expect("queue unpoisoned after replicate");
         assert!(
-            pending
-                .iter()
-                .any(|command| matches!(command, WorkerCommand::UpsertSynced(replica)
-                    if replica.key == entry.key)),
+            pending.iter().any(
+                |command| matches!(command, WorkerCommand::UpsertSynced(replica)
+                    if replica.key == entry.key)
+            ),
             "worker {worker_id} missing UpsertSynced replica"
         );
     }
@@ -4103,10 +4112,10 @@ fn replicate_session_delete_delivers_to_poisoned_queue() {
     for (worker_id, queue) in queues.iter().enumerate() {
         let pending = queue.lock().expect("queue unpoisoned after replicate");
         assert!(
-            pending
-                .iter()
-                .any(|command| matches!(command, WorkerCommand::DeleteSynced(deleted)
-                    if deleted == &key)),
+            pending.iter().any(
+                |command| matches!(command, WorkerCommand::DeleteSynced(deleted)
+                    if deleted == &key)
+            ),
             "worker {worker_id} missing DeleteSynced"
         );
     }
@@ -4394,8 +4403,7 @@ fn shared_nat_displacement_counter_counts_collisions_not_republishes() {
     let mut promoted_canonical = w3_forward_entry(130, 40_005, snat_ip);
     promoted_canonical.origin = SessionOrigin::SharedPromote;
     let mut promoted_alias = promoted_canonical.clone();
-    promoted_alias.key =
-        forward_wire_key(&promoted_canonical.key, promoted_canonical.decision.nat);
+    promoted_alias.key = forward_wire_key(&promoted_canonical.key, promoted_canonical.decision.nat);
     let promote_map = Arc::new(Mutex::new(FastMap::default()));
     let before_promote = NAT_REVERSE_KEY_SHARED_DISPLACEMENTS.load(Ordering::Relaxed);
     for entry in [
@@ -4417,7 +4425,6 @@ fn shared_nat_displacement_counter_counts_collisions_not_republishes() {
         "SharedPromote canonical<->alias churn must not count (either order)"
     );
 }
-
 
 #[test]
 fn nat_reverse_key_warn_throttle_claims_once_per_window() {

--- a/userspace-dp/src/afxdp/tunnel.rs
+++ b/userspace-dp/src/afxdp/tunnel.rs
@@ -362,11 +362,17 @@ pub(super) fn build_local_origin_tunnel_tx_request(
         monotonic_nanos() / 1_000_000_000,
     );
     let now_ns = monotonic_nanos();
+    // #2362 fold B: local tunnel-origin path — the inner-frame L3/L4 offsets in
+    // `meta` describe the pre-encap packet, so use the meta-only extra
+    // (tcp_flags authoritative; is-fragment / icmp-type under-match on this rare
+    // local path rather than risk mis-parsing inner offsets).
+    let cos_extra = crate::afxdp::frame::term_match_extra_from_meta(meta.into());
     let cos = resolve_cos_tx_selection_at(
         forwarding,
         decision.resolution.egress_ifindex,
         meta,
         Some(&session_entry.key),
+        cos_extra,
         now_ns,
     );
     if cos.drop {

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -75,7 +75,12 @@ pub(in crate::afxdp) fn classify_generated_reply(
             filter_log: None,
         };
     };
-    let selection = resolve_cos_tx_selection_at(forwarding, egress_ifindex, meta, Some(&key), now_ns);
+    // #2362 fold B: classify the generated reply on its OWN bytes — build the
+    // fragment-safe per-packet match inputs from the reply frame so a
+    // tcp-flags / icmp-type output-filter term matches the reply correctly.
+    let extra = crate::afxdp::frame::term_match_extra_from_frame_fwd(frame, meta);
+    let selection =
+        resolve_cos_tx_selection_at(forwarding, egress_ifindex, meta, Some(&key), extra, now_ns);
     GeneratedReplyVerdict {
         drop: selection.drop,
         parse_error: false,
@@ -235,7 +240,12 @@ pub(in crate::afxdp) fn resolve_cos_queue_id(
     meta: impl Into<ForwardPacketMeta>,
     flow_key: Option<&SessionKey>,
 ) -> Option<u8> {
-    resolve_cos_tx_selection(forwarding, egress_ifindex, meta, flow_key).queue_id
+    // #2362 fold B: no frame at this queue-id-only entry; the meta-only extra
+    // covers tcp-flags (authoritative in meta) and under-matches is-fragment /
+    // icmp-type (acceptable — this path selects a queue, not a security verdict).
+    let meta = meta.into();
+    let extra = crate::afxdp::frame::term_match_extra_from_meta(meta);
+    resolve_cos_tx_selection(forwarding, egress_ifindex, meta, flow_key, extra).queue_id
 }
 
 pub(in crate::afxdp) fn resolve_cos_tx_selection(
@@ -243,8 +253,9 @@ pub(in crate::afxdp) fn resolve_cos_tx_selection(
     egress_ifindex: i32,
     meta: impl Into<ForwardPacketMeta>,
     flow_key: Option<&SessionKey>,
+    extra: crate::filter::TermMatchExtra,
 ) -> CoSTxSelection {
-    resolve_cos_tx_selection_internal(forwarding, egress_ifindex, meta, flow_key, None)
+    resolve_cos_tx_selection_internal(forwarding, egress_ifindex, meta, flow_key, extra, None)
 }
 
 pub(in crate::afxdp) fn resolve_cos_tx_selection_at(
@@ -252,9 +263,17 @@ pub(in crate::afxdp) fn resolve_cos_tx_selection_at(
     egress_ifindex: i32,
     meta: impl Into<ForwardPacketMeta>,
     flow_key: Option<&SessionKey>,
+    extra: crate::filter::TermMatchExtra,
     now_ns: u64,
 ) -> CoSTxSelection {
-    resolve_cos_tx_selection_internal(forwarding, egress_ifindex, meta, flow_key, Some(now_ns))
+    resolve_cos_tx_selection_internal(
+        forwarding,
+        egress_ifindex,
+        meta,
+        flow_key,
+        extra,
+        Some(now_ns),
+    )
 }
 
 fn resolve_cos_tx_selection_internal(
@@ -262,6 +281,7 @@ fn resolve_cos_tx_selection_internal(
     egress_ifindex: i32,
     meta: impl Into<ForwardPacketMeta>,
     flow_key: Option<&SessionKey>,
+    extra: crate::filter::TermMatchExtra,
     now_ns: Option<u64>,
 ) -> CoSTxSelection {
     let meta = meta.into();
@@ -367,6 +387,7 @@ fn resolve_cos_tx_selection_internal(
                 flow_key.src_port,
                 flow_key.dst_port,
                 meta.dscp,
+                extra,
                 meta.pkt_len as u64,
                 now_ns,
             )
@@ -379,6 +400,7 @@ fn resolve_cos_tx_selection_internal(
                 flow_key.src_port,
                 flow_key.dst_port,
                 meta.dscp,
+                extra,
                 meta.pkt_len as u64,
             )
         }
@@ -402,6 +424,7 @@ fn resolve_cos_tx_selection_internal(
                 flow_key.src_port,
                 flow_key.dst_port,
                 meta.dscp,
+                extra,
                 meta.pkt_len as u64,
                 now_ns,
             )
@@ -414,6 +437,7 @@ fn resolve_cos_tx_selection_internal(
                 flow_key.src_port,
                 flow_key.dst_port,
                 meta.dscp,
+                extra,
                 meta.pkt_len as u64,
             )
         };

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -2971,6 +2971,7 @@ fn resolve_cos_tx_selection_honors_tcp_flags_per_packet_match() {
         Some(&key),
         TermMatchExtra {
             tcp_flags: 0x02,
+            l4_present: true,
             ..Default::default()
         },
     );
@@ -2989,6 +2990,7 @@ fn resolve_cos_tx_selection_honors_tcp_flags_per_packet_match() {
         Some(&key),
         TermMatchExtra {
             tcp_flags: 0x10,
+            l4_present: true,
             ..Default::default()
         },
     );

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -6,6 +6,7 @@
 use super::*;
 use crate::afxdp::tx::test_support::*;
 use crate::afxdp::types::SharedCoSExactBacklog;
+use crate::filter::TermMatchExtra;
 use crate::{
     ClassOfServiceSnapshot, CoSDSCPClassifierEntrySnapshot, CoSDSCPClassifierSnapshot,
     CoSForwardingClassSnapshot, CoSIEEE8021ClassifierEntrySnapshot, CoSIEEE8021ClassifierSnapshot,
@@ -30,7 +31,7 @@ fn resolve_cos_queue_idx_rejects_explicit_queue_miss() {
             surplus_weight: 1,
             buffer_bytes: COS_MIN_BURST_BYTES,
             dscp_rewrite: None,
-        codel_target_ns: 0,
+            codel_target_ns: 0,
         }],
     );
 
@@ -55,7 +56,7 @@ fn enqueue_exact_queue_publishes_shared_backlog_slot() {
             surplus_weight: 1,
             buffer_bytes: 4_000_000,
             dscp_rewrite: None,
-        codel_target_ns: 0,
+            codel_target_ns: 0,
         }],
     );
     let mut fast_interfaces = test_cos_fast_interfaces(
@@ -272,7 +273,7 @@ fn cos_queue_accepts_prepared_when_queue_is_prepared_only() {
             surplus_weight: 1,
             buffer_bytes: COS_MIN_BURST_BYTES,
             dscp_rewrite: None,
-        codel_target_ns: 0,
+            codel_target_ns: 0,
         }],
     );
     root.queues[0]
@@ -321,7 +322,7 @@ fn demote_prepared_cos_queue_to_local_recycles_frames_and_blocks_prepared_append
             surplus_weight: 1,
             buffer_bytes: COS_MIN_BURST_BYTES,
             dscp_rewrite: None,
-        codel_target_ns: 0,
+            codel_target_ns: 0,
         }],
     );
     root.queues[0]
@@ -422,7 +423,7 @@ fn demote_prepared_cos_queue_to_local_preserves_mqfq_frontier() {
             surplus_weight: 1,
             buffer_bytes: 128 * 1024,
             dscp_rewrite: None,
-        codel_target_ns: 0,
+            codel_target_ns: 0,
         }],
     );
     let queue = &mut root.queues[0];
@@ -578,7 +579,7 @@ fn demote_prepared_cos_queue_to_local_skips_non_exact_queue() {
             surplus_weight: 1,
             buffer_bytes: COS_MIN_BURST_BYTES,
             dscp_rewrite: None,
-        codel_target_ns: 0,
+            codel_target_ns: 0,
         }],
     );
     root.queues[0]
@@ -690,7 +691,7 @@ fn resolve_cos_queue_id_prefers_egress_output_filter_forwarding_class() {
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
@@ -702,7 +703,7 @@ fn resolve_cos_queue_id_prefers_egress_output_filter_forwarding_class() {
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
@@ -797,7 +798,7 @@ fn resolve_cos_queue_id_uses_reverse_output_source_port_filter() {
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "scheduler-iperf-a".into(),
@@ -809,7 +810,7 @@ fn resolve_cos_queue_id_uses_reverse_output_source_port_filter() {
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
@@ -949,7 +950,7 @@ fn resolve_cached_cos_tx_selection_prefers_egress_output_filter_and_keeps_counte
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
@@ -961,7 +962,7 @@ fn resolve_cached_cos_tx_selection_prefers_egress_output_filter_and_keeps_counte
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
@@ -1070,7 +1071,7 @@ fn resolve_cos_queue_id_uses_ingress_input_filter_when_no_output_filter_exists()
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
@@ -1082,7 +1083,7 @@ fn resolve_cos_queue_id_uses_ingress_input_filter_when_no_output_filter_exists()
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
@@ -1187,7 +1188,7 @@ fn resolve_cached_cos_tx_selection_uses_ingress_input_filter_when_no_output_exis
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
@@ -1199,7 +1200,7 @@ fn resolve_cached_cos_tx_selection_uses_ingress_input_filter_when_no_output_exis
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
@@ -1288,7 +1289,7 @@ fn resolve_cached_cos_tx_selection_keeps_counter_only_output_filter_hits() {
                 surplus_sharing: false,
                 equal_flow_enforcement: false,
                 equal_flow_target_policy: String::new(),
-            codel_target_ns: 0,
+                codel_target_ns: 0,
             }],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
                 name: "wan-map".into(),
@@ -1370,7 +1371,7 @@ fn resolve_cos_tx_selection_counts_counter_only_output_filter_hits() {
                 surplus_sharing: false,
                 equal_flow_enforcement: false,
                 equal_flow_target_policy: String::new(),
-            codel_target_ns: 0,
+                codel_target_ns: 0,
             }],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
                 name: "wan-map".into(),
@@ -1403,6 +1404,7 @@ fn resolve_cos_tx_selection_counts_counter_only_output_filter_hits() {
             src_port: 12345,
             dst_port: 443,
         }),
+        TermMatchExtra::default(),
     );
 
     assert_eq!(selection.queue_id, Some(0));
@@ -1463,6 +1465,7 @@ fn resolve_cos_tx_selection_drops_terminal_output_filter_without_log() {
             src_port: 12345,
             dst_port: 443,
         }),
+        TermMatchExtra::default(),
     );
 
     assert!(selection.drop);
@@ -1515,6 +1518,7 @@ fn resolve_cos_tx_selection_drops_reject_output_filter_without_log() {
             src_port: 12345,
             dst_port: 443,
         }),
+        TermMatchExtra::default(),
     );
 
     assert!(selection.drop);
@@ -1583,7 +1587,7 @@ fn resolve_cos_tx_selection_uses_ingress_filter_dscp_rewrite_when_no_output_filt
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
@@ -1595,7 +1599,7 @@ fn resolve_cos_tx_selection_uses_ingress_filter_dscp_rewrite_when_no_output_filt
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
@@ -1634,6 +1638,7 @@ fn resolve_cos_tx_selection_uses_ingress_filter_dscp_rewrite_when_no_output_filt
             src_port: 12345,
             dst_port: 443,
         }),
+        TermMatchExtra::default(),
     );
 
     assert_eq!(selection.queue_id, Some(1));
@@ -1694,7 +1699,7 @@ fn resolve_cos_tx_selection_skips_ingress_filter_without_tx_selection_effects() 
                 surplus_sharing: false,
                 equal_flow_enforcement: false,
                 equal_flow_target_policy: String::new(),
-            codel_target_ns: 0,
+                codel_target_ns: 0,
             }],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
                 name: "wan-map".into(),
@@ -1727,6 +1732,7 @@ fn resolve_cos_tx_selection_skips_ingress_filter_without_tx_selection_effects() 
             src_port: 12345,
             dst_port: 443,
         }),
+        TermMatchExtra::default(),
     );
 
     assert_eq!(selection.queue_id, Some(7));
@@ -1793,6 +1799,7 @@ fn resolve_cos_tx_selection_returns_none_when_no_cos_or_tx_selection_filters_exi
             src_port: 12345,
             dst_port: 443,
         }),
+        TermMatchExtra::default(),
     );
 
     assert_eq!(selection.queue_id, None);
@@ -1839,7 +1846,7 @@ fn resolve_cos_queue_id_falls_back_to_default_queue_without_filter_match() {
                 surplus_sharing: false,
                 equal_flow_enforcement: false,
                 equal_flow_target_policy: String::new(),
-            codel_target_ns: 0,
+                codel_target_ns: 0,
             }],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
                 name: "wan-map".into(),
@@ -1924,7 +1931,7 @@ fn resolve_cos_queue_id_uses_dscp_classifier_when_filters_do_not_set_class() {
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "voice-sched".into(),
@@ -1936,7 +1943,7 @@ fn resolve_cos_queue_id_uses_dscp_classifier_when_filters_do_not_set_class() {
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
         }),
@@ -2022,7 +2029,7 @@ fn resolve_cos_queue_id_uses_ieee8021_classifier_when_filters_do_not_set_class()
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "voice-sched".into(),
@@ -2034,7 +2041,7 @@ fn resolve_cos_queue_id_uses_ieee8021_classifier_when_filters_do_not_set_class()
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
             ..Default::default()
@@ -2122,7 +2129,7 @@ fn resolve_cos_queue_id_does_not_use_ieee8021_classifier_for_untagged_packets() 
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "bulk-sched".into(),
@@ -2134,7 +2141,7 @@ fn resolve_cos_queue_id_does_not_use_ieee8021_classifier_for_untagged_packets() 
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
             ..Default::default()
@@ -2249,7 +2256,7 @@ fn resolve_cos_queue_id_preserves_ingress_classification_when_output_filter_has_
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
                 CoSSchedulerSnapshot {
                     name: "ef-sched".into(),
@@ -2261,7 +2268,7 @@ fn resolve_cos_queue_id_preserves_ingress_classification_when_output_filter_has_
                     surplus_sharing: false,
                     equal_flow_enforcement: false,
                     equal_flow_target_policy: String::new(),
-                codel_target_ns: 0,
+                    codel_target_ns: 0,
                 },
             ],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
@@ -2352,7 +2359,7 @@ fn resolve_cos_tx_selection_preserves_output_filter_dscp_rewrite_without_forward
                 surplus_sharing: false,
                 equal_flow_enforcement: false,
                 equal_flow_target_policy: String::new(),
-            codel_target_ns: 0,
+                codel_target_ns: 0,
             }],
             scheduler_maps: vec![CoSSchedulerMapSnapshot {
                 name: "wan-map".into(),
@@ -2384,6 +2391,7 @@ fn resolve_cos_tx_selection_preserves_output_filter_dscp_rewrite_without_forward
             src_port: 12345,
             dst_port: 443,
         }),
+        TermMatchExtra::default(),
     );
 
     assert_eq!(selection.queue_id, Some(7));
@@ -2496,7 +2504,10 @@ fn generated_v4_frame(protocol: u8, tos: u8, src_port: u16, dst_port: u16) -> Ve
     frame
 }
 
-fn forwarding_with_v4_output_filter(filter_name: &str, term: FirewallTermSnapshot) -> ForwardingState {
+fn forwarding_with_v4_output_filter(
+    filter_name: &str,
+    term: FirewallTermSnapshot,
+) -> ForwardingState {
     let snapshot = ConfigSnapshot {
         interfaces: vec![InterfaceSnapshot {
             name: "reth0.0".into(),
@@ -2530,7 +2541,10 @@ fn classify_generated_reply_drops_icmp_on_terminal_discard() {
     );
     let frame = generated_v4_frame(PROTO_ICMP, 0x00, 0, 0);
     let verdict = classify_generated_reply(&forwarding, 202, &frame, 0);
-    assert!(verdict.drop, "generated ICMP reply must be dropped by `then discard`");
+    assert!(
+        verdict.drop,
+        "generated ICMP reply must be dropped by `then discard`"
+    );
     assert!(!verdict.parse_error);
 }
 
@@ -2549,7 +2563,10 @@ fn classify_generated_reply_ignores_trigger_protocol_filter() {
     );
     let frame = generated_v4_frame(PROTO_ICMP, 0x00, 0, 0);
     let verdict = classify_generated_reply(&forwarding, 202, &frame, 0);
-    assert!(!verdict.drop, "a TCP-matching filter must not drop the generated ICMP reply");
+    assert!(
+        !verdict.drop,
+        "a TCP-matching filter must not drop the generated ICMP reply"
+    );
     assert!(!verdict.parse_error);
 }
 
@@ -2581,8 +2598,14 @@ fn classify_generated_reply_assigns_forwarding_class_queue() {
         }],
         class_of_service: Some(ClassOfServiceSnapshot {
             forwarding_classes: vec![
-                CoSForwardingClassSnapshot { name: "best-effort".into(), queue: 0 },
-                CoSForwardingClassSnapshot { name: "iperf-a".into(), queue: 4 },
+                CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                },
+                CoSForwardingClassSnapshot {
+                    name: "iperf-a".into(),
+                    queue: 4,
+                },
             ],
             schedulers: vec![
                 CoSSchedulerSnapshot {
@@ -2633,7 +2656,11 @@ fn classify_generated_reply_assigns_forwarding_class_queue() {
     let frame = generated_v4_frame(PROTO_TCP, 0x00, 80, 49152);
     let verdict = classify_generated_reply(&forwarding, 202, &frame, 0);
     assert!(!verdict.drop);
-    assert_eq!(verdict.cos_queue_id, Some(4), "generated RST routes to the iperf-a queue");
+    assert_eq!(
+        verdict.cos_queue_id,
+        Some(4),
+        "generated RST routes to the iperf-a queue"
+    );
 }
 
 #[test]
@@ -2655,7 +2682,10 @@ fn classify_generated_reply_fails_closed_on_parse_failure() {
     ];
     let verdict = classify_generated_reply(&forwarding, 202, &frame, 0);
     assert!(verdict.drop, "parse failure must fail CLOSED (drop)");
-    assert!(verdict.parse_error, "parse failure must set parse_error so the caller counts it");
+    assert!(
+        verdict.parse_error,
+        "parse failure must set parse_error so the caller counts it"
+    );
     assert_eq!(verdict.cos_queue_id, None);
 }
 
@@ -2703,6 +2733,7 @@ fn classify_generated_reply_counterfactual_trigger_keying_would_misverdict() {
             ..Default::default()
         },
         Some(&trigger_key),
+        TermMatchExtra::default(),
         0,
     );
     assert!(
@@ -2796,8 +2827,14 @@ fn classify_post_transform_inner_ptb_drops_on_terminal_discard() {
         "PTB advertises the inner MTU"
     );
     let verdict = classify_generated_reply(&forwarding, 202, &ptb, 0);
-    assert!(verdict.drop, "post-transform PTB must honor the output discard filter");
-    assert!(!verdict.parse_error, "a well-formed PTB must NOT fail as a parse error");
+    assert!(
+        verdict.drop,
+        "post-transform PTB must honor the output discard filter"
+    );
+    assert!(
+        !verdict.parse_error,
+        "a well-formed PTB must NOT fail as a parse error"
+    );
 }
 
 #[test]
@@ -2816,6 +2853,148 @@ fn classify_post_transform_inner_ptb_admitted_without_filter() {
     );
     let ptb = post_transform_inner_frag_needed_ptb(1325); // WG inner MTU
     let verdict = classify_generated_reply(&forwarding, 202, &ptb, 0);
-    assert!(!verdict.drop, "a TCP-only discard must not drop the ICMP PTB");
+    assert!(
+        !verdict.drop,
+        "a TCP-only discard must not drop the ICMP PTB"
+    );
     assert!(!verdict.parse_error);
+}
+
+// #2362 fold B: the TX-selection / CoS leg must honor a per-packet L4 match
+// condition. A `from { tcp-flags syn } then forwarding-class ef` output filter
+// selects the EF queue ONLY for a packet whose tcp_flags carry SYN; a non-SYN
+// packet of the same 5-tuple falls through to the interface default queue. This
+// fails if the TX-selection path reverts to TermMatchExtra::default() (the SYN
+// term would never match → no EF selection on any packet → silent under-match).
+#[test]
+fn resolve_cos_tx_selection_honors_tcp_flags_per_packet_match() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.0".into(),
+            ifindex: 202,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "wan-syn-ef".into(),
+            cos_scheduler_map: "wan-map".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "wan-syn-ef".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "syn-ef".into(),
+                protocols: vec!["tcp".into()],
+                action: "accept".into(),
+                forwarding_class: "expedited-forwarding".into(),
+                tcp_flags: Some(0x02), // SYN
+                ..Default::default()
+            }],
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![
+                CoSForwardingClassSnapshot {
+                    name: "best-effort".into(),
+                    queue: 0,
+                },
+                CoSForwardingClassSnapshot {
+                    name: "expedited-forwarding".into(),
+                    queue: 1,
+                },
+            ],
+            schedulers: vec![
+                CoSSchedulerSnapshot {
+                    name: "be-sched".into(),
+                    transmit_rate_bytes: 4_000_000,
+                    transmit_rate_exact: false,
+                    priority: "low".into(),
+                    buffer_size_bytes: 128_000,
+                    buffer_size_percent: 0.0,
+                    surplus_sharing: false,
+                    equal_flow_enforcement: false,
+                    equal_flow_target_policy: String::new(),
+                    codel_target_ns: 0,
+                },
+                CoSSchedulerSnapshot {
+                    name: "ef-sched".into(),
+                    transmit_rate_bytes: 6_000_000,
+                    transmit_rate_exact: false,
+                    priority: "strict-high".into(),
+                    buffer_size_bytes: 64_000,
+                    buffer_size_percent: 0.0,
+                    surplus_sharing: false,
+                    equal_flow_enforcement: false,
+                    equal_flow_target_policy: String::new(),
+                    codel_target_ns: 0,
+                },
+            ],
+            scheduler_maps: vec![CoSSchedulerMapSnapshot {
+                name: "wan-map".into(),
+                entries: vec![
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "best-effort".into(),
+                        scheduler: "be-sched".into(),
+                    },
+                    CoSSchedulerMapEntrySnapshot {
+                        forwarding_class: "expedited-forwarding".into(),
+                        scheduler: "ef-sched".into(),
+                    },
+                ],
+            }],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+        }),
+        ..Default::default()
+    };
+
+    let forwarding = build_forwarding_state(&snapshot);
+    let key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 100)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+        src_port: 12345,
+        dst_port: 443,
+    };
+    let meta = || UserspaceDpMeta {
+        ingress_ifindex: 5,
+        addr_family: libc::AF_INET as u8,
+        pkt_len: 1514,
+        protocol: PROTO_TCP,
+        ..Default::default()
+    };
+
+    // SYN packet -> tcp-flags term matches -> EF (queue 1).
+    let syn = resolve_cos_tx_selection(
+        &forwarding,
+        202,
+        meta(),
+        Some(&key),
+        TermMatchExtra {
+            tcp_flags: 0x02,
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        syn.queue_id,
+        Some(1),
+        "SYN must select the EF forwarding-class queue"
+    );
+
+    // Pure-ACK packet -> tcp-flags term does NOT match -> interface default queue
+    // (queue 0), NOT EF.
+    let ack = resolve_cos_tx_selection(
+        &forwarding,
+        202,
+        meta(),
+        Some(&key),
+        TermMatchExtra {
+            tcp_flags: 0x10,
+            ..Default::default()
+        },
+    );
+    assert_ne!(
+        ack.queue_id,
+        Some(1),
+        "a non-SYN packet must NOT be classified into the SYN-gated EF queue (#2362 fold B)"
+    );
 }

--- a/userspace-dp/src/afxdp/tx/dispatch/cos.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/cos.rs
@@ -138,11 +138,15 @@ pub(super) fn resolve_pending_forward_cos_tx_selection(
     request: &PendingForwardRequest,
     now_ns: u64,
 ) -> CoSTxSelection {
+    // #2362 fold B: the deferred forward request runs after the UMEM frame may
+    // have been recycled, so it consumes the per-packet match inputs snapshotted
+    // at build time from the live frame rather than re-reading the frame.
     resolve_cos_tx_selection_at(
         forwarding,
         request.decision.resolution.egress_ifindex,
         request.meta,
         request.flow_key.as_ref(),
+        request.filter_match_extra,
         now_ns,
     )
 }

--- a/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
@@ -89,6 +89,7 @@ fn test_pending_forward_request(
         cos_queue_id: None,
         dscp_rewrite: None,
         cos_tx_selection_resolved,
+        filter_match_extra: crate::filter::TermMatchExtra::default(),
     }
 }
 
@@ -123,6 +124,7 @@ fn test_live_forward_request_for_frame(
         cos_queue_id: None,
         dscp_rewrite: None,
         cos_tx_selection_resolved: true,
+        filter_match_extra: crate::filter::TermMatchExtra::default(),
     }
 }
 
@@ -970,7 +972,10 @@ fn enqueue_failure_conserves_free_frames_across_many_forwards() {
         "every ingress descriptor must be recycled exactly once — no leak, \
          no double-recycle"
     );
-    assert_eq!(dbg.build_fail as usize, N, "every forward hit build failure");
+    assert_eq!(
+        dbg.build_fail as usize, N,
+        "every forward hit build failure"
+    );
     assert_eq!(
         bindings[0].live.slow_path_drops.load(Ordering::Relaxed) as usize,
         N,
@@ -1056,7 +1061,12 @@ fn run_ptb_dispatch(egress_mtu: usize) -> (Vec<BindingWorker>, DebugPollCounters
 /// the fail-on-revert tests can assert the generated-reply drop counters.
 fn run_ptb_dispatch_with_forwarding(
     forwarding: ForwardingState,
-) -> (Vec<BindingWorker>, DebugPollCounters, BatchCounters, Vec<String>) {
+) -> (
+    Vec<BindingWorker>,
+    DebugPollCounters,
+    BatchCounters,
+    Vec<String>,
+) {
     let mut bindings = vec![
         BindingWorker::new_for_mirror_test(0, 0, 11, 0),
         BindingWorker::new_for_mirror_test(1, 0, 22, 0),
@@ -1064,14 +1074,9 @@ fn run_ptb_dispatch_with_forwarding(
     // 1600-byte L3 payload -> 1614-byte frame. Fits a 4096 UMEM frame but
     // exceeds a 1400 egress MTU.
     let frame = large_udp_v4_df_frame(1600);
-    unsafe {
-        bindings[0]
-            .umem
-            .area()
-            .slice_mut_unchecked(0, frame.len())
-    }
-    .expect("ingress frame")
-    .copy_from_slice(&frame);
+    unsafe { bindings[0].umem.area().slice_mut_unchecked(0, frame.len()) }
+        .expect("ingress frame")
+        .copy_from_slice(&frame);
 
     let lookup = WorkerBindingLookup::from_bindings(&bindings);
     let mirror_targets = MirrorTargetMap::default();
@@ -1140,9 +1145,16 @@ fn oversized_forward_emits_ptb_and_drops_original() {
         "exactly one ICMP Frag-Needed must be enqueued on the ingress binding"
     );
     let reply = &ingress_tx[0];
-    assert_eq!(reply.egress_ifindex, 11, "PTB leaves via the ingress interface");
+    assert_eq!(
+        reply.egress_ifindex, 11,
+        "PTB leaves via the ingress interface"
+    );
     let b = &reply.bytes;
-    assert_eq!(&b[0..6], &[0x00, 0x25, 0x90, 0x12, 0x34, 0x56], "reflected to the sender");
+    assert_eq!(
+        &b[0..6],
+        &[0x00, 0x25, 0x90, 0x12, 0x34, 0x56],
+        "reflected to the sender"
+    );
     assert_eq!(&b[12..14], &[0x08, 0x00], "IPv4 reply");
     assert_eq!(b[14], 0x45);
     assert_eq!(b[23], PROTO_ICMP, "outer ICMP");
@@ -1200,7 +1212,10 @@ fn in_mtu_forward_emits_no_ptb_counterfactual() {
     // proving the in-MTU fast path is untouched.
     let egress_tx = bindings[1].tx_pipeline.pending_tx_local.len()
         + bindings[1].tx_pipeline.pending_tx_prepared.len();
-    assert_eq!(egress_tx, 1, "in-MTU frame must forward to the egress binding");
+    assert_eq!(
+        egress_tx, 1,
+        "in-MTU frame must forward to the egress binding"
+    );
 }
 
 /// #2328: build a v4 output firewall filter on the PTB egress interface
@@ -1244,8 +1259,8 @@ fn forwarding_for_ptb_with_output_term(
 /// enqueued and this assertion fails.
 #[test]
 fn ptb_dropped_by_egress_output_filter_discard() {
-    let (bindings, _dbg, counters, reasons) = run_ptb_dispatch_with_forwarding(
-        forwarding_for_ptb_with_output_term(
+    let (bindings, _dbg, counters, reasons) =
+        run_ptb_dispatch_with_forwarding(forwarding_for_ptb_with_output_term(
             1400,
             crate::FirewallTermSnapshot {
                 name: "drop-icmp".into(),
@@ -1253,8 +1268,7 @@ fn ptb_dropped_by_egress_output_filter_discard() {
                 protocols: vec!["icmp".into()],
                 ..Default::default()
             },
-        ),
-    );
+        ));
     // The generated PTB was DROPPED (not enqueued) by the output `discard`.
     assert_eq!(
         bindings[0].tx_pipeline.pending_tx_local.len(),
@@ -1281,8 +1295,8 @@ fn ptb_dropped_by_egress_output_filter_discard() {
 /// Exceeded `ignores_trigger_matching_output_filter` test.
 #[test]
 fn ptb_ignores_trigger_matching_output_filter() {
-    let (bindings, _dbg, counters, _reasons) = run_ptb_dispatch_with_forwarding(
-        forwarding_for_ptb_with_output_term(
+    let (bindings, _dbg, counters, _reasons) =
+        run_ptb_dispatch_with_forwarding(forwarding_for_ptb_with_output_term(
             1400,
             crate::FirewallTermSnapshot {
                 name: "drop-udp".into(),
@@ -1290,8 +1304,7 @@ fn ptb_ignores_trigger_matching_output_filter() {
                 protocols: vec!["udp".into()],
                 ..Default::default()
             },
-        ),
-    );
+        ));
     assert_eq!(
         bindings[0].tx_pipeline.pending_tx_local.len(),
         1,
@@ -1308,8 +1321,8 @@ fn ptb_ignores_trigger_matching_output_filter() {
 /// `dscp_rewrite: None` makes the asserted rewrite disappear.
 #[test]
 fn ptb_dscp_rewrite_comes_from_classifier_not_none() {
-    let (bindings, _dbg, counters, _reasons) = run_ptb_dispatch_with_forwarding(
-        forwarding_for_ptb_with_output_term(
+    let (bindings, _dbg, counters, _reasons) =
+        run_ptb_dispatch_with_forwarding(forwarding_for_ptb_with_output_term(
             1400,
             crate::FirewallTermSnapshot {
                 name: "mark-icmp".into(),
@@ -1318,8 +1331,7 @@ fn ptb_dscp_rewrite_comes_from_classifier_not_none() {
                 dscp_rewrite: Some(46),
                 ..Default::default()
             },
-        ),
-    );
+        ));
     let ptb = &bindings[0].tx_pipeline.pending_tx_local;
     assert_eq!(ptb.len(), 1, "PTB accepted (then accept) and enqueued");
     assert_eq!(
@@ -1345,7 +1357,10 @@ fn ptb_parse_failure_fails_closed_with_parse_error_verdict() {
     // reject them, exactly the canary a malformed PTB builder would hit.
     let malformed: Vec<u8> = vec![0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
     let verdict = classify_generated_reply(&forwarding, 11, &malformed, 1);
-    assert!(verdict.drop, "unparseable generated bytes must fail CLOSED (drop)");
+    assert!(
+        verdict.drop,
+        "unparseable generated bytes must fail CLOSED (drop)"
+    );
     assert!(
         verdict.parse_error,
         "the drop must be attributed as a parse error so the PTB path bumps generated_reply_classify_parse_errors"

--- a/userspace-dp/src/afxdp/types/tx.rs
+++ b/userspace-dp/src/afxdp/types/tx.rs
@@ -85,6 +85,14 @@ pub(in crate::afxdp) struct PendingForwardRequest {
     pub(in crate::afxdp) cos_queue_id: Option<u8>,
     pub(in crate::afxdp) dscp_rewrite: Option<u8>,
     pub(in crate::afxdp) cos_tx_selection_resolved: bool,
+    /// #2362 fold B: the per-packet L4 firewall-filter match inputs (tcp-flags
+    /// / is-fragment / icmp-type / icmp-code), captured from the live frame at
+    /// request-build time. The deferred TX-selection / CoS path
+    /// (resolve_pending_forward_cos_tx_selection) runs after the UMEM frame may
+    /// have been recycled, so it cannot re-read the frame — it consumes this
+    /// snapshot. Built fragment-safe (a non-first fragment zeroes the
+    /// L4-derived fields). Default for non-frame-derived requests.
+    pub(in crate::afxdp) filter_match_extra: crate::filter::TermMatchExtra,
 }
 
 pub(in crate::afxdp) struct PreparedTxRequest {
@@ -198,4 +206,3 @@ pub(in crate::afxdp) struct LocalTunnelTxPlan {
     pub(in crate::afxdp) session_entry: SyncedSessionEntry,
     pub(in crate::afxdp) reverse_session_entry: Option<SyncedSessionEntry>,
 }
-

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -76,8 +76,7 @@ pub(crate) fn worker_loop(
     // Worker calls publish_from_local() each ~1s tick alongside the
     // runtime_atomics.publish(). Coordinator status path reads via
     // snapshot() at each /metrics scrape.
-    cold_path_atomics:
-        Arc<crate::afxdp::cold_path_hist::WorkerColdPathAtomics>,
+    cold_path_atomics: Arc<crate::afxdp::cold_path_hist::WorkerColdPathAtomics>,
 ) {
     // #1776: one-shot setup moved verbatim to setup.rs. The returned
     // WorkerLoopSetup is destructured into the same-named locals so
@@ -193,13 +192,11 @@ pub(crate) fn worker_loop(
                 refresh_worker_cos_queue_lease_runtime_counters(&mut wr_counters, &bindings);
                 wr_counters.session_table_entries = sessions.len() as u64;
                 wr_counters.max_sessions = sessions.max_sessions() as u64;
-                wr_counters.nat_reverse_key_collisions =
-                    sessions.nat_reverse_key_collisions();
+                wr_counters.nat_reverse_key_collisions = sessions.nat_reverse_key_collisions();
                 // #1861: install-refusal trio from the worker's
                 // SessionTable (create_drops was write-only before).
                 wr_counters.session_create_drops = sessions.create_drops();
-                wr_counters.session_install_admission_refused =
-                    sessions.admission_refused();
+                wr_counters.session_install_admission_refused = sessions.admission_refused();
                 wr_counters.session_install_partial = sessions.install_partial();
                 // #1760 W1: durable artifact for the reverse-key-collision
                 // watch. The in-process counters reset on every restart
@@ -229,9 +226,7 @@ pub(crate) fn worker_loop(
                              events (>=1 means a real collision occurred; not a \
                              pair census — standing collisions against an \
                              already-unindexed session are not counted)",
-                            worker_id,
-                            wr_counters.nat_reverse_key_collisions,
-                            shared_displacements,
+                            worker_id, wr_counters.nat_reverse_key_collisions, shared_displacements,
                         );
                         wr_prev_nat_collisions = wr_counters.nat_reverse_key_collisions;
                         wr_prev_shared_displacements = shared_displacements;
@@ -252,21 +247,18 @@ pub(crate) fn worker_loop(
                     let mut merged = cph::WorkerColdPathCounters::default();
                     for binding in bindings.iter() {
                         let src = &binding.cold_path;
-                        merged.sample_phase = merged
-                            .sample_phase
-                            .saturating_add(src.sample_phase);
+                        merged.sample_phase = merged.sample_phase.saturating_add(src.sample_phase);
                         merged.wrapper_underflow_count = merged
                             .wrapper_underflow_count
                             .saturating_add(src.wrapper_underflow_count);
                         for slot in 0..cph::POLICY_COLD_PATH_ZONE_PAIR_SLOTS {
-                            merged.sum_ns[slot] = merged.sum_ns[slot]
-                                .saturating_add(src.sum_ns[slot]);
-                            merged.samples[slot] = merged.samples[slot]
-                                .saturating_add(src.samples[slot]);
+                            merged.sum_ns[slot] =
+                                merged.sum_ns[slot].saturating_add(src.sum_ns[slot]);
+                            merged.samples[slot] =
+                                merged.samples[slot].saturating_add(src.samples[slot]);
                             for b in 0..cph::POLICY_COLD_PATH_HIST_BUCKETS {
-                                merged.buckets[slot][b] = merged.buckets
-                                    [slot][b]
-                                    .saturating_add(src.buckets[slot][b]);
+                                merged.buckets[slot][b] =
+                                    merged.buckets[slot][b].saturating_add(src.buckets[slot][b]);
                             }
                             // first_key + builder_collision cross-binding merge.
                             if merged.first_key[slot] == 0 {
@@ -285,8 +277,7 @@ pub(crate) fn worker_loop(
                     // not yet installed).
                     if let Some(first) = bindings.first() {
                         merged.ns_per_tsc_q32 = first.cold_path.ns_per_tsc_q32;
-                        merged.wrapper_ns_baseline =
-                            first.cold_path.wrapper_ns_baseline;
+                        merged.wrapper_ns_baseline = first.cold_path.wrapper_ns_baseline;
                         merged.clock_source = first.cold_path.clock_source;
                     }
                     cold_path_atomics.publish_from_local(&merged);
@@ -307,11 +298,24 @@ pub(crate) fn worker_loop(
             // Compare BEFORE assignment — needs both old and new.
             let cos_changed =
                 cos_runtime_config_changed(forwarding.as_ref(), new_forwarding.as_ref());
-            let (purge_input_dscp_v4, purge_input_dscp_v6) =
+            let (dscp_changed_v4, dscp_changed_v6) =
                 crate::filter::input_dscp_filter_families_changed(
                     &forwarding.filter_state,
                     &new_forwarding.filter_state,
                 );
+            // #2362: a per-packet-L4 (tcp-flags / is-fragment / icmp-type /
+            // icmp-code) input filter rotation has the same revalidation
+            // requirement as a DSCP filter rotation — established sessions whose
+            // first packet was admitted under the old term set must be purged so
+            // the new term is re-evaluated. Fold the two change-sets into one
+            // purge per family.
+            let (per_packet_changed_v4, per_packet_changed_v6) =
+                crate::filter::input_per_packet_l4_filter_families_changed(
+                    &forwarding.filter_state,
+                    &new_forwarding.filter_state,
+                );
+            let purge_input_dscp_v4 = dscp_changed_v4 || per_packet_changed_v4;
+            let purge_input_dscp_v6 = dscp_changed_v6 || per_packet_changed_v6;
 
             // Use NEW values for dependent state updates (forwarding-site
             // ordering — old `forwarding` is stale once rotated).
@@ -355,9 +359,7 @@ pub(crate) fn worker_loop(
                     // (new == None) keeps its stale local data harmlessly
                     // — it is unmapped, never sampled, and gets zeroed
                     // when next reassigned.
-                    if new_pair.is_some()
-                        && new_pair != old_inverse.get(slot).copied().flatten()
-                    {
+                    if new_pair.is_some() && new_pair != old_inverse.get(slot).copied().flatten() {
                         for binding in bindings.iter_mut() {
                             binding.cold_path.zero_slot(slot);
                         }

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -164,9 +164,14 @@ The `tcp_flags_mask` / `is_fragment` / `icmp_type` / `icmp_code` inputs are
 carried in a small `TermMatchExtra` built once per packet at the filter-eval
 call sites (`term_match_extra_from_frame` and its `ForwardPacketMeta` /
 meta-only variants). The builder is fragment-safe: for a NON-FIRST fragment
-(no L4 header at `l4_offset` — its bytes are payload) the L4-derived inputs
-(`tcp_flags` / `icmp_type` / `icmp_code`) are forced to 0 so those terms fail
-closed, while the L3-derived `is_fragment` bit stays true. This applies on the
+(no L4 header at `l4_offset` — its bytes are payload) it sets an explicit
+`l4_present = false`, and the matcher (`per_packet_l4_matches`) gates the
+tcp-flags / icmp-type / icmp-code constraints on that flag — NOT on the byte
+value, because 0 is a valid `icmp-type` (echo-reply) and a valid `icmp-code`, so
+a zeroed byte would still match `from { icmp-type 0 }` / `from { icmp-code 0 }`.
+The L4 byte fields are also zeroed (defense-in-depth) but the gate is the flag.
+The L3-derived `is_fragment` bit is NOT gated by `l4_present` and stays true
+(a non-first fragment IS a fragment). This applies on the
 CoS / TX-selection leg too (`tx/cos_classify.rs`): the TX-selection evaluators
 thread the same `TermMatchExtra`, and the deferred path snapshots it on
 `PendingForwardRequest.filter_match_extra` because the UMEM frame may be

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -154,10 +154,10 @@ exactly one of these two classes:
 | `destination_ports` | yes (TCP/UDP); ICMP-zero | `dst_port` is 0 for ICMP |
 | `dscp_values` / `dscp_bitmap` (+ `dscp_match_enabled`) | NO — cache-sensitive | see #1430 pattern below |
 | (future) `tos_match` / ECN bits (non-DSCP TOS) | NO — cache-sensitive | TOS lower bits and ECN vary per packet |
-| (future) `tcp_flags_match` | NO — cache-sensitive | TCP flags vary per packet |
-| (future) `is_fragment` / fragment offset / MF | NO — cache-sensitive | only first fragment carries L4 |
+| `tcp_flags_mask` (#2362) | NO — cache-sensitive | required-bits mask over the TCP flags byte; TCP flags vary per packet. Threaded via `TermMatchExtra` (path (b)) |
+| `is_fragment` (#2362) | NO — cache-sensitive | Junos `is-fragment`: matches ANY fragment (IPv4 MF set OR offset != 0; IPv6 fragment header present). Computed by `is_any_fragment` |
 | (future) `ihl_match` / IP options | NO — cache-sensitive | IHL varies per packet |
-| (future) `icmp_type_match` / `icmp_code_match` | NO — cache-sensitive (today) | could be promoted to cache-key by adding (type, code) to `SessionKey` for ICMP |
+| `icmp_type` / `icmp_code` (#2362) | NO — cache-sensitive | exact match on the ICMP/ICMPv6 type/code byte; non-ICMP packets never match. Could later be promoted to cache-key by adding (type, code) to `SessionKey` |
 | (future) `flex_match` | NO — cache-sensitive | byte-offset match, fully per-packet |
 
 Fields like `action`, `count`, `log`, `policer`, `routing_instance`,

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -160,6 +160,20 @@ exactly one of these two classes:
 | `icmp_type` / `icmp_code` (#2362) | NO — cache-sensitive | exact match on the ICMP/ICMPv6 type/code byte; non-ICMP packets never match. Could later be promoted to cache-key by adding (type, code) to `SessionKey` |
 | (future) `flex_match` | NO — cache-sensitive | byte-offset match, fully per-packet |
 
+The `tcp_flags_mask` / `is_fragment` / `icmp_type` / `icmp_code` inputs are
+carried in a small `TermMatchExtra` built once per packet at the filter-eval
+call sites (`term_match_extra_from_frame` and its `ForwardPacketMeta` /
+meta-only variants). The builder is fragment-safe: for a NON-FIRST fragment
+(no L4 header at `l4_offset` — its bytes are payload) the L4-derived inputs
+(`tcp_flags` / `icmp_type` / `icmp_code`) are forced to 0 so those terms fail
+closed, while the L3-derived `is_fragment` bit stays true. This applies on the
+CoS / TX-selection leg too (`tx/cos_classify.rs`): the TX-selection evaluators
+thread the same `TermMatchExtra`, and the deferred path snapshots it on
+`PendingForwardRequest.filter_match_extra` because the UMEM frame may be
+recycled before the deferred recompute runs. The flow-cache decline (output and
+input legs) keeps the precomputed TX-selection descriptor from being built for a
+per-packet-L4 filter, so the live per-packet evaluator always runs.
+
 Fields like `action`, `count`, `log`, `policer`, `routing_instance`,
 `forwarding_class`, and `dscp_rewrite` are forwarding actions and
 modifiers, applied after a match has succeeded. They do not

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -105,10 +105,9 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
             affects_route_lookup: terms.iter().any(|term| !term.routing_instance.is_empty()),
             has_counter_terms: terms.iter().any(|term| term.has_count),
             has_log_terms: terms.iter().any(|term| term.log),
-            has_terminal_action_terms: terms
-                .iter()
-                .any(|term| term.action != FilterAction::Accept),
+            has_terminal_action_terms: terms.iter().any(|term| term.action != FilterAction::Accept),
             has_dscp_match_terms: terms.iter().any(|term| term.dscp_match_enabled),
+            has_per_packet_l4_match_terms: terms.iter().any(|term| term.has_per_packet_l4_match()),
             has_three_color_policer_terms: terms
                 .iter()
                 .any(|term| term.three_color_policer.is_some()),
@@ -141,6 +140,11 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 }
                 if filter.has_dscp_match_terms {
                     state.iface_filter_v4_has_dscp_match.insert(iface.ifindex);
+                }
+                if filter.has_per_packet_l4_match_terms {
+                    state
+                        .iface_filter_v4_has_per_packet_l4_match
+                        .insert(iface.ifindex);
                 }
                 state
                     .iface_filter_v4_fast
@@ -189,6 +193,11 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 }
                 if filter.has_dscp_match_terms {
                     state.iface_filter_v6_has_dscp_match.insert(iface.ifindex);
+                }
+                if filter.has_per_packet_l4_match_terms {
+                    state
+                        .iface_filter_v6_has_per_packet_l4_match
+                        .insert(iface.ifindex);
                 }
                 state
                     .iface_filter_v6_fast
@@ -281,11 +290,7 @@ pub(crate) fn three_color_policer_runtime_id(name: &str) -> u32 {
         hash ^= u32::from(*byte);
         hash = hash.wrapping_mul(FNV_PRIME);
     }
-    if hash == 0 {
-        1
-    } else {
-        hash
-    }
+    if hash == 0 { 1 } else { hash }
 }
 
 fn build_three_color_policer_state(
@@ -389,6 +394,14 @@ fn parse_term(
         dest_ports: build_port_matcher(dest_ports),
         dscp_bitmap: build_u6_match_bitmap(&snap.dscp_values),
         dscp_match_enabled: !snap.dscp_values.is_empty(),
+        // #2362 per-packet L4 match conditions. A zero tcp_flags mask means
+        // "no constraint" (would match every packet), so fold it to None — the
+        // Go side already omits a 0 mask; this is a guard against a
+        // hand-crafted snapshot.
+        tcp_flags_mask: snap.tcp_flags.filter(|&m| m != 0),
+        is_fragment: snap.is_fragment,
+        icmp_type: snap.icmp_type,
+        icmp_code: snap.icmp_code,
         action,
         count: snap.count.clone(),
         has_count: !snap.count.is_empty(),

--- a/userspace-dp/src/filter/engine/cache_sensitive.rs
+++ b/userspace-dp/src/filter/engine/cache_sensitive.rs
@@ -44,7 +44,16 @@ fn evaluate_filter_ref_tx_selection_cached_v4(
     dscp: u8,
 ) -> CachedTxSelectionFilterResult {
     for term in &filter.terms {
-        if !term_matches_v4(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v4(
+            term,
+            src_ip,
+            dst_ip,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            TermMatchExtra::default(),
+        ) {
             continue;
         }
         return CachedTxSelectionFilterResult {
@@ -72,7 +81,16 @@ fn evaluate_filter_ref_tx_selection_cached_v6(
     dscp: u8,
 ) -> CachedTxSelectionFilterResult {
     for term in &filter.terms {
-        if !term_matches_v6(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v6(
+            term,
+            src_ip,
+            dst_ip,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            TermMatchExtra::default(),
+        ) {
             continue;
         }
         return CachedTxSelectionFilterResult {
@@ -113,6 +131,10 @@ fn filter_term_semantics_match(old: &FilterTerm, new: &FilterTerm) -> bool {
         && old.dest_ports == new.dest_ports
         && old.dscp_bitmap == new.dscp_bitmap
         && old.dscp_match_enabled == new.dscp_match_enabled
+        && old.tcp_flags_mask == new.tcp_flags_mask
+        && old.is_fragment == new.is_fragment
+        && old.icmp_type == new.icmp_type
+        && old.icmp_code == new.icmp_code
         && old.action == new.action
         && old.count == new.count
         && old.has_count == new.has_count
@@ -133,6 +155,7 @@ fn dscp_sensitive_filter_semantics_match(old: &Filter, new: &Filter) -> bool {
         && old.has_log_terms == new.has_log_terms
         && old.has_terminal_action_terms == new.has_terminal_action_terms
         && old.has_dscp_match_terms == new.has_dscp_match_terms
+        && old.has_per_packet_l4_match_terms == new.has_per_packet_l4_match_terms
         && old.has_three_color_policer_terms == new.has_three_color_policer_terms
         && old.terms.len() == new.terms.len()
         && old
@@ -197,4 +220,81 @@ pub(crate) fn interface_output_filter_has_dscp_match(
         state.iface_filter_out_v4_fast.get(&ifindex)
     };
     filter.is_some_and(|filter| filter.has_dscp_match_terms)
+}
+
+// ---------------------------------------------------------------------------
+// #2362 per-packet L4 match (tcp-flags / is-fragment / icmp-type / icmp-code).
+// These vary per packet within a 5-tuple flow exactly like DSCP, so they get
+// the same cache-coherency treatment: a flow-cache decline (flow_cache.rs), a
+// per-packet re-evaluation on session hit (poll_descriptor/filter.rs), and a
+// config-rotation purge (worker/loop_body) when the per-packet-L4 filter set
+// changes. The structural equality test reuses dscp_sensitive_filter_semantics_match
+// (which now also compares the per-packet term fields).
+// ---------------------------------------------------------------------------
+
+fn input_per_packet_l4_filter_family_changed(
+    old_filters: &rustc_hash::FxHashMap<i32, Arc<Filter>>,
+    new_filters: &rustc_hash::FxHashMap<i32, Arc<Filter>>,
+) -> bool {
+    old_filters
+        .iter()
+        .filter(|(_, filter)| filter.has_per_packet_l4_match_terms)
+        .any(|(ifindex, old)| {
+            new_filters
+                .get(ifindex)
+                .is_none_or(|new| !dscp_sensitive_filter_semantics_match(old, new))
+        })
+        || new_filters
+            .iter()
+            .filter(|(_, filter)| filter.has_per_packet_l4_match_terms)
+            .any(|(ifindex, new)| {
+                old_filters
+                    .get(ifindex)
+                    .is_none_or(|old| !dscp_sensitive_filter_semantics_match(old, new))
+            })
+}
+
+pub(crate) fn input_per_packet_l4_filter_families_changed(
+    old: &FilterState,
+    new: &FilterState,
+) -> (bool, bool) {
+    (
+        input_per_packet_l4_filter_family_changed(
+            &old.iface_filter_v4_fast,
+            &new.iface_filter_v4_fast,
+        ),
+        input_per_packet_l4_filter_family_changed(
+            &old.iface_filter_v6_fast,
+            &new.iface_filter_v6_fast,
+        ),
+    )
+}
+
+pub(crate) fn interface_input_filter_has_per_packet_l4_match(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+) -> bool {
+    if is_v6 {
+        state
+            .iface_filter_v6_has_per_packet_l4_match
+            .contains(&ifindex)
+    } else {
+        state
+            .iface_filter_v4_has_per_packet_l4_match
+            .contains(&ifindex)
+    }
+}
+
+pub(crate) fn interface_output_filter_has_per_packet_l4_match(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+) -> bool {
+    let filter = if is_v6 {
+        state.iface_filter_out_v6_fast.get(&ifindex)
+    } else {
+        state.iface_filter_out_v4_fast.get(&ifindex)
+    };
+    filter.is_some_and(|filter| filter.has_per_packet_l4_match_terms)
 }

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -25,9 +25,10 @@ pub(crate) fn evaluate_filter(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
 ) -> FilterResult {
     evaluate_filter_counted(
-        state, filter_key, src_ip, dst_ip, protocol, src_port, dst_port, dscp, 0,
+        state, filter_key, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra, 0,
     )
 }
 
@@ -40,6 +41,7 @@ pub(crate) fn evaluate_filter_counted(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     let Some(filter) = state.filters.get(filter_key) else {
@@ -53,6 +55,7 @@ pub(crate) fn evaluate_filter_counted(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
     )
 }
@@ -66,6 +69,7 @@ pub(super) fn evaluate_filter_ref_counted(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     match (src_ip, dst_ip) {
@@ -77,6 +81,7 @@ pub(super) fn evaluate_filter_ref_counted(
             src_port,
             dst_port,
             dscp,
+            extra,
             packet_bytes,
         ),
         (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_counted_v6(
@@ -87,6 +92,7 @@ pub(super) fn evaluate_filter_ref_counted(
             src_port,
             dst_port,
             dscp,
+            extra,
             packet_bytes,
         ),
         _ => FilterResult::default(),
@@ -102,10 +108,13 @@ fn evaluate_filter_ref_counted_v4(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     for term in &filter.terms {
-        if !term_matches_v4(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v4(
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
+        ) {
             continue;
         }
         if term.has_count {
@@ -133,10 +142,13 @@ fn evaluate_filter_ref_counted_v6(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     for term in &filter.terms {
-        if !term_matches_v6(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v6(
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
+        ) {
             continue;
         }
         if term.has_count {
@@ -164,6 +176,7 @@ fn evaluate_filter_ref_non_routing_counted(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     match (src_ip, dst_ip) {
@@ -175,6 +188,7 @@ fn evaluate_filter_ref_non_routing_counted(
             src_port,
             dst_port,
             dscp,
+            extra,
             packet_bytes,
         ),
         (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_non_routing_counted_v6(
@@ -185,6 +199,7 @@ fn evaluate_filter_ref_non_routing_counted(
             src_port,
             dst_port,
             dscp,
+            extra,
             packet_bytes,
         ),
         _ => FilterResult::default(),
@@ -200,10 +215,13 @@ fn evaluate_filter_ref_non_routing_counted_v4(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     for term in &filter.terms {
-        if !term_matches_v4(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v4(
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
+        ) {
             continue;
         }
         if !term.routing_instance.is_empty() {
@@ -234,10 +252,13 @@ fn evaluate_filter_ref_non_routing_counted_v6(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     for term in &filter.terms {
-        if !term_matches_v6(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v6(
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
+        ) {
             continue;
         }
         if !term.routing_instance.is_empty() {
@@ -277,10 +298,13 @@ fn evaluate_filter_ref_routing_instance_counted_v4<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> Option<FilterRoutingInstanceResult<'a>> {
     for term in &filter.terms {
-        if !term_matches_v4(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v4(
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
+        ) {
             continue;
         }
         if term.has_count {
@@ -308,10 +332,13 @@ fn evaluate_filter_ref_routing_instance_counted_v6<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> Option<FilterRoutingInstanceResult<'a>> {
     for term in &filter.terms {
-        if !term_matches_v6(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v6(
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
+        ) {
             continue;
         }
         if term.has_count {
@@ -341,9 +368,10 @@ pub(crate) fn evaluate_lo0_filter(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
 ) -> FilterResult {
     evaluate_lo0_filter_counted(
-        state, is_v6, src_ip, dst_ip, protocol, src_port, dst_port, dscp, 0,
+        state, is_v6, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra, 0,
     )
 }
 
@@ -356,6 +384,7 @@ pub(crate) fn evaluate_lo0_filter_counted(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     let filter = if is_v6 {
@@ -374,6 +403,7 @@ pub(crate) fn evaluate_lo0_filter_counted(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
     )
 }
@@ -387,6 +417,7 @@ pub(crate) fn evaluate_lo0_filter_log_match(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
 ) -> Option<FilterLogMatch> {
     let filter = if is_v6 {
         state.lo0_filter_v6_fast.as_deref()
@@ -394,7 +425,7 @@ pub(crate) fn evaluate_lo0_filter_log_match(
         state.lo0_filter_v4_fast.as_deref()
     }?;
     evaluate_filter_ref_log_match(
-        filter, src_ip, dst_ip, protocol, src_port, dst_port, dscp, false,
+        filter, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra, false,
     )
 }
 
@@ -409,9 +440,10 @@ pub(crate) fn evaluate_interface_filter(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
 ) -> FilterResult {
     evaluate_interface_filter_counted(
-        state, ifindex, is_v6, src_ip, dst_ip, protocol, src_port, dst_port, dscp, 0,
+        state, ifindex, is_v6, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra, 0,
     )
 }
 
@@ -425,6 +457,7 @@ pub(crate) fn evaluate_interface_filter_counted(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     let filter = if is_v6 {
@@ -443,6 +476,7 @@ pub(crate) fn evaluate_interface_filter_counted(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
     )
 }
@@ -457,6 +491,7 @@ pub(crate) fn evaluate_interface_filter_non_routing_counted(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     let filter = if is_v6 {
@@ -475,6 +510,7 @@ pub(crate) fn evaluate_interface_filter_non_routing_counted(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
     )
 }
@@ -489,6 +525,7 @@ pub(crate) fn evaluate_interface_filter_log_match(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     skip_routing_instance: bool,
 ) -> Option<FilterLogMatch> {
     let filter = if is_v6 {
@@ -504,6 +541,7 @@ pub(crate) fn evaluate_interface_filter_log_match(
         src_port,
         dst_port,
         dscp,
+        extra,
         skip_routing_instance,
     )
 }
@@ -518,6 +556,7 @@ pub(crate) fn evaluate_interface_filter_routing_instance_counted<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> Option<&'a str> {
     evaluate_interface_filter_routing_instance_event_counted(
@@ -530,6 +569,7 @@ pub(crate) fn evaluate_interface_filter_routing_instance_counted<'a>(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
     )
     .map(|result| result.routing_instance)
@@ -545,6 +585,7 @@ pub(crate) fn evaluate_interface_filter_routing_instance_event_counted<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> Option<FilterRoutingInstanceResult<'a>> {
     let filter = if is_v6 {
@@ -564,6 +605,7 @@ pub(crate) fn evaluate_interface_filter_routing_instance_event_counted<'a>(
             src_port,
             dst_port,
             dscp,
+            extra,
             packet_bytes,
         ),
         (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_routing_instance_counted_v6(
@@ -574,6 +616,7 @@ pub(crate) fn evaluate_interface_filter_routing_instance_event_counted<'a>(
             src_port,
             dst_port,
             dscp,
+            extra,
             packet_bytes,
         ),
         _ => None,
@@ -588,15 +631,17 @@ fn evaluate_filter_ref_log_match(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     skip_routing_instance: bool,
 ) -> Option<FilterLogMatch> {
     if !filter.has_log_terms {
         return None;
     }
-    let first_matching_term = filter
-        .terms
-        .iter()
-        .find(|term| term_matches(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp))?;
+    let first_matching_term = filter.terms.iter().find(|term| {
+        term_matches(
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
+        )
+    })?;
     if skip_routing_instance && !first_matching_term.routing_instance.is_empty() {
         return None;
     }
@@ -614,9 +659,10 @@ pub(crate) fn evaluate_interface_output_filter(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
 ) -> FilterResult {
     evaluate_interface_output_filter_counted(
-        state, ifindex, is_v6, src_ip, dst_ip, protocol, src_port, dst_port, dscp, 0,
+        state, ifindex, is_v6, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra, 0,
     )
 }
 
@@ -630,6 +676,7 @@ pub(crate) fn evaluate_interface_output_filter_counted(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> FilterResult {
     let filter = if is_v6 {
@@ -654,6 +701,7 @@ pub(crate) fn evaluate_interface_output_filter_counted(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
     )
 }

--- a/userspace-dp/src/filter/engine/matching.rs
+++ b/userspace-dp/src/filter/engine/matching.rs
@@ -17,12 +17,24 @@ use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6, PROTO_TCP};
 /// icmp-type term against a TCP packet) fails closed — the term must NOT match,
 /// matching Junos semantics where `from tcp-flags ...` implies the TCP
 /// protocol family. Empty (`None` / false) conditions are no-ops.
+///
+/// #2362 fold A (Copilot): every L4-header-derived constraint (tcp-flags,
+/// icmp-type, icmp-code) additionally requires `extra.l4_present`. A NON-FIRST
+/// fragment carries no L4 header at `l4_offset` (its bytes are payload), so
+/// `l4_present` is false for it and those terms MUST NOT match. Keying off the
+/// byte VALUE alone is insufficient: 0 is a valid icmp-type (echo-reply) and a
+/// valid icmp-code, so a zeroed byte on a non-first fragment would still
+/// spuriously match `from { icmp-type 0 }` / `from { icmp-code 0 }`. The
+/// `is-fragment` constraint is L3-derived (every fragment carries the IP
+/// header) and is therefore NOT gated by `l4_present` — a non-first fragment
+/// still matches `from { is-fragment }`.
 #[inline(always)]
 fn per_packet_l4_matches(term: &FilterTerm, protocol: u8, extra: TermMatchExtra) -> bool {
     if let Some(mask) = term.tcp_flags_mask {
-        // A tcp-flags constraint only matches TCP segments. A non-TCP packet
-        // (or a non-first fragment with no L4 header) never matches.
-        if protocol != PROTO_TCP || (extra.tcp_flags & mask) != mask {
+        // A tcp-flags constraint only matches a TCP segment that actually has
+        // an L4 header. A non-TCP packet, or a non-first fragment (no L4
+        // header), never matches.
+        if !extra.l4_present || protocol != PROTO_TCP || (extra.tcp_flags & mask) != mask {
             return false;
         }
     }
@@ -31,12 +43,16 @@ fn per_packet_l4_matches(term: &FilterTerm, protocol: u8, extra: TermMatchExtra)
     }
     let is_icmp = protocol == PROTO_ICMP || protocol == PROTO_ICMPV6;
     if let Some(want_type) = term.icmp_type {
-        if !is_icmp || extra.icmp_type != want_type {
+        // Gate on l4_present, NOT just the value: icmp-type 0 (echo-reply) is a
+        // real term, so a non-first fragment with a forced-0 type byte must NOT
+        // match it.
+        if !extra.l4_present || !is_icmp || extra.icmp_type != want_type {
             return false;
         }
     }
     if let Some(want_code) = term.icmp_code {
-        if !is_icmp || extra.icmp_code != want_code {
+        // icmp-code 0 is the most common code — same l4_present gate.
+        if !extra.l4_present || !is_icmp || extra.icmp_code != want_code {
             return false;
         }
     }

--- a/userspace-dp/src/filter/engine/matching.rs
+++ b/userspace-dp/src/filter/engine/matching.rs
@@ -1,8 +1,47 @@
-// Per-term match predicates extracted from engine.rs by #1546. Bodies
-// byte-identical with the pre-split versions; #[inline(always)] preserved
-// so the hot per-packet path keeps folding through `cargo build --release`.
+// Per-term match predicates extracted from engine.rs by #1546. The hot
+// per-packet path keeps #[inline(always)] so it folds through
+// `cargo build --release`.
+//
+// #2362 added the per-packet L4 match conditions (tcp-flags, is-fragment,
+// icmp-type, icmp-code). They are carried in `TermMatchExtra`, computed once
+// per packet at the evaluate call site, and applied via `per_packet_l4_matches`
+// after the 5-tuple checks. They are family-agnostic, so the v4/v6 leaves share
+// the same helper.
 
 use super::super::*;
+use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6, PROTO_TCP};
+
+/// Apply the #2362 per-packet L4 match conditions. Returns `false` (no match)
+/// if any configured condition fails. A condition that constrains a protocol
+/// the packet is not (e.g. a tcp-flags term against a UDP packet, or an
+/// icmp-type term against a TCP packet) fails closed — the term must NOT match,
+/// matching Junos semantics where `from tcp-flags ...` implies the TCP
+/// protocol family. Empty (`None` / false) conditions are no-ops.
+#[inline(always)]
+fn per_packet_l4_matches(term: &FilterTerm, protocol: u8, extra: TermMatchExtra) -> bool {
+    if let Some(mask) = term.tcp_flags_mask {
+        // A tcp-flags constraint only matches TCP segments. A non-TCP packet
+        // (or a non-first fragment with no L4 header) never matches.
+        if protocol != PROTO_TCP || (extra.tcp_flags & mask) != mask {
+            return false;
+        }
+    }
+    if term.is_fragment && !extra.is_fragment {
+        return false;
+    }
+    let is_icmp = protocol == PROTO_ICMP || protocol == PROTO_ICMPV6;
+    if let Some(want_type) = term.icmp_type {
+        if !is_icmp || extra.icmp_type != want_type {
+            return false;
+        }
+    }
+    if let Some(want_code) = term.icmp_code {
+        if !is_icmp || extra.icmp_code != want_code {
+            return false;
+        }
+    }
+    true
+}
 
 /// Check whether a single filter term matches the given packet fields.
 /// All specified criteria must match (AND logic). Empty criteria = match any.
@@ -15,19 +54,21 @@ pub(super) fn term_matches(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
 ) -> bool {
     match (src_ip, dst_ip) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => {
-            term_matches_v4(term, src, dst, protocol, src_port, dst_port, dscp)
+            term_matches_v4(term, src, dst, protocol, src_port, dst_port, dscp, extra)
         }
         (IpAddr::V6(src), IpAddr::V6(dst)) => {
-            term_matches_v6(term, src, dst, protocol, src_port, dst_port, dscp)
+            term_matches_v6(term, src, dst, protocol, src_port, dst_port, dscp, extra)
         }
         _ => false,
     }
 }
 
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 pub(super) fn term_matches_v4(
     term: &FilterTerm,
     src_ip: Ipv4Addr,
@@ -36,6 +77,7 @@ pub(super) fn term_matches_v4(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
 ) -> bool {
     if term.protocol_match_enabled
         && (term.protocol_bitmap[(protocol / 64) as usize] & (1u64 << (protocol % 64))) == 0
@@ -57,10 +99,14 @@ pub(super) fn term_matches_v4(
     if term.dscp_match_enabled && (term.dscp_bitmap & (1u64 << dscp)) == 0 {
         return false;
     }
+    if !per_packet_l4_matches(term, protocol, extra) {
+        return false;
+    }
     true
 }
 
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 pub(super) fn term_matches_v6(
     term: &FilterTerm,
     src_ip: Ipv6Addr,
@@ -69,6 +115,7 @@ pub(super) fn term_matches_v6(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
 ) -> bool {
     if term.protocol_match_enabled
         && (term.protocol_bitmap[(protocol / 64) as usize] & (1u64 << (protocol % 64))) == 0
@@ -88,6 +135,9 @@ pub(super) fn term_matches_v6(
         return false;
     }
     if term.dscp_match_enabled && (term.dscp_bitmap & (1u64 << dscp)) == 0 {
+        return false;
+    }
+    if !per_packet_l4_matches(term, protocol, extra) {
         return false;
     }
     true

--- a/userspace-dp/src/filter/engine/mod.rs
+++ b/userspace-dp/src/filter/engine/mod.rs
@@ -12,7 +12,9 @@ mod tx_selection;
 
 pub(crate) use cache_sensitive::{
     evaluate_filter_ref_tx_selection_cached, input_dscp_filter_families_changed,
-    interface_input_filter_has_dscp_match, interface_output_filter_has_dscp_match,
+    input_per_packet_l4_filter_families_changed, interface_input_filter_has_dscp_match,
+    interface_input_filter_has_per_packet_l4_match, interface_output_filter_has_dscp_match,
+    interface_output_filter_has_per_packet_l4_match,
 };
 pub(crate) use eval::{
     evaluate_filter, evaluate_filter_counted, evaluate_interface_filter,

--- a/userspace-dp/src/filter/engine/tx_selection.rs
+++ b/userspace-dp/src/filter/engine/tx_selection.rs
@@ -27,6 +27,7 @@ pub(crate) fn evaluate_filter_ref_tx_selection_counted<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> TxSelectionFilterResult<'a> {
     evaluate_filter_ref_tx_selection_runtime(
@@ -37,6 +38,7 @@ pub(crate) fn evaluate_filter_ref_tx_selection_counted<'a>(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
         None,
     )
@@ -50,6 +52,7 @@ pub(crate) fn evaluate_filter_ref_tx_selection_runtime_counted<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
     now_ns: u64,
 ) -> TxSelectionFilterResult<'a> {
@@ -61,6 +64,7 @@ pub(crate) fn evaluate_filter_ref_tx_selection_runtime_counted<'a>(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
         Some(now_ns),
     )
@@ -75,6 +79,7 @@ fn evaluate_filter_ref_tx_selection_runtime<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
     now_ns: Option<u64>,
 ) -> TxSelectionFilterResult<'a> {
@@ -87,6 +92,7 @@ fn evaluate_filter_ref_tx_selection_runtime<'a>(
             src_port,
             dst_port,
             dscp,
+            extra,
             packet_bytes,
             now_ns,
         ),
@@ -98,6 +104,7 @@ fn evaluate_filter_ref_tx_selection_runtime<'a>(
             src_port,
             dst_port,
             dscp,
+            extra,
             packet_bytes,
             now_ns,
         ),
@@ -114,19 +121,13 @@ fn evaluate_filter_ref_tx_selection_counted_v4<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
     now_ns: Option<u64>,
 ) -> TxSelectionFilterResult<'a> {
     for term in &filter.terms {
         if !term_matches_v4(
-            term,
-            src_ip,
-            dst_ip,
-            protocol,
-            src_port,
-            dst_port,
-            dscp,
-            TermMatchExtra::default(),
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
         ) {
             continue;
         }
@@ -155,19 +156,13 @@ fn evaluate_filter_ref_tx_selection_counted_v6<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
     now_ns: Option<u64>,
 ) -> TxSelectionFilterResult<'a> {
     for term in &filter.terms {
         if !term_matches_v6(
-            term,
-            src_ip,
-            dst_ip,
-            protocol,
-            src_port,
-            dst_port,
-            dscp,
-            TermMatchExtra::default(),
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
         ) {
             continue;
         }
@@ -197,6 +192,7 @@ pub(crate) fn evaluate_interface_filter_tx_selection_counted<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> TxSelectionFilterResult<'a> {
     let filter = if is_v6 {
@@ -215,6 +211,7 @@ pub(crate) fn evaluate_interface_filter_tx_selection_counted<'a>(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
     )
 }
@@ -229,6 +226,7 @@ pub(crate) fn evaluate_interface_output_filter_tx_selection_counted<'a>(
     src_port: u16,
     dst_port: u16,
     dscp: u8,
+    extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> TxSelectionFilterResult<'a> {
     let filter = if is_v6 {
@@ -253,6 +251,7 @@ pub(crate) fn evaluate_interface_output_filter_tx_selection_counted<'a>(
         src_port,
         dst_port,
         dscp,
+        extra,
         packet_bytes,
     )
 }

--- a/userspace-dp/src/filter/engine/tx_selection.rs
+++ b/userspace-dp/src/filter/engine/tx_selection.rs
@@ -118,7 +118,16 @@ fn evaluate_filter_ref_tx_selection_counted_v4<'a>(
     now_ns: Option<u64>,
 ) -> TxSelectionFilterResult<'a> {
     for term in &filter.terms {
-        if !term_matches_v4(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v4(
+            term,
+            src_ip,
+            dst_ip,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            TermMatchExtra::default(),
+        ) {
             continue;
         }
         if term.has_count {
@@ -150,7 +159,16 @@ fn evaluate_filter_ref_tx_selection_counted_v6<'a>(
     now_ns: Option<u64>,
 ) -> TxSelectionFilterResult<'a> {
     for term in &filter.terms {
-        if !term_matches_v6(term, src_ip, dst_ip, protocol, src_port, dst_port, dscp) {
+        if !term_matches_v6(
+            term,
+            src_ip,
+            dst_ip,
+            protocol,
+            src_port,
+            dst_port,
+            dscp,
+            TermMatchExtra::default(),
+        ) {
             continue;
         }
         if term.has_count {

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -86,6 +86,22 @@ pub(crate) struct FilterTerm {
     pub(crate) dest_ports: PortMatcher,
     pub(crate) dscp_bitmap: u64,
     pub(crate) dscp_match_enabled: bool,
+    // Per-packet L4 match conditions (#2362). NOT in SessionKey, so a filter
+    // carrying any of these is cache-sensitive (path (b) per the #1431
+    // invariant above): the flow-cache must decline insertion and the
+    // change-detection / re-eval / rotation-purge machinery in
+    // cache_sensitive.rs must treat them like dscp.
+    //
+    // tcp_flags_mask: required-bits mask over the TCP flags byte. A TCP packet
+    // matches when (flags & mask) == mask. None = no constraint. Only TCP can
+    // match a term that sets this.
+    pub(crate) tcp_flags_mask: Option<u8>,
+    // is_fragment: matches any IP fragment.
+    pub(crate) is_fragment: bool,
+    // icmp_type / icmp_code: exact match on the ICMP/ICMPv6 type/code byte.
+    // None = no constraint. Only ICMP/ICMPv6 can match a term that sets these.
+    pub(crate) icmp_type: Option<u8>,
+    pub(crate) icmp_code: Option<u8>,
     pub(crate) action: FilterAction,
     pub(crate) count: String,
     pub(crate) has_count: bool,
@@ -96,6 +112,37 @@ pub(crate) struct FilterTerm {
     pub(crate) forwarding_class: Arc<str>,
     pub(crate) dscp_rewrite: Option<u8>,
     pub(crate) counter: Arc<FilterTermCounter>,
+}
+
+impl FilterTerm {
+    /// Whether this term carries any per-packet L4 match condition (#2362)
+    /// that is not part of the 5-tuple SessionKey: tcp-flags, is-fragment,
+    /// icmp-type, or icmp-code. A filter with such a term is cache-sensitive
+    /// (the flow-cache must decline insertion — see `flow_cache.rs`).
+    #[inline]
+    pub(crate) fn has_per_packet_l4_match(&self) -> bool {
+        self.tcp_flags_mask.is_some()
+            || self.is_fragment
+            || self.icmp_type.is_some()
+            || self.icmp_code.is_some()
+    }
+}
+
+/// Per-packet match inputs that are NOT in the 5-tuple (#2362). Computed once
+/// per packet at each evaluate call site (the only place that has the frame
+/// bytes) and threaded into the term predicate. `Default` (all-absent) makes
+/// every per-packet condition a no-op, so callers that cannot cheaply compute
+/// these (e.g. some log-only diagnostic paths) stay behavior-compatible.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct TermMatchExtra {
+    /// Raw TCP flags byte (only meaningful when protocol == TCP).
+    pub(crate) tcp_flags: u8,
+    /// Whether the packet is an IP fragment (any fragment).
+    pub(crate) is_fragment: bool,
+    /// ICMP/ICMPv6 type byte (only meaningful when protocol is ICMP/ICMPv6).
+    pub(crate) icmp_type: u8,
+    /// ICMP/ICMPv6 code byte (only meaningful when protocol is ICMP/ICMPv6).
+    pub(crate) icmp_code: u8,
 }
 
 /// Inclusive port range.
@@ -141,6 +188,10 @@ pub(crate) struct Filter {
     pub(crate) has_log_terms: bool,
     pub(crate) has_terminal_action_terms: bool,
     pub(crate) has_dscp_match_terms: bool,
+    /// Any term carries a per-packet L4 match (tcp-flags / is-fragment /
+    /// icmp-type / icmp-code) — #2362. Cache-sensitive like
+    /// `has_dscp_match_terms`: the flow-cache must decline for these filters.
+    pub(crate) has_per_packet_l4_match_terms: bool,
     pub(crate) has_three_color_policer_terms: bool,
 }
 
@@ -447,6 +498,9 @@ pub(crate) struct FilterState {
     pub(crate) iface_filter_v4_affects_route_lookup: rustc_hash::FxHashSet<i32>,
     /// Per-interface inet input filters with DSCP match terms.
     pub(crate) iface_filter_v4_has_dscp_match: rustc_hash::FxHashSet<i32>,
+    /// Per-interface inet input filters with per-packet L4 match terms (#2362:
+    /// tcp-flags / is-fragment / icmp-type / icmp-code). Cache-sensitive.
+    pub(crate) iface_filter_v4_has_per_packet_l4_match: rustc_hash::FxHashSet<i32>,
     /// Per-interface (ifindex) input filter key for inet6.
     pub(crate) iface_filter_v6: rustc_hash::FxHashMap<i32, String>,
     /// Direct per-interface inet6 filter reference for packet hot-path evaluation.
@@ -461,6 +515,8 @@ pub(crate) struct FilterState {
     pub(crate) iface_filter_v6_affects_route_lookup: rustc_hash::FxHashSet<i32>,
     /// Per-interface inet6 input filters with DSCP match terms.
     pub(crate) iface_filter_v6_has_dscp_match: rustc_hash::FxHashSet<i32>,
+    /// Per-interface inet6 input filters with per-packet L4 match terms (#2362).
+    pub(crate) iface_filter_v6_has_per_packet_l4_match: rustc_hash::FxHashSet<i32>,
     /// Per-interface (ifindex) output filter key for inet.
     pub(crate) iface_filter_out_v4: rustc_hash::FxHashMap<i32, String>,
     /// Direct per-interface inet output filter reference for packet hot-path evaluation.

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -130,19 +130,34 @@ impl FilterTerm {
 
 /// Per-packet match inputs that are NOT in the 5-tuple (#2362). Computed once
 /// per packet at each evaluate call site (the only place that has the frame
-/// bytes) and threaded into the term predicate. `Default` (all-absent) makes
-/// every per-packet condition a no-op, so callers that cannot cheaply compute
-/// these (e.g. some log-only diagnostic paths) stay behavior-compatible.
+/// bytes) and threaded into the term predicate. `Default` (all-absent,
+/// `l4_present = false`) makes every L4 per-packet condition fail to match, so
+/// callers that cannot cheaply compute these (cached/TX-selection rebuild
+/// paths, which never carry an L4-match term because the flow-cache declines
+/// for such filters) stay behavior-compatible AND fail closed.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct TermMatchExtra {
-    /// Raw TCP flags byte (only meaningful when protocol == TCP).
+    /// Raw TCP flags byte (only meaningful when protocol == TCP and
+    /// `l4_present`).
     pub(crate) tcp_flags: u8,
-    /// Whether the packet is an IP fragment (any fragment).
+    /// Whether the packet is an IP fragment (any fragment). L3-derived — valid
+    /// regardless of `l4_present` (every fragment carries the IP header).
     pub(crate) is_fragment: bool,
-    /// ICMP/ICMPv6 type byte (only meaningful when protocol is ICMP/ICMPv6).
+    /// ICMP/ICMPv6 type byte (only meaningful when protocol is ICMP/ICMPv6 and
+    /// `l4_present`).
     pub(crate) icmp_type: u8,
-    /// ICMP/ICMPv6 code byte (only meaningful when protocol is ICMP/ICMPv6).
+    /// ICMP/ICMPv6 code byte (only meaningful when protocol is ICMP/ICMPv6 and
+    /// `l4_present`).
     pub(crate) icmp_code: u8,
+    /// #2362 fold A (Copilot): whether a real L4 header is present at
+    /// `l4_offset`. FALSE for a NON-FIRST fragment (its post-IP bytes are
+    /// payload, not an L4 header) and for any other no-L4 case. The matcher
+    /// gates the tcp-flags / icmp-type / icmp-code constraints on this flag —
+    /// NOT on the byte values — because 0 is a VALID icmp-type (echo-reply) and
+    /// a VALID icmp-code, so a zeroed byte would still spuriously match
+    /// `icmp-type 0` / `icmp-code 0`. `is_fragment` is L3-derived and is NOT
+    /// gated by this flag.
+    pub(crate) l4_present: bool,
 }
 
 /// Inclusive port range.

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2821,6 +2821,9 @@ fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
 fn extra_tcp(flags: u8) -> TermMatchExtra {
     TermMatchExtra {
         tcp_flags: flags,
+        // A real (first/atomic) TCP segment has an L4 header — the matcher
+        // gates tcp-flags on l4_present (#2362 fold A).
+        l4_present: true,
         ..Default::default()
     }
 }
@@ -2996,6 +2999,7 @@ fn icmp_type_term_matches_only_that_type_v4() {
     );
     let echo = TermMatchExtra {
         icmp_type: 8,
+        l4_present: true,
         ..Default::default()
     };
     let drop = evaluate_filter(
@@ -3016,6 +3020,7 @@ fn icmp_type_term_matches_only_that_type_v4() {
     );
     let reply = TermMatchExtra {
         icmp_type: 0,
+        l4_present: true,
         ..Default::default()
     };
     let pass = evaluate_filter(
@@ -3046,6 +3051,7 @@ fn icmp_type_term_matches_icmpv6() {
     let v6 = |s: &str| IpAddr::V6(s.parse::<Ipv6Addr>().unwrap());
     let echo = TermMatchExtra {
         icmp_type: 128,
+        l4_present: true,
         ..Default::default()
     };
     let drop = evaluate_filter(
@@ -3062,6 +3068,7 @@ fn icmp_type_term_matches_icmpv6() {
     assert_eq!(drop.action, FilterAction::Discard);
     let na = TermMatchExtra {
         icmp_type: 136,
+        l4_present: true,
         ..Default::default()
     };
     let pass = evaluate_filter(
@@ -3092,6 +3099,7 @@ fn icmp_code_term_narrows_within_type() {
     let frag_needed = TermMatchExtra {
         icmp_type: 3,
         icmp_code: 4,
+        l4_present: true,
         ..Default::default()
     };
     let drop = evaluate_filter(
@@ -3109,6 +3117,7 @@ fn icmp_code_term_narrows_within_type() {
     let net_unreach = TermMatchExtra {
         icmp_type: 3,
         icmp_code: 0,
+        l4_present: true,
         ..Default::default()
     };
     let pass = evaluate_filter(
@@ -3136,9 +3145,11 @@ fn icmp_term_does_not_match_non_icmp() {
         &[],
     );
     // A TCP packet whose byte happens to equal 8 must not match an icmp-type term.
+    // l4_present: true so this proves the PROTOCOL gate, not the l4-absence gate.
     let tcp = TermMatchExtra {
         tcp_flags: 0x02,
         icmp_type: 8,
+        l4_present: true,
         ..Default::default()
     };
     let pass = evaluate_filter(
@@ -3256,4 +3267,143 @@ fn firewall_term_snapshot_per_packet_fields_round_trip() {
     assert!(!minimal.is_fragment);
     assert_eq!(minimal.icmp_type, None);
     assert_eq!(minimal.icmp_code, None);
+}
+
+// #2362 fold A (Copilot): the L4-present gate. Forcing the icmp byte to 0 for a
+// non-first fragment is NOT sufficient, because 0 is a valid icmp-type
+// (echo-reply) and a valid icmp-code — a value-only check would still match
+// `from { icmp-type 0 }` / `from { icmp-code 0 }`. The matcher MUST key off
+// extra.l4_present (false for a non-first fragment) so those terms fail closed,
+// while is-fragment (L3-derived) STILL matches. These fail if the gate reverts
+// to the value-0 sentinel.
+#[test]
+fn non_first_fragment_does_not_match_icmp_type_zero() {
+    let state = make_filter_state(
+        &per_packet_filter("inet", "icmp", None, false, Some(0), None),
+        &[],
+    );
+    // What term_match_extra_from_frame produces for a non-first ICMP fragment:
+    // l4_present false, icmp bytes forced 0, is_fragment true.
+    let frag = TermMatchExtra {
+        l4_present: false,
+        icmp_type: 0,
+        is_fragment: true,
+        ..Default::default()
+    };
+    let r = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_ICMP,
+        0,
+        0,
+        0,
+        frag,
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Accept,
+        "a non-first fragment (no L4 header) must NOT match `icmp-type 0` (#2362 fold A)"
+    );
+    // Anti-over-gate: a real echo-reply (type 0, l4_present) DOES match.
+    let echo_reply = TermMatchExtra {
+        l4_present: true,
+        icmp_type: 0,
+        ..Default::default()
+    };
+    let r2 = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_ICMP,
+        0,
+        0,
+        0,
+        echo_reply,
+    );
+    assert_eq!(
+        r2.action,
+        FilterAction::Discard,
+        "a real echo-reply (icmp-type 0, L4 present) MUST match `icmp-type 0`"
+    );
+}
+
+#[test]
+fn non_first_fragment_does_not_match_icmp_code_zero() {
+    let state = make_filter_state(
+        &per_packet_filter("inet", "icmp", None, false, None, Some(0)),
+        &[],
+    );
+    let frag = TermMatchExtra {
+        l4_present: false,
+        icmp_code: 0,
+        is_fragment: true,
+        ..Default::default()
+    };
+    let r = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_ICMP,
+        0,
+        0,
+        0,
+        frag,
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Accept,
+        "a non-first fragment must NOT match `icmp-code 0` (#2362 fold A)"
+    );
+    let real = TermMatchExtra {
+        l4_present: true,
+        icmp_code: 0,
+        ..Default::default()
+    };
+    let r2 = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_ICMP,
+        0,
+        0,
+        0,
+        real,
+    );
+    assert_eq!(
+        r2.action,
+        FilterAction::Discard,
+        "a real ICMP packet with code 0 (L4 present) MUST match `icmp-code 0`"
+    );
+}
+
+#[test]
+fn non_first_fragment_still_matches_is_fragment() {
+    // The is-fragment term is L3-derived and NOT gated by l4_present.
+    let state = make_filter_state(&per_packet_filter("inet", "", None, true, None, None), &[]);
+    let frag = TermMatchExtra {
+        l4_present: false,
+        is_fragment: true,
+        ..Default::default()
+    };
+    let r = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_ICMP,
+        0,
+        0,
+        0,
+        frag,
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Discard,
+        "a non-first fragment IS a fragment — is-fragment must still match (#2362 fold A)"
+    );
 }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -48,6 +48,10 @@ fn basic_accept_discard() {
                     routing_instance: String::new(),
                     forwarding_class: String::new(),
                     dscp_rewrite: None,
+                    tcp_flags: None,
+                    is_fragment: false,
+                    icmp_type: None,
+                    icmp_code: None,
                 },
                 FirewallTermSnapshot {
                     name: "allow-all".into(),
@@ -64,6 +68,10 @@ fn basic_accept_discard() {
                     routing_instance: String::new(),
                     forwarding_class: String::new(),
                     dscp_rewrite: None,
+                    tcp_flags: None,
+                    is_fragment: false,
+                    icmp_type: None,
+                    icmp_code: None,
                 },
             ],
         }],
@@ -79,6 +87,7 @@ fn basic_accept_discard() {
         12345,
         22,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Discard);
 
@@ -92,6 +101,7 @@ fn basic_accept_discard() {
         12345,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
 }
@@ -128,6 +138,7 @@ fn interface_filter_log_match_returns_filter_and_term_identity() {
         49152,
         443,
         0,
+        TermMatchExtra::default(),
         true,
     )
     .expect("logged input filter hit");
@@ -170,6 +181,7 @@ fn interface_filter_log_match_skips_pbr_terms_without_double_emit() {
         49152,
         443,
         0,
+        TermMatchExtra::default(),
         true,
     );
 
@@ -197,6 +209,10 @@ fn port_range_matching() {
                 routing_instance: String::new(),
                 forwarding_class: String::new(),
                 dscp_rewrite: None,
+                tcp_flags: None,
+                is_fragment: false,
+                icmp_type: None,
+                icmp_code: None,
             }],
         }],
         &[],
@@ -211,6 +227,7 @@ fn port_range_matching() {
         54321,
         2000,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Discard);
 
@@ -224,6 +241,7 @@ fn port_range_matching() {
         54321,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
 }
@@ -249,6 +267,10 @@ fn protocol_matching() {
                 routing_instance: String::new(),
                 forwarding_class: String::new(),
                 dscp_rewrite: None,
+                tcp_flags: None,
+                is_fragment: false,
+                icmp_type: None,
+                icmp_code: None,
             }],
         }],
         &[],
@@ -263,6 +285,7 @@ fn protocol_matching() {
         0,
         0,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Discard);
 
@@ -276,6 +299,7 @@ fn protocol_matching() {
         1234,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
 }
@@ -301,6 +325,10 @@ fn dscp_rewrite_action() {
                 routing_instance: String::new(),
                 forwarding_class: String::new(),
                 dscp_rewrite: Some(46), // EF
+                tcp_flags: None,
+                is_fragment: false,
+                icmp_type: None,
+                icmp_code: None,
             }],
         }],
         &[],
@@ -314,6 +342,7 @@ fn dscp_rewrite_action() {
         54321,
         5060,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
     assert_eq!(result.dscp_rewrite, Some(46));
@@ -340,6 +369,10 @@ fn dscp_rewrite_action_allows_default_zero() {
                 routing_instance: String::new(),
                 forwarding_class: String::new(),
                 dscp_rewrite: Some(0),
+                tcp_flags: None,
+                is_fragment: false,
+                icmp_type: None,
+                icmp_code: None,
             }],
         }],
         &[],
@@ -353,6 +386,7 @@ fn dscp_rewrite_action_allows_default_zero() {
         54321,
         5060,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
     assert_eq!(result.dscp_rewrite, Some(0));
@@ -1181,6 +1215,10 @@ fn multiple_terms_first_match_wins() {
                     routing_instance: String::new(),
                     forwarding_class: String::new(),
                     dscp_rewrite: None,
+                    tcp_flags: None,
+                    is_fragment: false,
+                    icmp_type: None,
+                    icmp_code: None,
                 },
                 FirewallTermSnapshot {
                     name: "deny-all-udp".into(),
@@ -1197,6 +1235,10 @@ fn multiple_terms_first_match_wins() {
                     routing_instance: String::new(),
                     forwarding_class: String::new(),
                     dscp_rewrite: None,
+                    tcp_flags: None,
+                    is_fragment: false,
+                    icmp_type: None,
+                    icmp_code: None,
                 },
             ],
         }],
@@ -1212,6 +1254,7 @@ fn multiple_terms_first_match_wins() {
         12345,
         53,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
 
@@ -1225,6 +1268,7 @@ fn multiple_terms_first_match_wins() {
         12345,
         1234,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Discard);
 }
@@ -1250,6 +1294,10 @@ fn source_dest_address_matching() {
                 routing_instance: String::new(),
                 forwarding_class: String::new(),
                 dscp_rewrite: None,
+                tcp_flags: None,
+                is_fragment: false,
+                icmp_type: None,
+                icmp_code: None,
             }],
         }],
         &[],
@@ -1264,6 +1312,7 @@ fn source_dest_address_matching() {
         1234,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Discard);
 
@@ -1277,6 +1326,7 @@ fn source_dest_address_matching() {
         1234,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
 }
@@ -1353,6 +1403,7 @@ fn interface_filter_assignment() {
         1234,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Discard);
 
@@ -1367,6 +1418,7 @@ fn interface_filter_assignment() {
         1234,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
 
@@ -1380,6 +1432,7 @@ fn interface_filter_assignment() {
         1234,
         5201,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.forwarding_class.as_ref(), "bandwidth-10mb");
 }
@@ -1521,6 +1574,7 @@ fn interface_filter_routing_instance_counted_returns_matching_override() {
         12345,
         5201,
         0,
+        TermMatchExtra::default(),
         1500,
     );
     assert_eq!(routing_instance, Some("sfmix"));
@@ -1566,6 +1620,7 @@ fn interface_output_filter_counted_records_term_hits() {
         40000,
         5201,
         0,
+        TermMatchExtra::default(),
         1514,
     );
     assert_eq!(result.forwarding_class.as_ref(), "iperf-a");
@@ -1614,6 +1669,7 @@ fn interface_output_filter_without_count_does_not_record_term_hits() {
         40000,
         5201,
         0,
+        TermMatchExtra::default(),
         1514,
     );
     assert_eq!(result.forwarding_class.as_ref(), "iperf-a");
@@ -1662,6 +1718,7 @@ fn lo0_filter_evaluation() {
         12345,
         22,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
 
@@ -1675,6 +1732,7 @@ fn lo0_filter_evaluation() {
         12345,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Discard);
 }
@@ -1712,6 +1770,7 @@ fn dscp_match_in_term() {
         1234,
         5060,
         46,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
 
@@ -1725,6 +1784,7 @@ fn dscp_match_in_term() {
         1234,
         5060,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Discard);
 }
@@ -2036,6 +2096,7 @@ fn evaluate_filter_returns_reject_action() {
         40000,
         23,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Reject);
 }
@@ -2066,6 +2127,7 @@ fn evaluate_filter_missing_key_returns_default_accept() {
         1234,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Accept);
     assert_eq!(result, FilterResult::default());
@@ -2090,13 +2152,17 @@ fn evaluate_filter_empty_filter_returns_default_accept() {
         1234,
         80,
         0,
+        TermMatchExtra::default(),
     );
     // A compiled-but-empty filter must fall through to the full default,
     // distinguishable from the missing-key path: the filter exists with zero
     // terms, so a compiler bug that dropped empty filters would also surface
     // here.
     assert_eq!(result, FilterResult::default());
-    let filter = state.filters.get("inet:empty").expect("empty filter compiled");
+    let filter = state
+        .filters
+        .get("inet:empty")
+        .expect("empty filter compiled");
     assert!(filter.terms.is_empty());
 }
 
@@ -2126,6 +2192,7 @@ fn evaluate_filter_mixed_address_family_returns_default_accept() {
         1234,
         80,
         0,
+        TermMatchExtra::default(),
     );
     // The default arm must produce the full default result, not just an Accept
     // action with leftover rewrite/routing/forwarding-class fields.
@@ -2165,6 +2232,7 @@ fn evaluate_filter_ipv6_matches_term() {
         40000,
         443,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(denied.action, FilterAction::Discard);
     // Out-of-prefix source falls through to the accept term.
@@ -2177,6 +2245,7 @@ fn evaluate_filter_ipv6_matches_term() {
         40000,
         443,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(allowed.action, FilterAction::Accept);
 }
@@ -2216,6 +2285,7 @@ fn evaluate_lo0_filter_ipv6_path() {
         40000,
         22,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(accepted.action, FilterAction::Accept);
     let discarded = evaluate_lo0_filter(
@@ -2227,6 +2297,7 @@ fn evaluate_lo0_filter_ipv6_path() {
         40000,
         80,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(discarded.action, FilterAction::Discard);
 }
@@ -2266,6 +2337,7 @@ fn evaluate_interface_filter_ipv6_input_path() {
         49152,
         443,
         0,
+        TermMatchExtra::default(),
     );
     assert_eq!(result.action, FilterAction::Discard);
 }
@@ -2297,6 +2369,7 @@ fn evaluate_filter_counted_increments_term_counter() {
         40000,
         80,
         0,
+        TermMatchExtra::default(),
         1400,
     );
     assert_eq!(result.action, FilterAction::Accept);
@@ -2315,6 +2388,7 @@ fn evaluate_filter_counted_increments_term_counter() {
         40000,
         443,
         0,
+        TermMatchExtra::default(),
         1400,
     );
     assert_eq!(miss.action, FilterAction::Accept);
@@ -2348,6 +2422,7 @@ fn evaluate_filter_counted_increments_term_counter_ipv6() {
         40000,
         80,
         0,
+        TermMatchExtra::default(),
         1500,
     );
     assert_eq!(result.action, FilterAction::Accept);
@@ -2409,6 +2484,7 @@ fn interface_filter_non_routing_counted_defers_pbr_term() {
         40000,
         5201,
         0,
+        TermMatchExtra::default(),
         1400,
     );
     assert_eq!(pbr.action, FilterAction::Accept);
@@ -2428,6 +2504,7 @@ fn interface_filter_non_routing_counted_defers_pbr_term() {
         40000,
         53,
         0,
+        TermMatchExtra::default(),
         500,
     );
     assert_eq!(plain.action, FilterAction::Discard);
@@ -2650,20 +2727,508 @@ fn cached_and_runtime_tx_selection_agree_on_plain_term() {
     let runtime = evaluate_filter_ref_tx_selection_runtime_counted(
         filter, src, dst, PROTO_TCP, 40000, 5201, 0, 0, 1,
     );
-    let cached = evaluate_filter_ref_tx_selection_cached(filter, src, dst, PROTO_TCP, 40000, 5201, 0);
+    let cached =
+        evaluate_filter_ref_tx_selection_cached(filter, src, dst, PROTO_TCP, 40000, 5201, 0);
 
     // A term with no three-color policer must yield identical action,
     // forwarding-class, DSCP rewrite, and log-match identity on both paths.
     assert_eq!(runtime.action, cached.action);
     assert_eq!(runtime.action, FilterAction::Accept);
-    assert_eq!(
-        runtime.forwarding_class,
-        cached.forwarding_class.as_deref()
-    );
+    assert_eq!(runtime.forwarding_class, cached.forwarding_class.as_deref());
     assert_eq!(runtime.forwarding_class, Some("iperf-a"));
     assert_eq!(runtime.dscp_rewrite, cached.dscp_rewrite);
     assert_eq!(runtime.dscp_rewrite, Some(46));
     assert_eq!(runtime.log_match, cached.log_match);
     assert!(runtime.log_match.is_some());
     assert!(!runtime.policer_drop);
+}
+
+// ===========================================================================
+// #2362 per-packet L4 match conditions (tcp-flags / is-fragment / icmp-type /
+// icmp-code). These were parsed by the Go compiler but dropped on the wire and
+// absent from the Rust matcher, so a term matched broader than authored. The
+// tests below exercise the runtime match predicate directly: a packet matching
+// the condition triggers the term action; one that does not (wrong flags / not
+// a fragment / wrong icmp-type / wrong protocol) falls through to the default.
+// ===========================================================================
+
+// Build a one-term filter carrying explicit per-packet conditions, then a
+// trailing accept-all term so a non-match is observably Accept.
+fn per_packet_filter(
+    family: &str,
+    proto: &str,
+    tcp_flags: Option<u8>,
+    is_fragment: bool,
+    icmp_type: Option<u8>,
+    icmp_code: Option<u8>,
+) -> Vec<FirewallFilterSnapshot> {
+    vec![FirewallFilterSnapshot {
+        name: "pp".into(),
+        family: family.into(),
+        terms: vec![
+            FirewallTermSnapshot {
+                name: "match".into(),
+                protocols: if proto.is_empty() {
+                    vec![]
+                } else {
+                    vec![proto.into()]
+                },
+                action: "discard".into(),
+                tcp_flags,
+                is_fragment,
+                icmp_type,
+                icmp_code,
+                ..Default::default()
+            },
+            FirewallTermSnapshot {
+                name: "rest".into(),
+                action: "accept".into(),
+                ..Default::default()
+            },
+        ],
+    }]
+}
+
+fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+}
+
+fn extra_tcp(flags: u8) -> TermMatchExtra {
+    TermMatchExtra {
+        tcp_flags: flags,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn tcp_flags_term_matches_syn_only() {
+    // tcp-flags syn then discard: SYN(0x02) is dropped, a pure ACK forwards.
+    let state = make_filter_state(
+        &per_packet_filter("inet", "tcp", Some(0x02), false, None, None),
+        &[],
+    );
+    let syn = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        1000,
+        22,
+        0,
+        extra_tcp(0x02),
+    );
+    assert_eq!(
+        syn.action,
+        FilterAction::Discard,
+        "SYN must match tcp-flags syn"
+    );
+    let ack = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        1000,
+        22,
+        0,
+        extra_tcp(0x10),
+    );
+    assert_eq!(
+        ack.action,
+        FilterAction::Accept,
+        "pure ACK must NOT match tcp-flags syn"
+    );
+    // SYN+ACK has SYN set -> still matches (Junos `tcp-flags syn` semantics).
+    let synack = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        1000,
+        22,
+        0,
+        extra_tcp(0x12),
+    );
+    assert_eq!(
+        synack.action,
+        FilterAction::Discard,
+        "SYN+ACK has SYN set -> matches"
+    );
+}
+
+#[test]
+fn tcp_flags_term_requires_all_listed_flags() {
+    // tcp-flags (syn & ack) folded to mask 0x12: only a segment with BOTH set matches.
+    let state = make_filter_state(
+        &per_packet_filter("inet", "tcp", Some(0x12), false, None, None),
+        &[],
+    );
+    let synack = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        1000,
+        80,
+        0,
+        extra_tcp(0x12),
+    );
+    assert_eq!(synack.action, FilterAction::Discard);
+    let syn = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        1000,
+        80,
+        0,
+        extra_tcp(0x02),
+    );
+    assert_eq!(
+        syn.action,
+        FilterAction::Accept,
+        "SYN alone lacks ACK -> no match"
+    );
+}
+
+#[test]
+fn tcp_flags_term_does_not_match_non_tcp() {
+    // A tcp-flags term must never match a UDP packet even if the (meaningless)
+    // tcp_flags byte happens to carry the bits.
+    let state = make_filter_state(
+        &per_packet_filter("inet", "", Some(0x02), false, None, None),
+        &[],
+    );
+    let udp = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_UDP,
+        1000,
+        53,
+        0,
+        extra_tcp(0x02),
+    );
+    assert_eq!(
+        udp.action,
+        FilterAction::Accept,
+        "UDP must not match a tcp-flags term"
+    );
+}
+
+#[test]
+fn is_fragment_term_spares_non_fragments() {
+    let state = make_filter_state(&per_packet_filter("inet", "", None, true, None, None), &[]);
+    let frag = TermMatchExtra {
+        is_fragment: true,
+        ..Default::default()
+    };
+    let dropped = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_UDP,
+        1000,
+        53,
+        0,
+        frag,
+    );
+    assert_eq!(
+        dropped.action,
+        FilterAction::Discard,
+        "a fragment must match is-fragment"
+    );
+    let whole = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_UDP,
+        1000,
+        53,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        whole.action,
+        FilterAction::Accept,
+        "a non-fragment must NOT match is-fragment"
+    );
+}
+
+#[test]
+fn icmp_type_term_matches_only_that_type_v4() {
+    // icmp-type 8 (echo-request) then discard must NOT collapse to drop-all-ICMP.
+    let state = make_filter_state(
+        &per_packet_filter("inet", "icmp", None, false, Some(8), None),
+        &[],
+    );
+    let echo = TermMatchExtra {
+        icmp_type: 8,
+        ..Default::default()
+    };
+    let drop = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_ICMP,
+        0,
+        0,
+        0,
+        echo,
+    );
+    assert_eq!(
+        drop.action,
+        FilterAction::Discard,
+        "echo-request must match icmp-type 8"
+    );
+    let reply = TermMatchExtra {
+        icmp_type: 0,
+        ..Default::default()
+    };
+    let pass = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_ICMP,
+        0,
+        0,
+        0,
+        reply,
+    );
+    assert_eq!(
+        pass.action,
+        FilterAction::Accept,
+        "echo-reply (type 0) must NOT match icmp-type 8"
+    );
+}
+
+#[test]
+fn icmp_type_term_matches_icmpv6() {
+    // icmp-type 128 (ICMPv6 echo-request) on an inet6 filter.
+    let state = make_filter_state(
+        &per_packet_filter("inet6", "icmpv6", None, false, Some(128), None),
+        &[],
+    );
+    let v6 = |s: &str| IpAddr::V6(s.parse::<Ipv6Addr>().unwrap());
+    let echo = TermMatchExtra {
+        icmp_type: 128,
+        ..Default::default()
+    };
+    let drop = evaluate_filter(
+        &state,
+        "inet6:pp",
+        v6("2001:db8::1"),
+        v6("2001:db8::2"),
+        PROTO_ICMPV6,
+        0,
+        0,
+        0,
+        echo,
+    );
+    assert_eq!(drop.action, FilterAction::Discard);
+    let na = TermMatchExtra {
+        icmp_type: 136,
+        ..Default::default()
+    };
+    let pass = evaluate_filter(
+        &state,
+        "inet6:pp",
+        v6("2001:db8::1"),
+        v6("2001:db8::2"),
+        PROTO_ICMPV6,
+        0,
+        0,
+        0,
+        na,
+    );
+    assert_eq!(
+        pass.action,
+        FilterAction::Accept,
+        "neighbor-advert (136) must NOT match icmp-type 128"
+    );
+}
+
+#[test]
+fn icmp_code_term_narrows_within_type() {
+    // icmp-type 3 code 4 (frag-needed) — code 0 must not match.
+    let state = make_filter_state(
+        &per_packet_filter("inet", "icmp", None, false, Some(3), Some(4)),
+        &[],
+    );
+    let frag_needed = TermMatchExtra {
+        icmp_type: 3,
+        icmp_code: 4,
+        ..Default::default()
+    };
+    let drop = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_ICMP,
+        0,
+        0,
+        0,
+        frag_needed,
+    );
+    assert_eq!(drop.action, FilterAction::Discard);
+    let net_unreach = TermMatchExtra {
+        icmp_type: 3,
+        icmp_code: 0,
+        ..Default::default()
+    };
+    let pass = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_ICMP,
+        0,
+        0,
+        0,
+        net_unreach,
+    );
+    assert_eq!(
+        pass.action,
+        FilterAction::Accept,
+        "code 0 must NOT match icmp-code 4"
+    );
+}
+
+#[test]
+fn icmp_term_does_not_match_non_icmp() {
+    let state = make_filter_state(
+        &per_packet_filter("inet", "", None, false, Some(8), None),
+        &[],
+    );
+    // A TCP packet whose byte happens to equal 8 must not match an icmp-type term.
+    let tcp = TermMatchExtra {
+        tcp_flags: 0x02,
+        icmp_type: 8,
+        ..Default::default()
+    };
+    let pass = evaluate_filter(
+        &state,
+        "inet:pp",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        1000,
+        80,
+        0,
+        tcp,
+    );
+    assert_eq!(
+        pass.action,
+        FilterAction::Accept,
+        "TCP must not match an icmp-type term"
+    );
+}
+
+#[test]
+fn per_packet_match_action_applies_with_count() {
+    // The term action AND its count side-effect apply on a per-packet match.
+    let filters = vec![FirewallFilterSnapshot {
+        name: "c".into(),
+        family: "inet".into(),
+        terms: vec![FirewallTermSnapshot {
+            name: "syn".into(),
+            protocols: vec!["tcp".into()],
+            action: "discard".into(),
+            count: "syns".into(),
+            tcp_flags: Some(0x02),
+            ..Default::default()
+        }],
+    }];
+    let state = make_filter_state(&filters, &[]);
+    let r = evaluate_filter_counted(
+        &state,
+        "inet:c",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        1000,
+        22,
+        0,
+        extra_tcp(0x02),
+        1500,
+    );
+    assert_eq!(r.action, FilterAction::Discard);
+    let filter = state.filters.get("inet:c").expect("filter");
+    assert_eq!(filter.terms[0].counter.packets.load(Ordering::Relaxed), 1);
+    assert_eq!(filter.terms[0].counter.bytes.load(Ordering::Relaxed), 1500);
+    // A non-matching ACK must NOT bump the counter.
+    let _ = evaluate_filter_counted(
+        &state,
+        "inet:c",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        1000,
+        22,
+        0,
+        extra_tcp(0x10),
+        1500,
+    );
+    assert_eq!(filter.terms[0].counter.packets.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn per_packet_match_marks_filter_cache_sensitive() {
+    // A filter carrying any per-packet L4 match term must be flagged so the
+    // flow-cache declines (path (b), #1431/#2362) and the on-session re-eval
+    // gate fires.
+    let filters = per_packet_filter("inet", "tcp", Some(0x02), false, None, None);
+    let interfaces = [crate::InterfaceSnapshot {
+        ifindex: 7,
+        filter_input_v4: "pp".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(&filters, &[], &interfaces, "", "");
+    assert!(
+        state.iface_filter_v4_has_per_packet_l4_match.contains(&7),
+        "interface input filter with a tcp-flags term must be marked per-packet-L4 cache-sensitive"
+    );
+    assert!(interface_input_filter_has_per_packet_l4_match(
+        &state, 7, false
+    ));
+    let filter = state.iface_filter_v4_fast.get(&7).expect("filter");
+    assert!(filter.has_per_packet_l4_match_terms);
+}
+
+// #2362 / #1961-class wire round-trip: a Go-encoded FirewallTermSnapshot with
+// the new fields must decode into the Rust DTO with the same values. Guards the
+// one-sided-field decode-failure (whole-snapshot abort -> no transit) class.
+#[test]
+fn firewall_term_snapshot_per_packet_fields_round_trip() {
+    let json = r#"{
+        "name": "syn-only",
+        "protocols": ["tcp"],
+        "action": "discard",
+        "tcp_flags": 2,
+        "is_fragment": true,
+        "icmp_type": 8,
+        "icmp_code": 0
+    }"#;
+    let term: FirewallTermSnapshot = serde_json::from_str(json).expect("decode");
+    assert_eq!(term.tcp_flags, Some(2));
+    assert!(term.is_fragment);
+    assert_eq!(term.icmp_type, Some(8));
+    assert_eq!(term.icmp_code, Some(0));
+    // Absent fields default to None/false (forward/backward compatibility).
+    let minimal: FirewallTermSnapshot =
+        serde_json::from_str(r#"{"name":"x","action":"accept"}"#).expect("decode minimal");
+    assert_eq!(minimal.tcp_flags, None);
+    assert!(!minimal.is_fragment);
+    assert_eq!(minimal.icmp_type, None);
+    assert_eq!(minimal.icmp_code, None);
 }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -481,6 +481,7 @@ fn three_color_runtime_ids_and_miss_path_counters_are_stable() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         100,
         0,
     );
@@ -494,6 +495,7 @@ fn three_color_runtime_ids_and_miss_path_counters_are_stable() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         51,
         0,
     );
@@ -592,6 +594,7 @@ fn equivalent_snapshot_refresh_preserves_three_color_state_and_counters() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         100,
         0,
     );
@@ -622,6 +625,7 @@ fn equivalent_snapshot_refresh_preserves_three_color_state_and_counters() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         51,
         0,
     );
@@ -676,6 +680,7 @@ fn three_color_adding_lower_sorted_policer_does_not_reset_existing_runtime() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         100,
         0,
     );
@@ -716,6 +721,7 @@ fn three_color_adding_lower_sorted_policer_does_not_reset_existing_runtime() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         51,
         0,
     );
@@ -772,6 +778,7 @@ fn three_color_compatible_refresh_observes_old_runtime_mutations_after_rebuild()
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         100,
         0,
     );
@@ -786,6 +793,7 @@ fn three_color_compatible_refresh_observes_old_runtime_mutations_after_rebuild()
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         51,
         0,
     );
@@ -837,6 +845,7 @@ fn changed_snapshot_shape_resets_three_color_runtime_state() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         100,
         0,
     );
@@ -860,6 +869,7 @@ fn changed_snapshot_shape_resets_three_color_runtime_state() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         200,
         0,
     );
@@ -1054,6 +1064,7 @@ fn unsupported_three_color_snapshots_fail_closed_in_rust_compiler() {
             12345,
             5000,
             0,
+            TermMatchExtra::default(),
             1,
             0,
         );
@@ -1104,6 +1115,7 @@ fn three_color_empty_then_action_uses_default_discard() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         100,
         0,
     );
@@ -1115,6 +1127,7 @@ fn three_color_empty_then_action_uses_default_discard() {
         12345,
         5000,
         0,
+        TermMatchExtra::default(),
         51,
         0,
     );
@@ -2565,6 +2578,7 @@ fn interface_filter_tx_selection_wrappers_dispatch_and_default() {
         40000,
         5201,
         0,
+        TermMatchExtra::default(),
         1400,
     );
     assert_eq!(input.action, FilterAction::Accept);
@@ -2580,6 +2594,7 @@ fn interface_filter_tx_selection_wrappers_dispatch_and_default() {
         40000,
         5202,
         0,
+        TermMatchExtra::default(),
         1400,
     );
     assert_eq!(output.action, FilterAction::Accept);
@@ -2596,6 +2611,7 @@ fn interface_filter_tx_selection_wrappers_dispatch_and_default() {
         40000,
         5201,
         0,
+        TermMatchExtra::default(),
         1400,
     );
     assert_eq!(none_in.action, FilterAction::Accept);
@@ -2725,7 +2741,16 @@ fn cached_and_runtime_tx_selection_agree_on_plain_term() {
     let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
 
     let runtime = evaluate_filter_ref_tx_selection_runtime_counted(
-        filter, src, dst, PROTO_TCP, 40000, 5201, 0, 0, 1,
+        filter,
+        src,
+        dst,
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        TermMatchExtra::default(),
+        0,
+        1,
     );
     let cached =
         evaluate_filter_ref_tx_selection_cached(filter, src, dst, PROTO_TCP, 40000, 5201, 0);

--- a/userspace-dp/src/protocol/security.rs
+++ b/userspace-dp/src/protocol/security.rs
@@ -121,6 +121,27 @@ pub(crate) struct FirewallTermSnapshot {
     pub forwarding_class: String,
     #[serde(rename = "dscp_rewrite", default)]
     pub dscp_rewrite: Option<u8>,
+    // Per-packet L4 match conditions (#2362). Mirror of the Go
+    // FirewallTermSnapshot fields. These are NOT in SessionKey, so a filter
+    // carrying any of them is cache-sensitive — see the #1431 invariant above
+    // and the path-(b) wiring in afxdp/flow_cache.rs.
+    //
+    // tcp_flags is a required-bits mask over the TCP flags byte (FIN=0x01,
+    // SYN=0x02, RST=0x04, PSH=0x08, ACK=0x10, URG=0x20): a TCP packet matches
+    // when (flags & mask) == mask. None = no constraint; a non-TCP packet
+    // never matches a term that sets it.
+    #[serde(rename = "tcp_flags", default)]
+    pub tcp_flags: Option<u8>,
+    // is_fragment matches any IP fragment (IPv4 MF set OR non-zero offset;
+    // IPv6 fragment extension header present).
+    #[serde(rename = "is_fragment", default)]
+    pub is_fragment: bool,
+    // icmp_type / icmp_code match the ICMP/ICMPv6 type and code bytes. None =
+    // no constraint; a non-ICMP(v6) packet never matches a term that sets them.
+    #[serde(rename = "icmp_type", default)]
+    pub icmp_type: Option<u8>,
+    #[serde(rename = "icmp_code", default)]
+    pub icmp_code: Option<u8>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -323,5 +344,3 @@ pub(crate) struct ThreeColorPolicerStatus {
     #[serde(rename = "drop_bytes", default)]
     pub drop_bytes: u64,
 }
-
-

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -490,13 +490,17 @@
     "dscp_rewrite": null,
     "dscp_values": [],
     "forwarding_class": "",
+    "icmp_code": null,
+    "icmp_type": null,
+    "is_fragment": false,
     "log": false,
     "name": "",
     "policer": "",
     "protocols": [],
     "routing_instance": "",
     "source_addresses": [],
-    "source_ports": []
+    "source_ports": [],
+    "tcp_flags": null
   },
   "flow_export_snapshot": {
     "active_timeout": 0,


### PR DESCRIPTION
Closes #2362

## Problem

The Junos firewall-filter compiler parses `tcp-flags`, `is-fragment`,
`icmp-type`, and `icmp-code` into `config.FirewallFilterTerm`, and the
docs claim they work — but **all four were silently dropped** on the
Go→Rust snapshot wire and absent from the Rust matcher. A committed term
like `from { tcp-flags syn; } then discard` reached the dataplane
carrying only `protocol tcp`, so it discarded **all TCP** instead of just
SYN. Symmetrically, `is-fragment then discard` lost the fragment
predicate and `icmp-type echo-request then discard` collapsed to
drop-all-ICMP. Terms matched **broader than authored** — a
security-relevant silent policy gap.

Verified against current master: all four were genuinely dropped (parsed
into the typed term, never serialized in `pkg/dataplane/userspace/filters.go`,
absent from `FirewallTermSnapshot` on both sides and from the Rust
`FilterTerm`). None were already wired.

## Fix (end-to-end)

**Go wire** (`protocol.go`, `filters.go`): added `tcp_flags` (`*uint8`
required-bits mask folded from the flag-name list via `tcpFlagsMask`),
`is_fragment` (`bool`), `icmp_type`/`icmp_code` (`*uint8`, only when the
compiler's `-1` "not set" is an in-range byte) to `FirewallTermSnapshot`.

**Rust wire** (`protocol/security.rs`): mirrored the four fields with
matching serde tags (`tcp_flags`/`is_fragment`/`icmp_type`/`icmp_code`).

**Rust match** (`filter/mod.rs`, `compiler.rs`, `engine/matching.rs`,
`engine/eval.rs`): runtime `FilterTerm` carries the fields; a new
`per_packet_l4_matches` predicate runs after the 5-tuple checks (v4+v6):
tcp-flags `(flags & mask) == mask` and only TCP; `is-fragment` matches
ANY fragment via the new `is_any_fragment` (IPv4 MF|offset, IPv6 frag
header) in `frame/inspect.rs`; icmp-type/code exact byte match and only
ICMP/ICMPv6. The inputs travel in a `Copy` `TermMatchExtra` built once
per packet at the cold filter-eval sites.

**Cache coherency** (path (b), #1431, same class as DSCP): new
`has_per_packet_l4_match_terms` aggregate + per-interface sets; the
flow-cache declines (`flow_cache.rs`), the session-hit decision is
re-evaluated, and a config rotation purges the affected sessions.

**Wire fields added on BOTH sides** + `protocol_wire_v1.json`
regenerated (the SSOT default-specimen fixture; guards the #1961
one-sided-field decode-failure class).

## Match-eval sites

- `userspace-dp/src/filter/engine/matching.rs:per_packet_l4_matches` (+ `term_matches_v4`/`term_matches_v6`)
- `userspace-dp/src/afxdp/frame/inspect.rs:is_any_fragment` / `ipv4_is_any_fragment` / `ipv6_is_any_fragment` / `term_match_extra_from_frame`
- flow-cache decline: `userspace-dp/src/afxdp/flow_cache.rs`
- session-hit re-eval: `userspace-dp/src/afxdp/poll_descriptor/filter.rs:evaluate_dscp_sensitive_input_filter_on_session_hit`
- rotation purge: `userspace-dp/src/afxdp/worker/loop_body/mod.rs`

## Tests

- **Go** (`filters_per_packet_match_2362_test.go`): each term is
  serialized (fails on pre-fix); `tcpFlagsMask` (multi-flag AND,
  unknown→nil); icmp `-1`→nil.
- **Rust** (`filter/tests.rs`): per-term match/no-match (wrong
  flags/not-a-fragment/wrong-icmp-type/wrong-proto), v4+v6 (ICMPv6
  echo-request), action+count on match only, cache-sensitive flag, and a
  Go→Rust wire round-trip.
- `flow_cache_tests.rs`: cache declines for per-packet-L4 input + output
  filters. `frame/tests.rs`: `is_any_fragment` truth tables.

`go build ./...` + `go test ./pkg/config/... ./pkg/dataplane/...` green;
`cargo build --release` + full test suite (2468) green; new tests 5x
stable; touched files `cargo fmt --check`-clean.

## Limitations (parser, not dataplane)

The parser yields a flat flag-name list, so the richer Junos
`tcp-flags "(syn & !ack)"` expression grammar (negation/disjunction,
`tcp-established`) is out of scope — only a conjunction of named flags is
supported (an unrecognized token yields no constraint, not match-all).
Named `icmp-type`/`icmp-code` aliases are likewise not parsed; numeric
only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi