### PR TITLE
afxdp/arp: validate htype/ptype/hlen/plen before learning ARP sender (#2369)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,31 @@
 # Action Log
 
+## 2026-06-23 — #2369 ARP fixed-header validation before neighbor learning
+
+- **Timestamp**: 2026-06-23 PDT
+- **Action**: Security fix (MED, neighbor-cache poisoning). `classify_arp`
+  learned an ARP sender (`sender_mac`/`sender_ip`) from any EtherType-ARP
+  opcode-2 frame with a >=28-byte body, reading the sender at the fixed
+  Ethernet/IPv4 offsets (`l3+8..14` / `l3+14..18`) WITHOUT validating the
+  ARP fixed header. A crafted opcode-2 ARP with htype!=1 / ptype!=0x0800 /
+  hlen!=6 / plen!=4 was parsed at those wrong-for-its-type offsets and the
+  attacker-chosen bytes learned into both `dynamic_neighbors` and the
+  kernel neighbor table — an on-link poisoning primitive (RFC 826: an ARP
+  packet MUST be interpreted per its type/length fields). Fix: before the
+  sender read, require htype==1, ptype==0x0800, hlen==6, plen==4; any
+  mismatch returns `OtherArp` (recycled, never learned), mirroring the
+  #2368 NDP NA fail-closed style. The existing 28-byte body-length guard
+  already bounds the fixed-offset reads (truncated ARP -> NotArp, no
+  panic). Only opcode-2 replies are ever learned (requests classify
+  `OtherArp`). No change to ifindex keying (left for #2370). Tests
+  (fail-on-revert): htype/ptype/hlen/plen each not-learned (verified flips
+  to Reply/poison if the check is removed) + valid Ethernet/IPv4 reply
+  still learns + truncated ARP does not panic. cargo build --release
+  clean; new tests green and 5x stable.
+- **File(s)**: userspace-dp/src/afxdp/parser.rs,
+  userspace-dp/src/afxdp/parser_tests.rs,
+  userspace-dp/src/afxdp/README.md, _Log.md
+
 ## 2026-06-23 — #2398 PR #2420 Copilot fold: symmetric v6/destination SNAT test coverage
 
 - **Timestamp**: 2026-06-23 PDT

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -56,6 +56,19 @@ sync.
   - **NS scope:** there is NO Neighbor Solicitation learning path in the
     userspace dataplane (NS is never parsed or learned), so #2368 is
     NA-only; there is no sibling NS gap to close here.
+  - **ARP fixed-header validation (`#2369`, RFC 826):** the sender MAC
+    (`l3+8..14`) and sender IP (`l3+14..18`) sit at offsets that are only
+    correct for Ethernet/IPv4 ARP. Before reading them, `classify_arp`
+    now requires htype==1 (Ethernet), ptype==0x0800 (IPv4), hlen==6, and
+    plen==4 (in addition to opcode==2 reply and a fully-present 28-byte
+    body). A crafted opcode-2 ARP declaring a different hardware/protocol
+    type or length would otherwise be read at the fixed Ethernet/IPv4
+    offsets and the attacker-chosen bytes learned as a MAC->IP binding —
+    an on-link neighbor-cache/kernel-table poisoning primitive. Any
+    mismatch → `OtherArp` (recycled, never learned), the ARP sibling of
+    the #2368 NA fail-closed discipline. Only opcode-2 replies are ever
+    learned; ARP requests (opcode 1) classify `OtherArp` and never write
+    the cache.
 - `poll_stages.rs` — sibling of `worker/`, not inside it. Holds the
   per-packet pipeline stages extracted in #946 Phase 1. The screen and
   SYN-cookie stages decide the L3 offset (14 vs 18) on tag PRESENCE

--- a/userspace-dp/src/afxdp/parser.rs
+++ b/userspace-dp/src/afxdp/parser.rs
@@ -26,6 +26,17 @@ const ICMPV6_NA_HDR_LEN: usize = 24;
 const NEXT_HEADER_ICMPV6: u8 = 58;
 const ICMPV6_TYPE_NA: u8 = 136;
 const ARP_OP_REPLY: u16 = 2;
+/// ARP hardware type for Ethernet (RFC 826 / IANA). The fixed-offset
+/// read of the sender hardware address is only meaningful when the
+/// hardware type is Ethernet.
+const ARP_HTYPE_ETHERNET: u16 = 1;
+/// ARP protocol type for IPv4 (EtherType 0x0800). The fixed-offset read
+/// of the sender protocol address is only meaningful for IPv4.
+const ARP_PTYPE_IPV4: u16 = 0x0800;
+/// ARP hardware address length for Ethernet (6-byte MAC).
+const ARP_HLEN_ETHERNET: u8 = 6;
+/// ARP protocol address length for IPv4 (4-byte address).
+const ARP_PLEN_IPV4: u8 = 4;
 const NDP_OPT_TARGET_LL: u8 = 2;
 /// RFC 4861 §7.1.2: every NDP message MUST be sent with an IPv6 Hop
 /// Limit of 255 so a receiver can reject any NDP packet whose hop
@@ -82,9 +93,12 @@ pub(super) struct ArpReply {
 pub(super) enum ArpClassification {
     /// Frame is not ARP (or is too short to classify).
     NotArp,
-    /// Frame is ARP but not a reply (e.g. request, RARP, gratuitous
-    /// announcement). Caller should recycle the frame — ARP does not
-    /// transit the firewall — but skip neighbor learning.
+    /// Frame is ARP but not a learnable Ethernet/IPv4 reply (e.g. a
+    /// request, RARP, gratuitous announcement, or — per #2369 — an
+    /// opcode-2 ARP whose fixed header is not Ethernet/IPv4:
+    /// htype!=1, ptype!=0x0800, hlen!=6, or plen!=4). Caller should
+    /// recycle the frame — ARP does not transit the firewall — but skip
+    /// neighbor learning.
     OtherArp,
     /// Frame is an ARP reply with a parsed `(sender_mac, sender_ip)`.
     Reply(ArpReply),
@@ -108,6 +122,28 @@ pub(super) fn classify_arp(raw_frame: &[u8]) -> ArpClassification {
     }
     if raw_frame.len() < l3_start + ARP_BODY_LEN {
         return ArpClassification::NotArp;
+    }
+    // #2369: validate the ARP fixed header BEFORE reading the sender
+    // hardware/protocol addresses. The sender MAC (l3+8..14) and sender IP
+    // (l3+14..18) sit at offsets that are only correct for Ethernet/IPv4
+    // ARP — i.e. when htype==1, ptype==0x0800, hlen==6, plen==4. A crafted
+    // opcode-2 ARP declaring a different hardware/protocol type or length
+    // would otherwise be parsed at these fixed offsets and the resulting
+    // attacker-chosen bytes learned as a MAC->IP binding into both the
+    // userspace `dynamic_neighbors` cache and the kernel neighbor table
+    // (RFC 826: an ARP packet MUST be interpreted per its type/length
+    // fields). Fail closed: any mismatch is treated as a non-learnable ARP
+    // (recycled, never learned), mirroring the #2368 NDP fail-closed style.
+    let htype = u16::from_be_bytes([raw_frame[l3_start], raw_frame[l3_start + 1]]);
+    let ptype = u16::from_be_bytes([raw_frame[l3_start + 2], raw_frame[l3_start + 3]]);
+    let hlen = raw_frame[l3_start + 4];
+    let plen = raw_frame[l3_start + 5];
+    if htype != ARP_HTYPE_ETHERNET
+        || ptype != ARP_PTYPE_IPV4
+        || hlen != ARP_HLEN_ETHERNET
+        || plen != ARP_PLEN_IPV4
+    {
+        return ArpClassification::OtherArp;
     }
     let opcode = u16::from_be_bytes([raw_frame[l3_start + 6], raw_frame[l3_start + 7]]);
     if opcode != ARP_OP_REPLY {

--- a/userspace-dp/src/afxdp/parser_tests.rs
+++ b/userspace-dp/src/afxdp/parser_tests.rs
@@ -77,6 +77,94 @@ fn classify_arp_rejects_short_frame() {
     assert_eq!(classify_arp(&f), ArpClassification::NotArp);
 }
 
+// #2369 fail-on-revert: a crafted opcode-2 ARP whose fixed header is not
+// Ethernet/IPv4 (htype!=1, ptype!=0x0800, hlen!=6, or plen!=4) must NOT
+// be learned — its sender bytes would otherwise be read at the
+// Ethernet/IPv4 fixed offsets and poison the neighbor cache. Each of
+// these MUST flip to `Reply` (poison) if the corresponding header check
+// is removed from `classify_arp`.
+
+#[test]
+fn classify_arp_rejects_non_ethernet_htype() {
+    let mut f = build_eth_arp_reply(false);
+    // htype is at l3_start (offset 14) for an untagged frame. Flip 1 -> 0xfe.
+    f[14] = 0x00;
+    f[15] = 0xfe;
+    assert_eq!(
+        classify_arp(&f),
+        ArpClassification::OtherArp,
+        "opcode-2 ARP with htype!=1 must not be learned (neighbor-cache poison)"
+    );
+}
+
+#[test]
+fn classify_arp_rejects_non_ipv4_ptype() {
+    let mut f = build_eth_arp_reply(false);
+    // ptype is at l3_start+2 (offset 16). Flip 0x0800 -> 0x86dd (IPv6).
+    f[16] = 0x86;
+    f[17] = 0xdd;
+    assert_eq!(
+        classify_arp(&f),
+        ArpClassification::OtherArp,
+        "opcode-2 ARP with ptype!=0x0800 must not be learned"
+    );
+}
+
+#[test]
+fn classify_arp_rejects_bad_hlen() {
+    let mut f = build_eth_arp_reply(false);
+    // hlen is at l3_start+4 (offset 18). Flip 6 -> 8.
+    f[18] = 8;
+    assert_eq!(
+        classify_arp(&f),
+        ArpClassification::OtherArp,
+        "opcode-2 ARP with hlen!=6 must not read sender at the Ethernet offset"
+    );
+}
+
+#[test]
+fn classify_arp_rejects_bad_plen() {
+    let mut f = build_eth_arp_reply(false);
+    // plen is at l3_start+5 (offset 19). Flip 4 -> 16.
+    f[19] = 16;
+    assert_eq!(
+        classify_arp(&f),
+        ArpClassification::OtherArp,
+        "opcode-2 ARP with plen!=4 must not read sender at the IPv4 offset"
+    );
+}
+
+#[test]
+fn classify_arp_valid_reply_still_learns_after_validation() {
+    // Anti-over-reject: a well-formed Ethernet/IPv4 opcode-2 ARP reply
+    // must STILL learn after the #2369 field checks — IPv4 neighbor
+    // resolution depends on this path. Pins that the validation does not
+    // regress legitimate ARP learning.
+    let f = build_eth_arp_reply(false);
+    match classify_arp(&f) {
+        ArpClassification::Reply(r) => {
+            assert_eq!(r.sender_mac, [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+            assert_eq!(r.sender_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 42)));
+        }
+        other => panic!("expected Reply (valid ARP must still learn), got {:?}", other),
+    }
+}
+
+#[test]
+fn classify_arp_truncated_body_does_not_panic() {
+    // A frame with the ARP EtherType but a body shorter than 28 bytes
+    // must classify without an out-of-bounds read/panic. Build a valid
+    // reply and truncate into the ARP body at every length below the
+    // full 28-byte body.
+    let full = build_eth_arp_reply(false);
+    for cut in 14..full.len() {
+        let truncated = &full[..cut];
+        // Must not panic; a too-short body is NotArp (the len guard fires
+        // before any fixed-offset field read).
+        let _ = classify_arp(truncated);
+    }
+}
+
 /// Compute the RFC 4443 ICMPv6 checksum over the message at
 /// `l4_start..packet_end` using the IPv6 pseudo-header taken from the
 /// IPv6 base header at `l3_start`. The on-wire checksum field


### PR DESCRIPTION
Closes #2369

## Poisoning vector

`classify_arp` (`userspace-dp/src/afxdp/parser.rs`) learned an ARP sender
(`sender_mac`, `sender_ip`) from any EtherType-ARP opcode-2 frame with a
`>= 28`-byte body, reading the sender hardware address at `l3+8..14` and
the sender protocol address at `l3+14..18`. Those are the **fixed
Ethernet/IPv4 ARP offsets** and are only correct when the ARP fixed
header declares Ethernet/IPv4: `htype==1`, `ptype==0x0800`, `hlen==6`,
`plen==4`. The parser never validated those fields.

A hostile on-link peer could craft an opcode-2 ARP declaring a different
hardware/protocol type or address length while still carrying a `>= 28`
byte body. `classify_arp` parsed it at the Ethernet/IPv4 offsets anyway,
and the resulting attacker-chosen bytes were learned as a MAC->IP binding
into **both** the userspace `dynamic_neighbors` cache and the **kernel
neighbor table** (`stage_link_layer_classify` in `poll_stages.rs` is a
control-plane MAC->IP write primitive). RFC 826 requires an ARP packet to
be interpreted per its hardware/protocol type and length fields — reading
from fixed offsets without confirming them gives a cheap neighbor-cache
poisoning vector (MED).

## Fix

Before reading the sender addresses, require `htype==1 && ptype==0x0800
&& hlen==6 && plen==4` (in addition to the existing `opcode==2` reply and
fully-present 28-byte-body checks). Any mismatch returns `OtherArp`
(recycled, never learned) — **fail closed**. The pre-existing
`l3 + ARP_BODY_LEN` length guard already bounds every fixed-offset read,
so a truncated ARP classifies as `NotArp` without an out-of-bounds read
or panic. Only opcode-2 replies are ever learned; ARP requests (opcode 1)
classify `OtherArp` and never write the cache. The ifindex keying at the
learn site is unchanged (left to #2370).

## Consistency with #2368

This is the ARP sibling of the just-merged #2368 NDP NA validation (RFC
4861 §7.1.2) in the same `parser.rs`. Same fail-closed discipline:
validate the control-plane learning shape's fixed header before reading
the MAC->IP binding, learn nothing on any failed check.

## Fail-on-revert tests

`userspace-dp/src/afxdp/parser_tests.rs`:
- `classify_arp_rejects_non_ethernet_htype` — opcode-2 ARP with `htype!=1` not learned
- `classify_arp_rejects_non_ipv4_ptype` — `ptype!=0x0800` not learned
- `classify_arp_rejects_bad_hlen` — `hlen!=6` not learned (no sender read at wrong offset)
- `classify_arp_rejects_bad_plen` — `plen!=4` not learned

Each was verified to **flip back to a learned `Reply` (the poison
outcome)** when its field check is removed from `classify_arp`. Plus:
- `classify_arp_valid_reply_still_learns_after_validation` — anti-over-reject
- `classify_arp_truncated_body_does_not_panic` — fuzz every body length below 28

## Validation

- `cargo build --release` clean (pre-existing warnings only).
- `cargo test --release` ARP/parser/neighbor/poll_stages green; new tests 5x stable.
- Loss userspace cluster smoke (deployed both nodes, verify-dataplane gate passed):
  both nodes `active`; IPv4 transit **8.45 Gbit/s, 0 drops**, 6M packets
  forwarded; the iperf3 target `172.16.80.200` and LAN host `10.0.61.102`
  both present in the neighbor cache with valid MACs — legitimate
  Ethernet/IPv4 ARP learning is NOT regressed (anti-over-reject gate).

No wire field changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi