### PR TITLE
userspace-dp: enforce tcp-mss all-tcp + gre-in; reject ipsec-vpn at commit (#2486)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12175,3 +12175,33 @@ top.
   userspace-dp/src/afxdp/frame/mod.rs,
   userspace-dp/src/afxdp/frame/tests.rs,
   userspace-dp/src/afxdp/coordinator/README.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2486 — enforce TCP MSS clamp for all-tcp + gre-in
+  contexts; reject ipsec-vpn at commit. Previously only tunnel egress
+  (gre-out / WG) clamped — all-tcp / ipsec-vpn / gre-in were accepted +
+  carried on the wire but never enforced (gre-in = silent full-MSS
+  blackhole on the GRE return path). Added per-packet MSS context
+  selection (`select_tcp_mss`) at frame build: all-tcp (plain forward,
+  v4+v6, universal fallback), gre-in (gated on a new
+  `GRE_DECAP_INGRESS_FLAG` 0x40 marker set by the GRE decap stage),
+  gre-out/WG unchanged. ipsec-vpn rejected at commit (no IPsec context
+  in the userspace forward path; kernel XFRM). all-tcp now lands in its
+  own `TCPMSSAllTCP` field (was silently fanned into gre-out only) and is
+  wired onto the existing `tcp_mss_all_tcp` wire field. Fail-on-revert
+  tests on both planes (all-tcp v4/v6 clamp/no-clamp/non-SYN/unset;
+  gre-in clamp + marker-required + decap-sets-marker; ipsec-vpn
+  commit-reject + all-tcp field mapping).
+- **File(s)**: userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/mod.rs, userspace-dp/src/afxdp/gre.rs,
+  userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/frame/build/mod.rs,
+  userspace-dp/src/afxdp/frame/tests.rs,
+  userspace-dp/src/afxdp/tests.rs, pkg/config/types_security.go,
+  pkg/config/compiler_security.go, pkg/dataplane/userspace/flow.go,
+  pkg/cli/cli_show_flow.go, pkg/grpcapi/server_show_flow.go,
+  pkg/api/show_text.go, pkg/config/compiler_tcp_mss_range_test.go,
+  pkg/config/parser_security_test.go, pkg/config/parser_ast_test.go,
+  pkg/config/dual_ast_differential_test.go,
+  pkg/dataplane/userspace/flow_wire_coerce_test.go,
+  test/incus/xpf-test.conf, docs/feature-gaps.md, _Log.md

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -219,7 +219,35 @@ xpf implements 11 screen checks (land, syn-flood, ping-death, teardrop, rate-lim
 
 ## 10. Security Flow Enhancements
 
-xpf has TCP session timeouts (established, initial, closing, time-wait), UDP/ICMP timeouts, TCP MSS clamping (IPsec, GRE in/out), allow-dns-reply, allow-embedded-icmp, GRE performance acceleration, and flow traceoptions (packet-filter source-prefix / destination-prefix / `protocol` — M8/#2008).
+xpf has TCP session timeouts (established, initial, closing, time-wait), UDP/ICMP timeouts, TCP MSS clamping, allow-dns-reply, allow-embedded-icmp, GRE performance acceleration, and flow traceoptions (packet-filter source-prefix / destination-prefix / `protocol` — M8/#2008).
+
+**TCP MSS clamping contexts (#2486).** The userspace AF_XDP forwarding
+path enforces three of the four Junos `security flow tcp-mss` contexts,
+selected per-packet at frame build (`select_tcp_mss`,
+`userspace-dp/src/afxdp/forwarding/mod.rs`):
+
+- `all-tcp` — clamps every forwarded TCP SYN (IPv4 and IPv6); also the
+  universal fallback for the contexts below.
+- `gre-in` — clamps an inbound GRE-decapped SYN. The decap stage marks
+  the inner packet with `GRE_DECAP_INGRESS_FLAG` in `meta_flags` so the
+  builder can select this value (fixes the prior silent full-MSS
+  blackhole on the GRE return path).
+- `gre-out` — clamps a SYN egressing into a native GRE tunnel
+  (gre-out value, or the MTU-derived formula; WireGuard uses the
+  overhead-aware value, #2299).
+- `ipsec-vpn` — **rejected at commit** (`validateTCPMSSRanges`,
+  pkg/config/compiler_security.go). IPsec is processed by the
+  kernel XFRM stack; the decrypted inner packets re-enter the userspace
+  path as plain traffic with no IPsec marker, so no IPsec context reaches
+  the MSS clamp. Carrying it as accepted-but-dead config was worse than
+  rejecting it; operators should use `all-tcp` to clamp all forwarded
+  TCP. Lenient (boot/peer-sync) load warn-loads a legacy `ipsec-vpn`
+  value but does NOT enforce it.
+
+Before #2486 only the tunnel-egress (`gre-out` / WG) context was
+enforced; `all-tcp` and `gre-in` were accepted on the wire but never
+applied (`all-tcp` silently fanned into gre-out only), and `ipsec-vpn`
+was dead config.
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|

--- a/pkg/api/show_text.go
+++ b/pkg/api/show_text.go
@@ -238,8 +238,12 @@ func (s *Server) showTextHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			fmt.Fprintf(&buf, "  UDP session:          %ds\n", flow.UDPSessionTimeout)
 			fmt.Fprintf(&buf, "  ICMP session:         %ds\n", flow.ICMPSessionTimeout)
+			if flow.TCPMSSAllTCP > 0 {
+				fmt.Fprintf(&buf, "  TCP MSS (all-tcp):    %d\n", flow.TCPMSSAllTCP)
+			}
 			if flow.TCPMSSIPsecVPN > 0 {
-				fmt.Fprintf(&buf, "  TCP MSS (IPsec VPN):  %d\n", flow.TCPMSSIPsecVPN)
+				// #2486: ipsec-vpn rejected at commit; not enforced.
+				fmt.Fprintf(&buf, "  TCP MSS (IPsec VPN):  %d (not enforced)\n", flow.TCPMSSIPsecVPN)
 			}
 			if flow.TCPMSSGreIn > 0 {
 				fmt.Fprintf(&buf, "  TCP MSS (GRE in):     %d\n", flow.TCPMSSGreIn)

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -879,11 +879,14 @@ func (c *CLI) showFlowTimeouts() error {
 	}
 
 	// TCP MSS clamping
-	if flow.TCPMSSIPsecVPN > 0 || flow.TCPMSSGreIn > 0 || flow.TCPMSSGreOut > 0 {
+	if flow.TCPMSSAllTCP > 0 || flow.TCPMSSIPsecVPN > 0 || flow.TCPMSSGreIn > 0 || flow.TCPMSSGreOut > 0 {
 		fmt.Println()
 		fmt.Println("TCP MSS clamping:")
+		if flow.TCPMSSAllTCP > 0 {
+			fmt.Printf("  %-30s %d\n", "All TCP MSS:", flow.TCPMSSAllTCP)
+		}
 		if flow.TCPMSSIPsecVPN > 0 {
-			fmt.Printf("  %-30s %d\n", "IPsec VPN MSS:", flow.TCPMSSIPsecVPN)
+			fmt.Printf("  %-30s %d\n", "IPsec VPN MSS (not enforced):", flow.TCPMSSIPsecVPN)
 		}
 		if flow.TCPMSSGreIn > 0 {
 			fmt.Printf("  %-30s %d\n", "GRE ingress MSS:", flow.TCPMSSGreIn)

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -774,7 +774,35 @@ func validateTCPMSSRanges(nodes []*Node, prefix string, lenient bool) ([]string,
 					mssPath := joinNodePath(flowPath, []string{"tcp-mss"})
 					for _, kind := range tcpMSSKinds {
 						for _, kn := range mss.FindChildren(kind) {
-							w, err := checkTCPMSSKind(kn, joinNodePath(mssPath, []string{kind}), lenient)
+							kindPath := joinNodePath(mssPath, []string{kind})
+							// #2486: `tcp-mss ipsec-vpn` is rejected at
+							// commit. There is no IPsec context in the
+							// userspace forward-build path — ESP/AH/IKE is
+							// local-delivered to the kernel XFRM stack and the
+							// decrypted inner packets re-enter as plain
+							// traffic with no IPsec marker — so the clamp can
+							// never be enforced. Carrying it silently as dead
+							// config (the prior behavior) is worse than
+							// rejecting it. Strict (commit/commit-check) is a
+							// hard error; lenient (load/peer-sync) downgrades
+							// to a warning so a legacy persisted/peer config
+							// still boots.
+							if kind == "ipsec-vpn" {
+								if _, ok := selectMSSToken(kn); ok {
+									msg := fmt.Sprintf("%s: tcp-mss ipsec-vpn is not "+
+										"supported in the userspace forwarding path "+
+										"(IPsec is processed by the kernel XFRM stack, "+
+										"so no IPsec context reaches the MSS clamp); "+
+										"use 'all-tcp' to clamp all forwarded TCP", kindPath)
+									if !lenient {
+										return nil, fmt.Errorf("%s", msg)
+									}
+									warnings = append(warnings, msg+
+										" (ignored: clamp not enforced)")
+								}
+								continue
+							}
+							w, err := checkTCPMSSKind(kn, kindPath, lenient)
 							warnings = append(warnings, w...)
 							if err != nil {
 								return nil, err
@@ -912,6 +940,11 @@ func compileFlow(node *Node, sec *SecurityConfig) error {
 		for _, opt := range mssNode.Children {
 			switch opt.Name() {
 			case "ipsec-vpn":
+				// #2486: rejected at commit by validateTCPMSSRanges (no
+				// IPsec context in the userspace forward path). In lenient
+				// load/peer-sync contexts the value is intentionally NOT
+				// assigned — it cannot be enforced, so it stays unset rather
+				// than becoming dead config.
 				if v := parseMSSValue(opt); v > 0 {
 					sec.Flow.TCPMSSIPsecVPN = v
 				}
@@ -924,10 +957,14 @@ func compileFlow(node *Node, sec *SecurityConfig) error {
 					sec.Flow.TCPMSSGreOut = v
 				}
 			case "all-tcp":
+				// #2486: all-tcp is the context-agnostic clamp — it lands in
+				// its own wire field (tcp_mss_all_tcp) and the dataplane
+				// applies it to every forwarded TCP SYN (plain + the fallback
+				// for gre-in / tunnel egress). Previously it fanned out into
+				// IPsecVPN/GreIn/GreOut, but only gre-out was ever enforced,
+				// so all-tcp silently behaved as gre-out-only.
 				if v := parseMSSValue(opt); v > 0 {
-					sec.Flow.TCPMSSIPsecVPN = v
-					sec.Flow.TCPMSSGreIn = v
-					sec.Flow.TCPMSSGreOut = v
+					sec.Flow.TCPMSSAllTCP = v
 				}
 			}
 		}

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -940,11 +940,13 @@ func compileFlow(node *Node, sec *SecurityConfig) error {
 		for _, opt := range mssNode.Children {
 			switch opt.Name() {
 			case "ipsec-vpn":
-				// #2486: rejected at commit by validateTCPMSSRanges (no
-				// IPsec context in the userspace forward path). In lenient
-				// load/peer-sync contexts the value is intentionally NOT
-				// assigned — it cannot be enforced, so it stays unset rather
-				// than becoming dead config.
+				// #2486: strict commit rejects this via
+				// validateTCPMSSRanges (no IPsec context in the userspace
+				// forward path). In lenient load/peer-sync contexts the
+				// value IS retained on the typed config below, so `show`
+				// output and config round-trip preserve it — but it is
+				// NEVER serialized to the dataplane wire (flow.go drops it)
+				// and NEVER enforced (no dataplane consumer reads it).
 				if v := parseMSSValue(opt); v > 0 {
 					sec.Flow.TCPMSSIPsecVPN = v
 				}

--- a/pkg/config/compiler_tcp_mss_range_test.go
+++ b/pkg/config/compiler_tcp_mss_range_test.go
@@ -64,8 +64,10 @@ func mssRejectStrict(t *testing.T, tree *config.ConfigTree) {
 // --- Flat shape (the issue headline: `tcp-mss gre-in 70000` typo) ---
 
 func TestTCPMSSRange_FlatShape(t *testing.T) {
-	// Valid flat values accepted.
-	for _, kind := range []string{"ipsec-vpn", "gre-in", "gre-out", "all-tcp"} {
+	// Valid flat values accepted. #2486: ipsec-vpn is excluded — it is
+	// rejected at commit regardless of the value (see
+	// TestTCPMSSIPsecVPNRejectedAtCommit).
+	for _, kind := range []string{"gre-in", "gre-out", "all-tcp"} {
 		mssAcceptStrict(t, mssFlatTree(t, "set security flow tcp-mss "+kind+" 1400"))
 	}
 	// all-tcp 1396 (docs/ha-cluster.conf value) accepted.
@@ -74,9 +76,73 @@ func TestTCPMSSRange_FlatShape(t *testing.T) {
 	mssAcceptStrict(t, mssFlatTree(t, "set security flow tcp-mss gre-in 65535"))
 	mssRejectStrict(t, mssFlatTree(t, "set security flow tcp-mss gre-in 65536"))
 
-	// The headline typo: every kind out-of-range flat is rejected.
-	for _, kind := range []string{"ipsec-vpn", "gre-in", "gre-out", "all-tcp"} {
+	// The headline typo: every enforceable kind out-of-range flat is
+	// rejected. (ipsec-vpn rejects on ANY value, not just out-of-range.)
+	for _, kind := range []string{"gre-in", "gre-out", "all-tcp"} {
 		mssRejectStrict(t, mssFlatTree(t, "set security flow tcp-mss "+kind+" 70000"))
+	}
+}
+
+// #2486: `security flow tcp-mss ipsec-vpn` is rejected at commit. There
+// is no IPsec context in the userspace forward-build path (ESP/AH/IKE is
+// local-delivered to the kernel XFRM stack; the decrypted inner packets
+// re-enter as plain traffic with no IPsec marker), so the clamp can never
+// be enforced. Strict (commit) is a hard error even for an in-range
+// value; lenient (boot/HA load) warn-loads so a legacy persisted/peer
+// config still boots.
+func TestTCPMSSIPsecVPNRejectedAtCommit(t *testing.T) {
+	// Flat, in-range value -> strict REJECT (this is the new behavior;
+	// previously this was accepted and carried as dead config).
+	flat := mssFlatTree(t, "set security flow tcp-mss ipsec-vpn 1400")
+	_, err := config.CompileConfig(flat)
+	if err == nil {
+		t.Fatal("strict commit must REJECT tcp-mss ipsec-vpn")
+	}
+	if !strings.Contains(err.Error(), "ipsec-vpn") || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("reject error should explain ipsec-vpn is unsupported: %v", err)
+	}
+
+	// Hierarchical form rejects identically.
+	hier := mssHierTree(t, `security {
+    flow { tcp-mss { ipsec-vpn { mss 1360; } } }
+}`)
+	if _, err := config.CompileConfig(hier); err == nil {
+		t.Fatal("strict commit must REJECT hierarchical tcp-mss ipsec-vpn")
+	}
+
+	// Lenient (boot/HA) path warn-loads rather than hard-failing.
+	cfg, err := config.CompileConfigLenient(flat)
+	if err != nil {
+		t.Fatalf("lenient load of a legacy ipsec-vpn config must not hard-fail: %v", err)
+	}
+	foundWarn := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "ipsec-vpn") {
+			foundWarn = true
+			break
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("lenient load should warn about the ignored ipsec-vpn clamp, got: %v", cfg.Warnings)
+	}
+}
+
+// #2486: all-tcp now lands in its own TCPMSSAllTCP field and is NOT
+// fanned into IPsecVPN/GreIn/GreOut. Pins the field mapping so a revert
+// (back to the fan-out) fails.
+func TestTCPMSSAllTCPMapsToOwnField(t *testing.T) {
+	cfg, err := config.CompileConfig(mssFlatTree(t, "set security flow tcp-mss all-tcp 1400"))
+	if err != nil {
+		t.Fatalf("all-tcp 1400 must compile: %v", err)
+	}
+	if cfg.Security.Flow.TCPMSSAllTCP != 1400 {
+		t.Fatalf("all-tcp must map to TCPMSSAllTCP, got %d", cfg.Security.Flow.TCPMSSAllTCP)
+	}
+	if cfg.Security.Flow.TCPMSSGreIn != 0 || cfg.Security.Flow.TCPMSSGreOut != 0 ||
+		cfg.Security.Flow.TCPMSSIPsecVPN != 0 {
+		t.Fatalf("all-tcp must NOT fan into gre-in/gre-out/ipsec-vpn (got in=%d out=%d ipsec=%d)",
+			cfg.Security.Flow.TCPMSSGreIn, cfg.Security.Flow.TCPMSSGreOut,
+			cfg.Security.Flow.TCPMSSIPsecVPN)
 	}
 }
 
@@ -84,9 +150,10 @@ func TestTCPMSSRange_FlatShape(t *testing.T) {
 
 func TestTCPMSSRange_HierarchicalShape(t *testing.T) {
 	// Valid hierarchical accepted (matches TestTCPMSSHierarchical).
+	// #2486: ipsec-vpn dropped from the accepted set — it is rejected at
+	// commit (TestTCPMSSIPsecVPNRejectedAtCommit covers it).
 	mssAcceptStrict(t, mssHierTree(t, `security {
     flow { tcp-mss {
-        ipsec-vpn { mss 1360; }
         gre-in { mss 1360; }
         gre-out { mss 1360; }
     } }

--- a/pkg/config/dual_ast_differential_test.go
+++ b/pkg/config/dual_ast_differential_test.go
@@ -406,7 +406,7 @@ var dualASTCases = []dualASTCase{
 		hier: `security {
     flow {
         tcp-mss {
-            ipsec-vpn 1350;
+            all-tcp 1350;
             gre-in 1400;
             gre-out 1380;
         }

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -1829,11 +1829,13 @@ security {
 }
 
 func TestTCPMSSHierarchical(t *testing.T) {
+	// #2486: ipsec-vpn dropped (rejected at commit); all-tcp added to
+	// exercise the hierarchical shape of the dedicated TCPMSSAllTCP field.
 	input := `
 security {
     flow {
         tcp-mss {
-            ipsec-vpn {
+            all-tcp {
                 mss 1360;
             }
             gre-in {
@@ -1855,8 +1857,8 @@ security {
 	if err != nil {
 		t.Fatalf("CompileConfig: %v", err)
 	}
-	if cfg.Security.Flow.TCPMSSIPsecVPN != 1360 {
-		t.Errorf("TCPMSSIPsecVPN = %d, want 1360", cfg.Security.Flow.TCPMSSIPsecVPN)
+	if cfg.Security.Flow.TCPMSSAllTCP != 1360 {
+		t.Errorf("TCPMSSAllTCP = %d, want 1360", cfg.Security.Flow.TCPMSSAllTCP)
 	}
 	if cfg.Security.Flow.TCPMSSGreIn != 1360 {
 		t.Errorf("TCPMSSGreIn = %d, want 1360", cfg.Security.Flow.TCPMSSGreIn)

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1166,10 +1166,13 @@ func TestIPFIXExportExtensionsWarnUnsupportedAppID(t *testing.T) {
 }
 
 func TestALGAndFlowOptions(t *testing.T) {
+	// #2486: ipsec-vpn dropped — it is now rejected at commit (covered by
+	// TestTCPMSSIPsecVPNRejectedAtCommit). all-tcp added to exercise the
+	// dedicated TCPMSSAllTCP field.
 	input := `security {
     flow {
         tcp-mss {
-            ipsec-vpn 1350;
+            all-tcp 1360;
             gre-in 1400;
             gre-out 1380;
         }
@@ -1191,8 +1194,8 @@ func TestALGAndFlowOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}
-	if cfg.Security.Flow.TCPMSSIPsecVPN != 1350 {
-		t.Errorf("tcp-mss ipsec-vpn: got %d, want 1350", cfg.Security.Flow.TCPMSSIPsecVPN)
+	if cfg.Security.Flow.TCPMSSAllTCP != 1360 {
+		t.Errorf("tcp-mss all-tcp: got %d, want 1360", cfg.Security.Flow.TCPMSSAllTCP)
 	}
 	if cfg.Security.Flow.TCPMSSGreIn != 1400 {
 		t.Errorf("tcp-mss gre-in: got %d, want 1400", cfg.Security.Flow.TCPMSSGreIn)
@@ -1213,7 +1216,7 @@ func TestALGAndFlowOptions(t *testing.T) {
 		t.Error("expected ALG FTP disable")
 	}
 	tree2 := &ConfigTree{}
-	setCommands := []string{"set security flow tcp-mss ipsec-vpn 1350", "set security flow tcp-mss gre-in 1400", "set security flow tcp-mss gre-out 1380", "set security flow allow-dns-reply", "set security flow allow-embedded-icmp", "set security alg dns disable", "set security alg ftp disable"}
+	setCommands := []string{"set security flow tcp-mss all-tcp 1360", "set security flow tcp-mss gre-in 1400", "set security flow tcp-mss gre-out 1380", "set security flow allow-dns-reply", "set security flow allow-embedded-icmp", "set security alg dns disable", "set security alg ftp disable"}
 	for _, cmd := range setCommands {
 		path, err := ParseSetCommand(cmd)
 		if err != nil {
@@ -1227,8 +1230,8 @@ func TestALGAndFlowOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("set-command compile error: %v", err)
 	}
-	if cfg2.Security.Flow.TCPMSSIPsecVPN != 1350 {
-		t.Errorf("set syntax: tcp-mss ipsec-vpn: got %d, want 1350", cfg2.Security.Flow.TCPMSSIPsecVPN)
+	if cfg2.Security.Flow.TCPMSSAllTCP != 1360 {
+		t.Errorf("set syntax: tcp-mss all-tcp: got %d, want 1360", cfg2.Security.Flow.TCPMSSAllTCP)
 	}
 	if cfg2.Security.Flow.TCPMSSGreIn != 1400 {
 		t.Errorf("set syntax: tcp-mss gre-in: got %d, want 1400", cfg2.Security.Flow.TCPMSSGreIn)

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -67,7 +67,8 @@ type FlowConfig struct {
 	TCPSession                 *TCPSessionConfig
 	UDPSessionTimeout          int // seconds, 0 = default (60s)
 	ICMPSessionTimeout         int // seconds, 0 = default (60s — DEFAULT_ICMP_SESSION_TIMEOUT_NS, userspace-dp/src/session/mod.rs)
-	TCPMSSIPsecVPN             int // TCP MSS clamp for IPsec VPN traffic (0 = disabled)
+	TCPMSSAllTCP               int // TCP MSS clamp for all forwarded TCP (0 = disabled) (#2486)
+	TCPMSSIPsecVPN             int // TCP MSS clamp for IPsec VPN traffic (0 = disabled) — rejected at commit (#2486: no IPsec context in the userspace forward path)
 	TCPMSSGreIn                int // TCP MSS clamp for GRE ingress traffic (0 = disabled)
 	TCPMSSGreOut               int // TCP MSS clamp for GRE egress traffic (0 = disabled)
 	AllowDNSReply              bool

--- a/pkg/dataplane/userspace/flow.go
+++ b/pkg/dataplane/userspace/flow.go
@@ -73,9 +73,13 @@ func coerceWireSessionTimeout(field string, v int) int {
 
 func buildFlowSnapshot(cfg *config.Config) FlowSnapshot {
 	snap := FlowSnapshot{
-		AllowDNSReply:      cfg.Security.Flow.AllowDNSReply,
-		AllowEmbeddedICMP:  cfg.Security.Flow.AllowEmbeddedICMP,
-		TCPMSSIPsecVPN:     coerceWireU16("tcp_mss_ipsec_vpn", cfg.Security.Flow.TCPMSSIPsecVPN),
+		AllowDNSReply:     cfg.Security.Flow.AllowDNSReply,
+		AllowEmbeddedICMP: cfg.Security.Flow.AllowEmbeddedICMP,
+		// #2486: all-tcp now lands in its own wire field; the dataplane
+		// applies it to plain forwarded SYNs (and as the gre-in / tunnel
+		// fallback). ipsec-vpn is rejected at commit, so it is NOT sent
+		// to the dataplane (it has no enforceable context there).
+		TCPMSSAllTCP:       coerceWireU16("tcp_mss_all_tcp", cfg.Security.Flow.TCPMSSAllTCP),
 		TCPMSSGreIn:        coerceWireU16("tcp_mss_gre_in", cfg.Security.Flow.TCPMSSGreIn),
 		TCPMSSGreOut:       coerceWireU16("tcp_mss_gre_out", cfg.Security.Flow.TCPMSSGreOut),
 		UDPSessionTimeout:  coerceWireSessionTimeout("udp_session_timeout", cfg.Security.Flow.UDPSessionTimeout),
@@ -85,10 +89,6 @@ func buildFlowSnapshot(cfg *config.Config) FlowSnapshot {
 		Lo0FilterInputV4:   cfg.System.Lo0FilterInputV4,
 		Lo0FilterInputV6:   cfg.System.Lo0FilterInputV6,
 	}
-	// TCPMSSAllTCP is in the wire contract (Rust u16) but is not populated by
-	// this builder today; coerce defensively so it stays safe if it is ever
-	// wired from config (#1977, Codex r2). No-op while it remains zero.
-	snap.TCPMSSAllTCP = coerceWireU16("tcp_mss_all_tcp", snap.TCPMSSAllTCP)
 	if cfg.Security.Flow.TCPSession != nil {
 		snap.TCPSessionTimeout = coerceWireSessionTimeout(
 			"tcp_session_timeout", cfg.Security.Flow.TCPSession.EstablishedTimeout)

--- a/pkg/dataplane/userspace/flow_wire_coerce_test.go
+++ b/pkg/dataplane/userspace/flow_wire_coerce_test.go
@@ -23,7 +23,9 @@ func assertInRange(t *testing.T, name string, v int, max int64) {
 
 func TestBuildFlowSnapshotCoercesOutOfRange_1977(t *testing.T) {
 	cfg := &config.Config{}
-	cfg.Security.Flow.TCPMSSIPsecVPN = 70000             // > u16 max
+	// #2486: TCPMSSAllTCP replaces TCPMSSIPsecVPN on the wire (ipsec-vpn is
+	// rejected at commit and never serialized). Coerce-test all-tcp here.
+	cfg.Security.Flow.TCPMSSAllTCP = 70000               // > u16 max
 	cfg.Security.Flow.TCPMSSGreIn = -5                   // < 0
 	cfg.Security.Flow.TCPMSSGreOut = math.MaxUint16 + 1  // > u16 max
 	cfg.Security.Flow.UDPSessionTimeout = -1             // < 0
@@ -31,15 +33,14 @@ func TestBuildFlowSnapshotCoercesOutOfRange_1977(t *testing.T) {
 	cfg.Security.Flow.TCPSession = &config.TCPSessionConfig{EstablishedTimeout: -7}
 
 	snap := buildFlowSnapshot(cfg)
-	assertInRange(t, "TCPMSSIPsecVPN", snap.TCPMSSIPsecVPN, math.MaxUint16)
+	assertInRange(t, "TCPMSSAllTCP", snap.TCPMSSAllTCP, math.MaxUint16)
 	assertInRange(t, "TCPMSSGreIn", snap.TCPMSSGreIn, math.MaxUint16)
 	assertInRange(t, "TCPMSSGreOut", snap.TCPMSSGreOut, math.MaxUint16)
-	assertInRange(t, "TCPMSSAllTCP", snap.TCPMSSAllTCP, math.MaxUint16)
 	assertInRange(t, "UDPSessionTimeout", snap.UDPSessionTimeout, config.MaxDurationSeconds)
 	assertInRange(t, "ICMPSessionTimeout", snap.ICMPSessionTimeout, config.MaxDurationSeconds)
 	assertInRange(t, "TCPSessionTimeout", snap.TCPSessionTimeout, config.MaxDurationSeconds)
 	// Specific coercions: out-of-range MSS -> 0; huge timeout -> MaxDurationSeconds.
-	if snap.TCPMSSIPsecVPN != 0 || snap.TCPMSSGreIn != 0 || snap.TCPMSSGreOut != 0 {
+	if snap.TCPMSSAllTCP != 0 || snap.TCPMSSGreIn != 0 || snap.TCPMSSGreOut != 0 {
 		t.Fatalf("out-of-range MSS not coerced to 0: %+v", snap)
 	}
 	if int64(snap.ICMPSessionTimeout) != config.MaxDurationSeconds {
@@ -113,7 +114,7 @@ func TestBuildFlowExportSnapshotCoercesOutOfRange_1977(t *testing.T) {
 }
 
 func TestCoerceWireHelpers_1977(t *testing.T) {
-	// u16 (covers TCPMSSAllTCP, which the builder does not populate today).
+	// u16 (covers TCPMSSAllTCP, now populated by buildFlowSnapshot, #2486).
 	for _, tc := range []struct{ in, want int }{
 		{70000, 0}, {-1, 0}, {math.MaxUint16 + 1, 0}, {math.MaxUint16, math.MaxUint16}, {0, 0}, {1400, 1400},
 	} {

--- a/pkg/grpcapi/server_show_flow.go
+++ b/pkg/grpcapi/server_show_flow.go
@@ -59,8 +59,13 @@ func (s *Server) showFlowTimeouts(cfg *config.Config, buf *strings.Builder) {
 	}
 	fmt.Fprintf(buf, "  UDP session:          %ds\n", flow.UDPSessionTimeout)
 	fmt.Fprintf(buf, "  ICMP session:         %ds\n", flow.ICMPSessionTimeout)
+	if flow.TCPMSSAllTCP > 0 {
+		fmt.Fprintf(buf, "  TCP MSS (all-tcp):    %d\n", flow.TCPMSSAllTCP)
+	}
 	if flow.TCPMSSIPsecVPN > 0 {
-		fmt.Fprintf(buf, "  TCP MSS (IPsec VPN):  %d\n", flow.TCPMSSIPsecVPN)
+		// #2486: ipsec-vpn is rejected at commit; a value can only appear
+		// from a leniently-loaded legacy config and is NOT enforced.
+		fmt.Fprintf(buf, "  TCP MSS (IPsec VPN):  %d (not enforced)\n", flow.TCPMSSIPsecVPN)
 	}
 	if flow.TCPMSSGreIn > 0 {
 		fmt.Fprintf(buf, "  TCP MSS (GRE in):     %d\n", flow.TCPMSSGreIn)

--- a/test/incus/xpf-test.conf
+++ b/test/incus/xpf-test.conf
@@ -67,7 +67,7 @@ interfaces {
 security {
     flow {
         tcp-mss {
-            ipsec-vpn 1350;
+            all-tcp 1350;
         }
         allow-dns-reply;
         allow-embedded-icmp;

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -722,19 +722,19 @@ pub(super) fn activated_owner_rgs(
         .collect()
 }
 
-/// Return the effective TCP MSS clamp value for the current config.
-/// Returns 0 if MSS clamping is disabled.
-#[allow(dead_code)]
+/// Return the `security flow tcp-mss all-tcp` clamp value (0 = unset).
+///
+/// #2486: `all-tcp` is the context-agnostic clamp — it applies to every
+/// forwarded TCP SYN regardless of tunnel context, and also serves as
+/// the fallback for the per-context selectors (`gre-in`, tunnel egress)
+/// below. `ipsec-vpn` is NOT read here: there is no IPsec context in the
+/// userspace forward-build path (ESP/AH/IKE is local-delivered to the
+/// kernel XFRM stack and the decrypted inner packets re-enter as plain
+/// traffic with no IPsec marker), so `security flow tcp-mss ipsec-vpn`
+/// is rejected at commit (pkg/config compiler) rather than carried as
+/// dead config.
 pub(super) fn effective_tcp_mss(forwarding: &ForwardingState) -> u16 {
-    if forwarding.tcp_mss_all_tcp > 0 {
-        return forwarding.tcp_mss_all_tcp;
-    }
-    // IPsec VPN and GRE MSS values are returned when configured;
-    // the caller is responsible for checking the tunnel context.
-    if forwarding.tcp_mss_ipsec_vpn > 0 {
-        return forwarding.tcp_mss_ipsec_vpn;
-    }
-    0
+    forwarding.tcp_mss_all_tcp
 }
 
 pub(super) fn native_gre_inner_mtu(
@@ -872,6 +872,42 @@ pub(super) fn tunnel_tcp_mss(
         );
     }
     native_gre_tcp_mss(forwarding, decision, addr_family)
+}
+
+/// #2486: select the per-packet TCP MSS clamp value by forwarding
+/// context. All four Junos `security flow tcp-mss` contexts are resolved
+/// here at frame-build time so an accepted clamp is actually enforced
+/// (previously only tunnel egress clamped — `all-tcp` / `gre-in` were
+/// dead config and `gre-in` produced a silent full-MSS blackhole on the
+/// GRE return path).
+///
+/// Priority (most specific wins, `all-tcp` is the universal fallback):
+///   1. Tunnel egress (`tunnel_endpoint_id != 0`): the GRE/WG
+///      overhead-aware value via `tunnel_tcp_mss` (gre-out, or the
+///      MTU-derived formula). Falls back to `all-tcp` only when that
+///      yields 0 (no gre-out and no MTU available).
+///   2. GRE-decapped ingress (`GRE_DECAP_INGRESS_FLAG`): `gre-in`,
+///      falling back to `all-tcp`.
+///   3. Plain forwarded packet: `all-tcp`.
+///
+/// `ipsec-vpn` is intentionally absent — it is rejected at commit (no
+/// IPsec context reaches this path; see `effective_tcp_mss`).
+pub(super) fn select_tcp_mss(
+    forwarding: &ForwardingState,
+    decision: &SessionDecision,
+    meta: &ForwardPacketMeta,
+) -> u16 {
+    if decision.resolution.tunnel_endpoint_id != 0 {
+        let tunnel = tunnel_tcp_mss(forwarding, decision, meta.addr_family);
+        if tunnel > 0 {
+            return tunnel;
+        }
+        return forwarding.tcp_mss_all_tcp;
+    }
+    if (meta.meta_flags & GRE_DECAP_INGRESS_FLAG) != 0 && forwarding.tcp_mss_gre_in > 0 {
+        return forwarding.tcp_mss_gre_in;
+    }
+    effective_tcp_mss(forwarding)
 }
 
 // #989: clamp_tcp_mss / clamp_tcp_mss_frame relocated to `frame/tcp.rs`.

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -875,8 +875,10 @@ pub(super) fn tunnel_tcp_mss(
 }
 
 /// #2486: select the per-packet TCP MSS clamp value by forwarding
-/// context. All four Junos `security flow tcp-mss` contexts are resolved
-/// here at frame-build time so an accepted clamp is actually enforced
+/// context. The three enforceable `security flow tcp-mss` contexts
+/// (all-tcp, gre-in, gre-out/WG) are resolved here at frame-build time so
+/// an accepted clamp is actually enforced; `ipsec-vpn` is rejected at
+/// commit and never reaches this path
 /// (previously only tunnel egress clamped — `all-tcp` / `gre-in` were
 /// dead config and `gre-in` produced a silent full-MSS blackhole on the
 /// GRE return path).

--- a/userspace-dp/src/afxdp/frame/build/ipv4.rs
+++ b/userspace-dp/src/afxdp/frame/build/ipv4.rs
@@ -3,7 +3,7 @@
 //! Body is byte-identical to the AF_INET match arm at
 //! `frame/mod.rs:285..341` before this split. The orchestrator at
 //! `frame/build/mod.rs` computes the L2 prelude (eth header, payload
-//! memcpy, ip_start, tunnel_tcp_mss, apply_nat) and dispatches here.
+//! memcpy, ip_start, selected_tcp_mss, apply_nat) and dispatches here.
 
 use super::super::tcp::clamp_tcp_mss_frame;
 use super::super::{
@@ -21,7 +21,7 @@ pub(in crate::afxdp::frame) fn build_forwarded_frame_into_ipv4(
     decision: &SessionDecision,
     apply_nat: bool,
     expected_ports: Option<(u16, u16)>,
-    tunnel_tcp_mss: u16,
+    selected_tcp_mss: u16,
     force_tunnel_l4_recompute: bool,
 ) -> Option<()> {
     let enforced_ports = expected_ports;
@@ -83,8 +83,8 @@ pub(in crate::afxdp::frame) fn build_forwarded_frame_into_ipv4(
         old_dst,
         old_ttl,
     )?;
-    if tunnel_tcp_mss > 0 {
-        let _ = clamp_tcp_mss_frame(out, ip_start, tunnel_tcp_mss);
+    if selected_tcp_mss > 0 {
+        let _ = clamp_tcp_mss_frame(out, ip_start, selected_tcp_mss);
     }
     // #1852: skip the full L4 recompute on a non-first fragment — it
     // writes the checksum at ihl+16/+6, which is payload here. The forced

--- a/userspace-dp/src/afxdp/frame/build/ipv6.rs
+++ b/userspace-dp/src/afxdp/frame/build/ipv6.rs
@@ -3,7 +3,7 @@
 //! Body is byte-identical to the AF_INET6 match arm at
 //! `frame/mod.rs:342..380` before this split. The orchestrator at
 //! `frame/build/mod.rs` computes the L2 prelude (eth header, payload
-//! memcpy, ip_start, tunnel_tcp_mss, apply_nat) and dispatches here.
+//! memcpy, ip_start, selected_tcp_mss, apply_nat) and dispatches here.
 
 use super::super::tcp::clamp_tcp_mss_frame;
 use super::super::{
@@ -20,7 +20,7 @@ pub(in crate::afxdp::frame) fn build_forwarded_frame_into_ipv6(
     decision: &SessionDecision,
     apply_nat: bool,
     expected_ports: Option<(u16, u16)>,
-    tunnel_tcp_mss: u16,
+    selected_tcp_mss: u16,
     force_tunnel_l4_recompute: bool,
 ) -> Option<()> {
     let enforced_ports = expected_ports;
@@ -66,8 +66,8 @@ pub(in crate::afxdp::frame) fn build_forwarded_frame_into_ipv6(
         non_first_fragment,
     )
     .unwrap_or(false);
-    if tunnel_tcp_mss > 0 {
-        let _ = clamp_tcp_mss_frame(out, ip_start, tunnel_tcp_mss);
+    if selected_tcp_mss > 0 {
+        let _ = clamp_tcp_mss_frame(out, ip_start, selected_tcp_mss);
     }
     // #1852: skip the full L4 recompute on a non-first fragment — it
     // writes the checksum at rel_l4+16/+6, which is payload here. The

--- a/userspace-dp/src/afxdp/frame/build/mod.rs
+++ b/userspace-dp/src/afxdp/frame/build/mod.rs
@@ -19,7 +19,7 @@ use ipv4::build_forwarded_frame_into_ipv4;
 use ipv6::build_forwarded_frame_into_ipv6;
 
 use super::{
-    decode_frame_summary, frame_has_tcp_rst, frame_l3_offset, trim_l3_payload, tunnel_tcp_mss,
+    decode_frame_summary, frame_has_tcp_rst, frame_l3_offset, select_tcp_mss, trim_l3_payload,
     verify_built_frame_checksums, write_eth_header_slice, ForwardPacketMeta,
     ForwardingDisposition, ForwardingState, SessionDecision,
 };
@@ -87,11 +87,14 @@ pub(in crate::afxdp) fn build_forwarded_frame_into_from_frame(
     }
     let out = &mut out[..frame_len];
     let force_tunnel_l4_recompute = decision.resolution.tunnel_endpoint_id != 0;
-    // #2299: dispatch the MSS clamp by tunnel kind — WG needs the larger
+    // #2486: select the MSS clamp by per-packet forwarding context
+    // (all-tcp / gre-in / tunnel-egress). #2299: tunnel egress still
+    // dispatches by kind inside `select_tcp_mss` — WG needs the larger
     // WG-overhead-aware value, not the GRE formula (which would clamp too
     // high and get the peer's full-MSS data dropped at the WG encap MTU
-    // guard). Non-WG / plain-forward keep the GRE formula bit-for-bit.
-    let tunnel_tcp_mss = tunnel_tcp_mss(forwarding, decision, meta.addr_family);
+    // guard). Plain forwarded SYNs now clamp to `all-tcp`; GRE-decapped
+    // ingress SYNs clamp to `gre-in` (was previously dead config).
+    let tunnel_tcp_mss = select_tcp_mss(forwarding, decision, &meta);
     let ip_start = eth_len;
     match meta.addr_family as i32 {
         libc::AF_INET => build_forwarded_frame_into_ipv4(

--- a/userspace-dp/src/afxdp/frame/build/mod.rs
+++ b/userspace-dp/src/afxdp/frame/build/mod.rs
@@ -1,7 +1,7 @@
 //! Orchestrator for `build_forwarded_frame_into_from_frame`.
 //!
 //! Computes the L2 prelude (eth header write + payload memcpy +
-//! resolution of `apply_nat` / `tunnel_tcp_mss` / `force_tunnel_l4_recompute`)
+//! resolution of `apply_nat` / `selected_tcp_mss` / `force_tunnel_l4_recompute`)
 //! and dispatches to the address-family helper.
 //!
 //! Codegen contract (see docs/pr/1352-frame-build-rewrite-split/plan.md):
@@ -94,7 +94,7 @@ pub(in crate::afxdp) fn build_forwarded_frame_into_from_frame(
     // high and get the peer's full-MSS data dropped at the WG encap MTU
     // guard). Plain forwarded SYNs now clamp to `all-tcp`; GRE-decapped
     // ingress SYNs clamp to `gre-in` (was previously dead config).
-    let tunnel_tcp_mss = select_tcp_mss(forwarding, decision, &meta);
+    let selected_tcp_mss = select_tcp_mss(forwarding, decision, &meta);
     let ip_start = eth_len;
     match meta.addr_family as i32 {
         libc::AF_INET => build_forwarded_frame_into_ipv4(
@@ -104,7 +104,7 @@ pub(in crate::afxdp) fn build_forwarded_frame_into_from_frame(
             decision,
             apply_nat,
             expected_ports,
-            tunnel_tcp_mss,
+            selected_tcp_mss,
             force_tunnel_l4_recompute,
         )?,
         libc::AF_INET6 => build_forwarded_frame_into_ipv6(
@@ -114,7 +114,7 @@ pub(in crate::afxdp) fn build_forwarded_frame_into_from_frame(
             decision,
             apply_nat,
             expected_ports,
-            tunnel_tcp_mss,
+            selected_tcp_mss,
             force_tunnel_l4_recompute,
         )?,
         _ => return None,

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -6282,3 +6282,393 @@ fn inject_ipv6_giant_length_clamped_no_wire_wrap() {
         "IPv6 payload-length must match the bounded frame (no u16 wrap)"
     );
 }
+
+// =====================================================================
+// #2486: per-context TCP MSS clamp enforcement (all-tcp / gre-in).
+//
+// Before #2486 only tunnel EGRESS clamped; `all-tcp` and `gre-in` were
+// accepted at commit and carried on the wire but never enforced. The
+// gre-in gap was a silent full-MSS blackhole on the GRE return path.
+// These tests prove the per-packet context selection in `select_tcp_mss`
+// (forwarding/mod.rs) reaches the clamp at frame build, and fail on
+// revert of either the all-tcp wiring or the gre-in marker plumbing.
+// =====================================================================
+
+/// Build a plain (non-tunnel) IPv4 TCP SYN frame carrying an MSS option.
+/// `mss` is the advertised MSS in the SYN's TCP options.
+fn build_ipv4_tcp_syn_with_mss(
+    src: Ipv4Addr,
+    dst: Ipv4Addr,
+    src_port: u16,
+    dst_port: u16,
+    mss: u16,
+) -> Vec<u8> {
+    let mut frame = Vec::new();
+    write_eth_header(
+        &mut frame,
+        [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+        [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+        0,
+        0x0800,
+    );
+    // IPv4 header: 20 bytes IP + 24 bytes TCP (20 + 4-byte MSS option).
+    let total_len = 20u16 + 24u16;
+    frame.extend_from_slice(&[
+        0x45,
+        0x00,
+        (total_len >> 8) as u8,
+        total_len as u8,
+        0x12,
+        0x34,
+        0x40,
+        0x00,
+        64,
+        PROTO_TCP,
+        0x00,
+        0x00,
+    ]);
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    frame.extend_from_slice(&src_port.to_be_bytes());
+    frame.extend_from_slice(&dst_port.to_be_bytes());
+    frame.extend_from_slice(&[
+        0x00, 0x00, 0x00, 0x01, // seq
+        0x00, 0x00, 0x00, 0x00, // ack
+        0x60, TCP_FLAG_SYN, 0xfa, 0xf0, // data offset (6 words = 24B)/flags/window
+        0x00, 0x00, 0x00, 0x00, // checksum + urg
+    ]);
+    frame.extend_from_slice(&[0x02, 0x04]); // MSS option kind=2 len=4
+    frame.extend_from_slice(&mss.to_be_bytes());
+    let ip_sum = checksum16(&frame[14..34]);
+    frame[24] = (ip_sum >> 8) as u8;
+    frame[25] = ip_sum as u8;
+    recompute_l4_checksum_ipv4(&mut frame[14..], 20, PROTO_TCP, false).expect("v4 tcp sum");
+    frame
+}
+
+/// Build a plain (non-tunnel) IPv6 TCP SYN frame carrying an MSS option.
+fn build_ipv6_tcp_syn_with_mss(
+    src: Ipv6Addr,
+    dst: Ipv6Addr,
+    src_port: u16,
+    dst_port: u16,
+    mss: u16,
+) -> Vec<u8> {
+    let mut frame = Vec::new();
+    write_eth_header(
+        &mut frame,
+        [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+        [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+        0,
+        0x86dd,
+    );
+    let plen = 24u16; // 20 TCP + 4 MSS option
+    frame.extend_from_slice(&[
+        0x60,
+        0x00,
+        0x00,
+        0x00,
+        (plen >> 8) as u8,
+        plen as u8,
+        PROTO_TCP,
+        64,
+    ]);
+    frame.extend_from_slice(&src.octets());
+    frame.extend_from_slice(&dst.octets());
+    frame.extend_from_slice(&src_port.to_be_bytes());
+    frame.extend_from_slice(&dst_port.to_be_bytes());
+    frame.extend_from_slice(&[
+        0x00, 0x00, 0x00, 0x01, // seq
+        0x00, 0x00, 0x00, 0x00, // ack
+        0x60, TCP_FLAG_SYN, 0xfa, 0xf0, // data offset (6 words)/flags/window
+        0x00, 0x00, 0x00, 0x00, // checksum + urg
+    ]);
+    frame.extend_from_slice(&[0x02, 0x04]);
+    frame.extend_from_slice(&mss.to_be_bytes());
+    recompute_l4_checksum_ipv6(&mut frame[14..], 40, PROTO_TCP).expect("v6 tcp sum");
+    frame
+}
+
+/// A plain ForwardCandidate decision (no tunnel) for a forwarded packet.
+fn plain_forward_decision_v4(dst: Ipv4Addr) -> SessionDecision {
+    SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 11,
+            tunnel_endpoint_id: 0,
+            next_hop: Some(IpAddr::V4(dst)),
+            neighbor_mac: Some([0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]),
+            src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]),
+            tx_vlan_id: 0,
+        },
+        nat: NatDecision::default(),
+    }
+}
+
+fn plain_meta_v4(src_port: u16, dst_port: u16, meta_flags: u8) -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        l3_offset: 14,
+        l4_offset: 34,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+        meta_flags,
+        flow_src_port: src_port,
+        flow_dst_port: dst_port,
+        ..UserspaceDpMeta::default()
+    }
+}
+
+/// Read the MSS option value back out of a built IPv4 frame (eth+20 IP).
+fn built_ipv4_mss(frame: &[u8]) -> u16 {
+    // eth(14) + IPv4(20) -> TCP; MSS option at TCP offset 20 (+2 for value).
+    let mss_off = 14 + 20 + 22;
+    u16::from_be_bytes([frame[mss_off], frame[mss_off + 1]])
+}
+
+fn built_ipv6_mss(frame: &[u8]) -> u16 {
+    let mss_off = 14 + 40 + 22;
+    u16::from_be_bytes([frame[mss_off], frame[mss_off + 1]])
+}
+
+#[test]
+fn all_tcp_clamps_plain_forwarded_ipv4_syn() {
+    let src = Ipv4Addr::new(10, 0, 1, 102);
+    let dst = Ipv4Addr::new(10, 0, 2, 200);
+    let frame = build_ipv4_tcp_syn_with_mss(src, dst, 40000, 5201, 1460);
+    let forwarding = ForwardingState {
+        tcp_mss_all_tcp: 1400,
+        ..ForwardingState::default()
+    };
+    let built = build_forwarded_frame_from_frame(
+        &frame,
+        plain_meta_v4(40000, 5201, 0),
+        &plain_forward_decision_v4(dst),
+        &forwarding,
+        false,
+        None,
+    )
+    .expect("plain forward build");
+    assert_eq!(
+        built_ipv4_mss(&built),
+        1400,
+        "all-tcp must clamp a plain forwarded IPv4 SYN with MSS 1460 -> 1400"
+    );
+    let inner = &built[14..];
+    assert!(tcp_checksum_ok_ipv4(inner), "clamped v4 TCP checksum valid");
+}
+
+#[test]
+fn all_tcp_clamps_plain_forwarded_ipv6_syn() {
+    let src: Ipv6Addr = "2001:559:8585:bf01::102".parse().unwrap();
+    let dst: Ipv6Addr = "2001:559:8585:bf02::200".parse().unwrap();
+    let frame = build_ipv6_tcp_syn_with_mss(src, dst, 40000, 5201, 1440);
+    let forwarding = ForwardingState {
+        tcp_mss_all_tcp: 1380,
+        ..ForwardingState::default()
+    };
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        l3_offset: 14,
+        l4_offset: 54,
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+        flow_src_port: 40000,
+        flow_dst_port: 5201,
+        ..UserspaceDpMeta::default()
+    };
+    let decision = SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 11,
+            tunnel_endpoint_id: 0,
+            next_hop: Some(IpAddr::V6(dst)),
+            neighbor_mac: Some([0xba, 0x86, 0xe9, 0xf6, 0x4b, 0xd5]),
+            src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x80, 0x08]),
+            tx_vlan_id: 0,
+        },
+        nat: NatDecision::default(),
+    };
+    let built = build_forwarded_frame_from_frame(&frame, meta, &decision, &forwarding, false, None)
+        .expect("plain forward v6 build");
+    assert_eq!(
+        built_ipv6_mss(&built),
+        1380,
+        "all-tcp must clamp a plain forwarded IPv6 SYN with MSS 1440 -> 1380"
+    );
+}
+
+#[test]
+fn all_tcp_leaves_smaller_mss_unchanged() {
+    let src = Ipv4Addr::new(10, 0, 1, 102);
+    let dst = Ipv4Addr::new(10, 0, 2, 200);
+    // Advertised MSS 1200 is already below the 1400 all-tcp clamp.
+    let frame = build_ipv4_tcp_syn_with_mss(src, dst, 40000, 5201, 1200);
+    let forwarding = ForwardingState {
+        tcp_mss_all_tcp: 1400,
+        ..ForwardingState::default()
+    };
+    let built = build_forwarded_frame_from_frame(
+        &frame,
+        plain_meta_v4(40000, 5201, 0),
+        &plain_forward_decision_v4(dst),
+        &forwarding,
+        false,
+        None,
+    )
+    .expect("plain forward build");
+    assert_eq!(
+        built_ipv4_mss(&built),
+        1200,
+        "all-tcp must NOT raise an MSS already below the clamp"
+    );
+}
+
+#[test]
+fn all_tcp_leaves_non_syn_untouched() {
+    let src = Ipv4Addr::new(10, 0, 1, 102);
+    let dst = Ipv4Addr::new(10, 0, 2, 200);
+    let mut frame = build_ipv4_tcp_syn_with_mss(src, dst, 40000, 5201, 1460);
+    // Clear the SYN flag -> ACK-only segment (0x10); the "MSS option" bytes
+    // are now just leftover option bytes but the clamp must skip non-SYN
+    // entirely.
+    const TCP_ACK_FLAG: u8 = 0x10;
+    frame[14 + 20 + 13] = TCP_ACK_FLAG;
+    recompute_l4_checksum_ipv4(&mut frame[14..], 20, PROTO_TCP, false).expect("recsum");
+    let forwarding = ForwardingState {
+        tcp_mss_all_tcp: 1400,
+        ..ForwardingState::default()
+    };
+    let mut meta = plain_meta_v4(40000, 5201, 0);
+    meta.tcp_flags = TCP_ACK_FLAG;
+    let built = build_forwarded_frame_from_frame(
+        &frame,
+        meta,
+        &plain_forward_decision_v4(dst),
+        &forwarding,
+        false,
+        None,
+    )
+    .expect("plain forward build");
+    assert_eq!(
+        built_ipv4_mss(&built),
+        1460,
+        "all-tcp must not clamp a non-SYN segment"
+    );
+}
+
+#[test]
+fn all_tcp_no_op_when_unset() {
+    // No all-tcp configured -> MSS must pass through unchanged on the
+    // plain forward path (regression guard against an accidental clamp).
+    let src = Ipv4Addr::new(10, 0, 1, 102);
+    let dst = Ipv4Addr::new(10, 0, 2, 200);
+    let frame = build_ipv4_tcp_syn_with_mss(src, dst, 40000, 5201, 1460);
+    let built = build_forwarded_frame_from_frame(
+        &frame,
+        plain_meta_v4(40000, 5201, 0),
+        &plain_forward_decision_v4(dst),
+        &ForwardingState::default(),
+        false,
+        None,
+    )
+    .expect("plain forward build");
+    assert_eq!(built_ipv4_mss(&built), 1460, "no clamp when all-tcp unset");
+}
+
+#[test]
+fn gre_in_clamps_decapped_ingress_syn() {
+    // An inbound GRE-decapped SYN (marked GRE_DECAP_INGRESS_FLAG by the
+    // decap stage) clamps to the gre-in value. Reverting the marker
+    // plumbing (clear meta_flags) makes this fail -> fail-on-revert for
+    // the gre-in HIGH part.
+    let src = Ipv4Addr::new(10, 0, 1, 102);
+    let dst = Ipv4Addr::new(10, 0, 2, 200);
+    let frame = build_ipv4_tcp_syn_with_mss(src, dst, 40000, 5201, 1460);
+    let forwarding = ForwardingState {
+        tcp_mss_gre_in: 1360,
+        ..ForwardingState::default()
+    };
+    let meta = plain_meta_v4(40000, 5201, GRE_DECAP_INGRESS_FLAG);
+    let built = build_forwarded_frame_from_frame(
+        &frame,
+        meta,
+        &plain_forward_decision_v4(dst),
+        &forwarding,
+        false,
+        None,
+    )
+    .expect("gre-in forward build");
+    assert_eq!(
+        built_ipv4_mss(&built),
+        1360,
+        "gre-in must clamp a GRE-decapped ingress SYN 1460 -> 1360"
+    );
+}
+
+#[test]
+fn gre_in_marker_required_for_gre_in_clamp() {
+    // Same gre-in config but WITHOUT the decap marker: the packet is a
+    // plain forward, so gre-in must NOT apply (and all-tcp is unset).
+    // This pins that the gre-in clamp is gated on the marker, not just on
+    // the config value being present.
+    let src = Ipv4Addr::new(10, 0, 1, 102);
+    let dst = Ipv4Addr::new(10, 0, 2, 200);
+    let frame = build_ipv4_tcp_syn_with_mss(src, dst, 40000, 5201, 1460);
+    let forwarding = ForwardingState {
+        tcp_mss_gre_in: 1360,
+        ..ForwardingState::default()
+    };
+    let built = build_forwarded_frame_from_frame(
+        &frame,
+        plain_meta_v4(40000, 5201, 0),
+        &plain_forward_decision_v4(dst),
+        &forwarding,
+        false,
+        None,
+    )
+    .expect("plain forward build");
+    assert_eq!(
+        built_ipv4_mss(&built),
+        1460,
+        "gre-in must require the GRE_DECAP_INGRESS_FLAG marker"
+    );
+}
+
+#[test]
+fn gre_in_falls_back_to_all_tcp() {
+    // A GRE-decapped SYN with no gre-in but an all-tcp value falls back
+    // to all-tcp (all-tcp is the universal fallback).
+    let src = Ipv4Addr::new(10, 0, 1, 102);
+    let dst = Ipv4Addr::new(10, 0, 2, 200);
+    let frame = build_ipv4_tcp_syn_with_mss(src, dst, 40000, 5201, 1460);
+    let forwarding = ForwardingState {
+        tcp_mss_all_tcp: 1410,
+        ..ForwardingState::default()
+    };
+    let meta = plain_meta_v4(40000, 5201, GRE_DECAP_INGRESS_FLAG);
+    let built = build_forwarded_frame_from_frame(
+        &frame,
+        meta,
+        &plain_forward_decision_v4(dst),
+        &forwarding,
+        false,
+        None,
+    )
+    .expect("gre-in fallback build");
+    assert_eq!(
+        built_ipv4_mss(&built),
+        1410,
+        "gre-in with no gre-in value falls back to all-tcp"
+    );
+}

--- a/userspace-dp/src/afxdp/gre.rs
+++ b/userspace-dp/src/afxdp/gre.rs
@@ -689,6 +689,11 @@ pub(super) fn try_native_gre_decap_from_frame(
         addr_family: inner_family,
         protocol,
         tcp_flags: packet_tcp_flags(inner_packet, inner_family, protocol, rel_l4_offset),
+        // #2486: mark this inner packet as GRE-decapped so the forward
+        // builder selects the `tcp-mss gre-in` clamp value. The inbound
+        // GRE-decapped SYN is the exact direction where an inner LAN peer
+        // would otherwise learn an MSS too large for the GRE return path.
+        meta_flags: GRE_DECAP_INGRESS_FLAG,
         flow_src_port: src_port,
         flow_dst_port: dst_port,
         flow_src_addr,

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -9,6 +9,12 @@ pub(super) const FABRIC_INGRESS_FLAG: u8 = 0x80;
 /// unclamped — a silent full-MSS blackhole on the GRE return path.
 /// Distinct bit from `FABRIC_INGRESS_FLAG` (0x80) and the TTL-skip
 /// reuse of 0x80; 0x40 is otherwise unused in `meta_flags`.
+/// Note: the retired-eBPF header `bpf/headers/xpf_common.h` defines
+/// `META_FLAG_DNS_REPLY_FASTPATH = (1<<6) = 0x40` (the same numeric bit),
+/// but it is DEAD — never written by the AF_XDP shim and never reaches
+/// `UserspaceDpMeta.meta_flags` — so there is no runtime collision today;
+/// a future revival of that header bit must pick a different value or
+/// coordinate with this flag.
 pub(super) const GRE_DECAP_INGRESS_FLAG: u8 = 0x40;
 
 /// RFC 1812 §4.3.2.7 / RFC 792 / RFC 4443 §2.4 error-suppression gate

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -2,6 +2,15 @@ use super::*;
 
 pub(super) const FABRIC_INGRESS_FLAG: u8 = 0x80;
 
+/// #2486: per-packet marker set by native GRE decap
+/// (`try_native_gre_decap_from_frame`) so the forward-frame builder can
+/// select the `security flow tcp-mss gre-in` clamp value for an inbound
+/// GRE-decapped SYN. Without this marker the inner SYN was forwarded
+/// unclamped — a silent full-MSS blackhole on the GRE return path.
+/// Distinct bit from `FABRIC_INGRESS_FLAG` (0x80) and the TTL-skip
+/// reuse of 0x80; 0x40 is otherwise unused in `meta_flags`.
+pub(super) const GRE_DECAP_INGRESS_FLAG: u8 = 0x40;
+
 /// RFC 1812 §4.3.2.7 / RFC 792 / RFC 4443 §2.4 error-suppression gate
 /// for LOCALLY GENERATED ICMP/ICMPv6 error messages (Time Exceeded,
 /// Destination Unreachable). A router MUST NOT originate an ICMP error

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -152,7 +152,9 @@ use self::forwarding::*;
 use self::forwarding_build::*;
 use self::frame::*;
 use self::gre::{encapsulate_native_gre_frame, try_native_gre_decap_from_frame};
-use self::icmp::{FABRIC_INGRESS_FLAG, build_local_time_exceeded_request, is_icmp_error};
+use self::icmp::{
+    FABRIC_INGRESS_FLAG, GRE_DECAP_INGRESS_FLAG, build_local_time_exceeded_request, is_icmp_error,
+};
 use self::icmp_ptb::{
     EgressMtuDecision, build_frag_needed_v4, build_packet_too_big_v6,
     forwarded_egress_mtu_decision, post_transform_inner_mtu, ptb_reply_suppressed,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7870,6 +7870,28 @@ fn gre_decap_well_formed_icmp_inner_v4_still_decaps() {
     assert_eq!(decap.meta.l4_offset, 14 + 20);
 }
 
+/// #2486 fail-on-revert: native GRE decap MUST stamp
+/// `GRE_DECAP_INGRESS_FLAG` on the inner packet's meta so the
+/// forward-frame builder selects the `tcp-mss gre-in` clamp. Reverting
+/// the `meta_flags: GRE_DECAP_INGRESS_FLAG` set in
+/// `try_native_gre_decap_from_frame` (gre.rs) makes this assertion fail
+/// — and with it the inbound GRE-decapped SYN goes back to being
+/// forwarded unclamped (the original silent full-MSS blackhole).
+#[test]
+fn gre_decap_marks_inner_meta_with_gre_in_flag() {
+    let forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let inner = build_gre_inner_icmp_packet_v4();
+    let frame = build_gre_to_self_outer_frame_with_inner(0x0800, &inner);
+    let meta = gre_to_self_outer_meta(0, frame.len());
+    let decap = try_native_gre_decap_from_frame(&frame, meta, &forwarding)
+        .expect("well-formed GRE inner must decap");
+    assert_ne!(
+        decap.meta.meta_flags & GRE_DECAP_INGRESS_FLAG,
+        0,
+        "decap must mark the inner meta as GRE-decapped (gre-in clamp marker)"
+    );
+}
+
 /// #2376 composition / no-regression: the pre-existing TCP guard must
 /// still drop a GRE inner declaring TCP but shorter than the 20-byte TCP
 /// header — the UDP/ICMP fix must not weaken the TCP path.


### PR DESCRIPTION
Closes #2486

## Problem
Three of the four Junos `security flow tcp-mss` contexts (`all-tcp`,
`ipsec-vpn`, `gre-in`) were carried end-to-end (snapshot decode +
ForwardingState) but never enforced — only tunnel egress (`gre-out`/WG)
clamped. Worst: an inbound GRE-decapped SYN was never clamped to `gre-in`,
a silent full-MSS blackhole on the GRE return path.

## Fix (per-packet MSS context)
- **all-tcp**: plain forwarded TCP SYNs now clamp to the `all-tcp` value
  (v4+v6). The previously-dead `tcp_mss_all_tcp` wire field is now
  populated (Go) and consumed (Rust); it already existed in the wire
  contract with `#[serde(default)]`.
- **gre-in**: the GRE decap stage marks the packet with a new
  `GRE_DECAP_INGRESS_FLAG` meta-flag (runtime per-packet flag, NOT a new
  wire field); MSS selection clamps a marked SYN to `tcp_mss_gre_in`,
  falling back to `all-tcp` when gre-in is unset.
- **ipsec-vpn** (design fork → REJECT): there is no IPsec context at the
  userspace forward-build path (IPsec is strongSwan/XFRM kernel-side), so
  `security flow tcp-mss ipsec-vpn` is now **rejected at commit**
  (`pkg/config` compiler) rather than silently accepted as dead config.
  The wire field remains present + `#[serde(default)]` (no decode break).
- `docs/feature-gaps.md` corrected to match what is actually enforced.

## Wire parity (#1961 guard)
No new Go↔Rust wire field. `tcp_mss_all_tcp` / `tcp_mss_ipsec_vpn` both
carry `#[serde(default)]` on the Rust side and `omitempty` on the Go
side; the gre-in marker is a runtime `meta_flags` bit.

## Tests (fail-on-revert)
- all-tcp clamps a plain forwarded SYN (v4+v6); sub-value SYN unchanged;
  non-SYN untouched.
- `gre_in_clamps_decapped_ingress_syn`, `gre_in_marker_required_for_gre_in_clamp`
  (revert the marker → fails), `gre_in_falls_back_to_all_tcp`.
- gre-out/WG egress clamp regression preserved.
- `pkg/config` commit-reject test for `tcp-mss ipsec-vpn`.

## Validation
cargo build --release clean; tcp_mss tests 16/16, mss 30/30;
`go test ./pkg/config/ ./pkg/dataplane/userspace/` ok; gofmt clean;
go build ./... ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
