### PR TITLE
userspace-dp: recover frames on partial bringup fill-ring prime (#2374)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26,6 +26,21 @@
   userspace-dp/src/afxdp/worker/mod.rs,
   docs/afxdp-packet-processing.md, _Log.md
 
+## 2026-06-23 — #2374 follow-up: skip NAPI loop on empty fill prime (Copilot)
+
+- **Timestamp**: 2026-06-23 PDT
+- **Action**: Bringup-efficiency fold (no behavior change). Copilot noted
+  `prime_fill_ring_offsets` ran the fixed 20-iteration NAPI-trigger loop
+  (recvmsg/poll/sendto/yield) even when called with an EMPTY offsets slice —
+  20 wasted syscalls at bringup for a no-op. Added an early
+  `if offsets.is_empty() { return Ok(Vec::new()); }` at the top, preserving
+  the "empty prime is a no-op, not a total failure" semantics (consistent
+  with `fill_prime_is_total_failure(0, 0) == false`). Extended
+  `zero_insert_is_total_failure` to assert the empty-prime defers nothing.
+  cargo build --release clean; fill_prime tests green and 5x stable; the
+  inserted==0-on-non-empty total-failure path is unchanged (still fatal).
+- **File(s)**: userspace-dp/src/afxdp/bind.rs, _Log.md
+
 ## 2026-06-23 — #2393 embedded-ICMP-NAT match adds ICMPv4 Redirect/Source-Quench
 
 - **Timestamp**: 2026-06-23 PDT

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,31 @@
 # Action Log
 
+## 2026-06-23 — #2374 AF_XDP bringup fill-ring partial-prime recovery
+
+- **Timestamp**: 2026-06-23 PDT
+- **Action**: Correctness fix (MED). The bringup fill-ring prime
+  (`prime_fill_ring_offsets`, `userspace-dp/src/afxdp/bind.rs`) errored only
+  on `inserted == 0` (total failure) and silently accepted a partial insert
+  (`0 < inserted < N`). The `(N - inserted)` un-inserted UMEM frames were
+  dropped from every local pool (the worker started with an empty
+  `pending_fill_frames`), permanently shrinking RX capacity / starving the
+  fill ring on a transiently-full ring at bind/rebind. Fix: retry the
+  un-inserted suffix across the existing NAPI-trigger loop, then RETURN the
+  remaining suffix (`defer_uninserted_fill_suffix`) and thread it through
+  `try_open_bind` / `open_binding_worker_rings` into the worker's
+  `pending_fill_frames` so `drain_pending_fill()` retries it — mirroring the
+  steady-state suffix recovery in `tx::rings::drain_pending_fill`. Total
+  failure still fails closed (`fill_prime_is_total_failure`). Extracted two
+  pure helpers so the recovery + fail-closed decisions are unit-testable
+  without a bound DeviceQueue. Tests assert: partial insert defers the exact
+  un-inserted suffix (none leaked) and FAILS if the recovery is reverted to
+  dropping the suffix; full insert defers nothing; `inserted == 0` still
+  errors. cargo build --release clean; new tests 5x stable; fail-on-revert
+  verified.
+- **File(s)**: userspace-dp/src/afxdp/bind.rs,
+  userspace-dp/src/afxdp/worker/mod.rs,
+  docs/afxdp-packet-processing.md, _Log.md
+
 ## 2026-06-23 — #2393 embedded-ICMP-NAT match adds ICMPv4 Redirect/Source-Quench
 
 - **Timestamp**: 2026-06-23 PDT

--- a/docs/afxdp-packet-processing.md
+++ b/docs/afxdp-packet-processing.md
@@ -112,6 +112,33 @@ zero-copy.
 **Single-queue processing**: One worker thread handles one (ifindex, queue_id)
 pair; all RX, TX, fill ring management, and session lookups are serialized.
 
+### 2a. Bringup fill-ring prime: partial-insert recovery (#2374)
+
+At socket bringup the worker constructor pops every non-reserved UMEM frame
+into `initial_fill_frames` and primes the RX fill ring with all of them via
+`prime_fill_ring_offsets()` (`userspace-dp/src/afxdp/bind.rs`). Two failure
+modes are handled:
+
+- **Total failure** (`inserted == 0` on a non-empty prime): fatal. The socket
+  would run with no RX descriptors, so the bind fails closed
+  (`fill_prime_is_total_failure`).
+- **Partial insert** (`0 < inserted < N`, e.g. a transiently-full ring during
+  rebind / shared-UMEM group churn): the prime first retries the un-inserted
+  suffix across the NAPI-trigger loop (each `recvmsg`/`poll`/`sendto` lets the
+  kernel consume fill entries and free ring slots). Any suffix the ring still
+  has not accepted is **returned** (`defer_uninserted_fill_suffix`) and threaded
+  back through `open_binding_worker_rings` into the worker's
+  `pending_fill_frames` queue. The steady-state `drain_pending_fill()` loop then
+  retries exactly those offsets.
+
+Before #2374 the prime errored only on `inserted == 0` and silently accepted a
+partial insert: the `(N - inserted)` un-inserted frames were dropped from every
+local pool (`pending_fill_frames` started empty), permanently shrinking RX
+capacity and starving the fill ring. The recovery mirrors the steady-state
+suffix recovery in `tx::rings::drain_pending_fill` (which already pushes a
+partial-insert suffix back onto `pending_fill_frames`) so bringup and the
+running loop handle a short fill-ring insert identically.
+
 ## 3. Current Mitigation: nftables RST Suppression
 
 Since the root cause is kernel-emitted RSTs for SNAT addresses the kernel

--- a/userspace-dp/src/afxdp/bind.rs
+++ b/userspace-dp/src/afxdp/bind.rs
@@ -114,6 +114,10 @@ pub(super) unsafe fn open_binding_worker_rings(
         u16,
         AfXdpBindStrategy,
         DeviceQueue,
+        // #2374: fill-ring suffix the bringup prime could not place — the
+        // caller stashes this in `pending_fill_frames` so it is retried by
+        // the steady-state drain rather than leaked.
+        Vec<u64>,
     ),
     Box<dyn std::error::Error + Send + Sync>,
 > {
@@ -134,8 +138,17 @@ pub(super) unsafe fn open_binding_worker_rings(
                 poll_mode,
                 pre_bind_fill_offsets,
             ) {
-                Ok((user, rx, tx, bind_mode, actual_flags, device)) => {
-                    return Ok((user, rx, tx, bind_mode, actual_flags, strategy, device));
+                Ok((user, rx, tx, bind_mode, actual_flags, device, uninserted_fill)) => {
+                    return Ok((
+                        user,
+                        rx,
+                        tx,
+                        bind_mode,
+                        actual_flags,
+                        strategy,
+                        device,
+                        uninserted_fill,
+                    ));
                 }
                 Err(err) => {
                     last_err = Some(err);
@@ -226,24 +239,71 @@ pub(super) fn describe_bind_flags(flags: u16) -> &'static str {
     }
 }
 
+/// Bringup fill-ring total-failure predicate (#2374).
+///
+/// A *total* failure (the very first reserve placed zero frames into a
+/// non-empty fill request) is fatal: the socket would run with no RX
+/// descriptors at all, so the bind must fail closed. An empty request
+/// (`total == 0`) is not a failure. Extracted as a pure helper so the
+/// fail-closed decision is unit-testable without a bound `DeviceQueue`.
+pub(super) fn fill_prime_is_total_failure(total: usize, inserted_first: usize) -> bool {
+    total > 0 && inserted_first == 0
+}
+
+/// Bringup fill-ring partial-insert suffix recovery (#2374).
+///
+/// Given the offsets handed to the bringup prime and the total number the fill
+/// ring eventually accepted (after retries), return the un-inserted suffix the
+/// caller MUST defer into the worker's `pending_fill_frames` queue. Returning
+/// the suffix (rather than dropping it) is what prevents the UMEM frame leak:
+/// the steady-state `tx::rings::drain_pending_fill` loop then retries exactly
+/// these offsets. A full insert returns an empty `Vec`. Pure helper so the
+/// recovery is unit-testable without a bound `DeviceQueue`.
+pub(super) fn defer_uninserted_fill_suffix(offsets: &[u64], inserted_total: usize) -> Vec<u64> {
+    let inserted_total = inserted_total.min(offsets.len());
+    offsets[inserted_total..].to_vec()
+}
+
+/// Prime the RX fill ring with `offsets` at socket bringup.
+///
+/// Returns the suffix of `offsets` that could NOT be inserted into the fill
+/// ring (empty `Vec` when all `offsets.len()` frames were placed). The caller
+/// MUST hand that suffix to the worker's `pending_fill_frames` queue so the
+/// steady-state `drain_pending_fill` loop retries it — otherwise those UMEM
+/// frame addresses are leaked from every local pool, permanently shrinking RX
+/// capacity (#2374).
+///
+/// A *total* failure (`inserted == 0` on the very first reserve) is fatal and
+/// returns `Err` so the bind fails closed rather than running with no RX
+/// descriptors. A *partial* insert is recovered: this matches the steady-state
+/// suffix recovery in `tx::rings::drain_pending_fill` (push the un-inserted
+/// suffix back for retry) rather than silently dropping it.
 pub(super) fn prime_fill_ring_offsets(
     device: &mut DeviceQueue,
     offsets: &[u64],
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let inserted = {
-        let mut fill = device.fill(offsets.len() as u32);
+) -> Result<Vec<u64>, Box<dyn std::error::Error + Send + Sync>> {
+    // `remaining` is the slice index of the first not-yet-inserted offset.
+    // We retry the insert across the NAPI-trigger loop below: each NAPI kick
+    // lets the kernel consume fill-ring entries and post RX WQEs, which frees
+    // ring slots so a transiently-full ring can accept the suffix on a later
+    // iteration without leaking frames.
+    let total = offsets.len();
+    let mut remaining: usize = {
+        let mut fill = device.fill(total as u32);
         let inserted = fill.insert(offsets.iter().copied());
         fill.commit();
-        inserted
+        inserted as usize
     };
     eprintln!(
         "prime_fill_ring: inserted={}/{} fill_pending={}",
-        inserted,
-        offsets.len(),
+        remaining,
+        total,
         device.pending()
     );
-    if inserted == 0 {
-        return Err(format!("prefill fill ring inserted 0/{}", offsets.len()).into());
+    // A total failure on the first reserve means the ring rejected everything;
+    // fail closed (no RX descriptors at all). Do NOT regress this behavior.
+    if fill_prime_is_total_failure(total, remaining) {
+        return Err(format!("prefill fill ring inserted 0/{}", total).into());
     }
     // Trigger NAPI to consume fill ring entries and post RX WQEs.
     // mlx5 zero-copy processes the fill ring during RX NAPI poll.
@@ -278,9 +338,32 @@ pub(super) fn prime_fill_ring_offsets(
                 0,
             );
         }
+        // After NAPI has had a chance to drain the ring, retry inserting the
+        // un-inserted suffix. This recovers a transiently-full fill ring at
+        // bringup the same way the steady-state drain does.
+        if remaining < total {
+            let suffix = &offsets[remaining..];
+            let inserted = {
+                let mut fill = device.fill(suffix.len() as u32);
+                let inserted = fill.insert(suffix.iter().copied());
+                fill.commit();
+                inserted as usize
+            };
+            remaining += inserted;
+        }
         std::thread::yield_now();
     }
-    Ok(())
+    if remaining < total {
+        eprintln!(
+            "prime_fill_ring: partial prime — {} of {} frames not placed, deferring suffix to pending_fill_frames",
+            total - remaining,
+            total
+        );
+    }
+    // Return the un-inserted suffix (frames the ring still has not accepted).
+    // The worker constructor stashes these in `pending_fill_frames` so the
+    // running loop's `drain_pending_fill` retries them — never leaked.
+    Ok(defer_uninserted_fill_suffix(offsets, remaining))
 }
 
 pub(super) fn bind_strategy_for_driver(driver: Option<&str>) -> AfXdpBindStrategy {
@@ -364,7 +447,7 @@ fn try_open_bind(
     poll_mode: crate::PollMode,
     pre_bind_fill_offsets: Option<&[u64]>,
 ) -> Result<
-    (User, RingRx, RingTx, XskBindMode, u16, DeviceQueue),
+    (User, RingRx, RingTx, XskBindMode, u16, DeviceQueue, Vec<u64>),
     Box<dyn std::error::Error + Send + Sync>,
 > {
     for attempt in 0..BIND_RETRY_ATTEMPTS {
@@ -393,9 +476,13 @@ fn try_open_bind(
                 // Prime the fill ring AFTER bind — libxdp already binds
                 // the socket during create_shared. Post-bind fill ring
                 // priming triggers NAPI to consume entries and post WQEs.
-                if let Some(offsets) = pre_bind_fill_offsets {
-                    prime_fill_ring_offsets(&mut device, offsets)?;
-                }
+                // Any suffix the ring could not accept is returned so the
+                // worker stashes it in `pending_fill_frames` (#2374) instead
+                // of leaking the UMEM frames.
+                let uninserted_fill = match pre_bind_fill_offsets {
+                    Some(offsets) => prime_fill_ring_offsets(&mut device, offsets)?,
+                    None => Vec::new(),
+                };
 
                 let bind_mode = query_bound_xsk_mode(user_fd).unwrap_or(XskBindMode::Copy);
                 if socket_role.requires_zerocopy() && !bind_mode.is_zerocopy() {
@@ -416,7 +503,7 @@ fn try_open_bind(
                     bind_flags,
                 );
 
-                return Ok((user, rx, tx, bind_mode, bind_flags, device));
+                return Ok((user, rx, tx, bind_mode, bind_flags, device, uninserted_fill));
             }
             Err(err) => {
                 let msg = err.to_string();
@@ -500,5 +587,76 @@ fn set_busy_poll_opts(fd: c_int, poll_mode: crate::PollMode) {
             (&budget as *const c_int).cast::<c_void>(),
             core::mem::size_of::<c_int>() as libc::socklen_t,
         );
+    }
+}
+
+#[cfg(test)]
+mod fill_prime_tests {
+    use super::{defer_uninserted_fill_suffix, fill_prime_is_total_failure};
+
+    // #2374: a partial bringup prime (inserted < N) MUST recover the
+    // un-inserted suffix so the worker can stash it in pending_fill_frames.
+    // If the recovery is removed (e.g. revert to dropping the suffix), the
+    // returned Vec would be empty and the (N - inserted) frames would leak —
+    // this test asserts the suffix is the EXACT tail and FAILS on that revert.
+    #[test]
+    fn partial_prime_recovers_uninserted_suffix_not_leaked() {
+        let offsets: Vec<u64> = vec![0, 4096, 8192, 12288, 16384];
+        // Ring accepted only the first 3; the remaining 2 must be deferred.
+        let inserted = 3;
+        let suffix = defer_uninserted_fill_suffix(&offsets, inserted);
+        assert_eq!(
+            suffix,
+            vec![12288, 16384],
+            "partial bringup prime must defer the exact un-inserted suffix \
+             (else the (N - inserted) UMEM frames leak — #2374)"
+        );
+        // No frame is lost: inserted-count + deferred-count == total.
+        assert_eq!(
+            inserted + suffix.len(),
+            offsets.len(),
+            "every bringup fill frame must be either inserted or deferred — none dropped"
+        );
+        // A partial insert is NOT a total failure (must not fail closed).
+        assert!(
+            !fill_prime_is_total_failure(offsets.len(), inserted),
+            "a partial insert must be recovered, not treated as a fatal bind failure"
+        );
+    }
+
+    // No regression: a full insert defers nothing and is not a failure.
+    #[test]
+    fn full_prime_defers_nothing() {
+        let offsets: Vec<u64> = vec![0, 4096, 8192, 12288];
+        let inserted = offsets.len();
+        let suffix = defer_uninserted_fill_suffix(&offsets, inserted);
+        assert!(
+            suffix.is_empty(),
+            "a full insert must defer nothing (no spurious pending_fill_frames)"
+        );
+        assert!(!fill_prime_is_total_failure(offsets.len(), inserted));
+        // Defensive: an over-count (inserted reported > total) still defers
+        // nothing and never panics (min() clamp).
+        assert!(defer_uninserted_fill_suffix(&offsets, inserted + 10).is_empty());
+    }
+
+    // No regression: a total failure (inserted == 0 on a non-empty request)
+    // must still be classified as fatal so the bind fails closed.
+    #[test]
+    fn zero_insert_is_total_failure() {
+        let offsets: Vec<u64> = vec![0, 4096, 8192];
+        assert!(
+            fill_prime_is_total_failure(offsets.len(), 0),
+            "inserted == 0 on a non-empty prime must remain a fatal bind failure (fail closed)"
+        );
+        // An empty prime request is a no-op, not a failure.
+        assert!(
+            !fill_prime_is_total_failure(0, 0),
+            "an empty fill request must not be treated as a failure"
+        );
+        // Even when total-failure errors out upstream, the suffix helper for a
+        // zero insert would be the whole set (nothing accepted) — proving the
+        // recovery path would otherwise carry all frames.
+        assert_eq!(defer_uninserted_fill_suffix(&offsets, 0), offsets);
     }
 }

--- a/userspace-dp/src/afxdp/bind.rs
+++ b/userspace-dp/src/afxdp/bind.rs
@@ -282,6 +282,13 @@ pub(super) fn prime_fill_ring_offsets(
     device: &mut DeviceQueue,
     offsets: &[u64],
 ) -> Result<Vec<u64>, Box<dyn std::error::Error + Send + Sync>> {
+    // An empty prime request is a no-op (not a total failure — see
+    // `fill_prime_is_total_failure`). Return the empty deferred suffix without
+    // entering the fixed 20-iteration NAPI-trigger loop below, which would
+    // otherwise burn 20 recvmsg/poll/sendto syscalls at bringup for no frames.
+    if offsets.is_empty() {
+        return Ok(Vec::new());
+    }
     // `remaining` is the slice index of the first not-yet-inserted offset.
     // We retry the insert across the NAPI-trigger loop below: each NAPI kick
     // lets the kernel consume fill-ring entries and post RX WQEs, which frees
@@ -649,10 +656,17 @@ mod fill_prime_tests {
             fill_prime_is_total_failure(offsets.len(), 0),
             "inserted == 0 on a non-empty prime must remain a fatal bind failure (fail closed)"
         );
-        // An empty prime request is a no-op, not a failure.
+        // An empty prime request is a no-op, not a failure. The empty-offsets
+        // early return in `prime_fill_ring_offsets` yields exactly this: no
+        // total failure AND an empty deferred suffix (and skips the NAPI loop).
         assert!(
             !fill_prime_is_total_failure(0, 0),
             "an empty fill request must not be treated as a failure"
+        );
+        let empty: Vec<u64> = Vec::new();
+        assert!(
+            defer_uninserted_fill_suffix(&empty, 0).is_empty(),
+            "an empty prime defers nothing"
         );
         // Even when total-failure errors out upstream, the suffix helper for a
         // zero insert would be the whole set (nothing accepted) — proving the

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -387,7 +387,16 @@ impl BindingWorker {
         // Safety: `BindingWorker` declares `xsk` before `umem`, so Rust drops
         // the socket/ring handles before the UMEM. That satisfies the UMEM
         // lifetime/drop-order contract enforced by `open_binding_worker_rings`.
-        let (user, rx, tx, bind_mode, bind_flags, actual_bind_strategy, device) = unsafe {
+        let (
+            user,
+            rx,
+            tx,
+            bind_mode,
+            bind_flags,
+            actual_bind_strategy,
+            device,
+            uninserted_fill_frames,
+        ) = unsafe {
             open_binding_worker_rings(
                 &mut worker_umem,
                 &info,
@@ -400,6 +409,11 @@ impl BindingWorker {
             )
         }
         .map_err(|err| format!("configure AF_XDP rings: {err}"))?;
+        // #2374: the bringup prime may not place every fill frame on a
+        // transiently-full ring. The uninserted suffix is seeded into
+        // `pending_fill_frames` below so the steady-state drain retries it —
+        // those UMEM frames are accounted, never leaked.
+        let pending_fill_frames: VecDeque<u64> = uninserted_fill_frames.into_iter().collect();
 
         let user_fd = user.as_raw_fd();
         live.set_bound(user_fd);
@@ -449,7 +463,7 @@ impl BindingWorker {
                 pending_tx_local: VecDeque::new(),
                 max_pending_tx,
                 outstanding_tx: 0,
-                pending_fill_frames: VecDeque::new(),
+                pending_fill_frames,
                 in_flight_prepared_recycles: FastMap::default(),
                 // #812: pre-allocate the submit-timestamp sidecar once,
                 // sized to the binding's total UMEM frame count so every


### PR DESCRIPTION
Closes #2374

## Problem

The AF_XDP worker constructor primes the RX fill ring with every
non-reserved UMEM frame at socket bringup, but `prime_fill_ring_offsets`
(`userspace-dp/src/afxdp/bind.rs`) treated only a **total** insert failure
(`inserted == 0`) as fatal. A short insert (`0 < inserted < N`) was silently
accepted as `Ok`. Because the worker started with an empty
`pending_fill_frames` queue, the `(N - inserted)` un-inserted UMEM frame
addresses were dropped from every local pool — neither placed in the fill
ring nor retried anywhere.

On a transiently-full fill ring at bind/rebind (rebind retries, shared-UMEM
group churn) the binding then ran with permanently depressed RX capacity and
fill-ring starvation. The bringup prime is outside `drain_pending_fill`
telemetry, so the only signal was a boot `eprintln` that did not fail the
bind — an operator-visible packet-loss mode that should fail closed at
dataplane bringup.

### Leak site (before)
`bind.rs` `prime_fill_ring_offsets` errored only on `inserted == 0`; a
partial insert returned `Ok(())` and the worker constructor
(`worker/mod.rs`) set `pending_fill_frames: VecDeque::new()` — nothing
carried the un-inserted suffix.

## Contrast: steady-state already does this right

`tx::rings::drain_pending_fill` (`userspace-dp/src/afxdp/tx/rings.rs`)
handles a short insert by pushing the un-inserted suffix back onto
`pending_fill_frames` for the next tick. The bringup prime lacked the
equivalent recovery.

## Fix (mirror steady-state suffix recovery)

- `prime_fill_ring_offsets` now retries the un-inserted suffix across the
  existing NAPI-trigger loop (each `recvmsg`/`poll`/`sendto` lets the kernel
  consume fill entries and free ring slots), then **returns** the suffix the
  ring still has not accepted instead of discarding it.
- The suffix is threaded back through `try_open_bind` and
  `open_binding_worker_rings` into the worker constructor, which seeds
  `pending_fill_frames` from it so `drain_pending_fill()` retries exactly
  those offsets — the frames are accounted, never leaked.
- A **total** failure (`inserted == 0` on a non-empty prime) still **fails
  closed**; the bind aborts rather than running with no RX descriptors.

The fail-closed and suffix-recovery decisions are extracted into two pure
helpers (`fill_prime_is_total_failure`, `defer_uninserted_fill_suffix`) so
they are unit-testable without a bound `DeviceQueue`.

## Tests (fail-on-revert)

`fill_prime_tests` in `bind.rs`:
- `partial_prime_recovers_uninserted_suffix_not_leaked` — a partial insert
  defers the **exact** un-inserted suffix and asserts
  `inserted + deferred == N`. **FAILS** if the recovery is reverted to
  dropping the suffix (verified by stubbing the suffix to `Vec::new()`).
- `full_prime_defers_nothing` — full insert defers nothing (no regression).
- `zero_insert_is_total_failure` — `inserted == 0` remains fatal; empty
  prime is a no-op (no regression).

## Validation

- `cargo build --release` clean (pre-existing warnings only).
- New tests green and 5x stable; fail-on-revert confirmed.
- Doc: `docs/afxdp-packet-processing.md` §2a (bringup partial-prime recovery).

No wire field. Bringup affects RX capacity → recommend a loss-cluster smoke
confirming xpfd boots + forwards at line rate (the prime runs at every xpfd
start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi