### PR TITLE
userspace-dp: count pending_neigh distinct-hop capacity drops (#2375)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11555,3 +11555,24 @@ top.
 - **File(s)**: userspace-dp/src/afxdp/poll_stages.rs,
     userspace-dp/src/afxdp/parser_tests.rs,
     userspace-dp/src/afxdp/test_fixtures.rs, _Log.md
+
+## 2026-06-23 — #2375 pending_neigh capacity-drop counter (recover + finish)
+- **Timestamp**: 2026-06-23
+- **Action**: Recovered a prior agent's uncommitted end-to-end wiring for
+  the silent `pending_neigh` CapacityDrop counter (#2375). Finished the gaps:
+  extracted `record_pending_neigh_admission_drop` helper (neighbor_dispatch.rs)
+  so the duplicate AND capacity increments are a unit-tested side-effect
+  (fail-on-revert); fixed the stale "counted nowhere" comments; regenerated
+  protocol_wire_v1.json (one new key); added Rust + Go ProcessStatus
+  round-trip parity tests (#serde(default), #1961 one-sided guard) and a
+  Rust fail-on-revert test; updated docs/userspace-dataplane-architecture.md.
+- **File(s)**: userspace-dp/src/afxdp/neighbor_dispatch.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs, userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/afxdp/umem/mod.rs, userspace-dp/src/afxdp/coordinator/status.rs,
+  userspace-dp/src/protocol/control.rs, userspace-dp/src/protocol/tests.rs,
+  userspace-dp/src/server/helpers.rs, userspace-dp/src/server/lifecycle.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  pkg/dataplane/userspace/protocol.go, pkg/dataplane/userspace/protocol_test.go,
+  pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go,
+  pkg/api/metrics_descriptor_coverage_test.go,
+  docs/userspace-dataplane-architecture.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -202,6 +202,26 @@ in `neighbor_dispatch.rs`). A hop that never resolves within the pending
 timeout is negatively cached for 3 s (`neg_neigh.rs`), and subsequent
 cold packets to it fast-fail at the buffer site.
 
+`pending_neigh_admission` returns one of three outcomes, each counted
+separately so an operator can tell normal cold-start coalescing from an
+exhaustion/attack mode (`record_pending_neigh_admission_drop`,
+`neighbor_dispatch.rs`):
+
+- **Buffer** — key absent, room available: this becomes the
+  representative driving the probe/dwell clock (no drop counter).
+- **DuplicateDrop** (`pending_neigh_duplicate_drops_total`) — the key is
+  already pending: normal cold-start sibling coalescing (the first
+  packet already drove the kernel probe).
+- **CapacityDrop** (`pending_neigh_capacity_drops_total`, #2375) — a NEW
+  distinct `(egress_ifindex, next_hop)` refused because the map is at
+  `MAX_PENDING_NEIGH` (4096) distinct unresolved hops: distinct-hop
+  neighbor exhaustion — the scan / upstream-outage failure mode. Before
+  #2375 this case was silent (`CapacityDrop => {}`, counted nowhere);
+  exposing it lets operators distinguish "a packet is already probing
+  this destination" (duplicate) from "the worker is refusing NEW
+  unresolved destinations" (capacity). The refused frame is recycled
+  exactly like the duplicate case.
+
 **Pairing contract (#1902, sibling of #1885/#1873):** an entry's
 `desc`/`meta`/`decision` must all describe the SAME UMEM frame, because
 `retry_pending_neigh` resumes the flow via an in-place UMEM rewrite +

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -363,7 +363,12 @@ type xpfCollector struct {
 	// #1902: decap-refusal gate at pending_neigh admission (frame/meta
 	// pairing defect class — see also #1885/#1873).
 	pendingNeighDecapDropsTotal *prometheus.Desc
-	dynamicNeighborPresent      *prometheus.Desc
+	// #2375: distinct-hop capacity-drop gate at pending_neigh admission —
+	// a NEW unresolved hop refused because the per-binding map is at
+	// MAX_PENDING_NEIGH (the scan/upstream-outage failure mode). Kept
+	// separate from pendingNeighDuplicateDropsTotal.
+	pendingNeighCapacityDropsTotal *prometheus.Desc
+	dynamicNeighborPresent         *prometheus.Desc
 	// #1769: on-demand neighbor-resolver telemetry — the operator-visible
 	// signal for the MissingNeighbor stuck-state.
 	neighborResolverQueueDepth        *prometheus.Desc
@@ -618,6 +623,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.negNeighFastFailTotal
 	ch <- c.pendingNeighDuplicateDropsTotal
 	ch <- c.pendingNeighDecapDropsTotal
+	ch <- c.pendingNeighCapacityDropsTotal
 	ch <- c.dynamicNeighborPresent
 	ch <- c.neighborResolverQueueDepth
 	ch <- c.neighborResolverEnqueueDropsTotal

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -327,7 +327,9 @@ func populatedCoverageStatus() dpuserspace.ProcessStatus {
 		PendingNeighDuplicateDropsTotal: 4,
 		// #1902: decap-refusal gate counter (always emits).
 		PendingNeighDecapDropsTotal: 2,
-		DynamicNeighborKeys:         []string{"7 10.0.61.1", "9 172.16.80.200"},
+		// #2375: distinct-hop capacity-drop counter (always emits).
+		PendingNeighCapacityDropsTotal: 5,
+		DynamicNeighborKeys:            []string{"7 10.0.61.1", "9 172.16.80.200"},
 		// #1789: failed USERSPACE_SESSIONS publish counter (always emits).
 		SessionPublishErrorsTotal: 5,
 		// #2244: failed dnat_table reverse-NAT publish counter (always
@@ -510,6 +512,7 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 		"xpf_userspace_worker_cos_queue_lease_undergrant_total",            // #1782 Step-1 (ii) per-cause
 		"xpf_userspace_pending_neigh_duplicate_drops_total",                // #1782 cold-start H5
 		"xpf_userspace_pending_neigh_decap_drops_total",                    // #1902 decap-refusal gate
+		"xpf_userspace_pending_neigh_capacity_drops_total",                 // #2375 distinct-hop exhaustion
 		"xpf_userspace_dynamic_neighbor_present",                           // #1782 cold-start H2 dump
 		"xpf_userspace_session_publish_errors_total",                       // #1789 publish failures
 		"xpf_userspace_dnat_publish_errors_total",                          // #2244 dnat_table reverse-NAT publish failures

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1253,6 +1253,11 @@ func newCollector(srv *Server) *xpfCollector {
 			"GRE-decapped MissingNeighbor packets refused pending_neigh admission: the buffered descriptor would pair the un-decapped OUTER UMEM frame with the post-decap INNER meta, and the neighbor-resolution retry would TX a mis-rewritten outer packet (#1902).",
 			nil, nil,
 		),
+		pendingNeighCapacityDropsTotal: prometheus.NewDesc(
+			"xpf_userspace_pending_neigh_capacity_drops_total",
+			"MissingNeighbor packets for a NEW distinct (egress_ifindex, next_hop) dropped because the per-binding pending_neigh map is at MAX_PENDING_NEIGH distinct unresolved hops — distinct-hop neighbor exhaustion (a scan or upstream outage hitting many cold next hops). Counted separately from xpf_userspace_pending_neigh_duplicate_drops_total, which is normal cold-start coalescing of siblings for an already-pending hop (#2375).",
+			nil, nil,
+		),
 		dynamicNeighborPresent: prometheus.NewDesc(
 			"xpf_userspace_dynamic_neighbor_present",
 			"Per-key presence gauge (always 1) dumped from the helper userspace dynamic_neighbors mirror so the cold-start capture harness can grep the pre-connect t0' next-hop membership (the H2 absence fingerprint) (#1782). DEBUG-ONLY: gated behind the helper's XPF_DEBUG_NEIGHBOR_KEYS env var and absent by default — an absent metric family means the dump is disabled, NOT that dynamic_neighbors is empty.",

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -191,6 +191,11 @@ func (c *xpfCollector) emitNeighborColdStartCapture(ch chan<- prometheus.Metric,
 		prometheus.CounterValue,
 		float64(status.PendingNeighDecapDropsTotal),
 	)
+	ch <- prometheus.MustNewConstMetric(
+		c.pendingNeighCapacityDropsTotal,
+		prometheus.CounterValue,
+		float64(status.PendingNeighCapacityDropsTotal),
+	)
 	for _, key := range status.DynamicNeighborKeys {
 		// Each key is rendered "ifindex ip" by the helper. Split on the
 		// single space into the two gauge labels; skip a malformed entry

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -810,8 +810,15 @@ type ProcessStatus struct {
 	// admission — buffering the outer UMEM frame with the post-decap
 	// inner meta would retry-TX a mis-rewritten outer packet once the
 	// neighbor resolves.
-	PendingNeighDecapDropsTotal uint64   `json:"pending_neigh_decap_drops_total,omitempty"`
-	DynamicNeighborKeys         []string `json:"dynamic_neighbor_keys,omitempty"`
+	PendingNeighDecapDropsTotal uint64 `json:"pending_neigh_decap_drops_total,omitempty"`
+	// #2375: MissingNeighbor packets for a NEW distinct (egress_ifindex,
+	// next_hop) refused because pending_neigh is at MAX_PENDING_NEIGH
+	// distinct hops (distinct-hop neighbor exhaustion — the
+	// scan/upstream-outage failure mode). Separate from
+	// PendingNeighDuplicateDropsTotal (the key was already pending —
+	// normal cold-start coalescing).
+	PendingNeighCapacityDropsTotal uint64   `json:"pending_neigh_capacity_drops_total,omitempty"`
+	DynamicNeighborKeys            []string `json:"dynamic_neighbor_keys,omitempty"`
 	// #1789: total failed USERSPACE_SESSIONS BPF-map publishes (per-binding
 	// worker-poll sites summed with the shared no-binding sites: HA upsert,
 	// session-glue worker publish, post-reconcile replay, activation/reverse

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -1534,6 +1534,62 @@ func TestProcessStatusNeighborPhase3CountersRoundTrip(t *testing.T) {
 	}
 }
 
+// #2375: wire pin for the pending_neigh distinct-hop capacity-drop
+// counter. Mirrors the Rust
+// process_status_pending_neigh_capacity_drops_roundtrip test — a rename
+// or a one-sided add fails a test instead of silently decoding zero
+// (#1961 one-sided-field risk). The duplicate counter must stay a
+// SEPARATE wire key (the #1782/#2375 split).
+func TestProcessStatusPendingNeighCapacityDropsRoundTrip(t *testing.T) {
+	in := ProcessStatus{
+		PendingNeighCapacityDropsTotal:  9,
+		PendingNeighDuplicateDropsTotal: 4,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range []string{
+		"pending_neigh_capacity_drops_total",
+		"pending_neigh_duplicate_drops_total",
+	} {
+		if _, ok := obj[key]; !ok {
+			t.Fatalf("wire key %q missing from ProcessStatus JSON: %s", key, string(raw))
+		}
+	}
+
+	var back ProcessStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal ProcessStatus: %v", err)
+	}
+	if back.PendingNeighCapacityDropsTotal != in.PendingNeighCapacityDropsTotal {
+		t.Fatalf("capacity round-trip mismatch: got %d, want %d",
+			back.PendingNeighCapacityDropsTotal, in.PendingNeighCapacityDropsTotal)
+	}
+	if back.PendingNeighDuplicateDropsTotal != in.PendingNeighDuplicateDropsTotal {
+		t.Fatalf("duplicate round-trip mismatch: got %d, want %d",
+			back.PendingNeighDuplicateDropsTotal, in.PendingNeighDuplicateDropsTotal)
+	}
+
+	// Pre-#2375 helper payload (key absent) must decode to zero.
+	var legacy ProcessStatus
+	if err := json.Unmarshal([]byte(`{"pending_neigh_duplicate_drops_total":7}`), &legacy); err != nil {
+		t.Fatalf("unmarshal legacy ProcessStatus: %v", err)
+	}
+	if legacy.PendingNeighCapacityDropsTotal != 0 {
+		t.Fatalf("legacy decode must zero-default capacity field: %d",
+			legacy.PendingNeighCapacityDropsTotal)
+	}
+	if legacy.PendingNeighDuplicateDropsTotal != 7 {
+		t.Fatalf("legacy duplicate field decode = %d, want 7",
+			legacy.PendingNeighDuplicateDropsTotal)
+	}
+}
+
 // #1829 Phase 1: wire pin for the sojourn telemetry trio on
 // CoSQueueStatus. Mirrors the Rust cos_queue_status_sojourn_roundtrip_1829
 // test — a rename on either side fails a test instead of silently

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -72,6 +72,22 @@ impl super::Coordinator {
             .sum()
     }
 
+    /// #2375: sum of per-binding `pending_neigh_capacity_drops` across
+    /// every `BindingLiveState`. Counts MissingNeighbor packets for a
+    /// NEW distinct `(egress_ifindex, next_hop)` refused because
+    /// `pending_neigh` is at `MAX_PENDING_NEIGH` distinct hops — the
+    /// distinct-hop exhaustion / scan failure mode. Kept separate from
+    /// `pending_neigh_duplicate_drops_total` (normal cold-start
+    /// coalescing). Surfaced as
+    /// `xpf_userspace_pending_neigh_capacity_drops_total`.
+    pub fn pending_neigh_capacity_drops_total(&self) -> u64 {
+        self.workers
+            .live
+            .values()
+            .map(|live| live.pending_neigh_capacity_drops.load(Ordering::Relaxed))
+            .sum()
+    }
+
     /// #1771 §2.6: distinct unresolved `(egress_ifindex, next_hop)` keys
     /// currently buffered across every binding's `pending_neigh` map
     /// (gauge). Each per-binding value is a `len()` snapshot published

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -713,7 +713,8 @@ use neighbor_latency::NeighborLatencyTelemetry;
 mod neighbor_dispatch;
 use neighbor_dispatch::{
     PendingNeighAdmission, build_missing_neighbor_session_metadata,
-    learn_dynamic_neighbor_from_packet, pending_neigh_admission, retry_pending_neigh,
+    learn_dynamic_neighbor_from_packet, pending_neigh_admission,
+    record_pending_neigh_admission_drop, retry_pending_neigh,
 };
 // `learn_dynamic_neighbor` / `pair_write_needed` are only referenced
 // by tests in afxdp/forwarding/tests.rs and afxdp/tests.rs; gate the

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -62,8 +62,9 @@ pub(super) enum PendingNeighAdmission {
     /// each unresolved hop pins at most one UMEM frame).
     DuplicateDrop,
     /// New key but the map is at `MAX_PENDING_NEIGH` distinct hops →
-    /// capacity drop (counted nowhere per the #1782 split; the
-    /// duplicate counter must not conflate this case).
+    /// capacity drop (counted SEPARATELY in `pending_neigh_capacity_drops`
+    /// per the #2375 split; the duplicate counter must not conflate this
+    /// case).
     CapacityDrop,
 }
 
@@ -78,6 +79,37 @@ pub(super) fn pending_neigh_admission(already_pending: bool, len: usize) -> Pend
         PendingNeighAdmission::Buffer
     } else {
         PendingNeighAdmission::CapacityDrop
+    }
+}
+
+/// #2375: record the per-binding drop counter for a non-buffered
+/// `pending_neigh` admission decision. Extracted (behavior-identical to
+/// the inline `fetch_add`s) so the two drop counters are a tested
+/// side-effect rather than an inline branch — a unit test FAILS if
+/// either increment is removed. `Buffer` is not a drop, so it is a
+/// no-op here (the caller does the insert). The two drop cases are kept
+/// SEPARATE per the #1782/#2375 split:
+///   - `DuplicateDrop` (`pending_neigh_duplicate_drops`) — the key was
+///     already pending: normal cold-start sibling coalescing.
+///   - `CapacityDrop` (`pending_neigh_capacity_drops`) — a NEW distinct
+///     hop refused because the map is at `MAX_PENDING_NEIGH`:
+///     distinct-hop neighbor exhaustion (the scan/upstream-outage
+///     failure mode).
+#[inline]
+pub(super) fn record_pending_neigh_admission_drop(
+    live: &BindingLiveState,
+    admission: PendingNeighAdmission,
+) {
+    match admission {
+        PendingNeighAdmission::DuplicateDrop => {
+            live.pending_neigh_duplicate_drops
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        PendingNeighAdmission::CapacityDrop => {
+            live.pending_neigh_capacity_drops
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        PendingNeighAdmission::Buffer => {}
     }
 }
 
@@ -1148,5 +1180,59 @@ mod pending_admission_tests {
             pending_neigh_admission(false, MAX_PENDING_NEIGH),
             PendingNeighAdmission::CapacityDrop
         );
+    }
+
+    /// #2375 fail-on-revert: the capacity-drop branch increments
+    /// `pending_neigh_capacity_drops` and ONLY that counter, kept
+    /// distinct from `pending_neigh_duplicate_drops`. This test drives
+    /// the same `record_pending_neigh_admission_drop` helper the poll
+    /// loop calls, so deleting the capacity increment (the original
+    /// silent `CapacityDrop => {}` bug) fails here. Buffer is a no-op.
+    #[test]
+    fn record_drop_counts_capacity_separately() {
+        use super::record_pending_neigh_admission_drop;
+        use crate::afxdp::umem::BindingLiveState;
+        use std::sync::atomic::Ordering;
+
+        let live = BindingLiveState::new();
+        assert_eq!(live.pending_neigh_capacity_drops.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            live.pending_neigh_duplicate_drops.load(Ordering::Relaxed),
+            0
+        );
+
+        // Buffer is not a drop — neither counter moves.
+        record_pending_neigh_admission_drop(&live, PendingNeighAdmission::Buffer);
+        assert_eq!(live.pending_neigh_capacity_drops.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            live.pending_neigh_duplicate_drops.load(Ordering::Relaxed),
+            0
+        );
+
+        // A capacity drop bumps ONLY the capacity counter.
+        record_pending_neigh_admission_drop(&live, PendingNeighAdmission::CapacityDrop);
+        assert_eq!(live.pending_neigh_capacity_drops.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            live.pending_neigh_duplicate_drops.load(Ordering::Relaxed),
+            0,
+            "capacity drop must not be conflated with the duplicate counter"
+        );
+
+        // Three more distinct-hop capacity drops → exactly 4 total
+        // (mirrors the issue's MAX_PENDING_NEIGH-then-one-more scenario
+        // repeated; the increment is per refused new key).
+        for _ in 0..3 {
+            record_pending_neigh_admission_drop(&live, PendingNeighAdmission::CapacityDrop);
+        }
+        assert_eq!(live.pending_neigh_capacity_drops.load(Ordering::Relaxed), 4);
+
+        // A duplicate drop bumps ONLY the duplicate counter, leaving the
+        // capacity counter narrow.
+        record_pending_neigh_admission_drop(&live, PendingNeighAdmission::DuplicateDrop);
+        assert_eq!(
+            live.pending_neigh_duplicate_drops.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(live.pending_neigh_capacity_drops.load(Ordering::Relaxed), 4);
     }
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -3346,7 +3346,8 @@ pub(super) fn poll_binding_process_descriptor(
                                 // H5 sibling drop (key already pending — the
                                 // first packet drove the kernel probe); the
                                 // CapacityDrop branch is a distinct
-                                // condition, counted nowhere here. #1771
+                                // condition, counted SEPARATELY (#2375) in
+                                // pending_neigh_capacity_drops. #1771
                                 // §2.4: the decision is the pure
                                 // `pending_neigh_admission` helper so
                                 // invariant N1's "at most one buffered
@@ -3355,16 +3356,20 @@ pub(super) fn poll_binding_process_descriptor(
                                 // iff the key is absent AND there is room,
                                 // otherwise `recycle_now` stays true and
                                 // the frame is recycled.
-                                match pending_neigh_admission(
+                                let admission = pending_neigh_admission(
                                     binding.pending_neigh.contains_key(&pending_key),
                                     binding.pending_neigh.len(),
-                                ) {
-                                    PendingNeighAdmission::DuplicateDrop => {
-                                        binding
-                                            .live
-                                            .pending_neigh_duplicate_drops
-                                            .fetch_add(1, Ordering::Relaxed);
-                                    }
+                                );
+                                // #2375: record the drop counters via the
+                                // extracted helper so both the duplicate and
+                                // the capacity case are a unit-tested
+                                // side-effect (the test fails if either
+                                // increment is removed). Buffer is a no-op
+                                // here — the buffering insert stays inline
+                                // below.
+                                record_pending_neigh_admission_drop(&binding.live, admission);
+                                match admission {
+                                    PendingNeighAdmission::DuplicateDrop => {}
                                     PendingNeighAdmission::Buffer => {
                                         // #2357: when this buffered packet is
                                         // later flushed by retry_pending_neigh,
@@ -3411,7 +3416,17 @@ pub(super) fn poll_binding_process_descriptor(
                                         );
                                         recycle_now = false;
                                     }
-                                    PendingNeighAdmission::CapacityDrop => {}
+                                    PendingNeighAdmission::CapacityDrop => {
+                                        // #2375: a NEW distinct hop refused
+                                        // because pending_neigh is at
+                                        // MAX_PENDING_NEIGH (distinct-hop
+                                        // neighbor exhaustion — the
+                                        // scan/upstream-outage failure mode).
+                                        // The counter increment is the helper
+                                        // call above; the frame is recycled
+                                        // exactly like the duplicate branch
+                                        // (recycle_now stays true).
+                                    }
                                 }
                             }
                             if cfg!(feature = "debug-log") {

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -529,6 +529,18 @@ pub(in crate::afxdp) struct BindingLiveState {
     /// `Coordinator::pending_neigh_decap_drops_total()` (Prometheus
     /// `xpf_userspace_pending_neigh_decap_drops_total`).
     pub(super) pending_neigh_decap_drops: AtomicU64,
+    /// #2375: per-binding count of `pending_neigh` admissions REFUSED
+    /// because the map already holds `MAX_PENDING_NEIGH` distinct
+    /// unresolved `(egress_ifindex, next_hop)` hops — the capacity-drop
+    /// case (a NEW distinct hop the worker cannot accept). Distinct from
+    /// `pending_neigh_duplicate_drops` (the key was already pending —
+    /// normal cold-start coalescing): a rising capacity counter means
+    /// the worker is refusing NEW unresolved destinations (distinct-hop
+    /// neighbor exhaustion / possible scan or upstream outage). The
+    /// refused packet is recycled exactly like the duplicate case.
+    /// Surfaced via `Coordinator::pending_neigh_capacity_drops_total()`
+    /// (Prometheus `xpf_userspace_pending_neigh_capacity_drops_total`).
+    pub(super) pending_neigh_capacity_drops: AtomicU64,
     /// #1771 §2.6: distinct unresolved `(egress_ifindex, next_hop)` keys
     /// currently buffered in this binding's `pending_neigh` map (gauge —
     /// post-#1779 §2.2 the map holds at most ONE representative packet
@@ -823,6 +835,7 @@ impl BindingLiveState {
             neg_neigh_fast_fail: AtomicU64::new(0),
             pending_neigh_duplicate_drops: AtomicU64::new(0),
             pending_neigh_decap_drops: AtomicU64::new(0),
+            pending_neigh_capacity_drops: AtomicU64::new(0),
             pending_neigh_keys: AtomicU64::new(0),
             neg_neigh_keys: AtomicU64::new(0),
             session_publish_errors: AtomicU64::new(0),

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -188,6 +188,15 @@ pub(crate) struct ProcessStatus {
     /// packet). Additive / defaulted for backward compatibility.
     #[serde(rename = "pending_neigh_decap_drops_total", default)]
     pub pending_neigh_decap_drops_total: u64,
+    /// #2375: MissingNeighbor packets for a NEW distinct
+    /// `(egress_ifindex, next_hop)` refused because `pending_neigh` is at
+    /// `MAX_PENDING_NEIGH` distinct hops (distinct-hop neighbor
+    /// exhaustion — the scan/upstream-outage failure mode). Kept distinct
+    /// from `pending_neigh_duplicate_drops_total` (the key was already
+    /// pending — normal cold-start coalescing). Additive / defaulted for
+    /// backward compatibility with older daemons.
+    #[serde(rename = "pending_neigh_capacity_drops_total", default)]
+    pub pending_neigh_capacity_drops_total: u64,
     /// #1789: total failed USERSPACE_SESSIONS BPF-map publishes
     /// (per-binding worker-poll sites summed with the shared no-binding
     /// sites: HA upsert, session-glue worker publish, post-reconcile

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -131,6 +131,42 @@ fn process_status_neighbor_phase3_counters_roundtrip() {
     assert_eq!(legacy.neg_neigh_keys, 0);
 }
 
+// #2375: round-trip + backward-compat pin for the pending_neigh
+// distinct-hop capacity-drop counter. The wire key feeds
+// pkg/dataplane/userspace/protocol.go and the Prometheus counter
+// `xpf_userspace_pending_neigh_capacity_drops_total`. Kept distinct
+// from `pending_neigh_duplicate_drops_total` so a rename or a one-sided
+// add fails a test instead of silently decoding zero (#1961 risk).
+#[test]
+fn process_status_pending_neigh_capacity_drops_roundtrip() {
+    let status = ProcessStatus {
+        pending_neigh_capacity_drops_total: 9,
+        pending_neigh_duplicate_drops_total: 4,
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize ProcessStatus to Value");
+    assert_eq!(value["pending_neigh_capacity_drops_total"], 9);
+    // The duplicate counter must stay a SEPARATE wire key, not conflated.
+    assert_eq!(value["pending_neigh_duplicate_drops_total"], 4);
+    let back: ProcessStatus = serde_json::from_value(value).expect("deserialize ProcessStatus");
+    assert_eq!(back.pending_neigh_capacity_drops_total, 9);
+    assert_eq!(back.pending_neigh_duplicate_drops_total, 4);
+
+    // Pre-#2375 payload (key absent) must decode with a zero default
+    // (#[serde(default)] backward-compat with an older daemon).
+    let mut legacy_value =
+        serde_json::to_value(ProcessStatus::default()).expect("serialize default ProcessStatus");
+    legacy_value
+        .as_object_mut()
+        .expect("ProcessStatus serializes to an object")
+        .remove("pending_neigh_capacity_drops_total")
+        .expect("new key present before strip");
+    let legacy: ProcessStatus =
+        serde_json::from_value(legacy_value).expect("pre-#2375 payload decodes");
+    assert_eq!(legacy.pending_neigh_capacity_drops_total, 0);
+}
+
 // #1807: round-trip + backward-compat pin for the worker-command-queue
 // poison-recovery counter. The wire key feeds
 // pkg/dataplane/userspace/protocol.go and the Prometheus counter

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -64,6 +64,12 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
     // outer-frame/inner-meta pairing must never reach the in-place
     // retry TX path).
     state.status.pending_neigh_decap_drops_total = state.afxdp.pending_neigh_decap_drops_total();
+    // #2375: distinct-hop capacity-drop gate at pending_neigh admission
+    // (a NEW unresolved hop refused because the map is at
+    // MAX_PENDING_NEIGH) — the scan/upstream-outage failure mode, kept
+    // separate from the duplicate-drop counter.
+    state.status.pending_neigh_capacity_drops_total =
+        state.afxdp.pending_neigh_capacity_drops_total();
     // #1789: total failed USERSPACE_SESSIONS BPF-map publishes
     // (per-binding worker-poll sites + shared no-binding sites). The
     // cause-side signal for rising XDP-shim NO_SESSION fallbacks.

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -111,6 +111,7 @@ pub(crate) fn run() -> Result<(), String> {
             neg_neigh_fast_fail_total: 0,
             pending_neigh_duplicate_drops_total: 0,
             pending_neigh_decap_drops_total: 0,
+            pending_neigh_capacity_drops_total: 0,
             session_publish_errors_total: 0,
             dnat_publish_errors_total: 0,
             nat_reverse_key_shared_displacements_total: 0,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -807,6 +807,7 @@
     "neighbor_resolver_queue_depth": 0,
     "neighbor_warm_disconnected_total": 0,
     "neighbor_warm_drops_total": 0,
+    "pending_neigh_capacity_drops_total": 0,
     "pending_neigh_decap_drops_total": 0,
     "pending_neigh_duplicate_drops_total": 0,
     "pid": 0,


### PR DESCRIPTION
Closes #2375

## Problem

The cold-neighbor buffering path has three outcomes — buffer a representative packet, drop a **duplicate** for an already-pending key, or drop a **NEW distinct** `(egress_ifindex, next_hop)` because `pending_neigh` is at `MAX_PENDING_NEIGH` (4096) distinct hops. Only the duplicate-drop and the GRE-decap-refusal cases were counted; the `CapacityDrop` arm in `poll_binding_process_descriptor` was a silent `=> {}`.

A scan or upstream outage that hits many unresolved next hops therefore silently recycled first packets for new destinations with **no operator-visible signal**. Operators could see the pending-neighbor gauge and the duplicate-drop counter, but not the actual capacity-denial event. The operational distinction was lost:
- **duplicate drop**: "a packet is already probing this destination" (normal cold-start coalescing);
- **capacity drop**: "the worker is refusing NEW unresolved destinations" (distinct-hop neighbor exhaustion / possible scan).

## Fix (end-to-end, mirrors `pending_neigh_decap_drops_total` / #2381 `event_stream_write_stalls`)

- `umem/mod.rs`: per-binding `pending_neigh_capacity_drops` atomic on `BindingLiveState`.
- `neighbor_dispatch.rs`: extract `record_pending_neigh_admission_drop` — a behavior-identical helper recording BOTH the duplicate and the capacity counter for a non-buffered admission (Buffer = no-op). Two inline `fetch_add`s become one tested side-effect. Stale "counted nowhere" comments corrected.
- `poll_descriptor/mod.rs`: the `CapacityDrop` arm is no longer silent. Behavior otherwise unchanged — a refused new key recycles the frame exactly like a duplicate.
- `coordinator/status.rs` + `server/{helpers,lifecycle}.rs`: sum across bindings, publish `pending_neigh_capacity_drops_total`.
- **Wire field (both sides):** `protocol/control.rs` adds the `ProcessStatus` field with `#[serde(rename = ...)]` + `#[serde(default)]` (additive / backward-compatible with an older daemon); `pkg/dataplane/userspace/protocol.go` adds the matching Go field + JSON tag. `protocol_wire_v1.json` **regenerated** (`XPF_PROTOCOL_WIRE_REGEN=1`) — diff is exactly the one new key.
- `metrics{,_descriptors,_userspace}.go`: new Prometheus counter `xpf_userspace_pending_neigh_capacity_drops_total`, kept SEPARATE from the narrow duplicate-drops counter.

`pending_neigh_duplicate_drops_total` stays narrow; the new counter is the distinct-hop denial signal.

## Sibling drop sites

`pending_neigh_admission` is the single admission decision; `poll_binding_process_descriptor` is its only consumer. The `neighbor_dispatch.rs` `CapacityDrop` is the same enum variant (decision-only, no separate drop site). No other capacity-drop path exists.

## Tests

- **Fail-on-revert (Rust):** `record_drop_counts_capacity_separately` drives the same helper the poll loop calls; **verified it FAILS if the capacity increment is removed** (re-run after deleting the `fetch_add`), and asserts the capacity case is not conflated with the duplicate counter.
- **Wire parity (both sides):** `process_status_pending_neigh_capacity_drops_roundtrip` (Rust) + `TestProcessStatusPendingNeighCapacityDropsRoundTrip` (Go) pin the wire key on each side and the `#[serde(default)]` zero-decode of an older payload (the #1961 one-sided-field guard).
- `metrics_descriptor_coverage_test.go` extended for the new metric.
- `wire_invariant_default_specimens` passes against the regenerated fixture.

## Validation

`cargo build --release` + targeted `cargo test` green; `go build ./...` + `go test ./pkg/{config,dataplane,dataplane/userspace,api}` green; new tests 5x clean. Docs: `docs/userspace-dataplane-architecture.md` documents the three admission outcomes and the new counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi