### PR TITLE
userspace-dp: whole-packet-atomic slow-path TUN writes (#2407)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11886,3 +11886,16 @@ top.
 - **File(s)**: userspace-dp/src/slowpath.rs,
   userspace-dp/src/io_uring_write.rs,
   docs/xdp-io-uring-userspace-dataplane.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2407 Copilot doc-fold (PR #2437) — corrected the
+  `write_packet_atomic` writer-seam doc comment in slowpath.rs. It said
+  the writer returns "<0 negated via errno", but `libc::write` returns
+  `-1` on error with `errno` set SEPARATELY (not a negated-errno value),
+  which is exactly what the seam and tests model (`-1` + an explicit
+  `set_errno`). Reworded to: non-negative byte count on success, or `-1`
+  on error with errno set separately, and noted that
+  `write_packet_atomic` reads errno via `io::Error::last_os_error()` to
+  split EINTR (retry-whole) from a hard error (drop). Comment-only — no
+  code change; cargo build --release clean.
+- **File(s)**: userspace-dp/src/slowpath.rs, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -11847,3 +11847,42 @@ top.
   clobbers base+0 → test fails). Build clean; xsk_ffi tests 7 passed 5x.
 - **File(s)**: userspace-dp/src/xsk_ffi.rs, userspace-dp/README.md,
   _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2407 — make slow-path TUN writes whole-packet-atomic
+  (sync + io_uring). A TUN/TAP fd is packet-oriented: one write() (or one
+  io_uring write submission) is exactly one L3 packet, never a byte
+  stream. Both slow-path writers retried a SHORT count by resubmitting
+  the REMAINING bytes (stream semantics) — which makes the kernel read
+  the leftover bytes as a SECOND, malformed packet, corrupting the device
+  stream. SYNC (`write_packet_sync`, userspace-dp/src/slowpath.rs): was a
+  `while written < len { write(ptr+written, len-written) }` loop. Now
+  extracted to `write_packet_atomic(len, writer)` (a closure seam so the
+  short-count/EINTR behaviour is unit-testable): always writes the WHOLE
+  packet from offset 0; EINTR retries the whole packet; a partial
+  (0<n<len) or zero count returns Err (the caller already counts that as
+  a dropped packet + write error); other errno → Err. IO_URING
+  (`write_all`, userspace-dp/src/io_uring_write.rs): the loop is SHARED
+  with the positioned state-writer (a regular file IS a byte stream and
+  legitimately resumes). Added a `!positioned` guard: for the
+  non-positioned TUN path a short CQE count (`n < data.len()`) returns
+  Err (drop) instead of resubmitting `data[n..]`; positioned writes keep
+  the multi-chunk resume. EINTR retry was already wait-only (no re-push)
+  so it stays whole-packet by construction. No new drop counter — the
+  existing slow_path_worker Err arm already increments
+  dropped_packets/dropped_bytes/write_errors. Tests (fail-on-revert,
+  verified by temporary revert): io_uring
+  packet_short_write_drops_no_remainder_resubmit (one push, Err, no
+  remainder bytes accepted), packet_full_write_succeeds,
+  packet_eintr_retries_whole_no_corruption,
+  positioned_short_write_advances_and_resubmits (file resume preserved);
+  sync sync_short_write_drops_no_remainder (exactly one full-length
+  write, never bytes[n..]), sync_full_write_succeeds_single_call,
+  sync_eintr_retries_whole_packet, sync_zero_write_drops,
+  sync_hard_error_drops. Repointed the pre-existing
+  stale_cqe_is_not_misattributed test to positioned=true (its two-chunk
+  resume is now only valid for the file path). Build clean; full
+  userspace-dp suite 2587+46+62 green; new tests 5x stable.
+- **File(s)**: userspace-dp/src/slowpath.rs,
+  userspace-dp/src/io_uring_write.rs,
+  docs/xdp-io-uring-userspace-dataplane.md, _Log.md

--- a/docs/xdp-io-uring-userspace-dataplane.md
+++ b/docs/xdp-io-uring-userspace-dataplane.md
@@ -614,6 +614,17 @@ io_uring helps a lot, but not in the way people often mean.
 
 1. **Slow-path reinjection**
 - write host-bound/exception packets to TUN/TAP with batched SQEs
+- a TUN/TAP fd is packet-oriented: one `write()` (or one io_uring write
+  submission) is exactly one L3 packet, never a byte stream. The slow-path
+  writers (`write_packet_sync` and the non-positioned io_uring `write_all`
+  in `userspace-dp/src/{slowpath,io_uring_write}.rs`) are therefore
+  whole-packet-atomic (#2407): `EINTR` retries the WHOLE packet from offset
+  0; a short count (`0 < n < len`) DROPS the packet (counted as a slow-path
+  drop + write error) instead of resubmitting `bytes[n..]`. Resubmitting the
+  remainder would make the kernel read the leftover bytes as a SECOND,
+  malformed packet — corrupting the device stream. Only the positioned
+  (state-writer / regular-file) io_uring path is a true byte stream and may
+  resume from `offset + n`.
 
 2. **Session sync transport**
 - replace blocking write/read goroutines with batched async I/O

--- a/userspace-dp/src/io_uring_write.rs
+++ b/userspace-dp/src/io_uring_write.rs
@@ -188,7 +188,21 @@ pub(crate) fn write_all(
         if res == 0 {
             return Err(format!("{label} io_uring short write: 0"));
         }
-        offset += res as usize;
+        let n = res as usize;
+        // A non-positioned (stream-mode) write targets a packet-oriented fd:
+        // the TUN slow path (#2407). One submission is one L3 packet. A short
+        // CQE count must NOT resubmit the remainder — re-writing `data[n..]`
+        // would inject the leftover bytes as a SECOND, malformed packet. Treat
+        // a partial as an unsendable packet and drop it (Err); the caller
+        // counts the drop. Positioned writes (a regular file — the state
+        // writer) are a true byte stream and DO resume from `offset + n`.
+        if !positioned && n < data.len() {
+            return Err(format!(
+                "{label} io_uring short write on packet fd: wrote {n} of {} bytes (packet dropped)",
+                data.len()
+            ));
+        }
+        offset += n;
         // Advance the tag so the next submission's CQE cannot be confused with
         // this one's (and a leftover CQE from this one cannot be reused).
         tag = tag.wrapping_add(1);
@@ -428,13 +442,70 @@ mod tests {
         assert_eq!(ring.push_calls, 1);
     }
 
+    /// Positioned (regular-file / state-writer) stream write: a short count
+    /// legitimately resumes from `offset + n` because a file IS a byte stream.
     #[test]
-    fn short_write_advances_and_resubmits() {
+    fn positioned_short_write_advances_and_resubmits() {
         // First completion reports 2 of 4 bytes; second reports the remaining 2.
         let mut ring = FakeRing::new(vec![Ok(()), Ok(())], vec![2, 2]);
-        let out = write_all(&mut ring, &[0u8; 4], false, "test").unwrap();
+        let out = write_all(&mut ring, &[0u8; 4], true, "state").unwrap();
         assert_eq!(out, WriteOutcome::Done);
         assert_eq!(ring.push_calls, 2);
+    }
+
+    /// #2407 fail-on-revert: a non-positioned (TUN, packet-oriented) write that
+    /// reports a SHORT count must NOT resubmit the remainder — doing so would
+    /// inject `data[n..]` as a second corrupt packet. It must return Err after
+    /// exactly ONE push, never a second `data[n..]` write.
+    ///
+    /// If the packet-fd guard is reverted (the loop resumes from `offset + n`
+    /// for non-positioned writes), the fake materialises the SECOND CQE (4),
+    /// `push_calls` becomes 2, and the call returns Ok — both asserts fail.
+    #[test]
+    fn packet_short_write_drops_no_remainder_resubmit() {
+        // Script a second successful wait + a second result so a (buggy)
+        // resubmit WOULD succeed and complete — proving the guard, not a lack of
+        // script, is what stops the corrupting remainder write.
+        let mut ring = FakeRing::new(vec![Ok(()), Ok(())], vec![2, 2]);
+        let err = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap_err();
+        assert!(
+            err.contains("short write on packet fd"),
+            "partial packet write must be a drop, got: {err}"
+        );
+        assert_eq!(
+            ring.push_calls, 1,
+            "a packet-fd short write must NOT resubmit the remainder (corruption)"
+        );
+        // Only the first (partial) CQE may have been accepted; the corrupting
+        // second chunk's bytes must never be applied.
+        assert_eq!(
+            ring.accepted_bytes(),
+            2,
+            "no remainder bytes may be written after a partial packet write"
+        );
+    }
+
+    /// A non-positioned FULL write still succeeds in one push (no regression).
+    #[test]
+    fn packet_full_write_succeeds() {
+        let mut ring = FakeRing::new(vec![Ok(())], vec![4]);
+        let out = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap();
+        assert_eq!(out, WriteOutcome::Done);
+        assert_eq!(ring.push_calls, 1);
+    }
+
+    /// #2407: EINTR on a packet write retries the WAIT (not a re-push) and then
+    /// reaps the full count — the whole packet is written with one submission.
+    #[test]
+    fn packet_eintr_retries_whole_no_corruption() {
+        let mut ring = FakeRing::new(vec![eintr(), Ok(())], vec![4]);
+        let out = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap();
+        assert_eq!(out, WriteOutcome::Done);
+        assert_eq!(
+            ring.push_calls, 1,
+            "EINTR retry must be wait-only, never a remainder re-push"
+        );
+        assert_eq!(ring.accepted_bytes(), 4);
     }
 
     /// The core #2297 regression: an EINTR on the wait must NOT abandon the SQE
@@ -493,7 +564,12 @@ mod tests {
             // Defended by the reap-loop user_data match (surfaces during the
             // first wait, ahead of the real CQE).
             .with_stale_on_wait(vec![Some(stale()), None]);
-        let out = write_all(&mut ring, &[0u8; 8], false, "test").unwrap();
+        // Positioned (file/state-writer) write: a short count legitimately
+        // resumes from offset+n, so the two-chunk resume here exercises the
+        // stale-CQE defences across both pushes. (A non-positioned/TUN partial
+        // would drop at the first chunk — that's the #2407 packet semantics,
+        // covered by `packet_short_write_drops_no_remainder_resubmit`.)
+        let out = write_all(&mut ring, &[0u8; 8], true, "test").unwrap();
         assert_eq!(out, WriteOutcome::Done);
         // A misattributed stale CQE (res=9999) would overshoot offset and finish
         // in ONE push; the correct path needs TWO.

--- a/userspace-dp/src/slowpath.rs
+++ b/userspace-dp/src/slowpath.rs
@@ -290,24 +290,58 @@ fn slow_path_worker(name: &str, rx: Receiver<PacketRequest>, status: Arc<SharedS
 }
 
 fn write_packet_sync(fd: i32, bytes: &[u8]) -> Result<(), String> {
-    let mut written = 0usize;
-    while written < bytes.len() {
-        let rc = unsafe {
-            libc::write(
-                fd,
-                bytes.as_ptr().add(written).cast::<libc::c_void>(),
-                bytes.len() - written,
-            )
-        };
+    write_packet_atomic(bytes.len(), |buf_len| {
+        // SAFETY: `bytes` is a valid slice for `buf_len` bytes; `fd` is the TUN
+        // fd owned by the worker. Always writes from offset 0 — a TUN write is
+        // one packet, never a partial-offset resubmit.
+        unsafe { libc::write(fd, bytes.as_ptr().cast::<libc::c_void>(), buf_len) }
+    })
+}
+
+/// Write one whole packet to a packet-oriented fd (the TUN device).
+///
+/// A TUN/TAP fd is datagram-like: each successful `write()` injects exactly one
+/// L3 packet. There is no byte-stream resume — re-writing a "remainder" after a
+/// short count would inject the leftover bytes as a SECOND, malformed packet
+/// (#2407). So this never advances an offset:
+///
+///   * `EINTR` — the write never started; retry the WHOLE packet.
+///   * full count (`rc == len`) — success.
+///   * partial (`0 < rc < len`) — the packet is unsendable as written and a
+///     resubmit would corrupt the stream; DROP it (return `Err`, which the
+///     caller counts as a dropped packet + write error).
+///   * `rc == 0` or `rc < 0` (any other errno, incl. `EAGAIN`) — `Err` (drop).
+///
+/// `writer(len)` performs one `write(fd, buf, len)` and returns its raw result
+/// (mirrors `libc::write`: `>=0` byte count, `<0` negated via `errno`). It is a
+/// seam so the short-count / EINTR behaviour is unit-testable without a real fd.
+fn write_packet_atomic<F>(len: usize, mut writer: F) -> Result<(), String>
+where
+    F: FnMut(usize) -> isize,
+{
+    loop {
+        let rc = writer(len);
         if rc < 0 {
-            return Err(format!("slow-path write: {}", io::Error::last_os_error()));
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                // The write was interrupted before transferring any bytes;
+                // retry the whole packet from offset 0.
+                continue;
+            }
+            return Err(format!("slow-path write: {err}"));
         }
-        if rc == 0 {
-            return Err("slow-path write returned 0".to_string());
+        let n = rc as usize;
+        if n == len {
+            return Ok(());
         }
-        written += rc as usize;
+        // A short or zero count on a packet device: the packet cannot be
+        // resumed (re-writing bytes[n..] would inject a corrupt packet), so
+        // drop it. This is unexpected for a valid TUN write; dropping avoids
+        // corrupting the device stream.
+        return Err(format!(
+            "slow-path short write on packet fd: wrote {n} of {len} bytes (packet dropped)"
+        ));
     }
-    Ok(())
 }
 
 fn write_packet_io_uring(ring: &mut IoUring, fd: i32, bytes: &[u8]) -> Result<(), String> {
@@ -458,5 +492,99 @@ mod tests {
         assert_eq!(snap.mode, "io_uring");
         assert_eq!(snap.device_name, "xpf-usp0");
         assert_eq!(snap.last_error, "none");
+    }
+
+    /// A normal full write succeeds in a single `write()` call (no regression).
+    #[test]
+    fn sync_full_write_succeeds_single_call() {
+        let len = 100usize;
+        let mut calls = 0usize;
+        let res = write_packet_atomic(len, |buf_len| {
+            calls += 1;
+            assert_eq!(buf_len, len, "writer must always be handed the full packet");
+            buf_len as isize
+        });
+        assert!(res.is_ok());
+        assert_eq!(calls, 1, "a full write must not loop");
+    }
+
+    /// #2407 fail-on-revert: a short count (0 < n < len) on the packet fd MUST
+    /// drop the packet (Err) — it must NOT issue a follow-up write of the
+    /// remaining bytes. The writer is invoked exactly once and always with the
+    /// FULL length; there is never a `write(bytes[n..])` of length `len - n`.
+    ///
+    /// If the stream-style remainder loop were restored, the writer would be
+    /// called a SECOND time with `len - n` to finish the packet — corrupting the
+    /// TUN. This asserts call count == 1 and that the one call used the full
+    /// length, so a remainder resubmit fails the test.
+    #[test]
+    fn sync_short_write_drops_no_remainder() {
+        let len = 100usize;
+        let mut observed_lens = Vec::new();
+        let res = write_packet_atomic(len, |buf_len| {
+            observed_lens.push(buf_len);
+            40 // partial: 40 of 100
+        });
+        let err = res.unwrap_err();
+        assert!(
+            err.contains("short write on packet fd"),
+            "partial packet write must be a drop, got: {err}"
+        );
+        assert_eq!(
+            observed_lens,
+            vec![len],
+            "a partial write must NOT trigger a remainder write — exactly one \
+             full-length write, never a write of bytes[n..]"
+        );
+    }
+
+    /// EINTR retries the WHOLE packet (offset 0), never a partial offset.
+    #[test]
+    fn sync_eintr_retries_whole_packet() {
+        let len = 100usize;
+        let mut observed_lens = Vec::new();
+        let mut first = true;
+        let res = write_packet_atomic(len, |buf_len| {
+            observed_lens.push(buf_len);
+            if first {
+                first = false;
+                // Simulate write() returning -1 with errno = EINTR.
+                set_errno(libc::EINTR);
+                -1
+            } else {
+                buf_len as isize
+            }
+        });
+        assert!(res.is_ok(), "EINTR must retry, not fail");
+        assert_eq!(
+            observed_lens,
+            vec![len, len],
+            "EINTR retry must re-issue the WHOLE packet, never bytes[n..]"
+        );
+    }
+
+    /// A zero count is treated as a short write and dropped (no infinite loop).
+    #[test]
+    fn sync_zero_write_drops() {
+        let res = write_packet_atomic(100, |_| 0);
+        assert!(res.unwrap_err().contains("short write on packet fd"));
+    }
+
+    /// A hard error (non-EINTR negative) drops the packet.
+    #[test]
+    fn sync_hard_error_drops() {
+        let res = write_packet_atomic(100, |_| {
+            set_errno(libc::EIO);
+            -1
+        });
+        assert!(res.unwrap_err().contains("slow-path write"));
+    }
+
+    /// Set the thread-local errno so the seam can simulate `libc::write`'s
+    /// errno reporting. `io::Error::last_os_error()` reads this.
+    fn set_errno(e: libc::c_int) {
+        unsafe {
+            *libc::__errno_location() = e;
+        }
     }
 }

--- a/userspace-dp/src/slowpath.rs
+++ b/userspace-dp/src/slowpath.rs
@@ -312,9 +312,13 @@ fn write_packet_sync(fd: i32, bytes: &[u8]) -> Result<(), String> {
 ///     caller counts as a dropped packet + write error).
 ///   * `rc == 0` or `rc < 0` (any other errno, incl. `EAGAIN`) — `Err` (drop).
 ///
-/// `writer(len)` performs one `write(fd, buf, len)` and returns its raw result
-/// (mirrors `libc::write`: `>=0` byte count, `<0` negated via `errno`). It is a
-/// seam so the short-count / EINTR behaviour is unit-testable without a real fd.
+/// `writer(len)` performs one `write(fd, buf, len)` and returns its raw result,
+/// mirroring `libc::write`: a non-negative byte count on success, or `-1` on
+/// error with `errno` set separately (the unit-test seam sets `errno`
+/// explicitly). On a `-1` return `write_packet_atomic` reads `errno` via
+/// `io::Error::last_os_error()` to distinguish `EINTR` (retry the whole packet)
+/// from a hard error (drop). It is a seam so the short-count / EINTR behaviour
+/// is unit-testable without a real fd.
 fn write_packet_atomic<F>(len: usize, mut writer: F) -> Result<(), String>
 where
     F: FnMut(usize) -> isize,


### PR DESCRIPTION
Closes #2407

## Problem
A TUN/TAP fd is **packet-oriented**: one `write()` (or one io_uring write submission) is exactly one L3 packet — it is *not* a byte stream. Both slow-path reinjection writers retried a **short** count by resubmitting the **remaining** bytes (stream semantics). On a packet device that makes the kernel interpret `bytes[n..]` as a **SECOND, malformed packet**: the original frame is truncated and a garbage packet is injected, showing up as intermittent slow-path packet corruption + kernel drop counts.

The slow path backs local-delivery and exception reinjection (ICMP, IPsec passthrough #2385, unresolved-neighbor/unsupported-route), so this is silent corruption under short-write / congestion / EINTR conditions.

Provenance: agy review-032 finding 2.

## Sites (current master)
- **sync** — `userspace-dp/src/slowpath.rs` `write_packet_sync`: `while written < len { write(ptr+written, len-written) }`.
- **io_uring** — `userspace-dp/src/io_uring_write.rs` `write_all`: `while offset < data.len()` resubmits `data[offset..]`; the TUN slow path uses non-positioned (stream) mode, so a short CQE triggered the resubmit-remainder loop.

## Fix — whole-packet-atomic, never resume from a partial offset
- **sync**: extracted to `write_packet_atomic(len, writer)` (closure seam → unit-testable without a real fd). Always writes the WHOLE packet from offset 0. `EINTR` → retry whole; full count → Ok; partial `0 < n < len` or `0` → `Err` (drop); any other errno (incl. `EAGAIN`) → `Err` (drop).
- **io_uring**: the loop is **shared** with the positioned state-writer (a regular file IS a byte stream and legitimately resumes). Added a `!positioned` guard: the TUN (non-positioned) path drops a short CQE count (`Err`) instead of resubmitting `data[n..]`; **positioned writes keep the multi-chunk resume**. The EINTR retry was already wait-only (no re-push), so it is whole-packet by construction.

**Drop counter:** none added — the existing `slow_path_worker` `Err` arm already increments `dropped_packets` / `dropped_bytes` / `write_errors`, so a dropped partial is accounted there.

## Tests (fail-on-revert — each verified by temporarily restoring the remainder loop)
io_uring:
- `packet_short_write_drops_no_remainder_resubmit` — one push, `Err`, **zero remainder bytes accepted** (asserts no `data[n..]` write; fails if the guard is reverted)
- `packet_full_write_succeeds`, `packet_eintr_retries_whole_no_corruption`
- `positioned_short_write_advances_and_resubmits` — file resume preserved (no regression)

sync:
- `sync_short_write_drops_no_remainder` — exactly one **full-length** write, never `bytes[n..]`
- `sync_full_write_succeeds_single_call`, `sync_eintr_retries_whole_packet`, `sync_zero_write_drops`, `sync_hard_error_drops`

Repointed the pre-existing `stale_cqe_is_not_misattributed` (#2297) test to `positioned=true` — its two-chunk resume is now valid only for the file path; packet semantics are covered by the new test.

## Validation
- `cargo build --release` clean; clippy no new findings on changed files
- full `userspace-dp` suite green (2587 + 46 + 62); new tests 5x stable
- fail-on-revert confirmed for both the sync and io_uring guards

No wire field. Doc: `docs/xdp-io-uring-userspace-dataplane.md` slow-path reinjection section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi