### PR TITLE
filter: fail-close all-malformed firewall-filter addresses/ports (#2400)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11419,3 +11419,34 @@ top.
     userspace-dp/src/filter/engine/matching.rs,
     userspace-dp/src/filter/engine/cache_sensitive.rs,
     userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2400 PR #2422 fold round (pre-merge; hostile reviewer MERGE-READY
+    — doc-accuracy + test-coverage, NO production logic change).
+    (1) Corrected the `*_addr_constrained` doc comments (mod.rs, compiler.rs) that
+    inaccurately said "true when the configured address list is NON-EMPTY": the
+    actual logic is `addr_is_real` — constrained when the term has at least one
+    REAL match entry EXCLUDING ""/"any", so an explicit `source-address any`
+    stays UNCONSTRAINED (match-any). README wording was already accurate.
+    (2) Added `term_2400_all_malformed_destination_address_fails_closed_v6` — the
+    inet6 destination-address fail-closed case was missing (only had v6 source +
+    v4 dest). Test set is now v4 src+dst AND v6 src+dst (the earlier log claim is
+    now accurate).
+    (3) Added two cache-sensitivity flip tests in cache_sensitive.rs
+    (cache_sensitive_2400_tests): `unscoped_vs_all_malformed_source_address_is_not_cache_equal`
+    and `..._source_port_is_not_cache_equal` — assert filter_term_semantics_match
+    reports NOT-equal across the unscoped↔all-malformed flip (parsed vecs/matcher
+    identical, only the *_constrained flag differs), pinning that a cached verdict
+    is invalidated. Both build the FilterTerm via parse_filter_state from
+    snapshots that differ only in scope.
+    All 3 new tests fail-on-revert proven: reverting nets_match_v6 to fail-open
+    fails the v6-dest test; dropping the *_constrained comparisons from
+    filter_term_semantics_match fails both flip tests. Total #2400 tests now 13
+    (11 matcher fail-closed/scope tests + 2 cache-sensitivity flip tests). cargo
+    build --release + cargo test -- filter / cache_sensitive_2400 green, 5x
+    stable; go build + go test ./pkg/config ./pkg/dataplane
+    ./pkg/dataplane/userspace green; protocol_wire_v1.json unchanged.
+- **File(s)**: userspace-dp/src/filter/mod.rs,
+    userspace-dp/src/filter/compiler.rs,
+    userspace-dp/src/filter/engine/cache_sensitive.rs,
+    userspace-dp/src/filter/tests.rs, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -11388,3 +11388,34 @@ top.
 - **File(s)**: pkg/config/types_system.go, pkg/config/compiler_firewall.go,
     pkg/config/compiler_validate_strict.go,
     pkg/config/compiler_filter_action_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2400 — fail-close all-malformed firewall-filter address/port
+    match sets (codex 032-18 addresses, 032-19 ports). A filter term whose
+    `source-address` / `destination-address` / `source-port` /
+    `destination-port` set was non-empty in the config but whose entries ALL
+    failed to parse degraded to match-ANY on that dimension (empty parsed list =
+    no constraint) — a `discard` term scoped to typo'd addresses became
+    discard-all (fail-OPEN broadening). Mirror of the #2398 (SNAT) / #2394
+    (DNAT) `*_constrained` fix. Added `source_addr_constrained` /
+    `dest_addr_constrained` / `source_port_constrained` / `dest_port_constrained`
+    to FilterTerm, DERIVED at compile time from the snapshot list holding a real
+    entry (`addr_is_real` skips ""/"any"; `port_is_real` skips ""). Matcher
+    helpers `nets_match_v4`/`nets_match_v6`/`port_match` (engine/matching.rs):
+    unconstrained → match any; constrained but parsed set empty → match NOTHING
+    (fail closed); else parsed prefix/range. Bare-host address already handled by
+    parse_address's bare-IP /32//128 fallback (kept). Flags also added to
+    filter_term_semantics_match (cache_sensitive.rs) so the unscoped↔all-
+    malformed flip is caught on flow-cache rebuild. NO new wire field
+    (protocol_wire_v1.json unchanged). 10 new fail-on-revert tests (all-malformed
+    src/dst address v4+v6, all-malformed src/dst port, bare-host scope,
+    valid-unscoped-matches-all, valid-scoped-matches-only-its-scope, compose with
+    #2362 tcp-flags + #2399 action, partial-malformed keeps valid scope) —
+    revert-proven: reverting the matcher to fail-open fails 6 of them.
+    cargo build --release + cargo test -- filter (133) green, 5x stable; go build
+    + go test ./pkg/config ./pkg/dataplane ./pkg/dataplane/userspace green.
+- **File(s)**: userspace-dp/src/filter/mod.rs,
+    userspace-dp/src/filter/compiler.rs,
+    userspace-dp/src/filter/engine/matching.rs,
+    userspace-dp/src/filter/engine/cache_sensitive.rs,
+    userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md, _Log.md

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -185,6 +185,40 @@ modifiers, applied after a match has succeeded. They do not
 participate in match-time key lookup and are out of scope for the
 cache-key contract.
 
+### All-malformed match sets fail CLOSED (#2400)
+
+A term's `source-address` / `destination-address` / `source-port` /
+`destination-port` match set restricts which traffic the term's action applies
+to. The Rust compiler drops any entry that fails to parse
+(`parse_address` skips an unparseable prefix; `parse_port_spec` returns `None`).
+Historically an EMPTY parsed list meant "no constraint → match any", so a term
+whose match set was non-empty in the config but whose entries ALL failed to
+parse (every address typo'd, every port out of range) silently broadened to
+match-ANY on that dimension — a `discard` term scoped to bad addresses became
+discard-all (fail-OPEN filter broadening, codex 032-18 / 032-19).
+
+`FilterTerm` now carries four derived flags —
+`source_addr_constrained` / `dest_addr_constrained` /
+`source_port_constrained` / `dest_port_constrained` — set at compile time when
+the snapshot list held at least one REAL entry (`addr_is_real` ignores the empty
+string and the literal `any`; `port_is_real` ignores the empty string). The
+matcher (`engine/matching.rs` `nets_match_v4` / `nets_match_v6` / `port_match`)
+then distinguishes:
+
+- unconstrained (no real entry) → match any (unchanged unscoped behavior);
+- constrained but the parsed set is empty for this packet's family (all entries
+  failed to parse) → match NOTHING (fail closed);
+- otherwise → the IP/port must fall in a parsed prefix/range.
+
+This mirrors the NAT `*_constrained` fail-closed pattern (#2398 SNAT, #2394
+DNAT). A bare-host address (`203.0.113.7`, no `/32`) is handled by
+`parse_address`'s bare-IP fallback (`IpNet::parse` rejects a bare IP). The flags
+are DERIVED from the existing snapshot lists, so there is NO new wire field
+(`protocol_wire_v1.json` is unchanged). The flags are also compared in
+`filter_term_semantics_match` (`engine/cache_sensitive.rs`) because the
+unscoped↔all-malformed transition flips match semantics WITHOUT changing the
+parsed vecs/matcher, so a flow-cache rebuild must catch it.
+
 ### Path (b) runbook — cache-sensitive
 
 Adding a per-packet match field that is NOT in the cache key

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -356,13 +356,14 @@ fn parse_term(
     for addr in &snap.destination_addresses {
         parse_address(addr, &mut dest_v4, &mut dest_v6);
     }
-    // #2400 (032-18): a term whose `from { source-address / destination-address }`
-    // stanza is non-empty in the snapshot is ADDRESS-CONSTRAINED. `addr_is_real`
-    // ignores the "any"/empty placeholders that `parse_address` already drops,
-    // so an explicit `from { source-address any; }` stays unconstrained (matches
-    // any) rather than degrading to fail-closed. When the term is constrained
-    // but every real entry failed to parse, the per-family vecs are empty and
-    // the matcher fails closed (see engine/matching.rs).
+    // #2400 (032-18): a term is ADDRESS-CONSTRAINED when it has at least one
+    // REAL `from { source-address / destination-address }` entry — `addr_is_real`
+    // EXCLUDES the empty string and the literal `any` (the placeholders
+    // `parse_address` already drops), so an explicit `from { source-address
+    // any; }` stays UNCONSTRAINED (match-any) rather than degrading to
+    // fail-closed. When the term is constrained but every real entry failed to
+    // parse, the per-family vecs are empty and the matcher fails closed (see
+    // engine/matching.rs).
     let source_addr_constrained = snap.source_addresses.iter().any(|a| addr_is_real(a));
     let dest_addr_constrained = snap.destination_addresses.iter().any(|a| addr_is_real(a));
     let protocols: Vec<u8> = snap

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -356,6 +356,15 @@ fn parse_term(
     for addr in &snap.destination_addresses {
         parse_address(addr, &mut dest_v4, &mut dest_v6);
     }
+    // #2400 (032-18): a term whose `from { source-address / destination-address }`
+    // stanza is non-empty in the snapshot is ADDRESS-CONSTRAINED. `addr_is_real`
+    // ignores the "any"/empty placeholders that `parse_address` already drops,
+    // so an explicit `from { source-address any; }` stays unconstrained (matches
+    // any) rather than degrading to fail-closed. When the term is constrained
+    // but every real entry failed to parse, the per-family vecs are empty and
+    // the matcher fails closed (see engine/matching.rs).
+    let source_addr_constrained = snap.source_addresses.iter().any(|a| addr_is_real(a));
+    let dest_addr_constrained = snap.destination_addresses.iter().any(|a| addr_is_real(a));
     let protocols: Vec<u8> = snap
         .protocols
         .iter()
@@ -373,6 +382,14 @@ fn parse_term(
         .filter_map(|p| parse_port_spec(p))
         .flatten()
         .collect();
+    // #2400 (032-19): mirror of the address constraint for the port match sets.
+    // `port_is_real` ignores the empty-string placeholder (which `parse_port_spec`
+    // treats as "no port range") so an empty entry never trips fail-closed. A
+    // constrained port set whose entries ALL failed to parse yields zero ranges
+    // -> `PortMatcher::Any`; the `*_port_constrained` flag lets the matcher tell
+    // that apart from a genuinely unscoped term and fail closed.
+    let source_port_constrained = snap.source_ports.iter().any(|p| port_is_real(p));
+    let dest_port_constrained = snap.destination_ports.iter().any(|p| port_is_real(p));
     let action = match snap.action.as_str() {
         "accept" => FilterAction::Accept,
         "reject" => FilterAction::Reject,
@@ -406,10 +423,14 @@ fn parse_term(
         source_v6,
         dest_v4,
         dest_v6,
+        source_addr_constrained,
+        dest_addr_constrained,
         protocol_bitmap: build_u8_match_bitmap(&protocols),
         protocol_match_enabled: !protocols.is_empty(),
         source_ports: build_port_matcher(source_ports),
         dest_ports: build_port_matcher(dest_ports),
+        source_port_constrained,
+        dest_port_constrained,
         dscp_bitmap: build_u6_match_bitmap(&snap.dscp_values),
         dscp_match_enabled: !snap.dscp_values.is_empty(),
         // #2362 per-packet L4 match conditions. A zero tcp_flags mask means
@@ -431,6 +452,24 @@ fn parse_term(
         dscp_rewrite,
         counter: Arc::new(FilterTermCounter::default()),
     }
+}
+
+/// #2400: whether an address entry imposes a real scope. `parse_address` drops
+/// the empty string and the literal `any` as "no constraint" placeholders, so
+/// they must NOT make a term address-constrained (otherwise `from {
+/// source-address any; }` would fail closed). Every other entry — valid OR
+/// malformed — is a real scope; an all-malformed list is exactly the fail-open
+/// case #2400 closes.
+fn addr_is_real(entry: &str) -> bool {
+    !entry.is_empty() && entry != "any"
+}
+
+/// #2400: whether a port entry imposes a real scope. `parse_port_spec` treats
+/// the empty string as "no port range", so an empty placeholder must NOT make a
+/// term port-constrained. Every other entry — valid OR malformed — is a real
+/// scope.
+fn port_is_real(entry: &str) -> bool {
+    !entry.is_empty()
 }
 
 fn parse_address(prefix: &str, out_v4: &mut Vec<PrefixV4>, out_v6: &mut Vec<PrefixV6>) {

--- a/userspace-dp/src/filter/engine/cache_sensitive.rs
+++ b/userspace-dp/src/filter/engine/cache_sensitive.rs
@@ -125,10 +125,19 @@ fn filter_term_semantics_match(old: &FilterTerm, new: &FilterTerm) -> bool {
         && old.source_v6 == new.source_v6
         && old.dest_v4 == new.dest_v4
         && old.dest_v6 == new.dest_v6
+        // #2400: the *_constrained flags change match semantics (fail-closed vs
+        // match-any) WITHOUT changing the parsed vecs/matcher in the
+        // unscoped<->all-malformed transition (both leave empty vecs /
+        // PortMatcher::Any), so they MUST be compared here or a flow-cache
+        // rebuild would keep stale match-any decisions.
+        && old.source_addr_constrained == new.source_addr_constrained
+        && old.dest_addr_constrained == new.dest_addr_constrained
         && old.protocol_bitmap == new.protocol_bitmap
         && old.protocol_match_enabled == new.protocol_match_enabled
         && old.source_ports == new.source_ports
         && old.dest_ports == new.dest_ports
+        && old.source_port_constrained == new.source_port_constrained
+        && old.dest_port_constrained == new.dest_port_constrained
         && old.dscp_bitmap == new.dscp_bitmap
         && old.dscp_match_enabled == new.dscp_match_enabled
         && old.tcp_flags_mask == new.tcp_flags_mask

--- a/userspace-dp/src/filter/engine/cache_sensitive.rs
+++ b/userspace-dp/src/filter/engine/cache_sensitive.rs
@@ -307,3 +307,95 @@ pub(crate) fn interface_output_filter_has_per_packet_l4_match(
     };
     filter.is_some_and(|filter| filter.has_per_packet_l4_match_terms)
 }
+
+#[cfg(test)]
+mod cache_sensitive_2400_tests {
+    use super::super::super::*;
+
+    // Compile a single-term filter from one snapshot and return its sole term.
+    fn term_from(snap: FirewallTermSnapshot) -> FilterTerm {
+        let state = parse_filter_state(
+            &[FirewallFilterSnapshot {
+                name: "f".into(),
+                family: "inet".into(),
+                terms: vec![snap],
+            }],
+            &[],
+            &[],
+            "",
+            "",
+        );
+        state
+            .filters
+            .get("inet:f")
+            .expect("filter compiled")
+            .terms
+            .first()
+            .expect("one term")
+            .clone()
+    }
+
+    /// #2400 (hostile reviewer MINOR): the unscoped <-> all-malformed ADDRESS
+    /// flip changes match semantics (match-any vs fail-closed) WITHOUT changing
+    /// any parsed vec/matcher — both leave `source_v4`/`source_v6` empty. The
+    /// ONLY difference is `source_addr_constrained`. `filter_term_semantics_match`
+    /// MUST report them as NOT equal so a flow-cache rebuild invalidates the
+    /// stale match-any verdict. REVERT (dropping the `*_constrained` comparisons
+    /// from `filter_term_semantics_match`) makes this assert FAIL.
+    #[test]
+    fn unscoped_vs_all_malformed_source_address_is_not_cache_equal() {
+        let unscoped = term_from(FirewallTermSnapshot {
+            name: "t".into(),
+            action: "discard".into(),
+            ..Default::default()
+        });
+        let all_malformed = term_from(FirewallTermSnapshot {
+            name: "t".into(),
+            source_addresses: vec!["not-an-ip".into()],
+            action: "discard".into(),
+            ..Default::default()
+        });
+        // Precondition: the parsed match state is otherwise identical — the only
+        // distinguishing bit is the constrained flag.
+        assert!(unscoped.source_v4.is_empty() && unscoped.source_v6.is_empty());
+        assert!(all_malformed.source_v4.is_empty() && all_malformed.source_v6.is_empty());
+        assert!(!unscoped.source_addr_constrained);
+        assert!(all_malformed.source_addr_constrained);
+
+        assert!(
+            !super::filter_term_semantics_match(&unscoped, &all_malformed),
+            "unscoped vs all-malformed address must NOT be cache-equal \
+             (the *_constrained flip must invalidate cached verdicts)"
+        );
+        // A term compared with itself stays equal (no spurious invalidation).
+        assert!(super::filter_term_semantics_match(&unscoped, &unscoped));
+        assert!(super::filter_term_semantics_match(&all_malformed, &all_malformed));
+    }
+
+    /// Same flip for the PORT match set: unscoped (PortMatcher::Any,
+    /// unconstrained) vs all-malformed (PortMatcher::Any, constrained) — the
+    /// matcher is byte-identical, only `source_port_constrained` differs.
+    #[test]
+    fn unscoped_vs_all_malformed_source_port_is_not_cache_equal() {
+        let unscoped = term_from(FirewallTermSnapshot {
+            name: "t".into(),
+            action: "discard".into(),
+            ..Default::default()
+        });
+        let all_malformed = term_from(FirewallTermSnapshot {
+            name: "t".into(),
+            source_ports: vec!["70000".into()], // out of range -> no parsed range
+            action: "discard".into(),
+            ..Default::default()
+        });
+        assert_eq!(unscoped.source_ports, PortMatcher::Any);
+        assert_eq!(all_malformed.source_ports, PortMatcher::Any);
+        assert!(!unscoped.source_port_constrained);
+        assert!(all_malformed.source_port_constrained);
+
+        assert!(
+            !super::filter_term_semantics_match(&unscoped, &all_malformed),
+            "unscoped vs all-malformed port must NOT be cache-equal"
+        );
+    }
+}

--- a/userspace-dp/src/filter/engine/matching.rs
+++ b/userspace-dp/src/filter/engine/matching.rs
@@ -100,16 +100,16 @@ pub(super) fn term_matches_v4(
     {
         return false;
     }
-    if !term.source_v4.is_empty() && !term.source_v4.iter().any(|net| net.contains(src_ip)) {
+    if !nets_match_v4(term.source_addr_constrained, &term.source_v4, src_ip) {
         return false;
     }
-    if !term.dest_v4.is_empty() && !term.dest_v4.iter().any(|net| net.contains(dst_ip)) {
+    if !nets_match_v4(term.dest_addr_constrained, &term.dest_v4, dst_ip) {
         return false;
     }
-    if !term.source_ports.matches(src_port) {
+    if !port_match(term.source_port_constrained, &term.source_ports, src_port) {
         return false;
     }
-    if !term.dest_ports.matches(dst_port) {
+    if !port_match(term.dest_port_constrained, &term.dest_ports, dst_port) {
         return false;
     }
     if term.dscp_match_enabled && (term.dscp_bitmap & (1u64 << dscp)) == 0 {
@@ -119,6 +119,58 @@ pub(super) fn term_matches_v4(
         return false;
     }
     true
+}
+
+/// #2400 (032-18): match a v4 IP against a filter term's address set with
+/// fail-closed semantics for an all-malformed list.
+///
+/// - `constrained == false` (the term carried no real source/dest address):
+///   match any IP — unchanged unscoped behavior.
+/// - `constrained == true` but `nets` empty (every configured prefix failed to
+///   parse for this family): match NOTHING — fail closed, never the pre-#2400
+///   collapse to the empty-list match-any fail-open broadening.
+/// - otherwise: the IP must fall in one of the parsed prefixes.
+///
+/// Mirrors `nat::source::nets_match_v4` (#2398).
+#[inline(always)]
+fn nets_match_v4(constrained: bool, nets: &[PrefixV4], ip: Ipv4Addr) -> bool {
+    if !constrained {
+        return true;
+    }
+    if nets.is_empty() {
+        return false;
+    }
+    nets.iter().any(|net| net.contains(ip))
+}
+
+/// #2400 (032-18): v6 sibling of `nets_match_v4`.
+#[inline(always)]
+fn nets_match_v6(constrained: bool, nets: &[PrefixV6], ip: Ipv6Addr) -> bool {
+    if !constrained {
+        return true;
+    }
+    if nets.is_empty() {
+        return false;
+    }
+    nets.iter().any(|net| net.contains(ip))
+}
+
+/// #2400 (032-19): match a port against a filter term's port matcher with
+/// fail-closed semantics for an all-malformed list.
+///
+/// - `constrained == false` (the term carried no real port spec): the matcher
+///   is `PortMatcher::Any` and matches any port — unchanged unscoped behavior.
+/// - `constrained == true` but the matcher is `PortMatcher::Any` (every
+///   configured port spec failed to parse, leaving zero ranges): match NOTHING
+///   — fail closed.
+/// - otherwise: the matcher's own range/set logic applies.
+#[inline(always)]
+fn port_match(constrained: bool, matcher: &PortMatcher, port: u16) -> bool {
+    if constrained && matches!(matcher, PortMatcher::Any) {
+        // Constrained but no range survived parsing -> fail closed.
+        return false;
+    }
+    matcher.matches(port)
 }
 
 #[inline(always)]
@@ -138,16 +190,16 @@ pub(super) fn term_matches_v6(
     {
         return false;
     }
-    if !term.source_v6.is_empty() && !term.source_v6.iter().any(|net| net.contains(src_ip)) {
+    if !nets_match_v6(term.source_addr_constrained, &term.source_v6, src_ip) {
         return false;
     }
-    if !term.dest_v6.is_empty() && !term.dest_v6.iter().any(|net| net.contains(dst_ip)) {
+    if !nets_match_v6(term.dest_addr_constrained, &term.dest_v6, dst_ip) {
         return false;
     }
-    if !term.source_ports.matches(src_port) {
+    if !port_match(term.source_port_constrained, &term.source_ports, src_port) {
         return false;
     }
-    if !term.dest_ports.matches(dst_port) {
+    if !port_match(term.dest_port_constrained, &term.dest_ports, dst_port) {
         return false;
     }
     if term.dscp_match_enabled && (term.dscp_bitmap & (1u64 << dscp)) == 0 {

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -81,10 +81,12 @@ pub(crate) struct FilterTerm {
     pub(crate) dest_v4: Vec<PrefixV4>,
     pub(crate) dest_v6: Vec<PrefixV6>,
     // #2400 (032-18): fail-closed flags for the source/destination ADDRESS
-    // match sets. `*_addr_constrained` is true when the term carried a
-    // NON-EMPTY configured address list in the snapshot — regardless of how
-    // many entries survived parsing. The matcher in `engine/matching.rs` uses
-    // it to tell apart an UNSCOPED term (constrained == false → match any
+    // match sets. `*_addr_constrained` is true when the term has at least one
+    // REAL match entry (`addr_is_real` in compiler.rs — EXCLUDING the empty
+    // string and the literal `any`), regardless of how many entries survived
+    // parsing. An explicit `from { source-address any; }` therefore stays
+    // UNCONSTRAINED (match-any). The matcher in `engine/matching.rs` uses the
+    // flag to tell apart an UNSCOPED term (constrained == false → match any
     // address) from a SCOPED term whose entries ALL failed to parse
     // (constrained == true but both prefix vecs empty for that family → match
     // NOTHING, fail closed). Without this flag an all-malformed address list

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -80,10 +80,34 @@ pub(crate) struct FilterTerm {
     pub(crate) source_v6: Vec<PrefixV6>,
     pub(crate) dest_v4: Vec<PrefixV4>,
     pub(crate) dest_v6: Vec<PrefixV6>,
+    // #2400 (032-18): fail-closed flags for the source/destination ADDRESS
+    // match sets. `*_addr_constrained` is true when the term carried a
+    // NON-EMPTY configured address list in the snapshot — regardless of how
+    // many entries survived parsing. The matcher in `engine/matching.rs` uses
+    // it to tell apart an UNSCOPED term (constrained == false → match any
+    // address) from a SCOPED term whose entries ALL failed to parse
+    // (constrained == true but both prefix vecs empty for that family → match
+    // NOTHING, fail closed). Without this flag an all-malformed address list
+    // collapses to the empty-list "match any" fail-open broadening (a `discard`
+    // term scoped to typo'd addresses would become discard-all). Mirrors the
+    // #2398/#2394 NAT `*_constrained` pattern.
+    pub(crate) source_addr_constrained: bool,
+    pub(crate) dest_addr_constrained: bool,
     pub(crate) protocol_bitmap: [u64; 4],
     pub(crate) protocol_match_enabled: bool,
     pub(crate) source_ports: PortMatcher,
     pub(crate) dest_ports: PortMatcher,
+    // #2400 (032-19): fail-closed flags for the source/destination PORT match
+    // sets. Same shape as the address flags above. A `PortMatcher::Any` arises
+    // from BOTH the legitimate unscoped case (no port configured) AND the
+    // all-malformed case (every configured port spec failed to parse), so the
+    // matcher cannot distinguish them from the `PortMatcher` alone. When
+    // `*_port_constrained` is true but the matcher is `PortMatcher::Any`, the
+    // term had a port list that ALL failed to parse → match NOTHING (fail
+    // closed). A valid scoped term yields a non-`Any` matcher and matches its
+    // ports as before.
+    pub(crate) source_port_constrained: bool,
+    pub(crate) dest_port_constrained: bool,
     pub(crate) dscp_bitmap: u64,
     pub(crate) dscp_match_enabled: bool,
     // Per-packet L4 match conditions (#2362). NOT in SessionKey, so a filter

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -3489,3 +3489,465 @@ fn empty_action_falls_through_to_accept() {
         "an empty (no terminating) action must keep fall-through accept semantics"
     );
 }
+
+// ============================================================
+// #2400 (codex 032-18 / 032-19): all-malformed firewall-filter
+// addresses/ports must FAIL CLOSED (match nothing), never degrade to
+// match-any (fail-open filter broadening). A `discard` term scoped to
+// an all-malformed address/port set must NOT become discard-all.
+//
+// The fail-on-revert pivot: the filter's implicit (no-term-match) action
+// is Accept (see evaluate_filter docstring). So a single `discard` term
+// scoped to bad addresses/ports yields Accept when the term correctly
+// matches NOTHING, and Discard if it wrongly broadens to match-any.
+// ============================================================
+
+/// One `discard` term scoped to an all-malformed source-address list. The fix
+/// makes the term match nothing -> the packet falls through to implicit Accept.
+/// REVERT (empty parsed list -> match-any) makes the term match every packet ->
+/// Discard, failing this assert.
+#[test]
+fn term_2400_all_malformed_source_address_fails_closed_v4() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "scoped-discard".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-bad-src".into(),
+                // Every entry is unparseable as an IP/CIDR.
+                source_addresses: vec!["not-an-ip".into(), "10.0.0.0/99".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter(
+        &state,
+        "inet:scoped-discard",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Accept,
+        "all-malformed source-address must fail CLOSED (term matches nothing -> \
+         implicit accept); a match-any regression would Discard"
+    );
+}
+
+/// Same for destination-address.
+#[test]
+fn term_2400_all_malformed_destination_address_fails_closed_v4() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "scoped-discard".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-bad-dst".into(),
+                destination_addresses: vec!["garbage".into(), "999.1.2.3".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter(
+        &state,
+        "inet:scoped-discard",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Accept,
+        "all-malformed destination-address must fail CLOSED"
+    );
+}
+
+/// v6 sibling: all-malformed source-address in an inet6 filter.
+#[test]
+fn term_2400_all_malformed_source_address_fails_closed_v6() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "scoped-discard6".into(),
+            family: "inet6".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-bad-src6".into(),
+                source_addresses: vec!["xyzzy".into(), "2001:db8::/200".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter(
+        &state,
+        "inet6:scoped-discard6",
+        IpAddr::V6("2001:db8::10".parse().unwrap()),
+        IpAddr::V6("2001:db8::200".parse().unwrap()),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Accept,
+        "all-malformed inet6 source-address must fail CLOSED"
+    );
+}
+
+/// All-malformed source-port set -> fail closed.
+#[test]
+fn term_2400_all_malformed_source_port_fails_closed() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "scoped-discard".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-bad-sport".into(),
+                // Unparseable port specs: a name not in the table, an out-of-range
+                // number, and an inverted range.
+                source_ports: vec!["nonsense".into(), "70000".into(), "100-50".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter(
+        &state,
+        "inet:scoped-discard",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        40000,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Accept,
+        "all-malformed source-port must fail CLOSED (term matches nothing); a \
+         PortMatcher::Any regression would Discard"
+    );
+}
+
+/// All-malformed destination-port set -> fail closed.
+#[test]
+fn term_2400_all_malformed_destination_port_fails_closed() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "scoped-discard".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-bad-dport".into(),
+                destination_ports: vec!["bogus".into(), "0".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter(
+        &state,
+        "inet:scoped-discard",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        40000,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Accept,
+        "all-malformed destination-port must fail CLOSED"
+    );
+}
+
+/// A bare-host match address (no /prefix) scopes correctly: the matching host
+/// hits the term, a different host does not (anti-over-restrict + anti-fail-open
+/// at once). IpNet::parse rejects a bare IP, so this exercises the bare-IP
+/// fallback to /32.
+#[test]
+fn term_2400_bare_host_source_address_scopes_correctly() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "scoped-discard".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-one-host".into(),
+                source_addresses: vec!["203.0.113.7".into()], // bare host, no /32
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    // The configured host is dropped.
+    let hit = evaluate_filter(
+        &state,
+        "inet:scoped-discard",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        hit.action,
+        FilterAction::Discard,
+        "bare-host source-address must match the configured host (bare-IP /32 fallback)"
+    );
+    // A different host is NOT dropped (falls through to implicit accept).
+    let miss = evaluate_filter(
+        &state,
+        "inet:scoped-discard",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 8)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        miss.action,
+        FilterAction::Accept,
+        "a non-configured host must NOT match the bare-host-scoped term"
+    );
+}
+
+/// Anti-over-restrict: a VALID UNSCOPED discard term (no address/port) still
+/// matches everything. The constrained flags must not narrow a genuinely
+/// unscoped term.
+#[test]
+fn term_2400_valid_unscoped_term_still_matches_all() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "unscoped".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-all".into(),
+                // no source/destination addresses, no ports.
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter(
+        &state,
+        "inet:unscoped",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Discard,
+        "a valid unscoped term must still match all traffic (no over-restriction)"
+    );
+}
+
+/// Anti-over-restrict: a VALID SCOPED term matches only its address and port,
+/// and falls through (accept) for everything else.
+#[test]
+fn term_2400_valid_scoped_term_matches_only_its_scope() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "scoped".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-net-port".into(),
+                source_addresses: vec!["203.0.113.0/24".into()],
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    // In-scope: matches -> discard.
+    let in_scope = evaluate_filter(
+        &state,
+        "inet:scoped",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(in_scope.action, FilterAction::Discard, "in-scope must match");
+    // Wrong port: out of scope -> accept.
+    let wrong_port = evaluate_filter(
+        &state,
+        "inet:scoped",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        80,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        wrong_port.action,
+        FilterAction::Accept,
+        "a valid scoped term must NOT match a packet outside its port scope"
+    );
+    // Wrong source: out of scope -> accept.
+    let wrong_src = evaluate_filter(
+        &state,
+        "inet:scoped",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        wrong_src.action,
+        FilterAction::Accept,
+        "a valid scoped term must NOT match a packet outside its address scope"
+    );
+}
+
+/// Composition with #2362 (tcp-flags) and #2399 (action) intact: a term that
+/// mixes a VALID scope with a tcp-flags constraint matches only the in-scope
+/// SYN packet, and an all-malformed address with the same tcp-flags still fails
+/// closed (does not broaden to match-any-SYN).
+#[test]
+fn term_2400_composes_with_2362_tcp_flags() {
+    // Valid scope + tcp-flags syn -> matches the in-scope SYN.
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "syn-scoped".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-syn-from-net".into(),
+                source_addresses: vec!["203.0.113.0/24".into()],
+                tcp_flags: Some(0x02), // SYN
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let syn_extra = TermMatchExtra {
+        tcp_flags: 0x02,
+        l4_present: true,
+        ..Default::default()
+    };
+    let in_scope_syn = evaluate_filter(
+        &state,
+        "inet:syn-scoped",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        syn_extra,
+    );
+    assert_eq!(
+        in_scope_syn.action,
+        FilterAction::Discard,
+        "valid scope + tcp-flags must still match the in-scope SYN (#2362 intact)"
+    );
+
+    // All-malformed address + the same tcp-flags -> fail closed even for a SYN.
+    let bad_state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "syn-bad".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-syn-bad-src".into(),
+                source_addresses: vec!["not-an-ip".into()],
+                tcp_flags: Some(0x02),
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let bad_syn = evaluate_filter(
+        &bad_state,
+        "inet:syn-bad",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        syn_extra,
+    );
+    assert_eq!(
+        bad_syn.action,
+        FilterAction::Accept,
+        "all-malformed address + tcp-flags must fail CLOSED, not broaden to match-any-SYN"
+    );
+}
+
+/// A term mixing one VALID and one malformed address keeps the valid scope
+/// (the malformed entry is dropped, the term stays constrained and matches the
+/// valid prefix only). This guards against an over-correction that would fail
+/// the whole term closed when ANY entry is bad.
+#[test]
+fn term_2400_partial_malformed_address_keeps_valid_scope() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "partial".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-mixed".into(),
+                source_addresses: vec!["203.0.113.0/24".into(), "garbage".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let in_valid = evaluate_filter(
+        &state,
+        "inet:partial",
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        in_valid.action,
+        FilterAction::Discard,
+        "the surviving valid prefix must still match (partial-malformed != all-malformed)"
+    );
+}

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -3609,6 +3609,43 @@ fn term_2400_all_malformed_source_address_fails_closed_v6() {
     );
 }
 
+/// v6 sibling of the destination-address fail-closed test: all-malformed
+/// destination-address in an inet6 filter must match nothing (fail closed).
+/// REVERT of the v6 dest fail-closed path makes the term broaden to match-any
+/// -> Discard, failing this assert.
+#[test]
+fn term_2400_all_malformed_destination_address_fails_closed_v6() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "scoped-discard6".into(),
+            family: "inet6".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-bad-dst6".into(),
+                destination_addresses: vec!["plugh".into(), "fe80::/200".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let result = evaluate_filter(
+        &state,
+        "inet6:scoped-discard6",
+        IpAddr::V6("2001:db8::10".parse().unwrap()),
+        IpAddr::V6("2001:db8::200".parse().unwrap()),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        result.action,
+        FilterAction::Accept,
+        "all-malformed inet6 destination-address must fail CLOSED"
+    );
+}
+
 /// All-malformed source-port set -> fail closed.
 #[test]
 fn term_2400_all_malformed_source_port_fails_closed() {


### PR DESCRIPTION
Closes #2400

## Problem (fail-open filter broadening, HIGH)

A firewall-filter term whose `source-address` / `destination-address` /
`source-port` / `destination-port` match set was non-empty in the config but
whose entries **all** failed to parse degraded to **match-ANY** on that
dimension. The matcher treated an empty *parsed* list as "no constraint", so a
term the operator scoped to specific addresses/ports — if every entry was
typo'd or out of range — silently became a match-everything term and applied
its action to **all** traffic:

- a `discard` term scoped to typo'd addresses became **discard-all**;
- an `accept` term scoped to typo'd addresses became **accept-all**.

Fail-OPEN. Provenance: codex review-032 findings **032-18** (addresses) /
**032-19** (ports).

### Match-any sites on current master

- `userspace-dp/src/filter/engine/matching.rs` — `!term.source_v4.is_empty() && …`
  (and the v6 / dest twins): an empty parsed prefix list short-circuits to
  match-any.
- `PortMatcher::Any` arises from zero parsed ranges (`build_port_matcher`,
  `compiler.rs`) and matches every port — indistinguishable from a genuinely
  unscoped term.

`parse_address` already carried the bare-IP `/32` // `/128` fallback (the
#2398 live bug), so that half was already fixed; the remaining gap was purely
the empty-parsed-list = match-any semantics.

## Fix (mirror of #2398 SNAT / #2394 DNAT)

Derive four constrained flags on `FilterTerm` at compile time —
`source_addr_constrained` / `dest_addr_constrained` /
`source_port_constrained` / `dest_port_constrained` — true when the snapshot
match list held at least one **real** entry (`addr_is_real` ignores the `""`
and `any` placeholders `parse_address` drops; `port_is_real` ignores `""`).
The matcher helpers `nets_match_v4` / `nets_match_v6` / `port_match`
distinguish:

| state | result |
|-------|--------|
| unconstrained (no real entry) | match any (unchanged unscoped behavior) |
| constrained, parsed set empty (all entries failed) | **match NONE — fail closed** |
| otherwise | parsed prefix/range applies |

The flags are also compared in `filter_term_semantics_match`
(`engine/cache_sensitive.rs`): the unscoped↔all-malformed transition flips
match semantics **without** changing the parsed vecs/matcher (both leave empty
vecs / `PortMatcher::Any`), so a flow-cache rebuild must catch the flag flip.

### No wire change

The flags are **derived** from the existing snapshot lists — no new wire
field. `protocol_wire_v1.json` is unchanged.

### Composition

Preserves #2362 (tcp-flags / is-fragment / icmp-type/code) and #2399 (filter
action fail-closed), verified by a dedicated composition test.

## Tests (fail-on-revert)

`term_2400_*`: all-malformed source/dest address (v4 + v6), all-malformed
source/dest port, bare-host address scopes correctly, valid unscoped term
still matches all (anti-over-restrict), valid scoped term matches only its
scope, composition with #2362 tcp-flags + #2399 action, partial-malformed
keeps the surviving valid scope. Reverting the matcher to the fail-open
empty=match-any behavior fails **6 of the 10** new tests.

## Validation

- `cargo build --release` + `cargo test -- filter` (133 filter tests; full bin
  suite 2522) green; filter tests 5x stable.
- `go build ./...` + `go test ./pkg/config ./pkg/dataplane
  ./pkg/dataplane/userspace` green.
- `protocol_wire_v1.json` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi