### PR TITLE
slowpath: warn when conf/all/rp_filter overrides per-device 0 (#2378)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -11959,3 +11959,13 @@ top.
 - **File(s)**: userspace-dp/src/slowpath.rs, pkg/networkd/networkd.go,
   pkg/networkd/rpfilter_test.go, docs/userspace-dataplane-architecture.md,
   _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2378 PR #2459 review folds — (1) corrected the ALL_RP_FILTER_PATH
+  doc comment (read_all_rp_filter takes the path as a parameter; the constant is
+  only the production default, not a test substitution seam). (2) Reworded both
+  the Rust eprintln! and the Go slog.Warn so the message states the all-knob
+  hazard directly and no longer asserts the per-device rp_filter=0 was written
+  — accurate even when the per-device write failed (drop hazard is then MORE
+  acute, so the warning is deliberately NOT suppressed). Tests/build green.
+- **File(s)**: userspace-dp/src/slowpath.rs, pkg/networkd/networkd.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -11944,3 +11944,18 @@ top.
   userspace-dp/src/afxdp/coordinator/mod.rs,
   userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs,
   docs/userspace-dataplane-architecture.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2378 — slow-path TUN rp_filter conf/all override warning.
+  Per-device rp_filter=0 on the slow-path TUN is overridden by the kernel
+  (effective = max(conf/all, conf/<dev>)), so a non-zero
+  net.ipv4.conf.all.rp_filter silently drops reinjected IPv4 packets.
+  Design fork resolved to the WARNING path: the helper owns no host-global
+  sysctls (grep conf/all userspace-dp/src → none), so it does NOT mutate
+  conf/all/rp_filter; it reads it once at bringup and emits a loud xpf-ha:
+  warning. Mirrored on the Go reload path (warnIfAllRPFilterOverrides).
+  Seamed helpers (rp_filter_all_warning / read_all_rp_filter; procSysNetRoot
+  package var) with fail-on-revert unit tests on both sides.
+- **File(s)**: userspace-dp/src/slowpath.rs, pkg/networkd/networkd.go,
+  pkg/networkd/rpfilter_test.go, docs/userspace-dataplane-architecture.md,
+  _Log.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -457,6 +457,21 @@ A TUN device (`xpf-usp0`) for packets that need kernel processing:
     snapshot MTU different from the live TUN's creation MTU, the reconcile
     path emits a one-shot (per distinct value) `xpf-ha:` warning so the
     stale-until-restart window is diagnosable rather than silent.
+- **Reverse-path filter (#2378):** reinjected IPv4 replies arrive on the
+  TUN but their reverse route still points at the real egress interface,
+  so `open_tun` writes `conf/<dev>/rp_filter=0`. The kernel, however, uses
+  the **maximum** of `conf/all/rp_filter` and `conf/<dev>/rp_filter`, so a
+  non-zero `net.ipv4.conf.all.rp_filter` (strict=1 / loose=2 — a common
+  Debian/Ubuntu default) overrides the per-device 0 and silently drops
+  every reinjected IPv4 packet. The helper does NOT own host-global
+  sysctls, so it does NOT mutate `conf/all/rp_filter`; instead `open_tun`
+  reads `conf/all/rp_filter` once at bringup and emits a loud `xpf-ha:`
+  warning (`rp_filter_all_warning`) when it is non-zero, instructing the
+  operator to `sysctl -w net.ipv4.conf.all.rp_filter=0`. The Go reload
+  path (`networkd.restoreSlowPathRPFilter`) re-asserts the per-device 0
+  after a `networkctl reload` and mirrors the same `conf/all` warning
+  (`warnIfAllRPFilterOverrides`). Both checks are bringup/reload-only,
+  never per-packet.
 
 ### 3. Go Manager (`pkg/dataplane/userspace/manager.go`)
 

--- a/pkg/networkd/networkd.go
+++ b/pkg/networkd/networkd.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -243,14 +244,27 @@ func (m *Manager) Apply(interfaces []InterfaceConfig) error {
 	return nil
 }
 
+// procSysNetRoot is the root of the IPv4 sysctl tree. It is a package var
+// (not a const) so tests can point the slow-path rp_filter handling at a
+// temp-file fixture instead of the live /proc.
+var procSysNetRoot = "/proc/sys/net/ipv4"
+
 // restoreSlowPathRPFilter re-disables rp_filter on the userspace dataplane's
 // slow-path TUN device after a networkctl reload. networkd resets sysctls to
 // defaults (rp_filter=2) on all interfaces during reload, which breaks
 // locally-originated traffic delivery via the TUN (the kernel drops packets
 // whose source route doesn't point at the TUN interface).
+//
+// The kernel computes the effective rp_filter for a packet as
+// max(conf/all/rp_filter, conf/<dev>/rp_filter), so the per-device 0 we write
+// here is ignored if conf/all/rp_filter is non-zero (a common Debian/Ubuntu
+// default). We do NOT mutate the host-global conf/all knob — instead, when it
+// is non-zero, we emit a one-time operator-visible warning that slow-path
+// reinjection will be dropped until it is lowered (#2378). This runs only on
+// the reload/clear path, never per-packet.
 func restoreSlowPathRPFilter() {
 	const tunName = "xpf-usp0"
-	path := fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", tunName)
+	path := fmt.Sprintf("%s/conf/%s/rp_filter", procSysNetRoot, tunName)
 	// BestEffortKernelKnob (#1894): procfs has no rename, so the
 	// fsatomic writers are impossible here by construction — the direct
 	// write is correct, not an oversight.
@@ -261,6 +275,28 @@ func restoreSlowPathRPFilter() {
 		}
 		slog.Warn("failed to restore rp_filter on slow-path TUN", "path", path, "err", err)
 	}
+	warnIfAllRPFilterOverrides(tunName)
+}
+
+// warnIfAllRPFilterOverrides emits a loud warning when net.ipv4.conf.all.rp_filter
+// is non-zero, which overrides the per-device 0 set above (kernel uses
+// max(all, dev)) and silently drops slow-path reinjected IPv4 packets (#2378).
+// A missing or unparsable conf/all/rp_filter is treated as "cannot determine"
+// and stays quiet so a read failure never produces a spurious warning.
+func warnIfAllRPFilterOverrides(tunName string) {
+	allPath := fmt.Sprintf("%s/conf/all/rp_filter", procSysNetRoot)
+	raw, err := os.ReadFile(allPath)
+	if err != nil {
+		return
+	}
+	val, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || val == 0 {
+		return
+	}
+	slog.Warn("net.ipv4.conf.all.rp_filter overrides per-device rp_filter=0 on "+
+		"slow-path TUN; reinjected IPv4 packets will be SILENTLY DROPPED until "+
+		"'sysctl -w net.ipv4.conf.all.rp_filter=0' is set",
+		"tun", tunName, "all_rp_filter", val, "issue", 2378)
 }
 
 // Clear removes all xpf-managed networkd files and reloads.

--- a/pkg/networkd/networkd.go
+++ b/pkg/networkd/networkd.go
@@ -279,10 +279,15 @@ func restoreSlowPathRPFilter() {
 }
 
 // warnIfAllRPFilterOverrides emits a loud warning when net.ipv4.conf.all.rp_filter
-// is non-zero, which overrides the per-device 0 set above (kernel uses
-// max(all, dev)) and silently drops slow-path reinjected IPv4 packets (#2378).
-// A missing or unparsable conf/all/rp_filter is treated as "cannot determine"
-// and stays quiet so a read failure never produces a spurious warning.
+// is non-zero. The kernel uses max(conf/all/rp_filter, conf/<dev>/rp_filter), so
+// a non-zero conf/all knob silently drops slow-path reinjected IPv4 packets
+// regardless of the per-device value (#2378). The message states the hazard from
+// the all-knob directly and does NOT assert that the per-device write above
+// succeeded — so it stays accurate when the per-device write failed (in which
+// case the drop hazard is in fact MORE acute, and suppressing the warning would
+// hide a still-relevant signal). A missing or unparsable conf/all/rp_filter is
+// treated as "cannot determine" and stays quiet so a read failure never produces
+// a spurious warning.
 func warnIfAllRPFilterOverrides(tunName string) {
 	allPath := fmt.Sprintf("%s/conf/all/rp_filter", procSysNetRoot)
 	raw, err := os.ReadFile(allPath)
@@ -293,8 +298,8 @@ func warnIfAllRPFilterOverrides(tunName string) {
 	if err != nil || val == 0 {
 		return
 	}
-	slog.Warn("net.ipv4.conf.all.rp_filter overrides per-device rp_filter=0 on "+
-		"slow-path TUN; reinjected IPv4 packets will be SILENTLY DROPPED until "+
+	slog.Warn("net.ipv4.conf.all.rp_filter is non-zero; kernel uses max(all,dev) "+
+		"so slow-path reinjected IPv4 packets will be SILENTLY DROPPED until "+
 		"'sysctl -w net.ipv4.conf.all.rp_filter=0' is set",
 		"tun", tunName, "all_rp_filter", val, "issue", 2378)
 }

--- a/pkg/networkd/rpfilter_test.go
+++ b/pkg/networkd/rpfilter_test.go
@@ -1,0 +1,86 @@
+package networkd
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// captureWarn runs fn with slog routed to an in-memory text handler and
+// returns everything logged. Used to assert the #2378 rp_filter warning fires
+// (or stays quiet) without touching the live /proc tree.
+func captureWarn(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	fn()
+	return buf.String()
+}
+
+// setupProcRoot builds a fake /proc/sys/net/ipv4 tree with a given
+// conf/all/rp_filter value and points procSysNetRoot at it for the duration of
+// the test.
+func setupProcRoot(t *testing.T, allValue string) {
+	t.Helper()
+	root := t.TempDir()
+	allDir := filepath.Join(root, "conf", "all")
+	if err := os.MkdirAll(allDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if allValue != "" {
+		if err := os.WriteFile(filepath.Join(allDir, "rp_filter"), []byte(allValue), 0644); err != nil {
+			t.Fatalf("write all rp_filter: %v", err)
+		}
+	}
+	prev := procSysNetRoot
+	procSysNetRoot = root
+	t.Cleanup(func() { procSysNetRoot = prev })
+}
+
+// #2378 fail-on-revert: when conf/all/rp_filter is strict (1) or loose (2),
+// the per-device 0 is overridden by the kernel (max(all, dev)) and slow-path
+// reinjected IPv4 packets are silently dropped. warnIfAllRPFilterOverrides MUST
+// emit a warning. If the all-rp_filter check is removed, this test fails.
+func TestWarnIfAllRPFilterOverrides_Nonzero(t *testing.T) {
+	for _, v := range []string{"1", "2", "1\n"} {
+		setupProcRoot(t, v)
+		out := captureWarn(t, func() { warnIfAllRPFilterOverrides("xpf-usp0") })
+		if !bytes.Contains([]byte(out), []byte("SILENTLY DROPPED")) {
+			t.Fatalf("all rp_filter=%q: expected a warning, got %q", v, out)
+		}
+		if !bytes.Contains([]byte(out), []byte("xpf-usp0")) {
+			t.Fatalf("all rp_filter=%q: warning must name the TUN device, got %q", v, out)
+		}
+	}
+}
+
+// When conf/all/rp_filter is 0 the per-device 0 is effective; no warning.
+func TestWarnIfAllRPFilterOverrides_Zero(t *testing.T) {
+	setupProcRoot(t, "0\n")
+	out := captureWarn(t, func() { warnIfAllRPFilterOverrides("xpf-usp0") })
+	if bytes.Contains([]byte(out), []byte("SILENTLY DROPPED")) {
+		t.Fatalf("all rp_filter=0 must not warn, got %q", out)
+	}
+}
+
+// A missing or unparsable conf/all/rp_filter is "cannot determine" — stay
+// quiet rather than emit a spurious warning.
+func TestWarnIfAllRPFilterOverrides_MissingOrGarbage(t *testing.T) {
+	// Missing file (no rp_filter written).
+	setupProcRoot(t, "")
+	out := captureWarn(t, func() { warnIfAllRPFilterOverrides("xpf-usp0") })
+	if bytes.Contains([]byte(out), []byte("SILENTLY DROPPED")) {
+		t.Fatalf("missing all rp_filter must not warn, got %q", out)
+	}
+
+	// Garbage contents.
+	setupProcRoot(t, "garbage")
+	out = captureWarn(t, func() { warnIfAllRPFilterOverrides("xpf-usp0") })
+	if bytes.Contains([]byte(out), []byte("SILENTLY DROPPED")) {
+		t.Fatalf("unparsable all rp_filter must not warn, got %q", out)
+	}
+}

--- a/userspace-dp/src/slowpath.rs
+++ b/userspace-dp/src/slowpath.rs
@@ -407,7 +407,52 @@ pub(crate) fn open_tun(name: &str) -> Result<(std::fs::File, String), String> {
     // reverse route still points at the real egress interface. Disable
     // per-device rp_filter so the kernel accepts those packets.
     set_ipv4_sysctl(&actual_name, "rp_filter", "0")?;
+    // The kernel computes the effective rp_filter for a packet as
+    // max(conf/all/rp_filter, conf/<dev>/rp_filter) (see
+    // Documentation/networking/ip-sysctl.rst). So the per-device 0 we just
+    // wrote is IGNORED if conf/all/rp_filter is non-zero (strict=1 / loose=2,
+    // a common Debian/Ubuntu default) — every slow-path reinjected IPv4 packet
+    // would then be silently dropped as a reverse-path failure (#2378). We do
+    // NOT mutate the host-global conf/all knob here (the helper owns no
+    // host-global sysctls); instead emit a one-time, operator-visible warning
+    // at TUN bringup. This is bringup-only, never per-packet.
+    let all_rpf = read_all_rp_filter(ALL_RP_FILTER_PATH);
+    if let Some(line) = rp_filter_all_warning(&actual_name, all_rpf) {
+        eprintln!("{line}");
+    }
     Ok((tun, actual_name))
+}
+
+/// Path to the host-global IPv4 reverse-path-filter sysctl. Split out as a
+/// constant so tests can substitute a temp-file path.
+const ALL_RP_FILTER_PATH: &str = "/proc/sys/net/ipv4/conf/all/rp_filter";
+
+/// Read the integer value of `conf/all/rp_filter` from `path`. Returns `None`
+/// if the file is missing or unparsable (treated as "cannot determine, do not
+/// warn") so a read failure never produces a spurious warning.
+fn read_all_rp_filter(path: &str) -> Option<i32> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    raw.trim().parse::<i32>().ok()
+}
+
+/// Decide whether to warn about an ineffective per-device rp_filter=0.
+///
+/// The kernel uses max(conf/all/rp_filter, conf/<dev>/rp_filter), so when
+/// conf/all/rp_filter is non-zero the per-device 0 is overridden and slow-path
+/// reinjection is dropped. Returns `Some(warning_line)` when `all_rpf` is a
+/// known non-zero value, `None` when it is 0 or unknown. Seamed (takes the
+/// already-read value) so it is unit-testable without touching live /proc.
+fn rp_filter_all_warning(dev: &str, all_rpf: Option<i32>) -> Option<String> {
+    match all_rpf {
+        Some(v) if v != 0 => Some(format!(
+            "xpf-ha: WARNING net.ipv4.conf.all.rp_filter={v} overrides the \
+             per-device rp_filter=0 on slow-path TUN {dev}; the kernel uses \
+             max(all,dev) so slow-path reinjected IPv4 packets will be SILENTLY \
+             DROPPED until 'sysctl -w net.ipv4.conf.all.rp_filter=0' is set \
+             (#2378)"
+        )),
+        _ => None,
+    }
 }
 
 fn set_if_up(name: &str) -> Result<(), String> {
@@ -538,6 +583,59 @@ impl IfReq {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #2378 fail-on-revert: when conf/all/rp_filter is strict (1) or loose (2),
+    /// the per-device rp_filter=0 we write on the slow-path TUN is overridden by
+    /// the kernel's max(all, dev) rule, so reinjected IPv4 packets are dropped.
+    /// `rp_filter_all_warning` MUST return a warning in that case. If the check
+    /// is removed (helper always returns None), these assertions fail.
+    #[test]
+    fn rp_filter_all_warning_fires_on_strict_and_loose() {
+        let strict = rp_filter_all_warning("xpf-usp0", Some(1));
+        assert!(strict.is_some(), "all=1 (strict) must warn");
+        assert!(strict.unwrap().contains("rp_filter"));
+
+        let loose = rp_filter_all_warning("xpf-usp0", Some(2));
+        assert!(loose.is_some(), "all=2 (loose) must warn");
+        let msg = loose.unwrap();
+        assert!(msg.contains("xpf-usp0"), "warning names the device");
+        assert!(msg.contains("=2"), "warning reports the offending value");
+    }
+
+    /// When conf/all/rp_filter is 0 (or unknown/unparsable) the per-device 0 is
+    /// effective, so the helper must stay quiet — no spurious operator warning.
+    #[test]
+    fn rp_filter_all_warning_quiet_when_zero_or_unknown() {
+        assert!(
+            rp_filter_all_warning("xpf-usp0", Some(0)).is_none(),
+            "all=0 must not warn"
+        );
+        assert!(
+            rp_filter_all_warning("xpf-usp0", None).is_none(),
+            "unknown all value must not warn"
+        );
+    }
+
+    /// The file-reading seam parses the sysctl value and tolerates trailing
+    /// whitespace; a missing or garbage file yields None (do-not-warn).
+    #[test]
+    fn read_all_rp_filter_parses_and_tolerates_missing() {
+        let dir = std::env::temp_dir().join(format!("xpf-rpf-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let ok = dir.join("all_rp_filter");
+        std::fs::write(&ok, "1\n").unwrap();
+        assert_eq!(read_all_rp_filter(ok.to_str().unwrap()), Some(1));
+
+        std::fs::write(&ok, "  2  ").unwrap();
+        assert_eq!(read_all_rp_filter(ok.to_str().unwrap()), Some(2));
+
+        let missing = dir.join("does-not-exist");
+        assert_eq!(read_all_rp_filter(missing.to_str().unwrap()), None);
+
+        std::fs::write(&ok, "garbage").unwrap();
+        assert_eq!(read_all_rp_filter(ok.to_str().unwrap()), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn rate_limiter_refills_after_window() {

--- a/userspace-dp/src/slowpath.rs
+++ b/userspace-dp/src/slowpath.rs
@@ -423,8 +423,10 @@ pub(crate) fn open_tun(name: &str) -> Result<(std::fs::File, String), String> {
     Ok((tun, actual_name))
 }
 
-/// Path to the host-global IPv4 reverse-path-filter sysctl. Split out as a
-/// constant so tests can substitute a temp-file path.
+/// Production default path to the host-global IPv4 reverse-path-filter sysctl.
+/// `read_all_rp_filter` takes the path as a parameter, so tests pass their own
+/// temp-file path directly; this constant is only the live-`/proc` default that
+/// `open_tun` reads.
 const ALL_RP_FILTER_PATH: &str = "/proc/sys/net/ipv4/conf/all/rp_filter";
 
 /// Read the integer value of `conf/all/rp_filter` from `path`. Returns `None`
@@ -435,21 +437,24 @@ fn read_all_rp_filter(path: &str) -> Option<i32> {
     raw.trim().parse::<i32>().ok()
 }
 
-/// Decide whether to warn about an ineffective per-device rp_filter=0.
+/// Decide whether to warn that a non-zero conf/all/rp_filter will drop
+/// slow-path reinjection.
 ///
-/// The kernel uses max(conf/all/rp_filter, conf/<dev>/rp_filter), so when
-/// conf/all/rp_filter is non-zero the per-device 0 is overridden and slow-path
-/// reinjection is dropped. Returns `Some(warning_line)` when `all_rpf` is a
-/// known non-zero value, `None` when it is 0 or unknown. Seamed (takes the
-/// already-read value) so it is unit-testable without touching live /proc.
+/// The kernel uses max(conf/all/rp_filter, conf/<dev>/rp_filter), so a non-zero
+/// conf/all/rp_filter defeats reverse-path acceptance on the slow-path TUN
+/// regardless of the per-device value. The message states the hazard from the
+/// all-knob directly (it does NOT assert that the per-device 0 was written), so
+/// it is accurate whether or not the per-device write succeeded. Returns
+/// `Some(warning_line)` when `all_rpf` is a known non-zero value, `None` when
+/// it is 0 or unknown. Seamed (takes the already-read value) so it is
+/// unit-testable without touching live /proc.
 fn rp_filter_all_warning(dev: &str, all_rpf: Option<i32>) -> Option<String> {
     match all_rpf {
         Some(v) if v != 0 => Some(format!(
-            "xpf-ha: WARNING net.ipv4.conf.all.rp_filter={v} overrides the \
-             per-device rp_filter=0 on slow-path TUN {dev}; the kernel uses \
-             max(all,dev) so slow-path reinjected IPv4 packets will be SILENTLY \
-             DROPPED until 'sysctl -w net.ipv4.conf.all.rp_filter=0' is set \
-             (#2378)"
+            "xpf-ha: WARNING net.ipv4.conf.all.rp_filter={v} is non-zero; the \
+             kernel uses max(all,dev) so slow-path reinjected IPv4 packets on \
+             TUN {dev} will be SILENTLY DROPPED until \
+             'sysctl -w net.ipv4.conf.all.rp_filter=0' is set (#2378)"
         )),
         _ => None,
     }


### PR DESCRIPTION
## Summary

Fixes #2378 (agy review-029 finding 5, MEDIUM). The slow-path TUN reinjector disabled reverse-path filtering by writing `0` to **only** the per-device `rp_filter` sysctl. The kernel computes the effective rp_filter as `max(conf/all/rp_filter, conf/<dev>/rp_filter)`, so when `net.ipv4.conf.all.rp_filter` is strict (`1`) or loose (`2`) — a common Debian/Ubuntu default — the per-device `0` is ignored and **every slow-path reinjected IPv4 packet is silently dropped** as a reverse-path failure (ICMP rejects, forwarding-resolution misses).

## Design-fork evidence

The issue says: *"Prefer a warning over silently mutating a host-global sysctl UNLESS the daemon already owns host tunables."*

- **Rust helper owns NO host-global sysctls** — `grep -rn 'conf/all\|/all/' userspace-dp/src/` returns **nothing**; the helper only ever writes per-device knobs (`set_ipv4_sysctl(iface, ...)`).
- The Go daemon *does* write some host-global tunables (`enableForwarding`/`applyKernelTuning` set `conf/all/forwarding`, `conf/all/accept_local`, `conf/all/send_redirects`, …), but `conf/all/rp_filter` is a deliberate operator security posture and the TUN bringup itself lives in the helper. Mutating it host-global would be a surprising side effect on non-firewall paths.

→ Both sites take the **WARNING path**: do **not** touch `conf/all/rp_filter`; emit a loud, operator-visible, one-time bringup/reload warning instead. This is the issue's expected answer.

## Mechanism

- `userspace-dp/src/slowpath.rs`: `open_tun` reads `conf/all/rp_filter` once after writing the per-device `0` and `eprintln!("xpf-ha: …")` warns when non-zero. Split into seamed helpers `read_all_rp_filter(path)` + `rp_filter_all_warning(dev, value)` so it is unit-testable without touching live `/proc`. Missing/unparsable value → no spurious warning.
- `pkg/networkd/networkd.go`: `restoreSlowPathRPFilter` re-asserts the per-device `0` after `networkctl reload`, then `warnIfAllRPFilterOverrides` mirrors the same `conf/all` check via `slog.Warn`. `procSysNetRoot` is now a package var so tests point the tree at a temp fixture.
- `docs/userspace-dataplane-architecture.md`: documents the `max(all, dev)` kernel rule + warning behavior in the slow-path TUN section.

Both checks are **bringup/reload-only, never per-packet**.

## Validation

- **Rust**: `cargo build --release` clean (pre-existing warnings only). New `slowpath::tests` (`rp_filter_all_warning_fires_on_strict_and_loose`, `..._quiet_when_zero_or_unknown`, `read_all_rp_filter_parses_and_tolerates_missing`) pass **5x**. Fail-on-revert verified — neutering the non-zero guard (`Some(v) if v != 0` → `if false`) **fails** the strict/loose test.
- **Go**: `gofmt` clean; `go test ./pkg/networkd/` green; `go vet` clean. Fail-on-revert verified — forcing `warnIfAllRPFilterOverrides` to return early **fails** `TestWarnIfAllRPFilterOverrides_Nonzero`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi