### PR TITLE
#2399: reject unknown firewall-filter action at commit (fail-closed); protocol-alias half already handled

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11367,3 +11367,24 @@ top.
     pkg/config/compiler_filter_action_test.go,
     userspace-dp/src/filter/compiler.rs, userspace-dp/src/filter/tests.rs,
     docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2399 PR #2421 review folds (anti-over-reject + message accuracy).
+    FOLD 1 (hostile MINOR — real over-reject): the #2399 default-arm wrongly
+    rejected VALID Junos `then reject <message-type>` (tcp-reset,
+    administratively-prohibited, the ICMP-unreachable family) and
+    `then next term`, both of which master committed. compileFilterThen now
+    recognizes the standard reject message-types (commit as plain reject,
+    capture on FirewallFilterTerm.RejectMessageType for fidelity — compile-time
+    only, no wire field since the dataplane acts only on FilterAction::Reject)
+    and `then next term`/`next` (fall-through, FirewallFilterTerm.NextTerm). A
+    typo AFTER reject (unknown message-type) still flags → still rejects. FOLD 2
+    (Copilot): the strict error message now lists syslog + traffic-class +
+    next-term (was omitting them). Tests: reject-message-types/next-term commit
+    cleanly (anti-over-reject), RejectMessageType captured, `reject blorp` still
+    rejects, existing typo-reject fail-on-revert tests unchanged. Rust untouched
+    (folds are Go compile-time only). go build + go test ./pkg/config
+    ./pkg/dataplane ./pkg/dataplane/userspace green; TestFilterAction 5x stable.
+- **File(s)**: pkg/config/types_system.go, pkg/config/compiler_firewall.go,
+    pkg/config/compiler_validate_strict.go,
+    pkg/config/compiler_filter_action_test.go, docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -11346,3 +11346,24 @@ top.
     pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
     pkg/config/compiler_dnat_protocol_test.go,
     pkg/dataplane/userspace/protocol.go, docs/userspace-dnat-plan.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2399 — firewall-filter fail-open fixes (codex 032-16 / 032-17).
+    (032-16, REAL) An unknown/misspelled `then` action was silently DROPPED by
+    `compileFilterThen` (no default arm), leaving `Action == ""`, which BOTH
+    the dataplane compiler and the Rust `parse_term` map to ACCEPT — a
+    fail-open permit, commit reported SUCCESS. Fixed fail-CLOSED: capture the
+    unknown token on `FirewallFilterTerm.UnknownActions` and reject it at
+    commit via `validateFilterActionsStrict` (strict/lenient split,
+    `lenientFilterActions`, #1960 no-brick). Rust defense-in-depth: a
+    non-empty unrecognized action now fails to `Discard` (empty string keeps
+    fall-through `Accept`). (032-17, ALREADY-HANDLED by #2175) an unresolvable
+    `from protocol` alias is already rejected at commit by
+    `validateFilterProtocolsStrict`; no new code, documented for completeness.
+    Tests fail-on-revert verified on both sides (Go gate removed → 3 reject
+    tests fail; Rust arm reverted to Accept → discard test fails); 5x stable.
+- **File(s)**: pkg/config/types_system.go, pkg/config/compiler_firewall.go,
+    pkg/config/compiler_validate_strict.go, pkg/config/compiler.go,
+    pkg/config/compiler_filter_action_test.go,
+    userspace-dp/src/filter/compiler.rs, userspace-dp/src/filter/tests.rs,
+    docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -556,6 +556,14 @@ at commit. `compileFilterThen` now records the unrecognized token on
 the family / filter / term / offending token. Note that an EMPTY action
 (`Action == ""`) is the legitimate "no terminating action" case (a term
 with only modifiers falls through to the next term) and is NOT flagged.
+Two more VALID Junos constructs are recognized so a real config import is
+NOT over-rejected: `then reject <message-type>` (the standard ICMP-unreachable
+codes plus `tcp-reset`) commits as a plain reject and captures the type on
+`FirewallFilterTerm.RejectMessageType` for fidelity — the dataplane acts only
+on `FilterAction::Reject` today, so the type is compile-time-only (no wire
+field); and `then next term` / `then next` (explicit fall-through) commits as
+a no-op, marked `FirewallFilterTerm.NextTerm`. A token after `reject` that is
+NOT a known message-type is still a typo and IS flagged.
 Defense-in-depth in the Rust filter: a NON-EMPTY unrecognized action (only
 reachable via a mixed-version snapshot now that commit rejects it) fails
 CLOSED to `Discard`, never `Accept`; the empty string keeps the
@@ -580,8 +588,11 @@ Regression coverage: `pkg/config/compiler_filter_action_test.go`
 (`TestFilterAction_UnknownAction_RejectsAtCommit` and the
 misspelled/inet6 variants — fail-on-revert guards,
 `TestFilterAction_ValidActions_Commit` — anti-over-reject across every
-terminating action and modifier + a modifier-only fall-through term,
-`TestFilterAction_Unknown_LenientWarns`,
+terminating action and modifier + a modifier-only fall-through term + the
+reject message-types + `next term`, `TestFilterAction_RejectMessageType_-
+CommitsAndCaptures`, `TestFilterAction_NextTerm_CommitsAndMarks`,
+`TestFilterAction_UnknownRejectMessageType_RejectsAtCommit` — a typo after
+reject still rejects, `TestFilterAction_Unknown_LenientWarns`,
 `TestFilterAction_CompileCapturesUnknownToken`) and, on the Rust side,
 `userspace-dp/src/filter/tests.rs`
 (`unknown_nonempty_action_fails_closed_discard`,

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -533,6 +533,60 @@ an undefined from-zone and to-zone, `TestPolicySpecialZoneTokensCommit` —
 `any`/`junos-host`/global anti-over-reject, `TestPolicyDefinedZonesCommit`,
 `TestPolicyUndefinedZoneLenientDowngradesToWarning`).
 
+### #2399 — firewall-filter unknown `then` action + unsupported `from protocol` (commit fail-closed)
+
+Two fail-OPEN behaviors in the firewall-filter compiler, both now rejected
+at commit (the firewall-FILTER analog of the #2401 policy fail-closed
+pattern). Provenance: codex review-032 findings 032-16 / 032-17.
+
+**(032-16) Unknown `then` action → silent ACCEPT.** A filter term whose
+`then` block carries a token that is neither a recognized terminating
+action (`accept`/`reject`/`discard`) nor a recognized modifier
+(`count`/`log`/`syslog`/`forwarding-class`/`loss-priority`/`dscp`/
+`traffic-class`/`policer`/`routing-instance`) was historically DROPPED by
+`compileFilterThen` (no default arm). The term's `Action` stayed `""`,
+which the dataplane compiler (`pkg/dataplane/compiler_filter.go`) and the
+Rust filter (`userspace-dp/src/filter/compiler.rs` `parse_term`) both map
+to `FilterAction::Accept` — a term the operator meant to DENY (a misspelled
+`then accpet`, or a newer action a peer node understands) silently became a
+PERMIT, and commit reported SUCCESS. Junos rejects an unknown filter action
+at commit. `compileFilterThen` now records the unrecognized token on
+`FirewallFilterTerm.UnknownActions`, and **`validateFilterActionsStrict`**
+(`compiler_validate_strict.go`) hard-rejects any term carrying one, naming
+the family / filter / term / offending token. Note that an EMPTY action
+(`Action == ""`) is the legitimate "no terminating action" case (a term
+with only modifiers falls through to the next term) and is NOT flagged.
+Defense-in-depth in the Rust filter: a NON-EMPTY unrecognized action (only
+reachable via a mixed-version snapshot now that commit rejects it) fails
+CLOSED to `Discard`, never `Accept`; the empty string keeps the
+fall-through `Accept` semantics.
+
+**(032-17) Unsupported `from protocol` alias → dropped constraint.**
+Already handled by #2175 — **`validateFilterProtocolsStrict`** rejects a
+`from protocol <token>` that the centralized `appid.ProtocolNumber` SSOT
+cannot resolve (a name, a `junos-*` alias, or a 0..255 number). Without the
+gate an unresolvable alias was silently dropped from the protocol set, so
+the term matched ALL protocols. Documented here for completeness; no new
+code in #2399.
+
+**Strict/lenient split (flag `lenientFilterActions`, sibling of
+`lenientFilterProtocols`):** strict on the commit / commit-check path
+(`CompileConfig` — hard-reject), downgraded to a `cfg.Warnings` entry on
+the tolerant load / peer-sync paths (`CompileConfigLenient` /
+`CompileConfigForNodeLenient`) so an already-persisted or peer-synced
+config carrying an unknown action still BOOTS (#1960 fail-closed-on-load
+doctrine). The gate runs immediately after `validateFilterProtocolsStrict`.
+Regression coverage: `pkg/config/compiler_filter_action_test.go`
+(`TestFilterAction_UnknownAction_RejectsAtCommit` and the
+misspelled/inet6 variants — fail-on-revert guards,
+`TestFilterAction_ValidActions_Commit` — anti-over-reject across every
+terminating action and modifier + a modifier-only fall-through term,
+`TestFilterAction_Unknown_LenientWarns`,
+`TestFilterAction_CompileCapturesUnknownToken`) and, on the Rust side,
+`userspace-dp/src/filter/tests.rs`
+(`unknown_nonempty_action_fails_closed_discard`,
+`empty_action_falls_through_to_accept`).
+
 ### #2053 — Config secret redaction at JSON/YAML marshal time
 
 The compiled `*config.Config` carries every operator secret verbatim in

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -290,6 +290,18 @@ type compileOpts struct {
 	// constraint, never silently "protocol 0"). Same doctrine as
 	// lenientApplicationSpecs.
 	lenientFilterProtocols bool
+	// lenientFilterActions (#2399 finding 032-16) downgrades the
+	// firewall-filter `then` action gate (validateFilterActionsStrict) from a
+	// hard compile error to a cfg.Warnings entry. The strict commit /
+	// commit-check path hard-rejects a term whose `then` block carries a token
+	// that is neither a recognized terminating action (accept/reject/discard)
+	// nor a recognized modifier. Before this gate such a token was silently
+	// DROPPED at compile, leaving Action == "" which the dataplane compiler and
+	// the Rust filter both map to ACCEPT (a fail-open permit). The tolerant
+	// load / peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config carrying an unknown action still BOOTS (#1960
+	// no-brick). Same doctrine as lenientFilterProtocols.
+	lenientFilterActions bool
 	// lenientNPTv6 (#2240) downgrades the NPTv6 (RFC 6296) validation gate
 	// (validateNPTv6Strict) from a hard compile error to a cfg.Warnings entry.
 	// The strict commit / commit-check path hard-rejects an NPTv6 static-NAT
@@ -448,6 +460,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRoutingExportRef:            true,
 		lenientApplicationSpecs:            true,
 		lenientFilterProtocols:             true,
+		lenientFilterActions:               true,
 		lenientNPTv6:                       true,
 		lenientFirewallRefs:                true,
 		lenientApplicationSetMembers:       true,
@@ -544,6 +557,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRoutingExportRef:            true,
 		lenientApplicationSpecs:            true,
 		lenientFilterProtocols:             true,
+		lenientFilterActions:               true,
 		lenientNPTv6:                       true,
 		lenientFirewallRefs:                true,
 		lenientApplicationSetMembers:       true,
@@ -1025,6 +1039,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientFilterProtocols {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("firewall filter protocol (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2399 (032-16) firewall-filter `then` action fail-open gate. Strict on
+	// commit / commit-check (hard-reject a term whose `then` block carries a
+	// token that is neither a recognized terminating action nor a recognized
+	// modifier). Before this gate such a token was silently DROPPED by
+	// compileFilterThen, leaving Action == "", which the dataplane compiler and
+	// the Rust filter (parse_term) both map to ACCEPT — a fail-open permit for
+	// a term the operator meant to deny. Lenient on load / peer-sync (warn so
+	// an already-persisted or peer-synced config carrying an unknown action
+	// still BOOTS — #1960 no-brick). Runs on the fully-compiled *Config so the
+	// typed term list (with UnknownActions populated by compileFilterThen) is
+	// available.
+	if err := validateFilterActionsStrict(cfg); err != nil {
+		if opts.lenientFilterActions {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("firewall filter action (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_filter_action_test.go
+++ b/pkg/config/compiler_filter_action_test.go
@@ -80,6 +80,13 @@ func TestFilterAction_ValidActions_Commit(t *testing.T) {
 		// A term with only modifiers and no terminating action is valid Junos
 		// (fall-through); it must NOT be flagged as an unknown action.
 		"count c1 log",
+		// #2399 fold: standard Junos reject message-types and explicit
+		// next-term fall-through. Master committed these; the over-reject
+		// default arm must not reject them.
+		"reject tcp-reset",
+		"reject administratively-prohibited",
+		"reject port-unreachable",
+		"next term",
 	} {
 		t.Run(strings.ReplaceAll(then, " ", "_"), func(t *testing.T) {
 			tree := flatTreeFromSets(t, filterWithThen(then)...)
@@ -150,5 +157,56 @@ func TestFilterAction_CompileCapturesUnknownToken(t *testing.T) {
 	// a non-empty unknown) are required.
 	if term.Action != "" {
 		t.Fatalf("expected Action to stay \"\" for an unknown token, got %q", term.Action)
+	}
+}
+
+// #2399 fold: `then reject <message-type>` commits as a plain reject and
+// captures the type for fidelity. MUST FAIL if the over-reject default-arm is
+// restored (it would route tcp-reset to UnknownActions and reject the commit).
+func TestFilterAction_RejectMessageType_CommitsAndCaptures(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithThen("reject tcp-reset")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("then reject tcp-reset must commit, got %v", err)
+	}
+	term := cfg.Firewall.FiltersInet["f1"].Terms[0]
+	if term.Action != "reject" {
+		t.Fatalf("expected Action reject, got %q", term.Action)
+	}
+	if term.RejectMessageType != "tcp-reset" {
+		t.Fatalf("expected RejectMessageType tcp-reset, got %q", term.RejectMessageType)
+	}
+	if len(term.UnknownActions) != 0 {
+		t.Fatalf("reject tcp-reset must not be flagged unknown, got %v", term.UnknownActions)
+	}
+}
+
+// `then next term` (explicit fall-through) commits cleanly and marks NextTerm.
+func TestFilterAction_NextTerm_CommitsAndMarks(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithThen("next term")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("then next term must commit, got %v", err)
+	}
+	term := cfg.Firewall.FiltersInet["f1"].Terms[0]
+	if !term.NextTerm {
+		t.Fatal("expected NextTerm to be set for then next term")
+	}
+	if len(term.UnknownActions) != 0 {
+		t.Fatalf("next term must not be flagged unknown, got %v", term.UnknownActions)
+	}
+	// Fall-through keeps Action == "" (no terminating action).
+	if term.Action != "" {
+		t.Fatalf("next term must keep Action \"\", got %q", term.Action)
+	}
+}
+
+// A genuine typo AFTER reject (an unrecognized message-type) must still be
+// rejected at commit — the fidelity acceptance is gated to the KNOWN
+// message-types only, so a fat-finger does not slip through.
+func TestFilterAction_UnknownRejectMessageType_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithThen("reject blorp")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("expected commit to reject `then reject blorp` (unknown message-type)")
 	}
 }

--- a/pkg/config/compiler_filter_action_test.go
+++ b/pkg/config/compiler_filter_action_test.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2399 finding 032-16: a firewall-filter `then` term with an UNKNOWN /
+// misspelled action token was silently DROPPED by compileFilterThen, leaving
+// the term's Action == "". Both the dataplane compiler
+// (pkg/dataplane/compiler_filter.go) and the Rust filter
+// (userspace-dp/src/filter/compiler.rs parse_term) map "" to ACCEPT, so a term
+// the operator meant to DENY became a fail-open PERMIT, and commit reported
+// SUCCESS. validateFilterActionsStrict now hard-rejects an unknown `then` token
+// at the strict commit path (CompileConfig) while the tolerant load /
+// peer-sync path (CompileConfigLenient) downgrades it to a warning (#1960
+// no-brick).
+//
+// All trees are built from flat `set` commands via flatTreeFromSets (defined in
+// compiler_interfaces_unsupported_test.go) — the only correct way to exercise
+// the flat-set AST shape.
+
+func filterWithThen(then string) []string {
+	return []string{
+		"set firewall family inet filter f1 term t1 from protocol tcp",
+		"set firewall family inet filter f1 term t1 then " + then,
+	}
+}
+
+// MUST FAIL if validateFilterActionsStrict (or the UnknownActions capture in
+// compileFilterThen) is reverted: without the gate the term silently compiles
+// to accept and CompileConfig returns no error.
+func TestFilterAction_UnknownAction_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithThen("frobnicate")...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to reject firewall filter f1 term t1 with then frobnicate")
+	}
+	if !strings.Contains(err.Error(), "frobnicate") ||
+		!strings.Contains(err.Error(), "f1") ||
+		!strings.Contains(err.Error(), "t1") {
+		t.Fatalf("error %q must name the family/filter/term and the offending action", err.Error())
+	}
+}
+
+// A misspelled terminating action ("accpet") is the canonical real-world fat
+// finger this gate exists to catch — it must be rejected, not coerced to a
+// permit.
+func TestFilterAction_MisspelledTerminatingAction_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithThen("accpet")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("expected commit to reject firewall filter with then accpet (typo of accept)")
+	}
+}
+
+func TestFilterAction_UnknownInet6_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set firewall family inet6 filter f6 term t1 from protocol tcp",
+		"set firewall family inet6 filter f6 term t1 then permitt",
+	)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("expected commit to reject inet6 firewall filter with then permitt")
+	}
+}
+
+// Anti-over-reject: every legitimate terminating action and modifier (and their
+// combinations, including a term that carries ONLY modifiers and falls through
+// with no terminating action) must still commit cleanly.
+func TestFilterAction_ValidActions_Commit(t *testing.T) {
+	for _, then := range []string{
+		"accept",
+		"discard",
+		"reject",
+		"count c1",
+		"log",
+		"syslog",
+		"forwarding-class be",
+		"loss-priority high",
+		"dscp ef",
+		// A term with only modifiers and no terminating action is valid Junos
+		// (fall-through); it must NOT be flagged as an unknown action.
+		"count c1 log",
+	} {
+		t.Run(strings.ReplaceAll(then, " ", "_"), func(t *testing.T) {
+			tree := flatTreeFromSets(t, filterWithThen(then)...)
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("valid filter then %q must commit, got %v", then, err)
+			}
+		})
+	}
+
+	// `then policer <name>` is valid only with a defined policer (a separate
+	// existing reference gate); the action token itself must not be flagged as
+	// unknown. Exercise it with the policer defined so the term commits.
+	t.Run("policer", func(t *testing.T) {
+		tree := flatTreeFromSets(t,
+			"set firewall policer p1 if-exceeding bandwidth-limit 1m",
+			"set firewall policer p1 if-exceeding burst-size-limit 15k",
+			"set firewall policer p1 then discard",
+			"set firewall family inet filter f1 term t1 from protocol tcp",
+			"set firewall family inet filter f1 term t1 then policer p1",
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("valid filter then policer p1 must commit, got %v", err)
+		}
+	})
+}
+
+// No-brick (#1960 doctrine): a config persisted / peer-synced with a filter term
+// carrying an unknown action must still LOAD on the tolerant path
+// (CompileConfigLenient), downgraded to a warning — an upgraded or receiving
+// node must not fail closed on boot. (The dataplane independently fails the
+// unknown action closed; the leniently-loaded Go term keeps Action == "".)
+func TestFilterAction_Unknown_LenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithThen("frobnicate")...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load of an unknown filter action must not fail: %v", err)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "firewall filter action") && strings.Contains(w, "frobnicate") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected lenient path to record a firewall-filter-action downgrade warning, got %v", cfg.Warnings)
+	}
+}
+
+// The unknown token must be captured onto the typed term (UnknownActions), not
+// silently dropped — this is the seam the strict gate reads. MUST FAIL if the
+// default arm of compileFilterThen is reverted.
+func TestFilterAction_CompileCapturesUnknownToken(t *testing.T) {
+	tree := flatTreeFromSets(t, filterWithThen("frobnicate")...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile failed: %v", err)
+	}
+	f := cfg.Firewall.FiltersInet["f1"]
+	if f == nil || len(f.Terms) == 0 {
+		t.Fatal("filter f1 term t1 not compiled")
+	}
+	term := f.Terms[0]
+	if len(term.UnknownActions) == 0 || term.UnknownActions[0] != "frobnicate" {
+		t.Fatalf("expected term.UnknownActions to capture %q, got %v", "frobnicate", term.UnknownActions)
+	}
+	// A captured-unknown term keeps Action == "" — which the dataplane maps to
+	// accept. This is exactly why the commit gate (and the Rust fail-closed for
+	// a non-empty unknown) are required.
+	if term.Action != "" {
+		t.Fatalf("expected Action to stay \"\" for an unknown token, got %q", term.Action)
+	}
+}

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -379,6 +379,30 @@ func compileFilterFrom(node *Node, term *FirewallFilterTerm) {
 	}
 }
 
+// rejectMessageTypes is the set of message-types Junos accepts after
+// `then reject <type>` (RFC 792 ICMP-unreachable codes plus tcp-reset). A term
+// with one of these still acts as a plain reject — the dataplane does not act
+// on the message-type today (#2399 fold) — but the type is recognized so a real
+// Juniper config import (`then reject tcp-reset`) commits cleanly instead of
+// being flagged as an unknown action. A token NOT in this set after `reject` is
+// a typo and is still flagged.
+var rejectMessageTypes = map[string]bool{
+	"administratively-prohibited": true,
+	"bad-host-tos":                true,
+	"bad-network-tos":             true,
+	"host-prohibited":             true,
+	"host-unreachable":            true,
+	"network-prohibited":          true,
+	"network-unreachable":         true,
+	"port-unreachable":            true,
+	"precedence-cutoff":           true,
+	"precedence-violation":        true,
+	"protocol-unreachable":        true,
+	"source-host-isolated":        true,
+	"source-route-failed":         true,
+	"tcp-reset":                   true,
+}
+
 func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 	// Handle leaf form: "then discard;" or "then accept;" produces
 	// Keys=["then", "discard"] with IsLeaf=true and no children. A leaf can
@@ -402,8 +426,25 @@ func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 				term.Action = "accept"
 			case "reject":
 				term.Action = "reject"
+				// Junos `then reject <message-type>`: the term is a plain
+				// reject; capture a KNOWN message-type for fidelity. Only
+				// consume the following token if it is a recognized type — a
+				// typo (e.g. `reject blorp`) must fall through to the default
+				// arm and be flagged, not silently swallowed as the reject arg.
+				if i+1 < len(keys) && rejectMessageTypes[keys[i+1]] {
+					i++
+					term.RejectMessageType = keys[i]
+				}
 			case "discard":
 				term.Action = "discard"
+			case "next":
+				// `then next term` / bare `then next` — explicit fall-through
+				// to the next term (a no-op terminating-wise). Consume an
+				// optional "term" token.
+				term.NextTerm = true
+				if i+1 < len(keys) && keys[i+1] == "term" {
+					i++
+				}
 			case "log":
 				term.Log = true
 			case "syslog":
@@ -449,8 +490,30 @@ func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 			term.Action = "accept"
 		case "reject":
 			term.Action = "reject"
+			// `then reject <message-type>` — capture a KNOWN type for fidelity;
+			// a typo after reject is flagged (see leaf-form note above). The
+			// message-type is the second key (block form) or a single child.
+			if len(child.Keys) >= 2 && rejectMessageTypes[child.Keys[1]] {
+				term.RejectMessageType = child.Keys[1]
+			} else if len(child.Keys) >= 2 {
+				// Unknown token after reject — a typo. Flag it.
+				term.UnknownActions = append(term.UnknownActions, "reject "+child.Keys[1])
+			} else {
+				for _, mt := range child.Children {
+					if len(mt.Keys) >= 1 {
+						if rejectMessageTypes[mt.Keys[0]] {
+							term.RejectMessageType = mt.Keys[0]
+						} else {
+							term.UnknownActions = append(term.UnknownActions, "reject "+mt.Keys[0])
+						}
+					}
+				}
+			}
 		case "discard":
 			term.Action = "discard"
+		case "next":
+			// `then next term` / bare `then next` — explicit fall-through.
+			term.NextTerm = true
 		case "log":
 			term.Log = true
 		case "syslog":

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -381,9 +381,22 @@ func compileFilterFrom(node *Node, term *FirewallFilterTerm) {
 
 func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 	// Handle leaf form: "then discard;" or "then accept;" produces
-	// Keys=["then", "discard"] with IsLeaf=true and no children.
+	// Keys=["then", "discard"] with IsLeaf=true and no children. A leaf can
+	// also carry an argument-bearing modifier, e.g. "then forwarding-class be"
+	// → Keys=["then","forwarding-class","be"], so the keyword consumes its
+	// following token rather than treating it as a separate action.
 	if node.IsLeaf && len(node.Keys) >= 2 {
-		for _, k := range node.Keys[1:] {
+		keys := node.Keys[1:]
+		for i := 0; i < len(keys); i++ {
+			k := keys[i]
+			arg := func() string {
+				// Consume the modifier's argument if present.
+				if i+1 < len(keys) {
+					i++
+					return keys[i]
+				}
+				return ""
+			}
 			switch k {
 			case "accept":
 				term.Action = "accept"
@@ -395,6 +408,36 @@ func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 				term.Log = true
 			case "syslog":
 				term.Log = true
+			case "routing-instance":
+				if v := arg(); v != "" {
+					term.RoutingInstance = v
+				}
+			case "count":
+				if v := arg(); v != "" {
+					term.Count = v
+				}
+			case "forwarding-class":
+				if v := arg(); v != "" {
+					term.ForwardingClass = v
+				}
+			case "loss-priority":
+				if v := arg(); v != "" {
+					term.LossPriority = v
+				}
+			case "dscp", "traffic-class":
+				if v := arg(); v != "" {
+					term.DSCPRewrite = v
+				}
+			case "policer":
+				if v := arg(); v != "" {
+					term.Policer = v
+				}
+			default:
+				// #2399 (032-16): an unrecognized `then` token must NOT be
+				// silently dropped — it would default to ACCEPT in the
+				// dataplane (fail-open). Record it so the strict commit gate
+				// (validateFilterActionsStrict) can reject the operator's typo.
+				term.UnknownActions = append(term.UnknownActions, k)
 			}
 		}
 		return
@@ -434,6 +477,10 @@ func compileFilterThen(node *Node, term *FirewallFilterTerm) {
 			if len(child.Keys) >= 2 {
 				term.Policer = child.Keys[1]
 			}
+		default:
+			// #2399 (032-16): see leaf-form note above — record the unknown
+			// `then` token for the strict commit gate instead of dropping it.
+			term.UnknownActions = append(term.UnknownActions, child.Name())
 		}
 	}
 }

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -1179,6 +1179,63 @@ func validateFilterProtocolsStrict(cfg *Config) error {
 	return check("inet6", cfg.Firewall.FiltersInet6)
 }
 
+// validateFilterActionsStrict hard-rejects any firewall-filter term whose
+// `then` block carries a token that is neither a recognized terminating action
+// (accept/reject/discard) nor a recognized modifier (count/log/syslog/
+// forwarding-class/loss-priority/dscp/traffic-class/policer/routing-instance)
+// — #2399 finding 032-16.
+//
+// Before this gate, compileFilterThen silently DROPPED an unrecognized or
+// misspelled `then` token. The term's Action stayed "", which the dataplane
+// compiler (pkg/dataplane/compiler_filter.go) and the Rust filter
+// (userspace-dp/src/filter/compiler.rs parse_term) BOTH map to
+// FilterAction::Accept — a fail-open permit. An operator who typed `then
+// frobnicate` (or a future action a peer node understands) got an ACCEPT for a
+// filter term they intended to deny. In Junos an unknown filter action is a
+// commit error, so the safe behavior is fail-CLOSED: refuse the commit and
+// name the offending token rather than silently permit.
+//
+// The walk is deterministic (filters sorted by name, terms in config order)
+// so the first-reported error is stable across runs, matching
+// validateFilterProtocolsStrict. On the tolerant load / peer-sync path the
+// caller downgrades the returned error to a warning (#1960 no-brick); the
+// dataplane still has no representation for the unknown token, so the
+// leniently-loaded term defaults to accept independently — but the operator
+// never reaches that state through a commit.
+func validateFilterActionsStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	check := func(family string, filters map[string]*FirewallFilter) error {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil {
+				continue
+			}
+			for _, term := range filter.Terms {
+				if term == nil || len(term.UnknownActions) == 0 {
+					continue
+				}
+				return fmt.Errorf(
+					"firewall family %s filter %q term %q: unknown `then` action %q "+
+						"(use accept/reject/discard or a modifier such as count/log/"+
+						"forwarding-class/loss-priority/dscp/policer/routing-instance)",
+					family, name, term.Name, term.UnknownActions[0])
+			}
+		}
+		return nil
+	}
+	if err := check("inet", cfg.Firewall.FiltersInet); err != nil {
+		return err
+	}
+	return check("inet6", cfg.Firewall.FiltersInet6)
+}
+
 // filterProtocolResolvable reports whether a `from protocol <token>` is
 // representable: it INLINE-mirrors the acceptance set of
 // appid.ProtocolNumber's ok==true result (the #2124/#2175 SSOT). pkg/config

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -1223,8 +1223,9 @@ func validateFilterActionsStrict(cfg *Config) error {
 				}
 				return fmt.Errorf(
 					"firewall family %s filter %q term %q: unknown `then` action %q "+
-						"(use accept/reject/discard or a modifier such as count/log/"+
-						"forwarding-class/loss-priority/dscp/policer/routing-instance)",
+						"(use accept/reject/discard/next-term or a modifier such as "+
+						"count/log/syslog/forwarding-class/loss-priority/dscp/"+
+						"traffic-class/policer/routing-instance)",
 					family, name, term.Name, term.UnknownActions[0])
 			}
 		}

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -831,6 +831,17 @@ type FirewallFilterTerm struct {
 	// load path downgrades it to a warning (#1960 no-brick). Populated by
 	// compileFilterThen.
 	UnknownActions    []string
+	// RejectMessageType is the optional message-type after `then reject`
+	// (e.g. tcp-reset, administratively-prohibited, port-unreachable). Junos
+	// accepts `then reject <message-type>` and the term acts as a plain reject;
+	// this captures the type for config fidelity. The dataplane does not act on
+	// it today (FilterAction::Reject only). An unknown token after `reject` is
+	// a typo and is NOT stored here — it is flagged via UnknownActions.
+	RejectMessageType string
+	// NextTerm records `then next term` / `then next-term` — an explicit
+	// fall-through to the next term (a no-op terminating-wise; Action stays "").
+	// It is a recognized, valid construct, not an unknown action.
+	NextTerm          bool
 	RoutingInstance   string          // routing-instance name (policy-based routing)
 	Log               bool
 	Count             string           // counter name

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -822,6 +822,15 @@ type FirewallFilterTerm struct {
 	TCPFlags          []string        // TCP flags: "syn", "ack", "fin", "rst", "psh", "urg"
 	IsFragment        bool            // match IP fragments
 	Action            string          // "accept", "reject", "discard", ""
+	// UnknownActions records `then` tokens that are neither a recognized
+	// terminating action nor a recognized modifier (#2399 finding 032-16).
+	// An unknown or misspelled action would otherwise be silently dropped
+	// during compile and default to ACCEPT in BOTH the dataplane compiler and
+	// the Rust filter (a fail-open permit). validateFilterActionsStrict
+	// hard-rejects any term carrying an entry here at commit; the tolerant
+	// load path downgrades it to a warning (#1960 no-brick). Populated by
+	// compileFilterThen.
+	UnknownActions    []string
 	RoutingInstance   string          // routing-instance name (policy-based routing)
 	Log               bool
 	Count             string           // counter name

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -377,7 +377,25 @@ fn parse_term(
         "accept" => FilterAction::Accept,
         "reject" => FilterAction::Reject,
         "discard" => FilterAction::Discard,
-        _ => FilterAction::Accept,
+        // #2399 (032-16): an EMPTY action is the legitimate "no terminating
+        // action" case — the term carries only modifiers (count/log/
+        // forwarding-class/...) and falls through to the next term, so it must
+        // NOT short-circuit to a terminating decision here (Accept preserves
+        // today's fall-through semantics). A NON-EMPTY but unrecognized action
+        // string, however, can only arrive from a mixed-version snapshot (the
+        // Go commit gate validateFilterActionsStrict now rejects an unknown
+        // `then` token before it is ever persisted). For a FIREWALL FILTER an
+        // unknown terminating action must fail CLOSED, never silently permit —
+        // map it to Discard rather than Accept.
+        "" => FilterAction::Accept,
+        other => {
+            eprintln!(
+                "xpf-filter: term {:?} carries an unknown action {:?}; \
+                 failing closed (discard) — snapshot/version drift",
+                snap.name, other
+            );
+            FilterAction::Discard
+        }
     };
     let dscp_rewrite = snap.dscp_rewrite.map(|value| value & 0x3f);
 

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -3407,3 +3407,85 @@ fn non_first_fragment_still_matches_is_fragment() {
         "a non-first fragment IS a fragment — is-fragment must still match (#2362 fold A)"
     );
 }
+
+// #2399 (032-16): a snapshot/version-drift term carrying a NON-EMPTY but
+// unrecognized action string must fail CLOSED (discard), never silently permit.
+// The Go commit gate (validateFilterActionsStrict) rejects an unknown `then`
+// token before it can be persisted, so a non-empty unknown action can only
+// reach the dataplane via a mixed-version snapshot — and for a firewall filter
+// that must deny, not accept. MUST FAIL if parse_term's non-empty arm reverts
+// to FilterAction::Accept.
+#[test]
+fn unknown_nonempty_action_fails_closed_discard() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "drift".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "future-action".into(),
+                protocols: vec!["tcp".into()],
+                // An action a future/peer version understands but this one does
+                // not. Today's code silently treated this as Accept.
+                action: "future-permit".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let r = evaluate_filter(
+        &state,
+        "inet:drift",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        12345,
+        80,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Discard,
+        "an unknown non-empty filter action must fail closed (discard), not accept"
+    );
+}
+
+// An EMPTY action is the legitimate "no terminating action" case: the term
+// carries only modifiers and falls through to the next term. It must remain
+// Accept (today's fall-through semantics) so a valid `then count`-only term is
+// not turned into a deny. MUST FAIL if the empty-string arm is folded into the
+// fail-closed default.
+#[test]
+fn empty_action_falls_through_to_accept() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "fallthrough".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "count-only".into(),
+                protocols: vec!["tcp".into()],
+                count: "c1".into(),
+                // No terminating action — empty string.
+                action: String::new(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let r = evaluate_filter(
+        &state,
+        "inet:fallthrough",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        12345,
+        80,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Accept,
+        "an empty (no terminating) action must keep fall-through accept semantics"
+    );
+}


### PR DESCRIPTION
Closes #2399

Two fail-OPEN behaviors in the firewall-filter compiler (codex review-032 findings 032-16 / 032-17), fixed/confirmed as the firewall-FILTER analog of the #2401 policy unknown-zone fail-closed pattern.

## (032-16) Unknown `then` action → silent ACCEPT — REAL, fixed

A filter term whose `then` block carried a token that is neither a recognized terminating action (`accept`/`reject`/`discard`) nor a recognized modifier (`count`/`log`/`syslog`/`forwarding-class`/`loss-priority`/`dscp`/`traffic-class`/`policer`/`routing-instance`) was silently DROPPED by `compileFilterThen` (no default arm). The term's `Action` stayed `""`.

Default-accept site (before): `Action == ""` flows to ACCEPT in BOTH layers —
- `pkg/dataplane/compiler_filter.go:439-446` — `switch term.Action { ... default: base.Action = FilterActionAccept }`
- `userspace-dp/src/filter/compiler.rs:376-381` — `match snap.action.as_str() { ... _ => FilterAction::Accept }`

So a term the operator meant to DENY (a misspelled `then accpet`, or a newer action a peer node understands) silently became a PERMIT, and commit reported SUCCESS.

**Fix (fail-CLOSED, primary = commit reject):**
- `compileFilterThen` (`pkg/config/compiler_firewall.go`) records the unrecognized token on the new `FirewallFilterTerm.UnknownActions` field (leaf + block AST forms; the leaf form now consumes an argument-bearing modifier's value so `then forwarding-class be` is not mis-read).
- `validateFilterActionsStrict` (`pkg/config/compiler_validate_strict.go`) hard-rejects any term carrying an `UnknownActions` entry at commit, naming family/filter/term/token. An EMPTY action (`Action == ""`) is the legitimate "no terminating action" fall-through case and is NOT flagged.
- Rust defense-in-depth (`parse_term`): a NON-EMPTY unrecognized action (only reachable via a mixed-version snapshot now that commit rejects it) fails CLOSED to `Discard`; the empty string keeps fall-through `Accept`.

## (032-17) Unsupported `from protocol` alias → dropped constraint — ALREADY HANDLED

Already fixed by #2175: `validateFilterProtocolsStrict` (`compiler_validate_strict.go`) rejects an unresolvable `from protocol <token>` at commit (mirrors the `appid.ProtocolNumber` SSOT). No new code in this PR; documented in `docs/config-schema.md` for completeness. The issue's evidence at `compiler.rs:359-363`/`439-451` is the Rust drop, but the Go commit gate already prevents an unresolvable token from ever being persisted.

## Lenient/strict split

New flag `lenientFilterActions` (sibling of `lenientFilterProtocols`): strict on the commit/commit-check path (`CompileConfig` — hard-reject), downgraded to a `cfg.Warnings` entry on the tolerant load / peer-sync paths (`CompileConfigLenient`) so an already-persisted or peer-synced config still BOOTS (#1960 no-brick). Gate runs immediately after `validateFilterProtocolsStrict`.

## Supported sets exempted (anti-over-reject)

- Actions/modifiers: `accept`, `reject`, `discard`, `count`, `log`, `syslog`, `forwarding-class`, `loss-priority`, `dscp`, `traffic-class`, `policer`, `routing-instance`, plus a modifier-only term (no terminating action — valid Junos fall-through).
- Protocols: unchanged — the #2175 resolvable set.

## Tests (fail-on-revert)

Go (`pkg/config/compiler_filter_action_test.go`):
- `TestFilterAction_UnknownAction_RejectsAtCommit`, `..._MisspelledTerminatingAction_...`, `..._UnknownInet6_...` — MUST FAIL if the gate is removed (verified: removing the gate makes all three pass through to accept).
- `TestFilterAction_ValidActions_Commit` — anti-over-reject.
- `TestFilterAction_Unknown_LenientWarns`, `TestFilterAction_CompileCapturesUnknownToken`.

Rust (`userspace-dp/src/filter/tests.rs`):
- `unknown_nonempty_action_fails_closed_discard` — MUST FAIL if the arm reverts to Accept (verified).
- `empty_action_falls_through_to_accept`.

## Validation

`go build ./...` + `go test ./pkg/config ./pkg/dataplane ./pkg/dataplane/userspace` green; `cargo build --release` + `cargo test --release -- filter` (123 pass) green. New tests 5x stable, both sides. No wire/snapshot structure change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi