### PR TITLE
userspace-dp: suppress ICMP errors for IPv4 directed broadcasts (#2411)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11758,3 +11758,28 @@ top.
   userspace-dp/src/afxdp/tests.rs,
   userspace-dp/src/afxdp/tx/dispatch/mod.rs,
   userspace-dp/src/afxdp/README.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2411 PR #2434 review folds (test-fidelity + cleanup, no
+  production behavior change). (1) tests.rs
+  time_exceeded_emitted_for_unicast_udp passed &ForwardingState::default()
+  to the gate while building `fwd` just below — changed to &fwd so the
+  assertion exercises the real connected-route forwarding state (unicast,
+  so still passes). (2) icmp_ptb_tests.rs
+  ptb_suppressed_for_v4_directed_broadcast_dst had a VACUOUS second
+  assertion (`build_frag_needed_v4(..).is_none() || ptb_reply_suppressed(..)`
+  — the OR'd suppressed check was already asserted true above, so always
+  passed). Removed it: build_frag_needed_v4 does NOT consult the gate (it
+  builds a frame regardless); the dispatch path calls it only behind
+  `if !ptb_reply_suppressed(..)`, so the gate assertion above IS the real
+  non-vacuous fail-on-revert invariant — asserting .is_none() on the
+  builder would be wrong. Added a comment explaining why. (3) inspect.rs
+  dest_is_directed_broadcast dropped the redundant `entry.prefix
+  .contains(dst) &&` — `directed_broadcast() == dst` already implies
+  containment (dst & mask == network when host bits are all-ones). Build
+  clean; icmp/icmp_ptb/prefix/broadcast/directed tests green (161
+  passed); the 2 suppression tests still FAIL on a stubbed-false gate;
+  new tests 5x stable.
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs,
+  userspace-dp/src/afxdp/tests.rs, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -11726,3 +11726,35 @@ top.
 - **File(s)**: userspace-dp/src/afxdp/gre.rs,
   userspace-dp/src/afxdp/tests.rs, docs/userspace-native-gre-plan.md,
   _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2411 — suppress ICMP errors for IPv4 subnet-directed
+  broadcasts (RFC 1812 §4.3.2.7). Confirmed the existing gate predicate
+  `dest_is_multicast_or_broadcast` covers L3 multicast + limited
+  broadcast (255.255.255.255 via `Ipv4Addr::is_broadcast()`) but NOT
+  directed broadcasts (e.g. 10.0.1.255 for a /24), which are plain
+  unicast to that test. Found the connected-route table
+  (`ForwardingState.connected_v4`, `ConnectedRouteV4 { prefix: PrefixV4
+  }`) IS reachable at all three ICMP-error gate sites: both
+  `can_generate_icmp_error_reply` callers (reject + Time-Exceeded
+  builders) already take `&ForwardingState`, and the PTB caller in
+  `tx/dispatch/mod.rs` has `forwarding` in scope. Added
+  `PrefixV4::directed_broadcast()` (`network | !mask`) + a shared
+  `dest_is_directed_broadcast(forwarding, packet)` predicate (v4-only,
+  skips prefix_len >= 31, reuses the same connected_v4 scan the FIB
+  does — cold path only). Threaded `&ForwardingState` into
+  `can_generate_icmp_error_reply` and `ptb_reply_suppressed` (v4-gated)
+  and added the check alongside the multicast/limited-broadcast/source
+  gates. 5 new tests (reject + PTB directed-broadcast suppressed;
+  unicast-in-subnet still allowed; /32 host not mis-suppressed); the two
+  suppression tests FAIL when the check is stubbed to false. Build clean,
+  icmp/prefix tests green (91 passed), new tests 5x stable.
+- **File(s)**: userspace-dp/src/prefix.rs,
+  userspace-dp/src/afxdp/frame/inspect.rs,
+  userspace-dp/src/afxdp/frame/mod.rs,
+  userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/icmp_ptb.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs,
+  userspace-dp/src/afxdp/tests.rs,
+  userspace-dp/src/afxdp/tx/dispatch/mod.rs,
+  userspace-dp/src/afxdp/README.md, _Log.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -210,7 +210,27 @@ sync.
   `None`/`None`). An output-filter drop lands on `ptb_output_filter_drops`;
   a parse failure of the built bytes fails CLOSED on
   `generated_reply_classify_parse_errors` (§6.2), never leaking the PTB
-  past an output `discard`.
+  past an output `discard`. #2411: the gate now ALSO drops ICMP errors
+  (reject, Time-Exceeded, and PTB) triggered by an IPv4 datagram destined
+  to a *subnet-directed* broadcast — the all-ones host of a configured
+  connected prefix, e.g. `10.0.1.255` for a connected `10.0.1.0/24`. RFC
+  1812 §4.3.2.7 forbids originating an ICMP error to any broadcast,
+  directed broadcasts included; but a directed broadcast is a plain
+  unicast to the limited-broadcast (`255.255.255.255`) / multicast tests,
+  so recognizing it needs the configured subnet MASK. The new shared
+  `dest_is_directed_broadcast` predicate (`frame/inspect.rs`) reuses the
+  forwarding state's connected-route table (`connected_v4`, the SAME rows
+  the FIB lookup scans — no new infrastructure) and suppresses when the
+  destination equals `network | !mask` of a connected prefix shorter than
+  /31 (a /31 has no broadcast per RFC 3021 and a /32's all-ones host is
+  the host itself, so both are skipped to avoid mis-suppressing a
+  legitimate unicast). `can_generate_icmp_error_reply` and
+  `ptb_reply_suppressed` both take `&ForwardingState` and call it (v4-only
+  — IPv6 has no broadcast), so the reject, Time-Exceeded, and PTB paths
+  apply ONE directed-broadcast gate. The lookup is a COLD-path scan: it
+  runs only when an ICMP error is about to be generated, never on the
+  per-packet fast path. No new counter — a suppressed error folds into
+  the existing fail-closed silent drop.
 - `cos/` — Class-of-Service scheduler: token-bucket admission, MQFQ
   active-bucket selection, fair-share lease (#1229 Phase 6 v8). See
   `docs/per-5-tuple/state.md` for the architectural ceiling.

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -551,6 +551,51 @@ pub(in crate::afxdp) fn dest_is_multicast_or_broadcast(addr_family: u8, packet: 
     }
 }
 
+/// #2411: RFC 1812 §4.3.2.7 — a router MUST NOT originate an ICMP error
+/// in reply to a datagram whose IP destination is a *directed* (subnet)
+/// broadcast, e.g. `10.0.1.255` for a connected `10.0.1.0/24`. Unlike
+/// the limited broadcast (`255.255.255.255`, caught by
+/// [`dest_is_multicast_or_broadcast`]'s `is_broadcast()`), a directed
+/// broadcast is a normal unicast address to the L3 destination test —
+/// recognizing it requires the configured subnet MASK, which only the
+/// forwarding state's connected-route table carries. This is the
+/// per-interface-prefix sibling of [`dest_is_multicast_or_broadcast`]
+/// (L3 group/limited-broadcast), [`l2_dst_is_group_or_broadcast`] (L2),
+/// and [`source_is_invalid_for_icmp_error`] (L3 source); it is shared by
+/// the reject / Time-Exceeded path (`can_generate_icmp_error_reply`) and
+/// the PTB path (`ptb_reply_suppressed`) so every locally generated ICMP
+/// error applies the SAME directed-broadcast gate.
+///
+/// IPv4-only: IPv6 has no broadcast (the v6 caller never invokes this).
+/// `packet` is the L3 (IP-header-first) slice. Returns `true` when the
+/// destination is the all-ones host address of a connected prefix and
+/// the ICMP error MUST be suppressed. A too-short slice fails closed
+/// (suppress). The connected table is reused from the forwarding path
+/// (no new infrastructure); the scan is the same `connected_v4.iter()`
+/// the FIB lookup already does, on a cold (error-generation) path only.
+///
+/// Prefixes shorter than /31 are the only ones with a meaningful
+/// directed broadcast: a /31 (RFC 3021) has no broadcast and a /32's
+/// host-all-ones value equals the host itself, so both are skipped to
+/// avoid mis-suppressing a legitimate unicast to a /32 connected host.
+#[inline]
+pub(in crate::afxdp) fn dest_is_directed_broadcast(
+    forwarding: &ForwardingState,
+    packet: &[u8],
+) -> bool {
+    let Some(dst) = packet.get(16..20) else {
+        // Fail closed: a destination we cannot read must suppress the
+        // error rather than risk directed-broadcast backscatter.
+        return true;
+    };
+    let dst = Ipv4Addr::new(dst[0], dst[1], dst[2], dst[3]);
+    forwarding.connected_v4.iter().any(|entry| {
+        entry.prefix.prefix_len() < 31
+            && entry.prefix.contains(dst)
+            && entry.prefix.directed_broadcast() == dst
+    })
+}
+
 /// #2367: RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a router MUST NOT
 /// originate an ICMP/ICMPv6 *error* in response to a datagram whose IP
 /// SOURCE address does not uniquely identify a single host. A locally

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -589,11 +589,16 @@ pub(in crate::afxdp) fn dest_is_directed_broadcast(
         return true;
     };
     let dst = Ipv4Addr::new(dst[0], dst[1], dst[2], dst[3]);
-    forwarding.connected_v4.iter().any(|entry| {
-        entry.prefix.prefix_len() < 31
-            && entry.prefix.contains(dst)
-            && entry.prefix.directed_broadcast() == dst
-    })
+    // `directed_broadcast() == dst` already implies the prefix contains
+    // dst: a directed broadcast is `network | !mask`, so `dst & mask ==
+    // network` (the host bits are all-ones and masked off) — i.e.
+    // `contains(dst)` is necessarily true. The explicit `contains` check
+    // would be redundant, so only the broadcast-equality and the
+    // prefix-length guard remain.
+    forwarding
+        .connected_v4
+        .iter()
+        .any(|entry| entry.prefix.prefix_len() < 31 && entry.prefix.directed_broadcast() == dst)
 }
 
 /// #2367: RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a router MUST NOT

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -61,9 +61,10 @@ pub(super) use inspect::{
     parse_zone_encoded_fabric_ingress, parse_zone_encoded_fabric_ingress_from_frame,
 };
 pub(in crate::afxdp) use inspect::{
-    authoritative_forward_ports, decode_frame_summary, dest_is_multicast_or_broadcast,
-    forward_tuple_mismatch_reason, ipv4_is_any_fragment, ipv4_is_non_first_fragment,
-    ipv6_is_any_fragment, ipv6_is_non_first_fragment, is_any_fragment, is_non_first_fragment,
+    authoritative_forward_ports, decode_frame_summary, dest_is_directed_broadcast,
+    dest_is_multicast_or_broadcast, forward_tuple_mismatch_reason, ipv4_is_any_fragment,
+    ipv4_is_non_first_fragment, ipv6_is_any_fragment, ipv6_is_non_first_fragment, is_any_fragment,
+    is_non_first_fragment,
     l2_dst_is_group_or_broadcast, parse_session_flow, source_is_invalid_for_icmp_error,
     term_match_extra_from_frame, term_match_extra_from_frame_fwd, term_match_extra_from_meta,
     try_parse_metadata,

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -28,7 +28,18 @@ pub(super) const FABRIC_INGRESS_FLAG: u8 = 0x80;
 /// `protocol`/`icmp_type`/fragment status are read from the inbound
 /// frame; the L4/ICMP-type read uses `meta.l4_offset`, which the shim
 /// fills for ICMP, matching [`build_reject_icmp_unreachable`].
-pub(super) fn can_generate_icmp_error_reply(frame: &[u8], meta: UserspaceDpMeta) -> bool {
+///
+/// `forwarding` supplies the connected-route table for the #2411
+/// directed-broadcast check (RFC 1812 §4.3.2.7): an IPv4 destination
+/// that is the all-ones host address of a configured connected subnet
+/// (e.g. `10.0.1.255` for `10.0.1.0/24`) is a subnet-directed broadcast
+/// and must also suppress the error. This is a cold-path lookup only —
+/// the gate runs solely when an error is about to be generated.
+pub(super) fn can_generate_icmp_error_reply(
+    frame: &[u8],
+    meta: UserspaceDpMeta,
+    forwarding: &ForwardingState,
+) -> bool {
     let l3 = match meta.l3_offset {
         14 | 18 => meta.l3_offset as usize,
         _ => match frame_l3_offset(frame) {
@@ -66,8 +77,12 @@ pub(super) fn can_generate_icmp_error_reply(frame: &[u8], meta: UserspaceDpMeta)
             // tests route through the shared predicates (#2367 source,
             // #2314 destination) so the PTB, reject, and Time Exceeded
             // paths agree on the disallowed source/destination sets.
+            // #2411: also suppress for an IPv4 subnet-directed broadcast
+            // (all-ones host of a connected prefix) — invisible to the
+            // limited-broadcast test, needs the connected subnet mask.
             if source_is_invalid_for_icmp_error(meta.addr_family, packet)
                 || dest_is_multicast_or_broadcast(meta.addr_family, packet)
+                || dest_is_directed_broadcast(forwarding, packet)
             {
                 return false;
             }
@@ -142,7 +157,7 @@ pub(super) fn build_local_time_exceeded_request(
     // originate a Time Exceeded in reply to an ICMP error, a non-first
     // fragment, a group/broadcast destination, or a bogus source. The
     // sibling reject path enforces the same contract via this gate.
-    if !can_generate_icmp_error_reply(frame, meta) {
+    if !can_generate_icmp_error_reply(frame, meta, forwarding) {
         return None;
     }
 
@@ -493,7 +508,7 @@ pub(super) fn build_reject_icmp_unreachable(
     // Subsumes the prior inline non-first-fragment and inbound-ICMP-error
     // checks and additionally suppresses group/broadcast destinations and
     // bogus sources — the same contract the Time Exceeded path now uses.
-    if !can_generate_icmp_error_reply(frame, meta) {
+    if !can_generate_icmp_error_reply(frame, meta, forwarding) {
         return None;
     }
     match meta.addr_family as i32 {
@@ -768,7 +783,7 @@ mod tests {
         let (mut frame, meta) = inbound_v4(InL2::Untagged);
         set_inbound_v4_dst(&mut frame, meta, Ipv4Addr::new(239, 1, 2, 3));
         assert!(
-            !can_generate_icmp_error_reply(&frame, meta),
+            !can_generate_icmp_error_reply(&frame, meta, &forwarding_with_egress(0)),
             "IPv4 multicast destination must suppress the reply"
         );
         let fwd = forwarding_with_egress(0);
@@ -785,8 +800,71 @@ mod tests {
         let (mut frame, meta) = inbound_v4(InL2::Untagged);
         set_inbound_v4_dst(&mut frame, meta, Ipv4Addr::new(255, 255, 255, 255));
         assert!(
-            !can_generate_icmp_error_reply(&frame, meta),
+            !can_generate_icmp_error_reply(&frame, meta, &forwarding_with_egress(0)),
             "IPv4 limited broadcast destination must suppress the reply"
+        );
+    }
+
+    /// #2411: a `ForwardingState` whose connected v4 table holds a single
+    /// connected prefix, so the directed-broadcast gate has a subnet mask
+    /// to test the trigger destination against.
+    fn forwarding_with_connected_v4(cidr: &str) -> ForwardingState {
+        let mut state = forwarding_with_egress(0);
+        state.connected_v4.push(ConnectedRouteV4 {
+            prefix: crate::prefix::PrefixV4::from_net(cidr.parse().expect("cidr")),
+            ifindex: ICMP_IFINDEX,
+            tunnel_endpoint_id: 0,
+        });
+        state
+    }
+
+    /// #2411: an IPv4 trigger destined to a SUBNET-DIRECTED broadcast
+    /// (the all-ones host of a configured connected prefix, e.g.
+    /// 10.0.1.255 for 10.0.1.0/24) must suppress the locally generated
+    /// ICMP error (RFC 1812 §4.3.2.7) even though it is a plain unicast
+    /// address to the limited-broadcast / multicast tests. Fails (error
+    /// generated) if the `dest_is_directed_broadcast` check is removed.
+    #[test]
+    fn reject_suppressed_for_v4_directed_broadcast_dst() {
+        let (mut frame, meta) = inbound_v4(InL2::Untagged);
+        set_inbound_v4_dst(&mut frame, meta, Ipv4Addr::new(10, 0, 1, 255));
+        let fwd = forwarding_with_connected_v4("10.0.1.0/24");
+        assert!(
+            !can_generate_icmp_error_reply(&frame, meta, &fwd),
+            "IPv4 subnet-directed broadcast must suppress the reply"
+        );
+        assert!(
+            build_reject_icmp_unreachable(&frame, meta, ICMP_IFINDEX, &fwd).is_none(),
+            "reject unreachable must not build for a directed broadcast"
+        );
+    }
+
+    /// #2411 anti-over-suppress: a normal unicast HOST inside the same
+    /// connected subnet (10.0.1.42 in 10.0.1.0/24) must STILL generate
+    /// the error — only the all-ones host is the directed broadcast.
+    #[test]
+    fn reject_still_allowed_for_unicast_in_connected_subnet() {
+        let (mut frame, meta) = inbound_v4(InL2::Untagged);
+        set_inbound_v4_dst(&mut frame, meta, Ipv4Addr::new(10, 0, 1, 42));
+        let fwd = forwarding_with_connected_v4("10.0.1.0/24");
+        assert!(
+            can_generate_icmp_error_reply(&frame, meta, &fwd),
+            "a unicast host inside a connected subnet must allow the reply"
+        );
+    }
+
+    /// #2411 fail-on-revert guard for the prefix-length skip: the .255
+    /// host of a /32 connected prefix is the host itself, NOT a directed
+    /// broadcast, so a normal unicast to a /32 host must NOT be
+    /// suppressed (the `prefix_len() < 31` guard keeps it allowed).
+    #[test]
+    fn reject_still_allowed_for_v4_host_route_all_ones_octet() {
+        let (mut frame, meta) = inbound_v4(InL2::Untagged);
+        set_inbound_v4_dst(&mut frame, meta, Ipv4Addr::new(10, 0, 1, 255));
+        let fwd = forwarding_with_connected_v4("10.0.1.255/32");
+        assert!(
+            can_generate_icmp_error_reply(&frame, meta, &fwd),
+            "a /32 connected host must not be treated as a directed broadcast"
         );
     }
 
@@ -796,7 +874,7 @@ mod tests {
     fn reject_suppressed_for_v6_multicast_dst() {
         let (frame, meta) = inbound_v6_to("ff02::1".parse().expect("v6 mcast"));
         assert!(
-            !can_generate_icmp_error_reply(&frame, meta),
+            !can_generate_icmp_error_reply(&frame, meta, &forwarding_with_egress(0)),
             "IPv6 multicast destination must suppress the reply"
         );
         let fwd = forwarding_with_egress(0);
@@ -814,7 +892,7 @@ mod tests {
         // IPv4 default destination 172.16.80.200 is plain unicast.
         let (frame4, meta4) = inbound_v4(InL2::Untagged);
         assert!(
-            can_generate_icmp_error_reply(&frame4, meta4),
+            can_generate_icmp_error_reply(&frame4, meta4, &forwarding_with_egress(0)),
             "a unicast IPv4 destination must allow the reply"
         );
         let fwd = forwarding_with_egress(0);
@@ -825,7 +903,7 @@ mod tests {
         // IPv6 global unicast destination.
         let (frame6, meta6) = inbound_v6_to("2001:559:8585:80::200".parse().expect("v6 ucast"));
         assert!(
-            can_generate_icmp_error_reply(&frame6, meta6),
+            can_generate_icmp_error_reply(&frame6, meta6, &forwarding_with_egress(0)),
             "a unicast IPv6 destination must allow the reply"
         );
     }

--- a/userspace-dp/src/afxdp/icmp_ptb.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb.rs
@@ -212,11 +212,19 @@ fn ipv4_df_set(packet: &[u8]) -> bool {
 /// into an ICMP-error backscatter storm), or to an inbound ICMP/ICMPv6
 /// *error* message (avoid error loops and amplification). Returns true
 /// when a PTB MUST be suppressed.
+///
+/// `forwarding` supplies the connected-route table for the #2411 IPv4
+/// directed-broadcast check (RFC 1812 §4.3.2.7): a PTB to the all-ones
+/// host of a connected subnet (e.g. `10.0.1.255` for `10.0.1.0/24`) is a
+/// subnet-directed broadcast and must be suppressed. v4-only; the table
+/// scan is a cold-path lookup that runs only when a PTB is about to be
+/// generated.
 #[inline]
 pub(in crate::afxdp) fn ptb_reply_suppressed(
     frame: &[u8],
     meta: UserspaceDpMeta,
     l3_offset: usize,
+    forwarding: &ForwardingState,
 ) -> bool {
     // #2325: never generate a PTB in reply to a datagram delivered as an
     // L2 broadcast/multicast frame. This gives the PTB path the same L2
@@ -249,6 +257,13 @@ pub(in crate::afxdp) fn ptb_reply_suppressed(
     // #2314: never generate a PTB in reply to a datagram whose IP
     // destination was multicast or broadcast.
     if dest_is_multicast_or_broadcast(meta.addr_family, packet) {
+        return true;
+    }
+    // #2411: never generate a PTB in reply to an IPv4 subnet-directed
+    // broadcast (all-ones host of a connected prefix). v4-only — IPv6
+    // has no broadcast and `dest_is_directed_broadcast` reads the v4
+    // destination octets, so it is gated on AF_INET.
+    if meta.addr_family as i32 == libc::AF_INET && dest_is_directed_broadcast(forwarding, packet) {
         return true;
     }
     if matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6) {

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -117,7 +117,7 @@ fn oversized_v4_df_udp_emits_frag_needed() {
     assert_eq!(next_hop_mtu, 1400, "advertised MTU must equal the egress MTU");
 
     assert!(
-        !ptb_reply_suppressed(&frame, meta, l3),
+        !ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "a plain UDP frame must not be suppressed"
     );
 
@@ -262,7 +262,7 @@ fn non_first_fragment_v4_is_suppressed() {
     };
     frame[l3 + 10..l3 + 12].copy_from_slice(&ip_csum.to_be_bytes());
     assert!(
-        ptb_reply_suppressed(&frame, meta, l3),
+        ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "non-first fragment must be suppressed"
     );
 }
@@ -296,7 +296,7 @@ fn inbound_icmp_error_is_suppressed() {
         ..UserspaceDpMeta::default()
     };
     assert!(
-        ptb_reply_suppressed(&frame, meta, l3),
+        ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "inbound ICMP error must be suppressed"
     );
     // Counter-factual: an inbound ICMP *echo request* (query, type 8) is
@@ -308,7 +308,7 @@ fn inbound_icmp_error_is_suppressed() {
         ..meta
     };
     assert!(
-        !ptb_reply_suppressed(&echo, echo_meta, l3),
+        !ptb_reply_suppressed(&echo, echo_meta, l3, &ForwardingState::default()),
         "an inbound ICMP echo request is a query, not suppressed"
     );
 }
@@ -338,7 +338,7 @@ fn ptb_suppressed_for_v4_multicast_dst() {
     let l3 = meta.l3_offset as usize;
     set_v4_dst(&mut frame, l3, Ipv4Addr::new(239, 1, 2, 3));
     assert!(
-        ptb_reply_suppressed(&frame, meta, l3),
+        ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "IPv4 multicast destination must suppress the PTB"
     );
 }
@@ -351,8 +351,56 @@ fn ptb_suppressed_for_v4_limited_broadcast_dst() {
     let l3 = meta.l3_offset as usize;
     set_v4_dst(&mut frame, l3, Ipv4Addr::new(255, 255, 255, 255));
     assert!(
-        ptb_reply_suppressed(&frame, meta, l3),
+        ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "IPv4 limited broadcast destination must suppress the PTB"
+    );
+}
+
+/// #2411: an oversized DF IPv4 datagram destined to a SUBNET-DIRECTED
+/// broadcast (all-ones host of a connected prefix, e.g. 10.0.1.255 for
+/// 10.0.1.0/24) must NOT generate a PTB (RFC 1812 §4.3.2.7). The
+/// directed broadcast is a plain unicast to the limited-broadcast test,
+/// so this exercises the connected-prefix lookup. Fails (PTB built) if
+/// the `dest_is_directed_broadcast` check is removed.
+#[test]
+fn ptb_suppressed_for_v4_directed_broadcast_dst() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    set_v4_dst(&mut frame, l3, Ipv4Addr::new(10, 0, 1, 255));
+    let mut fwd = forwarding_with_egress(1400);
+    fwd.connected_v4.push(ConnectedRouteV4 {
+        prefix: crate::prefix::PrefixV4::from_net("10.0.1.0/24".parse().expect("cidr")),
+        ifindex: PTB_IFINDEX,
+        tunnel_endpoint_id: 0,
+    });
+    assert!(
+        ptb_reply_suppressed(&frame, meta, l3, &fwd),
+        "IPv4 subnet-directed broadcast must suppress the PTB"
+    );
+    assert!(
+        build_frag_needed_v4(&frame, meta, PTB_IFINDEX, &fwd, 1400).is_none()
+            || ptb_reply_suppressed(&frame, meta, l3, &fwd),
+        "directed-broadcast PTB must be gated by the suppression predicate"
+    );
+}
+
+/// #2411 anti-over-suppress: a normal unicast HOST inside the same
+/// connected subnet must STILL generate the PTB; only the all-ones host
+/// is the directed broadcast.
+#[test]
+fn ptb_still_generated_for_unicast_in_connected_subnet() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    set_v4_dst(&mut frame, l3, Ipv4Addr::new(10, 0, 1, 42));
+    let mut fwd = forwarding_with_egress(1400);
+    fwd.connected_v4.push(ConnectedRouteV4 {
+        prefix: crate::prefix::PrefixV4::from_net("10.0.1.0/24".parse().expect("cidr")),
+        ifindex: PTB_IFINDEX,
+        tunnel_endpoint_id: 0,
+    });
+    assert!(
+        !ptb_reply_suppressed(&frame, meta, l3, &fwd),
+        "a unicast host inside a connected subnet must NOT suppress the PTB"
     );
 }
 
@@ -364,7 +412,7 @@ fn ptb_suppressed_for_v6_multicast_dst() {
     let l3 = meta.l3_offset as usize;
     set_v6_dst(&mut frame, l3, "ff02::1".parse().expect("v6 mcast"));
     assert!(
-        ptb_reply_suppressed(&frame, meta, l3),
+        ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "IPv6 multicast destination must suppress the PTB"
     );
 }
@@ -407,7 +455,7 @@ fn ptb_still_generated_for_v4_unicast_dst() {
     let l3 = meta.l3_offset as usize;
     // The default destination 172.16.80.200 is plain unicast.
     assert!(
-        !ptb_reply_suppressed(&frame, meta, l3),
+        !ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "a unicast destination must NOT suppress the PTB"
     );
     let fwd = forwarding_with_egress(1400);
@@ -438,7 +486,7 @@ fn ptb_suppressed_for_l2_multicast_dst() {
     // first octet (0x01) is the IEEE group bit.
     set_l2_dst(&mut frame, [0x01, 0x00, 0x5e, 0x01, 0x02, 0x03]);
     assert!(
-        ptb_reply_suppressed(&frame, meta, l3),
+        ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "L2 multicast (group bit) destination must suppress the PTB"
     );
 }
@@ -452,7 +500,7 @@ fn ptb_suppressed_for_l2_broadcast_dst() {
     let l3 = meta.l3_offset as usize;
     set_l2_dst(&mut frame, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
     assert!(
-        ptb_reply_suppressed(&frame, meta, l3),
+        ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "L2 broadcast destination must suppress the PTB"
     );
 }
@@ -465,7 +513,7 @@ fn ptb_suppressed_for_l2_multicast_dst_v6() {
     let l3 = meta.l3_offset as usize;
     set_l2_dst(&mut frame, [0x33, 0x33, 0x00, 0x00, 0x00, 0x01]);
     assert!(
-        ptb_reply_suppressed(&frame, meta, l3),
+        ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "L2 multicast (33:33:..) destination must suppress the IPv6 PTB"
     );
 }
@@ -482,7 +530,7 @@ fn ptb_still_generated_for_l2_unicast_dst() {
     // A plain unicast MAC: low bit of the first octet clear.
     set_l2_dst(&mut frame, [0x02, 0xbf, 0x72, 0x00, 0x00, 0x09]);
     assert!(
-        !ptb_reply_suppressed(&frame, meta, l3),
+        !ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "unicast L2 + unicast L3 destination must NOT suppress the PTB"
     );
     let fwd = forwarding_with_egress(1400);
@@ -552,7 +600,7 @@ fn ptb_suppressed_for_v4_bad_source_backscatter() {
         let l3 = meta.l3_offset as usize;
         set_v4_src(&mut frame, l3, bad);
         assert!(
-            ptb_reply_suppressed(&frame, meta, l3),
+            ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
             "IPv4 forbidden source {bad} must suppress the PTB (backscatter)"
         );
     }
@@ -568,7 +616,7 @@ fn ptb_suppressed_for_v6_bad_source_backscatter() {
         let l3 = meta.l3_offset as usize;
         set_v6_src(&mut frame, l3, bad.parse().expect("v6 src"));
         assert!(
-            ptb_reply_suppressed(&frame, meta, l3),
+            ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
             "IPv6 forbidden source {bad} must suppress the PTB (backscatter)"
         );
     }
@@ -586,7 +634,7 @@ fn ptb_still_generated_for_v4_unicast_source() {
     // Plain unicast source, distinct from the default to be explicit.
     set_v4_src(&mut frame, l3, Ipv4Addr::new(203, 0, 113, 7));
     assert!(
-        !ptb_reply_suppressed(&frame, meta, l3),
+        !ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "a unicast source must NOT suppress the PTB (PMTUD)"
     );
     let fwd = forwarding_with_egress(1400);
@@ -608,7 +656,7 @@ fn ptb_still_generated_for_v6_unicast_source() {
     let l3 = meta.l3_offset as usize;
     // The default source 2001:559:8585:bf01::20 is unicast.
     assert!(
-        !ptb_reply_suppressed(&frame, meta, l3),
+        !ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()),
         "a unicast IPv6 source must NOT suppress the PTB (PMTUD)"
     );
     let fwd = forwarding_with_egress(1280);
@@ -872,7 +920,7 @@ fn post_transform_gre_oversized_v4_df_emits_inner_ptb() {
         other => panic!("expected EmitPacketTooBig, got {other:?}"),
     };
     assert_eq!(next_hop_mtu, 1376, "advertised MTU = GRE inner MTU, not transport MTU");
-    assert!(!ptb_reply_suppressed(&frame, meta, l3));
+    assert!(!ptb_reply_suppressed(&frame, meta, l3, &ForwardingState::default()));
     let out = build_frag_needed_v4(&frame, meta, PTB_IFINDEX, &fwd, next_hop_mtu)
         .expect("inner-source frag-needed must build");
     let icmp = 14 + 20;

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -377,11 +377,14 @@ fn ptb_suppressed_for_v4_directed_broadcast_dst() {
         ptb_reply_suppressed(&frame, meta, l3, &fwd),
         "IPv4 subnet-directed broadcast must suppress the PTB"
     );
-    assert!(
-        build_frag_needed_v4(&frame, meta, PTB_IFINDEX, &fwd, 1400).is_none()
-            || ptb_reply_suppressed(&frame, meta, l3, &fwd),
-        "directed-broadcast PTB must be gated by the suppression predicate"
-    );
+    // Note: `build_frag_needed_v4` does NOT itself consult the
+    // suppression gate (it would happily build a frame for a directed
+    // broadcast). The dispatch path (`tx/dispatch/mod.rs`) only calls the
+    // builder behind `if !ptb_reply_suppressed(..)`, so the gate above IS
+    // the call-site invariant — asserting `build_frag_needed_v4(..)
+    // .is_none()` here would be WRONG (the builder builds; the gate is
+    // what stops the send). The gate assertion fails on a stubbed-false
+    // `dest_is_directed_broadcast`, which is the regression we guard.
 }
 
 /// #2411 anti-over-suppress: a normal unicast HOST inside the same

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -1876,7 +1876,7 @@ fn time_exceeded_emitted_for_unicast_udp() {
     let frame = build_udp_frame_v4_full([0x00, 0x25, 0x90, 0x12, 0x34, 0x56], client, server, 1);
     let meta = ttl_meta_v4();
     let fwd = icmp_suppress_forwarding();
-    assert!(can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()));
+    assert!(can_generate_icmp_error_reply(&frame, meta, &fwd));
     let desc = XdpDesc {
         addr: 4096,
         len: frame.len() as u32,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -1876,7 +1876,7 @@ fn time_exceeded_emitted_for_unicast_udp() {
     let frame = build_udp_frame_v4_full([0x00, 0x25, 0x90, 0x12, 0x34, 0x56], client, server, 1);
     let meta = ttl_meta_v4();
     let fwd = icmp_suppress_forwarding();
-    assert!(can_generate_icmp_error_reply(&frame, meta));
+    assert!(can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()));
     let desc = XdpDesc {
         addr: 4096,
         len: frame.len() as u32,
@@ -1917,7 +1917,7 @@ fn time_exceeded_emitted_for_unicast_tcp() {
     let mut meta = ttl_meta_v4();
     meta.protocol = PROTO_TCP;
     assert!(
-        can_generate_icmp_error_reply(&frame, meta),
+        can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()),
         "unicast TCP TTL 1 must be allowed"
     );
 }
@@ -1940,7 +1940,7 @@ fn time_exceeded_suppressed_for_inbound_icmp_error_v4() {
     };
     let fwd = icmp_suppress_forwarding();
     assert!(
-        !can_generate_icmp_error_reply(&frame, meta),
+        !can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()),
         "gate must suppress reply to an inbound ICMP error"
     );
     let desc = XdpDesc {
@@ -1965,7 +1965,7 @@ fn time_exceeded_suppressed_for_inbound_icmp_error_v4() {
     let mut echo = build_icmp_echo_frame_v4(client, server, 1);
     echo[34] = 8;
     assert!(
-        can_generate_icmp_error_reply(&echo, meta),
+        can_generate_icmp_error_reply(&echo, meta, &ForwardingState::default()),
         "inbound ICMP echo request (query) must still draw an error"
     );
 }
@@ -1986,13 +1986,13 @@ fn time_exceeded_suppressed_for_inbound_icmp_error_v6() {
         ..UserspaceDpMeta::default()
     };
     assert!(
-        !can_generate_icmp_error_reply(&frame, meta),
+        !can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()),
         "gate must suppress reply to an inbound ICMPv6 error"
     );
     // ICMPv6 echo request (type 128, a query) is NOT suppressed.
     let echo = build_icmp_echo_frame_v6(client, server, 1); // type 128
     assert!(
-        can_generate_icmp_error_reply(&echo, meta),
+        can_generate_icmp_error_reply(&echo, meta, &ForwardingState::default()),
         "inbound ICMPv6 echo request must still draw an error"
     );
 }
@@ -2012,7 +2012,7 @@ fn time_exceeded_suppressed_for_non_first_fragment_v4() {
     frame[24..26].copy_from_slice(&csum.to_be_bytes());
     let meta = ttl_meta_v4();
     assert!(
-        !can_generate_icmp_error_reply(&frame, meta),
+        !can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()),
         "gate must suppress reply to a non-first IPv4 fragment"
     );
     assert!(
@@ -2049,7 +2049,7 @@ fn time_exceeded_suppressed_for_non_first_fragment_v6() {
         ..UserspaceDpMeta::default()
     };
     assert!(
-        !can_generate_icmp_error_reply(&frame, meta),
+        !can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()),
         "gate must suppress reply to a non-first IPv6 fragment"
     );
     assert!(
@@ -2066,7 +2066,7 @@ fn time_exceeded_suppressed_for_multicast_dest_v4() {
     let frame = build_udp_frame_v4_full([0x01, 0x00, 0x5e, 0x00, 0x00, 0xfb], client, mcast, 1);
     let meta = ttl_meta_v4();
     assert!(
-        !can_generate_icmp_error_reply(&frame, meta),
+        !can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()),
         "gate must suppress reply to a multicast destination"
     );
     assert!(
@@ -2084,7 +2084,7 @@ fn time_exceeded_suppressed_for_l2_broadcast_dest() {
     let frame = build_udp_frame_v4_full([0xff, 0xff, 0xff, 0xff, 0xff, 0xff], client, server, 1);
     let meta = ttl_meta_v4();
     assert!(
-        !can_generate_icmp_error_reply(&frame, meta),
+        !can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()),
         "gate must suppress reply to an L2 broadcast frame"
     );
     assert!(
@@ -2101,14 +2101,14 @@ fn time_exceeded_suppressed_for_bad_source_v4() {
     let frame = build_udp_frame_v4_full([0x00, 0x25, 0x90, 0x12, 0x34, 0x56], bad_src, server, 1);
     let meta = ttl_meta_v4();
     assert!(
-        !can_generate_icmp_error_reply(&frame, meta),
+        !can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()),
         "gate must suppress reply to a loopback source"
     );
     // Unspecified 0.0.0.0 source is also suppressed.
     let zero_src =
         build_udp_frame_v4_full([0x00, 0x25, 0x90, 0x12, 0x34, 0x56], Ipv4Addr::UNSPECIFIED, server, 1);
     assert!(
-        !can_generate_icmp_error_reply(&zero_src, meta),
+        !can_generate_icmp_error_reply(&zero_src, meta, &ForwardingState::default()),
         "gate must suppress reply to a 0.0.0.0 source"
     );
     assert!(
@@ -2132,7 +2132,7 @@ fn time_exceeded_suppressed_for_bad_source_v6() {
         ..UserspaceDpMeta::default()
     };
     assert!(
-        !can_generate_icmp_error_reply(&frame, meta),
+        !can_generate_icmp_error_reply(&frame, meta, &ForwardingState::default()),
         "gate must suppress reply to a multicast IPv6 source"
     );
     assert!(

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -548,7 +548,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                         {
                             // RFC 792 / RFC 4443 suppression: never reply to
                             // a non-first fragment or an inbound ICMP error.
-                            if !ptb_reply_suppressed(source_frame, ptb_meta, l3) {
+                            if !ptb_reply_suppressed(source_frame, ptb_meta, l3, forwarding) {
                                 ptb_reply = match request.meta.addr_family as i32 {
                                     libc::AF_INET => build_frag_needed_v4(
                                         source_frame,

--- a/userspace-dp/src/prefix.rs
+++ b/userspace-dp/src/prefix.rs
@@ -30,6 +30,17 @@ impl PrefixV4 {
     pub(crate) fn addr(&self) -> Ipv4Addr {
         Ipv4Addr::from(self.network)
     }
+
+    /// The IPv4 subnet-directed broadcast address of this prefix: the
+    /// network address with an all-ones host part (`network | !mask`).
+    /// RFC 1812 §4.3.2.7 — a router MUST NOT originate an ICMP error to a
+    /// directed broadcast. For /31 (RFC 3021 point-to-point, no broadcast)
+    /// and /32 (`network | !mask` == the host itself) the host-all-ones
+    /// value is not a real broadcast; callers guard those prefix lengths
+    /// before comparing (see `dest_is_directed_broadcast`).
+    pub(crate) fn directed_broadcast(&self) -> Ipv4Addr {
+        Ipv4Addr::from(self.network | !self.mask)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Closes #2411

## Outcome: implemented directed-broadcast suppression

RFC 1812 §4.3.2.7 forbids originating an ICMP error in reply to a packet
destined to ANY broadcast, directed broadcasts included. The existing
suppression gate (#2314/#2325) caught L3 multicast, the limited
broadcast (255.255.255.255), and L2 group/broadcast — but a
subnet-directed broadcast (the all-ones host of a connected prefix, e.g.
`10.0.1.255` for a connected `10.0.1.0/24`) is a plain unicast to those
tests, so an ICMP error (reject / Time-Exceeded / PTB) could still be
generated as backscatter.

## Key finding: the connected prefix/mask IS available at the gate

The #2314/#2344 notes assumed the per-interface mask was unavailable at
the ICMP-error generation site. It is not — it is reachable at all three
sites:

- both `can_generate_icmp_error_reply` callers (the reject and
  Time-Exceeded builders, `icmp.rs`) already take `&ForwardingState`;
- the PTB caller in `tx/dispatch/mod.rs` has `forwarding` in scope.

`ForwardingState.connected_v4` (`ConnectedRouteV4 { prefix: PrefixV4 }`)
carries the prefix + mask — the SAME rows the FIB lookup scans. No new
infrastructure, no plumbing through new layers.

## Detection mechanism

`dest_is_directed_broadcast(forwarding, packet)` (shared, `frame/inspect.rs`):
scans `connected_v4` for a prefix that contains the dst and whose
`network | !mask` (`PrefixV4::directed_broadcast()`) equals the dst.
IPv4-only (IPv6 has no broadcast); skips `prefix_len >= 31` (a /31 has no
broadcast per RFC 3021, and a /32's all-ones host is the host itself, so
neither is mis-suppressed). The scan runs ONLY on the cold
error-generation path, never per-packet. Threaded into
`can_generate_icmp_error_reply` and `ptb_reply_suppressed` (v4-gated)
alongside the existing multicast / limited-broadcast / bad-source gates,
so the reject, Time-Exceeded, and PTB paths all apply one gate. A
suppressed error folds into the existing fail-closed silent drop — no new
counter.

## Tests

- `reject_suppressed_for_v4_directed_broadcast_dst`,
  `ptb_suppressed_for_v4_directed_broadcast_dst` — directed broadcast
  suppressed on both paths. Both FAIL (error generated) if the check is
  stubbed to `false` (verified).
- `reject_still_allowed_for_unicast_in_connected_subnet`,
  `ptb_still_generated_for_unicast_in_connected_subnet` — a unicast host
  inside the same subnet still generates the error (anti-over-suppress).
- `reject_still_allowed_for_v4_host_route_all_ones_octet` — a /32
  connected host is not treated as a directed broadcast (prefix-len
  guard).
- Existing multicast + limited-broadcast suppression and unicast
  no-regression tests still pass (updated only to thread the new arg).

## Validation

- `cargo build --release` clean (only pre-existing dead-code warnings).
- `cargo test --release -- afxdp::icmp afxdp::icmp_ptb prefix` green
  (91 passed); 5 new tests pass; suppression tests run 5x stable.
- Fail-on-revert confirmed: stubbing `dest_is_directed_broadcast` to
  `false` turns both suppression tests red.

Cold ICMP-error path; no smoke run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi