### PR TITLE
#2396: fix DNAT silent drops — non-TCP/UDP, IP-only ICMP, all-invalid-address

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11240,3 +11240,31 @@ top.
   - **File(s)**: pkg/dataplane/userspace/nat.go,
     pkg/dataplane/userspace/nat_per_uplink_test.go,
     userspace-dp/src/nat/tests.rs, docs/userspace-dnat-plan.md, _Log.md
+
+## 2026-06-23 — #2396 DNAT silent drops: non-TCP/UDP, IP-only ICMP, all-invalid-address
+
+- **Timestamp**: 2026-06-23 PDT
+- **Action**: Fixed three DNAT silent-drop fail patterns (HIGH). (a) Rust DNAT
+    builder recognized only tcp/udp/"" and SILENTLY DROPPED every other
+    protocol (`_ => continue`) — a `protocol gre`/`icmp6` or `application
+    junos-icmp-all` DNAT committed but never reached the dataplane. Now resolves
+    the protocol token through a new `ip_proto::proto_number` (mirrors the Go
+    SSOT `appid.ProtocolNumber`) and installs a protocol-scoped entry. (b) An
+    IP-only DNAT (`""` + port 0) expanded to TCP+UDP only, so it did NOT cover
+    ICMP despite the closeout-doc claim. Now keyed under a protocol WILDCARD
+    (`PROTO_ANY = 0`) with a wildcard fallback in `lookup_with_counter` so it
+    covers ALL L4 incl. ICMP/ICMPv6/GRE; a concrete (protocol,port) rule still
+    wins (wildcard is last-resort). (c) An all-invalid destination-address DNAT
+    rule was fail-closed at runtime (#2395) but gave the operator NO feedback;
+    added `validateDestinationNATAddressesStrict` (strict commit / lenient load,
+    #1960 no-brick) that hard-rejects a rule whose every destination-address is
+    unparseable. No wire field added/renamed (the `protocol` string already
+    carried the right value from Go; Rust now honors it) — wire fixture
+    unchanged. Composes with #2394 (source-scope) + #2395 (multi-dest).
+- **File(s)**: userspace-dp/src/ip_proto.rs,
+    userspace-dp/src/nat/destination.rs, userspace-dp/src/nat/tests.rs,
+    pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
+    pkg/config/compiler_dnat_address_test.go,
+    pkg/dataplane/userspace/protocol.go,
+    pkg/dataplane/userspace/nat_per_uplink_test.go,
+    docs/userspace-dnat-plan.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -11268,3 +11268,35 @@ top.
     pkg/dataplane/userspace/protocol.go,
     pkg/dataplane/userspace/nat_per_uplink_test.go,
     docs/userspace-dnat-plan.md, _Log.md
+
+## 2026-06-23 — #2396 PR #2418 Copilot fold: proto normalize, PROTO_ANY=256 (no HOPOPT collision), unresolvable-proto commit gate
+
+- **Timestamp**: 2026-06-23 PDT
+- **Action**: Folded three Copilot findings on PR #2418 — all VERIFIED
+    live-reachable (DNAT `match protocol` and `application protocol` reach the
+    wire VERBATIM via nodeVal; neither is validated before the gate).
+    (1) NORMALIZATION: `ip_proto::proto_number` now trims + lower-cases before
+    matching so `GRE`/` icmp ` resolve like `gre`/`icmp` (was: mixed-case token
+    resolved in Go, dropped in Rust → silent miss). (2) PROTO_ANY COLLISION:
+    the IP-only wildcard sentinel was protocol 0, which collides with HOPOPT (a
+    real protocol in the SSOT) — a `protocol 0` DNAT would have broadened to
+    match-all. Changed `DnatKey.protocol` to u16 and `PROTO_ANY = 256` (outside
+    0-255), so HOPOPT is a normal exact match and only `""`+port-0 uses the
+    wildcard. lookup widens the inbound u8 protocol to u16. Fixed the
+    tests.rs assertion (proto_number("0") => Some(0u8)/HOPOPT, NOT PROTO_ANY)
+    and the protocol.go doc. (3) UNRESOLVABLE-PROTOCOL SILENT DROP + false
+    comment: added `validateDestinationNATProtocolStrict` (strict-on-commit,
+    lenient-warn-on-load, shares lenientDestNATAddresses) that hard-rejects a
+    DNAT `match protocol` token `dnatProtocolResolvable` cannot resolve;
+    `dnatProtocolResolvable` is the Go mirror of `proto_number` (bare names +
+    0-255 number, normalized, NO junos-* aliases since the raw DNAT path does
+    not pre-resolve them) with a `DNATProtocolResolvable` test seam. Corrected
+    the destination.rs comment (the gate is on the commit path; the Rust
+    `continue` is the tolerant-load backstop). No wire change — the key
+    re-representation is internal to Rust; the wire `protocol` STRING is
+    unchanged (protocol_wire_v1.json regen = no-op, confirmed).
+- **File(s)**: userspace-dp/src/ip_proto.rs,
+    userspace-dp/src/nat/destination.rs, userspace-dp/src/nat/tests.rs,
+    pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
+    pkg/config/compiler_dnat_protocol_test.go,
+    pkg/dataplane/userspace/protocol.go, docs/userspace-dnat-plan.md, _Log.md

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -289,16 +289,28 @@ Initial implementation: use the existing per-binding `dnat_packets` counter (alr
    port-matching DNAT doesn't apply to it. An IP-only DNAT (no protocol, no
    port) now genuinely covers ALL L4 protocols including ICMP/ICMPv6/GRE: the
    builder emits it with an empty `protocol` and zero port, and the Rust table
-   keys it under the protocol WILDCARD (`PROTO_ANY = 0`), with
+   keys it under a protocol WILDCARD sentinel, with
    `DnatTable::lookup_with_counter` falling back to that wildcard after the
    concrete-protocol and wildcard-port lookups miss. A DNAT rule that names a
    concrete non-TCP/UDP protocol (`protocol gre`, `application junos-icmp-all`,
    ...) resolves through `ip_proto::proto_number` (mirrors the Go SSOT
-   `appid.ProtocolNumber`) and installs a protocol-scoped entry. Before #2396
-   the Rust builder recognized only `tcp`/`udp`/`""` and SILENTLY DROPPED
-   everything else (`_ => continue`), and `""`+port-0 expanded to TCP+UDP only
-   — so a GRE/ICMP DNAT committed but never reached the dataplane, and an
-   IP-only DNAT did NOT cover ICMP, contradicting the original claim here.
+   `appid.ProtocolNumber`) and installs a protocol-scoped entry. The token is
+   normalized (trim + lower-case) on both sides, and an unresolvable
+   `match protocol` token is hard-rejected at commit by
+   `validateDestinationNATProtocolStrict` (lenient-warn on tolerant load)
+   rather than silently dropped.
+
+   The wildcard sentinel is `PROTO_ANY = 256` — `DnatKey.protocol` is a `u16`
+   so the sentinel sits OUTSIDE the 0-255 IANA range and is DISTINCT from every
+   real protocol, including protocol `0` (HOPOPT). The first cut used
+   `PROTO_ANY = 0`, which COLLIDED with HOPOPT: a `protocol 0` DNAT would have
+   keyed under the wildcard and broadened to match every protocol. With the u16
+   key, `protocol 0` is a normal exact match and only `""` (no protocol, no
+   port) uses the wildcard. Before #2396 the Rust builder recognized only
+   `tcp`/`udp`/`""` and SILENTLY DROPPED everything else (`_ => continue`), and
+   `""`+port-0 expanded to TCP+UDP only — so a GRE/ICMP DNAT committed but never
+   reached the dataplane, and an IP-only DNAT did NOT cover ICMP, contradicting
+   the original claim here.
 
 3. **Session key stability**: Forward session key uses the ORIGINAL 5-tuple (pre-DNAT). The translation is carried in `NatDecision`. Matches static NAT pattern.
 

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -285,7 +285,20 @@ Initial implementation: use the existing per-binding `dnat_packets` counter (alr
 
 1. **SNAT overwrite bug (existing)**: Current code at `afxdp.rs:2449` overwrites any pre-routing DNAT decision when SNAT matches. The `merge()` fix resolves this for both static NAT and new DNAT.
 
-2. **ICMP DNAT**: ICMP has no ports. Port-matching DNAT doesn't apply to ICMP. IP-only DNAT (port=0) works for ICMP via wildcard lookup.
+2. **ICMP / non-TCP-UDP DNAT** (corrected #2396): ICMP has no ports, so
+   port-matching DNAT doesn't apply to it. An IP-only DNAT (no protocol, no
+   port) now genuinely covers ALL L4 protocols including ICMP/ICMPv6/GRE: the
+   builder emits it with an empty `protocol` and zero port, and the Rust table
+   keys it under the protocol WILDCARD (`PROTO_ANY = 0`), with
+   `DnatTable::lookup_with_counter` falling back to that wildcard after the
+   concrete-protocol and wildcard-port lookups miss. A DNAT rule that names a
+   concrete non-TCP/UDP protocol (`protocol gre`, `application junos-icmp-all`,
+   ...) resolves through `ip_proto::proto_number` (mirrors the Go SSOT
+   `appid.ProtocolNumber`) and installs a protocol-scoped entry. Before #2396
+   the Rust builder recognized only `tcp`/`udp`/`""` and SILENTLY DROPPED
+   everything else (`_ => continue`), and `""`+port-0 expanded to TCP+UDP only
+   — so a GRE/ICMP DNAT committed but never reached the dataplane, and an
+   IP-only DNAT did NOT cover ICMP, contradicting the original claim here.
 
 3. **Session key stability**: Forward session key uses the ORIGINAL 5-tuple (pre-DNAT). The translation is carried in `NatDecision`. Matches static NAT pattern.
 

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -394,6 +394,23 @@ type compileOpts struct {
 	// the dataplane drops the unindexed rule independently, so a leniently-
 	// loaded bad config is inert. Same doctrine as lenientPolicyMatchAddress.
 	lenientPolicyZoneRefs bool
+	// lenientDestNATAddresses (#2396) downgrades the destination-NAT
+	// destination-address gate (validateDestinationNATAddressesStrict) from a
+	// hard compile error to a cfg.Warnings entry. The strict commit /
+	// commit-check path hard-rejects a DNAT rule whose `match
+	// destination-address` resolves to NO parseable host IP at all — every
+	// configured destination is malformed/empty. The Go snapshot builder skips
+	// each unparseable destination (#2395) and the Rust DNAT table `continue`s
+	// on a destination it cannot parse, so such a rule emits NO table entry and
+	// silently translates NOTHING — an operator who fat-fingered the only
+	// destination gets a committed-but-inert rule with no feedback (the #2396
+	// (c) silent-drop). Hard-rejecting it at commit makes the mistake visible.
+	// The tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config carrying a bad destination still
+	// BOOTS (#1960 no-brick) — the dataplane drops the rule independently, so a
+	// leniently-loaded bad config is inert. Same doctrine as
+	// lenientPolicyZoneRefs / lenientNATHostMask.
+	lenientDestNATAddresses bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -438,6 +455,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientDHCPStaticBindings:          true,
 		lenientWireguardPeers:              true,
 		lenientPolicyZoneRefs:              true,
+		lenientDestNATAddresses:            true,
 	})
 }
 
@@ -533,6 +551,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientDHCPStaticBindings:          true,
 		lenientWireguardPeers:              true,
 		lenientPolicyZoneRefs:              true,
+		lenientDestNATAddresses:            true,
 	})
 }
 
@@ -898,6 +917,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientPolicyZoneRefs {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("policy zone reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2396(c) destination-NAT destination-address gate. Strict on commit /
+	// commit-check (hard-reject a DNAT rule whose `match destination-address`
+	// resolves to NO parseable host IP — every configured destination is
+	// empty/malformed); lenient on load / peer-sync (downgrade to a warning so
+	// an already-persisted or peer-synced config still boots — #1960 no-brick;
+	// the snapshot builder skips each bad destination and the Rust DNAT table
+	// drops the rule on its own, so a leniently-loaded bad config is inert).
+	// Without this gate such a rule committed cleanly and then silently
+	// translated nothing — the operator had no feedback that the only
+	// destination address was a typo. Runs AFTER the policy gates so a
+	// structural/policy error still wins the first-error slot.
+	if err := validateDestinationNATAddressesStrict(cfg); err != nil {
+		if opts.lenientDestNATAddresses {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("destination-nat address (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -942,6 +942,27 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #2396(a)/(3) destination-NAT match-protocol gate. The DNAT `match
+	// protocol <token>` reaches the wire VERBATIM (nodeVal -> rule.Match.Protocol
+	// -> snapshot, with no validation), and the Rust DNAT table drops a token
+	// ip_proto::proto_number cannot resolve (the dataplane backstop). So an
+	// unresolvable `match protocol` (a typo, or a junos-* alias the DNAT path
+	// does not pre-resolve) committed cleanly and then silently translated
+	// nothing — the #2396 silent-drop class. Strict on commit / commit-check
+	// (hard-reject); lenient on load / peer-sync (downgrade to a warning so a
+	// config persisted before this gate existed still boots — #1960 no-brick;
+	// the dataplane drops the inert rule on its own). Shares the
+	// lenientDestNATAddresses flag (same #2396 DNAT silent-drop doctrine). Runs
+	// after the address gate so a malformed-destination error wins first.
+	if err := validateDestinationNATProtocolStrict(cfg); err != nil {
+		if opts.lenientDestNATAddresses {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("destination-nat protocol (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
 	// #2243 DHCP-server static (fixed/reserved) host bindings. Strict on
 	// commit / commit-check (hard-reject a fixed-address that is malformed,
 	// family-mismatched, outside the enclosing pool subnet, or duplicates

--- a/pkg/config/compiler_dnat_address_test.go
+++ b/pkg/config/compiler_dnat_address_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2396(c): a destination-NAT rule whose `match destination-address` resolves
+// to NO parseable host IP (every configured token is malformed) compiles and
+// commits, but the snapshot builder skips each bad destination and the Rust
+// DNAT table drops the rule — so it silently translates NOTHING with no
+// operator feedback. validateDestinationNATAddressesStrict hard-rejects it at
+// commit / commit-check, and the tolerant load / peer-sync path downgrades the
+// error to a warning (#1960 no-brick).
+//
+// All tests use the production ParseSetCommand + SetPath path (buildTree),
+// never NewParser (the flat-set gotcha in CLAUDE.md).
+
+// dnatSet builds a minimal DNAT rule-set with one rule matching the given
+// destination-address (raw token) and a valid pool. The from-zone is defined
+// to avoid unrelated undefined-zone warnings.
+func dnatSet(matchDest string) []string {
+	return []string{
+		"set security zones security-zone untrust",
+		"set security nat destination pool dp address 10.0.0.5",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address " + matchDest,
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool dp",
+	}
+}
+
+func TestDNATValidDestinationCompiles(t *testing.T) {
+	tree := buildTree(t, dnatSet("203.0.113.10"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("a DNAT rule with a valid destination must compile, got: %v", err)
+	}
+}
+
+func TestDNATValidDestinationCIDRCompiles(t *testing.T) {
+	// A /32 host CIDR is a valid destination (the builder strips the mask).
+	tree := buildTree(t, dnatSet("203.0.113.10/32"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("a DNAT rule with a /32 destination must compile, got: %v", err)
+	}
+}
+
+func TestDNATAllInvalidDestinationRejected(t *testing.T) {
+	// The only destination is a typo (not an IP) — reject at commit so the
+	// operator sees the rule would never translate anything.
+	tree := buildTree(t, dnatSet("not-an-ip"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a DNAT rule whose only destination-address is malformed must be rejected at commit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "destination-nat") ||
+		!strings.Contains(msg, "r1") ||
+		!strings.Contains(msg, "not-an-ip") {
+		t.Fatalf("error must name the rule-set/rule + the malformed token, got: %v", err)
+	}
+}
+
+func TestDNATPartialValidDestinationAccepted(t *testing.T) {
+	// One malformed + one valid destination in a bracket list: the valid one
+	// still installs (the builder emits an entry for it and skips the typo),
+	// so this is NOT a total silent no-op. The gate must NOT reject it.
+	//
+	// Constructed at the struct level (not via flat-set syntax) because the
+	// flat-set parser collapses a `[ a b ]` destination-address list to its
+	// first token; the builder/gate operate on DestinationAddresses, which the
+	// hierarchical parser and the dataplane snapshot path populate fully.
+	cfg := &Config{}
+	cfg.Security.NAT.Destination = &DestinationNATConfig{
+		Pools: map[string]*NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+		RuleSets: []*NATRuleSet{
+			{Name: "rs1", FromZone: "untrust", Rules: []*NATRule{
+				{
+					Name: "r1",
+					Match: NATMatch{
+						DestinationAddresses: []string{"not-an-ip", "203.0.113.10"},
+						DestinationAddress:   "not-an-ip",
+					},
+					Then: NATThen{Type: NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+	}
+	if err := validateDestinationNATAddressesStrict(cfg); err != nil {
+		t.Fatalf("a DNAT rule with at least one valid destination must pass the gate, got: %v", err)
+	}
+}
+
+func TestDNATAllInvalidDestinationLenientWarns(t *testing.T) {
+	// Tolerant load / peer-sync must NOT brick on a config that committed
+	// before this gate existed — downgrade to a warning instead.
+	cfg, err := CompileConfigLenient(buildTree(t, dnatSet("not-an-ip")))
+	if err != nil {
+		t.Fatalf("lenient load must NOT fail (brick-on-restart), got: %v", err)
+	}
+	if !hasWarningContaining(cfg.Warnings, "destination-nat address") {
+		t.Fatalf("lenient load must emit a destination-nat warning, warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_dnat_protocol_test.go
+++ b/pkg/config/compiler_dnat_protocol_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2396 (a)/(3) + Copilot fold: a DNAT `match protocol <token>` reaches the
+// dataplane verbatim (no validation before this gate), and the Rust DNAT table
+// drops a token ip_proto::proto_number cannot resolve — a silent translation
+// loss. validateDestinationNATProtocolStrict hard-rejects an unresolvable token
+// at commit; the resolver normalizes (trim + lower-case) to match the Rust SSOT.
+//
+// All tests use the production ParseSetCommand + SetPath path (buildTree).
+
+// dnatProtoSet builds a minimal DNAT rule-set whose rule matches the given
+// protocol token (plus a valid destination + pool so only protocol is at test).
+func dnatProtoSet(protoToken string) []string {
+	return []string{
+		"set security zones security-zone untrust",
+		"set security nat destination pool dp address 10.0.0.5",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address 203.0.113.10",
+		"set security nat destination rule-set rs1 rule r1 match protocol " + protoToken,
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool dp",
+	}
+}
+
+func TestDNATProtocolKnownNamesCompile(t *testing.T) {
+	for _, tok := range []string{"tcp", "udp", "icmp", "icmp6", "icmpv6", "gre", "47", "0"} {
+		tree := buildTree(t, dnatProtoSet(tok))
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("match protocol %q must compile, got: %v", tok, err)
+		}
+	}
+}
+
+func TestDNATProtocolMixedCaseAndWhitespaceCompile(t *testing.T) {
+	// Normalization: a mixed-case or padded token resolves the same as the
+	// canonical lower-case token (matches Rust proto_number). The parser may
+	// trim surrounding whitespace, so the load-bearing case here is mixed-case.
+	for _, tok := range []string{"GRE", "Icmp", "TCP", "ICMP6"} {
+		tree := buildTree(t, dnatProtoSet(tok))
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("match protocol %q must compile after normalization, got: %v", tok, err)
+		}
+	}
+}
+
+func TestDNATProtocolUnresolvableRejected(t *testing.T) {
+	// A typo must be rejected at commit, not silently dropped at the dataplane.
+	tree := buildTree(t, dnatProtoSet("grre"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("an unresolvable DNAT match protocol must be rejected at commit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "destination-nat") ||
+		!strings.Contains(msg, "r1") ||
+		!strings.Contains(msg, "grre") {
+		t.Fatalf("error must name the rule-set/rule + the unresolvable token, got: %v", err)
+	}
+}
+
+func TestDNATProtocolUnresolvableLenientWarns(t *testing.T) {
+	// Tolerant load / peer-sync must NOT brick — downgrade to a warning.
+	cfg, err := CompileConfigLenient(buildTree(t, dnatProtoSet("grre")))
+	if err != nil {
+		t.Fatalf("lenient load must NOT fail (brick-on-restart), got: %v", err)
+	}
+	if !hasWarningContaining(cfg.Warnings, "destination-nat protocol") {
+		t.Fatalf("lenient load must emit a destination-nat protocol warning, warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestDNATProtocolResolvableMatchesRustSSOT pins the Go mirror's acceptance to
+// the documented Rust ip_proto::proto_number set: bare protocol names + a
+// 0-255 number (normalized), and NOT junos-* aliases (the DNAT path does not
+// pre-resolve them, so accepting one here would re-introduce the silent drop).
+// Empty ("" = any) is the IP-only wildcard and is resolvable.
+func TestDNATProtocolResolvableMatchesRustSSOT(t *testing.T) {
+	accept := []string{
+		"", "tcp", "udp", "icmp", "icmp6", "icmpv6", "gre", "ospf", "ipip",
+		"egp", "igmp", "pim", "ah", "esp", "sctp", "vrrp",
+		"0", "47", "255",
+		// Normalization.
+		"GRE", " icmp ", "Tcp",
+	}
+	for _, tok := range accept {
+		if !DNATProtocolResolvable(tok) {
+			t.Errorf("DNATProtocolResolvable(%q) = false, want true", tok)
+		}
+	}
+	reject := []string{
+		"grre", "bogus", "256", "-1",
+		// junos-* aliases are NOT resolved on the raw DNAT match-protocol path
+		// (proto_number rejects them), so the gate must reject them too.
+		"junos-gre", "junos-icmp-all", "junos-tcp-any",
+	}
+	for _, tok := range reject {
+		if DNATProtocolResolvable(tok) {
+			t.Errorf("DNATProtocolResolvable(%q) = true, want false", tok)
+		}
+	}
+}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -1593,3 +1593,79 @@ func validateDHCPStaticBindingsStrict(cfg *Config) error {
 	}
 	return check(cfg.System.DHCPServer.DHCPv6LocalServer, "dhcpv6-local-server", true)
 }
+
+// validateDestinationNATAddressesStrict (#2396(c)) hard-rejects a
+// destination-NAT rule whose `match destination-address` resolves to NO
+// parseable host IP — i.e. the rule HAS a destination match (singular or
+// bracket-list) but EVERY configured token fails to parse as a bare IP after
+// any CIDR mask is stripped.
+//
+// The DNAT snapshot builder (buildDestinationNATSnapshots, #2395) strips the
+// CIDR suffix from each destination and SKIPS any token where
+// `net.ParseIP(stripped) == nil`; the Rust DNAT table (DnatTable::from_snapshots)
+// independently `continue`s on a destination it cannot parse. So a rule whose
+// destinations are all malformed emits NO table entry and silently translates
+// NOTHING — it compiled and committed, but is inert, with no operator feedback.
+// This is the #2396(c) silent-drop. Surfacing it at commit / commit-check turns
+// a fat-fingered "the only destination is a typo" into a visible error.
+//
+// Acceptance MUST match the builder's exactly: a token is "good" iff, after
+// stripping a trailing `/mask`, the remainder parses with net.ParseIP. A rule
+// with NO destination match at all is out of scope (it never reaches the
+// builder's per-destination loop). A rule with at least one good destination is
+// fine even if others are malformed (the builder emits entries for the good
+// ones and skips the rest — partial, but not a silent total no-op).
+//
+// Reported deterministically: rule-sets are walked in sorted name order and
+// rules in their configured order, so the first-reported offender is stable.
+// The caller downgrades the error to a warning on the tolerant load / peer-sync
+// path (#1960 no-brick): a config persisted before this gate existed still
+// boots, and the dataplane drops the inert rule on its own.
+func validateDestinationNATAddressesStrict(cfg *Config) error {
+	if cfg == nil || cfg.Security.NAT.Destination == nil {
+		return nil
+	}
+	rulesets := append([]*NATRuleSet(nil), cfg.Security.NAT.Destination.RuleSets...)
+	sort.SliceStable(rulesets, func(i, j int) bool {
+		if rulesets[i] == nil || rulesets[j] == nil {
+			return rulesets[i] != nil
+		}
+		return rulesets[i].Name < rulesets[j].Name
+	})
+	for _, rs := range rulesets {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			// Mirror the builder's destination-address gathering: prefer the
+			// bracket-list form, fall back to the singular match value.
+			destAddrs := append([]string(nil), rule.Match.DestinationAddresses...)
+			if len(destAddrs) == 0 && rule.Match.DestinationAddress != "" {
+				destAddrs = append(destAddrs, rule.Match.DestinationAddress)
+			}
+			if len(destAddrs) == 0 {
+				// No destination match at all — out of scope.
+				continue
+			}
+			anyGood := false
+			for _, raw := range destAddrs {
+				ipPart := natCIDRIPPart(raw)
+				if ipPart != "" && net.ParseIP(ipPart) != nil {
+					anyGood = true
+					break
+				}
+			}
+			if !anyGood {
+				return fmt.Errorf(
+					"destination-nat rule-set %q rule %q: no valid destination-address "+
+						"(every match destination-address is malformed: %s); "+
+						"the rule would commit but never translate any traffic",
+					rs.Name, rule.Name, strings.Join(destAddrs, ", "))
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -1669,3 +1669,92 @@ func validateDestinationNATAddressesStrict(cfg *Config) error {
 	}
 	return nil
 }
+
+// dnatProtocolResolvable reports whether a DNAT `match protocol` token is one
+// the userspace dataplane can resolve. It is the Go mirror of the Rust
+// ip_proto::proto_number SSOT (userspace-dp/src/ip_proto.rs): the DNAT path
+// emits the token VERBATIM (no junos-* pre-resolution), and proto_number
+// accepts ONLY bare protocol names and a 0-255 number — NOT junos-* aliases
+// (those are resolved by the application path, never the raw match-protocol
+// path). Normalization (trim + lower-case) matches proto_number exactly, so
+// the commit gate and the dataplane agree on the accepted set.
+//
+// This is deliberately a TIGHTER set than filterProtocolResolvable /
+// appid.ProtocolNumber (which add junos-* aliases for the filter/application
+// paths): a junos-* token in a DNAT match-protocol would resolve in those
+// supersets but be DROPPED by proto_number, so accepting it here would
+// re-introduce the #2396 silent drop. Empty ("" = any protocol) is the IP-only
+// wildcard and is always resolvable.
+func dnatProtocolResolvable(token string) bool {
+	switch strings.ToLower(strings.TrimSpace(token)) {
+	case "",
+		"tcp", "udp",
+		"icmp", "icmp6", "icmpv6",
+		"gre", "ospf", "ipip",
+		"egp", "igmp", "pim",
+		"ah", "esp", "sctp", "vrrp":
+		return true
+	default:
+		if n, err := strconv.Atoi(strings.TrimSpace(token)); err == nil && n >= 0 && n < 256 {
+			return true
+		}
+		return false
+	}
+}
+
+// DNATProtocolResolvable exposes dnatProtocolResolvable for a cross-package
+// drift-guard test that asserts this acceptance set agrees with the Rust
+// proto_number SSOT (the two INLINE copies cannot drift silently). TEST seam,
+// not a runtime coupling.
+func DNATProtocolResolvable(token string) bool {
+	return dnatProtocolResolvable(token)
+}
+
+// validateDestinationNATProtocolStrict (#2396 (a)/(3)) hard-rejects a DNAT rule
+// whose `match protocol <token>` is not resolvable by the dataplane
+// (dnatProtocolResolvable / proto_number). The token reaches the snapshot
+// verbatim and the Rust table drops an unresolvable one with no apply failure,
+// so an operator typo (`match protocol grre`) or a junos-* alias the DNAT path
+// does not pre-resolve committed cleanly and silently translated nothing.
+//
+// Only the raw `match protocol` token is gated here. A protocol that comes from
+// a resolved `match application` is validated separately by
+// validateApplicationSpecsStrict (the application's own `protocol` leaf), so it
+// is not re-checked. Rule-sets are walked in sorted name order and rules in
+// configured order for a deterministic first-reported offender. The caller
+// downgrades the error to a warning on the tolerant load / peer-sync path
+// (#1960 no-brick).
+func validateDestinationNATProtocolStrict(cfg *Config) error {
+	if cfg == nil || cfg.Security.NAT.Destination == nil {
+		return nil
+	}
+	rulesets := append([]*NATRuleSet(nil), cfg.Security.NAT.Destination.RuleSets...)
+	sort.SliceStable(rulesets, func(i, j int) bool {
+		if rulesets[i] == nil || rulesets[j] == nil {
+			return rulesets[i] != nil
+		}
+		return rulesets[i].Name < rulesets[j].Name
+	})
+	for _, rs := range rulesets {
+		if rs == nil {
+			continue
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			// The raw match-protocol token is only emitted when the rule has no
+			// application override (the builder prefers app terms). But gating it
+			// regardless is correct: an unresolvable token can never be a valid
+			// DNAT protocol, application override or not.
+			if !dnatProtocolResolvable(rule.Match.Protocol) {
+				return fmt.Errorf(
+					"destination-nat rule-set %q rule %q: match protocol %q is not a "+
+						"resolvable protocol (known name or 0-255 number); the rule would "+
+						"commit but never translate any traffic",
+					rs.Name, rule.Name, rule.Match.Protocol)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/dataplane/userspace/nat_per_uplink_test.go
+++ b/pkg/dataplane/userspace/nat_per_uplink_test.go
@@ -335,3 +335,64 @@ func srcCounterID(s []SourceNATRuleSnapshot) uint32 {
 	}
 	return s[0].CounterID
 }
+
+// TestBuildDestinationNATSnapshotsNonTCPUDP is the Go half of #2396(a)/(b):
+// the snapshot builder must carry a non-TCP/UDP protocol (GRE/ICMP) verbatim
+// and emit an IP-only rule with an empty protocol + zero port (so the Rust
+// table keys it under the protocol wildcard). The Rust side then honors these
+// rather than dropping them (see nat::tests::dnat_protocol_gre_translates /
+// dnat_ip_only_covers_all_protocols_incl_icmp). This test FAILS if the builder
+// rewrites/drops the protocol or the IP-only shape regresses.
+func TestBuildDestinationNATSnapshotsNonTCPUDP(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{
+			"dp": {Name: "dp", Address: "10.0.0.9"},
+		},
+		RuleSets: []*config.NATRuleSet{
+			{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name: "gre-dnat",
+					Match: config.NATMatch{
+						DestinationAddress: "203.0.113.10",
+						Protocol:           "gre",
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+				{
+					Name: "icmp-dnat",
+					Match: config.NATMatch{
+						DestinationAddress: "203.0.113.11",
+						Protocol:           "icmp",
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+				{
+					// IP-only: no protocol, no application, no port.
+					Name: "ip-only-dnat",
+					Match: config.NATMatch{
+						DestinationAddress: "203.0.113.12",
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+	}
+
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	byName := map[string]DestinationNATRuleSnapshot{}
+	for _, s := range snaps {
+		byName[s.Name] = s
+	}
+
+	if got, ok := byName["gre-dnat"]; !ok || got.Protocol != "gre" {
+		t.Fatalf("gre-dnat protocol = %q (present=%v), want gre carried verbatim", got.Protocol, ok)
+	}
+	if got, ok := byName["icmp-dnat"]; !ok || got.Protocol != "icmp" {
+		t.Fatalf("icmp-dnat protocol = %q (present=%v), want icmp carried verbatim", got.Protocol, ok)
+	}
+	if got, ok := byName["ip-only-dnat"]; !ok || got.Protocol != "" || got.DestinationPort != 0 {
+		t.Fatalf("ip-only-dnat = {proto=%q port=%d present=%v}, want {proto=\"\" port=0} (wildcard shape)",
+			got.Protocol, got.DestinationPort, ok)
+	}
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -426,9 +426,15 @@ type DestinationNATRuleSnapshot struct {
 	// bare 0-255 number, or "" (any). #2396: the Rust DNAT table resolves the
 	// token through the shared SSOT (ip_proto::proto_number, which mirrors
 	// appid.ProtocolNumber) so a non-TCP/UDP DNAT (e.g. GRE/ICMP) is honored
-	// rather than silently dropped; "" with no destination port is an IP-only
-	// / any-protocol rule keyed under the protocol wildcard (PROTO_ANY) so it
-	// covers ALL L4 protocols including ICMP/ICMPv6/GRE.
+	// rather than silently dropped. A concrete number maps to its exact IANA
+	// value — INCLUDING "0" (HOPOPT), which is a normal exact match, NOT the
+	// wildcard. Only "" with no destination port is the IP-only / any-protocol
+	// rule; the Rust table keys it under a wildcard sentinel (PROTO_ANY = 256,
+	// outside the 0-255 protocol range, so it never aliases protocol 0) so it
+	// covers ALL L4 protocols including ICMP/ICMPv6/GRE. The token is
+	// normalized (trim + lower-case) on both sides before resolution, and an
+	// unresolvable token is rejected at commit by
+	// validateDestinationNATProtocolStrict.
 	Protocol           string   `json:"protocol,omitempty"`
 	PoolAddress        string   `json:"pool_address"`
 	PoolPort           uint16   `json:"pool_port,omitempty"`

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -421,7 +421,15 @@ type DestinationNATRuleSnapshot struct {
 	SourceAddresses    []string `json:"source_addresses,omitempty"`
 	DestinationAddress string   `json:"destination_address"`
 	DestinationPort    uint16   `json:"destination_port,omitempty"`
-	Protocol           string   `json:"protocol,omitempty"` // "tcp", "udp", or ""
+	// Protocol is the Junos config protocol token the DNAT rule matches:
+	// "tcp", "udp", "icmp", "icmp6"/"icmpv6", "gre", another known name, a
+	// bare 0-255 number, or "" (any). #2396: the Rust DNAT table resolves the
+	// token through the shared SSOT (ip_proto::proto_number, which mirrors
+	// appid.ProtocolNumber) so a non-TCP/UDP DNAT (e.g. GRE/ICMP) is honored
+	// rather than silently dropped; "" with no destination port is an IP-only
+	// / any-protocol rule keyed under the protocol wildcard (PROTO_ANY) so it
+	// covers ALL L4 protocols including ICMP/ICMPv6/GRE.
+	Protocol           string   `json:"protocol,omitempty"`
 	PoolAddress        string   `json:"pool_address"`
 	PoolPort           uint16   `json:"pool_port,omitempty"`
 	// CounterID is the compiler-assigned per-rule translation hit counter ID

--- a/userspace-dp/src/ip_proto.rs
+++ b/userspace-dp/src/ip_proto.rs
@@ -21,3 +21,39 @@ pub(crate) const PROTO_OSPF: u8 = 89;
 pub(crate) const PROTO_PIM: u8 = 103;
 pub(crate) const PROTO_VRRP: u8 = 112;
 pub(crate) const PROTO_SCTP: u8 = 132;
+
+/// Resolve a config-level protocol token to its IANA number.
+///
+/// #2396: the DNAT snapshot carries `protocol` as the Junos config string
+/// (`"tcp"`, `"udp"`, `"icmp"`, `"icmp6"`/`"icmpv6"`, `"gre"`, ..., or a bare
+/// 0-255 number). The Rust DNAT table used to recognize only `"tcp"`/`"udp"`
+/// and silently DROP everything else (`_ => continue`), so a GRE/ICMP DNAT
+/// rule compiled, committed, and never reached the dataplane. This resolver
+/// mirrors the Go SSOT `appid.ProtocolNumber` (the table the commit-time gate
+/// validates against) so the two views agree on the accepted set.
+///
+/// `junos-*` aliases are NOT handled here: the Go compiler resolves an
+/// `application junos-foo` to its numeric protocol before building the
+/// snapshot, so the wire `protocol` is already a bare name or number. Returns
+/// `None` for an unrecognized token (the DNAT builder treats that as "drop the
+/// entry" — but the Go side never emits one, since the commit gate rejects an
+/// unresolvable protocol first).
+pub(crate) fn proto_number(name: &str) -> Option<u8> {
+    match name {
+        "tcp" => Some(PROTO_TCP),
+        "udp" => Some(PROTO_UDP),
+        "icmp" => Some(PROTO_ICMP),
+        "icmp6" | "icmpv6" => Some(PROTO_ICMPV6),
+        "gre" => Some(PROTO_GRE),
+        "ospf" => Some(PROTO_OSPF),
+        "ipip" => Some(PROTO_IPIP),
+        "egp" => Some(PROTO_EGP),
+        "igmp" => Some(PROTO_IGMP),
+        "pim" => Some(PROTO_PIM),
+        "ah" => Some(PROTO_AH),
+        "esp" => Some(PROTO_ESP),
+        "sctp" => Some(PROTO_SCTP),
+        "vrrp" => Some(PROTO_VRRP),
+        other => other.parse::<u8>().ok(),
+    }
+}

--- a/userspace-dp/src/ip_proto.rs
+++ b/userspace-dp/src/ip_proto.rs
@@ -35,11 +35,20 @@ pub(crate) const PROTO_SCTP: u8 = 132;
 /// `junos-*` aliases are NOT handled here: the Go compiler resolves an
 /// `application junos-foo` to its numeric protocol before building the
 /// snapshot, so the wire `protocol` is already a bare name or number. Returns
-/// `None` for an unrecognized token (the DNAT builder treats that as "drop the
-/// entry" — but the Go side never emits one, since the commit gate rejects an
-/// unresolvable protocol first).
+/// `None` for an unrecognized token; the DNAT commit gate
+/// (validateDestinationNATProtocolStrict, #2396) rejects an unresolvable DNAT
+/// protocol so an inert rule never reaches the wire, and the dataplane drops
+/// any that slip through a tolerant load.
+///
+/// #2396 (Copilot fold): the token is trimmed and lower-cased before matching.
+/// DNAT `match protocol` and an `application`'s `protocol` reach the wire
+/// VERBATIM from the parser (`nodeVal`) — neither the parser nor the snapshot
+/// builder normalizes — so a config `protocol GRE` or `protocol " icmp "`
+/// would otherwise resolve to nothing here and be silently dropped. The Go
+/// commit gate normalizes the same way (strings.TrimSpace + ToLower) before
+/// validating, so the two views agree on the accepted set after normalization.
 pub(crate) fn proto_number(name: &str) -> Option<u8> {
-    match name {
+    match name.trim().to_ascii_lowercase().as_str() {
         "tcp" => Some(PROTO_TCP),
         "udp" => Some(PROTO_UDP),
         "icmp" => Some(PROTO_ICMP),

--- a/userspace-dp/src/nat/destination.rs
+++ b/userspace-dp/src/nat/destination.rs
@@ -13,16 +13,26 @@ pub(super) use crate::ip_proto::{PROTO_TCP, PROTO_UDP};
 /// #2396: protocol-wildcard sentinel for an IP-only / any-protocol DNAT rule
 /// (Junos `match destination-address <ip>` with no application and no port).
 /// Such a rule translates traffic to the destination REGARDLESS of L4
-/// protocol, including ICMP/ICMPv6/GRE. We key it under protocol 0 and have
-/// `lookup_with_counter` fall back to it after the concrete-protocol lookup
-/// misses. Real forwarded packets never carry protocol 0 (HOPOPT is an
-/// extension-header, not a transport), so reserving 0 as the table-side
-/// wildcard cannot collide with an exact-protocol entry.
-pub(crate) const PROTO_ANY: u8 = 0;
+/// protocol, including ICMP/ICMPv6/GRE. The IP-only case keys under this
+/// sentinel and `lookup_with_counter` falls back to it after the
+/// concrete-protocol and wildcard-port lookups miss.
+///
+/// #2396 (Copilot fold): the sentinel is `256`, OUTSIDE the 0-255 IANA
+/// protocol range, so it is DISTINCT from every real protocol — including
+/// protocol 0 (HOPOPT), which is a legitimate value in the SSOT
+/// (`appid.ProtocolNumber`/`proto_number`). The earlier `PROTO_ANY = 0`
+/// collided with HOPOPT: a DNAT rule with `protocol 0` would have keyed under
+/// the wildcard and broadened to match ALL protocols. `DnatKey.protocol` is
+/// therefore a `u16`: real protocol bytes widen losslessly to 0..=255 and the
+/// wildcard is the unreachable 256th value.
+pub(crate) const PROTO_ANY: u16 = 256;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct DnatKey {
-    pub protocol: u8,
+    /// IANA protocol number widened to u16 (0..=255), or `PROTO_ANY` (256) for
+    /// the IP-only / any-protocol wildcard entry. u16 so the wildcard is
+    /// distinct from protocol 0 (HOPOPT) — see `PROTO_ANY`.
+    pub protocol: u16,
     pub dst_ip: IpAddr,
     pub dst_port: u16,
 }
@@ -116,30 +126,35 @@ impl DnatTable {
             //
             // Now:
             //  - a concrete protocol token resolves through the shared SSOT
-            //    (`proto_number`, mirrors Go's `appid.ProtocolNumber`) to a
-            //    single keyed entry covering exactly that protocol.
+            //    (`proto_number`, mirrors Go's `appid.ProtocolNumber`) to its
+            //    IANA number (widened to u16) — a single keyed entry covering
+            //    exactly that protocol. This INCLUDES `"0"` (HOPOPT), which is
+            //    a real, exact protocol — NOT the wildcard.
             //  - `""` + a destination port is still a port-based rule and
             //    defaults to TCP (the Go builder already rewrites `""`->`"tcp"`
             //    for a non-zero port; we keep the fallback for robustness).
             //  - `""` + NO port is a true IP-only / any-protocol DNAT: it is
-            //    keyed under the protocol WILDCARD (`PROTO_ANY = 0`), and the
-            //    lookup falls back to that wildcard so it covers ALL protocols
-            //    INCLUDING ICMP/ICMPv6/GRE — honoring the doc.
+            //    keyed under the protocol WILDCARD (`PROTO_ANY = 256`, distinct
+            //    from every real protocol incl. HOPOPT), and the lookup falls
+            //    back to that wildcard so it covers ALL protocols INCLUDING
+            //    ICMP/ICMPv6/GRE — honoring the doc.
             //
             // An unresolvable token still drops the entry, but the Go commit
-            // gate rejects an unresolvable DNAT protocol before it can reach
-            // the wire (#2396), so this `continue` is a defense-in-depth tail,
-            // not the operator-facing failure mode.
-            let proto: u8 = match snap.protocol.as_str() {
+            // gate (validateDestinationNATProtocolStrict) rejects an
+            // unresolvable DNAT protocol before it can reach the wire on the
+            // commit path (#2396); a tolerant load downgrades to a warning, so
+            // this `continue` is the dataplane backstop for a leniently-loaded
+            // bad config, not the operator-facing failure mode.
+            let proto: u16 = match snap.protocol.as_str() {
                 "" => {
                     if snap.destination_port != 0 {
-                        PROTO_TCP
+                        u16::from(PROTO_TCP)
                     } else {
                         PROTO_ANY
                     }
                 }
                 token => match crate::ip_proto::proto_number(token) {
-                    Some(p) => p,
+                    Some(p) => u16::from(p),
                     None => continue,
                 },
             };
@@ -248,6 +263,12 @@ impl DnatTable {
         dst_port: u16,
         ingress_zone: &str,
     ) -> Option<(NatDecision, Option<Arc<NatRuleCounter>>)> {
+        // The inbound packet protocol is a real IANA byte; widen it to the
+        // u16 key space. The wildcard sentinel (PROTO_ANY = 256) is OUTSIDE
+        // this range, so a real packet — even one carrying protocol 0 (HOPOPT)
+        // — can never alias the wildcard entry on the exact/port-wildcard
+        // probes; the wildcard is only reached via the explicit final fallback.
+        let protocol = u16::from(protocol);
         let (value, hit_counter) = self
             .match_entries(
                 self.entries.get(&DnatKey {
@@ -273,11 +294,10 @@ impl DnatTable {
                 // #2396: protocol-wildcard, IP-only DNAT — matches any L4
                 // protocol (ICMP/ICMPv6/GRE/...) to this destination. Only
                 // reached when no concrete (protocol, port) entry matched, so
-                // a specific rule always wins. A real packet never carries
-                // protocol PROTO_ANY (0), so when the inbound `protocol` IS 0
-                // this `or_else` would re-probe the same key — harmless (it
-                // just repeats the wildcard lookup) and never double-counts
-                // because only one entry can match.
+                // a specific rule always wins. PROTO_ANY (256) is distinct
+                // from every real protocol, so this probe targets exactly the
+                // IP-only entries and a `protocol 0`/HOPOPT exact rule is never
+                // conflated with the catch-all.
                 self.match_entries(
                     self.entries.get(&DnatKey {
                         protocol: PROTO_ANY,

--- a/userspace-dp/src/nat/destination.rs
+++ b/userspace-dp/src/nat/destination.rs
@@ -10,6 +10,16 @@ use std::sync::Arc;
 
 pub(super) use crate::ip_proto::{PROTO_TCP, PROTO_UDP};
 
+/// #2396: protocol-wildcard sentinel for an IP-only / any-protocol DNAT rule
+/// (Junos `match destination-address <ip>` with no application and no port).
+/// Such a rule translates traffic to the destination REGARDLESS of L4
+/// protocol, including ICMP/ICMPv6/GRE. We key it under protocol 0 and have
+/// `lookup_with_counter` fall back to it after the concrete-protocol lookup
+/// misses. Real forwarded packets never carry protocol 0 (HOPOPT is an
+/// extension-header, not a transport), so reserving 0 as the table-side
+/// wildcard cannot collide with an exact-protocol entry.
+pub(crate) const PROTO_ANY: u8 = 0;
+
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct DnatKey {
     pub protocol: u8,
@@ -93,20 +103,45 @@ impl DnatTable {
                 Ok(ip) => ip,
                 Err(_) => continue,
             };
-            // Determine protocol(s) to insert entries for.
-            let protos: Vec<u8> = match snap.protocol.as_str() {
-                "tcp" => vec![PROTO_TCP],
-                "udp" => vec![PROTO_UDP],
+            // Determine the protocol key to insert this entry under.
+            //
+            // #2396: previously only `"tcp"`/`"udp"`/`""` were recognized and
+            // everything else hit `_ => continue` — a GRE/ICMP/ICMPv6 DNAT
+            // rule compiled and committed but was SILENTLY DROPPED here, never
+            // reaching the dataplane (fail-open: configured translation
+            // absent). And an IP-only rule (`""` + no port) expanded to
+            // TCP+UDP only, so an IP-only DNAT did NOT cover ICMP/GRE despite
+            // the closeout doc claiming "IP-only DNAT works for ICMP via
+            // wildcard lookup".
+            //
+            // Now:
+            //  - a concrete protocol token resolves through the shared SSOT
+            //    (`proto_number`, mirrors Go's `appid.ProtocolNumber`) to a
+            //    single keyed entry covering exactly that protocol.
+            //  - `""` + a destination port is still a port-based rule and
+            //    defaults to TCP (the Go builder already rewrites `""`->`"tcp"`
+            //    for a non-zero port; we keep the fallback for robustness).
+            //  - `""` + NO port is a true IP-only / any-protocol DNAT: it is
+            //    keyed under the protocol WILDCARD (`PROTO_ANY = 0`), and the
+            //    lookup falls back to that wildcard so it covers ALL protocols
+            //    INCLUDING ICMP/ICMPv6/GRE — honoring the doc.
+            //
+            // An unresolvable token still drops the entry, but the Go commit
+            // gate rejects an unresolvable DNAT protocol before it can reach
+            // the wire (#2396), so this `continue` is a defense-in-depth tail,
+            // not the operator-facing failure mode.
+            let proto: u8 = match snap.protocol.as_str() {
                 "" => {
                     if snap.destination_port != 0 {
-                        // Port-based rule with no explicit protocol: default TCP
-                        vec![PROTO_TCP]
+                        PROTO_TCP
                     } else {
-                        // No protocol, no port: expand to both TCP and UDP
-                        vec![PROTO_TCP, PROTO_UDP]
+                        PROTO_ANY
                     }
                 }
-                _ => continue,
+                token => match crate::ip_proto::proto_number(token) {
+                    Some(p) => p,
+                    None => continue,
+                },
             };
             let hit_counter = nat_counters.rule_counter(snap.counter_id);
             // #2394 (Copilot fold): parse the source-address constraint once per
@@ -148,7 +183,7 @@ impl DnatTable {
                     },
                 }
             }
-            for proto in protos {
+            {
                 Self::insert_entry(
                     table.entries.entry(DnatKey {
                         protocol: proto,
@@ -180,6 +215,10 @@ impl DnatTable {
     ///
     /// 1. Exact match: `(protocol, dst_ip, dst_port)`
     /// 2. Wildcard port fallback: `(protocol, dst_ip, 0)`
+    /// 3. #2396 protocol-wildcard fallback: `(PROTO_ANY, dst_ip, 0)` — an
+    ///    IP-only / any-protocol DNAT rule that covers ALL L4 protocols
+    ///    (incl. ICMP/ICMPv6/GRE). Tried last so a concrete-protocol or
+    ///    concrete-port rule always wins over the catch-all.
     ///
     /// Returns just the decision; existing callers/tests keep their
     /// `Option<NatDecision>` shape. The cold path uses
@@ -223,6 +262,25 @@ impl DnatTable {
                 self.match_entries(
                     self.entries.get(&DnatKey {
                         protocol,
+                        dst_ip,
+                        dst_port: 0,
+                    }),
+                    src_ip,
+                    ingress_zone,
+                )
+            })
+            .or_else(|| {
+                // #2396: protocol-wildcard, IP-only DNAT — matches any L4
+                // protocol (ICMP/ICMPv6/GRE/...) to this destination. Only
+                // reached when no concrete (protocol, port) entry matched, so
+                // a specific rule always wins. A real packet never carries
+                // protocol PROTO_ANY (0), so when the inbound `protocol` IS 0
+                // this `or_else` would re-probe the same key — harmless (it
+                // just repeats the wildcard lookup) and never double-counts
+                // because only one entry can match.
+                self.match_entries(
+                    self.entries.get(&DnatKey {
+                        protocol: PROTO_ANY,
                         dst_ip,
                         dst_port: 0,
                     }),

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -4148,8 +4148,79 @@ fn proto_number_resolver_matches_known_tokens() {
     assert_eq!(proto_number("gre"), Some(PROTO_GRE));
     // Bare numeric protocol number.
     assert_eq!(proto_number("47"), Some(PROTO_GRE));
-    assert_eq!(proto_number("0"), Some(PROTO_ANY));
+    // #2396 (Copilot fold): "0" is HOPOPT — a REAL, exact protocol number, NOT
+    // the wildcard. The wildcard sentinel (PROTO_ANY = 256) is u16 and outside
+    // proto_number's u8 range, so it can never be returned here.
+    assert_eq!(proto_number("0"), Some(0u8));
+    assert_eq!(u16::from(0u8) != PROTO_ANY, true, "HOPOPT must differ from PROTO_ANY");
     // Unresolvable token.
     assert_eq!(proto_number("bogus"), None);
     assert_eq!(proto_number("256"), None);
+}
+
+/// #2396 (Copilot fold, item 1): the resolver normalizes (trim + lower-case)
+/// so a mixed-case or whitespace-padded protocol token from the verbatim
+/// parser path resolves to the SAME number as the canonical lower-case token —
+/// rather than failing and being silently dropped while the Go side accepts it.
+#[test]
+fn proto_number_normalizes_case_and_whitespace() {
+    use crate::ip_proto::proto_number;
+    assert_eq!(proto_number(" GRE "), proto_number("gre"));
+    assert_eq!(proto_number("GRE"), Some(PROTO_GRE));
+    assert_eq!(proto_number("Icmp"), Some(PROTO_ICMP));
+    assert_eq!(proto_number("  TCP"), Some(PROTO_TCP));
+    assert_eq!(proto_number("ICMP6"), Some(PROTO_ICMPV6));
+    assert_eq!(proto_number(" 47 "), Some(PROTO_GRE));
+}
+
+/// #2396 (Copilot fold, item 2): a DNAT rule with `protocol "0"` (HOPOPT) is a
+/// DISTINCT exact match — it must NOT alias the IP-only wildcard. A separate
+/// IP-only ("") rule on the SAME destination still matches every OTHER
+/// protocol via the wildcard, but the HOPOPT rule owns protocol 0 exactly.
+#[test]
+fn dnat_protocol_zero_hopopt_is_distinct_from_wildcard() {
+    use crate::ip_proto::PROTO_TCP as P_TCP;
+    let table = DnatTable::from_snapshots(
+        &[
+            // IP-only catch-all -> pool A (every protocol EXCEPT an exact match)
+            DestinationNATRuleSnapshot {
+                name: "catch-all".to_string(),
+                destination_address: "203.0.113.10".to_string(),
+                destination_port: 0,
+                protocol: "".to_string(),
+                pool_address: "192.168.1.10".to_string(),
+                ..DestinationNATRuleSnapshot::default()
+            },
+            // Exact HOPOPT (protocol 0) -> pool B
+            DestinationNATRuleSnapshot {
+                name: "hopopt".to_string(),
+                destination_address: "203.0.113.10".to_string(),
+                destination_port: 0,
+                protocol: "0".to_string(),
+                pool_address: "192.168.1.20".to_string(),
+                ..DestinationNATRuleSnapshot::default()
+            },
+        ],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let src: IpAddr = "198.51.100.1".parse().unwrap();
+    let dst: IpAddr = "203.0.113.10".parse().unwrap();
+    // Protocol 0 (HOPOPT) -> the exact HOPOPT rule (pool B), NOT the wildcard.
+    assert_eq!(
+        table.lookup(0u8, src, dst, 0, ""),
+        Some(NatDecision {
+            rewrite_dst: Some("192.168.1.20".parse().unwrap()),
+            ..NatDecision::default()
+        }),
+        "protocol 0 (HOPOPT) must hit its exact rule, not the IP-only wildcard"
+    );
+    // Any OTHER protocol (TCP) -> the IP-only wildcard catch-all (pool A).
+    assert_eq!(
+        table.lookup(P_TCP, src, dst, 80, ""),
+        Some(NatDecision {
+            rewrite_dst: Some("192.168.1.10".parse().unwrap()),
+            ..NatDecision::default()
+        }),
+        "a non-HOPOPT protocol must still fall through to the IP-only wildcard"
+    );
 }

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -6,8 +6,9 @@
 use super::allocator::{
     ALLOCATION_GC_BUDGET, NS_PER_SEC, PersistentLease, PersistentSourceKey, sticky_pool_index,
 };
-use super::destination::{PROTO_TCP, PROTO_UDP};
+use super::destination::{PROTO_ANY, PROTO_TCP, PROTO_UDP};
 use super::*;
+use crate::ip_proto::{PROTO_GRE, PROTO_ICMP, PROTO_ICMPV6};
 use crate::{DestinationNATRuleSnapshot, SourceNATRuleSnapshot, StaticNATRuleSnapshot};
 use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -3928,4 +3929,227 @@ fn parsed_nat_rules_share_store_counters() {
         ),
         "DNAT entry shares the store Arc for counter_id 33"
     );
+}
+
+// ---------------------------------------------------------------------------
+// #2396: DNAT must not silently drop non-TCP/UDP protocols or IP-only rules.
+// ---------------------------------------------------------------------------
+
+/// #2396(a): a GRE DNAT rule (protocol "gre") must install a table entry and
+/// translate GRE traffic. Before #2396 the `_ => continue` arm SILENTLY
+/// dropped any protocol other than tcp/udp, so this rule never reached the
+/// dataplane. Fails (decision None) if the protocol is dropped again.
+#[test]
+fn dnat_protocol_gre_translates() {
+    let table = DnatTable::from_snapshots(
+        &[DestinationNATRuleSnapshot {
+            name: "gre-dnat".to_string(),
+            destination_address: "203.0.113.10".to_string(),
+            destination_port: 0,
+            protocol: "gre".to_string(),
+            pool_address: "192.168.1.10".to_string(),
+            ..DestinationNATRuleSnapshot::default()
+        }],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let decision = table.lookup(
+        PROTO_GRE,
+        "198.51.100.1".parse().unwrap(),
+        "203.0.113.10".parse().unwrap(),
+        0,
+        "",
+    );
+    assert_eq!(
+        decision,
+        Some(NatDecision {
+            rewrite_dst: Some("192.168.1.10".parse().unwrap()),
+            ..NatDecision::default()
+        }),
+        "GRE DNAT rule must translate GRE traffic, not be silently dropped"
+    );
+    // And it must NOT bleed into a different protocol (no PROTO_ANY wildcard
+    // was created — this is a protocol-scoped rule).
+    assert!(
+        table
+            .lookup(
+                PROTO_TCP,
+                "198.51.100.1".parse().unwrap(),
+                "203.0.113.10".parse().unwrap(),
+                0,
+                ""
+            )
+            .is_none(),
+        "GRE-scoped DNAT must not match TCP"
+    );
+}
+
+/// #2396(a): an ICMPv6 DNAT rule (protocol "icmp6") must install and translate.
+#[test]
+fn dnat_protocol_icmp6_translates() {
+    let table = DnatTable::from_snapshots(
+        &[DestinationNATRuleSnapshot {
+            name: "icmp6-dnat".to_string(),
+            destination_address: "2001:db8::1".to_string(),
+            destination_port: 0,
+            protocol: "icmp6".to_string(),
+            pool_address: "fd00::1".to_string(),
+            ..DestinationNATRuleSnapshot::default()
+        }],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let decision = table.lookup(
+        PROTO_ICMPV6,
+        "2001:db8::100".parse().unwrap(),
+        "2001:db8::1".parse().unwrap(),
+        0,
+        "",
+    );
+    assert_eq!(
+        decision,
+        Some(NatDecision {
+            rewrite_dst: Some("fd00::1".parse().unwrap()),
+            ..NatDecision::default()
+        }),
+        "ICMPv6 DNAT rule must translate, not be silently dropped"
+    );
+}
+
+/// #2396(b): an IP-only DNAT rule (no protocol, no port) must cover ALL L4
+/// protocols including ICMP via the protocol wildcard (PROTO_ANY). Before
+/// #2396 the `""` + port-0 arm expanded to TCP+UDP ONLY, so ICMP traffic to
+/// the destination was NOT translated — contradicting the closeout doc. Fails
+/// (ICMP decision None) if the rule reverts to TCP/UDP-only expansion.
+#[test]
+fn dnat_ip_only_covers_all_protocols_incl_icmp() {
+    let table = DnatTable::from_snapshots(
+        &[DestinationNATRuleSnapshot {
+            name: "ip-only".to_string(),
+            destination_address: "203.0.113.10".to_string(),
+            destination_port: 0,
+            protocol: "".to_string(),
+            pool_address: "192.168.1.10".to_string(),
+            ..DestinationNATRuleSnapshot::default()
+        }],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let expected = Some(NatDecision {
+        rewrite_dst: Some("192.168.1.10".parse().unwrap()),
+        ..NatDecision::default()
+    });
+    let src: IpAddr = "198.51.100.1".parse().unwrap();
+    let dst: IpAddr = "203.0.113.10".parse().unwrap();
+    // ICMP — the case the old TCP/UDP-only expansion missed.
+    assert_eq!(
+        table.lookup(PROTO_ICMP, src, dst, 0, ""),
+        expected,
+        "IP-only DNAT must cover ICMP"
+    );
+    // GRE — another non-TCP/UDP protocol.
+    assert_eq!(
+        table.lookup(PROTO_GRE, src, dst, 47, ""),
+        expected,
+        "IP-only DNAT must cover GRE"
+    );
+    // TCP/UDP at arbitrary ports still match (regression).
+    assert_eq!(
+        table.lookup(PROTO_TCP, src, dst, 443, ""),
+        expected,
+        "IP-only DNAT must still cover TCP"
+    );
+    assert_eq!(
+        table.lookup(PROTO_UDP, src, dst, 53, ""),
+        expected,
+        "IP-only DNAT must still cover UDP"
+    );
+}
+
+/// #2396(b): a CONCRETE protocol/port DNAT rule must win over a co-resident
+/// IP-only (PROTO_ANY) rule on the same destination — the wildcard is only a
+/// last-resort fallback, never an override.
+#[test]
+fn dnat_concrete_rule_wins_over_ip_only_wildcard() {
+    let table = DnatTable::from_snapshots(
+        &[
+            // IP-only catch-all -> pool A
+            DestinationNATRuleSnapshot {
+                name: "catch-all".to_string(),
+                destination_address: "203.0.113.10".to_string(),
+                destination_port: 0,
+                protocol: "".to_string(),
+                pool_address: "192.168.1.10".to_string(),
+                ..DestinationNATRuleSnapshot::default()
+            },
+            // Specific TCP/443 -> pool B
+            DestinationNATRuleSnapshot {
+                name: "https".to_string(),
+                destination_address: "203.0.113.10".to_string(),
+                destination_port: 443,
+                protocol: "tcp".to_string(),
+                pool_address: "192.168.1.20".to_string(),
+                ..DestinationNATRuleSnapshot::default()
+            },
+        ],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let src: IpAddr = "198.51.100.1".parse().unwrap();
+    let dst: IpAddr = "203.0.113.10".parse().unwrap();
+    // TCP/443 -> the specific rule (pool B).
+    assert_eq!(
+        table.lookup(PROTO_TCP, src, dst, 443, ""),
+        Some(NatDecision {
+            rewrite_dst: Some("192.168.1.20".parse().unwrap()),
+            ..NatDecision::default()
+        }),
+        "specific TCP/443 rule must win over the IP-only wildcard"
+    );
+    // ICMP -> falls through to the catch-all (pool A).
+    assert_eq!(
+        table.lookup(PROTO_ICMP, src, dst, 0, ""),
+        Some(NatDecision {
+            rewrite_dst: Some("192.168.1.10".parse().unwrap()),
+            ..NatDecision::default()
+        }),
+        "ICMP must fall through to the IP-only catch-all"
+    );
+}
+
+/// #2396(c) runtime sibling: a DNAT snapshot whose destination_address fails
+/// to parse emits NO entry (fail-closed), and the table is empty — the commit
+/// gate (validateDestinationNATAddressesStrict) is what gives the operator
+/// feedback, but the dataplane must not install a bogus entry either.
+#[test]
+fn dnat_invalid_destination_address_yields_no_entry() {
+    let table = DnatTable::from_snapshots(
+        &[DestinationNATRuleSnapshot {
+            name: "typo".to_string(),
+            destination_address: "not-an-ip".to_string(),
+            destination_port: 80,
+            protocol: "tcp".to_string(),
+            pool_address: "192.168.1.10".to_string(),
+            ..DestinationNATRuleSnapshot::default()
+        }],
+        &crate::nat::NatCounterStore::default(),
+    );
+    assert!(
+        table.is_empty(),
+        "a DNAT rule with an unparseable destination must install no entry"
+    );
+}
+
+/// #2396: the protocol token resolver mirrors the Go SSOT acceptance set.
+#[test]
+fn proto_number_resolver_matches_known_tokens() {
+    use crate::ip_proto::proto_number;
+    assert_eq!(proto_number("tcp"), Some(PROTO_TCP));
+    assert_eq!(proto_number("udp"), Some(PROTO_UDP));
+    assert_eq!(proto_number("icmp"), Some(PROTO_ICMP));
+    assert_eq!(proto_number("icmp6"), Some(PROTO_ICMPV6));
+    assert_eq!(proto_number("icmpv6"), Some(PROTO_ICMPV6));
+    assert_eq!(proto_number("gre"), Some(PROTO_GRE));
+    // Bare numeric protocol number.
+    assert_eq!(proto_number("47"), Some(PROTO_GRE));
+    assert_eq!(proto_number("0"), Some(PROTO_ANY));
+    // Unresolvable token.
+    assert_eq!(proto_number("bogus"), None);
+    assert_eq!(proto_number("256"), None);
 }


### PR DESCRIPTION
Closes #2396

Fixes three DNAT silent-drop fail patterns (HIGH). For a security appliance, "config accepted but no translation, with no error" is the wrong failure mode — each is now either honored end-to-end or rejected at commit.

## Sub-parts: real vs already-handled, and decision per shape

- **(a) non-TCP/UDP DNAT silently dropped — REAL. Decision: SUPPORT end-to-end.**
  `userspace-dp/src/nat/destination.rs` recognized only `tcp`/`udp`/`""` and hit `_ => continue` for everything else. The Go builder already emits `protocol="gre"/"icmp"/"icmp6"` verbatim (and `appid.ProtocolNumber` resolves applications), so only the Rust side needed to honor it. Now the protocol token resolves through a new `ip_proto::proto_number` (mirrors the Go SSOT `appid.ProtocolNumber`) into a protocol-scoped table entry. Bounded — no design fork.
  - Drop point: `destination.rs` protocol match `_ => continue`. Fix site: same match → `proto_number`.

- **(b) IP-only / no-application DNAT did not cover ICMP — REAL. Decision: SUPPORT (protocol wildcard).**
  `""` + port 0 expanded to TCP+UDP only, contradicting `docs/userspace-dnat-plan.md:288`. Now an IP-only rule is keyed under a protocol **wildcard** sentinel (`PROTO_ANY = 0`); `lookup_with_counter` gains a final `(PROTO_ANY, dst, 0)` fallback after the concrete-protocol and wildcard-port lookups miss, so it covers ALL L4 incl. ICMP/ICMPv6/GRE. A concrete `(protocol, port)` rule always wins (wildcard is last-resort). PROTO_ANY (0) is a safe table-side sentinel: real forwarded packets never carry IP proto 0 (HOPOPT is an extension header).
  - Drop point: `""`+port-0 → `vec![PROTO_TCP, PROTO_UDP]`. Fix site: → `PROTO_ANY` + lookup fallback.

- **(c) all-invalid-address DNAT — PARTLY already-handled (runtime), feedback gap REAL. Decision: add commit-time rejection.**
  #2395 already made the runtime fail-closed (builder skips each unparseable destination; Rust table drops the rule). What was missing is operator feedback. Added `validateDestinationNATAddressesStrict` (pkg/config) following the #2401 / lenientNATHostMask idiom: hard-reject on commit / commit-check, downgrade to a warning on the tolerant load / peer-sync path (#1960 no-brick). A rule with at least one valid destination still compiles (partial, not a total no-op).
  - Drop point: `buildDestinationNATSnapshots` `net.ParseIP==nil { continue }` (#2395). Fix site: new gate in `compiler.go` + `compiler_validate_strict.go`.

## Wire change
None. The `protocol` field is already a string carrying the right value from Go; the Rust side now honors it. `protocol_wire_v1.json` default-specimen fixture is unchanged (verified: `wire_invariant_default_specimens` passes).

## Composition with #2394 / #2395
Confirmed preserved. The per-protocol/per-destination insert still carries the #2394 source-address constraint and runs once per #2395-published destination. `TestBuildDestinationNATSnapshotsMultiDestination` and the existing #2394 source-scope tests still pass.

## Tests (fail-on-revert)
- Rust: `dnat_protocol_gre_translates`, `dnat_protocol_icmp6_translates`, `dnat_ip_only_covers_all_protocols_incl_icmp`, `dnat_concrete_rule_wins_over_ip_only_wildcard`, `dnat_invalid_destination_address_yields_no_entry`, `proto_number_resolver_matches_known_tokens`.
- Go: `TestBuildDestinationNATSnapshotsNonTCPUDP` (builder carries GRE/ICMP + IP-only shape); `TestDNATAllInvalidDestinationRejected`, `TestDNATAllInvalidDestinationLenientWarns`, `TestDNATValidDestination{,CIDR}Compiles`, `TestDNATPartialValidDestinationAccepted`.

## Validation
`go build ./...` + `go vet` clean; `go test ./pkg/config ./pkg/dataplane/...` green; `cargo build --release` + `cargo test --release` nat module (106) green; new tests run 5x stable on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
