### PR TITLE
userspace-dp: translate embedded inner on NAT44 ICMPv4 Redirect/Source-Quench (#2393)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,35 @@
 # Action Log
 
+## 2026-06-23 — #2393 embedded-ICMP-NAT match adds ICMPv4 Redirect/Source-Quench
+
+- **Timestamp**: 2026-06-23 PDT
+- **Action**: Correctness fix (LOW). The embedded-ICMP-NAT reversal gate
+  `is_icmp_error` (`userspace-dp/src/afxdp/icmp.rs`) matched ICMPv4 types
+  3/11/12 but omitted type 5 (Redirect) and type 4 (Source Quench), which
+  also quote an inner IP header + 8 bytes (RFC 792). Transit ICMP
+  forwarding is type-agnostic in the same-family path (no link-scope drop —
+  confirmed: the only type-4/5 drop is the NAT64 cross-family path,
+  `nat64.rs`, where they have no IPv6 analogue per RFC 7915), so a NAT44
+  transit Redirect/Source-Quench was forwarded with its quoted inner
+  addresses left at the post-SNAT value (mismatched at the host). Fix:
+  broaden the ICMPv4 arm to 3/4/5/11/12, matching the reject-suppression
+  guard `reject_icmp_reply_suppressed` and Linux netfilter conntrack's
+  `icmp_error`. All five share the 8-byte ICMP header layout, so the quoted
+  IP starts at `l4+8` and the type-agnostic parser/builders need no
+  per-type change; the three gate sites share this SSOT predicate. Updated
+  the now-stale "different (and broader) set" comment on the reject guard
+  (the ICMPv4 sets are now identical; only the ICMPv6 arms still differ).
+  Added an end-to-end fail-on-revert test
+  (`embedded_icmp_nat_match_translates_redirect_v4`: installs the SNAT
+  session, flips a TE frame to a Redirect, asserts both outer dst and
+  embedded inner src are reversed to the client) — verified it FAILS when
+  the v4 arm is reverted to 3/11/12 — plus extended the `is_icmp_error`
+  unit test to assert types 4/5. Targeted suite (icmp/nat64/embedded/
+  redirect) 237 passed; new tests 5x green.
+- **File(s)**: userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/tests.rs, docs/userspace-icmp-te-debugging.md,
+  _Log.md
+
 ## 2026-06-23 — #2369 ARP fixed-header validation before neighbor learning
 
 - **Timestamp**: 2026-06-23 PDT

--- a/_Log.md
+++ b/_Log.md
@@ -30,6 +30,25 @@
   userspace-dp/src/afxdp/tests.rs, docs/userspace-icmp-te-debugging.md,
   _Log.md
 
+## 2026-06-23 — #2393 Copilot fold: assert Redirect gateway preserved (test-only)
+
+- **Timestamp**: 2026-06-23 PDT
+- **Action**: Test strengthening (no code change) on PR #2432. The new
+  `embedded_icmp_nat_match_translates_redirect_v4` crafted the Redirect by
+  flipping only the type byte, leaving the Redirect gateway-address field
+  (ICMP header bytes 4..8) all-zero (inherited from the Time-Exceeded
+  template's unused word) — an unrealistic Redirect that also did not prove
+  the rewrite leaves the gateway field alone. Set the gateway to a non-zero
+  sentinel (192.0.2.1, RFC 5737 TEST-NET-1) before recomputing the ICMP
+  checksum, and added an assertion that the gateway field
+  (`result[38..42]`) is preserved byte-for-byte through the embedded-NAT
+  reversal — proving the rewrite touches only the quoted inner packet at
+  l4+8 and the outer IP, never the type-specific header word at l4+4..8.
+  Verified the new assertion FAILS when a temporary clobber of the output
+  gateway byte is injected. Targeted suite (icmp/embedded/redirect) 5x
+  green; build clean.
+- **File(s)**: userspace-dp/src/afxdp/tests.rs, _Log.md
+
 ## 2026-06-23 — #2369 ARP fixed-header validation before neighbor learning
 
 - **Timestamp**: 2026-06-23 PDT

--- a/docs/userspace-icmp-te-debugging.md
+++ b/docs/userspace-icmp-te-debugging.md
@@ -23,6 +23,37 @@ ICMP Time Exceeded (type 11) from intermediate routers arrives at the firewall's
 5. Recompute all checksums (outer IP, outer ICMP, embedded IP)
 6. Forward the rewritten ICMP error to the original client
 
+### Which ICMP error types are reversed (`is_icmp_error`)
+
+The embedded-NAT reversal only runs for ICMP messages that quote the
+offending datagram (an inner IP header + at least the first 8 bytes of its
+transport header). `is_icmp_error` (`userspace-dp/src/afxdp/icmp.rs`) is the
+single source of truth for that set, shared by all three gate sites
+(`icmp_embed/mod.rs`, `icmp_embed/session_match.rs`,
+`poll_descriptor/mod.rs`):
+
+- **ICMPv4**: types **3** (Dest Unreachable), **4** (Source Quench),
+  **5** (Redirect), **11** (Time Exceeded), **12** (Parameter Problem).
+  All five share the RFC 792 8-byte ICMP header layout — the type-specific
+  word (Redirect's gateway address; the unused word on the others) occupies
+  bytes 4..8 — so the quoted IP header always begins at `l4 + 8` and the
+  type-agnostic parser/builders need no per-type handling.
+- **ICMPv6**: types **1** (Dest Unreachable), **2** (Packet Too Big),
+  **3** (Time Exceeded), **4** (Parameter Problem).
+
+**#2393** added ICMPv4 types 4 and 5. Before that the set was 3/11/12, so a
+NAT44-transit Redirect (5) or Source Quench (4) was forwarded with its
+quoted inner addresses left at the post-SNAT value (mismatched at the
+host). Type 4 is deprecated (RFC 6633) and type 5 is normally link-scoped,
+so a NATed transit instance is rare — but ICMP transit forwarding is
+type-agnostic (no link-scope drop in the same-family path), so they *can*
+reach this path. The set now matches the reject-suppression guard
+(`reject_icmp_reply_suppressed`) and Linux netfilter conntrack's related-
+ICMP `icmp_error` (3/4/5/11/12). Note this governs only **same-family**
+embedded-NAT reversal; on the **NAT64** cross-family path Source Quench /
+Redirect have no IPv6 analogue and are still dropped, not mistranslated
+(RFC 7915, `nat64.rs`).
+
 ## What's Implemented (commit `d892376`)
 
 ### NAT Reversal Logic — WORKING (unit tested)

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -446,12 +446,18 @@ pub(super) fn build_local_icmp_error_v6(
 /// #2089 reject-action ICMP-error suppression guard, matching the
 /// retired eBPF `send_icmp_unreach_*` dispatch verbatim: never generate
 /// a Destination Unreachable in reply to an inbound ICMP/ICMPv6 *error*
-/// message (RFC 792 / RFC 4443). This is intentionally a different (and
-/// broader) set than [`is_icmp_error`], which the embedded-ICMP-NAT path
-/// uses — the reject guard suppresses ICMPv4 types {3,4,5,11,12} and ALL
-/// ICMPv6 types < 128 (the ICMPv6 error range). ICMP *query* types (echo
-/// request/reply, etc.) are NOT suppressed: a rejected echo gets an
-/// unreachable, matching Junos.
+/// message (RFC 792 / RFC 4443). The reject guard suppresses ICMPv4 types
+/// {3,4,5,11,12} and ALL ICMPv6 types < 128 (the ICMPv6 error range). ICMP
+/// *query* types (echo request/reply, etc.) are NOT suppressed: a rejected
+/// echo gets an unreachable, matching Junos.
+///
+/// #2393: the ICMPv4 set here now matches [`is_icmp_error`]
+/// ({3,4,5,11,12}) — both follow the full RFC 792 quoted-datagram error
+/// set. The two predicates remain separate because their ICMPv6 arms still
+/// differ: this guard suppresses the entire ICMPv6 error range (`< 128`,
+/// which includes types beyond the embedded-NAT set), while
+/// [`is_icmp_error`] enumerates only the ICMPv6 errors that quote a
+/// translatable inner packet (1/2/3/4).
 ///
 /// Returns true when a reject reply MUST be suppressed for this inbound
 /// ICMP/ICMPv6 message.
@@ -502,10 +508,35 @@ pub(super) fn build_reject_icmp_unreachable(
 }
 
 /// Returns true if the protocol and ICMP type indicate an ICMP error message
-/// (Destination Unreachable, Time Exceeded, Parameter Problem, Packet Too Big).
+/// that quotes the offending datagram (an inner IP header + at least the
+/// first 8 bytes of its transport header), which the embedded-ICMP-NAT
+/// reversal path must translate back to the pre-NAT tuple.
+///
+/// #2393: the ICMPv4 arm matches the full RFC 792 error set that carries a
+/// quoted datagram — Destination Unreachable (3), Source Quench (4),
+/// Redirect (5), Time Exceeded (11), Parameter Problem (12) — so that a
+/// NAT44 transit Redirect / Source Quench has its embedded inner addresses
+/// rewritten just like types 3/11/12. All five share the same 8-byte ICMP
+/// header layout (the type-specific word — Redirect's gateway address,
+/// Source Quench / Dest-Unreachable's unused word — occupies bytes 4..8),
+/// so the quoted IP header begins at `l4 + 8` for every one of them and the
+/// type-agnostic embedded parser/builders need no per-type handling. This
+/// now matches the broader [`reject_icmp_reply_suppressed`] set and Linux
+/// netfilter conntrack's related-ICMP `icmp_error` (3/4/5/11/12).
+///
+/// Type 4 (Source Quench) is deprecated (RFC 6633) and type 5 (Redirect)
+/// is normally link-scoped, so in practice a NATed transit instance is
+/// rare; including them is a correctness/parity completion, not a hot path.
+/// Note these two are still dropped (not mistranslated) on the NAT64
+/// cross-family path — they have no IPv6 analogue (RFC 7915, see
+/// `nat64.rs`); this set governs only same-family embedded-NAT reversal.
+///
+/// The ICMPv6 arm is the full ICMPv6 error range that carries a quoted
+/// packet: Destination Unreachable (1), Packet Too Big (2), Time Exceeded
+/// (3), Parameter Problem (4).
 pub(super) fn is_icmp_error(protocol: u8, icmp_type: u8) -> bool {
     match protocol {
-        PROTO_ICMP => matches!(icmp_type, 3 | 11 | 12),
+        PROTO_ICMP => matches!(icmp_type, 3 | 4 | 5 | 11 | 12),
         PROTO_ICMPV6 => matches!(icmp_type, 1 | 2 | 3 | 4),
         _ => false,
     }

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -3758,11 +3758,20 @@ fn embedded_icmp_nat_match_translates_redirect_v4() {
     let client_port: u16 = 12345;
 
     // ICMPv4 Redirect (5) carrying the SNAT'd inner tuple, then flip from
-    // the shared type-11 builder to type 5.
+    // the shared type-11 builder to type 5. Unlike Time Exceeded (whose
+    // bytes 4..8 are an unused word), a Redirect carries the better-gateway
+    // address there; set a distinctive non-zero sentinel so the test
+    // exercises a realistic Redirect AND can prove the embedded-NAT rewrite
+    // (at l4+8) leaves the gateway field (l4+4..8) untouched. Set the
+    // gateway BEFORE `rewrite_outer_icmpv4_type`, which recomputes the ICMP
+    // checksum over the whole header so the frame stays valid.
+    const REDIRECT_GATEWAY: [u8; 4] = [192, 0, 2, 1]; // RFC 5737 TEST-NET-1
     let mut frame =
         build_icmp_te_frame_v4(router_ip, snat_ip, server_ip, snat_port, 80, PROTO_TCP);
+    frame[38..42].copy_from_slice(&REDIRECT_GATEWAY); // ICMP bytes 4..8 = gateway
     rewrite_outer_icmpv4_type(&mut frame, 34, 5);
     assert_eq!(frame[34], 5, "outer ICMP type must be Redirect");
+    assert_eq!(&frame[38..42], &REDIRECT_GATEWAY, "gateway set in input frame");
 
     let meta = UserspaceDpMeta {
         magic: USERSPACE_META_MAGIC,
@@ -3862,6 +3871,17 @@ fn embedded_icmp_nat_match_translates_redirect_v4() {
     assert_eq!(
         embedded_src, client_ip,
         "embedded inner src must be translated from SNAT addr back to client"
+    );
+    // The Redirect-specific invariant: the gateway-address field (ICMP
+    // bytes 4..8 = frame offset 38..42, before the quoted IP at l4+8=42)
+    // must survive the embedded-NAT rewrite byte-for-byte. The rewrite
+    // touches only the quoted inner packet at l4+8 and the outer IP — never
+    // the type-specific header word. This assertion FAILS if the rewrite is
+    // ever changed to write into l4+4..8.
+    assert_eq!(
+        &result[38..42],
+        &REDIRECT_GATEWAY,
+        "Redirect gateway address must be preserved through embedded-NAT rewrite"
     );
 }
 

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -1127,13 +1127,19 @@ fn post_dnat_source_nat_matches_translated_destination() {
 
 #[test]
 fn is_icmp_error_identifies_v4_types() {
-    // ICMPv4 error types
+    // ICMPv4 error types that quote the offending datagram (RFC 792).
     assert!(is_icmp_error(PROTO_ICMP, 3)); // Destination Unreachable
+    // #2393: Source Quench (4) and Redirect (5) also quote an inner IP
+    // header + 8 bytes at l4+8 and must have their embedded inner
+    // translated on NAT44 transit, matching the reject/netfilter set.
+    assert!(is_icmp_error(PROTO_ICMP, 4)); // Source Quench (deprecated, RFC 6633)
+    assert!(is_icmp_error(PROTO_ICMP, 5)); // Redirect
     assert!(is_icmp_error(PROTO_ICMP, 11)); // Time Exceeded
     assert!(is_icmp_error(PROTO_ICMP, 12)); // Parameter Problem
-    // Non-error types
+    // Non-error (query) types
     assert!(!is_icmp_error(PROTO_ICMP, 0)); // Echo Reply
     assert!(!is_icmp_error(PROTO_ICMP, 8)); // Echo Request
+    assert!(!is_icmp_error(PROTO_ICMP, 13)); // Timestamp Request
 }
 
 #[test]
@@ -3716,6 +3722,146 @@ fn embedded_icmp_nat_match_uses_shared_nat_session_for_ipv4() {
     assert_eq!(
         icmp_match.resolution.neighbor_mac,
         Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff])
+    );
+}
+
+/// Rewrite the outer ICMPv4 type byte (frame[l4_offset]) to `new_type`
+/// and recompute the outer ICMP checksum, leaving the 8-byte ICMP header
+/// length unchanged. ICMPv4 Redirect (5) and Source Quench (4) share the
+/// 3/11/12 header layout — the type-specific word (Redirect's gateway
+/// address) occupies bytes 4..8 where Time Exceeded carries its unused
+/// word — so an existing type-11 frame becomes a valid type-5/4 frame by
+/// flipping the type byte and refreshing the checksum.
+fn rewrite_outer_icmpv4_type(frame: &mut [u8], l4_offset: usize, new_type: u8) {
+    frame[l4_offset] = new_type;
+    frame[l4_offset + 2] = 0;
+    frame[l4_offset + 3] = 0;
+    let csum = checksum16(&frame[l4_offset..]);
+    frame[l4_offset + 2..l4_offset + 4].copy_from_slice(&csum.to_be_bytes());
+}
+
+/// #2393: a NAT44-transit ICMPv4 Redirect (type 5) — like Time Exceeded
+/// (11) / Dest Unreachable (3) — quotes the offending datagram and MUST
+/// have its embedded inner addresses translated back to the pre-NAT
+/// tuple. Before #2393 the embedded-NAT `is_icmp_error` arm omitted 5, so
+/// the match returned None and the quoted inner kept the post-SNAT
+/// address (mismatched at the host). This test installs the SNAT session,
+/// flips an otherwise-identical TE frame to a Redirect, and asserts the
+/// match + reversed-frame build rewrite the embedded src to the client.
+#[test]
+fn embedded_icmp_nat_match_translates_redirect_v4() {
+    let router_ip = Ipv4Addr::new(10, 0, 0, 1);
+    let snat_ip = Ipv4Addr::new(172, 16, 80, 8);
+    let client_ip = Ipv4Addr::new(10, 0, 61, 102);
+    let server_ip = Ipv4Addr::new(1, 1, 1, 1);
+    let snat_port: u16 = 40000;
+    let client_port: u16 = 12345;
+
+    // ICMPv4 Redirect (5) carrying the SNAT'd inner tuple, then flip from
+    // the shared type-11 builder to type 5.
+    let mut frame =
+        build_icmp_te_frame_v4(router_ip, snat_ip, server_ip, snat_port, 80, PROTO_TCP);
+    rewrite_outer_icmpv4_type(&mut frame, 34, 5);
+    assert_eq!(frame[34], 5, "outer ICMP type must be Redirect");
+
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        l3_offset: 14,
+        l4_offset: 34,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_ICMP,
+        ..UserspaceDpMeta::default()
+    };
+
+    let mut sessions = SessionTable::new();
+    let forwarding = build_forwarding_state(&nat_snapshot());
+    let neighbors = Arc::new(ShardedNeighborMap::new());
+    learn_dynamic_neighbor(
+        &forwarding,
+        &neighbors,
+        24,
+        0,
+        IpAddr::V4(client_ip),
+        [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+    );
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+
+    // Forward-NAT session: client:port -> server:80, SNAT to snat_ip:snat_port.
+    assert!(sessions.install_with_protocol(
+        SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(client_ip),
+            dst_ip: IpAddr::V4(server_ip),
+            src_port: client_port,
+            dst_port: 80,
+        },
+        SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::ForwardCandidate,
+                local_ifindex: 0,
+                egress_ifindex: 24,
+                tx_ifindex: 24,
+                tunnel_endpoint_id: 0,
+                next_hop: Some(IpAddr::V4(client_ip)),
+                neighbor_mac: Some([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]),
+                src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x50, 0x08]),
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(snat_ip)),
+                rewrite_dst: None,
+                rewrite_src_port: Some(snat_port),
+                rewrite_dst_port: None,
+                nat64: false,
+                nptv6: false,
+            },
+        },
+        SessionMetadata {
+            ingress_zone: TEST_LAN_ZONE_ID,
+            egress_zone: TEST_WAN_ZONE_ID,
+            owner_rg_id: 0,
+            fabric_ingress: false,
+            is_reverse: false,
+            nat64_reverse: None,
+        },
+        1_000_000,
+        PROTO_TCP,
+        0,
+    ));
+
+    let icmp_match = try_embedded_icmp_nat_match_from_frame(
+        &frame,
+        meta,
+        &mut sessions,
+        &forwarding,
+        &neighbors,
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        1_000_000,
+    )
+    .expect("#2393: NAT44 Redirect must match the embedded session for reversal");
+
+    assert_eq!(icmp_match.original_src, IpAddr::V4(client_ip));
+    assert_eq!(icmp_match.original_src_port, client_port);
+
+    // Build the reversed frame and confirm BOTH the outer dst and the
+    // embedded inner src are translated back to the pre-NAT client.
+    let result = build_nat_reversed_icmp_error_v4(&frame, meta, &icmp_match)
+        .expect("#2393: reversed Redirect frame must build");
+    assert_eq!(result[34], 5, "reversed frame stays a Redirect");
+    let outer_dst = Ipv4Addr::new(result[30], result[31], result[32], result[33]);
+    assert_eq!(outer_dst, client_ip, "outer dst restored to client");
+    // Embedded IP starts at eth(14) + outer IP(20) + ICMP(8) = 42; src at +12.
+    let embedded_src = Ipv4Addr::new(result[54], result[55], result[56], result[57]);
+    assert_eq!(
+        embedded_src, client_ip,
+        "embedded inner src must be translated from SNAT addr back to client"
     );
 }
 


### PR DESCRIPTION
Closes #2393

## Outcome: fix added (types 4 + 5)

The embedded-ICMP-NAT reversal gate `is_icmp_error`
(`userspace-dp/src/afxdp/icmp.rs`) matched ICMPv4 error types **3/11/12**
but omitted **type 5 (Redirect)** and **type 4 (Source Quench)**. Both
carry a quoted inner packet that must be reversed on a NATed segment, and
investigation confirms they *can* transit this path — so this is a real
(latent, LOW) correctness gap, fixed by broadening the ICMPv4 arm to
**3/4/5/11/12**.

## Transit analysis (do type 4/5 reach this path?)

**Yes, on the same-family (NAT44) path.** Confirmed by codebase search:

- Same-family ICMP transit forwarding is **type-agnostic** — a transit
  ICMP packet enters the standard `ForwardCandidate` policy path
  (`poll_descriptor/mod.rs`) regardless of ICMP type. There is **no
  ICMP-type allowlist/blocklist and no link-scope drop** on this path.
- The **only** place type 4/5 are dropped is the **NAT64 cross-family**
  path: `map_icmpv4_error_to_icmpv6()` (`nat64.rs`) maps only 3/11/12 and
  returns `None` for 4/5, which are correctly dropped (no IPv6 analogue,
  RFC 7915). That is a *different* path (cf. #2405) and is unchanged.

So a NAT44-transit Redirect (5) / Source Quench (4) whose embedded inner
matches a NATed session was forwarded with its quoted inner addresses
left at the post-SNAT value — mismatched at the host that has to
correlate the error with its pre-NAT flow.

## RFC reasoning for 4/5

- **Type 4 (Source Quench)** is deprecated — RFC 6633 says routers MUST
  NOT generate it. Included for completeness/parity; near-zero practical
  traffic.
- **Type 5 (Redirect)** is normally link-scoped (a first-hop router tells
  a host on the same link about a better gateway) and not usually
  forwarded across subnets, so a NATed transit instance is rare.

Hence the **LOW** severity: real divergence from netfilter parity, but
marginal practical impact. The fix is mechanical and low-risk.

## Why no other code change is needed

All five types share the RFC 792 **8-byte ICMP header** layout — the
type-specific word (Redirect's gateway address; the unused word on the
others) occupies bytes 4..8 — so the quoted IP header always begins at
`l4 + 8`. The embedded parser and the `build_nat_reversed_icmp_error_v4`
builder are type-agnostic and need no per-type handling. The three gate
sites (`icmp_embed/mod.rs`, `icmp_embed/session_match.rs`,
`poll_descriptor/mod.rs`) share the single `is_icmp_error` SSOT, so they
all extend consistently.

The ICMPv4 set now matches the reject-suppression guard
(`reject_icmp_reply_suppressed`, 3/4/5/11/12) and Linux netfilter
conntrack's related-ICMP `icmp_error`. The stale "different (and broader)
set" comment on the reject guard is refreshed — the ICMPv4 sets are now
identical; only the ICMPv6 arms still differ (the reject guard suppresses
the whole `< 128` error range; `is_icmp_error` enumerates only the four
ICMPv6 errors that quote a translatable inner).

This is **not** #2371 (the embedded quoted-packet L4 checksum, left
unchanged) nor #2405 (NAT64 code 14) — #2393 is specifically the
type-match set for embedded-address rewrite.

## Tests

- `is_icmp_error_identifies_v4_types` — extended to assert types 4 and 5
  are now errors (and 13/Timestamp is not).
- `embedded_icmp_nat_match_translates_redirect_v4` (new, end-to-end):
  installs the SNAT session, flips an otherwise-identical Time Exceeded
  frame to a **Redirect (type 5)**, and asserts both the outer
  destination and the embedded inner source are reversed to the original
  client. **Verified it FAILS** when the v4 arm is reverted to 3/11/12.

`cargo build --release` clean; targeted suite (icmp/nat64/embedded/
redirect) **237 passed, 0 failed**; new tests 5x stable. Cold ICMP-error
NAT path — no smoke required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi