### PR TITLE
userspace-dp: make AF_XDP producer-ring writers (WriteTx/WriteFill) append-safe (#2383)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11824,3 +11824,26 @@ top.
 - **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
   userspace-dp/src/afxdp/icmp_ptb_tests.rs,
   userspace-dp/src/afxdp/tests.rs, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2383 — make AF_XDP producer-ring writers append-safe.
+  `WriteTx::insert` / `WriteFill::insert` (userspace-dp/src/xsk_ffi.rs)
+  wrote at `base_idx + n` ignoring `self.written`, so a SECOND insert()
+  on the same reservation would overwrite the slots the first wrote
+  (restart at base+0) while `written` summed across calls — commit()
+  would then submit a descriptor count over partly-uninitialized slots.
+  The bound check `n >= self.reserved` likewise ignored `written`, so a
+  second call could exceed the remaining reservation. LATENT: every
+  current callsite (afxdp/tx/transmit/write.rs, afxdp/tx/rings.rs,
+  afxdp/bind.rs) does exactly one insert per reservation; #2374's
+  fill-ring suffix retry re-`reserve`s a fresh WriteFill per NAPI
+  iteration (device.fill(suffix.len()) + commit) rather than
+  re-inserting, so it does NOT trip the hazard. FIX: index at
+  `base_idx + written + n` (libxdp masks against the ring size) and
+  bound each call by `reserved.saturating_sub(written)`; advance
+  `written` by the count inserted. Single-insert (written==0) behavior
+  unchanged. Added 6 unit tests incl. two-insert append fail-on-revert
+  for both WriteTx and WriteFill (revert to base+n → second insert
+  clobbers base+0 → test fails). Build clean; xsk_ffi tests 7 passed 5x.
+- **File(s)**: userspace-dp/src/xsk_ffi.rs, userspace-dp/README.md,
+  _Log.md

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -81,6 +81,19 @@ logging rules, not these specific hot-path constants.
 - Generic-XDP fallback consumes UMEM frames permanently on mlx5; the
   XDP shim redirects `XDP_PASS` to a cpumap stage that frees the frame
   immediately.
+- Producer-ring writers (`WriteTx` / `WriteFill` in
+  `userspace-dp/src/xsk_ffi.rs`) are **append-safe across multiple
+  `insert()` calls on one reservation**: each `insert()` writes at
+  `base_idx + written + n` and is bounded by the *remaining*
+  reservation (`reserved - written`), so a second `insert()` appends
+  after the first instead of overwriting it, and `commit()`/`Drop`
+  submit the accumulated `written` count over distinct, initialized
+  slots. libxdp masks the slot index against the ring size, so the
+  unwrapped sum is correct. (Fixed in #2383 — the prior `base_idx + n`
+  indexing was latent because every callsite did exactly one `insert()`
+  per reservation; the #2374 fill-ring suffix retry re-`reserve`s a
+  fresh `WriteFill` per NAPI iteration rather than re-inserting, so it
+  never tripped the hazard.)
 - `HEARTBEAT_GRACE_PERIOD_NS = 6 s` is defined in
   `userspace-dp/src/afxdp/mod.rs` but currently `#[allow(dead_code)]`
   — reserved for future XDP-shim heartbeat gating logic. Workers

--- a/userspace-dp/src/xsk_ffi.rs
+++ b/userspace-dp/src/xsk_ffi.rs
@@ -925,13 +925,20 @@ pub struct WriteTx<'a> {
 
 impl WriteTx<'_> {
     /// Insert descriptors from an iterator. Returns count inserted.
+    ///
+    /// Append-safe: writes start after the slots filled by any prior
+    /// `insert()` on this reservation (`base_idx + self.written + n`) and
+    /// are bounded by the *remaining* reservation, so a second call
+    /// appends rather than overwriting the first. libxdp masks the index
+    /// against the ring size, so the unwrapped sum is correct.
     pub fn insert(&mut self, it: impl Iterator<Item = XdpDesc>) -> u32 {
+        let remaining = self.reserved.saturating_sub(self.written);
         let mut n = 0u32;
         for desc in it {
-            if n >= self.reserved {
+            if n >= remaining {
                 break;
             }
-            let idx = self.base_idx.wrapping_add(n);
+            let idx = self.base_idx.wrapping_add(self.written).wrapping_add(n);
             unsafe {
                 bridge_xsk_tx_desc_set(self.ring, idx, desc.addr, desc.len, desc.options);
             }
@@ -978,13 +985,20 @@ pub struct WriteFill<'a> {
 
 impl WriteFill<'_> {
     /// Insert buffer offsets into the fill ring.
+    ///
+    /// Append-safe: writes start after the slots filled by any prior
+    /// `insert()` on this reservation (`base_idx + self.written + n`) and
+    /// are bounded by the *remaining* reservation, so a second call
+    /// appends rather than overwriting the first. libxdp masks the index
+    /// against the ring size, so the unwrapped sum is correct.
     pub fn insert(&mut self, it: impl Iterator<Item = u64>) -> u32 {
+        let remaining = self.reserved.saturating_sub(self.written);
         let mut n = 0u32;
         for addr in it {
-            if n >= self.reserved {
+            if n >= remaining {
                 break;
             }
-            let idx = self.base_idx.wrapping_add(n);
+            let idx = self.base_idx.wrapping_add(self.written).wrapping_add(n);
             unsafe { bridge_xsk_fill_addr_set(self.ring, idx, addr) };
             n += 1;
         }
@@ -1296,5 +1310,153 @@ mod tests {
         assert_ne!(rings.comp() as *const XskRingCons, socket_comp_addr);
         assert_eq!((&*umem_fill) as *const XskRingProd, umem_fill_addr);
         assert_eq!((&*umem_comp) as *const XskRingCons, umem_comp_addr);
+    }
+
+    // ── Producer-ring append safety (#2383) ──────────────────────────
+    //
+    // `WriteTx::insert` / `WriteFill::insert` must place the k-th total
+    // item of a reservation at `base_idx + written + n` so a second
+    // `insert()` APPENDS after the first instead of overwriting it.
+    // These tests fail-on-revert: reverting the index to `base_idx + n`
+    // makes the second insert clobber slot base+0.
+
+    /// Read TX descriptor slot `i` from the leaked test ring backing.
+    /// The bridge writes through libxdp at `idx & mask`, so reading the
+    /// raw ring buffer at `i & mask` observes what `insert` wrote.
+    fn tx_slot(ring: &XskRingProd, i: u32) -> XdpDesc {
+        let idx = (i & ring.mask) as usize;
+        unsafe { *(ring.ring as *const XdpDesc).add(idx) }
+    }
+
+    fn fill_slot(ring: &XskRingProd, i: u32) -> u64 {
+        let idx = (i & ring.mask) as usize;
+        unsafe { *(ring.ring as *const u64).add(idx) }
+    }
+
+    fn desc(addr: u64) -> XdpDesc {
+        XdpDesc {
+            addr,
+            len: addr as u32,
+            options: 0,
+        }
+    }
+
+    #[test]
+    fn write_tx_two_inserts_append_not_overwrite() {
+        let mut tx = RingTx::new_for_test(-1, 8);
+        let base;
+        {
+            let mut w = tx.transmit(4);
+            base = w.base_idx;
+            assert_eq!(w.reserved, 4);
+            // First insert: one descriptor at base+0.
+            assert_eq!(w.insert([desc(0xA0)].into_iter()), 1);
+            assert_eq!(w.written, 1);
+            // Second insert: must APPEND at base+1, base+2 (NOT base+0).
+            assert_eq!(w.insert([desc(0xB1), desc(0xC2)].into_iter()), 2);
+            assert_eq!(w.written, 3);
+            w.commit();
+        }
+        // All three distinct slots hold the items in insertion order.
+        assert_eq!(tx_slot(&tx.ring, base).addr, 0xA0);
+        assert_eq!(tx_slot(&tx.ring, base.wrapping_add(1)).addr, 0xB1);
+        assert_eq!(tx_slot(&tx.ring, base.wrapping_add(2)).addr, 0xC2);
+    }
+
+    #[test]
+    fn write_tx_single_insert_writes_base() {
+        let mut tx = RingTx::new_for_test(-1, 8);
+        let base;
+        {
+            let mut w = tx.transmit(4);
+            base = w.base_idx;
+            assert_eq!(w.insert([desc(0x11), desc(0x22)].into_iter()), 2);
+            assert_eq!(w.written, 2);
+            w.commit();
+        }
+        assert_eq!(tx_slot(&tx.ring, base).addr, 0x11);
+        assert_eq!(tx_slot(&tx.ring, base.wrapping_add(1)).addr, 0x22);
+    }
+
+    #[test]
+    fn write_tx_insert_bounded_by_remaining_reservation() {
+        let mut tx = RingTx::new_for_test(-1, 8);
+        {
+            let mut w = tx.transmit(2);
+            assert_eq!(w.reserved, 2);
+            // First insert fills the reservation.
+            assert_eq!(w.insert([desc(1), desc(2)].into_iter()), 2);
+            assert_eq!(w.written, 2);
+            // Second insert has zero remaining capacity — inserts nothing,
+            // does not write past the reservation.
+            assert_eq!(w.insert([desc(3), desc(4)].into_iter()), 0);
+            assert_eq!(w.written, 2);
+            // A single oversized insert is also capped at the reservation.
+            w.commit();
+        }
+        let mut tx2 = RingTx::new_for_test(-1, 8);
+        {
+            let mut w = tx2.transmit(2);
+            assert_eq!(w.insert((0..10).map(desc)), 2);
+            assert_eq!(w.written, 2);
+            w.commit();
+        }
+    }
+
+    #[test]
+    fn write_fill_two_inserts_append_not_overwrite() {
+        let mut dq = DeviceQueue::new_for_test(-1, 8);
+        let base;
+        {
+            let mut w = dq.fill(4);
+            base = w.base_idx;
+            assert_eq!(w.reserved, 4);
+            assert_eq!(w.insert([0xA0u64].into_iter()), 1);
+            assert_eq!(w.written, 1);
+            assert_eq!(w.insert([0xB1u64, 0xC2u64].into_iter()), 2);
+            assert_eq!(w.written, 3);
+            w.commit();
+        }
+        let ring = dq.rings.fill();
+        assert_eq!(fill_slot(ring, base), 0xA0);
+        assert_eq!(fill_slot(ring, base.wrapping_add(1)), 0xB1);
+        assert_eq!(fill_slot(ring, base.wrapping_add(2)), 0xC2);
+    }
+
+    #[test]
+    fn write_fill_single_insert_writes_base() {
+        let mut dq = DeviceQueue::new_for_test(-1, 8);
+        let base;
+        {
+            let mut w = dq.fill(4);
+            base = w.base_idx;
+            assert_eq!(w.insert([0x11u64, 0x22u64].into_iter()), 2);
+            assert_eq!(w.written, 2);
+            w.commit();
+        }
+        let ring = dq.rings.fill();
+        assert_eq!(fill_slot(ring, base), 0x11);
+        assert_eq!(fill_slot(ring, base.wrapping_add(1)), 0x22);
+    }
+
+    #[test]
+    fn write_fill_insert_bounded_by_remaining_reservation() {
+        let mut dq = DeviceQueue::new_for_test(-1, 8);
+        {
+            let mut w = dq.fill(2);
+            assert_eq!(w.reserved, 2);
+            assert_eq!(w.insert([1u64, 2u64].into_iter()), 2);
+            assert_eq!(w.written, 2);
+            assert_eq!(w.insert([3u64, 4u64].into_iter()), 0);
+            assert_eq!(w.written, 2);
+            w.commit();
+        }
+        let mut dq2 = DeviceQueue::new_for_test(-1, 8);
+        {
+            let mut w = dq2.fill(2);
+            assert_eq!(w.insert(0..10u64), 2);
+            assert_eq!(w.written, 2);
+            w.commit();
+        }
     }
 }


### PR DESCRIPTION
Closes #2383

## Problem (latent API hazard)
`WriteTx::insert` / `WriteFill::insert` in `userspace-dp/src/xsk_ffi.rs` wrote each item at `base_idx + n` (where `n` is the per-call iterator index), **ignoring `self.written`**. A second `insert()` on the same reservation restarts at `base+0` and overwrites the slots the first `insert()` wrote, while `self.written` is summed across calls — so `commit()`/`Drop` submit a descriptor count spanning double-written and uninitialized slots. The bound check `n >= self.reserved` likewise ignored `self.written`, so a second call could write past the remaining reservation.

The API looks like it supports multiple inserts per reservation (`reserve(N)` → `insert(...)` [possibly multiple] → `commit(written)`) but did not.

### Index calc (before → after)
| Writer | Before | After |
|--------|--------|-------|
| `WriteTx::insert` (xsk_ffi.rs ~934) | `base_idx.wrapping_add(n)` | `base_idx.wrapping_add(self.written).wrapping_add(n)` |
| `WriteFill::insert` (xsk_ffi.rs ~988) | `base_idx.wrapping_add(n)` | `base_idx.wrapping_add(self.written).wrapping_add(n)` |

Bound (both): `n >= self.reserved` → `n >= self.reserved.saturating_sub(self.written)`.

## Latent vs now-triggered
**Still latent.** Every current production callsite does exactly one `insert()` per reservation (`afxdp/tx/transmit/write.rs:26`, `afxdp/tx/rings.rs:121`, `afxdp/bind.rs:300`). 

**#2374 interaction (checked):** the fill-ring suffix retry (`afxdp/bind.rs:351-360`) re-reserves a **fresh** `WriteFill` per NAPI iteration — `device.fill(suffix.len())` + `commit()` each loop — rather than re-inserting into a held reservation. So #2374 does NOT trip the hazard; #2383 remains a latent unsafe-boundary invariant, fixed proactively.

## Fix
Index the k-th total item at `base_idx + self.written + n`; bound each call by `self.reserved.saturating_sub(self.written)`; advance `self.written` by the count inserted. libxdp masks the slot index against the ring size, so the unwrapped sum is correct (the existing code already relied on that mask). Single-insert (`written == 0`) is unchanged — still writes at `base+0`. `commit()`/`Drop` submit the accumulated `self.written`.

## Tests (fail-on-revert), both WriteTx and WriteFill
- `write_{tx,fill}_two_inserts_append_not_overwrite` — two inserts on one reservation; asserts slots `base+0/+1/+2` hold all items in order. **Verified it FAILS** when the index reverts to `base_idx + n` (second insert clobbers `base+0`), while the single-insert/bounds tests still pass.
- `write_{tx,fill}_single_insert_writes_base` — no regression for `written == 0`.
- `write_{tx,fill}_insert_bounded_by_remaining_reservation` — a second insert past a full reservation inserts 0; an oversized single insert is capped at the reservation.

`cargo build --release` clean; `xsk_ffi` tests 7 passed, stable 5x. No wire field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi