### PR TITLE
userspace-dp: fail closed on a present-but-unopenable optional map (#2444)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12036,3 +12036,37 @@ top.
 - **File(s)**: userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs,
   userspace-dp/src/afxdp/coordinator/reconcile/mod.rs,
   userspace-dp/src/afxdp/coordinator/tests.rs, _Log.md
+
+## 2026-06-23 — #2444 optional conntrack/dnat map open fail-closed (review-033 033-23)
+- **Timestamp**: 2026-06-23 16:45
+- **Action**: Fixed #2444 (MEDIUM). In `preflight_map_fds` the 4 optional
+  map opens (conntrack_v4/v6, dnat_table/_v6) used
+  `OwnedFd::open_bpf_map(&pin).ok()`, which conflated "pin empty → feature
+  absent" with "pin present but open failed". A present-but-unopenable
+  configured map (permission / pin mismatch / corruption) was swallowed and
+  the helper ran degraded (lost session zone/iface visibility; broken
+  embedded-ICMP NAT reversal → PMTUD/traceroute breakage) with no readiness
+  signal. Replaced each `.ok()` with a new `open_optional_map` helper that
+  mirrors the #2440 mandatory-map pattern: empty pin → Ok(None) (silent, the
+  common anti-over-gate case); present + open Ok → Ok(Some(fd)); present +
+  open Err → set `last_reconcile_stage = "open_<map>_map_failed:<err>"` +
+  per-registered-binding `last_error`, return Err(()) so the caller aborts
+  the reconcile BEFORE teardown/publish (keeps prior generation + workers
+  live, the #2440 invariant). Updated the stale "non-fatal / normal
+  forwarding unaffected" comments and the doc-comment claim that optional
+  maps "never gate the reconcile".
+- **Tests**: added 4 fail-on-revert tests in coordinator/tests.rs using the
+  TEST_MAP_PIN_OK/FAIL sentinel seam: present-conntrack-fail and
+  present-dnat-fail (abort + prior generation preserved + stage +
+  last_error), empty-optional-pins (anti-over-gate: generation advances),
+  present-optional-open-OK (positive control). Proved fail-on-revert:
+  restoring `.ok()` for conntrack_v4 makes the present-fail test FAIL
+  (reconcile wrongly spawns workers=1, generation advances). Restored fix.
+- **Validation**: cargo build --release clean (pre-existing warnings only);
+  reconcile suite 18/18 across 5 runs.
+- **Doc**: docs/userspace-dataplane-architecture.md reconcile/preflight
+  section — documented mandatory vs optional, empty-vs-present fail-closed,
+  + the new test names.
+- **File(s)**: userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs,
+  userspace-dp/src/afxdp/coordinator/tests.rs,
+  docs/userspace-dataplane-architecture.md, _Log.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -178,20 +178,43 @@ mandatory BPF map FDs**:
   down the prior workers or publishing a newer generation. The previous
   (stale-but-correct) forwarding generation stays published and the
   prior workers keep running.
-- Only once all mandatory FDs are in hand does the orchestrator tear
-  down + rebuild + publish. The optional maps (conntrack v4/v6, dnat
-  tables) remain best-effort and never gate the reconcile.
+- The optional maps (conntrack v4/v6, dnat tables) are opened in the same
+  preflight with an **empty-vs-present** discipline (codex review-033
+  finding 033-23, #2444). The pin string IS the "feature configured"
+  signal:
+  - An **empty** pin means the feature is genuinely absent — the common
+    case, since many deploys carry no conntrack/dnat pins. It yields
+    `None` silently and never gates the reconcile (the anti-over-gate
+    case).
+  - A **present** pin that fails to open means the feature WAS configured
+    but its map is unopenable (permission / pin mismatch / corruption).
+    That is fatal: it aborts the reconcile via the same fail-closed path
+    as a mandatory map (`open_<map>_map_failed:<err>` stage +
+    per-binding `last_error`, return before teardown/publish). Running
+    degraded would otherwise silently lose session zone/interface
+    visibility (conntrack) or break embedded-ICMP NAT reversal —
+    PMTUD/traceroute breakage (dnat) — with no readiness signal.
+- Only once all mandatory FDs **and** every present-and-configured
+  optional FD are in hand does the orchestrator tear down + rebuild +
+  publish.
 
 This closes a fail-open partial-apply window (codex review-033 finding
 033-01): previously the FD open happened *after* teardown + publish, so
 a snapshot with an unopenable required pin tore down the workers,
 published a newer generation, then aborted bring-up — leaving the helper
 advertising a data-plane view backed by no running workers. On a
-security appliance that is fail-open. Regression coverage lives in
-`coordinator/tests.rs`
+security appliance that is fail-open. Finding 033-23 (#2444) extended the
+same fail-closed treatment to a present-but-unopenable optional map (the
+prior `.ok()` swallowed the error and ran degraded). Regression coverage
+lives in `coordinator/tests.rs`
 (`reconcile_mandatory_map_open_failure_keeps_prior_generation_published`,
 `reconcile_missing_session_pin_keeps_prior_generation_published`,
-`reconcile_all_mandatory_maps_open_advances_published_generation`) using
+`reconcile_all_mandatory_maps_open_advances_published_generation`;
+optional-map: `reconcile_present_conntrack_pin_open_failure_keeps_prior_generation`,
+`reconcile_present_dnat_pin_open_failure_keeps_prior_generation`,
+`reconcile_empty_optional_pins_advance_published_generation` — the
+anti-over-gate control —, and
+`reconcile_present_optional_pins_open_ok_advance_generation`) using
 the `bpf_map::pin` sentinel-path test seam (`TEST_MAP_PIN_OK` /
 `TEST_MAP_PIN_FAIL`) so the ordering is exercised without real bpffs
 pins.

--- a/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
@@ -37,8 +37,14 @@ use std::sync::Arc;
 /// and the orchestrator aborts WITHOUT teardown or publish — the prior
 /// generation stays published and the prior workers keep running.
 ///
-/// The optional maps (conntrack v4/v6, dnat tables) are best-effort:
-/// they never gate the reconcile, matching the historical behavior.
+/// The optional maps (conntrack v4/v6, dnat tables) are configured
+/// per-feature: an EMPTY pin means the feature is absent (silent `None`,
+/// the common case), but a PRESENT pin is the signal the feature IS
+/// configured, so a present pin that fails to open is fatal — it aborts
+/// the reconcile via the same fail-closed path as a mandatory map (#2444,
+/// codex review-033 033-23). This prevents the helper from running
+/// degraded (lost session zone/iface visibility; broken embedded-ICMP NAT
+/// reversal → PMTUD/traceroute breakage) with no readiness signal.
 pub(super) fn preflight_map_fds(
     coord: &mut Coordinator,
     snapshot: &ConfigSnapshot,
@@ -107,32 +113,57 @@ pub(super) fn preflight_map_fds(
             return None;
         }
     };
-    // Open BPF conntrack maps (sessions, sessions_v6) so the helper can
-    // publish session entries that "show security flow session" reads.
-    // Non-fatal: if the maps don't exist, session display will lack
-    // zone/interface info.
-    let conntrack_v4_fd = if !snapshot.map_pins.conntrack_v4.is_empty() {
-        OwnedFd::open_bpf_map(&snapshot.map_pins.conntrack_v4).ok()
-    } else {
-        None
+    // #2444: Open the optional BPF maps (conntrack v4/v6, dnat tables)
+    // with the same EMPTY-vs-PRESENT discipline as the mandatory maps.
+    // The pin string IS the "feature configured" signal:
+    //   - empty pin  -> feature absent -> None (the common case; many
+    //     deploys carry no conntrack/dnat pins). Returns None silently;
+    //     it never gates the reconcile.
+    //   - present pin + open Ok  -> Some(fd).
+    //   - present pin + open Err -> the feature WAS configured but its
+    //     map cannot be opened (permission / pin mismatch / corruption).
+    //     Running degraded would silently lose session zone/interface
+    //     visibility (conntrack) or break embedded-ICMP NAT reversal —
+    //     PMTUD / traceroute breakage (dnat) — with NO readiness signal.
+    //     So fail closed exactly like the mandatory maps: record a
+    //     descriptive stage + per-binding last_error and return None to
+    //     abort BEFORE teardown/publish (#2440 invariant: prior
+    //     generation + workers stay live).
+    let conntrack_v4_fd = match open_optional_map(
+        coord,
+        bindings,
+        &snapshot.map_pins.conntrack_v4,
+        "conntrack_v4",
+    ) {
+        Ok(fd) => fd,
+        Err(()) => return None,
     };
-    let conntrack_v6_fd = if !snapshot.map_pins.conntrack_v6.is_empty() {
-        OwnedFd::open_bpf_map(&snapshot.map_pins.conntrack_v6).ok()
-    } else {
-        None
+    let conntrack_v6_fd = match open_optional_map(
+        coord,
+        bindings,
+        &snapshot.map_pins.conntrack_v6,
+        "conntrack_v6",
+    ) {
+        Ok(fd) => fd,
+        Err(()) => return None,
     };
-    // Open dnat_table BPF map for embedded ICMP NAT reversal support.
-    // Non-fatal: if the map doesn't exist, embedded ICMP won't work
-    // but normal forwarding is unaffected.
-    let dnat_table_fd = if !snapshot.map_pins.dnat_table.is_empty() {
-        OwnedFd::open_bpf_map(&snapshot.map_pins.dnat_table).ok()
-    } else {
-        None
+    let dnat_table_fd = match open_optional_map(
+        coord,
+        bindings,
+        &snapshot.map_pins.dnat_table,
+        "dnat_table",
+    ) {
+        Ok(fd) => fd,
+        Err(()) => return None,
     };
-    let dnat_table_v6_fd = if !snapshot.map_pins.dnat_table_v6.is_empty() {
-        OwnedFd::open_bpf_map(&snapshot.map_pins.dnat_table_v6).ok()
-    } else {
-        None
+    let dnat_table_v6_fd = match open_optional_map(
+        coord,
+        bindings,
+        &snapshot.map_pins.dnat_table_v6,
+        "dnat_table_v6",
+    ) {
+        Ok(fd) => fd,
+        Err(()) => return None,
     };
     let dnat_fds = DnatTableFds {
         v4: dnat_table_fd.as_ref().map(|f| f.fd),
@@ -148,6 +179,41 @@ pub(super) fn preflight_map_fds(
         dnat_table_v6_fd,
         dnat_fds,
     })
+}
+
+/// #2444: open an OPTIONAL BPF map pin with empty-vs-present discipline.
+///
+/// - empty pin -> `Ok(None)` (feature genuinely absent; no gating). This
+///   is the anti-over-gate path: the overwhelmingly common deploy has no
+///   conntrack/dnat pins and must reconcile normally.
+/// - present pin + open Ok -> `Ok(Some(fd))`.
+/// - present pin + open Err -> the feature was configured but its map is
+///   unopenable. Set `coord.last_reconcile_stage =
+///   "open_{name}_map_failed:{err}"` + per-registered-binding
+///   `last_error`, then return `Err(())` so the caller aborts the
+///   reconcile BEFORE teardown/publish (fail closed, mirroring the
+///   mandatory maps in `preflight_map_fds`).
+fn open_optional_map(
+    coord: &mut Coordinator,
+    bindings: &mut [BindingStatus],
+    pin: &str,
+    name: &str,
+) -> Result<Option<OwnedFd>, ()> {
+    if pin.is_empty() {
+        return Ok(None);
+    }
+    match OwnedFd::open_bpf_map(pin) {
+        Ok(fd) => Ok(Some(fd)),
+        Err(err) => {
+            coord.last_reconcile_stage = format!("open_{name}_map_failed:{err}");
+            for binding in bindings.iter_mut() {
+                if binding.registered {
+                    binding.last_error = format!("open {name} map: {err}");
+                }
+            }
+            Err(())
+        }
+    }
 }
 
 pub(super) fn apply_snapshot(

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -3022,3 +3022,218 @@ fn reconcile_snapshot_integrity_error_sets_observable_stage() {
         "integrity reject must not publish the rejected generation"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #2444 — an OPTIONAL map (conntrack v4/v6, dnat tables) whose pin is
+// PRESENT but fails to open must fail closed exactly like a mandatory map:
+// abort the reconcile in the preflight BEFORE teardown/publish, keeping the
+// prior generation + workers live. An EMPTY pin (feature genuinely absent)
+// must still reconcile normally — the anti-over-gate control.
+// ---------------------------------------------------------------------------
+
+/// Build a snapshot whose three mandatory pins are sentinel-OK (so the
+/// mandatory preflight passes) and `generation` is the new generation the
+/// reconcile would publish if it ran to completion. Optional pins are left
+/// empty by the caller unless explicitly set.
+fn mandatory_ok_snapshot(generation: u64) -> ConfigSnapshot {
+    ConfigSnapshot {
+        generation,
+        map_pins: crate::protocol::snapshot::MapPins {
+            xsk: format!("{TEST_MAP_PIN_OK}xsk"),
+            heartbeat: format!("{TEST_MAP_PIN_OK}heartbeat"),
+            sessions: format!("{TEST_MAP_PIN_OK}sessions"),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// fail-on-revert: a PRESENT conntrack_v4 pin that fails to open must
+/// abort the reconcile in the preflight, leaving the prior published
+/// generation intact and recording an observable
+/// `open_conntrack_v4_map_failed:` stage.
+///
+/// Fail-on-revert proof: restoring the pre-#2444
+/// `open_bpf_map(...).ok()` swallows the open error -> the optional map
+/// silently becomes `None`, the reconcile proceeds, and `config_generation`
+/// wrongly advances to the new generation. Every assertion below that the
+/// prior generation survives then fails.
+#[test]
+fn reconcile_present_conntrack_pin_open_failure_keeps_prior_generation() {
+    let mut coordinator = Coordinator::new();
+    let prior = ValidationState {
+        snapshot_installed: true,
+        config_generation: 30,
+        fib_generation: 9,
+    };
+    coordinator.validation = prior;
+    coordinator.shared_validation.store(Arc::new(prior));
+
+    let mut bindings: Vec<BindingStatus> = vec![BindingStatus {
+        slot: 1,
+        interface: "ge-0-0-0".into(),
+        ifindex: 10,
+        registered: true,
+        ..BindingStatus::default()
+    }];
+
+    // Mandatory pins OK; conntrack_v4 pin PRESENT but forced to fail open.
+    let mut snap = mandatory_ok_snapshot(31);
+    snap.map_pins.conntrack_v4 = format!("{TEST_MAP_PIN_FAIL}conntrack_v4");
+
+    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+
+    assert!(
+        coordinator
+            .last_reconcile_stage
+            .starts_with("open_conntrack_v4_map_failed:"),
+        "expected abort at the conntrack_v4 open, got {:?}",
+        coordinator.last_reconcile_stage
+    );
+
+    // FAIL-ON-REVERT CORE: the prior generation is still published.
+    assert_eq!(
+        coordinator.validation.config_generation, 30,
+        "config_generation must NOT advance on a present-but-unopenable optional map"
+    );
+    assert_eq!(coordinator.validation.fib_generation, 9);
+    assert_eq!(
+        (**coordinator.shared_validation.load()).config_generation,
+        30,
+        "shared_validation must still hold the prior generation"
+    );
+    assert!(
+        bindings[0]
+            .last_error
+            .starts_with("open conntrack_v4 map:"),
+        "expected per-binding last_error for the conntrack_v4 open failure, got {:?}",
+        bindings[0].last_error
+    );
+    assert!(
+        coordinator.workers.live.is_empty(),
+        "no workers should be live after an aborted reconcile"
+    );
+}
+
+/// fail-on-revert: same fail-closed behavior for a PRESENT dnat_table pin
+/// that fails to open (embedded-ICMP NAT reversal feature configured but
+/// unopenable -> must block, not run degraded).
+#[test]
+fn reconcile_present_dnat_pin_open_failure_keeps_prior_generation() {
+    let mut coordinator = Coordinator::new();
+    let prior = ValidationState {
+        snapshot_installed: true,
+        config_generation: 40,
+        fib_generation: 12,
+    };
+    coordinator.validation = prior;
+    coordinator.shared_validation.store(Arc::new(prior));
+
+    let mut bindings: Vec<BindingStatus> = vec![BindingStatus {
+        slot: 1,
+        interface: "ge-0-0-0".into(),
+        ifindex: 10,
+        registered: true,
+        ..BindingStatus::default()
+    }];
+
+    // Mandatory + conntrack pins OK; dnat_table pin PRESENT but fails open.
+    let mut snap = mandatory_ok_snapshot(41);
+    snap.map_pins.dnat_table = format!("{TEST_MAP_PIN_FAIL}dnat_table");
+
+    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+
+    assert!(
+        coordinator
+            .last_reconcile_stage
+            .starts_with("open_dnat_table_map_failed:"),
+        "expected abort at the dnat_table open, got {:?}",
+        coordinator.last_reconcile_stage
+    );
+    assert_eq!(
+        coordinator.validation.config_generation, 40,
+        "config_generation must NOT advance on a present-but-unopenable dnat map"
+    );
+    assert_eq!(
+        (**coordinator.shared_validation.load()).config_generation,
+        40
+    );
+    assert!(
+        bindings[0].last_error.starts_with("open dnat_table map:"),
+        "expected per-binding last_error for the dnat_table open failure, got {:?}",
+        bindings[0].last_error
+    );
+}
+
+/// ANTI-OVER-GATE control: when the optional conntrack/dnat pins are EMPTY
+/// (feature genuinely absent — the common deploy), the reconcile must NOT
+/// be gated: the preflight returns `None` silently for each empty pin and
+/// the reconcile proceeds to publish the new generation. This guards
+/// against the fix being too aggressive (treating "feature absent" as a
+/// failure).
+#[test]
+fn reconcile_empty_optional_pins_advance_published_generation() {
+    let mut coordinator = Coordinator::new();
+    let prior = ValidationState {
+        snapshot_installed: true,
+        config_generation: 50,
+        fib_generation: 0,
+    };
+    coordinator.validation = prior;
+    coordinator.shared_validation.store(Arc::new(prior));
+
+    let mut bindings: Vec<BindingStatus> = Vec::new();
+
+    // Mandatory pins OK; ALL optional pins left empty (the default).
+    let snap = mandatory_ok_snapshot(51);
+    assert!(snap.map_pins.conntrack_v4.is_empty());
+    assert!(snap.map_pins.conntrack_v6.is_empty());
+    assert!(snap.map_pins.dnat_table.is_empty());
+    assert!(snap.map_pins.dnat_table_v6.is_empty());
+
+    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+
+    assert_eq!(
+        coordinator.validation.config_generation, 51,
+        "empty optional pins must NOT gate the reconcile (anti-over-gate)"
+    );
+    assert_eq!(
+        (**coordinator.shared_validation.load()).config_generation,
+        51
+    );
+}
+
+/// Positive control: PRESENT optional pins that OPEN OK must reconcile
+/// normally and advance the published generation (the fix accepts a
+/// healthy configured map).
+#[test]
+fn reconcile_present_optional_pins_open_ok_advance_generation() {
+    let mut coordinator = Coordinator::new();
+    let prior = ValidationState {
+        snapshot_installed: true,
+        config_generation: 60,
+        fib_generation: 0,
+    };
+    coordinator.validation = prior;
+    coordinator.shared_validation.store(Arc::new(prior));
+
+    let mut bindings: Vec<BindingStatus> = Vec::new();
+
+    // Mandatory + all optional pins sentinel-OK (present + openable).
+    let mut snap = mandatory_ok_snapshot(61);
+    snap.map_pins.conntrack_v4 = format!("{TEST_MAP_PIN_OK}conntrack_v4");
+    snap.map_pins.conntrack_v6 = format!("{TEST_MAP_PIN_OK}conntrack_v6");
+    snap.map_pins.dnat_table = format!("{TEST_MAP_PIN_OK}dnat_table");
+    snap.map_pins.dnat_table_v6 = format!("{TEST_MAP_PIN_OK}dnat_table_v6");
+
+    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+
+    assert_eq!(
+        coordinator.validation.config_generation, 61,
+        "present + openable optional maps must reconcile normally"
+    );
+    assert_eq!(
+        (**coordinator.shared_validation.load()).config_generation,
+        61
+    );
+}


### PR DESCRIPTION
Closes #2444

## Problem (codex review-033 finding 033-23, MEDIUM)

`preflight_map_fds` (`userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs`) opened the four **optional** maps — `conntrack_v4`, `conntrack_v6`, `dnat_table`, `dnat_table_v6` — with `OwnedFd::open_bpf_map(&pin).ok()`. That `.ok()` conflated two cases:

- **pin EMPTY** → feature not configured → `None` is correct.
- **pin PRESENT but open FAILS** (permission / pin mismatch / corruption) → the error was **swallowed** → the helper ran degraded (no session zone/iface visibility from conntrack; broken embedded-ICMP NAT reversal → PMTUD/traceroute breakage from dnat) with **no readiness signal**.

A non-empty pin IS the signal the feature is configured, so a configured map that cannot be opened must block the deploy, not run silently degraded.

## Fix

New `open_optional_map` helper mirrors the #2440 mandatory-map fail-closed pattern, distinguishing **empty** (None, fine) from **present-but-unopenable** (fail closed):

- empty pin → `Ok(None)` (feature absent — the common case; never gates the reconcile).
- present + open Ok → `Ok(Some(fd))`.
- present + open Err → set `last_reconcile_stage = "open_<map>_map_failed:<err>"` (distinct stage per map) + per-registered-binding `last_error`, return `Err(())` so the caller **aborts before teardown/publish** — keeping the prior generation + workers live (the #2440 invariant).

The now-wrong "non-fatal / normal forwarding unaffected" comments and the doc-comment claim that optional maps "never gate the reconcile" are corrected.

### Empty-vs-present distinction (the key design point)

Only an **empty** pin is non-fatal. The overwhelmingly common deploy carries no conntrack/dnat pins and must reconcile normally — so the fix is careful NOT to over-gate: a present pin that fails to open is fatal; an empty pin returns `None` silently.

## Tests (fail-on-revert, sentinel-pin seam)

In `coordinator/tests.rs` via `TEST_MAP_PIN_OK` / `TEST_MAP_PIN_FAIL` (no real bpffs pins):

- `reconcile_present_conntrack_pin_open_failure_keeps_prior_generation` — present conntrack pin fails → abort, prior generation preserved, stage `open_conntrack_v4_map_failed:`, per-binding `last_error`, no workers spawned.
- `reconcile_present_dnat_pin_open_failure_keeps_prior_generation` — same for a present dnat pin.
- `reconcile_empty_optional_pins_advance_published_generation` — **anti-over-gate control**: empty optional pins do NOT gate; new generation publishes.
- `reconcile_present_optional_pins_open_ok_advance_generation` — positive control: present + openable optional maps reconcile normally.

**Fail-on-revert proof:** restoring the pre-#2444 `.ok()` for `conntrack_v4` makes the present-conntrack-fail test FAIL (reconcile wrongly spawns `workers=1` and advances `config_generation`). Verified, then restored.

## Validation

- `cargo build --release` clean (pre-existing warnings only).
- reconcile test suite **18/18** across 5 consecutive runs.

## Docs

`docs/userspace-dataplane-architecture.md` reconcile/preflight section now states which maps are mandatory-fail-closed vs optional, that an optional map with a **present** pin is also fail-closed on open error (only an empty pin is non-fatal), and lists the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi