### PR TITLE
icmp: gate PTB generation on the trigger's source address (#2367)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11606,3 +11606,27 @@ top.
   pkg/dataplane/userspace/format/status.go, pkg/api/metrics_userspace.go,
   pkg/api/metrics_test.go, pkg/api/metrics_descriptor_coverage_test.go,
   docs/session-sync-design.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2367 — add the bad-source-address suppression to the PTB
+  (Frag-Needed / Packet-Too-Big) generation gate. `ptb_reply_suppressed`
+  checked only L2/L3 destination + non-first fragment + inbound-ICMP-error,
+  never the trigger packet's IP SOURCE — so an oversized DF datagram with a
+  forbidden source (0.0.0.0/127.0.0.1/multicast/255.255.255.255 for v4,
+  ::/::1/ff00::/8 for v6) made the firewall emit a PTB addressed to that
+  source: spoofable ICMP backscatter (RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e)).
+  Extracted the reject/TE gate's inlined source check into a shared
+  `source_is_invalid_for_icmp_error` predicate (frame/inspect.rs) and called
+  it from BOTH `ptb_reply_suppressed` and `can_generate_icmp_error_reply`,
+  so the PTB, reject, and Time-Exceeded paths share ONE bad-source set
+  (closes the forkable per-error-type suppression contract). v4 + v6.
+  Fail-on-revert tests: v4/v6 bad-source backscatter suppression (red if the
+  source call is removed), v4/v6 unicast anti-over-suppress (PMTUD still
+  works), shared-predicate consistency + fail-closed on unknown family.
+  cargo build --release clean; targeted tests green; new tests stable 5x;
+  reject-gate tests still green after refactor.
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+  userspace-dp/src/afxdp/frame/mod.rs, userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/icmp_ptb.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs,
+  userspace-dp/src/afxdp/README.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -187,7 +187,17 @@ sync.
   L2+L3 suppression the reject / Time-Exceeded path already had — both
   call the shared `l2_dst_is_group_or_broadcast` predicate
   (`frame/inspect.rs`, the IEEE I/G group bit on the destination MAC's
-  first octet; all-FF broadcast is a group address). No new counter: a
+  first octet; all-FF broadcast is a group address). #2367: the gate now
+  also drops PTBs triggered by a datagram whose IP SOURCE is not a single
+  unicast host (unspecified, loopback, multicast, or — for IPv4 —
+  broadcast). The PTB is addressed to the trigger's source, so a forbidden
+  source would emit spoofable ICMP backscatter; this is the L3-SOURCE half
+  of RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e). Both `ptb_reply_suppressed` and
+  `can_generate_icmp_error_reply` now call the shared
+  `source_is_invalid_for_icmp_error` predicate (`frame/inspect.rs`), so the
+  PTB, reject, and Time-Exceeded paths apply ONE bad-source set (the
+  reject gate's inlined source check was refactored to call it, closing
+  the forkable per-error-type suppression contract). No new counter: a
   suppressed PTB is folded into the existing fail-closed silent-drop path
   (the oversized original is still dropped via `mtu_signalled`). #2328: a
   PTB that IS generated is now classified by its OWN egress 5-tuple through

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -551,6 +551,53 @@ pub(in crate::afxdp) fn dest_is_multicast_or_broadcast(addr_family: u8, packet: 
     }
 }
 
+/// #2367: RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a router MUST NOT
+/// originate an ICMP/ICMPv6 *error* in response to a datagram whose IP
+/// SOURCE address does not uniquely identify a single host. A locally
+/// generated error is addressed to the trigger packet's source, so a
+/// forbidden source (unspecified, loopback, multicast, or — for IPv4 —
+/// broadcast) would produce spoofable ICMP backscatter aimed at an
+/// address that is not a legitimate unicast host. This is the L3-SOURCE
+/// sibling of [`dest_is_multicast_or_broadcast`] (the L3-destination
+/// test) and [`l2_dst_is_group_or_broadcast`] (the L2 test); it is shared
+/// by the reject / Time-Exceeded path (`can_generate_icmp_error_reply`)
+/// and the PTB path (`ptb_reply_suppressed`) so every locally generated
+/// ICMP error applies the SAME bad-source gate.
+///
+/// `packet` is the L3 (IP-header-first) slice of the trigger frame.
+/// Returns `true` when the source is forbidden and the ICMP error MUST be
+/// suppressed. A too-short or unknown-family slice fails closed
+/// (suppress).
+#[inline]
+pub(in crate::afxdp) fn source_is_invalid_for_icmp_error(addr_family: u8, packet: &[u8]) -> bool {
+    match addr_family as i32 {
+        libc::AF_INET => {
+            // IPv4 source is header bytes 12..16.
+            let Some(src) = packet.get(12..16) else {
+                return true;
+            };
+            let src = Ipv4Addr::new(src[0], src[1], src[2], src[3]);
+            src.is_unspecified() || src.is_loopback() || src.is_multicast() || src.is_broadcast()
+        }
+        libc::AF_INET6 => {
+            // IPv6 source is header bytes 8..24. IPv6 has no broadcast;
+            // multicast (ff00::/8) covers the group case.
+            let Some(src) = packet.get(8..24) else {
+                return true;
+            };
+            let src = Ipv6Addr::from(match <[u8; 16]>::try_from(src) {
+                Ok(addr) => addr,
+                Err(_) => return true,
+            });
+            src.is_unspecified() || src.is_loopback() || src.is_multicast()
+        }
+        // Unknown family — fail closed (suppress). Mirrors the
+        // destination predicate's "suppress on anything we could not
+        // classify" contract.
+        _ => true,
+    }
+}
+
 /// #2325: RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a router MUST NOT
 /// originate an ICMP/ICMPv6 *error* in reply to a datagram that was
 /// delivered as a link-layer (L2) broadcast or multicast. The IEEE 802

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -64,8 +64,9 @@ pub(in crate::afxdp) use inspect::{
     authoritative_forward_ports, decode_frame_summary, dest_is_multicast_or_broadcast,
     forward_tuple_mismatch_reason, ipv4_is_any_fragment, ipv4_is_non_first_fragment,
     ipv6_is_any_fragment, ipv6_is_non_first_fragment, is_any_fragment, is_non_first_fragment,
-    l2_dst_is_group_or_broadcast, parse_session_flow, term_match_extra_from_frame,
-    term_match_extra_from_frame_fwd, term_match_extra_from_meta, try_parse_metadata,
+    l2_dst_is_group_or_broadcast, parse_session_flow, source_is_invalid_for_icmp_error,
+    term_match_extra_from_frame, term_match_extra_from_frame_fwd, term_match_extra_from_meta,
+    try_parse_metadata,
 };
 
 // #989: TCP-specific inspection + mutation kernels relocated from

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -62,15 +62,11 @@ pub(super) fn can_generate_icmp_error_reply(frame: &[u8], meta: UserspaceDpMeta)
             if packet.len() < 20 {
                 return false;
             }
-            let src = Ipv4Addr::new(packet[12], packet[13], packet[14], packet[15]);
-            // (d) bad source / (c) group or broadcast destination. The
-            // destination test routes through the shared #2314 predicate
-            // so the PTB, reject, and Time Exceeded paths agree on what a
-            // multicast/broadcast destination is.
-            if src.is_unspecified()
-                || src.is_loopback()
-                || src.is_multicast()
-                || src.is_broadcast()
+            // (d) bad source / (c) group or broadcast destination. Both
+            // tests route through the shared predicates (#2367 source,
+            // #2314 destination) so the PTB, reject, and Time Exceeded
+            // paths agree on the disallowed source/destination sets.
+            if source_is_invalid_for_icmp_error(meta.addr_family, packet)
                 || dest_is_multicast_or_broadcast(meta.addr_family, packet)
             {
                 return false;
@@ -80,16 +76,11 @@ pub(super) fn can_generate_icmp_error_reply(frame: &[u8], meta: UserspaceDpMeta)
             if packet.len() < 40 {
                 return false;
             }
-            let src = Ipv6Addr::from(match <[u8; 16]>::try_from(&packet[8..24]) {
-                Ok(addr) => addr,
-                Err(_) => return false,
-            });
             // (d) bad source / (c) multicast destination. IPv6 has no
-            // broadcast; multicast (ff00::/8) covers the group case. The
-            // destination test routes through the shared #2314 predicate.
-            if src.is_unspecified()
-                || src.is_loopback()
-                || src.is_multicast()
+            // broadcast; multicast (ff00::/8) covers the group case. Both
+            // tests route through the shared predicates (#2367 source,
+            // #2314 destination).
+            if source_is_invalid_for_icmp_error(meta.addr_family, packet)
                 || dest_is_multicast_or_broadcast(meta.addr_family, packet)
             {
                 return false;

--- a/userspace-dp/src/afxdp/icmp_ptb.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb.rs
@@ -236,6 +236,16 @@ pub(in crate::afxdp) fn ptb_reply_suppressed(
     if is_non_first_fragment(packet, meta.addr_family) {
         return true;
     }
+    // #2367: never generate a PTB in reply to a datagram whose IP SOURCE
+    // is not a single unicast host (unspecified, loopback, multicast, or
+    // — for IPv4 — broadcast). The PTB is addressed to the trigger's
+    // source, so a forbidden source would produce spoofable ICMP
+    // backscatter. Routes through the shared predicate so the PTB,
+    // reject, and Time-Exceeded paths agree on the bad-source set
+    // (RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e)).
+    if source_is_invalid_for_icmp_error(meta.addr_family, packet) {
+        return true;
+    }
     // #2314: never generate a PTB in reply to a datagram whose IP
     // destination was multicast or broadcast.
     if dest_is_multicast_or_broadcast(meta.addr_family, packet) {

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -509,6 +509,173 @@ fn l2_dst_group_broadcast_helper() {
     assert!(l2_dst_is_group_or_broadcast(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
 }
 
+// === #2367: bad-source suppression (spoofable backscatter) ===
+//
+// The PTB is addressed to the trigger packet's SOURCE address. A trigger
+// whose source is not a single unicast host (unspecified, loopback,
+// multicast, or — for IPv4 — broadcast) would make the firewall emit a
+// PTB to a forbidden address: spoofable ICMP backscatter. RFC 1812
+// §4.3.2.7 / RFC 4443 §2.4(e). The reject / Time-Exceeded gate already
+// enforces this; these tests prove the PTB gate now does too and that the
+// two share the SAME bad-source set. Each suppression test FAILS (the PTB
+// is generated) if the `source_is_invalid_for_icmp_error` call in
+// `ptb_reply_suppressed` is removed.
+
+/// Rewrite the IPv4 SOURCE of a built inbound frame (and fix the IP header
+/// checksum). The PTB builder reflects this as the reply destination.
+fn set_v4_src(frame: &mut [u8], l3: usize, src: Ipv4Addr) {
+    frame[l3 + 12..l3 + 16].copy_from_slice(&src.octets());
+    frame[l3 + 10..l3 + 12].copy_from_slice(&[0, 0]);
+    let csum = checksum16(&frame[l3..l3 + 20]);
+    frame[l3 + 10..l3 + 12].copy_from_slice(&csum.to_be_bytes());
+}
+
+/// Rewrite the IPv6 SOURCE of a built inbound frame.
+fn set_v6_src(frame: &mut [u8], l3: usize, src: Ipv6Addr) {
+    frame[l3 + 8..l3 + 24].copy_from_slice(&src.octets());
+}
+
+/// #2367 fail-on-revert (backscatter): an oversized DF IPv4 datagram whose
+/// SOURCE is one of the forbidden addresses (0.0.0.0, 127.0.0.1,
+/// 224.0.0.1 multicast, 255.255.255.255 broadcast) must NOT generate a PTB
+/// — otherwise the firewall emits spoofable ICMP backscatter to that
+/// source. Mirrors the reject/TE gate's IPv4 bad-source set exactly.
+#[test]
+fn ptb_suppressed_for_v4_bad_source_backscatter() {
+    for bad in [
+        Ipv4Addr::new(0, 0, 0, 0),         // unspecified
+        Ipv4Addr::new(127, 0, 0, 1),       // loopback
+        Ipv4Addr::new(224, 0, 0, 1),       // multicast
+        Ipv4Addr::new(255, 255, 255, 255), // limited broadcast
+    ] {
+        let (mut frame, meta) = inbound_v4_udp(1500, true);
+        let l3 = meta.l3_offset as usize;
+        set_v4_src(&mut frame, l3, bad);
+        assert!(
+            ptb_reply_suppressed(&frame, meta, l3),
+            "IPv4 forbidden source {bad} must suppress the PTB (backscatter)"
+        );
+    }
+}
+
+/// #2367 fail-on-revert (backscatter): an oversized IPv6 datagram whose
+/// SOURCE is forbidden (::, ::1, ff02::1 multicast) must NOT generate a
+/// Packet-Too-Big. Mirrors the reject/TE gate's IPv6 bad-source set.
+#[test]
+fn ptb_suppressed_for_v6_bad_source_backscatter() {
+    for bad in ["::", "::1", "ff02::1"] {
+        let (mut frame, meta) = inbound_v6_udp(1300);
+        let l3 = meta.l3_offset as usize;
+        set_v6_src(&mut frame, l3, bad.parse().expect("v6 src"));
+        assert!(
+            ptb_reply_suppressed(&frame, meta, l3),
+            "IPv6 forbidden source {bad} must suppress the PTB (backscatter)"
+        );
+    }
+}
+
+/// #2367 anti-over-suppress (PMTUD must still work): an oversized DF IPv4
+/// datagram from a NORMAL unicast source must STILL generate the PTB.
+/// Pairs with the suppression test above: reverting the source gate turns
+/// that one red while this stays green (the suppression is the source
+/// gate, not the frame bytes).
+#[test]
+fn ptb_still_generated_for_v4_unicast_source() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    // Plain unicast source, distinct from the default to be explicit.
+    set_v4_src(&mut frame, l3, Ipv4Addr::new(203, 0, 113, 7));
+    assert!(
+        !ptb_reply_suppressed(&frame, meta, l3),
+        "a unicast source must NOT suppress the PTB (PMTUD)"
+    );
+    let fwd = forwarding_with_egress(1400);
+    let out = build_frag_needed_v4(&frame, meta, PTB_IFINDEX, &fwd, 1400)
+        .expect("unicast-source PTB must build");
+    // The PTB is addressed back to the (unicast) source.
+    assert_eq!(
+        &out[30..34],
+        &Ipv4Addr::new(203, 0, 113, 7).octets(),
+        "PTB dst = unicast trigger source"
+    );
+}
+
+/// #2367 anti-over-suppress: an oversized IPv6 datagram from a normal
+/// unicast source must STILL generate the Packet-Too-Big.
+#[test]
+fn ptb_still_generated_for_v6_unicast_source() {
+    let (frame, meta) = inbound_v6_udp(1300);
+    let l3 = meta.l3_offset as usize;
+    // The default source 2001:559:8585:bf01::20 is unicast.
+    assert!(
+        !ptb_reply_suppressed(&frame, meta, l3),
+        "a unicast IPv6 source must NOT suppress the PTB (PMTUD)"
+    );
+    let fwd = forwarding_with_egress(1280);
+    assert!(
+        build_packet_too_big_v6(&frame, meta, PTB_IFINDEX, &fwd, 1280).is_some(),
+        "unicast-source IPv6 PTB must build"
+    );
+}
+
+/// #2367 direct unit test of the shared `source_is_invalid_for_icmp_error`
+/// predicate, plus its fail-closed contract on an unknown family. This is
+/// the SAME predicate the reject / Time-Exceeded gate
+/// (`can_generate_icmp_error_reply`) calls, so the PTB and reject paths
+/// suppress an identical source set.
+#[test]
+fn source_predicate_matches_reject_set_and_fails_closed() {
+    // IPv4 forbidden sources -> invalid.
+    for bad in [
+        Ipv4Addr::new(0, 0, 0, 0),
+        Ipv4Addr::new(127, 0, 0, 1),
+        Ipv4Addr::new(224, 0, 0, 1),
+        Ipv4Addr::new(255, 255, 255, 255),
+    ] {
+        let (mut frame, meta) = inbound_v4_udp(64, true);
+        let l3 = meta.l3_offset as usize;
+        set_v4_src(&mut frame, l3, bad);
+        assert!(
+            source_is_invalid_for_icmp_error(libc::AF_INET as u8, &frame[l3..]),
+            "IPv4 {bad} must be an invalid ICMP-error source"
+        );
+    }
+    // IPv4 unicast -> valid.
+    let (frame, meta) = inbound_v4_udp(64, true);
+    let l3 = meta.l3_offset as usize;
+    assert!(
+        !source_is_invalid_for_icmp_error(libc::AF_INET as u8, &frame[l3..]),
+        "IPv4 unicast source must be valid"
+    );
+    // IPv6 forbidden sources -> invalid.
+    for bad in ["::", "::1", "ff02::1"] {
+        let (mut frame, meta) = inbound_v6_udp(64);
+        let l3 = meta.l3_offset as usize;
+        set_v6_src(&mut frame, l3, bad.parse().expect("v6 src"));
+        assert!(
+            source_is_invalid_for_icmp_error(libc::AF_INET6 as u8, &frame[l3..]),
+            "IPv6 {bad} must be an invalid ICMP-error source"
+        );
+    }
+    // IPv6 unicast -> valid.
+    let (frame6, meta6) = inbound_v6_udp(64);
+    let l36 = meta6.l3_offset as usize;
+    assert!(
+        !source_is_invalid_for_icmp_error(libc::AF_INET6 as u8, &frame6[l36..]),
+        "IPv6 unicast source must be valid"
+    );
+    // Fail-closed: an unknown / non-IP family is treated as invalid
+    // (suppress). Fails if the default arm is reverted to `false`.
+    assert!(
+        source_is_invalid_for_icmp_error(0, &frame[l3..]),
+        "unknown addr_family must fail closed -> invalid source"
+    );
+    assert!(
+        source_is_invalid_for_icmp_error(libc::AF_UNIX as u8, &frame[l3..]),
+        "non-IP addr_family must fail closed -> invalid source"
+    );
+}
+
 #[test]
 fn no_primary_address_fails_closed() {
     // Egress has no primary v4 -> the builder returns None (caller silently


### PR DESCRIPTION
Closes #2367

## Backscatter vector

The forwarded-path Packet-Too-Big suppression gate (`ptb_reply_suppressed`, `userspace-dp/src/afxdp/icmp_ptb.rs`) checked only the L2 destination MAC, non-first fragment, L3 destination (multicast/broadcast, #2314), and inbound-ICMP-error cases — it **never read the trigger packet's IP SOURCE**.

A locally generated PTB is addressed to the trigger's source. So an oversized DF datagram whose source is a forbidden address — `0.0.0.0`, `127.0.0.1`, `224.0.0.0/4` multicast, `255.255.255.255` broadcast (v4); `::`, `::1`, `ff00::/8` multicast (v6) — made the appliance emit a PTB to that address: **spoofable ICMP backscatter** (an attacker spoofs the source, the firewall emits PTBs to the victim).

The reject / Time-Exceeded gate (`can_generate_icmp_error_reply`, `icmp.rs`) already enforced the bad-source check; the PTB gate did not. This is exactly the divergence the shared-predicate refactors (#2314/#2325) were meant to prevent — the L2/L3-**destination** gates were unified, but the L3-**source** gate was not.

## RFC basis

RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e): a router MUST NOT originate an ICMP error in response to a datagram whose source does not uniquely identify a single host (unspecified, loopback, multicast, broadcast). The PTB is an ICMP error — same rule.

## Fix

Extract the reject/TE gate's inlined source check into a shared `source_is_invalid_for_icmp_error` predicate (`frame/inspect.rs`, the sibling of the existing `dest_is_multicast_or_broadcast` / `l2_dst_is_group_or_broadcast` predicates), and call it from **both** `ptb_reply_suppressed` and `can_generate_icmp_error_reply`. The PTB, reject, and Time-Exceeded paths now share **one** bad-source set, closing the forkable per-error-type suppression contract.

- v4 + v6.
- Disallowed source set (mirrors the reject gate exactly): v4 = unspecified / loopback / multicast / broadcast; v6 = unspecified / loopback / multicast.
- Predicate fails closed on an unknown address family.
- A suppressed PTB folds into the existing fail-closed silent-drop path (the oversized original is still dropped) — no new counter, no wire field.

## Tests (fail-on-revert, security)

- `ptb_suppressed_for_v4_bad_source_backscatter` / `ptb_suppressed_for_v6_bad_source_backscatter` — bad-source triggers must NOT generate a PTB. **Verified red** when the source call is removed from `ptb_reply_suppressed`; the unicast tests stay green (proving the suppression is the source gate, not the bytes).
- `ptb_still_generated_for_v4_unicast_source` / `ptb_still_generated_for_v6_unicast_source` — anti-over-suppress: a legitimate unicast trigger still emits a PTB (PMTUD works), addressed back to that unicast source.
- `source_predicate_matches_reject_set_and_fails_closed` — the PTB gate suppresses the SAME source set the reject gate does, and the predicate fails closed on an unknown family.

## Validation

`cargo build --release` clean; new tests green and stable across 5 runs; the reject-gate suppression tests still pass after the refactor. Cold ICMP-error generation path, not the per-packet fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi