### PR TITLE
userspace-dp: bound GRE decap inner UDP/ICMP/ICMPv6 L4 read (#2376)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11655,3 +11655,25 @@ top.
   still clean.
 - **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs (doc comment),
   userspace-dp/src/afxdp/forwarding/README.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2376 — GRE decap inner-L4 minimum-header bounds. The
+  inner-protocol parser (parse_inner_protocol_and_offsets, afxdp/gre.rs)
+  length-validated inner TCP but advanced UDP/ICMP (IPv4) and
+  UDP/ICMPv6 (IPv6) by 8 bytes with NO bounds check. The inner is
+  trimmed to its IP-declared length before the parse, so a short inner
+  (e.g. total_len = ihl + 2, proto UDP) survived and stamped
+  protocol/l4_offset/payload_offset (payload_offset past the packet end)
+  from bytes that are not a real L4 header — fed into the synthetic inner
+  meta (gre.rs stamp site) and reinjected into the worker pipeline. Fix:
+  require packet.len() >= ihl+8 (v4 UDP/ICMP) and >= rel_l4+8 (v6
+  UDP/ICMPv6), return None (fail closed) otherwise; mirrors the existing
+  TCP guard, which is untouched. Distinct from #2361 (that hardened the
+  live frame parser's port fabrication; this is the synthetic-inner
+  metadata stamped by the decap stage). 7 fail-on-revert tests added
+  (4 truncated-drop UDP/ICMP/UDPv6/ICMPv6 + 2 well-formed happy-path with
+  port assertions + 1 TCP no-regression); verified the 4 drop tests FAIL
+  when the guard is reverted. Full unittest suite 2564 passed.
+- **File(s)**: userspace-dp/src/afxdp/gre.rs,
+  userspace-dp/src/afxdp/tests.rs, docs/userspace-native-gre-plan.md,
+  _Log.md

--- a/docs/userspace-native-gre-plan.md
+++ b/docs/userspace-native-gre-plan.md
@@ -313,6 +313,41 @@ keep that table from crossing security boundaries:
   place — `tunnel_mode_kind` — and the dispatcher will keep failing
   closed until the new arm is added deliberately.
 
+### 6b. Inner-L4 Minimum-Header Bounds On Decap (#2376)
+
+`parse_inner_protocol_and_offsets` (`afxdp/gre.rs`) builds the synthetic
+inner metadata (`protocol`, `l4_offset`, `payload_offset`) for the
+decapsulated inner. The inner is first trimmed to its IP-declared total
+length (`packet_trimmed_len`), so an inner whose declared length ends
+before its L4 header survives to the parse.
+
+Inner TCP was always length-validated (the IHL + 20-byte TCP-header
+check). UDP, ICMP, and ICMPv6, however, advanced the payload offset by 8
+unconditionally — with NO check that the inner actually contained the
+8-byte L4 minimum header (RFC 768 UDP, RFC 792 ICMP, RFC 4443 ICMPv6).
+A malformed inner (e.g. IPv4 `total_len = ihl + 2`, `protocol = UDP`)
+therefore left decap with internally inconsistent metadata: `protocol`
+claiming UDP/ICMP while `l4_offset`/`payload_offset` were derived from —
+and pointed past — bytes that are not a real L4 header. Decap is a
+trusted chokepoint that reinjects the synthetic frame into the worker
+pipeline (`poll_descriptor`), so every downstream consumer of
+`meta.protocol`/`l4_offset`/`payload_offset` (policy, logging, slow-path,
+generated-reply) then operated on a packet shape that should have failed
+closed.
+
+The fix mirrors the TCP guard for the other three protocols: IPv4 UDP/
+ICMP require `packet.len() >= ihl + 8`, IPv6 UDP/ICMPv6 require
+`packet.len() >= rel_l4 + 8`, and `parse_inner_protocol_and_offsets`
+returns `None` (no decap / drop) otherwise. A well-formed GRE-tunneled
+UDP/ICMP inner still decaps and stamps correct ports (anti-over-reject).
+
+This is **distinct from #2361**: #2361 hardened the live frame parser
+(`parse_session_flow_from_frame`) so it no longer fabricates ports from
+bytes past the IP-declared length, so a *ported SessionFlow* is no longer
+produced from a short inner. #2376 is narrower — the synthetic inner
+*metadata* (`protocol`/`l4_offset`/`payload_offset`) stamped by the GRE
+decap stage itself, which #2361 did not touch.
+
 ## Policy-Based Routing Without A Tunnel Netdevice
 
 This is the most important control-plane question.

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -475,8 +475,23 @@ fn parse_inner_protocol_and_offsets(packet: &[u8], addr_family: u8) -> Option<(u
                     }
                     l4_offset + tcp_len as u16
                 }
-                PROTO_UDP => l4_offset + 8,
-                PROTO_ICMP => l4_offset + 8,
+                // #2376: UDP (RFC 768) and ICMP (RFC 792) both have an
+                // 8-byte minimum header. The inner packet was already
+                // trimmed to its IP-declared total length
+                // (`packet_trimmed_len`), so a short inner (e.g.
+                // total_len = ihl + 2) survives to here. Unlike TCP
+                // above, these arms previously advanced the payload
+                // offset by 8 with NO bounds check, stamping
+                // `l4_offset`/`payload_offset` from bytes that are not a
+                // real L4 header and pointing `payload_offset` past the
+                // packet end. Fail CLOSED (drop / no decap) when the
+                // inner cannot contain the claimed L4 header.
+                PROTO_UDP | PROTO_ICMP => {
+                    if packet.len() < ihl + 8 {
+                        return None;
+                    }
+                    l4_offset + 8
+                }
                 _ => l4_offset,
             };
             Some((protocol, l4_offset, payload_offset))
@@ -514,8 +529,21 @@ fn parse_inner_protocol_and_offsets(packet: &[u8], addr_family: u8) -> Option<(u
                     }
                     rel_l4 + tcp_len as u16
                 }
-                PROTO_UDP => rel_l4 + 8,
-                PROTO_ICMPV6 => rel_l4 + 8,
+                // #2376: mirror the IPv4 UDP/ICMP guard for the IPv6
+                // inner. UDP (RFC 768) and ICMPv6 (RFC 4443) both have
+                // an 8-byte minimum header. `rel_l4` is the offset of
+                // the resolved L4 header within the (already
+                // IP-declared-length-trimmed) inner packet; if the
+                // packet ends before that header is complete, the
+                // previous `rel_l4 + 8` stamped a payload offset past
+                // the packet end from non-L4 bytes. Fail CLOSED.
+                PROTO_UDP | PROTO_ICMPV6 => {
+                    let l4 = rel_l4 as usize;
+                    if packet.len() < l4 + 8 {
+                        return None;
+                    }
+                    rel_l4 + 8
+                }
                 // #2292: an unresolved/extension-header protocol is a drop,
                 // not a forward. 0/43/51/59/60 are IPv6 ext-header or
                 // no-next-header sentinels, never a real inner L4.

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7492,6 +7492,234 @@ fn gre_decap_still_matches_genuine_gre_row() {
     );
 }
 
+// ====================================================================
+// #2376: GRE decap inner-L4 minimum-header bounds (UDP/ICMP/ICMPv6).
+//
+// The inner-protocol parser length-validated inner TCP but advanced the
+// UDP/ICMP/ICMPv6 payload offset by 8 with NO minimum-header bounds
+// check. The inner is trimmed to its IP-declared total length before the
+// parse, so an inner whose declared length ends before its L4 header
+// (e.g. IPv4 total_len = ihl + 2, proto = UDP) survived and stamped a
+// synthetic `protocol`/`l4_offset`/`payload_offset` from bytes that are
+// not a real L4 header — `payload_offset` even pointed past the packet
+// end. The fix fails CLOSED (no decap) when the inner cannot contain the
+// claimed 8-byte L4 minimum header. These tests pin that contract and
+// the anti-over-reject happy path. They drive
+// `try_native_gre_decap_from_frame` directly so the assertion is on the
+// decap chokepoint, not a downstream consumer.
+// ====================================================================
+
+/// Build a flagless-GRE OUTER frame (peer 203.0.113.9 -> local
+/// 172.16.80.8, the `gre_to_self_snapshot` tunnel tuple) carrying an
+/// arbitrary `inner` packet under the GRE inner proto `gre_inner_proto`
+/// (0x0800 = IPv4 inner, 0x86dd = IPv6 inner). The outer IP total length
+/// is taken from the actual byte counts so a deliberately short inner
+/// still produces a well-formed OUTER — the truncation is purely in the
+/// inner, which is what the #2376 guard inspects. Untagged underlay
+/// (L3 at 14).
+fn build_gre_to_self_outer_frame_with_inner(gre_inner_proto: u16, inner: &[u8]) -> Vec<u8> {
+    let mut frame = Vec::new();
+    write_eth_header(
+        &mut frame,
+        [0x02, 0xbf, 0x72, 0x00, 0x80, 0x08],
+        [0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5],
+        0,
+        0x0800,
+    );
+    let l3 = frame.len();
+    let total = (20 + 4 + inner.len()) as u16;
+    frame.extend_from_slice(&[0x45, 0x00]);
+    frame.extend_from_slice(&total.to_be_bytes());
+    frame.extend_from_slice(&[
+        0x00, 0x01, 0x00, 0x00, 64, PROTO_GRE, 0x00, 0x00, 203, 0, 113, 9, 172, 16, 80, 8,
+    ]);
+    let ip_sum = checksum16(&frame[l3..l3 + 20]);
+    frame[l3 + 10] = (ip_sum >> 8) as u8;
+    frame[l3 + 11] = ip_sum as u8;
+    // Flagless GRE header: flags/version = 0, protocol = gre_inner_proto.
+    frame.extend_from_slice(&[0x00, 0x00]);
+    frame.extend_from_slice(&gre_inner_proto.to_be_bytes());
+    frame.extend_from_slice(inner);
+    frame
+}
+
+/// IPv4 inner with `protocol` and `total_len` set to `ihl + l4_bytes`
+/// (ihl = 20). `l4_bytes` is how many bytes of L4 follow the IP header in
+/// the IP-declared length; the physical packet is padded to the declared
+/// length so `packet_trimmed_len` returns `total_len` (the truncation
+/// being tested is "declared length too short for the L4 header", not a
+/// short physical buffer).
+fn build_gre_inner_v4(protocol: u8, l4_bytes: usize) -> Vec<u8> {
+    let total = 20 + l4_bytes;
+    let mut packet = vec![
+        0x45,
+        0x00,
+        (total >> 8) as u8,
+        total as u8,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        64,
+        protocol,
+        0x00,
+        0x00,
+        10,
+        255,
+        0,
+        2,
+        10,
+        255,
+        0,
+        1,
+    ];
+    let ip_sum = checksum16(&packet[0..20]);
+    packet[10] = (ip_sum >> 8) as u8;
+    packet[11] = ip_sum as u8;
+    packet.extend(std::iter::repeat(0u8).take(l4_bytes));
+    packet
+}
+
+/// IPv6 inner with the given next-header `protocol`, `payload_len`
+/// L4 bytes after the 40-byte fixed header. Physical buffer padded to the
+/// declared length so the truncation is in the IP-declared length, not
+/// the buffer.
+fn build_gre_inner_v6(protocol: u8, payload_len: usize) -> Vec<u8> {
+    let mut packet = vec![0x60, 0x00, 0x00, 0x00];
+    packet.extend_from_slice(&(payload_len as u16).to_be_bytes());
+    packet.push(protocol);
+    packet.push(64); // hop limit
+    // src 2001:db8::2, dst 2001:db8::1
+    packet.extend_from_slice(&[
+        0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+    ]);
+    packet.extend_from_slice(&[
+        0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    ]);
+    packet.extend(std::iter::repeat(0u8).take(payload_len));
+    packet
+}
+
+/// A GRE packet whose IPv4 inner declares UDP but its IP-declared length
+/// ends before the 8-byte UDP header (total_len = ihl + 2). Pre-#2376
+/// this stamped `protocol = UDP`, `l4_offset = ihl`, and
+/// `payload_offset = ihl + 8` (past the packet end) from non-L4 bytes.
+/// The guard must now drop (decap returns `None`). FAILS if the
+/// `packet.len() >= ihl + 8` guard is removed.
+#[test]
+fn gre_decap_drops_truncated_udp_inner_v4() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let inner = build_gre_inner_v4(PROTO_UDP, 2); // only 2 of 8 UDP bytes declared
+    let frame = build_gre_to_self_outer_frame_with_inner(0x0800, &inner);
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    assert!(
+        try_native_gre_decap_from_frame(&frame, meta, &forwarding).is_none(),
+        "a GRE inner declaring UDP but shorter than the 8-byte UDP \
+         header must fail closed (no decap), not stamp synthetic ports \
+         from out-of-bounds bytes"
+    );
+}
+
+/// Same as above for an IPv4 ICMP inner shorter than its 8-byte header.
+#[test]
+fn gre_decap_drops_truncated_icmp_inner_v4() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let inner = build_gre_inner_v4(PROTO_ICMP, 3); // only 3 of 8 ICMP bytes declared
+    let frame = build_gre_to_self_outer_frame_with_inner(0x0800, &inner);
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    assert!(
+        try_native_gre_decap_from_frame(&frame, meta, &forwarding).is_none(),
+        "a GRE inner declaring ICMP but shorter than the 8-byte ICMP \
+         header must fail closed (no decap)"
+    );
+}
+
+/// IPv6 inner declaring UDP but with payload_len < 8 (the UDP header does
+/// not fit). FAILS if the IPv6 `packet.len() >= l4 + 8` guard is removed.
+#[test]
+fn gre_decap_drops_truncated_udp_inner_v6() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let inner = build_gre_inner_v6(PROTO_UDP, 4); // 4 of 8 UDP bytes
+    let frame = build_gre_to_self_outer_frame_with_inner(0x86dd, &inner);
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    assert!(
+        try_native_gre_decap_from_frame(&frame, meta, &forwarding).is_none(),
+        "an IPv6 GRE inner declaring UDP shorter than the 8-byte UDP \
+         header must fail closed (no decap)"
+    );
+}
+
+/// IPv6 inner declaring ICMPv6 but with payload_len < 8.
+#[test]
+fn gre_decap_drops_truncated_icmpv6_inner_v6() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let inner = build_gre_inner_v6(PROTO_ICMPV6, 7); // 7 of 8 ICMPv6 bytes
+    let frame = build_gre_to_self_outer_frame_with_inner(0x86dd, &inner);
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    assert!(
+        try_native_gre_decap_from_frame(&frame, meta, &forwarding).is_none(),
+        "an IPv6 GRE inner declaring ICMPv6 shorter than the 8-byte \
+         header must fail closed (no decap)"
+    );
+}
+
+/// #2376 anti-over-reject: a WELL-FORMED GRE-tunneled UDP inner (full
+/// 8-byte UDP header + payload) still decaps and stamps the correct
+/// ports / L4 offset. Guards the happy path against an over-strict
+/// length check. The synthetic inner meta's `l4_offset` is `14 + ihl`
+/// (eth + IP header) and the stamped ports come from the real UDP header.
+#[test]
+fn gre_decap_well_formed_udp_inner_v4_still_decaps_with_ports() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let mut inner = build_gre_inner_v4(PROTO_UDP, 8 + 4); // full UDP header + 4B payload
+    // src port 0x1234, dst port 0x5678, length 16, checksum 0 (unchecked).
+    inner[20..28].copy_from_slice(&[0x12, 0x34, 0x56, 0x78, 0x00, 0x10, 0x00, 0x00]);
+    let frame = build_gre_to_self_outer_frame_with_inner(0x0800, &inner);
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    let decap = try_native_gre_decap_from_frame(&frame, meta, &forwarding)
+        .expect("a well-formed GRE-tunneled UDP inner must still decap");
+    assert_eq!(decap.meta.protocol, PROTO_UDP);
+    assert_eq!(decap.meta.l4_offset, 14 + 20, "inner L4 at eth+IP header");
+    assert_eq!(decap.meta.flow_src_port, 0x1234, "stamped UDP src port");
+    assert_eq!(decap.meta.flow_dst_port, 0x5678, "stamped UDP dst port");
+    assert_eq!(
+        &decap.frame[decap.meta.l3_offset as usize..],
+        &inner[..],
+        "synthetic frame and inner meta must stay self-consistent"
+    );
+}
+
+/// #2376 anti-over-reject: a well-formed GRE-tunneled ICMP echo inner
+/// still decaps (mirrors `build_gre_inner_icmp_packet_v4`, full 8-byte
+/// ICMP header). Complements the existing self-consistency tests.
+#[test]
+fn gre_decap_well_formed_icmp_inner_v4_still_decaps() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let inner = build_gre_inner_icmp_packet_v4();
+    let frame = build_gre_to_self_outer_frame_with_inner(0x0800, &inner);
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    let decap = try_native_gre_decap_from_frame(&frame, meta, &forwarding)
+        .expect("a well-formed GRE-tunneled ICMP inner must still decap");
+    assert_eq!(decap.meta.protocol, PROTO_ICMP);
+    assert_eq!(decap.meta.l4_offset, 14 + 20);
+}
+
+/// #2376 composition / no-regression: the pre-existing TCP guard must
+/// still drop a GRE inner declaring TCP but shorter than the 20-byte TCP
+/// header — the UDP/ICMP fix must not weaken the TCP path.
+#[test]
+fn gre_decap_drops_truncated_tcp_inner_v4_no_regression() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let inner = build_gre_inner_v4(PROTO_TCP, 10); // 10 of 20 TCP bytes
+    let frame = build_gre_to_self_outer_frame_with_inner(0x0800, &inner);
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    assert!(
+        try_native_gre_decap_from_frame(&frame, meta, &forwarding).is_none(),
+        "the existing TCP minimum-header guard must still drop a short \
+         TCP inner (the #2376 UDP/ICMP fix must not regress TCP)"
+    );
+}
+
 /// #2327 fail-on-revert: the egress encap dispatcher must FAIL CLOSED on
 /// an unknown tunnel mode — a row whose mode is neither GRE nor
 /// WireGuard must NOT be silently GRE-encapsulated (the pre-#2327


### PR DESCRIPTION
Closes #2376

## Problem

The native GRE decap inner-protocol parser (`parse_inner_protocol_and_offsets`, `userspace-dp/src/afxdp/gre.rs`) length-validated an inner **TCP** header but advanced the payload offset by 8 bytes **unconditionally** for inner **UDP/ICMP** (IPv4) and **UDP/ICMPv6** (IPv6) — with no check that the inner packet actually contained the 8-byte L4 minimum header (RFC 768 UDP, RFC 792 ICMP, RFC 4443 ICMPv6). This is the TCP-guarded-but-UDP/ICMP-unguarded asymmetry.

The inner packet is trimmed to its IP-declared total length (`packet_trimmed_len`) *before* the parse, so a malformed inner whose declared length ends before the L4 header (e.g. IPv4 `total_len = ihl + 2`, `protocol = UDP`) survives. Decap then stamps a synthetic inner `UserspaceDpMeta` whose `protocol` claims UDP/ICMP while `l4_offset` / `payload_offset` are derived from — and point past — bytes that are not a real L4 header.

Decap is a trusted chokepoint that reinjects the synthetic frame into the worker pipeline (`poll_descriptor`), so every downstream consumer of `meta.protocol` / `l4_offset` / `payload_offset` (policy, logging, slow-path, generated-reply) then operates on a packet shape that should have failed closed.

### Unguarded sites (before)
- `gre.rs` IPv4: `PROTO_UDP => l4_offset + 8`, `PROTO_ICMP => l4_offset + 8`
- `gre.rs` IPv6: `PROTO_UDP => rel_l4 + 8`, `PROTO_ICMPV6 => rel_l4 + 8`
- Stamped into the synthetic inner meta at the `l4_offset = 14 + rel_l4_offset` / `payload_offset = 14 + payload_offset` site.

## Fix

Mirror the existing TCP guard for the other three protocols (fail closed):
- IPv4 UDP/ICMP: require `packet.len() >= ihl + 8`
- IPv6 UDP/ICMPv6: require `packet.len() >= rel_l4 + 8`
- Return `None` (no decap / drop) otherwise.

The TCP guard is untouched. A well-formed GRE-tunneled UDP/ICMP inner still decaps and stamps correct ports (anti-over-reject).

## Distinction from #2361

#2361 hardened the **live frame parser** (`parse_session_flow_from_frame`) so it no longer fabricates ports from bytes past the IP-declared length — a *ported SessionFlow* is no longer produced from a short inner. #2376 is narrower: the **synthetic inner metadata** (`protocol` / `l4_offset` / `payload_offset`) stamped by the GRE **decap stage itself**, which #2361 did not touch.

## Tests (fail-on-revert)

Added in `userspace-dp/src/afxdp/tests.rs`, driving `try_native_gre_decap_from_frame` directly (the decap chokepoint):
- `gre_decap_drops_truncated_udp_inner_v4`
- `gre_decap_drops_truncated_icmp_inner_v4`
- `gre_decap_drops_truncated_udp_inner_v6`
- `gre_decap_drops_truncated_icmpv6_inner_v6`
- `gre_decap_well_formed_udp_inner_v4_still_decaps_with_ports` (anti-over-reject + port assertions)
- `gre_decap_well_formed_icmp_inner_v4_still_decaps` (anti-over-reject)
- `gre_decap_drops_truncated_tcp_inner_v4_no_regression` (TCP path still guarded)

Verified the four truncated-drop tests **FAIL** when the guard is reverted, and pass with it. No panic on a truncated inner (bounds-safe `None`).

## Validation
- `cargo build --release` clean (pre-existing warnings only).
- Full unittest suite: 2564 passed, 0 failed.
- `gre_decap` subset 16/16 stable across 5 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi