### PR TITLE
afxdp/ndp: validate NA per RFC 4861 §7.1.2 + bound option walk by payload_len (#2368)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11450,3 +11450,32 @@ top.
     userspace-dp/src/filter/compiler.rs,
     userspace-dp/src/filter/engine/cache_sensitive.rs,
     userspace-dp/src/filter/tests.rs, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2368 (HIGH) — NDP NA neighbor-cache poisoning. Added RFC
+    4861 §7.1.2 validation to `parse_ndp_neighbor_advert` and bounded the
+    NDP option walk by the IPv6-declared packet end. (A) Before learning a
+    Target Link-Layer Address, the parser now requires IPv6 Hop Limit ==
+    255 (off-link impersonation gate), ICMPv6 Code == 0, ICMP length >=
+    24, Target Address not multicast, and a valid ICMPv6 checksum
+    (recomputed over the IPv6 pseudo-header via the shared
+    `frame::checksum16_add_bytes`/`checksum16_finish` accumulator). Any
+    failure returns None (no learn), so a spoofed/off-link NA can no
+    longer poison the dynamic-neighbor cache or the kernel neighbor table.
+    (B) The option walk is now bounded by `l3 + 40 + payload_len` (clamped
+    to the slice; rejected if it overruns the frame) instead of
+    `raw_frame.len()`, so a forged TLLA in the Ethernet trailer/padding
+    beyond the declared payload is never read. NS shares no learning path
+    (NS is never parsed/learned in the userspace dataplane) → NA-only fix.
+    Scoped to validation; does NOT touch the #2370 ifindex keying at the
+    learn site (the learn site already only learns on a Some(target_mac),
+    so all checks live in the parser). 8 new fail-on-revert tests
+    (hop-limit<255, code!=0, bad checksum, multicast target, TLLA past
+    payload_len, payload_len overrun, valid-NA-still-learns untagged +
+    VLAN). Reverting the hop-limit gate and the option-walk bound both
+    proven to fail the corresponding tests. cargo build --release clean;
+    parser tests 25/25 green, 5x stable; targeted suite (ndp/neighbor/na/
+    parser/poll_stages) 729 green.
+- **File(s)**: userspace-dp/src/afxdp/parser.rs,
+    userspace-dp/src/afxdp/parser_tests.rs,
+    userspace-dp/src/afxdp/README.md, _Log.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -29,6 +29,33 @@ sync.
     which the control plane can read as a hung worker and turn into a
     spurious VRRP failover / route withdrawal.
 - `worker/` — the per-worker poll loop (`mod.rs` runs the dispatch).
+- `parser.rs` — pure control-plane parsers (#947) for the two L2/L3
+  learning shapes that drive the dynamic-neighbor cache: ARP replies
+  (`classify_arp`) and IPv6 Neighbor Advertisements
+  (`parse_ndp_neighbor_advert`). The poll-stage learn site
+  (`poll_stages.rs::stage_link_layer_classify`) inserts the parsed
+  `(ifindex, ip) -> mac` binding into `dynamic_neighbors` AND the kernel
+  neighbor table, so these parsers are a MAC->IP write primitive — they
+  MUST fail closed on untrusted input.
+  - **NA validation (`#2368`, RFC 4861 §7.1.2 / RFC 4443):** before an
+    NA learns a Target Link-Layer Address, `parse_ndp_neighbor_advert`
+    enforces the §7.1.2 MUSTs — IPv6 Hop Limit == 255 (the off-link
+    impersonation gate: a lower hop limit means a router forwarded the
+    packet, so it did not originate on-link), ICMPv6 Code == 0, ICMP
+    length >= 24, Target Address not multicast, and a valid ICMPv6
+    checksum (computed over the IPv6 pseudo-header via the shared
+    `frame::checksum16_*` accumulator). Any failure → `None` (no learn),
+    so a spoofed/off-link NA cannot poison the cache.
+  - **payload_len-bounded option walk (`#2368` B, #2361 class):** the
+    NDP option walk (locating the TLLA) is bounded by the IPv6-declared
+    packet end (`l3 + 40 + payload_len`, rejected if it overruns the
+    frame), NOT the raw Ethernet frame length. A short NA whose declared
+    payload covers only the fixed header cannot smuggle a forged TLLA in
+    the L2 trailer/padding — trailing slack is never read as a
+    link-layer address.
+  - **NS scope:** there is NO Neighbor Solicitation learning path in the
+    userspace dataplane (NS is never parsed or learned), so #2368 is
+    NA-only; there is no sibling NS gap to close here.
 - `poll_stages.rs` — sibling of `worker/`, not inside it. Holds the
   per-packet pipeline stages extracted in #946 Phase 1. The screen and
   SYN-cookie stages decide the L3 offset (14 vs 18) on tag PRESENCE

--- a/userspace-dp/src/afxdp/parser.rs
+++ b/userspace-dp/src/afxdp/parser.rs
@@ -27,6 +27,13 @@ const NEXT_HEADER_ICMPV6: u8 = 58;
 const ICMPV6_TYPE_NA: u8 = 136;
 const ARP_OP_REPLY: u16 = 2;
 const NDP_OPT_TARGET_LL: u8 = 2;
+/// RFC 4861 §7.1.2: every NDP message MUST be sent with an IPv6 Hop
+/// Limit of 255 so a receiver can reject any NDP packet whose hop
+/// limit is lower — such a packet was necessarily forwarded by a
+/// router and therefore did not originate on-link. An off-link or
+/// spoofed-but-routed NA cannot satisfy this without a router
+/// decrementing the field.
+const NDP_REQUIRED_HOP_LIMIT: u8 = 255;
 
 /// Resolve the L3-header offset and the EtherType. Handles untagged
 /// and single-tagged frames carrying either an 802.1Q (0x8100) or an
@@ -176,19 +183,71 @@ pub(super) fn parse_ndp_neighbor_advert(raw_frame: &[u8]) -> Option<NdpNeighborA
     {
         return None;
     }
+
+    // #2368 (B): bound the whole NDP parse — header AND option walk — by
+    // the IPv6-declared packet end, not the raw frame length. A
+    // minimum-size Ethernet frame can declare a payload covering only
+    // the fixed NA header and then place a forged TLLA option in the
+    // L2 padding/trailer beyond `40 + payload_len`. Reading that trailer
+    // as an option would learn an attacker-chosen MAC from bytes the
+    // sender never accounted for in the IP length. Compute the declared
+    // end (mirrors the #2361 declared-end discipline) and reject if it
+    // overruns the frame or is too short to even hold the NA header.
+    let payload_len = u16::from_be_bytes([raw_frame[l3_start + 4], raw_frame[l3_start + 5]]) as usize;
+    let packet_end = l3_start.checked_add(IPV6_HDR_LEN)?.checked_add(payload_len)?;
+    if packet_end > raw_frame.len() || packet_end < l4_start + ICMPV6_NA_HDR_LEN {
+        return None;
+    }
+
+    // #2368 (A): RFC 4861 §7.1.2 NA validity MUSTs. Without these an
+    // off-link/spoofed NA poisons the dynamic-neighbor cache and the
+    // kernel neighbor table (this is a control-plane MAC->IP learning
+    // path). Fail-closed: any failed check learns nothing.
+    //
+    //  - Hop Limit MUST be 255 (the off-link-impersonation gate).
+    //  - ICMPv6 Code MUST be 0.
+    //  - ICMP length (here `packet_end - l4_start`) MUST be >= 24, which
+    //    `packet_end` already guarantees above.
+    //  - Target Address MUST NOT be multicast (a multicast target is
+    //    never a unicast neighbor to learn).
+    //  - The ICMPv6 checksum (RFC 4443, computed over the IPv6
+    //    pseudo-header + the ICMPv6 message) MUST be valid.
+    if raw_frame[l3_start + 7] != NDP_REQUIRED_HOP_LIMIT {
+        return None;
+    }
+    if raw_frame[l4_start + 1] != 0 {
+        return None;
+    }
     let target_bytes: [u8; 16] =
         <[u8; 16]>::try_from(&raw_frame[l4_start + 8..l4_start + 24]).ok()?;
+    if target_bytes[0] == 0xff {
+        // ff00::/8 is the IPv6 multicast range.
+        return None;
+    }
     let target_ip = IpAddr::V6(Ipv6Addr::from(target_bytes));
-    // Walk the NDP options for a Target Link-Layer Address (type 2).
+
+    // ICMPv6 checksum over the IPv6 pseudo-header + the ICMPv6 message
+    // (`l4_start..packet_end`). A valid packet sums (including its own
+    // checksum field) to zero in 16-bit one's complement, i.e. the
+    // recomputed value is 0x0000. Reuse the shared one's-complement
+    // accumulator (#2211) so this matches every other checksum site.
+    if !icmpv6_checksum_valid(raw_frame, l3_start, l4_start, packet_end) {
+        return None;
+    }
+
+    // Walk the NDP options for a Target Link-Layer Address (type 2),
+    // strictly within the IPv6-declared packet end (#2368 B). An option
+    // whose declared length overruns `packet_end` is rejected (stop the
+    // walk) rather than read out of the declared packet.
     let mut target_mac: Option<[u8; 6]> = None;
     let mut opt_off = l4_start + ICMPV6_NA_HDR_LEN;
-    while opt_off + 2 <= raw_frame.len() {
+    while opt_off + 2 <= packet_end {
         let opt_type = raw_frame[opt_off];
         let opt_len = raw_frame[opt_off + 1] as usize * 8;
-        if opt_len == 0 {
+        if opt_len == 0 || opt_off + opt_len > packet_end {
             break;
         }
-        if opt_type == NDP_OPT_TARGET_LL && opt_len >= 8 && opt_off + 8 <= raw_frame.len() {
+        if opt_type == NDP_OPT_TARGET_LL && opt_len >= 8 {
             target_mac = Some([
                 raw_frame[opt_off + 2],
                 raw_frame[opt_off + 3],
@@ -205,6 +264,38 @@ pub(super) fn parse_ndp_neighbor_advert(raw_frame: &[u8]) -> Option<NdpNeighborA
         target_ip,
         target_mac,
     })
+}
+
+/// Validate the ICMPv6 checksum (RFC 4443 §2.3) of a Neighbor
+/// Advertisement. The checksum is computed over the IPv6 pseudo-header
+/// (source + destination address from the IPv6 header, the upper-layer
+/// packet length, and the next-header value 58) followed by the entire
+/// ICMPv6 message (`l4_start..packet_end`, which includes the checksum
+/// field itself). For a valid packet the one's-complement sum folds to
+/// zero, so the recomputed checksum is 0x0000.
+///
+/// Reuses the shared `frame` one's-complement accumulator (#2211) so the
+/// arithmetic is bit-identical to the NAT64 / forwarding checksum paths
+/// and benefits from the same AVX2 fast path.
+#[inline(always)]
+fn icmpv6_checksum_valid(
+    raw_frame: &[u8],
+    l3_start: usize,
+    l4_start: usize,
+    packet_end: usize,
+) -> bool {
+    let icmp = &raw_frame[l4_start..packet_end];
+    let mut sum: u32 = 0;
+    // IPv6 pseudo-header: src (16) + dst (16).
+    sum = super::frame::checksum16_add_bytes(sum, &raw_frame[l3_start + 8..l3_start + 24]);
+    sum = super::frame::checksum16_add_bytes(sum, &raw_frame[l3_start + 24..l3_start + 40]);
+    // Upper-layer packet length (32-bit) — the ICMPv6 message length.
+    sum = super::frame::checksum16_add_bytes(sum, &(icmp.len() as u32).to_be_bytes());
+    // Three zero bytes + next-header (58).
+    sum = super::frame::checksum16_add_bytes(sum, &[0, 0, 0, NEXT_HEADER_ICMPV6]);
+    // The ICMPv6 message itself (the on-wire checksum field included).
+    sum = super::frame::checksum16_add_bytes(sum, icmp);
+    super::frame::checksum16_finish(sum) == 0
 }
 
 #[cfg(test)]

--- a/userspace-dp/src/afxdp/parser_tests.rs
+++ b/userspace-dp/src/afxdp/parser_tests.rs
@@ -77,7 +77,69 @@ fn classify_arp_rejects_short_frame() {
     assert_eq!(classify_arp(&f), ArpClassification::NotArp);
 }
 
+/// Compute the RFC 4443 ICMPv6 checksum over the message at
+/// `l4_start..packet_end` using the IPv6 pseudo-header taken from the
+/// IPv6 base header at `l3_start`. The on-wire checksum field
+/// (`l4_start + 2..l4_start + 4`) is treated as zero for the
+/// computation. Used by the test builders to stamp a VALID checksum so
+/// the #2368 §7.1.2 validation accepts a legitimate NA.
+fn compute_icmpv6_checksum(frame: &[u8], l3_start: usize, l4_start: usize, packet_end: usize) -> u16 {
+    let mut sum: u32 = 0;
+    let add = |sum: &mut u32, bytes: &[u8]| {
+        let mut i = 0;
+        while i + 1 < bytes.len() {
+            *sum += u16::from_be_bytes([bytes[i], bytes[i + 1]]) as u32;
+            i += 2;
+        }
+        if i < bytes.len() {
+            *sum += (bytes[i] as u32) << 8;
+        }
+    };
+    // pseudo-header: src(16) + dst(16) + len(32) + [0,0,0,58]
+    add(&mut sum, &frame[l3_start + 8..l3_start + 24]);
+    add(&mut sum, &frame[l3_start + 24..l3_start + 40]);
+    let icmp_len = (packet_end - l4_start) as u32;
+    add(&mut sum, &icmp_len.to_be_bytes());
+    add(&mut sum, &[0, 0, 0, NEXT_HEADER_ICMPV6]);
+    // ICMPv6 message with the checksum field zeroed.
+    let mut icmp = frame[l4_start..packet_end].to_vec();
+    icmp[2] = 0;
+    icmp[3] = 0;
+    add(&mut sum, &icmp);
+    while (sum >> 16) != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+/// Stamp a valid ICMPv6 checksum into `frame` in place (l4 at `l4_start`,
+/// declared packet end at `packet_end`, IPv6 base header at `l3_start`).
+fn stamp_icmpv6_checksum(frame: &mut [u8], l3_start: usize, l4_start: usize, packet_end: usize) {
+    let csum = compute_icmpv6_checksum(frame, l3_start, l4_start, packet_end);
+    frame[l4_start + 2..l4_start + 4].copy_from_slice(&csum.to_be_bytes());
+}
+
 fn build_eth_ndp_na(vlan: bool, with_tlla: bool) -> Vec<u8> {
+    build_eth_ndp_na_full(vlan, with_tlla, 255, 0, false)
+}
+
+/// Full NDP NA builder with explicit RFC 4861 §7.1.2 knobs (#2368).
+///
+///  - `hop_limit`        — IPv6 Hop Limit byte (255 required by §7.1.2).
+///  - `code`             — ICMPv6 Code byte (0 required by §7.1.2).
+///  - `target_multicast` — when true the Target Address is ff02::1
+///    (multicast) instead of the default unicast fe80::abcd:ef01:0:42.
+///
+/// Always stamps a VALID ICMPv6 checksum over the declared packet so a
+/// well-formed frame is accepted; rejection tests that need a bad
+/// checksum corrupt the field after building.
+fn build_eth_ndp_na_full(
+    vlan: bool,
+    with_tlla: bool,
+    hop_limit: u8,
+    code: u8,
+    target_multicast: bool,
+) -> Vec<u8> {
     let mut f = Vec::new();
     f.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
     f.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
@@ -86,34 +148,44 @@ fn build_eth_ndp_na(vlan: bool, with_tlla: bool) -> Vec<u8> {
     }
     // ethertype IPv6
     f.extend_from_slice(&[0x86, 0xdd]);
+    let l3_start = if vlan { 18 } else { 14 };
     // IPv6 header (40 bytes): version=6, payload-len=24+8 if TLLA else 24,
-    // next-header=58 ICMPv6, hop-limit=255
+    // next-header=58 ICMPv6
     let payload_len = if with_tlla { 32u16 } else { 24u16 };
     f.extend_from_slice(&[0x60, 0x00, 0x00, 0x00]); // ver+tc+flow
     f.extend_from_slice(&payload_len.to_be_bytes());
     f.push(NEXT_HEADER_ICMPV6); // next header
-    f.push(255); // hop limit
-                 // src ip
+    f.push(hop_limit); // hop limit
+                       // src ip
     f.extend_from_slice(&[
         0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0xab, 0xcd, 0xef, 0x01, 0x00, 0x00, 0x00, 0x01,
     ]);
     // dst ip
     f.extend_from_slice(&[0xff; 16]);
-    // ICMPv6 NA: type=136, code=0, checksum=0xffff, flags=0, target=fe80::abcd:ef01:0:42
+    let l4_start = l3_start + 40;
+    // ICMPv6 NA: type=136, code, checksum(placeholder), flags=0, target
     f.push(ICMPV6_TYPE_NA);
-    f.push(0); // code
-    f.extend_from_slice(&[0xff, 0xff]); // checksum
+    f.push(code); // code
+    f.extend_from_slice(&[0x00, 0x00]); // checksum placeholder (stamped below)
     f.extend_from_slice(&[0; 4]); // flags
-                                  // target address
-    f.extend_from_slice(&[
-        0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0xab, 0xcd, 0xef, 0x01, 0x00, 0x00, 0x00, 0x42,
-    ]);
+    if target_multicast {
+        // ff02::1 — all-nodes multicast: an invalid Target Address.
+        f.extend_from_slice(&[
+            0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x00, 0x00, 0x00, 0x01,
+        ]);
+    } else {
+        f.extend_from_slice(&[
+            0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0xab, 0xcd, 0xef, 0x01, 0x00, 0x00, 0x00, 0x42,
+        ]);
+    }
     if with_tlla {
         // option type=2 (TLLA), len=1 (×8 = 8 bytes), MAC
         f.push(NDP_OPT_TARGET_LL);
         f.push(1);
         f.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
     }
+    let packet_end = l3_start + 40 + payload_len as usize;
+    stamp_icmpv6_checksum(&mut f, l3_start, l4_start, packet_end);
     f
 }
 
@@ -320,7 +392,7 @@ fn build_ndp_na_with_ext_chain(ext_chain: &[u8]) -> Vec<u8> {
     let mut na = Vec::new();
     na.push(ICMPV6_TYPE_NA);
     na.push(0); // code
-    na.extend_from_slice(&[0xff, 0xff]); // checksum
+    na.extend_from_slice(&[0x00, 0x00]); // checksum placeholder (stamped below)
     na.extend_from_slice(&[0u8; 4]); // flags
     na.extend_from_slice(&[
         0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0xab, 0xcd, 0xef, 0x01, 0x00, 0x00, 0x00, 0x42,
@@ -343,7 +415,13 @@ fn build_ndp_na_with_ext_chain(ext_chain: &[u8]) -> Vec<u8> {
     f.extend_from_slice(&[0xff; 16]); // dst
 
     f.extend_from_slice(&ext_block);
+    let l4_start = f.len();
     f.extend_from_slice(&na);
+    // ext chain sits between the base IPv6 header (l3=14) and the NA;
+    // the NA's L4 start is wherever the chain ends. The declared packet
+    // end is l3 + 40 + payload_len = end of frame here.
+    let packet_end = f.len();
+    stamp_icmpv6_checksum(&mut f, 14, l4_start, packet_end);
     f
 }
 
@@ -410,4 +488,118 @@ fn parse_ndp_na_truncated_ext_chain_no_panic() {
     // Truncate inside the ICMPv6 NA body (keep base + HBH + a few bytes).
     f.truncate(14 + 40 + 8 + 4);
     assert!(parse_ndp_neighbor_advert(&f).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// #2368 — RFC 4861 §7.1.2 NA validation + payload_len-bounded option walk.
+//
+// These are fail-on-revert security tests: each MUST fail (the neighbor
+// cache is poisoned) if the corresponding validity check is removed, and
+// the valid-NA test MUST fail if the validation is too strict.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_ndp_na_2368_valid_na_still_learns() {
+    // Anti-over-reject: a well-formed NA (hop-limit 255, code 0, valid
+    // ICMPv6 checksum, TLLA within payload_len) MUST still learn the MAC.
+    // Fails if the §7.1.2 validation is too strict (e.g. checksum logic
+    // inverted) → legitimate IPv6 neighbor resolution would break.
+    let f = build_eth_ndp_na_full(false, true, 255, 0, false);
+    let r = parse_ndp_neighbor_advert(&f).expect("valid NA must still parse");
+    assert_eq!(r.target_mac, Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]));
+}
+
+#[test]
+fn parse_ndp_na_2368_valid_na_vlan_still_learns() {
+    // Same anti-over-reject check on a VLAN-tagged NA (l3 at 18).
+    let f = build_eth_ndp_na_full(true, true, 255, 0, false);
+    let r = parse_ndp_neighbor_advert(&f).expect("valid VLAN NA must still parse");
+    assert_eq!(r.target_mac, Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]));
+}
+
+#[test]
+fn parse_ndp_na_2368_rejects_hop_limit_below_255() {
+    // RFC 4861 §7.1.2: an NA with Hop Limit < 255 was forwarded by a
+    // router and is therefore off-link — MUST NOT be learned. Fails (the
+    // cache is poisoned by an off-link impersonator) if the hop-limit
+    // gate is removed.
+    let f = build_eth_ndp_na_full(false, true, 254, 0, false);
+    assert!(
+        parse_ndp_neighbor_advert(&f).is_none(),
+        "NA with hop-limit 254 must not be learned"
+    );
+}
+
+#[test]
+fn parse_ndp_na_2368_rejects_nonzero_code() {
+    // RFC 4861 §7.1.2: ICMPv6 Code MUST be 0. Fails if the code gate is
+    // removed.
+    let f = build_eth_ndp_na_full(false, true, 255, 1, false);
+    assert!(
+        parse_ndp_neighbor_advert(&f).is_none(),
+        "NA with ICMPv6 code 1 must not be learned"
+    );
+}
+
+#[test]
+fn parse_ndp_na_2368_rejects_bad_checksum() {
+    // RFC 4443: a valid ICMPv6 checksum is required. Corrupt the stamped
+    // checksum and confirm the NA is rejected. Fails if the checksum
+    // validation is removed.
+    let mut f = build_eth_ndp_na_full(false, true, 255, 0, false);
+    let l4_start = 14 + 40;
+    // Flip the checksum field so it no longer matches the message.
+    f[l4_start + 2] ^= 0xff;
+    f[l4_start + 3] ^= 0xff;
+    assert!(
+        parse_ndp_neighbor_advert(&f).is_none(),
+        "NA with a bad ICMPv6 checksum must not be learned"
+    );
+}
+
+#[test]
+fn parse_ndp_na_2368_rejects_multicast_target() {
+    // RFC 4861 §7.1.2: the Target Address MUST NOT be multicast. Fails if
+    // the multicast-target gate is removed.
+    let f = build_eth_ndp_na_full(false, true, 255, 0, true);
+    assert!(
+        parse_ndp_neighbor_advert(&f).is_none(),
+        "NA with a multicast Target Address must not be learned"
+    );
+}
+
+#[test]
+fn parse_ndp_na_2368_tlla_past_payload_len_not_read() {
+    // #2368 (B): a frame declares payload_len covering ONLY the fixed NA
+    // header (24 bytes, no TLLA), then appends a forged TLLA option in
+    // the Ethernet trailer beyond `40 + payload_len`. The option walk
+    // MUST be bounded by the IPv6-declared packet end, not raw_frame.len(),
+    // so the trailer TLLA is NOT read as a link-layer address.
+    //
+    // Fails (the trailer MAC is learned) if the walk bound reverts to
+    // frame.len().
+    let mut f = build_eth_ndp_na_full(false, false, 255, 0, false); // no TLLA, payload_len=24
+    // The stamped checksum already covers exactly l4..l3+40+24. Append a
+    // forged TLLA option as pure Ethernet trailer (outside payload_len).
+    f.push(NDP_OPT_TARGET_LL);
+    f.push(1);
+    f.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]); // attacker MAC
+    let r = parse_ndp_neighbor_advert(&f).expect("base NA (no in-bounds TLLA) still parses");
+    assert_eq!(
+        r.target_mac, None,
+        "a TLLA option in the trailer beyond payload_len must not be learned"
+    );
+}
+
+#[test]
+fn parse_ndp_na_2368_rejects_payload_len_overrunning_frame() {
+    // A declared payload_len longer than the actual frame must be
+    // rejected (packet_end > raw_frame.len()), never read OOB.
+    let mut f = build_eth_ndp_na_full(false, true, 255, 0, false);
+    // Inflate payload_len well past the real frame length.
+    f[14 + 4..14 + 6].copy_from_slice(&0xffffu16.to_be_bytes());
+    assert!(
+        parse_ndp_neighbor_advert(&f).is_none(),
+        "NA whose declared payload_len overruns the frame must be rejected"
+    );
 }


### PR DESCRIPTION
Closes #2368

## Poisoning vector

`parse_ndp_neighbor_advert` learned a Target Link-Layer Address (TLLA)
into the dynamic-neighbor cache **and** the kernel neighbor table
(`poll_stages.rs::stage_link_layer_classify`) without enforcing any RFC
4861 NA validity, and it walked the NDP options bounded by the raw
Ethernet frame length rather than the IPv6-declared payload. This is a
control-plane MAC->IP write primitive, so untrusted L2/off-link traffic
could poison neighbor state.

**(A) No RFC 4861 §7.1.2 validation.** The parser checked only ICMPv6
type == 136 — never the IPv6 Hop Limit, the ICMPv6 Code, or the ICMPv6
checksum (`payload_len` was read nowhere). §7.1.2 mandates Hop Limit 255
precisely so an off-link sender — whose packet a router must have
forwarded, lowering the hop limit — cannot impersonate an on-link
neighbor. Current behavior (master): `parser.rs` `parse_ndp_neighbor_advert`
accepted any hop limit / code / checksum.

**(B) Option walk bounded by `frame.len()`.** `while opt_off + 2 <=
raw_frame.len()` — a minimum-size frame can declare a payload covering
only the fixed NA header, then place a forged TLLA option in the L2
padding/trailer beyond `40 + payload_len`; that trailer was parsed and
learned (same class as #2361).

## Fix

Entirely in `parse_ndp_neighbor_advert` (fail-closed — the learn site
only learns on `Some(target_mac)`, so all checks live in the parser):

- Compute `packet_end = l3 + 40 + payload_len`; reject if it overruns the
  frame or is shorter than the fixed NA header (mirrors the #2361
  declared-end discipline).
- Require **Hop Limit == 255**, **ICMPv6 Code == 0**, **ICMP length >=
  24**, **Target Address not multicast**, and a **valid ICMPv6
  checksum** — recomputed over the IPv6 pseudo-header + the ICMPv6
  message via the shared one's-complement accumulator
  (`frame::checksum16_add_bytes` / `checksum16_finish`, #2211;
  AVX2-accelerated, bit-identical to the NAT64/forwarding sites).
- Walk options strictly within `packet_end`; an option overrunning it
  stops the walk instead of reading trailing slack.

## NS scope

NA-only. The userspace dataplane has **no Neighbor Solicitation learning
path** (NS is never parsed or learned), so there is no sibling NS gap.

## Composition with #2370

Independent. #2370 concerns the **ifindex KEY** used at the learn site;
this PR touches only **validation** in the parser and does not change the
keying.

## Tests (fail-on-revert, in `parser_tests.rs`)

- `parse_ndp_na_2368_rejects_hop_limit_below_255`
- `parse_ndp_na_2368_rejects_nonzero_code`
- `parse_ndp_na_2368_rejects_bad_checksum`
- `parse_ndp_na_2368_rejects_multicast_target`
- `parse_ndp_na_2368_tlla_past_payload_len_not_read`
- `parse_ndp_na_2368_rejects_payload_len_overrunning_frame`
- `parse_ndp_na_2368_valid_na_still_learns` (anti-over-reject)
- `parse_ndp_na_2368_valid_na_vlan_still_learns` (anti-over-reject)

The existing NDP test builders now stamp a valid ICMPv6 checksum so
legitimate NAs still learn. Verified by reverting the hop-limit gate and
the option-walk bound that the corresponding tests fail.

## Validation

- `cargo build --release` clean.
- Parser tests 25/25 green, 5x stable; targeted suite
  (`ndp neighbor na advertis parser poll_stages`) 729 green.
- Loss-cluster smoke (xpfd boots + forwards + legitimate IPv6 neighbor
  learning) — see PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi