### PR TITLE
nat: install every DNAT destination-address, not just the first (#2395)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11217,3 +11217,26 @@ top.
   - **File(s)**: pkg/config/compiler_validate_warn.go,
     pkg/config/parser_ast_test.go, pkg/config/policy_zone_ref_test.go,
     _Log.md
+
+- **Timestamp**: 2026-06-23
+  - **Action**: #2395 fix DNAT multiple destination-addresses collapse.
+    buildDestinationNATSnapshots iterated only the singular
+    rule.Match.DestinationAddress (first list element), so a rule with
+    `match destination-address [ A B C ]` installed a DNAT table entry only
+    for A — traffic to B and C was forwarded untranslated (HIGH). Fix: build
+    destAddrs from rule.Match.DestinationAddresses with a singular fallback
+    (mirrors the #2394 source-address idiom) and emit one
+    DestinationNATRuleSnapshot per destination sharing the rule's
+    pool/port/counter. The DNAT table is keyed by exact dst_ip, so per-entry
+    is the natural shape — NO wire change (reuse the existing scalar
+    destination_address; protocol_wire_v1.json unchanged). Per-destination
+    CIDR-strip + net.ParseIP validation; all-malformed destination set emits
+    no rows => matches nothing (fail-closed, not match-any). Source-constraint
+    setup wraps the destination loop so each per-dest snapshot carries the
+    same SourceAddresses (#2394 composition preserved). Added Go test
+    TestBuildDestinationNATSnapshotsMultiDestination (fail-on-revert: collapse
+    to destAddrs[:1] fails) and Rust dnat_multiple_destinations_each_fire /
+    _v6_each_fire / _compose_with_source_scope.
+  - **File(s)**: pkg/dataplane/userspace/nat.go,
+    pkg/dataplane/userspace/nat_per_uplink_test.go,
+    userspace-dp/src/nat/tests.rs, docs/userspace-dnat-plan.md, _Log.md

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -348,3 +348,39 @@ Two robustness fixes (the DNAT sibling of #2398 SNAT):
    any" from "scoped rule, zero entries parsed -> match none". A scoped rule
    whose entries all fail to parse matches nothing rather than reverting to
    match-any. A mix of valid + garbage entries keeps the valid prefixes.
+
+## 11. Multiple destination-addresses (#2395)
+
+Junos DNAT `match destination-address [ A B C ]` publishes the SAME
+translation for several external destinations. The compiler already parsed the
+full list into `rule.Match.DestinationAddresses` (with `DestinationAddress`
+mirroring the first element), but `buildDestinationNATSnapshots` iterated only
+the singular `DestinationAddress`. The rule therefore collapsed to its FIRST
+destination — traffic to B and C was forwarded untranslated (configured
+translation silently not applied; HIGH).
+
+The DNAT table is keyed by exact destination IP (`DnatKey.dst_ip`,
+`nat/destination.rs`), so the natural fix is **one snapshot entry per
+destination** sharing the rule's pool/port/counter — no wire change (the
+existing scalar `destination_address` field is reused; `protocol_wire_v1.json`
+is unchanged).
+
+- `buildDestinationNATSnapshots` (`nat.go`) now builds `destAddrs` from
+  `rule.Match.DestinationAddresses` with a singular `DestinationAddress`
+  fallback (mirrors the #2394 source-address idiom), then emits one
+  `DestinationNATRuleSnapshot` per destination inside the existing
+  app-term/port loop. Each destination has its CIDR suffix stripped (DNAT
+  matches exact host IPs) and is validated with `net.ParseIP`.
+- **Fail-closed on all-malformed** — a destination that is empty or not a bare
+  host IP is skipped. If a rule has destinations but EVERY one is malformed, no
+  snapshot row is emitted, so the rule matches NOTHING rather than broadening
+  to match-any. (The Rust `from_snapshots` also `continue`s on a destination it
+  cannot `IpAddr::parse`, so the fail-closed posture holds on both sides.)
+- **Composition with #2394** — the per-destination loop is nested inside the
+  source-constraint setup, so every emitted per-destination snapshot carries
+  the same `SourceAddresses`. A source-scoped multi-destination DNAT fires for
+  each destination only when the source also matches; neither constraint is
+  regressed.
+
+The rewrite target (translated destination/port from the pool) is unchanged —
+only the MATCH set grows from one destination to all configured destinations.

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -2,6 +2,7 @@ package userspace
 
 import (
 	"log/slog"
+	"net"
 	"strconv"
 	"strings"
 
@@ -206,7 +207,19 @@ func buildDestinationNATSnapshots(cfg *config.Config, natCounterIDs map[string]u
 			if !ok || pool == nil || pool.Address == "" {
 				continue
 			}
-			if rule.Match.DestinationAddress == "" {
+			// #2395: a DNAT rule may publish multiple destination addresses
+			// (`match destination-address [ A B C ]`). The DNAT table is keyed
+			// by exact destination IP, so each configured destination needs its
+			// OWN snapshot entry sharing the rule's pool/counter id. Iterating
+			// only the singular `DestinationAddress` (the first list element)
+			// collapsed the rule to its first destination and silently dropped
+			// translation for B and C. Mirror the source-address idiom: prefer
+			// the bracket-list form, fall back to the singular match value.
+			destAddrs := append([]string(nil), rule.Match.DestinationAddresses...)
+			if len(destAddrs) == 0 && rule.Match.DestinationAddress != "" {
+				destAddrs = append(destAddrs, rule.Match.DestinationAddress)
+			}
+			if len(destAddrs) == 0 {
 				continue
 			}
 
@@ -276,28 +289,47 @@ func buildDestinationNATSnapshots(cfg *config.Config, natCounterIDs map[string]u
 						proto = "tcp" // default for port-based DNAT
 					}
 
-					// Strip the destination address CIDR suffix for the snapshot
-					// (DNAT matches exact host IPs).
-					dstAddr := rule.Match.DestinationAddress
-					if idx := strings.IndexByte(dstAddr, '/'); idx != -1 {
-						dstAddr = dstAddr[:idx]
-					}
 					poolAddr := pool.Address
 					if idx := strings.IndexByte(poolAddr, '/'); idx != -1 {
 						poolAddr = poolAddr[:idx]
 					}
 
-					out = append(out, DestinationNATRuleSnapshot{
-						Name:               rule.Name,
-						FromZone:           rs.FromZone,
-						SourceAddresses:    sourceAddrs,
-						DestinationAddress: dstAddr,
-						DestinationPort:    dstPort,
-						Protocol:           proto,
-						PoolAddress:        poolAddr,
-						PoolPort:           poolPort,
-						CounterID:          ruleCounterID,
-					})
+					// #2395: emit one snapshot per configured destination so a
+					// bracket-list DNAT installs a table entry for EVERY
+					// published destination, not just the first. Strip any CIDR
+					// suffix (DNAT matches exact host IPs) and skip a malformed
+					// destination — if a rule has destinations but ALL are
+					// malformed, no entry is emitted, so the rule matches NOTHING
+					// (fail-closed) rather than broadening to match-any.
+					for _, rawDst := range destAddrs {
+						dstAddr := rawDst
+						if idx := strings.IndexByte(dstAddr, '/'); idx != -1 {
+							dstAddr = dstAddr[:idx]
+						}
+						if dstAddr == "" {
+							continue
+						}
+						// Reject anything that is not a bare host IP — the Rust
+						// table parses `destination_address` with `IpAddr::parse`
+						// and would `continue` (drop) a non-IP entry; skipping
+						// here keeps the Go and Rust views aligned and avoids
+						// emitting dead snapshot rows.
+						if net.ParseIP(dstAddr) == nil {
+							continue
+						}
+
+						out = append(out, DestinationNATRuleSnapshot{
+							Name:               rule.Name,
+							FromZone:           rs.FromZone,
+							SourceAddresses:    sourceAddrs,
+							DestinationAddress: dstAddr,
+							DestinationPort:    dstPort,
+							Protocol:           proto,
+							PoolAddress:        poolAddr,
+							PoolPort:           poolPort,
+							CounterID:          ruleCounterID,
+						})
+					}
 				}
 			}
 		}

--- a/pkg/dataplane/userspace/nat_per_uplink_test.go
+++ b/pkg/dataplane/userspace/nat_per_uplink_test.go
@@ -194,6 +194,141 @@ func TestBuildDestinationNATSnapshotsCarriesSourceAddress(t *testing.T) {
 	}
 }
 
+// TestBuildDestinationNATSnapshotsMultiDestination is the Go half of the #2395
+// collapse fix: a DNAT rule with `match destination-address [ A B C ]` MUST
+// install a table entry for EVERY published destination, not just the first.
+// Before #2395 the builder iterated only the singular DestinationAddress (the
+// first list element), so traffic to B and C was forwarded untranslated. This
+// test FAILS if the per-destination loop is removed (only one entry emitted).
+func TestBuildDestinationNATSnapshotsMultiDestination(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{
+			"dp4": {Name: "dp4", Address: "10.0.0.5"},
+			"dp6": {Name: "dp6", Address: "2001:db8:dead::5"},
+		},
+		RuleSets: []*config.NATRuleSet{
+			{Name: "multi", FromZone: "untrust", Rules: []*config.NATRule{
+				{
+					// Bracket list (v4): all three destinations must DNAT.
+					Name: "multi-dnat",
+					Match: config.NATMatch{
+						DestinationAddresses: []string{
+							"203.0.113.20",
+							"203.0.113.21/32", // CIDR suffix must be stripped
+							"203.0.113.22",
+						},
+						DestinationAddress: "203.0.113.20", // compiler mirrors first
+						Protocol:           "tcp",
+						DestinationPort:    443,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp4"},
+				},
+				{
+					// Bracket list combined with a source-address scope (#2394):
+					// both source AND each destination must be carried.
+					Name: "multi-dnat-scoped",
+					Match: config.NATMatch{
+						SourceAddresses: []string{"198.51.100.0/24"},
+						SourceAddress:   "198.51.100.0/24",
+						DestinationAddresses: []string{
+							"203.0.113.30",
+							"203.0.113.31",
+						},
+						DestinationAddress: "203.0.113.30",
+						Protocol:           "tcp",
+						DestinationPort:    80,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp4"},
+				},
+				{
+					// Single destination (non-bracket) must still work.
+					Name: "single-dnat",
+					Match: config.NATMatch{
+						DestinationAddress: "203.0.113.40",
+						Protocol:           "tcp",
+						DestinationPort:    8080,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp4"},
+				},
+				{
+					// IPv6 bracket list.
+					Name: "multi-dnat-v6",
+					Match: config.NATMatch{
+						DestinationAddresses: []string{
+							"2001:db8:beef::10",
+							"2001:db8:beef::11/128",
+						},
+						DestinationAddress: "2001:db8:beef::10",
+						Protocol:           "tcp",
+						DestinationPort:    443,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp6"},
+				},
+				{
+					// All-malformed destination set => fail-closed (no entry),
+					// must NOT broaden to match-any.
+					Name: "bad-dnat",
+					Match: config.NATMatch{
+						DestinationAddresses: []string{"not-an-ip", "also/bad"},
+						DestinationAddress:   "not-an-ip",
+						Protocol:             "tcp",
+						DestinationPort:      9999,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp4"},
+				},
+			}},
+		},
+	}
+
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+
+	// Collect destination addresses emitted per rule name.
+	dstByName := map[string][]string{}
+	srcByName := map[string][]string{}
+	for _, s := range snaps {
+		dstByName[s.Name] = append(dstByName[s.Name], s.DestinationAddress)
+		srcByName[s.Name] = s.SourceAddresses
+	}
+
+	hasAll := func(got []string, want ...string) bool {
+		set := map[string]bool{}
+		for _, g := range got {
+			set[g] = true
+		}
+		for _, w := range want {
+			if !set[w] {
+				return false
+			}
+		}
+		return len(got) == len(want)
+	}
+
+	// All three v4 destinations must be installed (collapse bug => only first).
+	if got := dstByName["multi-dnat"]; !hasAll(got, "203.0.113.20", "203.0.113.21", "203.0.113.22") {
+		t.Fatalf("multi-dnat destinations = %+v, want all three (collapse bug installs only the first)", got)
+	}
+	// Source-scoped multi-dest: both destinations + the source constraint.
+	if got := dstByName["multi-dnat-scoped"]; !hasAll(got, "203.0.113.30", "203.0.113.31") {
+		t.Fatalf("multi-dnat-scoped destinations = %+v, want both", got)
+	}
+	if got := srcByName["multi-dnat-scoped"]; len(got) != 1 || got[0] != "198.51.100.0/24" {
+		t.Fatalf("multi-dnat-scoped SourceAddresses = %+v, want #2394 source constraint preserved", got)
+	}
+	// Single destination still works.
+	if got := dstByName["single-dnat"]; !hasAll(got, "203.0.113.40") {
+		t.Fatalf("single-dnat destinations = %+v, want single entry", got)
+	}
+	// IPv6 bracket list.
+	if got := dstByName["multi-dnat-v6"]; !hasAll(got, "2001:db8:beef::10", "2001:db8:beef::11") {
+		t.Fatalf("multi-dnat-v6 destinations = %+v, want both v6 entries (CIDR stripped)", got)
+	}
+	// All-malformed => fail-closed (no snapshot rows at all).
+	if got := dstByName["bad-dnat"]; len(got) != 0 {
+		t.Fatalf("bad-dnat destinations = %+v, want NONE (all-malformed fails closed, not match-any)", got)
+	}
+}
+
 func srcCounterID(s []SourceNATRuleSnapshot) uint32 {
 	if len(s) == 0 {
 		return 0

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -1136,6 +1136,135 @@ fn dnat_source_scoped_mixed_valid_and_malformed_keeps_valid() {
 }
 
 #[test]
+fn dnat_multiple_destinations_each_fire() {
+    // #2395: a DNAT rule with `match destination-address [ A B C ]` is emitted
+    // by the Go builder as ONE snapshot per destination sharing the rule's
+    // pool/port/counter. The dataplane keys DNAT by exact dst_ip, so each
+    // destination must install its own table entry and translate. Before #2395
+    // only the FIRST destination got a snapshot, so traffic to B and C was
+    // forwarded untranslated. FAIL-ON-REVERT: with the collapse bug only the
+    // first lookup returns Some — the B and C lookups assert Some here.
+    let dests = ["203.0.113.20", "203.0.113.21", "203.0.113.22"];
+    let snaps: Vec<DestinationNATRuleSnapshot> = dests
+        .iter()
+        .map(|d| DestinationNATRuleSnapshot {
+            name: "multi-dnat".to_string(),
+            destination_address: d.to_string(),
+            destination_port: 443,
+            protocol: "tcp".to_string(),
+            pool_address: "10.0.0.5".to_string(),
+            pool_port: 8443,
+            ..DestinationNATRuleSnapshot::default()
+        })
+        .collect();
+    let table = DnatTable::from_snapshots(&snaps, &crate::nat::NatCounterStore::default());
+    for d in dests {
+        let got = table.lookup(
+            PROTO_TCP,
+            "198.51.100.1".parse().unwrap(),
+            d.parse().unwrap(),
+            443,
+            "",
+        );
+        assert_eq!(
+            got.and_then(|dec| dec.rewrite_dst),
+            Some("10.0.0.5".parse().unwrap()),
+            "destination {d} of a multi-dest DNAT must be translated (collapse bug drops B/C)"
+        );
+        assert_eq!(
+            got.unwrap().rewrite_dst_port,
+            Some(8443),
+            "destination {d} must rewrite the port to the shared pool port"
+        );
+    }
+}
+
+#[test]
+fn dnat_multiple_destinations_v6_each_fire() {
+    // #2395 IPv6 sibling: every v6 destination in the bracket list translates.
+    let dests = ["2001:db8:beef::10", "2001:db8:beef::11"];
+    let snaps: Vec<DestinationNATRuleSnapshot> = dests
+        .iter()
+        .map(|d| DestinationNATRuleSnapshot {
+            name: "multi-dnat-v6".to_string(),
+            destination_address: d.to_string(),
+            destination_port: 443,
+            protocol: "tcp".to_string(),
+            pool_address: "2001:db8:dead::5".to_string(),
+            pool_port: 0,
+            ..DestinationNATRuleSnapshot::default()
+        })
+        .collect();
+    let table = DnatTable::from_snapshots(&snaps, &crate::nat::NatCounterStore::default());
+    for d in dests {
+        let got = table.lookup(
+            PROTO_TCP,
+            "2001:db8:aaaa::1".parse().unwrap(),
+            d.parse().unwrap(),
+            443,
+            "",
+        );
+        assert_eq!(
+            got.and_then(|dec| dec.rewrite_dst),
+            Some("2001:db8:dead::5".parse().unwrap()),
+            "v6 destination {d} of a multi-dest DNAT must be translated"
+        );
+    }
+}
+
+#[test]
+fn dnat_multiple_destinations_compose_with_source_scope() {
+    // #2395 + #2394: a multi-destination DNAT that is ALSO source-scoped must
+    // fire for each destination ONLY when the source matches. Each per-dest
+    // snapshot carries the same source constraint (the Go builder shares
+    // sourceAddrs across the destination loop). FAIL-ON-REVERT for both: a
+    // dropped destination (collapse) loses B; a dropped source constraint
+    // (#2394) fires for the wrong source.
+    let dests = ["203.0.113.30", "203.0.113.31"];
+    let snaps: Vec<DestinationNATRuleSnapshot> = dests
+        .iter()
+        .map(|d| DestinationNATRuleSnapshot {
+            name: "multi-scoped".to_string(),
+            destination_address: d.to_string(),
+            destination_port: 80,
+            protocol: "tcp".to_string(),
+            pool_address: "10.0.0.5".to_string(),
+            pool_port: 8080,
+            source_addresses: vec!["198.51.100.0/24".to_string()],
+            ..DestinationNATRuleSnapshot::default()
+        })
+        .collect();
+    let table = DnatTable::from_snapshots(&snaps, &crate::nat::NatCounterStore::default());
+    for d in dests {
+        // In-scope source -> both destinations translate.
+        assert!(
+            table
+                .lookup(
+                    PROTO_TCP,
+                    "198.51.100.7".parse().unwrap(),
+                    d.parse().unwrap(),
+                    80,
+                    "",
+                )
+                .is_some(),
+            "in-scope source must DNAT destination {d}"
+        );
+        // Out-of-scope source -> no translation for any destination.
+        assert_eq!(
+            table.lookup(
+                PROTO_TCP,
+                "203.0.113.250".parse().unwrap(),
+                d.parse().unwrap(),
+                80,
+                "",
+            ),
+            None,
+            "out-of-scope source must NOT DNAT destination {d} (#2394 not regressed)"
+        );
+    }
+}
+
+#[test]
 fn dnat_port_aware_reverse() {
     // DNAT: rewrite dst to internal, rewrite dst_port from 80 to 8080
     let decision = NatDecision {


### PR DESCRIPTION
Closes #2395

## Collapse (HIGH)

A destination-NAT rule with a bracket list of destination addresses
(`match destination-address [ A B C ]`) collapsed to its **first**
destination. The compiler parsed the whole list into
`rule.Match.DestinationAddresses`, but `buildDestinationNATSnapshots`
iterated only the singular `rule.Match.DestinationAddress` (the mirrored
first element), so the dataplane installed a DNAT table entry only for A.
Traffic to B and C was forwarded **untranslated** — configured translation
silently not applied.

### Collapse point (current master, post-#2394)
- `pkg/config/compiler_nat.go` fills `rule.Match.DestinationAddresses`
  (full list) and mirrors only the first into the scalar
  `rule.Match.DestinationAddress`.
- `pkg/dataplane/userspace/nat.go` `buildDestinationNATSnapshots` gated on
  the scalar `DestinationAddress` and emitted `DestinationAddress: dstAddr`
  once per app-term/port — never iterating `DestinationAddresses`.

## Fix: per-destination snapshot entries (no wire change)

The DNAT table is keyed by exact destination IP (`DnatKey.dst_ip`,
`userspace-dp/src/nat/destination.rs`), so the natural shape is **one
snapshot entry per destination** sharing the rule's pool/port/counter. The
existing scalar `destination_address` field is reused — **no wire field
added/changed**, `protocol_wire_v1.json` unchanged (`git diff` confirms).

- `buildDestinationNATSnapshots` builds `destAddrs` from
  `rule.Match.DestinationAddresses` with a singular `DestinationAddress`
  fallback (mirrors the #2394 source-address idiom), then emits one
  `DestinationNATRuleSnapshot` per destination inside the existing
  app-term/port loop.
- **Robustness (mirrors #2394 fold):** each destination has its CIDR
  suffix stripped (DNAT matches exact host IPs) and is validated with
  `net.ParseIP`. A destination that is empty or not a bare host IP is
  skipped. If a rule has destinations but EVERY one is malformed, no
  snapshot row is emitted → the rule matches **NOTHING** (fail-closed),
  not match-any. The Rust `from_snapshots` already `continue`s on a
  destination it cannot `IpAddr::parse`, so the posture holds both sides.
- **Composition with #2394:** the per-destination loop is nested inside
  the source-constraint setup, so every per-destination snapshot carries
  the same `SourceAddresses`. A source-scoped multi-destination DNAT fires
  for each destination only when the source also matches — the #2394
  source enforcement is not regressed. The rewrite target (translated
  destination/port) is unchanged; only the MATCH set grows.

## Tests (fail-on-revert)

- Go `TestBuildDestinationNATSnapshotsMultiDestination`: three v4
  destinations → three entries; IPv6 bracket list; single destination
  (no regression); source-scoped multi-dest (both #2394 source AND all
  destinations carried); all-malformed destination set → **zero** rows
  (fail-closed). Verified to FAIL when the per-destination loop is
  collapsed to `destAddrs[:1]`.
- Rust `dnat_multiple_destinations_each_fire` / `_v6_each_fire` /
  `_compose_with_source_scope`: every destination translates (dst + port
  rewrite); v6; source-scoped multi-dest fires per destination only for
  the in-scope source (out-of-scope source → no match).

## Validation
- `go build ./...` + `go test ./pkg/config ./pkg/dataplane/...` green.
- `cargo build --release` + `cargo test --release` (nat suite 394 + new
  DNAT tests) green.
- New Go and Rust tests run 5x clean.
- No wire field changed; `protocol_wire_v1.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi