### PR TITLE
afxdp/neighbor: key learned ARP/NDP neighbors by logical VLAN ifindex (#2370)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11530,3 +11530,28 @@ top.
     273 green, no regression.
 - **File(s)**: userspace-dp/src/afxdp/poll_stages.rs,
     userspace-dp/src/afxdp/README.md, _Log.md
+- **Timestamp**: 2026-06-23 07:20
+- **Action**: #2370 review fold (PR #2425) — three reviewer items.
+    (1) PRIMARY hot-path: `stage_link_layer_classify` runs per-packet for
+    ALL ingress traffic (before the flow-cache fast path). The #2370 fix
+    initially computed `resolve_ingress_logical_ifindex` UNCONDITIONALLY at
+    the top, so every non-ARP/non-NDP packet (the overwhelming majority,
+    incl. flow-cache hits) paid an avoidable FastMap lookup. Moved the
+    resolve into a `learn_ifindex` closure called ONLY inside the ARP-reply
+    and NDP-NA learn arms — a non-ARP/non-NDP packet (classify_arp ==
+    NotArp, parse_ndp_neighbor_advert == None) never invokes it, restoring
+    the pre-#2370 zero-cost data path. Learn-path result is identical (same
+    logical key); the VLAN fail-on-revert tests still prove it (3 fail on
+    revert, untagged green). (2) Test drift: factored the duplicated
+    ICMPv6 checksum stamper into one shared
+    `afxdp::test_fixtures::{compute_icmpv6_checksum, stamp_icmpv6_checksum}`
+    and switched both parser_tests.rs (#2368 NA frames) and poll_stages.rs
+    (#2370 NDP frame) to it. (3) Doc fix: `neighbor_learn_ctx` `Box::leak`
+    comment corrected — the leak is NOT one-shot; it accumulates (bounded,
+    test-only) across the many tests in one test-binary process.
+    cargo build --release clean; poll_stages 6/6, parser 31/31, combined
+    neighbor/dynamic/ifindex/vlan/poll_stages/forwarding 300 green; 5x
+    stable. No wire change.
+- **File(s)**: userspace-dp/src/afxdp/poll_stages.rs,
+    userspace-dp/src/afxdp/parser_tests.rs,
+    userspace-dp/src/afxdp/test_fixtures.rs, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -11505,3 +11505,28 @@ top.
 - **File(s)**: userspace-dp/src/afxdp/parser.rs,
     userspace-dp/src/afxdp/parser_tests.rs,
     userspace-dp/src/afxdp/README.md, _Log.md
+- **Timestamp**: 2026-06-23 06:39
+- **Action**: #2370 — key learned ARP/NDP dynamic neighbors by the LOGICAL
+    (VLAN sub-interface) ifindex, not the physical/parent ingress ifindex.
+    `stage_link_layer_classify` inserted dynamic neighbors under
+    `meta.ingress_ifindex` (physical) while the forwarder
+    (`lookup_neighbor_entry`) probes them by the connected-route LOGICAL
+    ifindex (`forwarding_build/interfaces.rs` stores routes under
+    `iface.ifindex`). On a VLAN sub-interface physical != logical, so the
+    just-learned entry was missed → MissingNeighbor cold path + first-packet
+    latency until the kernel neighbor resolved (kernel entry was already keyed
+    correctly via `add_kernel_neighbor`, which used the logical ifindex). Fix:
+    hoist `resolve_ingress_logical_ifindex(parent, vlan)` to the top of the
+    stage and key BOTH the `dynamic_neighbors.insert` and `add_kernel_neighbor`
+    under that single `learn_ifindex`. Untagged interfaces resolve
+    physical==logical (unchanged); unmatched physical port falls back to the
+    physical ifindex (no drop); two VLANs on one parent get distinct logical
+    keys (no same-IP collision). 4 new tests in poll_stages: VLAN ARP learns
+    under logical 12 (fail-on-revert), untagged learns under 24 unchanged, two
+    VLANs same-IP distinct logical keys (12 vs 13, no collapse to 11), valid
+    NDP NA VLAN learns under logical 12. Revert-to-physical proven to FAIL the
+    3 VLAN tests while the untagged one stays green. cargo build --release
+    clean; 6 poll_stages tests green, 5x stable; neighbor/forwarding suites
+    273 green, no regression.
+- **File(s)**: userspace-dp/src/afxdp/poll_stages.rs,
+    userspace-dp/src/afxdp/README.md, _Log.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -37,6 +37,25 @@ sync.
   `(ifindex, ip) -> mac` binding into `dynamic_neighbors` AND the kernel
   neighbor table, so these parsers are a MAC->IP write primitive — they
   MUST fail closed on untrusted input.
+  - **Logical-ifindex keying (`#2370`):** the `ifindex` in that
+    `(ifindex, ip)` key is the LOGICAL (L3) ifindex, NOT the physical
+    ingress port. For a frame arriving on a VLAN sub-interface,
+    `meta.ingress_ifindex` is the parent/bind port and
+    `meta.ingress_vlan_id` selects the logical interface;
+    `stage_link_layer_classify` resolves `(parent, vlan) -> logical` once
+    via `resolve_ingress_logical_ifindex` and keys BOTH the
+    `dynamic_neighbors` insert and `add_kernel_neighbor` under it. This
+    matches the forwarder, which looks up neighbors by the connected-route
+    (logical) ifindex (`lookup_neighbor_entry`; routes are stored under
+    `iface.ifindex` in `forwarding_build/interfaces.rs`). Keying the
+    insert by the physical parent (the pre-#2370 bug) made the just-learned
+    entry invisible to the lookup on VLAN sub-interfaces → an avoidable
+    MissingNeighbor cold-path probe and first-packet latency. Untagged
+    interfaces resolve physical == logical (unchanged); a physical port
+    with no matching logical sub-interface falls back to the physical
+    ifindex (no drop). Two VLANs on one physical port resolve to distinct
+    logical ifindexes, so a same-IP-different-subnet neighbor never
+    collides in the cache.
   - **NA validation (`#2368`, RFC 4861 §7.1.2 / RFC 4443):** before an
     NA learns a Target Link-Layer Address, `parse_ndp_neighbor_advert`
     enforces the §7.1.2 MUSTs — IPv6 Hop Limit == 255 (the off-link

--- a/userspace-dp/src/afxdp/parser_tests.rs
+++ b/userspace-dp/src/afxdp/parser_tests.rs
@@ -165,47 +165,10 @@ fn classify_arp_truncated_body_does_not_panic() {
     }
 }
 
-/// Compute the RFC 4443 ICMPv6 checksum over the message at
-/// `l4_start..packet_end` using the IPv6 pseudo-header taken from the
-/// IPv6 base header at `l3_start`. The on-wire checksum field
-/// (`l4_start + 2..l4_start + 4`) is treated as zero for the
-/// computation. Used by the test builders to stamp a VALID checksum so
-/// the #2368 §7.1.2 validation accepts a legitimate NA.
-fn compute_icmpv6_checksum(frame: &[u8], l3_start: usize, l4_start: usize, packet_end: usize) -> u16 {
-    let mut sum: u32 = 0;
-    let add = |sum: &mut u32, bytes: &[u8]| {
-        let mut i = 0;
-        while i + 1 < bytes.len() {
-            *sum += u16::from_be_bytes([bytes[i], bytes[i + 1]]) as u32;
-            i += 2;
-        }
-        if i < bytes.len() {
-            *sum += (bytes[i] as u32) << 8;
-        }
-    };
-    // pseudo-header: src(16) + dst(16) + len(32) + [0,0,0,58]
-    add(&mut sum, &frame[l3_start + 8..l3_start + 24]);
-    add(&mut sum, &frame[l3_start + 24..l3_start + 40]);
-    let icmp_len = (packet_end - l4_start) as u32;
-    add(&mut sum, &icmp_len.to_be_bytes());
-    add(&mut sum, &[0, 0, 0, NEXT_HEADER_ICMPV6]);
-    // ICMPv6 message with the checksum field zeroed.
-    let mut icmp = frame[l4_start..packet_end].to_vec();
-    icmp[2] = 0;
-    icmp[3] = 0;
-    add(&mut sum, &icmp);
-    while (sum >> 16) != 0 {
-        sum = (sum & 0xffff) + (sum >> 16);
-    }
-    !(sum as u16)
-}
-
-/// Stamp a valid ICMPv6 checksum into `frame` in place (l4 at `l4_start`,
-/// declared packet end at `packet_end`, IPv6 base header at `l3_start`).
-fn stamp_icmpv6_checksum(frame: &mut [u8], l3_start: usize, l4_start: usize, packet_end: usize) {
-    let csum = compute_icmpv6_checksum(frame, l3_start, l4_start, packet_end);
-    frame[l4_start + 2..l4_start + 4].copy_from_slice(&csum.to_be_bytes());
-}
+// ICMPv6 checksum stamping is shared with the poll_stages #2370 tests via
+// `afxdp::test_fixtures::stamp_icmpv6_checksum` (single source of truth so
+// the pseudo-header / fold logic cannot drift between the two test sites).
+use super::super::test_fixtures::stamp_icmpv6_checksum;
 
 fn build_eth_ndp_na(vlan: bool, with_tlla: bool) -> Vec<u8> {
     build_eth_ndp_na_full(vlan, with_tlla, 255, 0, false)

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -85,7 +85,7 @@ pub(super) fn stage_link_layer_classify(
     // and `meta.ingress_vlan_id` selects the logical interface;
     // resolving (parent, vlan) -> logical makes the insert key match the
     // lookup key, so the just-learned entry is found instead of falling
-    // through to the MissingNeighbor cold path. The SAME `learn_ifindex`
+    // through to the MissingNeighbor cold path. The SAME logical ifindex
     // keys `add_kernel_neighbor` too (already correct before this fix).
     // For untagged / non-VLAN interfaces the mapping resolves
     // physical == logical, so behavior is unchanged; if no logical
@@ -93,21 +93,31 @@ pub(super) fn stage_link_layer_classify(
     // dropping the learned neighbor. Two VLANs sharing a physical port
     // resolve to distinct logical ifindexes (distinct (parent, vlan)
     // keys), so a same-IP-different-subnet neighbor never collides.
-    let learn_ifindex = resolve_ingress_logical_ifindex(
-        worker_ctx.forwarding,
-        meta.ingress_ifindex as i32,
-        meta.ingress_vlan_id,
-    )
-    .unwrap_or(meta.ingress_ifindex as i32);
+    //
+    // The resolve is computed ONLY inside the ARP-reply / NDP-NA learn
+    // arms below, NOT at the top of the stage. This stage runs per-packet
+    // for ALL ingress traffic (before the flow-cache fast path), so the
+    // overwhelming majority of packets (every non-ARP/non-NDP frame,
+    // including flow-cache hits) must skip the FastMap lookup entirely —
+    // they pay zero resolve cost, matching the pre-#2370 data path.
+    let learn_ifindex = || {
+        resolve_ingress_logical_ifindex(
+            worker_ctx.forwarding,
+            meta.ingress_ifindex as i32,
+            meta.ingress_vlan_id,
+        )
+        .unwrap_or(meta.ingress_ifindex as i32)
+    };
     match parser::classify_arp(raw_frame) {
         parser::ArpClassification::Reply(arp) => {
+            let ifindex = learn_ifindex();
             worker_ctx.dynamic_neighbors.insert(
-                (learn_ifindex, arp.sender_ip),
+                (ifindex, arp.sender_ip),
                 NeighborEntry {
                     mac: arp.sender_mac,
                 },
             );
-            add_kernel_neighbor(learn_ifindex, arp.sender_ip, arp.sender_mac);
+            add_kernel_neighbor(ifindex, arp.sender_ip, arp.sender_mac);
             return StageOutcome::RecycleAndContinue;
         }
         parser::ArpClassification::OtherArp => {
@@ -118,10 +128,11 @@ pub(super) fn stage_link_layer_classify(
     if let Some(na) = parser::parse_ndp_neighbor_advert(raw_frame)
         && let Some(mac) = na.target_mac
     {
+        let ifindex = learn_ifindex();
         worker_ctx
             .dynamic_neighbors
-            .insert((learn_ifindex, na.target_ip), NeighborEntry { mac });
-        add_kernel_neighbor(learn_ifindex, na.target_ip, mac);
+            .insert((ifindex, na.target_ip), NeighborEntry { mac });
+        add_kernel_neighbor(ifindex, na.target_ip, mac);
     }
     StageOutcome::Continue(())
 }
@@ -1102,10 +1113,16 @@ mod tests {
 
     /// Build a `WorkerContext` over the supplied forwarding state and a
     /// fresh empty dynamic-neighbor map, returning the map so the test
-    /// can assert the key the stage inserted under. The boxed values are
-    /// leaked: each test runs once and the process exits, so this trades
-    /// a tiny one-shot leak for a borrow-friendly `'static` context that
-    /// avoids threading a dozen owned locals through every call site.
+    /// can assert the key the stage inserted under.
+    ///
+    /// The boxed values are intentionally `Box::leak`'d to obtain the
+    /// `&'static` borrows the `WorkerContext<'a>` shape requires, instead
+    /// of threading a dozen owned locals through every call site. The
+    /// leak is NOT one-shot: a single test binary runs many tests in one
+    /// process, so each `neighbor_learn_ctx` call adds a small, bounded
+    /// allocation that persists for the test-binary lifetime. This is
+    /// test-only and the per-call footprint is tiny (a handful of empty
+    /// maps + the context struct), so the accumulation is harmless.
     fn neighbor_learn_ctx(
         forwarding: &'static ForwardingState,
     ) -> (&'static WorkerContext<'static>, Arc<ShardedNeighborMap>) {
@@ -1423,45 +1440,11 @@ mod tests {
         f.push(1);
         f.extend_from_slice(&target_mac);
         let packet_end = l3_start + 40 + payload_len as usize;
-        let csum = compute_icmpv6_checksum_local(&f, l3_start, l4_start, packet_end);
-        f[l4_start + 2..l4_start + 4].copy_from_slice(&csum.to_be_bytes());
+        // Shared stamper (single source of truth, also used by the #2368
+        // parser tests) — the strict NA parser requires a valid checksum.
+        super::super::test_fixtures::stamp_icmpv6_checksum(
+            &mut f, l3_start, l4_start, packet_end,
+        );
         (f, IpAddr::V6(Ipv6Addr::from(target_bytes)), target_mac)
-    }
-
-    /// One's-complement ICMPv6 checksum over the IPv6 pseudo-header +
-    /// the ICMPv6 message (`l4_start..packet_end`). Local copy mirroring
-    /// the parser-test stamper so the strict NA parser accepts the frame.
-    fn compute_icmpv6_checksum_local(
-        frame: &[u8],
-        l3_start: usize,
-        l4_start: usize,
-        packet_end: usize,
-    ) -> u16 {
-        let mut sum: u32 = 0;
-        let mut add = |bytes: &[u8]| {
-            let mut i = 0;
-            while i + 1 < bytes.len() {
-                sum += u16::from_be_bytes([bytes[i], bytes[i + 1]]) as u32;
-                i += 2;
-            }
-            if i < bytes.len() {
-                sum += (bytes[i] as u32) << 8;
-            }
-        };
-        // Pseudo-header: src(16) + dst(16) + upper-len(4) + zeros(3) + nh(1).
-        add(&frame[l3_start + 8..l3_start + 24]); // src
-        add(&frame[l3_start + 24..l3_start + 40]); // dst
-        let upper_len = (packet_end - l4_start) as u32;
-        add(&upper_len.to_be_bytes());
-        add(&[0, 0, 0, 58]);
-        // ICMPv6 message with checksum field zeroed.
-        let mut icmp = frame[l4_start..packet_end].to_vec();
-        icmp[2] = 0;
-        icmp[3] = 0;
-        add(&icmp);
-        while (sum >> 16) != 0 {
-            sum = (sum & 0xffff) + (sum >> 16);
-        }
-        !(sum as u16)
     }
 }

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -75,21 +75,39 @@ pub(super) fn stage_link_layer_classify(
     meta: UserspaceDpMeta,
     worker_ctx: &WorkerContext,
 ) -> StageOutcome<()> {
+    // #2370: learn dynamic neighbors under the LOGICAL (L3) ifindex,
+    // not the physical/parent ingress ifindex. The forwarder looks up
+    // dynamic neighbors keyed by the connected-route ifindex, which is
+    // the logical VLAN sub-interface (see `lookup_neighbor_entry` and
+    // `forwarding_build/interfaces.rs` `ConnectedRouteV4/V6 { ifindex:
+    // iface.ifindex }`). For an ARP/NDP frame arriving on a VLAN
+    // sub-interface, `meta.ingress_ifindex` is the parent/bind ifindex
+    // and `meta.ingress_vlan_id` selects the logical interface;
+    // resolving (parent, vlan) -> logical makes the insert key match the
+    // lookup key, so the just-learned entry is found instead of falling
+    // through to the MissingNeighbor cold path. The SAME `learn_ifindex`
+    // keys `add_kernel_neighbor` too (already correct before this fix).
+    // For untagged / non-VLAN interfaces the mapping resolves
+    // physical == logical, so behavior is unchanged; if no logical
+    // interface matches we fall back to the physical ifindex rather than
+    // dropping the learned neighbor. Two VLANs sharing a physical port
+    // resolve to distinct logical ifindexes (distinct (parent, vlan)
+    // keys), so a same-IP-different-subnet neighbor never collides.
+    let learn_ifindex = resolve_ingress_logical_ifindex(
+        worker_ctx.forwarding,
+        meta.ingress_ifindex as i32,
+        meta.ingress_vlan_id,
+    )
+    .unwrap_or(meta.ingress_ifindex as i32);
     match parser::classify_arp(raw_frame) {
         parser::ArpClassification::Reply(arp) => {
             worker_ctx.dynamic_neighbors.insert(
-                (meta.ingress_ifindex as i32, arp.sender_ip),
+                (learn_ifindex, arp.sender_ip),
                 NeighborEntry {
                     mac: arp.sender_mac,
                 },
             );
-            let neigh_ifindex = resolve_ingress_logical_ifindex(
-                worker_ctx.forwarding,
-                meta.ingress_ifindex as i32,
-                meta.ingress_vlan_id,
-            )
-            .unwrap_or(meta.ingress_ifindex as i32);
-            add_kernel_neighbor(neigh_ifindex, arp.sender_ip, arp.sender_mac);
+            add_kernel_neighbor(learn_ifindex, arp.sender_ip, arp.sender_mac);
             return StageOutcome::RecycleAndContinue;
         }
         parser::ArpClassification::OtherArp => {
@@ -100,17 +118,10 @@ pub(super) fn stage_link_layer_classify(
     if let Some(na) = parser::parse_ndp_neighbor_advert(raw_frame)
         && let Some(mac) = na.target_mac
     {
-        worker_ctx.dynamic_neighbors.insert(
-            (meta.ingress_ifindex as i32, na.target_ip),
-            NeighborEntry { mac },
-        );
-        let neigh_ifindex = resolve_ingress_logical_ifindex(
-            worker_ctx.forwarding,
-            meta.ingress_ifindex as i32,
-            meta.ingress_vlan_id,
-        )
-        .unwrap_or(meta.ingress_ifindex as i32);
-        add_kernel_neighbor(neigh_ifindex, na.target_ip, mac);
+        worker_ctx
+            .dynamic_neighbors
+            .insert((learn_ifindex, na.target_ip), NeighborEntry { mac });
+        add_kernel_neighbor(learn_ifindex, na.target_ip, mac);
     }
     StageOutcome::Continue(())
 }
@@ -177,9 +188,7 @@ pub(super) fn stage_parse_flow_and_learn(
     worker_ctx: &WorkerContext,
 ) -> Option<SessionFlow> {
     let flow = parse_session_flow_from_bytes(packet_frame, meta);
-    if learn_from_live_frame
-        && let Some(flow) = flow.as_ref()
-    {
+    if learn_from_live_frame && let Some(flow) = flow.as_ref() {
         learn_dynamic_neighbor_from_packet(
             area,
             desc,
@@ -281,7 +290,11 @@ pub(super) fn stage_screen_check(
     // #2145 misclassification. `ingress_vlan_present` is the
     // tag-presence signal the shim already sets (mirrors the CoS path
     // in tx/cos_classify.rs).
-    let l3_off = if meta.ingress_vlan_present != 0 { 18 } else { 14 };
+    let l3_off = if meta.ingress_vlan_present != 0 {
+        18
+    } else {
+        14
+    };
     let screen_pkt = match extract_screen_info(
         packet_frame,
         meta.addr_family,
@@ -408,7 +421,11 @@ pub(super) fn stage_screen_syn_cookie_ack_on_session_miss(
     // See `stage_screen_check`: decide L3 offset on tag PRESENCE, not
     // VID > 0, so a priority-tagged VID-0 cookie ACK is parsed at the
     // correct offset (18) instead of mis-reading the tag bytes (#2145).
-    let l3_off = if meta.ingress_vlan_present != 0 { 18 } else { 14 };
+    let l3_off = if meta.ingress_vlan_present != 0 {
+        18
+    } else {
+        14
+    };
     let screen_pkt = match extract_screen_info(
         packet_frame,
         meta.addr_family,
@@ -745,7 +762,7 @@ mod tests {
             peer_worker_commands: &peer_worker_commands,
             dnat_fds: &dnat_fds,
             rg_epochs: &rg_epochs,
-        cold_path_sample_mask: 0xff,
+            cold_path_sample_mask: 0xff,
         };
 
         let client = Ipv4Addr::new(192, 0, 2, 10);
@@ -782,19 +799,11 @@ mod tests {
             other => panic!("expected SYN-cookie challenge, got {other:?}"),
         };
 
-        let invalid_ack_frame = tcp_v4_frame(
-            client,
-            server,
-            49152,
-            443,
-            TCP_FLAG_ACK,
-            2,
-            0xdead_beef,
-        );
+        let invalid_ack_frame =
+            tcp_v4_frame(client, server, 49152, 443, TCP_FLAG_ACK, 2, 0xdead_beef);
         let invalid_ack_meta = tcp_v4_meta(&invalid_ack_frame, TCP_FLAG_ACK);
-        let invalid_ack_flow =
-            parse_session_flow_from_bytes(&invalid_ack_frame, invalid_ack_meta)
-                .expect("session flow from invalid ACK");
+        let invalid_ack_flow = parse_session_flow_from_bytes(&invalid_ack_frame, invalid_ack_meta)
+            .expect("session flow from invalid ACK");
         let mut invalid_counters = BatchCounters::default();
 
         assert!(matches!(
@@ -1046,8 +1055,7 @@ mod tests {
             // field at 38+8=46.
             f[51] = TCP_FLAG_ACK;
             f[46..50].copy_from_slice(&challenge.cookie_isn.wrapping_add(1).to_be_bytes());
-            recompute_l4_checksum_ipv4(&mut f[18..], 20, PROTO_TCP, false)
-                .expect("tcp checksum");
+            recompute_l4_checksum_ipv4(&mut f[18..], 20, PROTO_TCP, false).expect("tcp checksum");
             f
         };
         let ack_meta = tcp_v4_syn_meta_with_l2(&ack_frame, Vlan::PriorityTagged);
@@ -1084,5 +1092,376 @@ mod tests {
             counters.syn_cookie_ack_valid, 1,
             "the tagged cookie ACK must validate exactly once"
         );
+    }
+
+    // ===================================================================
+    // #2370 — learned dynamic neighbors must be keyed by the LOGICAL
+    // (L3 / VLAN sub-interface) ifindex the forwarder looks them up by,
+    // not the physical/parent ingress ifindex they arrived on.
+    // ===================================================================
+
+    /// Build a `WorkerContext` over the supplied forwarding state and a
+    /// fresh empty dynamic-neighbor map, returning the map so the test
+    /// can assert the key the stage inserted under. The boxed values are
+    /// leaked: each test runs once and the process exits, so this trades
+    /// a tiny one-shot leak for a borrow-friendly `'static` context that
+    /// avoids threading a dozen owned locals through every call site.
+    fn neighbor_learn_ctx(
+        forwarding: &'static ForwardingState,
+    ) -> (&'static WorkerContext<'static>, Arc<ShardedNeighborMap>) {
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+        let ident = Box::leak(Box::new(BindingIdentity {
+            slot: 0,
+            queue_id: 0,
+            worker_id: 0,
+            interface: Arc::<str>::from("ge-0-0-0"),
+            ifindex: 11,
+        }));
+        let binding_lookup = Box::leak(Box::new(WorkerBindingLookup::default()));
+        let mirror_targets = Box::leak(Box::new(MirrorTargetMap::default()));
+        let ha_state = Box::leak(Box::new(BTreeMap::new()));
+        let dynamic_neighbors_ref =
+            Box::leak(Box::new(dynamic_neighbors.clone())) as &'static Arc<_>;
+        let shared_sessions = Box::leak(Box::new(Arc::new(Mutex::new(FastMap::default()))));
+        let shared_nat_sessions = Box::leak(Box::new(Arc::new(Mutex::new(FastMap::default()))));
+        let shared_forward_wire_sessions =
+            Box::leak(Box::new(Arc::new(Mutex::new(FastMap::default()))));
+        let shared_owner_rg_indexes = Box::leak(Box::new(SharedSessionOwnerRgIndexes::default()));
+        let local_tunnel_deliveries =
+            Box::leak(Box::new(Arc::new(ArcSwap::from_pointee(BTreeMap::new()))));
+        let recent_exceptions = Box::leak(Box::new(Arc::new(Mutex::new(VecDeque::new()))));
+        let last_resolution = Box::leak(Box::new(Arc::new(Mutex::new(None))));
+        let peer_worker_commands = Box::leak(Box::new(Vec::new()));
+        let dnat_fds = Box::leak(Box::new(DnatTableFds::default()));
+        let rg_epochs = Box::leak(Box::new(std::array::from_fn(|_| AtomicU32::new(0))));
+        let ctx = Box::leak(Box::new(WorkerContext {
+            ident,
+            binding_lookup,
+            mirror_targets,
+            forwarding,
+            ha_state,
+            dynamic_neighbors: dynamic_neighbors_ref,
+            neighbor_resolver: None,
+            shared_sessions,
+            shared_nat_sessions,
+            shared_forward_wire_sessions,
+            shared_owner_rg_indexes,
+            slow_path: None,
+            event_stream: None,
+            local_tunnel_deliveries,
+            recent_exceptions,
+            last_resolution,
+            peer_worker_commands,
+            dnat_fds,
+            rg_epochs,
+            cold_path_sample_mask: 0xff,
+        }));
+        (ctx, dynamic_neighbors)
+    }
+
+    /// ARP reply frame (untagged) with a configurable sender IP. The
+    /// stage classifies it as `Reply` and learns `(learn_ifindex,
+    /// sender_ip) -> sender_mac`.
+    fn arp_reply_frame(sender_ip: Ipv4Addr, sender_mac: [u8; 6]) -> Vec<u8> {
+        let mut f = Vec::new();
+        f.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]); // dst
+        f.extend_from_slice(&sender_mac); // src
+        f.extend_from_slice(&[0x08, 0x06]); // ethertype ARP
+        // htype=1, ptype=0x0800, hlen=6, plen=4, op=2 (reply)
+        f.extend_from_slice(&[0x00, 0x01, 0x08, 0x00, 0x06, 0x04, 0x00, 0x02]);
+        f.extend_from_slice(&sender_mac); // sender mac
+        f.extend_from_slice(&sender_ip.octets()); // sender ip
+        f.extend_from_slice(&[0x00; 6]); // target mac
+        f.extend_from_slice(&[10, 0, 0, 1]); // target ip
+        f
+    }
+
+    /// Meta for a frame arriving on physical ifindex `parent` with the
+    /// given `vlan` (0 = untagged). Only the fields the link-layer stage
+    /// reads (`ingress_ifindex`, `ingress_vlan_id`) matter here.
+    fn link_layer_meta(parent: u32, vlan: u16) -> UserspaceDpMeta {
+        UserspaceDpMeta {
+            magic: USERSPACE_META_MAGIC,
+            version: USERSPACE_META_VERSION,
+            length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+            ingress_ifindex: parent,
+            ingress_vlan_id: vlan,
+            ingress_vlan_present: (vlan != 0) as u8,
+            l3_offset: 14,
+            ..UserspaceDpMeta::default()
+        }
+    }
+
+    /// #2370 fail-on-revert (ARP, VLAN sub-interface). The `nat_snapshot`
+    /// fixture defines `reth0.80` as logical ifindex 12 on parent
+    /// ifindex 11 / VLAN 80. An ARP reply arriving on (parent=11,
+    /// vlan=80) MUST be learned under the LOGICAL ifindex 12 — the key
+    /// the forwarder's connected-route lookup uses — NOT the physical
+    /// ifindex 11. If the insert reverts to `meta.ingress_ifindex` the
+    /// entry lands under (11, ip), `lookup_neighbor_entry` (which probes
+    /// the logical ifindex 12) misses, and these asserts fail.
+    #[test]
+    fn arp_learns_vlan_neighbor_under_logical_ifindex_2370() {
+        let forwarding: &'static ForwardingState = Box::leak(Box::new(build_forwarding_state(
+            &super::super::test_fixtures::nat_snapshot(),
+        )));
+        let (ctx, neighbors) = neighbor_learn_ctx(forwarding);
+
+        let sender_ip = Ipv4Addr::new(172, 16, 80, 9);
+        let sender_mac = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x09];
+        let frame = arp_reply_frame(sender_ip, sender_mac);
+        let meta = link_layer_meta(11, 80);
+
+        // Sanity: the fixture really maps (parent=11, vlan=80) -> 12.
+        assert_eq!(
+            resolve_ingress_logical_ifindex(forwarding, 11, 80),
+            Some(12),
+            "fixture must map parent ifindex 11 / VLAN 80 to logical 12"
+        );
+
+        let outcome = stage_link_layer_classify(&frame, meta, ctx);
+        assert!(matches!(outcome, StageOutcome::RecycleAndContinue));
+
+        // The forwarder looks up by the logical (route egress) ifindex.
+        let found = lookup_neighbor_entry(
+            forwarding,
+            Some(&neighbors),
+            12, // logical ifindex (reth0.80)
+            IpAddr::V4(sender_ip),
+        );
+        assert_eq!(
+            found.map(|e| e.mac),
+            Some(sender_mac),
+            "ARP learned on a VLAN sub-interface must be found by the \
+             forwarder's LOGICAL-ifindex (12) lookup (#2370); a physical \
+             ifindex (11) key would miss here"
+        );
+        // And it must NOT have landed under the physical/parent ifindex.
+        assert!(
+            neighbors.get(&(11, IpAddr::V4(sender_ip))).is_none(),
+            "the learned entry must not be keyed by the physical/parent \
+             ifindex 11 (the bug); only the logical ifindex 12"
+        );
+    }
+
+    /// #2370 — a non-VLAN (physical == logical) ARP neighbor still
+    /// learns under the interface ifindex unchanged. `reth1.0` in the
+    /// fixture has ifindex 24 and no parent (untagged), so
+    /// `resolve_ingress_logical_ifindex(24, 0)` resolves to 24 and the
+    /// learn key equals the lookup key.
+    #[test]
+    fn arp_learns_untagged_neighbor_under_same_ifindex_2370() {
+        let forwarding: &'static ForwardingState = Box::leak(Box::new(build_forwarding_state(
+            &super::super::test_fixtures::nat_snapshot(),
+        )));
+        let (ctx, neighbors) = neighbor_learn_ctx(forwarding);
+
+        let sender_ip = Ipv4Addr::new(10, 0, 61, 50);
+        let sender_mac = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x18];
+        let frame = arp_reply_frame(sender_ip, sender_mac);
+        let meta = link_layer_meta(24, 0);
+
+        let outcome = stage_link_layer_classify(&frame, meta, ctx);
+        assert!(matches!(outcome, StageOutcome::RecycleAndContinue));
+
+        let found = lookup_neighbor_entry(forwarding, Some(&neighbors), 24, IpAddr::V4(sender_ip));
+        assert_eq!(
+            found.map(|e| e.mac),
+            Some(sender_mac),
+            "untagged ARP must learn under the (logical==physical) ifindex 24"
+        );
+    }
+
+    /// #2370 multi-VLAN no-collision. Two VLAN sub-interfaces (VID 80 and
+    /// VID 50) share ONE physical parent (ifindex 11) but own distinct
+    /// logical ifindexes (12 and 13) in different subnets. The SAME
+    /// neighbor IP learned on each VLAN must land under DISTINCT keys
+    /// (12, ip) and (13, ip) — proving the logical-ifindex key keeps
+    /// them apart. Keying by the shared physical ifindex would collapse
+    /// both into (11, ip) and the second learn would overwrite the
+    /// first, corrupting one VLAN's neighbor entry.
+    #[test]
+    fn arp_two_vlans_same_ip_distinct_logical_keys_2370() {
+        let forwarding: &'static ForwardingState =
+            Box::leak(Box::new(build_forwarding_state(&two_vlan_snapshot())));
+        let (ctx, neighbors) = neighbor_learn_ctx(forwarding);
+
+        assert_eq!(
+            resolve_ingress_logical_ifindex(forwarding, 11, 80),
+            Some(12),
+            "parent 11 / VLAN 80 -> logical 12"
+        );
+        assert_eq!(
+            resolve_ingress_logical_ifindex(forwarding, 11, 50),
+            Some(13),
+            "parent 11 / VLAN 50 -> logical 13"
+        );
+
+        let ip = Ipv4Addr::new(172, 16, 0, 99);
+        let mac_v80 = [0x02, 0x00, 0x00, 0x00, 0x00, 0x80];
+        let mac_v50 = [0x02, 0x00, 0x00, 0x00, 0x00, 0x50];
+
+        // Same physical port (11), same neighbor IP, different VLANs.
+        let _ =
+            stage_link_layer_classify(&arp_reply_frame(ip, mac_v80), link_layer_meta(11, 80), ctx);
+        let _ =
+            stage_link_layer_classify(&arp_reply_frame(ip, mac_v50), link_layer_meta(11, 50), ctx);
+
+        assert_eq!(
+            neighbors.get(&(12, IpAddr::V4(ip))).map(|e| e.mac),
+            Some(mac_v80),
+            "VLAN-80 neighbor must be keyed by logical ifindex 12"
+        );
+        assert_eq!(
+            neighbors.get(&(13, IpAddr::V4(ip))).map(|e| e.mac),
+            Some(mac_v50),
+            "VLAN-50 neighbor must be keyed by logical ifindex 13 — a \
+             physical-ifindex key would collide both into (11, ip)"
+        );
+        assert!(
+            neighbors.get(&(11, IpAddr::V4(ip))).is_none(),
+            "neither learn may land under the shared physical ifindex 11"
+        );
+    }
+
+    /// #2370 NDP variant. A valid Neighbor Advertisement (hop-limit 255,
+    /// code 0, valid ICMPv6 checksum, TLLA option) arriving on a VLAN
+    /// sub-interface must learn its target under the LOGICAL ifindex too.
+    /// Shares the exact `learn_ifindex` computation with the ARP path.
+    #[test]
+    fn ndp_learns_vlan_neighbor_under_logical_ifindex_2370() {
+        let forwarding: &'static ForwardingState = Box::leak(Box::new(build_forwarding_state(
+            &super::super::test_fixtures::nat_snapshot(),
+        )));
+        let (ctx, neighbors) = neighbor_learn_ctx(forwarding);
+
+        let (frame, target_ip, target_mac) = ndp_na_frame();
+        // Frame is built untagged; the meta declares VLAN 80 on parent
+        // 11 (the shim conveys the VLAN out-of-band in meta, not in the
+        // already-stripped L2 header for the learn-key decision).
+        let meta = link_layer_meta(11, 80);
+
+        let outcome = stage_link_layer_classify(&frame, meta, ctx);
+        assert!(matches!(outcome, StageOutcome::Continue(())));
+
+        let found = lookup_neighbor_entry(forwarding, Some(&neighbors), 12, target_ip);
+        assert_eq!(
+            found.map(|e| e.mac),
+            Some(target_mac),
+            "NDP NA learned on a VLAN sub-interface must be found by the \
+             forwarder's LOGICAL-ifindex (12) lookup (#2370)"
+        );
+        assert!(
+            neighbors.get(&(11, target_ip)).is_none(),
+            "the NDP entry must not be keyed by the physical ifindex 11"
+        );
+    }
+
+    /// A `nat_snapshot`-shaped config with TWO VLAN sub-interfaces on the
+    /// same physical parent (ifindex 11): `reth0.80` (logical 12, VID 80)
+    /// and `reth0.50` (logical 13, VID 50), in different subnets.
+    fn two_vlan_snapshot() -> crate::ConfigSnapshot {
+        let mut snap = super::super::test_fixtures::nat_snapshot();
+        // Existing reth0.80 already has ifindex 12, parent 11, VID 80.
+        snap.interfaces.push(crate::InterfaceSnapshot {
+            name: "reth0.50".to_string(),
+            zone: "wan".to_string(),
+            linux_name: "ge-0-0-0.50".to_string(),
+            ifindex: 13,
+            parent_ifindex: 11,
+            redundancy_group: 1,
+            vlan_id: 50,
+            hardware_addr: "02:bf:72:00:50:08".to_string(),
+            addresses: vec![crate::InterfaceAddressSnapshot {
+                family: "inet".to_string(),
+                address: "172.16.50.8/24".to_string(),
+                scope: 0,
+            }],
+            ..Default::default()
+        });
+        snap
+    }
+
+    /// Build a minimal but VALID untagged IPv6 Neighbor Advertisement
+    /// (hop-limit 255, code 0, TLLA option, correct ICMPv6 checksum) and
+    /// return `(frame, target_ip, target_mac)`. Mirrors the parser-test
+    /// builder; the checksum is stamped so the strict #2368 NA parser
+    /// accepts it.
+    fn ndp_na_frame() -> (Vec<u8>, IpAddr, [u8; 6]) {
+        const NEXT_HEADER_ICMPV6: u8 = 58;
+        const ICMPV6_TYPE_NA: u8 = 136;
+        const NDP_OPT_TARGET_LL: u8 = 2;
+        let target_mac = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let mut f = Vec::new();
+        f.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]); // dst
+        f.extend_from_slice(&target_mac); // src
+        f.extend_from_slice(&[0x86, 0xdd]); // ethertype IPv6
+        let l3_start = 14usize;
+        let payload_len = 32u16; // NA(24) + TLLA(8)
+        f.extend_from_slice(&[0x60, 0x00, 0x00, 0x00]);
+        f.extend_from_slice(&payload_len.to_be_bytes());
+        f.push(NEXT_HEADER_ICMPV6);
+        f.push(255); // hop limit (required)
+        // src ip fe80::abcd:ef01:0:1
+        f.extend_from_slice(&[
+            0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0xab, 0xcd, 0xef, 0x01, 0x00, 0x00, 0x00, 0x01,
+        ]);
+        // dst ip (all-ff placeholder; not validated for unicast target)
+        f.extend_from_slice(&[0xff; 16]);
+        let l4_start = l3_start + 40;
+        f.push(ICMPV6_TYPE_NA);
+        f.push(0); // code
+        f.extend_from_slice(&[0x00, 0x00]); // checksum placeholder
+        f.extend_from_slice(&[0; 4]); // flags
+        // target fe80::abcd:ef01:0:42
+        let target_bytes = [
+            0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0xab, 0xcd, 0xef, 0x01, 0x00, 0x00, 0x00, 0x42,
+        ];
+        f.extend_from_slice(&target_bytes);
+        // TLLA option
+        f.push(NDP_OPT_TARGET_LL);
+        f.push(1);
+        f.extend_from_slice(&target_mac);
+        let packet_end = l3_start + 40 + payload_len as usize;
+        let csum = compute_icmpv6_checksum_local(&f, l3_start, l4_start, packet_end);
+        f[l4_start + 2..l4_start + 4].copy_from_slice(&csum.to_be_bytes());
+        (f, IpAddr::V6(Ipv6Addr::from(target_bytes)), target_mac)
+    }
+
+    /// One's-complement ICMPv6 checksum over the IPv6 pseudo-header +
+    /// the ICMPv6 message (`l4_start..packet_end`). Local copy mirroring
+    /// the parser-test stamper so the strict NA parser accepts the frame.
+    fn compute_icmpv6_checksum_local(
+        frame: &[u8],
+        l3_start: usize,
+        l4_start: usize,
+        packet_end: usize,
+    ) -> u16 {
+        let mut sum: u32 = 0;
+        let mut add = |bytes: &[u8]| {
+            let mut i = 0;
+            while i + 1 < bytes.len() {
+                sum += u16::from_be_bytes([bytes[i], bytes[i + 1]]) as u32;
+                i += 2;
+            }
+            if i < bytes.len() {
+                sum += (bytes[i] as u32) << 8;
+            }
+        };
+        // Pseudo-header: src(16) + dst(16) + upper-len(4) + zeros(3) + nh(1).
+        add(&frame[l3_start + 8..l3_start + 24]); // src
+        add(&frame[l3_start + 24..l3_start + 40]); // dst
+        let upper_len = (packet_end - l4_start) as u32;
+        add(&upper_len.to_be_bytes());
+        add(&[0, 0, 0, 58]);
+        // ICMPv6 message with checksum field zeroed.
+        let mut icmp = frame[l4_start..packet_end].to_vec();
+        icmp[2] = 0;
+        icmp[3] = 0;
+        add(&icmp);
+        while (sum >> 16) != 0 {
+            sum = (sum & 0xffff) + (sum >> 16);
+        }
+        !(sum as u16)
     }
 }

--- a/userspace-dp/src/afxdp/test_fixtures.rs
+++ b/userspace-dp/src/afxdp/test_fixtures.rs
@@ -666,3 +666,57 @@ pub(super) fn static_nat_snapshot() -> ConfigSnapshot {
         ..Default::default()
     }
 }
+
+/// Compute the RFC 4443 ICMPv6 checksum over the IPv6 pseudo-header
+/// (src + dst + upper-layer length + next-header 58) plus the ICMPv6
+/// message (`l4_start..packet_end`, checksum field treated as zero).
+/// One-shot 16-bit one's-complement fold. Shared by the parser tests
+/// (#2368 NDP NA frames) and the poll_stages neighbor-keying tests
+/// (#2370) so the stamping logic has a single source of truth.
+pub(super) fn compute_icmpv6_checksum(
+    frame: &[u8],
+    l3_start: usize,
+    l4_start: usize,
+    packet_end: usize,
+) -> u16 {
+    const NEXT_HEADER_ICMPV6: u8 = 58;
+    let mut sum: u32 = 0;
+    let add = |sum: &mut u32, bytes: &[u8]| {
+        let mut i = 0;
+        while i + 1 < bytes.len() {
+            *sum += u16::from_be_bytes([bytes[i], bytes[i + 1]]) as u32;
+            i += 2;
+        }
+        if i < bytes.len() {
+            *sum += (bytes[i] as u32) << 8;
+        }
+    };
+    // pseudo-header: src(16) + dst(16) + len(32) + [0,0,0,58]
+    add(&mut sum, &frame[l3_start + 8..l3_start + 24]);
+    add(&mut sum, &frame[l3_start + 24..l3_start + 40]);
+    let icmp_len = (packet_end - l4_start) as u32;
+    add(&mut sum, &icmp_len.to_be_bytes());
+    add(&mut sum, &[0, 0, 0, NEXT_HEADER_ICMPV6]);
+    // ICMPv6 message with the checksum field zeroed.
+    let mut icmp = frame[l4_start..packet_end].to_vec();
+    icmp[2] = 0;
+    icmp[3] = 0;
+    add(&mut sum, &icmp);
+    while (sum >> 16) != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+/// Stamp a valid ICMPv6 checksum into `frame` in place (IPv6 base header
+/// at `l3_start`, ICMPv6 message at `l4_start`, declared packet end at
+/// `packet_end`). See [`compute_icmpv6_checksum`].
+pub(super) fn stamp_icmpv6_checksum(
+    frame: &mut [u8],
+    l3_start: usize,
+    l4_start: usize,
+    packet_end: usize,
+) {
+    let csum = compute_icmpv6_checksum(frame, l3_start, l4_start, packet_end);
+    frame[l4_start + 2..l4_start + 4].copy_from_slice(&csum.to_be_bytes());
+}


### PR DESCRIPTION
## Summary

Closes #2370.

`stage_link_layer_classify` inserted dynamic neighbors learned from ARP
replies / NDP Neighbor Advertisements keyed by `meta.ingress_ifindex`
(the **physical / parent** ingress port), while the forwarder looks
dynamic neighbors up by the **logical** (L3) ifindex of the connected
route. On a VLAN sub-interface physical != logical, so the just-learned
entry landed under the wrong key and the lookup missed it.

## The physical-vs-logical key mismatch (VLAN)

- **Insert (before):** `poll_stages.rs::stage_link_layer_classify` —
  `dynamic_neighbors.insert((meta.ingress_ifindex as i32, ip), ..)`
  (physical/parent ifindex). The logical ifindex was already resolved at
  the same site but used **only** for `add_kernel_neighbor`.
- **Lookup:** `forwarding/mod.rs::lookup_neighbor_entry` —
  `dynamic_neighbors.get(&(ifindex, target))` where `ifindex` is the
  connected-route (logical) ifindex. Connected routes are stored under
  `iface.ifindex` in `forwarding_build/interfaces.rs`.

For an ARP/NDP frame on a VLAN sub-interface, `meta.ingress_ifindex` is
the parent/bind port and `meta.ingress_vlan_id` selects the logical
interface. The insert key `(parent, ip)` therefore never matched the
lookup key `(logical, ip)` → MissingNeighbor cold path, an avoidable
re-resolution probe, and first-packet latency on every cold start until
the kernel neighbor resolved. (The kernel neighbor entry was already
correct; `add_kernel_neighbor` used the logical ifindex.) This is MEDIUM:
correctness + cold-start latency on VLAN deployments, not a steady-state
or security drop.

## Fix

Hoist `resolve_ingress_logical_ifindex(parent, vlan)` to the top of the
stage and key **both** the `dynamic_neighbors.insert` and
`add_kernel_neighbor` under that single `learn_ifindex`. The insert key
now agrees with the forwarder's lookup key.

- **Insert (after):** `dynamic_neighbors.insert((learn_ifindex, ip), ..)`
  where `learn_ifindex = resolve_ingress_logical_ifindex(parent, vlan).unwrap_or(parent)`.

### Properties
- Untagged / non-VLAN interfaces resolve physical == logical → unchanged.
- A physical port with no matching logical sub-interface falls back to the
  physical ifindex (`unwrap_or`) rather than dropping the learned neighbor.
- **Multi-VLAN no-collision:** two VLAN sub-interfaces on one physical
  port resolve to distinct logical ifindexes, so a same-IP-different-subnet
  neighbor learned on each VLAN lands under distinct keys and never
  collides. Keying by the shared physical ifindex would have collapsed
  both into one entry.

## Tests (fail-on-revert, `poll_stages`)

- `arp_learns_vlan_neighbor_under_logical_ifindex_2370` — ARP on
  (parent=11, vlan=80) is found by the forwarder's logical (12) lookup and
  is NOT under the physical (11) key.
- `arp_learns_untagged_neighbor_under_same_ifindex_2370` — untagged ARP
  still learns under ifindex 24 (physical==logical).
- `arp_two_vlans_same_ip_distinct_logical_keys_2370` — same IP on VID 80
  and VID 50 over one parent lands under distinct logical keys (12, 13),
  nothing under the shared physical key (11).
- `ndp_learns_vlan_neighbor_under_logical_ifindex_2370` — a valid NA
  (hop-limit 255, code 0, valid ICMPv6 checksum, TLLA) on a VLAN
  sub-interface learns under the logical ifindex too.

Reverting the insert key to `meta.ingress_ifindex` was verified to **FAIL
the three VLAN tests** while the untagged test stays green. `cargo build
--release` clean; the 6 `poll_stages` tests pass, 5x stable; neighbor +
forwarding suites green with no regression.

No wire field changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi