### PR TITLE
#2484: hoist snapshot-integrity validation before tear_down (completes #2440/#2444 trilogy)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12070,3 +12070,59 @@ top.
 - **File(s)**: userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs,
   userspace-dp/src/afxdp/coordinator/tests.rs,
   docs/userspace-dataplane-architecture.md, _Log.md
+
+## 2026-06-23 — #2484 snapshot-integrity preflight hoist (completes #2440/#2444 trilogy)
+
+- **Timestamp**: 2026-06-23
+- **Action**: Closed the last reconcile fail-open window — snapshot
+  INTEGRITY faults. #2440 hoisted mandatory map-FD opens before tear_down;
+  #2444 did the same for present-but-unopenable optional maps. #2484
+  remained: build_forwarding_state_with_policy_counters_and_previous can
+  return Err (Nat64UnparseableRule, NPTv6 / static-NAT integrity faults)
+  reachable only inside apply_snapshot — which ran AFTER tear_down stopped
+  the workers and stop_inner reset coord.validation / shared_validation, so
+  the helper was left torn down with no forwarding + no workers (it only
+  set last_reconcile_stage="snapshot_integrity_error" and returned None,
+  PR #2483). The top-of-reconcile policy preflight runs before teardown but
+  only parses policy/address-book state, missing the NAT64/NPTv6 integrity
+  set.
+- **Fix (build-once-reuse, mirrors #2440 hoist)**: added
+  snapshot::build_reconcile_forwarding(coord, snap) which runs the SAME
+  full build apply_snapshot used, in the pre-teardown preflight stage of
+  reconcile/mod.rs (right after preflight_map_fds). On Err it sets
+  last_reconcile_stage="snapshot_integrity_error" and returns Err(()) so
+  the orchestrator aborts BEFORE teardown/publish — prior generation +
+  workers stay live. On Ok the built ForwardingState is stashed on the new
+  ReconcileSnapshotFds::forwarding field; apply_snapshot REUSES it via
+  std::mem::take instead of rebuilding (no second build on the success
+  path, no double-insert of per-rule counter handles into the live
+  policy/nat counter stores). The build MUST precede teardown because it
+  reads Some(&coord.forwarding) as its "previous" arg, which stop_inner
+  defaults to empty. bringup destructure updated to ignore forwarding.
+  apply_snapshot's integrity Err arm is removed; its Option return is kept
+  for signature stability (always Some now, else arm defensively dead).
+- **Tests**: upgraded the #2483 test
+  reconcile_snapshot_integrity_error_sets_observable_stage ->
+  reconcile_snapshot_integrity_error_preserves_prior_generation_and_state.
+  Seeds a prior generation (config 20 / fib 7 / installed) AND a sentinel
+  live worker (workers.live[0]), feeds a NAT64 empty-prefix rule (sentinel-
+  OK map pins so the map-FD preflight passes), then asserts: prior
+  config/fib generation preserved, snapshot_installed still true,
+  shared_validation == prior, rejected generation 21 never published, AND
+  the seeded worker survives (workers.live.len()==1, contains slot 0).
+  Proved fail-on-revert: temporarily moved the integrity build back inside
+  apply_snapshot (post-teardown) + skipped the preflight build — the
+  generation-preservation assertion FAILED (stop_inner defaulted it to 0).
+  Restored the fix.
+- **Validation**: cargo build --release clean (pre-existing warnings only);
+  reconcile suite 18/18; coordinator suite 99/99 across 5 runs.
+- **Doc**: docs/userspace-dataplane-architecture.md — Reconcile Ordering
+  Invariant section retitled #2440/#2444/#2484, added the integrity-build
+  bullet (build-once-reuse + before-teardown rationale), the "all mandatory
+  validation before teardown/publish" completion note, and the new test in
+  the regression list.
+- **File(s)**: userspace-dp/src/afxdp/coordinator/reconcile/mod.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs,
+  userspace-dp/src/afxdp/coordinator/tests.rs,
+  docs/userspace-dataplane-architecture.md, _Log.md

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -158,7 +158,7 @@ Each worker thread is pinned to a CPU and processes all packets from
 its assigned RSS queues. Workers are independent — no locks on the
 forwarding hot path.
 
-#### Reconcile Ordering Invariant (#2440)
+#### Reconcile Ordering Invariant (#2440 / #2444 / #2484)
 
 `Coordinator::reconcile` (`coordinator/reconcile/mod.rs`) applies a new
 config snapshot in phases: preflight → teardown → reset → apply/publish
@@ -194,9 +194,30 @@ mandatory BPF map FDs**:
     degraded would otherwise silently lose session zone/interface
     visibility (conntrack) or break embedded-ICMP NAT reversal —
     PMTUD/traceroute breakage (dnat) — with no readiness signal.
-- Only once all mandatory FDs **and** every present-and-configured
-  optional FD are in hand does the orchestrator tear down + rebuild +
-  publish.
+- The **full forwarding-state build** runs in the same preflight, also
+  **before** `tear_down` (#2484). The top-of-reconcile policy preflight
+  only parses the policy/address-book state, so snapshot INTEGRITY faults
+  reachable only inside the full build — `Nat64UnparseableRule`, NPTv6 /
+  static-NAT integrity faults from
+  `build_forwarding_state_with_policy_counters_and_previous` — used to
+  surface *inside* `apply_snapshot`, after teardown had already stopped the
+  workers and reset `coord.validation` / `shared_validation`. They are now
+  detected by `snapshot::build_reconcile_forwarding` in the preflight: on
+  an integrity `Err` the reconcile sets
+  `last_reconcile_stage = "snapshot_integrity_error"` and aborts before
+  teardown/publish, so the prior generation + workers stay live. The built
+  state is stashed on `ReconcileSnapshotFds::forwarding` and **reused** by
+  `apply_snapshot` (build-once — no second build on the success path, and
+  no double-insert of per-rule counter handles into the live counter
+  stores). The build reads `Some(&coord.forwarding)` as its "previous"
+  arg, which `tear_down` defaults to empty — another reason it MUST run
+  before teardown.
+- Only once all mandatory FDs, every present-and-configured optional FD,
+  **and** the integrity-validated forwarding state are in hand does the
+  orchestrator tear down + rebuild + publish. This completes the
+  "all mandatory validation before teardown/publish" invariant across the
+  #2440 (map-FD) / #2444 (optional-map) / #2484 (snapshot-integrity)
+  trilogy.
 
 This closes a fail-open partial-apply window (codex review-033 finding
 033-01): previously the FD open happened *after* teardown + publish, so
@@ -205,8 +226,10 @@ published a newer generation, then aborted bring-up — leaving the helper
 advertising a data-plane view backed by no running workers. On a
 security appliance that is fail-open. Finding 033-23 (#2444) extended the
 same fail-closed treatment to a present-but-unopenable optional map (the
-prior `.ok()` swallowed the error and ran degraded). Regression coverage
-lives in `coordinator/tests.rs`
+prior `.ok()` swallowed the error and ran degraded). #2484 closed the last
+window — a snapshot-integrity fault detected only inside the full
+forwarding build, which previously surfaced *after* teardown. Regression
+coverage lives in `coordinator/tests.rs`
 (`reconcile_mandatory_map_open_failure_keeps_prior_generation_published`,
 `reconcile_missing_session_pin_keeps_prior_generation_published`,
 `reconcile_all_mandatory_maps_open_advances_published_generation`;
@@ -214,10 +237,16 @@ optional-map: `reconcile_present_conntrack_pin_open_failure_keeps_prior_generati
 `reconcile_present_dnat_pin_open_failure_keeps_prior_generation`,
 `reconcile_empty_optional_pins_advance_published_generation` — the
 anti-over-gate control —, and
-`reconcile_present_optional_pins_open_ok_advance_generation`) using
-the `bpf_map::pin` sentinel-path test seam (`TEST_MAP_PIN_OK` /
-`TEST_MAP_PIN_FAIL`) so the ordering is exercised without real bpffs
-pins.
+`reconcile_present_optional_pins_open_ok_advance_generation`;
+snapshot-integrity:
+`reconcile_snapshot_integrity_error_preserves_prior_generation_and_state`,
+which seeds a prior generation + a sentinel live worker, feeds a
+NAT64-unparseable rule, and asserts BOTH the prior generation and the
+prior worker survive — fail-on-revert: moving the integrity build back
+inside `apply_snapshot` post-teardown makes the preservation assertions
+fail) using the `bpf_map::pin` sentinel-path test seam
+(`TEST_MAP_PIN_OK` / `TEST_MAP_PIN_FAIL`) so the ordering is exercised
+without real bpffs pins.
 
 #### Per-Packet Processing Pipeline
 

--- a/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
@@ -35,6 +35,10 @@ pub(super) fn bring_up_workers(
         dnat_table_fd,
         dnat_table_v6_fd,
         dnat_fds,
+        // #2484: forwarding was consumed by apply_snapshot (built in the
+        // pre-teardown preflight, moved into coord.forwarding); bring-up
+        // reads coord.forwarding, not this field.
+        forwarding: _,
     } = fds;
     let ring_entries = ring_entries.max(64).min(u32::MAX as usize) as u32;
     let mut workers: BTreeMap<u32, Vec<BindingPlan>> = BTreeMap::new();

--- a/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
@@ -53,6 +53,15 @@ pub(in crate::afxdp) struct ReconcileSnapshotFds {
     pub(super) dnat_table_fd: Option<OwnedFd>,
     pub(super) dnat_table_v6_fd: Option<OwnedFd>,
     pub(super) dnat_fds: DnatTableFds,
+    /// #2484: the fully-built forwarding state, produced in the
+    /// pre-teardown preflight so a snapshot INTEGRITY fault aborts the
+    /// reconcile BEFORE `tear_down` stops the workers and resets
+    /// `coord.forwarding` / `coord.validation`. `apply_snapshot` REUSES
+    /// this rather than rebuilding — the build reads `Some(&coord.forwarding)`
+    /// as the "previous" arg, which teardown defaults to empty, so it MUST
+    /// happen before teardown. Building once also avoids re-inserting
+    /// per-rule counter handles into the live counter stores twice.
+    pub(super) forwarding: ForwardingState,
 }
 
 impl Coordinator {
@@ -122,14 +131,43 @@ impl Coordinator {
         // `last_reconcile_stage` / per-binding `last_error` on failure;
         // it mutates no published state, so returning here is safe.
         let preflight_fds = if let Some(snap) = snapshot {
-            match snapshot::preflight_map_fds(self, snap, bindings) {
-                Some(fds) => Some(fds),
+            let mut fds = match snapshot::preflight_map_fds(self, snap, bindings) {
+                Some(fds) => fds,
                 None => {
                     // last_reconcile_stage + per-binding last_error set
                     // inside preflight_map_fds. No teardown, no publish.
                     return;
                 }
+            };
+            // #2484 fail-open partial-apply fix (completes the #2440/#2444
+            // trilogy): build the full forwarding state HERE, BEFORE
+            // `tear_down`. The top-of-reconcile policy preflight above only
+            // parses policy/address-book state, so snapshot INTEGRITY faults
+            // reachable only inside the full build (e.g. Nat64UnparseableRule,
+            // NPTv6/static-NAT integrity faults) used to surface inside
+            // `apply_snapshot` — AFTER teardown stopped the workers and reset
+            // `coord.validation` / `shared_validation`, stranding the helper
+            // with no forwarding and no workers (residual fail-open). Building
+            // here aborts on such a fault with the prior generation + workers
+            // still live, mirroring the map-FD hoist #2440 added.
+            //
+            // This is the SAME call `apply_snapshot` made; the result is
+            // stashed on `fds.forwarding` and reused there (build-once), so we
+            // do NOT pay a second build on the success path nor re-insert
+            // per-rule counter handles into the live stores twice. The build
+            // reads `Some(&self.forwarding)` as its "previous" arg, which
+            // `tear_down` defaults to empty — another reason it MUST run
+            // before teardown.
+            match snapshot::build_reconcile_forwarding(self, snap) {
+                Ok(forwarding) => fds.forwarding = forwarding,
+                Err(()) => {
+                    // last_reconcile_stage = "snapshot_integrity_error" set
+                    // inside build_reconcile_forwarding. No teardown, no
+                    // publish: prior generation + workers stay live.
+                    return;
+                }
             }
+            Some(fds)
         } else {
             None
         };
@@ -145,6 +183,13 @@ impl Coordinator {
         // SAFETY: preflight_fds is Some whenever snapshot is Some (both
         // gated on the same `snapshot` Option above).
         let fds = preflight_fds.expect("preflight_map_fds ran for a Some snapshot");
+        // #2484: `apply_snapshot` no longer rebuilds the forwarding state
+        // or rejects on an integrity fault — that build (and its integrity
+        // check) was hoisted into the pre-teardown preflight above
+        // (`build_reconcile_forwarding`), so by the time we reach here the
+        // build has already succeeded and `apply_snapshot` reuses
+        // `fds.forwarding`. The `Option` return is retained for signature
+        // stability; the `else` arm is now defensively unreachable.
         let Some(fds) = snapshot::apply_snapshot(
             self,
             snapshot,
@@ -154,12 +199,6 @@ impl Coordinator {
             &mut preserved.synced_sessions,
             fds,
         ) else {
-            // last_reconcile_stage set inside apply_snapshot on the
-            // integrity-error leg ("snapshot_integrity_error"). That leg
-            // rejects the snapshot before any publish, so the prior
-            // forwarding generation stays published. It does NOT touch
-            // per-binding last_error — there is no per-binding signal
-            // for an address-book integrity fault.
             return;
         };
         bringup::bring_up_workers(

--- a/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
@@ -178,7 +178,53 @@ pub(super) fn preflight_map_fds(
         dnat_table_fd,
         dnat_table_v6_fd,
         dnat_fds,
+        // #2484: filled in by `build_reconcile_forwarding`, which the
+        // orchestrator runs right after this (still before teardown). A
+        // default placeholder until then; the orchestrator never reads it
+        // before assigning the real build result.
+        forwarding: ForwardingState::default(),
     })
+}
+
+/// #2484: build the full forwarding state for `snapshot` BEFORE the
+/// orchestrator tears down the running workers. This is the SAME call
+/// `apply_snapshot` previously made internally — hoisted ahead of
+/// `tear_down` so a snapshot INTEGRITY fault (Nat64UnparseableRule,
+/// NPTv6 / static-NAT / address-book integrity faults reachable only
+/// inside the full build, NOT caught by the top-of-reconcile policy
+/// preflight) aborts the reconcile while the prior generation + workers
+/// are still live, instead of surfacing post-teardown.
+///
+/// On success returns the built `ForwardingState` for the orchestrator to
+/// stash on `ReconcileSnapshotFds::forwarding` (build-once, reused by
+/// `apply_snapshot`). On an integrity error sets
+/// `coord.last_reconcile_stage = "snapshot_integrity_error"` (matching the
+/// descriptive-stage pattern) and returns `Err(())`; the orchestrator
+/// aborts WITHOUT teardown or publish.
+///
+/// MUST run before `tear_down`: it reads `Some(&coord.forwarding)` as the
+/// build's "previous" arg (WG engine reuse, NAT counter carry-over, cold-
+/// path slot map carry-over), which `stop_inner(false)` defaults to empty.
+pub(super) fn build_reconcile_forwarding(
+    coord: &mut Coordinator,
+    snapshot: &ConfigSnapshot,
+) -> Result<ForwardingState, ()> {
+    match build_forwarding_state_with_policy_counters_and_previous(
+        snapshot,
+        &coord.policy_counters,
+        &coord.nat_counters,
+        Some(&coord.forwarding),
+    ) {
+        Ok(fwd) => Ok(fwd),
+        Err(err) => {
+            coord.last_reconcile_stage = "snapshot_integrity_error".to_string();
+            eprintln!(
+                "xpf-userspace-dp: snapshot integrity error during reconcile preflight: {} — keeping previous forwarding state + workers",
+                err
+            );
+            Err(())
+        }
+    }
 }
 
 /// #2444: open an OPTIONAL BPF map pin with empty-vs-present discipline.
@@ -225,32 +271,22 @@ pub(super) fn apply_snapshot(
     preserved_synced_sessions: &mut Vec<SyncedSessionEntry>,
     fds: ReconcileSnapshotFds,
 ) -> Option<ReconcileSnapshotFds> {
-    // #1606: preflight policy build BEFORE any side-effecting
-    // mutation. Surfaces address-book integrity errors (id=0,
-    // duplicate ids, unknown rule references) before
-    // ValidationState, policy_counters, or coord.forwarding is
-    // mutated.
-    let new_forwarding = match build_forwarding_state_with_policy_counters_and_previous(
-        snapshot,
-        &coord.policy_counters,
-        &coord.nat_counters,
-        Some(&coord.forwarding),
-    ) {
-        Ok(fwd) => fwd,
-        Err(err) => {
-            // #2440 (Copilot follow-up): record the stage so the
-            // integrity failure is observable via status.rs
-            // (last_reconcile_stage), matching the descriptive-stage
-            // pattern the preflight_map_fds legs use. Without this the
-            // field retained a stale value from a prior reconcile.
-            coord.last_reconcile_stage = "snapshot_integrity_error".to_string();
-            eprintln!(
-                "xpf-userspace-dp: snapshot integrity error during reconcile: {} — keeping previous forwarding state",
-                err
-            );
-            return None;
-        }
-    };
+    // #2484: the forwarding state was already built in the pre-teardown
+    // preflight (`build_reconcile_forwarding`) and stashed on
+    // `fds.forwarding`. REUSE it here rather than rebuilding — build-once,
+    // and (critically) the integrity check that this build performs now
+    // happens BEFORE `tear_down`, so an integrity-faulted snapshot aborts
+    // the reconcile while the prior generation + workers are still live
+    // instead of stranding the helper post-teardown. By the time control
+    // reaches `apply_snapshot` the build has already succeeded; there is no
+    // longer an integrity Err arm here.
+    //
+    // The previous #1606 preflight policy-build (and the #2440 Copilot
+    // follow-up that stamped `last_reconcile_stage` on its Err arm) moved
+    // into `build_reconcile_forwarding` in the orchestrator's pre-teardown
+    // stage.
+    let mut fds = fds;
+    let new_forwarding = std::mem::take(&mut fds.forwarding);
 
     coord.validation = ValidationState {
         snapshot_installed: true,

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -2956,32 +2956,34 @@ fn reconcile_all_mandatory_maps_open_advances_published_generation() {
     assert_eq!((**coordinator.shared_validation.load()).config_generation, 2);
 }
 
-/// #2440 (Copilot follow-up): the snapshot-integrity rejection leg in
-/// `apply_snapshot` (`build_forwarding_state...` -> Err) must record
-/// `last_reconcile_stage = "snapshot_integrity_error"` so the failure is
-/// observable via status. Previously that leg only `eprintln!`d and
-/// returned None, leaving `last_reconcile_stage` at its prior value.
+/// #2484 (completes the #2440/#2444 fail-open trilogy): a snapshot
+/// INTEGRITY fault must abort the reconcile BEFORE `tear_down`, keeping
+/// the prior generation published AND the prior workers/state live — not
+/// merely record an observable stage post-teardown.
 ///
 /// Seam: a NAT64 rule with an empty prefix trips
 /// `Nat64State::try_from_snapshots` (Nat64UnparseableRule). That path is
-/// NOT checked by the top-of-reconcile policy preflight (which only
-/// parses the policy/address-book state), so it reaches the
-/// `apply_snapshot` integrity Err arm. Map pins are sentinel-OK so the
-/// map-FD preflight passes and the integrity check is what fires.
+/// NOT checked by the top-of-reconcile policy preflight (which only parses
+/// the policy/address-book state), so before #2484 it reached the
+/// `apply_snapshot` integrity Err arm — which ran AFTER `tear_down`
+/// (`stop_inner`) had already reset `coord.validation`,
+/// `shared_validation`, `snapshot_installed`, and stopped the workers.
+/// #2484 hoists the full forwarding build into the pre-teardown preflight
+/// (`build_reconcile_forwarding`), so the fault is now detected with the
+/// prior state still live. Map pins are sentinel-OK so the map-FD preflight
+/// passes and the integrity check is what fires.
 ///
-/// Scope note: unlike the address-book policy preflight (which runs
-/// before `tear_down`), this NAT64 integrity check fires INSIDE
-/// `apply_snapshot` — after `tear_down` (`stop_inner`) has already reset
-/// both `coord.validation` and `shared_validation` to default. That
-/// post-teardown integrity-reject ordering is pre-existing and is NOT
-/// what this fold changes, so this test asserts ONLY the observable
-/// stage (the fold's subject). It does not assert generation
-/// preservation for this leg.
-///
-/// Fail-on-revert: drop the `coord.last_reconcile_stage = ...` line in
-/// the Err arm and this asserts against the stale "start" value.
+/// Fail-on-revert: this is the KEY difference from the pre-#2484 test
+/// (which asserted only the stage + non-installation, because the check was
+/// post-teardown). With the fix reverted — integrity build back inside
+/// `apply_snapshot`, after `tear_down` — `stop_inner` resets
+/// `coord.validation` (config_generation -> 0, snapshot_installed -> false)
+/// and `shared_validation` to default, so EVERY preservation assertion
+/// below fails. The stage assertion alone is NOT revert-sensitive (both the
+/// old post-teardown leg and the new pre-teardown leg set it); the
+/// preservation assertions are.
 #[test]
-fn reconcile_snapshot_integrity_error_sets_observable_stage() {
+fn reconcile_snapshot_integrity_error_preserves_prior_generation_and_state() {
     let mut coordinator = Coordinator::new();
     let prior = ValidationState {
         snapshot_installed: true,
@@ -2990,6 +2992,15 @@ fn reconcile_snapshot_integrity_error_sets_observable_stage() {
     };
     coordinator.validation = prior;
     coordinator.shared_validation.store(Arc::new(prior));
+
+    // Seed a sentinel live worker. `tear_down` -> `stop_inner` ->
+    // `workers.stop_and_clear` would empty `workers.live`; if the integrity
+    // fault is (correctly) detected before teardown, this entry survives.
+    // This is the direct "prior workers are NOT torn down" proof.
+    coordinator
+        .workers
+        .live
+        .insert(0, std::sync::Arc::new(BindingLiveState::new()));
 
     let mut bindings: Vec<BindingStatus> = Vec::new();
 
@@ -3010,16 +3021,43 @@ fn reconcile_snapshot_integrity_error_sets_observable_stage() {
         "integrity-error leg must record an observable stage, got {:?}",
         coordinator.last_reconcile_stage
     );
-    // The integrity leg rejects the new snapshot before it can publish a
-    // newer generation: the new generation 21 is never installed.
-    assert_ne!(
-        coordinator.validation.config_generation, 21,
-        "integrity reject must not advance to the rejected generation"
+
+    // FAIL-ON-REVERT CORE: the prior generation is still the published one,
+    // proving the integrity fault aborted BEFORE `tear_down`. A pre-#2484
+    // post-teardown reject would have run `stop_inner`, defaulting these.
+    assert_eq!(
+        coordinator.validation.config_generation, 20,
+        "integrity reject must PRESERVE the prior generation (not tear down)"
     );
-    assert_ne!(
-        (**coordinator.shared_validation.load()).config_generation,
-        21,
-        "integrity reject must not publish the rejected generation"
+    assert_eq!(
+        coordinator.validation.fib_generation, 7,
+        "integrity reject must PRESERVE the prior fib generation"
+    );
+    assert!(
+        coordinator.validation.snapshot_installed,
+        "integrity reject must keep snapshot_installed (stop_inner would clear it)"
+    );
+    let shared = **coordinator.shared_validation.load();
+    assert_eq!(
+        shared, prior,
+        "shared_validation (worker-visible view) must still hold the prior published state"
+    );
+    // The rejected generation is never published anywhere.
+    assert_ne!(coordinator.validation.config_generation, 21);
+    assert_ne!(shared.config_generation, 21);
+
+    // FAIL-ON-REVERT (worker preservation): the seeded prior worker is
+    // still present — `tear_down`/`stop_inner`/`stop_and_clear` was never
+    // reached. A pre-#2484 post-teardown reject would have emptied
+    // `workers.live` before the integrity fault was detected.
+    assert_eq!(
+        coordinator.workers.live.len(),
+        1,
+        "integrity reject must PRESERVE the prior workers (not tear them down)"
+    );
+    assert!(
+        coordinator.workers.live.contains_key(&0),
+        "the seeded prior worker (slot 0) must survive an integrity-faulted reconcile"
     );
 }
 


### PR DESCRIPTION
Closes #2484

## Verify-first findings (on this worktree's master, base fbc7a3551)

Confirmed all three points from the issue against the current source
(line numbers shifted after #2440/#2444):

- **(a) Pre-teardown policy preflight exists** — `reconcile/mod.rs:100-116`
  runs `parse_policy_state_with_counters(...)` against a scratch
  `PolicyCounterStore` BEFORE `tear_down`, rejecting duplicate/zero/unknown
  book IDs without teardown.
- **(b) The full-build integrity Err was only reached post-teardown** —
  `apply_snapshot` (`snapshot.rs:233`) called
  `build_forwarding_state_with_policy_counters_and_previous(...)`, whose Err
  arm (`snapshot.rs:240-252`) set
  `last_reconcile_stage="snapshot_integrity_error"` and returned `None`. This
  ran AFTER `reconcile/mod.rs:136 tear_down` → `stop_inner(false)`, which
  resets `self.forwarding`, `self.validation`, `self.shared_validation`,
  `self.slow_path` and stops/clears workers
  (`coordinator/mod.rs:436-520`). So an integrity fault left the helper torn
  down with no forwarding + no workers.
- **(c) Which faults the top preflight misses** — the top preflight only
  parses policy/address-book state. The full build additionally fails CLOSED
  on `Nat64State::try_from_snapshots` (`Nat64UnparseableRule`, #2212) and
  `Nptv6State::try_from_snapshots` (#2240), plus static/source-NAT integrity
  — these are reachable ONLY inside the full build, so they slipped past the
  top preflight to the post-teardown leg. (The #2483 test uses a NAT64
  empty-prefix rule precisely because it bypasses the policy preflight.)

## The fix — build-once-reuse hoist (preferred shape, NOT validate-twice)

Mirrors the #2440 map-FD hoist. New `snapshot::build_reconcile_forwarding`
runs the SAME full build `apply_snapshot` made, in the pre-teardown preflight
stage of `reconcile/mod.rs` (right after `preflight_map_fds`):

- On `Err`: set `last_reconcile_stage="snapshot_integrity_error"`, abort
  BEFORE teardown/publish → prior generation + workers stay live.
- On `Ok`: stash the built `ForwardingState` on the new
  `ReconcileSnapshotFds::forwarding` field; `apply_snapshot` REUSES it via
  `std::mem::take` instead of rebuilding.

**No STOP-AND-ASK blocker hit.** The build is feasible before teardown and
reusable: it returns a fresh `ForwardingState` (does not mutate `coord`
directly); the only side effect is get-or-create insertion of per-rule
counter handles into `coord.policy_counters`/`nat_counters`, which is
identical to today's single-build behavior — just moved earlier — and is
then pruned by the existing `reconcile_rules`/`reconcile_ids` calls. Because
we build ONCE and reuse, there is no double-processing and **no double-build
perf regression**. The build MUST precede teardown because it reads
`Some(&coord.forwarding)` as its "previous" arg (WG engine reuse, NAT
counter carry-over, cold-path slot-map carry-over), which `stop_inner`
defaults to empty — so building-then-reusing is both correct and required.

`apply_snapshot`'s integrity Err arm is removed (build already succeeded by
the time it runs); its `Option` return is retained for signature stability
and the orchestrator's `else` arm is now defensively unreachable. `bringup`'s
struct destructure ignores the consumed `forwarding` field.

### Why this fully closes the window

Every form of mandatory validation — mandatory map FDs (#2440),
present-and-configured optional map FDs (#2444), and now the full
forwarding-state integrity build (#2484) — happens in the preflight BEFORE
`tear_down`/publish. There is no remaining path where an integrity-faulted
snapshot can reach `tear_down`.

## Preservation test (fail-on-revert)

Upgraded the #2483 test
`reconcile_snapshot_integrity_error_sets_observable_stage` →
`reconcile_snapshot_integrity_error_preserves_prior_generation_and_state`.
It seeds a prior published generation (config 20 / fib 7 / installed) AND a
sentinel live worker (`workers.live[0]`), feeds a NAT64 empty-prefix rule
(sentinel-OK map pins so the map-FD preflight passes), then asserts: prior
config/fib generation preserved, `snapshot_installed` still true,
`shared_validation == prior`, rejected generation 21 never published, AND the
seeded worker survives (`workers.live` still holds slot 0).

**Fail-on-revert proven:** temporarily moving the integrity build back inside
`apply_snapshot` (post-teardown) + skipping the preflight build makes
`stop_inner` default `coord.validation` → the generation-/worker-preservation
assertions FAIL (`assertion left == right failed: integrity reject must
PRESERVE the prior generation`). Restored the fix. This is the load-bearing
difference from #2483's test, which asserted only stage + non-installation
because the check was post-teardown (nothing to preserve).

## Validation

- `cargo build --release` clean (pre-existing unused-import warnings only).
- New preservation test: 5/5 passes.
- `reconcile` suite 18/18; `coordinator::` suite 99/99 across 5 runs.
- Build-once confirmed: no second `build_forwarding_state` call on the
  success path (apply_snapshot reuses the preflight result), so no
  double-build perf cost.

## Doc

`docs/userspace-dataplane-architecture.md` Reconcile Ordering Invariant
section retitled #2440/#2444/#2484, with the integrity-build bullet,
the completion note for the "all mandatory validation before
teardown/publish" invariant, and the new test in the regression list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
