### PR TITLE
userspace-dp: count RT_FLOW replay-buffer eviction as telemetry loss (#2382)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11576,3 +11576,33 @@ top.
   pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go,
   pkg/api/metrics_descriptor_coverage_test.go,
   docs/userspace-dataplane-architecture.md
+
+## #2382 — count RT_FLOW replay-buffer eviction as telemetry loss (codex review-030 finding 2)
+
+- **Timestamp**: 2026-06-23
+- **Action**: Added a distinct telemetry-loss counter for replay-buffer
+  eviction. The event-stream replay buffer (`REPLAY_BUFFER_CAPACITY` = 4096)
+  evicts the oldest accepted-and-enqueued frame when it wraps before the daemon
+  ACKs; that frame was already counted in `event_stream_sent` at enqueue, so its
+  silent loss was invisible to operators. Split the buffer-full eviction into a
+  new `evict_replay_frame` (increments `frames_replay_evicted`) distinct from
+  `pop_replay_frame` (ACK-trim + shutdown drain — acknowledged removal, NOT a
+  loss, must NOT count). Exposed end-to-end mirroring #2381/#2375: Rust atomic →
+  EventStreamStats.replay_evictions → ProcessStatus.event_stream_replay_evictions
+  (serde rename + default) → Go ProcessStatus.EventStreamReplayEvictions
+  (omitempty, matching tag) → Prometheus
+  `xpf_userspace_event_stream_producer_frames_total{outcome="replay_evicted"}`
+  + `show` status line. Regenerated protocol_wire_v1.json (one new key:
+  event_stream_replay_evictions). Tests: Rust eviction-counts (fail-on-revert),
+  ack-trim-does-not-count, stats-surface, ProcessStatus wire-key + serde-default
+  round-trip; Go Parity1642 decode + missing-key-defaults-0 + Prometheus
+  replay_evicted/write_stalled label assertions. Doc: docs/session-sync-design.md.
+- **File(s)**: userspace-dp/src/event_stream/mod.rs,
+  userspace-dp/src/event_stream/tests.rs, userspace-dp/src/server/helpers.rs,
+  userspace-dp/src/server/lifecycle.rs, userspace-dp/src/protocol/control.rs,
+  userspace-dp/src/protocol/tests.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  pkg/dataplane/userspace/protocol.go, pkg/dataplane/userspace/protocol_test.go,
+  pkg/dataplane/userspace/format/status.go, pkg/api/metrics_userspace.go,
+  pkg/api/metrics_test.go, pkg/api/metrics_descriptor_coverage_test.go,
+  docs/session-sync-design.md

--- a/docs/session-sync-design.md
+++ b/docs/session-sync-design.md
@@ -589,6 +589,21 @@ be lost across a second reconnect. HA backup nodes ACK and ignore session
 events because they are permanent non-owners, while transient primary readiness
 gaps withhold ACK for replay.
 
+**Replay-buffer eviction loss (#2382)**: the replay buffer is bounded at
+`REPLAY_BUFFER_CAPACITY` (4096). If the daemon disconnects or withholds ACKs
+long enough for the buffer to wrap, the oldest accepted-and-enqueued frame is
+evicted to make room. That frame was already counted in `event_stream_sent` at
+enqueue, but is unrecoverable after reconnect — a real telemetry loss (exactly
+the storm / daemon-restart path operators inspect for deny/drop/log audit
+completeness). The buffer-full eviction path (`evict_replay_frame` in
+`event_stream/mod.rs`) increments `event_stream_replay_evictions`, surfaced as
+`xpf_userspace_event_stream_producer_frames_total{outcome="replay_evicted"}`
+and in `show ... | display` status (`Event stream producer: ... replay_evictions=N`).
+This is **distinct from ACK-trim** (`pop_replay_frame` via the MSG_ACK handler),
+which removes acknowledged frames that WERE delivered — ACK-trim and shutdown
+drain do NOT bump the eviction counter, so a growing `replay_evictions` value is
+an unambiguous accepted-telemetry-loss signal, not normal acknowledged removal.
+
 ### Integration with Existing Code
 
 **Rust side** (`userspace-dp/src/main.rs`):

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -316,8 +316,11 @@ func populatedCoverageStatus() dpuserspace.ProcessStatus {
 			PolicyDenyDrops: 1, ScreenDropDrops: 4, FilterLogDrops: 9,
 			UnknownFrameDrops: 3,
 		},
-		EventStreamSent:               101,
-		EventStreamDropped:            7,
+		EventStreamSent:    101,
+		EventStreamDropped: 7,
+		// #2382: replay-buffer eviction telemetry-loss counter — surfaced under
+		// the producer-frames metric with the "replay_evicted" label.
+		EventStreamReplayEvictions:    3,
 		NeighborWarmDropsTotal:        2,
 		NeighborWarmDisconnectedTotal: 0,
 		// #1782 cold-start capture instrumentation: drive all three new

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -426,8 +426,10 @@ func TestEmitUserspaceEventStreamMetrics(t *testing.T) {
 		userspaceEventStreamUnknownDropsTotal:    mkNoLabel("xpf_userspace_event_stream_unknown_frame_drops_total"),
 	}
 	status := dpuserspace.ProcessStatus{
-		EventStreamSent:    101,
-		EventStreamDropped: 7,
+		EventStreamSent:            101,
+		EventStreamDropped:         7,
+		EventStreamWriteStalls:     13,
+		EventStreamReplayEvictions: 4,
 		EventStream: &dpuserspace.EventStreamStatus{
 			FramesRead:        11,
 			FramesWritten:     7,
@@ -455,6 +457,10 @@ func TestEmitUserspaceEventStreamMetrics(t *testing.T) {
 	assertCounterClose(t, got, c.userspaceEventStreamFramesTotal, map[string]string{"direction": "written"}, 7)
 	assertCounterClose(t, got, c.userspaceEventStreamProducerFramesTotal, map[string]string{"outcome": "sent"}, 101)
 	assertCounterClose(t, got, c.userspaceEventStreamProducerFramesTotal, map[string]string{"outcome": "dropped"}, 7)
+	// #2381 / #2382: the stalled-consumer and replay-eviction telemetry-loss
+	// counters surface under distinct outcome labels on the same metric.
+	assertCounterClose(t, got, c.userspaceEventStreamProducerFramesTotal, map[string]string{"outcome": "write_stalled"}, 13)
+	assertCounterClose(t, got, c.userspaceEventStreamProducerFramesTotal, map[string]string{"outcome": "replay_evicted"}, 4)
 	assertCounterClose(t, got, c.userspaceEventStreamDecodeErrorsTotal, nil, 2)
 	assertCounterClose(t, got, c.userspaceEventStreamSequenceGapsTotal, nil, 3)
 	assertCounterClose(t, got, c.userspaceEventStreamDataplaneEventsTotal, map[string]string{"type": "policy_deny"}, 5)

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -1236,6 +1236,14 @@ func (c *xpfCollector) emitUserspaceEventStream(ch chan<- prometheus.Metric, sta
 	// wedged consumer is observable instead of silently OOMing the helper.
 	ch <- prometheus.MustNewConstMetric(c.userspaceEventStreamProducerFramesTotal,
 		prometheus.CounterValue, float64(status.EventStreamWriteStalls), "write_stalled")
+	// #2382: accepted RT_FLOW / dataplane-telemetry frames evicted from the
+	// helper's replay buffer when it wrapped at capacity before the daemon
+	// ACKed them. These were counted under the "sent" label at enqueue but are
+	// permanently lost — a real telemetry-loss signal. Surfaced under the
+	// producer metric with a distinct "replay_evicted" label so the loss is
+	// observable (it is NOT ACK-trim, which is normal acknowledged removal).
+	ch <- prometheus.MustNewConstMetric(c.userspaceEventStreamProducerFramesTotal,
+		prometheus.CounterValue, float64(status.EventStreamReplayEvictions), "replay_evicted")
 	ch <- prometheus.MustNewConstMetric(c.userspaceEventStreamDecodeErrorsTotal,
 		prometheus.CounterValue, float64(es.DecodeErrors))
 	ch <- prometheus.MustNewConstMetric(c.userspaceEventStreamSequenceGapsTotal,

--- a/pkg/dataplane/userspace/format/status.go
+++ b/pkg/dataplane/userspace/format/status.go
@@ -430,8 +430,9 @@ func FormatStatusSummary(status userspace.ProcessStatus) string {
 		es := status.EventStream
 		fmt.Fprintf(&b, "  Event stream frames:       read=%d written=%d decode_errors=%d seq_gaps=%d\n",
 			es.FramesRead, es.FramesWritten, es.DecodeErrors, es.SeqGaps)
-		fmt.Fprintf(&b, "  Event stream producer:     sent=%d dropped=%d write_stalls=%d\n",
-			status.EventStreamSent, status.EventStreamDropped, status.EventStreamWriteStalls)
+		fmt.Fprintf(&b, "  Event stream producer:     sent=%d dropped=%d write_stalls=%d replay_evictions=%d\n",
+			status.EventStreamSent, status.EventStreamDropped, status.EventStreamWriteStalls,
+			status.EventStreamReplayEvictions)
 		fmt.Fprintf(&b, "  Event stream events:       policy_deny=%d screen_drop=%d screen_alarm=%d filter_log=%d unknown_drops=%d\n",
 			es.PolicyDenyEvents, es.ScreenDropEvents, es.ScreenAlarmEvents, es.FilterLogEvents, es.UnknownFrameDrops)
 		fmt.Fprintf(&b, "  Event stream drops:        policy_deny=%d screen_drop=%d filter_log=%d\n",

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -435,9 +435,9 @@ type DestinationNATRuleSnapshot struct {
 	// normalized (trim + lower-case) on both sides before resolution, and an
 	// unresolvable token is rejected at commit by
 	// validateDestinationNATProtocolStrict.
-	Protocol           string   `json:"protocol,omitempty"`
-	PoolAddress        string   `json:"pool_address"`
-	PoolPort           uint16   `json:"pool_port,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	PoolAddress string `json:"pool_address"`
+	PoolPort    uint16 `json:"pool_port,omitempty"`
 	// CounterID is the compiler-assigned per-rule translation hit counter ID
 	// (stable key-derived hash, non-zero; 0 means "no counter"). All expanded
 	// (protocol, port) tuples of the same DNAT rule share one counter ID so
@@ -755,9 +755,9 @@ type ProcessStatus struct {
 	// *EventStreamStatus above carries different, Go-populated counters
 	// (frames_read, decode_errors) the Rust helper never emits. JSON tags
 	// MUST match Rust serde rename(...) exactly.
-	EventStreamConnected bool                      `json:"event_stream_connected,omitempty"`
-	EventStreamSeq       uint64                    `json:"event_stream_seq,omitempty"`
-	EventStreamAcked     uint64                    `json:"event_stream_acked,omitempty"`
+	EventStreamConnected bool   `json:"event_stream_connected,omitempty"`
+	EventStreamSeq       uint64 `json:"event_stream_seq,omitempty"`
+	EventStreamAcked     uint64 `json:"event_stream_acked,omitempty"`
 	// EventStreamWriteStalls counts I/O cycles in which the helper's
 	// event-stream socket-write backlog hit its cap and the helper stopped
 	// draining the bounded channel because the daemon reader was wedged
@@ -766,8 +766,18 @@ type ProcessStatus struct {
 	// is not draining the socket; the forwarding plane is unaffected. JSON tag
 	// MUST match the Rust serde rename(...) exactly.
 	EventStreamWriteStalls uint64 `json:"event_stream_write_stalls,omitempty"`
-	CoSInterfaces        []CoSInterfaceStatus      `json:"cos_interfaces,omitempty"`
-	PolicyRuleCounters   []PolicyRuleCounterStatus `json:"policy_rule_counters,omitempty"`
+	// EventStreamReplayEvictions counts accepted RT_FLOW / dataplane-telemetry
+	// frames the helper evicted from its replay buffer when the buffer wrapped
+	// at capacity before the daemon ACKed them (#2382). These frames were
+	// already counted in EventStreamSent at enqueue but are permanently lost
+	// after reconnect, so a growing value means telemetry was dropped via
+	// replay-buffer eviction (a disconnected or non-ACKing daemon let the
+	// window wrap). It is distinct from ACK-trim (acknowledged-frame removal,
+	// which is NOT a loss and is NOT counted here). JSON tag MUST match the
+	// Rust serde rename(...) exactly.
+	EventStreamReplayEvictions uint64                    `json:"event_stream_replay_evictions,omitempty"`
+	CoSInterfaces              []CoSInterfaceStatus      `json:"cos_interfaces,omitempty"`
+	PolicyRuleCounters         []PolicyRuleCounterStatus `json:"policy_rule_counters,omitempty"`
 	// NATRuleCounters carries the userspace dataplane's per-rule SNAT/DNAT/
 	// static-NAT translation hit counters keyed by the compiler-assigned
 	// counter ID (#2218). The Go control plane mirrors these into the legacy

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -1391,7 +1391,8 @@ func TestProcessStatusEventStreamFieldsParity1642(t *testing.T) {
 		"event_stream_acked": 4200,
 		"event_stream_sent": 5000,
 		"event_stream_dropped": 3,
-		"event_stream_write_stalls": 17
+		"event_stream_write_stalls": 17,
+		"event_stream_replay_evictions": 9
 	}`
 	var got ProcessStatus
 	if err := json.Unmarshal([]byte(rustJSON), &got); err != nil {
@@ -1414,6 +1415,21 @@ func TestProcessStatusEventStreamFieldsParity1642(t *testing.T) {
 	// wire key so a wedged daemon reader is observable in status/metrics.
 	if got.EventStreamWriteStalls != 17 {
 		t.Errorf("event_stream_write_stalls dropped: got %d, want 17", got.EventStreamWriteStalls)
+	}
+	// #2382: the replay-buffer eviction telemetry-loss counter must decode
+	// under its exact wire key so a daemon that let the replay window wrap
+	// (dropping accepted RT_FLOW frames) is observable in status/metrics.
+	if got.EventStreamReplayEvictions != 9 {
+		t.Errorf("event_stream_replay_evictions dropped: got %d, want 9", got.EventStreamReplayEvictions)
+	}
+	// #2382: a legacy helper that omits the key must decode to 0, not error
+	// (omitempty + Go zero-value default).
+	var legacy ProcessStatus
+	if err := json.Unmarshal([]byte(`{"event_stream_sent": 1}`), &legacy); err != nil {
+		t.Fatalf("unmarshal legacy ProcessStatus (no replay key): %v", err)
+	}
+	if legacy.EventStreamReplayEvictions != 0 {
+		t.Errorf("missing event_stream_replay_evictions must default to 0, got %d", legacy.EventStreamReplayEvictions)
 	}
 
 	raw, _ := json.Marshal(&ProcessStatus{EventStreamConnected: true, EventStreamSeq: 1, EventStreamAcked: 1})

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -95,6 +95,13 @@ pub(crate) struct EventStreamStats {
     /// channel because the consumer is not draining the socket — the dataplane
     /// is unaffected.
     pub(crate) write_stalls: u64,
+    /// Count of accepted frames evicted from the replay buffer on wrap before
+    /// the daemon ACKed them (#2382). These were counted as `sent` but are
+    /// permanently lost; a non-zero, growing value means RT_FLOW / dataplane
+    /// telemetry was dropped via replay-buffer eviction (a daemon that
+    /// disconnected or withheld ACKs long enough for the window to wrap).
+    /// ACK-trim does NOT increment this — only the buffer-full eviction.
+    pub(crate) replay_evictions: u64,
     #[allow(dead_code)] // stats field for future reporting
     pub(crate) replayed: u64,
     #[allow(dead_code)] // producer-call-site wiring will surface these fields
@@ -116,6 +123,13 @@ struct EventStreamShared {
     /// I/O cycles in which `write_buf` hit `WRITE_BACKLOG_MAX_BYTES` and the
     /// channel drain was halted (stalled consumer signal, #2381).
     frames_write_stalled: AtomicU64,
+    /// Accepted-and-enqueued frames evicted from the replay buffer when it
+    /// wrapped at `REPLAY_BUFFER_CAPACITY` before the daemon ACKed them
+    /// (#2382). These frames were counted in `frames_sent` at enqueue but are
+    /// unrecoverable after reconnect — a real telemetry loss. Distinct from
+    /// ACK-trim (frames removed because they were acknowledged, which is NOT a
+    /// loss): only the buffer-full eviction path increments this.
+    frames_replay_evicted: AtomicU64,
     frames_replayed: AtomicU64,
     dataplane_event_counters: DataplaneEventCounters,
     #[allow(dead_code)] // consumed by producer call sites once they are wired
@@ -144,6 +158,7 @@ impl EventStreamShared {
             frames_sent: AtomicU64::new(0),
             frames_dropped: AtomicU64::new(0),
             frames_write_stalled: AtomicU64::new(0),
+            frames_replay_evicted: AtomicU64::new(0),
             frames_replayed: AtomicU64::new(0),
             dataplane_event_counters: DataplaneEventCounters::new(),
             dataplane_event_limiter: DataplaneEventRateLimiter::new(config),
@@ -214,6 +229,7 @@ impl EventStreamSender {
             sent: self.shared.frames_sent.load(Ordering::Relaxed),
             dropped: self.shared.frames_dropped.load(Ordering::Relaxed),
             write_stalls: self.shared.frames_write_stalled.load(Ordering::Relaxed),
+            replay_evictions: self.shared.frames_replay_evicted.load(Ordering::Relaxed),
             replayed: self.shared.frames_replayed.load(Ordering::Relaxed),
             dataplane_events: self.shared.dataplane_event_counters.snapshot(),
         }
@@ -843,11 +859,37 @@ fn push_replay_frame(
     frame: EventFrame,
 ) {
     if replay_buf.len() >= REPLAY_BUFFER_CAPACITY {
-        pop_replay_frame(shared, replay_buf);
+        // Buffer-full eviction: the oldest accepted-and-enqueued frame is
+        // dropped before the daemon ACKed it. It was already counted in
+        // `frames_sent`, so it must be counted as a telemetry loss here
+        // (#2382). This is distinct from ACK-trim / shutdown drain, which
+        // remove frames via `pop_replay_frame` WITHOUT bumping the eviction
+        // counter (an ACKed frame is delivered, not lost).
+        evict_replay_frame(shared, replay_buf);
     }
     replay_buf.push_back(frame);
 }
 
+/// Evict the oldest replay frame because the buffer wrapped at capacity. This
+/// is the ONLY telemetry-loss removal path: it increments
+/// `frames_replay_evicted` (#2382) in addition to releasing the queue budget.
+fn evict_replay_frame(
+    shared: &Arc<EventStreamShared>,
+    replay_buf: &mut VecDeque<EventFrame>,
+) -> Option<EventFrame> {
+    let frame = pop_replay_frame(shared, replay_buf);
+    if frame.is_some() {
+        shared
+            .frames_replay_evicted
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    frame
+}
+
+/// Remove the oldest replay frame and release its queue budget WITHOUT
+/// counting it as an eviction. Used by ACK-trim (the frame was acknowledged —
+/// delivered, not lost) and shutdown drain. The buffer-full loss path is
+/// `evict_replay_frame`.
 fn pop_replay_frame(
     shared: &Arc<EventStreamShared>,
     replay_buf: &mut VecDeque<EventFrame>,

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -309,6 +309,105 @@ fn dataplane_event_budget_releases_when_replay_eviction_drops_frame() {
     release_replay_dataplane_event_queue_budget(&shared, &mut replay_buf);
 }
 
+// #2382: replay-buffer eviction (buffer wrapped at capacity before ACK) is a
+// real telemetry loss and must be counted; ACK-trim (acknowledged-frame
+// removal) is NOT a loss and must NOT bump the eviction counter. These tests
+// fail if the increment is removed or moved into the shared pop path.
+
+#[test]
+fn replay_buffer_eviction_counts_telemetry_loss_2382() {
+    let shared = Arc::new(EventStreamShared::new());
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::with_capacity(REPLAY_BUFFER_CAPACITY);
+
+    // Fill the replay buffer exactly to capacity — no eviction yet.
+    for seq in 1..=REPLAY_BUFFER_CAPACITY as u64 {
+        push_replay_frame(&shared, &mut replay_buf, EventFrame::encode_drain_complete(seq));
+    }
+    assert_eq!(replay_buf.len(), REPLAY_BUFFER_CAPACITY);
+    assert_eq!(
+        shared.frames_replay_evicted.load(Ordering::Relaxed),
+        0,
+        "filling to capacity must not evict anything"
+    );
+
+    // Push N more frames past capacity: each wraps the buffer and evicts the
+    // oldest unACKed frame. The counter must go 0 -> N. This assertion FAILS
+    // (stays 0) if the eviction increment in `evict_replay_frame` is removed.
+    let overflow = 5u64;
+    for seq in 0..overflow {
+        push_replay_frame(
+            &shared,
+            &mut replay_buf,
+            EventFrame::encode_drain_complete(REPLAY_BUFFER_CAPACITY as u64 + 1 + seq),
+        );
+    }
+    assert_eq!(replay_buf.len(), REPLAY_BUFFER_CAPACITY);
+    assert_eq!(
+        shared.frames_replay_evicted.load(Ordering::Relaxed),
+        overflow,
+        "each buffer-full wrap must count exactly one replay eviction"
+    );
+    // And the surviving window starts past the evicted prefix.
+    assert_eq!(replay_buf.front().map(|f| f.seq), Some(overflow + 1));
+}
+
+#[test]
+fn ack_trim_does_not_count_as_replay_eviction_2382() {
+    let shared = Arc::new(EventStreamShared::new());
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+
+    // Buffer well under capacity so no wrap occurs.
+    for seq in 1..=10u64 {
+        push_replay_frame(&shared, &mut replay_buf, EventFrame::encode_drain_complete(seq));
+    }
+    assert_eq!(shared.frames_replay_evicted.load(Ordering::Relaxed), 0);
+
+    // Simulate the MSG_ACK trim path: acked_seq = 5 removes the first 5 frames
+    // via `pop_replay_frame`. Those frames were DELIVERED (acknowledged), not
+    // lost — the eviction counter must stay 0.
+    let acked_seq = 5u64;
+    while let Some(front) = replay_buf.front() {
+        if front.seq <= acked_seq {
+            pop_replay_frame(&shared, &mut replay_buf);
+        } else {
+            break;
+        }
+    }
+    assert_eq!(replay_buf.len(), 5);
+    assert_eq!(replay_buf.front().unwrap().seq, 6);
+    assert_eq!(
+        shared.frames_replay_evicted.load(Ordering::Relaxed),
+        0,
+        "ACK-trim is acknowledged removal, not a telemetry loss — must not \
+         bump the replay-eviction counter"
+    );
+
+    // Shutdown drain (release_replay_dataplane_event_queue_budget → pop) also
+    // must not count as eviction.
+    release_replay_dataplane_event_queue_budget(&shared, &mut replay_buf);
+    assert_eq!(replay_buf.len(), 0);
+    assert_eq!(
+        shared.frames_replay_evicted.load(Ordering::Relaxed),
+        0,
+        "shutdown drain must not bump the replay-eviction counter"
+    );
+}
+
+#[test]
+fn replay_evictions_surface_in_event_stream_stats_2382() {
+    let sender = EventStreamSender {
+        tx: mpsc::sync_channel(1).0,
+        shared: Arc::new(EventStreamShared::new()),
+        io_thread: None,
+        stop: Arc::new(AtomicBool::new(false)),
+    };
+    sender
+        .shared
+        .frames_replay_evicted
+        .store(42, Ordering::Relaxed);
+    assert_eq!(sender.stats().replay_evictions, 42);
+}
+
 // #2381: the write-backlog cap converts a wedged daemon reader from
 // unbounded helper heap growth into bounded, counted telemetry loss at the
 // already-bounded mpsc channel. These tests fail if the cap is removed or the

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -458,6 +458,15 @@ pub(crate) struct ProcessStatus {
     /// unaffected.
     #[serde(rename = "event_stream_write_stalls", default)]
     pub event_stream_write_stalls: u64,
+    /// Accepted RT_FLOW / dataplane-telemetry frames evicted from the helper's
+    /// replay buffer when it wrapped at capacity before the daemon ACKed them
+    /// (#2382). These were counted in `event_stream_sent` at enqueue but are
+    /// permanently lost after reconnect. A non-zero, growing value means
+    /// telemetry was dropped via replay-buffer eviction (a disconnected or
+    /// non-ACKing daemon let the window wrap). Distinct from ACK-trim, which
+    /// is normal acknowledged-frame removal and is NOT counted here.
+    #[serde(rename = "event_stream_replay_evictions", default)]
+    pub event_stream_replay_evictions: u64,
     /// Monotonic timestamp (secs) of the last HA flow cache flush (#312).
     #[serde(rename = "last_cache_flush_at", default)]
     pub last_cache_flush_at: u64,

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1682,6 +1682,32 @@ fn process_status_event_stream_fields_wire_keys_1642() {
     assert_eq!(value["event_stream_write_stalls"], 17u64);
 }
 
+#[test]
+fn process_status_replay_evictions_wire_key_2382() {
+    let status = ProcessStatus {
+        event_stream_replay_evictions: 9,
+        ..Default::default()
+    };
+    let value: serde_json::Value =
+        serde_json::to_value(&status).expect("serialize ProcessStatus");
+    // #2382: the replay-buffer eviction telemetry-loss counter must survive
+    // the wire under its exact key so the Go status adapter and Prometheus
+    // collector can surface it.
+    assert_eq!(value["event_stream_replay_evictions"], 9u64);
+
+    // Round-trip with the key absent (legacy helper) must default to 0, not
+    // fail to decode (#[serde(default)]).
+    let mut legacy = serde_json::to_value(ProcessStatus::default())
+        .expect("serialize default ProcessStatus");
+    legacy
+        .as_object_mut()
+        .expect("object")
+        .remove("event_stream_replay_evictions");
+    let decoded: ProcessStatus =
+        serde_json::from_value(legacy).expect("decode legacy ProcessStatus");
+    assert_eq!(decoded.event_stream_replay_evictions, 0);
+}
+
 // #1863 Step-0: round-trip + omitempty pin for the per-worker v8
 // lease claim-flow vectors. The wire keys feed
 // pkg/dataplane/userspace/protocol.go and the Prometheus counters

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -285,6 +285,7 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
         state.status.event_stream_sent = es_stats.sent;
         state.status.event_stream_dropped = es_stats.dropped;
         state.status.event_stream_write_stalls = es_stats.write_stalls;
+        state.status.event_stream_replay_evictions = es_stats.replay_evictions;
     }
     state.status.last_cache_flush_at = state.afxdp.last_cache_flush_at();
 }

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -177,6 +177,7 @@ pub(crate) fn run() -> Result<(), String> {
             event_stream_sent: 0,
             event_stream_dropped: 0,
             event_stream_write_stalls: 0,
+            event_stream_replay_evictions: 0,
             last_cache_flush_at: 0,
         },
         snapshot: None,

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -753,6 +753,7 @@
     "event_stream_acked": 0,
     "event_stream_connected": false,
     "event_stream_dropped": 0,
+    "event_stream_replay_evictions": 0,
     "event_stream_sent": 0,
     "event_stream_seq": 0,
     "event_stream_write_stalls": 0,


### PR DESCRIPTION
Closes #2382

## Problem
The event-stream replay buffer is bounded at `REPLAY_BUFFER_CAPACITY` (4096). When the daemon disconnects or withholds ACKs long enough for the buffer to wrap, `push_replay_frame` evicts the oldest accepted-and-enqueued frame to make room. That frame was already counted in `frames_sent` at enqueue, yet the eviction released the producer-queue budget **without incrementing any drop counter** — so permanently-lost accepted RT_FLOW / dataplane telemetry showed as sent-with-no-corresponding-loss. This is exactly the storm / daemon-restart path operators inspect for deny/drop/log audit completeness (codex review-030 finding 2). MEDIUM, observability/audit-accuracy — not a forwarding bug.

Worse, the buffer-full eviction shared the `pop_replay_frame` helper with the MSG_ACK trim path and the shutdown drain, so an eviction (a real loss) and an acknowledged-frame removal (delivered — **not** a loss) were indistinguishable to accounting.

## Fix (eviction-only, not ACK-trim)
- Split the buffer-full eviction into a dedicated `evict_replay_frame` (`event_stream/mod.rs`) that increments a new `frames_replay_evicted` atomic **in addition to** releasing the queue budget.
- `pop_replay_frame` — used by the MSG_ACK trim path and shutdown drain — stays uncounted, because acknowledged removal is a delivery, not a loss. A growing counter is therefore an unambiguous accepted-telemetry-loss signal.

## End-to-end exposure (mirrors #2381 write-stalls / #2375 pending-neigh)
- Rust atomic `frames_replay_evicted` → `EventStreamStats.replay_evictions` → `ProcessStatus.event_stream_replay_evictions` (serde rename + `#[serde(default)]`).
- Go `ProcessStatus.EventStreamReplayEvictions` with the matching `json:"event_stream_replay_evictions,omitempty"` tag.
- Prometheus: `xpf_userspace_event_stream_producer_frames_total{outcome="replay_evicted"}` (reuses the existing labeled producer-frames family — same descriptor as sent/dropped/write_stalled, no new descriptor).
- `show` status line: `Event stream producer: ... replay_evictions=N`.
- Doc: `docs/session-sync-design.md`.

## Wire field (both sides + regen)
The new field is added to **both** the Rust `ProcessStatus` and the Go `ProcessStatus` with matching tags (#1961 one-sided-field guard). `protocol_wire_v1.json` regenerated — diff is **exactly one new key** (`event_stream_replay_evictions`). Verified serde-default / omitempty round-trips on both sides.

## Tests (fail-on-revert)
- `replay_buffer_eviction_counts_telemetry_loss_2382` — filling past capacity drives the counter 0→N; **fails (stays 0) if the increment is removed** (verified by temporarily deleting the `fetch_add` → test FAILED).
- `ack_trim_does_not_count_as_replay_eviction_2382` — the MSG_ACK trim path and shutdown drain leave the eviction counter at 0; distinguishes loss from acknowledged removal.
- `replay_evictions_surface_in_event_stream_stats_2382` — the atomic reaches `EventStreamStats`.
- `process_status_replay_evictions_wire_key_2382` — exact wire key + serde-default round-trip with the key absent.
- Go `TestProcessStatusEventStreamFieldsParity1642` — decodes the new wire key and asserts a missing key defaults to 0.
- Go `TestEmitUserspaceEventStreamMetrics` — asserts `outcome="replay_evicted"` (and `write_stalled`) series emit.

## Validation
- `cargo build --release` + targeted `cargo test --release` green; new Rust tests 5×0 flake; fail-on-revert confirmed.
- `go build ./...`, `go vet`, `go test ./pkg/dataplane/userspace/... ./pkg/api/` green.
- protocol_wire diff = one new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi